### PR TITLE
docs: add remote hooks spec and skeleton scripts

### DIFF
--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -1,0 +1,83 @@
+# Remote Hooks
+
+Agent Factory supports remote machine backends via user-provided hook scripts. When configured, remote sessions appear alongside local sessions in the TUI with the same attach/kill/preview experience.
+
+## Configuration
+
+Add remote hooks to your per-repo config at `~/.agent-factory/repos/<repoID>/config.json`:
+
+```json
+{
+  "remote_hooks": {
+    "launch_cmd": "/path/to/launch.sh",
+    "list_cmd": "/path/to/list.sh",
+    "attach_cmd": "/path/to/attach.sh",
+    "delete_cmd": "/path/to/delete.sh"
+  }
+}
+```
+
+When `remote_hooks` is absent, Agent Factory uses local tmux+git worktrees (default). When present, all sessions for that repo use the remote backend.
+
+## Script Protocol
+
+All scripts must:
+- Return exit code 0 on success, non-zero on failure
+- Write JSON output to **stdout**
+- Write progress/log messages to **stderr**
+- Accept the flags documented below
+
+### `launch_cmd`
+
+Starts a new remote agent session.
+
+**Arguments:** `--name <name> --prompt <prompt> --json`
+
+**stdout (JSON):**
+```json
+{"name": "fix-auth-bug", "status": "running"}
+```
+
+Required fields: `name` (string), `status` (string: `running`).
+Additional fields are stored as metadata but not required.
+
+### `list_cmd`
+
+Lists all running remote sessions.
+
+**Arguments:** `--json`
+
+**stdout (JSON):**
+```json
+[
+  {"name": "fix-auth-bug", "status": "running"},
+  {"name": "refactor-api", "status": "stopped"}
+]
+```
+
+Required fields per entry: `name` (string), `status` (string: `running`, `stopped`, or `error`).
+
+### `delete_cmd`
+
+Tears down a remote session and cleans up all associated resources.
+
+**Arguments:** `--name <name> --json`
+
+**stdout (JSON):**
+```json
+{"name": "fix-auth-bug", "deleted": true}
+```
+
+### `attach_cmd`
+
+Gives interactive terminal access to a running session (e.g., SSH + tmux attach).
+
+**Arguments:** `<name>`
+
+**No JSON output** — this command takes over the terminal. It should behave like `ssh -t host "tmux attach"`.
+
+Agent Factory also uses this script for the preview pane by running it in a background PTY and capturing its output.
+
+## Example
+
+See `examples/remote-hooks/` for skeleton scripts that implement this protocol.

--- a/examples/remote-hooks/README.md
+++ b/examples/remote-hooks/README.md
@@ -1,0 +1,35 @@
+# Remote Hooks — Skeleton Scripts
+
+These are starter scripts for the Agent Factory remote hooks protocol. Copy them into your own repo or infrastructure tooling directory and fill in the `TODO` sections with your provisioning logic.
+
+For the full protocol specification, see [docs/remote-hooks.md](../../docs/remote-hooks.md).
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `launch.sh` | Start a new remote agent session |
+| `list.sh` | List all running remote sessions |
+| `attach.sh` | Attach interactively to a session |
+| `delete.sh` | Tear down a session and clean up |
+
+## Quick start
+
+```bash
+cp examples/remote-hooks/*.sh /path/to/your/hooks/
+chmod +x /path/to/your/hooks/*.sh
+# Edit each script to add your infrastructure logic
+```
+
+Then configure your repo to use them:
+
+```json
+{
+  "remote_hooks": {
+    "launch_cmd": "/path/to/your/hooks/launch.sh",
+    "list_cmd": "/path/to/your/hooks/list.sh",
+    "attach_cmd": "/path/to/your/hooks/attach.sh",
+    "delete_cmd": "/path/to/your/hooks/delete.sh"
+  }
+}
+```

