### PR TITLE
fix(session/git): prune stale worktree metadata before recreating from existing branch (#695)

### DIFF
--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -49,6 +49,15 @@ func (g *GitWorktree) setupFromExistingBranch() error {
 	// Clean up any existing worktree first
 	_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath) // Ignore error if worktree doesn't exist
 
+	// Prune stale worktree metadata BEFORE re-adding. If the worktree
+	// directory was deleted externally (rm -rf, disk cleanup, etc.), git
+	// still tracks it internally and `worktree add <same-path>` fails with
+	// "missing but already registered worktree". Recent git clears that
+	// registration on the `worktree remove -f` above, but older git errors
+	// ("is not a working tree") and leaves it behind; pruning here recovers
+	// either way. Mirrors the prune-before-add ordering in setupNewWorktree.
+	_, _ = g.runGitCommand(g.repoPath, "worktree", "prune")
+
 	// Create a new worktree from the existing branch
 	if _, err := g.runGitCommand(g.repoPath, "worktree", "add", g.worktreePath, g.branchName); err != nil {
 		return fmt.Errorf("failed to create worktree from branch %s: %w", g.branchName, err)

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -169,6 +169,67 @@ func TestSetupFromExistingBranch_SetsBaseCommitSHA(t *testing.T) {
 	require.NoError(t, gw.Cleanup())
 }
 
+// TestSetupFromExistingBranch_RecreatesAfterExternalDeletion is a regression
+// test for issue #695. When a worktree directory is deleted outside the tool
+// (rm -rf, disk cleanup, etc.) git keeps tracking the worktree internally, and
+// a subsequent `git worktree add <same-path>` can fail with "missing but
+// already registered worktree". This guards the user-facing contract: reusing
+// a session name whose worktree directory was deleted externally must recreate
+// the worktree successfully.
+//
+// setupFromExistingBranch recovers via `worktree remove -f` followed by
+// `worktree prune` (added for this fix) before re-adding. Recent git clears a
+// missing-but-registered worktree on `remove -f` alone, so this test passes
+// even without the prune on such versions; the prune mirrors setupNewWorktree
+// and covers older git where `remove` errors on a missing worktree and leaves
+// the stale registration that blocks `worktree add`.
+func TestSetupFromExistingBranch_RecreatesAfterExternalDeletion(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+
+	// Initial commit so HEAD is valid.
+	cmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "initial")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	// Pre-existing branch so Setup() takes the setupFromExistingBranch path.
+	cmd = exec.Command("git", "-C", repoRoot, "branch", "test/existing-branch")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, _, err := NewGitWorktree(repoRoot, "existing-branch")
+	require.NoError(t, err)
+
+	// First setup succeeds and registers the worktree.
+	require.NoError(t, gw.Setup())
+	worktreePath := gw.GetWorktreePath()
+
+	// Simulate the user deleting the worktree directory out from under git
+	// (rm -rf). The registration in .git/worktrees/<name> survives.
+	require.NoError(t, os.RemoveAll(worktreePath))
+
+	// Recreating the session reuses the same path. Without the prune this
+	// fails with "missing but already registered worktree".
+	require.NoError(t, gw.Setup(),
+		"recreating a worktree after its directory was deleted externally should succeed")
+
+	// The worktree directory should exist again.
+	_, err = os.Stat(worktreePath)
+	require.NoError(t, err, "worktree directory should be recreated")
+
+	require.NoError(t, gw.Cleanup())
+}
+
 // TestCleanup_PreservesPreExistingBranch verifies that when Setup() reuses a
 // pre-existing local branch, Cleanup() does NOT delete it. Previously,
 // Cleanup() always ran `git branch -D <branch>`, destroying user work on any


### PR DESCRIPTION
## Root cause

`setupFromExistingBranch` recreates a worktree for a pre-existing branch when a user reuses a session name. It ran:

```go
_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath)
// (no prune)
_, err := g.runGitCommand(g.repoPath, "worktree", "add", g.worktreePath, g.branchName)
```

When the worktree directory is deleted **outside** the tool (`rm -rf`, disk cleanup, unmount), git keeps the worktree registered in `.git/worktrees/<name>`. On git versions where `worktree remove -f` errors on a missing worktree (`fatal: '<path>' is not a working tree`) the stale registration survives, and the subsequent `worktree add <same-path>` fails with:

```
fatal: '<path>' is a missing but already registered worktree;
use 'add -f' to override, or 'prune' or 'remove' to clear
```

Result: users can't recreate a session after the worktree directory was deleted externally. Introduced in 453ad89 (pause/resume), which added the recreate path without a prune.

## Fix

Add a best-effort `git worktree prune` between `remove -f` and `add`, mirroring the prune-before-add ordering already present in `setupNewWorktree` (and the prune-before-branch-delete in `Cleanup`/`CleanupWorktreesForRepo`). Prune clears the stale registration so `add` succeeds.

```go
_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath)
_, _ = g.runGitCommand(g.repoPath, "worktree", "prune") // <- added
_, err := g.runGitCommand(g.repoPath, "worktree", "add", g.worktreePath, g.branchName)
```

## Adjacent call-site audit

Per `CLAUDE.md`, I grepped every `worktree add` call site repo-wide. There are exactly two, both in `session/git/worktree_ops.go`:

| Site | Status |
|------|--------|
| `setupFromExistingBranch` (line 53) | **Was missing prune — fixed here.** |
| `setupNewWorktree` (line 132) | Already prunes before the add (line 107). No change needed. |

No other `worktree add` call sites exist (`CleanupWorktreesForRepo` only removes/prunes, never adds).

## Honest note on reproduction

On **recent git** (verified on 2.43.0), `worktree remove -f` already clears a missing-but-registered worktree on its own, so the `add` succeeds even without this prune — the bug surfaces on **older git** where `remove` errors on a missing worktree and leaves the registration. The prune is the defensive, version-independent guard and restores consistency with the sibling flows. Code comment and test document this precisely rather than overstating it.

## Test

`TestSetupFromExistingBranch_RecreatesAfterExternalDeletion` codifies the user-facing contract: set up a worktree for a pre-existing branch, `os.RemoveAll` the directory to simulate external deletion, then recreate the same session and assert `Setup()` succeeds and the worktree directory is recreated.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — OK
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./session/git/ -race` — pass

(The full-suite `daemon.TestSigtermFallback_DeadPID` failure is pre-existing/environmental — it fails on clean `master` too because the dev machine has real `af --daemon` processes running. Unrelated to this change.)

Fixes #695

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)