### PR TITLE
fix: recover from corrupted pending_instances.json by clearing it (#269)

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -71,7 +71,8 @@ func LoadAndClearPendingInstances() ([]session.InstanceData, error) {
 		}
 
 		if err := json.Unmarshal(raw, &pending); err != nil {
-			return err
+			log.WarningLog.Printf("failed to parse pending instances file, discarding: %v", err)
+			pending = nil
 		}
 
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -1,6 +1,22 @@
 package task
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestMain initializes the logger so that functions under test that write
+// WarningLog/ErrorLog messages do not nil-deref.
+func TestMain(m *testing.M) {
+	log.Initialize(false)
+	defer log.Close()
+	os.Exit(m.Run())
+}
 
 func TestIsReadyContent(t *testing.T) {
 	tests := []struct {
@@ -58,5 +74,86 @@ func TestIsReadyContent(t *testing.T) {
 				t.Errorf("isReadyContent(%q) = %v, want %v", tc.content, got, tc.want)
 			}
 		})
+	}
+}
+
+// setupPendingInstancesDir overrides AGENT_FACTORY_HOME to a temp directory
+// for the duration of the test and returns the expected pending instances
+// file path.
+func setupPendingInstancesDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig, hadOrig := os.LookupEnv("AGENT_FACTORY_HOME")
+	if err := os.Setenv("AGENT_FACTORY_HOME", dir); err != nil {
+		t.Fatalf("failed to set AGENT_FACTORY_HOME: %v", err)
+	}
+	t.Cleanup(func() {
+		if hadOrig {
+			os.Setenv("AGENT_FACTORY_HOME", orig)
+		} else {
+			os.Unsetenv("AGENT_FACTORY_HOME")
+		}
+	})
+	return filepath.Join(dir, pendingInstancesFileName)
+}
+
+func TestLoadAndClearPendingInstances_Missing(t *testing.T) {
+	setupPendingInstancesDir(t)
+
+	pending, err := LoadAndClearPendingInstances()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("expected no pending, got %d", len(pending))
+	}
+}
+
+func TestLoadAndClearPendingInstances_Valid(t *testing.T) {
+	path := setupPendingInstancesDir(t)
+
+	data := []session.InstanceData{{Title: "one"}, {Title: "two"}}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, raw, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	pending, err := LoadAndClearPendingInstances()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pending) != 2 || pending[0].Title != "one" || pending[1].Title != "two" {
+		t.Fatalf("unexpected pending: %+v", pending)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected pending file to be removed, stat err = %v", err)
+	}
+}
+
+// TestLoadAndClearPendingInstances_Corrupted verifies that corrupted JSON is
+// treated as a recoverable condition: the function returns no error, yields
+// no pending instances, and removes the corrupted file so that subsequent
+// calls are not stuck repeating the same failure.
+func TestLoadAndClearPendingInstances_Corrupted(t *testing.T) {
+	path := setupPendingInstancesDir(t)
+
+	if err := os.WriteFile(path, []byte("this is not json{"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	pending, err := LoadAndClearPendingInstances()
+	if err != nil {
+		t.Fatalf("expected nil error on corrupted file, got %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("expected no pending instances on corrupted file, got %d", len(pending))
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected corrupted pending file to be removed, stat err = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- LoadAndClearPendingInstances returned JSON unmarshal errors from inside the file-lock callback, bailing before os.Remove. A single corrupted write caused permanent failure + log spam every 5 seconds.
- Match appendPendingInstance's recovery shape: log a warning, treat the file as empty, and still remove it.

Closes #269.

## Test plan
- [x] go build ./...
- [x] go test ./task/... (new _Missing / _Valid / _Corrupted tests)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)