### PR TITLE
fix(tmux): clear ptmx on Detach Restore failure so Attach does not hang (#464)

### DIFF
--- a/session/tmux/race_test.go
+++ b/session/tmux/race_test.go
@@ -2,7 +2,9 @@ package tmux
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -75,6 +77,103 @@ func TestCloseDuringAttachRace(t *testing.T) {
 		if session.ptmx != nil {
 			t.Fatalf("expected ptmx to be nil after Close")
 		}
+	}
+}
+
+// TestDetachClearsPtmxOnRestoreFailure is a regression test for issue #464.
+//
+// Detach used to close t.ptmx and then call Restore without clearing the
+// field. If Restore failed (e.g. tmux session vanished between detach and
+// re-attach), t.ptmx was left pointing at the closed file. A subsequent
+// Attach would silently bind goroutines to the closed handle and hang.
+//
+// Detach must clear t.ptmx after closing so the state is unambiguously
+// "no PTY", and Attach must surface a clear error rather than proceeding
+// against a nil/closed handle.
+func TestDetachClearsPtmxOnRestoreFailure(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+
+	// First has-session (from the test's initial Restore) reports the
+	// session exists so we can stand up a live ptmx. Subsequent calls
+	// (from Detach's internal Restore("")) report missing so Restore
+	// fails and exercises the bug.
+	hasSessionCalls := 0
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				hasSessionCalls++
+				if hasSessionCalls > 1 {
+					return fmt.Errorf("session vanished")
+				}
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("detach-restore-fail", ""), "claude", ptyFactory, cmdExec)
+
+	// Stand up the initial PTY the way Start would.
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+
+	// Mimic the bookkeeping that Attach() sets up so Detach has matching
+	// state to tear down. The real Attach goroutines touch stdin/SIGWINCH
+	// and so are unsuitable for tests; an empty wg is sufficient for
+	// Detach to complete.
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+
+	session.Detach()
+
+	if session.ptmx != nil {
+		t.Fatalf("expected ptmx to be nil after Detach with failed Restore, got %v", session.ptmx)
+	}
+
+	// A subsequent Attach must surface a clear error rather than hang on
+	// a closed PTY.
+	ch, err := session.Attach()
+	if err == nil {
+		t.Fatalf("expected Attach to error when ptmx is nil")
+	}
+	if ch != nil {
+		t.Fatalf("expected nil channel when Attach errors, got %v", ch)
+	}
+	if !strings.Contains(err.Error(), "no PTY") {
+		t.Fatalf("expected error to mention missing PTY, got %v", err)
+	}
+}
+
+// TestDetachHappyPathReplacesPtmx confirms the normal Detach flow still
+// installs a fresh PTY via Restore, so the issue #464 fix doesn't regress
+// the path where the tmux session is alive after detach.
+func TestDetachHappyPathReplacesPtmx(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("detach-happy", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+	original := session.ptmx
+
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+
+	session.Detach()
+
+	if session.ptmx == nil {
+		t.Fatalf("expected ptmx to be set after successful Detach -> Restore")
+	}
+	if session.ptmx == original {
+		t.Fatalf("expected Detach to swap in a fresh ptmx, got the original handle")
 	}
 }
 

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -364,6 +364,14 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
 }
 
 func (t *TmuxSession) Attach() (chan struct{}, error) {
+	// Detach clears t.ptmx after closing it so a Restore failure in the
+	// detach path can't leave a stale closed handle behind (issue #464).
+	// Refuse to attach without a live PTY rather than binding goroutines
+	// to a nil or closed file and hanging.
+	if t.ptmx == nil {
+		return nil, fmt.Errorf("cannot attach: no PTY available, call Restore first")
+	}
+
 	t.attachCh = make(chan struct{})
 
 	t.wg = &sync.WaitGroup{}
@@ -500,9 +508,14 @@ func (t *TmuxSession) Detach() {
 	// "Session terminated without detaching" warning.
 	t.cancel()
 
-	// Close the attached pty session.
-	if err := t.ptmx.Close(); err != nil {
-		log.ErrorLog.Printf("error closing attach pty session: %v", err)
+	// Close the attached pty session. Clear t.ptmx unconditionally before
+	// Restore so a Restore failure (or a Close failure) can't leave the
+	// closed handle dangling on the struct — a subsequent Attach would
+	// otherwise silently bind goroutines to a closed file and hang (#464).
+	closeErr := t.ptmx.Close()
+	t.ptmx = nil
+	if closeErr != nil {
+		log.ErrorLog.Printf("error closing attach pty session: %v", closeErr)
 		t.wg.Wait()
 		return
 	}


### PR DESCRIPTION
## Summary

- `TmuxSession.Detach` closed `t.ptmx` and then called `Restore` without clearing the field. If `Restore` failed (e.g. the tmux session vanished between detach and re-attach), `t.ptmx` was left pointing at the closed file and a subsequent `Attach` silently bound goroutines to a dead handle, hanging the UI.
- Clear `t.ptmx` unconditionally right after `Close` so the struct state is unambiguously "no PTY" on every failure path. Restore's success path already replaces the field with a fresh PTY.
- Guard `Attach` with an explicit `nil` check so the caller gets a clear error instead of hanging.

Closes #464

## Test Plan

- [x] `gofmt -l .` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go build ./...` — clean
- [x] `go test -race ./...` — green (full repo)
- [x] New regression test `TestDetachClearsPtmxOnRestoreFailure` simulates a vanished session, asserts `t.ptmx == nil` after `Detach`, and confirms a subsequent `Attach` surfaces a clear error.
- [x] New test `TestDetachHappyPathReplacesPtmx` guards the unchanged happy path: `Detach` still swaps in a fresh PTY via `Restore`.
- [ ] Captain Claude to exercise the failure scenario manually before merge — `session/tmux/` is special-care.

Co-Authored-By: Captain Claude <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>