### PR TITLE
fix: prioritize scroll mode over fallback in PreviewPane

### DIFF
--- a/ui/preview.go
+++ b/ui/preview.go
@@ -105,6 +105,11 @@ func (p *PreviewPane) String() string {
 		return strings.Repeat("\n", p.height)
 	}
 
+	// If in scroll/copy mode, always use the viewport
+	if p.isScrolling {
+		return p.viewport.View()
+	}
+
 	if p.previewState.fallback {
 		// Calculate available height for fallback text
 		availableHeight := p.height - 3 - 4 // 2 for borders, 1 for margin, 1 for padding
@@ -136,11 +141,6 @@ func (p *PreviewPane) String() string {
 			Width(p.width).
 			Align(lipgloss.Center).
 			Render(strings.Join(lines, ""))
-	}
-
-	// If in copy mode, use the viewport to display scrollable content
-	if p.isScrolling {
-		return p.viewport.View()
 	}
 
 	// Normal mode display


### PR DESCRIPTION
## Summary
- Reorders the isScrolling check before the fallback check in PreviewPane.String()
- Ensures scroll mode is respected when user explicitly enters it, even during loading state

Fixes #218

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)