### PR TITLE
fix: prevent panic on negative pane height

### DIFF
--- a/ui/preview.go
+++ b/ui/preview.go
@@ -101,8 +101,8 @@ func (p *PreviewPane) UpdateContent(instance *session.Instance) error {
 
 // Returns the preview pane content as a string.
 func (p *PreviewPane) String() string {
-	if p.width == 0 || p.height == 0 {
-		return strings.Repeat("\n", p.height)
+	if p.width <= 0 || p.height <= 0 {
+		return ""
 	}
 
 	if p.previewState.fallback {

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -249,8 +249,8 @@ func (t *TerminalPane) String() string {
 	width := t.width
 	height := t.height
 
-	if width == 0 || height == 0 {
-		return strings.Repeat("\n", height)
+	if width <= 0 || height <= 0 {
+		return ""
 	}
 
 	if t.isScrolling {


### PR DESCRIPTION
## Summary
- Changes dimension guards from `== 0` to `<= 0` in PreviewPane and TerminalPane String() methods
- Returns empty string instead of calling `strings.Repeat` with a potentially negative count

Fixes #220

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)