### PR TITLE
Fix triaged open issue regressions

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -70,6 +70,23 @@ func findInstanceByTitle(title string) (*session.InstanceData, string, error) {
 	return nil, "", fmt.Errorf("instance %q not found", title)
 }
 
+func repoHasInstanceTitle(repoID, title string) (bool, error) {
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		return false, fmt.Errorf("failed to load instances for repo %s: %w", repoID, err)
+	}
+	var instances []session.InstanceData
+	if err := json.Unmarshal(raw, &instances); err != nil {
+		return false, fmt.Errorf("failed to parse instances for repo %s: %w", repoID, err)
+	}
+	for i := range instances {
+		if instances[i].Title == title {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // findLiveInstanceByTitle finds an instance by title and restores it as a live *Instance.
 func findLiveInstanceByTitle(title string) (*session.Instance, string, error) {
 	data, repoID, err := findInstanceByTitle(title)

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -103,11 +103,15 @@ var sessionsCreateCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("path %s is not a git repository", repo.Root))
 		}
 
-		// Best-effort pre-check to fail fast on duplicate titles before we
-		// spend time creating a tmux session and git worktree we'd just
-		// have to tear down. The authoritative race-safe check still
+		// Best-effort per-repo pre-check to fail fast on duplicate titles
+		// before we spend time creating a tmux session and git worktree we'd
+		// just have to tear down. The authoritative race-safe check still
 		// happens inside appendInstanceFn under the per-repo file lock.
-		if existing, _, lookupErr := findInstanceByTitle(createNameFlag); lookupErr == nil && existing != nil {
+		exists, err := repoHasInstanceTitle(repo.ID, createNameFlag)
+		if err != nil {
+			return jsonError(err)
+		}
+		if exists {
 			return jsonError(fmt.Errorf("session with title %q already exists", createNameFlag))
 		}
 
@@ -212,6 +216,14 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 
 			if !git.IsGitRepo(repo.Root) {
 				return jsonError(fmt.Errorf("path %s is not a git repository", repo.Root))
+			}
+
+			exists, err := repoHasInstanceTitle(repo.ID, title)
+			if err != nil {
+				return jsonError(err)
+			}
+			if exists {
+				return jsonError(fmt.Errorf("session with title %q already exists", title))
 			}
 
 			program := sendPromptProgramFlag

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -67,6 +67,44 @@ func TestAppendInstanceFn_DuplicateTitle(t *testing.T) {
 	}
 }
 
+func TestRepoHasInstanceTitleScopedToRepo(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoA := "repo-a"
+	repoB := "repo-b"
+	rawA, err := json.Marshal([]session.InstanceData{{Title: "shared"}})
+	if err != nil {
+		t.Fatalf("marshal repo A: %v", err)
+	}
+	rawB, err := json.Marshal([]session.InstanceData{{Title: "other"}})
+	if err != nil {
+		t.Fatalf("marshal repo B: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoA, rawA); err != nil {
+		t.Fatalf("save repo A: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoB, rawB); err != nil {
+		t.Fatalf("save repo B: %v", err)
+	}
+
+	exists, err := repoHasInstanceTitle(repoB, "shared")
+	if err != nil {
+		t.Fatalf("repoHasInstanceTitle repo B: %v", err)
+	}
+	if exists {
+		t.Fatalf("title from repo A must not block creation in repo B")
+	}
+
+	exists, err = repoHasInstanceTitle(repoA, "shared")
+	if err != nil {
+		t.Fatalf("repoHasInstanceTitle repo A: %v", err)
+	}
+	if !exists {
+		t.Fatalf("same-repo duplicate title should be detected")
+	}
+}
+
 // TestAppendInstanceFn_CorruptedJSON is the regression test for issue #257.
 // Previously, the callback silently reset the existing data to an empty
 // array on unmarshal failure, wiping all saved sessions. It must now return

--- a/app/app.go
+++ b/app/app.go
@@ -73,10 +73,6 @@ type home struct {
 
 	// state is the current discrete state of the application
 	state state
-	// newInstanceFinalizer is called when the state is stateNew and then you press enter.
-	// It registers the new instance in the list after the instance has been started.
-	newInstanceFinalizer func()
-
 	// namingInstance is the instance currently being named in stateNew.
 	// Stored as a direct pointer so background sync cannot change which
 	// instance the naming keystrokes target.
@@ -372,6 +368,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		msg.instance.SetStatus(session.Running)
+		m.sidebar.RegisterRepoForInstance(msg.instance)
 		if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
 			return m, m.handleError(err)
 		}
@@ -414,13 +411,14 @@ func (m *home) saveContentPaneState() {
 	if hp.IsDirty() {
 		repoCfg, err := config.LoadRepoConfig(m.repoID)
 		if err != nil {
-			repoCfg = &config.RepoConfig{}
+			log.ErrorLog.Printf("failed to save hooks: could not load repo config: %v", err)
+		} else {
+			repoCfg.PostWorktreeCommands = hp.GetCommands()
+			if err := config.SaveRepoConfig(m.repoID, repoCfg); err != nil {
+				log.ErrorLog.Printf("failed to save hooks: %v", err)
+			}
+			m.sidebar.SetHookCount(len(hp.GetCommands()))
 		}
-		repoCfg.PostWorktreeCommands = hp.GetCommands()
-		if err := config.SaveRepoConfig(m.repoID, repoCfg); err != nil {
-			log.ErrorLog.Printf("failed to save hooks: %v", err)
-		}
-		m.sidebar.SetHookCount(len(hp.GetCommands()))
 	}
 
 	sp := m.contentPane.TaskPane()
@@ -521,10 +519,9 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 		return m.handleError(fmt.Errorf("failed to create instance: %w", err))
 	}
 
-	finalizer := m.sidebar.AddInstance(instance)
+	m.sidebar.AddInstance(instance)
 	m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
 	instance.SetStatus(session.Loading)
-	finalizer()
 	m.menu.SetState(ui.StateDefault)
 
 	m.preSaveInstances()
@@ -557,7 +554,8 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 		m.keySent = false
 		return nil, false
 	}
-	if m.state == stateHelp || m.state == stateConfirm || m.state == stateSelectWorktree {
+	if m.state == stateHelp || m.state == stateConfirm || m.state == stateSelectWorktree ||
+		m.state == stateNew || m.state == stateSearch || m.state == stateSelectProgram {
 		return nil, false
 	}
 	// Don't highlight when content pane has focus

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -3,12 +3,15 @@ package app
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -182,6 +185,56 @@ func TestInstanceStarted_Success_AutoYesApplied(t *testing.T) {
 	_, _ = h.Update(instanceStartedMsg{instance: inst, err: nil})
 
 	assert.True(t, inst.AutoYes, "autoYes must propagate to the new instance when enabled")
+}
+
+func TestSaveContentPaneStateDoesNotOverwriteUnreadableRepoConfig(t *testing.T) {
+	h := newTestHome(t)
+
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	repoConfigPath := filepath.Join(configDir, "repos", h.repoID, config.RepoConfigFileName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(repoConfigPath), 0755))
+	corruptConfig := []byte(`{"remote_hooks":{"launch_cmd":"/bin/launch"`)
+	require.NoError(t, os.WriteFile(repoConfigPath, corruptConfig, 0644))
+
+	hooks := h.contentPane.HooksPane()
+	hooks.SetFocus(true)
+	require.True(t, hooks.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")}))
+	require.True(t, hooks.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("m")}))
+	require.True(t, hooks.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}))
+	require.True(t, hooks.IsDirty())
+
+	h.saveContentPaneState()
+
+	raw, err := os.ReadFile(repoConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(corruptConfig), string(raw))
+}
+
+func TestInstanceStartedRegistersRepoAfterStart(t *testing.T) {
+	h := newTestHome(t)
+	repoRoot := filepath.Join(t.TempDir(), "repo-a")
+	worktreePath := filepath.Join(t.TempDir(), "repo-a-session")
+	gw, err := sessiongit.NewGitWorktreeFromStorage(repoRoot, worktreePath, "new-session", "branch", "sha", false, true)
+	require.NoError(t, err)
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "new-session",
+		Path:    repoRoot,
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	inst.SetStatus(session.Loading)
+	inst.SetStartedForTest(true)
+	inst.SetGitWorktreeForTest(gw)
+
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+	require.Equal(t, 0, h.sidebar.NumRepos())
+
+	_, _ = h.Update(instanceStartedMsg{instance: inst, err: nil})
+
+	assert.Equal(t, 1, h.sidebar.NumRepos())
 }
 
 func collectTitles(instances []*session.Instance) []string {

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -44,7 +43,6 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Apply the program selected during naming
 		instance.Program = m.pendingProgram
 		instance.SetStatus(session.Loading)
-		m.newInstanceFinalizer()
 		m.namingInstance = nil
 		m.state = stateDefault
 		m.menu.SetState(ui.StateDefault)
@@ -72,9 +70,10 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Open program selection overlay
 		items := make([]string, len(tmux.SupportedPrograms))
 		selectedIdx := 0
+		baseProgram := session.BaseCommand(m.pendingProgram)
 		for i, p := range tmux.SupportedPrograms {
 			items[i] = p
-			if strings.Contains(strings.ToLower(m.pendingProgram), p) {
+			if baseProgram == p {
 				selectedIdx = i
 			}
 		}
@@ -141,7 +140,7 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 		return m, m.handleError(err)
 	}
 	instance.SetStatus(session.Loading)
-	m.newInstanceFinalizer = m.sidebar.AddInstance(instance)
+	m.sidebar.AddInstance(instance)
 	m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
 	m.namingInstance = instance
 	m.state = stateNew

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -70,3 +70,13 @@ func TestHandleStateNewKeySpaceUnderLimit(t *testing.T) {
 
 	assert.Equal(t, "hello ", homeModel.namingInstance.Title)
 }
+
+func TestHandleMenuHighlightingDoesNotInterceptNamingText(t *testing.T) {
+	h := newTestHome(t)
+	h.state = stateNew
+
+	cmd, returnEarly := h.handleMenuHighlighting(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+
+	assert.False(t, returnEarly)
+	assert.Nil(t, cmd)
+}

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
@@ -38,7 +37,7 @@ func (m *home) handleStateSelectWorktree(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 
 			instance.SetStatus(session.Loading)
-			m.newInstanceFinalizer = m.sidebar.AddInstance(instance)
+			m.sidebar.AddInstance(instance)
 			m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
 			m.namingInstance = instance
 			m.state = stateNew
@@ -65,7 +64,7 @@ func (m *home) handleStateSelectProgram(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// If the user re-selected the program matching the default (which may
 			// contain flags like --dangerously-skip-permissions), keep the full
 			// default string. Otherwise use the bare program name.
-			if strings.Contains(strings.ToLower(m.program), selected) {
+			if session.BaseCommand(m.program) == selected {
 				m.pendingProgram = m.program
 			} else {
 				m.pendingProgram = selected

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/ui/overlay"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleStateSelectProgramSubstringCollision(t *testing.T) {
+	h := newTestHome(t)
+	h.program = "/tmp/claude-wrapper --flag"
+	h.selectionOverlay = overlay.NewSelectionOverlay("Select Program", tmux.SupportedPrograms)
+	h.selectionOverlay.SetSelectedIndex(0) // claude
+	h.state = stateSelectProgram
+
+	_, _ = h.handleStateSelectProgram(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, "claude", h.pendingProgram)
+}
+
+func TestHandleStateSelectProgramPreservesExactProgramFlags(t *testing.T) {
+	h := newTestHome(t)
+	h.program = "/usr/local/bin/claude --dangerously-skip-permissions"
+	h.selectionOverlay = overlay.NewSelectionOverlay("Select Program", tmux.SupportedPrograms)
+	h.selectionOverlay.SetSelectedIndex(0) // claude
+	h.state = stateSelectProgram
+
+	_, _ = h.handleStateSelectProgram(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, h.program, h.pendingProgram)
+}

--- a/app/help.go
+++ b/app/help.go
@@ -77,7 +77,7 @@ func (h helpTypeInstanceStart) toContent() string {
 		"",
 		descStyle.Render("New session created:"),
 		descStyle.Render(fmt.Sprintf("• Git branch: %s (isolated worktree)",
-			lipgloss.NewStyle().Bold(true).Render(h.instance.Branch))),
+			lipgloss.NewStyle().Bold(true).Render(h.instance.GetBranch()))),
 		descStyle.Render(fmt.Sprintf("• %s running in background tmux session",
 			lipgloss.NewStyle().Bold(true).Render(h.instance.Program))),
 		"",

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,8 @@ const (
 	defaultProgram = "claude"
 )
 
+var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|->|^[^/=\s]+\s*=)\s*(.+)`)
+
 // GetConfigDir returns the path to the application's configuration directory.
 // If AGENT_FACTORY_HOME is set, it is used as the config directory.
 // Otherwise, defaults to ~/.agent-factory.
@@ -123,8 +125,7 @@ func GetClaudeCommand() (string, error) {
 			// Capture everything after the alias marker so paths containing spaces
 			// (e.g. "/Applications/Claude Code.app/.../claude") are preserved; trim
 			// surrounding whitespace afterwards.
-			aliasRegex := regexp.MustCompile(`(?:aliased to|->|=)\s*(.+)`)
-			matches := aliasRegex.FindStringSubmatch(path)
+			matches := aliasOutputRegex.FindStringSubmatch(path)
 			if len(matches) > 1 {
 				path = strings.TrimSpace(matches[1])
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -84,10 +83,8 @@ func TestGetClaudeCommand(t *testing.T) {
 	t.Run("handles alias parsing", func(t *testing.T) {
 		// Test core alias formats. Keep this regex in sync with the one used in
 		// GetClaudeCommand so the test exercises the real extraction logic.
-		aliasRegex := regexp.MustCompile(`(?:aliased to|->|=)\s*(.+)`)
-
 		extract := func(output string) (string, bool) {
-			matches := aliasRegex.FindStringSubmatch(output)
+			matches := aliasOutputRegex.FindStringSubmatch(output)
 			if len(matches) < 2 {
 				return "", false
 			}
@@ -116,6 +113,10 @@ func TestGetClaudeCommand(t *testing.T) {
 
 		// Direct path (no alias)
 		_, ok = extract("/usr/local/bin/claude")
+		assert.False(t, ok)
+
+		// Direct path containing "=" is still a path, not an alias assignment.
+		_, ok = extract("/tmp/test=dir/bin/claude")
 		assert.False(t, ok)
 	})
 }

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -30,11 +30,14 @@ type HookBackend struct {
 // Instead of allocating a real PTY (which SSH rejects without a terminal),
 // we use a pipe-based approach that captures whatever the attach_cmd writes.
 type hookPTY struct {
-	cmd    *exec.Cmd
-	stdout *os.File // read end of stdout pipe
-	buf    []byte
-	mu     sync.Mutex
-	closed bool
+	cmd      *exec.Cmd
+	stdout   *os.File // read end of stdout pipe
+	buf      []byte
+	mu       sync.Mutex
+	closed   bool
+	waitOnce sync.Once
+	waitDone chan struct{}
+	waitErr  error
 }
 
 var slugRegexp = regexp.MustCompile(`[^a-z0-9-]`)
@@ -281,7 +284,7 @@ func (b *HookBackend) ensurePTY(i *Instance) {
 	// Close the write end in the parent so reads get EOF when the child exits.
 	_ = stdoutW.Close()
 
-	hp := &hookPTY{cmd: cmd, stdout: stdoutR}
+	hp := &hookPTY{cmd: cmd, stdout: stdoutR, waitDone: make(chan struct{})}
 	b.ptys[i.Title] = hp
 
 	// Background goroutine reads output into a ring buffer.
@@ -314,7 +317,7 @@ func (b *HookBackend) ensurePTY(i *Instance) {
 		if alreadyClosed {
 			return
 		}
-		if err := hp.cmd.Wait(); err != nil {
+		if err := hp.wait(); err != nil {
 			log.ErrorLog.Printf("attach_cmd preview process exited: %v", err)
 		}
 		hp.mu.Lock()
@@ -337,14 +340,28 @@ func (b *HookBackend) closePTY(title string) {
 
 	_ = hp.stdout.Close()
 	// Give the process a moment to exit, then kill if needed.
-	done := make(chan error, 1)
-	go func() { done <- hp.cmd.Wait() }()
+	done := hp.waitAsync()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		_ = hp.cmd.Process.Kill()
 	}
 	delete(b.ptys, title)
+}
+
+func (hp *hookPTY) waitAsync() <-chan struct{} {
+	hp.waitOnce.Do(func() {
+		go func() {
+			hp.waitErr = hp.cmd.Wait()
+			close(hp.waitDone)
+		}()
+	})
+	return hp.waitDone
+}
+
+func (hp *hookPTY) wait() error {
+	<-hp.waitAsync()
+	return hp.waitErr
 }
 
 func (b *HookBackend) getPTY(title string) *hookPTY {

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -121,23 +121,36 @@ func (b *LocalBackend) Kill(i *Instance) error {
 	ts := i.tmuxSession
 	gw := i.gitWorktree
 	i.started = false
-	i.tmuxSession = nil
-	i.gitWorktree = nil
 	i.mu.Unlock()
 
 	var errs []error
+	tmuxCleaned := ts == nil
+	worktreeCleaned := gw == nil
 
 	if ts != nil {
 		if err := ts.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to close tmux session: %w", err))
+		} else {
+			tmuxCleaned = true
 		}
 	}
 
 	if gw != nil {
 		if err := gw.Cleanup(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to cleanup git worktree: %w", err))
+		} else {
+			worktreeCleaned = true
 		}
 	}
+
+	i.mu.Lock()
+	if tmuxCleaned && i.tmuxSession == ts {
+		i.tmuxSession = nil
+	}
+	if worktreeCleaned && i.gitWorktree == gw {
+		i.gitWorktree = nil
+	}
+	i.mu.Unlock()
 
 	return errors.Join(errs...)
 }

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -2,13 +2,17 @@ package session
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,6 +33,30 @@ func TestLocalBackendType(t *testing.T) {
 func TestHookBackendType(t *testing.T) {
 	b := &HookBackend{Hooks: config.RemoteHooks{}}
 	assert.Equal(t, "remote", b.Type())
+}
+
+func TestLocalBackendKillRetainsFailedTmuxForRetry(t *testing.T) {
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error {
+			return errors.New("kill failed")
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, nil
+		},
+	}
+	ts := tmux.NewTmuxSessionWithDeps("retry-kill", "bash", nil, cmdExec)
+	inst := &Instance{
+		Title:       "retry-kill",
+		backend:     &LocalBackend{},
+		started:     true,
+		tmuxSession: ts,
+	}
+
+	err := inst.Kill()
+	require.Error(t, err)
+
+	err = inst.Kill()
+	require.Error(t, err, "failed tmux cleanup must remain retryable instead of becoming a false success")
 }
 
 // --- IsRemote helper ---

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -148,8 +148,12 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 
 	worktreePath := basePath
 	for i := 2; ; i++ {
-		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+		_, err := os.Stat(worktreePath)
+		if os.IsNotExist(err) {
 			break
+		}
+		if err != nil {
+			return nil, "", fmt.Errorf("cannot check worktree path %q: %w", worktreePath, err)
 		}
 		worktreePath = fmt.Sprintf("%s-%d", basePath, i)
 	}

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
@@ -97,6 +98,30 @@ func TestNewGitWorktree_CollisionSuffix(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, strings.HasSuffix(gw3.GetWorktreePath(), repoName+"-my-feature-3"),
 		"third worktree should have -3 suffix, got: %s", gw3.GetWorktreePath())
+}
+
+func TestNewGitWorktree_StatErrorReturns(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := NewGitWorktree(repoRoot, strings.Repeat("a", 300))
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot check worktree path")
+	case <-time.After(2 * time.Second):
+		t.Fatal("NewGitWorktree hung on a non-ENOENT stat error")
+	}
 }
 
 func TestSetupFromExistingBranch_SetsBaseCommitSHA(t *testing.T) {

--- a/session/instance.go
+++ b/session/instance.go
@@ -279,10 +279,17 @@ func (i *Instance) RepoName() (string, error) {
 	if i.IsRemote() {
 		return "", fmt.Errorf("remote instances do not have a local repo")
 	}
-	if !i.started {
+	i.mu.RLock()
+	started := i.started
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+	if !started {
 		return "", fmt.Errorf("cannot get repo name for instance that has not been started")
 	}
-	return i.gitWorktree.GetRepoName(), nil
+	if gw == nil {
+		return "", fmt.Errorf("cannot get repo name for instance without a git worktree")
+	}
+	return gw.GetRepoName(), nil
 }
 
 func (i *Instance) SetStatus(status Status) {

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -81,6 +81,11 @@ func getBaseCommand(program string) string {
 	return strings.ToLower(filepath.Base(cmd))
 }
 
+// BaseCommand extracts the lowercase executable basename from a program string.
+func BaseCommand(program string) string {
+	return getBaseCommand(program)
+}
+
 // injectSystemPrompt injects Agent Factory instructions into the session.
 //
 // Strategy per tool:

--- a/task/cron.go
+++ b/task/cron.go
@@ -328,7 +328,9 @@ func expandCronField(field string, min, max int) ([]int, error) {
 // expandCronPart expands a single cron part (number, range, or step) into values.
 func expandCronPart(part string, min, max int) ([]int, error) {
 	step := 1
+	hasStep := false
 	if idx := strings.Index(part, "/"); idx != -1 {
+		hasStep = true
 		stepStr := part[idx+1:]
 		var err error
 		step, err = strconv.Atoi(stepStr)
@@ -368,7 +370,7 @@ func expandCronPart(part string, min, max int) ([]int, error) {
 	}
 	// When a step is provided with a single number (e.g. "5/10"), expand from
 	// that number to max by step. Without a step, return just the single value.
-	if step > 1 {
+	if hasStep {
 		var vals []int
 		for i := val; i <= max; i += step {
 			vals = append(vals, i)

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -57,6 +57,12 @@ func TestCronFieldExpandSingleWithStepAtBoundary(t *testing.T) {
 	assert.Equal(t, []int{59}, vals)
 }
 
+func TestCronFieldExpandSingleWithStepOne(t *testing.T) {
+	vals, err := expandCronField("5/1", 0, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []int{5, 6, 7, 8, 9, 10}, vals)
+}
+
 func TestCronFieldExpandListWithSingleStep(t *testing.T) {
 	// A list element with a single-number step should also expand.
 	vals, err := expandCronField("0,5/20", 0, 59)

--- a/task/launchd.go
+++ b/task/launchd.go
@@ -8,15 +8,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
 )
-
-// maxCalendarIntervals caps the cartesian product size to prevent
-// memory explosion from complex cron expressions like "*/1 */1 * * *".
-const maxCalendarIntervals = 512
 
 func getLaunchAgentLabel(t Task) string {
 	return "com.agent-factory.task-" + t.ID
@@ -47,7 +42,7 @@ func InstallScheduler(t Task) error {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
 
-	calendarXML, err := cronToCalendarIntervalXML(t.CronExpr)
+	scheduleXML, err := cronToLaunchdScheduleXML(t.CronExpr)
 	if err != nil {
 		return fmt.Errorf("failed to convert cron expression: %w", err)
 	}
@@ -94,7 +89,6 @@ func InstallScheduler(t Task) error {
         <key>TERM</key>
         <string>%s</string>
     </dict>
-    <key>StartCalendarInterval</key>
 %s
     <key>StandardOutPath</key>
     <string>%s</string>
@@ -104,7 +98,7 @@ func InstallScheduler(t Task) error {
 </plist>
 `, esc(label), esc(execPath), esc(t.ID), esc(t.ProjectPath),
 		esc(pathEnv), esc(homeEnv), esc(shellEnv), esc(termEnv),
-		calendarXML, esc(logPath), esc(logPath))
+		scheduleXML, esc(logPath), esc(logPath))
 
 	plistPath := filepath.Join(dir, label+".plist")
 
@@ -144,140 +138,4 @@ func RemoveScheduler(t Task) error {
 	}
 
 	return nil
-}
-
-// cronToCalendarIntervalXML converts a 5-field cron expression to launchd
-// StartCalendarInterval XML fragment.
-func cronToCalendarIntervalXML(cronExpr string) (string, error) {
-	if err := ValidateCronExpr(cronExpr); err != nil {
-		return "", err
-	}
-
-	fields := strings.Fields(cronExpr)
-
-	type fieldDef struct {
-		key string
-		min int
-		max int
-	}
-	defs := []fieldDef{
-		{"Minute", 0, 59},
-		{"Hour", 0, 23},
-		{"Day", 1, 31},
-		{"Month", 1, 12},
-		{"Weekday", 0, 7},
-	}
-
-	type expandedField struct {
-		key  string
-		vals []int // nil = wildcard
-	}
-
-	var expanded []expandedField
-	for i, def := range defs {
-		vals, err := expandCronField(fields[i], def.min, def.max)
-		if err != nil {
-			return "", fmt.Errorf("failed to expand %s field: %w", def.key, err)
-		}
-		// Normalize weekday 7 -> 0 (both mean Sunday in cron; launchd uses 0).
-		if def.key == "Weekday" && vals != nil {
-			vals = normalizeDOWValues(vals)
-		}
-		expanded = append(expanded, expandedField{key: def.key, vals: vals})
-	}
-
-	// When both day-of-month (DOM) and day-of-week (DOW) are non-wildcard,
-	// standard cron uses OR semantics: run on matching DOM OR matching DOW.
-	// We handle this by building two separate sets of combos and merging them.
-	domIdx, dowIdx := 2, 4
-
-	// Detect when DOM or DOW is syntactically restricted but semantically
-	// covers all possible values (e.g., DOW=0-6 or DOM=1-31). Under cron OR
-	// semantics, "X OR every-day" collapses to "every day", so both the DOM
-	// and DOW restrictions become irrelevant and we emit a single
-	// wildcard-day dict.
-	dowCoversAll := expanded[dowIdx].vals != nil && len(expanded[dowIdx].vals) >= 7
-	domCoversAll := expanded[domIdx].vals != nil && len(expanded[domIdx].vals) >= 31
-	if dowCoversAll || domCoversAll {
-		expanded[dowIdx].vals = nil
-		expanded[domIdx].vals = nil
-	}
-
-	bothDOMandDOW := expanded[domIdx].vals != nil && expanded[dowIdx].vals != nil
-
-	// buildCombos builds the cartesian product of the given expanded fields.
-	type combo map[string]int
-	buildCombos := func(fields []expandedField) ([]combo, error) {
-		result := []combo{{}}
-		for _, ef := range fields {
-			if ef.vals == nil {
-				continue // wildcard, omit from dict
-			}
-			var newResult []combo
-			for _, existing := range result {
-				for _, val := range ef.vals {
-					c := make(combo)
-					for k, v := range existing {
-						c[k] = v
-					}
-					c[ef.key] = val
-					newResult = append(newResult, c)
-				}
-			}
-			if len(newResult) > maxCalendarIntervals {
-				return nil, fmt.Errorf("cron expression %q expands to too many intervals (%d > %d)", cronExpr, len(newResult), maxCalendarIntervals)
-			}
-			result = newResult
-		}
-		return result, nil
-	}
-
-	if bothDOMandDOW {
-		return "", fmt.Errorf("cron expression %q combines day-of-month and day-of-week; macOS launchd cannot correctly express this. Use either DOM or DOW, not both", cronExpr)
-	}
-
-	combos, err := buildCombos(expanded)
-	if err != nil {
-		return "", err
-	}
-
-	if len(combos) == 0 || (len(combos) == 1 && len(combos[0]) == 0) {
-		return "", fmt.Errorf("cron expression %q results in no specific schedule", cronExpr)
-	}
-
-	// Deterministic key order for output.
-	keyOrder := []string{"Month", "Day", "Weekday", "Hour", "Minute"}
-
-	var sb strings.Builder
-	sb.WriteString("    <array>\n")
-	for _, c := range combos {
-		sb.WriteString("        <dict>\n")
-		for _, key := range keyOrder {
-			if val, ok := c[key]; ok {
-				fmt.Fprintf(&sb, "            <key>%s</key>\n            <integer>%d</integer>\n", key, val)
-			}
-		}
-		sb.WriteString("        </dict>\n")
-	}
-	sb.WriteString("    </array>")
-
-	return sb.String(), nil
-}
-
-// normalizeDOWValues maps weekday value 7 to 0 (both mean Sunday)
-// and deduplicates/sorts the result.
-func normalizeDOWValues(vals []int) []int {
-	seen := make(map[int]bool)
-	var unique []int
-	for _, v := range vals {
-		if v == 7 {
-			v = 0
-		}
-		if !seen[v] {
-			seen[v] = true
-			unique = append(unique, v)
-		}
-	}
-	sort.Ints(unique)
-	return unique
 }

