### PR TITLE
Fix remote hook session import and identity

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -168,6 +168,8 @@ func newHome(ctx context.Context, program string, autoYes bool, repoID string) *
 		instance.AutoYes = autoYes
 	}
 
+	h.importRemoteHookSessions()
+
 	// Merge pending instances from task runs.
 	h.mergePendingInstances()
 

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -39,6 +39,29 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(instance.Title) == 0 {
 			return m, m.handleError(fmt.Errorf("title cannot be empty"))
 		}
+		for _, other := range m.sidebar.GetInstances() {
+			if other == instance {
+				continue
+			}
+			if other.Title == instance.Title {
+				return m, m.handleError(fmt.Errorf("a session titled %q already exists", instance.Title))
+			}
+		}
+		if instance.IsRemote() {
+			existing := make([]*session.Instance, 0, m.sidebar.NumInstances())
+			for _, other := range m.sidebar.GetInstances() {
+				if other == instance || !other.IsRemote() {
+					continue
+				}
+				existing = append(existing, other)
+			}
+			if dup := session.FindSlugCollision(instance.Title, existing); dup != "" {
+				return m, m.handleError(fmt.Errorf(
+					"a remote session titled %q already maps to hook name %q",
+					dup, session.Slugify(instance.Title),
+				))
+			}
+		}
 
 		// Apply the program selected during naming
 		instance.Program = m.pendingProgram

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -80,3 +80,70 @@ func TestHandleMenuHighlightingDoesNotInterceptNamingText(t *testing.T) {
 	assert.False(t, returnEarly)
 	assert.Nil(t, cmd)
 }
+
+func TestHandleStateNewRejectsDuplicateTitle(t *testing.T) {
+	h := newTestHome(t)
+	h.state = stateNew
+	h.errBox.SetSize(120, 1)
+
+	existing, err := session.NewInstance(session.InstanceOptions{
+		Title:   "fix-bug",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	h.sidebar.AddInstance(existing)
+
+	naming, err := session.NewInstance(session.InstanceOptions{
+		Title:   "fix-bug",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	h.namingInstance = naming
+
+	_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, stateNew, h.state)
+	require.NotNil(t, h.namingInstance)
+	assert.Contains(t, h.errBox.String(), "fix-bug")
+}
+
+func TestHandleStateNewRejectsRemoteSlugCollision(t *testing.T) {
+	h := newTestHome(t)
+	h.state = stateNew
+	h.errBox.SetSize(120, 1)
+
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, _ string) (session.Backend, error) {
+		if opts.ForceRemote {
+			return &session.HookBackend{Hooks: config.RemoteHooks{}}, nil
+		}
+		return &session.LocalBackend{}, nil
+	})
+	defer restore()
+
+	existing, err := session.NewInstance(session.InstanceOptions{
+		Title:       "myapp",
+		Path:        t.TempDir(),
+		Program:     "claude",
+		ForceRemote: true,
+	})
+	require.NoError(t, err)
+	h.sidebar.AddInstance(existing)
+
+	naming, err := session.NewInstance(session.InstanceOptions{
+		Title:       "my_app",
+		Path:        t.TempDir(),
+		Program:     "claude",
+		ForceRemote: true,
+	})
+	require.NoError(t, err)
+	h.namingInstance = naming
+
+	_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, stateNew, h.state)
+	require.NotNil(t, h.namingInstance)
+	assert.Equal(t, "my_app", h.namingInstance.Title)
+	assert.Contains(t, h.errBox.String(), "myapp")
+}

--- a/app/sync.go
+++ b/app/sync.go
@@ -293,3 +293,62 @@ func upsertInstanceDataByTitle(existing, incoming []session.InstanceData) []sess
 	}
 	return existing
 }
