### PR TITLE
fix: replace dead sidebar instance instead of duplicating on rerun (#203)

### DIFF
--- a/app/sync.go
+++ b/app/sync.go
@@ -58,24 +58,52 @@ func (m *home) mergePendingInstances() int {
 		return 0
 	}
 
+	sidebarTitles := m.sidebar.GetInstanceTitles()
+
 	var otherRepoPending []session.InstanceData
 	var mergedCount int
 	for _, data := range pendingData {
 		rid := config.RepoIDFromRoot(data.Worktree.RepoPath)
-		if rid == m.repoID {
-			pendingInstance, err := session.FromInstanceData(data)
-			if err != nil {
-				log.WarningLog.Printf("failed to restore pending instance %s: %v", data.Title, err)
+		if rid != m.repoID {
+			otherRepoPending = append(otherRepoPending, data)
+			continue
+		}
+
+		// If an entry with the same title already exists in the sidebar, replace
+		// it only if the existing instance is dead (tmux gone). If it's still
+		// alive, skip the new pending instance to avoid creating a duplicate.
+		if sidebarTitles[data.Title] {
+			skip := false
+			for _, existing := range m.sidebar.GetInstances() {
+				if existing.Title != data.Title {
+					continue
+				}
+				if existing.TmuxAlive() {
+					log.WarningLog.Printf("skipping pending instance %q: already exists and is alive", data.Title)
+					skip = true
+				} else {
+					log.InfoLog.Printf("replacing dead instance %q with new pending instance", data.Title)
+					m.sidebar.RemoveInstanceByTitle(data.Title)
+					delete(sidebarTitles, data.Title)
+				}
+				break
+			}
+			if skip {
 				continue
 			}
-			m.sidebar.AddInstance(pendingInstance)()
-			if m.autoYes {
-				pendingInstance.AutoYes = true
-			}
-			mergedCount++
-		} else {
-			otherRepoPending = append(otherRepoPending, data)
 		}
+
+		pendingInstance, err := session.FromInstanceData(data)
+		if err != nil {
+			log.WarningLog.Printf("failed to restore pending instance %s: %v", data.Title, err)
+			continue
+		}
+		m.sidebar.AddInstance(pendingInstance)()
+		if m.autoYes {
+			pendingInstance.AutoYes = true
+		}
+		sidebarTitles[data.Title] = true
+		mergedCount++
 	}
 
 	if len(otherRepoPending) > 0 {


### PR DESCRIPTION
## Summary
- Scheduled task reruns added a second sidebar entry when the prior tmux session had been killed externally.
- mergePendingInstances now checks same-title collisions: replaces the entry if dead, skips and warns if still alive — matching the existing refreshExternalInstances pattern.

Closes #203.

## Test plan
- [x] go build ./...
- [x] go test ./app/... ./session/... ./ui/...
- [x] gofmt -l . is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)