### PR TITLE
fix: enforce 32-cell title width on spacebar in handleStateNew (#252)

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -102,7 +102,11 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.handleError(err)
 		}
 	case tea.KeySpace:
-		if err := instance.SetTitle(instance.Title + " "); err != nil {
+		newTitle := instance.Title + " "
+		if runewidth.StringWidth(newTitle) > 32 {
+			return m, m.handleError(fmt.Errorf("title cannot be longer than 32 characters"))
+		}
+		if err := instance.SetTitle(newTitle); err != nil {
 			return m, m.handleError(err)
 		}
 	case tea.KeyEsc:

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -1,0 +1,72 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui"
+)
+
+// TestHandleStateNewKeySpaceWidthLimit ensures that pressing the spacebar
+// while naming a new instance respects the same 32-cell width cap that
+// regular character input enforces.
+func TestHandleStateNewKeySpaceWidthLimit(t *testing.T) {
+	h := &home{
+		ctx:       context.Background(),
+		state:     stateNew,
+		appConfig: config.DefaultConfig(),
+		errBox:    ui.NewErrBox(),
+	}
+
+	// Build an instance whose title is exactly at the 32-cell limit.
+	instance, err := session.NewInstance(session.InstanceOptions{
+		Title:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 32 characters
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+
+	h.namingInstance = instance
+
+	keyMsg := tea.KeyMsg{Type: tea.KeySpace}
+	model, _ := h.handleStateNew(keyMsg)
+	homeModel, ok := model.(*home)
+	require.True(t, ok)
+
+	assert.Equal(t, 32, len(homeModel.namingInstance.Title),
+		"Title should remain at 32 characters, but got %d: %q",
+		len(homeModel.namingInstance.Title), homeModel.namingInstance.Title)
+}
+
+// TestHandleStateNewKeySpaceUnderLimit ensures that a spacebar press is
+// still accepted when the resulting title stays within the 32-cell cap.
+func TestHandleStateNewKeySpaceUnderLimit(t *testing.T) {
+	h := &home{
+		ctx:       context.Background(),
+		state:     stateNew,
+		appConfig: config.DefaultConfig(),
+		errBox:    ui.NewErrBox(),
+	}
+
+	instance, err := session.NewInstance(session.InstanceOptions{
+		Title:   "hello",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+
+	h.namingInstance = instance
+
+	keyMsg := tea.KeyMsg{Type: tea.KeySpace}
+	model, _ := h.handleStateNew(keyMsg)
+	homeModel, ok := model.(*home)
+	require.True(t, ok)
+
+	assert.Equal(t, "hello ", homeModel.namingInstance.Title)
+}


### PR DESCRIPTION
## Summary
- handleStateNew validated the 32-cell width limit on tea.KeyRunes but not on tea.KeySpace, so pressing space at the limit bypassed the check.
- Mirror the candidate-title width validation into the KeySpace case.

Closes #252.

## Test plan
- [x] go build ./...
- [x] go test ./app/... (new TestHandleStateNewKeySpaceWidthLimit + under-limit regression)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)