### PR TITLE
fix(config): shellQuoteProgram must not split on " -" inside directory names (#606)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,12 @@ const (
 
 var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|->|^[^/=\s]+\s*=)\s*(.+)`)
 
+// flagBoundaryRegex matches the first " -X" / " --X" sequence in a program
+// string, where X is an ASCII letter. The trailing letter requirement is
+// what distinguishes a real flag boundary from a literal " - " (space dash
+// space) that appears inside a directory name (issue #606).
+var flagBoundaryRegex = regexp.MustCompile(` -{1,2}[a-zA-Z]`)
+
 // GetConfigDir returns the path to the application's configuration directory.
 // If AGENT_FACTORY_HOME is set, it is used as the config directory.
 // Otherwise, defaults to ~/.agent-factory.
@@ -65,19 +71,21 @@ type Config struct {
 // shellQuoteProgram returns a tmux-safe form of program. tmux passes a
 // session's program string to `sh -c`, so paths containing spaces or
 // apostrophes must be shell-quoted or the shell will split them. The input
-// may be a bare program path or a path followed by flags; the first " -"
-// is treated as the flag boundary so only the path portion is quoted and
-// trailing flags are preserved verbatim. Values whose path portion is
-// already wrapped in matching single or double quotes are returned
-// unchanged to avoid double-quoting user-provided config.
+// may be a bare program path or a path followed by flags; the first
+// space-dash-letter sequence is treated as the flag boundary so only the
+// path portion is quoted and trailing flags are preserved verbatim. The
+// trailing-letter requirement avoids false matches on literal " - " (space
+// dash space) inside a directory name (issue #606). Values whose path
+// portion is already wrapped in matching single or double quotes are
+// returned unchanged to avoid double-quoting user-provided config.
 func shellQuoteProgram(program string) string {
 	if program == "" {
 		return program
 	}
 
 	path, suffix := program, ""
-	if i := strings.Index(program, " -"); i >= 0 {
-		path, suffix = program[:i], program[i:]
+	if loc := flagBoundaryRegex.FindStringIndex(program); loc != nil {
+		path, suffix = program[:loc[0]], program[loc[0]:]
 	}
 
 	if len(path) >= 2 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -417,6 +417,23 @@ func TestShellQuoteProgram(t *testing.T) {
 			want: "'/opt/My Tools/claude' -v --dangerously-skip-permissions",
 		},
 		{
+			// Regression for #606: " - " in a directory name must not be
+			// treated as a flag boundary.
+			name: "dir name contains space-dash-space",
+			in:   "/home/user/my - project/claude",
+			want: "'/home/user/my - project/claude'",
+		},
+		{
+			name: "dir name contains space-dash-space, with long flag",
+			in:   "/home/user/my - project/claude --foo",
+			want: "'/home/user/my - project/claude' --foo",
+		},
+		{
+			name: "dir name contains multiple space-dash-space, with flag and value",
+			in:   "/home/user/a - b - c/aider --model x",
+			want: "'/home/user/a - b - c/aider' --model x",
+		},
+		{
 			name: "empty string",
 			in:   "",
 			want: "",


### PR DESCRIPTION
## Summary

- Fixes #606. `shellQuoteProgram` was splitting on the first literal `" -"` to peel flags off the program path before quoting. When the path itself contained `" - "` (space dash space) inside a directory name — e.g. `/home/user/my - project/claude` — the split landed mid-path, the prefix had no spaces, the "needs quoting" check returned false, and tmux's `sh -c` word-split the result into `command not found`. Regression introduced in #591 (fix for #569).
- Tighten flag-boundary detection: only treat `" -"` as a flag boundary when followed by an ASCII letter (`" -X"` / `" --X"`). Plain `" - "` inside a path no longer matches. Implemented with a small package-level regex (`\` `-{1,2}[a-zA-Z]`).
- Tests extended with the new path shapes; existing #569/#591 cases (macOS App Bundle paths with spaces, paths with apostrophes, already-quoted inputs, flagged invocations) continue to pass.

## Audit

Grepped the codebase for other call-sites that split a program string at a flag boundary. The only one was `config/config.go:shellQuoteProgram`. `session/systemprompt.go:getBaseCommand` uses a proper shell tokenizer (`splitShell`) and already handles `" - "` directory names via the "known agent basename" heuristic (issue #513) — no change needed there.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go test ./config/...` — all `TestShellQuoteProgram` cases pass, including #569/#591 inputs and three new #606 cases
- [x] `go test -race ./config/... ./session/...` — clean
- [x] `go test ./...` — full suite green except a preexisting `TestSigtermFallback_DeadPID` flake driven by stray `af --daemon` processes on the dev host (reproduces on `master` without this change; unrelated to this PR)

— Captain Claude