### PR TITLE
fix(session/backend_hook): clean up dead preview process so ensurePTY can recreate

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -243,8 +243,17 @@ func (b *HookBackend) ensurePTY(i *Instance) {
 	if b.ptys == nil {
 		b.ptys = make(map[string]*hookPTY)
 	}
-	if _, ok := b.ptys[i.Title]; ok {
-		return
+	if existing, ok := b.ptys[i.Title]; ok {
+		// If the existing entry is still alive, reuse it. Otherwise drop
+		// the stale entry and fall through to create a fresh process so
+		// preview can recover after attach_cmd has exited.
+		existing.mu.Lock()
+		alive := !existing.closed
+		existing.mu.Unlock()
+		if alive {
+			return
+		}
+		delete(b.ptys, i.Title)
 	}
 
 	slug := slugify(i.Title)
@@ -293,6 +302,24 @@ func (b *HookBackend) ensurePTY(i *Instance) {
 				break
 			}
 		}
+		// The reader has hit EOF or an error, which means the attach_cmd
+		// child has closed its stdout (typically because it exited).
+		// If closePTY already marked us closed, it owns the Wait() call
+		// (and may need to Kill the process); otherwise the child exited
+		// on its own, so we Wait() here to reap it and mark the entry
+		// closed so a subsequent ensurePTY call can recreate it.
+		hp.mu.Lock()
+		alreadyClosed := hp.closed
+		hp.mu.Unlock()
+		if alreadyClosed {
+			return
+		}
+		if err := hp.cmd.Wait(); err != nil {
+			log.ErrorLog.Printf("attach_cmd preview process exited: %v", err)
+		}
+		hp.mu.Lock()
+		hp.closed = true
+		hp.mu.Unlock()
 	}()
 }
 

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -577,6 +577,87 @@ func TestHookBackendClosePTYNonexistent(t *testing.T) {
 	b.closePTY("nonexistent")
 }
 
+// TestHookBackendEnsurePTYRecreatesAfterAttachCmdExits verifies that when
+// attach_cmd exits on its own (e.g. SSH disconnect, remote-side restart),
+// a subsequent ensurePTY call replaces the dead entry instead of leaving
+// it cached forever. Regression test for issue #328.
+func TestHookBackendEnsurePTYRecreatesAfterAttachCmdExits(t *testing.T) {
+	dir := t.TempDir()
+	// attach_cmd exits immediately so the read goroutine sees EOF and
+	// must mark the hookPTY closed.
+	attachCmd := writeScript(t, dir, "attach.sh",
+		`echo "first run for $1"; exit 0`)
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{AttachCmd: attachCmd},
+	}
+	i := &Instance{
+		Title:   "recreate-test",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	b.ensurePTY(i)
+
+	// Wait for the reader goroutine to observe EOF and mark the entry closed.
+	deadline := time.Now().Add(2 * time.Second)
+	var hp *hookPTY
+	for time.Now().Before(deadline) {
+		hp = b.getPTY(i.Title)
+		if hp == nil {
+			t.Fatalf("ensurePTY did not register a hookPTY entry")
+		}
+		hp.mu.Lock()
+		closed := hp.closed
+		hp.mu.Unlock()
+		if closed {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	hp.mu.Lock()
+	closed := hp.closed
+	hp.mu.Unlock()
+	require.True(t, closed,
+		"reader goroutine should have marked the dead entry as closed")
+	firstCmd := hp.cmd
+
+	// A second ensurePTY call must drop the stale entry and start a new
+	// process rather than returning early.
+	b.ensurePTY(i)
+	hp2 := b.getPTY(i.Title)
+	require.NotNil(t, hp2)
+	assert.NotSame(t, firstCmd, hp2.cmd,
+		"ensurePTY should have created a fresh process, not reused the dead one")
+
+	// Cleanup: the second process also exits quickly, but closePTY is idempotent.
+	b.closePTY(i.Title)
+}
+
+// TestHookBackendEnsurePTYReturnsEarlyWhenAlive ensures we don't replace a
+// healthy preview process — only stale ones get recreated.
+func TestHookBackendEnsurePTYReturnsEarlyWhenAlive(t *testing.T) {
+	b := makeHooks(t) // attach script sleeps 0.1s, alive when we re-check
+	i := &Instance{
+		Title:   "alive-test",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	b.ensurePTY(i)
+	hp := b.getPTY(i.Title)
+	require.NotNil(t, hp)
+	firstCmd := hp.cmd
+
+	// Immediately call ensurePTY again — the existing entry is still alive.
+	b.ensurePTY(i)
+	hp2 := b.getPTY(i.Title)
+	require.NotNil(t, hp2)
+	assert.Same(t, firstCmd, hp2.cmd,
+		"ensurePTY must reuse a live entry rather than spawning a duplicate")
+
+	b.closePTY(i.Title)
+}
+
 // --- Instance delegation ---
 
 func TestInstanceDelegatesStartToBackend(t *testing.T) {


### PR DESCRIPTION
## Summary
- The stdout-reader goroutine in `HookBackend.ensurePTY` broke out of its loop without ever calling `cmd.Wait()` or marking the `hookPTY` closed, so when `attach_cmd` exited (e.g. SSH disconnect, remote-side restart) the dead entry stayed cached in `b.ptys` forever.
- `ensurePTY` returned early whenever `b.ptys[i.Title]` existed, regardless of liveness, which meant preview was permanently broken until the app was restarted.
- After the read loop exits we now reap the child with `cmd.Wait()` (unless `closePTY` already owns Wait) and set `hp.closed = true`. `ensurePTY` skips stale entries and creates a fresh process.

Fixes #328

## Test plan
- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] New regression test `TestHookBackendEnsurePTYRecreatesAfterAttachCmdExits` exercises the fix path (attach_cmd exits, second ensurePTY call must spawn a new process).
- [x] New `TestHookBackendEnsurePTYReturnsEarlyWhenAlive` guards against accidentally double-spawning when the preview process is healthy.

Generated with [Claude Code](https://claude.com/claude-code)