### PR TITLE
fix(config): include config-dir path and comma-separated enum in program validation error (#661)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -73,20 +73,44 @@ type Config struct {
 
 // ValidateProgramEnum returns nil when name is one of tmux.SupportedPrograms.
 // Otherwise it returns a user-facing migration error explaining how to move a
-// legacy "path with flags" value into the new program_overrides map.
+// legacy "path with flags" value into the new program_overrides map. The
+// returned message is wrapped in leading and trailing newlines so that when
+// Cobra prefixes it with "Error: " the body is visually separated from the
+// usage block (see #661).
 func ValidateProgramEnum(field, name string) error {
 	for _, supported := range tmux.SupportedPrograms {
 		if name == supported {
 			return nil
 		}
 	}
+	// Cobra renders this via `fmt.Fprintln(stderr, "Error:", err)` which
+	// adds a single trailing newline. Leading "\n\n" gives a blank line
+	// after the literal "Error:" prefix; trailing "\n" combined with
+	// Fprintln's own newline yields a blank line before "Usage:".
 	return fmt.Errorf(
-		"%s must be one of %v, got %q. To preserve a custom path or flags, set %s to the agent name and move the full command into program_overrides. Example: %q: %q, %q: { %q: %q }",
-		field, tmux.SupportedPrograms, name,
+		"\n\n%s must be one of [%s], got %q. To preserve a custom path or flags, set %s to the agent name and move the full command into program_overrides. Example: \"default_program\": \"claude\", \"program_overrides\": { \"claude\": %q }\n",
+		field, strings.Join(tmux.SupportedPrograms, ", "), name,
 		field,
-		"default_program", tmux.ProgramClaude,
-		"program_overrides", tmux.ProgramClaude, name,
+		name,
 	)
+}
+
+// prettyHomePath returns absPath with the user's home directory prefix
+// collapsed to "~". Used to render config-file paths in user-facing errors
+// without leaking the absolute filesystem layout. Returns absPath unchanged
+// when the home directory cannot be determined or is not a prefix.
+func prettyHomePath(absPath string) string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		return absPath
+	}
+	if absPath == homeDir {
+		return "~"
+	}
+	if strings.HasPrefix(absPath, homeDir+string(filepath.Separator)) {
+		return "~" + absPath[len(homeDir):]
+	}
+	return absPath
 }
 
 // ResolveProgram returns the actual tmux invocation for an agent. When
@@ -234,11 +258,12 @@ func LoadConfig() (*Config, error) {
 		return DefaultConfig(), nil
 	}
 
