### PR TITLE
fix(tmux): clear t.ptmx after wg.Wait to avoid race with resize goroutines (#512)

### DIFF
--- a/session/tmux/race_test.go
+++ b/session/tmux/race_test.go
@@ -255,6 +255,66 @@ func TestKeystrokeMethodsReturnErrSessionGoneAfterDetachRestoreFailure(t *testin
 	}
 }
 
+// TestDetachDuringResizeRace is a regression test for issue #512.
+//
+// TmuxSession.Detach used to clear t.ptmx (and call Restore which writes
+// t.ptmx) before t.wg.Wait, racing those writes against monitorWindowSize
+// goroutines tracked by t.wg — they read t.ptmx via updateWindowSize until
+// t.ctx was observed cancelled. Under `go test -race`, the read/write of
+// t.ptmx flagged a data race.
+//
+// Detach must now wg.Wait before mutating t.ptmx so the resize goroutines
+// have drained, mirroring the coordination Close uses (#331).
+func TestDetachDuringResizeRace(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		ptyFactory := NewMockPtyFactory(t)
+		cmdExec := cmd_test.MockCmdExec{
+			RunFunc:    func(cmd *exec.Cmd) error { return nil },
+			OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+		}
+
+		session := newTmuxSession(toTmuxName("detach-race-session", ""), "claude", ptyFactory, cmdExec)
+		if err := session.Restore(""); err != nil {
+			t.Fatalf("Restore: %v", err)
+		}
+
+		// Mimic the bookkeeping that Attach() sets up so Detach has matching
+		// state to tear down. The real monitorWindowSize touches stdin and
+		// SIGWINCH so we stand in for it with a goroutine that reads the
+		// field — the bug is the unsynchronized read of t.ptmx, regardless
+		// of whether the read goes on to Fd() or not.
+		session.attachCh = make(chan struct{})
+		session.wg = &sync.WaitGroup{}
+		session.ctx, session.cancel = context.WithCancel(context.Background())
+
+		session.wg.Add(1)
+		go func() {
+			defer session.wg.Done()
+			for {
+				select {
+				case <-session.ctx.Done():
+					return
+				default:
+					if p := session.ptmx; p == nil {
+						t.Errorf("monitor goroutine observed nil ptmx before ctx cancel")
+						return
+					}
+				}
+			}
+		}()
+
+		// Let the goroutine spin so Detach races with active reads.
+		time.Sleep(time.Microsecond)
+
+		session.Detach()
+
+		// After Detach completes, the goroutine must have exited (wg.Wait
+		// in Detach drained it). t.ptmx may be non-nil here because Detach's
+		// internal Restore("") succeeded against the mock — that's expected
+		// and tested by TestDetachHappyPathReplacesPtmx.
+	}
+}
+
 // TestCloseWithoutAttach ensures Close is safe when Attach was never called
 // (cancel/wg are nil).
 func TestCloseWithoutAttach(t *testing.T) {

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -546,33 +546,39 @@ func (t *TmuxSession) Detach() {
 		t.wg = nil
 	}()
 
-	// Cancel context FIRST so the io.Copy goroutine in Attach() sees a normal
-	// detach rather than an abnormal termination. Without this, closing the PTY
-	// can wake the goroutine before cancel() runs, causing a spurious
+	// Cancel context FIRST so monitorWindowSize goroutines exit promptly and
+	// the io.Copy goroutine in Attach() sees a normal detach rather than an
+	// abnormal termination. Without this, closing the PTY can wake the
+	// io.Copy goroutine before cancel() runs, causing a spurious
 	// "Session terminated without detaching" warning.
 	t.cancel()
 
-	// Close the attached pty session. Clear t.ptmx unconditionally before
-	// Restore so a Restore failure (or a Close failure) can't leave the
-	// closed handle dangling on the struct — a subsequent Attach would
-	// otherwise silently bind goroutines to a closed file and hang (#464).
+	// Close the attached pty session so the io.Copy goroutine returns.
 	closeErr := t.ptmx.Close()
+
+	// Wait for the attach goroutines (io.Copy + monitorWindowSize x2) to
+	// finish before mutating t.ptmx. monitorWindowSize reads t.ptmx via
+	// updateWindowSize, so clearing the field before wg.Wait races against
+	// those reads (#512). Coordinated like Close already is.
+	t.wg.Wait()
+
+	// Now safe to clear t.ptmx. Clearing unconditionally before Restore
+	// means a Restore failure (or a Close failure) can't leave the closed
+	// handle dangling on the struct — a subsequent Attach would otherwise
+	// silently bind goroutines to a closed file and hang (#464).
 	t.ptmx = nil
+
 	if closeErr != nil {
 		log.ErrorLog.Printf("error closing attach pty session: %v", closeErr)
-		t.wg.Wait()
 		return
 	}
 
-	// Attach goroutines should die due to the ptmx closing. Call
-	// t.Restore to set a new t.ptmx. The session is alive (we just detached
-	// from it), so pass empty workDir — a missing session here is a real
-	// problem and should surface, not silently re-spawn and lose history.
+	// Call t.Restore to set a new t.ptmx. The session is alive (we just
+	// detached from it), so pass empty workDir — a missing session here is a
+	// real problem and should surface, not silently re-spawn and lose history.
 	if err := t.Restore(""); err != nil {
 		log.ErrorLog.Printf("error restoring pty after detach: %v", err)
 	}
-
-	t.wg.Wait()
 }
 
 // Close terminates the tmux session and cleans up resources


### PR DESCRIPTION
## Summary
- Move `t.ptmx = nil` (and the follow-up `Restore("")`) in `Detach()` to after `t.wg.Wait()` so the mutation can't race against `monitorWindowSize` goroutines that read `t.ptmx` via `updateWindowSize`. Mirrors the coordination `Close()` already uses (#331).
- Add `TestDetachDuringResizeRace` (100 iters, stand-in resize goroutine, asserts the goroutine never observes a nil ptmx before ctx cancel). Verified the test reproduces the original race under `go test -race` when the fix is reverted.
- Re-dispatch of the previously closed #528 against current master, which now includes #527 (keystroke nil-guards on `TapEnter`/`TapDAndEnter`/`SendKeys`). Those guards remain intact — they're the right belt to this suspenders.

Closes #512

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)
- [x] `go test -race -count=1 ./session/tmux/` (passes; fails on master without this commit)
- [x] `go test ./...` (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)