### PR TITLE
fix(session/git): skip PR-info lookup on detached-HEAD worktrees (#687, #694)

### DIFF
--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -103,6 +103,28 @@ func TestFetchPRInfoCmd_NoGitWorktree_ReturnsNil(t *testing.T) {
 	assert.Nil(t, fetchPRInfoCmd(inst, false))
 }
 
+// TestFetchPRInfoCmd_DetachedHead_ReturnsNil — a detached-HEAD worktree has a
+// non-empty repoPath but an empty branch (#687). fetchPRInfoCmd must skip the
+// fetch entirely so it never spawns `gh pr view ""` every tick. We force the
+// fetch (bypassing the freshness debounce) and assert the fetcher is never
+// invoked even though the instance is started, local, and has a worktree.
+func TestFetchPRInfoCmd_DetachedHead_ReturnsNil(t *testing.T) {
+	inst := newStartedInstanceWithWorktree(t, "detached")
+	inst.Branch = "" // detached HEAD: no branch to look up
+
+	var calls int32
+	restore := SetPRInfoFetcherForTest(func(repoPath, branch string) (*git.PRInfo, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, nil
+	})
+	defer restore()
+
+	assert.Nil(t, fetchPRInfoCmd(inst, true),
+		"detached-HEAD instance must not schedule a fetch")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&calls),
+		"fetcher must not be invoked for an empty branch (no gh pr view \"\")")
+}
+
 // TestFetchPRInfoCmd_Fresh_NotForced_DebouncesFetch — core laziness check:
 // within prInfoStaleAfter of the last fetch, non-forced calls are a no-op.
 func TestFetchPRInfoCmd_Fresh_NotForced_DebouncesFetch(t *testing.T) {

--- a/app/sync.go
+++ b/app/sync.go
@@ -135,7 +135,11 @@ func fetchPRInfoCmd(inst *session.Instance, force bool) tea.Cmd {
 		return nil
 	}
 	repoPath, branch := inst.FetchPRInfoSnapshot()
-	if repoPath == "" {
+	// An empty branch means a detached-HEAD worktree: there is no branch to
+	// look up, so skip the fetch entirely rather than spawning `gh pr view ""`
+	// on every tick. FetchPRInfo defends against this too, but stopping here
+	// avoids the goroutine and subprocess churn for the selected instance.
+	if repoPath == "" || branch == "" {
 		return nil
 	}
 	// Mark as fetched at kickoff so concurrent callers observe the debounce

--- a/session/git/github.go
+++ b/session/git/github.go
@@ -16,8 +16,21 @@ type PRInfo struct {
 }
 
 // FetchPRInfo runs `gh pr view` to look up a PR for the given branch.
-// Returns nil with no error if no PR exists or gh is not installed.
+//
+// It returns (nil, nil) — not an error — whenever there is no PR to look up.
+// That covers three by-design cases:
+//   - an empty branch name (a detached-HEAD worktree has no branch to query),
+//   - the `gh` binary not being installed,
+//   - `gh` reporting that the branch has no associated PR.
+//
+// A non-nil error is reserved for genuine failures (e.g. a transient `gh`
+// error or malformed output) so callers can preserve previously cached PR
+// info instead of clearing it.
 func FetchPRInfo(repoPath, branchName string) (*PRInfo, error) {
+	if branchName == "" {
+		return nil, nil
+	}
+
 	if _, err := exec.LookPath("gh"); err != nil {
 		return nil, nil
 	}

--- a/session/git/github_test.go
+++ b/session/git/github_test.go
@@ -5,6 +5,21 @@ import (
 	"testing"
 )
 
+// TestFetchPRInfo_EmptyBranch verifies the (nil, nil) contract for a
+// detached-HEAD worktree (#694): an empty branch name has no PR to look up,
+// so FetchPRInfo must return (nil, nil) without shelling out to `gh`. This
+// holds whether or not `gh` is installed because the empty-branch guard runs
+// before the LookPath/exec path.
+func TestFetchPRInfo_EmptyBranch(t *testing.T) {
+	info, err := FetchPRInfo("/some/repo/path", "")
+	if err != nil {
+		t.Fatalf("empty branch should not be an error, got %v", err)
+	}
+	if info != nil {
+		t.Errorf("empty branch should yield nil PRInfo, got %+v", info)
+	}
+}
+
 func TestParsePRInfo(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Problem

Detached-HEAD worktrees have **no branch name** (`git.ListWorktrees()` reports `WorktreeInfo{Branch: ""}`). When a user attaches to such a worktree, the sidebar's periodic PR-info refresh spawned a failing `gh pr view ""` subprocess on **every ~60s tick** while that instance was selected, producing a recurring warning in `agent-factory.log`. This was two distinct bugs sharing one root cause:

### #694 — the contract bug (`session/git/github.go`)
`FetchPRInfo` documents that it returns `(nil, nil)` for "no PR exists" and "gh not installed", but for an **empty branch** it still ran `gh pr view ""`. With `gh` installed that fails with a stderr string that does *not* match the two handled "no PR" cases, so the function fell through to `return nil, fmt.Errorf(...)` — wrongly signalling a genuine failure for what is a normal state.

### #687 — the surface symptom (`app/sync.go`)
`fetchPRInfoCmd` only guarded `repoPath == ""`, never `branch == ""`. So the empty branch from a detached-HEAD instance reached the fetcher and spawned `gh pr view ""` on every `prInfoStaleAfter` tick.

## Fix — dual-layer defense

Both layers now treat an empty branch as "nothing to look up":

1. **`session/git/github.go`** — `FetchPRInfo` returns `(nil, nil)` immediately when `branchName == ""`, before the `gh` LookPath/exec. The doc comment is expanded to pin the `(nil, nil)` contract across all three by-design cases (empty branch / `gh` missing / no PR found). This is the contract change requested in #694 — no backward-compat shim.
2. **`app/sync.go`** — `fetchPRInfoCmd` short-circuits on `repoPath == "" || branch == ""`, so the selected instance never even schedules the goroutine/subprocess.

Either layer alone fixes the log warning; both are included so the contract holds regardless of caller, and the hot path avoids the goroutine churn.

## Audit (adjacent call-sites)

Grepped the whole repo for every `gh pr view` invocation and every `FetchPRInfo` / `prInfoFetcher` caller:

| Call site | File:line | Empty-branch handling |
|---|---|---|
| `gh pr view` exec | `session/git/github.go:38` | Guarded by new `if branchName == "" { return nil, nil }` at top of `FetchPRInfo`. ✅ |
| `FetchPRInfo` reference | `app/sync.go:115` (`var prInfoFetcher = git.FetchPRInfo`) | Indirected through `prInfoFetcher`; sole invocation is in `fetchPRInfoCmd`. ✅ |
| `prInfoFetcher(...)` call | `app/sync.go:152` (inside `fetchPRInfoCmd`) | Guarded by new `repoPath == "" || branch == ""` check before the goroutine. ✅ |
| `SetPRInfoFetcherForTest` fakes | `app/pr_info_test.go`, `app/e2e_test.go`, `app/attached_pause_test.go` | Test-only fakes, never shell out to `gh`. N/A. |

No other `gh pr view` invocations exist. Both real call sites are now covered.

## Tests

- `session/git`: `TestFetchPRInfo_EmptyBranch` — empty branch returns `(nil, nil)` with no error, and never execs `gh` (passes whether or not `gh` is installed, since the guard precedes LookPath).
- `app`: `TestFetchPRInfoCmd_DetachedHead_ReturnsNil` — a detached-HEAD instance (`Branch == ""`, started, local, with a worktree) makes `fetchPRInfoCmd(inst, true)` return `nil` and the injected fetcher is never invoked.

## CI gates

All green locally: `gofmt -l .` (clean), `go build ./...`, `go test ./...`, `go test -race ./session/git/ ./app/`, `golangci-lint run --timeout=3m --fast` (clean), `deadcode -test ./...` (clean). The only failing test on my box is the pre-existing `daemon/TestSigtermFallback_DeadPID` flake (caused by real running `af --daemon` processes on the dev machine, not by this change).

Fixes #687
Fixes #694

— Captain Claude