### PR TITLE
fix(overlay): fade multi-parameter ANSI SGR sequences (#469)

### DIFF
--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -17,7 +17,7 @@ import (
 var (
 	bgColorRegex     = regexp.MustCompile(`\x1b\[(?:[0-9;]*;)?48;[25];[0-9;]+m`)
 	fgColorRegex     = regexp.MustCompile(`\x1b\[(?:[0-9;]*;)?38;[25];[0-9;]+m`)
-	simpleColorRegex = regexp.MustCompile(`\x1b\[[0-9]+m`)
+	simpleColorRegex = regexp.MustCompile(`\x1b\[[0-9;]+m`)
 )
 
 // WhitespaceOption sets a styling rule for rendering whitespace.
@@ -71,19 +71,34 @@ func PlaceOverlay(
 		// Replace foreground color codes with a faded version
 		content = fgColorRegex.ReplaceAllString(content, "\x1b[38;5;240m") // Medium gray foreground
 
-		// Replace simple color codes with a faded version
+		// Replace simple color codes with a faded version. Handles both
+		// single-parameter (e.g. \x1b[37m) and multi-parameter (e.g.
+		// \x1b[1;37m) SGR sequences emitted by lipgloss in 16-color mode.
 		content = simpleColorRegex.ReplaceAllStringFunc(content, func(match string) string {
-			// Skip reset codes
+			// Preserve pure reset (\x1b[0m) so styled regions still close.
 			if match == "\x1b[0m" {
 				return match
 			}
 			codeText := strings.TrimSuffix(strings.TrimPrefix(match, "\x1b["), "m")
-			code, err := strconv.Atoi(codeText)
-			if err == nil && (code == 7 || (code >= 40 && code <= 47) || (code >= 100 && code <= 107)) {
+			isBg := false
+			hasFadeableParam := false
+			for _, p := range strings.Split(codeText, ";") {
+				code, err := strconv.Atoi(p)
+				if err != nil || code == 0 {
+					continue
+				}
+				hasFadeableParam = true
+				if code == 7 || (code >= 40 && code <= 47) || (code >= 100 && code <= 107) {
+					isBg = true
+				}
+			}
+			if !hasFadeableParam {
+				return match
+			}
+			if isBg {
 				return "\x1b[48;5;236m" // Dark gray background
 			}
-			// Replace with dimmed color
-			return "\x1b[38;5;240m" // Medium gray
+			return "\x1b[38;5;240m" // Medium gray foreground
 		})
 
 		fadedBgLines[i] = content

--- a/ui/overlay/overlay_test.go
+++ b/ui/overlay/overlay_test.go
@@ -131,3 +131,52 @@ func TestPlaceOverlayReverseVideoFadesAsBackground(t *testing.T) {
 		t.Fatalf("expected reverse-video styling to preserve background semantics, got: %q", result)
 	}
 }
+
+// TestPlaceOverlaySingleParamForegroundFade verifies the pre-existing
+// single-parameter case (e.g. \x1b[37m) is still faded to the medium-gray
+// foreground. Regression guard for the regex broadening in #469.
+func TestPlaceOverlaySingleParamForegroundFade(t *testing.T) {
+	result := PlaceOverlay(0, 0, "XX", "\x1b[37mhello\x1b[0m", false)
+
+	if !strings.Contains(result, "\x1b[38;5;240m") {
+		t.Fatalf("expected single-param fg code to be faded, got: %q", result)
+	}
+	if strings.Contains(result, "\x1b[37m") {
+		t.Fatalf("original \\x1b[37m should have been rewritten, got: %q", result)
+	}
+	if !strings.Contains(result, "\x1b[0m") {
+		t.Fatalf("trailing reset should be preserved, got: %q", result)
+	}
+}
+
+// TestPlaceOverlayMultiParamForegroundFade covers the #469 bug: lipgloss in
+// 16-color mode emits multi-parameter SGR sequences like \x1b[1;37m (bold +
+// white). The original regex only matched single-parameter sequences, so these
+// passed through the fade logic unchanged and stayed visible under overlays.
+func TestPlaceOverlayMultiParamForegroundFade(t *testing.T) {
+	result := PlaceOverlay(0, 0, "XX", "\x1b[1;37mhello\x1b[0m", false)
+
+	if strings.Contains(result, "\x1b[1;37m") {
+		t.Fatalf("multi-param SGR \\x1b[1;37m leaked through fade: %q", result)
+	}
+	if !strings.Contains(result, "\x1b[38;5;240m") {
+		t.Fatalf("expected multi-param fg code to be faded, got: %q", result)
+	}
+	if !strings.Contains(result, "\x1b[0m") {
+		t.Fatalf("trailing reset should be preserved, got: %q", result)
+	}
+}
+
+// TestPlaceOverlayMultiParamBackgroundFade verifies that a multi-parameter SGR
+// whose parameters include a background-color code is faded to the dark-gray
+// background rather than the foreground gray.
+func TestPlaceOverlayMultiParamBackgroundFade(t *testing.T) {
+	result := PlaceOverlay(0, 0, "XX", "\x1b[1;41mbold-red-bg\x1b[0m", false)
+
+	if strings.Contains(result, "\x1b[1;41m") {
+		t.Fatalf("multi-param SGR \\x1b[1;41m leaked through fade: %q", result)
+	}
+	if !strings.Contains(result, "\x1b[48;5;236m") {
+		t.Fatalf("expected multi-param bg code to be faded to bg gray, got: %q", result)
+	}
+}


### PR DESCRIPTION
## Summary
- `ui/overlay/overlay.go` only matched single-parameter SGR sequences (`\x1b\[[0-9]+m`), so multi-parameter sequences emitted by lipgloss in the ANSI 16-color profile — e.g. `\x1b[1;37m` for bold + white when `TERM=xterm/linux/screen` — slipped past the fade and stayed visible behind overlays.
- Broadened the regex to `\x1b\[[0-9;]+m` and taught the replacement function to walk every semicolon-separated parameter. If any parameter is a background-color or reverse-video code the sequence fades to the dark-gray background; otherwise it fades to the medium-gray foreground. Pure `\x1b[0m` resets and sequences with no fadeable parameters (e.g. `\x1b[0;0m`) are left untouched.

Closes #469

## Test plan
- [x] `gofmt -l .` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go build ./...`
- [x] `go test -race ./...` (the unrelated `integration.TestConcurrentCLIClientsUseDaemonCoordinator` flaked once on a busy host and passed when re-run in isolation)
- [x] New `ui/overlay/overlay_test.go` cases:
  - `TestPlaceOverlaySingleParamForegroundFade` — regression guard for the pre-existing `\x1b[37m` path.
  - `TestPlaceOverlayMultiParamForegroundFade` — the #469 case: `\x1b[1;37m` fades to fg gray and the trailing `\x1b[0m` stays a reset.
  - `TestPlaceOverlayMultiParamBackgroundFade` — `\x1b[1;41m` fades to bg gray rather than fg gray.

🤖 Generated with [Claude Code](https://claude.com/claude-code)