### PR TITLE
fix(session): make Instance.Kill best-effort so a broken worktree does not block deletion (#478)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -126,43 +125,40 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 	return nil
 }
 
+// Kill is best-effort: each cleanup step runs independently and a failure in
+// one (e.g. a broken git worktree) only logs a warning rather than aborting
+// the rest. The in-memory pointers are cleared regardless so the daemon
+// caller can always proceed to remove the persisted record. See issue #478.
 func (b *LocalBackend) Kill(i *Instance) error {
 	i.mu.Lock()
 	ts := i.tmuxSession
 	gw := i.gitWorktree
+	title := i.Title
 	i.started = false
 	i.mu.Unlock()
 
-	var errs []error
-	tmuxCleaned := ts == nil
-	worktreeCleaned := gw == nil
-
 	if ts != nil {
 		if err := ts.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to close tmux session: %w", err))
-		} else {
-			tmuxCleaned = true
+			log.WarningLog.Printf("kill %q: tmux cleanup failed: %v", title, err)
 		}
 	}
 
 	if gw != nil {
 		if err := gw.Cleanup(); err != nil {
-			errs = append(errs, fmt.Errorf("failed to cleanup git worktree: %w", err))
-		} else {
-			worktreeCleaned = true
+			log.WarningLog.Printf("kill %q: git worktree cleanup failed: %v", title, err)
 		}
 	}
 
 	i.mu.Lock()
-	if tmuxCleaned && i.tmuxSession == ts {
+	if i.tmuxSession == ts {
 		i.tmuxSession = nil
 	}
-	if worktreeCleaned && i.gitWorktree == gw {
+	if i.gitWorktree == gw {
 		i.gitWorktree = nil
 	}
 	i.mu.Unlock()
 
-	return errors.Join(errs...)
+	return nil
 }
 
 func (b *LocalBackend) Preview(i *Instance) (string, error) {

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -1,18 +1,22 @@
 package session
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
+	stdlog "log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +40,12 @@ func TestHookBackendType(t *testing.T) {
 	assert.Equal(t, "remote", b.Type())
 }
 
-func TestLocalBackendKillRetainsFailedTmuxForRetry(t *testing.T) {
+// TestLocalBackendKillBestEffort_TmuxFails is a regression test for issue
+// #478. When the tmux teardown fails, Kill must still clear in-memory state
+// and return nil so the caller can finish removing the session from the
+// persisted instances.json. The failure is surfaced as a WarningLog entry
+// (including the instance title) for diagnosis.
+func TestLocalBackendKillBestEffort_TmuxFails(t *testing.T) {
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(*exec.Cmd) error {
 			return errors.New("kill failed")
@@ -45,19 +54,126 @@ func TestLocalBackendKillRetainsFailedTmuxForRetry(t *testing.T) {
 			return nil, nil
 		},
 	}
-	ts := tmux.NewTmuxSessionWithDeps("retry-kill", "bash", nil, cmdExec)
+	ts := tmux.NewTmuxSessionWithDeps("best-effort-tmux", "bash", nil, cmdExec)
 	inst := &Instance{
-		Title:       "retry-kill",
+		Title:       "best-effort-tmux",
 		backend:     &LocalBackend{},
 		started:     true,
 		tmuxSession: ts,
 	}
 
-	err := inst.Kill()
-	require.Error(t, err)
+	buf := captureWarningLog(t)
 
-	err = inst.Kill()
-	require.Error(t, err, "failed tmux cleanup must remain retryable instead of becoming a false success")
+	require.NoError(t, inst.Kill(), "tmux cleanup failure must not block deletion")
+	assert.False(t, inst.Started(), "started flag should be cleared")
+	assert.Nil(t, inst.tmuxSession, "tmux pointer should be cleared so a retry is a clean no-op")
+
+	logged := buf.String()
+	assert.Contains(t, logged, "best-effort-tmux", "warning must include instance title for correlation in agent-factory.log")
+	assert.Contains(t, logged, "tmux cleanup failed")
+
+	require.NoError(t, inst.Kill(), "second kill on a cleared instance must be a no-op")
+}
+
+// TestLocalBackendKillBestEffort_WorktreeFails reproduces the exact scenario
+// from issue #478: the git worktree cleanup fails because the path is no
+// longer a working tree, and the user is stuck unable to delete the session.
+// After the fix, Kill logs a warning and returns nil so the caller can
+// remove the row from the sidebar and the persisted record.
+func TestLocalBackendKillBestEffort_WorktreeFails(t *testing.T) {
+	repoRoot := initTempGitRepo(t)
+
+	// Create a real directory that exists but is NOT a git worktree.
+	// `git worktree remove -f` on this path returns the "is not a working
+	// tree" error pattern users see in the issue.
+	stalePath := filepath.Join(t.TempDir(), "stale-worktree")
+	require.NoError(t, os.MkdirAll(stalePath, 0755))
+
+	gw, err := git.NewGitWorktreeFromStorage(repoRoot, stalePath, "issue-478", "issue-478-branch", "", false, false)
+	require.NoError(t, err)
+
+	inst := &Instance{
+		Title:       "issue-478",
+		backend:     &LocalBackend{},
+		started:     true,
+		gitWorktree: gw,
+	}
+
+	buf := captureWarningLog(t)
+
+	require.NoError(t, inst.Kill(), "worktree cleanup failure must not block deletion")
+	assert.False(t, inst.Started())
+	assert.Nil(t, inst.gitWorktree, "git worktree pointer should be cleared")
+
+	logged := buf.String()
+	assert.Contains(t, logged, "issue-478", "warning must include instance title")
+	assert.Contains(t, logged, "git worktree cleanup failed")
+	assert.Contains(t, logged, "is not a working tree", "warning should preserve the underlying git error so users can diagnose")
+}
+
+// TestLocalBackendKillBestEffort_BothFail covers the multi-component failure
+// case: both tmux and worktree cleanup blow up, and Kill should still return
+// nil with a warning per component.
+func TestLocalBackendKillBestEffort_BothFail(t *testing.T) {
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(*exec.Cmd) error {
+			return errors.New("kill failed")
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) {
+			return nil, nil
+		},
+	}
+	ts := tmux.NewTmuxSessionWithDeps("both-fail", "bash", nil, cmdExec)
+
+	repoRoot := initTempGitRepo(t)
+	stalePath := filepath.Join(t.TempDir(), "stale")
+	require.NoError(t, os.MkdirAll(stalePath, 0755))
+	gw, err := git.NewGitWorktreeFromStorage(repoRoot, stalePath, "both-fail", "both-fail-branch", "", false, false)
+	require.NoError(t, err)
+
+	inst := &Instance{
+		Title:       "both-fail",
+		backend:     &LocalBackend{},
+		started:     true,
+		tmuxSession: ts,
+		gitWorktree: gw,
+	}
+
+	buf := captureWarningLog(t)
+
+	require.NoError(t, inst.Kill())
+	assert.Nil(t, inst.tmuxSession)
+	assert.Nil(t, inst.gitWorktree)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "tmux cleanup failed")
+	assert.Contains(t, logged, "git worktree cleanup failed")
+	assert.Equal(t, 2, strings.Count(logged, "both-fail"), "title should appear in both component warnings")
+}
+
+// captureWarningLog redirects log.WarningLog to a buffer for the duration of
+// the test and returns the buffer. Restoration happens via t.Cleanup.
+func captureWarningLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := log.WarningLog
+	log.WarningLog = stdlog.New(&buf, "WARNING: ", 0)
+	t.Cleanup(func() { log.WarningLog = orig })
+	return &buf
+}
+
+// initTempGitRepo initializes an empty git repo in a temp directory and
+// returns its absolute path. Used by best-effort Kill tests that need a
+// real repo path for git worktree commands to dispatch against.
+func initTempGitRepo(t *testing.T) string {
+	t.Helper()
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(repoRoot, 0755))
+	cmd := exec.Command("git", "init")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	return repoRoot
 }
 
 // --- IsRemote helper ---