--- a/task/launchd_schedule.go
+++ b/task/launchd_schedule.go
@@ -1,0 +1,172 @@
+package task
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// maxCalendarIntervals caps the cartesian product size to prevent
+// memory explosion from complex cron expressions like "*/1 */1 * * *".
+const maxCalendarIntervals = 512
+
+func cronToLaunchdScheduleXML(cronExpr string) (string, error) {
+	if isEveryMinuteCron(cronExpr) {
+		if err := ValidateCronExpr(cronExpr); err != nil {
+			return "", err
+		}
+		return "    <key>StartInterval</key>\n    <integer>60</integer>", nil
+	}
+
+	calendarXML, err := cronToCalendarIntervalXML(cronExpr)
+	if err != nil {
+		return "", err
+	}
+	return "    <key>StartCalendarInterval</key>\n" + calendarXML, nil
+}
+
+func isEveryMinuteCron(cronExpr string) bool {
+	fields := strings.Fields(cronExpr)
+	if len(fields) != 5 {
+		return false
+	}
+	for _, field := range fields {
+		if field != "*" {
+			return false
+		}
+	}
+	return true
+}
+
+// cronToCalendarIntervalXML converts a 5-field cron expression to a launchd
+// StartCalendarInterval XML value fragment.
+func cronToCalendarIntervalXML(cronExpr string) (string, error) {
+	if err := ValidateCronExpr(cronExpr); err != nil {
+		return "", err
+	}
+
+	fields := strings.Fields(cronExpr)
+
+	type fieldDef struct {
+		key string
+		min int
+		max int
+	}
+	defs := []fieldDef{
+		{"Minute", 0, 59},
+		{"Hour", 0, 23},
+		{"Day", 1, 31},
+		{"Month", 1, 12},
+		{"Weekday", 0, 7},
+	}
+
+	type expandedField struct {
+		key  string
+		vals []int // nil = wildcard
+	}
+
+	var expanded []expandedField
+	for i, def := range defs {
+		vals, err := expandCronField(fields[i], def.min, def.max)
+		if err != nil {
+			return "", fmt.Errorf("failed to expand %s field: %w", def.key, err)
+		}
+		// Normalize weekday 7 -> 0 (both mean Sunday in cron; launchd uses 0).
+		if def.key == "Weekday" && vals != nil {
+			vals = normalizeDOWValues(vals)
+		}
+		expanded = append(expanded, expandedField{key: def.key, vals: vals})
+	}
+
+	// When both day-of-month (DOM) and day-of-week (DOW) are non-wildcard,
+	// standard cron uses OR semantics: run on matching DOM OR matching DOW.
+	// We reject non-collapsible cases because launchd cannot express that
+	// semantics without duplicate fires.
+	domIdx, dowIdx := 2, 4
+
+	// Detect when DOM or DOW is syntactically restricted but semantically
+	// covers all possible values (e.g., DOW=0-6 or DOM=1-31). Under cron OR
+	// semantics, "X OR every-day" collapses to "every day", so both the DOM
+	// and DOW restrictions become irrelevant and we emit a single
+	// wildcard-day dict.
+	dowCoversAll := expanded[dowIdx].vals != nil && len(expanded[dowIdx].vals) >= 7
+	domCoversAll := expanded[domIdx].vals != nil && len(expanded[domIdx].vals) >= 31
+	if dowCoversAll || domCoversAll {
+		expanded[dowIdx].vals = nil
+		expanded[domIdx].vals = nil
+	}
+
+	bothDOMandDOW := expanded[domIdx].vals != nil && expanded[dowIdx].vals != nil
+
+	// buildCombos builds the cartesian product of the given expanded fields.
+	type combo map[string]int
+	buildCombos := func(fields []expandedField) ([]combo, error) {
+		result := []combo{{}}
+		for _, ef := range fields {
+			if ef.vals == nil {
+				continue // wildcard, omit from dict
+			}
+			var newResult []combo
+			for _, existing := range result {
+				for _, val := range ef.vals {
+					c := make(combo)
+					for k, v := range existing {
+						c[k] = v
+					}
+					c[ef.key] = val
+					newResult = append(newResult, c)
+				}
+			}
+			if len(newResult) > maxCalendarIntervals {
+				return nil, fmt.Errorf("cron expression %q expands to too many intervals (%d > %d)", cronExpr, len(newResult), maxCalendarIntervals)
+			}
+			result = newResult
+		}
+		return result, nil
+	}
+
+	if bothDOMandDOW {
+		return "", fmt.Errorf("cron expression %q combines day-of-month and day-of-week; macOS launchd cannot correctly express this. Use either DOM or DOW, not both", cronExpr)
+	}
+
+	combos, err := buildCombos(expanded)
+	if err != nil {
+		return "", err
+	}
+
+	// Deterministic key order for output.
+	keyOrder := []string{"Month", "Day", "Weekday", "Hour", "Minute"}
+
+	var sb strings.Builder
+	sb.WriteString("    <array>\n")
+	for _, c := range combos {
+		sb.WriteString("        <dict>\n")
+		for _, key := range keyOrder {
+			if val, ok := c[key]; ok {
+				fmt.Fprintf(&sb, "            <key>%s</key>\n            <integer>%d</integer>\n", key, val)
+			}
+		}
+		sb.WriteString("        </dict>\n")
+	}
+	sb.WriteString("    </array>")
+
+	return sb.String(), nil
+}
+
+// normalizeDOWValues maps weekday value 7 to 0 (both mean Sunday)
+// and deduplicates/sorts the result.
+func normalizeDOWValues(vals []int) []int {
+	seen := make(map[int]bool)
+	var unique []int
+	for _, v := range vals {
+		if v == 7 {
+			v = 0
+		}
+		if !seen[v] {
+			seen[v] = true
+			unique = append(unique, v)
+		}
+	}
+	sort.Ints(unique)
+	return unique
+}

