### PR TITLE
fix: prevent runner leak when saving pending instance fails

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -180,14 +180,14 @@ func RunTask(taskID string) error {
 	}
 	instance.SetStatus(session.Running)
 
-	// Instance is successfully handed off, don't kill it on return.
-	started = false
-
 	// Write instance to a separate pending file to avoid racing with the
 	// daemon/TUI which also read-modify-write state.json concurrently.
 	if err := appendPendingInstance(instance.ToInstanceData()); err != nil {
 		return fmt.Errorf("failed to save pending instance: %w", err)
 	}
+
+	// Instance is successfully handed off, don't kill it on return.
+	started = false
 
 	// Create a board task linked to the new instance.
 	repo, repoErr := config.RepoFromPath(t.ProjectPath)


### PR DESCRIPTION
## Summary
- Moves `started = false` to after `appendPendingInstance()` succeeds in `RunTask()`, so the defer cleanup properly kills the instance if the save fails
- Prevents orphaned tmux sessions and git worktrees when pending instance persistence fails

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./task/...` passes

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)