### PR TITLE
fix(task): normalize ProjectPath on task edit to match create behavior (#641)

### DIFF
--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -2,9 +2,11 @@ package ui
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
-	"strings"
 
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -398,11 +400,20 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 					s.editError = fmt.Sprintf("invalid cron: %v", err)
 					return true
 				}
+				// Mirror the create path (app.handleTaskCreate): resolve
+				// the user-entered path to an absolute form so an empty
+				// or relative value behaves the same when the scheduler
+				// fires as it does in the TUI trigger (#641).
+				absPath, err := filepath.Abs(s.editPath.Value())
+				if err != nil {
+					s.editError = fmt.Sprintf("invalid path: %v", err)
+					return true
+				}
 				s.editError = ""
 				s.tasks[s.selectedIdx].Name = s.editName.Value()
 				s.tasks[s.selectedIdx].Prompt = s.editPrompt.Value()
 				s.tasks[s.selectedIdx].CronExpr = s.editCron.Value()
-				s.tasks[s.selectedIdx].ProjectPath = s.editPath.Value()
+				s.tasks[s.selectedIdx].ProjectPath = absPath
 				s.tasks[s.selectedIdx].Program = s.programValue()
 				s.dirty = true
 				s.editing = false

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -286,6 +288,129 @@ func TestTaskPaneCreateModeCtrlCCancels(t *testing.T) {
 
 	assert.False(t, tp.IsCreating(), "Ctrl+C should exit create mode")
 	assert.False(t, tp.HasPendingCreate(), "Ctrl+C must not produce a pending create")
+}
+
+// editPathTo opens edit mode on the first task and overwrites the Path field
+// with newPath, then saves. Used by the ProjectPath-normalization regression
+// tests to drive only the Path input without disturbing the other fields.
+func editPathTo(t *testing.T, tp *TaskPane, newPath string) {
+	t.Helper()
+	tp.SetFocus(true)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}) // enter edit mode
+	if !tp.IsEditing() {
+		t.Fatalf("expected edit mode")
+	}
+	// Tab Name -> Prompt -> Cron -> Path
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	// Clear current value then type the new one.
+	for range tp.editPath.Value() {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	if newPath != "" {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(newPath)})
+	}
+	// Tab Path -> Program -> Save, then submit.
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+}
+
+// TestTaskPaneEditModeNormalizesEmptyPath is the regression guard for #641:
+// editing ProjectPath to "" must normalize to the CWD (via filepath.Abs)
+// so the scheduler receives the same absolute path the TUI trigger would
+// produce. Prior to the fix the empty value was stored verbatim, causing
+// scheduled runs to fail with "repo path is required" while TUI triggers
+// silently fell back to CWD.
+func TestTaskPaneEditModeNormalizesEmptyPath(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	expected, err := filepath.Abs(cwd)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "0 0 * * *",
+		ProjectPath: "/tmp/repo",
+		Program:     "claude",
+		Enabled:     true,
+	}})
+
+	editPathTo(t, tp, "")
+
+	assert.False(t, tp.IsEditing(), "save should exit edit mode")
+	assert.Equal(t, "", tp.editError, "empty path must normalize, not surface an error")
+	tasks := tp.GetTasks()
+	if assert.Len(t, tasks, 1) {
+		assert.Equal(t, expected, tasks[0].ProjectPath,
+			"empty ProjectPath must be normalized to absolute CWD on save, matching the create path")
+	}
+}
+
+// TestTaskPaneEditModeNormalizesRelativePath verifies that editing
+// ProjectPath to a relative value resolves it via filepath.Abs at save
+// time, mirroring the create path (#641). Without this, the scheduler
+// would pass a relative path that resolves against the daemon's CWD
+// rather than the user's CWD.
+func TestTaskPaneEditModeNormalizesRelativePath(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	expected, err := filepath.Abs(filepath.Join(cwd, "relative"))
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "0 0 * * *",
+		ProjectPath: "/tmp/repo",
+		Program:     "claude",
+		Enabled:     true,
+	}})
+
+	editPathTo(t, tp, "./relative")
+
+	tasks := tp.GetTasks()
+	if assert.Len(t, tasks, 1) {
+		assert.Equal(t, expected, tasks[0].ProjectPath,
+			"relative ProjectPath must be resolved via filepath.Abs on save")
+	}
+}
+
+// TestTaskPaneEditModeKeepsAbsolutePath verifies that an already-absolute
+// ProjectPath is preserved verbatim across edit/save (#641).
+func TestTaskPaneEditModeKeepsAbsolutePath(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "0 0 * * *",
+		ProjectPath: "/tmp/old",
+		Program:     "claude",
+		Enabled:     true,
+	}})
+
+	editPathTo(t, tp, "/tmp/new-repo")
+
+	tasks := tp.GetTasks()
+	if assert.Len(t, tasks, 1) {
+		assert.Equal(t, "/tmp/new-repo", tasks[0].ProjectPath,
+			"absolute ProjectPath must be preserved verbatim across edit/save")
+	}
 }
 
 // TestTaskPaneListShowsAgentNameNotFullProgram confirms the list view collapses


### PR DESCRIPTION
## Summary
- TUI create normalizes `ProjectPath` via `filepath.Abs` in `app.handleTaskCreate`; TUI edit stored `s.editPath.Value()` verbatim. Editing the Path field to empty left `ProjectPath == ""` on disk.
- Caused a TUI-vs-scheduler split: TUI trigger silently resolved empty to CWD via `config.RepoFromPath`; scheduled runs hit `daemon.CreateSession` and failed with `repo path is required`.
- Fix mirrors the create path: on edit-save, call `filepath.Abs(s.editPath.Value())` and surface an inline error if it fails. No new validation, no trim — same UX both directions.

## Audit of TaskPane edit-save assignments
- `Name`: raw assignment, non-empty check in both create & edit — consistent.
- `Prompt`: raw assignment, `TrimSpace != ""` check in both — consistent.
- `CronExpr`: raw assignment, `ValidateCronExpr` in both — consistent.
- `Program`: `programValue()` in both. Create additionally falls back to the CLI launch program when empty (in `app.go`); empty in edit means "use config default". Intentional and out of scope.
- `ProjectPath`: **this PR**.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l ui/task_pane.go ui/task_pane_test.go` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `go test ./ui/...` passes, including 3 new regression tests:
      - empty Path → normalized to absolute CWD
      - `./relative` → `filepath.Abs(CWD/relative)`
      - `/absolute` → kept verbatim
- [x] `go test -race ./ui/...` clean
- [x] `deadcode ./...` clean for this change
- [ ] Full `go test ./...` — one daemon test (`TestSigtermFallback_DeadPID`) fails locally because two real `af --daemon` processes are running on this dev machine, not related to this change. CI will run in a clean env.

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude