### PR TITLE
feat(upgrade): restart daemon after successful binary swap (#498)

### DIFF
--- a/autoupdate.go
+++ b/autoupdate.go
@@ -80,7 +80,7 @@ func autoUpdate() error {
 		return err
 	}
 
-	execPath, err := os.Executable()
+	execPath, err := osExecutableFn()
 	if err != nil {
 		return fmt.Errorf("failed to find executable: %w", err)
 	}
@@ -95,7 +95,18 @@ func autoUpdate() error {
 		return fmt.Errorf("failed to write new binary: %w", err)
 	}
 
-	log.ErrorLog.Printf("auto-update: successfully updated to %s (effective on next launch)", latestVersion)
+	// Same rationale as `af upgrade` (#498): take down the running daemon so
+	// the next RPC respawns it from the freshly written binary. Quiet on the
+	// no-daemon path since autoUpdate runs in the background on every launch.
+	restarted, shutdownErr := requestDaemonShutdownFn()
+	switch {
+	case shutdownErr != nil:
+		log.WarningLog.Printf("auto-update: updated to %s but failed to restart daemon: %v", latestVersion, shutdownErr)
+	case restarted:
+		log.InfoLog.Printf("auto-update: updated to %s and stopped running daemon", latestVersion)
+	default:
+		log.InfoLog.Printf("auto-update: updated to %s (effective on next launch)", latestVersion)
+	}
 	return nil
 }
 

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -163,6 +163,100 @@ func TestAutoUpdateRecordsCheckOnDownloadFailure(t *testing.T) {
 	}
 }
 
