### PR TITLE
fix: drain gzip reader for CRC validation on upgrade

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -96,6 +96,10 @@ func extractBinaryFromTarGz(r io.Reader, binaryName string) ([]byte, error) {
 			if int64(len(data)) > maxBinarySize {
 				return nil, fmt.Errorf("binary exceeds maximum size of %d bytes", maxBinarySize)
 			}
+			// Drain remaining gzip data to trigger CRC32 validation
+			if _, err := io.Copy(io.Discard, gz); err != nil {
+				return nil, fmt.Errorf("gzip integrity check failed: %w", err)
+			}
 			return data, nil
 		}
 	}


### PR DESCRIPTION
## Summary
- Drains remaining gzip stream data after extracting the binary in `extractBinaryFromTarGz`, triggering CRC32 checksum validation
- Prevents silently accepting corrupted .tar.gz archives

Fixes #223

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)