### PR TITLE
fix: handle POSIX quote escape idiom in getBaseCommand (#254)

### DIFF
--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -35,14 +35,32 @@ func getBaseCommand(program string) string {
 	}
 
 	var cmd string
-	// Handle single-quoted paths
+	// Handle single-quoted paths. Embedded single quotes are escaped using the
+	// POSIX idiom '\'' (close quote, escaped literal quote, reopen quote), so
+	// scan for a closing quote that is NOT part of a '\'' escape sequence.
 	if program[0] == '\'' {
-		end := strings.Index(program[1:], "'")
+		end := -1
+		for i := 1; i < len(program); i++ {
+			if program[i] != '\'' {
+				continue
+			}
+			// Check for the '\'' escape idiom: current ' followed by \'' —
+			// i.e. program[i..i+3] == "'\\''". Advance past the whole 4-byte
+			// sequence so the reopening quote is not mistaken for the closer.
+			if i+3 < len(program) && program[i+1] == '\\' && program[i+2] == '\'' && program[i+3] == '\'' {
+				i += 3
+				continue
+			}
+			end = i
+			break
+		}
 		if end >= 0 {
-			cmd = program[1 : end+1]
+			cmd = program[1:end]
 		} else {
 			cmd = program[1:]
 		}
+		// Unescape '\'' sequences back to a literal ' so filepath.Base works.
+		cmd = strings.ReplaceAll(cmd, "'\\''", "'")
 	} else if program[0] == '"' {
 		end := strings.Index(program[1:], "\"")
 		if end >= 0 {

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -165,11 +165,44 @@ func TestGetBaseCommand(t *testing.T) {
 		{"/usr/bin/codex", "codex"},
 		{"", ""},
 		{"Claude", "claude"},
+		// Single-quoted path (config.go quotes paths containing spaces).
+		{"'/home/user/my apps/claude'", "claude"},
+		{"'/home/user/my apps/claude' --model opus", "claude"},
+		// POSIX escape idiom '\'' for an embedded apostrophe inside a
+		// single-quoted path. Regression test for issue #254.
+		{"'/home/user/o'\\''brien/my apps/claude'", "claude"},
+		{"'/home/user/o'\\''brien/my apps/claude' --model opus", "claude"},
+		{"'/home/user/o'\\''brien/codex'", "codex"},
+		// Double-quoted path.
+		{"\"/home/user/my apps/claude\"", "claude"},
 	}
 	for _, tt := range tests {
 		got := getBaseCommand(tt.input)
 		if got != tt.expected {
 			t.Errorf("getBaseCommand(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+// TestGetBaseCommand_RoundTripWithShellQuote verifies that getBaseCommand
+// correctly parses output from shellQuote (same quoting format used by
+// config.go for paths with spaces), including paths with embedded apostrophes.
+func TestGetBaseCommand_RoundTripWithShellQuote(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"/home/user/my apps/claude", "claude"},
+		{"/home/user/o'brien/my apps/claude", "claude"},
+		{"/home/user/o'brien/codex", "codex"},
+		{"/plain/claude", "claude"},
+	}
+	for _, tt := range tests {
+		quoted := shellQuote(tt.path)
+		got := getBaseCommand(quoted)
+		if got != tt.expected {
+			t.Errorf("getBaseCommand(shellQuote(%q)) = getBaseCommand(%q) = %q, want %q",
+				tt.path, quoted, got, tt.expected)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- config/config.go shell-quotes program paths with the POSIX `'\''` idiom for embedded apostrophes, but session/systemprompt.go's getBaseCommand used `strings.Index` to find the closing `'` — matching the middle quote of the escape sequence. A path like `/home/user/o'brien/.../claude` was truncated to `o`, so plugin flags weren't injected.
- Scan for the closing quote while skipping the 4-byte `'\''` escape sequence, then replace `'\''` back to a literal `'` before filepath.Base.

Closes #254.

## Test plan
- [x] go build ./...
- [x] go test ./session/... (TestGetBaseCommand extended + new round-trip with shellQuote)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)