### PR TITLE
fix: cap decompressed binary size in upgrade to prevent OOM

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -91,9 +91,16 @@ func extractBinaryFromTarGz(r io.Reader, binaryName string) ([]byte, error) {
 
 		name := hdr.Name
 		if hdr.Typeflag == tar.TypeReg && (name == binaryName || strings.HasSuffix(name, "/"+binaryName)) {
-			data, err := io.ReadAll(tr)
+			const maxBinarySize = 500 << 20 // 500 MB
+			if hdr.Size > maxBinarySize {
+				return nil, fmt.Errorf("binary too large: %d bytes (max %d)", hdr.Size, maxBinarySize)
+			}
+			data, err := io.ReadAll(io.LimitReader(tr, maxBinarySize+1))
 			if err != nil {
 				return nil, fmt.Errorf("failed to read binary from archive: %w", err)
+			}
+			if int64(len(data)) > maxBinarySize {
+				return nil, fmt.Errorf("binary exceeds maximum size of %d bytes", maxBinarySize)
 			}
 			return data, nil
 		}


### PR DESCRIPTION
## Summary
- Adds a 500 MB size cap to `extractBinaryFromTarGz` to prevent OOM from unbounded decompression
- Checks `hdr.Size` before reading, and uses `io.LimitReader` as a defense-in-depth guard against crafted archives with a false header size

Closes #60

## Test plan
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)