### PR TITLE
Add daemon control-plane integration coverage

### DIFF
--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -1,0 +1,123 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTUIRefreshSeesCLIChangesThroughDaemon(t *testing.T) {
+	skipIfRealBackendDepsMissing(t)
+
+	bin := buildIntegrationBinary(t)
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+	h.storage, err = session.NewStorage(config.DefaultState(), repo.ID)
+	require.NoError(t, err)
+	writeIntegrationConfig(t, os.Getenv("AGENT_FACTORY_HOME"))
+
+	t.Cleanup(func() {
+		_, _ = runIntegrationAF(t, bin, repoDir, "sessions", "kill", "cli-made")
+		killIntegrationDaemon(os.Getenv("AGENT_FACTORY_HOME"))
+	})
+
+	runIntegrationAFOK(t, bin, repoDir, "sessions", "--repo", repoDir, "create", "--name", "cli-made", "--program", "cat")
+	require.True(t, h.refreshExternalInstances(), "TUI refresh should import CLI-created session")
+	require.NotNil(t, findSidebarInstance(h, "cli-made"))
+
+	runIntegrationAFOK(t, bin, repoDir, "sessions", "kill", "cli-made")
+	require.True(t, h.refreshExternalInstances(), "TUI refresh should remove CLI-killed session")
+	require.Nil(t, findSidebarInstance(h, "cli-made"))
+}
+
+func findSidebarInstance(h *home, title string) *session.Instance {
+	for _, inst := range h.sidebar.GetInstances() {
+		if inst.Title == title {
+			return inst
+		}
+	}
+	return nil
+}
+
+func buildIntegrationBinary(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	repoRoot := filepath.Dir(filepath.Dir(file))
+	bin := filepath.Join(t.TempDir(), "af")
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", bin, repoRoot)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "go build failed:\n%s", out)
+	return bin
+}
+
+func runIntegrationAFOK(t *testing.T, bin, dir string, args ...string) string {
+	t.Helper()
+	out, err := runIntegrationAF(t, bin, dir, args...)
+	require.NoError(t, err)
+	return out
+}
+
+func runIntegrationAF(t *testing.T, bin, dir string, args ...string) (string, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "TERM=xterm")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return stdout.String(), fmt.Errorf("timed out running af %s; stderr=%s", strings.Join(args, " "), stderr.String())
+	}
+	if err != nil {
+		return stdout.String(), fmt.Errorf("%w; stderr=%s stdout=%s", err, stderr.String(), stdout.String())
+	}
+	return stdout.String(), nil
+}
+
+func writeIntegrationConfig(t *testing.T, home string) {
+	t.Helper()
+	cfg := &config.Config{
+		DefaultProgram:     "cat",
+		AutoYes:            false,
+		DaemonPollInterval: 100,
+		BranchPrefix:       "test/",
+		DetachKeys:         "ctrl-w",
+	}
+	require.NoError(t, config.SaveConfig(cfg))
+}
+
+func killIntegrationDaemon(home string) {
+	raw, err := os.ReadFile(filepath.Join(home, "daemon.pid"))
+	if err != nil {
+		return
+	}
+	var pid int
+	if _, err := fmt.Sscanf(string(raw), "%d", &pid); err != nil || pid <= 1 {
+		return
+	}
+	if proc, err := os.FindProcess(pid); err == nil {
+		_ = proc.Kill()
+	}
+}

--- a/app/e2e_test.go
+++ b/app/e2e_test.go
@@ -41,6 +41,8 @@ type e2eHarness struct {
 	prFetchResp *git.PRInfo
 }
 
