### PR TITLE
fix(session): log warning when plugin dir setup fails

### DIFF
--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -3,6 +3,8 @@ package session
 import (
 	"path/filepath"
 	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // codexSystemPrompt is the system prompt for Codex sessions, which don't support plugins.
@@ -93,6 +95,7 @@ func injectSystemPrompt(program, sessionTitle, worktreePath string) string {
 	if base == "claude" || base == "claude-code" {
 		pluginDir, err := ensurePluginDir()
 		if err != nil {
+			log.WarningLog.Printf("failed to set up plugin directory, slash commands unavailable: %v", err)
 			return program
 		}
 		return program + " --plugin-dir " + shellQuote(pluginDir)


### PR DESCRIPTION
## Summary
- In `session/systemprompt.go`'s `injectSystemPrompt`, an `ensurePluginDir()` failure now logs a warning before falling back to launching Claude without `--plugin-dir`.
- Previously, the failure was completely silent — users would notice missing `/af-*` slash commands but had no log to point them at the cause (e.g., a stray regular file at `<config-dir>/plugin`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./session/...`

Closes #375