### PR TITLE
fix: naming session can overwrite wrong instance

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -77,6 +77,11 @@ type home struct {
 	// It registers the new instance in the list after the instance has been started.
 	newInstanceFinalizer func()
 
+	// namingInstance is the instance currently being named in stateNew.
+	// Stored as a direct pointer so background sync cannot change which
+	// instance the naming keystrokes target.
+	namingInstance *session.Instance
+
 	// promptAfterName tracks if we should enter prompt mode after naming
 	promptAfterName bool
 

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -15,6 +15,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.String() == "ctrl+c" {
 		m.state = stateDefault
 		m.promptAfterName = false
+		m.namingInstance = nil
 		m.selectedWorktree = nil
 		m.availableWorktrees = nil
 		m.sidebar.Kill()
@@ -27,7 +28,10 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		)
 	}
 
-	instance := m.sidebar.GetInstances()[m.sidebar.NumInstances()-1]
+	instance := m.namingInstance
+	if instance == nil {
+		return m, nil
+	}
 	switch msg.Type {
 	case tea.KeyEnter:
 		if len(instance.Title) == 0 {
@@ -36,6 +40,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		instance.SetStatus(session.Loading)
 		m.newInstanceFinalizer()
+		m.namingInstance = nil
 		promptAfterName := m.promptAfterName
 		m.promptAfterName = false
 		m.state = stateDefault
@@ -82,6 +87,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case tea.KeyEsc:
 		m.sidebar.Kill()
+		m.namingInstance = nil
 		m.state = stateDefault
 		m.selectedWorktree = nil
 		m.availableWorktrees = nil
@@ -139,6 +145,7 @@ func (m *home) startNewInstance(promptAfterName bool) (tea.Model, tea.Cmd) {
 	instance.SetStatus(session.Loading)
 	m.newInstanceFinalizer = m.sidebar.AddInstance(instance)
 	m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
+	m.namingInstance = instance
 	m.state = stateNew
 	m.menu.SetState(ui.StateNewInstance)
 	m.promptAfterName = promptAfterName

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -38,6 +38,7 @@ func (m *home) handleStateSelectWorktree(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			instance.SetStatus(session.Loading)
 			m.newInstanceFinalizer = m.sidebar.AddInstance(instance)
 			m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
+			m.namingInstance = instance
 			m.state = stateNew
 			m.menu.SetState(ui.StateNewInstance)
 			return m, nil


### PR DESCRIPTION
## Summary
- `handleStateNew` found the instance being named via `GetInstances()[NumInstances()-1]` — always the last element. If background sync added an instance while the user was typing, keystrokes would target the wrong instance.
- Store a direct `namingInstance` pointer on the `home` struct, set it when entering `stateNew`, and clear it on every exit path (Enter, Esc, ctrl+c).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./app/...` passes
- [ ] Manual: create a new session while other instances are syncing — keystrokes only modify the intended instance

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)