### PR TITLE
feat(ui): replace task Program textinput with agent selector (#492)

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -25,9 +25,10 @@ const ProgramClaude = "claude"
 const ProgramCodex = "codex"
 const ProgramAider = "aider"
 const ProgramGemini = "gemini"
+const ProgramAmp = "amp"
 
 // SupportedPrograms is the canonical list of known agent programs.
-var SupportedPrograms = []string{ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini}
+var SupportedPrograms = []string{ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini, ProgramAmp}
 
 // AgentNameFromProgram extracts a short, user-facing agent name from a program
 // command string. It first looks for a known SupportedPrograms token (after

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -12,20 +12,34 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// programDefaultLabel is the selector option that resolves to an empty Program
+// string (the daemon then falls back to the user's configured default_program).
+const programDefaultLabel = "(use config default)"
+
 // TaskPane renders an inline task editor in the right pane.
 type TaskPane struct {
 	tasks       []task.Task
 	selectedIdx int
 
 	// Edit mode
-	editing     bool
-	editName    textinput.Model
-	editPrompt  textarea.Model
-	editCron    textinput.Model
-	editPath    textinput.Model
-	editProgram textinput.Model
-	editError   string // last validation error shown to the user
-	focusIndex  int    // 0=name, 1=prompt, 2=cron, 3=path, 4=program, 5=save button
+	editing    bool
+	editName   textinput.Model
+	editPrompt textarea.Model
+	editCron   textinput.Model
+	editPath   textinput.Model
+	// Program selector state. editProgramOptions is the list of choices shown
+	// inline (index 0 is always the "use config default" entry, followed by
+	// tmux.SupportedPrograms, optionally followed by a "(custom: ...)" entry
+	// preserving an unrecognized legacy program string from before #492).
+	editProgramOptions []string
+	editProgramIdx     int
+	// editProgramCustom holds the raw legacy program string when the existing
+	// task.Program doesn't match any canonical option. The selector renders
+	// "(custom: <raw>)" for it and writes the raw value back on save unless
+	// the user chooses a different option.
+	editProgramCustom string
+	editError         string // last validation error shown to the user
+	focusIndex        int    // 0=name, 1=prompt, 2=cron, 3=path, 4=program, 5=save button
 
 	// Create mode
 	creating       bool
@@ -130,20 +144,58 @@ func (s *TaskPane) EnterCreateMode(defaultPath string) {
 	path.CharLimit = 256
 	path.Blur()
 
-	program := textinput.New()
-	program.Placeholder = "leave empty for config default"
-	program.CharLimit = 256
-	program.Blur()
-
 	s.editName = name
 	s.editPrompt = prompt
 	s.editCron = cron
 	s.editPath = path
-	s.editProgram = program
+	s.setProgramFromValue("")
 	s.focusIndex = 0
 	s.creating = true
 	s.hasFocus = true
 	s.editError = ""
+}
+
+// setProgramFromValue initializes the selector state from a stored Program
+// string. An empty value selects "(use config default)"; a value matching a
+// SupportedPrograms entry pre-selects that canonical option; anything else is
+// preserved verbatim as a "(custom: <raw>)" option so editing other fields
+// can't accidentally rewrite a legacy command line.
+func (s *TaskPane) setProgramFromValue(value string) {
+	opts := make([]string, 0, len(tmux.SupportedPrograms)+2)
+	opts = append(opts, programDefaultLabel)
+	opts = append(opts, tmux.SupportedPrograms...)
+
+	trimmed := strings.TrimSpace(value)
+	s.editProgramCustom = ""
+	if trimmed == "" {
+		s.editProgramOptions = opts
+		s.editProgramIdx = 0
+		return
+	}
+	for i, p := range tmux.SupportedPrograms {
+		if trimmed == p {
+			s.editProgramOptions = opts
+			s.editProgramIdx = i + 1
+			return
+		}
+	}
+	s.editProgramCustom = value
+	opts = append(opts, fmt.Sprintf("(custom: %s)", value))
+	s.editProgramOptions = opts
+	s.editProgramIdx = len(opts) - 1
+}
+
+// programValue returns the Program string corresponding to the current
+// selector state: "" for the default option, the raw custom string for the
+// custom entry, or the canonical agent name otherwise.
+func (s *TaskPane) programValue() string {
+	if s.editProgramIdx <= 0 || s.editProgramIdx >= len(s.editProgramOptions) {
+		return ""
+	}
+	if s.editProgramCustom != "" && s.editProgramIdx == len(s.editProgramOptions)-1 {
+		return s.editProgramCustom
+	}
+	return s.editProgramOptions[s.editProgramIdx]
 }
 
 // HasPendingCreate returns true if a new task was submitted and needs saving.
@@ -155,7 +207,7 @@ func (s *TaskPane) HasPendingCreate() bool {
 // program is the user-supplied program override; empty means "use the caller's default".
 func (s *TaskPane) ConsumePendingCreate() (name, prompt, cron, path, program string) {
 	s.pendingCreate = false
-	return s.editName.Value(), s.editPrompt.Value(), s.editCron.Value(), s.editPath.Value(), s.editProgram.Value()
+	return s.editName.Value(), s.editPrompt.Value(), s.editCron.Value(), s.editPath.Value(), s.programValue()
 }
 
 // SetPendingTrigger marks the currently selected task to be triggered.
@@ -270,17 +322,11 @@ func (s *TaskPane) enterEditMode() {
 	path.CharLimit = 256
 	path.Blur()
 
-	program := textinput.New()
-	program.SetValue(tsk.Program)
-	program.Placeholder = "leave empty for config default"
-	program.CharLimit = 256
-	program.Blur()
-
 	s.editName = name
 	s.editPrompt = prompt
 	s.editCron = cron
 	s.editPath = path
-	s.editProgram = program
+	s.setProgramFromValue(tsk.Program)
 	s.focusIndex = 0
 	s.editing = true
 	s.editError = ""
@@ -326,7 +372,7 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 				s.tasks[s.selectedIdx].Prompt = s.editPrompt.Value()
 				s.tasks[s.selectedIdx].CronExpr = s.editCron.Value()
 				s.tasks[s.selectedIdx].ProjectPath = s.editPath.Value()
-				s.tasks[s.selectedIdx].Program = s.editProgram.Value()
+				s.tasks[s.selectedIdx].Program = s.programValue()
 				s.dirty = true
 				s.editing = false
 			}
@@ -346,10 +392,29 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 		case 3:
 			s.editPath, _ = s.editPath.Update(msg)
 		case 4:
-			s.editProgram, _ = s.editProgram.Update(msg)
+			s.handleProgramKey(msg)
 		}
 	}
 	return true
+}
+
+// handleProgramKey moves the selector cursor when the Program field has focus.
+// Up/k and down/j navigate; other keys are ignored so the selector behaves
+// like a list, not a free-text input (#492).
+func (s *TaskPane) handleProgramKey(msg tea.KeyMsg) {
+	if len(s.editProgramOptions) == 0 {
+		return
+	}
+	switch msg.String() {
+	case "up", "k", "left", "h":
+		if s.editProgramIdx > 0 {
+			s.editProgramIdx--
+		}
+	case "down", "j", "right", "l":
+		if s.editProgramIdx < len(s.editProgramOptions)-1 {
+			s.editProgramIdx++
+		}
+	}
 }
 
 func (s *TaskPane) updateEditFocus() {
@@ -357,7 +422,6 @@ func (s *TaskPane) updateEditFocus() {
 	s.editPrompt.Blur()
 	s.editCron.Blur()
 	s.editPath.Blur()
-	s.editProgram.Blur()
 
 	switch s.focusIndex {
 	case 0:
@@ -368,8 +432,6 @@ func (s *TaskPane) updateEditFocus() {
 		s.editCron.Focus()
 	case 3:
 		s.editPath.Focus()
-	case 4:
-		s.editProgram.Focus()
 	}
 }
 
@@ -489,7 +551,6 @@ func (s *TaskPane) renderEditMode() string {
 	}
 	s.editCron.Width = inputWidth
 	s.editPath.Width = inputWidth
-	s.editProgram.Width = inputWidth
 
 	var b strings.Builder
 	if s.creating {
@@ -516,9 +577,9 @@ func (s *TaskPane) renderEditMode() string {
 	b.WriteString(s.editPath.View())
 	b.WriteString("\n")
 	b.WriteString(labelStyle.Render("Program:"))
-	b.WriteString("  ")
-	b.WriteString(s.editProgram.View())
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+	b.WriteString(s.renderProgramSelector())
+	b.WriteString("\n")
 
 	submitLabel := " Save "
 	if s.creating {
@@ -536,6 +597,36 @@ func (s *TaskPane) renderEditMode() string {
 		b.WriteString(errorStyle.Render("! " + s.editError))
 	}
 
+	return b.String()
+}
+
+// renderProgramSelector renders the inline agent selector. Focused selection
+// is highlighted in yellow with a ▸ marker; the unfocused row gets the
+// dim/focus-hint treatment used by the rest of the edit form.
+func (s *TaskPane) renderProgramSelector() string {
+	focused := s.focusIndex == 4
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
+	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
+	dimSelectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+
+	var b strings.Builder
+	for i, opt := range s.editProgramOptions {
+		isSel := i == s.editProgramIdx
+		switch {
+		case isSel && focused:
+			b.WriteString("    " + selectedStyle.Render("▸ "+opt))
+		case isSel:
+			b.WriteString("    " + dimSelectedStyle.Render("▸ "+opt))
+		default:
+			b.WriteString("    " + normalStyle.Render("  "+opt))
+		}
+		b.WriteString("\n")
+	}
+	if focused {
+		hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+		b.WriteString("    " + hintStyle.Render("↑/↓ change agent"))
+		b.WriteString("\n")
+	}
 	return b.String()
 }
 

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -84,82 +84,126 @@ func TestTaskPaneNormalModeAllowsQuitKeysToPropagate(t *testing.T) {
 	assert.False(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlC}))
 }
 
-// TestTaskPaneCreateModeCapturesProgram drives the create form with the same
-// key events the bubbletea runtime would deliver, confirming that the Program
-// field is captured into the pending-create payload alongside the existing
-// fields. Regression test for #453.
-func TestTaskPaneCreateModeCapturesProgram(t *testing.T) {
+// fillCreateForm types a name and cron into the create form so submitting via
+// the Save button doesn't trip name/cron validation. Leaves focus on index 0
+// (Name) so callers can walk to whichever field they want to drive next.
+func fillCreateForm(t *testing.T, tp *TaskPane, name string) {
+	t.Helper()
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(name)})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> cron
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
+	// Walk back to name (index 0) so callers can navigate forward consistently.
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
+}
+
+// TestTaskPaneCreateModeSelectorDefaultsToConfigDefault verifies that creating
+// a new task without touching the Program selector persists "" so the daemon
+// uses the configured default_program. Regression test for #492.
+func TestTaskPaneCreateModeSelectorDefaultsToConfigDefault(t *testing.T) {
 	tp := NewTaskPane()
 	tp.EnterCreateMode("/tmp/repo")
+	fillCreateForm(t, tp, "daily")
 
-	typeRunes := func(runes string) {
-		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(runes)})
-	}
-
-	// Name
-	typeRunes("daily")
-	// Move to prompt, cron, path, program (program is focus index 4).
-	for i := 0; i < 4; i++ {
-		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
-	}
-	// Replace the default path with a valid value isn't necessary — path
-	// already carries the default. Type into the program field.
-	typeRunes("aider")
-	// Set a valid cron by jumping back to the cron field.
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
-	// We're on cron now (index 2); type a valid expression.
-	typeRunes("* * * * *")
-	// Walk forward past path and program to the submit button (index 5).
-	for i := 0; i < 3; i++ {
+	// Walk to the Save button (index 5) without touching the Program selector.
+	for i := 0; i < 5; i++ {
 		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
 	}
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.True(t, tp.HasPendingCreate(), "submit should mark a pending create")
-	name, _, cron, path, program := tp.ConsumePendingCreate()
-	assert.Equal(t, "daily", name)
-	assert.Equal(t, "* * * * *", cron)
-	assert.Equal(t, "/tmp/repo", path)
-	assert.Equal(t, "aider", program, "Program field must be carried through to the pending-create payload")
+	_, _, _, _, program := tp.ConsumePendingCreate()
+	assert.Equal(t, "", program, "default selector option must persist an empty Program")
 }
 