-	if err := ValidateProgramEnum("config.json: default_program", config.DefaultProgram); err != nil {
+	prettyConfigPath := prettyHomePath(configPath)
+	if err := ValidateProgramEnum(fmt.Sprintf("Config issue in %s: default_program", prettyConfigPath), config.DefaultProgram); err != nil {
 		return nil, err
 	}
 	for key := range config.ProgramOverrides {
-		if err := ValidateProgramEnum("config.json: program_overrides key", key); err != nil {
+		if err := ValidateProgramEnum(fmt.Sprintf("Config issue in %s: program_overrides key", prettyConfigPath), key); err != nil {
 			return nil, err
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -190,8 +190,43 @@ func TestValidateProgramEnum(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "default_program")
 			assert.Contains(t, err.Error(), "program_overrides")
+			// Enum must render comma-separated so the message is readable
+			// when Cobra prefixes it with "Error: " (see #661).
+			assert.Contains(t, err.Error(), "[claude, codex, aider, gemini]")
+			// Leading "\n\n" + trailing "\n" pair with Cobra's "Error: "
+			// prefix and Println-added newline to produce a blank line on
+			// both sides of the message body.
+			assert.True(t, strings.HasPrefix(err.Error(), "\n\n"), "expected leading double newline, got %q", err.Error())
+			assert.True(t, strings.HasSuffix(err.Error(), "\n"), "expected trailing newline, got %q", err.Error())
 		})
 	}
+}
+
+func TestPrettyHomePath(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	t.Run("collapses home prefix to tilde", func(t *testing.T) {
+		assert.Equal(t,
+			"~/.agent-factory/config.json",
+			prettyHomePath(filepath.Join(homeDir, ".agent-factory", "config.json")),
+		)
+	})
+
+	t.Run("returns ~ for exact home dir", func(t *testing.T) {
+		assert.Equal(t, "~", prettyHomePath(homeDir))
+	})
+
+	t.Run("returns input unchanged when no home prefix", func(t *testing.T) {
+		assert.Equal(t, "/tmp/foo/bar", prettyHomePath("/tmp/foo/bar"))
+	})
+
+	t.Run("does not collapse a path that shares a prefix substring with home", func(t *testing.T) {
+		// "/home/alice-other/foo" must not be mangled when home is "/home/alice".
+		// Build the sibling by appending a suffix to the home basename.
+		sibling := homeDir + "-other/foo"
+		assert.Equal(t, sibling, prettyHomePath(sibling))
+	})
 }
 
 func TestResolveProgram(t *testing.T) {
@@ -419,6 +454,30 @@ func TestLoadConfig(t *testing.T) {
 		assert.Contains(t, err.Error(), "default_program")
 		assert.Contains(t, err.Error(), "program_overrides")
 		assert.Contains(t, err.Error(), legacy)
+	})
+
+	t.Run("error references home-relative config path", func(t *testing.T) {
+		// Set AGENT_FACTORY_HOME under $HOME so prettyHomePath collapses it
+		// to a ~/-rooted string in the error message (see #661).
+		homeDir, err := os.UserHomeDir()
+		require.NoError(t, err)
+		tmpUnderHome, err := os.MkdirTemp(homeDir, "agent-factory-test-")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.RemoveAll(tmpUnderHome) })
+
+		t.Setenv("AGENT_FACTORY_HOME", tmpUnderHome)
+		configDir, err := GetConfigDir()
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(configDir, 0755))
+
+		configPath := filepath.Join(configDir, ConfigFileName)
+		require.NoError(t, os.WriteFile(configPath, []byte(`{"default_program": "amp"}`), 0644))
+
+		cfg, err := LoadConfig()
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), "Config issue in ~/")
+		assert.Contains(t, err.Error(), "default_program")
 	})
 
 	t.Run("rejects unknown agent in default_program", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Renders the program-enum migration error from #659 with a home-relative path (`~/.agent-factory/config.json`), a comma-separated enum (`[claude, codex, aider, gemini]`), and leading/trailing newlines so Cobra's `Error:` / `Usage:` blocks no longer collide with the body.
- All call sites funnel through the existing `config.ValidateProgramEnum(field, name)` helper; only the two `config.go` call sites adopt the new `Config issue in <pretty path>: …` prefix, so `--program flag` and `task program` errors stay unchanged.
- Adds a small `prettyHomePath` helper to collapse the `$HOME` prefix to `~` (no-op when home is not a prefix or `UserHomeDir` fails).

Closes #661.

## Before / After

**Before** (from the issue, run with a legacy config under `AGENT_FACTORY_HOME=$tmpdir`):

```
$ af
wrote logs to /home/matt/.config/agent-factory/agent-factory.log
Error: config.json: default_program must be one of [claude codex aider gemini], got "/home/matt/.local/bin/claude --dangerously-skip-permissions". To preserve a custom path or flags, set config.json: default_program to the agent name and move the full command into program_overrides. Example: "default_program": "claude", "program_overrides": { "claude": "/home/matt/.local/bin/claude --dangerously-skip-permissions" }
Usage:
  af [flags]
...
```

**After** (verified locally with the same legacy config):

```
$ AGENT_FACTORY_HOME=$tmpdir ./af
wrote logs to /home/siyer/.config/agent-factory/agent-factory.log
Error: 

Config issue in ~/af-661-3w3F/config.json: default_program must be one of [claude, codex, aider, gemini], got "/home/matt/.local/bin/claude --dangerously-skip-permissions". To preserve a custom path or flags, set Config issue in ~/af-661-3w3F/config.json: default_program to the agent name and move the full command into program_overrides. Example: "default_program": "claude", "program_overrides": { "claude": "/home/matt/.local/bin/claude --dangerously-skip-permissions" }

Usage:
  af [flags]
...
```

When `AGENT_FACTORY_HOME` is outside `$HOME`, the absolute path is shown verbatim (e.g. `Config issue in /tmp/af-661-outside-KCZY/config.json: …`).

## Call-site audit

All `ValidateProgramEnum` call sites funnel through the same helper. Only the two `config.go` sites get the new path-prefixed label; CLI/task sites are intentionally left as-is.

| File | Line | Field label passed | Touched here? |
|---|---|---|---|
| config/config.go | 261 | `fmt.Sprintf("Config issue in %s: default_program", prettyConfigPath)` | yes |
| config/config.go | 265 | `fmt.Sprintf("Config issue in %s: program_overrides key", prettyConfigPath)` | yes |
| main.go | 74 | `"--program flag"` | no (intentional — non-config error) |
| api/sessions.go | 184 | `"--program flag"` | no |
| api/sessions.go | 319 | `"--program flag"` | no |
| api/tasks.go | 106 | `"--program flag"` | no |
| task/task.go | 130 | `"task program"` | no |
| task/task.go | 231 | `"task program"` | no |

## Note on emoji

User suggested adding ❌ to the error; deferred until owner approval per repo convention against emojis.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `deadcode -test ./...` clean
- [x] `go test -race -count=1 ./config/... ./api/... ./task/... .` green (full-suite `daemon` failure is a pre-existing env issue: two real `af --daemon` PIDs on the dev box interfere with `TestSigtermFallback_DeadPID`, unrelated to this change)
- [x] `TestValidateProgramEnum` now also asserts comma-separated enum + leading `\n\n` + trailing `\n`
- [x] New `TestLoadConfig/error references home-relative config path` subtest exercises the `~/`-collapse path via `AGENT_FACTORY_HOME` under `$HOME`
- [x] New `TestPrettyHomePath` covers the home-prefix collapse, `~` for exact home, no-op for outside-home, and the `homeDir+"-other"` sibling-prefix edge case
- [x] Manually ran built `af` with a legacy `{"default_program": "/home/matt/.local/bin/claude --dangerously-skip-permissions"}` config under both home-rooted and non-home `AGENT_FACTORY_HOME` and confirmed `Error:` is on its own line, blank line follows, enum renders comma-separated, message ends with a blank line before `Usage:`, and no emoji is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)