### PR TITLE
fix(app): flush dirty TaskPane state before reloading on inline-create (#578)

### DIFF
--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -184,6 +184,13 @@ func (m *home) handleContentPaneFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 	// Check if a new task was submitted via the inline form
 	sp := m.contentPane.TaskPane()
 	if sp.HasPendingCreate() {
+		// Submitting the create form sets pendingCreate without releasing
+		// focus, so the "save on focus release" branch above doesn't run.
+		// handleTaskCreate writes the new task to disk and then reloads
+		// every task via SetTasks, which clears the dirty flag and any
+		// unsaved toggle/edit/delete. Flush those changes first so the
+		// reload picks them up (#578).
+		m.saveContentPaneState()
 		return m, m.handleTaskCreate(), true
 	}
 	if sp.HasPendingTrigger() {

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -2,11 +2,16 @@ package app
 
 import (
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleStateSelectProgramSubstringCollision(t *testing.T) {
@@ -31,4 +36,115 @@ func TestHandleStateSelectProgramPreservesExactProgramFlags(t *testing.T) {
 	_, _ = h.handleStateSelectProgram(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.Equal(t, h.program, h.pendingProgram)
+}
+
+// TestHandleContentPaneFocus_PendingCreateFlushesDirtyTaskState is the
+// regression guard for #578.
+//
+// The bug: toggling a task with 'x' marks the TaskPane dirty in memory but
+// the toggle is not yet on disk. Submitting the inline create form sets
+// pendingCreate WITHOUT releasing focus, so the "save on Esc" branch in
+// handleContentPaneFocus does not run. handleTaskCreate then writes the new
+// task to disk and calls LoadTasksForCurrentRepo + SetTasks, which overwrites
+// the in-memory TaskPane with stale disk state and clears `dirty` — silently
+// discarding the toggle.
+//
+// The fix is one extra m.saveContentPaneState() call before m.handleTaskCreate()
+// in app/handle_overlay.go so dirty toggles/edits/deletes hit disk before the
+// reload.
+//
+// We assert directly on tasks.json after driving the handler with the same
+// key sequence a user would press. handleTaskCreate also calls
+// task.InstallScheduler under the hood, which shells out to `systemctl --user`
+// — that step is flaky in CI containers without a user systemd manager.
+// Independent of whether InstallScheduler succeeds:
+//   - on success, LoadTasksForCurrentRepo + SetTasks reload the (already-saved)
+//     toggle from disk;
+//   - on failure, handleTaskCreate rolls back the new task via RemoveTask, but
+//     saveContentPaneState has already persisted the toggle.
+//
+// Either way the on-disk Enabled bit must reflect the user's toggle. Without
+// the fix it would still be `true` on disk because saveContentPaneState never
+// ran. We redirect HOME so scheduler writes land in a tempdir, which keeps the
+// test from polluting the developer's real systemd-user units even on the
+// platforms where the systemctl call would succeed against a real session.
+func TestHandleContentPaneFocus_PendingCreateFlushesDirtyTaskState(t *testing.T) {
+	h := newTestHome(t)
+	// Keep any task.InstallScheduler/RemoveScheduler file writes inside the
+	// test tempdir so a real user-systemd doesn't end up with stale units
+	// pointing into deleted tempdirs after the test exits.
+	t.Setenv("HOME", t.TempDir())
+
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+
+	// Seed an existing, enabled task on disk and load it into the TaskPane —
+	// this is the equivalent of opening the app with one task configured.
+	existing := task.Task{
+		ID:          "existing-578",
+		Name:        "nightly",
+		Prompt:      "do something",
+		CronExpr:    "* * * * *",
+		ProjectPath: repo.Root,
+		Program:     "claude",
+		Enabled:     true,
+		CreatedAt:   time.Now(),
+	}
+	require.NoError(t, task.AddTask(existing))
+
+	loaded, err := task.LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	tp := h.contentPane.TaskPane()
+	tp.SetTasks(loaded)
+	h.contentPane.SetMode(ui.ContentModeTasks)
+	tp.SetFocus(true)
+
+	// User presses 'x' to toggle the task off — dirty in memory, not yet on disk.
+	_, _, consumed := h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	require.True(t, consumed, "'x' must route through the focus handler")
+	require.True(t, tp.IsDirty(), "toggle must mark the pane dirty")
+	require.False(t, tp.GetTasks()[0].Enabled, "in-memory state reflects the toggle")
+
+	diskBefore, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.True(t, diskBefore[0].Enabled,
+		"disk must still hold the pre-toggle value until something flushes the pane")
+
+	// User opens the inline create form with 'n' and fills it in.
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	require.True(t, tp.IsCreating(), "'n' must open the inline create form")
+
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("new-task")})
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do other thing")})
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> cron
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> path
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> program
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> save button
+
+	// Submit. This sets pendingCreate inside TaskPane and then the focus
+	// handler's HasPendingCreate branch runs — which is the code path the fix
+	// modifies. We don't care whether handleTaskCreate's downstream
+	// InstallScheduler ultimately succeeds; we only care that the toggle is on
+	// disk by the time the dust settles.
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyEnter})
+
+	diskAfter, err := task.LoadTasks()
+	require.NoError(t, err)
+	var found *task.Task
+	for i := range diskAfter {
+		if diskAfter[i].ID == existing.ID {
+			found = &diskAfter[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "existing task must still be on disk after the create flow")
+	assert.False(t, found.Enabled,
+		"toggle must be persisted to disk before handleTaskCreate reloads "+
+			"(regression for #578: handler now calls saveContentPaneState first)")
 }


### PR DESCRIPTION
## Summary

Fixes #578.

Toggling a task with `x` and then submitting the inline create form silently
discarded the toggle. The TaskPane keeps toggles/edits/deletes in memory and
only persists them via `saveContentPaneState()` on focus-release.
`handleContentPaneFocus` (`app/handle_overlay.go`) only calls
`saveContentPaneState()` when the keypress *releases* focus — but submitting
the create form sets `pendingCreate` while focus is still held.
`handleTaskCreate()` then writes the new task to disk and reloads via
`task.LoadTasksForCurrentRepo()` + `sp.SetTasks()`, and `TaskPane.SetTasks`
clears `dirty`/`deleted` and overwrites the in-memory list with stale disk
state.

## Fix

One added line: `m.saveContentPaneState()` runs in the `HasPendingCreate()`
branch of `handleContentPaneFocus` before `m.handleTaskCreate()`. Dirty
toggles/edits/deletes hit disk first, then the reload picks them up.

## Audit

Per the audit request, every caller of `task.LoadTasksForCurrentRepo` and
`SetTasks` was reviewed for the same in-memory-clobbered-by-reload pattern:

**`LoadTasksForCurrentRepo` callers:**

| Site | Verdict |
|---|---|
| `app/app.go:178` (startup load) | **Out of scope** — no TaskPane in-memory state exists yet at this point. |
| `app/app.go:465` (inside `saveContentPaneState`) | **Saves-first by construction** — this reload runs *after* the same function flushed dirty state. |
| `app/app.go:524` (inside `handleTaskCreate`) | **Fixed by this PR** — callers now flush dirty state before invoking it. |

**`SetTasks` callers (TaskPane + sidebar):**

| Site | Verdict |
|---|---|
| `app/app.go:182,187` (startup load) | **Out of scope** — same as the startup `LoadTasksForCurrentRepo`. |
| `app/app.go:467` (sidebar-only inside `saveContentPaneState`) | **Saves-first by construction.** |
| `app/app.go:526,527` (sidebar + TaskPane inside `handleTaskCreate`) | **Fixed by this PR.** |
| `ui/*_test.go` (`tp.SetTasks`, `cp.TaskPane().SetTasks`, etc.) | Test-only setup, not a real reload site. |

**Hooks pane** (`ui/hooks_pane.go`): has the same `dirty` flag + `SetCommands`
clears it pattern, but there is **no analogous reload-from-disk path** after
a hook mutation. Hook mutations stay in memory until `saveContentPaneState`
batches them out as a single `repoCfg.PostWorktreeCommands` write, with no
follow-up reload that could clobber in-memory state. No equivalent clobber
site exists to fix.

## Regression test

`TestHandleContentPaneFocus_PendingCreateFlushesDirtyTaskState` drives the
real `handleContentPaneFocus` with the same key sequence a user would press:
toggle (`x`), open the create form (`n`), fill name/prompt/cron, walk to
Save, press Enter. It asserts that the toggle is persisted to disk
regardless of whether `handleTaskCreate`'s downstream `task.InstallScheduler`
call ultimately succeeded — i.e. the fix's `saveContentPaneState()` ran
before the reload. Removing the new `m.saveContentPaneState()` call in
`handle_overlay.go` makes the test fail (verified locally with a temporary
revert).

`HOME` is redirected to a tempdir so on platforms where `systemctl --user`
*would* succeed, no real systemd-user units are left behind after the test
exits.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `GOTOOLCHAIN=go1.24.1 golangci-lint run --timeout=3m --fast` clean
- [x] `go test -race -count=1 ./app/ ./ui/ ./task/ ./api/ ./session/... ./config/` all green
- [x] Regression test fails on a temporary revert of the fix, passes with the fix applied

Co-Authored-By: Captain Claude <noreply@anthropic.com>