### PR TITLE
fix(config): use AtomicWriteFile for SaveRepoConfig (and audited adjacent writers) (#570)

### DIFF
--- a/autoupdate.go
+++ b/autoupdate.go
@@ -210,7 +210,5 @@ func recordCheck() {
 	if path == "" {
 		return
 	}
-	dir := filepath.Dir(path)
-	os.MkdirAll(dir, 0755)
-	os.WriteFile(path, []byte(time.Now().UTC().Format(time.RFC3339)), 0644)
+	_ = config.AtomicWriteFile(path, []byte(time.Now().UTC().Format(time.RFC3339)), 0644)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -197,7 +197,7 @@ func saveConfig(config *Config) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	return os.WriteFile(configPath, data, 0644)
+	return AtomicWriteFile(configPath, data, 0644)
 }
 
 // SaveConfig exports the saveConfig function for use by other packages

--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -85,5 +85,5 @@ func SaveRepoConfig(repoID string, cfg *RepoConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal repo config: %w", err)
 	}
-	return os.WriteFile(path, data, 0644)
+	return AtomicWriteFile(path, data, 0644)
 }

--- a/config/repo_config_test.go
+++ b/config/repo_config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -171,5 +172,62 @@ func TestRemoteHooksJSON(t *testing.T) {
 		assert.Contains(t, string(raw), `"remote_hooks"`)
 		assert.Contains(t, string(raw), `"launch_cmd"`)
 		assert.Contains(t, string(raw), `"/x/launch"`)
+	})
+}
+
+// TestSaveRepoConfigAtomicWrite verifies SaveRepoConfig uses AtomicWriteFile:
+// a failed write must leave the prior on-disk content intact (crash-mid-write
+// safety), and a successful write must not leave temp-file droppings behind.
+func TestSaveRepoConfigAtomicWrite(t *testing.T) {
+	t.Run("failed write preserves prior content", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("chmod-based write barrier is bypassed when running as root")
+		}
+		tempHome := t.TempDir()
+		t.Setenv("AGENT_FACTORY_HOME", tempHome)
+
+		repoID := "preserve-on-failure"
+		initial := &RepoConfig{PostWorktreeCommands: []string{"echo initial"}}
+		require.NoError(t, SaveRepoConfig(repoID, initial))
+
+		dir, path, err := repoConfigPath(repoID)
+		require.NoError(t, err)
+		priorBytes, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		// Strip write permission from the repo dir so AtomicWriteFile cannot
+		// create its temp file. A non-atomic implementation that truncated
+		// the destination before writing would clobber the prior content;
+		// AtomicWriteFile must leave it untouched.
+		require.NoError(t, os.Chmod(dir, 0o555))
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+		err = SaveRepoConfig(repoID, &RepoConfig{
+			PostWorktreeCommands: []string{"echo replacement"},
+		})
+		require.Error(t, err, "save into read-only dir must fail")
+
+		after, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, priorBytes, after, "prior content must survive failed write")
+	})
+
+	t.Run("successful write leaves no tmp files", func(t *testing.T) {
+		tempHome := t.TempDir()
+		t.Setenv("AGENT_FACTORY_HOME", tempHome)
+
+		repoID := "no-tmp-droppings"
+		cfg := &RepoConfig{PostWorktreeCommands: []string{"echo hi"}}
+		require.NoError(t, SaveRepoConfig(repoID, cfg))
+		require.NoError(t, SaveRepoConfig(repoID, cfg))
+
+		dir, _, err := repoConfigPath(repoID)
+		require.NoError(t, err)
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		for _, e := range entries {
+			assert.False(t, strings.Contains(e.Name(), ".tmp."),
+				"leftover tmp file in repo config dir: %s", e.Name())
+		}
 	})
 }

