### PR TITLE
fix: -y flag enables bypass permissions mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -65,6 +66,9 @@ var (
 			autoYes := cfg.AutoYes
 			if autoYesFlag {
 				autoYes = true
+			}
+			if autoYes && strings.Contains(strings.ToLower(program), "claude") {
+				program = program + " --permission-mode bypassPermissions"
 			}
 			if autoYes {
 				defer func() {

--- a/session/instance.go
+++ b/session/instance.go
@@ -176,7 +176,7 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		Width:     0,
 		CreatedAt: t,
 		UpdatedAt: t,
-		AutoYes:   false,
+		AutoYes:   opts.AutoYes,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- When `-y`/`--autoyes` flag is set and the program is Claude, appends `--permission-mode bypassPermissions` to the program command so Claude Code doesn't prompt for permissions
- Fixes `NewInstance` to propagate `AutoYes` from `InstanceOptions` instead of hardcoding `false`

Fixes #222

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: run `af -y` and verify Claude launches with `--permission-mode bypassPermissions`
- [ ] Manual: run `af` (without `-y`) and verify no extra flags are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)