### PR TITLE
Remove: dead showPromptOverlay method and unused import

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui"
-	"github.com/sachiniyer/agent-factory/ui/overlay"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-runewidth"
@@ -145,11 +144,4 @@ func (m *home) startNewInstance(promptAfterName bool) (tea.Model, tea.Cmd) {
 	m.menu.SetState(ui.StateNewInstance)
 	m.promptAfterName = promptAfterName
 	return m, nil
-}
-
-// showPromptOverlay displays the prompt text input overlay for the selected instance.
-func (m *home) showPromptOverlay() {
-	m.state = statePrompt
-	m.menu.SetState(ui.StatePrompt)
-	m.textInputOverlay = overlay.NewTextInputOverlay("Enter prompt", "")
 }


### PR DESCRIPTION
## What
`showPromptOverlay()` in `app/handle_input.go` was defined but never called. Every call site sets up the text input overlay inline. Removing it also eliminates the now-unused `ui/overlay` import in that file.

## Verification
- [x] `go build ./...` passes
- [x] `go test ./...` passes (pre-existing unrelated test failures in config/session/git packages due to macOS /var vs /private/var symlink resolution)

Net: -7 lines