### PR TITLE
docs(cli): update --program flag help text to match enum constraint (#674)

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/api"
 	"github.com/sachiniyer/agent-factory/app"
@@ -190,8 +191,11 @@ var (
 )
 
 func init() {
+	// The --program flag is validated as an enum (bare agent name) via
+	// tmux.SupportedPrograms, so advertise exactly those accepted values.
 	rootCmd.Flags().StringVarP(&programFlag, "program", "p", "",
-		"Program to run in new instances (e.g. 'aider --model ollama_chat/gemma3:1b')")
+		fmt.Sprintf("Program to run in new instances (one of: %s)",
+			strings.Join(tmux.SupportedPrograms, ", ")))
 	rootCmd.Flags().BoolVarP(&autoYesFlag, "autoyes", "y", false,
 		"[experimental] If enabled, all instances will automatically accept prompts")
 	rootCmd.Flags().BoolVar(&daemonFlag, "daemon", false, "Run a program that loads all sessions"+


### PR DESCRIPTION
## Summary

`af --help` advertised an invalid value for the root `--program`/`-p` flag.

**Root cause (per Detail report):** The help text showed
`'aider --model ollama_chat/gemma3:1b'` as an example. That string was correct
when the flag accepted free-form commands (added in 8446b16, March 2025), but
commit 7bac9f3 added `ValidateProgramEnum`, restricting `--program` to bare
agent names (`claude`, `codex`, `aider`, `gemini`). The enum-validation audit
in 7bac9f3 listed the CLI validation site but missed this help-text string, so
the CLI kept advertising input it now always rejects. Users who copied the
example verbatim hit an immediate validation error.

**Fix:** Derive the advertised values from `tmux.SupportedPrograms` via
`strings.Join`, so the help string reads `(one of: claude, codex, aider,
gemini)` and can never drift from the enum again.

```
  -p, --program string   Program to run in new instances (one of: claude, codex, aider, gemini)
```

## Adjacent-call-sites audit (per CLAUDE.md)

Grepped the whole repo for `aider --model`, `ollama_chat`, `"program"` flag
declarations, and `--program`/`-p` examples in `docs/` and `README.md`:

| Site | Disposition |
|------|-------------|
| `main.go:193` root `--program` help | **Fixed** (this PR) |
| `api/api.go:128,132,147` (`sessions create`, `sessions send-prompt`, `tasks add`) | No example, already describe behavior — correct as-is |
| `README.md:112` `--program claude`, `README.md:163` `af -p aider` | Valid bare agent names — no change |
| `docs/release-testing-plan.md:81` `--program claude` | Valid (already fixed in 83ae0b6) — verified clean |
| `session/instance.go:215` `Program` field comment | **Intentional exclusion** — the field still legitimately holds legacy free-form program strings for stored/resumed sessions (exercised by `session/tmux/resume_test.go`); the comment documents possible field contents, not a CLI example |
| `session/tmux/resume_test.go:142,143,276`, `ui/task_pane_test.go:221` | **Intentional exclusion** — test fixtures exercising legacy free-form program resume/handling; not user-facing examples |

## Testing

- `gofmt -l .` — clean
- `go build ./...` — OK
- `golangci-lint run --timeout=3m --fast` — pass
- `deadcode -test ./...` — clean
- `go test -race ./...` — pass (the two `daemon/TestSigtermFallback_*` failures
  are a pre-existing local environment flake from stray `af --daemon` processes
  on this dev machine; they fail identically on a clean checkout of the base
  commit and are unrelated to this change)

## Behavior change

None. Help-text only.

Fixes #674

— Captain Claude