### PR TITLE
fix(session/git): skip CleanupWorktreesForRepo for missing repo paths

### DIFF
--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -231,6 +231,17 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 		return fmt.Errorf("repo root is empty")
 	}
 
+	// Skip cleanup if the repo path no longer exists on disk. `af reset`
+	// iterates over collected repo roots, which may include deleted, moved,
+	// or unmounted paths; without this check, `git -C` would fail and abort
+	// the entire reset before subsequent repos (and DeleteAllInstances) ran.
+	if _, err := os.Stat(repoRoot); os.IsNotExist(err) {
+		log.WarningLog.Printf("skipping cleanup for deleted repo: %s", repoRoot)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to access repo path: %w", err)
+	}
+
 	// List all worktrees from the repo
 	cmd := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain")
 	output, err := cmd.Output()

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"bytes"
+	stdlog "log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -396,4 +398,28 @@ func TestCleanupWorktreesForRepo_CleansGivenRepo(t *testing.T) {
 	require.NoError(t, err, string(out))
 	assert.Equal(t, 1, strings.Count(string(out), "worktree "),
 		"only the main worktree should remain, got:\n%s", string(out))
+}
+
+// TestCleanupWorktreesForRepo_SkipsMissingPath verifies that when a stored
+// repo root no longer exists on disk (e.g. because the user moved or deleted
+// the repo), CleanupWorktreesForRepo logs a warning and returns nil instead
+// of aborting `af reset`. See issue #341.
+func TestCleanupWorktreesForRepo_SkipsMissingPath(t *testing.T) {
+	// Redirect WarningLog to a buffer so we can assert on the message.
+	var buf bytes.Buffer
+	origWarning := log.WarningLog
+	log.WarningLog = stdlog.New(&buf, "WARNING: ", 0)
+	t.Cleanup(func() { log.WarningLog = origWarning })
+
+	missing := filepath.Join(t.TempDir(), "definitely-does-not-exist")
+	// Sanity: the path really is absent.
+	_, statErr := os.Stat(missing)
+	require.True(t, os.IsNotExist(statErr), "test setup: path should not exist")
+
+	err := CleanupWorktreesForRepo(missing)
+	require.NoError(t, err,
+		"CleanupWorktreesForRepo should return nil when the repo path is missing")
+
+	assert.Contains(t, buf.String(), "skipping cleanup for deleted repo",
+		"expected warning log about skipped cleanup, got: %q", buf.String())
 }


### PR DESCRIPTION
## Summary
- `af reset` iterates collected repo roots, which may include deleted, moved, or unmounted paths.
- `CleanupWorktreesForRepo` previously shelled out directly to `git -C <repoRoot>`, so the first missing path aborted the entire reset and `DeleteAllInstances` never ran.
- Stat the repo path up front: warn and return `nil` for nonexistent paths, return a wrapped error for other stat failures.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New `TestCleanupWorktreesForRepo_SkipsMissingPath` regression test verifies the helper returns `nil` and logs `skipping cleanup for deleted repo` when given a nonexistent path.

Fixes #341

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>