### PR TITLE
fix: only log daemon error when err is non-nil

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,9 @@ var (
 			if daemonFlag {
 				cfg := config.LoadConfig()
 				err := daemon.RunDaemon(cfg)
-				log.ErrorLog.Printf("failed to start daemon %v", err)
+				if err != nil {
+					log.ErrorLog.Printf("failed to start daemon %v", err)
+				}
 				return err
 			}
 


### PR DESCRIPTION
## Summary
- Wraps the daemon error log in `if err != nil` so clean shutdowns no longer produce misleading `failed to start daemon <nil>` messages

Fixes #206

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)