### PR TITLE
fix(session/hook): bound startup list_cmd calls with restoreAliveTimeout (#692)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -351,7 +351,7 @@ func (b *HookBackend) IsAlive(i *Instance) bool {
 // UI (#666). Callers must pass either restoreAliveTimeout or
 // runtimeAliveTimeout.
 func (b *HookBackend) isAliveWithTimeout(i *Instance, timeout time.Duration) bool {
-	out, err := b.runListCmd(timeout)
+	out, err := runListCmd(b.Hooks.ListCmd, timeout)
 	// exec.ErrWaitDelay is non-fatal here (#676). runListCmd sets
 	// cmd.WaitDelay, so CombinedOutput returns ErrWaitDelay when the list_cmd
 	// script itself exited (per docs/remote-hooks.md, with code 0 on success)
@@ -383,18 +383,28 @@ func (b *HookBackend) isAliveWithTimeout(i *Instance, timeout time.Duration) boo
 	return false
 }
 
-func (b *HookBackend) runListCmd(timeout time.Duration) ([]byte, error) {
+// runListCmd executes the user-supplied list_cmd and returns its combined
+// output. A non-zero timeout bounds the wait via context + WaitDelay; zero
+// falls through to an unbounded exec, which no production caller should use.
+// Every list_cmd invocation runs on a path where an unbounded wait freezes
+// the UI, so each caller MUST pass a non-zero timeout:
+//   - IsAlive → runtimeAliveTimeout (steady-state TUI event loop, #666)
+//   - Start restore → restoreAliveTimeout (TUI startup, #645)
+//   - ListRemoteHookInstanceData → restoreAliveTimeout (startup import; the
+//     TUI blocks on this over RPC with no client-side deadline, so a hanging
+//     list_cmd would stall startup indefinitely, #692)
+func runListCmd(listCmd string, timeout time.Duration) ([]byte, error) {
 	if timeout <= 0 {
-		return exec.Command(b.Hooks.ListCmd, "--json").CombinedOutput()
+		return exec.Command(listCmd, "--json").CombinedOutput()
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, b.Hooks.ListCmd, "--json")
+	cmd := exec.CommandContext(ctx, listCmd, "--json")
 	// WaitDelay bounds how long CombinedOutput keeps reading from the
 	// command's stdout/stderr after the context is cancelled. Without it,
 	// a list_cmd script that spawned a long-running child (e.g. `sleep
 	// 30`) would keep the read-side pipe open past the kill signal sent
-	// to the script itself, defeating the restore-path timeout (#645).
+	// to the script itself, defeating the timeout (#645).
 	cmd.WaitDelay = 500 * time.Millisecond
 	return cmd.CombinedOutput()
 }
@@ -412,8 +422,19 @@ func ListRemoteHookInstanceData(repoPath string, hooks config.RemoteHooks, now t
 		return nil, nil
 	}
 
-	out, err := exec.Command(hooks.ListCmd, "--json").CombinedOutput()
-	if err != nil {
+	// Bound the wait with restoreAliveTimeout (2s). This runs at TUI startup
+	// inside the daemon handler that the TUI blocks on over RPC, and the RPC
+	// client sets no call deadline, so an unbounded list_cmd would hang
+	// startup indefinitely (#692). Fast-fail is appropriate for a startup
+	// gate; the caller logs the error and proceeds with persisted sessions.
+	out, err := runListCmd(hooks.ListCmd, restoreAliveTimeout)
+	// exec.ErrWaitDelay is non-fatal here, mirroring isAliveWithTimeout (#676):
+	// runListCmd sets cmd.WaitDelay, so CombinedOutput returns ErrWaitDelay
+	// when the list_cmd script exited 0 with complete output but a backgrounded
+	// child still holds the stdout/stderr pipes open. Fall through to
+	// extractJSON + json.Unmarshal, which validate the payload; a genuinely
+	// broken or timed-out list_cmd produces no parseable JSON and still errors.
+	if err != nil && !errors.Is(err, exec.ErrWaitDelay) {
 		return nil, fmt.Errorf("list_cmd failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -1192,6 +1192,35 @@ exit 1
 		"error must surface captured stderr so users can debug list_cmd failures (#561)")
 }
 
+// TestListRemoteHookInstanceDataListCmdHangs is the regression test for #692:
+// ListRemoteHookInstanceData runs the user-supplied list_cmd at TUI startup
+// inside the daemon handler that the TUI blocks on over RPC (with no
+// client-side call deadline). A hanging list_cmd (e.g. SSH to a wedged host)
+// previously had no timeout here, so startup blocked for the full duration of
+// the script. The startup import path must abort within restoreAliveTimeout
+// plus a small tolerance for WaitDelay and scheduling slack.
+func TestListRemoteHookInstanceDataListCmdHangs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timeout-bound test in short mode")
+	}
+
+	dir := t.TempDir()
+	// Sleep well past restoreAliveTimeout so the timeout, not the script,
+	// is what ends the call.
+	listCmd := writeScript(t, dir, "list.sh", `sleep 30; echo '[]'`)
+
+	start := time.Now()
+	_, err := ListRemoteHookInstanceData("/repo/root", config.RemoteHooks{ListCmd: listCmd}, time.Now())
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "startup import must error when list_cmd hangs past timeout")
+	// restoreAliveTimeout is 2s; allow a buffer for WaitDelay (500ms) plus
+	// scheduling slack. The key bound is that startup must NOT block anywhere
+	// near the script's 30s sleep — that was the #692 hang.
+	assert.Less(t, elapsed, restoreAliveTimeout+2*time.Second,
+		"startup import must return within restoreAliveTimeout+tolerance when list_cmd hangs (got %v)", elapsed)
+}
+
 func TestRunHookAttachWithDetachKey(t *testing.T) {
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("sh not available")


### PR DESCRIPTION
## Root cause

`ListRemoteHookInstanceData` runs the user-supplied `list_cmd` at TUI startup to import remote sessions. It used a bare `exec.Command(hooks.ListCmd, "--json").CombinedOutput()` with **no timeout**.

The TUI reaches this function through an RPC round-trip to the daemon (`callDaemonNoEnsure` → `Manager.ImportRemoteHookSessions` → `ListRemoteHookInstanceData`). The RPC client sets only a *dial* timeout — `net/rpc.Client.Call` has no read/write deadline. So when `list_cmd` blocks (hanging SSH, network partition, buggy script), the daemon handler blocks, and the TUI startup hangs for the full duration of the script (30s+).

The timeout helpers added in #666/#676 covered the steady-state `IsAlive` tick and the restore path, but the commit that fixed `IsAlive` (72709c7) explicitly left this startup-import path out of scope — that's the gap #692 reports.

## Fix

- Extracted the timeout-bounded runner into a package-level `runListCmd(listCmd, timeout)` (was a `HookBackend` method) so the startup-import function can share the exact same `context.WithTimeout` + `exec.CommandContext` + `WaitDelay` implementation.
- Routed `ListRemoteHookInstanceData` through it with `restoreAliveTimeout` (**2s**, not the 5s `runtimeAliveTimeout`) — this is a startup gate where fast-fail is correct; the callers (`app/sync.go`, `daemon/control.go`) log the error and proceed with persisted sessions.
- Tolerate `exec.ErrWaitDelay` here, mirroring `isAliveWithTimeout` (#676): a `list_cmd` that exits 0 with complete output but backgrounds a child holding the stdout pipe open must not be misreported as failed. Without this, the fix would have introduced a regression for those scripts.

The #666/#676 timeouts are unchanged — `IsAlive` still uses `runtimeAliveTimeout` (5s), restore still uses `restoreAliveTimeout` (2s).

## Adjacent call-site audit (per CLAUDE.md)

Every `list_cmd` invocation now routes through `runListCmd` with a non-zero timeout. The only remaining bare `exec.Command(listCmd, ...)` is inside `runListCmd`'s `timeout <= 0` defensive branch, which no caller reaches.

| Call site | Path | Timeout passed | Status |
|---|---|---|---|
| `isAliveWithTimeout` (via `IsAlive`) | steady-state TUI tick (#666) | `runtimeAliveTimeout` (5s) | ✅ unchanged |
| `isAliveWithTimeout` (via `Start` restore) | TUI startup restore (#645) | `restoreAliveTimeout` (2s) | ✅ unchanged |
| `ListRemoteHookInstanceData` | TUI startup import via daemon RPC (#692) | `restoreAliveTimeout` (2s) | ✅ **fixed** (was bare `exec.Command`, no timeout) |
| `runListCmd` `timeout <= 0` branch | defensive only | n/a | ✅ no caller passes 0 |

## Test

`TestListRemoteHookInstanceDataListCmdHangs`: a `list_cmd` that `sleep 30`s must make `ListRemoteHookInstanceData` return an error within `restoreAliveTimeout + 2s` tolerance, asserting startup no longer blocks near the script's 30s sleep. Passes under `-race`.

## Gates

- `go build ./...` ✅
- `gofmt -l .` ✅ (no output)
- `golangci-lint run --timeout=3m --fast` ✅
- `deadcode -test ./...` ✅ (no output)
- `go test ./...` ✅ (the one failure, `daemon.TestSigtermFallback_DeadPID`, is a pre-existing environmental flake — it scans the host for stray `af --daemon` processes and reproduces identically on a clean checkout; unrelated to this change)
- `go test -race` on the hook backend suite ✅

Fixes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by Captain Claude