### PR TITLE
fix: return error on malformed PR info JSON to preserve cache (#256)

### DIFF
--- a/session/git/github.go
+++ b/session/git/github.go
@@ -36,9 +36,17 @@ func FetchPRInfo(repoPath, branchName string) (*PRInfo, error) {
 		return nil, fmt.Errorf("failed to fetch PR info: %w", err)
 	}
 
+	return parsePRInfo(out)
+}
+
+// parsePRInfo parses the JSON output from `gh pr view`.
+// Returns (nil, nil) only when the output clearly indicates no PR exists
+// (i.e. PR number of 0). On malformed JSON it returns an error so that
+// callers preserve previously cached PR info rather than clearing it.
+func parsePRInfo(out []byte) (*PRInfo, error) {
 	var info PRInfo
 	if err := json.Unmarshal(out, &info); err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("failed to parse PR info JSON: %w", err)
 	}
 	if info.Number == 0 {
 		return nil, nil

--- a/session/git/github_test.go
+++ b/session/git/github_test.go
@@ -1,0 +1,83 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePRInfo(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantInfo   *PRInfo
+		wantErr    bool
+		wantErrSub string
+	}{
+		{
+			name:  "valid PR JSON",
+			input: `{"number":42,"title":"Add feature","url":"https://example.com/pr/42","state":"OPEN"}`,
+			wantInfo: &PRInfo{
+				Number: 42,
+				Title:  "Add feature",
+				URL:    "https://example.com/pr/42",
+				State:  "OPEN",
+			},
+		},
+		{
+			name:     "zero PR number is treated as no PR",
+			input:    `{"number":0,"title":"","url":"","state":""}`,
+			wantInfo: nil,
+		},
+		{
+			name:       "malformed JSON returns error and preserves cache",
+			input:      `not-json-at-all`,
+			wantErr:    true,
+			wantErrSub: "failed to parse PR info JSON",
+		},
+		{
+			name:       "empty output returns error",
+			input:      ``,
+			wantErr:    true,
+			wantErrSub: "failed to parse PR info JSON",
+		},
+		{
+			name:       "truncated JSON returns error",
+			input:      `{"number":42,"title":"Add feat`,
+			wantErr:    true,
+			wantErrSub: "failed to parse PR info JSON",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePRInfo([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (info=%v)", got)
+				}
+				if got != nil {
+					t.Errorf("expected nil PRInfo on error, got %+v", got)
+				}
+				if tc.wantErrSub != "" && !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Errorf("expected error to contain %q, got %q", tc.wantErrSub, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantInfo == nil {
+				if got != nil {
+					t.Errorf("expected nil PRInfo, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected PRInfo %+v, got nil", tc.wantInfo)
+			}
+			if *got != *tc.wantInfo {
+				t.Errorf("expected %+v, got %+v", tc.wantInfo, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- FetchPRInfo returned (nil, nil) on json.Unmarshal failure — same sentinel as "no PR exists" — so malformed gh output silently cleared the cached PR info that callers rely on.
- Return a wrapped error for parse failures; extracted parsePRInfo helper so it's unit-testable without invoking the gh binary.

Closes #256.

## Test plan
- [x] go build ./...
- [x] go test ./session/git/... (new TestParsePRInfo with valid / no-PR / 3 malformed cases)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)