### PR TITLE
fix: guard tmuxSession nil in SendKeys and HasUpdated (#267)

### DIFF
--- a/session/backend.go
+++ b/session/backend.go
@@ -32,6 +32,9 @@ type Backend interface {
 	// approach (e.g. tmux send-keys).
 	SendPromptCommand(instance *Instance, prompt string) error
 
+	// SendKeys sends raw keys to the session (without pressing Enter).
+	SendKeys(instance *Instance, keys string) error
+
 	// SetPreviewSize sets the terminal dimensions for the session preview.
 	SetPreviewSize(instance *Instance, width, height int) error
 

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -194,6 +194,10 @@ func (b *HookBackend) SendPromptCommand(_ *Instance, _ string) error {
 	return fmt.Errorf("SendPromptCommand not supported for remote sessions")
 }
 
+func (b *HookBackend) SendKeys(_ *Instance, _ string) error {
+	return fmt.Errorf("SendKeys not supported for remote sessions")
+}
+
 func (b *HookBackend) SetPreviewSize(_ *Instance, _, _ int) error {
 	// No-op: remote session size is controlled by the remote host.
 	return nil

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -184,7 +184,7 @@ func (b *LocalBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool) {
 	ts := i.tmuxSession
 	i.mu.RUnlock()
 
-	if !s {
+	if !s || ts == nil {
 		return false, false
 	}
 	return ts.HasUpdated()
@@ -227,6 +227,21 @@ func (b *LocalBackend) SendPromptCommand(i *Instance, prompt string) error {
 		return fmt.Errorf("tmux session not initialized")
 	}
 	return ts.SendKeysCommand(prompt)
+}
+
+func (b *LocalBackend) SendKeys(i *Instance, keys string) error {
+	i.mu.RLock()
+	s := i.started
+	ts := i.tmuxSession
+	i.mu.RUnlock()
+
+	if !s {
+		return fmt.Errorf("cannot send keys to instance that has not been started")
+	}
+	if ts == nil {
+		return fmt.Errorf("tmux session not initialized")
+	}
+	return ts.SendKeys(keys)
 }
 
 func (b *LocalBackend) SetPreviewSize(i *Instance, width, height int) error {

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -261,6 +261,69 @@ func TestHookBackendSendPromptCommandReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "not supported")
 }
 
+func TestHookBackendSendKeysReturnsError(t *testing.T) {
+	b := &HookBackend{Hooks: config.RemoteHooks{}}
+	i := &Instance{backend: b}
+	err := b.SendKeys(i, "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+// Regression test for #267: SendKeys on a remote instance must return an
+// error rather than panic with a nil tmuxSession dereference.
+func TestInstanceSendKeysRemoteNoPanic(t *testing.T) {
+	b := &HookBackend{Hooks: config.RemoteHooks{}}
+	i := &Instance{
+		Title:   "remote-inst",
+		backend: b,
+		started: true, // simulate remote instance started without tmux session
+	}
+	err := i.SendKeys("hello")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+}
+
+// Regression test for #267: LocalBackend.HasUpdated must not panic when
+// started=true but tmuxSession=nil (it should report no updates instead).
+func TestLocalBackendHasUpdatedNilTmuxSession(t *testing.T) {
+	b := &LocalBackend{}
+	i := &Instance{
+		Title:   "local-inst",
+		backend: b,
+		started: true, // tmuxSession intentionally left nil
+	}
+	updated, hasPrompt := b.HasUpdated(i)
+	assert.False(t, updated)
+	assert.False(t, hasPrompt)
+}
+
+// LocalBackend.SendKeys should return an error (not panic) when the tmux
+// session has not been initialized yet.
+func TestLocalBackendSendKeysNilTmuxSession(t *testing.T) {
+	b := &LocalBackend{}
+	i := &Instance{
+		Title:   "local-inst",
+		backend: b,
+		started: true, // tmuxSession intentionally left nil
+	}
+	err := b.SendKeys(i, "hello")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tmux session not initialized")
+}
+
+// LocalBackend.SendKeys should return an error when the instance has not
+// been started yet.
+func TestLocalBackendSendKeysNotStarted(t *testing.T) {
+	b := &LocalBackend{}
+	i := &Instance{
+		Title:   "local-inst",
+		backend: b,
+	}
+	err := b.SendKeys(i, "hello")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has not been started")
+}
+
 func TestHookBackendSetPreviewSizeIsNoop(t *testing.T) {
 	b := &HookBackend{Hooks: config.RemoteHooks{}}
 	i := &Instance{backend: b}

--- a/session/instance.go
+++ b/session/instance.go
@@ -439,17 +439,10 @@ func (i *Instance) SetTmuxSession(session *tmux.TmuxSession) {
 	i.tmuxSession = session
 }
 
-// SendKeys sends keys to the tmux session
+// SendKeys sends keys to the underlying session. For remote backends this
+// returns an explicit error since raw key injection is not supported.
 func (i *Instance) SendKeys(keys string) error {
-	i.mu.RLock()
-	s := i.started
-	ts := i.tmuxSession
-	i.mu.RUnlock()
-
-	if !s {
-		return fmt.Errorf("cannot send keys to instance that has not been started")
-	}
-	return ts.SendKeys(keys)
+	return i.backend.SendKeys(i, keys)
 }
 
 // IsRemote returns true if this instance uses the remote hook backend.


### PR DESCRIPTION
## Summary
- Instance.SendKeys called ts.SendKeys without checking tmuxSession==nil — panic on remote instances (HookBackend) where started=true but tmuxSession=nil.
- LocalBackend.HasUpdated had the same nil-deref shape.
- Move SendKeys onto the Backend interface (mirroring SendPrompt); LocalBackend guards tmuxSession==nil and HookBackend returns an explicit "not supported for remote sessions" error. Fix HasUpdated to return false, false when tmuxSession is nil.

Closes #267.

## Test plan
- [x] go build ./...
- [x] go test ./... (5 new regression tests incl. the two panic paths)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)