### PR TITLE
fix(app): sync content pane on ctrl+c cancel

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -28,7 +28,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// on the event-loop goroutine rather than from a tea.Cmd closure
 		// that runs off-loop and races with home.View -> Menu.String.
 		m.menu.SetState(ui.StateDefault)
-		return m, tea.WindowSize()
+		return m, tea.Batch(m.selectionChanged(), tea.WindowSize())
 	}
 
 	instance := m.namingInstance


### PR DESCRIPTION
## Summary
- The ctrl+c cancel in `handleStateNew` now returns `tea.Batch(m.selectionChanged(), tea.WindowSize())`, matching the ESC cancel handler immediately below.
- Previously, ctrl+c left the content pane in its old/empty state until the next periodic preview tick.

## Test plan
- [x] `go build ./...`
- [x] `go test ./app/...`

Closes #372