### PR TITLE
fix(ui/terminal): exit scroll mode when instance changes

### DIFF
--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -90,6 +90,15 @@ func (t *TerminalPane) UpdateContent(instance *session.Instance) error {
 		return nil
 	}
 
+	// If the selected instance changed while in scroll mode, exit scroll mode
+	// so ensureSessionLocked() runs and updates t.currentTitle. Otherwise
+	// Attach() would resolve t.sessions[t.currentTitle] to the previous
+	// instance's session (issue #384).
+	if t.isScrolling && t.currentTitle != "" && t.currentTitle != instance.Title {
+		t.isScrolling = false
+		t.viewport.SetContent("")
+	}
+
 	// Skip content updates while in scroll mode
 	if t.isScrolling {
 		return nil


### PR DESCRIPTION
## Summary
- `TerminalPane.UpdateContent()` now exits scroll mode (clears `isScrolling` and viewport content) when the selected instance differs from the one cached in `currentTitle`, *before* the `if t.isScrolling { return nil }` early-return.
- This lets `ensureSessionLocked()` run on instance switch and update `currentTitle`, so subsequent `Attach()` calls resolve `t.sessions[t.currentTitle]` to the correct session.
- Previously, navigating between instances while scrolling left `currentTitle` stale, and `Attach()` would connect to the previously-selected session — risking commands run in the wrong worktree.

## Test plan
- [x] `go build ./...`
- [x] `go test ./ui/...`

Closes #384