### PR TITLE
fix(session): guard Instance.Branch reads with the mutex

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -291,6 +291,32 @@ func (i *Instance) SetStatus(status Status) {
 	i.Status = status
 }
 
+// GetBranch returns the current worktree branch name under the Instance's
+// mutex. Readers that run from goroutines other than the one mutating the
+// instance (notably the bubbletea renderer) must use this accessor rather
+// than reading i.Branch directly, or the race detector flags a write in
+// LocalBackend.Start vs a read in InstanceRenderer.Render.
+func (i *Instance) GetBranch() string {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.Branch
+}
+
+// GetStatus returns the current status under the Instance's mutex, so
+// cross-goroutine readers don't race with SetStatus.
+func (i *Instance) GetStatus() Status {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.Status
+}
+
+// GetTitle returns the instance title under the Instance's mutex.
+func (i *Instance) GetTitle() string {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.Title
+}
+
 // firstTimeSetup is true if this is a new instance. Otherwise, it's one loaded from storage.
 func (i *Instance) Start(firstTimeSetup bool) error {
 	return i.backend.Start(i, firstTimeSetup)

--- a/ui/list.go
+++ b/ui/list.go
@@ -147,7 +147,10 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	remainingWidth -= runewidth.StringWidth(branchIcon)
 	remainingWidth -= 2 // for the literal " " and "-" in the branchLine format string
 
-	branch := i.Branch
+	// Use the mutex-guarded accessor so this read (on the renderer
+	// goroutine) doesn't race with LocalBackend.Start's write on the
+	// instance-creation tea.Cmd goroutine.
+	branch := i.GetBranch()
 	if i.Started() && hasMultipleRepos {
 		repoName, err := i.RepoName()
 		if err != nil {


### PR DESCRIPTION
Fixes sachiniyer/agent-factory#315.

## Problem

`LocalBackend.Start` writes `i.Branch` under `i.mu.Lock()` from the instance-creation `tea.Cmd` goroutine, but `InstanceRenderer.Render` reads the same field directly from the bubbletea renderer goroutine. The race detector fires on that overlap during real-backend instance creation.

## Fix

Add `GetBranch`, `GetStatus`, and `GetTitle` accessors on `*Instance` that take `i.mu.RLock()` (mirroring the existing `GetPRInfo`/`FetchPRInfoSnapshot` pattern), and switch the renderer read in `ui/list.go` to `GetBranch`.

`GetStatus` / `GetTitle` are included for completeness so the next caller using either from a cross-goroutine path has a safe accessor to reach for.

## Test

`go test -race ./session/...` passes locally; the one `ui/` failure is a pre-existing `tmux`-not-in-`$PATH` failure unrelated to this change.