### PR TITLE
fix(daemon): StopDaemon should try SIGTERM before escalating to SIGKILL (#571)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -237,9 +237,24 @@ func removeDaemonPIDFile() {
 	}
 }
 
+// stopDaemonGrace bounds how long StopDaemon waits for a SIGTERM'd daemon to
+// exit before escalating to SIGKILL. stopDaemonPoll is the polling cadence.
+// Package vars rather than constants so tests can shorten them. Production
+// defaults mirror sigtermFallbackGrace / sigtermFallbackPoll — the same
+// timings already used by signalAndWait on the upgrade fallback path.
+var (
+	stopDaemonGrace = sigtermFallbackGrace
+	stopDaemonPoll  = sigtermFallbackPoll
+)
+
 // StopDaemon attempts to stop a running daemon process if it exists. Returns no error if the daemon is not found
 // (assumes the daemon does not exist). It verifies the PID actually belongs to an agent-factory daemon before
-// sending a kill signal, so a stale or reused PID in the PID file can't take down an unrelated process.
+// signaling it, so a stale or reused PID in the PID file can't take down an unrelated process.
+//
+// Shutdown is graceful by default: SIGTERM gives the daemon's signal handler a
+// chance to run SaveInstances() and clean up the PID file (see RunDaemon). We
+// only escalate to SIGKILL if the daemon does not exit within stopDaemonGrace,
+// matching the SIGTERM-first pattern in signalAndWait (#571).
 func StopDaemon() error {
 	pidDir, err := config.GetConfigDir()
 	if err != nil {
@@ -282,28 +297,64 @@ func StopDaemon() error {
 		return nil
 	}
 
-	// Verify the process is actually an agent-factory daemon before killing it. If we can't verify,
-	// err on the side of caution and treat the PID file as stale rather than killing a random process.
+	// Verify the process is actually an agent-factory daemon before signaling it. If we can't verify,
+	// err on the side of caution and treat the PID file as stale rather than signaling a random process.
 	if !isAgentFactoryDaemon(pid) {
 		log.InfoLog.Printf("PID %d does not look like an agent-factory daemon; removing stale PID file", pid)
 		_ = os.Remove(pidFile)
 		return nil
 	}
 
-	if err := proc.Kill(); err != nil {
-		return fmt.Errorf("failed to stop daemon process: %w", err)
+	// Send SIGTERM so the daemon's signal handler can SaveInstances() before
+	// exit (#571). A race where the daemon exits between the signal-0 probe
+	// above and this call is benign: errIsProcessGone covers both ESRCH and
+	// the os.ErrProcessDone surface.
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		if errIsProcessGone(err) {
+			log.InfoLog.Printf("daemon process (PID: %d) exited before SIGTERM landed; cleaning up", pid)
+			cleanupDaemonRuntimeFiles(pidFile)
+			return nil
+		}
+		return fmt.Errorf("failed to signal daemon process: %w", err)
 	}
 
-	// Clean up PID file
-	if err := os.Remove(pidFile); err != nil {
-		return fmt.Errorf("failed to remove PID file: %w", err)
+	// Poll for graceful exit.
+	gracefulDeadline := time.Now().Add(stopDaemonGrace)
+	exited := false
+	for time.Now().Before(gracefulDeadline) {
+		if !pidLooksAlive(pid) {
+			exited = true
+			break
+		}
+		time.Sleep(stopDaemonPoll)
+	}
+
+	if exited {
+		log.InfoLog.Printf("daemon process (PID: %d) exited gracefully after SIGTERM", pid)
+	} else {
+		log.WarningLog.Printf("daemon process (PID: %d) did not exit within %s of SIGTERM; escalating to SIGKILL", pid, stopDaemonGrace)
+		if err := proc.Signal(syscall.SIGKILL); err != nil && !errIsProcessGone(err) {
+			return fmt.Errorf("failed to stop daemon process: %w", err)
+		}
+	}
+
+	cleanupDaemonRuntimeFiles(pidFile)
+	log.InfoLog.Printf("daemon process (PID: %d) stopped successfully", pid)
+	return nil
+}
+
+// cleanupDaemonRuntimeFiles removes the PID file and (best-effort) the control
+// socket left behind by a stopped daemon. The PID file is tolerated as
+// already-gone because the daemon's own SIGTERM handler removes it via
+// removeDaemonPIDFile() before exiting — so on the SIGTERM-success path we
+// race with the daemon's own cleanup.
+func cleanupDaemonRuntimeFiles(pidFile string) {
+	if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+		log.WarningLog.Printf("failed to remove daemon PID file: %v", err)
 	}
 	if socketPath, socketErr := DaemonSocketPath(); socketErr == nil {
 		_ = os.Remove(socketPath)
 	}
-
-	log.InfoLog.Printf("daemon process (PID: %d) stopped successfully", pid)
-	return nil
 }
 
 // isAgentFactoryDaemon checks whether the process at pid looks like an agent-factory daemon

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -129,6 +129,193 @@ func TestCmdlineHasDaemonFlag(t *testing.T) {
 	}
 }
 