--- a/examples/remote-hooks/attach.sh
+++ b/examples/remote-hooks/attach.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Skeleton attach script for Agent Factory remote hooks.
+# Gives interactive terminal access to a running session.
+#
+# Required args: <name>
+# This command takes over the terminal (no JSON output).
+
+set -euo pipefail
+
+NAME="${1:?Usage: attach.sh <session-name>}"
+
+# TODO: Replace with your connection logic
+# Examples:
+#   - ssh -t user@host "tmux attach -t $NAME"
+#   - kubectl exec -it pod-$NAME -- tmux attach -t main
+
+echo "Error: attach not implemented — replace this script with your connection logic" >&2
+exit 1

--- a/examples/remote-hooks/delete.sh
+++ b/examples/remote-hooks/delete.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Skeleton delete script for Agent Factory remote hooks.
+# Tears down a remote session and cleans up resources.
+#
+# Required args: --name <name> --json
+# stdout: JSON {"name": "...", "deleted": true}
+# stderr: progress logs
+
+set -euo pipefail
+
+NAME=""
+JSON_OUTPUT=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --name) NAME="$2"; shift 2 ;;
+    --json) JSON_OUTPUT=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+if [[ -z "$NAME" ]]; then
+  echo "Error: --name is required" >&2
+  exit 1
+fi
+
+# TODO: Replace with your cleanup logic
+# Examples:
+#   - Kill the remote tmux session and remove the machine
+#   - Stop and delete the cloud container
+#   - Delete the Kubernetes pod
+
+echo "Deleting session $NAME..." >&2
+
+if [[ "$JSON_OUTPUT" == true ]]; then
+  echo "{\"name\": \"$NAME\", \"deleted\": true}"
+fi

--- a/examples/remote-hooks/launch.sh
+++ b/examples/remote-hooks/launch.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Skeleton launch script for Agent Factory remote hooks.
+# Starts a remote agent session.
+#
+# Required args: --name <name> --prompt <prompt> --json
+# stdout: JSON {"name": "...", "status": "running"}
+# stderr: progress logs
+
+set -euo pipefail
+
+NAME=""
+PROMPT=""
+JSON_OUTPUT=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --name) NAME="$2"; shift 2 ;;
+    --prompt) PROMPT="$2"; shift 2 ;;
+    --json) JSON_OUTPUT=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+if [[ -z "$NAME" ]] || [[ -z "$PROMPT" ]]; then
+  echo "Error: --name and --prompt are required" >&2
+  exit 1
+fi
+
+# TODO: Replace with your infrastructure provisioning logic
+# Examples:
+#   - SSH to a machine and start a tmux session
+#   - Launch a cloud container (Modal, AWS, GCP, etc.)
+#   - Start a Kubernetes pod
+
+echo "Launching session $NAME..." >&2
+
+# Output required JSON
+if [[ "$JSON_OUTPUT" == true ]]; then
+  echo "{\"name\": \"$NAME\", \"status\": \"running\"}"
+fi

--- a/examples/remote-hooks/list.sh
+++ b/examples/remote-hooks/list.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Skeleton list script for Agent Factory remote hooks.
+# Lists all running remote agent sessions.
+#
+# Required args: --json
+# stdout: JSON [{"name": "...", "status": "running"}, ...]
+
+set -euo pipefail
+
+# TODO: Replace with your infrastructure query logic
+# Examples:
+#   - Query cloud API for running containers
+#   - List tmux sessions on a remote host via SSH
+#   - Query Kubernetes for running pods
+
+echo "[]"


### PR DESCRIPTION
## Summary
- Add `docs/remote-hooks.md` with the full protocol specification for remote hooks (launch, list, attach, delete)
- Add `examples/remote-hooks/` with 4 skeleton scripts and a README that users can copy and customize
- Remote hooks allow Agent Factory to manage sessions on remote machines via user-provided hook scripts

Closes #129

## Test plan
- [ ] Verify `docs/remote-hooks.md` renders correctly on GitHub
- [ ] Verify skeleton scripts are executable and parse args correctly
- [ ] Verify example JSON output matches the spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)