### PR TITLE
fix(task/cron): use max=7 for DOW expansion to match validation

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -214,17 +214,23 @@ func convertTimeField(field string, oneIndexed bool) string {
 func convertDOW(field string) string {
 	// Handle step values (e.g. "*/2" or "1-5/2") by expanding to explicit day names
 	if strings.Contains(field, "/") {
-		expanded, err := expandCronField(field, 0, 6)
+		expanded, err := expandCronField(field, 0, 7)
 		if err != nil {
 			return ""
 		}
-		// If all 7 days are covered, omit DOW entirely.
-		if len(expanded) >= 7 {
-			return ""
+		// Map to day names, deduplicating (since both 0 and 7 mean Sunday).
+		seen := make(map[string]bool)
+		var names []string
+		for _, v := range expanded {
+			name := dowNames[strconv.Itoa(v)]
+			if !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
 		}
-		names := make([]string, len(expanded))
-		for i, v := range expanded {
-			names[i] = dowNames[strconv.Itoa(v)]
+		// If all 7 days are covered, omit DOW entirely.
+		if len(names) >= 7 {
+			return ""
 		}
 		return strings.Join(names, ",")
 	}

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -130,6 +130,19 @@ func TestCronToOnCalendarDOWStepRange(t *testing.T) {
 	assert.Equal(t, "Mon,Wed,Fri *-*-* 09:00:00", result)
 }
 
+// TestCronToOnCalendarDOWStepFrom7 is a regression test for a bug where DOW
+// step expressions starting at 7 (e.g. "7/2") expanded to an empty set because
+// convertDOW called expandCronField with max=6, while validation treats DOW as
+// 0-7 (with 7 also meaning Sunday). The empty set caused the DOW constraint to
+// be silently dropped, changing the schedule to run every day.
+func TestCronToOnCalendarDOWStepFrom7(t *testing.T) {
+	// "7/2" should expand to just [7] (i.e. Sunday); step 2 from 7 with max=7
+	// yields a single value. The result must include Sunday and not omit DOW.
+	result, err := CronToOnCalendar("0 9 * * 7/2")
+	require.NoError(t, err)
+	assert.Equal(t, "Sun *-*-* 09:00:00", result)
+}
+
 func TestCronToOnCalendarDOWSundayRange01(t *testing.T) {
 	result, err := CronToOnCalendar("0 9 * * 0-1")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Fixes #332

`convertDOW` in `task/cron.go` expanded DOW step expressions with `max=6`, while cron validation (and `launchd.go`, and `dowNames`) treat DOW as `0-7` (both `0` and `7` mean Sunday). Step expressions starting at `7` (e.g. `7/2`) iterated `for i := 7; i <= 6` and produced an empty slice, which caused the DOW constraint to be silently omitted from the generated `OnCalendar` value — turning what was meant to be a Sunday-only schedule into every-day execution.

### Changes

- `task/cron.go`: change `expandCronField(field, 0, 6)` to `expandCronField(field, 0, 7)` in `convertDOW` so step expansion is consistent with validation. Deduplicate day names after expansion (since both `0` and `7` map to `Sun`) and gate the "all 7 days" omit-DOW check on the deduplicated name count.
- `task/cron_test.go`: add regression test `TestCronToOnCalendarDOWStepFrom7` covering `7/2` and asserting Sunday is preserved (`Sun *-*-* 09:00:00`).

## Test plan

- [x] `gofmt -l .` produces no output
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] New regression test `TestCronToOnCalendarDOWStepFrom7` passes
- [x] Existing DOW tests (`*/2` → `Sun,Tue,Thu,Sat`, `1-5/2` → `Mon,Wed,Fri`, `0-6`/`0-7` → omitted, etc.) still pass