### PR TITLE
fix(ui/preview): fallback view should fill full height to match normal mode (#616)

### DIFF
--- a/ui/preview.go
+++ b/ui/preview.go
@@ -181,10 +181,10 @@ func (p *PreviewPane) String() string {
 
 	if p.previewState.fallback {
 		// TabbedWindow.SetSize already subtracts borders/margins/padding from
-		// p.height, so we mirror the normal-mode subtraction here to avoid
-		// double-counting chrome and truncating the welcome ASCII art on
-		// smaller terminals.
-		availableHeight := p.height - 1
+		// p.height, so we use p.height directly to match normal mode (which
+		// pads to the full p.height). Subtracting again here would
+		// double-count chrome and leave a trailing blank line (#616).
+		availableHeight := p.height
 
 		// Count the number of lines in the fallback text
 		fallbackLines := len(strings.Split(p.previewState.text, "\n"))

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -472,8 +472,8 @@ func TestPreviewFallbackHeightNoDoubleCounting(t *testing.T) {
 
 	t.Run("matches normal-mode height budget", func(t *testing.T) {
 		// At any height, the fallback should compute the same availableHeight
-		// as normal mode (p.height - 1), so the rendered output fills the
-		// same number of lines.
+		// as normal mode (p.height), so the rendered output fills the same
+		// number of lines.
 		for _, h := range []int{20, 25, 30, 50} {
 			p := NewPreviewPane()
 			p.SetSize(80, h)
@@ -482,20 +482,54 @@ func TestPreviewFallbackHeightNoDoubleCounting(t *testing.T) {
 			rendered := p.String()
 			lines := strings.Split(rendered, "\n")
 
-			// We expect at least max(fallbackTextLines, h-1) lines; the pane
+			// We expect at least max(fallbackTextLines, h) lines; the pane
 			// pads to fill the available area when content is shorter than
 			// the budget.
-			expected := h - 1
+			expected := h
 			if fallbackTextLines > expected {
 				expected = fallbackTextLines
 			}
 			require.GreaterOrEqual(t, len(lines), expected,
-				"height=%d: fallback must fill p.height-1 (no double-counting of chrome)",
+				"height=%d: fallback must fill p.height (no double-counting of chrome)",
 				h)
 			require.Contains(t, rendered, "msg",
 				"height=%d: fallback message must remain visible", h)
 		}
 	})
+}
+
+// TestPreviewFallbackMatchesNormalModeHeight is the regression test for #616.
+// Before the fix, fallback rendering computed availableHeight as p.height - 1
+// while normal mode (post-#405) padded to the full p.height, so fallback views
+// rendered one line shorter than normal views and left a trailing blank line.
+// Both modes must now render the same number of lines for the same p.height.
+func TestPreviewFallbackMatchesNormalModeHeight(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	// Heights large enough that the height budget — not the fallback ASCII
+	// art — bounds the rendered output. At smaller heights the ASCII art
+	// overflows the budget and the two modes are not comparable.
+	for _, h := range []int{20, 25, 30, 50} {
+		// Normal mode: short content padded to full height.
+		normal := NewPreviewPane()
+		normal.SetSize(80, h)
+		normal.previewState = previewState{
+			fallback: false,
+			text:     "line1\nline2",
+		}
+		normalLines := len(strings.Split(normal.String(), "\n"))
+
+		// Fallback mode at the same height with a short message.
+		fb := NewPreviewPane()
+		fb.SetSize(80, h)
+		fb.setFallbackState("msg")
+		fbLines := len(strings.Split(fb.String(), "\n"))
+
+		require.Equal(t, normalLines, fbLines,
+			"height=%d: fallback and normal mode must render the same number of lines",
+			h)
+	}
 }
 
 // setupTwoInstances creates two independent instances in the same test so we


### PR DESCRIPTION
## Summary

- Fixes #616. `PreviewPane`'s fallback branch computed `availableHeight := p.height - 1` based on a stale comment claiming it mirrored normal mode. After #405 / `40ea10a` fixed normal mode to pad short content to the full `p.height`, the fallback was off by one and left a trailing blank line on loading / error / no-agents screens.
- Changes the fallback to use `p.height` directly, updates the misleading comment, fixes the stale `h - 1` assertion in `TestPreviewFallbackHeightNoDoubleCounting/matches_normal-mode_height_budget`, and adds a new regression test `TestPreviewFallbackMatchesNormalModeHeight` that compares fallback and normal-mode line counts side-by-side.
- Audited the rest of `ui/preview.go`: the remaining `p.height-1` is the normal-mode truncation branch that reserves a line for the `...` marker — unrelated to this bug.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go test -race ./ui/` passes (includes the new regression test)
- [x] Temporarily restoring `p.height - 1` makes `TestPreviewFallbackMatchesNormalModeHeight` fail with `expected: 20, actual: 19` at `h=20` — confirming the test catches the off-by-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)