### PR TITLE
feat: warn about uncommitted changes before killing a session

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -156,7 +156,19 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		return instanceChangedMsg{}
 	}
 
+	// Check for uncommitted changes in the worktree
+	hasChanges := false
+	if wt := selected.GetWorktreePath(); wt != "" {
+		out, err := exec.Command("git", "-C", wt, "status", "--porcelain").Output()
+		if err == nil && len(strings.TrimSpace(string(out))) > 0 {
+			hasChanges = true
+		}
+	}
+
 	message := fmt.Sprintf("[!] Kill session '%s'?", selected.Title)
+	if hasChanges {
+		message = fmt.Sprintf("[!] Kill session '%s'?\n\nWARNING: This worktree has uncommitted changes that will be lost!", selected.Title)
+	}
 	return m, m.confirmAction(message, killAction)
 }
 


### PR DESCRIPTION
## Summary
- When pressing D to kill a session, checks if the worktree has uncommitted changes (staged or unstaged)
- Shows a warning in the confirmation dialog so users don't accidentally lose work

Closes #100

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- Manual: kill a session with uncommitted changes and verify warning appears
- Manual: kill a clean session and verify no warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)