### PR TITLE
fix(app,ui): snapshot under mutex to eliminate metadata-tick and tabbed-window data races (#682, #684)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -355,7 +355,12 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.attached.Load() {
 			return m, tickUpdateMetadataCmd
 		}
-		instances := m.sidebar.GetInstances()
+		// Snapshot the instance list on the event loop before handing it to the
+		// background tick goroutine: GetInstances() shares the sidebar's backing
+		// array, which the event loop mutates via AddInstance/RemoveInstanceByTitle,
+		// so iterating it off-loop is a data race (#682). The copy is cheap and
+		// gives the goroutine a stable list to walk.
+		instances := m.sidebar.GetInstancesSnapshot()
 		return m, runMetadataTickCmd(instances)
 	case tea.MouseMsg:
 		if msg.Action == tea.MouseActionPress {

--- a/app/metadata_tick_race_test.go
+++ b/app/metadata_tick_race_test.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestMetadataTickSnapshotRace is the race-detector regression for issue #682.
+//
+// The tickUpdateMetadataMessage handler snapshots the sidebar instance list and
+// hands it to a background tea.Cmd goroutine (runMetadataTickCmd). Before the
+// fix the handler passed the sidebar's own slice (GetInstances), so the
+// goroutine iterated the same backing array the event loop mutates via
+// RemoveInstanceByTitle/AddInstance — a data race on the slice memory.
+//
+// This test drives the real handler (h.Update) so the snapshot is taken exactly
+// where production takes it, runs the returned cmd on its own goroutine just as
+// bubbletea would, and churns the sidebar on the event-loop goroutine in
+// between. Removing the front instance forces a full-array slicecopy, which is
+// the write that races with the goroutine's read.
+//
+// All instances are kept in Loading status so runMetadataTick's per-instance
+// branch is skipped (the loop body only does mutex-guarded GetStatus/Started
+// reads): that isolates the slice race so a clean run proves #682 is fixed
+// rather than masking an unrelated instance-internal race.
+//
+// Run with `go test -race`: this reports a DATA RACE on master and passes once
+// the handler copies the list via GetInstancesSnapshot.
+func TestMetadataTickSnapshotRace(t *testing.T) {
+	h := newTestHome(t)
+	for i := 0; i < 24; i++ {
+		inst := instanceWithFakeBackend(t, fmt.Sprintf("seed-%d", i))
+		inst.SetStatus(session.Loading)
+		h.sidebar.AddInstance(inst)
+	}
+
+	var wg sync.WaitGroup
+	const iters = 60
+	for i := 0; i < iters; i++ {
+		// The handler snapshots the instance list on the event loop and returns
+		// the tick cmd; bubbletea runs that cmd on a fresh goroutine.
+		_, cmd := h.Update(tickUpdateMetadataMessage{})
+		if cmd == nil {
+			t.Fatal("handler must return a re-schedule cmd")
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cmd()
+		}()
+
+		// Event-loop-side churn: removing the front instance shifts the whole
+		// backing array (slicecopy) — the write that races with the goroutine's
+		// iteration when the list is shared rather than copied. Re-adding the
+		// same pointer keeps the population stable across iterations.
+		insts := h.sidebar.GetInstances()
+		front := insts[0]
+		h.sidebar.RemoveInstanceByTitle(front.Title)
+		h.sidebar.AddInstance(front)
+	}
+	wg.Wait()
+}

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -390,9 +390,25 @@ func (s *Sidebar) ReplaceInstance(target, replacement *session.Instance) bool {
 	return false
 }
 
-// GetInstances returns all instances.
+// GetInstances returns all instances. The returned slice shares the sidebar's
+// backing array, so callers must only read it on the bubbletea event loop —
+// never hand it to a goroutine that outlives the call (see
+// GetInstancesSnapshot for that).
 func (s *Sidebar) GetInstances() []*session.Instance {
 	return s.instances
+}
+
+// GetInstancesSnapshot returns a copy of the instances slice for handing off
+// to a background goroutine. The metadata tick (#682) iterates the list on a
+// separate goroutine while the event loop may append/remove instances; copying
+// the slice header here (on the event loop, where mutations also happen) gives
+// the goroutine a private backing array so the two cannot race on the same
+// memory. The *session.Instance elements are shared, but each guards its own
+// fields with a mutex, so reading them across goroutines is safe.
+func (s *Sidebar) GetInstancesSnapshot() []*session.Instance {
+	out := make([]*session.Instance, len(s.instances))
+	copy(out, s.instances)
+	return out
 }
 
 // GetInstanceTitles returns a set of all instance titles for quick comparison.

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"sync/atomic"
+
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 
@@ -41,7 +43,11 @@ const (
 type TabbedWindow struct {
 	tabs []string
 
-	activeTab int
+	// activeTab is read from the background refreshPanesCmd goroutine
+	// (UpdatePreview/UpdateTerminal) while the bubbletea event loop writes it
+	// via Toggle/ToggleBack, so it is an atomic to avoid a data race (#684).
+	// The tab indices fit in an int32 (there are two tabs).
+	activeTab atomic.Int32
 	height    int
 	width     int
 
@@ -98,16 +104,18 @@ func (w *TabbedWindow) GetPreviewSize() (width, height int) {
 }
 
 func (w *TabbedWindow) Toggle() {
-	w.activeTab = (w.activeTab + 1) % len(w.tabs)
+	n := int32(len(w.tabs))
+	w.activeTab.Store((w.activeTab.Load() + 1) % n)
 }
 
 func (w *TabbedWindow) ToggleBack() {
-	w.activeTab = (w.activeTab - 1 + len(w.tabs)) % len(w.tabs)
+	n := int32(len(w.tabs))
+	w.activeTab.Store((w.activeTab.Load() - 1 + n) % n)
 }
 
 // UpdatePreview updates the content of the preview pane. instance may be nil.
 func (w *TabbedWindow) UpdatePreview(instance *session.Instance) error {
-	if w.activeTab != PreviewTab {
+	if int(w.activeTab.Load()) != PreviewTab {
 		return nil
 	}
 	return w.preview.UpdateContent(instance)
@@ -115,7 +123,7 @@ func (w *TabbedWindow) UpdatePreview(instance *session.Instance) error {
 
 // UpdateTerminal updates the terminal pane content. Only updates when terminal tab is active.
 func (w *TabbedWindow) UpdateTerminal(instance *session.Instance) error {
-	if w.activeTab != TerminalTab {
+	if int(w.activeTab.Load()) != TerminalTab {
 		return nil
 	}
 	return w.terminal.UpdateContent(instance)
@@ -128,7 +136,7 @@ func (w *TabbedWindow) ResetPreviewToNormalMode(instance *session.Instance) erro
 
 // Add these new methods for handling scroll events
 func (w *TabbedWindow) ScrollUp() {
-	switch w.activeTab {
+	switch int(w.activeTab.Load()) {
 	case PreviewTab:
 		err := w.preview.ScrollUp(w.instance)
 		if err != nil {
@@ -142,7 +150,7 @@ func (w *TabbedWindow) ScrollUp() {
 }
 
 func (w *TabbedWindow) ScrollDown() {
-	switch w.activeTab {
+	switch int(w.activeTab.Load()) {
 	case PreviewTab:
 		err := w.preview.ScrollDown(w.instance)
 		if err != nil {
@@ -157,17 +165,17 @@ func (w *TabbedWindow) ScrollDown() {
 
 // IsInPreviewTab returns true if the preview tab is currently active
 func (w *TabbedWindow) IsInPreviewTab() bool {
-	return w.activeTab == PreviewTab
+	return int(w.activeTab.Load()) == PreviewTab
 }
 
 // IsInTerminalTab returns true if the terminal tab is currently active
 func (w *TabbedWindow) IsInTerminalTab() bool {
-	return w.activeTab == TerminalTab
+	return int(w.activeTab.Load()) == TerminalTab
 }
 
 // GetActiveTab returns the currently active tab index
 func (w *TabbedWindow) GetActiveTab() int {
-	return w.activeTab
+	return int(w.activeTab.Load())
 }
 
 // AttachTerminal attaches to the terminal tmux session
@@ -207,6 +215,7 @@ func (w *TabbedWindow) String() string {
 
 	var renderedTabs []string
 
+	activeTab := int(w.activeTab.Load())
 	totalTabWidth := w.width
 	tabWidth := totalTabWidth / len(w.tabs)
 	lastTabWidth := totalTabWidth - tabWidth*(len(w.tabs)-1)
@@ -219,7 +228,7 @@ func (w *TabbedWindow) String() string {
 		}
 
 		var style lipgloss.Style
-		isFirst, isLast, isActive := i == 0, i == len(w.tabs)-1, i == w.activeTab
+		isFirst, isLast, isActive := i == 0, i == len(w.tabs)-1, i == activeTab
 		if isActive {
 			style = activeTabStyle
 		} else {
@@ -242,7 +251,7 @@ func (w *TabbedWindow) String() string {
 
 	row := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
 	var content string
-	switch w.activeTab {
+	switch activeTab {
 	case PreviewTab:
 		content = w.preview.String()
 	case TerminalTab:

--- a/ui/tabbed_window_race_test.go
+++ b/ui/tabbed_window_race_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestTabbedWindowActiveTabRace is the race-detector regression for issue #684.
+//
+// Toggle()/ToggleBack() write activeTab from the bubbletea event loop while the
+// refreshPanesCmd goroutine reads it via UpdatePreview()/UpdateTerminal(). With
+// activeTab as a plain int this is a data race; the fix makes it an
+// atomic.Int32.
+//
+// The background goroutine here mirrors refreshPanesCmd. Passing a nil instance
+// keeps UpdateContent a cheap fallback-state write under each pane's own mutex
+// (no tmux shell-out), so the only cross-goroutine access under test is
+// activeTab itself.
+//
+// Run with `go test -race`: reports a DATA RACE on master and passes after the
+// fix.
+func TestTabbedWindowActiveTabRace(t *testing.T) {
+	tw := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = tw.UpdatePreview(nil)
+			_ = tw.UpdateTerminal(nil)
+		}
+	}()
+
+	for i := 0; i < 100000; i++ {
+		tw.Toggle()
+	}
+	close(stop)
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Two data races, both introduced by the #560/#593 goroutine refactor and both the **same class**: a background goroutine reading/mutating state owned by the single-threaded bubbletea event loop. Bubbletea serializes `Update()` handlers, but `tea.Cmd` functions run on their own goroutines — so any event-loop-owned state a `tea.Cmd` touches must be snapshotted (or made atomic) at the seam.

### #682 — metadata tick vs. instance-list modifications
`tickUpdateMetadataMessage` handed `Sidebar.GetInstances()` (the sidebar's **own** backing array) to `runMetadataTickCmd`'s goroutine. That goroutine iterated the slice while the event loop mutated it via `RemoveInstanceByTitle`/`AddInstance` (`append(s.instances[:i], s.instances[i+1:]...)` → `slicecopy`) — a data race on the slice memory.

**Fix:** snapshot the slice on the event loop before handoff. New `Sidebar.GetInstancesSnapshot()` returns a copy (mirroring the existing `daemon/control.go` `InstancesSnapshot()` convention the issue cited). The `*session.Instance` elements stay shared but each guards its own fields with a mutex, so reading them across goroutines is safe.

### #684 — tab switching vs. background pane refresh
`refreshPanesCmd`'s goroutine read `TabbedWindow.activeTab` via `UpdatePreview`/`UpdateTerminal` while `Toggle`/`ToggleBack` wrote it on the event loop — an unsynchronized plain-`int` field.

**Fix:** make `activeTab` an `atomic.Int32`. No lock needed (per the "don't introduce locks where atomic suffices" constraint); all reads/writes go through `Load`/`Store`.

## Snapshot/atomic pattern
- **List handed to a goroutine** → copy on the event loop, iterate the copy.
- **Scalar shared with a goroutine** → atomic, no lock.

## Adjacent-call-site audit (per CLAUDE.md)
Swept every goroutine/`tea.Cmd` launched from `app/`, `ui/sidebar.go`, `ui/tabbed_window.go` for reads of event-loop-owned state:

| Goroutine (`tea.Cmd`) | Event-loop state read off-loop? | Status |
|---|---|---|
| `runMetadataTickCmd` (`app/sync.go`) | sidebar instance slice | **FIXED #682** — now snapshotted |
| `refreshPanesCmd` (`app/app.go`) | `tabbed_window.activeTab` | **FIXED #684** — now atomic |
| `refreshPanesCmd` → `preview`/`terminal` `UpdateContent` | pane content | Safe — `PreviewPane`/`TerminalPane` each guard state with an internal `sync.Mutex` (confirmed in `ui/preview.go`, `ui/terminal.go`; #579) |
| `fetchPRInfoCmd` (`app/sync.go`) | repo/branch via `FetchPRInfoSnapshot()`; `inst` passed through only | Safe — already snapshots its inputs |
| `killAction` (`app/handle_actions.go`) | iterates `GetInstances`, calls `RemoveInstanceByTitle` | Safe — invoked **synchronously** inside `ConfirmationOverlay.OnConfirm` from `HandleKeyPress`, i.e. on the event loop, not as a goroutine. (The `func() tea.Msg` signature is incidental.) |
| `startCmd` (`app/handle_input.go`, `app/app.go`) | captured value fields + `instance` pointer; `startSessionThroughDaemon` | Safe — no shared mutable event-loop state |
| `tickUpdate*Cmd`, `tickPending*`, `tickRefreshExternalCmd` | none (sleep → return msg) | Safe |
| `keydownCallback`, `handleError`, previewTick re-schedule, repaint-after-detach | none (timer/`ctx` select → return msg) | Safe |
| `startSlowDetachWatchdog` (`app/detach_trace.go`) | none (timer select; trace-only, gated) | Safe |

No remaining off-loop reads of event-loop-owned state.

## Tests (race detector)
Added focused `-race` regression tests that **fail on the unpatched source and pass after the fix**:

- `app.TestMetadataTickSnapshotRace` — drives the real `Update(tickUpdateMetadataMessage{})` handler (so the snapshot happens exactly where production takes it), runs the returned cmd on its own goroutine as bubbletea would, and churns the sidebar (front-instance removal → full-array `slicecopy`) on the event-loop goroutine. Instances kept `Loading` so the loop body only does mutex-guarded reads, isolating the slice race.
- `ui.TestTabbedWindowActiveTabRace` — loops `Toggle()` against a background goroutine calling `UpdatePreview(nil)`/`UpdateTerminal(nil)` (mirroring `refreshPanesCmd`; nil instance keeps `UpdateContent` a cheap mutex-guarded fallback write).

Verified by stashing the source fix and re-running: both report the exact DATA RACE from the issues (`RemoveInstanceByTitle` vs `runMetadataTick`; `UpdatePreview`/`UpdateTerminal` vs `Toggle`), then pass once restored. Stressed at `-count=5 -race`.

## CI gates
- `go build ./...` ✅
- `gofmt -l .` ✅ (clean)
- `golangci-lint run --timeout=3m --fast` ✅
- `deadcode -test ./...` ✅ (clean)
- `go test -race ./...` ✅ for all packages. Two unrelated failures on this dev box only: `daemon.TestSigtermFallback_DeadPID` (9 stray `af --daemon` processes already running on the machine) and `app.TestRealTUI_CreateThroughKeypresses` (real-tmux e2e, flaky under full parallel `-race` load — passes in isolation). Neither touches `app/`/`ui/` changes here.

Fixes #682
Fixes #684

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)