### PR TITLE
fix(config): AtomicWriteFile must not return error after rename succeeds (#608)

### DIFF
--- a/config/filelock.go
+++ b/config/filelock.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // WithFileLock acquires an exclusive flock on a .lock file adjacent to the target path,
@@ -93,20 +95,26 @@ func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		return fmt.Errorf("failed to rename temp file to %s: %w", path, err)
 	}
 
+	// Rename succeeded: data is visible on disk. The contract
+	// "err == nil ⟺ data is persisted" must hold from this point on, so the
+	// parent-directory fsync below (which only affects crash durability, not
+	// visibility) becomes best-effort. Mark success so the deferred temp-file
+	// cleanup is a no-op and downstream callers don't roll back persisted data.
+	success = true
+
 	// Fsync the parent directory to ensure the rename (new directory entry) is
-	// persisted. Without this, a crash right after rename could lose the file.
+	// persisted across a crash. Failures here are logged but not returned --
+	// the data is already visible to readers.
 	dirFd, err := os.Open(dir)
 	if err != nil {
-		return fmt.Errorf("failed to open directory %s for sync: %w", dir, err)
+		log.WarningLog.Printf("AtomicWriteFile: failed to open directory %s for post-rename sync: %v", dir, err)
+		return nil
 	}
 	if err := dirFd.Sync(); err != nil {
-		dirFd.Close()
-		return fmt.Errorf("failed to sync directory %s: %w", dir, err)
+		log.WarningLog.Printf("AtomicWriteFile: failed to fsync directory %s after rename of %s: %v", dir, path, err)
 	}
 	if err := dirFd.Close(); err != nil {
-		return fmt.Errorf("failed to close directory %s: %w", dir, err)
+		log.WarningLog.Printf("AtomicWriteFile: failed to close directory %s after post-rename sync of %s: %v", dir, path, err)
 	}
-
-	success = true
 	return nil
 }

--- a/config/filelock_test.go
+++ b/config/filelock_test.go
@@ -61,3 +61,64 @@ func TestAtomicWriteFileCreatesDir(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, data, got)
 }
+
+// TestAtomicWriteFileSucceedsEvenIfDirSyncWouldFail locks in the post-rename
+// contract for #608: once os.Rename has placed the data on disk, AtomicWriteFile
+// must return nil. The parent-directory fsync is best-effort for crash
+// durability and must not turn into a returned error -- callers (api/tasks.go,
+// daemon/control.go) treat any error as "data was not persisted" and roll back.
+//
+// The function as-written makes injecting a real dir-sync failure require
+// either a func var seam or an OS-specific hack; both were considered worse
+// than a behavior-level assertion of the contract. So this test exercises the
+// happy path and asserts (a) nil return, (b) file present, (c) bytes match,
+// (d) perm bits as requested.
+func TestAtomicWriteFileSucceedsEvenIfDirSyncWouldFail(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "persisted.json")
+
+	data := []byte(`{"persisted": true}`)
+	err := AtomicWriteFile(path, data, 0640)
+	require.NoError(t, err, "post-rename failures must not surface as an error")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0640), info.Mode().Perm())
+}
+
+// TestAtomicWriteFileReturnsErrorOnPreRenameFailure proves that errors before
+// os.Rename succeeds (the failure modes where data is NOT yet on disk) still
+// surface as a returned error. We make the parent directory read-only so that
+// CreateTemp inside AtomicWriteFile fails, ensuring no rename can happen and
+// any pre-existing file at `path` is left untouched.
+func TestAtomicWriteFileReturnsErrorOnPreRenameFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0500 does not prevent writes")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.json")
+
+	original := []byte(`{"original": "untouched"}`)
+	require.NoError(t, os.WriteFile(path, original, 0644))
+
+	// Make the directory read+execute only so CreateTemp fails.
+	require.NoError(t, os.Chmod(dir, 0500))
+	t.Cleanup(func() {
+		// Restore perms so t.TempDir cleanup can remove the directory.
+		_ = os.Chmod(dir, 0700)
+	})
+
+	err := AtomicWriteFile(path, []byte(`{"new": "value"}`), 0644)
+	require.Error(t, err, "pre-rename failures must surface as an error so callers can roll back")
+
+	// Re-grant read access for the assertion read; we already failed the write.
+	require.NoError(t, os.Chmod(dir, 0700))
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, got, "original file must be unchanged when AtomicWriteFile returns error")
+}


### PR DESCRIPTION
## Summary

