### PR TITLE
fix(log): redirect loggers to stderr in Close to avoid silent drops

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -84,6 +84,19 @@ func Close() {
 
 	if globalLogFile != nil {
 		_ = globalLogFile.Close()
+		globalLogFile = nil
+	}
+	// Redirect any further log writes to stderr so that messages from
+	// goroutines that outlive Close() are not silently dropped to a closed
+	// fd. log.Logger.SetOutput is documented as safe for concurrent use.
+	if InfoLog != nil {
+		InfoLog.SetOutput(os.Stderr)
+	}
+	if WarningLog != nil {
+		WarningLog.SetOutput(os.Stderr)
+	}
+	if ErrorLog != nil {
+		ErrorLog.SetOutput(os.Stderr)
 	}
 	fmt.Fprintln(os.Stderr, "wrote logs to "+logFileName)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,6 +1,9 @@
 package log
 
 import (
+	"io"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -22,4 +25,46 @@ func TestInitializeRace(t *testing.T) {
 
 	// Clean up the file descriptor opened by the last Initialize call.
 	Close()
+}
+
+// TestCloseRedirectsToStderr verifies that after Close(), the package-level
+// loggers no longer point at the closed log file fd. Instead they should be
+// redirected to stderr so late writes from background goroutines surface
+// rather than being silently dropped.
+func TestCloseRedirectsToStderr(t *testing.T) {
+	// Redirect the process's stderr to a pipe so we can observe what Close()
+	// and any subsequent log call actually write.
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	Initialize(false)
+	Close()
+
+	// Logging after Close should not panic and should reach stderr (the pipe).
+	const msg = "post-close-message-xyz"
+	InfoLog.Println(msg)
+	WarningLog.Println(msg)
+	ErrorLog.Println(msg)
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	captured, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+
+	if !strings.Contains(string(captured), msg) {
+		t.Fatalf("expected post-close log message %q to appear on stderr, got: %q", msg, string(captured))
+	}
+
+	// globalLogFile should be cleared so a follow-up Close is a no-op.
+	if globalLogFile != nil {
+		t.Fatalf("expected globalLogFile to be nil after Close")
+	}
 }


### PR DESCRIPTION
## Summary
- `log.Close()` closed `globalLogFile` but left `InfoLog` / `WarningLog` / `ErrorLog` pointing at the closed fd, so any post-`Close` log call (e.g. from background goroutines that outlive shutdown) was silently discarded — Go's `log.Logger` swallows write errors.
- Fix: in `Close()`, after closing the file, call `SetOutput(os.Stderr)` on each logger and `nil` out `globalLogFile`. `log.Logger.SetOutput` is documented as safe for concurrent use.
- Added `TestCloseRedirectsToStderr` regression test that captures stderr via a pipe, runs `Initialize` then `Close`, then logs and asserts the message reaches stderr and `globalLogFile` is cleared.

Fixes #327

## Test plan
- [x] `gofmt -l .` produces no output
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test ./log/ -v -run TestCloseRedirectsToStderr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)