### PR TITLE
chore(app): add detach-path instrumentation to catch #598 hang in the wild

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -266,6 +266,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		selected := m.sidebar.GetSelectedInstance()
 		return m, tea.Batch(tickUpdatePRInfoCmd, fetchPRInfoCmd(selected, true))
 	case prInfoUpdatedMsg:
+		detachTraceMark("prInfoUpdatedMsg-handler-entry")
 		if msg.err != nil {
 			log.WarningLog.Printf("PR info fetch failed for %q: %v", msg.instance.Title, msg.err)
 			// Mark as fetched anyway so we don't thrash retries on every
@@ -274,21 +275,31 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		msg.instance.SetPRInfo(msg.info)
+		saveStart := time.Now()
 		if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
 			log.WarningLog.Printf("failed to save instances after PR update: %v", err)
 		}
+		detachTrace(saveStart, "prInfoUpdatedMsg-SaveInstances-returned")
 		return m, nil
 	case tickPendingInstancesMessage:
+		detachTraceMark("tickPendingInstancesMessage-handler-entry")
 		m.mergePendingInstances()
 		return m, tickPendingInstancesCmd
 	case tickRefreshExternalMessage:
+		// Logged even when the tick is a no-op so we can spot it racing
+		// with detach in the trace tail.
+		detachTraceMark("tickRefreshExternalMessage-handler-entry")
+		tickStart := time.Now()
 		changed := m.refreshExternalInstances()
+		detachTrace(tickStart, "tickRefreshExternalMessage-refreshExternalInstances-returned")
 		var cmds []tea.Cmd
 		cmds = append(cmds, tickRefreshExternalCmd)
 		if changed {
+			saveStart := time.Now()
 			if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
 				log.WarningLog.Printf("failed to save instances after refresh: %v", err)
 			}
+			detachTrace(saveStart, "tickRefreshExternalMessage-SaveInstances-returned")
 			cmds = append(cmds, m.selectionChanged())
 		}
 		return m, tea.Batch(cmds...)
@@ -300,6 +311,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// after tmux detach, because rendering can't catch up until the
 		// loop drains. Snapshot the instance list on the event loop and
 		// hand the work off to a goroutine so View() isn't blocked.
+		detachTraceMark("tickUpdateMetadataMessage-handler-entry")
 		instances := m.sidebar.GetInstances()
 		return m, runMetadataTickCmd(instances)
 	case tea.MouseMsg:
@@ -341,11 +353,19 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// preview/terminal refresh so fresh content lands within a few
 		// milliseconds. selectionChanged() also dispatches the captures
 		// off the event loop, so this handler returns instantly.
-		return m, m.selectionChanged()
+		detachTraceMark("repaintAfterDetachMsg-handler-entry")
+		cmd := m.selectionChanged()
+		detachTraceMark("repaintAfterDetachMsg-handler-exit")
+		return m, cmd
 	case panesRefreshedMsg:
 		// The refresh cmd already wrote captured content into the mutex-
 		// guarded pane state. Returning here causes bubbletea to invoke
 		// View() again, which renders the now-fresh content.
+		detachTraceMark("panesRefreshedMsg-handler-entry")
+		// End the slow-detach watchdog: the post-detach paint completed,
+		// so any in-flight watchdog should stop. No-op when no detach is
+		// currently in flight.
+		endDetachWatchdog()
 		return m, nil
 	case instanceStartedMsg:
 		// The user may have navigated elsewhere while the instance was
