### PR TITLE
fix(config): surface I/O and parse errors from LoadConfig instead of silently using defaults (#734)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -237,18 +237,31 @@ func GetClaudeCommand() (string, error) {
 }
 
 // LoadConfig reads the user's config.json, validates it, and returns the
-// resulting Config. A missing file is materialized from DefaultConfig (which
-// is always valid). A file present on disk that fails enum validation
-// returns an actionable migration error — there is no implicit migration
-// from legacy "path with flags" values; the user must rewrite their config.
+// resulting Config.
+//
+// Error handling distinguishes "no config yet" from "config present but
+// unusable" so a user whose settings are being ignored gets told why instead
+// of silently inheriting defaults (#734):
+//   - File does not exist → DefaultConfig() is materialized and saved, with no
+//     error. This is the first-run path and must keep working.
+//   - File exists but cannot be read (permission denied, disk error), is empty,
+//     or fails to parse → an error naming the file and the underlying cause is
+//     returned. Defaults are NOT substituted, since doing so would hide the
+//     user's broken config behind a working-looking app.
+//   - File parses but fails enum validation → an actionable migration error is
+//     returned (there is no implicit migration from legacy "path with flags"
+//     values; the user must rewrite their config).
+//
+// This mirrors the error-propagation contract already adopted by
+// LoadRepoConfig, where only os.IsNotExist yields defaults.
 func LoadConfig() (*Config, error) {
 	configDir, err := GetConfigDir()
 	if err != nil {
-		log.ErrorLog.Printf("failed to get config directory: %v", err)
-		return DefaultConfig(), nil
+		return nil, fmt.Errorf("failed to get config directory: %w", err)
 	}
 
 	configPath := filepath.Join(configDir, ConfigFileName)
+	prettyConfigPath := prettyHomePath(configPath)
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -260,17 +273,18 @@ func LoadConfig() (*Config, error) {
 			return defaultCfg, nil
 		}
 
-		log.WarningLog.Printf("failed to get config file: %v", err)
-		return DefaultConfig(), nil
+		return nil, fmt.Errorf("failed to read config file %s: %w", prettyConfigPath, err)
+	}
+
+	if len(data) == 0 {
+		return nil, fmt.Errorf("config file %s is empty; delete it to regenerate defaults, or add valid JSON", prettyConfigPath)
 	}
 
 	config := DefaultConfig()
 	if err := json.Unmarshal(data, config); err != nil {
-		log.ErrorLog.Printf("failed to parse config file: %v", err)
-		return DefaultConfig(), nil
+		return nil, fmt.Errorf("failed to parse config file %s: %w", prettyConfigPath, err)
 	}
 
-	prettyConfigPath := prettyHomePath(configPath)
 	if err := ValidateProgramEnum(
 		fmt.Sprintf("Config issue in %s: default_program", prettyConfigPath),
 		"default_program",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -586,7 +586,9 @@ func TestLoadConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("returns default config on invalid JSON", func(t *testing.T) {
+	t.Run("surfaces parse error on invalid JSON instead of using defaults", func(t *testing.T) {
+		// A present-but-corrupt config must NOT be silently replaced by
+		// defaults — that hides a user's broken settings (#734).
 		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 		configDir, err := GetConfigDir()
 		require.NoError(t, err)
@@ -596,9 +598,49 @@ func TestLoadConfig(t *testing.T) {
 		require.NoError(t, os.WriteFile(configPath, []byte(`{"invalid": json content}`), 0644))
 
 		cfg, err := LoadConfig()
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), "parse config file")
+		assert.Contains(t, err.Error(), ConfigFileName)
+	})
+
+	t.Run("surfaces error on empty config file", func(t *testing.T) {
+		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+		configDir, err := GetConfigDir()
 		require.NoError(t, err)
-		require.NotNil(t, cfg)
-		assert.Equal(t, tmux.ProgramClaude, cfg.DefaultProgram)
+		require.NoError(t, os.MkdirAll(configDir, 0755))
+
+		configPath := filepath.Join(configDir, ConfigFileName)
+		require.NoError(t, os.WriteFile(configPath, []byte(``), 0644))
+
+		cfg, err := LoadConfig()
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), "empty")
+		assert.Contains(t, err.Error(), ConfigFileName)
+	})
+
+	t.Run("surfaces error when config file is unreadable", func(t *testing.T) {
+		// chmod 000 is honored only for non-root users; skip when running
+		// as root (e.g. some CI containers), where the read still succeeds.
+		if os.Geteuid() == 0 {
+			t.Skip("cannot exercise permission-denied path as root")
+		}
+		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+		configDir, err := GetConfigDir()
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(configDir, 0755))
+
+		configPath := filepath.Join(configDir, ConfigFileName)
+		require.NoError(t, os.WriteFile(configPath, []byte(`{"default_program": "codex"}`), 0644))
+		require.NoError(t, os.Chmod(configPath, 0000))
+		t.Cleanup(func() { _ = os.Chmod(configPath, 0644) })
+
+		cfg, err := LoadConfig()
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), "read config file")
+		assert.Contains(t, err.Error(), ConfigFileName)
 	})
 }
 


