### PR TITLE
fix(task/systemd): escape $ and % in quoteExecStartPath

### DIFF
--- a/task/systemd.go
+++ b/task/systemd.go
@@ -33,6 +33,8 @@ func getSystemdUserDir() (string, error) {
 func quoteExecStartPath(p string) string {
 	escaped := strings.ReplaceAll(p, `\`, `\\`)
 	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, `$`, `$$`)
+	escaped = strings.ReplaceAll(escaped, `%`, `%%`)
 	return `"` + escaped + `"`
 }
 

--- a/task/systemd_test.go
+++ b/task/systemd_test.go
@@ -141,3 +141,12 @@ func TestGenerateServiceContentExecStartEscapesQuotes(t *testing.T) {
 
 	assert.Contains(t, content, `ExecStart="/opt/weird\"path/agent-factory" task run q1`)
 }
+
+func TestQuoteExecStartPathEscapesDollarAndPercent(t *testing.T) {
+	// systemd performs $VAR variable expansion and %X specifier substitution
+	// inside ExecStart= values even within double quotes. Literal `$` and `%`
+	// in the path must be doubled (`$$`, `%%`) so systemd preserves them.
+	assert.Equal(t, `"/tmp/weird$$path/bin/af"`, quoteExecStartPath(`/tmp/weird$path/bin/af`))
+	assert.Equal(t, `"/tmp/weird%%h/bin/af"`, quoteExecStartPath(`/tmp/weird%h/bin/af`))
+	assert.Equal(t, `"/tmp/$$HOME-%%t/af"`, quoteExecStartPath(`/tmp/$HOME-%t/af`))
+}


### PR DESCRIPTION
## Summary
- systemd performs `$VAR` variable expansion and `%X` specifier substitution inside `ExecStart=` values even within double quotes. The previous `quoteExecStartPath` only escaped `\` and `"`, so an executable path containing a literal `$` or `%` was interpreted by systemd and the service ran the wrong binary or failed to start.
- Escape `$` -> `$$` and `%` -> `%%` in `quoteExecStartPath` (`task/systemd.go`).
- Add a regression test in `task/systemd_test.go` covering both substitutions.

Fixes #320
Fixes #344

## Test plan
- [x] `gofmt -w .` produces no diff
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New `TestQuoteExecStartPathEscapesDollarAndPercent` passes and asserts both `$` -> `$$` and `%` -> `%%` escaping

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>