### PR TITLE
fix: prevent panic when background refresh removes instance during stateNew

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -138,6 +138,7 @@ func (m *home) startNewInstance(promptAfterName bool) (tea.Model, tea.Cmd) {
 	if err != nil {
 		return m, m.handleError(err)
 	}
+	instance.SetStatus(session.Loading)
 	m.newInstanceFinalizer = m.sidebar.AddInstance(instance)
 	m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
 	m.state = stateNew

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -35,6 +35,7 @@ func (m *home) handleStateSelectWorktree(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, m.handleError(err)
 			}
 
+			instance.SetStatus(session.Loading)
 			m.newInstanceFinalizer = m.sidebar.AddInstance(instance)
 			m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
 			m.state = stateNew


### PR DESCRIPTION
## Summary

**Bug:** `runtime error: index out of range [-1]` panic in `handleStateNew` (`handle_input.go:30`).

### Root Cause

When a user starts creating a new instance, two things happen concurrently:

1. `startNewInstance` (or the worktree selection path) creates a `session.Instance` with:
   - `Title: ""` (empty — user hasn't named it yet)
   - `Status: Ready` (the default from `NewInstance`)
   - Adds it to the sidebar, sets `m.state = stateNew`

2. A background tick (`tickRefreshExternalMessage`) periodically calls `refreshExternalInstances`, which reconciles the sidebar against the on-disk `instances.json`. Its removal loop:
   ```go
   // Skip instances with Loading status (TUI is currently creating them).
   for _, inst := range m.sidebar.GetInstances() {
       if !diskTitles[inst.Title] && inst.Status != session.Loading {
           m.sidebar.RemoveInstanceByTitle(inst.Title)
       }
   }
   ```
   The new instance has `Status: Ready` and `Title: ""` (never saved to disk), so it satisfies both conditions and gets removed.

3. With 0 instances in the sidebar but `m.state` still `stateNew`, the next keypress reaches:
   ```go
   instance := m.sidebar.GetInstances()[m.sidebar.NumInstances()-1]
   //                                                           ^^ -1 when empty
   ```
   → **panic: index out of range [-1]**

### Fix

Set the instance status to `Loading` immediately before adding it to the sidebar, in both code paths that enter `stateNew`:

- `startNewInstance` in `app/handle_input.go`
- The worktree selection path in `app/handle_overlay.go`

This is consistent with the existing guard comment in `refreshExternalInstances` — "the TUI is currently creating them" applies to the naming phase too, not just post-Enter startup.

## Test plan

- [ ] Start `af` with no existing instances; press the new-instance key and wait 2+ seconds (longer than the refresh interval) before typing a name — should no longer panic
- [ ] Same test via the worktree selection overlay
- [ ] Pressing Escape or Ctrl+C while naming still cancels correctly
- [ ] Normal happy-path instance creation still works end-to-end