### PR TITLE
fix: fsync parent directory after rename in AtomicWriteFile

### DIFF
--- a/config/filelock.go
+++ b/config/filelock.go
@@ -92,6 +92,21 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("failed to rename temp file to %s: %w", path, err)
 	}
+
+	// Fsync the parent directory to ensure the rename (new directory entry) is
+	// persisted. Without this, a crash right after rename could lose the file.
+	dirFd, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("failed to open directory %s for sync: %w", dir, err)
+	}
+	if err := dirFd.Sync(); err != nil {
+		dirFd.Close()
+		return fmt.Errorf("failed to sync directory %s: %w", dir, err)
+	}
+	if err := dirFd.Close(); err != nil {
+		return fmt.Errorf("failed to close directory %s: %w", dir, err)
+	}
+
 	success = true
 	return nil
 }


### PR DESCRIPTION
## Summary
- Adds directory fsync after os.Rename() in AtomicWriteFile to ensure the new directory entry is persisted to disk
- Without this, a power failure or crash immediately after rename could result in the file being lost even though rename returned successfully
- Follows POSIX best practice for atomic file writes (write → fsync file → rename → fsync directory)

Fixes sachiniyer/agent-factory#55

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Verify file persistence behavior under crash scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)