### PR TITLE
fix(api): kill tmux session in ghost cleanup regardless of worktree state (#516)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,58 @@ var (
 	killSessionViaDaemon   = daemon.KillSession
 	sendPromptViaDaemon    = daemon.SendPrompt
 )
+
+// ghostKillTmuxByName issues a tmux kill-session for a persisted sanitized
+// name. Package-level so tests can stub it without invoking real tmux. The
+// af_ prefix check refuses to act on names the daemon would never write, so a
+// corrupted store can't make us kill an unrelated tmux session.
+var ghostKillTmuxByName = func(sanitizedName string) error {
+	if !strings.HasPrefix(sanitizedName, tmux.TmuxPrefix) {
+		return fmt.Errorf("refusing to kill tmux session without %q prefix: %q", tmux.TmuxPrefix, sanitizedName)
+	}
+	return tmux.NewTmuxSessionFromSanitizedName(sanitizedName, "").Close()
+}
+
+// ghostCleanupWorktree performs best-effort worktree teardown for a ghost
+// session whose live restore failed. Package-level so tests can stub it.
+var ghostCleanupWorktree = func(data *session.InstanceData, title string) {
+	if data.Worktree.RepoPath == "" || data.Worktree.WorktreePath == "" || data.Worktree.ExternalWorktree {
+		return
+	}
+	branchCreatedByUs := true
+	if data.Worktree.BranchCreatedByUs != nil {
+		branchCreatedByUs = *data.Worktree.BranchCreatedByUs
+	}
+	gw, gwErr := git.NewGitWorktreeFromStorage(
+		data.Worktree.RepoPath,
+		data.Worktree.WorktreePath,
+		data.Worktree.SessionName,
+		data.Worktree.BranchName,
+		data.Worktree.BaseCommitSHA,
+		data.Worktree.ExternalWorktree,
+		branchCreatedByUs,
+	)
+	if gwErr != nil {
+		log.WarningLog.Printf("ghost session %q: failed to load worktree for cleanup: %v", title, gwErr)
+		return
+	}
+	if cleanupErr := gw.Cleanup(); cleanupErr != nil {
+		log.WarningLog.Printf("ghost session %q: worktree cleanup failed: %v", title, cleanupErr)
+	}
+}
+
+// ghostCleanup runs best-effort teardown of a ghost session's external
+// resources. Tmux teardown is independent of worktree state (#516): a ghost
+// record can have an empty worktree path while a tmux session with the
+// persisted name is still running, so the two branches share no condition.
+func ghostCleanup(data *session.InstanceData, title string) {
+	ghostCleanupWorktree(data, title)
+	if data.TmuxName != "" {
+		if killErr := ghostKillTmuxByName(data.TmuxName); killErr != nil {
+			log.WarningLog.Printf("ghost session %q: tmux cleanup failed: %v", title, killErr)
+		}
+	}
+}
 
 var sessionsListCmd = &cobra.Command{
 	Use:   "list",
@@ -177,26 +230,7 @@ func killSessionDirect(title string) error {
 			return err
 		}
 
-		if data.Worktree.RepoPath != "" && data.Worktree.WorktreePath != "" && !data.Worktree.ExternalWorktree {
-			branchCreatedByUs := true
-			if data.Worktree.BranchCreatedByUs != nil {
-				branchCreatedByUs = *data.Worktree.BranchCreatedByUs
-			}
-			gw, gwErr := git.NewGitWorktreeFromStorage(
-				data.Worktree.RepoPath,
-				data.Worktree.WorktreePath,
-				data.Worktree.SessionName,
-				data.Worktree.BranchName,
-				data.Worktree.BaseCommitSHA,
-				data.Worktree.ExternalWorktree,
-				branchCreatedByUs,
-			)
-			if gwErr != nil {
-				log.WarningLog.Printf("ghost session %q: failed to load worktree for cleanup: %v", title, gwErr)
-			} else if cleanupErr := gw.Cleanup(); cleanupErr != nil {
-				log.WarningLog.Printf("ghost session %q: worktree cleanup failed: %v", title, cleanupErr)
-			}
-		}
+		ghostCleanup(data, title)
 
 		state := config.LoadState()
 		storage, storageErr := session.NewStorage(state, ghostRepoID)

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -297,3 +297,108 @@ func stubKillSessionDirect() func() {
 	}
 	return func() { killSessionViaDaemon = prev }
 }
