### PR TITLE
fix(session/tmux): preserve shell expansion in codex resume rewrite (#640)

### DIFF
--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -10,15 +10,20 @@ import (
 // #595). For agents without a resume-most-recent flag, programs that already
 // include one, and unknown programs, returns program unchanged.
 //
-// Agent-specific rewrites:
+// Agent-specific rewrites — all four paths preserve the original program
+// string verbatim (modulo the inserted resume tokens) so user shell quoting,
+// $VAR / ~ / glob metacharacters survive respawn unchanged (#640):
 //
 //   - claude: append --continue at the end. claude's resume flags are
 //     position-independent, so appending preserves the original program
 //     string verbatim (including any shell quoting on the executable
 //     path — see #569).
-//   - codex: insert "resume --last" immediately after the codex token,
-//     or after "exec" if it follows codex. Subcommand position matters
-//     for codex, so this can't be a tail append.
+//   - codex: splice " resume --last" into the original program string at
+//     the byte offset right after the codex (or "codex exec") token.
+//     Subcommand position matters for codex, so this can't be a tail
+//     append; but a tokenize+rejoin round-trip would defensively quote
+//     metachars in user flags (#640 regression of #596) — splicing the
+//     original avoids that.
 //   - aider: append --restore-chat-history at the end. Reads
 //     .aider.chat.history.md from cwd if present; silently falls back to
 //     a fresh chat if absent. Skipped if the user passed an explicit
@@ -30,7 +35,7 @@ import (
 // All four CLIs silently fall back to a fresh session when no prior session
 // exists in cwd, so the rewrite is safe to apply unconditionally.
 func resumeProgram(program string) string {
-	tokens := splitShellTokens(program)
+	tokens, ends := splitShellTokens(program)
 	if len(tokens) == 0 {
 		return program
 	}
@@ -75,11 +80,14 @@ func resumeProgram(program string) string {
 		if insertAt < len(tokens) && tokens[insertAt] == "resume" {
 			return program
 		}
-		newTokens := make([]string, 0, len(tokens)+2)
-		newTokens = append(newTokens, tokens[:insertAt]...)
-		newTokens = append(newTokens, "resume", "--last")
-		newTokens = append(newTokens, tokens[insertAt:]...)
-		return shellJoinTokens(newTokens)
+		// Splice " resume --last" into the ORIGINAL program string at the
+		// byte offset right after the codex (or "codex exec") token so
+		// the user's quoting / $VAR / ~ / * / ? all pass through
+		// untouched. A tokenize+rejoin round-trip would defensively
+		// single-quote those metachars and break shell expansion on
+		// respawn (#640).
+		off := ends[insertAt-1]
+		return program[:off] + " resume --last" + program[off:]
 	case ProgramAider:
 		for _, tok := range tokens {
 			if tok == "--restore-chat-history" || tok == "--no-restore-chat-history" {
@@ -102,11 +110,14 @@ func resumeProgram(program string) string {
 // splitShellTokens tokenizes a shell-style command string, respecting single
 // quotes (no escapes), double quotes (with \" and \\ escapes), and backslash
 // escapes outside quotes. Adjacent runs concatenate into a single token (e.g.
-// 'foo'bar -> "foobar"). Unclosed quotes consume to end of input. Mirrors the
-// session.splitShell helper used by injectSystemPrompt — kept private here
-// to avoid an import cycle (session/tmux is imported by session).
-func splitShellTokens(s string) []string {
-	var tokens []string
+// 'foo'bar -> "foobar"). Unclosed quotes consume to end of input.
+//
+// Returns the tokens alongside ends[i], the byte offset in s immediately
+// after token i ends (one past any closing quote). resumeProgram's codex
+// rewrite uses these offsets to splice text into the original string
+// without round-tripping through a join step that would defensively quote
+// shell metacharacters (#640).
+func splitShellTokens(s string) (tokens []string, ends []int) {
 	var cur strings.Builder
 	inToken := false
 	i := 0
@@ -116,6 +127,7 @@ func splitShellTokens(s string) []string {
 		case ' ', '\t':
 			if inToken {
 				tokens = append(tokens, cur.String())
+				ends = append(ends, i)
 				cur.Reset()
 				inToken = false
 			}
@@ -164,42 +176,7 @@ func splitShellTokens(s string) []string {
 	}
 	if inToken {
 		tokens = append(tokens, cur.String())
+		ends = append(ends, i)
 	}
-	return tokens
-}
-
-// shellJoinTokens joins tokens with spaces, single-quoting any token that
-// would otherwise be reinterpreted by the shell. Used to rebuild a program
-// string after token-level surgery in resumeProgram.
-func shellJoinTokens(tokens []string) string {
-	var b strings.Builder
-	for i, tok := range tokens {
-		if i > 0 {
-			b.WriteByte(' ')
-		}
-		if needsShellQuote(tok) {
-			b.WriteByte('\'')
-			b.WriteString(strings.ReplaceAll(tok, "'", `'\''`))
-			b.WriteByte('\'')
-		} else {
-			b.WriteString(tok)
-		}
-	}
-	return b.String()
-}
-
-func needsShellQuote(s string) bool {
-	if s == "" {
-		return true
-	}
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case ' ', '\t', '\n', '\'', '"', '\\',
-			'$', '`', '*', '?', '[', ']',
-			'(', ')', '{', '}', '|', '&',
-			';', '<', '>', '#', '~', '!':
-			return true
-		}
-	}
-	return false
+	return tokens, ends
 }

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -89,6 +89,48 @@ func TestResumeProgram(t *testing.T) {
 			"codex --model resume",
 			"codex resume --last --model resume",
 		},
+		// Codex shell-expansion preservation (#640): the codex rewrite must
+		// preserve user metacharacters ($VAR, ~, *, ?, globs) verbatim. A
+		// prior implementation tokenize+rejoined the program string and
+		// defensively single-quoted any token containing shell metachars,
+		// turning `--model $MODEL` into `--model '$MODEL'` and breaking
+		// expansion on respawn. The fix splices " resume --last" into the
+		// original string at a known byte offset instead.
+		{
+			"codex preserves $VAR in flag value",
+			"codex --model $MODEL",
+			"codex resume --last --model $MODEL",
+		},
+		{
+			"codex preserves ~ in flag value",
+			"codex --profile ~/profiles/foo",
+			"codex resume --last --profile ~/profiles/foo",
+		},
+		{
+			"codex exec preserves $VAR after subcommand",
+			"codex exec --model $MODEL ./prompt.md",
+			"codex exec resume --last --model $MODEL ./prompt.md",
+		},
+		{
+			"codex absolute path preserves $VAR",
+			"/usr/local/bin/codex --model $MODEL",
+			"/usr/local/bin/codex resume --last --model $MODEL",
+		},
+		{
+			"codex double-quoted path with spaces preserves quotes",
+			`"/path with spaces/codex" --model $MODEL`,
+			`"/path with spaces/codex" resume --last --model $MODEL`,
+		},
+		{
+			"codex preserves quoted glob in flag value",
+			"codex --include 'models/*.txt'",
+			"codex resume --last --include 'models/*.txt'",
+		},
+		{
+			"codex preserves bare glob in flag value",
+			"codex --include models/*.txt",
+			"codex resume --last --include models/*.txt",
+		},
 
 		// Aider: append --restore-chat-history at the end. Position-
 		// independent flag, so the original program string is preserved
@@ -244,6 +286,12 @@ func TestResumeProgram_Idempotent(t *testing.T) {
 		"codex --profile resume",
 		"codex --profile=resume",
 		"codex exec --profile resume",
+		// #640 — shell-expansion-preserving splice must also be idempotent.
+		"codex --model $MODEL",
+		"codex exec --model $MODEL ./prompt.md",
+		"codex --profile ~/profiles/foo",
+		"codex --include 'models/*.txt'",
+		`"/path with spaces/codex" --model $MODEL`,
 	} {
 		once := resumeProgram(in)
 		twice := resumeProgram(once)


### PR DESCRIPTION
## Summary

- The codex case in `resumeProgram` (session/tmux/resume.go) tokenized the program string via `splitShellTokens` then rejoined with `shellJoinTokens`, which defensively single-quotes any token containing shell metacharacters (`$`, `~`, `*`, `?`, `[`, `]`, etc.).
- That turned `codex --model $MODEL` into `codex resume --last --model '$MODEL'` on respawn, killing shell expansion. Same class of breakage for `~/...` paths and glob arguments. Regression of #596.
- Fix: splice `" resume --last"` directly into the **original** program string at the byte offset right after the codex (or `codex exec`) token. No tokenize+rejoin for codex anymore — the user's quoting, `$VAR`, `~`, `*`, `?` all pass through untouched.

## Implementation

- `splitShellTokens` now also returns `ends[i]` — the byte offset in the input immediately after token `i` ends (one past any closing quote). Same lexer, same token output, just an extra parallel slice.
- The codex branch uses `ends[insertAt-1]` to locate the splice point, then does plain string slicing: `program[:off] + " resume --last" + program[off:]`.
- `shellJoinTokens` and `needsShellQuote` become unused and are removed. `deadcode -test ./...` is clean.

## Audit of resume.go (every branch — claim: only codex was unsafe)

| Agent  | Strategy                                                  | Preserves metachars? |
| ------ | --------------------------------------------------------- | -------------------- |
| claude | tail-append `" --continue"` to original `program`         | ✅ yes               |
| aider  | tail-append `" --restore-chat-history"` to original       | ✅ yes               |
| gemini | tail-append `" --resume latest"` to original              | ✅ yes               |
| codex  | string-splice `" resume --last"` at byte offset in original (**this PR**) | ✅ yes (was ❌) |

Before this PR, codex was the **only** branch that round-tripped through tokenize+join. After this PR, no branch does — every resume rewrite preserves the original `program` string verbatim outside of the inserted tokens.

## Test cases added (to existing `TestResumeProgram` table)

- `codex --model $MODEL` → `codex resume --last --model $MODEL` (NOT `'$MODEL'`)
- `codex --profile ~/profiles/foo` → `codex resume --last --profile ~/profiles/foo`
- `codex exec --model $MODEL ./prompt.md` → `codex exec resume --last --model $MODEL ./prompt.md`
- `/usr/local/bin/codex --model $MODEL` → `/usr/local/bin/codex resume --last --model $MODEL` (absolute path verbatim)
- `"/path with spaces/codex" --model $MODEL` → `"/path with spaces/codex" resume --last --model $MODEL` (double-quoted path verbatim)
- ``codex --include 'models/*.txt'`` → ``codex resume --last --include 'models/*.txt'`` (quoted glob preserved)
- `codex --include models/*.txt` → `codex resume --last --include models/*.txt` (bare glob preserved)

Plus the same metachar cases added to `TestResumeProgram_Idempotent` so repeated `Restore()` calls remain a no-op. **All existing #596 / #604 / #632 test cases pass unchanged.**

## Verification

- `gofmt -l .` clean
- `go build ./...` clean
- `go test ./...` clean (one pre-existing failure in `daemon/TestSigtermFallback_DeadPID` is caused by two stray `af --daemon` processes on this dev host — reproduces on `master`, unrelated to this fix)
- `go test -race ./session/tmux/...` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean

Closes #640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)