### PR TITLE
fix: remove Windows from release workflows, use AtomicWriteFile in upgrade

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -72,11 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, darwin, windows]
+        goos: [linux, darwin]
         goarch: [amd64, arm64]
-        exclude:
-          - goos: windows
-            goarch: arm64
     steps:
     - uses: actions/checkout@v4
       with:
@@ -94,19 +91,11 @@ jobs:
         GOARCH: ${{ matrix.goarch }}
       run: |
         VERSION="${{ needs.check-and-bump.outputs.new_version }}"
-        BINARY_NAME=agent-factory
-        if [ "${{ matrix.goos }}" = "windows" ]; then
-          BINARY_NAME=$BINARY_NAME.exe
-        fi
         ARCHIVE_NAME=agent-factory-${{ matrix.goos }}-${{ matrix.goarch }}
         mkdir -p dist
-        go build -v -ldflags "-X main.version=${VERSION}" -o dist/$BINARY_NAME
+        go build -v -ldflags "-X main.version=${VERSION}" -o dist/agent-factory
         cd dist
-        if [ "${{ matrix.goos }}" = "windows" ]; then
-          zip ../${ARCHIVE_NAME}.zip $BINARY_NAME
-        else
-          tar czf ../${ARCHIVE_NAME}.tar.gz $BINARY_NAME
-        fi
+        tar czf ../${ARCHIVE_NAME}.tar.gz agent-factory
 
     - name: Upload release assets
       uses: softprops/action-gh-release@v2
@@ -114,4 +103,3 @@ jobs:
         tag_name: v${{ needs.check-and-bump.outputs.new_version }}
         files: |
           *.tar.gz
-          *.zip

--- a/upgrade.go
+++ b/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/spf13/cobra"
 )
 
@@ -54,15 +55,8 @@ var upgradeCmd = &cobra.Command{
 			return fmt.Errorf("failed to find current executable: %w", err)
 		}
 
-		// Write to temp file next to the executable, then rename (atomic on same filesystem)
-		tmpPath := execPath + ".upgrade-tmp"
-		if err := os.WriteFile(tmpPath, binary, 0755); err != nil {
+		if err := config.AtomicWriteFile(execPath, binary, 0755); err != nil {
 			return fmt.Errorf("failed to write new binary: %w", err)
-		}
-
-		if err := os.Rename(tmpPath, execPath); err != nil {
-			os.Remove(tmpPath)
-			return fmt.Errorf("failed to replace binary: %w", err)
 		}
 
 		fmt.Printf("Upgraded successfully!\n")


### PR DESCRIPTION
## Summary
- Remove Windows from `auto-release.yml` build matrix — `syscall.Flock` is undefined on Windows, and `fail-fast: true` (the default) cancels remaining darwin/linux-arm64 builds when the Windows job fails
- Remove Windows-specific binary naming (`.exe`) and zip logic from the build step
- Replace manual temp-file-and-rename in `upgrade.go` with `config.AtomicWriteFile` for consistency with `autoupdate.go`

Fixes #94

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Trigger a release and confirm all 4 linux/darwin matrix jobs succeed
- [ ] Run `af upgrade` and confirm it downloads + replaces the binary correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)