### PR TITLE
docs: correct remote hooks docs and N-key help text (#208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each session runs an AI agent in an isolated git worktree with its own branch. S
 | Key | Action |
 |-----|--------|
 | `n` | Create a new session |
-| `N` | Create a session with an initial prompt |
+| `N` | Create a new remote session (requires `remote_hooks` config) |
 | `Enter` / `o` | Attach to selected session |
 | `Ctrl-w` | Detach from session |
 | `D` | Kill (delete) selected session |

--- a/app/help.go
+++ b/app/help.go
@@ -40,7 +40,7 @@ func (h helpTypeGeneral) toContent() string {
 		"",
 		headerStyle.Render("Managing:"),
 		keyStyle.Render("n")+descStyle.Render("         - Create a new session"),
-		keyStyle.Render("N")+descStyle.Render("         - Create a new session with a prompt"),
+		keyStyle.Render("N")+descStyle.Render("         - Create a new remote session (requires remote_hooks config)"),
 		keyStyle.Render("s")+descStyle.Render("         - Create a new task"),
 		keyStyle.Render("S")+descStyle.Render("         - List tasks"),
 		keyStyle.Render("r")+descStyle.Render("         - Run selected task now"),

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -17,7 +17,7 @@ Add remote hooks to your per-repo config at `~/.agent-factory/repos/<repoID>/con
 }
 ```
 
-When `remote_hooks` is absent, Agent Factory uses local tmux+git worktrees (default). When present, all sessions for that repo use the remote backend.
+Configuring `remote_hooks` enables the remote backend for that repo, but using it is explicit opt-in: press `N` in the TUI to create a remote session. Pressing `n` still creates a local tmux+git worktree session. When `remote_hooks` is absent, `N` is unavailable and all sessions are local.
 
 ## Script Protocol
 


### PR DESCRIPTION
## Summary
- Remote hooks are opt-in via N — not auto-selected by config presence. Update docs/remote-hooks.md, README.md, and app/help.go to match keys/keys.go.
- N creates a remote session; n stays local.

Closes #208.

## Test plan
- [x] go build ./...
- [x] go test ./app/...
- [x] gofmt -l . is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)