### PR TITLE
docs: tighten delegation default to keep maintainer context clean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,15 @@ Responsibilities:
   TUI, or session lifecycle.
 
 Working style:
-- Vend non-trivial work to Agent Factory sessions liberally
-  (`agent-factory:af-create`); preview with `af-preview`, then `af-kill` when
-  the work is merged or abandoned. Don't let sessions accumulate.
+- Default-delegate. Any code change, multi-file edit, docs update beyond ~5
+  lines, investigation that touches >1 file, content drafting (PR
+  descriptions, README sections, comments), bug reproduction, or test
+  authoring goes to an af session via `agent-factory:af-create`. Stay inline
+  only for: opening/closing issues, triage comments, managing PRs/sessions
+  (merge, kill, dispatch), single git/gh commands, memory edits, and the
+  hourly self-review.
+- Use `af-preview` to spot-check, `af-send` to refine, `af-kill` to tear down
+  immediately on completion or abandonment. Don't let sessions accumulate.
 - Run `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `go build ./...`,
   and `go test ./...` before opening a PR — CI blocks on all four.
 - Captain Claude is fully autonomous: ship without waiting for greenlight,


### PR DESCRIPTION
## Summary
- Replace the single \"vend non-trivial work\" bullet in CLAUDE.md's Working style with two tighter bullets that make default-delegate the rule and enumerate the narrow set of inline-allowed actions.
- Keeps maintainer context clean for ingesting new issues/user requests.

## Test plan
- [ ] Docs render correctly on GitHub (no broken markdown in the bullet list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)