### PR TITLE
fix(app/detach_trace): cancel watchdog on no-instances early-return (#683)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -399,6 +399,19 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		detachTraceMark("repaintAfterDetachMsg-handler-entry")
 		cmd := m.selectionChanged()
 		detachTraceMark("repaintAfterDetachMsg-handler-exit")
+		// The watchdog armed in attachOverlayCallback is ended when the
+		// post-detach paint completes (panesRefreshedMsg). That msg is only
+		// emitted by refreshPanesCmd, which selectionChanged dispatches only
+		// when an instance row is selected. When the selection has fallen back
+		// to a section header — e.g. the only instance was removed while the
+		// user was attached — selectionChanged returns nil, no
+		// panesRefreshedMsg ever arrives, and the watchdog would fire a
+		// spurious goroutine dump after slowDetachThreshold even though there
+		// were no panes to refresh. Cancel it here: a nil cmd means the detach
+		// already completed everything it was going to do (#683).
+		if cmd == nil {
+			endDetachWatchdog()
+		}
 		return m, cmd
 	case panesRefreshedMsg:
 		// The refresh cmd already wrote captured content into the mutex-

--- a/app/detach_watchdog_test.go
+++ b/app/detach_watchdog_test.go
@@ -1,0 +1,118 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/require"
+)
+
+// resetDetachWatchdog tears down any watchdog left armed by a test so it
+// cannot leak its goroutine (or a spurious dump) into a sibling test that
+// shares the package-global detachWatchdogDone.
+func resetDetachWatchdog(t *testing.T) {
+	t.Helper()
+	t.Cleanup(endDetachWatchdog)
+}
+
+// TestWatchdogCanceled_WhenLastInstanceRemovedWhileAttached is the regression
+// test for issue #683. The slow-detach watchdog (armed in
+// attachOverlayCallback) is normally ended when the post-detach paint
+// completes via panesRefreshedMsg. That msg is only emitted by refreshPanesCmd,
+// which selectionChanged dispatches only when an instance row is selected.
+//
+// When the only instance is removed while the user is attached, the sidebar
+// selection falls back to the Instances header. On detach, selectionChanged
+// returns nil (no refresh cmd), so panesRefreshedMsg never arrives. Before the
+// fix the watchdog stayed armed and fired a spurious goroutine dump after
+// slowDetachThreshold. After the fix, the repaintAfterDetachMsg handler ends
+// the watchdog when selectionChanged returns nil.
+func TestWatchdogCanceled_WhenLastInstanceRemovedWhileAttached(t *testing.T) {
+	resetDetachWatchdog(t)
+
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "only-instance")
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	require.False(t, h.sidebar.GetSelection().IsHeader,
+		"initial selection should be on the instance row")
+
+	// Simulate: attached, then the only instance is removed out from under us.
+	h.attached.Store(true)
+	h.sidebar.RemoveInstanceByTitle("only-instance")
+	require.True(t, h.sidebar.GetSelection().IsHeader,
+		"after removing the only instance, selection falls back to the header")
+
+	// Detach: arm the watchdog exactly as attachOverlayCallback does, then run
+	// the post-detach repaint handler.
+	h.attached.Store(false)
+	beginDetachWatchdog("test-attach")
+
+	_, cmd := h.Update(repaintAfterDetachMsg{})
+	require.Nil(t, cmd,
+		"selectionChanged returns nil on a header selection (no panes to refresh)")
+
+	// The handler must have ended the watchdog itself, since no
+	// panesRefreshedMsg will ever arrive to do it.
+	detachWatchdogMu.Lock()
+	armed := detachWatchdogDone
+	detachWatchdogMu.Unlock()
+	require.Nil(t, armed,
+		"watchdog must be canceled on the no-instances early-return, "+
+			"otherwise it fires a spurious goroutine dump after slowDetachThreshold (#683)")
+}
+
+// TestWatchdog_NoSpuriousDumpAfterHeaderDetach is the end-to-end proof that the
+// fix prevents the spurious diagnostic file. It runs past the real
+// slowDetachThreshold and asserts detach-slow.log is never written for the
+// header-selection detach. The first phase is a control that lets an
+// un-canceled watchdog fire, proving the dump wiring (config dir →
+// detach-slow.log) works and that this test can actually observe a dump.
+func TestWatchdog_NoSpuriousDumpAfterHeaderDetach(t *testing.T) {
+	resetDetachWatchdog(t)
+
+	// newTestHome redirects AGENT_FACTORY_HOME to its own tempdir, so derive
+	// the dump path from the config dir *after* building the home — otherwise
+	// dumpSlowDetach writes to the home's dir while we watch the wrong one.
+	h := newTestHome(t)
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	dumpPath := filepath.Join(configDir, detachSlowDumpFileName)
+
+	prev := detachTraceEnabled
+	detachTraceEnabled = true
+	t.Cleanup(func() { detachTraceEnabled = prev })
+
+	// --- Control: an un-canceled watchdog DOES write a dump after the
+	// threshold. This guards against the regression assertion silently passing
+	// because the dump path was misconfigured.
+	beginDetachWatchdog("control-uncanceled")
+	time.Sleep(slowDetachThreshold + 300*time.Millisecond)
+	_, err = os.Stat(dumpPath)
+	require.NoError(t, err,
+		"control: an un-canceled watchdog must write detach-slow.log after the threshold")
+	endDetachWatchdog()
+	require.NoError(t, os.Remove(dumpPath))
+
+	// --- Regression: the header-selection detach must NOT write a dump.
+	inst := instanceWithFakeBackend(t, "only-instance")
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+	h.attached.Store(true)
+	h.sidebar.RemoveInstanceByTitle("only-instance")
+	require.True(t, h.sidebar.GetSelection().IsHeader)
+	h.attached.Store(false)
+
+	beginDetachWatchdog("regression-header-detach")
+	_, cmd := h.Update(repaintAfterDetachMsg{})
+	require.Nil(t, cmd)
+
+	time.Sleep(slowDetachThreshold + 300*time.Millisecond)
+	_, err = os.Stat(dumpPath)
+	require.True(t, os.IsNotExist(err),
+		"watchdog wrote a spurious goroutine dump for a header-selection detach (#683)")
+}


