### PR TITLE
fix: scope daemon allInMemoryTitles to repo in SaveInstances (#198)

### DIFF
--- a/session/storage.go
+++ b/session/storage.go
@@ -102,15 +102,7 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 		grouped[rid] = append(grouped[rid], d)
 	}
 
-	// Build a set of ALL in-memory instance titles (including non-started/
-	// non-loading ones) so we can distinguish "killed in daemon" from
-	// "added externally on disk".
-	allInMemoryTitles := make(map[string]bool, len(instances))
-	for _, inst := range instances {
-		allInMemoryTitles[inst.Title] = true
-	}
-
-	// Also collect repo IDs that the daemon knows about so we visit repos
+	// Collect repo IDs that the daemon knows about so we visit repos
 	// that had all their in-memory instances killed (group would be empty).
 	knownRepoIDs := make(map[string]bool)
 	for _, inst := range instances {
@@ -121,6 +113,20 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 	// Merge each repo's in-memory state with disk state.
 	for rid := range knownRepoIDs {
 		group := grouped[rid] // may be nil if all instances for this repo were killed
+
+		// Build a per-repo set of ALL in-memory instance titles (including
+		// non-started/non-loading ones) belonging to THIS repo. This is used
+		// to distinguish "killed in daemon" from "added externally on disk".
+		// IMPORTANT: this must be scoped per-repo. Using a global set across
+		// all repos causes cross-repo title collisions to drop legitimate
+		// externally-added instances from other repos (issue #198).
+		repoMemTitlesAll := make(map[string]bool)
+		for _, inst := range instances {
+			if config.RepoIDFromRoot(inst.Path) == rid {
+				repoMemTitlesAll[inst.Title] = true
+			}
+		}
+
 		path, pathErr := config.RepoInstancesPath(rid)
 		if pathErr != nil {
 			return pathErr
@@ -154,9 +160,9 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 					// Already covered by the in-memory version.
 					continue
 				}
-				if allInMemoryTitles[dd.Title] {
-					// The daemon knew about this instance but it is no
-					// longer started/loading (e.g. killed). Don't
+				if repoMemTitlesAll[dd.Title] {
+					// The daemon knew about this instance in THIS repo but
+					// it is no longer started/loading (e.g. killed). Don't
 					// preserve it.
 					continue
 				}

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -235,6 +235,58 @@ func TestDaemonSaveEmptyDisk(t *testing.T) {
 	assert.Equal(t, "instance-A", result[0].Title)
 }
 
+// TestDaemonSaveCrossRepoTitleCollision verifies that when two repos have
+// instances with the same title, saving does not drop an externally-added
+// instance from one repo just because the daemon knows about a same-titled
+// instance in another repo. Regression test for #198.
+func TestDaemonSaveCrossRepoTitleCollision(t *testing.T) {
+	const repoPathA = "/tmp/repo-a"
+	const repoPathB = "/tmp/repo-b"
+	ms := newMockStorage()
+
+	// Repo A has instance "shared" known to the daemon.
+	// Repo B has instance "shared" added externally (NOT known to the daemon).
+	seedDisk(t, ms, repoPathA, []InstanceData{
+		{Title: "shared", Path: repoPathA, Branch: "branch-a"},
+	})
+	seedDisk(t, ms, repoPathB, []InstanceData{
+		{Title: "shared", Path: repoPathB, Branch: "branch-b"},
+	})
+
+	// Daemon knows about repo A's "shared" and also has some other instance
+	// in repo B so that repo B is a known repo (forcing SaveInstances to
+	// visit repo B).
+	instanceAShared := makeInstance("shared", repoPathA, true)
+	instanceAShared.Branch = "branch-a"
+	instanceBOther := makeInstance("other-b", repoPathB, true)
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{instanceAShared, instanceBOther})
+	require.NoError(t, err)
+
+	// Repo A: "shared" should be present (in-memory copy).
+	resultA := readDisk(t, ms, repoPathA)
+	titlesA := make(map[string]bool)
+	for _, d := range resultA {
+		titlesA[d.Title] = true
+	}
+	assert.True(t, titlesA["shared"], "repo A's shared instance should be preserved")
+
+	// Repo B: BOTH "shared" (externally added) AND "other-b" (in-memory)
+	// should be present. Before the fix, "shared" would be dropped from
+	// repo B because the global allInMemoryTitles set contained "shared"
+	// (from repo A).
+	resultB := readDisk(t, ms, repoPathB)
+	titlesB := make(map[string]bool)
+	for _, d := range resultB {
+		titlesB[d.Title] = true
+	}
+	assert.True(t, titlesB["other-b"], "repo B's in-memory instance should be saved")
+	assert.True(t, titlesB["shared"], "repo B's externally-added instance with title colliding with a different repo's daemon instance must be preserved")
+}
+
 func TestDaemonSaveNoInstances(t *testing.T) {
 	ms := newMockStorage()
 


### PR DESCRIPTION
## Summary
- Daemon SaveInstances used a global title set across all repos to decide whether a disk-only instance was "killed" vs "externally added" — cross-repo title collisions caused data loss.
- Build the known-to-daemon set per-repo so external instances in one repo aren't dropped because a different repo has the same title.

Closes #198.

## Test plan
- [x] go build ./...
- [x] go test ./session/... (new TestDaemonSaveCrossRepoTitleCollision)
- [x] gofmt -l . is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)