### PR TITLE
fix(tmux): re-spawn session on Restore when tmux session missing (#386)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -81,8 +81,18 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 	}()
 
 	if !firstTimeSetup {
-		// Reuse existing session
-		if err := tmuxSession.Restore(); err != nil {
+		// Reuse existing session. Pass the worktree path so Restore can
+		// re-spawn the tmux session if the server died across a reboot
+		// (see #386). When the worktree is unavailable (e.g. tests inject
+		// a tmux session without a gitWorktree), pass empty string.
+		i.mu.RLock()
+		gw := i.gitWorktree
+		i.mu.RUnlock()
+		var workDir string
+		if gw != nil {
+			workDir = gw.GetWorktreePath()
+		}
+		if err := tmuxSession.Restore(workDir); err != nil {
 			setupErr = fmt.Errorf("failed to restore existing session: %w", err)
 			return setupErr
 		}

--- a/session/tmux/race_test.go
+++ b/session/tmux/race_test.go
@@ -33,7 +33,7 @@ func TestCloseDuringAttachRace(t *testing.T) {
 		}
 
 		session := newTmuxSession(toTmuxName("race-session", ""), "claude", ptyFactory, cmdExec)
-		if err := session.Restore(); err != nil {
+		if err := session.Restore(""); err != nil {
 			t.Fatalf("Restore: %v", err)
 		}
 
@@ -88,7 +88,7 @@ func TestCloseWithoutAttach(t *testing.T) {
 	}
 
 	session := newTmuxSession(toTmuxName("no-attach-session", ""), "claude", ptyFactory, cmdExec)
-	if err := session.Restore(); err != nil {
+	if err := session.Restore(""); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
 

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -189,7 +189,9 @@ func (t *TmuxSession) Start(workDir string) error {
 		log.InfoLog.Printf("Warning: failed to enable mouse scrolling for session %s: %v", t.sanitizedName, err)
 	}
 
-	err = t.Restore()
+	// Attach to the session we just created. Pass empty workDir so a missing
+	// session here surfaces as an error rather than recursively re-spawning.
+	err = t.Restore("")
 	if err != nil {
 		if cleanupErr := t.Close(); cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
@@ -229,8 +231,22 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 	return false
 }
 
-// Restore attaches to an existing session and restores the window size
-func (t *TmuxSession) Restore() error {
+// Restore attaches to an existing tmux session. If the session is missing
+// (e.g. the tmux server died after a machine reboot, see #386) and workDir is
+// non-empty, a fresh session is spawned in workDir using the same program so
+// persisted instances can resume across reboots. If the session is missing
+// and workDir is empty, the missing-session condition is surfaced as an error;
+// real failures (PTY open errors, Start failures such as missing binaries or
+// vanished worktrees) are always surfaced.
+func (t *TmuxSession) Restore(workDir string) error {
+	if !t.DoesSessionExist() {
+		if workDir == "" {
+			return fmt.Errorf("tmux session %q does not exist", t.sanitizedName)
+		}
+		log.InfoLog.Printf("tmux session %q missing on Restore; re-spawning in %s", t.sanitizedName, workDir)
+		return t.Start(workDir)
+	}
+
 	ptmx, err := t.ptyFactory.Start(exec.Command("tmux", "attach-session", "-t", t.sanitizedName))
 	if err != nil {
 		return fmt.Errorf("error opening PTY: %w", err)
@@ -470,8 +486,10 @@ func (t *TmuxSession) Detach() {
 	}
 
 	// Attach goroutines should die due to the ptmx closing. Call
-	// t.Restore to set a new t.ptmx.
-	if err := t.Restore(); err != nil {
+	// t.Restore to set a new t.ptmx. The session is alive (we just detached
+	// from it), so pass empty workDir — a missing session here is a real
+	// problem and should surface, not silently re-spawn and lose history.
+	if err := t.Restore(""); err != nil {
 		log.ErrorLog.Printf("error restoring pty after detach: %v", err)
 	}
 

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -11,9 +11,18 @@ import (
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	aflog "github.com/sachiniyer/agent-factory/log"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestMain initializes the logger so tests that exercise paths writing to
+// InfoLog/ErrorLog (e.g. Restore's re-spawn fallback) do not nil-deref.
+func TestMain(m *testing.M) {
+	aflog.Initialize(false)
+	defer aflog.Close()
+	os.Exit(m.Run())
+}
 
 type MockPtyFactory struct {
 	t *testing.T
@@ -61,6 +70,119 @@ func TestSanitizeName(t *testing.T) {
 	// FromSanitizedName preserves exact name
 	session3 := NewTmuxSessionFromSanitizedName("af_custom_name", "program")
 	require.Equal(t, "af_custom_name", session3.sanitizedName)
+}
+
+// errPtyFactory is a PtyFactory that fails Start(). Used to verify Restore
+// surfaces non-missing-session errors from the PTY layer.
+type errPtyFactory struct {
+	err error
+}
+
+func (e errPtyFactory) Start(_ *exec.Cmd) (*os.File, error) { return nil, e.err }
+func (e errPtyFactory) Close()                              {}
+
+// TestRestoreAttachesWhenSessionExists covers issue #386 case (a): when the
+// tmux session is alive, Restore must attach to it (not re-spawn) regardless
+// of whether a workDir was supplied.
+func TestRestoreAttachesWhenSessionExists(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+
+	cmdExec := cmd_test.MockCmdExec{
+		// All cmdExec.Run calls succeed → has-session reports the session exists.
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+	}
+
+	session := newTmuxSession(toTmuxName("existing", ""), "claude", ptyFactory, cmdExec)
+
+	require.NoError(t, session.Restore("/some/work/dir"))
+
+	require.Equal(t, 1, len(ptyFactory.cmds), "expected exactly one PTY command (attach-session)")
+	require.Equal(t, "tmux attach-session -t af_existing", cmd2.ToString(ptyFactory.cmds[0]))
+}
+
+// TestRestoreRespawnsWhenSessionMissing covers issue #386 case (b): when the
+// tmux server has died (e.g. across a machine reboot) the session is gone but
+// the worktree on disk is fine. Restore must transparently re-spawn the
+// session in workDir using the same program.
+func TestRestoreRespawnsWhenSessionMissing(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+
+	// First two has-session calls report missing (the outer Restore check, then
+	// the existence check at the top of Start). After tmux new-session runs via
+	// the PTY factory, subsequent has-session calls report exists so Start's
+	// poll loop and the inner Restore("") call can succeed.
+	hasSessionCalls := 0
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				hasSessionCalls++
+				if hasSessionCalls <= 2 {
+					return fmt.Errorf("can't find session")
+				}
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+	}
+
+	workdir := t.TempDir()
+	session := newTmuxSession(toTmuxName("missing", ""), "claude", ptyFactory, cmdExec)
+
+	require.NoError(t, session.Restore(workdir))
+
+	require.Equal(t, 2, len(ptyFactory.cmds),
+		"expected new-session followed by attach-session via PTY")
+	require.Equal(t,
+		fmt.Sprintf("tmux new-session -d -s af_missing -c %s claude", workdir),
+		cmd2.ToString(ptyFactory.cmds[0]))
+	require.Equal(t, "tmux attach-session -t af_missing", cmd2.ToString(ptyFactory.cmds[1]))
+}
+
+// TestRestoreSurfacesPtyError covers issue #386 case (c): real failures
+// distinct from "session does not exist" — here a PTY allocation failure on
+// the attach path — must propagate to the caller unchanged so an operator
+// can act on them rather than silently fall back to a re-spawn.
+func TestRestoreSurfacesPtyError(t *testing.T) {
+	ptyFactory := errPtyFactory{err: fmt.Errorf("pty allocation failed")}
+
+	cmdExec := cmd_test.MockCmdExec{
+		// Session exists → Restore takes the attach branch where PTY error fires.
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+	}
+
+	session := newTmuxSession(toTmuxName("ptyerr", ""), "claude", ptyFactory, cmdExec)
+
+	err := session.Restore("/some/work/dir")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pty allocation failed")
+}
+
+// TestRestoreReturnsErrorWhenSessionMissingAndNoWorkDir guards the contract
+// used by Detach() and Start()'s internal Restore("") call: when no workDir
+// is provided, a missing session is a real error and must not silently
+// re-spawn (which would lose history on Detach or recurse infinitely from
+// Start).
+func TestRestoreReturnsErrorWhenSessionMissingAndNoWorkDir(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				return fmt.Errorf("can't find session")
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+	}
+
+	session := newTmuxSession(toTmuxName("gone", ""), "claude", ptyFactory, cmdExec)
+
+	err := session.Restore("")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not exist")
+	require.Equal(t, 0, len(ptyFactory.cmds), "expected no PTY commands when no workDir is provided")
 }
 
 func TestStartTmuxSession(t *testing.T) {

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -177,9 +177,11 @@ func (t *TerminalPane) ensureSessionLocked(instance *session.Instance) error {
 	termName := "term_" + instance.Title
 	ts := newTerminalTmuxSessionForRepo(termName, worktreePath, shell)
 
-	// Check if session already exists (e.g. from a previous run)
+	// Check if session already exists (e.g. from a previous run). Pass empty
+	// workDir so Restore() does not silently re-spawn — this caller already
+	// has its own kill-and-restart fallback below.
 	if ts.DoesSessionExist() {
-		if err := ts.Restore(); err != nil {
+		if err := ts.Restore(""); err != nil {
 			// Session exists but can't restore, kill it and start fresh
 			if closeErr := ts.Close(); closeErr != nil {
 				if ts.DoesSessionExist() {


### PR DESCRIPTION
## Summary

Fixes #386. Persisted instances now resume after a machine reboot kills the tmux server.

- `TmuxSession.Restore` now takes a `workDir` argument and detects the
  missing-session condition via `tmux has-session` before attaching.
  When the session is missing and `workDir` is non-empty, it transparently
  re-spawns a fresh session in that worktree using the same program.
- `LocalBackend.Start` passes the worktree path through so a reboot no
  longer leaves every saved instance in a failed state.
- Empty `workDir` preserves the prior "surface the error" semantics, which
  is what `Detach()` and `Start()`'s internal `Restore("")` call rely on
  (avoids silent re-spawn that would lose history, and avoids infinite
  recursion from `Start`).
- Real failures (PTY allocation errors, vanished worktrees, missing
  binaries) continue to surface unchanged.

## Test Plan

- [x] `go test ./...` passes (full suite, including new tests below)
- [x] `go test -race ./...` passes (CI gate)
- [x] `gofmt -l .` is clean
- [x] `golangci-lint run --timeout=3m --fast` is clean
- [x] `go build ./...` clean

New unit tests in `session/tmux/tmux_test.go`, fakes tmux via the
`cmdExec` and `PtyFactory` abstractions:

- [x] `TestRestoreAttachesWhenSessionExists` — existing sessions still
  attach normally (no regression).
- [x] `TestRestoreRespawnsWhenSessionMissing` — when `tmux has-session`
  reports missing, Restore spawns `tmux new-session` in the supplied
  workDir then attaches (the #386 path).
- [x] `TestRestoreSurfacesPtyError` — non-missing-session errors (PTY
  allocation failure here) propagate unchanged.
- [x] `TestRestoreReturnsErrorWhenSessionMissingAndNoWorkDir` — guards
  the `Detach()` / inner-`Start` contract: empty `workDir` still errors
  on missing session rather than silently re-spawning.

## Manual verification suggestion

1. `af` start a session in a worktree.
2. `tmux kill-server` to simulate the reboot scenario.
3. Restart `af` — the session should resume in a fresh tmux session
   pointing at the same worktree, with the same program.

Co-authored-by: Captain Claude