### PR TITLE
feat(daemon): include pane snippet in waitForReady timeout error (#502, partial)

### DIFF
--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -242,3 +242,42 @@ func collectTitles(instances []*session.Instance) []string {
 	}
 	return out
 }
+
+// TestInstanceStarted_TimeoutError_SurfacesPaneSnippet covers the UX half of
+// sachiniyer/agent-factory#502: a daemon-side timeout error that carries a
+// "last pane content:" snippet should reach the user-facing ErrBox unchanged
+// so the user can see what the agent was doing when it stalled.
+func TestInstanceStarted_TimeoutError_SurfacesPaneSnippet(t *testing.T) {
+	h := newTestHome(t)
+	failing := newLoadingInstance(t, "stalled")
+	h.sidebar.AddInstance(failing)
+	h.sidebar.SetSelectedInstance(0)
+	h.errBox.SetSize(500, 1)
+
+	daemonErr := errors.New("failed to start instance: timed out waiting for program to start (1m0s)\nlast pane content:\n  Loading config...\n  Connecting to MCP server...")
+	_, _ = h.Update(instanceStartedMsg{instance: failing, err: daemonErr})
+
+	rendered := h.errBox.String()
+	assert.Contains(t, rendered, "timed out waiting for program to start")
+	assert.Contains(t, rendered, "last pane content:")
+	assert.Contains(t, rendered, "Connecting to MCP server...")
+}
+
+// TestInstanceStarted_TimeoutError_EmptyContentOmitsHeader covers the
+// no-snippet branch: when the daemon couldn't capture any pane content the
+// error string should remain the original bare timeout message — no empty
+// "last pane content:" header.
+func TestInstanceStarted_TimeoutError_EmptyContentOmitsHeader(t *testing.T) {
+	h := newTestHome(t)
+	failing := newLoadingInstance(t, "stalled-empty")
+	h.sidebar.AddInstance(failing)
+	h.sidebar.SetSelectedInstance(0)
+	h.errBox.SetSize(500, 1)
+
+	daemonErr := errors.New("failed to start instance: timed out waiting for program to start (1m0s)")
+	_, _ = h.Update(instanceStartedMsg{instance: failing, err: daemonErr})
+
+	rendered := h.errBox.String()
+	assert.Contains(t, rendered, "timed out waiting for program to start")
+	assert.NotContains(t, rendered, "last pane content:")
+}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -853,10 +853,10 @@ func waitForReady(instance *session.Instance) error {
 			content, err := instance.Preview()
 			if err != nil {
 				log.ErrorLog.Printf("waitForReady timed out (preview also failed: %v)", err)
-			} else {
-				log.ErrorLog.Printf("waitForReady timed out. Last pane content: %s", content)
+				return formatWaitForReadyTimeoutError(waitForReadyTimeout, "")
 			}
-			return fmt.Errorf("timed out waiting for program to start (%s)", waitForReadyTimeout)
+			log.ErrorLog.Printf("waitForReady timed out. Last pane content: %s", content)
+			return formatWaitForReadyTimeoutError(waitForReadyTimeout, content)
 		case <-ticker.C:
 			content, err := instance.Preview()
 			if err != nil {
@@ -867,6 +867,47 @@ func waitForReady(instance *session.Instance) error {
 			}
 		}
 	}
