### PR TITLE
fix(ui): wire Shift+Up/Down scroll to Tasks/Hooks panes (#524)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -313,8 +313,9 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.MouseMsg:
 		if msg.Action == tea.MouseActionPress {
 			if msg.Button == tea.MouseButtonWheelDown || msg.Button == tea.MouseButtonWheelUp {
-				selected := m.sidebar.GetSelectedInstance()
-				if selected == nil {
+				// Instance mode needs a selected instance to scroll preview/terminal;
+				// Tasks/Hooks modes scroll their own list independent of sidebar selection (#524).
+				if m.contentPane.GetMode() == ui.ContentModeInstance && m.sidebar.GetSelectedInstance() == nil {
 					return m, nil
 				}
 				switch msg.Button {

--- a/ui/content_pane.go
+++ b/ui/content_pane.go
@@ -118,11 +118,17 @@ func (c *ContentPane) HooksPane() *HooksPane {
 	return c.hooksPane
 }
 
-// ScrollUp scrolls the active pane up.
+// ScrollUp scrolls the active pane up. Mirrors the Terminal/Preview routing
+// pattern: Tasks and Hooks modes each delegate to their own pane's cursor
+// movement so shift+up and mouse wheel work in those modes too (#524).
 func (c *ContentPane) ScrollUp() {
 	switch c.mode {
 	case ContentModeInstance:
 		c.tabbedWindow.ScrollUp()
+	case ContentModeTasks:
+		c.taskPane.ScrollUp()
+	case ContentModeHooks:
+		c.hooksPane.ScrollUp()
 	}
 }
 
@@ -131,6 +137,10 @@ func (c *ContentPane) ScrollDown() {
 	switch c.mode {
 	case ContentModeInstance:
 		c.tabbedWindow.ScrollDown()
+	case ContentModeTasks:
+		c.taskPane.ScrollDown()
+	case ContentModeHooks:
+		c.hooksPane.ScrollDown()
 	}
 }
 

--- a/ui/content_pane_test.go
+++ b/ui/content_pane_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/task"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -88,6 +89,115 @@ func TestContentPaneSetSizeMatchesRenderHeight(t *testing.T) {
 		"taskPane height must match renderInlinePane Place height")
 	assert.Equal(t, expected, cp.hooksPane.height,
 		"hooksPane height must match renderInlinePane Place height")
+}
+
+// TestContentPaneScrollRoutesToTaskPane verifies that ContentPane.ScrollUp /
+// ScrollDown in Tasks mode actually move the TaskPane's selected index,
+// rather than being a no-op as in #524. Both shift+up/down keys and mouse
+// wheel events feed into these same methods.
+func TestContentPaneScrollRoutesToTaskPane(t *testing.T) {
+	tw := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
+	cp := NewContentPane(tw)
+	cp.SetMode(ContentModeTasks)
+	cp.TaskPane().SetTasks([]task.Task{
+		{ID: "a", Name: "first"},
+		{ID: "b", Name: "second"},
+		{ID: "c", Name: "third"},
+	})
+
+	assert.Equal(t, 0, cp.TaskPane().selectedIdx)
+
+	cp.ScrollDown()
+	assert.Equal(t, 1, cp.TaskPane().selectedIdx, "ScrollDown should advance selection")
+
+	cp.ScrollDown()
+	assert.Equal(t, 2, cp.TaskPane().selectedIdx)
+
+	cp.ScrollDown()
+	assert.Equal(t, 2, cp.TaskPane().selectedIdx, "ScrollDown at end should clamp")
+
+	cp.ScrollUp()
+	assert.Equal(t, 1, cp.TaskPane().selectedIdx, "ScrollUp should move selection back")
+
+	cp.ScrollUp()
+	cp.ScrollUp()
+	assert.Equal(t, 0, cp.TaskPane().selectedIdx, "ScrollUp past 0 should clamp")
+}
+
+// TestContentPaneScrollRoutesToHooksPane is the hooks-mode counterpart of the
+// task-pane test above. Regression test for #524.
+func TestContentPaneScrollRoutesToHooksPane(t *testing.T) {
+	tw := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
+	cp := NewContentPane(tw)
+	cp.SetMode(ContentModeHooks)
+	cp.HooksPane().SetCommands([]string{"make build", "make test", "make lint"})
+
+	assert.Equal(t, 0, cp.HooksPane().selectedIdx)
+
+	cp.ScrollDown()
+	assert.Equal(t, 1, cp.HooksPane().selectedIdx)
+
+	cp.ScrollDown()
+	cp.ScrollDown()
+	assert.Equal(t, 2, cp.HooksPane().selectedIdx, "ScrollDown at end should clamp")
+
+	cp.ScrollUp()
+	assert.Equal(t, 1, cp.HooksPane().selectedIdx)
+
+	cp.ScrollUp()
+	cp.ScrollUp()
+	assert.Equal(t, 0, cp.HooksPane().selectedIdx, "ScrollUp past 0 should clamp")
+}
+
+// TestContentPaneScrollEmptyModeNoOp verifies scroll in modes without lists
+// remains a safe no-op (no panics, no side-effects on other panes).
+func TestContentPaneScrollEmptyModeNoOp(t *testing.T) {
+	tw := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
+	cp := NewContentPane(tw)
+	cp.TaskPane().SetTasks([]task.Task{{ID: "a"}, {ID: "b"}})
+	cp.HooksPane().SetCommands([]string{"x", "y"})
+
+	cp.SetMode(ContentModeEmpty)
+	assert.NotPanics(t, func() {
+		cp.ScrollUp()
+		cp.ScrollDown()
+	})
+	assert.Equal(t, 0, cp.TaskPane().selectedIdx, "ContentModeEmpty must not move task selection")
+	assert.Equal(t, 0, cp.HooksPane().selectedIdx, "ContentModeEmpty must not move hooks selection")
+}
+
+// TestTaskPaneScrollNoOpDuringEdit verifies scroll is suppressed while the
+// task pane is in edit/create mode so background selection doesn't drift out
+// from under the form.
+func TestTaskPaneScrollNoOpDuringEdit(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{
+		{ID: "a", Name: "first", Prompt: "p"},
+		{ID: "b", Name: "second", Prompt: "p"},
+	})
+	tp.SetFocus(true)
+	// Enter edit mode on the first task.
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, tp.IsEditing())
+
+	tp.ScrollDown()
+	assert.Equal(t, 0, tp.selectedIdx, "ScrollDown during edit must be a no-op")
+	tp.ScrollUp()
+	assert.Equal(t, 0, tp.selectedIdx, "ScrollUp during edit must be a no-op")
+}
+
+// TestHooksPaneScrollNoOpDuringEdit is the hooks counterpart of the above.
+func TestHooksPaneScrollNoOpDuringEdit(t *testing.T) {
+	hp := NewHooksPane()
+	hp.SetCommands([]string{"a", "b"})
+	hp.SetFocus(true)
+	hp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, hp.editing)
+
+	hp.ScrollDown()
+	assert.Equal(t, 0, hp.selectedIdx, "ScrollDown during edit must be a no-op")
+	hp.ScrollUp()
+	assert.Equal(t, 0, hp.selectedIdx, "ScrollUp during edit must be a no-op")
 }
 
 func TestContentPaneRender(t *testing.T) {

--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -59,6 +59,28 @@ func (h *HooksPane) SetFocus(focus bool) {
 	}
 }
 
