### PR TITLE
fix(autoupdate): record check before fallible work so failed attempts respect 24h throttle (#459)

### DIFF
--- a/autoupdate.go
+++ b/autoupdate.go
@@ -45,6 +45,11 @@ func autoUpdate() error {
 	if !shouldCheck() {
 		return nil
 	}
+	// Record the check up front so failure-prone steps below (network fetch,
+	// download, install) still honor the 24-hour throttle. Without this,
+	// persistent failures (blocked api.github.com, corp proxy, DNS) would
+	// retry on every launch and flood GitHub's rate limit. See issue #459.
+	recordCheck()
 
 	latestTag, err := fetchLatestReleaseTagFn()
 	if err != nil {
@@ -55,7 +60,6 @@ func autoUpdate() error {
 	latestVersion := strings.TrimPrefix(latestTag, "v")
 	currentVersion := strings.TrimPrefix(version, "v")
 	if !isNewer(latestVersion, currentVersion) {
-		recordCheck()
 		return nil
 	}
 
@@ -64,9 +68,7 @@ func autoUpdate() error {
 	goos := runtimeGOOS
 	goarch := runtime.GOARCH
 	if goos == "windows" {
-		// Auto-update is not supported on Windows, but record the check so the
-		// 24-hour throttle fires and we don't hit the GitHub API on every launch.
-		recordCheck()
+		// Auto-update is not supported on Windows.
 		return nil
 	}
 
@@ -93,7 +95,6 @@ func autoUpdate() error {
 		return fmt.Errorf("failed to write new binary: %w", err)
 	}
 
-	recordCheck()
 	log.ErrorLog.Printf("auto-update: successfully updated to %s (effective on next launch)", latestVersion)
 	return nil
 }

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -93,6 +94,72 @@ func TestAutoUpdateWindowsRecordsCheckWhenNoUpdate(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(dir, lastCheckFile)); err != nil {
 		t.Fatalf("expected %s to be written, got: %v", lastCheckFile, err)
+	}
+}
+
+// TestAutoUpdateRecordsCheckOnFetchFailure guards against the regression
+// tracked in issue #459: when fetchLatestReleaseTag fails (blocked API, DNS,
+// proxy, rate limit), the 24-hour throttle must still fire so the next launch
+// does not retry the network immediately.
+func TestAutoUpdateRecordsCheckOnFetchFailure(t *testing.T) {
+	dir := withTestHome(t)
+
+	prevFetch := fetchLatestReleaseTagFn
+	t.Cleanup(func() {
+		fetchLatestReleaseTagFn = prevFetch
+	})
+
+	fetchLatestReleaseTagFn = func() (string, error) {
+		return "", errors.New("simulated network failure")
+	}
+
+	if err := autoUpdate(); err == nil {
+		t.Fatalf("autoUpdate returned nil error; expected fetch failure")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, lastCheckFile)); err != nil {
+		t.Fatalf("expected %s to be written after fetch failure, got: %v",
+			lastCheckFile, err)
+	}
+	if shouldCheck() {
+		t.Fatalf("shouldCheck() returned true after fetch failure; throttle is broken")
+	}
+}
+
+// TestAutoUpdateRecordsCheckOnDownloadFailure guards against the regression
+// tracked in issue #459: when downloadBinary fails (network error mid-update),
+// the 24-hour throttle must still fire.
+func TestAutoUpdateRecordsCheckOnDownloadFailure(t *testing.T) {
+	dir := withTestHome(t)
+
+	prevGOOS := runtimeGOOS
+	prevFetch := fetchLatestReleaseTagFn
+	prevDownload := downloadBinaryFn
+	prevVersion := version
+	t.Cleanup(func() {
+		runtimeGOOS = prevGOOS
+		fetchLatestReleaseTagFn = prevFetch
+		downloadBinaryFn = prevDownload
+		version = prevVersion
+	})
+
+	runtimeGOOS = "linux"
+	version = "1.0.0"
+	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.1", nil }
+	downloadBinaryFn = func(string) ([]byte, error) {
+		return nil, errors.New("simulated download failure")
+	}
+
+	if err := autoUpdate(); err == nil {
+		t.Fatalf("autoUpdate returned nil error; expected download failure")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, lastCheckFile)); err != nil {
+		t.Fatalf("expected %s to be written after download failure, got: %v",
+			lastCheckFile, err)
+	}
+	if shouldCheck() {
+		t.Fatalf("shouldCheck() returned true after download failure; throttle is broken")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `autoUpdate()` only recorded the check on success paths, so any failure after `shouldCheck()` (network/DNS/proxy block, API rate-limit, mid-download error) bypassed the 24h throttle and retried on every launch — flooding GitHub's 60-req/hr unauthenticated limit.
- Move `recordCheck()` to fire immediately after `shouldCheck()` reports true, before any fallible work. Drop the now-redundant later calls on the no-update / Windows / success branches.
- Public API (`shouldCheck`, `recordCheck`) and the 24h interval are unchanged.

Closes #459

## Test Plan
- [x] `gofmt -l .` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go build ./...`
- [x] `go test -race ./...` — all packages pass
- [x] New: `TestAutoUpdateRecordsCheckOnFetchFailure` — stubs `fetchLatestReleaseTagFn` to error, asserts `last_update_check` is written and `shouldCheck()` returns false
- [x] New: `TestAutoUpdateRecordsCheckOnDownloadFailure` — stubs `downloadBinaryFn` to error, asserts throttle still fires
- [x] Existing Windows + no-update tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude <noreply@anthropic.com>