### PR TITLE
fix(ui/content_pane): match child pane height to rendered area

### DIFF
--- a/ui/content_pane.go
+++ b/ui/content_pane.go
@@ -47,7 +47,7 @@ func (c *ContentPane) SetSize(width, height int) {
 
 	// Calculate content area for inline panes (matching window style)
 	contentWidth := AdjustPreviewWidth(width) - windowStyle.GetHorizontalFrameSize()
-	contentHeight := height - windowStyle.GetVerticalFrameSize() - 4
+	contentHeight := height - windowStyle.GetVerticalFrameSize() - 2
 	c.taskPane.SetSize(contentWidth, contentHeight)
 	c.hooksPane.SetSize(contentWidth, contentHeight)
 }

--- a/ui/content_pane_test.go
+++ b/ui/content_pane_test.go
@@ -73,6 +73,23 @@ func TestContentPaneModeSwitchUnfocuses(t *testing.T) {
 	assert.False(t, cp.HasFocus())
 }
 
+func TestContentPaneSetSizeMatchesRenderHeight(t *testing.T) {
+	tw := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
+	cp := NewContentPane(tw)
+
+	const w, h = 80, 30
+	cp.SetSize(w, h)
+
+	// renderInlinePane uses Place height = c.height - windowStyle.GetVerticalFrameSize() - 2.
+	// The child panes must be sized to match, otherwise content is cut off
+	// or padded incorrectly (issue #336).
+	expected := h - windowStyle.GetVerticalFrameSize() - 2
+	assert.Equal(t, expected, cp.taskPane.height,
+		"taskPane height must match renderInlinePane Place height")
+	assert.Equal(t, expected, cp.hooksPane.height,
+		"hooksPane height must match renderInlinePane Place height")
+}
+
 func TestContentPaneRender(t *testing.T) {
 	tw := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
 	tw.SetSize(80, 30)


### PR DESCRIPTION
## Summary
- `ContentPane.SetSize` subtracted 4 from the child height while `renderInlinePane` (and `renderEmptyPane`) used `lipgloss.Place` with `-2`. After commit 44029cc reduced the leading newlines from two to one, the child panes (`TaskPane`, `HooksPane`) were being told they had 2 fewer lines than their actual render area.
- Change `-4` to `-2` in `SetSize` so the child height matches the placement used by `lipgloss.Place`.
- Add a regression test asserting that the height set on `taskPane` and `hooksPane` matches the height used in `renderInlinePane`.

Fixes #336

## Test plan
- [x] `gofmt -w .` produces no diffs
- [x] `go build ./...` passes
- [x] `go test ./...` passes (including new `TestContentPaneSetSizeMatchesRenderHeight`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)