### PR TITLE
fix: handle git dot restrictions in branch name sanitization

### DIFF
--- a/session/git/util.go
+++ b/session/git/util.go
@@ -35,6 +35,27 @@ func sanitizeBranchName(s string) string {
 	// Trim leading and trailing dashes or slashes to avoid issues
 	s = strings.Trim(s, "-/")
 
+	// Handle git dot restrictions:
+	// 1. Remove leading dots from each path component (no hidden-file-style names like .env)
+	//    This also handles ".." since stripping leading dots from ".." leaves it empty.
+	parts := strings.Split(s, "/")
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimLeft(part, ".")
+		if part != "" {
+			filtered = append(filtered, part)
+		}
+	}
+	s = strings.Join(filtered, "/")
+	// 2. Replace any remaining double dots with a dash (e.g., "a..b")
+	s = strings.ReplaceAll(s, "..", "-")
+	// 3. No .lock suffix (reserved by git)
+	s = strings.TrimSuffix(s, ".lock")
+	// 4. No trailing dots
+	s = strings.TrimRight(s, ".")
+	// 5. Clean up any trailing dashes or slashes left after dot removal
+	s = strings.Trim(s, "-/")
+
 	// If the result is empty (e.g., input was only special characters),
 	// generate a fallback branch name to prevent worktree creation failures.
 	if s == "" {

--- a/session/git/util_test.go
+++ b/session/git/util_test.go
@@ -56,6 +56,41 @@ func TestSanitizeBranchName(t *testing.T) {
 			input:    "USER/Feature Branch!@#$%^&*()/v1.0",
 			expected: "user/feature-branch/v1.0",
 		},
+		{
+			name:     "leading dot in path component",
+			input:    "john/.env",
+			expected: "john/env",
+		},
+		{
+			name:     "name ending with .lock",
+			input:    "john/config.lock",
+			expected: "john/config",
+		},
+		{
+			name:     "double dots in name",
+			input:    "feature..branch",
+			expected: "feature-branch",
+		},
+		{
+			name:     "trailing dots",
+			input:    "feature.branch...",
+			expected: "feature.branch",
+		},
+		{
+			name:     "path component is only dots",
+			input:    "john/.../file",
+			expected: "john/file",
+		},
+		{
+			name:     "multiple leading dots",
+			input:    "john/...hidden",
+			expected: "john/hidden",
+		},
+		{
+			name:     "standalone dotfile name",
+			input:    ".env",
+			expected: "env",
+		},
 	}
 
 	for _, tt := range tests {
@@ -76,6 +111,8 @@ func TestSanitizeBranchName_FallbackOnEmpty(t *testing.T) {
 		"---",
 		"///",
 		"-/-/-/",
+		"...",
+		"/.../",
 	}
 	for _, input := range inputs {
 		t.Run("input="+input, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds post-processing in `sanitizeBranchName` for git's dot restrictions: leading dots in path components, `.lock` suffix, double dots, and trailing dots
- Adds 7 new test cases for dot edge cases

Fixes #209

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including new test cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)