### PR TITLE
fix(ui/overlay): truncate xansi.TruncateLeft result when wide-char straddle pushes it past remaining width (#647)

### DIFF
--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -160,8 +160,18 @@ func PlaceOverlay(
 		right := xansi.TruncateLeft(bgLine, pos, "")
 		bgLineWidth := ansi.PrintableRuneWidth(bgLine)
 		rightWidth := ansi.PrintableRuneWidth(right)
-		if rightWidth <= bgLineWidth-pos {
-			b.WriteString(ws.render(bgLineWidth - rightWidth - pos))
+		remainingWidth := bgLineWidth - pos
+		if rightWidth > remainingWidth {
+			// TruncateLeft returned more than fits because pos landed in the
+			// middle of a wide (CJK/emoji) grapheme and the whole cluster was
+			// preserved. Re-truncate from the right with the ANSI-aware helper
+			// so we don't render past bgLineWidth. The dropped half-cell shows
+			// as the leading pad below. (#647)
+			right = xansi.Truncate(right, remainingWidth, "")
+			rightWidth = ansi.PrintableRuneWidth(right)
+		}
+		if rightWidth < remainingWidth {
+			b.WriteString(ws.render(remainingWidth - rightWidth))
 		}
 		b.WriteString(right)
 	}

--- a/ui/overlay/overlay_test.go
+++ b/ui/overlay/overlay_test.go
@@ -205,3 +205,86 @@ func TestPlaceOverlayTrueColorBackgroundFade(t *testing.T) {
 		t.Fatalf("BUG CONFIRMED: true-color background was faded as foreground")
 	}
 }
+
+// TestPlaceOverlayCJKWideCharStraddle is a regression guard for #647. When the
+// position after the foreground falls inside a wide (CJK) grapheme,
+// xansi.TruncateLeft preserves the entire grapheme — returning a string whose
+// printable width is 1 cell larger than the remaining background space. The
+// pre-fix code wrote that right-side slab unconditionally and skipped padding,
+// producing a line 1 cell wider than the background.
+func TestPlaceOverlayCJKWideCharStraddle(t *testing.T) {
+	// bg: 7 ASCII + three 2-cell CJK = width 13.
+	// fg width 4 placed at x=4 → pos=8 lands inside the first 界.
+	bg := "abcdefg界界界"
+	fg := "XXXX"
+	bgWidth := ansi.PrintableRuneWidth(bg)
+
+	result := PlaceOverlay(4, 0, fg, bg, false)
+
+	gotWidth := ansi.PrintableRuneWidth(result)
+	if gotWidth != bgWidth {
+		t.Fatalf("PlaceOverlay overflow: got width %d, want %d (bg=%q result=%q)",
+			gotWidth, bgWidth, bg, result)
+	}
+}
+
+// TestPlaceOverlayCJKWideCharStraddleCentered exercises the centered variant
+// from the bug report: centering a width-2 fg on a width-12 bg yields placeX=5,
+// so pos=7 lands inside a CJK glyph at cells 7-8.
+func TestPlaceOverlayCJKWideCharStraddleCentered(t *testing.T) {
+	// bg: 6 ASCII + three 2-cell CJK = width 12. pos after fg = 5+2 = 7.
+	bg := "abcdef界界界"
+	fg := "YY"
+	bgWidth := ansi.PrintableRuneWidth(bg)
+
+	result := PlaceOverlay(0, 0, fg, bg, true)
+
+	gotWidth := ansi.PrintableRuneWidth(result)
+	if gotWidth != bgWidth {
+		t.Fatalf("PlaceOverlay centered overflow: got width %d, want %d (bg=%q result=%q)",
+			gotWidth, bgWidth, bg, result)
+	}
+}
+
+// TestPlaceOverlayASCIINoRegression is a guard that the #647 fix doesn't change
+// the ASCII-only path, where rightWidth always equals remainingWidth exactly.
+func TestPlaceOverlayASCIINoRegression(t *testing.T) {
+	bg := "abcdefghij" // width 10
+	fg := "XX"
+	bgWidth := ansi.PrintableRuneWidth(bg)
+
+	result := PlaceOverlay(3, 0, fg, bg, false)
+
+	gotWidth := ansi.PrintableRuneWidth(result)
+	if gotWidth != bgWidth {
+		t.Fatalf("ASCII PlaceOverlay width changed: got %d, want %d (result=%q)",
+			gotWidth, bgWidth, result)
+	}
+	if !strings.Contains(result, "abc") || !strings.Contains(result, "XX") || !strings.Contains(result, "fghij") {
+		t.Fatalf("ASCII composition incorrect: %q", result)
+	}
+}
+
+// TestPlaceOverlayCJKAlignedNoTruncation verifies that when pos lands cleanly
+// on a CJK grapheme boundary (even pos in this layout), TruncateLeft already
+// returns the exact remaining width and no re-truncation is needed. This guards
+// against the fix accidentally trimming a cell in the well-behaved case.
+func TestPlaceOverlayCJKAlignedNoTruncation(t *testing.T) {
+	// 6 ASCII + three 2-cell CJK = width 12. fg width 2 placed at x=6 →
+	// pos=8 lands exactly between the first and second CJK glyph.
+	bg := "abcdef界界界"
+	fg := "ZZ"
+	bgWidth := ansi.PrintableRuneWidth(bg)
+
+	result := PlaceOverlay(6, 0, fg, bg, false)
+
+	gotWidth := ansi.PrintableRuneWidth(result)
+	if gotWidth != bgWidth {
+		t.Fatalf("CJK-aligned PlaceOverlay width changed: got %d, want %d (result=%q)",
+			gotWidth, bgWidth, result)
+	}
+	// Both trailing CJK glyphs should survive since pos sits on the boundary.
+	if !strings.Contains(result, "界界") {
+		t.Fatalf("expected trailing CJK glyphs preserved, got: %q", result)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `PlaceOverlay` overflow: when the cursor lands mid-CJK after the foreground, `xansi.TruncateLeft` preserves the full wide glyph and returns a slab 1 cell wider than the remaining background space. The old code wrote that slab unconditionally and skipped padding, producing a line 1 cell wider than the background (`bgLineWidth + 1`).
- New logic computes `remainingWidth` once: if the slab overflows, re-truncate via `xansi.Truncate` (ANSI-aware, cuts by printable width); the dropped half-cell becomes leading pad. ASCII-only and CJK-aligned paths are unchanged.
- Audited overlay/ and ui/: `xansi.TruncateLeft` only appears in this one site. Other truncation calls (`truncate.String`, `runewidth.Truncate`, `xansi.Truncate`) cut from the right, so a straddling wide glyph is dropped (narrowing the output, not widening it) — no overflow risk.

## Test plan
- [x] New `TestPlaceOverlayCJKWideCharStraddle`, `TestPlaceOverlayCJKWideCharStraddleCentered` — fail at width 14 (was 13)/13 (was 12) against the pre-fix code, pass after.
- [x] New `TestPlaceOverlayASCIINoRegression`, `TestPlaceOverlayCJKAlignedNoTruncation` — guard the non-straddle paths; pass both before and after.
- [x] `go build ./...`, `gofmt -l .`, `go test ./ui/overlay/... -race`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` all clean.
- [x] Pre-existing `TestSigtermFallback_DeadPID` failure in `daemon/` reproduces on master (real `af --daemon` PIDs on the dev box confuse the ambiguity probe) — not introduced here.

Closes #647

Co-Authored-By: Captain Claude <noreply@anthropic.com>