### PR TITLE
fix: measure rune that was written in whitespace.render (#272)

### DIFF
--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -180,12 +180,13 @@ func (w whitespace) render(width int) string {
 
 	// Cycle through runes and print them into the whitespace.
 	for i := 0; i < width; {
-		b.WriteRune(r[j])
+		writtenRune := r[j]
+		b.WriteRune(writtenRune)
 		j++
 		if j >= len(r) {
 			j = 0
 		}
-		i += ansi.PrintableRuneWidth(string(r[j]))
+		i += ansi.PrintableRuneWidth(string(writtenRune))
 	}
 
 	// Fill any extra gaps white spaces. This might be necessary if any runes

--- a/ui/overlay/overlay_test.go
+++ b/ui/overlay/overlay_test.go
@@ -1,0 +1,42 @@
+package overlay
+
+import (
+	"testing"
+
+	"github.com/muesli/ansi"
+)
+
+// TestWhitespaceRenderWideCharExceedsWidth verifies that render() does not
+// over-emit cells when the whitespace pattern mixes wide and narrow runes.
+// Previously the loop counted the width of the next rune (rather than the one
+// it just wrote), which made termination off-by-one for CJK patterns.
+func TestWhitespaceRenderWideCharExceedsWidth(t *testing.T) {
+	ws := &whitespace{chars: "界a"} // 界 is 2 cells wide, 'a' is 1 cell
+	result := ws.render(2)
+	width := ansi.PrintableRuneWidth(result)
+	if width != 2 {
+		t.Fatalf("Expected width 2, got %d, result=%q", width, result)
+	}
+}
+
+// TestWhitespaceRenderASCII verifies the common single-space case still fills
+// the requested width exactly.
+func TestWhitespaceRenderASCII(t *testing.T) {
+	ws := &whitespace{}
+	result := ws.render(5)
+	width := ansi.PrintableRuneWidth(result)
+	if width != 5 {
+		t.Fatalf("Expected width 5, got %d, result=%q", width, result)
+	}
+}
+
+// TestWhitespaceRenderWideCharEvenWidth verifies a pure wide-char pattern
+// fills an even width exactly using two runes.
+func TestWhitespaceRenderWideCharEvenWidth(t *testing.T) {
+	ws := &whitespace{chars: "界"}
+	result := ws.render(4)
+	width := ansi.PrintableRuneWidth(result)
+	if width != 4 {
+		t.Fatalf("Expected width 4, got %d, result=%q", width, result)
+	}
+}


### PR DESCRIPTION
## Summary
- whitespace.render advanced its width accumulator using the NEXT rune's width after the post-increment of j, not the rune that was just written. For mixed-width patterns (e.g. CJK + ASCII) this produced off-width output.
- Capture the rune locally, write it, then measure it.

Closes #272.

## Test plan
- [x] go build ./...
- [x] go test ./ui/... (new TestWhitespaceRenderWideCharExceedsWidth plus regression guards)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)