### PR TITLE
fix: handle bare tilde in AGENT_FACTORY_HOME to prevent panic

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,9 @@ func GetConfigDir() (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("failed to expand home directory: %w", err)
 			}
+			if envDir == "~" {
+				return homeDir, nil
+			}
 			envDir = filepath.Join(homeDir, envDir[2:])
 		}
 		return envDir, nil


### PR DESCRIPTION
## Summary
- Fix slice bounds out of range panic in `GetConfigDir()` when `AGENT_FACTORY_HOME` is set to bare `~`
- Add explicit check for `envDir == "~"` before performing `envDir[2:]` slice operation
- The bare tilde now correctly resolves to the user's home directory

Fixes #143

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./config/...` passes
- [ ] Manual test: set `AGENT_FACTORY_HOME=~` and verify no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)