### PR TITLE
refactor: flatten CLI, remove duplicate task commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,19 +89,19 @@ All data (sessions, tasks) is scoped to the current git repository. The TUI show
 
 ## Programmatic API
 
-The `af api` subcommand provides a JSON CLI for driving Agent Factory without the TUI:
+The `af sessions` and `af tasks` subcommands provide a JSON CLI for driving Agent Factory without the TUI:
 
 ```bash
 # Sessions
-af api sessions list
-af api sessions create --name my-task --prompt "fix the login bug"
-af api sessions preview my-task
-af api sessions kill my-task
+af sessions list
+af sessions create --name my-task --prompt "fix the login bug"
+af sessions preview my-task
+af sessions kill my-task
 
 # Tasks
-af api tasks list
-af api tasks add --name "Daily triage" --prompt "triage new issues" --cron "0 9 * * *"
-af api tasks remove <id>
+af tasks list
+af tasks add --name "Daily triage" --prompt "triage new issues" --cron "0 9 * * *"
+af tasks remove <id>
 ```
 
 All commands output JSON to stdout and errors to stderr. Use `--repo <path>` or `--repo-id <id>` to target a specific repository.

--- a/api/api.go
+++ b/api/api.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
-
-	"github.com/spf13/cobra"
 )
 
 // Shared flags
@@ -102,16 +100,10 @@ func jsonError(err error) error {
 	return err
 }
 
