### PR TITLE
fix(api,daemon): warn-and-preserve on corrupted or missing repo session storage (#730, #736)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -56,9 +59,15 @@ func findInstanceByTitle(title string) (*session.InstanceData, string, error) {
 		return nil, "", fmt.Errorf("failed to load instances: %w", err)
 	}
 
+	var corrupted []string
 	for repoID, raw := range allInstances {
 		var instances []session.InstanceData
 		if err := json.Unmarshal(raw, &instances); err != nil {
+			// Warn and record the corrupted repo rather than silently
+			// skipping it (#730). If the target title lives in this repo we
+			// would otherwise report a misleading "not found".
+			log.WarningLog.Printf("skipping repo %s: corrupted instances.json: %v", repoID, err)
+			corrupted = append(corrupted, repoID)
 			continue
 		}
 		for i := range instances {
@@ -67,7 +76,52 @@ func findInstanceByTitle(title string) (*session.InstanceData, string, error) {
 			}
 		}
 	}
+	if len(corrupted) > 0 {
+		return nil, "", fmt.Errorf("instance %q not found; %s", title, corruptedReposSuffix(corrupted))
+	}
 	return nil, "", fmt.Errorf("instance %q not found", title)
+}
+
+// corruptedReposSuffix builds a sorted, human-readable clause naming the repos
+// whose instances.json failed to parse. Callers use it to surface corruption
+// loudly instead of silently returning empty/partial results (#730).
+func corruptedReposSuffix(corrupted []string) string {
+	sort.Strings(corrupted)
+	return fmt.Sprintf("%d repo(s) have a corrupted instances.json and may be hiding it: %s", len(corrupted), strings.Join(corrupted, ", "))
+}
+
+// corruptedReposError builds a structured error for aggregate queries (e.g.
+// `sessions list`) that name the repos whose instances.json failed to parse.
+// Returning this instead of a silently-truncated result lets users tell "no
+// sessions exist" apart from "sessions exist but the file is corrupted" (#730).
+func corruptedReposError(corrupted []string) error {
+	sort.Strings(corrupted)
+	return fmt.Errorf("%d repo(s) have a corrupted instances.json and their sessions are hidden until it is repaired: %s", len(corrupted), strings.Join(corrupted, ", "))
+}
+
+// loadAllInstancesAggregate aggregates instances across every repo, returning
+// the parsed entries plus the IDs of repos whose instances.json failed to
+// parse. Corrupted repos are logged (naming the repo) and reported via the
+// second return value so callers surface them instead of silently returning a
+// truncated list (#730). Empty/new repos parse cleanly to zero entries and are
+// not treated as corruption, preserving backward-compatible empty results.
+func loadAllInstancesAggregate() ([]session.InstanceData, []string, error) {
+	allInstances, err := config.LoadAllRepoInstances()
+	if err != nil {
+		return nil, nil, err
+	}
+	var allData []session.InstanceData
+	var corrupted []string
+	for repoID, raw := range allInstances {
+		var instances []session.InstanceData
+		if err := json.Unmarshal(raw, &instances); err != nil {
+			log.WarningLog.Printf("skipping repo %s: corrupted instances.json: %v", repoID, err)
+			corrupted = append(corrupted, repoID)
+			continue
+		}
+		allData = append(allData, instances...)
+	}
+	return allData, corrupted, nil
 }
 
 func repoHasInstanceTitle(repoID, title string) (bool, error) {

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -103,17 +103,18 @@ var sessionsListCmd = &cobra.Command{
 				return jsonError(fmt.Errorf("failed to parse instances: %w", err))
 			}
 		} else {
-			allInstances, err := config.LoadAllRepoInstances()
+			// Don't silently substitute an empty/partial list when a repo
+			// file is corrupted (#730): loadAllInstancesAggregate warns naming
+			// each bad repo, and we fail loudly so users can tell "no sessions"
+			// apart from "sessions hidden behind a corrupt file."
+			data, corrupted, err := loadAllInstancesAggregate()
 			if err != nil {
 				return jsonError(err)
 			}
-			for _, raw := range allInstances {
-				var instances []session.InstanceData
-				if err := json.Unmarshal(raw, &instances); err != nil {
-					continue
-				}
-				allData = append(allData, instances...)
+			if len(corrupted) > 0 {
+				return jsonError(corruptedReposError(corrupted))
 			}
+			allData = data
 		}
 
 		if allData == nil {
@@ -427,9 +428,15 @@ var sessionsWhoamiCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("failed to load instances: %w", err))
 		}
 
