### PR TITLE
ci: opt into Node 24 actions runtime

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 */3 * * *'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
       - 'go.sum'
       - '.github/workflows/build.yml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     name: Build Binary and Test

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #
 # permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
       - 'go.sum'
       - '.github/workflows/lint.yml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,9 @@ on:
   schedule:
   - cron: '15 8 * * *'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   stale:
 


### PR DESCRIPTION
## Summary
- opt all repository workflows into GitHub Actions' Node 24 JavaScript action runtime using `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`
- keep the current action major versions for now so this validates the upcoming runner behavior without broad workflow dependency churn

## Why
The post-merge push workflows for #438 passed, but GitHub emitted Node.js 20 deprecation annotations for checkout/setup-go/upload-artifact/golangci-lint actions. This PR makes CI run under the upcoming Node 24 behavior now so we catch incompatibilities before the release.

## Testing
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --check`
- PR CI should confirm the Node 24 runtime path across lint/test/build/dependency-review/CodeQL.
