### PR TITLE
fix: account for PaddingTop in layout to prevent overflow

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -206,7 +206,7 @@ func (m *home) updateHandleWindowSizeEvent(msg tea.WindowSizeMsg) {
 
 	// Menu takes 10% of height, sidebar and content take 90%
 	contentHeight := int(float32(msg.Height) * 0.9)
-	menuHeight := msg.Height - contentHeight - 1
+	menuHeight := msg.Height - contentHeight - 2
 	m.errBox.SetSize(int(float32(msg.Width)*0.9), 1)
 
 	m.contentPane.SetSize(contentWidth, contentHeight)


### PR DESCRIPTION
## Summary
- Changes menuHeight calculation from `msg.Height - contentHeight - 1` to `msg.Height - contentHeight - 2` to account for the extra row added by PaddingTop(1) in View()
- Prevents 1-line vertical overflow that clips the bottom errBox content

Fixes #214

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)