-		for _, raw := range allInstances {
+		var corrupted []string
+		for repoID, raw := range allInstances {
 			var instances []session.InstanceData
 			if err := json.Unmarshal(raw, &instances); err != nil {
+				// Warn and record rather than silently skip (#730): the
+				// current session's record may live in the corrupted repo,
+				// so a bare "not found" would mask the real cause.
+				log.WarningLog.Printf("skipping repo %s: corrupted instances.json: %v", repoID, err)
+				corrupted = append(corrupted, repoID)
 				continue
 			}
 			for i := range instances {
@@ -439,6 +446,9 @@ var sessionsWhoamiCmd = &cobra.Command{
 			}
 		}
 
+		if len(corrupted) > 0 {
+			return jsonError(fmt.Errorf("no Agent Factory session found for tmux session %q; %s", tmuxName, corruptedReposSuffix(corrupted)))
+		}
 		return jsonError(fmt.Errorf("no Agent Factory session found for tmux session %q", tmuxName))
 	},
 }

--- a/api/storage_inconsistency_test.go
+++ b/api/storage_inconsistency_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// captureWarnings redirects WarningLog output into a buffer for the duration
+// of a test so assertions can confirm corrupted/missing storage is surfaced
+// loudly rather than dropped silently (#730). It points the logger straight at
+// the buffer (rather than teeing through the prior writer) because sibling
+// tests can leave WarningLog attached to a since-closed fd — io.MultiWriter
+// aborts on the first writer's error, which would swallow the captured output.
+func captureWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := log.WarningLog.Writer()
+	log.WarningLog.SetOutput(&buf)
+	t.Cleanup(func() { log.WarningLog.SetOutput(prev) })
+	return &buf
+}
+
+// TestLoadAllInstancesAggregate_WarnsAndReportsCorruptedRepo is the regression
+// test for #730: aggregating sessions across repos must not silently skip a
+// repo whose instances.json is corrupted. The bad repo has to be both logged
+// (naming it) and reported back to the caller so `sessions list` can fail
+// loudly instead of returning a truncated list that looks like "no sessions."
+func TestLoadAllInstancesAggregate_WarnsAndReportsCorruptedRepo(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	warnBuf := captureWarnings(t)
+
+	validRepoID := "valid-repo"
+	validJSON, err := json.Marshal([]session.InstanceData{{Title: "good-session"}})
+	if err != nil {
+		t.Fatalf("marshal valid: %v", err)
+	}
+	if err := config.SaveRepoInstances(validRepoID, validJSON); err != nil {
+		t.Fatalf("save valid repo: %v", err)
+	}
+
+	corruptedRepoID := "corrupted-repo"
+	if err := config.SaveRepoInstances(corruptedRepoID, json.RawMessage("{not valid json")); err != nil {
+		t.Fatalf("save corrupted repo: %v", err)
+	}
+
+	data, corrupted, err := loadAllInstancesAggregate()
+	if err != nil {
+		t.Fatalf("loadAllInstancesAggregate returned hard error: %v", err)
+	}
+	if len(corrupted) != 1 || corrupted[0] != corruptedRepoID {
+		t.Fatalf("expected corrupted=[%q], got %v", corruptedRepoID, corrupted)
+	}
+	// Valid data must still be parsed (the corruption is per-repo).
+	if len(data) != 1 || data[0].Title != "good-session" {
+		t.Fatalf("expected the valid repo's session to parse, got %+v", data)
+	}
+	if !strings.Contains(warnBuf.String(), corruptedRepoID) {
+		t.Fatalf("expected warning naming corrupted repo %q; got: %q", corruptedRepoID, warnBuf.String())
+	}
+
+	// corruptedReposError must name the bad repo so the CLI/API surfaces it.
+	cerr := corruptedReposError(corrupted)
+	if !strings.Contains(cerr.Error(), corruptedRepoID) {
+		t.Fatalf("expected structured error to name corrupted repo %q; got: %v", corruptedRepoID, cerr)
+	}
+}
+
+// TestLoadAllInstancesAggregate_EmptyNotCorrupted guards backward compatibility
+// (#730 constraint): empty/new instance stores must produce an empty result
+// with NO corruption reported and NO error — only malformed JSON counts as
+// corruption.
+func TestLoadAllInstancesAggregate_EmptyNotCorrupted(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	warnBuf := captureWarnings(t)
+
+	// No repos at all.
+	data, corrupted, err := loadAllInstancesAggregate()
+	if err != nil {
+		t.Fatalf("unexpected error with no repos: %v", err)
+	}
+	if len(corrupted) != 0 {
+		t.Fatalf("no repos should mean no corruption, got %v", corrupted)
+	}
+	if len(data) != 0 {
+		t.Fatalf("expected empty result, got %+v", data)
+	}
+
+	// A repo whose file holds an empty array is "new/empty", not corrupted.
+	if err := config.SaveRepoInstances("empty-repo", json.RawMessage("[]")); err != nil {
+		t.Fatalf("save empty repo: %v", err)
+	}
+	data, corrupted, err = loadAllInstancesAggregate()
+	if err != nil {
+		t.Fatalf("unexpected error with empty repo: %v", err)
+	}
+	if len(corrupted) != 0 {
+		t.Fatalf("empty array must not be treated as corruption, got %v", corrupted)
+	}
+	if len(data) != 0 {
+		t.Fatalf("expected empty result, got %+v", data)
+	}
+	if warnBuf.Len() != 0 {
+		t.Fatalf("empty/new stores should not warn; got: %q", warnBuf.String())
+	}
+}
+
+// TestFindInstanceByTitle_NamesCorruptedRepoOnNotFound covers #730 for the
+// title-lookup path: when the title is absent and a repo is corrupted, the
+// returned error must name the corrupted repo (so the user knows the session
+// may be hidden behind a bad file) rather than a bare "not found."
+func TestFindInstanceByTitle_NamesCorruptedRepoOnNotFound(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	warnBuf := captureWarnings(t)
+
+	corruptedRepoID := "corrupted-repo"
+	if err := config.SaveRepoInstances(corruptedRepoID, json.RawMessage("{not valid json")); err != nil {
+		t.Fatalf("save corrupted repo: %v", err)
+	}
+
+	_, _, err := findInstanceByTitle("ghost-title")
+	if err == nil {
+		t.Fatalf("expected error when title missing and a repo is corrupted")
+	}
+	if !strings.Contains(err.Error(), corruptedRepoID) {
+		t.Fatalf("expected error to name corrupted repo %q; got: %v", corruptedRepoID, err)
+	}
+	if !strings.Contains(warnBuf.String(), corruptedRepoID) {
+		t.Fatalf("expected warning naming corrupted repo %q; got: %q", corruptedRepoID, warnBuf.String())
+	}
+}
+
+// TestFindInstanceByTitle_PositiveLookupNotBlockedByCorruption verifies that a
+// corrupted repo does not prevent a successful lookup of a title that lives in
+// a healthy repo — corruption is warned about, not fatal to findable sessions.
+func TestFindInstanceByTitle_PositiveLookupNotBlockedByCorruption(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	_ = captureWarnings(t)
+
+	if err := config.SaveRepoInstances("corrupted-repo", json.RawMessage("{not valid json")); err != nil {
+		t.Fatalf("save corrupted repo: %v", err)
+	}
+	validJSON, err := json.Marshal([]session.InstanceData{{Title: "findme"}})
+	if err != nil {
+		t.Fatalf("marshal valid: %v", err)
+	}
+	if err := config.SaveRepoInstances("valid-repo", validJSON); err != nil {
+		t.Fatalf("save valid repo: %v", err)
+	}
+
+	data, repoID, err := findInstanceByTitle("findme")
+	if err != nil {
+		t.Fatalf("expected to find session in healthy repo despite corruption elsewhere: %v", err)
+	}
+	if data.Title != "findme" || repoID != "valid-repo" {
+		t.Fatalf("unexpected lookup result: data=%+v repoID=%q", data, repoID)
+	}
+}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -9,6 +9,7 @@ import (
 	"net/rpc"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -935,9 +936,15 @@ func findInstanceDataByTitle(title, repoID string) (*session.InstanceData, strin
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load instances: %w", err)
 	}
+	var corrupted []string
 	for rid, raw := range allInstances {
 		var data []session.InstanceData
 		if err := json.Unmarshal(raw, &data); err != nil {
+			// Warn and record the corrupted repo rather than silently
+			// skipping it (#730). If the target title lives in this repo we
+			// would otherwise report a misleading "not found".
+			log.WarningLog.Printf("daemon skipping repo %s: corrupted instances.json: %v", rid, err)
+			corrupted = append(corrupted, rid)
 			continue
 		}
 		for i := range data {
@@ -945,6 +952,10 @@ func findInstanceDataByTitle(title, repoID string) (*session.InstanceData, strin
 				return &data[i], rid, nil
 			}
 		}
+	}
+	if len(corrupted) > 0 {
+		sort.Strings(corrupted)
+		return nil, "", fmt.Errorf("instance %q not found; %d repo(s) have a corrupted instances.json that may be hiding it: %s", title, len(corrupted), strings.Join(corrupted, ", "))
 	}
 	return nil, "", fmt.Errorf("instance %q not found", title)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -164,6 +164,30 @@ func refreshDaemonInstances(existing map[string]*session.Instance) (map[string]*
 		}
 	}
 
