### PR TITLE
fix(upgrade): apply timeout to binary download in upgrade and auto-update (#471)

### DIFF
--- a/autoupdate.go
+++ b/autoupdate.go
@@ -73,19 +73,9 @@ func autoUpdate() error {
 	downloadURL := fmt.Sprintf("%s/latest/download/agent-factory-%s-%s.tar.gz",
 		releaseBaseURL, goos, goarch)
 
-	resp, err := http.Get(downloadURL)
+	binary, err := downloadBinaryFn(downloadURL)
 	if err != nil {
-		return fmt.Errorf("download failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
-	}
-
-	binary, err := extractBinaryFromTarGz(resp.Body, "agent-factory")
-	if err != nil {
-		return fmt.Errorf("extract failed: %w", err)
+		return err
 	}
 
 	execPath, err := os.Executable()

--- a/upgrade.go
+++ b/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/spf13/cobra"
@@ -18,6 +19,55 @@ import (
 const (
 	releaseBaseURL = "https://github.com/sachiniyer/agent-factory/releases"
 )
+
+// Download timeouts are variables (not consts) so tests can shrink them to
+// keep the stalled-server case under a few seconds.
+var (
+	// downloadTimeout caps the total time spent fetching the release tarball.
+	// Binaries are <10MB but we stay generous to tolerate slow links.
+	downloadTimeout = 5 * time.Minute
+	// downloadResponseHeaderTimeout caps the time spent waiting for response
+	// headers, so a server that accepts the TCP connection but never replies
+	// fails fast instead of consuming the full downloadTimeout budget.
+	downloadResponseHeaderTimeout = 30 * time.Second
+)
+
+// newDownloadClient builds an *http.Client suitable for fetching a release
+// tarball, with both an overall request timeout and a header timeout so a
+// stalled server can't hang the upgrade indefinitely (#471).
+func newDownloadClient() *http.Client {
+	return &http.Client{
+		Timeout: downloadTimeout,
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: downloadResponseHeaderTimeout,
+		},
+	}
+}
+
+// downloadBinaryFn is indirected so tests can stub the download without
+// standing up an httptest server.
+var downloadBinaryFn = downloadBinary
+
+// downloadBinary fetches the release tarball at url and returns the embedded
+// `agent-factory` binary bytes. It uses newDownloadClient() to bound the
+// fetch with a timeout.
+func downloadBinary(url string) ([]byte, error) {
+	resp, err := newDownloadClient().Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("download failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("download failed: HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	binary, err := extractBinaryFromTarGz(resp.Body, "agent-factory")
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract binary: %w", err)
+	}
+	return binary, nil
+}
 
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
@@ -34,20 +84,9 @@ var upgradeCmd = &cobra.Command{
 
 		fmt.Printf("Downloading latest release for %s/%s...\n", goos, goarch)
 
-		resp, err := http.Get(downloadURL)
+		binary, err := downloadBinaryFn(downloadURL)
 		if err != nil {
-			return fmt.Errorf("download failed: %w", err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != 200 {
-			return fmt.Errorf("download failed: HTTP %d from %s", resp.StatusCode, downloadURL)
-		}
-
-		// Extract binary from tar.gz
-		binary, err := extractBinaryFromTarGz(resp.Body, "agent-factory")
-		if err != nil {
-			return fmt.Errorf("failed to extract binary: %w", err)
+			return err
 		}
 
 		// Find current executable path

--- a/upgrade_test.go
+++ b/upgrade_test.go
@@ -4,8 +4,11 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestExtractBinaryFromTarGz(t *testing.T) {
@@ -52,6 +55,137 @@ func TestExtractBinaryFromTarGzInvalidGzip(t *testing.T) {
 	_, err := extractBinaryFromTarGz(strings.NewReader("not gzip"), "agent-factory")
 	if err == nil || !strings.Contains(err.Error(), "gzip") {
 		t.Fatalf("expected gzip error, got %v", err)
+	}
+}
+
+// TestDownloadBinarySuccess covers the happy path: an httptest server serves
+// a valid tar.gz and downloadBinary returns the embedded bytes.
+func TestDownloadBinarySuccess(t *testing.T) {
+	archive := makeTarGz(t, map[string][]byte{
+		"agent-factory": []byte("binary-content"),
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		w.WriteHeader(200)
+		w.Write(archive)
+	}))
+	defer srv.Close()
+
+	got, err := downloadBinary(srv.URL)
+	if err != nil {
+		t.Fatalf("downloadBinary returned error: %v", err)
+	}
+	if string(got) != "binary-content" {
+		t.Fatalf("downloadBinary returned %q, want binary-content", string(got))
+	}
+}
+
+// TestDownloadBinaryNon200 ensures a non-200 response surfaces as an error
+// rather than being fed to the gzip reader.
+func TestDownloadBinaryNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := downloadBinary(srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Fatalf("expected HTTP 404 error, got %v", err)
+	}
+}
+
+// TestDownloadBinaryStalled guards #471: a server that writes the response
+// headers but never the body must not be allowed to hang the download
+// forever. downloadTimeout is shrunk for the test so the failure is
+// observable inside a few seconds.
+func TestDownloadBinaryStalled(t *testing.T) {
+	prevTimeout := downloadTimeout
+	prevHeader := downloadResponseHeaderTimeout
+	t.Cleanup(func() {
+		downloadTimeout = prevTimeout
+		downloadResponseHeaderTimeout = prevHeader
+	})
+	downloadTimeout = 500 * time.Millisecond
+	downloadResponseHeaderTimeout = 500 * time.Millisecond
+
+	stalled := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Send headers immediately, then hang until the test ends. The
+		// client should hit downloadTimeout while reading the body.
+		w.Header().Set("Content-Type", "application/gzip")
+		w.WriteHeader(200)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-stalled
+	}))
+	// Order matters: unblock handler goroutines before Close() waits on them.
+	t.Cleanup(func() {
+		close(stalled)
+		srv.Close()
+	})
+
+	deadline := time.After(3 * time.Second)
+	done := make(chan error, 1)
+	go func() {
+		_, err := downloadBinary(srv.URL)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "deadline") &&
+			!strings.Contains(err.Error(), "timeout") &&
+			!strings.Contains(err.Error(), "Timeout") {
+			t.Fatalf("expected timeout-like error, got %v", err)
+		}
+	case <-deadline:
+		t.Fatalf("downloadBinary did not return within 3s; timeout not enforced")
+	}
+}
+
+// TestDownloadBinaryStalledHeaders covers the case where the server accepts
+// the connection but never writes response headers — the
+// ResponseHeaderTimeout on the Transport should fire well before the overall
+// downloadTimeout.
+func TestDownloadBinaryStalledHeaders(t *testing.T) {
+	prevTimeout := downloadTimeout
+	prevHeader := downloadResponseHeaderTimeout
+	t.Cleanup(func() {
+		downloadTimeout = prevTimeout
+		downloadResponseHeaderTimeout = prevHeader
+	})
+	// Overall timeout intentionally larger so we observe the header-timeout
+	// path firing first.
+	downloadTimeout = 10 * time.Second
+	downloadResponseHeaderTimeout = 500 * time.Millisecond
+
+	stalled := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-stalled
+	}))
+	t.Cleanup(func() {
+		close(stalled)
+		srv.Close()
+	})
+
+	deadline := time.After(3 * time.Second)
+	done := make(chan error, 1)
+	go func() {
+		_, err := downloadBinary(srv.URL)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("expected header-timeout error, got nil")
+		}
+	case <-deadline:
+		t.Fatalf("downloadBinary did not return within 3s; header timeout not enforced")
 	}
 }
 


