### PR TITLE
fix: kill confirmation uses captured instance title to prevent wrong worktree deletion

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -145,11 +145,27 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Capture the title at confirmation time so that background tick events
+	// cannot change which instance we operate on.
+	selectedTitle := selected.Title
+
 	tw := m.contentPane.TabbedWindow()
 	killAction := func() tea.Msg {
-		tw.CleanupTerminalForInstance(selected.Title)
-		m.sidebar.Kill()
-		if err := m.storage.DeleteInstance(selected.Title); err != nil {
+		tw.CleanupTerminalForInstance(selectedTitle)
+
+		// Find and kill by title, not by current selection index, to avoid
+		// destroying the wrong worktree if the sidebar order changed.
+		for _, inst := range m.sidebar.GetInstances() {
+			if inst.Title == selectedTitle {
+				if err := inst.Kill(); err != nil {
+					log.ErrorLog.Printf("could not kill instance: %v", err)
+				}
+				break
+			}
+		}
+		m.sidebar.RemoveInstanceByTitle(selectedTitle)
+
+		if err := m.storage.DeleteInstance(selectedTitle); err != nil {
 			log.ErrorLog.Printf("failed to delete instance from storage: %v", err)
 		}
 
@@ -168,9 +184,9 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		}
 	}
 
-	message := fmt.Sprintf("[!] Kill session '%s'?", selected.Title)
+	message := fmt.Sprintf("[!] Kill session '%s'?", selectedTitle)
 	if hasChanges {
-		message = fmt.Sprintf("[!] Kill session '%s'?\n\nWARNING: This worktree has uncommitted changes that will be lost!", selected.Title)
+		message = fmt.Sprintf("[!] Kill session '%s'?\n\nWARNING: This worktree has uncommitted changes that will be lost!", selectedTitle)
 	}
 	return m, m.confirmAction(message, killAction)
 }


### PR DESCRIPTION
## Summary
- **Fixes a race condition** where `handleKill`'s confirmation closure called `m.sidebar.Kill()`, which re-reads the current sidebar selection index at execution time. If background tick events reordered the sidebar during the confirmation dialog, this could kill the wrong instance and delete the wrong worktree (with all uncommitted changes).
- The closure now captures the selected instance's title upfront and uses title-based lookup (`GetInstances` iteration + `RemoveInstanceByTitle`) instead of index-based `sidebar.Kill()`.
- The existing `RemoveInstanceByTitle` method on `Sidebar` already handled repo cleanup and list removal, so no new methods were needed.

Fixes #136

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [ ] Manual test: open multiple instances, trigger kill on one, verify the correct instance is killed
- [ ] Manual test: rapidly navigate sidebar while confirmation dialog is open, confirm kill still targets the original instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)