### PR TITLE
fix(ui/task_pane): consume deleted slice after save to prevent re-firing scheduler removal (#763)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -538,7 +538,7 @@ func (m *home) saveContentPaneState() {
 				}
 			}
 		}
-		for _, tsk := range sp.GetDeleted() {
+		for _, tsk := range sp.ConsumeDeleted() {
 			// Tear down the scheduler before deleting the task record so
 			// a phantom timer can't keep firing for a deleted task. If
 			// RemoveTask then fails, re-install the scheduler so the

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -79,9 +79,17 @@ func (s *TaskPane) GetTasks() []task.Task {
 	return s.tasks
 }
 
-// GetDeleted returns deleted tasks for cleanup.
-func (s *TaskPane) GetDeleted() []task.Task {
-	return s.deleted
+// ConsumeDeleted returns the tasks pending deletion and clears the pane's
+// dirty state so a subsequent save can't reprocess already-deleted tasks. The
+// deletion loop in saveContentPaneState removes schedulers and task records as
+// a side effect, so re-running it would call RemoveScheduler/RemoveTask on
+// records that no longer exist and trip the rollback path that re-installs an
+// orphaned scheduler (fixes #763).
+func (s *TaskPane) ConsumeDeleted() []task.Task {
+	deleted := s.deleted
+	s.deleted = nil
+	s.dirty = false
+	return deleted
 }
 
 // IsDirty returns true if tasks were modified.

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -455,3 +455,41 @@ func TestTaskPaneListShowsConfigDefaultWhenProgramEmpty(t *testing.T) {
 	assert.Contains(t, out, programDefaultLabel,
 		"list view should render the config-default sentinel for empty Program")
 }
+
+// TestTaskPaneConsumeDeletedClearsState verifies that deleting a task and then
+// consuming the deletion clears both the pending-deletion slice and the dirty
+// flag, so a second save pass finds nothing to reprocess. Regression test for
+// #763: saveContentPaneState previously read GetDeleted() without clearing it,
+// so pressing ESC (save) twice re-ran the deletion loop on an already-removed
+// task, tripping the rollback path that re-installs an orphaned scheduler.
+func TestTaskPaneConsumeDeletedClearsState(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{
+		{ID: "a", Name: "alpha"},
+		{ID: "b", Name: "beta"},
+	})
+
+	// Select and delete the first task (the "D" key in normal mode). The pane
+	// only handles keys while focused.
+	tp.SetFocus(true)
+	tp.selectedIdx = 0
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+
+	assert.True(t, tp.IsDirty(), "deleting a task must mark the pane dirty")
+
+	// First save consumes the deletion: the deleted task is returned exactly
+	// once, and the pane state is cleared.
+	first := tp.ConsumeDeleted()
+	if assert.Len(t, first, 1, "first save should surface the deleted task once") {
+		assert.Equal(t, "a", first[0].ID)
+	}
+	assert.False(t, tp.IsDirty(),
+		"consuming the deletion must clear the dirty flag so updates aren't re-run")
+
+	// Second save (e.g. ESC pressed again) must find nothing to process, so the
+	// deletion loop in saveContentPaneState never re-runs RemoveScheduler/
+	// RemoveTask and can't re-install an orphaned scheduler.
+	second := tp.ConsumeDeleted()
+	assert.Empty(t, second,
+		"second save must not reprocess an already-deleted task (#763)")
+}


### PR DESCRIPTION
## Root cause

`saveContentPaneState` (`app/app.go`) read `sp.GetDeleted()` but never cleared the TaskPane's pending-deletion slice or its `dirty` flag afterward. Pressing ESC to save twice (delete a task → ESC → re-focus → ESC) re-ran the deletion loop on an already-removed task:

- `RemoveScheduler` is effectively idempotent (ignores missing units/files) → returns `nil`.
- `RemoveTask` then fails with `task with id "..." not found` because the record was already deleted.
- That failure trips the rollback path `InstallScheduler(tsk)`, which recreates and enables a scheduler for a task ID that no longer exists — an **orphaned scheduler** that keeps firing and logging "task not found".

Introduced in `ab149c4a`, which added the unified sidebar's `saveContentPaneState` deletion loop calling `GetDeleted()` without clearing the list.

## Fix

Replace `GetDeleted()` with `ConsumeDeleted()`, which returns the pending deletions and clears both `s.deleted` and `s.dirty`. This matches the consume-after-apply pattern already used by `ConsumePendingCreate` / `ConsumePendingTrigger`, and the clearing already done in `SetTasks`. Clearing `dirty` also stops the update loop (`UpdateTask` + `Install`/`RemoveScheduler`) from needlessly re-running on a second save.

## Audit (per adjacent-call-sites convention)

- `TaskPane` has no separate `updated`/`added` slices — deletions and in-place task edits (toggle `x`, edit-mode saves) are both gated by the single `dirty` flag, which `ConsumeDeleted` now clears.
- `pendingCreate` / `pendingTrigger` already follow the consume pattern.
- `GetDeleted` had no other callers, so it is removed (keeps `deadcode` clean).

## Test

`TestTaskPaneConsumeDeletedClearsState`: deletes a task, asserts the first save surfaces it exactly once and clears `dirty`, then asserts a second save returns nothing — proving the deletion loop (and its `RemoveScheduler` / rollback `InstallScheduler`) never re-runs.

## Gates

- `gofmt -l .` — clean
- `go build ./...` — ok
- `go test ./...` — pass
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test -race ./ui/... ./app/... ./task/...` — pass, no data races

Fixes #763

— Captain Claude
