### PR TITLE
fix(ui): correct height/centering math in preview fallback, inline panes, and terminal fallback (#699, #700, #703)

### DIFF
--- a/ui/content_pane.go
+++ b/ui/content_pane.go
@@ -180,34 +180,38 @@ func (c *ContentPane) renderInlinePane(content string) string {
 		return ""
 	}
 
-	style := windowStyle.Width(w).Height(c.height - windowStyle.GetVerticalFrameSize() - 2)
-	wrapped := style.Render(
-		lipgloss.Place(
-			w-windowStyle.GetHorizontalFrameSize(),
-			c.height-windowStyle.GetVerticalFrameSize()-2,
-			lipgloss.Left, lipgloss.Top,
-			content))
+	innerWidth := w - windowStyle.GetHorizontalFrameSize()
+	// The -2 budgets for the two spacer lines the JoinVertical("\n", ...)
+	// below emits, mirroring TabbedWindow.String's height math so inline
+	// panes line up with the tabbed window.
+	innerHeight := c.height - windowStyle.GetVerticalFrameSize() - 2
+	if innerHeight < 0 {
+		innerHeight = 0
+	}
 
-	return lipgloss.JoinVertical(lipgloss.Left, "\n", wrapped)
+	// lipgloss.Place pads short content but never truncates tall content, and
+	// the window border's Width re-wraps lines wider than the frame. Wrap to
+	// the frame width first, then clamp to the height budget, so the pane can
+	// never render taller than its SetSize allocation and push the menu and
+	// error box off-screen (#700).
+	wrapped := strings.Split(lipgloss.NewStyle().Width(innerWidth).Render(content), "\n")
+	if len(wrapped) > innerHeight {
+		wrapped = wrapped[:innerHeight]
+	}
+
+	window := windowStyle.Width(w).Render(
+		lipgloss.Place(
+			innerWidth, innerHeight,
+			lipgloss.Left, lipgloss.Top,
+			strings.Join(wrapped, "\n")))
+
+	return lipgloss.JoinVertical(lipgloss.Left, "\n", window)
 }
 
 func (c *ContentPane) renderEmptyPane() string {
-	w := AdjustPreviewWidth(c.width)
-	if w <= 0 || c.height <= 0 {
-		return ""
-	}
-
 	emptyStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
 
-	content := emptyStyle.Render(strings.Repeat("\n", 3) + "  Select an item from the sidebar")
-	style := windowStyle.Width(w).Height(c.height - windowStyle.GetVerticalFrameSize() - 2)
-	wrapped := style.Render(
-		lipgloss.Place(
-			w-windowStyle.GetHorizontalFrameSize(),
-			c.height-windowStyle.GetVerticalFrameSize()-2,
-			lipgloss.Left, lipgloss.Top,
-			content))
-
-	return lipgloss.JoinVertical(lipgloss.Left, "\n", wrapped)
+	return c.renderInlinePane(
+		emptyStyle.Render(strings.Repeat("\n", 3) + "  Select an item from the sidebar"))
 }

--- a/ui/fallback.go
+++ b/ui/fallback.go
@@ -1,0 +1,42 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderCenteredFallback renders fallback text horizontally and vertically
+// centered within a width×height content box, returning exactly height lines.
+//
+// The text is rendered (and therefore wrapped) at the target width before the
+// vertical padding is computed, so centering uses the wrapped line count
+// rather than the pre-wrap count — on narrow panes the fallback ASCII art
+// wraps and padding computed from the raw line count miscenters it (#699).
+//
+// When the wrapped text is taller than the box it is clamped to the bottom
+// height lines — keeping the trailing message visible, matching the
+// keep-newest truncation both panes use in normal mode — so a fallback can
+// never overflow its allocation and push the menu/error box off-screen.
+//
+// Callers pass their pane's full content dimensions: TabbedWindow.SetSize has
+// already stripped tab-bar and window-frame chrome, so subtracting chrome
+// here would double-count it (#703, #616).
+func renderCenteredFallback(style lipgloss.Style, text string, width, height int) string {
+	if width <= 0 || height <= 0 {
+		return ""
+	}
+
+	rendered := style.Width(width).Align(lipgloss.Center).Render(text)
+	lines := strings.Split(rendered, "\n")
+	if len(lines) >= height {
+		return strings.Join(lines[len(lines)-height:], "\n")
+	}
+
+	topPadding := (height - len(lines)) / 2
+	out := make([]string, 0, height)
+	out = append(out, make([]string, topPadding)...)
+	out = append(out, lines...)
+	out = append(out, make([]string, height-len(lines)-topPadding)...)
+	return strings.Join(out, "\n")
+}

