### PR TITLE
fix: config missing keys load as zero values instead of defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -150,13 +150,13 @@ func LoadConfig() *Config {
 		return DefaultConfig()
 	}
 
-	var config Config
-	if err := json.Unmarshal(data, &config); err != nil {
+	config := DefaultConfig()
+	if err := json.Unmarshal(data, config); err != nil {
 		log.ErrorLog.Printf("failed to parse config file: %v", err)
 		return DefaultConfig()
 	}
 
-	return &config
+	return config
 }
 
 // saveConfig saves the configuration to disk


### PR DESCRIPTION
## Summary
- Fix `LoadConfig()` to unmarshal JSON into `DefaultConfig()` instead of a zero-valued struct
- Missing keys in `config.json` now retain their default values (e.g. `DaemonPollInterval=1000`, proper `DefaultProgram`)
- Prevents daemon panic from `time.NewTicker(0)` when `DaemonPollInterval` is missing

## Test plan
- [x] `go test ./config/...` passes
- [ ] Verify with partial config.json (missing some keys) that defaults are used

🤖 Generated with [Claude Code](https://claude.com/claude-code)