### PR TITLE
refactor: centralize instance start pattern via StartAndSendPrompt

### DIFF
--- a/api/board.go
+++ b/api/board.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/sachiniyer/agent-factory/board"
 	"github.com/sachiniyer/agent-factory/config"
@@ -295,26 +294,10 @@ var boardSpawnCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("failed to create instance: %w", err))
 		}
 
-		if err := instance.Start(true); err != nil {
+		if err := task.StartAndSendPrompt(instance, t.Title); err != nil {
 			return jsonError(fmt.Errorf("failed to start instance: %w", err))
 		}
 		instance.SetStatus(session.Running)
-
-		// Wait for ready and send the task title as the prompt
-		if err := task.WaitForReady(instance); err != nil {
-			return jsonError(fmt.Errorf("program did not become ready: %w", err))
-		}
-
-		if instance.CheckAndHandleTrustPrompt() {
-			time.Sleep(1 * time.Second)
-			if err := task.WaitForReady(instance); err != nil {
-				return jsonError(fmt.Errorf("program did not become ready after trust prompt: %w", err))
-			}
-		}
-
-		if err := instance.SendPromptCommand(t.Title); err != nil {
-			return jsonError(fmt.Errorf("failed to send prompt: %w", err))
-		}
 
 		// Save instance to per-repo storage under file lock
 		data := instance.ToInstanceData()

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/sachiniyer/agent-factory/board"
 	"github.com/sachiniyer/agent-factory/config"
@@ -115,27 +114,10 @@ var sessionsCreateCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("failed to create instance: %w", err))
 		}
 
