### PR TITLE
fix: clean worktrees across all repos during af reset (#265)

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,17 +113,37 @@ var (
 			}
 			fmt.Println("Tmux sessions have been cleaned up")
 
-			if err := git.CleanupWorktrees(); err != nil {
-				return fmt.Errorf("failed to cleanup worktrees: %w", err)
-			}
-			fmt.Println("Worktrees have been cleaned up")
-
-			// Delete storage last, after resources are cleaned up
+			// Clean worktrees across ALL repos with stored instances, not
+			// just the current repo. Storage is global (DeleteAllInstances
+			// removes records for every repo), so worktree cleanup must match
+			// that scope — otherwise repos we don't run reset from are left
+			// with orphaned worktrees/branches (issue #265).
 			state := config.LoadState()
 			storage, err := session.NewStorage(state, "")
 			if err != nil {
 				return fmt.Errorf("failed to initialize storage: %w", err)
 			}
+
+			repoRoots, err := storage.CollectRepoRoots()
+			if err != nil {
+				return fmt.Errorf("failed to collect repo roots: %w", err)
+			}
+			// Ensure the current repo (if any) is cleaned even when it has
+			// no stored instances, matching prior behavior.
+			if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+				if root, rerr := config.ResolveMainRepoRoot(cwd); rerr == nil {
+					repoRoots[root] = struct{}{}
+				}
+			}
+
+			for root := range repoRoots {
+				if err := git.CleanupWorktreesForRepo(root); err != nil {
+					return fmt.Errorf("failed to cleanup worktrees for %s: %w", root, err)
+				}
+			}
+			fmt.Println("Worktrees have been cleaned up")
+
+			// Delete storage last, after resources are cleaned up
 			if err := storage.DeleteAllInstances(); err != nil {
 				return fmt.Errorf("failed to reset storage: %w", err)
 			}

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -206,7 +206,8 @@ func (g *GitWorktree) Prune() error {
 	return nil
 }
 
-// CleanupWorktrees removes all worktrees and their associated branches
+// CleanupWorktrees removes all worktrees and their associated branches for
+// the git repo containing the current working directory.
 func CleanupWorktrees() error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -216,6 +217,18 @@ func CleanupWorktrees() error {
 	repoRoot, err := findGitRepoRoot(cwd)
 	if err != nil {
 		return fmt.Errorf("failed to find git repo root: %w", err)
+	}
+
+	return CleanupWorktreesForRepo(repoRoot)
+}
+
+// CleanupWorktreesForRepo removes all worktrees and their associated branches
+// for the given repo root. The main worktree (the repo itself) is preserved.
+// The repoRoot must be the main repo path; callers should resolve linked
+// worktree paths to the main repo root before invoking this function.
+func CleanupWorktreesForRepo(repoRoot string) error {
+	if repoRoot == "" {
+		return fmt.Errorf("repo root is empty")
 	}
 
 	// List all worktrees from the repo

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -336,3 +336,64 @@ func createGitRepo(t *testing.T) string {
 
 	return repoRoot
 }
+
+// TestCleanupWorktreesForRepo_RejectsEmpty verifies the exported helper does
+// not silently operate on the cwd when given an empty repo root.
+func TestCleanupWorktreesForRepo_RejectsEmpty(t *testing.T) {
+	err := CleanupWorktreesForRepo("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repo root is empty")
+}
+
+// TestCleanupWorktreesForRepo_CleansGivenRepo verifies that
+// CleanupWorktreesForRepo targets the repo it is given — regardless of the
+// process's current working directory. This is the core of the #265 fix:
+// `af reset` must be able to clean worktrees in repos OTHER than the cwd.
+func TestCleanupWorktreesForRepo_CleansGivenRepo(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	// Build a repo, make an initial commit, and add a linked worktree.
+	repoRoot := createGitRepo(t)
+	env := append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	commitCmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "init")
+	commitCmd.Env = env
+	out, err := commitCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	linkedPath := filepath.Join(filepath.Dir(repoRoot), "linked-wt")
+	addCmd := exec.Command("git", "-C", repoRoot, "worktree", "add", "-b", "linked-branch", linkedPath)
+	addCmd.Env = env
+	out, err = addCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	// Sanity: the linked worktree is on disk and known to git.
+	_, err = os.Stat(linkedPath)
+	require.NoError(t, err)
+
+	// Run cleanup targeting this repo EXPLICITLY. We do not chdir, so if
+	// the helper were derived from cwd (the old behavior) it would not
+	// touch this repo at all.
+	require.NoError(t, CleanupWorktreesForRepo(repoRoot))
+
+	// The linked worktree directory should have been removed.
+	if _, statErr := os.Stat(linkedPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected linked worktree to be removed; got stat err: %v", statErr)
+	}
+
+	// The linked branch should have been deleted.
+	branchCmd := exec.Command("git", "-C", repoRoot, "branch", "--list", "linked-branch")
+	out, err = branchCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Empty(t, strings.TrimSpace(string(out)), "linked branch should be deleted")
+
+	// Only the main worktree should remain.
+	listCmd := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain")
+	out, err = listCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Equal(t, 1, strings.Count(string(out), "worktree "),
+		"only the main worktree should remain, got:\n%s", string(out))
+}

