### PR TITLE
fix(git): prune worktree metadata before deleting branch in Cleanup (#611)

### DIFF
--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -99,6 +99,13 @@ func (g *GitWorktree) setupNewWorktree() error {
 	// Clean up any existing worktree first
 	_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath) // Ignore error if worktree doesn't exist
 
+	// Prune stale worktree metadata BEFORE deleting the branch. If `worktree
+	// remove -f` above failed (corrupted .git pointer, etc.), git still tracks
+	// the worktree internally and `branch -D` will fail with "branch is
+	// checked out", leaving the orphaned branch behind and blocking
+	// `worktree add -b` below.
+	_, _ = g.runGitCommand(g.repoPath, "worktree", "prune")
+
 	// Clean up any existing branch using git CLI (much faster than go-git PlainOpen)
 	_, _ = g.runGitCommand(g.repoPath, "branch", "-D", g.branchName) // Ignore error if branch doesn't exist
 
@@ -164,6 +171,17 @@ func (g *GitWorktree) Cleanup() error {
 		errs = append(errs, fmt.Errorf("failed to check worktree path: %w", err))
 	}
 
+	// Prune stale worktree metadata BEFORE deleting the branch. When the
+	// `git worktree remove -f` above fails (e.g. the worktree's `.git`
+	// pointer file was removed externally), git still tracks the worktree
+	// internally and `git branch -D` will fail with "branch is checked
+	// out", leaving an orphaned branch behind. Mirrors the ordering in
+	// CleanupWorktreesForRepo (#330). Best-effort: a prune failure here
+	// should not block the branch-delete attempt.
+	if err := g.Prune(); err != nil {
+		errs = append(errs, err)
+	}
+
 	// Only delete the branch if this session actually created it. When we
 	// reused a pre-existing branch via setupFromExistingBranch(), the branch
 	// may contain unrelated user work and must be preserved.
@@ -176,7 +194,8 @@ func (g *GitWorktree) Cleanup() error {
 		}
 	}
 
-	// Prune the worktree to clean up any remaining references
+	// Final prune to clean up any remaining references. Usually a no-op
+	// after the prune above, but mirrors CleanupWorktreesForRepo.
 	if err := g.Prune(); err != nil {
 		errs = append(errs, err)
 	}

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -254,6 +254,65 @@ func TestCleanup_DeletesBranchWeCreated(t *testing.T) {
 		"branch created by the session should be deleted by Cleanup")
 }
 
+// TestCleanup_PrunesBeforeBranchDelete is a regression test for #611. When
+// `git worktree remove -f` fails (e.g. the worktree's `.git` pointer file
+// has been removed externally), git retains internal worktree metadata.
+// Without an intervening `git worktree prune`, `git branch -D` reports the
+// branch is "in use" and the orphaned branch is left behind.
+// CleanupWorktreesForRepo already prunes before branch deletion (#330);
+// this verifies GitWorktree.Cleanup() follows the same order.
+func TestCleanup_PrunesBeforeBranchDelete(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+
+	// Initial commit so HEAD is valid (required for `worktree add`).
+	cmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "initial")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, branchName, err := NewGitWorktree(repoRoot, "corrupted")
+	require.NoError(t, err)
+
+	// Setup() creates a fresh branch and worktree owned by this session.
+	require.NoError(t, gw.Setup())
+	require.True(t, gw.BranchCreatedByUs(),
+		"BranchCreatedByUs should be true when Setup created a new branch")
+
+	// Corrupt the worktree by removing its `.git` pointer file. This makes
+	// `git worktree remove -f` fail validation; without the prune-before-delete
+	// fix, git still tracks the worktree internally and blocks `branch -D`.
+	require.NoError(t, os.Remove(filepath.Join(gw.GetWorktreePath(), ".git")))
+
+	// Cleanup may return errors from the failed `worktree remove`, but it
+	// must still delete the branch — that's the user-visible regression.
+	_ = gw.Cleanup()
+
+	// The branch should be gone — this is what regresses without the prune
+	// before `git branch -D`.
+	branchCmd := exec.Command("git", "-C", repoRoot, "branch", "--list", branchName)
+	out, err = branchCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Empty(t, strings.TrimSpace(string(out)),
+		"session-owned branch should be deleted even when `git worktree remove` fails on a corrupted worktree")
+
+	// Only the main worktree should remain — no stale linked-worktree metadata.
+	listCmd := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain")
+	out, err = listCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Equal(t, 1, strings.Count(string(out), "worktree "),
+		"only the main worktree should remain, got:\n%s", string(out))
+}
+
 func TestNewGitWorktreeFromStorage_EmptyWorktreePath(t *testing.T) {
 	_, err := NewGitWorktreeFromStorage("/some/repo", "", "session", "branch", "abc123", false, true)
 	require.Error(t, err)


### PR DESCRIPTION
## Summary

- `GitWorktree.Cleanup()` ran `git branch -D` BEFORE `git worktree prune`. When `git worktree remove -f` fails on a corrupted worktree (e.g. its `.git` pointer was removed externally), git keeps stale internal metadata and the subsequent `branch -D` fails with "branch is checked out", leaving an orphaned branch behind on every ghost-session cleanup.
- `CleanupWorktreesForRepo` already prunes before deleting the branch (fixed in #330). `Cleanup()` simply never got the same protection — it kept the original ordering from 453ad89b. Mirror the prune-before-delete ordering here, and apply the same fix to the analogous reset path in `setupNewWorktree()` (which also did `worktree remove -f` → `branch -D` with no intervening prune). The trailing `Prune()` in `Cleanup()` is kept as a defensive no-op for parity.
- Adds `TestCleanup_PrunesBeforeBranchDelete`, a regression test that creates a session worktree, deletes its `.git` pointer file, calls `Cleanup()`, and asserts the branch is removed and no stale linked-worktree metadata remains. Verified failing without the fix (`assert: should be empty, but was test/corrupted`) and passing with it.

## Audit of `git branch -D` call sites in `session/git/`

| File:line | Function | Prune-before-delete? |
|---|---|---|
| `worktree_ops.go:103` | `setupNewWorktree` (pre-create cleanup) | **fixed in this PR** |
| `worktree_ops.go:171` | `Cleanup` | **fixed in this PR** (#611) |
| `worktree_ops.go:309` | `CleanupWorktreesForRepo` | already correct (#330) |

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go test ./session/git/...` passes (including new regression test)
- [x] `go test -race ./session/git/...` passes
- [x] Verified the new test fails on un-patched code (orphaned `test/corrupted` branch remains)
- [x] `go test ./...` green (integration daemon-socket flakes resolved on re-run, unrelated to this change)

Fixes #611.

Signed off by Captain Claude.