### PR TITLE
fix: replace sidebar instance when pending worktree differs on rerun (#255)

### DIFF
--- a/app/sync.go
+++ b/app/sync.go
@@ -69,20 +69,23 @@ func (m *home) mergePendingInstances() int {
 			continue
 		}
 
-		// If an entry with the same title already exists in the sidebar, replace
-		// it only if the existing instance is dead (tmux gone). If it's still
-		// alive, skip the new pending instance to avoid creating a duplicate.
+		// If an entry with the same title already exists in the sidebar, decide
+		// whether to replace it or skip the pending instance. A scheduled task
+		// rerun may recreate the same tmux session name under a different
+		// worktree path (worktrees gain a numeric suffix on collision), so we
+		// cannot rely on TmuxAlive() alone to tell whether the sidebar
+		// instance still reflects the pending one.
 		if sidebarTitles[data.Title] {
 			skip := false
 			for _, existing := range m.sidebar.GetInstances() {
 				if existing.Title != data.Title {
 					continue
 				}
-				if existing.TmuxAlive() {
+				if pendingInstanceCollisionShouldSkip(existing.GetWorktreePath(), data.Worktree.WorktreePath, existing.TmuxAlive()) {
 					log.WarningLog.Printf("skipping pending instance %q: already exists and is alive", data.Title)
 					skip = true
 				} else {
-					log.InfoLog.Printf("replacing dead instance %q with new pending instance", data.Title)
+					log.InfoLog.Printf("replacing stale instance %q with new pending instance", data.Title)
 					m.sidebar.RemoveInstanceByTitle(data.Title)
 					delete(sidebarTitles, data.Title)
 				}
@@ -192,4 +195,22 @@ func (m *home) refreshExternalInstances() bool {
 	}
 
 	return changed
+}
+
+// pendingInstanceCollisionShouldSkip decides whether to skip a pending
+// instance when an instance with the same title already exists in the
+// sidebar. It returns true when the pending instance should be skipped
+// (sidebar instance is still valid), false when the sidebar instance is
+// stale and should be replaced.
+//
+// If both worktree paths are known and differ, the sidebar instance is
+// stale regardless of TmuxAlive() — a scheduled task rerun creates a new
+// worktree with a numeric suffix and a tmux session with the same name,
+// so TmuxAlive() would incorrectly report the sidebar instance as live.
+// Otherwise, fall back to the tmuxAlive signal.
+func pendingInstanceCollisionShouldSkip(existingWorktreePath, pendingWorktreePath string, tmuxAlive bool) bool {
+	if existingWorktreePath != "" && pendingWorktreePath != "" && existingWorktreePath != pendingWorktreePath {
+		return false
+	}
+	return tmuxAlive
 }

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -1,0 +1,81 @@
+package app
+
+import (
+	"testing"
+)
+
+// TestPendingInstanceCollisionShouldSkip covers the decision logic used by
+// mergePendingInstances when a scheduled-task rerun produces a pending
+// instance whose title collides with an existing sidebar instance. See
+// issue #255: a rerun recreates the same tmux session name under a new
+// worktree path, so TmuxAlive() alone cannot tell whether the sidebar
+// instance is still valid.
+func TestPendingInstanceCollisionShouldSkip(t *testing.T) {
+	cases := []struct {
+		name             string
+		existingWorktree string
+		pendingWorktree  string
+		tmuxAlive        bool
+		wantSkip         bool
+	}{
+		{
+			name:             "worktree paths differ and tmux alive -> replace (issue #255)",
+			existingWorktree: "/repo/worktrees/task",
+			pendingWorktree:  "/repo/worktrees/task-2",
+			tmuxAlive:        true,
+			wantSkip:         false,
+		},
+		{
+			name:             "worktree paths differ and tmux dead -> replace",
+			existingWorktree: "/repo/worktrees/task",
+			pendingWorktree:  "/repo/worktrees/task-2",
+			tmuxAlive:        false,
+			wantSkip:         false,
+		},
+		{
+			name:             "worktree paths match and tmux alive -> skip",
+			existingWorktree: "/repo/worktrees/task",
+			pendingWorktree:  "/repo/worktrees/task",
+			tmuxAlive:        true,
+			wantSkip:         true,
+		},
+		{
+			name:             "worktree paths match and tmux dead -> replace",
+			existingWorktree: "/repo/worktrees/task",
+			pendingWorktree:  "/repo/worktrees/task",
+			tmuxAlive:        false,
+			wantSkip:         false,
+		},
+		{
+			name:             "existing worktree unknown and tmux alive -> skip",
+			existingWorktree: "",
+			pendingWorktree:  "/repo/worktrees/task",
+			tmuxAlive:        true,
+			wantSkip:         true,
+		},
+		{
+			name:             "pending worktree unknown and tmux alive -> skip",
+			existingWorktree: "/repo/worktrees/task",
+			pendingWorktree:  "",
+			tmuxAlive:        true,
+			wantSkip:         true,
+		},
+		{
+			name:             "both worktrees unknown and tmux dead -> replace",
+			existingWorktree: "",
+			pendingWorktree:  "",
+			tmuxAlive:        false,
+			wantSkip:         false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pendingInstanceCollisionShouldSkip(tc.existingWorktree, tc.pendingWorktree, tc.tmuxAlive)
+			if got != tc.wantSkip {
+				t.Fatalf("pendingInstanceCollisionShouldSkip(%q, %q, %v) = %v; want %v",
+					tc.existingWorktree, tc.pendingWorktree, tc.tmuxAlive, got, tc.wantSkip)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- mergePendingInstances skipped colliding pending instances based solely on existing.TmuxAlive(). Because tmux session names are deterministic per (title, repoPath) but worktree paths gain a numeric suffix on collision, a scheduled task rerun after its tmux session was killed externally created a new worktree (...-2) yet found TmuxAlive()=true on the new session — so the pending instance was silently skipped, leaving the sidebar pointing at the stale worktree.
- Also compare existing.GetWorktreePath() with data.Worktree.WorktreePath. When both are known and differ, replace the sidebar instance regardless of TmuxAlive(). Extracted the decision into a pure helper for testability.

Closes #255.

## Test plan
- [x] go build ./...
- [x] go test ./app/... (new TestPendingInstanceCollisionShouldSkip — 7 subcases covering paths differ/match/unknown × tmux alive/dead)
- [x] gofmt -l . clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)