### PR TITLE
fix(task/runner): save scheduled instance to per-repo storage before launching daemon

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -205,9 +205,38 @@ func RunTask(taskID string) error {
 	}
 	instance.SetStatus(session.Running)
 
-	// Write instance to a separate pending file to avoid racing with the
-	// daemon/TUI which also read-modify-write state.json concurrently.
-	if err := appendPendingInstance(instance.ToInstanceData()); err != nil {
+	// Apply AutoYes to the in-memory instance before persisting so the
+	// flag is part of the saved data the daemon will read back.
+	if cfg.AutoYes {
+		instance.AutoYes = true
+	}
+
+	// Persist the new instance into per-repo instances.json under the
+	// file lock. This is the source of truth the daemon reads via
+	// storage.LoadInstances; without this write, the daemon never sees
+	// scheduled tasks and AutoYes runs hang. Mirrors api/sessions.go.
+	repo, err := config.RepoFromPath(t.ProjectPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve repo for project path %s: %w", t.ProjectPath, err)
+	}
+	data := instance.ToInstanceData()
+	if err := config.UpdateRepoInstances(repo.ID, func(raw json.RawMessage) (json.RawMessage, error) {
+		var existing []session.InstanceData
+		if err := json.Unmarshal(raw, &existing); err != nil {
+			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
+		}
+		existing = append(existing, data)
+		return json.MarshalIndent(existing, "", "  ")
+	}); err != nil {
+		return fmt.Errorf("failed to save instance to per-repo storage: %w", err)
+	}
+
+	// Also write to the pending file so the running TUI (which doesn't
+	// re-read instances.json on every tick) can merge the new instance
+	// into its in-memory list at startup. This is defensive: the daemon
+	// reads from per-repo instances.json above, which is the load-bearing
+	// path for AutoYes.
+	if err := appendPendingInstance(data); err != nil {
 		return fmt.Errorf("failed to save pending instance: %w", err)
 	}
 
@@ -216,7 +245,6 @@ func RunTask(taskID string) error {
 
 	// Launch daemon for autoyes if configured.
 	if cfg.AutoYes {
-		instance.AutoYes = true
 		if err := daemon.LaunchDaemon(); err != nil {
 			log.ErrorLog.Printf("failed to launch daemon: %v", err)
 		}

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -2,10 +2,12 @@ package task
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
@@ -160,5 +162,110 @@ func TestLoadAndClearPendingInstances_Corrupted(t *testing.T) {
 
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("expected corrupted pending file to be removed, stat err = %v", err)
+	}
+}
+
+// runnerAppendInstance mirrors the inline UpdateRepoInstances callback in
+// RunTask. Keeping it identical here lets us exercise the per-repo write
+// path without spinning up a full session/tmux/git-worktree fixture.
+func runnerAppendInstance(repoID string, data session.InstanceData) error {
+	return config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {
+		var existing []session.InstanceData
+		if err := json.Unmarshal(raw, &existing); err != nil {
+			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
+		}
+		existing = append(existing, data)
+		return json.MarshalIndent(existing, "", "  ")
+	})
+}
+
+// TestRunTask_WritesToPerRepoStorage is the regression test for issue #334.
+// The bug: RunTask wrote scheduled instances only to pending_instances.json
+// and launched the daemon, which loads from per-repo instances.json. The
+// daemon therefore never saw the scheduled instance and AutoYes runs hung.
+// This test asserts that the per-repo storage write that RunTask now performs
+// produces a file the daemon path (config.LoadRepoInstances) can read back
+// with the new instance present.
+func TestRunTask_WritesToPerRepoStorage(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoID := "test-repo-334"
+	instancesPath, err := config.RepoInstancesPath(repoID)
+	if err != nil {
+		t.Fatalf("RepoInstancesPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(instancesPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	data := session.InstanceData{Title: "task-instance", AutoYes: true}
+	if err := runnerAppendInstance(repoID, data); err != nil {
+		t.Fatalf("runnerAppendInstance: %v", err)
+	}
+
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var got []session.InstanceData
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 instance in per-repo storage, got %d: %+v", len(got), got)
+	}
+	if got[0].Title != "task-instance" {
+		t.Fatalf("unexpected instance title: %q", got[0].Title)
+	}
+	if !got[0].AutoYes {
+		t.Fatalf("expected AutoYes=true on persisted instance so the daemon picks it up")
+	}
+}
+
+// TestRunTask_AppendsToExistingPerRepoStorage verifies that the runner's
+// append callback preserves existing instances written by other paths
+// (e.g. the API or TUI), so concurrent writers don't clobber each other.
+func TestRunTask_AppendsToExistingPerRepoStorage(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoID := "test-repo-334-merge"
+	instancesPath, err := config.RepoInstancesPath(repoID)
+	if err != nil {
+		t.Fatalf("RepoInstancesPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(instancesPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Pre-populate with an existing instance, simulating one created via
+	// the API or TUI.
+	preexisting := []session.InstanceData{{Title: "existing-from-api"}}
+	preRaw, err := json.MarshalIndent(preexisting, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal preexisting: %v", err)
+	}
+	if err := os.WriteFile(instancesPath, preRaw, 0644); err != nil {
+		t.Fatalf("write preexisting: %v", err)
+	}
+
+	if err := runnerAppendInstance(repoID, session.InstanceData{Title: "task-instance"}); err != nil {
+		t.Fatalf("runnerAppendInstance: %v", err)
+	}
+
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var got []session.InstanceData
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 instances after append, got %d: %+v", len(got), got)
+	}
+	if got[0].Title != "existing-from-api" || got[1].Title != "task-instance" {
+		t.Fatalf("unexpected merged instances: %+v", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes #334. RunTask wrote new instances only to `pending_instances.json` then launched the daemon, but the daemon loads from per-repo `instances.json` (via `storage.LoadInstances`) and never reads pending. AutoYes scheduled tasks therefore hung indefinitely because the daemon never saw the instance to send Enter to.
- Mirror the API path (`api/sessions.go`): resolve the repo from the task's project path and persist the new instance into per-repo `instances.json` via `config.UpdateRepoInstances` (file-locked, atomic) before launching the daemon. AutoYes is applied to the in-memory instance prior to serialization so the persisted record carries the flag.
- Pending writes are kept (defensive) so the running TUI can still merge new instances at startup; the per-repo write is the load-bearing change for the daemon.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] New regression tests in `task/runner_test.go`:
  - `TestRunTask_WritesToPerRepoStorage` confirms the runner's append callback produces a per-repo `instances.json` that `config.LoadRepoInstances` reads back with the new instance and AutoYes set.
  - `TestRunTask_AppendsToExistingPerRepoStorage` confirms pre-existing instances (e.g. created via the API) are preserved across the runner's append.

Fixes #334

Generated with [Claude Code](https://claude.com/claude-code)