### PR TITLE
fix(ui/terminal): reset scroll state when entering fallback (#669)

### DIFF
--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -66,10 +66,17 @@ func (t *TerminalPane) SetSize(width, height int) {
 
 // setFallbackState sets the terminal pane to display a fallback message.
 // Caller must hold t.mu.
+//
+// Also resets scroll-mode state so fallback=true cannot coexist with
+// isScrolling=true. String() checks isScrolling before fallback, so leaving
+// scroll state intact when switching to a nil/unstarted/remote selection
+// would render the prior instance's viewport instead of the fallback (#669).
 func (t *TerminalPane) setFallbackState(message string) {
 	t.fallback = true
 	t.fallbackText = lipgloss.JoinVertical(lipgloss.Center, FallBackText, "", message)
 	t.content = ""
+	t.isScrolling = false
+	t.viewport.SetContent("")
 }
 
 // UpdateContent captures the tmux pane output for the terminal session.

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -483,6 +483,78 @@ func TestTerminalCloseForInstanceResetsScrollMode(t *testing.T) {
 	tp.mu.Unlock()
 }
 
+// TestTerminalFallbackResetsScrollMode is a regression test for #669.
+// Entering the fallback state (nil/!Started/IsRemote selection, or session-gone
+// errors) must reset isScrolling and clear the viewport. String() checks
+// isScrolling before fallback, so leaving scroll state intact would render
+// the prior instance's stale viewport content instead of the fallback message.
+func TestTerminalFallbackResetsScrollMode(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	priorInstance := makeStartedInstance(t, "prior-scroll")
+	defer func() { _ = priorInstance.Kill() }()
+
+	priorContent := "stale-history-from-prior-instance"
+	priorTs := newMockTmuxSession(t, "prior-scroll", mockCmdExec(priorContent, true))
+
+	enterScrollOnPrior := func(tp *TerminalPane) {
+		t.Helper()
+		injectSession(tp, priorInstance.Title, priorTs, priorInstance.GetWorktreePath())
+		require.NoError(t, tp.ScrollUp())
+		require.True(t, tp.IsScrolling(), "precondition: should be in scroll mode")
+		require.Contains(t, tp.viewport.View(), priorContent,
+			"precondition: viewport should hold prior instance's history")
+	}
+
+	t.Run("nil instance", func(t *testing.T) {
+		tp := NewTerminalPane()
+		tp.SetSize(80, 30)
+		enterScrollOnPrior(tp)
+
+		require.NoError(t, tp.UpdateContent(nil))
+
+		tp.mu.Lock()
+		require.True(t, tp.fallback, "should enter fallback for nil instance")
+		require.False(t, tp.isScrolling,
+			"setFallbackState must clear isScrolling so String() does not render stale viewport (#669)")
+		tp.mu.Unlock()
+
+		rendered := tp.String()
+		require.Contains(t, rendered, "Select an instance",
+			"String() must render fallback message, not stale viewport content")
+		require.NotContains(t, rendered, priorContent,
+			"String() must not render the prior instance's scroll-mode content")
+	})
+
+	t.Run("not started instance", func(t *testing.T) {
+		tp := NewTerminalPane()
+		tp.SetSize(80, 30)
+		enterScrollOnPrior(tp)
+
+		notStarted, err := session.NewInstance(session.InstanceOptions{
+			Title:   "not-started-669",
+			Path:    t.TempDir(),
+			Program: "bash",
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, tp.UpdateContent(notStarted))
+
+		tp.mu.Lock()
+		require.True(t, tp.fallback, "should enter fallback for unstarted instance")
+		require.False(t, tp.isScrolling,
+			"setFallbackState must clear isScrolling so String() does not render stale viewport (#669)")
+		tp.mu.Unlock()
+
+		rendered := tp.String()
+		require.Contains(t, rendered, "not started",
+			"String() must render fallback message, not stale viewport content")
+		require.NotContains(t, rendered, priorContent,
+			"String() must not render the prior instance's scroll-mode content")
+	})
+}
+
 type failingPtyFactory struct{}
 
 func (f failingPtyFactory) Start(*exec.Cmd) (*os.File, error) {


### PR DESCRIPTION
## Summary

Fixes #669

## Root cause

`setFallbackState` set `fallback=true` and a fallback message, but left
`isScrolling` and the viewport untouched. `String()` short-circuits on
`isScrolling` *before* checking `fallback`:

```go
if t.isScrolling {
    return t.viewport.View()
}
// ... fallback rendering below
```

So when the user is in scroll mode on a local instance and switches
selection to a `nil`, `!Started()`, or `IsRemote()` instance, the pane
ends up with `fallback=true` **and** `isScrolling=true`. The render
path returns the prior instance's viewport content instead of the
"Terminal tab not available…" / "Instance is not started yet." /
"Select an instance to open a terminal" fallback.

Introduced in `e69ff9ce` (per the Detail report). Related fixes for
scroll-mode bleed-through landed in `3f0e75d` (instance-change branch
of `UpdateContent`) and `a8f187d` (`CloseForInstance` / `Close`), but
the fallback entry paths were missed.

## Fix

Reset `isScrolling` and clear the viewport inside `setFallbackState`,
so **all** fallback entry paths benefit:

- `UpdateContent` early returns for `nil`, `!Started()`, `IsRemote()`
- `UpdateContent` "Terminal session not available." path
- `UpdateContent` `ErrSessionGone` recovery
- `enterScrollMode` `ErrSessionGone` recovery

Invariant established: **`fallback=true` ⇒ `isScrolling=false`**.

## Adjacent call-sites audit (per CLAUDE.md)

Grepped every mutation of `fallback`, `isScrolling`, and `viewport`:

| Site | State after | Status |
|---|---|---|
| `setFallbackState` | fallback=true, isScrolling=false, viewport cleared | **fixed here** |
| `UpdateContent` instance-change branch (`L100-103`) | isScrolling=false, viewport cleared | already correct |
| `UpdateContent` normal path (`L134-135`) | fallback=false | unreachable while isScrolling=true (earlier guard returns) — no change needed |
| `Close` | full reset incl. scroll | already correct (#619) |
| `CloseForInstance` | full reset incl. scroll | already correct (#619) |
| `enterScrollMode` | isScrolling=true, viewport set | correct transition INTO scroll |
| `ResetToNormalMode` | isScrolling=false, viewport cleared | already correct |

No deliberate exclusions — every fallback entry now goes through the
fixed `setFallbackState`.

## Test

`TestTerminalFallbackResetsScrollMode` covers the regression for the
`nil` and unstarted-instance entry paths: enters scroll mode on a
prior instance, calls `UpdateContent` with the fallback-triggering
selection, then asserts:

- `fallback=true`
- `isScrolling=false`
- `String()` output contains the fallback message
- `String()` output does **not** contain the prior viewport content

The `IsRemote()` path executes the same `setFallbackState` code as the
two tested paths, so the invariant holds for it as well.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` — clean
- [x] `golangci-lint run --timeout=3m --fast` — clean
- [x] `deadcode -test ./...` — clean
- [x] `go test -race ./ui/...` — pass
- [x] New `TestTerminalFallbackResetsScrollMode` passes (both subtests)
- [x] Existing `TestTerminalScrolling`, `TestTerminalCloseForInstanceResetsScrollMode`, `TestTerminalFallbackStates` still pass

Co-Authored-By: Captain Claude <noreply@anthropic.com>