### PR TITLE
fix(app): pause background tmux work while attached to eliminate detach hang (#598)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -112,6 +113,19 @@ type home struct {
 	availableWorktrees []git.WorktreeInfo
 	// pendingProgram tracks the program selected during new instance naming
 	pendingProgram string
+
+	// attached is set while the user is inside an attached tmux session.
+	// While true, periodic background work that hits the shared tmux server
+	// (capture-pane via runMetadataTick, refreshPanesCmd, fetchPRInfoCmd) is
+	// paused so the user's detach key-press is never queued behind it. See
+	// issue #598 — the 44s detach hang was traced to wg.Wait waiting on
+	// the tmux client to exit, which itself was blocked behind ~40 RPS of
+	// capture-pane requests we were generating from the metadata tick.
+	//
+	// Stored as atomic because the attach overlay's onDismiss callback runs
+	// off the bubbletea Update goroutine (as a tea.Cmd) and toggles this
+	// while Update reads it on every tick.
+	attached atomic.Bool
 }
 
 func newHome(ctx context.Context, program string, autoYes bool, repoID string) *home {
@@ -247,7 +261,17 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case hideErrMsg:
 		m.errBox.Clear()
 	case previewTickMsg:
-		cmd := m.selectionChanged()
+		// While the user is attached to an instance, the preview/terminal
+		// panes are hidden behind the tmux client they detached into. Running
+		// selectionChanged here would dispatch refreshPanesCmd (two tmux
+		// capture-pane shell-outs against the shared tmux server) every
+		// 100ms — exactly the contention that produced the 44s detach hang
+		// in #598. Keep the tick alive so the first post-detach iteration
+		// fires within ~100ms of clearing the flag, but skip the work.
+		var cmd tea.Cmd
+		if !m.attached.Load() {
+			cmd = m.selectionChanged()
+		}
 		return m, tea.Batch(
 			cmd,
 			func() tea.Msg {
@@ -263,6 +287,11 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// instances keep whatever was last fetched (or restored from disk) —
 		// they'll refresh when the user actually looks at them. The fetch
 		// itself runs in a background goroutine so the UI stays responsive.
+		// Skip the fetch while attached: gh pr view is a network call and
+		// the sidebar PR badge is hidden behind the tmux client (#598).
+		if m.attached.Load() {
+			return m, tickUpdatePRInfoCmd
+		}
 		selected := m.sidebar.GetSelectedInstance()
 		return m, tea.Batch(tickUpdatePRInfoCmd, fetchPRInfoCmd(selected, true))
 	case prInfoUpdatedMsg:
@@ -311,7 +340,17 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// after tmux detach, because rendering can't catch up until the
 		// loop drains. Snapshot the instance list on the event loop and
 		// hand the work off to a goroutine so View() isn't blocked.
+		//
+		// While the user is attached, skip the per-instance work entirely:
+		// the sidebar is hidden, status flips have no visible effect, and
+		// the capture-pane calls were contending with the user's detach
+		// keystroke against the shared tmux server (#598). Keep the
+		// re-schedule cmd so the next tick fires within ~500ms of detach,
+		// catching the sidebar up promptly.
 		detachTraceMark("tickUpdateMetadataMessage-handler-entry")
+		if m.attached.Load() {
+			return m, tickUpdateMetadataCmd
+		}
 		instances := m.sidebar.GetInstances()
 		return m, runMetadataTickCmd(instances)
 	case tea.MouseMsg:
@@ -750,34 +789,57 @@ func (m *home) attachToInstance(title string) (tea.Model, tea.Cmd) {
 			m.sidebar.SelectInstance(inst)
 			m.contentPane.SetMode(ui.ContentModeInstance)
 			return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-				detachTraceMark(fmt.Sprintf("attachToInstance-onDismiss-entry title=%s", title))
-				ch, err := inst.Attach()
-				if err != nil {
-					log.ErrorLog.Printf("failed to attach to %s: %v", title, err)
-					return nil
-				}
-				// <-ch blocks for as long as the user is attached. Mark the
-				// boundary so post-detach elapsed times in the trace are
-				// measured from when the user actually returned to the UI,
-				// not from when the attach started.
-				detachTraceMark(fmt.Sprintf("attachToInstance-blocking-on-<-ch title=%s", title))
-				<-ch
-				detachStart := time.Now()
-				detachTraceMark(fmt.Sprintf("attachToInstance-<-ch-unblocked title=%s", title))
-				m.state = stateDefault
-				// Arm the slow-detach watchdog: if the post-detach paint
-				// (panesRefreshedMsg) does not arrive within
-				// slowDetachThreshold, a goroutine dump is appended to
-				// detach-slow.log so we can see which goroutine is blocked.
-				beginDetachWatchdog(fmt.Sprintf("attachToInstance title=%s", title))
-				return func() tea.Msg {
-					detachTrace(detachStart, "attachToInstance-repaintAfterDetachMsg-emitted")
-					return repaintAfterDetachMsg{}
-				}
+				return m.attachOverlayCallback("attachToInstance",
+					fmt.Sprintf(" title=%s", title), inst.Attach)
 			})
 		}
 	}
 	return m, m.handleError(fmt.Errorf("instance %q not found", title))
