### PR TITLE
fix: race condition causing orphaned tmux sessions on scheduled task trigger

### DIFF
--- a/api/board.go
+++ b/api/board.go
@@ -298,6 +298,7 @@ var boardSpawnCmd = &cobra.Command{
 		if err := instance.Start(true); err != nil {
 			return jsonError(fmt.Errorf("failed to start instance: %w", err))
 		}
+		instance.SetStatus(session.Running)
 
 		// Wait for ready and send the task title as the prompt
 		if err := task.WaitForReady(instance); err != nil {

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -118,6 +118,7 @@ var sessionsCreateCmd = &cobra.Command{
 		if err := instance.Start(true); err != nil {
 			return jsonError(fmt.Errorf("failed to start instance: %w", err))
 		}
+		instance.SetStatus(session.Running)
 
 		if createPromptFlag != "" {
 			if err := task.WaitForReady(instance); err != nil {
@@ -214,6 +215,7 @@ or use 'af api sessions create --name <title> --prompt <prompt>' instead.`,
 			if err := instance.Start(true); err != nil {
 				return jsonError(fmt.Errorf("failed to start instance: %w", err))
 			}
+			instance.SetStatus(session.Running)
 
 			if err := task.WaitForReady(instance); err != nil {
 				return jsonError(fmt.Errorf("program did not become ready: %w", err))

--- a/app/app.go
+++ b/app/app.go
@@ -296,7 +296,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(cmds...)
 	case tickUpdateMetadataMessage:
 		for _, instance := range m.sidebar.GetInstances() {
-			if !instance.Started() {
+			if !instance.Started() || instance.Status == session.Loading {
 				continue
 			}
 			instance.CheckAndHandleTrustPrompt()
@@ -368,6 +368,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(m.handleError(msg.err), m.selectionChanged())
 		}
 
+		msg.instance.SetStatus(session.Running)
 		if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
 			return m, m.handleError(err)
 		}

--- a/session/instance.go
+++ b/session/instance.go
@@ -277,9 +277,6 @@ func (i *Instance) Start(firstTimeSetup bool) error {
 		}
 	}
 
-	// SetStatus acquires its own lock.
-	i.SetStatus(Running)
-
 	return nil
 }
 
@@ -314,7 +311,6 @@ func (i *Instance) StartWithExistingWorktree(worktreePath, branchName string) er
 
 	i.mu.Lock()
 	i.started = true
-	i.Status = Running
 	i.mu.Unlock()
 
 	return nil

--- a/task/runner.go
+++ b/task/runner.go
@@ -168,6 +168,7 @@ func RunTask(taskID string) error {
 	if err := instance.Start(true); err != nil {
 		return fmt.Errorf("failed to start instance: %w", err)
 	}
+	instance.SetStatus(session.Running)
 
 	// If anything fails after Start(), kill the instance to avoid orphaned resources.
 	started := true


### PR DESCRIPTION
## Summary
- `Instance.Start()` was setting status to `Running`, but `preSaveInstances()` skipped non-started instances (`Started() == false`). This created a window where `refreshExternalInstances()` (every 3s) would see the instance as not on disk and not `Loading`, removing it from the sidebar and orphaning the tmux session and worktree.
- Fix: remove `SetStatus(Running)` from `Start()`/`StartWithExistingWorktree()` so the instance stays `Loading` (protected from removal) throughout the async start. Callers now set `Running` explicitly.
- Also skip `Loading` instances in the metadata tick to prevent premature status changes.

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: trigger a scheduled task with 'r' key and verify the instance appears in the sidebar and persists
- [ ] Manual: create a new instance with 'n' key and verify it works as before
- [ ] Manual: verify `af api sessions create` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)