### PR TITLE
fix(session/git): fall back to prune + RemoveAll when worktree remove fails (#719)

### DIFF
--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -173,7 +173,29 @@ func (g *GitWorktree) Cleanup() error {
 	if _, err := os.Stat(g.worktreePath); err == nil {
 		// Remove the worktree using git command
 		if _, err := g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath); err != nil {
-			errs = append(errs, err)
+			// When the worktree's `.git` pointer is corrupted, `git worktree
+			// remove -f` fails with "validation failed, cannot remove working
+			// tree" and leaves the directory orphaned on disk — previously the
+			// only escape was `af reset`. Fall back to removing the directory
+			// manually, mirroring CleanupWorktreesForRepo (#719). The Prune()
+			// below reconciles git's internal worktree metadata.
+			//
+			// Gate on "validation failed": unlike CleanupWorktreesForRepo,
+			// which only ever sees paths emitted by `git worktree list` (all
+			// real worktrees), g.worktreePath is a stored value with no such
+			// guarantee. "validation failed" means git DOES recognize the path
+			// as one of its registered worktrees, so removing the directory is
+			// safe. Other failures — notably "is not a working tree" — mean git
+			// does not own the path, so we surface the error instead of
+			// deleting it (preserves the best-effort Kill behavior of #478).
+			log.ErrorLog.Printf("failed to remove worktree %s: %v", g.worktreePath, err)
+			if strings.Contains(err.Error(), "validation failed") {
+				if removeErr := os.RemoveAll(g.worktreePath); removeErr != nil {
+					errs = append(errs, fmt.Errorf("failed to remove worktree directory %s: %w", g.worktreePath, removeErr))
+				}
+			} else {
+				errs = append(errs, err)
+			}
 		}
 	} else if !os.IsNotExist(err) {
 		// Only append error if it's not a "not exists" error

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -374,6 +374,49 @@ func TestCleanup_PrunesBeforeBranchDelete(t *testing.T) {
 		"only the main worktree should remain, got:\n%s", string(out))
 }
 
+// TestCleanup_RemovesOrphanedDirectory is a regression test for #719. When the
+// worktree's `.git` pointer is corrupted, `git worktree remove -f` fails with
+// "validation failed" and leaves the directory on disk. Cleanup() must fall
+// back to os.RemoveAll so the orphaned directory does not leak disk space and
+// force the user into `af reset`. CleanupWorktreesForRepo already does this;
+// this verifies GitWorktree.Cleanup() follows the same fallback.
+func TestCleanup_RemovesOrphanedDirectory(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+
+	// Initial commit so HEAD is valid (required for `worktree add`).
+	cmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "initial")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, _, err := NewGitWorktree(repoRoot, "orphan")
+	require.NoError(t, err)
+	require.NoError(t, gw.Setup())
+
+	worktreePath := gw.GetWorktreePath()
+
+	// Corrupt the worktree by removing its `.git` pointer file so that
+	// `git worktree remove -f` fails validation and leaves the directory.
+	require.NoError(t, os.Remove(filepath.Join(worktreePath, ".git")))
+
+	// Cleanup may report errors, but it must remove the on-disk directory.
+	_ = gw.Cleanup()
+
+	_, err = os.Stat(worktreePath)
+	assert.True(t, os.IsNotExist(err),
+		"Cleanup() must remove the orphaned worktree directory when `git worktree remove` fails validation")
+}
+
 func TestNewGitWorktreeFromStorage_EmptyWorktreePath(t *testing.T) {
 	_, err := NewGitWorktreeFromStorage("/some/repo", "", "session", "branch", "abc123", false, true)
 	require.Error(t, err)


### PR DESCRIPTION
## Root cause

`GitWorktree.Cleanup()` (session/git/worktree_ops.go) recorded the error from `git worktree remove -f` but never removed the directory. When a worktree's `.git` pointer is corrupted, that command fails with `fatal: validation failed, cannot remove working tree` and leaves the directory on disk. Because session state is deleted regardless of `Cleanup()`'s result (the error is only logged), there was no durable handle to retry — `af reset` (which wipes **all** storage) was the only escape, and the orphaned directories accumulated as a disk leak.

Confirmed locally:
```
$ git worktree remove -f <wt-with-missing-.git>
fatal: validation failed, cannot remove working tree: '.../wt/.git' does not exist
exit=128   # directory still present
```

## Mirror analogy

`CleanupWorktreesForRepo()` already handles this — on remove failure it logs and falls back to `os.RemoveAll`, then prunes (#330 / #104). `Cleanup()` is the per-session counterpart and was missing the same fallback. This PR mirrors that pattern: on failure, fall back to `os.RemoveAll`; the existing `Prune()` call right after reconciles git's internal worktree metadata.

## One deliberate refinement: gate on `"validation failed"`

`CleanupWorktreesForRepo` can safely `RemoveAll` **unconditionally** because every path it touches comes from `git worktree list --porcelain` — all git-verified worktrees. `Cleanup()` operates on a **stored** `g.worktreePath` with no such guarantee, so an unconditional `RemoveAll` would delete paths git doesn't own. Two distinct git errors make the distinction crisp:

| Scenario | `git worktree remove -f` error | Action |
|---|---|---|
| Corrupted worktree (`.git` removed, still tracked) — **#719** | `validation failed, cannot remove working tree` | `os.RemoveAll` (git owns it) |
| Path git doesn't track — **#478** | `is not a working tree` | surface error, do **not** delete |

Gating on `"validation failed"` is the issue author's recommended guard and is empirically verified above. An unconditional fallback regressed `TestLocalBackendKillBestEffort_WorktreeFails` / `_BothFail` (#478) by deleting an unowned path — the gate keeps both behaviors correct.

## Adjacent-call-site audit (`worktree remove` callers)

- `Cleanup()` (line 175) — **fixed here.**
- `CleanupWorktreesForRepo()` (line 301) — already has the fallback; the reference pattern.
- `setupFromExistingBranch()` (line 50) & `setupNewWorktree()` (line 109) — errors intentionally ignored and immediately followed by `worktree prune` + `worktree add`; these are setup paths, not cleanup, and any stale state is reconciled by the prune/add. No fallback needed.
- `Remove()` (line 222) — keeps the branch and returns the error; has **no callers** in the codebase and is not part of the session-destroy/orphan path. Left unchanged.

## Test

`TestCleanup_RemovesOrphanedDirectory`: create a session worktree, remove its `.git` pointer to force `validation failed`, call `Cleanup()`, assert the directory is gone. Verified the test **fails** without the fallback (directory remains) and passes with it. `TestCleanup_PrunesBeforeBranchDelete` and the #478 best-effort-Kill tests continue to pass.

## CI gates

`gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./session/... -race` green. (The unrelated `daemon/TestSigtermFallback_DeadPID` failure is the known dev-box flake from real running `af --daemon` processes, not this change.)

Fixes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)