--- a/task/launchd_test.go
+++ b/task/launchd_test.go
@@ -1,5 +1,3 @@
-//go:build darwin
-
 package task
 
 import (
@@ -110,4 +108,22 @@ func TestCronToCalendarIntervalXML_DOW7NormalizesAndCoversAll(t *testing.T) {
 	assert.Equal(t, 1, countDicts(xml), "expected a single dict, got:\n%s", xml)
 	assert.NotContains(t, xml, "<key>Day</key>")
 	assert.NotContains(t, xml, "<key>Weekday</key>")
+}
+
+func TestCronToCalendarIntervalXML_AllWildcards(t *testing.T) {
+	xml, err := cronToCalendarIntervalXML("* * * * *")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countDicts(xml), "expected one wildcard dict, got:\n%s", xml)
+	assert.NotContains(t, xml, "<key>Minute</key>")
+	assert.NotContains(t, xml, "<key>Hour</key>")
+}
+
+func TestCronToLaunchdScheduleXML_AllWildcardsUsesStartInterval(t *testing.T) {
+	xml, err := cronToLaunchdScheduleXML("* * * * *")
+	require.NoError(t, err)
+
+	assert.Contains(t, xml, "<key>StartInterval</key>")
+	assert.Contains(t, xml, "<integer>60</integer>")
+	assert.NotContains(t, xml, "<key>StartCalendarInterval</key>")
 }

