### PR TITLE
fix(ui/overlay): match combined SGR sequences in fade regex

### DIFF
--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -14,8 +14,8 @@ import (
 
 // Pre-compiled regexes for ANSI color code replacement in overlay fade effect.
 var (
-	bgColorRegex     = regexp.MustCompile(`\x1b\[48;[25];[0-9;]+m`)
-	fgColorRegex     = regexp.MustCompile(`\x1b\[38;[25];[0-9;]+m`)
+	bgColorRegex     = regexp.MustCompile(`\x1b\[(?:[0-9;]*;)?48;[25];[0-9;]+m`)
+	fgColorRegex     = regexp.MustCompile(`\x1b\[(?:[0-9;]*;)?38;[25];[0-9;]+m`)
 	simpleColorRegex = regexp.MustCompile(`\x1b\[[0-9]+m`)
 )
 


### PR DESCRIPTION
## Summary
- Updates `fgColorRegex` and `bgColorRegex` to allow optional leading SGR parameters before `38;` / `48;`, so combined sequences emitted by lipgloss like `\\x1b[1;38;5;188m` (bold + fg) are matched and dimmed by the overlay fade effect.
- Previously, the regex only matched standalone `\\x1b[38;...m` codes, and overlays left bold styled text undimmed in the background.

## Test plan
- [x] `go build ./...`
- [x] `go test ./ui/overlay/...`

Closes #381