### PR TITLE
feat: make detach key configurable

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sachiniyer/agent-factory/microclaw"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
@@ -124,6 +125,16 @@ type home struct {
 func newHome(ctx context.Context, program string, autoYes bool, repoID string) *home {
 	// Load application config
 	appConfig := config.LoadConfig()
+
+	// Apply configured detach key
+	if appConfig.DetachKeys != "" {
+		b, err := config.ParseDetachKey(appConfig.DetachKeys)
+		if err != nil {
+			fmt.Printf("Invalid detach_keys %q in config: %v\n", appConfig.DetachKeys, err)
+			os.Exit(1)
+		}
+		tmux.SetDetachKey(b, appConfig.DetachKeys)
+	}
 
 	// Load application state
 	appState := config.LoadState()

--- a/app/help.go
+++ b/app/help.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 
@@ -46,7 +47,7 @@ func (h helpTypeGeneral) toContent() string {
 		keyStyle.Render("D")+descStyle.Render("         - Kill (delete) the selected session"),
 		keyStyle.Render("↑/j, ↓/k")+descStyle.Render("  - Navigate between sessions"),
 		keyStyle.Render("↵/o")+descStyle.Render("       - Attach to the selected session"),
-		keyStyle.Render("ctrl-w")+descStyle.Render("    - Detach from session"),
+		keyStyle.Render(tmux.DetachKeyDisplay)+descStyle.Render("    - Detach from session"),
 		"",
 		headerStyle.Render("Sidebar:"),
 		keyStyle.Render("↑/j, ↓/k")+descStyle.Render("  - Navigate sidebar items"),
@@ -102,7 +103,7 @@ func (h helpTypeInstanceAttach) toContent() string {
 	content := lipgloss.JoinVertical(lipgloss.Left,
 		titleStyle.Render("Attaching to Instance"),
 		"",
-		descStyle.Render("To detach from a session, press ")+keyStyle.Render("ctrl-w"),
+		descStyle.Render("To detach from a session, press ")+keyStyle.Render(tmux.DetachKeyDisplay),
 	)
 	return content
 }

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	DaemonPollInterval int `json:"daemon_poll_interval"`
 	// BranchPrefix is the prefix used for git branches created by the application.
 	BranchPrefix string `json:"branch_prefix"`
+	// DetachKeys is the key combination used to detach from an attached session (e.g. "ctrl-w", "ctrl-q").
+	DetachKeys string `json:"detach_keys"`
 }
 
 // DefaultConfig returns the default configuration
@@ -60,6 +62,7 @@ func DefaultConfig() *Config {
 			}
 			return fmt.Sprintf("%s/", strings.ToLower(user.Username))
 		}(),
+		DetachKeys: "ctrl-w",
 	}
 }
 

--- a/config/detach_key.go
+++ b/config/detach_key.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseDetachKey parses a human-readable key name like "ctrl-w" into its ASCII byte value.
+// Supported formats:
+//   - "ctrl-a" through "ctrl-z" (case-insensitive)
+//   - "ctrl-[", "ctrl-]", "ctrl-\", "ctrl-^", "ctrl-_"
+//
+// Returns the ASCII byte and an error if the key string is not recognized.
+func ParseDetachKey(key string) (byte, error) {
+	key = strings.TrimSpace(strings.ToLower(key))
+
+	if !strings.HasPrefix(key, "ctrl-") {
+		return 0, fmt.Errorf("unsupported key format %q: must start with \"ctrl-\"", key)
+	}
+
+	suffix := key[len("ctrl-"):]
+	if len(suffix) != 1 {
+		return 0, fmt.Errorf("unsupported key format %q: expected single character after \"ctrl-\"", key)
+	}
+
+	ch := suffix[0]
+	switch {
+	case ch >= 'a' && ch <= 'z':
+		return ch - 'a' + 1, nil
+	case ch == '[':
+		return 27, nil // ESC
+	case ch == '\\':
+		return 28, nil
+	case ch == ']':
+		return 29, nil
+	case ch == '^':
+		return 30, nil
+	case ch == '_':
+		return 31, nil
+	default:
+		return 0, fmt.Errorf("unsupported key %q: character %q is not a valid ctrl- combination", key, ch)
+	}
+}

