### PR TITLE
fix(tmux): nil-guard TapEnter/TapDAndEnter on closed PTY (#510)

### DIFF
--- a/session/tmux/race_test.go
+++ b/session/tmux/race_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -174,6 +175,83 @@ func TestDetachHappyPathReplacesPtmx(t *testing.T) {
 	}
 	if session.ptmx == original {
 		t.Fatalf("expected Detach to swap in a fresh ptmx, got the original handle")
+	}
+}
+
+// TestKeystrokeMethodsReturnErrSessionGoneAfterDetachRestoreFailure is a
+// regression test for issue #510.
+//
+// PR #474 cleared t.ptmx in Detach when the follow-up Restore failed and
+// gated Attach on the nil, but TapEnter/TapDAndEnter/SendKeys still
+// dereferenced t.ptmx directly. A status-check (CheckAndHandleTrustPrompt)
+// or autoyes daemon tick that fired after a failed Detach Restore would
+// panic on the nil Write instead of surfacing ErrSessionGone.
+//
+// After this fix, every keystroke method that reads t.ptmx must short-
+// circuit to ErrSessionGone when the PTY is nil so callers (preview pane,
+// daemon, app key handler) can degrade gracefully — mirroring the gate
+// already on Attach (#474) and SetDetachedSize (#499).
+func TestKeystrokeMethodsReturnErrSessionGoneAfterDetachRestoreFailure(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+
+	// Same has-session script as TestDetachClearsPtmxOnRestoreFailure: the
+	// initial Restore succeeds, then Detach's internal Restore("") sees a
+	// vanished session and fails — leaving t.ptmx nil.
+	hasSessionCalls := 0
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				hasSessionCalls++
+				if hasSessionCalls > 1 {
+					return fmt.Errorf("session vanished")
+				}
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("keystroke-detach-fail", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+
+	session.Detach()
+
+	if session.ptmx != nil {
+		t.Fatalf("expected ptmx to be nil after Detach with failed Restore")
+	}
+
+	// Each keystroke method must return ErrSessionGone instead of panicking
+	// on the nil Write. Use a table so a future addition can't silently skip
+	// the regression check.
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"TapEnter", session.TapEnter},
+		{"TapDAndEnter", session.TapDAndEnter},
+		{"SendKeys", func() error { return session.SendKeys("hello") }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("%s panicked on nil PTY: %v", c.name, r)
+				}
+			}()
+			err := c.call()
+			if err == nil {
+				t.Fatalf("%s returned nil error, expected ErrSessionGone", c.name)
+			}
+			if !errors.Is(err, ErrSessionGone) {
+				t.Fatalf("%s returned %v, expected ErrSessionGone", c.name, err)
+			}
+		})
 	}
 }
 

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -311,6 +311,12 @@ func (m *statusMonitor) hash(s string) []byte {
 
 // TapEnter sends an enter keystroke to the tmux pane.
 func (t *TmuxSession) TapEnter() error {
+	// Detach failure (or Close) clears t.ptmx (#474), so callers that fire
+	// keystrokes against a detached session must surface ErrSessionGone
+	// instead of panicking on a nil Write (#510).
+	if t.ptmx == nil {
+		return ErrSessionGone
+	}
 	_, err := t.ptmx.Write([]byte{0x0D})
 	if err != nil {
 		return fmt.Errorf("error sending enter keystroke to PTY: %w", err)
@@ -320,6 +326,9 @@ func (t *TmuxSession) TapEnter() error {
 
 // TapDAndEnter sends 'D' followed by an enter keystroke to the tmux pane.
 func (t *TmuxSession) TapDAndEnter() error {
+	if t.ptmx == nil {
+		return ErrSessionGone
+	}
 	_, err := t.ptmx.Write([]byte{0x44, 0x0D})
 	if err != nil {
 		return fmt.Errorf("error sending enter keystroke to PTY: %w", err)
@@ -328,6 +337,9 @@ func (t *TmuxSession) TapDAndEnter() error {
 }
 
 func (t *TmuxSession) SendKeys(keys string) error {
+	if t.ptmx == nil {
+		return ErrSessionGone
+	}
 	_, err := t.ptmx.Write([]byte(keys))
 	return err
 }


### PR DESCRIPTION
## Summary

Closes #510.

#474 cleared `t.ptmx` in `Detach` when the follow-up `Restore` failed and gated `Attach` on the resulting nil — but `TapEnter`, `TapDAndEnter`, and `SendKeys` still dereferenced `t.ptmx` directly. A `CheckAndHandleTrustPrompt` call (claude/codex trust screen) or an autoyes daemon tick that fired after a failed Detach Restore panicked on the nil `Write` instead of surfacing `ErrSessionGone`.

This extends the same nil-guard pattern already on `Attach` (#474) and `SetDetachedSize` (#499) to every keystroke method that reads `t.ptmx`, so non-daemon callers (preview pane, app key handler, daemon autoyes) can degrade gracefully via `errors.Is(err, ErrSessionGone)`.

## Audit — every method that touches `t.ptmx` in `session/tmux/tmux.go`

| Method | Reads `t.ptmx`? | Pre-fix classification | Post-fix |
| --- | --- | --- | --- |
| `Restore` | writes only | n/a | unchanged |
| `TapEnter` | yes (`Write`) | **panics-on-nil** | gated → `ErrSessionGone` |
| `TapDAndEnter` | yes (`Write`) | **panics-on-nil** | gated → `ErrSessionGone` |
| `SendKeys` | yes (`Write`) | **panics-on-nil** | gated → `ErrSessionGone` |
| `Attach` | yes (entry check + goroutines) | gated (#474) | unchanged |
| `DetachSafely` | yes (`Close`) | gated (`if t.ptmx != nil`) | unchanged |
| `Detach` | yes (`Close`) | not-reachable-after-Detach (only invoked from the Attach goroutine while ptmx is live) | unchanged |
| `Close` | yes (`Close`) | gated (`if t.ptmx != nil`) | unchanged |
| `SetDetachedSize` | yes (`updateWindowSize`) | gated (#499) | unchanged |
| `updateWindowSize` | yes (`pty.Setsize`) | private; called from `SetDetachedSize` (gated) and `monitorWindowSize` (only runs during Attach when ptmx is live) | unchanged |

## Test plan

- [x] New regression test `TestKeystrokeMethodsReturnErrSessionGoneAfterDetachRestoreFailure` drives Detach with a failed Restore and asserts `TapEnter`, `TapDAndEnter`, and `SendKeys` each return `ErrSessionGone` (with `recover()` to catch any panic regression). Mirrors the mock pattern from `TestDetachClearsPtmxOnRestoreFailure`.
- [x] `go build ./...`
- [x] `go test ./...` (full suite passes including app/integration)
- [x] `golangci-lint run --timeout=3m --fast` (clean)
- [x] `gofmt -l .` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)