### PR TITLE
feat: support AGENT_FACTORY_HOME env var for custom config directory

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,8 +17,21 @@ const (
 	defaultProgram = "claude"
 )
 
-// GetConfigDir returns the path to the application's configuration directory
+// GetConfigDir returns the path to the application's configuration directory.
+// If AGENT_FACTORY_HOME is set, it is used as the config directory.
+// Otherwise, defaults to ~/.agent-factory.
 func GetConfigDir() (string, error) {
+	if envDir := os.Getenv("AGENT_FACTORY_HOME"); envDir != "" {
+		if strings.HasPrefix(envDir, "~") {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("failed to expand home directory: %w", err)
+			}
+			envDir = filepath.Join(homeDir, envDir[2:])
+		}
+		return envDir, nil
+	}
+
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get config home directory: %w", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -123,6 +123,43 @@ func TestGetConfigDir(t *testing.T) {
 		// Verify it's an absolute path
 		assert.True(t, filepath.IsAbs(configDir))
 	})
+
+	t.Run("uses AGENT_FACTORY_HOME when set", func(t *testing.T) {
+		originalVal := os.Getenv("AGENT_FACTORY_HOME")
+		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
+
+		customDir := t.TempDir()
+		os.Setenv("AGENT_FACTORY_HOME", customDir)
+
+		configDir, err := GetConfigDir()
+		assert.NoError(t, err)
+		assert.Equal(t, customDir, configDir)
+	})
+
+	t.Run("expands tilde in AGENT_FACTORY_HOME", func(t *testing.T) {
+		originalVal := os.Getenv("AGENT_FACTORY_HOME")
+		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
+
+		os.Setenv("AGENT_FACTORY_HOME", "~/.my-custom-config")
+
+		homeDir, err := os.UserHomeDir()
+		require.NoError(t, err)
+
+		configDir, err := GetConfigDir()
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(homeDir, ".my-custom-config"), configDir)
+	})
+
+	t.Run("falls back to default when AGENT_FACTORY_HOME is empty", func(t *testing.T) {
+		originalVal := os.Getenv("AGENT_FACTORY_HOME")
+		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
+
+		os.Setenv("AGENT_FACTORY_HOME", "")
+
+		configDir, err := GetConfigDir()
+		assert.NoError(t, err)
+		assert.True(t, strings.HasSuffix(configDir, ".agent-factory"))
+	})
 }
 
 func TestLoadConfig(t *testing.T) {


### PR DESCRIPTION
## Summary
- `GetConfigDir()` now checks the `AGENT_FACTORY_HOME` environment variable first, using it as the config directory path when set (with `~` expansion)
- Falls back to the default `~/.agent-factory` when the env var is unset or empty
- Added tests for env var override, tilde expansion, and empty string fallback

Closes #245

## Test plan
- [x] All existing config tests pass
- [x] New tests cover: env var override, tilde expansion, empty string fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)