### PR TITLE
refactor: remove subdirectory worktree option, always create siblings

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ Configuration lives at `~/.agent-factory/config.json`:
   "auto_yes": false,
   "daemon_poll_interval": 1000,
   "branch_prefix": "username/",
-  "worktree_root": "subdirectory"
 }
 ```
 
@@ -166,7 +165,6 @@ Configuration lives at `~/.agent-factory/config.json`:
 | `auto_yes` | Auto-accept agent prompts |
 | `daemon_poll_interval` | Daemon polling interval in ms |
 | `branch_prefix` | Prefix for worktree branches (defaults to `username/`) |
-| `worktree_root` | Where worktrees are created: `subdirectory` (under `~/.agent-factory`) or `sibling` (next to repo) |
 
 Override the program per-session with `-p`:
 

--- a/config/config.go
+++ b/config/config.go
@@ -15,10 +15,6 @@ import (
 const (
 	ConfigFileName = "config.json"
 	defaultProgram = "claude"
-	// WorktreeRootSubdirectory stores worktrees under the global config subdirectory.
-	WorktreeRootSubdirectory = "subdirectory"
-	// WorktreeRootSibling stores worktrees in a sibling directory next to the repository.
-	WorktreeRootSibling = "sibling"
 )
 
 // GetConfigDir returns the path to the application's configuration directory
@@ -40,8 +36,6 @@ type Config struct {
 	DaemonPollInterval int `json:"daemon_poll_interval"`
 	// BranchPrefix is the prefix used for git branches created by the application.
 	BranchPrefix string `json:"branch_prefix"`
-	// WorktreeRoot controls where worktrees are created: "subdirectory" or "sibling".
-	WorktreeRoot string `json:"worktree_root"`
 }
 
 // DefaultConfig returns the default configuration
@@ -66,7 +60,6 @@ func DefaultConfig() *Config {
 			}
 			return fmt.Sprintf("%s/", strings.ToLower(user.Username))
 		}(),
-		WorktreeRoot: WorktreeRootSibling,
 	}
 }
 
@@ -145,10 +138,6 @@ func LoadConfig() *Config {
 	if err := json.Unmarshal(data, &config); err != nil {
 		log.ErrorLog.Printf("failed to parse config file: %v", err)
 		return DefaultConfig()
-	}
-
-	if config.WorktreeRoot == "" {
-		config.WorktreeRoot = WorktreeRootSibling
 	}
 
 	return &config

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,7 +108,6 @@ func TestDefaultConfig(t *testing.T) {
 		assert.Equal(t, 1000, config.DaemonPollInterval)
 		assert.NotEmpty(t, config.BranchPrefix)
 		assert.True(t, strings.HasSuffix(config.BranchPrefix, "/"))
-		assert.Equal(t, WorktreeRootSibling, config.WorktreeRoot)
 	})
 
 }
@@ -156,8 +155,7 @@ func TestLoadConfig(t *testing.T) {
 			"default_program": "test-claude",
 			"auto_yes": true,
 			"daemon_poll_interval": 2000,
-			"branch_prefix": "test/",
-			"worktree_root": "sibling"
+			"branch_prefix": "test/"
 		}`
 		err = os.WriteFile(configPath, []byte(configContent), 0644)
 		require.NoError(t, err)
@@ -174,31 +172,6 @@ func TestLoadConfig(t *testing.T) {
 		assert.True(t, config.AutoYes)
 		assert.Equal(t, 2000, config.DaemonPollInterval)
 		assert.Equal(t, "test/", config.BranchPrefix)
-		assert.Equal(t, WorktreeRootSibling, config.WorktreeRoot)
-	})
-
-	t.Run("defaults worktree_root when missing from existing config", func(t *testing.T) {
-		tempHome := t.TempDir()
-		configDir := filepath.Join(tempHome, ".agent-factory")
-		err := os.MkdirAll(configDir, 0755)
-		require.NoError(t, err)
-
-		configPath := filepath.Join(configDir, ConfigFileName)
-		configContent := `{
-			"default_program": "test-claude",
-			"auto_yes": true,
-			"daemon_poll_interval": 2000,
-			"branch_prefix": "test/"
-		}`
-		err = os.WriteFile(configPath, []byte(configContent), 0644)
-		require.NoError(t, err)
-
-		originalHome := os.Getenv("HOME")
-		os.Setenv("HOME", tempHome)
-		defer os.Setenv("HOME", originalHome)
-
-		loadedConfig := LoadConfig()
-		assert.Equal(t, WorktreeRootSibling, loadedConfig.WorktreeRoot)
 	})
 
 	t.Run("returns default config on invalid JSON", func(t *testing.T) {
@@ -226,7 +199,6 @@ func TestLoadConfig(t *testing.T) {
 		assert.NotEmpty(t, config.DefaultProgram)
 		assert.False(t, config.AutoYes)                  // Default value
 		assert.Equal(t, 1000, config.DaemonPollInterval) // Default value
-		assert.Equal(t, WorktreeRootSibling, config.WorktreeRoot)
 	})
 }
 
