### PR TITLE
fix(upgrade): nil-guard RPC client in SIGTERM fallback path (#514)

### DIFF
--- a/daemon/sigterm_fallback_test.go
+++ b/daemon/sigterm_fallback_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/rpc"
 	"os"
 	"os/exec"
@@ -331,5 +332,98 @@ func TestErrIsProcessGone(t *testing.T) {
 				t.Errorf("errIsProcessGone(%v) = %v, want %v", c.err, got, c.want)
 			}
 		})
+	}
+}
+
+// preShutdownDaemonRPC is an RPC service that exposes Ping but deliberately
+// omits Shutdown — modeling a pre-#501 daemon that registered Control before
+// the Shutdown method existed. Used by TestRequestShutdown_PreShutdownDaemon.
+type preShutdownDaemonRPC struct{}
+
+func (preShutdownDaemonRPC) Ping(_ PingRequest, resp *PingResponse) error {
+	resp.OK = true
+	return nil
+}
+
+// startPreShutdownFakeDaemon listens on the daemon control socket and serves
+// a Control service that registers Ping but no Shutdown method. Returns a
+// cleanup function that closes the listener.
+func startPreShutdownFakeDaemon(t *testing.T) func() {
+	t.Helper()
+	socketPath, err := DaemonSocketPath()
+	if err != nil {
+		t.Fatalf("DaemonSocketPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0755); err != nil {
+		t.Fatalf("mkdir socket parent: %v", err)
+	}
+	_ = os.Remove(socketPath)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen on %s: %v", socketPath, err)
+	}
+	server := rpc.NewServer()
+	if err := server.RegisterName(controlServiceName, preShutdownDaemonRPC{}); err != nil {
+		_ = listener.Close()
+		t.Fatalf("RegisterName: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go server.ServeConn(conn)
+		}
+	}()
+	return func() {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	}
+}
+
+// TestRequestShutdown_PreShutdownDaemon regresses sachiniyer/agent-factory#514.
+// The scenario from the report: a daemon that registers Control as an RPC
+// service but never registered Shutdown (the method added in #498/#501).
+// RequestShutdown must:
+//   - detect the rpc method-not-found via isRPCMethodNotFoundErr,
+//   - route to sigtermFallback rather than treating the daemon as absent,
+//   - return a sane (Result, error) pair without panicking.
+//
+// Prior to the #514 fix the sigtermFallback log.InfoLog.Printf call would
+// nil-deref when the upgrade path reached this code without log.Initialize
+// having been called. We can't replay the missing-Initialize case in this
+// process (TestMain runs Initialize) — that's covered separately by the
+// log-package default-initializer test. This test pins the routing+behavior
+// half: the rpc-method-not-found branch must reach sigtermFallback cleanly,
+// which is the structural precondition for the upgrade flow to recover.
+func TestRequestShutdown_PreShutdownDaemon(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	stop := startPreShutdownFakeDaemon(t)
+	defer stop()
+
+	// Sanity: a Ping over the socket succeeds — this is what makes the
+	// daemon look "alive" so RequestShutdown does not short-circuit at the
+	// socket-stat step.
+	if err := pingDaemon(); err != nil {
+		t.Fatalf("ping fake daemon: %v", err)
+	}
+
+	// The fallback's pgrep step would, on a busy host, find a real
+	// `af --daemon` process and try to signal it. That host-state
+	// dependency belongs in an integration test, not a unit test —
+	// here we only need to assert RequestShutdown completes without
+	// a panic and surfaces a Result/error consistent with the routing
+	// having reached the fallback. The result space is:
+	//   - ShutdownNoDaemon, nil           (clean test host)
+	//   - ShutdownViaSIGTERM, nil         (host has a real daemon — uncommon)
+	//   - ShutdownNoDaemon, non-nil error (ambiguous pgrep matches)
+	// What is NOT acceptable: a panic, or ShutdownViaRPC (would mean the
+	// fake daemon answered Shutdown, which it does not implement).
+	result, err := RequestShutdown()
+	if result == ShutdownViaRPC {
+		t.Fatalf("RequestShutdown returned ShutdownViaRPC; fake daemon has no Shutdown method — routing into the SIGTERM fallback is broken (err=%v)", err)
 	}
 }

--- a/log/log.go
+++ b/log/log.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -14,6 +15,16 @@ var (
 	InfoLog    *log.Logger
 	ErrorLog   *log.Logger
 )
