### PR TITLE
fix(ui/overlay): preserve both colors when fading combined ANSI FG+BG SGR sequences (#701)

### DIFF
--- a/ui/overlay/combined_fgbg_test.go
+++ b/ui/overlay/combined_fgbg_test.go
@@ -1,0 +1,101 @@
+package overlay
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// TestPlaceOverlayCombinedFgBgFade is the headline regression guard for #701:
+// a combined foreground+background SGR sequence emitted by lipgloss must keep
+// BOTH colors when faded. The pre-fix code over-matched the combined sequence
+// with bgColorRegex and replaced it with a background-only gray, dropping the
+// foreground entirely.
+func TestPlaceOverlayCombinedFgBgFade(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI256)
+
+	style := lipgloss.NewStyle().
+		Background(lipgloss.Color("#dde4f0")).
+		Foreground(lipgloss.Color("#1a1a1a"))
+
+	bg := style.Render("Selected Item")
+	// Produces: "\x1b[38;5;232;48;5;189mSelected Item\x1b[0m"
+
+	if !strings.Contains(bg, "38;5;232;48;5;") {
+		t.Fatalf("Setup error: expected combined FG+BG sequence, got: %q", bg)
+	}
+
+	result := PlaceOverlay(0, 0, "XX", bg, false)
+
+	if !strings.Contains(result, "48;5;236") {
+		t.Fatalf("expected background to be faded to gray 236, got: %q", result)
+	}
+	if !strings.Contains(result, "38;5;240") {
+		t.Fatalf("BUG CONFIRMED (#701): input had both 38;5 (fg) and 48;5 (bg), "+
+			"but output dropped the faded foreground. Got: %q", result)
+	}
+}
+
+// TestFadeSGR exercises fadeSGR directly across the SGR shapes that flow
+// through the overlay fade path. Each case asserts the exact faded sequence so
+// that both colors of a combined FG+BG input are provably preserved (#701) and
+// the pre-existing FG-only / BG-only / attribute behavior is unchanged.
+func TestFadeSGR(t *testing.T) {
+	const (
+		fg = "\x1b[38;5;240m"
+		bg = "\x1b[48;5;236m"
+	)
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"reset", "\x1b[0m", "\x1b[0m"},
+		{"empty-reset", "\x1b[m", "\x1b[m"},
+
+		{"bare-fg-256", "\x1b[38;5;232m", fg},
+		{"bare-fg-basic", "\x1b[37m", fg},
+		{"bare-fg-bright", "\x1b[97m", fg},
+		{"bare-fg-truecolor", "\x1b[38;2;10;20;30m", fg},
+
+		{"bare-bg-256", "\x1b[48;5;189m", bg},
+		{"bare-bg-basic", "\x1b[41m", bg},
+		{"bare-bg-bright", "\x1b[101m", bg},
+		{"bare-bg-truecolor", "\x1b[48;2;200;210;220m", bg},
+		{"reverse-video", "\x1b[7m", bg},
+
+		{"combined-256", "\x1b[38;5;232;48;5;189m", "\x1b[38;5;240;48;5;236m"},
+		{"combined-256-reversed", "\x1b[48;5;189;38;5;232m", "\x1b[38;5;240;48;5;236m"},
+		{"combined-truecolor", "\x1b[38;2;10;20;30;48;2;200;210;220m", "\x1b[38;5;240;48;5;236m"},
+		{"combined-mixed", "\x1b[38;5;232;48;2;200;210;220m", "\x1b[38;5;240;48;5;236m"},
+
+		{"bold-fg-256", "\x1b[1;38;5;188m", fg},
+		{"bold-italic-combined", "\x1b[1;3;38;5;232;48;5;189m", "\x1b[38;5;240;48;5;236m"},
+		{"bold-bg", "\x1b[1;41m", bg},
+		{"bold-only", "\x1b[1m", fg},
+		{"underline-fg", "\x1b[4;32m", fg},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fadeSGR(tc.in); got != tc.want {
+				t.Fatalf("fadeSGR(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFadeSGRTrueColorCombinedThroughOverlay drives the truecolor combined case
+// end-to-end through PlaceOverlay to confirm both colors survive there too.
+func TestFadeSGRTrueColorCombinedThroughOverlay(t *testing.T) {
+	input := "\x1b[38;2;10;20;30;48;2;200;210;220mhi\x1b[0m"
+	result := PlaceOverlay(0, 0, "XX", input, false)
+
+	if !strings.Contains(result, "38;5;240") {
+		t.Fatalf("truecolor combined: faded foreground missing, got: %q", result)
+	}
+	if !strings.Contains(result, "48;5;236") {
+		t.Fatalf("truecolor combined: faded background missing, got: %q", result)
+	}
+}

--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -13,12 +13,95 @@ import (
 
 // Most of this code is modified from https://github.com/charmbracelet/lipgloss/pull/102
 
-// Pre-compiled regexes for ANSI color code replacement in overlay fade effect.
-var (
-	bgColorRegex     = regexp.MustCompile(`\x1b\[(?:[0-9;]*;)?48;[25];[0-9;]+m`)
-	fgColorRegex     = regexp.MustCompile(`\x1b\[(?:[0-9;]*;)?38;[25];[0-9;]+m`)
-	simpleColorRegex = regexp.MustCompile(`\x1b\[[0-9;]+m`)
+// Faded gray tones used by the overlay fade effect.
+const (
+	fadedFg = "38;5;240" // Medium gray foreground
+	fadedBg = "48;5;236" // Dark gray background
 )
+
+// sgrRegex matches any SGR (Select Graphic Rendition) sequence so the fade
+// pass can parse its parameters as a whole. A single pass over the full
+// sequence is required to correctly handle combined FG+BG sequences such as
+// \x1b[38;5;232;48;5;189m, which earlier per-color regexes mishandled by
+// dropping the foreground portion (#701).
+var sgrRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// extendedColorLen returns the number of tokens an extended-color introducer
+// (38 or 48) spans, given tokens[i] is the introducer. 38;5;n / 48;5;n span 3
+// tokens; 38;2;r;g;b / 48;2;r;g;b span 5. Consuming these together is what
+// prevents the inner parameters (e.g. the "5" in 48;5;189) from being
+// misread as a standalone attribute such as blink.
+func extendedColorLen(tokens []string, i int) int {
+	if i+1 < len(tokens) {
+		switch tokens[i+1] {
+		case "5":
+			return 3
+		case "2":
+			return 5
+		}
+	}
+	return 1
+}
+
+// fadeSGR rewrites a single SGR sequence to its faded equivalent. It detects
+// whether the sequence sets a foreground and/or background color (or any other
+// fadeable attribute) and emits faded gray codes for whichever are present,
+// combining both into one sequence when the input was combined. Pure resets
+// (\x1b[0m, \x1b[m) and sequences with no fadeable parameters are preserved
+// unchanged so styled regions still close correctly.
+func fadeSGR(match string) string {
+	params := strings.TrimSuffix(strings.TrimPrefix(match, "\x1b["), "m")
+	if params == "" || params == "0" {
+		return match
+	}
+
+	tokens := strings.Split(params, ";")
+	hasFg, hasBg, hasOtherFadeable := false, false, false
+	for i := 0; i < len(tokens); {
+		code, err := strconv.Atoi(tokens[i])
+		if err != nil || code == 0 {
+			i++
+			continue
+		}
+		switch {
+		case code == 38: // extended foreground (38;5;n or 38;2;r;g;b)
+			hasFg = true
+			i += extendedColorLen(tokens, i)
+		case code == 48: // extended background (48;5;n or 48;2;r;g;b)
+			hasBg = true
+			i += extendedColorLen(tokens, i)
+		case (code >= 30 && code <= 37) || (code >= 90 && code <= 97):
+			hasFg = true // basic/bright foreground
+			i++
+		case code == 7 || (code >= 40 && code <= 47) || (code >= 100 && code <= 107):
+			hasBg = true // reverse video or basic/bright background
+			i++
+		default:
+			// Non-color attribute (bold, italic, …). Tracked separately so it
+			// doesn't inject a foreground gray when a real background color is
+			// present (preserving the bg-only fade of e.g. \x1b[1;41m).
+			hasOtherFadeable = true
+			i++
+		}
+	}
+
+	if !hasFg && !hasBg {
+		// Attribute-only sequence (e.g. bold \x1b[1m): fold to foreground gray,
+		// matching the long-standing behavior for such 16-color sequences.
+		if hasOtherFadeable {
+			return "\x1b[" + fadedFg + "m"
+		}
+		return match
+	}
+	parts := make([]string, 0, 2)
+	if hasFg {
+		parts = append(parts, fadedFg)
+	}
+	if hasBg {
+		parts = append(parts, fadedBg)
+	}
+	return "\x1b[" + strings.Join(parts, ";") + "m"
+}
 
 // WhitespaceOption sets a styling rule for rendering whitespace.
 type WhitespaceOption func(*whitespace)
@@ -65,46 +148,11 @@ func PlaceOverlay(
 	fadedBgLines := make([]string, len(bgLines))
 
 	for i, line := range bgLines {
-		// Replace background color codes with a faded version
-		content := bgColorRegex.ReplaceAllString(line, "\x1b[48;5;236m") // Dark gray background
-
-		// Replace foreground color codes with a faded version
-		content = fgColorRegex.ReplaceAllString(content, "\x1b[38;5;240m") // Medium gray foreground
-
-		// Replace simple color codes with a faded version. Handles both
-		// single-parameter (e.g. \x1b[37m) and multi-parameter (e.g.
-		// \x1b[1;37m) SGR sequences emitted by lipgloss in 16-color mode.
-		content = simpleColorRegex.ReplaceAllStringFunc(content, func(match string) string {
-			// Preserve pure reset (\x1b[0m) so styled regions still close.
-			if match == "\x1b[0m" {
-				return match
-			}
-			codeText := strings.TrimSuffix(strings.TrimPrefix(match, "\x1b["), "m")
-			isBg := false
-			hasFadeableParam := false
-			for _, p := range strings.Split(codeText, ";") {
-				code, err := strconv.Atoi(p)
-				if err != nil || code == 0 {
-					continue
-				}
-				hasFadeableParam = true
-				// SGR 48 catches the extended-bg replacement (\x1b[48;5;236m)
-				// that step 1 emits — without it, the loop misclassifies our
-				// own rewrite as foreground and re-fades it to fg gray (#564).
-				if code == 7 || code == 48 || (code >= 40 && code <= 47) || (code >= 100 && code <= 107) {
-					isBg = true
-				}
-			}
-			if !hasFadeableParam {
-				return match
-			}
-			if isBg {
-				return "\x1b[48;5;236m" // Dark gray background
-			}
-			return "\x1b[38;5;240m" // Medium gray foreground
-		})
-
-		fadedBgLines[i] = content
+		// Fade every SGR sequence on the line in a single pass. Parsing each
+		// sequence whole lets combined FG+BG codes keep both colors (#701) while
+		// still graying standalone FG-only, BG-only, and 16-color/attribute
+		// sequences.
+		fadedBgLines[i] = sgrRegex.ReplaceAllStringFunc(line, fadeSGR)
 	}
 
 	// Replace the original background with the faded version


### PR DESCRIPTION
## Root cause

`PlaceOverlay` faded background content by running three sequential regex replacements. `bgColorRegex` (`\x1b\[(?:[0-9;]*;)?48;[25];[0-9;]+m`) carries a `(?:[0-9;]*;)?` prefix — added in cad9a95 so it could match bold+color sequences like `\x1b[1;38;5;188m`. That prefix made it **over-match combined FG+BG sequences** such as `\x1b[38;5;232;48;5;189m`: the whole sequence (foreground included) matched, and the replacement rewrote it to a background-only gray `\x1b[48;5;236m`. The foreground code was gone before the later `fgColorRegex` pass could touch it, so selected list items, sidebar headers, and buttons fell back to the terminal default foreground under overlays.

## Fix

Replace the three-pass regex approach with a single-pass SGR parser, `fadeSGR`, scoped to the fade path (no rewrite of the wider ANSI handling):

- Match each SGR sequence whole with `\x1b\[[0-9;]*m`, then tokenize on `;`.
- Consume extended-color introducers (`38`/`48` with their `5;n` or `2;r;g;b` params) as a unit, so inner params like the `5` in `48;5;189` aren't misread as a standalone attribute.
- Detect foreground and background **independently**, and emit faded gray for whichever are present — combining both into one `\x1b[38;5;240;48;5;236m` sequence when the input was combined.
- Preserve pure resets (`\x1b[0m`, `\x1b[m`) and fold attribute-only sequences (e.g. bold `\x1b[1m`) to foreground gray, matching long-standing behavior. Bg-only-with-attribute sequences like `\x1b[1;41m` stay bg-only.

## Adjacent-call-site audit

Grepped all ANSI parsing in `ui/`. The fade path in `ui/overlay/overlay.go` was the only bespoke SGR color parser. `ui/err.go` already uses the library `xansi.Strip`, which handles combined SGR sequences correctly — no change needed.

## Tests

Added `ui/overlay/combined_fgbg_test.go`:
- The issue's headline regression (`TestPlaceOverlayCombinedFgBgFade`).
- Table-driven `TestFadeSGR` covering bare FG/BG (256, truecolor, basic, bright), reverse video, combined FG+BG (256, truecolor, mixed, param-reversed), and bold/italic-interleaved combined sequences — each asserting the exact faded output so both colors are provably preserved.
- An end-to-end truecolor-combined guard through `PlaceOverlay`.

All pre-existing overlay tests still pass.

## Verification

`gofmt -l .` clean · `go build ./...` clean · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean (overlay) · `go test -race ./...` green except `daemon/TestSigtermFallback_DeadPID`, which is an environmental flake on the dev box (it discovers real running `af --daemon` processes) and is unrelated to this `ui/overlay`-only change.

Fixes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude