### PR TITLE
fix(ui/terminal): guard against stale viewport on instance switch and session creation failure (#746, #747)

### DIFF
--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -143,7 +143,7 @@ func (w *TabbedWindow) ScrollUp() {
 			log.InfoLog.Printf("tabbed window failed to scroll up: %v", err)
 		}
 	case TerminalTab:
-		if err := w.terminal.ScrollUp(); err != nil {
+		if err := w.terminal.ScrollUp(w.instance); err != nil {
 			log.InfoLog.Printf("tabbed window failed to scroll terminal up: %v", err)
 		}
 	}
@@ -157,7 +157,7 @@ func (w *TabbedWindow) ScrollDown() {
 			log.InfoLog.Printf("tabbed window failed to scroll down: %v", err)
 		}
 	case TerminalTab:
-		if err := w.terminal.ScrollDown(); err != nil {
+		if err := w.terminal.ScrollDown(w.instance); err != nil {
 			log.InfoLog.Printf("tabbed window failed to scroll terminal down: %v", err)
 		}
 	}

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -64,6 +64,30 @@ func (t *TerminalPane) SetSize(width, height int) {
 	}
 }
 
+// dropStaleScrollState clears scroll-mode viewport content captured from a
+// previously selected instance. Caller must hold t.mu.
+//
+// UpdateContent runs this on every refresh, but the mouse/keyboard scroll path
+// (ScrollUp/ScrollDown) is driven straight off the bubbletea event loop and
+// can fire before the async UpdateContent for the newly selected instance has
+// run. Without this guard a scroll would re-capture and scroll the previous
+// instance's terminal history instead of resetting scroll mode (#746). Unlike
+// PreviewPane.dropStaleScrollState this does not adopt the new title:
+// currentTitle is owned by ensureSessionLocked, which only sets it once a live
+// session exists. Mirrors PreviewPane.dropStaleScrollState (#702), the same
+// motivation as the setFallbackState consolidation in #669.
+func (t *TerminalPane) dropStaleScrollState(instance *session.Instance) {
+	title := ""
+	if instance != nil {
+		title = instance.Title
+	}
+	if t.isScrolling && t.currentTitle != "" && t.currentTitle != title {
+		t.isScrolling = false
+		t.viewport.SetContent("")
+		t.viewport.GotoTop()
+	}
+}
+
 // setFallbackState sets the terminal pane to display a fallback message.
 // Caller must hold t.mu.
 //
