### PR TITLE
fix(session/tmux): make resume detection position-aware for claude/aider/gemini wrappers (#742)

### DIFF
--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -61,7 +61,12 @@ func resumeProgram(program string) string {
 
 	switch agent {
 	case ProgramClaude:
-		for _, tok := range tokens {
+		// Only scan tokens AFTER the agent token. Tokens before it belong to
+		// a wrapper command (e.g. `ionice -c 3 claude`, `taskset -c 0-3
+		// claude`) whose flags can collide with claude's resume flags and
+		// false-positive the already-has-resume check (#742). Mirrors the
+		// position-aware codex check below (#632).
+		for _, tok := range tokens[agentIdx+1:] {
 			if tok == "-c" || tok == "--continue" || tok == "-r" || tok == "--resume" ||
 				strings.HasPrefix(tok, "--resume=") || strings.HasPrefix(tok, "-r=") ||
 				isShortResumeWithAttachedValue(tok) {
@@ -90,14 +95,19 @@ func resumeProgram(program string) string {
 		off := ends[insertAt-1]
 		return program[:off] + " resume --last" + program[off:]
 	case ProgramAider:
-		for _, tok := range tokens {
+		// Only scan tokens after the agent token so wrapper-command flags
+		// can't false-positive the already-has-resume check (#742).
+		for _, tok := range tokens[agentIdx+1:] {
 			if tok == "--restore-chat-history" || tok == "--no-restore-chat-history" {
 				return program
 			}
 		}
 		return program + " --restore-chat-history"
 	case ProgramGemini:
-		for _, tok := range tokens {
+		// Only scan tokens after the agent token so wrapper-command flags
+		// (e.g. `ionice -c 3 gemini`) can't false-positive the
+		// already-has-resume check (#742).
+		for _, tok := range tokens[agentIdx+1:] {
 			if tok == "--resume" || tok == "-r" ||
 				strings.HasPrefix(tok, "--resume=") || strings.HasPrefix(tok, "-r=") ||
 				isShortResumeWithAttachedValue(tok) {

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -249,6 +249,75 @@ func TestResumeProgram(t *testing.T) {
 			"gemini --model x -r5",
 		},
 
+		// Wrapper-command flags must not be mistaken for agent resume flags
+		// (#742). The already-has-resume scan is position-aware: only tokens
+		// AFTER the agent token are inspected, so a wrapper flag like
+		// `ionice -c 3` or `taskset -c 0-3` (whose `-c` collides with claude's
+		// `--continue` short flag and gemini's flag space) doesn't suppress
+		// the legitimate resume append. Mirrors the codex position-aware
+		// check (#632).
+		//
+		// Critical regression case: `ionice -c 3 claude` previously matched
+		// the leading `-c` and returned the program unchanged, launching a
+		// fresh session and losing conversation history on respawn.
+		{"claude ionice wrapper", "ionice -c 3 claude", "ionice -c 3 claude --continue"},
+		{"claude taskset wrapper", "taskset -c 0-3 claude", "taskset -c 0-3 claude --continue"},
+		{
+			"claude wrapper with agent resume flag",
+			"ionice -c 3 claude --resume X",
+			"ionice -c 3 claude --resume X",
+		},
+		{
+			"claude wrapper with agent attached resume",
+			"ionice -c 3 claude -r5",
+			"ionice -c 3 claude -r5",
+		},
+		{
+			"claude env wrapper",
+			"env FOO=bar claude",
+			"env FOO=bar claude --continue",
+		},
+		// Aider wrappers: aider has no `-c` resume flag, but a wrapper whose
+		// flags happened to match would still be wrongly scanned pre-#742;
+		// guard the position-aware behavior regardless.
+		{
+			"aider ionice wrapper",
+			"ionice -c 3 aider",
+			"ionice -c 3 aider --restore-chat-history",
+		},
+		{
+			"aider wrapper with agent resume flag",
+			"ionice -c 3 aider --restore-chat-history",
+			"ionice -c 3 aider --restore-chat-history",
+		},
+		{
+			"aider wrapper with opt-out",
+			"ionice -c 3 aider --no-restore-chat-history",
+			"ionice -c 3 aider --no-restore-chat-history",
+		},
+		// Gemini wrappers: `ionice -c 3 gemini` must still get
+		// `--resume latest`; the `-c` belongs to ionice, not gemini.
+		{
+			"gemini ionice wrapper",
+			"ionice -c 3 gemini",
+			"ionice -c 3 gemini --resume latest",
+		},
+		{
+			"gemini taskset wrapper",
+			"taskset -c 0-3 gemini",
+			"taskset -c 0-3 gemini --resume latest",
+		},
+		{
+			"gemini wrapper with agent resume flag",
+			"ionice -c 3 gemini --resume 5",
+			"ionice -c 3 gemini --resume 5",
+		},
+		{
+			"gemini wrapper with agent attached resume",
+			"ionice -c 3 gemini -r5",
+			"ionice -c 3 gemini -r5",
+		},
+
 		// Unknown programs are passed through unchanged so unrelated CLIs
 		// aren't accidentally rewritten.
 		{"unknown program", "mytool --bar", "mytool --bar"},
@@ -317,6 +386,13 @@ func TestResumeProgram_Idempotent(t *testing.T) {
 		"codex --profile ~/profiles/foo",
 		"codex --include 'models/*.txt'",
 		`"/path with spaces/codex" --model $MODEL`,
+		// #742 — wrapper-prefixed programs must be idempotent too.
+		"ionice -c 3 claude",
+		"taskset -c 0-3 claude",
+		"env FOO=bar claude",
+		"ionice -c 3 aider",
+		"ionice -c 3 gemini",
+		"taskset -c 0-3 gemini",
 	} {
 		once := resumeProgram(in)
 		twice := resumeProgram(once)


### PR DESCRIPTION
## Root cause

`resumeProgram` already resolves the agent's position in the token list
(`agentIdx`) so it can handle absolute paths and wrapper prefixes like
`env FOO=bar claude` or `ionice -c 3 claude`. But the "already has a
resume flag" scan for **claude / aider / gemini** looped over *all*
tokens — including the wrapper-command tokens before the agent.

When a wrapper flag collides with an agent resume flag, the scan
false-positives. The canonical case: `ionice -c 3 claude` — the leading
`-c` (ionice's I/O class) is mistaken for claude's `-c`/`--continue`,
so the function returns the program unchanged. On respawn the session
launches **fresh**, losing the conversation. Same failure with
`taskset -c 0-3 claude`.

## Fix

Mirror the position-aware codex check (#632/#633/#640): scan only the
tokens **after** the resolved agent token — `tokens[agentIdx+1:]`.
Everything before the agent belongs to the wrapper tool and is ignored.
`agentIdx` was already computed and used by the codex path; this brings
claude/aider/gemini in line.

```go
// before — scans wrapper tokens too
for _, tok := range tokens { ... }
// after — position-aware, mirrors codex
for _, tok := range tokens[agentIdx+1:] { ... }
```

## Audit (all 4 supported agents)

| agent  | before        | after                  |
|--------|---------------|------------------------|
| codex  | position-aware (#632) | unchanged — preserved |
| claude | scanned all tokens 🔴 | `tokens[agentIdx+1:]` ✅ |
| aider  | scanned all tokens 🔴 | `tokens[agentIdx+1:]` ✅ |
| gemini | scanned all tokens 🔴 | `tokens[agentIdx+1:]` ✅ |

All four now use position-aware scanning consistently.

## Test matrix

Added to `TestResumeProgram` + `TestResumeProgram_Idempotent`:

- **Critical regression** (each of claude/aider/gemini): `ionice -c 3 <agent>`
  and `taskset -c 0-3 <agent>` now correctly append the resume flag.
- Wrapper + existing agent resume flag (`ionice -c 3 claude --resume X`,
  `ionice -c 3 gemini -r5`, …) → still a no-op.
- Wrapper + opt-out (`ionice -c 3 aider --no-restore-chat-history`) → respected.
- `env FOO=bar claude` wrapper → appends `--continue`.
- Idempotency across all new wrapper forms.

## Verification

`gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./...` green · `go test -race ./session/tmux/` green.

(The one local `TestSigtermFallback_DeadPID` failure is the known dev-box flake from real running `af --daemon` processes, not this change.)

Fixes #742

— Captain Claude