### PR TITLE
fix(ui): drop ellipsis tail when container is narrower than the tail

### DIFF
--- a/ui/err.go
+++ b/ui/err.go
@@ -49,7 +49,12 @@ func (e *ErrBox) String() string {
 			// Otherwise just hard-truncate to avoid losing more content
 			// to the 3-char ellipsis than we save by truncating.
 			tail := "..."
-			if runewidth.StringWidth(err) <= e.width+runewidth.StringWidth(tail) {
+			tailWidth := runewidth.StringWidth(tail)
+			if e.width < tailWidth {
+				// Container is too narrow to fit "..."; drop the tail to
+				// avoid overflowing past e.width (lipgloss.Place won't clip).
+				tail = ""
+			} else if runewidth.StringWidth(err) <= e.width+tailWidth {
 				tail = ""
 			}
 			err = runewidth.Truncate(err, e.width, tail)

--- a/ui/err_test.go
+++ b/ui/err_test.go
@@ -1,0 +1,80 @@
+package ui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// TestErrBoxNarrowWidthDoesNotOverflow is a regression test for issue #337.
+// When the container width is less than the width of the "..." tail,
+// runewidth.Truncate(..., width, "...") returns "..." which is wider than
+// the container. lipgloss.Place does not clip, so the overflow is visible.
+// The fix drops the ellipsis tail when the container can't fit it.
+func TestErrBoxNarrowWidthDoesNotOverflow(t *testing.T) {
+	for _, width := range []int{1, 2, 3} {
+		width := width
+		t.Run("width="+itoa(width), func(t *testing.T) {
+			e := NewErrBox()
+			e.SetSize(width, 1)
+			e.SetError(errors.New("a very long error message that needs truncation"))
+
+			out := e.String()
+			// lipgloss.Place pads with spaces; check each line's rune width.
+			for _, line := range strings.Split(out, "\n") {
+				if got := runewidth.StringWidth(stripANSI(line)); got > width {
+					t.Errorf("rendered line width %d exceeds container width %d (line=%q)", got, width, line)
+				}
+			}
+		})
+	}
+}
+
+// itoa is a tiny helper to avoid importing strconv just for subtest names.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// stripANSI removes ANSI escape sequences (CSI) so width measurements
+// reflect only visible runes.
+func stripANSI(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			// Skip until a final byte in the range 0x40-0x7e.
+			j := i + 2
+			for j < len(s) {
+				c := s[j]
+				j++
+				if c >= 0x40 && c <= 0x7e {
+					break
+				}
+			}
+			i = j - 1
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -475,7 +475,14 @@ func (s *Sidebar) renderHeader(kind SidebarSectionKind, selected bool) string {
 	w := AdjustPreviewWidth(s.width)
 	text := arrow + label
 	if w > 0 && runewidth.StringWidth(text) > w {
-		text = runewidth.Truncate(text, w, "...")
+		// Drop the "..." tail when the container is too narrow to fit it,
+		// otherwise runewidth.Truncate returns content wider than w and
+		// lipgloss.Place won't clip the overflow.
+		tail := "..."
+		if w < runewidth.StringWidth(tail) {
+			tail = ""
+		}
+		text = runewidth.Truncate(text, w, tail)
 	}
 	return style.Padding(0, 1).Render(
 		lipgloss.Place(w, 1, lipgloss.Left, lipgloss.Center, text))


### PR DESCRIPTION
## Summary
- Fix overflow in `ErrBox` and `Sidebar` section header rendering when container width is 1 or 2: `runewidth.Truncate(..., w, "...")` returns the full 3-rune `"..."` even when `w < 3`, and `lipgloss.Place` does not clip the result.
- Match the safe pattern already used in `ui/list.go` by dropping the ellipsis tail when the container can't fit it.
- Add a regression test (`ui/err_test.go`) that exercises widths 1, 2, and 3 and asserts no rendered line exceeds the container width.

Fixes #337

## Test plan
- [x] `gofmt -l .` produces no output
- [x] `go build ./...`
- [x] `go test ./...` (full suite passes)
- [x] New test fails on master (verified via `git stash`) and passes with the fix

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>