### PR TITLE
fix: rollback task on scheduler install failure

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -100,6 +100,10 @@ var tasksAddCmd = &cobra.Command{
 		}
 
 		if err := task.InstallScheduler(s); err != nil {
+			// Rollback: remove the task we just added
+			if removeErr := task.RemoveTask(s.ID); removeErr != nil {
+				log.ErrorLog.Printf("failed to rollback task after scheduler install failure: %v", removeErr)
+			}
 			return jsonError(fmt.Errorf("failed to install task scheduler: %w", err))
 		}
 

--- a/app/app.go
+++ b/app/app.go
@@ -458,7 +458,11 @@ func (m *home) handleTaskCreate() tea.Cmd {
 		return m.handleError(fmt.Errorf("failed to save task: %v", err))
 	}
 	if err := task.InstallScheduler(t); err != nil {
-		log.WarningLog.Printf("failed to install task scheduler: %v", err)
+		// Rollback: remove the task we just added
+		if removeErr := task.RemoveTask(t.ID); removeErr != nil {
+			log.ErrorLog.Printf("failed to rollback task after scheduler install failure: %v", removeErr)
+		}
+		return m.handleError(fmt.Errorf("failed to install task scheduler: %v", err))
 	}
 	// Refresh sidebar and task pane
 	tasks, err := task.LoadTasksForCurrentRepo()


### PR DESCRIPTION
## Summary
- Fixes #105: failed scheduler install leaves orphaned tasks and duplicates on retry
- In `api/tasks.go` (`tasksAddCmd`): if `InstallScheduler` fails, the task added by `AddTask` is now removed
- In `app/app.go` (`handleTaskCreate`): same rollback added for the TUI task creation path, plus it now returns an error to the user instead of silently logging

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)