--- a/ui/layout_height_test.go
+++ b/ui/layout_height_test.go
@@ -1,0 +1,169 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/stretchr/testify/require"
+)
+
+// renderedLineCount counts the lines a component emits. Every component must
+// emit exactly its allocated height: lipgloss.Place pads but never truncates,
+// so a single over-tall pane pushes the menu and error box below the fold.
+func renderedLineCount(s string) int {
+	return len(strings.Split(s, "\n"))
+}
+
+// blankRuns returns the number of fully-empty lines at the top and bottom of
+// the output. renderCenteredFallback pads with literally-empty lines, while
+// rendered content lines (including the ASCII art's own blank rows) are
+// space-padded to the pane width — so literal "" lines are exactly the
+// vertical-centering padding.
+func blankRuns(s string) (top, bottom int) {
+	lines := strings.Split(s, "\n")
+	for _, l := range lines {
+		if l != "" {
+			break
+		}
+		top++
+	}
+	for i := len(lines) - 1; i >= 0; i-- {
+		if lines[i] != "" {
+			break
+		}
+		bottom++
+	}
+	return top, bottom
+}
+
+// TestPreviewFallbackWrappedArtMatchesAllocatedHeight is the regression test
+// for #699. At an 80-column terminal the preview pane is ~48 columns wide and
+// the 58-column fallback ASCII art wraps, increasing the rendered line count.
+// Centering math that counts pre-wrap lines then under-pads and the overall
+// output overflows the pane allocation (49 lines for a 30-line pane).
+func TestPreviewFallbackWrappedArtMatchesAllocatedHeight(t *testing.T) {
+	for _, tc := range []struct{ w, h int }{
+		{48, 15}, // 80x24 terminal: real preview pane content size
+		{48, 30},
+		{48, 60},
+		{80, 30}, // wide enough that the art does not wrap
+	} {
+		p := NewPreviewPane()
+		p.SetSize(tc.w, tc.h)
+		p.setFallbackState("msg")
+
+		got := renderedLineCount(p.String())
+		require.Equal(t, tc.h, got,
+			"%dx%d: fallback must render exactly the allocated height", tc.w, tc.h)
+	}
+}
+
+// TestPreviewFallbackCentersWrappedLineCount verifies the padding is computed
+// from the wrapped (rendered) line count: the top and bottom padding runs must
+// be balanced even when wrapping changes the art's height (#699).
+func TestPreviewFallbackCentersWrappedLineCount(t *testing.T) {
+	for _, tc := range []struct{ w, h int }{
+		{48, 60}, // art wraps at this width
+		{80, 30}, // art does not wrap
+	} {
+		p := NewPreviewPane()
+		p.SetSize(tc.w, tc.h)
+		p.setFallbackState("msg")
+		out := p.String()
+
+		require.Contains(t, out, "msg",
+			"%dx%d: message must be visible when the box is tall enough", tc.w, tc.h)
+		top, bottom := blankRuns(out)
+		require.Greater(t, top, 0,
+			"%dx%d: content shorter than the box must be padded down from the top", tc.w, tc.h)
+		require.InDelta(t, top, bottom, 1,
+			"%dx%d: top/bottom padding must be balanced (centering must use the wrapped line count)", tc.w, tc.h)
+	}
+}
+
+// TestTerminalFallbackMatchesNormalModeHeight is the regression test for
+// #703. TabbedWindow.SetSize already strips tab-bar and window-frame chrome
+// before sizing the terminal pane, but fallback rendering subtracted another
+// 3+4 lines, rendering 7 lines short (23 lines for a 30-line pane) and
+// centering the message 4 lines too high. Fallback and normal mode must fill
+// the same allocation. PreviewPane had the identical bug, fixed for #616.
+func TestTerminalFallbackMatchesNormalModeHeight(t *testing.T) {
+	for _, h := range []int{20, 25, 30, 50} {
+		fb := NewTerminalPane()
+		fb.SetSize(80, h)
+		fb.setFallbackState("Select an instance to open a terminal")
+		require.Equal(t, h, renderedLineCount(fb.String()),
+			"height=%d: fallback must render exactly the allocated height", h)
+
+		normal := NewTerminalPane()
+		normal.SetSize(80, h)
+		normal.fallback = false
+		normal.content = "line1\nline2"
+		require.Equal(t, h, renderedLineCount(normal.String()),
+			"height=%d: normal mode must render exactly the allocated height", h)
+	}
+}
+
+// TestTerminalFallbackWrappedArtMatchesAllocatedHeight covers the terminal
+// pane's variant of #699: at narrow widths the fallback art wraps, and the
+// pre-fix centering math both miscentered and overflowed the allocation.
+func TestTerminalFallbackWrappedArtMatchesAllocatedHeight(t *testing.T) {
+	for _, tc := range []struct{ w, h int }{
+		{48, 15},
+		{48, 30},
+		{80, 30},
+	} {
+		tp := NewTerminalPane()
+		tp.SetSize(tc.w, tc.h)
+		tp.setFallbackState("msg")
+		require.Equal(t, tc.h, renderedLineCount(tp.String()),
+			"%dx%d: fallback must render exactly the allocated height", tc.w, tc.h)
+	}
+}
+
+// TestContentPaneRendersExactlyAllocatedHeight is the regression test for
+// #700. lipgloss.Place and Style.Height are minimums — they pad short content
+// but never truncate tall content — so an over-tall task/hooks list made
+// ContentPane.String() exceed its SetSize allocation and pushed the menu and
+// error box below the fold at common terminal sizes. Every mode must render
+// exactly the allocated height regardless of content volume.
+func TestContentPaneRendersExactlyAllocatedHeight(t *testing.T) {
+	// 80x24 terminal: contentWidth = 80 - int(80*0.3) = 56,
+	// contentHeight = int(24*0.9) = 21 (see app.updateHandleWindowSizeEvent).
+	const w, h = 56, 21
+
+	longName := strings.Repeat("long-task-name-", 8)
+	var tasks []task.Task
+	for i := 0; i < 40; i++ {
+		tasks = append(tasks, task.Task{ID: "t", Name: longName, Prompt: "p"})
+	}
+	var hooks []string
+	for i := 0; i < 40; i++ {
+		hooks = append(hooks, strings.Repeat("hook-cmd ", 20))
+	}
+
+	tw := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
+	cp := NewContentPane(tw)
+	cp.SetSize(w, h)
+
+	cp.SetMode(ContentModeEmpty)
+	require.Equal(t, h, renderedLineCount(cp.String()), "empty mode")
+
+	cp.SetMode(ContentModeTasks)
+	require.Equal(t, h, renderedLineCount(cp.String()), "tasks mode, no tasks")
+
+	cp.TaskPane().SetTasks(tasks)
+	require.Equal(t, h, renderedLineCount(cp.String()),
+		"tasks mode with an over-tall task list must not overflow the allocation")
+
+	cp.HooksPane().SetCommands(hooks)
+	cp.SetMode(ContentModeHooks)
+	require.Equal(t, h, renderedLineCount(cp.String()),
+		"hooks mode with an over-tall hooks list must not overflow the allocation")
+
+	// Inline panes must keep the same total height as the tabbed window so
+	// the layout does not jump when switching sidebar selections.
+	cp.SetMode(ContentModeInstance)
+	require.Equal(t, h, renderedLineCount(tw.String()), "tabbed window")
+}

