### PR TITLE
fix: verify PID ownership before killing daemon (#264)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -123,7 +124,8 @@ func LaunchDaemon() error {
 }
 
 // StopDaemon attempts to stop a running daemon process if it exists. Returns no error if the daemon is not found
-// (assumes the daemon does not exist).
+// (assumes the daemon does not exist). It verifies the PID actually belongs to an agent-factory daemon before
+// sending a kill signal, so a stale or reused PID in the PID file can't take down an unrelated process.
 func StopDaemon() error {
 	pidDir, err := config.GetConfigDir()
 	if err != nil {
@@ -144,9 +146,34 @@ func StopDaemon() error {
 		return fmt.Errorf("invalid PID file format: %w", err)
 	}
 
+	// Defensively refuse to kill our own process or obviously invalid PIDs.
+	if pid <= 1 || pid == os.Getpid() {
+		log.InfoLog.Printf("daemon PID file contained invalid PID %d; removing stale file", pid)
+		_ = os.Remove(pidFile)
+		return nil
+	}
+
 	proc, err := os.FindProcess(pid)
 	if err != nil {
-		return fmt.Errorf("failed to find daemon process: %w", err)
+		// On unix, FindProcess never returns an error, but handle it defensively anyway.
+		log.InfoLog.Printf("daemon process (PID: %d) not found; removing stale PID file", pid)
+		_ = os.Remove(pidFile)
+		return nil
+	}
+
+	// Check the process exists at all. Signal 0 is a no-op that just validates permissions/existence.
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		log.InfoLog.Printf("daemon process (PID: %d) is not running (%v); removing stale PID file", pid, err)
+		_ = os.Remove(pidFile)
+		return nil
+	}
+
+	// Verify the process is actually an agent-factory daemon before killing it. If we can't verify,
+	// err on the side of caution and treat the PID file as stale rather than killing a random process.
+	if !isAgentFactoryDaemon(pid) {
+		log.InfoLog.Printf("PID %d does not look like an agent-factory daemon; removing stale PID file", pid)
+		_ = os.Remove(pidFile)
+		return nil
 	}
 
 	if err := proc.Kill(); err != nil {
@@ -160,4 +187,44 @@ func StopDaemon() error {
 
 	log.InfoLog.Printf("daemon process (PID: %d) stopped successfully", pid)
 	return nil
+}
+
+// isAgentFactoryDaemon checks whether the process at pid looks like an agent-factory daemon
+// (i.e. its command line contains the --daemon flag). It tries /proc/<pid>/cmdline first (Linux)
+// and falls back to `ps -p <pid> -o args=` (macOS and other unixes). If neither source yields a
+// readable command line, returns false so callers treat the PID as unverified.
+func isAgentFactoryDaemon(pid int) bool {
+	cmdline := readProcCmdline(pid)
+	if cmdline == "" {
+		cmdline = readPsArgs(pid)
+	}
+	if cmdline == "" {
+		return false
+	}
+	return strings.Contains(cmdline, "--daemon")
+}
+
+// readProcCmdline returns the full command line for pid via /proc/<pid>/cmdline (Linux).
+// Returns "" if /proc is unavailable or the file cannot be read.
+func readProcCmdline(pid int) string {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return ""
+	}
+	// /proc/<pid>/cmdline separates args with NUL bytes.
+	return strings.ReplaceAll(strings.TrimRight(string(data), "\x00"), "\x00", " ")
+}
+
+// readPsArgs returns the full command line for pid via `ps -p <pid> -o args=`. This flag set is
+// portable across Linux and macOS.
+func readPsArgs(pid int) string {
+	psPath, err := exec.LookPath("ps")
+	if err != nil {
+		return ""
+	}
+	out, err := exec.Command(psPath, "-p", fmt.Sprintf("%d", pid), "-o", "args=").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1,0 +1,126 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+func TestMain(m *testing.M) {
+	log.Initialize(false)
+	code := m.Run()
+	os.Exit(code)
+}
+
+// processAlive returns true if sending signal 0 to pid succeeds, meaning the process is still
+// running and reachable.
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// TestStopDaemon_DoesNotKillUnrelatedPID verifies that StopDaemon refuses to kill a process whose
+// command line does not match an agent-factory daemon. Regression test for issue #264.
+func TestStopDaemon_DoesNotKillUnrelatedPID(t *testing.T) {
+	// Redirect config dir to a scratch location so we don't touch the user's real daemon.pid.
+	tmpHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
+
+	pidFile := filepath.Join(tmpHome, "daemon.pid")
+
+	// Spawn a long-running process that is NOT an agent-factory daemon.
+	sleepCmd := exec.Command("sleep", "60")
+	if err := sleepCmd.Start(); err != nil {
+		t.Fatalf("failed to start sleep process: %v", err)
+	}
+	victimPID := sleepCmd.Process.Pid
+	defer func() {
+		// Best-effort cleanup regardless of test outcome.
+		_ = sleepCmd.Process.Kill()
+		_, _ = sleepCmd.Process.Wait()
+	}()
+
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", victimPID)), 0644); err != nil {
+		t.Fatalf("failed to write PID file: %v", err)
+	}
+
+	if err := StopDaemon(); err != nil {
+		t.Fatalf("StopDaemon returned error: %v", err)
+	}
+
+	// Give the process a brief moment; if StopDaemon killed it (the bug), it will have exited.
+	time.Sleep(100 * time.Millisecond)
+
+	if !processAlive(victimPID) {
+		t.Fatalf("StopDaemon killed an unrelated process (PID %d); the vulnerability is still present", victimPID)
+	}
+
+	// PID file should have been cleaned up as stale.
+	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
+		t.Fatalf("expected stale PID file to be removed, stat err = %v", err)
+	}
+}
+
+// TestStopDaemon_NoPIDFile verifies StopDaemon succeeds silently when there is no PID file.
+func TestStopDaemon_NoPIDFile(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
+
+	if err := StopDaemon(); err != nil {
+		t.Fatalf("StopDaemon with no PID file should succeed, got: %v", err)
+	}
+}
+
+// TestStopDaemon_NonExistentPID verifies that StopDaemon treats a PID file pointing at a dead
+// process as stale and removes it instead of returning an error or killing a reused PID.
+func TestStopDaemon_NonExistentPID(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
+	pidFile := filepath.Join(tmpHome, "daemon.pid")
+
+	// Use a large PID that we're confident isn't in use. On Linux the default pid_max is 32768
+	// and on macOS it's 99999; 0x7fffffff is well above both.
+	deadPID := 0x7fffffff
+
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", deadPID)), 0644); err != nil {
+		t.Fatalf("failed to write PID file: %v", err)
+	}
+
+	if err := StopDaemon(); err != nil {
+		t.Fatalf("StopDaemon returned error for dead PID: %v", err)
+	}
+
+	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
+		t.Fatalf("expected stale PID file to be removed, stat err = %v", err)
+	}
+}
+
+// TestStopDaemon_RefusesSelfPID verifies that StopDaemon refuses to kill the current test process
+// even if the PID file points at it.
+func TestStopDaemon_RefusesSelfPID(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
+	pidFile := filepath.Join(tmpHome, "daemon.pid")
+
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+		t.Fatalf("failed to write PID file: %v", err)
+	}
+
+	// If StopDaemon killed us, the test binary would exit with signal: killed.
+	if err := StopDaemon(); err != nil {
+		t.Fatalf("StopDaemon returned error: %v", err)
+	}
+
+	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
+		t.Fatalf("expected PID file to be removed, stat err = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- StopDaemon blindly called proc.Kill() on whatever PID lived in daemon.pid; a stale/reused PID could terminate an unrelated process.
- Add isAgentFactoryDaemon(pid): refuse pid<=1 and self; signal(0)-probe existence; verify the command line contains --daemon via /proc/<pid>/cmdline on Linux with a portable `ps` fallback. Stale PID files are cleaned up rather than acted on.

Closes #264.

## Test plan
- [x] go build ./...
- [x] go test ./daemon/... (regression test TestStopDaemon_DoesNotKillUnrelatedPID + 3 sibling tests)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)