### PR TITLE
fix(task): normalize leading zeros in cron fields before emitting systemd timer (#743)

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -18,6 +18,33 @@ var dowNames = map[string]string{
 	"7": "Sun",
 }
 
+// dowName returns the systemd day-of-week name for a single numeric cron token,
+// normalizing leading zeros (e.g. "07" → "Sun", "01" → "Mon") before the
+// dowNames lookup. ValidateCronExpr accepts leading zeros via strconv.Atoi, so
+// the conversion path must normalize identically or it emits invalid OnCalendar
+// output (a missing name yields ".." which systemd rejects, or drops the DOW
+// constraint so the timer fires daily). Non-numeric tokens — which only reach
+// here if a caller bypasses validation — return "", preserving the prior
+// raw-map-lookup behavior (#743).
+func dowName(token string) string {
+	v, err := strconv.Atoi(token)
+	if err != nil {
+		return ""
+	}
+	return dowNames[strconv.Itoa(v)]
+}
+
+// normalizeNum strips leading zeros from a numeric string (e.g. "05" → "5").
+// Non-numeric tokens are returned unchanged. Used to normalize step values
+// before emitting them to systemd, which expects bare integers (#743).
+func normalizeNum(s string) string {
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return s
+	}
+	return strconv.Itoa(v)
+}
+
 // ValidateCronExpr validates a 5-field cron expression (minute hour dom month dow).
 func ValidateCronExpr(expr string) error {
 	fields := strings.Fields(expr)
@@ -195,7 +222,7 @@ func convertTimeField(field string, oneIndexed bool) string {
 	if strings.Contains(field, "/") {
 		idx := strings.Index(field, "/")
 		base := field[:idx]
-		step := field[idx+1:]
+		step := normalizeNum(field[idx+1:])
 		if base == "*" {
 			if oneIndexed {
 				return fmt.Sprintf("01/%s", step)
@@ -285,7 +312,7 @@ func convertDOW(field string) string {
 	}
 
 	// Single value
-	return dowNames[field]
+	return dowName(field)
 }
 
 // convertSingleDOW converts a single DOW element (number or range) to a name.
@@ -308,7 +335,10 @@ func convertSingleDOW(part string) string {
 		start := part[:idx]
 		end := part[idx+1:]
 
-		if start == "0" {
+		// Match leading-zero forms too ("00" as well as "0"); strconv.Atoi
+		// normalizes both, but guard on err so non-numeric tokens (which
+		// Atoi maps to 0) don't falsely enter the Sunday-start branch.
+		if startVal, err := strconv.Atoi(start); err == nil && startVal == 0 {
 			endVal, _ := strconv.Atoi(end)
 			var names []string
 			for i := 0; i <= endVal; i++ {
@@ -317,9 +347,9 @@ func convertSingleDOW(part string) string {
 			return strings.Join(names, ",")
 		}
 
-		return fmt.Sprintf("%s..%s", dowNames[start], dowNames[end])
+		return fmt.Sprintf("%s..%s", dowName(start), dowName(end))
 	}
-	return dowNames[part]
+	return dowName(part)
 }
 
 // zeroPad pads a numeric string to 2 digits.

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -383,6 +383,95 @@ func TestCronToOnCalendarDOMSingleDayFanOut(t *testing.T) {
 	}, result)
 }
 
+// --- Leading-zero normalization (#743) ---
+//
+// ValidateCronExpr accepts leading zeros via strconv.Atoi, but the conversion
+// path previously used raw string tokens as dowNames keys, so "07"/"01-05"
+// produced invalid OnCalendar output: a single value silently dropped the DOW
+// constraint (fired daily instead of Sunday), and a range emitted ".." which
+// systemd rejects with "Invalid argument". The conversion must normalize
+// leading zeros identically to validation.
+
+// TestCronToOnCalendarDOWLeadingZeroSingle is the headline #743 repro: "07"
+// (Sunday with a leading zero) validated but produced "*-*-* 09:00:00" (daily)
+// because dowNames["07"] was "" and the DOW constraint was dropped.
+func TestCronToOnCalendarDOWLeadingZeroSingle(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 07")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Sun *-*-* 09:00:00"}, result)
+}
+
+// TestCronToOnCalendarDOWLeadingZeroSingleZero confirms "00" also normalizes to
+// Sunday (matching plain "0").
+func TestCronToOnCalendarDOWLeadingZeroSingleZero(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 00")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Sun *-*-* 09:00:00"}, result)
+}
+
+// TestCronToOnCalendarDOWLeadingZeroRange is the second #743 repro: "01-05"
+// previously produced "..  *-*-* 09:00:00" which systemd rejects, because
+// dowNames["01"] and dowNames["05"] were both "".
+func TestCronToOnCalendarDOWLeadingZeroRange(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 01-05")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Mon..Fri *-*-* 09:00:00"}, result)
+}
+
+// TestCronToOnCalendarDOWLeadingZeroSundayRange exercises the Sunday-start
+// expansion path with leading zeros ("00-03"); the start==0 branch must match
+// "00" as well as "0".
+func TestCronToOnCalendarDOWLeadingZeroSundayRange(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 00-03")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Sun,Mon,Tue,Wed *-*-* 09:00:00"}, result)
+}
+
+// TestCronToOnCalendarDOWLeadingZeroList covers a comma list with leading
+// zeros in each element.
+func TestCronToOnCalendarDOWLeadingZeroList(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 01,03,05")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Mon,Wed,Fri *-*-* 09:00:00"}, result)
+}
+
+// TestCronToOnCalendarDOWLeadingZeroListSundayDedupe confirms "00,07" (both
+// Sunday with leading zeros) dedupes to a single "Sun".
+func TestCronToOnCalendarDOWLeadingZeroListSundayDedupe(t *testing.T) {
+	result, err := CronToOnCalendar("0 9 * * 00,07")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Sun *-*-* 09:00:00"}, result)
+}
+
+// TestCronToOnCalendarAllFieldsLeadingZero exercises a leading zero in every
+// field at once: minute/hour/DOM/month normalize via zeroPad and DOW via
+// dowName. DOM=03 and DOW=Fri are both restricted, so the result fans out
+// under DOM/DOW OR-semantics (#522).
+func TestCronToOnCalendarAllFieldsLeadingZero(t *testing.T) {
+	result, err := CronToOnCalendar("01 02 03 04 05")
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"*-04-03 02:01:00",
+		"Fri *-04-* 02:01:00",
+	}, result)
+}
+
+// TestCronToOnCalendarStepLeadingZero verifies a leading zero in a step value
+// is stripped ("*/05" → "00/5", not "00/05").
+func TestCronToOnCalendarStepLeadingZero(t *testing.T) {
+	result, err := CronToOnCalendar("*/05 * * * *")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*-*-* *:00/5:00"}, result)
+}
+
+// TestCronToOnCalendarRangeStepLeadingZero verifies leading zeros are stripped
+// from both the range bounds (zero-padded) and the step.
+func TestCronToOnCalendarRangeStepLeadingZero(t *testing.T) {
+	result, err := CronToOnCalendar("00-30/05 * * * *")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*-*-* *:00..30/5:00"}, result)
+}
+
 // TestCronToOnCalendarDOWCoversAllNoSplit verifies the symmetric case where
 // DOW covers all 7 days. The OR collapses to "every day", so DOW is dropped
 // and only the DOM restriction remains in a single entry.


