### PR TITLE
fix: correct task pane empty state hint key

### DIFF
--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -350,7 +350,7 @@ func (s *TaskPane) renderListMode() string {
 	b.WriteString("\n\n")
 
 	if len(s.tasks) == 0 {
-		b.WriteString(disabledStyle.Render("  No tasks. Press s to create one."))
+		b.WriteString(disabledStyle.Render("  No tasks. Press n to create one."))
 		b.WriteString("\n")
 	}
 


### PR DESCRIPTION
## Summary
- Changes TaskPane empty state hint from "Press s to create one" to "Press n to create one" to match the actual keybinding

Fixes #221

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)