### PR TITLE
fix(session): lock Instance.GetGitWorktree to match other accessors (#462)

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -398,6 +398,8 @@ func (i *Instance) SetPreviewSize(width, height int) error {
 
 // GetGitWorktree returns the git worktree for the instance
 func (i *Instance) GetGitWorktree() (*git.GitWorktree, error) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
 	if !i.started {
 		return nil, fmt.Errorf("cannot get git worktree for instance that has not been started")
 	}

--- a/session/instance_test.go
+++ b/session/instance_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -81,4 +82,37 @@ func TestFetchPRInfoSnapshot_StartedWithoutWorktree(t *testing.T) {
 	assert.Empty(t, repoPath,
 		"snapshot must be empty when gitWorktree is nil (remote / mid-setup)")
 	assert.Empty(t, branch)
+}
+
+// TestGetGitWorktree_RaceWithStart guards the fix for #462. GetGitWorktree
+// must read i.started and i.gitWorktree under i.mu — Start() writes both
+// under the lock, so an unlocked reader trips the race detector. Run with
+// `go test -race ./session/...` to validate.
+func TestGetGitWorktree_RaceWithStart(t *testing.T) {
+	i, err := NewInstance(InstanceOptions{Title: "t", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer goroutine: mirrors the lock-protected writes in
+	// StartWithExistingWorktree (i.gitWorktree, then i.started).
+	go func() {
+		defer wg.Done()
+		for n := 0; n < iterations; n++ {
+			i.SetGitWorktreeForTest(&git.GitWorktree{})
+			i.SetStartedForTest(true)
+		}
+	}()
+
+	// Reader goroutine: exercises the path the bug lived on.
+	go func() {
+		defer wg.Done()
+		for n := 0; n < iterations; n++ {
+			_, _ = i.GetGitWorktree()
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
- `Instance.GetGitWorktree` read `i.started` and `i.gitWorktree` without holding `i.mu`, while `Start`/`StartWithExistingWorktree` write both fields under the lock. `go test -race` reliably flagged the read once a concurrent starter was in flight.
- Acquire `i.mu.RLock()` in `GetGitWorktree`, mirroring `GetWorktreePath`, `Started`, and every other read-side accessor on `Instance`.
- Adds a focused regression test (`TestGetGitWorktree_RaceWithStart`) that pairs the read with the same lock-protected writes Start performs; without the fix the race detector flags two distinct addresses, with the fix it is clean across repeated runs.

Closes #462

## Test Plan
- [x] `gofmt -l .` — clean
- [x] `go build ./...`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `go test -race ./...` (all packages green, including `session`)
- [x] `go test -race ./session/ -run TestGetGitWorktree_RaceWithStart -count=5` — passes
- [x] Sanity-check: reverting just the lock makes the new test fail with `WARNING: DATA RACE` on both `i.started` and `i.gitWorktree`

🤖 Generated with [Claude Code](https://claude.com/claude-code)