### PR TITLE
fix(log): redirect log outputs to stderr BEFORE closing log file to eliminate race-window drops (#642)

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -57,7 +57,21 @@ func Initialize(daemon bool) {
 
 	// Close any previously opened log file to avoid leaking file descriptors
 	// when Initialize is called multiple times (e.g. af tasks trigger -> RunTask).
+	// Redirect to stderr BEFORE closing for the same reason as Close (#642):
+	// concurrent Printfs holding the old logger pointer would otherwise race
+	// the file close and land on a closed fd. After reassignment below,
+	// further Printfs see the new loggers; any still using old pointers fall
+	// through to stderr instead of being dropped.
 	if globalLogFile != nil {
+		if InfoLog != nil {
+			InfoLog.SetOutput(os.Stderr)
+		}
+		if WarningLog != nil {
+			WarningLog.SetOutput(os.Stderr)
+		}
+		if ErrorLog != nil {
+			ErrorLog.SetOutput(os.Stderr)
+		}
 		_ = globalLogFile.Close()
 		globalLogFile = nil
 	}
@@ -93,13 +107,12 @@ func Close() {
 	mu.Lock()
 	defer mu.Unlock()
 
-	if globalLogFile != nil {
-		_ = globalLogFile.Close()
-		globalLogFile = nil
-	}
-	// Redirect any further log writes to stderr so that messages from
-	// goroutines that outlive Close() are not silently dropped to a closed
-	// fd. log.Logger.SetOutput is documented as safe for concurrent use.
+	// Redirect to stderr BEFORE closing the file. SetOutput and Output share
+	// each *log.Logger's internal mutex, so a concurrent Printf either fully
+	// precedes the redirect (and completes its write to the still-open file)
+	// or fully follows it (and writes to stderr). Closing after the redirect
+	// guarantees no Printf ever lands on a closed fd. Reversing this order
+	// loses messages logged in the gap between Close and SetOutput (#642).
 	if InfoLog != nil {
 		InfoLog.SetOutput(os.Stderr)
 	}
@@ -108,6 +121,10 @@ func Close() {
 	}
 	if ErrorLog != nil {
 		ErrorLog.SetOutput(os.Stderr)
+	}
+	if globalLogFile != nil {
+		_ = globalLogFile.Close()
+		globalLogFile = nil
 	}
 	fmt.Fprintln(os.Stderr, "wrote logs to "+logFileName)
 }

--- a/log/log_race_test.go
+++ b/log/log_race_test.go
@@ -1,0 +1,153 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestCloseRaceConcurrentPrintf reproduces the #642 race over many iterations.
+// Each iteration: Initialize, spawn a burst of goroutines that each Printf
+// once, call Close concurrently with the burst, then check that every Printf
+// landed somewhere (log file or stderr). On the pre-fix code (close before
+// SetOutput) a fraction of each burst is dropped to the closed fd.
+//
+// Burst pattern (every goroutine does exactly one Printf gated by a shared
+// channel) is what makes the window observable — it maximizes the number of
+// Printfs in-flight at the moment Close runs globalLogFile.Close().
+func TestCloseRaceConcurrentPrintf(t *testing.T) {
+	tmpDir := t.TempDir()
+	origLogFileName := logFileName
+	logFileName = filepath.Join(tmpDir, "race.log")
+	t.Cleanup(func() { logFileName = origLogFileName })
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	stderrCh := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		stderrCh <- b
+	}()
+
+	const (
+		iterations = 100
+		burstSize  = 200
+	)
+
+	var totalWrites int64
+
+	for iter := 0; iter < iterations; iter++ {
+		Initialize(false)
+
+		var wg sync.WaitGroup
+		wg.Add(burstSize)
+		startGate := make(chan struct{})
+		for g := 0; g < burstSize; g++ {
+			go func(iter, gid int) {
+				defer wg.Done()
+				<-startGate
+				InfoLog.Printf("RACEMARK iter=%d g=%d", iter, gid)
+				atomic.AddInt64(&totalWrites, 1)
+			}(iter, g)
+		}
+		close(startGate)
+		// Race the close against the in-flight burst.
+		Close()
+		wg.Wait()
+	}
+
+	_ = w.Close()
+	capturedStderr := <-stderrCh
+
+	fileContent, err := os.ReadFile(logFileName)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+
+	combined := string(fileContent) + string(capturedStderr)
+	found := int64(strings.Count(combined, "RACEMARK "))
+
+	if found != totalWrites {
+		t.Fatalf("message loss detected: wrote %d Printfs but only %d markers found in log+stderr (lost %d)",
+			totalWrites, found, totalWrites-found)
+	}
+}
+
+// TestCloseRaceSingleBurst is the smallest reproducer: one Initialize, one
+// large burst of concurrent Printfs, one Close racing them. A failure here
+// names specific missing ids, which is easier to debug than the iteration-
+// summed loss reported by TestCloseRaceConcurrentPrintf.
+func TestCloseRaceSingleBurst(t *testing.T) {
+	tmpDir := t.TempDir()
+	origLogFileName := logFileName
+	logFileName = filepath.Join(tmpDir, "burst.log")
+	t.Cleanup(func() { logFileName = origLogFileName })
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	stderrCh := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		stderrCh <- b
+	}()
+
+	Initialize(false)
+
+	const total = 2000
+	var wg sync.WaitGroup
+	wg.Add(total)
+	startGate := make(chan struct{})
+	for i := 0; i < total; i++ {
+		go func(id int) {
+			defer wg.Done()
+			<-startGate
+			InfoLog.Printf("BURSTMARK %d", id)
+		}(i)
+	}
+	close(startGate)
+	Close()
+	wg.Wait()
+
+	_ = w.Close()
+	capturedStderr := <-stderrCh
+
+	fileContent, err := os.ReadFile(logFileName)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+
+	combined := string(fileContent) + string(capturedStderr)
+
+	// Account for every Printf: each unique id must appear somewhere.
+	var missing []int
+	for i := 0; i < total; i++ {
+		needle := fmt.Sprintf("BURSTMARK %d\n", i)
+		if !strings.Contains(combined, needle) {
+			missing = append(missing, i)
+		}
+	}
+	if len(missing) > 0 {
+		preview := missing
+		if len(preview) > 10 {
+			preview = preview[:10]
+		}
+		t.Fatalf("lost %d/%d messages (first missing ids: %v)", len(missing), total, preview)
+	}
+}

