### PR TITLE
fix: add fsync before rename in AtomicWriteFile

### DIFF
--- a/config/filelock.go
+++ b/config/filelock.go
@@ -63,6 +63,10 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		tmp.Close()
 		return fmt.Errorf("failed to chmod temp file: %w", err)
 	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to sync temp file: %w", err)
+	}
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("failed to close temp file: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Adds `tmp.Sync()` call in `AtomicWriteFile` before closing and renaming the temp file
- Without fsync, data may remain in kernel buffers on crash/power loss, leading to an empty or corrupt file after recovery

Fixes #55

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./config/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)