### PR TITLE
fix(main): use exact basename match for --autoyes Claude detection (#520)

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/sachiniyer/agent-factory/api"
 	"github.com/sachiniyer/agent-factory/app"
@@ -71,7 +70,11 @@ var (
 			if autoYesFlag {
 				autoYes = true
 			}
-			if autoYes && strings.Contains(strings.ToLower(program), "claude") {
+			// Match Claude by exact basename (issue #520). A substring check
+			// false-matched paths like /home/claude-user/bin/aider or wrapper
+			// scripts named claude-something, appending Claude's permission
+			// flag to non-Claude commands.
+			if autoYes && session.BaseCommand(program) == tmux.ProgramClaude {
 				program = program + " --permission-mode bypassPermissions"
 			}
 			if autoYes {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// TestAutoYesClaudeDetection covers the --autoyes Claude detection logic
+// (issue #520). The previous substring match falsely classified paths and
+// wrapper scripts containing "claude" as Claude itself, appending the Claude
+// --permission-mode flag to unrelated programs.
+func TestAutoYesClaudeDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		program  string
+		isClaude bool
+	}{
+		{"bare claude", "claude", true},
+		{"absolute path to claude", "/usr/local/bin/claude", true},
+		{"claude with args", "claude --model opus", true},
+		{"absolute claude with args", "/usr/local/bin/claude --model opus", true},
+
+		// #520 regressions: these must NOT be classified as Claude.
+		{"aider under claude-user home", "/home/claude-user/bin/aider", false},
+		{"codex under claude-wrapper dir", "/opt/claude-wrapper/bin/codex", false},
+		{"hyphen-prefixed wrapper", "claude-code-cli", false},
+
+		// Other agents must remain unmatched.
+		{"aider", "aider", false},
+		{"codex", "codex", false},
+		{"gemini", "gemini", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := session.BaseCommand(tt.program) == tmux.ProgramClaude
+			if got != tt.isClaude {
+				t.Errorf("BaseCommand(%q)==ProgramClaude = %v, want %v",
+					tt.program, got, tt.isClaude)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `main.go` used `strings.Contains(strings.ToLower(program), \"claude\")` to decide whether to append `--permission-mode bypassPermissions` to the program when `--autoyes` was set. That false-matched paths like `/home/claude-user/bin/aider`, wrappers under `/opt/claude-wrapper/`, and binaries named `claude-code-cli` — appending a Claude-only flag to entirely different agents.
- Switch to `session.BaseCommand(program) == tmux.ProgramClaude`. `BaseCommand` is the shell-quoting-aware basename helper landed in #481 and is already the canonical way to identify the agent across the codebase (`app/handle_overlay.go`, `app/handle_input.go`).
- Add table tests in `main_test.go` covering the regression cases (`/home/claude-user/bin/aider`, `/opt/claude-wrapper/bin/codex`, `claude-code-cli`) plus the happy paths (`claude`, `/usr/local/bin/claude`, with and without args) and the other supported agents.

Closes #520

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` (no output)
- [x] `go test ./...` (all packages green, including the new `TestAutoYesClaudeDetection`)
- [x] `golangci-lint run --timeout=3m --fast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)