--- a/ui/preview.go
+++ b/ui/preview.go
@@ -199,35 +199,10 @@ func (p *PreviewPane) String() string {
 		// p.height, so we use p.height directly to match normal mode (which
 		// pads to the full p.height). Subtracting again here would
 		// double-count chrome and leave a trailing blank line (#616).
-		availableHeight := p.height
-
-		// Count the number of lines in the fallback text
-		fallbackLines := len(strings.Split(p.previewState.text, "\n"))
-
-		// Calculate padding needed above and below to center the content
-		totalPadding := availableHeight - fallbackLines
-		topPadding := 0
-		bottomPadding := 0
-		if totalPadding > 0 {
-			topPadding = totalPadding / 2
-			bottomPadding = totalPadding - topPadding // accounts for odd numbers
-		}
-
-		// Build the centered content
-		var lines []string
-		if topPadding > 0 {
-			lines = append(lines, strings.Repeat("\n", topPadding))
-		}
-		lines = append(lines, p.previewState.text)
-		if bottomPadding > 0 {
-			lines = append(lines, strings.Repeat("\n", bottomPadding))
-		}
-
-		// Center both vertically and horizontally
-		return previewPaneStyle.
-			Width(p.width).
-			Align(lipgloss.Center).
-			Render(strings.Join(lines, ""))
+		// renderCenteredFallback centers using the wrapped line count: on
+		// narrow panes Width(p.width) wraps the ASCII art, and padding
+		// computed from the pre-wrap count miscenters and overflows (#699).
+		return renderCenteredFallback(previewPaneStyle, p.previewState.text, p.width, p.height)
 	}
 
 	// Normal mode display

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -378,30 +378,13 @@ func (t *TerminalPane) String() string {
 	content := t.content
 
 	if fallback {
-		// 3 = tab bar height (border + padding + text), 4 = window style frame (top/bottom border + padding)
-		availableHeight := height - 3 - 4
-		fallbackLines := len(strings.Split(fallbackText, "\n"))
-		totalPadding := availableHeight - fallbackLines
-		topPadding := 0
-		bottomPadding := 0
-		if totalPadding > 0 {
-			topPadding = totalPadding / 2
-			bottomPadding = totalPadding - topPadding
-		}
-
-		var lines []string
-		if topPadding > 0 {
-			lines = append(lines, strings.Repeat("\n", topPadding))
-		}
-		lines = append(lines, fallbackText)
-		if bottomPadding > 0 {
-			lines = append(lines, strings.Repeat("\n", bottomPadding))
-		}
-
-		return terminalPaneStyle.
-			Width(width).
-			Align(lipgloss.Center).
-			Render(strings.Join(lines, ""))
+		// TabbedWindow.SetSize already strips tab-bar and window-frame chrome
+		// before sizing this pane, so height is the content height — use it
+		// directly, like normal mode below pads to the full height.
+		// Subtracting chrome again here rendered the fallback 7 lines short
+		// and centered it 4 lines too high (#703). PreviewPane had the same
+		// double subtraction and was fixed the same way (#616).
+		return renderCenteredFallback(terminalPaneStyle, fallbackText, width, height)
 	}
 
 	// Normal mode: show captured content


### PR DESCRIPTION
Fixes #699
Fixes #700
Fixes #703

Three lipgloss height/centering miscounts in `ui/`, each making a pane render a different number of lines than its `SetSize` allocation. All three were verified by measurement before fixing, and each new regression test fails on `master` and passes with this change.

## #699 — Preview fallback miscentered when the ASCII art wraps

`PreviewPane.String()` computed vertical-centering padding from the **pre-wrap** line count of the fallback text (18 lines), but the final render applies `Width(p.width)`, which wraps the 58-column ASCII art on narrow panes. At the real 80-column-terminal preview width (~48 cols), the art wraps to ~37 lines: measured **49 lines rendered into a 30-line allocation**, miscentered and overflowing the layout.

**Fix:** render at the target width first, then center using the wrapped line count.

## #700 — Content pane taller than allocated, pushing menu/errBox off-screen

The overflow is real, but the issue's diagnosis isn't quite right: the `JoinVertical(lipgloss.Left, "\n", wrapped)` spacer **is** budgeted — the `-2` in both `renderInlinePane` and `SetSize` accounts for it, mirroring `TabbedWindow.String`'s identical spacer/budget, and at-rest output measures exactly `c.height` lines. Removing the `"\n"` (the issue's recommended fix) would render inline panes 2 lines **short** and make the layout jump when switching sidebar selections.