-		if err := instance.Start(true); err != nil {
+		if err := task.StartAndSendPrompt(instance, createPromptFlag); err != nil {
 			return jsonError(fmt.Errorf("failed to start instance: %w", err))
 		}
 		instance.SetStatus(session.Running)
-
-		if createPromptFlag != "" {
-			if err := task.WaitForReady(instance); err != nil {
-				return jsonError(fmt.Errorf("program did not become ready: %w", err))
-			}
-
-			if instance.CheckAndHandleTrustPrompt() {
-				time.Sleep(1 * time.Second)
-				if err := task.WaitForReady(instance); err != nil {
-					return jsonError(fmt.Errorf("program did not become ready after trust prompt: %w", err))
-				}
-			}
-
-			if err := instance.SendPromptCommand(createPromptFlag); err != nil {
-				return jsonError(fmt.Errorf("failed to send prompt: %w", err))
-			}
-		}
 
 		// Save to per-repo storage under file lock
 		data := instance.ToInstanceData()
@@ -212,21 +194,10 @@ or use 'af api sessions create --name <title> --prompt <prompt>' instead.`,
 				return jsonError(fmt.Errorf("failed to create instance: %w", err))
 			}
 
-			if err := instance.Start(true); err != nil {
+			if err := task.StartAndSendPrompt(instance, ""); err != nil {
 				return jsonError(fmt.Errorf("failed to start instance: %w", err))
 			}
 			instance.SetStatus(session.Running)
-
-			if err := task.WaitForReady(instance); err != nil {
-				return jsonError(fmt.Errorf("program did not become ready: %w", err))
-			}
-
-			if instance.CheckAndHandleTrustPrompt() {
-				time.Sleep(1 * time.Second)
-				if err := task.WaitForReady(instance); err != nil {
-					return jsonError(fmt.Errorf("program did not become ready after trust prompt: %w", err))
-				}
-			}
 
 			// Save to per-repo storage under file lock
 			data := instance.ToInstanceData()

--- a/app/app.go
+++ b/app/app.go
@@ -564,22 +564,7 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 	prompt := tsk.Prompt
 	taskID := tsk.ID
 	startCmd := func() tea.Msg {
-		if err := instance.Start(true); err != nil {
-			return instanceStartedMsg{instance: instance, err: err}
-		}
-
-		if err := task.WaitForReady(instance); err != nil {
-			return instanceStartedMsg{instance: instance, err: err}
-		}
-
-		if instance.CheckAndHandleTrustPrompt() {
-			time.Sleep(1 * time.Second)
-			if err := task.WaitForReady(instance); err != nil {
-				return instanceStartedMsg{instance: instance, err: err}
-			}
-		}
-
-		if err := instance.SendPromptCommand(prompt); err != nil {
+		if err := task.StartAndSendPrompt(instance, prompt); err != nil {
 			return instanceStartedMsg{instance: instance, err: err}
 		}
 

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -284,25 +283,9 @@ func (m *home) handleBoardSpawn(bt *board.Task) tea.Cmd {
 
 	prompt := bt.Title
 	startCmd := func() tea.Msg {
-		if err := instance.Start(true); err != nil {
+		if err := task.StartAndSendPrompt(instance, prompt); err != nil {
 			return instanceStartedMsg{instance: instance, err: err}
 		}
-
-		if err := task.WaitForReady(instance); err != nil {
-			return instanceStartedMsg{instance: instance, err: err}
-		}
-
-		if instance.CheckAndHandleTrustPrompt() {
-			time.Sleep(1 * time.Second)
-			if err := task.WaitForReady(instance); err != nil {
-				return instanceStartedMsg{instance: instance, err: err}
-			}
-		}
-
-		if err := instance.SendPromptCommand(prompt); err != nil {
-			return instanceStartedMsg{instance: instance, err: err}
-		}
-
 		return instanceStartedMsg{instance: instance, err: nil}
 	}
 

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -41,6 +41,8 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.state = stateDefault
 		m.menu.SetState(ui.StateDefault)
 
+		m.preSaveInstances()
+
 		selectedWt := m.selectedWorktree
 		m.selectedWorktree = nil
 		m.availableWorktrees = nil

--- a/session/storage.go
+++ b/session/storage.go
@@ -61,11 +61,15 @@ func NewStorage(state config.InstanceStorage, repoID string) (*Storage, error) {
 }
 
 // SaveInstances saves the list of instances to disk under file locks.
+// Includes both started instances and Loading instances (which are in the
+// process of being started asynchronously). This ensures preSaveInstances
+// persists Loading instances to disk so refreshExternalInstances won't
+// remove them during the Loading→Running transition.
 func (s *Storage) SaveInstances(instances []*Instance) error {
 	// Convert instances to InstanceData
 	data := make([]InstanceData, 0)
 	for _, instance := range instances {
-		if instance.Started() {
+		if instance.Started() || instance.Status == Loading {
 			data = append(data, instance.ToInstanceData())
 		}
 	}

--- a/task/runner.go
+++ b/task/runner.go
@@ -165,11 +165,6 @@ func RunTask(taskID string) error {
 		return fmt.Errorf("failed to create instance: %w", err)
 	}
 
-	if err := instance.Start(true); err != nil {
-		return fmt.Errorf("failed to start instance: %w", err)
-	}
-	instance.SetStatus(session.Running)
-
 	// If anything fails after Start(), kill the instance to avoid orphaned resources.
 	started := true
 	defer func() {
@@ -180,26 +175,10 @@ func RunTask(taskID string) error {
 		}
 	}()
 
-	// Wait for the program to be ready before sending the prompt.
-	// Claude Code (and similar tools) take a few seconds to initialize.
-	if err := WaitForReady(instance); err != nil {
-		return fmt.Errorf("program did not become ready: %w", err)
+	if err := StartAndSendPrompt(instance, t.Prompt); err != nil {
+		return fmt.Errorf("failed to start instance: %w", err)
 	}
-
-	// Check for and dismiss the trust prompt if present.
-	if instance.CheckAndHandleTrustPrompt() {
-		log.InfoLog.Printf("trust prompt detected and dismissed, waiting for ready again")
-		time.Sleep(1 * time.Second)
-		if err := WaitForReady(instance); err != nil {
-			return fmt.Errorf("program did not become ready after trust prompt: %w", err)
-		}
-	}
-
-	// Use SendPromptCommand (tmux send-keys) instead of SendPrompt (PTY write)
-	// for reliability in headless/task runs.
-	if err := instance.SendPromptCommand(t.Prompt); err != nil {
-		return fmt.Errorf("failed to send prompt: %w", err)
-	}
+	instance.SetStatus(session.Running)
 
 	// Instance is successfully handed off, don't kill it on return.
 	started = false

--- a/task/start.go
+++ b/task/start.go
@@ -1,0 +1,42 @@
+package task
+
+import (
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// StartAndSendPrompt is the canonical way to start an instance, wait for
+// readiness, handle trust prompts, and optionally send a prompt.
+//
+// It always waits for the program to become ready. If prompt is non-empty,
+// it sends the prompt via tmux send-keys after readiness.
+//
+// It does NOT set the instance status to Running — callers must do so when
+// appropriate. For TUI async paths, the instanceStartedMsg handler sets
+// Running after saving to disk; for synchronous API/runner paths, the caller
+// sets Running immediately after this function returns.
+func StartAndSendPrompt(instance *session.Instance, prompt string) error {
+	if err := instance.Start(true); err != nil {
+		return err
+	}
+
+	if err := WaitForReady(instance); err != nil {
+		return err
+	}
+
+	if instance.CheckAndHandleTrustPrompt() {
+		time.Sleep(1 * time.Second)
+		if err := WaitForReady(instance); err != nil {
+			return err
+		}
+	}
+
+	if prompt != "" {
+		if err := instance.SendPromptCommand(prompt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Extract the duplicated Start → WaitForReady → trust prompt → SendPromptCommand pattern into `task.StartAndSendPrompt`, consolidating 6 call sites (TUI trigger, TUI board spawn, API create, API send-prompt, API board spawn, daemon RunTask)
- Fix `SaveInstances` to include Loading instances so `preSaveInstances` actually persists them to disk (defense-in-depth for the race fix in #44)
- Add missing `preSaveInstances()` to `handleStateNew` (the 'n' key new-instance flow was vulnerable to the same race)

Net result: -108 lines, +57 lines across 8 files.

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: trigger a scheduled task with 'r' key
- [ ] Manual: create a new instance with 'n' key
- [ ] Manual: `af api sessions create` and `af api board spawn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)