### PR TITLE
fix(ui/preview): pad to full height to eliminate trailing blank line

### DIFF
--- a/ui/preview.go
+++ b/ui/preview.go
@@ -147,19 +147,16 @@ func (p *PreviewPane) String() string {
 	}
 
 	// Normal mode display
-	// Calculate available height accounting for border and margin
-	availableHeight := p.height - 1 //  1 for ellipsis
-
 	lines := strings.Split(p.previewState.text, "\n")
 
 	// Truncate if we have more lines than available height
-	if availableHeight > 0 {
-		if len(lines) > availableHeight {
-			lines = lines[:availableHeight]
+	if p.height > 0 {
+		if len(lines) > p.height-1 {
+			lines = lines[:p.height-1]
 			lines = append(lines, "...")
 		} else {
 			// Pad with empty lines to fill available height
-			padding := availableHeight - len(lines)
+			padding := p.height - len(lines)
 			lines = append(lines, make([]string, padding)...)
 		}
 	}


### PR DESCRIPTION
## Summary
- Normal-mode preview rendering now pads short content up to `p.height` and only reserves a line for `"..."` in the truncation branch. Both branches yield exactly `p.height` lines, matching `TerminalPane`'s pattern.
- Previously, padding filled to `p.height-1`, leaving one blank line in the preview area for short content while truncated content correctly filled the area.

## Test plan
- [x] `go build ./...`
- [x] `go test ./ui/...`

Closes #382