### PR TITLE
fix(task): remove scheduler files when InstallScheduler fails (#458)

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -109,11 +110,25 @@ var tasksAddCmd = &cobra.Command{
 		}
 
 		if err := installScheduler(s); err != nil {
-			// Rollback: remove the task we just added
-			if removeErr := task.RemoveTask(s.ID); removeErr != nil {
-				log.ErrorLog.Printf("failed to rollback task after scheduler install failure: %v", removeErr)
+			// InstallScheduler writes the systemd unit/timer (or launchd
+			// plist) to disk BEFORE running systemctl/launchctl, so a
+			// failure on the external command leaves the scheduler files
+			// behind. RemoveTask alone only clears the JSON record, so
+			// we must also call RemoveScheduler to clean up those files
+			// (fixes #458). Both rollbacks are best-effort and run
+			// independently — if one fails the other is still attempted,
+			// and any failures are folded into the returned error so the
+			// user knows what to clean up manually.
+			msg := fmt.Sprintf("failed to install task scheduler: %v", err)
+			if rmSchedErr := removeScheduler(s); rmSchedErr != nil {
+				log.ErrorLog.Printf("failed to remove scheduler files during rollback: %v", rmSchedErr)
+				msg += fmt.Sprintf("; scheduler file cleanup also failed: %v", rmSchedErr)
 			}
-			return jsonError(fmt.Errorf("failed to install task scheduler: %w", err))
+			if removeErr := removeTask(s.ID); removeErr != nil {
+				log.ErrorLog.Printf("failed to rollback task after scheduler install failure: %v", removeErr)
+				msg += fmt.Sprintf("; task record rollback also failed: %v", removeErr)
+			}
+			return jsonError(errors.New(msg))
 		}
 
 		return jsonOut(map[string]any{"id": id})

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"errors"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/task"
@@ -414,4 +416,122 @@ func TestTasksRemove_RollbackInstallAlsoFails(t *testing.T) {
 	got, err := task.GetTask("r4")
 	require.NoError(t, err, "task record must remain when RemoveTask fails")
 	assert.Equal(t, "r4", got.ID)
+}
+
+// resetAddFlags clears the package-level add flag variables so add-path
+// tests don't leak state into each other.
+func resetAddFlags(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		taskAddNameFlag = ""
+		taskAddPromptFlag = ""
+		taskAddCronFlag = ""
+		taskAddProgramFlag = ""
+		repoFlag = ""
+	})
+	taskAddNameFlag = ""
+	taskAddPromptFlag = ""
+	taskAddCronFlag = ""
+	taskAddProgramFlag = ""
+}
+
+// setupAddRepo creates a throwaway git repo so resolveRepo() inside
+// tasksAddCmd succeeds. Returns the repo path.
+func setupAddRepo(t *testing.T) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, exec.Command("git", "init", repo).Run(), "git init")
+	require.NoError(t, exec.Command("git", "-C", repo, "config", "user.email", "test@example.com").Run())
+	require.NoError(t, exec.Command("git", "-C", repo, "config", "user.name", "Test User").Run())
+	require.NoError(t, exec.Command("git", "-C", repo, "commit", "--allow-empty", "-m", "init").Run())
+	repoFlag = repo
+	return repo
+}
+
+// TestTasksAdd_HappyPathDoesNotRollBack is the regression guard for the
+// existing behavior: when installScheduler succeeds, neither
+// removeScheduler nor removeTask runs.
+func TestTasksAdd_HappyPathDoesNotRollBack(t *testing.T) {
+	useTempConfig(t)
+	resetAddFlags(t)
+	calls := stubSchedulers(t)
+	setupAddRepo(t)
+
+	taskAddNameFlag = "happy"
+	taskAddPromptFlag = "hello"
+	taskAddCronFlag = "0 9 * * *"
+	taskAddProgramFlag = "claude"
+
+	err := tasksAddCmd.RunE(tasksAddCmd, nil)
+	require.NoError(t, err)
+
+	require.Len(t, calls.installed, 1, "installScheduler runs once")
+	assert.Empty(t, calls.removed, "no rollback when install succeeds")
+
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1, "task record must persist on success")
+}
+
+// TestTasksAdd_InstallSchedulerFailsRollsBackBoth is the regression
+// test for #458: when installScheduler fails after writing scheduler
+// files, the rollback must call BOTH removeScheduler (to clean up
+// systemd unit/timer or launchd plist) and removeTask (to clean up the
+// JSON record).
+func TestTasksAdd_InstallSchedulerFailsRollsBackBoth(t *testing.T) {
+	useTempConfig(t)
+	resetAddFlags(t)
+	calls := stubSchedulers(t)
+	setupAddRepo(t)
+
+	calls.installErrs = []error{errors.New("simulated systemctl enable failure")}
+
+	taskAddNameFlag = "rollback-both"
+	taskAddPromptFlag = "p"
+	taskAddCronFlag = "0 9 * * *"
+	taskAddProgramFlag = "claude"
+
+	err := tasksAddCmd.RunE(tasksAddCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to install task scheduler")
+
+	require.Len(t, calls.installed, 1, "installScheduler runs once")
+	require.Len(t, calls.removed, 1, "rollback must call removeScheduler to clean up files written before install failure")
+
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	assert.Empty(t, tasks, "task record must be removed when scheduler install fails")
+}
+
+// TestTasksAdd_RollbackRemoveSchedulerAlsoFails verifies that when the
+// scheduler-file rollback ALSO fails, removeTask is still attempted and
+// the returned error names both failures so the user can clean up
+// orphaned scheduler files manually.
+func TestTasksAdd_RollbackRemoveSchedulerAlsoFails(t *testing.T) {
+	useTempConfig(t)
+	resetAddFlags(t)
+	calls := stubSchedulers(t)
+	setupAddRepo(t)
+
+	calls.installErrs = []error{errors.New("simulated systemctl enable failure")}
+	calls.removeErrs = []error{errors.New("simulated scheduler cleanup failure")}
+
+	taskAddNameFlag = "rollback-fail"
+	taskAddPromptFlag = "p"
+	taskAddCronFlag = "0 9 * * *"
+	taskAddProgramFlag = "claude"
+
+	err := tasksAddCmd.RunE(tasksAddCmd, nil)
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "simulated systemctl enable failure", "primary install failure must surface")
+	assert.Contains(t, msg, "simulated scheduler cleanup failure", "scheduler-rollback failure must surface")
+	assert.Contains(t, msg, "scheduler file cleanup also failed")
+
+	require.Len(t, calls.installed, 1, "installScheduler runs once")
+	require.Len(t, calls.removed, 1, "removeScheduler is still attempted")
+
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	assert.Empty(t, tasks, "removeTask must still run even when scheduler rollback fails")
 }

