### PR TITLE
Add af-create skill and prune stale plugin files on launch

### DIFF
--- a/session/plugin.go
+++ b/session/plugin.go
@@ -18,6 +18,9 @@ const pluginManifest = `{
 `
 
 // pluginCommands defines the slash command files to write into the plugin directory.
+// ensurePluginDir writes this map to disk on every session launch and prunes any
+// .md file that isn't listed here, so adding/removing/editing a skill is as simple
+// as changing this map.
 var pluginCommands = map[string]string{
 	"af-sessions.md": "---\n" +
 		"allowed-tools: Bash(af sessions list:*)\n" +
@@ -29,6 +32,21 @@ var pluginCommands = map[string]string{
 		"## Context\n" +
 		"\n" +
 		"- Current sessions: !`af sessions list`\n",
+
+	"af-create.md": "---\n" +
+		"allowed-tools: Bash(af sessions create:*)\n" +
+		"description: Create a new Agent Factory session\n" +
+		"argument-hint: <session-name> [initial-prompt]\n" +
+		"---\n" +
+		"\n" +
+		"Create a new Agent Factory session (a new agent instance in an isolated git worktree).\n" +
+		"\n" +
+		"The user provided: $ARGUMENTS\n" +
+		"\n" +
+		"Parse the session name (first argument) and optional initial prompt (remaining arguments), " +
+		"then run `af sessions create --name <name> --prompt <prompt>`. " +
+		"If no prompt is given, omit the --prompt flag. " +
+		"The name should be a short kebab-case identifier the user will recognize in the session list.\n",
 
 	"af-kill.md": "---\n" +
 		"allowed-tools: Bash(af sessions kill:*)\n" +
@@ -81,6 +99,11 @@ var pluginCommands = map[string]string{
 
 // ensurePluginDir creates the plugin directory with manifest and slash command
 // files and returns its path. The directory is located at <config-dir>/plugin/.
+//
+// This is called on every claude-based session launch (see injectSystemPrompt),
+// and rewrites the manifest, writes every file in pluginCommands, and prunes any
+// stray .md in commands/ that isn't in the map — so inserts, edits, and removes
+// in pluginCommands all propagate on the next session start.
 func ensurePluginDir() (string, error) {
 	configDir, err := config.GetConfigDir()
 	if err != nil {
@@ -102,6 +125,24 @@ func ensurePluginDir() (string, error) {
 	manifestPath := filepath.Join(manifestDir, "plugin.json")
 	if err := os.WriteFile(manifestPath, []byte(pluginManifest), 0644); err != nil {
 		return "", err
+	}
+
+	// Prune stale command files no longer declared in pluginCommands so
+	// removed/renamed skills don't linger as orphan slash commands.
+	entries, err := os.ReadDir(commandsDir)
+	if err != nil {
+		return "", err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".md" {
+			continue
+		}
+		if _, ok := pluginCommands[entry.Name()]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(commandsDir, entry.Name())); err != nil {
+			return "", err
+		}
 	}
 
 	// Write command files

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -11,6 +11,7 @@ const codexSystemPrompt = `You are running inside Agent Factory (af), a terminal
 You can manage sessions using the "af" CLI:
 
 Session commands:
+  af sessions create --name <title> [--prompt <prompt>]  Create a new session
   af sessions whoami                        Identify your current session
   af sessions list                          List all sessions
   af sessions kill <title>                  Delete/kill a session

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -195,7 +195,7 @@ func TestEnsurePluginDir(t *testing.T) {
 	}
 
 	commandsDir := filepath.Join(pluginDir, "commands")
-	expectedFiles := []string{"af-sessions.md", "af-kill.md", "af-send.md", "af-preview.md", "af-whoami.md"}
+	expectedFiles := []string{"af-sessions.md", "af-kill.md", "af-send.md", "af-preview.md", "af-whoami.md", "af-create.md"}
 	for _, name := range expectedFiles {
 		path := filepath.Join(commandsDir, name)
 		if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -229,5 +229,44 @@ func TestEnsurePluginDir_Idempotent(t *testing.T) {
 
 	if dir1 != dir2 {
 		t.Errorf("expected same dir on repeated calls, got %q and %q", dir1, dir2)
+	}
+}
+
+func TestEnsurePluginDir_PrunesStaleFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpDir)
+
+	pluginDir, err := ensurePluginDir()
+	if err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+
+	commandsDir := filepath.Join(pluginDir, "commands")
+	stale := filepath.Join(commandsDir, "af-removed.md")
+	if err := os.WriteFile(stale, []byte("stale"), 0644); err != nil {
+		t.Fatalf("failed to seed stale file: %v", err)
+	}
+
+	// Non-.md files and unrelated content must be left alone.
+	keep := filepath.Join(commandsDir, "README.txt")
+	if err := os.WriteFile(keep, []byte("keep me"), 0644); err != nil {
+		t.Fatalf("failed to seed keep file: %v", err)
+	}
+
+	if _, err := ensurePluginDir(); err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("expected stale file %s to be pruned, got err=%v", stale, err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("expected non-.md file %s to survive prune: %v", keep, err)
+	}
+
+	for name := range pluginCommands {
+		if _, err := os.Stat(filepath.Join(commandsDir, name)); err != nil {
+			t.Errorf("expected %s to still exist after prune: %v", name, err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add `af-create.md` to `pluginCommands` so agents have a discoverable skill for `af sessions create` when asked to spin up a new instance (the current "agent doesn't understand 'create a new agent factory instance'" failure mode).
- `ensurePluginDir` now prunes any `.md` in `commands/` that isn't declared in `pluginCommands`, giving a clean insert/update/remove path — rebuild `af` and the next session launch reconciles the plugin dir with the Go source of truth.
- Mirror the create command into `codexSystemPrompt` since Codex doesn't consume the plugin dir.

## Test Plan

- [x] `go test ./...` passes
- [x] `gofmt -l .` produces no output
- [x] `go build ./...` passes
- [x] New `TestEnsurePluginDir_PrunesStaleFiles` covers the remove path (and verifies non-`.md` siblings survive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)