### PR TITLE
fix(session/hook): validate hook commands upfront and clean up orphans on JSON-parse failure (#738, #739)

### DIFF
--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -20,6 +20,31 @@ type RemoteHooks struct {
 	DeleteCmd string `json:"delete_cmd"`
 }
 
+// Validate checks that the command strings required to operate a remote hook
+// backend are non-empty. It is called at backend-resolution time rather than
+// at config load so that reading or rewriting a partially-configured repo
+// config never fails; the error only surfaces when agent-factory actually
+// needs to run the hooks.
+//
+// Without this guard, an empty command string defers to exec.Command(""),
+// which fails at operation time with Go's cryptic "exec: no command" and, on
+// the attach path, is swallowed in a goroutine so attach silently no-ops
+// (#738). list_cmd is intentionally not required here: import/sync paths treat
+// an empty list_cmd as "no remote sessions to enumerate" (see app/sync.go and
+// daemon/control.go), so requiring it would break that documented behavior.
+func (h RemoteHooks) Validate() error {
+	if strings.TrimSpace(h.LaunchCmd) == "" {
+		return fmt.Errorf("remote_hooks.launch_cmd is required")
+	}
+	if strings.TrimSpace(h.AttachCmd) == "" {
+		return fmt.Errorf("remote_hooks.attach_cmd is required")
+	}
+	if strings.TrimSpace(h.DeleteCmd) == "" {
+		return fmt.Errorf("remote_hooks.delete_cmd is required")
+	}
+	return nil
+}
+
 // RepoConfig holds per-repository configuration.
 type RepoConfig struct {
 	// PostWorktreeCommands are shell commands run asynchronously in the worktree

--- a/config/repo_config_test.go
+++ b/config/repo_config_test.go
@@ -231,3 +231,50 @@ func TestSaveRepoConfigAtomicWrite(t *testing.T) {
 		}
 	})
 }
