### PR TITLE
fix(config): preserve user command in program_overrides validation error (#675)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -181,7 +181,7 @@ var sessionsCreateCmd = &cobra.Command{
 		program := createProgramFlag
 		if program == "" {
 			program = cfg.DefaultProgram
-		} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program); err != nil {
+		} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program, ""); err != nil {
 			return jsonError(err)
 		}
 
@@ -316,7 +316,7 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 			program := sendPromptProgramFlag
 			if program == "" {
 				program = cfg.DefaultProgram
-			} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program); err != nil {
+			} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program, ""); err != nil {
 				return jsonError(err)
 			}
 

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -103,7 +103,7 @@ var tasksAddCmd = &cobra.Command{
 				return jsonError(err)
 			}
 			program = cfg.DefaultProgram
-		} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program); err != nil {
+		} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program, ""); err != nil {
 			return jsonError(err)
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -83,17 +83,27 @@ type Config struct {
 // the same string. The message is wrapped in leading "\n\n" and trailing
 // "\n" so it visually separates from Cobra's "Error: " prefix and the
 // trailing "Usage:" block (see #661).
-func ValidateProgramEnum(lead, referent, name string) error {
+//
+// exampleValue is the command string rendered as the program_overrides example
+// value in the suggested fix. For default_program (and any call site where
+// name IS the user-supplied command) pass "" to fall back to using name. For
+// program_overrides key validation, name is the map key — not a command — so
+// the caller passes the corresponding map value here to keep the user's
+// original command in the example instead of replacing it with the key (#675).
+func ValidateProgramEnum(lead, referent, name, exampleValue string) error {
 	for _, supported := range tmux.SupportedPrograms {
 		if name == supported {
 			return nil
 		}
 	}
+	if exampleValue == "" {
+		exampleValue = name
+	}
 	return fmt.Errorf(
 		"\n\n%s must be one of [%s], got %q. To preserve a custom path or flags, set %s to the agent name and move the full command into program_overrides. Example: \"default_program\": \"claude\", \"program_overrides\": { \"claude\": %q }\n",
 		lead, strings.Join(tmux.SupportedPrograms, ", "), name,
 		referent,
-		name,
+		exampleValue,
 	)
 }
 
@@ -265,14 +275,16 @@ func LoadConfig() (*Config, error) {
 		fmt.Sprintf("Config issue in %s: default_program", prettyConfigPath),
 		"default_program",
 		config.DefaultProgram,
+		"",
 	); err != nil {
 		return nil, err
 	}
-	for key := range config.ProgramOverrides {
+	for key, value := range config.ProgramOverrides {
 		if err := ValidateProgramEnum(
 			fmt.Sprintf("Config issue in %s: program_overrides key", prettyConfigPath),
 			"program_overrides key",
 			key,
+			value,
 		); err != nil {
 			return nil, err
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -170,7 +170,7 @@ func TestDefaultConfig(t *testing.T) {
 func TestValidateProgramEnum(t *testing.T) {
 	for _, name := range tmux.SupportedPrograms {
 		t.Run("accepts "+name, func(t *testing.T) {
-			assert.NoError(t, ValidateProgramEnum("field", "field", name))
+			assert.NoError(t, ValidateProgramEnum("field", "field", name, ""))
 		})
 	}
 
@@ -185,11 +185,14 @@ func TestValidateProgramEnum(t *testing.T) {
 		{"random word", "foo"},
 	}
 	for _, tc := range rejectCases {
+		// default_program-style: name IS the user-supplied command, so no
+		// exampleValue is passed and the message uses name as the example.
 		t.Run("rejects "+tc.name, func(t *testing.T) {
 			err := ValidateProgramEnum(
 				"Config issue in ~/.agent-factory/config.json: default_program",
 				"default_program",
 				tc.in,
+				"",
 			)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "default_program")
@@ -206,8 +209,35 @@ func TestValidateProgramEnum(t *testing.T) {
 			// not the path-prefixed lead.
 			assert.Contains(t, err.Error(), "set default_program to the agent name")
 			assert.NotContains(t, err.Error(), "set Config issue in")
+			// With no exampleValue, the example override value falls back to
+			// name (the existing default_program behavior).
+			if tc.in != "" {
+				assert.Contains(t, err.Error(), fmt.Sprintf("{ \"claude\": %q }", tc.in))
+			}
 		})
 	}
+
+	// program_overrides-style: name is the map key (an invalid agent name)
+	// and exampleValue is the user's full command. The example must preserve
+	// the user's command, not echo the invalid key (#675).
+	t.Run("program_overrides preserves user command in example", func(t *testing.T) {
+		const (
+			key     = "amp"
+			command = "/opt/amp --some-flag"
+		)
+		err := ValidateProgramEnum(
+			"Config issue in ~/.agent-factory/config.json: program_overrides key",
+			"program_overrides key",
+			key,
+			command,
+		)
+		require.Error(t, err)
+		// The reported invalid value is still the key.
+		assert.Contains(t, err.Error(), fmt.Sprintf("got %q", key))
+		// The suggested example embeds the user's command, not the bare key.
+		assert.Contains(t, err.Error(), fmt.Sprintf("{ \"claude\": %q }", command))
+		assert.NotContains(t, err.Error(), fmt.Sprintf("{ \"claude\": %q }", key))
+	})
 }
 
 func TestPrettyHomePath(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ var (
 			// or flag overrides belong in program_overrides.
 			program := cfg.DefaultProgram
 			if programFlag != "" {
-				if err := config.ValidateProgramEnum("--program flag", "--program flag", programFlag); err != nil {
+				if err := config.ValidateProgramEnum("--program flag", "--program flag", programFlag, ""); err != nil {
 					return err
 				}
 				program = programFlag

--- a/task/task.go
+++ b/task/task.go
@@ -127,7 +127,7 @@ func AddTask(t Task) error {
 	// Empty Program means "fall back to the configured default_program at
 	// run time"; only validate when an explicit per-task override was set.
 	if t.Program != "" {
-		if err := config.ValidateProgramEnum("task program", "task program", t.Program); err != nil {
+		if err := config.ValidateProgramEnum("task program", "task program", t.Program, ""); err != nil {
 			return err
 		}
 	}
@@ -266,7 +266,7 @@ func UpdateTask(t Task) error {
 	// Empty Program means "fall back to the configured default_program at
 	// run time"; only validate when an explicit per-task override was set.
 	if t.Program != "" {
-		if err := config.ValidateProgramEnum("task program", "task program", t.Program); err != nil {
+		if err := config.ValidateProgramEnum("task program", "task program", t.Program, ""); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Root cause

Per the [Detail report](https://app.detail.dev/org_d0a388e8-ab25-4b0e-bf83-9421012703cd/bugs/bug_3aa00608-1a07-4752-8c2d-d5d5d1a09519) (introduced in #659, commit `7bac9f3`), `ValidateProgramEnum` reused its `name` argument as **both** the rejected value *and* the example `program_overrides` value in the migration error message.

That error template was designed for `default_program` migration, where `name` *is* the user's command string — so the example was correct there. But `LoadConfig` also calls it to validate `program_overrides` **keys**, where `name` is the map key (the invalid agent name), not the command. For an invalid override like `"amp": "/opt/amp --some-flag"`, the error suggested:

```
"program_overrides": { "claude": "amp" }
```

dropping the user's real command (`/opt/amp --some-flag`) and replacing it with the bare key. A user following the guidance literally would write a broken config. The data needed for a correct example (`config.ProgramOverrides[key]`) existed at the call site but was never passed in.

## Fix

New signature appends a third runtime parameter, keeping the existing `lead`/`referent` two-arg label split intact:

```go
func ValidateProgramEnum(lead, referent, name, exampleValue string) error
```

- When `exampleValue != ""`, it is rendered as the example override value.
- When `exampleValue == ""`, it falls back to `name` — preserving the correct prior behavior for `default_program` and other call sites where `name` already *is* the command.

The `program_overrides` loop in `LoadConfig` now ranges over `key, value` and passes `value` as `exampleValue`, so the user's original command is preserved in the example.

The leading `\n\n` / trailing `\n` CLI-rendering framing (#661) is unchanged.

## Audited callers (adjacent-call-sites rule)

All six callers updated. Only the `program_overrides` site passes a real `exampleValue`; the rest pass `""` because their `name` already is the user command:

| Call site | `exampleValue` | Why |
|---|---|---|
| `config/config.go` `default_program` | `""` | `name` IS the command |
| `config/config.go` `program_overrides` key | `value` | **the fix** — `name` is the key, value is the command |
| `main.go` `--program flag` | `""` | flag value IS the command |
| `api/sessions.go` (×2) `--program flag` | `""` | same |
| `api/tasks.go` `--program flag` | `""` | same |
| `task/task.go` (×2) `task program` | `""` | `t.Program` IS the command |

## Test coverage

`TestValidateProgramEnum` now exercises both shapes:
- **default_program-style** (`exampleValue == ""`): asserts the example falls back to `name`.
- **program_overrides-style** (`name` is key, `exampleValue` is command): regression assertion that the example embeds the user's command (`/opt/amp --some-flag`) and **not** the bare key (`amp`).

## CI gates

`golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `go build ./...`, `deadcode -test ./...` all clean. `go test -race ./...` passes for all touched packages (`config`, `api`, `task`, `main`). Two unrelated failures (`daemon`/`integration` PID/socket lifecycle tests) are environmental — flaky on re-run and confounded by stray `af --daemon` processes on the dev box; they don't touch `ValidateProgramEnum`.

Fixes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude
