### PR TITLE
fix(tmux): sanitize ':' and '#' in session names so DoesSessionExist matches what tmux creates (#574)

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -114,9 +114,29 @@ func repoHash(repoPath string) string {
 	return hex.EncodeToString(h[:4]) // 8 hex chars
 }
 
+// toTmuxName builds the tmux session name from a user-supplied title.
+//
+// Characters that tmux does not preserve verbatim in session names must be
+// replaced here so DoesSessionExist() and kill paths match the name tmux
+// actually created (#574). Verified against tmux 3.4:
+//   - '.' and ':' are silently rewritten to '_'; using them as-is causes
+//     Start() to poll for a name tmux never created and time out, orphaning
+//     the session.
+//   - '$' is rewritten to a literal backslash+'$' (tmux uses '$' as the
+//     session-id prefix), which has the same round-trip failure.
+//   - '#' is preserved verbatim but is tmux's format-escape character, so
+//     it can corrupt status-line and display-message output that includes
+//     the session name. Sanitized defensively.
+//
+// Other punctuation (',', ';', '@', '%', '(', etc.) is preserved verbatim
+// by tmux and round-trips correctly, so we leave it alone to keep names
+// recognizable.
 func toTmuxName(title string, repoPath string) string {
 	title = whiteSpaceRegex.ReplaceAllString(title, "")
-	title = strings.ReplaceAll(title, ".", "_") // tmux replaces all . with _
+	title = strings.ReplaceAll(title, ".", "_") // tmux silently rewrites '.' to '_'
+	title = strings.ReplaceAll(title, ":", "_") // tmux silently rewrites ':' to '_'
+	title = strings.ReplaceAll(title, "#", "_") // tmux treats '#' as format-escape
+	title = strings.ReplaceAll(title, "$", "_") // tmux escapes '$' to '\$' in session names
 	if repoPath != "" {
 		return fmt.Sprintf("%s%s_%s", TmuxPrefix, repoHash(repoPath), title)
 	}

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -75,6 +75,43 @@ func TestSanitizeName(t *testing.T) {
 	require.Equal(t, "af_custom_name", session3.sanitizedName)
 }
 
+// TestSanitizeNameTmuxRestrictedChars guards toTmuxName against the #574
+// failure mode: tmux silently rewrites or escapes certain characters in
+// session names, so a title containing them must be transformed before we
+// hand it to tmux. Otherwise DoesSessionExist() polls for a name tmux never
+// created and Start() times out, orphaning the session.
+func TestSanitizeNameTmuxRestrictedChars(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		// Existing dot behavior — regression guard.
+		{"dot", "a.b", TmuxPrefix + "a_b"},
+		// Issue #574: colon causes tmux to silently rewrite to '_'.
+		{"colon", "test:session", TmuxPrefix + "test_session"},
+		// '#' is tmux's format-escape — sanitize defensively.
+		{"hash", "fix#574", TmuxPrefix + "fix_574"},
+		// '$' is tmux's session-id prefix — tmux escapes it to '\$' in the
+		// stored name, so has-session round-trips fail without sanitization.
+		{"dollar", "a$b", TmuxPrefix + "a_b"},
+		// All four together, plus whitespace stripping.
+		{"all-four-and-spaces", "a.b :c #d $e", TmuxPrefix + "a_b_c_d_e"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			session := NewTmuxSession(tc.title, "program")
+			require.Equal(t, tc.want, session.sanitizedName)
+		})
+	}
+
+	// Same checks for repo-scoped names.
+	repoPath := "/home/user/repo"
+	hash := repoHash(repoPath)
+	scoped := NewTmuxSessionForRepo("test:session#1.x$2", repoPath, "program")
+	require.Equal(t, TmuxPrefix+hash+"_test_session_1_x_2", scoped.sanitizedName)
+}
+
 // errPtyFactory is a PtyFactory that fails Start(). Used to verify Restore
 // surfaces non-missing-session errors from the PTY layer.
 type errPtyFactory struct {


### PR DESCRIPTION
Closes #574.

## Summary

`toTmuxName` previously sanitized only `.`, leaving titles containing `:`,
`#`, or `$` to produce names that don't match what tmux actually stores on
disk. `Start()` then polls `DoesSessionExist()` for the unsanitized name,
times out after 2s, and orphans the underlying tmux session — requiring
`af reset` to recover.

## Audit table

Generated by creating a session with each candidate character via
`tmux -L af-audit new-session -d -s "pre<c>post"`, then verifying the
listed name and a `has-session -t=<original>` round-trip. tmux 3.4.

| char | input          | tmux stores as       | has-session(original) | classification          |
|------|----------------|----------------------|-----------------------|--------------------------|
| `.`  | `pre.post`     | `pre_post`           | FAIL                  | silent rewrite — sanitize |
| `:`  | `pre:post`     | `pre_post`           | FAIL                  | silent rewrite — sanitize |
| `$`  | `pre$post`     | `pre\$post`          | FAIL                  | tmux escapes session-id prefix — sanitize |
| `#`  | `pre#post`     | `pre#post`           | OK                    | preserved, but tmux format-escape — sanitize defensively |
| `%`  | `pre%post`     | `pre%post`           | OK                    | preserved (pane-id prefix in target syntax, not in stored name) |
| `;` `,` `@` `\`` `(` `)` `-` `_` ` ` | preserved | preserved | OK | leave alone |

Headline: `.` and `:` are the only chars tmux **silently rewrites to `_`**.
`$` has a different but equivalent failure mode (escape insertion). `#` is
preserved verbatim but is tmux's format-escape character (e.g., `#S`,
`#{session_name}`), so a `#` inside a session name will corrupt
`display-message`/status-line output that includes the name; sanitized
defensively for hygiene rather than to fix the #574 mismatch.

