### PR TITLE
fix: stop existing daemon before launching new one

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -79,6 +79,12 @@ func RunDaemon(cfg *config.Config) error {
 
 // LaunchDaemon launches the daemon process.
 func LaunchDaemon() error {
+	// Stop any existing daemon first to prevent duplicates.
+	if err := StopDaemon(); err != nil {
+		log.ErrorLog.Printf("failed to stop existing daemon: %v", err)
+		// Continue anyway — best effort
+	}
+
 	// Find the agent-factory binary.
 	execPath, err := os.Executable()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixes #28: `LaunchDaemon()` now calls `StopDaemon()` at the start to kill any existing daemon before spawning a new one
- Prevents multiple daemon processes from running simultaneously and sending duplicate `TapEnter` commands that corrupt agent sessions
- Best-effort: if stopping the old daemon fails, it logs the error and continues with the launch

## Test plan
- [x] `go build ./...` passes
- [ ] Launch daemon, verify PID file is written
- [ ] Launch daemon again, verify old process is killed and new PID file is written
- [ ] Confirm only one daemon process is running after multiple launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)