### PR TITLE
feat(session/tmux): resume agent conversation when tmux session is respawned after loss (#595)

### DIFF
--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -1,0 +1,180 @@
+package tmux
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// resumeProgram derives a "resume the most recent session in cwd" variant of
+// program for use when Restore() re-spawns a vanished tmux session (#386,
+// #595). For agents without a resume-most-recent flag, programs that already
+// include one, and unknown programs, returns program unchanged.
+//
+// Agent-specific rewrites:
+//
+//   - claude: append --continue at the end. claude's resume flags are
+//     position-independent, so appending preserves the original program
+//     string verbatim (including any shell quoting on the executable
+//     path — see #569).
+//   - codex: insert "resume --last" immediately after the codex token,
+//     or after "exec" if it follows codex. Subcommand position matters
+//     for codex, so this can't be a tail append.
+//
+// Both CLIs silently fall back to a fresh session when no prior session
+// exists in cwd, so the rewrite is safe to apply unconditionally.
+func resumeProgram(program string) string {
+	tokens := splitShellTokens(program)
+	if len(tokens) == 0 {
+		return program
+	}
+
+	agentIdx := -1
+	var agent string
+	for i, tok := range tokens {
+		base := strings.ToLower(filepath.Base(tok))
+		for _, supported := range SupportedPrograms {
+			if base == supported {
+				agentIdx = i
+				agent = supported
+				break
+			}
+		}
+		if agentIdx >= 0 {
+			break
+		}
+	}
+	if agentIdx < 0 {
+		return program
+	}
+
+	switch agent {
+	case ProgramClaude:
+		for _, tok := range tokens {
+			if tok == "-c" || tok == "--continue" || tok == "-r" || tok == "--resume" {
+				return program
+			}
+		}
+		return program + " --continue"
+	case ProgramCodex:
+		for _, tok := range tokens {
+			if tok == "resume" {
+				return program
+			}
+		}
+		insertAt := agentIdx + 1
+		if insertAt < len(tokens) && tokens[insertAt] == "exec" {
+			insertAt++
+		}
+		newTokens := make([]string, 0, len(tokens)+2)
+		newTokens = append(newTokens, tokens[:insertAt]...)
+		newTokens = append(newTokens, "resume", "--last")
+		newTokens = append(newTokens, tokens[insertAt:]...)
+		return shellJoinTokens(newTokens)
+	}
+	return program
+}
+
+// splitShellTokens tokenizes a shell-style command string, respecting single
+// quotes (no escapes), double quotes (with \" and \\ escapes), and backslash
+// escapes outside quotes. Adjacent runs concatenate into a single token (e.g.
+// 'foo'bar -> "foobar"). Unclosed quotes consume to end of input. Mirrors the
+// session.splitShell helper used by injectSystemPrompt — kept private here
+// to avoid an import cycle (session/tmux is imported by session).
+func splitShellTokens(s string) []string {
+	var tokens []string
+	var cur strings.Builder
+	inToken := false
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		switch c {
+		case ' ', '\t':
+			if inToken {
+				tokens = append(tokens, cur.String())
+				cur.Reset()
+				inToken = false
+			}
+			i++
+		case '\\':
+			inToken = true
+			if i+1 < len(s) {
+				cur.WriteByte(s[i+1])
+				i += 2
+			} else {
+				i++
+			}
+		case '\'':
+			inToken = true
+			i++
+			for i < len(s) && s[i] != '\'' {
+				cur.WriteByte(s[i])
+				i++
+			}
+			if i < len(s) {
+				i++
+			}
+		case '"':
+			inToken = true
+			i++
+			for i < len(s) && s[i] != '"' {
+				if s[i] == '\\' && i+1 < len(s) {
+					n := s[i+1]
+					if n == '"' || n == '\\' {
+						cur.WriteByte(n)
+						i += 2
+						continue
+					}
+				}
+				cur.WriteByte(s[i])
+				i++
+			}
+			if i < len(s) {
+				i++
+			}
+		default:
+			inToken = true
+			cur.WriteByte(c)
+			i++
+		}
+	}
+	if inToken {
+		tokens = append(tokens, cur.String())
+	}
+	return tokens
+}
+
+// shellJoinTokens joins tokens with spaces, single-quoting any token that
+// would otherwise be reinterpreted by the shell. Used to rebuild a program
+// string after token-level surgery in resumeProgram.
+func shellJoinTokens(tokens []string) string {
+	var b strings.Builder
+	for i, tok := range tokens {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		if needsShellQuote(tok) {
+			b.WriteByte('\'')
+			b.WriteString(strings.ReplaceAll(tok, "'", `'\''`))
+			b.WriteByte('\'')
+		} else {
+			b.WriteString(tok)
+		}
+	}
+	return b.String()
+}
+
+func needsShellQuote(s string) bool {
+	if s == "" {
+		return true
+	}
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case ' ', '\t', '\n', '\'', '"', '\\',
+			'$', '`', '*', '?', '[', ']',
+			'(', ')', '{', '}', '|', '&',
+			';', '<', '>', '#', '~', '!':
+			return true
+		}
+	}
+	return false
+}

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -1,0 +1,108 @@
+package tmux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResumeProgram(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Claude: append --continue at the end. Position-independent flag,
+		// so the original program string is preserved verbatim except for
+		// the appended token.
+		{"claude bare", "claude", "claude --continue"},
+		{
+			"claude with flag",
+			"claude --dangerously-skip-permissions",
+			"claude --dangerously-skip-permissions --continue",
+		},
+		{
+			"claude absolute path",
+			"/home/user/.local/bin/claude --foo",
+			"/home/user/.local/bin/claude --foo --continue",
+		},
+		{
+			// Quoted path with spaces (regression for #569): existing
+			// quoting on the executable token must survive untouched.
+			"claude quoted path with spaces",
+			"'/Applications/Claude Code.app/Contents/MacOS/claude' --foo",
+			"'/Applications/Claude Code.app/Contents/MacOS/claude' --foo --continue",
+		},
+		// Claude: already-has-resume cases — no-op so repeated Restore
+		// calls (e.g. user kills tmux several times in a row) don't
+		// accumulate flags.
+		{"claude already --continue", "claude --continue", "claude --continue"},
+		{"claude already -c", "claude -c", "claude -c"},
+		{"claude already --resume", "claude --resume foo", "claude --resume foo"},
+		{"claude already -r", "claude -r abc123", "claude -r abc123"},
+
+		// Codex: insert "resume --last" after the codex token (subcommand
+		// position matters for codex; a tail append wouldn't parse).
+		{"codex bare", "codex", "codex resume --last"},
+		{"codex with model flag", "codex --model gpt-5", "codex resume --last --model gpt-5"},
+		{
+			"codex absolute path",
+			"/usr/local/bin/codex --model gpt-5",
+			"/usr/local/bin/codex resume --last --model gpt-5",
+		},
+		// Codex headless: "exec" is a subcommand; resume comes after it.
+		{"codex exec", "codex exec", "codex exec resume --last"},
+		{"codex exec with flag", "codex exec --foo bar", "codex exec resume --last --foo bar"},
+		// Codex: already-has-resume cases — no-op.
+		{"codex already resume", "codex resume --last", "codex resume --last"},
+		{"codex exec already resume", "codex exec resume --last", "codex exec resume --last"},
+
+		// Agents without a documented resume-most-recent flag are passed
+		// through unchanged. Deferred to follow-up issues if/when those
+		// CLIs expose comparable flags.
+		{"aider with model flag", "aider --model x", "aider --model x"},
+		{"aider absolute path", "/usr/local/bin/aider", "/usr/local/bin/aider"},
+		{"gemini bare", "gemini", "gemini"},
+		{"gemini with flag", "gemini --quiet", "gemini --quiet"},
+
+		// Unknown programs are passed through unchanged so unrelated CLIs
+		// aren't accidentally rewritten.
+		{"unknown program", "mytool --bar", "mytool --bar"},
+		{"empty", "", ""},
+		{"whitespace only", "   ", "   "},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, resumeProgram(tc.in))
+		})
+	}
+}
+
+// TestResumeProgram_QuotedCodexPath verifies that a codex executable whose
+// path is quoted because it contains spaces still gets the resume insertion
+// in the right token slot, and the rebuilt string preserves shell-safe
+// quoting on the path.
+func TestResumeProgram_QuotedCodexPath(t *testing.T) {
+	got := resumeProgram("'/path with space/codex' --model gpt-5")
+	require.Equal(t, "'/path with space/codex' resume --last --model gpt-5", got)
+}
+
+// TestResumeProgram_Idempotent verifies that running the rewrite twice
+// produces the same string as running it once — defense against repeated
+// Restore() calls (e.g. user kills tmux multiple times in a row).
+func TestResumeProgram_Idempotent(t *testing.T) {
+	for _, in := range []string{
+		"claude",
+		"claude --foo",
+		"codex",
+		"codex exec",
+		"codex --model gpt-5",
+		"aider",
+		"gemini",
+	} {
+		once := resumeProgram(in)
+		twice := resumeProgram(once)
+		require.Equal(t, once, twice, "resumeProgram should be idempotent for %q", in)
+	}
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -288,12 +288,19 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 // and workDir is empty, the missing-session condition is surfaced as an error;
 // real failures (PTY open errors, Start failures such as missing binaries or
 // vanished worktrees) are always surfaced.
+//
+// When re-spawning, the program string is rewritten via resumeProgram so
+// agents that expose a "resume the most recent session in cwd" flag pick
+// the prior conversation back up instead of starting fresh (#595). Agents
+// without such a flag, or programs that already include one, are left
+// untouched.
 func (t *TmuxSession) Restore(workDir string) error {
 	if !t.DoesSessionExist() {
 		if workDir == "" {
 			return fmt.Errorf("tmux session %q does not exist", t.sanitizedName)
 		}
 		log.InfoLog.Printf("tmux session %q missing on Restore; re-spawning in %s", t.sanitizedName, workDir)
+		t.program = resumeProgram(t.program)
 		return t.Start(workDir)
 	}
 

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -173,8 +173,10 @@ func TestRestoreRespawnsWhenSessionMissing(t *testing.T) {
 
 	require.Equal(t, 2, len(ptyFactory.cmds),
 		"expected new-session followed by attach-session via PTY")
+	// Re-spawn must include the resume-most-recent flag so the prior
+	// conversation isn't lost on lazy respawn after a reboot (#595).
 	require.Equal(t,
-		fmt.Sprintf("tmux new-session -d -s af_missing -c %s claude", workdir),
+		fmt.Sprintf("tmux new-session -d -s af_missing -c %s claude --continue", workdir),
 		cmd2.ToString(ptyFactory.cmds[0]))
 	require.Equal(t, "tmux attach-session -t af_missing", cmd2.ToString(ptyFactory.cmds[1]))
 }


### PR DESCRIPTION
Closes #595.

## Summary

When tmux's server dies (typically across a machine reboot, see #386), `TmuxSession.Restore()` falls through to `Start(workDir)` and re-spawns the session with the original program string. Today that means the agent starts a fresh conversation even though the prior transcript is still on disk in the cwd.

This PR rewrites the program string in the missing-session branch so agents that expose a "resume the most recent session in cwd" flag pick the prior conversation back up.

## Decisions

1. **Always-on, not opt-in.** Both `claude --continue` and `codex resume --last` silently fall back to a fresh session when no prior session exists in cwd (verified in the linked issue). So the rewrite is safe to apply unconditionally — behavior in fresh dirs is unchanged.
2. **claude + codex only in this PR.** `aider` and `gemini` don't currently expose comparable flags; left untouched and deferred to follow-up issues if/when their CLIs add equivalents. Unknown programs are also left untouched.
3. **Scope: only `Restore()`'s missing-session branch.** First-time launches and user-triggered restart paths are unchanged. This is the only path that loses context today.

## Transformation

| Input                                                          | Output                                                                       |
|----------------------------------------------------------------|------------------------------------------------------------------------------|
| `claude`                                                       | `claude --continue`                                                          |
| `claude --dangerously-skip-permissions`                        | `claude --dangerously-skip-permissions --continue`                           |
| `'/Applications/Claude Code.app/Contents/MacOS/claude' --foo`  | `'/Applications/Claude Code.app/Contents/MacOS/claude' --foo --continue`     |
| `codex`                                                        | `codex resume --last`                                                        |
| `codex --model gpt-5`                                          | `codex resume --last --model gpt-5`                                          |
| `codex exec`                                                   | `codex exec resume --last`                                                   |
| `claude --continue` (already has flag)                         | `claude --continue` (no-op)                                                  |
| `codex resume --last` (already has flag)                       | `codex resume --last` (no-op)                                                |
| `aider --model x`                                              | `aider --model x` (unchanged)                                                |
| `gemini --quiet`                                               | `gemini --quiet` (unchanged)                                                 |
| `mytool --bar`                                                 | `mytool --bar` (unchanged)                                                   |

The rewrite is **idempotent** so repeated `Restore()` calls (e.g. the user kills tmux several times in a row) don't accumulate flags. Token-level surgery preserves any shell quoting on the executable path (regression-safe against #569).

## Audit — `t.Start(workDir)` call sites

| File:Line                            | Caller                                | Gets resume rewrite? |
|--------------------------------------|---------------------------------------|----------------------|
| `session/tmux/tmux.go:298`           | `Restore()` missing-session branch    | ✅ yes (this PR)     |
| `session/backend_local.go:125`       | `firstTimeSetup` (new session)        | ❌ no — fresh launch |
| `session/instance.go:368`            | `StartWithExistingWorktree`           | ❌ no — fresh launch |

`Restore("")` calls from `Detach()` and `Start()`'s tail short-circuit on the empty-workDir branch and never reach the rewrite.

## Verifications

- ✅ `gofmt -l .` clean
- ✅ `go build ./...` clean
- ✅ `golangci-lint run --timeout=3m --fast` clean
- ✅ `go test -race -count=1 ./...` clean — the daemon `TestSigtermFallback_DeadPID` failure observed locally is an environmental flake (two real `af --daemon` processes on the dev machine), reproduces on clean `master`, and runs green in CI's clean environment.

## Test plan

- [x] Unit tests in `session/tmux/resume_test.go` cover every transformation row above, the quoted-codex-path edge case, and idempotence.
- [x] Existing `TestRestoreRespawnsWhenSessionMissing` updated to assert the rewritten program in the `tmux new-session` argv.
- [x] All other `Restore()` tests (alive session, PTY error, no-workDir error) continue to pass.

— Captain Claude