### PR TITLE
fix(session/daemon): handle codex trust prompt before declaring ready (#729)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1134,11 +1134,17 @@ func isReadyContent(content, agent string) bool {
 	switch agent {
 	case tmux.ProgramCodex:
 		// codex renders "›" (U+203A — distinct from claude's "❯" U+276F) as
-		// its input-prompt glyph after the banner, and "Do you trust this
-		// folder" for its workspace-trust dialog. See the pane capture in
+		// its input-prompt glyph after the banner. See the pane capture in
 		// sachiniyer/agent-factory#714.
-		return strings.Contains(content, "›") ||
-			strings.Contains(content, "Do you trust this folder")
+		//
+		// The workspace-trust dialog ("Do you trust this folder") is
+		// deliberately NOT a ready signal (#729): unlike claude's trust
+		// prompt, there is no codex-specific dismissal in
+		// CheckAndHandleTrustPrompt, so treating it as ready let the next
+		// user prompt get typed into the dialog. Waiting for the real "›"
+		// prompt is the safe behavior — the prompt is only sent once codex
+		// is genuinely ready for input. Regression from #714/#715.
+		return strings.Contains(content, "›")
 	case tmux.ProgramAider:
 		// aider prints an "Aider v…" banner, then a line-start "> " input
 		// prompt. The shared doc-trust dialog is handled by isDocTrustPrompt.

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -600,7 +600,12 @@ func TestIsReadyContent(t *testing.T) {
 		// codex — the #714 regression case.
 		{"codex YOLO banner with prompt (#714)", "codex", codexYOLOBanner, true},
 		{"codex bare prompt glyph", "codex", "some output\n› ", true},
-		{"codex trust folder prompt", "codex", "Do you trust this folder?\n> Yes", true},
+		// #729: the workspace-trust dialog must NOT be treated as ready —
+		// there is no codex dismissal for it, so waitForReady must keep
+		// waiting for the real "›" prompt rather than letting the user's
+		// prompt be typed into the dialog. Regression from #714/#715.
+		{"codex trust folder prompt is not ready (#729)", "codex", "Do you trust this folder?\n> Yes", false},
+		{"codex trust dialog with later prompt is ready (#729)", "codex", "Do you trust this folder?\n› ", true},
 		{"codex not ready on claude glyph", "codex", "rendering\n❯ ", false},
 		{"codex not ready on box border alone", "codex", "╭──╮\n│ x │\n╰──╯", false},
 

--- a/integration/codex_ready_test.go
+++ b/integration/codex_ready_test.go
@@ -93,3 +93,100 @@ func TestCLICreateCodexSessionBecomesReady(t *testing.T) {
 		t.Fatalf("unexpected create response: %+v", data)
 	}
 }
+
+// TestCLICreateCodexWaitsPastTrustPrompt is the regression test for
+// sachiniyer/agent-factory#729. The #714/#715 fix added "Do you trust this
+// folder" to codex's ready signals so waitForReady would exit on the trust
+// dialog — but codex has no trust-dismissal in CheckAndHandleTrustPrompt, so
+// the next user prompt was typed into the dialog instead of the agent.
+//
+// The fix removes the trust string from codex's ready set: a codex pane
+// showing only the trust dialog is NOT ready, and waitForReady must keep
+// waiting until the real "›" prompt appears. The fake codex wrapper prints
+// the trust dialog, holds it for a few seconds, then prints the "›" prompt —
+// mirroring codex resolving the dialog before becoming ready.
+//
+// Discriminator: with the bug, waitForReady exits on the trust dialog and the
+// create returns almost immediately; with the fix it must wait for the "›"
+// prompt, so the create cannot complete before the wrapper emits it.
+func TestCLICreateCodexWaitsPastTrustPrompt(t *testing.T) {
+	requireTool(t, "git")
+	requireTool(t, "tmux")
+
+	home := t.TempDir()
+	repo := setupGitRepo(t)
+
+	// The wrapper prints codex's workspace-trust dialog (no "›"), holds it for
+	// trustHold, then prints the "›" prompt and reads stdin. The trust dialog
+	// alone must not satisfy waitForReady; only the trailing "›" does. The
+	// hold is set well above session-startup overhead (daemon launch + git
+	// worktree, observed ~6s) so the timing assertion below is unambiguous.
+	const trustHold = 12 * time.Second
+	wrapper := filepath.Join(home, "fake-codex-trust.sh")
+	writeFile(t, wrapper,
+		"#!/bin/sh\n"+
+			"printf 'OpenAI Codex (vX)\\nDo you trust this folder?\\n> 1. Yes\\n'\n"+
+			"sleep 12\n"+
+			"printf '\\342\\200\\272 '\n"+ // U+203A "›" in octal-escaped UTF-8
+			"exec cat\n",
+		0755)
+
+	cfg := testConfig()
+	cfg.DefaultProgram = tmux.ProgramCodex
+	cfg.ProgramOverrides = map[string]string{tmux.ProgramCodex: wrapper}
+	raw, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	writeFile(t, filepath.Join(home, config.ConfigFileName), string(raw), 0644)
+
+	bin := buildBinary(t)
+	runAF := func(args ...string) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, bin, args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(), "AGENT_FACTORY_HOME="+home, "TERM=xterm")
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if ctx.Err() == context.DeadlineExceeded {
+			return stdout.String(), fmt.Errorf("timed out; stderr=%s", stderr.String())
+		}
+		if err != nil {
+			return stdout.String(), fmt.Errorf("%w; stderr=%s", err, stderr.String())
+		}
+		return stdout.String(), nil
+	}
+
+	t.Cleanup(func() {
+		_, _ = runAF("sessions", "kill", "codex-trust")
+		killDaemonFromHome(home)
+	})
+
+	start := time.Now()
+	out, err := runAF("sessions", "--repo", repo, "create", "--name", "codex-trust", "--program", tmux.ProgramCodex)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("create codex session failed: %v\n%s", err, out)
+	}
+
+	// With the #729 regression, the trust dialog counted as ready and the
+	// create returned at startup time (~6s) — before the wrapper emitted the
+	// "›" prompt at trustHold. The fix makes waitForReady block past the trust
+	// dialog, so the create cannot finish before the prompt appears. The
+	// threshold sits comfortably above startup overhead and below trustHold.
+	const minElapsed = trustHold - 3*time.Second
+	if elapsed < minElapsed {
+		t.Fatalf("create returned in %s (< %s), before the codex prompt appeared at ~%s: the trust dialog was treated as ready (#729 regression)", elapsed, minElapsed, trustHold)
+	}
+
+	var data instanceData
+	if err := json.Unmarshal([]byte(out), &data); err != nil {
+		t.Fatalf("parse create response: %v\n%s", err, out)
+	}
+	if data.Title != "codex-trust" {
+		t.Fatalf("unexpected create response: %+v", data)
+	}
+}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -331,9 +331,11 @@ func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {
 	}
 	// Normalize so restored sessions with legacy free-form Program values
 	// (e.g. "/home/foo/bin/claude") still get trust-prompt auto-handling —
