### PR TITLE
fix: reconcile systemd scheduler in CLI tasks update (#258)

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -18,6 +18,12 @@ var TasksCmd = &cobra.Command{
 	Short: "Manage tasks",
 }
 
+// Indirected so tests can stub out scheduler side effects.
+var (
+	installScheduler = task.InstallScheduler
+	removeScheduler  = task.RemoveScheduler
+)
+
 var tasksListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List tasks",
@@ -100,7 +106,7 @@ var tasksAddCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("failed to add task: %w", err))
 		}
 
-		if err := task.InstallScheduler(s); err != nil {
+		if err := installScheduler(s); err != nil {
 			// Rollback: remove the task we just added
 			if removeErr := task.RemoveTask(s.ID); removeErr != nil {
 				log.ErrorLog.Printf("failed to rollback task after scheduler install failure: %v", removeErr)
@@ -125,7 +131,7 @@ var tasksRemoveCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("failed to get task: %w", err))
 		}
 
-		if err := task.RemoveScheduler(*s); err != nil {
+		if err := removeScheduler(*s); err != nil {
 			return jsonError(fmt.Errorf("failed to remove task scheduler: %w", err))
 		}
 
@@ -206,10 +212,18 @@ var tasksUpdateCmd = &cobra.Command{
 			cronChanged = true
 		}
 
+		enabledChanged := false
+		wasEnabled := s.Enabled
 		switch taskUpdateEnabledFlag {
 		case "true":
+			if !s.Enabled {
+				enabledChanged = true
+			}
 			s.Enabled = true
 		case "false":
+			if s.Enabled {
+				enabledChanged = true
+			}
 			s.Enabled = false
 		case "":
 			// not changed
@@ -217,28 +231,38 @@ var tasksUpdateCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("--enabled must be 'true' or 'false'"))
 		}
 
-		// When the cron expression changes, install the new scheduler
-		// *before* persisting the update so that a failed install doesn't
-		// leave the task unscheduled (fixes #160).
-		if cronChanged {
-			oldCron := ""
-			if old, err := task.GetTask(s.ID); err == nil {
-				oldCron = old.CronExpr
-			}
-
-			// Install the new scheduler (overwrites existing unit/plist
-			// because the scheduler key is the task ID).
-			if err := task.InstallScheduler(*s); err != nil {
-				// Installation failed — attempt to re-install the old
-				// scheduler so the task doesn't end up unscheduled.
-				if oldCron != "" {
-					rollback := *s
-					rollback.CronExpr = oldCron
-					if rbErr := task.InstallScheduler(rollback); rbErr != nil {
-						log.ErrorLog.Printf("failed to rollback scheduler to old cron %q: %v", oldCron, rbErr)
-					}
+		// Reconcile scheduler state whenever the cron expression or the
+		// Enabled flag changes. When the task is disabled we always remove
+		// the scheduler (even if cron changed), so a disabled task never
+		// has an active timer. When enabled we (re)install the scheduler
+		// with the new cron. See #258.
+		if cronChanged || enabledChanged {
+			if s.Enabled {
+				oldCron := ""
+				if old, err := task.GetTask(s.ID); err == nil {
+					oldCron = old.CronExpr
 				}
-				return jsonError(fmt.Errorf("failed to reinstall scheduler: %w", err))
+
+				// Install the new scheduler (overwrites existing unit/plist
+				// because the scheduler key is the task ID).
+				if err := installScheduler(*s); err != nil {
+					// Installation failed — attempt to re-install the old
+					// scheduler so the task doesn't end up unscheduled
+					// (fixes #160). Only meaningful if the task was already
+					// enabled with a previous cron.
+					if oldCron != "" && wasEnabled {
+						rollback := *s
+						rollback.CronExpr = oldCron
+						if rbErr := installScheduler(rollback); rbErr != nil {
+							log.ErrorLog.Printf("failed to rollback scheduler to old cron %q: %v", oldCron, rbErr)
+						}
+					}
+					return jsonError(fmt.Errorf("failed to reinstall scheduler: %w", err))
+				}
+			} else {
+				if err := removeScheduler(*s); err != nil {
+					return jsonError(fmt.Errorf("failed to remove task scheduler: %w", err))
+				}
 			}
 		}
 

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -1,0 +1,202 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/task"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// schedulerCalls tracks stubbed invocations of the scheduler helpers so
+// tests can assert that `af tasks update` reconciles systemd state
+// correctly (see #258).
+type schedulerCalls struct {
+	installed []task.Task
+	removed   []task.Task
+}
+
+// stubSchedulers swaps installScheduler/removeScheduler for in-memory
+// stubs and restores them on test cleanup.
+func stubSchedulers(t *testing.T) *schedulerCalls {
+	t.Helper()
+	calls := &schedulerCalls{}
+
+	origInstall := installScheduler
+	origRemove := removeScheduler
+	installScheduler = func(tsk task.Task) error {
+		calls.installed = append(calls.installed, tsk)
+		return nil
+	}
+	removeScheduler = func(tsk task.Task) error {
+		calls.removed = append(calls.removed, tsk)
+		return nil
+	}
+	t.Cleanup(func() {
+		installScheduler = origInstall
+		removeScheduler = origRemove
+	})
+	return calls
+}
+
+// useTempConfig redirects AGENT_FACTORY_HOME to a temp dir so task
+// persistence is isolated per-test.
+func useTempConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+}
+
+// resetUpdateFlags clears the package-level update flag variables so
+// tests don't leak state into each other.
+func resetUpdateFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		taskUpdateNameFlag = ""
+		taskUpdatePromptFlag = ""
+		taskUpdateCronFlag = ""
+		taskUpdateEnabledFlag = ""
+	})
+	taskUpdateNameFlag = ""
+	taskUpdatePromptFlag = ""
+	taskUpdateCronFlag = ""
+	taskUpdateEnabledFlag = ""
+}
+
+// seedTask persists a single task for update tests.
+func seedTask(t *testing.T, tsk task.Task) {
+	t.Helper()
+	require.NoError(t, task.AddTask(tsk))
+}
+
+func TestTasksUpdate_DisableRemovesScheduler(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubSchedulers(t)
+
+	seedTask(t, task.Task{ID: "t1", CronExpr: "0 9 * * *", Enabled: true})
+
+	taskUpdateEnabledFlag = "false"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t1"})
+	require.NoError(t, err)
+
+	assert.Empty(t, calls.installed, "disable should not install scheduler")
+	require.Len(t, calls.removed, 1, "disable should remove scheduler")
+	assert.Equal(t, "t1", calls.removed[0].ID)
+
+	got, err := task.GetTask("t1")
+	require.NoError(t, err)
+	assert.False(t, got.Enabled)
+}
+
+func TestTasksUpdate_EnableInstallsScheduler(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubSchedulers(t)
+
+	seedTask(t, task.Task{ID: "t2", CronExpr: "0 9 * * *", Enabled: false})
+
+	taskUpdateEnabledFlag = "true"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t2"})
+	require.NoError(t, err)
+
+	assert.Empty(t, calls.removed, "enable should not remove scheduler")
+	require.Len(t, calls.installed, 1, "enable should install scheduler")
+	assert.Equal(t, "t2", calls.installed[0].ID)
+	assert.True(t, calls.installed[0].Enabled)
+
+	got, err := task.GetTask("t2")
+	require.NoError(t, err)
+	assert.True(t, got.Enabled)
+}
+
+func TestTasksUpdate_CronChangeOnDisabledTaskRemovesScheduler(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubSchedulers(t)
+
+	seedTask(t, task.Task{ID: "t3", CronExpr: "0 9 * * *", Enabled: false})
+
+	taskUpdateCronFlag = "0 10 * * *"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t3"})
+	require.NoError(t, err)
+
+	assert.Empty(t, calls.installed, "cron change on disabled task must not install scheduler")
+	require.Len(t, calls.removed, 1, "cron change on disabled task should remove scheduler")
+
+	got, err := task.GetTask("t3")
+	require.NoError(t, err)
+	assert.Equal(t, "0 10 * * *", got.CronExpr)
+	assert.False(t, got.Enabled)
+}
+
+func TestTasksUpdate_CronChangeWithDisableRemovesScheduler(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubSchedulers(t)
+
+	seedTask(t, task.Task{ID: "t4", CronExpr: "0 9 * * *", Enabled: true})
+
+	taskUpdateCronFlag = "0 10 * * *"
+	taskUpdateEnabledFlag = "false"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t4"})
+	require.NoError(t, err)
+
+	assert.Empty(t, calls.installed, "simultaneous cron change + disable must not install scheduler")
+	require.Len(t, calls.removed, 1, "simultaneous cron change + disable should remove scheduler")
+
+	got, err := task.GetTask("t4")
+	require.NoError(t, err)
+	assert.Equal(t, "0 10 * * *", got.CronExpr)
+	assert.False(t, got.Enabled)
+}
+
+func TestTasksUpdate_CronChangeOnEnabledTaskInstallsScheduler(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubSchedulers(t)
+
+	seedTask(t, task.Task{ID: "t5", CronExpr: "0 9 * * *", Enabled: true})
+
+	taskUpdateCronFlag = "0 10 * * *"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t5"})
+	require.NoError(t, err)
+
+	assert.Empty(t, calls.removed, "cron change on enabled task should not remove scheduler")
+	require.Len(t, calls.installed, 1, "cron change on enabled task should install scheduler")
+	assert.Equal(t, "0 10 * * *", calls.installed[0].CronExpr)
+}
+
+func TestTasksUpdate_NameOnlyChangeDoesNotTouchScheduler(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubSchedulers(t)
+
+	seedTask(t, task.Task{ID: "t6", Name: "old", CronExpr: "0 9 * * *", Enabled: true})
+
+	taskUpdateNameFlag = "new"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t6"})
+	require.NoError(t, err)
+
+	assert.Empty(t, calls.installed, "name-only change should not install scheduler")
+	assert.Empty(t, calls.removed, "name-only change should not remove scheduler")
+
+	got, err := task.GetTask("t6")
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.Name)
+}
+
+func TestTasksUpdate_EnabledToggleNoOpWhenAlreadyEnabled(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubSchedulers(t)
+
+	seedTask(t, task.Task{ID: "t7", CronExpr: "0 9 * * *", Enabled: true})
+
+	taskUpdateEnabledFlag = "true"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t7"})
+	require.NoError(t, err)
+
+	assert.Empty(t, calls.installed, "setting enabled=true on already-enabled task should be a no-op")
+	assert.Empty(t, calls.removed)
+}


### PR DESCRIPTION
## Summary
- af tasks update didn't reconcile the systemd scheduler when --enabled toggled (disabled tasks kept running), and unconditionally called InstallScheduler on cron changes — even when --enabled=false (installing a timer for a disabled task).
- Track enabledChanged (only true when the flag flips stored value). When cron or enabled changes: if s.Enabled, install; else remove. Rollback of a failed install now runs only when the previous state was enabled.
- Introduce package-level installScheduler/removeScheduler vars so the reconciliation is unit-testable.

Closes #258.

## Test plan
- [x] go build ./...
- [x] go test ./api/... (7 new TestTasksUpdate_* covering enable/disable/cron×enabled interactions)
- [x] gofmt -l . clean
- [x] golangci-lint --fast clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)