### PR DESCRIPTION
## Problem

`LoadConfig()` advertises error reporting through its `(*Config, error)`
signature, but it swallowed every failure short of validation and returned
`DefaultConfig()` with a `nil` error:

- `GetConfigDir()` failure → logged, defaults returned
- `os.ReadFile` permission/disk error → logged, defaults returned
- `json.Unmarshal` parse error → logged, defaults returned

A user whose `config.json` was unreadable (`chmod 000`), partially written, or
contained a typo saw the app start normally on built-in defaults with **no
indication their settings were being ignored** — the "my config is ignored"
mystery reported in #734. The bug dates to b3b121e4, which dropped the error
return ("we can just fall back to the default config").

## Fix — three-case distinction

Matching the contract `LoadRepoConfig` already adopted (only `os.IsNotExist`
yields defaults):

| Config file state | Behavior |
|---|---|
| **Missing** | `DefaultConfig()` materialized + saved, **no error** (first-run path, unchanged) |
| **Unreadable / empty / unparseable** | **Error** naming the file + underlying cause; defaults **not** substituted |
| **Parses but fails enum validation** | Existing actionable migration error (unchanged) |

Error messages render the path home-relative via the existing `prettyHomePath`
helper, matching the quality bar already used by the validation errors (#661).

## Backward compatibility

The missing-file → `DefaultConfig()` first-run path is preserved exactly. All
10 call sites of `LoadConfig()` already handle the returned `error` (validation
errors flowed through this same path), so surfacing additional error cases is
safe.

## Audit (adjacent call-sites)

- **`LoadRepoConfig`** — already remediated in `15c176a`; `LoadConfig` now
  matches its bar.
- **`LoadState`** — returns bare `*State` (no error in its signature). It backs
  a non-user-authored state file (e.g. help-screens-seen counter); silently
  defaulting there is not a "my config is ignored" surprise, and changing its
  signature would touch every caller. Left out of this focused PR by design.

## Tests

- File missing → `DefaultConfig()`, no error *(existing, still green)*
- Invalid JSON → error naming the file *(rewrote the obsolete "returns defaults
  on invalid JSON" test to assert the new surface-the-error behavior)*
- Empty file → error naming the file
- Unreadable file (`chmod 000`) → error naming the file *(skips when euid 0)*

## Gates

`gofmt -l` clean · `go build ./...` · `golangci-lint run --fast` clean ·
`deadcode -test ./...` clean · `go test -race ./config/` green. The only
`-race` failures in the full run were pre-existing daemon/integration socket
flakes (stray `af --daemon` processes on the dev box; no integration test
touches config) — unrelated to this change.

Fixes #734

— Captain Claude
