### PR TITLE
fix: clean up tmux session and worktree on failed API session startup

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -118,6 +118,7 @@ var sessionsCreateCmd = &cobra.Command{
 		}
 
 		if err := task.StartAndSendPrompt(instance, createPromptFlag); err != nil {
+			instance.Kill() // Clean up tmux session and git worktree
 			return jsonError(fmt.Errorf("failed to start instance: %w", err))
 		}
 		instance.SetStatus(session.Running)
@@ -199,6 +200,7 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 			}
 
 			if err := task.StartAndSendPrompt(instance, ""); err != nil {
+				instance.Kill() // Clean up tmux session and git worktree
 				return jsonError(fmt.Errorf("failed to start instance: %w", err))
 			}
 			instance.SetStatus(session.Running)


### PR DESCRIPTION
## Summary
- Adds `instance.Kill()` cleanup in `sessionsCreateCmd` when `StartAndSendPrompt` fails after `instance.Start()` has already created a tmux session and git worktree
- Adds the same cleanup in `sessionsSendPromptCmd` (with `--create` flag) for the equivalent error path
- Prevents orphaned tmux sessions and git worktrees from accumulating when API session creation fails partway through

Fixes #144

## Test plan
- [ ] Verify `go build ./...` passes (confirmed locally)
- [ ] Verify no regressions in existing tests (`go test ./api/...` -- no test files in this package)
- [ ] Manually test: create a session with an invalid prompt/program and confirm no orphaned tmux sessions or worktrees remain after the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)