### PR TITLE
fix(config): tighten flagBoundaryRegex so " -v2/" inside paths isn't treated as a flag (#631)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,11 +20,14 @@ const (
 
 var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|->|^[^/=\s]+\s*=)\s*(.+)`)
 
-// flagBoundaryRegex matches the first " -X" / " --X" sequence in a program
-// string, where X is an ASCII letter. The trailing letter requirement is
-// what distinguishes a real flag boundary from a literal " - " (space dash
-// space) that appears inside a directory name (issue #606).
-var flagBoundaryRegex = regexp.MustCompile(` -{1,2}[a-zA-Z]`)
+// flagBoundaryRegex matches the first " -X" / " --X" flag token in a
+// program string, where X is an ASCII letter and the token runs to the
+// next space or end-of-string without containing a path separator. The
+// trailing-letter requirement avoids matching literal " - " (space dash
+// space) inside a directory name (issue #606); the "no '/' before the
+// terminator" requirement avoids matching " -v2/" or " -Main/" inside a
+// directory name (issue #631).
+var flagBoundaryRegex = regexp.MustCompile(` -{1,2}[a-zA-Z][^/ ]*( |$)`)
 
 // GetConfigDir returns the path to the application's configuration directory.
 // If AGENT_FACTORY_HOME is set, it is used as the config directory.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -434,6 +434,36 @@ func TestShellQuoteProgram(t *testing.T) {
 			want: "'/home/user/a - b - c/aider' --model x",
 		},
 		{
+			// Regression for #631: " -v2/" inside a directory name must not
+			// be treated as a flag boundary — the dash-letter sequence is
+			// followed by "/" before the next space, so it's part of a path
+			// segment, not a flag.
+			name: "dir name contains space-dash-letter-digits-slash",
+			in:   "/tmp/My Projects -v2/claude",
+			want: "'/tmp/My Projects -v2/claude'",
+		},
+		{
+			// Regression for #631: same shape but with a real trailing flag.
+			// Only the trailing " --bar" should be treated as the boundary.
+			name: "dir name contains space-dash-letters-slash, with long flag",
+			in:   "/tmp/Apps -Main/claude --bar",
+			want: "'/tmp/Apps -Main/claude' --bar",
+		},
+		{
+			// Regression for #631: " -v/" inside a directory name (no
+			// trailing chars between letter and "/") must not be a boundary.
+			name: "dir name ends with space-dash-letter-slash",
+			in:   "/tmp/foo -v/claude",
+			want: "'/tmp/foo -v/claude'",
+		},
+		{
+			// Real short flag (followed by space) must still be detected
+			// even when long flags also follow.
+			name: "short flag followed by long flag",
+			in:   "/path/agent -v --verbose",
+			want: "/path/agent -v --verbose",
+		},
+		{
 			name: "empty string",
 			in:   "",
 			want: "",


### PR DESCRIPTION
Closes #631.

## Summary
- Regression of #620's fix for #606: the boundary regex `` ` -{1,2}[a-zA-Z]` `` matches dash-letter sequences inside directory names (e.g. `/tmp/My Projects -v2/claude`), splitting the path at ` -v` and producing a truncated executable path that `sh -c` can't find.
- Tighten the regex to `` ` -{1,2}[a-zA-Z][^/ ]*( |$)` ``: the dash-letter token must run to the next space or end-of-string without containing `/`. Real flags (`-v`, `--foo`, `--model x`) still match; `" -v2/"`, `" -Main/"`, `" -v/"` inside paths do not.
- Update the doc comment on `flagBoundaryRegex` to spell out both #606 and #631 invariants.

## Cases verified

| Input | Before | After |
| --- | --- | --- |
| `/tmp/My Projects -v2/claude` | split at ` -v` → `'/tmp/My Projects' -v2/claude` ❌ | no boundary → `'/tmp/My Projects -v2/claude'` ✅ |
| `/tmp/Apps -Main/claude --bar` | split at ` -M` ❌ | split at ` --bar` ✅ |
| `/tmp/foo -v/claude` | split at ` -v` ❌ | no boundary ✅ |
| `/home/user/my - project/claude` (#606) | no boundary ✅ | no boundary ✅ |
| `/path/agent -v --verbose` | split at ` -v` ✅ | split at ` -v` ✅ |
| `/opt/My Tools/claude -v --dangerously-skip-permissions` | split at ` -v` ✅ | split at ` -v` ✅ |
| `claude --dangerously-skip-permissions` | split at ` --d` ✅ | split at ` --d` ✅ |

All existing #569/#591/#606/#620 cases still pass.

## Audit
`config/` has only one regex/string operation that splits or matches against program strings — `flagBoundaryRegex`. Other regex/string uses in `config/` deal with shell-alias parsing (`aliasOutputRegex`), repo IDs, tilde expansion, and shell-name detection. None of them touch the path/flag boundary.

## Test plan
- [x] `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint run --timeout=3m --fast ./config/...` — clean
- [x] `go test ./config/...` — pass (16 cases incl. 4 new #631 regressions)
- [x] `go test -race ./config/...` — pass
- [x] `go test ./...` — all packages pass except one pre-existing environmental flake in `daemon/TestSigtermFallback_DeadPID` (host has two long-running `af --daemon` processes from prior sessions; unrelated to this change)

Co-Authored-By: Captain Claude <noreply@anthropic.com>