### PR TITLE
fix: cron ranges produce valid systemd OnCalendar expressions

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -137,16 +137,10 @@ func CronToOnCalendar(cronExpr string) (string, error) {
 	}
 
 	// Convert month
-	monthPart := "*"
-	if monthField != "*" {
-		monthPart = zeroPad(monthField)
-	}
+	monthPart := convertTimeField(monthField)
 
 	// Convert day-of-month
-	domPart := "*"
-	if domField != "*" {
-		domPart = zeroPad(domField)
-	}
+	domPart := convertTimeField(domField)
 
 	// Convert hour
 	hourPart := convertTimeField(hourField)
@@ -173,6 +167,16 @@ func convertTimeField(field string) string {
 		return "*"
 	}
 
+	// Handle lists (e.g. "1,3,5" → "01,03,05")
+	if strings.Contains(field, ",") {
+		parts := strings.Split(field, ",")
+		converted := make([]string, len(parts))
+		for i, p := range parts {
+			converted[i] = convertTimeField(p)
+		}
+		return strings.Join(converted, ",")
+	}
+
 	// Handle step values
 	if strings.Contains(field, "/") {
 		idx := strings.Index(field, "/")
@@ -181,12 +185,20 @@ func convertTimeField(field string) string {
 		if base == "*" {
 			return fmt.Sprintf("00/%s", step)
 		}
-		// Range with step: "X-Y/N" → "X/N"
+		// Range with step: "X-Y/N" → "XX..YY/N"
 		if dashIdx := strings.Index(base, "-"); dashIdx != -1 {
 			start := base[:dashIdx]
-			return fmt.Sprintf("%s/%s", zeroPad(start), step)
+			end := base[dashIdx+1:]
+			return fmt.Sprintf("%s..%s/%s", zeroPad(start), zeroPad(end), step)
 		}
 		return fmt.Sprintf("%s/%s", zeroPad(base), step)
+	}
+
+	// Handle ranges (e.g. "1-5" → "01..05")
+	if dashIdx := strings.Index(field, "-"); dashIdx != -1 {
+		start := field[:dashIdx]
+		end := field[dashIdx+1:]
+		return fmt.Sprintf("%s..%s", zeroPad(start), zeroPad(end))
 	}
 
 	// Plain number — zero-pad

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -48,3 +48,51 @@ func TestCronFieldExpandDedup(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []int{1, 3}, vals)
 }
+
+func TestCronToOnCalendarSimple(t *testing.T) {
+	result, err := CronToOnCalendar("30 2 * * *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-* 02:30:00", result)
+}
+
+func TestCronToOnCalendarRange(t *testing.T) {
+	result, err := CronToOnCalendar("0 9-17 * * *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-* 09..17:00:00", result)
+}
+
+func TestCronToOnCalendarRangeWithStep(t *testing.T) {
+	result, err := CronToOnCalendar("0 9-17/2 * * *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-* 09..17/2:00:00", result)
+}
+
+func TestCronToOnCalendarList(t *testing.T) {
+	result, err := CronToOnCalendar("0 1,3,5 * * *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-* 01,03,05:00:00", result)
+}
+
+func TestCronToOnCalendarMonthRange(t *testing.T) {
+	result, err := CronToOnCalendar("0 0 1 6-8 *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-06..08-01 00:00:00", result)
+}
+
+func TestCronToOnCalendarDOMRange(t *testing.T) {
+	result, err := CronToOnCalendar("0 0 1-15 * *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-01..15 00:00:00", result)
+}
+
+func TestCronToOnCalendarMinuteRange(t *testing.T) {
+	result, err := CronToOnCalendar("0-30/10 * * * *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-* *:00..30/10:00", result)
+}
+
+func TestCronToOnCalendarDOW(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 1-5")
+	require.NoError(t, err)
+	assert.Equal(t, "Mon..Fri *-*-* 09:00:00", result)
+}


### PR DESCRIPTION
## Summary
- **Plain ranges** `X-Y` now use systemd's `..` separator instead of cron's `-` (e.g. `9-17` → `09..17`)
- **Range-with-step** `X-Y/N` preserves the upper bound `Y` (was producing `X/N`, now `X..Y/N`)
- **Lists** in time/month/DOM fields are properly handled with zero-padded elements
- Month and DOM fields now go through the same conversion as hour/minute, fixing ranges and lists there too

Fixes #52

## Test plan
- [x] Added 8 `TestCronToOnCalendar*` tests covering simple, range, range-with-step, list, month range, DOM range, minute range-with-step, and DOW range
- [x] All existing `expandCronField` tests still pass
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)