-// TestTaskPaneEditModePersistsProgramChange confirms that editing an existing
-// task's Program field via the form writes the change back to the task slice
-// so the caller persists it on save. Regression test for #453.
-func TestTaskPaneEditModePersistsProgramChange(t *testing.T) {
+// TestTaskPaneCreateModeSelectorPicksCanonicalAgent verifies that advancing
+// the Program selector to a SupportedPrograms entry persists the canonical
+// bare name (no path, no flags). Regression test for #492.
+func TestTaskPaneCreateModeSelectorPicksCanonicalAgent(t *testing.T) {
+	tp := NewTaskPane()
+	tp.EnterCreateMode("/tmp/repo")
+	fillCreateForm(t, tp, "daily")
+
+	// Walk to the Program field (index 4) and step the selector to "claude"
+	// (option index 1: 0 is the default sentinel, 1 is the first supported).
+	for i := 0; i < 4; i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	}
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyDown})
+	// Advance to the Save button and submit.
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.True(t, tp.HasPendingCreate(), "submit should mark a pending create")
+	_, _, _, _, program := tp.ConsumePendingCreate()
+	assert.Equal(t, "claude", program, "selector must persist the canonical agent name")
+}
+
+// TestTaskPaneEditModePresetFromExistingProgram verifies that opening edit
+// mode on a task whose Program already matches a SupportedPrograms entry
+// pre-selects that option so saving without changes is a no-op. Regression
+// test for #492.
+func TestTaskPaneEditModePresetFromExistingProgram(t *testing.T) {
 	tp := NewTaskPane()
 	tp.SetTasks([]task.Task{{
 		ID:          "abc",
-		Name:        "old-name",
+		Name:        "nightly",
 		Prompt:      "do it",
 		CronExpr:    "* * * * *",
 		ProjectPath: "/tmp/repo",
-		Program:     "claude",
+		Program:     "aider",
 		Enabled:     true,
 	}})
 	tp.SetFocus(true)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}) // enter edit mode
 	assert.True(t, tp.IsEditing())
 
