### PR TITLE
fix: handle DOW step values in cron-to-OnCalendar conversion

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -207,6 +207,19 @@ func convertTimeField(field string) string {
 
 // convertDOW converts a cron day-of-week field to systemd day names.
 func convertDOW(field string) string {
+	// Handle step values (e.g. "*/2" or "1-5/2") by expanding to explicit day names
+	if strings.Contains(field, "/") {
+		expanded, err := expandCronField(field, 0, 6)
+		if err != nil {
+			return ""
+		}
+		names := make([]string, len(expanded))
+		for i, v := range expanded {
+			names[i] = dowNames[strconv.Itoa(v)]
+		}
+		return strings.Join(names, ",")
+	}
+
 	// Handle lists (e.g. "1,3,5" → "Mon,Wed,Fri")
 	if strings.Contains(field, ",") {
 		parts := strings.Split(field, ",")

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -96,3 +96,15 @@ func TestCronToOnCalendarDOW(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Mon..Fri *-*-* 09:00:00", result)
 }
+
+func TestCronToOnCalendarDOWStepAll(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * */2")
+	require.NoError(t, err)
+	assert.Equal(t, "Sun,Tue,Thu,Sat *-*-* 09:00:00", result)
+}
+
+func TestCronToOnCalendarDOWStepRange(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 1-5/2")
+	require.NoError(t, err)
+	assert.Equal(t, "Mon,Wed,Fri *-*-* 09:00:00", result)
+}


### PR DESCRIPTION
## Summary
- Fixes `convertDOW` to handle step values like `*/2` and `1-5/2` by expanding them into explicit day name lists using the existing `expandCronField` function
- Previously, `*/2` silently dropped the DOW constraint and `1-5/2` produced invalid output
- Adds tests for DOW step patterns

Fixes #107

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./task/...` passes with new DOW step tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)