### PR TITLE
fix(ui/hooks): clamp selectedIdx to 0 when SetCommands gets empty slice (#615)

### DIFF
--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -33,7 +33,9 @@ func (h *HooksPane) SetSize(width, height int) {
 func (h *HooksPane) SetCommands(commands []string) {
 	h.commands = commands
 	h.dirty = false
-	if h.selectedIdx >= len(h.commands) && h.selectedIdx > 0 {
+	if len(h.commands) == 0 {
+		h.selectedIdx = 0
+	} else if h.selectedIdx >= len(h.commands) {
 		h.selectedIdx = len(h.commands) - 1
 	}
 }

--- a/ui/hooks_pane_test.go
+++ b/ui/hooks_pane_test.go
@@ -20,3 +20,47 @@ func TestHooksPaneEditModeCtrlCCancels(t *testing.T) {
 	assert.False(t, h.adding)
 	assert.Empty(t, h.editBuffer)
 }
+
+func TestHooksPaneSetCommandsEmptySliceBug(t *testing.T) {
+	h := NewHooksPane()
+	h.SetCommands([]string{"cmd1", "cmd2", "cmd3"})
+	h.SetFocus(true)
+	h.ScrollDown() // selectedIdx: 0 -> 1
+	h.ScrollDown() // selectedIdx: 1 -> 2
+
+	h.SetCommands([]string{})         // selectedIdx = -1
+	h.SetCommands([]string{"newcmd"}) // selectedIdx stays -1
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Logf("Bug confirmed: panic occurred: %v", r)
+		}
+	}()
+
+	h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}) // PANIC
+}
+
+// TestHooksPaneSetCommandsRoundtripKeepsSelectedIdxValid verifies that going
+// non-empty -> empty -> non-empty leaves selectedIdx in range so subsequent
+// indexing is safe. Regression test for #615.
+func TestHooksPaneSetCommandsRoundtripKeepsSelectedIdxValid(t *testing.T) {
+	h := NewHooksPane()
+	h.SetCommands([]string{"cmd1", "cmd2", "cmd3"})
+	h.SetFocus(true)
+	h.ScrollDown()
+	h.ScrollDown()
+	assert.Equal(t, 2, h.selectedIdx)
+
+	h.SetCommands([]string{})
+	assert.Equal(t, 0, h.selectedIdx, "selectedIdx should reset to 0 for an empty list")
+
+	h.SetCommands([]string{"newcmd"})
+	assert.GreaterOrEqual(t, h.selectedIdx, 0, "selectedIdx must not be negative")
+	assert.Less(t, h.selectedIdx, len(h.GetCommands()), "selectedIdx must be in range")
+
+	assert.NotPanics(t, func() {
+		h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	})
+	assert.True(t, h.editing)
+	assert.Equal(t, "newcmd", h.editBuffer)
+}


### PR DESCRIPTION
## Summary
- `HooksPane.SetCommands` clamped `selectedIdx` to `len(commands)-1`, which becomes `-1` for an empty slice.
- A subsequent `SetCommands` with a non-empty list did not recover, because `selectedIdx >= len(commands)` is false for `-1`. Pressing Enter then indexed `h.commands[-1]` and panicked.
- Fix: explicitly handle the empty case by resetting `selectedIdx = 0`, otherwise clamp to `len-1`. Matches the TaskPane fix in f136256 / #285.
- Audited the other panes with `selectedIdx` clamping:
  - `Sidebar` (ui/sidebar.go:143) — safe; the `selectedIdx < 0` follow-up re-clamps to 0.
  - `SearchOverlay` (ui/overlay/searchOverlay.go:113) — safe; same follow-up clamp.
  - `TaskPane` — already fixed in f136256.
  - `HooksPane` — this PR.
  No other instances of the bug.

## Test plan
- [x] Bot's failing test `TestHooksPaneSetCommandsEmptySliceBug` added verbatim — passes after fix.
- [x] Added positive test `TestHooksPaneSetCommandsRoundtripKeepsSelectedIdxValid` covering non-empty → empty → non-empty and asserting `Enter` doesn't panic.
- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go test ./ui/... -race` passes
- [x] `golangci-lint run --timeout=3m --fast ./ui/...` clean

Closes #615.

Signed-off-by: Captain Claude