### PR TITLE
fix(config): reject malformed AGENT_FACTORY_HOME tilde values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,9 @@ func GetConfigDir() (string, error) {
 			if envDir == "~" {
 				return homeDir, nil
 			}
+			if !strings.HasPrefix(envDir, "~/") {
+				return "", fmt.Errorf("AGENT_FACTORY_HOME: invalid tilde format %q (expected ~ or ~/path)", envDir)
+			}
 			envDir = filepath.Join(homeDir, envDir[2:])
 		}
 		return envDir, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -182,6 +182,58 @@ func TestGetConfigDir(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, strings.HasSuffix(configDir, ".agent-factory"))
 	})
+
+	t.Run("returns home dir when AGENT_FACTORY_HOME is exactly ~", func(t *testing.T) {
+		originalVal := os.Getenv("AGENT_FACTORY_HOME")
+		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
+
+		os.Setenv("AGENT_FACTORY_HOME", "~")
+
+		homeDir, err := os.UserHomeDir()
+		require.NoError(t, err)
+
+		configDir, err := GetConfigDir()
+		assert.NoError(t, err)
+		assert.Equal(t, homeDir, configDir)
+	})
+
+	t.Run("expands ~/foo correctly", func(t *testing.T) {
+		originalVal := os.Getenv("AGENT_FACTORY_HOME")
+		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
+
+		os.Setenv("AGENT_FACTORY_HOME", "~/foo")
+
+		homeDir, err := os.UserHomeDir()
+		require.NoError(t, err)
+
+		configDir, err := GetConfigDir()
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(homeDir, "foo"), configDir)
+	})
+
+	t.Run("returns error for malformed ~.config", func(t *testing.T) {
+		originalVal := os.Getenv("AGENT_FACTORY_HOME")
+		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
+
+		os.Setenv("AGENT_FACTORY_HOME", "~.config")
+
+		configDir, err := GetConfigDir()
+		assert.Error(t, err)
+		assert.Empty(t, configDir)
+		assert.Contains(t, err.Error(), "invalid tilde format")
+	})
+
+	t.Run("returns error for malformed ~config", func(t *testing.T) {
+		originalVal := os.Getenv("AGENT_FACTORY_HOME")
+		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
+
+		os.Setenv("AGENT_FACTORY_HOME", "~config")
+
+		configDir, err := GetConfigDir()
+		assert.Error(t, err)
+		assert.Empty(t, configDir)
+		assert.Contains(t, err.Error(), "invalid tilde format")
+	})
 }
 
 func TestLoadConfig(t *testing.T) {


### PR DESCRIPTION
## Summary
- `GetConfigDir` unconditionally sliced `envDir[2:]` whenever `AGENT_FACTORY_HOME` started with `~`, so values like `~.config` silently dropped the dot and wrote config to `~/config`.
- Validate that the value is exactly `~` or starts with `~/` before slicing; return a clear error otherwise.
- Adds regression tests covering `~.config`, `~config`, `~/foo`, and bare `~`.

Fixes #325

## Test plan
- [x] `gofmt -l .` (no output)
- [x] `go build ./...`
- [x] `go test ./...`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>