### PR TITLE
fix(app): debounce in-flight PR info fetches at kickoff

### DIFF
--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"errors"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,6 +13,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newStartedInstanceWithWorktree returns an instance that passes all the
+// guards in fetchPRInfoCmd (not nil, started, not remote, has a gitWorktree
+// that yields a non-empty repoPath from FetchPRInfoSnapshot). Use for tests
+// that need fetchPRInfoCmd to actually return a non-nil command.
+func newStartedInstanceWithWorktree(t *testing.T, title string) *session.Instance {
+	t.Helper()
+	inst := newStartedInstance(t, title)
+	inst.Branch = "feature/" + title
+	gw, err := git.NewGitWorktreeFromStorage(
+		t.TempDir(),
+		filepath.Join(t.TempDir(), "worktree"),
+		title,
+		inst.Branch,
+		"deadbeef",
+		false,
+		true,
+	)
+	require.NoError(t, err)
+	inst.SetGitWorktreeForTest(gw)
+	return inst
+}
 
 // newStartedInstance builds an instance that Started() reports as true.
 // Uses the test-only SetStartedForTest seam so we don't need a real git repo
@@ -190,6 +214,79 @@ func TestSelectionChanged_DoesNotRefetchFreshInstance(t *testing.T) {
 
 	cmd := h.selectionChanged()
 	assert.Nil(t, cmd, "no PR fetch should be scheduled for a fresh instance")
+}
+
+// TestFetchPRInfoCmd_MarksFetchAtKickoff_DebouncesConcurrentCalls verifies the
+// fix for the in-flight-fetch thrash described in issue #311: selectionChanged
+// runs on every 100ms preview tick, and fetchPRInfoCmd was previously only
+// bumping prInfoLastFetched once the fetch completed. A restored instance
+// (prInfoLastFetched == 0) would therefore trigger a new `gh pr view`
+// subprocess on every tick until one finally returned.
+//
+// The fix marks the instance as fetched at kickoff. This test asserts:
+//  1. the first non-forced call returns a non-nil cmd and immediately
+//     bumps PRInfoAge out of the "never fetched" sentinel range,
+//  2. a second non-forced call within prInfoStaleAfter returns nil even
+//     though the fetcher has not been invoked yet (the in-flight fetch is
+//     the debounce anchor), and
+//  3. when the returned cmd is eventually executed the fetcher runs
+//     exactly once per kickoff.
+func TestFetchPRInfoCmd_MarksFetchAtKickoff_DebouncesConcurrentCalls(t *testing.T) {
+	inst := newStartedInstanceWithWorktree(t, "needs-fetch")
+
+	var calls int32
+	block := make(chan struct{})
+	restore := SetPRInfoFetcherForTest(func(repoPath, branch string) (*git.PRInfo, error) {
+		atomic.AddInt32(&calls, 1)
+		<-block
+		return &git.PRInfo{Number: 99, Title: "done"}, nil
+	})
+	t.Cleanup(restore)
+
+	require.Greater(t, inst.PRInfoAge(), 365*24*time.Hour,
+		"precondition: a freshly-restored instance reports a very large age")
+
+	cmd1 := fetchPRInfoCmd(inst, false)
+	require.NotNil(t, cmd1, "first call should dispatch a fetch")
+	assert.Less(t, inst.PRInfoAge(), time.Second,
+		"kickoff must bump prInfoLastFetched so the next tick is debounced")
+
+	cmd2 := fetchPRInfoCmd(inst, false)
+	assert.Nil(t, cmd2,
+		"second non-forced call within the stale window must be a no-op, "+
+			"even while the first fetch is still in flight")
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&calls),
+		"kickoff must not run the fetcher — tea runs returned Cmds off-loop")
+
+	// Drain the in-flight fetch before letting t.Cleanup swap the fetcher
+	// back — otherwise the goroutine's read of prInfoFetcher races with the
+	// restore write.
+	done := make(chan struct{})
+	go func() {
+		_ = cmd1()
+		close(done)
+	}()
+	close(block)
+	<-done
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"each returned cmd should invoke the fetcher exactly once")
+}
+
+// TestFetchPRInfoCmd_Force_StillRunsWhileFetchInFlight — force=true bypasses
+// the kickoff debounce. The 60s ticker relies on this to always refresh the
+// selected instance, even if selectionChanged just kicked off a fetch.
+func TestFetchPRInfoCmd_Force_StillRunsWhileFetchInFlight(t *testing.T) {
+	inst := newStartedInstanceWithWorktree(t, "force-through")
+
+	restore := SetPRInfoFetcherForTest(func(repoPath, branch string) (*git.PRInfo, error) {
+		return &git.PRInfo{Number: 1}, nil
+	})
+	t.Cleanup(restore)
+
+	require.NotNil(t, fetchPRInfoCmd(inst, false), "first lazy call dispatches")
+	assert.NotNil(t, fetchPRInfoCmd(inst, true),
+		"force=true must bypass the kickoff-debounce the previous call set")
 }
 
 // sanity: exercise config.DefaultConfig / AppState wiring so a compile

