### PR TITLE
fix(session/git): separate stdout from stderr in runGitCommand

### DIFF
--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -5,14 +5,20 @@ import (
 	"os/exec"
 )
 
-// runGitCommand executes a git command and returns any error
+// runGitCommand executes a git command and returns any error.
+// Only stdout is returned on success so callers parsing the output (e.g. SHAs
+// or porcelain status) are not corrupted by warnings git emits on stderr.
+// On error, stderr is folded into the returned error for diagnostics.
 func (g *GitWorktree) runGitCommand(path string, args ...string) (string, error) {
 	baseArgs := []string{"-C", path}
 	cmd := exec.Command("git", append(baseArgs, args...)...)
 
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("git command failed: %s (%w)", output, err)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return string(output), fmt.Errorf("git command failed: %s (%w)", string(exitErr.Stderr), err)
+		}
+		return string(output), fmt.Errorf("git command failed: %w", err)
 	}
 
 	return string(output), nil


### PR DESCRIPTION
## Summary
- `runGitCommand` switches from `cmd.CombinedOutput()` to `cmd.Output()` so callers parsing the result (e.g. `resolveOriginHead` consuming a SHA) don't get stderr warnings concatenated into stdout.
- On non-zero exit, stderr is folded into the returned error via `*exec.ExitError`, preserving diagnostic info.
- Audited callers in `session/git/worktree_ops.go`: those that match against `err.Error()` substrings still work because the stderr text is now in the error string.

## Test plan
- [x] `go build ./...`
- [x] `go test ./session/...`

Closes #374