### PR TITLE
fix(upgrade,autoupdate): resolve symlinks before atomic binary replace

### DIFF
--- a/autoupdate.go
+++ b/autoupdate.go
@@ -92,8 +92,14 @@ func autoUpdate() error {
 	if err != nil {
 		return fmt.Errorf("failed to find executable: %w", err)
 	}
+	// Resolve symlinks so we replace the real binary, not the symlink
+	// pointing to it (e.g. on macOS Homebrew installs).
+	resolvedPath, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve executable path: %w", err)
+	}
 
-	if err := config.AtomicWriteFile(execPath, binary, 0755); err != nil {
+	if err := config.AtomicWriteFile(resolvedPath, binary, 0755); err != nil {
 		return fmt.Errorf("failed to write new binary: %w", err)
 	}
 

--- a/upgrade.go
+++ b/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -54,8 +55,14 @@ var upgradeCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to find current executable: %w", err)
 		}
+		// Resolve symlinks so we replace the real binary, not the symlink
+		// pointing to it (e.g. on macOS Homebrew installs).
+		resolvedPath, err := filepath.EvalSymlinks(execPath)
+		if err != nil {
+			return fmt.Errorf("failed to resolve executable path: %w", err)
+		}
 
-		if err := config.AtomicWriteFile(execPath, binary, 0755); err != nil {
+		if err := config.AtomicWriteFile(resolvedPath, binary, 0755); err != nil {
 			return fmt.Errorf("failed to write new binary: %w", err)
 		}
 


### PR DESCRIPTION
## Summary
- Both `upgrade.go` and `autoupdate.go` now call `filepath.EvalSymlinks` on `os.Executable()` before passing the path to `config.AtomicWriteFile`, ensuring the rename writes to the resolved target rather than replacing an invoking symlink.
- Fixes the macOS-specific failure mode where `os.Executable()` returns the invoked symlink path (Homebrew installs) — previously the upgrade replaced the symlink with a regular file instead of updating the real binary.
- The other `os.Executable()` call sites (`task/systemd.go`, `task/launchd.go`, `daemon/daemon.go`) only spawn the binary as a subprocess, so they don't have this bug and are left untouched.

## Test plan
- [x] `go build ./...`
- [x] `go test .`

Closes #385