### PR TITLE
fix: daemon SaveInstances uses read-merge-write to preserve external changes

### DIFF
--- a/session/storage.go
+++ b/session/storage.go
@@ -93,19 +93,78 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 		})
 	}
 
-	// Daemon mode: group by repo and save each group separately
+	// Daemon mode: group in-memory instances by repo.
+	// Use d.Path (always set) rather than d.Worktree.RepoPath (empty for
+	// remote backends) so the grouping key is consistent with knownRepoIDs.
 	grouped := make(map[string][]InstanceData)
 	for _, d := range data {
-		rid := config.RepoIDFromRoot(d.Worktree.RepoPath)
+		rid := config.RepoIDFromRoot(d.Path)
 		grouped[rid] = append(grouped[rid], d)
 	}
-	for rid, group := range grouped {
+
+	// Build a set of ALL in-memory instance titles (including non-started/
+	// non-loading ones) so we can distinguish "killed in daemon" from
+	// "added externally on disk".
+	allInMemoryTitles := make(map[string]bool, len(instances))
+	for _, inst := range instances {
+		allInMemoryTitles[inst.Title] = true
+	}
+
+	// Also collect repo IDs that the daemon knows about so we visit repos
+	// that had all their in-memory instances killed (group would be empty).
+	knownRepoIDs := make(map[string]bool)
+	for _, inst := range instances {
+		rid := config.RepoIDFromRoot(inst.Path)
+		knownRepoIDs[rid] = true
+	}
+
+	// Merge each repo's in-memory state with disk state.
+	for rid := range knownRepoIDs {
+		group := grouped[rid] // may be nil if all instances for this repo were killed
 		path, pathErr := config.RepoInstancesPath(rid)
 		if pathErr != nil {
 			return pathErr
 		}
 		if err := config.WithFileLock(path, func() error {
-			jsonData, err := json.Marshal(group)
+			// Read existing disk state inside the lock.
+			diskJSON := s.state.GetInstances(rid)
+			var diskData []InstanceData
+			if diskJSON != nil && string(diskJSON) != "[]" && string(diskJSON) != "null" {
+				if err := json.Unmarshal(diskJSON, &diskData); err != nil {
+					log.WarningLog.Printf("failed to parse disk instances for repo %s, overwriting: %v", rid, err)
+					diskData = nil
+				}
+			}
+
+			// Build set of in-memory titles for this repo's group for
+			// quick lookup when replacing disk entries.
+			memTitles := make(map[string]bool, len(group))
+			for _, d := range group {
+				memTitles[d.Title] = true
+			}
+
+			// Start with the in-memory instances (they take precedence).
+			merged := make([]InstanceData, 0, len(group)+len(diskData))
+			merged = append(merged, group...)
+
+			// Preserve disk-only instances that were NOT known to the
+			// daemon (i.e. added externally while the daemon was running).
+			for _, dd := range diskData {
+				if memTitles[dd.Title] {
+					// Already covered by the in-memory version.
+					continue
+				}
+				if allInMemoryTitles[dd.Title] {
+					// The daemon knew about this instance but it is no
+					// longer started/loading (e.g. killed). Don't
+					// preserve it.
+					continue
+				}
+				// Externally added instance — keep it.
+				merged = append(merged, dd)
+			}
+
+			jsonData, err := json.Marshal(merged)
 			if err != nil {
 				return fmt.Errorf("failed to marshal instances for repo %s: %w", rid, err)
 			}
@@ -114,6 +173,12 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 			return err
 		}
 	}
+
+	// Handle repos that exist ONLY on disk (no in-memory instances at all).
+	// These repos were never loaded by the daemon, so we must not touch them.
+	// Since we only iterate knownRepoIDs above, disk-only repos are
+	// naturally preserved (we never write to them).
+
 	return nil
 }
 

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -1,0 +1,247 @@
+package session
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockInstanceStorage is a simple in-memory implementation of config.InstanceStorage.
+type mockInstanceStorage struct {
+	mu   sync.Mutex
+	data map[string]json.RawMessage
+}
+
+func newMockStorage() *mockInstanceStorage {
+	return &mockInstanceStorage{data: make(map[string]json.RawMessage)}
+}
+
+func (m *mockInstanceStorage) SaveInstances(repoID string, instancesJSON json.RawMessage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[repoID] = instancesJSON
+	return nil
+}
+
+func (m *mockInstanceStorage) GetInstances(repoID string) json.RawMessage {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.data[repoID]
+}
+
+func (m *mockInstanceStorage) GetAllInstances() map[string]json.RawMessage {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[string]json.RawMessage, len(m.data))
+	for k, v := range m.data {
+		out[k] = v
+	}
+	return out
+}
+
+func (m *mockInstanceStorage) DeleteAllInstances() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data = make(map[string]json.RawMessage)
+	return nil
+}
+
+// helper to seed disk state for a specific repo.
+func seedDisk(t *testing.T, ms *mockInstanceStorage, repoPath string, instances []InstanceData) {
+	t.Helper()
+	rid := config.RepoIDFromRoot(repoPath)
+	b, err := json.Marshal(instances)
+	require.NoError(t, err)
+	ms.data[rid] = b
+}
+
+// helper to read back disk state for a repo.
+func readDisk(t *testing.T, ms *mockInstanceStorage, repoPath string) []InstanceData {
+	t.Helper()
+	rid := config.RepoIDFromRoot(repoPath)
+	raw := ms.data[rid]
+	if raw == nil {
+		return nil
+	}
+	var out []InstanceData
+	require.NoError(t, json.Unmarshal(raw, &out))
+	return out
+}
+
+// makeInstance creates a minimal Instance for testing.
+// started controls whether the instance appears started.
+func makeInstance(title, repoPath string, started bool) *Instance {
+	i := &Instance{
+		Title:     title,
+		Path:      repoPath,
+		Status:    Running,
+		CreatedAt: time.Now(),
+		backend:   &LocalBackend{},
+		started:   started,
+	}
+	return i
+}
+
+func TestDaemonSavePreservesExternalInstances(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	ms := newMockStorage()
+
+	// Seed disk with two instances: A (daemon-loaded) and B (added externally).
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "instance-A", Path: repoPath},
+		{Title: "instance-B", Path: repoPath},
+	})
+
+	// The daemon only knows about instance-A (loaded at startup).
+	instanceA := makeInstance("instance-A", repoPath, true)
+
+	storage, err := NewStorage(ms, "") // daemon mode (empty repoID)
+	require.NoError(t, err)
+
+	// Save: daemon has only instance-A in memory.
+	err = storage.SaveInstances([]*Instance{instanceA})
+	require.NoError(t, err)
+
+	// Verify: both A and B should be on disk.
+	result := readDisk(t, ms, repoPath)
+	titles := make(map[string]bool)
+	for _, d := range result {
+		titles[d.Title] = true
+	}
+	assert.True(t, titles["instance-A"], "in-memory instance should be saved")
+	assert.True(t, titles["instance-B"], "externally-added instance should be preserved")
+}
+
+func TestDaemonSaveRemovesKilledInstances(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	ms := newMockStorage()
+
+	// Seed disk with instances A and B (both known to daemon).
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "instance-A", Path: repoPath},
+		{Title: "instance-B", Path: repoPath},
+	})
+
+	// The daemon knows about both, but B was killed (started=false).
+	instanceA := makeInstance("instance-A", repoPath, true)
+	instanceB := makeInstance("instance-B", repoPath, false) // killed
+
+	storage, err := NewStorage(ms, "") // daemon mode
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{instanceA, instanceB})
+	require.NoError(t, err)
+
+	// Verify: only A should remain; B was killed and should be removed.
+	result := readDisk(t, ms, repoPath)
+	titles := make(map[string]bool)
+	for _, d := range result {
+		titles[d.Title] = true
+	}
+	assert.True(t, titles["instance-A"], "started instance should be saved")
+	assert.False(t, titles["instance-B"], "killed instance should not be preserved")
+}
+
+func TestDaemonSaveMergesCorrectly(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	ms := newMockStorage()
+
+	// Disk has: A (daemon-known), B (external), C (daemon-known, will be killed).
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "instance-A", Path: repoPath, Branch: "old-branch-a"},
+		{Title: "instance-B", Path: repoPath, Branch: "branch-b"},
+		{Title: "instance-C", Path: repoPath, Branch: "branch-c"},
+	})
+
+	// Daemon memory: A (started, updated), C (killed).
+	instanceA := makeInstance("instance-A", repoPath, true)
+	instanceA.Branch = "new-branch-a" // updated in memory
+	instanceC := makeInstance("instance-C", repoPath, false) // killed
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{instanceA, instanceC})
+	require.NoError(t, err)
+
+	result := readDisk(t, ms, repoPath)
+	titleMap := make(map[string]InstanceData)
+	for _, d := range result {
+		titleMap[d.Title] = d
+	}
+
+	// A should be present with updated data from memory.
+	assert.Contains(t, titleMap, "instance-A")
+	// B should be preserved (external).
+	assert.Contains(t, titleMap, "instance-B")
+	assert.Equal(t, "branch-b", titleMap["instance-B"].Branch)
+	// C should be gone (killed).
+	assert.NotContains(t, titleMap, "instance-C")
+}
+
+func TestDaemonSaveDoesNotTouchUnknownRepos(t *testing.T) {
+	const repoPath1 = "/tmp/repo1"
+	const repoPath2 = "/tmp/repo2"
+	ms := newMockStorage()
+
+	// Seed disk with instances in two different repos.
+	seedDisk(t, ms, repoPath1, []InstanceData{
+		{Title: "instance-A", Path: repoPath1},
+	})
+	seedDisk(t, ms, repoPath2, []InstanceData{
+		{Title: "instance-X", Path: repoPath2},
+	})
+
+	// Daemon only knows about repo1.
+	instanceA := makeInstance("instance-A", repoPath1, true)
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{instanceA})
+	require.NoError(t, err)
+
+	// Repo2 should be untouched.
+	result2 := readDisk(t, ms, repoPath2)
+	require.Len(t, result2, 1)
+	assert.Equal(t, "instance-X", result2[0].Title)
+
+	// Repo1 should have instance-A.
+	result1 := readDisk(t, ms, repoPath1)
+	require.Len(t, result1, 1)
+	assert.Equal(t, "instance-A", result1[0].Title)
+}
+
+func TestDaemonSaveEmptyDisk(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	ms := newMockStorage()
+
+	// No existing disk state.
+	instanceA := makeInstance("instance-A", repoPath, true)
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{instanceA})
+	require.NoError(t, err)
+
+	result := readDisk(t, ms, repoPath)
+	require.Len(t, result, 1)
+	assert.Equal(t, "instance-A", result[0].Title)
+}
+
+func TestDaemonSaveNoInstances(t *testing.T) {
+	ms := newMockStorage()
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	// Saving empty list should succeed without error.
+	err = storage.SaveInstances([]*Instance{})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- Daemon mode `SaveInstances` now implements a read-merge-write pattern instead of blindly overwriting disk state with in-memory instances
- Within the file lock, reads existing disk state, merges with in-memory instances (in-memory takes precedence), preserves externally-added instances (from API), and removes instances that were killed in the daemon
- Uses `d.Path` instead of `d.Worktree.RepoPath` for repo grouping to handle remote backends consistently
- Repos that exist only on disk (unknown to daemon) are left untouched

Fixes #138

## Test plan
- [x] Added `TestDaemonSavePreservesExternalInstances` -- verifies externally-added disk instances survive daemon save
- [x] Added `TestDaemonSaveRemovesKilledInstances` -- verifies killed in-memory instances are not preserved from disk
- [x] Added `TestDaemonSaveMergesCorrectly` -- verifies full merge: in-memory updates, external preserves, killed removes
- [x] Added `TestDaemonSaveDoesNotTouchUnknownRepos` -- verifies repos the daemon doesn't know about are left untouched
- [x] Added `TestDaemonSaveEmptyDisk` -- verifies save works with no prior disk state
- [x] Added `TestDaemonSaveNoInstances` -- verifies empty instance list is handled gracefully
- [x] All existing tests pass (`go test ./session/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)