@@ -730,14 +750,30 @@ func (m *home) attachToInstance(title string) (tea.Model, tea.Cmd) {
 			m.sidebar.SelectInstance(inst)
 			m.contentPane.SetMode(ui.ContentModeInstance)
 			return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
+				detachTraceMark(fmt.Sprintf("attachToInstance-onDismiss-entry title=%s", title))
 				ch, err := inst.Attach()
 				if err != nil {
 					log.ErrorLog.Printf("failed to attach to %s: %v", title, err)
 					return nil
 				}
+				// <-ch blocks for as long as the user is attached. Mark the
+				// boundary so post-detach elapsed times in the trace are
+				// measured from when the user actually returned to the UI,
+				// not from when the attach started.
+				detachTraceMark(fmt.Sprintf("attachToInstance-blocking-on-<-ch title=%s", title))
 				<-ch
+				detachStart := time.Now()
+				detachTraceMark(fmt.Sprintf("attachToInstance-<-ch-unblocked title=%s", title))
 				m.state = stateDefault
-				return func() tea.Msg { return repaintAfterDetachMsg{} }
+				// Arm the slow-detach watchdog: if the post-detach paint
+				// (panesRefreshedMsg) does not arrive within
+				// slowDetachThreshold, a goroutine dump is appended to
+				// detach-slow.log so we can see which goroutine is blocked.
+				beginDetachWatchdog(fmt.Sprintf("attachToInstance title=%s", title))
+				return func() tea.Msg {
+					detachTrace(detachStart, "attachToInstance-repaintAfterDetachMsg-emitted")
+					return repaintAfterDetachMsg{}
+				}
 			})
 		}
 	}
