### PR TITLE
fix(daemon): kill tmux session in cleanupGhostWorktree (#549)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -691,7 +691,7 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 			return fmt.Errorf("failed to kill instance: %w", err)
 		}
 	} else if data != nil {
-		cleanupGhostWorktree(*data, req.Title)
+		ghostCleanup(data, req.Title)
 	}
 
 	state := config.LoadState()
@@ -880,7 +880,22 @@ func findInstanceDataByTitle(title, repoID string) (*session.InstanceData, strin
 	return nil, "", fmt.Errorf("instance %q not found", title)
 }
 
-func cleanupGhostWorktree(data session.InstanceData, title string) {
+// ghostKillTmuxByName issues a tmux kill-session for a persisted sanitized
+// name. Package-level so tests can stub it without invoking real tmux. The
+// af_ prefix check refuses to act on names the daemon would never write, so a
+// corrupted store can't make us kill an unrelated tmux session. Mirror of the
+// api/sessions.go helper added in #536 — duplicated here because daemon/
+// cannot import api/ without a cycle.
+var ghostKillTmuxByName = func(sanitizedName string) error {
+	if !strings.HasPrefix(sanitizedName, tmux.TmuxPrefix) {
+		return fmt.Errorf("refusing to kill tmux session without %q prefix: %q", tmux.TmuxPrefix, sanitizedName)
+	}
+	return tmux.NewTmuxSessionFromSanitizedName(sanitizedName, "").Close()
+}
+
+// ghostCleanupWorktree performs best-effort worktree teardown for a ghost
+// session whose live restore failed. Package-level so tests can stub it.
+var ghostCleanupWorktree = func(data *session.InstanceData, title string) {
 	if data.Worktree.RepoPath == "" || data.Worktree.WorktreePath == "" || data.Worktree.ExternalWorktree {
 		return
 	}
@@ -888,7 +903,7 @@ func cleanupGhostWorktree(data session.InstanceData, title string) {
 	if data.Worktree.BranchCreatedByUs != nil {
 		branchCreatedByUs = *data.Worktree.BranchCreatedByUs
 	}
-	gw, err := git.NewGitWorktreeFromStorage(
+	gw, gwErr := git.NewGitWorktreeFromStorage(
 		data.Worktree.RepoPath,
 		data.Worktree.WorktreePath,
 		data.Worktree.SessionName,
@@ -897,12 +912,25 @@ func cleanupGhostWorktree(data session.InstanceData, title string) {
 		data.Worktree.ExternalWorktree,
 		branchCreatedByUs,
 	)
-	if err != nil {
-		log.WarningLog.Printf("ghost session %q: failed to load worktree for cleanup: %v", title, err)
+	if gwErr != nil {
+		log.WarningLog.Printf("ghost session %q: failed to load worktree for cleanup: %v", title, gwErr)
 		return
 	}
-	if err := gw.Cleanup(); err != nil {
-		log.WarningLog.Printf("ghost session %q: worktree cleanup failed: %v", title, err)
+	if cleanupErr := gw.Cleanup(); cleanupErr != nil {
+		log.WarningLog.Printf("ghost session %q: worktree cleanup failed: %v", title, cleanupErr)
+	}
+}
+
+// ghostCleanup runs best-effort teardown of a ghost session's external
+// resources. Tmux teardown is independent of worktree state (#516/#549): a
+// ghost record can have an empty worktree path while a tmux session with the
+// persisted name is still running, so the two branches share no condition.
+func ghostCleanup(data *session.InstanceData, title string) {
+	ghostCleanupWorktree(data, title)
+	if data.TmuxName != "" {
+		if killErr := ghostKillTmuxByName(data.TmuxName); killErr != nil {
+			log.WarningLog.Printf("ghost session %q: tmux cleanup failed: %v", title, killErr)
+		}
 	}
 }
 

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -428,6 +428,109 @@ func TestFormatWaitForReadyTimeoutError(t *testing.T) {
 	})
 }
 
+// stubGhostCleanup replaces both ghostCleanupWorktree and ghostKillTmuxByName
+// with recorders so tests can assert which teardown branches fired without
+// invoking real git / real tmux.
+func stubGhostCleanup(t *testing.T) (wtCalls *[]string, tmuxCalls *[]string) {
+	t.Helper()
+	var wt, tm []string
+	prevWT := ghostCleanupWorktree
+	prevTmux := ghostKillTmuxByName
+	ghostCleanupWorktree = func(data *session.InstanceData, title string) {
+		if data.Worktree.RepoPath == "" || data.Worktree.WorktreePath == "" || data.Worktree.ExternalWorktree {
+			return
+		}
+		wt = append(wt, title)
+	}
+	ghostKillTmuxByName = func(name string) error {
+		tm = append(tm, name)
+		return nil
+	}
+	t.Cleanup(func() {
+		ghostCleanupWorktree = prevWT
+		ghostKillTmuxByName = prevTmux
+	})
+	return &wt, &tm
+}
+
+// TestGhostCleanup_TmuxOrphan is the daemon-side regression test for #549:
+// PR #536 fixed the same orphan in api/sessions.go, but the daemon kill path
+// kept the old worktree-only teardown, so the bug returned through the
+// daemon-routed kill. With an empty worktree path and a populated TmuxName,
+// ghostCleanup must still attempt to kill the tmux session.
+func TestGhostCleanup_TmuxOrphan(t *testing.T) {
+	wtCalls, tmCalls := stubGhostCleanup(t)
+
+	data := &session.InstanceData{
+		Title:    "ghost",
+		Program:  "claude",
+		TmuxName: "af_ghost",
+	}
+	ghostCleanup(data, "ghost")
+
+	if len(*wtCalls) != 0 {
+		t.Fatalf("expected worktree cleanup skipped, got: %v", *wtCalls)
+	}
+	if len(*tmCalls) != 1 || (*tmCalls)[0] != "af_ghost" {
+		t.Fatalf("expected tmux kill for af_ghost, got: %v", *tmCalls)
+	}
+}
+
+// TestGhostCleanup_BothPopulated verifies the fix did not regress the
+// worktree-cleanup branch: with both fields populated, both teardowns fire.
+func TestGhostCleanup_BothPopulated(t *testing.T) {
+	wtCalls, tmCalls := stubGhostCleanup(t)
+
+	data := &session.InstanceData{
+		Title:    "ghost",
+		Program:  "claude",
+		TmuxName: "af_ghost",
+		Worktree: session.GitWorktreeData{
+			RepoPath:     "/tmp/repo",
+			WorktreePath: "/tmp/wt",
+			SessionName:  "ghost",
+			BranchName:   "af/ghost",
+		},
+	}
+	ghostCleanup(data, "ghost")
+
+	if len(*wtCalls) != 1 || (*wtCalls)[0] != "ghost" {
+		t.Fatalf("expected worktree cleanup, got: %v", *wtCalls)
+	}
+	if len(*tmCalls) != 1 || (*tmCalls)[0] != "af_ghost" {
+		t.Fatalf("expected tmux kill for af_ghost, got: %v", *tmCalls)
+	}
+}
+
+// TestGhostCleanup_AllEmpty verifies that with no TmuxName and no worktree
+// paths, both teardown branches are skipped.
+func TestGhostCleanup_AllEmpty(t *testing.T) {
+	wtCalls, tmCalls := stubGhostCleanup(t)
+
+	data := &session.InstanceData{
+		Title:   "ghost",
+		Program: "claude",
+	}
+	ghostCleanup(data, "ghost")
+
+	if len(*wtCalls) != 0 {
+		t.Fatalf("expected no worktree cleanup, got: %v", *wtCalls)
+	}
+	if len(*tmCalls) != 0 {
+		t.Fatalf("expected no tmux kill, got: %v", *tmCalls)
+	}
+}
+
+// TestGhostKillTmuxByName_RefusesNonAfPrefix guards the validation in the
+// real ghostKillTmuxByName: a sanitized name without the af_ prefix would
+// only appear via storage corruption, and silently killing whatever tmux
+// session it names could destroy unrelated work.
+func TestGhostKillTmuxByName_RefusesNonAfPrefix(t *testing.T) {
+	if err := ghostKillTmuxByName("not-ours"); err == nil {
+		t.Fatalf("expected refusal for non-af prefix, got nil")
+	}
+}
+
 // TestIsDaemonAbsentErr covers the small classifier RequestShutdown uses to
 // decide whether a dial/RPC failure means "no daemon" (silent no-op) or
 // "unexpected transport problem" (surface to the caller).


### PR DESCRIPTION
## Summary
- PR #536 fixed the ghost-tmux orphan from #478 in `api/sessions.go` `killSessionDirect`, but the daemon path (`daemon/control.go` `cleanupGhostWorktree`) was never updated. The user-facing bug returns whenever the kill routes through the daemon — which is the production path.
- Mirror the api-side pattern in `daemon/control.go`: extract package-level `ghostCleanupWorktree` + `ghostKillTmuxByName` (stubbable for tests), and replace the old `cleanupGhostWorktree` call-site at `Manager.KillSession` with a `ghostCleanup` wrapper. Tmux teardown is now gated only on `TmuxName != ""` with the same `af_`-prefix guard, fully decoupled from worktree state.
- Helpers are duplicated rather than shared because `daemon/` cannot import `api/` without a cycle (`api/` already imports `daemon/`).

## Test plan
- [x] New daemon tests in `daemon/control_test.go` cover: empty worktree + populated `TmuxName` → tmux kill fires (regression); both populated → both fire; all empty → no-op; non-`af_` prefix → refused.
- [x] `gofmt -l .` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go build ./...` clean
- [x] `go test ./...` green (full suite)

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)