### PR TITLE
fix: mark instance stopped before hook backend Kill cleanup (#266)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -121,6 +121,16 @@ func extractJSON(output string) string {
 }
 
 func (b *HookBackend) Kill(i *Instance) error {
+	// Mark the instance as stopped BEFORE any resource cleanup so that the
+	// instance is in a consistent state even if delete_cmd fails. Otherwise
+	// the PTY could be closed while started=true, leaving the session
+	// appearing running but unusable (empty preview, broken attach).
+	// This mirrors LocalBackend.Kill's behavior.
+	i.mu.Lock()
+	i.started = false
+	i.remoteMeta = nil
+	i.mu.Unlock()
+
 	b.closePTY(i.Title)
 
 	slug := slugify(i.Title)
@@ -129,11 +139,6 @@ func (b *HookBackend) Kill(i *Instance) error {
 	if err != nil {
 		return fmt.Errorf("delete_cmd failed: %s: %w", string(out), err)
 	}
-
-	i.mu.Lock()
-	i.started = false
-	i.remoteMeta = nil
-	i.mu.Unlock()
 
 	return nil
 }

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -448,10 +448,22 @@ func TestHookBackendKillDeleteCmdFails(t *testing.T) {
 
 	err := b.Start(i, true)
 	require.NoError(t, err)
+	assert.True(t, i.Started())
 
 	err = b.Kill(i)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "delete_cmd failed")
+
+	// Even when delete_cmd fails, the instance must be marked stopped and
+	// its remote metadata cleared so that the UI doesn't show it as running
+	// while its PTY is already closed (see issue #266).
+	assert.False(t, i.Started(), "instance should be stopped after failed Kill")
+	i.mu.RLock()
+	meta := i.remoteMeta
+	i.mu.RUnlock()
+	assert.Nil(t, meta, "remoteMeta should be cleared after failed Kill")
+	// The PTY should have been cleaned up too.
+	assert.Nil(t, b.getPTY(i.Title), "PTY should be closed after failed Kill")
 }
 
 // --- PTY management ---


### PR DESCRIPTION
## Summary
- HookBackend.Kill closed the PTY and ran delete_cmd before flipping i.started=false, so a delete_cmd failure left the instance reporting Started()=true with a dead PTY (empty preview, broken attach) — users saw it as running but couldn't interact.
- Mirror LocalBackend.Kill: mark the instance stopped (i.started=false, remoteMeta=nil) BEFORE resource cleanup, so state is consistent even on failure.

Closes #266.

## Test plan
- [x] go build ./...
- [x] go test ./session/... (extended TestHookBackendKillDeleteCmdFails)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)