### PR TITLE
fix: use OR semantics for DOM+DOW in macOS launchd scheduling

### DIFF
--- a/task/launchd.go
+++ b/task/launchd.go
@@ -186,29 +186,68 @@ func cronToCalendarIntervalXML(cronExpr string) (string, error) {
 		expanded = append(expanded, expandedField{key: def.key, vals: vals})
 	}
 
-	// Build cartesian product of all non-wildcard field values.
-	type combo map[string]int
-	combos := []combo{{}}
+	// When both day-of-month (DOM) and day-of-week (DOW) are non-wildcard,
+	// standard cron uses OR semantics: run on matching DOM OR matching DOW.
+	// We handle this by building two separate sets of combos and merging them.
+	domIdx, dowIdx := 2, 4
+	bothDOMandDOW := expanded[domIdx].vals != nil && expanded[dowIdx].vals != nil
 
-	for _, ef := range expanded {
-		if ef.vals == nil {
-			continue // wildcard, omit from dict
-		}
-		var newCombos []combo
-		for _, existing := range combos {
-			for _, val := range ef.vals {
-				c := make(combo)
-				for k, v := range existing {
-					c[k] = v
-				}
-				c[ef.key] = val
-				newCombos = append(newCombos, c)
+	// buildCombos builds the cartesian product of the given expanded fields.
+	type combo map[string]int
+	buildCombos := func(fields []expandedField) ([]combo, error) {
+		result := []combo{{}}
+		for _, ef := range fields {
+			if ef.vals == nil {
+				continue // wildcard, omit from dict
 			}
+			var newResult []combo
+			for _, existing := range result {
+				for _, val := range ef.vals {
+					c := make(combo)
+					for k, v := range existing {
+						c[k] = v
+					}
+					c[ef.key] = val
+					newResult = append(newResult, c)
+				}
+			}
+			if len(newResult) > maxCalendarIntervals {
+				return nil, fmt.Errorf("cron expression %q expands to too many intervals (%d > %d)", cronExpr, len(newResult), maxCalendarIntervals)
+			}
+			result = newResult
 		}
-		if len(newCombos) > maxCalendarIntervals {
-			return "", fmt.Errorf("cron expression %q expands to too many intervals (%d > %d)", cronExpr, len(newCombos), maxCalendarIntervals)
+		return result, nil
+	}
+
+	var combos []combo
+	if bothDOMandDOW {
+		// OR semantics: generate DOM combos (without DOW) and DOW combos (without DOM).
+		domFields := make([]expandedField, len(expanded))
+		copy(domFields, expanded)
+		domFields[dowIdx] = expandedField{key: "Weekday", vals: nil} // exclude DOW
+
+		dowFields := make([]expandedField, len(expanded))
+		copy(dowFields, expanded)
+		dowFields[domIdx] = expandedField{key: "Day", vals: nil} // exclude DOM
+
+		domCombos, err := buildCombos(domFields)
+		if err != nil {
+			return "", err
 		}
-		combos = newCombos
+		dowCombos, err := buildCombos(dowFields)
+		if err != nil {
+			return "", err
+		}
+		combos = append(domCombos, dowCombos...)
+		if len(combos) > maxCalendarIntervals {
+			return "", fmt.Errorf("cron expression %q expands to too many intervals (%d > %d)", cronExpr, len(combos), maxCalendarIntervals)
+		}
+	} else {
+		var err error
+		combos, err = buildCombos(expanded)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	if len(combos) == 0 || (len(combos) == 1 && len(combos[0]) == 0) {


### PR DESCRIPTION
## Summary

- When both day-of-month (DOM) and day-of-week (DOW) are non-wildcard in a cron expression, standard cron uses OR semantics: the job should run on matching DOM **or** matching DOW
- The previous `cronToCalendarIntervalXML` implementation placed both DOM and DOW in the same `<dict>`, giving AND semantics (only runs when both match)
- This fix generates two separate sets of `<dict>` entries -- one with DOM (no DOW) and one with DOW (no DOM) -- achieving OR semantics via launchd's `<array>` of `<dict>` entries
- When only one of DOM/DOW is specified (or neither), the existing cartesian product logic is preserved unchanged

Fixes #142

## Test plan

- [ ] Verify `go build ./...` passes
- [ ] Verify `go test ./task/...` passes
- [ ] On macOS, test that `0 9 15 * 1` produces two separate `<dict>` entries: one with `Day=15` and one with `Weekday=1`
- [ ] On macOS, test that `0 9 15 * *` (only DOM, no DOW) still produces a single `<dict>` with `Day=15`
- [ ] On macOS, test that `0 9 * * 1` (only DOW, no DOM) still produces a single `<dict>` with `Weekday=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)