### PR TITLE
fix(ui): show scroll shortcuts in Preview tab menu (#467)

### DIFF
--- a/ui/menu.go
+++ b/ui/menu.go
@@ -178,8 +178,8 @@ func (m *Menu) addInstanceOptions() {
 	// Action group
 	actionGroup := []keys.KeyName{keys.KeyEnter}
 
-	// Navigation group (when in terminal tab)
-	if m.activeTab == TerminalTab {
+	// Navigation group (tabs that support scrolling)
+	if m.activeTab == TerminalTab || m.activeTab == PreviewTab {
 		actionGroup = append(actionGroup, keys.KeyShiftUp)
 		actionGroup = append(actionGroup, keys.KeyShiftDown)
 	}

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -34,16 +34,29 @@ func TestMenuTerminalTabShowsBothScrollKeys(t *testing.T) {
 	}
 }
 
-// TestMenuPreviewTabHidesScrollKeys ensures scroll shortcuts remain hidden
-// when the preview tab (not the terminal tab) is active.
-func TestMenuPreviewTabHidesScrollKeys(t *testing.T) {
+// TestMenuPreviewTabShowsBothScrollKeys verifies that the preview tab also
+// surfaces shift+up and shift+down — preview supports scrolling identically to
+// terminal, and the help screen documents the shortcuts for both. Regression
+// test for issue #467.
+func TestMenuPreviewTabShowsBothScrollKeys(t *testing.T) {
 	m := NewMenu()
 	m.SetInstance(&session.Instance{Status: session.Ready})
 	m.SetActiveTab(PreviewTab)
 
+	var gotShiftUp, gotShiftDown int
 	for _, k := range m.options {
-		if k == keys.KeyShiftUp || k == keys.KeyShiftDown {
-			t.Errorf("preview tab menu should not contain scroll keys, found %v", k)
+		switch k {
+		case keys.KeyShiftUp:
+			gotShiftUp++
+		case keys.KeyShiftDown:
+			gotShiftDown++
 		}
+	}
+
+	if gotShiftUp != 1 {
+		t.Errorf("expected exactly 1 KeyShiftUp in preview tab menu, got %d", gotShiftUp)
+	}
+	if gotShiftDown != 1 {
+		t.Errorf("expected exactly 1 KeyShiftDown in preview tab menu, got %d", gotShiftDown)
 	}
 }


### PR DESCRIPTION
## Summary

- The instance menu's shift+up / shift+down hints were only rendered when the Terminal tab was active, but the Preview tab supports scrolling identically and `app/help.go` documents the shortcut for "preview/terminal view". Users on the Preview tab had no on-screen indication that scroll was available.
- Extend the conditional in `ui/menu.go:addInstanceOptions` from `m.activeTab == TerminalTab` to `m.activeTab == TerminalTab || m.activeTab == PreviewTab`.
- Update `ui/menu_test.go`: the old `TestMenuPreviewTabHidesScrollKeys` case actually pinned the buggy behavior. Replace it with `TestMenuPreviewTabShowsBothScrollKeys` asserting the fix. `TestMenuTerminalTabShowsBothScrollKeys` stays as the regression guard for the existing Terminal-tab behavior.

(There are only two tabs in `TabbedWindow` — `PreviewTab` and `TerminalTab` — so no third "scroll keys NOT shown" case exists to test.)

Closes #467

## Test Plan

- [x] `gofmt -l .` → clean
- [x] `golangci-lint run --timeout=3m --fast` → clean
- [x] `go build ./...` → clean
- [x] `go test -race ./...` → all packages pass (ui, app, integration, etc.)
- [ ] Manual: open af, focus Preview tab on a Ready instance, confirm `shift ↑ scroll up` / `shift ↓ scroll down` render in the menu bar and scrolling still works on both tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)