### PR TITLE
fix: use AtomicWriteFile in auto-update to prevent concurrent corruption

### DIFF
--- a/autoupdate.go
+++ b/autoupdate.go
@@ -81,14 +81,8 @@ func autoUpdate() error {
 		return fmt.Errorf("failed to find executable: %w", err)
 	}
 
-	tmpPath := execPath + ".autoupdate-tmp"
-	if err := os.WriteFile(tmpPath, binary, 0755); err != nil {
+	if err := config.AtomicWriteFile(execPath, binary, 0755); err != nil {
 		return fmt.Errorf("failed to write new binary: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, execPath); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("failed to replace binary: %w", err)
 	}
 
 	recordCheck()


### PR DESCRIPTION
## Summary
- Replace hardcoded temp path (`execPath + ".autoupdate-tmp"`) in `autoupdate.go` with `config.AtomicWriteFile`, which uses a unique temp file per process
- Prevents binary corruption when multiple instances auto-update concurrently

Closes #47

## Test plan
- [x] `go build ./...` passes
- [ ] Verify auto-update still works end-to-end on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)