### PR TITLE
fix(session): guard HookBackend.Kill delete_cmd on remoteMeta (#518)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -168,17 +168,28 @@ func extractJSON(output string) string {
 func (b *HookBackend) Kill(i *Instance) error {
 	slug := hookNameForInstance(i)
 
+	// Snapshot whether a remote session was ever allocated before clearing
+	// state. If Start never ran successfully there is nothing for delete_cmd
+	// to clean up — invoking it would surface as a confusing failure against
+	// a slug the user-provided script has never heard of. Mirrors
+	// LocalBackend.Kill's tmuxSession/gitWorktree guards.
+	//
 	// Mark the instance as stopped BEFORE any resource cleanup so that the
 	// instance is in a consistent state even if delete_cmd fails. Otherwise
 	// the PTY could be closed while started=true, leaving the session
 	// appearing running but unusable (empty preview, broken attach).
-	// This mirrors LocalBackend.Kill's behavior.
 	i.mu.Lock()
+	hadRemote := i.remoteMeta != nil
 	i.started = false
 	i.remoteMeta = nil
 	i.mu.Unlock()
 
 	b.closePTY(i.Title)
+
+	if !hadRemote {
+		log.WarningLog.Printf("kill %q: skipping delete_cmd, no remote session allocated", i.Title)
+		return nil
+	}
 
 	args := []string{"--name", slug, "--json"}
 	out, err := exec.Command(b.Hooks.DeleteCmd, args...).CombinedOutput()

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -303,6 +303,42 @@ func TestHookBackendKill(t *testing.T) {
 	assert.Nil(t, i.remoteMeta)
 }
 
+// TestHookBackendKillUnallocatedSkipsDeleteCmd verifies that Kill on an
+// instance that was never successfully Start'd (no remoteMeta) does not
+// invoke delete_cmd. Otherwise we'd ask the user-provided cleanup script
+// to delete a slug it never saw — surfacing as a spurious failure on a
+// kill that had nothing to do. See issue #518.
+func TestHookBackendKillUnallocatedSkipsDeleteCmd(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "delete-ran")
+	// delete_cmd touches a sentinel file iff it runs; the test fails the
+	// kill guard by detecting the sentinel afterward.
+	deleteCmd := writeScript(t, dir, "delete.sh", `touch `+sentinel+`; echo '{"deleted": true}'`)
+
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{
+			DeleteCmd: deleteCmd,
+		},
+	}
+	i := &Instance{
+		Title:   "never-started",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	// Sanity: no Start call, so remoteMeta is nil.
+	require.Nil(t, i.remoteMeta)
+
+	err := b.Kill(i)
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(sentinel)
+	assert.True(t, os.IsNotExist(statErr),
+		"delete_cmd should not run when no remote session was allocated (sentinel exists: %v)", statErr)
+	assert.False(t, i.Started())
+	assert.Nil(t, i.remoteMeta)
+}
+
 func TestHookBackendPreview(t *testing.T) {
 	b := makeHooks(t)
 	i := &Instance{


### PR DESCRIPTION
## Summary
- `HookBackend.Kill` now skips `delete_cmd` when `remoteMeta` is nil, mirroring `LocalBackend.Kill`'s `tmuxSession`/`gitWorktree` guards. Previously Kill invoked `delete_cmd` unconditionally, so killing an instance whose `Start` never succeeded (or that never ran) failed against a slug the user-provided script never allocated.
- Logs a `WarningLog` line with the instance title when the skip path fires, so users can still tell the kill ran with nothing to clean up.
- New test `TestHookBackendKillUnallocatedSkipsDeleteCmd` uses a sentinel-file `delete.sh` to assert the script never executes on a never-started instance. Existing `TestHookBackendKill` and `TestHookBackendKillDeleteCmdFails` continue to cover the allocated path.

Closes #518.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)
- [x] `go test ./session/...` (all green, including new test)
- [x] `go test ./...` (only unrelated flaky `TestScheduledTaskRunnerUsesDaemonAndAllocatesRerunTitle` blipped — passes on retry; touches daemon socket, not session/backend_hook.go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)