### PR TITLE
fix(upgrade): SIGTERM-fallback when stale daemon lacks Shutdown RPC (#504)

### DIFF
--- a/autoupdate.go
+++ b/autoupdate.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -98,12 +99,16 @@ func autoUpdate() error {
 	// Same rationale as `af upgrade` (#498): take down the running daemon so
 	// the next RPC respawns it from the freshly written binary. Quiet on the
 	// no-daemon path since autoUpdate runs in the background on every launch.
-	restarted, shutdownErr := requestDaemonShutdownFn()
+	// Pre-#501 daemons don't speak the Shutdown RPC; RequestShutdown falls
+	// back to PID-file-based SIGTERM (#504).
+	result, shutdownErr := requestDaemonShutdownFn()
 	switch {
 	case shutdownErr != nil:
 		log.WarningLog.Printf("auto-update: updated to %s but failed to restart daemon: %v", latestVersion, shutdownErr)
-	case restarted:
+	case result == daemon.ShutdownViaRPC:
 		log.InfoLog.Printf("auto-update: updated to %s and stopped running daemon", latestVersion)
+	case result == daemon.ShutdownViaSIGTERM:
+		log.InfoLog.Printf("auto-update: updated to %s and stopped pre-#501 running daemon via SIGTERM fallback", latestVersion)
 	default:
 		log.InfoLog.Printf("auto-update: updated to %s (effective on next launch)", latestVersion)
 	}

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	aflog "github.com/sachiniyer/agent-factory/log"
 )
 
@@ -197,9 +198,9 @@ func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
 	downloadBinaryFn = func(string) ([]byte, error) { return []byte("new-binary"), nil }
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	shutdownCalls := 0
-	requestDaemonShutdownFn = func() (bool, error) {
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
 		shutdownCalls++
-		return true, nil
+		return daemon.ShutdownViaRPC, nil
 	}
 
 	if err := autoUpdate(); err != nil {
@@ -248,8 +249,8 @@ func TestAutoUpdateSucceedsWhenShutdownErrors(t *testing.T) {
 	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.1", nil }
 	downloadBinaryFn = func(string) ([]byte, error) { return []byte("new-binary"), nil }
 	osExecutableFn = func() (string, error) { return tempBin, nil }
-	requestDaemonShutdownFn = func() (bool, error) {
-		return false, errors.New("simulated rpc failure")
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
+		return daemon.ShutdownNoDaemon, errors.New("simulated rpc failure")
 	}
 
 	if err := autoUpdate(); err != nil {

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -199,41 +199,82 @@ func ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest) ([]session.In
 	return resp.Instances, nil
 }
 
-// RequestShutdown asks any running daemon to exit cleanly via the control
-// socket. Returns (true, nil) when a daemon acknowledged the request and
-// will exit, (false, nil) when no daemon is running (no socket or connection
-// refused — common in CI, fresh installs, or interactive `af upgrade`), and
-// (false, err) for unexpected errors.
+// ShutdownResult reports how RequestShutdown stopped (or failed to stop) the
+// running daemon. Used by upgrade.go and autoupdate.go to pick the right
+// user-facing message after a binary swap.
+type ShutdownResult int
+
+const (
+	// ShutdownNoDaemon means no daemon was running (no socket, ECONNREFUSED,
+	// or PID-file scan found nothing). The upgrade prints bare success.
+	ShutdownNoDaemon ShutdownResult = iota
+	// ShutdownViaRPC means the daemon acknowledged the Shutdown RPC and is
+	// exiting cleanly. The post-#501 happy path.
+	ShutdownViaRPC
+	// ShutdownViaSIGTERM means the daemon was a pre-#501 binary that did not
+	// register the Shutdown RPC, so we located its PID and signaled it
+	// directly. The upgrade prints a slightly different success message so
+	// users know we used the fallback. See #504.
+	ShutdownViaSIGTERM
+)
+
+// sigtermFallbackGrace is the max time we wait for a SIGTERM'd daemon to exit
+// before escalating to SIGKILL.
+const sigtermFallbackGrace = 5 * time.Second
+
+// sigtermFallbackPoll is how often we check whether the SIGTERM'd daemon has
+// exited.
+const sigtermFallbackPoll = 100 * time.Millisecond
+
+// RequestShutdown asks any running daemon to exit cleanly. The normal path
+// uses the Shutdown RPC (#498/#501). When the running daemon is a pre-#501
+// binary that does not register Shutdown, we fall back to locating the
+// daemon's PID and sending SIGTERM directly (#504) so an `af upgrade` does
+// not leave a stale daemon running the old binary.
 //
-// This is invoked after `af upgrade` / autoUpdate() write a new binary so the
-// running daemon process, which still references the old binary's inode, is
-// taken down. A subsequent RPC call (CreateSession, KillSession, etc.) will
-// EnsureDaemon-respawn from the freshly written binary.
-func RequestShutdown() (bool, error) {
+// Returns (ShutdownNoDaemon, nil) when no daemon is running (no socket,
+// ECONNREFUSED, or no signalable PID), (ShutdownViaRPC, nil) when the Shutdown
+// RPC acknowledged, (ShutdownViaSIGTERM, nil) when the fallback signaled a
+// real `af --daemon` process, and (ShutdownNoDaemon, err) for unexpected
+// errors that the caller should surface (e.g. multiple ambiguous candidates,
+// permission denied on signal).
+func RequestShutdown() (ShutdownResult, error) {
 	socketPath, err := DaemonSocketPath()
 	if err != nil {
-		return false, err
+		return ShutdownNoDaemon, err
 	}
 	if _, statErr := os.Stat(socketPath); statErr != nil {
 		if errors.Is(statErr, fs.ErrNotExist) {
-			return false, nil
+			return ShutdownNoDaemon, nil
 		}
-		return false, statErr
+		return ShutdownNoDaemon, statErr
 	}
 	var resp ShutdownResponse
-	if err := callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &resp); err != nil {
-		if isDaemonAbsentErr(err) {
-			return false, nil
+	if rpcErr := callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &resp); rpcErr != nil {
+		if isDaemonAbsentErr(rpcErr) {
+			return ShutdownNoDaemon, nil
 		}
-		return false, err
+		if isRPCMethodNotFoundErr(rpcErr) {
+			// Daemon is alive on the socket but does not speak Shutdown
+			// (pre-#501 binary). Fall through to the PID-based fallback.
+			return sigtermFallback()
+		}
+		return ShutdownNoDaemon, rpcErr
 	}
-	return resp.OK, nil
+	if !resp.OK {
+		return ShutdownNoDaemon, fmt.Errorf("daemon Shutdown RPC returned OK=false")
+	}
+	return ShutdownViaRPC, nil
 }
 
 // isDaemonAbsentErr reports whether err from a dial/RPC call indicates that
 // no daemon is currently listening on the control socket (vs. some other
 // transport failure). Both ECONNREFUSED (stale socket, no listener) and
-// ENOENT (socket removed between Stat and Dial) qualify.
+// ENOENT (socket removed between Stat and Dial) qualify. Application-level
+// RPC errors (method-not-found, server panic) do NOT — those are handled
+// separately by isRPCMethodNotFoundErr so we can route them to the SIGTERM
+// fallback rather than treating them as "no daemon" and silently leaving the
+// stale process running (#504).
 func isDaemonAbsentErr(err error) bool {
 	if err == nil {
 		return false
@@ -242,6 +283,24 @@ func isDaemonAbsentErr(err error) bool {
 		return true
 	}
 	return false
+}
+
+// isRPCMethodNotFoundErr reports whether err is the net/rpc server's reply
+// for an unknown method or service. The connection succeeded (daemon is
+// running, control socket is alive) but the registered service did not have
+// the requested method — i.e. a pre-#501 daemon that never registered
+// "Control.Shutdown". The stdlib returns this as rpc.ServerError with the
+// literal prefix "rpc: can't find method " or "rpc: can't find service ".
+func isRPCMethodNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var serverErr rpc.ServerError
+	if !errors.As(err, &serverErr) {
+		return false
+	}
+	s := string(serverErr)
+	return strings.Contains(s, "can't find method") || strings.Contains(s, "can't find service")
 }
 
 type controlServer struct {

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -192,12 +192,12 @@ func TestControlServerShutdownClosesChannel(t *testing.T) {
 func TestRequestShutdownNoDaemon(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
-	restarted, err := RequestShutdown()
+	result, err := RequestShutdown()
 	if err != nil {
 		t.Fatalf("RequestShutdown returned error when no daemon present: %v", err)
 	}
-	if restarted {
-		t.Fatalf("RequestShutdown reported restart when no daemon was running")
+	if result != ShutdownNoDaemon {
+		t.Fatalf("RequestShutdown returned %v when no daemon was running, want ShutdownNoDaemon", result)
 	}
 }
 
@@ -221,12 +221,12 @@ func TestRequestShutdownStaleSocket(t *testing.T) {
 		t.Fatalf("write stale socket placeholder: %v", err)
 	}
 
-	restarted, err := RequestShutdown()
+	result, err := RequestShutdown()
 	if err != nil {
 		t.Fatalf("RequestShutdown returned error on stale socket: %v", err)
 	}
-	if restarted {
-		t.Fatalf("RequestShutdown reported restart against stale socket")
+	if result != ShutdownNoDaemon {
+		t.Fatalf("RequestShutdown returned %v against stale socket, want ShutdownNoDaemon", result)
 	}
 }
 
@@ -247,12 +247,12 @@ func TestRequestShutdownSuccess(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = closeServer() })
 
-	restarted, err := RequestShutdown()
+	result, err := RequestShutdown()
 	if err != nil {
 		t.Fatalf("RequestShutdown: %v", err)
 	}
-	if !restarted {
-		t.Fatalf("expected restarted=true against live control server")
+	if result != ShutdownViaRPC {
+		t.Fatalf("RequestShutdown returned %v against live control server, want ShutdownViaRPC", result)
 	}
 	select {
 	case <-shutdownCh:

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -35,6 +36,17 @@ func RunDaemon(cfg *config.Config) error {
 			log.WarningLog.Printf("failed to close daemon control socket: %v", err)
 		}
 	}()
+
+	// Write our PID so `af upgrade`'s SIGTERM fallback (#504) can find the
+	// running daemon. Both the SIGTERM and Shutdown-RPC exit paths fall
+	// through to the deferred cleanup, so the file is removed on any graceful
+	// shutdown. A stale file is harmless — readers verify the live process's
+	// cmdline before signaling it.
+	if err := writeDaemonPIDFile(); err != nil {
+		log.WarningLog.Printf("failed to write daemon PID file: %v", err)
+	} else {
+		defer removeDaemonPIDFile()
+	}
 
 	pollInterval := time.Duration(cfg.DaemonPollInterval) * time.Millisecond
 
@@ -177,19 +189,44 @@ func launchDaemonProcess() error {
 
 	log.InfoLog.Printf("started daemon child process with PID: %d", cmd.Process.Pid)
 
-	// Save PID to a file for later management
-	pidDir, err := config.GetConfigDir()
-	if err != nil {
-		return fmt.Errorf("failed to get config directory: %w", err)
-	}
-
-	pidFile := filepath.Join(pidDir, "daemon.pid")
-	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0644); err != nil {
-		return fmt.Errorf("failed to write PID file: %w", err)
-	}
-
-	// Don't wait for the child to exit, it's detached
+	// The child writes its own PID file from RunDaemon (#504). Don't wait for
+	// the child to exit, it's detached.
 	return nil
+}
+
+// daemonPIDFilePath returns the path to the daemon PID file, or "" if the
+// config dir cannot be resolved.
+func daemonPIDFilePath() (string, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "daemon.pid"), nil
+}
+
+// writeDaemonPIDFile atomically writes the current process's PID to the daemon
+// PID file with mode 0600. Used by RunDaemon so callers (StopDaemon, the
+// SIGTERM fallback in RequestShutdown) can locate and signal this daemon.
+func writeDaemonPIDFile() error {
+	path, err := daemonPIDFilePath()
+	if err != nil {
+		return err
+	}
+	return config.AtomicWriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0600)
+}
+
+// removeDaemonPIDFile deletes the daemon PID file. Best-effort: an ENOENT is
+// already harmless (a stale file is fine — readers verify cmdline) and
+// permission errors only occur in pathological setups. Logs at warning level
+// rather than failing the daemon teardown.
+func removeDaemonPIDFile() {
+	path, err := daemonPIDFilePath()
+	if err != nil {
+		return
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.WarningLog.Printf("failed to remove daemon PID file: %v", err)
+	}
 }
 
 // StopDaemon attempts to stop a running daemon process if it exists. Returns no error if the daemon is not found

--- a/daemon/sigterm_fallback.go
+++ b/daemon/sigterm_fallback.go
@@ -1,0 +1,261 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// sigtermFallback locates a running pre-#501 daemon and sends it SIGTERM,
+// escalating to SIGKILL after sigtermFallbackGrace. Used when the Shutdown
+// RPC returned method-not-found (the daemon is listening on the control
+// socket but the binary predates #501).
+//
+// Strategy:
+//  1. If ~/.config/agent-factory/daemon.pid exists, parse it. Verify the PID
+//     is alive AND its command line contains "--daemon" as a discrete token
+//     (defensive against PID reuse — the file may be stale).
+//  2. Otherwise (or if the PID file is missing), scan with `pgrep -f
+//     "af --daemon"`, filter out /tmp/Test* paths (Go test binaries) and the
+//     current process, and require exactly one candidate.
+//
+// Returns ShutdownViaSIGTERM when a signal was delivered, ShutdownNoDaemon
+// when nothing eligible was found, or an error for ambiguous cases (multiple
+// pgrep matches) so the caller can surface a clear actionable message.
+func sigtermFallback() (ShutdownResult, error) {
+	pid, source, err := locateDaemonPID()
+	if err != nil {
+		return ShutdownNoDaemon, err
+	}
+	if pid == 0 {
+		// Nothing to signal. Treat as ShutdownNoDaemon: the upgrade prints
+		// bare success and the next RPC EnsureDaemon-respawns from the new
+		// binary anyway.
+		return ShutdownNoDaemon, nil
+	}
+
+	log.InfoLog.Printf("sigterm fallback: signaling pre-#501 daemon (pid=%d source=%s)", pid, source)
+	if err := signalAndWait(pid); err != nil {
+		return ShutdownNoDaemon, fmt.Errorf("sigterm fallback for daemon pid %d: %w", pid, err)
+	}
+
+	// Best-effort PID file cleanup so the next `af` invocation does not see
+	// a stale file. StopDaemon does this on its happy path too; doing it
+	// here keeps state tidy when the daemon binary never wrote one itself.
+	removeDaemonPIDFile()
+	return ShutdownViaSIGTERM, nil
+}
+
+// locateDaemonPID returns the PID of the running daemon to signal, the source
+// it was found in ("pid-file" or "pgrep") for diagnostics, or (0, "", nil)
+// when no eligible target exists. An error is returned only for ambiguous
+// pgrep results where signaling would be unsafe.
+func locateDaemonPID() (int, string, error) {
+	if pid, ok := readPIDFromFile(); ok {
+		if pidLooksAlive(pid) && isAgentFactoryDaemon(pid) {
+			return pid, "pid-file", nil
+		}
+		log.InfoLog.Printf("sigterm fallback: PID file pid=%d is dead or non-daemon; falling back to pgrep", pid)
+	}
+
+	pids, err := pgrepDaemonCandidates()
+	if err != nil {
+		return 0, "", err
+	}
+	switch len(pids) {
+	case 0:
+		return 0, "", nil
+	case 1:
+		return pids[0], "pgrep", nil
+	default:
+		return 0, "", fmt.Errorf(
+			"sigterm fallback: ambiguous, found %d `af --daemon` processes (%s) — "+
+				"kill the right one manually then re-run `af upgrade`",
+			len(pids), formatPIDList(pids),
+		)
+	}
+}
+
+// readPIDFromFile parses the daemon PID file. Returns (0, false) when the
+// file is missing, malformed, or points at an obviously bogus PID. A stale
+// or reused PID is not filtered here — callers re-verify with cmdline.
+func readPIDFromFile() (int, bool) {
+	path, err := daemonPIDFilePath()
+	if err != nil {
+		return 0, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 1 || pid == os.Getpid() {
+		return 0, false
+	}
+	return pid, true
+}
+
+// pidLooksAlive returns true when signal 0 to pid succeeds AND the kernel
+// still has user-space state for the process (cmdline is non-empty). The
+// cmdline check is the cheap Linux-side way to filter out zombies: once a
+// process has exited but not yet been reaped, /proc/<pid>/cmdline is empty,
+// but kill(pid, 0) still succeeds because the process entry exists. Without
+// the second check, signalAndWait would wait the full sigtermFallbackGrace
+// for any zombie before escalating to SIGKILL — visible as a 5s pause in
+// `af upgrade` when the dying daemon's parent isn't waiting.
+//
+// On platforms without /proc (macOS), readProcCmdline returns "" and we
+// can't distinguish zombie from "kernel doesn't expose the cmdline"; we
+// fall back to the signal-0 result. The cost there is the 5s grace, which
+// is correct but slow.
+func pidLooksAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		return false
+	}
+	if _, err := os.Stat("/proc"); err == nil {
+		// /proc is mounted (Linux). An empty cmdline means the task is a
+		// zombie or kernel thread; for our purposes either is "dead".
+		data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+		if err == nil && len(strings.TrimRight(string(data), "\x00")) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// pgrepDaemonCandidates scans for processes whose full command line contains
+// "af --daemon", excluding Go test binaries living under /tmp/Test* and the
+// current process. We rely on pgrep -f rather than parsing /proc directly so
+// the path works on both Linux and macOS.
+func pgrepDaemonCandidates() ([]int, error) {
+	pgrep, err := exec.LookPath("pgrep")
+	if err != nil {
+		// No pgrep is unusual but recoverable: just report no candidates so
+		// the upgrade falls back to "bare success". The daemon will keep
+		// running but the next RPC respawns the right one anyway, and we
+		// surface this in the log for debugging.
+		log.WarningLog.Printf("sigterm fallback: pgrep not found in PATH; cannot scan for daemons: %v", err)
+		return nil, nil
+	}
+	out, err := exec.Command(pgrep, "-f", "af --daemon").Output()
+	if err != nil {
+		// pgrep exits 1 when there are no matches. Treat that as zero
+		// candidates rather than an error.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("pgrep failed: %w", err)
+	}
+
+	self := os.Getpid()
+	var pids []int
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		pid, parseErr := strconv.Atoi(line)
+		if parseErr != nil {
+			continue
+		}
+		if pid == self {
+			continue
+		}
+		// Defensive: re-read the cmdline and require it to (a) contain
+		// "--daemon" as a discrete token (pgrep -f does substring matching,
+		// not token matching) and (b) not be a Go test binary (these live
+		// under /tmp/Test... when invoked from `go test`).
+		cmdline := readProcCmdline(pid)
+		if cmdline == "" {
+			cmdline = readPsArgs(pid)
+		}
+		if cmdline == "" {
+			continue
+		}
+		if !cmdlineHasDaemonFlag(cmdline) {
+			continue
+		}
+		if isTestBinaryCmdline(cmdline) {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids, nil
+}
+
+// isTestBinaryCmdline filters out Go test binaries spawned during `go test`.
+// They typically live under /tmp/Test<name>... (t.TempDir paths) or
+// /tmp/go-build... (compiled-test cache). We don't want a test that spawns a
+// fake "af --daemon" subprocess to accidentally claim a real daemon match
+// when run in parallel with another test.
+func isTestBinaryCmdline(cmdline string) bool {
+	for _, field := range strings.Fields(cmdline) {
+		if strings.HasPrefix(field, "/tmp/Test") || strings.HasPrefix(field, "/tmp/go-build") {
+			return true
+		}
+	}
+	return false
+}
+
+// signalAndWait sends SIGTERM to pid, polls for exit up to
+// sigtermFallbackGrace, and escalates to SIGKILL if it has not exited.
+func signalAndWait(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("FindProcess: %w", err)
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		if errIsProcessGone(err) {
+			return nil
+		}
+		return fmt.Errorf("SIGTERM: %w", err)
+	}
+
+	deadline := time.Now().Add(sigtermFallbackGrace)
+	for time.Now().Before(deadline) {
+		if !pidLooksAlive(pid) {
+			return nil
+		}
+		time.Sleep(sigtermFallbackPoll)
+	}
+
+	log.WarningLog.Printf("sigterm fallback: pid %d did not exit within %s; escalating to SIGKILL", pid, sigtermFallbackGrace)
+	if err := proc.Signal(syscall.SIGKILL); err != nil && !errIsProcessGone(err) {
+		return fmt.Errorf("SIGKILL: %w", err)
+	}
+	return nil
+}
+
+// errIsProcessGone reports whether err from Signal indicates the target is
+// already gone. POSIX returns ESRCH; os.Process surfaces this as "os: process
+// already finished".
+func errIsProcessGone(err error) bool {
+	if err == nil {
+		return false
+	}
+	if err == os.ErrProcessDone {
+		return true
+	}
+	return strings.Contains(err.Error(), "process already finished") ||
+		strings.Contains(err.Error(), "no such process")
+}
+
+// formatPIDList renders []int as a comma-separated list for user-facing
+// error messages.
+func formatPIDList(pids []int) string {
+	parts := make([]string, len(pids))
+	for i, p := range pids {
+		parts[i] = strconv.Itoa(p)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/daemon/sigterm_fallback_test.go
+++ b/daemon/sigterm_fallback_test.go
@@ -1,0 +1,335 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"net/rpc"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// TestWriteDaemonPIDFile_AtomicAndPermissions verifies that writing the PID
+// file produces a 0600 file containing the current process's PID (#504).
+func TestWriteDaemonPIDFile_AtomicAndPermissions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	if err := writeDaemonPIDFile(); err != nil {
+		t.Fatalf("writeDaemonPIDFile: %v", err)
+	}
+	pidPath := filepath.Join(home, "daemon.pid")
+	info, err := os.Stat(pidPath)
+	if err != nil {
+		t.Fatalf("stat PID file: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Errorf("PID file mode = %o, want 0600", mode)
+	}
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		t.Fatalf("read PID file: %v", err)
+	}
+	gotPID, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("parse PID: %v", err)
+	}
+	if gotPID != os.Getpid() {
+		t.Errorf("PID file contains %d, want %d (this process)", gotPID, os.Getpid())
+	}
+
+	// removeDaemonPIDFile is the defer companion. After running it the file
+	// must be gone.
+	removeDaemonPIDFile()
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Errorf("expected PID file to be removed, stat err=%v", err)
+	}
+
+	// Second remove must be a no-op (graceful shutdown can race with a
+	// second SIGTERM arriving during teardown).
+	removeDaemonPIDFile()
+}
+
+// TestRunDaemonPIDFileLifecycle drives the daemon's main loop end-to-end:
+// start RunDaemon in a goroutine, wait for the PID file to appear, ask it to
+// shut down via the Shutdown RPC, then verify the PID file was removed when
+// the daemon exited (#504).
+func TestRunDaemonPIDFileLifecycle(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	installInstantBackend(t)
+
+	pidPath := filepath.Join(home, "daemon.pid")
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Fatalf("PID file already exists before daemon start, stat err=%v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.DaemonPollInterval = 50
+
+	done := make(chan error, 1)
+	go func() { done <- RunDaemon(cfg) }()
+
+	// The daemon writes the PID file early in RunDaemon, before the main
+	// select. Poll briefly for it to appear.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(pidPath); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, err := os.Stat(pidPath); err != nil {
+		t.Fatalf("PID file did not appear within 3s, stat err=%v", err)
+	}
+
+	// Ask the daemon to exit via the Shutdown RPC.
+	result, err := RequestShutdown()
+	if err != nil {
+		t.Fatalf("RequestShutdown: %v", err)
+	}
+	if result != ShutdownViaRPC {
+		t.Fatalf("RequestShutdown returned %v, want ShutdownViaRPC", result)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunDaemon returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("RunDaemon did not return within 5s after Shutdown RPC")
+	}
+
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Errorf("expected PID file to be removed after graceful shutdown, stat err=%v", err)
+	}
+}
+
+// TestIsRPCMethodNotFoundErr covers the classifier change at the core of
+// #504: a connected-but-stale daemon returns an rpc.ServerError that must
+// trigger the SIGTERM fallback, NOT be folded into "no daemon present".
+func TestIsRPCMethodNotFoundErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"method not found", rpc.ServerError("rpc: can't find method Control.Shutdown"), true},
+		{"service not found", rpc.ServerError("rpc: can't find service Control"), true},
+		{"other server error", rpc.ServerError("rpc: unexpected EOF"), false},
+		{"plain error", errors.New("some other error"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isRPCMethodNotFoundErr(c.err); got != c.want {
+				t.Errorf("isRPCMethodNotFoundErr(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// TestIsDaemonAbsentErr_RejectsMethodNotFound is a regression guard: prior
+// to #504 the issue report assumed isDaemonAbsentErr was folding the rpc
+// method-not-found case into the "absent" bucket. It must NOT — otherwise
+// the SIGTERM fallback never fires.
+func TestIsDaemonAbsentErr_RejectsMethodNotFound(t *testing.T) {
+	err := rpc.ServerError("rpc: can't find method Control.Shutdown")
+	if isDaemonAbsentErr(err) {
+		t.Fatalf("isDaemonAbsentErr(method-not-found) = true; would suppress the SIGTERM fallback")
+	}
+}
+
+// spawnFakeDaemonWithDaemonFlag launches a long-lived child process whose
+// /proc/<pid>/cmdline contains "--daemon" as a discrete token. We use
+// bash's `exec -a` to rewrite argv[0] of `sleep` so the cmdline carries
+// "--daemon" without sleep actually being asked to parse it as a flag (it
+// would reject "--daemon" as an invalid time interval). The single process
+// is just sleep, which terminates cleanly on SIGTERM — making this the
+// minimum-moving-parts way to test the fallback's SIGTERM path.
+//
+// Returns the *exec.Cmd so the test can call cmd.Wait() to reap the zombie
+// after SIGTERM. Without that, kill(pid, 0) keeps returning success against
+// the zombie, defeating any "did it die?" check based on signal probes.
+func spawnFakeDaemonWithDaemonFlag(t *testing.T) *exec.Cmd {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not available, skipping SIGTERM-fallback test: %v", err)
+	}
+	cmd := exec.Command("bash", "-c", "exec -a 'sleep --daemon af-test' sleep 60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon: %v", err)
+	}
+	// Wait briefly for bash to exec into sleep so the cmdline we read is
+	// the post-exec one with the rewritten argv[0]. Re-check up to ~500ms.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if isAgentFactoryDaemon(cmd.Process.Pid) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cmd
+}
+
+// TestSigtermFallback_KillsPIDFileDaemon verifies the happy path of #504:
+// when the PID file points at a live process whose cmdline matches
+// `--daemon`, SIGTERM is delivered and the process exits.
+func TestSigtermFallback_KillsPIDFileDaemon(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	cmd := spawnFakeDaemonWithDaemonFlag(t)
+	pid := cmd.Process.Pid
+	defer func() {
+		// Defensive: if anything went wrong and sigtermFallback didn't
+		// terminate the fake daemon, make sure we don't leak a sleep.
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	// Sanity: the spawned process is reachable and matches cmdline.
+	if !pidLooksAlive(pid) {
+		t.Fatalf("fake daemon pid=%d not alive immediately after spawn", pid)
+	}
+	if !isAgentFactoryDaemon(pid) {
+		t.Fatalf("fake daemon pid=%d cmdline did not match --daemon", pid)
+	}
+
+	if err := os.WriteFile(filepath.Join(home, "daemon.pid"),
+		[]byte(strconv.Itoa(pid)), 0600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	// Start reaping in a goroutine so the kernel can clear the zombie as
+	// soon as SIGTERM lands. Without this, kill(pid, 0) keeps reporting
+	// the zombie as "alive" and we can't distinguish the success case from
+	// "sleep ignored the signal".
+	exited := make(chan *os.ProcessState, 1)
+	go func() {
+		state, _ := cmd.Process.Wait()
+		exited <- state
+	}()
+
+	result, err := sigtermFallback()
+	if err != nil {
+		t.Fatalf("sigtermFallback: %v", err)
+	}
+	if result != ShutdownViaSIGTERM {
+		t.Fatalf("sigtermFallback returned %v, want ShutdownViaSIGTERM", result)
+	}
+
+	select {
+	case state := <-exited:
+		if state == nil {
+			t.Fatalf("fake daemon exited but ProcessState was nil")
+		}
+		if state.ExitCode() == 0 {
+			// SIGTERM exits with a non-zero status in os.Process. A clean
+			// 0 would mean sleep finished its natural 60s — i.e. SIGTERM
+			// did not actually kill it.
+			t.Fatalf("fake daemon exited with code 0; expected signal-induced exit (state=%v)", state)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatalf("fake daemon pid=%d did not exit within 8s after sigtermFallback", pid)
+	}
+
+	// PID file should have been cleaned up by sigtermFallback.
+	if _, err := os.Stat(filepath.Join(home, "daemon.pid")); !os.IsNotExist(err) {
+		t.Errorf("expected PID file to be removed after sigtermFallback, stat err=%v", err)
+	}
+}
+
+// TestSigtermFallback_IgnoresNonMatchingCmdline guards against killing an
+// unrelated process whose PID happens to be in the PID file (e.g. PID
+// reuse). The fallback should fall through to pgrep, which on a clean test
+// env finds zero candidates and returns ShutdownNoDaemon — the unrelated
+// process must remain alive.
+func TestSigtermFallback_IgnoresNonMatchingCmdline(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	// sleep, no --daemon flag in its argv — cmdlineHasDaemonFlag must say no.
+	victim := exec.Command("sleep", "60")
+	if err := victim.Start(); err != nil {
+		t.Fatalf("start victim: %v", err)
+	}
+	defer func() {
+		_ = victim.Process.Kill()
+		_, _ = victim.Process.Wait()
+	}()
+
+	if err := os.WriteFile(filepath.Join(home, "daemon.pid"),
+		[]byte(strconv.Itoa(victim.Process.Pid)), 0600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	// We don't care which result the fallback returns (ShutdownNoDaemon or
+	// an ambiguous-pgrep error if the host has rogue `af --daemon` procs).
+	// We only require that the victim survives.
+	_, _ = sigtermFallback()
+
+	time.Sleep(100 * time.Millisecond)
+	if !pidLooksAlive(victim.Process.Pid) {
+		t.Fatalf("sigtermFallback killed an unrelated process (pid=%d) whose cmdline did not match --daemon",
+			victim.Process.Pid)
+	}
+}
+
+// TestSigtermFallback_DeadPID covers the second specified test: when the PID
+// file points at a process that no longer exists (or was never one), the
+// fallback should clean up gracefully and report ShutdownNoDaemon rather
+// than erroring or hanging.
+func TestSigtermFallback_DeadPID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	// Pick a PID well above any realistic running PID. 0x7fffffff exceeds
+	// the default pid_max on both Linux (32768/4M) and macOS (99999).
+	deadPID := 0x7fffffff
+	if err := os.WriteFile(filepath.Join(home, "daemon.pid"),
+		[]byte(strconv.Itoa(deadPID)), 0600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	result, err := sigtermFallback()
+	if err != nil {
+		t.Fatalf("sigtermFallback returned error for dead PID: %v", err)
+	}
+	// The dead-PID branch falls through to pgrep; on a clean test runner
+	// there are no `af --daemon` matches, so we expect ShutdownNoDaemon.
+	if result != ShutdownNoDaemon {
+		t.Fatalf("sigtermFallback returned %v for dead PID, want ShutdownNoDaemon", result)
+	}
+}
+
+// TestErrIsProcessGone covers the small helper that decides whether a
+// failed Signal call means "already gone" (benign) vs. a real problem.
+func TestErrIsProcessGone(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"already finished", os.ErrProcessDone, true},
+		{"message-only", fmt.Errorf("os: process already finished"), true},
+		{"esrch literal", fmt.Errorf("kill: no such process"), true},
+		{"unrelated", syscall.EPERM, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := errIsProcessGone(c.err); got != c.want {
+				t.Errorf("errIsProcessGone(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}

--- a/upgrade.go
+++ b/upgrade.go
@@ -128,13 +128,17 @@ func runUpgrade(downloadURL string) error {
 	// on Linux, so users would keep running the stale image until they
 	// killed it manually. Ask any running daemon to exit; the next `af`
 	// invocation will EnsureDaemon-respawn from the new binary (#498).
-	restarted, shutdownErr := requestDaemonShutdownFn()
+	// Pre-#501 daemons don't speak the Shutdown RPC, so RequestShutdown
+	// falls back to PID-file-based SIGTERM (#504).
+	result, shutdownErr := requestDaemonShutdownFn()
 	switch {
 	case shutdownErr != nil:
 		fmt.Printf("Upgraded successfully! Failed to restart the running daemon: %v\n", shutdownErr)
 		fmt.Println("Stop the daemon manually (e.g. `af reset`) or kill the `--daemon` process to pick up the new binary.")
-	case restarted:
+	case result == daemon.ShutdownViaRPC:
 		fmt.Println("Upgraded successfully! Stopped the running daemon; it will respawn from the new binary on next use.")
+	case result == daemon.ShutdownViaSIGTERM:
+		fmt.Println("Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM); it will respawn from the new binary on next use.")
 	default:
 		fmt.Println("Upgraded successfully!")
 	}

--- a/upgrade_test.go
+++ b/upgrade_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -12,6 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sachiniyer/agent-factory/daemon"
 )
 
 func TestExtractBinaryFromTarGz(t *testing.T) {
@@ -216,9 +219,9 @@ func TestUpgradeCallsShutdownAfterBinarySwap(t *testing.T) {
 	})
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	shutdownCalls := 0
-	requestDaemonShutdownFn = func() (bool, error) {
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
 		shutdownCalls++
-		return true, nil
+		return daemon.ShutdownViaRPC, nil
 	}
 
 	if err := runUpgrade(srv.URL); err != nil {
@@ -259,10 +262,10 @@ func TestUpgradeSucceedsWhenNoDaemon(t *testing.T) {
 		requestDaemonShutdownFn = prevShutdown
 	})
 	osExecutableFn = func() (string, error) { return tempBin, nil }
-	requestDaemonShutdownFn = func() (bool, error) {
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
 		// Mirror what daemon.RequestShutdown returns when no daemon is
-		// running: (false, nil) — silently no-op.
-		return false, nil
+		// running: (ShutdownNoDaemon, nil) — silently no-op.
+		return daemon.ShutdownNoDaemon, nil
 	}
 
 	if err := runUpgrade(srv.URL); err != nil {
@@ -299,8 +302,8 @@ func TestUpgradeSucceedsWhenShutdownErrors(t *testing.T) {
 		requestDaemonShutdownFn = prevShutdown
 	})
 	osExecutableFn = func() (string, error) { return tempBin, nil }
-	requestDaemonShutdownFn = func() (bool, error) {
-		return false, errors.New("simulated rpc failure")
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
+		return daemon.ShutdownNoDaemon, errors.New("simulated rpc failure")
 	}
 
 	if err := runUpgrade(srv.URL); err != nil {
@@ -312,6 +315,58 @@ func TestUpgradeSucceedsWhenShutdownErrors(t *testing.T) {
 	}
 	if string(got) != "new-binary" {
 		t.Fatalf("binary contents = %q, want new-binary", got)
+	}
+}
+
+// TestUpgradeReportsSIGTERMFallback verifies the user-facing message when
+// RequestShutdown stopped a pre-#501 daemon via the SIGTERM fallback (#504).
+// Users need to see that we used the fallback so support can tell whether
+// the daemon will respawn cleanly.
+func TestUpgradeReportsSIGTERMFallback(t *testing.T) {
+	tempBin := filepath.Join(t.TempDir(), "agent-factory")
+	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+
+	archive := makeTarGz(t, map[string][]byte{"agent-factory": []byte("new-binary")})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(archive)
+	}))
+	defer srv.Close()
+
+	prevExe := osExecutableFn
+	prevShutdown := requestDaemonShutdownFn
+	t.Cleanup(func() {
+		osExecutableFn = prevExe
+		requestDaemonShutdownFn = prevShutdown
+	})
+	osExecutableFn = func() (string, error) { return tempBin, nil }
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
+		return daemon.ShutdownViaSIGTERM, nil
+	}
+
+	// Capture stdout so we can assert on the user-visible message.
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	if err := runUpgrade(srv.URL); err != nil {
+		t.Fatalf("runUpgrade: %v", err)
+	}
+	w.Close()
+	captured, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read captured stdout: %v", err)
+	}
+
+	got := string(captured)
+	want := "Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM)"
+	if !strings.Contains(got, want) {
+		t.Fatalf("runUpgrade stdout missing SIGTERM-fallback message.\n got=%q\nwant substring=%q", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #504.

## Audit (what's broken)

Pre-#501 daemons register `Control` as a net/rpc service but never registered a `Shutdown` method (added in #498/#501). After #501 made `af upgrade` call `daemon.RequestShutdown` to restart the running daemon, the following happens on a stale daemon:

1. Socket exists, dial succeeds.
2. `client.Call("Control.Shutdown", …)` returns `rpc.ServerError("rpc: can't find method Control.Shutdown")` — the literal Go stdlib message for an unregistered method (see `net/rpc/server.go` in the Go stdlib).
3. `isDaemonAbsentErr` does NOT match that error (it only matches `ECONNREFUSED` / `ENOENT`), so `RequestShutdown` returns `(false, err)` and the upgrade prints the "Failed to restart the running daemon: …" branch.

So the upgrade message is currently a failure-with-recovery-hint, not the silent success suggested in the issue body. Either way the user-visible effect matches the symptom — `af upgrade` declares done while the stale daemon keeps running the old binary. The fix is the same: refine the classifier so method-not-found does NOT mean "no daemon", and add a SIGTERM-based fallback so the upgrade actually stops the running pre-#501 binary.

I also audited the daemon's startup path: `daemon.go launchDaemonProcess` writes a PID file on the parent side with mode `0644`, non-atomic. `RunDaemon` itself writes nothing. This PR moves the PID write into the daemon process and makes it atomic / `0600` so the SIGTERM fallback has a reliable place to look.

## Design choice

I put the SIGTERM fallback **inside** `daemon.RequestShutdown` rather than in `upgrade.go`. Rationale: keeps daemon-control concerns in `daemon/`, leaves the upgrade/autoupdate sites symmetric and trivial, and lets us return a single `ShutdownResult` enum that drives the user-facing message. `RequestShutdown` is the only caller-facing API for shutdown, so callers only need to consume one return value, not interleave RPC + signal logic themselves.

The fallback strategy:
1. **PID file** at `~/.config/agent-factory/daemon.pid`. Verify the PID is alive and `/proc/<pid>/cmdline` (Linux) or `ps -p <pid> -o args=` (macOS) contains `--daemon` as a discrete token. Defensive against PID reuse.
2. **Pgrep fallback** when the PID file is missing or stale: `pgrep -f "af --daemon"`, filter out `/tmp/Test*` / `/tmp/go-build*` paths (Go test binaries) and the current process. Exactly one match → SIGTERM. Zero matches → `ShutdownNoDaemon` (the daemon must have already died). Multiple → surface an actionable error naming the PIDs.
3. SIGTERM, poll for exit every 100ms, escalate to SIGKILL after 5s.

`pidLooksAlive` does a Linux zombie check via `/proc/<pid>/cmdline` so a dying daemon whose parent isn't waiting doesn't block the upgrade for the full 5s grace.

## What changed

* `daemon/daemon.go`: `RunDaemon` writes a `0600` atomic PID file at startup and removes it on graceful shutdown. Removes the parent-side `0644` write.
* `daemon/control.go`: tightens `isDaemonAbsentErr` to socket-level errors only; adds `isRPCMethodNotFoundErr`; reshapes `RequestShutdown` to return `ShutdownResult` (`ShutdownNoDaemon` / `ShutdownViaRPC` / `ShutdownViaSIGTERM`).
* `daemon/sigterm_fallback.go` (new): PID file + pgrep candidate resolution; SIGTERM-with-escalation.
* `upgrade.go`: new user-facing message for the SIGTERM-fallback branch.
* `autoupdate.go`: same shape, logs instead of stdout.
* Tests for: PID file lifecycle (helpers + full `RunDaemon` flow); `isRPCMethodNotFoundErr` and the `isDaemonAbsentErr` regression guard; SIGTERM fallback kills a process with matching cmdline; SIGTERM fallback refuses a process with non-matching cmdline; SIGTERM fallback handles dead PID cleanly; `runUpgrade` prints the new SIGTERM-fallback message.

## Test plan

- [x] `gofmt -l .` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go build ./...` clean
- [x] `go test -race ./...` green (full suite, including new daemon tests under race detector)
- [ ] Captain Claude: manual repro on dev box — `af upgrade` against stale daemon PID 243967 (started May 8, pre-#501 binary). Expected: upgrade prints "Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM); it will respawn from the new binary on next use." and `ps -p 243967` reports no such process.

## Manual repro recipe (matches Captain Claude's pre-fix repro)

```bash
# Start a stale daemon using the pre-#501 binary (no Shutdown RPC).
# Substitute the path to a pre-1.0.68 af binary you have laying around.
./af-old --daemon &
STALE_PID=$!
sleep 1
ls -la ~/.config/agent-factory/daemon.sock  # socket exists
ls -la ~/.config/agent-factory/daemon.pid  # 0644 PID file from the pre-#501 parent

# Install this branch.
./dev-install.sh

# Run upgrade. Pre-fix: "Failed to restart the running daemon: rpc: can't find method Control.Shutdown".
# Post-fix: "Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM); ..."
af upgrade

ps -p $STALE_PID  # should be gone
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)