### PR TITLE
fix(ui/preview): clear fallback flag when ResetToNormalMode sets real content (#577)

### DIFF
--- a/ui/preview.go
+++ b/ui/preview.go
@@ -26,6 +26,12 @@ type PreviewPane struct {
 	currentInstance *session.Instance
 }
 
+// previewState holds the rendered content of the preview pane.
+//
+// Invariant: fallback==true iff text is a centered fallback message
+// (loading / error / inactive). Writers MUST replace the whole struct
+// rather than mutate fields individually, so the two fields can never
+// disagree about which rendering branch String() should take (#577).
 type previewState struct {
 	// fallback is true if the preview pane is displaying fallback text
 	fallback bool
@@ -299,7 +305,10 @@ func (p *PreviewPane) ResetToNormalMode(instance *session.Instance) error {
 			}
 			return err
 		}
-		p.previewState.text = content
+		p.previewState = previewState{
+			fallback: false,
+			text:     content,
+		}
 	}
 
 	return nil

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -654,6 +654,82 @@ func TestPreviewUpdateContentSessionGoneRendersFallback(t *testing.T) {
 		"no ERROR log line on session-gone fallback path")
 }
 
+// TestResetToNormalModeDoesNotClearFallbackFlag is the #577 regression: when
+// ResetToNormalMode exits scroll mode it fetches fresh preview content and
+// writes it into previewState.text, but previously it left previewState.fallback
+// untouched. If the prior state was a fallback (e.g. Loading or Session no
+// longer running), the pane would then hold real terminal output while still
+// flagged as fallback, and a subsequent UpdateContent that errored before
+// reaching its own `fallback: false` assignment would render the captured
+// terminal output with centered fallback styling.
+func TestResetToNormalModeDoesNotClearFallbackFlag(t *testing.T) {
+	const expectedContent = "$ terminal output"
+
+	sessionCreated := false
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			cmdStr := cmd.String()
+			if strings.Contains(cmdStr, "has-session") {
+				if sessionCreated {
+					return nil
+				}
+				return fmt.Errorf("session does not exist")
+			}
+			if strings.Contains(cmdStr, "new-session") {
+				sessionCreated = true
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			cmdStr := cmd.String()
+			if strings.Contains(cmdStr, "capture-pane") {
+				return []byte(expectedContent), nil
+			}
+			return []byte(""), nil
+		},
+	}
+
+	setup := setupTestEnvironment(t, cmdExec)
+	defer setup.cleanupFn()
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+
+	// Simulate the precondition: pane is in a fallback state (e.g. Loading)
+	// and the user has entered scroll mode while it was still showing the
+	// fallback. setFallbackState is the production path that gets us into
+	// fallback==true; isScrolling/viewport mimic ScrollUp's side effects
+	// without depending on tmux capture-pane behavior here.
+	p.setFallbackState("Setting up workspace...")
+	require.True(t, p.previewState.fallback,
+		"precondition: fallback should be true after setFallbackState")
+	p.isScrolling = true
+	p.viewport.SetContent("ESC to exit scroll mode")
+
+	// Exit scroll mode. ResetToNormalMode pulls fresh content via Preview()
+	// (our mock returns expectedContent) and must clear the stale fallback
+	// flag at the same time, otherwise String() would render the captured
+	// terminal output with centered fallback styling.
+	require.NoError(t, p.ResetToNormalMode(setup.instance))
+
+	require.False(t, p.isScrolling, "should exit scroll mode")
+	require.Equal(t, expectedContent, p.previewState.text,
+		"text should be set to the captured preview content")
+	require.False(t, p.previewState.fallback,
+		"fallback must be cleared when ResetToNormalMode sets real content (#577)")
+
+	// And the rendered output must use the normal (left-aligned) branch,
+	// not the centered fallback layout — i.e. it must not be padded with
+	// the giant top-of-pane vertical whitespace that fallback rendering
+	// injects to vertically center its message.
+	rendered := p.String()
+	require.Contains(t, rendered, expectedContent,
+		"normal-mode render must contain the captured content")
+	require.False(t, strings.HasPrefix(rendered, "\n\n\n\n"),
+		"normal-mode render must not be vertically centered like fallback")
+}
+
 // TestPreviewSwitchInstanceResetsScroll is a regression test for issue #470:
 // when the user is in scroll mode on instance A and switches to instance B,
 // the preview pane must drop the scroll-mode viewport (which still holds A's


### PR DESCRIPTION
## Summary
- `PreviewPane.ResetToNormalMode` wrote new preview content into `previewState.text` but left `previewState.fallback` untouched. If the prior state was a fallback (e.g. `Loading`, `Session no longer running`), the pane then held captured tmux output while still flagged as fallback — and the next `UpdateContent` that errored before reaching its own `fallback: false` line would render that captured terminal output with the centered fallback layout (issue #577).
- Fix: replace the whole struct on the exit-scroll path (mirroring `UpdateContent`'s pattern at `ui/preview.go:124-127`) so the two fields can never disagree about which rendering branch `String()` should take.
- Document the `fallback ↔ text` invariant on `previewState` so future writers preserve it.

## Audit of adjacent call-sites
Grepped every `previewState` writer in `ui/preview.go`:
- `setFallbackState` (`ui/preview.go:50`) — full-struct replace ✅
- `UpdateContent` happy path (`ui/preview.go:124`) — full-struct replace ✅
- `ResetToNormalMode` (`ui/preview.go:302`) — was single-field; now full-struct replace ✅

Scroll-mode entry (`ScrollUp` / `ScrollDown`) does not touch `previewState` except via `setFallbackState` on `ErrSessionGone`, and `String()` ignores `previewState` while `isScrolling==true`, so any leftover staleness during scroll mode is unreachable.

`ui/terminal.go` `TerminalPane` uses three flat fields rather than a struct. `UpdateContent`'s happy path leaves `fallbackText` stale when flipping `fallback=false`, but `String()` reads `fallbackText` only inside the `if fallback {…}` branch — so the staleness never reaches the render. No bug, no change needed.

`ui/tabbed_window.go` doesn't own a `previewState`-like struct; it only delegates.

## Test plan
- [x] New regression test `TestResetToNormalModeDoesNotClearFallbackFlag` in `ui/preview_test.go` exercises the exact scenario: enter fallback (Loading), simulate scroll, call `ResetToNormalMode`, assert `fallback==false` and that `String()` does not render with fallback's vertically centered layout.
- [x] Existing preview tests (`TestPreviewScrolling`, `TestPreviewResetToNormalModeNilInstance`, `TestPreviewContentWithoutScrolling`, `TestPreviewSwitchInstanceResetsScroll`, `TestPreviewUpdateContentSessionGoneRendersFallback`, `TestPreviewFallbackHeightNoDoubleCounting`) pass.
- [x] `go test -race ./...` clean (a single flaky integration test for daemon socket lifecycle reproduced and passed on re-run; unrelated to this change).
- [x] `golangci-lint run --timeout=3m --fast` clean.
- [x] `gofmt -l .` clean.
- [x] `go build ./...` clean.

Closes #577.

Co-Authored-By: Captain Claude <noreply@anthropic.com>