### PR TITLE
fix(config,session/storage): surface transient read errors instead of silently returning empty session list (#766)

### DIFF
--- a/config/state.go
+++ b/config/state.go
@@ -20,7 +20,13 @@ type InstanceStorage interface {
 	// SaveInstances saves the raw instance data for a specific repo.
 	SaveInstances(repoID string, instancesJSON json.RawMessage) error
 	// GetInstances returns the raw instance data for a specific repo.
-	GetInstances(repoID string) json.RawMessage
+	//
+	// A missing instances file yields "[]" with a nil error so first-run
+	// callers proceed normally. Any other failure (permission denied,
+	// I/O/NFS error, truncation) is PROPAGATED rather than masked as an
+	// empty list — read-modify-write callers must not merge against, and
+	// then overwrite, disk state they failed to read (#766).
+	GetInstances(repoID string) (json.RawMessage, error)
 	// GetAllInstances returns instance data for all repos, keyed by repo ID.
 	GetAllInstances() map[string]json.RawMessage
 	// DeleteAllInstances removes all stored instances across all repos.
@@ -253,13 +259,12 @@ func (s *State) SaveInstances(repoID string, instancesJSON json.RawMessage) erro
 	return SaveRepoInstances(repoID, instancesJSON)
 }
 
-func (s *State) GetInstances(repoID string) json.RawMessage {
-	data, err := LoadRepoInstances(repoID)
-	if err != nil {
-		log.ErrorLog.Printf("failed to load repo instances: %v", err)
-		return json.RawMessage("[]")
-	}
-	return data
+func (s *State) GetInstances(repoID string) (json.RawMessage, error) {
+	// LoadRepoInstances already distinguishes "missing file" (-> "[]", nil)
+	// from a genuine read error, so surface its result verbatim. Swallowing
+	// the error here is what let saveRepoInstances merge against an empty
+	// disk state and clobber unreadable-but-present sessions (#766).
+	return LoadRepoInstances(repoID)
 }
 
 func (s *State) GetAllInstances() map[string]json.RawMessage {

--- a/config/state_test.go
+++ b/config/state_test.go
@@ -116,6 +116,34 @@ func TestLoadSaveRepoInstances_RejectsTraversal(t *testing.T) {
 	assert.Equal(t, originalBytes, after, "sentinel file should not have been modified")
 }
 
+// TestLoadRepoInstances_SurfacesReadError verifies that an existing-but-
+// unreadable instances.json produces an error rather than a silent empty list.
+// This is the load-side guarantee behind #766: callers must be able to tell
+// "no sessions" apart from "couldn't read sessions" so read-modify-write paths
+// don't clobber present-but-unreadable data. A missing file is a separate case
+// (covered elsewhere) and must continue to yield "[]" with no error.
+func TestLoadRepoInstances_SurfacesReadError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-based permission denial is ineffective when running as root")
+	}
+	tempHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tempHome)
+
+	repoID := RepoIDFromRoot("/path/to/repo")
+	require.NoError(t, SaveRepoInstances(repoID, json.RawMessage(`[{"title":"keep-me"}]`)))
+
+	path, err := repoInstancesPath(repoID)
+	require.NoError(t, err)
+
+	// Make the file unreadable, simulating a transient permission/I/O error.
+	require.NoError(t, os.Chmod(path, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	_, err = LoadRepoInstances(repoID)
+	require.Error(t, err, "an unreadable instances.json must surface an error, not an empty list")
+	assert.False(t, os.IsNotExist(err), "error must be a read/permission failure, not a missing-file case")
+}
+
 // TestSaveRepoInstances_RoundTrip is a smoke test that the legitimate path
 // still works end-to-end after the validation change.
 func TestSaveRepoInstances_RoundTrip(t *testing.T) {

--- a/session/storage.go
+++ b/session/storage.go
@@ -144,8 +144,16 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 			return pathErr
 		}
 		if err := config.WithFileLock(path, func() error {
-			// Read existing disk state inside the lock.
-			diskJSON := s.state.GetInstances(rid)
+			// Read existing disk state inside the lock. A genuine read
+			// failure (permission denied, I/O error) must abort this repo's
+			// save: merging against the empty list GetInstances used to
+			// return would overwrite instances.json and permanently drop
+			// sessions that are present on disk but momentarily unreadable
+			// (#766). Missing files still come back as "[]" with a nil error.
+			diskJSON, err := s.state.GetInstances(rid)
+			if err != nil {
+				return fmt.Errorf("refusing to overwrite repo %s: failed to read existing instances: %w", rid, err)
+			}
 			var diskData []InstanceData
 			if diskJSON != nil && string(diskJSON) != "[]" && string(diskJSON) != "null" {
 				if err := json.Unmarshal(diskJSON, &diskData); err != nil {
@@ -213,7 +221,13 @@ func (s *Storage) saveRepoInstances(instances []*Instance) error {
 		return pathErr
 	}
 	return config.WithFileLock(path, func() error {
-		raw := s.state.GetInstances(s.repoID)
+		// A transient read failure must not be mistaken for "no sessions":
+		// merging against an empty disk state and writing the result back
+		// would clobber the unreadable-but-present instances.json (#766).
+		raw, err := s.state.GetInstances(s.repoID)
+		if err != nil {
+			return fmt.Errorf("refusing to overwrite repo %s: failed to read existing instances: %w", s.repoID, err)
+		}
 		var diskData []InstanceData
 		if raw != nil && string(raw) != "[]" && string(raw) != "null" {
 			if err := json.Unmarshal(raw, &diskData); err != nil {
@@ -276,8 +290,13 @@ func (s *Storage) saveRepoInstances(instances []*Instance) error {
 func (s *Storage) LoadInstances() ([]*Instance, error) {
 	var allJSON map[string]json.RawMessage
 	if s.repoID != "" {
-		// TUI mode: load just this repo
-		raw := s.state.GetInstances(s.repoID)
+		// TUI mode: load just this repo. Surface read errors so startup can
+		// report "couldn't read your sessions" instead of silently showing
+		// an empty list that looks like a fresh install (#766).
+		raw, err := s.state.GetInstances(s.repoID)
+		if err != nil {
+			return nil, err
+		}
 		allJSON = map[string]json.RawMessage{s.repoID: raw}
 	} else {
 		// Daemon mode: load all repos
@@ -318,7 +337,10 @@ func (s *Storage) DeleteInstance(title string) error {
 		return pathErr
 	}
 	return config.WithFileLock(path, func() error {
-		raw := s.state.GetInstances(s.repoID)
+		raw, err := s.state.GetInstances(s.repoID)
+		if err != nil {
+			return err
+		}
 		if raw == nil || string(raw) == "[]" || string(raw) == "null" {
 			return fmt.Errorf("instance not found: %s", title)
 		}
@@ -354,7 +376,10 @@ func (s *Storage) DeleteInstance(title string) error {
 // constructing live Instance objects (no tmux session restoration).
 // Used for lightweight comparison against in-memory state.
 func (s *Storage) LoadInstanceData() ([]InstanceData, error) {
-	raw := s.state.GetInstances(s.repoID)
+	raw, err := s.state.GetInstances(s.repoID)
+	if err != nil {
+		return nil, err
+	}
 	if raw == nil || string(raw) == "[]" || string(raw) == "null" {
 		return nil, nil
 	}

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +17,9 @@ import (
 type mockInstanceStorage struct {
 	mu   sync.Mutex
 	data map[string]json.RawMessage
+	// readErr, when non-nil, makes GetInstances fail to simulate a transient
+	// read failure (permission denied, I/O error) on instances.json.
+	readErr error
 }
 
 func newMockStorage() *mockInstanceStorage {
@@ -29,10 +33,13 @@ func (m *mockInstanceStorage) SaveInstances(repoID string, instancesJSON json.Ra
 	return nil
 }
 
-func (m *mockInstanceStorage) GetInstances(repoID string) json.RawMessage {
+func (m *mockInstanceStorage) GetInstances(repoID string) (json.RawMessage, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.data[repoID]
+	if m.readErr != nil {
+		return nil, m.readErr
+	}
+	return m.data[repoID], nil
 }
 
 func (m *mockInstanceStorage) GetAllInstances() map[string]json.RawMessage {
@@ -286,6 +293,40 @@ func TestDaemonSaveCrossRepoTitleCollision(t *testing.T) {
 	}
 	assert.True(t, titlesB["other-b"], "repo B's in-memory instance should be saved")
 	assert.True(t, titlesB["shared"], "repo B's externally-added instance with title colliding with a different repo's daemon instance must be preserved")
+}
+
+// TestRepoSaveAbortsOnReadError is the core regression test for #766. When the
+// existing instances.json cannot be read (a transient permission/I/O error, as
+// opposed to a missing file), saveRepoInstances must NOT treat disk as empty
+// and merge-then-overwrite — that silently and permanently drops sessions that
+// are present on disk. The save must surface the error and leave disk untouched.
+func TestRepoSaveAbortsOnReadError(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	repoID := config.RepoIDFromRoot(repoPath)
+	ms := newMockStorage()
+
+	// Seed disk with a real, present-on-disk session.
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "on-disk", Path: repoPath, Status: Running},
+	})
+	// Snapshot the exact bytes so we can prove they are untouched afterwards.
+	before := append(json.RawMessage(nil), ms.data[repoID]...)
+
+	// Reads now fail (e.g. EACCES / EIO on instances.json).
+	ms.readErr = errors.New("permission denied")
+
+	// The TUI has a different session in memory; a naive merge against an
+	// empty disk state would write only this one and erase "on-disk".
+	inMem := makeInstance("in-memory", repoPath, true)
+	storage, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{inMem})
+	require.Error(t, err, "SaveInstances must surface the read error instead of overwriting disk")
+
+	// Disk bytes must be exactly what we seeded — no empty/partial overwrite.
+	assert.Equal(t, string(before), string(ms.data[repoID]),
+		"on-disk session data must be preserved when the existing file cannot be read (#766)")
 }
 
 func TestDaemonSaveNoInstances(t *testing.T) {


### PR DESCRIPTION
## Root cause (data loss)

`config.State.GetInstances` mapped **every** `LoadRepoInstances` failure — permission denied, disk/NFS I/O errors, truncation, transient file locks — to the JSON value `[]`, logging and swallowing the error:

```go
func (s *State) GetInstances(repoID string) json.RawMessage {
    data, err := LoadRepoInstances(repoID)
    if err != nil {
        log.ErrorLog.Printf("failed to load repo instances: %v", err)
        return json.RawMessage("[]")   // <-- indistinguishable from "no sessions"
    }
    return data
}
```

`session/storage.go`'s save paths are **read-modify-write**: they read the existing `instances.json`, merge it with in-memory state, and write the result back. When the read silently became `[]`, the merge treated disk as empty and wrote out only the in-memory instances — **permanently overwriting sessions that were present on disk but momentarily unreadable.** This is real, irreversible data loss, not a cosmetic glitch.

Secondary impact: TUI startup (`Storage.LoadInstances`) showed an empty session list on a transient read error, indistinguishable from a fresh install.

## The missing-vs-unreadable distinction

`config.LoadRepoInstances` was already correct — it returns `"[]"` with a nil error only for `os.IsNotExist`, and propagates every other read error. The bug lived entirely in the `GetInstances` wrapper that discarded that distinction.

This PR changes `GetInstances` to `(json.RawMessage, error)` and returns `LoadRepoInstances`'s result verbatim:
- **missing file** → `"[]"`, nil error → first-run experience preserved (required).
- **exists but unreadable / parse error** → error propagated → caller must not save empty back over it.

Every per-repo read in `session/storage.go` now propagates the error. The two read-modify-write save paths abort instead of overwriting:
- `saveRepoInstances` (TUI mode) — returns `refusing to overwrite repo %s: failed to read existing instances` and never writes.
- the daemon `SaveInstances` merge loop — same guard inside the per-repo file lock; a read failure aborts the save rather than zeroing that repo's file.
- `DeleteInstance` and `LoadInstanceData` (also read per-repo state) propagate too, for consistency.

This mirrors the warn-and-preserve pattern established in `aaf407c` (#730/#736), which bypassed `GetInstances` and called `LoadRepoInstances` directly in `api/sessions.go`, `daemon/daemon.go`, and `daemon/control.go`. `session/storage.go` was the remaining caller still routing through the swallowing wrapper.

## Adjacent-call-site audit (per CLAUDE.md)

Every caller that reads per-repo instance state and then writes:

| Call site | Read path | Verdict |
|---|---|---|
| `session/storage.go` saveRepoInstances (TUI RMW) | `state.GetInstances` | **Fixed** — was the data-loss path |
| `session/storage.go` SaveInstances daemon merge loop (RMW) | `state.GetInstances` | **Fixed** — aborts per-repo on read error |
| `session/storage.go` DeleteInstance (RMW) | `state.GetInstances` | **Fixed** — propagates |
| `session/storage.go` LoadInstances (TUI read) / LoadInstanceData | `state.GetInstances` | **Fixed** — propagates (fixes silent-empty startup) |
| `task/runner.go` NextTaskRunTitle (RMW under lock) | `config.LoadRepoInstances` directly | Already correct — propagates |
| `daemon/control.go` loadRepoInstanceData / save RMWs | `config.LoadRepoInstances` directly | Already correct — propagates |
| `api/sessions.go` sessions list (per-repo branch) | `config.LoadRepoInstances` directly | Already correct — propagates |

### Explicitly out of scope: `LoadAllRepoInstances`

The aggregate daemon path (`LoadAllRepoInstances` / `loadAllInstancesAggregate`, consumed by `Storage.GetAllInstances`, `daemon/daemon.go`, `api/api.go`) was **already** hardened by #730: it logs and skips a single bad repo without zeroing the others. Touching it here would risk regressing that behavior, so `GetAllInstances` is intentionally left unchanged.

## Tests

- `session/storage_test.go` → `TestRepoSaveAbortsOnReadError`: seeds the mock disk with a present session, sets the mock to fail reads, calls `SaveInstances` on the per-repo path, and asserts (a) `SaveInstances` returns an error **and** (b) the on-disk bytes are byte-for-byte unchanged.
- `config/state_test.go` → `TestLoadRepoInstances_SurfacesReadError`: writes a valid `instances.json`, `chmod 000`s it (root-guarded skip), and asserts `LoadRepoInstances` surfaces a non-`IsNotExist` error.

All four CI gates pass locally (`go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `go test ./...`), plus `deadcode -test ./...` and `go test -race ./...`. The only failing test on the dev box is the pre-existing `daemon/TestSigtermFallback_DeadPID` flake caused by real `af --daemon` processes running locally — unrelated to this change.

Fixes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude