### PR TITLE
fix(session/git): prune worktree metadata before branch -D in cleanup

### DIFF
--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -280,6 +280,15 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 				}
 			}
 
+			// Prune stale worktree metadata (best-effort) BEFORE deleting the
+			// branch. When the `git worktree remove -f` above fails and we fall
+			// back to os.RemoveAll, git still tracks the worktree internally,
+			// causing `git branch -D` to fail with "branch is checked out".
+			pruneCmd := exec.Command("git", "-C", repoRoot, "worktree", "prune")
+			if err := pruneCmd.Run(); err != nil {
+				log.ErrorLog.Printf("failed to prune worktree metadata before deleting branch %s: %v", wt.branch, err)
+			}
+
 			// THEN delete the branch
 			if wt.branch != "" {
 				deleteCmd := exec.Command("git", "-C", repoRoot, "branch", "-D", wt.branch)

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -337,6 +337,57 @@ func createGitRepo(t *testing.T) string {
 	return repoRoot
 }
 
+// TestCleanupWorktreesForRepo_PrunesBeforeBranchDelete is a regression test
+// for issue #330. When `git worktree remove -f` fails (e.g. the worktree's
+// `.git` pointer file has been removed externally) and CleanupWorktreesForRepo
+// falls back to os.RemoveAll, git still tracks the worktree in its metadata.
+// Without an intervening `git worktree prune`, `git branch -D` reports the
+// branch is "in use" and the orphaned branch is left behind.
+func TestCleanupWorktreesForRepo_PrunesBeforeBranchDelete(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+	env := append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	commitCmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "init")
+	commitCmd.Env = env
+	out, err := commitCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	linkedPath := filepath.Join(filepath.Dir(repoRoot), "linked-wt")
+	addCmd := exec.Command("git", "-C", repoRoot, "worktree", "add", "-b", "linked-branch", linkedPath)
+	addCmd.Env = env
+	out, err = addCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	// Corrupt the worktree by removing its `.git` pointer file. This makes
+	// `git worktree remove -f` fail validation, forcing the os.RemoveAll
+	// fallback path. Git's internal metadata still references the worktree
+	// until `git worktree prune` runs.
+	require.NoError(t, os.Remove(filepath.Join(linkedPath, ".git")))
+
+	// Cleanup should still complete successfully and delete the branch.
+	require.NoError(t, CleanupWorktreesForRepo(repoRoot))
+
+	// The branch should be gone — this is what regresses without the prune
+	// before `git branch -D`.
+	branchCmd := exec.Command("git", "-C", repoRoot, "branch", "--list", "linked-branch")
+	out, err = branchCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Empty(t, strings.TrimSpace(string(out)),
+		"linked branch should be deleted even when `git worktree remove` falls back to os.RemoveAll")
+
+	// Only the main worktree should remain.
+	listCmd := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain")
+	out, err = listCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Equal(t, 1, strings.Count(string(out), "worktree "),
+		"only the main worktree should remain, got:\n%s", string(out))
+}
+
 // TestCleanupWorktreesForRepo_RejectsEmpty verifies the exported helper does
 // not silently operate on the cwd when given an empty repo root.
 func TestCleanupWorktreesForRepo_RejectsEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary
- In `CleanupWorktreesForRepo`, when `git worktree remove -f` fails and the loop falls back to `os.RemoveAll`, git's internal worktree metadata still references the directory, so the subsequent `git branch -D` fails with "branch is checked out" and leaves an orphaned branch behind.
- Fix: run `git worktree prune` (best-effort) inside the loop, after the worktree-remove step and BEFORE `git branch -D`. The trailing prune at the end of the function is left in place as a no-op safety net.
- Adds a regression test that corrupts a linked worktree's `.git` pointer to force the fallback path, then asserts the branch is still deleted.

Fixes #330

## Test plan
- [x] `gofmt -l .` produces no output
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] New `TestCleanupWorktreesForRepo_PrunesBeforeBranchDelete` fails on master and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)