### PR TITLE
fix(task/runner): treat MCP trust prompts as ready

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -89,7 +89,9 @@ func LoadAndClearPendingInstances() ([]session.InstanceData, error) {
 // and trust prompt as well as the Aider/Gemini trust prompt
 // ("Open documentation url" + "(D)on't ask again").
 func isReadyContent(content string) bool {
-	if strings.Contains(content, "❯") || strings.Contains(content, "Do you trust") {
+	if strings.Contains(content, "❯") ||
+		strings.Contains(content, "Do you trust") ||
+		strings.Contains(content, "new MCP server") {
 		return true
 	}
 	// Aider/Gemini trust prompt. Require both substrings to avoid false

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -40,6 +40,11 @@ func TestIsReadyContent(t *testing.T) {
 			want:    true,
 		},
 		{
+			name:    "claude mcp trust prompt",
+			content: "Claude Code detected a new MCP server from `.mcp.json`.\n1. Use this and all future MCP servers in this project\n2. Use this MCP server\n3. Continue without using this MCP server",
+			want:    true,
+		},
+		{
 			name: "aider trust prompt",
 			content: "Aider v0.1\nOpen documentation url for more info: https://aider.chat/docs/\n" +
 				"(Y)es/(N)o/(D)on't ask again [Yes]:",


### PR DESCRIPTION
## Summary
- `isReadyContent` only matched `❯` and `Do you trust`, so when an MCP trust prompt (`new MCP server`) appeared during startup, `WaitForReady` blocked until its 60s timeout instead of letting `CheckAndHandleTrustPrompt` dismiss it.
- `session/tmux/tmux.go` already treats folder trust prompts and MCP trust prompts equivalently; this change applies the same logic in `task/runner.go`.
- Adds a regression test in `task/runner_test.go` for MCP prompt content.

Fixes #335

## Test plan
- [x] `gofmt -w . && gofmt -l .` (no output)
- [x] `go build ./...`
- [x] `go test ./...`

Generated with [Claude Code](https://claude.com/claude-code)