### PR TITLE
fix(task): split DOM+DOW cron into OR-semantic OnCalendar entries (#522)

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -116,10 +116,16 @@ func validatePart(part string, min, max int) error {
 	return nil
 }
 
-// CronToOnCalendar converts a 5-field cron expression to systemd OnCalendar format.
-func CronToOnCalendar(cronExpr string) (string, error) {
+// CronToOnCalendar converts a 5-field cron expression to one or more systemd
+// OnCalendar entries. When both day-of-month and day-of-week are restricted,
+// Vixie cron uses OR semantics (match DOM OR match DOW), while a single
+// systemd OnCalendar entry combines all fields with AND. In that case this
+// returns two entries — one constraining DOM (DOW=*), one constraining DOW
+// (DOM=*) — and the caller emits one OnCalendar= line per entry so systemd
+// unions them, reproducing cron's OR semantics.
+func CronToOnCalendar(cronExpr string) ([]string, error) {
 	if err := ValidateCronExpr(cronExpr); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	fields := strings.Fields(cronExpr)
@@ -129,35 +135,39 @@ func CronToOnCalendar(cronExpr string) (string, error) {
 	monthField := fields[3]
 	dowField := fields[4]
 
-	// Convert day-of-week
+	monthPart := convertTimeField(monthField, true)
+	domPart := convertTimeField(domField, true)
+	hourPart := convertTimeField(hourField, false)
+	minutePart := convertTimeField(minuteField, false)
+	timePart := fmt.Sprintf("%s:%s:00", hourPart, minutePart)
+
 	dowPart := ""
 	if dowField != "*" {
 		dowPart = convertDOW(dowField)
 	}
 
-	// Convert month (1-indexed)
-	monthPart := convertTimeField(monthField, true)
+	// A field that syntactically restricts but covers every legal value
+	// (DOM=1-31, DOW=0-6, DOW=*/1, etc.) is an effective wildcard. Under
+	// cron OR semantics, "X OR every-day" collapses to "every day", so an
+	// effective-wildcard side must not trigger the OR fan-out. convertDOW
+	// already returns "" for the DOW side; for DOM we expand and check.
+	domVals, _ := expandCronField(domField, 1, 31)
+	domCoversAll := domVals != nil && len(domVals) >= 31
 
-	// Convert day-of-month (1-indexed)
-	domPart := convertTimeField(domField, true)
+	domRestricted := domField != "*" && !domCoversAll
+	dowRestricted := dowPart != ""
 
-	// Convert hour (0-indexed)
-	hourPart := convertTimeField(hourField, false)
-
-	// Convert minute (0-indexed)
-	minutePart := convertTimeField(minuteField, false)
-
-	// Build the date part: YEAR-MONTH-DAY
-	datePart := fmt.Sprintf("*-%s-%s", monthPart, domPart)
-
-	// Build the time part: HOUR:MIN:SEC
-	timePart := fmt.Sprintf("%s:%s:00", hourPart, minutePart)
-
-	// Combine
-	if dowPart != "" {
-		return fmt.Sprintf("%s %s %s", dowPart, datePart, timePart), nil
+	if domRestricted && dowRestricted {
+		domOnly := fmt.Sprintf("*-%s-%s %s", monthPart, domPart, timePart)
+		dowOnly := fmt.Sprintf("%s *-%s-* %s", dowPart, monthPart, timePart)
+		return []string{domOnly, dowOnly}, nil
 	}
-	return fmt.Sprintf("%s %s", datePart, timePart), nil
+
+	datePart := fmt.Sprintf("*-%s-%s", monthPart, domPart)
+	if dowRestricted {
+		return []string{fmt.Sprintf("%s %s %s", dowPart, datePart, timePart)}, nil
+	}
+	return []string{fmt.Sprintf("%s %s", datePart, timePart)}, nil
 }
 
 // convertTimeField converts a cron time field to OnCalendar format.

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -79,61 +79,61 @@ func TestCronFieldExpandDedup(t *testing.T) {
 func TestCronToOnCalendarSimple(t *testing.T) {
 	result, err := CronToOnCalendar("30 2 * * *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-* 02:30:00", result)
+	assert.Equal(t, []string{"*-*-* 02:30:00"}, result)
 }
 
 func TestCronToOnCalendarRange(t *testing.T) {
 	result, err := CronToOnCalendar("0 9-17 * * *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-* 09..17:00:00", result)
+	assert.Equal(t, []string{"*-*-* 09..17:00:00"}, result)
 }
 
 func TestCronToOnCalendarRangeWithStep(t *testing.T) {
 	result, err := CronToOnCalendar("0 9-17/2 * * *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-* 09..17/2:00:00", result)
+	assert.Equal(t, []string{"*-*-* 09..17/2:00:00"}, result)
 }
 
 func TestCronToOnCalendarList(t *testing.T) {
 	result, err := CronToOnCalendar("0 1,3,5 * * *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-* 01,03,05:00:00", result)
+	assert.Equal(t, []string{"*-*-* 01,03,05:00:00"}, result)
 }
 
 func TestCronToOnCalendarMonthRange(t *testing.T) {
 	result, err := CronToOnCalendar("0 0 1 6-8 *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-06..08-01 00:00:00", result)
+	assert.Equal(t, []string{"*-06..08-01 00:00:00"}, result)
 }
 
 func TestCronToOnCalendarDOMRange(t *testing.T) {
 	result, err := CronToOnCalendar("0 0 1-15 * *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-01..15 00:00:00", result)
+	assert.Equal(t, []string{"*-*-01..15 00:00:00"}, result)
 }
 
 func TestCronToOnCalendarMinuteRange(t *testing.T) {
 	result, err := CronToOnCalendar("0-30/10 * * * *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-* *:00..30/10:00", result)
+	assert.Equal(t, []string{"*-*-* *:00..30/10:00"}, result)
 }
 
 func TestCronToOnCalendarDOW(t *testing.T) {
 	result, err := CronToOnCalendar("0 9 * * 1-5")
 	require.NoError(t, err)
-	assert.Equal(t, "Mon..Fri *-*-* 09:00:00", result)
+	assert.Equal(t, []string{"Mon..Fri *-*-* 09:00:00"}, result)
 }
 
 func TestCronToOnCalendarDOWStepAll(t *testing.T) {
 	result, err := CronToOnCalendar("0 9 * * */2")
 	require.NoError(t, err)
-	assert.Equal(t, "Sun,Tue,Thu,Sat *-*-* 09:00:00", result)
+	assert.Equal(t, []string{"Sun,Tue,Thu,Sat *-*-* 09:00:00"}, result)
 }
 
 func TestCronToOnCalendarDOWStepRange(t *testing.T) {
 	result, err := CronToOnCalendar("0 9 * * 1-5/2")
 	require.NoError(t, err)
-	assert.Equal(t, "Mon,Wed,Fri *-*-* 09:00:00", result)
+	assert.Equal(t, []string{"Mon,Wed,Fri *-*-* 09:00:00"}, result)
 }
 
 // TestCronToOnCalendarDOWStepFrom7 is a regression test for a bug where DOW
@@ -146,33 +146,33 @@ func TestCronToOnCalendarDOWStepFrom7(t *testing.T) {
 	// yields a single value. The result must include Sunday and not omit DOW.
 	result, err := CronToOnCalendar("0 9 * * 7/2")
 	require.NoError(t, err)
-	assert.Equal(t, "Sun *-*-* 09:00:00", result)
+	assert.Equal(t, []string{"Sun *-*-* 09:00:00"}, result)
 }
 
 func TestCronToOnCalendarDOWSundayRange01(t *testing.T) {
 	result, err := CronToOnCalendar("0 9 * * 0-1")
 	require.NoError(t, err)
-	assert.Equal(t, "Sun,Mon *-*-* 09:00:00", result)
+	assert.Equal(t, []string{"Sun,Mon *-*-* 09:00:00"}, result)
 }
 
 func TestCronToOnCalendarDOWSundayRange03(t *testing.T) {
 	result, err := CronToOnCalendar("0 9 * * 0-3")
 	require.NoError(t, err)
-	assert.Equal(t, "Sun,Mon,Tue,Wed *-*-* 09:00:00", result)
+	assert.Equal(t, []string{"Sun,Mon,Tue,Wed *-*-* 09:00:00"}, result)
 }
 
 func TestCronToOnCalendarDOWSundayRange06(t *testing.T) {
 	// 0-6 covers all 7 days, so DOW should be omitted.
 	result, err := CronToOnCalendar("0 9 * * 0-6")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-* 09:00:00", result)
+	assert.Equal(t, []string{"*-*-* 09:00:00"}, result)
 }
 
 func TestCronToOnCalendarDOWSundayRange07(t *testing.T) {
 	// 0-7 also covers all days (7 is Sunday in cron), so DOW should be omitted.
 	result, err := CronToOnCalendar("0 9 * * 0-7")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-* 09:00:00", result)
+	assert.Equal(t, []string{"*-*-* 09:00:00"}, result)
 }
 
 // TestCronToOnCalendarDOWListDedupes is a regression test for #465: "0,7"
@@ -181,13 +181,13 @@ func TestCronToOnCalendarDOWSundayRange07(t *testing.T) {
 func TestCronToOnCalendarDOWListDedupes(t *testing.T) {
 	result, err := CronToOnCalendar("0 9 * * 0,7")
 	require.NoError(t, err)
-	assert.Equal(t, "Sun *-*-* 09:00:00", result)
+	assert.Equal(t, []string{"Sun *-*-* 09:00:00"}, result)
 }
 
 func TestCronToOnCalendarDOWListMonWedFri(t *testing.T) {
 	result, err := CronToOnCalendar("0 9 * * 1,3,5")
 	require.NoError(t, err)
-	assert.Equal(t, "Mon,Wed,Fri *-*-* 09:00:00", result)
+	assert.Equal(t, []string{"Mon,Wed,Fri *-*-* 09:00:00"}, result)
 }
 
 // TestCronToOnCalendarDOWListAllDays covers a list whose elements union to
@@ -196,40 +196,107 @@ func TestCronToOnCalendarDOWListMonWedFri(t *testing.T) {
 func TestCronToOnCalendarDOWListAllDays(t *testing.T) {
 	result, err := CronToOnCalendar("0 9 * * 0-6,7")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-* 09:00:00", result)
+	assert.Equal(t, []string{"*-*-* 09:00:00"}, result)
 }
 
 func TestCronToOnCalendarDOWNonSundayRange(t *testing.T) {
 	// Non-zero-starting ranges should still use .. syntax.
 	result, err := CronToOnCalendar("0 9 * * 2-4")
 	require.NoError(t, err)
-	assert.Equal(t, "Tue..Thu *-*-* 09:00:00", result)
+	assert.Equal(t, []string{"Tue..Thu *-*-* 09:00:00"}, result)
 }
 
 func TestCronToOnCalendarMonthStep(t *testing.T) {
 	// Month is 1-indexed, so */3 should become 01/3, not 00/3.
 	result, err := CronToOnCalendar("0 0 1 */3 *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-01/3-01 00:00:00", result)
+	assert.Equal(t, []string{"*-01/3-01 00:00:00"}, result)
 }
 
 func TestCronToOnCalendarDOMStep(t *testing.T) {
 	// Day-of-month is 1-indexed, so */5 should become 01/5, not 00/5.
 	result, err := CronToOnCalendar("0 0 */5 * *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-01/5 00:00:00", result)
+	assert.Equal(t, []string{"*-*-01/5 00:00:00"}, result)
 }
 
 func TestCronToOnCalendarHourStep(t *testing.T) {
 	// Hour is 0-indexed, so */4 should become 00/4.
 	result, err := CronToOnCalendar("0 */4 * * *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-* 00/4:00:00", result)
+	assert.Equal(t, []string{"*-*-* 00/4:00:00"}, result)
 }
 
 func TestCronToOnCalendarMinuteStep(t *testing.T) {
 	// Minute is 0-indexed, so */15 should become 00/15.
 	result, err := CronToOnCalendar("*/15 * * * *")
 	require.NoError(t, err)
-	assert.Equal(t, "*-*-* *:00/15:00", result)
+	assert.Equal(t, []string{"*-*-* *:00/15:00"}, result)
+}
+
+// TestCronToOnCalendarDOMandDOW is a regression test for #522. Vixie cron
+// fires when DOM matches OR DOW matches when both are restricted; systemd's
+// OnCalendar combines fields with AND, so a single entry under-fires by ~85%
+// (only ~7 Monday-1st-of-month dates per year instead of ~60). Fan out into
+// two entries — one constrains DOM (DOW=*), one constrains DOW (DOM=*) —
+// because systemd unions multiple OnCalendar lines.
+func TestCronToOnCalendarDOMandDOW(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 1 * 1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"*-*-01 09:00:00",
+		"Mon *-*-* 09:00:00",
+	}, result)
+}
+
+// TestCronToOnCalendarDOMandDOWPreservesMonth confirms that the month
+// restriction is preserved on both split entries (only DOM/DOW are subject
+// to OR semantics; month is always ANDed in cron).
+func TestCronToOnCalendarDOMandDOWPreservesMonth(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 1 6 1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"*-06-01 09:00:00",
+		"Mon *-06-* 09:00:00",
+	}, result)
+}
+
+// TestCronToOnCalendarDOMandDOWRanges exercises the split with multi-value
+// DOM and DOW fields.
+func TestCronToOnCalendarDOMandDOWRanges(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 1,15 * 1-5")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"*-*-01,15 09:00:00",
+		"Mon..Fri *-*-* 09:00:00",
+	}, result)
+}
+
+// TestCronToOnCalendarDOMandDOWStep exercises a stepped DOM combined with a
+// restricted DOW.
+func TestCronToOnCalendarDOMandDOWStep(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 */10 * 1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"*-*-01/10 09:00:00",
+		"Mon *-*-* 09:00:00",
+	}, result)
+}
+
+// TestCronToOnCalendarDOMCoversAllNoSplit verifies that when DOM is
+// syntactically restricted but covers every day (1-31), the OR collapses to
+// "every day" and the result is a single DOW-restricted entry.
+func TestCronToOnCalendarDOMCoversAllNoSplit(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 1-31 * 1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Mon *-*-01..31 09:00:00"}, result)
+}
+
+// TestCronToOnCalendarDOWCoversAllNoSplit verifies the symmetric case where
+// DOW covers all 7 days. The OR collapses to "every day", so DOW is dropped
+// and only the DOM restriction remains in a single entry.
+func TestCronToOnCalendarDOWCoversAllNoSplit(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 1 * 0-6")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*-*-01 09:00:00"}, result)
 }

