### PR TITLE
fix: honor step in single-number cron fields for launchd (#268)

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -361,5 +361,14 @@ func expandCronPart(part string, min, max int) ([]int, error) {
 	if err != nil {
 		return nil, err
 	}
+	// When a step is provided with a single number (e.g. "5/10"), expand from
+	// that number to max by step. Without a step, return just the single value.
+	if step > 1 {
+		var vals []int
+		for i := val; i <= max; i += step {
+			vals = append(vals, i)
+		}
+		return vals, nil
+	}
 	return []int{val}, nil
 }

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -43,6 +43,27 @@ func TestCronFieldExpandRangeWithStep(t *testing.T) {
 	assert.Equal(t, []int{0, 3, 6, 9}, vals)
 }
 
+func TestCronFieldExpandSingleWithStep(t *testing.T) {
+	// "5/10" means "every 10 starting at 5" — the step must be honored.
+	vals, err := expandCronField("5/10", 0, 59)
+	require.NoError(t, err)
+	assert.Equal(t, []int{5, 15, 25, 35, 45, 55}, vals)
+}
+
+func TestCronFieldExpandSingleWithStepAtBoundary(t *testing.T) {
+	// Starting value equal to max should yield just that value.
+	vals, err := expandCronField("59/10", 0, 59)
+	require.NoError(t, err)
+	assert.Equal(t, []int{59}, vals)
+}
+
+func TestCronFieldExpandListWithSingleStep(t *testing.T) {
+	// A list element with a single-number step should also expand.
+	vals, err := expandCronField("0,5/20", 0, 59)
+	require.NoError(t, err)
+	assert.Equal(t, []int{0, 5, 25, 45}, vals)
+}
+
 func TestCronFieldExpandDedup(t *testing.T) {
 	vals, err := expandCronField("1,1,3", 0, 7)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- expandCronPart parsed the /N step for all branches but dropped it in the single-number branch, returning []int{val} unconditionally — so launchd cron like "5/10 * * * *" fired once per hour instead of six times.
- When a step was provided with a single number, expand from val to max by step; when no step, preserve the existing single-value behavior.

Closes #268.

## Test plan
- [x] go build ./...
- [x] go test ./task/... (3 new tests covering step, boundary, and list+single-step mix)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)