### PR TITLE
fix: handle MCP server trust prompts in auto-dismiss

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -160,22 +160,26 @@ func (t *TmuxSession) Start(workDir string) error {
 // CheckAndHandleTrustPrompt checks the pane content once for a trust prompt and dismisses it if found.
 // Returns true if the prompt was found and handled.
 func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
-	searchString := "Do you trust the files in this folder?"
-	tapFunc := t.TapEnter
-	if !strings.Contains(t.program, ProgramClaude) {
-		searchString = "Open documentation url for more info"
-		tapFunc = t.TapDAndEnter
-	}
-
 	content, err := t.CapturePaneContent()
 	if err != nil {
 		return false
 	}
-	if strings.Contains(content, searchString) {
-		if err := tapFunc(); err != nil {
-			log.ErrorLog.Printf("could not tap enter on trust screen: %v", err)
+
+	if strings.Contains(t.program, ProgramClaude) {
+		if strings.Contains(content, "Do you trust the files in this folder?") ||
+			strings.Contains(content, "new MCP server") {
+			if err := t.TapEnter(); err != nil {
+				log.ErrorLog.Printf("could not tap enter on trust/MCP screen: %v", err)
+			}
+			return true
 		}
-		return true
+	} else {
+		if strings.Contains(content, "Open documentation url for more info") {
+			if err := t.TapDAndEnter(); err != nil {
+				log.ErrorLog.Printf("could not tap enter on trust screen: %v", err)
+			}
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- Syncs the trust prompt fix from upstream (smtg-ai/claude-squad#263)
- Auto-dismisses "new MCP server" approval prompts in Claude Code sessions, which previously caused sessions to hang
- Restructures `CheckAndHandleTrustPrompt` to check pane content first, then branch on program type, allowing multiple prompt patterns per program

## Test plan
- [ ] Start a session with an MCP server configured — verify the "new MCP server" prompt is auto-dismissed
- [ ] Start a session without MCP — verify the "Do you trust the files?" prompt is still auto-dismissed
- [ ] Start an aider session — verify the "Open documentation url" prompt is still handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)