--- a/task/runner.go
+++ b/task/runner.go
@@ -18,6 +18,11 @@ import (
 
 const pendingInstancesFileName = "pending_instances.json"
 
+var (
+	waitForReadyTimeout      = 60 * time.Second
+	waitForReadyPollInterval = 500 * time.Millisecond
+)
+
 func getPendingInstancesPath() (string, error) {
 	configDir, err := config.GetConfigDir()
 	if err != nil {
@@ -106,8 +111,8 @@ func isReadyContent(content string) bool {
 // WaitForReady polls the instance's tmux pane until the program shows its
 // input prompt (e.g. Claude Code's ">" prompt) or trust prompt, or times out after 60 seconds.
 func WaitForReady(instance *session.Instance) error {
-	timeout := time.After(60 * time.Second)
-	ticker := time.NewTicker(500 * time.Millisecond)
+	timeout := time.After(waitForReadyTimeout)
+	ticker := time.NewTicker(waitForReadyPollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -119,7 +124,7 @@ func WaitForReady(instance *session.Instance) error {
 			} else {
 				log.ErrorLog.Printf("waitForReady timed out. Last pane content: %s", content)
 			}
-			return fmt.Errorf("timed out waiting for program to start (60s)")
+			return fmt.Errorf("timed out waiting for program to start (%s)", waitForReadyTimeout)
 		case <-ticker.C:
 			content, err := instance.Preview()
 			if err != nil {
@@ -220,14 +225,7 @@ func RunTask(taskID string) error {
 		return fmt.Errorf("failed to resolve repo for project path %s: %w", t.ProjectPath, err)
 	}
 	data := instance.ToInstanceData()
-	if err := config.UpdateRepoInstances(repo.ID, func(raw json.RawMessage) (json.RawMessage, error) {
-		var existing []session.InstanceData
-		if err := json.Unmarshal(raw, &existing); err != nil {
-			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
-		}
-		existing = append(existing, data)
-		return json.MarshalIndent(existing, "", "  ")
-	}); err != nil {
+	if err := config.UpdateRepoInstances(repo.ID, appendTaskRunnerInstanceFn(data)); err != nil {
 		return fmt.Errorf("failed to save instance to per-repo storage: %w", err)
 	}
 
@@ -260,4 +258,20 @@ func RunTask(taskID string) error {
 
 	log.InfoLog.Printf("task %s started successfully as instance %s", taskID, title)
 	return nil
+}
+
+func appendTaskRunnerInstanceFn(data session.InstanceData) func(json.RawMessage) (json.RawMessage, error) {
+	return func(raw json.RawMessage) (json.RawMessage, error) {
+		var existing []session.InstanceData
+		if err := json.Unmarshal(raw, &existing); err != nil {
+			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
+		}
+		for i := range existing {
+			if existing[i].Title == data.Title {
+				return nil, fmt.Errorf("session with title %q already exists", data.Title)
+			}
+		}
+		existing = append(existing, data)
+		return json.MarshalIndent(existing, "", "  ")
+	}
 }

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -2,9 +2,9 @@ package task
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -169,14 +169,7 @@ func TestLoadAndClearPendingInstances_Corrupted(t *testing.T) {
 // RunTask. Keeping it identical here lets us exercise the per-repo write
 // path without spinning up a full session/tmux/git-worktree fixture.
 func runnerAppendInstance(repoID string, data session.InstanceData) error {
-	return config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {
-		var existing []session.InstanceData
-		if err := json.Unmarshal(raw, &existing); err != nil {
-			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
-		}
-		existing = append(existing, data)
-		return json.MarshalIndent(existing, "", "  ")
-	})
+	return config.UpdateRepoInstances(repoID, appendTaskRunnerInstanceFn(data))
 }
 
 // TestRunTask_WritesToPerRepoStorage is the regression test for issue #334.
@@ -267,5 +260,58 @@ func TestRunTask_AppendsToExistingPerRepoStorage(t *testing.T) {
 	}
 	if got[0].Title != "existing-from-api" || got[1].Title != "task-instance" {
 		t.Fatalf("unexpected merged instances: %+v", got)
+	}
+}
+
+func TestRunTask_RejectsDuplicateTitleInPerRepoStorage(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoID := "test-repo-dup"
+	instancesPath, err := config.RepoInstancesPath(repoID)
+	if err != nil {
+		t.Fatalf("RepoInstancesPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(instancesPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	preexisting := []session.InstanceData{{
+		Title: "task-instance",
+		Worktree: session.GitWorktreeData{
+			WorktreePath: "/repo/worktrees/task-instance",
+		},
+	}}
+	preRaw, err := json.MarshalIndent(preexisting, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal preexisting: %v", err)
+	}
+	if err := os.WriteFile(instancesPath, preRaw, 0644); err != nil {
+		t.Fatalf("write preexisting: %v", err)
+	}
+
+	err = runnerAppendInstance(repoID, session.InstanceData{
+		Title: "task-instance",
+		Worktree: session.GitWorktreeData{
+			WorktreePath: "/repo/worktrees/task-instance-2",
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected duplicate title error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var got []session.InstanceData
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 1 || got[0].Worktree.WorktreePath != "/repo/worktrees/task-instance" {
+		t.Fatalf("duplicate append should preserve original storage, got %+v", got)
 	}
 }

--- a/task/start.go
+++ b/task/start.go
@@ -1,10 +1,15 @@
 package task
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/session"
 )
+
+const maxTrustPromptAttempts = 20
+
+var trustPromptRetryDelay = time.Second
 
 // StartAndSendPrompt is the canonical way to start an instance, wait for
 // readiness, handle trust prompts, and optionally send a prompt.
@@ -30,8 +35,11 @@ func StartAndSendPrompt(instance *session.Instance, prompt string) error {
 		return err
 	}
 
-	for instance.CheckAndHandleTrustPrompt() {
-		time.Sleep(1 * time.Second)
+	for attempts := 0; instance.CheckAndHandleTrustPrompt(); attempts++ {
+		if attempts+1 >= maxTrustPromptAttempts {
+			return fmt.Errorf("trust prompt did not dismiss after %d attempts", maxTrustPromptAttempts)
+		}
+		time.Sleep(trustPromptRetryDelay)
 		if err := WaitForReady(instance); err != nil {
 			return err
 		}

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -1,0 +1,119 @@
+package task
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+type startBackend struct {
+	trustPrompts int
+	trustChecks  int
+	sentPrompt   string
+}
+
+func (b *startBackend) Start(instance *session.Instance, _ bool) error {
+	instance.SetStartedForTest(true)
+	return nil
+}
+
+func (b *startBackend) Kill(instance *session.Instance) error {
+	instance.SetStartedForTest(false)
+	return nil
+}
+
+func (b *startBackend) Preview(*session.Instance) (string, error) {
+	return "ready\n❯", nil
+}
+
+func (b *startBackend) PreviewFullHistory(*session.Instance) (string, error) {
+	return "ready\n❯", nil
+}
+
+func (b *startBackend) Attach(*session.Instance) (chan struct{}, error) {
+	ch := make(chan struct{})
+	close(ch)
+	return ch, nil
+}
+
+func (b *startBackend) HasUpdated(*session.Instance) (bool, bool)  { return false, false }
+func (b *startBackend) SendPrompt(*session.Instance, string) error { return nil }
+func (b *startBackend) SendPromptCommand(_ *session.Instance, prompt string) error {
+	b.sentPrompt = prompt
+	return nil
+}
+func (b *startBackend) SendKeys(*session.Instance, string) error         { return nil }
+func (b *startBackend) SetPreviewSize(*session.Instance, int, int) error { return nil }
+func (b *startBackend) IsAlive(*session.Instance) bool                   { return true }
+func (b *startBackend) CheckAndHandleTrustPrompt(*session.Instance) bool {
+	b.trustChecks++
+	if b.trustPrompts <= 0 {
+		return false
+	}
+	b.trustPrompts--
+	return true
+}
+func (b *startBackend) TapEnter(*session.Instance) {}
+func (b *startBackend) Type() string               { return "local" }
+
+func newStartTestInstance(t *testing.T, backend *startBackend) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "start-test",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	inst.SetBackend(backend)
+	return inst
+}
+
+func TestStartAndSendPrompt_BoundsPersistentTrustPrompt(t *testing.T) {
+	oldDelay := trustPromptRetryDelay
+	oldPoll := waitForReadyPollInterval
+	trustPromptRetryDelay = 0
+	waitForReadyPollInterval = time.Nanosecond
+	t.Cleanup(func() {
+		trustPromptRetryDelay = oldDelay
+		waitForReadyPollInterval = oldPoll
+	})
+
+	backend := &startBackend{trustPrompts: maxTrustPromptAttempts + 5}
+	err := StartAndSendPrompt(newStartTestInstance(t, backend), "do work")
+	if err == nil {
+		t.Fatalf("expected persistent trust prompt error")
+	}
+	if !strings.Contains(err.Error(), "trust prompt did not dismiss") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if backend.trustChecks != maxTrustPromptAttempts {
+		t.Fatalf("expected %d trust checks, got %d", maxTrustPromptAttempts, backend.trustChecks)
+	}
+	if backend.sentPrompt != "" {
+		t.Fatalf("prompt should not be sent after trust prompt failure, got %q", backend.sentPrompt)
+	}
+}
+
+func TestStartAndSendPrompt_AllowsSequentialTrustPrompts(t *testing.T) {
+	oldDelay := trustPromptRetryDelay
+	oldPoll := waitForReadyPollInterval
+	trustPromptRetryDelay = time.Nanosecond
+	waitForReadyPollInterval = time.Nanosecond
+	t.Cleanup(func() {
+		trustPromptRetryDelay = oldDelay
+		waitForReadyPollInterval = oldPoll
+	})
+
+	backend := &startBackend{trustPrompts: 3}
+	err := StartAndSendPrompt(newStartTestInstance(t, backend), "do work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if backend.sentPrompt != "do work" {
+		t.Fatalf("expected prompt to be sent after trust prompts clear, got %q", backend.sentPrompt)
+	}
+}

--- a/task/systemd.go
+++ b/task/systemd.go
@@ -50,6 +50,8 @@ func quoteExecStartPath(p string) string {
 func sanitizeEnvValue(v string) string {
 	v = strings.ReplaceAll(v, "\n", " ")
 	v = strings.ReplaceAll(v, "\r", " ")
+	v = strings.ReplaceAll(v, `$`, `$$`)
+	v = strings.ReplaceAll(v, `%`, `%%`)
 	return v
 }
 

--- a/task/systemd_test.go
+++ b/task/systemd_test.go
@@ -150,3 +150,23 @@ func TestQuoteExecStartPathEscapesDollarAndPercent(t *testing.T) {
 	assert.Equal(t, `"/tmp/weird%%h/bin/af"`, quoteExecStartPath(`/tmp/weird%h/bin/af`))
 	assert.Equal(t, `"/tmp/$$HOME-%%t/af"`, quoteExecStartPath(`/tmp/$HOME-%t/af`))
 }
+
+func TestSanitizeEnvValueEscapesDollarAndPercent(t *testing.T) {
+	assert.Equal(t, `/tmp/$$HOME-%%h`, sanitizeEnvValue(`/tmp/$HOME-%h`))
+}
+
+func TestGenerateServiceContentEscapesWorkingDirectorySpecifier(t *testing.T) {
+	content := generateServiceContent(
+		"agent-factory-task-spec",
+		"/usr/local/bin/agent-factory",
+		"spec",
+		"/tmp/test%hdir",
+		"/usr/bin",
+		"/home/user",
+		"/bin/bash",
+		"xterm-256color",
+	)
+
+	assert.Contains(t, content, "\nWorkingDirectory=/tmp/test%%hdir\n")
+	assert.NotContains(t, content, "\nWorkingDirectory=/tmp/test%hdir\n")
+}

--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -126,7 +126,7 @@ func (h *HooksPane) handleEditMode(msg tea.KeyMsg) bool {
 		h.adding = false
 		h.editing = false
 		h.editBuffer = ""
-	case tea.KeyEsc:
+	case tea.KeyEsc, tea.KeyCtrlC:
 		h.adding = false
 		h.editing = false
 		h.editBuffer = ""

--- a/ui/hooks_pane_test.go
+++ b/ui/hooks_pane_test.go
@@ -1,0 +1,22 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHooksPaneEditModeCtrlCCancels(t *testing.T) {
+	h := NewHooksPane()
+	h.SetCommands([]string{"make test"})
+	h.SetFocus(true)
+
+	assert.True(t, h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}))
+	assert.True(t, h.editing)
+
+	assert.True(t, h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlC}))
+	assert.False(t, h.editing)
+	assert.False(t, h.adding)
+	assert.Empty(t, h.editBuffer)
+}

--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -2,6 +2,7 @@ package overlay
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	xansi "github.com/charmbracelet/x/ansi"
@@ -75,6 +76,11 @@ func PlaceOverlay(
 			// Skip reset codes
 			if match == "\x1b[0m" {
 				return match
+			}
+			codeText := strings.TrimSuffix(strings.TrimPrefix(match, "\x1b["), "m")
+			code, err := strconv.Atoi(codeText)
+			if err == nil && (code == 7 || (code >= 40 && code <= 47) || (code >= 100 && code <= 107)) {
+				return "\x1b[48;5;236m" // Dark gray background
 			}
 			// Replace with dimmed color
 			return "\x1b[38;5;240m" // Medium gray

--- a/ui/overlay/overlay_test.go
+++ b/ui/overlay/overlay_test.go
@@ -112,3 +112,22 @@ func TestPlaceOverlayEqualHeight(t *testing.T) {
 		}
 	}
 }
+
+func TestPlaceOverlayBasicBackgroundFade(t *testing.T) {
+	result := PlaceOverlay(0, 0, "XX", "\x1b[41mred-bg\x1b[0m", false)
+
+	if strings.Contains(result, "\x1b[38;5;240m") {
+		t.Fatalf("basic background code was faded as foreground: %q", result)
+	}
+	if !strings.Contains(result, "\x1b[48;5;236m") {
+		t.Fatalf("expected faded background code, got: %q", result)
+	}
+}
+
+func TestPlaceOverlayReverseVideoFadesAsBackground(t *testing.T) {
+	result := PlaceOverlay(0, 0, "XX", "\x1b[7mreverse\x1b[0m", false)
+
+	if !strings.Contains(result, "\x1b[48;5;236m") {
+		t.Fatalf("expected reverse-video styling to preserve background semantics, got: %q", result)
+	}
+}

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -123,7 +123,7 @@ func (s *SearchOverlay) matches(inst *session.Instance, query string) bool {
 		return true
 	}
 	title := strings.ToLower(inst.Title)
-	branch := strings.ToLower(inst.Branch)
+	branch := strings.ToLower(inst.GetBranch())
 
 	// Simple fuzzy: check if all query chars appear in order in the title or branch
 	return fuzzyMatch(query, title) || fuzzyMatch(query, branch)
@@ -184,7 +184,7 @@ func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
 
 		// Status indicator
 		var statusStr string
-		switch r.Instance.Status {
+		switch r.Instance.GetStatus() {
 		case session.Running:
 			statusStr = statusRunning.Render("●")
 		case session.Ready:
@@ -196,14 +196,15 @@ func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
 		}
 
 		label := r.Instance.Title
-		if r.Instance.Branch != "" {
-			label += normalStyle.Render(" (" + r.Instance.Branch + ")")
+		branch := r.Instance.GetBranch()
+		if branch != "" {
+			label += normalStyle.Render(" (" + branch + ")")
 		}
 
 		if i == s.selectedIdx {
 			content += "  " + statusStr + " " + selectedStyle.Render("▸ "+r.Instance.Title)
-			if r.Instance.Branch != "" {
-				content += normalStyle.Render(" (" + r.Instance.Branch + ")")
+			if branch != "" {
+				content += normalStyle.Render(" (" + branch + ")")
 			}
 			content += "\n"
 		} else {

--- a/ui/preview.go
+++ b/ui/preview.go
@@ -151,7 +151,7 @@ func (p *PreviewPane) String() string {
 
 	// Truncate if we have more lines than available height
 	if p.height > 0 {
-		if len(lines) > p.height-1 {
+		if len(lines) > p.height {
 			lines = lines[:p.height-1]
 			lines = append(lines, "...")
 		} else {

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -381,6 +381,19 @@ func TestPreviewContentWithoutScrolling(t *testing.T) {
 	require.Contains(t, renderedString, "test", "Rendered preview should contain the test content")
 }
 
+func TestPreviewExactFitDoesNotTruncate(t *testing.T) {
+	p := NewPreviewPane()
+	p.SetSize(80, 3)
+	p.previewState = previewState{
+		fallback: false,
+		text:     "one\ntwo\nthree",
+	}
+
+	rendered := p.String()
+	require.Contains(t, rendered, "three")
+	require.NotContains(t, rendered, "...")
+}
+
 // Helper function for max
 func max(a, b int) int {
 	if a > b {

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -252,18 +252,27 @@ func (s *Sidebar) NumInstances() int {
 	return len(s.instances)
 }
 
+// NumRepos returns the number of repositories represented in the sidebar.
+func (s *Sidebar) NumRepos() int {
+	return len(s.repos)
+}
+
 // AddInstance adds a new instance. Returns a finalizer to register the repo.
 func (s *Sidebar) AddInstance(instance *session.Instance) (finalize func()) {
 	s.instances = append(s.instances, instance)
 	s.rebuildVisibleItems()
-	return func() {
-		repoName, err := instance.RepoName()
-		if err != nil {
-			log.ErrorLog.Printf("could not get repo name: %v", err)
-			return
-		}
-		s.addRepo(repoName)
+	return func() { s.RegisterRepoForInstance(instance) }
+}
+
+// RegisterRepoForInstance records the instance's repo after the instance has
+// started and its worktree is available.
+func (s *Sidebar) RegisterRepoForInstance(instance *session.Instance) {
+	repoName, err := instance.RepoName()
+	if err != nil {
+		log.ErrorLog.Printf("could not get repo name: %v", err)
+		return
 	}
+	s.addRepo(repoName)
 }
 
 // Kill kills the selected instance. It returns an error if the underlying

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -207,7 +207,7 @@ func (w *TabbedWindow) String() string {
 
 	var renderedTabs []string
 
-	totalTabWidth := w.width + windowStyle.GetHorizontalFrameSize()
+	totalTabWidth := w.width
 	tabWidth := totalTabWidth / len(w.tabs)
 	lastTabWidth := totalTabWidth - tabWidth*(len(w.tabs)-1)
 	tabHeight := activeTabStyle.GetVerticalFrameSize() + 1 // get padding border margin size + 1 for character height
@@ -248,9 +248,13 @@ func (w *TabbedWindow) String() string {
 	case TerminalTab:
 		content = w.terminal.String()
 	}
+	contentWidth := w.width - windowStyle.GetHorizontalFrameSize()
+	if contentWidth < 0 {
+		contentWidth = 0
+	}
 	window := windowStyle.Render(
 		lipgloss.Place(
-			w.width, w.height-2-windowStyle.GetVerticalFrameSize()-tabHeight,
+			contentWidth, w.height-2-windowStyle.GetVerticalFrameSize()-tabHeight,
 			lipgloss.Left, lipgloss.Top, content))
 
 	return lipgloss.JoinVertical(lipgloss.Left, "\n", row, window)

--- a/ui/tabbed_window_test.go
+++ b/ui/tabbed_window_test.go
@@ -1,8 +1,10 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/muesli/ansi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,4 +48,20 @@ func TestTabbedWindowSetSizeNormal(t *testing.T) {
 	previewW, previewH := w.GetPreviewSize()
 	assert.Greater(t, previewW, 0)
 	assert.Greater(t, previewH, 0)
+}
+
+func TestTabbedWindowStringDoesNotExceedConfiguredWidth(t *testing.T) {
+	w := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
+	w.SetSize(100, 30)
+	w.preview.previewState = previewState{text: "content"}
+
+	rendered := w.String()
+	maxWidth := 0
+	for _, line := range strings.Split(rendered, "\n") {
+		if width := ansi.PrintableRuneWidth(line); width > maxWidth {
+			maxWidth = width
+		}
+	}
+
+	assert.LessOrEqual(t, maxWidth, w.width)
 }

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -183,6 +183,9 @@ func (s *TaskPane) HandleKeyPress(msg tea.KeyMsg) bool {
 }
 
 func (s *TaskPane) handleNormalMode(msg tea.KeyMsg) bool {
+	if msg.String() == "ctrl+c" || msg.String() == "q" {
+		return false
+	}
 	switch msg.String() {
 	case "esc":
 		s.hasFocus = false

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/stretchr/testify/assert"
 )
@@ -72,4 +73,12 @@ func TestTaskPaneConsumePendingTriggerReturnsSelected(t *testing.T) {
 		assert.Equal(t, "b", got.ID)
 	}
 	assert.False(t, tp.pendingTrigger)
+}
+
+func TestTaskPaneNormalModeAllowsQuitKeysToPropagate(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetFocus(true)
+
+	assert.False(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}))
+	assert.False(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlC}))
 }

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -19,6 +19,8 @@ var terminalPaneStyle = lipgloss.NewStyle().
 var terminalFooterStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#808080", Dark: "#808080"})
 
+var newTerminalTmuxSessionForRepo = tmux.NewTmuxSessionForRepo
+
 // terminalSession holds a cached tmux session for a specific instance.
 type terminalSession struct {
 	tmuxSession  *tmux.TmuxSession
@@ -173,16 +175,19 @@ func (t *TerminalPane) ensureSessionLocked(instance *session.Instance) error {
 	}
 
 	termName := "term_" + instance.Title
-	ts := tmux.NewTmuxSessionForRepo(termName, worktreePath, shell)
+	ts := newTerminalTmuxSessionForRepo(termName, worktreePath, shell)
 
 	// Check if session already exists (e.g. from a previous run)
 	if ts.DoesSessionExist() {
 		if err := ts.Restore(); err != nil {
 			// Session exists but can't restore, kill it and start fresh
 			if closeErr := ts.Close(); closeErr != nil {
-				log.ErrorLog.Printf("terminal pane: failed to close stale session %s: %v", termName, closeErr)
+				if ts.DoesSessionExist() {
+					return fmt.Errorf("terminal pane: failed to close stale session %s: %w", termName, closeErr)
+				}
+				log.ErrorLog.Printf("terminal pane: partial cleanup of stale session %s: %v", termName, closeErr)
 			}
-			ts = tmux.NewTmuxSessionForRepo(termName, worktreePath, shell)
+			ts = newTerminalTmuxSessionForRepo(termName, worktreePath, shell)
 			if err := ts.Start(worktreePath); err != nil {
 				return fmt.Errorf("terminal pane: failed to start session: %w", err)
 			}

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -423,4 +424,48 @@ func TestTerminalCloseForInstance(t *testing.T) {
 	tp.mu.Lock()
 	require.Len(t, tp.sessions, 1, "non-existent close should not affect existing sessions")
 	tp.mu.Unlock()
+}
+
+type failingPtyFactory struct{}
+
+func (f failingPtyFactory) Start(*exec.Cmd) (*os.File, error) {
+	return nil, fmt.Errorf("restore failed")
+}
+
+func (f failingPtyFactory) Close() {}
+
+func TestTerminalEnsureSessionReturnsStaleCleanupError(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	instance := makeStartedInstance(t, "stale-cleanup")
+	defer func() { _ = instance.Kill() }()
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			cmdStr := cmd.String()
+			if strings.Contains(cmdStr, "has-session") {
+				return nil
+			}
+			if strings.Contains(cmdStr, "kill-session") {
+				return fmt.Errorf("kill failed")
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, nil
+		},
+	}
+
+	oldFactory := newTerminalTmuxSessionForRepo
+	newTerminalTmuxSessionForRepo = func(name, program, shell string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionWithDeps(name, shell, failingPtyFactory{}, cmdExec)
+	}
+	t.Cleanup(func() { newTerminalTmuxSessionForRepo = oldFactory })
+
+	tp := NewTerminalPane()
+	err := tp.ensureSession(instance)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to close stale session")
+	require.Contains(t, err.Error(), "kill failed")
 }


### PR DESCRIPTION
## Summary
- Fix the scoped, reproducible regressions from the open issue queue across task startup, session persistence, cleanup retry behavior, cron/scheduler conversion, and UI rendering/input handling.
- Keep session title collision checks per repo: same-repo duplicates are rejected before creating resources, while cross-repo duplicate titles remain allowed.
- Harden concurrent/session code paths: bound trust prompt retries, serialize hook preview `Wait`, preserve failed local cleanup refs for retry, and use synchronized instance accessors in search/help rendering.
- Move pure launchd schedule conversion into an always-built file so macOS schedule conversion logic is covered by Linux CI/local tests.

Fixes #317, #409, #410, #411, #412, #413, #414, #415, #416, #417, #418, #419, #420, #421, #422, #423, #424, #425, #426, #427, #428, #429, #430.

## Triage Notes
Not addressed in this PR:
- #432: current code already uses locked atomic writes with file and directory fsync, and `af sessions list` is read-only in this branch; this needs more diagnostics rather than a speculative rewrite.
- #303 and #386: feature requests, not bug fixes.
- #309, #312, #313: remote-hook protocol/design work with migration and behavior tradeoffs; left for dedicated PRs.

## Testing
- `git diff --check`
- `go test ./...`
- `go test -race ./...`
