### PR TITLE
fix(ui/overlay): allow equal dimensions in PlaceOverlay early return

### DIFF
--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -93,7 +93,7 @@ func PlaceOverlay(
 	}
 
 	// Check if foreground exceeds background size
-	if fgWidth >= bgWidth || fgHeight >= bgHeight {
+	if fgWidth > bgWidth || fgHeight > bgHeight {
 		return fg // Return foreground if it's larger than background
 	}
 

--- a/ui/overlay/overlay_test.go
+++ b/ui/overlay/overlay_test.go
@@ -1,6 +1,7 @@
 package overlay
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/muesli/ansi"
@@ -38,5 +39,76 @@ func TestWhitespaceRenderWideCharEvenWidth(t *testing.T) {
 	width := ansi.PrintableRuneWidth(result)
 	if width != 4 {
 		t.Fatalf("Expected width 4, got %d, result=%q", width, result)
+	}
+}
+
+// TestPlaceOverlayEqualWidth verifies that when the foreground width exactly
+// matches the background width (a common case with hardcoded 60-col overlays
+// in 60-col tmux panes), the dimmed background is still composited above and
+// below the foreground rather than the function early-returning the foreground
+// alone. Regression test for #322.
+func TestPlaceOverlayEqualWidth(t *testing.T) {
+	bg := strings.Join([]string{
+		"aaaaaaaaaa",
+		"bbbbbbbbbb",
+		"cccccccccc",
+		"dddddddddd",
+	}, "\n")
+	fg := strings.Join([]string{
+		"XXXXXXXXXX",
+		"YYYYYYYYYY",
+	}, "\n")
+
+	result := PlaceOverlay(0, 1, fg, bg, false)
+
+	// The result must span all 4 background rows, not just the 2 foreground
+	// rows. Prior to the fix, PlaceOverlay early-returned `fg` (2 lines) when
+	// fgWidth == bgWidth.
+	gotLines := strings.Split(result, "\n")
+	if len(gotLines) != 4 {
+		t.Fatalf("Expected 4 lines (background height), got %d: %q", len(gotLines), result)
+	}
+
+	// The foreground content should appear in the result somewhere.
+	if !strings.Contains(result, "XXXXXXXXXX") || !strings.Contains(result, "YYYYYYYYYY") {
+		t.Fatalf("Foreground content missing from composite result: %q", result)
+	}
+
+	// At least one background row's content (the 'a' or 'd' rows that the
+	// foreground does not cover) must appear in the result, indicating that
+	// the dimmed background was composited rather than dropped.
+	if !strings.Contains(result, "aaaaaaaaaa") && !strings.Contains(result, "dddddddddd") {
+		t.Fatalf("Dimmed background content missing from composite result: %q", result)
+	}
+}
+
+// TestPlaceOverlayEqualHeight verifies the height-equal case symmetrically.
+// Regression test for #322.
+func TestPlaceOverlayEqualHeight(t *testing.T) {
+	bg := strings.Join([]string{
+		"aaaaaaaaaa",
+		"bbbbbbbbbb",
+		"cccccccccc",
+	}, "\n")
+	fg := strings.Join([]string{
+		"XXXX",
+		"YYYY",
+		"ZZZZ",
+	}, "\n")
+
+	result := PlaceOverlay(0, 0, fg, bg, false)
+
+	gotLines := strings.Split(result, "\n")
+	if len(gotLines) != 3 {
+		t.Fatalf("Expected 3 lines (background height), got %d: %q", len(gotLines), result)
+	}
+
+	// Each line should be at least as wide as the background (the foreground
+	// only covers the leftmost 4 cells, so the right side must come from the
+	// dimmed background).
+	for i, line := range gotLines {
+		if ansi.PrintableRuneWidth(line) < 10 {
+			t.Fatalf("Line %d shorter than background width: %q (width %d)", i, line, ansi.PrintableRuneWidth(line))
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- `PlaceOverlay` early-returned the foreground when `fgWidth >= bgWidth || fgHeight >= bgHeight`, so when overlay dimensions exactly matched the terminal/background dimensions (common with hardcoded 60-col overlays in 60-col tmux panes) the dimmed background composite was dropped entirely.
- Change the comparison to strict `>` so equal dimensions still composite the dimmed background under/around the foreground.
- Add regression tests covering both the equal-width and equal-height cases.

Fixes #322

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `gofmt -l .` produces no output
- [x] Verified both new tests fail without the one-line fix and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)