### PR TITLE
feat(session/tmux): extend resume-on-respawn to aider and gemini (follow-up to #595)

### DIFF
--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -19,8 +19,15 @@ import (
 //   - codex: insert "resume --last" immediately after the codex token,
 //     or after "exec" if it follows codex. Subcommand position matters
 //     for codex, so this can't be a tail append.
+//   - aider: append --restore-chat-history at the end. Reads
+//     .aider.chat.history.md from cwd if present; silently falls back to
+//     a fresh chat if absent. Skipped if the user passed an explicit
+//     --no-restore-chat-history opt-out.
+//   - gemini: append --resume latest at the end. The "latest" keyword
+//     resumes the most recent session in cwd and silently falls back
+//     to a fresh session if none exists.
 //
-// Both CLIs silently fall back to a fresh session when no prior session
+// All four CLIs silently fall back to a fresh session when no prior session
 // exists in cwd, so the rewrite is safe to apply unconditionally.
 func resumeProgram(program string) string {
 	tokens := splitShellTokens(program)
@@ -70,6 +77,20 @@ func resumeProgram(program string) string {
 		newTokens = append(newTokens, "resume", "--last")
 		newTokens = append(newTokens, tokens[insertAt:]...)
 		return shellJoinTokens(newTokens)
+	case ProgramAider:
+		for _, tok := range tokens {
+			if tok == "--restore-chat-history" || tok == "--no-restore-chat-history" {
+				return program
+			}
+		}
+		return program + " --restore-chat-history"
+	case ProgramGemini:
+		for _, tok := range tokens {
+			if tok == "--resume" || tok == "-r" {
+				return program
+			}
+		}
+		return program + " --resume latest"
 	}
 	return program
 }

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -57,13 +57,77 @@ func TestResumeProgram(t *testing.T) {
 		{"codex already resume", "codex resume --last", "codex resume --last"},
 		{"codex exec already resume", "codex exec resume --last", "codex exec resume --last"},
 
-		// Agents without a documented resume-most-recent flag are passed
-		// through unchanged. Deferred to follow-up issues if/when those
-		// CLIs expose comparable flags.
-		{"aider with model flag", "aider --model x", "aider --model x"},
-		{"aider absolute path", "/usr/local/bin/aider", "/usr/local/bin/aider"},
-		{"gemini bare", "gemini", "gemini"},
-		{"gemini with flag", "gemini --quiet", "gemini --quiet"},
+		// Aider: append --restore-chat-history at the end. Position-
+		// independent flag, so the original program string is preserved
+		// verbatim except for the appended token. Aider silently falls
+		// back to a fresh chat when .aider.chat.history.md is absent.
+		{"aider bare", "aider", "aider --restore-chat-history"},
+		{
+			"aider with model flag",
+			"aider --model x",
+			"aider --model x --restore-chat-history",
+		},
+		{
+			"aider absolute path",
+			"/usr/local/bin/aider --foo",
+			"/usr/local/bin/aider --foo --restore-chat-history",
+		},
+		{
+			// Quoted path with spaces (regression for #569): existing
+			// quoting on the executable token must survive untouched.
+			"aider quoted path with spaces",
+			"'/path with space/aider' --foo",
+			"'/path with space/aider' --foo --restore-chat-history",
+		},
+		// Aider: already-has-resume cases — no-op.
+		{
+			"aider already --restore-chat-history",
+			"aider --restore-chat-history",
+			"aider --restore-chat-history",
+		},
+		// Aider: explicit opt-out — respect the user's choice and leave
+		// the program string alone.
+		{
+			"aider explicit --no-restore-chat-history",
+			"aider --no-restore-chat-history",
+			"aider --no-restore-chat-history",
+		},
+
+		// Gemini: append --resume latest at the end. "latest" resumes
+		// the most recent session in cwd and silently falls back to a
+		// fresh session if none exists.
+		{"gemini bare", "gemini", "gemini --resume latest"},
+		{
+			"gemini with flag",
+			"gemini --model x",
+			"gemini --model x --resume latest",
+		},
+		{
+			"gemini absolute path",
+			"/usr/local/bin/gemini --foo",
+			"/usr/local/bin/gemini --foo --resume latest",
+		},
+		{
+			// Quoted path with spaces (regression for #569).
+			"gemini quoted path with spaces",
+			"'/path with space/gemini' --foo",
+			"'/path with space/gemini' --foo --resume latest",
+		},
+		// Gemini: already-has-resume cases — no-op so repeated Restore
+		// calls don't accumulate flags.
+		{
+			"gemini already --resume latest",
+			"gemini --resume latest",
+			"gemini --resume latest",
+		},
+		{
+			// User picked a specific session by index — respect it,
+			// don't clobber with "latest".
+			"gemini already --resume numeric",
+			"gemini --resume 5",
+			"gemini --resume 5",
+		},
+		{"gemini already -r", "gemini -r latest", "gemini -r latest"},
 
 		// Unknown programs are passed through unchanged so unrelated CLIs
 		// aren't accidentally rewritten.
@@ -99,7 +163,11 @@ func TestResumeProgram_Idempotent(t *testing.T) {
 		"codex exec",
 		"codex --model gpt-5",
 		"aider",
+		"aider --model x",
+		"aider --no-restore-chat-history",
 		"gemini",
+		"gemini --model x",
+		"gemini --resume 5",
 	} {
 		once := resumeProgram(in)
 		twice := resumeProgram(once)


### PR DESCRIPTION
## Summary

Follow-up to #595 / #596. PR #596 wired the resume-on-respawn rewrite for `claude` (`--continue`) and `codex` (`resume --last`) inside `session/tmux/resume.go`. This PR extends the same `Restore()` path to the remaining two entries in `SupportedPrograms` so all four supported agents reconnect to their prior conversation when tmux re-spawns a vanished session (e.g. tmux server died after reboot, #386).

## Transformation table (additions to #596)

| Agent  | Before                          | After                                                  | Notes |
|--------|---------------------------------|--------------------------------------------------------|-------|
| aider  | `aider`                         | `aider --restore-chat-history`                         | Reads `.aider.chat.history.md` from cwd; silent fallback when absent. |
| aider  | `aider --model x`               | `aider --model x --restore-chat-history`               | Tail append — flag is position-independent. |
| aider  | `'/path with space/aider' --foo`| `'/path with space/aider' --foo --restore-chat-history`| Quoting on the executable token preserved (regression-safe vs #569). |
| aider  | `aider --restore-chat-history`  | unchanged                                              | Idempotent — repeated Restore() calls don't accumulate. |
| aider  | `aider --no-restore-chat-history`| unchanged                                             | Respect explicit user opt-out. |
| gemini | `gemini`                        | `gemini --resume latest`                               | `latest` resumes most recent session in cwd; silent fallback when none. |
| gemini | `gemini --model x`              | `gemini --model x --resume latest`                     | Tail append. |
| gemini | `'/path with space/gemini' --foo`| `'/path with space/gemini' --foo --resume latest`     | Quoting preserved. |
| gemini | `gemini --resume latest`        | unchanged                                              | Idempotent. |
| gemini | `gemini --resume 5`             | unchanged                                              | User picked a specific session by index — respect it. |
| gemini | `gemini -r latest`              | unchanged                                              | Short form already present. |

## Audit (re-confirming #596)

- `Restore()` in `session/tmux/tmux.go:303` remains the single call site that goes through `resumeProgram`. No new callers in this PR.
- After this PR, **all four** `SupportedPrograms` (claude, codex, aider, gemini) have explicit resume handling. The `// unknown program → unchanged` default branch still covers anything else.
- Idempotence guards on both new cases prevent flag accumulation across repeated `Restore()` calls.
- Token-level surgery preserves shell quoting on the executable path (regression-safe vs #569 macOS App Bundle paths).
- Both `--restore-chat-history` and `--resume latest` silently fall back to a fresh session when no prior history exists in cwd, matching the unconditional-rewrite contract from #596.

## CI gate confirmations

Run locally before push:

- [x] `gofmt -l .` clean (excluding `.claude/worktrees/`)
- [x] `go build ./...` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go test -race -count=1 ./session/tmux/...` clean

## Test plan

New subtests under `TestResumeProgram` in `session/tmux/resume_test.go`:

- [x] `aider bare`
- [x] `aider with model flag`
- [x] `aider absolute path`
- [x] `aider quoted path with spaces`
- [x] `aider already --restore-chat-history`
- [x] `aider explicit --no-restore-chat-history`
- [x] `gemini bare`
- [x] `gemini with flag`
- [x] `gemini absolute path`
- [x] `gemini quoted path with spaces`
- [x] `gemini already --resume latest`
- [x] `gemini already --resume numeric`
- [x] `gemini already -r`

Idempotence (`TestResumeProgram_Idempotent`) extended with `aider`, `aider --model x`, `aider --no-restore-chat-history`, `gemini`, `gemini --model x`, `gemini --resume 5`.

Signed-off-by: Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)