### PR TITLE
fix: use repo-scoped naming for terminal tmux sessions to prevent collisions

### DIFF
--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -152,7 +152,7 @@ func (t *TerminalPane) ensureSessionLocked(instance *session.Instance) error {
 	}
 
 	termName := "term_" + instance.Title
-	ts := tmux.NewTmuxSession(termName, shell)
+	ts := tmux.NewTmuxSessionForRepo(termName, worktreePath, shell)
 
 	// Check if session already exists (e.g. from a previous run)
 	if ts.DoesSessionExist() {
@@ -161,7 +161,7 @@ func (t *TerminalPane) ensureSessionLocked(instance *session.Instance) error {
 			if closeErr := ts.Close(); closeErr != nil {
 				log.ErrorLog.Printf("terminal pane: failed to close stale session %s: %v", termName, closeErr)
 			}
-			ts = tmux.NewTmuxSession(termName, shell)
+			ts = tmux.NewTmuxSessionForRepo(termName, worktreePath, shell)
 			if err := ts.Start(worktreePath); err != nil {
 				return fmt.Errorf("terminal pane: failed to start session: %w", err)
 			}


### PR DESCRIPTION
## Summary
- Switch terminal tmux session creation from `NewTmuxSession` to `NewTmuxSessionForRepo` in `ui/terminal.go`
- This includes a repo path hash in the tmux session name, preventing collisions when instance titles differ only by whitespace (e.g. "test one" vs "testone")
- Matches the naming pattern already used for main instance sessions

Fixes #145

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./ui/...` passes
- [x] `go test ./session/tmux/...` passes
- [ ] Manual: create two instances with titles that differ only by whitespace, verify they get separate terminal sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)