### PR TITLE
fix(task): case-insensitive title compare in NextTaskRunTitle to match daemon validation (#721)

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -320,9 +320,23 @@ func NextTaskRunTitle(repoID, repoPath, baseTitle, program string) (string, erro
 			return fmt.Errorf("failed to parse existing instances: %w", err)
 		}
 
-		used := make(map[string]bool, len(existing))
+		usedTitles := make([]string, 0, len(existing))
 		for _, data := range existing {
-			used[data.Title] = true
+			usedTitles = append(usedTitles, data.Title)
+		}
+
+		// Compare case-insensitively to match the daemon's title-conflict
+		// validation (strings.EqualFold, see daemon.findTitleConflictLocked).
+		// A case-sensitive check here would hand back a candidate (e.g.
+		// "nightly" when "Nightly" exists) that the daemon later rejects,
+		// turning every TUI-triggered run into a round-trip error. (#721)
+		titleTaken := func(candidate string) bool {
+			for _, used := range usedTitles {
+				if strings.EqualFold(used, candidate) {
+					return true
+				}
+			}
+			return false
 		}
 
 		for i := 1; i <= 10000; i++ {
@@ -330,7 +344,7 @@ func NextTaskRunTitle(repoID, repoPath, baseTitle, program string) (string, erro
 			if i > 1 {
 				candidate = fmt.Sprintf("%s-%d", baseTitle, i)
 			}
-			if used[candidate] {
+			if titleTaken(candidate) {
 				continue
 			}
 			if tmux.NewTmuxSessionForRepo(candidate, repoPath, program).DoesSessionExist() {

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -360,6 +360,43 @@ func TestNextTaskRunTitleSkipsPersistedTitles(t *testing.T) {
 	}
 }
 
+// TestNextTaskRunTitleCaseInsensitive guards against #721: the persisted title
+// "Foo" must block the case-variant base "foo", so the next title is "foo-2"
+// rather than "foo". A case-sensitive check would hand back "foo", which the
+// daemon's EqualFold validation then rejects.
+func TestNextTaskRunTitleCaseInsensitive(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoID := "test-repo-title-case"
+	instancesPath, err := config.RepoInstancesPath(repoID)
+	if err != nil {
+		t.Fatalf("RepoInstancesPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(instancesPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	preexisting := []session.InstanceData{
+		{Title: "Foo"},
+	}
+	preRaw, err := json.MarshalIndent(preexisting, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal preexisting: %v", err)
+	}
+	if err := os.WriteFile(instancesPath, preRaw, 0644); err != nil {
+		t.Fatalf("write preexisting: %v", err)
+	}
+
+	title, err := NextTaskRunTitle(repoID, "/tmp/repo", "foo", "claude")
+	if err != nil {
+		t.Fatalf("NextTaskRunTitle: %v", err)
+	}
+	if title != "foo-2" {
+		t.Fatalf("expected foo-2 (case-variant of persisted %q must collide), got %q", "Foo", title)
+	}
+}
+
 func TestTaskRunBaseTitleFallsBackToTaskID(t *testing.T) {
 	got := TaskRunBaseTitle(Task{ID: "abc123"})
 	if got != "task-abc123" {


### PR DESCRIPTION
## Root cause — TUI/daemon contract mismatch

`NextTaskRunTitle` (`task/runner.go`) allocates collision-free titles for
TUI-triggered task runs, but did so with a **case-sensitive** map lookup:

```go
used[data.Title] = true
...
if used[candidate] { continue }
```

The daemon, however, validates title uniqueness **case-insensitively** via
`strings.EqualFold` in `daemon.findTitleConflictLocked` (added for #605):

```go
if !strings.EqualFold(data.Title, title) { continue }
// conflict
```

So when `"Nightly"` is persisted and a task fires with base `"nightly"`, the
TUI allocator considered `"nightly"` free and handed it back — then the daemon
rejected it as a case-insensitive conflict. Result: TUI-triggered task runs
**fail** on an avoidable round-trip error instead of auto-incrementing to
`"nightly-2"`. (The bug dates to #434; the daemon went case-insensitive in
#605 but that audit explicitly excluded `task/runner.go`.)

## Fix

Compare candidates against persisted titles with `strings.EqualFold`, matching
the daemon's contract (and the git branch layer, where `sanitizeBranchName`
lowercases — the deeper reason #605 went case-insensitive). The allocator's
choice now round-trips cleanly through daemon validation. Small, focused, one
function.

## Regression test

`TestNextTaskRunTitleCaseInsensitive`: with `"Foo"` persisted,
`NextTaskRunTitle(base="foo")` now returns `"foo-2"` (previously `"foo"`).

## Adjacent-call-site audit (per CLAUDE.md)

Grepped every `*.Title`-comparison site. The distinction that matters is
**allocation/collision-detection** (deciding whether a *new candidate* is free —
must match the daemon's `EqualFold` + branch-layer contract) vs.
**exact-identity lookup** (finding/removing/updating an *already-allocated*
session whose title is its canonical primary key — correctly case-sensitive).

| Site | Kind | Verdict |
|------|------|---------|
| `task/runner.go` `NextTaskRunTitle` | allocation / collision-detection | **Fixed → EqualFold** |
| `daemon/control.go` `findTitleConflictLocked` (live/reserved/disk) | allocation / collision-detection | Already EqualFold (#605) ✓ |
| `daemon/control.go` `appendInstanceData`, `findInstanceDataByTitle` | exact-identity write/lookup of allocated title (guarded upstream by `validateTitleAvailableLocked`) | Correct as-is (case-sensitive) |
| `session/storage.go`, `app/sync.go` dedup maps | exact-identity dedup of persisted titles (primary key) | Correct as-is |
| `ui/sidebar.go`, `ui/terminal.go`, `api/api.go` lookups | exact-identity lookup/remove by canonical title | Correct as-is |
| `app/handle_input.go:47` (TUI manual create pre-flight) | allocation-ish, but human-driven | **Excluded** — see below |
| `api/sessions.go` `appendInstanceFn` / `repoHasInstanceTitle` (JSON-API create path) | allocation, but self-consistent within the API path | **Excluded** — see below |

**Justified exclusions.** The two excluded sites are a real but distinct,
pre-existing inconsistency (branch-layer case collision, related to #605), not
the #721 bug:

- `app/handle_input.go:47` is a *human-driven* manual-create pre-flight; the
  daemon's `EqualFold` check is authoritative and still rejects a case-variant.
  The user gets an error either way and retypes — no silent functional failure.
  By contrast `NextTaskRunTitle` is *automated* (no human in the loop), so a
  collision silently produces a broken title and a failed run — which is why it
  is the severe, in-scope case.
- The JSON-API create path validates and allocates *case-sensitively within
  itself*, so it has no internal round-trip mismatch.

Both are candidates for a separate, broader "unify title-comparison on
`EqualFold` everywhere" follow-up rather than being smuggled into this focused
#721 fix.

## Gates

`gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --fast` clean ·
`deadcode -test ./...` clean · `go vet` clean · `go test ./... -race` green
(only the known `daemon/TestSigtermFallback_DeadPID` dev-box flake fails —
caused by real `af --daemon` processes running locally, not by this change).

Fixes #721

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)