--- a/app/sync.go
+++ b/app/sync.go
@@ -78,8 +78,8 @@ func SetPRInfoFetcherForTest(f func(repoPath, branch string) (*git.PRInfo, error
 // fetchPRInfoCmd returns a tea.Cmd that fetches PR info for inst in a
 // background goroutine and emits a prInfoUpdatedMsg. Returns nil when the
 // instance is not eligible for a fetch (nil / not started / remote / already
-// fresh). Using force=true ignores the freshness check — for tick-driven
-// refreshes of the selected instance.
+// fresh / fetch already in flight). Using force=true ignores the freshness
+// check — for tick-driven refreshes of the selected instance.
 func fetchPRInfoCmd(inst *session.Instance, force bool) tea.Cmd {
 	if inst == nil || inst.IsRemote() {
 		return nil
@@ -91,6 +91,14 @@ func fetchPRInfoCmd(inst *session.Instance, force bool) tea.Cmd {
 	if repoPath == "" {
 		return nil
 	}
+	// Mark as fetched at kickoff so concurrent callers observe the debounce
+	// window while this fetch is in flight. selectionChanged is re-entered
+	// every 100ms by the preview tick; without this, restored instances
+	// (whose prInfoLastFetched is zero until the first fetch completes)
+	// would spawn a new `gh pr view` subprocess on every tick until one
+	// returned. The completion handler bumps the timestamp again with the
+	// real result, so the fresh window starts from fetch completion.
+	inst.MarkPRInfoFetched()
 	return func() tea.Msg {
 		info, err := prInfoFetcher(repoPath, branch)
 		return prInfoUpdatedMsg{instance: inst, info: info, err: err}


### PR DESCRIPTION
## Summary

Closes #311 (follow-up to #314).

`fetchPRInfoCmd` only bumped `prInfoLastFetched` once the `gh pr view` fetch completed, but `selectionChanged` is re-entered every 100ms by the preview tick loop. A restored instance (`prInfoLastFetched == 0` by design — we don't persist the timestamp) would therefore spawn a new `gh` subprocess on every tick until the first finally returned — commonly 5–20 concurrent processes per selected instance at startup. PR #314 made the fetch async and lazy at the tick/selection layer; this PR closes the last gap by debouncing concurrent kickoffs.

## Fix

Mark the instance as fetched at kickoff so the 60s debounce covers the in-flight fetch. The completion handler still bumps the timestamp with the real result, so the fresh window starts from fetch completion as before. `force=true` (used by the 60s tick-driven refresh) continues to bypass the age check.

## Tests

- `TestFetchPRInfoCmd_MarksFetchAtKickoff_DebouncesConcurrentCalls` — first non-forced call dispatches and bumps the age out of the "never fetched" sentinel; a second non-forced call within the stale window returns `nil` even while the fetch is in flight; the fetcher is invoked exactly once per kickoff.
- `TestFetchPRInfoCmd_Force_StillRunsWhileFetchInFlight` — `force=true` bypasses the kickoff debounce so the 60s ticker always refreshes.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -race ./app/... ./session/...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)