### PR TITLE
fix: detect Aider/Gemini trust prompts in WaitForReady (#213)

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -82,6 +82,24 @@ func LoadAndClearPendingInstances() ([]session.InstanceData, error) {
 	return pending, err
 }
 
+// isReadyContent reports whether the captured pane content indicates the
+// program is ready for input or is showing a trust prompt that downstream
+// handlers know how to dismiss. It recognizes Claude Code's input prompt
+// and trust prompt as well as the Aider/Gemini trust prompt
+// ("Open documentation url" + "(D)on't ask again").
+func isReadyContent(content string) bool {
+	if strings.Contains(content, "❯") || strings.Contains(content, "Do you trust") {
+		return true
+	}
+	// Aider/Gemini trust prompt. Require both substrings to avoid false
+	// positives from documentation links unrelated to the trust prompt.
+	if strings.Contains(content, "Open documentation url") &&
+		strings.Contains(content, "(D)on't ask again") {
+		return true
+	}
+	return false
+}
+
 // WaitForReady polls the instance's tmux pane until the program shows its
 // input prompt (e.g. Claude Code's ">" prompt) or trust prompt, or times out after 60 seconds.
 func WaitForReady(instance *session.Instance) error {
@@ -104,7 +122,7 @@ func WaitForReady(instance *session.Instance) error {
 			if err != nil {
 				continue
 			}
-			if strings.Contains(content, "❯") || strings.Contains(content, "Do you trust") {
+			if isReadyContent(content) {
 				return nil
 			}
 		}

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -1,0 +1,62 @@
+package task
+
+import "testing"
+
+func TestIsReadyContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "empty",
+			content: "",
+			want:    false,
+		},
+		{
+			name:    "claude input prompt",
+			content: "some output\n\n❯ ",
+			want:    true,
+		},
+		{
+			name:    "claude trust prompt",
+			content: "Do you trust the files in this folder?\n1. Yes\n2. No",
+			want:    true,
+		},
+		{
+			name: "aider trust prompt",
+			content: "Aider v0.1\nOpen documentation url for more info: https://aider.chat/docs/\n" +
+				"(Y)es/(N)o/(D)on't ask again [Yes]:",
+			want: true,
+		},
+		{
+			name: "gemini trust prompt",
+			content: "Gemini CLI\nOpen documentation url for more info.\n" +
+				"(D)on't ask again",
+			want: true,
+		},
+		{
+			name:    "only open documentation url without confirm",
+			content: "See Open documentation url for details about this command.",
+			want:    false,
+		},
+		{
+			name:    "only dont ask again without doc url",
+			content: "Some prompt asking (D)on't ask again without the documentation prefix",
+			want:    false,
+		},
+		{
+			name:    "unrelated output",
+			content: "installing dependencies...\nready soon",
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isReadyContent(tc.content); got != tc.want {
+				t.Errorf("isReadyContent(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- WaitForReady only matched Claude-specific substrings, so Aider/Gemini trust prompts never satisfied the ready condition and task startup timed out at 60s.
- Recognize the Aider/Gemini trust prompt ("Open documentation url" + "(D)on't ask again") as ready so the trust-prompt handler downstream can run.

Closes #213.

## Test plan
- [x] go build ./...
- [x] go test ./task/...
- [x] gofmt -l . is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)