@@ -246,7 +218,6 @@ func TestSaveConfig(t *testing.T) {
 			AutoYes:            true,
 			DaemonPollInterval: 3000,
 			BranchPrefix:       "test-branch/",
-			WorktreeRoot:       WorktreeRootSibling,
 		}
 
 		err := SaveConfig(testConfig)
@@ -264,6 +235,5 @@ func TestSaveConfig(t *testing.T) {
 		assert.Equal(t, testConfig.AutoYes, loadedConfig.AutoYes)
 		assert.Equal(t, testConfig.DaemonPollInterval, loadedConfig.DaemonPollInterval)
 		assert.Equal(t, testConfig.BranchPrefix, loadedConfig.BranchPrefix)
-		assert.Equal(t, testConfig.WorktreeRoot, loadedConfig.WorktreeRoot)
 	})
 }

--- a/config/repo_test.go
+++ b/config/repo_test.go
@@ -11,16 +11,30 @@ import (
 )
 
 func TestResolveMainRepoRoot_MainRepo(t *testing.T) {
-	// When run from the main repo (this test itself), resolveMainRepoRoot
-	// should return the same path as git rev-parse --show-toplevel.
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	out, err := cmd.Output()
-	require.NoError(t, err)
-	expected := string(out)
+	// Create a standalone git repo so the test doesn't depend on cwd
+	// (which may itself be a worktree).
+	mainDir := t.TempDir()
 
-	root, err := resolveMainRepoRoot()
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v failed: %s", args, out)
+	}
+
+	run(mainDir, "init")
+	run(mainDir, "config", "user.email", "test@test.com")
+	run(mainDir, "config", "user.name", "Test")
+
+	require.NoError(t, os.WriteFile(filepath.Join(mainDir, "file.txt"), []byte("hello"), 0644))
+	run(mainDir, "add", ".")
+	run(mainDir, "commit", "-m", "init")
+
+	root, err := resolveMainRepoRoot("-C", mainDir)
 	require.NoError(t, err)
