### PR TITLE
fix(session/hook): actionable error when restore needs list_cmd but it is empty (#753)

### DIFF
--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -19,7 +19,9 @@ Add remote hooks to your per-repo config at `~/.agent-factory/repos/<repoID>/con
 
 Configuring `remote_hooks` enables the remote backend for that repo, but using it is explicit opt-in: press `N` in the TUI to create a remote session. Pressing `n` still creates a local tmux+git worktree session. When `remote_hooks` is absent, `N` is unavailable and all sessions are local.
 
-`launch_cmd`, `attach_cmd`, and `delete_cmd` are **required** — an empty value is rejected when the remote backend is resolved, with an error naming the missing field (e.g. `remote_hooks.launch_cmd is required`) rather than a cryptic `exec: no command` at operation time. `list_cmd` is optional: when it is empty, Agent Factory simply reports no remote sessions to enumerate (import/sync are skipped).
+`launch_cmd`, `attach_cmd`, and `delete_cmd` are **required** — an empty value is rejected when the remote backend is resolved, with an error naming the missing field (e.g. `remote_hooks.launch_cmd is required`) rather than a cryptic `exec: no command` at operation time. `list_cmd` is **optional for import/sync only**: when it is empty, Agent Factory simply reports no remote sessions to enumerate (import/sync are skipped) and config validation does not reject it.
+
+> **Note:** `list_cmd` is **required for restore**. To carry remote sessions across restarts, Agent Factory re-runs `list_cmd` at startup to confirm each persisted session is still alive (#645). If `list_cmd` is empty, restore cannot verify liveness and the session is dropped with an actionable error naming the missing field — so configure `list_cmd` whenever you want remote sessions to survive restarts.
 
 ## Script Protocol
 

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -134,6 +134,17 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 		// exists. Without this check, deleted/expired remote sessions
 		// were restored and shown with a green Ready dot in the sidebar
 		// even though attaching was a silent no-op (#645).
+		//
+		// list_cmd is optional at config-validation time (import/sync treat
+		// an empty list_cmd as "no remote sessions to enumerate", #738), but
+		// restore has no other way to verify liveness. An empty list_cmd here
+		// would defer to exec.Command(""), which isAliveWithTimeout swallows
+		// into a false, surfacing the misleading "no longer exists" message
+		// below as if the session had been deleted remotely. Fail fast with an
+		// actionable message that names the missing field instead (#753).
+		if strings.TrimSpace(b.Hooks.ListCmd) == "" {
+			return fmt.Errorf("cannot restore remote session %q: list_cmd is required for restore (currently empty in config; add a list_cmd to remote_hooks so the agent can verify the remote session is still alive)", i.Title)
+		}
 		if !b.isAliveWithTimeout(i, restoreAliveTimeout) {
 			return fmt.Errorf("remote session %q no longer exists in list_cmd output", i.Title)
 		}

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -319,6 +319,41 @@ func TestHookBackendStartRestoreListCmdFails(t *testing.T) {
 	assert.False(t, i.Started())
 }
 
+// TestHookBackendStartRestoreEmptyListCmd is the regression test for #753:
+// list_cmd is optional at config-validation time (import/sync treat empty as
+// "nothing to enumerate", #738), but restore has no other way to verify
+// liveness. With an empty list_cmd, restore must fail fast with an actionable
+// error that names the missing field — not the misleading "no longer exists in
+// list_cmd output" message, which falsely implies the remote session was
+// deleted (it was the local config that was incomplete).
+func TestHookBackendStartRestoreEmptyListCmd(t *testing.T) {
+	dir := t.TempDir()
+	attachCmd := writeScript(t, dir, "attach.sh", `echo "attached"; sleep 0.1`)
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{
+			// ListCmd intentionally empty.
+			AttachCmd: attachCmd,
+		},
+	}
+	i := &Instance{
+		Title:   "my-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	err := b.Start(i, false)
+	require.Error(t, err)
+	assert.False(t, i.Started())
+	assert.Contains(t, err.Error(), "list_cmd is required for restore",
+		"error must explain that restore needs list_cmd")
+	assert.Contains(t, err.Error(), "list_cmd",
+		"error must name the missing field")
+	// Must NOT use the misleading "no longer exists" wording reserved for the
+	// case where list_cmd is present but does not list the session.
+	assert.NotContains(t, err.Error(), "no longer exists",
+		"empty list_cmd must not be reported as a remotely-deleted session")
+}
+
 // TestHookBackendStartRestoreListCmdHangs covers the timeout path: when
 // list_cmd takes longer than restoreAliveTimeout, restore must return an
 // error rather than blocking the TUI startup indefinitely for every


### PR DESCRIPTION
## Root cause

Regression surfaced by #750 (`af997ac`). That change added `RemoteHooks.Validate()` to give actionable, fail-fast errors for empty required hook commands (e.g. `remote_hooks.launch_cmd is required`), replacing Go's cryptic `exec: no command`. It **intentionally** left `list_cmd` out of validation, because import/sync treat an empty `list_cmd` as "no remote sessions to enumerate" (#738).

But the restore path (`HookBackend.Start(i, firstTimeSetup=false)`, added in #645) *needs* `list_cmd` to verify a persisted remote session is still alive. With an empty `list_cmd`, restore deferred to `exec.Command("")`, which `isAliveWithTimeout` swallowed into `false`, producing:

> `remote session "my-session" no longer exists in list_cmd output`

That message falsely implies the remote session was deleted, when the real problem is an incomplete local config. Net effect: remote sessions silently disappear on restart with no actionable guidance.

## Fix (error quality)

On the **restore path only**, before calling `isAliveWithTimeout`, detect an empty `b.Hooks.ListCmd` and return:

> `cannot restore remote session "my-session": list_cmd is required for restore (currently empty in config; add a list_cmd to remote_hooks so the agent can verify the remote session is still alive)`

The existing "no longer exists in list_cmd output" message is preserved for the legitimate case where `list_cmd` is present but does not list the session.

Per the constraints: **no** config-load-time validation of `list_cmd` — that would break #738's intentional "optional for import/sync" behavior. The check lives only where it is actually load-bearing.

## Docs

`docs/remote-hooks.md` now scopes "optional" explicitly: `list_cmd` is **optional for import/sync only** and **required for restore**, with a note explaining that restore re-runs `list_cmd` at startup to verify liveness (#645).

## Audit (CLAUDE.md adjacent call-sites)

Grepped every `isAliveWithTimeout` / `runListCmd` / `ListCmd` use:
- `ListRemoteHookInstanceData` (import) — already guards `ListCmd == "" → return nil, nil`. ✅
- `daemon/control.go:839`, `app/sync.go:356` (sync) — already guard `ListCmd == "" → skip`. ✅
- `Start` restore path — was the only unguarded require-list_cmd site; fixed here.
- `IsAlive` (steady-state ticks) — only reachable for an already-restored session, so the restore guard covers it; intentionally not touched to keep the diff focused.

## Test

`TestHookBackendStartRestoreEmptyListCmd`: `Start(firstTimeSetup=false)` with empty `ListCmd` asserts the error contains `list_cmd is required for restore`, names the field, and does **not** use the misleading "no longer exists" wording.

## Verification

`gofmt -l .` clean · `go build ./...` · `go test ./... -race` (only pre-existing dev-box flake `daemon/TestSigtermFallback_DeadPID` from real running `af --daemon` processes) · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean.

Fixes #753

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)