### PR TITLE
fix(session): reconstruct path before token-scan in getBaseCommand to avoid intermediate-dir false-match (#639)

### DIFF
--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -103,6 +103,21 @@ func splitShell(s string) []string {
 // and additionally tolerates unquoted absolute or relative paths whose
 // directory components contain spaces — common when users pass --program
 // with a path like "/home/my user/claude" via the CLI (issue #463).
+//
+// Authoritative principle: the basename of the RECONSTRUCTED command path
+// is the source of truth. The left-to-right token scan over
+// tmux.SupportedPrograms is a fallback ONLY for the case where
+// reconstruction lands on a non-agent basename — specifically, paths whose
+// directory components contain a literal " - " (issue #513) that breaks
+// the naive "join non-flag tokens" reconstruction by splitting at the
+// "-" token.
+//
+// Reorder rationale (issue #639): scanning all tokens left-to-right
+// BEFORE reconstruction false-matches on intermediate directories named
+// like a supported agent. For example "/home/user/claude backups/aider"
+// splits into ["/home/user/claude", "backups/aider"]; a leading scan
+// would match "claude" on the intermediate dir and return the wrong
+// agent for the actual "aider" executable.
 func getBaseCommand(program string) string {
 	program = strings.TrimSpace(program)
 	if len(program) == 0 {
@@ -112,12 +127,30 @@ func getBaseCommand(program string) string {
 	if len(parts) == 0 {
 		return ""
 	}
-	// If any token's basename matches a known agent (tmux.SupportedPrograms),
-	// prefer it. Handles unquoted paths whose directories contain literal
-	// " - " (issue #513): splitShell yields ["/home/u/my", "-", "proj/claude"]
-	// and the simple "join non-flag tokens" heuristic below stops at "-",
-	// landing on "my". Left-to-right wins so the leading executable still
-	// dominates when a flag value happens to point at another known agent.
+	cmd := parts[0]
+	// If the first token looks like an unquoted path (absolute or relative),
+	// greedily join the following non-flag tokens to recover the executable
+	// basename for inputs like `/home/my user/claude --foo` where the path
+	// contains spaces and was not quoted on the command line (#463).
+	if strings.HasPrefix(cmd, "/") || strings.HasPrefix(cmd, "./") || strings.HasPrefix(cmd, "../") {
+		end := 1
+		for end < len(parts) && !strings.HasPrefix(parts[end], "-") {
+			end++
+		}
+		cmd = strings.Join(parts[:end], " ")
+	}
+	reconstructed := strings.ToLower(filepath.Base(cmd))
+	for _, supported := range tmux.SupportedPrograms {
+		if reconstructed == supported {
+			return supported
+		}
+	}
+	// Fallback (#513/#537): reconstruction landed on a non-agent basename,
+	// which happens when an unquoted path contains a literal " - " segment
+	// — splitShell emits the "-" as its own token and the reconstruction
+	// loop stops there. Scan all tokens left-to-right for a supported
+	// program basename; left-to-right wins so the leading executable
+	// dominates if a flag value happens to point at another known agent.
 	for _, p := range parts {
 		base := strings.ToLower(filepath.Base(p))
 		for _, supported := range tmux.SupportedPrograms {
@@ -126,19 +159,7 @@ func getBaseCommand(program string) string {
 			}
 		}
 	}
-	cmd := parts[0]
-	// If the first token looks like an unquoted path (absolute or relative),
-	// assume following non-flag tokens are literal spaces in that path. This
-	// recovers the basename for inputs like `/home/my user/claude --foo`
-	// where the path contains spaces and was not quoted on the command line.
-	if strings.HasPrefix(cmd, "/") || strings.HasPrefix(cmd, "./") || strings.HasPrefix(cmd, "../") {
-		end := 1
-		for end < len(parts) && !strings.HasPrefix(parts[end], "-") {
-			end++
-		}
-		cmd = strings.Join(parts[:end], " ")
-	}
-	return strings.ToLower(filepath.Base(cmd))
+	return reconstructed
 }
 
 // BaseCommand extracts the lowercase executable basename from a program string.

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -192,6 +192,18 @@ func TestGetBaseCommand(t *testing.T) {
 		{"/home/user/my - project/claude --foo", "claude"},
 		{"/home/user/my - project/codex", "codex"},
 		{"/home/user/a - b - c/aider --model x", "aider"},
+		// Issue #639: unquoted path with spaces where an intermediate dir
+		// is named like a supported agent. A naive left-to-right token scan
+		// would false-match on the intermediate "claude"/"codex" dir; the
+		// reconstructed-path-first logic returns the actual executable
+		// basename.
+		{"/home/user/claude backups/aider", "aider"},
+		{"/tmp/codex backups/claude", "claude"},
+		{"/Applications/Claude Code.app/Contents/MacOS/claude", "claude"},
+		{"aider --model x", "aider"},
+		// Unsupported bare name: no SupportedPrograms match anywhere, so
+		// the reconstructed basename (lowercased) is returned as-is.
+		{"unknown_agent", "unknown_agent"},
 	}
 	for _, tt := range tests {
 		got := getBaseCommand(tt.input)


### PR DESCRIPTION
## Summary

Reorder `getBaseCommand` (`session/systemprompt.go`) so that the basename of the **reconstructed** command path is the source of truth, and the left-to-right `tmux.SupportedPrograms` token scan added in #537 is a fallback only.

Closes #639.

## Why

Before this change, `getBaseCommand` scanned **all** tokens left-to-right first and returned the first token whose basename matched a supported agent. For an unquoted path with spaces where an intermediate directory was named like a supported agent (e.g. `/home/user/claude backups/aider`), `splitShell` yields `["/home/user/claude", "backups/aider"]` and the leading scan false-matched `claude` on the intermediate directory, returning the wrong agent. `injectSystemPrompt` then attached `claude`'s `--plugin-dir` flag to what was actually an `aider` invocation, producing an `unrecognized arguments` failure at startup.

This is a regression of the #537 fix (which itself fixed #513). The token scan correctly handled paths containing a literal ` - ` (where the simple non-flag-token reconstruction stops at the `-` token), but it scanned too eagerly.

## The fix

`getBaseCommand` now:

1. Reconstructs the command path by joining non-flag tokens when the first token looks like a path (existing #463 heuristic).
2. If the reconstructed basename matches a `SupportedPrograms` entry, returns it. (Covers #463 and #639.)
3. Otherwise, falls back to the left-to-right token scan from #537. (Covers #513: paths whose directory contains a literal ` - ` segment where reconstruction stops at the `-` token and lands on a non-agent basename like `my`.)
4. If nothing matches the supported list, returns the reconstructed basename lowercased. (Preserves behavior for unsupported tools like `TestInjectSystemPrompt_PathContainingClaude` where `/home/claude-user/bin/mytool` returns `mytool`.)

The authoritative principle is codified in the function's top-of-function comment: the basename of the reconstructed command path is the source of truth; the token scan is a fallback only for cases where reconstruction lands on a non-agent basename.

## Test coverage

Extended `TestGetBaseCommand` in `session/systemprompt_test.go`. Every case from #463, #513/#537, and #639 passes:

| Issue       | Input                                                            | Got              | Want             |
| ----------- | ---------------------------------------------------------------- | ---------------- | ---------------- |
| #463        | `/home/my user/claude`                                           | `claude`         | `claude`         |
| #463        | `/home/my user/claude --foo`                                     | `claude`         | `claude`         |
| #463        | `/Applications/My Apps/claude`                                   | `claude`         | `claude`         |
| #463        | `"/home/my user/claude" --foo`                                   | `claude`         | `claude`         |
| #463        | `'/home/my user/claude' --foo`                                   | `claude`         | `claude`         |
| #463        | `/home/me\ name/claude --foo`                                    | `claude`         | `claude`         |
| #513 / #537 | `/home/user/my - project/claude`                                 | `claude`         | `claude`         |
| #513 / #537 | `/home/user/my - project/claude --foo`                           | `claude`         | `claude`         |
| #513 / #537 | `/home/user/my - project/codex`                                  | `codex`          | `codex`          |
| #513 / #537 | `/home/user/a - b - c/aider --model x`                           | `aider`          | `aider`          |
| #639        | `/home/user/claude backups/aider`                                | `aider`          | `aider`          |
| #639        | `/tmp/codex backups/claude`                                      | `claude`         | `claude`         |
| #639        | `/Applications/Claude Code.app/Contents/MacOS/claude`            | `claude`         | `claude`         |
| #639        | `aider --model x`                                                | `aider`          | `aider`          |
| #639        | `unknown_agent`                                                  | `unknown_agent`  | `unknown_agent`  |

`go test -v -run TestGetBaseCommand ./session/`:

```
=== RUN   TestGetBaseCommand
--- PASS: TestGetBaseCommand (0.00s)
=== RUN   TestGetBaseCommand_RoundTripWithShellQuote
--- PASS: TestGetBaseCommand_RoundTripWithShellQuote (0.00s)
PASS
ok  	github.com/sachiniyer/agent-factory/session	0.004s
```

## Audit findings (same anti-pattern elsewhere)

Per repo policy on adjacent call-sites, I grepped for the same "scan tokens left-to-right for a `SupportedPrograms` basename" logic and found two more call sites in `session/tmux/` with the same bug class. They are **out of scope for this PR** (which is scoped to `getBaseCommand` as titled) but should be addressed in follow-ups:

| Location                                 | Bug example                                                                                               | Observed (buggy)                                                  | Expected            |
| ---------------------------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------- |
| `session/tmux/tmux.go` `AgentNameFromProgram` (L39-53) | `AgentNameFromProgram("/home/user/claude backups/aider")`                                  | `"claude"`                                                        | `"aider"`           |
| `session/tmux/resume.go` `resumeProgram` (L32-100)     | `resumeProgram("/home/user/claude backups/aider")` would append `--continue` to an aider command | `/home/user/claude backups/aider --continue` (claude resume flag) | program unchanged or aider resume |

`AgentNameFromProgram` is straightforward to fix the same way; `resumeProgram` is trickier because it tracks `agentIdx` for codex's resume-subcommand insertion position, which requires a small redesign. I left them untouched to keep this PR matching its title and to give each its own focused tests, but I wanted to surface the findings explicitly — Sachin called out the three-strikes count on `getBaseCommand` and asked for confidence the anti-pattern isn't elsewhere. It is. Happy to file follow-up issues / PRs on request.

## Verification

Run from the worktree root:

- [x] `gofmt -l .` → clean
- [x] `go build ./...` → clean
- [x] `go vet ./...` → clean
- [x] `go test ./...` → pass (the `daemon/TestSigtermFallback_DeadPID` failure on this host is environmental: two leftover `af --daemon` processes on the dev machine. It reproduces on `master` with this branch's diff stashed, so it's not caused by this change.)
- [x] `go test -race ./session/...` → pass
- [x] `golangci-lint run --timeout=3m --fast` → clean
- [x] `deadcode -test ./...` → clean

## Test plan

- [ ] CI green (gofmt, build, test, golangci-lint, deadcode)
- [ ] Confirm `TestGetBaseCommand` covers all three issues' cases and passes
- [ ] Optional manual smoke: launch a session with `--program "/tmp/codex backups/claude --model opus"` (after creating that path) and confirm `claude`'s `--plugin-dir` injection still works for the real `claude` executable

---

Signed,
Captain Claude