### PR TITLE
fix: add missing read locks to Preview/Attach/SetPreviewSize to prevent data races

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -147,7 +147,11 @@ func (b *HookBackend) PreviewFullHistory(i *Instance) (string, error) {
 }
 
 func (b *HookBackend) Attach(i *Instance) (chan struct{}, error) {
-	if !i.started {
+	i.mu.RLock()
+	s := i.started
+	i.mu.RUnlock()
+
+	if !s {
 		return nil, fmt.Errorf("cannot attach instance that has not been started")
 	}
 

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -127,24 +127,39 @@ func (b *LocalBackend) Kill(i *Instance) error {
 }
 
 func (b *LocalBackend) Preview(i *Instance) (string, error) {
-	if !i.started {
+	i.mu.RLock()
+	s := i.started
+	ts := i.tmuxSession
+	i.mu.RUnlock()
+
+	if !s || ts == nil {
 		return "", nil
 	}
-	return i.tmuxSession.CapturePaneContent()
+	return ts.CapturePaneContent()
 }
 
 func (b *LocalBackend) PreviewFullHistory(i *Instance) (string, error) {
-	if !i.started {
+	i.mu.RLock()
+	s := i.started
+	ts := i.tmuxSession
+	i.mu.RUnlock()
+
+	if !s || ts == nil {
 		return "", nil
 	}
-	return i.tmuxSession.CapturePaneContentWithOptions("-", "-")
+	return ts.CapturePaneContentWithOptions("-", "-")
 }
 
 func (b *LocalBackend) Attach(i *Instance) (chan struct{}, error) {
-	if !i.started {
+	i.mu.RLock()
+	s := i.started
+	ts := i.tmuxSession
+	i.mu.RUnlock()
+
+	if !s || ts == nil {
 		return nil, fmt.Errorf("cannot attach instance that has not been started")
 	}
-	return i.tmuxSession.Attach()
+	return ts.Attach()
 }
 
 func (b *LocalBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool) {
@@ -199,10 +214,15 @@ func (b *LocalBackend) SendPromptCommand(i *Instance, prompt string) error {
 }
 
 func (b *LocalBackend) SetPreviewSize(i *Instance, width, height int) error {
-	if !i.started {
+	i.mu.RLock()
+	s := i.started
+	ts := i.tmuxSession
+	i.mu.RUnlock()
+
+	if !s || ts == nil {
 		return fmt.Errorf("cannot set preview size for instance that has not been started")
 	}
-	return i.tmuxSession.SetDetachedSize(width, height)
+	return ts.SetDetachedSize(width, height)
 }
 
 func (b *LocalBackend) IsAlive(i *Instance) bool {


### PR DESCRIPTION
## Summary
- Add `i.mu.RLock()`/`i.mu.RUnlock()` around reads of `i.started` and `i.tmuxSession` in `LocalBackend.Preview`, `LocalBackend.PreviewFullHistory`, `LocalBackend.Attach`, and `LocalBackend.SetPreviewSize`
- Add `i.mu.RLock()`/`i.mu.RUnlock()` around the read of `i.started` in `HookBackend.Attach`
- Copy protected fields into local variables under the lock, then use the copies — matching the pattern already used in `HasUpdated`, `SendPrompt`, `CheckAndHandleTrustPrompt`, etc.

Fixes #139

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./session/...` passes with no race warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)