@@ -780,6 +816,8 @@ func (m *home) navigateToSection(kind ui.SidebarSectionKind) {
 // the goroutine can mutate it while View() reads it. Synchronous fields
 // touched here (mode, menu state, scroll-reset) stay on the event loop.
 func (m *home) selectionChanged() tea.Cmd {
+	selectionStart := time.Now()
+	detachTraceMark("selectionChanged-entry")
 	sel := m.sidebar.GetSelection()
 	tw := m.contentPane.TabbedWindow()
 
@@ -793,6 +831,7 @@ func (m *home) selectionChanged() tea.Cmd {
 		m.menu.SetInstance(selected)
 		m.menu.SetSidebarContext(sel.Kind, sel.IsHeader)
 		refreshCmd = refreshPanesCmd(tw, selected)
+		detachTrace(selectionStart, "selectionChanged-instance-branch-built-cmds")
 		// Lazily refresh PR info when the user lands on an instance that
 		// hasn't been fetched recently. fetchPRInfoCmd is a no-op when the
 		// data is still fresh, so rapid Up/Down navigation doesn't hammer gh.
@@ -842,12 +881,19 @@ type panesRefreshedMsg struct{}
 // captured content concurrently with the renderer (#579).
 func refreshPanesCmd(tw *ui.TabbedWindow, selected *session.Instance) tea.Cmd {
 	return func() tea.Msg {
+		cmdStart := time.Now()
+		detachTraceMark("refreshPanesCmd-goroutine-entry")
+		previewStart := time.Now()
 		if err := tw.UpdatePreview(selected); err != nil {
 			log.WarningLog.Printf("UpdatePreview failed: %v", err)
 		}
+		detachTrace(previewStart, "refreshPanesCmd-UpdatePreview-returned")
+		terminalStart := time.Now()
 		if err := tw.UpdateTerminal(selected); err != nil {
 			log.WarningLog.Printf("UpdateTerminal failed: %v", err)
 		}
+		detachTrace(terminalStart, "refreshPanesCmd-UpdateTerminal-returned")
+		detachTrace(cmdStart, "refreshPanesCmd-goroutine-exit")
 		return panesRefreshedMsg{}
 	}
 }

--- a/app/detach_trace.go
+++ b/app/detach_trace.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// detachTraceEnabled gates the [detach-trace] markers emitted on the
+// post-detach hot path. Defaulting to true means real users hit by issue
+// #598 capture diagnostic markers in agent-factory.log automatically — the
+// prior two attempts at this bug (#560, #593) shipped synthetic
+// microbenches that did not reproduce what users actually hit, so we need
+// data from real slow detaches. log.WarningLog writes are buffered through
+// the Go log package and are cheap; gating still gives us a flip-the-switch
+// off in case it ever proves otherwise.
+var detachTraceEnabled = true
+
+// slowDetachThreshold is the elapsed window above which startSlowDetachWatchdog
+// takes a goroutine dump. 2s is well above the post-detach paint budget
+// (#579 measured the BEFORE worst case at ~109ms) so any dump represents a
+// real hang worth reading the stacks of.
+const slowDetachThreshold = 2 * time.Second
+
+// detachSlowDumpFileName is the basename of the goroutine-dump file written
+// next to agent-factory.log on a slow detach. The full path is
+// <config-dir>/detach-slow.log — on Linux that is
+// ~/.config/agent-factory/detach-slow.log, matching where agent-factory.log
+// lives so users already know where to look.
+const detachSlowDumpFileName = "detach-slow.log"
+
+// detachTrace logs a marker with the elapsed time since start. Cheap when
+// detachTraceEnabled is false (compiles to a single compare-and-branch).
+func detachTrace(start time.Time, marker string) {
+	if !detachTraceEnabled {
+		return
+	}
+	log.WarningLog.Printf("[detach-trace] %s elapsed=%v", marker, time.Since(start))
+}
+
+// detachTraceFields logs a marker with elapsed time and a free-form fields
+// string (e.g. instance title, error message). Use this when the marker
+// alone is ambiguous.
+func detachTraceFields(start time.Time, marker, fields string) {
+	if !detachTraceEnabled {
+		return
+	}
+	log.WarningLog.Printf("[detach-trace] %s elapsed=%v %s", marker, time.Since(start), fields)
+}
+
+// detachTraceMark logs a marker without an elapsed time — for boundaries
+// where we don't have a reference start (e.g. tick handlers that may race
+// with a detach in progress; correlating against nearby start-relative
+// markers in the same log tail is enough).
+func detachTraceMark(marker string) {
+	if !detachTraceEnabled {
+		return
+	}
+	log.WarningLog.Printf("[detach-trace] %s", marker)
+}
+
+// dumpSlowDetach writes a full goroutine dump to <config-dir>/detach-slow.log,
+// prefixed with a header line carrying the label, elapsed time, and an
+// RFC3339 timestamp so multiple slow detaches in one session are easy to
+// pull apart. runtime.GC() is run first so any goroutines waiting on a
+// finalizer-driven release surface in the dump in their post-GC state.
+//
+// Best-effort: every failure (config-dir lookup, mkdir, open, write) logs
+// to WarningLog and returns. The instrumentation must never break the
+// running app even if disk is full or the home directory is unwritable.
+func dumpSlowDetach(label string, start time.Time) {
+	runtime.GC()
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		log.WarningLog.Printf("[detach-trace] could not resolve config dir for slow-dump: %v", err)
+		return
+	}
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		log.WarningLog.Printf("[detach-trace] could not mkdir config dir for slow-dump: %v", err)
+		return
+	}
+	dumpPath := filepath.Join(configDir, detachSlowDumpFileName)
+	f, err := os.OpenFile(dumpPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		log.WarningLog.Printf("[detach-trace] could not open slow-dump file %s: %v", dumpPath, err)
+		return
+	}
+	defer f.Close()
+
+	elapsed := time.Since(start)
+	header := fmt.Sprintf("=== %s — %s — elapsed=%v ===\n",
+		time.Now().Format(time.RFC3339Nano), label, elapsed)
+	if _, err := f.WriteString(header); err != nil {
+		log.WarningLog.Printf("[detach-trace] failed to write slow-dump header: %v", err)
+		return
+	}
+	if _, err := f.Write(buf[:n]); err != nil {
+		log.WarningLog.Printf("[detach-trace] failed to write slow-dump stacks: %v", err)
+		return
+	}
+	if _, err := f.WriteString("\n\n"); err != nil {
+		log.WarningLog.Printf("[detach-trace] failed to write slow-dump trailer: %v", err)
+		return
+	}
+	log.WarningLog.Printf("[detach-trace] SLOW DETACH (%s) elapsed=%v — goroutine dump appended to %s",
+		label, elapsed, dumpPath)
+}
+
+// startSlowDetachWatchdog spawns a goroutine that waits up to
+// slowDetachThreshold for completion (close(done)) and, if the threshold
+// elapses first, takes a goroutine dump and then continues waiting so it
+// never leaks. The dump is taken exactly once per call. Returns the done
+// channel — callers MUST close it when the detach completes (or abandon
+// it, in which case the watchdog leaks for one cycle plus the wait).
+//
+// No-op when detachTraceEnabled is false: returns a non-nil channel so
+// callers' close(done) does not panic, but the goroutine never sleeps.
+func startSlowDetachWatchdog(label string) chan struct{} {
+	done := make(chan struct{})
+	if !detachTraceEnabled {
+		return done
+	}
+	start := time.Now()
+	go func() {
+		select {
+		case <-done:
+			return
+		case <-time.After(slowDetachThreshold):
+		}
+		dumpSlowDetach(label, start)
+		<-done
+	}()
+	return done
+}
+
+// detachWatchdog tracks the in-flight slow-detach watchdog so the
+// repaint-completion handler (panesRefreshedMsg) can signal completion.
+// Guarded by a mutex because the begin/end pair straddles the bubbletea
+// Update goroutine and the cmd goroutines that drive the post-detach
+// refresh.
+var (
+	detachWatchdogMu   sync.Mutex
+	detachWatchdogDone chan struct{}
+)
+
+// beginDetachWatchdog arms the slow-detach watchdog for the current
+// detach cycle. Safe to call repeatedly: a stale watchdog from a prior
+// detach (which would only happen if the panesRefreshedMsg signal was
+// dropped) is closed before a new one is armed.
+func beginDetachWatchdog(label string) {
+	detachWatchdogMu.Lock()
+	defer detachWatchdogMu.Unlock()
+	if detachWatchdogDone != nil {
+		close(detachWatchdogDone)
+	}
+	detachWatchdogDone = startSlowDetachWatchdog(label)
+}
+
+// endDetachWatchdog signals the in-flight watchdog that the detach
+// completed cleanly. No-op when no watchdog is currently armed.
+func endDetachWatchdog() {
+	detachWatchdogMu.Lock()
+	defer detachWatchdogMu.Unlock()
+	if detachWatchdogDone != nil {
+		close(detachWatchdogDone)
+		detachWatchdogDone = nil
+	}
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -211,30 +212,46 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		}
 		if tw.IsInTerminalTab() {
 			return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
+				detachTraceMark("handleEnter-terminal-onDismiss-entry")
 				ch, err := tw.AttachTerminal()
 				if err != nil {
 					log.ErrorLog.Printf("failed to attach terminal: %v", err)
 					return nil
 				}
+				detachTraceMark("handleEnter-terminal-blocking-on-<-ch")
 				<-ch
+				detachStart := time.Now()
+				detachTraceMark("handleEnter-terminal-<-ch-unblocked")
 				m.state = stateDefault
 				// Without this msg the post-detach repaint waits up to one
 				// previewTickMsg cycle (~100ms) for the first paint. With it
 				// the bubbletea loop wakes immediately, repaints the cached
 				// content, and the async refresh in the handler swaps in
 				// fresh content within a few ms (#579).
-				return func() tea.Msg { return repaintAfterDetachMsg{} }
+				beginDetachWatchdog("handleEnter-terminal")
+				return func() tea.Msg {
+					detachTrace(detachStart, "handleEnter-terminal-repaintAfterDetachMsg-emitted")
+					return repaintAfterDetachMsg{}
+				}
 			})
 		}
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
+			detachTraceMark("handleEnter-sidebar-onDismiss-entry")
 			ch, err := m.sidebar.Attach()
 			if err != nil {
 				log.ErrorLog.Printf("failed to attach: %v", err)
 				return nil
 			}