The actual overflow source: `lipgloss.Place` and `Style.Height` are *minimums* — they pad short content but never truncate tall content — and the window frame's `Width` re-wraps long lines. A populated task/hooks list blows straight through the budget: measured **246 lines for a 21-line allocation** at 80×24, which is what pushes the menu and error box below the fold.

**Fix:** wrap content to the frame width, clamp to the height budget, then frame. `ContentPane.String()` now renders exactly its allocation in every mode regardless of content volume. (`renderEmptyPane` now delegates to `renderInlinePane` — they were copy-paste identical.)

## #703 — Terminal fallback 7 lines short, centered 4 lines too high

`TerminalPane.String()` fallback subtracted tab-bar + window-frame chrome (`height - 3 - 4`) from a height that `TabbedWindow.SetSize` had already stripped chrome from. Measured **23 lines for a 30-line allocation**. This is the exact bug `PreviewPane` had and fixed for #616 — `TerminalPane` was missed.

**Fix:** use `height` directly, same as normal mode and same as the PreviewPane precedent. Both fallback paths now share `renderCenteredFallback` (new `ui/fallback.go`), which also clamps over-tall fallbacks to the bottom `height` lines so the trailing message stays visible (matching normal mode's keep-newest truncation).

## Adjacent-site audit (all `lipgloss.Place` / `JoinVertical` height math in `ui/`)

| Site | Verdict |
|---|---|
| `tabbed_window.go` `SetSize`/`String` budget | **Correct** — measured exactly `height` lines at 80×24; children now can't overflow it |
| `preview.go` / `terminal.go` normal modes | **Correct** — pad and truncate to exact height |
| `menu.go:270`, `err.go:76`, `list.go`, `sidebar.go` single-line `Place`s | **Correct** — single-line, or have explicit clip handling with comments |
| `content_pane.go` inline/empty panes | **Fixed** (#700) |
| `preview.go` / `terminal.go` fallback branches | **Fixed** (#699/#703) |
| `sidebar.go:539` full-pane `Place` | **Excluded** — can overflow with very long instance lists, but needs selection-aware windowing (a blind clamp would hide the selected instance); follow-up issue to be filed |

## Tests

New `ui/layout_height_test.go` — every test asserts rendered line count **equals** the allocated height at the issue-reported dimensions (no overflow, no shortfall), all failing pre-fix:

- `TestPreviewFallbackWrappedArtMatchesAllocatedHeight` (48×15, 48×30, 48×60, 80×30)
- `TestPreviewFallbackCentersWrappedLineCount` (top/bottom padding balanced using wrapped count)
- `TestTerminalFallbackMatchesNormalModeHeight` (heights 20/25/30/50, fallback == normal == h; adapted from the failing test in #703)
- `TestTerminalFallbackWrappedArtMatchesAllocatedHeight` (terminal variant of the wrap bug)
- `TestContentPaneRendersExactlyAllocatedHeight` (80×24 layout dims; empty/tasks/hooks/instance modes, including 40-item over-tall lists)

## Verification

- `go build ./...` ✅
- `gofmt -l .` clean ✅
- `golangci-lint run --timeout=3m --fast` ✅
- `deadcode -test ./...` clean ✅
- `go test ./...` ✅ (only failure: `daemon/TestSigtermFallback_DeadPID`, the known dev-box flake from live `af --daemon` processes, unrelated)
- `go test -race ./ui/` ✅

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)