### PR TITLE
fix(cli): distinguish missing git from non-repo cwd in startup error (#737)

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,8 +53,8 @@ var (
 				return fmt.Errorf("failed to get current directory: %w", err)
 			}
 
-			if !git.IsGitRepo(currentDir) {
-				return fmt.Errorf("error: agent-factory must be run from within a git repository")
+			if err := git.EnsureRepo(currentDir); err != nil {
+				return err
 			}
 
 			repo, err := config.CurrentRepo()

--- a/session/git/util.go
+++ b/session/git/util.go
@@ -74,10 +74,35 @@ func randomHex(n int) string {
 	return fmt.Sprintf("%x", b)
 }
 
-// IsGitRepo checks if the given path is within a git repository
+// IsGitInstalled reports whether the git binary is available on PATH.
+func IsGitInstalled() bool {
+	_, err := exec.LookPath("git")
+	return err == nil
+}
+
+// IsGitRepo checks if the given path is within a git repository.
+//
+// Note: this returns false both when git is not installed and when the path is
+// not inside a repository. Callers that need to tell those cases apart (e.g.
+// to surface an actionable startup error) should use EnsureRepo instead.
 func IsGitRepo(path string) bool {
 	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
 	return cmd.Run() == nil
+}
+
+// EnsureRepo verifies that git is installed and that path is within a git
+// repository, returning an actionable error that distinguishes the two failure
+// modes. IsGitRepo collapses both into a bare false, which previously produced
+// a misleading "must be run from within a git repository" message for users
+// who simply did not have git installed (issue #737).
+func EnsureRepo(path string) error {
+	if !IsGitInstalled() {
+		return fmt.Errorf("git is not installed or could not be found in PATH; install git and ensure it is available in your PATH")
+	}
+	if !IsGitRepo(path) {
+		return fmt.Errorf("agent-factory must be run from within a git repository")
+	}
+	return nil
 }
 
 func findGitRepoRoot(path string) (string, error) {

--- a/session/git/util_test.go
+++ b/session/git/util_test.go
@@ -155,3 +155,51 @@ func TestSanitizeBranchName_FallbackIsUnique(t *testing.T) {
 		t.Errorf("expected unique fallback names, got %q twice", a)
 	}
 }
+
+// TestEnsureRepo_DistinguishesMissingGit verifies the #737 fix: when git is not
+// on PATH, EnsureRepo reports a "git is not installed" error rather than the
+// misleading "must be run from within a git repository" message.
+func TestEnsureRepo_DistinguishesMissingGit(t *testing.T) {
+	// Point PATH at an empty directory so exec.LookPath("git") fails.
+	emptyDir := t.TempDir()
+	t.Setenv("PATH", emptyDir)
+
+	if IsGitInstalled() {
+		t.Fatal("expected IsGitInstalled() to be false with git absent from PATH")
+	}
+
+	err := EnsureRepo(emptyDir)
+	if err == nil {
+		t.Fatal("expected EnsureRepo to return an error when git is not installed")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "git is not installed") {
+		t.Errorf("expected missing-git error, got %q", msg)
+	}
+	if strings.Contains(msg, "must be run from within a git repository") {
+		t.Errorf("missing-git case must not return the non-repo message, got %q", msg)
+	}
+}
+
+// TestEnsureRepo_NonRepoWithGitInstalled verifies that when git is installed but
+// the path is not inside a repository, EnsureRepo returns the repo-context
+// message rather than the missing-git message.
+func TestEnsureRepo_NonRepoWithGitInstalled(t *testing.T) {
+	if !IsGitInstalled() {
+		t.Skip("git binary not available in test environment")
+	}
+	// A bare temp dir under the OS temp root is not inside a git repository.
+	nonRepo := t.TempDir()
+	// Guard against the rare case where the temp root itself is tracked.
+	if IsGitRepo(nonRepo) {
+		t.Skip("temp dir unexpectedly inside a git repository")
+	}
+
+	err := EnsureRepo(nonRepo)
+	if err == nil {
+		t.Fatal("expected EnsureRepo to return an error for a non-repo path")
+	}
+	if got := err.Error(); !strings.Contains(got, "must be run from within a git repository") {
+		t.Errorf("expected non-repo error, got %q", got)
+	}
+}

--- a/task/runner.go
+++ b/task/runner.go
@@ -245,7 +245,11 @@ func RunTask(taskID string) error {
 	}
 	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
 
-	// Validate project path.
+	// Validate project path. Distinguish a missing git binary from a path that
+	// simply is not a repo so the daemon surfaces an actionable error (#737).
+	if !git.IsGitInstalled() {
+		return fmt.Errorf("git is not installed or could not be found in PATH; install git and ensure it is available in your PATH")
+	}
 	if !git.IsGitRepo(t.ProjectPath) {
 		return fmt.Errorf("project path %s is not a valid git repository", t.ProjectPath)
 	}


### PR DESCRIPTION
## Root cause

The startup guard in `main.go` called `git.IsGitRepo(currentDir)`, which runs `git rev-parse` and returns a bare `bool`. That collapses two distinct failure modes — **git not installed** and **cwd is not a repository** — into a single `false`. The guard then returned a hardcoded `error: agent-factory must be run from within a git repository`.

Result: a user *inside* a perfectly valid git repo who simply doesn't have the `git` binary on `PATH` got told to "run from within a git repository" — pointing them at the wrong problem. (Introduced in `19d20d1`, when `IsGitRepo` was switched from `go-git` to `exec.Command("git", ...)` for startup speed but kept the boolean signature.)

## Fix

- Add `git.IsGitInstalled()` (`exec.LookPath("git")`) and `git.EnsureRepo(path)`, which checks the binary **first** and returns an actionable `git is not installed or could not be found in PATH; install git and ensure it is available in your PATH` before falling back to the non-repo message.
- Wire `EnsureRepo` into the `main.go` startup guard.
- Also drops a redundant `error:` prefix on the non-repo message — cobra already prefixes with `Error:`, so the old text rendered as `Error: error: ...`.

## Adjacent-call-site audit (per CLAUDE.md)

Grepped every `git.IsGitRepo` caller and classified each by whether a missing-git environment can actually reach it:

| Site | First git call on the path? | Action |
|------|------------------------------|--------|
| `main.go:56` (startup guard) | yes | **fixed** — the #737 path |
| `task/runner.go:249` (project-path validation) | yes | **fixed** — same missing-git pre-check |
| `api/sessions.go:161`, `:300` | no | **excluded** — both run after `resolveRepo()`, which invokes `git rev-parse` via `config.CurrentRepo`/`RepoFromPath`; a missing-git env fails there first with a wrapped exec error and never reaches these checks |

## Tests

`session/git/util_test.go`:
- `TestEnsureRepo_DistinguishesMissingGit` — points `PATH` at an empty dir so `git` is absent, asserts the missing-git message and that the non-repo message is *not* returned.
- `TestEnsureRepo_NonRepoWithGitInstalled` — git present, path outside any repo, asserts the non-repo message.

## Gates

`gofmt -l .` clean · `go build ./...` ok · `go vet ./...` clean · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./...` green (sole failure was the known environment-sensitive daemon-lifecycle flake, which passes in isolation) · `go test -race` clean on `session/git` and `task`.

Fixes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude <noreply@anthropic.com>