### PR TITLE
fix: remove trailing newline in app/sync.go

### DIFF
--- a/app/sync.go
+++ b/app/sync.go
@@ -160,4 +160,3 @@ func (m *home) refreshExternalInstances() bool {
 
 	return changed
 }
-


### PR DESCRIPTION
## Summary
- Removes trailing newline at end of `app/sync.go` to fix gofmt lint failure

## Test plan
- [x] `gofmt -l .` reports no formatting issues
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)