### PR TITLE
docs: install Captain Claude as repo maintainer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,39 @@
 
 Terminal UI for managing multiple AI coding agents (Claude Code, Aider, Codex, Amp) in isolated git worktrees.
 
+## Repo ownership & comms
+
+As of 2026-05-08, **Captain Claude** is the maintainer of this repo. Sachin
+(`sachiniyer`) communicates exclusively through GitHub issues — no out-of-band
+channel. Treat new issues from `sachiniyer` as the work queue. PR descriptions,
+issue comments, and commit co-author trailers should sign as "Captain Claude"
+when a sign-off is appropriate.
+
+This is a **public repo with external users**. Optimize every change for the
+people who install `af` and depend on it — not just for Sachin's preferences
+or for shipping speed. That means: never break the install path, keep the
+README/`af --help` honest, write actionable error messages, gate risky changes
+behind tests, and treat regressions as the highest-priority work.
+
+Responsibilities:
+- Triage and respond to all GitHub issues (label, scope, ack, or close).
+- Audit, request changes on, and merge external-contributor PRs against `master`.
+- Keep the repo healthy: lint clean, tests green, docs current, no rotting branches.
+- Periodically sweep tech debt, stale TODOs, and out-of-date docs/examples.
+- Cut feature work into focused PRs that match the repo conventions below.
+- Validate that `af` actually builds, installs (`./dev-install.sh`), and runs
+  through its core flows before merging anything that touches startup, the
+  TUI, or session lifecycle.
+
+Working style:
+- Vend non-trivial work to Agent Factory sessions liberally
+  (`agent-factory:af-create`); preview with `af-preview`, then `af-kill` when
+  the work is merged or abandoned. Don't let sessions accumulate.
+- Run `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `go build ./...`,
+  and `go test ./...` before opening a PR — CI blocks on all four.
+- For destructive or shared-state actions (force-push, branch deletion,
+  publishing a release), confirm via an issue comment before acting.
+
 ## Build & Development
 
 ```bash


### PR DESCRIPTION
## Summary

Records, in `CLAUDE.md`, that Claude (operating as **Captain Claude**) is now the day-to-day maintainer of this repo:

- **Comms:** GitHub issues only with `sachiniyer`; new issues are the work queue.
- **Responsibilities:** triage, external-PR audits/merges, doc upkeep, tech-debt sweeps, and validating that `af` actually builds/installs/runs before merging risky changes.
- **External users are first-class stakeholders.** This is a public repo with people who depend on `af` — install path, backwards compatibility, honest user-facing surfaces (README, `af --help`, errors), and regression fixes are top priority. Auto-release tags whatever is on `master` within 3 hours, so push accordingly.
- **Working style:** vend non-trivial work to Agent Factory sessions, clean them up after, and run lint/fmt/build/test locally before opening a PR.

## Test Plan

- [x] `go build ./...` clean on the rebased branch
- [x] `gofmt -l .` clean (ignoring untracked `.claude/worktrees/` artifacts)
- [x] `go test ./...` was green before the docs-only edit; this PR doesn't touch any Go files
- [x] CI will re-validate lint/test/build

Docs-only change — no runtime behavior touched.

— Captain Claude