### PR TITLE
fix: clamp negative tabbed window content dimensions (#276)

### DIFF
--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -79,6 +79,16 @@ func (w *TabbedWindow) SetSize(width, height int) {
 	contentHeight := height - tabHeight - windowStyle.GetVerticalFrameSize() - 2
 	contentWidth := w.width - windowStyle.GetHorizontalFrameSize()
 
+	// Clamp to zero so tiny terminals don't produce negative dimensions,
+	// which would otherwise overflow when later cast to uint16 (e.g. by
+	// pty.Setsize for the tmux preview/terminal panes).
+	if contentHeight < 0 {
+		contentHeight = 0
+	}
+	if contentWidth < 0 {
+		contentWidth = 0
+	}
+
 	w.preview.SetSize(contentWidth, contentHeight)
 	w.terminal.SetSize(contentWidth, contentHeight)
 }

--- a/ui/tabbed_window_test.go
+++ b/ui/tabbed_window_test.go
@@ -1,0 +1,49 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTabbedWindowSetSizeClampsNegativeDimensions verifies that SetSize never
+// propagates negative content dimensions down to the preview/terminal panes.
+// Without clamping, tiny terminal windows (height <= 5) produce negative ints
+// that later overflow to huge uint16 values inside pty.Setsize, corrupting the
+// tmux PTY size. See issue #276.
+func TestTabbedWindowSetSizeClampsNegativeDimensions(t *testing.T) {
+	cases := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{"zero size", 0, 0},
+		{"tiny height", 10, 1},
+		{"height just below threshold", 10, 5},
+		{"negative inputs", -10, -10},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
+			w.SetSize(tc.width, tc.height)
+
+			previewW, previewH := w.GetPreviewSize()
+			assert.GreaterOrEqual(t, previewW, 0, "preview width should be clamped to >= 0")
+			assert.GreaterOrEqual(t, previewH, 0, "preview height should be clamped to >= 0")
+			assert.GreaterOrEqual(t, w.terminal.width, 0, "terminal width should be clamped to >= 0")
+			assert.GreaterOrEqual(t, w.terminal.height, 0, "terminal height should be clamped to >= 0")
+		})
+	}
+}
+
+// TestTabbedWindowSetSizeNormal sanity-checks that reasonable sizes still
+// produce positive content dimensions.
+func TestTabbedWindowSetSizeNormal(t *testing.T) {
+	w := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
+	w.SetSize(200, 100)
+
+	previewW, previewH := w.GetPreviewSize()
+	assert.Greater(t, previewW, 0)
+	assert.Greater(t, previewH, 0)
+}


### PR DESCRIPTION
## Summary
- TabbedWindow.SetSize computed contentHeight without a lower bound; for terminal heights ≤5 this went negative and flowed into pty.Setsize, where uint16(-1) wraps to 65535.
- Clamp contentHeight and contentWidth to 0 before storing them.

Closes #276.

## Test plan
- [x] go build ./...
- [x] go test ./ui/... (new TestTabbedWindowSetSizeClampsNegativeDimensions table tests)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)