### PR TITLE
fix: use 1-indexed start for month/DOM cron step patterns

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -136,17 +136,17 @@ func CronToOnCalendar(cronExpr string) (string, error) {
 		dowPart = convertDOW(dowField)
 	}
 
-	// Convert month
-	monthPart := convertTimeField(monthField)
+	// Convert month (1-indexed)
+	monthPart := convertTimeField(monthField, true)
 
-	// Convert day-of-month
-	domPart := convertTimeField(domField)
+	// Convert day-of-month (1-indexed)
+	domPart := convertTimeField(domField, true)
 
-	// Convert hour
-	hourPart := convertTimeField(hourField)
+	// Convert hour (0-indexed)
+	hourPart := convertTimeField(hourField, false)
 
-	// Convert minute
-	minutePart := convertTimeField(minuteField)
+	// Convert minute (0-indexed)
+	minutePart := convertTimeField(minuteField, false)
 
 	// Build the date part: YEAR-MONTH-DAY
 	datePart := fmt.Sprintf("*-%s-%s", monthPart, domPart)
@@ -161,8 +161,10 @@ func CronToOnCalendar(cronExpr string) (string, error) {
 	return fmt.Sprintf("%s %s", datePart, timePart), nil
 }
 
-// convertTimeField converts a cron time field (minute or hour) to OnCalendar format.
-func convertTimeField(field string) string {
+// convertTimeField converts a cron time field to OnCalendar format.
+// oneIndexed should be true for month and day-of-month fields (which start at 1),
+// and false for hour and minute fields (which start at 0).
+func convertTimeField(field string, oneIndexed bool) string {
 	if field == "*" {
 		return "*"
 	}
@@ -172,7 +174,7 @@ func convertTimeField(field string) string {
 		parts := strings.Split(field, ",")
 		converted := make([]string, len(parts))
 		for i, p := range parts {
-			converted[i] = convertTimeField(p)
+			converted[i] = convertTimeField(p, oneIndexed)
 		}
 		return strings.Join(converted, ",")
 	}
@@ -183,6 +185,9 @@ func convertTimeField(field string) string {
 		base := field[:idx]
 		step := field[idx+1:]
 		if base == "*" {
+			if oneIndexed {
+				return fmt.Sprintf("01/%s", step)
+			}
 			return fmt.Sprintf("00/%s", step)
 		}
 		// Range with step: "X-Y/N" → "XX..YY/N"

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -141,3 +141,31 @@ func TestCronToOnCalendarDOWNonSundayRange(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Tue..Thu *-*-* 09:00:00", result)
 }
+
+func TestCronToOnCalendarMonthStep(t *testing.T) {
+	// Month is 1-indexed, so */3 should become 01/3, not 00/3.
+	result, err := CronToOnCalendar("0 0 1 */3 *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-01/3-01 00:00:00", result)
+}
+
+func TestCronToOnCalendarDOMStep(t *testing.T) {
+	// Day-of-month is 1-indexed, so */5 should become 01/5, not 00/5.
+	result, err := CronToOnCalendar("0 0 */5 * *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-01/5 00:00:00", result)
+}
+
+func TestCronToOnCalendarHourStep(t *testing.T) {
+	// Hour is 0-indexed, so */4 should become 00/4.
+	result, err := CronToOnCalendar("0 */4 * * *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-* 00/4:00:00", result)
+}
+
+func TestCronToOnCalendarMinuteStep(t *testing.T) {
+	// Minute is 0-indexed, so */15 should become 00/15.
+	result, err := CronToOnCalendar("*/15 * * * *")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-* *:00/15:00", result)
+}


### PR DESCRIPTION
## Summary
- Adds `oneIndexed` parameter to `convertTimeField` so month and day-of-month step patterns produce `01/N` instead of `00/N`
- Hour and minute fields continue to use `00/N` (0-indexed)
- Adds test cases verifying correct conversion for all four field types

Fixes #212

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including 4 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)