### PR TITLE
fix: preserve spaces in aliased Claude binary paths (#263)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -117,10 +117,13 @@ func GetClaudeCommand() (string, error) {
 		if path != "" {
 			// Check if the output is an alias definition and extract the actual path
 			// Handle formats like "claude: aliased to /path/to/claude" or other shell-specific formats
-			aliasRegex := regexp.MustCompile(`(?:aliased to|->|=)\s*([^\s]+)`)
+			// Capture everything after the alias marker so paths containing spaces
+			// (e.g. "/Applications/Claude Code.app/.../claude") are preserved; trim
+			// surrounding whitespace afterwards.
+			aliasRegex := regexp.MustCompile(`(?:aliased to|->|=)\s*(.+)`)
 			matches := aliasRegex.FindStringSubmatch(path)
 			if len(matches) > 1 {
-				path = matches[1]
+				path = strings.TrimSpace(matches[1])
 			}
 			return path, nil
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -82,19 +82,41 @@ func TestGetClaudeCommand(t *testing.T) {
 	})
 
 	t.Run("handles alias parsing", func(t *testing.T) {
-		// Test core alias formats
-		aliasRegex := regexp.MustCompile(`(?:aliased to|->|=)\s*([^\s]+)`)
+		// Test core alias formats. Keep this regex in sync with the one used in
+		// GetClaudeCommand so the test exercises the real extraction logic.
+		aliasRegex := regexp.MustCompile(`(?:aliased to|->|=)\s*(.+)`)
+
+		extract := func(output string) (string, bool) {
+			matches := aliasRegex.FindStringSubmatch(output)
+			if len(matches) < 2 {
+				return "", false
+			}
+			return strings.TrimSpace(matches[1]), true
+		}
 
 		// Standard alias format
-		output := "claude: aliased to /usr/local/bin/claude"
-		matches := aliasRegex.FindStringSubmatch(output)
-		assert.Len(t, matches, 2)
-		assert.Equal(t, "/usr/local/bin/claude", matches[1])
+		got, ok := extract("claude: aliased to /usr/local/bin/claude")
+		assert.True(t, ok)
+		assert.Equal(t, "/usr/local/bin/claude", got)
+
+		// Alias path containing spaces (e.g. macOS app bundle) must be preserved.
+		got, ok = extract("claude: aliased to /Applications/Claude Code.app/Contents/MacOS/claude")
+		assert.True(t, ok)
+		assert.Equal(t, "/Applications/Claude Code.app/Contents/MacOS/claude", got)
+
+		// Arrow format with spaces in the path.
+		got, ok = extract("claude -> /path/with spaces/claude")
+		assert.True(t, ok)
+		assert.Equal(t, "/path/with spaces/claude", got)
+
+		// Equals format with trailing whitespace should be trimmed.
+		got, ok = extract("claude=/path/with spaces/claude   ")
+		assert.True(t, ok)
+		assert.Equal(t, "/path/with spaces/claude", got)
 
 		// Direct path (no alias)
-		output = "/usr/local/bin/claude"
-		matches = aliasRegex.FindStringSubmatch(output)
-		assert.Len(t, matches, 0)
+		_, ok = extract("/usr/local/bin/claude")
+		assert.False(t, ok)
 	})
 }
 


### PR DESCRIPTION
## Summary
- GetClaudeCommand parsed alias output with `(?:aliased to|->|=)\s*([^\s]+)`, so paths containing spaces (e.g. "/Applications/Claude Code.app/.../claude") were truncated at the first space.
- Capture everything after the alias marker with `(.+)` and TrimSpace.

Closes #263.

## Test plan
- [x] go build ./...
- [x] go test ./config/... (new cases for paths with spaces and trailing whitespace)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)