### PR TITLE
fix(session/hooks): validate remote session exists before marking restored instance as Ready (#645)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,6 +18,12 @@ import (
 
 	"github.com/creack/pty"
 )
+
+// restoreAliveTimeout bounds how long we wait for list_cmd to report on
+// whether a persisted remote session still exists. list_cmd is user-supplied
+// and may block on network/SSH; the restore path runs at TUI startup for
+// every persisted instance, so an unbounded wait would stall the TUI.
+const restoreAliveTimeout = 2 * time.Second
 
 // HookBackend implements Backend by delegating to user-provided shell scripts.
 type HookBackend struct {
@@ -110,8 +117,17 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 	}
 
 	if !firstTimeSetup {
-		// Restoring from storage — just reconnect the preview PTY.
-		b.ensurePTY(i)
+		// Restoring from storage. Before marking the instance started,
+		// confirm that the remote session reported by list_cmd still
+		// exists. Without this check, deleted/expired remote sessions
+		// were restored and shown with a green Ready dot in the sidebar
+		// even though attaching was a silent no-op (#645).
+		if !b.isAliveWithTimeout(i, restoreAliveTimeout) {
+			return fmt.Errorf("remote session %q no longer exists in list_cmd output", i.Title)
+		}
+		if err := b.ensurePTY(i); err != nil {
+			return fmt.Errorf("failed to start preview process: %w", err)
+		}
 		i.mu.Lock()
 		i.started = true
 		i.mu.Unlock()
@@ -148,7 +164,12 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 	i.started = true
 	i.mu.Unlock()
 
-	b.ensurePTY(i)
+	if err := b.ensurePTY(i); err != nil {
+		// launch_cmd succeeded so the remote session itself is alive; we
+		// just couldn't spin up the preview process. Log and continue —
+		// the user can still attach interactively.
+		log.WarningLog.Printf("hook backend: preview process failed for %s: %v", i.Title, err)
+	}
 	return nil
 }
 
@@ -268,7 +289,14 @@ func (b *HookBackend) Attach(i *Instance) (chan struct{}, error) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		defer b.ensurePTY(i) // restart preview process after detach
+		defer func() {
+			// Restart preview process after detach. Failure is non-fatal —
+			// the user can still re-attach interactively; we just lose the
+			// background preview snapshot.
+			if err := b.ensurePTY(i); err != nil {
+				log.WarningLog.Printf("hook backend: preview process failed to restart for %s: %v", i.Title, err)
+			}
+		}()
 
 		slug := hookNameForInstance(i)
 		cmd := exec.Command(b.Hooks.AttachCmd, slug)
@@ -301,7 +329,14 @@ func (b *HookBackend) SetPreviewSize(_ *Instance, _, _ int) error {
 }
 
 func (b *HookBackend) IsAlive(i *Instance) bool {
-	out, err := exec.Command(b.Hooks.ListCmd, "--json").CombinedOutput()
+	return b.isAliveWithTimeout(i, 0)
+}
+
+// isAliveWithTimeout asks list_cmd whether the remote session backing i is
+// currently running. A non-zero timeout bounds the wait; zero means "no
+// timeout" (matches the legacy IsAlive behavior used by the metadata tick).
+func (b *HookBackend) isAliveWithTimeout(i *Instance, timeout time.Duration) bool {
+	out, err := b.runListCmd(timeout)
 	if err != nil {
 		return false
 	}
@@ -324,6 +359,22 @@ func (b *HookBackend) IsAlive(i *Instance) bool {
 		}
 	}
 	return false
