### PR TITLE
fix(session): synchronize Instance.AutoYes (and audited adjacent fields) under instance mutex (#563)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -166,7 +166,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repoID string) *
 	// Add loaded instances to the sidebar
 	for _, instance := range instances {
 		h.sidebar.AddInstance(instance)()
-		instance.AutoYes = autoYes
+		instance.SetAutoYes(autoYes)
 	}
 
 	h.importRemoteHookSessions()
@@ -379,7 +379,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !started.IsRemote() {
 			m.sidebar.RegisterRepoForInstance(started)
 		}
-		started.AutoYes = m.autoYes
+		started.SetAutoYes(m.autoYes)
 
 		if !userStillWatching {
 			// User moved on — update status silently and keep their current

--- a/app/sync.go
+++ b/app/sync.go
@@ -213,7 +213,7 @@ func (m *home) mergePendingInstances() int {
 		}
 
 		m.sidebar.AddInstance(pendingInstance)()
-		pendingInstance.AutoYes = m.autoYes
+		pendingInstance.SetAutoYes(m.autoYes)
 		sidebarTitles[data.Title] = true
 		mergedCount++
 	}
@@ -275,7 +275,7 @@ func (m *home) refreshExternalInstances() bool {
 				continue
 			}
 			m.sidebar.AddInstance(inst)()
-			inst.AutoYes = m.autoYes
+			inst.SetAutoYes(m.autoYes)
 			changed = true
 		}
 	}
@@ -376,7 +376,7 @@ func (m *home) importRemoteHookSessions() int {
 			continue
 		}
 		m.sidebar.AddInstance(inst)()
-		inst.AutoYes = m.autoYes
+		inst.SetAutoYes(m.autoYes)
 		existingTitles[data.Title] = true
 		existingHookNames[name] = true
 		imported++

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -141,7 +141,7 @@ func TestSessionAutoYesAuthoritative(t *testing.T) {
 			instances := []*session.Instance{{Title: "t", AutoYes: tc.persistedValue}}
 			autoYes := tc.sessionAutoYes
 			for _, instance := range instances {
-				instance.AutoYes = autoYes
+				instance.SetAutoYes(autoYes)
 			}
 			if instances[0].AutoYes != tc.want {
 				t.Fatalf("instance.AutoYes = %v; want %v", instances[0].AutoYes, tc.want)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -142,7 +142,7 @@ func refreshDaemonInstances(existing map[string]*session.Instance) (map[string]*
 				continue
 			}
 			// Assume AutoYes is true if the daemon is running.
-			instance.AutoYes = true
+			instance.SetAutoYes(true)
 			next[key] = instance
 		}
 	}

--- a/session/autoyes_race_test.go
+++ b/session/autoyes_race_test.go
@@ -1,0 +1,72 @@
+package session
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestAutoYesDataRace is the regression test for issue #563.
+//
+// PR #560 moved the metadata tick onto a background goroutine. That goroutine
+// calls LocalBackend.TapEnter, which reads Instance.AutoYes under i.mu.RLock.
+// Several event-loop call sites (app/app.go, app/sync.go, daemon/daemon.go)
+// previously wrote i.AutoYes directly with no mutex, producing a real data
+// race that `go test -race` would flag.
+//
+// The fix introduces Instance.SetAutoYes so every writer goes through the
+// instance mutex. This test exercises a tight concurrent write/read loop
+// against the same instance; under `go test -race -run TestAutoYesDataRace
+// ./session/...` it must complete cleanly with the fix in place, and would
+// have tripped the race detector against the pre-fix code that wrote
+// `i.AutoYes = ...` directly.
+func TestAutoYesDataRace(t *testing.T) {
+	inst := &Instance{Title: "race"}
+	inst.SetBackend(&LocalBackend{})
+	inst.SetStartedForTest(true)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writer: mirrors the event-loop call sites (app/app.go,
+	// app/sync.go, daemon/daemon.go) that flip AutoYes after the
+	// instance has been added to the sidebar.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		toggle := false
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			inst.SetAutoYes(toggle)
+			toggle = !toggle
+		}
+	}()
+
+	// Reader: mirrors the metadata-tick background goroutine introduced
+	// by PR #560, which sweeps instances and calls TapEnter on each one.
+	// TapEnter reads i.AutoYes under i.mu.RLock — that read is what the
+	// race detector flagged against the pre-fix unsynchronized writes.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			inst.TapEnter()
+		}
+	}()
+
+	// 200ms is plenty for the race detector to observe a violation if
+	// any read/write pair is unsynchronized; in practice the failure
+	// triggers within microseconds.
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -298,6 +298,17 @@ func (i *Instance) SetStatus(status Status) {
 	i.Status = status
 }
 
+// SetAutoYes sets the AutoYes flag under the instance mutex. Writers must use
+// this rather than assigning i.AutoYes directly: TapEnter runs from the
+// metadata-tick background goroutine and reads AutoYes under i.mu.RLock, so
+// any unsynchronized write produces a data race (issue #563, regression from
+// PR #560 which moved the tick off the bubbletea event loop).
+func (i *Instance) SetAutoYes(autoYes bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.AutoYes = autoYes
+}
+
 // GetBranch returns the current worktree branch name under the Instance's
 // mutex. Readers that run from goroutines other than the one mutating the
 // instance (notably the bubbletea renderer) must use this accessor rather


### PR DESCRIPTION
Closes #563.

## Summary

