### PR TITLE
fix: preserve git worktree on session restore failure

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -54,8 +54,24 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 	var setupErr error
 	defer func() {
 		if setupErr != nil {
-			if cleanupErr := i.Kill(); cleanupErr != nil {
-				setupErr = fmt.Errorf("%v (cleanup error: %v)", setupErr, cleanupErr)
+			if firstTimeSetup {
+				// New session: full cleanup (tmux + worktree) is safe.
+				if cleanupErr := i.Kill(); cleanupErr != nil {
+					setupErr = fmt.Errorf("%v (cleanup error: %v)", setupErr, cleanupErr)
+				}
+			} else {
+				// Restore: only clean up tmux session, preserve the worktree
+				// to avoid data loss.
+				i.mu.Lock()
+				ts := i.tmuxSession
+				i.tmuxSession = nil
+				i.started = false
+				i.mu.Unlock()
+				if ts != nil {
+					if cleanupErr := ts.Close(); cleanupErr != nil {
+						setupErr = fmt.Errorf("%v (cleanup error: %v)", setupErr, cleanupErr)
+					}
+				}
 			}
 		} else {
 			i.mu.Lock()


### PR DESCRIPTION
## Summary
- On restore failure, only cleans up the tmux session while preserving the git worktree and its uncommitted changes
- First-time setup failures still do full cleanup (tmux + worktree) since the worktree was just created

Fixes #207

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)