### PR TITLE
fix: close local PTY handle on timeout to prevent fd leak

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -159,6 +159,7 @@ func (t *TmuxSession) Start(workDir string) error {
 	for !t.DoesSessionExist() {
 		select {
 		case <-timeout:
+			ptmx.Close()
 			if cleanupErr := t.Close(); cleanupErr != nil {
 				err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
 			}


### PR DESCRIPTION
## Summary
- Closes the local `ptmx` file descriptor on the timeout path in `Start()` before calling `t.Close()`, preventing a PTY fd leak when tmux session creation times out.

Fixes #111

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)