### PR TITLE
fix: unified file locking for board and task writes

### DIFF
--- a/board/board.go
+++ b/board/board.go
@@ -193,7 +193,9 @@ func SaveBoardForRepo(repo *config.RepoContext, board *Board) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal board: %w", err)
 	}
-	return config.AtomicWriteFile(path, data, 0644)
+	return config.WithFileLock(path, func() error {
+		return config.AtomicWriteFile(path, data, 0644)
+	})
 }
 
 // MergeBoards merges external changes from disk into the user's edited board.
@@ -268,7 +270,13 @@ func updateBoardForRepo(repo *config.RepoContext, fn func(*Board) error) error {
 		if err := fn(board); err != nil {
 			return err
 		}
-		return SaveBoardForRepo(repo, board)
+		// Save directly (already under lock).
+		board.UpdatedAt = time.Now()
+		data, err := json.MarshalIndent(board, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal board: %w", err)
+		}
+		return config.AtomicWriteFile(path, data, 0644)
 	})
 }
 
@@ -292,7 +300,13 @@ func AddTaskForRepoWithStatus(repo *config.RepoContext, title, status string) (T
 			return loadErr
 		}
 		t = board.AddTask(title, status)
-		return SaveBoardForRepo(repo, board)
+		// Save directly (already under lock).
+		board.UpdatedAt = time.Now()
+		data, marshalErr := json.MarshalIndent(board, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal board: %w", marshalErr)
+		}
+		return config.AtomicWriteFile(path, data, 0644)
 	})
 	return t, err
 }

--- a/config/filelock.go
+++ b/config/filelock.go
@@ -32,6 +32,24 @@ func WithFileLock(path string, fn func() error) error {
 	return fn()
 }
 
+// LockedUpdate loads a file under an exclusive lock, applies fn to transform
+// its contents, and atomically writes the result back. If the file doesn't
+// exist, fn receives nil. This is the preferred way to do read-modify-write
+// on any shared JSON file.
+func LockedUpdate(path string, perm os.FileMode, fn func(data []byte) ([]byte, error)) error {
+	return WithFileLock(path, func() error {
+		data, err := os.ReadFile(path)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read %s: %w", path, err)
+		}
+		newData, err := fn(data)
+		if err != nil {
+			return err
+		}
+		return AtomicWriteFile(path, newData, perm)
+	})
+}
+
 // AtomicWriteFile writes data to a temporary file in the same directory as path
 // and atomically renames it to path. This prevents partial writes from being
 // visible to readers.

--- a/task/task.go
+++ b/task/task.go
@@ -71,6 +71,21 @@ func SaveTasks(tasks []Task) error {
 		return fmt.Errorf("failed to marshal tasks: %w", err)
 	}
 
+	return config.WithFileLock(path, func() error {
+		return config.AtomicWriteFile(path, data, 0644)
+	})
+}
+
+// saveTasks writes tasks without locking. Must be called from within WithFileLock.
+func saveTasks(tasks []Task) error {
+	path, err := getTasksPathFn()
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(tasks, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal tasks: %w", err)
+	}
 	return config.AtomicWriteFile(path, data, 0644)
 }
 
@@ -85,7 +100,7 @@ func AddTask(t Task) error {
 			return err
 		}
 		tasks = append(tasks, t)
-		return SaveTasks(tasks)
+		return saveTasks(tasks)
 	})
 }
 
@@ -114,7 +129,7 @@ func RemoveTask(id string) error {
 			return fmt.Errorf("task with id %q not found", id)
 		}
 
-		return SaveTasks(filtered)
+		return saveTasks(filtered)
 	})
 }
 
@@ -183,6 +198,6 @@ func UpdateTask(t Task) error {
 			return fmt.Errorf("task with id %q not found", t.ID)
 		}
 
-		return SaveTasks(tasks)
+		return saveTasks(tasks)
 	})
 }


### PR DESCRIPTION
## Summary
- **`SaveBoardForRepo`** and **`SaveTasks`** used `AtomicWriteFile` without acquiring a file lock, so concurrent TUI and CLI/API writes could silently overwrite each other's changes.
- Adds `LockedUpdate` helper to `config/filelock.go` for generic locked read-modify-write on shared JSON files.
- Wraps `SaveBoardForRepo` and `SaveTasks` in `WithFileLock` so all external callers are now safe.
- Adds private `saveTasks` for callers already holding the lock (`AddTask`, `RemoveTask`, `UpdateTask`).
- Inlines save logic in `updateBoardForRepo` and `AddTaskForRepoWithStatus` to avoid double-locking.

Fixes #56, #57, #58, #35, #38, #48

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [ ] Manual: run TUI + concurrent CLI board operations and verify no data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)