### PR TITLE
fix: accept uppercase Y/N in confirmation dialog

### DIFF
--- a/ui/overlay/confirmationOverlay.go
+++ b/ui/overlay/confirmationOverlay.go
@@ -1,6 +1,8 @@
 package overlay
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -40,14 +42,15 @@ func NewConfirmationOverlay(message string) *ConfirmationOverlay {
 // HandleKeyPress processes a key press and updates the state
 // Returns true if the overlay should be closed
 func (c *ConfirmationOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
-	switch msg.String() {
-	case c.ConfirmKey:
+	key := strings.ToLower(msg.String())
+	switch key {
+	case strings.ToLower(c.ConfirmKey):
 		c.Dismissed = true
 		if c.OnConfirm != nil {
 			c.OnConfirm()
 		}
 		return true
-	case c.CancelKey, "esc":
+	case strings.ToLower(c.CancelKey), "esc":
 		c.Dismissed = true
 		if c.OnCancel != nil {
 			c.OnCancel()


### PR DESCRIPTION
## Summary
- Makes confirmation dialog key comparison case-insensitive so Shift+Y and Shift+N work correctly
- Uses `strings.ToLower` on both the input key and configured confirm/cancel keys

Fixes #216

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)