--- a/session/storage.go
+++ b/session/storage.go
@@ -293,3 +293,38 @@ func (s *Storage) LoadInstanceData() ([]InstanceData, error) {
 func (s *Storage) DeleteAllInstances() error {
 	return s.state.DeleteAllInstances()
 }
+
+// CollectRepoRoots returns the set of unique repo root paths referenced by
+// stored instances across all repos. This is used by operations whose scope
+// must span every repo with persisted state (e.g. `af reset` cleaning
+// worktrees in all repos before deleting global instance storage).
+//
+// Instances without a usable repo path (e.g. certain remote backends where
+// Worktree.RepoPath is empty and Path is not a local filesystem path) are
+// skipped. Callers should treat the result as best-effort.
+func (s *Storage) CollectRepoRoots() (map[string]struct{}, error) {
+	roots := make(map[string]struct{})
+	allJSON := s.state.GetAllInstances()
+	for _, jsonData := range allJSON {
+		if jsonData == nil || string(jsonData) == "[]" || string(jsonData) == "null" {
+			continue
+		}
+		var instancesData []InstanceData
+		if err := json.Unmarshal(jsonData, &instancesData); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal instances: %w", err)
+		}
+		for _, data := range instancesData {
+			// Prefer the worktree's repo path; fall back to the
+			// instance path (the repo the instance was created in).
+			root := data.Worktree.RepoPath
+			if root == "" {
+				root = data.Path
+			}
+			if root == "" {
+				continue
+			}
+			roots[root] = struct{}{}
+		}
+	}
+	return roots, nil
+}

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -297,3 +297,78 @@ func TestDaemonSaveNoInstances(t *testing.T) {
 	err = storage.SaveInstances([]*Instance{})
 	require.NoError(t, err)
 }
+
+// TestCollectRepoRoots verifies that Storage.CollectRepoRoots returns the
+// unique set of repo roots from stored instances across ALL repos. This
+// underpins the fix for #265 (af reset must clean worktrees in every repo
+// whose instance storage will be deleted, not just the current repo).
+func TestCollectRepoRoots(t *testing.T) {
+	const repoA = "/tmp/repo-a"
+	const repoB = "/tmp/repo-b"
+	const repoC = "/tmp/repo-c"
+	ms := newMockStorage()
+
+	// Repo A: two instances, both with Worktree.RepoPath set.
+	seedDisk(t, ms, repoA, []InstanceData{
+		{Title: "a1", Path: repoA, Worktree: GitWorktreeData{RepoPath: repoA}},
+		{Title: "a2", Path: repoA, Worktree: GitWorktreeData{RepoPath: repoA}},
+	})
+	// Repo B: one instance with Worktree.RepoPath set.
+	seedDisk(t, ms, repoB, []InstanceData{
+		{Title: "b1", Path: repoB, Worktree: GitWorktreeData{RepoPath: repoB}},
+	})
+	// Repo C: instance with empty Worktree.RepoPath (e.g. remote backend);
+	// should fall back to Path.
+	seedDisk(t, ms, repoC, []InstanceData{
+		{Title: "c1", Path: repoC},
+	})
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	roots, err := storage.CollectRepoRoots()
+	require.NoError(t, err)
+
+	assert.Len(t, roots, 3, "should collect one entry per unique repo root")
+	assert.Contains(t, roots, repoA)
+	assert.Contains(t, roots, repoB)
+	assert.Contains(t, roots, repoC)
+}
+
+// TestCollectRepoRootsEmpty verifies the helper returns an empty set when
+// there are no stored instances.
+func TestCollectRepoRootsEmpty(t *testing.T) {
+	ms := newMockStorage()
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	roots, err := storage.CollectRepoRoots()
+	require.NoError(t, err)
+	assert.Empty(t, roots)
+}
+
+// TestCollectRepoRootsSkipsEmpty verifies that instances with neither a
+// Worktree.RepoPath nor a Path are skipped rather than producing an empty
+// string entry.
+func TestCollectRepoRootsSkipsEmpty(t *testing.T) {
+	const repoA = "/tmp/repo-a"
+	ms := newMockStorage()
+
+	// One usable instance and one with no usable repo info.
+	seedDisk(t, ms, repoA, []InstanceData{
+		{Title: "a1", Path: repoA, Worktree: GitWorktreeData{RepoPath: repoA}},
+		{Title: "ghost"},
+	})
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	roots, err := storage.CollectRepoRoots()
+	require.NoError(t, err)
+
+	assert.Len(t, roots, 1)
+	assert.Contains(t, roots, repoA)
+	_, hasEmpty := roots[""]
+	assert.False(t, hasEmpty, "empty repo root should be skipped")
+}


### PR DESCRIPTION
## Summary
- af reset wiped storage for ALL repos via DeleteAllInstances() but only cleaned git worktrees for the current repo via CleanupWorktrees(), leaving orphaned worktrees/branches in other repos whose storage was just deleted.
- Add Storage.CollectRepoRoots() to enumerate every repo with persisted instances and session/git.CleanupWorktreesForRepo(repoRoot) that accepts an explicit repo root. resetCmd now iterates all known repo roots (plus the cwd repo) before calling DeleteAllInstances.

Closes #265.

## Test plan
- [x] go build ./...
- [x] go test ./... (new TestCollectRepoRoots* + TestCleanupWorktreesForRepo_*)
- [x] gofmt -l . clean
- [x] golangci-lint --fast clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)