### PR TITLE
fix(app): avoid Menu.SetState race by calling it on the event-loop goroutine

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -24,13 +24,11 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if err := m.sidebar.Kill(); err != nil {
 			log.ErrorLog.Printf("failed to clean up instance on cancel: %v", err)
 		}
-		return m, tea.Sequence(
-			tea.WindowSize(),
-			func() tea.Msg {
-				m.menu.SetState(ui.StateDefault)
-				return nil
-			},
-		)
+		// Menu.SetState rebuilds the options slice; call it synchronously
+		// on the event-loop goroutine rather than from a tea.Cmd closure
+		// that runs off-loop and races with home.View -> Menu.String.
+		m.menu.SetState(ui.StateDefault)
+		return m, tea.WindowSize()
 	}
 
 	instance := m.namingInstance
@@ -119,13 +117,11 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.availableWorktrees = nil
 		cmd := m.selectionChanged()
 
-		return m, tea.Batch(cmd, tea.Sequence(
-			tea.WindowSize(),
-			func() tea.Msg {
-				m.menu.SetState(ui.StateDefault)
-				return nil
-			},
-		))
+		// Menu.SetState rebuilds the options slice; call it synchronously
+		// on the event-loop goroutine rather than from a tea.Cmd closure
+		// that runs off-loop and races with home.View -> Menu.String.
+		m.menu.SetState(ui.StateDefault)
+		return m, tea.Batch(cmd, tea.WindowSize())
 	default:
 	}
 	return m, nil

--- a/app/help.go
+++ b/app/help.go
@@ -157,13 +157,11 @@ func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	shouldClose := m.textOverlay.HandleKeyPress(msg)
 	if shouldClose {
 		m.state = stateDefault
-		return m, tea.Sequence(
-			tea.WindowSize(),
-			func() tea.Msg {
-				m.menu.SetState(ui.StateDefault)
-				return nil
-			},
-		)
+		// Menu.SetState rebuilds the options slice; call it synchronously
+		// on the event-loop goroutine rather than from a tea.Cmd closure
+		// that runs off-loop and races with home.View -> Menu.String.
+		m.menu.SetState(ui.StateDefault)
+		return m, tea.WindowSize()
 	}
 
 	return m, nil


### PR DESCRIPTION
Fixes sachiniyer/agent-factory#316.

## Problem

Three cancel/dismiss paths returned a `tea.Cmd` whose closure called `m.menu.SetState(StateDefault)`:

- `app/help.go:163` — help overlay dismissal
- `app/handle_input.go:30` — ctrl+c cancel in `handleStateNew`
- `app/handle_input.go:125` — Esc cancel in `handleStateNew`

`tea.Cmd` closures run in bubbletea-spawned goroutines, while `home.View` → `Menu.String` runs on the event-loop goroutine. `Menu.SetState` → `updateOptions` rebuilds the options slice, and a concurrent `Menu.String` iterates / reads option fields — the race detector fires, and an unlucky interleaving could render stale text or nil-deref an option slice mid-reallocation.

## Fix

Call `m.menu.SetState` synchronously on the event-loop goroutine and drop the `tea.Sequence` / closure wrapper. The Esc-cancel path preserves its `m.selectionChanged` command via `tea.Batch`.

## Test

`go test -race ./app/... ./ui/...` clean aside from an unrelated `tmux`-not-in-$PATH failure on my machine.