### PR TITLE
fix(task): reject empty prompt at CLI and TUI form (#517)

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -82,6 +83,13 @@ var tasksAddCmd = &cobra.Command{
 		repo, err := resolveRepo()
 		if err != nil {
 			return jsonError(fmt.Errorf("--repo is required: %w", err))
+		}
+
+		// MarkFlagRequired only enforces presence, so --prompt "" or
+		// whitespace-only values slip past Cobra and create tasks that
+		// no-op when triggered (#517).
+		if strings.TrimSpace(taskAddPromptFlag) == "" {
+			return jsonError(errors.New("prompt must be non-empty"))
 		}
 
 		if err := task.ValidateCronExpr(taskAddCronFlag); err != nil {

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -534,4 +535,34 @@ func TestTasksAdd_RollbackRemoveSchedulerAlsoFails(t *testing.T) {
 	tasks, err := task.LoadTasks()
 	require.NoError(t, err)
 	assert.Empty(t, tasks, "removeTask must still run even when scheduler rollback fails")
+}
+
+// TestTasksAdd_RejectsEmptyPrompt is the regression guard for #517: Cobra's
+// MarkFlagRequired only checks flag presence, so --prompt "" (or
+// whitespace-only) used to slip through and create a task that no-ops when
+// triggered. tasksAddCmd must reject the value before any scheduler work runs.
+func TestTasksAdd_RejectsEmptyPrompt(t *testing.T) {
+	for _, prompt := range []string{"", "   ", "\t\n"} {
+		t.Run(fmt.Sprintf("prompt=%q", prompt), func(t *testing.T) {
+			useTempConfig(t)
+			resetAddFlags(t)
+			calls := stubSchedulers(t)
+			setupAddRepo(t)
+
+			taskAddNameFlag = "blank"
+			taskAddPromptFlag = prompt
+			taskAddCronFlag = "0 9 * * *"
+			taskAddProgramFlag = "claude"
+
+			err := tasksAddCmd.RunE(tasksAddCmd, nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "prompt must be non-empty")
+
+			assert.Empty(t, calls.installed, "scheduler install must not run when prompt fails validation")
+
+			tasks, err := task.LoadTasks()
+			require.NoError(t, err)
+			assert.Empty(t, tasks, "no task record must be persisted when prompt fails validation")
+		})
+	}
 }

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -351,6 +351,10 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 					s.editError = "name is required"
 					return true
 				}
+				if strings.TrimSpace(s.editPrompt.Value()) == "" {
+					s.editError = "prompt must be non-empty"
+					return true
+				}
 				if err := task.ValidateCronExpr(s.editCron.Value()); err != nil {
 					s.editError = fmt.Sprintf("invalid cron: %v", err)
 					return true
@@ -361,6 +365,10 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 			} else {
 				if s.editName.Value() == "" {
 					s.editError = "name is required"
+					return true
+				}
+				if strings.TrimSpace(s.editPrompt.Value()) == "" {
+					s.editError = "prompt must be non-empty"
 					return true
 				}
 				if err := task.ValidateCronExpr(s.editCron.Value()); err != nil {

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -84,18 +84,53 @@ func TestTaskPaneNormalModeAllowsQuitKeysToPropagate(t *testing.T) {
 	assert.False(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlC}))
 }
 
-// fillCreateForm types a name and cron into the create form so submitting via
-// the Save button doesn't trip name/cron validation. Leaves focus on index 0
-// (Name) so callers can walk to whichever field they want to drive next.
+// fillCreateForm types a name, prompt, and cron into the create form so
+// submitting via the Save button doesn't trip validation. Leaves focus on
+// index 0 (Name) so callers can walk to whichever field they want to drive
+// next.
 func fillCreateForm(t *testing.T, tp *TaskPane, name string) {
 	t.Helper()
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(name)})
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do something")})
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> cron
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
 	// Walk back to name (index 0) so callers can navigate forward consistently.
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
+}
+
+// TestTaskPaneCreateModeRejectsEmptyPrompt is the regression guard for #517:
+// submitting the create form with no prompt (or whitespace-only) must surface
+// an inline validation error instead of marking a pending create with a blank
+// prompt that no-ops when the scheduler fires.
+func TestTaskPaneCreateModeRejectsEmptyPrompt(t *testing.T) {
+	for _, prompt := range []string{"", "   "} {
+		t.Run("prompt="+prompt, func(t *testing.T) {
+			tp := NewTaskPane()
+			tp.EnterCreateMode("/tmp/repo")
+
+			// Fill name, leave prompt empty/whitespace, fill cron.
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("daily")})
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+			if prompt != "" {
+				tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(prompt)})
+			}
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> cron
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
+
+			// Walk to Save and submit.
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> path
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> program
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> save
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+			assert.False(t, tp.HasPendingCreate(), "empty prompt must not produce a pending create")
+			assert.True(t, tp.IsCreating(), "form must stay open so user can fix the error")
+			assert.Equal(t, "prompt must be non-empty", tp.editError,
+				"inline validation error must surface to the user")
+		})
+	}
 }
 
 // TestTaskPaneCreateModeSelectorDefaultsToConfigDefault verifies that creating


### PR DESCRIPTION
## Summary
- `af tasks add --prompt ""` and the TUI task form both accepted empty/whitespace prompts because Cobra's `MarkFlagRequired` only checks presence, not value emptiness. The resulting task no-ops when the scheduler fires.
- `tasksAddCmd` (api/tasks.go) now rejects empty/whitespace prompts before any scheduler work runs.
- The TUI create/edit form (ui/task_pane.go) shows an inline `prompt must be non-empty` error and keeps the form open instead of saving a blank task.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go test ./api/... ./ui/...` green, including new regression tests:
  - `TestTasksAdd_RejectsEmptyPrompt` (empty, spaces, tab/newline)
  - `TestTaskPaneCreateModeRejectsEmptyPrompt` (empty and whitespace-only)

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)