### PR TITLE
fix(session/git/hooks): SIGKILL process group on hook completion to clean up backgrounded grandchildren (#769)

### DIFF
--- a/session/git/hooks.go
+++ b/session/git/hooks.go
@@ -3,20 +3,33 @@ package git
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
+// hookWaitDelay bounds how long cmd.Wait blocks after a hook's shell exits
+// before the inherited stdout/stderr pipes are force-closed. A script that
+// backgrounds a process with `&`/`disown` and exits immediately leaves that
+// grandchild holding the write end of the capture pipe, so without a bound
+// cmd.Wait would block until the grandchild itself exits (defeating the
+// process-group cleanup below). It only elapses when something outlives the
+// shell — normal hooks complete their I/O at shell exit and return instantly.
+const hookWaitDelay = 2 * time.Second
+
 // RunPostWorktreeHooksAsync runs the per-repo post_worktree_commands in the
 // background. Each command is executed sequentially via "sh -c" with the
 // working directory set to worktreePath. The provided context can be used to
 // cancel in-flight hooks (e.g. when the worktree is being cleaned up). Each
-// command runs as the leader of its own process group so that, on
-// cancellation, the whole tree — including grandchildren the script
-// backgrounded with `&` or `disown` — is killed together.
+// command runs as the leader of its own process group so that the whole tree
+// — including grandchildren the script backgrounded with `&` or `disown` —
+// is killed together once the hook's shell exits, whether that exit is normal
+// completion or cancellation. Backgrounded grandchildren therefore never
+// outlive their parent hook.
 // Errors are logged but do not propagate.
 func RunPostWorktreeHooksAsync(ctx context.Context, repoPath, worktreePath string) {
 	repoID := config.RepoIDFromRoot(repoPath)
@@ -51,16 +64,20 @@ func RunPostWorktreeHooksAsync(ctx context.Context, repoPath, worktreePath strin
 			// with `&` or `disown` alive — they get reparented to init and
 			// outlive the session (see #610).
 			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+			// Bound the post-exit wait so a backgrounded grandchild holding the
+			// capture pipe cannot keep cmd.Wait blocked until it exits.
+			cmd.WaitDelay = hookWaitDelay
 
 			if err := cmd.Start(); err != nil {
 				log.ErrorLog.Printf("post-worktree hook %q failed: %v", cmdStr, err)
 				continue
 			}
 
-			// On cancellation, SIGKILL the whole process group (negative pid
-			// targets the group led by cmd.Process.Pid). doneCh ensures the
-			// watchdog exits when the command finishes normally so it does
-			// not leak across loop iterations.
+			// While the hook is running, a watchdog SIGKILLs the whole process
+			// group on cancellation (negative pid targets the group led by
+			// cmd.Process.Pid) so a long-running hook is torn down promptly.
+			// doneCh stops the watchdog once cmd.Wait() returns so it does not
+			// leak across loop iterations.
 			doneCh := make(chan struct{})
 			go func(pgid int) {
 				select {
@@ -73,14 +90,31 @@ func RunPostWorktreeHooksAsync(ctx context.Context, repoPath, worktreePath strin
 			waitErr := cmd.Wait()
 			close(doneCh)
 
+			// Always SIGKILL the process group once the shell has exited, not
+			// just on cancellation. If the script backgrounded a process with
+			// `&` or `disown` and the shell exited immediately (no `wait`), that
+			// grandchild keeps running in the worktree's process group; the
+			// watchdog above only fires on cancellation and may already have
+			// exited via doneCh. Signalling the group here reaps any survivors
+			// on every exit path — normal completion or a cancellation that
+			// raced ahead of doneCh — so no grandchild outlives its parent hook
+			// (see #610, #769).
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+
 			if ctx.Err() != nil {
 				log.InfoLog.Printf("post-worktree hooks cancelled for %s", worktreePath)
 				return
 			}
-			if waitErr != nil {
-				log.ErrorLog.Printf("post-worktree hook %q failed: %v\n%s", cmdStr, waitErr, output.String())
-			} else {
+			switch {
+			case waitErr == nil:
 				log.InfoLog.Printf("post-worktree hook %q completed successfully", cmdStr)
+			case errors.Is(waitErr, exec.ErrWaitDelay):
+				// The shell exited but a backgrounded grandchild held the
+				// capture pipe open past hookWaitDelay; it was just killed with
+				// the process group above. This is not a hook failure.
+				log.InfoLog.Printf("post-worktree hook %q completed; terminated backgrounded processes that outlived the shell", cmdStr)
+			default:
+				log.ErrorLog.Printf("post-worktree hook %q failed: %v\n%s", cmdStr, waitErr, output.String())
 			}
 		}
 	}()

--- a/session/git/hooks_test.go
+++ b/session/git/hooks_test.go
@@ -84,6 +84,36 @@ func TestHookCancellation_BackgroundedGrandchildKilledByGroupSignal(t *testing.T
 	}
 }
 
+// TestHookCompletion_BackgroundedGrandchildKilled is the regression test for
+// #769. A hook that backgrounds a process and exits immediately (no `wait`)
+// used to leak the grandchild: the watchdog exited via doneCh on normal
+// completion before any cancellation, so nothing ever signalled the process
+// group. With the fix, the group is SIGKILL'd on every exit path — including
+// normal completion with no cancellation at all — so the grandchild dies.
+func TestHookCompletion_BackgroundedGrandchildKilled(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	// No `wait`: the shell backgrounds sleep, records its pid, and exits 0
+	// immediately. The context is never cancelled, so the leak is only caught
+	// by the completion-path group kill.
+	repoPath := freshRepoConfig(t, []string{
+		fmt.Sprintf(`sleep 30 & echo $! > %q`, pidFile),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	RunPostWorktreeHooksAsync(ctx, repoPath, t.TempDir())
+
+	pid := waitForPidFile(t, pidFile, 5*time.Second)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	// cmd.Wait unblocks ~hookWaitDelay after the shell exits, then the group
+	// kill fires; allow margin over that bound for the grandchild to be reaped.
+	if !waitForProcessExit(pid, 6*time.Second) {
+		t.Fatalf("backgrounded grandchild pid %d survived hook completion — process group not killed on the success path", pid)
+	}
+}
+
 // freshRepoConfig isolates the per-test config dir via AGENT_FACTORY_HOME,
 // writes a repo config with the given post-worktree commands, and returns a
 // repo path the test should hand to RunPostWorktreeHooksAsync. The repo path


### PR DESCRIPTION
## Summary

Fixes #769.

Post-worktree hooks run each `sh -c` command as the leader of its own process group so the whole tree — including grandchildren backgrounded with `&`/`disown` — can be killed together (the #610 fix). The cleanup was incomplete: the watchdog goroutine only SIGKILL'd the group on **context cancellation**.

A hook that backgrounds a process and exits immediately (no `wait`) closes `doneCh` on **normal completion**, so the watchdog exits via `doneCh` without ever signalling the group. If the context is later cancelled, nothing remains to kill the group, and the backgrounded grandchild runs indefinitely — surviving worktree removal and violating the documented "killed together" contract.

## Root cause

Two issues compounded:

1. **The kill only happened on cancellation.** On the fast-exit path the watchdog returned via `doneCh` and no signal was ever sent.
2. **`cmd.Wait()` itself blocks on the leaked grandchild.** Because `cmd.Stdout`/`cmd.Stderr` are a `bytes.Buffer`, Go wires up an internal pipe, and the backgrounded grandchild inherits its write end. `cmd.Wait()` drains that pipe until EOF, so it would block until the grandchild *itself* exits (e.g. the full `sleep 30`) — meaning a naive "kill after Wait" still wouldn't fire in time.

## Fix

- **Always SIGKILL the process group once the shell exits**, on every exit path (normal completion and cancellation), so no grandchild outlives its parent hook.
- **Bound `cmd.Wait()` with `cmd.WaitDelay` (2s)** so the inherited capture pipe is force-closed shortly after the shell exits instead of blocking on the leaked grandchild. It only elapses when something outlives the shell — normal hooks complete their I/O at shell exit and `Wait` returns instantly.
- The resulting `exec.ErrWaitDelay` is reported as completion-with-cleanup, **not** a hook failure.

## Audit (CLAUDE.md adjacent call-sites)

`grep -rn "Setpgid"` across the repo returns exactly one site — `session/git/hooks.go`. No other process-group launches exist, so this is the only place that needed the success-path group kill.

## Tests

- New `TestHookCompletion_BackgroundedGrandchildKilled`: a hook backgrounds `sleep 30 &` and exits 0 with **no cancellation**; the test asserts the grandchild is reaped after completion. This fails before the fix (grandchild survives) and passes after.
- Existing `#610` cancellation regression tests still pass (the watchdog still kills the group promptly on cancel, so those return in ~50ms).

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test -race ./session/git/...` — pass

(The `daemon`/`integration` race-suite failures on the dev box are the known environmental flake: 18 stale `af --daemon` processes from prior local runs hold sockets and match the daemon-discovery scan; they are unrelated to this change, which is confined to `session/git`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude