### PR TITLE
fix(session/hook): apply 5s timeout to runtime IsAlive (#666)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -23,7 +23,18 @@ import (
 // whether a persisted remote session still exists. list_cmd is user-supplied
 // and may block on network/SSH; the restore path runs at TUI startup for
 // every persisted instance, so an unbounded wait would stall the TUI.
+//
+// The restore path is intentionally aggressive: a session that was alive a
+// moment ago must respond promptly, so 2s is enough to clear out stale
+// entries without dragging out startup.
 const restoreAliveTimeout = 2 * time.Second
+
+// runtimeAliveTimeout bounds steady-state IsAlive checks issued from
+// background ticks (every 3-5s). list_cmd may SSH to remote hosts where
+// transient latency is routine, so this is intentionally more generous than
+// restoreAliveTimeout; the goal is to avoid freezing the TUI on a hanging
+// list_cmd (#666), not to fail fast on slow networks.
+const runtimeAliveTimeout = 5 * time.Second
 
 // HookBackend implements Backend by delegating to user-provided shell scripts.
 type HookBackend struct {
@@ -329,12 +340,15 @@ func (b *HookBackend) SetPreviewSize(_ *Instance, _, _ int) error {
 }
 
 func (b *HookBackend) IsAlive(i *Instance) bool {
-	return b.isAliveWithTimeout(i, 0)
+	return b.isAliveWithTimeout(i, runtimeAliveTimeout)
 }
 
 // isAliveWithTimeout asks list_cmd whether the remote session backing i is
-// currently running. A non-zero timeout bounds the wait; zero means "no
-// timeout" (matches the legacy IsAlive behavior used by the metadata tick).
+// currently running. A non-zero timeout bounds the wait; zero falls through
+// to an unbounded exec, which no production caller should use because
+// IsAlive runs on the TUI event loop and a hanging list_cmd would freeze the
+// UI (#666). Callers must pass either restoreAliveTimeout or
+// runtimeAliveTimeout.
 func (b *HookBackend) isAliveWithTimeout(i *Instance, timeout time.Duration) bool {
 	out, err := b.runListCmd(timeout)
 	if err != nil {

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -357,6 +357,41 @@ func TestHookBackendStartRestoreListCmdHangs(t *testing.T) {
 		"restore must abort within timeout when list_cmd hangs (got %v)", elapsed)
 }
 
+// TestHookBackendIsAliveListCmdHangs is the runtime analogue of
+// TestHookBackendStartRestoreListCmdHangs and the regression test for #666:
+// background reconciliation ticks call IsAlive every 3-5s on the TUI event
+// loop, so a list_cmd that SSHs to a wedged host must not be allowed to
+// freeze the UI indefinitely.
+func TestHookBackendIsAliveListCmdHangs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timeout-bound test in short mode")
+	}
+
+	dir := t.TempDir()
+	// Sleep well past runtimeAliveTimeout so the timeout, not the script,
+	// is what ends the call.
+	listCmd := writeScript(t, dir, "list.sh", `sleep 30; echo '[]'`)
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{ListCmd: listCmd},
+	}
+	i := &Instance{
+		Title:   "test-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	start := time.Now()
+	alive := b.IsAlive(i)
+	elapsed := time.Since(start)
+
+	assert.False(t, alive, "IsAlive must report false when list_cmd hangs past timeout")
+	// runtimeAliveTimeout is 5s; allow a small buffer for WaitDelay (500ms)
+	// plus scheduling slack. The key bound is that IsAlive must NOT block
+	// anywhere near the script's 30s sleep — that was the #666 freeze.
+	assert.Less(t, elapsed, runtimeAliveTimeout+2*time.Second,
+		"IsAlive must return within runtimeAliveTimeout+tolerance when list_cmd hangs (got %v)", elapsed)
+}
+
 func TestHookBackendStartEmptyTitle(t *testing.T) {
 	b := makeHooks(t)
 	i := &Instance{


### PR DESCRIPTION
## Summary
- `HookBackend.IsAlive()` was passing `timeout = 0` to `isAliveWithTimeout`, which `runListCmd` treats as "no timeout" — so a hanging `list_cmd` (e.g. SSH to a wedged remote) could block the TUI event loop indefinitely. Background reconciliation ticks invoke `IsAlive` every 3-5s, so this freeze triggered during routine operation, not only user actions. Reported by Detail Bot in #666.
- Introduce `runtimeAliveTimeout = 5 * time.Second` and pass it from `IsAlive`. Update the stale comment that claimed `0` meant "legacy IsAlive behavior used by the metadata tick" — factually wrong (the metadata tick never calls `IsAlive`) and was the rationale for the bug.

## Why 5s and not `restoreAliveTimeout` (2s)?
- The 2s restore-path bound stays aggressive on purpose: a session that was alive moments ago must respond promptly, and the restore path runs once per persisted instance at startup, so dragging it out hurts every launch.
- The runtime path runs every few seconds against potentially-flaky SSH/network. 5s tolerates routine transient latency without UI hiccups while still cutting off pathological hangs an order of magnitude faster than the 30s+ no-bound behavior.

## Adjacent call-site audit (per `CLAUDE.md`)
Grepped every caller of `runListCmd` / `isAliveWithTimeout` / unbounded `list_cmd` execs:

| Site | Status |
| --- | --- |
| `runListCmd(timeout)` direct callers | Only `isAliveWithTimeout` |
| `isAliveWithTimeout` from `IsAlive` | **Fixed in this PR** → `runtimeAliveTimeout` |
| `isAliveWithTimeout` from `Start` restore path | Already passed `restoreAliveTimeout` |
| Any caller passing `0` to a `list_cmd` helper | None remain after this PR |
| `ListRemoteHookInstanceData` (separate helper) | **Justified exclusion**: not a caller of `runListCmd`/`isAliveWithTimeout`. Runs in the daemon (RPC boundary), only on user-initiated import (no background-tick blast radius). Worth a follow-up issue for the startup-import path bound, but out of scope for the #666 freeze.

## Test
Added `TestHookBackendIsAliveListCmdHangs` — runtime analogue of `TestHookBackendStartRestoreListCmdHangs`. Runs `IsAlive` against a `list_cmd` that sleeps 30s, asserts `IsAlive` returns `false` and elapsed < `runtimeAliveTimeout + 2s` tolerance. Locally completes in ~5.5s (5s timeout + 500ms `WaitDelay`).

## CI gates (local)
- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test -race ./...` — all packages pass except `TestSigtermFallback_DeadPID`, which fails because two real `af --daemon` processes are running on the maintainer dev box and the test (correctly) refuses to disambiguate. Unrelated to this diff; verified by re-running the diff's tests in isolation.

## Test plan
- [ ] Pull branch locally, run `./dev-install.sh`
- [ ] Configure a `list_cmd` that hangs (`#!/bin/sh\nsleep 60`) and confirm TUI no longer freezes when a remote instance is loaded
- [ ] Confirm steady-state Ready indicator flips to dead within ~5s instead of never

Fixes #666

Co-Authored-By: Captain Claude <noreply@anthropic.com>