### PR TITLE
fix(daemon/control): make isReadyContent agent-aware so non-claude programs are recognized as ready (#714)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1035,6 +1035,11 @@ func startAndSendPrompt(instance *session.Instance, prompt string) error {
 }
 
 func waitForReady(instance *session.Instance) error {
+	// Resolve the canonical agent once so isReadyContent can match the right
+	// per-agent prompt signals. DetectAgentFromProgram normalizes legacy
+	// free-form Program values (e.g. "/home/foo/bin/codex"); a non-canonical
+	// value falls through to the Claude signals (the historical default).
+	agent := session.DetectAgentFromProgram(instance.Program)
 	timeout := time.After(waitForReadyTimeout)
 	ticker := time.NewTicker(waitForReadyPollInterval)
 	defer ticker.Stop()
@@ -1054,7 +1059,7 @@ func waitForReady(instance *session.Instance) error {
 			if err != nil {
 				continue
 			}
-			if isReadyContent(content) {
+			if isReadyContent(content, agent) {
 				return nil
 			}
 		}
@@ -1102,12 +1107,58 @@ func trimPaneSnippet(content string) string {
 	return out
 }
 
-func isReadyContent(content string) bool {
-	if strings.Contains(content, "❯") ||
-		strings.Contains(content, "Do you trust") ||
-		strings.Contains(content, "new MCP server") {
-		return true
+// isReadyContent reports whether the captured pane content indicates that the
+// given agent is ready for input — or is showing a trust/confirmation prompt
+// that downstream handlers (CheckAndHandleTrustPrompt) know how to dismiss.
+//
+// The ready signals differ per agent, so callers resolve the canonical agent
+// name (session.DetectAgentFromProgram, which handles legacy free-form Program
+// paths) and pass it here. An empty or non-canonical agent falls through to
+// the Claude signals, which was the historical behavior before this became
+// agent-aware: until #714 the check only matched Claude's prompt, so codex /
+// aider / gemini sessions never looked ready and waitForReady spun for the
+// full 60s timeout. (Exposed by #709 removing the empty-prompt early-return
+// that previously skipped waitForReady on the common create path.)
+func isReadyContent(content, agent string) bool {
+	switch agent {
+	case tmux.ProgramCodex:
+		// codex renders "›" (U+203A — distinct from claude's "❯" U+276F) as
+		// its input-prompt glyph after the banner, and "Do you trust this
+		// folder" for its workspace-trust dialog. See the pane capture in
+		// sachiniyer/agent-factory#714.
+		return strings.Contains(content, "›") ||
+			strings.Contains(content, "Do you trust this folder")
+	case tmux.ProgramAider:
+		// aider prints an "Aider v…" banner, then a line-start "> " input
+		// prompt. The shared doc-trust dialog is handled by isDocTrustPrompt.
+		return strings.Contains(content, "\n> ") ||
+			strings.Contains(content, "Aider v") ||
+			isDocTrustPrompt(content)
+	case tmux.ProgramGemini:
+		// Best-guess (#714): we have no in-the-wild gemini-cli pane capture.
+		// gemini-cli renders its prompt inside a box-drawing frame, so the
+		// closing "╰" corner is used as a weak readiness signal alongside the
+		// shared doc-trust dialog. TODO(#714): replace "╰" with a confirmed
+		// gemini-specific ready string once a real capture is available.
+		return strings.Contains(content, "╰") ||
+			isDocTrustPrompt(content)
+	default:
+		// claude and any unknown / legacy program (historical default): the
+		// "❯" (U+276F) input prompt, the trust dialog, the new-MCP-server
+		// confirmation, and the shared doc-trust dialog.
+		if strings.Contains(content, "❯") ||
+			strings.Contains(content, "Do you trust") ||
+			strings.Contains(content, "new MCP server") {
+			return true
+		}
+		return isDocTrustPrompt(content)
 	}
+}
+
+// isDocTrustPrompt reports whether content shows the documentation-link trust
+// dialog shared by aider/gemini (and surfaced by claude too). Both substrings
+// are required so an unrelated documentation link doesn't false-positive.
+func isDocTrustPrompt(content string) bool {
 	return strings.Contains(content, "Open documentation url") &&
 		strings.Contains(content, "(D)on't ask again")
 }

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -561,6 +561,84 @@ func TestFormatWaitForReadyTimeoutError(t *testing.T) {
 	})
 }
 
+// codexYOLOBanner is the actual codex startup pane reported in
+// sachiniyer/agent-factory#714: codex rendered its banner, the YOLO-mode
+// header, and the "›" (U+203A) input prompt, but the claude-only
+// isReadyContent never matched it, so waitForReady spun for the full timeout.
+const codexYOLOBanner = "╭───────────────────────────────────────────────╮\n" +
+	"│ >_ OpenAI Codex (v0.135.0)                    │\n" +
+	"│ permissions: YOLO mode                        │\n" +
+	"╰───────────────────────────────────────────────╯\n" +
+	"› Use /skills to list available skills"
+
+// TestIsReadyContent covers the agent-aware ready detection added for #714.
+// Mirrors task.TestIsReadyContent — the two packages keep duplicate copies of
+// isReadyContent (no shared home without an import cycle), so both are tested.
+func TestIsReadyContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		agent   string
+		content string
+		want    bool
+	}{
+		// claude (and the default / legacy fallback)
+		{"empty", "claude", "", false},
+		{"claude input prompt", "claude", "some output\n\n❯ ", true},
+		{"claude trust prompt", "claude", "Do you trust the files in this folder?\n1. Yes", true},
+		{"claude mcp trust prompt", "claude", "detected a new MCP server from `.mcp.json`.", true},
+		{
+			name:    "claude doc trust prompt",
+			agent:   "claude",
+			content: "Open documentation url: https://docs/\n(Y)es/(N)o/(D)on't ask again [Yes]:",
+			want:    true,
+		},
+		{"claude not ready", "claude", "installing dependencies...", false},
+		// Unknown / legacy program falls through to the claude signals.
+		{"unknown program uses claude signals", "/usr/bin/some-tool", "out\n❯ ", true},
+		{"unknown program not ready", "/usr/bin/some-tool", "compiling…", false},
+
+		// codex — the #714 regression case.
+		{"codex YOLO banner with prompt (#714)", "codex", codexYOLOBanner, true},
+		{"codex bare prompt glyph", "codex", "some output\n› ", true},
+		{"codex trust folder prompt", "codex", "Do you trust this folder?\n> Yes", true},
+		{"codex not ready on claude glyph", "codex", "rendering\n❯ ", false},
+		{"codex not ready on box border alone", "codex", "╭──╮\n│ x │\n╰──╯", false},
+
+		// aider
+		{"aider banner", "aider", "Aider v0.74.0\nMain model: ...", true},
+		{"aider input prompt", "aider", "some output\n> ", true},
+		{
+			name:    "aider doc trust prompt",
+			agent:   "aider",
+			content: "Open documentation url: https://aider.chat/docs/\n(Y)es/(N)o/(D)on't ask again [Yes]:",
+			want:    true,
+		},
+		{"aider not ready", "aider", "loading model weights…", false},
+
+		// gemini (best-guess box-border signal — see #714)
+		{"gemini box frame", "gemini", "╭──╮\n│ Gemini │\n╰──╯", true},
+		{
+			name:    "gemini doc trust prompt",
+			agent:   "gemini",
+			content: "Gemini CLI\nOpen documentation url for more info.\n(D)on't ask again",
+			want:    true,
+		},
+		{"gemini not ready", "gemini", "starting gemini-cli…", false},
+
+		// shared doc-trust guard: both substrings required.
+		{"only open documentation url without confirm", "claude", "See Open documentation url for details.", false},
+		{"only dont ask again without doc url", "aider", "Some prompt asking (D)on't ask again", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isReadyContent(tc.content, tc.agent); got != tc.want {
+				t.Errorf("isReadyContent(%q, %q) = %v, want %v", tc.content, tc.agent, got, tc.want)
+			}
+		})
+	}
+}
+
 // stubGhostCleanup replaces both ghostCleanupWorktree and ghostKillTmuxByName
 // with recorders so tests can assert which teardown branches fired without
 // invoking real git / real tmux.

