### PR TITLE
fix(api/sessions): honor --repo scoping in send-prompt (#776)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -154,6 +154,28 @@ func findLiveInstanceByTitle(title string) (*session.Instance, string, error) {
 	return instance, repoID, nil
 }
 
+// instanceTitleExistsInScope reports whether a session with the given title
+// exists within the resolved repo scope (#776). An empty repoID preserves the
+// prior all-repo search; a non-empty one confines the check to that repo so a
+// same-titled session in a different repo can never satisfy the pre-check.
+// Mirrors how resolveRepoID() scopes the other sessions subcommands (list,
+// kill). This is a pure existence check: unlike findLiveInstanceByTitle it does
+// not restore (and Start) the instance, since callers only need to know whether
+// the title is taken in scope and the daemon does its own session restore on
+// delivery.
+func instanceTitleExistsInScope(repoID, title string) (bool, error) {
+	if repoID != "" {
+		return repoHasInstanceTitle(repoID, title)
+	}
+	if _, _, err := findInstanceByTitle(title); err != nil {
+		// findInstanceByTitle errors only on not-found / corruption; treat
+		// either as "not present in scope", matching the prior all-repo
+		// behavior where the pre-check error drove the create-vs-error branch.
+		return false, nil
+	}
+	return true, nil
+}
+
 // jsonOut marshals v to JSON and writes to stdout.
 func jsonOut(v any) error {
 	data, err := json.MarshalIndent(v, "", "  ")

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -285,8 +285,20 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 		title := args[0]
 		prompt := args[1]
 
-		_, _, err := findLiveInstanceByTitle(title)
+		// Honor --repo scoping (#776, follow-up to #761/#775). An empty repoID
+		// preserves the prior all-repo search; a non-empty one confines both
+		// the existence pre-check and the delivery to that repo so a
+		// same-titled session in a different repo never receives the prompt.
+		repoID, err := resolveRepoID()
 		if err != nil {
+			return jsonError(err)
+		}
+
+		exists, err := instanceTitleExistsInScope(repoID, title)
+		if err != nil {
+			return jsonError(err)
+		}
+		if !exists {
 			if !sendPromptCreateFlag {
 				return jsonError(fmt.Errorf("instance %q not found. Use --create to auto-create the session, or run: af sessions create --name %q --prompt <prompt>", title, title))
 			}
@@ -334,7 +346,7 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 			return jsonOut(map[string]bool{"ok": true})
 		}
 
-		if err := sendPromptViaDaemon(daemon.SendPromptRequest{Title: title, Prompt: prompt}); err != nil {
+		if err := sendPromptViaDaemon(daemon.SendPromptRequest{Title: title, RepoID: repoID, Prompt: prompt}); err != nil {
 			return jsonError(err)
 		}
 		return jsonOut(map[string]bool{"ok": true})

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -414,6 +414,102 @@ func TestSessionsKill_HonorsRepoScoping(t *testing.T) {
 	}
 }
 
+// TestSessionsSendPrompt_HonorsRepoScoping is the regression test for issue
+// #776 (follow-up to #761/#775). Two repos each hold a session with the same
+// title. Sending a prompt with `--repo <repoA>` must scope delivery to repo
+// A's session: the existence pre-check must look only in repo A, and the CLI
+// must pass repo A's RepoID to the daemon so a same-titled session in repo B
+// can never receive the prompt. Previously --repo was dropped on the floor and
+// the all-repo search could deliver to the wrong repo.
+func TestSessionsSendPrompt_HonorsRepoScoping(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	// Repo A is a real git repo so resolveRepoID(--repo) can compute its ID
+	// the same way the running CLI would.
+	repoARoot := filepath.Join(tmp, "repo-a")
+	if err := os.MkdirAll(repoARoot, 0755); err != nil {
+		t.Fatalf("mkdir repo A: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoARoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init repo A: %v (%s)", err, out)
+	}
+	repoA, err := config.RepoFromPath(repoARoot)
+	if err != nil {
+		t.Fatalf("RepoFromPath repo A: %v", err)
+	}
+
+	// Repo B is a distinct synthetic repo on disk holding a same-titled session.
+	repoBID := "repo-b-synthetic"
+	if repoBID == repoA.ID {
+		t.Fatalf("test setup: synthetic repo B ID collided with repo A")
+	}
+
+	const title = "shared-title"
+	const prompt = "do the thing"
+
+	rawA, err := json.Marshal([]session.InstanceData{{Title: title, Path: repoARoot}})
+	if err != nil {
+		t.Fatalf("marshal repo A instances: %v", err)
+	}
+	rawB, err := json.Marshal([]session.InstanceData{{Title: title, Path: tmp}})
+	if err != nil {
+		t.Fatalf("marshal repo B instances: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoA.ID, rawA); err != nil {
+		t.Fatalf("save repo A instances: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoBID, rawB); err != nil {
+		t.Fatalf("save repo B instances: %v", err)
+	}
+
+	// Point --repo at repo A and capture the request the CLI hands to the
+	// daemon. The daemon's findSession scopes on RepoID (proven elsewhere), so
+	// asserting the request carries repo A's RepoID proves the prompt can't be
+	// delivered to repo B's same-titled session.
+	prevRepoFlag := repoFlag
+	repoFlag = repoARoot
+	defer func() { repoFlag = prevRepoFlag }()
+
+	var gotReq daemon.SendPromptRequest
+	prevSend := sendPromptViaDaemon
+	sendPromptViaDaemon = func(req daemon.SendPromptRequest) error {
+		gotReq = req
+		if req.RepoID == "" {
+			return errors.New("RepoID empty: --repo scoping was dropped")
+		}
+		return nil
+	}
+	defer func() { sendPromptViaDaemon = prevSend }()
+
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devnull.Close()
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout = devnull
+	os.Stderr = devnull
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	if err := sessionsSendPromptCmd.RunE(sessionsSendPromptCmd, []string{title, prompt}); err != nil {
+		t.Fatalf("sessionsSendPromptCmd returned error: %v", err)
+	}
+
+	if gotReq.RepoID != repoA.ID {
+		t.Fatalf("send-prompt request RepoID = %q, want repo A %q", gotReq.RepoID, repoA.ID)
+	}
+	if gotReq.Title != title {
+		t.Fatalf("send-prompt request Title = %q, want %q", gotReq.Title, title)
+	}
+	if gotReq.Prompt != prompt {
+		t.Fatalf("send-prompt request Prompt = %q, want %q", gotReq.Prompt, prompt)
+	}
+}
+
 func stubKillSessionDirect() func() {
 	prev := killSessionViaDaemon
 	killSessionViaDaemon = func(req daemon.KillSessionRequest) error {


### PR DESCRIPTION
## Summary

`af sessions send-prompt <title> <prompt>` advertises the `sessions`
persistent `--repo` flag (`Path to git repository`) but **dropped it on
the floor**:

- the existence pre-check used the all-repo `findLiveInstanceByTitle`,
  which scans every repo for the first title match;
- the delivery call `sendPromptViaDaemon(SendPromptRequest{Title, Prompt})`
  never set `RepoID`, even though `daemon.SendPromptRequest` carries it and
  `Manager.findSession` honors it.

So when two repos hold a session with the same title,
`af sessions send-prompt T "..." --repo A` could deliver the prompt to
repo **B**'s session, and with `--create` the all-repo pre-check could see
repo B's `T` and wrongly skip creation in repo A. Not data-loss like
`kill`, but a wrong-target **write** that contradicts the `--repo` flag's
documented scoping and the behavior now established by `list`, `create`,
and `kill`.

This is the precedent set by **#761 → #775** (`sessions kill` honoring
`--repo`). The #775 adjacent-call-site audit explicitly named
`send-prompt` as the remaining mutating subcommand ignoring `--repo` and
filed it as the tracked follow-up — this PR.

## Fix

Mirrors #775: resolve `resolveRepoID()` and thread it through both the
existence pre-check and `SendPromptRequest.RepoID`.

- empty `RepoID` (no `--repo`, cwd not a repo) → unchanged all-repo
  behavior, no regression for existing single-repo workflows;
- non-empty `RepoID` → the existence check is confined to that repo and
  the daemon's `findSession` confines delivery, so a same-titled session
  elsewhere is never touched.

No daemon change needed — `findSession(title, repoID)` already scopes on
a non-empty `RepoID` (`daemon/control.go`).

### Pre-check is now a pure existence check

The pre-check switched from `findLiveInstanceByTitle` to a new
`instanceTitleExistsInScope`. The old call ran
`session.FromInstanceData → instance.Start()` and then **discarded** the
restored instance — the daemon does its own session restore on delivery,
so the CLI-side restore was wasted work that also made the command slow
and unit-untestable (`Start()` blocks ~3s waiting for a real tmux
session). The new helper only answers "is this title taken in scope",
which is all the create-vs-error branch needs. Error/corruption is treated
as "not present", matching the prior all-repo behavior where the pre-check
error drove that branch.

## Adjacent-call-site audit

Re-confirming the #775 table — `send-prompt` was the last **mutating**
gap:

| Subcommand | Repo scoping | Notes |
|---|---|---|
| `list` | ✅ `resolveRepoID()` | reference behavior |
| `create` | ✅ `resolveRepo()` (required) | always repo-scoped |
| `kill` | ✅ `resolveRepoID()` (#775) | data-loss bug, fixed |
| `send-prompt` | ✅ **fixed here** | mutating, was the wrong-target write |
| `whoami` | n/a | no title arg; matches by tmux session name |
| `get` | ⚠️ all-repo | read-only; first title match |
| `preview` | ⚠️ all-repo | read-only |
| `attach` | ⚠️ all-repo | read-only |

With this PR **every mutating `sessions` subcommand honors `--repo`.** The
remaining `get`/`preview`/`attach` are read-only — they return/attach to
the wrong session's *view* but cause no loss or wrong-target write, so
they stay out of scope (tracked, lower priority), exactly as #775 framed
them.

## Test

`TestSessionsSendPrompt_HonorsRepoScoping` mirrors
`TestSessionsKill_HonorsRepoScoping`: a same-titled session in two repos
(repo A a real `git init`, repo B synthetic on disk), runs
`send-prompt --repo <repoA>`, and asserts the request the CLI hands to the
daemon carries repo A's `RepoID` (an empty one would mean `--repo` was
dropped) plus the correct title and prompt. The daemon's `findSession`
scopes on `RepoID` (proven separately), so this proves repo B's
same-titled session can never receive the prompt.

## Verification

- `go build ./...` ✅
- `go test ./api/...` (incl. `-race`) ✅
- `gofmt -l .` clean ✅
- `golangci-lint run --timeout=3m --fast` clean ✅
- `deadcode -test ./...` clean ✅

One unrelated full-suite failure was confirmed environmental, not from
this change: `daemon/TestSigtermFallback_DeadPID` (known flake — real
`af --daemon` processes on the dev box, see the test output naming live
PIDs).

Fixes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude