### PR TITLE
fix(daemon): update in-memory state before disk to avoid duplicate-from-poll race (#509)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -512,14 +512,29 @@ func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData,
 
 	instance.SetStatus(session.Running)
 	data := instance.ToInstanceData()
-	if err := appendInstanceData(repo.ID, data); err != nil {
-		_ = instance.Kill()
-		return session.InstanceData{}, err
-	}
 
-	m.mu.Lock()
-	m.instances[daemonInstanceKey(repo.ID, title)] = instance
-	m.mu.Unlock()
+	// Register the in-memory instance and persist it to disk inside the
+	// same critical section. The daemon refresh loop rebuilds
+	// session.Instance objects from disk for any key it does not already
+	// see in m.instances, so a window where the entry exists on disk but
+	// not in memory would let refresh construct a duplicate Instance
+	// (opening a fresh PTY in the tmux backend) that gets orphaned when
+	// the original is later stored under the same key.
+	key := daemonInstanceKey(repo.ID, title)
+	persistErr := func() error {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		m.instances[key] = instance
+		if err := appendInstanceData(repo.ID, data); err != nil {
+			delete(m.instances, key)
+			return err
+		}
+		return nil
+	}()
+	if persistErr != nil {
+		_ = instance.Kill()
+		return session.InstanceData{}, persistErr
+	}
 
 	return data, nil
 }

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -3,12 +3,15 @@ package daemon
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -89,6 +92,109 @@ func TestManagerCreateSessionPersistsAndRejectsDuplicate(t *testing.T) {
 		Program:  "claude",
 	}); err == nil {
 		t.Fatalf("expected duplicate title to be rejected")
+	}
+}
+
+// TestManagerCreateSessionAtomicWithRefresh is a regression test for
+// sachiniyer/agent-factory#509. The pre-fix code persisted a new session to
+// disk before inserting it into m.instances under m.mu. The daemon's refresh
+// loop rebuilds session.Instance objects from disk for any key it does not
+// already see in m.instances — so a refresh that fired between disk-write
+// and memory-insert constructed a duplicate Instance via FromInstanceData
+// (opening a fresh PTY in the tmux backend) that became unreachable when
+// CreateSession finally stored its own instance under the same key. The
+// duplicate's PTY fd was then leaked for the lifetime of the daemon.
+//
+// The fix folds the in-memory insert and the disk write into a single
+// critical section under m.mu, so refresh either runs before the disk
+// write happens or blocks until the in-memory entry is present and is
+// reused via existing-key dedup.
+//
+// We assert that property by counting how many times the refresh path
+// invokes FromInstanceData. With the fix, refresh races with CreateSession
+// can never observe a disk-only state, so FromInstanceData is never called
+// for newly-created sessions and the counter stays at zero. With the buggy
+// ordering, refresh occasionally observes the gap and increments the
+// counter — even in the test environment where the real FromInstanceData
+// would have failed for lack of tmux, the call itself is recorded.
+func TestManagerCreateSessionAtomicWithRefresh(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	var fromInstanceDataCalls atomic.Int32
+	prev := fromInstanceDataForRefresh
+	fromInstanceDataForRefresh = func(d session.InstanceData) (*session.Instance, error) {
+		fromInstanceDataCalls.Add(1)
+		return prev(d)
+	}
+	t.Cleanup(func() { fromInstanceDataForRefresh = prev })
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = manager.RefreshInstances()
+				}
+			}
+		}()
+	}
+	t.Cleanup(func() {
+		close(stop)
+		wg.Wait()
+	})
+
+	const numSessions = 8
+	for i := 0; i < numSessions; i++ {
+		title := fmt.Sprintf("race-%d", i)
+		if _, err := manager.CreateSession(CreateSessionRequest{
+			Title:    title,
+			RepoPath: repoPath,
+			Program:  "claude",
+		}); err != nil {
+			t.Fatalf("CreateSession(%q): %v", title, err)
+		}
+	}
+
+	for i := 0; i < 50; i++ {
+		_ = manager.RefreshInstances()
+	}
+
+	if got := fromInstanceDataCalls.Load(); got != 0 {
+		t.Fatalf("refresh invoked FromInstanceData %d times — would have constructed duplicate Instance(s) and orphaned their PTY fds (#509)", got)
+	}
+
+	snap := manager.InstancesSnapshot()
+	if len(snap) != numSessions {
+		t.Fatalf("expected %d instances in memory, got %d", numSessions, len(snap))
+	}
+
+	raw, err := config.LoadRepoInstances(repo.ID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var stored []session.InstanceData
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("unmarshal stored: %v", err)
+	}
+	if len(stored) != numSessions {
+		t.Fatalf("expected %d sessions on disk, got %d", numSessions, len(stored))
 	}
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -102,6 +102,14 @@ func RunDaemon(cfg *config.Config) error {
 	return nil
 }
 
