### PR TITLE
fix(api/sessions): honor --repo scoping in sessions kill (#761)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -373,7 +373,16 @@ var sessionsKillCmd = &cobra.Command{
 		log.Initialize(false)
 		defer log.Close()
 
-		if err := killSessionViaDaemon(daemon.KillSessionRequest{Title: args[0]}); err != nil {
+		// Honor --repo scoping (#761). An empty repoID preserves the prior
+		// all-repo search; a non-empty one confines the kill to that repo so a
+		// same-titled session in a different repo is never destroyed by
+		// mistake. Mirrors sessionsListCmd's resolveRepoID() usage.
+		repoID, err := resolveRepoID()
+		if err != nil {
+			return jsonError(err)
+		}
+
+		if err := killSessionViaDaemon(daemon.KillSessionRequest{Title: args[0], RepoID: repoID}); err != nil {
 			return jsonError(err)
 		}
 

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -287,6 +288,129 @@ func TestSessionsKill_UnknownTitle(t *testing.T) {
 
 	if err := sessionsKillCmd.RunE(sessionsKillCmd, []string{"does-not-exist"}); err == nil {
 		t.Fatalf("expected error for unknown session, got nil")
+	}
+}
+
+// TestSessionsKill_HonorsRepoScoping is the regression test for issue #761.
+// Two repos each hold a session with the same title. Killing it with
+// `--repo <repoA>` must scope the kill to repo A's session: the CLI must pass
+// the resolved RepoID to the daemon, and only repo A's entry may be removed.
+// Previously the --repo flag was dropped on the floor, so the kill ran in
+// all-repo mode and could destroy the wrong repo's session.
+func TestSessionsKill_HonorsRepoScoping(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	// Repo A is a real git repo so resolveRepoID(--repo) can compute its ID
+	// the same way the running CLI would.
+	repoARoot := filepath.Join(tmp, "repo-a")
+	if err := os.MkdirAll(repoARoot, 0755); err != nil {
+		t.Fatalf("mkdir repo A: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoARoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init repo A: %v (%s)", err, out)
+	}
+	repoA, err := config.RepoFromPath(repoARoot)
+	if err != nil {
+		t.Fatalf("RepoFromPath repo A: %v", err)
+	}
+
+	// Repo B is a distinct synthetic repo on disk holding a same-titled session.
+	repoBID := "repo-b-synthetic"
+	if repoBID == repoA.ID {
+		t.Fatalf("test setup: synthetic repo B ID collided with repo A")
+	}
+
+	const title = "shared-title"
+	rawA, err := json.Marshal([]session.InstanceData{{Title: title, Path: repoARoot}})
+	if err != nil {
+		t.Fatalf("marshal repo A instances: %v", err)
+	}
+	rawB, err := json.Marshal([]session.InstanceData{{Title: title, Path: tmp}})
+	if err != nil {
+		t.Fatalf("marshal repo B instances: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoA.ID, rawA); err != nil {
+		t.Fatalf("save repo A instances: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoBID, rawB); err != nil {
+		t.Fatalf("save repo B instances: %v", err)
+	}
+
+	// Point --repo at repo A and capture the request the CLI hands to the
+	// daemon. The stub also mirrors the daemon's repo-scoped delete so we can
+	// assert at the storage level that only repo A's session is removed.
+	prevRepoFlag := repoFlag
+	repoFlag = repoARoot
+	defer func() { repoFlag = prevRepoFlag }()
+
+	var gotReq daemon.KillSessionRequest
+	prevKill := killSessionViaDaemon
+	killSessionViaDaemon = func(req daemon.KillSessionRequest) error {
+		gotReq = req
+		if req.RepoID == "" {
+			return errors.New("RepoID empty: --repo scoping was dropped")
+		}
+		return config.UpdateRepoInstances(req.RepoID, func(raw json.RawMessage) (json.RawMessage, error) {
+			var instances []session.InstanceData
+			if err := json.Unmarshal(raw, &instances); err != nil {
+				return nil, err
+			}
+			kept := instances[:0]
+			for _, inst := range instances {
+				if inst.Title != req.Title {
+					kept = append(kept, inst)
+				}
+			}
+			return json.Marshal(kept)
+		})
+	}
+	defer func() { killSessionViaDaemon = prevKill }()
+
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devnull.Close()
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout = devnull
+	os.Stderr = devnull
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	if err := sessionsKillCmd.RunE(sessionsKillCmd, []string{title}); err != nil {
+		t.Fatalf("sessionsKillCmd returned error: %v", err)
+	}
+
+	if gotReq.RepoID != repoA.ID {
+		t.Fatalf("kill request RepoID = %q, want repo A %q", gotReq.RepoID, repoA.ID)
+	}
+
+	// Repo A's session must be gone; repo B's same-titled session must survive.
+	gotA, err := config.LoadRepoInstances(repoA.ID)
+	if err != nil {
+		t.Fatalf("load repo A instances: %v", err)
+	}
+	var instancesA []session.InstanceData
+	if err := json.Unmarshal(gotA, &instancesA); err != nil {
+		t.Fatalf("unmarshal repo A: %v", err)
+	}
+	if len(instancesA) != 0 {
+		t.Fatalf("expected repo A session killed, still present: %+v", instancesA)
+	}
+
+	gotB, err := config.LoadRepoInstances(repoBID)
+	if err != nil {
+		t.Fatalf("load repo B instances: %v", err)
+	}
+	var instancesB []session.InstanceData
+	if err := json.Unmarshal(gotB, &instancesB); err != nil {
+		t.Fatalf("unmarshal repo B: %v", err)
+	}
+	if len(instancesB) != 1 || instancesB[0].Title != title {
+		t.Fatalf("repo B's same-titled session must be untouched, got: %+v", instancesB)
 	}
 }
 


### PR DESCRIPTION
## Summary

`af sessions kill <title>` advertises the `sessions` persistent `--repo`
flag (`Path to git repository`), but `sessionsKillCmd` passed only
`Title` to `daemon.KillSessionRequest` and dropped `--repo` on the floor.
The kill therefore **always ran in all-repo mode**, even when the user
explicitly scoped it.

### Root cause — data-loss risk

`daemon.KillSessionRequest` carries an optional `RepoID` that
`Manager.findSession` honors (non-empty → scope to that repo; empty →
search all repos and take the first title match). Because the CLI never
set `RepoID`, two repos holding a session with the same title meant
`kill T --repo A` would happily destroy repo **B**'s session if it was
found first. Killing a session tears down its tmux session, worktree, and
storage entry — so this is silent, irreversible loss of the wrong work.

This also made `sessions kill` the odd one out: `sessionsListCmd` already
resolves scoping via `resolveRepoID()`, and the TUI kill path
(`app/session_control.go`) passes a `repoID`.

## Fix

Resolve the repo with `resolveRepoID()` — exactly as `sessionsListCmd`
does — and populate `RepoID` on the request:

- empty `RepoID` (no `--repo`, cwd not a repo) → unchanged all-repo
  behavior, so no regression for existing single-repo workflows;
- non-empty `RepoID` → the daemon confines the kill to that repo and a
  same-titled session elsewhere is never touched.

Minimal, mirrors the established pattern; no daemon changes needed
(`findSession` already scopes on `RepoID`).

## Adjacent-call-site audit

All `sessions` subcommands inherit the `--repo` persistent flag. Audited
each for scoping:

| Subcommand | Repo scoping | Notes |
|---|---|---|
| `list` | ✅ `resolveRepoID()` | reference behavior |
| `create` | ✅ `resolveRepo()` (required) | always repo-scoped |
| `kill` | ✅ **fixed here** | was the data-loss bug |
| `whoami` | n/a | no title arg; matches by tmux session name |
| `get` | ⚠️ all-repo | read-only; returns metadata for first title match |
| `preview` | ⚠️ all-repo | read-only |
| `attach` | ⚠️ all-repo | read-only |
| `send-prompt` | ⚠️ all-repo | **mutating** — same latent wrong-target class as kill |

**Deliberate exclusion for this PR:** `kill` is the only subcommand whose
mis-scoping is *destructive*, so it's fixed in isolation to keep the diff
focused and low-risk. The read-only commands (`get`/`preview`/`attach`)
return or attach to the wrong session's view but cause no loss. The one
remaining write path, `send-prompt`, can deliver a prompt to a
same-titled session in the wrong repo and deserves the same treatment —
filed as a tracked follow-up rather than bundled here.

## Test

`TestSessionsKill_HonorsRepoScoping` creates a session with the same
title in two repos (repo A a real `git init`, repo B synthetic on disk),
runs the command with `--repo <repoA>`, and asserts both that the request
carries repo A's `RepoID` and that **only** repo A's entry is removed
while repo B's same-titled session survives.

## Verification

- `go build ./...` ✅
- `go test ./api/...` (incl. `-race`) ✅
- `gofmt -l .` clean ✅
- `golangci-lint run --timeout=3m --fast` clean ✅
- `deadcode -test ./...` clean ✅

Two unrelated full-suite failures were confirmed environmental, not from
this change: `daemon/TestSigtermFallback_DeadPID` (known flake — real
`af --daemon` processes on the box) and
`integration/TestCLICreateCodexSessionBecomesReady` (daemon-socket flake
under parallel `-race` load; passes in isolation with this change
stashed).

Fixes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude
