### PR TITLE
fix(ui/err): use xansi.Strip so OSC sequences don't break width math (#565)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/creack/pty v1.1.24
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6
@@ -23,7 +24,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
 	github.com/charmbracelet/colorprofile v0.3.2 // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b // indirect
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20260422141420-a6cbdff8a7e2 // indirect

--- a/ui/err.go
+++ b/ui/err.go
@@ -1,21 +1,12 @@
 package ui
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 )
-
-// ansiEscapeRegex matches CSI escape sequences (e.g. SGR colors) so they can
-// be stripped before width-based truncation. Truncating a string that still
-// contains escape sequences risks cutting one mid-byte, leaking visible
-// garbage like "[31m" into the rendered output (issue #525). The "?" prefix
-// covers private-mode sequences like \x1b[?25l (cursor hide) which would
-// otherwise be width-counted as visible runes and trigger premature truncation
-// (issue #552).
-var ansiEscapeRegex = regexp.MustCompile(`\x1b\[[?0-9;]*[a-zA-Z]`)
 
 type ErrBox struct {
 	height, width int
@@ -52,9 +43,12 @@ func (e *ErrBox) String() string {
 	if e.err != nil {
 		err = e.err.Error()
 		// Agent pane output can reach us via wrapped errors (see #502) and
-		// carry ANSI escape sequences. Strip them so width math and the
-		// final Truncate operate on plain text only.
-		err = ansiEscapeRegex.ReplaceAllString(err, "")
+		// carry ANSI escape sequences — CSI (SGR colors, private-mode like
+		// \x1b[?25l) and OSC (e.g. the OSC 8 hyperlink protocol from #565).
+		// Use xansi.Strip so width math and the final Truncate operate on
+		// plain text only — a bespoke regex repeatedly missed variants
+		// (#525 → #552 → #565).
+		err = xansi.Strip(err)
 		lines := strings.Split(err, "\n")
 		err = strings.Join(lines, "//")
 		if runewidth.StringWidth(err) > e.width {

--- a/ui/err_test.go
+++ b/ui/err_test.go
@@ -96,34 +96,78 @@ func TestErrBoxWithoutANSIUnchanged(t *testing.T) {
 	}
 }
 
-// TestErrBoxStripsPrivateModeCSI is a regression test for issue #552. The
-// original strip regex only allowed [0-9;] in the parameter byte slot, so
-// private-mode sequences like \x1b[?25l (cursor hide/show), \x1b[?1049h
-// (alt-screen), and \x1b[?7l (autowrap off) leaked through. runewidth then
-// counted "?25l" etc. as visible runes and the box truncated prematurely.
-func TestErrBoxStripsPrivateModeCSI(t *testing.T) {
-	payload := "agent crashed"
-	// Mix display SGR with several private-mode sequences.
-	raw := "\x1b[?25l\x1b[?1049h\x1b[?7l\x1b[31m" + payload + "\x1b[0m\x1b[?25h\x1b[?1049l"
-	stripped := ansiEscapeRegex.ReplaceAllString(raw, "")
-	if stripped != payload {
-		t.Fatalf("private-mode CSI not stripped: got %q want %q", stripped, payload)
-	}
-	if got := runewidth.StringWidth(stripped); got != runewidth.StringWidth(payload) {
-		t.Errorf("width after strip = %d, want %d", got, runewidth.StringWidth(payload))
+// TestErrBoxStripsANSIVariants is a regression matrix covering every ANSI
+// variant the strip pass has had to learn the hard way:
+//   - Plain CSI / SGR (#525, original bug — partial CSI bytes leaked).
+//   - Private-mode CSI like \x1b[?25l (#552 — the bespoke regex's [0-9;]
+//     parameter class didn't allow the "?" prefix, so these inflated width).
+//   - OSC 8 hyperlinks terminated by ST (\x1b\\) (#565 — the bespoke regex
+//     never matched \x1b] at all, so OSC payload counted as visible runes).
+//   - OSC terminated by BEL (\x07), the legacy xterm terminator that some
+//     emitters (e.g. iTerm OSC 1337) still use instead of ST.
+//
+// Switching to xansi.Strip handles all of these uniformly; this test pins
+// that behavior so the next exotic variant doesn't require another fix-up.
+func TestErrBoxStripsANSIVariants(t *testing.T) {
+	const payload = "agent crashed"
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "plain_csi_sgr",
+			raw:  "\x1b[31m" + payload + "\x1b[0m",
+		},
+		{
+			name: "private_mode_csi",
+			raw:  "\x1b[?25l\x1b[?1049h\x1b[?7l\x1b[31m" + payload + "\x1b[0m\x1b[?25h\x1b[?1049l",
+		},
+		{
+			name: "osc8_hyperlink_st_terminated",
+			// OSC 8 ; params ; URI ST <link text> OSC 8 ;; ST
+			raw: "\x1b]8;;https://example.com/very/long/url/that/blows/up/width/math\x1b\\" + payload + "\x1b]8;;\x1b\\",
+		},
+		{
+			name: "osc_bel_terminated",
+			// OSC 0 (set window title) terminated by BEL. The title payload
+			// must not be width-counted.
+			raw: "\x1b]0;a title that is much longer than the payload\x07" + payload,
+		},
 	}
 
-	// End-to-end: a wide-enough box must render the full payload without
-	// truncation now that private-mode bytes no longer inflate the width.
-	e := NewErrBox()
-	e.SetSize(80, 1)
-	e.SetError(errors.New(raw))
-	out := e.String()
-	if !strings.Contains(stripANSI(out), payload) {
-		t.Errorf("payload missing from rendered output: %q", out)
-	}
-	if strings.Contains(out, "?25l") || strings.Contains(out, "?1049h") || strings.Contains(out, "?7l") {
-		t.Errorf("private-mode sequence leaked into output: %q", out)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Box wide enough to fit the visible payload but NOT wide enough
+			// to fit any inflated count from leaked escape bytes. This is
+			// the condition that historically tripped truncation.
+			width := runewidth.StringWidth(payload) + 4
+			e := NewErrBox()
+			e.SetSize(width, 1)
+			e.SetError(errors.New(tc.raw))
+
+			out := e.String()
+
+			// 1. Visible payload survives intact (no premature truncation).
+			if !strings.Contains(stripANSI(out), payload) {
+				t.Errorf("payload missing from rendered output: %q", out)
+			}
+			// 2. No escape-sequence carcass leaks as visible characters.
+			//    Spot-check signature fragments from each variant.
+			for _, leak := range []string{"[31m", "[?25l", "[?1049h", "8;;https://", "0;a title"} {
+				if strings.Contains(out, leak) {
+					t.Errorf("escape fragment %q leaked into output: %q", leak, out)
+				}
+			}
+			// 3. The rendered line width must equal the visible payload
+			//    width (within the box). If OSC/private-mode bytes had been
+			//    width-counted, this would fail with an inflated width.
+			for _, line := range strings.Split(out, "\n") {
+				if got := runewidth.StringWidth(stripANSI(line)); got > width {
+					t.Errorf("rendered line width %d exceeds container width %d (line=%q)", got, width, line)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- `ErrBox`'s ANSI strip pass used a hand-rolled regex (`\x1b\[[?0-9;]*[a-zA-Z]`) that only matched CSI. OSC sequences (`\x1b]…`) — ANSI hyperlinks (OSC 8), window titles (OSC 0/2), iTerm payloads (OSC 1337) — passed through, so `runewidth.StringWidth` counted URL/title payloads as visible characters and the box truncated/centered using wildly inflated widths. On terminals without OSC support, the raw markers leaked as visible garbage. Closes #565.
- Replace the bespoke regex with `xansi.Strip` from `github.com/charmbracelet/x/ansi`, which is already pulled in indirectly and used in `ui/overlay`. It handles CSI, OSC (ST- and BEL-terminated), DCS, and the other ESC-introduced families uniformly. Promote `charmbracelet/x/ansi` from indirect to direct in `go.mod`.
- This is the third "bespoke regex missed an ANSI variant" miss in `ui/err.go` (#525 → #552 → #565). Switching to a curated library means the next exotic variant won't need another patch in this file.

## Why a library swap and not "just add `\x1b\]…` to the regex"
The previous CSI-only regex was already a hardened patch (#552 added the `?` for private-mode). Each new variant — DCS (`\x1bP…`), APC (`\x1b_…`), 8-bit C1 forms (`\x9b`/`\x9d`), undocumented terminator combinations — would require another fix-up. `xansi.Strip` is the maintained reference for that grammar; this is exactly the kind of "use the library" call where the cost is one dependency promotion (already a transitive dep) and the payoff is closing the regex-miss class.

## Tests
- Replaced the per-variant test with a regression matrix in `TestErrBoxStripsANSIVariants` that drives `ErrBox.String` end-to-end for:
  - Plain CSI/SGR (regression guard for #525).
  - Private-mode CSI like `\x1b[?25l`, `\x1b[?1049h`, `\x1b[?7l` (regression guard for #552).
  - OSC 8 hyperlink with ST (`\x1b\`) terminator (regression guard for #565).
  - OSC terminated by BEL (`\x07`), the legacy xterm form some emitters still use.
- Each case picks a width that's wide enough for the visible payload but narrow enough to be tripped by even a few leaked escape bytes — the historical failure mode. The test asserts: visible payload survives, no escape-fragment signature leaks, and rendered line width stays inside the container.
- Existing tests (`TestErrBoxNarrowWidthDoesNotOverflow` for #337, `TestErrBoxStripsANSIBeforeTruncating` for #525 end-to-end, `TestErrBoxWithoutANSIUnchanged` for plain text) all kept and still pass.

## Adjacent-site audit
Per the recurring pattern in this repo (issues #525 → #552 → #565 all in `ui/err.go`), I grepped for any other site that combines a bespoke ANSI strip with downstream `runewidth` width math:

| Site | Status | Note |
| --- | --- | --- |
| `ui/err.go` | **fixed by this PR** | the bug |
| `ui/overlay/overlay.go` | out of scope | uses regexes for color *replacement* (fade effect), not stripping; width math uses `muesli/ansi.PrintableRuneWidth` and `xansi.TruncateLeft`, both ANSI-aware |
| `ui/sidebar.go:539` | out of scope | `runewidth.StringWidth(text)` on `arrow + label` — literal strings, no ANSI source |
| `ui/list.go:141/176/202` | out of scope | width on user-typed instance title / branch / PR title — not ANSI-bearing |
| `ui/menu.go` | out of scope | renders via lipgloss, no width math on ANSI-bearing strings |
| `ui/preview.go` | out of scope | ANSI-rich content goes to viewport/lipgloss; no bespoke strip or width math |
| `ui/terminal.go` | out of scope | same — lipgloss/viewport handle ANSI |
| `ui/tabbed_window.go` | out of scope | width math on plain tab labels and frame chrome |
| `app/handle_input.go:115/131` | out of scope | width on text-entry title input, no ANSI |

`ui/err.go` is the only site that combined a hand-rolled strip with downstream `runewidth` math. Nothing else needs converting.

## Test plan
- [x] `gofmt -l .` — no output
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go build ./...` — clean
- [x] `go test -race ./...` — all packages pass, including the new `TestErrBoxStripsANSIVariants/{plain_csi_sgr,private_mode_csi,osc8_hyperlink_st_terminated,osc_bel_terminated}` subtests
- [x] `./dev-install.sh` — built and installed; `af version` runs

Co-Authored-By: Captain Claude <noreply@anthropic.com>