### PR TITLE
fix: preserve pre-existing branches on session cleanup (#210)

### DIFF
--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -43,6 +43,10 @@ type GitWorktree struct {
 	baseCommitSHA string
 	// externalWorktree is true if the worktree was not created by agent-factory
 	externalWorktree bool
+	// branchCreatedByUs is true if this session created the underlying branch
+	// itself (via setupNewWorktree). When false, Cleanup() must NOT delete the
+	// branch because it pre-existed and likely contains user work.
+	branchCreatedByUs bool
 	// hooksCtx and hooksCancel control the lifetime of post-worktree hooks.
 	// Cancelling hooksCtx stops any in-flight hook commands so they don't
 	// outlive the worktree itself.
@@ -62,7 +66,18 @@ func (g *GitWorktree) IsExternalWorktree() bool {
 	return g.externalWorktree
 }
 
-func NewGitWorktreeFromStorage(repoPath string, worktreePath string, sessionName string, branchName string, baseCommitSHA string, externalWorktree bool) (*GitWorktree, error) {
+// BranchCreatedByUs returns true if this session created the underlying
+// branch (rather than reusing a pre-existing one). Cleanup() uses this to
+// decide whether it is safe to delete the branch.
+func (g *GitWorktree) BranchCreatedByUs() bool {
+	return g.branchCreatedByUs
+}
+
+// NewGitWorktreeFromStorage restores a GitWorktree from persisted state.
+// branchCreatedByUs indicates whether the session originally created the
+// branch itself. Existing saved sessions (written before this field was
+// persisted) should pass true to preserve prior cleanup behavior.
+func NewGitWorktreeFromStorage(repoPath string, worktreePath string, sessionName string, branchName string, baseCommitSHA string, externalWorktree bool, branchCreatedByUs bool) (*GitWorktree, error) {
 	if worktreePath == "" {
 		return nil, fmt.Errorf("worktree path is empty")
 	}
@@ -71,15 +86,16 @@ func NewGitWorktreeFromStorage(repoPath string, worktreePath string, sessionName
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &GitWorktree{
-		repoPath:         repoPath,
-		worktreePath:     worktreePath,
-		worktreeDir:      filepath.Dir(worktreePath),
-		sessionName:      sessionName,
-		branchName:       branchName,
-		baseCommitSHA:    baseCommitSHA,
-		externalWorktree: externalWorktree,
-		hooksCtx:         ctx,
-		hooksCancel:      cancel,
+		repoPath:          repoPath,
+		worktreePath:      worktreePath,
+		worktreeDir:       filepath.Dir(worktreePath),
+		sessionName:       sessionName,
+		branchName:        branchName,
+		baseCommitSHA:     baseCommitSHA,
+		externalWorktree:  externalWorktree,
+		branchCreatedByUs: branchCreatedByUs,
+		hooksCtx:          ctx,
+		hooksCancel:       cancel,
 	}, nil
 }
 
@@ -205,14 +221,15 @@ func NewGitWorktreeFromExistingWorktree(repoPath, worktreePath, branchName strin
 
 	ctx, cancel := context.WithCancel(context.Background())
 	return &GitWorktree{
-		repoPath:         repoRoot,
-		worktreePath:     worktreePath,
-		worktreeDir:      filepath.Dir(worktreePath),
-		branchName:       branchName,
-		baseCommitSHA:    baseCommitSHA,
-		externalWorktree: true,
-		hooksCtx:         ctx,
-		hooksCancel:      cancel,
+		repoPath:          repoRoot,
+		worktreePath:      worktreePath,
+		worktreeDir:       filepath.Dir(worktreePath),
+		branchName:        branchName,
+		baseCommitSHA:     baseCommitSHA,
+		externalWorktree:  true,
+		branchCreatedByUs: false,
+		hooksCtx:          ctx,
+		hooksCancel:       cancel,
 	}, nil
 }
 

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -43,6 +43,9 @@ func (g *GitWorktree) Setup() error {
 func (g *GitWorktree) setupFromExistingBranch() error {
 	// Directory already created in Setup(), skip duplicate creation
 
+	// We are reusing a pre-existing branch — Cleanup() must not delete it.
+	g.branchCreatedByUs = false
+
 	// Clean up any existing worktree first
 	_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath) // Ignore error if worktree doesn't exist
 
@@ -90,6 +93,9 @@ func (g *GitWorktree) resolveOriginHead() string {
 
 // setupNewWorktree creates a new worktree from origin's default branch (or HEAD as fallback)
 func (g *GitWorktree) setupNewWorktree() error {
+	// We are creating the branch ourselves — Cleanup() may delete it.
+	g.branchCreatedByUs = true
+
 	// Clean up any existing worktree first
 	_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath) // Ignore error if worktree doesn't exist
 
@@ -158,11 +164,15 @@ func (g *GitWorktree) Cleanup() error {
 		errs = append(errs, fmt.Errorf("failed to check worktree path: %w", err))
 	}
 
-	// Delete the branch using git CLI
-	if _, err := g.runGitCommand(g.repoPath, "branch", "-D", g.branchName); err != nil {
-		// Only log if it's not a "branch not found" error
-		if !strings.Contains(err.Error(), "not found") {
-			errs = append(errs, fmt.Errorf("failed to remove branch %s: %w", g.branchName, err))
+	// Only delete the branch if this session actually created it. When we
+	// reused a pre-existing branch via setupFromExistingBranch(), the branch
+	// may contain unrelated user work and must be preserved.
+	if g.branchCreatedByUs {
+		if _, err := g.runGitCommand(g.repoPath, "branch", "-D", g.branchName); err != nil {
+			// Only log if it's not a "branch not found" error
+			if !strings.Contains(err.Error(), "not found") {
+				errs = append(errs, fmt.Errorf("failed to remove branch %s: %w", g.branchName, err))
+			}
 		}
 	}
 

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -142,29 +142,115 @@ func TestSetupFromExistingBranch_SetsBaseCommitSHA(t *testing.T) {
 	require.NoError(t, gw.Cleanup())
 }
 
+// TestCleanup_PreservesPreExistingBranch verifies that when Setup() reuses a
+// pre-existing local branch, Cleanup() does NOT delete it. Previously,
+// Cleanup() always ran `git branch -D <branch>`, destroying user work on any
+// branch whose name happened to match the session's derived branch name.
+func TestCleanup_PreservesPreExistingBranch(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+
+	// Initial commit so HEAD is valid.
+	cmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "initial")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	// Create a pre-existing branch the user might care about.
+	cmd = exec.Command("git", "-C", repoRoot, "branch", "test/preexisting")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, _, err := NewGitWorktree(repoRoot, "preexisting")
+	require.NoError(t, err)
+
+	// Setup() should detect the existing branch and reuse it.
+	require.NoError(t, gw.Setup())
+	assert.False(t, gw.BranchCreatedByUs(),
+		"BranchCreatedByUs should be false when Setup reused an existing branch")
+
+	// Cleanup should remove the worktree but NOT delete the branch.
+	require.NoError(t, gw.Cleanup())
+
+	// Verify the branch still exists in the repo.
+	verifyCmd := exec.Command("git", "-C", repoRoot, "show-ref", "--verify", "refs/heads/test/preexisting")
+	out, err = verifyCmd.CombinedOutput()
+	require.NoError(t, err,
+		"pre-existing branch was deleted by Cleanup; output: %s", string(out))
+}
+
+// TestCleanup_DeletesBranchWeCreated verifies that when Setup() creates a new
+// branch itself, Cleanup() still deletes it (preserving existing behavior for
+// branches that the session owns).
+func TestCleanup_DeletesBranchWeCreated(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+
+	// Initial commit so HEAD is valid.
+	cmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "initial")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, _, err := NewGitWorktree(repoRoot, "brand-new")
+	require.NoError(t, err)
+
+	// No pre-existing branch — Setup() should create a fresh one.
+	require.NoError(t, gw.Setup())
+	assert.True(t, gw.BranchCreatedByUs(),
+		"BranchCreatedByUs should be true when Setup created a new branch")
+
+	require.NoError(t, gw.Cleanup())
+
+	// Branch should be gone.
+	verifyCmd := exec.Command("git", "-C", repoRoot, "show-ref", "--verify", "refs/heads/test/brand-new")
+	err = verifyCmd.Run()
+	require.Error(t, err,
+		"branch created by the session should be deleted by Cleanup")
+}
+
 func TestNewGitWorktreeFromStorage_EmptyWorktreePath(t *testing.T) {
-	_, err := NewGitWorktreeFromStorage("/some/repo", "", "session", "branch", "abc123", false)
+	_, err := NewGitWorktreeFromStorage("/some/repo", "", "session", "branch", "abc123", false, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "worktree path is empty")
 }
 
 func TestNewGitWorktreeFromStorage_EmptyRepoPath(t *testing.T) {
-	_, err := NewGitWorktreeFromStorage("", "/some/worktree", "session", "branch", "abc123", false)
+	_, err := NewGitWorktreeFromStorage("", "/some/worktree", "session", "branch", "abc123", false, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "repo path is empty")
 }
 
 func TestNewGitWorktreeFromStorage_ValidPaths(t *testing.T) {
-	gw, err := NewGitWorktreeFromStorage("/some/repo", "/some/worktree", "session", "branch", "abc123", false)
+	gw, err := NewGitWorktreeFromStorage("/some/repo", "/some/worktree", "session", "branch", "abc123", false, true)
 	require.NoError(t, err)
 	assert.Equal(t, "/some/repo", gw.GetRepoPath())
 	assert.Equal(t, "/some/worktree", gw.GetWorktreePath())
 	assert.Equal(t, "branch", gw.GetBranchName())
 	assert.Equal(t, "abc123", gw.GetBaseCommitSHA())
+	assert.True(t, gw.BranchCreatedByUs())
 }
 
 func TestCleanup_EmptyRepoPath(t *testing.T) {
-	gw, err := NewGitWorktreeFromStorage("/some/repo", "/some/worktree", "session", "branch", "abc123", false)
+	gw, err := NewGitWorktreeFromStorage("/some/repo", "/some/worktree", "session", "branch", "abc123", false, true)
 	require.NoError(t, err)
 	// Simulate a corrupted state by zeroing out repoPath
 	gw.repoPath = ""
@@ -174,7 +260,7 @@ func TestCleanup_EmptyRepoPath(t *testing.T) {
 }
 
 func TestCleanup_EmptyWorktreePath(t *testing.T) {
-	gw, err := NewGitWorktreeFromStorage("/some/repo", "/some/worktree", "session", "branch", "abc123", false)
+	gw, err := NewGitWorktreeFromStorage("/some/repo", "/some/worktree", "session", "branch", "abc123", false, true)
 	require.NoError(t, err)
 	// Simulate a corrupted state by zeroing out worktreePath
 	gw.worktreePath = ""

--- a/session/instance.go
+++ b/session/instance.go
@@ -101,13 +101,15 @@ func (i *Instance) ToInstanceData() InstanceData {
 
 	// Only include worktree data if gitWorktree is initialized
 	if i.gitWorktree != nil {
+		branchCreatedByUs := i.gitWorktree.BranchCreatedByUs()
 		data.Worktree = GitWorktreeData{
-			RepoPath:         i.gitWorktree.GetRepoPath(),
-			WorktreePath:     i.gitWorktree.GetWorktreePath(),
-			SessionName:      i.Title,
-			BranchName:       i.gitWorktree.GetBranchName(),
-			BaseCommitSHA:    i.gitWorktree.GetBaseCommitSHA(),
-			ExternalWorktree: i.gitWorktree.IsExternalWorktree(),
+			RepoPath:          i.gitWorktree.GetRepoPath(),
+			WorktreePath:      i.gitWorktree.GetWorktreePath(),
+			SessionName:       i.Title,
+			BranchName:        i.gitWorktree.GetBranchName(),
+			BaseCommitSHA:     i.gitWorktree.GetBaseCommitSHA(),
+			ExternalWorktree:  i.gitWorktree.IsExternalWorktree(),
+			BranchCreatedByUs: &branchCreatedByUs,
 		}
 	}
 
@@ -149,6 +151,16 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 	} else {
 		instance.backend = &LocalBackend{}
 
+		// Preserve backward compatibility: when the branch_created_by_us
+		// field is missing from persisted data (written before this field
+		// was added), default to true. Old saved sessions were created
+		// under the assumption that the session owned the branch, so
+		// keeping that behavior avoids surprising changes on restore.
+		branchCreatedByUs := true
+		if data.Worktree.BranchCreatedByUs != nil {
+			branchCreatedByUs = *data.Worktree.BranchCreatedByUs
+		}
+
 		gw, err := git.NewGitWorktreeFromStorage(
 			data.Worktree.RepoPath,
 			data.Worktree.WorktreePath,
@@ -156,6 +168,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 			data.Worktree.BranchName,
 			data.Worktree.BaseCommitSHA,
 			data.Worktree.ExternalWorktree,
+			branchCreatedByUs,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to restore git worktree: %w", err)

--- a/session/storage.go
+++ b/session/storage.go
@@ -36,14 +36,22 @@ type PRInfoData struct {
 	State  string `json:"state,omitempty"`
 }
 
-// GitWorktreeData represents the serializable data of a GitWorktree
+// GitWorktreeData represents the serializable data of a GitWorktree.
+//
+// BranchCreatedByUs indicates whether the session created the underlying
+// branch itself (vs. reused a pre-existing one). It is serialized via a
+// pointer so that "missing" (nil, for data written before this field was
+// added) can be distinguished from an explicit false. Missing values are
+// treated as true to preserve the prior behavior for sessions that existed
+// before this flag was introduced.
 type GitWorktreeData struct {
-	RepoPath         string `json:"repo_path"`
-	WorktreePath     string `json:"worktree_path"`
-	SessionName      string `json:"session_name"`
-	BranchName       string `json:"branch_name"`
-	BaseCommitSHA    string `json:"base_commit_sha"`
-	ExternalWorktree bool   `json:"external_worktree,omitempty"`
+	RepoPath          string `json:"repo_path"`
+	WorktreePath      string `json:"worktree_path"`
+	SessionName       string `json:"session_name"`
+	BranchName        string `json:"branch_name"`
+	BaseCommitSHA     string `json:"base_commit_sha"`
+	ExternalWorktree  bool   `json:"external_worktree,omitempty"`
+	BranchCreatedByUs *bool  `json:"branch_created_by_us,omitempty"`
 }
 
 // Storage handles saving and loading instances using the state interface.


### PR DESCRIPTION
## Summary
- Session Cleanup() always deleted the branch, even when Setup() reused a pre-existing one — losing user work.
- Track branchCreatedByUs; skip branch deletion in Cleanup when the branch pre-existed.
- Persist the flag; default to true for old saved sessions to keep prior behavior.

Closes #210.

## Test plan
- [x] go build ./...
- [x] go test ./session/git/... (includes new test for pre-existing branch preservation)
- [x] gofmt -l . is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)