### PR TITLE
fix(session/tmux): coordinate Close with Attach goroutines

### DIFF
--- a/session/tmux/race_test.go
+++ b/session/tmux/race_test.go
@@ -1,0 +1,98 @@
+package tmux
+
+import (
+	"context"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+)
+
+// TestCloseDuringAttachRace is a regression test for issue #331.
+//
+// TmuxSession.Close used to nil out t.ptmx without coordinating with the
+// monitorWindowSize goroutines spawned by Attach. A concurrent shutdown
+// during attach raced and would panic dereferencing a nil PTY in
+// updateWindowSize.
+//
+// We simulate a minimal Attach lifecycle (without invoking the real
+// monitorWindowSize, which touches stdin/SIGWINCH and so is unsuitable
+// for tests) by spawning a goroutine modeled on the real one: it watches
+// ctx.Done and reads t.ptmx (the field) until cancelled. Close must
+// cancel the context and wg.Wait the goroutine before clearing t.ptmx,
+// otherwise the race detector will flag the read/write of t.ptmx and a
+// real callsite would panic.
+func TestCloseDuringAttachRace(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		ptyFactory := NewMockPtyFactory(t)
+		cmdExec := cmd_test.MockCmdExec{
+			RunFunc:    func(cmd *exec.Cmd) error { return nil },
+			OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+		}
+
+		session := newTmuxSession(toTmuxName("race-session", ""), "claude", ptyFactory, cmdExec)
+		if err := session.Restore(); err != nil {
+			t.Fatalf("Restore: %v", err)
+		}
+
+		// Mimic the bookkeeping that Attach() sets up so Close has goroutines
+		// to coordinate with.
+		session.attachCh = make(chan struct{})
+		session.wg = &sync.WaitGroup{}
+		session.ctx, session.cancel = context.WithCancel(context.Background())
+
+		// Stand-in for monitorWindowSize: reads t.ptmx (the field) until ctx
+		// is cancelled. Without the Close fix, the pre-fix Close cleared
+		// t.ptmx without cancelling the context first, so the read here
+		// raced with the field write in Close. We deliberately read only
+		// the field (not Fd()) to focus on the bug from #331 — the
+		// nil-pointer panic in updateWindowSize.
+		session.wg.Add(1)
+		go func() {
+			defer session.wg.Done()
+			for {
+				select {
+				case <-session.ctx.Done():
+					return
+				default:
+					if p := session.ptmx; p == nil {
+						t.Errorf("monitor goroutine observed nil ptmx before ctx cancel")
+						return
+					}
+				}
+			}
+		}()
+
+		// Let the goroutine spin so Close races with active reads.
+		time.Sleep(time.Microsecond)
+
+		if err := session.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+
+		if session.ptmx != nil {
+			t.Fatalf("expected ptmx to be nil after Close")
+		}
+	}
+}
+
+// TestCloseWithoutAttach ensures Close is safe when Attach was never called
+// (cancel/wg are nil).
+func TestCloseWithoutAttach(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("no-attach-session", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -482,11 +482,33 @@ func (t *TmuxSession) Detach() {
 func (t *TmuxSession) Close() error {
 	var errs []error
 
+	// Coordinate with any in-flight Attach goroutines (mirrors Detach):
+	// cancel context first so monitorWindowSize goroutines exit before we
+	// nil out t.ptmx, otherwise they can race against updateWindowSize and
+	// panic dereferencing a nil PTY. Safe to call when Attach was never
+	// invoked because cancel/wg are only set by Attach.
+	if t.cancel != nil {
+		t.cancel()
+		t.cancel = nil
+	}
+
 	if t.ptmx != nil {
 		if err := t.ptmx.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("error closing PTY: %w", err))
 		}
-		t.ptmx = nil
+	}
+
+	if t.wg != nil {
+		t.wg.Wait()
+		t.wg = nil
+	}
+
+	t.ptmx = nil
+	t.ctx = nil
+
+	if t.attachCh != nil {
+		close(t.attachCh)
+		t.attachCh = nil
 	}
 
 	cmd := exec.Command("tmux", "kill-session", "-t", t.sanitizedName)


### PR DESCRIPTION
## Summary
- `TmuxSession.Close()` cleared `t.ptmx` without coordinating with the `monitorWindowSize` goroutines that `Attach()` spawns. A concurrent shutdown during attach therefore raced against `updateWindowSize` and could panic on a nil PTY.
- Mirror `Detach()`'s coordination in `Close()`: cancel the attach context first, close the PTY, `wg.Wait()` for the monitor goroutines, then clear `t.ptmx`. The new code is a no-op when `Attach()` was never called (cancel/wg are nil).
- Added `session/tmux/race_test.go` with a regression test (`TestCloseDuringAttachRace`) that runs `Close` concurrently with a simulated monitor goroutine; without the fix it trips `-race` and observes nil `ptmx`. Also covers the no-attach path.

Fixes #331

## Test plan
- [x] `gofmt -w .` and `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -race ./session/tmux/...`
- [x] Verified the new regression test fails on master and passes with the fix

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)