### PR TITLE
fix(task/runner): treat pending instance write failure as non-fatal

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -237,7 +237,7 @@ func RunTask(taskID string) error {
 	// reads from per-repo instances.json above, which is the load-bearing
 	// path for AutoYes.
 	if err := appendPendingInstance(data); err != nil {
-		return fmt.Errorf("failed to save pending instance: %w", err)
+		log.WarningLog.Printf("failed to save pending instance: %v", err)
 	}
 
 	// Instance is successfully handed off, don't kill it on return.


### PR DESCRIPTION
## Summary
- After PR #365, `instances.json` (via `UpdateRepoInstances`) is the load-bearing persistence path; the subsequent `pending_instances.json` write is defensive (per the comment in code) but its failure was still treated as fatal, triggering the deferred `Kill` and orphaning the persisted entry as a ghost.
- Replaces the fatal return with a warning log so `started = false` always runs after a successful primary persistence.

## Test plan
- [x] `go build ./...`
- [x] `go test ./task/...`

Closes #369