+// fromInstanceDataForRefresh is the entry point refreshDaemonInstances uses
+// to materialize a session.Instance from a persisted on-disk entry. It is a
+// package-level variable so tests can observe (or substitute) the call —
+// see TestManagerCreateSessionAtomicWithRefresh, which uses it to detect
+// whether refresh ever raced CreateSession and tried to construct a
+// duplicate Instance from disk.
+var fromInstanceDataForRefresh = session.FromInstanceData
+
 func refreshDaemonInstances(existing map[string]*session.Instance) (map[string]*session.Instance, error) {
 	allInstances, err := config.LoadAllRepoInstances()
 	if err != nil {
@@ -128,7 +136,7 @@ func refreshDaemonInstances(existing map[string]*session.Instance) (map[string]*
 				}
 			}
 
-			instance, err := session.FromInstanceData(item)
+			instance, err := fromInstanceDataForRefresh(item)
 			if err != nil {
 				log.WarningLog.Printf("daemon skipping instance %q: %v", item.Title, err)
 				continue


### PR DESCRIPTION
Closes #509.

## Audit

`Manager.CreateSession` in `daemon/control.go` ordered the on-disk persist before the in-memory insert. The pre-fix sequence:

```go
// daemon/control.go, pre-fix
instance.SetStatus(session.Running)
data := instance.ToInstanceData()
if err := appendInstanceData(repo.ID, data); err != nil {  // (1) disk write
    _ = instance.Kill()
    return session.InstanceData{}, err
}

m.mu.Lock()                                                 // (2) lock taken AFTER disk write
m.instances[daemonInstanceKey(repo.ID, title)] = instance
m.mu.Unlock()
```

The daemon's polling goroutine (`daemon/daemon.go:60-81`) calls `Manager.RefreshInstances` every `DaemonPollInterval` (default 500 ms). `RefreshInstances` takes `m.mu` and delegates to `refreshDaemonInstances`, which reads every repo's on-disk session list and, for any key not already in the passed-in `existing` map, calls `session.FromInstanceData` to construct a fresh `*session.Instance`. In the tmux backend that path runs `TmuxSession.Restore` which opens a new PTY (`t.ptmx = ptmx`).

Between (1) returning and (2) acquiring `m.mu`, the poll loop can:

- take `m.mu` first,
- observe disk has the new entry and memory does not,
- call `FromInstanceData` → opens a fresh PTY,
- store the new `Instance` in the rebuilt map and swap it into `m.instances`,
- release `m.mu`.

`CreateSession` then takes `m.mu` and overwrites `m.instances[key]` with its own `Instance`. The refresh-built `Instance` is unreachable; nothing ever calls `Kill` on it, and its PTY fd leaks for the daemon's lifetime.

## Fix

Fold the in-memory insert and the disk write into a single critical section under `m.mu` (`daemon/control.go`):

```go
key := daemonInstanceKey(repo.ID, title)
persistErr := func() error {
    m.mu.Lock()
    defer m.mu.Unlock()
    m.instances[key] = instance
    if err := appendInstanceData(repo.ID, data); err != nil {
        delete(m.instances, key)
        return err
    }
    return nil
}()
if persistErr != nil {
    _ = instance.Kill()
    return session.InstanceData{}, persistErr
}
```

With the lock held across both operations, `RefreshInstances` either:

- blocks on `m.mu` and, when it runs, finds the entry in `m.instances`; the existing-key dedup in `refreshDaemonInstances` reuses it without invoking `FromInstanceData`, or
- runs before `CreateSession` takes the lock; the on-disk file does not yet contain the new entry, so refresh sees nothing to construct.

On `appendInstanceData` failure the in-memory entry is rolled back before unlocking, and `Kill` runs outside the lock.

## Regression test

`TestManagerCreateSessionAtomicWithRefresh` in `daemon/control_test.go` runs two background `RefreshInstances` goroutines while `CreateSession` creates eight sessions. The test asserts that `FromInstanceData` is never invoked from the refresh path — that's the deterministic, observable signal that no duplicate `Instance` construction occurred. To make the call countable from a test, `refreshDaemonInstances` now goes through a small package-level seam (`fromInstanceDataForRefresh`).

Sanity-checked locally by reverting only the `control.go` ordering change: the pre-fix code triggers 100–180 spurious `FromInstanceData` calls per run; the fix produces zero across 20 consecutive runs.

## Gates

- `go build ./...` — clean
- `gofmt -l .` — empty
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — green
- `go test ./daemon -race -count=3` — clean

## Test plan

- [x] Regression test fails on pre-fix code (verified locally by reverting the `control.go` change)
- [x] Regression test passes deterministically on fixed code (20 consecutive runs)
- [x] Full test suite green with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)