### PR DESCRIPTION
## Summary

Both `af upgrade` and the background auto-updater previously called `http.Get(downloadURL)` with no timeout. A stalled GitHub release CDN connection blocked indefinitely — and because auto-update runs on every launch, a single bad CDN moment could brick startup.

This PR introduces `newDownloadClient()`, which wraps `http.Client` with explicit timeouts, and routes both call sites through a shared `downloadBinary(url)` helper. The existing GitHub-API metadata fetch already used the bounded-client pattern; the binary download now matches.

### Timeout values

- **`downloadTimeout = 5 * time.Minute`** — overall request budget. Release binaries are <10MB so this is generous; the upper bound exists to tolerate slow links, not to enforce a tight SLA.
- **`downloadResponseHeaderTimeout = 30 * time.Second`** — header-only budget on the `Transport`. If a server accepts the TCP connection but never replies (the exact failure mode from #471), this fires well before the 5-minute overall ceiling and surfaces a fast, actionable error.

Both are package vars (not consts) so unit tests can shrink them.

## Test Plan

Local CI gates:

- [x] `gofmt -l .` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go build ./...` — clean
- [x] `go test -race -timeout 300s ./...` — clean (one unrelated flake in `TestRealTUI_CreateThroughKeypresses` passed on rerun)

New unit tests in `upgrade_test.go`:

- [x] `TestDownloadBinarySuccess` — httptest server serves a valid tar.gz; `downloadBinary` returns the embedded bytes.
- [x] `TestDownloadBinaryNon200` — server returns 404; error surfaces before the gzip reader is invoked.
- [x] `TestDownloadBinaryStalled` — server writes 200 headers then hangs on the body; `downloadTimeout` shrunk to 500ms; test asserts `downloadBinary` returns a timeout-like error within 3s.
- [x] `TestDownloadBinaryStalledHeaders` — server accepts the connection but never writes headers; `ResponseHeaderTimeout` shrunk to 500ms; same 3s budget.

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)