### PR TITLE
fix(task): treat full-range DOM as wildcard in OR-semantics fan-out (#550)

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -153,6 +153,9 @@ func CronToOnCalendar(cronExpr string) ([]string, error) {
 	// already returns "" for the DOW side; for DOM we expand and check.
 	domVals, _ := expandCronField(domField, 1, 31)
 	domCoversAll := domVals != nil && len(domVals) >= 31
+	if domCoversAll {
+		domPart = "*"
+	}
 
 	domRestricted := domField != "*" && !domCoversAll
 	dowRestricted := dowPart != ""

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -285,11 +285,41 @@ func TestCronToOnCalendarDOMandDOWStep(t *testing.T) {
 
 // TestCronToOnCalendarDOMCoversAllNoSplit verifies that when DOM is
 // syntactically restricted but covers every day (1-31), the OR collapses to
-// "every day" and the result is a single DOW-restricted entry.
+// "every day" and the result is a single DOW-restricted entry with DOM=*.
 func TestCronToOnCalendarDOMCoversAllNoSplit(t *testing.T) {
 	result, err := CronToOnCalendar("0 9 1-31 * 1")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"Mon *-*-01..31 09:00:00"}, result)
+	assert.Equal(t, []string{"Mon *-*-* 09:00:00"}, result)
+}
+
+// TestCronToOnCalendarDOMTrulyRestrictedFanOut verifies the OR-semantics
+// fan-out still triggers when DOM is a real subset of days (1-7, not 1-31).
+func TestCronToOnCalendarDOMTrulyRestrictedFanOut(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 1-7 * 1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"*-*-01..07 09:00:00",
+		"Mon *-*-* 09:00:00",
+	}, result)
+}
+
+// TestCronToOnCalendarDOMCoversAllNoDOW verifies that a full-range DOM with
+// wildcard DOW collapses to plain every-day (no DOM restriction in output).
+func TestCronToOnCalendarDOMCoversAllNoDOW(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 1-31 * *")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*-*-* 09:00:00"}, result)
+}
+
+// TestCronToOnCalendarDOMSingleDayFanOut verifies that a single restrictive
+// DOM still produces the OR-semantics fan-out.
+func TestCronToOnCalendarDOMSingleDayFanOut(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 1 * 1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"*-*-01 09:00:00",
+		"Mon *-*-* 09:00:00",
+	}, result)
 }
 
 // TestCronToOnCalendarDOWCoversAllNoSplit verifies the symmetric case where


### PR DESCRIPTION
## Summary
- PR #535 added an "effective wildcard" check for the DOM side of the cron OR-semantics fan-out, but only used it to skip fan-out. The single-entry fallback still rendered `domPart` as the literal range, so `0 9 1-31 * 1` produced `Mon *-*-01..31 09:00:00` instead of `Mon *-*-* 09:00:00`.
- Promote `domPart` to `*` when `domCoversAll`, mirroring the existing DOW=* collapse.
- Genuinely-restrictive DOM (e.g. `1-7`) still fans out as before.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages green)
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `gofmt -l .` (no output)
- [x] New regression tests in `task/cron_test.go`:
  - `0 9 1-31 * 1` → `Mon *-*-* 09:00:00` (collapse)
  - `0 9 1-7 * 1` → fan-out (truly restrictive)
  - `0 9 1-31 * *` → `*-*-* 09:00:00` (every day)
  - `0 9 1 * 1` → fan-out (single day)

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)