+
+// stubGhostCleanup replaces both ghostCleanupWorktree and ghostKillTmuxByName
+// with recorders so tests can assert which teardown branches fired without
+// invoking real git / real tmux.
+func stubGhostCleanup() (wtCalls *[]string, tmuxCalls *[]string, restore func()) {
+	var wt, tm []string
+	prevWT := ghostCleanupWorktree
+	prevTmux := ghostKillTmuxByName
+	ghostCleanupWorktree = func(data *session.InstanceData, title string) {
+		if data.Worktree.RepoPath == "" || data.Worktree.WorktreePath == "" || data.Worktree.ExternalWorktree {
+			return
+		}
+		wt = append(wt, title)
+	}
+	ghostKillTmuxByName = func(name string) error {
+		tm = append(tm, name)
+		return nil
+	}
+	return &wt, &tm, func() {
+		ghostCleanupWorktree = prevWT
+		ghostKillTmuxByName = prevTmux
+	}
+}
+
+// TestGhostCleanup_TmuxOrphan is the regression test for issue #516: when the
+// persisted worktree path is empty but TmuxName is populated, the ghost
+// cleanup path must still attempt to kill the tmux session. Previously, tmux
+// teardown was never attempted from the ghost path, leaving an orphan that
+// blocked recreation under the same title with "session already exists".
+func TestGhostCleanup_TmuxOrphan(t *testing.T) {
+	wtCalls, tmCalls, restore := stubGhostCleanup()
+	defer restore()
+
+	data := &session.InstanceData{
+		Title:    "ghost",
+		Program:  "claude",
+		TmuxName: "af_ghost",
+		// Worktree fields intentionally empty.
+	}
+	ghostCleanup(data, "ghost")
+
+	if len(*wtCalls) != 0 {
+		t.Fatalf("expected worktree cleanup skipped, got: %v", *wtCalls)
+	}
+	if len(*tmCalls) != 1 || (*tmCalls)[0] != "af_ghost" {
+		t.Fatalf("expected tmux kill for af_ghost, got: %v", *tmCalls)
+	}
+}
+
+// TestGhostCleanup_BothPopulated verifies the fix did not regress the
+// worktree-cleanup branch: with both fields populated, both teardowns fire.
+func TestGhostCleanup_BothPopulated(t *testing.T) {
+	wtCalls, tmCalls, restore := stubGhostCleanup()
+	defer restore()
+
+	data := &session.InstanceData{
+		Title:    "ghost",
+		Program:  "claude",
+		TmuxName: "af_ghost",
+		Worktree: session.GitWorktreeData{
+			RepoPath:     "/tmp/repo",
+			WorktreePath: "/tmp/wt",
+			SessionName:  "ghost",
+			BranchName:   "af/ghost",
+		},
+	}
+	ghostCleanup(data, "ghost")
+
+	if len(*wtCalls) != 1 || (*wtCalls)[0] != "ghost" {
+		t.Fatalf("expected worktree cleanup, got: %v", *wtCalls)
+	}
+	if len(*tmCalls) != 1 || (*tmCalls)[0] != "af_ghost" {
+		t.Fatalf("expected tmux kill for af_ghost, got: %v", *tmCalls)
+	}
+}
+
+// TestGhostCleanup_AllEmpty verifies that with no TmuxName and no worktree
+// paths, both teardown branches are skipped.
+func TestGhostCleanup_AllEmpty(t *testing.T) {
+	wtCalls, tmCalls, restore := stubGhostCleanup()
+	defer restore()
+
+	data := &session.InstanceData{
+		Title:   "ghost",
+		Program: "claude",
+	}
+	ghostCleanup(data, "ghost")
+
+	if len(*wtCalls) != 0 {
+		t.Fatalf("expected no worktree cleanup, got: %v", *wtCalls)
+	}
+	if len(*tmCalls) != 0 {
+		t.Fatalf("expected no tmux kill, got: %v", *tmCalls)
+	}
+}
+
+// TestGhostKillTmuxByName_RefusesNonAfPrefix guards the validation in the
+// real ghostKillTmuxByName: a sanitized name without the af_ prefix would
+// only appear via storage corruption, and silently killing whatever tmux
+// session it names could destroy unrelated work.
+func TestGhostKillTmuxByName_RefusesNonAfPrefix(t *testing.T) {
+	if err := ghostKillTmuxByName("not-ours"); err == nil {
+		t.Fatalf("expected refusal for non-af prefix, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- In `killSessionDirect`'s ghost path (`FromInstanceData` failed), tmux teardown was never attempted — only worktree cleanup ran, and it was further gated on a non-empty worktree path. A persisted record with an empty worktree but populated `TmuxName` left the tmux session orphaned and blocked recreation under the same title with "session already exists" (#516).
- Extract `ghostCleanup` so the two teardown branches run independently: tmux teardown fires whenever `TmuxName` is set; worktree teardown stays gated on a non-empty worktree path (still correct — nothing to clean if no path was recorded).
- The tmux kill is guarded by the `af_` prefix so a corrupted store can't trick us into killing an unrelated tmux session.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all green, including new `TestGhostCleanup_*` cases
- [x] `gofmt -l .` — no output
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] Unit tests cover the three branch combinations: tmux-only ghost (the #516 case), both populated (regression guard for the worktree branch), and all-empty (skip both).
- [x] `TestGhostKillTmuxByName_RefusesNonAfPrefix` guards the prefix validation against corrupted storage.

Closes #516

Co-Authored-By: Captain Claude <noreply@anthropic.com>