### PR TITLE
fix(tmux): tolerate missing sessions in non-daemon call-sites (#496)

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -86,6 +86,14 @@ type TmuxSession struct {
 
 const TmuxPrefix = "af_"
 
+// ErrSessionGone is returned by PTY/tmux operations when the underlying tmux
+// session no longer exists. Non-daemon callers (preview pane, sidebar resize,
+// terminal pane) use errors.Is to detect this case and degrade gracefully
+// (render an inactive-session state, skip silently) instead of logging at
+// ERROR level (#496). The daemon's statusMonitor has its own latch (#489) and
+// does not use this sentinel.
+var ErrSessionGone = errors.New("tmux session no longer exists")
+
 // DetachKeyByte is the ASCII byte for the key used to detach from attached sessions.
 // Default is 23 (Ctrl-W). Set via SetDetachKey.
 var DetachKeyByte byte = 23
@@ -360,7 +368,9 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
 		// monitor as dead so the daemon's per-second poll doesn't spam
 		// the log (#489). Transient capture-pane failures while the
 		// session is still alive are rare and still surface every tick.
-		if !t.DoesSessionExist() {
+		// CapturePaneContent has already probed DoesSessionExist on the
+		// error path, so use the wrapped sentinel rather than re-probing.
+		if errors.Is(err, ErrSessionGone) {
 			log.ErrorLog.Printf("tmux session %s is gone; status monitor going silent (capture-pane error: %v)", t.sanitizedName, err)
 			t.monitor.dead = true
 			return false, false
@@ -609,7 +619,20 @@ func (t *TmuxSession) Close() error {
 // SetDetachedSize set the width and height of the session while detached. This makes the
 // tmux output conform to the specified shape.
 func (t *TmuxSession) SetDetachedSize(width, height int) error {
-	return t.updateWindowSize(width, height)
+	// Detach failure (or Close) clears t.ptmx (#474), and the tmux session
+	// may have been killed externally. Guard the ioctl so a missing PTY
+	// surfaces as ErrSessionGone instead of panicking on nil.Fd() or
+	// logging "bad file descriptor" at ERROR (#496).
+	if t.ptmx == nil {
+		return ErrSessionGone
+	}
+	if err := t.updateWindowSize(width, height); err != nil {
+		if !t.DoesSessionExist() {
+			return fmt.Errorf("%w: %v", ErrSessionGone, err)
+		}
+		return err
+	}
+	return nil
 }
 
 // updateWindowSize updates the window size of the PTY.
@@ -628,24 +651,34 @@ func (t *TmuxSession) DoesSessionExist() bool {
 	return t.cmdExec.Run(existsCmd) == nil
 }
 
-// CapturePaneContent captures the content of the tmux pane
+// CapturePaneContent captures the content of the tmux pane. When the
+// capture fails and DoesSessionExist confirms the session is gone, the
+// returned error wraps ErrSessionGone so non-daemon callers can degrade
+// gracefully instead of logging at ERROR (#496).
 func (t *TmuxSession) CapturePaneContent() (string, error) {
 	// Add -e flag to preserve escape sequences (ANSI color codes)
 	cmd := exec.Command("tmux", "capture-pane", "-p", "-e", "-J", "-t", t.sanitizedName)
 	output, err := t.cmdExec.Output(cmd)
 	if err != nil {
+		if !t.DoesSessionExist() {
+			return "", fmt.Errorf("%w: capture-pane: %v", ErrSessionGone, err)
+		}
 		return "", fmt.Errorf("error capturing pane content: %v", err)
 	}
 	return string(output), nil
 }
 
 // CapturePaneContentWithOptions captures the pane content with additional options
-// start and end specify the starting and ending line numbers (use "-" for the start/end of history)
+// start and end specify the starting and ending line numbers (use "-" for the start/end of history).
+// Wraps ErrSessionGone when the session has vanished, mirroring CapturePaneContent.
 func (t *TmuxSession) CapturePaneContentWithOptions(start, end string) (string, error) {
 	// Add -e flag to preserve escape sequences (ANSI color codes)
 	cmd := exec.Command("tmux", "capture-pane", "-p", "-e", "-J", "-S", start, "-E", end, "-t", t.sanitizedName)
 	output, err := t.cmdExec.Output(cmd)
 	if err != nil {
+		if !t.DoesSessionExist() {
+			return "", fmt.Errorf("%w: capture-pane: %v", ErrSessionGone, err)
+		}
 		return "", fmt.Errorf("failed to capture tmux pane content with options: %v", err)
 	}
 	return string(output), nil

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	cmd2 "github.com/sachiniyer/agent-factory/cmd"
 	"math/rand"
@@ -357,6 +358,62 @@ func TestHasUpdatedTransientErrorKeepsLogging(t *testing.T) {
 	require.Equal(t, int32(3), hasSessionCalls.Load())
 	require.Equal(t, 3, strings.Count(logs.String(), "error capturing pane content in status monitor"))
 	require.NotContains(t, logs.String(), "going silent")
+}
+
+// TestCapturePaneContentWrapsErrSessionGoneWhenGone covers #496: a vanished
+// tmux session must surface to non-daemon callers as ErrSessionGone so the
+// preview pane can render an inactive-session state instead of
+// handleError-ing at ERROR.
+func TestCapturePaneContentWrapsErrSessionGoneWhenGone(t *testing.T) {
+	var captureOK, sessionAlive atomic.Bool
+	// capture-pane fails AND has-session reports dead.
+	session, _, _ := makeAttachedSession(t, &captureOK, &sessionAlive)
+
+	_, err := session.CapturePaneContent()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSessionGone,
+		"capture-pane failure on a gone session must wrap ErrSessionGone")
+}
+
+// TestCapturePaneContentTransientErrorDoesNotWrap guards the other branch:
+// if has-session still reports alive, the wrap must NOT happen — callers
+// should still see/log the original error and operators get visibility into
+// rare transient capture-pane failures.
+func TestCapturePaneContentTransientErrorDoesNotWrap(t *testing.T) {
+	var captureOK, sessionAlive atomic.Bool
+	sessionAlive.Store(true) // alive but capture fails
+	session, _, _ := makeAttachedSession(t, &captureOK, &sessionAlive)
+
+	_, err := session.CapturePaneContent()
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrSessionGone),
+		"transient capture-pane error must not be misclassified as ErrSessionGone")
+	require.Contains(t, err.Error(), "error capturing pane content")
+}
+
+// TestCapturePaneContentWithOptionsWrapsErrSessionGone mirrors the
+// CapturePaneContent test for the scroll-mode/full-history path that
+// PreviewFullHistory and the terminal pane's scroll mode use.
+func TestCapturePaneContentWithOptionsWrapsErrSessionGone(t *testing.T) {
+	var captureOK, sessionAlive atomic.Bool
+	session, _, _ := makeAttachedSession(t, &captureOK, &sessionAlive)
+
+	_, err := session.CapturePaneContentWithOptions("-", "-")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSessionGone)
+}
+
+// TestSetDetachedSizeReturnsErrSessionGoneWhenPtmxNil covers #496: when the
+// PTY has been cleared (Detach failure in #474, Close, or never restored),
+// SetDetachedSize must surface ErrSessionGone instead of panicking on
+// nil.Fd() or emitting "bad file descriptor" at ERROR.
+func TestSetDetachedSizeReturnsErrSessionGoneWhenPtmxNil(t *testing.T) {
+	var captureOK, sessionAlive atomic.Bool
+	session, _, _ := makeAttachedSession(t, &captureOK, &sessionAlive)
+	require.Nil(t, session.ptmx, "precondition: helper builds a session without a PTY")
+
+	err := session.SetDetachedSize(80, 24)
+	require.ErrorIs(t, err, ErrSessionGone)
 }
 
 func TestAgentNameFromProgram(t *testing.T) {

--- a/ui/list.go
+++ b/ui/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -72,7 +73,9 @@ func (l *List) SetSize(width, height int) {
 }
 
 // SetSessionPreviewSize sets the height and width for the tmux sessions. This makes the stdout line have the correct
-// width and height.
+// width and height. Instances whose tmux session has vanished are skipped
+// silently (ErrSessionGone) so an external `tmux kill-session` doesn't spam
+// ERROR logs on every window-resize (#496).
 func (l *List) SetSessionPreviewSize(width, height int) (err error) {
 	for i, item := range l.items {
 		if !item.Started() {
@@ -80,6 +83,9 @@ func (l *List) SetSessionPreviewSize(width, height int) (err error) {
 		}
 
 		if innerErr := item.SetPreviewSize(width, height); innerErr != nil {
+			if errors.Is(innerErr, tmux.ErrSessionGone) {
+				continue
+			}
 			err = errors.Join(
 				err, fmt.Errorf("could not set preview size for instance %d: %v", i, innerErr))
 		}

--- a/ui/preview.go
+++ b/ui/preview.go
@@ -1,7 +1,9 @@
 package ui
 
 import (
+	"errors"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -84,6 +86,11 @@ func (p *PreviewPane) UpdateContent(instance *session.Instance) error {
 		// Capture full pane content including scrollback history using capture-pane -p -S -
 		content, err = instance.PreviewFullHistory()
 		if err != nil {
+			if errors.Is(err, tmux.ErrSessionGone) {
+				p.isScrolling = false
+				p.setFallbackState("Session no longer running.")
+				return nil
+			}
 			return err
 		}
 
@@ -97,6 +104,14 @@ func (p *PreviewPane) UpdateContent(instance *session.Instance) error {
 		// In normal mode, use the usual preview
 		content, err = instance.Preview()
 		if err != nil {
+			// Tmux session vanished out from under us (#496). Render an
+			// inactive-session fallback instead of propagating the error
+			// up to handleError, which would log "error capturing pane
+			// content" at ERROR every preview tick (every 100ms).
+			if errors.Is(err, tmux.ErrSessionGone) {
+				p.setFallbackState("Session no longer running.")
+				return nil
+			}
 			return err
 		}
 
@@ -193,6 +208,10 @@ func (p *PreviewPane) ScrollUp(instance *session.Instance) error {
 		// Entering scroll mode - capture entire pane content including scrollback history
 		content, err := instance.PreviewFullHistory()
 		if err != nil {
+			if errors.Is(err, tmux.ErrSessionGone) {
+				p.setFallbackState("Session no longer running.")
+				return nil
+			}
 			return err
 		}
 
@@ -226,6 +245,10 @@ func (p *PreviewPane) ScrollDown(instance *session.Instance) error {
 		// Entering scroll mode - capture entire pane content including scrollback history
 		content, err := instance.PreviewFullHistory()
 		if err != nil {
+			if errors.Is(err, tmux.ErrSessionGone) {
+				p.setFallbackState("Session no longer running.")
+				return nil
+			}
 			return err
 		}
 
@@ -270,6 +293,10 @@ func (p *PreviewPane) ResetToNormalMode(instance *session.Instance) error {
 		// Immediately update content instead of waiting for next UpdateContent call
 		content, err := instance.Preview()
 		if err != nil {
+			if errors.Is(err, tmux.ErrSessionGone) {
+				p.setFallbackState("Session no longer running.")
+				return nil
+			}
 			return err
 		}
 		p.previewState.text = content

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/log"
@@ -10,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -582,6 +584,74 @@ func setupTwoInstances(t *testing.T, previewA, previewB string) (*session.Instan
 		log.Close()
 	}
 	return a, b, cleanup
+}
+
+// TestPreviewUpdateContentSessionGoneRendersFallback is the #496 regression:
+// when the underlying tmux session vanishes between ticks, UpdateContent
+// must enter the inactive-session fallback rather than propagate an error
+// that the app-level handleError would log at ERROR every 100ms.
+func TestPreviewUpdateContentSessionGoneRendersFallback(t *testing.T) {
+	var sessionCreated, sessionGone atomic.Bool
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			cmdStr := cmd.String()
+			if strings.Contains(cmdStr, "has-session") {
+				if sessionGone.Load() {
+					return fmt.Errorf("session gone")
+				}
+				if sessionCreated.Load() {
+					return nil
+				}
+				return fmt.Errorf("session does not exist")
+			}
+			if strings.Contains(cmdStr, "new-session") {
+				sessionCreated.Store(true)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			cmdStr := cmd.String()
+			if strings.Contains(cmdStr, "capture-pane") {
+				if sessionGone.Load() {
+					return nil, fmt.Errorf("exit status 1")
+				}
+				return []byte("hello world"), nil
+			}
+			return []byte(""), nil
+		},
+	}
+
+	setup := setupTestEnvironment(t, cmdExec)
+	defer setup.cleanupFn()
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+
+	// Happy path first: session alive, normal content renders.
+	require.NoError(t, p.UpdateContent(setup.instance))
+	require.False(t, p.previewState.fallback,
+		"happy path must not render fallback")
+	require.Contains(t, p.previewState.text, "hello world")
+
+	// Session vanishes externally; redirect ErrorLog so we can prove
+	// UpdateContent does not log anything at ERROR.
+	var errBuf bytes.Buffer
+	prev := log.ErrorLog.Writer()
+	log.ErrorLog.SetOutput(&errBuf)
+	defer log.ErrorLog.SetOutput(prev)
+
+	sessionGone.Store(true)
+
+	err := p.UpdateContent(setup.instance)
+	require.NoError(t, err,
+		"dead session must NOT bubble an error up to handleError")
+	require.True(t, p.previewState.fallback,
+		"preview must enter fallback state when session is gone")
+	require.Contains(t, p.previewState.text, "Session no longer running")
+	require.Empty(t, errBuf.String(),
+		"no ERROR log line on session-gone fallback path")
 }
 
 // TestPreviewSwitchInstanceResetsScroll is a regression test for issue #470:

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -1,9 +1,11 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 	"strings"
 
@@ -86,7 +88,10 @@ func (s *Sidebar) SetSize(width, height int) {
 	s.renderer.setWidth(width)
 }
 
-// SetSessionPreviewSize sets the tmux session preview sizes.
+// SetSessionPreviewSize sets the tmux session preview sizes. Instances whose
+// underlying tmux session has vanished (ErrSessionGone) are skipped silently
+// — the daemon-side latch already covers ongoing polling and the resize itself
+// has no useful work to do on a dead session (#496).
 func (s *Sidebar) SetSessionPreviewSize(width, height int) error {
 	var err error
 	for i, item := range s.instances {
@@ -94,6 +99,9 @@ func (s *Sidebar) SetSessionPreviewSize(width, height int) error {
 			continue
 		}
 		if innerErr := item.SetPreviewSize(width, height); innerErr != nil {
+			if errors.Is(innerErr, tmux.ErrSessionGone) {
+				continue
+			}
 			err = fmt.Errorf("could not set preview size for instance %d: %v", i, innerErr)
 		}
 	}

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 	"strings"
 	"testing"
@@ -183,6 +184,39 @@ func TestSidebarInstanceManagement(t *testing.T) {
 	instances := s.GetInstances()
 	assert.Len(t, instances, 1)
 	assert.Equal(t, "test", instances[0].Title)
+}
+
+// goneSetPreviewSizeBackend wraps FakeBackend so SetPreviewSize emulates the
+// state after `tmux kill-session`: the underlying tmux/PTY layer returns
+// ErrSessionGone. Used to verify the sidebar's SetSessionPreviewSize swallows
+// the sentinel rather than spamming ERROR (#496).
+type goneSetPreviewSizeBackend struct {
+	*session.FakeBackend
+}
+
+func (b *goneSetPreviewSizeBackend) SetPreviewSize(*session.Instance, int, int) error {
+	return tmux.ErrSessionGone
+}
+
+// TestSidebarSetSessionPreviewSizeSkipsErrSessionGone is the #496 regression:
+// when an instance's tmux session has vanished, item.SetPreviewSize returns
+// ErrSessionGone, and the sidebar wrapper must skip that instance silently —
+// not surface it as a returned error that the caller (app.go:226) would log
+// at ERROR on every window-resize.
+func TestSidebarSetSessionPreviewSizeSkipsErrSessionGone(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false)
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: "dead", Path: t.TempDir(), Program: "test",
+	})
+	require.NoError(t, err)
+	inst.SetBackend(&goneSetPreviewSizeBackend{FakeBackend: session.NewFakeBackend()})
+	inst.SetStartedForTest(true)
+	s.AddInstance(inst)
+
+	require.NoError(t, s.SetSessionPreviewSize(80, 24),
+		"ErrSessionGone from a single instance must not propagate as a returned error")
 }
 
 func TestSidebarSelectInstance(t *testing.T) {

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -119,6 +120,14 @@ func (t *TerminalPane) UpdateContent(instance *session.Instance) error {
 
 	content, err := s.tmuxSession.CapturePaneContent()
 	if err != nil {
+		// The DoesSessionExist pre-check above can race against an external
+		// kill of the tmux session. When CapturePaneContent reports the
+		// session is gone, fall through to the fallback state instead of
+		// propagating an error that handleError logs at ERROR (#496).
+		if errors.Is(err, tmux.ErrSessionGone) {
+			t.setFallbackState("Terminal session no longer running.")
+			return nil
+		}
 		return fmt.Errorf("terminal pane: failed to capture content: %w", err)
 	}
 
@@ -342,6 +351,10 @@ func (t *TerminalPane) enterScrollMode() error {
 
 	content, err := s.tmuxSession.CapturePaneContentWithOptions("-", "-")
 	if err != nil {
+		if errors.Is(err, tmux.ErrSessionGone) {
+			t.setFallbackState("Terminal session no longer running.")
+			return nil
+		}
 		return fmt.Errorf("terminal pane: failed to capture full history: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

After #490 stopped the daemon's status monitor from spamming ERROR when a tmux session vanished, my log monitor caught three other ERROR-level call-sites that hit the same dead-session condition and didn't have the same latch. This audits every non-daemon tmux/PTY call-site and gives the leaking ones a clean degradation path.

Closes #496

## Audit

Grepped `app/`, `ui/`, and `daemon/` for calls into `session/tmux/` that do PTY I/O or shell out to `tmux`. Classification:

| Call-site | Path | Classification | Action |
|---|---|---|---|
| `app/app.go:225` → `sidebar.SetSessionPreviewSize` → `instance.SetPreviewSize` → `ts.SetDetachedSize` → `pty.Setsize` | window-resize | **(c) MISSING** — logs `could not set preview size for instance N: bad file descriptor` at ERROR | **fix** |
| `app/app.go:779` → `tw.UpdatePreview` → `preview.UpdateContent` → `instance.Preview` → `ts.CapturePaneContent` | preview tick (100ms) | **(c) MISSING** — logs `error capturing pane content: exit status 1` at ERROR every tick via `handleError` | **fix** |
| `app/app.go:782` → `tw.UpdateTerminal` → `terminal.UpdateContent` → `ts.CapturePaneContent` | terminal tab tick | **(a) Tolerant** mostly (pre-checks `DoesSessionExist` at `ui/terminal.go:115`) but races against external kill → same ERROR via `handleError` | **fix the race** |
| `ui/preview.go` ScrollUp/ScrollDown/ResetToNormalMode → `instance.PreviewFullHistory` | user scrolls preview | **(c) MISSING** — propagates error up; today logged at InfoLog only by tabbed_window's scroll wrappers, but the underlying capture failure still raises noise on dead sessions | **fix** |
| `ui/terminal.go:343` `enterScrollMode` → `ts.CapturePaneContentWithOptions` | user scrolls terminal | (a) Tolerant (pre-checks `DoesSessionExist`) but races same as above | **fix the race** |
| `ui/terminal.go:60` / `:210` `ts.SetDetachedSize` | terminal pane resize / ensure | (a) Tolerant — already logs at InfoLog only. Now also returns `ErrSessionGone` instead of panicking on nil PTY | covered by typed return |
| `daemon/daemon.go:55` → `instance.HasUpdated` | daemon poll | **(b) Daemon-fixed** by #490 (`monitor.dead` latch) | unchanged behavior |
| `app/app.go:301` autoyes → `instance.HasUpdated` | autoyes tap | **(b) Daemon-fixed** by #490 (same latch via Backend.HasUpdated) | unchanged |
| `TmuxSession.Attach` callers | `app/handle_actions.go:214,225`, `app/app.go:727`, `ui/terminal.go:232` | (a) Tolerant — `Attach` pre-checks `t.ptmx == nil` and returns a real error | skip |
| `daemon/control.go:500` `NewTmuxSessionForRepo(...).DoesSessionExist()` | pre-creation probe | (a) Tolerant — just a probe | skip |
| `TmuxSession.Restore` / `Detach` / `Close` callers | various | (a) Tolerant — already handle missing-session via existing pathways | skip |

## Design choice

Took the typed-error path from the issue suggestion: `session/tmux` exports `ErrSessionGone`, and `CapturePaneContent`, `CapturePaneContentWithOptions`, and `SetDetachedSize` wrap it when the underlying tmux session has gone missing. Each call-site uses `errors.Is(err, tmux.ErrSessionGone)` to degrade gracefully:

- **Preview pane**: enters fallback with text "Session no longer running." instead of returning the error up to `handleError`.
- **Terminal pane**: enters fallback with "Terminal session no longer running." (covers the race against an external kill that the pre-check can't catch).
- **Sidebar / List `SetSessionPreviewSize`**: skips dead instances silently per-iteration; happy-path instances still error normally.

`SetDetachedSize` additionally nil-checks `t.ptmx` upfront so the post-#474 case where Detach failure cleared the handle returns `ErrSessionGone` rather than panicking on `nil.Fd()` or emitting the EBADF `bad file descriptor` line. After the ioctl, if it errored, the session-existence probe still wraps `ErrSessionGone` for the external-kill case.

`HasUpdated` (the daemon's call-site, already latch-fixed by #490) was refactored to use `errors.Is(err, ErrSessionGone)` instead of calling `DoesSessionExist` again — `CapturePaneContent` now does the probe on the error path internally, so the old #489 test's "exactly one has-session call per first poll" property is preserved.

No public TmuxSession or Backend API surface changes beyond the new sentinel.

## Test Plan

Local gates (all clean):
- [x] `gofmt -l .` (no output)
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `go build ./...`
- [x] `go test -race ./...` — all packages green (`session/tmux`, `ui`, `app`, `daemon`, `integration`, …)

New tests:

`session/tmux/tmux_test.go`:
- [x] `TestCapturePaneContentWrapsErrSessionGoneWhenGone` — capture-pane fails + has-session reports gone → returned error `errors.Is` matches `ErrSessionGone`.
- [x] `TestCapturePaneContentTransientErrorDoesNotWrap` — capture-pane fails + has-session reports alive → error returned but does NOT wrap `ErrSessionGone` (transient failures still visible).
- [x] `TestCapturePaneContentWithOptionsWrapsErrSessionGone` — same contract for the scroll-mode full-history variant.
- [x] `TestSetDetachedSizeReturnsErrSessionGoneWhenPtmxNil` — nil `t.ptmx` returns `ErrSessionGone` instead of panicking on `pty.Setsize`.

`ui/preview_test.go`:
- [x] `TestPreviewUpdateContentSessionGoneRendersFallback` — happy path renders content; after sessionGone flag flips, `UpdateContent` returns nil, enters fallback ("Session no longer running"), and emits **zero** ERROR-log lines (asserted by redirecting `log.ErrorLog`).

`ui/sidebar_test.go`:
- [x] `TestSidebarSetSessionPreviewSizeSkipsErrSessionGone` — an instance whose `SetPreviewSize` returns `ErrSessionGone` is skipped silently; the wrapper returns nil rather than folding the sentinel into a returned error string.

Manual verification (deferred to Captain Claude's dev box):
- [ ] Start TUI with at least one instance, kill its tmux session out-of-band (`tmux kill-session -t af_…`), confirm `agent-factory.log` does NOT get the previously-seen `app.go:226` (`bad file descriptor`) or `app.go:852` (`error capturing pane content: exit status 1`) ERROR lines.
- [ ] Preview pane for the killed instance shows "Session no longer running." Resize the window — no new ERROR lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)