### PR TITLE
fix(daemon): reject case-variant session names instead of failing at git worktree layer (#605)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -655,26 +655,21 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 	if title == "" {
 		return fmt.Errorf("session title is required")
 	}
-	key := daemonInstanceKey(repoID, title)
-	if _, ok := m.reservedTitles[key]; ok {
-		return fmt.Errorf("session with title %q is already reserved", title)
-	}
-	if _, ok := m.instances[key]; ok {
-		return fmt.Errorf("session with title %q already exists", title)
-	}
-	for _, data := range diskData {
-		if data.Title != title {
-			continue
+	// Title comparisons are case-insensitive: sanitizeBranchName lowercases
+	// titles when deriving git branch names, so two case-variant titles
+	// (e.g. "MyApp" and "myapp") would map to the same branch and the
+	// second worktree create would fail with a cryptic git error. Reject
+	// the conflict here, before any worktree or tmux setup runs. (#605)
+	if existing, kind := m.findTitleConflictLocked(repoID, title, diskData); existing != "" {
+		switch {
+		case existing == title:
+			if kind == titleConflictReserved {
+				return fmt.Errorf("session with title %q is already reserved", title)
+			}
+			return fmt.Errorf("session with title %q already exists", title)
+		default:
+			return fmt.Errorf("session titled %q conflicts with existing session %q (case-insensitive comparison; sanitize collides at git layer)", title, existing)
 		}
-		// Loading entries are transient TUI state with an empty worktree
-		// path and cannot be restored. Older TUI binaries (#551) could
-		// persist them to disk on quit, where they would block title
-		// reuse forever. Treat them as ghosts that the next save will
-		// reap rather than as live reservations.
-		if data.Status == session.Loading {
-			continue
-		}
-		return fmt.Errorf("session with title %q already exists", title)
 	}
 	if remote {
 		candidate := session.Slugify(title)
@@ -695,6 +690,53 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 		return fmt.Errorf("tmux session for title %q already exists", title)
 	}
 	return nil
+}
+
+type titleConflictKind int
+
+const (
+	titleConflictNone titleConflictKind = iota
+	titleConflictReserved
+	titleConflictLive
+	titleConflictDisk
+)
+
+// findTitleConflictLocked returns the existing title that conflicts with the
+// given candidate under case-insensitive comparison, along with the source of
+// the conflict. An empty result means the title is available. Comparisons are
+// case-insensitive so that titles which would collide at the git branch layer
+// (sanitizeBranchName lowercases) are rejected before worktree setup. (#605)
+func (m *Manager) findTitleConflictLocked(repoID, title string, diskData []session.InstanceData) (string, titleConflictKind) {
+	for key := range m.reservedTitles {
+		rid, existing := splitDaemonInstanceKey(key)
+		if rid == repoID && strings.EqualFold(existing, title) {
+			return existing, titleConflictReserved
+		}
+	}
+	for key, inst := range m.instances {
+		rid, _ := splitDaemonInstanceKey(key)
+		if rid != repoID || inst == nil {
+			continue
+		}
+		if strings.EqualFold(inst.Title, title) {
+			return inst.Title, titleConflictLive
+		}
+	}
+	for _, data := range diskData {
+		if !strings.EqualFold(data.Title, title) {
+			continue
+		}
+		// Loading entries are transient TUI state with an empty worktree
+		// path and cannot be restored. Older TUI binaries (#551) could
+		// persist them to disk on quit, where they would block title
+		// reuse forever. Treat them as ghosts that the next save will
+		// reap rather than as live reservations.
+		if data.Status == session.Loading {
+			continue
+		}
+		return data.Title, titleConflictDisk
+	}
+	return "", titleConflictNone
 }
 
 func (m *Manager) KillSession(req KillSessionRequest) error {

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -237,6 +237,90 @@ func TestManagerCreateSessionIgnoresLoadingGhost(t *testing.T) {
 	}
 }
 
+// TestManagerCreateSessionRejectsCaseVariantTitle is a regression test for
+// sachiniyer/agent-factory#605. sanitizeBranchName lowercases titles when
+// deriving git branch names, so two case-variant titles ("MyApp" and "myapp")
+// would map to the same branch. The daemon used to validate titles
+// case-sensitively, accept both, and let the second worktree create fail with
+// a cryptic git error. The daemon now rejects the case-variant up front with
+// a clear conflict error before any worktree or tmux setup runs.
+func TestManagerCreateSessionRejectsCaseVariantTitle(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "MyApp",
+		RepoPath: repoPath,
+		Program:  "claude",
+		AutoYes:  true,
+	}); err != nil {
+		t.Fatalf("first CreateSession: %v", err)
+	}
+
+	_, err = manager.CreateSession(CreateSessionRequest{
+		Title:    "myapp",
+		RepoPath: repoPath,
+		Program:  "claude",
+		AutoYes:  true,
+	})
+	if err == nil {
+		t.Fatalf("expected case-variant title to be rejected")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "myapp") || !strings.Contains(msg, "MyApp") {
+		t.Fatalf("expected error to name both titles, got: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(msg), "case-insensitive") {
+		t.Fatalf("expected error to mention case-insensitive conflict, got: %v", err)
+	}
+}
+
+// TestManagerCreateSessionRejectsCaseVariantTitleFromDisk covers the disk-side
+// branch of the #605 fix: a case-variant title persisted to disk from a prior
+// daemon run must still be rejected when the manager loads fresh and a new
+// CreateSession arrives.
+func TestManagerCreateSessionRejectsCaseVariantTitleFromDisk(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	seeded, err := json.Marshal([]session.InstanceData{
+		{Title: "MyApp", Path: repoPath, Status: session.Running},
+	})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := config.LoadState().SaveInstances(repo.ID, seeded); err != nil {
+		t.Fatalf("seed disk: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	_, err = manager.CreateSession(CreateSessionRequest{
+		Title:    "myapp",
+		RepoPath: repoPath,
+		Program:  "claude",
+		AutoYes:  true,
+	})
+	if err == nil {
+		t.Fatalf("expected case-variant title to be rejected by disk check")
+	}
+	if !strings.Contains(err.Error(), "MyApp") {
+		t.Fatalf("expected error to name the on-disk title, got: %v", err)
+	}
+}
+
 func TestControlServerCreateAndKillSession(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	installInstantBackend(t)


### PR DESCRIPTION
## Summary

Fixes #605. Two session titles that differ only in case (`"MyApp"` and `"myapp"`) used to be accepted as distinct by the daemon's title validation, then collide at the git worktree layer because `sanitizeBranchName` lowercases titles when deriving branch names. The second session's `Setup()` would fail with a cryptic `fatal: 'test/myapp' is already used by worktree …` after the daemon had already reserved the title and allocated state.

- Make `validateTitleAvailableLocked` case-insensitive across all three reservation sources (in-flight reservations, live instances, on-disk entries) via a new `findTitleConflictLocked` helper.
- Return a clear error naming both titles when a case-only collision is detected: `session titled %q conflicts with existing session %q (case-insensitive comparison; sanitize collides at git layer)`.
- Preserve the existing error messages and `Loading`-ghost handling (#551) for exact-match collisions.
- Remote sessions were already covered by the existing `Slugify`-based slug check; the local path now matches that behavior.

The rejection happens inside `reserveCreate`, before any worktree or tmux setup runs, so no half-created state is produced.

## Audit

Title-comparison sites touched / reviewed for #605:

- `daemon/control.go` `validateTitleAvailableLocked` — primary bug, now case-insensitive across all three sources.
- `daemon/control.go` `nextAvailableTitleLocked` — calls the same validator, inherits the fix.
- `daemon/control.go` remote slug check at line ~688 — `Slugify` already lowercases, no change needed.
- `daemon/control.go` `findSession`, `findInstanceDataByTitle`, `appendInstanceData` — exact-match lookups for already-created sessions. Safe to leave case-sensitive: the new gate guarantees at most one case-variant exists.

## Test plan

- [x] `go test ./daemon/ -run TestManagerCreateSessionRejectsCaseVariantTitle -count=1` — new in-memory case-variant rejection test passes.
- [x] `go test ./daemon/ -run TestManagerCreateSessionRejectsCaseVariantTitleFromDisk -count=1` — new disk-side case-variant rejection test passes.
- [x] `go test -race ./daemon/ -run TestManagerCreateSession -count=1` — race-clean.
- [x] `go build ./...`
- [x] `gofmt -l .`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] Pre-existing dirty-environment failures unrelated to this change (`TestSigtermFallback_DeadPID` — host has stale `af --daemon` PIDs; `TestE2ERemoteHooksMultipleSessions` / `TestDaemonLifecycleRecoversFromStaleSocketAndDeadDaemon` flake when run in the full suite, pass in isolation).

Co-Authored-By: Captain Claude <noreply@anthropic.com>