### PR TITLE
fix(git/hooks): use process group to kill backgrounded hook children on cancellation (#610)

### DIFF
--- a/session/git/hooks.go
+++ b/session/git/hooks.go
@@ -1,8 +1,10 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"os/exec"
+	"syscall"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
@@ -11,7 +13,10 @@ import (
 // RunPostWorktreeHooksAsync runs the per-repo post_worktree_commands in the
 // background. Each command is executed sequentially via "sh -c" with the
 // working directory set to worktreePath. The provided context can be used to
-// cancel in-flight hooks (e.g. when the worktree is being cleaned up).
+// cancel in-flight hooks (e.g. when the worktree is being cleaned up). Each
+// command runs as the leader of its own process group so that, on
+// cancellation, the whole tree — including grandchildren the script
+// backgrounded with `&` or `disown` — is killed together.
 // Errors are logged but do not propagate.
 func RunPostWorktreeHooksAsync(ctx context.Context, repoPath, worktreePath string) {
 	repoID := config.RepoIDFromRoot(repoPath)
@@ -34,15 +39,46 @@ func RunPostWorktreeHooksAsync(ctx context.Context, repoPath, worktreePath strin
 			default:
 			}
 			log.InfoLog.Printf("running post-worktree hook in %s: %s", worktreePath, cmdStr)
-			cmd := exec.CommandContext(ctx, "sh", "-c", cmdStr)
+
+			var output bytes.Buffer
+			cmd := exec.Command("sh", "-c", cmdStr)
 			cmd.Dir = worktreePath
-			output, err := cmd.CombinedOutput()
+			cmd.Stdout = &output
+			cmd.Stderr = &output
+			// Place sh in its own process group so we can signal the whole
+			// tree on cancellation. exec.CommandContext only kills the
+			// immediate shell, leaving grandchildren the script backgrounded
+			// with `&` or `disown` alive — they get reparented to init and
+			// outlive the session (see #610).
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+			if err := cmd.Start(); err != nil {
+				log.ErrorLog.Printf("post-worktree hook %q failed: %v", cmdStr, err)
+				continue
+			}
+
+			// On cancellation, SIGKILL the whole process group (negative pid
+			// targets the group led by cmd.Process.Pid). doneCh ensures the
+			// watchdog exits when the command finishes normally so it does
+			// not leak across loop iterations.
+			doneCh := make(chan struct{})
+			go func(pgid int) {
+				select {
+				case <-ctx.Done():
+					_ = syscall.Kill(-pgid, syscall.SIGKILL)
+				case <-doneCh:
+				}
+			}(cmd.Process.Pid)
+
+			waitErr := cmd.Wait()
+			close(doneCh)
+
 			if ctx.Err() != nil {
 				log.InfoLog.Printf("post-worktree hooks cancelled for %s", worktreePath)
 				return
 			}
-			if err != nil {
-				log.ErrorLog.Printf("post-worktree hook %q failed: %v\n%s", cmdStr, err, string(output))
+			if waitErr != nil {
+				log.ErrorLog.Printf("post-worktree hook %q failed: %v\n%s", cmdStr, waitErr, output.String())
 			} else {
 				log.InfoLog.Printf("post-worktree hook %q completed successfully", cmdStr)
 			}

--- a/session/git/hooks_test.go
+++ b/session/git/hooks_test.go
@@ -1,0 +1,133 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHookCancellation_ChildProcessOrphaned is the regression test for #610.
+// Before the process-group fix, cancelling the context only SIGKILL'd the
+// `sh -c` shell, leaving any backgrounded grandchildren (e.g. `sleep 30 &`)
+// reparented to init and alive indefinitely. With the fix, sh runs as the
+// leader of its own process group and the watchdog signals the whole group,
+// so the grandchild dies along with its shell.
+func TestHookCancellation_ChildProcessOrphaned(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	repoPath := freshRepoConfig(t, []string{
+		fmt.Sprintf(`sleep 30 & echo $! > %q; wait`, pidFile),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	RunPostWorktreeHooksAsync(ctx, repoPath, t.TempDir())
+
+	pid := waitForPidFile(t, pidFile, 5*time.Second)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	cancel()
+
+	if !waitForProcessExit(pid, 3*time.Second) {
+		t.Fatalf("grandchild pid %d survived ctx cancellation — process-group kill did not reach it", pid)
+	}
+}
+
+// TestHookCancellation_BackgroundedGrandchildKilledByGroupSignal codifies the
+// process-group contract beyond the single-child case: a hook script that
+// backgrounds multiple processes should have all of them reaped on
+// cancellation, not just the shell or the first backgrounded child.
+func TestHookCancellation_BackgroundedGrandchildKilledByGroupSignal(t *testing.T) {
+	pidDir := t.TempDir()
+	pidFiles := []string{
+		filepath.Join(pidDir, "pid1"),
+		filepath.Join(pidDir, "pid2"),
+		filepath.Join(pidDir, "pid3"),
+	}
+
+	script := fmt.Sprintf(
+		"sleep 30 & echo $! > %q\nsleep 30 & echo $! > %q\nsleep 30 & echo $! > %q\nwait",
+		pidFiles[0], pidFiles[1], pidFiles[2],
+	)
+	repoPath := freshRepoConfig(t, []string{script})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	RunPostWorktreeHooksAsync(ctx, repoPath, t.TempDir())
+
+	pids := make([]int, len(pidFiles))
+	for i, f := range pidFiles {
+		pids[i] = waitForPidFile(t, f, 5*time.Second)
+	}
+	t.Cleanup(func() {
+		for _, p := range pids {
+			_ = syscall.Kill(p, syscall.SIGKILL)
+		}
+	})
+
+	cancel()
+
+	for _, p := range pids {
+		if !waitForProcessExit(p, 3*time.Second) {
+			t.Fatalf("backgrounded grandchild pid %d survived ctx cancellation — process group not killed", p)
+		}
+	}
+}
+
+// freshRepoConfig isolates the per-test config dir via AGENT_FACTORY_HOME,
+// writes a repo config with the given post-worktree commands, and returns a
+// repo path the test should hand to RunPostWorktreeHooksAsync. The repo path
+// itself never needs to exist on disk — hooks.go only passes it through
+// RepoIDFromRoot to locate the per-repo config file.
+func freshRepoConfig(t *testing.T, postCmds []string) string {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	repoID := config.RepoIDFromRoot(repoPath)
+	require.NoError(t, config.SaveRepoConfig(repoID, &config.RepoConfig{
+		PostWorktreeCommands: postCmds,
+	}))
+	return repoPath
+}
+
+// waitForPidFile polls until pidFile contains a parseable positive pid and
+// returns it, or fails the test on timeout.
+func waitForPidFile(t *testing.T, pidFile string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidFile)
+		if err == nil {
+			if pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data))); parseErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pid file %s did not appear with a valid pid within %s", pidFile, timeout)
+	return 0
+}
+
+// waitForProcessExit polls until syscall.Kill(pid, 0) reports ESRCH. Signal 0
+// is a permission/existence probe that delivers nothing; ESRCH means the
+// process has been reaped (init reaps the orphaned grandchild after SIGKILL).
+func waitForProcessExit(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Post-worktree hooks that backgrounded a grandchild — `sleep 30 &`, a long `disown`'d process, etc. — survived ctx cancellation indefinitely. `exec.CommandContext(ctx, "sh", "-c", cmdStr)` only sends SIGKILL to the immediate `sh` process; grandchildren get reparented to init and outlive the worktree they were spawned for. d2898f0 (#598 follow-up) wired the context in, but inherited this limitation from `exec.CommandContext`.

## Fix

Switch to `exec.Command` + `Setpgid: true` so `sh` runs as the leader of its own process group. A watchdog goroutine watches `ctx.Done()` and calls `syscall.Kill(-pgid, SIGKILL)` — the negative pid signals every member of the group, so backgrounded grandchildren go with the shell.

- `doneCh` closed after `cmd.Wait()` returns ensures the watchdog exits and does not leak across loop iterations on the normal completion path.
- Output collection moves from `CombinedOutput()` to a `bytes.Buffer` on `cmd.Stdout`/`cmd.Stderr` since we manage Start/Wait ourselves.
- All existing log lines (`running`, `cancelled`, `failed`, `completed successfully`) preserved verbatim.
- The top-of-loop `select` on `ctx.Done()` is preserved so the loop early-exits before launching the next command.

Unix-only — no platform build tags needed (`syscall.SysProcAttr{Setpgid:true}` compiles on every unix platform Go supports, and the repo has no windows build tags anywhere).

## Audit

Grep confirmed `session/git/hooks.go` is the only `exec.CommandContext` call-site that shell-forks. The other two call-sites (`integration/cli_daemon_test.go`, `app/cli_daemon_integration_test.go`) invoke `go build` and the `af` binary directly without `sh -c`, so they have no shell-grandchild problem. **No other call-sites need patching.**

## Tests

`session/git/hooks_test.go` (new) exercises the fix end-to-end:

1. **`TestHookCancellation_ChildProcessOrphaned`** — the regression test for #610. Hook backgrounds `sleep 30 &` and records its pid; test cancels ctx and polls `syscall.Kill(pid, 0)` for ESRCH.
2. **`TestHookCancellation_BackgroundedGrandchildKilledByGroupSignal`** — multi-child variant that codifies the process-group contract: a script that backgrounds three sleeps has all three reaped, not just one.

Both tests **fail against the prior code** (verified locally — grandchild pid survived) and **pass with the fix**. `t.Cleanup` SIGKILLs any escaped pids so test failures don't leave zombies.

## Test plan

- [x] `gofmt -l .` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go build ./...` — ok
- [x] `go test -race ./session/git/` — ok (both new tests)
- [x] Verified tests fail against unmodified `hooks.go` (regression coverage proven)

Closes #610

Co-Authored-By: Captain Claude <noreply@anthropic.com>