### PR TITLE
fix: highlight change program option on Tab in new instance

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -544,6 +544,9 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 	if name == keys.KeyEnter && m.state == stateNew {
 		name = keys.KeySubmitName
 	}
+	if name == keys.KeyTab && m.state == stateNew {
+		name = keys.KeyChangeProgram
+	}
 	m.keySent = true
 	return tea.Batch(
 		func() tea.Msg { return msg },


### PR DESCRIPTION
## Summary
- Adds KeyTab -> KeyChangeProgram mapping in handleMenuHighlighting for stateNew, matching the existing KeyEnter -> KeySubmitName pattern
- Tab now correctly underlines the "change program" menu option during instance naming

Fixes #199

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)