### PR TITLE
fix(ui/menu): guard against non-positive dimensions

### DIFF
--- a/ui/menu.go
+++ b/ui/menu.go
@@ -212,6 +212,10 @@ func (m *Menu) SetSize(width, height int) {
 }
 
 func (m *Menu) String() string {
+	if m.width <= 0 || m.height <= 0 {
+		return ""
+	}
+
 	var s strings.Builder
 
 	for i, k := range m.options {


### PR DESCRIPTION
## Summary
- Adds an early return in `Menu.String()` when `width <= 0` or `height <= 0`, matching the pattern already used in `ErrBox` and `ContentPane`.
- Prevents the menu from rendering with invalid dimensions on small terminals (where `menuHeight = msg.Height - contentHeight - 2` becomes non-positive).

## Test plan
- [x] `go build ./...`
- [x] `go test ./ui/...`

Closes #366