### PR TITLE
fix(worktree): accept worktrees under filesystem root (#461)

### DIFF
--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -12,6 +12,20 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
+// isPathStrictlyInside reports whether absBase is a strict descendant of
+// absDir (absBase != absDir and absBase is not outside absDir). Both
+// arguments must be absolute, cleaned paths.
+func isPathStrictlyInside(absBase, absDir string) bool {
+	rel, err := filepath.Rel(absDir, absBase)
+	if err != nil {
+		return false
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
 // getWorktreeDirectoryForRepo returns the parent directory of the repo,
 // so worktrees are created as siblings next to the repository.
 func getWorktreeDirectoryForRepo(repoPath string) (string, error) {
@@ -139,10 +153,13 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 
 	basePath := filepath.Join(worktreeDir, repoName+"-"+safeSessionName)
 
-	// Ensure the worktree path is under worktreeDir
+	// Ensure the worktree path is strictly nested inside worktreeDir. We use
+	// filepath.Rel instead of a HasPrefix check so the validation is correct
+	// when worktreeDir is the filesystem root ("/"): the naive prefix check
+	// produces "//" and rejects every valid child path. See #461.
 	absBase, _ := filepath.Abs(basePath)
 	absDir, _ := filepath.Abs(worktreeDir)
-	if !strings.HasPrefix(absBase, absDir+string(filepath.Separator)) {
+	if !isPathStrictlyInside(absBase, absDir) {
 		return nil, "", fmt.Errorf("invalid session name: would create worktree outside expected directory")
 	}
 

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -351,6 +351,31 @@ func TestGetWorktreeDirectoryForRepo_FromLinkedWorktree(t *testing.T) {
 		"new worktrees should be placed next to the main repo, not next to a linked worktree")
 }
 
+// TestIsPathStrictlyInside covers the containment check used to validate that
+// a derived worktree path lives under the configured worktree directory. The
+// `/`-root cases exercise the fix for #461.
+func TestIsPathStrictlyInside(t *testing.T) {
+	cases := []struct {
+		name    string
+		absBase string
+		absDir  string
+		want    bool
+	}{
+		{"nested under home", "/home/user/repo-session", "/home/user", true},
+		{"nested under root", "/repo-session", "/", true},
+		{"sibling directory", "/home/user2/foo", "/home/user", false},
+		{"equal to dir", "/home/user", "/home/user", false},
+		{"equal to root", "/", "/", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isPathStrictlyInside(tc.absBase, tc.absDir)
+			assert.Equal(t, tc.want, got,
+				"isPathStrictlyInside(%q, %q)", tc.absBase, tc.absDir)
+		})
+	}
+}
+
 func createGitRepo(t *testing.T) string {
 	t.Helper()
 	repoRoot := filepath.Join(t.TempDir(), "repo")


### PR DESCRIPTION
## Summary
- `NewGitWorktree` validated the derived basePath with `strings.HasPrefix(absBase, absDir+string(filepath.Separator))`. When the repo lives at the filesystem root, `absDir` is `/` and the joined prefix becomes `//`, which never matches a valid absolute path — so every session for a root-level repo failed with `invalid session name: would create worktree outside expected directory`.
- Replaced the prefix check with a `filepath.Rel`-based helper (`isPathStrictlyInside`) that correctly accepts strict descendants of `absDir` and rejects equal-or-outside paths, regardless of whether `absDir` is `/` or a deeper directory.
- Added unit tests for the helper covering the regression case, the fix case, sibling rejection, and equal-path rejection (including at `/`).

Closes #461

## Test plan
- [x] `gofmt -l .`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `go build ./...`
- [x] `go test -race ./session/git/... -count=1`
- [x] `go test -race ./... -count=1` (integration daemon flakes verified pre-existing, pass on rerun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)