### PR TITLE
feat: add missing CLI commands for TUI parity

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -120,6 +120,7 @@ func init() {
 	SessionsCmd.AddCommand(sessionsSendPromptCmd)
 	SessionsCmd.AddCommand(sessionsPreviewCmd)
 	SessionsCmd.AddCommand(sessionsKillCmd)
+	SessionsCmd.AddCommand(sessionsAttachCmd)
 	SessionsCmd.AddCommand(sessionsWhoamiCmd)
 
 	// Tasks
@@ -131,7 +132,15 @@ func init() {
 	tasksAddCmd.MarkFlagRequired("prompt")
 	tasksAddCmd.MarkFlagRequired("cron")
 
+	tasksUpdateCmd.Flags().StringVar(&taskUpdateNameFlag, "name", "", "New task name")
+	tasksUpdateCmd.Flags().StringVar(&taskUpdatePromptFlag, "prompt", "", "New prompt")
+	tasksUpdateCmd.Flags().StringVar(&taskUpdateCronFlag, "cron", "", "New cron expression")
+	tasksUpdateCmd.Flags().StringVar(&taskUpdateEnabledFlag, "enabled", "", "Enable or disable the task (true/false)")
+
 	TasksCmd.AddCommand(tasksListCmd)
+	TasksCmd.AddCommand(tasksGetCmd)
 	TasksCmd.AddCommand(tasksAddCmd)
+	TasksCmd.AddCommand(tasksUpdateCmd)
 	TasksCmd.AddCommand(tasksRemoveCmd)
+	TasksCmd.AddCommand(tasksRunCmd)
 }

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -289,6 +289,29 @@ var sessionsKillCmd = &cobra.Command{
 	},
 }
 
+var sessionsAttachCmd = &cobra.Command{
+	Use:   "attach <title>",
+	Short: "Attach to a session's terminal",
+	Long:  "Attach to a running session's tmux terminal. Detach with the configured detach key (default: Ctrl-b d).",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		instance, _, err := findLiveInstanceByTitle(args[0])
+		if err != nil {
+			return jsonError(err)
+		}
+
+		detached, err := instance.Attach()
+		if err != nil {
+			return jsonError(fmt.Errorf("failed to attach: %w", err))
+		}
+		<-detached
+		return nil
+	},
+}
+
 var sessionsWhoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "Identify the current Agent Factory session",

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -136,3 +136,100 @@ var tasksRemoveCmd = &cobra.Command{
 		return jsonOut(map[string]bool{"ok": true})
 	},
 }
+
+var tasksGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get a task by ID",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		s, err := task.GetTask(args[0])
+		if err != nil {
+			return jsonError(fmt.Errorf("failed to get task: %w", err))
+		}
+
+		return jsonOut(s)
+	},
+}
+
+var tasksRunCmd = &cobra.Command{
+	Use:   "trigger <id>",
+	Short: "Trigger a task to run immediately",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		if err := task.RunTask(args[0]); err != nil {
+			return jsonError(fmt.Errorf("failed to trigger task: %w", err))
+		}
+
+		return jsonOut(map[string]bool{"ok": true})
+	},
+}
+
+var (
+	taskUpdateNameFlag    string
+	taskUpdatePromptFlag  string
+	taskUpdateCronFlag    string
+	taskUpdateEnabledFlag string
+)
+
+var tasksUpdateCmd = &cobra.Command{
+	Use:   "update <id>",
+	Short: "Update a task's properties",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		s, err := task.GetTask(args[0])
+		if err != nil {
+			return jsonError(fmt.Errorf("failed to get task: %w", err))
+		}
+
+		if taskUpdateNameFlag != "" {
+			s.Name = taskUpdateNameFlag
+		}
+		if taskUpdatePromptFlag != "" {
+			s.Prompt = taskUpdatePromptFlag
+		}
+
+		cronChanged := false
+		if taskUpdateCronFlag != "" {
+			if err := task.ValidateCronExpr(taskUpdateCronFlag); err != nil {
+				return jsonError(fmt.Errorf("invalid cron expression: %w", err))
+			}
+			s.CronExpr = taskUpdateCronFlag
+			cronChanged = true
+		}
+
+		switch taskUpdateEnabledFlag {
+		case "true":
+			s.Enabled = true
+		case "false":
+			s.Enabled = false
+		case "":
+			// not changed
+		default:
+			return jsonError(fmt.Errorf("--enabled must be 'true' or 'false'"))
+		}
+
+		if err := task.UpdateTask(*s); err != nil {
+			return jsonError(fmt.Errorf("failed to update task: %w", err))
+		}
+
+		if cronChanged {
+			if err := task.RemoveScheduler(*s); err != nil {
+				log.ErrorLog.Printf("failed to remove old scheduler: %v", err)
+			}
+			if err := task.InstallScheduler(*s); err != nil {
+				return jsonError(fmt.Errorf("failed to reinstall scheduler: %w", err))
+			}
+		}
+
+		return jsonOut(s)
+	},
+}


### PR DESCRIPTION
## Summary
- Add `af tasks get <id>` to retrieve a single task's details as JSON
- Add `af tasks trigger <id>` to run a task immediately (same as scheduler does)
- Add `af tasks update <id> [--name] [--prompt] [--cron] [--enabled]` to edit task properties, with automatic scheduler reinstall on cron changes
- Add `af sessions attach <title>` to attach to a running session's tmux terminal

These close the expressiveness gap between the TUI and CLI. The only remaining TUI-only features are hooks editing and worktree attachment, which are inherently interactive workflows.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] `af tasks get <id>` returns JSON for a valid task
- [ ] `af tasks trigger <id>` runs a task immediately
- [ ] `af tasks update <id> --enabled false` disables a task
- [ ] `af sessions attach <title>` attaches to a live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)