### PR TITLE
fix: forward non-error tea.Msg from confirmation action to event loop (#259)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -101,6 +101,10 @@ type home struct {
 	textOverlay *overlay.TextOverlay
 	// confirmationOverlay displays confirmation modals
 	confirmationOverlay *overlay.ConfirmationOverlay
+	// pendingConfirmMsg holds a non-error tea.Msg returned by a confirmation
+	// action so that handleStateConfirm can forward it to the Bubble Tea
+	// event loop after OnConfirm runs.
+	pendingConfirmMsg tea.Msg
 	// selectionOverlay handles worktree selection
 	selectionOverlay *overlay.SelectionOverlay
 	// searchOverlay handles session search
@@ -782,6 +786,10 @@ func (m *home) confirmAction(message string, action tea.Cmd) tea.Cmd {
 				if err, ok := msg.(error); ok {
 					log.ErrorLog.Printf("confirmation action failed: %v", err)
 					m.errBox.SetError(err)
+				} else {
+					// Stash non-error messages so handleStateConfirm can
+					// forward them into the Bubble Tea event loop.
+					m.pendingConfirmMsg = msg
 				}
 			}
 		}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -437,6 +437,85 @@ func TestMultipleConfirmationsDontInterfere(t *testing.T) {
 	assert.True(t, action1Called, "First action should be callable after being replaced")
 }
 
+// TestConfirmActionForwardsNonErrorMsg verifies that a non-error tea.Msg returned
+// by a confirmation action (e.g. instanceChangedMsg{}) is forwarded back into the
+// Bubble Tea event loop so its handler runs (e.g. selectionChanged updating the
+// content pane after a session is killed). Regression test for #259.
+func TestConfirmActionForwardsNonErrorMsg(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	sidebar := ui.NewSidebar(&spin, false)
+	tw := ui.NewTabbedWindow(ui.NewPreviewPane(), ui.NewTerminalPane())
+	cp := ui.NewContentPane(tw)
+
+	h := &home{
+		ctx:         context.Background(),
+		state:       stateDefault,
+		appConfig:   config.DefaultConfig(),
+		sidebar:     sidebar,
+		contentPane: cp,
+		menu:        ui.NewMenu(),
+		errBox:      ui.NewErrBox(),
+	}
+
+	// Build an action mirroring killAction: returns instanceChangedMsg{} on success.
+	actionCalled := false
+	action := func() tea.Msg {
+		actionCalled = true
+		return instanceChangedMsg{}
+	}
+
+	// Trigger the confirmation flow.
+	_ = h.confirmAction("Kill session 'test'?", action)
+	require.Equal(t, stateConfirm, h.state)
+	require.NotNil(t, h.confirmationOverlay)
+
+	// Simulate pressing 'y' to confirm. handleStateConfirm should now return
+	// a command that emits the instanceChangedMsg back to the event loop.
+	confirmKey := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")}
+	_, cmd := h.handleStateConfirm(confirmKey)
+
+	assert.True(t, actionCalled, "confirmation action should have run")
+	assert.Equal(t, stateDefault, h.state)
+	assert.Nil(t, h.confirmationOverlay)
+	assert.Nil(t, h.pendingConfirmMsg, "pending msg should be consumed after forwarding")
+	require.NotNil(t, cmd, "handleStateConfirm must return a tea.Cmd that forwards instanceChangedMsg")
+
+	// Execute the returned command and confirm it emits instanceChangedMsg.
+	msg := cmd()
+	_, ok := msg.(instanceChangedMsg)
+	assert.True(t, ok, "expected instanceChangedMsg, got %T", msg)
+
+	// Feed the message into Update to confirm the main event loop routes it to
+	// selectionChanged (which manipulates the sidebar/content pane, verifying
+	// the message really reaches its handler without panicking).
+	_, updateCmd := h.Update(msg)
+	_ = updateCmd // selectionChanged returns nil when no instance is selected
+}
+
+// TestConfirmActionErrorStillRecorded verifies that error returns from the
+// confirmation action still reach the error box and do NOT get forwarded as
+// a regular tea.Msg.
+func TestConfirmActionErrorStillRecorded(t *testing.T) {
+	h := &home{
+		ctx:       context.Background(),
+		state:     stateDefault,
+		appConfig: config.DefaultConfig(),
+		errBox:    ui.NewErrBox(),
+	}
+
+	expectedErr := fmt.Errorf("boom")
+	action := func() tea.Msg { return expectedErr }
+
+	_ = h.confirmAction("Do thing?", action)
+	confirmKey := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")}
+	_, cmd := h.handleStateConfirm(confirmKey)
+
+	// Errors are handled inline (recorded in errBox); no tea.Cmd should be returned.
+	assert.Nil(t, cmd, "errors should not be forwarded as tea.Msg")
+	assert.Nil(t, h.pendingConfirmMsg)
+	assert.Equal(t, stateDefault, h.state)
+}
+
 // TestConfirmationModalVisualAppearance tests that confirmation modal has distinct visual appearance
 func TestConfirmationModalVisualAppearance(t *testing.T) {
 	h := &home{

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -87,6 +87,13 @@ func (m *home) handleStateConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.state = stateDefault
 		}
 		m.confirmationOverlay = nil
+		// Forward any non-error tea.Msg returned by the confirmation
+		// action (e.g. instanceChangedMsg{}) back into the Bubble Tea
+		// event loop so its handler can run (e.g. selectionChanged).
+		if pending := m.pendingConfirmMsg; pending != nil {
+			m.pendingConfirmMsg = nil
+			return m, func() tea.Msg { return pending }
+		}
 		return m, nil
 	}
 	return m, nil


### PR DESCRIPTION
## Summary
- confirmAction's OnConfirm callback only handled error returns from action(). Non-error tea.Msg values — specifically killAction's instanceChangedMsg{} — were silently dropped, so selectionChanged() never fired and the UI didn't refresh after destructive actions.
- Stash non-error tea.Msg on home.pendingConfirmMsg; handleStateConfirm returns a tea.Cmd emitting that message after the overlay closes, so the main Bubble Tea loop dispatches it to the existing case instanceChangedMsg handler.

Closes #259.

## Test plan
- [x] go build ./...
- [x] go test ./app/... (new TestConfirmActionForwardsNonErrorMsg + error-path regression)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)