--- a/integration/codex_ready_test.go
+++ b/integration/codex_ready_test.go
@@ -1,0 +1,95 @@
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// TestCLICreateCodexSessionBecomesReady is the regression test for
+// sachiniyer/agent-factory#714. Before isReadyContent became agent-aware, a
+// codex session's "›" (U+203A) prompt glyph never matched the claude-only
+// ready check, so `af sessions create --program codex` blocked inside
+// waitForReady for the full 60s timeout (well past the CLI's 30s deadline) and
+// failed. The empty-prompt early-return removed in #709 is what newly routed
+// every create through waitForReady and exposed the blind spot.
+//
+// The fake codex wrapper prints codex's banner and the "›" prompt, then reads
+// stdin — mirroring the claude fixture in newHarness. With the agent-aware fix
+// the create returns promptly; without it this create times out and errors.
+func TestCLICreateCodexSessionBecomesReady(t *testing.T) {
+	requireTool(t, "git")
+	requireTool(t, "tmux")
+
+	home := t.TempDir()
+	repo := setupGitRepo(t)
+
+	// printf interprets the \n (backslash-n) into a newline; the "›" is the
+	// literal U+203A glyph. The wrapper ignores any injected flags
+	// (-c developer_instructions=…) exactly like the claude fixture.
+	wrapper := filepath.Join(home, "fake-codex.sh")
+	writeFile(t, wrapper, "#!/bin/sh\nprintf 'OpenAI Codex (vX)\\npermissions: YOLO mode\\n› '\nexec cat\n", 0755)
+
+	cfg := testConfig()
+	cfg.DefaultProgram = tmux.ProgramCodex
+	cfg.ProgramOverrides = map[string]string{tmux.ProgramCodex: wrapper}
+	raw, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	writeFile(t, filepath.Join(home, config.ConfigFileName), string(raw), 0644)
+
+	bin := buildBinary(t)
+	// Capture stdout separately from stderr: the CLI writes the session JSON
+	// to stdout but a "wrote logs to …" line to stderr, so CombinedOutput
+	// would corrupt the JSON parse.
+	runAF := func(args ...string) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, bin, args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "AGENT_FACTORY_HOME="+home, "TERM=xterm")
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if ctx.Err() == context.DeadlineExceeded {
+			return stdout.String(), fmt.Errorf("timed out; stderr=%s", stderr.String())
+		}
+		if err != nil {
+			return stdout.String(), fmt.Errorf("%w; stderr=%s", err, stderr.String())
+		}
+		return stdout.String(), nil
+	}
+
+	t.Cleanup(func() {
+		_, _ = runAF("sessions", "kill", "codex-ready")
+		killDaemonFromHome(home)
+	})
+
+	start := time.Now()
+	out, err := runAF("sessions", "--repo", repo, "create", "--name", "codex-ready", "--program", tmux.ProgramCodex)
+	if err != nil {
+		t.Fatalf("create codex session failed (regression #714: codex prompt not recognized as ready): %v\n%s", err, out)
+	}
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Fatalf("codex create took %s; waitForReady likely did not recognize the codex prompt", elapsed)
+	}
+
+	var data instanceData
+	if err := json.Unmarshal([]byte(out), &data); err != nil {
+		t.Fatalf("parse create response: %v\n%s", err, out)
+	}
+	if data.Title != "codex-ready" {
+		t.Fatalf("unexpected create response: %+v", data)
+	}
+}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -25,7 +25,7 @@ func resolveProgramForInstance(i *Instance) string {
 		cfg = nil
 	}
 	resolved := config.ResolveProgram(cfg, i.Program)
