### PR TITLE
ci: create release as draft and publish after asset upload

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -117,8 +117,17 @@ jobs:
         path: dist
         merge-multiple: true
 
-    - name: Create release
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: v${{ needs.check-and-bump.outputs.new_version }}
-        files: dist/*.tar.gz
+    # Immutable releases require all assets to be attached before the release
+    # is published: create as draft, upload assets into the draft, then publish.
+    - name: Publish release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        VERSION: ${{ needs.check-and-bump.outputs.new_version }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        gh release create "v${VERSION}" \
+          --title "v${VERSION}" \
+          --generate-notes \
+          --draft \
+          dist/*.tar.gz
+        gh release edit "v${VERSION}" --draft=false --latest


### PR DESCRIPTION
## Summary
- v1.0.50 published with only 1 of 4 tarballs again. Root cause: repo has GitHub's immutable releases feature enabled, so `softprops/action-gh-release`'s delete-then-upload flow fails after the first asset lands (`Cannot delete asset from an immutable release`).
- Switch to `gh release create --draft ... files` + `gh release edit --draft=false`. Immutable releases allow asset writes only before publish, which is exactly the window a draft gives us.

## Test plan
- [ ] After merge, dispatch `Auto Release`. Verify the release ends up published with all 4 tarballs attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)