+	// Preserve in-memory instances whose repo directory vanished from disk
+	// entirely (#736). LoadAllRepoInstances only returns repos that still have
+	// an on-disk instances directory, so an externally-deleted repo dir is
+	// simply absent from allInstances and would otherwise be dropped from
+	// `next`. This is a recoverable disk inconsistency — SaveInstances recreates
+	// missing repo directories — so we re-hydrate the prior instances and log
+	// loudly rather than silently abandoning running AutoYes sessions. This
+	// parallels the corrupted-JSON handling above, which also re-hydrates from
+	// `existing`. On startup (existing == nil) there is nothing to preserve.
+	if existing != nil {
+		warnedRepos := make(map[string]bool)
+		for key, inst := range existing {
+			repoID, _ := splitDaemonInstanceKey(key)
+			if _, ok := allInstances[repoID]; ok {
+				continue
+			}
+			if !warnedRepos[repoID] {
+				log.WarningLog.Printf("daemon preserving in-memory instances for missing repo directory: %s", repoID)
+				warnedRepos[repoID] = true
+			}
+			next[key] = inst
+		}
+	}
+
 	return next, nil
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -424,6 +424,130 @@ func TestRefreshDaemonInstances_PreservesExistingForCorruptedRepoOnPoll(t *testi
 	}
 }
 
