### PR TITLE
fix(reset): skip non-git stored repo paths instead of aborting

### DIFF
--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -242,11 +242,15 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 		return fmt.Errorf("failed to access repo path: %w", err)
 	}
 
-	// List all worktrees from the repo
+	// List all worktrees from the repo. If the path exists but is no longer a
+	// git repo (e.g. `.git` was removed), `git -C` exits non-zero. Treat that
+	// like the missing-directory case above: log and skip, so `af reset` can
+	// still clean up other repos and reset storage (issue #370).
 	cmd := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain")
 	output, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("failed to list worktrees: %w", err)
+		log.WarningLog.Printf("skipping cleanup for non-git path: %s", repoRoot)
+		return nil
 	}
 
 	// Parse output to get (worktreePath, branchName) pairs.

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -474,3 +474,30 @@ func TestCleanupWorktreesForRepo_SkipsMissingPath(t *testing.T) {
 	assert.Contains(t, buf.String(), "skipping cleanup for deleted repo",
 		"expected warning log about skipped cleanup, got: %q", buf.String())
 }
+
+// TestCleanupWorktreesForRepo_SkipsNonGitPath verifies that when a stored repo
+// path exists but is no longer a git repo (e.g. `.git` has been removed),
+// CleanupWorktreesForRepo logs a warning and returns nil instead of aborting
+// `af reset`. See issue #370.
+func TestCleanupWorktreesForRepo_SkipsNonGitPath(t *testing.T) {
+	// Redirect WarningLog to a buffer so we can assert on the message.
+	var buf bytes.Buffer
+	origWarning := log.WarningLog
+	log.WarningLog = stdlog.New(&buf, "WARNING: ", 0)
+	t.Cleanup(func() { log.WarningLog = origWarning })
+
+	// Create a directory that exists but is not a git repo.
+	nonGit := t.TempDir()
+	// Sanity: the directory exists but has no .git entry.
+	_, statErr := os.Stat(nonGit)
+	require.NoError(t, statErr, "test setup: path should exist")
+	_, gitStatErr := os.Stat(filepath.Join(nonGit, ".git"))
+	require.True(t, os.IsNotExist(gitStatErr), "test setup: .git should not exist")
+
+	err := CleanupWorktreesForRepo(nonGit)
+	require.NoError(t, err,
+		"CleanupWorktreesForRepo should return nil when the path is not a git repo")
+
+	assert.Contains(t, buf.String(), "skipping cleanup for non-git path",
+		"expected warning log about non-git path, got: %q", buf.String())
+}


### PR DESCRIPTION
## Summary
- In `CleanupWorktreesForRepo`, treat `git worktree list --porcelain` failure on an existing-but-not-a-git path as skippable: log a warning and return nil, mirroring the existing missing-directory skip.
- Previously, a single stored repo with `.git` removed caused `af reset` to abort, leaving instance storage for **all** repos undeleted.
- Adds a regression test alongside the existing missing-path test.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`

Closes #370