### PR TITLE
fix: avoid unnecessary ellipsis truncation in ErrBox

### DIFF
--- a/ui/err.go
+++ b/ui/err.go
@@ -44,7 +44,15 @@ func (e *ErrBox) String() string {
 		lines := strings.Split(err, "\n")
 		err = strings.Join(lines, "//")
 		if runewidth.StringWidth(err) > e.width {
-			err = runewidth.Truncate(err, e.width, "...")
+			// Only add ellipsis when the string is long enough that the
+			// truncated content plus "..." is shorter than the original.
+			// Otherwise just hard-truncate to avoid losing more content
+			// to the 3-char ellipsis than we save by truncating.
+			tail := "..."
+			if runewidth.StringWidth(err) <= e.width+runewidth.StringWidth(tail) {
+				tail = ""
+			}
+			err = runewidth.Truncate(err, e.width, tail)
 		}
 	}
 	return lipgloss.Place(e.width, e.height, lipgloss.Center, lipgloss.Center, errStyle.Render(err))


### PR DESCRIPTION
## Summary
- Fixes ErrBox truncating error messages too early due to ellipsis double-counting
- When error text overflows by only 1-3 characters, the "..." ellipsis actually removes MORE content than it saves — now falls back to hard-truncation in that case
- Only adds "..." when the string is meaningfully longer than the available width

Fixes sachiniyer/agent-factory#171

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify error messages near the width boundary display correctly in TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)