### PR TITLE
fix(tmux): SIGKILL the attach-session child if wg.Wait exceeds 1s during Detach (#598)

### DIFF
--- a/session/tmux/detach_slow_test.go
+++ b/session/tmux/detach_slow_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -110,5 +111,177 @@ func TestDetach_DoesNotLogErrorOnFastWgWait(t *testing.T) {
 
 	if strings.Contains(buf.String(), "tmux.Detach: wg.Wait took") {
 		t.Fatalf("did not expect slow-detach ERROR on a fast wg.Wait; got %q", buf.String())
+	}
+}
+
+// TestDetach_SIGKILLsAttachOnSlowWgWait is the regression guard for the
+// follow-up fix from issue #598: when wg.Wait blocks longer than
+// wgWaitSigkillDeadline, Detach() must SIGKILL the tmux attach-session
+// child so the io.Copy goroutine's PTY-master Read returns EOF. Without
+// this, the user's sidebar is held hostage by whichever process is starving
+// the tmux server (in the original incident: the daemon's capture-pane
+// poll, which lives in a separate process the in-app pause-while-attached
+// gate from #600 cannot reach). The test verifies the kill is invoked AND
+// that Detach returns even though the simulated io.Copy goroutine was
+// hanging — the whole point of the fix is "Detach returns within ~1s".
+func TestDetach_SIGKILLsAttachOnSlowWgWait(t *testing.T) {
+	prevDeadline := wgWaitSigkillDeadline
+	wgWaitSigkillDeadline = 50 * time.Millisecond
+	t.Cleanup(func() { wgWaitSigkillDeadline = prevDeadline })
+
+	// Replace WarningLog with a buffer so we can assert the SIGKILL log
+	// landed with the recorded pid (the diagnostic that lets us tie a
+	// future hang back to which client got killed).
+	prevWarn := aflog.WarningLog
+	var warnBuf bytes.Buffer
+	aflog.WarningLog = log.New(&warnBuf, "WARN: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = prevWarn })
+
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("sigkill-on-slow-wg", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+
+	// Swap the real (mock-Process-nil) killAttach for one that records the
+	// call and signals the simulated io.Copy goroutine to exit. This is
+	// what would happen for real: SIGKILL → slave closes → master Read
+	// returns EOF → io.Copy returns → wg.Done. Here we short-circuit
+	// directly to the goroutine.
+	var killCalls atomic.Int32
+	killed := make(chan struct{})
+	session.killAttach = func() (int, error) {
+		killCalls.Add(1)
+		close(killed)
+		return 12345, nil
+	}
+
+	session.wg.Add(1)
+	go func() {
+		defer session.wg.Done()
+		select {
+		case <-killed:
+			// SIGKILL arrived — simulate io.Copy returning immediately.
+		case <-time.After(2 * time.Second):
+			// Safety bound: if Detach never invokes killAttach the
+			// goroutine still drains so the test doesn't leak. The
+			// killCalls assertion below will catch the missing call.
+		}
+	}()
+
+	detachDone := make(chan struct{})
+	go func() {
+		session.Detach()
+		close(detachDone)
+	}()
+
+	select {
+	case <-detachDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Detach did not return within 3s — the SIGKILL fallback is not unblocking wg.Wait")
+	}
+
+	if got := killCalls.Load(); got != 1 {
+		t.Fatalf("expected killAttach to be invoked exactly once after wgWaitSigkillDeadline; got %d calls", got)
+	}
+	if !strings.Contains(warnBuf.String(), "SIGKILLing tmux attach-session pid=12345") {
+		t.Fatalf("expected WARN log naming the SIGKILLed pid; got %q", warnBuf.String())
+	}
+}
+
+// TestDetach_DoesNotSIGKILLOnFastWgWait covers the inverse: when wg.Wait
+// returns inside the deadline (the overwhelming common case), killAttach
+// must not be invoked. SIGKILLing the attach client unnecessarily would
+// race with the normal io.Copy drain and could surface as spurious
+// "process killed" log noise even though the detach worked correctly.
+func TestDetach_DoesNotSIGKILLOnFastWgWait(t *testing.T) {
+	prevDeadline := wgWaitSigkillDeadline
+	wgWaitSigkillDeadline = 500 * time.Millisecond
+	t.Cleanup(func() { wgWaitSigkillDeadline = prevDeadline })
+
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("no-sigkill-on-fast-wg", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+
+	var killCalls atomic.Int32
+	session.killAttach = func() (int, error) {
+		killCalls.Add(1)
+		return 0, nil
+	}
+	// No goroutine added: wg.Wait returns immediately.
+
+	session.Detach()
+
+	if got := killCalls.Load(); got != 0 {
+		t.Fatalf("expected killAttach to NOT be invoked on a fast wg.Wait; got %d calls", got)
+	}
+}
+
+// TestDetach_DoesNotPanicWhenKillAttachNil guards the should-not-happen
+// path: if somehow Detach() runs without Restore() having set killAttach
+// (a bug elsewhere, or future refactor that loses the wiring), the SIGKILL
+// fallback must degrade to a logged warning rather than panicking on a nil
+// function pointer. We don't want a defensive bound to itself become a
+// crash.
+func TestDetach_DoesNotPanicWhenKillAttachNil(t *testing.T) {
+	prevDeadline := wgWaitSigkillDeadline
+	wgWaitSigkillDeadline = 50 * time.Millisecond
+	t.Cleanup(func() { wgWaitSigkillDeadline = prevDeadline })
+
+	prevWarn := aflog.WarningLog
+	var warnBuf bytes.Buffer
+	aflog.WarningLog = log.New(&warnBuf, "WARN: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = prevWarn })
+
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("nil-killattach", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+	// Force the should-not-happen state by clearing what Restore set.
+	session.killAttach = nil
+
+	session.wg.Add(1)
+	go func() {
+		defer session.wg.Done()
+		// Sleep past the deadline so the SIGKILL branch runs, then drain
+		// so the test doesn't hang forever.
+		time.Sleep(150 * time.Millisecond)
+	}()
+
+	// Must not panic.
+	session.Detach()
+
+	if !strings.Contains(warnBuf.String(), "no attach process recorded") {
+		t.Fatalf("expected WARN log noting missing attach process; got %q", warnBuf.String())
 	}
 }

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -81,6 +81,15 @@ type TmuxSession struct {
 	ctx    context.Context
 	cancel func()
 	wg     *sync.WaitGroup
+
+	// killAttach SIGKILLs the tmux attach-session client child whose slave end
+	// of the PTY is keeping io.Copy(os.Stdout, t.ptmx) blocked in Attach().
+	// Set by Restore() once the PTY-backed child is running; cleared by the
+	// detach/teardown paths after wg drains. Returns (pid, err) so the
+	// fallback log can name the pid that was signalled. See Detach() for the
+	// "why" — this is the defensive escape hatch for #598 when the tmux
+	// server is too contended to let the client exit on its own.
+	killAttach func() (int, error)
 }
 
 const TmuxPrefix = "af_"
@@ -92,6 +101,16 @@ const TmuxPrefix = "af_"
 // separates "noise" from "regression of the contention fix". Exported as
 // a var so future regressions can be detected without recompiling.
 var slowDetachWgWaitThreshold = 5 * time.Second
+
+// wgWaitSigkillDeadline is the wg.Wait elapsed above which the
+// detach/teardown paths SIGKILL the tmux attach-session child to force
+// io.Copy to return. The 1s value is generous enough to absorb routine
+// kernel scheduling but short enough that the user-visible hang is bounded
+// regardless of tmux-server load — even with the pause-while-attached gate
+// in app/app.go, the daemon (separate process) still polls capture-pane
+// every second and can contend with the attach client's exit round-trip
+// (see the #598 follow-up). var, not const, so tests can lower it.
+var wgWaitSigkillDeadline = 1 * time.Second
 
 // ErrSessionGone is returned by PTY/tmux operations when the underlying tmux
 // session no longer exists. Non-daemon callers (preview pane, sidebar resize,
@@ -312,13 +331,65 @@ func (t *TmuxSession) Restore(workDir string) error {
 		return t.Start(workDir)
 	}
 
-	ptmx, err := t.ptyFactory.Start(exec.Command("tmux", "attach-session", "-t", t.sanitizedName))
+	attachCmd := exec.Command("tmux", "attach-session", "-t", t.sanitizedName)
+	ptmx, err := t.ptyFactory.Start(attachCmd)
 	if err != nil {
 		return fmt.Errorf("error opening PTY: %w", err)
 	}
 	t.ptmx = ptmx
 	t.monitor = newStatusMonitor()
+	// Save a closure that SIGKILLs the attach-session child so Detach() can
+	// force io.Copy(os.Stdout, t.ptmx) to unblock when the tmux server is
+	// too contended to let the client exit on its own. Closing ptmx (the
+	// master end) doesn't wake a blocking Read on a non-pollable character
+	// device — only the slave end closing (i.e. the client child exiting)
+	// does. See Detach() and the wgWaitSigkillDeadline comment for the
+	// full reasoning (#598 follow-up).
+	t.killAttach = func() (int, error) {
+		if attachCmd.Process == nil {
+			return 0, errors.New("attach process not started")
+		}
+		return attachCmd.Process.Pid, attachCmd.Process.Kill()
+	}
 	return nil
+}
+
+// waitForAttachDrain waits for the attach goroutines (io.Copy +
+// monitorWindowSize x2) to finish, falling back to SIGKILLing the
+// attach-session child if the wait exceeds wgWaitSigkillDeadline. The
+// fallback exists because closing the PTY master (t.ptmx) does not wake a
+// blocking Read on a character device — that read only returns when the
+// slave end closes, which happens when the tmux client child exits, which
+// requires a round-trip through a potentially contended tmux server (#598).
+// Returns the elapsed wait so callers that surface diagnostics about a slow
+// wg.Wait (Detach) can do so without re-measuring.
+func (t *TmuxSession) waitForAttachDrain() time.Duration {
+	if t.wg == nil {
+		return 0
+	}
+	waitStart := time.Now()
+	waitDone := make(chan struct{})
+	go func() {
+		t.wg.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-time.After(wgWaitSigkillDeadline):
+		if t.killAttach != nil {
+			pid, killErr := t.killAttach()
+			log.WarningLog.Printf("tmux: wg.Wait exceeded %v; SIGKILLing tmux attach-session pid=%d to unblock io.Copy",
+				wgWaitSigkillDeadline, pid)
+			if killErr != nil {
+				log.WarningLog.Printf("tmux: SIGKILL attempt failed: %v", killErr)
+			}
+		} else {
+			log.WarningLog.Printf("tmux: wg.Wait exceeded %v but no attach process recorded; cannot SIGKILL",
+				wgWaitSigkillDeadline)
+		}
+		<-waitDone
+	}
+	return time.Since(waitStart)
 }
 
 type statusMonitor struct {
@@ -562,12 +633,13 @@ func (t *TmuxSession) DetachSafely() error {
 		t.attachCh = nil
 	}
 
-	if t.wg != nil {
-		t.wg.Wait()
-		t.wg = nil
-	}
+	// Same bounded wait as Detach (#598 follow-up) — share the SIGKILL
+	// fallback so the safety variant can't hang either.
+	_ = t.waitForAttachDrain()
+	t.wg = nil
 
 	t.ctx = nil
+	t.killAttach = nil
 
 	if len(errs) > 0 {
 		return fmt.Errorf("errors during detach: %v", errs)
@@ -588,6 +660,7 @@ func (t *TmuxSession) Detach() {
 		t.cancel = nil
 		t.ctx = nil
 		t.wg = nil
+		t.killAttach = nil
 	}()
 
 	// Cancel context FIRST so monitorWindowSize goroutines exit promptly and
@@ -609,20 +682,16 @@ func (t *TmuxSession) Detach() {
 	// Wait for the attach goroutines (io.Copy + monitorWindowSize x2) to
 	// finish before mutating t.ptmx. monitorWindowSize reads t.ptmx via
 	// updateWindowSize, so clearing the field before wg.Wait races against
-	// those reads (#512). Coordinated like Close already is.
-	waitStart := time.Now()
-	t.wg.Wait()
-	waitElapsed := time.Since(waitStart)
+	// those reads (#512). waitForAttachDrain bounds the wait by SIGKILLing
+	// the attach-session child if wg.Wait exceeds wgWaitSigkillDeadline —
+	// see #598 follow-up for the diagnosis.
+	waitElapsed := t.waitForAttachDrain()
 	log.WarningLog.Printf("[detach-trace] tmux.Detach-wg.Wait-done name=%s elapsed=%v",
 		t.sanitizedName, waitElapsed)
-	// Defense-in-depth against #598: closing the PTY master does not wake
-	// the io.Copy(os.Stdout, t.ptmx) goroutine on a character device —
-	// that read only returns when the tmux client child exits, which
-	// requires a round-trip through the tmux server. If the server is
-	// being starved by background capture-pane work (the original
-	// failure mode) wg.Wait can block for tens of seconds. The
-	// pause-while-attached gate in app/app.go should prevent this, so if
-	// it still happens we want to know loudly.
+	// Defense-in-depth: if wg.Wait still exceeded the slow threshold after
+	// the SIGKILL fallback ran, that means killAttach didn't unstick the
+	// goroutine — a deeper bug than what this fix targets. Keep the loud
+	// log so we hear about it.
 	if waitElapsed > slowDetachWgWaitThreshold {
 		log.ErrorLog.Printf("tmux.Detach: wg.Wait took %v — likely tmux server "+
 			"contention from background capture-pane operations. Sessions paused "+
@@ -671,13 +740,18 @@ func (t *TmuxSession) Close() error {
 		}
 	}
 
-	if t.wg != nil {
-		t.wg.Wait()
-		t.wg = nil
-	}
+	// Same bounded wait as Detach (#598 follow-up). The tmux kill-session
+	// below will eventually force the attach client to exit on its own, but
+	// that depends on the same tmux-server round-trip that #598 showed can
+	// stall for tens of seconds. Sharing the SIGKILL fallback keeps Close
+	// snappy when used from user-driven teardown paths (terminal pane
+	// close).
+	_ = t.waitForAttachDrain()
+	t.wg = nil
 
 	t.ptmx = nil
 	t.ctx = nil
+	t.killAttach = nil
 
 	if t.attachCh != nil {
 		close(t.attachCh)


### PR DESCRIPTION
## Summary

Follow-up to #600 for issue #598. The defense-in-depth ERROR log added in
#600 fired AT v1.0.80 on Sachin's binary: `wg.Wait took 49.08911249s`. The
TUI-side pause-while-attached gate *is* working — the trace confirms zero
`runMetadataTick`, `refreshPanesCmd`, or `fetchPRInfoCmd` events during the
3-minute attach window — but a separate process is still hitting the tmux
server enough to stall the user's detach. This PR breaks the dependency on
tmux server response time entirely.

## Phase breakdown of the 49s detach (v1.0.80, the gate from #600 ON)

```
18:08:17 saw-detach-key
18:08:17 cancel-done       elapsed=10µs
18:08:17 ptmx.Close-done   elapsed=2µs
18:09:06 wg.Wait-done      elapsed=49.08s  ← still here
18:09:06 Restore-done      elapsed=~ms
```

Same exact shape as the 44s hang #600 was diagnosed from. The gate
prevented the *TUI's* shell-outs from contending, but the **daemon's**
autoyes poll (`daemon/daemon.go:68`'s `instance.HasUpdated()`, which calls
`tmux capture-pane`) runs in a separate process that has no awareness of
`m.attached`. #600's audit table explicitly noted this — *"gating it would
require cross-process coordination outside scope of #598."* This PR takes a
different approach: don't try to remove the contention, just bound the
detach time regardless.

## Why this works — the root mechanism

The blocked goroutine is `io.Copy(os.Stdout, t.ptmx)` in `Attach()`. It is
blocked on a Read against the PTY master. Closing the master from another
goroutine (which `Detach` does via `t.ptmx.Close()`) does **not** wake an
in-flight blocking Read on a non-pollable character device. The read only
returns when the **slave** end closes. The slave end is owned by the
`tmux attach-session` child process. That child can only exit after a
round-trip with the tmux server. If the server is busy, the child waits.

Solution: bypass the round-trip. If `wg.Wait` exceeds 1s, SIGKILL the
attach-session child directly. Its slave end closes immediately, the
master-side Read returns EOF, `io.Copy` returns, `wg.Done` runs. Whole
sequence < 100ms regardless of tmux server load.

## Why SIGKILL of the client is safe

This was Sachin's explicit warning on the issue: *"be careful about
degrading any other features when trying to fix this."*

The tmux process model has two roles for any given `tmux session`:

1. The **session** lives in the tmux *server* process (one server per user
   on the host). The server holds the pane, the scrollback, the program
   running inside (claude / aider / etc.) — all the state we care about.
2. The **client** is a *separate* `tmux attach-session` child process that
   the user's terminal is connected to. Closing the client disconnects
   that one display from the session. The server keeps running. Other
   clients (including the af binary's own `tmux capture-pane`,
   `has-session`, `kill-session`, etc.) continue to talk to the server
   normally.

So SIGKILLing the attach-session client = closing the user's view. It
**does not** kill the session, lose scrollback, terminate the agent
process, or affect any other af functionality.

## Implementation

- Capture the `*exec.Cmd` returned by `pty.Start` in `Restore()` (the call
  site that actually allocates the attach PTY, despite the helper plan
  calling it `Attach`). Store a closure `killAttach func() (int, error)`
  on `TmuxSession` that returns the pid (for the log) and the `Kill()`
  result.
- Closure-based rather than raw `*exec.Cmd` so tests can swap the kill
  function without constructing a real `os.Process` — `MockPtyFactory`
  doesn't actually `cmd.Start()` so its `cmd.Process` is nil. The
  production closure handles that case defensively too (returns an
  error rather than nil-deref) to keep the layers decoupled.
- New `waitForAttachDrain()` helper does
  `select{ <-waitDone | <-time.After(deadline) }` with the SIGKILL
  fallback in the timeout branch. Returns the elapsed wait so Detach can
  still surface the existing `>5s ERROR` log.
- The existing >5s ERROR log stays. It will now fire only if the SIGKILL
  itself didn't unstick the goroutine — a class of bug deeper than #598
  and worth shouting about.
- `wgWaitSigkillDeadline` is a package-level `var` (1s default) so tests
  can lower it. Same pattern `slowDetachWgWaitThreshold` already uses.

## Audit

| Call site | Same blocking pattern? | Fixed? | Notes |
| --- | --- | --- | --- |
| `tmux.Detach` | yes | yes | Primary fix. User-visible sidebar-exit hang. |
| `tmux.DetachSafely` | yes — same `cancel → ptmx.Close → wg.Wait` shape | yes | Public API surface; not called from production code today but defensive fix via the shared helper costs nothing. |
| `tmux.Close` | yes | yes | `kill-session` later in the function was a partial backstop, but it runs AFTER `wg.Wait`. A user-driven terminal-pane close (`ui/terminal.go:174/250/268`) could have hit the same hang. Now bounded. |
| `tmux.Start` | no | n/a | Calls `ptyFactory.Start` for `new-session -d` (not attach). The returned PTY is closed immediately. No blocking-read goroutine, nothing to bound. |

## Sachin's warning, applied

> be careful about degrading any other features when trying to fix this

- SIGKILL on the **client** is safe — see "Why SIGKILL is safe" above.
- 1s deadline is generous enough to absorb routine kernel scheduling
  without false-positive kills. The lowest pre-SIGKILL deadline
  considered (500ms) was rejected as too aggressive — short routine
  pauses on busy CI runners shouldn't trigger SIGKILL.
- The 1s SIGKILL deadline is **before** the existing 5s ERROR threshold.
  In the normal slow-detach case, SIGKILL bails us out before the ERROR
  ever fires. If both fire, that's a true second-order bug we'd want to
  know about — keeping the ERROR log preserves that signal.

## Tests

`session/tmux/detach_slow_test.go` (new tests):

- `TestDetach_SIGKILLsAttachOnSlowWgWait` — the deadline is lowered, a
  goroutine on `wg` blocks until killed. A recording `killAttach` closes
  a channel to simulate slave-end close. Asserts: kill was invoked
  exactly once, the WARN log names the recorded pid, and Detach returns
  within 3s (the whole point of the fix).
- `TestDetach_DoesNotSIGKILLOnFastWgWait` — fast drain with a recording
  `killAttach`; count stays at 0 (no spurious kill).
- `TestDetach_DoesNotPanicWhenKillAttachNil` — the should-not-happen path
  (Detach reached without Restore having set `killAttach`) degrades to a
  logged warning, not a nil-function-pointer panic.

Existing detach tests (`TestDetach_LogsErrorWhenWgWaitExceedsThreshold`,
`TestDetach_DoesNotLogErrorOnFastWgWait`) continue to pass unchanged —
their wg drains in ~200ms, well below the new (default 1s) SIGKILL
deadline, so the existing 5s-ERROR-log behavior is unaffected.

## CI gates (all confirmed locally)

- `gofmt -l .` — clean (excluding `.claude/worktrees/`)
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go test -race -count=1 ./...` — all packages pass except
  `daemon.TestSigtermFallback_DeadPID`, which fails identically on master
  HEAD `ed83f12` because two real `af --daemon` processes are running on
  this dev machine. Pre-existing environment-dependent flake, unrelated.

## Manual test plan

- [ ] `./dev-install.sh` succeeds.
- [ ] Open af with 5+ sessions; verify sidebar Running/Ready badges
      update normally (`Restore` still wires `killAttach`; metadata tick
      still gated by `m.attached` from #600).
- [ ] Attach to any session, detach with `ctrl-w`; verify detach is
      sub-second under normal load.
- [ ] If a slow detach reproduces (`>1s wg.Wait`): grep
      `~/.config/agent-factory/agent-factory.log` for the new
      `tmux: wg.Wait exceeded` WARN line — it should name the pid that
      was killed, and the next `Detach-exit total=...` should be ≤ ~1.1s.

Refs #598
Follow-up to #600

— Captain Claude