### PR TITLE
ci: add dedicated PR validation workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,6 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/build.yml'
-  pull_request:
-    branches: [ master ]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/build.yml'
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,13 +8,6 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/lint.yml'
-  pull_request:
-    branches: [ master ]
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/lint.yml'
 
 jobs:
   golangci:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,69 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60.1
+          args: --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0
+          only-new-issues: true
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::Unformatted files found:"
+            echo "$unformatted"
+            gofmt -d .
+            exit 1
+          fi
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+
+      - name: Run tests
+        run: go test -v -race -count=1 ./...
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+
+      - name: Verify compilation
+        run: go build ./...

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -19,7 +19,7 @@ const (
 	KeySubmitName // SubmitName is a special keybinding for submitting the name of a new instance.
 
 	KeyNewRemote // Key for creating a new remote instance
-	KeyHelp   // Key for showing help screen
+	KeyHelp      // Key for showing help screen
 
 	// Diff keybindings
 	KeyShiftUp

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -164,4 +164,3 @@ func TestEnsurePluginDir_Idempotent(t *testing.T) {
 		t.Errorf("expected same dir on repeated calls, got %q and %q", dir1, dir2)
 	}
 }
-


### PR DESCRIPTION
## Summary
- Add a new `.github/workflows/pr.yml` workflow optimized for fast PR feedback
- Runs lint, test (with race detector), and build sequentially on a single platform (ubuntu/amd64) instead of the full 4-node cross-platform matrix in `build.yml`
- Includes concurrency control to cancel in-progress runs when new commits are pushed to the same PR

## Test plan
- [ ] Verify the workflow triggers on a PR to master
- [ ] Confirm concurrency cancellation works when pushing multiple commits
- [ ] Check that lint failures produce GitHub annotations
- [ ] Validate that the build job waits for lint and test to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)