### PR DESCRIPTION
## Problem

`ValidateCronExpr` accepts cron fields with leading zeros — it parses every
field with `strconv.Atoi`, so `0 9 * * 07` and `0 9 * * 01-05` validate fine.
But `CronToOnCalendar` did **not** normalize them, so a *validated* expression
could emit systemd `OnCalendar=` output that is rejected or silently wrong. A
validator ↔ systemd contract mismatch.

### Root cause

The DOW conversion path used **raw string tokens as `dowNames` keys**. The map
only holds unpadded keys `"0".."7"`, so:

| Input | Buggy output | Effect |
|-------|--------------|--------|
| `0 9 * * 07` | `*-*-* 09:00:00` | DOW dropped → fires **daily** instead of Sunday |
| `0 9 * * 01-05` | `.. *-*-* 09:00:00` | systemd **rejects**: `Failed to parse calendar specification: Invalid argument` |

`dowNames["07"]`, `dowNames["01"]`, `dowNames["05"]` are all `""`. The
Sunday-start range branch also only matched the literal `"0"`, never `"00"`.

Verified against the local `systemd-analyze calendar`:
```
$ systemd-analyze calendar "..Wed *-*-* 09:00:00"
Failed to parse calendar specification '..Wed *-*-* 09:00:00': Invalid argument
```

## Fix

Normalize numeric tokens via `strconv.Atoi`/`Itoa` before lookup, matching what
the validator already does:

- **`dowName(token)`** — new helper normalizing single-value and range-bound
  DOW lookups (`"07"` → `"Sun"`, `"01"` → `"Mon"`). Non-numeric tokens (only
  reachable if a caller bypasses validation) return `""`, preserving prior
  behavior.
- The **Sunday-start range** branch now matches on the parsed int `0`, guarded
  on the `Atoi` error so day-name ranges (`MON-FRI`) don't falsely enter it.
- **Step values** in `convertTimeField` are run through `normalizeNum`, so
  `*/05` emits `00/5` (not `00/05`).

The validator is intentionally left **accepting** leading zeros — this
preserves user intent (typing `07` for Sunday is reasonable) and the conversion
now faithfully matches what was validated, rather than rejecting input the TUI
already accepted.

## Audit (adjacent call-sites)

Swept all five cron fields. Minute/hour/DOM/month already normalize their base
values through `zeroPad` (Atoi-based); only **step values** were passed raw —
now fixed. DOW step lists already normalized via `expandCronField`. The only
un-normalized paths were the three DOW lookups and the time-field step, all
addressed here.

## Tests

New regression tests covering a leading zero in: a single DOW (`07`, `00`), a
DOW range (`01-05`), a Sunday-start range (`00-03`), a DOW list (`01,03,05`),
Sunday dedupe (`00,07`), **every field at once** (`01 02 03 04 05`), and step
values (`*/05`, `00-30/05`). Every emitted spec was confirmed parseable by
`systemd-analyze calendar` on a real systemd host.

## Gates

`gofmt -l .` clean · `go build ./...` OK · `go test -race ./...` green (only the
known dev-box daemon flake from live `af --daemon` processes) · `golangci-lint
run --fast` clean · `deadcode -test ./...` clean.

Fixes #743

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Captain Claude