### PR TITLE
fix(config): reapply shell-quoting to user-provided default_program with spaces (#569)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,38 @@ type Config struct {
 	DetachKeys string `json:"detach_keys"`
 }
 
+// shellQuoteProgram returns a tmux-safe form of program. tmux passes a
+// session's program string to `sh -c`, so paths containing spaces or
+// apostrophes must be shell-quoted or the shell will split them. The input
+// may be a bare program path or a path followed by flags; the first " -"
+// is treated as the flag boundary so only the path portion is quoted and
+// trailing flags are preserved verbatim. Values whose path portion is
+// already wrapped in matching single or double quotes are returned
+// unchanged to avoid double-quoting user-provided config.
+func shellQuoteProgram(program string) string {
+	if program == "" {
+		return program
+	}
+
+	path, suffix := program, ""
+	if i := strings.Index(program, " -"); i >= 0 {
+		path, suffix = program[:i], program[i:]
+	}
+
+	if len(path) >= 2 {
+		first, last := path[0], path[len(path)-1]
+		if (first == '\'' && last == '\'') || (first == '"' && last == '"') {
+			return program
+		}
+	}
+
+	if !strings.ContainsAny(path, " '") {
+		return program
+	}
+
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'" + suffix
+}
+
 // DefaultConfig returns the default configuration
 func DefaultConfig() *Config {
 	program, err := GetClaudeCommand()
@@ -70,11 +102,7 @@ func DefaultConfig() *Config {
 		program = defaultProgram
 	}
 
-	// Quote path if it contains spaces or apostrophes (for tmux shell execution)
-	if strings.Contains(program, " ") || strings.Contains(program, "'") {
-		program = "'" + strings.ReplaceAll(program, "'", "'\\''") + "'"
-	}
-
+	program = shellQuoteProgram(program)
 	program = program + " --dangerously-skip-permissions"
 
 	return &Config{
@@ -171,6 +199,11 @@ func LoadConfig() *Config {
 		log.ErrorLog.Printf("failed to parse config file: %v", err)
 		return DefaultConfig()
 	}
+
+	// User-provided default_program overwrites the auto-detected (and
+	// already-quoted) value from DefaultConfig, so re-apply the same
+	// shell-quoting before handing it to tmux. See issue #569.
+	config.DefaultProgram = shellQuoteProgram(config.DefaultProgram)
 
 	if config.DaemonPollInterval <= 0 {
 		log.WarningLog.Printf("daemon_poll_interval=%d is non-positive; using default %dms", config.DaemonPollInterval, defaultDaemonPollInterval)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -319,6 +319,29 @@ func TestLoadConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("reapplies shell-quoting to user default_program with spaces", func(t *testing.T) {
+		// Regression for #569: a user-provided default_program with spaces
+		// (typical macOS App Bundle install) used to overwrite the quoted
+		// auto-detected value and reach tmux unquoted, breaking sh -c.
+		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+		configDir, err := GetConfigDir()
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(configDir, 0755))
+
+		configPath := filepath.Join(configDir, ConfigFileName)
+		const userProgram = "/Applications/Claude Code.app/Contents/MacOS/claude --dangerously-skip-permissions"
+		content := fmt.Sprintf(`{"default_program": %q}`, userProgram)
+		require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
+
+		config := LoadConfig()
+		assert.NotNil(t, config)
+		assert.Equal(t,
+			"'/Applications/Claude Code.app/Contents/MacOS/claude' --dangerously-skip-permissions",
+			config.DefaultProgram,
+		)
+	})
+
 	t.Run("returns default config on invalid JSON", func(t *testing.T) {
 		// Create a temporary config directory
 		tempHome := t.TempDir()
@@ -345,6 +368,66 @@ func TestLoadConfig(t *testing.T) {
 		assert.False(t, config.AutoYes)                  // Default value
 		assert.Equal(t, 1000, config.DaemonPollInterval) // Default value
 	})
+}
+
+func TestShellQuoteProgram(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "macOS App Bundle path",
+			in:   "/Applications/Claude Code.app/Contents/MacOS/claude",
+			want: "'/Applications/Claude Code.app/Contents/MacOS/claude'",
+		},
+		{
+			name: "path with apostrophe",
+			in:   "/Users/o'malley/bin/claude",
+			want: `'/Users/o'\''malley/bin/claude'`,
+		},
+		{
+			name: "path with trailing flags",
+			in:   "/Applications/Claude Code.app/Contents/MacOS/claude --dangerously-skip-permissions",
+			want: "'/Applications/Claude Code.app/Contents/MacOS/claude' --dangerously-skip-permissions",
+		},
+		{
+			name: "already single-quoted with flags",
+			in:   "'/Applications/Claude Code.app/Contents/MacOS/claude' --dangerously-skip-permissions",
+			want: "'/Applications/Claude Code.app/Contents/MacOS/claude' --dangerously-skip-permissions",
+		},
+		{
+			name: "already double-quoted",
+			in:   `"/Applications/Claude Code.app/Contents/MacOS/claude"`,
+			want: `"/Applications/Claude Code.app/Contents/MacOS/claude"`,
+		},
+		{
+			name: "plain identifier",
+			in:   "claude",
+			want: "claude",
+		},
+		{
+			name: "plain identifier with flags",
+			in:   "claude --dangerously-skip-permissions",
+			want: "claude --dangerously-skip-permissions",
+		},
+		{
+			name: "spaces and multiple flags",
+			in:   "/opt/My Tools/claude -v --dangerously-skip-permissions",
+			want: "'/opt/My Tools/claude' -v --dangerously-skip-permissions",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, shellQuoteProgram(tc.in))
+		})
+	}
 }
 
 func TestSaveConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #569.

