### PR TITLE
fix: strip all trailing .lock suffixes in sanitizeBranchName (#253)

### DIFF
--- a/session/git/util.go
+++ b/session/git/util.go
@@ -49,8 +49,10 @@ func sanitizeBranchName(s string) string {
 	s = strings.Join(filtered, "/")
 	// 2. Replace any remaining double dots with a dash (e.g., "a..b")
 	s = strings.ReplaceAll(s, "..", "-")
-	// 3. No .lock suffix (reserved by git)
-	s = strings.TrimSuffix(s, ".lock")
+	// 3. No .lock suffix (reserved by git) - remove ALL trailing .lock suffixes
+	for strings.HasSuffix(s, ".lock") {
+		s = strings.TrimSuffix(s, ".lock")
+	}
 	// 4. No trailing dots
 	s = strings.TrimRight(s, ".")
 	// 5. Clean up any trailing dashes or slashes left after dot removal

--- a/session/git/util_test.go
+++ b/session/git/util_test.go
@@ -67,6 +67,11 @@ func TestSanitizeBranchName(t *testing.T) {
 			expected: "john/config",
 		},
 		{
+			name:     "multiple .lock suffixes",
+			input:    "john/config.lock.lock",
+			expected: "john/config",
+		},
+		{
 			name:     "double dots in name",
 			input:    "feature..branch",
 			expected: "feature-branch",


### PR DESCRIPTION
## Summary
- sanitizeBranchName used a single strings.TrimSuffix to strip ".lock", so an input like "foo.lock.lock" came out still ending in ".lock" — which git rejects.
- Loop until no .lock suffix remains.

Closes #253.

## Test plan
- [x] go build ./...
- [x] go test ./session/git/... (new table case "multiple .lock suffixes")
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)