### PR TITLE
fix(app/ui): swap stale sidebar instance when CLI kill+recreate reuses same title (#765)

### DIFF
--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -47,6 +47,66 @@ func TestTUIRefreshSeesCLIChangesThroughDaemon(t *testing.T) {
 	require.Nil(t, findSidebarInstance(h, "cli-made"))
 }
 
+// TestTUIRefreshSwapsKillRecreatedSameTitle is the regression test for #765.
+//
+// When a session is killed and recreated under the SAME title via the CLI
+// WITHOUT an intervening refresh, the sidebar holds a dead in-memory instance
+// while a fresh, live instance exists on disk. The old title-only
+// reconciliation skipped both the add (title already present) and the remove
+// (title still on disk), so the corpse permanently shadowed the new session:
+// the user could neither attach nor preview it. refreshExternalInstances must
+// detect the stale instance (its tmux session is gone) and swap it for the
+// recreated on-disk one.
+func TestTUIRefreshSwapsKillRecreatedSameTitle(t *testing.T) {
+	skipIfRealBackendDepsMissing(t)
+
+	bin := buildIntegrationBinary(t)
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+	h.storage, err = session.NewStorage(config.DefaultState(), repo.ID)
+	require.NoError(t, err)
+	writeIntegrationConfig(t, os.Getenv("AGENT_FACTORY_HOME"))
+
+	t.Cleanup(func() {
+		_, _ = runIntegrationAF(t, bin, repoDir, "sessions", "kill", "recreated")
+		killIntegrationDaemon(os.Getenv("AGENT_FACTORY_HOME"))
+	})
+
+	// Create the session and import it into the sidebar.
+	runIntegrationAFOK(t, bin, repoDir, "sessions", "--repo", repoDir, "create", "--name", "recreated", "--program", tmux.ProgramClaude)
+	require.True(t, h.refreshExternalInstances(), "TUI refresh should import CLI-created session")
+	original := findSidebarInstance(h, "recreated")
+	require.NotNil(t, original)
+	require.True(t, original.TmuxAlive(), "imported instance should be alive")
+
+	// Kill then recreate the SAME title via the CLI, with NO refresh in
+	// between. The in-memory instance now points at a dead tmux session while
+	// a brand-new live instance sits on disk under the same title.
+	runIntegrationAFOK(t, bin, repoDir, "sessions", "kill", "recreated")
+	require.False(t, original.TmuxAlive(), "killed instance's tmux session must be gone")
+	runIntegrationAFOK(t, bin, repoDir, "sessions", "--repo", repoDir, "create", "--name", "recreated", "--program", tmux.ProgramClaude)
+
+	require.True(t, h.refreshExternalInstances(), "TUI refresh should swap the stale instance")
+
+	// Exactly one "recreated" instance, and it must be the new live one — not
+	// the dead corpse we started with.
+	var matches []*session.Instance
+	for _, inst := range h.sidebar.GetInstances() {
+		if inst.Title == "recreated" {
+			matches = append(matches, inst)
+		}
+	}
+	require.Len(t, matches, 1, "sidebar must hold exactly one instance for the reused title")
+	swapped := matches[0]
+	require.NotSame(t, original, swapped, "sidebar must hold the recreated instance, not the dead one")
+	require.True(t, swapped.TmuxAlive(), "swapped-in instance must be attachable (live tmux session)")
+}
+
 func findSidebarInstance(h *home, title string) *session.Instance {
 	for _, inst := range h.sidebar.GetInstances() {
 		if inst.Title == title {

--- a/app/sync.go
+++ b/app/sync.go
@@ -201,7 +201,7 @@ func (m *home) mergePendingInstances() int {
 				if existing.Title != data.Title {
 					continue
 				}
-				if pendingInstanceCollisionShouldSkip(existing.GetWorktreePath(), data.Worktree.WorktreePath, existing.TmuxAlive()) {
+				if instanceCollisionShouldSkip(existing.GetWorktreePath(), data.Worktree.WorktreePath, existing.CreatedAt, data.CreatedAt, existing.TmuxAlive()) {
 					log.WarningLog.Printf("skipping pending instance %q: already exists and is alive", data.Title)
 					skip = true
 				} else {
@@ -282,18 +282,57 @@ func (m *home) refreshExternalInstances() bool {
 
 	changed := false
 
-	// Add instances that exist on disk but not in sidebar.
+	// Add instances that exist on disk, and replace stale sidebar instances
+	// whose title was reused by a CLI kill+recreate.
+	//
+	// A title present in both the sidebar and on disk usually means the
+	// instance is unchanged, so we skip it. But when a session is killed and
+	// recreated under the same title via the CLI, the dead in-memory instance
+	// shadows the freshly created on-disk one: title-only membership makes the
+	// add pass skip it and the remove pass keep the corpse, leaving the new
+	// session invisible (#765). Reuse the same liveness/staleness check as
+	// mergePendingInstances — when the colliding sidebar instance is stale
+	// (different worktree, its tmux session is gone, or it was superseded by a
+	// more recently created on-disk record) swap it for the disk instance.
+	// Construct the replacement BEFORE removing the existing entry so a
+	// transient FromInstanceData failure can't drop it from disk on save.
 	for _, d := range diskData {
-		if !sidebarTitles[d.Title] {
-			inst, err := session.FromInstanceData(d)
-			if err != nil {
-				log.WarningLog.Printf("failed to restore external instance %q: %v", d.Title, err)
+		shouldReplace := false
+		if sidebarTitles[d.Title] {
+			skip := true
+			for _, existing := range m.sidebar.GetInstances() {
+				if existing.Title != d.Title {
+					continue
+				}
+				if !instanceCollisionShouldSkip(existing.GetWorktreePath(), d.Worktree.WorktreePath, existing.CreatedAt, d.CreatedAt, existing.TmuxAlive()) {
+					skip = false
+					shouldReplace = true
+				}
+				break
+			}
+			if skip {
 				continue
 			}
-			m.sidebar.AddInstance(inst)()
-			inst.SetAutoYes(m.autoYes)
-			changed = true
 		}
+
+		inst, err := session.FromInstanceData(d)
+		if err != nil {
+			log.WarningLog.Printf("failed to restore external instance %q: %v", d.Title, err)
+			// Leave any colliding sidebar instance untouched so SaveInstances
+			// does not drop it from disk.
+			continue
+		}
+
+		if shouldReplace {
+			log.InfoLog.Printf("swapping stale sidebar instance %q for recreated on-disk instance", d.Title)
+			m.sidebar.RemoveInstanceByTitle(d.Title)
+			delete(sidebarTitles, d.Title)
+		}
+
+		m.sidebar.AddInstance(inst)()
+		inst.SetAutoYes(m.autoYes)
+		sidebarTitles[d.Title] = true
+		changed = true
 	}
 
 	// Remove instances that exist in sidebar but not on disk.
@@ -313,19 +352,29 @@ func (m *home) refreshExternalInstances() bool {
 	return changed
 }
 
-// pendingInstanceCollisionShouldSkip decides whether to skip a pending
-// instance when an instance with the same title already exists in the
-// sidebar. It returns true when the pending instance should be skipped
-// (sidebar instance is still valid), false when the sidebar instance is
-// stale and should be replaced.
+// instanceCollisionShouldSkip decides whether to keep an existing sidebar
+// instance when an incoming on-disk or pending instance reuses its title. It
+// returns true when the incoming instance should be skipped (the sidebar
+// instance is still the authoritative live session), false when the sidebar
+// instance is stale and must be replaced.
 //
-// If both worktree paths are known and differ, the sidebar instance is
-// stale regardless of TmuxAlive() — a scheduled task rerun creates a new
-// worktree with a numeric suffix and a tmux session with the same name,
-// so TmuxAlive() would incorrectly report the sidebar instance as live.
+// The incoming instance supersedes the existing one when:
+//   - both worktree paths are known and differ — a scheduled task rerun
+//     creates a new worktree with a numeric suffix while reusing the tmux
+//     session name, so TmuxAlive() would wrongly report the sidebar instance
+//     as live (issue #255); or
+//   - the incoming record was created more recently — a CLI kill+recreate
+//     reuses the same title, and because both the worktree path and the tmux
+//     session name are derived deterministically from the title, the recreated
+//     session collides with the corpse on both. Neither worktree nor
+//     TmuxAlive() can then distinguish them; the newer CreatedAt can (#765).
+//
 // Otherwise, fall back to the tmuxAlive signal.
-func pendingInstanceCollisionShouldSkip(existingWorktreePath, pendingWorktreePath string, tmuxAlive bool) bool {
-	if existingWorktreePath != "" && pendingWorktreePath != "" && existingWorktreePath != pendingWorktreePath {
+func instanceCollisionShouldSkip(existingWorktreePath, incomingWorktreePath string, existingCreatedAt, incomingCreatedAt time.Time, tmuxAlive bool) bool {
+	if existingWorktreePath != "" && incomingWorktreePath != "" && existingWorktreePath != incomingWorktreePath {
+		return false
+	}
+	if incomingCreatedAt.After(existingCreatedAt) {
 		return false
 	}
 	return tmuxAlive

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -13,77 +13,122 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPendingInstanceCollisionShouldSkip covers the decision logic used by
-// mergePendingInstances when a scheduled-task rerun produces a pending
-// instance whose title collides with an existing sidebar instance. See
-// issue #255: a rerun recreates the same tmux session name under a new
-// worktree path, so TmuxAlive() alone cannot tell whether the sidebar
-// instance is still valid.
-func TestPendingInstanceCollisionShouldSkip(t *testing.T) {
+// TestInstanceCollisionShouldSkip covers the decision logic used by both
+// mergePendingInstances and refreshExternalInstances when an incoming on-disk
+// or pending instance reuses the title of an existing sidebar instance.
+//
+// Issue #255: a scheduled-task rerun recreates the same tmux session name
+// under a new worktree path, so TmuxAlive() alone cannot tell whether the
+// sidebar instance is still valid — the differing worktree must.
+//
+// Issue #765: a CLI kill+recreate reuses the title, and because the worktree
+// path and tmux session name are both derived deterministically from the
+// title, the recreated session collides with the corpse on both. Only the
+// newer CreatedAt distinguishes them.
+func TestInstanceCollisionShouldSkip(t *testing.T) {
+	// Default timestamps: incoming created at or before existing, so the
+	// CreatedAt rule never fires unless a case overrides it. Avoids
+	// time.Now() so the cases stay deterministic.
+	base := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+
 	cases := []struct {
 		name             string
 		existingWorktree string
-		pendingWorktree  string
+		incomingWorktree string
+		existingCreated  time.Time
+		incomingCreated  time.Time
 		tmuxAlive        bool
 		wantSkip         bool
 	}{
 		{
 			name:             "worktree paths differ and tmux alive -> replace (issue #255)",
 			existingWorktree: "/repo/worktrees/task",
-			pendingWorktree:  "/repo/worktrees/task-2",
+			incomingWorktree: "/repo/worktrees/task-2",
+			existingCreated:  base,
+			incomingCreated:  base,
 			tmuxAlive:        true,
 			wantSkip:         false,
 		},
 		{
 			name:             "worktree paths differ and tmux dead -> replace",
 			existingWorktree: "/repo/worktrees/task",
-			pendingWorktree:  "/repo/worktrees/task-2",
+			incomingWorktree: "/repo/worktrees/task-2",
+			existingCreated:  base,
+			incomingCreated:  base,
 			tmuxAlive:        false,
 			wantSkip:         false,
 		},
 		{
 			name:             "worktree paths match and tmux alive -> skip",
 			existingWorktree: "/repo/worktrees/task",
-			pendingWorktree:  "/repo/worktrees/task",
+			incomingWorktree: "/repo/worktrees/task",
+			existingCreated:  base,
+			incomingCreated:  base,
 			tmuxAlive:        true,
 			wantSkip:         true,
 		},
 		{
 			name:             "worktree paths match and tmux dead -> replace",
 			existingWorktree: "/repo/worktrees/task",
-			pendingWorktree:  "/repo/worktrees/task",
+			incomingWorktree: "/repo/worktrees/task",
+			existingCreated:  base,
+			incomingCreated:  base,
 			tmuxAlive:        false,
 			wantSkip:         false,
 		},
 		{
 			name:             "existing worktree unknown and tmux alive -> skip",
 			existingWorktree: "",
-			pendingWorktree:  "/repo/worktrees/task",
+			incomingWorktree: "/repo/worktrees/task",
+			existingCreated:  base,
+			incomingCreated:  base,
 			tmuxAlive:        true,
 			wantSkip:         true,
 		},
 		{
 			name:             "pending worktree unknown and tmux alive -> skip",
 			existingWorktree: "/repo/worktrees/task",
-			pendingWorktree:  "",
+			incomingWorktree: "",
+			existingCreated:  base,
+			incomingCreated:  base,
 			tmuxAlive:        true,
 			wantSkip:         true,
 		},
 		{
 			name:             "both worktrees unknown and tmux dead -> replace",
 			existingWorktree: "",
-			pendingWorktree:  "",
+			incomingWorktree: "",
+			existingCreated:  base,
+			incomingCreated:  base,
 			tmuxAlive:        false,
 			wantSkip:         false,
+		},
+		{
+			name:             "same worktree, tmux alive (name reused), incoming newer -> replace (issue #765)",
+			existingWorktree: "/repo/worktrees/task",
+			incomingWorktree: "/repo/worktrees/task",
+			existingCreated:  base,
+			incomingCreated:  base.Add(time.Minute),
+			tmuxAlive:        true,
+			wantSkip:         false,
+		},
+		{
+			name:             "same worktree, tmux alive, incoming same age -> skip (unchanged session)",
+			existingWorktree: "/repo/worktrees/task",
+			incomingWorktree: "/repo/worktrees/task",
+			existingCreated:  base,
+			incomingCreated:  base,
+			tmuxAlive:        true,
+			wantSkip:         true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := pendingInstanceCollisionShouldSkip(tc.existingWorktree, tc.pendingWorktree, tc.tmuxAlive)
+			got := instanceCollisionShouldSkip(tc.existingWorktree, tc.incomingWorktree, tc.existingCreated, tc.incomingCreated, tc.tmuxAlive)
 			if got != tc.wantSkip {
-				t.Fatalf("pendingInstanceCollisionShouldSkip(%q, %q, %v) = %v; want %v",
-					tc.existingWorktree, tc.pendingWorktree, tc.tmuxAlive, got, tc.wantSkip)
+				t.Fatalf("instanceCollisionShouldSkip(%q, %q, %v, %v, %v) = %v; want %v",
+					tc.existingWorktree, tc.incomingWorktree, tc.existingCreated, tc.incomingCreated, tc.tmuxAlive, got, tc.wantSkip)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes #765 — the TUI sidebar failed to show a session that was killed and recreated under the **same title** via the CLI. The dead instance stayed visible and the new running session was invisible (no attach/preview).

## Root cause

`refreshExternalInstances` (`app/sync.go`) reconciled the sidebar's in-memory instances against on-disk `instances.json` using **title-only set membership**. On a CLI kill→recreate-same-title with no intervening refresh, the title exists in both the sidebar and on disk, so:

- the *add* pass skipped the freshly-created on-disk record (`sidebarTitles[title]` already true), and
- the *remove* pass kept the dead in-memory instance (`diskTitles[title]` still true).

The corpse permanently shadowed the live session. Worse, the stale in-memory instance carries old metadata (base SHA, `created_at`, PR info); on the next `SaveInstances` it clobbers the daemon's fresh on-disk record.

The Detail report suggested reusing the existing liveness check, but that alone is **insufficient** here: the worktree path *and* the tmux session name are both derived deterministically from the title, so a recreate collides with the corpse on both. After recreate, the dead instance's `TmuxAlive()` even flips back to `true` because the tmux name is reused. I verified this empirically:

```
DISK worktree=/tmp/.../002-recreated  tmux=af_bd57e540_recreated
ORIG worktree=/tmp/.../002-recreated  alive=true   <-- identical, both "alive"
```

The distinguishing signal is **`CreatedAt`**: the recreated record is strictly newer.

## Fix

Generalized the existing `pendingInstanceCollisionShouldSkip` into `instanceCollisionShouldSkip`, adding a third supersede rule — *incoming record was created more recently* — and wired it into **both** `mergePendingInstances` and `refreshExternalInstances` so the two reconciliation paths handle same-title collisions identically (as the issue recommended). The replacement is constructed via `FromInstanceData` **before** the stale entry is removed, so a transient construction failure can't drop the entry from disk (same ordering discipline as the pending path, guarding #367).

For the normal steady state (unchanged session) `existing.CreatedAt == disk.CreatedAt`, so the new rule never fires and the 3-second refresh does not needlessly reconstruct/reattach live instances.

## Adjacent-call-site audit (per CLAUDE.md)

Grepped every sidebar sync/refresh/import path that matches by title:

| Site | Verdict |
|------|---------|
| `refreshExternalInstances` (`app/sync.go`) | **Fixed** — the reported bug. |
| `mergePendingInstances` (`app/sync.go`) | **Fixed/consistent** — already collision-aware via the shared helper; now also robust to identical-worktree recreate via `CreatedAt`. |
| `importRemoteHookSessions` (`app/sync.go`) | **Not vulnerable / out of scope** — remote sessions aren't created via the local kill+recreate CLI flow; identity also keys on `RemoteHookName`/slug, remote worktree paths aren't deterministically reused, and this importer only *adds* sessions that `list_cmd` reports live — it never persists stale in-memory data over a recreated record. |
| `saveRepoInstances` (`session/storage.go:244`, `!diskTitles[title] && !instance.TmuxAlive()`) | **Sufficient as-is** — this is the persist path, not sidebar reconciliation; it pairs title-absence with liveness to avoid resurrecting a dropped instance. After the swap, only the fresh instance reaches it. |
| `handleInput` title check (`app/handle_input.go:46`) | **Not applicable** — TUI create-time duplicate-title rejection, not disk reconciliation. |

## Test

Added `TestTUIRefreshSwapsKillRecreatedSameTitle` (real-backend integration test, alongside the existing `TestTUIRefreshSeesCLIChangesThroughDaemon`): create→import→`kill`→`create` same title with no intervening refresh, then assert `refreshExternalInstances` reports a change, the sidebar holds exactly one instance for the title, it is a **different** (live, attachable) instance than the dead original. Verified it **fails without** the `CreatedAt` signal and **passes with** it. Also extended the renamed `TestInstanceCollisionShouldSkip` table with the #765 cases (same worktree + alive + newer → replace; same age → skip).

## CI gates

- `gofmt -l .` — clean (empty)
- `go build ./...` — OK
- `go test ./...` — all pass except the known dev-box flake `daemon/TestSigtermFallback_DeadPID` (fails because real `af --daemon` processes are running on the box, not a code issue); the `app` package passes
- `go test -race ./app/...` — OK
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude
