### PR TITLE
Auto-refresh external instance and board changes in TUI

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/board"
 	"github.com/sachiniyer/agent-factory/config"
@@ -197,7 +196,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repoID string) *
 	// Load tasks for sidebar display
 	tasks, err := task.LoadTasksForCurrentRepo()
 	if err != nil {
-		log.WarningLog.Printf("Failed to load tasks: %v", err)
+		log.WarningLog.Printf("failed to load tasks: %v", err)
 	} else {
 		h.sidebar.SetTasks(tasks)
 	}
@@ -205,7 +204,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repoID string) *
 	// Load board for sidebar display and kanban pane
 	b, err := board.LoadBoard()
 	if err != nil {
-		log.WarningLog.Printf("Failed to load board: %v", err)
+		log.WarningLog.Printf("failed to load board: %v", err)
 	} else {
 		h.sidebar.SetTaskCount(b.TaskCount())
 		h.contentPane.KanbanPane().SetBoard(b)
@@ -219,7 +218,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repoID string) *
 	// Load hooks for sidebar display and hooks pane
 	repoCfg, err := config.LoadRepoConfig(repoID)
 	if err != nil {
-		log.WarningLog.Printf("Failed to load repo config: %v", err)
+		log.WarningLog.Printf("failed to load repo config: %v", err)
 	} else {
 		h.sidebar.SetHookCount(len(repoCfg.PostWorktreeCommands))
 		h.contentPane.HooksPane().SetCommands(repoCfg.PostWorktreeCommands)
@@ -260,73 +259,6 @@ func (m *home) updateHandleWindowSizeEvent(msg tea.WindowSizeMsg) {
 	m.menu.SetSize(msg.Width, menuHeight)
 }
 
-// mergePendingInstances loads pending instances written by scheduled task runs,
-// adds matching ones to the sidebar, and routes others to their per-repo storage.
-func (m *home) mergePendingInstances() int {
-	pendingData, err := task.LoadAndClearPendingInstances()
-	if err != nil {
-		log.WarningLog.Printf("Failed to load pending instances: %v", err)
-		return 0
-	}
-
-	var otherRepoPending []session.InstanceData
-	var mergedCount int
-	for _, data := range pendingData {
-		rid := config.RepoIDFromRoot(data.Worktree.RepoPath)
-		if rid == m.repoID {
-			pendingInstance, err := session.FromInstanceData(data)
-			if err != nil {
-				log.WarningLog.Printf("Failed to restore pending instance %s: %v", data.Title, err)
-				continue
-			}
-			m.sidebar.AddInstance(pendingInstance)()
-			if m.autoYes {
-				pendingInstance.AutoYes = true
-			}
-			mergedCount++
-		} else {
-			otherRepoPending = append(otherRepoPending, data)
-		}
-	}
-
-	if len(otherRepoPending) > 0 {
-		grouped := make(map[string][]session.InstanceData)
-		for _, d := range otherRepoPending {
-			rid := config.RepoIDFromRoot(d.Worktree.RepoPath)
-			grouped[rid] = append(grouped[rid], d)
-		}
-		for rid, group := range grouped {
-			existing, err := config.LoadRepoInstances(rid)
-			if err != nil {
-				log.WarningLog.Printf("Failed to load existing instances for repo %s: %v", rid, err)
-			}
-			var existingData []session.InstanceData
-			if existing != nil && string(existing) != "[]" && string(existing) != "null" {
-				if err := json.Unmarshal(existing, &existingData); err != nil {
-					log.WarningLog.Printf("Failed to parse existing instances for repo %s: %v", rid, err)
-				}
-			}
-			existingData = append(existingData, group...)
-			jsonData, err := json.Marshal(existingData)
-			if err != nil {
-				log.WarningLog.Printf("Failed to marshal instances for repo %s: %v", rid, err)
-				continue
-			}
-			if err := config.SaveRepoInstances(rid, jsonData); err != nil {
-				log.WarningLog.Printf("Failed to save instances for repo %s: %v", rid, err)
-			}
-		}
-	}
-
-	if mergedCount > 0 {
-		if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
-			log.WarningLog.Printf("Failed to save merged instances: %v", err)
-		}
-	}
-
-	return mergedCount
-}
-
 func (m *home) Init() tea.Cmd {
 	return tea.Batch(
 		m.spinner.Tick,
@@ -337,6 +269,7 @@ func (m *home) Init() tea.Cmd {
 		tickUpdateMetadataCmd,
 		tickUpdatePRInfoCmd,
 		tickPendingInstancesCmd,
+		tickRefreshExternalCmd,
 	)
 }
 
@@ -370,6 +303,18 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickPendingInstancesMessage:
 		m.mergePendingInstances()
 		return m, tickPendingInstancesCmd
+	case tickRefreshExternalMessage:
+		changed := m.refreshExternalInstances()
+		m.refreshExternalBoard()
+		var cmds []tea.Cmd
+		cmds = append(cmds, tickRefreshExternalCmd)
+		if changed {
+			if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
+				log.WarningLog.Printf("failed to save instances after refresh: %v", err)
+			}
+			cmds = append(cmds, m.selectionChanged())
+		}
+		return m, tea.Batch(cmds...)
 	case tickUpdateMetadataMessage:
 		for _, instance := range m.sidebar.GetInstances() {
 			if !instance.Started() {
@@ -890,30 +835,12 @@ func (m *home) keydownCallback(name keys.KeyName) tea.Cmd {
 
 type hideErrMsg struct{}
 type previewTickMsg struct{}
-type tickUpdateMetadataMessage struct{}
-type tickUpdatePRInfoMessage struct{}
-type tickPendingInstancesMessage struct{}
 type instanceChangedMsg struct{}
 
 type instanceStartedMsg struct {
 	instance        *session.Instance
 	err             error
 	promptAfterName bool
-}
-
-var tickUpdateMetadataCmd = func() tea.Msg {
-	time.Sleep(500 * time.Millisecond)
-	return tickUpdateMetadataMessage{}
-}
-
-var tickUpdatePRInfoCmd = func() tea.Msg {
-	time.Sleep(60 * time.Second)
-	return tickUpdatePRInfoMessage{}
-}
-
-var tickPendingInstancesCmd = func() tea.Msg {
-	time.Sleep(5 * time.Second)
-	return tickPendingInstancesMessage{}
 }
 
 func (m *home) handleError(err error) tea.Cmd {

--- a/app/help.go
+++ b/app/help.go
@@ -143,7 +143,7 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func()) (tea.Model, t
 	if alwaysShow || (m.appState.GetHelpScreensSeen()&flag) == 0 {
 		// Mark this help screen as seen and save state
 		if err := m.appState.SetHelpScreensSeen(m.appState.GetHelpScreensSeen() | flag); err != nil {
-			log.WarningLog.Printf("Failed to save help screen state: %v", err)
+			log.WarningLog.Printf("failed to save help screen state: %v", err)
 		}
 
 		content := helpType.toContent()

--- a/app/sync.go
+++ b/app/sync.go
@@ -1,0 +1,178 @@
+package app
+
+import (
+	"encoding/json"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/board"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// -- Ticker message types --
+
+type tickUpdateMetadataMessage struct{}
+type tickUpdatePRInfoMessage struct{}
+type tickPendingInstancesMessage struct{}
+type tickRefreshExternalMessage struct{}
+
+// -- Ticker commands --
+// Each ticker sleeps for a fixed interval, then returns its message type to
+// re-enter Update(). The ticker is re-scheduled at the end of its handler.
+
+var tickUpdateMetadataCmd = func() tea.Msg {
+	time.Sleep(500 * time.Millisecond)
+	return tickUpdateMetadataMessage{}
+}
+
+var tickUpdatePRInfoCmd = func() tea.Msg {
+	time.Sleep(60 * time.Second)
+	return tickUpdatePRInfoMessage{}
+}
+
+// tickPendingInstancesCmd processes one-shot pending instances written by
+// scheduled task runs (cleared after reading). Runs every 5s.
+var tickPendingInstancesCmd = func() tea.Msg {
+	time.Sleep(5 * time.Second)
+	return tickPendingInstancesMessage{}
+}
+
+// tickRefreshExternalCmd reconciles the sidebar and board with on-disk state
+// to pick up changes made via the CLI (e.g. `af api sessions create/kill`,
+// `af api board add/remove`). Runs every 3s.
+var tickRefreshExternalCmd = func() tea.Msg {
+	time.Sleep(3 * time.Second)
+	return tickRefreshExternalMessage{}
+}
+
+// -- Sync methods --
+
+// mergePendingInstances loads pending instances written by scheduled task runs,
+// adds matching ones to the sidebar, and routes others to their per-repo storage.
+func (m *home) mergePendingInstances() int {
+	pendingData, err := task.LoadAndClearPendingInstances()
+	if err != nil {
+		log.WarningLog.Printf("failed to load pending instances: %v", err)
+		return 0
+	}
+
+	var otherRepoPending []session.InstanceData
+	var mergedCount int
+	for _, data := range pendingData {
+		rid := config.RepoIDFromRoot(data.Worktree.RepoPath)
+		if rid == m.repoID {
+			pendingInstance, err := session.FromInstanceData(data)
+			if err != nil {
+				log.WarningLog.Printf("failed to restore pending instance %s: %v", data.Title, err)
+				continue
+			}
+			m.sidebar.AddInstance(pendingInstance)()
+			if m.autoYes {
+				pendingInstance.AutoYes = true
+			}
+			mergedCount++
+		} else {
+			otherRepoPending = append(otherRepoPending, data)
+		}
+	}
+
+	if len(otherRepoPending) > 0 {
+		grouped := make(map[string][]session.InstanceData)
+		for _, d := range otherRepoPending {
+			rid := config.RepoIDFromRoot(d.Worktree.RepoPath)
+			grouped[rid] = append(grouped[rid], d)
+		}
+		for rid, group := range grouped {
+			existing, err := config.LoadRepoInstances(rid)
+			if err != nil {
+				log.WarningLog.Printf("failed to load existing instances for repo %s: %v", rid, err)
+			}
+			var existingData []session.InstanceData
+			if existing != nil && string(existing) != "[]" && string(existing) != "null" {
+				if err := json.Unmarshal(existing, &existingData); err != nil {
+					log.WarningLog.Printf("failed to parse existing instances for repo %s: %v", rid, err)
+				}
+			}
+			existingData = append(existingData, group...)
+			jsonData, err := json.Marshal(existingData)
+			if err != nil {
+				log.WarningLog.Printf("failed to marshal instances for repo %s: %v", rid, err)
+				continue
+			}
+			if err := config.SaveRepoInstances(rid, jsonData); err != nil {
+				log.WarningLog.Printf("failed to save instances for repo %s: %v", rid, err)
+			}
+		}
+	}
+
+	if mergedCount > 0 {
+		if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
+			log.WarningLog.Printf("failed to save merged instances: %v", err)
+		}
+	}
+
+	return mergedCount
+}
+
+// refreshExternalInstances reconciles the sidebar's in-memory instances with
+// the on-disk instances.json. Returns true if anything changed.
+func (m *home) refreshExternalInstances() bool {
+	diskData, err := m.storage.LoadInstanceData()
+	if err != nil {
+		log.WarningLog.Printf("failed to load instance data for refresh: %v", err)
+		return false
+	}
+
+	sidebarTitles := m.sidebar.GetInstanceTitles()
+	diskTitles := make(map[string]bool, len(diskData))
+	for _, d := range diskData {
+		diskTitles[d.Title] = true
+	}
+
+	changed := false
+
+	// Add instances that exist on disk but not in sidebar.
+	for _, d := range diskData {
+		if !sidebarTitles[d.Title] {
+			inst, err := session.FromInstanceData(d)
+			if err != nil {
+				log.WarningLog.Printf("failed to restore external instance %q: %v", d.Title, err)
+				continue
+			}
+			m.sidebar.AddInstance(inst)()
+			if m.autoYes {
+				inst.AutoYes = true
+			}
+			changed = true
+		}
+	}
+
+	// Remove instances that exist in sidebar but not on disk.
+	// Skip instances with Loading status (TUI is currently creating them).
+	for _, inst := range m.sidebar.GetInstances() {
+		if !diskTitles[inst.Title] && inst.Status != session.Loading {
+			m.sidebar.RemoveInstanceByTitle(inst.Title)
+			changed = true
+		}
+	}
+
+	return changed
+}
+
+// refreshExternalBoard reconciles the kanban board with the on-disk state.
+func (m *home) refreshExternalBoard() {
+	kp := m.contentPane.KanbanPane()
+	if kp.IsDirty() || kp.HasFocus() {
+		return
+	}
+	b, err := board.LoadBoard()
+	if err != nil {
+		log.WarningLog.Printf("failed to load board for refresh: %v", err)
+		return
+	}
+	kp.SetBoard(b)
+	m.sidebar.SetTaskCount(b.TaskCount())
+}

--- a/session/storage.go
+++ b/session/storage.go
@@ -79,13 +79,9 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 	}
 
 	if s.repoID != "" {
-		// TUI mode: merge with on-disk state to preserve externally-created sessions
-		// (e.g. sessions created by `af api sessions create` while the TUI was running)
-		merged, err := s.mergeWithDisk(data)
-		if err != nil {
-			return fmt.Errorf("failed to merge instances: %w", err)
-		}
-		jsonData, err := json.Marshal(merged)
+		// TUI mode: the sidebar is the source of truth; external instances
+		// are already pulled in by the periodic refreshExternalInstances tick.
+		jsonData, err := json.Marshal(data)
 		if err != nil {
 			return fmt.Errorf("failed to marshal instances: %w", err)
 		}
@@ -182,38 +178,19 @@ func (s *Storage) DeleteInstance(title string) error {
 	return s.state.SaveInstances(s.repoID, out)
 }
 
-// mergeWithDisk reads the current on-disk instances and merges them with the
-// in-memory set. Instances known to the TUI (by title) are replaced with the
-// in-memory version. Instances that only exist on disk (created externally)
-// are preserved.
-func (s *Storage) mergeWithDisk(memoryData []InstanceData) ([]InstanceData, error) {
+// LoadInstanceData reads and unmarshals instance data from disk without
+// constructing live Instance objects (no tmux session restoration).
+// Used for lightweight comparison against in-memory state.
+func (s *Storage) LoadInstanceData() ([]InstanceData, error) {
 	raw := s.state.GetInstances(s.repoID)
 	if raw == nil || string(raw) == "[]" || string(raw) == "null" {
-		return memoryData, nil
+		return nil, nil
 	}
-
-	var diskData []InstanceData
-	if err := json.Unmarshal(raw, &diskData); err != nil {
-		// Can't parse disk data, just use memory
-		return memoryData, nil
+	var data []InstanceData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal instances: %w", err)
 	}
-
-	// Build a set of titles the TUI knows about
-	knownTitles := make(map[string]bool, len(memoryData))
-	for _, d := range memoryData {
-		knownTitles[d.Title] = true
-	}
-
-	// Keep disk-only instances (ones the TUI doesn't know about)
-	merged := make([]InstanceData, 0, len(memoryData)+len(diskData))
-	merged = append(merged, memoryData...)
-	for _, d := range diskData {
-		if !knownTitles[d.Title] {
-			merged = append(merged, d)
-		}
-	}
-
-	return merged, nil
+	return data, nil
 }
 
 // DeleteAllInstances removes all stored instances

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -363,6 +363,34 @@ func (s *Sidebar) GetInstances() []*session.Instance {
 	return s.instances
 }
 
+// GetInstanceTitles returns a set of all instance titles for quick comparison.
+func (s *Sidebar) GetInstanceTitles() map[string]bool {
+	titles := make(map[string]bool, len(s.instances))
+	for _, inst := range s.instances {
+		titles[inst.Title] = true
+	}
+	return titles
+}
+
+// RemoveInstanceByTitle removes an instance from the sidebar by title without
+// killing it (the external process already cleaned up tmux/worktree).
+func (s *Sidebar) RemoveInstanceByTitle(title string) bool {
+	for i, inst := range s.instances {
+		if inst.Title == title {
+			repoName, err := inst.RepoName()
+			if err != nil {
+				log.ErrorLog.Printf("could not get repo name: %v", err)
+			} else {
+				s.rmRepo(repoName)
+			}
+			s.instances = append(s.instances[:i], s.instances[i+1:]...)
+			s.rebuildVisibleItems()
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Sidebar) addRepo(repo string) {
 	if _, ok := s.repos[repo]; !ok {
 		s.repos[repo] = 0


### PR DESCRIPTION
## Summary
- Adds a 3-second polling ticker that reconciles the TUI's in-memory instances and board state with on-disk JSON, so changes made via `af api sessions create/kill` and `af api board add/remove/move/link/unlink` appear in the running TUI without restart
- Removes the now-redundant `mergeWithDisk()` call from `SaveInstances()` — the sidebar is kept in sync by the refresh ticker, so the extra disk read + merge on every save is no longer needed
- Extracts all sync/ticker logic (4 tickers + merge/refresh methods) from `app.go` into a new `app/sync.go` for better navigability
- Standardizes log message casing to lowercase throughout the `app/` package

## Changes
| File | What |
|------|------|
| `session/storage.go` | Add `LoadInstanceData()`, remove `mergeWithDisk()` |
| `ui/sidebar.go` | Add `GetInstanceTitles()`, `RemoveInstanceByTitle()` |
| `app/sync.go` | **New** — all ticker definitions and sync methods extracted here |
| `app/app.go` | Wire ticker into Init/Update, remove extracted code, fix log casing |
| `app/help.go` | Fix log casing |

## Safety considerations
- Instances in `Loading` state are skipped during removal (not yet persisted to disk)
- Board refresh is skipped when the kanban pane is dirty or focused (avoids overwriting local edits)
- JSON file writes are effectively atomic; worst case is reading stale data corrected on next tick

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Start TUI, run `af api sessions create --name test --repo .` in another terminal — instance appears within ~3s
- [ ] Run `af api sessions kill test` — instance disappears within ~3s
- [ ] Run `af api board add --title "ext task"` — task appears in kanban within ~3s (when board is not focused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)