### PR TITLE
fix: collapse sidebar section in single keypress from child

### DIFF
--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -215,7 +215,6 @@ func (s *Sidebar) CollapseSection() {
 				break
 			}
 		}
-		return
 	}
 	for i, sec := range s.sections {
 		if sec.Kind == sel.Kind {


### PR DESCRIPTION
## Summary
- Removes early `return` in CollapseSection() so that pressing collapse on a child item both selects the header AND collapses the section in one keypress

Fixes #219

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)