### PR TITLE
fix(task/systemd, ui/task_pane): validate cron before mutating state

### DIFF
--- a/task/systemd.go
+++ b/task/systemd.go
@@ -76,6 +76,15 @@ WorkingDirectory=%s
 }
 
 func InstallScheduler(t Task) error {
+	// Validate the cron expression FIRST, before any file writes.
+	// Otherwise a bad cron leaves a stale .service on disk while the previous
+	// timer keeps running, so the user sees their edit "saved" but the
+	// schedule never updates.
+	onCalendar, err := CronToOnCalendar(t.CronExpr)
+	if err != nil {
+		return fmt.Errorf("failed to convert cron expression: %w", err)
+	}
+
 	unitName := getUnitName(t)
 
 	dir, err := getSystemdUserDir()
@@ -101,11 +110,6 @@ func InstallScheduler(t Task) error {
 	servicePath := filepath.Join(dir, unitName+".service")
 	if err := os.WriteFile(servicePath, []byte(serviceContent), 0644); err != nil {
 		return fmt.Errorf("failed to write service file: %w", err)
-	}
-
-	onCalendar, err := CronToOnCalendar(t.CronExpr)
-	if err != nil {
-		return fmt.Errorf("failed to convert cron expression: %w", err)
 	}
 
 	timerContent := fmt.Sprintf(`[Unit]

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -22,7 +22,8 @@ type TaskPane struct {
 	editPrompt textarea.Model
 	editCron   textinput.Model
 	editPath   textinput.Model
-	focusIndex int // 0=name, 1=prompt, 2=cron, 3=path, 4=save button
+	editError  string // last validation error shown to the user
+	focusIndex int    // 0=name, 1=prompt, 2=cron, 3=path, 4=save button
 
 	// Create mode
 	creating       bool
@@ -134,6 +135,7 @@ func (s *TaskPane) EnterCreateMode(defaultPath string) {
 	s.focusIndex = 0
 	s.creating = true
 	s.hasFocus = true
+	s.editError = ""
 }
 
 // HasPendingCreate returns true if a new task was submitted and needs saving.
@@ -262,6 +264,7 @@ func (s *TaskPane) enterEditMode() {
 	s.editPath = path
 	s.focusIndex = 0
 	s.editing = true
+	s.editError = ""
 }
 
 func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
@@ -275,15 +278,31 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 	case tea.KeyEsc:
 		s.editing = false
 		s.creating = false
+		s.editError = ""
 	case tea.KeyEnter:
 		if s.focusIndex == 4 {
 			if s.creating {
 				if s.editName.Value() == "" {
-					return true // name is required
+					s.editError = "name is required"
+					return true
 				}
+				if err := task.ValidateCronExpr(s.editCron.Value()); err != nil {
+					s.editError = fmt.Sprintf("invalid cron: %v", err)
+					return true
+				}
+				s.editError = ""
 				s.pendingCreate = true
 				s.creating = false
 			} else {
+				if s.editName.Value() == "" {
+					s.editError = "name is required"
+					return true
+				}
+				if err := task.ValidateCronExpr(s.editCron.Value()); err != nil {
+					s.editError = fmt.Sprintf("invalid cron: %v", err)
+					return true
+				}
+				s.editError = ""
 				s.tasks[s.selectedIdx].Name = s.editName.Value()
 				s.tasks[s.selectedIdx].Prompt = s.editPrompt.Value()
 				s.tasks[s.selectedIdx].CronExpr = s.editCron.Value()
@@ -479,6 +498,12 @@ func (s *TaskPane) renderEditMode() string {
 		b.WriteString("       " + focusedButtonStyle.Render(submitLabel))
 	} else {
 		b.WriteString("       " + buttonStyle.Render(submitLabel))
+	}
+
+	if s.editError != "" {
+		errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
+		b.WriteString("\n\n")
+		b.WriteString(errorStyle.Render("! " + s.editError))
 	}
 
 	return b.String()


### PR DESCRIPTION
## Summary
- `task/systemd.go` `InstallScheduler` now calls `CronToOnCalendar` *before* writing the `.service` file, matching the existing `task/launchd.go` pattern. An invalid cron expression no longer leaves a stale `.service` file on disk while the old timer keeps running.
- `ui/task_pane.go` adds upfront validation via `task.ValidateCronExpr` on Save/Create. Errors are surfaced inline (red `editError`) and submission is blocked, so invalid cron can no longer be silently persisted to the task JSON.

## Test plan
- [x] `go build ./...`
- [x] `go test ./task/... ./ui/...`

Closes #379