### PR TITLE
fix(session/tmux): detect --resume=VALUE syntax in resumeProgram so Gemini doesn't get duplicate flags (#604)

### DIFF
--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -57,7 +57,8 @@ func resumeProgram(program string) string {
 	switch agent {
 	case ProgramClaude:
 		for _, tok := range tokens {
-			if tok == "-c" || tok == "--continue" || tok == "-r" || tok == "--resume" {
+			if tok == "-c" || tok == "--continue" || tok == "-r" || tok == "--resume" ||
+				strings.HasPrefix(tok, "--resume=") {
 				return program
 			}
 		}
@@ -86,7 +87,7 @@ func resumeProgram(program string) string {
 		return program + " --restore-chat-history"
 	case ProgramGemini:
 		for _, tok := range tokens {
-			if tok == "--resume" || tok == "-r" {
+			if tok == "--resume" || tok == "-r" || strings.HasPrefix(tok, "--resume=") {
 				return program
 			}
 		}

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -40,6 +40,11 @@ func TestResumeProgram(t *testing.T) {
 		{"claude already -c", "claude -c", "claude -c"},
 		{"claude already --resume", "claude --resume foo", "claude --resume foo"},
 		{"claude already -r", "claude -r abc123", "claude -r abc123"},
+		// Long-option = syntax: claude accepts `--resume=<value>` so the
+		// rewrite must detect it and skip appending `--continue` (regression
+		// of #604 for claude — same flag-detection class as gemini).
+		{"claude already --resume=value", "claude --resume=abc123", "claude --resume=abc123"},
+		{"claude already --resume=latest", "claude --resume=latest", "claude --resume=latest"},
 
 		// Codex: insert "resume --last" after the codex token (subcommand
 		// position matters for codex; a tail append wouldn't parse).
@@ -128,6 +133,24 @@ func TestResumeProgram(t *testing.T) {
 			"gemini --resume 5",
 		},
 		{"gemini already -r", "gemini -r latest", "gemini -r latest"},
+		// Long-option = syntax: gemini accepts `--resume=<value>` and would
+		// concatenate duplicate values with commas ("5,latest") and exit 42
+		// if we appended a second flag (#604).
+		{
+			"gemini already --resume=numeric",
+			"gemini --resume=5",
+			"gemini --resume=5",
+		},
+		{
+			"gemini already --resume=latest",
+			"gemini --resume=latest",
+			"gemini --resume=latest",
+		},
+		{
+			"gemini already --resume=arbitrary",
+			"gemini --resume=anything",
+			"gemini --resume=anything",
+		},
 
 		// Unknown programs are passed through unchanged so unrelated CLIs
 		// aren't accidentally rewritten.
@@ -168,6 +191,8 @@ func TestResumeProgram_Idempotent(t *testing.T) {
 		"gemini",
 		"gemini --model x",
 		"gemini --resume 5",
+		"gemini --resume=5",
+		"claude --resume=abc123",
 	} {
 		once := resumeProgram(in)
 		twice := resumeProgram(once)


### PR DESCRIPTION
## Summary

`resumeProgram` (`session/tmux/resume.go`) tokenizes the configured program and skips appending a resume flag if one is already present. Detection used exact token matching (`tok == "--resume"`), so the long-option `=` form like `--resume=5` slipped through. For Gemini this produced a respawned command with two resume flags; Gemini concatenates the values with a comma (`"5,latest"`) and exits 42 with `Invalid session identifier`, breaking session restart completely.

This is a regression of #597 (afb2491), which extended resume-on-respawn to aider/gemini by copy-pasting the exact-token pattern from the earlier claude/codex implementation without accounting for `--resume=VALUE`.

Fix: apply the same `field == "--flag" || strings.HasPrefix(field, "--flag=")` pattern the daemon code already uses for `--daemon` ([daemon/daemon.go:384](https://github.com/sachiniyer/agent-factory/blob/master/daemon/daemon.go#L384)).

## Audit table

Every resume-detection check in `resumeProgram`, with each agent CLI verified against `--help` and a runtime `--flag=value` probe on this machine:

| Agent  | Check                       | Accepts `=VALUE`? | Action |
|--------|-----------------------------|-------------------|--------|
| claude | `--continue` / `-c`         | No — `error: unknown option '--continue=true'` (boolean) | None |
| claude | `--resume` / `-r`           | **Yes** — accepts `claude -p --resume=<id>` | **Fix** |
| codex  | `resume` (subcommand)       | n/a — subcommands have no `=value` form | None |
| codex  | `--last`                    | No — `unexpected value 'true' for '--last'` (and the code only checks for the `resume` subcommand, not `--last`) | None |
| aider  | `--restore-chat-history`    | No (boolean) | None |
| aider  | `--no-restore-chat-history` | No (boolean) | None |
| gemini | `--resume` / `-r`           | **Yes** — accepts `gemini --resume=5` (root cause of #604) | **Fix** |

So both gemini (the regressed agent) and claude (same flag class) get the `strings.HasPrefix(tok, "--resume=")` detection added. The other three branches stay as-is because no value form is reachable.

## Tests

Added to `session/tmux/resume_test.go`:

- `gemini --resume=5` (numeric) → unchanged
- `gemini --resume=latest` (string) → unchanged
- `gemini --resume=anything` (arbitrary) → unchanged
- `claude --resume=abc123` → unchanged (claude branch)
- `claude --resume=latest` → unchanged (claude branch)
- Idempotency check extended to `gemini --resume=5` and `claude --resume=abc123`

Without the fix, the new gemini cases produce `--resume=5 --resume latest` and the duplicate-flag bug reproduces.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go test -race ./session/tmux/...` — all resume tests pass, including the new `--resume=VALUE` cases and the extended idempotency check
- [x] `claude --help`, `gemini --help`, `codex --help`, `aider --help` consulted for each branch
- [x] Runtime probe of `--flag=value` against each CLI to confirm which boolean flags reject it and which value-taking flags accept it

Closes #604.

Co-Authored-By: Captain Claude <noreply@anthropic.com>