### PR TITLE
feat(ui): show agent name instead of full program in scheduled task view (#455)

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -27,6 +28,27 @@ const ProgramGemini = "gemini"
 
 // SupportedPrograms is the canonical list of known agent programs.
 var SupportedPrograms = []string{ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini}
+
+// AgentNameFromProgram extracts a short, user-facing agent name from a program
+// command string. It first looks for a known SupportedPrograms token (after
+// stripping any path prefix) and returns that canonical name. Otherwise it
+// returns the basename of the first whitespace-separated token, with no
+// directory and no flags. Empty input returns the empty string.
+func AgentNameFromProgram(prog string) string {
+	tokens := strings.Fields(strings.ToLower(prog))
+	if len(tokens) == 0 {
+		return ""
+	}
+	for _, tok := range tokens {
+		base := filepath.Base(tok)
+		for _, supported := range SupportedPrograms {
+			if base == supported {
+				return supported
+			}
+		}
+	}
+	return filepath.Base(tokens[0])
+}
 
 // TmuxSession represents a managed tmux session
 type TmuxSession struct {

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -222,3 +222,28 @@ func TestStartTmuxSession(t *testing.T) {
 	_, err = ptyFactory.files[1].Stat()
 	require.NoError(t, err)
 }
+
+func TestAgentNameFromProgram(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"bare canonical name", "claude", "claude"},
+		{"canonical with flags", "claude --dangerously-skip-permissions", "claude"},
+		{"absolute path", "/home/user/.local/bin/claude --foo", "claude"},
+		{"aider with model flag", "/usr/local/bin/aider --model gpt-4", "aider"},
+		{"codex bare", "codex", "codex"},
+		{"gemini in path", "/opt/gemini/bin/gemini --quiet", "gemini"},
+		{"unknown binary with flags", "foo --bar", "foo"},
+		{"unknown absolute path", "/opt/tools/foo --bar baz", "foo"},
+		{"uppercase canonical", "CLAUDE --foo", "claude"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, AgentNameFromProgram(tc.in))
+		})
+	}
+}

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 	"strings"
 
@@ -446,7 +447,7 @@ func (s *TaskPane) renderListMode() string {
 		if tsk.LastRunAt != nil {
 			lastRun = tsk.LastRunAt.Format("Jan 02 15:04")
 		}
-		detail := fmt.Sprintf("    %s • last: %s", tsk.Program, lastRun)
+		detail := fmt.Sprintf("    %s • last: %s", tmux.AgentNameFromProgram(tsk.Program), lastRun)
 		if tsk.LastRunStatus != "" {
 			detail += " (" + tsk.LastRunStatus + ")"
 		}

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -160,4 +161,27 @@ func TestTaskPaneEditModePersistsProgramChange(t *testing.T) {
 	if assert.Len(t, tasks, 1) {
 		assert.Equal(t, "aider", tasks[0].Program, "Program field must reflect the edited value")
 	}
+}
+
+// TestTaskPaneListShowsAgentNameNotFullProgram confirms the list view collapses
+// a noisy program string (path + flags) down to the agent name for #455.
+func TestTaskPaneListShowsAgentNameNotFullProgram(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(80, 24)
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "0 0 * * *",
+		ProjectPath: "/tmp/repo",
+		Program:     "/usr/local/bin/aider --model gpt-4",
+		Enabled:     true,
+	}})
+
+	out := tp.String()
+	assert.Contains(t, out, "aider", "list view should render the agent name")
+	assert.False(t, strings.Contains(out, "/usr/local/bin/aider"),
+		"list view must not include the full program path")
+	assert.False(t, strings.Contains(out, "--model gpt-4"),
+		"list view must not include program flags")
 }


### PR DESCRIPTION
## Summary

Closes #455.

In the scheduled task view (TUI), the row's detail line previously surfaced the raw `Program` string (path + flags), e.g.
`/home/user/.local/bin/claude --dangerously-skip-permissions`. Render the canonical agent name (`claude`, `aider`, etc.) instead.

The persisted `Task.Program` field and the JSON returned by `af tasks list` / `af tasks get` are **unchanged** — scripters keep their existing contract. The display change is TUI-only.

## Audit findings (read-only)

1. `session/tmux/tmux.go` — `ProgramClaude`/`ProgramCodex`/`ProgramAider`/`ProgramGemini` constants live at L23–26 and `SupportedPrograms` at L29. **No existing helper** like `AgentNameFromProgram`; added one next to `SupportedPrograms`.
2. `ui/task_pane.go` Program render sites:
   - L449 — task list row detail line (`tsk.Program • last: ...`). **Changed** to render via `tmux.AgentNameFromProgram`.
   - L273 — seeds the text-input value when entering edit mode (raw editable string). **Left as-is** per brief.
   - L328 — writes the text-input value back on save. **Left as-is** per brief.
   - L519 — renders the live text input view in edit mode. **Left as-is** (user is actively typing the raw string).
3. `api/tasks.go` does **not** alter the `Task` struct's JSON serialization. The struct tag is `Program string \`json:"program"\`` (`task/task.go:22`). The CLI/JSON contract is untouched.

Other `*.Program` references (`app/help.go:82`, `app/handle_input.go`, `app/session_control.go`, `app/app.go`) are for **session instances**, not scheduled tasks — out of scope for #455.

## Helper behavior

`AgentNameFromProgram(prog string) string`:
- Lowercases + tokenizes on whitespace.
- Returns the canonical name if any token's basename matches a `SupportedPrograms` entry.
- Otherwise returns `filepath.Base(firstToken)` — binary name, no path, no flags.
- Empty / whitespace-only input → `""`.

## Test plan

- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)
- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] Unit test `TestAgentNameFromProgram` covers: bare canonical, canonical-with-flags, absolute-path, `aider --model gpt-4`, unknown binary, empty/whitespace, uppercase.
- [x] Render test `TestTaskPaneListShowsAgentNameNotFullProgram` confirms `Program="/usr/local/bin/aider --model gpt-4"` renders `aider` (and NOT the full path or `--model gpt-4`) in the list view.
- [ ] Manual: `./dev-install.sh`, run `af tasks add --name demo --cron "0 9 * * 1-5" --prompt hi --program "/usr/local/bin/aider --model gpt-4"`, open the TUI task pane, confirm the detail line shows `aider` rather than the full path/flags. Confirm `af tasks list --json` still returns the full program string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)