+
+func (m *home) importRemoteHookSessions() int {
+	repoCfg, err := config.LoadRepoConfig(m.repoID)
+	if err != nil {
+		log.WarningLog.Printf("failed to load repo config for remote import: %v", err)
+		return 0
+	}
+	if repoCfg.RemoteHooks == nil || repoCfg.RemoteHooks.ListCmd == "" {
+		return 0
+	}
+
+	repo, err := config.CurrentRepo()
+	if err != nil {
+		log.WarningLog.Printf("failed to resolve repo for remote import: %v", err)
+		return 0
+	}
+
+	listed, err := session.ListRemoteHookInstanceData(repo.Root, *repoCfg.RemoteHooks, time.Now())
+	if err != nil {
+		log.WarningLog.Printf("failed to list remote hook sessions: %v", err)
+		return 0
+	}
+
+	existingTitles := m.sidebar.GetInstanceTitles()
+	existingHookNames := make(map[string]bool)
+	for _, inst := range m.sidebar.GetInstances() {
+		if !inst.IsRemote() {
+			continue
+		}
+		data := inst.ToInstanceData()
+		existingHookNames[session.RemoteHookName(data.Title, data.RemoteMeta)] = true
+	}
+
+	imported := 0
+	for _, data := range listed {
+		name := session.RemoteHookName(data.Title, data.RemoteMeta)
+		if existingTitles[data.Title] || existingHookNames[name] {
+			continue
+		}
+
+		inst, err := session.FromInstanceData(data)
+		if err != nil {
+			log.WarningLog.Printf("failed to import remote hook session %q: %v", data.Title, err)
+			continue
+		}
+		m.sidebar.AddInstance(inst)()
+		inst.AutoYes = m.autoYes
+		existingTitles[data.Title] = true
+		existingHookNames[name] = true
+		imported++
+	}
+
+	if imported > 0 {
+		if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
+			log.WarningLog.Printf("failed to save imported remote sessions: %v", err)
+		}
+	}
+	return imported
+}

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -1,9 +1,14 @@
 package app
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
 )
 
 // TestPendingInstanceCollisionShouldSkip covers the decision logic used by
@@ -171,4 +176,53 @@ func TestUpsertInstanceDataByTitleReplacesDuplicates(t *testing.T) {
 	if byTitle["add"].Worktree.WorktreePath != "/add" {
 		t.Fatalf("expected new entry to be appended, got %+v", byTitle["add"])
 	}
+}
+
+func TestImportRemoteHookSessionsAddsListCmdSessions(t *testing.T) {
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+	h.storage, err = session.NewStorage(config.DefaultState(), repo.ID)
+	require.NoError(t, err)
+
+	scriptDir := t.TempDir()
+	write := func(name, body string) string {
+		t.Helper()
+		path := filepath.Join(scriptDir, name)
+		require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0755))
+		return path
+	}
+
+	listCmd := write("list.sh", `echo '[{"name": "remote-one", "status": "running", "host": "h1"}, {"name": "remote-two", "status": "stopped"}]'`)
+	attachCmd := write("attach.sh", `echo "attached $1"`)
+	noopCmd := write("noop.sh", `echo '{"ok": true}'`)
+	require.NoError(t, config.SaveRepoConfig(repo.ID, &config.RepoConfig{
+		RemoteHooks: &config.RemoteHooks{
+			LaunchCmd: noopCmd,
+			ListCmd:   listCmd,
+			AttachCmd: attachCmd,
+			DeleteCmd: noopCmd,
+		},
+	}))
+
+	imported := h.importRemoteHookSessions()
+	require.Equal(t, 1, imported)
+	require.Equal(t, 1, h.sidebar.NumInstances())
+
+	inst := h.sidebar.GetInstances()[0]
+	require.True(t, inst.IsRemote())
+	require.Equal(t, "remote-one", inst.Title)
+
+	stored, err := config.LoadRepoInstances(repo.ID)
+	require.NoError(t, err)
+	var data []session.InstanceData
+	require.NoError(t, json.Unmarshal(stored, &data))
+	require.Len(t, data, 1)
+	require.Equal(t, "remote-one", data[0].Title)
+	require.Equal(t, "remote-one", data[0].RemoteMeta["name"])
+	require.Equal(t, "h1", data[0].RemoteMeta["host"])
 }

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -27,6 +27,22 @@ All scripts must:
 - Write progress/log messages to **stderr**
 - Accept the flags documented below
 
+### Session Names
+
+The `<name>` value passed to hooks is a slug derived from the session title:
+
+1. lowercase the title
+2. replace spaces with `-`
+3. drop every character that is not `[a-z0-9-]`
+4. trim leading/trailing `-`
+5. if empty, use `session`
+
+Examples: `"Fix Auth Bug"` becomes `fix-auth-bug`, `"my_app"` becomes `myapp`, and `"af-test"` stays `af-test`.
+
+This slug is the stable remote identity. Agent Factory passes it to `launch_cmd --name`, expects `list_cmd` to report it as `name`, passes it to `delete_cmd --name`, and passes it as the positional argument to `attach_cmd`. There is no hidden hash suffix.
+
+When Agent Factory imports an existing remote session from `list_cmd`, the reported `name` is stored in `remote_meta.name` and remains authoritative even if the display title differs.
+
 ### `launch_cmd`
 
 Starts a new remote agent session.
