### PR TITLE
revert(tmux): drop ProgramAmp from SupportedPrograms (#494)

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -25,10 +25,9 @@ const ProgramClaude = "claude"
 const ProgramCodex = "codex"
 const ProgramAider = "aider"
 const ProgramGemini = "gemini"
-const ProgramAmp = "amp"
 
 // SupportedPrograms is the canonical list of known agent programs.
-var SupportedPrograms = []string{ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini, ProgramAmp}
+var SupportedPrograms = []string{ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini}
 
 // AgentNameFromProgram extracts a short, user-facing agent name from a program
 // command string. It first looks for a known SupportedPrograms token (after

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -376,6 +376,10 @@ func TestAgentNameFromProgram(t *testing.T) {
 		{"unknown binary with flags", "foo --bar", "foo"},
 		{"unknown absolute path", "/opt/tools/foo --bar baz", "foo"},
 		{"uppercase canonical", "CLAUDE --foo", "claude"},
+		// amp is intentionally not in SupportedPrograms (see #494); the helper
+		// must still degrade gracefully and yield the basename so reintroducing
+		// it requires an explicit decision.
+		{"amp falls through basename", "amp", "amp"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Removes `ProgramAmp` constant and the `ProgramAmp` entry from `SupportedPrograms` in `session/tmux/tmux.go`. The slice is back to `[ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini]`.
- Adds a `TestAgentNameFromProgram` case asserting `amp` → `amp` via the basename fallback, so reintroducing it requires an intentional `SupportedPrograms` edit.
- This is a targeted revert of the amp additions from #493 only — the inline new-instance selector and the `(custom: ...)` preservation from #493 are preserved.

## Audit (grep results)
```
$ grep -rn "ProgramAmp\|\"amp\"" --include="*.go" .
session/systemprompt_test.go:97:	result := injectSystemPrompt("amp", "test-session", dir)
session/systemprompt_test.go:99:	if result != "amp" {
session/tmux/tmux.go:28:const ProgramAmp = "amp"
session/tmux/tmux.go:31:var SupportedPrograms = []string{..., ProgramAmp}
```
- `session/tmux/tmux.go`: removed both lines.
- `session/systemprompt_test.go`: `TestInjectSystemPrompt_UnknownProgram` uses `"amp"` as a representative *unknown* program (pre-#493 behavior). With amp removed from `SupportedPrograms` it is again unknown — the test's intent is satisfied and the code path is unchanged. Left alone.
- No references in `app/`, `ui/`, `config/`, or `task/`.
- `CLAUDE.md` mentions "Amp" once in the user-edited tagline at line 3 — left untouched (out of scope; not a `SupportedPrograms` enumeration).
- `README.md` does not mention Amp.
- Task pane / new-instance selector tests in `ui/task_pane_test.go` and `app/handle_overlay_test.go` use field indices and canonical names (`claude`, `aider`), not the program count — no updates needed.

## Test Plan
- [x] `gofmt -l .` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go build ./...` — succeeds
- [x] `go test -race ./...` — all packages pass (including `session/tmux` with the new `amp falls through basename` case and `session` with the existing unknown-program test)

Closes #494

Co-Authored-By: Captain Claude <noreply@anthropic.com>