+// TestRefreshDaemonInstances_PreservesInstancesForMissingRepoDirectory covers
+// #736: when a repo's instances directory is deleted externally while the
+// daemon is running, config.LoadAllRepoInstances no longer returns that repo,
+// so the polling refresh must preserve its in-memory instances (parallel to
+// the corrupted-JSON path) and log a warning naming the missing repo. Dropping
+// them would silently abandon a running AutoYes session.
+func TestRefreshDaemonInstances_PreservesInstancesForMissingRepoDirectory(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	var warnBuf bytes.Buffer
+	prevOut := log.WarningLog.Writer()
+	log.WarningLog.SetOutput(io.MultiWriter(prevOut, &warnBuf))
+	t.Cleanup(func() { log.WarningLog.SetOutput(prevOut) })
+
+	prevFromInstance := fromInstanceDataForRefresh
+	fromInstanceDataForRefresh = func(d session.InstanceData) (*session.Instance, error) {
+		return &session.Instance{}, nil
+	}
+	t.Cleanup(func() { fromInstanceDataForRefresh = prevFromInstance })
+
+	// A repo that stays on disk — proves we don't over-preserve and that the
+	// normal load path still works alongside a vanished repo.
+	presentRepoID := "present-repo"
+	presentJSON, err := json.Marshal([]session.InstanceData{{Title: "present-session"}})
+	if err != nil {
+		t.Fatalf("marshal present: %v", err)
+	}
+	if err := config.SaveRepoInstances(presentRepoID, presentJSON); err != nil {
+		t.Fatalf("save present repo: %v", err)
+	}
+
+	// A repo whose directory we delete out from under the daemon.
+	missingRepoID := "missing-repo"
+	missingJSON, err := json.Marshal([]session.InstanceData{{Title: "running-session"}})
+	if err != nil {
+		t.Fatalf("marshal missing: %v", err)
+	}
+	if err := config.SaveRepoInstances(missingRepoID, missingJSON); err != nil {
+		t.Fatalf("save missing repo: %v", err)
+	}
+
+	// In-memory state as if both sessions had already been loaded.
+	presentKey := daemonInstanceKey(presentRepoID, "present-session")
+	missingKey := daemonInstanceKey(missingRepoID, "running-session")
+	presentInst := &session.Instance{}
+	missingInst := &session.Instance{}
+	existing := map[string]*session.Instance{
+		presentKey: presentInst,
+		missingKey: missingInst,
+	}
+
+	// Remove the missing repo's directory entirely (not just the file), as an
+	// external `rm -rf` of the repo's storage would.
+	missingPath, err := config.RepoInstancesPath(missingRepoID)
+	if err != nil {
+		t.Fatalf("resolve missing repo path: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Dir(missingPath)); err != nil {
+		t.Fatalf("remove missing repo dir: %v", err)
+	}
+
+	got, err := refreshDaemonInstances(existing)
+	if err != nil {
+		t.Fatalf("refreshDaemonInstances returned error: %v", err)
+	}
+
+	if got[missingKey] != missingInst {
+		t.Fatalf("running AutoYes session for missing repo %q was dropped; in-memory instance must be preserved", missingRepoID)
+	}
+	if got[presentKey] != presentInst {
+		t.Fatalf("session for present repo %q should still be loaded", presentRepoID)
+	}
+	if !strings.Contains(warnBuf.String(), missingRepoID) {
+		t.Fatalf("expected warning naming missing repo %q; got: %q", missingRepoID, warnBuf.String())
+	}
+}
+
+// TestRefreshDaemonInstances_StartupDoesNotInventMissingRepos guards the
+// startup path (existing == nil): there is no prior in-memory state to
+// preserve, so a missing repo must contribute nothing and not panic.
+func TestRefreshDaemonInstances_StartupDoesNotInventMissingRepos(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	prevOut := log.WarningLog.Writer()
+	log.WarningLog.SetOutput(io.Discard)
+	t.Cleanup(func() { log.WarningLog.SetOutput(prevOut) })
+
+	got, err := refreshDaemonInstances(nil)
+	if err != nil {
+		t.Fatalf("startup refresh errored: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty map at startup with no repos, got %d entries", len(got))
+	}
+}
+
+// TestFindInstanceDataByTitle_NamesCorruptedRepoOnNotFound covers the all-repo
+// scan path (#730): a corrupted repo must be logged and named in the returned
+// error instead of silently skipped, so a title that could be hidden in the
+// bad file doesn't surface as a bare "not found."
+func TestFindInstanceDataByTitle_NamesCorruptedRepoOnNotFound(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	var warnBuf bytes.Buffer
+	prevOut := log.WarningLog.Writer()
+	log.WarningLog.SetOutput(io.MultiWriter(prevOut, &warnBuf))
+	t.Cleanup(func() { log.WarningLog.SetOutput(prevOut) })
+
+	corruptedRepoID := "corrupted-repo"
+	if err := config.SaveRepoInstances(corruptedRepoID, json.RawMessage("{not valid json")); err != nil {
+		t.Fatalf("save corrupted repo: %v", err)
+	}
+
+	_, _, err := findInstanceDataByTitle("ghost-title", "")
+	if err == nil {
+		t.Fatalf("expected error when title missing and a repo is corrupted")
+	}
+	if !strings.Contains(err.Error(), corruptedRepoID) {
+		t.Fatalf("expected error to name corrupted repo %q; got: %v", corruptedRepoID, err)
+	}
+	if !strings.Contains(warnBuf.String(), corruptedRepoID) {
+		t.Fatalf("expected warning naming corrupted repo %q; got: %q", corruptedRepoID, warnBuf.String())
+	}
+}
+
 // TestStopDaemon_RefusesSelfPID verifies that StopDaemon refuses to kill the current test process
 // even if the PID file points at it.
 func TestStopDaemon_RefusesSelfPID(t *testing.T) {


### PR DESCRIPTION
## Summary

#730 and #736 are the same class of bug: the daemon/CLI encountered an
**unexpected on-disk session-storage state** (a corrupted `instances.json`, or
a repo directory that disappeared) and **silently substituted empty intent** —
dropping data with no signal. A user can't tell "I have no sessions" from "my
sessions are hidden behind a bad file," and a running AutoYes session can be
abandoned without a trace.

This PR applies one consistent **warn-and-preserve** pattern across every
repo-storage load:

- **empty / new** (`[]`, `null`, missing file) → proceed, return empty (unchanged)
- **corrupted / unreadable** → log a warning naming the repo **and** surface a
  structured error instead of a truncated result
- **missing-but-had-running-sessions** (daemon poll) → preserve the in-memory
  instances and log loudly rather than reaping them

## Root causes

**#730** — `sessionsListCmd`, `sessionsWhoamiCmd` (`api/sessions.go`),
`findInstanceByTitle` (`api/api.go`), and the daemon's `findInstanceDataByTitle`
(`daemon/control.go`) all swallowed `json.Unmarshal` failures with a bare
`continue`, producing partial/empty results with no log line. Introduced in
`94eff6b`, carried through the `9ebec09` refactor.

**#736** — `refreshDaemonInstances` (`daemon/daemon.go`) only iterated repos
returned by `config.LoadAllRepoInstances()`, which omits any repo whose on-disk
directory was deleted externally. Such a repo's in-memory AutoYes instances
were never re-hydrated into the refreshed map and were silently dropped on the
next poll. The corrupted-JSON path (added in `68b3c29`/#627) already preserved
+ warned, so missing directories were the inconsistent gap.

## Audit (per CLAUDE.md adjacent-call-sites)

All repo-storage loads that parse per-repo `instances.json` were swept:

| Site | File | Before | After |
|------|------|--------|-------|
| `sessionsListCmd` (all-repo) | `api/sessions.go` | silent `continue` → partial/empty | warn naming repo + structured error |
| `sessionsListCmd` (single-repo) | `api/sessions.go` | already errored on parse failure | unchanged |
| `sessionsWhoamiCmd` | `api/sessions.go` | silent `continue` → bare not-found | warn naming repo + names repos in not-found error |
| `findInstanceByTitle` | `api/api.go` | silent `continue` → bare not-found | warn naming repo + names repos in not-found error |
| `findInstanceDataByTitle` (all-repo) | `daemon/control.go` | silent `continue` → bare not-found | warn naming repo + names repos in not-found error |
| `refreshDaemonInstances` (corrupted JSON) | `daemon/daemon.go` | already warn + re-hydrate | unchanged |
| `refreshDaemonInstances` (missing repo dir) | `daemon/daemon.go` | **silently dropped** | preserve in-memory + warn (#736 fix) |
| `repoHasInstanceTitle` / `loadRepoInstanceData` (single-repo) | `api/api.go`, `daemon/control.go` | already return a wrapped parse error | unchanged |

## Tests

- `TestLoadAllInstancesAggregate_WarnsAndReportsCorruptedRepo` — corrupted repo is logged (named) and reported; valid repos still parse.
- `TestLoadAllInstancesAggregate_EmptyNotCorrupted` — backward-compat guard: empty/new stores produce empty result, no warning, no error.
- `TestFindInstanceByTitle_NamesCorruptedRepoOnNotFound` / `_PositiveLookupNotBlockedByCorruption` — corruption named on not-found, but a findable session in a healthy repo is never blocked.
- `TestFindInstanceDataByTitle_NamesCorruptedRepoOnNotFound` — same for the daemon scan path.
- `TestRefreshDaemonInstances_PreservesInstancesForMissingRepoDirectory` — repo dir deleted mid-flight with a running AutoYes instance → instance preserved, warning names the missing repo.
- `TestRefreshDaemonInstances_StartupDoesNotInventMissingRepos` — startup path (`existing == nil`) has nothing to preserve and doesn't panic.

## Notes

- No new panic paths — all handling is log + warn at the load boundaries.
- Backward compatible: empty / new `instances.json` still yields an empty result, not an error.
- Gates: `go build ./...`, `go vet ./...`, `golangci-lint run --fast`, `gofmt -l .`, and `deadcode -test ./...` all clean. New tests pass under `-race`. (`daemon/TestSigtermFallback_DeadPID` and a full-suite-only timeout in `TestConcurrentCLIClientsUseDaemonCoordinator` are pre-existing dev-box flakes from stray `af --daemon` processes — both pass clean in isolation and are unrelated to this change.)

Fixes #730
Fixes #736

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)