+// TestAutoUpdateCallsShutdownAfterBinarySwap guards the #498 fix on the
+// background path: when autoUpdate() successfully writes a new binary, it
+// must also ask any running daemon to exit so users don't keep running
+// the stale image silently for days.
+func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
+	withTestHome(t)
+
+	tempBin := filepath.Join(t.TempDir(), "agent-factory")
+	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+
+	prevGOOS := runtimeGOOS
+	prevFetch := fetchLatestReleaseTagFn
+	prevDownload := downloadBinaryFn
+	prevVersion := version
+	prevExe := osExecutableFn
+	prevShutdown := requestDaemonShutdownFn
+	t.Cleanup(func() {
+		runtimeGOOS = prevGOOS
+		fetchLatestReleaseTagFn = prevFetch
+		downloadBinaryFn = prevDownload
+		version = prevVersion
+		osExecutableFn = prevExe
+		requestDaemonShutdownFn = prevShutdown
+	})
+
+	runtimeGOOS = "linux"
+	version = "1.0.0"
+	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.1", nil }
+	// Bypass the tarball extract by returning the raw binary directly.
+	downloadBinaryFn = func(string) ([]byte, error) { return []byte("new-binary"), nil }
+	osExecutableFn = func() (string, error) { return tempBin, nil }
+	shutdownCalls := 0
+	requestDaemonShutdownFn = func() (bool, error) {
+		shutdownCalls++
+		return true, nil
+	}
+
+	if err := autoUpdate(); err != nil {
+		t.Fatalf("autoUpdate: %v", err)
+	}
+	if shutdownCalls != 1 {
+		t.Fatalf("expected one Shutdown call, got %d", shutdownCalls)
+	}
+	got, err := os.ReadFile(tempBin)
+	if err != nil {
+		t.Fatalf("read upgraded binary: %v", err)
+	}
+	if string(got) != "new-binary" {
+		t.Fatalf("binary contents = %q, want new-binary", got)
+	}
+}
+
+// TestAutoUpdateSucceedsWhenShutdownErrors verifies that an error from
+// RequestShutdown is logged but does not cause autoUpdate to surface a
+// failure to the background goroutine — the binary is on disk.
+func TestAutoUpdateSucceedsWhenShutdownErrors(t *testing.T) {
+	withTestHome(t)
+
+	tempBin := filepath.Join(t.TempDir(), "agent-factory")
+	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+
+	prevGOOS := runtimeGOOS
+	prevFetch := fetchLatestReleaseTagFn
+	prevDownload := downloadBinaryFn
+	prevVersion := version
+	prevExe := osExecutableFn
+	prevShutdown := requestDaemonShutdownFn
+	t.Cleanup(func() {
+		runtimeGOOS = prevGOOS
+		fetchLatestReleaseTagFn = prevFetch
+		downloadBinaryFn = prevDownload
+		version = prevVersion
+		osExecutableFn = prevExe
+		requestDaemonShutdownFn = prevShutdown
+	})
+
+	runtimeGOOS = "linux"
+	version = "1.0.0"
+	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.1", nil }
+	downloadBinaryFn = func(string) ([]byte, error) { return []byte("new-binary"), nil }
+	osExecutableFn = func() (string, error) { return tempBin, nil }
+	requestDaemonShutdownFn = func() (bool, error) {
+		return false, errors.New("simulated rpc failure")
+	}
+
+	if err := autoUpdate(); err != nil {
+		t.Fatalf("autoUpdate should not fail when Shutdown errors, got: %v", err)
+	}
+}
+
 func TestIsNewer(t *testing.T) {
 	cases := []struct {
 		latest, current string

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -2,13 +2,16 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/rpc"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -27,6 +30,10 @@ const (
 	trustPromptRetryDelay    = time.Second
 	waitForReadyTimeout      = 60 * time.Second
 	waitForReadyPollInterval = 500 * time.Millisecond
+	// shutdownAckGrace delays the daemon main-loop teardown after a Shutdown
+	// RPC handler returns so the response can flush back to the caller before
+	// the listener closes.
+	shutdownAckGrace = 50 * time.Millisecond
 )
 
 var ensureDaemonMu sync.Mutex
@@ -78,6 +85,11 @@ type ImportRemoteHookSessionsResponse struct {
 
 type PingRequest struct{}
 type PingResponse struct {
+	OK bool
+}
+
+type ShutdownRequest struct{}
+type ShutdownResponse struct {
 	OK bool
 }
 
@@ -187,12 +199,76 @@ func ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest) ([]session.In
 	return resp.Instances, nil
 }
 
+// RequestShutdown asks any running daemon to exit cleanly via the control
+// socket. Returns (true, nil) when a daemon acknowledged the request and
+// will exit, (false, nil) when no daemon is running (no socket or connection
+// refused — common in CI, fresh installs, or interactive `af upgrade`), and
+// (false, err) for unexpected errors.
+//
+// This is invoked after `af upgrade` / autoUpdate() write a new binary so the
+// running daemon process, which still references the old binary's inode, is
+// taken down. A subsequent RPC call (CreateSession, KillSession, etc.) will
+// EnsureDaemon-respawn from the freshly written binary.
+func RequestShutdown() (bool, error) {
+	socketPath, err := DaemonSocketPath()
+	if err != nil {
+		return false, err
+	}
+	if _, statErr := os.Stat(socketPath); statErr != nil {
+		if errors.Is(statErr, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, statErr
+	}
+	var resp ShutdownResponse
+	if err := callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &resp); err != nil {
+		if isDaemonAbsentErr(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return resp.OK, nil
+}
+
+// isDaemonAbsentErr reports whether err from a dial/RPC call indicates that
+// no daemon is currently listening on the control socket (vs. some other
+// transport failure). Both ECONNREFUSED (stale socket, no listener) and
+// ENOENT (socket removed between Stat and Dial) qualify.
+func isDaemonAbsentErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, fs.ErrNotExist) {
+		return true
+	}
+	return false
+}
+
 type controlServer struct {
-	manager *Manager
+	manager      *Manager
+	shutdownCh   chan struct{}
+	shutdownOnce sync.Once
 }
 
 func (s *controlServer) Ping(_ PingRequest, resp *PingResponse) error {
 	resp.OK = true
+	return nil
+}
+
+// Shutdown acknowledges a request to terminate the daemon, then asynchronously
+// signals the main loop to tear down after a short grace period. The grace
+// lets the RPC response flush back to the caller before the listener closes.
+func (s *controlServer) Shutdown(_ ShutdownRequest, resp *ShutdownResponse) error {
+	resp.OK = true
+	if s.shutdownCh == nil {
+		return nil
+	}
+	s.shutdownOnce.Do(func() {
+		go func() {
+			time.Sleep(shutdownAckGrace)
+			close(s.shutdownCh)
+		}()
+	})
 	return nil
 }
 
@@ -230,7 +306,11 @@ func (s *controlServer) ImportRemoteHookSessions(req ImportRemoteHookSessionsReq
 	return nil
 }
 
-func startControlServer(manager *Manager) (func() error, error) {
+// startControlServer registers the control RPC service on the Unix socket and
+// returns a cleanup function that closes the listener and removes the socket
+// file. When shutdownCh is non-nil, the Shutdown RPC will close it on the
+// first invocation, allowing the daemon main loop to exit on RPC request.
+func startControlServer(manager *Manager, shutdownCh chan struct{}) (func() error, error) {
 	socketPath, err := DaemonSocketPath()
 	if err != nil {
 		return nil, err
@@ -250,7 +330,10 @@ func startControlServer(manager *Manager) (func() error, error) {
 	}
 
 	server := rpc.NewServer()
-	if err := server.RegisterName(controlServiceName, &controlServer{manager: manager}); err != nil {
+	if err := server.RegisterName(controlServiceName, &controlServer{
+		manager:    manager,
+		shutdownCh: shutdownCh,
+	}); err != nil {
 		_ = listener.Close()
 		return nil, err
 	}

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -2,9 +2,15 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
+	"io/fs"
+	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
@@ -98,7 +104,7 @@ func TestControlServerCreateAndKillSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	closeServer, err := startControlServer(manager)
+	closeServer, err := startControlServer(manager, nil)
 	if err != nil {
 		t.Fatalf("startControlServer: %v", err)
 	}
@@ -134,5 +140,145 @@ func TestControlServerCreateAndKillSession(t *testing.T) {
 	}
 	if len(stored) != 0 {
 		t.Fatalf("expected storage to be empty after kill, got %+v", stored)
+	}
+}
+
+// TestControlServerShutdownClosesChannel verifies that the Shutdown RPC
+// acknowledges with OK and closes the supplied shutdownCh exactly once,
+// which is what RunDaemon's main select uses to exit the daemon loop (#498).
+func TestControlServerShutdownClosesChannel(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	shutdownCh := make(chan struct{})
+	closeServer, err := startControlServer(manager, shutdownCh)
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	t.Cleanup(func() { _ = closeServer() })
+
+	var resp ShutdownResponse
+	if err := callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &resp); err != nil {
+		t.Fatalf("rpc Shutdown: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("Shutdown returned OK=false")
+	}
+
+	select {
+	case <-shutdownCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("shutdownCh was not closed within 2s after Shutdown RPC")
+	}
+
+	// A second Shutdown call must not double-close the channel (panic).
+	var resp2 ShutdownResponse
+	if err := callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &resp2); err != nil {
+		// The listener may already be closed depending on timing; accept
+		// either a successful ack or a transport-level error, but never a
+		// double-close panic on the server side.
+		t.Logf("second Shutdown returned (expected, may race with teardown): %v", err)
+	}
+}
+
+// TestRequestShutdownNoDaemon verifies that RequestShutdown silently
+// no-ops when no daemon socket exists — the case during `af upgrade` on a
+// fresh install or in CI.
+func TestRequestShutdownNoDaemon(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	restarted, err := RequestShutdown()
+	if err != nil {
+		t.Fatalf("RequestShutdown returned error when no daemon present: %v", err)
+	}
+	if restarted {
+		t.Fatalf("RequestShutdown reported restart when no daemon was running")
+	}
+}
+
+// TestRequestShutdownStaleSocket verifies that RequestShutdown treats a
+// socket file with no listener as "no daemon" (connection refused) rather
+// than propagating the transport error to callers.
+func TestRequestShutdownStaleSocket(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	socketPath, err := DaemonSocketPath()
+	if err != nil {
+		t.Fatalf("DaemonSocketPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A regular file at the socket path causes Dial to return ECONNREFUSED
+	// (or an equivalent transport error). RequestShutdown must swallow it.
+	if err := os.WriteFile(socketPath, nil, 0600); err != nil {
+		t.Fatalf("write stale socket placeholder: %v", err)
+	}
+
+	restarted, err := RequestShutdown()
+	if err != nil {
+		t.Fatalf("RequestShutdown returned error on stale socket: %v", err)
+	}
+	if restarted {
+		t.Fatalf("RequestShutdown reported restart against stale socket")
+	}
+}
+
+// TestRequestShutdownSuccess starts a real control server and verifies the
+// end-to-end Shutdown flow: client sees OK, server's shutdownCh closes.
+func TestRequestShutdownSuccess(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	shutdownCh := make(chan struct{})
+	closeServer, err := startControlServer(manager, shutdownCh)
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	t.Cleanup(func() { _ = closeServer() })
+
+	restarted, err := RequestShutdown()
+	if err != nil {
+		t.Fatalf("RequestShutdown: %v", err)
+	}
+	if !restarted {
+		t.Fatalf("expected restarted=true against live control server")
+	}
+	select {
+	case <-shutdownCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("shutdownCh was not closed after RequestShutdown")
+	}
+}
+
+// TestIsDaemonAbsentErr covers the small classifier RequestShutdown uses to
+// decide whether a dial/RPC failure means "no daemon" (silent no-op) or
+// "unexpected transport problem" (surface to the caller).
+func TestIsDaemonAbsentErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"connection refused", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, true},
+		{"no such file", &net.OpError{Op: "dial", Err: fs.ErrNotExist}, true},
+		{"wrapped enoent", errors.New("some other error"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isDaemonAbsentErr(c.err); got != c.want {
+				t.Errorf("isDaemonAbsentErr(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
 	}
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -25,7 +25,8 @@ func RunDaemon(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	closeControl, err := startControlServer(manager)
+	shutdownCh := make(chan struct{})
+	closeControl, err := startControlServer(manager, shutdownCh)
 	if err != nil {
 		return fmt.Errorf("failed to start daemon control server: %w", err)
 	}
@@ -67,11 +68,17 @@ func RunDaemon(cfg *config.Config) error {
 		}
 	}()
 
-	// Notify on SIGINT (Ctrl+C) and SIGTERM. Save instances before
+	// Notify on SIGINT (Ctrl+C) and SIGTERM, and watch for a Shutdown RPC.
+	// The RPC path is used by `af upgrade` / autoUpdate after writing a new
+	// binary so the next RPC respawns the daemon from the fresh image (#498).
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	sig := <-sigChan
-	log.InfoLog.Printf("received signal %s", sig.String())
+	select {
+	case sig := <-sigChan:
+		log.InfoLog.Printf("received signal %s", sig.String())
+	case <-shutdownCh:
+		log.InfoLog.Printf("received shutdown request via control socket")
+	}
 
 	// Stop the goroutine so we don't race.
 	close(stopCh)

--- a/upgrade.go
+++ b/upgrade.go
@@ -13,8 +13,20 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/spf13/cobra"
 )
+
+// requestDaemonShutdownFn is indirected so tests can stub the daemon
+// shutdown call without standing up a real control socket. The production
+// implementation contacts the local control plane (#436) and asks any
+// running daemon to exit so the next RPC respawns from the freshly written
+// binary (#498).
+var requestDaemonShutdownFn = daemon.RequestShutdown
+
+// osExecutableFn is indirected so tests can point the upgrade flow at a
+// temp file rather than overwriting the test binary itself.
+var osExecutableFn = os.Executable
 
 const (
 	releaseBaseURL = "https://github.com/sachiniyer/agent-factory/releases"
@@ -83,31 +95,50 @@ var upgradeCmd = &cobra.Command{
 		downloadURL := fmt.Sprintf("%s/latest/download/agent-factory-%s-%s.tar.gz", releaseBaseURL, goos, goarch)
 
 		fmt.Printf("Downloading latest release for %s/%s...\n", goos, goarch)
-
-		binary, err := downloadBinaryFn(downloadURL)
-		if err != nil {
-			return err
-		}
-
-		// Find current executable path
-		execPath, err := os.Executable()
-		if err != nil {
-			return fmt.Errorf("failed to find current executable: %w", err)
-		}
-		// Resolve symlinks so we replace the real binary, not the symlink
-		// pointing to it (e.g. on macOS Homebrew installs).
-		resolvedPath, err := filepath.EvalSymlinks(execPath)
-		if err != nil {
-			return fmt.Errorf("failed to resolve executable path: %w", err)
-		}
-
-		if err := config.AtomicWriteFile(resolvedPath, binary, 0755); err != nil {
-			return fmt.Errorf("failed to write new binary: %w", err)
-		}
-
-		fmt.Printf("Upgraded successfully!\n")
-		return nil
+		return runUpgrade(downloadURL)
 	},
+}
+
+// runUpgrade downloads the release tarball at downloadURL, atomically swaps
+// the current executable with the embedded binary, and asks any running
+// daemon to exit so users actually pick up the new image. Extracted from
+// upgradeCmd.RunE so tests can drive it without going through Cobra.
+func runUpgrade(downloadURL string) error {
+	binary, err := downloadBinaryFn(downloadURL)
+	if err != nil {
+		return err
+	}
+
+	execPath, err := osExecutableFn()
+	if err != nil {
+		return fmt.Errorf("failed to find current executable: %w", err)
+	}
+	// Resolve symlinks so we replace the real binary, not the symlink
+	// pointing to it (e.g. on macOS Homebrew installs).
+	resolvedPath, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve executable path: %w", err)
+	}
+
+	if err := config.AtomicWriteFile(resolvedPath, binary, 0755); err != nil {
+		return fmt.Errorf("failed to write new binary: %w", err)
+	}
+
+	// The running daemon process still references the old binary's inode
+	// on Linux, so users would keep running the stale image until they
+	// killed it manually. Ask any running daemon to exit; the next `af`
+	// invocation will EnsureDaemon-respawn from the new binary (#498).
+	restarted, shutdownErr := requestDaemonShutdownFn()
+	switch {
+	case shutdownErr != nil:
+		fmt.Printf("Upgraded successfully! Failed to restart the running daemon: %v\n", shutdownErr)
+		fmt.Println("Stop the daemon manually (e.g. `af reset`) or kill the `--daemon` process to pick up the new binary.")
+	case restarted:
+		fmt.Println("Upgraded successfully! Stopped the running daemon; it will respawn from the new binary on next use.")
+	default:
+		fmt.Println("Upgraded successfully!")
+	}
+	return nil
 }
 
 // extractBinaryFromTarGz reads a tar.gz stream and returns the contents of the

--- a/upgrade_test.go
+++ b/upgrade_test.go
@@ -4,8 +4,11 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -186,6 +189,129 @@ func TestDownloadBinaryStalledHeaders(t *testing.T) {
 		}
 	case <-deadline:
 		t.Fatalf("downloadBinary did not return within 3s; header timeout not enforced")
+	}
+}
+
+// TestUpgradeCallsShutdownAfterBinarySwap verifies the upgrade flow
+// requests a daemon shutdown after a successful binary write (#498), so
+// users actually pick up the version they just downloaded instead of the
+// daemon continuing to run the old image.
+func TestUpgradeCallsShutdownAfterBinarySwap(t *testing.T) {
+	tempBin := filepath.Join(t.TempDir(), "agent-factory")
+	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+
+	archive := makeTarGz(t, map[string][]byte{"agent-factory": []byte("new-binary")})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(archive)
+	}))
+	defer srv.Close()
+
+	prevExe := osExecutableFn
+	prevShutdown := requestDaemonShutdownFn
+	t.Cleanup(func() {
+		osExecutableFn = prevExe
+		requestDaemonShutdownFn = prevShutdown
+	})
+	osExecutableFn = func() (string, error) { return tempBin, nil }
+	shutdownCalls := 0
+	requestDaemonShutdownFn = func() (bool, error) {
+		shutdownCalls++
+		return true, nil
+	}
+
+	if err := runUpgrade(srv.URL); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+	if shutdownCalls != 1 {
+		t.Fatalf("expected one Shutdown call, got %d", shutdownCalls)
+	}
+	got, err := os.ReadFile(tempBin)
+	if err != nil {
+		t.Fatalf("read upgraded binary: %v", err)
+	}
+	if string(got) != "new-binary" {
+		t.Fatalf("binary contents = %q, want new-binary", got)
+	}
+}
+
+// TestUpgradeSucceedsWhenNoDaemon verifies that a connection-refused /
+// no-socket result from RequestShutdown does NOT fail the upgrade — this is
+// the common case in CI, fresh installs, and interactive `af upgrade` runs
+// where no daemon is currently active.
+func TestUpgradeSucceedsWhenNoDaemon(t *testing.T) {
+	tempBin := filepath.Join(t.TempDir(), "agent-factory")
+	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+
+	archive := makeTarGz(t, map[string][]byte{"agent-factory": []byte("new-binary")})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(archive)
+	}))
+	defer srv.Close()
+
+	prevExe := osExecutableFn
+	prevShutdown := requestDaemonShutdownFn
+	t.Cleanup(func() {
+		osExecutableFn = prevExe
+		requestDaemonShutdownFn = prevShutdown
+	})
+	osExecutableFn = func() (string, error) { return tempBin, nil }
+	requestDaemonShutdownFn = func() (bool, error) {
+		// Mirror what daemon.RequestShutdown returns when no daemon is
+		// running: (false, nil) — silently no-op.
+		return false, nil
+	}
+
+	if err := runUpgrade(srv.URL); err != nil {
+		t.Fatalf("runUpgrade with absent daemon failed: %v", err)
+	}
+	got, err := os.ReadFile(tempBin)
+	if err != nil {
+		t.Fatalf("read upgraded binary: %v", err)
+	}
+	if string(got) != "new-binary" {
+		t.Fatalf("binary contents = %q, want new-binary", got)
+	}
+}
+
+// TestUpgradeSucceedsWhenShutdownErrors verifies that an unexpected error
+// from RequestShutdown is reported to the user but does not roll back the
+// binary swap — the new binary is on disk and will be used next launch.
+func TestUpgradeSucceedsWhenShutdownErrors(t *testing.T) {
+	tempBin := filepath.Join(t.TempDir(), "agent-factory")
+	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+
+	archive := makeTarGz(t, map[string][]byte{"agent-factory": []byte("new-binary")})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(archive)
+	}))
+	defer srv.Close()
+
+	prevExe := osExecutableFn
+	prevShutdown := requestDaemonShutdownFn
+	t.Cleanup(func() {
+		osExecutableFn = prevExe
+		requestDaemonShutdownFn = prevShutdown
+	})
+	osExecutableFn = func() (string, error) { return tempBin, nil }
+	requestDaemonShutdownFn = func() (bool, error) {
+		return false, errors.New("simulated rpc failure")
+	}
+
+	if err := runUpgrade(srv.URL); err != nil {
+		t.Fatalf("runUpgrade should not fail when Shutdown errors, got: %v", err)
+	}
+	got, err := os.ReadFile(tempBin)
+	if err != nil {
+		t.Fatalf("read upgraded binary: %v", err)
+	}
+	if string(got) != "new-binary" {
+		t.Fatalf("binary contents = %q, want new-binary", got)
 	}
 }
 


