### PR TITLE
fix(session/git): use gh pr list --head to avoid numeric-branch-as-PR-number ambiguity (#740)

### DIFF
--- a/session/git/github.go
+++ b/session/git/github.go
@@ -15,13 +15,21 @@ type PRInfo struct {
 	State  string `json:"state"`
 }
 
-// FetchPRInfo runs `gh pr view` to look up a PR for the given branch.
+// FetchPRInfo runs `gh pr list --head <branch>` to look up a PR for the
+// given branch. `--head` always treats its argument as a branch name, unlike
+// `gh pr view <arg>` which disambiguates an all-numeric argument as a PR
+// NUMBER — so a branch named "123" used to resolve to PR #123 (#740).
+//
+// `--state all` plus the open-first selection in parsePRList mirrors how
+// `gh pr view <branch>` resolves a branch: prefer the open PR, but still
+// surface a merged/closed one so the sidebar keeps showing a session's PR
+// after it merges.
 //
 // It returns (nil, nil) — not an error — whenever there is no PR to look up.
 // That covers three by-design cases:
 //   - an empty branch name (a detached-HEAD worktree has no branch to query),
 //   - the `gh` binary not being installed,
-//   - `gh` reporting that the branch has no associated PR.
+//   - no PR existing for the branch (`gh pr list` prints an empty array).
 //
 // A non-nil error is reserved for genuine failures (e.g. a transient `gh`
 // error or malformed output) so callers can preserve previously cached PR
@@ -35,34 +43,40 @@ func FetchPRInfo(repoPath, branchName string) (*PRInfo, error) {
 		return nil, nil
 	}
 
-	cmd := exec.Command("gh", "pr", "view", branchName, "--json", "number,title,url,state")
+	cmd := exec.Command("gh", "pr", "list", "--head", branchName, "--state", "all",
+		"--json", "number,title,url,state", "--limit", "10")
 	cmd.Dir = repoPath
 	out, err := cmd.Output()
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			stderr := string(exitErr.Stderr)
-			if strings.Contains(stderr, "no pull requests found") ||
-				strings.Contains(stderr, "Could not resolve to a PullRequest") {
-				return nil, nil // genuinely no PR
-			}
-		}
 		return nil, fmt.Errorf("failed to fetch PR info: %w", err)
 	}
 
-	return parsePRInfo(out)
+	return parsePRList(out)
 }
 