PR #560 (`fix(app): make post-detach instances pane paint snappy`) moved the
`tickUpdateMetadataMessage` handler off the bubbletea event loop and onto a
background goroutine (`runMetadataTickCmd`). That goroutine ends up inside
`LocalBackend.TapEnter`, which reads `Instance.AutoYes` under `i.mu.RLock`:

```go
// session/backend_local.go:317
func (b *LocalBackend) TapEnter(i *Instance) {
    i.mu.RLock()
    s := i.started
    ts := i.tmuxSession
    autoYes := i.AutoYes // <-- read under RLock
    i.mu.RUnlock()
    ...
}
```

The event-loop writers, however, were still assigning `i.AutoYes` directly
with no mutex. `go test -race` reliably flags this as a data race between the
unsynchronized write and the `RLock`-protected read — Go's memory model
defines it as undefined behavior (stale reads, reordering, missed Enter
presses).

This PR adds `Instance.SetAutoYes(autoYes bool)` (which takes `i.mu.Lock`)
and routes every writer through it. A new regression test reproduces the race
and would have caught the bug.

## Adjacent-fields audit

Per `CLAUDE.md` (and prior feedback), I grepped every field on
`session.Instance` for the same write-without-the-lock-that-readers-use
pattern. Verdicts:

| Field | Status | Notes |
|---|---|---|
| `AutoYes` | **🔴 fixed this PR** | Was written unlocked at 6 call sites (`app/app.go`×2, `app/sync.go`×3, `daemon/daemon.go`); read under `RLock` in `LocalBackend.TapEnter` and `ToInstanceData`. Now routed through `SetAutoYes`. |
| `Status` | ✅ all-writes-locked | `SetStatus` is the only mutator; reads via `GetStatus`/`ToInstanceData` under `RLock`. |
| `started` | ✅ all-writes-locked | Written under `Lock` in `Start`/`Kill`/`StartWithExistingWorktree`/`SetStartedForTest`. |
| `Branch` | ✅ all-writes-locked | Writes at `backend_local.go:47`, `backend_hook.go:146`, `instance.go:346` all under `Lock`. |
| `tmuxSession` | ✅ production locked | All production writes (Start/Kill paths) under `Lock`. `SetTmuxSession` is a test-only seam called pre-start before any background goroutine exists. |
| `gitWorktree` | ✅ all-writes-locked | Production writes and `SetGitWorktreeForTest` all under `Lock`. |
| `remoteMeta` | ✅ all-writes-locked | Only mutated in `HookBackend.Start`/`Kill` under `Lock`. |
| `prInfo` / `prInfoLastFetched` | ✅ all-writes-locked | `SetPRInfo`, `MarkPRInfoFetched` both take `Lock`. |
| `Title` | ✅ write-only-pre-start | `SetTitle` takes `Lock` and explicitly errors after `started==true`; all other writes are init-only. Effectively immutable once a background goroutine could observe it. |
| `Path` | ✅ write-only-from-init | Set in `NewInstance`/`FromInstanceData`, never mutated. |
| `Program` | ✅ write-only-pre-start | Only mutator is `app/handle_input.go:67` during the naming flow, before `Start` is invoked; the goroutine-spawn establishes happens-before for the subsequent unlocked reads in `LocalBackend.Start`/`CheckAndHandleTrustPrompt`. |
| `Height` / `Width` / `CreatedAt` / `UpdatedAt` | ✅ write-only-from-init | Never mutated post-construction. (`UpdatedAt` snapshot in `ToInstanceData` uses `time.Now()` directly, not `i.UpdatedAt`.) |
| `backend` | ✅ write-only-pre-start | Set in `NewInstance`/`FromInstanceData`. `SetBackend` is a test-only seam used before goroutines are spawned. |
| `Prompt` | ➖ out of scope | Declared on the struct but never read or written by any production or test code. |

Net: `AutoYes` was the only field with a production unlocked-write racing a
locked-read. Everything else is either correctly mutex-protected or
effectively immutable by the time the background tick can observe it.

## Race-detector output

### Before (synthetic — confirmed locally by stubbing `SetAutoYes` to write without `Lock`)

```
==================
WARNING: DATA RACE
Write at 0x00c0001fe760 by goroutine 9:
  session.(*Instance).SetAutoYes()
      session/instance.go:308
  session.TestAutoYesDataRace.func1()
      session/autoyes_race_test.go:44

Previous read at 0x00c0001fe760 by goroutine 10:
  session.(*LocalBackend).TapEnter()
      session/backend_local.go:321
  session.(*Instance).TapEnter()
      session/instance.go:398
  session.TestAutoYesDataRace.func2()
      session/autoyes_race_test.go:62
==================
--- FAIL: TestAutoYesDataRace (0.20s)
    testing.go:1490: race detected during execution of test
FAIL
```

### After (this PR)

```
$ go test -race -count=1 -run TestAutoYesDataRace ./session/...
ok   github.com/sachiniyer/agent-factory/session  1.222s
```

## CI gate confirmations

- ✅ `gofmt -l .` (excluding `.claude/worktrees/`) — no output
- ✅ `go build ./...` — clean
- ✅ `golangci-lint run --timeout=3m --fast` — clean
- ✅ `go test -race -count=1 ./...` — all 14 packages pass with the race detector on

## Test plan

- [x] `TestAutoYesDataRace` passes under `-race` with the fix
- [x] `TestAutoYesDataRace` fails under `-race` when `SetAutoYes` is reverted to an unsynchronized write (verified locally)
- [x] Full `go test -race ./...` is green
- [x] Existing `TestSessionAutoYesAuthoritative` still passes after routing the test through `SetAutoYes`

Signed off by Captain Claude.