### PR TITLE
fix(session/hook): treat exec.ErrWaitDelay as non-fatal when list_cmd exited 0 (#676)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -351,7 +352,14 @@ func (b *HookBackend) IsAlive(i *Instance) bool {
 // runtimeAliveTimeout.
 func (b *HookBackend) isAliveWithTimeout(i *Instance, timeout time.Duration) bool {
 	out, err := b.runListCmd(timeout)
-	if err != nil {
+	// exec.ErrWaitDelay is non-fatal here (#676). runListCmd sets
+	// cmd.WaitDelay, so CombinedOutput returns ErrWaitDelay when the list_cmd
+	// script itself exited (per docs/remote-hooks.md, with code 0 on success)
+	// but a backgrounded child still holds the stdout/stderr pipes open. In
+	// that case the script's output is already complete on stdout; fall
+	// through to extractJSON + json.Unmarshal, which validate it. A genuinely
+	// broken list_cmd produces no parseable JSON and still returns false.
+	if err != nil && !errors.Is(err, exec.ErrWaitDelay) {
 		return false
 	}
 	// Mirror launch_cmd: list_cmd may write progress to stderr and JSON to

--- a/session/backend_orphan_test.go
+++ b/session/backend_orphan_test.go
@@ -1,0 +1,78 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHookBackendIsAliveListCmdOutputThenOrphan demonstrates a bug where
+// a script that exits with code 0 and outputs valid JSON returns false
+// from IsAlive because ErrWaitDelay is treated as a failure.
+//
+// This violates the documented protocol in docs/remote-hooks.md:24-25:
+// "All scripts must: Return exit code 0 on success"
+func TestHookBackendIsAliveListCmdOutputThenOrphan(t *testing.T) {
+	dir := t.TempDir()
+	// Script outputs valid JSON, then exits with code 0 while child holds stdout
+	listCmd := writeScript(t, dir, "list.sh", `echo '[{"name":"test-session","status":"running"}]'
+sleep 30 &
+exit 0
+`)
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{ListCmd: listCmd},
+	}
+	i := &Instance{
+		Title:   "test-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	alive := b.IsAlive(i)
+
+	// BUG DEMONSTRATION: This assertion FAILS with current code
+	if !alive {
+		t.Errorf("BUG: IsAlive returned false for script that exited with code 0 and output valid JSON")
+	}
+}
+
+// TestHookBackendIsAliveOrphanNoJSON is the complement to the #676 fix and a
+// guard against making the ErrWaitDelay tolerance too loose. A list_cmd that
+// backgrounds a child holding stdout open (so CombinedOutput returns
+// exec.ErrWaitDelay) but never emits parseable JSON must still return false:
+// tolerating ErrWaitDelay must not short-circuit the extractJSON +
+// json.Unmarshal validation. It also exercises the #666 contract that IsAlive
+// returns promptly rather than blocking on the orphaned child's 30s sleep.
+func TestHookBackendIsAliveOrphanNoJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timeout-bound test in short mode")
+	}
+
+	dir := t.TempDir()
+	// Exits 0 with no JSON on stdout, but a backgrounded child holds the pipe
+	// open past the parent's exit, triggering exec.ErrWaitDelay.
+	listCmd := writeScript(t, dir, "list.sh", `echo "starting up..." >&2
+sleep 30 &
+exit 0
+`)
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{ListCmd: listCmd},
+	}
+	i := &Instance{
+		Title:   "test-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	start := time.Now()
+	alive := b.IsAlive(i)
+	elapsed := time.Since(start)
+
+	assert.False(t, alive, "IsAlive must report false when list_cmd emits no parseable JSON, even on ErrWaitDelay")
+	// Must not block on the orphaned child's sleep (#666): the parent exits
+	// immediately and WaitDelay bounds the trailing pipe read at 500ms.
+	assert.Less(t, elapsed, runtimeAliveTimeout,
+		"IsAlive must return promptly when the script exits but a child holds the pipe (got %v)", elapsed)
+}


### PR DESCRIPTION
## Root cause

`HookBackend.isAliveWithTimeout` ran `b.runListCmd(timeout)` and treated **any**
non-nil error as a hard failure (`if err != nil { return false }`).

`runListCmd` sets `cmd.WaitDelay = 500ms` (added in #656 / commit `57e8ed6d` to
keep the restore-path timeout honest, #645). With `WaitDelay` set,
`CombinedOutput` returns `exec.ErrWaitDelay` when the `list_cmd` script itself
has exited — including the documented success case, exit code 0 per
[`docs/remote-hooks.md`](docs/remote-hooks.md) ("All scripts must: Return exit
code 0 on success") — but a backgrounded child still holds the stdout/stderr
pipes open. In that scenario the script's output is already complete and valid
on stdout, yet `IsAlive` returned `false`, falsely reporting a live remote
session as dead. #656 added `WaitDelay` but did not distinguish `ErrWaitDelay`
from real failures.

## Fix

Tolerate `exec.ErrWaitDelay` and fall through to the existing `extractJSON` +
`json.Unmarshal` validation:

```go
out, err := b.runListCmd(timeout)
if err != nil && !errors.Is(err, exec.ErrWaitDelay) {
    return false
}
```

A genuinely broken `list_cmd` still produces no parseable JSON and returns
`false`, so the tolerance can't make `IsAlive` return `true` unconditionally.

## Adjacent-call-sites audit (CLAUDE.md)

- **`b.runListCmd` has exactly one caller: `isAliveWithTimeout`.** That single
  function serves **both** the steady-state runtime path
  (`IsAlive → isAliveWithTimeout(i, runtimeAliveTimeout)`) **and** the restore
  path (`Start` when `!firstTimeSetup → isAliveWithTimeout(i, restoreAliveTimeout)`,
  `backend_hook.go:136`). Fixing the guard once covers both — no duplication
  needed, and the restore path no longer falsely evicts a live persisted
  session whose `list_cmd` backgrounds children.
- **`ListRemoteHookInstanceData`** (`backend_hook.go:407`) runs
  `exec.Command(hooks.ListCmd, "--json").CombinedOutput()` directly, with **no**
  `cmd.WaitDelay` and no context timeout, so it can never return
  `exec.ErrWaitDelay`. **No change needed.**
- **`launch_cmd`** (`Start`) and **`delete_cmd`** (`Kill`) likewise use bare
  `CombinedOutput()` with no `WaitDelay` and are unaffected.

## Tests

Both added in `session/backend_orphan_test.go`:

- **`TestHookBackendIsAliveListCmdOutputThenOrphan`** — the verbatim repro from
  the Detail report: a `list_cmd` that prints valid JSON, backgrounds
  `sleep 30 &`, and `exit 0`. Confirmed **FAILS** on the current code
  (`BUG: IsAlive returned false for script that exited with code 0 and output
  valid JSON`) and **PASSES** with the fix.
- **`TestHookBackendIsAliveOrphanNoJSON`** — regression guard against making the
  tolerance too loose: a `list_cmd` that backgrounds a child holding the pipe
  open (→ `ErrWaitDelay`) but emits **no** parseable JSON must still return
  `false`, and must return promptly (well under `runtimeAliveTimeout`) rather
  than blocking on the orphan's 30s sleep (#666).

The existing #666 timeout test (`TestHookBackendIsAliveListCmdHangs`) and the
#645 restore-hang test (`TestHookBackendStartRestoreListCmdHangs`) are
**unchanged and still pass** — `IsAlive` still aborts within
`runtimeAliveTimeout` when `list_cmd` truly hangs without output.

## CI gates

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — empty
- `go build ./...` — OK
- `deadcode -test ./...` — clean
- `go test -race ./...` — **`session` package (the only package this diff
  touches) passes cleanly under `-race`.** Unrelated pre-existing failures in
  `daemon` (`TestSigtermFallback_*`) and `integration`
  (`TestConcurrentCLIClientsUseDaemonCoordinator`) are caused by stray
  `af --daemon` processes on the dev host ("ambiguous, found N af --daemon
  processes") and reproduce identically on the clean baseline with my changes
  stashed — they are environmental, not introduced by this PR.

Fixes #676

— Captain Claude