### PR TITLE
feat: spawn instance from board task (TUI + CLI)

### DIFF
--- a/api/board.go
+++ b/api/board.go
@@ -262,7 +262,19 @@ var boardSpawnCmd = &cobra.Command{
 		// Determine session name and program
 		sessionName := boardSpawnNameFlag
 		if sessionName == "" {
-			sessionName = fmt.Sprintf("task-%s", t.ID)
+			// Auto-generate from task title, avoiding clashes with existing instances.
+			existingTitles := make(map[string]bool)
+			if allInstances, err := config.LoadAllRepoInstances(); err == nil {
+				for _, raw := range allInstances {
+					var instances []session.InstanceData
+					if err := json.Unmarshal(raw, &instances); err == nil {
+						for _, inst := range instances {
+							existingTitles[inst.Title] = true
+						}
+					}
+				}
+			}
+			sessionName = board.GenerateInstanceTitle(t.Title, existingTitles)
 		}
 
 		program := boardSpawnProgramFlag

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -6,11 +6,13 @@ import (
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -264,6 +266,75 @@ func (m *home) handleOpenPR() (tea.Model, tea.Cmd) {
 		return m, m.handleError(fmt.Errorf("failed to open PR: %w", err))
 	}
 	return m, nil
+}
+
+// handleBoardSpawn creates a new instance from a board task, using the task title as the prompt.
+func (m *home) handleBoardSpawn(bt *board.Task) tea.Cmd {
+	if m.sidebar.NumInstances() >= GlobalInstanceLimit {
+		return m.handleError(fmt.Errorf("you can't create more than %d instances", GlobalInstanceLimit))
+	}
+
+	// Auto-generate a unique instance title from the task title.
+	existing := make(map[string]bool, len(m.sidebar.GetInstances()))
+	for _, inst := range m.sidebar.GetInstances() {
+		existing[inst.Title] = true
+	}
+	title := board.GenerateInstanceTitle(bt.Title, existing)
+
+	instance, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    ".",
+		Program: m.program,
+	})
+	if err != nil {
+		return m.handleError(fmt.Errorf("failed to create instance: %w", err))
+	}
+
+	finalizer := m.sidebar.AddInstance(instance)
+	m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
+	instance.SetStatus(session.Loading)
+	finalizer()
+	m.menu.SetState(ui.StateDefault)
+
+	// Link the board task to the new instance and move to in_progress.
+	kp := m.contentPane.KanbanPane()
+	if b := kp.GetBoard(); b != nil {
+		b.LinkTask(bt.ID, title)
+		if err := b.MoveTask(bt.ID, "in_progress"); err != nil {
+			log.ErrorLog.Printf("failed to move task to in_progress: %v", err)
+		}
+		if err := board.SaveBoard(b); err != nil {
+			log.ErrorLog.Printf("failed to save board: %v", err)
+		}
+		kp.SetBoard(b)
+		m.sidebar.SetTaskCount(b.TaskCount())
+	}
+
+	prompt := bt.Title
+	startCmd := func() tea.Msg {
+		if err := instance.Start(true); err != nil {
+			return instanceStartedMsg{instance: instance, err: err}
+		}
+
+		if err := task.WaitForReady(instance); err != nil {
+			return instanceStartedMsg{instance: instance, err: err}
+		}
+
+		if instance.CheckAndHandleTrustPrompt() {
+			time.Sleep(1 * time.Second)
+			if err := task.WaitForReady(instance); err != nil {
+				return instanceStartedMsg{instance: instance, err: err}
+			}
+		}
+
+		if err := instance.SendPromptCommand(prompt); err != nil {
+			return instanceStartedMsg{instance: instance, err: err}
+		}
+
+		return instanceStartedMsg{instance: instance, err: nil}
+	}
+
+	return tea.Batch(tea.WindowSize(), m.selectionChanged(), startCmd)
 }
 
 // handleCopyPR copies the PR URL to the clipboard.

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -214,6 +214,9 @@ func (m *home) handleContentPaneFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 	if taskID := kp.ConsumePendingLink(); taskID != "" {
 		return m, m.showLinkInstanceOverlay(taskID), true
 	}
