### PR TITLE
fix: log Close() writes to stderr instead of stdout

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -46,7 +46,7 @@ func Close() {
 	if globalLogFile != nil {
 		_ = globalLogFile.Close()
 	}
-	fmt.Println("wrote logs to " + logFileName)
+	fmt.Fprintln(os.Stderr, "wrote logs to "+logFileName)
 }
 
 // Every is used to log at most once every timeout duration.


### PR DESCRIPTION
## Summary
- Fixes #34: `log.Close()` used `fmt.Println` which writes to stdout, corrupting JSON output from API commands (e.g. `af api tasks list`)
- Changed to `fmt.Fprintln(os.Stderr, ...)` so the status message no longer interferes with structured output

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- Verify `af api tasks list` returns clean JSON without trailing log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)