-// parsePRInfo parses the JSON output from `gh pr view`.
-// Returns (nil, nil) only when the output clearly indicates no PR exists
-// (i.e. PR number of 0). On malformed JSON it returns an error so that
-// callers preserve previously cached PR info rather than clearing it.
-func parsePRInfo(out []byte) (*PRInfo, error) {
-	var info PRInfo
-	if err := json.Unmarshal(out, &info); err != nil {
+// parsePRList parses the JSON array output from `gh pr list` and selects the
+// PR to display: the first open PR if one exists, otherwise the first entry
+// (gh orders by creation date, newest first). Returns (nil, nil) when the
+// array is empty, i.e. the branch has no PR. On malformed JSON it returns an
+// error so that callers preserve previously cached PR info rather than
+// clearing it.
+func parsePRList(out []byte) (*PRInfo, error) {
+	var prs []PRInfo
+	if err := json.Unmarshal(out, &prs); err != nil {
 		return nil, fmt.Errorf("failed to parse PR info JSON: %w", err)
 	}
-	if info.Number == 0 {
+	if len(prs) == 0 {
 		return nil, nil
 	}
-	return &info, nil
+	selected := prs[0]
+	for _, pr := range prs {
+		if strings.EqualFold(pr.State, "OPEN") {
+			selected = pr
+			break
+		}
+	}
+	if selected.Number == 0 {
+		return nil, nil
+	}
+	return &selected, nil
 }

--- a/session/git/github_test.go
+++ b/session/git/github_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -20,7 +21,47 @@ func TestFetchPRInfo_EmptyBranch(t *testing.T) {
 	}
 }
 
-func TestParsePRInfo(t *testing.T) {
+// TestFetchPRInfo_NumericBranch_UsesHeadFlag guards the #740 fix: the lookup
+// must run `gh pr list --head <branch>` (which always treats its argument as
+// a branch name) rather than `gh pr view <branch>` (which parses an
+// all-numeric argument as a PR NUMBER, so branch "123" resolved to PR #123).
+// A stub `gh` on PATH records its argv so the test asserts the exact command
+// shape without any network access.
+func TestFetchPRInfo_NumericBranch_UsesHeadFlag(t *testing.T) {
+	dir := t.TempDir()
+	argvFile := dir + "/argv"
+	stub := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argvFile + "\necho '[]'\n"
+	if err := os.WriteFile(dir+"/gh", []byte(stub), 0o755); err != nil {
+		t.Fatalf("failed to write gh stub: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	info, err := FetchPRInfo(dir, "123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info != nil {
+		t.Errorf("empty pr list should yield nil PRInfo, got %+v", info)
+	}
+
+	argv, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatalf("gh stub was not invoked: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(argv)), "\n")
+	joined := strings.Join(args, " ")
+	if len(args) < 2 || args[0] != "pr" || args[1] != "list" {
+		t.Errorf("expected `gh pr list ...`, got `gh %s`", joined)
+	}
+	if !strings.Contains(joined, "--head 123") {
+		t.Errorf("expected `--head 123` in argv, got `gh %s`", joined)
+	}
+	if !strings.Contains(joined, "--state all") {
+		t.Errorf("expected `--state all` so merged/closed PRs stay visible, got `gh %s`", joined)
+	}
+}
+
+func TestParsePRList(t *testing.T) {
 	tests := []struct {
 		name       string
 		input      string
@@ -29,8 +70,8 @@ func TestParsePRInfo(t *testing.T) {
 		wantErrSub string
 	}{
 		{
-			name:  "valid PR JSON",
-			input: `{"number":42,"title":"Add feature","url":"https://example.com/pr/42","state":"OPEN"}`,
+			name:  "single open PR",
+			input: `[{"number":42,"title":"Add feature","url":"https://example.com/pr/42","state":"OPEN"}]`,
 			wantInfo: &PRInfo{
 				Number: 42,
 				Title:  "Add feature",
@@ -39,8 +80,35 @@ func TestParsePRInfo(t *testing.T) {
 			},
 		},
 		{
+			name:     "empty array is treated as no PR",
+			input:    `[]`,
+			wantInfo: nil,
+		},
+		{
+			name: "open PR preferred over newer merged PR",
+			input: `[{"number":50,"title":"Reopened work","url":"https://example.com/pr/50","state":"MERGED"},` +
+				`{"number":42,"title":"Add feature","url":"https://example.com/pr/42","state":"OPEN"}]`,
+			wantInfo: &PRInfo{
+				Number: 42,
+				Title:  "Add feature",
+				URL:    "https://example.com/pr/42",
+				State:  "OPEN",
+			},
+		},
+		{
+			name: "no open PR falls back to first (newest) entry",
+			input: `[{"number":50,"title":"Shipped","url":"https://example.com/pr/50","state":"MERGED"},` +
+				`{"number":42,"title":"Abandoned","url":"https://example.com/pr/42","state":"CLOSED"}]`,
+			wantInfo: &PRInfo{
+				Number: 50,
+				Title:  "Shipped",
+				URL:    "https://example.com/pr/50",
+				State:  "MERGED",
+			},
+		},
+		{
 			name:     "zero PR number is treated as no PR",
-			input:    `{"number":0,"title":"","url":"","state":""}`,
+			input:    `[{"number":0,"title":"","url":"","state":""}]`,
 			wantInfo: nil,
 		},
 		{
@@ -57,7 +125,13 @@ func TestParsePRInfo(t *testing.T) {
 		},
 		{
 			name:       "truncated JSON returns error",
-			input:      `{"number":42,"title":"Add feat`,
+			input:      `[{"number":42,"title":"Add feat`,
+			wantErr:    true,
+			wantErrSub: "failed to parse PR info JSON",
+		},
+		{
+			name:       "single object (gh pr view shape) returns error",
+			input:      `{"number":42,"title":"Add feature","url":"https://example.com/pr/42","state":"OPEN"}`,
 			wantErr:    true,
 			wantErrSub: "failed to parse PR info JSON",
 		},
@@ -65,7 +139,7 @@ func TestParsePRInfo(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parsePRInfo([]byte(tc.input))
+			got, err := parsePRList([]byte(tc.input))
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil (info=%v)", got)


### PR DESCRIPTION
## Summary

`FetchPRInfo` looked up a branch's PR with `gh pr view <branch>`. The GitHub CLI disambiguates an all-numeric positional argument as a **PR number**, so a branch named `123` (reachable with an empty `branch_prefix` config plus a numeric session name) resolved to PR #123 — wrong PR info or an error in the sidebar.

The lookup now uses `gh pr list --head <branch> --state all --json number,title,url,state --limit 10`, where `--head` always treats its argument as a branch name.

## Behavior preserved

- `--state all` plus open-first selection in the new `parsePRList` mirrors how `gh pr view <branch>` resolves a branch (prefer the open PR, otherwise fall back to the newest entry), so a session's merged PR stays visible in the sidebar after merge.
- The #694 contract is unchanged: `(nil, nil)` for empty branch, missing `gh` binary, or no PR (now signaled by an empty JSON array instead of a stderr match); errors only for genuine failures so callers keep cached PR info.

## Call-site audit

`session/git/github.go` was the only `gh pr view` invocation in the codebase; remaining mentions are comments referring to this fetch path (left as-is — they describe the PR-info fetch generically).

## Testing

- New `TestFetchPRInfo_NumericBranch_UsesHeadFlag`: a stub `gh` on `PATH` records argv; asserts `gh pr list` with `--head 123` and `--state all` (no positional branch arg).
- `TestParsePRList` covers: single open PR, empty array → no PR, open preferred over newer merged, fallback to newest when none open, zero number, malformed/truncated/empty JSON, and the old `gh pr view` single-object shape (now an error).
- `gofmt -l`, `go build ./...`, `go test ./...`, `golangci-lint run --fast`, `deadcode -test ./...` all clean; `go test -race ./session/git/ ./app/` passes. (The only suite failure is the known dev-box `daemon/TestSigtermFallback_DeadPID` flake from live `af --daemon` processes.)

Fixes #740

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)