### PR TITLE
fix: handle empty instances.json to prevent state corruption

### DIFF
--- a/config/state.go
+++ b/config/state.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/log"
@@ -135,6 +136,10 @@ func LoadRepoInstances(repoID string) (json.RawMessage, error) {
 			return json.RawMessage("[]"), nil
 		}
 		return nil, fmt.Errorf("failed to read repo instances: %w", err)
+	}
+	// Handle empty file (e.g. from interrupted write)
+	if len(bytes.TrimSpace(data)) == 0 {
+		return json.RawMessage("[]"), nil
 	}
 	return json.RawMessage(data), nil
 }


### PR DESCRIPTION
## Summary
- Fixes `LoadRepoInstances` to treat empty/whitespace-only `instances.json` files as equivalent to missing files, returning `[]` instead of an empty `json.RawMessage` that fails to unmarshal
- Prevents instance list corruption when the file exists but is empty (e.g. from an interrupted atomic write)

Fixes #33

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./config/...` passes
- [ ] Manually create an empty `instances.json` file and verify sessions load without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)