### PR TITLE
test: add release stability gate

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -21,23 +21,43 @@ jobs:
         fetch-depth: 0
         ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+        cache: true
+
     - name: Check for new commits since last tag
       id: check
       run: |
         LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
         if [ -z "$LATEST_TAG" ]; then
           echo "No tags found, should release"
-          echo "should_release=true" >> $GITHUB_OUTPUT
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
         else
-          COMMITS_SINCE=$(git rev-list ${LATEST_TAG}..HEAD --count)
+          COMMITS_SINCE=$(git rev-list "${LATEST_TAG}..HEAD" --count)
           if [ "$COMMITS_SINCE" -gt 0 ]; then
             echo "Found $COMMITS_SINCE new commits since $LATEST_TAG"
-            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
           else
             echo "No new commits since $LATEST_TAG"
-            echo "should_release=false" >> $GITHUB_OUTPUT
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
           fi
         fi
+
+    - name: Release preflight
+      if: steps.check.outputs.should_release == 'true'
+      run: |
+        unformatted=$(gofmt -l .)
+        if [ -n "$unformatted" ]; then
+          echo "::error::Unformatted files found:"
+          echo "$unformatted"
+          gofmt -d .
+          exit 1
+        fi
+        go vet ./...
+        go test -v -race -count=1 ./...
+        go build ./...
 
     - name: Bump version
       id: bump
@@ -52,7 +72,7 @@ jobs:
         NEW_PATCH=$((PATCH + 1))
         NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
         echo "New version: $NEW_VERSION"
