### PR TITLE
fix(task): collapse all-days DOW ranges so OR-semantics fan-out doesn't fire daily (#576)

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -289,23 +289,27 @@ func convertDOW(field string) string {
 }
 
 // convertSingleDOW converts a single DOW element (number or range) to a name.
-// For ranges starting with 0 (Sunday), it expands to a comma-separated list
-// because systemd's range syntax requires Day1 < Day2 in weekly order
-// (Mon->Tue->...->Sun), making Sun..X invalid.
+// Ranges covering all 7 unique days (0-6, 0-7, 1-7) return "" so the caller
+// omits DOW entirely; otherwise CronToOnCalendar treats DOW as restricted and
+// emits a "Mon..Sun" line that systemd normalizes to daily, fanning out under
+// DOM/DOW OR-semantics to fire monthly schedules every day (#576).
+// For ranges starting with 0 (Sunday) but not all-days, the range expands to
+// a comma-separated list because systemd's range syntax requires Day1 < Day2
+// in weekly order (Mon->Tue->...->Sun), making Sun..X invalid.
 func convertSingleDOW(part string) string {
 	if strings.Contains(part, "-") {
+		if expanded, err := expandCronField(part, 0, 7); err == nil {
+			if len(normalizeDOWValues(expanded)) >= 7 {
+				return ""
+			}
+		}
+
 		idx := strings.Index(part, "-")
 		start := part[:idx]
 		end := part[idx+1:]
 
-		// For ranges starting with Sunday (0), expand to comma-separated names.
 		if start == "0" {
 			endVal, _ := strconv.Atoi(end)
-			// 0-6 or 0-7 covers all 7 days (7 is also Sunday in cron).
-			// Return empty to signal the caller to omit DOW entirely.
-			if endVal >= 6 {
-				return ""
-			}
 			var names []string
 			for i := 0; i <= endVal; i++ {
 				names = append(names, dowNames[strconv.Itoa(i)])

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -206,6 +206,67 @@ func TestCronToOnCalendarDOWNonSundayRange(t *testing.T) {
 	assert.Equal(t, []string{"Tue..Thu *-*-* 09:00:00"}, result)
 }
 
+// TestCronToOnCalendarDOWRange17Monthly is the regression for #576.
+// 1-7 covers all 7 unique days (1=Mon, 7=Sun, 0=Sun). Previously
+// convertSingleDOW only collapsed ranges starting with 0, so this emitted a
+// "Mon..Sun" DOW line; combined with the DOM=15 restriction, the DOM/DOW
+// fan-out unioned a daily entry with the monthly entry and systemd fired
+// daily instead of monthly.
+func TestCronToOnCalendarDOWRange17Monthly(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 15 * 1-7")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*-*-15 09:00:00"}, result)
+}
+
+func TestCronToOnCalendarDOWRange17(t *testing.T) {
+	// 1-7 alone collapses to every-day.
+	result, err := CronToOnCalendar("0 9 * * 1-7")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*-*-* 09:00:00"}, result)
+}
+
+func TestCronToOnCalendarDOWRange27(t *testing.T) {
+	// 2-7 covers Tue,Wed,Thu,Fri,Sat,Sun — 6 unique days (missing Monday),
+	// so it must NOT collapse to every-day.
+	result, err := CronToOnCalendar("0 9 * * 2-7")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Tue..Sun *-*-* 09:00:00"}, result)
+}
+
+func TestCronToOnCalendarDOWStepOneCollapses(t *testing.T) {
+	// */1 expands to [0..7] which normalizes to all 7 days.
+	result, err := CronToOnCalendar("0 9 * * */1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*-*-* 09:00:00"}, result)
+}
+
+func TestCronToOnCalendarDOWListAllDaysZeroSix(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 0,1,2,3,4,5,6")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*-*-* 09:00:00"}, result)
+}
+
+func TestCronToOnCalendarDOWListAllDaysOneSeven(t *testing.T) {
+	// 1..7 explicit list: 7 = Sunday completes the week.
+	result, err := CronToOnCalendar("0 9 * * 1,2,3,4,5,6,7")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*-*-* 09:00:00"}, result)
+}
+
+func TestCronToOnCalendarDOWRange26(t *testing.T) {
+	// 2-6 covers 5 weekdays; must NOT collapse.
+	result, err := CronToOnCalendar("0 9 * * 2-6")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Tue..Sat *-*-* 09:00:00"}, result)
+}
+
+// TestConvertSingleDOWDayNames protects against future callers that bypass
+// ValidateCronExpr: day-name ranges like MON-FRI are not numerically
+// expandable, so the all-days collapse must not falsely fire.
+func TestConvertSingleDOWDayNames(t *testing.T) {
+	assert.NotEqual(t, "", convertSingleDOW("MON-FRI"))
+}
+
 func TestCronToOnCalendarMonthStep(t *testing.T) {
 	// Month is 1-indexed, so */3 should become 01/3, not 00/3.
 	result, err := CronToOnCalendar("0 0 1 */3 *")


### PR DESCRIPTION
## Summary
- `convertSingleDOW("1-7")` returned `"Mon..Sun"` instead of `""` because the all-days collapse only fired for ranges starting with `0`. With DOM also restricted, `CronToOnCalendar` fans out into two `OnCalendar` lines under cron's OR semantics; systemd unions them, so `0 9 15 * 1-7` fired daily instead of monthly. Regression of #535.
- Generalize the range check: expand via `expandCronField` and dedupe via `normalizeDOWValues` (7→0). When 7 unique days are covered, return `""` so the caller omits DOW entirely. Step (`*/1`) and list (`1,2,3,4,5,6,7`) paths already had equivalent dedup; only the range branch was missing it.
- Audited adjacent handlers per #535: DOM in `CronToOnCalendar` already collapses `1-31`/`*/1`/`1,..,31` via `domCoversAll`, and `launchd_schedule.go` runs every field through `expandCronField` + `normalizeDOWValues`. DOW range was the sole remaining gap.

## Test plan
- [x] `go build ./...` clean
- [x] `gofmt -l .` produces no output
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go test -race ./task/...` green
- [x] New regression test: `TestCronToOnCalendarDOWRange17Monthly` confirms `0 9 15 * 1-7` produces `["*-*-15 09:00:00"]` (single monthly entry, no fan-out)
- [x] Collapse tests: `1-7`, `*/1`, `0,1,2,3,4,5,6`, `1,2,3,4,5,6,7` all collapse to plain every-day
- [x] No-regression tests: `2-7` → `Tue..Sun`, `2-6` → `Tue..Sat`, `1-5` and `MON-FRI` unchanged

Closes #576.

Co-Authored-By: Captain Claude <noreply@anthropic.com>