### PR TITLE
feat: add per-session program selection in TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Factory
 
-A terminal UI that manages multiple AI coding agents (Claude Code, Aider, Codex, Amp) in separate git worktrees. Each agent runs in its own isolated workspace with full git integration, automated tasks, and a programmatic API for orchestration.
+A terminal UI that manages multiple AI coding agents (Claude Code, Aider, Codex, Gemini) in separate git worktrees. Each agent runs in its own isolated workspace with full git integration, automated tasks, and a programmatic API for orchestration.
 
 Fork of [claude-squad](https://github.com/smtg-ai/claude-squad) with per-repo scoping, programmatic API, and automated tasks.
 

--- a/app/app.go
+++ b/app/app.go
@@ -49,6 +49,8 @@ const (
 	stateSelectWorktree
 	// stateSearch is the state when the user is searching sessions.
 	stateSearch
+	// stateSelectProgram is the state when the user is selecting a program during naming.
+	stateSelectProgram
 )
 
 type home struct {
@@ -107,6 +109,8 @@ type home struct {
 	selectedWorktree *git.WorktreeInfo
 	// availableWorktrees stores the worktrees shown in the selection overlay
 	availableWorktrees []git.WorktreeInfo
+	// pendingProgram tracks the program selected during new instance naming
+	pendingProgram string
 }
 
 func newHome(ctx context.Context, program string, autoYes bool, repoID string) *home {
@@ -564,6 +568,8 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m.handleStateConfirm(msg)
 	case stateSearch:
 		return m.handleStateSearch(msg)
+	case stateSelectProgram:
+		return m.handleStateSelectProgram(msg)
 	}
 
 	// Route keys to content pane if it has focus (e.g., editing tasks/hooks)
@@ -815,6 +821,11 @@ func (m *home) View() string {
 			log.ErrorLog.Printf("search overlay is nil")
 		}
 		return overlay.PlaceOverlay(0, 0, m.searchOverlay.Render(), mainView, true)
+	} else if m.state == stateSelectProgram {
+		if m.selectionOverlay == nil {
+			log.ErrorLog.Printf("selection overlay is nil")
+		}
+		return overlay.PlaceOverlay(0, 0, m.selectionOverlay.Render(), mainView, true)
 	}
 
 	return mainView

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -2,9 +2,13 @@ package app
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/overlay"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mattn/go-runewidth"
@@ -39,6 +43,8 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.handleError(fmt.Errorf("title cannot be empty"))
 		}
 
+		// Apply the program selected during naming
+		instance.Program = m.pendingProgram
 		instance.SetStatus(session.Loading)
 		m.newInstanceFinalizer()
 		m.namingInstance = nil
