### PR TITLE
fix(app): capture instance identifier at deferred-step entry to avoid selection-drift on cancel (#717, #716)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -209,13 +209,23 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		if selected == nil || selected.GetStatus() == session.Loading || !selected.TmuxAlive() {
 			return m, nil
 		}
+		// Capture the instance at Enter-press time — the synchronous moment the
+		// selection is provably current. For first-time attachers the attach is
+		// deferred until the help overlay is dismissed, and a background refresh
+		// can drift the selection onto a different instance in the meantime; the
+		// callbacks must attach to this captured instance, not re-read the live
+		// selection (#716).
 		if tw.IsInTerminalTab() {
 			return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-				return m.attachOverlayCallback("handleEnter-terminal", "", tw.AttachTerminal)
+				return m.attachOverlayCallback("handleEnter-terminal", "", func() (chan struct{}, error) {
+					return tw.AttachTerminalForInstance(selected)
+				})
 			})
 		}
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-			return m.attachOverlayCallback("handleEnter-sidebar", "", m.sidebar.Attach)
+			return m.attachOverlayCallback("handleEnter-sidebar", "", func() (chan struct{}, error) {
+				return m.sidebar.AttachInstance(selected)
+			})
 		})
 	}
 	return m, nil

--- a/app/handle_actions_test.go
+++ b/app/handle_actions_test.go
@@ -1,0 +1,81 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// recordingAttachBackend wraps a FakeBackend and records the title of the
+// instance whose Attach() is invoked, so tests can prove which instance the
+// deferred attach actually connected to.
+type recordingAttachBackend struct {
+	*session.FakeBackend
+	title string
+	log   *[]string
+}
+
+func (b *recordingAttachBackend) Attach(*session.Instance) (chan struct{}, error) {
+	*b.log = append(*b.log, b.title)
+	ch := make(chan struct{})
+	close(ch)
+	return ch, nil
+}
+
+// TestHandleEnterAttachesCapturedInstanceAfterSelectionDrift is the regression
+// guard for issue #716. For first-time attachers the attach is deferred until
+// the attach help overlay is dismissed. The old code captured a method value
+// (m.sidebar.Attach) that re-read the live selection at dismiss time, so a
+// background refresh that drifted the selection onto a different instance while
+// the overlay was open caused the attach to connect to the wrong instance.
+//
+// The fix captures the instance at Enter-press time (the synchronous moment the
+// selection is provably current) and attaches to that captured instance. This
+// test selects instance-a, presses Enter, drifts the selection to instance-b
+// while the help overlay is open, then dismisses it and asserts the attach
+// targeted instance-a.
+func TestHandleEnterAttachesCapturedInstanceAfterSelectionDrift(t *testing.T) {
+	var attachLog []string
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, _ string) (session.Backend, error) {
+		return &recordingAttachBackend{
+			FakeBackend: session.NewFakeBackend(),
+			title:       opts.Title,
+			log:         &attachLog,
+		}, nil
+	})
+	defer restore()
+
+	h := newTestHome(t)
+
+	a, err := session.NewInstance(session.InstanceOptions{Title: "instance-a", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	a.SetStatus(session.Running)
+	b, err := session.NewInstance(session.InstanceOptions{Title: "instance-b", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	b.SetStatus(session.Running)
+
+	h.sidebar.AddInstance(a)
+	h.sidebar.AddInstance(b)
+	// User presses Enter on instance-a.
+	h.sidebar.SetSelectedInstance(0)
+
+	model, _ := h.handleEnter()
+	h = model.(*home)
+	require.Equal(t, stateHelp, h.state, "first-time attach must show the help overlay")
+	require.NotNil(t, h.textOverlay, "help overlay should be installed")
+
+	// Background refresh drifts the selection onto instance-b while the overlay
+	// is open.
+	h.sidebar.SetSelectedInstance(1)
+	require.Same(t, b, h.sidebar.GetSelectedInstance(),
+		"precondition: selection must have drifted onto instance-b")
+
+	// Dismissing the overlay runs the deferred attach callback.
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyEnter})
+
+	require.Equal(t, []string{"instance-a"}, attachLog,
+		"attach must target the instance captured at Enter-press time, not the drifted selection")
+}

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -16,13 +16,17 @@ import (
 // handleStateNew handles key events when in stateNew (naming a new instance).
 func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.String() == "ctrl+c" {
+		// Kill by the captured namingInstance pointer, not the live selection:
+		// background sync may have drifted the selection off the naming row, in
+		// which case selection-based Kill() silently no-ops and leaves a
+		// "Loading" zombie behind (#717). Kill before clearing the pointer.
+		if err := m.sidebar.KillInstance(m.namingInstance); err != nil {
+			log.ErrorLog.Printf("failed to clean up instance on cancel: %v", err)
+		}
 		m.state = stateDefault
 		m.namingInstance = nil
 		m.selectedWorktree = nil
 		m.availableWorktrees = nil
-		if err := m.sidebar.Kill(); err != nil {
-			log.ErrorLog.Printf("failed to clean up instance on cancel: %v", err)
-		}
 		// Menu.SetState rebuilds the options slice; call it synchronously
 		// on the event-loop goroutine rather than from a tea.Cmd closure
 		// that runs off-loop and races with home.View -> Menu.String.
@@ -134,7 +138,9 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.handleError(err)
 		}
 	case tea.KeyEsc:
-		if err := m.sidebar.Kill(); err != nil {
+		// Kill by the captured namingInstance pointer, not the live selection
+		// (#717) — see the ctrl+c branch above for the full rationale.
+		if err := m.sidebar.KillInstance(m.namingInstance); err != nil {
 			log.ErrorLog.Printf("failed to clean up instance on cancel: %v", err)
 		}
 		m.namingInstance = nil

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -135,6 +135,67 @@ func TestHandleMenuHighlightingNewInstanceEnterTab(t *testing.T) {
 	}
 }
 
+// TestCancelNamingRemovesZombieAfterSelectionDrift is the regression guard for
+// issue #717. While the user is naming a new instance, a background sync
+// (refreshExternalInstances) can remove a *preceding* instance, which rebuilds
+// the sidebar's visibleItems and drifts the selection off the naming row onto a
+// section header. The old cancel handlers called selection-based
+// sidebar.Kill(), which silently no-ops on a header — leaving the naming
+// instance behind as a "Loading" zombie. The fix kills by the captured
+// namingInstance pointer instead. Both cancel paths (Escape and ctrl+c) must
+// remove the zombie regardless of where the selection drifted.
+func TestCancelNamingRemovesZombieAfterSelectionDrift(t *testing.T) {
+	cases := []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{"escape", tea.KeyMsg{Type: tea.KeyEsc}},
+		{"ctrl+c", tea.KeyMsg{Type: tea.KeyCtrlC}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.state = stateNew
+
+			// A preceding instance that is NOT persisted to disk, so the next
+			// sync removes it. It is not Loading, so sync is allowed to remove
+			// it (Loading rows are protected as in-flight creations).
+			preceding := newLoadingInstance(t, "preceding")
+			preceding.SetStatus(session.Running)
+			h.sidebar.AddInstance(preceding)
+
+			// The naming instance: Loading, empty title — exactly what
+			// startNewInstance creates. It is selected (last row).
+			naming, err := session.NewInstance(session.InstanceOptions{
+				Title:   "",
+				Path:    t.TempDir(),
+				Program: "claude",
+			})
+			require.NoError(t, err)
+			naming.SetStatus(session.Loading)
+			h.sidebar.AddInstance(naming)
+			h.sidebar.SetSelectedInstance(h.sidebar.NumInstances() - 1)
+			h.namingInstance = naming
+
+			// Background sync removes `preceding` (absent on disk). This rebuilds
+			// visibleItems without adjusting selectedIdx, drifting the selection
+			// off the naming row onto a section header.
+			require.True(t, h.refreshExternalInstances(),
+				"sync should report a change after removing the non-persisted preceding instance")
+			require.Nil(t, h.sidebar.GetSelectedInstance(),
+				"precondition: selection must have drifted off the naming row onto a header")
+
+			_, _ = h.handleStateNew(tc.key)
+
+			assert.Equal(t, stateDefault, h.state, "cancel must return to the default state")
+			assert.Nil(t, h.namingInstance, "namingInstance pointer must be cleared on cancel")
+			assert.Equal(t, 0, h.sidebar.NumInstances(),
+				"the naming instance must be removed on cancel, not left as a Loading zombie; remaining titles: %v",
+				collectTitles(h.sidebar.GetInstances()))
+		})
+	}
+}
+
 func TestHandleStateNewRejectsDuplicateTitle(t *testing.T) {
 	h := newTestHome(t)
 	h.state = stateNew

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -283,19 +283,38 @@ func (s *Sidebar) RegisterRepoForInstance(instance *session.Instance) {
 	s.addRepo(repoName)
 }
 
-// Kill kills the selected instance. It returns an error if the underlying
-// kill fails, in which case the instance is NOT removed from the sidebar
-// so the user can retry.
+// Kill kills the currently selected instance. It returns an error if the
+// underlying kill fails, in which case the instance is NOT removed from the
+// sidebar so the user can retry. See KillInstance for the pointer-based
+// variant that deferred/cancel flows must use.
 func (s *Sidebar) Kill() error {
-	sel := s.GetSelection()
-	if sel.Kind != SectionInstances || sel.IsHeader {
+	return s.KillInstance(s.GetSelectedInstance())
+}
+
+// KillInstance kills the given instance by pointer identity, independent of the
+// current selection. Deferred flows — most notably canceling a new instance
+// via Escape/ctrl+c — must use this rather than Kill(): background sync can
+// rebuild visibleItems and drift the selection off the target row between the
+// time the operation is initiated and the time it runs. Selection-based Kill()
+// would then silently no-op (selection landed on a section header) and leave
+// the naming instance behind as a "Loading" zombie (#717).
+//
+// A nil target or an instance no longer in the sidebar is a no-op, mirroring
+// Kill()'s tolerance for a stale selection.
+func (s *Sidebar) KillInstance(target *session.Instance) error {
+	if target == nil {
 		return nil
 	}
-	idx := sel.ItemIndex
-	if idx < 0 || idx >= len(s.instances) {
+	idx := -1
+	for i, inst := range s.instances {
+		if inst == target {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
 		return nil
 	}
-	target := s.instances[idx]
 	// Capture repo name before Kill(), because Kill() sets started=false
 	// which causes RepoName() to fail.
 	repoName, repoErr := target.RepoName()
@@ -312,13 +331,18 @@ func (s *Sidebar) Kill() error {
 	return nil
 }
 
-// Attach attaches to the selected instance.
-func (s *Sidebar) Attach() (chan struct{}, error) {
-	inst := s.GetSelectedInstance()
-	if inst == nil {
-		return nil, fmt.Errorf("no instance selected")
+// AttachInstance attaches to the given instance by pointer identity, but only
+// if it is still present in the sidebar. Deferred attach flows — the first-time
+// attach help screen, whose onDismiss callback runs after the overlay is
+// dismissed — must capture the instance at key-press time and attach through
+// this method rather than re-reading the live selection: a background refresh
+// can drift the selection onto a different instance while the help overlay is
+// open, so Attach() would connect to the wrong session (#716).
+func (s *Sidebar) AttachInstance(target *session.Instance) (chan struct{}, error) {
+	if target == nil || !s.ContainsInstance(target) {
+		return nil, fmt.Errorf("instance no longer exists")
 	}
-	return inst.Attach()
+	return target.Attach()
 }
 
 // GetSelectedInstance returns the currently selected instance, or nil.

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -178,9 +178,13 @@ func (w *TabbedWindow) GetActiveTab() int {
 	return int(w.activeTab.Load())
 }
 
-// AttachTerminal attaches to the terminal tmux session
-func (w *TabbedWindow) AttachTerminal() (chan struct{}, error) {
-	return w.terminal.Attach()
+// AttachTerminalForInstance attaches to the terminal session of the given
+// instance by binding the terminal pane to it first. Deferred attach flows
+// must use this rather than re-reading the live selection: the terminal's
+// bound instance (currentTitle) can be rebound by a background refresh while
+// the help overlay is open (#716).
+func (w *TabbedWindow) AttachTerminalForInstance(instance *session.Instance) (chan struct{}, error) {
+	return w.terminal.AttachForInstance(instance)
 }
 
 // CleanupTerminal closes the terminal session

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -248,6 +248,35 @@ func (t *TerminalPane) Attach() (chan struct{}, error) {
 	return ts.Attach()
 }
 
+// AttachForInstance binds the terminal pane to the given instance, then
+// attaches. Deferred attach flows (the first-time attach help screen) must use
+// this rather than Attach(): while the help overlay is open, a background
+// refresh tick calls UpdateContent with the live (possibly drifted) selection,
+// which rebinds currentTitle. Attach() would then connect to whatever instance
+// is selected at dismiss time instead of the one the user pressed Enter on
+// (#716).
+//
+// ensureSessionLocked sets currentTitle only when the instance is started with
+// a live worktree; if it bailed early (the captured instance died during the
+// help screen) we refuse to attach rather than falling back to a possibly
+// drifted currentTitle.
+func (t *TerminalPane) AttachForInstance(instance *session.Instance) (chan struct{}, error) {
+	if instance == nil {
+		return nil, fmt.Errorf("no terminal session to attach to")
+	}
+	t.mu.Lock()
+	if err := t.ensureSessionLocked(instance); err != nil {
+		t.mu.Unlock()
+		return nil, err
+	}
+	if t.currentTitle != instance.Title {
+		t.mu.Unlock()
+		return nil, fmt.Errorf("terminal session for %q is no longer available", instance.Title)
+	}
+	t.mu.Unlock()
+	return t.Attach()
+}
+
 // Close kills all cached terminal tmux sessions and cleans up.
 func (t *TerminalPane) Close() {
 	t.mu.Lock()

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -598,3 +598,30 @@ func TestTerminalEnsureSessionReturnsStaleCleanupError(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to close stale session")
 	require.Contains(t, err.Error(), "kill failed")
 }
+
+// TestTerminalAttachForInstanceRefusesUnboundInstance is part of the regression
+// guard for issue #716. AttachForInstance binds the terminal to the captured
+// instance before attaching, but ensureSessionLocked only sets currentTitle
+// when the instance is started with a live worktree. If it bails early (nil or
+// a captured instance that died while the help overlay was open), the method
+// must refuse to attach rather than fall back to a possibly-drifted
+// currentTitle — which is exactly the wrong-instance attach #716 fixes.
+func TestTerminalAttachForInstanceRefusesUnboundInstance(t *testing.T) {
+	tp := NewTerminalPane()
+
+	if _, err := tp.AttachForInstance(nil); err == nil {
+		t.Fatal("AttachForInstance(nil) must return an error, not attach")
+	}
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "unstarted",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	require.False(t, inst.Started(), "precondition: instance must not be started")
+
+	if _, err := tp.AttachForInstance(inst); err == nil {
+		t.Fatal("AttachForInstance must refuse to attach an instance it cannot bind")
+	}
+}


### PR DESCRIPTION
## Root cause (shared by #717 and #716)

A deferred handler trusted the **live** `sidebar.GetSelectedInstance()` (or selection-based `sidebar.Kill()`/`tw.AttachTerminal()`) *after* a background sync had mutated the sidebar. The sidebar tracks selection as an index into `visibleItems` (which includes section headers), not into the instances slice. When background sync (`refreshExternalInstances`, fired on `tickRefreshExternalMessage` and re-run via `selectionChanged` on `previewTickMsg`) adds/removes a row, `visibleItems` is rebuilt but `selectedIdx` is not re-anchored — so the selection **drifts**, often onto a section header. The deferred step then operates on the wrong instance, or no-ops.

The fix is the identifier-capture pattern (already used by `handleKill`, which captures `selectedTitle` up front): capture the target instance at the **synchronous bubbletea event-loop step where the selection is provably current**, and have the deferred step act on that captured reference — never re-read the live selection.

### #717 — "Loading" zombie on cancel
Canceling a new instance (Escape/ctrl+c) called selection-based `m.sidebar.Kill()`. If sync removed a *preceding* instance while the user was naming, the selection drifted onto a header; `Kill()` returns early on headers (`if sel.IsHeader { return nil }`), so cancel became a silent no-op and the naming instance (empty title, `Loading`) was stranded in the sidebar forever. The `namingInstance` pointer was already captured at name-prompt entry (`startNewInstance`) but the cancel handlers ignored it.

**Fix:** both cancel handlers now call the new pointer-based `Sidebar.KillInstance(m.namingInstance)`. The ctrl+c branch kills *before* clearing the pointer (it previously cleared first).

### #716 — first-time attach connects to wrong instance (bundled)
Audit confirmed the **same root cause**, so it is included here (`Fixes #716`). For first-time attachers the attach is deferred to the help overlay's `onDismiss` callback, which captured a *method value* (`m.sidebar.Attach` / `tw.AttachTerminal`) that re-read the live selection at dismiss time. While the overlay is open, background ticks call `selectionChanged` (no `stateHelp` guard) → `tw.SetInstance(...)`, which both drifts the sidebar selection and rebinds the terminal pane's `currentTitle`. On dismiss, the attach connected to whatever was selected *then*, not what the user pressed Enter on.

**Fix:** `handleEnter` captures `selected` at Enter-press time and the deferred callbacks attach to it via the new `Sidebar.AttachInstance(selected)` / `TabbedWindow.AttachTerminalForInstance(selected)`. Both refuse (error) if the captured instance is gone, rather than silently attaching to a drifted one.

## Audit table (CLAUDE.md adjacent-call-sites)

| Site | File | Deferred step | Before (re-read live state) | After |
|---|---|---|---|---|
| Cancel naming — ctrl+c | `app/handle_input.go` | key handler, post background-sync drift | `m.sidebar.Kill()` (selection) | `m.sidebar.KillInstance(m.namingInstance)` ✅ |
| Cancel naming — Escape | `app/handle_input.go` | same | `m.sidebar.Kill()` (selection) | `m.sidebar.KillInstance(m.namingInstance)` ✅ |
| Attach — sidebar | `app/handle_actions.go` | help-overlay `onDismiss` | `m.sidebar.Attach` (method value) | capture `selected`, `m.sidebar.AttachInstance(selected)` ✅ |
| Attach — terminal tab | `app/handle_actions.go` | help-overlay `onDismiss` | `tw.AttachTerminal` (`currentTitle`) | capture `selected`, `tw.AttachTerminalForInstance(selected)` ✅ |
| Kill (`d` key) | `app/handle_actions.go` | confirm-overlay action | already captures `selectedTitle` up front | reference pattern — no change |
| `instanceStartedMsg` failure | `app/app.go` | n/a — captures `priorSelection` before mutating, removes by title | already correct | no change |
| Search-overlay select | `app/handle_overlay.go` | synchronous (no defer) | n/a | no change |

`Sidebar.Attach()` and `TabbedWindow.AttachTerminal()` had no remaining callers after the conversion and were removed (deadcode-clean).

## Tests (each verified to fail on the pre-fix code)

- `TestCancelNamingRemovesZombieAfterSelectionDrift` (`app/handle_input_test.go`, Escape + ctrl+c subtests) — exercises the **real** sync path (`refreshExternalInstances()`): adds a preceding non-persisted instance, asserts the selection drifts off the naming row (precondition `GetSelectedInstance() == nil`), then cancels and asserts the naming instance is removed (no `Loading` zombie). Fails on reverted code with `NumInstances == 1`.
- `TestHandleEnterAttachesCapturedInstanceAfterSelectionDrift` (`app/handle_actions_test.go`) — selects instance-a, presses Enter (help overlay shown), drifts selection to instance-b, dismisses, and asserts the attach targeted **instance-a** via a recording backend. Fails on reverted code with `["instance-b"]`.
- `TestTerminalAttachForInstanceRefusesUnboundInstance` (`ui/terminal_test.go`) — guards the defensive path: `AttachForInstance` refuses (errors) for nil/unbindable instances instead of falling back to a drifted `currentTitle`.

## Gates
- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go build ./...` — clean
- `go test ./...` — green (the lone `daemon/TestSigtermFallback_DeadPID` failure is the known dev-box flake from real running `af --daemon` processes, not this change — only `app/` and `ui/` were touched)
- `deadcode -test ./...` — clean
- `go test -race ./app/ ./ui/` — clean

Fixes #717
Fixes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude