### PR TITLE
Fix TUI/session sync and recurring task reruns

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -505,9 +505,13 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 		return m.handleError(fmt.Errorf("no task selected"))
 	}
 
-	title := tsk.Name
-	if title == "" {
-		title = fmt.Sprintf("task-%s", tsk.ID)
+	repo, err := config.RepoFromPath(tsk.ProjectPath)
+	if err != nil {
+		return m.handleError(fmt.Errorf("failed to resolve repo for task path: %w", err))
+	}
+	title, err := task.NextTaskRunTitle(repo.ID, tsk.ProjectPath, task.TaskRunBaseTitle(*tsk), tsk.Program)
+	if err != nil {
+		return m.handleError(fmt.Errorf("failed to allocate task run title: %w", err))
 	}
 
 	instance, err := session.NewInstance(session.InstanceOptions{

--- a/app/sync.go
+++ b/app/sync.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -187,24 +188,17 @@ func (m *home) mergePendingInstances() int {
 			grouped[rid] = append(grouped[rid], d)
 		}
 		for rid, group := range grouped {
-			existing, err := config.LoadRepoInstances(rid)
-			if err != nil {
-				log.WarningLog.Printf("failed to load existing instances for repo %s: %v", rid, err)
-			}
-			var existingData []session.InstanceData
-			if existing != nil && string(existing) != "[]" && string(existing) != "null" {
-				if err := json.Unmarshal(existing, &existingData); err != nil {
-					log.WarningLog.Printf("failed to parse existing instances for repo %s: %v", rid, err)
+			if err := config.UpdateRepoInstances(rid, func(existing json.RawMessage) (json.RawMessage, error) {
+				var existingData []session.InstanceData
+				if existing != nil && string(existing) != "[]" && string(existing) != "null" {
+					if err := json.Unmarshal(existing, &existingData); err != nil {
+						return nil, fmt.Errorf("failed to parse existing instances for repo %s: %w", rid, err)
+					}
 				}
-			}
-			existingData = append(existingData, group...)
-			jsonData, err := json.Marshal(existingData)
-			if err != nil {
-				log.WarningLog.Printf("failed to marshal instances for repo %s: %v", rid, err)
-				continue
-			}
-			if err := config.SaveRepoInstances(rid, jsonData); err != nil {
-				log.WarningLog.Printf("failed to save instances for repo %s: %v", rid, err)
+				existingData = upsertInstanceDataByTitle(existingData, group)
+				return json.Marshal(existingData)
+			}); err != nil {
+				log.WarningLog.Printf("failed to merge pending instances for repo %s: %v", rid, err)
 			}
 		}
 	}
@@ -282,4 +276,20 @@ func pendingInstanceCollisionShouldSkip(existingWorktreePath, pendingWorktreePat
 		return false
 	}
 	return tmuxAlive
+}
+
+func upsertInstanceDataByTitle(existing, incoming []session.InstanceData) []session.InstanceData {
+	index := make(map[string]int, len(existing))
+	for i := range existing {
+		index[existing[i].Title] = i
+	}
+	for _, data := range incoming {
+		if i, ok := index[data.Title]; ok {
+			existing[i] = data
+			continue
+		}
+		index[data.Title] = len(existing)
+		existing = append(existing, data)
+	}
+	return existing
 }

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -142,3 +142,33 @@ func TestSessionAutoYesAuthoritative(t *testing.T) {
 		})
 	}
 }
+
+func TestUpsertInstanceDataByTitleReplacesDuplicates(t *testing.T) {
+	existing := []session.InstanceData{
+		{Title: "already", Worktree: session.GitWorktreeData{WorktreePath: "/old"}},
+		{Title: "keep", Worktree: session.GitWorktreeData{WorktreePath: "/keep"}},
+	}
+	incoming := []session.InstanceData{
+		{Title: "already", Worktree: session.GitWorktreeData{WorktreePath: "/new"}},
+		{Title: "add", Worktree: session.GitWorktreeData{WorktreePath: "/add"}},
+	}
+
+	got := upsertInstanceDataByTitle(existing, incoming)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %+v", len(got), got)
+	}
+
+	byTitle := make(map[string]session.InstanceData)
+	for _, data := range got {
+		byTitle[data.Title] = data
+	}
+	if byTitle["already"].Worktree.WorktreePath != "/new" {
+		t.Fatalf("expected duplicate title to be replaced, got %+v", byTitle["already"])
+	}
+	if byTitle["keep"].Worktree.WorktreePath != "/keep" {
+		t.Fatalf("expected unrelated existing entry to remain, got %+v", byTitle["keep"])
+	}
+	if byTitle["add"].Worktree.WorktreePath != "/add" {
+		t.Fatalf("expected new entry to be appended, got %+v", byTitle["add"])
+	}
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
@@ -9,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -25,14 +27,11 @@ func RunDaemon(cfg *config.Config) error {
 		return fmt.Errorf("failed to initialize storage: %w", err)
 	}
 
