### PR TITLE
fix(session/tmux): reap pty child process via cmd.Wait

### DIFF
--- a/session/tmux/pty.go
+++ b/session/tmux/pty.go
@@ -16,7 +16,15 @@ type PtyFactory interface {
 type Pty struct{}
 
 func (pt Pty) Start(cmd *exec.Cmd) (*os.File, error) {
-	return pty.Start(cmd)
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return nil, err
+	}
+	// Reap the child process when it exits to avoid zombie processes.
+	go func() {
+		_ = cmd.Wait()
+	}()
+	return ptmx, nil
 }
 
 func (pt Pty) Close() {}


### PR DESCRIPTION
## Summary
- `Pty.Start` now spawns a goroutine that calls `cmd.Wait()` after `pty.Start(cmd)`, so short-lived tmux subprocesses (`new-session`, `attach-session`) are reaped instead of accumulating as zombies in long-running daemon mode.
- Kept the value receiver to avoid changing how `MakePtyFactory()` constructs and returns the type.

## Test plan
- [x] `go build ./...`
- [x] `go test ./session/tmux/...`

Closes #376