### PR TITLE
fix(ui/sidebar): decrement repo count on action overlay kill

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -155,8 +155,13 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 
 		// Find and kill by title, not by current selection index, to avoid
 		// destroying the wrong worktree if the sidebar order changed.
+		// Capture the repo name before Kill(), because Kill() sets started=false
+		// which causes RepoName() to fail — leaving the sidebar repo count stale.
+		var repoName string
+		var repoErr error = fmt.Errorf("instance not found")
 		for _, inst := range m.sidebar.GetInstances() {
 			if inst.Title == selectedTitle {
+				repoName, repoErr = inst.RepoName()
 				if err := inst.Kill(); err != nil {
 					log.ErrorLog.Printf("could not kill instance: %v", err)
 					return fmt.Errorf("failed to kill session '%s': %w", selectedTitle, err)
@@ -164,7 +169,11 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 				break
 			}
 		}
-		m.sidebar.RemoveInstanceByTitle(selectedTitle)
+		if repoErr == nil {
+			m.sidebar.RemoveInstanceByTitleWithRepo(selectedTitle, repoName)
+		} else {
+			m.sidebar.RemoveInstanceByTitle(selectedTitle)
+		}
 
 		if err := m.storage.DeleteInstance(selectedTitle); err != nil {
 			log.ErrorLog.Printf("failed to delete instance from storage: %v", err)

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -384,6 +384,23 @@ func (s *Sidebar) RemoveInstanceByTitle(title string) bool {
 	return false
 }
 
+// RemoveInstanceByTitleWithRepo removes an instance from the sidebar by title
+// using the supplied repoName instead of calling RepoName() on the instance.
+// This is useful when the caller has already killed the instance (which causes
+// RepoName() to fail) but captured the repo name beforehand, ensuring the repo
+// count is still decremented correctly.
+func (s *Sidebar) RemoveInstanceByTitleWithRepo(title, repoName string) bool {
+	for i, inst := range s.instances {
+		if inst.Title == title {
+			s.rmRepo(repoName)
+			s.instances = append(s.instances[:i], s.instances[i+1:]...)
+			s.rebuildVisibleItems()
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Sidebar) addRepo(repo string) {
 	if _, ok := s.repos[repo]; !ok {
 		s.repos[repo] = 0


### PR DESCRIPTION
## Summary
- Adds `Sidebar.RemoveInstanceByTitleWithRepo(title, repoName)` for callers that already have the repo name. The existing `RemoveInstanceByTitle` is unchanged.
- In `app/handle_actions.go`'s action-overlay kill flow, the repo name is now captured *before* `inst.Kill()` (which clears state needed by `RepoName()`) and passed to the new method, so `s.repos` is decremented correctly.
- Mirrors the existing fix in `Sidebar.Kill()` (commit 92a4c289). Without this fix, `len(s.repos) > 1` could remain true after killing the last instance from a repo, causing the sidebar to render unnecessary `(repo-name)` suffixes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./ui/... ./app/...`

Closes #383