### PR TITLE
fix: preserve PR info on transient gh failures

### DIFF
--- a/session/git/github.go
+++ b/session/git/github.go
@@ -2,7 +2,9 @@ package git
 
 import (
 	"encoding/json"
+	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // PRInfo holds information about a GitHub pull request associated with a branch.
@@ -24,8 +26,14 @@ func FetchPRInfo(repoPath, branchName string) (*PRInfo, error) {
 	cmd.Dir = repoPath
 	out, err := cmd.Output()
 	if err != nil {
-		// Non-zero exit means no PR found (or other error) — treat as no PR.
-		return nil, nil
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exitErr.Stderr)
+			if strings.Contains(stderr, "no pull requests found") ||
+				strings.Contains(stderr, "Could not resolve to a PullRequest") {
+				return nil, nil // genuinely no PR
+			}
+		}
+		return nil, fmt.Errorf("failed to fetch PR info: %w", err)
 	}
 
 	var info PRInfo

--- a/session/instance.go
+++ b/session/instance.go
@@ -1,13 +1,14 @@
 package session
 
 import (
-	"github.com/sachiniyer/agent-factory/session/git"
-	"github.com/sachiniyer/agent-factory/session/tmux"
+	"fmt"
 	"path/filepath"
 	"sync"
-
-	"fmt"
 	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 type Status int
@@ -390,7 +391,8 @@ func (i *Instance) UpdatePRInfo() error {
 	}
 	info, err := git.FetchPRInfo(gw.GetRepoPath(), i.Branch)
 	if err != nil {
-		return err
+		log.ErrorLog.Printf("transient PR fetch error (keeping cached info): %v", err)
+		return nil // don't propagate, just keep existing cached info
 	}
 
 	i.mu.Lock()


### PR DESCRIPTION
## Summary
- **`FetchPRInfo`** now inspects `gh pr view` stderr to distinguish "no pull requests found" from transient errors (network failures, rate limiting). Only the genuine "no PR" case returns `nil, nil`; other failures return an error.
- **`UpdatePRInfo`** now keeps cached PR info when a transient fetch error occurs, logging the failure instead of clearing the data and propagating the error.

Fixes #140

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./session/...` passes
- [ ] Verify that when `gh` returns a network error, existing PR info is preserved
- [ ] Verify that when no PR exists, info is correctly set to nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)