### PR TITLE
fix(ui/err): strip carriage returns from rendered error messages (#668)

### DIFF
--- a/ui/err.go
+++ b/ui/err.go
@@ -49,6 +49,11 @@ func (e *ErrBox) String() string {
 		// plain text only — a bespoke regex repeatedly missed variants
 		// (#525 → #552 → #565).
 		err = xansi.Strip(err)
+		// xansi.Strip handles ANSI escapes but leaves bare \r untouched. Hook
+		// scripts commonly emit \r from progress indicators on stderr (see
+		// #668); a \r reaching the terminal moves the cursor back to column 0,
+		// overwriting lipgloss.Place's padding and corrupting the box.
+		err = strings.ReplaceAll(err, "\r", "")
 		lines := strings.Split(err, "\n")
 		err = strings.Join(lines, "//")
 		if runewidth.StringWidth(err) > e.width {

--- a/ui/err_test.go
+++ b/ui/err_test.go
@@ -171,6 +171,23 @@ func TestErrBoxStripsANSIVariants(t *testing.T) {
 	}
 }
 
+// TestErrBoxStripsCarriageReturns is a regression test for issue #668. Hook
+// scripts (see session/backend_hook.go, which wraps mixed stdout/stderr from
+// CombinedOutput into error messages) commonly emit \r from progress
+// indicators. A \r reaching the terminal moves the cursor to column 0,
+// overwriting lipgloss.Place's padding and corrupting the error box.
+func TestErrBoxStripsCarriageReturns(t *testing.T) {
+	e := NewErrBox()
+	e.SetSize(40, 1)
+	// Simulate a progress indicator that overwrites itself with \r.
+	e.SetError(errors.New("Loading...\rLoading....\rLoading.....\rReady"))
+
+	out := e.String()
+	if strings.Contains(out, "\r") {
+		t.Errorf("carriage return (\\r) leaked into rendered output, corrupting display: %q", out)
+	}
+}
+
 // stripANSI removes ANSI escape sequences (CSI) so width measurements
 // reflect only visible runes.
 func stripANSI(s string) string {


### PR DESCRIPTION
## Summary

Hook scripts often emit `\r` from progress indicators on stderr. `session/backend_hook.go` wraps the mixed stdout/stderr from `exec.Command(...).CombinedOutput()` directly into error messages (e.g. `launch_cmd failed: %s: %w` with `string(out)`), and those errors then flow into `ErrBox.SetError`. `xansi.Strip` handles ANSI escapes but leaves bare `\r` untouched, so it reaches the terminal and moves the cursor back to column 0 — overwriting `lipgloss.Place`'s centering padding and visually corrupting the error box.

The fix strips `\r` after the ANSI pass and before the newline → `//` normalization, mirroring what `task/systemd.go`'s `sanitizeEnvValue` already does in another context.

## Root cause

Identified by Detail (https://app.detail.dev/.../bug_1be4e24e-...). Introduced in 2a4a67b when newline normalization was added without a matching pass for `\r`. The realistic source path is hook-script progress indicators reaching `ErrBox` via `backend_hook.go`'s `CombinedOutput` → `string(out)` → wrapped error → `errBox.SetError`.

## Adjacent call-sites audit

Per CLAUDE.md, audited every TUI render path that takes externally-sourced strings and routes them into lipgloss/bubbletea:

- `ui/err.go` `ErrBox.String()` — **affected**, receives wrapped errors carrying raw process output. **Fixed.**
- `ui/overlay/textOverlay.go` `NewTextOverlay` — content comes from static `helpType.toContent()` in `app/help.go`. Not affected.
- `ui/overlay/confirmationOverlay.go` `NewConfirmationOverlay` — message comes from `confirmAction(message, ...)` with config-sourced session titles + static strings. Not affected.
- `ui/sidebar.go`, `ui/content_pane.go` — render config-sourced strings (instance titles, branch names) and child component output (already-sanitized). Not affected.

Single-site fix under the ≥3-duplicate-sites threshold; no sanitizer helper introduced.

## Test

Added `TestErrBoxStripsCarriageReturns` (regression test from the Detail report). Simulates a progress indicator (`Loading...\rLoading....\rLoading.....\rReady`) and asserts no `\r` survives into `e.String()`. Fails on master, passes with the fix.

## CI gates (local)

- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go build ./...` — clean
- `go test -race ./...` — all tests pass (one unrelated `daemon/TestSigtermFallback_DeadPID` failure reproduces on stashed master — caused by stray `af --daemon` processes on the dev machine, not by this change)
- `deadcode -test ./...` — clean

## Test plan

- [ ] Trigger a hook-script failure with a progress indicator that uses `\r` (e.g. `printf 'Loading...\rDone\n'; exit 1` in a `launch_cmd`) and confirm the error box renders cleanly without cursor jumping to column 0.
- [ ] Confirm existing ErrBox regression tests (ANSI variants, narrow-width truncation) still pass.

Fixes #668

Co-Authored-By: Captain Claude <noreply@anthropic.com>