### PR TITLE
fix(daemon): match --daemon as a complete arg, not a substring

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -190,9 +190,13 @@ func StopDaemon() error {
 }
 
 // isAgentFactoryDaemon checks whether the process at pid looks like an agent-factory daemon
-// (i.e. its command line contains the --daemon flag). It tries /proc/<pid>/cmdline first (Linux)
-// and falls back to `ps -p <pid> -o args=` (macOS and other unixes). If neither source yields a
-// readable command line, returns false so callers treat the PID as unverified.
+// (i.e. its command line contains the --daemon flag as a discrete argument). It tries
+// /proc/<pid>/cmdline first (Linux) and falls back to `ps -p <pid> -o args=` (macOS and other
+// unixes). If neither source yields a readable command line, returns false so callers treat the
+// PID as unverified.
+//
+// We split the command line on whitespace and require an exact "--daemon" token (or a
+// "--daemon=..." form), so flags like --daemonize don't get matched as substrings.
 func isAgentFactoryDaemon(pid int) bool {
 	cmdline := readProcCmdline(pid)
 	if cmdline == "" {
@@ -201,7 +205,19 @@ func isAgentFactoryDaemon(pid int) bool {
 	if cmdline == "" {
 		return false
 	}
-	return strings.Contains(cmdline, "--daemon")
+	return cmdlineHasDaemonFlag(cmdline)
+}
+
+// cmdlineHasDaemonFlag reports whether cmdline contains "--daemon" as a discrete argument
+// (either bare or in the "--daemon=value" form). It deliberately rejects substring matches like
+// "--daemonize" or "--daemon-mode".
+func cmdlineHasDaemonFlag(cmdline string) bool {
+	for _, field := range strings.Fields(cmdline) {
+		if field == "--daemon" || strings.HasPrefix(field, "--daemon=") {
+			return true
+		}
+	}
+	return false
 }
 
 // readProcCmdline returns the full command line for pid via /proc/<pid>/cmdline (Linux).

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -104,6 +104,31 @@ func TestStopDaemon_NonExistentPID(t *testing.T) {
 	}
 }
 
+// TestCmdlineHasDaemonFlag verifies that --daemon is matched only as a discrete argument,
+// not as a substring of unrelated flags like --daemonize. Regression test for issue #342.
+func TestCmdlineHasDaemonFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdline string
+		want    bool
+	}{
+		{name: "empty", cmdline: "", want: false},
+		{name: "bare --daemon flag", cmdline: "/usr/local/bin/agent-factory --daemon", want: true},
+		{name: "--daemon with leading args", cmdline: "agent-factory --verbose --daemon", want: true},
+		{name: "--daemon= form", cmdline: "agent-factory --daemon=foo", want: true},
+		{name: "--daemonize substring should not match", cmdline: "/usr/bin/some-tool --daemonize", want: false},
+		{name: "--daemon-mode substring should not match", cmdline: "agent-factory --daemon-mode", want: false},
+		{name: "no daemon flag at all", cmdline: "/usr/bin/sleep 60", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cmdlineHasDaemonFlag(tt.cmdline); got != tt.want {
+				t.Errorf("cmdlineHasDaemonFlag(%q) = %v, want %v", tt.cmdline, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestStopDaemon_RefusesSelfPID verifies that StopDaemon refuses to kill the current test process
 // even if the PID file points at it.
 func TestStopDaemon_RefusesSelfPID(t *testing.T) {


### PR DESCRIPTION
## Summary
- `isAgentFactoryDaemon` used `strings.Contains(cmdline, \"--daemon\")`, which also matched processes whose cmdline contained `--daemonize` (or `--daemon-mode`, etc.). After PID reuse, `StopDaemon` could kill an unrelated process.
- Fix splits the cmdline into fields and accepts only an exact `--daemon` token or the `--daemon=...` form, so substring lookalikes no longer match.
- Adds a `cmdlineHasDaemonFlag` table-driven regression test covering bare `--daemon`, `--daemon=foo`, `--daemonize`, `--daemon-mode`, and the empty-cmdline case.

Fixes #342

## Test plan
- [x] `gofmt -l .` produces no output
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (including new `TestCmdlineHasDaemonFlag` and existing `TestStopDaemon_*` tests)

Generated with [Claude Code](https://claude.com/claude-code)