### PR TITLE
fix(ui): strip ANSI before truncating ErrBox messages (#525)

### DIFF
--- a/ui/err.go
+++ b/ui/err.go
@@ -1,11 +1,18 @@
 package ui
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-runewidth"
 )
+
+// ansiEscapeRegex matches CSI escape sequences (e.g. SGR colors) so they can
+// be stripped before width-based truncation. Truncating a string that still
+// contains escape sequences risks cutting one mid-byte, leaking visible
+// garbage like "[31m" into the rendered output (issue #525).
+var ansiEscapeRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
 type ErrBox struct {
 	height, width int
@@ -41,6 +48,10 @@ func (e *ErrBox) String() string {
 	var err string
 	if e.err != nil {
 		err = e.err.Error()
+		// Agent pane output can reach us via wrapped errors (see #502) and
+		// carry ANSI escape sequences. Strip them so width math and the
+		// final Truncate operate on plain text only.
+		err = ansiEscapeRegex.ReplaceAllString(err, "")
 		lines := strings.Split(err, "\n")
 		err = strings.Join(lines, "//")
 		if runewidth.StringWidth(err) > e.width {

--- a/ui/err_test.go
+++ b/ui/err_test.go
@@ -55,6 +55,47 @@ func itoa(n int) string {
 	return string(buf[i:])
 }
 
+// TestErrBoxStripsANSIBeforeTruncating is a regression test for issue #525.
+// When an error string carries embedded ANSI escape sequences (e.g. from an
+// agent's pane output reaching ErrBox via #502), runewidth.Truncate would
+// cut sequences mid-byte and leak visible garbage like "[31m". Stripping
+// ANSI before truncation keeps the rendered text clean.
+func TestErrBoxStripsANSIBeforeTruncating(t *testing.T) {
+	e := NewErrBox()
+	e.SetSize(20, 1)
+	// Red SGR, payload, reset, then filler beyond the 20-cell width.
+	e.SetError(errors.New("\x1b[31merror in red\x1b[0m " + strings.Repeat("x", 200)))
+
+	out := e.String()
+	// The raw ESC byte must not appear anywhere in the input portion — only
+	// in lipgloss's own styling wrapping the result. Easier check: the
+	// literal "[31m" and "[0m" payloads must not survive into the output.
+	if strings.Contains(out, "[31m") {
+		t.Errorf("output leaked partial ANSI input sequence [31m: %q", out)
+	}
+	if strings.Contains(out, "[0m ") {
+		t.Errorf("output leaked partial ANSI input sequence [0m: %q", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if got := runewidth.StringWidth(stripANSI(line)); got > 20 {
+			t.Errorf("rendered line width %d exceeds container width 20 (line=%q)", got, line)
+		}
+	}
+}
+
+// TestErrBoxWithoutANSIUnchanged ensures the strip pass is a no-op for
+// plain-text errors (no spurious changes to existing rendering).
+func TestErrBoxWithoutANSIUnchanged(t *testing.T) {
+	e := NewErrBox()
+	e.SetSize(500, 1)
+	e.SetError(errors.New("plain error message"))
+
+	out := e.String()
+	if !strings.Contains(stripANSI(out), "plain error message") {
+		t.Errorf("expected plain message to render unchanged, got %q", out)
+	}
+}
+
 // stripANSI removes ANSI escape sequences (CSI) so width measurements
 // reflect only visible runes.
 func stripANSI(s string) string {


### PR DESCRIPTION
## Summary
- `ui/err.go` `ErrBox.String()` previously called `runewidth.Truncate` on the raw error string. When the error carried embedded ANSI escape sequences (a real path since #502 surfaces agent pane content via wrapped errors), the truncation could cut a CSI sequence mid-byte and leak visible garbage like `[31m` into the rendered output.
- Fix: strip ANSI escape sequences with a small regex (`\x1b\[[0-9;]*[a-zA-Z]`) before width measurement and truncation. Error styling continues to be applied via `errStyle.Render`, so the user-visible color treatment is unchanged.

## Test plan
- [x] New `TestErrBoxStripsANSIBeforeTruncating` exercises an error with embedded `\x1b[31m...\x1b[0m` plus filler beyond the container width; asserts no partial CSI payloads (`[31m`, `[0m `) appear in the output and the rendered line width stays within bounds.
- [x] New `TestErrBoxWithoutANSIUnchanged` confirms a plain-text error renders unchanged.
- [x] Existing `TestErrBoxNarrowWidthDoesNotOverflow` (regression for #337) still passes.
- [x] `go build ./...`, `go test ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast` all clean.

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)