### PR TITLE
fix(api/tasks): roll back scheduler when updateTask fails

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -22,6 +22,7 @@ var TasksCmd = &cobra.Command{
 var (
 	installScheduler = task.InstallScheduler
 	removeScheduler  = task.RemoveScheduler
+	updateTask       = task.UpdateTask
 )
 
 var tasksListCmd = &cobra.Command{
@@ -236,13 +237,15 @@ var tasksUpdateCmd = &cobra.Command{
 		// the scheduler (even if cron changed), so a disabled task never
 		// has an active timer. When enabled we (re)install the scheduler
 		// with the new cron. See #258.
+		oldCron := ""
+		schedulerInstalled := false
+		schedulerRemoved := false
 		if cronChanged || enabledChanged {
-			if s.Enabled {
-				oldCron := ""
-				if old, err := task.GetTask(s.ID); err == nil {
-					oldCron = old.CronExpr
-				}
+			if old, err := task.GetTask(s.ID); err == nil {
+				oldCron = old.CronExpr
+			}
 
+			if s.Enabled {
 				// Install the new scheduler (overwrites existing unit/plist
 				// because the scheduler key is the task ID).
 				if err := installScheduler(*s); err != nil {
@@ -259,14 +262,45 @@ var tasksUpdateCmd = &cobra.Command{
 					}
 					return jsonError(fmt.Errorf("failed to reinstall scheduler: %w", err))
 				}
+				schedulerInstalled = true
 			} else {
 				if err := removeScheduler(*s); err != nil {
 					return jsonError(fmt.Errorf("failed to remove task scheduler: %w", err))
 				}
+				schedulerRemoved = true
 			}
 		}
 
-		if err := task.UpdateTask(*s); err != nil {
+		if err := updateTask(*s); err != nil {
+			// Roll back the scheduler change so the system doesn't stay
+			// in an inconsistent state where the scheduler reflects new
+			// settings but the JSON still has the old ones (fixes #324).
+			// Mirrors the install-failure rollback above; best-effort.
+			if schedulerInstalled {
+				if wasEnabled && oldCron != "" {
+					// Previously enabled — restore old cron.
+					rollback := *s
+					rollback.CronExpr = oldCron
+					if rbErr := installScheduler(rollback); rbErr != nil {
+						log.ErrorLog.Printf("failed to rollback scheduler after updateTask failure: %v", rbErr)
+					}
+				} else {
+					// Was disabled — undo the install by removing.
+					rollback := *s
+					rollback.Enabled = false
+					if rbErr := removeScheduler(rollback); rbErr != nil {
+						log.ErrorLog.Printf("failed to rollback scheduler after updateTask failure: %v", rbErr)
+					}
+				}
+			} else if schedulerRemoved && wasEnabled && oldCron != "" {
+				// Was enabled — re-install with old cron to undo the removal.
+				rollback := *s
+				rollback.Enabled = true
+				rollback.CronExpr = oldCron
+				if rbErr := installScheduler(rollback); rbErr != nil {
+					log.ErrorLog.Printf("failed to rollback scheduler after updateTask failure: %v", rbErr)
+				}
+			}
 			return jsonError(fmt.Errorf("failed to update task: %w", err))
 		}
 

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/task"
@@ -13,18 +14,20 @@ import (
 // tests can assert that `af tasks update` reconciles systemd state
 // correctly (see #258).
 type schedulerCalls struct {
-	installed []task.Task
-	removed   []task.Task
+	installed     []task.Task
+	removed       []task.Task
+	updateTaskErr error
 }
 
-// stubSchedulers swaps installScheduler/removeScheduler for in-memory
-// stubs and restores them on test cleanup.
+// stubSchedulers swaps installScheduler/removeScheduler/updateTask for
+// in-memory stubs and restores them on test cleanup.
 func stubSchedulers(t *testing.T) *schedulerCalls {
 	t.Helper()
 	calls := &schedulerCalls{}
 
 	origInstall := installScheduler
 	origRemove := removeScheduler
+	origUpdate := updateTask
 	installScheduler = func(tsk task.Task) error {
 		calls.installed = append(calls.installed, tsk)
 		return nil
@@ -33,9 +36,16 @@ func stubSchedulers(t *testing.T) *schedulerCalls {
 		calls.removed = append(calls.removed, tsk)
 		return nil
 	}
+	updateTask = func(tsk task.Task) error {
+		if calls.updateTaskErr != nil {
+			return calls.updateTaskErr
+		}
+		return origUpdate(tsk)
+	}
 	t.Cleanup(func() {
 		installScheduler = origInstall
 		removeScheduler = origRemove
+		updateTask = origUpdate
 	})
 	return calls
 }
@@ -199,4 +209,79 @@ func TestTasksUpdate_EnabledToggleNoOpWhenAlreadyEnabled(t *testing.T) {
 
 	assert.Empty(t, calls.installed, "setting enabled=true on already-enabled task should be a no-op")
 	assert.Empty(t, calls.removed)
+}
+
+// TestTasksUpdate_RollsBackSchedulerWhenUpdateTaskFails is the
+// regression test for #324: when installScheduler succeeds but the
+// subsequent updateTask write fails, tasksUpdateCmd must best-effort
+// roll back the scheduler so that JSON state and scheduler state stay
+// consistent.
+func TestTasksUpdate_RollsBackSchedulerWhenUpdateTaskFails(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubSchedulers(t)
+
+	seedTask(t, task.Task{ID: "t8", CronExpr: "0 9 * * *", Enabled: true})
+
+	calls.updateTaskErr = errors.New("simulated JSON write failure")
+	taskUpdateCronFlag = "0 10 * * *"
+
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t8"})
+	assert.Error(t, err, "update should fail when JSON write fails")
+
+	// Scheduler was installed with the new cron, then rolled back to
+	// the old cron when the JSON write failed.
+	require.Len(t, calls.installed, 2, "scheduler should be installed then rolled back")
+	assert.Equal(t, "0 10 * * *", calls.installed[0].CronExpr, "first install uses new cron")
+	assert.Equal(t, "0 9 * * *", calls.installed[1].CronExpr, "rollback restores old cron")
+
+	// JSON file still has the old cron because updateTask failed.
+	got, err := task.GetTask("t8")
+	require.NoError(t, err)
+	assert.Equal(t, "0 9 * * *", got.CronExpr, "JSON should retain old cron after failed write")
+}
+
+// TestTasksUpdate_RollsBackSchedulerInstallOnEnableWhenUpdateTaskFails
+// covers the disabled→enabled transition: installScheduler succeeded
+// but updateTask failed, so the scheduler install should be undone via
+// removeScheduler.
+func TestTasksUpdate_RollsBackSchedulerInstallOnEnableWhenUpdateTaskFails(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubSchedulers(t)
+
+	seedTask(t, task.Task{ID: "t9", CronExpr: "0 9 * * *", Enabled: false})
+
+	calls.updateTaskErr = errors.New("simulated JSON write failure")
+	taskUpdateEnabledFlag = "true"
+
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t9"})
+	assert.Error(t, err, "update should fail when JSON write fails")
+
+	require.Len(t, calls.installed, 1, "scheduler should be installed once")
+	require.Len(t, calls.removed, 1, "scheduler install should be rolled back via remove")
+	assert.Equal(t, "t9", calls.removed[0].ID)
+}
+
+// TestTasksUpdate_RollsBackSchedulerRemoveOnDisableWhenUpdateTaskFails
+// covers the enabled→disabled transition: removeScheduler succeeded
+// but updateTask failed, so the scheduler should be re-installed with
+// the old cron.
+func TestTasksUpdate_RollsBackSchedulerRemoveOnDisableWhenUpdateTaskFails(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubSchedulers(t)
+
+	seedTask(t, task.Task{ID: "t10", CronExpr: "0 9 * * *", Enabled: true})
+
+	calls.updateTaskErr = errors.New("simulated JSON write failure")
+	taskUpdateEnabledFlag = "false"
+
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t10"})
+	assert.Error(t, err, "update should fail when JSON write fails")
+
+	require.Len(t, calls.removed, 1, "scheduler should be removed once")
+	require.Len(t, calls.installed, 1, "scheduler remove should be rolled back via install")
+	assert.Equal(t, "0 9 * * *", calls.installed[0].CronExpr, "rollback restores old cron")
+	assert.True(t, calls.installed[0].Enabled, "rollback restores enabled=true")
 }


### PR DESCRIPTION
## Summary
- `tasksUpdateCmd` in `api/tasks.go` already rolled back the scheduler when `installScheduler` failed, but the symmetric case — scheduler change succeeded, then `updateTask` (JSON write) failed — left the system inconsistent: the scheduler ran with the new cron / enabled state while the JSON kept the old one.
- Added best-effort scheduler rollback after a successful scheduler change when `updateTask` returns an error, mirroring the existing install-failure rollback pattern. Failures during rollback are logged.
- Indirected `task.UpdateTask` through a package-level `updateTask` var so tests can stub the JSON-write failure.

## Rollback matrix
- Cron change on enabled task (was enabled): re-install with old cron.
- Disabled → enabled: remove scheduler (undo install).
- Enabled → disabled: re-install with old cron + enabled=true (undo remove).

## Test plan
- [x] Added `TestTasksUpdate_RollsBackSchedulerWhenUpdateTaskFails` (cron change rollback path) — matches the failing test from #324.
- [x] Added `TestTasksUpdate_RollsBackSchedulerInstallOnEnableWhenUpdateTaskFails` (disabled→enabled).
- [x] Added `TestTasksUpdate_RollsBackSchedulerRemoveOnDisableWhenUpdateTaskFails` (enabled→disabled).
- [x] `gofmt -l .` clean
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run --timeout=3m --fast` clean

Fixes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)