+}
+
+// formatWaitForReadyTimeoutError builds the user-facing timeout error. When
+// the captured pane content is non-empty, the error body carries a trimmed
+// snippet of the last few lines so users see what the agent was doing instead
+// of an opaque "timed out" message. See sachiniyer/agent-factory#502.
+func formatWaitForReadyTimeoutError(timeout time.Duration, content string) error {
+	base := fmt.Sprintf("timed out waiting for program to start (%s)", timeout)
+	snippet := trimPaneSnippet(content)
+	if snippet == "" {
+		return errors.New(base)
+	}
+	var b strings.Builder
+	b.WriteString(base)
+	b.WriteString("\nlast pane content:")
+	for _, line := range strings.Split(snippet, "\n") {
+		b.WriteString("\n  ")
+		b.WriteString(line)
+	}
+	return errors.New(b.String())
+}
+
+// trimPaneSnippet returns at most the last 5 non-empty trailing lines of the
+// captured pane content, capped at 400 bytes. ANSI escape sequences are left
+// intact — keeping the snippet short matters more than stripping them.
+func trimPaneSnippet(content string) string {
+	lines := strings.Split(content, "\n")
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	if len(lines) > 5 {
+		lines = lines[len(lines)-5:]
+	}
+	out := strings.Join(lines, "\n")
+	if len(out) > 400 {
+		out = out[len(out)-400:]
+	}
+	return out
 }
 
 func isReadyContent(content string) bool {

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -258,6 +259,67 @@ func TestRequestShutdownSuccess(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatalf("shutdownCh was not closed after RequestShutdown")
 	}
+}
+
+// TestFormatWaitForReadyTimeoutError covers the UX half of
+// sachiniyer/agent-factory#502: when waitForReady gives up, the returned
+// error must carry a trimmed snippet of the captured pane content so the
+// user-facing TUI shows what the agent was doing — not just "timed out".
+// Empty captured content collapses back to the bare timeout message so
+// users don't see a dangling "last pane content:" header.
+func TestFormatWaitForReadyTimeoutError(t *testing.T) {
+	timeout := 60 * time.Second
+
+	t.Run("happy case appends trimmed snippet", func(t *testing.T) {
+		// >5 lines and well under 400 bytes — should keep only the last 5.
+		content := "boot 1\nboot 2\nboot 3\nLoading config...\nConnecting to MCP server...\nStill waiting on handshake\nAlmost there..."
+		got := formatWaitForReadyTimeoutError(timeout, content).Error()
+
+		wantHeader := "timed out waiting for program to start (1m0s)\nlast pane content:"
+		if !strings.HasPrefix(got, wantHeader) {
+			t.Fatalf("missing header.\n got=%q\nwant prefix=%q", got, wantHeader)
+		}
+		if !strings.Contains(got, "  Almost there...") {
+			t.Errorf("expected indented snippet line in error, got %q", got)
+		}
+		if !strings.Contains(got, "  Loading config...") {
+			t.Errorf("expected last-5-lines window to include 'Loading config...', got %q", got)
+		}
+		if strings.Contains(got, "boot 1") || strings.Contains(got, "boot 2") {
+			t.Errorf("expected oldest lines to be trimmed off, got %q", got)
+		}
+	})
+
+	t.Run("empty content omits header entirely", func(t *testing.T) {
+		got := formatWaitForReadyTimeoutError(timeout, "").Error()
+		want := "timed out waiting for program to start (1m0s)"
+		if got != want {
+			t.Fatalf("empty content error mismatch.\n got=%q\nwant=%q", got, want)
+		}
+	})
+
+	t.Run("whitespace-only content treated as empty", func(t *testing.T) {
+		got := formatWaitForReadyTimeoutError(timeout, "\n\n   \n\n").Error()
+		want := "timed out waiting for program to start (1m0s)"
+		if got != want {
+			t.Fatalf("whitespace-only content error mismatch.\n got=%q\nwant=%q", got, want)
+		}
+	})
+
+	t.Run("long content is byte-capped", func(t *testing.T) {
+		// One huge line well over the 400-byte cap.
+		long := strings.Repeat("x", 1200)
+		got := formatWaitForReadyTimeoutError(timeout, long).Error()
+		// Header + "\n  " + at most 400 bytes of snippet.
+		header := "timed out waiting for program to start (1m0s)\nlast pane content:\n  "
+		if !strings.HasPrefix(got, header) {
+			t.Fatalf("missing header prefix, got %q", got)
+		}
+		snippet := strings.TrimPrefix(got, header)
+		if len(snippet) > 400 {
+			t.Errorf("snippet not capped: len=%d, want <=400", len(snippet))
+		}
+	})
 }
 
 // TestIsDaemonAbsentErr covers the small classifier RequestShutdown uses to

--- a/task/runner.go
+++ b/task/runner.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -122,10 +123,10 @@ func WaitForReady(instance *session.Instance) error {
 			content, err := instance.Preview()
 			if err != nil {
 				log.ErrorLog.Printf("waitForReady timed out (preview also failed: %v)", err)
-			} else {
-				log.ErrorLog.Printf("waitForReady timed out. Last pane content: %s", content)
+				return formatWaitForReadyTimeoutError(waitForReadyTimeout, "")
 			}
-			return fmt.Errorf("timed out waiting for program to start (%s)", waitForReadyTimeout)
+			log.ErrorLog.Printf("waitForReady timed out. Last pane content: %s", content)
+			return formatWaitForReadyTimeoutError(waitForReadyTimeout, content)
 		case <-ticker.C:
 			content, err := instance.Preview()
 			if err != nil {
@@ -136,6 +137,47 @@ func WaitForReady(instance *session.Instance) error {
 			}
 		}
 	}
