### PR TITLE
fix(session): tolerate legacy Program paths in restored-session flag injection (#677)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -25,7 +25,7 @@ func resolveProgramForInstance(i *Instance) string {
 		cfg = nil
 	}
 	resolved := config.ResolveProgram(cfg, i.Program)
-	if i.AutoYes && i.Program == tmux.ProgramClaude {
+	if i.AutoYes && detectAgentFromProgram(i.Program) == tmux.ProgramClaude {
 		resolved = resolved + " --permission-mode bypassPermissions"
 	}
 	return resolved
@@ -329,7 +329,10 @@ func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {
 	if !s || ts == nil {
 		return false
 	}
-	switch i.Program {
+	// Normalize so restored sessions with legacy free-form Program values
+	// (e.g. "/home/foo/bin/claude") still get trust-prompt auto-handling —
+	// same persisted-state class of regression as #677.
+	switch detectAgentFromProgram(i.Program) {
 	case tmux.ProgramClaude, tmux.ProgramAider, tmux.ProgramGemini:
 		return ts.CheckAndHandleTrustPrompt()
 	}

--- a/session/legacy_program_test.go
+++ b/session/legacy_program_test.go
@@ -1,0 +1,125 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// detectAgentFromProgram is the normalization seam that lets restored sessions
+// with legacy free-form Program values keep their agent-specific flags (#677).
+// It must recover the canonical agent for paths and path-plus-flags, leave the
+// bare enum untouched, and — critically — return unknown programs unchanged so
+// no agent flags leak into a non-agent session.
+func TestDetectAgentFromProgram(t *testing.T) {
+	tests := []struct {
+		name    string
+		program string
+		want    string
+	}{
+		{"bare claude enum", "claude", tmux.ProgramClaude},
+		{"bare codex enum", "codex", tmux.ProgramCodex},
+		{"bare aider enum", "aider", tmux.ProgramAider},
+		{"bare gemini enum", "gemini", tmux.ProgramGemini},
+		{"legacy claude path", "/home/foo/bin/claude", tmux.ProgramClaude},
+		{"legacy claude path with flags", "/home/foo/bin/claude --plugin-dir x", tmux.ProgramClaude},
+		{"legacy codex path", "/usr/local/bin/codex", tmux.ProgramCodex},
+		{"unknown tool path unchanged", "/usr/bin/some-other-tool", "/usr/bin/some-other-tool"},
+		{"unknown tool with flags unchanged", "/usr/bin/some-other-tool --foo", "/usr/bin/some-other-tool --foo"},
+		{"empty unchanged", "", ""},
+		{"substring-but-not-base unchanged", "/opt/claude-wrapper/run", "/opt/claude-wrapper/run"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectAgentFromProgram(tt.program); got != tt.want {
+				t.Errorf("detectAgentFromProgram(%q) = %q, want %q", tt.program, got, tt.want)
+			}
+		})
+	}
+}
+
+// Regression for #677: a restored Claude session whose persisted Program is a
+// legacy absolute path must still receive --plugin-dir, or /af-* slash commands
+// silently vanish after upgrade.
+func TestInjectSystemPrompt_LegacyClaudePath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+
+	legacyPath := "/home/foo/bin/claude"
+	result := injectSystemPrompt(legacyPath, legacyPath, "legacy-session", dir)
+
+	if !strings.Contains(result, "--plugin-dir") {
+		t.Errorf("expected --plugin-dir for legacy claude path, got %q", result)
+	}
+}
+
+// Companion to the Claude case: legacy Codex paths must still receive the
+// developer_instructions flag.
+func TestInjectSystemPrompt_LegacyCodexPath(t *testing.T) {
+	dir := t.TempDir()
+	legacyPath := "/usr/local/bin/codex"
+	result := injectSystemPrompt(legacyPath, legacyPath, "legacy-codex", dir)
+
+	if !strings.Contains(result, "developer_instructions=") {
+		t.Errorf("expected developer_instructions for legacy codex path, got %q", result)
+	}
+}
+
+// Defensive guard: an unknown program path must NOT trigger any agent flag
+// injection — we must never append Claude/Codex flags to a session we don't
+// recognize.
+func TestInjectSystemPrompt_UnknownProgramNoInjection(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+
+	program := "/usr/bin/some-other-tool"
+	result := injectSystemPrompt(program, program, "mystery-session", dir)
+
+	if result != program {
+		t.Errorf("expected unknown program left unchanged, got %q", result)
+	}
+}
+
+// Regression guard: the bare enum value (what current binaries persist) must
+// keep working exactly as before the normalization seam was added.
+func TestInjectSystemPrompt_BareEnumStillInjects(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+
+	result := injectSystemPrompt(tmux.ProgramClaude, "claude", "enum-session", dir)
+	if !strings.Contains(result, "--plugin-dir") {
+		t.Errorf("expected --plugin-dir for bare claude enum, got %q", result)
+	}
+}
+
+// Regression for #677: a restored AutoYes Claude session with a legacy path
+// must still get --permission-mode bypassPermissions, or unattended operation
+// silently breaks after upgrade.
+func TestResolveProgramForInstance_LegacyAutoYes(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	i := &Instance{
+		Program: "/home/foo/bin/claude",
+		AutoYes: true,
+	}
+	result := resolveProgramForInstance(i)
+	if !strings.Contains(result, "--permission-mode bypassPermissions") {
+		t.Errorf("expected --permission-mode bypassPermissions, got %q", result)
+	}
+}
+
+// Defensive guard for the AutoYes branch: an unknown AutoYes program must NOT
+// get the Claude-only bypassPermissions flag.
+func TestResolveProgramForInstance_UnknownAutoYesNoFlag(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	i := &Instance{
+		Program: "/usr/bin/some-other-tool",
+		AutoYes: true,
+	}
+	result := resolveProgramForInstance(i)
+	if strings.Contains(result, "bypassPermissions") {
+		t.Errorf("expected no bypassPermissions for unknown program, got %q", result)
+	}
+}

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -26,17 +27,50 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
+// detectAgentFromProgram maps a possibly-legacy Program value to its canonical
+// agent enum name (one of tmux.SupportedPrograms). Sessions persisted by
+// pre-#659 binaries may hold free-form Program strings — an absolute path
+// and/or trailing flags, e.g. "/home/foo/bin/claude --plugin-dir x" — rather
+// than the bare enum that current binaries write. On restore those legacy
+// values flow into the flag-injection layer, where strict enum equality
+// (added in #659) no longer recognizes them, silently dropping --plugin-dir,
+// bypassPermissions, and Codex developer_instructions (#677).
+//
+// The match is deliberately DEFENSIVE, not permissive: it returns a canonical
+// name only when filepath.Base of the first whitespace-split token equals a
+// tmux.SupportedPrograms entry verbatim. For anything else — unknown tools,
+// empty input, the bare enum (which maps to itself) — it returns the input
+// unchanged, so we never inject Claude flags into a non-Claude session. This
+// is scoped purely to flag injection on restore; it is NOT a general-purpose
+// command parser and must not be reused as one.
+func detectAgentFromProgram(program string) string {
+	fields := strings.Fields(program)
+	if len(fields) == 0 {
+		return program
+	}
+	base := filepath.Base(fields[0])
+	for _, supported := range tmux.SupportedPrograms {
+		if base == supported {
+			return supported
+		}
+	}
+	return program
+}
+
 // injectSystemPrompt injects Agent Factory instructions into the session.
 //
-// agent is the canonical enum name (e.g. tmux.ProgramClaude) and resolved is
+// agent is the Instance.Program value (normally the canonical enum, but
+// possibly a legacy free-form string on restored sessions) and resolved is
 // the actual command string to be passed to tmux (the agent name or the
-// configured program_overrides entry). System-prompt flags are appended to
+// configured program_overrides entry). agent is normalized via
+// detectAgentFromProgram so legacy paths still match; flags are appended to
 // resolved.
 //
 // Strategy per tool:
 //   - Claude Code: --plugin-dir flag only (slash commands + /af-whoami for self-identification)
 //   - Codex: -c developer_instructions="..." flag (text-based, no plugin support)
 func injectSystemPrompt(agent, resolved, sessionTitle, worktreePath string) string {
+	agent = detectAgentFromProgram(agent)
 	if agent == tmux.ProgramClaude {
 		pluginDir, err := ensurePluginDir()
 		if err != nil {


### PR DESCRIPTION
## Root cause (from Detail)

`#659` (commit `7bac9f3`) restricted `default_program` to a canonical enum and deleted the `getBaseCommand` helper that used to extract the agent type from free-form command/path strings. Detection at the flag-injection layer was switched to **strict enum equality** (`i.Program == tmux.ProgramClaude`).

Session restore, however, still supplies whatever `Program` value the *prior* binary persisted. Sessions created before `7bac9f3` hold legacy free-form values like `/home/foo/bin/claude` (an absolute path, possibly with trailing flags). Those no longer match the enum, so on restore:

- `injectSystemPrompt` silently drops Claude's `--plugin-dir` (breaking `/af-*` slash commands) and Codex's `developer_instructions`.
- `resolveProgramForInstance` silently drops AutoYes's `--permission-mode bypassPermissions` (breaking unattended operation).

This is a silent post-upgrade regression: the session launches, but features quietly fail.

## Why normalize here instead of rejecting at `LoadInstances`

`#658`/`#659` intentionally hard-error on non-enum **config** values, and this PR does **not** relax that. Config is authored by the user, so a hard error is a correct, actionable migration prompt.

Persisted **session state** is different: it was written by a prior binary, not the user. Hard-failing restore (or silently dropping flags) punishes the user for an upgrade they didn't author. For binary-written state, a forgiving runtime normalization is strictly better than silent feature breakage. So we normalize at the flag-injection layer and leave `LoadConfig` validation untouched.

## The normalization helper's narrow scope

```go
func detectAgentFromProgram(program string) string {
	fields := strings.Fields(program)
	if len(fields) == 0 {
		return program
	}
	base := filepath.Base(fields[0])
	for _, supported := range tmux.SupportedPrograms {
		if base == supported {
			return supported
		}
	}
	return program
}
```

Deliberately **defensive, not permissive**:

- Returns a canonical name **only** when `filepath.Base` of the first whitespace-split token equals a `SupportedPrograms` entry **verbatim**.
- Returns the input **unchanged** for everything else — unknown tools, empty input, `/opt/claude-wrapper/run` (substring but not base). This guarantees we never inject Claude flags into a non-Claude session.
- The bare enum maps to itself, so current-binary sessions are unaffected.
- Scoped purely to the flag-injection layer. It is **not** a revived general-purpose `getBaseCommand` and must not be reused as one.

## Audited call-sites

Per the adjacent-call-sites rule, every comparison of an agent value against the `tmux.Program*` enums:

| Site | Compares | Source of value | Action |
|------|----------|-----------------|--------|
| `session/systemprompt.go` `injectSystemPrompt` (Claude + Codex) | `agent == ProgramClaude / ProgramCodex` | persisted `Instance.Program` | **Fixed** — normalize `agent` once at top |
| `session/backend_local.go` `resolveProgramForInstance` AutoYes | `i.Program == ProgramClaude` | persisted `Instance.Program` | **Fixed** — normalized check |
| `session/backend_local.go` `CheckAndHandleTrustPrompt` | `switch i.Program { case Claude, Aider, Gemini }` | persisted `Instance.Program` | **Fixed** — same persisted-state class; legacy paths would skip trust-prompt auto-handling |
| `session/tmux/tmux.go:281,635` | `strings.Contains(t.program, ProgramClaude/Aider/Gemini)` | resolved program string | No change — substring match already tolerates legacy paths |
| `session/tmux/resume.go` `resumeProgram` | `filepath.Base(tok) == supported` | persisted program string | No change — already tokenizes + base-matches (the model for this helper) |
| `config/config.go` `ValidateProgramEnum` | loop `name == supported` | **config** (`default_program`) | No change — strict by design (#658/#659) |
| `config/config.go` `DefaultConfig` / `ResolveProgram` | map key `ProgramClaude` | config / enum agent key | No change — config-authored |
| `ui/task_pane.go`, `app/handle_overlay.go`, `app/handle_input.go` | build option lists from `SupportedPrograms` | UI menu selection | No change — not a persisted-state comparison |

## Tests

- `TestInjectSystemPrompt_LegacyClaudePath`, `TestResolveProgramForInstance_LegacyAutoYes` — the two failing cases from the Detail report, now passing.
- `TestInjectSystemPrompt_UnknownProgramNoInjection`, `TestResolveProgramForInstance_UnknownAutoYesNoFlag` — unknown program paths get **no** spurious flag injection.
- `TestInjectSystemPrompt_BareEnumStillInjects`, `TestInjectSystemPrompt_LegacyCodexPath` — regression guards.
- `TestDetectAgentFromProgram` — table covering bare enums, legacy paths, path+flags, unknown, empty, and substring-but-not-base.

## Gates

`golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `go build ./...`, `go test -race ./...`, `deadcode -test ./...` — all clean. (One unrelated daemon-socket integration test, `TestDaemonLifecycleRecoversFromStaleSocketAndDeadDaemon`, flaked under heavy parallel load and passes in isolation.)

Fixes #677

— Captain Claude
