### PR TITLE
fix: prevent nil pointer panic on resize after detach

### DIFF
--- a/session/tmux/tmux_unix.go
+++ b/session/tmux/tmux_unix.go
@@ -53,10 +53,11 @@ func (t *TmuxSession) monitorWindowSize() {
 				if resizeTimer != nil {
 					resizeTimer.Stop()
 				}
+				ctx := t.ctx
 				resizeTimer = time.AfterFunc(50*time.Millisecond, func() {
 					select {
 					case debouncedWinch <- syscall.SIGWINCH:
-					case <-t.ctx.Done():
+					case <-ctx.Done():
 					}
 				})
 			}


### PR DESCRIPTION
## Summary
- Fixes #39: Tmux nil pointer panic on resize after detach
- In `monitorWindowSize`, the `time.AfterFunc` debounce closure referenced `t.ctx` directly, but `Detach()` sets `t.ctx` to nil. If the timer fires after detach, this causes a nil pointer dereference panic.
- Fix: capture `t.ctx` in a local variable before creating the closure so it remains valid for the lifetime of the timer callback.

## Test plan
- [x] `go build ./...` passes
- [ ] Manual: attach to a session, resize terminal, quickly detach — no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)