### PR TITLE
feat(task): respect per-task program when scheduling and executing (#453)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ af sessions kill <title>                                       # kill + clean up
 
 ```bash
 af tasks list                                                  # list scheduled tasks
-af tasks add --name "Daily triage" --prompt "..." --cron "0 9 * * *"
+af tasks add --name "Daily triage" --prompt "..." --cron "0 9 * * *" --program claude
 af tasks get <id>                                              # fetch one task
 af tasks trigger <id>                                          # run task immediately
 af tasks update <id> --cron "..." --prompt "..." --enabled true

--- a/app/app.go
+++ b/app/app.go
@@ -469,7 +469,7 @@ func (m *home) saveContentPaneState() {
 // handleTaskCreate processes a pending task creation from the inline form.
 func (m *home) handleTaskCreate() tea.Cmd {
 	sp := m.contentPane.TaskPane()
-	name, prompt, cronExpr, projectPath := sp.ConsumePendingCreate()
+	name, prompt, cronExpr, projectPath, program := sp.ConsumePendingCreate()
 
 	if name == "" {
 		return m.handleError(fmt.Errorf("task name is required"))
@@ -481,13 +481,16 @@ func (m *home) handleTaskCreate() tea.Cmd {
 	if err != nil {
 		return m.handleError(fmt.Errorf("invalid path: %v", err))
 	}
+	if program == "" {
+		program = m.program
+	}
 	t := task.Task{
 		ID:          task.GenerateID(),
 		Name:        name,
 		Prompt:      prompt,
 		CronExpr:    cronExpr,
 		ProjectPath: absPath,
-		Program:     m.program,
+		Program:     program,
 		Enabled:     true,
 		CreatedAt:   time.Now(),
 	}

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -173,6 +173,47 @@ func TestGenerateID(t *testing.T) {
 	assert.NotEqual(t, id1, id2)
 }
 
+// TestLoadTaskWithoutProgramFieldFallsBackToEmpty verifies that a task record
+// persisted before the per-task program feature (i.e. without a "program"
+// key) loads cleanly with Program == "". The runner / daemon path treats an
+// empty Program as "use the config default", so this is the backwards-compat
+// path users on stale tasks.json files depend on. Regression test for #453.
+func TestLoadTaskWithoutProgramFieldFallsBackToEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, tasksFileName)
+
+	legacyJSON := `[{"id":"legacy","name":"Old Task","prompt":"do it","cron_expr":"0 9 * * *","project_path":"/tmp","enabled":true,"created_at":"2025-01-01T00:00:00Z"}]`
+	require.NoError(t, os.WriteFile(path, []byte(legacyJSON), 0644))
+
+	origGetPath := getTasksPathFn
+	getTasksPathFn = func() (string, error) { return path, nil }
+	t.Cleanup(func() { getTasksPathFn = origGetPath })
+
+	tasks, err := LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "legacy", tasks[0].ID)
+	assert.Equal(t, "", tasks[0].Program, "legacy task without program key must load with Program=\"\" so the runner falls back to the config default")
+}
+
+// TestUpdateTaskPersistsProgram verifies that the Program field is persisted
+// through UpdateTask. Regression test for #453: editing a task's program
+// through the TUI must survive a SaveTasks -> LoadTasks round-trip.
+func TestUpdateTaskPersistsProgram(t *testing.T) {
+	tasks := []Task{
+		{ID: "p1", Name: "Original", Program: "claude", Enabled: true},
+	}
+	setupTestTasks(t, tasks)
+
+	updated := tasks[0]
+	updated.Program = "aider"
+	require.NoError(t, UpdateTask(updated))
+
+	got, err := GetTask("p1")
+	require.NoError(t, err)
+	assert.Equal(t, "aider", got.Program)
+}
+
 func TestTaskNameInJSON(t *testing.T) {
 	s := Task{ID: "n1", Name: "My Task", Prompt: "do things"}
 	data, err := json.Marshal(s)

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -17,13 +17,14 @@ type TaskPane struct {
 	selectedIdx int
 
 	// Edit mode
-	editing    bool
-	editName   textinput.Model
-	editPrompt textarea.Model
-	editCron   textinput.Model
-	editPath   textinput.Model
-	editError  string // last validation error shown to the user
-	focusIndex int    // 0=name, 1=prompt, 2=cron, 3=path, 4=save button
+	editing     bool
+	editName    textinput.Model
+	editPrompt  textarea.Model
+	editCron    textinput.Model
+	editPath    textinput.Model
+	editProgram textinput.Model
+	editError   string // last validation error shown to the user
+	focusIndex  int    // 0=name, 1=prompt, 2=cron, 3=path, 4=program, 5=save button
 
 	// Create mode
 	creating       bool
@@ -128,10 +129,16 @@ func (s *TaskPane) EnterCreateMode(defaultPath string) {
 	path.CharLimit = 256
 	path.Blur()
 
+	program := textinput.New()
+	program.Placeholder = "leave empty for config default"
+	program.CharLimit = 256
+	program.Blur()
+
 	s.editName = name
 	s.editPrompt = prompt
 	s.editCron = cron
 	s.editPath = path
+	s.editProgram = program
 	s.focusIndex = 0
 	s.creating = true
 	s.hasFocus = true
@@ -144,9 +151,10 @@ func (s *TaskPane) HasPendingCreate() bool {
 }
 
 // ConsumePendingCreate returns the submitted create data and clears the pending flag.
-func (s *TaskPane) ConsumePendingCreate() (name, prompt, cron, path string) {
+// program is the user-supplied program override; empty means "use the caller's default".
+func (s *TaskPane) ConsumePendingCreate() (name, prompt, cron, path, program string) {
 	s.pendingCreate = false
-	return s.editName.Value(), s.editPrompt.Value(), s.editCron.Value(), s.editPath.Value()
+	return s.editName.Value(), s.editPrompt.Value(), s.editCron.Value(), s.editPath.Value(), s.editProgram.Value()
 }
 
 // SetPendingTrigger marks the currently selected task to be triggered.
@@ -261,10 +269,17 @@ func (s *TaskPane) enterEditMode() {
 	path.CharLimit = 256
 	path.Blur()
 
+	program := textinput.New()
+	program.SetValue(tsk.Program)
+	program.Placeholder = "leave empty for config default"
+	program.CharLimit = 256
+	program.Blur()
+
 	s.editName = name
 	s.editPrompt = prompt
 	s.editCron = cron
 	s.editPath = path
+	s.editProgram = program
 	s.focusIndex = 0
 	s.editing = true
 	s.editError = ""
@@ -273,17 +288,17 @@ func (s *TaskPane) enterEditMode() {
 func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 	switch msg.Type {
 	case tea.KeyTab:
-		s.focusIndex = (s.focusIndex + 1) % 5
+		s.focusIndex = (s.focusIndex + 1) % 6
 		s.updateEditFocus()
 	case tea.KeyShiftTab:
-		s.focusIndex = (s.focusIndex + 4) % 5
+		s.focusIndex = (s.focusIndex + 5) % 6
 		s.updateEditFocus()
 	case tea.KeyEsc:
 		s.editing = false
 		s.creating = false
 		s.editError = ""
 	case tea.KeyEnter:
-		if s.focusIndex == 4 {
+		if s.focusIndex == 5 {
 			if s.creating {
 				if s.editName.Value() == "" {
 					s.editError = "name is required"
@@ -310,6 +325,7 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 				s.tasks[s.selectedIdx].Prompt = s.editPrompt.Value()
 				s.tasks[s.selectedIdx].CronExpr = s.editCron.Value()
 				s.tasks[s.selectedIdx].ProjectPath = s.editPath.Value()
+				s.tasks[s.selectedIdx].Program = s.editProgram.Value()
 				s.dirty = true
 				s.editing = false
 			}
@@ -328,6 +344,8 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 			s.editCron, _ = s.editCron.Update(msg)
 		case 3:
 			s.editPath, _ = s.editPath.Update(msg)
+		case 4:
+			s.editProgram, _ = s.editProgram.Update(msg)
 		}
 	}
 	return true
@@ -338,6 +356,7 @@ func (s *TaskPane) updateEditFocus() {
 	s.editPrompt.Blur()
 	s.editCron.Blur()
 	s.editPath.Blur()
+	s.editProgram.Blur()
 
 	switch s.focusIndex {
 	case 0:
@@ -348,6 +367,8 @@ func (s *TaskPane) updateEditFocus() {
 		s.editCron.Focus()
 	case 3:
 		s.editPath.Focus()
+	case 4:
+		s.editProgram.Focus()
 	}
 }
 
@@ -467,6 +488,7 @@ func (s *TaskPane) renderEditMode() string {
 	}
 	s.editCron.Width = inputWidth
 	s.editPath.Width = inputWidth
+	s.editProgram.Width = inputWidth
 
 	var b strings.Builder
 	if s.creating {
@@ -491,13 +513,17 @@ func (s *TaskPane) renderEditMode() string {
 	b.WriteString(labelStyle.Render("Path:"))
 	b.WriteString("  ")
 	b.WriteString(s.editPath.View())
+	b.WriteString("\n")
+	b.WriteString(labelStyle.Render("Program:"))
+	b.WriteString("  ")
+	b.WriteString(s.editProgram.View())
 	b.WriteString("\n\n")
 
 	submitLabel := " Save "
 	if s.creating {
 		submitLabel = " Create "
 	}
-	if s.focusIndex == 4 {
+	if s.focusIndex == 5 {
 		b.WriteString("       " + focusedButtonStyle.Render(submitLabel))
 	} else {
 		b.WriteString("       " + buttonStyle.Render(submitLabel))

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -82,3 +82,82 @@ func TestTaskPaneNormalModeAllowsQuitKeysToPropagate(t *testing.T) {
 	assert.False(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}))
 	assert.False(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlC}))
 }
+
+// TestTaskPaneCreateModeCapturesProgram drives the create form with the same
+// key events the bubbletea runtime would deliver, confirming that the Program
+// field is captured into the pending-create payload alongside the existing
+// fields. Regression test for #453.
+func TestTaskPaneCreateModeCapturesProgram(t *testing.T) {
+	tp := NewTaskPane()
+	tp.EnterCreateMode("/tmp/repo")
+
+	typeRunes := func(runes string) {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(runes)})
+	}
+
+	// Name
+	typeRunes("daily")
+	// Move to prompt, cron, path, program (program is focus index 4).
+	for i := 0; i < 4; i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	}
+	// Replace the default path with a valid value isn't necessary — path
+	// already carries the default. Type into the program field.
+	typeRunes("aider")
+	// Set a valid cron by jumping back to the cron field.
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
+	// We're on cron now (index 2); type a valid expression.
+	typeRunes("* * * * *")
+	// Walk forward past path and program to the submit button (index 5).
+	for i := 0; i < 3; i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	}
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.True(t, tp.HasPendingCreate(), "submit should mark a pending create")
+	name, _, cron, path, program := tp.ConsumePendingCreate()
+	assert.Equal(t, "daily", name)
+	assert.Equal(t, "* * * * *", cron)
+	assert.Equal(t, "/tmp/repo", path)
+	assert.Equal(t, "aider", program, "Program field must be carried through to the pending-create payload")
+}
+
+// TestTaskPaneEditModePersistsProgramChange confirms that editing an existing
+// task's Program field via the form writes the change back to the task slice
+// so the caller persists it on save. Regression test for #453.
+func TestTaskPaneEditModePersistsProgramChange(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "old-name",
+		Prompt:      "do it",
+		CronExpr:    "* * * * *",
+		ProjectPath: "/tmp/repo",
+		Program:     "claude",
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}) // enter edit mode
+	assert.True(t, tp.IsEditing())
+
+	// Walk to the Program field (index 4).
+	for i := 0; i < 4; i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	}
+	// Clear by overwriting: textinput.Update treats backspace as delete.
+	for i := 0; i < len("claude"); i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("aider")})
+	// Tab to the Save button (index 5) and press enter.
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.False(t, tp.IsEditing(), "save should exit edit mode")
+	assert.True(t, tp.IsDirty(), "edit should mark the pane dirty")
+	tasks := tp.GetTasks()
+	if assert.Len(t, tasks, 1) {
+		assert.Equal(t, "aider", tasks[0].Program, "Program field must reflect the edited value")
+	}
+}


### PR DESCRIPTION
## Summary

User wants to specify the agent program per scheduled task (e.g. one task runs Claude, another runs Aider). Audit found a single gap in the TUI form; everything else was already wired up.

**Audit findings:**

1. **`task.Task` struct** — Already has a `Program` field with `json:"program"`. Persisted to `tasks.json`. ✅
2. **systemd / launchd unit generation** — Both `task/systemd.go` and `task/launchd.go` install units whose `ExecStart` / `ProgramArguments` invoke `af task run <taskID>`. The program is **not** baked into the unit file; it is read from the persisted task at run time. This means changes to a task's Program take effect on the next fire with no need to regenerate units. ✅
3. **TUI task editor (`ui/task_pane.go`)** — ❌ **Gap.** The inline form exposed Name / Prompt / Cron / Path (focus indices 0..3) and a Save button (4). No Program field. `app/handleTaskCreate` therefore stamped every task with the session's startup program (`m.program`) with no way to override.
4. **`af tasks add`** — Already accepts `--program` (`api/tasks.go:147`), persists it, falls back to `config.LoadConfig().DefaultProgram` when omitted. ✅
5. **Task runner (`task/runner.go`)** — `RunTask` passes `t.Program` to `daemon.CreateSession`. The daemon (`daemon/control.go:332-335`) substitutes `m.cfg.DefaultProgram` when `req.Program == ""`. So legacy `tasks.json` entries without a `program` key keep working without code changes. ✅

## Gap addressed

- **TUI form:** added a Program textinput (focus index 4; Save moved to 5). The field is populated from the existing task in edit mode and defaults to empty in create mode (empty → fall back to the session's startup program in `handleTaskCreate`). Captured into `ConsumePendingCreate` alongside the existing fields.
- **README:** updated the `af tasks add` example to include `--program`.

No changes were needed in the persistence layer, the schedule generators, the CLI, or the runner — they were already program-aware.

## Test plan

Automated:
- [x] `gofmt -l .` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go build ./...` clean
- [x] `go test -race ./...` green (all packages)
- [x] New `ui` tests drive the create + edit forms with bubbletea key events and confirm `Program` is captured and persisted back to the task slice.
- [x] New `task` test loads a legacy `tasks.json` without a `program` key and confirms it round-trips with `Program=""` (the backwards-compat path that the daemon's default-program fallback handles).

Manual:
- [ ] Build `af`, install via `./dev-install.sh`
- [ ] `af tasks add --name foo --prompt 'check status' --cron '*/5 * * * *' --program aider`
- [ ] `af tasks trigger <id>` and confirm the spawned session runs Aider, not the config default
- [ ] In the TUI, create a new task and set Program=`aider`; confirm next fire runs Aider
- [ ] Confirm an existing task created on the previous version (no `program` key in `tasks.json`) still fires using the config default

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude <noreply@anthropic.com>