### PR TITLE
fix: use flock for task locking to prevent stale locks after crash

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -126,12 +127,17 @@ func RunTask(taskID string) error {
 		return fmt.Errorf("failed to create lock directory: %w", err)
 	}
 	lockPath := filepath.Join(lockDir, "task-"+taskID+".lock")
-	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
-		return fmt.Errorf("another run is already active for task %s: %w", taskID, err)
+		return fmt.Errorf("failed to open lock file: %w", err)
 	}
-	defer os.Remove(lockPath)
 	defer lockFile.Close()
+	defer os.Remove(lockPath)
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return fmt.Errorf("another run is already active for task %s", taskID)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
 
 	// Load the task.
 	t, err := GetTask(taskID)


### PR DESCRIPTION
## Summary
- Replace existence-based locking (`O_CREATE|O_EXCL`) with `flock`-based locking in task runner
- `flock` auto-releases when the process dies, preventing stale lock files from blocking future task runs
- Consistent with the existing locking pattern in `config/filelock.go`

Fixes #106

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: kill a running task mid-execution, verify the next run is not blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)