### PR TITLE
fix: human-readable worktree names

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -552,7 +552,10 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 		return m.handleError(fmt.Errorf("you can't create more than %d instances", GlobalInstanceLimit))
 	}
 
-	title := fmt.Sprintf("task-%s-%s", tsk.ID, time.Now().Format("20060102-150405"))
+	title := tsk.Name
+	if title == "" {
+		title = fmt.Sprintf("task-%s", tsk.ID)
+	}
 
 	instance, err := session.NewInstance(session.InstanceOptions{
 		Title:   title,

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -2,12 +2,13 @@ package git
 
 import (
 	"fmt"
-	"github.com/sachiniyer/agent-factory/config"
-	"github.com/sachiniyer/agent-factory/log"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 func getWorktreeDirectory() (string, error) {
@@ -110,15 +111,22 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		return nil, "", err
 	}
 
-	// Use sanitized branch name for the worktree directory name
-	var worktreePath string
+	// Use sanitized branch name for the worktree directory name.
+	// Only append a numeric suffix if the path already exists (collision).
+	var basePath string
 	if cfg.WorktreeRoot == config.WorktreeRootSibling {
 		repoName := filepath.Base(repoPath)
-		worktreePath = filepath.Join(worktreeDir, repoName+"-"+sessionName)
+		basePath = filepath.Join(worktreeDir, repoName+"-"+sessionName)
 	} else {
-		worktreePath = filepath.Join(worktreeDir, branchName)
+		basePath = filepath.Join(worktreeDir, branchName)
 	}
-	worktreePath = worktreePath + "_" + fmt.Sprintf("%x", time.Now().UnixNano())
+	worktreePath := basePath
+	for i := 2; ; i++ {
+		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+			break
+		}
+		worktreePath = fmt.Sprintf("%s-%d", basePath, i)
+	}
 
 	return &GitWorktree{
 		repoPath:     repoPath,

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -1,13 +1,14 @@
 package git
 
 import (
-	"github.com/sachiniyer/agent-factory/config"
-	"github.com/sachiniyer/agent-factory/log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,6 +60,114 @@ func TestGetWorktreeDirectoryForRepo_SiblingRequiresRepoPath(t *testing.T) {
 
 	_, err := getWorktreeDirectoryForRepo("")
 	require.Error(t, err)
+}
+
+func TestNewGitWorktree_CleanName(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+
+	cfg := config.DefaultConfig()
+	cfg.WorktreeRoot = config.WorktreeRootSubdirectory
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, branchName, err := NewGitWorktree(repoRoot, "my-feature")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test/my-feature", branchName)
+
+	// Worktree path should end with the branch name, no hex suffix
+	assert.True(t, strings.HasSuffix(gw.GetWorktreePath(), "test/my-feature"),
+		"expected worktree path to end with 'test/my-feature', got: %s", gw.GetWorktreePath())
+	// Should NOT contain an underscore followed by hex (old format)
+	base := filepath.Base(gw.GetWorktreePath())
+	assert.False(t, strings.Contains(base, "_"),
+		"worktree path should not contain underscore hex suffix, got: %s", base)
+}
+
+func TestNewGitWorktree_CollisionSuffix(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+
+	cfg := config.DefaultConfig()
+	cfg.WorktreeRoot = config.WorktreeRootSubdirectory
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	// Create first worktree - should get clean name
+	gw1, _, err := NewGitWorktree(repoRoot, "my-feature")
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(gw1.GetWorktreePath(), "test/my-feature"),
+		"first worktree should have clean name, got: %s", gw1.GetWorktreePath())
+
+	// Create the directory so the next call sees a collision
+	require.NoError(t, os.MkdirAll(gw1.GetWorktreePath(), 0755))
+
+	// Create second worktree with same name - should get -2 suffix
+	gw2, _, err := NewGitWorktree(repoRoot, "my-feature")
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(gw2.GetWorktreePath(), "test/my-feature-2"),
+		"second worktree should have -2 suffix, got: %s", gw2.GetWorktreePath())
+
+	// Create that directory too
+	require.NoError(t, os.MkdirAll(gw2.GetWorktreePath(), 0755))
+
+	// Create third worktree with same name - should get -3 suffix
+	gw3, _, err := NewGitWorktree(repoRoot, "my-feature")
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(gw3.GetWorktreePath(), "test/my-feature-3"),
+		"third worktree should have -3 suffix, got: %s", gw3.GetWorktreePath())
+}
+
+func TestNewGitWorktree_SiblingCleanName(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+	repoName := filepath.Base(repoRoot)
+
+	cfg := config.DefaultConfig()
+	cfg.WorktreeRoot = config.WorktreeRootSibling
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, _, err := NewGitWorktree(repoRoot, "my-feature")
+	require.NoError(t, err)
+
+	expectedSuffix := repoName + "-my-feature"
+	assert.True(t, strings.HasSuffix(gw.GetWorktreePath(), expectedSuffix),
+		"sibling worktree should end with '%s', got: %s", expectedSuffix, gw.GetWorktreePath())
+
+	// Should be in the parent directory of the repo
+	assert.Equal(t, filepath.Dir(repoRoot), filepath.Dir(gw.GetWorktreePath()))
+}
+
+func TestNewGitWorktree_SiblingCollision(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+	repoName := filepath.Base(repoRoot)
+
+	cfg := config.DefaultConfig()
+	cfg.WorktreeRoot = config.WorktreeRootSibling
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw1, _, err := NewGitWorktree(repoRoot, "my-feature")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(gw1.GetWorktreePath(), 0755))
+
+	gw2, _, err := NewGitWorktree(repoRoot, "my-feature")
+	require.NoError(t, err)
+
+	expectedSuffix := repoName + "-my-feature-2"
+	assert.True(t, strings.HasSuffix(gw2.GetWorktreePath(), expectedSuffix),
+		"sibling collision worktree should end with '%s', got: %s", expectedSuffix, gw2.GetWorktreePath())
 }
 
 func createGitRepo(t *testing.T) string {

--- a/task/runner.go
+++ b/task/runner.go
@@ -146,7 +146,10 @@ func RunTask(taskID string) error {
 
 	cfg := config.LoadConfig()
 
-	title := fmt.Sprintf("task-%s-%s", t.ID, time.Now().Format("20060102-150405"))
+	title := t.Name
+	if title == "" {
+		title = fmt.Sprintf("task-%s", t.ID)
+	}
 
 	instance, err := session.NewInstance(session.InstanceOptions{
 		Title:   title,


### PR DESCRIPTION
## Summary
- Remove hex timestamp suffix from worktree directory names, using clean names like `siyer/my-feature` instead of `siyer/my-feature_189b75ccfc898b3f`
- Only append `-2`, `-3`, etc. when a worktree directory already exists (collision)
- Name scheduled task instances after the task name instead of `task-<id>-<timestamp>`

## Test plan
- [x] Added tests for clean naming (subdirectory and sibling modes)
- [x] Added tests for collision-based numbering (-2, -3, etc.)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)