### PR TITLE
fix(session): guard nil tmuxSession in LocalBackend.TapEnter

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -292,7 +292,7 @@ func (b *LocalBackend) TapEnter(i *Instance) {
 	autoYes := i.AutoYes
 	i.mu.RUnlock()
 
-	if !s || !autoYes {
+	if !s || !autoYes || ts == nil {
 		return
 	}
 	if err := ts.TapEnter(); err != nil {

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -297,6 +297,21 @@ func TestLocalBackendHasUpdatedNilTmuxSession(t *testing.T) {
 	assert.False(t, hasPrompt)
 }
 
+// Regression test for #329: LocalBackend.TapEnter must not panic when
+// started=true and AutoYes=true but tmuxSession=nil (it should return
+// early instead).
+func TestLocalBackendTapEnterNilTmuxSession(t *testing.T) {
+	b := &LocalBackend{}
+	i := &Instance{
+		Title:   "local-inst",
+		backend: b,
+		started: true,
+		AutoYes: true, // tmuxSession intentionally left nil
+	}
+	// Should not panic.
+	b.TapEnter(i)
+}
+
 // LocalBackend.SendKeys should return an error (not panic) when the tmux
 // session has not been initialized yet.
 func TestLocalBackendSendKeysNilTmuxSession(t *testing.T) {


### PR DESCRIPTION
## Summary
- `LocalBackend.TapEnter` dereferenced `i.tmuxSession` without a nil guard, causing a nil-pointer panic when `started=true` and `AutoYes=true` but `tmuxSession=nil` (e.g., a race between `Start`/`Kill`).
- Sibling methods (`Preview`, `Attach`, `HasUpdated`, `SendKeys`, etc.) all guard `ts == nil`; `TapEnter` is updated to follow the same pattern.
- Added a regression test `TestLocalBackendTapEnterNilTmuxSession` that reproduces the panic on the unfixed code and passes with the guard in place.

Fixes #329

## Test plan
- [x] `gofmt -l .` produces no output
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including the new regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)