+}
+
+// attachOverlayCallback runs the attach-overlay onDismiss lifecycle: emits
+// the detach-trace markers, invokes attach, arms the attached flag for the
+// duration of `<-ch`, then returns the tea.Cmd to emit the
+// repaintAfterDetachMsg{}. Returns nil when attach itself fails so the
+// callback can be passed directly to showHelpScreen's onDismiss.
+//
+// The defer on m.attached.Store(false) is load-bearing: it guarantees the
+// flag clears even if `<-ch` is woken by an abnormal close or a panic
+// further down the stack. Leaving the flag stuck at true would silently
+// stall the metadata tick, preview refresh, and PR info fetcher until the
+// next process restart — exactly the kind of regression #598 wants to
+// avoid creating while fixing the original hang.
+//
+// Extracted so the three attach call-sites (handleEnter sidebar, handleEnter
+// terminal-tab, attachToInstance) all funnel through one place — and so the
+// pause-while-attached gating + the flag-clears-on-error path are testable
+// without spinning up real tmux.
+func (m *home) attachOverlayCallback(label, traceSuffix string, attach func() (chan struct{}, error)) tea.Cmd {
+	detachTraceMark(label + "-onDismiss-entry" + traceSuffix)
+	ch, err := attach()
+	if err != nil {
+		log.ErrorLog.Printf("failed to attach (%s): %v", label+traceSuffix, err)
+		return nil
+	}
+	m.attached.Store(true)
+	defer m.attached.Store(false)
+	// <-ch blocks for as long as the user is attached. Mark the boundary so
+	// post-detach elapsed times in the trace are measured from when the user
+	// actually returned to the UI, not from when the attach started.
+	detachTraceMark(label + "-blocking-on-<-ch" + traceSuffix)
+	<-ch
+	detachStart := time.Now()
+	detachTraceMark(label + "-<-ch-unblocked" + traceSuffix)
+	m.state = stateDefault
+	// Arm the slow-detach watchdog: if the post-detach paint
+	// (panesRefreshedMsg) does not arrive within slowDetachThreshold, a
+	// goroutine dump is appended to detach-slow.log so we can see which
+	// goroutine is blocked.
+	beginDetachWatchdog(label + traceSuffix)
+	return func() tea.Msg {
+		detachTrace(detachStart, label+"-repaintAfterDetachMsg-emitted")
+		return repaintAfterDetachMsg{}
+	}
 }
 
 // navigateToSection moves the sidebar selection to the header of the given section.