-	assert.Equal(t, expected[:len(expected)-1], root) // trim newline
+	assert.Equal(t, mainDir, root)
 }
 
 func TestResolveMainRepoRoot_Worktree(t *testing.T) {

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -11,36 +11,19 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
-func getWorktreeDirectory() (string, error) {
-	configDir, err := config.GetConfigDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(configDir, "worktrees"), nil
-}
-
+// getWorktreeDirectoryForRepo returns the parent directory of the repo,
+// so worktrees are created as siblings next to the repository.
 func getWorktreeDirectoryForRepo(repoPath string) (string, error) {
-	cfg := config.LoadConfig()
-	if cfg.WorktreeRoot == config.WorktreeRootSibling {
-		if repoPath == "" {
-			return "", fmt.Errorf("repo path is required when worktree_root is %q", config.WorktreeRootSibling)
-		}
-
-		repoRoot, err := findGitRepoRoot(repoPath)
-		if err != nil {
-			return "", err
-		}
-
-		repoParent := filepath.Dir(repoRoot)
-		return repoParent, nil
+	if repoPath == "" {
+		return "", fmt.Errorf("repo path is required for worktree creation")
 	}
 
-	configDir, err := config.GetConfigDir()
+	repoRoot, err := findGitRepoRoot(repoPath)
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(configDir, "worktrees"), nil
+	return filepath.Dir(repoRoot), nil
 }
 
 // GitWorktree manages git worktree operations for a session
@@ -111,15 +94,10 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		return nil, "", err
 	}
 
-	// Use sanitized branch name for the worktree directory name.
+	// Worktree is placed as a sibling: {repoParent}/{repoName}-{sessionName}
 	// Only append a numeric suffix if the path already exists (collision).
-	var basePath string
-	if cfg.WorktreeRoot == config.WorktreeRootSibling {
-		repoName := filepath.Base(repoPath)
-		basePath = filepath.Join(worktreeDir, repoName+"-"+sessionName)
-	} else {
-		basePath = filepath.Join(worktreeDir, branchName)
-	}
+	repoName := filepath.Base(repoPath)
+	basePath := filepath.Join(worktreeDir, repoName+"-"+sessionName)
 	worktreePath := basePath
 	for i := 2; ; i++ {
 		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -19,45 +19,18 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestGetWorktreeDirectoryForRepo_Subdirectory(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
-
-	cfg := config.DefaultConfig()
-	cfg.WorktreeRoot = config.WorktreeRootSubdirectory
-	require.NoError(t, config.SaveConfig(cfg))
-
-	worktreeDir, err := getWorktreeDirectoryForRepo(t.TempDir())
-	require.NoError(t, err)
-
-	configDir, err := config.GetConfigDir()
-	require.NoError(t, err)
-	assert.Equal(t, filepath.Join(configDir, "worktrees"), worktreeDir)
-}
-
-func TestGetWorktreeDirectoryForRepo_Sibling(t *testing.T) {
+func TestGetWorktreeDirectoryForRepo(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)
 
 	repoRoot := createGitRepo(t)
-
-	cfg := config.DefaultConfig()
-	cfg.WorktreeRoot = config.WorktreeRootSibling
-	require.NoError(t, config.SaveConfig(cfg))
 
 	worktreeDir, err := getWorktreeDirectoryForRepo(repoRoot)
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Dir(repoRoot), worktreeDir)
 }
 
-func TestGetWorktreeDirectoryForRepo_SiblingRequiresRepoPath(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
-
-	cfg := config.DefaultConfig()
-	cfg.WorktreeRoot = config.WorktreeRootSibling
-	require.NoError(t, config.SaveConfig(cfg))
-
+func TestGetWorktreeDirectoryForRepo_RequiresRepoPath(t *testing.T) {
 	_, err := getWorktreeDirectoryForRepo("")
 	require.Error(t, err)
 }
@@ -67,9 +40,9 @@ func TestNewGitWorktree_CleanName(t *testing.T) {
 	t.Setenv("HOME", tempHome)
 
 	repoRoot := createGitRepo(t)
+	repoName := filepath.Base(repoRoot)
 
 	cfg := config.DefaultConfig()
-	cfg.WorktreeRoot = config.WorktreeRootSubdirectory
 	cfg.BranchPrefix = "test/"
 	require.NoError(t, config.SaveConfig(cfg))
 
@@ -78,13 +51,12 @@ func TestNewGitWorktree_CleanName(t *testing.T) {
 
 	assert.Equal(t, "test/my-feature", branchName)
 
-	// Worktree path should end with the branch name, no hex suffix
-	assert.True(t, strings.HasSuffix(gw.GetWorktreePath(), "test/my-feature"),
-		"expected worktree path to end with 'test/my-feature', got: %s", gw.GetWorktreePath())
-	// Should NOT contain an underscore followed by hex (old format)
-	base := filepath.Base(gw.GetWorktreePath())
-	assert.False(t, strings.Contains(base, "_"),
-		"worktree path should not contain underscore hex suffix, got: %s", base)
+	expectedSuffix := repoName + "-my-feature"
+	assert.True(t, strings.HasSuffix(gw.GetWorktreePath(), expectedSuffix),
+		"expected worktree path to end with '%s', got: %s", expectedSuffix, gw.GetWorktreePath())
+
+	// Should be in the parent directory of the repo
+	assert.Equal(t, filepath.Dir(repoRoot), filepath.Dir(gw.GetWorktreePath()))
 }
 
 func TestNewGitWorktree_CollisionSuffix(t *testing.T) {
@@ -92,16 +64,18 @@ func TestNewGitWorktree_CollisionSuffix(t *testing.T) {
 	t.Setenv("HOME", tempHome)
 
 	repoRoot := createGitRepo(t)
+	repoName := filepath.Base(repoRoot)
 
 	cfg := config.DefaultConfig()
-	cfg.WorktreeRoot = config.WorktreeRootSubdirectory
 	cfg.BranchPrefix = "test/"
 	require.NoError(t, config.SaveConfig(cfg))
 
 	// Create first worktree - should get clean name
 	gw1, _, err := NewGitWorktree(repoRoot, "my-feature")
 	require.NoError(t, err)
-	assert.True(t, strings.HasSuffix(gw1.GetWorktreePath(), "test/my-feature"),
+
+	expectedSuffix := repoName + "-my-feature"
+	assert.True(t, strings.HasSuffix(gw1.GetWorktreePath(), expectedSuffix),
 		"first worktree should have clean name, got: %s", gw1.GetWorktreePath())
 
 	// Create the directory so the next call sees a collision
@@ -110,7 +84,7 @@ func TestNewGitWorktree_CollisionSuffix(t *testing.T) {
 	// Create second worktree with same name - should get -2 suffix
 	gw2, _, err := NewGitWorktree(repoRoot, "my-feature")
 	require.NoError(t, err)
-	assert.True(t, strings.HasSuffix(gw2.GetWorktreePath(), "test/my-feature-2"),
+	assert.True(t, strings.HasSuffix(gw2.GetWorktreePath(), repoName+"-my-feature-2"),
 		"second worktree should have -2 suffix, got: %s", gw2.GetWorktreePath())
 
 	// Create that directory too
@@ -119,55 +93,8 @@ func TestNewGitWorktree_CollisionSuffix(t *testing.T) {
 	// Create third worktree with same name - should get -3 suffix
 	gw3, _, err := NewGitWorktree(repoRoot, "my-feature")
 	require.NoError(t, err)
-	assert.True(t, strings.HasSuffix(gw3.GetWorktreePath(), "test/my-feature-3"),
+	assert.True(t, strings.HasSuffix(gw3.GetWorktreePath(), repoName+"-my-feature-3"),
 		"third worktree should have -3 suffix, got: %s", gw3.GetWorktreePath())
-}
-
-func TestNewGitWorktree_SiblingCleanName(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
-
-	repoRoot := createGitRepo(t)
-	repoName := filepath.Base(repoRoot)
-
-	cfg := config.DefaultConfig()
-	cfg.WorktreeRoot = config.WorktreeRootSibling
-	cfg.BranchPrefix = "test/"
-	require.NoError(t, config.SaveConfig(cfg))
-
-	gw, _, err := NewGitWorktree(repoRoot, "my-feature")
-	require.NoError(t, err)
-
-	expectedSuffix := repoName + "-my-feature"
-	assert.True(t, strings.HasSuffix(gw.GetWorktreePath(), expectedSuffix),
-		"sibling worktree should end with '%s', got: %s", expectedSuffix, gw.GetWorktreePath())
-
-	// Should be in the parent directory of the repo
-	assert.Equal(t, filepath.Dir(repoRoot), filepath.Dir(gw.GetWorktreePath()))
-}
-
-func TestNewGitWorktree_SiblingCollision(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
-
-	repoRoot := createGitRepo(t)
-	repoName := filepath.Base(repoRoot)
-
-	cfg := config.DefaultConfig()
-	cfg.WorktreeRoot = config.WorktreeRootSibling
-	cfg.BranchPrefix = "test/"
-	require.NoError(t, config.SaveConfig(cfg))
-
-	gw1, _, err := NewGitWorktree(repoRoot, "my-feature")
-	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(gw1.GetWorktreePath(), 0755))
-
-	gw2, _, err := NewGitWorktree(repoRoot, "my-feature")
-	require.NoError(t, err)
-
-	expectedSuffix := repoName + "-my-feature-2"
-	assert.True(t, strings.HasSuffix(gw2.GetWorktreePath(), expectedSuffix),
-		"sibling collision worktree should end with '%s', got: %s", expectedSuffix, gw2.GetWorktreePath())
 }
 
 func createGitRepo(t *testing.T) string {


### PR DESCRIPTION
## Summary
- Removes the `worktree_root` config option — worktrees are now always created as siblings next to the repo
- Deletes all subdirectory-mode code paths, constants, and tests (-171 lines, +47 lines)
- Fixes a flaky `TestResolveMainRepoRoot_MainRepo` test that failed when run from a worktree

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./config/ ./session/git/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)