### PR TITLE
fix(ui/overlay): handle SGR 39/49 (default fg/bg reset) in fadeSGR (#728)

### DIFF
--- a/ui/overlay/combined_fgbg_test.go
+++ b/ui/overlay/combined_fgbg_test.go
@@ -76,6 +76,19 @@ func TestFadeSGR(t *testing.T) {
 		{"bold-bg", "\x1b[1;41m", bg},
 		{"bold-only", "\x1b[1m", fg},
 		{"underline-fg", "\x1b[4;32m", fg},
+
+		// Default-color resets (#728): SGR 39/49 must be preserved verbatim, not
+		// faded. Before the fix, 49 fell into the default branch and wrongly
+		// produced a faded foreground.
+		{"bare-reset-bg", "\x1b[49m", "\x1b[49m"},
+		{"bare-reset-fg", "\x1b[39m", "\x1b[39m"},
+		{"reset-both", "\x1b[39;49m", "\x1b[39;49m"},
+		// Combined: a real color in one channel is faded; the other channel's
+		// reset is preserved, so colors that ARE set survive alongside the reset.
+		{"fg-color-plus-reset-bg", "\x1b[38;5;232;49m", "\x1b[38;5;240;49m"},
+		{"bg-color-plus-reset-fg", "\x1b[48;5;189;39m", "\x1b[39;48;5;236m"},
+		{"reset-bg-plus-fg-color", "\x1b[49;38;5;232m", "\x1b[38;5;240;49m"},
+		{"basic-bg-plus-reset-fg", "\x1b[41;39m", "\x1b[39;48;5;236m"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/ui/overlay/overlay.go
+++ b/ui/overlay/overlay.go
@@ -48,7 +48,10 @@ func extendedColorLen(tokens []string, i int) int {
 // fadeable attribute) and emits faded gray codes for whichever are present,
 // combining both into one sequence when the input was combined. Pure resets
 // (\x1b[0m, \x1b[m) and sequences with no fadeable parameters are preserved
-// unchanged so styled regions still close correctly.
+// unchanged so styled regions still close correctly. Default-color resets
+// (SGR 39 foreground, 49 background) are preserved verbatim rather than faded,
+// so a region that returns to the terminal default stays default instead of
+// gaining a spurious gray (#728).
 func fadeSGR(match string) string {
 	params := strings.TrimSuffix(strings.TrimPrefix(match, "\x1b["), "m")
 	if params == "" || params == "0" {
@@ -57,6 +60,7 @@ func fadeSGR(match string) string {
 
 	tokens := strings.Split(params, ";")
 	hasFg, hasBg, hasOtherFadeable := false, false, false
+	fgReset, bgReset := false, false
 	for i := 0; i < len(tokens); {
 		code, err := strconv.Atoi(tokens[i])
 		if err != nil || code == 0 {
@@ -70,6 +74,19 @@ func fadeSGR(match string) string {
 		case code == 48: // extended background (48;5;n or 48;2;r;g;b)
 			hasBg = true
 			i += extendedColorLen(tokens, i)
+		case code == 39: // reset foreground to default
+			// An explicit reset, NOT a color: the region wants the terminal
+			// default foreground, so it must be preserved verbatim rather than
+			// substituted with the faded gray (or, before #728, mis-folded to a
+			// faded foreground via the default branch).
+			fgReset = true
+			i++
+		case code == 49: // reset background to default
+			// An explicit reset, NOT a color. Preserve it so a default-bg region
+			// stays default; before #728 this fell into the default branch and
+			// wrongly emitted a faded *foreground* instead.
+			bgReset = true
+			i++
 		case (code >= 30 && code <= 37) || (code >= 90 && code <= 97):
 			hasFg = true // basic/bright foreground
 			i++
@@ -85,7 +102,7 @@ func fadeSGR(match string) string {
 		}
 	}
 
-	if !hasFg && !hasBg {
+	if !hasFg && !hasBg && !fgReset && !bgReset {
 		// Attribute-only sequence (e.g. bold \x1b[1m): fold to foreground gray,
 		// matching the long-standing behavior for such 16-color sequences.
 		if hasOtherFadeable {
@@ -94,11 +111,20 @@ func fadeSGR(match string) string {
 		return match
 	}
 	parts := make([]string, 0, 2)
-	if hasFg {
+	// A real color in a channel wins over a reset in the same sequence: it is
+	// what the region ends up showing, so emit the faded substitute. Otherwise
+	// a bare reset (39/49) is preserved so the channel returns to default.
+	switch {
+	case hasFg:
 		parts = append(parts, fadedFg)
+	case fgReset:
+		parts = append(parts, "39")
 	}
-	if hasBg {
+	switch {
+	case hasBg:
 		parts = append(parts, fadedBg)
+	case bgReset:
+		parts = append(parts, "49")
 	}
 	return "\x1b[" + strings.Join(parts, ";") + "m"
 }


### PR DESCRIPTION
## Summary

`fadeSGR` (the overlay background-fade pass) classifies each SGR parameter to decide whether to emit a faded foreground and/or background. SGR **49** (reset background to default) and **39** (reset foreground to default) had no explicit `case`, so they fell into the `default` branch and were treated as generic "other fadeable" attributes.

The visible symptom from #728:

```
fadeSGR("\x1b[49m") = "\x1b[38;5;240m"   // faded FOREGROUND — wrong
```

A bare background reset became a faded *foreground*, corrupting terminal-state progression under overlays. For input `\x1b[41mRed\x1b[49mDefault\x1b[44mBlue\x1b[0m`, the `\x1b[49m` no longer reset the background, so the faded gray bg from the prior `41` bled across the "Default" region.

## Root cause

Introduced in #711 / a959d7c, which replaced the three-pass regex approach with the single-pass `fadeSGR` parser (to fix combined FG+BG dropping the foreground, #701). That rewrite handled `0`, color codes, reverse video, and attribute-only sequences, but never gave 39/49 an explicit branch — they were silently swept into `default`.

## Fix

Add explicit cases for 39 and 49 that mark the channel as an **explicit reset**, distinct from a color. When rebuilding the sequence:

- a real color in a channel **wins** over a reset in the same sequence (it is what the region ends up showing, so it is faded);
- otherwise a bare reset is **preserved verbatim** (`39`/`49`) so the channel returns to the terminal default instead of gaining a spurious gray.

This is more faithful than mapping 49 → faded-bg: regions the original wanted at the terminal default stay default, mirroring how plain (no-SGR) text is already left untouched by the fade.

| input | before | after |
|---|---|---|
| `\x1b[49m` | `\x1b[38;5;240m` 🔴 | `\x1b[49m` |
| `\x1b[39m` | `\x1b[38;5;240m` 🔴 | `\x1b[39m` |
| `\x1b[39;49m` | `\x1b[38;5;240m` 🔴 | `\x1b[39;49m` |
| `\x1b[38;5;232;49m` | `\x1b[38;5;240m` (bg reset lost) | `\x1b[38;5;240;49m` |
| `\x1b[48;5;189;39m` | `\x1b[48;5;236m` (fg reset lost) | `\x1b[39;48;5;236m` |
| `\x1b[49;38;5;232m` | `\x1b[38;5;240m` (bg reset lost) | `\x1b[38;5;240;49m` |

## Adjacent-call-site audit

Per the repo's "fix all instances of the anti-pattern" rule, I grepped for every place that classifies SGR parameters by code:

- **`ui/overlay/overlay.go` `fadeSGR`** — the only site that inspects SGR codes individually. Fixed here.
- **`ui/err.go`, `ui/preview.go`, `session/tmux/tmux.go`, etc.** — these use `xansi.Strip` / a whole-sequence regex (`\x1b\[[0-9;]*m`) and discard or width-measure SGR uniformly. They never branch on the parameter value, so 39/49 need no special handling there.

No other site requires a change.

## Tests

Extended `TestFadeSGR` with: bare `49`, bare `39`, `39;49`, and combined color+reset cases in both orders, asserting that set colors are faded **and** the reset channel is preserved (`fg-color-plus-reset-bg`, `bg-color-plus-reset-fg`, `reset-bg-plus-fg-color`, `basic-bg-plus-reset-fg`). All pre-existing color/attribute cases unchanged.

## Validation

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test -race ./ui/...` — pass (overlay + ui green)

(The daemon/integration suites fail locally due to a real `af --daemon` already running on the dev box contending for the coordinator socket — a known environmental flake, unrelated to this UI-only change.)

Fixes #728

— Captain Claude