@@ -821,6 +883,14 @@ func (m *home) selectionChanged() tea.Cmd {
 	sel := m.sidebar.GetSelection()
 	tw := m.contentPane.TabbedWindow()
 
+	// While attached, the sidebar is hidden behind the tmux client and the
+	// preview/terminal panes will be repainted by repaintAfterDetachMsg as
+	// soon as the user detaches. Skip the refresh + PR fetch dispatches so
+	// they don't queue capture-pane / gh pr view work behind the user's
+	// detach key (#598). The synchronous mutations (mode, menu state) still
+	// run so sidebar nav that happens between attach failures is consistent.
+	attachedNow := m.attached.Load()
+
 	var prFetch tea.Cmd
 	var refreshCmd tea.Cmd
 	switch {
@@ -830,12 +900,14 @@ func (m *home) selectionChanged() tea.Cmd {
 		tw.SetInstance(selected)
 		m.menu.SetInstance(selected)
 		m.menu.SetSidebarContext(sel.Kind, sel.IsHeader)
-		refreshCmd = refreshPanesCmd(tw, selected)
+		if !attachedNow {
+			refreshCmd = refreshPanesCmd(tw, selected)
+		}
 		detachTrace(selectionStart, "selectionChanged-instance-branch-built-cmds")
 		// Lazily refresh PR info when the user lands on an instance that
 		// hasn't been fetched recently. fetchPRInfoCmd is a no-op when the
 		// data is still fresh, so rapid Up/Down navigation doesn't hammer gh.
-		if selected != nil && selected.Started() {
+		if !attachedNow && selected != nil && selected.Started() {
 			prFetch = fetchPRInfoCmd(selected, false)
 		}
 	case sel.Kind == ui.SectionTasks:

--- a/app/attached_pause_test.go
+++ b/app/attached_pause_test.go
@@ -1,0 +1,278 @@
+package app
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTickUpdateMetadata_PausedWhileAttached is the regression test for #598:
+// while the user is inside an attached tmux session, the metadata tick must
+// not dispatch runMetadataTickCmd. The handler should return only the
+// re-schedule cmd so the next tick fires within ~500ms of detach — which is
+// what keeps the sidebar caught up without a multi-second backoff.
+//
+// Before the fix, runMetadataTickCmd ran every 500ms regardless of attach
+// state and shelled out to tmux capture-pane 2 × N times. With ~10 sessions
+// and an occasional slow capture, the resulting 40+ RPS against the shared
+// tmux server queued the user's detach key for tens of seconds (#598).
+func TestTickUpdateMetadata_PausedWhileAttached(t *testing.T) {
+	h := newTestHome(t)
+	a := instanceWithFakeBackend(t, "a")
+	h.sidebar.AddInstance(a)
+
+	h.attached.Store(true)
+	_, cmd := h.Update(tickUpdateMetadataMessage{})
+	require.NotNil(t, cmd, "handler must still return a re-schedule cmd while attached")
+
+	// The re-schedule cmd is the package-level tickUpdateMetadataCmd; the
+	// per-instance work cmd is runMetadataTickCmd(...). The only way to
+	// tell them apart cheaply is by what they return when invoked: the
+	// re-schedule sleeps then returns tickUpdateMetadataMessage{}; the
+	// work cmd runs CheckAndHandleTrustPrompt/HasUpdated on each instance
+	// and then returns tickUpdateMetadataMessage{}.
+	//
+	// Asserting on the function-pointer identity is the most direct check:
+	// while attached we must return the bare re-schedule var, not a
+	// freshly-constructed runMetadataTickCmd closure that captured the
+	// instance slice.
+	gotPtr := reflect.ValueOf(cmd).Pointer()
+	wantPtr := reflect.ValueOf(tickUpdateMetadataCmd).Pointer()
+	assert.Equal(t, wantPtr, gotPtr,
+		"while attached the handler must return tickUpdateMetadataCmd, "+
+			"not runMetadataTickCmd — otherwise capture-pane work runs in "+
+			"the background and contends with the user's detach key (#598)")
+
+	// And just to be sure: invoking the cmd must not have mutated the
+	// instance status (which is what runMetadataTickCmd would do via
+	// HasUpdated → Ready).
+	assert.Equal(t, session.Running, a.GetStatus(),
+		"instance status must not flip while attached — no per-instance "+
+			"capture-pane work should have run")
+}
+
+// TestTickUpdateMetadata_RunsWhenNotAttached is the symmetric test: with
+// attached=false, the handler must dispatch the work cmd as it always has.
+// This guards against the gate being too aggressive (e.g. an inverted
+// boolean) and silently breaking the sidebar Running/Ready status forever.
+func TestTickUpdateMetadata_RunsWhenNotAttached(t *testing.T) {
+	h := newTestHome(t)
+	a := instanceWithFakeBackend(t, "a")
+	h.sidebar.AddInstance(a)
+
+	require.False(t, h.attached.Load(), "test pre-condition: not attached")
+	_, cmd := h.Update(tickUpdateMetadataMessage{})
+	require.NotNil(t, cmd)
+
+	// Identity check the other way around: the cmd we got must NOT be the
+	// bare re-schedule cmd. It must be a freshly-constructed closure from
+	// runMetadataTickCmd.
+	gotPtr := reflect.ValueOf(cmd).Pointer()
+	wantPtr := reflect.ValueOf(tickUpdateMetadataCmd).Pointer()
+	assert.NotEqual(t, wantPtr, gotPtr,
+		"while not attached the handler must dispatch runMetadataTickCmd "+
+			"with the snapshot of instances, not the bare re-schedule cmd")
+
+	// Invoking the cmd should drive the FakeBackend HasUpdated path, which
+	// returns (updated=false, hasPrompt=false), flipping Running → Ready.
+	msg := cmd()
+	_, ok := msg.(tickUpdateMetadataMessage)
+	require.True(t, ok, "runMetadataTickCmd must re-emit tickUpdateMetadataMessage; got %T", msg)
+	assert.Equal(t, session.Ready, a.GetStatus(),
+		"work cmd must have executed against the instance")
+}
+
+// TestPreviewTick_PausedWhileAttached verifies that the previewTickMsg
+// handler skips selectionChanged (and therefore refreshPanesCmd, two
+// capture-pane shell-outs) while attached. The handler must still re-arm
+// the tick so a sub-second post-detach repaint is guaranteed.
+func TestPreviewTick_PausedWhileAttached(t *testing.T) {
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "a")
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	h.attached.Store(true)
+	_, cmd := h.Update(previewTickMsg{})
+	require.NotNil(t, cmd, "previewTickMsg must keep the tick alive even while attached")
+
+	// We can't compare tea.Batch closures by identity. Instead, drive the
+	// batch and confirm panesRefreshedMsg never lands (which is what
+	// refreshPanesCmd would return). The batch only contains the
+	// re-schedule sleep — running it should yield previewTickMsg.
+	got := drainCmd(t, cmd, 250*time.Millisecond)
+	for _, msg := range got {
+		_, isPanesRefreshed := msg.(panesRefreshedMsg)
+		assert.False(t, isPanesRefreshed,
+			"while attached previewTickMsg must not dispatch refreshPanesCmd — "+
+				"saw a panesRefreshedMsg in the batch")
+	}
+}
+
+// TestSelectionChanged_SkipsRefreshWhileAttached covers selectionChanged
+// directly. While attached, it must skip refreshPanesCmd and fetchPRInfoCmd
+// — both of which were observed in the #598 trace adding to tmux-server
+// contention. The synchronous mutations (mode, menu state) still run so
+// other code paths that happen to call selectionChanged stay consistent.
+func TestSelectionChanged_SkipsRefreshWhileAttached(t *testing.T) {
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "a")
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	h.attached.Store(true)
+	cmd := h.selectionChanged()
+	// tea.Batch(nil, nil) returns nil; that's the expected result while
+	// attached. If the gate fails we'd see a non-nil batch from
+	// refreshPanesCmd.
+	assert.Nil(t, cmd,
+		"selectionChanged must return nil while attached: refreshPanesCmd "+
+			"and fetchPRInfoCmd are both gated — neither should be queued "+
+			"behind the user's detach key (#598)")
+}
+
+// TestTickUpdatePRInfo_PausedWhileAttached: the 60s PR info refresh tick
+// shells out to `gh pr view` for the selected instance. While attached
+// that network round-trip provides no visible benefit (PR badge in the
+// hidden sidebar) and races against detach for the tmux/socket stack.
+func TestTickUpdatePRInfo_PausedWhileAttached(t *testing.T) {
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "a")
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	// Count fetch invocations to prove fetchPRInfoCmd was NOT dispatched.
+	calls := 0
+	restore := SetPRInfoFetcherForTest(func(string, string) (*git.PRInfo, error) {
+		calls++
+		return nil, nil
+	})
+	defer restore()
+
+	h.attached.Store(true)
+	_, cmd := h.Update(tickUpdatePRInfoMessage{})
+	require.NotNil(t, cmd, "tick must still re-arm itself")
+
+	// Identity check: the cmd should be the bare re-schedule, not a
+	// tea.Batch that contains fetchPRInfoCmd.
+	gotPtr := reflect.ValueOf(cmd).Pointer()
+	wantPtr := reflect.ValueOf(tickUpdatePRInfoCmd).Pointer()
+	assert.Equal(t, wantPtr, gotPtr,
+		"while attached the handler must return tickUpdatePRInfoCmd, "+
+			"not a tea.Batch that includes fetchPRInfoCmd (#598)")
+	assert.Equal(t, 0, calls,
+		"prInfoFetcher must not be invoked while attached: gh pr view "+
+			"is a network call we don't want racing detach")
+}
+
+// TestAttachOverlayCallback_ClearsFlagOnDetach exercises the success path
+// of the attach lifecycle helper: the attached flag is armed before <-ch
+// blocks and disarmed after it unblocks. The defer in attachOverlayCallback
+// is what guarantees the disarm — this test would fail if someone replaced
+// the defer with a plain `Store(false)` and a panic occurred between the
+// two.
+func TestAttachOverlayCallback_ClearsFlagOnDetach(t *testing.T) {
+	h := newTestHome(t)
+	require.False(t, h.attached.Load(), "test pre-condition: not attached")
+
+	ch := make(chan struct{})
+	attach := func() (chan struct{}, error) { return ch, nil }
+
+	done := make(chan tea.Cmd, 1)
+	go func() {
+		done <- h.attachOverlayCallback("test-attach", " title=t1", attach)
+	}()
+
+	// While the callback is blocked on <-ch the flag must be set.
+	require.Eventually(t, func() bool { return h.attached.Load() },
+		time.Second, time.Millisecond,
+		"attached flag must be armed before <-ch blocks")
+
+	// Simulate user detaching.
+	close(ch)
+	postDetachCmd := <-done
+
+	require.False(t, h.attached.Load(),
+		"attached flag must clear after <-ch unblocks — otherwise the "+
+			"metadata tick / preview refresh / PR info fetcher stay paused "+
+			"until the next process restart")
+	require.NotNil(t, postDetachCmd, "success path returns repaintAfterDetachMsg cmd")
+	msg := postDetachCmd()
+	_, ok := msg.(repaintAfterDetachMsg)
+	assert.True(t, ok, "post-detach cmd must emit repaintAfterDetachMsg, got %T", msg)
+	// End the watchdog we armed via beginDetachWatchdog so subsequent
+	// tests don't see a stray running goroutine.
+	endDetachWatchdog()
+}
+
+// TestAttachOverlayCallback_LeavesFlagAloneWhenAttachErrors is THE
+// regression-risk path called out in the brief: if the underlying attach
+// fails before <-ch is ever reached, the callback returns nil without
+// touching the flag. That's the only way to guarantee a transient attach
+// failure can't strand the app in a permanently-paused state.
+func TestAttachOverlayCallback_LeavesFlagAloneWhenAttachErrors(t *testing.T) {
+	h := newTestHome(t)
+	require.False(t, h.attached.Load(), "test pre-condition: not attached")
+
+	attachErr := errors.New("simulated attach failure")
+	attach := func() (chan struct{}, error) { return nil, attachErr }
+
+	cmd := h.attachOverlayCallback("test-attach", "", attach)
+
+	assert.Nil(t, cmd, "attachOverlayCallback must return nil when attach fails")
+	assert.False(t, h.attached.Load(),
+		"attached flag must NOT be set when attach itself errors — "+
+			"otherwise a single failed attach permanently disables the "+
+			"metadata tick (#598 regression-risk path)")
+}
+
+// drainCmd runs cmd (and any nested tea.Cmd it produces via tea.Batch) up
+// to the given deadline and returns the messages it produced. Used by the
+// previewTickMsg pause test to inspect the batch contents.
+func drainCmd(t *testing.T, cmd tea.Cmd, deadline time.Duration) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	done := make(chan tea.Msg, 1)
+	go func() {
+		done <- cmd()
+	}()
+	select {
+	case msg := <-done:
+		// tea.Batch returns a msg of type tea.BatchMsg ([]tea.Cmd internally
+		// in bubbletea). We only care about whether any nested cmd
+		// produces a panesRefreshedMsg; recursing one level deep is enough
+		// for our purposes here.
+		batch, ok := msg.(tea.BatchMsg)
+		if !ok {
+			return []tea.Msg{msg}
+		}
+		var got []tea.Msg
+		for _, inner := range batch {
+			if inner == nil {
+				continue
+			}
+			innerCh := make(chan tea.Msg, 1)
+			go func(c tea.Cmd) { innerCh <- c() }(inner)
+			select {
+			case innerMsg := <-innerCh:
+				got = append(got, innerMsg)
+			case <-time.After(deadline):
+				// Slow re-schedule sleep — that's the only cmd in the
+				// batch that takes longer than a few µs.
+			}
+		}
+		return got
+	case <-time.After(deadline):
+		t.Fatalf("cmd did not return within %v", deadline)
+		return nil
+	}
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -212,46 +211,11 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		}
 		if tw.IsInTerminalTab() {
 			return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-				detachTraceMark("handleEnter-terminal-onDismiss-entry")
-				ch, err := tw.AttachTerminal()
-				if err != nil {
-					log.ErrorLog.Printf("failed to attach terminal: %v", err)
-					return nil
-				}
-				detachTraceMark("handleEnter-terminal-blocking-on-<-ch")
-				<-ch
-				detachStart := time.Now()
-				detachTraceMark("handleEnter-terminal-<-ch-unblocked")
-				m.state = stateDefault
-				// Without this msg the post-detach repaint waits up to one
-				// previewTickMsg cycle (~100ms) for the first paint. With it
-				// the bubbletea loop wakes immediately, repaints the cached
-				// content, and the async refresh in the handler swaps in
-				// fresh content within a few ms (#579).
-				beginDetachWatchdog("handleEnter-terminal")
-				return func() tea.Msg {
-					detachTrace(detachStart, "handleEnter-terminal-repaintAfterDetachMsg-emitted")
-					return repaintAfterDetachMsg{}
-				}
+				return m.attachOverlayCallback("handleEnter-terminal", "", tw.AttachTerminal)
 			})
 		}
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-			detachTraceMark("handleEnter-sidebar-onDismiss-entry")
-			ch, err := m.sidebar.Attach()
-			if err != nil {
-				log.ErrorLog.Printf("failed to attach: %v", err)
-				return nil
-			}
-			detachTraceMark("handleEnter-sidebar-blocking-on-<-ch")
-			<-ch
-			detachStart := time.Now()
-			detachTraceMark("handleEnter-sidebar-<-ch-unblocked")
-			m.state = stateDefault
-			beginDetachWatchdog("handleEnter-sidebar")
-			return func() tea.Msg {
-				detachTrace(detachStart, "handleEnter-sidebar-repaintAfterDetachMsg-emitted")
-				return repaintAfterDetachMsg{}
-			}
+			return m.attachOverlayCallback("handleEnter-sidebar", "", m.sidebar.Attach)
 		})
 	}
 	return m, nil

