### PR TITLE
fix(autoupdate): treat future last_update_check timestamps as invalid

### DIFF
--- a/autoupdate.go
+++ b/autoupdate.go
@@ -186,6 +186,9 @@ func shouldCheck() bool {
 	if err != nil {
 		return true
 	}
+	if t.After(time.Now()) {
+		return true
+	}
 	return time.Since(t) >= autoUpdateCheckInterval
 }
 


### PR DESCRIPTION
## Summary
- `shouldCheck()` now returns `true` when the persisted `last_update_check` timestamp is in the future (e.g., from clock corrections via NTP, VM time-sync, dual-boot drift), instead of suppressing checks until the local clock catches up.

## Test plan
- [x] `go build ./...`
- [x] `go test .`

Closes #373