### PR TITLE
ci: authenticate auto-release push with deploy key

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
     - name: Check for new commits since last tag
       id: check


### PR DESCRIPTION
## Summary
- Auto Release's version-bump commit push was rejected by the master ruleset (`GH013 — required status checks expected`) because the push from `github-actions[bot]` can't satisfy checks on a commit it just created.
- Switch the checkout to use a write-enabled deploy key (`RELEASE_DEPLOY_KEY` secret). The ruleset already has `DeployKey` in its bypass list, so the push is allowed while keeping checks required for everyone else.

## Test plan
- [ ] After merge, dispatch `Auto Release` and confirm the version bump commit + tag land on `master` and the `Build and Release` job completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)