### PR TITLE
fix(config): quote tmux command when Claude path contains apostrophe

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -67,8 +67,8 @@ func DefaultConfig() *Config {
 		program = defaultProgram
 	}
 
-	// Quote path if it contains spaces (for tmux shell execution)
-	if strings.Contains(program, " ") {
+	// Quote path if it contains spaces or apostrophes (for tmux shell execution)
+	if strings.Contains(program, " ") || strings.Contains(program, "'") {
 		program = "'" + strings.ReplaceAll(program, "'", "'\\''") + "'"
 	}
 


### PR DESCRIPTION
## Summary
- `DefaultConfig()` now also triggers shell-quoting when the Claude binary path contains a single quote, not just when it contains a space. The inner POSIX `'\\''` escape was already in place; only the outer condition was too narrow.
- Fixes session creation for paths like `/home/o'brien/bin/claude`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./config/...`

Closes #368