`DefaultConfig()` shell-quotes auto-detected program paths so tmux's `sh -c` won't split them, but `LoadConfig()` unmarshals the user's `config.json` on top of the default, overwriting that quoted value. macOS users with Claude installed via App Bundle (path contains spaces) ended up with an unquoted `default_program` reaching `tmux new-session`, which then failed with `/Applications/Claude not found`.

- Extract the inline quoting in `DefaultConfig` into a shared `shellQuoteProgram` helper.
- Call it from `LoadConfig` immediately after `json.Unmarshal` (and from `DefaultConfig`, replacing the old inline logic).
- Helper splits off a trailing flag suffix on the first `" -"` so only the program-path portion is quoted, leaves already-quoted (single or double) values unchanged to avoid double-quoting, and leaves plain identifiers like `claude` untouched.

## Audit

Every tmux `new-session` shell-command construction site:

| Site | Disposition |
| --- | --- |
| `session/tmux/tmux.go:175` | **fix** — only production site that takes a user-controlled program string; now receives the quoted form via the config path. |
| `session/tmux/tmux_test.go` | out of scope — constructs literal program strings for assertions. |
| `session/backend_test.go` | out of scope — same, in mock command recorder. |
| `ui/terminal_test.go`, `ui/preview_test.go` | out of scope — test-only command capture for assertions. |
| Hook commands (`launch_cmd` / `list_cmd` / etc.) | out of scope — invoked via `exec.Command`, not tmux, so no `sh -c` quoting needed. |

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go test -race ./config/...` passes (new `TestShellQuoteProgram` + `TestLoadConfig` subtest)
- [x] `go test -race ./...` — config + all related packages pass; two unrelated pre-existing failures on this box (`TestSigtermFallback_DeadPID` finds two leftover `af --daemon` PIDs; `TestE2ERemoteHooksFullLifecycle` hits a broken `~/.pyenv/shims/python3` symlink that `exec.LookPath` still finds). Both reproduce on plain `master` without these changes.

New table-driven test coverage for `shellQuoteProgram`:

- macOS App Bundle path → quoted
- path with apostrophe → quoted with `'\''` escaping
- path with trailing flags → only path portion quoted, flags preserved
- already single-quoted (with flags) → unchanged (no double-quote)
- already double-quoted → unchanged
- plain identifier `claude` → unchanged
- plain identifier with flags → unchanged
- spaces + multiple flags → only path portion quoted, all flags preserved
- empty string → unchanged

Plus a `TestLoadConfig` subtest that writes an unquoted spaced `default_program` to `config.json`, calls `LoadConfig`, and asserts the returned value is the quoted form.

🫡 Captain Claude