### PR TITLE
fix: remove lock file deletion to prevent concurrent task runs

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -132,7 +132,6 @@ func RunTask(taskID string) error {
 		return fmt.Errorf("failed to open lock file: %w", err)
 	}
 	defer lockFile.Close()
-	defer os.Remove(lockPath)
 
 	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		return fmt.Errorf("another run is already active for task %s", taskID)


### PR DESCRIPTION
## Summary

- Removes `defer os.Remove(lockPath)` in `task/runner.go` which was registered before the flock check, causing it to delete the lock file even when a process failed to acquire the lock
- This deletion allowed subsequent processes to create and lock a new inode, breaking flock exclusivity and permitting concurrent task runs
- The lock file now persists on disk; flock auto-releases on process exit and the file is reused by future processes, matching the pattern in `config/filelock.go`

Fixes #137

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./task/...` passes
- [ ] Manual verification: start two concurrent runs of the same task and confirm the second is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)