### PR TITLE
fix(upgrade): return ShutdownFailed when daemon is proven-running but PID-source is missing (#553)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -216,6 +216,13 @@ const (
 	// directly. The upgrade prints a slightly different success message so
 	// users know we used the fallback. See #504.
 	ShutdownViaSIGTERM
+	// ShutdownFailed means a daemon was proven to be listening on the
+	// control socket (the Shutdown RPC came back as method-not-found, not
+	// ECONNREFUSED) but the SIGTERM fallback could not locate a PID to
+	// signal — e.g. no PID file AND pgrep is unavailable on this host. The
+	// daemon is still running the old binary; the caller must surface the
+	// recovery hint in the accompanying error. See #553.
+	ShutdownFailed
 )
 
 // sigtermFallbackGrace is the max time we wait for a SIGTERM'd daemon to exit
@@ -232,12 +239,13 @@ const sigtermFallbackPoll = 100 * time.Millisecond
 // daemon's PID and sending SIGTERM directly (#504) so an `af upgrade` does
 // not leave a stale daemon running the old binary.
 //
-// Returns (ShutdownNoDaemon, nil) when no daemon is running (no socket,
-// ECONNREFUSED, or no signalable PID), (ShutdownViaRPC, nil) when the Shutdown
-// RPC acknowledged, (ShutdownViaSIGTERM, nil) when the fallback signaled a
-// real `af --daemon` process, and (ShutdownNoDaemon, err) for unexpected
-// errors that the caller should surface (e.g. multiple ambiguous candidates,
-// permission denied on signal).
+// Returns (ShutdownNoDaemon, nil) when no daemon is running (no socket or
+// ECONNREFUSED), (ShutdownViaRPC, nil) when the Shutdown RPC acknowledged,
+// (ShutdownViaSIGTERM, nil) when the fallback signaled a real `af --daemon`
+// process, and (ShutdownFailed, err) when the daemon is provably running but
+// the fallback could not locate or signal it (ambiguous pgrep matches, no
+// PID file with pgrep unavailable, permission denied on signal) — the
+// returned error carries the recovery hint the caller must surface.
 func RequestShutdown() (ShutdownResult, error) {
 	socketPath, err := DaemonSocketPath()
 	if err != nil {

--- a/daemon/sigterm_fallback.go
+++ b/daemon/sigterm_fallback.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,24 +26,34 @@ import (
 //     "af --daemon"`, filter out /tmp/Test* paths (Go test binaries) and the
 //     current process, and require exactly one candidate.
 //
-// Returns ShutdownViaSIGTERM when a signal was delivered, ShutdownNoDaemon
-// when nothing eligible was found, or an error for ambiguous cases (multiple
-// pgrep matches) so the caller can surface a clear actionable message.
+// Returns ShutdownViaSIGTERM when a signal was delivered, or ShutdownFailed
+// with an actionable error when the daemon (which is provably running — the
+// caller only invokes us after the Shutdown RPC returned method-not-found,
+// not ECONNREFUSED) could not be located or signaled. Returning
+// ShutdownNoDaemon here would contradict the established state and silently
+// leave the stale daemon running (#553).
 func sigtermFallback() (ShutdownResult, error) {
 	pid, source, err := locateDaemonPID()
 	if err != nil {
-		return ShutdownNoDaemon, err
+		return ShutdownFailed, fmt.Errorf(
+			"sigterm fallback failed: %w; run 'pkill -f \"af --daemon\"' to stop the old daemon manually before retrying `af upgrade`",
+			err,
+		)
 	}
 	if pid == 0 {
-		// Nothing to signal. Treat as ShutdownNoDaemon: the upgrade prints
-		// bare success and the next RPC EnsureDaemon-respawns from the new
-		// binary anyway.
-		return ShutdownNoDaemon, nil
+		return ShutdownFailed, fmt.Errorf(
+			"sigterm fallback: daemon is running on the control socket but no PID candidate was found (%s); "+
+				"run 'pkill -f \"af --daemon\"' to stop the old daemon manually before retrying `af upgrade`",
+			source,
+		)
 	}
 
 	log.InfoLog.Printf("sigterm fallback: signaling pre-#501 daemon (pid=%d source=%s)", pid, source)
 	if err := signalAndWait(pid); err != nil {
-		return ShutdownNoDaemon, fmt.Errorf("sigterm fallback for daemon pid %d: %w", pid, err)
+		return ShutdownFailed, fmt.Errorf(
+			"sigterm fallback for daemon pid %d: %w; run 'pkill -f \"af --daemon\"' to stop the old daemon manually before retrying `af upgrade`",
+			pid, err,
+		)
 	}
 
 	// Best-effort PID file cleanup so the next `af` invocation does not see
@@ -52,25 +63,32 @@ func sigtermFallback() (ShutdownResult, error) {
 	return ShutdownViaSIGTERM, nil
 }
 
-// locateDaemonPID returns the PID of the running daemon to signal, the source
-// it was found in ("pid-file" or "pgrep") for diagnostics, or (0, "", nil)
-// when no eligible target exists. An error is returned only for ambiguous
-// pgrep results where signaling would be unsafe.
+// locateDaemonPID returns the PID of the running daemon to signal and the
+// source it was found in ("pid-file" or "pgrep") on success. On failure to
+// locate a PID, returns (0, source, nil) where source describes the suspected
+// PID source for diagnostics (e.g. "pid-file pid=N stale, pgrep: no matches"
+// or "no pid-file, pgrep unavailable"). An error is returned only for hard
+// failures (ambiguous pgrep results, pgrep itself failing to execute).
 func locateDaemonPID() (int, string, error) {
+	pidFileSource := "no pid-file"
 	if pid, ok := readPIDFromFile(); ok {
 		if pidLooksAlive(pid) && isAgentFactoryDaemon(pid) {
 			return pid, "pid-file", nil
 		}
 		log.InfoLog.Printf("sigterm fallback: PID file pid=%d is dead or non-daemon; falling back to pgrep", pid)
+		pidFileSource = fmt.Sprintf("pid-file pid=%d stale", pid)
 	}
 
 	pids, err := pgrepDaemonCandidates()
 	if err != nil {
-		return 0, "", err
+		if errors.Is(err, errPgrepUnavailable) {
+			return 0, fmt.Sprintf("%s, pgrep unavailable", pidFileSource), nil
+		}
+		return 0, "", fmt.Errorf("%s, pgrep: %w", pidFileSource, err)
 	}
 	switch len(pids) {
 	case 0:
-		return 0, "", nil
+		return 0, fmt.Sprintf("%s, pgrep: no matches", pidFileSource), nil
 	case 1:
 		return pids[0], "pgrep", nil
 	default:
@@ -133,6 +151,12 @@ func pidLooksAlive(pid int) bool {
 	return true
 }
 
+// errPgrepUnavailable signals that `pgrep` is not on PATH, distinct from
+// "pgrep ran and returned no matches". Surfaced by locateDaemonPID so the
+// caller can build an actionable error rather than misclassifying the running
+// daemon as absent (#553).
+var errPgrepUnavailable = errors.New("pgrep not found in PATH")
+
 // pgrepDaemonCandidates scans for processes whose full command line contains
 // "af --daemon", excluding Go test binaries living under /tmp/Test* and the
 // current process. We rely on pgrep -f rather than parsing /proc directly so
@@ -140,12 +164,8 @@ func pidLooksAlive(pid int) bool {
 func pgrepDaemonCandidates() ([]int, error) {
 	pgrep, err := exec.LookPath("pgrep")
 	if err != nil {
-		// No pgrep is unusual but recoverable: just report no candidates so
-		// the upgrade falls back to "bare success". The daemon will keep
-		// running but the next RPC respawns the right one anyway, and we
-		// surface this in the log for debugging.
 		log.WarningLog.Printf("sigterm fallback: pgrep not found in PATH; cannot scan for daemons: %v", err)
-		return nil, nil
+		return nil, fmt.Errorf("%w: %v", errPgrepUnavailable, err)
 	}
 	out, err := exec.Command(pgrep, "-f", "af --daemon").Output()
 	if err != nil {

--- a/daemon/sigterm_fallback_test.go
+++ b/daemon/sigterm_fallback_test.go
@@ -285,10 +285,12 @@ func TestSigtermFallback_IgnoresNonMatchingCmdline(t *testing.T) {
 	}
 }
 
-// TestSigtermFallback_DeadPID covers the second specified test: when the PID
-// file points at a process that no longer exists (or was never one), the
-// fallback should clean up gracefully and report ShutdownNoDaemon rather
-// than erroring or hanging.
+// TestSigtermFallback_DeadPID covers the dead-PID case: the PID file points
+// at a process that no longer exists, pgrep falls through to "no matches".
+// Per #553 the fallback's contract is invoked only after the Shutdown RPC
+// has proven the daemon is running, so "could not locate a PID" must be
+// reported as ShutdownFailed (not ShutdownNoDaemon) along with an actionable
+// recovery hint — anything else would silently leave the stale daemon up.
 func TestSigtermFallback_DeadPID(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", home)
@@ -302,13 +304,51 @@ func TestSigtermFallback_DeadPID(t *testing.T) {
 	}
 
 	result, err := sigtermFallback()
-	if err != nil {
-		t.Fatalf("sigtermFallback returned error for dead PID: %v", err)
+	if result != ShutdownFailed {
+		t.Fatalf("sigtermFallback returned %v for dead PID, want ShutdownFailed", result)
 	}
-	// The dead-PID branch falls through to pgrep; on a clean test runner
-	// there are no `af --daemon` matches, so we expect ShutdownNoDaemon.
-	if result != ShutdownNoDaemon {
-		t.Fatalf("sigtermFallback returned %v for dead PID, want ShutdownNoDaemon", result)
+	if err == nil {
+		t.Fatalf("sigtermFallback returned nil error for dead PID; expected one carrying the recovery hint")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `pkill -f "af --daemon"`) {
+		t.Errorf("sigtermFallback error %q missing recovery hint with `pkill -f \"af --daemon\"`", msg)
+	}
+	if !strings.Contains(msg, strconv.Itoa(deadPID)) {
+		t.Errorf("sigtermFallback error %q missing stale PID-file pid=%d in source", msg, deadPID)
+	}
+}
+
+// TestSigtermFallback_NoPIDFileAndNoPgrep covers #553: the Shutdown RPC
+// proved the daemon is listening on the socket, but the fallback path has
+// no PID file to consult AND pgrep is unavailable. Returning ShutdownNoDaemon
+// would contradict the established state and leave the stale daemon running;
+// the fix is to return ShutdownFailed with an actionable error pointing at
+// `pkill -f "af --daemon"`.
+func TestSigtermFallback_NoPIDFileAndNoPgrep(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	// Force pgrep off PATH for this test only. Using a fresh, empty temp
+	// dir guarantees exec.LookPath("pgrep") fails.
+	t.Setenv("PATH", t.TempDir())
+
+	result, err := sigtermFallback()
+	if result != ShutdownFailed {
+		t.Fatalf("sigtermFallback returned %v, want ShutdownFailed", result)
+	}
+	if err == nil {
+		t.Fatalf("sigtermFallback returned nil error; expected one carrying the recovery hint")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `pkill -f "af --daemon"`) {
+		t.Errorf("sigtermFallback error %q missing recovery hint with `pkill -f \"af --daemon\"`", msg)
+	}
+	if !strings.Contains(msg, "pgrep unavailable") {
+		t.Errorf("sigtermFallback error %q missing `pgrep unavailable` source", msg)
+	}
+	if !strings.Contains(msg, "no pid-file") {
+		t.Errorf("sigtermFallback error %q missing `no pid-file` source", msg)
 	}
 }
 
@@ -416,14 +456,19 @@ func TestRequestShutdown_PreShutdownDaemon(t *testing.T) {
 	// dependency belongs in an integration test, not a unit test —
 	// here we only need to assert RequestShutdown completes without
 	// a panic and surfaces a Result/error consistent with the routing
-	// having reached the fallback. The result space is:
-	//   - ShutdownNoDaemon, nil           (clean test host)
-	//   - ShutdownViaSIGTERM, nil         (host has a real daemon — uncommon)
-	//   - ShutdownNoDaemon, non-nil error (ambiguous pgrep matches)
-	// What is NOT acceptable: a panic, or ShutdownViaRPC (would mean the
-	// fake daemon answered Shutdown, which it does not implement).
+	// having reached the fallback. The result space (post-#553) is:
+	//   - ShutdownFailed, non-nil error (clean test host: pgrep found
+	//       no matches; or ambiguous pgrep matches; both fold into the
+	//       "daemon is provably running but unsignaled" bucket)
+	//   - ShutdownViaSIGTERM, nil       (host has a real daemon — uncommon)
+	// What is NOT acceptable: a panic, ShutdownViaRPC (would mean the
+	// fake daemon answered Shutdown, which it does not implement), or
+	// ShutdownNoDaemon (would contradict the proven-alive socket).
 	result, err := RequestShutdown()
 	if result == ShutdownViaRPC {
 		t.Fatalf("RequestShutdown returned ShutdownViaRPC; fake daemon has no Shutdown method — routing into the SIGTERM fallback is broken (err=%v)", err)
+	}
+	if result == ShutdownNoDaemon {
+		t.Fatalf("RequestShutdown returned ShutdownNoDaemon after a successful Ping; the socket proved the daemon is alive, so #553's invariant is violated (err=%v)", err)
 	}
 }


### PR DESCRIPTION
## Summary
- `sigtermFallback` is only invoked after the Shutdown RPC has returned method-not-found — i.e. the daemon is proven to be listening on the control socket. Returning `ShutdownNoDaemon` when `pgrep` is unavailable (or returns zero matches) contradicts that established state and silently leaves the stale daemon running.
- Introduces `ShutdownFailed` for "daemon is alive but the fallback could not locate or signal it". Surfaces the suspected PID source (PID file contents if any, or `pgrep unavailable`) plus the recovery hint (`pkill -f "af --daemon"`) in the returned error so `af upgrade`/auto-update prints something actionable instead of bare success.
- `pgrepDaemonCandidates` now distinguishes "pgrep missing from PATH" (`errPgrepUnavailable`) from "pgrep ran, no matches" — the former drove the regression #505 introduced, since the old code conflated them as "no daemon present".

## Test plan
- [x] New `TestSigtermFallback_NoPIDFileAndNoPgrep` simulates the exact #553 path (empty `PATH`, no PID file); asserts `ShutdownFailed` + error contains the `pkill -f "af --daemon"` hint and the `pgrep unavailable` source.
- [x] `TestSigtermFallback_DeadPID` updated: dead PID-file + pgrep finds nothing → `ShutdownFailed` with the stale PID in the message and the recovery hint.
- [x] `TestRequestShutdown_PreShutdownDaemon` now also rejects `ShutdownNoDaemon` (was only rejecting `ShutdownViaRPC`).
- [x] `gofmt -l .` clean, `golangci-lint run --timeout=3m --fast` clean.
- [x] `go build ./...` and `go test ./...` green.

Closes #553.