### PR TITLE
Route session mutations through daemon control plane

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
-	"github.com/sachiniyer/agent-factory/task"
 
 	"github.com/spf13/cobra"
 )
@@ -22,6 +21,12 @@ var SessionsCmd = &cobra.Command{
 	Use:   "sessions",
 	Short: "Manage sessions",
 }
+
+var (
+	createSessionViaDaemon = daemon.CreateSession
+	killSessionViaDaemon   = daemon.KillSession
+	sendPromptViaDaemon    = daemon.SendPrompt
+)
 
 var sessionsListCmd = &cobra.Command{
 	Use:   "list",
@@ -120,34 +125,16 @@ var sessionsCreateCmd = &cobra.Command{
 			program = config.LoadConfig().DefaultProgram
 		}
 
-		instance, err := session.NewInstance(session.InstanceOptions{
-			Title:   createNameFlag,
-			Path:    repo.Root,
-			Program: program,
+		cfg := config.LoadConfig()
+		data, err := createSessionViaDaemon(daemon.CreateSessionRequest{
+			Title:    createNameFlag,
+			RepoPath: repo.Root,
+			Program:  program,
+			Prompt:   createPromptFlag,
+			AutoYes:  cfg.AutoYes,
 		})
 		if err != nil {
-			return jsonError(fmt.Errorf("failed to create instance: %w", err))
-		}
-
-		if err := task.StartAndSendPrompt(instance, createPromptFlag); err != nil {
-			instance.Kill() // Clean up tmux session and git worktree
-			return jsonError(fmt.Errorf("failed to start instance: %w", err))
-		}
-		instance.SetStatus(session.Running)
-
-		// Save to per-repo storage under file lock
-		data := instance.ToInstanceData()
-		if err := config.UpdateRepoInstances(repo.ID, appendInstanceFn(data)); err != nil {
-			instance.Kill()
 			return jsonError(err)
-		}
-
-		// Launch daemon for autoyes if configured
-		cfg := config.LoadConfig()
-		if cfg.AutoYes {
-			if err := daemon.LaunchDaemon(); err != nil {
-				log.ErrorLog.Printf("failed to launch daemon: %v", err)
-			}
 		}
 
 		return jsonOut(data)
@@ -182,6 +169,61 @@ func appendInstanceFn(data session.InstanceData) func(json.RawMessage) (json.Raw
 	}
 }
 
+func killSessionDirect(title string) error {
+	instance, repoID, err := findLiveInstanceByTitle(title)
+	if err != nil {
+		data, ghostRepoID, lookupErr := findInstanceByTitle(title)
+		if lookupErr != nil {
+			return err
+		}
+
+		if data.Worktree.RepoPath != "" && data.Worktree.WorktreePath != "" && !data.Worktree.ExternalWorktree {
+			branchCreatedByUs := true
+			if data.Worktree.BranchCreatedByUs != nil {
+				branchCreatedByUs = *data.Worktree.BranchCreatedByUs
+			}
+			gw, gwErr := git.NewGitWorktreeFromStorage(
+				data.Worktree.RepoPath,
+				data.Worktree.WorktreePath,
+				data.Worktree.SessionName,
+				data.Worktree.BranchName,
+				data.Worktree.BaseCommitSHA,
+				data.Worktree.ExternalWorktree,
+				branchCreatedByUs,
+			)
+			if gwErr != nil {
+				log.WarningLog.Printf("ghost session %q: failed to load worktree for cleanup: %v", title, gwErr)
+			} else if cleanupErr := gw.Cleanup(); cleanupErr != nil {
+				log.WarningLog.Printf("ghost session %q: worktree cleanup failed: %v", title, cleanupErr)
+			}
+		}
+
+		state := config.LoadState()
+		storage, storageErr := session.NewStorage(state, ghostRepoID)
+		if storageErr != nil {
+			return storageErr
+		}
+		if delErr := storage.DeleteInstance(title); delErr != nil {
+			return fmt.Errorf("failed to delete instance from storage: %w", delErr)
+		}
+		return nil
+	}
+
+	if err := instance.Kill(); err != nil {
+		return fmt.Errorf("failed to kill instance: %w", err)
+	}
+
+	state := config.LoadState()
+	storage, err := session.NewStorage(state, repoID)
+	if err != nil {
+		return err
+	}
+	if err := storage.DeleteInstance(title); err != nil {
+		log.ErrorLog.Printf("failed to delete instance from storage: %v", err)
+	}
+	return nil
+}
+
 var (
 	sendPromptCreateFlag  bool
 	sendPromptProgramFlag string
@@ -202,7 +244,7 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 		title := args[0]
 		prompt := args[1]
 
-		instance, _, err := findLiveInstanceByTitle(title)
+		_, _, err := findLiveInstanceByTitle(title)
 		if err != nil {
 			if !sendPromptCreateFlag {
 				return jsonError(fmt.Errorf("instance %q not found. Use --create to auto-create the session, or run: af sessions create --name %q --prompt <prompt>", title, title))
@@ -231,39 +273,22 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 				program = config.LoadConfig().DefaultProgram
 			}
 
-			instance, err = session.NewInstance(session.InstanceOptions{
-				Title:   title,
-				Path:    repo.Root,
-				Program: program,
+			cfg := config.LoadConfig()
+			_, err = createSessionViaDaemon(daemon.CreateSessionRequest{
+				Title:    title,
+				RepoPath: repo.Root,
+				Program:  program,
+				Prompt:   prompt,
+				AutoYes:  cfg.AutoYes,
 			})
 			if err != nil {
-				return jsonError(fmt.Errorf("failed to create instance: %w", err))
-			}
-
-			if err := task.StartAndSendPrompt(instance, ""); err != nil {
-				instance.Kill() // Clean up tmux session and git worktree
-				return jsonError(fmt.Errorf("failed to start instance: %w", err))
-			}
-			instance.SetStatus(session.Running)
-
-			// Save to per-repo storage under file lock
-			data := instance.ToInstanceData()
-			if err := config.UpdateRepoInstances(repo.ID, appendInstanceFn(data)); err != nil {
-				instance.Kill()
 				return jsonError(err)
 			}
-
-			// Launch daemon for autoyes if configured
-			cfg := config.LoadConfig()
-			if cfg.AutoYes {
-				if err := daemon.LaunchDaemon(); err != nil {
-					log.ErrorLog.Printf("failed to launch daemon: %v", err)
-				}
-			}
+			return jsonOut(map[string]bool{"ok": true})
 		}
 
-		if err := instance.SendPromptCommand(prompt); err != nil {
-			return jsonError(fmt.Errorf("failed to send prompt: %w", err))
+		if err := sendPromptViaDaemon(daemon.SendPromptRequest{Title: title, Prompt: prompt}); err != nil {
+			return jsonError(err)
 		}
 		return jsonOut(map[string]bool{"ok": true})
 	},
@@ -301,66 +326,8 @@ var sessionsKillCmd = &cobra.Command{
 		log.Initialize(false)
 		defer log.Close()
 
-		instance, repoID, err := findLiveInstanceByTitle(args[0])
-		if err != nil {
-			// The live instance could not be restored (e.g. the tmux
-			// session was destroyed externally). Fall back to a raw
-			// InstanceData lookup so we can still clean up the stored
-			// metadata for these "ghost" sessions. Without this, users
-			// can see the entry via `af sessions list` but have no way
-			// to delete it short of the destructive `af reset`.
-			data, ghostRepoID, lookupErr := findInstanceByTitle(args[0])
-			if lookupErr != nil {
-				// No metadata either — surface the original restore error.
-				return jsonError(err)
-			}
-
-			// Best-effort worktree cleanup since instance.Kill() can't run.
-			if data.Worktree.RepoPath != "" && data.Worktree.WorktreePath != "" && !data.Worktree.ExternalWorktree {
-				branchCreatedByUs := true
-				if data.Worktree.BranchCreatedByUs != nil {
-					branchCreatedByUs = *data.Worktree.BranchCreatedByUs
-				}
-				gw, gwErr := git.NewGitWorktreeFromStorage(
-					data.Worktree.RepoPath,
-					data.Worktree.WorktreePath,
-					data.Worktree.SessionName,
-					data.Worktree.BranchName,
-					data.Worktree.BaseCommitSHA,
-					data.Worktree.ExternalWorktree,
-					branchCreatedByUs,
-				)
-				if gwErr != nil {
-					log.WarningLog.Printf("ghost session %q: failed to load worktree for cleanup: %v", args[0], gwErr)
-				} else if cleanupErr := gw.Cleanup(); cleanupErr != nil {
-					log.WarningLog.Printf("ghost session %q: worktree cleanup failed: %v", args[0], cleanupErr)
-				}
-			}
-
-			state := config.LoadState()
-			storage, storageErr := session.NewStorage(state, ghostRepoID)
-			if storageErr != nil {
-				return jsonError(storageErr)
-			}
-			if delErr := storage.DeleteInstance(args[0]); delErr != nil {
-				return jsonError(fmt.Errorf("failed to delete instance from storage: %w", delErr))
-			}
-			return jsonOut(map[string]bool{"ok": true})
-		}
-
-		if err := instance.Kill(); err != nil {
-			return jsonError(fmt.Errorf("failed to kill instance: %w", err))
-		}
-
-		// Remove from storage
-		state := config.LoadState()
-		storage, err := session.NewStorage(state, repoID)
-		if err != nil {
+		if err := killSessionViaDaemon(daemon.KillSessionRequest{Title: args[0]}); err != nil {
 			return jsonError(err)
-		}
-		if err := storage.DeleteInstance(args[0]); err != nil {
-			// Not fatal - instance is already killed
-			log.ErrorLog.Printf("failed to delete instance from storage: %v", err)
 		}
 
 		return jsonOut(map[string]bool{"ok": true})

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -226,6 +227,8 @@ func TestSessionsKill_GhostSessionDeleted(t *testing.T) {
 	}
 
 	// Run the kill command. Suppress stdout/stderr noise from jsonOut/jsonError.
+	restoreKill := stubKillSessionDirect()
+	defer restoreKill()
 	devnull, err := os.Open(os.DevNull)
 	if err != nil {
 		t.Fatalf("open devnull: %v", err)
@@ -266,6 +269,8 @@ func TestSessionsKill_GhostSessionDeleted(t *testing.T) {
 func TestSessionsKill_UnknownTitle(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", tmp)
+	restoreKill := stubKillSessionDirect()
+	defer restoreKill()
 
 	devnull, err := os.Open(os.DevNull)
 	if err != nil {
@@ -283,4 +288,12 @@ func TestSessionsKill_UnknownTitle(t *testing.T) {
 	if err := sessionsKillCmd.RunE(sessionsKillCmd, []string{"does-not-exist"}); err == nil {
 		t.Fatalf("expected error for unknown session, got nil")
 	}
+}
+
+func stubKillSessionDirect() func() {
+	prev := killSessionViaDaemon
+	killSessionViaDaemon = func(req daemon.KillSessionRequest) error {
+		return killSessionDirect(req.Title)
+	}
+	return func() { killSessionViaDaemon = prev }
 }

--- a/app/app.go
+++ b/app/app.go
@@ -369,12 +369,23 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(m.handleError(msg.err), m.selectionChanged())
 		}
 
-		msg.instance.SetStatus(session.Running)
-		m.sidebar.RegisterRepoForInstance(msg.instance)
-		if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
-			return m, m.handleError(err)
+		started := msg.instance
+		if msg.started != nil {
+			started = msg.started
 		}
-		msg.instance.AutoYes = m.autoYes
+		if started != msg.instance {
+			if !m.sidebar.ReplaceInstance(msg.instance, started) && !m.sidebar.ContainsInstance(started) {
+				m.sidebar.AddInstance(started)
+			}
+		} else if !m.sidebar.ContainsInstance(started) {
+			m.sidebar.AddInstance(started)
+		}
+
+		started.SetStatus(session.Running)
+		if !started.IsRemote() {
+			m.sidebar.RegisterRepoForInstance(started)
+		}
+		started.AutoYes = m.autoYes
 
 		if !userStillWatching {
 			// User moved on — update status silently and keep their current
@@ -384,7 +395,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		m.menu.SetState(ui.StateDefault)
-		m.showHelpScreen(helpStart(msg.instance), nil)
+		m.showHelpScreen(helpStart(started), nil)
 
 		return m, tea.Batch(tea.WindowSize(), m.selectionChanged())
 	case spinner.TickMsg:
@@ -530,12 +541,17 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 	instance.SetStatus(session.Loading)
 	m.menu.SetState(ui.StateDefault)
 
-	m.preSaveInstances()
-
 	prompt := tsk.Prompt
 	taskID := tsk.ID
 	startCmd := func() tea.Msg {
-		if err := task.StartAndSendPrompt(instance, prompt); err != nil {
+		started, err := startSessionThroughDaemon(instance, sessionStartRequest{
+			Title:    instance.Title,
+			RepoPath: instance.Path,
+			Program:  instance.Program,
+			Prompt:   prompt,
+			AutoYes:  m.autoYes,
+		})
+		if err != nil {
 			return instanceStartedMsg{instance: instance, err: err}
 		}
 
@@ -549,7 +565,7 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 			}
 		}
 
-		return instanceStartedMsg{instance: instance, err: nil}
+		return instanceStartedMsg{instance: instance, started: started, err: nil}
 	}
 
 	return tea.Batch(tea.WindowSize(), m.selectionChanged(), startCmd)
@@ -802,16 +818,8 @@ type runOnEventLoopMsg struct {
 
 type instanceStartedMsg struct {
 	instance *session.Instance
+	started  *session.Instance
 	err      error
-}
-
-// preSaveInstances persists the current sidebar instances to disk so that
-// refreshExternalInstances won't remove a newly-created instance whose
-// status transitions from Loading to Running during async Start().
-func (m *home) preSaveInstances() {
-	if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
-		log.ErrorLog.Printf("failed to pre-save instance: %v", err)
-	}
 }
 
 func (m *home) handleError(err error) tea.Cmd {

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -50,10 +50,8 @@ func newTestHome(t *testing.T) *home {
 	}
 }
 
-// newLoadingInstance returns an instance in Loading status — mirroring the
-// state that preSaveInstances produces before Start() runs. started=false so
-// ToInstanceData / SaveInstances include it via the "|| Status == Loading"
-// branch.
+// newLoadingInstance returns an instance in Loading status, matching the UI
+// placeholder shown while the daemon starts a session.
 func newLoadingInstance(t *testing.T, title string) *session.Instance {
 	t.Helper()
 	inst, err := session.NewInstance(session.InstanceOptions{

--- a/app/e2e_test.go
+++ b/app/e2e_test.go
@@ -64,6 +64,7 @@ func newE2EHarness(t *testing.T) *e2eHarness {
 		return fb, nil
 	})
 	t.Cleanup(restoreBackend)
+	installDirectSessionStarter(t)
 
 	restoreFetcher := SetPRInfoFetcherForTest(func(repoPath, branch string) (*git.PRInfo, error) {
 		eh.fmu.Lock()
@@ -75,6 +76,42 @@ func newE2EHarness(t *testing.T) *e2eHarness {
 	t.Cleanup(restoreFetcher)
 
 	return eh
+}
+
+func installDirectSessionStarter(t *testing.T) {
+	t.Helper()
+	restore := SetSessionStarterForTest(func(inst *session.Instance, req sessionStartRequest) (*session.Instance, error) {
+		if inst == nil {
+			var err error
+			inst, err = session.NewInstance(session.InstanceOptions{
+				Title:       req.Title,
+				Path:        req.RepoPath,
+				Program:     req.Program,
+				AutoYes:     req.AutoYes,
+				ForceRemote: req.ForceRemote,
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+		inst.Program = req.Program
+		var err error
+		if req.ExistingWorktreePath != "" {
+			err = inst.StartWithExistingWorktree(req.ExistingWorktreePath, req.ExistingWorktreeBranch)
+		} else {
+			err = inst.Start(true)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if req.Prompt != "" {
+			if err := inst.SendPromptCommand(req.Prompt); err != nil {
+				return nil, err
+			}
+		}
+		return inst, nil
+	})
+	t.Cleanup(restore)
 }
 
 // start launches the teatest program. Must be called exactly once, after any

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -153,30 +153,22 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	killAction := func() tea.Msg {
 		tw.CleanupTerminalForInstance(selectedTitle)
 
-		// Find and kill by title, not by current selection index, to avoid
-		// destroying the wrong worktree if the sidebar order changed.
-		// Capture the repo name before Kill(), because Kill() sets started=false
-		// which causes RepoName() to fail — leaving the sidebar repo count stale.
 		var repoName string
 		var repoErr error = fmt.Errorf("instance not found")
 		for _, inst := range m.sidebar.GetInstances() {
 			if inst.Title == selectedTitle {
 				repoName, repoErr = inst.RepoName()
-				if err := inst.Kill(); err != nil {
-					log.ErrorLog.Printf("could not kill instance: %v", err)
-					return fmt.Errorf("failed to kill session '%s': %w", selectedTitle, err)
-				}
 				break
 			}
+		}
+		if err := killSessionThroughDaemon(selectedTitle, m.repoID); err != nil {
+			log.ErrorLog.Printf("could not kill instance: %v", err)
+			return fmt.Errorf("failed to kill session '%s': %w", selectedTitle, err)
 		}
 		if repoErr == nil {
 			m.sidebar.RemoveInstanceByTitleWithRepo(selectedTitle, repoName)
 		} else {
 			m.sidebar.RemoveInstanceByTitle(selectedTitle)
-		}
-
-		if err := m.storage.DeleteInstance(selectedTitle); err != nil {
-			log.ErrorLog.Printf("failed to delete instance from storage: %v", err)
 		}
 
 		return instanceChangedMsg{}

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -70,20 +70,25 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.state = stateDefault
 		m.menu.SetState(ui.StateDefault)
 
-		m.preSaveInstances()
-
 		selectedWt := m.selectedWorktree
 		m.selectedWorktree = nil
 		m.availableWorktrees = nil
 		startCmd := func() tea.Msg {
-			var err error
-			if selectedWt != nil {
-				err = instance.StartWithExistingWorktree(selectedWt.Path, selectedWt.Branch)
-			} else {
-				err = instance.Start(true)
+			req := sessionStartRequest{
+				Title:       instance.Title,
+				RepoPath:    instance.Path,
+				Program:     instance.Program,
+				AutoYes:     m.autoYes,
+				ForceRemote: instance.IsRemote(),
 			}
+			if selectedWt != nil {
+				req.ExistingWorktreePath = selectedWt.Path
+				req.ExistingWorktreeBranch = selectedWt.Branch
+			}
+			started, err := startSessionThroughDaemon(instance, req)
 			return instanceStartedMsg{
 				instance: instance,
+				started:  started,
 				err:      err,
 			}
 		}

--- a/app/real_e2e_test.go
+++ b/app/real_e2e_test.go
@@ -139,6 +139,7 @@ func newRealE2EHarness(t *testing.T) *e2eHarness {
 	t.Helper()
 	h := newTestHome(t)
 	eh := &e2eHarness{t: t, home: h}
+	installDirectSessionStarter(t)
 
 	// Stub PR fetcher: return no PR, zero log noise. Don't count calls —
 	// we don't care here, the PR behaviour is covered by the faked tests.

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+type sessionStartRequest struct {
+	Title                  string
+	TitleBase              string
+	RepoPath               string
+	Program                string
+	Prompt                 string
+	AutoYes                bool
+	ForceRemote            bool
+	ExistingWorktreePath   string
+	ExistingWorktreeBranch string
+}
+
+var startSessionThroughDaemon = func(_ *session.Instance, req sessionStartRequest) (*session.Instance, error) {
+	data, err := daemon.CreateSession(daemon.CreateSessionRequest{
+		Title:                  req.Title,
+		TitleBase:              req.TitleBase,
+		RepoPath:               req.RepoPath,
+		Program:                req.Program,
+		Prompt:                 req.Prompt,
+		AutoYes:                req.AutoYes,
+		ForceRemote:            req.ForceRemote,
+		ExistingWorktreePath:   req.ExistingWorktreePath,
+		ExistingWorktreeBranch: req.ExistingWorktreeBranch,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return session.FromInstanceData(*data)
+}
+
+var killSessionThroughDaemon = func(title, repoID string) error {
+	return daemon.KillSession(daemon.KillSessionRequest{Title: title, RepoID: repoID})
+}
+
+var importRemoteSessionsThroughDaemon = func(repoPath string) ([]session.InstanceData, error) {
+	return daemon.ImportRemoteHookSessions(daemon.ImportRemoteHookSessionsRequest{RepoPath: repoPath})
+}
+
+func SetSessionStarterForTest(f func(*session.Instance, sessionStartRequest) (*session.Instance, error)) func() {
+	prev := startSessionThroughDaemon
+	startSessionThroughDaemon = f
+	return func() { startSessionThroughDaemon = prev }
+}
+
+func SetSessionKillerForTest(f func(title, repoID string) error) func() {
+	prev := killSessionThroughDaemon
+	killSessionThroughDaemon = f
+	return func() { killSessionThroughDaemon = prev }
+}
+
+func SetRemoteImporterForTest(f func(repoPath string) ([]session.InstanceData, error)) func() {
+	prev := importRemoteSessionsThroughDaemon
+	importRemoteSessionsThroughDaemon = f
+	return func() { importRemoteSessionsThroughDaemon = prev }
+}

--- a/app/sync.go
+++ b/app/sync.go
@@ -310,7 +310,7 @@ func (m *home) importRemoteHookSessions() int {
 		return 0
 	}
 
-	listed, err := session.ListRemoteHookInstanceData(repo.Root, *repoCfg.RemoteHooks, time.Now())
+	listed, err := importRemoteSessionsThroughDaemon(repo.Root)
 	if err != nil {
 		log.WarningLog.Printf("failed to list remote hook sessions: %v", err)
 		return 0
@@ -345,10 +345,5 @@ func (m *home) importRemoteHookSessions() int {
 		imported++
 	}
 
-	if imported > 0 {
-		if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
-			log.WarningLog.Printf("failed to save imported remote sessions: %v", err)
-		}
-	}
 	return imported
 }

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
@@ -208,6 +209,22 @@ func TestImportRemoteHookSessionsAddsListCmdSessions(t *testing.T) {
 			DeleteCmd: noopCmd,
 		},
 	}))
+
+	restoreImporter := SetRemoteImporterForTest(func(repoPath string) ([]session.InstanceData, error) {
+		listed, err := session.ListRemoteHookInstanceData(repoPath, config.RemoteHooks{ListCmd: listCmd}, time.Now())
+		if err != nil {
+			return nil, err
+		}
+		raw, err := json.Marshal(listed)
+		if err != nil {
+			return nil, err
+		}
+		if err := config.SaveRepoInstances(repo.ID, raw); err != nil {
+			return nil, err
+		}
+		return listed, nil
+	})
+	t.Cleanup(restoreImporter)
 
 	imported := h.importRemoteHookSessions()
 	require.Equal(t, 1, imported)

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1,0 +1,788 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/rpc"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+const (
+	controlServiceName       = "Control"
+	daemonSocketFileName     = "daemon.sock"
+	daemonReadyTimeout       = 5 * time.Second
+	daemonDialTimeout        = 250 * time.Millisecond
+	maxTrustPromptAttempts   = 20
+	trustPromptRetryDelay    = time.Second
+	waitForReadyTimeout      = 60 * time.Second
+	waitForReadyPollInterval = 500 * time.Millisecond
+)
+
+var ensureDaemonMu sync.Mutex
+
+// CreateSessionRequest is the daemon-owned session creation contract used by
+// the TUI, CLI, and scheduled task runner.
+type CreateSessionRequest struct {
+	Title                  string
+	TitleBase              string
+	RepoPath               string
+	Program                string
+	Prompt                 string
+	AutoYes                bool
+	ForceRemote            bool
+	ExistingWorktreePath   string
+	ExistingWorktreeBranch string
+}
+
+type CreateSessionResponse struct {
+	Instance session.InstanceData
+}
+
+type KillSessionRequest struct {
+	Title  string
+	RepoID string
+}
+
+type KillSessionResponse struct {
+	OK bool
+}
+
+type SendPromptRequest struct {
+	Title  string
+	RepoID string
+	Prompt string
+}
+
+type SendPromptResponse struct {
+	OK bool
+}
+
+type ImportRemoteHookSessionsRequest struct {
+	RepoPath string
+}
+
+type ImportRemoteHookSessionsResponse struct {
+	Instances []session.InstanceData
+}
+
+type PingRequest struct{}
+type PingResponse struct {
+	OK bool
+}
+
+// DaemonSocketPath returns the Unix socket path used by the local control
+// plane.
+func DaemonSocketPath() (string, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, daemonSocketFileName), nil
+}
+
+// EnsureDaemon starts the daemon if the control socket is not already serving.
+func EnsureDaemon() error {
+	ensureDaemonMu.Lock()
+	defer ensureDaemonMu.Unlock()
+
+	if err := pingDaemon(); err == nil {
+		return nil
+	}
+
+	// A previous daemon version may have a PID file but no control socket. Stop
+	// it before launching the control-plane daemon so we do not run duplicate
+	// AutoYes loops.
+	if err := StopDaemon(); err != nil {
+		log.WarningLog.Printf("failed to stop stale daemon before launch: %v", err)
+	}
+
+	if err := launchDaemonProcess(); err != nil {
+		return err
+	}
+
+	deadline := time.Now().Add(daemonReadyTimeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if err := pingDaemon(); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("daemon did not become ready: %w", lastErr)
+}
+
+func pingDaemon() error {
+	var resp PingResponse
+	return callDaemonNoEnsure("Ping", PingRequest{}, &resp)
+}
+
+func callDaemon(method string, req any, resp any) error {
+	if err := EnsureDaemon(); err != nil {
+		return err
+	}
+	return callDaemonNoEnsure(method, req, resp)
+}
+
+func callDaemonNoEnsure(method string, req any, resp any) error {
+	socketPath, err := DaemonSocketPath()
+	if err != nil {
+		return err
+	}
+	conn, err := net.DialTimeout("unix", socketPath, daemonDialTimeout)
+	if err != nil {
+		return err
+	}
+	client := rpc.NewClient(conn)
+	defer client.Close()
+	return client.Call(controlServiceName+"."+method, req, resp)
+}
+
+// CreateSession asks the daemon to create, start, and persist a session.
+func CreateSession(req CreateSessionRequest) (*session.InstanceData, error) {
+	var resp CreateSessionResponse
+	if err := callDaemon("CreateSession", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Instance, nil
+}
+
+// KillSession asks the daemon to kill a session and remove it from storage.
+func KillSession(req KillSessionRequest) error {
+	var resp KillSessionResponse
+	if err := callDaemon("KillSession", req, &resp); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SendPrompt asks the daemon to send a prompt to an existing session.
+func SendPrompt(req SendPromptRequest) error {
+	var resp SendPromptResponse
+	if err := callDaemon("SendPrompt", req, &resp); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ImportRemoteHookSessions asks the daemon to reconcile remote sessions
+// reported by list_cmd into persisted storage.
+func ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest) ([]session.InstanceData, error) {
+	var resp ImportRemoteHookSessionsResponse
+	if err := callDaemon("ImportRemoteHookSessions", req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Instances, nil
+}
+
+type controlServer struct {
+	manager *Manager
+}
+
+func (s *controlServer) Ping(_ PingRequest, resp *PingResponse) error {
+	resp.OK = true
+	return nil
+}
+
+func (s *controlServer) CreateSession(req CreateSessionRequest, resp *CreateSessionResponse) error {
+	data, err := s.manager.CreateSession(req)
+	if err != nil {
+		return err
+	}
+	resp.Instance = data
+	return nil
+}
+
+func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionResponse) error {
+	if err := s.manager.KillSession(req); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+func (s *controlServer) SendPrompt(req SendPromptRequest, resp *SendPromptResponse) error {
+	if err := s.manager.SendPrompt(req); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+func (s *controlServer) ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest, resp *ImportRemoteHookSessionsResponse) error {
+	data, err := s.manager.ImportRemoteHookSessions(req)
+	if err != nil {
+		return err
+	}
+	resp.Instances = data
+	return nil
+}
+
+func startControlServer(manager *Manager) (func() error, error) {
+	socketPath, err := DaemonSocketPath()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0755); err != nil {
+		return nil, err
+	}
+	_ = os.Remove(socketPath)
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(socketPath, 0600); err != nil {
+		_ = listener.Close()
+		return nil, err
+	}
+
+	server := rpc.NewServer()
+	if err := server.RegisterName(controlServiceName, &controlServer{manager: manager}); err != nil {
+		_ = listener.Close()
+		return nil, err
+	}
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go server.ServeConn(conn)
+		}
+	}()
+
+	return func() error {
+		err := listener.Close()
+		_ = os.Remove(socketPath)
+		return err
+	}, nil
+}
+
+// Manager owns the daemon's authoritative session mutations.
+type Manager struct {
+	cfg *config.Config
+
+	mu                  sync.Mutex
+	storage             *session.Storage
+	instances           map[string]*session.Instance
+	reservedTitles      map[string]struct{}
+	reservedRemoteNames map[string]struct{}
+}
+
+func NewManager(cfg *config.Config) (*Manager, error) {
+	state := config.LoadState()
+	storage, err := session.NewStorage(state, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize storage: %w", err)
+	}
+	instances, err := refreshDaemonInstances(nil)
+	if err != nil {
+		return nil, err
+	}
+	return &Manager{
+		cfg:                 cfg,
+		storage:             storage,
+		instances:           instances,
+		reservedTitles:      make(map[string]struct{}),
+		reservedRemoteNames: make(map[string]struct{}),
+	}, nil
+}
+
+func (m *Manager) RefreshInstances() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.refreshLocked()
+}
+
+func (m *Manager) InstancesSnapshot() []*session.Instance {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return daemonInstances(m.instances)
+}
+
+func (m *Manager) SaveInstances() error {
+	return m.storage.SaveInstances(m.InstancesSnapshot())
+}
+
+func (m *Manager) refreshLocked() error {
+	refreshed, err := refreshDaemonInstances(m.instances)
+	if err != nil {
+		return err
+	}
+	m.instances = refreshed
+	return nil
+}
+
+func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData, error) {
+	if req.Program == "" {
+		req.Program = m.cfg.DefaultProgram
+	}
+	repo, title, release, err := m.reserveCreate(req)
+	if err != nil {
+		return session.InstanceData{}, err
+	}
+	defer release()
+
+	instance, err := session.NewInstance(session.InstanceOptions{
+		Title:       title,
+		Path:        repo.Root,
+		Program:     req.Program,
+		AutoYes:     req.AutoYes,
+		ForceRemote: req.ForceRemote,
+	})
+	if err != nil {
+		return session.InstanceData{}, err
+	}
+
+	if req.ExistingWorktreePath != "" && req.ForceRemote {
+		return session.InstanceData{}, fmt.Errorf("remote sessions cannot use an existing local worktree")
+	}
+
+	if req.ExistingWorktreePath != "" {
+		err = instance.StartWithExistingWorktree(req.ExistingWorktreePath, req.ExistingWorktreeBranch)
+	} else {
+		err = startAndSendPrompt(instance, req.Prompt)
+	}
+	if err != nil {
+		_ = instance.Kill()
+		return session.InstanceData{}, fmt.Errorf("failed to start instance: %w", err)
+	}
+
+	instance.SetStatus(session.Running)
+	data := instance.ToInstanceData()
+	if err := appendInstanceData(repo.ID, data); err != nil {
+		_ = instance.Kill()
+		return session.InstanceData{}, err
+	}
+
+	m.mu.Lock()
+	m.instances[daemonInstanceKey(repo.ID, title)] = instance
+	m.mu.Unlock()
+
+	return data, nil
+}
+
+func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, string, func(), error) {
+	if req.RepoPath == "" {
+		return nil, "", nil, fmt.Errorf("repo path is required")
+	}
+	repo, err := config.RepoFromPath(req.RepoPath)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.refreshLocked(); err != nil {
+		return nil, "", nil, err
+	}
+
+	diskData, err := loadRepoInstanceData(repo.ID)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	title := req.Title
+	if title == "" {
+		base := req.TitleBase
+		if base == "" {
+			return nil, "", nil, fmt.Errorf("session title is required")
+		}
+		title, err = m.nextAvailableTitleLocked(repo.ID, repo.Root, base, req.Program, req.ForceRemote, diskData)
+		if err != nil {
+			return nil, "", nil, err
+		}
+	} else if err := m.validateTitleAvailableLocked(repo.ID, repo.Root, title, req.Program, req.ForceRemote, diskData); err != nil {
+		return nil, "", nil, err
+	}
+
+	key := daemonInstanceKey(repo.ID, title)
+	remoteName := ""
+	if req.ForceRemote {
+		remoteName = session.Slugify(title)
+		if _, ok := m.reservedRemoteNames[remoteName]; ok {
+			return nil, "", nil, fmt.Errorf("remote hook name %q is already reserved", remoteName)
+		}
+	}
+
+	m.reservedTitles[key] = struct{}{}
+	if remoteName != "" {
+		m.reservedRemoteNames[remoteName] = struct{}{}
+	}
+	release := func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		delete(m.reservedTitles, key)
+		if remoteName != "" {
+			delete(m.reservedRemoteNames, remoteName)
+		}
+	}
+
+	return repo, title, release, nil
+}
+
+func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program string, remote bool, diskData []session.InstanceData) (string, error) {
+	for i := 1; i <= 10000; i++ {
+		candidate := baseTitle
+		if i > 1 {
+			candidate = fmt.Sprintf("%s-%d", baseTitle, i)
+		}
+		if err := m.validateTitleAvailableLocked(repoID, repoPath, candidate, program, remote, diskData); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("could not find an available title for %q", baseTitle)
+}
+
+func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program string, remote bool, diskData []session.InstanceData) error {
+	if title == "" {
+		return fmt.Errorf("session title is required")
+	}
+	key := daemonInstanceKey(repoID, title)
+	if _, ok := m.reservedTitles[key]; ok {
+		return fmt.Errorf("session with title %q is already reserved", title)
+	}
+	if _, ok := m.instances[key]; ok {
+		return fmt.Errorf("session with title %q already exists", title)
+	}
+	for _, data := range diskData {
+		if data.Title == title {
+			return fmt.Errorf("session with title %q already exists", title)
+		}
+	}
+	if remote {
+		candidate := session.Slugify(title)
+		if _, ok := m.reservedRemoteNames[candidate]; ok {
+			return fmt.Errorf("remote hook name %q is already reserved", candidate)
+		}
+		for _, data := range diskData {
+			if data.BackendType != "remote" {
+				continue
+			}
+			if session.RemoteHookName(data.Title, data.RemoteMeta) == candidate {
+				return fmt.Errorf("remote session titled %q already maps to hook name %q", data.Title, candidate)
+			}
+		}
+		return nil
+	}
+	if tmux.NewTmuxSessionForRepo(title, repoPath, program).DoesSessionExist() {
+		return fmt.Errorf("tmux session for title %q already exists", title)
+	}
+	return nil
+}
+
+func (m *Manager) KillSession(req KillSessionRequest) error {
+	instance, repoID, data, err := m.findSession(req.Title, req.RepoID)
+	if err != nil {
+		return err
+	}
+
+	if instance != nil {
+		if err := instance.Kill(); err != nil {
+			return fmt.Errorf("failed to kill instance: %w", err)
+		}
+	} else if data != nil {
+		cleanupGhostWorktree(*data, req.Title)
+	}
+
+	state := config.LoadState()
+	storage, err := session.NewStorage(state, repoID)
+	if err != nil {
+		return err
+	}
+	if err := storage.DeleteInstance(req.Title); err != nil {
+		return fmt.Errorf("failed to delete instance from storage: %w", err)
+	}
+
+	m.mu.Lock()
+	delete(m.instances, daemonInstanceKey(repoID, req.Title))
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *Manager) SendPrompt(req SendPromptRequest) error {
+	if req.Prompt == "" {
+		return fmt.Errorf("prompt is required")
+	}
+	instance, _, _, err := m.findSession(req.Title, req.RepoID)
+	if err != nil {
+		return err
+	}
+	if instance == nil {
+		return fmt.Errorf("failed to restore instance %q", req.Title)
+	}
+	if err := instance.SendPromptCommand(req.Prompt); err != nil {
+		return fmt.Errorf("failed to send prompt: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) findSession(title, repoID string) (*session.Instance, string, *session.InstanceData, error) {
+	if title == "" {
+		return nil, "", nil, fmt.Errorf("session title is required")
+	}
+
+	m.mu.Lock()
+	if err := m.refreshLocked(); err != nil {
+		m.mu.Unlock()
+		return nil, "", nil, err
+	}
+	if repoID != "" {
+		key := daemonInstanceKey(repoID, title)
+		if instance := m.instances[key]; instance != nil {
+			m.mu.Unlock()
+			return instance, repoID, nil, nil
+		}
+	} else {
+		for key, instance := range m.instances {
+			if instance.Title == title {
+				rid, _ := splitDaemonInstanceKey(key)
+				m.mu.Unlock()
+				return instance, rid, nil, nil
+			}
+		}
+	}
+	m.mu.Unlock()
+
+	data, rid, err := findInstanceDataByTitle(title, repoID)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	instance, restoreErr := session.FromInstanceData(*data)
+	if restoreErr != nil {
+		return nil, rid, data, nil
+	}
+	return instance, rid, data, nil
+}
+
+func (m *Manager) ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest) ([]session.InstanceData, error) {
+	if req.RepoPath == "" {
+		return nil, fmt.Errorf("repo path is required")
+	}
+	repo, err := config.RepoFromPath(req.RepoPath)
+	if err != nil {
+		return nil, err
+	}
+	repoCfg, err := config.LoadRepoConfig(repo.ID)
+	if err != nil {
+		return nil, err
+	}
+	if repoCfg.RemoteHooks == nil || repoCfg.RemoteHooks.ListCmd == "" {
+		return nil, nil
+	}
+
+	listed, err := session.ListRemoteHookInstanceData(repo.Root, *repoCfg.RemoteHooks, time.Now())
+	if err != nil {
+		return nil, err
+	}
+
+	imported := make([]session.InstanceData, 0, len(listed))
+	if err := config.UpdateRepoInstances(repo.ID, func(raw json.RawMessage) (json.RawMessage, error) {
+		var existing []session.InstanceData
+		if err := json.Unmarshal(raw, &existing); err != nil {
+			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
+		}
+		existingTitles := make(map[string]bool, len(existing))
+		existingHookNames := make(map[string]bool)
+		for _, data := range existing {
+			existingTitles[data.Title] = true
+			if data.BackendType == "remote" {
+				existingHookNames[session.RemoteHookName(data.Title, data.RemoteMeta)] = true
+			}
+		}
+		for _, data := range listed {
+			name := session.RemoteHookName(data.Title, data.RemoteMeta)
+			if existingTitles[data.Title] || existingHookNames[name] {
+				continue
+			}
+			existing = append(existing, data)
+			imported = append(imported, data)
+			existingTitles[data.Title] = true
+			existingHookNames[name] = true
+		}
+		return json.Marshal(existing)
+	}); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	_ = m.refreshLocked()
+	m.mu.Unlock()
+	return imported, nil
+}
+
+func appendInstanceData(repoID string, data session.InstanceData) error {
+	return config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {
+		var existing []session.InstanceData
+		if err := json.Unmarshal(raw, &existing); err != nil {
+			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
+		}
+		for i := range existing {
+			if existing[i].Title == data.Title {
+				return nil, fmt.Errorf("session with title %q already exists", data.Title)
+			}
+		}
+		existing = append(existing, data)
+		return json.MarshalIndent(existing, "", "  ")
+	})
+}
+
+func loadRepoInstanceData(repoID string) ([]session.InstanceData, error) {
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		return nil, err
+	}
+	var data []session.InstanceData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("failed to parse existing instances: %w", err)
+	}
+	return data, nil
+}
+
+func findInstanceDataByTitle(title, repoID string) (*session.InstanceData, string, error) {
+	if repoID != "" {
+		data, err := loadRepoInstanceData(repoID)
+		if err != nil {
+			return nil, "", err
+		}
+		for i := range data {
+			if data[i].Title == title {
+				return &data[i], repoID, nil
+			}
+		}
+		return nil, "", fmt.Errorf("instance %q not found", title)
+	}
+
+	allInstances, err := config.LoadAllRepoInstances()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to load instances: %w", err)
+	}
+	for rid, raw := range allInstances {
+		var data []session.InstanceData
+		if err := json.Unmarshal(raw, &data); err != nil {
+			continue
+		}
+		for i := range data {
+			if data[i].Title == title {
+				return &data[i], rid, nil
+			}
+		}
+	}
+	return nil, "", fmt.Errorf("instance %q not found", title)
+}
+
+func cleanupGhostWorktree(data session.InstanceData, title string) {
+	if data.Worktree.RepoPath == "" || data.Worktree.WorktreePath == "" || data.Worktree.ExternalWorktree {
+		return
+	}
+	branchCreatedByUs := true
+	if data.Worktree.BranchCreatedByUs != nil {
+		branchCreatedByUs = *data.Worktree.BranchCreatedByUs
+	}
+	gw, err := git.NewGitWorktreeFromStorage(
+		data.Worktree.RepoPath,
+		data.Worktree.WorktreePath,
+		data.Worktree.SessionName,
+		data.Worktree.BranchName,
+		data.Worktree.BaseCommitSHA,
+		data.Worktree.ExternalWorktree,
+		branchCreatedByUs,
+	)
+	if err != nil {
+		log.WarningLog.Printf("ghost session %q: failed to load worktree for cleanup: %v", title, err)
+		return
+	}
+	if err := gw.Cleanup(); err != nil {
+		log.WarningLog.Printf("ghost session %q: worktree cleanup failed: %v", title, err)
+	}
+}
+
+func startAndSendPrompt(instance *session.Instance, prompt string) error {
+	if err := instance.Start(true); err != nil {
+		return err
+	}
+	if instance.IsRemote() {
+		return nil
+	}
+	if prompt == "" {
+		return nil
+	}
+	if err := waitForReady(instance); err != nil {
+		return err
+	}
+	for attempts := 0; instance.CheckAndHandleTrustPrompt(); attempts++ {
+		if attempts+1 >= maxTrustPromptAttempts {
+			return fmt.Errorf("trust prompt did not dismiss after %d attempts", maxTrustPromptAttempts)
+		}
+		time.Sleep(trustPromptRetryDelay)
+		if err := waitForReady(instance); err != nil {
+			return err
+		}
+	}
+	if prompt != "" {
+		if err := instance.SendPromptCommand(prompt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func waitForReady(instance *session.Instance) error {
+	timeout := time.After(waitForReadyTimeout)
+	ticker := time.NewTicker(waitForReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			content, err := instance.Preview()
+			if err != nil {
+				log.ErrorLog.Printf("waitForReady timed out (preview also failed: %v)", err)
+			} else {
+				log.ErrorLog.Printf("waitForReady timed out. Last pane content: %s", content)
+			}
+			return fmt.Errorf("timed out waiting for program to start (%s)", waitForReadyTimeout)
+		case <-ticker.C:
+			content, err := instance.Preview()
+			if err != nil {
+				continue
+			}
+			if isReadyContent(content) {
+				return nil
+			}
+		}
+	}
+}
+
+func isReadyContent(content string) bool {
+	if strings.Contains(content, "❯") ||
+		strings.Contains(content, "Do you trust") ||
+		strings.Contains(content, "new MCP server") {
+		return true
+	}
+	return strings.Contains(content, "Open documentation url") &&
+		strings.Contains(content, "(D)on't ask again")
+}
+
+func splitDaemonInstanceKey(key string) (string, string) {
+	for i := 0; i < len(key); i++ {
+		if key[i] == 0 {
+			return key[:i], key[i+1:]
+		}
+	}
+	return "", key
+}

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -1,0 +1,138 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+func setupControlRepo(t *testing.T) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := exec.Command("git", "init", repo).Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := exec.Command("git", "-C", repo, "config", "user.email", "test@example.com").Run(); err != nil {
+		t.Fatalf("git config email: %v", err)
+	}
+	if err := exec.Command("git", "-C", repo, "config", "user.name", "Test User").Run(); err != nil {
+		t.Fatalf("git config name: %v", err)
+	}
+	if err := exec.Command("git", "-C", repo, "commit", "--allow-empty", "-m", "init").Run(); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	return repo
+}
+
+func installInstantBackend(t *testing.T) {
+	t.Helper()
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, absPath string) (session.Backend, error) {
+		backend := session.NewFakeBackend()
+		backend.CompleteStart()
+		return backend, nil
+	})
+	t.Cleanup(restore)
+}
+
+func TestManagerCreateSessionPersistsAndRejectsDuplicate(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	data, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "daemon-owned",
+		RepoPath: repoPath,
+		Program:  "claude",
+		AutoYes:  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if data.Title != "daemon-owned" || !data.AutoYes || data.Status != session.Running {
+		t.Fatalf("unexpected created data: %+v", data)
+	}
+
+	raw, err := config.LoadRepoInstances(repo.ID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var stored []session.InstanceData
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("unmarshal stored: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Title != "daemon-owned" {
+		t.Fatalf("expected created session in storage, got %+v", stored)
+	}
+
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "daemon-owned",
+		RepoPath: repoPath,
+		Program:  "claude",
+	}); err == nil {
+		t.Fatalf("expected duplicate title to be rejected")
+	}
+}
+
+func TestControlServerCreateAndKillSession(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	closeServer, err := startControlServer(manager)
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	t.Cleanup(func() { _ = closeServer() })
+
+	var createResp CreateSessionResponse
+	if err := callDaemonNoEnsure("CreateSession", CreateSessionRequest{
+		Title:    "rpc-session",
+		RepoPath: repoPath,
+		Program:  "claude",
+	}, &createResp); err != nil {
+		t.Fatalf("rpc CreateSession: %v", err)
+	}
+	if createResp.Instance.Title != "rpc-session" {
+		t.Fatalf("unexpected create response: %+v", createResp)
+	}
+
+	var killResp KillSessionResponse
+	if err := callDaemonNoEnsure("KillSession", KillSessionRequest{
+		Title:  "rpc-session",
+		RepoID: repo.ID,
+	}, &killResp); err != nil {
+		t.Fatalf("rpc KillSession: %v", err)
+	}
+
+	raw, err := config.LoadRepoInstances(repo.ID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var stored []session.InstanceData
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("unmarshal stored: %v", err)
+	}
+	if len(stored) != 0 {
+		t.Fatalf("expected storage to be empty after kill, got %+v", stored)
+	}
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -17,21 +17,23 @@ import (
 	"time"
 )
 
-// RunDaemon runs the daemon process which iterates over all sessions and runs AutoYes mode on them.
-// It's expected that the main process kills the daemon when the main process starts.
+// RunDaemon runs the daemon process, serves the local control plane, and
+// iterates over all sessions to run AutoYes mode on them.
 func RunDaemon(cfg *config.Config) error {
 	log.InfoLog.Printf("starting daemon")
-	state := config.LoadState()
-	storage, err := session.NewStorage(state, "")
+	manager, err := NewManager(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to initialize storage: %w", err)
+		return err
 	}
-
-	instanceMap, err := refreshDaemonInstances(nil)
+	closeControl, err := startControlServer(manager)
 	if err != nil {
-		return fmt.Errorf("failed to load instances: %w", err)
+		return fmt.Errorf("failed to start daemon control server: %w", err)
 	}
-	instances := daemonInstances(instanceMap)
+	defer func() {
+		if err := closeControl(); err != nil {
+			log.WarningLog.Printf("failed to close daemon control socket: %v", err)
+		}
+	}()
 
 	pollInterval := time.Duration(cfg.DaemonPollInterval) * time.Millisecond
 
@@ -43,14 +45,11 @@ func RunDaemon(cfg *config.Config) error {
 		ticker := time.NewTicker(pollInterval)
 		defer ticker.Stop()
 		for {
-			if refreshed, err := refreshDaemonInstances(instanceMap); err != nil {
+			if err := manager.RefreshInstances(); err != nil {
 				log.WarningLog.Printf("failed to refresh daemon instances: %v", err)
-			} else {
-				instanceMap = refreshed
-				instances = daemonInstances(instanceMap)
 			}
 
-			for _, instance := range instances {
+			for _, instance := range manager.InstancesSnapshot() {
 				// We only store started instances, but check anyway.
 				if instance.Started() {
 					if _, hasPrompt := instance.HasUpdated(); hasPrompt {
@@ -78,7 +77,7 @@ func RunDaemon(cfg *config.Config) error {
 	close(stopCh)
 	wg.Wait()
 
-	if err := storage.SaveInstances(instances); err != nil {
+	if err := manager.SaveInstances(); err != nil {
 		log.ErrorLog.Printf("failed to save instances when terminating daemon: %v", err)
 	}
 	return nil
@@ -142,14 +141,13 @@ func daemonInstances(instanceMap map[string]*session.Instance) []*session.Instan
 	return instances
 }
 
-// LaunchDaemon launches the daemon process.
+// LaunchDaemon launches the daemon process if it is not already serving the
+// local control plane.
 func LaunchDaemon() error {
-	// Stop any existing daemon first to prevent duplicates.
-	if err := StopDaemon(); err != nil {
-		log.ErrorLog.Printf("failed to stop existing daemon: %v", err)
-		// Continue anyway — best effort
-	}
+	return EnsureDaemon()
+}
 
+func launchDaemonProcess() error {
 	// Find the agent-factory binary.
 	execPath, err := os.Executable()
 	if err != nil {
@@ -247,6 +245,9 @@ func StopDaemon() error {
 	// Clean up PID file
 	if err := os.Remove(pidFile); err != nil {
 		return fmt.Errorf("failed to remove PID file: %w", err)
+	}
+	if socketPath, socketErr := DaemonSocketPath(); socketErr == nil {
+		_ = os.Remove(socketPath)
 	}
 
 	log.InfoLog.Printf("daemon process (PID: %d) stopped successfully", pid)

--- a/main.go
+++ b/main.go
@@ -81,11 +81,6 @@ var (
 					}
 				}()
 			}
-			// Kill any daemon that's running.
-			if err := daemon.StopDaemon(); err != nil {
-				log.ErrorLog.Printf("failed to stop daemon: %v", err)
-			}
-
 			// Check for updates in the background (non-blocking).
 			autoUpdateInBackground()
 

--- a/task/runner.go
+++ b/task/runner.go
@@ -180,75 +180,17 @@ func RunTask(taskID string) error {
 		return fmt.Errorf("project path %s is not a valid git repository", t.ProjectPath)
 	}
 
-	cfg := config.LoadConfig()
-
 	baseTitle := TaskRunBaseTitle(*t)
-
-	repo, err := config.RepoFromPath(t.ProjectPath)
-	if err != nil {
-		return fmt.Errorf("failed to resolve repo for project path %s: %w", t.ProjectPath, err)
-	}
-	title, err := NextTaskRunTitle(repo.ID, t.ProjectPath, baseTitle, t.Program)
-	if err != nil {
-		return fmt.Errorf("failed to allocate task run title: %w", err)
-	}
-
-	instance, err := session.NewInstance(session.InstanceOptions{
-		Title:   title,
-		Path:    t.ProjectPath,
-		Program: t.Program,
+	cfg := config.LoadConfig()
+	data, err := daemon.CreateSession(daemon.CreateSessionRequest{
+		TitleBase: baseTitle,
+		RepoPath:  t.ProjectPath,
+		Program:   t.Program,
+		Prompt:    t.Prompt,
+		AutoYes:   cfg.AutoYes,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create instance: %w", err)
-	}
-
-	// If anything fails after Start(), kill the instance to avoid orphaned resources.
-	started := true
-	defer func() {
-		if started {
-			if killErr := instance.Kill(); killErr != nil {
-				log.ErrorLog.Printf("failed to kill orphaned instance %s: %v", title, killErr)
-			}
-		}
-	}()
-
-	if err := StartAndSendPrompt(instance, t.Prompt); err != nil {
-		return fmt.Errorf("failed to start instance: %w", err)
-	}
-	instance.SetStatus(session.Running)
-
-	// Apply AutoYes to the in-memory instance before persisting so the
-	// flag is part of the saved data the daemon will read back.
-	if cfg.AutoYes {
-		instance.AutoYes = true
-	}
-
-	// Persist the new instance into per-repo instances.json under the
-	// file lock. This is the source of truth the daemon reads via
-	// storage.LoadInstances; without this write, the daemon never sees
-	// scheduled tasks and AutoYes runs hang. Mirrors api/sessions.go.
-	data := instance.ToInstanceData()
-	if err := config.UpdateRepoInstances(repo.ID, appendTaskRunnerInstanceFn(data)); err != nil {
-		return fmt.Errorf("failed to save instance to per-repo storage: %w", err)
-	}
-
-	// Also write to the pending file so the running TUI (which doesn't
-	// re-read instances.json on every tick) can merge the new instance
-	// into its in-memory list at startup. This is defensive: the daemon
-	// reads from per-repo instances.json above, which is the load-bearing
-	// path for AutoYes.
-	if err := appendPendingInstance(data); err != nil {
-		log.WarningLog.Printf("failed to save pending instance: %v", err)
-	}
-
-	// Instance is successfully handed off, don't kill it on return.
-	started = false
-
-	// Launch daemon for autoyes if configured.
-	if cfg.AutoYes {
-		if err := daemon.LaunchDaemon(); err != nil {
-			log.ErrorLog.Printf("failed to launch daemon: %v", err)
-		}
+		return fmt.Errorf("failed to start task session: %w", err)
 	}
 
 	// Update task status.
@@ -259,7 +201,7 @@ func RunTask(taskID string) error {
 		log.ErrorLog.Printf("failed to update task status: %v", err)
 	}
 
-	log.InfoLog.Printf("task %s started successfully as instance %s", taskID, title)
+	log.InfoLog.Printf("task %s started successfully as instance %s", taskID, data.Title)
 	return nil
 }
 

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -165,20 +165,15 @@ func TestLoadAndClearPendingInstances_Corrupted(t *testing.T) {
 	}
 }
 
-// runnerAppendInstance mirrors the inline UpdateRepoInstances callback in
-// RunTask. Keeping it identical here lets us exercise the per-repo write
-// path without spinning up a full session/tmux/git-worktree fixture.
+// runnerAppendInstance exercises the legacy append helper kept for storage
+// merge regression coverage without spinning up a full session fixture.
 func runnerAppendInstance(repoID string, data session.InstanceData) error {
 	return config.UpdateRepoInstances(repoID, appendTaskRunnerInstanceFn(data))
 }
 
-// TestRunTask_WritesToPerRepoStorage is the regression test for issue #334.
-// The bug: RunTask wrote scheduled instances only to pending_instances.json
-// and launched the daemon, which loads from per-repo instances.json. The
-// daemon therefore never saw the scheduled instance and AutoYes runs hung.
-// This test asserts that the per-repo storage write that RunTask now performs
-// produces a file the daemon path (config.LoadRepoInstances) can read back
-// with the new instance present.
+// TestRunTask_WritesToPerRepoStorage is legacy regression coverage for issue
+// #334: scheduled instances must end up in per-repo instances.json so the
+// daemon can see them.
 func TestRunTask_WritesToPerRepoStorage(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", tmp)

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -354,6 +354,34 @@ func (s *Sidebar) SelectInstance(target *session.Instance) {
 	}
 }
 
+// ContainsInstance reports whether target is currently in the sidebar.
+func (s *Sidebar) ContainsInstance(target *session.Instance) bool {
+	for _, inst := range s.instances {
+		if inst == target {
+			return true
+		}
+	}
+	return false
+}
+
+// ReplaceInstance swaps an existing sidebar instance for replacement while
+// preserving the selected row when the replaced instance was selected.
+func (s *Sidebar) ReplaceInstance(target, replacement *session.Instance) bool {
+	for i, inst := range s.instances {
+		if inst != target {
+			continue
+		}
+		wasSelected := s.GetSelectedInstance() == inst
+		s.instances[i] = replacement
+		s.rebuildVisibleItems()
+		if wasSelected {
+			s.SetSelectedInstance(i)
+		}
+		return true
+	}
+	return false
+}
+
 // GetInstances returns all instances.
 func (s *Sidebar) GetInstances() []*session.Instance {
 	return s.instances


### PR DESCRIPTION
## Summary
- add a small Unix-socket net/rpc control plane to the daemon with create, kill, send-prompt, remote-import, and ping operations
- make the daemon manager own session creation/start/persistence, task-run session starts, remote hook imports, and kill/delete storage mutations
- route TUI, CLI, and scheduled task creation paths through the daemon while keeping attach/preview/rendering local
- stop using Loading pre-save records as a client-side coordination mechanism for new session starts

## Scope Notes
- This intentionally keeps the app footprint small: standard-library RPC over a local Unix socket, no new dependencies, and no broad UI rewrite.
- The TUI still owns rendering, local attach/preview, task/hook editing, and lightweight storage refreshes. The daemon now owns the authoritative lifecycle mutations that were causing cross-client races.
- Legacy pending-instance loading remains so older scheduled runs can still be reconciled, but new scheduled runs go through the daemon.

## Testing
- 
- ok  	github.com/sachiniyer/agent-factory	(cached)
ok  	github.com/sachiniyer/agent-factory/api	(cached)
ok  	github.com/sachiniyer/agent-factory/app	(cached)
?   	github.com/sachiniyer/agent-factory/cmd	[no test files]
?   	github.com/sachiniyer/agent-factory/cmd/cmd_test	[no test files]
ok  	github.com/sachiniyer/agent-factory/config	(cached)
ok  	github.com/sachiniyer/agent-factory/daemon	(cached)
?   	github.com/sachiniyer/agent-factory/keys	[no test files]
ok  	github.com/sachiniyer/agent-factory/log	(cached)
ok  	github.com/sachiniyer/agent-factory/session	(cached)
ok  	github.com/sachiniyer/agent-factory/session/git	(cached)
ok  	github.com/sachiniyer/agent-factory/session/tmux	(cached)
ok  	github.com/sachiniyer/agent-factory/task	(cached)
ok  	github.com/sachiniyer/agent-factory/ui	(cached)
ok  	github.com/sachiniyer/agent-factory/ui/overlay	(cached)
- ok  	github.com/sachiniyer/agent-factory	(cached)
ok  	github.com/sachiniyer/agent-factory/api	(cached)
ok  	github.com/sachiniyer/agent-factory/app	(cached)
?   	github.com/sachiniyer/agent-factory/cmd	[no test files]
?   	github.com/sachiniyer/agent-factory/cmd/cmd_test	[no test files]
ok  	github.com/sachiniyer/agent-factory/config	(cached)
ok  	github.com/sachiniyer/agent-factory/daemon	(cached)
?   	github.com/sachiniyer/agent-factory/keys	[no test files]
ok  	github.com/sachiniyer/agent-factory/log	(cached)
ok  	github.com/sachiniyer/agent-factory/session	(cached)
ok  	github.com/sachiniyer/agent-factory/session/git	(cached)
ok  	github.com/sachiniyer/agent-factory/session/tmux	(cached)
ok  	github.com/sachiniyer/agent-factory/task	1.068s
ok  	github.com/sachiniyer/agent-factory/ui	(cached)
ok  	github.com/sachiniyer/agent-factory/ui/overlay	(cached)