### PR TITLE
fix: collapse launchd schedule to wildcard when DOM or DOW covers all values (#201)

### DIFF
--- a/task/launchd.go
+++ b/task/launchd.go
@@ -190,6 +190,19 @@ func cronToCalendarIntervalXML(cronExpr string) (string, error) {
 	// standard cron uses OR semantics: run on matching DOM OR matching DOW.
 	// We handle this by building two separate sets of combos and merging them.
 	domIdx, dowIdx := 2, 4
+
+	// Detect when DOM or DOW is syntactically restricted but semantically
+	// covers all possible values (e.g., DOW=0-6 or DOM=1-31). Under cron OR
+	// semantics, "X OR every-day" collapses to "every day", so both the DOM
+	// and DOW restrictions become irrelevant and we emit a single
+	// wildcard-day dict.
+	dowCoversAll := expanded[dowIdx].vals != nil && len(expanded[dowIdx].vals) >= 7
+	domCoversAll := expanded[domIdx].vals != nil && len(expanded[domIdx].vals) >= 31
+	if dowCoversAll || domCoversAll {
+		expanded[dowIdx].vals = nil
+		expanded[domIdx].vals = nil
+	}
+
 	bothDOMandDOW := expanded[domIdx].vals != nil && expanded[dowIdx].vals != nil
 
 	// buildCombos builds the cartesian product of the given expanded fields.

--- a/task/launchd_test.go
+++ b/task/launchd_test.go
@@ -1,0 +1,104 @@
+//go:build darwin
+
+package task
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countDicts returns the number of <dict> entries in a
+// StartCalendarInterval XML fragment.
+func countDicts(xml string) int {
+	return strings.Count(xml, "<dict>")
+}
+
+// TestCronToCalendarIntervalXML_NoDoubleTrigger verifies that when DOW is
+// syntactically restricted but covers all possible weekdays (e.g., 0-6),
+// the schedule collapses to a single wildcard-day dict rather than
+// emitting both a DOM dict and 7 DOW dicts (which would double-fire on
+// the overlap day).
+func TestCronToCalendarIntervalXML_NoDoubleTrigger(t *testing.T) {
+	// DOW=0-6 covers every weekday. Under cron OR semantics, this is
+	// equivalent to "every day at 09:00"; launchd must receive a single
+	// dict with only Hour and Minute.
+	xml, err := cronToCalendarIntervalXML("0 9 1 * 0-6")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countDicts(xml), "expected a single dict, got:\n%s", xml)
+	assert.Contains(t, xml, "<key>Hour</key>")
+	assert.Contains(t, xml, "<integer>9</integer>")
+	assert.Contains(t, xml, "<key>Minute</key>")
+	assert.Contains(t, xml, "<integer>0</integer>")
+	assert.NotContains(t, xml, "<key>Day</key>", "Day key must be omitted when DOW covers all")
+	assert.NotContains(t, xml, "<key>Weekday</key>", "Weekday key must be omitted when DOW covers all")
+}
+
+// TestCronToCalendarIntervalXML_DOMCoversAll verifies the symmetric case
+// where DOM covers all 31 possible values. Under cron OR semantics this
+// also collapses to "every day".
+func TestCronToCalendarIntervalXML_DOMCoversAll(t *testing.T) {
+	xml, err := cronToCalendarIntervalXML("30 8 1-31 * 1")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countDicts(xml), "expected a single dict, got:\n%s", xml)
+	assert.Contains(t, xml, "<key>Hour</key>")
+	assert.Contains(t, xml, "<integer>8</integer>")
+	assert.Contains(t, xml, "<key>Minute</key>")
+	assert.Contains(t, xml, "<integer>30</integer>")
+	assert.NotContains(t, xml, "<key>Day</key>", "Day key must be omitted when DOM covers all")
+	assert.NotContains(t, xml, "<key>Weekday</key>", "Weekday key must be omitted when DOM covers all")
+}
+
+// TestCronToCalendarIntervalXML_DOWStepCoversAll verifies that a step
+// expression that expands to every weekday also triggers the collapse.
+func TestCronToCalendarIntervalXML_DOWStepCoversAll(t *testing.T) {
+	xml, err := cronToCalendarIntervalXML("0 9 15 * */1")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countDicts(xml), "expected a single dict, got:\n%s", xml)
+	assert.NotContains(t, xml, "<key>Day</key>")
+	assert.NotContains(t, xml, "<key>Weekday</key>")
+}
+
+// TestCronToCalendarIntervalXML_BothRestricted verifies that when DOM and
+// DOW are both restricted and neither covers all values, we still emit
+// the OR-semantics union (one DOM dict + one DOW dict).
+func TestCronToCalendarIntervalXML_BothRestricted(t *testing.T) {
+	xml, err := cronToCalendarIntervalXML("0 9 1 * 1")
+	require.NoError(t, err)
+
+	// Expect two dicts: one for Day=1 (with Hour/Minute) and one for
+	// Weekday=1 (with Hour/Minute).
+	assert.Equal(t, 2, countDicts(xml), "expected exactly two dicts, got:\n%s", xml)
+	assert.Contains(t, xml, "<key>Day</key>")
+	assert.Contains(t, xml, "<key>Weekday</key>")
+}
+
+// TestCronToCalendarIntervalXML_WildcardDOW verifies the baseline case
+// where DOW is an explicit wildcard — only the DOM dict should be
+// emitted (no OR-semantics merging needed).
+func TestCronToCalendarIntervalXML_WildcardDOW(t *testing.T) {
+	xml, err := cronToCalendarIntervalXML("0 9 1 * *")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countDicts(xml), "expected one dict, got:\n%s", xml)
+	assert.Contains(t, xml, "<key>Day</key>")
+	assert.Contains(t, xml, "<integer>1</integer>")
+	assert.NotContains(t, xml, "<key>Weekday</key>")
+}
+
+// TestCronToCalendarIntervalXML_DOW7NormalizesAndCoversAll verifies that
+// a DOW range of 1-7 (where 7 normalizes to 0) covers all weekdays and
+// triggers the collapse.
+func TestCronToCalendarIntervalXML_DOW7NormalizesAndCoversAll(t *testing.T) {
+	xml, err := cronToCalendarIntervalXML("0 9 15 * 1-7")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countDicts(xml), "expected a single dict, got:\n%s", xml)
+	assert.NotContains(t, xml, "<key>Day</key>")
+	assert.NotContains(t, xml, "<key>Weekday</key>")
+}


### PR DESCRIPTION
## Summary
- launchd cron OR-semantics could double-trigger when one of DOM/DOW was syntactically restricted but covered all possible values (e.g., DOW=0-6).
- Detect the covers-all case and collapse the schedule to a single wildcard-day dict.

Closes #201.

## Test plan
- [x] go build ./...
- [x] go test ./task/... (new TestCronToCalendarIntervalXML_NoDoubleTrigger)
- [x] gofmt -l . is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)