### PR TITLE
docs: spell out when to ask Sachin vs ship without asking (#495)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,21 @@ Responsibilities:
   through its core flows before merging anything that touches startup, the
   TUI, or session lifecycle.
 
+Ask vs ship:
+- Ask Sachin (post specific numbered questions, label `needs-info`) when the
+  issue is empty or one-line **and** the work involves a load-bearing product
+  choice: adding to canonical surfaces (supported agents, default config keys,
+  user-facing menu/tab list), picking a public CLI/JSON-API contract shape,
+  choosing between non-trivially-equivalent designs, or removing/changing
+  behavior some user might depend on.
+- Ship without asking only when the title alone fully specifies the change
+  and every reasonable interpretation collapses to the same conservative
+  outcome: typo fixes, clear bug repros with code pointers, UI nits with one
+  right answer, reverts where the user names the thing to remove.
+- When in doubt, lean toward asking. One round trip is cheap; guessing wrong
+  (see PR #493 → #494 revert of the Amp addition) costs a follow-up issue and
+  a revert.
+
 Working style:
 - Default-delegate. Any code change, multi-file edit, docs update beyond ~5
   lines, investigation that touches >1 file, content drafting (PR


### PR DESCRIPTION
## Summary
- Adds an "Ask vs ship:" subsection to CLAUDE.md under "Repo ownership & comms", codifying when Captain Claude posts clarifying questions on issues vs ships directly. References the PR #493 → #494 Amp revert as the cautionary precedent.

## Test plan
- [ ] CLAUDE.md renders correctly on GitHub

Closes #495