### PR TITLE
fix(session/plugin): treat ENOENT during stale plugin prune as success

### DIFF
--- a/session/plugin.go
+++ b/session/plugin.go
@@ -140,7 +140,7 @@ func ensurePluginDir() (string, error) {
 		if _, ok := pluginCommands[entry.Name()]; ok {
 			continue
 		}
-		if err := os.Remove(filepath.Join(commandsDir, entry.Name())); err != nil {
+		if err := os.Remove(filepath.Join(commandsDir, entry.Name())); err != nil && !os.IsNotExist(err) {
 			return "", err
 		}
 	}

--- a/session/plugin_test.go
+++ b/session/plugin_test.go
@@ -1,0 +1,70 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestEnsurePluginDir_ConcurrentStalePrune is a regression test for issues
+// #321 / #343: when two sessions start at the same time, both ReadDir the
+// commands directory, both decide the same .md file is stale, and one of
+// the os.Remove calls returns os.ErrNotExist because the other goroutine
+// already deleted it. The previous code propagated that error and silently
+// disabled --plugin-dir for the affected session. With the fix
+// (!os.IsNotExist guard), every concurrent caller succeeds even when stale
+// files race to be pruned.
+func TestEnsurePluginDir_ConcurrentStalePrune(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpDir)
+
+	// Seed many stale .md files so concurrent prune calls reliably collide
+	// on at least one file (without the fix, ENOENT would surface as a
+	// fatal error in at least one goroutine).
+	commandsDir := filepath.Join(tmpDir, "plugin", "commands")
+	if err := os.MkdirAll(commandsDir, 0755); err != nil {
+		t.Fatalf("failed to mkdir commands dir: %v", err)
+	}
+	const staleCount = 50
+	for i := 0; i < staleCount; i++ {
+		path := filepath.Join(commandsDir, fmt.Sprintf("stale-%d.md", i))
+		if err := os.WriteFile(path, []byte("stale"), 0644); err != nil {
+			t.Fatalf("failed to seed stale file: %v", err)
+		}
+	}
+
+	const workers = 20
+	var wg sync.WaitGroup
+	errs := make([]error, workers)
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			_, errs[i] = ensurePluginDir()
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("worker %d: ensurePluginDir must tolerate ENOENT during stale-file prune: %v", i, err)
+		}
+	}
+
+	// All stale files must have been pruned.
+	for i := 0; i < staleCount; i++ {
+		stale := filepath.Join(commandsDir, fmt.Sprintf("stale-%d.md", i))
+		if _, err := os.Stat(stale); !os.IsNotExist(err) {
+			t.Errorf("expected stale file %s to be pruned, got err=%v", stale, err)
+		}
+	}
+	// Declared command files must exist.
+	for name := range pluginCommands {
+		if _, err := os.Stat(filepath.Join(commandsDir, name)); err != nil {
+			t.Errorf("expected %s to exist after concurrent prune: %v", name, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `ensurePluginDir` reads the plugin commands directory and removes any `.md` file not declared in `pluginCommands`. If two sessions start at the same time, both can decide the same file is stale; one `os.Remove` succeeds and the other returns `os.ErrNotExist`. The previous code propagated that error, causing the affected session to launch without `--plugin-dir` (no `/af-*` slash commands, no `/af-whoami`) — silently, with no logging.
- Match the established pattern used in `task/runner.go`, `task/launchd.go`, `task/systemd.go`, and `config/state.go` and ignore `os.IsNotExist` during the cleanup `os.Remove`.

Fixes #321
Fixes #343

## Test plan
- [x] `gofmt -l .` (no output)
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run --timeout=3m --fast ./session/...`
- [x] New regression test `TestEnsurePluginDir_ConcurrentStalePrune` reliably fails on master (5/5 runs surface ENOENT errors from concurrent goroutines) and passes after the fix (10/10 runs).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>