-// ApiCmd is the parent command for the programmatic API
-var ApiCmd = &cobra.Command{
-	Use:   "api",
-	Short: "Programmatic JSON API for external orchestrators",
-	Long:  "Machine-readable CLI interface for driving agent-factory sessions and tasks.",
-}
-
 func init() {
-	// Persistent flags on ApiCmd (available to all subcommands)
-	ApiCmd.PersistentFlags().StringVar(&repoFlag, "repo", "", "Path to git repository")
+	// --repo flag on each top-level subcommand
+	SessionsCmd.PersistentFlags().StringVar(&repoFlag, "repo", "", "Path to git repository")
+	TasksCmd.PersistentFlags().StringVar(&repoFlag, "repo", "", "Path to git repository")
 
 	// Sessions
 	sessionsCreateCmd.Flags().StringVar(&createNameFlag, "name", "", "Session name (required)")
@@ -122,13 +114,13 @@ func init() {
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptCreateFlag, "create", false, "Auto-create the session if it doesn't exist")
 	sessionsSendPromptCmd.Flags().StringVar(&sendPromptProgramFlag, "program", "", "Program to run when creating a new session (defaults to config default)")
 
-	sessionsCmd.AddCommand(sessionsListCmd)
-	sessionsCmd.AddCommand(sessionsGetCmd)
-	sessionsCmd.AddCommand(sessionsCreateCmd)
-	sessionsCmd.AddCommand(sessionsSendPromptCmd)
-	sessionsCmd.AddCommand(sessionsPreviewCmd)
-	sessionsCmd.AddCommand(sessionsKillCmd)
-	sessionsCmd.AddCommand(sessionsWhoamiCmd)
+	SessionsCmd.AddCommand(sessionsListCmd)
+	SessionsCmd.AddCommand(sessionsGetCmd)
+	SessionsCmd.AddCommand(sessionsCreateCmd)
+	SessionsCmd.AddCommand(sessionsSendPromptCmd)
+	SessionsCmd.AddCommand(sessionsPreviewCmd)
+	SessionsCmd.AddCommand(sessionsKillCmd)
+	SessionsCmd.AddCommand(sessionsWhoamiCmd)
 
 	// Tasks
 	tasksAddCmd.Flags().StringVar(&taskAddNameFlag, "name", "", "Task name (required)")
@@ -139,11 +131,7 @@ func init() {
 	tasksAddCmd.MarkFlagRequired("prompt")
 	tasksAddCmd.MarkFlagRequired("cron")
 
-	tasksCmd.AddCommand(tasksListCmd)
-	tasksCmd.AddCommand(tasksAddCmd)
-	tasksCmd.AddCommand(tasksRemoveCmd)
-
-	// Register subcommand groups
-	ApiCmd.AddCommand(sessionsCmd)
-	ApiCmd.AddCommand(tasksCmd)
+	TasksCmd.AddCommand(tasksListCmd)
+	TasksCmd.AddCommand(tasksAddCmd)
+	TasksCmd.AddCommand(tasksRemoveCmd)
 }

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -17,7 +17,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var sessionsCmd = &cobra.Command{
+// SessionsCmd is the top-level command for session management.
+var SessionsCmd = &cobra.Command{
 	Use:   "sessions",
 	Short: "Manage sessions",
 }
@@ -158,7 +159,7 @@ var sessionsSendPromptCmd = &cobra.Command{
 	Long: `Send a prompt to an existing session. The session must already exist unless --create is used.
 
 If the session does not exist, use --create to automatically create it first,
-or use 'af api sessions create --name <title> --prompt <prompt>' instead.`,
+or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
@@ -170,7 +171,7 @@ or use 'af api sessions create --name <title> --prompt <prompt>' instead.`,
 		instance, _, err := findLiveInstanceByTitle(title)
 		if err != nil {
 			if !sendPromptCreateFlag {
-				return jsonError(fmt.Errorf("instance %q not found. Use --create to auto-create the session, or run: af api sessions create --name %q --prompt <prompt>", title, title))
+				return jsonError(fmt.Errorf("instance %q not found. Use --create to auto-create the session, or run: af sessions create --name %q --prompt <prompt>", title, title))
 			}
 
 			// Auto-create the session

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -12,7 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var tasksCmd = &cobra.Command{
+// TasksCmd is the top-level command for task management.
+var TasksCmd = &cobra.Command{
 	Use:   "tasks",
 	Short: "Manage tasks",
 }

--- a/app/sync.go
+++ b/app/sync.go
@@ -40,7 +40,7 @@ var tickPendingInstancesCmd = func() tea.Msg {
 }
 
 // tickRefreshExternalCmd reconciles the sidebar with on-disk state
-// to pick up changes made via the CLI (e.g. `af api sessions create/kill`).
+// to pick up changes made via the CLI (e.g. `af sessions create/kill`).
 // Runs every 3s.
 var tickRefreshExternalCmd = func() tea.Msg {
 	time.Sleep(3 * time.Second)

--- a/main.go
+++ b/main.go
@@ -179,7 +179,8 @@ func init() {
 	rootCmd.AddCommand(resetCmd)
 	rootCmd.AddCommand(upgradeCmd)
 	rootCmd.AddCommand(task.TaskCmd)
-	rootCmd.AddCommand(api.ApiCmd)
+	rootCmd.AddCommand(api.SessionsCmd)
+	rootCmd.AddCommand(api.TasksCmd)
 }
 
 func main() {

--- a/session/plugin.go
+++ b/session/plugin.go
@@ -20,7 +20,7 @@ const pluginManifest = `{
 // pluginCommands defines the slash command files to write into the plugin directory.
 var pluginCommands = map[string]string{
 	"af-sessions.md": "---\n" +
-		"allowed-tools: Bash(af api sessions list:*)\n" +
+		"allowed-tools: Bash(af sessions list:*)\n" +
 		"description: List all Agent Factory sessions\n" +
 		"---\n" +
 		"\n" +
@@ -28,10 +28,10 @@ var pluginCommands = map[string]string{
 		"\n" +
 		"## Context\n" +
 		"\n" +
-		"- Current sessions: !`af api sessions list`\n",
+		"- Current sessions: !`af sessions list`\n",
 
 	"af-kill.md": "---\n" +
-		"allowed-tools: Bash(af api sessions kill:*)\n" +
+		"allowed-tools: Bash(af sessions kill:*)\n" +
 		"description: Kill an Agent Factory session by title\n" +
 		"argument-hint: <session-title>\n" +
 		"---\n" +
@@ -40,10 +40,10 @@ var pluginCommands = map[string]string{
 		"\n" +
 		"The user wants to kill the session: $ARGUMENTS\n" +
 		"\n" +
-		"Run `af api sessions kill $ARGUMENTS` to kill it.\n",
+		"Run `af sessions kill $ARGUMENTS` to kill it.\n",
 
 	"af-send.md": "---\n" +
-		"allowed-tools: Bash(af api sessions send-prompt:*)\n" +
+		"allowed-tools: Bash(af sessions send-prompt:*)\n" +
 		"description: Send a prompt to another Agent Factory session\n" +
 		"argument-hint: <session-title> <prompt>\n" +
 		"---\n" +
@@ -53,10 +53,10 @@ var pluginCommands = map[string]string{
 		"The user provided: $ARGUMENTS\n" +
 		"\n" +
 		"Parse the session title (first argument) and prompt (remaining arguments), " +
-		"then run `af api sessions send-prompt <title> <prompt>`.\n",
+		"then run `af sessions send-prompt <title> <prompt>`.\n",
 
 	"af-preview.md": "---\n" +
-		"allowed-tools: Bash(af api sessions preview:*)\n" +
+		"allowed-tools: Bash(af sessions preview:*)\n" +
 		"description: Preview another Agent Factory session's terminal output\n" +
 		"argument-hint: <session-title>\n" +
 		"---\n" +
@@ -65,10 +65,10 @@ var pluginCommands = map[string]string{
 		"\n" +
 		"The user wants to preview the session: $ARGUMENTS\n" +
 		"\n" +
-		"Run `af api sessions preview $ARGUMENTS` to view it.\n",
+		"Run `af sessions preview $ARGUMENTS` to view it.\n",
 
 	"af-whoami.md": "---\n" +
-		"allowed-tools: Bash(af api sessions whoami:*)\n" +
+		"allowed-tools: Bash(af sessions whoami:*)\n" +
 		"description: Identify the current Agent Factory session\n" +
 		"---\n" +
 		"\n" +
@@ -76,7 +76,7 @@ var pluginCommands = map[string]string{
 		"\n" +
 		"## Context\n" +
 		"\n" +
-		"- Current session: !`af api sessions whoami`\n",
+		"- Current session: !`af sessions whoami`\n",
 }
 
 // ensurePluginDir creates the plugin directory with manifest and slash command

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -10,11 +10,11 @@ const codexSystemPrompt = `You are running inside Agent Factory (af), a terminal
 You can manage sessions using the "af" CLI:
 
 Session commands:
-  af api sessions whoami                        Identify your current session
-  af api sessions list                          List all sessions
-  af api sessions kill <title>                  Delete/kill a session
-  af api sessions send-prompt <title> <prompt>  Send a prompt to another session
-  af api sessions preview <title>               View another session's terminal output`
+  af sessions whoami                        Identify your current session
+  af sessions list                          List all sessions
+  af sessions kill <title>                  Delete/kill a session
+  af sessions send-prompt <title> <prompt>  Send a prompt to another session
+  af sessions preview <title>               View another session's terminal output`
 
 // shellQuote wraps a string in single quotes, escaping any embedded single quotes
 // using the standard shell idiom: replace ' with '\"

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -66,7 +66,7 @@ func TestInjectSystemPrompt_Codex(t *testing.T) {
 	if !strings.Contains(result, "developer_instructions=") {
 		t.Errorf("expected developer_instructions= in flag, got %q", result)
 	}
-	if !strings.Contains(result, "af api sessions whoami") {
+	if !strings.Contains(result, "af sessions whoami") {
 		t.Errorf("expected whoami command in codex prompt, got %q", result)
 	}
 	if !strings.HasPrefix(result, "codex") {

--- a/task/cmd.go
+++ b/task/cmd.go
@@ -1,124 +1,15 @@
 package task
 
 import (
-	"fmt"
-	"github.com/sachiniyer/agent-factory/config"
-	"os"
-	"path/filepath"
-	"text/tabwriter"
-	"time"
-
 	"github.com/spf13/cobra"
 )
 
-var (
-	nameFlag    string
-	promptFlag  string
-	cronFlag    string
-	pathFlag    string
-	programFlag string
-)
-
-// TaskCmd is the parent command for task management
+// TaskCmd is a hidden parent command that only exposes the "run" subcommand
+// used internally by the scheduler (systemd/launchd).
 var TaskCmd = &cobra.Command{
-	Use:   "task",
-	Short: "Manage automated tasks",
-	Long:  "Create, list, and manage recurring automated tasks that run automatically.",
-}
-
-var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all automated tasks",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		tasks, err := LoadTasks()
-		if err != nil {
-			return fmt.Errorf("failed to load tasks: %w", err)
-		}
-
-		if len(tasks) == 0 {
-			fmt.Println("No tasks found.")
-			return nil
-		}
-
-		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-		fmt.Fprintln(w, "ID\tNAME\tENABLED\tCRON\tPROGRAM\tPATH\tLAST_RUN\tSTATUS")
-		for _, s := range tasks {
-			lastRun := "never"
-			if s.LastRunAt != nil {
-				lastRun = s.LastRunAt.Format(time.RFC822)
-			}
-			fmt.Fprintf(w, "%s\t%s\t%t\t%s\t%s\t%s\t%s\t%s\n",
-				s.ID, s.Name, s.Enabled, s.CronExpr, s.Program, s.ProjectPath, lastRun, s.LastRunStatus)
-		}
-		w.Flush()
-		return nil
-	},
-}
-
-var addCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Add a new automated task",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := ValidateCronExpr(cronFlag); err != nil {
-			return fmt.Errorf("invalid cron expression: %w", err)
-		}
-
-		absPath, err := filepath.Abs(pathFlag)
-		if err != nil {
-			return fmt.Errorf("failed to resolve path: %w", err)
-		}
-
-		program := programFlag
-		if program == "" {
-			program = config.LoadConfig().DefaultProgram
-		}
-
-		id := GenerateID()
-		s := Task{
-			ID:          id,
-			Name:        nameFlag,
-			Prompt:      promptFlag,
-			CronExpr:    cronFlag,
-			ProjectPath: absPath,
-			Program:     program,
-			Enabled:     true,
-			CreatedAt:   time.Now(),
-		}
-
-		if err := AddTask(s); err != nil {
-			return fmt.Errorf("failed to add task: %w", err)
-		}
-
-		if err := InstallScheduler(s); err != nil {
-			return fmt.Errorf("failed to install task scheduler: %w", err)
-		}
-
-		fmt.Printf("Task added successfully (ID: %s)\n", id)
-		return nil
-	},
-}
-
-var removeCmd = &cobra.Command{
-	Use:   "remove",
-	Short: "Remove an automated task",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		s, err := GetTask(args[0])
-		if err != nil {
-			return fmt.Errorf("failed to get task: %w", err)
-		}
-
-		if err := RemoveScheduler(*s); err != nil {
-			return fmt.Errorf("failed to remove task scheduler: %w", err)
-		}
-
-		if err := RemoveTask(args[0]); err != nil {
-			return fmt.Errorf("failed to remove task: %w", err)
-		}
-
-		fmt.Printf("Task removed successfully (ID: %s)\n", args[0])
-		return nil
-	},
+	Use:    "task",
+	Short:  "Internal task runner (used by scheduler)",
+	Hidden: true,
 }
 
 var runCmd = &cobra.Command{
@@ -131,16 +22,5 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
-	addCmd.Flags().StringVar(&nameFlag, "name", "", "Task name")
-	addCmd.Flags().StringVar(&promptFlag, "prompt", "", "Prompt to send to the AI agent (required)")
-	addCmd.Flags().StringVar(&cronFlag, "cron", "", "Cron expression (required)")
-	addCmd.Flags().StringVar(&pathFlag, "path", ".", "Project path (defaults to current directory)")
-	addCmd.Flags().StringVar(&programFlag, "program", "", "Program to run (defaults to config default)")
-	addCmd.MarkFlagRequired("prompt")
-	addCmd.MarkFlagRequired("cron")
-
-	TaskCmd.AddCommand(listCmd)
-	TaskCmd.AddCommand(addCmd)
-	TaskCmd.AddCommand(removeCmd)
 	TaskCmd.AddCommand(runCmd)
 }


### PR DESCRIPTION
## Summary
- Remove duplicate top-level `af task list/add/remove` commands (kept in `af tasks`)
- Keep hidden `af task run <id>` for scheduler (systemd/launchd) internal use
- Flatten `af api sessions` → `af sessions` and `af api tasks` → `af tasks`
- Update all references in plugin commands, system prompts, help text, tests, and README

Closes #116

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify `af sessions list`, `af tasks list` work as expected
- [ ] Verify `af task run <id>` still works for scheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)