### PR TITLE
fix(ui): match private-mode CSI in ANSI strip regex (#552)

### DIFF
--- a/ui/err.go
+++ b/ui/err.go
@@ -11,8 +11,11 @@ import (
 // ansiEscapeRegex matches CSI escape sequences (e.g. SGR colors) so they can
 // be stripped before width-based truncation. Truncating a string that still
 // contains escape sequences risks cutting one mid-byte, leaking visible
-// garbage like "[31m" into the rendered output (issue #525).
-var ansiEscapeRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+// garbage like "[31m" into the rendered output (issue #525). The "?" prefix
+// covers private-mode sequences like \x1b[?25l (cursor hide) which would
+// otherwise be width-counted as visible runes and trigger premature truncation
+// (issue #552).
+var ansiEscapeRegex = regexp.MustCompile(`\x1b\[[?0-9;]*[a-zA-Z]`)
 
 type ErrBox struct {
 	height, width int

--- a/ui/err_test.go
+++ b/ui/err_test.go
@@ -96,6 +96,37 @@ func TestErrBoxWithoutANSIUnchanged(t *testing.T) {
 	}
 }
 
+// TestErrBoxStripsPrivateModeCSI is a regression test for issue #552. The
+// original strip regex only allowed [0-9;] in the parameter byte slot, so
+// private-mode sequences like \x1b[?25l (cursor hide/show), \x1b[?1049h
+// (alt-screen), and \x1b[?7l (autowrap off) leaked through. runewidth then
+// counted "?25l" etc. as visible runes and the box truncated prematurely.
+func TestErrBoxStripsPrivateModeCSI(t *testing.T) {
+	payload := "agent crashed"
+	// Mix display SGR with several private-mode sequences.
+	raw := "\x1b[?25l\x1b[?1049h\x1b[?7l\x1b[31m" + payload + "\x1b[0m\x1b[?25h\x1b[?1049l"
+	stripped := ansiEscapeRegex.ReplaceAllString(raw, "")
+	if stripped != payload {
+		t.Fatalf("private-mode CSI not stripped: got %q want %q", stripped, payload)
+	}
+	if got := runewidth.StringWidth(stripped); got != runewidth.StringWidth(payload) {
+		t.Errorf("width after strip = %d, want %d", got, runewidth.StringWidth(payload))
+	}
+
+	// End-to-end: a wide-enough box must render the full payload without
+	// truncation now that private-mode bytes no longer inflate the width.
+	e := NewErrBox()
+	e.SetSize(80, 1)
+	e.SetError(errors.New(raw))
+	out := e.String()
+	if !strings.Contains(stripANSI(out), payload) {
+		t.Errorf("payload missing from rendered output: %q", out)
+	}
+	if strings.Contains(out, "?25l") || strings.Contains(out, "?1049h") || strings.Contains(out, "?7l") {
+		t.Errorf("private-mode sequence leaked into output: %q", out)
+	}
+}
+
 // stripANSI removes ANSI escape sequences (CSI) so width measurements
 // reflect only visible runes.
 func stripANSI(s string) string {


### PR DESCRIPTION
## Summary
- The ANSI strip regex from #544 used `[0-9;]` in the parameter byte slot, missing private-mode CSI sequences like `\x1b[?25l`, `\x1b[?1049h`, `\x1b[?7l` (the `?` prefix isn't `0-9` or `;`).
- `runewidth.StringWidth` then counted `?25l` etc. as visible runes, triggering premature truncation in `ErrBox`.
- Fix: add `?` to the parameter class — `\x1b\[[?0-9;]*[a-zA-Z]`. Conservative widening that covers the reported sequences without overmatching.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages)
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)
- [x] New `TestErrBoxStripsPrivateModeCSI` mixes private-mode CSI with display SGR and verifies the stripped payload matches and renders without leakage.

Closes #552

Co-Authored-By: Captain Claude <noreply@anthropic.com>