--- a/log/log_realpath_test.go
+++ b/log/log_realpath_test.go
@@ -1,0 +1,85 @@
+package log
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestRealPathActualLoss exercises the production Initialize/Close path with
+// the logFileName var pointed at a temp directory, and reports any Printf
+// that lands in neither the log file nor captured stderr.
+//
+// Pre-fix (#642): the close-before-SetOutput ordering leaves a window where
+// Printfs in flight when globalLogFile.Close() runs write to a closed fd and
+// disappear. On the buggy code this test reports "actually lost (nowhere): N"
+// with N > 0. Post-fix N is always zero.
+//
+// Burst pattern (one Printf per goroutine, gated by a shared channel) is
+// what makes the window observable — it maximizes the number of in-flight
+// Printfs at the moment Close races them.
+func TestRealPathActualLoss(t *testing.T) {
+	tmpDir := t.TempDir()
+	origLogFileName := logFileName
+	logFileName = filepath.Join(tmpDir, "actual.log")
+	t.Cleanup(func() { logFileName = origLogFileName })
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	stderrCh := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		stderrCh <- b
+	}()
+
+	const burst = 3000
+
+	Initialize(false)
+
+	var totalWrites int64
+	var wg sync.WaitGroup
+	wg.Add(burst)
+	startGate := make(chan struct{})
+	for g := 0; g < burst; g++ {
+		go func(gid int) {
+			defer wg.Done()
+			<-startGate
+			// Hit all three loggers so the race covers Info / Warning / Error.
+			InfoLog.Printf("REALPATH I g=%d", gid)
+			WarningLog.Printf("REALPATH W g=%d", gid)
+			ErrorLog.Printf("REALPATH E g=%d", gid)
+			atomic.AddInt64(&totalWrites, 3)
+		}(g)
+	}
+	close(startGate)
+	Close()
+	wg.Wait()
+
+	_ = w.Close()
+	capturedStderr := <-stderrCh
+
+	fileContent, err := os.ReadFile(logFileName)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+
+	inFile := int64(strings.Count(string(fileContent), "REALPATH "))
+	inStderr := int64(strings.Count(string(capturedStderr), "REALPATH "))
+	totalFound := inFile + inStderr
+
+	lost := totalWrites - totalFound
+	if lost != 0 {
+		t.Fatalf("actually lost (nowhere): %d (wrote=%d, in file=%d, in stderr=%d)",
+			lost, totalWrites, inFile, inStderr)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #642. Fixes a regression of #358.

`log.Close()` calls `globalLogFile.Close()` and *then* calls `SetOutput(os.Stderr)` on each package logger. Any `Printf` that begins between the two calls writes to a closed fd — `os.File.Write` returns `EBADF`, `log.Logger.Output` silently discards the error, and the message disappears. The race window is brief but reliably observable under load: auto-update errors, post-worktree hooks, and any background goroutine logging during shutdown can vanish.

PR #358 introduced the `SetOutput(os.Stderr)` redirect to avoid drops from goroutines that outlive `Close()`. The redirect is correct; the ordering was wrong.

## Fix

Reorder `Close()` so `SetOutput(os.Stderr)` runs **before** `globalLogFile.Close()`. Each `*log.Logger` has an internal mutex that serializes `SetOutput` against concurrent `Output` calls — a `Printf` either fully precedes the redirect (and completes its write to the still-open file) or fully follows it (and writes to stderr). After all three loggers have been redirected, closing the fd is safe.

Same race exists in `Initialize()` when it is called more than once (which happens on every `api/tasks.go` / `api/sessions.go` handler, and `task/runner.go`): the old `globalLogFile` is closed *before* the new loggers are assigned at lines 85-87, with an `os.OpenFile` call in between widening the window. Mirrored the same SetOutput-before-close reorder there. After reassignment, further Printfs see the new loggers; any goroutine still holding the old logger pointer falls through to stderr instead of a closed fd.

## Audit

Grepped the repo for `log.New` / `SetOutput` / `globalLogFile` / `log.Close()`.

- Production mutation of logger outputs lives only in `log/log.go` — `Initialize` and `Close`. Both fixed.
- All remaining `log.New` / `SetOutput` hits (`session/backend_test.go`, `session/tmux/tmux_test.go`, `session/tmux/detach_slow_test.go`, `daemon/daemon_test.go`, `session/git/worktree_test.go`, `ui/preview_test.go`, `autoupdate_test.go`) are test capture/restore patterns. They reassign loggers to a `bytes.Buffer` and restore on `t.Cleanup` — no goroutines racing with `Close()`, no fd to drop.
- `log.SetFlags` (`log.go:79`) only sets stdlib default-logger flags, unrelated.

## Tests

Three new race-pattern tests in `log/`:

- `log/log_realpath_test.go` / `TestRealPathActualLoss` — production `Initialize`/`Close` path with `logFileName` overridden to a temp dir, 3000 goroutines x 3 Printfs (`Info`/`Warning`/`Error`) gated by a shared channel, `Close()` races the burst. Reports drops in the mandated `"actually lost (nowhere): N"` format.
- `log/log_race_test.go` / `TestCloseRaceConcurrentPrintf` — 100 iterations of 200-goroutine bursts, asserts total Printf count matches markers found in log file + stderr.
- `log/log_race_test.go` / `TestCloseRaceSingleBurst` — single-burst variant that names specific missing message ids, for easier debug on failure.

All three were verified to **fail** on the pre-fix code with deterministic loss (e.g. `actually lost (nowhere): 293 (wrote=9000)`), and **pass** on the fix under `-race` over multiple repeats.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./...` (`TestSigtermFallback_DeadPID` fails identically on master in this environment — ambient `af --daemon` processes — unrelated)
- [x] `go test -race -count=3 ./log/...` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `deadcode -test ./...` clean
- [x] New tests fail on reverted Close + pass on fix

Co-Authored-By: Captain Claude <noreply@anthropic.com>