@@ -64,6 +70,21 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 		return m, tea.Batch(tea.WindowSize(), m.selectionChanged(), startCmd)
+	case tea.KeyTab:
+		// Open program selection overlay
+		items := make([]string, len(tmux.SupportedPrograms))
+		selectedIdx := 0
+		for i, p := range tmux.SupportedPrograms {
+			items[i] = p
+			if strings.Contains(strings.ToLower(m.pendingProgram), p) {
+				selectedIdx = i
+			}
+		}
+		m.selectionOverlay = overlay.NewSelectionOverlay("Select Program", items)
+		m.selectionOverlay.SetWidth(40)
+		m.selectionOverlay.SetSelectedIndex(selectedIdx)
+		m.state = stateSelectProgram
+		return m, nil
 	case tea.KeyRunes:
 		if runewidth.StringWidth(instance.Title) >= 32 {
 			return m, m.handleError(fmt.Errorf("title cannot be longer than 32 characters"))
@@ -108,10 +129,11 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // startNewInstance creates a new instance and enters stateNew for naming.
 // If remote is true, the instance is forced to use the remote hook backend.
 func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
+	m.pendingProgram = m.program
 	instance, err := session.NewInstance(session.InstanceOptions{
 		Title:       "",
 		Path:        ".",
-		Program:     m.program,
+		Program:     m.pendingProgram,
 		ForceRemote: remote,
 	})
 	if err != nil {

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -2,9 +2,12 @@ package app
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 
@@ -20,11 +23,12 @@ func (m *home) handleStateSelectWorktree(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			wt := m.availableWorktrees[idx]
 			m.selectedWorktree = &wt
 			m.selectionOverlay = nil
+			m.pendingProgram = m.program
 
 			instance, err := session.NewInstance(session.InstanceOptions{
 				Title:   "",
 				Path:    ".",
-				Program: m.program,
+				Program: m.pendingProgram,
 			})
 			if err != nil {
 				m.selectedWorktree = nil
@@ -46,6 +50,30 @@ func (m *home) handleStateSelectWorktree(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.availableWorktrees = nil
 		m.state = stateDefault
 		m.menu.SetState(ui.StateDefault)
+		return m, nil
+	}
+	return m, nil
+}
+
+// handleStateSelectProgram handles key events during program selection.
+func (m *home) handleStateSelectProgram(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	shouldClose := m.selectionOverlay.HandleKeyPress(msg)
+	if shouldClose {
+		if m.selectionOverlay.IsSubmitted() {
+			idx := m.selectionOverlay.GetSelectedIndex()
+			selected := tmux.SupportedPrograms[idx]
+			// If the user re-selected the program matching the default (which may
+			// contain flags like --dangerously-skip-permissions), keep the full
+			// default string. Otherwise use the bare program name.
+			if strings.Contains(strings.ToLower(m.program), selected) {
+				m.pendingProgram = m.program
+			} else {
+				m.pendingProgram = selected
+			}
+		}
+		m.selectionOverlay = nil
+		m.state = stateNew
+		m.menu.SetState(ui.StateNewInstance)
 		return m, nil
 	}
 	return m, nil

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -36,6 +36,8 @@ const (
 	KeyCopyPR // Key for copying PR URL to clipboard
 	KeyHooks  // Key for editing post-worktree hooks
 
+	KeyChangeProgram // Key for changing the program during new instance naming
+
 	// Sidebar navigation
 	KeyLeft        // Collapse section / move to parent
 	KeyRight       // Expand section
@@ -180,5 +182,9 @@ var GlobalKeyBindings = map[KeyName]key.Binding{
 	KeySubmitName: key.NewBinding(
 		key.WithKeys("enter"),
 		key.WithHelp("enter", "submit name"),
+	),
+	KeyChangeProgram: key.NewBinding(
+		key.WithKeys("tab"),
+		key.WithHelp("tab", "change program"),
 	),
 }

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ var (
 	daemonFlag  bool
 	rootCmd     = &cobra.Command{
 		Use:   "af",
-		Short: "Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, and Amp.",
+		Short: "Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, and Gemini.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			log.Initialize(daemonFlag)

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -21,9 +21,12 @@ import (
 )
 
 const ProgramClaude = "claude"
-
+const ProgramCodex = "codex"
 const ProgramAider = "aider"
 const ProgramGemini = "gemini"
+
+// SupportedPrograms is the canonical list of known agent programs.
+var SupportedPrograms = []string{ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini}
 
 // TmuxSession represents a managed tmux session
 type TmuxSession struct {

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -61,7 +61,7 @@ type Menu struct {
 }
 
 var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyNewRemote, keys.KeyAttach, keys.KeySearch, keys.KeyHelp, keys.KeyQuit}
-var newInstanceMenuOptions = []keys.KeyName{keys.KeySubmitName}
+var newInstanceMenuOptions = []keys.KeyName{keys.KeySubmitName, keys.KeyChangeProgram}
 
 func NewMenu() *Menu {
 	m := &Menu{

--- a/ui/overlay/selectionOverlay.go
+++ b/ui/overlay/selectionOverlay.go
@@ -62,6 +62,13 @@ func (s *SelectionOverlay) IsCanceled() bool {
 	return s.canceled
 }
 
+// SetSelectedIndex sets the initially selected item index
+func (s *SelectionOverlay) SetSelectedIndex(idx int) {
+	if idx >= 0 && idx < len(s.items) {
+		s.selectedIdx = idx
+	}
+}
+
 // SetWidth sets the width of the selection overlay
 func (s *SelectionOverlay) SetWidth(width int) {
 	s.width = width


### PR DESCRIPTION
## Summary
- Adds a **program picker overlay** during new instance naming: press `tab` to choose between claude, codex, aider, or gemini
- Adds `ProgramCodex` constant and canonical `SupportedPrograms` list to `session/tmux/tmux.go`
- Default program is pre-selected so the flow is unchanged if you don't need to switch
- Fixes README to list Gemini instead of Amp as a supported agent

## Changes
- `session/tmux/tmux.go` — Added `ProgramCodex` constant and `SupportedPrograms` slice
- `ui/overlay/selectionOverlay.go` — Added `SetSelectedIndex()` method
- `keys/keys.go` — Added `KeyChangeProgram` bound to `tab`
- `ui/menu.go` — Added `KeyChangeProgram` to new instance menu
- `app/app.go` — Added `stateSelectProgram` state and `pendingProgram` field
- `app/handle_input.go` — Tab opens picker; enter applies selected program
- `app/handle_overlay.go` — New `handleStateSelectProgram` handler (preserves flags when re-selecting default)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Manual TUI testing: overlay renders, arrow keys navigate, enter selects, esc cancels
- [x] Verified codex process actually launches when selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)