### PR TITLE
fix: synchronize log Initialize/Close to prevent data race (#205)

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -15,6 +15,13 @@ var (
 	ErrorLog   *log.Logger
 )
 
+// mu guards writes to globalLogFile and the exported *log.Logger pointers
+// performed by Initialize and Close. Readers (e.g. InfoLog.Printf) rely on
+// init-once-before-use semantics: Initialize is expected to complete before
+// any goroutine reads the logger pointers. *log.Logger itself is internally
+// thread-safe, so we do not take this lock on the logging hot path.
+var mu sync.Mutex
+
 func getLogPath() string {
 	configDir, err := os.UserConfigDir()
 	if err != nil {
@@ -34,6 +41,9 @@ var globalLogFile *os.File
 // the user config directory.
 
 func Initialize(daemon bool) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	// Close any previously opened log file to avoid leaking file descriptors
 	// when Initialize is called multiple times (e.g. af tasks trigger -> RunTask).
 	if globalLogFile != nil {
@@ -69,6 +79,9 @@ func Initialize(daemon bool) {
 }
 
 func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+
 	if globalLogFile != nil {
 		_ = globalLogFile.Close()
 	}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,25 @@
+package log
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestInitializeRace spins multiple goroutines concurrently calling
+// Initialize to make sure the package-level mutex prevents data races on
+// globalLogFile and the exported logger pointers. Run with `go test -race`.
+func TestInitializeRace(t *testing.T) {
+	var wg sync.WaitGroup
+	const n = 10
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			Initialize(false)
+		}()
+	}
+	wg.Wait()
+
+	// Clean up the file descriptor opened by the last Initialize call.
+	Close()
+}


### PR DESCRIPTION
## Summary
- Initialize and Close mutated globalLogFile and InfoLog/WarningLog/ErrorLog without synchronization — Go race detector fired on concurrent calls.
- Guard both with a package-level sync.Mutex so init/teardown is atomic.

Closes #205.

## Test plan
- [x] go build ./...
- [x] go test -race ./log/... (new TestInitializeRace passes cleanly)
- [x] gofmt -l . is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)