### PR TITLE
feat: remove --prompt from remote hooks protocol

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -41,8 +41,6 @@ const (
 	stateDefault state = iota
 	// stateNew is the state when the user is creating a new instance.
 	stateNew
-	// stateRemotePrompt is the state when the user is entering a prompt for a remote instance.
-	stateRemotePrompt
 	// stateHelp is the state when a help screen is displayed.
 	stateHelp
 	// stateConfirm is the state when a confirmation modal is displayed.
@@ -81,11 +79,6 @@ type home struct {
 	// Stored as a direct pointer so background sync cannot change which
 	// instance the naming keystrokes target.
 	namingInstance *session.Instance
-
-	// remotePromptInstance is the instance waiting for a prompt in stateRemotePrompt.
-	remotePromptInstance *session.Instance
-	// remotePromptOverlay is the text input overlay for the remote prompt.
-	remotePromptOverlay *overlay.TextInputOverlay
 
 	// keySent is used to manage underlining menu items
 	keySent bool
@@ -220,9 +213,6 @@ func (m *home) updateHandleWindowSizeEvent(msg tea.WindowSizeMsg) {
 	}
 	if m.selectionOverlay != nil {
 		m.selectionOverlay.SetWidth(int(float32(msg.Width) * 0.6))
-	}
-	if m.remotePromptOverlay != nil {
-		m.remotePromptOverlay.SetSize(int(float32(msg.Width)*0.6), int(float32(msg.Height)*0.4))
 	}
 
 	tw := m.contentPane.TabbedWindow()
@@ -525,7 +515,7 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 		m.keySent = false
 		return nil, false
 	}
-	if m.state == stateHelp || m.state == stateConfirm || m.state == stateSelectWorktree || m.state == stateRemotePrompt {
+	if m.state == stateHelp || m.state == stateConfirm || m.state == stateSelectWorktree {
 		return nil, false
 	}
 	// Don't highlight when content pane has focus
@@ -566,8 +556,6 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m.handleHelpState(msg)
 	case stateNew:
 		return m.handleStateNew(msg)
-	case stateRemotePrompt:
-		return m.handleStateRemotePrompt(msg)
 	case stateSelectWorktree:
 		return m.handleStateSelectWorktree(msg)
 	case stateConfirm:
@@ -805,9 +793,7 @@ func (m *home) View() string {
 		m.errBox.String(),
 	)
 
-	if m.state == stateRemotePrompt && m.remotePromptOverlay != nil {
-		return overlay.PlaceOverlay(0, 0, m.remotePromptOverlay.Render(), mainView, true)
-	} else if m.state == stateHelp {
+	if m.state == stateHelp {
 		if m.textOverlay == nil {
 			log.ErrorLog.Printf("text overlay is nil")
 		}

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui"
-	"github.com/sachiniyer/agent-factory/ui/overlay"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-runewidth"
@@ -37,18 +36,31 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.handleError(fmt.Errorf("title cannot be empty"))
 		}
 
-		// For remote instances, collect a prompt before launching.
-		if instance.IsRemote() {
-			m.remotePromptInstance = instance
-			m.namingInstance = nil
-			m.state = stateRemotePrompt
-			m.remotePromptOverlay = overlay.NewTextInputOverlay("Enter prompt for remote session", "")
-			// Size will be set on the next WindowSizeMsg; use a default for now.
-			m.remotePromptOverlay.SetSize(60, 10)
-			return m, tea.WindowSize()
+		instance.SetStatus(session.Loading)
+		m.newInstanceFinalizer()
+		m.namingInstance = nil
+		m.state = stateDefault
+		m.menu.SetState(ui.StateDefault)
+
+		m.preSaveInstances()
+
+		selectedWt := m.selectedWorktree
+		m.selectedWorktree = nil
+		m.availableWorktrees = nil
+		startCmd := func() tea.Msg {
+			var err error
+			if selectedWt != nil {
+				err = instance.StartWithExistingWorktree(selectedWt.Path, selectedWt.Branch)
+			} else {
+				err = instance.Start(true)
+			}
+			return instanceStartedMsg{
+				instance: instance,
+				err:      err,
+			}
 		}
 
-		return m.finishNewInstance(instance)
+		return m, tea.Batch(tea.WindowSize(), m.selectionChanged(), startCmd)
 	case tea.KeyRunes:
 		if runewidth.StringWidth(instance.Title) >= 32 {
 			return m, m.handleError(fmt.Errorf("title cannot be longer than 32 characters"))
@@ -86,72 +98,6 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	default:
 	}
 	return m, nil
-}
-
-// handleStateRemotePrompt handles key events when entering a prompt for a remote instance.
-func (m *home) handleStateRemotePrompt(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if m.remotePromptOverlay == nil {
-		m.state = stateDefault
-		return m, nil
-	}
-
-	closed := m.remotePromptOverlay.HandleKeyPress(msg)
-	if !closed {
-		return m, nil
-	}
-
-	instance := m.remotePromptInstance
-	m.remotePromptInstance = nil
-
-	if m.remotePromptOverlay.IsCanceled() {
-		// User cancelled — remove the instance.
-		m.remotePromptOverlay = nil
-		m.sidebar.Kill()
-		m.state = stateDefault
-		m.menu.SetState(ui.StateDefault)
-		cmd := m.selectionChanged()
-		return m, tea.Batch(cmd, tea.WindowSize())
-	}
-
-	// Submit — set the prompt and launch.
-	prompt := m.remotePromptOverlay.GetValue()
-	m.remotePromptOverlay = nil
-
-	if prompt == "" {
-		return m, m.handleError(fmt.Errorf("prompt cannot be empty for remote sessions"))
-	}
-
-	instance.Prompt = prompt
-	return m.finishNewInstance(instance)
-}
-
-// finishNewInstance finalizes instance creation: sets loading, triggers Start in background.
-func (m *home) finishNewInstance(instance *session.Instance) (tea.Model, tea.Cmd) {
-	instance.SetStatus(session.Loading)
-	m.newInstanceFinalizer()
-	m.namingInstance = nil
-	m.state = stateDefault
-	m.menu.SetState(ui.StateDefault)
-
-	m.preSaveInstances()
-
-	selectedWt := m.selectedWorktree
-	m.selectedWorktree = nil
-	m.availableWorktrees = nil
-	startCmd := func() tea.Msg {
-		var err error
-		if selectedWt != nil {
-			err = instance.StartWithExistingWorktree(selectedWt.Path, selectedWt.Branch)
-		} else {
-			err = instance.Start(true)
-		}
-		return instanceStartedMsg{
-			instance: instance,
-			err:      err,
-		}
-	}
-
-	return m, tea.Batch(tea.WindowSize(), m.selectionChanged(), startCmd)
 }
 
 // startNewInstance creates a new instance and enters stateNew for naming.

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -31,7 +31,7 @@ All scripts must:
 
 Starts a new remote agent session.
 
-**Arguments:** `--name <name> --prompt <prompt> --json`
+**Arguments:** `--name <name> --json`
 
 **stdout (JSON):**
 ```json

--- a/examples/remote-hooks/launch.sh
+++ b/examples/remote-hooks/launch.sh
@@ -2,27 +2,25 @@
 # Skeleton launch script for Agent Factory remote hooks.
 # Starts a remote agent session.
 #
-# Required args: --name <name> --prompt <prompt> --json
+# Required args: --name <name> --json
 # stdout: JSON {"name": "...", "status": "running"}
 # stderr: progress logs
 
 set -euo pipefail
 
 NAME=""
-PROMPT=""
 JSON_OUTPUT=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
     --name) NAME="$2"; shift 2 ;;
-    --prompt) PROMPT="$2"; shift 2 ;;
     --json) JSON_OUTPUT=true; shift ;;
     *) shift ;;
   esac
 done
 
-if [[ -z "$NAME" ]] || [[ -z "$PROMPT" ]]; then
-  echo "Error: --name and --prompt are required" >&2
+if [[ -z "$NAME" ]]; then
+  echo "Error: --name is required" >&2
   exit 1
 fi
 

--- a/session/backend_e2e_test.go
+++ b/session/backend_e2e_test.go
@@ -161,7 +161,6 @@ func TestE2ERemoteHooksFullLifecycle(t *testing.T) {
 	assert.False(t, instance.Started())
 
 	// --- Step 2: Start (first-time) should call launch_cmd ---
-	instance.Prompt = "fix the auth bug in login.go"
 	err = instance.Start(true)
 	require.NoError(t, err)
 	assert.True(t, instance.Started())

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -69,9 +69,6 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 	// Launch a new remote session.
 	slug := slugify(i.Title)
 	args := []string{"--name", slug, "--json"}
-	if i.Prompt != "" {
-		args = append(args, "--prompt", i.Prompt)
-	}
 	cmd := exec.Command(b.Hooks.LaunchCmd, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -371,54 +371,7 @@ func TestInstanceDataJSONRoundTrip(t *testing.T) {
 	})
 }
 
-// --- HookBackend launch with prompt ---
-
-func TestHookBackendStartWithPrompt(t *testing.T) {
-	dir := t.TempDir()
-
-	// Script that parses --name and --prompt flags.
-	// Args: --name <name> --json --prompt <prompt>
-	// $2=name, $5=prompt (after --json is $3, --prompt is $4, value is $5)
-	launchCmd := writeScript(t, dir, "launch.sh",
-		`NAME=""; PROMPT=""
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --name) NAME="$2"; shift 2;;
-    --prompt) PROMPT="$2"; shift 2;;
-    *) shift;;
-  esac
-done
-echo "{\"name\": \"$NAME\", \"status\": \"running\", \"prompt\": \"$PROMPT\"}"
-`)
-	attachCmd := writeScript(t, dir, "attach.sh", `echo "attached"; sleep 0.1`)
-	deleteCmd := writeScript(t, dir, "delete.sh", `echo '{"deleted": true}'`)
-	listCmd := writeScript(t, dir, "list.sh", `echo '[]'`)
-
-	b := &HookBackend{
-		Hooks: config.RemoteHooks{
-			LaunchCmd: launchCmd,
-			ListCmd:   listCmd,
-			AttachCmd: attachCmd,
-			DeleteCmd: deleteCmd,
-		},
-	}
-
-	i := &Instance{
-		Title:   "prompt-test",
-		Path:    t.TempDir(),
-		Prompt:  "fix the auth bug",
-		backend: b,
-	}
-
-	err := b.Start(i, true)
-	require.NoError(t, err)
-	assert.True(t, i.Started())
-	assert.Equal(t, "prompt-test", i.Branch)
-	// The prompt should be captured in remoteMeta
-	assert.Equal(t, "fix the auth bug", i.remoteMeta["prompt"])
-
-	b.closePTY(i.Title)
-}
+// --- HookBackend launch (no prompt) ---
 
 // --- HookBackend launch failure ---
 


### PR DESCRIPTION
## Summary

- Remove `--prompt` from the `launch_cmd` protocol — prompts are never specified from the AF side
- Remove the remote prompt overlay flow (`stateRemotePrompt`, `remotePromptOverlay`)
- `HookBackend.Start` only passes `--name` and `--json` to `launch_cmd`
- Update spec, skeleton script, and `agent-launch.sh`

## Test plan

- [x] `go build ./...` and `go test ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)