### PR TITLE
fix(config): detect bash aliases for claude during default config generation (#688)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -21,6 +23,10 @@ const (
 )
 
 var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|->|^[^/=\s]+\s*=)\s*(.+)`)
+
+// bashTypeOutputRegex matches the bash `type` builtin's output for a
+// PATH-resolved command, e.g. "claude is /usr/local/bin/claude".
+var bashTypeOutputRegex = regexp.MustCompile(`^\S+ is (/.+)$`)
 
 // GetConfigDir returns the path to the application's configuration directory.
 // If AGENT_FACTORY_HOME is set, it is used as the config directory.
@@ -162,8 +168,16 @@ func DefaultConfig() *Config {
 	}
 
 	if claudePath, err := GetClaudeCommand(); err == nil && claudePath != "" {
+		// An alias can resolve to a full command with flags (e.g. "claude
+		// --model opus"), which is already shell syntax and must not be
+		// re-quoted wholesale. Only a bare path that exists on disk gets the
+		// space/apostrophe quoting treatment (#569).
+		command := claudePath
+		if _, statErr := os.Stat(claudePath); statErr == nil {
+			command = shellQuotePath(claudePath)
+		}
 		cfg.ProgramOverrides = map[string]string{
-			tmux.ProgramClaude: shellQuotePath(claudePath) + " --dangerously-skip-permissions",
+			tmux.ProgramClaude: command + " --dangerously-skip-permissions",
 		}
 	} else if err != nil {
 		log.ErrorLog.Printf("failed to get claude command: %v", err)
@@ -188,7 +202,7 @@ func shellQuotePath(path string) string {
 
 // GetClaudeCommand attempts to find the "claude" command in the user's shell
 // It checks in the following order:
-// 1. Shell alias resolution: using "which" command
+// 1. Shell alias resolution (zsh's `which` builtin, bash's `type` builtin)
 // 2. PATH lookup
 //
 // If both fail, it returns an error.
@@ -198,31 +212,29 @@ func GetClaudeCommand() (string, error) {
 		shell = "/bin/bash" // Default to bash if SHELL is not set
 	}
 
-	// Force the shell to load the user's profile and then run the command
-	// For zsh, source .zshrc; for bash, source .bashrc
-	var shellCmd string
+	var args []string
 	if strings.Contains(shell, "zsh") {
-		shellCmd = "source ~/.zshrc &>/dev/null || true; which claude"
+		// zsh's `which` is a builtin that reports aliases ("claude: aliased
+		// to ..."), so sourcing the rc file is enough to surface them.
+		args = []string{"-c", "source ~/.zshrc &>/dev/null || true; which claude"}
 	} else if strings.Contains(shell, "bash") {
-		shellCmd = "source ~/.bashrc &>/dev/null || true; which claude"
+		// bash needs an interactive shell for alias detection: the external
+		// `which` binary cannot see aliases at all, and distro ~/.bashrc
+		// files typically return early in non-interactive shells, so the
+		// alias would not even be defined under plain `bash -c`. -i sources
+		// ~/.bashrc, and the `type` builtin reports aliases (#688).
+		args = []string{"-i", "-c", "type claude"}
 	} else {
-		shellCmd = "which claude"
+		args = []string{"-c", "which claude"}
 	}
 
-	cmd := exec.Command(shell, "-c", shellCmd)
-	output, err := cmd.Output()
+	// Interactive rc files can block (start tmux, wait for input, ...);
+	// don't let first-run config generation hang on them.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, shell, args...).Output()
 	if err == nil && len(output) > 0 {
-		path := strings.TrimSpace(string(output))
-		if path != "" {
-			// Check if the output is an alias definition and extract the actual path
-			// Handle formats like "claude: aliased to /path/to/claude" or other shell-specific formats
-			// Capture everything after the alias marker so paths containing spaces
-			// (e.g. "/Applications/Claude Code.app/.../claude") are preserved; trim
-			// surrounding whitespace afterwards.
-			matches := aliasOutputRegex.FindStringSubmatch(path)
-			if len(matches) > 1 {
-				path = strings.TrimSpace(matches[1])
-			}
+		if path := parseCommandProbeOutput(string(output)); path != "" {
 			return path, nil
 		}
 	}
@@ -234,6 +246,41 @@ func GetClaudeCommand() (string, error) {
 	}
 
 	return "", fmt.Errorf("claude command not found in aliases or PATH")
+}
+
+// parseCommandProbeOutput extracts the claude command (a path, possibly
+// followed by alias-provided flags) from the shell probe output produced in
+// GetClaudeCommand. Interactive rc files may print unrelated text to stdout
+// (motd hints, echo statements), so each line is tried until one matches a
+// known format:
+//   - zsh `which` alias output:  "claude: aliased to /path/claude --flag"
+//   - bash `type` alias output:  "claude is aliased to `/path/claude --flag'"
+//   - bash `type` path output:   "claude is /path/claude"
+//   - plain `which` output:      "/path/claude"
+//
+// Returns "" when no line carries a usable command (e.g. "claude is a
+// function"), letting the caller fall back to a PATH lookup.
+func parseCommandProbeOutput(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Capture everything after the alias marker so paths containing
+		// spaces (e.g. "/Applications/Claude Code.app/.../claude") are
+		// preserved. bash's `type` wraps the alias value in `...' (or, in
+		// some locales, Unicode ‘...’) quotes — strip those.
+		if matches := aliasOutputRegex.FindStringSubmatch(line); len(matches) > 1 {
+			return strings.TrimSpace(strings.Trim(strings.TrimSpace(matches[1]), "`'‘’\""))
+		}
+		if matches := bashTypeOutputRegex.FindStringSubmatch(line); len(matches) > 1 {
+			return matches[1]
+		}
+		if strings.HasPrefix(line, "/") {
+			return line
+		}
+	}
+	return ""
 }
 
 // LoadConfig reads the user's config.json, validates it, and returns the

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,13 +25,31 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+// requireBash skips the test when /bin/bash (or any bash on PATH) is not
+// available, and returns the resolved bash path. The bash-alias integration
+// tests spawn a real interactive bash.
+func requireBash(t *testing.T) string {
+	t.Helper()
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available on this system")
+	}
+	return bashPath
+}
+
+// writeGuardedBashrc writes a .bashrc into homeDir that mimics the standard
+// distro layout: an early return for non-interactive shells (as shipped in
+// e.g. Ubuntu's default ~/.bashrc) followed by the given alias definition.
+// Alias detection must survive that guard (#688).
+func writeGuardedBashrc(t *testing.T, homeDir, aliasValue string) {
+	t.Helper()
+	bashrc := "case $- in\n    *i*) ;;\n      *) return;;\nesac\n" +
+		"alias claude='" + aliasValue + "'\n"
+	require.NoError(t, os.WriteFile(filepath.Join(homeDir, ".bashrc"), []byte(bashrc), 0644))
+}
+
 func TestGetClaudeCommand(t *testing.T) {
-	originalShell := os.Getenv("SHELL")
 	originalPath := os.Getenv("PATH")
-	defer func() {
-		os.Setenv("SHELL", originalShell)
-		os.Setenv("PATH", originalPath)
-	}()
 
 	t.Run("finds claude in PATH", func(t *testing.T) {
 		// Create a temporary directory with a mock claude executable
@@ -41,9 +60,11 @@ func TestGetClaudeCommand(t *testing.T) {
 		err := os.WriteFile(claudePath, []byte("#!/bin/bash\necho 'mock claude'"), 0755)
 		require.NoError(t, err)
 
-		// Set PATH to include our temp directory
-		os.Setenv("PATH", tempDir+":"+originalPath)
-		os.Setenv("SHELL", "/bin/bash")
+		// Set PATH to include our temp directory; isolate HOME so the
+		// interactive bash probe doesn't read the dev machine's ~/.bashrc.
+		t.Setenv("PATH", tempDir+":"+originalPath)
+		t.Setenv("SHELL", "/bin/bash")
+		t.Setenv("HOME", t.TempDir())
 
 		result, err := GetClaudeCommand()
 
@@ -54,8 +75,9 @@ func TestGetClaudeCommand(t *testing.T) {
 	t.Run("handles missing claude command", func(t *testing.T) {
 		// Set PATH to a directory that doesn't contain claude
 		tempDir := t.TempDir()
-		os.Setenv("PATH", tempDir)
-		os.Setenv("SHELL", "/bin/bash")
+		t.Setenv("PATH", tempDir)
+		t.Setenv("SHELL", "/bin/bash")
+		t.Setenv("HOME", t.TempDir())
 
 		result, err := GetClaudeCommand()
 
@@ -74,7 +96,9 @@ func TestGetClaudeCommand(t *testing.T) {
 		require.NoError(t, err)
 
 		// Set PATH and unset SHELL
-		os.Setenv("PATH", tempDir+":"+originalPath)
+		t.Setenv("PATH", tempDir+":"+originalPath)
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("SHELL", "")
 		os.Unsetenv("SHELL")
 
 		result, err := GetClaudeCommand()
@@ -83,44 +107,60 @@ func TestGetClaudeCommand(t *testing.T) {
 		assert.True(t, strings.Contains(result, "claude"))
 	})
 
-	t.Run("handles alias parsing", func(t *testing.T) {
-		// Test core alias formats. Keep this regex in sync with the one used in
-		// GetClaudeCommand so the test exercises the real extraction logic.
-		extract := func(output string) (string, bool) {
-			matches := aliasOutputRegex.FindStringSubmatch(output)
-			if len(matches) < 2 {
-				return "", false
-			}
-			return strings.TrimSpace(matches[1]), true
+	t.Run("detects bash alias with flags", func(t *testing.T) {
+		// End-to-end: a claude alias defined in a distro-style guarded
+		// ~/.bashrc must be detected including its flags, even with no
+		// claude binary on PATH (#688).
+		bashPath := requireBash(t)
+		homeDir := t.TempDir()
+		writeGuardedBashrc(t, homeDir, "/custom/bin/claude --model opus")
+
+		t.Setenv("HOME", homeDir)
+		t.Setenv("SHELL", bashPath)
+		t.Setenv("PATH", t.TempDir()) // no claude on PATH — alias is the only source
+
+		result, err := GetClaudeCommand()
+
+		require.NoError(t, err)
+		assert.Equal(t, "/custom/bin/claude --model opus", result)
+	})
+
+	t.Run("handles probe output parsing", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			output string
+			want   string
+		}{
+			// zsh `which` builtin alias format.
+			{"zsh alias", "claude: aliased to /usr/local/bin/claude", "/usr/local/bin/claude"},
+			// Alias path containing spaces (e.g. macOS app bundle) must be preserved.
+			{"zsh alias with spaces", "claude: aliased to /Applications/Claude Code.app/Contents/MacOS/claude", "/Applications/Claude Code.app/Contents/MacOS/claude"},
+			// bash `type` builtin alias format wraps the value in `...'.
+			{"bash type alias", "claude is aliased to `/usr/local/bin/claude --model opus'", "/usr/local/bin/claude --model opus"},
+			{"bash type alias unicode quotes", "claude is aliased to ‘/usr/local/bin/claude --model opus’", "/usr/local/bin/claude --model opus"},
+			// bash `type` output for a PATH-resolved binary.
+			{"bash type path", "claude is /usr/local/bin/claude", "/usr/local/bin/claude"},
+			// Arrow format with spaces in the path.
+			{"arrow format", "claude -> /path/with spaces/claude", "/path/with spaces/claude"},
+			// Equals format with trailing whitespace should be trimmed.
+			{"equals format", "claude=/path/with spaces/claude   ", "/path/with spaces/claude"},
+			// Direct path (no alias).
+			{"plain path", "/usr/local/bin/claude", "/usr/local/bin/claude"},
+			// Direct path containing "=" is still a path, not an alias assignment.
+			{"path containing equals", "/tmp/test=dir/bin/claude", "/tmp/test=dir/bin/claude"},
+			// Interactive rc files may print noise (motd hints, echoes)
+			// before the probe result — the matching line must still win.
+			{"noise before alias", "To run a command as administrator, use sudo.\n\nclaude is aliased to `/opt/claude --fast'", "/opt/claude --fast"},
+			// A function carries no usable path; fall back to PATH lookup.
+			{"bash type function", "claude is a function\nclaude () \n{ \n    echo hi\n}", ""},
+			{"bash type builtin", "claude is a shell builtin", ""},
+			{"empty output", "\n\n", ""},
 		}
-
-		// Standard alias format
-		got, ok := extract("claude: aliased to /usr/local/bin/claude")
-		assert.True(t, ok)
-		assert.Equal(t, "/usr/local/bin/claude", got)
-
-		// Alias path containing spaces (e.g. macOS app bundle) must be preserved.
-		got, ok = extract("claude: aliased to /Applications/Claude Code.app/Contents/MacOS/claude")
-		assert.True(t, ok)
-		assert.Equal(t, "/Applications/Claude Code.app/Contents/MacOS/claude", got)
-
-		// Arrow format with spaces in the path.
-		got, ok = extract("claude -> /path/with spaces/claude")
-		assert.True(t, ok)
-		assert.Equal(t, "/path/with spaces/claude", got)
-
-		// Equals format with trailing whitespace should be trimmed.
-		got, ok = extract("claude=/path/with spaces/claude   ")
-		assert.True(t, ok)
-		assert.Equal(t, "/path/with spaces/claude", got)
-
-		// Direct path (no alias)
-		_, ok = extract("/usr/local/bin/claude")
-		assert.False(t, ok)
-
-		// Direct path containing "=" is still a path, not an alias assignment.
-		_, ok = extract("/tmp/test=dir/bin/claude")
-		assert.False(t, ok)
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Equal(t, tc.want, parseCommandProbeOutput(tc.output))
+			})
+		}
 	})
 }
 
@@ -134,6 +174,7 @@ func TestDefaultConfig(t *testing.T) {
 		require.NoError(t, os.WriteFile(stub, []byte("#!/bin/bash\n"), 0755))
 		t.Setenv("PATH", tempDir+":"+os.Getenv("PATH"))
 		t.Setenv("SHELL", "/bin/bash")
+		t.Setenv("HOME", t.TempDir())
 
 		cfg := DefaultConfig()
 
@@ -156,6 +197,7 @@ func TestDefaultConfig(t *testing.T) {
 	t.Run("default_program is enum even when claude is not on PATH", func(t *testing.T) {
 		t.Setenv("PATH", t.TempDir())
 		t.Setenv("SHELL", "/bin/bash")
+		t.Setenv("HOME", t.TempDir())
 
 		cfg := DefaultConfig()
 
@@ -164,6 +206,49 @@ func TestDefaultConfig(t *testing.T) {
 		// No override populated when auto-detect fails — bare enum is
 		// resolved to a $PATH lookup at exec time.
 		assert.Empty(t, cfg.ProgramOverrides[tmux.ProgramClaude])
+	})
+
+	t.Run("bash alias with flags lands in override unquoted", func(t *testing.T) {
+		// An alias value is already shell syntax: it must reach the
+		// override verbatim, NOT wrapped in quotes by shellQuotePath as a
+		// single "path" (#688).
+		bashPath := requireBash(t)
+		homeDir := t.TempDir()
+		writeGuardedBashrc(t, homeDir, "/custom/bin/claude --model opus")
+
+		t.Setenv("HOME", homeDir)
+		t.Setenv("SHELL", bashPath)
+		t.Setenv("PATH", t.TempDir())
+
+		cfg := DefaultConfig()
+
+		require.NotNil(t, cfg)
+		assert.Equal(t,
+			"/custom/bin/claude --model opus --dangerously-skip-permissions",
+			cfg.ProgramOverrides[tmux.ProgramClaude])
+	})
+
+	t.Run("alias to existing path with spaces is still quoted", func(t *testing.T) {
+		// A detected value that is a real on-disk path keeps the #569
+		// quoting treatment so tmux's `sh -c` doesn't split it.
+		bashPath := requireBash(t)
+		homeDir := t.TempDir()
+		binDir := filepath.Join(t.TempDir(), "Claude Code")
+		require.NoError(t, os.MkdirAll(binDir, 0755))
+		target := filepath.Join(binDir, "claude")
+		require.NoError(t, os.WriteFile(target, []byte("#!/bin/bash\n"), 0755))
+		writeGuardedBashrc(t, homeDir, target)
+
+		t.Setenv("HOME", homeDir)
+		t.Setenv("SHELL", bashPath)
+		t.Setenv("PATH", t.TempDir())
+
+		cfg := DefaultConfig()
+
+		require.NotNil(t, cfg)
+		assert.Equal(t,
+			"'"+target+"' --dangerously-skip-permissions",
+			cfg.ProgramOverrides[tmux.ProgramClaude])
 	})
 }
 


### PR DESCRIPTION
Fixes #688

## Problem

`GetClaudeCommand()` claimed to resolve shell aliases for all shells, but only zsh worked. Bash users with `alias claude='claude --model opus'` silently lost their flags on first-run config generation.

Two stacked causes:

1. The bash probe used the external `which` binary, which cannot see shell aliases at all.
2. Even switching to the `type` builtin (the fix recommended in the issue) is not enough: distro `~/.bashrc` files (e.g. Ubuntu's default) return early in non-interactive shells via `case $- in *i*) ;; *) return;; esac`, so under plain `bash -c` the alias is never even defined. Verified empirically with a guarded `.bashrc`.

## Fix

- **Probe**: bash now runs `bash -i -c 'type claude'`. `-i` sources `~/.bashrc` past the interactive guard, and the `type` builtin reports aliases. The zsh and generic paths are unchanged.
- **Parsing**: interactive rc files can print unrelated noise to stdout (Ubuntu's sudo hint, user `echo`s), so probe output is parsed line by line (`parseCommandProbeOutput`) against the known formats — zsh `which` alias, bash `type` alias (with its `` `...' `` quote wrapping stripped), bash `type` path, plain path. Unusable output (`claude is a function`) falls back to PATH lookup instead of being returned verbatim.
- **Timeout**: the probe is capped at 5s so a blocking rc file can't hang first-run config generation.
- **DefaultConfig interplay** (required so the fix doesn't regress alias users from "flags dropped" to "broken command"): an alias value with flags is already shell syntax, but `shellQuotePath` would wrap the whole string in quotes as if it were one path, producing an unrunnable override. Quoting now applies only when the detected value is an existing on-disk path, preserving the #569 space-in-path behavior. This also repairs the same latent breakage for zsh users with flag-carrying aliases.

## Adjacent-call-site audit

`GetClaudeCommand` (config/config.go) is the only place that probes shell aliases; `session/backend_hook.go` grep hits were Go `type` declarations, not shell probes.

## Verification

- `go build ./...`, `gofmt -l`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` all clean; `go test ./...` green except the known dev-box-only `daemon/TestSigtermFallback_DeadPID` flake (caused by real `af --daemon` processes on the machine, fails identically on a clean tree); `go test -race ./config/` green.
- New tests: end-to-end bash alias detection through a real interactive bash with a distro-style guarded `.bashrc` (skips if bash is absent), table-driven coverage of all probe output formats including noise lines and function/builtin fallbacks, and DefaultConfig tests for both flag-carrying aliases (unquoted) and space-containing real paths (still quoted).
- Real-binary smoke test: first run of `af` with `SHELL=/bin/bash` and a guarded `.bashrc` alias produced `"claude": "/custom/bin/claude --model opus --dangerously-skip-permissions"` in `config.json`; same flow with `SHELL=/usr/bin/zsh` and a `.zshrc` alias produced `"claude": "/zsh/custom/claude --fast --dangerously-skip-permissions"`.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)