### PR TITLE
fix(config): clamp non-positive daemon_poll_interval to default (#460)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	ConfigFileName = "config.json"
-	defaultProgram = "claude"
+	ConfigFileName            = "config.json"
+	defaultProgram            = "claude"
+	defaultDaemonPollInterval = 1000
 )
 
 var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|->|^[^/=\s]+\s*=)\s*(.+)`)
@@ -79,7 +80,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		DefaultProgram:     program,
 		AutoYes:            false,
-		DaemonPollInterval: 1000,
+		DaemonPollInterval: defaultDaemonPollInterval,
 		BranchPrefix: func() string {
 			user, err := user.Current()
 			if err != nil || user == nil || user.Username == "" {
@@ -169,6 +170,11 @@ func LoadConfig() *Config {
 	if err := json.Unmarshal(data, config); err != nil {
 		log.ErrorLog.Printf("failed to parse config file: %v", err)
 		return DefaultConfig()
+	}
+
+	if config.DaemonPollInterval <= 0 {
+		log.WarningLog.Printf("daemon_poll_interval=%d is non-positive; using default %dms", config.DaemonPollInterval, defaultDaemonPollInterval)
+		config.DaemonPollInterval = defaultDaemonPollInterval
 	}
 
 	return config

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"github.com/sachiniyer/agent-factory/log"
 	"os"
 	"path/filepath"
@@ -284,6 +285,38 @@ func TestLoadConfig(t *testing.T) {
 		assert.True(t, config.AutoYes)
 		assert.Equal(t, 2000, config.DaemonPollInterval)
 		assert.Equal(t, "test/", config.BranchPrefix)
+	})
+
+	t.Run("clamps non-positive daemon_poll_interval to default", func(t *testing.T) {
+		cases := []struct {
+			name     string
+			raw      int
+			expected int
+		}{
+			{"zero -> default", 0, defaultDaemonPollInterval},
+			{"negative -> default", -500, defaultDaemonPollInterval},
+			{"positive -> as-is", 2500, 2500},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				tempHome := t.TempDir()
+				configDir := filepath.Join(tempHome, ".agent-factory")
+				require.NoError(t, os.MkdirAll(configDir, 0755))
+
+				configPath := filepath.Join(configDir, ConfigFileName)
+				content := fmt.Sprintf(`{"daemon_poll_interval": %d}`, tc.raw)
+				require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
+
+				originalHome := os.Getenv("HOME")
+				os.Setenv("HOME", tempHome)
+				defer os.Setenv("HOME", originalHome)
+
+				config := LoadConfig()
+				assert.NotNil(t, config)
+				assert.Equal(t, tc.expected, config.DaemonPollInterval)
+			})
+		}
 	})
 
 	t.Run("returns default config on invalid JSON", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `config.LoadConfig` now clamps `daemon_poll_interval` to the package default (1000ms) when the value parsed from `config.json` is `<= 0`, preventing a silent `time.NewTicker(0)` panic in the daemon goroutine.
- Logs a warning so users see why the override happened.

## Test Plan
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)
- [x] `go build ./...`
- [x] `go test -race ./...` (full suite green; one unrelated `TestRealTUI_CreateThroughKeypresses` flake passed on retry)
- [x] New unit test `TestLoadConfig/clamps_non-positive_daemon_poll_interval_to_default` covers zero → default, negative → default, positive → as-is
- [ ] Manual: set `"daemon_poll_interval": 0` in `~/.agent-factory/config.json`, start `af`, confirm daemon does not panic and the warning is logged with the 1000ms default applied

Closes #460