### PR TITLE
fix(task): validate task IDs at CLI + RunTask boundary to prevent path traversal (#575)

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -151,6 +151,10 @@ var tasksRemoveCmd = &cobra.Command{
 		log.Initialize(false)
 		defer log.Close()
 
+		if err := task.ValidateTaskID(args[0]); err != nil {
+			return jsonError(err)
+		}
+
 		s, err := task.GetTask(args[0])
 		if err != nil {
 			return jsonError(fmt.Errorf("failed to get task: %w", err))
@@ -191,6 +195,10 @@ var tasksGetCmd = &cobra.Command{
 		log.Initialize(false)
 		defer log.Close()
 
+		if err := task.ValidateTaskID(args[0]); err != nil {
+			return jsonError(err)
+		}
+
 		s, err := task.GetTask(args[0])
 		if err != nil {
 			return jsonError(fmt.Errorf("failed to get task: %w", err))
@@ -207,6 +215,10 @@ var tasksRunCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
+
+		if err := task.ValidateTaskID(args[0]); err != nil {
+			return jsonError(err)
+		}
 
 		if err := task.RunTask(args[0]); err != nil {
 			return jsonError(fmt.Errorf("failed to trigger task: %w", err))
@@ -230,6 +242,10 @@ var tasksUpdateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
+
+		if err := task.ValidateTaskID(args[0]); err != nil {
+			return jsonError(err)
+		}
 
 		s, err := task.GetTask(args[0])
 		if err != nil {

--- a/task/runner.go
+++ b/task/runner.go
@@ -186,6 +186,26 @@ func RunTask(taskID string) error {
 	log.Initialize(false)
 	defer log.Close()
 
+	// Validate the task ID before it flows into any filesystem path. The
+	// CLI boundary also validates, but RunTask is exposed via `af task run`
+	// (the hidden scheduler entry point) and via the API, so this is the
+	// shared chokepoint that protects every caller.
+	if err := ValidateTaskID(taskID); err != nil {
+		return err
+	}
+
+	// Load the task first so a nonexistent ID never causes a lock file to
+	// be created. The original ordering wrote a lock for any caller-supplied
+	// ID before validation (issue #575).
+	t, err := GetTask(taskID)
+	if err != nil {
+		return fmt.Errorf("failed to load task: %w", err)
+	}
+
+	if !t.Enabled {
+		return fmt.Errorf("task %s is disabled", taskID)
+	}
+
 	// Create lock file to prevent overlapping runs.
 	configDir, err := config.GetConfigDir()
 	if err != nil {
@@ -196,6 +216,14 @@ func RunTask(taskID string) error {
 		return fmt.Errorf("failed to create lock directory: %w", err)
 	}
 	lockPath := filepath.Join(lockDir, "task-"+taskID+".lock")
+	// Defense in depth: even after ValidateTaskID, confirm the joined path
+	// remains inside lockDir. ValidateTaskID already rejects "..", "/",
+	// and "\", so this is a belt-and-suspenders check matching the
+	// config.repoInstancesPath pattern.
+	cleanLockDir := filepath.Clean(lockDir) + string(filepath.Separator)
+	if !strings.HasPrefix(filepath.Clean(lockPath), cleanLockDir) {
+		return fmt.Errorf("invalid task id: resolved lock path escapes locks directory")
+	}
 	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open lock file: %w", err)
@@ -206,16 +234,6 @@ func RunTask(taskID string) error {
 		return fmt.Errorf("another run is already active for task %s", taskID)
 	}
 	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
-
-	// Load the task.
-	t, err := GetTask(taskID)
-	if err != nil {
-		return fmt.Errorf("failed to load task: %w", err)
-	}
-
-	if !t.Enabled {
-		return fmt.Errorf("task %s is disabled", taskID)
-	}
 
 	// Validate project path.
 	if !git.IsGitRepo(t.ProjectPath) {

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -351,3 +351,50 @@ func TestTaskRunBaseTitleFallsBackToTaskID(t *testing.T) {
 		t.Fatalf("unexpected fallback title: %q", got)
 	}
 }
+
+// TestRunTask_PathTraversalCreatesLockOutsideLocksDir is the regression test
+// for issue #575: a user-supplied task ID containing path-traversal sequences
+// must not cause a lock file to be created outside ~/.agent-factory/locks/.
+// Before the fix RunTask called filepath.Join(lockDir, "task-"+taskID+".lock")
+// without validating taskID, so an ID like "foo/../../rogue/pwned" produced a
+// lock file in an arbitrary writable directory.
+func TestRunTask_PathTraversalCreatesLockOutsideLocksDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	// Pre-create the rogue parent so an unchecked OpenFile would succeed:
+	// without the directory the file open errors out for the wrong reason
+	// and the test would pass against the unpatched code too. We want to
+	// prove that even when the rogue path is writable, the call refuses.
+	rogueDir := filepath.Join(tmp, "rogue")
+	if err := os.MkdirAll(rogueDir, 0755); err != nil {
+		t.Fatalf("setup rogue dir: %v", err)
+	}
+
+	// Same payload as the issue report.
+	payload := "foo/../../rogue/pwned"
+
+	err := RunTask(payload)
+	if err == nil {
+		t.Fatalf("expected error when triggering task with path-traversal ID")
+	}
+
+	roguePath := filepath.Join(rogueDir, "pwned.lock")
+	if _, statErr := os.Stat(roguePath); statErr == nil {
+		t.Fatalf("SECURITY: path traversal allowed lock file creation outside locks directory at %s", roguePath)
+	} else if !os.IsNotExist(statErr) {
+		t.Fatalf("unexpected stat error checking rogue lock path: %v", statErr)
+	}
+
+	// Also confirm nothing was written into the legitimate locks dir for a
+	// task ID that does not correspond to a real task — i.e., the lock is
+	// only created after GetTask succeeds.
+	locksDir := filepath.Join(tmp, "locks")
+	if entries, err := os.ReadDir(locksDir); err == nil && len(entries) > 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected no lock files for invalid/nonexistent task, found: %v", names)
+	}
+}

--- a/task/task.go
+++ b/task/task.go
@@ -8,10 +8,40 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 )
 
 const tasksFileName = "tasks.json"
+
+// taskIDPattern restricts a task ID to characters that are safe to use as a
+// single path segment. Legitimate IDs from GenerateID are 8 lowercase hex
+// characters; the wider class accommodates any future ID scheme while
+// preventing path-traversal segments like "..", "/", or "\".
+var taskIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// maxTaskIDLength caps the size of an accepted task ID. Legitimate IDs are
+// 8 chars; the cap is loose enough for future schemes while bounding the
+// size of values that flow into filesystem paths and error messages.
+const maxTaskIDLength = 128
+
+// ValidateTaskID enforces the shape of a task identifier before it is used
+// to construct filesystem paths (lock files, log files, scheduler units).
+// Returns an error when the id is empty, exceeds maxTaskIDLength, or
+// contains any character outside [a-zA-Z0-9_-] — in particular "." (used
+// in traversal), "/", or "\". Mirrors config.ValidateRepoID.
+func ValidateTaskID(taskID string) error {
+	if taskID == "" {
+		return fmt.Errorf("invalid task id: empty")
+	}
+	if len(taskID) > maxTaskIDLength {
+		return fmt.Errorf("invalid task id: length %d exceeds maximum %d", len(taskID), maxTaskIDLength)
+	}
+	if !taskIDPattern.MatchString(taskID) {
+		return fmt.Errorf("invalid task id: must match %s", taskIDPattern.String())
+	}
+	return nil
+}
 
 type Task struct {
 	ID            string     `json:"id"`
@@ -90,6 +120,9 @@ func saveTasks(tasks []Task) error {
 }
 
 func AddTask(t Task) error {
+	if err := ValidateTaskID(t.ID); err != nil {
+		return err
+	}
 	path, err := getTasksPathFn()
 	if err != nil {
 		return err
@@ -105,6 +138,9 @@ func AddTask(t Task) error {
 }
 
 func RemoveTask(id string) error {
+	if err := ValidateTaskID(id); err != nil {
+		return err
+	}
 	path, err := getTasksPathFn()
 	if err != nil {
 		return err
@@ -134,6 +170,9 @@ func RemoveTask(id string) error {
 }
 
 func GetTask(id string) (*Task, error) {
+	if err := ValidateTaskID(id); err != nil {
+		return nil, err
+	}
 	tasks, err := LoadTasks()
 	if err != nil {
 		return nil, err
@@ -175,6 +214,9 @@ func LoadTasksForCurrentRepo() ([]Task, error) {
 }
 
 func UpdateTask(t Task) error {
+	if err := ValidateTaskID(t.ID); err != nil {
+		return err
+	}
 	path, err := getTasksPathFn()
 	if err != nil {
 		return err

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -212,6 +213,96 @@ func TestUpdateTaskPersistsProgram(t *testing.T) {
 	got, err := GetTask("p1")
 	require.NoError(t, err)
 	assert.Equal(t, "aider", got.Program)
+}
+
+// TestValidateTaskID_PathTraversalRejected covers the CLI path-traversal
+// exploit class from #575. Every input that could break out of the locks
+// directory (or any other path segment built from the task ID) must be
+// rejected. Mirrors config.TestValidateRepoID_PathTraversalRejected.
+func TestValidateTaskID_PathTraversalRejected(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"dot", "."},
+		{"dotdot", ".."},
+		{"dotdot-slash", "../"},
+		{"deep-traversal", "../../../etc/passwd"},
+		{"embedded-traversal", "foo/../bar"},
+		{"trailing-traversal", "abc/.."},
+		{"absolute-path", "/etc/passwd"},
+		{"windows-absolute", "C:\\windows\\system32"},
+		{"forward-slash", "foo/bar"},
+		{"backslash", "foo\\bar"},
+		{"null-byte", "foo\x00bar"},
+		{"newline", "foo\nbar"},
+		{"tilde", "~/secrets"},
+		{"hidden", ".hidden"},
+		{"glob", "foo*"},
+		{"space", "foo bar"},
+		{"issue-575-payload", "foo/../../rogue/pwned"},
+		{"too-long", strings.Repeat("a", maxTaskIDLength+1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTaskID(tc.input)
+			assert.Error(t, err, "expected %q to be rejected", tc.input)
+		})
+	}
+}
+
+// TestValidateTaskID_LegitimateAccepted ensures real-world task IDs from
+// GenerateID and the fixture IDs already used elsewhere in the test suite
+// continue to validate.
+func TestValidateTaskID_LegitimateAccepted(t *testing.T) {
+	cases := []string{
+		GenerateID(), // 8 hex chars from production helper
+		"a1b2",
+		"abc1",
+		"x1",
+		"u1",
+		"underscore_id",
+		"dashed-id",
+		"A",
+		strings.Repeat("a", maxTaskIDLength),
+	}
+	for _, id := range cases {
+		t.Run(id, func(t *testing.T) {
+			assert.NoError(t, ValidateTaskID(id))
+		})
+	}
+}
+
+// TestGetTask_RejectsInvalidID verifies that GetTask rejects path-traversal
+// IDs without touching the on-disk tasks file. This is the defense-in-depth
+// layer that protects callers that bypass the CLI validation.
+func TestGetTask_RejectsInvalidID(t *testing.T) {
+	setupTestTasks(t, []Task{{ID: "real"}})
+
+	_, err := GetTask("../etc/passwd")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid task id")
+}
+
+// TestRemoveTask_RejectsInvalidID mirrors TestGetTask_RejectsInvalidID for
+// RemoveTask, which is reachable from the API and TUI.
+func TestRemoveTask_RejectsInvalidID(t *testing.T) {
+	setupTestTasks(t, []Task{{ID: "real"}})
+
+	err := RemoveTask("../etc/passwd")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid task id")
+}
+
+// TestUpdateTask_RejectsInvalidID mirrors TestGetTask_RejectsInvalidID for
+// UpdateTask.
+func TestUpdateTask_RejectsInvalidID(t *testing.T) {
+	setupTestTasks(t, []Task{{ID: "real"}})
+
+	err := UpdateTask(Task{ID: "../etc/passwd"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid task id")
 }
 
 func TestTaskNameInJSON(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `task.ValidateTaskID` (mirrors `config.ValidateRepoID`: `^[a-zA-Z0-9_-]+$`, max 128 chars) and applies it at the CLI boundary (`tasks get|trigger|remove|update`) **and** at the `task` package boundary (`AddTask`, `GetTask`, `RemoveTask`, `UpdateTask`, `RunTask`) so every entry point — CLI, API, the hidden `af task run` scheduler hook — is covered.
- Reorders `RunTask` to call `GetTask` **before** creating the lock file, so a nonexistent ID no longer leaks an empty lock under `~/.agent-factory/locks/` (the auxiliary lock-leak called out in the issue).
- Adds a defense-in-depth `HasPrefix(filepath.Clean(lockDir)+sep)` guard in `RunTask`, matching the existing belt-and-suspenders pattern in `config.repoInstancesPath`.

## Why
`af tasks trigger 'foo/../../rogue/pwned'` previously created `~/.agent-factory/rogue/pwned.lock` because `RunTask` did `filepath.Join(lockDir, "task-"+taskID+".lock")` without validating `taskID`. The write happened *before* `GetTask` validated the ID existed, so a hostile user could create empty files at any writable path even for nonexistent tasks. Fixes #575.

## Audit of adjacent path-from-identifier sites
| Site | Source | Status |
|---|---|---|
| `task/runner.go` lockPath | caller-supplied `taskID` | **fixed-by-this-PR** |
| `task/launchd.go` log/plist paths | `t.ID` from `Task` struct | safe — every writer (`AddTask`, `UpdateTask`) now validates first |
| `task/systemd.go` unit/timer paths | `t.ID` from `Task` struct | same |
| `config/state.go` repo instances | `repoID` | already validated (`ValidateRepoID` + `HasPrefix`) |
| `session/git/worktree.go` worktree path | `safeSessionName` (pre-sanitized via `sanitizeBranchName`) | out-of-scope — separate sanitizer |
| `api/sessions.go` title lookups | session title from args | out-of-scope — in-memory equality, not a path component |

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` (no output)
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `go test -race ./task/ ./api/ ./config/ ./...` — all task/api tests green, including new `TestRunTask_PathTraversalCreatesLockOutsideLocksDir`, `TestValidateTaskID_PathTraversalRejected`, `TestValidateTaskID_LegitimateAccepted`, and reject coverage on `GetTask`/`RemoveTask`/`UpdateTask`. Two pre-existing daemon/integration failures reproduce on `master` (host has stray `af --daemon` processes) and are unrelated to this change.

Co-Authored-By: Captain Claude <noreply@anthropic.com>