### PR DESCRIPTION
Closes #498.

## Problem

`af upgrade` (and the silent background autoUpdate path) wrote a new
binary to disk but never told the running daemon process to restart.
Because the daemon was launched from the old binary's inode and Linux
keeps the running image alive even after the file is replaced, users
ran a stale daemon for days after every upgrade — masking every fix
between releases.

## Audit findings

1. **Control plane** (introduced by #436): `net/rpc` service `Control`
   on a Unix socket at `~/.config/agent-factory/daemon.sock`.
   Existing methods: `Ping`, `CreateSession`, `KillSession`,
   `SendPrompt`, `ImportRemoteHookSessions`. **No existing
   Shutdown endpoint** — this PR adds one.
2. **Daemon lifecycle**: not always-running. Lazy: `EnsureDaemon` is
   invoked on every RPC call (`callDaemon → EnsureDaemon`) and on
   the autoyes deferred path in `main.go`. So a clean exit naturally
   re-spawns from the freshly written binary on the next RPC.
3. **TUI reconnect**: each `callDaemon` re-dials, so TUI does not hold
   a persistent connection. After daemon teardown, the next RPC
   triggers `EnsureDaemon` which re-launches from the new binary.
   No TUI-side changes needed.
4. **Binary swap point**: `config.AtomicWriteFile` in both
   `upgrade.go:104` and `autoupdate.go:94`. Shutdown belongs right
   after, before the function returns success.

## Design choice

Added a new `Shutdown` RPC on the existing control service rather
than reusing `StopDaemon` (which kills via PID + verifies cmdline):

- `daemon.Shutdown` (server): acks immediately, then async after a
  50ms grace period closes a `shutdownCh` that `RunDaemon`'s main
  `select` watches alongside SIGINT/SIGTERM. The grace lets the
  RPC response flush before the listener tears down.
- `daemon.RequestShutdown` (client): pre-checks the socket exists,
  then calls the RPC. ECONNREFUSED / ENOENT are classified as
  "no daemon running" and surface as `(false, nil)` — common in
  CI, fresh installs, and interactive `af upgrade` runs.

The existing graceful teardown path (`SaveInstances` on exit) is
reused, so RPC-driven shutdown saves instance state the same way
SIGTERM does.

## User-facing messages

`af upgrade`:
- Daemon restarted: `Upgraded successfully! Stopped the running daemon; it will respawn from the new binary on next use.`
- No daemon running: `Upgraded successfully!`
- Daemon Shutdown errored: `Upgraded successfully! Failed to restart the running daemon: <err>` + manual recovery hint.

`autoUpdate()` (background, no interactive output): identical state
machine but logs at INFO/WARNING instead of stdout.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go test -race -count=1 ./...` green
- [x] New unit tests:
  - `daemon.TestControlServerShutdownClosesChannel` — Shutdown RPC acks OK and closes shutdownCh.
  - `daemon.TestRequestShutdownNoDaemon` — no socket → silent `(false, nil)`.
  - `daemon.TestRequestShutdownStaleSocket` — stale socket file → silent no-op.
  - `daemon.TestRequestShutdownSuccess` — end-to-end against a live control server.
  - `daemon.TestIsDaemonAbsentErr` — classifier for ECONNREFUSED / ENOENT.
  - `main.TestUpgradeCallsShutdownAfterBinarySwap` — happy path.
  - `main.TestUpgradeSucceedsWhenNoDaemon` — connection-refused does not fail upgrade.
  - `main.TestUpgradeSucceedsWhenShutdownErrors` — unexpected RPC error does not roll back the swap.
  - `main.TestAutoUpdateCallsShutdownAfterBinarySwap` — background path calls Shutdown.
  - `main.TestAutoUpdateSucceedsWhenShutdownErrors` — background path tolerates errors.

## Manual repro

```sh
go build ./... && ./dev-install.sh
af --autoyes &              # spawns the daemon via the deferred LaunchDaemon
ps -ef | grep -- '--daemon' # note the PID
af upgrade                  # should print "Stopped the running daemon..."
ps -ef | grep -- '--daemon' # PID should be gone
af sessions list            # respawns daemon from the new binary
ps -ef | grep -- '--daemon' # new PID, new image
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)