### PR TITLE
fix(session/tmux): omit nil cleanup error from timeout message (#696)

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -231,10 +231,11 @@ func (t *TmuxSession) Start(workDir string) error {
 		select {
 		case <-timeout:
 			ptmx.Close()
+			timeoutErr := fmt.Errorf("timed out waiting for tmux session %s", t.sanitizedName)
 			if cleanupErr := t.Close(); cleanupErr != nil {
-				err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
+				timeoutErr = fmt.Errorf("%v (cleanup error: %v)", timeoutErr, cleanupErr)
 			}
-			return fmt.Errorf("timed out waiting for tmux session %s: %v", t.sanitizedName, err)
+			return timeoutErr
 		default:
 			time.Sleep(sleepDuration)
 			// Exponential backoff up to 50ms max

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -265,6 +265,60 @@ func TestStartTmuxSession(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestStartTimeoutCleanupSucceeds guards issue #696: when the session never
+// appears before the startup timeout and cleanup succeeds, the error must
+// describe the timeout without rendering a nil error as the literal "<nil>".
+func TestStartTimeoutCleanupSucceeds(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			// Session never appears; kill-session (cleanup) succeeds.
+			if strings.Contains(cmd.String(), "has-session") {
+				return fmt.Errorf("session not found")
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+	}
+
+	session := newTmuxSession(toTmuxName("timeout-ok", ""), "claude", ptyFactory, cmdExec)
+
+	err := session.Start(t.TempDir())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out waiting for tmux session af_timeout-ok")
+	require.NotContains(t, err.Error(), "<nil>")
+	require.NotContains(t, err.Error(), "cleanup error")
+}
+
+// TestStartTimeoutCleanupFails is the companion to the #696 guard: when
+// cleanup also fails, the timeout error must include the cleanup cause.
+func TestStartTimeoutCleanupFails(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				return fmt.Errorf("session not found")
+			}
+			if strings.Contains(cmd.String(), "kill-session") {
+				return fmt.Errorf("kill-session exploded")
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+	}
+
+	session := newTmuxSession(toTmuxName("timeout-bad", ""), "claude", ptyFactory, cmdExec)
+
+	err := session.Start(t.TempDir())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out waiting for tmux session af_timeout-bad")
+	require.Contains(t, err.Error(), "cleanup error")
+	require.Contains(t, err.Error(), "kill-session exploded")
+	require.NotContains(t, err.Error(), "<nil>")
+}
+
 // captureErrorLog redirects log.ErrorLog at the test's ErrorLog into the
 // returned buffer for the duration of the test, restoring the previous
 // destination on cleanup.


### PR DESCRIPTION
## Summary

When `TmuxSession.Start()`'s session-existence poll timed out, the error path formatted a nil `err` with `%v`, producing operator-facing messages like:

```
timed out waiting for tmux session af_xxx: <nil>
```

`err` was only assigned when cleanup failed, so the common case (cleanup succeeds) rendered Go's nil. The fix builds the timeout error from a descriptive base and appends the cleanup error only when cleanup actually fails:

- cleanup succeeds → `timed out waiting for tmux session af_xxx`
- cleanup fails → `timed out waiting for tmux session af_xxx (cleanup error: ...)`

## Adjacent-site audit

Grepped all `(cleanup error: %v)` sites repo-wide. The other two in `session/tmux/tmux.go` (pty-start failure, restore failure) and all three in `session/backend_local.go` are reached only with a non-nil base error, so this was the lone instance of the anti-pattern.

## Testing

- New regression tests `TestStartTimeoutCleanupSucceeds` (asserts no `<nil>` and no spurious cleanup clause) and `TestStartTimeoutCleanupFails` (asserts the cleanup cause is included).
- `gofmt -l .` clean, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` all pass.
- `go test ./...` green except the known dev-box flake `daemon/TestSigtermFallback_DeadPID` (caused by real running `af --daemon` processes on the test machine, unrelated to this change).
- `go test -race ./session/tmux/` passes.

Fixes #696

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)