-        echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+        echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
         # Update main.go
         sed -i "s/version     = \"${CURRENT}\"/version     = \"${NEW_VERSION}\"/" main.go

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v10.2.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ af -p "aider --model ollama_chat/gemma3:1b"
 
 For general documentation about the original claude-squad project, see [smtg-ai/claude-squad](https://github.com/smtg-ai/claude-squad).
 
+## Release Testing
+
+See [docs/release-testing-plan.md](docs/release-testing-plan.md) for the release gate, manual smoke checks, and artifact verification checklist.
+
 ## License
 
 [GNU AGPL v3](LICENSE.md)

--- a/app/app.go
+++ b/app/app.go
@@ -293,7 +293,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(cmds...)
 	case tickUpdateMetadataMessage:
 		for _, instance := range m.sidebar.GetInstances() {
-			if !instance.Started() || instance.Status == session.Loading {
+			if !instance.Started() || instance.GetStatus() == session.Loading {
 				continue
 			}
 			instance.CheckAndHandleTrustPrompt()
@@ -691,7 +691,7 @@ func (m *home) jumpToInstance(title string) tea.Cmd {
 func (m *home) attachToInstance(title string) (tea.Model, tea.Cmd) {
 	for _, inst := range m.sidebar.GetInstances() {
 		if inst.Title == title {
-			if inst.Status == session.Loading || !inst.TmuxAlive() {
+			if inst.GetStatus() == session.Loading || !inst.TmuxAlive() {
 				return m, m.handleError(fmt.Errorf("instance %q is not ready", title))
 			}
 			m.sidebar.ExpandInstancesSection()

--- a/app/e2e_test.go
+++ b/app/e2e_test.go
@@ -380,7 +380,7 @@ func TestE2E_310_Success_NavigateAwayDuringCreation(t *testing.T) {
 	eh.waitForStart(fb, e2eAsyncTimeout)
 
 	// Creation is now in flight. Grab the creating instance for later
-	// assertions (pointer is stable, so no race on reading .Status).
+	// assertions; status reads go through instanceStatus below.
 	fig := eh.findInstance("fig")
 	require.NotNil(t, fig, "'fig' should be in sidebar while creating")
 	require.Equal(t, session.Loading, eh.instanceStatus(fig),

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -141,7 +141,7 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 // handleKill handles the kill/delete session action.
 func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
-	if selected == nil || selected.Status == session.Loading {
+	if selected == nil || selected.GetStatus() == session.Loading {
 		return m, nil
 	}
 
@@ -206,7 +206,7 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 	// Instance selected
 	if sel.Kind == ui.SectionInstances {
 		selected := m.sidebar.GetSelectedInstance()
-		if selected == nil || selected.Status == session.Loading || !selected.TmuxAlive() {
+		if selected == nil || selected.GetStatus() == session.Loading || !selected.TmuxAlive() {
 			return m, nil
 		}
 		if tw.IsInTerminalTab() {

--- a/app/real_e2e_test.go
+++ b/app/real_e2e_test.go
@@ -156,6 +156,5 @@ func newRealE2EHarness(t *testing.T) *e2eHarness {
 }
 
 // The TUI-level test TestRealTUI_CreateThroughKeypresses lives in
-// real_tui_e2e_test.go (gated with //go:build !race) because it surfaces a
-// pre-existing production race on Instance.Branch — out of scope for the
-// async-issues PR but worth fixing separately.
+// real_tui_e2e_test.go. It drives the same real LocalBackend through
+// Bubble Tea so renderer-facing reads stay covered by the race detector.

--- a/app/real_tui_e2e_test.go
+++ b/app/real_tui_e2e_test.go
@@ -1,20 +1,3 @@
-//go:build !race
-
-// This TUI-level real-backend test is excluded from `go test -race` runs
-// because it surfaces a pre-existing production race in ui.InstanceRenderer
-// (reads instance.Branch from the renderer goroutine without the mutex
-// LocalBackend.Start takes when it writes the same field). That bug is
-// real but out of scope for the async-issues PR; fixing it requires
-// plumbing read locks through the renderer. Leaving the test behind the
-// !race tag so:
-//   - normal `go test ./...` still exercises the real LocalBackend → UI
-//     path (high-value contract check)
-//   - `go test -race ./...` stays clean as a regression signal for
-//     other race-prone changes
-//
-// The session-level TestRealLocalBackend_FullLifecycle in real_e2e_test.go
-// is race-safe and keeps coverage of the LocalBackend itself under -race.
-
 package app
 
 import (

--- a/app/sync.go
+++ b/app/sync.go
@@ -248,7 +248,7 @@ func (m *home) refreshExternalInstances() bool {
 	// Collect removals first to avoid modifying the slice during iteration.
 	var toRemove []*session.Instance
 	for _, inst := range m.sidebar.GetInstances() {
-		if !diskTitles[inst.Title] && inst.Status != session.Loading {
+		if !diskTitles[inst.Title] && inst.GetStatus() != session.Loading {
 			toRemove = append(toRemove, inst)
 		}
 	}

--- a/docs/release-testing-plan.md
+++ b/docs/release-testing-plan.md
@@ -1,0 +1,127 @@
+# Release Testing Plan
+
+This checklist is the release gate for Agent Factory. It focuses on the
+behaviors that can lose user work or leave background resources behind:
+daemon coordination, tmux sessions, git worktrees, scheduled task runs,
+remote hooks, and release artifacts.
+
+## Automated Release Gate
+
+These checks must pass on the release commit before cutting a release:
+
+```bash
+gofmt -l .
+go vet ./...
+go test -v -race -count=1 ./...
+go build ./...
+```
+
+The PR workflow also runs lint, dependency review, CodeQL, and a build job.
+The auto-release workflow runs the release preflight before bumping
+`main.go`, tagging, or publishing artifacts. Workflow linting with
+`actionlint` is part of the local release review because broken workflow
+syntax or retired action runtimes can block CI/release automation.
+
+## Local Preflight
+
+Run this from a clean checkout of `master`:
+
+```bash
+git fetch origin --prune
+git status --short --branch
+go test -v -race -count=1 ./...
+go vet ./...
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+git diff --check
+for goos in linux darwin; do
+  for goarch in amd64 arm64; do
+    GOOS=$goos GOARCH=$goarch go build -o /tmp/af-$goos-$goarch .
+  done
+done
+```
+
+Expected result:
+- Worktree is clean before and after tests.
+- All tests pass.
+- Cross-compiled binaries build for Linux and macOS on amd64 and arm64.
+
+## Functional Coverage Matrix
+
+| Area | Automated coverage | Manual release smoke |
+| --- | --- | --- |
+| CLI session lifecycle | `integration/cli_daemon_test.go` creates, lists, sends prompts, previews, kills, and checks tmux/worktree cleanup through the real CLI and daemon. | Run the commands in "Manual Smoke" against a temp repo. |
+| Daemon coordination | Integration tests cover stale socket recovery, dead daemon restart, duplicate create races, and daemon-owned mutations. | Verify `daemon.sock` and `daemon.pid` are created in a temp `AGENT_FACTORY_HOME`, then removed or replaced after kill/restart. |
+| TUI creation and sync | App E2E tests cover async creation, navigation while creating, TUI refresh seeing CLI changes, and real TUI creation with real tmux/git under the race detector. | Launch `af` in a temp repo, create one `cat` session, switch preview/terminal tabs, then kill it. |
+| Git worktrees | Session/git tests cover worktree naming, collisions, linked worktrees, branch cleanup, prune before delete, and missing paths. | After kill/reset, run `git worktree list` and confirm no test worktree remains. |
+| Scheduled tasks | Unit tests cover cron parsing, systemd/launchd rendering, task CRUD, and task runner storage. Integration tests run the same task twice and verify `name` then `name-2`. | On a Linux machine with systemd user timers, add/list/remove one task and confirm the timer exists then disappears. On macOS, verify launchd plist load/unload on a real host before macOS-targeted releases. |
+| Remote hooks | Session and integration tests cover launch/list/import/attach/delete protocols, bad JSON, command failures, duplicate imports, and imported display-title deletion. | Configure `examples/remote-hooks` or a repo-local fake hook set, import, preview, and delete a remote session. |
+| Reset/cleanup | Unit tests cover ghost sessions and worktree cleanup helpers. | With temp `AGENT_FACTORY_HOME`, create two sessions, run `af reset`, then confirm tmux sessions, worktrees, and stored instances are gone. |
+| Upgrade/release artifacts | Unit tests cover archive extraction and release URL behavior indirectly; CI builds Linux/macOS artifacts. | Download the release tarball for the host platform, unpack it, run `af version`, and test `af upgrade` from the previous release binary. |
+| UI rendering | UI tests cover sidebar/menu/task pane/preview/terminal layout and overlay behavior. | Open the TUI in a narrow terminal and a normal terminal, verify text does not overlap, and check help/confirmation overlays. |
+
+## Manual Smoke
+
+Use an isolated config directory so release testing cannot touch real user
+sessions:
+
+```bash
+tmp_home=$(mktemp -d)
+tmp_repo=$(mktemp -d)
+export AGENT_FACTORY_HOME="$tmp_home"
+
+git -C "$tmp_repo" init
+git -C "$tmp_repo" config user.email test@example.com
+git -C "$tmp_repo" config user.name "Release Test"
+git -C "$tmp_repo" commit --allow-empty -m init
+
+go build -o /tmp/af-release-smoke .
+/tmp/af-release-smoke version
+/tmp/af-release-smoke debug
+
+/tmp/af-release-smoke sessions --repo "$tmp_repo" create --name smoke --program cat
+/tmp/af-release-smoke sessions --repo "$tmp_repo" list
+/tmp/af-release-smoke sessions send-prompt smoke "release-smoke"
+/tmp/af-release-smoke sessions preview smoke
+/tmp/af-release-smoke sessions kill smoke
+/tmp/af-release-smoke sessions --repo "$tmp_repo" list
+```
+
+Expected result:
+- `preview` contains `release-smoke` before kill.
+- `list` is empty after kill.
+- No `af_` tmux session or generated worktree remains for the smoke repo.
+
+## Release Artifact Verification
+
+After the release workflow publishes:
+
+```bash
+gh release view --repo sachiniyer/agent-factory --latest
+gh release download --repo sachiniyer/agent-factory --latest --pattern 'agent-factory-*.tar.gz' --dir /tmp/af-release
+for archive in /tmp/af-release/*.tar.gz; do
+  tar tzf "$archive"
+done
+```
+
+Expected result:
+- Artifacts exist for `linux-amd64`, `linux-arm64`, `darwin-amd64`, and
+  `darwin-arm64`.
+- Each archive contains one executable named `agent-factory`.
+- The host-platform binary runs `version` and reports the new tag.
+
+## Go/No-Go Criteria
+
+Do not cut or publish a release if any of these are true:
+- Any required CI check is failing or pending.
+- Local `go test -v -race -count=1 ./...` fails.
+- Manual smoke leaves behind tmux sessions, worktrees, or stale storage.
+- The release workflow cannot build all four artifacts.
+- There is an open issue or PR marked as a release blocker.
+
+Non-blocking, known limits:
+- Real Claude/Aider/Codex/Gemini interactive behavior is not fully automated;
+  tests use `cat` and fake backends for deterministic runs.
+- Real systemd and launchd scheduling should be manually smoke-tested on their
+  native OS before a release that changes scheduler code.
+- `af upgrade` requires a published release asset, so end-to-end upgrade is a
+  post-publish verification step.

--- a/ui/list.go
+++ b/ui/list.go
@@ -118,7 +118,7 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 
 	// add spinner next to title if it's running
 	var join string
-	switch i.Status {
+	switch i.GetStatus() {
 	case session.Running, session.Loading:
 		join = fmt.Sprintf("%s ", r.spinner.View())
 	case session.Ready:

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -164,7 +164,7 @@ func (m *Menu) updateOptions() {
 
 func (m *Menu) addInstanceOptions() {
 	// Loading instances only get minimal options
-	if m.instance != nil && m.instance.Status == session.Loading {
+	if m.instance != nil && m.instance.GetStatus() == session.Loading {
 		m.options = []keys.KeyName{keys.KeyNew, keys.KeyHelp, keys.KeyQuit}
 		m.groups = []menuGroup{
 			{start: 0, end: 3, isAction: false},

--- a/ui/preview.go
+++ b/ui/preview.go
@@ -54,7 +54,7 @@ func (p *PreviewPane) UpdateContent(instance *session.Instance) error {
 	case instance == nil:
 		p.setFallbackState("No agents running yet. Spin up a new instance with 'n' to get started!")
 		return nil
-	case instance.Status == session.Loading:
+	case instance.GetStatus() == session.Loading:
 		p.setFallbackState("Setting up workspace...")
 		return nil
 	}

--- a/upgrade_test.go
+++ b/upgrade_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"strings"
+	"testing"
+)
+
+func TestExtractBinaryFromTarGz(t *testing.T) {
+	archive := makeTarGz(t, map[string][]byte{
+		"agent-factory": []byte("binary-content"),
+		"README":        []byte("not the binary"),
+	})
+
+	got, err := extractBinaryFromTarGz(bytes.NewReader(archive), "agent-factory")
+	if err != nil {
+		t.Fatalf("extractBinaryFromTarGz returned error: %v", err)
+	}
+	if string(got) != "binary-content" {
+		t.Fatalf("extracted %q, want binary-content", string(got))
+	}
+}
+
+func TestExtractBinaryFromTarGzNestedPath(t *testing.T) {
+	archive := makeTarGz(t, map[string][]byte{
+		"dist/agent-factory": []byte("nested-binary"),
+	})
+
+	got, err := extractBinaryFromTarGz(bytes.NewReader(archive), "agent-factory")
+	if err != nil {
+		t.Fatalf("extractBinaryFromTarGz returned error: %v", err)
+	}
+	if string(got) != "nested-binary" {
+		t.Fatalf("extracted %q, want nested-binary", string(got))
+	}
+}
+
+func TestExtractBinaryFromTarGzMissingBinary(t *testing.T) {
+	archive := makeTarGz(t, map[string][]byte{
+		"other": []byte("content"),
+	})
+
+	_, err := extractBinaryFromTarGz(bytes.NewReader(archive), "agent-factory")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestExtractBinaryFromTarGzInvalidGzip(t *testing.T) {
+	_, err := extractBinaryFromTarGz(strings.NewReader("not gzip"), "agent-factory")
+	if err == nil || !strings.Contains(err.Error(), "gzip") {
+		t.Fatalf("expected gzip error, got %v", err)
+	}
+}
+
+func makeTarGz(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, data := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0755,
+			Size: int64(len(data)),
+		}); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatalf("write tar data: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary
- add a documented release testing plan covering daemon coordination, tmux/worktree cleanup, scheduled tasks, remote hooks, UI smoke, and artifact verification
- make the auto-release workflow run a Go preflight before bumping, tagging, or publishing
- bring the real TUI creation test into `-race` coverage by replacing concurrent app/UI status reads with `GetStatus()`
- add upgrade archive extraction tests and update the stale workflow action runtime

## Testing
- `unformatted=$(gofmt -l .); if [ -n "$unformatted" ]; then printf '%s\n' "$unformatted"; gofmt -d .; exit 1; fi; go vet ./...; go test -v -race -count=1 ./...; go build ./...`
- `go test -count=1 ./...`
- `go test -count=1 -coverprofile=/tmp/af-coverage.out ./...` and `go tool cover -func=/tmp/af-coverage.out` reported total statement coverage 45.5%; `upgrade.go:extractBinaryFromTarGz` is now 80.0%
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --check`
- cross-builds: `GOOS=linux GOARCH=amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`
- manual CLI smoke with temp `AGENT_FACTORY_HOME` and temp git repo: `version`, `debug`, `sessions create --program cat`, `list`, `send-prompt`, `preview`, `kill`, final empty list, and no smoke tmux leak

## Release Notes
- Current latest release is v1.0.58; this should auto-bump to v1.0.59 after merge.
- There are no open PRs at the time of this PR.
- The only open issue found is #386, a session-resume feature request; I do not consider it a release blocker.
