### PR TITLE
fix(task): skip Program validation on internal status updates (#664)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -650,14 +650,12 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 			return instanceStartedMsg{instance: instance, err: err}
 		}
 
-		// Update task last run status.
-		if t, err := task.GetTask(taskID); err == nil {
-			now := time.Now()
-			t.LastRunAt = &now
-			t.LastRunStatus = "triggered"
-			if err := task.UpdateTask(*t); err != nil {
-				log.ErrorLog.Printf("failed to update task status: %v", err)
-			}
+		// Update task last run status. UpdateTaskStatus skips Program enum
+		// validation so legacy task records (pre-#658) still receive status
+		// bumps; see #664.
+		now := time.Now()
+		if err := task.UpdateTaskStatus(taskID, &now, "triggered"); err != nil {
+			log.ErrorLog.Printf("failed to update task status: %v", err)
 		}
 
 		return instanceStartedMsg{instance: instance, started: started, err: nil}

--- a/task/runner.go
+++ b/task/runner.go
@@ -230,11 +230,11 @@ func RunTask(taskID string) error {
 		return fmt.Errorf("failed to start task session: %w", err)
 	}
 
-	// Update task status.
+	// Update task status. Use UpdateTaskStatus so we don't re-validate Program
+	// — the task already ran via daemon.CreateSession, and the stored Program
+	// value may predate current enum validation (see #664).
 	now := time.Now()
-	t.LastRunAt = &now
-	t.LastRunStatus = "started"
-	if err := UpdateTask(*t); err != nil {
+	if err := UpdateTaskStatus(taskID, &now, "started"); err != nil {
 		log.ErrorLog.Printf("failed to update task status: %v", err)
 	}
 

--- a/task/task.go
+++ b/task/task.go
@@ -221,6 +221,44 @@ func LoadTasksForCurrentRepo() ([]Task, error) {
 	return filtered, nil
 }
 
+// UpdateTaskStatus updates only the LastRunAt and LastRunStatus fields of the
+// task with the given ID. Unlike UpdateTask, it does not re-validate other
+// fields (notably Program), so pre-existing tasks whose Program value would
+// fail current enum validation can still have their run status bumped by the
+// scheduler and TUI dispatch paths. Returns an error if no task with the given
+// ID exists.
+func UpdateTaskStatus(taskID string, lastRunAt *time.Time, lastRunStatus string) error {
+	if err := ValidateTaskID(taskID); err != nil {
+		return err
+	}
+	path, err := getTasksPathFn()
+	if err != nil {
+		return err
+	}
+	return config.WithFileLock(path, func() error {
+		tasks, err := LoadTasks()
+		if err != nil {
+			return err
+		}
+
+		found := false
+		for i := range tasks {
+			if tasks[i].ID == taskID {
+				tasks[i].LastRunAt = lastRunAt
+				tasks[i].LastRunStatus = lastRunStatus
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("task with id %q not found", taskID)
+		}
+
+		return saveTasks(tasks)
+	})
+}
+
 func UpdateTask(t Task) error {
 	if err := ValidateTaskID(t.ID); err != nil {
 		return err

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -305,6 +305,55 @@ func TestUpdateTask_RejectsInvalidID(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid task id")
 }
 
+// TestUpdateTaskStatus_BypassesProgramValidation is the regression guard for
+// #664: scheduler/TUI status bumps must succeed on tasks whose stored Program
+// value would now fail enum validation (e.g. a legacy absolute path created
+// before #658 introduced the enum check).
+func TestUpdateTaskStatus_BypassesProgramValidation(t *testing.T) {
+	stored := []Task{
+		{ID: "legacy1", Name: "Pre-#658", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: "/tmp", Program: "/home/foo/bin/claude", Enabled: true},
+	}
+	setupTestTasks(t, stored)
+
+	now := time.Now().Truncate(time.Second)
+	require.NoError(t, UpdateTaskStatus("legacy1", &now, "started"))
+
+	got, err := GetTask("legacy1")
+	require.NoError(t, err)
+	require.NotNil(t, got.LastRunAt)
+	assert.True(t, got.LastRunAt.Equal(now))
+	assert.Equal(t, "started", got.LastRunStatus)
+	assert.Equal(t, "/home/foo/bin/claude", got.Program, "Program must not be touched by status updates")
+}
+
+// TestUpdateTaskStatus_NotFound verifies the not-found error path that the
+// runner / TUI rely on to log a meaningful failure when a task is deleted
+// mid-run.
+func TestUpdateTaskStatus_NotFound(t *testing.T) {
+	setupTestTasks(t, []Task{{ID: "exists"}})
+
+	now := time.Now()
+	err := UpdateTaskStatus("missing", &now, "started")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestUpdateTask_RejectsBadProgram is the regression guard that #664's fix
+// does NOT loosen validation on the user-edit path: UpdateTask must still
+// reject a non-enum Program so the TUI/CLI editor flows fail fast.
+func TestUpdateTask_RejectsBadProgram(t *testing.T) {
+	stored := []Task{
+		{ID: "edit1", Name: "Editable", Program: "claude", Enabled: true},
+	}
+	setupTestTasks(t, stored)
+
+	bad := stored[0]
+	bad.Program = "/home/foo/bin/claude"
+	err := UpdateTask(bad)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task program")
+}
+
 func TestTaskNameInJSON(t *testing.T) {
 	s := Task{ID: "n1", Name: "My Task", Prompt: "do things"}
 	data, err := json.Marshal(s)


### PR DESCRIPTION
## Root cause

#658 added enum validation inside `task.UpdateTask`:

```go
if t.Program != "" {
    if err := config.ValidateProgramEnum("task program", "task program", t.Program); err != nil {
        return err
    }
}
```

That's the correct behavior on **user-edit** paths (TUI sidebar save, `af tasks update`). But two **internal** paths also call `UpdateTask` purely to bump `LastRunAt` / `LastRunStatus` after a session has already started:

- `task/runner.go:237` — post-`daemon.CreateSession` status bump in the scheduler.
- `app/app.go:658` — TUI `instanceStartedMsg` "task triggered" flow.

Pre-#658 tasks whose stored `Program` value would fail the new enum (e.g. an absolute path like `/home/siyer/.local/bin/claude`) ran fine via `daemon.CreateSession` (it takes the value as-is) but the follow-on `UpdateTask` rejected the same record, so every scheduled run logged a noisy error and left status fields stuck at their previous value.

## Fix

Add `task.UpdateTaskStatus(id, lastRunAt, lastRunStatus)` — same file-lock + load + save flow as `UpdateTask`, but mutates only the two status fields and skips Program validation entirely.

Swap the two internal sites to use it. Leave the user-edit sites on `UpdateTask` so the editor flows still reject bad Program values.

## Call-site audit (per CLAUDE.md adjacent-call-sites rule)

`grep -rn "task.UpdateTask\|UpdateTask(" --include="*.go"` — non-test callers:

| Site | Purpose | Action |
|---|---|---|
| `task/runner.go:237` | scheduler status bump after `daemon.CreateSession` succeeds | **switch** to `UpdateTaskStatus` |
| `app/app.go:658` | TUI status bump in `instanceStartedMsg` "triggered" path | **switch** to `UpdateTaskStatus` |
| `app/app.go:510` | TUI sidebar dirty save — user edited the task | **keep** `UpdateTask` (user-edit, must validate) |
| `api/tasks.go:27` (`updateTask = task.UpdateTask`, used by `tasksUpdateCmd`) | CLI `af tasks update` — user editing | **keep** `UpdateTask` (user-edit, must validate) |

`AddTask` (creation, user-supplied) still validates — correct. `LoadTasks` / `LoadTasksForCurrentRepo` don't validate — correct (read path).

## Tests

`task/task_test.go` gains three cases:

- `TestUpdateTaskStatus_BypassesProgramValidation` — stores a task with `Program: "/home/foo/bin/claude"`, asserts `UpdateTaskStatus` succeeds and updates only the two status fields (Program untouched).
- `TestUpdateTaskStatus_NotFound` — covers the "task with id %q not found" error path the scheduler/TUI rely on.
- `TestUpdateTask_RejectsBadProgram` — regression guard that the fix does **not** loosen `UpdateTask`'s validation on the editor paths.

## CI gates

All four gates clean locally on this branch:

- `go build ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go test -race ./...` — all packages pass except `daemon/TestSigtermFallback_DeadPID`, which fails on this host because two real `af --daemon` processes are running locally; the test inspects host process state, unrelated to this change.
- `deadcode -test ./...` — clean

Fixes #664

Co-Authored-By: Captain Claude <noreply@anthropic.com>