### PR TITLE
fix(api/tasks): reject whitespace-only prompts in tasks update (#568)

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -256,6 +256,14 @@ var tasksUpdateCmd = &cobra.Command{
 			s.Name = taskUpdateNameFlag
 		}
 		if taskUpdatePromptFlag != "" {
+			// Partial-update semantics keep `--prompt ""` as "leave
+			// unchanged", but whitespace-only values used to slip past
+			// the != "" check and be sent literally to tmux via
+			// send-keys (#568). Mirrors the trim-validation tasksAddCmd
+			// applies for #517.
+			if strings.TrimSpace(taskUpdatePromptFlag) == "" {
+				return jsonError(errors.New("prompt must be non-empty"))
+			}
 			s.Prompt = taskUpdatePromptFlag
 		}
 

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -322,6 +322,39 @@ func TestTasksUpdate_RollsBackSchedulerRemoveOnDisableWhenUpdateTaskFails(t *tes
 	assert.True(t, calls.installed[0].Enabled, "rollback restores enabled=true")
 }
 
+// TestTasksUpdate_RejectsEmptyPrompt is the regression guard for #568:
+// tasksUpdateCmd used to accept whitespace-only --prompt values, which
+// were saved and later sent literally to the agent via tmux send-keys.
+// The trim-validation must match tasksAddCmd and the TUI forms (fixed
+// for #517).
+func TestTasksUpdate_RejectsEmptyPrompt(t *testing.T) {
+	for _, prompt := range []string{"   ", "\t\n"} {
+		t.Run(fmt.Sprintf("prompt=%q", prompt), func(t *testing.T) {
+			useTempConfig(t)
+			resetUpdateFlags(t)
+			stubSchedulers(t)
+
+			seedTask(t, task.Task{
+				ID:       "t-whitespace",
+				Name:     "test",
+				Prompt:   "valid prompt",
+				CronExpr: "0 9 * * *",
+				Enabled:  true,
+			})
+
+			taskUpdatePromptFlag = prompt
+			err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t-whitespace"})
+
+			require.Error(t, err, "whitespace-only prompt should be rejected")
+			assert.Contains(t, err.Error(), "prompt must be non-empty")
+
+			got, err := task.GetTask("t-whitespace")
+			require.NoError(t, err)
+			assert.Equal(t, "valid prompt", got.Prompt, "prompt should remain unchanged")
+		})
+	}
+}
+
 // TestTasksRemove_HappyPath verifies that when both removeScheduler and
 // RemoveTask succeed, the final state has no scheduler and no task
 // record.


### PR DESCRIPTION
## Summary
- Closes #568. \`af tasks update --prompt \"   \"\` slipped past the \`!= \"\"\` guard in \`tasksUpdateCmd.RunE\` (api/tasks.go:242), persisted the whitespace, and the runner later sent it literally to the agent via \`tmux send-keys -l\` + Enter — undefined AI behavior.
- Mirror the trim-validation that \`tasksAddCmd\` and the TUI create/edit forms already apply (#517, commit 925720b8): if \`--prompt\` is set AND \`strings.TrimSpace(...) == \"\"\`, return \`jsonError(\"prompt must be non-empty\")\` before any persistence or scheduler work. Partial-update semantics are preserved — \`--prompt \"\"\` still means \"leave unchanged.\"
- Adds \`TestTasksUpdate_RejectsEmptyPrompt\` covering \`\"   \"\` and \`\"\\t\\n\"\` (the bot-provided regression test), asserts the prompt on disk stays unchanged.

## Audit (every user-supplied prompt entry point)
Per the audit-adjacent-callsites rule, every place a user-supplied prompt enters the system was checked:
- \`tasksAddCmd\` (api/tasks.go:91) — **trim-validated** (fixed in #517)
- \`tasksUpdateCmd\` (api/tasks.go:242) — **fixed by this PR**
- TUI task create form (ui/task_pane.go:377) — **trim-validated** (fixed in #517)
- TUI task edit form (ui/task_pane.go:393) — **trim-validated** (fixed in #517)
- Name fields (\`taskAddNameFlag\`, \`taskUpdateNameFlag\`) — **out of scope**: Name is a display label and is not sent to the agent via tmux \`send-keys\`; the #568 bug class is specifically about whitespace flowing to the agent.

## Diagnosis
\`tasksUpdateCmd\` was introduced by 56e13ad7 with the loose \`!= \"\"\` check. When 925720b8 fixed #517 it added \`strings.TrimSpace\` validation to \`tasksAddCmd\` and both TUI forms but overlooked the update CLI path, leaving it as the lone inconsistent entry point. This PR closes that gap.

## Test plan
- [x] \`gofmt -l . | grep -v .claude/worktrees/\` — clean
- [x] \`go build ./...\` — clean
- [x] \`go test -race -count=1 ./api/...\` — green (new test \`TestTasksUpdate_RejectsEmptyPrompt\` passes for both \`\"   \"\` and \`\"\\t\\n\"\`)
- [x] \`go test -race -count=1 ./...\` — \`api/\`, \`task/\`, \`session/\`, \`ui/\`, \`config/\`, \`app/\`, \`log/\` all green. Two unrelated environmental failures (\`daemon/TestSigtermFallback_DeadPID\`, \`integration/TestConcurrentCLIClientsUseDaemonCoordinator\`, \`integration/TestScheduledTaskRunnerUsesDaemonAndAllocatesRerunTitle\`) reproduce on a clean checkout of master in this shared sandbox — they discover stray \`af --daemon\` PIDs from concurrent sibling worktrees and contend for daemon sockets. Not caused by this change.
- [x] \`golangci-lint run --timeout=3m --fast\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)