### PR TITLE
fix(api/sessions): run trust-dialog handling for sessions without an initial prompt (#698)

### DIFF
--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -102,8 +102,13 @@ func writeIntegrationConfig(t *testing.T, home string) {
 	// Write a wrapper script that ignores any --plugin-dir / --dangerously-skip
 	// flags injectSystemPrompt would append; route the claude enum to it via
 	// ProgramOverrides so the CLI accepts --program claude (#658).
+	//
+	// It prints a "❯" ready prompt before reading stdin so the daemon's
+	// waitForReady loop recognises the pane as ready. The create path now
+	// always waits for readiness — even for empty-prompt sessions (#698) — so
+	// a real agent's startup prompt must be emulated here.
 	wrapper := filepath.Join(home, "fake-agent.sh")
-	require.NoError(t, os.WriteFile(wrapper, []byte("#!/bin/sh\nexec cat\n"), 0755))
+	require.NoError(t, os.WriteFile(wrapper, []byte("#!/bin/sh\nprintf '❯ '\nexec cat\n"), 0755))
 	cfg := &config.Config{
 		DefaultProgram:     tmux.ProgramClaude,
 		ProgramOverrides:   map[string]string{tmux.ProgramClaude: wrapper},

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1010,9 +1010,10 @@ func startAndSendPrompt(instance *session.Instance, prompt string) error {
 	if instance.IsRemote() {
 		return nil
 	}
-	if prompt == "" {
-		return nil
-	}
+	// Always wait for readiness and dismiss trust prompts, even when no
+	// initial prompt is sent (#698). Skipping this on empty prompt left
+	// sessions stuck on the trust dialog, so a later send-prompt typed into
+	// the dialog instead of the agent.
 	if err := waitForReady(instance); err != nil {
 		return err
 	}

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -38,12 +38,22 @@ func setupControlRepo(t *testing.T) string {
 	return repo
 }
 
+// readyFakeBackend is a FakeBackend whose Preview reports a ready prompt so
+// that the daemon's waitForReady loop returns immediately. The create path
+// now always waits for readiness — even for empty-prompt sessions (#698) — so
+// the backend must look ready rather than returning blank Preview output.
+type readyFakeBackend struct {
+	*session.FakeBackend
+}
+
+func (readyFakeBackend) Preview(*session.Instance) (string, error) { return "ready\n❯", nil }
+
 func installInstantBackend(t *testing.T) {
 	t.Helper()
 	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, absPath string) (session.Backend, error) {
 		backend := session.NewFakeBackend()
 		backend.CompleteStart()
-		return backend, nil
+		return readyFakeBackend{backend}, nil
 	})
 	t.Cleanup(restore)
 }

--- a/daemon/start_test.go
+++ b/daemon/start_test.go
@@ -1,0 +1,102 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// startTestBackend is a minimal Backend that records whether trust-prompt
+// handling and prompt-send ran, so we can assert startAndSendPrompt's
+// behaviour independent of any real tmux/PTY.
+type startTestBackend struct {
+	trustChecks int
+	sentPrompt  string
+	promptSent  bool
+}
+
+func (b *startTestBackend) Start(instance *session.Instance, _ bool) error {
+	instance.SetStartedForTest(true)
+	return nil
+}
+
+func (b *startTestBackend) Kill(instance *session.Instance) error {
+	instance.SetStartedForTest(false)
+	return nil
+}
+
+func (b *startTestBackend) Preview(*session.Instance) (string, error) {
+	return "ready\n❯", nil
+}
+
+func (b *startTestBackend) PreviewFullHistory(*session.Instance) (string, error) {
+	return "ready\n❯", nil
+}
+
+func (b *startTestBackend) Attach(*session.Instance) (chan struct{}, error) {
+	ch := make(chan struct{})
+	close(ch)
+	return ch, nil
+}
+
+func (b *startTestBackend) HasUpdated(*session.Instance) (bool, bool)  { return false, false }
+func (b *startTestBackend) SendPrompt(*session.Instance, string) error { return nil }
+func (b *startTestBackend) SendPromptCommand(_ *session.Instance, prompt string) error {
+	b.promptSent = true
+	b.sentPrompt = prompt
+	return nil
+}
+func (b *startTestBackend) SendKeys(*session.Instance, string) error         { return nil }
+func (b *startTestBackend) SetPreviewSize(*session.Instance, int, int) error { return nil }
+func (b *startTestBackend) IsAlive(*session.Instance) bool                   { return true }
+func (b *startTestBackend) CheckAndHandleTrustPrompt(*session.Instance) bool {
+	b.trustChecks++
+	return false
+}
+func (b *startTestBackend) TapEnter(*session.Instance) {}
+func (b *startTestBackend) Type() string               { return "local" }
+
+func newStartTestInstance(t *testing.T, backend session.Backend) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "start-test",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	inst.SetBackend(backend)
+	return inst
+}
+
+// TestStartAndSendPrompt_EmptyPromptStillHandlesTrust is the regression test
+// for #698: a session created without an initial prompt must still wait for
+// readiness and dismiss trust prompts, even though no prompt is sent.
+func TestStartAndSendPrompt_EmptyPromptStillHandlesTrust(t *testing.T) {
+	backend := &startTestBackend{}
+	if err := startAndSendPrompt(newStartTestInstance(t, backend), ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if backend.trustChecks == 0 {
+		t.Fatalf("trust prompt handling must run for empty-prompt sessions (#698)")
+	}
+	if backend.promptSent {
+		t.Fatalf("no prompt should be sent for empty prompt, got %q", backend.sentPrompt)
+	}
+}
+
+// TestStartAndSendPrompt_NonEmptyPromptSends confirms the prompt is still sent
+// (after trust handling) when one is provided.
+func TestStartAndSendPrompt_NonEmptyPromptSends(t *testing.T) {
+	backend := &startTestBackend{}
+	if err := startAndSendPrompt(newStartTestInstance(t, backend), "do work"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if backend.trustChecks == 0 {
+		t.Fatalf("trust prompt handling must run before sending the prompt")
+	}
+	if backend.sentPrompt != "do work" {
+		t.Fatalf("expected prompt to be sent, got %q", backend.sentPrompt)
+	}
+}

--- a/integration/cli_daemon_test.go
+++ b/integration/cli_daemon_test.go
@@ -297,8 +297,13 @@ func newHarness(t *testing.T) *harness {
 	// errors out on those flags, so write a shell wrapper that swallows any
 	// args and behaves as a stdin-reading pane process. ProgramOverrides
 	// in testConfig points the claude enum at this wrapper.
+	//
+	// The wrapper prints a "❯" ready prompt before reading stdin so the
+	// daemon's waitForReady loop recognises the pane as ready. The create
+	// path now always waits for readiness — even for empty-prompt sessions
+	// (#698) — so a real agent's startup prompt must be emulated here.
 	wrapper := filepath.Join(home, "fake-agent.sh")
-	writeFile(t, wrapper, "#!/bin/sh\nexec cat\n", 0755)
+	writeFile(t, wrapper, "#!/bin/sh\nprintf '❯ '\nexec cat\n", 0755)
 	writeConfigWithProgramPath(t, home, wrapper)
 
 	h := &harness{


### PR DESCRIPTION
## Root cause

`daemon.startAndSendPrompt` (the daemon control-plane path that backs the TUI, `af sessions create`, and scheduled tasks since #436) returned early when the initial prompt was empty:

```go
if prompt == "" {
    return nil   // <-- before waitForReady() + trust-prompt dismissal
}
```

That early return sat *before* `waitForReady()` and the `CheckAndHandleTrustPrompt` loop. So a session created without `--prompt` (e.g. `af sessions create --name foo`) never had its startup trust dialog dismissed and was left blocked on it. A later `af sessions send-prompt` then typed the prompt text into the trust dialog instead of the agent.

The AutoYes daemon loop is not a workaround: it keys off approval-prompt strings via `HasUpdated()`, which don't match the trust-prompt strings.

This regressed in `d0afe1c`, which introduced the buggy daemon copy and routed creation through it. The canonical `task.StartAndSendPrompt` always did trust handling *before* the empty-prompt check — this change restores that ordering in the daemon path.

## Fix

Removed the empty-prompt early return. Every local session now waits for readiness and dismisses trust prompts on start; the prompt is sent only when non-empty (`SendPromptCommand` is still guarded by `prompt != ""`). One-line production change.

## Adjacent call-site audit

Per the repo's adjacent-call-sites convention, I swept every path that starts a session or sends a prompt:

- **`daemon.startAndSendPrompt`** — fixed (this PR).
- **`task.StartAndSendPrompt`** — already correct; trust handling precedes the empty-prompt check. No change.
- **`daemon.SendPrompt` (later `send-prompt` endpoint)** — *excluded*: it requires a non-empty prompt and targets an already-started session. With trust dismissed at create time, this path is correct as-is; adding trust handling here would be scope creep and diverges from the canonical path.
- **`StartWithExistingWorktree`** (restore/attach branch) — *excluded*: separate code path, unchanged by this issue; the worktree was previously trusted. Out of scope for #698.
- **Remote sessions** — *excluded*: `startAndSendPrompt` returns early on `IsRemote()`; readiness/prompts are handled on the remote host (this is why `app/sync_test.go`'s remote-hook wrapper needs no change).

## Tests

- **New regression test** `daemon/start_test.go`:
  - `TestStartAndSendPrompt_EmptyPromptStillHandlesTrust` — a fake-backend session started with **no prompt** must still invoke `CheckAndHandleTrustPrompt` and must **not** send a prompt. This test fails on the pre-fix code (verified) and passes with the fix.
  - `TestStartAndSendPrompt_NonEmptyPromptSends` — trust handling runs *and* the prompt is sent.
- **Fixture updates required by the fix** (empty-prompt creates now run `waitForReady`, so test agents must report ready like real agents do):
  - `daemon/control_test.go`: `readyFakeBackend` reports a `❯` ready prompt.
  - `integration/cli_daemon_test.go` and `app/cli_daemon_integration_test.go`: the `fake-agent.sh` wrapper now prints a `❯` ready prompt before `exec cat`.

All four CI gates pass locally (`gofmt -l`, `go build ./...`, `golangci-lint run --fast`, `deadcode -test ./...`), and `go test -race -count=1 ./...` is green except `TestSigtermFallback_DeadPID`, which is a pre-existing environmental failure on the dev box (it counts live `af --daemon` processes; fails identically on unmodified `master` and is unrelated to this change).

Fixes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude
