### PR TITLE
fix: expand instances section in SetSelectedInstance when collapsed (#275)

### DIFF
--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -317,10 +317,15 @@ func (s *Sidebar) GetSelectedInstance() *session.Instance {
 }
 
 // SetSelectedInstance sets the selected index to point at the given instance index.
+// If the Instances section is collapsed, it is expanded first so the target row
+// is always reachable.
 func (s *Sidebar) SetSelectedInstance(idx int) {
 	if idx >= len(s.instances) {
 		return
 	}
+	// Ensure the Instances section is expanded so the target row is part of
+	// visibleItems; otherwise the search below would silently no-op.
+	s.ExpandInstancesSection()
 	// Find the visible item that corresponds to this instance
 	for i, item := range s.visibleItems {
 		if item.Kind == SectionInstances && !item.IsHeader && item.ItemIndex == idx {

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -206,6 +206,45 @@ func TestSidebarSelectInstance(t *testing.T) {
 	assert.Equal(t, "first", selected.Title)
 }
 
+// TestSetSelectedInstanceExpandsCollapsedSection verifies that calling
+// SetSelectedInstance while the Instances section is collapsed transparently
+// expands the section and selects the target instance (regression for #275).
+func TestSetSelectedInstanceExpandsCollapsedSection(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false)
+
+	inst1, _ := session.NewInstance(session.InstanceOptions{
+		Title: "first", Path: t.TempDir(), Program: "test",
+	})
+	inst2, _ := session.NewInstance(session.InstanceOptions{
+		Title: "second", Path: t.TempDir(), Program: "test",
+	})
+	s.AddInstance(inst1)
+	s.AddInstance(inst2)
+
+	// Sanity check: SetSelectedInstance works when expanded.
+	s.SetSelectedInstance(1)
+	selected := s.GetSelectedInstance()
+	require.NotNil(t, selected)
+	assert.Equal(t, "second", selected.Title)
+
+	// Collapse the Instances section; selection lands on the Instances header.
+	s.CollapseSection()
+	sel := s.GetSelection()
+	require.True(t, sel.IsHeader)
+	require.Equal(t, SectionInstances, sel.Kind)
+
+	// Selecting while collapsed should transparently expand the section and
+	// land on the requested instance instead of silently no-oping.
+	s.SetSelectedInstance(0)
+	selected = s.GetSelectedInstance()
+	require.NotNil(t, selected, "SetSelectedInstance should expand the collapsed Instances section")
+	assert.Equal(t, "first", selected.Title)
+
+	// The Instances section should now be expanded.
+	assert.True(t, s.sections[0].Expanded)
+}
+
 func TestSidebarTaskData(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	s := NewSidebar(&spin, false)


### PR DESCRIPTION
## Summary
- Sidebar.SetSelectedInstance searched visibleItems, which only contains instance rows when the Instances section is expanded; callers on the new-instance path didn't expand first, so selection silently no-oped after creating an instance while collapsed.
- Call ExpandInstancesSection before the lookup so callers can treat this as a contract-level "select this instance".

Closes #275.

## Test plan
- [x] go build ./...
- [x] go test ./ui/... (new TestSetSelectedInstanceExpandsCollapsedSection)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)