### PR DESCRIPTION
## Root cause

The slow-detach watchdog (added in #599 to diagnose the #598 multi-second detach hangs) is armed in `attachOverlayCallback` right after `<-ch` unblocks (`app/app.go:807`), and is ended when the post-detach paint completes via `panesRefreshedMsg` (`app/app.go:411`).

`panesRefreshedMsg` is **only** emitted by `refreshPanesCmd`, which `selectionChanged` dispatches **only** when an instance row is selected. When the only instance is removed while the user is attached, the sidebar selection falls back to the **Instances header**. On detach, `repaintAfterDetachMsg` → `selectionChanged()` returns `nil` (the `default`/header branch builds no refresh cmd, so `tea.Batch(nil, nil) == nil`). No `panesRefreshedMsg` ever arrives, the watchdog stays armed, and after `slowDetachThreshold` (2s) it appends a **spurious goroutine dump** to `~/.config/agent-factory/detach-slow.log` — even though there were no panes to refresh. Each false positive makes that log less useful for diagnosing real hangs.

## Fix

End the watchdog in the `repaintAfterDetachMsg` handler when `selectionChanged()` returns `nil`. A `nil` cmd means the detach already did everything it was going to do, so no `panesRefreshedMsg` is coming.

```go
case repaintAfterDetachMsg:
    detachTraceMark("repaintAfterDetachMsg-handler-entry")
    cmd := m.selectionChanged()
    detachTraceMark("repaintAfterDetachMsg-handler-exit")
    if cmd == nil {
        endDetachWatchdog()
    }
    return m, cmd
```

The 2s threshold and the goroutine dump are **untouched** — they remain load-bearing for diagnosing genuinely slow refreshes per #598. Only the no-work early-return is short-circuited.

## Adjacent-call-site audit (per CLAUDE.md)

`beginDetachWatchdog` has a single arm site. Every post-arm exit now terminates the watchdog within the 2s window:

| Detach path (after arming in `attachOverlayCallback`) | `selectionChanged` result | How the watchdog ends |
| --- | --- | --- |
| Instance row selected, not attached | `refreshPanesCmd` (+ maybe `prFetch`) | `panesRefreshedMsg` → `endDetachWatchdog` (existing) |
| Instance row selected, still attached | `nil` | **new** `cmd == nil` → `endDetachWatchdog` |
| Tasks section selected | `nil` | **new** `cmd == nil` → `endDetachWatchdog` |
| Hooks section selected | `nil` | **new** `cmd == nil` → `endDetachWatchdog` |
| Section header (incl. no-instances, **#683**) | `nil` | **new** `cmd == nil` → `endDetachWatchdog` |
| Genuinely slow `refreshPanesCmd` (>2s) | non-nil | watchdog **fires** (intended — real hang) |
| Attach itself fails | n/a | watchdog never armed (early `return nil` precedes `beginDetachWatchdog`) |

The only "non-nil cmd but no `panesRefreshedMsg`" case to worry about would be a prefetch-only batch — but `prFetch`'s guard (`!attachedNow && selected != nil && selected.Started()`) is a strict subset of `refreshCmd`'s (`!attachedNow`) inside the instance-row branch, so any non-nil cmd always carries `refreshPanesCmd`. The `cmd == nil` guard is therefore both necessary and sufficient.

## Tests (`app/detach_watchdog_test.go`)

- **`TestWatchdogCanceled_WhenLastInstanceRemovedWhileAttached`** — deterministic: builds the scenario (attach → remove only instance → selection falls to header → detach), runs the `repaintAfterDetachMsg` handler, asserts `cmd == nil` and that `detachWatchdogDone` is `nil` (watchdog canceled).
- **`TestWatchdog_NoSpuriousDumpAfterHeaderDetach`** — end-to-end: runs past the **real** 2s threshold and asserts `detach-slow.log` is never written for the header detach. A **control phase** first lets an un-canceled watchdog fire and asserts the dump *is* written, proving the dump wiring works and the negative assertion is meaningful.

Both tests **fail without the fix** (verified by reverting `app/app.go`) and pass with it.

## Gates

- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go build ./...` — ok
- `go test ./...` — `app` and all other packages green; the lone failure is `daemon/TestSigtermFallback_DeadPID`, which is **pre-existing and environmental** (fails identically on the unmodified tree because this host has 8–9 stray `af --daemon` processes polluting its process scan — unrelated to this app-only change).
- `go test -race ./app/ -run 'TestWatchdog|Detach|Repaint|SelectionChanged'` — green

Fixes #683

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)