### PR TITLE
fix(task): loop trust prompt dismissal to prevent prompt loss

### DIFF
--- a/task/start.go
+++ b/task/start.go
@@ -30,7 +30,7 @@ func StartAndSendPrompt(instance *session.Instance, prompt string) error {
 		return err
 	}
 
-	if instance.CheckAndHandleTrustPrompt() {
+	for instance.CheckAndHandleTrustPrompt() {
 		time.Sleep(1 * time.Second)
 		if err := WaitForReady(instance); err != nil {
 			return err


### PR DESCRIPTION
## Summary
- `StartAndSendPrompt` now loops on `CheckAndHandleTrustPrompt()` until no further trust dialog is detected, instead of dismissing only the first.
- Previously, a second sequential trust dialog could remain on-screen when `WaitForReady` returned (it treats trust prompts as ready), and the user prompt would be sent into the trust dialog via `send-keys` — wasting the prompt and silently doing no work.

## Test plan
- [x] `go build ./...`
- [x] `go test ./task/...`

Closes #378