### PR TITLE
fix: Kill() skips cleanup and leaves started=true

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -318,16 +318,13 @@ func (i *Instance) StartWithExistingWorktree(worktreePath, branchName string) er
 
 // Kill terminates the instance and cleans up all resources
 func (i *Instance) Kill() error {
-	i.mu.RLock()
-	wasStarted := i.started
+	i.mu.Lock()
 	ts := i.tmuxSession
 	gw := i.gitWorktree
-	i.mu.RUnlock()
-
-	if !wasStarted {
-		// If instance was never started, just return success
-		return nil
-	}
+	i.started = false
+	i.tmuxSession = nil
+	i.gitWorktree = nil
+	i.mu.Unlock()
 
 	var errs []error
 


### PR DESCRIPTION
## Summary
- **`RLock` → `Lock`**: `Kill()` mutates `started`, `tmuxSession`, and `gitWorktree`, so it needs a write lock
- **Remove early-return guard on `!started`**: allows cleanup of partially-created resources from failed `Start()` (orphaned worktrees/tmux sessions)
- **Set `started = false` and nil out resource refs**: makes `Kill()` idempotent and ensures callers see correct state

Closes #50

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./session/...` passes
- [x] `go test ./ui/...` passes (tests use `Kill()` in defers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)