--- a/session/plugin.go
+++ b/session/plugin.go
@@ -134,7 +134,7 @@ func ensurePluginDir() (string, error) {
 
 	// Write plugin manifest
 	manifestPath := filepath.Join(manifestDir, "plugin.json")
-	if err := os.WriteFile(manifestPath, []byte(pluginManifest), 0644); err != nil {
+	if err := config.AtomicWriteFile(manifestPath, []byte(pluginManifest), 0644); err != nil {
 		return "", err
 	}
 
@@ -159,7 +159,7 @@ func ensurePluginDir() (string, error) {
 	// Write command files
 	for name, content := range pluginCommands {
 		path := filepath.Join(commandsDir, name)
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		if err := config.AtomicWriteFile(path, []byte(content), 0644); err != nil {
 			return "", err
 		}
 	}

--- a/task/launchd.go
+++ b/task/launchd.go
@@ -106,7 +106,7 @@ func InstallScheduler(t Task) error {
 	unloadCmd := exec.Command("launchctl", "unload", plistPath)
 	_ = unloadCmd.Run()
 
-	if err := os.WriteFile(plistPath, []byte(plistContent), 0644); err != nil {
+	if err := config.AtomicWriteFile(plistPath, []byte(plistContent), 0644); err != nil {
 		return fmt.Errorf("failed to write plist file: %w", err)
 	}
 

--- a/task/systemd.go
+++ b/task/systemd.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
 )
 
 func getUnitName(t Task) string {
@@ -110,7 +112,7 @@ func InstallScheduler(t Task) error {
 	serviceContent := generateServiceContent(unitName, execPath, t.ID, t.ProjectPath, pathEnv, homeEnv, shellEnv, termEnv)
 
 	servicePath := filepath.Join(dir, unitName+".service")
-	if err := os.WriteFile(servicePath, []byte(serviceContent), 0644); err != nil {
+	if err := config.AtomicWriteFile(servicePath, []byte(serviceContent), 0644); err != nil {
 		return fmt.Errorf("failed to write service file: %w", err)
 	}
 
@@ -132,7 +134,7 @@ WantedBy=timers.target
 `, unitName, onCalendarLines.String())
 
 	timerPath := filepath.Join(dir, unitName+".timer")
-	if err := os.WriteFile(timerPath, []byte(timerContent), 0644); err != nil {
+	if err := config.AtomicWriteFile(timerPath, []byte(timerContent), 0644); err != nil {
 		return fmt.Errorf("failed to write timer file: %w", err)
 	}
 


### PR DESCRIPTION
Closes #570.

## Summary

`config.SaveRepoConfig` was the lone config writer still using `os.WriteFile`, leaving per-repo config at `~/.agent-factory/repos/<repoID>/config.json` vulnerable to truncated/empty files on crash or power loss. The fix is one line — swap `os.WriteFile` for the existing `config.AtomicWriteFile` (temp file + fsync + rename + directory fsync) — but I audited every `os.WriteFile` call in the repo and pulled along all other config/state writers that were drifting from the established pattern.

## Diagnosis

- `SaveRepoConfig` was added in commit `a9a7687d`.
- 13 days later, commit `2badb7f` introduced `AtomicWriteFile` and migrated the other persistence functions (`SaveRepoInstances`, `SaveState`, `SaveTasks`).
- `repo_config.go` was never updated to match, leaving non-atomic writes for one of the more user-facing config files (remote hooks, post-worktree commands).

The codebase standard is "config files use atomic writes" — even single-writer config goes through `AtomicWriteFile` (e.g., `SaveState`). Per-repo config should not be the exception.

## Audit of every `os.WriteFile` call

| File:line | Purpose | Verdict |
|---|---|---|
| `config/repo_config.go:88` `SaveRepoConfig` | per-repo config persistence | **Fixed — the #570 bug** |
| `config/config.go:200` `saveConfig` | user config file | **Fixed — same anti-pattern** |
| `autoupdate.go:215` `recordCheck` | last-check timestamp under config dir | **Fixed — state file, was also ignoring error** |
| `task/launchd.go:109` plist install | persistent launchd unit | **Fixed — survives reboots** |
| `task/systemd.go:113,135` service+timer install | persistent systemd units | **Fixed — survives reboots** |
| `session/plugin.go:137,162` plugin manifest+commands | persistent Claude Code plugin install | **Fixed — read by external tool** |
| `upgrade.go`, `autoupdate.go` (binary install paths) | already use `AtomicWriteFile` | OK |
| `daemon/daemon.go` PID file | already uses `AtomicWriteFile` | OK |
| `task/task.go`, `task/runner.go`, `config/state.go`, `config/filelock.go` | already use `AtomicWriteFile` | OK |
| `*_test.go` (numerous) | test fixtures | Out of scope |

No remaining `os.WriteFile` config/state writers after this PR.

## Regression test

`TestSaveRepoConfigAtomicWrite` in `config/repo_config_test.go`:

1. **Failed write preserves prior content** — pre-populates the repo config, drops write permission on the repo dir so `AtomicWriteFile`'s `CreateTemp` cannot create its temp file, then asserts the on-disk bytes are unchanged. A non-atomic implementation that called `OpenFile(O_TRUNC)` on the existing file would succeed (file perms unchanged), clobber it, and the test would fail — verified locally by temporarily reverting the fix.
2. **Successful write leaves no `.tmp.*` droppings** — guards against tmp-file leakage.

Skipped under `Geteuid() == 0` because root bypasses the chmod barrier.

## Local CI gates

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go test -race -count=1 ./...` — passes (one integration test flaked on a contended host due to leaked test daemons from prior runs; passed on retry)

## Test plan

- [x] `go test -race ./config/...` passes including new test
- [x] `go build ./...` clean on linux + GOOS=darwin
- [x] Regression test confirmed to fail when `SaveRepoConfig` is reverted to `os.WriteFile`
- [ ] Reviewer: verify the audit table is exhaustive (`rg "os\.WriteFile" --type go`)