### PR TITLE
docs(readme): remove non-existent --repo-id flag reference (#508)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ All data (sessions, tasks) is scoped to the current git repository. The TUI show
 
 ## Programmatic API
 
-The `af sessions` and `af tasks` subcommands provide a JSON CLI for driving Agent Factory without the TUI. All commands output JSON to stdout and errors to stderr; use `--repo <path>` or `--repo-id <id>` to target a specific repository.
+The `af sessions` and `af tasks` subcommands provide a JSON CLI for driving Agent Factory without the TUI. All commands output JSON to stdout and errors to stderr; use `--repo <path>` to target a specific repository.
 
 ### Sessions
 


### PR DESCRIPTION
## Summary
- README.md line 92 mentioned a `--repo-id <id>` flag alongside `--repo <path>`, but only `--repo` exists on `af sessions`/`af tasks` subcommands.
- Verified against `~/.local/bin/af sessions list --help`: the only global flag is `--repo string`.
- Removed the `--repo-id` reference; kept `--repo`.

Closes #508

## Test plan
- [x] `gofmt -l .` clean (docs-only change)
- [x] Diff inspected — single-line edit, no other surface affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)