-	// Walk to the Program field (index 4).
-	for i := 0; i < 4; i++ {
+	// Tab to Save and submit without touching the selector.
+	for i := 0; i < 5; i++ {
 		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
 	}
-	// Clear by overwriting: textinput.Update treats backspace as delete.
-	for i := 0; i < len("claude"); i++ {
-		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyBackspace})
-	}
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("aider")})
-	// Tab to the Save button (index 5) and press enter.
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.False(t, tp.IsEditing(), "save should exit edit mode")
-	assert.True(t, tp.IsDirty(), "edit should mark the pane dirty")
 	tasks := tp.GetTasks()
 	if assert.Len(t, tasks, 1) {
-		assert.Equal(t, "aider", tasks[0].Program, "Program field must reflect the edited value")
+		assert.Equal(t, "aider", tasks[0].Program,
+			"pre-selected canonical option must round-trip the original value")
+	}
+}
+
+// TestTaskPaneEditModePreservesCustomProgram verifies that opening edit mode
+// on a task whose Program is a legacy free-text command preserves the raw
+// value verbatim — saving without explicit change must not collapse it to
+// a canonical agent name (#492).
+func TestTaskPaneEditModePreservesCustomProgram(t *testing.T) {
+	tp := NewTaskPane()
+	const raw = "/usr/local/bin/aider --model gpt-4"
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "* * * * *",
+		ProjectPath: "/tmp/repo",
+		Program:     raw,
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}) // enter edit mode
+	assert.True(t, tp.IsEditing())
+
+	// Tab to Save and submit without touching the selector.
+	for i := 0; i < 5; i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	}
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.False(t, tp.IsEditing(), "save should exit edit mode")
+	tasks := tp.GetTasks()
+	if assert.Len(t, tasks, 1) {
+		assert.Equal(t, raw, tasks[0].Program,
+			"legacy free-text program must be preserved verbatim across edit/save")
 	}
 }
 


