### PR TITLE
fix: accept ctrl+c as cancel in confirmation overlay (#271)

### DIFF
--- a/ui/overlay/confirmationOverlay.go
+++ b/ui/overlay/confirmationOverlay.go
@@ -50,7 +50,7 @@ func (c *ConfirmationOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
 			c.OnConfirm()
 		}
 		return true
-	case strings.ToLower(c.CancelKey), "esc":
+	case strings.ToLower(c.CancelKey), "esc", "ctrl+c":
 		c.Dismissed = true
 		if c.OnCancel != nil {
 			c.OnCancel()

--- a/ui/overlay/confirmationOverlay_test.go
+++ b/ui/overlay/confirmationOverlay_test.go
@@ -1,0 +1,84 @@
+package overlay
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfirmationOverlay_HandleKeyPress_CtrlC(t *testing.T) {
+	overlay := NewConfirmationOverlay("Test confirmation")
+
+	cancelCalled := false
+	overlay.OnCancel = func() {
+		cancelCalled = true
+	}
+
+	confirmCalled := false
+	overlay.OnConfirm = func() {
+		confirmCalled = true
+	}
+
+	ctrlCMsg := tea.KeyMsg{Type: tea.KeyCtrlC}
+	shouldClose := overlay.HandleKeyPress(ctrlCMsg)
+
+	assert.True(t, shouldClose, "ctrl+c should close the overlay")
+	assert.True(t, overlay.Dismissed, "overlay should be dismissed")
+	assert.True(t, cancelCalled, "OnCancel should be called")
+	assert.False(t, confirmCalled, "OnConfirm should not be called")
+}
+
+func TestConfirmationOverlay_HandleKeyPress_Esc(t *testing.T) {
+	overlay := NewConfirmationOverlay("Test confirmation")
+
+	cancelCalled := false
+	overlay.OnCancel = func() {
+		cancelCalled = true
+	}
+
+	escMsg := tea.KeyMsg{Type: tea.KeyEsc}
+	shouldClose := overlay.HandleKeyPress(escMsg)
+
+	assert.True(t, shouldClose, "esc should close the overlay")
+	assert.True(t, overlay.Dismissed, "overlay should be dismissed")
+	assert.True(t, cancelCalled, "OnCancel should be called")
+}
+
+func TestConfirmationOverlay_HandleKeyPress_ConfirmKey(t *testing.T) {
+	overlay := NewConfirmationOverlay("Test confirmation")
+
+	confirmCalled := false
+	overlay.OnConfirm = func() {
+		confirmCalled = true
+	}
+
+	yMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
+	shouldClose := overlay.HandleKeyPress(yMsg)
+
+	assert.True(t, shouldClose, "confirm key should close the overlay")
+	assert.True(t, overlay.Dismissed, "overlay should be dismissed")
+	assert.True(t, confirmCalled, "OnConfirm should be called")
+}
+
+func TestConfirmationOverlay_HandleKeyPress_OtherKey(t *testing.T) {
+	overlay := NewConfirmationOverlay("Test confirmation")
+
+	cancelCalled := false
+	overlay.OnCancel = func() {
+		cancelCalled = true
+	}
+
+	confirmCalled := false
+	overlay.OnConfirm = func() {
+		confirmCalled = true
+	}
+
+	otherMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}}
+	shouldClose := overlay.HandleKeyPress(otherMsg)
+
+	assert.False(t, shouldClose, "other keys should not close the overlay")
+	assert.False(t, overlay.Dismissed, "overlay should not be dismissed")
+	assert.False(t, cancelCalled, "OnCancel should not be called")
+	assert.False(t, confirmCalled, "OnConfirm should not be called")
+}


### PR DESCRIPTION
## Summary
- ConfirmationOverlay.HandleKeyPress only matched the configured confirm/cancel keys plus esc; ctrl+c fell through to default and left the dialog open.
- Added "ctrl+c" to the cancel branch so users can dismiss the overlay consistently (matches SelectionOverlay, which already handles ctrl+c).

Closes #271.

## Test plan
- [x] go build ./...
- [x] go test ./ui/... (new TestConfirmationOverlay_HandleKeyPress_CtrlC + 3 siblings)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)