### PR TITLE
fix(task): normalize */N to wildcard when N covers the full range (#523)

### DIFF
--- a/task/launchd_schedule.go
+++ b/task/launchd_schedule.go
@@ -25,13 +25,38 @@ func cronToLaunchdScheduleXML(cronExpr string) (string, error) {
 	return "    <key>StartCalendarInterval</key>\n" + calendarXML, nil
 }
 
+// isEveryMinuteCron reports whether cronExpr is semantically "every minute" —
+// either a literal "* * * * *" or a form whose fields all cover every legal
+// value (e.g. "*/1 */1 * * *"). Matching the equivalent forms here lets us
+// emit StartInterval=60 instead of a single empty StartCalendarInterval dict.
 func isEveryMinuteCron(cronExpr string) bool {
 	fields := strings.Fields(cronExpr)
 	if len(fields) != 5 {
 		return false
 	}
-	for _, field := range fields {
-		if field != "*" {
+	ranges := []struct{ min, max int }{
+		{0, 59}, // minute
+		{0, 23}, // hour
+		{1, 31}, // day-of-month
+		{1, 12}, // month
+		{0, 7},  // day-of-week (0 and 7 both mean Sunday)
+	}
+	for i, field := range fields {
+		if field == "*" {
+			continue
+		}
+		vals, err := expandCronField(field, ranges[i].min, ranges[i].max)
+		if err != nil {
+			return false
+		}
+		if i == 4 {
+			vals = normalizeDOWValues(vals)
+			if len(vals) < 7 {
+				return false
+			}
+			continue
+		}
+		if len(vals) < (ranges[i].max - ranges[i].min + 1) {
 			return false
 		}
 	}
@@ -74,6 +99,15 @@ func cronToCalendarIntervalXML(cronExpr string) (string, error) {
 		// Normalize weekday 7 -> 0 (both mean Sunday in cron; launchd uses 0).
 		if def.key == "Weekday" && vals != nil {
 			vals = normalizeDOWValues(vals)
+		}
+		// Collapse fields that syntactically cover every legal value
+		// (e.g. "*/1" for minute expands to all 60 values) back to a
+		// wildcard. Without this, the cartesian product blows past
+		// maxCalendarIntervals and we reject schedules that are
+		// semantically identical to "* * * * *". DOM/DOW have their
+		// own collapse below for OR-semantics reasons.
+		if def.key != "Day" && def.key != "Weekday" && vals != nil && len(vals) >= (def.max-def.min+1) {
+			vals = nil
 		}
 		expanded = append(expanded, expandedField{key: def.key, vals: vals})
 	}

--- a/task/launchd_test.go
+++ b/task/launchd_test.go
@@ -119,6 +119,53 @@ func TestCronToCalendarIntervalXML_AllWildcards(t *testing.T) {
 	assert.NotContains(t, xml, "<key>Hour</key>")
 }
 
+// TestCronToLaunchdScheduleXML_StepOneCoversAll verifies that "*/N" forms
+// that cover every legal value for their field are normalized back to a
+// wildcard, so semantically-equivalent expressions of "every minute" do
+// not trip the maxCalendarIntervals guard.
+func TestCronToLaunchdScheduleXML_StepOneCoversAll(t *testing.T) {
+	cases := []string{
+		"*/1 */1 * * *", // every minute via */1 on minute and hour
+		"*/1 * * * *",   // every minute via */1 on minute only
+		"* */1 * * *",   // wildcard hour via */1
+	}
+	for _, expr := range cases {
+		expr := expr
+		t.Run(expr, func(t *testing.T) {
+			xml, err := cronToLaunchdScheduleXML(expr)
+			require.NoError(t, err)
+			assert.Contains(t, xml, "<key>StartInterval</key>")
+			assert.Contains(t, xml, "<integer>60</integer>")
+			assert.NotContains(t, xml, "<key>StartCalendarInterval</key>")
+		})
+	}
+}
+
+// TestCronToCalendarIntervalXML_StepStillRestrictive verifies that step
+// expressions that do NOT cover every value (e.g. */2 on minute) remain
+// restrictive and emit the expected number of dicts.
+func TestCronToCalendarIntervalXML_StepStillRestrictive(t *testing.T) {
+	xml, err := cronToCalendarIntervalXML("*/2 * * * *")
+	require.NoError(t, err)
+
+	assert.Equal(t, 30, countDicts(xml), "expected 30 dicts for every-2-minutes, got:\n%s", xml)
+	assert.Contains(t, xml, "<key>Minute</key>")
+	assert.NotContains(t, xml, "<key>Hour</key>")
+}
+
+// TestCronToCalendarIntervalXML_MonthStepCoversAll verifies the symmetric
+// collapse for the month field — "*/1" on month covers all 12 values and
+// must drop the Month key from the emitted dict.
+func TestCronToCalendarIntervalXML_MonthStepCoversAll(t *testing.T) {
+	xml, err := cronToCalendarIntervalXML("0 9 15 */1 *")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countDicts(xml), "expected a single dict, got:\n%s", xml)
+	assert.NotContains(t, xml, "<key>Month</key>")
+	assert.Contains(t, xml, "<key>Day</key>")
+	assert.Contains(t, xml, "<integer>15</integer>")
+}
+
 func TestCronToLaunchdScheduleXML_AllWildcardsUsesStartInterval(t *testing.T) {
 	xml, err := cronToLaunchdScheduleXML("* * * * *")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- `*/1 */1 * * *` was rejected with `expands to too many intervals (1440 > 512)` even though it is semantically identical to `* * * * *`. The covers-all collapse already existed for DOM/DOW but was missing for minute, hour, and month — `*/1` on minute expanded to 60 values and on hour to 24, blowing the cartesian-product cap.
- Collapse any expanded field whose values cover its full legal range back to wildcard, per field. DOM/DOW keep their separate OR-semantics collapse below.
- Extend `isEveryMinuteCron` to recognize wildcard-equivalent forms (e.g. `*/1 */1 * * *`, `* */1 * * *`) so they route to `StartInterval=60` like the literal `* * * * *` instead of emitting an empty `StartCalendarInterval` dict.

## Test plan
- [x] `*/1 */1 * * *` → `StartInterval=60`
- [x] `*/1 * * * *` and `* */1 * * *` → `StartInterval=60`
- [x] `*/2 * * * *` stays restrictive (30 dicts)
- [x] `0 9 15 */1 *` collapses Month, keeps Day
- [x] Pre-existing DOM/DOW collapse + rejection cases unchanged
- [x] `go build ./...`, `go test ./...`, `golangci-lint run --timeout=3m --fast`, `gofmt -l .` all clean

Closes #523

Co-Authored-By: Captain Claude <noreply@anthropic.com>