### PR TITLE
fix: prevent race condition removing spawned instances from sidebar

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -319,10 +319,11 @@ var sessionsKillCmd = &cobra.Command{
 			log.ErrorLog.Printf("failed to delete instance from storage: %v", err)
 		}
 
-		// Auto-move linked board task to "done"
+		// Auto-move linked board task to "done" and unlink it.
 		b, boardErr := board.LoadBoard()
 		if boardErr == nil {
 			if linkedTask := b.FindTaskByInstance(args[0]); linkedTask != nil {
+				b.UnlinkTask(linkedTask.ID)
 				if err := b.MoveTask(linkedTask.ID, "done"); err == nil {
 					if err := board.SaveBoard(b); err != nil {
 						log.ErrorLog.Printf("failed to save board after moving task to done: %v", err)

--- a/app/app.go
+++ b/app/app.go
@@ -344,7 +344,30 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.sidebar.SelectInstance(msg.instance)
 
 		if msg.err != nil {
+			// Unlink any board task that was linked to this failed instance.
+			kp := m.contentPane.KanbanPane()
+			if b := kp.GetBoard(); b != nil {
+				if linkedTask := b.FindTaskByInstance(msg.instance.Title); linkedTask != nil {
+					if err := b.UnlinkTask(linkedTask.ID); err != nil {
+						log.ErrorLog.Printf("failed to unlink task: %v", err)
+					}
+					if err := b.MoveTask(linkedTask.ID, "backlog"); err != nil {
+						log.ErrorLog.Printf("failed to move task to backlog: %v", err)
+					}
+					if err := board.SaveBoard(b); err != nil {
+						log.ErrorLog.Printf("failed to save board after unlinking failed instance: %v", err)
+					}
+					kp.SetBoard(b)
+				}
+			}
+
 			m.sidebar.Kill()
+
+			// Save to disk to remove the pre-saved instance entry.
+			if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
+				log.ErrorLog.Printf("failed to save instances after kill: %v", err)
+			}
+
 			return m, tea.Batch(m.handleError(msg.err), m.selectionChanged())
 		}
 
@@ -528,6 +551,8 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 		}
 		m.sidebar.SetTaskCount(b.TaskCount())
 	}
+
+	m.preSaveInstances()
 
 	prompt := tsk.Prompt
 	taskID := tsk.ID
@@ -800,6 +825,15 @@ type instanceStartedMsg struct {
 	instance        *session.Instance
 	err             error
 	promptAfterName bool
+}
+
+// preSaveInstances persists the current sidebar instances to disk so that
+// refreshExternalInstances won't remove a newly-created instance whose
+// status transitions from Loading to Running during async Start().
+func (m *home) preSaveInstances() {
+	if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
+		log.ErrorLog.Printf("failed to pre-save instance: %v", err)
+	}
 }
 
 func (m *home) handleError(err error) tea.Cmd {

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -160,9 +160,10 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 			log.ErrorLog.Printf("failed to delete instance from storage: %v", err)
 		}
 
-		// Auto-move linked board task to "done"
+		// Auto-move linked board task to "done" and unlink it.
 		if b := m.contentPane.KanbanPane().GetBoard(); b != nil {
 			if linkedTask := b.FindTaskByInstance(selected.Title); linkedTask != nil {
+				b.UnlinkTask(linkedTask.ID)
 				if err := b.MoveTask(linkedTask.ID, "done"); err == nil {
 					if err := board.SaveBoard(b); err != nil {
 						log.ErrorLog.Printf("failed to save board after moving task to done: %v", err)
@@ -282,6 +283,8 @@ func (m *home) handleBoardSpawn(bt *board.Task) tea.Cmd {
 		kp.SetBoard(b)
 		m.sidebar.SetTaskCount(b.TaskCount())
 	}
+
+	m.preSaveInstances()
 
 	prompt := bt.Title
 	startCmd := func() tea.Msg {


### PR DESCRIPTION
## Summary
- Pre-save instances to disk before async `Start()` in `handleBoardSpawn` and `handleTaskTrigger`, preventing `refreshExternalInstances` from removing them during the Loading→Running status transition
- Unlink board tasks when instance spawn fails (moves task back to backlog)
- Unlink board tasks when instances are killed (previously left orphaned `InstanceTitle` on "done" tasks)
- Extract `preSaveInstances()` helper to deduplicate the pre-save pattern
- Add error checking on `UnlinkTask`/`MoveTask` calls

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: spawn instance from board via N hotkey, verify it persists in sidebar
- [ ] Manual: kill spawned instance, verify board task is unlinked and moved to done

🤖 Generated with [Claude Code](https://claude.com/claude-code)