--- a/session/tmux/detach_slow_test.go
+++ b/session/tmux/detach_slow_test.go
@@ -1,0 +1,114 @@
+package tmux
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	aflog "github.com/sachiniyer/agent-factory/log"
+)
+
+// TestDetach_LogsErrorWhenWgWaitExceedsThreshold is the regression guard for
+// the defense-in-depth ERROR log added in fix-598. If the
+// pause-while-attached gate in app/app.go ever regresses (or a new code
+// path starts contending with the tmux server while the user is attached),
+// Detach() should surface that loudly so we don't have to wait for a user
+// to report another multi-second hang. The brief: wg.Wait > 5s → ERROR log
+// naming the elapsed and pointing at the likely cause.
+//
+// We exercise the timing by:
+//  1. Lowering slowDetachWgWaitThreshold to 50ms so the test runs quickly.
+//  2. Adding a goroutine to t.wg that sleeps longer than the threshold —
+//     simulating an io.Copy on a PTY whose tmux client is stuck waiting on
+//     a contended tmux server.
+//  3. Swapping out ErrorLog with a buffer-backed logger so we can assert
+//     on what was emitted.
+func TestDetach_LogsErrorWhenWgWaitExceedsThreshold(t *testing.T) {
+	prevThreshold := slowDetachWgWaitThreshold
+	slowDetachWgWaitThreshold = 50 * time.Millisecond
+	t.Cleanup(func() { slowDetachWgWaitThreshold = prevThreshold })
+
+	// Replace ErrorLog with a buffer-backed logger for assertion.
+	prevErrorLog := aflog.ErrorLog
+	var buf bytes.Buffer
+	aflog.ErrorLog = log.New(&buf, "ERROR: ", 0)
+	t.Cleanup(func() { aflog.ErrorLog = prevErrorLog })
+
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("slow-wg-wait", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+
+	// Mimic Attach() bookkeeping. Add a goroutine to wg that sleeps past the
+	// lowered threshold — this is the part Detach's wg.Wait blocks on.
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+	session.wg.Add(1)
+	go func() {
+		defer session.wg.Done()
+		// Sleep long enough that the test deterministically crosses the
+		// threshold even on a busy CI runner — 4x the threshold gives
+		// plenty of room without dragging the test out.
+		time.Sleep(4 * slowDetachWgWaitThreshold)
+	}()
+
+	session.Detach()
+
+	got := buf.String()
+	if !strings.Contains(got, "tmux.Detach: wg.Wait took") {
+		t.Fatalf("expected ERROR log naming wg.Wait elapsed; got %q", got)
+	}
+	if !strings.Contains(got, "Sessions paused while attached should have prevented this") {
+		t.Fatalf("expected ERROR log to reference the pause-while-attached fix; got %q", got)
+	}
+}
+
+// TestDetach_DoesNotLogErrorOnFastWgWait is the inverted case: on a normal
+// detach where wg.Wait finishes quickly (the io.Copy goroutine drains in a
+// few ms), no ERROR should be emitted. Otherwise every benign detach would
+// log spam and dull our reaction to a real regression.
+func TestDetach_DoesNotLogErrorOnFastWgWait(t *testing.T) {
+	prevThreshold := slowDetachWgWaitThreshold
+	slowDetachWgWaitThreshold = 200 * time.Millisecond
+	t.Cleanup(func() { slowDetachWgWaitThreshold = prevThreshold })
+
+	prevErrorLog := aflog.ErrorLog
+	var buf bytes.Buffer
+	aflog.ErrorLog = log.New(&buf, "ERROR: ", 0)
+	t.Cleanup(func() { aflog.ErrorLog = prevErrorLog })
+
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("fast-wg-wait", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+	// No goroutine added: wg.Wait returns immediately.
+
+	session.Detach()
+
+	if strings.Contains(buf.String(), "tmux.Detach: wg.Wait took") {
+		t.Fatalf("did not expect slow-detach ERROR on a fast wg.Wait; got %q", buf.String())
+	}
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -85,6 +85,14 @@ type TmuxSession struct {
 
 const TmuxPrefix = "af_"
 
+// slowDetachWgWaitThreshold is the wg.Wait elapsed above which Detach()
+// emits an ErrorLog entry. Picked above the worst recorded non-pathological
+// wait (~120ms during normal io.Copy drain) and well below the smallest
+// observed pathological wait (~42s in #598), so the threshold cleanly
+// separates "noise" from "regression of the contention fix". Exported as
+// a var so future regressions can be detected without recompiling.
+var slowDetachWgWaitThreshold = 5 * time.Second
+
 // ErrSessionGone is returned by PTY/tmux operations when the underlying tmux
 // session no longer exists. Non-daemon callers (preview pane, sidebar resize,
 // terminal pane) use errors.Is to detect this case and degrade gracefully
@@ -602,10 +610,24 @@ func (t *TmuxSession) Detach() {
 	// finish before mutating t.ptmx. monitorWindowSize reads t.ptmx via
 	// updateWindowSize, so clearing the field before wg.Wait races against
 	// those reads (#512). Coordinated like Close already is.
-	stepStart = time.Now()
+	waitStart := time.Now()
 	t.wg.Wait()
+	waitElapsed := time.Since(waitStart)
 	log.WarningLog.Printf("[detach-trace] tmux.Detach-wg.Wait-done name=%s elapsed=%v",
-		t.sanitizedName, time.Since(stepStart))
+		t.sanitizedName, waitElapsed)
+	// Defense-in-depth against #598: closing the PTY master does not wake
+	// the io.Copy(os.Stdout, t.ptmx) goroutine on a character device —
+	// that read only returns when the tmux client child exits, which
+	// requires a round-trip through the tmux server. If the server is
+	// being starved by background capture-pane work (the original
+	// failure mode) wg.Wait can block for tens of seconds. The
+	// pause-while-attached gate in app/app.go should prevent this, so if
+	// it still happens we want to know loudly.
+	if waitElapsed > slowDetachWgWaitThreshold {
+		log.ErrorLog.Printf("tmux.Detach: wg.Wait took %v — likely tmux server "+
+			"contention from background capture-pane operations. Sessions paused "+
+			"while attached should have prevented this; bug?", waitElapsed)
+	}
 
 	// Now safe to clear t.ptmx. Clearing unconditionally before Restore
 	// means a Restore failure (or a Close failure) can't leave the closed


### PR DESCRIPTION
## Summary

#598 reported intermittent multi-second hangs detaching back to the sidebar. The instrumentation in #599 captured **three slow detaches today at v1.0.79: 44.0s, 42.3s, 42.5s**. Phase breakdown of the 44s case:

```
15:18:18 saw-detach-key
15:18:18 cancel-done       elapsed=10µs
15:18:18 ptmx.Close-done   elapsed=3µs
15:19:02 wg.Wait-done      elapsed=43.76s  ← here
15:19:02 Restore-done      elapsed=119ms
```

## Root cause

`wg.Wait` is waiting on the `io.Copy(os.Stdout, t.ptmx)` goroutine. Closing the PTY master from another goroutine does **not** wake a blocking Read on a character device — the read only returns when the tmux client child exits, which requires a round-trip with the tmux **server**. The tmux server was being starved by background work we generate while the user is attached: `runMetadataTick` at N=10 instances × 2 capture-pane / 500ms = **~40 RPS**, plus `refreshPanesCmd` (2 capture-pane per call, driven every 100ms by `previewTickMsg`) and `fetchPRInfoCmd` (`gh pr view` network round-trip). The detach key queues behind that pile.

Prior PRs on this hot path (#560, #593) moved the work off the bubbletea Update goroutine but did nothing to stop the shell-outs from contending with the user's tmux session. This PR adds the missing piece: **while the user is attached, pause the background work that competes with their tmux client.**

## Fix shape

1. New `m.attached atomic.Bool` on `home`.
2. Set true before `<-ch` blocks, defer cleared after — on all three attach paths (`attachToInstance`, `handleEnter` sidebar, `handleEnter` terminal-tab). The three call-sites now share a single `attachOverlayCallback` helper so the lifecycle and tracing markers live in one place.
3. While attached:
   - `tickUpdateMetadataMessage` handler returns just the re-schedule cmd (skips `runMetadataTickCmd`).
   - `previewTickMsg` skips its `selectionChanged` dispatch.
   - `selectionChanged` itself skips `refreshPanesCmd` and `fetchPRInfoCmd` (defense in depth — covers any other path that calls it).
   - `tickUpdatePRInfoMessage` skips the `fetchPRInfoCmd` dispatch.
4. Defense-in-depth: `tmux.Detach` logs an `ErrorLog` entry when `wg.Wait > 5s`, naming the elapsed and pointing at the likely cause. Threshold is a package-level `var` for the test.

The metadata tick is re-armed unconditionally (no backoff), so the first post-detach iteration fires within ~500ms of clearing the flag and the sidebar Running/Ready status catches up promptly.

## Table A — periodic tea.Cmd / tickXxxMsg in `app/app.go`

| Cmd / msg | Interval | Decision | Reason |
| --- | --- | --- | --- |
| `tickUpdateMetadataCmd` → `runMetadataTickCmd` | 500ms | **PAUSE** | Dominant source. 2 × N tmux capture-pane shell-outs per tick. Sidebar status is hidden during attach; first post-detach tick fires within 500ms. |
| `previewTickMsg` → `selectionChanged` → `refreshPanesCmd` | 100ms | **PAUSE** | Two more capture-pane per tick (preview + terminal pane). Re-paint after detach happens via `repaintAfterDetachMsg` anyway. |
| `tickUpdatePRInfoCmd` → `fetchPRInfoCmd` | 60s | **PAUSE** | Network call (`gh pr view`). PR badge invisible during attach; safe to skip. |
| `tickPendingInstancesCmd` → `mergePendingInstances` | 5s | **KEEP** | Picks up scheduled task runs (per brief). No tmux/network work — just a disk read of `pending.json`. |
| `tickRefreshExternalCmd` → `refreshExternalInstances` | 3s | **KEEP** | Picks up sessions created externally by the CLI (per brief). Disk read of `instances.json` only. The follow-up `selectionChanged()` it dispatches when state actually changes is itself gated, so even the rare case of a write-during-attach doesn't queue a capture-pane. |

## Table B — `tmux capture-pane` invocation sites (repo-wide grep)

| Call-site | Periodic? | Gated by attached? |
| --- | --- | --- |
| `app/sync.go:59` `instance.CheckAndHandleTrustPrompt()` (in `runMetadataTick`) | ✅ 500ms | ✅ via `tickUpdateMetadataMessage` gate |
| `app/sync.go:60` `instance.HasUpdated()` (in `runMetadataTick`) | ✅ 500ms | ✅ via `tickUpdateMetadataMessage` gate |
| `ui/preview.go:122/140/248/287/337` `instance.Preview()` / `PreviewFullHistory()` (called from `UpdatePreview`) | ✅ via `refreshPanesCmd` | ✅ via `selectionChanged` gate |
| `ui/terminal.go:121` `CapturePaneContent` (called from `UpdateTerminal`) | ✅ via `refreshPanesCmd` | ✅ via `selectionChanged` gate |
| `ui/terminal.go:352` `CapturePaneContentWithOptions("-","-")` | ❌ user-driven (enter scroll mode) | n/a — discrete, not periodic |
| `task/start.go:38` `CheckAndHandleTrustPrompt` | ❌ one-shot at task start | n/a |
| `daemon/daemon.go:68` `instance.HasUpdated()` (autoyes daemon poll) | ✅ in daemon process | n/a — separate process, no awareness of TUI attach state. Hits the same tmux server but at the existing once-per-second cadence; not what the trace pinned the hang on, and gating it would require cross-process coordination outside scope of #598. |
| `daemon/control.go:977` `CheckAndHandleTrustPrompt` | ❌ one-shot at session-start | n/a |
| `daemon/control.go:1002/1010` `instance.Preview()` (RPC handler) | ❌ user-driven | n/a |
| `api/sessions.go:344` `instance.Preview()` (HTTP API) | ❌ user-driven | n/a |
| `task/runner.go:123/131` `instance.Preview()` (task runner) | ❌ one-shot | n/a |

Daemon-side `capture-pane` is the one parallel call path the brief flagged for explicit justification. Leaving it untouched is deliberate: the daemon's poll is ~1 RPS per instance vs. the TUI's old 40+ RPS, the trace did not implicate it, and gating it would require a new TUI ↔ daemon protocol that #598 does not call for.

## Defense-in-depth ERROR log

`tmux.Detach` now measures `wg.Wait` elapsed and emits `ErrorLog` if it crosses `slowDetachWgWaitThreshold` (5s). The message names the elapsed and points at the likely cause (tmux server contention from background capture-pane), so a future regression of this gate — or a new contention source we haven't anticipated — shows up loudly in `agent-factory.log` instead of waiting for another user-reported multi-second hang. The threshold is a package-level `var` so the test can lower it without recompiling.

## Tests

`app/attached_pause_test.go`:
- `TestTickUpdateMetadata_PausedWhileAttached` — handler returns the bare re-schedule cmd while attached; instance status does not flip.
- `TestTickUpdateMetadata_RunsWhenNotAttached` — symmetric guard against an inverted gate; the work cmd runs and flips Running → Ready.
- `TestPreviewTick_PausedWhileAttached` — `previewTickMsg` re-arms but never produces a `panesRefreshedMsg`.
- `TestSelectionChanged_SkipsRefreshWhileAttached` — direct test of the gate inside `selectionChanged`.
- `TestTickUpdatePRInfo_PausedWhileAttached` — `prInfoFetcher` is never invoked while attached.
- `TestAttachOverlayCallback_ClearsFlagOnDetach` — success path: armed before `<-ch`, cleared after.
- `TestAttachOverlayCallback_LeavesFlagAloneWhenAttachErrors` — THE regression-risk path called out in the brief: if attach fails before `<-ch`, the flag stays at its prior (false) value rather than being stranded at true. Extracted helper made this testable without spinning up real tmux.

`session/tmux/detach_slow_test.go`:
- `TestDetach_LogsErrorWhenWgWaitExceedsThreshold` — threshold lowered, a wg-tracked goroutine sleeps past it, `ErrorLog` is asserted to contain the expected message.
- `TestDetach_DoesNotLogErrorOnFastWgWait` — fast detach (no goroutine added) emits no ERROR.

## CI gates (all confirmed locally)

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go test -race -count=1 ./...` — all packages pass except the pre-existing `daemon.TestSigtermFallback_DeadPID` (two real `af --daemon` processes running on the dev machine, called out in #599's PR body — unrelated to this change).

## Manual test plan

- [ ] `./dev-install.sh` succeeds and ships `af` to `~/.local/bin`.
- [ ] Open af with 5+ sessions; verify sidebar Running/Ready badges update normally (metadata tick still firing).
- [ ] Attach to any session, detach with `ctrl-w`; verify detach is sub-second.
- [ ] Repeat several times with different sessions to stress the gate-clear path.
- [ ] After detach, verify sidebar Ready/Running status catches up within ~1s (the metadata tick re-fires within 500ms of clearing the flag).
- [ ] If a slow detach is somehow reproducible: grep `~/.local/share/agent-factory/agent-factory.log` for the new `ERROR ... tmux.Detach: wg.Wait took` line.

Closes #598

— Captain Claude