### PR TITLE
fix(session): recognize known agents in path-reconcat heuristic (#513)

### DIFF
--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // codexSystemPrompt is the system prompt for Codex sessions, which don't support plugins.
@@ -110,6 +111,20 @@ func getBaseCommand(program string) string {
 	parts := splitShell(program)
 	if len(parts) == 0 {
 		return ""
+	}
+	// If any token's basename matches a known agent (tmux.SupportedPrograms),
+	// prefer it. Handles unquoted paths whose directories contain literal
+	// " - " (issue #513): splitShell yields ["/home/u/my", "-", "proj/claude"]
+	// and the simple "join non-flag tokens" heuristic below stops at "-",
+	// landing on "my". Left-to-right wins so the leading executable still
+	// dominates when a flag value happens to point at another known agent.
+	for _, p := range parts {
+		base := strings.ToLower(filepath.Base(p))
+		for _, supported := range tmux.SupportedPrograms {
+			if base == supported {
+				return supported
+			}
+		}
 	}
 	cmd := parts[0]
 	// If the first token looks like an unquoted path (absolute or relative),

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -184,6 +184,14 @@ func TestGetBaseCommand(t *testing.T) {
 		{"'/home/my user/claude' --foo", "claude"},
 		// Backslash-escaped space in an unquoted path.
 		{"/home/me\\ name/claude --foo", "claude"},
+		// Issue #513: unquoted path whose directory contains literal " - ".
+		// splitShell produces ["/home/user/my", "-", "project/claude"] and
+		// the simple reconcat heuristic stops at "-"; the SupportedPrograms
+		// basename match recovers the right answer.
+		{"/home/user/my - project/claude", "claude"},
+		{"/home/user/my - project/claude --foo", "claude"},
+		{"/home/user/my - project/codex", "codex"},
+		{"/home/user/a - b - c/aider --model x", "aider"},
 	}
 	for _, tt := range tests {
 		got := getBaseCommand(tt.input)


### PR DESCRIPTION
## Summary
- `getBaseCommand` mis-resolved unquoted paths containing literal " - " (e.g. `/home/user/my - project/claude` → `"my"`). `splitShell` produces three tokens (`"/home/user/my"`, `"-"`, `"project/claude"`) and the path-reconcat heuristic from #481 stops at the first `-`-prefixed token.
- Scan all tokens left-to-right for a basename matching `tmux.SupportedPrograms`; return the canonical name when found. Falls back to the existing reconcat for unknown executables. Left-to-right ordering keeps the leading executable dominant when a flag value happens to point at another agent (e.g. `claude --plugin-dir /home/x/codex` → `"claude"`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `gofmt -l .`
- [x] New `TestGetBaseCommand` cases:
  - `/home/user/my - project/claude` → `claude`
  - `/home/user/my - project/claude --foo` → `claude`
  - `/home/user/my - project/codex` → `codex`
  - `/home/user/a - b - c/aider --model x` → `aider`
- [x] Existing path-without-dash cases (`/home/my user/claude`, `/home/user/claude-projects/aider`, `/home/claude-user/bin/mytool`, `claude-code`, quoted variants) still pass.

Closes #513.