--- a/app/app.go
+++ b/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/keys"
@@ -507,11 +508,24 @@ func (m *home) handleTaskCreate() tea.Cmd {
 		return m.handleError(fmt.Errorf("failed to save task: %v", err))
 	}
 	if err := task.InstallScheduler(t); err != nil {
-		// Rollback: remove the task we just added
+		// InstallScheduler writes the systemd unit/timer (or launchd
+		// plist) to disk BEFORE running systemctl/launchctl, so a
+		// failure on the external command leaves the scheduler files
+		// behind. RemoveTask alone only clears the JSON record, so we
+		// must also call RemoveScheduler to clean up those files
+		// (fixes #458). Both rollbacks are best-effort and run
+		// independently; failures are folded into the returned error so
+		// the user knows what to clean up manually.
+		msg := fmt.Sprintf("failed to install task scheduler: %v", err)
+		if rmSchedErr := task.RemoveScheduler(t); rmSchedErr != nil {
+			log.ErrorLog.Printf("failed to remove scheduler files during rollback: %v", rmSchedErr)
+			msg += fmt.Sprintf("; scheduler file cleanup also failed: %v", rmSchedErr)
+		}
 		if removeErr := task.RemoveTask(t.ID); removeErr != nil {
 			log.ErrorLog.Printf("failed to rollback task after scheduler install failure: %v", removeErr)
+			msg += fmt.Sprintf("; task record rollback also failed: %v", removeErr)
 		}
-		return m.handleError(fmt.Errorf("failed to install task scheduler: %v", err))
+		return m.handleError(errors.New(msg))
 	}
 	// Refresh sidebar and task pane
 	tasks, err := task.LoadTasksForCurrentRepo()


### PR DESCRIPTION
## Summary
- `InstallScheduler` writes the systemd unit/timer (or launchd plist) to disk *before* running the external `systemctl`/`launchctl` commands. When those external commands fail, the scheduler files remain on disk while the previous rollback only called `RemoveTask`, leaving orphaned units the user had to clean up by hand.
- Both `handleTaskCreate` (app/app.go) and `tasksAddCmd` (api/tasks.go) now call `RemoveScheduler` before `RemoveTask` on install failure. Both rollbacks are best-effort and run independently; any rollback failure is folded into the returned error so the user knows what's left to clean up.
- Adds three regression tests in `api/tasks_test.go`: happy path stays no-rollback, an install-fail rolls back both calls, and a rollback-of-the-rollback still attempts `RemoveTask` and surfaces both errors.

## Test Plan
- [x] `gofmt -l .` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go build ./...` — clean
- [x] `go test -race ./...` — green (one unrelated flake in `TestRealTUI_CreateThroughKeypresses` passed on rerun)

Closes #458

Co-Authored-By: Captain Claude <noreply@anthropic.com>