### PR TITLE
fix(daemon): reject session titles whose sanitized branch collides with an existing branch (#741)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -656,11 +656,12 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 	if title == "" {
 		return fmt.Errorf("session title is required")
 	}
-	// Title comparisons are case-insensitive: sanitizeBranchName lowercases
-	// titles when deriving git branch names, so two case-variant titles
-	// (e.g. "MyApp" and "myapp") would map to the same branch and the
-	// second worktree create would fail with a cryptic git error. Reject
-	// the conflict here, before any worktree or tmux setup runs. (#605)
+	// Titles are sanitized into git branch names (git.SanitizeBranchName
+	// lowercases, turns spaces into dashes, strips unsafe chars, and collapses
+	// dashes), so distinct titles can map to the same branch: "MyApp"/"myapp"
+	// (#605) or "A B"/"a-b" (#741) both collide. The second worktree create
+	// would otherwise fail with a cryptic git error, so reject the conflict
+	// here, before any worktree or tmux setup runs.
 	if existing, kind := m.findTitleConflictLocked(repoID, title, diskData); existing != "" {
 		switch {
 		case existing == title:
@@ -669,7 +670,7 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 			}
 			return fmt.Errorf("session with title %q already exists", title)
 		default:
-			return fmt.Errorf("session titled %q conflicts with existing session %q (case-insensitive comparison; sanitize collides at git layer)", title, existing)
+			return fmt.Errorf("session titled %q conflicts with existing session %q: both sanitize to the same git branch %q", title, existing, m.branchForTitle(title))
 		}
 	}
 	if remote {
@@ -703,14 +704,17 @@ const (
 )
 
 // findTitleConflictLocked returns the existing title that conflicts with the
-// given candidate under case-insensitive comparison, along with the source of
-// the conflict. An empty result means the title is available. Comparisons are
-// case-insensitive so that titles which would collide at the git branch layer
-// (sanitizeBranchName lowercases) are rejected before worktree setup. (#605)
+// given candidate, along with the source of the conflict. An empty result means
+// the title is available. Two titles conflict when they derive the same git
+// branch name: branches are produced by git.SanitizeBranchName, which lowercases
+// and normalizes (spaces -> dashes, unsafe chars stripped, dashes collapsed),
+// so distinct titles like "MyApp"/"myapp" (#605) or "A B"/"a-b" (#741) can map
+// to one branch. Rejecting the collision here keeps the second worktree create
+// from failing with a cryptic git error.
 func (m *Manager) findTitleConflictLocked(repoID, title string, diskData []session.InstanceData) (string, titleConflictKind) {
 	for key := range m.reservedTitles {
 		rid, existing := splitDaemonInstanceKey(key)
-		if rid == repoID && strings.EqualFold(existing, title) {
+		if rid == repoID && m.titlesCollide(existing, title) {
 			return existing, titleConflictReserved
 		}
 	}
@@ -719,12 +723,12 @@ func (m *Manager) findTitleConflictLocked(repoID, title string, diskData []sessi
 		if rid != repoID || inst == nil {
 			continue
 		}
-		if strings.EqualFold(inst.Title, title) {
+		if m.titlesCollide(inst.Title, title) {
 			return inst.Title, titleConflictLive
 		}
 	}
 	for _, data := range diskData {
-		if !strings.EqualFold(data.Title, title) {
+		if !m.titlesCollide(data.Title, title) {
 			continue
 		}
 		// Loading entries are transient TUI state with an empty worktree
@@ -738,6 +742,26 @@ func (m *Manager) findTitleConflictLocked(repoID, title string, diskData []sessi
 		return data.Title, titleConflictDisk
 	}
 	return "", titleConflictNone
+}
+
+// titlesCollide reports whether two session titles cannot coexist in the same
+// repo because they would derive the same git branch. Exact (case-insensitive)
+// duplicates always collide; beyond that, the titles collide when they sanitize
+// to the same branch name (e.g. "A B" and "a-b" -> "af-a-b"). The EqualFold
+// guard also covers titles made only of unsafe characters, whose sanitized
+// branch is a random fallback that would otherwise never compare equal.
+func (m *Manager) titlesCollide(a, b string) bool {
+	if strings.EqualFold(a, b) {
+		return true
+	}
+	return m.branchForTitle(a) == m.branchForTitle(b)
+}
+
+// branchForTitle derives the git branch name for a session title using the same
+// prefix and sanitization the git worktree layer applies, so the daemon can
+// detect branch collisions before worktree setup runs.
+func (m *Manager) branchForTitle(title string) string {
+	return git.SanitizeBranchName(m.cfg.BranchPrefix + title)
 }
 
 func (m *Manager) KillSession(req KillSessionRequest) error {

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -248,7 +248,7 @@ func TestManagerCreateSessionIgnoresLoadingGhost(t *testing.T) {
 }
 
 // TestManagerCreateSessionRejectsCaseVariantTitle is a regression test for
-// sachiniyer/agent-factory#605. sanitizeBranchName lowercases titles when
+// sachiniyer/agent-factory#605. git.SanitizeBranchName lowercases titles when
 // deriving git branch names, so two case-variant titles ("MyApp" and "myapp")
 // would map to the same branch. The daemon used to validate titles
 // case-sensitively, accept both, and let the second worktree create fail with
@@ -285,8 +285,8 @@ func TestManagerCreateSessionRejectsCaseVariantTitle(t *testing.T) {
 	if !strings.Contains(msg, "myapp") || !strings.Contains(msg, "MyApp") {
 		t.Fatalf("expected error to name both titles, got: %v", err)
 	}
-	if !strings.Contains(strings.ToLower(msg), "case-insensitive") {
-		t.Fatalf("expected error to mention case-insensitive conflict, got: %v", err)
+	if !strings.Contains(strings.ToLower(msg), "branch") {
+		t.Fatalf("expected error to mention the shared git branch, got: %v", err)
 	}
 }
 
@@ -328,6 +328,68 @@ func TestManagerCreateSessionRejectsCaseVariantTitleFromDisk(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "MyApp") {
 		t.Fatalf("expected error to name the on-disk title, got: %v", err)
+	}
+}
+
+// TestManagerCreateSessionRejectsSanitizeCollision is a regression test for
+// sachiniyer/agent-factory#741, which completes #605. git.SanitizeBranchName
+// normalizes more than case: it turns spaces into dashes, strips unsafe chars,
+// and collapses dashes. So "A B" and "a-b" both derive the same branch (e.g.
+// "<prefix>/a-b") even though they differ by more than case. The #605 fix only compared titles
+// case-insensitively, so it accepted both and let the second worktree create
+// fail with a cryptic git error. The daemon now compares the derived branch and
+// rejects the collision up front.
+func TestManagerCreateSessionRejectsSanitizeCollision(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "A B",
+		RepoPath: repoPath,
+		Program:  "claude",
+		AutoYes:  true,
+	}); err != nil {
+		t.Fatalf("first CreateSession: %v", err)
+	}
+
+	_, err = manager.CreateSession(CreateSessionRequest{
+		Title:    "a-b",
+		RepoPath: repoPath,
+		Program:  "claude",
+		AutoYes:  true,
+	})
+	if err == nil {
+		t.Fatalf("expected sanitize-collision title to be rejected")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "a-b") || !strings.Contains(msg, "A B") {
+		t.Fatalf("expected error to name both titles, got: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(msg), "branch") {
+		t.Fatalf("expected error to mention the shared git branch, got: %v", err)
+	}
+
+	// The case-only path from #605 must still work: "Foo" then "foo" collides.
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "Foo",
+		RepoPath: repoPath,
+		Program:  "claude",
+		AutoYes:  true,
+	}); err != nil {
+		t.Fatalf("CreateSession Foo: %v", err)
+	}
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "foo",
+		RepoPath: repoPath,
+		Program:  "claude",
+		AutoYes:  true,
+	}); err == nil {
+		t.Fatalf("expected case-variant title \"foo\" to still be rejected (#605)")
 	}
 }
 

--- a/session/git/util.go
+++ b/session/git/util.go
@@ -15,10 +15,15 @@ var (
 	reMultiDash = regexp.MustCompile(`-+`)
 )
 
-// sanitizeBranchName transforms an arbitrary string into a Git branch name friendly string.
+// SanitizeBranchName transforms an arbitrary string into a Git branch name friendly string.
 // Note: Git branch names have several rules, so this function uses a simple approach
 // by allowing only a safe subset of characters.
-func sanitizeBranchName(s string) string {
+//
+// It is exported so the daemon can pre-validate that two distinct session titles
+// would not derive the same git branch (e.g. "A B" and "a-b" both -> "af-a-b"),
+// rejecting the collision before worktree setup fails with a cryptic git error
+// (sachiniyer/agent-factory#741, completing #605).
+func SanitizeBranchName(s string) string {
 	// Convert to lower-case
 	s = strings.ToLower(s)
 

--- a/session/git/util_test.go
+++ b/session/git/util_test.go
@@ -115,9 +115,9 @@ func TestSanitizeBranchName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sanitizeBranchName(tt.input)
+			got := SanitizeBranchName(tt.input)
 			if got != tt.expected {
-				t.Errorf("sanitizeBranchName(%q) = %q, want %q", tt.input, got, tt.expected)
+				t.Errorf("SanitizeBranchName(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}
@@ -136,12 +136,12 @@ func TestSanitizeBranchName_FallbackOnEmpty(t *testing.T) {
 	}
 	for _, input := range inputs {
 		t.Run("input="+input, func(t *testing.T) {
-			got := sanitizeBranchName(input)
+			got := SanitizeBranchName(input)
 			if got == "" {
-				t.Errorf("sanitizeBranchName(%q) returned empty string, expected fallback name", input)
+				t.Errorf("SanitizeBranchName(%q) returned empty string, expected fallback name", input)
 			}
 			if !strings.HasPrefix(got, "session-") {
-				t.Errorf("sanitizeBranchName(%q) = %q, expected prefix \"session-\"", input, got)
+				t.Errorf("SanitizeBranchName(%q) = %q, expected prefix \"session-\"", input, got)
 			}
 		})
 	}
@@ -149,8 +149,8 @@ func TestSanitizeBranchName_FallbackOnEmpty(t *testing.T) {
 
 func TestSanitizeBranchName_FallbackIsUnique(t *testing.T) {
 	// Each call with an empty-producing input should return a unique fallback.
-	a := sanitizeBranchName("")
-	b := sanitizeBranchName("")
+	a := SanitizeBranchName("")
+	b := SanitizeBranchName("")
 	if a == b {
 		t.Errorf("expected unique fallback names, got %q twice", a)
 	}

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -122,7 +122,7 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 	branchName := fmt.Sprintf("%s%s", cfg.BranchPrefix, sessionName)
 	// Sanitize the final branch name to handle invalid characters from any source
 	// (e.g., backslashes from Windows domain usernames like DOMAIN\user)
-	branchName = sanitizeBranchName(branchName)
+	branchName = SanitizeBranchName(branchName)
 
 	// Convert repoPath to absolute path
 	absPath, err := filepath.Abs(repoPath)

--- a/task/runner.go
+++ b/task/runner.go
@@ -329,14 +329,26 @@ func NextTaskRunTitle(repoID, repoPath, baseTitle, program string) (string, erro
 			usedTitles = append(usedTitles, data.Title)
 		}
 
-		// Compare case-insensitively to match the daemon's title-conflict
-		// validation (strings.EqualFold, see daemon.findTitleConflictLocked).
-		// A case-sensitive check here would hand back a candidate (e.g.
-		// "nightly" when "Nightly" exists) that the daemon later rejects,
-		// turning every TUI-triggered run into a round-trip error. (#721)
+		// Mirror the daemon's title-conflict validation so we never hand back a
+		// candidate the daemon would reject, which would turn every
+		// TUI-triggered run into a round-trip error. The daemon rejects titles
+		// that collide either case-insensitively or after branch sanitization
+		// (see daemon.titlesCollide / git.SanitizeBranchName). A candidate like
+		// "nightly" collides with an existing "Nightly" (#721); "my-task"
+		// collides with "My Task" once both sanitize to the same branch (#741).
+		// LoadConfig supplies the same BranchPrefix the worktree layer uses;
+		// fall back to case-insensitive-only if it is unavailable.
+		branchPrefix := ""
+		if cfg, cfgErr := config.LoadConfig(); cfgErr == nil {
+			branchPrefix = cfg.BranchPrefix
+		}
 		titleTaken := func(candidate string) bool {
+			candidateBranch := git.SanitizeBranchName(branchPrefix + candidate)
 			for _, used := range usedTitles {
 				if strings.EqualFold(used, candidate) {
+					return true
+				}
+				if git.SanitizeBranchName(branchPrefix+used) == candidateBranch {
 					return true
 				}
 			}

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -401,6 +401,44 @@ func TestNextTaskRunTitleCaseInsensitive(t *testing.T) {
 	}
 }
 
+// TestNextTaskRunTitleSanitizeCollision guards against #741 (completing #721):
+// the persisted title "My Task" must block the base "my-task" because both
+// sanitize to the same git branch, so the next title is "my-task-2". A check
+// that only compared case-insensitively would hand back "my-task", which the
+// daemon's branch-collision validation then rejects.
+func TestNextTaskRunTitleSanitizeCollision(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoID := "test-repo-title-sanitize"
+	instancesPath, err := config.RepoInstancesPath(repoID)
+	if err != nil {
+		t.Fatalf("RepoInstancesPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(instancesPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	preexisting := []session.InstanceData{
+		{Title: "My Task"},
+	}
+	preRaw, err := json.MarshalIndent(preexisting, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal preexisting: %v", err)
+	}
+	if err := os.WriteFile(instancesPath, preRaw, 0644); err != nil {
+		t.Fatalf("write preexisting: %v", err)
+	}
+
+	title, err := NextTaskRunTitle(repoID, "/tmp/repo", "my-task", "claude")
+	if err != nil {
+		t.Fatalf("NextTaskRunTitle: %v", err)
+	}
+	if title != "my-task-2" {
+		t.Fatalf("expected my-task-2 (sanitize-variant of persisted %q must collide), got %q", "My Task", title)
+	}
+}
+
 func TestTaskRunBaseTitleFallsBackToTaskID(t *testing.T) {
 	got := TaskRunBaseTitle(Task{ID: "abc123"})
 	if got != "task-abc123" {


### PR DESCRIPTION
## Summary

Completes #605. Fixes #741.

When a session is created, its title is sanitized into a git branch name by `git.SanitizeBranchName` — which lowercases, turns spaces into dashes, strips unsafe characters, and collapses runs of dashes. Two **distinct** titles can therefore derive the **same** branch (e.g. `"A B"` and `"a-b"` both → `<prefix>/a-b`).

The daemon's pre-validation (`findTitleConflictLocked`) only compared titles with `strings.EqualFold`, so it caught **case-only** collisions (`"MyApp"`/`"myapp"`, the #605 fix) but let every other sanitization collision through. The daemon accepted both sessions, and the second worktree create then failed with a cryptic git error:

```
fatal: '<prefix>/a-b' is already used by worktree at '/tmp/.../repo-A B'
```

— the exact UX #605 set out to prevent. #605 was an incomplete fix: it handled case but not the rest of `sanitizeBranchName`'s normalizations.

## Root cause

`daemon/control.go:findTitleConflictLocked` compared raw titles (`EqualFold`) rather than the **derived branch**, while the git layer keys worktrees off the sanitized branch. Case-folding is only one of several normalizations, so the two layers disagreed for non-case collisions.

## Fix

- Export `sanitizeBranchName` → `git.SanitizeBranchName` so the daemon can derive the same branch the worktree layer will.
- Replace the `EqualFold` comparisons in `findTitleConflictLocked` with `titlesCollide`, which compares the derived branch `git.SanitizeBranchName(BranchPrefix + title)`.
- **Strict superset of #605:** `titlesCollide` keeps an `EqualFold` guard, so exact duplicates are still caught — including unsafe-char-only titles whose sanitized branch is a random fallback that would otherwise never compare equal. Case-only collisions remain rejected.
- The conflict error now names **both** titles and the shared branch, so the message is actionable instead of cryptic.

## Adjacent call-site audit (per CLAUDE.md)

Grepped for every title-uniqueness / branch-derivation site. `task.NextTaskRunTitle` (`task/runner.go`) deliberately mirrors the daemon's check (#721) to avoid handing back a candidate the daemon would later reject (round-trip error). It used `EqualFold` only — now out of sync with the stricter daemon. Brought it into lockstep with the same branch-collision comparison so task-triggered runs never propose a sanitize-colliding candidate. `session/git/worktree.go` (the actual branch derivation) is unchanged behaviorally — only the function rename.

## Tests

- `daemon/TestManagerCreateSessionRejectsSanitizeCollision`: `"A B"` then `"a-b"` → rejected with a branch-collision error naming both titles; also asserts the #605 case-only path (`"Foo"` then `"foo"`) still rejects.
- `daemon/TestManagerCreateSessionRejectsCaseVariantTitle` (#605): retained; message-wording assertion generalized from "case-insensitive" to "branch" (behavior unchanged).
- `task/TestNextTaskRunTitleSanitizeCollision`: persisted `"My Task"` blocks base `"my-task"` → next title `"my-task-2"`.

## Gates

`go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, and `go test ./...` (incl. `-race` on `daemon`/`session/git`/`task`) all green. The only failing test in the suite is the pre-existing, environment-specific `TestSigtermFallback_DeadPID` flake (real running `af --daemon` processes on the dev box, not code).

— Captain Claude