@@ -104,19 +128,21 @@ func (t *TerminalPane) UpdateContent(instance *session.Instance) error {
 	// so ensureSessionLocked() runs and updates t.currentTitle. Otherwise
 	// Attach() would resolve t.sessions[t.currentTitle] to the previous
 	// instance's session (issue #384).
-	if t.isScrolling && t.currentTitle != "" && t.currentTitle != instance.Title {
-		t.isScrolling = false
-		t.viewport.SetContent("")
-	}
+	t.dropStaleScrollState(instance)
 
 	// Skip content updates while in scroll mode
 	if t.isScrolling {
 		return nil
 	}
 
-	// Ensure we have a terminal session for this instance
+	// Ensure we have a terminal session for this instance. On failure the
+	// instance has no usable session, so show a fallback rather than
+	// returning an error: the caller only logs it, leaving the previous
+	// instance's captured content on screen (#747). Mirrors the
+	// ErrSessionGone fallback handling below.
 	if err := t.ensureSessionLocked(instance); err != nil {
-		return err
+		t.setFallbackState(fmt.Sprintf("Failed to start terminal session: %v", err))
+		return nil
 	}
 
 	s, ok := t.sessions[t.currentTitle]
@@ -396,8 +422,16 @@ func (t *TerminalPane) String() string {
 
 // enterScrollMode captures the full terminal history and enters scroll mode.
 // Caller must hold t.mu.
-func (t *TerminalPane) enterScrollMode() error {
-	s, ok := t.sessions[t.currentTitle]
+//
+// Looks the session up by the selected instance's title rather than
+// t.currentTitle: in the scroll path UpdateContent may not have run yet, so
+// currentTitle can still name the previously selected instance and would
+// capture its history (#746).
+func (t *TerminalPane) enterScrollMode(instance *session.Instance) error {
+	if instance == nil {
+		return nil
+	}
+	s, ok := t.sessions[instance.Title]
 	if !ok || s.tmuxSession == nil || !s.tmuxSession.DoesSessionExist() {
 		return nil
 	}
@@ -416,26 +450,34 @@ func (t *TerminalPane) enterScrollMode() error {
 	t.viewport.SetContent(contentWithFooter)
 	t.viewport.GotoBottom()
 	t.isScrolling = true
+	// Adopt the scrolled instance as current. The scroll path can run before
+	// UpdateContent has bound currentTitle to the new selection; without this
+	// the next refresh's dropStaleScrollState would see a mismatched title and
+	// immediately discard the scroll the user just started (#746). Safe wrt
+	// #716 — we only get here once a live session for this instance exists.
+	t.currentTitle = instance.Title
 	return nil
 }
 
 // ScrollUp enters scroll mode (if not already) and scrolls up.
-func (t *TerminalPane) ScrollUp() error {
+func (t *TerminalPane) ScrollUp(instance *session.Instance) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.dropStaleScrollState(instance)
 	if !t.isScrolling {
-		return t.enterScrollMode()
+		return t.enterScrollMode(instance)
 	}
 	t.viewport.LineUp(1)
 	return nil
 }
 
 // ScrollDown enters scroll mode (if not already) and scrolls down.
-func (t *TerminalPane) ScrollDown() error {
+func (t *TerminalPane) ScrollDown(instance *session.Instance) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.dropStaleScrollState(instance)
 	if !t.isScrolling {
-		return t.enterScrollMode()
+		return t.enterScrollMode(instance)
 	}
 	t.viewport.LineDown(1)
 	return nil

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -305,7 +305,7 @@ func TestTerminalScrolling(t *testing.T) {
 	require.False(t, tp.IsScrolling(), "should not be scrolling initially")
 
 	// ScrollUp should enter scroll mode
-	err := tp.ScrollUp()
+	err := tp.ScrollUp(instance)
 	require.NoError(t, err)
 	require.True(t, tp.IsScrolling(), "should be in scroll mode after ScrollUp")
 
@@ -314,7 +314,7 @@ func TestTerminalScrolling(t *testing.T) {
 	require.NotEmpty(t, viewContent, "viewport should have content in scroll mode")
 
 	// ScrollDown should continue in scroll mode
-	err = tp.ScrollDown()
+	err = tp.ScrollDown(instance)
 	require.NoError(t, err)
 	require.True(t, tp.IsScrolling(), "should still be in scroll mode after ScrollDown")
 
@@ -451,7 +451,7 @@ func TestTerminalCloseForInstanceResetsScrollMode(t *testing.T) {
 	injectSession(tp, closedInstance.Title, closedTs, closedInstance.GetWorktreePath())
 
 	// Enter scroll mode on closedInstance — populates viewport, sets isScrolling=true.
-	require.NoError(t, tp.ScrollUp())
+	require.NoError(t, tp.ScrollUp(closedInstance))
 	require.True(t, tp.IsScrolling(), "precondition: should be in scroll mode after ScrollUp")
 
 	// Close the instance whose terminal we are scrolling. With the bug,
@@ -501,7 +501,7 @@ func TestTerminalFallbackResetsScrollMode(t *testing.T) {
 	enterScrollOnPrior := func(tp *TerminalPane) {
 		t.Helper()
 		injectSession(tp, priorInstance.Title, priorTs, priorInstance.GetWorktreePath())
-		require.NoError(t, tp.ScrollUp())
+		require.NoError(t, tp.ScrollUp(priorInstance))
 		require.True(t, tp.IsScrolling(), "precondition: should be in scroll mode")
 		require.Contains(t, tp.viewport.View(), priorContent,
 			"precondition: viewport should hold prior instance's history")
@@ -553,6 +553,121 @@ func TestTerminalFallbackResetsScrollMode(t *testing.T) {
 		require.NotContains(t, rendered, priorContent,
 			"String() must not render the prior instance's scroll-mode content")
 	})
+}
+
+// TestTerminalScrollUsesSelectedInstance is a regression test for #746.
+// The scroll path (ScrollUp/ScrollDown) is driven straight off the bubbletea
+// event loop and can fire before the async UpdateContent for a newly selected
+// instance has run, leaving t.currentTitle pointing at the previously selected
+// instance. Before the fix enterScrollMode captured t.sessions[t.currentTitle]
+// — the previous instance — so the user scrolled the wrong terminal's history.
+// The scroll path must key off the selected instance. Mirrors the PreviewPane
+// mouse-scroll guard (#702).
+func TestTerminalScrollUsesSelectedInstance(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	const contentA = "terminal-history-from-instance-A"
+	const contentB = "terminal-history-from-instance-B"
+
+	instA := makeStartedInstance(t, "scroll-A")
+	defer func() { _ = instA.Kill() }()
+	instB := makeStartedInstance(t, "scroll-B")
+	defer func() { _ = instB.Kill() }()
+
+	tp := NewTerminalPane()
+	tp.SetSize(80, 30)
+
+	tsA := newMockTmuxSession(t, "scroll-A", mockCmdExec(contentA, true))
+	tsB := newMockTmuxSession(t, "scroll-B", mockCmdExec(contentB, true))
+
+	// A is selected and displayed: injectSession sets currentTitle == A.
+	injectSession(tp, instA.Title, tsA, instA.GetWorktreePath())
+
+	// B becomes selected, but UpdateTerminal(B) has not run yet — B's session
+	// is cached while currentTitle still names A. This is the race window the
+	// bug lives in.
+	tp.mu.Lock()
+	tp.sessions[instB.Title] = &terminalSession{
+		tmuxSession:  tsB,
+		worktreePath: instB.GetWorktreePath(),
+	}
+	tp.mu.Unlock()
+
+	// User scrolls while B is the selected instance.
+	require.NoError(t, tp.ScrollUp(instB))
+	require.True(t, tp.IsScrolling(), "should enter scroll mode for the selected instance")
+
+	rendered := tp.viewport.View()
+	require.Contains(t, rendered, contentB,
+		"scroll must capture the selected instance's (B) terminal history")
+	require.NotContains(t, rendered, contentA,
+		"scroll must not capture the previously selected instance's (A) history (#746)")
+
+	// enterScrollMode adopts B as current, so a subsequent refresh for B does
+	// not discard the scroll the user just started.
+	require.NoError(t, tp.UpdateContent(instB))
+	require.True(t, tp.IsScrolling(), "scroll on the selected instance must survive the next refresh")
+	require.Contains(t, tp.viewport.View(), contentB, "scroll content must remain B's history")
+}
+
+// TestTerminalSessionCreationFailureShowsFallback is a regression test for
+// #747. When ensureSessionLocked fails, the new instance has no usable session.
+// UpdateContent previously returned the error (which the caller only logs),
+// leaving the previous instance's captured content on screen. It must instead
+// drop into a fallback state — mirroring the ErrSessionGone handling — so the
+// stale content is replaced with a clear failure message.
+func TestTerminalSessionCreationFailureShowsFallback(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	tp := NewTerminalPane()
+	tp.SetSize(80, 30)
+
+	// A previously selected, working instance leaves content on screen.
+	const priorContent = "stale-output-from-prior-instance"
+	priorInstance := makeStartedInstance(t, "prior")
+	defer func() { _ = priorInstance.Kill() }()
+	priorTs := newMockTmuxSession(t, "prior", mockCmdExec(priorContent, true))
+	injectSession(tp, priorInstance.Title, priorTs, priorInstance.GetWorktreePath())
+	require.NoError(t, tp.UpdateContent(priorInstance))
+	tp.mu.Lock()
+	require.Equal(t, priorContent, tp.content, "precondition: prior instance content is displayed")
+	tp.mu.Unlock()
+
+	// Now select an instance whose terminal session creation fails.
+	failInstance := makeStartedInstance(t, "fails")
+	defer func() { _ = failInstance.Kill() }()
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				return fmt.Errorf("session does not exist")
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+	oldFactory := newTerminalTmuxSessionForRepo
+	newTerminalTmuxSessionForRepo = func(name, program, shell string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionWithDeps(name, shell, failingPtyFactory{}, cmdExec)
+	}
+	t.Cleanup(func() { newTerminalTmuxSessionForRepo = oldFactory })
+
+	// UpdateContent must not propagate the error; it must set fallback state.
+	require.NoError(t, tp.UpdateContent(failInstance),
+		"session-creation failure must be handled as a fallback, not returned (#747)")
+
+	tp.mu.Lock()
+	require.True(t, tp.fallback, "must enter fallback state when session creation fails")
+	require.False(t, tp.isScrolling, "fallback must clear scroll state")
+	tp.mu.Unlock()
+
+	rendered := tp.String()
+	require.Contains(t, rendered, "Failed to start terminal session",
+		"must show a clear failure message")
+	require.NotContains(t, rendered, priorContent,
+		"must not render the previously selected instance's stale content (#747)")
 }
 
 type failingPtyFactory struct{}


### PR DESCRIPTION
## Summary

Two related stale-content bugs in the Terminal tab, both introduced in `e69ff9ce` (PR #247) when per-instance terminal sessions were added without the guards `PreviewPane` already has. The Terminal tab could render a *previously selected* instance's content in two distinct paths.

### #746 — scroll path shows the wrong instance's terminal output

`TabbedWindow` delegates scroll to `TerminalPane.ScrollUp/ScrollDown`, but those methods took no instance and keyed capture off `t.currentTitle`. Pane refresh is async: a user can switch selection A→B and scroll the Terminal tab before `UpdateTerminal(B)` has rebound `currentTitle`. `enterScrollMode` then captured `t.sessions[t.currentTitle]` — instance A — so the user scrolled the wrong worktree's history.

**Fix:** `ScrollUp/ScrollDown` now take `instance *session.Instance` (mirroring `PreviewPane.ScrollUp(instance)`); `TabbedWindow` passes `w.instance`. A new `dropStaleScrollState` helper drops scroll-mode viewport state on a title mismatch, and `enterScrollMode` looks the session up by `instance.Title` and adopts it as `currentTitle` so the next refresh doesn't discard the just-started scroll.

### #747 — session-creation failure shows stale content

When `ensureSessionLocked` failed, `UpdateContent` returned the error. The caller (`refreshPanesCmd` → `UpdateTerminal`) only logs it, so the previous instance's captured `t.content` stayed on screen with no indication anything went wrong, and `Attach()` would fail against a non-existent session.

**Fix:** on `ensureSessionLocked` failure, `UpdateContent` now calls `setFallbackState("Failed to start terminal session: <reason>")` and returns nil — exactly mirroring the existing `ErrSessionGone` fallback a few lines below.

## Mirror analogy

- `dropStaleScrollState` mirrors `PreviewPane.dropStaleScrollState` (**#702**), which fixed the identical race on the preview mouse-scroll path.
- The fallback-on-failure mirrors the `setFallbackState` consolidation from **#669**, where scroll state must be cleared so `String()` (which checks `isScrolling` before `fallback`) cannot render a stale viewport.

The one deliberate difference from `PreviewPane`: `dropStaleScrollState` does **not** adopt the new title, because `currentTitle` is owned by `ensureSessionLocked` (the #716 invariant: it is set only once a live session exists). `enterScrollMode` adopts the title only after confirming a live session, preserving that invariant.

## Audit (per adjacent-call-sites convention)

Reviewed every `TerminalPane` method that reads `t.viewport`/`t.currentTitle` for rendering:
- `String()` renders the viewport only when `isScrolling`; both fixes guarantee scroll state is dropped/fallback-cleared on instance change, so it can't show a stale viewport.
- `enterScrollMode` — now keys off the selected instance.
- `Attach`/`AttachForInstance` — already guarded by #716 (`AttachForInstance` re-binds and refuses on title mismatch); session-creation failure now also surfaces a fallback.
- `SetSize`, `Close`, `CloseForInstance`, `ResetToNormalMode` — already reset/scope state correctly.

Only production caller of the changed signatures is `TabbedWindow` (updated).

## Tests

- `TestTerminalScrollUsesSelectedInstance` (#746): inject A (current) + B (cached but `currentTitle` still A), scroll on B → asserts the viewport holds B's history, not A's, and that the scroll survives the next `UpdateContent(B)`.
- `TestTerminalSessionCreationFailureShowsFallback` (#747): display a working prior instance, then select an instance whose session creation fails → asserts fallback state, the "Failed to start terminal session" message, and that the prior instance's content is gone.

## Verification

All four CI gates plus `deadcode` and `-race`:
- `go build ./...` ✅
- `gofmt -l .` ✅ (no output)
- `golangci-lint run --timeout=3m --fast` ✅
- `deadcode -test ./...` ✅ (no output)
- `go test ./...` ✅
- `go test -race ./ui/` ✅

Fixes #746
Fixes #747

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)