+
+// Default the package-level loggers to discard sinks so callers that reach a
+// log call before Initialize do not nil-panic. Initialize replaces these with
+// real file/stderr loggers. Without this, code paths like `af upgrade` that
+// forget to call Initialize crash inside the SIGTERM fallback (#514).
+func init() {
+	InfoLog = log.New(io.Discard, "", 0)
+	WarningLog = log.New(io.Discard, "", 0)
+	ErrorLog = log.New(io.Discard, "", 0)
+}
 
 // mu guards writes to globalLogFile and the exported *log.Logger pointers
 // performed by Initialize and Close. Readers (e.g. InfoLog.Printf) rely on

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -8,6 +8,28 @@ import (
 	"testing"
 )
 
+// TestLoggersInitializedByDefault asserts that the package-level loggers are
+// non-nil before any Initialize call. Regression for sachiniyer/agent-factory#514:
+// `af upgrade` reaches the SIGTERM fallback in daemon/sigterm_fallback.go
+// before runUpgrade has a chance to call Initialize, and the fallback writes
+// through InfoLog/WarningLog. Without non-nil defaults those Printf calls
+// nil-dereference and panic the upgrade.
+func TestLoggersInitializedByDefault(t *testing.T) {
+	if InfoLog == nil {
+		t.Error("InfoLog is nil at package-init time; upgrade SIGTERM fallback would panic")
+	}
+	if WarningLog == nil {
+		t.Error("WarningLog is nil at package-init time; upgrade SIGTERM fallback would panic")
+	}
+	if ErrorLog == nil {
+		t.Error("ErrorLog is nil at package-init time")
+	}
+	// Exercise each logger to confirm no panic on a Printf path.
+	InfoLog.Printf("default-logger-smoke-test")
+	WarningLog.Printf("default-logger-smoke-test")
+	ErrorLog.Printf("default-logger-smoke-test")
+}
+
 // TestInitializeRace spins multiple goroutines concurrently calling
 // Initialize to make sure the package-level mutex prevents data races on
 // globalLogFile and the exported logger pointers. Run with `go test -race`.

--- a/upgrade.go
+++ b/upgrade.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/spf13/cobra"
 )
 
@@ -85,6 +86,13 @@ var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade agent-factory to the latest version",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// RequestShutdown's SIGTERM fallback (#504) writes through
+		// log.InfoLog / log.WarningLog. Initialize logging up-front so those
+		// pointers are non-nil when we hit a pre-#501 daemon — otherwise the
+		// upgrade panics with a nil-deref instead of finishing cleanly (#514).
+		log.Initialize(false)
+		defer log.Close()
+
 		goos := runtime.GOOS
 		goarch := runtime.GOARCH
 


### PR DESCRIPTION
## Summary

`af upgrade` panicked with a nil pointer dereference when the running daemon was a pre-#501 binary (Control RPC service registered, but no Control.Shutdown method). The audit landed in the SIGTERM fallback path introduced in #505: `sigtermFallback` writes through `log.InfoLog` / `log.WarningLog` while handling a stale PID file, but `upgradeCmd.RunE` never called `log.Initialize`, so those loggers were nil.

Two-layer fix:

- **`upgrade.go`** — call `log.Initialize(false)` + `defer log.Close()` at the top of `upgradeCmd.RunE`, matching `reset` and `debug`. The direct root cause; users also start getting the diagnostic log entries the upgrade flow writes.
- **`log/log.go`** — seed `InfoLog` / `WarningLog` / `ErrorLog` with `io.Discard` loggers at package `init()` time. Defense in depth so any caller that reaches a log call before `Initialize` gets a silent no-op instead of crashing the binary. Removes the footgun.

## Tests

- `log/log_test.go` → `TestLoggersInitializedByDefault` — asserts the three package vars are non-nil at init and exercises each `Printf` path. Verified to fail (panic) when the `init()` block is removed, confirming it catches the regression.
- `daemon/sigterm_fallback_test.go` → `TestRequestShutdown_PreShutdownDaemon` — stands up a fake `Control` RPC service that exposes `Ping` but not `Shutdown` (the exact scenario from the report) and asserts `RequestShutdown` routes into the SIGTERM fallback rather than returning `ShutdownViaRPC` or panicking.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` (no output)
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `go test ./...` (all packages green)
- [x] New regression test fails when the fix is reverted

Closes #514.