### PR TITLE
fix(sidebar): exclude Loading instances from disk persistence (#551)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -655,9 +655,18 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 		return fmt.Errorf("session with title %q already exists", title)
 	}
 	for _, data := range diskData {
-		if data.Title == title {
-			return fmt.Errorf("session with title %q already exists", title)
+		if data.Title != title {
+			continue
 		}
+		// Loading entries are transient TUI state with an empty worktree
+		// path and cannot be restored. Older TUI binaries (#551) could
+		// persist them to disk on quit, where they would block title
+		// reuse forever. Treat them as ghosts that the next save will
+		// reap rather than as live reservations.
+		if data.Status == session.Loading {
+			continue
+		}
+		return fmt.Errorf("session with title %q already exists", title)
 	}
 	if remote {
 		candidate := session.Slugify(title)
@@ -827,9 +836,19 @@ func appendInstanceData(repoID string, data session.InstanceData) error {
 			return nil, fmt.Errorf("failed to parse existing instances: %w", err)
 		}
 		for i := range existing {
-			if existing[i].Title == data.Title {
-				return nil, fmt.Errorf("session with title %q already exists", data.Title)
+			if existing[i].Title != data.Title {
+				continue
 			}
+			// A Loading ghost left by an older TUI binary (#551) should
+			// be overwritten rather than blocking the new session.
+			// validateTitleAvailableLocked already cleared this title,
+			// so reaching here under a same-titled non-Loading entry
+			// is a real conflict.
+			if existing[i].Status == session.Loading {
+				existing[i] = data
+				return json.MarshalIndent(existing, "", "  ")
+			}
+			return nil, fmt.Errorf("session with title %q already exists", data.Title)
 		}
 		existing = append(existing, data)
 		return json.MarshalIndent(existing, "", "  ")

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -198,6 +198,45 @@ func TestManagerCreateSessionAtomicWithRefresh(t *testing.T) {
 	}
 }
 
+// TestManagerCreateSessionIgnoresLoadingGhost is a regression test for
+// sachiniyer/agent-factory#551. An older TUI binary could persist a
+// Loading-status entry on quit; the daemon's title-collision check
+// then treated it as a live reservation and rejected any future
+// session creation with the same title. The fix skips Loading entries
+// in disk-side validation so they no longer block — the next save will
+// reap them.
+func TestManagerCreateSessionIgnoresLoadingGhost(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	ghostJSON, err := json.Marshal([]session.InstanceData{
+		{Title: "stuck", Path: repoPath, Status: session.Loading},
+	})
+	if err != nil {
+		t.Fatalf("marshal ghost: %v", err)
+	}
+	if err := config.LoadState().SaveInstances(repo.ID, ghostJSON); err != nil {
+		t.Fatalf("seed ghost: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "stuck",
+		RepoPath: repoPath,
+		Program:  "claude",
+	}); err != nil {
+		t.Fatalf("CreateSession should ignore Loading ghost, got: %v", err)
+	}
+}
+
 func TestControlServerCreateAndKillSession(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	installInstantBackend(t)

--- a/session/storage.go
+++ b/session/storage.go
@@ -72,10 +72,12 @@ func NewStorage(state config.InstanceStorage, repoID string) (*Storage, error) {
 }
 
 // SaveInstances saves the list of instances to disk under file locks.
-// Includes both started instances and Loading instances (which are in the
-// process of being started asynchronously). This ensures preSaveInstances
-// persists Loading instances to disk so refreshExternalInstances won't
-// remove them during the Loading→Running transition.
+// Loading instances are excluded — they represent in-flight TUI session
+// creations whose worktree is not yet populated, so they cannot be
+// restored via FromInstanceData. refreshExternalInstances already
+// protects in-memory Loading entries from being reaped, so they don't
+// need a disk presence. Persisting them risked orphaned records that
+// the daemon's title-collision check would treat as live (#551).
 func (s *Storage) SaveInstances(instances []*Instance) error {
 	if s.repoID != "" {
 		return s.saveRepoInstances(instances)
@@ -84,7 +86,7 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 	// Convert instances to InstanceData
 	data := make([]InstanceData, 0)
 	for _, instance := range instances {
-		if instance.Started() || instance.GetStatus() == Loading {
+		if instance.Started() {
 			data = append(data, instance.ToInstanceData())
 		}
 	}
@@ -162,6 +164,13 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 					// preserve it.
 					continue
 				}
+				// Legacy Loading ghosts (#551) left by older binaries
+				// would block title reuse via the daemon's collision
+				// check. Drop them on the next save instead of
+				// preserving them as "external".
+				if dd.Status == Loading {
+					continue
+				}
 				// Externally added instance — keep it.
 				merged = append(merged, dd)
 			}
@@ -206,16 +215,20 @@ func (s *Storage) saveRepoInstances(instances []*Instance) error {
 		data := make([]InstanceData, 0)
 		memTitles := make(map[string]bool)
 		for _, instance := range instances {
-			status := instance.GetStatus()
-			if status != Loading {
-				if !instance.Started() {
-					continue
-				}
-				// If another process deleted the disk record and the backing
-				// session is gone, don't resurrect it from stale TUI memory.
-				if !diskTitles[instance.Title] && !instance.TmuxAlive() {
-					continue
-				}
+			// Loading is transient TUI state — its worktree is not yet
+			// populated, so FromInstanceData cannot restore it. Persisting
+			// it would leave an orphan that the daemon's title-collision
+			// check would treat as live (#551).
+			if instance.GetStatus() == Loading {
+				continue
+			}
+			if !instance.Started() {
+				continue
+			}
+			// If another process deleted the disk record and the backing
+			// session is gone, don't resurrect it from stale TUI memory.
+			if !diskTitles[instance.Title] && !instance.TmuxAlive() {
+				continue
 			}
 			d := instance.ToInstanceData()
 			data = append(data, d)

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -343,6 +343,89 @@ func TestRepoSaveDoesNotResurrectDeadDiskMissingInstance(t *testing.T) {
 	assert.Empty(t, result, "stale TUI memory must not recreate a deleted instance record")
 }
 
+// TestRepoSaveDropsLoadingFromMemory is a regression test for
+// sachiniyer/agent-factory#551. When the TUI quits while a session is
+// still in Loading status (worktree not yet populated), the in-memory
+// instance must not be persisted to disk. FromInstanceData cannot
+// restore Loading entries, and the daemon's title-collision check would
+// otherwise see the orphan and reject any future session with the same
+// title.
+func TestRepoSaveDropsLoadingFromMemory(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	repoID := config.RepoIDFromRoot(repoPath)
+	ms := newMockStorage()
+
+	loading := makeInstance("in-flight", repoPath, false)
+	loading.Status = Loading
+	storage, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{loading})
+	require.NoError(t, err)
+
+	result := readDisk(t, ms, repoPath)
+	assert.Empty(t, result, "Loading instance must not be persisted to disk (#551)")
+}
+
+// TestRepoSaveReapsLegacyLoadingGhost verifies that an older binary's
+// orphaned Loading record on disk is reaped on the next TUI save, even
+// when the in-memory state does not include a same-titled instance. The
+// merge path used to preserve such entries as "external", which kept
+// the ghost alive across saves.
+func TestRepoSaveReapsLegacyLoadingGhost(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	repoID := config.RepoIDFromRoot(repoPath)
+	ms := newMockStorage()
+
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "ghost", Path: repoPath, Status: Loading},
+		{Title: "alive", Path: repoPath, Status: Running},
+	})
+
+	alive := makeInstance("alive", repoPath, true)
+	storage, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{alive})
+	require.NoError(t, err)
+
+	result := readDisk(t, ms, repoPath)
+	titles := make(map[string]bool, len(result))
+	for _, d := range result {
+		titles[d.Title] = true
+	}
+	assert.True(t, titles["alive"], "running instance should remain on disk")
+	assert.False(t, titles["ghost"], "legacy Loading ghost must be reaped on save (#551)")
+}
+
+// TestDaemonSaveReapsLegacyLoadingGhost mirrors the TUI check for the
+// daemon merge path: a Loading record on disk that the daemon did not
+// create should be dropped rather than preserved as an external entry.
+func TestDaemonSaveReapsLegacyLoadingGhost(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	ms := newMockStorage()
+
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "ghost", Path: repoPath, Status: Loading},
+		{Title: "alive", Path: repoPath, Status: Running},
+	})
+
+	alive := makeInstance("alive", repoPath, true)
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{alive})
+	require.NoError(t, err)
+
+	result := readDisk(t, ms, repoPath)
+	titles := make(map[string]bool, len(result))
+	for _, d := range result {
+		titles[d.Title] = true
+	}
+	assert.True(t, titles["alive"], "daemon-known instance should remain on disk")
+	assert.False(t, titles["ghost"], "legacy Loading ghost must be reaped by daemon save (#551)")
+}
+
 // TestCollectRepoRoots verifies that Storage.CollectRepoRoots returns the
 // unique set of repo roots from stored instances across ALL repos. This
 // underpins the fix for #265 (af reset must clean worktrees in every repo


### PR DESCRIPTION
## Summary
- TUI's `SaveInstances` was persisting in-flight `Loading` entries on quit; their empty worktree path makes them unrestorable, and the daemon's title-collision check read raw disk data and treated each ghost as a live reservation — permanently blocking same-titled session creation.
- Drops `Loading` instances from every save path (TUI `saveRepoInstances` and daemon `SaveInstances` merge), and reaps legacy `Loading` ghosts left on disk by older binaries.
- Hardens the daemon: `validateTitleAvailableLocked` ignores `Loading`-status disk records, and `appendInstanceData` overwrites a same-titled `Loading` ghost instead of rejecting. Real same-title conflicts still surface.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite, including new tests)
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)
- [x] New regression tests:
  - `TestRepoSaveDropsLoadingFromMemory` — TUI save excludes `Loading`.
  - `TestRepoSaveReapsLegacyLoadingGhost` / `TestDaemonSaveReapsLegacyLoadingGhost` — ghost `Loading` records on disk are reaped on next save.
  - `TestManagerCreateSessionIgnoresLoadingGhost` — daemon `CreateSession` succeeds against a seeded `Loading` ghost.

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)