+}
+
+func (b *HookBackend) runListCmd(timeout time.Duration) ([]byte, error) {
+	if timeout <= 0 {
+		return exec.Command(b.Hooks.ListCmd, "--json").CombinedOutput()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, b.Hooks.ListCmd, "--json")
+	// WaitDelay bounds how long CombinedOutput keeps reading from the
+	// command's stdout/stderr after the context is cancelled. Without it,
+	// a list_cmd script that spawned a long-running child (e.g. `sleep
+	// 30`) would keep the read-side pipe open past the kill signal sent
+	// to the script itself, defeating the restore-path timeout (#645).
+	cmd.WaitDelay = 500 * time.Millisecond
+	return cmd.CombinedOutput()
 }
 
 func (b *HookBackend) CheckAndHandleTrustPrompt(_ *Instance) bool {
@@ -453,7 +504,7 @@ func runHookAttachWithDetach(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.W
 
 // --- Process management for preview capture ---
 
-func (b *HookBackend) ensurePTY(i *Instance) {
+func (b *HookBackend) ensurePTY(i *Instance) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -468,7 +519,7 @@ func (b *HookBackend) ensurePTY(i *Instance) {
 		alive := !existing.closed
 		existing.mu.Unlock()
 		if alive {
-			return
+			return nil
 		}
 		delete(b.ptys, i.Title)
 	}
@@ -483,8 +534,7 @@ func (b *HookBackend) ensurePTY(i *Instance) {
 	// the user attaches interactively.)
 	stdoutR, stdoutW, err := os.Pipe()
 	if err != nil {
-		log.ErrorLog.Printf("failed to create pipe for preview of %s: %v", i.Title, err)
-		return
+		return fmt.Errorf("create pipe for preview of %s: %w", i.Title, err)
 	}
 	cmd.Stdout = stdoutW
 	cmd.Stderr = stdoutW
@@ -492,8 +542,7 @@ func (b *HookBackend) ensurePTY(i *Instance) {
 	if err := cmd.Start(); err != nil {
 		_ = stdoutR.Close()
 		_ = stdoutW.Close()
-		log.ErrorLog.Printf("failed to start attach_cmd for preview of %s: %v", i.Title, err)
-		return
+		return fmt.Errorf("start attach_cmd for preview of %s: %w", i.Title, err)
 	}
 	// Close the write end in the parent so reads get EOF when the child exits.
 	_ = stdoutW.Close()
@@ -538,6 +587,7 @@ func (b *HookBackend) ensurePTY(i *Instance) {
 		hp.closed = true
 		hp.mu.Unlock()
 	}()
+	return nil
 }
 
 func (b *HookBackend) closePTY(title string) {

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -273,6 +273,90 @@ func TestHookBackendStartRestore(t *testing.T) {
 	b.closePTY(i.Title)
 }
 
+// TestHookBackendStartRestoreDeadSession is a regression test for #645:
+// when list_cmd no longer reports the persisted remote session, Start in
+// the restore branch must return an error rather than silently marking the
+// instance as Ready. Without this guard, deleted/expired remote sessions
+// were restored with a green Ready dot in the sidebar even though attaching
+// was a silent no-op.
+func TestHookBackendStartRestoreDeadSession(t *testing.T) {
+	// list_cmd reports a different session, so our instance looks "dead".
+	b := makeHooksWithListName(t, "some-other-session")
+	i := &Instance{
+		Title:   "test-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	err := b.Start(i, false)
+	require.Error(t, err, "restore must fail when list_cmd does not report the session")
+	assert.Contains(t, err.Error(), "no longer exists")
+	assert.False(t, i.Started(), "instance must not be marked Started when remote session is gone")
+}
+
+// TestHookBackendStartRestoreListCmdFails covers the second leg of #645:
+// when list_cmd itself fails (e.g. network/auth error), we treat the
+// session as not-alive and refuse to mark it Started rather than
+// optimistically restoring a possibly-dead session.
+func TestHookBackendStartRestoreListCmdFails(t *testing.T) {
+	dir := t.TempDir()
+	listCmd := writeScript(t, dir, "list.sh", `exit 1`)
+	attachCmd := writeScript(t, dir, "attach.sh", `echo "attached"; sleep 0.1`)
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{
+			ListCmd:   listCmd,
+			AttachCmd: attachCmd,
+		},
+	}
+	i := &Instance{
+		Title:   "test-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	err := b.Start(i, false)
+	require.Error(t, err)
+	assert.False(t, i.Started())
+}
+
+// TestHookBackendStartRestoreListCmdHangs covers the timeout path: when
+// list_cmd takes longer than restoreAliveTimeout, restore must return an
+// error rather than blocking the TUI startup indefinitely for every
+// persisted instance (#645).
+func TestHookBackendStartRestoreListCmdHangs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timeout-bound test in short mode")
+	}
+
+	dir := t.TempDir()
+	// Sleep long enough that the 2s restoreAliveTimeout fires first.
+	listCmd := writeScript(t, dir, "list.sh", `sleep 30; echo '[]'`)
+	attachCmd := writeScript(t, dir, "attach.sh", `echo "attached"; sleep 0.1`)
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{
+			ListCmd:   listCmd,
+			AttachCmd: attachCmd,
+		},
+	}
+	i := &Instance{
+		Title:   "test-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	start := time.Now()
+	err := b.Start(i, false)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.False(t, i.Started())
+	// The bound is the TUI startup latency promise: even with a hung
+	// list_cmd, restore must return within a small multiple of
+	// restoreAliveTimeout.
+	assert.Less(t, elapsed, 5*time.Second,
+		"restore must abort within timeout when list_cmd hangs (got %v)", elapsed)
+}
+
 func TestHookBackendStartEmptyTitle(t *testing.T) {
 	b := makeHooks(t)
 	i := &Instance{


### PR DESCRIPTION
## Summary

Fixes #645. `HookBackend.Start(i, firstTimeSetup=false)` used to always return `nil` and mark the instance started even when the remote session had been deleted/expired, so dead remote sessions showed up in the sidebar with a green Ready dot and silently no-op'd on attach.

- Restore branch now calls `list_cmd` via a bounded `isAliveWithTimeout(2s)` before marking the instance started; if the session isn't reported running, restore returns an error and the higher-level loader (`storage.LoadInstances` / `sync.refresh*`) skips the dead instance instead of resurrecting it.
- The 2s bound caps TUI-startup latency per persisted instance even when `list_cmd` is a slow user script; `cmd.WaitDelay = 500ms` ensures `CombinedOutput` actually returns when the deadline fires (otherwise a script that forks a long-running child would keep the read pipe open past the kill).
- `ensurePTY` now returns an error instead of silently swallowing `os.Pipe`/`cmd.Start` failures (Detail Bot follow-up). The restore path propagates it; first-time setup and the post-detach restart in `Attach()` log-and-continue (the remote session itself is alive — only preview capture failed).

Audited all restore call sites — `storage.LoadInstances`, `app/sync.go` (pending/refresh/import), `daemon/control.go`, `api/api.go`, `app/session_control.go` — they all delegate through `Instance.Start(false) → HookBackend.Start(_, false)`, so the single fix covers every restore path.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `deadcode -test ./...` clean
- [x] `go test -race ./...` — all packages green except the pre-existing `TestSigtermFallback_DeadPID` flake (caused by stale `af --daemon` processes on the dev host, not by this change)
- [x] New regression tests in `session/backend_test.go`:
  - `TestHookBackendStartRestoreDeadSession` — `list_cmd` reports a different name → restore fails and `Started()` stays false
  - `TestHookBackendStartRestoreListCmdFails` — `list_cmd` exits non-zero → restore refuses to mark Started
  - `TestHookBackendStartRestoreListCmdHangs` — `list_cmd` sleeps past the timeout → restore aborts within ~2.5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)