### PR TITLE
fix(session/hooks): capture stderr from list_cmd so failures are debuggable (#561)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -152,13 +152,16 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 	return nil
 }
 
-// extractJSON finds the last JSON object in mixed output (stderr + stdout).
+// extractJSON finds the last JSON value in mixed output (stderr + stdout).
+// It matches either a JSON object (`{...}`) or a JSON array (`[...]`) so
+// list_cmd (array) and launch_cmd (object) can both recover their payload
+// from output that interleaves diagnostics on stderr with JSON on stdout.
 func extractJSON(output string) string {
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	// Search from the end for a line that looks like JSON
 	for idx := len(lines) - 1; idx >= 0; idx-- {
 		line := strings.TrimSpace(lines[idx])
-		if strings.HasPrefix(line, "{") {
+		if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "[") {
 			return line
 		}
 	}
@@ -263,12 +266,18 @@ func (b *HookBackend) SetPreviewSize(_ *Instance, _, _ int) error {
 }
 
 func (b *HookBackend) IsAlive(i *Instance) bool {
-	out, err := exec.Command(b.Hooks.ListCmd, "--json").Output()
+	out, err := exec.Command(b.Hooks.ListCmd, "--json").CombinedOutput()
 	if err != nil {
 		return false
 	}
+	// Mirror launch_cmd: list_cmd may write progress to stderr and JSON to
+	// stdout, so recover the JSON object from the combined output.
+	jsonStr := extractJSON(string(out))
+	if jsonStr == "" {
+		return false
+	}
 	var sessions []map[string]interface{}
-	if err := json.Unmarshal(out, &sessions); err != nil {
+	if err := json.Unmarshal([]byte(jsonStr), &sessions); err != nil {
 		return false
 	}
 	slug := hookNameForInstance(i)
@@ -295,14 +304,21 @@ func ListRemoteHookInstanceData(repoPath string, hooks config.RemoteHooks, now t
 		return nil, nil
 	}
 
-	out, err := exec.Command(hooks.ListCmd, "--json").Output()
+	out, err := exec.Command(hooks.ListCmd, "--json").CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("list_cmd failed: %w", err)
+		return nil, fmt.Errorf("list_cmd failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	// Mirror launch_cmd: list_cmd may write progress to stderr and JSON to
+	// stdout, so recover the JSON array from the combined output.
+	jsonStr := extractJSON(string(out))
+	if jsonStr == "" {
+		return nil, fmt.Errorf("list_cmd returned no JSON in output: %s", strings.TrimSpace(string(out)))
 	}
 
 	var listed []map[string]interface{}
-	if err := json.Unmarshal(out, &listed); err != nil {
-		return nil, fmt.Errorf("list_cmd returned invalid JSON: %w", err)
+	if err := json.Unmarshal([]byte(jsonStr), &listed); err != nil {
+		return nil, fmt.Errorf("list_cmd returned invalid JSON: %s: %w", jsonStr, err)
 	}
 
 	imported := make([]InstanceData, 0, len(listed))

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -1034,6 +1034,45 @@ func TestListRemoteHookInstanceDataImportsRunningSessions(t *testing.T) {
 	assert.Equal(t, "h1", data[0].RemoteMeta["host"])
 }
 
+// TestListRemoteHookInstanceDataIgnoresStderrDiagnostics covers the common
+// pattern of a list_cmd script that writes progress to stderr while emitting
+// JSON on stdout (e.g. an ssh-backed lister that logs "connecting…"). The
+// captured stderr must not corrupt the JSON we parse. See #561.
+func TestListRemoteHookInstanceDataIgnoresStderrDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	listCmd := writeScript(t, dir, "list.sh", `
+echo "connecting to remote host..." >&2
+echo "fetched 1 session" >&2
+echo '[{"name": "remote-one", "status": "running", "host": "h1"}]'
+`)
+
+	now := time.Now()
+	data, err := ListRemoteHookInstanceData("/repo/root", config.RemoteHooks{ListCmd: listCmd}, now)
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+	assert.Equal(t, "remote-one", data[0].Title)
+	assert.Equal(t, "remote-one", data[0].RemoteMeta["name"])
+	assert.Equal(t, "h1", data[0].RemoteMeta["host"])
+}
+
+// TestListRemoteHookInstanceDataSurfacesStderrOnFailure verifies that when
+// list_cmd exits non-zero, the returned error includes the captured stderr
+// so the warning surfaced at app/sync.go and daemon/control.go is actually
+// diagnostic. Before #561 the error was just "list_cmd failed: exit status 1".
+func TestListRemoteHookInstanceDataSurfacesStderrOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	listCmd := writeScript(t, dir, "list.sh", `
+echo "ssh: could not resolve hostname remote.example.com" >&2
+exit 1
+`)
+
+	_, err := ListRemoteHookInstanceData("/repo/root", config.RemoteHooks{ListCmd: listCmd}, time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list_cmd failed")
+	assert.Contains(t, err.Error(), "ssh: could not resolve hostname remote.example.com",
+		"error must surface captured stderr so users can debug list_cmd failures (#561)")
+}
+
 func TestRunHookAttachWithDetachKey(t *testing.T) {
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("sh not available")


### PR DESCRIPTION
## Summary

Closes #561.

Both `list_cmd` callers in `session/backend_hook.go` used `exec.Command(...).Output()`, which captures stdout but **drops stderr**. When a user's `list_cmd` exited non-zero, the warning surfaced at `app/sync.go:352` and `daemon/control.go:800` was just `list_cmd failed: exit status 1` — no hint at *why*. Users had to instrument their own scripts to debug.

This change switches `IsAlive` and `ListRemoteHookInstanceData` to `CombinedOutput`, mirroring `launch_cmd`. The captured bytes are run through `extractJSON` so a JSON-on-stdout / progress-on-stderr script still parses, and on error the bytes are wrapped into the returned error so the warning becomes diagnostic. `extractJSON` is widened to accept JSON arrays as well as objects, since `list_cmd`'s payload is an array.

## Audit (per the adjacent-call-sites guideline)

Every `exec.Command(*Hooks.*)` / `exec.Command(hooks.*)` caller in `session/backend_hook.go`:

| Site | Capture | Stderr surfaced? |
| --- | --- | --- |
| `LaunchCmd` (line 124) | `CombinedOutput` | yes (pre-existing) |
| `DeleteCmd` (line 195) | `CombinedOutput` | yes (pre-existing) |
| `AttachCmd` (line 236, interactive) | PTY / runHookAttachWithDetach | N/A (interactive) |
| `AttachCmd` (line 426, preview) | piped stdout+stderr into ring buffer | N/A (captured into preview) |
| `ListCmd` — `IsAlive` (line 266) | `CombinedOutput` | yes (**this PR**) |
| `ListCmd` — `ListRemoteHookInstanceData` (line 298) | `CombinedOutput` | yes (**this PR**) |

No other hook call-site drops stderr.

## Before / after

`list_cmd` script:

```sh
#!/bin/sh
echo "ssh: could not resolve hostname remote.example.com" >&2
exit 1
```

**Before:**

```
WARNING: failed to list remote hook sessions: list_cmd failed: exit status 1
```

**After:**

```
WARNING: failed to list remote hook sessions: list_cmd failed: ssh: could not resolve hostname remote.example.com: exit status 1
```

## CI confirmations

Run locally on this branch:

- ``gofmt -l `find . -type f -name '*.go' -not -path './.claude/worktrees/*'` `` — clean
- `go build ./...` — clean
- `go test -race ./...` — all packages pass
- `golangci-lint run --timeout=3m --fast` — clean

## Test plan

- [x] New `TestListRemoteHookInstanceDataIgnoresStderrDiagnostics` — script writes progress on stderr + JSON on stdout, importer still parses the JSON array correctly.
- [x] New `TestListRemoteHookInstanceDataSurfacesStderrOnFailure` — script exits 1 with stderr text; returned error includes the stderr text so the warning surfaced upstream is actionable.
- [x] Existing `TestHookBackendIsAlive*` tests (success / not-found / failed-cmd / bad-JSON / stopped / multiple) all pass against the new `CombinedOutput` + `extractJSON` path.

— Captain Claude