### PR TITLE
fix(ui/preview): always clear scroll state in ResetToNormalMode

### DIFF
--- a/ui/preview.go
+++ b/ui/preview.go
@@ -237,16 +237,22 @@ func (p *PreviewPane) ScrollDown(instance *session.Instance) error {
 
 // ResetToNormalMode exits scroll mode and returns to normal mode
 func (p *PreviewPane) ResetToNormalMode(instance *session.Instance) error {
-	if instance == nil {
-		return nil
-	}
-
-	if p.isScrolling {
+	// Always clear scroll state first so that pressing ESC while no instance
+	// is selected (e.g., the sidebar header) does not leave the preview pane
+	// stuck on stale viewport content. Mirrors TerminalPane.ResetToNormalMode.
+	wasScrolling := p.isScrolling
+	if wasScrolling {
 		p.isScrolling = false
 		// Reset viewport
 		p.viewport.SetContent("")
 		p.viewport.GotoTop()
+	}
 
+	if instance == nil {
+		return nil
+	}
+
+	if wasScrolling {
 		// Immediately update content instead of waiting for next UpdateContent call
 		content, err := instance.Preview()
 		if err != nil {

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -389,6 +389,41 @@ func max(a, b int) int {
 	return b
 }
 
+// TestPreviewResetToNormalModeNilInstance is a regression test for issue #338.
+// When ResetToNormalMode is called with a nil instance (e.g., the user pressed
+// ESC while the sidebar header was selected), the pane previously returned
+// early without clearing isScrolling, leaving it stuck on stale viewport
+// content. After the fix, the scroll state must be cleared regardless of
+// whether an instance is provided.
+func TestPreviewResetToNormalModeNilInstance(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+
+	// Simulate being in scroll mode with stale viewport content.
+	const staleContent = "stale-scroll-content-line\nanother-line"
+	p.isScrolling = true
+	p.viewport.SetContent(staleContent)
+
+	require.True(t, p.isScrolling, "precondition: should be in scrolling mode")
+	require.Contains(t, p.viewport.View(), "stale-scroll-content-line",
+		"precondition: viewport should hold stale content")
+
+	// Calling ResetToNormalMode with nil must still clear scroll state.
+	err := p.ResetToNormalMode(nil)
+	require.NoError(t, err)
+
+	require.False(t, p.isScrolling,
+		"isScrolling must be false after ResetToNormalMode(nil)")
+
+	// The rendered output must no longer be the stale scroll-mode viewport.
+	rendered := p.String()
+	require.NotContains(t, rendered, "stale-scroll-content-line",
+		"rendered content must not be the stale scroll-mode viewport after reset")
+}
+
 // TestPreviewFallbackHeightNoDoubleCounting ensures that the fallback welcome
 // screen does not over-subtract lines for borders/margins that
 // TabbedWindow.SetSize has already stripped. Previously it subtracted 7, which


### PR DESCRIPTION
## Summary
- `PreviewPane.ResetToNormalMode` returned early on a nil instance, skipping the `isScrolling=false` reset and viewport clear. Pressing ESC while the sidebar header was selected left the preview pane stuck on stale scroll-mode content until app restart.
- Reorder the function to clear scroll state unconditionally first (mirroring `TerminalPane.ResetToNormalMode`), then early-return when there is no instance, then refresh the preview text only when an instance is available.
- Add a regression test that enters scroll mode with stale viewport content, calls `ResetToNormalMode(nil)`, and asserts that `isScrolling` is false and the rendered output no longer contains the stale viewport content.

Fixes #338

## Test plan
- [x] `gofmt -l .` (no output)
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test ./ui/ -run TestPreviewResetToNormalModeNilInstance -v`

Generated with [Claude Code](https://claude.com/claude-code)