-	if i.AutoYes && detectAgentFromProgram(i.Program) == tmux.ProgramClaude {
+	if i.AutoYes && DetectAgentFromProgram(i.Program) == tmux.ProgramClaude {
 		resolved = resolved + " --permission-mode bypassPermissions"
 	}
 	return resolved
@@ -332,7 +332,7 @@ func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {
 	// Normalize so restored sessions with legacy free-form Program values
 	// (e.g. "/home/foo/bin/claude") still get trust-prompt auto-handling —
 	// same persisted-state class of regression as #677.
-	switch detectAgentFromProgram(i.Program) {
+	switch DetectAgentFromProgram(i.Program) {
 	case tmux.ProgramClaude, tmux.ProgramAider, tmux.ProgramGemini:
 		return ts.CheckAndHandleTrustPrompt()
 	}

--- a/session/legacy_program_test.go
+++ b/session/legacy_program_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
-// detectAgentFromProgram is the normalization seam that lets restored sessions
+// DetectAgentFromProgram is the normalization seam that lets restored sessions
 // with legacy free-form Program values keep their agent-specific flags (#677).
 // It must recover the canonical agent for paths and path-plus-flags, leave the
 // bare enum untouched, and — critically — return unknown programs unchanged so
@@ -32,8 +32,8 @@ func TestDetectAgentFromProgram(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := detectAgentFromProgram(tt.program); got != tt.want {
-				t.Errorf("detectAgentFromProgram(%q) = %q, want %q", tt.program, got, tt.want)
+			if got := DetectAgentFromProgram(tt.program); got != tt.want {
+				t.Errorf("DetectAgentFromProgram(%q) = %q, want %q", tt.program, got, tt.want)
 			}
 		})
 	}

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -27,7 +27,7 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-// detectAgentFromProgram maps a possibly-legacy Program value to its canonical
+// DetectAgentFromProgram maps a possibly-legacy Program value to its canonical
 // agent enum name (one of tmux.SupportedPrograms). Sessions persisted by
 // pre-#659 binaries may hold free-form Program strings — an absolute path
 // and/or trailing flags, e.g. "/home/foo/bin/claude --plugin-dir x" — rather
@@ -43,7 +43,7 @@ func shellQuote(s string) string {
 // unchanged, so we never inject Claude flags into a non-Claude session. This
 // is scoped purely to flag injection on restore; it is NOT a general-purpose
 // command parser and must not be reused as one.
-func detectAgentFromProgram(program string) string {
+func DetectAgentFromProgram(program string) string {
 	fields := strings.Fields(program)
 	if len(fields) == 0 {
 		return program
@@ -63,14 +63,14 @@ func detectAgentFromProgram(program string) string {
 // possibly a legacy free-form string on restored sessions) and resolved is
 // the actual command string to be passed to tmux (the agent name or the
 // configured program_overrides entry). agent is normalized via
-// detectAgentFromProgram so legacy paths still match; flags are appended to
+// DetectAgentFromProgram so legacy paths still match; flags are appended to
 // resolved.
 //
 // Strategy per tool:
 //   - Claude Code: --plugin-dir flag only (slash commands + /af-whoami for self-identification)
 //   - Codex: -c developer_instructions="..." flag (text-based, no plugin support)
 func injectSystemPrompt(agent, resolved, sessionTitle, worktreePath string) string {
-	agent = detectAgentFromProgram(agent)
+	agent = DetectAgentFromProgram(agent)
 	if agent == tmux.ProgramClaude {
 		pluginDir, err := ensurePluginDir()
 		if err != nil {

--- a/task/runner.go
+++ b/task/runner.go
@@ -64,29 +64,61 @@ func LoadAndClearPendingInstances() ([]session.InstanceData, error) {
 	return pending, err
 }
 
-// isReadyContent reports whether the captured pane content indicates the
-// program is ready for input or is showing a trust prompt that downstream
-// handlers know how to dismiss. It recognizes Claude Code's input prompt
-// and trust prompt as well as the Aider/Gemini trust prompt
-// ("Open documentation url" + "(D)on't ask again").
-func isReadyContent(content string) bool {
-	if strings.Contains(content, "❯") ||
-		strings.Contains(content, "Do you trust") ||
-		strings.Contains(content, "new MCP server") {
-		return true
+// isReadyContent reports whether the captured pane content indicates that the
+// given agent is ready for input — or is showing a trust/confirmation prompt
+// that downstream handlers know how to dismiss.
+//
+// The ready signals differ per agent, so callers resolve the canonical agent
+// name (session.DetectAgentFromProgram, which handles legacy free-form Program
+// paths) and pass it here. An empty or non-canonical agent falls through to
+// the Claude signals — the historical behavior before this became agent-aware
+// (#714). Kept in sync with daemon.isReadyContent; the two packages can't
+// share the helper without an import cycle (task already imports daemon).
+func isReadyContent(content, agent string) bool {
+	switch agent {
+	case tmux.ProgramCodex:
+		// codex renders "›" (U+203A — distinct from claude's "❯" U+276F) as
+		// its input-prompt glyph after the banner, and "Do you trust this
+		// folder" for its workspace-trust dialog (#714).
+		return strings.Contains(content, "›") ||
+			strings.Contains(content, "Do you trust this folder")
+	case tmux.ProgramAider:
+		// aider prints an "Aider v…" banner, then a line-start "> " prompt.
+		return strings.Contains(content, "\n> ") ||
+			strings.Contains(content, "Aider v") ||
+			isDocTrustPrompt(content)
+	case tmux.ProgramGemini:
+		// Best-guess (#714): no in-the-wild gemini-cli capture yet. The "╰"
+		// box-drawing corner of gemini-cli's frame is a weak readiness signal.
+		// TODO(#714): replace with a confirmed gemini-specific ready string.
+		return strings.Contains(content, "╰") ||
+			isDocTrustPrompt(content)
+	default:
+		// claude and any unknown / legacy program (historical default).
+		if strings.Contains(content, "❯") ||
+			strings.Contains(content, "Do you trust") ||
+			strings.Contains(content, "new MCP server") {
+			return true
+		}
+		return isDocTrustPrompt(content)
 	}
-	// Aider/Gemini trust prompt. Require both substrings to avoid false
-	// positives from documentation links unrelated to the trust prompt.
-	if strings.Contains(content, "Open documentation url") &&
-		strings.Contains(content, "(D)on't ask again") {
-		return true
-	}
-	return false
+}
+
+// isDocTrustPrompt reports whether content shows the documentation-link trust
+// dialog shared by aider/gemini (and surfaced by claude). Both substrings are
+// required to avoid false positives from unrelated documentation links.
+func isDocTrustPrompt(content string) bool {
+	return strings.Contains(content, "Open documentation url") &&
+		strings.Contains(content, "(D)on't ask again")
 }
 
 // WaitForReady polls the instance's tmux pane until the program shows its
-// input prompt (e.g. Claude Code's ">" prompt) or trust prompt, or times out after 60 seconds.
+// input prompt or trust prompt, or times out after 60 seconds.
 func WaitForReady(instance *session.Instance) error {
+	// Resolve the canonical agent once so isReadyContent matches the right
+	// per-agent prompt signals; legacy free-form Program values normalize via
+	// DetectAgentFromProgram and unknown values fall through to claude (#714).
+	agent := session.DetectAgentFromProgram(instance.Program)
 	timeout := time.After(waitForReadyTimeout)
 	ticker := time.NewTicker(waitForReadyPollInterval)
 	defer ticker.Stop()
@@ -106,7 +138,7 @@ func WaitForReady(instance *session.Instance) error {
 			if err != nil {
 				continue
 			}
-			if isReadyContent(content) {
+			if isReadyContent(content, agent) {
 				return nil
 			}
 		}

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -20,65 +20,80 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// codexYOLOBanner is the actual codex startup pane from
+// sachiniyer/agent-factory#714 — codex rendered its banner, the YOLO-mode
+// header, and the "›" (U+203A) input prompt, but the claude-only
+// isReadyContent never matched it, so waitForReady spun for the full 60s.
+const codexYOLOBanner = "╭───────────────────────────────────────────────╮\n" +
+	"│ >_ OpenAI Codex (v0.135.0)                    │\n" +
+	"│ permissions: YOLO mode                        │\n" +
+	"╰───────────────────────────────────────────────╯\n" +
+	"› Use /skills to list available skills"
+
 func TestIsReadyContent(t *testing.T) {
 	tests := []struct {
 		name    string
+		agent   string
 		content string
 		want    bool
 	}{
+		// claude (and the default/legacy fallback)
+		{"empty", "claude", "", false},
+		{"claude input prompt", "claude", "some output\n\n❯ ", true},
+		{"claude trust prompt", "claude", "Do you trust the files in this folder?\n1. Yes\n2. No", true},
+		{"claude mcp trust prompt", "claude", "Claude Code detected a new MCP server from `.mcp.json`.\n1. Use this MCP server", true},
 		{
-			name:    "empty",
-			content: "",
-			want:    false,
-		},
-		{
-			name:    "claude input prompt",
-			content: "some output\n\n❯ ",
-			want:    true,
-		},
-		{
-			name:    "claude trust prompt",
-			content: "Do you trust the files in this folder?\n1. Yes\n2. No",
-			want:    true,
-		},
-		{
-			name:    "claude mcp trust prompt",
-			content: "Claude Code detected a new MCP server from `.mcp.json`.\n1. Use this and all future MCP servers in this project\n2. Use this MCP server\n3. Continue without using this MCP server",
-			want:    true,
-		},
-		{
-			name: "aider trust prompt",
-			content: "Aider v0.1\nOpen documentation url for more info: https://aider.chat/docs/\n" +
+			name:  "claude doc trust prompt",
+			agent: "claude",
+			content: "Open documentation url for more info: https://docs/\n" +
 				"(Y)es/(N)o/(D)on't ask again [Yes]:",
 			want: true,
 		},
+		{"claude not ready", "claude", "installing dependencies...\nready soon", false},
+		// An unknown / legacy program falls through to the claude signals.
+		{"unknown program uses claude signals", "/usr/bin/some-tool", "some output\n❯ ", true},
+		{"unknown program not ready", "/usr/bin/some-tool", "compiling…", false},
+
+		// codex — regression case from #714.
+		{"codex YOLO banner with prompt (#714)", "codex", codexYOLOBanner, true},
+		{"codex bare prompt glyph", "codex", "some output\n› ", true},
+		{"codex trust folder prompt", "codex", "Do you trust this folder?\n> Yes", true},
+		// Codex must NOT be considered ready on claude's "❯" alone, and the
+		// banner box border ("╰") is not a codex ready signal by itself.
+		{"codex not ready on claude glyph", "codex", "rendering\n❯ ", false},
+		{"codex not ready on box border alone", "codex", "╭──╮\n│ x │\n╰──╯", false},
+
+		// aider
+		{"aider banner", "aider", "Aider v0.74.0\nMain model: ...", true},
+		{"aider input prompt", "aider", "some output\n> ", true},
 		{
-			name: "gemini trust prompt",
-			content: "Gemini CLI\nOpen documentation url for more info.\n" +
-				"(D)on't ask again",
+			name:  "aider doc trust prompt",
+			agent: "aider",
+			content: "Open documentation url for more info: https://aider.chat/docs/\n" +
+				"(Y)es/(N)o/(D)on't ask again [Yes]:",
 			want: true,
 		},
+		{"aider not ready", "aider", "loading model weights…", false},
+
+		// gemini (best-guess box-border signal — see #714)
+		{"gemini box frame", "gemini", "╭──╮\n│ Gemini │\n╰──╯", true},
 		{
-			name:    "only open documentation url without confirm",
-			content: "See Open documentation url for details about this command.",
-			want:    false,
+			name:    "gemini doc trust prompt",
+			agent:   "gemini",
+			content: "Gemini CLI\nOpen documentation url for more info.\n(D)on't ask again",
+			want:    true,
 		},
-		{
-			name:    "only dont ask again without doc url",
-			content: "Some prompt asking (D)on't ask again without the documentation prefix",
-			want:    false,
-		},
-		{
-			name:    "unrelated output",
-			content: "installing dependencies...\nready soon",
-			want:    false,
-		},
+		{"gemini not ready", "gemini", "starting gemini-cli…", false},
+
+		// shared doc-trust guard: both substrings required.
+		{"only open documentation url without confirm", "claude", "See Open documentation url for details.", false},
+		{"only dont ask again without doc url", "aider", "Some prompt asking (D)on't ask again", false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isReadyContent(tc.content); got != tc.want {
-				t.Errorf("isReadyContent(%q) = %v, want %v", tc.content, got, tc.want)
+			if got := isReadyContent(tc.content, tc.agent); got != tc.want {
+				t.Errorf("isReadyContent(%q, %q) = %v, want %v", tc.content, tc.agent, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Root cause

`daemon/control.go` `isReadyContent` only recognized **claude's** ready signals:

```go
strings.Contains(content, "❯") || "Do you trust" || "new MCP server" ||
("Open documentation url" && "(D)on't ask again")
```

codex's prompt glyph is `›` (U+203A — a different code point from claude's `❯` U+276F), and aider/gemini have their own prompt forms. None of them matched, so `waitForReady` polled until the 60s timeout and the create failed for **any** user whose `default_program` is not `claude`.

## Why it became user-visible now (regression from #709)

Until #709 (merged 2026-05-29), `startAndSendPrompt` had an empty-prompt early-return that skipped `waitForReady` on the common create path (`af sessions create`, TUI new-instance). #709 removed it to fix the trust-dialog regression in #698 — **correct, and preserved here**. That just newly routed every create through `waitForReady`, exposing the claude-only blind spot.

## The fix

`isReadyContent(content, agent string)` now switches on the resolved agent:

| agent | ready signals |
|---|---|
| **claude** (+ unknown/legacy fallback) | `❯`, `Do you trust`, `new MCP server`, doc-trust dialog — unchanged, still load-bearing for the trust + MCP paths |
| **codex** | `›` (U+203A), `Do you trust this folder` |
| **aider** | `\n> ` line-start prompt, `Aider v` banner, doc-trust dialog |
| **gemini** | `╰` box-frame corner ⚠️ **best-guess**, doc-trust dialog |

`waitForReady` resolves the agent once via `session.DetectAgentFromProgram(instance.Program)` (the #677 helper, now exported). Legacy free-form `Program` values (e.g. `/home/foo/bin/codex`) normalize correctly, and a non-canonical value falls through to the **claude** signals — the historical default — so this can never regress a claude session.

⚠️ **Gemini's signal is an educated guess** — I have no in-the-wild gemini-cli pane capture. gemini-cli renders its prompt inside a box-drawing frame, so the closing `╰` corner is used as a weak readiness signal (plus the shared doc-trust dialog). Marked with a `TODO(#714)` to replace once a real capture is available. codex/aider are grounded in the #714 pane capture and known banners; claude is unchanged.

## Adjacent call-site audit (per CLAUDE.md)

Grepped all callers of `isReadyContent` / `waitForReady`:

| Location | Action |
|---|---|
| `daemon/control.go` `isReadyContent` / `waitForReady` | made agent-aware; wired agent through |
| `task/runner.go` `isReadyContent` / `WaitForReady` (**duplicate** copy) | fixed identically — same bug, same fix. Can't share the helper without an import cycle (task already imports daemon), so the two copies are kept in sync with a cross-reference comment |
| `session/systemprompt.go` `detectAgentFromProgram` | exported → `DetectAgentFromProgram`; internal callers (`backend_local.go` ×2, `injectSystemPrompt`, test) updated |

## Tests

- Table-driven `TestIsReadyContent` in **both** `daemon` and `task` (guards against the two copies diverging): each agent × ready/not-ready samples, including the **actual #714 codex YOLO banner + `›`** as a regression case, plus negative cases (codex must not be ready on claude's `❯` alone or the box border alone; doc-trust requires both substrings).
- New integration test `TestCLICreateCodexSessionBecomesReady`: spawns a fake codex agent (banner + `›`, mirroring the existing fake-claude wrapper) and asserts `af sessions create --program codex` returns promptly instead of hanging to the timeout. Verified it fails (parse/timeout) without the fix and passes with it.
- Existing fake-claude fixtures (the `❯` wrappers) confirmed still ready under the agent-aware check when the test passes `program=claude` (the default case).

## Gates

`gofmt -l .`, `go build ./...`, `golangci-lint run --fast`, `deadcode -test ./...` all clean. `go test ./...` green except the pre-existing `daemon/TestSigtermFallback_DeadPID` flake (real `af --daemon` processes on the dev box, unrelated). Changed packages pass under `-race`.

Fixes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)