### PR TITLE
fix: prevent upgrade from extracting directory entry as binary

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -90,7 +90,7 @@ func extractBinaryFromTarGz(r io.Reader, binaryName string) ([]byte, error) {
 		}
 
 		name := hdr.Name
-		if name == binaryName || strings.HasSuffix(name, "/"+binaryName) {
+		if hdr.Typeflag == tar.TypeReg && (name == binaryName || strings.HasSuffix(name, "/"+binaryName)) {
 			data, err := io.ReadAll(tr)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read binary from archive: %w", err)


### PR DESCRIPTION
## Summary
- Adds `hdr.Typeflag == tar.TypeReg` check in `extractBinaryFromTarGz` so only regular files are matched, preventing directory entries from being extracted as empty binaries which bricks the installation.

Fixes #37

## Test plan
- [ ] `go build ./...` passes
- [ ] Verify upgrade with a tar.gz containing a directory entry with the same name as the binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)