+// ScrollUp moves the selection up one row. Used by shift+up and mouse wheel
+// regardless of focus. No-op while a hook is being edited or added so the
+// background selection doesn't drift out from under the edit buffer.
+func (h *HooksPane) ScrollUp() {
+	if h.editing || h.adding {
+		return
+	}
+	if h.selectedIdx > 0 {
+		h.selectedIdx--
+	}
+}
+
+// ScrollDown moves the selection down one row. See ScrollUp.
+func (h *HooksPane) ScrollDown() {
+	if h.editing || h.adding {
+		return
+	}
+	if h.selectedIdx < len(h.commands)-1 {
+		h.selectedIdx++
+	}
+}
+
 // HandleKeyPress processes a key press. Returns true if the key was consumed.
 func (h *HooksPane) HandleKeyPress(msg tea.KeyMsg) bool {
 	if !h.hasFocus {

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -232,6 +232,29 @@ func (s *TaskPane) ConsumePendingTrigger() *task.Task {
 	return nil
 }
 
+// ScrollUp moves the selection up one row. Used by shift+up and mouse wheel
+// regardless of focus, so the user can browse the task list without first
+// focusing the pane. No-op while a task is being edited or created so the
+// background selection doesn't drift out from under the form.
+func (s *TaskPane) ScrollUp() {
+	if s.editing || s.creating {
+		return
+	}
+	if s.selectedIdx > 0 {
+		s.selectedIdx--
+	}
+}
+
+// ScrollDown moves the selection down one row. See ScrollUp.
+func (s *TaskPane) ScrollDown() {
+	if s.editing || s.creating {
+		return
+	}
+	if s.selectedIdx < len(s.tasks)-1 {
+		s.selectedIdx++
+	}
+}
+
 // HandleKeyPress processes a key press. Returns true if consumed.
 func (s *TaskPane) HandleKeyPress(msg tea.KeyMsg) bool {
 	if !s.hasFocus {


### PR DESCRIPTION
## Summary
- `ContentPane.ScrollUp/ScrollDown` only handled `ContentModeInstance`; in Tasks/Hooks modes the call was a no-op, so Shift+Up/Down and mouse wheel did nothing.
- Route the calls to `TaskPane.ScrollUp/Down` and `HooksPane.ScrollUp/Down` (moves the list cursor), mirroring the existing Preview/Terminal routing pattern.
- Loosen the mouse-wheel guard in `app/app.go` so it no longer bails on missing sidebar instance when the right pane is Tasks/Hooks.
- Scroll is suppressed while a task or hook is being edited so the background selection can't drift out from under the form.

Closes #524.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)
- [x] `go test ./ui/...` (new tests in `ui/content_pane_test.go` cover ScrollUp/Down for Tasks + Hooks modes, no-op for Empty mode, and no-op-during-edit guards)
- [x] Full `go test ./...` — only failure is an unrelated environmental flake in `session/TestE2ERemoteHooksFullLifecycle` (pyenv shim) that passes when run in isolation

Co-Authored-By: Captain Claude <noreply@anthropic.com>