### PR TITLE
fix(task/launchd): reject cron expressions combining DOM and DOW

### DIFF
--- a/task/launchd.go
+++ b/task/launchd.go
@@ -232,35 +232,13 @@ func cronToCalendarIntervalXML(cronExpr string) (string, error) {
 		return result, nil
 	}
 
-	var combos []combo
 	if bothDOMandDOW {
-		// OR semantics: generate DOM combos (without DOW) and DOW combos (without DOM).
-		domFields := make([]expandedField, len(expanded))
-		copy(domFields, expanded)
-		domFields[dowIdx] = expandedField{key: "Weekday", vals: nil} // exclude DOW
+		return "", fmt.Errorf("cron expression %q combines day-of-month and day-of-week; macOS launchd cannot correctly express this. Use either DOM or DOW, not both", cronExpr)
+	}
 
-		dowFields := make([]expandedField, len(expanded))
-		copy(dowFields, expanded)
-		dowFields[domIdx] = expandedField{key: "Day", vals: nil} // exclude DOM
-
-		domCombos, err := buildCombos(domFields)
-		if err != nil {
-			return "", err
-		}
-		dowCombos, err := buildCombos(dowFields)
-		if err != nil {
-			return "", err
-		}
-		combos = append(domCombos, dowCombos...)
-		if len(combos) > maxCalendarIntervals {
-			return "", fmt.Errorf("cron expression %q expands to too many intervals (%d > %d)", cronExpr, len(combos), maxCalendarIntervals)
-		}
-	} else {
-		var err error
-		combos, err = buildCombos(expanded)
-		if err != nil {
-			return "", err
-		}
+	combos, err := buildCombos(expanded)
+	if err != nil {
+		return "", err
 	}
 
 	if len(combos) == 0 || (len(combos) == 1 && len(combos[0]) == 0) {

--- a/task/launchd_test.go
+++ b/task/launchd_test.go
@@ -64,18 +64,27 @@ func TestCronToCalendarIntervalXML_DOWStepCoversAll(t *testing.T) {
 	assert.NotContains(t, xml, "<key>Weekday</key>")
 }
 
-// TestCronToCalendarIntervalXML_BothRestricted verifies that when DOM and
-// DOW are both restricted and neither covers all values, we still emit
-// the OR-semantics union (one DOM dict + one DOW dict).
-func TestCronToCalendarIntervalXML_BothRestricted(t *testing.T) {
-	xml, err := cronToCalendarIntervalXML("0 9 1 * 1")
-	require.NoError(t, err)
-
-	// Expect two dicts: one for Day=1 (with Hour/Minute) and one for
-	// Weekday=1 (with Hour/Minute).
-	assert.Equal(t, 2, countDicts(xml), "expected exactly two dicts, got:\n%s", xml)
-	assert.Contains(t, xml, "<key>Day</key>")
-	assert.Contains(t, xml, "<key>Weekday</key>")
+// TestCronToCalendarIntervalXML_BothRestrictedRejected verifies that when
+// DOM and DOW are both restricted and neither covers all values, the
+// expression is rejected. launchd cannot express the cron OR-semantics
+// without double-firing on dates that match both fields, so we surface a
+// clear error rather than silently scheduling duplicate runs.
+func TestCronToCalendarIntervalXML_BothRestrictedRejected(t *testing.T) {
+	cases := []string{
+		"0 9 1 * 1",     // single DOM, single DOW
+		"0 9 1,15 * 2",  // multi DOM, single DOW
+		"0 9 1-5 * 1-3", // range DOM, range DOW
+		"0 9 */10 * 1",  // step DOM, single DOW
+	}
+	for _, expr := range cases {
+		expr := expr
+		t.Run(expr, func(t *testing.T) {
+			xml, err := cronToCalendarIntervalXML(expr)
+			require.Error(t, err, "expected rejection for %q", expr)
+			assert.Empty(t, xml)
+			assert.Contains(t, err.Error(), "day-of-month and day-of-week")
+		})
+	}
 }
 
 // TestCronToCalendarIntervalXML_WildcardDOW verifies the baseline case


### PR DESCRIPTION
## Summary
- Replaces the OR-semantics workaround in `cronToCalendarIntervalXML` with a clear rejection when both day-of-month and day-of-week are restricted.
- The previous code emitted two `StartCalendarInterval` dicts that launchd evaluates independently, so on dates matching both DOM and DOW the task fired twice; the second invocation hit the runner lock with a misleading "another run is already active" error.
- Users can split into separate tasks if both DOM and DOW scheduling are genuinely needed.

## Test plan
- [x] `gofmt -w . && gofmt -l .` produces no output
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `GOOS=darwin go build ./...` and `go vet ./task/...` pass
- [x] New regression test `TestCronToCalendarIntervalXML_BothRestrictedRejected` covers `0 9 1 * 1` and several other DOM+DOW combinations and asserts the rejection error message

Fixes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)