### PR TITLE
fix: remove worktree before deleting branch in CleanupWorktrees

### DIFF
--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -216,17 +216,22 @@ func CleanupWorktrees() error {
 	// Skip the first entry (the main worktree / repo itself)
 	if len(worktrees) > 1 {
 		for _, wt := range worktrees[1:] {
-			// Delete the branch if one exists (worktree may have detached HEAD)
+			// Remove the worktree FIRST (git refuses to delete a branch checked out in a worktree)
+			removeCmd := exec.Command("git", "-C", repoRoot, "worktree", "remove", "-f", wt.path)
+			if err := removeCmd.Run(); err != nil {
+				log.ErrorLog.Printf("failed to remove worktree %s: %v", wt.path, err)
+				// Fallback: remove directory manually
+				if err := os.RemoveAll(wt.path); err != nil {
+					log.ErrorLog.Printf("failed to remove worktree directory %s: %v", wt.path, err)
+				}
+			}
+
+			// THEN delete the branch
 			if wt.branch != "" {
 				deleteCmd := exec.Command("git", "-C", repoRoot, "branch", "-D", wt.branch)
 				if err := deleteCmd.Run(); err != nil {
 					log.ErrorLog.Printf("failed to delete branch %s: %v", wt.branch, err)
 				}
-			}
-
-			// Remove the worktree directory
-			if err := os.RemoveAll(wt.path); err != nil {
-				log.ErrorLog.Printf("failed to remove worktree directory %s: %v", wt.path, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes `af reset` leaving orphaned branches by swapping the order of operations in `CleanupWorktrees()`: remove worktree first, then delete the branch
- Git refuses to delete a branch checked out in a worktree, so the previous order (delete branch → remove worktree) silently failed on branch deletion
- Added fallback to `os.RemoveAll` if `git worktree remove -f` fails

Fixes #104

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)