### PR TITLE
fix: expand Sunday-starting DOW ranges to comma-separated list for systemd

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -213,6 +213,10 @@ func convertDOW(field string) string {
 		if err != nil {
 			return ""
 		}
+		// If all 7 days are covered, omit DOW entirely.
+		if len(expanded) >= 7 {
+			return ""
+		}
 		names := make([]string, len(expanded))
 		for i, v := range expanded {
 			names[i] = dowNames[strconv.Itoa(v)]
@@ -231,11 +235,11 @@ func convertDOW(field string) string {
 	}
 
 	// Handle ranges (e.g. "1-5" → "Mon..Fri")
+	// For ranges starting with 0 (Sunday), expand to comma-separated day names
+	// because systemd requires Day1 < Day2 in weekly order (Mon..Sun), and
+	// Sun..X is invalid.
 	if strings.Contains(field, "-") {
-		idx := strings.Index(field, "-")
-		start := field[:idx]
-		end := field[idx+1:]
-		return fmt.Sprintf("%s..%s", dowNames[start], dowNames[end])
+		return convertSingleDOW(field)
 	}
 
 	// Single value
@@ -243,11 +247,30 @@ func convertDOW(field string) string {
 }
 
 // convertSingleDOW converts a single DOW element (number or range) to a name.
+// For ranges starting with 0 (Sunday), it expands to a comma-separated list
+// because systemd's range syntax requires Day1 < Day2 in weekly order
+// (Mon->Tue->...->Sun), making Sun..X invalid.
 func convertSingleDOW(part string) string {
 	if strings.Contains(part, "-") {
 		idx := strings.Index(part, "-")
 		start := part[:idx]
 		end := part[idx+1:]
+
+		// For ranges starting with Sunday (0), expand to comma-separated names.
+		if start == "0" {
+			endVal, _ := strconv.Atoi(end)
+			// 0-6 or 0-7 covers all 7 days (7 is also Sunday in cron).
+			// Return empty to signal the caller to omit DOW entirely.
+			if endVal >= 6 {
+				return ""
+			}
+			var names []string
+			for i := 0; i <= endVal; i++ {
+				names = append(names, dowNames[strconv.Itoa(i)])
+			}
+			return strings.Join(names, ",")
+		}
+
 		return fmt.Sprintf("%s..%s", dowNames[start], dowNames[end])
 	}
 	return dowNames[part]

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -108,3 +108,36 @@ func TestCronToOnCalendarDOWStepRange(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Mon,Wed,Fri *-*-* 09:00:00", result)
 }
+
+func TestCronToOnCalendarDOWSundayRange01(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 0-1")
+	require.NoError(t, err)
+	assert.Equal(t, "Sun,Mon *-*-* 09:00:00", result)
+}
+
+func TestCronToOnCalendarDOWSundayRange03(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 0-3")
+	require.NoError(t, err)
+	assert.Equal(t, "Sun,Mon,Tue,Wed *-*-* 09:00:00", result)
+}
+
+func TestCronToOnCalendarDOWSundayRange06(t *testing.T) {
+	// 0-6 covers all 7 days, so DOW should be omitted.
+	result, err := CronToOnCalendar("0 9 * * 0-6")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-* 09:00:00", result)
+}
+
+func TestCronToOnCalendarDOWSundayRange07(t *testing.T) {
+	// 0-7 also covers all days (7 is Sunday in cron), so DOW should be omitted.
+	result, err := CronToOnCalendar("0 9 * * 0-7")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-* 09:00:00", result)
+}
+
+func TestCronToOnCalendarDOWNonSundayRange(t *testing.T) {
+	// Non-zero-starting ranges should still use .. syntax.
+	result, err := CronToOnCalendar("0 9 * * 2-4")
+	require.NoError(t, err)
+	assert.Equal(t, "Tue..Thu *-*-* 09:00:00", result)
+}


### PR DESCRIPTION
## Summary
- Fix invalid systemd `OnCalendar` syntax for cron day-of-week ranges starting with `0` (Sunday). `Sun..Wed` is invalid because systemd requires `Day1 < Day2` in weekly order (`Mon->...->Sun`). Now these ranges are expanded to comma-separated day names (e.g., `0-3` becomes `Sun,Mon,Tue,Wed`).
- Ranges covering all 7 days (`0-6`, `0-7`) now omit the DOW field entirely, matching `*` behavior.
- Non-zero-starting ranges (e.g., `1-5` -> `Mon..Fri`) are unchanged.

Fixes #141

## Test plan
- [x] Existing tests continue to pass (`go test ./task/...`)
- [x] New tests added for `0-1`, `0-3`, `0-6`, `0-7`, and non-Sunday ranges
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)