### PR TITLE
fix: PlaceOverlay returns fg when either dimension overflows

### DIFF
--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -93,7 +93,7 @@ func PlaceOverlay(
 	}
 
 	// Check if foreground exceeds background size
-	if fgWidth >= bgWidth && fgHeight >= bgHeight {
+	if fgWidth >= bgWidth || fgHeight >= bgHeight {
 		return fg // Return foreground if it's larger than background
 	}
 


### PR DESCRIPTION
## Summary
- Changes `&&` to `||` in PlaceOverlay's dimension check so it returns the foreground when *either* dimension exceeds the background, preventing negative placement coordinates

Fixes #217

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)