### PR TITLE
fix(ui/terminal): reset isScrolling in CloseForInstance so next selection sees fresh state (#619)

### DIFF
--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -257,6 +257,14 @@ func (t *TerminalPane) Close() {
 	t.content = ""
 	t.fallback = false
 	t.fallbackText = ""
+	// Match CloseForInstance: a wholesale teardown of "current" state should
+	// also drop scroll-mode state so the pane is not left in a stuck
+	// isScrolling=true state if it is ever reused (#619).
+	if t.isScrolling {
+		t.isScrolling = false
+		t.viewport.SetContent("")
+		t.viewport.GotoTop()
+	}
 }
 
 // CloseForInstance kills the cached terminal session for a specific instance.
@@ -276,6 +284,15 @@ func (t *TerminalPane) CloseForInstance(title string) {
 		t.content = ""
 		t.fallback = false
 		t.fallbackText = ""
+		// Drop scroll-mode state too; otherwise UpdateContent's isScrolling
+		// guard suppresses the next selection's content updates until the
+		// user presses ESC (issue #619, regression of #407). Mirrors
+		// PreviewPane's instance-change reset.
+		if t.isScrolling {
+			t.isScrolling = false
+			t.viewport.SetContent("")
+			t.viewport.GotoTop()
+		}
 	}
 }
 

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -426,6 +426,58 @@ func TestTerminalCloseForInstance(t *testing.T) {
 	tp.mu.Unlock()
 }
 
+// TestTerminalCloseForInstanceResetsScrollMode is a regression test for #619.
+// CloseForInstance must clear isScrolling when it clears the current-title
+// state; otherwise UpdateContent's isScrolling guard suppresses content
+// updates on the next selection, leaving the pane stuck on stale (empty)
+// content until the user presses ESC. Regression of #407.
+func TestTerminalCloseForInstanceResetsScrollMode(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	tp := NewTerminalPane()
+	tp.SetSize(80, 30)
+
+	// Instance whose terminal is being viewed in scroll mode.
+	closedInstance := makeStartedInstance(t, "closed")
+	defer func() { _ = closedInstance.Kill() }()
+
+	closedTs := newMockTmuxSession(t, "closed-scroll", mockCmdExec("history-content", true))
+	injectSession(tp, closedInstance.Title, closedTs, closedInstance.GetWorktreePath())
+
+	// Enter scroll mode on closedInstance — populates viewport, sets isScrolling=true.
+	require.NoError(t, tp.ScrollUp())
+	require.True(t, tp.IsScrolling(), "precondition: should be in scroll mode after ScrollUp")
+
+	// Close the instance whose terminal we are scrolling. With the bug,
+	// currentTitle/content are cleared but isScrolling stays true.
+	tp.CloseForInstance(closedInstance.Title)
+
+	tp.mu.Lock()
+	require.False(t, tp.isScrolling,
+		"CloseForInstance must reset isScrolling when clearing currentTitle (#619)")
+	require.Empty(t, tp.currentTitle, "currentTitle should be cleared")
+	tp.mu.Unlock()
+	require.False(t, tp.IsScrolling(), "IsScrolling() must report false after CloseForInstance")
+
+	// Selecting a new instance must now render its content, not be silently
+	// suppressed by the stale scroll-mode guard.
+	nextContent := "fresh-content"
+	nextInstance := makeStartedInstance(t, "next")
+	defer func() { _ = nextInstance.Kill() }()
+
+	nextTs := newMockTmuxSession(t, "next-scroll", mockCmdExec(nextContent, true))
+	injectSession(tp, nextInstance.Title, nextTs, nextInstance.GetWorktreePath())
+
+	require.NoError(t, tp.UpdateContent(nextInstance))
+
+	tp.mu.Lock()
+	require.False(t, tp.fallback, "should not be in fallback after UpdateContent on next instance")
+	require.Equal(t, nextContent, tp.content,
+		"UpdateContent must capture fresh content after CloseForInstance (would be empty if isScrolling guard still suppressed it)")
+	tp.mu.Unlock()
+}
+
 type failingPtyFactory struct{}
 
 func (f failingPtyFactory) Start(*exec.Cmd) (*os.File, error) {


### PR DESCRIPTION
## Summary
- `TerminalPane.CloseForInstance` cleared `currentTitle`/`content`/`fallback*` but left `isScrolling=true` when the closed instance was the one being viewed in scroll mode. `UpdateContent`'s scroll-mode guard (`terminal.go:106`) then short-circuited every subsequent capture, so selecting another instance showed stale (empty) content until the user pressed ESC. Regression of #407.
- Mirror `PreviewPane`'s instance-change reset (`preview.go:99-103`) inside the `t.currentTitle == title` branch: clear `isScrolling`, reset the viewport, `GotoTop`.
- Apply the same reset to the wholesale `Close()` teardown path for symmetry — same latent bug if `Close` were ever invoked outside shutdown.
- Add a regression test that enters scroll mode on instance A, calls `CloseForInstance(A)`, asserts `isScrolling == false`, then verifies `UpdateContent(B)` captures fresh content (the old guard would silently keep it empty).

## Audit
Catalogued every site that clears "current" `TerminalPane` state:

| Site | Clears isScrolling? | Notes |
|---|---|---|
| `CloseForInstance` (when `currentTitle == title`) | **was missing → fixed** | primary bug |
| `Close()` (wholesale teardown) | **was missing → fixed** | symmetry; latent bug if reused after Close |
| `UpdateContent` instance-change branch | ✓ already correct | `terminal.go:100-103` |
| `ResetToNormalMode` | ✓ explicit exit | `terminal.go:392-401` |

`PreviewPane` has no `Close`/`CloseForInstance`; it already drops scroll state on instance change inside `UpdateContent`, so nothing else needed.

## Test plan
- [x] `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race ./ui/...` — pass (incl. new `TestTerminalCloseForInstanceResetsScrollMode`)
- [ ] Manual: kill an instance while in scroll mode in the terminal tab, select another instance, confirm its content renders immediately (no ESC needed).

Closes #619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude <noreply@anthropic.com>