### PR TITLE
fix(ui/preview): bottom-truncate to show newest lines (match TerminalPane) (#649)

### DIFF
--- a/ui/preview.go
+++ b/ui/preview.go
@@ -218,11 +218,19 @@ func (p *PreviewPane) String() string {
 	// Normal mode display
 	lines := strings.Split(p.previewState.text, "\n")
 
-	// Truncate if we have more lines than available height
+	// strings.Split produces a trailing empty element when text ends in "\n"
+	// (common for terminal capture output). Drop it so the off-by-one does
+	// not trigger truncation when content actually fits, and so the truncate
+	// branch keeps the right slice of lines (#649).
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	// Truncate to the most recent p.height lines (match TerminalPane: show
+	// newest output, not oldest — #649).
 	if p.height > 0 {
 		if len(lines) > p.height {
-			lines = lines[:p.height-1]
-			lines = append(lines, "...")
+			lines = lines[len(lines)-p.height:]
 		} else {
 			// Pad with empty lines to fill available height
 			padding := p.height - len(lines)

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -396,6 +396,88 @@ func TestPreviewExactFitDoesNotTruncate(t *testing.T) {
 	require.NotContains(t, rendered, "...")
 }
 
+// TestPreviewBottomTruncateShowsNewestLines is the regression test for #649:
+// when content exceeds the pane height, PreviewPane must keep the BOTTOM
+// p.height lines (newest output) — matching TerminalPane — rather than the
+// top p.height-1 lines plus a "..." marker. Showing the start of the output
+// while the agent has moved on is confusing UX.
+func TestPreviewBottomTruncateShowsNewestLines(t *testing.T) {
+	const totalLines = 100
+	const paneHeight = 10
+
+	lines := make([]string, totalLines)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line-%03d", i+1)
+	}
+	text := strings.Join(lines, "\n")
+
+	p := NewPreviewPane()
+	p.SetSize(80, paneHeight)
+	p.previewState = previewState{fallback: false, text: text}
+
+	rendered := p.String()
+
+	// The newest p.height lines must be present; the oldest lines must not.
+	for i := totalLines - paneHeight; i < totalLines; i++ {
+		require.Contains(t, rendered, lines[i],
+			"newest line %q must be visible after truncation", lines[i])
+	}
+	for i := 0; i < totalLines-paneHeight; i++ {
+		require.NotContains(t, rendered, lines[i],
+			"older line %q must NOT be visible after truncation", lines[i])
+	}
+
+	// Match TerminalPane: no "..." indicator.
+	require.NotContains(t, rendered, "...",
+		"bottom-truncation should not append a '...' marker")
+}
+
+// TestPreviewTrailingNewlineDoesNotTriggerTruncation guards the off-by-one
+// fix in #649: tmux capture-pane output frequently ends in "\n", which made
+// strings.Split produce len(lines) == p.height+1 even when the visible
+// content fits the pane. Before the fix, this took the truncation branch
+// and dropped a line.
+func TestPreviewTrailingNewlineDoesNotTriggerTruncation(t *testing.T) {
+	p := NewPreviewPane()
+	p.SetSize(80, 10)
+	// Five lines of content + trailing newline. Total visible content is 5
+	// lines, well below the 10-line budget; the trailing "\n" must not cause
+	// the renderer to truncate.
+	p.previewState = previewState{
+		fallback: false,
+		text:     "one\ntwo\nthree\nfour\nfive\n",
+	}
+
+	rendered := p.String()
+	require.Contains(t, rendered, "one",
+		"first line must remain visible — trailing newline must not trigger truncation")
+	require.Contains(t, rendered, "five",
+		"last content line must remain visible")
+	require.NotContains(t, rendered, "...",
+		"no truncation marker expected when content fits")
+}
+
+// TestPreviewTrailingNewlineAtExactHeight checks the boundary: content that
+// fills exactly p.height lines but ends in "\n" must not be truncated. The
+// trailing-empty strip exists to handle this case.
+func TestPreviewTrailingNewlineAtExactHeight(t *testing.T) {
+	const paneHeight = 5
+	contentLines := []string{"a", "b", "c", "d", "e"}
+	text := strings.Join(contentLines, "\n") + "\n"
+
+	p := NewPreviewPane()
+	p.SetSize(80, paneHeight)
+	p.previewState = previewState{fallback: false, text: text}
+
+	rendered := p.String()
+	for _, line := range contentLines {
+		require.Contains(t, rendered, line,
+			"line %q must remain visible at exact-fit boundary", line)
+	}
+	require.NotContains(t, rendered, "...",
+		"no truncation marker expected at exact-fit boundary")
+}
+
 // Helper function for max
 func max(a, b int) int {
 	if a > b {


### PR DESCRIPTION
## Summary

- `PreviewPane.String()` truncated content from the **top** (kept oldest
  `p.height-1` lines + `"..."`) while `TerminalPane.String()` truncates
  from the **bottom** (newest `p.height` lines). When an agent produced
  more output than fit, the preview showed the **start** of the output
  instead of the current state — confusing UX and inconsistent with the
  sibling pane.
- A common off-by-one made this fire spuriously even when content fit:
  tmux capture-pane output frequently ends in `"\n"`, so
  `strings.Split(text, "\n")` produced `len(lines) == p.height+1` and
  pushed the renderer into the truncation branch.

## Fix

Per the Detail bot recommendation on the issue:

1. Strip the trailing empty element produced by `strings.Split` when
   text ends in `"\n"`. Removes the off-by-one.
2. When still over budget, keep the **bottom** `p.height` lines:
   `lines = lines[len(lines)-p.height:]`.
3. Drop the `"..."` marker entirely to match `TerminalPane` (no
   indicator).

The fallback padding semantics from #616 are preserved: when the content
fits, the renderer still pads to exactly `p.height` lines, so fallback
and normal mode continue to render the same number of lines.

## Audit

Grepped `ui/` for every place that truncates a slice of lines to a fixed
height. Catalogue:

| Site | Direction | Status |
|---|---|---|
| `ui/preview.go` `PreviewPane.String()` | bottom (post-fix) | fixed by this PR |
| `ui/terminal.go` `TerminalPane.String()` | bottom | already correct |

No other panes (`sidebar`, `hooks_pane`, `task_pane`, `content_pane`,
`list`, `menu`, `tabbed_window`, `overlay`) have a `len(lines) > height`
truncation pattern. `ui/err.go` uses `runewidth.Truncate` for **width**
truncation only — unrelated.

## Tests

Added to `ui/preview_test.go`:

- `TestPreviewBottomTruncateShowsNewestLines` — 100 lines, `p.height=10`
  → asserts lines 91–100 visible, lines 1–90 absent, no `"..."` marker.
- `TestPreviewTrailingNewlineDoesNotTriggerTruncation` — 5 lines +
  trailing `"\n"`, `p.height=10` → all 5 lines remain visible.
- `TestPreviewTrailingNewlineAtExactHeight` — exactly `p.height` lines
  with trailing `"\n"` → no truncation at the boundary.

Existing regression tests still pass:

- `TestPreviewExactFitDoesNotTruncate`
- `TestPreviewFallbackMatchesNormalModeHeight` (the #616 padding fix)
- `TestPreviewFallbackHeightNoDoubleCounting` (the #274 fix)

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go test ./ui/...`
- [x] `go test -race ./ui/...`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `deadcode -test ./...`
- [x] Full `go test ./...` — only failure is `daemon.TestSigtermFallback_DeadPID`, environmental (it detects the dev box's real running `af --daemon` processes), unrelated to this change.

Fixes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude <captain@agent-factory.dev>