### PR TITLE
fix(session/hooks): bracket-count extractJSON so multi-line / pretty-printed JSON parses (#572)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -129,7 +129,7 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 
 	// The script writes progress to stderr and JSON to stdout.
 	// With CombinedOutput we get both mixed together. Try to find
-	// the JSON object in the output (last line starting with '{').
+	// the first complete top-level JSON value in the output.
 	jsonStr := extractJSON(string(out))
 	if jsonStr == "" {
 		return fmt.Errorf("launch_cmd returned no JSON in output: %s", string(out))
@@ -152,17 +152,52 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 	return nil
 }
 
-// extractJSON finds the last JSON value in mixed output (stderr + stdout).
-// It matches either a JSON object (`{...}`) or a JSON array (`[...]`) so
-// list_cmd (array) and launch_cmd (object) can both recover their payload
-// from output that interleaves diagnostics on stderr with JSON on stdout.
+// extractJSON finds the first complete top-level JSON value (object or array)
+// in output, ignoring text outside JSON delimiters. It handles pretty-printed
+// / multi-line JSON and stderr interleaving around (but not inside) the JSON
+// payload. Returns empty string if no valid JSON value is found.
 func extractJSON(output string) string {
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-	// Search from the end for a line that looks like JSON
-	for idx := len(lines) - 1; idx >= 0; idx-- {
-		line := strings.TrimSpace(lines[idx])
-		if strings.HasPrefix(line, "{") || strings.HasPrefix(line, "[") {
-			return line
+	for i := 0; i < len(output); i++ {
+		if output[i] != '{' && output[i] != '[' {
+			continue
+		}
+
+		var depth int
+		inString := false
+		escape := false
+
+		for j := i; j < len(output); j++ {
+			c := output[j]
+
+			if escape {
+				escape = false
+				continue
+			}
+			if c == '\\' && inString {
+				escape = true
+				continue
+			}
+			if c == '"' {
+				inString = !inString
+				continue
+			}
+
+			if !inString {
+				if c == '{' || c == '[' {
+					depth++
+				}
+				if c == '}' || c == ']' {
+					depth--
+					if depth == 0 {
+						candidate := output[i : j+1]
+						var test interface{}
+						if json.Unmarshal([]byte(candidate), &test) == nil {
+							return candidate
+						}
+						break
+					}
+				}
+			}
 		}
 	}
 	return ""

--- a/session/backend_hook_test.go
+++ b/session/backend_hook_test.go
@@ -1,0 +1,118 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExtractJSON exercises the bracket-counting parser added for #572,
+// which replaced the previous line-based heuristic. The parser must
+// recover the first complete top-level JSON value from mixed
+// stderr+stdout output, including pretty-printed (multi-line) payloads
+// produced by tools like `jq .` and `python3 -m json.tool`.
+func TestExtractJSON(t *testing.T) {
+	prettyObject := `{
+  "name": "remote-one",
+  "status": "running",
+  "host": "h1"
+}`
+
+	prettyArray := `[
+  {
+    "name": "remote-one",
+    "status": "running"
+  },
+  {
+    "name": "remote-two",
+    "status": "stopped"
+  }
+]`
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "pretty-printed object",
+			in:   prettyObject,
+			want: prettyObject,
+		},
+		{
+			name: "pretty-printed array",
+			in:   prettyArray,
+			want: prettyArray,
+		},
+		{
+			name: "stderr progress before multi-line array",
+			in:   "connecting to remote host...\nfetched 2 sessions\n" + prettyArray,
+			want: prettyArray,
+		},
+		{
+			name: "noise around (not inside) JSON",
+			in:   "begin output\n" + prettyObject + "\nend of output\n",
+			want: prettyObject,
+		},
+		{
+			name: "escaped quotes inside string",
+			in:   `{"msg": "she said \"hi\""}`,
+			want: `{"msg": "she said \"hi\""}`,
+		},
+		{
+			name: "nested arrays inside object",
+			in:   `{"items": [1, 2, [3, 4]]}`,
+			want: `{"items": [1, 2, [3, 4]]}`,
+		},
+		{
+			name: "top-level string is not a match",
+			in:   `"abc"`,
+			want: "",
+		},
+		{
+			name: "empty input",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "no JSON at all",
+			in:   "just some log lines\nnothing structured here\n",
+			want: "",
+		},
+		{
+			name: "single-line object regression",
+			in:   `{"name": "remote-one", "status": "running"}`,
+			want: `{"name": "remote-one", "status": "running"}`,
+		},
+		{
+			name: "single-line array regression",
+			in:   `[{"name": "remote-one", "status": "running"}]`,
+			want: `[{"name": "remote-one", "status": "running"}]`,
+		},
+		{
+			name: "brace inside string does not unbalance",
+			in:   `{"text": "this } is not a close"}`,
+			want: `{"text": "this } is not a close"}`,
+		},
+		{
+			name: "bracket inside string does not unbalance",
+			in:   `{"text": "this ] is not a close"}`,
+			want: `{"text": "this ] is not a close"}`,
+		},
+		{
+			name: "skips invalid candidate then finds valid one",
+			// First `{` opens an invalid candidate (unbalanced after `:`); the
+			// parser must keep scanning until it finds a complete value.
+			in:   "noise { not json } more\n" + `{"name": "remote-one"}`,
+			want: `{"name": "remote-one"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractJSON(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`session.extractJSON` was line-based: it split combined hook output on `\n`,
scanned backward for a line starting with `{` or `[`, and returned that
single line. For pretty-printed JSON — multi-line `jq .` or `python3 -m
json.tool` output — it returned just the closing line (e.g. `]` or `}`),
which then failed `json.Unmarshal` in every caller. With mixed
stderr+stdout containing a multi-line array of objects, it could also
return an inner object line instead of the top-level array.

## New contract
`extractJSON` now finds the **first complete top-level JSON value** in
output, ignoring text outside JSON delimiters:

1. Scan forward for the first `{` or `[`.
2. Track depth, respecting strings (and `\\`-escapes inside strings) so
   braces/brackets inside string literals don't unbalance the count.
3. At `depth == 0`, validate the candidate substring with
   `json.Unmarshal`. If it parses, return it; otherwise keep scanning.
4. Return `""` if nothing valid is found.

This handles pretty-printed payloads and stderr noise **around** (not
inside) the JSON.

## Caller audit — first-valid vs last-line semantics
All three callers want the JSON payload the script emitted, not whatever
happens to be on the last line:

- `HookBackend.Start` — `launch_cmd` returns an object describing the
  newly allocated remote session.
- `HookBackend.IsAlive` — `list_cmd` returns an array of sessions
  (introduced in #562).
- `ListRemoteHookInstanceData` — `list_cmd` returns the same array
  (introduced in #562).

Issue #572 explicitly argues for first-valid: hook scripts emit one
top-level JSON value as their structured output; anything before or
after is stderr noise. The existing #562 stderr-diagnostics test
(`TestListRemoteHookInstanceDataIgnoresStderrDiagnostics`) passes
unchanged under the new semantics — the stderr lines come before the
JSON, so first-valid and last-line-prefix-match agree there.

## Test coverage (`session/backend_hook_test.go`, new file)
- Pretty-printed object (multi-line, indented)
- Pretty-printed array (multi-line)
- Stderr progress lines before a multi-line array
- Noise around (not inside) JSON
- Escaped quotes inside a string: `{"msg": "she said \"hi\""}`
- Nested arrays inside objects: `{"items": [1, 2, [3, 4]]}`
- Top-level string `"abc"` → empty (only objects/arrays match)
- Empty input → empty
- No JSON at all → empty
- Single-line object/array regressions
- Braces and brackets inside string literals do not unbalance the parser
- Skips a malformed `{ not json }` candidate and finds the next valid one

Existing #562 tests (`TestListRemoteHookInstanceDataImportsRunningSessions`,
`TestListRemoteHookInstanceDataIgnoresStderrDiagnostics`,
`TestListRemoteHookInstanceDataSurfacesStderrOnFailure`) all still pass.

## Verification
- `gofmt -l .` → clean
- `go build ./...` → clean
- `golangci-lint run --timeout=3m --fast` → clean
- `go test -race ./...` → all packages green

Fixes #572

Co-Authored-By: Captain Claude <noreply@anthropic.com>