### PR TITLE
fix: enforce 32-cell title width limit for CJK characters

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -86,10 +86,11 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.state = stateSelectProgram
 		return m, nil
 	case tea.KeyRunes:
-		if runewidth.StringWidth(instance.Title) >= 32 {
+		newTitle := instance.Title + string(msg.Runes)
+		if runewidth.StringWidth(newTitle) > 32 {
 			return m, m.handleError(fmt.Errorf("title cannot be longer than 32 characters"))
 		}
-		if err := instance.SetTitle(instance.Title + string(msg.Runes)); err != nil {
+		if err := instance.SetTitle(newTitle); err != nil {
 			return m, m.handleError(err)
 		}
 	case tea.KeyBackspace:


### PR DESCRIPTION
## Summary
- Checks title width *after* constructing the candidate title instead of before, preventing 2-cell CJK characters from pushing width to 33 cells

Fixes #202

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)