### PR TITLE
fix(task): preserve scheduler-owned LastRunAt/LastRunStatus across UpdateTask (#731)

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -283,6 +283,18 @@ func UpdateTask(t Task) error {
 		found := false
 		for i, existing := range tasks {
 			if existing.ID == t.ID {
+				// Preserve scheduler/system-managed fields from the freshly
+				// loaded record. UpdateTask is a user-edit path (name, prompt,
+				// cron, program, enabled); its caller may carry a stale copy of
+				// LastRunAt/LastRunStatus read before a concurrent scheduler run
+				// or manual trigger updated them (TOCTOU via GetTask outside the
+				// lock, or a stale TUI cache). Re-applying the caller's struct
+				// wholesale would clobber those fresher values. CreatedAt is
+				// immutable. UpdateTaskStatus remains the canonical path for the
+				// scheduler-owned status fields. See #731.
+				t.LastRunAt = existing.LastRunAt
+				t.LastRunStatus = existing.LastRunStatus
+				t.CreatedAt = existing.CreatedAt
 				tasks[i] = t
 				found = true
 				break

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -166,6 +166,43 @@ func TestUpdateTaskNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+// TestUpdateTaskPreservesSchedulerOwnedFields is the regression test for #731.
+// UpdateTask is a user-edit path; its caller may hold a stale copy of the
+// scheduler-owned status fields (read before a concurrent scheduler run or
+// manual trigger bumped them via UpdateTaskStatus). UpdateTask must NOT
+// clobber the fresher on-disk LastRunAt/LastRunStatus (nor the immutable
+// CreatedAt) when applying a user edit.
+func TestUpdateTaskPreservesSchedulerOwnedFields(t *testing.T) {
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	created := time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC)
+	tasks := []Task{
+		{ID: "u1", Name: "Old Name", Prompt: "old prompt", CronExpr: "0 * * * *", Enabled: true, CreatedAt: created, LastRunAt: &t1, LastRunStatus: "started"},
+	}
+	setupTestTasks(t, tasks)
+
+	// Scheduler bumps the status to a fresher value via the canonical path.
+	t2 := time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, UpdateTaskStatus("u1", &t2, "completed"))
+
+	// User edit carries a STALE copy: LastRunAt=t1, LastRunStatus="started",
+	// plus an attempt to mutate CreatedAt. None of these should win.
+	stale := Task{ID: "u1", Name: "New Name", Prompt: "new prompt", CronExpr: "0 0 * * *", Enabled: false, CreatedAt: time.Time{}, LastRunAt: &t1, LastRunStatus: "started"}
+	require.NoError(t, UpdateTask(stale))
+
+	s, err := GetTask("u1")
+	require.NoError(t, err)
+	// User-editable fields applied.
+	assert.Equal(t, "New Name", s.Name)
+	assert.Equal(t, "new prompt", s.Prompt)
+	assert.Equal(t, "0 0 * * *", s.CronExpr)
+	assert.False(t, s.Enabled)
+	// Scheduler-owned fields preserved at the fresher disk values.
+	require.NotNil(t, s.LastRunAt)
+	assert.True(t, s.LastRunAt.Equal(t2), "LastRunAt must retain the fresher scheduler value t2, not regress to stale t1")
+	assert.Equal(t, "completed", s.LastRunStatus, "LastRunStatus must retain the fresher scheduler value, not regress to stale")
+	assert.True(t, s.CreatedAt.Equal(created), "CreatedAt is immutable and must be preserved from disk")
+}
+
 func TestGenerateID(t *testing.T) {
 	id1 := GenerateID()
 	id2 := GenerateID()


### PR DESCRIPTION
## Root cause

`task.UpdateTask` is the user-edit path (name / prompt / cron / program /
enabled), but inside the file lock it replaced the freshly-loaded on-disk
record with the caller's struct wholesale (`tasks[i] = t`).

Both callers read the task *before* the locked write, so the struct they pass
can be stale:
- **CLI** (`api/tasks.go`): reads via `GetTask()` **outside** the file lock,
  modifies in memory, then writes under the lock — a classic TOCTOU window.
- **TUI** (`app/app.go`): writes back a `TaskPane` cache that isn't refreshed
  after a status update lands on disk.

If a scheduler run or manual trigger bumped `LastRunAt`/`LastRunStatus` (via
the dedicated `UpdateTaskStatus`, #664) in that window, `UpdateTask`
overwrote the fresher status with the stale copy. Users then saw a regressed
"last run" time/status until the next run — potentially hours for infrequent
tasks.

## Fix

Inside the file-lock critical section, after locating the existing record,
preserve the scheduler/system-managed fields from the freshly loaded task
before applying the caller's edits:

```go
t.LastRunAt = existing.LastRunAt
t.LastRunStatus = existing.LastRunStatus
t.CreatedAt = existing.CreatedAt   // immutable
tasks[i] = t
```

This is a read-modify-write entirely inside the lock and fixes both the CLI
and TUI paths at once, since both write through `UpdateTask`.
`UpdateTaskStatus` remains the **canonical** path for the scheduler-owned
status fields.

## Audit (adjacent call-sites)

Grepped all `UpdateTask` / `UpdateTaskStatus` callers:
- `UpdateTask` callers — `api/tasks.go:343` (CLI edit) and `app/app.go:528`
  (TUI edit). Both are user-edit paths; neither intends to write status fields.
- Status writes already go through `UpdateTaskStatus` — `task/runner.go:273`
  and `app/app.go:675`. Unaffected.

No caller intentionally overwrites the scheduler-owned fields, so preserving
them is safe.

## Test

`TestUpdateTaskPreservesSchedulerOwnedFields` reproduces the concurrent flow:
write a task with `LastRunAt=t1`/`"started"`, bump it via `UpdateTaskStatus`
to `t2`/`"completed"`, then call `UpdateTask` with a stale `t1`-shaped struct.
Asserts the persisted task retains `t2`/`"completed"` (and the original
`CreatedAt`) while the user-editable fields are applied.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `go test -race ./task/` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- Full `go test ./...`: only pre-existing environmental flakes failed
  (`daemon/TestSigtermFallback_DeadPID` from real `af --daemon` processes on
  the box, and a TUI e2e test under full-suite contention — both pass in
  isolation and are unrelated to this change).

Fixes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)
