### PR TITLE
fix(daemon): skip corrupted per-repo instances.json at startup instead of refusing to start (#603)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -124,7 +124,24 @@ func refreshDaemonInstances(existing map[string]*session.Instance) (map[string]*
 
 		var data []session.InstanceData
 		if err := json.Unmarshal(raw, &data); err != nil {
-			return existing, fmt.Errorf("failed to parse instances for repo %s: %w", repoID, err)
+			// Skip corrupted per-repo JSON instead of failing the whole
+			// refresh (#603). At startup (existing==nil) a single corrupt
+			// file used to abort NewManager and orphan every AutoYes
+			// session across every repo. On the polling path we also
+			// re-hydrate this repo's prior in-memory instances so a
+			// transient/persistent corruption doesn't silently drop
+			// already-running sessions — matching the pre-fix semantics
+			// of returning `existing` on parse failure.
+			log.WarningLog.Printf("daemon skipping repo %s: corrupted instances.json: %v", repoID, err)
+			if existing != nil {
+				keyPrefix := repoID + "\x00"
+				for key, inst := range existing {
+					if strings.HasPrefix(key, keyPrefix) {
+						next[key] = inst
+					}
+				}
+			}
+			continue
 		}
 
 		for _, item := range data {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1,15 +1,21 @@
 package daemon
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
 )
 
 func TestMain(m *testing.M) {
@@ -313,6 +319,108 @@ func TestStopDaemon_EscalatesToSIGKILL(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatalf("fake daemon did not exit within 5s after StopDaemon")
+	}
+}
+
+// TestRefreshDaemonInstances_SkipsCorruptedRepoAtStartup is the regression
+// test for #603. Pre-fix, a single corrupted per-repo instances.json caused
+// refreshDaemonInstances(nil) to return (nil, err); NewManager propagated
+// that error so the daemon never started, orphaning every AutoYes session
+// across every repo. The fix logs a WARNING and continues, so valid repos
+// still load on startup.
+func TestRefreshDaemonInstances_SkipsCorruptedRepoAtStartup(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	// Capture warning output so we can assert the corrupted repo was named
+	// in the log line — silent skipping would re-introduce a different bug
+	// (invisible data drop).
+	var warnBuf bytes.Buffer
+	prevOut := log.WarningLog.Writer()
+	log.WarningLog.SetOutput(io.MultiWriter(prevOut, &warnBuf))
+	t.Cleanup(func() { log.WarningLog.SetOutput(prevOut) })
+
+	// Stub the session restore so we don't need a live tmux/PTY backend.
+	prevFromInstance := fromInstanceDataForRefresh
+	fromInstanceDataForRefresh = func(d session.InstanceData) (*session.Instance, error) {
+		return &session.Instance{}, nil
+	}
+	t.Cleanup(func() { fromInstanceDataForRefresh = prevFromInstance })
+
+	validRepoID := "valid-repo-a"
+	validData := []session.InstanceData{{Title: "valid-session"}}
+	validJSON, err := json.Marshal(validData)
+	if err != nil {
+		t.Fatalf("marshal valid: %v", err)
+	}
+	if err := config.SaveRepoInstances(validRepoID, validJSON); err != nil {
+		t.Fatalf("save valid repo: %v", err)
+	}
+
+	corruptedRepoID := "corrupted-repo-b"
+	if err := config.SaveRepoInstances(corruptedRepoID, json.RawMessage("{not valid json")); err != nil {
+		t.Fatalf("save corrupted repo: %v", err)
+	}
+
+	got, err := refreshDaemonInstances(nil)
+	if err != nil {
+		t.Fatalf("refreshDaemonInstances(nil) returned error on corrupted-repo input — daemon startup would fail and orphan every AutoYes session: %v", err)
+	}
+
+	validKey := daemonInstanceKey(validRepoID, "valid-session")
+	if _, ok := got[validKey]; !ok {
+		keys := make([]string, 0, len(got))
+		for k := range got {
+			keys = append(keys, k)
+		}
+		t.Fatalf("expected valid repo's session %q to load; got keys: %v", validKey, keys)
+	}
+
+	corruptedPrefix := corruptedRepoID + "\x00"
+	for k := range got {
+		if strings.HasPrefix(k, corruptedPrefix) {
+			t.Fatalf("corrupted repo %q must not contribute entries on startup; key=%q", corruptedRepoID, k)
+		}
+	}
+
+	if !strings.Contains(warnBuf.String(), corruptedRepoID) {
+		t.Fatalf("expected warning log to name corrupted repo %q so users can find the bad file; got: %q", corruptedRepoID, warnBuf.String())
+	}
+}
+
+// TestRefreshDaemonInstances_PreservesExistingForCorruptedRepoOnPoll covers
+// the polling path (existing != nil). The pre-fix code returned the entire
+// `existing` map on any unmarshal error, preserving prior in-memory state.
+// The fix replaces that with a per-repo skip — to keep the same "don't drop
+// running sessions on a transient corrupt write" guarantee, the skip path
+// re-hydrates this repo's prior keys from `existing` into the returned map.
+func TestRefreshDaemonInstances_PreservesExistingForCorruptedRepoOnPoll(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	prevOut := log.WarningLog.Writer()
+	log.WarningLog.SetOutput(io.Discard)
+	t.Cleanup(func() { log.WarningLog.SetOutput(prevOut) })
+
+	prevFromInstance := fromInstanceDataForRefresh
+	fromInstanceDataForRefresh = func(d session.InstanceData) (*session.Instance, error) {
+		return &session.Instance{}, nil
+	}
+	t.Cleanup(func() { fromInstanceDataForRefresh = prevFromInstance })
+
+	repoID := "corrupted-repo-c"
+	if err := config.SaveRepoInstances(repoID, json.RawMessage("{not valid json")); err != nil {
+		t.Fatalf("save corrupted repo: %v", err)
+	}
+
+	priorKey := daemonInstanceKey(repoID, "still-running")
+	prior := &session.Instance{}
+	existing := map[string]*session.Instance{priorKey: prior}
+
+	got, err := refreshDaemonInstances(existing)
+	if err != nil {
+		t.Fatalf("refreshDaemonInstances on poll path errored on corrupted-repo input: %v", err)
+	}
+	if got[priorKey] != prior {
+		t.Fatalf("polling refresh dropped prior in-memory instance for corrupted repo %q; running AutoYes session would be silently abandoned", repoID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #603. A single unparseable per-repo `instances.json` used to abort
`NewManager`'s `refreshDaemonInstances(nil)` call at startup, so the daemon
never started and *every* AutoYes session across *every* repo was orphaned —
including the valid ones. The polling path already tolerated the same
corruption (it returned prior state), so only startup was fatal.

- `refreshDaemonInstances` now logs a `WARNING` naming the corrupted repo +
  parse error and continues to the next entry, matching the skip-with-warn
  pattern in `config/state.go:LoadAllRepoInstances`.
- On the polling path (`existing != nil`), the prior in-memory instances for
  the corrupted repo are re-hydrated into the returned map so a transient
  or persistent bad write can't silently drop a running session — preserving
  the original "return existing on parse failure" guarantee.

## Audit of adjacent daemon I/O sites

Per repo `instances.json` consumers in `daemon/`:
- `daemon/daemon.go:113-127` — `refreshDaemonInstances` — **fail-fast, fixed here**.
- `daemon/control.go:896-900` — `findInstanceDataByTitle` silent `continue` on
  bad JSON. Not startup-fatal; only used by single-title lookups. Out of
  scope for this PR (could be made loud in a follow-up if useful).
- `daemon/control.go:806-810, 840-844, 871-875` — `UpdateRepoInstances` /
  `appendInstanceData` / `loadRepoInstanceData` operate on **one specific
  repo by RPC request**, not multi-repo iteration. Failing the caller is
  correct.
- `config/state.go:222-231` — `LoadAllRepoInstances` directory scan already
  skips per-repo read errors with a warning, so other repos' I/O errors
  never reach `refreshDaemonInstances`.

No silent data drop introduced: every skipped repo emits a `WARNING` line
with the repo ID and the underlying error.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go test -race -count=1 ./daemon/` — new regression tests pass; the
      only failure (`TestSigtermFallback_DeadPID`) reproduces on `master`
      and is caused by two real `~/.local/bin/af --daemon` processes on the
      dev box being picked up by the test's `pgrep`.
- [x] `go test -race -count=1 ./integration/` clean after pruning leaked
      test daemons from earlier local runs.
- [x] Regression test `TestRefreshDaemonInstances_SkipsCorruptedRepoAtStartup`
      writes a valid + a corrupted `instances.json`, calls
      `refreshDaemonInstances(nil)`, and asserts (a) no error, (b) the
      valid repo's session is in the returned map, (c) the corrupted repo
      contributes nothing, (d) a warning log line names the corrupted repo.
- [x] Companion test `TestRefreshDaemonInstances_PreservesExistingForCorruptedRepoOnPoll`
      pins the polling-path no-regression: when `existing != nil` and the
      repo's JSON is corrupt, prior in-memory instances for that repo are
      kept in the returned map.

— Captain Claude