### PR TITLE
docs(examples): add GitHub issue listener that auto-creates af sessions (#450)

### DIFF
--- a/examples/github-issue-listener/README.md
+++ b/examples/github-issue-listener/README.md
@@ -1,0 +1,98 @@
+# GitHub Issue Listener
+
+A small polling script that watches a GitHub repo for newly opened issues and spawns an Agent Factory session for each one. Each session is named `issue-<number>` and seeded with the issue's title and body as its prompt.
+
+## Prerequisites
+
+- `gh` authenticated against the target repo (`gh auth status` should report you as logged in).
+- `jq` on `PATH`.
+- `af` on `PATH` (`./dev-install.sh` from the repo root).
+
+## Quick start
+
+```bash
+export REPO=owner/name           # required
+export POLL_INTERVAL=60          # optional
+export LABEL=agent-factory       # optional — only spawn for issues with this label
+./listen.sh
+```
+
+The first run records the current UTC timestamp in the state file and only reacts to issues opened after that. Historical issues are not backfilled.
+
+## Configuration
+
+| Var | Default | Meaning |
+|---|---|---|
+| `REPO` | — (required) | Repo to watch, in `owner/name` form. |
+| `POLL_INTERVAL` | `60` | Seconds to sleep between polls. |
+| `STATE_FILE` | `$HOME/.agent-factory/issue-listener-state` | Cursor file. Holds the UTC timestamp of the last poll. Delete it to reset. |
+| `LABEL` | unset | If set, only issues carrying this label spawn a session. |
+
+## Run it persistently
+
+The project's `task/` directory has fuller systemd / launchd integration for scheduled jobs; the snippets below are standalone and have no dependency on it.
+
+### Linux — systemd user unit
+
+`~/.config/systemd/user/af-issue-listener.service`:
+
+```ini
+[Unit]
+Description=Agent Factory GitHub issue listener
+After=network-online.target
+
+[Service]
+Type=simple
+Environment=REPO=owner/name
+Environment=LABEL=agent-factory
+ExecStart=%h/path/to/listen.sh
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now af-issue-listener.service
+journalctl --user -u af-issue-listener -f
+```
+
+### macOS — launchd plist
+
+`~/Library/LaunchAgents/dev.agent-factory.issue-listener.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>dev.agent-factory.issue-listener</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/you/path/to/listen.sh</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>REPO</key><string>owner/name</string>
+        <key>LABEL</key><string>agent-factory</string>
+    </dict>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>StandardOutPath</key><string>/tmp/af-issue-listener.out</string>
+    <key>StandardErrorPath</key><string>/tmp/af-issue-listener.err</string>
+</dict>
+</plist>
+```
+
+```bash
+launchctl load ~/Library/LaunchAgents/dev.agent-factory.issue-listener.plist
+```
+
+## Caveats
+
+- **Cost.** Every new issue spawns a session, which runs your configured AI agent against your account. Set `LABEL` to opt in selectively rather than dispatching on every issue.
+- **Idempotence.** If a session named `issue-<n>` already exists, `af sessions create` fails and the script logs and continues. Re-running on a repo with existing matching session names will not double-spawn.
+- **Trust.** Anyone who can open an issue on the watched repo can effectively dispatch a session on your machine. Don't point this at repos with untrusted issue authors unless you're comfortable with that.
+- **Closed/triaged issues.** The script only reacts to *newly opened* issues — those whose `created_at` is after the cursor in the state file. Existing open issues are never picked up, even after a restart. Delete the state file to reset the cursor (this will pick up any issues opened after the new initial timestamp, not historical ones).

--- a/examples/github-issue-listener/listen.sh
+++ b/examples/github-issue-listener/listen.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Poll a GitHub repo for newly opened issues and spawn an Agent Factory
+# session for each one.
+#
+# Env:
+#   REPO            owner/name of the repo to watch (required)
+#   POLL_INTERVAL   seconds between polls (default: 60)
+#   STATE_FILE      path to the cursor file (default: $HOME/.agent-factory/issue-listener-state)
+#   LABEL           if set, only spawn for issues carrying this label
+#
+# Logs go to stderr. Stdout is reserved for future structured output.
+
+set -euo pipefail
+
+: "${REPO:?REPO is required (e.g. owner/name)}"
+POLL_INTERVAL="${POLL_INTERVAL:-60}"
+STATE_FILE="${STATE_FILE:-$HOME/.agent-factory/issue-listener-state}"
+LABEL="${LABEL:-}"
+
+log() { printf '[issue-listener] %s\n' "$*" >&2; }
+
+shutdown() {
+  log "shutting down"
+  exit 0
+}
+trap shutdown SIGTERM SIGINT
+
+now_utc() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+mkdir -p "$(dirname "$STATE_FILE")"
+if [[ ! -f "$STATE_FILE" ]]; then
+  now_utc > "$STATE_FILE"
+  log "initialized state file at $STATE_FILE; only issues opened after $(cat "$STATE_FILE") will be picked up"
+fi
+
+log "watching $REPO every ${POLL_INTERVAL}s${LABEL:+ (label: $LABEL)}"
+
+while true; do
+  since="$(cat "$STATE_FILE")"
+  next="$(now_utc)"
+
+  # $since is a jq variable; LABEL is read from the env. Quoting is correct.
+  # shellcheck disable=SC2016
+  jq_filter='.[] | select(.pull_request | not) | select(.created_at >= $since)'
+  if [[ -n "$LABEL" ]]; then
+    # shellcheck disable=SC2016
+    jq_filter="$jq_filter"' | select(.labels | map(.name) | index(env.LABEL))'
+  fi
+  # shellcheck disable=SC2016
+  jq_filter="$jq_filter"' | {number, title, body}'
+
+  if ! issues_json="$(gh api \
+      "repos/$REPO/issues?since=$since&state=open&per_page=100" \
+      --paginate 2>/dev/null \
+    | jq -c --arg since "$since" "$jq_filter")"; then
+    log "gh api call failed; will retry next tick"
+    sleep "$POLL_INTERVAL"
+    continue
+  fi
+
+  if [[ -n "$issues_json" ]]; then
+    while IFS= read -r issue; do
+      [[ -z "$issue" ]] && continue
+      number="$(printf '%s' "$issue" | jq -r '.number')"
+      title="$(printf '%s' "$issue" | jq -r '.title')"
+      body="$(printf '%s' "$issue" | jq -r '.body // ""')"
+      session_name="issue-$number"
+
+      if [[ -z "$body" ]]; then
+        body='(no issue body — use the title as the spec)'
+      fi
+      prompt="$(printf '%s\n\n%s' "$title" "$body")"
+
+      log "spawning session $session_name for issue #$number: $title"
+      if ! af sessions create --name "$session_name" --prompt "$prompt" >/dev/null 2>&1; then
+        log "af sessions create failed for $session_name (already exists?); skipping"
+      fi
+    done < <(printf '%s\n' "$issues_json")
+  fi
+
+  printf '%s\n' "$next" > "$STATE_FILE"
+  sleep "$POLL_INTERVAL"
+done

--- a/examples/github-issue-listener/listen.sh
+++ b/examples/github-issue-listener/listen.sh
@@ -33,6 +33,11 @@ if [[ ! -f "$STATE_FILE" ]]; then
   log "initialized state file at $STATE_FILE; only issues opened after $(cat "$STATE_FILE") will be picked up"
 fi
 
+if ! gh api "repos/$REPO" --silent >/dev/null 2>&1; then
+  log "cannot read repos/$REPO via gh — check that the repo exists, is spelled owner/name, and that gh auth has access"
+  exit 1
+fi
+
 log "watching $REPO every ${POLL_INTERVAL}s${LABEL:+ (label: $LABEL)}"
 
 while true; do


### PR DESCRIPTION
## Summary
- Adds `examples/github-issue-listener/` with a bash polling script and README.
- Watches a GitHub repo for newly opened issues and spawns an `af` session per issue (`issue-<number>`), seeded with the issue title and body. Optional `LABEL` filter for opt-in dispatch.
- Cursor-tracked via a state file so historical issues aren't backfilled and restarts don't re-spawn.

Closes #450

## Test plan
- [x] `shellcheck examples/github-issue-listener/listen.sh` (clean).
- [x] `bash -n` syntax check.
- [x] Missing `REPO` smoke test exits non-zero with a clear error.
- [ ] Dry-run against a real repo with zero new issues (no sessions created, state file advances on each tick).
- [ ] Visual render of the README on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)