+	if spawnTask := kp.ConsumePendingSpawn(); spawnTask != nil {
+		return m, m.handleBoardSpawn(spawnTask), true
+	}
 
 	// Check if a new task was submitted via the inline form
 	sp := m.contentPane.TaskPane()

--- a/board/board.go
+++ b/board/board.go
@@ -9,6 +9,7 @@ import (
 
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -259,4 +260,32 @@ func generateID() string {
 	b := make([]byte, 4)
 	rand.Read(b)
 	return hex.EncodeToString(b)
+}
+
+// GenerateInstanceTitle creates a short, unique session title from a task description.
+// existingTitles is the set of titles already in use.
+func GenerateInstanceTitle(taskTitle string, existingTitles map[string]bool) string {
+	base := strings.TrimSpace(taskTitle)
+	if len(base) > 24 {
+		base = base[:24]
+		if idx := strings.LastIndex(base, " "); idx > 8 {
+			base = base[:idx]
+		}
+	}
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "board-task"
+	}
+
+	candidate := base
+	if !existingTitles[candidate] {
+		return candidate
+	}
+	for i := 2; i < 100; i++ {
+		candidate = fmt.Sprintf("%s-%d", base, i)
+		if !existingTitles[candidate] {
+			return candidate
+		}
+	}
+	return candidate
 }

--- a/ui/kanban_pane.go
+++ b/ui/kanban_pane.go
@@ -37,6 +37,7 @@ type KanbanPane struct {
 	pendingJumpInstance   string
 	pendingAttachInstance string
 	pendingLinkTaskID     string
+	pendingSpawnTask      *board.Task
 	statusMsg             string
 }
 
@@ -76,6 +77,13 @@ func (k *KanbanPane) ConsumePendingLink() string {
 	id := k.pendingLinkTaskID
 	k.pendingLinkTaskID = ""
 	return id
+}
+
+// ConsumePendingSpawn returns and clears the pending spawn task.
+func (k *KanbanPane) ConsumePendingSpawn() *board.Task {
+	t := k.pendingSpawnTask
+	k.pendingSpawnTask = nil
+	return t
 }
 
 // ConsumeStatusMsg returns and clears any status message (e.g. error feedback).
@@ -182,6 +190,16 @@ func (k *KanbanPane) HandleKeyPress(msg tea.KeyMsg) bool {
 					k.pendingAttachInstance = t.InstanceTitle
 				} else {
 					k.pendingLinkTaskID = t.ID
+				}
+			}
+			return true
+		case "N":
+			if t := k.getTaskAtFlat(k.selectedIdx); t != nil {
+				if t.InstanceTitle != "" {
+					k.statusMsg = "task already linked to a session"
+				} else {
+					spawned := *t
+					k.pendingSpawnTask = &spawned
 				}
 			}
 			return true
@@ -571,6 +589,6 @@ func (k *KanbanPane) writeHints(b *strings.Builder) {
 	} else if k.carrying {
 		b.WriteString(kanbanHintStyle.Render("m drop here | j/k position | h/l column | esc cancel"))
 	} else {
-		b.WriteString(kanbanHintStyle.Render("j/k navigate | h/l column | n add | m move | d del | o open | a link/attach | c clear done"))
+		b.WriteString(kanbanHintStyle.Render("j/k navigate | h/l column | n add | N spawn | m move | d del | o open | a link/attach | c clear done"))
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `N` hotkey in the focused kanban board to spawn a new Claude Code instance from the selected task's title
- Updates `af api board spawn` CLI to auto-generate session names from task text (instead of `task-<id>`) when `--name` is not provided
- Shared `GenerateInstanceTitle` in `board` package truncates to 24 chars at word boundaries with dedup suffixes (`-2`, `-3`, etc.)

Closes #12

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: focus board → select task → press `N` → instance spawns with task text as prompt
- [ ] Manual: `af api board spawn <id>` generates a readable title from task text
- [ ] Manual: duplicate titles get `-2` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)