### PR TITLE
fix(session/storage): prefer resolved Worktree.RepoPath when computing daemon repo IDs (#667)

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -429,6 +429,21 @@ func (i *Instance) GetWorktreePath() string {
 	return gw.GetWorktreePath()
 }
 
+// GetRepoPath returns the resolved git repo path stored in the instance's
+// worktree, or empty string when no worktree is attached (e.g. a remote-
+// backend instance). Callers using the result to derive a repo ID must
+// fall back to Instance.Path when this is empty (#667).
+func (i *Instance) GetRepoPath() string {
+	i.mu.RLock()
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+
+	if gw == nil {
+		return ""
+	}
+	return gw.GetRepoPath()
+}
+
 func (i *Instance) Started() bool {
 	i.mu.RLock()
 	defer i.mu.RUnlock()

--- a/session/storage.go
+++ b/session/storage.go
@@ -91,12 +91,18 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 		}
 	}
 
-	// Daemon mode: group in-memory instances by repo.
-	// Use d.Path (always set) rather than d.Worktree.RepoPath (empty for
-	// remote backends) so the grouping key is consistent with knownRepoIDs.
+	// Daemon mode: group in-memory instances by repo root.
+	// Prefer the worktree's resolved repo path so we share a repo ID with
+	// the TUI even when the instance was created from a symlinked path;
+	// fall back to Path for remote backends where Worktree.RepoPath is
+	// empty. This mirrors CollectRepoRoots (#667).
 	grouped := make(map[string][]InstanceData)
 	for _, d := range data {
-		rid := config.RepoIDFromRoot(d.Path)
+		root := d.Worktree.RepoPath
+		if root == "" {
+			root = d.Path
+		}
+		rid := config.RepoIDFromRoot(root)
 		grouped[rid] = append(grouped[rid], d)
 	}
 
@@ -104,7 +110,11 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 	// that had all their in-memory instances killed (group would be empty).
 	knownRepoIDs := make(map[string]bool)
 	for _, inst := range instances {
-		rid := config.RepoIDFromRoot(inst.Path)
+		root := inst.GetRepoPath()
+		if root == "" {
+			root = inst.Path
+		}
+		rid := config.RepoIDFromRoot(root)
 		knownRepoIDs[rid] = true
 	}
 
@@ -120,7 +130,11 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 		// externally-added instances from other repos (issue #198).
 		repoMemTitlesAll := make(map[string]bool)
 		for _, inst := range instances {
-			if config.RepoIDFromRoot(inst.Path) == rid {
+			root := inst.GetRepoPath()
+			if root == "" {
+				root = inst.Path
+			}
+			if config.RepoIDFromRoot(root) == rid {
 				repoMemTitlesAll[inst.Title] = true
 			}
 		}

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -424,6 +425,76 @@ func TestDaemonSaveReapsLegacyLoadingGhost(t *testing.T) {
 	}
 	assert.True(t, titles["alive"], "daemon-known instance should remain on disk")
 	assert.False(t, titles["ghost"], "legacy Loading ghost must be reaped by daemon save (#551)")
+}
+
+// TestDaemonSaveUsesResolvedRepoPathForSymlinkedRepo verifies that the daemon
+// computes the on-disk repo ID from the worktree's resolved repo path rather
+// than the (possibly symlinked) Instance.Path. Before the fix, an instance
+// created from a symlinked directory would be persisted under a *different*
+// repo ID than the TUI used, splitting the same repo's state across two
+// files and creating ghost sessions on subsequent reloads (#667).
+func TestDaemonSaveUsesResolvedRepoPathForSymlinkedRepo(t *testing.T) {
+	const resolvedRepoPath = "/tmp/test-repo-resolved"
+	const symlinkPath = "/tmp/test-repo-symlink"
+	ms := newMockStorage()
+
+	// Disk state pre-exists under the RESOLVED repo ID (this is what the
+	// TUI wrote — TUI does not recompute the ID on save).
+	seedDisk(t, ms, resolvedRepoPath, []InstanceData{
+		{Title: "from-tui", Path: symlinkPath, Worktree: GitWorktreeData{RepoPath: resolvedRepoPath}, Status: Running},
+	})
+
+	// The daemon loaded that instance: Path is the symlinked path, but its
+	// gitWorktree carries the resolved repo path (set during construction).
+	gw, err := git.NewGitWorktreeFromStorage(
+		resolvedRepoPath, "/tmp/test-repo-symlink-wt", "from-tui",
+		"branch-x", "deadbeef", false, true,
+	)
+	require.NoError(t, err)
+	inst := makeInstance("from-tui", symlinkPath, true)
+	inst.gitWorktree = gw
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	require.NoError(t, storage.SaveInstances([]*Instance{inst}))
+
+	// The instance must be written back to the resolved-path repo ID,
+	// not the symlinked-path repo ID. Before the fix, the daemon would
+	// create a SECOND file under RepoIDFromRoot(symlinkPath).
+	resolvedID := config.RepoIDFromRoot(resolvedRepoPath)
+	symlinkID := config.RepoIDFromRoot(symlinkPath)
+	require.NotEqual(t, resolvedID, symlinkID, "test fixture: paths must hash to distinct IDs")
+
+	all := ms.GetAllInstances()
+	_, hasResolved := all[resolvedID]
+	_, hasSymlink := all[symlinkID]
+	assert.True(t, hasResolved, "instance must be saved under the resolved repo ID")
+	assert.False(t, hasSymlink, "instance must NOT be duplicated under the symlinked repo ID")
+
+	result := readDisk(t, ms, resolvedRepoPath)
+	require.Len(t, result, 1, "exactly one record should be persisted for the repo")
+	assert.Equal(t, "from-tui", result[0].Title)
+}
+
+// TestDaemonSaveFallsBackToPathForRemoteBackend verifies that the daemon
+// still groups by Instance.Path when no worktree is attached (load-bearing
+// for remote backends where Worktree.RepoPath is empty).
+func TestDaemonSaveFallsBackToPathForRemoteBackend(t *testing.T) {
+	const repoPath = "/tmp/test-repo-remote"
+	ms := newMockStorage()
+
+	// Remote-backend instance: no gitWorktree, Worktree.RepoPath empty.
+	inst := makeInstance("remote-1", repoPath, true)
+	require.Empty(t, inst.GetRepoPath(), "test fixture: remote instance must have empty resolved repo path")
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+	require.NoError(t, storage.SaveInstances([]*Instance{inst}))
+
+	result := readDisk(t, ms, repoPath)
+	require.Len(t, result, 1)
+	assert.Equal(t, "remote-1", result[0].Title)
 }
 
 // TestCollectRepoRoots verifies that Storage.CollectRepoRoots returns the


