### PR TITLE
docs(skill): clarify af-create session output contract (#541)

### DIFF
--- a/session/plugin.go
+++ b/session/plugin.go
@@ -46,7 +46,18 @@ var pluginCommands = map[string]string{
 		"Parse the session name (first argument) and optional initial prompt (remaining arguments), " +
 		"then run `af sessions create --name <name> --prompt <prompt>`. " +
 		"If no prompt is given, omit the --prompt flag. " +
-		"The name should be a short kebab-case identifier the user will recognize in the session list.\n",
+		"The name should be a short kebab-case identifier the user will recognize in the session list.\n" +
+		"\n" +
+		"## Output contract\n" +
+		"\n" +
+		"The initial prompt is the entire contract — the spawned session inherits no context from this conversation. " +
+		"State everything it needs, including the expected output mode. Common shapes:\n" +
+		"\n" +
+		"- \"Open a PR titled X, link it back here, do not merge — the parent will verify and merge.\"\n" +
+		"- \"Produce a report in tmp_docs/<name>.md and exit. Do NOT write code or open a PR.\"\n" +
+		"- \"Diagnose only — stop after the audit summary, no implementation.\"\n" +
+		"\n" +
+		"If the user's instruction is short or ambiguous (e.g. \"spawn an agent to audit X\"), confirm the desired output shape with them before spawning — a wrong guess surfaces later as a \"did you do it or did the af session?\" round-trip.\n",
 
 	"af-kill.md": "---\n" +
 		"allowed-tools: Bash(af sessions kill:*)\n" +


### PR DESCRIPTION
## Summary

- Add an "Output contract" section to the `af-create` skill text in `session/plugin.go` (the embedded source of truth for `plugin/commands/af-create.md`, which is generated at runtime by `ensurePluginDir`).
- Tells the dispatching agent that the initial prompt is the entire contract — the spawned session inherits no parent context.
- Names the three common output modes (open-a-PR, report-and-exit, diagnose-only) so dispatchers pick one explicitly instead of leaving the spawned session to guess.
- Tells the dispatcher to confirm the output shape with the user when the request is short or ambiguous, before spawning.

Note: the issue framed this as editing `plugin/commands/af-create.md` directly, but that path is a runtime artifact written from the `pluginCommands` map in `session/plugin.go`. Modifying the Go string is the only way to change the skill content; the file on disk regenerates on the next session launch.

Closes #541

## Test Plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` passes
- [x] `go test ./session/...` passes (existing `TestEnsurePluginDir_*` cover the write/prune path; no content assertions to update)
- [x] `golangci-lint run --timeout=3m --fast ./session/...` clean
- [x] Rendered the resulting `af-create.md` content via AST walk — the new "Output contract" section is 9 lines, formats as valid markdown, bullet quoting survives Go-string escaping intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude <noreply@anthropic.com>