### PR TITLE
fix(session/tmux): position-aware codex resume check + detect -r=VALUE for gemini (#632, #633)

### DIFF
--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -58,20 +58,22 @@ func resumeProgram(program string) string {
 	case ProgramClaude:
 		for _, tok := range tokens {
 			if tok == "-c" || tok == "--continue" || tok == "-r" || tok == "--resume" ||
-				strings.HasPrefix(tok, "--resume=") {
+				strings.HasPrefix(tok, "--resume=") || strings.HasPrefix(tok, "-r=") {
 				return program
 			}
 		}
 		return program + " --continue"
 	case ProgramCodex:
-		for _, tok := range tokens {
-			if tok == "resume" {
-				return program
-			}
-		}
+		// "resume" is a subcommand, not a flag, and codex only accepts it
+		// immediately after the codex token (or after "exec"). Checking any
+		// other position would false-positive on flag values like
+		// `codex --profile resume` (#632).
 		insertAt := agentIdx + 1
 		if insertAt < len(tokens) && tokens[insertAt] == "exec" {
 			insertAt++
+		}
+		if insertAt < len(tokens) && tokens[insertAt] == "resume" {
+			return program
 		}
 		newTokens := make([]string, 0, len(tokens)+2)
 		newTokens = append(newTokens, tokens[:insertAt]...)
@@ -87,7 +89,8 @@ func resumeProgram(program string) string {
 		return program + " --restore-chat-history"
 	case ProgramGemini:
 		for _, tok := range tokens {
-			if tok == "--resume" || tok == "-r" || strings.HasPrefix(tok, "--resume=") {
+			if tok == "--resume" || tok == "-r" ||
+				strings.HasPrefix(tok, "--resume=") || strings.HasPrefix(tok, "-r=") {
 				return program
 			}
 		}

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -45,6 +45,10 @@ func TestResumeProgram(t *testing.T) {
 		// of #604 for claude — same flag-detection class as gemini).
 		{"claude already --resume=value", "claude --resume=abc123", "claude --resume=abc123"},
 		{"claude already --resume=latest", "claude --resume=latest", "claude --resume=latest"},
+		// Short-option = syntax: detect defensively so we don't accumulate
+		// flags if the CLI accepts `-r=VALUE` (same class as gemini's #633).
+		{"claude already -r=value", "claude -r=abc123", "claude -r=abc123"},
+		{"claude already -r=latest", "claude -r=latest", "claude -r=latest"},
 
 		// Codex: insert "resume --last" after the codex token (subcommand
 		// position matters for codex; a tail append wouldn't parse).
@@ -61,6 +65,30 @@ func TestResumeProgram(t *testing.T) {
 		// Codex: already-has-resume cases — no-op.
 		{"codex already resume", "codex resume --last", "codex resume --last"},
 		{"codex exec already resume", "codex exec resume --last", "codex exec resume --last"},
+		// Codex: "resume" appearing in flag-value position must NOT trip
+		// the already-has-resume check (#632). The subcommand can only
+		// appear immediately after `codex` or after `codex exec`, so the
+		// detection is position-aware.
+		{
+			"codex profile named resume",
+			"codex --profile resume",
+			"codex resume --last --profile resume",
+		},
+		{
+			"codex profile=resume equals form",
+			"codex --profile=resume",
+			"codex resume --last --profile=resume",
+		},
+		{
+			"codex exec with profile named resume",
+			"codex exec --profile resume",
+			"codex exec resume --last --profile resume",
+		},
+		{
+			"codex model value named resume",
+			"codex --model resume",
+			"codex resume --last --model resume",
+		},
 
 		// Aider: append --restore-chat-history at the end. Position-
 		// independent flag, so the original program string is preserved
@@ -151,6 +179,12 @@ func TestResumeProgram(t *testing.T) {
 			"gemini --resume=anything",
 			"gemini --resume=anything",
 		},
+		// Short-option = syntax: gemini accepts `-r=<value>` and would
+		// concatenate duplicate values with commas ("5,latest") and exit 1
+		// if we appended a second flag (#633).
+		{"gemini already -r=numeric", "gemini -r=5", "gemini -r=5"},
+		{"gemini already -r=latest", "gemini -r=latest", "gemini -r=latest"},
+		{"gemini already -r=arbitrary", "gemini -r=anything", "gemini -r=anything"},
 
 		// Unknown programs are passed through unchanged so unrelated CLIs
 		// aren't accidentally rewritten.
@@ -175,6 +209,17 @@ func TestResumeProgram_QuotedCodexPath(t *testing.T) {
 	require.Equal(t, "'/path with space/codex' resume --last --model gpt-5", got)
 }
 
+// TestResumeProgram_CodexProfileResumeFalsePositive guards #632: the codex
+// "already has resume" check must be position-aware. A profile named "resume"
+// (or any other flag value of "resume") must not be mistaken for the resume
+// subcommand, otherwise the user loses their conversation on respawn.
+func TestResumeProgram_CodexProfileResumeFalsePositive(t *testing.T) {
+	in := "codex --profile resume"
+	want := "codex resume --last --profile resume"
+	got := resumeProgram(in)
+	require.Equal(t, want, got, "BUG: 'resume' in flag value position should not be detected as subcommand")
+}
+
 // TestResumeProgram_Idempotent verifies that running the rewrite twice
 // produces the same string as running it once — defense against repeated
 // Restore() calls (e.g. user kills tmux multiple times in a row).
@@ -192,7 +237,13 @@ func TestResumeProgram_Idempotent(t *testing.T) {
 		"gemini --model x",
 		"gemini --resume 5",
 		"gemini --resume=5",
+		"gemini -r=5",
+		"gemini -r=latest",
 		"claude --resume=abc123",
+		"claude -r=abc123",
+		"codex --profile resume",
+		"codex --profile=resume",
+		"codex exec --profile resume",
 	} {
 		once := resumeProgram(in)
 		twice := resumeProgram(once)


### PR DESCRIPTION
## Summary

Two related regressions in `resumeProgram` (`session/tmux/resume.go`) that drop conversation history when a tmux session is respawned after loss:

- **#632 (codex):** the already-has-resume check scanned every token for `tok == "resume"`, so any flag value of `"resume"` (e.g. `codex --profile resume`) was misread as the subcommand and the rewrite was skipped. Fixed by computing the insert position first (immediately after `codex`, or after `exec`) and only checking `tokens[insertAt]`. The codex CLI only accepts the `resume` subcommand in that slot, so any other occurrence is necessarily a flag value.
- **#633 (gemini):** `-r=VALUE` slipped past the already-has-resume check, so we appended ` --resume latest` on top, yielding `gemini -r=5 --resume latest`. Gemini concatenated the two values into `5,latest` and exited with `Invalid session identifier`. Fixed by adding `strings.HasPrefix(tok, "-r=")` to the detection set.

## Audit (4-position × 4-agent)

While in here I enumerated every flag-detection condition against the four positional forms so the same gap doesn't keep being found one CLI at a time. Claude turned out to have the same `-r=VALUE` gap as gemini and is fixed defensively in the same change.

| Agent | `--flag` (long bare) | `--flag=value` (long equals) | `-X` (short bare) | `-X=value` (short equals) | Subcommand position |
|---|---|---|---|---|---|
| **claude** | ✅ `--continue`, `--resume` | ✅ `--resume=value` | ✅ `-c`, `-r` | ✅ `-r=value` (**added defensively** — same regression class as gemini #633; `-c=value` N/A since `-c` is a boolean) | N/A — claude flags are position-independent |
| **codex** | N/A — codex uses a subcommand (`resume`), not a flag | N/A | N/A | N/A | ✅ **fixed (#632)** — only `tokens[insertAt]` is checked, where `insertAt` is `codex+1` or `codex exec+1` |
| **aider** | ✅ `--restore-chat-history`, `--no-restore-chat-history` | N/A — boolean flags don't take values | N/A — aider has no short forms for these flags | N/A | N/A — flag is position-independent |
| **gemini** | ✅ `--resume` | ✅ `--resume=value` | ✅ `-r` | ✅ `-r=value` (**fixed #633**) | N/A — flag is position-independent |

## Test plan

- [x] Bot-requested failing test added: `TestResumeProgram_CodexProfileResumeFalsePositive` (`codex --profile resume` → `codex resume --last --profile resume`)
- [x] Bot-requested gemini cases added: `gemini -r=5` and `gemini -r=latest` (no-op)
- [x] Full 4x4 battery in the table-driven `TestResumeProgram`: every agent × every applicable position has a no-op subtest; codex has additional position-aware regression cases (`--profile resume`, `--profile=resume`, `exec --profile resume`, `--model resume`)
- [x] `TestResumeProgram_Idempotent` extended with the new forms (claude `-r=abc123`, gemini `-r=5`, gemini `-r=latest`, codex `--profile resume`, codex `--profile=resume`, codex `exec --profile resume`)
- [x] `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `go test ./session/tmux/...` — all pass
- [x] `go test -race ./session/tmux/...` — all pass
- [x] `go test ./...` — only unrelated `TestSigtermFallback_DeadPID` fails (environmental: real `af --daemon` processes running on dev machine; fails identically on `master` at base commit `f75c7f0`)

Closes #632
Closes #633

Co-Authored-By: Captain Claude <noreply@anthropic.com>