Fixes #608.

`AtomicWriteFile` in `config/filelock.go` used to return a non-nil error if the parent-directory `Open`/`Sync`/`Close` (run after a successful `os.Rename` to ensure crash durability) failed. But once `os.Rename` returns nil, the data is already visible to readers — those subsequent operations only affect *crash durability*, not visibility. The old behavior broke the implicit contract callers rely on: "`err == nil` ⟺ data is persisted." Callers with rollback logic (e.g. `api/tasks.go`, `daemon/control.go`) would interpret the error as "write didn't happen" and proceed to delete real persisted data or kill running sessions.

The fix marks the write `success = true` immediately after `os.Rename`, then attempts the parent-dir fsync/close as best-effort. Any failure on the open / sync / close path is logged via `log.WarningLog.Printf` and `nil` is returned. Pre-rename failures (MkdirAll, CreateTemp, Write, Chmod, tmp.Sync, tmp.Close, Rename) still return errors, because in those cases the data is genuinely not persisted.

## Caller audit

No code changes to call sites — the existing rollback logic is correct under the new (and intended) contract. Pre-fix, a post-rename warning could have caused these caller behaviors:

- `api/tasks.go:116-139` (task add + scheduler rollback) — `task.AddTask` would have reported failure even though the task JSON was persisted; user sees error while task quietly exists.
- `api/tasks.go:314-326` (task update + scheduler reinstall) — `installScheduler` would have reported failure post-write, triggering the rollback to re-install the *old* cron, overwriting the correctly-persisted new unit file. Destructive.
- `daemon/control.go:551-567` (session create + kill on persist failure) — `appendInstanceData` would have reported failure even though the session record was on disk, prompting `instance.Kill()` on a real running session and deleting the in-memory entry. Destructive.
- `autoupdate.go:95`, `upgrade.go:131` (binary atomic update) — error would have aborted the install flow with the new binary already on disk; non-destructive but inconsistent state.
- `autoupdate.go:213` (timestamp marker) — return value discarded with `_ =`; unaffected either way.
- `task/systemd.go:115`, `task/systemd.go:137`, `task/launchd.go:109` (scheduler unit files) — return is composed via `installScheduler`; see `api/tasks.go` rows above.
- `session/plugin.go:137`, `session/plugin.go:162` (plugin manifest / files) — caller propagates the error; no destructive rollback. User sees spurious install failure while manifest is persisted.
- `task/task.go:105`, `task/task.go:119` (task JSON writes) — composed via `task.AddTask`/`task.UpdateTask`; see `api/tasks.go` rows above.
- `task/runner.go:58` (task run record) — caller logs and continues; non-destructive.
- `daemon/daemon.go:223` (daemon pidfile) — daemon startup would have aborted with a valid pidfile on disk; not destructive of user data.
- `config/config.go:233` (config save) — caller in `LoadConfig` only logs the save error; non-destructive but log spam.
- `config/state.go:107`, `config/state.go:166` (state writes) — propagated to callers; daemon/control session-create path is the destructive case noted above.
- `config/repo_config.go:88` (repo config) — caller propagates; non-destructive.
- `config/filelock.go:49` (`LockedUpdate`) — wraps `AtomicWriteFile`; inherits the new contract for every locked RMW caller.

The two destructive call sites (`api/tasks.go:314-326`, `daemon/control.go:551-567`) are the ones #608 specifically calls out. With this fix, those rollback paths still execute on real pre-rename failures (where the data is genuinely not on disk) and no longer execute on the post-rename fsync/close warning case.

## Tests

Added in `config/filelock_test.go`:

- `TestAtomicWriteFileSucceedsEvenIfDirSyncWouldFail` — locks in the post-rename success contract: nil return, file present, correct bytes, correct perm. Adding an actual dir-sync failure injection would have required a func-var seam or OS-specific hack — both were judged worse than a behavior-level contract assertion.
- `TestAtomicWriteFileReturnsErrorOnPreRenameFailure` — makes the parent directory read-only so `CreateTemp` fails before rename, asserts (a) non-nil error and (b) any pre-existing file at `path` is unchanged. Skipped under uid 0.

## Test plan

- [x] `gofmt -l .`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `go build ./...`
- [x] `go test ./...` *(only pre-existing environmental daemon test flakes failed; reproduced identically on master with the patch stashed — caused by stale `af --daemon` processes on the dev host, unrelated to this change)*
- [x] `go test -race ./config/...`

— Captain Claude