### PR DESCRIPTION
Closes #492.

## Audit findings

1. **New-instance program selector** lives in `app/handle_input.go:97-112` (Tab keypress in `stateNew` opens a modal `overlay.NewSelectionOverlay` populated from `tmux.SupportedPrograms`). The submit handler is `app/handle_overlay.go:57-79`. The overlay component itself is `ui/overlay/selectionOverlay.go`.
2. **`tmux.SupportedPrograms`** at `session/tmux/tmux.go:30` previously listed only `[claude, codex, aider, gemini]`. `amp` was not a first-class agent (only a generic string in `session/systemprompt_test.go:97`). The CLAUDE.md operating contract advertises Amp as supported, so I added `ProgramAmp` to the canonical list.
3. **`ui/task_pane.go`** (added in #454) wired Program as a `textinput.Model` at focus index 4, written to `task.Program` in the save path at `ui/task_pane.go:329`. The list view already collapses the stored string to the agent name via `tmux.AgentNameFromProgram` (#455) — that side stays as-is.
4. **`app/handle_input.go`** / the daemon don't transform `task.Program` further — it flows through to the runtime tmux launch unchanged.

## Design choice

I considered reusing the existing modal `SelectionOverlay`, but it's wired into app-level state (`m.state = stateSelectProgram`) and reaching it from inside the task pane would require routing through a new state and submit-handler. That's a lot of plumbing for a pane-local concern.

Instead I added an inline list selector inside the task pane:

- Focus index 4 (Program) renders the list of canonical agents plus a `(use config default)` first option.
- ↑/↓ (or h/j/k/l, ←/→) move the cursor; Tab/Shift-Tab still moves between fields; Enter on Save (index 5) writes the selection.
- Empty-string Program maps to the default sentinel.
- An existing `task.Program` that exactly matches a canonical agent pre-selects it. Anything else (legacy free-text command, path with flags) is preserved verbatim as a `(custom: <raw>)` entry so saving doesn't accidentally rewrite it.

No persisted shape changed (still `Task.Program string`), the API output is unchanged, and `af tasks add --program` still accepts arbitrary strings.

### Note on Amp

`amp` is added to `SupportedPrograms` so it appears in the selector. The runtime tmux launch already works generically for any binary on PATH (codex follows the same minimal pattern without per-agent behavior in `tmux.go`/`backend_local.go`). Adding richer behavior for `amp` — autoyes prompt detection, trust-prompt taps, system-prompt injection — would be a separate end-to-end piece of work and is out of scope for this PR.

## Test Plan

- [x] `gofmt -l .` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go build ./...` clean
- [x] `go test -race ./...` green
- [x] New tests cover the four selector behaviors:
  - `TestTaskPaneCreateModeSelectorDefaultsToConfigDefault` — new task with the default option persists `""`.
  - `TestTaskPaneCreateModeSelectorPicksCanonicalAgent` — stepping the selector to `claude` persists `"claude"`.
  - `TestTaskPaneEditModePresetFromExistingProgram` — task with `Program="aider"` pre-selects aider and round-trips on save.
  - `TestTaskPaneEditModePreservesCustomProgram` — task with `Program="/usr/local/bin/aider --model gpt-4"` preserves the raw value verbatim across edit/save.
- [ ] Manual: `./dev-install.sh`, open the TUI, hit `n` on a repo's task pane, confirm the Program row now shows a selector listing `(use config default)` + supported agents; pick one, save, confirm the persisted task picks it up; edit a task whose `Program` is a legacy free-text command and confirm it shows up as `(custom: …)` and survives save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)