### PR TITLE
fix: only clear menu highlight when matching key timer fires

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -255,7 +255,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			},
 		)
 	case keyupMsg:
-		m.menu.ClearKeydown()
+		m.menu.ClearKeydownIfMatch(msg.name)
 		return m, nil
 	case tickUpdatePRInfoMessage:
 		for _, instance := range m.sidebar.GetInstances() {
@@ -722,7 +722,9 @@ func (m *home) selectionChanged() tea.Cmd {
 	return nil
 }
 
-type keyupMsg struct{}
+type keyupMsg struct {
+	name keys.KeyName
+}
 
 func (m *home) keydownCallback(name keys.KeyName) tea.Cmd {
 	m.menu.Keydown(name)
@@ -731,7 +733,7 @@ func (m *home) keydownCallback(name keys.KeyName) tea.Cmd {
 		case <-m.ctx.Done():
 		case <-time.After(500 * time.Millisecond):
 		}
-		return keyupMsg{}
+		return keyupMsg{name: name}
 	}
 }
 

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -82,6 +82,12 @@ func (m *Menu) ClearKeydown() {
 	m.keyDown = -1
 }
 
+func (m *Menu) ClearKeydownIfMatch(name keys.KeyName) {
+	if m.keyDown == name {
+		m.keyDown = -1
+	}
+}
+
 // SetState updates the menu state and options accordingly
 func (m *Menu) SetState(state MenuState) {
 	m.state = state


### PR DESCRIPTION
## Summary
- Adds key name to keyupMsg so each timer is associated with the key that started it
- Adds ClearKeydownIfMatch method that only clears the highlight when the key matches
- Prevents rapid key presses from prematurely clearing the highlight of the most recent key

Fixes #215

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)