### PR TITLE
fix(ui/overlay): treat SGR 48/38 as background/foreground so extended colors aren't re-faded as fg (#564)

### DIFF
--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -88,7 +88,10 @@ func PlaceOverlay(
 					continue
 				}
 				hasFadeableParam = true
-				if code == 7 || (code >= 40 && code <= 47) || (code >= 100 && code <= 107) {
+				// SGR 48 catches the extended-bg replacement (\x1b[48;5;236m)
+				// that step 1 emits — without it, the loop misclassifies our
+				// own rewrite as foreground and re-fades it to fg gray (#564).
+				if code == 7 || code == 48 || (code >= 40 && code <= 47) || (code >= 100 && code <= 107) {
 					isBg = true
 				}
 			}

--- a/ui/overlay/overlay_test.go
+++ b/ui/overlay/overlay_test.go
@@ -180,3 +180,28 @@ func TestPlaceOverlayMultiParamBackgroundFade(t *testing.T) {
 		t.Fatalf("expected multi-param bg code to be faded to bg gray, got: %q", result)
 	}
 }
+
+// TestPlaceOverlayExtendedBackgroundFade is a regression guard for #564:
+// step 1 of PlaceOverlay rewrites \x1b[48;5;Nm to \x1b[48;5;236m, but
+// simpleColorRegex then re-matched that rewrite and (because SGR 48 was
+// missing from the background detector) re-faded it as foreground gray.
+func TestPlaceOverlayExtendedBackgroundFade(t *testing.T) {
+	input := "\x1b[48;5;196mred-bg\x1b[0m"
+	result := PlaceOverlay(0, 0, "XX", input, false)
+
+	if strings.Contains(result, "\x1b[38;5;240m") && strings.Contains(input, "\x1b[48;5;") {
+		t.Fatalf("BUG CONFIRMED: extended background was faded as foreground.\nInput had 48;5 (bg), output has 38;5 (fg)")
+	}
+}
+
+// TestPlaceOverlayTrueColorBackgroundFade is the true-color (24-bit, 48;2;R;G;B)
+// counterpart to TestPlaceOverlayExtendedBackgroundFade — same #564 bug,
+// different input shape.
+func TestPlaceOverlayTrueColorBackgroundFade(t *testing.T) {
+	input := "\x1b[48;2;255;0;0mtrue-color-red-bg\x1b[0m"
+	result := PlaceOverlay(0, 0, "XX", input, false)
+
+	if strings.Contains(result, "\x1b[38;5;240m") && strings.Contains(input, "\x1b[48;2;") {
+		t.Fatalf("BUG CONFIRMED: true-color background was faded as foreground")
+	}
+}


### PR DESCRIPTION
## Summary

`PlaceOverlay` was correctly rewriting extended background ANSI codes
(`\x1b[48;5;Nm`, `\x1b[48;2;R;G;Bm`) to the faded `\x1b[48;5;236m` in
step 1, but `simpleColorRegex` then re-matched that very replacement and
the inner classifier — `code == 7 || (40..47) || (100..107)` — did not
recognize SGR `48` as background. The faded bg was reclassified as fg
and re-rewritten to `\x1b[38;5;240m`, so on 256-color and true-color
terminals overlay backgrounds rendered with foreground gray semantics.

Adds `code == 48` to the background branch. One-token behavioral diff.

Fixes #564.

## What changed

- `ui/overlay/overlay.go`: extend the bg classifier inside the
  `simpleColorRegex.ReplaceAllStringFunc` callback so the rewrite from
  step 1 is recognized when it re-enters step 3, with a short comment
  pointing at #564 for future readers.
- `ui/overlay/overlay_test.go`: add
  `TestPlaceOverlayExtendedBackgroundFade` (256-color) and
  `TestPlaceOverlayTrueColorBackgroundFade` (24-bit) verbatim from the
  Detail bot report. Both fail on master, pass on this branch.

## SGR-code coverage audit (`ui/overlay/overlay.go`)

Every code the classifier needs to decide on, and its status after this PR:

| Code(s) | Meaning | Status |
| --- | --- | --- |
| 7 | reverse video | handled — classified as bg (preserves swap semantics) |
| 30–37 | fg standard | handled — falls through to fg gray |
| 38 | extended fg (256/24-bit) | covered by step 2 (`fgColorRegex`), and the step-3 fall-through also returns fg gray for any leftover, so no explicit branch needed |
| 39 | default fg | falls through to fg gray (current behavior; out of scope) |
| 40–47 | bg standard | handled |
| **48** | **extended bg (256/24-bit)** | **fixed by this PR** — now classified as bg in step 3 |
| 49 | default bg | falls through to fg gray (current behavior; out of scope — would need a separate decision about whether default-bg should stay default-bg under fade) |
| 90–97 | fg bright | handled — falls through to fg gray |
| 100–107 | bg bright | handled |

Why `38` doesn't need an explicit branch in this PR:

- Step 2 (`fgColorRegex`) already rewrites every extended-fg sequence to
  `\x1b[38;5;240m` before step 3 runs.
- When that replacement re-enters `simpleColorRegex`, the loop sees codes
  `38`, `5`, `240` — none match the bg detector, `isBg` stays `false`,
  and the function returns `\x1b[38;5;240m` (idempotent, correct).
- Adding an explicit `isFg` flag would either be a no-op or would change
  behavior for non-color SGR codes like `\x1b[1m` (bold), which is out
  of scope for this bug.

Cross-package audit: grepped for `(code >= 40 && code <= 47)`,
`isBg`, `simpleColorRegex`, `bgColorRegex`, `fgColorRegex` across all
`.go` files. The SGR-classification loop lives only in
`ui/overlay/overlay.go`; nothing else duplicates the pattern.

## Verify (clean on this branch)

- `gofmt -l .` → no output
- `go build ./...` → no output
- `golangci-lint run --timeout=3m --fast` → no output
- `go test -race -count=1 ./...` → all packages OK, including
  `ui/overlay 1.046s` (both new regression tests pass; no existing
  tests regressed)

## Test plan

- [x] `TestPlaceOverlayExtendedBackgroundFade` passes
- [x] `TestPlaceOverlayTrueColorBackgroundFade` passes
- [x] All pre-existing overlay tests still pass
  (`TestPlaceOverlayBasicBackgroundFade`,
  `TestPlaceOverlayReverseVideoFadesAsBackground`,
  `TestPlaceOverlaySingleParamForegroundFade`,
  `TestPlaceOverlayMultiParamForegroundFade`,
  `TestPlaceOverlayMultiParamBackgroundFade`,
  `TestPlaceOverlayEqualWidth`, `TestPlaceOverlayEqualHeight`)
- [x] Full `go test -race -count=1 ./...` clean
- [x] `golangci-lint --fast` clean
- [x] `gofmt -l .` clean

— Captain Claude