+			detachTraceMark("handleEnter-sidebar-blocking-on-<-ch")
 			<-ch
+			detachStart := time.Now()
+			detachTraceMark("handleEnter-sidebar-<-ch-unblocked")
 			m.state = stateDefault
-			return func() tea.Msg { return repaintAfterDetachMsg{} }
+			beginDetachWatchdog("handleEnter-sidebar")
+			return func() tea.Msg {
+				detachTrace(detachStart, "handleEnter-sidebar-repaintAfterDetachMsg-emitted")
+				return repaintAfterDetachMsg{}
+			}
 		})
 	}
 	return m, nil

--- a/app/sync.go
+++ b/app/sync.go
@@ -49,10 +49,13 @@ var tickUpdateMetadataCmd = func() tea.Msg {
 // Status mutations go through Instance.SetStatus, which holds the instance
 // mutex, so concurrent reads from the renderer remain safe.
 func runMetadataTick(instances []*session.Instance) {
+	tickStart := time.Now()
+	detachTraceMark("runMetadataTick-entry")
 	for _, instance := range instances {
 		if !instance.Started() || instance.GetStatus() == session.Loading {
 			continue
 		}
+		instStart := time.Now()
 		instance.CheckAndHandleTrustPrompt()
 		updated, prompt := instance.HasUpdated()
 		if updated {
@@ -64,7 +67,13 @@ func runMetadataTick(instances []*session.Instance) {
 				instance.SetStatus(session.Ready)
 			}
 		}
+		// Per-instance elapsed makes contention visible: if 1 of N tmux
+		// capture-pane shell-outs hangs, the marker for that instance
+		// will dominate the total while the others stay sub-10ms.
+		detachTraceFields(instStart, "runMetadataTick-instance-done",
+			fmt.Sprintf("title=%s", instance.Title))
 	}
+	detachTrace(tickStart, "runMetadataTick-exit")
 }
 
 // runMetadataTickCmd returns a tea.Cmd that performs the metadata tick work
@@ -138,7 +147,10 @@ func fetchPRInfoCmd(inst *session.Instance, force bool) tea.Cmd {
 	// real result, so the fresh window starts from fetch completion.
 	inst.MarkPRInfoFetched()
 	return func() tea.Msg {
+		fetchStart := time.Now()
+		detachTraceMark("fetchPRInfoCmd-goroutine-entry")
 		info, err := prInfoFetcher(repoPath, branch)
+		detachTrace(fetchStart, "fetchPRInfoCmd-prInfoFetcher-returned")
 		return prInfoUpdatedMsg{instance: inst, info: info, err: err}
 	}
 }

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -505,6 +505,11 @@ func (t *TmuxSession) Attach() (chan struct{}, error) {
 
 			// Check for detach key
 			if nr == 1 && buf[0] == DetachKeyByte {
+				// Closest point to "user pressed detach" we can observe —
+				// the elapsed in this trace is whatever Detach() itself
+				// took, which matches what blocks the app-side <-ch.
+				log.WarningLog.Printf("[detach-trace] tmux-stdin-reader-saw-detach-key name=%s",
+					t.sanitizedName)
 				// Detach from the session
 				t.Detach()
 				return
@@ -565,7 +570,11 @@ func (t *TmuxSession) DetachSafely() error {
 // Detach disconnects from the current tmux session. Logs errors instead of panicking
 // so the application can attempt graceful recovery.
 func (t *TmuxSession) Detach() {
+	detachStart := time.Now()
+	log.WarningLog.Printf("[detach-trace] tmux.Detach-entry name=%s", t.sanitizedName)
 	defer func() {
+		log.WarningLog.Printf("[detach-trace] tmux.Detach-exit name=%s total=%v",
+			t.sanitizedName, time.Since(detachStart))
 		close(t.attachCh)
 		t.attachCh = nil
 		t.cancel = nil
@@ -578,16 +587,25 @@ func (t *TmuxSession) Detach() {
 	// abnormal termination. Without this, closing the PTY can wake the
 	// io.Copy goroutine before cancel() runs, causing a spurious
 	// "Session terminated without detaching" warning.
+	stepStart := time.Now()
 	t.cancel()
+	log.WarningLog.Printf("[detach-trace] tmux.Detach-cancel-done name=%s elapsed=%v",
+		t.sanitizedName, time.Since(stepStart))
 
 	// Close the attached pty session so the io.Copy goroutine returns.
+	stepStart = time.Now()
 	closeErr := t.ptmx.Close()
+	log.WarningLog.Printf("[detach-trace] tmux.Detach-ptmx.Close-done name=%s elapsed=%v",
+		t.sanitizedName, time.Since(stepStart))
 
 	// Wait for the attach goroutines (io.Copy + monitorWindowSize x2) to
 	// finish before mutating t.ptmx. monitorWindowSize reads t.ptmx via
 	// updateWindowSize, so clearing the field before wg.Wait races against
 	// those reads (#512). Coordinated like Close already is.
+	stepStart = time.Now()
 	t.wg.Wait()
+	log.WarningLog.Printf("[detach-trace] tmux.Detach-wg.Wait-done name=%s elapsed=%v",
+		t.sanitizedName, time.Since(stepStart))
 
 	// Now safe to clear t.ptmx. Clearing unconditionally before Restore
 	// means a Restore failure (or a Close failure) can't leave the closed
@@ -603,9 +621,12 @@ func (t *TmuxSession) Detach() {
 	// Call t.Restore to set a new t.ptmx. The session is alive (we just
 	// detached from it), so pass empty workDir — a missing session here is a
 	// real problem and should surface, not silently re-spawn and lose history.
+	stepStart = time.Now()
 	if err := t.Restore(""); err != nil {
 		log.ErrorLog.Printf("error restoring pty after detach: %v", err)
 	}
+	log.WarningLog.Printf("[detach-trace] tmux.Detach-Restore-done name=%s elapsed=%v",
+		t.sanitizedName, time.Since(stepStart))
 }
 
 // Close terminates the tmux session and cleans up resources


### PR DESCRIPTION
## Summary

Instrumentation-only PR for #598 — **no behavior changes**.

The two prior attempts on this hot path ([#560](https://github.com/sachiniyer/agent-factory/pull/560), [#593](https://github.com/sachiniyer/agent-factory/pull/593)) shipped synthetic microbench fixes that did not reproduce what users actually hit. Sachin reports a 10-second intermittent post-detach hang that scales with tab count — several orders of magnitude beyond either prior microbench, so something concrete is blocking on the post-detach path. The right next step is to ship observability and read a real trace, rather than guess a third time.

This PR adds:

1. **`[detach-trace]` log markers** (via `log.WarningLog`, so they land in `agent-factory.log`) at every interesting boundary on the post-detach hot path.
2. **A slow-detach goroutine dump** that fires when the post-detach paint takes longer than 2s. The full goroutine dump is appended to `<config-dir>/detach-slow.log` (Linux: `~/.config/agent-factory/detach-slow.log`), prefixed with a timestamp and the elapsed time so multiple slow detaches in one session are easy to pull apart.

Enabled by default (`detachTraceEnabled = true` in `app/detach_trace.go`) so the markers ship to real users automatically. `log.WarningLog` writes are buffered through the Go log package and are cheap; if it ever proves otherwise the gate is a single boolean flip.

## Markers added

All markers are prefixed `[detach-trace]` so a grep against `agent-factory.log` pulls just the relevant traffic.

| boundary | file | marker(s) |
| --- | --- | --- |
| user pressed detach key (closest observable point) | `session/tmux/tmux.go` | `tmux-stdin-reader-saw-detach-key` |
| inside `tmux.Detach()` — each step | `session/tmux/tmux.go` | `tmux.Detach-entry`, `tmux.Detach-cancel-done`, `tmux.Detach-ptmx.Close-done`, `tmux.Detach-wg.Wait-done`, `tmux.Detach-Restore-done`, `tmux.Detach-exit` |
| attach overlay dismiss callback (3 sites: instance attach, terminal-tab attach, sidebar attach) | `app/app.go`, `app/handle_actions.go` | `attachToInstance-onDismiss-entry`, `handleEnter-terminal-onDismiss-entry`, `handleEnter-sidebar-onDismiss-entry`, plus the `blocking-on-<-ch` / `<-ch-unblocked` / `repaintAfterDetachMsg-emitted` markers each |
| `repaintAfterDetachMsg` Update handler | `app/app.go` | `repaintAfterDetachMsg-handler-entry`, `repaintAfterDetachMsg-handler-exit` |
| `selectionChanged` (dispatches the post-detach refresh) | `app/app.go` | `selectionChanged-entry`, `selectionChanged-instance-branch-built-cmds` |
| `refreshPanesCmd` goroutine (tmux capture-pane shell-outs) | `app/app.go` | `refreshPanesCmd-goroutine-entry`, `refreshPanesCmd-UpdatePreview-returned`, `refreshPanesCmd-UpdateTerminal-returned`, `refreshPanesCmd-goroutine-exit` |
| `panesRefreshedMsg` — final repaint signal (also ends the watchdog) | `app/app.go` | `panesRefreshedMsg-handler-entry` |
| tick handlers that race with detach | `app/app.go` | `tickRefreshExternalMessage-handler-entry`, `tickUpdateMetadataMessage-handler-entry`, `tickPendingInstancesMessage-handler-entry`, `prInfoUpdatedMsg-handler-entry` |
| `SaveInstances` disk writes on the post-detach window | `app/app.go` | `tickRefreshExternalMessage-SaveInstances-returned`, `prInfoUpdatedMsg-SaveInstances-returned` |
| `runMetadataTick` per-instance tmux capture-pane (off-loop after #560 but can still contend with the tmux server) | `app/sync.go` | `runMetadataTick-entry`, `runMetadataTick-instance-done title=...`, `runMetadataTick-exit` |
| `fetchPRInfoCmd` (`gh pr view` shell-out — dispatched from `selectionChanged`) | `app/sync.go` | `fetchPRInfoCmd-goroutine-entry`, `fetchPRInfoCmd-prInfoFetcher-returned` |

Markers that bracket work (e.g. `tmux.Detach-cancel-done`) include `elapsed=<duration>` so each step's cost is visible without subtracting timestamps by hand.

## Slow-detach goroutine dump

When the post-detach paint takes longer than 2s, a goroutine dump is appended to `<config-dir>/detach-slow.log`. The watchdog is armed in the attach-overlay dismiss callback right after `<-ch` unblocks (3 sites) and cleared by the `panesRefreshedMsg` handler.

- Path: `<config-dir>/detach-slow.log` — Linux: `~/.config/agent-factory/detach-slow.log`, macOS: `~/Library/Application Support/agent-factory/detach-slow.log`, or under `$AGENT_FACTORY_HOME` if set. Sits next to `agent-factory.log` so users already know where to look.
- Each dump is prefixed with `=== <RFC3339-timestamp> — <label> — elapsed=<duration> ===`.
- `runtime.GC()` is run before `runtime.Stack(buf, true)` so any finalizer-driven releases surface in their post-GC state.
- 1 MiB buffer; truncation is preferable to OOM if the runtime ever spawns an enormous number of goroutines.
- Best-effort writes — every failure (config-dir lookup, mkdir, open, write) logs to `WarningLog` and returns. The instrumentation must never break the running app.

## Why this matters for #598

A 10s hang scaling with tab count is most plausibly one of:

- tmux server contention — capture-pane is now async after #560, so multiple ticks can hit the same tmux server simultaneously; the user's detach Restore (which runs `tmux attach-session`) waits behind queued capture-pane requests.
- daemon RPC blocking a code path I haven't audited.
- disk I/O on `SaveInstances` scaling with N instances.
- a goroutine deadlock or lock contention reachable only at higher tab counts.

The trace markers + the goroutine dump together pin down which of these (or something else entirely) is actually happening. Once Sachin hits the hang and shares the trace, the fix PR follows.

## Scope discipline

- No control-flow changes. Every existing code path produces the same outcome it did before — the only additions are `log.WarningLog.Printf` calls and one watchdog goroutine that exists only between the detach key press and the post-detach repaint.
- The watchdog goroutine never holds locks while sleeping and uses a closeable done channel so it cannot leak across detaches.
- `selectionChanged` is reached from many call sites; the marker there fires on every selection change, not only on detach. That's intentional — it makes the per-call cost visible in the same log, and matches the granularity needed to distinguish "the detach itself was slow" from "an unrelated selection-change happened to overlap".

## CI gates (all confirmed locally)

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go test -race -count=1 ./...` — all packages pass except the pre-existing `daemon.TestSigtermFallback_DeadPID`, which fails identically on this branch's parent commit (`git stash` confirmed). That failure is caused by two real `af --daemon` processes running on the dev machine and was already called out in #593's PR body — not related to this change.

## Next step

After this lands and ships in a release, wait for Sachin (or any user) to hit the hang again. Read `agent-factory.log` for the `[detach-trace]` markers and `~/.config/agent-factory/detach-slow.log` for the goroutine dump. The fix PR follows from what the trace actually says.

— Captain Claude

Co-authored-by: Captain Claude <noreply@anthropic.com>