--- a/config/detach_key_test.go
+++ b/config/detach_key_test.go
@@ -27,11 +27,11 @@ func TestParseDetachKey(t *testing.T) {
 		{"ctrl-\\", 28, false},
 		{"ctrl-^", 30, false},
 		{"ctrl-_", 31, false},
-		{"w", 0, true},           // missing ctrl- prefix
-		{"ctrl-", 0, true},       // missing character
-		{"ctrl-ab", 0, true},     // too many characters
-		{"ctrl-1", 0, true},      // digit not supported
-		{"alt-w", 0, true},       // wrong prefix
+		{"w", 0, true},       // missing ctrl- prefix
+		{"ctrl-", 0, true},   // missing character
+		{"ctrl-ab", 0, true}, // too many characters
+		{"ctrl-1", 0, true},  // digit not supported
+		{"alt-w", 0, true},   // wrong prefix
 	}
 
 	for _, tt := range tests {

--- a/config/detach_key_test.go
+++ b/config/detach_key_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDetachKey(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected byte
+		wantErr  bool
+	}{
+		{"ctrl-a", 1, false},
+		{"ctrl-b", 2, false},
+		{"ctrl-c", 3, false},
+		{"ctrl-w", 23, false},
+		{"ctrl-q", 17, false},
+		{"ctrl-z", 26, false},
+		{"Ctrl-W", 23, false},   // case insensitive
+		{"CTRL-Q", 17, false},   // case insensitive
+		{" ctrl-w ", 23, false}, // trimmed
+		{"ctrl-[", 27, false},   // ESC
+		{"ctrl-]", 29, false},
+		{"ctrl-\\", 28, false},
+		{"ctrl-^", 30, false},
+		{"ctrl-_", 31, false},
+		{"w", 0, true},           // missing ctrl- prefix
+		{"ctrl-", 0, true},       // missing character
+		{"ctrl-ab", 0, true},     // too many characters
+		{"ctrl-1", 0, true},      // digit not supported
+		{"alt-w", 0, true},       // wrong prefix
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			b, err := ParseDetachKey(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, b)
+			}
+		})
+	}
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -59,6 +59,19 @@ type TmuxSession struct {
 
 const TmuxPrefix = "claudesquad_"
 
+// DetachKeyByte is the ASCII byte for the key used to detach from attached sessions.
+// Default is 23 (Ctrl-W). Set via SetDetachKey.
+var DetachKeyByte byte = 23
+
+// DetachKeyDisplay is the human-readable name for the detach key (e.g. "ctrl-w").
+var DetachKeyDisplay string = "ctrl-w"
+
+// SetDetachKey sets the global detach key byte and display name.
+func SetDetachKey(b byte, display string) {
+	DetachKeyByte = b
+	DetachKeyDisplay = display
+}
+
 var whiteSpaceRegex = regexp.MustCompile(`\s+`)
 
 func toClaudeSquadTmuxName(str string) string {
@@ -304,7 +317,7 @@ func (t *TmuxSession) Attach() (chan struct{}, error) {
 		default:
 			// If context is not done, it was likely an abnormal termination (Ctrl-D)
 			// Print warning message
-			fmt.Fprintf(os.Stderr, "\n\033[31mError: Session terminated without detaching. Use Ctrl-W to properly detach from tmux sessions.\033[0m\n")
+			fmt.Fprintf(os.Stderr, "\n\033[31mError: Session terminated without detaching. Use %s to properly detach from tmux sessions.\033[0m\n", DetachKeyDisplay)
 		}
 	}()
 
@@ -341,8 +354,8 @@ func (t *TmuxSession) Attach() (chan struct{}, error) {
 				continue
 			}
 
-			// Check for Ctrl+W (ASCII 23)
-			if nr == 1 && buf[0] == 23 {
+			// Check for detach key
+			if nr == 1 && buf[0] == DetachKeyByte {
 				// Detach from the session
 				t.Detach()
 				return


### PR DESCRIPTION
## Summary
- Adds `detach_keys` field to config (`~/.agent-factory/config.json`) allowing users to customize the key used to detach from attached sessions (default: `ctrl-w`)
- Supports any `ctrl-` key combination (e.g. `ctrl-q`, `ctrl-b`, `ctrl-]`)
- App exits with a clear error on startup if the configured value is invalid
- Help text and error messages dynamically reflect the configured key

Closes #5

## Test plan
- [ ] Verify default behavior unchanged (`ctrl-w` detaches) when `detach_keys` is not set
- [ ] Set `"detach_keys": "ctrl-q"` in config and verify `ctrl-q` detaches
- [ ] Set an invalid value (e.g. `"detach_keys": "alt-w"`) and verify app exits with error
- [ ] Verify help screen (`?`) shows the configured key
- [ ] Run `go test ./...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)