+}
+
+// formatWaitForReadyTimeoutError builds the user-facing timeout error. When
+// the captured pane content is non-empty, the error body carries a trimmed
+// snippet of the last few lines so users see what the agent was doing instead
+// of an opaque "timed out" message. See sachiniyer/agent-factory#502.
+func formatWaitForReadyTimeoutError(timeout time.Duration, content string) error {
+	base := fmt.Sprintf("timed out waiting for program to start (%s)", timeout)
+	snippet := trimPaneSnippet(content)
+	if snippet == "" {
+		return errors.New(base)
+	}
+	var b strings.Builder
+	b.WriteString(base)
+	b.WriteString("\nlast pane content:")
+	for _, line := range strings.Split(snippet, "\n") {
+		b.WriteString("\n  ")
+		b.WriteString(line)
+	}
+	return errors.New(b.String())
+}
+
+// trimPaneSnippet returns at most the last 5 non-empty trailing lines of the
+// captured pane content, capped at 400 bytes. ANSI escape sequences are left
+// intact — keeping the snippet short matters more than stripping them.
+func trimPaneSnippet(content string) string {
+	lines := strings.Split(content, "\n")
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	if len(lines) > 5 {
+		lines = lines[len(lines)-5:]
+	}
+	out := strings.Join(lines, "\n")
+	if len(out) > 400 {
+		out = out[len(out)-400:]
+	}
+	return out
 }
 
 // RunTask executes a task by creating a new instance,


### PR DESCRIPTION
## Summary

Partial fix for #502 — the conservative UX-only path. Surfaces the captured pane content in the user-facing error when `waitForReady` times out so users see what the agent was doing instead of an opaque "timed out waiting for program to start (1m0s)".

The 60s timeout itself is **unchanged** in this PR. The follow-up question of whether to raise it or expose a config knob is still open on #502 pending Sachin's reply.

## Audit

- `daemon/control.go` `waitForReady` (around line 845) calls `instance.Preview()` after the timeout fires. The captured content was only being logged via `log.ErrorLog.Printf("waitForReady timed out. Last pane content: %s", content)` — the returned `error` carried just the bare timeout message.
- The RPC error path is plain `error` over `net/rpc`: `controlServer.CreateSession` returns the error from `manager.CreateSession`, which wraps the start failure as `fmt.Errorf("failed to start instance: %w", err)`. The error string round-trips intact to the TUI.
- `app/app.go` `handleError` (around line 851) just renders whatever `Error()` returns into `ui.ErrBox` — no special-casing, no transformation. So plumbing the snippet through the daemon's error string is sufficient; no RPC method shape change is required.
- `task/runner.go` `WaitForReady` is a near-identical duplicate of the daemon's `waitForReady` (used by the scheduled task runner). Both were updated for consistency so the runner's surface area doesn't drift.

## Implementation

- Added a shared-shape helper `formatWaitForReadyTimeoutError(timeout, content)` in both `daemon/control.go` and `task/runner.go` (the packages can't share without an import cycle — `task` already imports `daemon`).
- Snippet trimming: last 5 non-empty trailing lines, capped at 400 bytes. ANSI escapes left intact — short matters more than clean, per the issue scope.
- Empty captured content collapses back to the original bare timeout message — no dangling "last pane content:" header.
- Daemon log line unchanged; the snippet flows through the error rather than being double-logged.

User-facing error now reads:
```
failed to start instance: timed out waiting for program to start (1m0s)
last pane content:
  Loading config...
  Connecting to MCP server...
```

## Test plan

- [x] New `TestFormatWaitForReadyTimeoutError` in `daemon/control_test.go` — covers happy case (snippet appended + last-5 window), empty-content case (header omitted), whitespace-only-content case (treated as empty), and long-content case (byte cap enforced).
- [x] New `TestInstanceStarted_TimeoutError_SurfacesPaneSnippet` and `TestInstanceStarted_TimeoutError_EmptyContentOmitsHeader` in `app/creation_test.go` — confirm a daemon-style timeout error with snippet reaches `ErrBox` unchanged, and the bare timeout error stays bare.
- [x] `gofmt -l .` — clean.
- [x] `golangci-lint run --timeout=3m --fast` — clean.
- [x] `go build ./...` — clean.
- [x] `go test -race ./...` — full suite green (daemon, app, task, integration).

## Out of scope

- Raising the 60s timeout (open on #502).
- Adding a config knob for the timeout (open on #502).
- Stripping ANSI escapes from the snippet — the issue explicitly accepts raw content for now.

Does **not** close #502 — the timeout-tuning half remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)