### PR TITLE
ci: add minimal permissions blocks to PR validation workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
       - 'go.sum'
       - '.github/workflows/build.yml'
 
+# Read-only: workflow only checks out source, runs tests, and uploads artifacts (artifact upload uses the Actions API, not repo contents).
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Binary and Test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,10 @@ on:
       - 'go.sum'
       - '.github/workflows/lint.yml'
 
+# Read-only: workflow only checks out source and runs golangci-lint + gofmt.
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,10 @@ concurrency:
   group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Read-only: workflow only checks out source and runs lint/test/build; it never comments on or modifies the PR.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
## Summary

Closes the 5 open code-scanning alerts under the `actions/missing-workflow-permissions` rule.

The PR validation workflows (`build.yml`, `lint.yml`, `pr.yml`) had no explicit top-level `permissions:` block, so `GITHUB_TOKEN` inherited the repo default — broader than each workflow actually needs.

Per-file scopes set:

- **`.github/workflows/build.yml`** → `contents: read`. Checks out source, runs `go test`, builds the binary matrix, uploads artifacts. Artifact upload uses the Actions API (not repo contents), so read-only is sufficient.
- **`.github/workflows/lint.yml`** → `contents: read`. Checks out source, runs `golangci-lint` (via `go run`, not the action) and `gofmt`. No PR/comment surface.
- **`.github/workflows/pr.yml`** → `contents: read`. Checks out source, runs lint/test/build. Uses `go run github.com/golangci/golangci-lint/...` directly rather than `golangci-lint-action` with `only-new-issues`, so `pull-requests: read` is **not** required here.

`auto-release.yml` is intentionally untouched — it already declares `contents: write`, which it legitimately needs for tagging releases.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` parses each workflow
- [x] `gofmt -l .` clean (no Go files touched)
- [x] `go build ./...` clean
- [x] `golangci-lint run --fast` clean
- [ ] CI runs the workflows on this PR — confirms `contents: read` is sufficient for all three
- [ ] CodeQL alerts auto-close on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)