### PR TITLE
fix(task/cron): reject cron parts with empty step value

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -61,13 +61,12 @@ func validateField(field string, min, max int) error {
 
 func validatePart(part string, min, max int) error {
 	// Handle step values (e.g. "*/5" or "1-5/2")
-	step := ""
 	if idx := strings.Index(part, "/"); idx != -1 {
-		step = part[idx+1:]
+		step := part[idx+1:]
 		part = part[:idx]
-	}
-
-	if step != "" {
+		if step == "" {
+			return fmt.Errorf("empty step value")
+		}
 		stepVal, err := strconv.Atoi(step)
 		if err != nil {
 			return fmt.Errorf("invalid step value %q", step)


### PR DESCRIPTION
## Summary
- `validatePart` now treats the presence of `/` as requiring a non-empty step substring, returning a validation error.
- Previously, expressions like `*/ * * * *` slipped past validation and produced invalid systemd `OnCalendar` syntax (`"00/"`) or silently dropped DOW constraints during conversion.

## Test plan
- [x] `go build ./...`
- [x] `go test ./task/...`

Closes #377