### PR TITLE
fix(task/launchd): normalize full-range DOM/DOW wildcards to preserve monthly/weekly schedules (#770)

### DIFF
--- a/task/launchd_schedule.go
+++ b/task/launchd_schedule.go
@@ -120,13 +120,19 @@ func cronToCalendarIntervalXML(cronExpr string) (string, error) {
 
 	// Detect when DOM or DOW is syntactically restricted but semantically
 	// covers all possible values (e.g., DOW=0-6 or DOM=1-31). Under cron OR
-	// semantics, "X OR every-day" collapses to "every day", so both the DOM
-	// and DOW restrictions become irrelevant and we emit a single
-	// wildcard-day dict.
+	// semantics, "X OR every-day" collapses to "every day", so an
+	// effective-wildcard side is irrelevant and must be dropped to a
+	// wildcard. Clear only the field that covers all values — clearing both
+	// would erase the surviving constraint and silently turn a monthly
+	// (e.g. "0 9 15 * 1-7") or weekly (e.g. "0 9 1-31 * 1") schedule into a
+	// daily one. This mirrors the systemd path in CronToOnCalendar, which
+	// neutralizes DOM and DOW independently.
 	dowCoversAll := expanded[dowIdx].vals != nil && len(expanded[dowIdx].vals) >= 7
 	domCoversAll := expanded[domIdx].vals != nil && len(expanded[domIdx].vals) >= 31
-	if dowCoversAll || domCoversAll {
+	if dowCoversAll {
 		expanded[dowIdx].vals = nil
+	}
+	if domCoversAll {
 		expanded[domIdx].vals = nil
 	}
 

--- a/task/launchd_test.go
+++ b/task/launchd_test.go
@@ -16,13 +16,13 @@ func countDicts(xml string) int {
 
 // TestCronToCalendarIntervalXML_NoDoubleTrigger verifies that when DOW is
 // syntactically restricted but covers all possible weekdays (e.g., 0-6),
-// the schedule collapses to a single wildcard-day dict rather than
-// emitting both a DOM dict and 7 DOW dicts (which would double-fire on
-// the overlap day).
+// the DOW side is dropped — emitting a single DOM dict rather than a DOM
+// dict plus 7 DOW dicts (which would double-fire on the overlap day). The
+// surviving DOM=1 constraint must be preserved so the schedule stays
+// monthly on the 1st (regression for #770).
 func TestCronToCalendarIntervalXML_NoDoubleTrigger(t *testing.T) {
-	// DOW=0-6 covers every weekday. Under cron OR semantics, this is
-	// equivalent to "every day at 09:00"; launchd must receive a single
-	// dict with only Hour and Minute.
+	// DOW=0-6 covers every weekday, so it is an effective wildcard and is
+	// dropped; DOM=1 survives, leaving a single monthly dict.
 	xml, err := cronToCalendarIntervalXML("0 9 1 * 0-6")
 	require.NoError(t, err)
 
@@ -30,14 +30,16 @@ func TestCronToCalendarIntervalXML_NoDoubleTrigger(t *testing.T) {
 	assert.Contains(t, xml, "<key>Hour</key>")
 	assert.Contains(t, xml, "<integer>9</integer>")
 	assert.Contains(t, xml, "<key>Minute</key>")
-	assert.Contains(t, xml, "<integer>0</integer>")
-	assert.NotContains(t, xml, "<key>Day</key>", "Day key must be omitted when DOW covers all")
+	assert.Contains(t, xml, "<key>Day</key>", "Day must be preserved so the schedule stays monthly")
+	assert.Contains(t, xml, "<integer>1</integer>")
 	assert.NotContains(t, xml, "<key>Weekday</key>", "Weekday key must be omitted when DOW covers all")
 }
 
-// TestCronToCalendarIntervalXML_DOMCoversAll verifies the symmetric case
-// where DOM covers all 31 possible values. Under cron OR semantics this
-// also collapses to "every day".
+// TestCronToCalendarIntervalXML_DOMCoversAll verifies the case where DOM
+// covers all 31 possible values while DOW stays restricted. Only the DOM
+// side is an effective wildcard, so it must be dropped while the surviving
+// DOW constraint keeps the schedule weekly (regression for #770: clearing
+// both fields silently turned this into a daily schedule).
 func TestCronToCalendarIntervalXML_DOMCoversAll(t *testing.T) {
 	xml, err := cronToCalendarIntervalXML("30 8 1-31 * 1")
 	require.NoError(t, err)
@@ -48,17 +50,20 @@ func TestCronToCalendarIntervalXML_DOMCoversAll(t *testing.T) {
 	assert.Contains(t, xml, "<key>Minute</key>")
 	assert.Contains(t, xml, "<integer>30</integer>")
 	assert.NotContains(t, xml, "<key>Day</key>", "Day key must be omitted when DOM covers all")
-	assert.NotContains(t, xml, "<key>Weekday</key>", "Weekday key must be omitted when DOM covers all")
+	assert.Contains(t, xml, "<key>Weekday</key>", "Weekday must be preserved so the schedule stays weekly")
+	assert.Contains(t, xml, "<integer>1</integer>")
 }
 
 // TestCronToCalendarIntervalXML_DOWStepCoversAll verifies that a step
-// expression that expands to every weekday also triggers the collapse.
+// expression that expands to every weekday neutralizes only the DOW side,
+// leaving the DOM=15 constraint intact (monthly on the 15th).
 func TestCronToCalendarIntervalXML_DOWStepCoversAll(t *testing.T) {
 	xml, err := cronToCalendarIntervalXML("0 9 15 * */1")
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, countDicts(xml), "expected a single dict, got:\n%s", xml)
-	assert.NotContains(t, xml, "<key>Day</key>")
+	assert.Contains(t, xml, "<key>Day</key>", "Day must be preserved so the schedule stays monthly")
+	assert.Contains(t, xml, "<integer>15</integer>")
 	assert.NotContains(t, xml, "<key>Weekday</key>")
 }
 
@@ -99,15 +104,43 @@ func TestCronToCalendarIntervalXML_WildcardDOW(t *testing.T) {
 }
 
 // TestCronToCalendarIntervalXML_DOW7NormalizesAndCoversAll verifies that
-// a DOW range of 1-7 (where 7 normalizes to 0) covers all weekdays and
-// triggers the collapse.
+// a DOW range of 1-7 (where 7 normalizes to 0) covers all weekdays and so
+// the DOW side is dropped, while DOM=15 is preserved (monthly on the 15th).
+// Regression for #770: previously both fields were cleared, firing daily.
 func TestCronToCalendarIntervalXML_DOW7NormalizesAndCoversAll(t *testing.T) {
 	xml, err := cronToCalendarIntervalXML("0 9 15 * 1-7")
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, countDicts(xml), "expected a single dict, got:\n%s", xml)
-	assert.NotContains(t, xml, "<key>Day</key>")
+	assert.Contains(t, xml, "<key>Day</key>", "Day must be preserved so the schedule stays monthly")
+	assert.Contains(t, xml, "<integer>15</integer>")
 	assert.NotContains(t, xml, "<key>Weekday</key>")
+}
+
+// TestCronToCalendarIntervalXML_MonthlyDOWWildcardRange is the #770
+// regression for the issue's primary example: DOM=1 with DOW=1-7 (an
+// effective wildcard) must stay monthly on the 1st, not collapse to daily.
+func TestCronToCalendarIntervalXML_MonthlyDOWWildcardRange(t *testing.T) {
+	xml, err := cronToCalendarIntervalXML("0 0 1 * 1-7")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countDicts(xml), "expected a single dict, got:\n%s", xml)
+	assert.Contains(t, xml, "<key>Day</key>", "Day must be preserved so the schedule stays monthly")
+	assert.Contains(t, xml, "<integer>1</integer>")
+	assert.NotContains(t, xml, "<key>Weekday</key>")
+}
+
+// TestCronToCalendarIntervalXML_WeeklyDOMWildcardRange is the #770
+// regression for the symmetric example: DOW=1 (Monday) with DOM=1-31 (an
+// effective wildcard) must stay weekly on Monday, not collapse to daily.
+func TestCronToCalendarIntervalXML_WeeklyDOMWildcardRange(t *testing.T) {
+	xml, err := cronToCalendarIntervalXML("0 0 1-31 * 1")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, countDicts(xml), "expected a single dict, got:\n%s", xml)
+	assert.NotContains(t, xml, "<key>Day</key>")
+	assert.Contains(t, xml, "<key>Weekday</key>", "Weekday must be preserved so the schedule stays weekly")
+	assert.Contains(t, xml, "<integer>1</integer>")
 }
 
 func TestCronToCalendarIntervalXML_AllWildcards(t *testing.T) {


### PR DESCRIPTION
## Root cause

`cronToCalendarIntervalXML` (launchd `StartCalendarInterval` generation, `task/launchd_schedule.go`) collapsed **both** the day-of-month and day-of-week fields to a wildcard whenever **either** one syntactically covered all of its legal values:

```go
if dowCoversAll || domCoversAll {
    expanded[dowIdx].vals = nil
    expanded[domIdx].vals = nil   // <-- clears both even if only one covers all
}
```

Under cron OR semantics, "X OR every-day" does collapse to "every day", so the effective-wildcard side *should* be neutralized — but clearing **both** also erased the surviving constraint, silently turning monthly/weekly schedules into daily ones:

| Cron | Intended | Before fix |
|------|----------|------------|
| `0 9 15 * 1-7` | monthly on the 15th (DOW=1-7 is an effective wildcard) | fired **daily** |
| `0 0 1-31 * 1` | weekly on Monday (DOM=1-31 is an effective wildcard) | fired **daily** |
| `0 9 1 * 0-6` | monthly on the 1st | fired **daily** |

Tasks that should run monthly or weekly ran every day.

## Fix

Clear each field independently so the surviving constraint is preserved:

```go
if dowCoversAll {
    expanded[dowIdx].vals = nil
}
if domCoversAll {
    expanded[domIdx].vals = nil
}
```

This is a verbatim port of the existing **systemd** behavior. `CronToOnCalendar` in `task/cron.go` already neutralizes DOM and DOW separately — `domCoversAll` only rewrites `domPart` to `*`, and `convertDOW` independently returns `""` when DOW covers all — which is why systemd was correct after #550/#576 while launchd was never updated. The launchd path now matches.

## Audit (adjacent call-sites)

Per the repo convention, I checked the sibling normalization path. The systemd path (`task/cron.go` `CronToOnCalendar`) was already correct and is the source pattern being mirrored here; no other scheduler emits day constraints. After this change the launchd and systemd paths handle full-range DOM/DOW consistently. The double-fire rejection for *genuinely* both-restricted expressions (e.g. `0 9 1 * 1`) is unchanged — those still surface the "day-of-month and day-of-week" error rather than collapsing.

## Tests

Several existing launchd tests had codified the buggy daily behavior; they now assert the surviving constraint is preserved, matching the systemd regressions (e.g. `TestCronToOnCalendarDOWRange17Monthly`):

- `TestCronToCalendarIntervalXML_NoDoubleTrigger` (`0 9 1 * 0-6`) → Day=1 preserved (monthly), Weekday dropped
- `TestCronToCalendarIntervalXML_DOMCoversAll` (`30 8 1-31 * 1`) → Weekday=1 preserved (weekly), Day dropped
- `TestCronToCalendarIntervalXML_DOWStepCoversAll` (`0 9 15 * */1`) → Day=15 preserved (monthly)
- `TestCronToCalendarIntervalXML_DOW7NormalizesAndCoversAll` (`0 9 15 * 1-7`) → Day=15 preserved (monthly)

New regressions for the issue's primary examples:

- `TestCronToCalendarIntervalXML_MonthlyDOWWildcardRange` (`0 0 1 * 1-7`) → monthly on the 1st
- `TestCronToCalendarIntervalXML_WeeklyDOMWildcardRange` (`0 0 1-31 * 1`) → weekly on Monday

## Validation

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./task/ -race -count=1` — pass; full `go test ./...` green except a pre-existing environmental daemon-socket flake (`integration.TestDaemonLifecycleRecoversFromStaleSocketAndDeadDaemon`, caused by stray `af --daemon` processes on the dev box; passes in isolation)

Fixes #770

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)