--- a/task/systemd.go
+++ b/task/systemd.go
@@ -82,7 +82,7 @@ func InstallScheduler(t Task) error {
 	// Otherwise a bad cron leaves a stale .service on disk while the previous
 	// timer keeps running, so the user sees their edit "saved" but the
 	// schedule never updates.
-	onCalendar, err := CronToOnCalendar(t.CronExpr)
+	onCalendars, err := CronToOnCalendar(t.CronExpr)
 	if err != nil {
 		return fmt.Errorf("failed to convert cron expression: %w", err)
 	}
@@ -114,16 +114,22 @@ func InstallScheduler(t Task) error {
 		return fmt.Errorf("failed to write service file: %w", err)
 	}
 
+	var onCalendarLines strings.Builder
+	for _, oc := range onCalendars {
+		onCalendarLines.WriteString("OnCalendar=")
+		onCalendarLines.WriteString(oc)
+		onCalendarLines.WriteString("\n")
+	}
+
 	timerContent := fmt.Sprintf(`[Unit]
 Description=Timer for Agent Factory task %s
 
 [Timer]
-OnCalendar=%s
-Persistent=true
+%sPersistent=true
 
 [Install]
 WantedBy=timers.target
-`, unitName, onCalendar)
+`, unitName, onCalendarLines.String())
 
 	timerPath := filepath.Join(dir, unitName+".timer")
 	if err := os.WriteFile(timerPath, []byte(timerContent), 0644); err != nil {


### PR DESCRIPTION
## Summary

Fixes #522. `task/cron.go::CronToOnCalendar` emitted a single OnCalendar string for every cron expression. Vixie cron applies day-of-month and day-of-week with **OR** semantics when both are restricted (fire on matching DOM **or** matching DOW), but systemd combines all fields in an OnCalendar entry with **AND**. So `0 9 1 * 1` (1st-of-month **or** Monday at 09:00) compiled to `Mon *-*-01 09:00:00` and only fired on a Monday that was also the 1st — about 7 dates/year instead of the ~60 the user expected. Silent under-fire, no error logged.

## Audit

| cron | meaning (Vixie) | old OnCalendar | semantics | fires/year |
| --- | --- | --- | --- | --- |
| `0 9 1 * 1` | 1st **OR** Monday @ 09:00 | `Mon *-*-01 09:00:00` | AND | ~7 |
| `0 9 1 6 1` | June 1st **OR** any June Monday @ 09:00 | `Mon *-06-01 09:00:00` | AND | 0–1 |
| `0 9 1 * *` | 1st of month @ 09:00 | `*-*-01 09:00:00` | correct | 12 |
| `0 9 * * 1` | Mondays @ 09:00 | `Mon *-*-* 09:00:00` | correct | ~52 |

The launchd generator already detected this case and errored out (`launchd_schedule.go:128`); only the systemd path silently misfired.

## Fix

`CronToOnCalendar` now returns `[]string`. When DOM and DOW are both effectively restricted, it fans out to **two** entries:

```
*-*-01 09:00:00          # DOM=1, DOW=*
Mon *-*-* 09:00:00       # DOM=*, DOW=Mon
```

`InstallScheduler` writes one `OnCalendar=` line per entry. systemd unions multiple `OnCalendar=` lines in a single `[Timer]` block, which reproduces cron's OR semantics. The month restriction is preserved on **both** branches because only DOM/DOW participate in the OR — `0 9 1 6 1` becomes `*-06-01 09:00:00` + `Mon *-06-* 09:00:00`.

When one side is an effective wildcard (`DOM=1-31` or `DOW=0-6` / `*/1`), the OR collapses to "every day" and only a single entry is emitted — matching the existing `convertDOW` empty-string convention and the launchd generator's coverage check.

## Tests

- `TestCronToOnCalendarDOMandDOW` — `0 9 1 * 1` → 2 entries (DOM-only + DOW-only)
- `TestCronToOnCalendarDOMandDOWPreservesMonth` — month restriction kept on both branches
- `TestCronToOnCalendarDOMandDOWRanges` — multi-value DOM + range DOW
- `TestCronToOnCalendarDOMandDOWStep` — stepped DOM + restricted DOW
- `TestCronToOnCalendarDOMCoversAllNoSplit` — `1-31` DOM collapses to single entry
- `TestCronToOnCalendarDOWCoversAllNoSplit` — `0-6` DOW collapses to single entry
- All existing tests (DOW-only, DOM-only, wildcard) re-pass against the new `[]string` API

## Test plan

- [x] `gofmt -l .` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go build ./...` succeeds
- [x] `go test ./...` all packages pass

Closes #522.

Co-Authored-By: Captain Claude <noreply@anthropic.com>