### PR TITLE
fix(ui/list): clamp titleText to empty when widthAvail is non-positive to prevent sidebar overflow at narrow widths (#646)

### DIFF
--- a/ui/list.go
+++ b/ui/list.go
@@ -84,7 +84,12 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		titleText = "[remote] " + titleText
 	}
 	widthAvail := r.width - 3 - runewidth.StringWidth(prefix) - 1
-	if widthAvail > 0 && runewidth.StringWidth(titleText) > widthAvail {
+	if widthAvail <= 0 {
+		// No room for any title text at this width; render just the prefix.
+		// lipgloss.Place doesn't clip oversize content, so leaving titleText
+		// intact here would spill past sidebarW (#646).
+		titleText = ""
+	} else if runewidth.StringWidth(titleText) > widthAvail {
 		// Drop the "..." tail when the container is too narrow to fit it,
 		// otherwise runewidth.Truncate returns content wider than widthAvail
 		// and lipgloss.Place won't clip the overflow.
@@ -93,6 +98,19 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 			tail = ""
 		}
 		titleText = runewidth.Truncate(titleText, widthAvail, tail)
+	}
+	// At very narrow widths (sidebarW ≤ 11, r.width ≤ 9) the row would still
+	// overflow sidebarW even with the bot's titleText="" fix above:
+	// titleStyle.Padding(1,1,0,1) and descStyle's matching horizontal padding
+	// each add 2 cells beyond r.width, exceeding the 10% buffer that
+	// AdjustPreviewWidth carves out below sidebarW. JoinVertical then pads the
+	// shorter title row up to the wider branchLine row, so the row spills past
+	// the sidebar container. Drop horizontal padding on both styles at narrow
+	// widths so the rendered row stays inside sidebarW (#646). Keep the top
+	// padding line so the existing test's line indexing still works.
+	if r.width <= 9 {
+		titleS = titleS.PaddingLeft(0).PaddingRight(0)
+		descS = descS.PaddingLeft(0).PaddingRight(0)
 	}
 	title := titleS.Render(lipgloss.JoinHorizontal(
 		lipgloss.Left,

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -362,9 +362,21 @@ func TestInstanceRendererNarrowTerminalNoOverflow(t *testing.T) {
 		{name: "width42", terminalW: 42, expectNoOverflow: true, expectNoTitleTail: true},
 		{name: "width41", terminalW: 41, expectNoOverflow: true, expectNoTitleTail: true},
 		{name: "width40", terminalW: 40, expectNoOverflow: true, expectNoTitleTail: true},
-		// Even narrower — widthAvail <= 0 so the truncation block is skipped,
-		// but the row must still not contain a stray "..." artifact.
-		{name: "width30", terminalW: 30, expectNoTitleTail: true},
+		// Bug range from #646: widthAvail goes non-positive so the
+		// truncation block used to be skipped entirely and the rendered
+		// row spilled past sidebarW. Sweep 30..39 inclusive — every row
+		// must fit within the sidebar container width and must not leave
+		// a stray "..." artifact.
+		{name: "width39", terminalW: 39, expectNoOverflow: true, expectNoTitleTail: true},
+		{name: "width38", terminalW: 38, expectNoOverflow: true, expectNoTitleTail: true},
+		{name: "width37", terminalW: 37, expectNoOverflow: true, expectNoTitleTail: true},
+		{name: "width36", terminalW: 36, expectNoOverflow: true, expectNoTitleTail: true},
+		{name: "width35", terminalW: 35, expectNoOverflow: true, expectNoTitleTail: true},
+		{name: "width34", terminalW: 34, expectNoOverflow: true, expectNoTitleTail: true},
+		{name: "width33", terminalW: 33, expectNoOverflow: true, expectNoTitleTail: true},
+		{name: "width32", terminalW: 32, expectNoOverflow: true, expectNoTitleTail: true},
+		{name: "width31", terminalW: 31, expectNoOverflow: true, expectNoTitleTail: true},
+		{name: "width30", terminalW: 30, expectNoOverflow: true, expectNoTitleTail: true},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Fixes #646. At terminal widths 30-39, `InstanceRenderer.Render` in `ui/list.go` skipped truncation when `widthAvail <= 0`. Since `lipgloss.Place` does not clip oversize content, the full instance title rendered past both `r.width` and `sidebarW`, spilling into the main pane.

- Apply the bot's recommended fix: clamp `titleText` to empty when `widthAvail <= 0`.
- Drop horizontal padding on `titleS`/`descS` when `r.width <= 9` (sidebarW ≤ 11). Even with empty title text the row would still overflow sidebarW by 1-2 cells because `titleStyle.Padding(1,1,0,1)` and the matching descStyle horizontal padding each add 2 cells beyond `r.width`, exceeding the 10% buffer `AdjustPreviewWidth` carves out below `sidebarW`. `JoinVertical` then pads the title row up to the wider branchLine row, so the sidebar boundary is still crossed. The top padding line is preserved so existing test line indexing keeps working.

## Tests

Extended `TestInstanceRendererNarrowTerminalNoOverflow` in `ui/sidebar_test.go` with a sweep of terminal widths 30..39 inclusive (the affected range), each asserting `expectNoOverflow: true` (line width ≤ sidebarW). Width 30 was previously present but had the `expectNoOverflow` assertion omitted — restored.

```
$ go test ./ui/ -run TestInstanceRendererNarrowTerminalNoOverflow -v
... all 16 subtests pass (widths 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 50, 80)
```

`gofmt -l .`, `go build ./...`, `golangci-lint run --timeout=3m --fast`, and `deadcode -test ./...` all clean. Full `go test -race ./...` passes for every package except `daemon/TestSigtermFallback_DeadPID`, which is environment-sensitive (the dev machine has live `af --daemon` PIDs the test does not expect) and unrelated to this change.

## Audit — other `ui/` sites with derived widths

Per the issue's request, I audited every place in `ui/` that computes a derived width from a parent dimension and could go non-positive. The following three sites share the same "skip-truncate-when-non-positive" anti-pattern that caused #646 and are worth a follow-up issue. **They are out of scope for this PR** which is intentionally limited to `InstanceRenderer.Render` per the bug report.

1. **`ui/list.go:152-159` — PR text truncation.** `prMaxWidth := r.width - len(prefix) - 2`; guarded by `if prMaxWidth > 0`. Same anti-pattern: at narrow widths where `prMaxWidth <= 0`, the truncation is skipped and the full PR text renders unmodified. The existing `TestInstanceRendererNarrowTerminalPRNoTail` already exercises the small-but-positive case; the `<= 0` case is unguarded.

2. **`ui/sidebar.go:537-548` — sidebar header text.** `w := AdjustPreviewWidth(s.width)`; guarded by `if w > 0`. Skips truncation when `w <= 0`, leaving e.g. "▼ Instances (N)" intact past the container boundary at extremely narrow widths.

3. **`ui/sidebar.go:473-482` — title bar ("Agent Factory" / auto-yes badge).** `titleWidth := AdjustPreviewWidth(s.width) + 2`; the fixed "Agent Factory" string is never truncated, just placed at the computed width. At very narrow widths it overflows.

Other derived-width sites I scanned (`content_pane.go`, `tabbed_window.go`, `task_pane.go`, `err.go`) are properly guarded — they either early-return on `<= 0`, clamp to 0, or floor at a minimum value (e.g., `wrapWidth < 20`).

## Test plan

- [x] `go test ./ui/ -run TestInstanceRendererNarrowTerminalNoOverflow -v` — all width subtests pass (30 through 80)
- [x] `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `deadcode -test ./...` — clean
- [x] `go test -race ./...` — clean except for environment-sensitive `daemon/TestSigtermFallback_DeadPID` (unrelated)
- [ ] Visual smoke check on a real narrow terminal (do not merge until eyeballed at 30-column width)

Captain Claude