### PR TITLE
fix(api/sessions): reject duplicate session titles in create

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -103,6 +103,14 @@ var sessionsCreateCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("path %s is not a git repository", repo.Root))
 		}
 
+		// Best-effort pre-check to fail fast on duplicate titles before we
+		// spend time creating a tmux session and git worktree we'd just
+		// have to tear down. The authoritative race-safe check still
+		// happens inside appendInstanceFn under the per-repo file lock.
+		if existing, _, lookupErr := findInstanceByTitle(createNameFlag); lookupErr == nil && existing != nil {
+			return jsonError(fmt.Errorf("session with title %q already exists", createNameFlag))
+		}
+
 		program := createProgramFlag
 		if program == "" {
 			program = config.LoadConfig().DefaultProgram
@@ -146,11 +154,24 @@ var sessionsCreateCmd = &cobra.Command{
 // appends data to the existing instances array. If the existing file is
 // corrupted, it returns an error so the update is aborted without
 // overwriting the on-disk file (preserving it for manual recovery).
+//
+// If an entry with the same Title already exists, it returns an error
+// rather than appending a duplicate or silently replacing the existing
+// entry. Title-based lookup (findInstanceByTitle) assumes uniqueness, and
+// silently replacing would orphan the prior tmux session/worktree without
+// cleanup. Erroring out makes the conflict explicit to the caller, who is
+// then responsible for cleaning up the just-created instance (typically
+// via instance.Kill()).
 func appendInstanceFn(data session.InstanceData) func(json.RawMessage) (json.RawMessage, error) {
 	return func(raw json.RawMessage) (json.RawMessage, error) {
 		var existing []session.InstanceData
 		if err := json.Unmarshal(raw, &existing); err != nil {
 			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
+		}
+		for i := range existing {
+			if existing[i].Title == data.Title {
+				return nil, fmt.Errorf("session with title %q already exists", data.Title)
+			}
 		}
 		existing = append(existing, data)
 		return json.MarshalIndent(existing, "", "  ")

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -41,6 +41,32 @@ func TestAppendInstanceFn_ValidJSON(t *testing.T) {
 	}
 }
 
+// TestAppendInstanceFn_DuplicateTitle is the regression test for issue #371.
+// Previously, appendInstanceFn blindly appended without checking whether an
+// entry with the same Title already existed, producing duplicate stored
+// entries that confused title-based lookup (findInstanceByTitle returns only
+// the first match). It must now reject duplicates so the caller can clean up
+// the just-created instance (tmux session + worktree) rather than orphaning
+// the prior session's state.
+func TestAppendInstanceFn_DuplicateTitle(t *testing.T) {
+	existing := []session.InstanceData{{Title: "dupe"}}
+	raw, err := json.Marshal(existing)
+	if err != nil {
+		t.Fatalf("marshal existing: %v", err)
+	}
+
+	out, err := appendInstanceFn(session.InstanceData{Title: "dupe"})(raw)
+	if err == nil {
+		t.Fatalf("expected error on duplicate title, got nil (output=%s)", string(out))
+	}
+	if out != nil {
+		t.Fatalf("expected nil output on error, got: %s", string(out))
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected duplicate-title error, got: %v", err)
+	}
+}
+
 // TestAppendInstanceFn_CorruptedJSON is the regression test for issue #257.
 // Previously, the callback silently reset the existing data to an empty
 // array on unmarshal failure, wiping all saved sessions. It must now return


### PR DESCRIPTION
## Summary
- `appendInstanceFn` now scans for an existing entry with the same Title under the per-repo file lock and returns `"session with title %q already exists"` instead of blindly appending.
- Adds an early best-effort check in `sessionsCreateCmd` so we fail fast before creating a tmux session/worktree we'd just have to tear down (the authoritative race-safe check stays inside the lock).
- Erroring is preferred over silent upsert because the codebase assumes title uniqueness in `findInstanceByTitle` and there's no existing cleanup path for a displaced live tmux session/worktree.

## Test plan
- [x] `go build ./...`
- [x] `go test ./api/...`
- [x] Adds `TestAppendInstanceFn_DuplicateTitle`.

Closes #371