### PR TITLE
fix(config): keep sentence-internal field reference bare in program validation error (#661)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -181,7 +181,7 @@ var sessionsCreateCmd = &cobra.Command{
 		program := createProgramFlag
 		if program == "" {
 			program = cfg.DefaultProgram
-		} else if err := config.ValidateProgramEnum("--program flag", program); err != nil {
+		} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program); err != nil {
 			return jsonError(err)
 		}
 
@@ -316,7 +316,7 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 			program := sendPromptProgramFlag
 			if program == "" {
 				program = cfg.DefaultProgram
-			} else if err := config.ValidateProgramEnum("--program flag", program); err != nil {
+			} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program); err != nil {
 				return jsonError(err)
 			}
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -103,7 +103,7 @@ var tasksAddCmd = &cobra.Command{
 				return jsonError(err)
 			}
 			program = cfg.DefaultProgram
-		} else if err := config.ValidateProgramEnum("--program flag", program); err != nil {
+		} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program); err != nil {
 			return jsonError(err)
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -73,24 +73,26 @@ type Config struct {
 
 // ValidateProgramEnum returns nil when name is one of tmux.SupportedPrograms.
 // Otherwise it returns a user-facing migration error explaining how to move a
-// legacy "path with flags" value into the new program_overrides map. The
-// returned message is wrapped in leading and trailing newlines so that when
-// Cobra prefixes it with "Error: " the body is visually separated from the
-// usage block (see #661).
-func ValidateProgramEnum(field, name string) error {
+// legacy "path with flags" value into the new program_overrides map.
+//
+// lead is the full label rendered at the start of the message — it may
+// include a path prefix (e.g. "Config issue in ~/.agent-factory/config.json:
+// default_program") to anchor the error to a specific file. referent is the
+// short, sentence-internal name (e.g. "default_program") used in the "set X
+// to the agent name" clause; for non-config call sites lead and referent are
+// the same string. The message is wrapped in leading "\n\n" and trailing
+// "\n" so it visually separates from Cobra's "Error: " prefix and the
+// trailing "Usage:" block (see #661).
+func ValidateProgramEnum(lead, referent, name string) error {
 	for _, supported := range tmux.SupportedPrograms {
 		if name == supported {
 			return nil
 		}
 	}
-	// Cobra renders this via `fmt.Fprintln(stderr, "Error:", err)` which
-	// adds a single trailing newline. Leading "\n\n" gives a blank line
-	// after the literal "Error:" prefix; trailing "\n" combined with
-	// Fprintln's own newline yields a blank line before "Usage:".
 	return fmt.Errorf(
 		"\n\n%s must be one of [%s], got %q. To preserve a custom path or flags, set %s to the agent name and move the full command into program_overrides. Example: \"default_program\": \"claude\", \"program_overrides\": { \"claude\": %q }\n",
-		field, strings.Join(tmux.SupportedPrograms, ", "), name,
-		field,
+		lead, strings.Join(tmux.SupportedPrograms, ", "), name,
+		referent,
 		name,
 	)
 }
@@ -259,11 +261,19 @@ func LoadConfig() (*Config, error) {
 	}
 
 	prettyConfigPath := prettyHomePath(configPath)
-	if err := ValidateProgramEnum(fmt.Sprintf("Config issue in %s: default_program", prettyConfigPath), config.DefaultProgram); err != nil {
+	if err := ValidateProgramEnum(
+		fmt.Sprintf("Config issue in %s: default_program", prettyConfigPath),
+		"default_program",
+		config.DefaultProgram,
+	); err != nil {
 		return nil, err
 	}
 	for key := range config.ProgramOverrides {
-		if err := ValidateProgramEnum(fmt.Sprintf("Config issue in %s: program_overrides key", prettyConfigPath), key); err != nil {
+		if err := ValidateProgramEnum(
+			fmt.Sprintf("Config issue in %s: program_overrides key", prettyConfigPath),
+			"program_overrides key",
+			key,
+		); err != nil {
 			return nil, err
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -170,7 +170,7 @@ func TestDefaultConfig(t *testing.T) {
 func TestValidateProgramEnum(t *testing.T) {
 	for _, name := range tmux.SupportedPrograms {
 		t.Run("accepts "+name, func(t *testing.T) {
-			assert.NoError(t, ValidateProgramEnum("field", name))
+			assert.NoError(t, ValidateProgramEnum("field", "field", name))
 		})
 	}
 
@@ -186,7 +186,11 @@ func TestValidateProgramEnum(t *testing.T) {
 	}
 	for _, tc := range rejectCases {
 		t.Run("rejects "+tc.name, func(t *testing.T) {
-			err := ValidateProgramEnum("default_program", tc.in)
+			err := ValidateProgramEnum(
+				"Config issue in ~/.agent-factory/config.json: default_program",
+				"default_program",
+				tc.in,
+			)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "default_program")
 			assert.Contains(t, err.Error(), "program_overrides")
@@ -198,6 +202,10 @@ func TestValidateProgramEnum(t *testing.T) {
 			// both sides of the message body.
 			assert.True(t, strings.HasPrefix(err.Error(), "\n\n"), "expected leading double newline, got %q", err.Error())
 			assert.True(t, strings.HasSuffix(err.Error(), "\n"), "expected trailing newline, got %q", err.Error())
+			// The "set X to the agent name" clause uses the bare referent,
+			// not the path-prefixed lead.
+			assert.Contains(t, err.Error(), "set default_program to the agent name")
+			assert.NotContains(t, err.Error(), "set Config issue in")
 		})
 	}
 }
@@ -478,6 +486,8 @@ func TestLoadConfig(t *testing.T) {
 		assert.Nil(t, cfg)
 		assert.Contains(t, err.Error(), "Config issue in ~/")
 		assert.Contains(t, err.Error(), "default_program")
+		// Sentence-internal referent stays bare — no path prefix mid-sentence.
+		assert.Contains(t, err.Error(), "set default_program to the agent name")
 	})
 
 	t.Run("rejects unknown agent in default_program", func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ var (
 			// or flag overrides belong in program_overrides.
 			program := cfg.DefaultProgram
 			if programFlag != "" {
-				if err := config.ValidateProgramEnum("--program flag", programFlag); err != nil {
+				if err := config.ValidateProgramEnum("--program flag", "--program flag", programFlag); err != nil {
 					return err
 				}
 				program = programFlag

--- a/task/task.go
+++ b/task/task.go
@@ -127,7 +127,7 @@ func AddTask(t Task) error {
 	// Empty Program means "fall back to the configured default_program at
 	// run time"; only validate when an explicit per-task override was set.
 	if t.Program != "" {
-		if err := config.ValidateProgramEnum("task program", t.Program); err != nil {
+		if err := config.ValidateProgramEnum("task program", "task program", t.Program); err != nil {
 			return err
 		}
 	}
@@ -228,7 +228,7 @@ func UpdateTask(t Task) error {
 	// Empty Program means "fall back to the configured default_program at
 	// run time"; only validate when an explicit per-task override was set.
 	if t.Program != "" {
-		if err := config.ValidateProgramEnum("task program", t.Program); err != nil {
+		if err := config.ValidateProgramEnum("task program", "task program", t.Program); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up to #662 (merged) addressing the review feedback that the single-arg `ValidateProgramEnum(field, name)` shape routed the path-prefixed label through the message twice, producing:

> "To preserve a custom path or flags, set **Config issue in ~/.agent-factory/config.json: default_program** to the agent name and move the full command into program_overrides."

The sentence-internal referent should stay bare.

This PR splits the helper into `ValidateProgramEnum(lead, referent, name string)`:

- `lead` anchors the opening clause to a specific file/flag (e.g. `Config issue in ~/.agent-factory/config.json: default_program`).
- `referent` is the bare sentence-internal name (e.g. `default_program`) used in "set X to the agent name".
- For the two `config.go` call sites `lead` carries the path prefix while `referent` stays bare.
- For the six CLI/task call sites `lead` and `referent` are the same string (`--program flag` / `task program`), so their wording is unchanged.

(This should have been part of #662; PR #662 was squash-merged while I was rewriting the helper based on the review.)

## Before / After

**Before** (now on master from #662):

```
Error: 

Config issue in ~/.agent-factory/config.json: default_program must be one of [claude, codex, aider, gemini], got "/home/matt/.local/bin/claude --dangerously-skip-permissions". To preserve a custom path or flags, set Config issue in ~/.agent-factory/config.json: default_program to the agent name and move the full command into program_overrides. Example: "default_program": "claude", "program_overrides": { "claude": "/home/matt/.local/bin/claude --dangerously-skip-permissions" }

Usage:
  af [flags]
...
```

**After** (verified locally):

```
Error: 

Config issue in ~/af-661-HVDH/config.json: default_program must be one of [claude, codex, aider, gemini], got "/home/matt/.local/bin/claude --dangerously-skip-permissions". To preserve a custom path or flags, set default_program to the agent name and move the full command into program_overrides. Example: "default_program": "claude", "program_overrides": { "claude": "/home/matt/.local/bin/claude --dangerously-skip-permissions" }

Usage:
  af [flags]
...
```

(`AGENT_FACTORY_HOME` outside `$HOME` still shows the absolute path verbatim — `Config issue in /tmp/af-661-outside-tWzo/config.json: …` — also verified.)

## Call-site audit

| File | Line | Lead | Referent |
|---|---|---|---|
| config/config.go | 264 | `fmt.Sprintf("Config issue in %s: default_program", prettyConfigPath)` | `"default_program"` |
| config/config.go | 272 | `fmt.Sprintf("Config issue in %s: program_overrides key", prettyConfigPath)` | `"program_overrides key"` |
| main.go | 74 | `"--program flag"` | `"--program flag"` |
| api/sessions.go | 184 | `"--program flag"` | `"--program flag"` |
| api/sessions.go | 319 | `"--program flag"` | `"--program flag"` |
| api/tasks.go | 106 | `"--program flag"` | `"--program flag"` |
| task/task.go | 130 | `"task program"` | `"task program"` |
| task/task.go | 231 | `"task program"` | `"task program"` |

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `golangci-lint run --timeout=3m --fast` clean
- [x] `deadcode -test ./...` clean
- [x] `go test -race -count=1 ./...` green (the `daemon` `TestSigtermFallback_DeadPID` failure is a pre-existing env issue: two real `af --daemon` PIDs on the dev box interfere with the test — unrelated to this change)
- [x] `TestValidateProgramEnum` now passes both `lead` and `referent`, asserts `set default_program to the agent name` is present and `set Config issue in` is **not** present in the error
- [x] `TestLoadConfig/error references home-relative config path` also asserts `set default_program to the agent name`
- [x] Manually ran built `af` with a legacy `{"default_program": "/home/matt/.local/bin/claude --dangerously-skip-permissions"}` config under both home-rooted and non-home `AGENT_FACTORY_HOME` and confirmed the rendered output above

🤖 Generated with [Claude Code](https://claude.com/claude-code)