### PR TITLE
fix(tmux): clear t.ptmx after wg.Wait to avoid race with resize goroutines (#512)

### DIFF
--- a/session/tmux/race_test.go
+++ b/session/tmux/race_test.go
@@ -177,6 +177,69 @@ func TestDetachHappyPathReplacesPtmx(t *testing.T) {
 	}
 }
 
+// TestDetachDuringResizeRace is a regression test for issue #512.
+//
+// PR #474 changed Detach to clear t.ptmx right after closing the PTY so a
+// Restore failure couldn't leave a stale closed handle dangling on the
+// struct. That nil-clear happened BEFORE t.wg.Wait(), so it raced with
+// monitorWindowSize's resize goroutine — which reads t.ptmx via
+// updateWindowSize and is tracked by t.wg. Under -race the read/write of
+// t.ptmx is flagged; in production it could observe a nil ptmx and panic.
+//
+// Detach must drain t.wg.Wait() BEFORE touching t.ptmx (clear or replace
+// via Restore). Mirrors TestCloseDuringAttachRace: a stand-in goroutine
+// reads the t.ptmx field until ctx is cancelled. Many iterations to give
+// the race detector room to fire.
+func TestDetachDuringResizeRace(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		ptyFactory := NewMockPtyFactory(t)
+		cmdExec := cmd_test.MockCmdExec{
+			RunFunc:    func(cmd *exec.Cmd) error { return nil },
+			OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+		}
+
+		session := newTmuxSession(toTmuxName("detach-race", ""), "claude", ptyFactory, cmdExec)
+		if err := session.Restore(""); err != nil {
+			t.Fatalf("Restore: %v", err)
+		}
+
+		session.attachCh = make(chan struct{})
+		session.wg = &sync.WaitGroup{}
+		session.ctx, session.cancel = context.WithCancel(context.Background())
+
+		// Stand-in for monitorWindowSize's resize goroutine: reads t.ptmx
+		// (the field) until ctx is cancelled. The real goroutine calls
+		// pty.Setsize(t.ptmx, ...) which reads the same field; we read the
+		// field directly to focus on the data race without touching real
+		// terminal state.
+		session.wg.Add(1)
+		go func() {
+			defer session.wg.Done()
+			for {
+				select {
+				case <-session.ctx.Done():
+					return
+				default:
+					_ = session.ptmx
+				}
+			}
+		}()
+
+		// Let the goroutine spin so Detach races with active reads.
+		time.Sleep(time.Microsecond)
+
+		session.Detach()
+
+		// Happy path: Detach calls Restore("") which succeeds and installs a
+		// fresh ptmx. The point of this test is the race detector, but
+		// asserting the happy-path invariant keeps the test honest about what
+		// state Detach leaves behind.
+		if session.ptmx == nil {
+			t.Fatalf("expected ptmx to be set after successful Detach -> Restore")
+		}
+	}
+}
+
 // TestCloseWithoutAttach ensures Close is safe when Attach was never called
 // (cancel/wg are nil).
 func TestCloseWithoutAttach(t *testing.T) {

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -540,27 +540,34 @@ func (t *TmuxSession) Detach() {
 	// "Session terminated without detaching" warning.
 	t.cancel()
 
-	// Close the attached pty session. Clear t.ptmx unconditionally before
-	// Restore so a Restore failure (or a Close failure) can't leave the
-	// closed handle dangling on the struct — a subsequent Attach would
-	// otherwise silently bind goroutines to a closed file and hang (#464).
+	// Close the attached pty session, then wait for the goroutines tracked
+	// by t.wg to drain BEFORE touching t.ptmx. monitorWindowSize's resize
+	// goroutine reads t.ptmx via updateWindowSize, so clearing it (or
+	// having Restore replace it) while that goroutine is live is a data
+	// race (#512). The goroutines exit promptly once t.ctx is cancelled
+	// and the PTY is closed.
 	closeErr := t.ptmx.Close()
+	t.wg.Wait()
+
+	// Goroutines have exited; safe to touch t.ptmx without coordination.
+	// Clear unconditionally so that a subsequent Restore failure (or the
+	// Close failure above) can't leave a stale closed handle on the
+	// struct — a later Attach would otherwise silently bind goroutines
+	// to a closed file and hang (#464).
 	t.ptmx = nil
 	if closeErr != nil {
 		log.ErrorLog.Printf("error closing attach pty session: %v", closeErr)
-		t.wg.Wait()
 		return
 	}
 
-	// Attach goroutines should die due to the ptmx closing. Call
-	// t.Restore to set a new t.ptmx. The session is alive (we just detached
-	// from it), so pass empty workDir — a missing session here is a real
-	// problem and should surface, not silently re-spawn and lose history.
+	// Call t.Restore to install a fresh t.ptmx. The session is alive (we
+	// just detached from it), so pass empty workDir — a missing session
+	// here is a real problem and should surface, not silently re-spawn
+	// and lose history. On Restore failure, t.ptmx remains nil per the
+	// clear above (#474).
 	if err := t.Restore(""); err != nil {
 		log.ErrorLog.Printf("error restoring pty after detach: %v", err)
 	}
-
-	t.wg.Wait()
 }
 
 // Close terminates the tmux session and cleans up resources


### PR DESCRIPTION
## Summary

Closes #512.

`Detach()` in `session/tmux/tmux.go` cancelled the context and closed the PTY, then immediately cleared `t.ptmx = nil` — **before** `t.wg.Wait()`. The `monitorWindowSize` resize goroutine is tracked by `t.wg` and reads `t.ptmx` via `updateWindowSize` → `pty.Setsize(t.ptmx, ...)`, so the early clear races with the read. Under `-race` the read/write is flagged; in production the goroutine could observe a nil `ptmx` and panic dereferencing it. PR #474 introduced the early clear (to fix #464) without accounting for these goroutines.

### Fix

Reorder `Detach()` so `t.wg.Wait()` drains the resize goroutines before any further touch of `t.ptmx`:

1. `t.cancel()` — unchanged, ensures the io.Copy goroutine sees a normal detach.
2. `t.ptmx.Close()` — same as before; wakes the resize goroutines so they can return.
3. **`t.wg.Wait()`** — now happens here, BEFORE any field write.
4. `t.ptmx = nil` — unconditional, preserving #474's invariant on every error path.
5. `t.Restore("")` — installs a fresh handle, or leaves it nil on failure.

### Why option (a) over a mutex

Smaller diff, no new state, and the resize goroutines were already designed to exit on `t.ctx.Done()` — so they drain quickly once cancel + Close happen. A mutex would have to wrap every read in `updateWindowSize`/`TapEnter`/`SendKeys`/etc. and the locking discipline would be easy to break.

### Invariants preserved

- **#464**: `t.ptmx` is still cleared on every error path before Detach returns, so a subsequent `Attach()` still returns the "no PTY available" error rather than binding goroutines to a closed handle. Verified by the existing `TestDetachClearsPtmxOnRestoreFailure`.
- **#474**: same — the unconditional nil-clear is just moved one statement later.

### Test plan

- [x] `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` — green across the repo
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go test -race -count=100 -run 'TestDetach.*|TestClose.*' ./session/tmux/` — green; no races
- [x] Verified the new `TestDetachDuringResizeRace` **fails** the race detector when reverted to the pre-fix code (data race report on `t.ptmx`), then passes once the fix is restored. Mirrors `TestCloseDuringAttachRace`'s pattern from #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)