+const e2eAsyncTimeout = 5 * time.Second
+
 type prFetchCall struct {
 	repoPath string
 	branch   string
@@ -321,8 +323,12 @@ func (eh *e2eHarness) namingTitle() string {
 // racing SetStatus writes from Update handlers.
 func (eh *e2eHarness) instanceStatus(inst *session.Instance) session.Status {
 	var s session.Status
-	eh.query(func(*home) { s = inst.Status })
+	eh.query(func(*home) { s = inst.GetStatus() })
 	return s
+}
+
+func isActiveStatus(status session.Status) bool {
+	return status == session.Running || status == session.Ready
 }
 
 // ----------------------------------------------------------------------------
@@ -350,7 +356,7 @@ func TestE2E_310_Success_NavigateAwayDuringCreation(t *testing.T) {
 	// handleMenuHighlighting (which re-emits it once for highlighting
 	// bookkeeping), so this lands in stateNew after the second Update cycle.
 	eh.tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
-	eh.waitUntil(time.Second, "state transitions to stateNew", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "state transitions to stateNew", func() bool {
 		return eh.homeState() == stateNew
 	})
 
@@ -358,20 +364,20 @@ func TestE2E_310_Success_NavigateAwayDuringCreation(t *testing.T) {
 	// entries ({k,j,o,n,q,s,a,r,p,h,l}) — handleMenuHighlighting re-emits
 	// any mapped key, which reorders typing in subtle ways.
 	eh.tm.Type("fig")
-	eh.waitUntil(2*time.Second, "title 'fig' fully typed", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "title 'fig' fully typed", func() bool {
 		return eh.namingTitle() == "fig"
 	})
 
 	// Commit with Enter. This fires startCmd (which blocks on FakeBackend).
 	eh.tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-	eh.waitUntil(time.Second, "state returns to stateDefault after Enter", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "state returns to stateDefault after Enter", func() bool {
 		return eh.homeState() == stateDefault
 	})
 
 	// FakeBackend was created by the factory during NewInstance; wait for
 	// Start to be invoked by the creation goroutine.
-	fb := eh.latestBackend(time.Second)
-	eh.waitForStart(fb, time.Second)
+	fb := eh.latestBackend(e2eAsyncTimeout)
+	eh.waitForStart(fb, e2eAsyncTimeout)
 
 	// Creation is now in flight. Grab the creating instance for later
 	// assertions (pointer is stable, so no race on reading .Status).
@@ -384,17 +390,18 @@ func TestE2E_310_Success_NavigateAwayDuringCreation(t *testing.T) {
 	// instance was just added and auto-selected (see startNewInstance), so
 	// a single Up moves us back.
 	eh.tm.Send(tea.KeyMsg{Type: tea.KeyUp})
-	eh.waitUntil(time.Second, "selection moves back to 'other'", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "selection moves back to 'other'", func() bool {
 		return eh.selectedInstance() == other
 	})
 
 	// Unblock Start — creation completes successfully.
 	fb.CompleteStart()
 
-	// Wait for the async instanceStartedMsg handler to flip status. Read
-	// via instanceStatus so the test goroutine doesn't race SetStatus.
-	eh.waitUntil(time.Second, "'fig' status flips to Running", func() bool {
-		return eh.instanceStatus(fig) == session.Running
+	// Wait for the async instanceStartedMsg handler to leave Loading. The
+	// metadata tick may quickly move Running sessions to Ready, so both active
+	// states are valid here.
+	eh.waitUntil(e2eAsyncTimeout, "'fig' leaves Loading", func() bool {
+		return isActiveStatus(eh.instanceStatus(fig))
 	})
 
 	// Core assertions for #310:
@@ -404,8 +411,8 @@ func TestE2E_310_Success_NavigateAwayDuringCreation(t *testing.T) {
 		"no help overlay should be set")
 	assert.Same(t, other, eh.selectedInstance(),
 		"user's selection on 'other' must be preserved across creation completion")
-	assert.Equal(t, session.Running, eh.instanceStatus(fig),
-		"'fig' must still flip to Running even though no modal was shown")
+	assert.True(t, isActiveStatus(eh.instanceStatus(fig)),
+		"'fig' must become active even though no modal was shown")
 }
 
 // TestE2E_310_Success_UserStillOnInstance verifies the counterpart: when
@@ -418,29 +425,29 @@ func TestE2E_310_Success_UserStillOnInstance(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	eh.tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
-	eh.waitUntil(time.Second, "stateNew", func() bool { return eh.homeState() == stateNew })
+	eh.waitUntil(e2eAsyncTimeout, "stateNew", func() bool { return eh.homeState() == stateNew })
 	eh.tm.Type("bee")
-	eh.waitUntil(time.Second, "title typed", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "title typed", func() bool {
 		return eh.namingTitle() == "bee"
 	})
 	eh.tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-	eh.waitUntil(time.Second, "stateDefault", func() bool { return eh.homeState() == stateDefault })
+	eh.waitUntil(e2eAsyncTimeout, "stateDefault", func() bool { return eh.homeState() == stateDefault })
 
-	fb := eh.latestBackend(time.Second)
-	eh.waitForStart(fb, time.Second)
+	fb := eh.latestBackend(e2eAsyncTimeout)
+	eh.waitForStart(fb, e2eAsyncTimeout)
 
 	// User does NOT navigate away — they stay on 'bee'.
 	fb.CompleteStart()
 
 	// The attach-help modal should fire: state flips to stateHelp.
-	eh.waitUntil(time.Second, "state flips to stateHelp", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "state flips to stateHelp", func() bool {
 		return eh.homeState() == stateHelp
 	})
 	assert.False(t, eh.homeTextOverlayNil(), "help overlay must be installed")
 
 	bee := eh.findInstance("bee")
 	require.NotNil(t, bee)
-	assert.Equal(t, session.Running, eh.instanceStatus(bee))
+	assert.True(t, isActiveStatus(eh.instanceStatus(bee)))
 }
 
 // ----------------------------------------------------------------------------
@@ -458,20 +465,20 @@ func TestE2E_310_Failure_DoesNotTouchOtherInstance(t *testing.T) {
 
 	// Kick off creation of 'bug'.
 	eh.tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
-	eh.waitUntil(time.Second, "stateNew", func() bool { return eh.homeState() == stateNew })
+	eh.waitUntil(e2eAsyncTimeout, "stateNew", func() bool { return eh.homeState() == stateNew })
 	eh.tm.Type("bug")
-	eh.waitUntil(time.Second, "title typed", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "title typed", func() bool {
 		return eh.namingTitle() == "bug"
 	})
 	eh.tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-	eh.waitUntil(time.Second, "stateDefault", func() bool { return eh.homeState() == stateDefault })
+	eh.waitUntil(e2eAsyncTimeout, "stateDefault", func() bool { return eh.homeState() == stateDefault })
 
-	fb := eh.latestBackend(time.Second)
-	eh.waitForStart(fb, time.Second)
+	fb := eh.latestBackend(e2eAsyncTimeout)
+	eh.waitForStart(fb, e2eAsyncTimeout)
 
 	// User navigates back to 'other' while 'bug' is mid-creation.
 	eh.tm.Send(tea.KeyMsg{Type: tea.KeyUp})
-	eh.waitUntil(time.Second, "selection back on 'other'", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "selection back on 'other'", func() bool {
 		return eh.selectedInstance() == other
 	})
 
@@ -479,7 +486,7 @@ func TestE2E_310_Failure_DoesNotTouchOtherInstance(t *testing.T) {
 	fb.FailStart(errors.New("simulated launch failure"))
 
 	// Wait for the handler to run RemoveInstanceByTitle.
-	eh.waitUntil(2*time.Second, "'bug' is removed from sidebar", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "'bug' is removed from sidebar", func() bool {
 		return eh.findInstance("bug") == nil
 	})
 
@@ -509,7 +516,7 @@ func TestE2E_311_LazyDebounce_OnSelectionChange(t *testing.T) {
 
 	// Wait for the initial selection-triggered fetch. Freshness age is
 	// sentinel-infinite on process start, so the first selection dispatches.
-	eh.waitUntil(2*time.Second, "first fetch (for 'egg') dispatches", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "first fetch (for 'egg') dispatches", func() bool {
 		return eh.prFetchCount() >= 1
 	})
 	require.Equal(t, []string{"branch-a"}, eh.prFetchBranches(),
@@ -517,7 +524,7 @@ func TestE2E_311_LazyDebounce_OnSelectionChange(t *testing.T) {
 
 	// Navigate down to B — triggers a second selectionChanged and fetch.
 	eh.tm.Send(tea.KeyMsg{Type: tea.KeyDown})
-	eh.waitUntil(2*time.Second, "second fetch (for 'fig') dispatches", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "second fetch (for 'fig') dispatches", func() bool {
 		return eh.prFetchCount() >= 2
 	})
 	assert.Equal(t, []string{"branch-a", "branch-b"}, eh.prFetchBranches())
@@ -548,7 +555,7 @@ func TestE2E_311_TickRefresh_OnlySelectedInstance(t *testing.T) {
 	eh.start()
 
 	// Let the initial selection-triggered fetch complete.
-	eh.waitUntil(2*time.Second, "initial fetch for selected instance", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "initial fetch for selected instance", func() bool {
 		return eh.prFetchCount() >= 1
 	})
 	initial := eh.prFetchCount()
@@ -559,7 +566,7 @@ func TestE2E_311_TickRefresh_OnlySelectedInstance(t *testing.T) {
 	// 60s, too long for a unit test. The handler forces a fetch for the
 	// selected instance regardless of freshness.
 	eh.tm.Send(tickUpdatePRInfoMessage{})
-	eh.waitUntil(2*time.Second, "tick triggers another fetch", func() bool {
+	eh.waitUntil(e2eAsyncTimeout, "tick triggers another fetch", func() bool {
 		return eh.prFetchCount() > initial
 	})
 

--- a/integration/cli_daemon_test.go
+++ b/integration/cli_daemon_test.go
@@ -1,0 +1,578 @@
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+)
+
+type harness struct {
+	t    *testing.T
+	bin  string
+	home string
+	repo string
+}
+
+type instanceData struct {
+	Title       string                 `json:"title"`
+	TmuxName    string                 `json:"tmux_name"`
+	BackendType string                 `json:"backend_type"`
+	RemoteMeta  map[string]interface{} `json:"remote_meta"`
+	Worktree    struct {
+		WorktreePath string `json:"worktree_path"`
+	} `json:"worktree"`
+}
+
+func TestBlackBoxCLIDaemonLifecycle(t *testing.T) {
+	h := newHarness(t)
+
+	created := h.createSession("alpha")
+	if created.Title != "alpha" {
+		t.Fatalf("unexpected create response: %+v", created)
+	}
+
+	socketPath := filepath.Join(h.home, "daemon.sock")
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("daemon socket was not created: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("daemon socket permissions = %o, want 0600", info.Mode().Perm())
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("daemon socket path is not a socket: mode=%s", info.Mode())
+	}
+	if !pidAlive(readDaemonPID(t, h.home)) {
+		t.Fatalf("daemon pid is not alive")
+	}
+
+	assertTitles(t, h.listSessions(), "alpha")
+
+	h.run("sessions", "send-prompt", "alpha", "hello-integration")
+	waitUntil(t, 5*time.Second, "preview contains sent prompt", func() bool {
+		return strings.Contains(h.preview("alpha"), "hello-integration")
+	})
+
+	h.run("sessions", "kill", "alpha")
+	waitUntil(t, 5*time.Second, "session removed from CLI list", func() bool {
+		return !hasTitle(h.listSessions(), "alpha")
+	})
+	if created.TmuxName != "" && tmuxSessionExists(created.TmuxName) {
+		t.Fatalf("tmux session %q still exists after kill", created.TmuxName)
+	}
+	if wt := created.Worktree.WorktreePath; wt != "" {
+		if _, err := os.Stat(wt); !os.IsNotExist(err) {
+			t.Fatalf("worktree %q still exists after kill; stat err=%v", wt, err)
+		}
+	}
+}
+
+func TestConcurrentCLIClientsUseDaemonCoordinator(t *testing.T) {
+	h := newHarness(t)
+
+	// Warm the daemon before stressing concurrent lifecycle operations. This
+	// keeps this test focused on daemon-owned mutation coordination rather than
+	// daemon startup races.
+	h.createSession("warmup")
+
+	var wg sync.WaitGroup
+	distinctErrs := make(chan error, 5)
+	duplicateErrs := make(chan error, 5)
+	for i := 0; i < 5; i++ {
+		name := fmt.Sprintf("parallel-%d", i)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := h.runResult("sessions", "--repo", h.repo, "create", "--name", name, "--program", "cat")
+			distinctErrs <- err
+		}()
+	}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := h.runResult("sessions", "--repo", h.repo, "create", "--name", "dupe", "--program", "cat")
+			duplicateErrs <- err
+		}()
+	}
+	wg.Wait()
+	close(distinctErrs)
+	close(duplicateErrs)
+
+	for err := range distinctErrs {
+		if err != nil {
+			t.Fatalf("distinct concurrent create failed: %v", err)
+		}
+	}
+
+	duplicateSuccesses := 0
+	for err := range duplicateErrs {
+		if err == nil {
+			duplicateSuccesses++
+		} else if !strings.Contains(err.Error(), "already exists") && !strings.Contains(err.Error(), "reserved") {
+			t.Fatalf("unexpected duplicate create error: %v", err)
+		}
+	}
+	if duplicateSuccesses != 1 {
+		t.Fatalf("duplicate create successes = %d, want 1", duplicateSuccesses)
+	}
+
+	sessions := h.listSessions()
+	for i := 0; i < 5; i++ {
+		if !hasTitle(sessions, fmt.Sprintf("parallel-%d", i)) {
+			t.Fatalf("missing parallel-%d in sessions: %+v", i, sessions)
+		}
+	}
+	if got := countTitle(sessions, "dupe"); got != 1 {
+		t.Fatalf("duplicate title records = %d, want 1; sessions=%+v", got, sessions)
+	}
+}
+
+func TestScheduledTaskRunnerUsesDaemonAndAllocatesRerunTitle(t *testing.T) {
+	h := newHarness(t)
+	writeTasksFile(t, h.home, []map[string]interface{}{
+		{
+			"id":           "task-one",
+			"name":         "nightly",
+			"prompt":       "",
+			"cron_expr":    "* * * * *",
+			"project_path": h.repo,
+			"program":      "cat",
+			"enabled":      true,
+			"created_at":   time.Now().Format(time.RFC3339Nano),
+		},
+	})
+
+	h.run("task", "run", "task-one")
+	h.run("task", "run", "task-one")
+
+	sessions := h.listSessions()
+	assertTitles(t, sessions, "nightly", "nightly-2")
+
+	var tasks []struct {
+		ID            string     `json:"id"`
+		LastRunAt     *time.Time `json:"last_run_at"`
+		LastRunStatus string     `json:"last_run_status"`
+	}
+	readJSONFile(t, filepath.Join(h.home, "tasks.json"), &tasks)
+	if len(tasks) != 1 || tasks[0].LastRunAt == nil || tasks[0].LastRunStatus != "started" {
+		t.Fatalf("task status was not updated after run: %+v", tasks)
+	}
+}
+
+func TestDaemonLifecycleRecoversFromStaleSocketAndDeadDaemon(t *testing.T) {
+	h := newHarness(t)
+
+	staleSocket := filepath.Join(h.home, "daemon.sock")
+	if err := os.WriteFile(staleSocket, []byte("not a socket"), 0600); err != nil {
+		t.Fatalf("write stale socket: %v", err)
+	}
+	h.createSession("after-stale-socket")
+	firstPID := readDaemonPID(t, h.home)
+
+	if err := os.Remove(staleSocket); err != nil {
+		t.Fatalf("remove live socket: %v", err)
+	}
+	h.createSession("after-missing-socket")
+	secondPID := readDaemonPID(t, h.home)
+	if secondPID == firstPID {
+		t.Fatalf("daemon PID did not change after live socket was removed; pid=%d", secondPID)
+	}
+
+	killPID(secondPID)
+	waitUntil(t, 5*time.Second, "daemon process exits", func() bool {
+		return !pidAlive(secondPID)
+	})
+	h.createSession("after-dead-daemon")
+	thirdPID := readDaemonPID(t, h.home)
+	if thirdPID == secondPID {
+		t.Fatalf("daemon PID did not change after daemon was killed; pid=%d", thirdPID)
+	}
+
+	assertTitles(t, h.listSessions(), "after-stale-socket", "after-missing-socket", "after-dead-daemon")
+}
+
+func TestRemoteHookImportKillAndFailureModes(t *testing.T) {
+	h := newHarness(t)
+
+	scriptDir := t.TempDir()
+	stateFile := filepath.Join(scriptDir, "remote-state.json")
+	failFile := filepath.Join(scriptDir, "fail-list")
+	deleteLog := filepath.Join(scriptDir, "delete.log")
+
+	writeFile(t, stateFile, `[{"name":"remote-one","title":"Display One","status":"running","host":"h1"},{"name":"remote-two","status":"stopped"}]`, 0644)
+	listCmd := writeScript(t, filepath.Join(scriptDir, "list.sh"), fmt.Sprintf(`
+if [ -f %q ]; then
+  echo "forced list failure" >&2
+  exit 7
+fi
+cat %q
+`, failFile, stateFile))
+	attachCmd := writeScript(t, filepath.Join(scriptDir, "attach.sh"), `echo "preview $1"`)
+	deleteCmd := writeScript(t, filepath.Join(scriptDir, "delete.sh"), fmt.Sprintf(`
+echo "$@" >> %q
+exit 0
+`, deleteLog))
+	launchCmd := writeScript(t, filepath.Join(scriptDir, "launch.sh"), `echo '{"name":"launched"}'`)
+
+	repo, err := config.RepoFromPath(h.repo)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	if err := config.SaveRepoConfig(repo.ID, &config.RepoConfig{
+		RemoteHooks: &config.RemoteHooks{
+			LaunchCmd: launchCmd,
+			ListCmd:   listCmd,
+			AttachCmd: attachCmd,
+			DeleteCmd: deleteCmd,
+		},
+	}); err != nil {
+		t.Fatalf("SaveRepoConfig: %v", err)
+	}
+
+	manager, err := daemon.NewManager(testConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	imported, err := manager.ImportRemoteHookSessions(daemon.ImportRemoteHookSessionsRequest{RepoPath: h.repo})
+	if err != nil {
+		t.Fatalf("ImportRemoteHookSessions: %v", err)
+	}
+	if len(imported) != 1 || imported[0].Title != "Display One" || imported[0].RemoteMeta["name"] != "remote-one" {
+		t.Fatalf("unexpected imported sessions: %+v", imported)
+	}
+
+	imported, err = manager.ImportRemoteHookSessions(daemon.ImportRemoteHookSessionsRequest{RepoPath: h.repo})
+	if err != nil {
+		t.Fatalf("second ImportRemoteHookSessions: %v", err)
+	}
+	if len(imported) != 0 {
+		t.Fatalf("duplicate import should be skipped, got %+v", imported)
+	}
+
+	if err := manager.KillSession(daemon.KillSessionRequest{Title: "Display One", RepoID: repo.ID}); err != nil {
+		t.Fatalf("KillSession remote: %v", err)
+	}
+	deleteArgs := strings.TrimSpace(readFile(t, deleteLog))
+	if !strings.Contains(deleteArgs, "--name remote-one --json") {
+		t.Fatalf("delete hook used wrong remote identity: %q", deleteArgs)
+	}
+
+	writeFile(t, stateFile, `not-json`, 0644)
+	if _, err := manager.ImportRemoteHookSessions(daemon.ImportRemoteHookSessionsRequest{RepoPath: h.repo}); err == nil {
+		t.Fatalf("expected bad JSON from list hook to fail")
+	}
+	writeFile(t, failFile, "fail", 0644)
+	if _, err := manager.ImportRemoteHookSessions(daemon.ImportRemoteHookSessionsRequest{RepoPath: h.repo}); err == nil {
+		t.Fatalf("expected failing list hook command to fail")
+	}
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	requireTool(t, "git")
+	requireTool(t, "tmux")
+
+	home := t.TempDir()
+	if err := os.Setenv("AGENT_FACTORY_HOME", home); err != nil {
+		t.Fatalf("setenv AGENT_FACTORY_HOME: %v", err)
+	}
+	writeConfig(t, home)
+
+	h := &harness{
+		t:    t,
+		bin:  buildBinary(t),
+		home: home,
+		repo: setupGitRepo(t),
+	}
+	t.Cleanup(func() {
+		h.cleanupSessions()
+		killDaemonFromHome(home)
+	})
+	return h
+}
+
+func buildBinary(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Dir(filepath.Dir(file))
+	bin := filepath.Join(t.TempDir(), "af")
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", bin, repoRoot)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func setupGitRepo(t *testing.T) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	runExternal(t, "", "git", "init", repo)
+	runExternal(t, repo, "git", "config", "user.email", "test@example.com")
+	runExternal(t, repo, "git", "config", "user.name", "Test User")
+	runExternal(t, repo, "git", "commit", "--allow-empty", "-m", "init")
+	return repo
+}
+
+func (h *harness) createSession(name string) instanceData {
+	out := h.run("sessions", "--repo", h.repo, "create", "--name", name, "--program", "cat")
+	var data instanceData
+	if err := json.Unmarshal([]byte(out), &data); err != nil {
+		h.t.Fatalf("parse create response: %v\n%s", err, out)
+	}
+	return data
+}
+
+func (h *harness) listSessions() []instanceData {
+	out := h.run("sessions", "--repo", h.repo, "list")
+	var data []instanceData
+	if err := json.Unmarshal([]byte(out), &data); err != nil {
+		h.t.Fatalf("parse list response: %v\n%s", err, out)
+	}
+	return data
+}
+
+func (h *harness) preview(title string) string {
+	out := h.run("sessions", "preview", title)
+	var data map[string]string
+	if err := json.Unmarshal([]byte(out), &data); err != nil {
+		h.t.Fatalf("parse preview response: %v\n%s", err, out)
+	}
+	return data["content"]
+}
+
+func (h *harness) run(args ...string) string {
+	h.t.Helper()
+	out, err := h.runResult(args...)
+	if err != nil {
+		h.t.Fatalf("af %s failed: %v", strings.Join(args, " "), err)
+	}
+	return out
+}
+
+func (h *harness) runResult(args ...string) (string, error) {
+	h.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, h.bin, args...)
+	cmd.Dir = h.repo
+	cmd.Env = append(os.Environ(),
+		"AGENT_FACTORY_HOME="+h.home,
+		"TERM=xterm",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return stdout.String(), fmt.Errorf("timed out; stderr=%s", stderr.String())
+	}
+	if err != nil {
+		return stdout.String(), fmt.Errorf("%w; stderr=%s stdout=%s", err, stderr.String(), stdout.String())
+	}
+	return stdout.String(), nil
+}
+
+func (h *harness) cleanupSessions() {
+	out, err := h.runResult("sessions", "--repo", h.repo, "list")
+	if err != nil {
+		return
+	}
+	var sessions []instanceData
+	if err := json.Unmarshal([]byte(out), &sessions); err != nil {
+		return
+	}
+	for _, item := range sessions {
+		_, _ = h.runResult("sessions", "kill", item.Title)
+		if item.TmuxName != "" && tmuxSessionExists(item.TmuxName) {
+			_ = exec.Command("tmux", "kill-session", fmt.Sprintf("-t=%s", item.TmuxName)).Run()
+		}
+	}
+}
+
+func requireTool(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("%s not available: %v", name, err)
+	}
+}
+
+func runExternal(t *testing.T, dir, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+func writeConfig(t *testing.T, home string) {
+	t.Helper()
+	cfg := testConfig()
+	raw, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	writeFile(t, filepath.Join(home, config.ConfigFileName), string(raw), 0644)
+}
+
+func testConfig() *config.Config {
+	return &config.Config{
+		DefaultProgram:     "cat",
+		AutoYes:            false,
+		DaemonPollInterval: 100,
+		BranchPrefix:       "test/",
+		DetachKeys:         "ctrl-w",
+	}
+}
+
+func writeTasksFile(t *testing.T, home string, tasks []map[string]interface{}) {
+	t.Helper()
+	raw, err := json.MarshalIndent(tasks, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal tasks: %v", err)
+	}
+	writeFile(t, filepath.Join(home, "tasks.json"), string(raw), 0644)
+}
+
+func writeScript(t *testing.T, path, body string) string {
+	t.Helper()
+	writeFile(t, path, "#!/bin/sh\nset -eu\n"+body+"\n", 0755)
+	return path
+}
+
+func writeFile(t *testing.T, path, body string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(raw)
+}
+
+func readJSONFile(t *testing.T, path string, dst interface{}) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := json.Unmarshal(raw, dst); err != nil {
+		t.Fatalf("unmarshal %s: %v\n%s", path, err, raw)
+	}
+}
+
+func waitUntil(t *testing.T, timeout time.Duration, desc string, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s", desc)
+}
+
+func assertTitles(t *testing.T, sessions []instanceData, titles ...string) {
+	t.Helper()
+	for _, title := range titles {
+		if !hasTitle(sessions, title) {
+			t.Fatalf("missing title %q in sessions: %+v", title, sessions)
+		}
+	}
+}
+
+func hasTitle(sessions []instanceData, title string) bool {
+	return countTitle(sessions, title) > 0
+}
+
+func countTitle(sessions []instanceData, title string) int {
+	count := 0
+	for _, item := range sessions {
+		if item.Title == title {
+			count++
+		}
+	}
+	return count
+}
+
+func tmuxSessionExists(name string) bool {
+	return exec.Command("tmux", "has-session", fmt.Sprintf("-t=%s", name)).Run() == nil
+}
+
+func readDaemonPID(t *testing.T, home string) int {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(home, "daemon.pid"))
+	if err != nil {
+		t.Fatalf("read daemon.pid: %v", err)
+	}
+	var pid int
+	if _, err := fmt.Sscanf(string(raw), "%d", &pid); err != nil {
+		t.Fatalf("parse daemon.pid %q: %v", string(raw), err)
+	}
+	return pid
+}
+
+func killDaemonFromHome(home string) {
+	raw, err := os.ReadFile(filepath.Join(home, "daemon.pid"))
+	if err != nil {
+		return
+	}
+	var pid int
+	if _, err := fmt.Sscanf(string(raw), "%d", &pid); err != nil {
+		return
+	}
+	killPID(pid)
+}
+
+func killPID(pid int) {
+	if pid <= 1 {
+		return
+	}
+	proc, err := os.FindProcess(pid)
+	if err == nil {
+		_ = proc.Kill()
+	}
+}
+
+func pidAlive(pid int) bool {
+	if pid <= 1 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -166,6 +166,8 @@ func extractJSON(output string) string {
 }
 
 func (b *HookBackend) Kill(i *Instance) error {
+	slug := hookNameForInstance(i)
+
 	// Mark the instance as stopped BEFORE any resource cleanup so that the
 	// instance is in a consistent state even if delete_cmd fails. Otherwise
 	// the PTY could be closed while started=true, leaving the session
@@ -178,7 +180,6 @@ func (b *HookBackend) Kill(i *Instance) error {
 
 	b.closePTY(i.Title)
 
-	slug := hookNameForInstance(i)
 	args := []string{"--name", slug, "--json"}
 	out, err := exec.Command(b.Hooks.DeleteCmd, args...).CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add black-box CLI/daemon integration coverage for session create/list/send-prompt/preview/kill using the real af binary, daemon process, tmux, and temp git repos.
- Cover concurrent CLI clients, duplicate-title coordination, scheduled task reruns allocating new titles, and daemon recovery from stale sockets or dead daemon processes.
- Add TUI refresh coverage for CLI-created and CLI-killed sessions flowing through daemon-owned state.
- Add remote hook import/kill integration coverage and fix remote delete identity so imported sessions use remote_meta.name when the display title differs.
- Stabilize existing app E2E async waits and status assertions under the race detector on CI.

## Testing
- go test ./integration ./app
- go test ./...
- git diff --check
- go test -race ./...
- go test -v -race -count=1 ./...
