### PR TITLE
feat: display version in help pane

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -21,6 +21,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// Version is set by main before calling Run.
+var Version string
+
 // Run is the main entrypoint into the application.
 func Run(ctx context.Context, program string, autoYes bool, repoID string) error {
 	p := tea.NewProgram(

--- a/app/help.go
+++ b/app/help.go
@@ -34,7 +34,7 @@ func helpStart(instance *session.Instance) helpText {
 
 func (h helpTypeGeneral) toContent() string {
 	content := lipgloss.JoinVertical(lipgloss.Left,
-		titleStyle.Render("Agent Factory"),
+		titleStyle.Render(fmt.Sprintf("Agent Factory v%s", Version)),
 		"",
 		"A terminal UI that manages multiple Claude Code (and other local agents) in separate workspaces.",
 		"",

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ var (
 			// Check for updates in the background (non-blocking).
 			autoUpdateInBackground()
 
+			app.Version = version
 			return app.Run(ctx, program, autoYes, repo.ID)
 		},
 	}


### PR DESCRIPTION
## Summary
- Adds the version string to the help pane title (e.g. "Agent Factory v1.0.37")
- Exposes `app.Version` package var, set from `main.go` before `app.Run()`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run `af` and press `?` — title should show "Agent Factory v1.0.37"

🤖 Generated with [Claude Code](https://claude.com/claude-code)