### PR TITLE
fix(git): strip .lock suffix per segment in sanitizeBranchName (#521)

### DIFF
--- a/session/git/util.go
+++ b/session/git/util.go
@@ -36,12 +36,16 @@ func sanitizeBranchName(s string) string {
 	s = strings.Trim(s, "-/")
 
 	// Handle git dot restrictions:
-	// 1. Remove leading dots from each path component (no hidden-file-style names like .env)
-	//    This also handles ".." since stripping leading dots from ".." leaves it empty.
+	// 1. For each path component: strip leading dots (no hidden-file-style names
+	//    like .env; also collapses ".." to empty) and strip any trailing ".lock"
+	//    suffixes (reserved by git for every path segment, not just the final one).
 	parts := strings.Split(s, "/")
 	filtered := make([]string, 0, len(parts))
 	for _, part := range parts {
 		part = strings.TrimLeft(part, ".")
+		for strings.HasSuffix(part, ".lock") {
+			part = strings.TrimSuffix(part, ".lock")
+		}
 		if part != "" {
 			filtered = append(filtered, part)
 		}
@@ -49,13 +53,9 @@ func sanitizeBranchName(s string) string {
 	s = strings.Join(filtered, "/")
 	// 2. Replace any remaining double dots with a dash (e.g., "a..b")
 	s = strings.ReplaceAll(s, "..", "-")
-	// 3. No .lock suffix (reserved by git) - remove ALL trailing .lock suffixes
-	for strings.HasSuffix(s, ".lock") {
-		s = strings.TrimSuffix(s, ".lock")
-	}
-	// 4. No trailing dots
+	// 3. No trailing dots
 	s = strings.TrimRight(s, ".")
-	// 5. Clean up any trailing dashes or slashes left after dot removal
+	// 4. Clean up any trailing dashes or slashes left after dot removal
 	s = strings.Trim(s, "-/")
 
 	// If the result is empty (e.g., input was only special characters),

--- a/session/git/util_test.go
+++ b/session/git/util_test.go
@@ -72,6 +72,21 @@ func TestSanitizeBranchName(t *testing.T) {
 			expected: "john/config",
 		},
 		{
+			name:     ".lock in intermediate path segment",
+			input:    "foo.lock/bar",
+			expected: "foo/bar",
+		},
+		{
+			name:     ".locked is not stripped (internal .lock preserved)",
+			input:    "foo.locked/bar",
+			expected: "foo.locked/bar",
+		},
+		{
+			name:     ".lock in multiple segments",
+			input:    "foo.lock/bar.lock/baz",
+			expected: "foo/bar/baz",
+		},
+		{
 			name:     "double dots in name",
 			input:    "feature..branch",
 			expected: "feature-branch",


### PR DESCRIPTION
## Summary
- `sanitizeBranchName` only trimmed trailing `.lock` from the final joined string, so a name like `fix/foo.lock/bar` passed sanitization but was then rejected by git (every path segment is reserved, not just the leaf).
- Moved the `.lock`-suffix strip into the existing per-segment loop next to the leading-dot strip. Each segment is cleaned independently and repeatedly, preserving the prior multi-suffix behavior (`foo.lock.lock` → `foo`).
- Internal `.lock` (e.g. `foo.locked`) is still preserved — the strip only fires when a segment literally ends in `.lock`.

## Test plan
- [x] `go test ./session/git/...` — new cases cover `foo.lock/bar` → `foo/bar`, `foo.locked/bar` preserved, and `.lock` in multiple segments. Existing `john/config.lock` and `john/config.lock.lock` cases continue to pass.
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)

Closes #521

Co-Authored-By: Captain Claude <noreply@anthropic.com>