### PR TITLE
fix(session/tmux): detect -XVAL contiguous resume flag form in resumeProgram (#685)

### DIFF
--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -63,7 +63,8 @@ func resumeProgram(program string) string {
 	case ProgramClaude:
 		for _, tok := range tokens {
 			if tok == "-c" || tok == "--continue" || tok == "-r" || tok == "--resume" ||
-				strings.HasPrefix(tok, "--resume=") || strings.HasPrefix(tok, "-r=") {
+				strings.HasPrefix(tok, "--resume=") || strings.HasPrefix(tok, "-r=") ||
+				isShortResumeWithAttachedValue(tok) {
 				return program
 			}
 		}
@@ -98,13 +99,25 @@ func resumeProgram(program string) string {
 	case ProgramGemini:
 		for _, tok := range tokens {
 			if tok == "--resume" || tok == "-r" ||
-				strings.HasPrefix(tok, "--resume=") || strings.HasPrefix(tok, "-r=") {
+				strings.HasPrefix(tok, "--resume=") || strings.HasPrefix(tok, "-r=") ||
+				isShortResumeWithAttachedValue(tok) {
 				return program
 			}
 		}
 		return program + " --resume latest"
 	}
 	return program
+}
+
+// isShortResumeWithAttachedValue reports whether tok is the POSIX
+// attached-value form of the short resume flag, e.g. "-r5" or "-rlatest"
+// (#685). Both claude and gemini expose "-r" as their only "-r*" short flag
+// (per their --help output), so any "-r"-prefixed token with a non-"="
+// attached value is unambiguously a resume flag. The "=" forms ("-r" /
+// "-r=VALUE") are matched separately by the callers, so they're excluded here.
+// Not used for codex (resume is a subcommand) or aider (no "-r" resume flag).
+func isShortResumeWithAttachedValue(tok string) bool {
+	return strings.HasPrefix(tok, "-r") && len(tok) > 2 && tok[2] != '='
 }
 
 // splitShellTokens tokenizes a shell-style command string, respecting single

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -49,6 +49,16 @@ func TestResumeProgram(t *testing.T) {
 		// flags if the CLI accepts `-r=VALUE` (same class as gemini's #633).
 		{"claude already -r=value", "claude -r=abc123", "claude -r=abc123"},
 		{"claude already -r=latest", "claude -r=latest", "claude -r=latest"},
+		// Short-option attached-value syntax (#685): claude parses `-r5` as
+		// `--resume 5`, so a second resume flag must not be appended.
+		{"claude already -rVALUE", "claude -r5", "claude -r5"},
+		{"claude already -rlatest", "claude -rlatest", "claude -rlatest"},
+		{"claude already -rabc123", "claude -rabc123", "claude -rabc123"},
+		{
+			"claude -rVALUE with other flags",
+			"claude --dangerously-skip-permissions -r5",
+			"claude --dangerously-skip-permissions -r5",
+		},
 
 		// Codex: insert "resume --last" after the codex token (subcommand
 		// position matters for codex; a tail append wouldn't parse).
@@ -227,6 +237,17 @@ func TestResumeProgram(t *testing.T) {
 		{"gemini already -r=numeric", "gemini -r=5", "gemini -r=5"},
 		{"gemini already -r=latest", "gemini -r=latest", "gemini -r=latest"},
 		{"gemini already -r=arbitrary", "gemini -r=anything", "gemini -r=anything"},
+		// Short-option attached-value syntax (#685): gemini parses `-r5` as
+		// `--resume 5`. Appending `--resume latest` would make gemini
+		// concatenate "5,latest" and fail with "Invalid session identifier".
+		{"gemini already -rVALUE", "gemini -r5", "gemini -r5"},
+		{"gemini already -rlatest", "gemini -rlatest", "gemini -rlatest"},
+		{"gemini already -rarbitrary", "gemini -ranything", "gemini -ranything"},
+		{
+			"gemini -rVALUE with other flags",
+			"gemini --model x -r5",
+			"gemini --model x -r5",
+		},
 
 		// Unknown programs are passed through unchanged so unrelated CLIs
 		// aren't accidentally rewritten.
@@ -281,8 +302,12 @@ func TestResumeProgram_Idempotent(t *testing.T) {
 		"gemini --resume=5",
 		"gemini -r=5",
 		"gemini -r=latest",
+		"gemini -r5",
+		"gemini -rlatest",
 		"claude --resume=abc123",
 		"claude -r=abc123",
+		"claude -r5",
+		"claude -rlatest",
 		"codex --profile resume",
 		"codex --profile=resume",
 		"codex exec --profile resume",


### PR DESCRIPTION
## Root cause

`resumeProgram` (`session/tmux/resume.go`) rewrites a session's program string to add a "resume most recent" flag when `Restore()` re-spawns a vanished tmux session. Before appending, it checks whether a resume flag is already present.

The detection covered four shapes of the short/long resume flag:

- `-r` / `--resume` (bare)
- `-r VALUE` / `--resume VALUE` (separate token)
- `-r=VALUE` / `--resume=VALUE` (equals form)

…but missed the **POSIX attached-value form** `-rVALUE` (e.g. `-r5`, `-rlatest`). So a user override like `gemini -r5` was rewritten to `gemini -r5 --resume latest`. Gemini concatenates the two resume values into `5,latest` and exits with **"Invalid session identifier"**. Claude had the identical gap on its `-r` branch (it parses `-r5` as `--resume 5`).

Introduced in #596; later fixes (#604 `--resume=VALUE`, #633 `-r=VALUE`) closed adjacent gaps but not the attached-value form.

## Fix

Surgical, no rewrite. Added one helper:

```go
func isShortResumeWithAttachedValue(tok string) bool {
    return strings.HasPrefix(tok, "-r") && len(tok) > 2 && tok[2] != '='
}
```

wired into the **claude** and **gemini** detection loops alongside the existing checks. Both CLIs expose `-r` as their only `-r*` short flag (per `--help`), so matching `-r<value>` carries no false-positive risk. The `=` forms stay matched by their own `-r=` prefix check, hence the `tok[2] != '='` guard.

## Audit (per CLAUDE.md adjacent-call-sites)

This is the same parser that handled #595 / #604 / #632 / #633 / #640. Covered all four supported agents:

| Agent  | Resume mechanism                | `-rVALUE` applicable? | Action |
|--------|---------------------------------|-----------------------|--------|
| claude | `-r`/`--resume`/`-c`/`--continue` | yes (`-r` short flag) | **fixed** — added attached-value detection (not to boolean `-c`) |
| gemini | `-r`/`--resume`                 | yes (`-r` short flag) | **fixed** — added attached-value detection |
| codex  | `resume` **subcommand**, position-aware | no `-r` flag | unchanged |
| aider  | `--restore-chat-history`        | no `-r` flag          | unchanged |

## Test matrix

Extended the table-driven `TestResumeProgram` and `TestResumeProgram_Idempotent` to cover, per affected agent, all flag shapes — bare enum, `--flag=VAL`, `--flag VAL`, `-r VAL`, `-r=VAL`, and the newly-handled `-rVAL` (`-r5`, `-rlatest`, `-rarbitrary`, plus combined-with-other-flags) — and confirm no double-append. Idempotency verified for the new `-rVALUE` inputs.

## Validation

- `go build ./...` ✅
- `gofmt -l .` ✅ (clean)
- `golangci-lint run --timeout=3m --fast` ✅
- `deadcode -test ./...` ✅ (clean)
- `go test -race ./...` — `session/tmux` ✅ and all primary packages green. (Two failures in `daemon`/`integration` on the dev box are host pollution — stray live `af --daemon` processes from prior runs — unrelated to this change; they pass in CI's clean sandbox.)

Fixes #685

— Captain Claude