### PR TITLE
fix(tmux): anchor CleanupSessions regex to start-of-line to avoid killing non-af sessions (#613)

### DIFF
--- a/session/tmux/cleanup_bug_test.go
+++ b/session/tmux/cleanup_bug_test.go
@@ -1,0 +1,71 @@
+package tmux
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCleanupSessionsOnlyKillsPrefixedSessions guards against #613: an
+// unanchored regex used to match `af_` anywhere on a `tmux ls` line, which
+// caused a user's `my_af_project` session to be misread as `af_project` and
+// destroyed. After the fix, only sessions whose names start with the `af_`
+// prefix are killed.
+func TestCleanupSessionsOnlyKillsPrefixedSessions(t *testing.T) {
+	tmuxOutput := `my_af_project: 1 windows (created Wed May 20 12:00:00 2026) [179x47]
+af_real_session: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
+
+	var killedSessions []string
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			for i, arg := range cmd.Args {
+				if arg == "-t" && i+1 < len(cmd.Args) {
+					killedSessions = append(killedSessions, cmd.Args[i+1])
+				}
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return []byte(tmuxOutput), nil
+		},
+	}
+
+	err := CleanupSessions(cmdExec)
+	require.NoError(t, err)
+	require.Equal(t, []string{"af_real_session"}, killedSessions,
+		"only `af_`-prefixed sessions should be killed; `my_af_project` must be left alone")
+}
+
+// TestCleanupSessionsHandlesMixedAndColonNames covers the full matrix from
+// the #613 audit: prefixed, suffixed-but-not-prefixed, mid-name, and a
+// session name that itself contains colons (tmux usually rewrites those,
+// but the cleanup path should still extract the name through the first ':'
+// without duplicating the kill).
+func TestCleanupSessionsHandlesMixedAndColonNames(t *testing.T) {
+	tmuxOutput := `my_af_personal: 1 windows (created Wed May 20 12:00:00 2026) [179x47]
+af_real_session: 1 windows (created Wed May 20 12:01:00 2026) [179x47]
+prefix_af_other: 1 windows (created Wed May 20 12:02:00 2026) [179x47]
+af_a:b:c: 1 windows (created Wed May 20 12:03:00 2026) [179x47]`
+
+	var killedSessions []string
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			for i, arg := range cmd.Args {
+				if arg == "-t" && i+1 < len(cmd.Args) {
+					killedSessions = append(killedSessions, cmd.Args[i+1])
+				}
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return []byte(tmuxOutput), nil
+		},
+	}
+
+	err := CleanupSessions(cmdExec)
+	require.NoError(t, err)
+	require.Equal(t, []string{"af_real_session", "af_a"}, killedSessions,
+		"only `af_`-prefixed sessions should be killed, with `af_a:b:c` truncated to `af_a` and killed exactly once")
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -1030,7 +1030,9 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 		return fmt.Errorf("failed to list tmux sessions: %v", err)
 	}
 
-	re := regexp.MustCompile(fmt.Sprintf(`%s.*:`, TmuxPrefix))
+	// Anchor to start-of-line so `af_` embedded in a non-agent session name
+	// (e.g. `my_af_project:`) is never matched and killed (#613).
+	re := regexp.MustCompile(fmt.Sprintf(`(?m)^%s[^:]*:`, regexp.QuoteMeta(TmuxPrefix)))
 	matches := re.FindAllString(string(output), -1)
 	for i, match := range matches {
 		matches[i] = match[:strings.Index(match, ":")]


### PR DESCRIPTION
## Summary
`CleanupSessions()` in `session/tmux/tmux.go` extracted session names from `tmux ls` output via the unanchored regex `af_.*:`. Because `tmux ls` output is multi-line and the pattern was not anchored to start-of-line, a user's personal session named `my_af_project: …` matched the embedded `af_` substring and the code extracted `af_project` as the "session name" to kill — destroying the real `af_project` session on `af reset`.

Fix: anchor to start-of-line with `(?m)^`, terminate at the first colon with `[^:]*`, and wrap `TmuxPrefix` in `regexp.QuoteMeta` for defense-in-depth.

```go
re := regexp.MustCompile(fmt.Sprintf(`(?m)^%s[^:]*:`, regexp.QuoteMeta(TmuxPrefix)))
```

Closes #613

## Adjacent-call-site audit
Grepped `TmuxPrefix`, `"af_`, and all regex matchers across the repo. Findings:

| Site | Pattern | Classification |
| --- | --- | --- |
| `session/tmux/tmux.go:1033` (this fix) | `regexp` over multi-line `tmux ls` output | **Was unsafe — fixed** |
| `session/tmux/tmux.go:181` | `fmt.Sprintf("%s%s_%s", TmuxPrefix, …)` | Construction, not matching — safe |
| `session/tmux/tmux.go:493` (`killTmuxAttachByName`) | `tmux attach-session -t %s$` with `QuoteMeta` | Already anchored on both sides — safe |
| `daemon/control.go:917` | `strings.HasPrefix(sanitizedName, tmux.TmuxPrefix)` on a single name | Prefix check on a single token — safe |
| `api/sessions.go:37` | same `strings.HasPrefix` guard | Prefix check on a single token — safe |
| `ui/preview_test.go:48,563` | `"af_" + sessionName` for `tmux kill-session` | Test-only construction — safe |
| `daemon/control_test.go`, `api/sessions_test.go`, `session/tmux/tmux_test.go` | literal `"af_ghost"`, `"af_custom_name"` test data | Test data, not regex sources — safe |

The cleanup regex was the only call-site exposed to multi-line input.

## Tests
- `TestCleanupSessionsOnlyKillsPrefixedSessions` — the failing case from the bug report. With the buggy regex the test killed `af_project` (the misextracted name) and surfaced the synthetic "no session found" error from the mock. With the fix it kills exactly `af_real_session` and `my_af_project` is left untouched.
- `TestCleanupSessionsHandlesMixedAndColonNames` — full matrix from the audit:
  - `my_af_personal: …` → NOT killed
  - `af_real_session: …` → killed
  - `prefix_af_other: …` → NOT killed
  - `af_a:b:c: …` → killed exactly once with extracted name `af_a` (first-colon truncation)

  Asserts `killedSessions == ["af_real_session", "af_a"]` (order and exactly-once).

## Verification
- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean (exit 0)
- `go test -race ./...` — `session/tmux` and every other package pass. One unrelated failure, `daemon.TestSigtermFallback_DeadPID`, reproduces on `master` on this dev machine because there are live `af --daemon` processes running locally that the test's process discovery picks up. Not introduced by this PR.

🤖 Co-authored with Captain Claude