@@ -76,7 +92,9 @@ Gives interactive terminal access to a running session (e.g., SSH + tmux attach)
 
 **No JSON output** — this command takes over the terminal. It should behave like `ssh -t host "tmux attach"`.
 
-Agent Factory also uses this script for the preview pane by running it in a background PTY and capturing its output.
+Agent Factory runs this command behind a local PTY and intercepts the configured detach key before forwarding input to the hook process. On detach, Agent Factory terminates the local `attach_cmd` process; remote tmux sessions should survive the client disconnect and be attachable again later.
+
+Agent Factory also uses this script for the preview pane by running it in a background process and capturing its output.
 
 ## Example
 

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -1,10 +1,9 @@
 package session
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -14,6 +13,9 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/creack/pty"
 )
 
 // HookBackend implements Backend by delegating to user-provided shell scripts.
@@ -42,22 +44,62 @@ type hookPTY struct {
 
 var slugRegexp = regexp.MustCompile(`[^a-z0-9-]`)
 
-// slugify converts a title to a slug-safe string for hook scripts.
-// A short hash of the original title is appended to prevent collisions
-// when different titles (e.g. "my_app" vs "myapp") reduce to the same slug.
-func slugify(title string) string {
+// Slugify converts a title to a slug-safe string for hook scripts.
+// The slug is part of the public remote hook protocol documented in
+// docs/remote-hooks.md: launch_cmd, list_cmd, attach_cmd, and delete_cmd all
+// receive this value unless the instance was imported with an explicit
+// remote_meta.name.
+func Slugify(title string) string {
 	s := strings.ToLower(title)
 	s = strings.ReplaceAll(s, " ", "-")
 	s = slugRegexp.ReplaceAllString(s, "")
-	// Trim leading/trailing hyphens
 	s = strings.Trim(s, "-")
 	if s == "" {
 		s = "session"
 	}
+	return s
+}
 
-	// Append a short hash of the original title to guarantee uniqueness.
-	h := sha256.Sum256([]byte(title))
-	return s + "-" + hex.EncodeToString(h[:])[:8]
+// slugify is kept as an unexported alias for existing package-local call sites
+// and tests.
+func slugify(title string) string { return Slugify(title) }
+
+// RemoteHookName returns the hook-protocol name for a title and persisted
+// remote metadata. Imported remote sessions can carry their authoritative
+// list_cmd name in remote_meta.name; TUI-created sessions derive it from the
+// title.
+func RemoteHookName(title string, meta map[string]interface{}) string {
+	if name, ok := meta["name"].(string); ok && name != "" {
+		return name
+	}
+	return Slugify(title)
+}
+
+// FindSlugCollision returns the title of the first existing remote instance
+// whose hook name collides with candidate, or "" if none do.
+func FindSlugCollision(candidate string, existing []*Instance) string {
+	if candidate == "" {
+		return ""
+	}
+	want := Slugify(candidate)
+	for _, inst := range existing {
+		if inst == nil || inst.Title == candidate {
+			continue
+		}
+		inst.mu.RLock()
+		name := RemoteHookName(inst.Title, inst.remoteMeta)
+		inst.mu.RUnlock()
+		if name == want {
+			return inst.Title
+		}
+	}
+	return ""
+}
+
+func hookNameForInstance(i *Instance) string {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return RemoteHookName(i.Title, i.remoteMeta)
 }
 
 func (b *HookBackend) Type() string { return "remote" }
@@ -77,7 +119,7 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 	}
 
 	// Launch a new remote session.
-	slug := slugify(i.Title)
+	slug := Slugify(i.Title)
 	args := []string{"--name", slug, "--json"}
 	cmd := exec.Command(b.Hooks.LaunchCmd, args...)
 	out, err := cmd.CombinedOutput()
@@ -136,7 +178,7 @@ func (b *HookBackend) Kill(i *Instance) error {
 
 	b.closePTY(i.Title)
 
-	slug := slugify(i.Title)
+	slug := hookNameForInstance(i)
 	args := []string{"--name", slug, "--json"}
 	out, err := exec.Command(b.Hooks.DeleteCmd, args...).CombinedOutput()
 	if err != nil {
@@ -178,12 +220,9 @@ func (b *HookBackend) Attach(i *Instance) (chan struct{}, error) {
 		defer close(done)
 		defer b.ensurePTY(i) // restart preview process after detach
 
-		slug := slugify(i.Title)
+		slug := hookNameForInstance(i)
 		cmd := exec.Command(b.Hooks.AttachCmd, slug)
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
+		if err := runHookAttachWithDetach(cmd, os.Stdin, os.Stdout, os.Stderr); err != nil {
 			log.ErrorLog.Printf("attach_cmd error: %v", err)
 		}
 	}()
@@ -220,7 +259,7 @@ func (b *HookBackend) IsAlive(i *Instance) bool {
 	if err := json.Unmarshal(out, &sessions); err != nil {
 		return false
 	}
-	slug := slugify(i.Title)
+	slug := hookNameForInstance(i)
 	for _, s := range sessions {
 		name, _ := s["name"].(string)
 		status, _ := s["status"].(string)
@@ -236,6 +275,118 @@ func (b *HookBackend) CheckAndHandleTrustPrompt(_ *Instance) bool {
 }
 
 func (b *HookBackend) TapEnter(_ *Instance) {}
+
+// ListRemoteHookInstanceData converts running sessions reported by list_cmd
+// into persistable remote InstanceData records for the current repo.
+func ListRemoteHookInstanceData(repoPath string, hooks config.RemoteHooks, now time.Time) ([]InstanceData, error) {
+	if hooks.ListCmd == "" {
+		return nil, nil
+	}
+
+	out, err := exec.Command(hooks.ListCmd, "--json").Output()
+	if err != nil {
+		return nil, fmt.Errorf("list_cmd failed: %w", err)
+	}
+
+	var listed []map[string]interface{}
+	if err := json.Unmarshal(out, &listed); err != nil {
+		return nil, fmt.Errorf("list_cmd returned invalid JSON: %w", err)
+	}
+
+	imported := make([]InstanceData, 0, len(listed))
+	for _, meta := range listed {
+		name, _ := meta["name"].(string)
+		if name == "" {
+			continue
+		}
+		status, _ := meta["status"].(string)
+		if status != "running" {
+			continue
+		}
+
+		title := name
+		if displayTitle, _ := meta["title"].(string); displayTitle != "" {
+			title = displayTitle
+		}
+
+		imported = append(imported, InstanceData{
+			Title:       title,
+			Path:        repoPath,
+			Branch:      name,
+			Status:      Running,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+			BackendType: "remote",
+			RemoteMeta:  meta,
+		})
+	}
+	return imported, nil
+}
+
+func runHookAttachWithDetach(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.Writer) error {
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return err
+	}
+	defer ptmx.Close()
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- cmd.Wait()
+	}()
+
+	copyDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(stdout, ptmx)
+		close(copyDone)
+	}()
+
+	detached := make(chan struct{})
+	var detachOnce sync.Once
+	detach := func() {
+		detachOnce.Do(func() {
+			close(detached)
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			_ = ptmx.Close()
+		})
+	}
+
+	go func() {
+		buf := make([]byte, 32)
+		for {
+			n, err := stdin.Read(buf)
+			if n > 0 {
+				if n == 1 && buf[0] == tmux.DetachKeyByte {
+					detach()
+					return
+				}
+				if _, writeErr := ptmx.Write(buf[:n]); writeErr != nil {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	err = <-waitDone
+	_ = ptmx.Close()
+	<-copyDone
+
+	select {
+	case <-detached:
+		return nil
+	default:
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "remote attach exited: %v\n", err)
+		return err
+	}
+	return nil
+}
 
 // --- Process management for preview capture ---
 
@@ -259,7 +410,7 @@ func (b *HookBackend) ensurePTY(i *Instance) {
 		delete(b.ptys, i.Title)
 	}
 
-	slug := slugify(i.Title)
+	slug := hookNameForInstance(i)
 	cmd := exec.Command(b.Hooks.AttachCmd, slug)
 
 	// Use pipes instead of a PTY. The attach_cmd for preview doesn't need

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -802,20 +803,21 @@ func TestHookBackendIsAliveWithMultipleSessions(t *testing.T) {
 	assert.True(t, b.IsAlive(iB))
 }
 
-// --- slugify uniqueness ---
+// --- slugify shape ---
 
-func TestSlugifyUniqueness(t *testing.T) {
-	// Titles that reduce to the same base slug must produce distinct slugified names.
-	pairs := [][2]string{
-		{"my_app", "myapp"},
-		{"My App!", "my-app"},
-		{"hello world", "hello-world"},
-		{"HELLO", "hello"},
+func TestSlugifyNoHashSuffix(t *testing.T) {
+	cases := map[string]string{
+		"hello":             "hello",
+		"Hello World":       "hello-world",
+		"My App!":           "my-app",
+		"  spaced  ":        "spaced",
+		"CAPS":              "caps",
+		"already-a-slug":    "already-a-slug",
+		"af-test":           "af-test",
+		"some/name:thing@1": "somenamething1",
 	}
-	for _, p := range pairs {
-		a := slugify(p[0])
-		b := slugify(p[1])
-		assert.NotEqual(t, a, b, "slugify(%q) == slugify(%q) == %q", p[0], p[1], a)
+	for title, want := range cases {
+		assert.Equal(t, want, slugify(title), "slugify(%q)", title)
 	}
 }
 
@@ -829,5 +831,75 @@ func TestSlugifyNonEmpty(t *testing.T) {
 	for _, title := range []string{"!!!", "   ", ""} {
 		s := slugify(title)
 		assert.NotEmpty(t, s, "slugify(%q) should not be empty", title)
+	}
+}
+
+func TestSlugifyCollisionsReduce(t *testing.T) {
+	collisions := [][2]string{
+		{"my_app", "myapp"},
+		{"My App!", "my-app"},
+		{"HELLO", "hello"},
+	}
+	for _, p := range collisions {
+		assert.Equal(t, slugify(p[0]), slugify(p[1]))
+	}
+}
+
+func TestFindSlugCollision(t *testing.T) {
+	mk := func(title string) *Instance { return &Instance{Title: title} }
+	existing := []*Instance{mk("myapp"), mk("other"), nil}
+
+	assert.Equal(t, "myapp", FindSlugCollision("my_app", existing))
+	assert.Equal(t, "myapp", FindSlugCollision("MyApp", existing))
+	assert.Equal(t, "", FindSlugCollision("fresh-title", existing))
+	assert.Equal(t, "", FindSlugCollision("myapp", existing))
+	assert.Equal(t, "", FindSlugCollision("", existing))
+}
+
+func TestRemoteHookNamePrefersRemoteMetaName(t *testing.T) {
+	assert.Equal(t, "box-af-test", RemoteHookName("af-test", map[string]interface{}{"name": "box-af-test"}))
+	assert.Equal(t, "af-test", RemoteHookName("af-test", nil))
+}
+
+func TestListRemoteHookInstanceDataImportsRunningSessions(t *testing.T) {
+	dir := t.TempDir()
+	listCmd := writeScript(t, dir, "list.sh",
+		`echo '[{"name": "remote-one", "status": "running", "host": "h1"}, {"name": "remote-two", "status": "stopped"}]'`)
+
+	now := time.Now()
+	data, err := ListRemoteHookInstanceData("/repo/root", config.RemoteHooks{ListCmd: listCmd}, now)
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+	assert.Equal(t, "remote-one", data[0].Title)
+	assert.Equal(t, "/repo/root", data[0].Path)
+	assert.Equal(t, "remote-one", data[0].Branch)
+	assert.Equal(t, Running, data[0].Status)
+	assert.Equal(t, "remote", data[0].BackendType)
+	assert.Equal(t, "remote-one", data[0].RemoteMeta["name"])
+	assert.Equal(t, "h1", data[0].RemoteMeta["host"])
+}
+
+func TestRunHookAttachWithDetachKey(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		cmd := exec.Command("sh", "-c", "sleep 10")
+		done <- runHookAttachWithDetach(cmd, stdinR, io.Discard, io.Discard)
+	}()
+
+	_, err := stdinW.Write([]byte{tmux.DetachKeyByte})
+	require.NoError(t, err)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("remote attach did not exit after detach key")
 	}
 }


### PR DESCRIPTION
## Summary
- remove the hidden hash suffix from remote hook names and document the slug rules
- prefer `remote_meta.name` for imported/adopted remote sessions so hook names round-trip through `list_cmd`
- import running remote sessions from `list_cmd` on TUI startup
- reject duplicate titles and remote slug collisions before starting a new session
- run remote `attach_cmd` behind a local PTY and intercept the configured detach key

## PR Review Notes
- Supersedes stale/conflicting #340 with the still-relevant #312 fix on top of current master.
- #431 was reviewed as a good external patch, but #317 had already been fixed in #433, so it was closed as redundant rather than merged.

## Testing
- `git diff --check`
- `go test ./...`
- `go test -race ./...`

Fixes #309.
Fixes #312.
Fixes #313.