-	// same persisted-state class of regression as #677.
+	// same persisted-state class of regression as #677. Codex was added in
+	// #729: it was previously excluded here, so a codex trust/confirmation
+	// dialog was never dismissed even though isReadyContent could surface it.
 	switch DetectAgentFromProgram(i.Program) {
-	case tmux.ProgramClaude, tmux.ProgramAider, tmux.ProgramGemini:
+	case tmux.ProgramClaude, tmux.ProgramCodex, tmux.ProgramAider, tmux.ProgramGemini:
 		return ts.CheckAndHandleTrustPrompt()
 	}
 	return false

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -655,6 +655,57 @@ func TestHookBackendCheckAndHandleTrustPrompt(t *testing.T) {
 	assert.False(t, b.CheckAndHandleTrustPrompt(i))
 }
 
+// TestLocalBackendCheckAndHandleTrustPromptDispatch verifies which agents are
+// routed through the tmux trust handler. Codex was excluded until #729, so a
+// codex trust/confirmation dialog was never dismissed even though
+// isReadyContent could surface it — letting the next user prompt get typed
+// into the dialog. Dispatch is observed by whether the handler reaches the
+// pane capture (tmux capture-pane); agents not in the set short-circuit to
+// false without capturing. Mirrors the NewTmuxSessionWithDeps + MockCmdExec
+// pattern used by the Kill best-effort tests above.
+func TestLocalBackendCheckAndHandleTrustPromptDispatch(t *testing.T) {
+	cases := []struct {
+		name         string
+		program      string
+		wantDispatch bool
+	}{
+		{"claude dispatches", tmux.ProgramClaude, true},
+		{"codex dispatches (#729)", tmux.ProgramCodex, true},
+		{"aider dispatches", tmux.ProgramAider, true},
+		{"gemini dispatches", tmux.ProgramGemini, true},
+		{"legacy codex path dispatches (#729)", "/usr/local/bin/codex", true},
+		{"unknown program does not dispatch", "some-other-tool", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured bool
+			cmdExec := cmd_test.MockCmdExec{
+				OutputFunc: func(*exec.Cmd) ([]byte, error) {
+					captured = true
+					// An idle pane with no trust prompt: the handler returns
+					// false regardless, but the capture call itself is the
+					// observable proof that the agent was dispatched.
+					return []byte("idle pane, no trust prompt"), nil
+				},
+				RunFunc: func(*exec.Cmd) error { return nil },
+			}
+			ts := tmux.NewTmuxSessionWithDeps("trust-dispatch", tc.program, nil, cmdExec)
+			inst := &Instance{
+				Title:       "trust-dispatch",
+				Program:     tc.program,
+				backend:     &LocalBackend{},
+				started:     true,
+				tmuxSession: ts,
+			}
+
+			inst.CheckAndHandleTrustPrompt()
+
+			assert.Equal(t, tc.wantDispatch, captured,
+				"capture-pane should run iff the agent is in the trust-handling set")
+		})
+	}
+}
+
 func TestHookBackendTapEnterIsNoop(t *testing.T) {
 	b := &HookBackend{Hooks: config.RemoteHooks{}}
 	i := &Instance{backend: b}

--- a/task/runner.go
+++ b/task/runner.go
@@ -78,10 +78,14 @@ func isReadyContent(content, agent string) bool {
 	switch agent {
 	case tmux.ProgramCodex:
 		// codex renders "›" (U+203A — distinct from claude's "❯" U+276F) as
-		// its input-prompt glyph after the banner, and "Do you trust this
-		// folder" for its workspace-trust dialog (#714).
-		return strings.Contains(content, "›") ||
-			strings.Contains(content, "Do you trust this folder")
+		// its input-prompt glyph after the banner (#714).
+		//
+		// The workspace-trust dialog ("Do you trust this folder") is
+		// deliberately NOT a ready signal (#729): there is no codex-specific
+		// dismissal in CheckAndHandleTrustPrompt, so treating it as ready let
+		// the next user prompt get typed into the dialog. Wait for the real
+		// "›" prompt instead. Kept in sync with daemon.isReadyContent.
+		return strings.Contains(content, "›")
 	case tmux.ProgramAider:
 		// aider prints an "Aider v…" banner, then a line-start "> " prompt.
 		return strings.Contains(content, "\n> ") ||

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -57,7 +57,11 @@ func TestIsReadyContent(t *testing.T) {
 		// codex — regression case from #714.
 		{"codex YOLO banner with prompt (#714)", "codex", codexYOLOBanner, true},
 		{"codex bare prompt glyph", "codex", "some output\n› ", true},
-		{"codex trust folder prompt", "codex", "Do you trust this folder?\n> Yes", true},
+		// #729: the workspace-trust dialog must NOT be treated as ready —
+		// no codex dismissal exists for it, so the prompt would be typed into
+		// the dialog. Wait for the real "›" prompt. Regression from #714/#715.
+		{"codex trust folder prompt is not ready (#729)", "codex", "Do you trust this folder?\n> Yes", false},
+		{"codex trust dialog with later prompt is ready (#729)", "codex", "Do you trust this folder?\n› ", true},
 		// Codex must NOT be considered ready on claude's "❯" alone, and the
 		// banner box border ("╰") is not a codex ready signal by itself.
 		{"codex not ready on claude glyph", "codex", "rendering\n❯ ", false},


### PR DESCRIPTION
## Root cause

Regression from my own #714/#715 (v1.0.96). That fix made `isReadyContent`
agent-aware and added `"Do you trust this folder"` to codex's ready signals so
`waitForReady` would exit on codex's workspace-trust dialog.

The problem: codex has **no dismissal path** in `CheckAndHandleTrustPrompt`
(it was excluded from the trust-handling dispatch in `backend_local.go`, and
the tmux handler has no codex-specific logic). So once the trust dialog was
treated as "ready", the readiness loop proceeded and the next user prompt was
typed **into the trust dialog** instead of the agent. Sachin uses codex daily,
so this blocked his flow.

## Fix — option (b): don't declare a trust dialog "ready"

Dismiss-before-ready. A trust dialog is explicitly **not** ready; the prompt is
only sent once codex shows its real `›` input glyph.

1. **`daemon/control.go` + `task/runner.go` `isReadyContent`** (the two copies
   kept in sync): codex's ready signal is now **only** `›`. The trust-dialog
   string is removed, so `waitForReady` keeps polling past the dialog and never
   lets a prompt land in it.
2. **`session/backend_local.go` `CheckAndHandleTrustPrompt`**: add `codex` to
   the trust-handling dispatch set (was `claude`/`aider`/`gemini` only, per
   #677) so a codex doc-trust dialog is dismissed like the other agents.

**This does not revert #715** — codex's `›` ready signal (and the #714
agent-aware routing) remains load-bearing and is still tested.

## Adjacent-call-site audit (per CLAUDE.md)

| Site | Role | Codex before | Codex after |
|------|------|--------------|-------------|
| `daemon/control.go` `isReadyContent` | ready detection | trust dialog = ready 🔴 | `›` only ✅ |
| `task/runner.go` `isReadyContent` | ready detection (synced copy) | trust dialog = ready 🔴 | `›` only ✅ |
| `session/backend_local.go` `CheckAndHandleTrustPrompt` | trust-handling dispatch | excluded 🔴 | included ✅ |
| `session/tmux/tmux.go` `CheckAndHandleTrustPrompt` | per-agent dismissal | falls to else (doc-url) branch | unchanged — codex handled like aider/gemini ✅ |
| `session/tmux/tmux.go` `HasUpdated` hasPrompt (L635) | autoyes confirm detection | codex absent | unchanged — out of scope for #729 (autoyes Y/N detection, no codex capture) |
| `session/tmux/resume.go`, `session/systemprompt.go` | resume flag / prompt injection | codex handled | unrelated ✅ |

Net invariant now holds: **codex IS in the trust-handling set, and the codex
trust dialog is NOT in the ready set.**

## Tests

- `daemon/control_test.go` + `task/runner_test.go`: the `codex trust folder
  prompt` case flips to **not ready**; added a case proving a pane showing the
  dialog *and* a trailing `›` is ready.
- `session/backend_test.go`: new `TestLocalBackendCheckAndHandleTrustPromptDispatch`
  — asserts codex (and the legacy `/usr/local/bin/codex` path) routes through
  the tmux trust handler, while an unknown program does not. Mirrors the
  existing `NewTmuxSessionWithDeps` + `MockCmdExec` pattern.
- `integration/codex_ready_test.go`: new `TestCLICreateCodexWaitsPastTrustPrompt`
  — a fake codex that holds the trust dialog then emits `›` must not be
  declared ready until the prompt appears. **Verified to fail on the pre-fix
  code** (create returned in ~4.6s, before the prompt) and pass after.

## Gates

`gofmt -l .`, `go build ./...`, `golangci-lint run --timeout=3m --fast`,
`deadcode -test ./...` all clean. `go test ./...` green except the known
dev-box flake `TestSigtermFallback_DeadPID` (real running `af --daemon`
processes, not code). `-race` clean on session/task/daemon.

Fixes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude