### PR TITLE
docs(readme): fix send-prompt usage to positional syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ af sessions get <title>                                        # fetch one sessi
 af sessions create --name <title> --prompt "fix the bug"       # create + start a session
 af sessions preview <title>                                    # snapshot the session's pane
 af sessions attach <title>                                     # attach interactively (foreground)
-af sessions send-prompt <title> --prompt "..."                 # append a prompt to a session
-af sessions send-prompt <title> --prompt "..." --create        # send-or-create
+af sessions send-prompt <title> "..."                          # append a prompt to a session
+af sessions send-prompt <title> "..." --create                 # send-or-create
 af sessions whoami                                             # report the session this shell is inside
 af sessions kill <title>                                       # kill + clean up the session
 ```


### PR DESCRIPTION
## Summary
- Corrects the `af sessions send-prompt` examples in the Programmatic API > Sessions section of the README. PR #445 introduced a `--prompt` flag form, but the actual CLI accepts the prompt positionally (`<title> <prompt>`); only `--create` and `--program` are real flags.

## Test plan
- [x] Built `af` from `master` and ran `af sessions send-prompt --help`; the `Usage:` line is `af sessions send-prompt <title> <prompt> [flags]`, confirming the positional form.
- [x] `git diff` touches only the two intended README lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)