-	instances, err := storage.LoadInstances()
+	instanceMap, err := refreshDaemonInstances(nil)
 	if err != nil {
 		return fmt.Errorf("failed to load instances: %w", err)
 	}
-	for _, instance := range instances {
-		// Assume AutoYes is true if the daemon is running.
-		instance.AutoYes = true
-	}
+	instances := daemonInstances(instanceMap)
 
 	pollInterval := time.Duration(cfg.DaemonPollInterval) * time.Millisecond
 
@@ -44,6 +43,13 @@ func RunDaemon(cfg *config.Config) error {
 		ticker := time.NewTicker(pollInterval)
 		defer ticker.Stop()
 		for {
+			if refreshed, err := refreshDaemonInstances(instanceMap); err != nil {
+				log.WarningLog.Printf("failed to refresh daemon instances: %v", err)
+			} else {
+				instanceMap = refreshed
+				instances = daemonInstances(instanceMap)
+			}
+
 			for _, instance := range instances {
 				// We only store started instances, but check anyway.
 				if instance.Started() {
@@ -76,6 +82,64 @@ func RunDaemon(cfg *config.Config) error {
 		log.ErrorLog.Printf("failed to save instances when terminating daemon: %v", err)
 	}
 	return nil
+}
+
+func refreshDaemonInstances(existing map[string]*session.Instance) (map[string]*session.Instance, error) {
+	allInstances, err := config.LoadAllRepoInstances()
+	if err != nil {
+		return existing, err
+	}
+
+	next := make(map[string]*session.Instance)
+	for repoID, raw := range allInstances {
+		if raw == nil || string(raw) == "[]" || string(raw) == "null" {
+			continue
+		}
+
+		var data []session.InstanceData
+		if err := json.Unmarshal(raw, &data); err != nil {
+			return existing, fmt.Errorf("failed to parse instances for repo %s: %w", repoID, err)
+		}
+
+		for _, item := range data {
+			key := daemonInstanceKey(repoID, item.Title)
+			if existing != nil {
+				if instance := existing[key]; instance != nil {
+					next[key] = instance
+					continue
+				}
+			}
+
+			instance, err := session.FromInstanceData(item)
+			if err != nil {
+				log.WarningLog.Printf("daemon skipping instance %q: %v", item.Title, err)
+				continue
+			}
+			// Assume AutoYes is true if the daemon is running.
+			instance.AutoYes = true
+			next[key] = instance
+		}
+	}
+
+	return next, nil
+}
+
+func daemonInstanceKey(repoID, title string) string {
+	return repoID + "\x00" + title
+}
+
+func daemonInstances(instanceMap map[string]*session.Instance) []*session.Instance {
+	keys := make([]string, 0, len(instanceMap))
+	for key := range instanceMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	instances := make([]*session.Instance, 0, len(keys))
+	for _, key := range keys {
+		instances = append(instances, instanceMap[key])
+	}
+	return instances
 }
 
 // LaunchDaemon launches the daemon process.

--- a/session/storage.go
+++ b/session/storage.go
@@ -77,28 +77,16 @@ func NewStorage(state config.InstanceStorage, repoID string) (*Storage, error) {
 // persists Loading instances to disk so refreshExternalInstances won't
 // remove them during the Loading→Running transition.
 func (s *Storage) SaveInstances(instances []*Instance) error {
+	if s.repoID != "" {
+		return s.saveRepoInstances(instances)
+	}
+
 	// Convert instances to InstanceData
 	data := make([]InstanceData, 0)
 	for _, instance := range instances {
-		if instance.Started() || instance.Status == Loading {
+		if instance.Started() || instance.GetStatus() == Loading {
 			data = append(data, instance.ToInstanceData())
 		}
-	}
-
-	if s.repoID != "" {
-		// TUI mode: the sidebar is the source of truth; external instances
-		// are already pulled in by the periodic refreshExternalInstances tick.
-		path, pathErr := config.RepoInstancesPath(s.repoID)
-		if pathErr != nil {
-			return pathErr
-		}
-		return config.WithFileLock(path, func() error {
-			jsonData, err := json.Marshal(data)
-			if err != nil {
-				return fmt.Errorf("failed to marshal instances: %w", err)
-			}
-			return s.state.SaveInstances(s.repoID, jsonData)
-		})
 	}
 
 	// Daemon mode: group in-memory instances by repo.
@@ -194,6 +182,67 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 	// naturally preserved (we never write to them).
 
 	return nil
+}
+
+func (s *Storage) saveRepoInstances(instances []*Instance) error {
+	path, pathErr := config.RepoInstancesPath(s.repoID)
+	if pathErr != nil {
+		return pathErr
+	}
+	return config.WithFileLock(path, func() error {
+		raw := s.state.GetInstances(s.repoID)
+		var diskData []InstanceData
+		if raw != nil && string(raw) != "[]" && string(raw) != "null" {
+			if err := json.Unmarshal(raw, &diskData); err != nil {
+				return fmt.Errorf("failed to parse existing instances for repo %s: %w", s.repoID, err)
+			}
+		}
+
+		diskTitles := make(map[string]bool, len(diskData))
+		for _, disk := range diskData {
+			diskTitles[disk.Title] = true
+		}
+
+		data := make([]InstanceData, 0)
+		memTitles := make(map[string]bool)
+		for _, instance := range instances {
+			status := instance.GetStatus()
+			if status != Loading {
+				if !instance.Started() {
+					continue
+				}
+				// If another process deleted the disk record and the backing
+				// session is gone, don't resurrect it from stale TUI memory.
+				if !diskTitles[instance.Title] && !instance.TmuxAlive() {
+					continue
+				}
+			}
+			d := instance.ToInstanceData()
+			data = append(data, d)
+			memTitles[d.Title] = true
+		}
+
+		merged := make([]InstanceData, 0, len(data)+len(diskData))
+		merged = append(merged, data...)
+		for _, disk := range diskData {
+			if memTitles[disk.Title] {
+				continue
+			}
+			// Disk-only Loading entries are stale pre-save records from a TUI
+			// start that never completed. External CLI/task creates are only
+			// persisted after startup succeeds, so they arrive as non-Loading.
+			if disk.Status == Loading {
+				continue
+			}
+			merged = append(merged, disk)
+		}
+
+		jsonData, err := json.Marshal(merged)
+		if err != nil {
+			return fmt.Errorf("failed to marshal instances: %w", err)
+		}
+		return s.state.SaveInstances(s.repoID, jsonData)
+	})
 }
 
 // LoadInstances loads the list of instances from disk.

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -298,6 +298,51 @@ func TestDaemonSaveNoInstances(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRepoSavePreservesDiskOnlyInstances(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	repoID := config.RepoIDFromRoot(repoPath)
+	ms := newMockStorage()
+
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "loaded-in-tui", Path: repoPath, Status: Running, Branch: "old"},
+		{Title: "created-by-cli", Path: repoPath, Status: Running},
+	})
+
+	tuiInstance := makeInstance("loaded-in-tui", repoPath, true)
+	tuiInstance.Branch = "new"
+	storage, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{tuiInstance})
+	require.NoError(t, err)
+
+	result := readDisk(t, ms, repoPath)
+	byTitle := make(map[string]InstanceData)
+	for _, d := range result {
+		byTitle[d.Title] = d
+	}
+	assert.Equal(t, "new", byTitle["loaded-in-tui"].Branch, "in-memory TUI instance should update its disk record")
+	assert.Contains(t, byTitle, "created-by-cli", "disk-only CLI/task instance must not be overwritten by TUI saves")
+}
+
+func TestRepoSaveDoesNotResurrectDeadDiskMissingInstance(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	repoID := config.RepoIDFromRoot(repoPath)
+	ms := newMockStorage()
+
+	// This looks started in memory but has no tmux session, which is the
+	// shape left behind if another process already killed and deleted it.
+	stale := makeInstance("stale", repoPath, true)
+	storage, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{stale})
+	require.NoError(t, err)
+
+	result := readDisk(t, ms, repoPath)
+	assert.Empty(t, result, "stale TUI memory must not recreate a deleted instance record")
+}
+
 // TestCollectRepoRoots verifies that Storage.CollectRepoRoots returns the
 // unique set of repo roots from stored instances across ALL repos. This
 // underpins the fix for #265 (af reset must clean worktrees in every repo

--- a/task/runner.go
+++ b/task/runner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 const pendingInstancesFileName = "pending_instances.json"
@@ -181,9 +182,15 @@ func RunTask(taskID string) error {
 
 	cfg := config.LoadConfig()
 
-	title := t.Name
-	if title == "" {
-		title = fmt.Sprintf("task-%s", t.ID)
+	baseTitle := TaskRunBaseTitle(*t)
+
+	repo, err := config.RepoFromPath(t.ProjectPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve repo for project path %s: %w", t.ProjectPath, err)
+	}
+	title, err := NextTaskRunTitle(repo.ID, t.ProjectPath, baseTitle, t.Program)
+	if err != nil {
+		return fmt.Errorf("failed to allocate task run title: %w", err)
 	}
 
 	instance, err := session.NewInstance(session.InstanceOptions{
@@ -220,10 +227,6 @@ func RunTask(taskID string) error {
 	// file lock. This is the source of truth the daemon reads via
 	// storage.LoadInstances; without this write, the daemon never sees
 	// scheduled tasks and AutoYes runs hang. Mirrors api/sessions.go.
-	repo, err := config.RepoFromPath(t.ProjectPath)
-	if err != nil {
-		return fmt.Errorf("failed to resolve repo for project path %s: %w", t.ProjectPath, err)
-	}
 	data := instance.ToInstanceData()
 	if err := config.UpdateRepoInstances(repo.ID, appendTaskRunnerInstanceFn(data)); err != nil {
 		return fmt.Errorf("failed to save instance to per-repo storage: %w", err)
@@ -274,4 +277,61 @@ func appendTaskRunnerInstanceFn(data session.InstanceData) func(json.RawMessage)
 		existing = append(existing, data)
 		return json.MarshalIndent(existing, "", "  ")
 	}
+}
+
+// TaskRunBaseTitle returns the preferred title for a task-created session.
+func TaskRunBaseTitle(t Task) string {
+	if t.Name != "" {
+		return t.Name
+	}
+	return fmt.Sprintf("task-%s", t.ID)
+}
+
+// NextTaskRunTitle chooses a repo-scoped title for a task run that will not
+// collide with persisted sessions or an already-live tmux session. Recurring
+// tasks can fire while a previous run is still around, so task sessions cannot
+// use the static task name blindly.
+func NextTaskRunTitle(repoID, repoPath, baseTitle, program string) (string, error) {
+	path, err := config.RepoInstancesPath(repoID)
+	if err != nil {
+		return "", err
+	}
+
+	var title string
+	if err := config.WithFileLock(path, func() error {
+		raw, err := config.LoadRepoInstances(repoID)
+		if err != nil {
+			return err
+		}
+
+		var existing []session.InstanceData
+		if err := json.Unmarshal(raw, &existing); err != nil {
+			return fmt.Errorf("failed to parse existing instances: %w", err)
+		}
+
+		used := make(map[string]bool, len(existing))
+		for _, data := range existing {
+			used[data.Title] = true
+		}
+
+		for i := 1; i <= 10000; i++ {
+			candidate := baseTitle
+			if i > 1 {
+				candidate = fmt.Sprintf("%s-%d", baseTitle, i)
+			}
+			if used[candidate] {
+				continue
+			}
+			if tmux.NewTmuxSessionForRepo(candidate, repoPath, program).DoesSessionExist() {
+				continue
+			}
+			title = candidate
+			return nil
+		}
+		return fmt.Errorf("could not find an available title for %q", baseTitle)
+	}); err != nil {
+		return "", err
+	}
+
+	return title, nil
 }

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -315,3 +315,44 @@ func TestRunTask_RejectsDuplicateTitleInPerRepoStorage(t *testing.T) {
 		t.Fatalf("duplicate append should preserve original storage, got %+v", got)
 	}
 }
+
+func TestNextTaskRunTitleSkipsPersistedTitles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoID := "test-repo-title"
+	instancesPath, err := config.RepoInstancesPath(repoID)
+	if err != nil {
+		t.Fatalf("RepoInstancesPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(instancesPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	preexisting := []session.InstanceData{
+		{Title: "nightly"},
+		{Title: "nightly-2"},
+	}
+	preRaw, err := json.MarshalIndent(preexisting, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal preexisting: %v", err)
+	}
+	if err := os.WriteFile(instancesPath, preRaw, 0644); err != nil {
+		t.Fatalf("write preexisting: %v", err)
+	}
+
+	title, err := NextTaskRunTitle(repoID, "/tmp/repo", "nightly", "claude")
+	if err != nil {
+		t.Fatalf("NextTaskRunTitle: %v", err)
+	}
+	if title != "nightly-3" {
+		t.Fatalf("expected nightly-3, got %q", title)
+	}
+}
+
+func TestTaskRunBaseTitleFallsBackToTaskID(t *testing.T) {
+	got := TaskRunBaseTitle(Task{ID: "abc123"})
+	if got != "task-abc123" {
+		t.Fatalf("unexpected fallback title: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- make repo-scoped TUI saves merge with on-disk session records instead of treating sidebar memory as canonical
- have scheduled/manual task runs allocate collision-free run titles so leftover task sessions do not break later triggers
- make pending-instance merges upsert by title under the per-repo file lock
- refresh daemon instances from persisted storage while the daemon is running so newly persisted task/CLI sessions are picked up without relying on a restart

## Daemon boundary
This stops short of a full daemon RPC/control-plane rewrite, but moves the important source-of-truth behavior in that direction: the daemon now reconciles from durable storage continuously, while clients use merge-preserving locked writes instead of overwriting the world from local memory. A full always-on daemon coordinator with create/kill RPCs is still the right larger follow-up, but it needs a dedicated socket/API lifecycle rather than a hidden storage refactor.

## Testing
- `git diff --check`
- `go test ./...`
- `go test -race ./...`

Fixes #432.
Fixes #409.