### PR DESCRIPTION
Closes #478.

## Audit findings

1. **`session/backend_local.go` `LocalBackend.Kill`** ran tmux close + git worktree cleanup, collected any errors with `errors.Join`, and returned the compound error. State was only nulled-out for the components that *succeeded*, on the theory that the user might retry — but in practice the surfaced error blocks the retry path entirely.
2. **`daemon/control.go` `Manager.KillSession`** (line 513) bails out the moment `instance.Kill()` returns non-nil and *skips* `storage.DeleteInstance(...)`. This is the root cause of the user-visible bug: the in-memory tmux process can already be dead, the worktree can already be gone, but a single residual error leaves the row in `instances.json` forever.
3. **`ui/sidebar.go` `Sidebar.Kill`** / **`ui/list.go` `List.Kill`** propagate the error and refuse to remove the row from the visible list. Same story from the UI layer.
4. **`app/handle_actions.go` `handleKill`** wraps the daemon error as `failed to kill session '%s': %w` and shows it via `handleError` — exactly the text the user saw in the issue.
5. **`session/backend_hook.go` `HookBackend.Kill`** has a different shape (single `delete_cmd` call) and is out of scope for this fix per the issue's reproduction.

## Shape

Returns **`nil`** (preferred option in the issue brief).

- Each cleanup step runs in its own block.
- A failure emits `log.WarningLog.Printf("kill %q: <component> cleanup failed: %v", title, err)` so users can grep the title in `agent-factory.log`.
- In-memory pointers (`tmuxSession`, `gitWorktree`) are cleared regardless of per-component outcome.
- `started=false` is set before any I/O, matching the pre-existing pattern.
- Daemon `KillSession` therefore always proceeds to `storage.DeleteInstance` and the sidebar row is always removed on `D`.

The public signature is unchanged (`func (b *LocalBackend) Kill(i *Instance) error`); only the failure semantics changed.

## Test plan

New tests in `session/backend_test.go`:

- `TestLocalBackendKillBestEffort_TmuxFails` — tmux `Close()` errors; assert Kill returns nil, `started=false`, `tmuxSession=nil`, warning contains the instance title and `"tmux cleanup failed"`. Calling Kill a second time is a clean no-op.
- `TestLocalBackendKillBestEffort_WorktreeFails` — uses a real git repo + a non-worktree directory to reproduce the exact `"is not a working tree"` pattern from the issue. Asserts Kill returns nil, state cleared, warning preserves the underlying git error message.
- `TestLocalBackendKillBestEffort_BothFail` — both components fail; both warnings logged (title appears twice); state cleared; nil returned.

Removed `TestLocalBackendKillRetainsFailedTmuxForRetry` — it asserted the prior fail-fast behavior that this PR intentionally inverts. The "retry" path it was protecting is now satisfied by a successful no-op second Kill.

Local CI gates (all clean):

- [x] `gofmt -l .`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `go build ./...`
- [x] `go test -race ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)