+// TestStopDaemon_SIGTERMFirst verifies that StopDaemon sends SIGTERM (giving
+// the daemon's signal handler a chance to run SaveInstances) and only
+// escalates to SIGKILL after the grace period. Regression test for #571 —
+// before the fix this called proc.Kill() unconditionally, bypassing the
+// daemon's state-save path.
+func TestStopDaemon_SIGTERMFirst(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not available: %v", err)
+	}
+	tmpHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
+
+	// Spawn a process that responds to SIGTERM by exiting (sleep's default
+	// behavior) and exposes "--daemon" as a discrete token in /proc cmdline
+	// (via bash's `exec -a` argv[0] rewrite). This is the same recipe used
+	// in TestSigtermFallback_KillsPIDFileDaemon.
+	cmd := exec.Command("bash", "-c", "exec -a 'sleep --daemon af-test' sleep 60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon: %v", err)
+	}
+	pid := cmd.Process.Pid
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	// Wait for the post-exec cmdline to be readable.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if isAgentFactoryDaemon(pid) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !isAgentFactoryDaemon(pid) {
+		t.Fatalf("fake daemon pid=%d not recognized as agent-factory daemon", pid)
+	}
+
+	// Reap in a goroutine so /proc/<pid>/cmdline clears once the process
+	// exits — otherwise pidLooksAlive keeps seeing the zombie as alive and
+	// StopDaemon would wait the full grace period before declaring success.
+	exited := make(chan *os.ProcessState, 1)
+	go func() {
+		state, _ := cmd.Process.Wait()
+		exited <- state
+	}()
+
+	pidFile := filepath.Join(tmpHome, "daemon.pid")
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", pid)), 0600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	start := time.Now()
+	if err := StopDaemon(); err != nil {
+		t.Fatalf("StopDaemon: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// If StopDaemon respected SIGTERM-first, the process exits within the
+	// poll cadence — well under the grace period. A near-full-grace duration
+	// would mean we're back to the immediate-SIGKILL bug or that the poll
+	// never observed the exit.
+	if elapsed >= stopDaemonGrace {
+		t.Errorf("StopDaemon took %s (>= grace %s); SIGTERM may not have been sent first", elapsed, stopDaemonGrace)
+	}
+
+	select {
+	case state := <-exited:
+		if state == nil {
+			t.Fatalf("process state nil")
+		}
+		ws, ok := state.Sys().(syscall.WaitStatus)
+		if !ok {
+			t.Fatalf("WaitStatus assertion failed: %T", state.Sys())
+		}
+		if !ws.Signaled() {
+			t.Fatalf("process exited without a signal (status=%v); expected SIGTERM", state)
+		}
+		if ws.Signal() != syscall.SIGTERM {
+			t.Errorf("process exited via signal %v, want SIGTERM (the SIGKILL escalation path fired)", ws.Signal())
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatalf("fake daemon did not exit within 8s of StopDaemon")
+	}
+}
+
+// TestStopDaemon_EscalatesToSIGKILL verifies the SIGKILL escalation path:
+// when the daemon ignores SIGTERM, StopDaemon must wait stopDaemonGrace and
+// then SIGKILL the process. Companion to TestStopDaemon_SIGTERMFirst.
+func TestStopDaemon_EscalatesToSIGKILL(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not available: %v", err)
+	}
+	tmpHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
+
+	// Shorten the grace so the test runs in ~300ms instead of ~5s.
+	origGrace := stopDaemonGrace
+	origPoll := stopDaemonPoll
+	stopDaemonGrace = 250 * time.Millisecond
+	stopDaemonPoll = 25 * time.Millisecond
+	defer func() {
+		stopDaemonGrace = origGrace
+		stopDaemonPoll = origPoll
+	}()
+
+	// Inner bash sets SIGTERM to SIG_IGN via `trap '' TERM` (the empty-string
+	// form, which truly ignores the signal — `trap : TERM` would run a no-op
+	// but bash still terminates non-interactively after the handler). Outer
+	// bash uses `exec -a` to rewrite argv[0] so the cmdline contains
+	// "--daemon" as a discrete token (passes isAgentFactoryDaemon). A
+	// ready-file sentinel proves the trap was installed before SIGTERM lands,
+	// closing a race where the cmdline becomes visible while bash is still
+	// parsing the script.
+	readyFile := filepath.Join(tmpHome, "trap-ready")
+	script := fmt.Sprintf(
+		`exec -a 'bash --daemon af-test' bash -c 'trap "" TERM; : > %q; while :; do sleep 1; done'`,
+		readyFile,
+	)
+	cmd := exec.Command("bash", "-c", script)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon: %v", err)
+	}
+	pid := cmd.Process.Pid
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(readyFile); err == nil && isAgentFactoryDaemon(pid) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, err := os.Stat(readyFile); err != nil {
+		t.Fatalf("ready sentinel never appeared (trap not installed): %v", err)
+	}
+	if !isAgentFactoryDaemon(pid) {
+		t.Fatalf("fake daemon pid=%d cmdline does not match --daemon", pid)
+	}
+
+	exited := make(chan *os.ProcessState, 1)
+	go func() {
+		state, _ := cmd.Process.Wait()
+		exited <- state
+	}()
+
+	pidFile := filepath.Join(tmpHome, "daemon.pid")
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", pid)), 0600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	start := time.Now()
+	if err := StopDaemon(); err != nil {
+		t.Fatalf("StopDaemon: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// Must have waited at least the grace period before escalating. A
+	// shorter elapsed time would mean we skipped the SIGTERM grace and
+	// went straight to SIGKILL — the pre-#571 behavior.
+	if elapsed < stopDaemonGrace {
+		t.Errorf("StopDaemon returned in %s, want at least grace %s before SIGKILL", elapsed, stopDaemonGrace)
+	}
+
+	select {
+	case state := <-exited:
+		if state == nil {
+			t.Fatalf("process state nil")
+		}
+		ws, ok := state.Sys().(syscall.WaitStatus)
+		if !ok {
+			t.Fatalf("WaitStatus assertion failed: %T", state.Sys())
+		}
+		if !ws.Signaled() {
+			t.Fatalf("process exited without a signal (status=%v); expected SIGKILL", state)
+		}
+		if ws.Signal() != syscall.SIGKILL {
+			t.Errorf("process exited via signal %v, want SIGKILL (escalation never fired)", ws.Signal())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("fake daemon did not exit within 5s after StopDaemon")
+	}
+}
+
 // TestStopDaemon_RefusesSelfPID verifies that StopDaemon refuses to kill the current test process
 // even if the PID file points at it.
 func TestStopDaemon_RefusesSelfPID(t *testing.T) {


### PR DESCRIPTION
## Summary
- `daemon.StopDaemon` called `proc.Kill()` (SIGKILL) immediately, bypassing the daemon's SIGTERM handler that runs `manager.SaveInstances()` before exit. That dropped `UpdatedAt` refreshes and any in-memory mutations since the last persisted write.
- Switch to SIGTERM-first: send SIGTERM, poll the PID at `sigtermFallbackPoll` cadence up to `sigtermFallbackGrace` (5s, same constants the upgrade fallback uses), and escalate to SIGKILL only on timeout. Log INFO on graceful success, WARNING on escalation.
- PID file cleanup is now ENOENT-tolerant because the daemon's own deferred `removeDaemonPIDFile()` runs first on the graceful path.

Fixes #571.

## Diagnosis
`RunDaemon` registers a SIGTERM handler that closes the worker goroutine and calls `manager.SaveInstances()` before returning. `StopDaemon` always went through `proc.Kill()`, which delivers SIGKILL — the kernel terminates the process before any user-space cleanup runs. The handler was effectively dead code from the `af stop` path.

`signalAndWait()` in `daemon/sigterm_fallback.go` already implements the correct pattern for the upgrade-path fallback (#505/#553). This PR mirrors that pattern in `StopDaemon` rather than reusing the helper directly, so log lines stay tagged with the right context (`daemon process (PID: %d) ...` vs. `sigterm fallback: ...`).

## SIGKILL audit
Grepped every `proc.Kill()`, `proc.Signal(syscall.SIGKILL)`, and `syscall.Kill(pid, syscall.SIGKILL)` in the repo:

| Site | Classification |
| --- | --- |
| `daemon/daemon.go:293` `proc.Kill()` in `StopDaemon` | **Fixed by this PR** |
| `daemon/sigterm_fallback.go:253` `proc.Signal(syscall.SIGKILL)` in `signalAndWait` | Correct — escalation after SIGTERM timeout |
| `session/backend_hook.go:526` `cmd.Process.Kill()` | Already graceful-first: stdout close + 2s wait |
| `session/backend_hook.go:378` `cmd.Process.Kill()` | Intentional PTY teardown on user detach (no daemon state to save) |
| `session/tmux/tmux_unix.go:18` `syscall.Kill` | Not SIGKILL (SIGWINCH) |
| Test cleanup sites in `integration/`, `app/`, `daemon/..._test.go` | Out of scope — test teardown is intentionally forceful |

The SIGTERM-fallback path from #505/#553 already uses SIGTERM-first via `signalAndWait` and is not duplicated by this fix; the two functions intentionally have different log prefixes for their distinct caller contexts.

## API impact
`StopDaemon()` signature unchanged. Callers (`main.go`'s `af stop`, `daemon/control.go RequestShutdown`'s fallback) need no changes.

The graceful path takes up to 5 seconds in the worst case (daemon ignores SIGTERM). In the common case (the production daemon catches SIGTERM and exits within a tick) it returns within ~100ms — typically faster than the pre-fix SIGKILL because the daemon's defer chain runs in parallel with the poller.

## Tests
- `TestStopDaemon_SIGTERMFirst` spawns a SIGTERM-responsive fake daemon (sleep with `exec -a` rewriting argv[0]) and asserts: elapsed time < grace, `WaitStatus.Signal() == SIGTERM`.
- `TestStopDaemon_EscalatesToSIGKILL` spawns a SIGTERM-ignoring fake daemon (`trap '' TERM` — empty-string form which sets SIG_IGN, since `trap : TERM` only runs a no-op then lets non-interactive bash exit) with a ready-file sentinel so the trap is provably installed before SIGTERM lands. Asserts: elapsed >= grace and `WaitStatus.Signal() == SIGKILL`. Uses package vars to shrink the grace to 250ms.

Both tests skip cleanly when `bash` is unavailable.

## Test plan
- [x] `gofmt -l . | grep -v .claude/worktrees/` clean
- [x] `go build ./...` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go test -race -count=1 ./...` clean (modulo the pre-existing `TestSigtermFallback_DeadPID` host-pollution flake — fails identically on `master` when the local machine has real `af --daemon` processes that confuse pgrep; not introduced by this PR)
- [x] New tests pass with the race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude <noreply@anthropic.com>