### PR TITLE
fix(tmux): bound waitForAttachDrain even when killAttach is nil (#598 follow-up)

### DIFF
--- a/session/tmux/detach_slow_test.go
+++ b/session/tmux/detach_slow_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log"
 	"os/exec"
 	"strings"
@@ -242,11 +243,16 @@ func TestDetach_DoesNotSIGKILLOnFastWgWait(t *testing.T) {
 // (a bug elsewhere, or future refactor that loses the wiring), the SIGKILL
 // fallback must degrade to a logged warning rather than panicking on a nil
 // function pointer. We don't want a defensive bound to itself become a
-// crash.
+// crash. Stubs the pgrep/kill hooks so the test doesn't shell out and
+// stays deterministic.
 func TestDetach_DoesNotPanicWhenKillAttachNil(t *testing.T) {
 	prevDeadline := wgWaitSigkillDeadline
 	wgWaitSigkillDeadline = 50 * time.Millisecond
 	t.Cleanup(func() { wgWaitSigkillDeadline = prevDeadline })
+
+	prevPgrep := pgrepRunnerVar
+	pgrepRunnerVar = func(string) ([]int, error) { return nil, nil }
+	t.Cleanup(func() { pgrepRunnerVar = prevPgrep })
 
 	prevWarn := aflog.WarningLog
 	var warnBuf bytes.Buffer
@@ -283,5 +289,328 @@ func TestDetach_DoesNotPanicWhenKillAttachNil(t *testing.T) {
 
 	if !strings.Contains(warnBuf.String(), "no attach process recorded") {
 		t.Fatalf("expected WARN log noting missing attach process; got %q", warnBuf.String())
+	}
+}
+
+// TestDetach_BoundsWaitWhenKillAttachNilAndWgHangs is the direct regression
+// guard for the 51-second hang observed at 00:05:14 on 2026-05-20: when
+// Detach() runs without a working killAttach AND the io.Copy goroutine is
+// genuinely stuck (PTY drain never returns), the previous implementation
+// fell through to an unconditional <-waitDone after logging "cannot
+// SIGKILL", blocking the user's TUI indefinitely.
+//
+// The new contract: even if the pgrep fallback fails to find anything to
+// kill, the secondary wait MUST be bounded by wgWaitAbandonDeadline.
+// Returning with a leaked goroutine is correct here — the kernel will
+// eventually unstick the PTY and the goroutine will exit on its own. The
+// test asserts:
+//
+//  1. Detach returns within wgWaitSigkillDeadline + wgWaitAbandonDeadline +
+//     slack, not the multi-second hang the original incident produced.
+//  2. The ERROR log naming the abandoned wait fires so future occurrences
+//     are visible in agent-factory.log.
+//  3. The pgrep fallback was attempted (stubbed to return nothing).
+//
+// We deliberately leave the wg goroutine running past Detach's return.
+// That IS the bug fix: leaking one goroutine is acceptable when the
+// alternative is freezing the TUI for 51 seconds. The goroutine drains
+// later via t.Cleanup so the test process exits cleanly.
+func TestDetach_BoundsWaitWhenKillAttachNilAndWgHangs(t *testing.T) {
+	prevSigkill := wgWaitSigkillDeadline
+	wgWaitSigkillDeadline = 50 * time.Millisecond
+	t.Cleanup(func() { wgWaitSigkillDeadline = prevSigkill })
+
+	prevAbandon := wgWaitAbandonDeadline
+	wgWaitAbandonDeadline = 100 * time.Millisecond
+	t.Cleanup(func() { wgWaitAbandonDeadline = prevAbandon })
+
+	// pgrep returns no matches — simulates the real case where the attach
+	// client either already exited or never matched our pattern. The
+	// secondary timeout must still fire.
+	var pgrepCalls atomic.Int32
+	prevPgrep := pgrepRunnerVar
+	pgrepRunnerVar = func(pattern string) ([]int, error) {
+		pgrepCalls.Add(1)
+		return nil, nil
+	}
+	t.Cleanup(func() { pgrepRunnerVar = prevPgrep })
+
+	prevErr := aflog.ErrorLog
+	var errBuf bytes.Buffer
+	aflog.ErrorLog = log.New(&errBuf, "ERROR: ", 0)
+	t.Cleanup(func() { aflog.ErrorLog = prevErr })
+
+	prevWarn := aflog.WarningLog
+	var warnBuf bytes.Buffer
+	aflog.WarningLog = log.New(&warnBuf, "WARN: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = prevWarn })
+
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("bounded-wait-no-kill", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+	session.killAttach = nil // the trigger condition from the 00:05:14 incident
+
+	// A genuinely hung io.Copy: do not exit until told. This is the
+	// "kernel never drains the PTY" simulation.
+	releaseHang := make(chan struct{})
+	t.Cleanup(func() { close(releaseHang) })
+	// Capture wg locally so Done() doesn't race against Detach's defer
+	// nilifying t.wg. The leaked-goroutine contract requires the
+	// goroutine to survive past Detach's return — that survival can't
+	// itself crash the test process.
+	wg := session.wg
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-releaseHang
+	}()
+
+	detachDone := make(chan struct{})
+	go func() {
+		session.Detach()
+		close(detachDone)
+	}()
+
+	// Total ceiling: sigkill (50ms) + abandon (100ms) + slack for Restore
+	// + log flush + scheduler. 2s is generous and still proves the
+	// guarantee — the original incident took 51s.
+	select {
+	case <-detachDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Detach blocked past sigkill+abandon deadlines — the secondary bound is not firing")
+	}
+
+	if got := pgrepCalls.Load(); got != 1 {
+		t.Fatalf("expected pgrep fallback to be attempted exactly once when killAttach is nil; got %d calls", got)
+	}
+	if !strings.Contains(warnBuf.String(), "attempting pgrep-based fallback") {
+		t.Fatalf("expected WARN log noting pgrep fallback attempt; got %q", warnBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "abandoning wg.Wait") {
+		t.Fatalf("expected ERROR log on the abandon path; got %q", errBuf.String())
+	}
+}
+
+// TestKillTmuxAttachByName_KillsMatchingPids verifies the pgrep fallback
+// actually invokes the kill hook for every pid pgrep returns. This is the
+// "what happens after we find a stuck attach client" half of the safety
+// net. We stub both pgrep and kill so the test never touches real
+// processes — the goal is to prove wiring, not to test pgrep itself.
+func TestKillTmuxAttachByName_KillsMatchingPids(t *testing.T) {
+	prevPgrep := pgrepRunnerVar
+	pgrepRunnerVar = func(pattern string) ([]int, error) {
+		// Confirm the pattern is anchored to the attach-session invocation
+		// for the given name — we don't want bare-name matches that could
+		// hit a concurrent `tmux kill-session -t <name>`.
+		if !strings.Contains(pattern, "tmux attach-session -t ") {
+			t.Errorf("pgrep pattern should anchor to attach-session invocation; got %q", pattern)
+		}
+		if !strings.Contains(pattern, "my-session") {
+			t.Errorf("pgrep pattern should reference the session name; got %q", pattern)
+		}
+		return []int{1111, 2222}, nil
+	}
+	t.Cleanup(func() { pgrepRunnerVar = prevPgrep })
+
+	var killed []int
+	var mu sync.Mutex
+	prevKill := killByPidVar
+	killByPidVar = func(pid int) error {
+		mu.Lock()
+		defer mu.Unlock()
+		killed = append(killed, pid)
+		return nil
+	}
+	t.Cleanup(func() { killByPidVar = prevKill })
+
+	n, err := killTmuxAttachByName("my-session")
+	if err != nil {
+		t.Fatalf("killTmuxAttachByName: unexpected error: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 kills; got %d", n)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(killed) != 2 || killed[0] != 1111 || killed[1] != 2222 {
+		t.Fatalf("expected SIGKILL to pids [1111 2222]; got %v", killed)
+	}
+}
+
+// TestKillTmuxAttachByName_NoMatches confirms the "session already
+// exited" case is handled silently — pgrep returns no pids, no kill is
+// attempted, no error is surfaced. This is the common happy-path for the
+// pgrep fallback: in most cases by the time we reach this branch the
+// attach client has already exited and there's nothing to kill.
+func TestKillTmuxAttachByName_NoMatches(t *testing.T) {
+	prevPgrep := pgrepRunnerVar
+	pgrepRunnerVar = func(string) ([]int, error) { return nil, nil }
+	t.Cleanup(func() { pgrepRunnerVar = prevPgrep })
+
+	var killCalls atomic.Int32
+	prevKill := killByPidVar
+	killByPidVar = func(int) error { killCalls.Add(1); return nil }
+	t.Cleanup(func() { killByPidVar = prevKill })
+
+	n, err := killTmuxAttachByName("missing")
+	if err != nil {
+		t.Fatalf("expected no error for no-match case; got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 kills for no-match case; got %d", n)
+	}
+	if got := killCalls.Load(); got != 0 {
+		t.Fatalf("expected zero kill invocations when pgrep returns nothing; got %d", got)
+	}
+}
+
+// TestDetach_LogsErrorWhenBothFallbacksFail covers the double-failure
+// path called out in the brief: both killAttach is nil AND the pgrep
+// fallback returns nothing (or an error), AND wg.Wait is still stuck.
+// We must log the abandon ERROR and return — never block. This is
+// distinct from TestDetach_BoundsWaitWhenKillAttachNilAndWgHangs above
+// in that it asserts on the specific log text used to surface the
+// failure mode in agent-factory.log, so an operator grepping for the
+// regression signature can find it.
+func TestDetach_LogsErrorWhenBothFallbacksFail(t *testing.T) {
+	prevSigkill := wgWaitSigkillDeadline
+	wgWaitSigkillDeadline = 30 * time.Millisecond
+	t.Cleanup(func() { wgWaitSigkillDeadline = prevSigkill })
+
+	prevAbandon := wgWaitAbandonDeadline
+	wgWaitAbandonDeadline = 60 * time.Millisecond
+	t.Cleanup(func() { wgWaitAbandonDeadline = prevAbandon })
+
+	// pgrep returns an error — simulates "pgrep not on PATH" or other
+	// unexpected shellout failures. The fallback should log the error
+	// and still hit the abandon deadline cleanly.
+	prevPgrep := pgrepRunnerVar
+	pgrepRunnerVar = func(string) ([]int, error) {
+		return nil, errors.New("synthetic pgrep failure")
+	}
+	t.Cleanup(func() { pgrepRunnerVar = prevPgrep })
+
+	prevErr := aflog.ErrorLog
+	var errBuf bytes.Buffer
+	aflog.ErrorLog = log.New(&errBuf, "ERROR: ", 0)
+	t.Cleanup(func() { aflog.ErrorLog = prevErr })
+
+	prevWarn := aflog.WarningLog
+	var warnBuf bytes.Buffer
+	aflog.WarningLog = log.New(&warnBuf, "WARN: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = prevWarn })
+
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("double-fallback-fail", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+	session.killAttach = nil
+
+	releaseHang := make(chan struct{})
+	t.Cleanup(func() { close(releaseHang) })
+	// Capture wg locally so Done() doesn't race against Detach's defer
+	// nilifying t.wg. The leaked-goroutine contract requires the
+	// goroutine to survive past Detach's return — that survival can't
+	// itself crash the test process.
+	wg := session.wg
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-releaseHang
+	}()
+
+	detachDone := make(chan struct{})
+	go func() {
+		session.Detach()
+		close(detachDone)
+	}()
+
+	select {
+	case <-detachDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Detach blocked despite both fallbacks being exhausted")
+	}
+
+	if !strings.Contains(warnBuf.String(), "pgrep fallback failed") {
+		t.Fatalf("expected WARN log noting pgrep failure; got %q", warnBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "abandoning wg.Wait") {
+		t.Fatalf("expected ERROR log on the abandon path; got %q", errBuf.String())
+	}
+}
+
+// TestDetach_KillAttachSurvivesNextDetach is the direct regression guard
+// for Problem A: in the 2026-05-20 incident, the previous Detach's defer
+// nilified t.killAttach AFTER Restore() had set a fresh closure for the
+// next attach lifecycle. The next Detach then ran with killAttach == nil
+// and hit the unbounded-wait bug.
+//
+// The fix moves the killAttach clear to the inline t.ptmx = nil site
+// (before Restore), so by the time Detach returns, t.killAttach is the
+// fresh closure Restore just installed — not nil. This test
+// reproduces the sequence: Detach → Restore → check killAttach is still
+// set. Without the fix, killAttach would be nil here.
+func TestDetach_KillAttachSurvivesNextDetach(t *testing.T) {
+	// Keep deadlines short so this test doesn't slow the suite, even
+	// though we expect wg.Wait to return promptly.
+	prevSigkill := wgWaitSigkillDeadline
+	wgWaitSigkillDeadline = 500 * time.Millisecond
+	t.Cleanup(func() { wgWaitSigkillDeadline = prevSigkill })
+
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("killattach-survives", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+	if session.killAttach == nil {
+		t.Fatal("Restore should have set killAttach")
+	}
+
+	// Stand in for Attach()'s bookkeeping so Detach has something to
+	// tear down. wg has no goroutines so wg.Wait returns immediately
+	// and we never enter the SIGKILL branch.
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+
+	session.Detach()
+
+	// The contract we're enforcing: after Detach returns, the next
+	// attach lifecycle inherits a Restore-installed killAttach, not
+	// the nil left behind by the old defer. The trace at 00:05:14 on
+	// 2026-05-20 showed exactly this invariant breaking — the warning
+	// at tmux.go:387 only fires when killAttach == nil at the start
+	// of waitForAttachDrain.
+	if session.killAttach == nil {
+		t.Fatal("Detach's post-Restore state should leave killAttach non-nil — Problem A regression")
+	}
+	if session.ptmx == nil {
+		t.Fatal("Detach's post-Restore state should leave ptmx non-nil")
 	}
 }

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -14,8 +14,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/creack/pty"
@@ -111,6 +113,17 @@ var slowDetachWgWaitThreshold = 5 * time.Second
 // every second and can contend with the attach client's exit round-trip
 // (see the #598 follow-up). var, not const, so tests can lower it.
 var wgWaitSigkillDeadline = 1 * time.Second
+
+// wgWaitAbandonDeadline bounds the secondary wait after the SIGKILL/pgrep
+// fallback has already fired. If wg.Wait still hasn't returned by this
+// deadline, the io.Copy goroutine is wedged in a way our escape hatches
+// can't unstick (kernel-level PTY drain bug, syscall stuck in D-state).
+// Leaking that one goroutine until the OS eventually drains the PTY is
+// strictly better than holding the user's TUI hostage for tens of seconds
+// — the original incident in #598 was a 51s hang at 00:05:14 because the
+// fallback was missing. Set to 2× wgWaitSigkillDeadline so the total
+// worst-case detach is ~3s. var, not const, so tests can lower it.
+var wgWaitAbandonDeadline = 2 * time.Second
 
 // ErrSessionGone is returned by PTY/tmux operations when the underlying tmux
 // session no longer exists. Non-daemon callers (preview pane, sidebar resize,
@@ -361,21 +374,47 @@ func (t *TmuxSession) Restore(workDir string) error {
 // blocking Read on a character device — that read only returns when the
 // slave end closes, which happens when the tmux client child exits, which
 // requires a round-trip through a potentially contended tmux server (#598).
+//
+// Three-stage bound to guarantee the user-visible detach is finite even
+// when our escape hatches fail (#598 follow-up regression at 00:05:14
+// 2026-05-20 — a 51s hang because killAttach was nil and the post-SIGKILL
+// wait was unbounded):
+//
+//  1. wg.Wait returns within wgWaitSigkillDeadline (the happy path).
+//  2. Otherwise: try the recorded killAttach closure if present, then a
+//     pgrep-based "find the tmux attach-session for this name and kill it"
+//     as last-resort. Then wait at most wgWaitAbandonDeadline for the
+//     stuck goroutine to drain.
+//  3. Otherwise: log ERROR, return, and let the goroutine leak. The
+//     kernel will eventually drain the PTY and the goroutine will exit on
+//     its own — a leaked goroutine is strictly better than freezing the
+//     TUI.
+//
 // Returns the elapsed wait so callers that surface diagnostics about a slow
-// wg.Wait (Detach) can do so without re-measuring.
+// wg.Wait (Detach) can do so without re-measuring. On the abandon path
+// returns wgWaitAbandonDeadline (not the literal elapsed) so the caller's
+// slowDetachWgWaitThreshold check still fires cleanly.
 func (t *TmuxSession) waitForAttachDrain() time.Duration {
-	if t.wg == nil {
+	// Capture the WaitGroup pointer locally so the helper goroutine below
+	// doesn't race against the Detach/Close defer that nils t.wg after
+	// we return. The abandon path leaks the goroutine on purpose; capture
+	// here means the leaked goroutine reads its own local, not a field
+	// concurrent goroutines may have mutated.
+	wg := t.wg
+	if wg == nil {
 		return 0
 	}
 	waitStart := time.Now()
 	waitDone := make(chan struct{})
 	go func() {
-		t.wg.Wait()
+		wg.Wait()
 		close(waitDone)
 	}()
 	select {
 	case <-waitDone:
+		return time.Since(waitStart)
 	case <-time.After(wgWaitSigkillDeadline):
+		// Primary fallback: SIGKILL the recorded attach process.
 		if t.killAttach != nil {
 			pid, killErr := t.killAttach()
 			log.WarningLog.Printf("tmux: wg.Wait exceeded %v; SIGKILLing tmux attach-session pid=%d to unblock io.Copy",
@@ -384,12 +423,130 @@ func (t *TmuxSession) waitForAttachDrain() time.Duration {
 				log.WarningLog.Printf("tmux: SIGKILL attempt failed: %v", killErr)
 			}
 		} else {
-			log.WarningLog.Printf("tmux: wg.Wait exceeded %v but no attach process recorded; cannot SIGKILL",
+			// Last-resort fallback: locate the attach client via pgrep -f
+			// and SIGKILL by pid. We get here when the pairing invariant
+			// between t.ptmx and t.killAttach was violated (a bug
+			// elsewhere) — the Problem A fix should prevent this, but
+			// the safety net protects against any future regression.
+			log.WarningLog.Printf("tmux: wg.Wait exceeded %v but no attach process recorded; attempting pgrep-based fallback",
 				wgWaitSigkillDeadline)
+			if killed, err := killTmuxAttachByName(t.sanitizedName); err != nil {
+				log.WarningLog.Printf("tmux: pgrep fallback failed: %v", err)
+			} else if killed > 0 {
+				log.WarningLog.Printf("tmux: pgrep fallback killed %d attach-session process(es) for %s",
+					killed, t.sanitizedName)
+			} else {
+				log.WarningLog.Printf("tmux: pgrep fallback found no matching attach-session process for %s",
+					t.sanitizedName)
+			}
 		}
-		<-waitDone
+		// Secondary bound: even if the SIGKILL/pgrep attempts above
+		// failed (or there was nothing to kill), do not block the TUI
+		// indefinitely waiting for the io.Copy goroutine to drain. If
+		// it's still stuck after wgWaitAbandonDeadline more, abandon
+		// the wait, leak the goroutine, and return. See the package
+		// doc on wgWaitAbandonDeadline.
+		select {
+		case <-waitDone:
+			return time.Since(waitStart)
+		case <-time.After(wgWaitAbandonDeadline):
+			log.ErrorLog.Printf("tmux: wg.Wait exceeded %v even after SIGKILL/pgrep fallback; "+
+				"abandoning wg.Wait. The io.Copy goroutine may leak until the kernel drains the PTY. "+
+				"This is preferable to freezing the TUI but indicates a deeper PTY/tmux-server issue.",
+				wgWaitAbandonDeadline)
+			return wgWaitSigkillDeadline + wgWaitAbandonDeadline
+		}
 	}
-	return time.Since(waitStart)
+}
+
+// pgrepRunner abstracts the "pgrep -f <pattern>" call so tests can stub
+// process discovery without actually shelling out. Returns the matched
+// pids (one per line of pgrep stdout) or an error if pgrep fails for a
+// reason other than "no matches" (which pgrep signals with exit code 1
+// and the runner reports as len(pids) == 0, nil).
+type pgrepRunner func(pattern string) (pids []int, err error)
+
+// killByPid abstracts SIGKILL-by-pid so tests can record calls without
+// actually killing real processes.
+type killByPidFn func(pid int) error
+
+// pgrepRunnerVar / killByPidVar are package-level hooks tests can swap.
+// Production uses defaultPgrepRunner + defaultKillByPid via exec/syscall.
+var (
+	pgrepRunnerVar pgrepRunner = defaultPgrepRunner
+	killByPidVar   killByPidFn = defaultKillByPid
+)
+
+// killTmuxAttachByName locates tmux attach-session client(s) bound to the
+// given sanitized session name via `pgrep -f` and SIGKILLs each match.
+// Returns the number of processes signalled and any error encountered.
+//
+// The pgrep pattern is anchored to the literal `tmux attach-session ... -t
+// <name>` invocation we run in Restore(), so the worst that can happen is
+// missing a kill (graceful) — not killing the wrong process. A bare name
+// match could collide with other tmux invocations (e.g. `tmux kill-session
+// -t <name>`), which we explicitly do NOT want to interrupt mid-flight.
+//
+// Exit code 1 from pgrep means "no matches" and is treated as success
+// with 0 kills; any other exit code is surfaced as an error.
+func killTmuxAttachByName(sanitizedName string) (int, error) {
+	pattern := fmt.Sprintf(`tmux attach-session -t %s$`, regexp.QuoteMeta(sanitizedName))
+	pids, err := pgrepRunnerVar(pattern)
+	if err != nil {
+		return 0, fmt.Errorf("pgrep -f %q: %w", pattern, err)
+	}
+	killed := 0
+	for _, pid := range pids {
+		if killErr := killByPidVar(pid); killErr != nil {
+			log.WarningLog.Printf("tmux: SIGKILL pid=%d (pgrep fallback) failed: %v", pid, killErr)
+			continue
+		}
+		killed++
+	}
+	return killed, nil
+}
+
+// defaultPgrepRunner shells out to `pgrep -f <pattern>` and parses the
+// pid list. Exit status 1 = "no matches" returns (nil, nil); any other
+// non-zero exit is an error.
+func defaultPgrepRunner(pattern string) ([]int, error) {
+	out, err := exec.Command("pgrep", "-f", pattern).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var pids []int
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		pid, parseErr := strconv.Atoi(line)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parsing pgrep pid %q: %w", line, parseErr)
+		}
+		pids = append(pids, pid)
+	}
+	return pids, nil
+}
+
+// defaultKillByPid sends SIGKILL to the given pid. ESRCH (process already
+// exited) is silently ignored — the goal is "no longer a blocker", which
+// an already-dead process satisfies.
+func defaultKillByPid(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	if err := proc.Signal(syscall.SIGKILL); err != nil {
+		if errors.Is(err, syscall.ESRCH) || errors.Is(err, os.ErrProcessDone) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 type statusMonitor struct {
@@ -660,7 +817,14 @@ func (t *TmuxSession) Detach() {
 		t.cancel = nil
 		t.ctx = nil
 		t.wg = nil
-		t.killAttach = nil
+		// NOTE: t.killAttach is deliberately NOT cleared here. The Restore()
+		// call below sets a fresh killAttach paired with the new t.ptmx; if
+		// we cleared it here we'd leave the next Attach lifecycle in a
+		// ptmx-valid / killAttach-nil state, which is exactly the
+		// invariant break that caused the 51s detach hang in the #598
+		// follow-up regression. killAttach is now paired with t.ptmx
+		// inline below — set/cleared together. See the in-line clear next
+		// to "t.ptmx = nil".
 	}()
 
 	// Cancel context FIRST so monitorWindowSize goroutines exit promptly and
@@ -702,7 +866,13 @@ func (t *TmuxSession) Detach() {
 	// means a Restore failure (or a Close failure) can't leave the closed
 	// handle dangling on the struct — a subsequent Attach would otherwise
 	// silently bind goroutines to a closed file and hang (#464).
+	// Pair the clear with t.killAttach: the closure references the dying
+	// attachCmd whose process is being torn down, so it must not survive
+	// past this point. Restore() below will assign both fields together
+	// for the next attach lifecycle; this is the invariant the #598
+	// follow-up regression broke.
 	t.ptmx = nil
+	t.killAttach = nil
 
 	if closeErr != nil {
 		log.ErrorLog.Printf("error closing attach pty session: %v", closeErr)


### PR DESCRIPTION
## Summary

Follow-up fix for the #598/#601 regression observed at 00:05:14 on
2026-05-20: detach hung for 51.3s. The previous SIGKILL fallback merged
in #601 had two gaps that compounded — without the kill closure, the
fallback path STILL waited unbounded.

### Log evidence (from `~/.config/agent-factory/agent-factory.log`)

```
2026/05/20 00:04:23 tmux.go:654: [detach-trace] tmux.Detach-entry name=af_bc8bf732_remove-rainfrog-from-CLIS
2026/05/20 00:04:23 tmux.go:673: [detach-trace] tmux.Detach-cancel-done elapsed=8.625µs
2026/05/20 00:04:23 tmux.go:679: [detach-trace] tmux.Detach-ptmx.Close-done elapsed=4.487µs
2026/05/20 00:04:24 tmux.go:387: WARNING tmux: wg.Wait exceeded 1s but no attach process recorded; cannot SIGKILL
2026/05/20 00:05:14 tmux.go:689: [detach-trace] tmux.Detach-wg.Wait-done elapsed=51.301646739s
2026/05/20 00:05:14 tmux.go:696: ERROR tmux.Detach: wg.Wait took 51.3s — likely tmux server contention…
2026/05/20 00:05:14 tmux.go:656: [detach-trace] tmux.Detach-exit total=51.308989046s
```

The earlier successful detach at 23:57:14 ran cleanly in 100ms — Restore
at the bottom of Detach set a fresh killAttach. The defer at the top of
Detach then unconditionally cleared it. The next attach lifecycle
inherited ptmx-valid / killAttach-nil; the next Detach landed in the
"cannot SIGKILL" path and blocked.

## Problem A — pairing invariant break

**The bug**: Detach's defer set `t.killAttach = nil` AFTER the in-function
`Restore("")` (line 716) had already installed a fresh closure paired
with the new `t.ptmx`. Result: between two Detaches, the session sat
with valid ptmx but nil killAttach. Attach didn't reassign killAttach
(it's only Restore's job), so the next Detach hit the fallback branch
with nothing to invoke.

**The fix**: pair set/clear sites — `t.killAttach = nil` is now adjacent
to `t.ptmx = nil` inline (before the Restore call), so if Restore
succeeds both are set, if Restore fails both stay nil.

## Problem B — abandon-after-fallback safety net

**The bug**: after the "cannot SIGKILL" warning, the previous code fell
through to an unconditional `<-waitDone`. With a wedged io.Copy, that
blocks forever.

**The fix**: three-stage bound in `waitForAttachDrain`:

1. `wg.Wait` returns within `wgWaitSigkillDeadline` (1s) — happy path.
2. Otherwise: try recorded `killAttach`, else fall back to `pgrep -f`
   anchored on `tmux attach-session -t <name>$` (no bare-name match —
   we don't want to interrupt a concurrent `tmux kill-session -t
   <name>`). Then wait at most `wgWaitAbandonDeadline` (2s).
3. Otherwise: log ERROR, return, leak the goroutine. The kernel will
   eventually drain the PTY. Leaking one goroutine is strictly better
   than a 51-second frozen TUI.

Total user-visible worst case: ~3s, down from unbounded.

Also fixed a data race that the abandon path surfaced: the helper
goroutine inside `waitForAttachDrain` now captures `t.wg` into a local
so the leaked goroutine doesn't read the field concurrently with
Detach's defer nilifying it.

## Mutation-site audit (`t.ptmx` / `t.killAttach`)

| Site | `t.ptmx` action | `t.killAttach` action | Paired? |
| ---- | --------------- | --------------------- | ------- |
| `Restore` line 339, 361 | `t.ptmx = ptmx` | sets closure | yes |
| `DetachSafely` line 627–628, 642 | `t.ptmx = nil` | `nil` after `waitForAttachDrain` | yes |
| `Detach` line 678 (close), 707 (`= nil`), 708 (`killAttach = nil`) | `t.ptmx = nil` inline | `t.killAttach = nil` inline, no longer in defer | **yes (this PR)** |
| `Close` line 749, 765, 767 | `t.ptmx = nil` | `nil` after `waitForAttachDrain` | yes |
| `Start` (lines 224, 242, 255) | local ptmx only, never assigned to field | — | n/a |
| `Attach` | read-only on both | does not touch | n/a |

The only violation was Detach's defer pulling killAttach apart from its
ptmx pair. Other call sites already paired the set/clear correctly.

## CI gates locally

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go test -race -count=1 ./...` — `session/tmux` clean. One unrelated
  failure in `daemon/TestSigtermFallback_DeadPID` reproduces identically
  on `master` and is caused by two stale `af --daemon` processes on the
  test machine, not by this change.

## Test plan

- [x] `go test -race -count=1 ./session/tmux/` passes
- [x] New regression guard `TestDetach_BoundsWaitWhenKillAttachNilAndWgHangs` asserts Detach returns within `sigkill + abandon + slack` even when wg is wedged AND killAttach is nil
- [x] New regression guard `TestDetach_KillAttachSurvivesNextDetach` asserts Problem A: after Detach returns, the post-Restore killAttach is still non-nil
- [x] `TestKillTmuxAttachByName_KillsMatchingPids` verifies pgrep pattern anchoring and pid → kill wiring
- [x] `TestKillTmuxAttachByName_NoMatches` verifies the no-match path is silent
- [x] `TestDetach_LogsErrorWhenBothFallbacksFail` verifies the abandon ERROR log when both fallbacks fail
- [ ] Manual verification: attach / detach repeatedly under daemon contention to confirm no multi-second hangs in `agent-factory.log`

Signed-off-by: Captain Claude