+
+// TestRemoteHooksValidate covers the fail-fast guard added for #738: empty
+// (or whitespace-only) command strings for launch_cmd, attach_cmd, or
+// delete_cmd must produce an actionable error naming the offending field
+// rather than deferring to exec.Command's cryptic "exec: no command" at
+// operation time. list_cmd is intentionally optional (import/sync treat an
+// empty list_cmd as "no remote sessions to enumerate").
+func TestRemoteHooksValidate(t *testing.T) {
+	full := func() RemoteHooks {
+		return RemoteHooks{
+			LaunchCmd: "/bin/launch",
+			ListCmd:   "/bin/list",
+			AttachCmd: "/bin/attach",
+			DeleteCmd: "/bin/delete",
+		}
+	}
+
+	t.Run("fully populated is valid", func(t *testing.T) {
+		assert.NoError(t, full().Validate())
+	})
+
+	t.Run("empty list_cmd is allowed", func(t *testing.T) {
+		h := full()
+		h.ListCmd = ""
+		assert.NoError(t, h.Validate())
+	})
+
+	cases := []struct {
+		name    string
+		mutate  func(*RemoteHooks)
+		wantMsg string
+	}{
+		{"empty launch_cmd", func(h *RemoteHooks) { h.LaunchCmd = "" }, "remote_hooks.launch_cmd is required"},
+		{"whitespace launch_cmd", func(h *RemoteHooks) { h.LaunchCmd = "   " }, "remote_hooks.launch_cmd is required"},
+		{"empty attach_cmd", func(h *RemoteHooks) { h.AttachCmd = "" }, "remote_hooks.attach_cmd is required"},
+		{"empty delete_cmd", func(h *RemoteHooks) { h.DeleteCmd = "" }, "remote_hooks.delete_cmd is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := full()
+			tc.mutate(&h)
+			err := h.Validate()
+			require.Error(t, err)
+			assert.EqualError(t, err, tc.wantMsg)
+		})
+	}
+}

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -19,6 +19,8 @@ Add remote hooks to your per-repo config at `~/.agent-factory/repos/<repoID>/con
 
 Configuring `remote_hooks` enables the remote backend for that repo, but using it is explicit opt-in: press `N` in the TUI to create a remote session. Pressing `n` still creates a local tmux+git worktree session. When `remote_hooks` is absent, `N` is unavailable and all sessions are local.
 
+`launch_cmd`, `attach_cmd`, and `delete_cmd` are **required** — an empty value is rejected when the remote backend is resolved, with an error naming the missing field (e.g. `remote_hooks.launch_cmd is required`) rather than a cryptic `exec: no command` at operation time. `list_cmd` is optional: when it is empty, Agent Factory simply reports no remote sessions to enumerate (import/sync are skipped).
+
 ## Script Protocol
 
 All scripts must:
@@ -56,6 +58,8 @@ Starts a new remote agent session.
 
 Required fields: `name` (string), `status` (string: `running`).
 Additional fields are stored as metadata but not required.
+
+If `launch_cmd` exits 0 but its output cannot be parsed as the expected JSON object, Agent Factory assumes the remote session may have been created and invokes `delete_cmd --name <name>` best-effort to avoid orphaning it, then surfaces the parse error. Keep `launch_cmd` output limited to the JSON object (progress text on stderr) so this fallback is not triggered for healthy sessions.
 
 ### `list_cmd`
 

--- a/session/backend_e2e_test.go
+++ b/session/backend_e2e_test.go
@@ -357,6 +357,47 @@ func TestE2EBackendResolutionWithConfig(t *testing.T) {
 	assert.Equal(t, "remote", b.Type())
 }
 
+// TestE2EBackendResolutionRejectsEmptyHookCommands is the resolution-layer
+// regression test for #738: a remote_hooks config with an empty required
+// command string must fail fast at backend resolution with an actionable error
+// naming the offending field, rather than constructing a HookBackend that
+// later dies with exec's cryptic "exec: no command" at operation time.
+func TestE2EBackendResolutionRejectsEmptyHookCommands(t *testing.T) {
+	afHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "--local", "user.email", "test@empty.com")
+	runGit(t, repoDir, "config", "--local", "user.name", "Empty Test")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "f.txt"), []byte("x"), 0644))
+	runGit(t, repoDir, "add", "f.txt")
+	runGit(t, repoDir, "commit", "-m", "init")
+
+	repo, err := config.RepoFromPath(repoDir)
+	require.NoError(t, err)
+	// list_cmd is intentionally left empty here too, to confirm it remains
+	// optional: only launch_cmd should trip the guard.
+	cfg := &config.RepoConfig{
+		RemoteHooks: &config.RemoteHooks{
+			LaunchCmd: "",
+			AttachCmd: "/bin/echo",
+			DeleteCmd: "/bin/echo",
+		},
+	}
+	require.NoError(t, config.SaveRepoConfig(repo.ID, cfg))
+
+	_, err = backendForPath(repoDir)
+	require.Error(t, err, "resolution must reject an empty launch_cmd")
+	assert.Contains(t, err.Error(), "launch_cmd",
+		"error must name the offending field so the user can fix the config")
+
+	// loadHookBackendForPath shares the same guard.
+	_, err = loadHookBackendForPath(repoDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "launch_cmd")
+}
+
 // readStateFile reads and parses the sessions state file that the e2e hook
 // scripts maintain.
 func readStateFile(t *testing.T, _ string) []map[string]interface{} {

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -155,16 +155,27 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 		return fmt.Errorf("launch_cmd failed: %s: %w", string(out), err)
 	}
 
+	// launch_cmd exited 0, so the remote session may now exist on the remote
+	// host even though we have not yet parsed its metadata. From here on, any
+	// failure must trigger best-effort cleanup via delete_cmd, otherwise the
+	// remote session is orphaned: Start returns an error, the caller's Kill
+	// sees remoteMeta == nil and skips delete_cmd, and the session leaks
+	// permanently (#739). delete_cmd is invoked with the same slug launch_cmd
+	// received, which is the only identifier we have when the JSON is
+	// unparseable.
+
 	// The script writes progress to stderr and JSON to stdout.
 	// With CombinedOutput we get both mixed together. Try to find
 	// the first complete top-level JSON value in the output.
 	jsonStr := extractJSON(string(out))
 	if jsonStr == "" {
+		b.cleanupOrphanedLaunch(slug, i.Title)
 		return fmt.Errorf("launch_cmd returned no JSON in output: %s", string(out))
 	}
 
 	var meta map[string]interface{}
 	if err := json.Unmarshal([]byte(jsonStr), &meta); err != nil {
+		b.cleanupOrphanedLaunch(slug, i.Title)
 		return fmt.Errorf("launch_cmd returned invalid JSON: %s: %w", jsonStr, err)
 	}
 
@@ -262,13 +273,39 @@ func (b *HookBackend) Kill(i *Instance) error {
 		return nil
 	}
 
-	args := []string{"--name", slug, "--json"}
-	out, err := exec.Command(b.Hooks.DeleteCmd, args...).CombinedOutput()
+	out, err := b.runDeleteCmd(slug)
 	if err != nil {
 		return fmt.Errorf("delete_cmd failed: %s: %w", string(out), err)
 	}
 
 	return nil
+}
+
+// runDeleteCmd invokes delete_cmd for the given hook name and returns its
+// combined output and error. Shared by Kill (which surfaces the error to the
+// user) and the orphan-cleanup path in Start (which logs it best-effort, #739)
+// so both stay in sync on how delete_cmd is invoked.
+func (b *HookBackend) runDeleteCmd(name string) ([]byte, error) {
+	return exec.Command(b.Hooks.DeleteCmd, "--name", name, "--json").CombinedOutput()
+}
+
+// cleanupOrphanedLaunch best-effort deletes a remote session that launch_cmd
+// created but whose metadata Start failed to parse (#739). It never retries
+// and never returns an error: the parse failure is the error the user sees,
+// and if delete_cmd also fails the user can clean up manually with delete_cmd.
+// slug is the --name launch_cmd was invoked with — the only identifier we have
+// once the JSON payload is unusable.
+func (b *HookBackend) cleanupOrphanedLaunch(slug, title string) {
+	out, err := b.runDeleteCmd(slug)
+	if err != nil {
+		log.WarningLog.Printf(
+			"hook backend: failed to clean up orphaned remote session %q (slug %q) after launch_cmd JSON parse failure; clean up manually via delete_cmd: %s: %v",
+			title, slug, strings.TrimSpace(string(out)), err)
+		return
+	}
+	log.WarningLog.Printf(
+		"hook backend: cleaned up orphaned remote session %q (slug %q) after launch_cmd JSON parse failure",
+		title, slug)
 }
 
 func (b *HookBackend) Preview(i *Instance) (string, error) {

--- a/session/backend_orphan_test.go
+++ b/session/backend_orphan_test.go
@@ -1,11 +1,14 @@
 package session
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestHookBackendIsAliveListCmdOutputThenOrphan demonstrates a bug where
@@ -75,4 +78,115 @@ exit 0
 	// immediately and WaitDelay bounds the trailing pipe read at 500ms.
 	assert.Less(t, elapsed, runtimeAliveTimeout,
 		"IsAlive must return promptly when the script exits but a child holds the pipe (got %v)", elapsed)
+}
+
+// makeOrphanHooks builds a HookBackend whose launch_cmd exits 0 but emits the
+// given output (simulating a remote session that was created but whose
+// metadata we cannot parse), and whose delete_cmd appends the slug it was
+// asked to delete to a marker file. The returned path is that marker file, so
+// tests can assert whether delete_cmd ran and with what slug (#739).
+func makeOrphanHooks(t *testing.T, launchOutput string) (*HookBackend, string) {
+	t.Helper()
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "deleted.log")
+
+	launchCmd := writeScript(t, dir, "launch.sh", "echo '"+launchOutput+"'\nexit 0\n")
+	// $2 is the slug (delete_cmd is invoked as: --name <slug> --json).
+	deleteCmd := writeScript(t, dir, "delete.sh", "echo \"$2\" >> \""+marker+"\"\n")
+	attachCmd := writeScript(t, dir, "attach.sh", `echo "attached to $1"; sleep 0.1`)
+
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{
+			LaunchCmd: launchCmd,
+			AttachCmd: attachCmd,
+			DeleteCmd: deleteCmd,
+		},
+	}
+	return b, marker
+}
+
+// TestHookBackendStartCleansUpOrphanOnNoJSON is the primary regression test for
+// #739: launch_cmd exits 0 (creating a remote session) but emits no JSON.
+// Start must invoke delete_cmd best-effort to clean up the orphaned remote
+// session, then return the parse error to the user.
+func TestHookBackendStartCleansUpOrphanOnNoJSON(t *testing.T) {
+	b, marker := makeOrphanHooks(t, "starting up... done, but no json here")
+	i := &Instance{Title: "orphan-session", Path: t.TempDir(), backend: b}
+
+	err := b.Start(i, true)
+
+	require.Error(t, err, "Start must surface the parse failure")
+	assert.Contains(t, err.Error(), "no JSON")
+	assert.False(t, i.Started(), "instance must not be marked Started on parse failure")
+	assert.Nil(t, i.remoteMeta, "remoteMeta must remain unset on parse failure")
+
+	deleted, readErr := os.ReadFile(marker)
+	require.NoError(t, readErr, "delete_cmd must have run and written the marker")
+	assert.Contains(t, string(deleted), slugify("orphan-session"),
+		"delete_cmd must be invoked with the slug launch_cmd received")
+}
+
+// TestHookBackendStartCleansUpOrphanOnInvalidJSON covers the second leg of
+// #739: launch_cmd exits 0 and emits a parseable JSON value that is not the
+// expected object (a JSON array), so json.Unmarshal into the metadata map
+// fails. The orphan must still be cleaned up via delete_cmd.
+func TestHookBackendStartCleansUpOrphanOnInvalidJSON(t *testing.T) {
+	b, marker := makeOrphanHooks(t, "[1, 2, 3]")
+	i := &Instance{Title: "orphan-session", Path: t.TempDir(), backend: b}
+
+	err := b.Start(i, true)
+
+	require.Error(t, err, "Start must surface the invalid-JSON error")
+	assert.Contains(t, err.Error(), "invalid JSON")
+	assert.False(t, i.Started())
+	assert.Nil(t, i.remoteMeta)
+
+	deleted, readErr := os.ReadFile(marker)
+	require.NoError(t, readErr, "delete_cmd must have run on invalid JSON")
+	assert.Contains(t, string(deleted), slugify("orphan-session"))
+}
+
+// TestHookBackendStartHappyPathSkipsCleanup guards against over-eager cleanup:
+// a launch_cmd that returns well-formed JSON must NOT trigger delete_cmd. The
+// session is healthy and deleting it would defeat the create.
+func TestHookBackendStartHappyPathSkipsCleanup(t *testing.T) {
+	b, marker := makeOrphanHooks(t, `{"name": "orphan-session", "status": "running"}`)
+	i := &Instance{Title: "orphan-session", Path: t.TempDir(), backend: b}
+
+	err := b.Start(i, true)
+	require.NoError(t, err)
+	assert.True(t, i.Started())
+	require.NotNil(t, i.remoteMeta)
+	assert.Equal(t, "running", i.remoteMeta["status"])
+	b.closePTY(i.Title)
+
+	_, statErr := os.Stat(marker)
+	assert.True(t, os.IsNotExist(statErr),
+		"delete_cmd must not run on the happy path (marker file should not exist)")
+}
+
+// TestHookBackendStartCleanupBestEffort verifies the cleanup is best-effort:
+// when launch_cmd produces no JSON AND delete_cmd itself fails, Start still
+// returns the original parse error (not the delete failure) so the user sees
+// the root cause. Cleanup failures are logged, not surfaced or retried.
+func TestHookBackendStartCleanupBestEffort(t *testing.T) {
+	dir := t.TempDir()
+	launchCmd := writeScript(t, dir, "launch.sh", "echo 'no json'\nexit 0\n")
+	deleteCmd := writeScript(t, dir, "delete.sh", "echo 'delete boom' >&2\nexit 1\n")
+	attachCmd := writeScript(t, dir, "attach.sh", `echo "attached"; sleep 0.1`)
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{
+			LaunchCmd: launchCmd,
+			AttachCmd: attachCmd,
+			DeleteCmd: deleteCmd,
+		},
+	}
+	i := &Instance{Title: "orphan-session", Path: t.TempDir(), backend: b}
+
+	err := b.Start(i, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no JSON",
+		"the original parse error must surface even when best-effort cleanup fails")
+	assert.NotContains(t, err.Error(), "delete boom",
+		"delete_cmd failure must not replace the root-cause error")
 }

--- a/session/backend_resolve.go
+++ b/session/backend_resolve.go
@@ -24,6 +24,9 @@ func backendForRepoID(repoID string) (Backend, error) {
 		return nil, fmt.Errorf("failed to load repo config: %w", err)
 	}
 	if cfg.RemoteHooks != nil {
+		if err := cfg.RemoteHooks.Validate(); err != nil {
+			return nil, err
+		}
 		return &HookBackend{Hooks: *cfg.RemoteHooks}, nil
 	}
 	return &LocalBackend{}, nil
@@ -42,6 +45,9 @@ func loadHookBackendForPath(absPath string) (*HookBackend, error) {
 	}
 	if cfg.RemoteHooks == nil {
 		return nil, fmt.Errorf("no remote hooks configured for repo %s", repo.ID)
+	}
+	if err := cfg.RemoteHooks.Validate(); err != nil {
+		return nil, err
 	}
 	return &HookBackend{Hooks: *cfg.RemoteHooks}, nil
 }


### PR DESCRIPTION
## Summary

Hardens the remote-hooks backend against two failure modes that surfaced as cryptic errors or silent resource leaks. Fixes #738 and #739.

### #738 — empty hook commands fail cryptically (and silently on attach)

Empty command strings in `remote_hooks` (`launch_cmd`, `attach_cmd`, `delete_cmd`) were accepted by backend resolution (`backendForRepoID` / `loadHookBackendForPath` only checked `RemoteHooks != nil`). They only failed at operation time with Go's `exec: no command` — and on the attach path that error is logged inside a goroutine, so attach silently no-oped.

**Fix:** new `config.RemoteHooks.Validate()`, called from both resolve functions, fails fast with an actionable error naming the field (e.g. `remote_hooks.launch_cmd is required`). Whitespace-only values are caught too. `list_cmd` stays **optional** — import/sync (`app/sync.go`, `daemon/control.go`) intentionally treat an empty `list_cmd` as "no remote sessions to enumerate," so requiring it would break documented behavior.

### #739 — successful launch + bad JSON orphans the remote session

`HookBackend.Start` only set `i.remoteMeta` *after* parsing `launch_cmd`'s JSON. If `launch_cmd` exited 0 (creating the remote session) but emitted missing/invalid JSON, `Start` returned before setting `remoteMeta`. The caller's `Kill` then saw `hadRemote := i.remoteMeta != nil` as false and skipped `delete_cmd` — leaking the remote session permanently with no way to clean it up from the TUI.

**Fix:** once `launch_cmd` exits 0, any subsequent parse failure (no JSON, or non-object JSON) triggers a best-effort `delete_cmd` against the slug `launch_cmd` received — the only identifier available when the payload is unusable — then returns the original parse error. Cleanup is **best-effort**: failures are logged, not retried, not surfaced, so the root-cause parse error always reaches the user (they can clean up manually).

## Root causes

- **#738** (introduced in #131): `cfg.RemoteHooks != nil` was the only gate; per-command non-emptiness was never checked, deferring to `exec.Command("")`.
- **#739** (introduced in #539): the `hadRemote := i.remoteMeta != nil` guard added in #518 conflates "Start never ran" with "Start ran but JSON parse failed." `remoteMeta` is only set after parse success, so the partial-success case leaked.

## Audit (CLAUDE.md adjacent-call-sites)

All production `HookBackend` construction flows through `backendForRepoID` and `loadHookBackendForPath`, so the `Validate()` guard covers every downstream `launch_cmd` / `attach_cmd` / `delete_cmd` invocation. `ListRemoteHookInstanceData` (called directly from sync/daemon) only touches `list_cmd` and already guards `ListCmd == ""`. `Kill`'s `delete_cmd` invocation and the new orphan cleanup now share `runDeleteCmd` so they cannot drift on how `delete_cmd` is called.

## Tests

- `config`: `RemoteHooks.Validate` — fully-populated valid; empty `list_cmd` allowed; empty/whitespace `launch_cmd`, empty `attach_cmd`, empty `delete_cmd` each rejected with the field-named message.
- `session` (resolution): empty `launch_cmd` rejected via `backendForPath` **and** `loadHookBackendForPath`; `list_cmd` confirmed optional.
- `session` (#739): `launch_cmd` exit-0 with no JSON → `delete_cmd` invoked with the correct slug, error returned; exit-0 with non-object JSON (`[1,2,3]`) → same; happy path → `delete_cmd` **not** invoked; `delete_cmd` failing → original parse error still surfaces.

## Validation

- `gofmt -l .` clean · `go build ./...` clean · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean
- `go test ./...` green, plus `go test -race ./session/ ./config/` green. (The unrelated `daemon/TestSigtermFallback_DeadPID` failure on the dev box comes from real running `af --daemon` processes, not this change.)

Docs in `docs/remote-hooks.md` updated to document which commands are required vs. optional and the orphan-cleanup fallback.

Fixes #738
Fixes #739

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