### PR DESCRIPTION
## Summary

Daemon `SaveInstances` was deriving the on-disk per-repo file name from `InstanceData.Path`, which may be a symlink. The TUI hashes the git-resolved repo path, so opening a repo via a symlinked directory caused the daemon to persist that repo's instances into a *second* repo-ID file, splitting state and producing ghost sessions on subsequent reloads.

The fix matches the existing `CollectRepoRoots` pattern verbatim: prefer `Worktree.RepoPath` (set by git resolution for local backends) and fall back to `Path` (load-bearing for remote backends where `Worktree.RepoPath` is empty).

## Root cause (per Detail report)

Commit 19f1f46 changed the daemon's grouping key from `Worktree.RepoPath` to `Path` to handle remote backends with empty `Worktree.RepoPath`. The TUI side, however, continued to hash whatever resolved repo root it was given at startup (`config.ResolveMainRepoRoot`), so the two paths to the same repo could yield two different repo IDs. The correct fix — already adopted in `CollectRepoRoots` in 85db6e4 — is to prefer `Worktree.RepoPath` and fall back to `Path`.

## Changes

- `session/storage.go` (`SaveInstances`): three daemon-side call sites switched to the resolved-with-fallback pattern:
  - building `grouped` (InstanceData)
  - building `knownRepoIDs` (Instance)
  - building per-repo `repoMemTitlesAll` (Instance) — also needed to keep the resolved-ID match consistent with the new `knownRepoIDs` IDs
- `session/instance.go`: adds `Instance.GetRepoPath()` — a thread-safe accessor mirroring `GetWorktreePath()`, needed because `gitWorktree` is unexported and the existing `GetGitWorktree()` requires `started=true`.
- `session/storage_test.go`: adds `TestDaemonSaveUsesResolvedRepoPathForSymlinkedRepo` (verified to fail on the buggy code and pass after the fix) and `TestDaemonSaveFallsBackToPathForRemoteBackend` (verifies the remote-backend fallback path).

## Call-site audit (per CLAUDE.md adjacent call-sites rule)

`grep -n "RepoIDFromRoot(" **/*.go` — every non-test production call site:

- `session/storage.go:99,107,123` — fixed in this PR
- `session/git/hooks.go:22` — input is `g.repoPath` (set during `GitWorktree` construction via git resolution); already resolved
- `app/sync.go:174,236` — already use `data.Worktree.RepoPath` (not raw `Path`), so they do not have the symlink-splitting bug. They lack a `Path` fallback, but that only matters for remote-backend task-pending instances, which is a separate concern not in scope here
- `config/repo.go:145` — internal helper; caller is responsible for passing a resolved root

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run --timeout=3m --fast` (clean)
- [x] `deadcode -test ./...` (clean)
- [x] `go test -race ./...` — full suite passes except `TestSigtermFallback_DeadPID` in `daemon/`, which is preexisting environmental flake (real `af --daemon` PIDs on the dev machine make the test's `pgrep` ambiguous; reproduces on master without these changes)
- [x] New test fails on buggy code, passes after fix

Fixes #667

Co-Authored-By: Captain Claude <noreply@anthropic.com>