### PR TITLE
fix(ui/menu): show Enter/Tab highlight while naming a new instance (#691)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -687,8 +687,30 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 		m.keySent = false
 		return nil, false
 	}
+	// While naming a new instance the menu only shows the submit-name (enter)
+	// and change-program (tab) options, so those two keys are the only ones
+	// that should drive the highlight animation. Every other key is naming
+	// text and must pass through untouched — matching on msg.String() rather
+	// than GlobalKeyStringsMap also keeps "o" (a KeyEnter alias) usable as a
+	// literal name character. See #691: stateNew used to sit in the
+	// early-return filter below, which made this remapping unreachable.
+	if m.state == stateNew {
+		var name keys.KeyName
+		switch msg.String() {
+		case "enter":
+			name = keys.KeySubmitName
+		case "tab":
+			name = keys.KeyChangeProgram
+		default:
+			return nil, false
+		}
+		m.keySent = true
+		return tea.Batch(
+			func() tea.Msg { return msg },
+			m.keydownCallback(name)), true
+	}
 	if m.state == stateHelp || m.state == stateConfirm || m.state == stateSelectWorktree ||
-		m.state == stateNew || m.state == stateSearch || m.state == stateSelectProgram {
+		m.state == stateSearch || m.state == stateSelectProgram {
 		return nil, false
 	}
 	// Don't highlight when content pane has focus
@@ -708,12 +730,6 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 		return nil, false
 	}
 
-	if name == keys.KeyEnter && m.state == stateNew {
-		name = keys.KeySubmitName
-	}
-	if name == keys.KeyTab && m.state == stateNew {
-		name = keys.KeyChangeProgram
-	}
 	m.keySent = true
 	return tea.Batch(
 		func() tea.Msg { return msg },

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -79,6 +81,58 @@ func TestHandleMenuHighlightingDoesNotInterceptNamingText(t *testing.T) {
 
 	assert.False(t, returnEarly)
 	assert.Nil(t, cmd)
+}
+
+// TestHandleMenuHighlightingNewInstanceEnterTab is the regression guard for
+// issue #691: pressing Enter or Tab while naming a new instance must drive the
+// menu highlight animation. The bug (commit f294e5b) folded stateNew into the
+// early-return filter, which made the Enter→KeySubmitName / Tab→KeyChangeProgram
+// remapping — and thus the highlight render path — unreachable.
+func TestHandleMenuHighlightingNewInstanceEnterTab(t *testing.T) {
+	// Force a real color profile so lipgloss emits the underline escape that
+	// signals a highlighted menu option; the Ascii profile used by default in
+	// non-TTY test runs strips all styling and would hide the highlight.
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	// lipgloss folds the underline attribute (SGR 4) into a combined escape
+	// such as "\x1b[4;38;5;99;4m" rather than a bare "\x1b[4m", so match the
+	// underline parameter at the head of a sequence.
+	const underline = "\x1b[4;"
+
+	cases := []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{"enter", tea.KeyMsg{Type: tea.KeyEnter}},
+		{"tab", tea.KeyMsg{Type: tea.KeyTab}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.state = stateNew
+			h.menu.SetState(ui.StateNewInstance)
+			h.menu.SetSize(200, 3)
+
+			// Baseline: nothing highlighted before the keypress.
+			require.NotContains(t, h.menu.String(), underline,
+				"menu should not be highlighted before the keypress")
+
+			cmd, returnEarly := h.handleMenuHighlighting(tc.key)
+
+			// The keypress is intercepted so the highlight + re-emit fire.
+			assert.True(t, returnEarly, "Enter/Tab should be intercepted during stateNew")
+			assert.NotNil(t, cmd)
+			assert.True(t, h.keySent, "keySent guards the re-emitted key from re-highlighting")
+
+			// keydownCallback runs synchronously when the batch is built, so the
+			// menu now renders the matching option underlined.
+			assert.Contains(t, h.menu.String(), underline,
+				"menu highlight render path should run for %s during stateNew", tc.name)
+		})
+	}
 }
 
 func TestHandleStateNewRejectsDuplicateTitle(t *testing.T) {


### PR DESCRIPTION
## Summary

Pressing **Enter** or **Tab** while naming a new instance (`stateNew`) showed no menu highlight — the intentional 500ms underline animation on the `submit name` / `change program` options never fired.

### Root cause

`handleMenuHighlighting` is designed to remap `KeyEnter → KeySubmitName` and `KeyTab → KeyChangeProgram` during `stateNew` and drive the highlight, re-emitting the original key so the underlying naming handler still runs. Commit `f294e5b` bulk-added `stateNew` (alongside `stateSearch` and `stateSelectProgram`) to the early-return state filter at the top of the function. That made the function return **before** reaching the remap branch — turning lines 693-698 into dead code and silently killing the highlight during instance naming. The menu (`ui/menu.go:64`) still advertises `newInstanceMenuOptions = {KeySubmitName, KeyChangeProgram}`, so the visual feedback was expected but never rendered.

### Fix

Handle `stateNew` explicitly *before* the early-return filter:

- Intercept **only** Enter and Tab, matched on `msg.String()`. Everything else is naming text and passes through untouched. Matching on the literal key string (rather than `GlobalKeyStringsMap`) also keeps `"o"` — a `KeyEnter` alias in the global map — usable as a literal name character, which the previous `KeyEnter`-based remap would have wrongly swallowed.
- `stateSearch` / `stateSelectProgram` stay in the early-return filter — they are overlay states where the menu isn't interactive.
- The redundant remap branch at the bottom of the function is removed.

This is deliberately narrower than the Detail report's suggestion (just deleting `stateNew` from the filter): that would re-intercept and re-emit **every** keystroke during naming, adding event-loop latency per character and breaking `TestHandleMenuHighlightingDoesNotInterceptNamingText`.

### Adjacent-call-site audit

Per repo convention, swept every state gate on the highlight render path:

- `handleMenuHighlighting` (`app/app.go`) — **the sole state gate. Fixed.**
- `keydownCallback → menu.Keydown` (`app/app.go:988`) — no state gate. Kept.
- `keyupMsg → ClearKeydownIfMatch` (`app/app.go:287`) — no state gate. Kept.
- `keyDown == k` render (`ui/menu.go:229`) — no state gate; only highlights options present in the displayed menu, so during `StateNewInstance` it correctly affects just `submit name` / `change program`. Kept.

No adjacent fixes required.

### Test

Adds `TestHandleMenuHighlightingNewInstanceEnterTab` (table-driven, enter + tab). It forces a real color profile so lipgloss emits the underline escape, renders the menu before and after the keypress, and asserts the highlight appears only after. Verified it **fails against the buggy condition** and passes with the fix. The existing `TestHandleMenuHighlightingDoesNotInterceptNamingText` still passes — typed name characters are not intercepted.

### Verification

- `gofmt -l .` — clean
- `go build ./...` — OK
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test -race ./...` — green (the unrelated `daemon/TestSigtermFallback_DeadPID` failure is dev-box environment coupling from live `af --daemon` processes, reproducible on a clean tree; CI runs without them)

Fixes #691

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)