### PR TITLE
fix: shell-quote binary path with spaces for tmux execution

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,11 @@ func DefaultConfig() *Config {
 		program = defaultProgram
 	}
 
+	// Quote path if it contains spaces (for tmux shell execution)
+	if strings.Contains(program, " ") {
+		program = "'" + strings.ReplaceAll(program, "'", "'\\''") + "'"
+	}
+
 	program = program + " --dangerously-skip-permissions"
 
 	return &Config{

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -26,12 +26,38 @@ func shellQuote(s string) string {
 // getBaseCommand extracts the lowercase basename of the executable from a
 // program string that may include a full path and arguments.
 // For example, "/home/user/bin/claude --model opus" returns "claude".
+// It handles single-quoted and double-quoted paths for binaries whose
+// paths contain spaces (e.g. on WSL).
 func getBaseCommand(program string) string {
-	parts := strings.Fields(program)
-	if len(parts) == 0 {
+	program = strings.TrimSpace(program)
+	if len(program) == 0 {
 		return ""
 	}
-	return strings.ToLower(filepath.Base(parts[0]))
+
+	var cmd string
+	// Handle single-quoted paths
+	if program[0] == '\'' {
+		end := strings.Index(program[1:], "'")
+		if end >= 0 {
+			cmd = program[1 : end+1]
+		} else {
+			cmd = program[1:]
+		}
+	} else if program[0] == '"' {
+		end := strings.Index(program[1:], "\"")
+		if end >= 0 {
+			cmd = program[1 : end+1]
+		} else {
+			cmd = program[1:]
+		}
+	} else {
+		parts := strings.Fields(program)
+		if len(parts) == 0 {
+			return ""
+		}
+		cmd = parts[0]
+	}
+	return strings.ToLower(filepath.Base(cmd))
 }
 
 // injectSystemPrompt injects Agent Factory instructions into the session.


### PR DESCRIPTION
## Summary
- Wraps the claude command path in single quotes when it contains spaces (e.g., WSL paths with spaces in Windows username)
- Updates `getBaseCommand` to parse single/double-quoted paths correctly instead of naive `strings.Fields` splitting

Fixes #204

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)