### PR TITLE
fix(ui): ensure ESC/Ctrl+C always cancel Confirmation dialog (#468)

### DIFF
--- a/ui/overlay/confirmationOverlay.go
+++ b/ui/overlay/confirmationOverlay.go
@@ -43,17 +43,21 @@ func NewConfirmationOverlay(message string) *ConfirmationOverlay {
 // Returns true if the overlay should be closed
 func (c *ConfirmationOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
 	key := strings.ToLower(msg.String())
+	// ESC and Ctrl+C must always cancel. The UI promises "esc to cancel", so
+	// check the cancel branch first — if ConfirmKey is misconfigured to "esc"
+	// or "ctrl+c", the dialog becomes cancel-only rather than silently
+	// confirming a destructive action.
 	switch key {
-	case strings.ToLower(c.ConfirmKey):
-		c.Dismissed = true
-		if c.OnConfirm != nil {
-			c.OnConfirm()
-		}
-		return true
 	case strings.ToLower(c.CancelKey), "esc", "ctrl+c":
 		c.Dismissed = true
 		if c.OnCancel != nil {
 			c.OnCancel()
+		}
+		return true
+	case strings.ToLower(c.ConfirmKey):
+		c.Dismissed = true
+		if c.OnConfirm != nil {
+			c.OnConfirm()
 		}
 		return true
 	default:

--- a/ui/overlay/confirmationOverlay_test.go
+++ b/ui/overlay/confirmationOverlay_test.go
@@ -61,6 +61,80 @@ func TestConfirmationOverlay_HandleKeyPress_ConfirmKey(t *testing.T) {
 	assert.True(t, confirmCalled, "OnConfirm should be called")
 }
 
+func TestConfirmationOverlay_HandleKeyPress_CancelKey(t *testing.T) {
+	overlay := NewConfirmationOverlay("Test confirmation")
+
+	cancelCalled := false
+	overlay.OnCancel = func() {
+		cancelCalled = true
+	}
+
+	confirmCalled := false
+	overlay.OnConfirm = func() {
+		confirmCalled = true
+	}
+
+	nMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
+	shouldClose := overlay.HandleKeyPress(nMsg)
+
+	assert.True(t, shouldClose, "cancel key should close the overlay")
+	assert.True(t, overlay.Dismissed, "overlay should be dismissed")
+	assert.True(t, cancelCalled, "OnCancel should be called")
+	assert.False(t, confirmCalled, "OnConfirm should not be called")
+}
+
+// TestConfirmationOverlay_HandleKeyPress_EscBeatsConfirmKey verifies the
+// invariant from #468: when ConfirmKey is set to "esc", pressing ESC must
+// still cancel rather than silently confirming a destructive action.
+func TestConfirmationOverlay_HandleKeyPress_EscBeatsConfirmKey(t *testing.T) {
+	overlay := NewConfirmationOverlay("Test confirmation")
+	overlay.SetConfirmKey("esc")
+
+	cancelCalled := false
+	overlay.OnCancel = func() {
+		cancelCalled = true
+	}
+
+	confirmCalled := false
+	overlay.OnConfirm = func() {
+		confirmCalled = true
+	}
+
+	escMsg := tea.KeyMsg{Type: tea.KeyEsc}
+	shouldClose := overlay.HandleKeyPress(escMsg)
+
+	assert.True(t, shouldClose, "esc should close the overlay")
+	assert.True(t, overlay.Dismissed, "overlay should be dismissed")
+	assert.True(t, cancelCalled, "OnCancel should be called even when ConfirmKey is esc")
+	assert.False(t, confirmCalled, "OnConfirm must not be called for esc")
+}
+
+// TestConfirmationOverlay_HandleKeyPress_CtrlCBeatsConfirmKey verifies the
+// invariant from #468 for Ctrl+C: it must always cancel, even if ConfirmKey
+// is misconfigured to "ctrl+c".
+func TestConfirmationOverlay_HandleKeyPress_CtrlCBeatsConfirmKey(t *testing.T) {
+	overlay := NewConfirmationOverlay("Test confirmation")
+	overlay.SetConfirmKey("ctrl+c")
+
+	cancelCalled := false
+	overlay.OnCancel = func() {
+		cancelCalled = true
+	}
+
+	confirmCalled := false
+	overlay.OnConfirm = func() {
+		confirmCalled = true
+	}
+
+	ctrlCMsg := tea.KeyMsg{Type: tea.KeyCtrlC}
+	shouldClose := overlay.HandleKeyPress(ctrlCMsg)
+
+	assert.True(t, shouldClose, "ctrl+c should close the overlay")
+	assert.True(t, overlay.Dismissed, "overlay should be dismissed")
+	assert.True(t, cancelCalled, "OnCancel should be called even when ConfirmKey is ctrl+c")
+	assert.False(t, confirmCalled, "OnConfirm must not be called for ctrl+c")
+}
+
 func TestConfirmationOverlay_HandleKeyPress_OtherKey(t *testing.T) {
 	overlay := NewConfirmationOverlay("Test confirmation")
 


### PR DESCRIPTION
## Summary
- `ConfirmationOverlay.HandleKeyPress` matched `ConfirmKey` before the cancel branch, so when `ConfirmKey` was set to `esc` or `ctrl+c` (user config or an unintended default), pressing ESC silently confirmed a destructive action — contradicting the UI text "esc to cancel".
- Reordered the switch so the cancel branch (`CancelKey`, `"esc"`, `"ctrl+c"`) is matched first. If `ConfirmKey` is misconfigured to one of those keys, the dialog becomes cancel-only — safer than silently confirming.
- No public API or UI-text changes.

## Test plan
- [x] New regression test: `ConfirmKey="y"`, `CancelKey="n"` — `y` confirms, `n` cancels, `esc` cancels, `ctrl+c` cancels (existing tests plus a new `CancelKey` case).
- [x] New invariant test: `ConfirmKey="esc"` → ESC cancels, `OnConfirm` is never called.
- [x] New invariant test: `ConfirmKey="ctrl+c"` → Ctrl+C cancels, `OnConfirm` is never called.
- [x] `gofmt -l .` clean.
- [x] `golangci-lint run --timeout=3m --fast` clean.
- [x] `go build ./...` succeeds.
- [x] `go test -race ./...` passes.

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)