### PR TITLE
fix(ui/preview): guard mouse scroll path against stale viewport on instance switch (#702)

### DIFF
--- a/ui/preview.go
+++ b/ui/preview.go
@@ -73,6 +73,28 @@ func (p *PreviewPane) SetSize(width, maxHeight int) {
 	p.viewport.Height = maxHeight
 }
 
+// dropStaleScrollState clears scroll-mode viewport content captured from a
+// previously selected instance and updates currentInstance. Caller must hold
+// p.mu.
+//
+// UpdateContent runs this on every refresh, but the mouse scroll path
+// (ScrollUp/ScrollDown) is driven straight off the bubbletea event loop and
+// can fire before the async UpdateContent for the newly selected instance has
+// run. Without this guard a wheel scroll would scroll the previous instance's
+// stale viewport instead of resetting scroll mode (#702). Consolidating the
+// reset here keeps the three entry points consistent — the same motivation as
+// the TerminalPane.setFallbackState consolidation in #669.
+func (p *PreviewPane) dropStaleScrollState(instance *session.Instance) {
+	if instance != p.currentInstance {
+		if p.isScrolling {
+			p.isScrolling = false
+			p.viewport.SetContent("")
+			p.viewport.GotoTop()
+		}
+		p.currentInstance = instance
+	}
+}
+
 // setFallbackState sets the preview state with fallback text and a message
 func (p *PreviewPane) setFallbackState(message string) {
 	p.previewState = previewState{
@@ -95,14 +117,7 @@ func (p *PreviewPane) UpdateContent(instance *session.Instance) error {
 	// scroll-mode viewport content captured from the previous instance.
 	// Otherwise switching instances while scrolling leaves the viewport
 	// pinned on the previous instance's output (issue #470).
-	if instance != p.currentInstance {
-		if p.isScrolling {
-			p.isScrolling = false
-			p.viewport.SetContent("")
-			p.viewport.GotoTop()
-		}
-		p.currentInstance = instance
-	}
+	p.dropStaleScrollState(instance)
 
 	switch {
 	case instance == nil:
@@ -251,6 +266,11 @@ func (p *PreviewPane) ScrollUp(instance *session.Instance) error {
 		return nil
 	}
 
+	// Reset scroll mode if the selection changed out from under us, so we
+	// capture the newly selected instance's content rather than scrolling the
+	// previous instance's stale viewport (#702).
+	p.dropStaleScrollState(instance)
+
 	if !p.isScrolling {
 		// Entering scroll mode - capture entire pane content including scrollback history
 		content, err := instance.PreviewFullHistory()
@@ -289,6 +309,11 @@ func (p *PreviewPane) ScrollDown(instance *session.Instance) error {
 	if instance == nil {
 		return nil
 	}
+
+	// Reset scroll mode if the selection changed out from under us, so we
+	// capture the newly selected instance's content rather than scrolling the
+	// previous instance's stale viewport (#702).
+	p.dropStaleScrollState(instance)
 
 	if !p.isScrolling {
 		// Entering scroll mode - capture entire pane content including scrollback history

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -892,3 +892,45 @@ func TestPreviewSwitchInstanceResetsScroll(t *testing.T) {
 	require.NotContains(t, p.viewport.View(), previewA,
 		"stale viewport content from A must be cleared")
 }
+
+// TestScrollMouseDifferentInstanceResetsScrollMode is a regression test for
+// issue #702: the mouse-wheel scroll path (ScrollUp/ScrollDown) runs straight
+// off the bubbletea event loop and can fire before the async UpdateContent for
+// a newly selected instance has run. When the user is scrolling instance A and
+// the selection switches to B, a wheel scroll must NOT scroll A's stale
+// viewport — it must reset scroll mode and capture B's content, mirroring the
+// guard UpdateContent already had.
+func TestScrollMouseDifferentInstanceResetsScrollMode(t *testing.T) {
+	const previewA = "instance-A-content"
+	const previewB = "instance-B-content"
+
+	instA, instB, cleanup := setupTwoInstances(t, previewA, previewB)
+	defer cleanup()
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+
+	// Enter scroll mode on A via the mouse path (no prior UpdateContent).
+	require.NoError(t, p.ScrollUp(instA))
+	require.True(t, p.isScrolling, "should be scrolling A after ScrollUp(A)")
+	require.Contains(t, p.viewport.View(), previewA,
+		"precondition: viewport should hold A's captured content")
+
+	// Selection switches to B, but UpdateContent(B) has not run yet. A
+	// wheel-up arrives for B. Before the fix this scrolled A's stale viewport;
+	// now it must drop scroll state and re-capture B's content.
+	require.NoError(t, p.ScrollUp(instB))
+	require.True(t, p.isScrolling,
+		"should re-enter scroll mode for B after the switch")
+	require.Contains(t, p.viewport.View(), previewB,
+		"viewport must reflect B after the mouse scroll, not stale A")
+	require.NotContains(t, p.viewport.View(), previewA,
+		"stale viewport content from A must be cleared on the scroll path")
+
+	// The same must hold for the ScrollDown entry point.
+	require.NoError(t, p.ScrollDown(instA))
+	require.Contains(t, p.viewport.View(), previewA,
+		"ScrollDown on a switched-to instance must re-capture its content")
+	require.NotContains(t, p.viewport.View(), previewB,
+		"stale viewport content from B must be cleared on ScrollDown path")
+}


### PR DESCRIPTION
## Root cause

`PreviewPane.ScrollUp` / `ScrollDown` are driven straight off the bubbletea event loop (mouse-wheel path). `UpdateContent` already dropped scroll-mode viewport content captured from a previously selected instance:

```go
if instance != p.currentInstance {
    if p.isScrolling { p.isScrolling = false; p.viewport.SetContent(""); p.viewport.GotoTop() }
    p.currentInstance = instance
}
```

…but the scroll handlers did not. The preview refresh runs asynchronously, so when the selection switches from A to B a wheel scroll can fire `ScrollUp(instB)` *before* `UpdateContent(instB)` runs. In scroll mode the handler then called `p.viewport.LineUp(1)` on A's stale captured viewport instead of resetting and capturing B's content — the displayed output no longer matched the selected instance.

## Fix

Extract the mismatch guard into `dropStaleScrollState(instance)` and call it from **all three** entry points — `UpdateContent`, `ScrollUp`, `ScrollDown`. On the scroll path, a mismatch now clears scroll mode so the `!p.isScrolling` branch re-captures the newly selected instance's full history before scrolling.

This is the same class of bug and the same remedy as **#669**, where `TerminalPane.setFallbackState` was made the single place that resets scroll state so `isScrolling=true` could never coexist with stale content that `String()` would render in preference to the intended state.

## Adjacent call-site audit (per CLAUDE.md)

Every `PreviewPane` method that touches the viewport:

- `UpdateContent` — already guarded; now routes through the shared helper.
- `ScrollUp` / `ScrollDown` — **fixed here.**
- `ResetToNormalMode(instance)` — unconditionally clears the viewport (`SetContent("")` + `GotoTop()`) before doing anything, so it can never scroll stale content; no guard needed.
- `String()` — renderer-only, takes no instance and merely renders current state; the instance-switch reset belongs on the mutating entry points, which now all have it.

## Test

Added `TestScrollMouseDifferentInstanceResetsScrollMode`: enters scroll mode on A via the mouse path, then — without any intervening `UpdateContent(B)` — calls `ScrollUp(instB)` and asserts the viewport reflects B's content (not stale A) and that `ScrollDown` behaves the same. Fails before the fix, passes after. Existing `TestPreviewSwitchInstanceResetsScroll` (#470) still passes.

## Gates

`go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, and `deadcode -test ./...` all clean; `go test -race ./ui/...` green. (The unrelated `daemon` `TestSigtermFallback_DeadPID` failure is an environment artifact — stray `af --daemon` processes on the test host, not touched by this change.)

Fixes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)