### PR TITLE
fix: kill spawned instance on storage save failure in API handlers

### DIFF
--- a/api/board.go
+++ b/api/board.go
@@ -313,6 +313,7 @@ var boardSpawnCmd = &cobra.Command{
 			}
 			return out, nil
 		}); err != nil {
+			instance.Kill()
 			return jsonError(err)
 		}
 

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -129,6 +129,7 @@ var sessionsCreateCmd = &cobra.Command{
 			existing = append(existing, data)
 			return json.MarshalIndent(existing, "", "  ")
 		}); err != nil {
+			instance.Kill()
 			return jsonError(err)
 		}
 
@@ -209,6 +210,7 @@ or use 'af api sessions create --name <title> --prompt <prompt>' instead.`,
 				existing = append(existing, data)
 				return json.MarshalIndent(existing, "", "  ")
 			}); err != nil {
+				instance.Kill()
 				return jsonError(err)
 			}
 


### PR DESCRIPTION
## Summary
- When `config.UpdateRepoInstances()` fails after `task.StartAndSendPrompt()` has already started the instance, the API handlers returned an error without cleaning up the running instance, leaking tmux sessions and git worktrees
- Added `instance.Kill()` before returning the error in all three affected code paths: `sessionsCreateCmd`, `sessionsSendPromptCmd` (auto-create), and `boardSpawnCmd`
- Follows the same pattern established in #81 / `task/runner.go`

## Test plan
- [ ] Simulate storage write failure after `StartAndSendPrompt` succeeds; verify the tmux session and worktree are cleaned up
- [ ] Normal `af api sessions create` and `af api board spawn` still work correctly

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)