### PR TITLE
fix(task): dedupe + filter empty DOW entries in systemd OnCalendar (#465)

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -234,12 +234,31 @@ func convertDOW(field string) string {
 		return strings.Join(names, ",")
 	}
 
-	// Handle lists (e.g. "1,3,5" → "Mon,Wed,Fri")
+	// Handle lists (e.g. "1,3,5" → "Mon,Wed,Fri"). Dedupe day names so
+	// "0,7" → "Sun" (not "Sun,Sun"), and short-circuit to "" if any element
+	// already covers all 7 days (e.g. "0-6,7"), matching the wildcard
+	// convention of omitting DOW entirely.
 	if strings.Contains(field, ",") {
 		parts := strings.Split(field, ",")
-		names := make([]string, len(parts))
-		for i, p := range parts {
-			names[i] = convertSingleDOW(p)
+		seen := make(map[string]bool)
+		var names []string
+		for _, p := range parts {
+			converted := convertSingleDOW(p)
+			if converted == "" {
+				// A single element covers all 7 days; so does the list.
+				return ""
+			}
+			// A single element may itself expand to a comma-separated
+			// list (e.g. "0-1" → "Sun,Mon"); split before dedupe.
+			for _, n := range strings.Split(converted, ",") {
+				if !seen[n] {
+					seen[n] = true
+					names = append(names, n)
+				}
+			}
+		}
+		if len(names) >= 7 {
+			return ""
 		}
 		return strings.Join(names, ",")
 	}

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -175,6 +175,30 @@ func TestCronToOnCalendarDOWSundayRange07(t *testing.T) {
 	assert.Equal(t, "*-*-* 09:00:00", result)
 }
 
+// TestCronToOnCalendarDOWListDedupes is a regression test for #465: "0,7"
+// both map to Sunday, which previously produced an invalid "Sun,Sun"
+// OnCalendar string that systemd rejects.
+func TestCronToOnCalendarDOWListDedupes(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 0,7")
+	require.NoError(t, err)
+	assert.Equal(t, "Sun *-*-* 09:00:00", result)
+}
+
+func TestCronToOnCalendarDOWListMonWedFri(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 1,3,5")
+	require.NoError(t, err)
+	assert.Equal(t, "Mon,Wed,Fri *-*-* 09:00:00", result)
+}
+
+// TestCronToOnCalendarDOWListAllDays covers a list whose elements union to
+// all 7 days. "0-6" alone is all days, so "0-6,7" must omit DOW entirely
+// (previously emitted invalid ",Sun").
+func TestCronToOnCalendarDOWListAllDays(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 0-6,7")
+	require.NoError(t, err)
+	assert.Equal(t, "*-*-* 09:00:00", result)
+}
+
 func TestCronToOnCalendarDOWNonSundayRange(t *testing.T) {
 	// Non-zero-starting ranges should still use .. syntax.
 	result, err := CronToOnCalendar("0 9 * * 2-4")


### PR DESCRIPTION
## Summary

`convertDOW` in `task/cron.go` built the list-path OnCalendar string by calling `convertSingleDOW` per element and joining with commas, which produced invalid output for two cases:

- `0,7` → `Sun,Sun` (both map to Sunday) — systemd rejects duplicates.
- `0-6,7` → `,Sun` (the range expanded to the "all days" empty-string signal) — systemd rejects the leading comma.

The fix dedupes day names while preserving order, splits elements that themselves expand to a comma list (`0-1` → `Sun,Mon`) before dedupe, and short-circuits to `""` (the existing "omit DOW entirely" convention used by the step-path) when any element already covers all 7 days.

Closes #465

## Test plan

- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)
- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] New regression tests:
  - `0,7` → `Sun *-*-* 09:00:00`
  - `1,3,5` → `Mon,Wed,Fri *-*-* 09:00:00`
  - `0-6,7` → `*-*-* 09:00:00` (DOW omitted)
- [x] Existing range/wildcard cases (`1-5`, `*`, `0-6`, `0-7`) still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)