### PR TITLE
fix: sanitize newlines in systemd WorkingDirectory (#250)

### DIFF
--- a/task/systemd.go
+++ b/task/systemd.go
@@ -41,6 +41,10 @@ func quoteExecStartPath(p string) string {
 // so surrounding quotes would be preserved literally. Newlines are also
 // disallowed by systemd in Environment= values; replace them with spaces
 // rather than emitting a syntactically invalid unit file.
+//
+// The same rules apply to WorkingDirectory=: a raw newline would terminate
+// the value and cause systemd to run the task in a truncated path, so this
+// helper is reused there as well.
 func sanitizeEnvValue(v string) string {
 	v = strings.ReplaceAll(v, "\n", " ")
 	v = strings.ReplaceAll(v, "\r", " ")
@@ -66,7 +70,7 @@ WorkingDirectory=%s
 		sanitizeEnvValue(homeEnv),
 		sanitizeEnvValue(shellEnv),
 		sanitizeEnvValue(termEnv),
-		projectPath)
+		sanitizeEnvValue(projectPath))
 }
 
 func InstallScheduler(t Task) error {

--- a/task/systemd_test.go
+++ b/task/systemd_test.go
@@ -93,6 +93,38 @@ func TestGenerateServiceContentEnvNewlineSanitized(t *testing.T) {
 	assert.Contains(t, content, "Environment=PATH=/usr/bin /evil")
 }
 
+func TestGenerateServiceContentWorkingDirectoryNewlineSanitized(t *testing.T) {
+	// A newline inside WorkingDirectory= would terminate the value and cause
+	// systemd to run the task in a truncated directory. The unit must have
+	// the newline replaced so the full path is preserved on a single line.
+	projectPath := "/tmp/test\ninjected"
+	content := generateServiceContent(
+		"agent-factory-task-nl1",
+		"/usr/local/bin/agent-factory",
+		"nl1",
+		projectPath,
+		"/usr/bin",
+		"/home/user",
+		"/bin/bash",
+		"xterm-256color",
+	)
+
+	// The raw newline must not appear mid-value.
+	assert.NotContains(t, content, "WorkingDirectory=/tmp/test\n")
+
+	// The sanitized single-line WorkingDirectory= should contain the full
+	// path with the newline replaced (spaces, matching Environment= handling).
+	assert.Contains(t, content, "\nWorkingDirectory=/tmp/test injected\n")
+
+	// Defensive: whichever line holds WorkingDirectory= must be free of any
+	// embedded newline in its value.
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "WorkingDirectory=") {
+			assert.NotContains(t, line, "\n")
+		}
+	}
+}
+
 func TestGenerateServiceContentExecStartEscapesQuotes(t *testing.T) {
 	// An executable path containing a literal double-quote must not
 	// break out of the ExecStart= quoted string.


### PR DESCRIPTION
## Summary
- generateServiceContent passed projectPath to WorkingDirectory= unsanitized. Environment= values went through sanitizeEnvValue, but WorkingDirectory didn't, so a newline in the project path silently truncated the directory and ran the task in the wrong place.
- Wrap projectPath in sanitizeEnvValue for WorkingDirectory too.

Closes #250.

## Test plan
- [x] go build ./...
- [x] go test ./task/... (new TestGenerateServiceContentWorkingDirectoryNewlineSanitized)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)