### PR TITLE
fix(ui/hooks): propagate ctrl+c and q to global quit handler

### DIFF
--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -71,6 +71,9 @@ func (h *HooksPane) HandleKeyPress(msg tea.KeyMsg) bool {
 }
 
 func (h *HooksPane) handleNormalMode(msg tea.KeyMsg) bool {
+	if msg.String() == "ctrl+c" || msg.String() == "q" {
+		return false
+	}
 	switch msg.String() {
 	case "esc":
 		h.hasFocus = false


### PR DESCRIPTION
## Summary
- `HooksPane.handleNormalMode` now returns `false` for `ctrl+c` and `q`, allowing the global quit handler in the app model to receive them.
- Previously, the pane returned `true` (consumed) for all unhandled keys, silently swallowing the universal quit shortcut while focused.

## Test plan
- [x] `go build ./...`
- [x] `go test ./ui/...`

Closes #380