### PR TITLE
fix: include repo hash in tmux session name to avoid collisions

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -84,6 +84,11 @@ func (i *Instance) ToInstanceData() InstanceData {
 		AutoYes:   i.AutoYes,
 	}
 
+	// Persist the tmux session name so we can restore it exactly
+	if i.tmuxSession != nil {
+		data.TmuxName = i.tmuxSession.SanitizedName()
+	}
+
 	// Only include worktree data if gitWorktree is initialized
 	if i.gitWorktree != nil {
 		data.Worktree = GitWorktreeData{
@@ -129,6 +134,15 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 			data.Worktree.BaseCommitSHA,
 			data.Worktree.ExternalWorktree,
 		),
+	}
+
+	// Pre-set the tmux session with the correct name for backward compat.
+	// If TmuxName was persisted, use it exactly; otherwise fall back to
+	// the legacy naming scheme (no repo hash) so old sessions still restore.
+	if data.TmuxName != "" {
+		instance.tmuxSession = tmux.NewTmuxSessionFromSanitizedName(data.TmuxName, data.Program)
+	} else {
+		instance.tmuxSession = tmux.NewTmuxSession(data.Title, data.Program)
 	}
 
 	if data.PRInfo.Number != 0 {
@@ -209,8 +223,8 @@ func (i *Instance) Start(firstTimeSetup bool) error {
 		// Use existing tmux session (useful for testing)
 		tmuxSession = existingSession
 	} else {
-		// Create new tmux session
-		tmuxSession = tmux.NewTmuxSession(i.Title, i.Program)
+		// Create new tmux session with repo-scoped name
+		tmuxSession = tmux.NewTmuxSessionForRepo(i.Title, i.Path, i.Program)
 	}
 
 	i.mu.Lock()
@@ -299,7 +313,7 @@ func (i *Instance) StartWithExistingWorktree(worktreePath, branchName string) er
 	i.mu.Unlock()
 
 	program := injectSystemPrompt(i.Program, i.Title, worktreePath)
-	tmuxSession := tmux.NewTmuxSession(i.Title, program)
+	tmuxSession := tmux.NewTmuxSessionForRepo(i.Title, i.Path, program)
 
 	i.mu.Lock()
 	i.tmuxSession = tmuxSession

--- a/session/storage.go
+++ b/session/storage.go
@@ -21,6 +21,7 @@ type InstanceData struct {
 	AutoYes   bool      `json:"auto_yes"`
 
 	Program  string          `json:"program"`
+	TmuxName string          `json:"tmux_name,omitempty"`
 	Worktree GitWorktreeData `json:"worktree"`
 	PRInfo   PRInfoData      `json:"pr_info,omitempty"`
 }

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/cmd"
@@ -74,25 +75,50 @@ func SetDetachKey(b byte, display string) {
 
 var whiteSpaceRegex = regexp.MustCompile(`\s+`)
 
-func toTmuxName(str string) string {
-	str = whiteSpaceRegex.ReplaceAllString(str, "")
-	str = strings.ReplaceAll(str, ".", "_") // tmux replaces all . with _
-	return fmt.Sprintf("%s%s", TmuxPrefix, str)
+// repoHash returns a short hex hash of the repo path for use in tmux session names.
+func repoHash(repoPath string) string {
+	h := sha256.Sum256([]byte(repoPath))
+	return hex.EncodeToString(h[:4]) // 8 hex chars
 }
 
-// NewTmuxSession creates a new TmuxSession with the given name and program.
+func toTmuxName(title string, repoPath string) string {
+	title = whiteSpaceRegex.ReplaceAllString(title, "")
+	title = strings.ReplaceAll(title, ".", "_") // tmux replaces all . with _
+	if repoPath != "" {
+		return fmt.Sprintf("%s%s_%s", TmuxPrefix, repoHash(repoPath), title)
+	}
+	return fmt.Sprintf("%s%s", TmuxPrefix, title)
+}
+
+// NewTmuxSession creates a new TmuxSession with the given name and program (no repo scoping).
 func NewTmuxSession(name string, program string) *TmuxSession {
-	return newTmuxSession(name, program, MakePtyFactory(), cmd.MakeExecutor())
+	return newTmuxSession(toTmuxName(name, ""), program, MakePtyFactory(), cmd.MakeExecutor())
+}
+
+// NewTmuxSessionForRepo creates a new TmuxSession with a repo-scoped name to avoid collisions.
+func NewTmuxSessionForRepo(name string, repoPath string, program string) *TmuxSession {
+	return newTmuxSession(toTmuxName(name, repoPath), program, MakePtyFactory(), cmd.MakeExecutor())
+}
+
+// NewTmuxSessionFromSanitizedName creates a new TmuxSession with an exact pre-computed name.
+// Used when restoring sessions from storage where the tmux name was already persisted.
+func NewTmuxSessionFromSanitizedName(sanitizedName string, program string) *TmuxSession {
+	return newTmuxSession(sanitizedName, program, MakePtyFactory(), cmd.MakeExecutor())
 }
 
 // NewTmuxSessionWithDeps creates a new TmuxSession with provided dependencies for testing.
 func NewTmuxSessionWithDeps(name string, program string, ptyFactory PtyFactory, cmdExec cmd.Executor) *TmuxSession {
-	return newTmuxSession(name, program, ptyFactory, cmdExec)
+	return newTmuxSession(toTmuxName(name, ""), program, ptyFactory, cmdExec)
 }
 
-func newTmuxSession(name string, program string, ptyFactory PtyFactory, cmdExec cmd.Executor) *TmuxSession {
+// SanitizedName returns the sanitized tmux session name.
+func (t *TmuxSession) SanitizedName() string {
+	return t.sanitizedName
+}
+
+func newTmuxSession(sanitizedName string, program string, ptyFactory PtyFactory, cmdExec cmd.Executor) *TmuxSession {
 	return &TmuxSession{
-		sanitizedName: toTmuxName(name),
+		sanitizedName: sanitizedName,
 		program:       program,
 		ptyFactory:    ptyFactory,
 		cmdExec:       cmdExec,

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -42,11 +42,25 @@ func NewMockPtyFactory(t *testing.T) *MockPtyFactory {
 }
 
 func TestSanitizeName(t *testing.T) {
+	// Without repo path (legacy naming)
 	session := NewTmuxSession("asdf", "program")
 	require.Equal(t, TmuxPrefix+"asdf", session.sanitizedName)
 
 	session = NewTmuxSession("a sd f . . asdf", "program")
 	require.Equal(t, TmuxPrefix+"asdf__asdf", session.sanitizedName)
+
+	// With repo path (repo-scoped naming)
+	session = NewTmuxSessionForRepo("asdf", "/home/user/repo", "program")
+	hash := repoHash("/home/user/repo")
+	require.Equal(t, TmuxPrefix+hash+"_asdf", session.sanitizedName)
+
+	// Same title, different repo → different tmux name
+	session2 := NewTmuxSessionForRepo("asdf", "/home/user/other-repo", "program")
+	require.NotEqual(t, session.sanitizedName, session2.sanitizedName)
+
+	// FromSanitizedName preserves exact name
+	session3 := NewTmuxSessionFromSanitizedName("af_custom_name", "program")
+	require.Equal(t, "af_custom_name", session3.sanitizedName)
 }
 
 func TestStartTmuxSession(t *testing.T) {
@@ -67,7 +81,7 @@ func TestStartTmuxSession(t *testing.T) {
 	}
 
 	workdir := t.TempDir()
-	session := newTmuxSession("test-session", "claude", ptyFactory, cmdExec)
+	session := newTmuxSession(toTmuxName("test-session", ""), "claude", ptyFactory, cmdExec)
 
 	err := session.Start(workdir)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Tmux session names now include a short repo hash (`af_<hash>_<title>`) to prevent collisions when two repos have instances with the same title
- Persists the tmux session name in `InstanceData` so old sessions (without the hash) still restore correctly
- Adds `NewTmuxSessionForRepo`, `NewTmuxSessionFromSanitizedName`, and `SanitizedName()` to the tmux package

## Test plan
- [x] Existing `TestSanitizeName` updated with repo-scoped and backward-compat cases
- [x] `TestStartTmuxSession` passes with refactored internals
- [x] `go build ./...` and `go test ./...` pass

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)