Issue #574's body claimed `#` was also silently rewritten — the audit
shows it isn't on tmux 3.4. The fix still sanitizes it for the format-
escape reason above. `$` is a new finding from this audit, not mentioned
in the issue, with the same orphan-on-Start failure mode as `:`.

## Call-site consistency

Every tmux shell-out in the codebase goes through `t.sanitizedName`,
which is set once at `TmuxSession` construction via `toTmuxName`. Audit:

- `session/tmux/tmux.go`: `Start`, `Restore`, `Close`, `DoesSessionExist`,
  `CapturePaneContent[WithOptions]`, `SendKeysCommand`, history/mouse
  options — all use `t.sanitizedName`.
- `session/tmux/tmux.go:CleanupSessions` — reads session names back from
  `tmux ls` output, doesn't reconstruct from a title.
- `session/instance.go` — persists `tmuxSession.SanitizedName()` to disk
  (already-sanitized form) and restores via `NewTmuxSessionFromSanitizedName`.
- `daemon/control.go` and `api/sessions.go` — kill-by-name paths require
  the `af_` prefix and pass the already-sanitized name straight through to
  `NewTmuxSessionFromSanitizedName`.

No path reconstructs a name from a raw title outside `toTmuxName`, so
this single function is the correct (and sufficient) sanitization point.

## Test plan

- [x] Added `TestSanitizeNameTmuxRestrictedChars` covering `:`, `#`, `$`,
      `.` (regression guard), and all four combined with whitespace, for
      both repo-scoped and unscoped names.
- [x] `go test -race ./session/tmux/...` passes.
- [x] `go test -race ./...` passes (one unrelated environmental
      failure in `daemon/TestSigtermFallback_DeadPID` due to lingering
      `af --daemon` processes on the dev box — also fails on `master`
      without this PR's changes).
- [x] `gofmt -l .` clean, `go build ./...` clean,
      `golangci-lint run --timeout=3m --fast` clean.
- [x] End-to-end repro: started real tmux sessions via `NewTmuxSession`
      with titles `test:session`, `fix#574`, `var$x`, and
      `all.of:them#and$too`. Each `Start()` returned nil, the sanitized
      name matched the name in `tmux list-sessions`, and `Close()`
      removed the session cleanly — no orphans, no timeouts.

Captain Claude