### PR TITLE
fix(ui/sidebar): selection-aware windowing so long instance lists stay within allocation (#787)

### DIFF
--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -46,11 +46,20 @@ var sectionHeaderSelectedStyle = lipgloss.NewStyle().
 	Background(lipgloss.Color("#dde4f0")).
 	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#1a1a1a"})
 
+var windowIndicatorStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+
 // Sidebar is the unified left navigation pane with collapsible sections.
 type Sidebar struct {
 	sections     []SidebarSection
 	visibleItems []SidebarItem
 	selectedIdx  int
+
+	// scrollOffset is the index into visibleItems of the first rendered row
+	// when the list is too tall for the allocation. It is adjusted lazily in
+	// String() (rebuilds can shift indices between renders), scrolling
+	// minimally so the selected row stays visible.
+	scrollOffset int
 
 	// Data
 	instances []*session.Instance
@@ -504,8 +513,50 @@ func (s *Sidebar) rmRepo(repo string) {
 	}
 }
 
-// String renders the sidebar.
+// String renders the sidebar. The item list is windowed around the selection
+// (#787): lipgloss.Place pads short content but never truncates, so rendering
+// every row would overflow the allocation once enough instances exist and push
+// the menu/error box below the fold. A blind clamp (the #700 fix for the
+// content pane) would be wrong here because the selected row can sit below the
+// fold while navigating — instead the rendered slice scrolls so the selection
+// is always visible, with "▲/▼ N more" rows marking hidden items.
 func (s *Sidebar) String() string {
+	// Chrome above the item list: one leading blank line plus the title row.
+	const chromeLines = 2
+
+	// Render every visible row up front and measure real heights: instance
+	// rows are multi-line (title + branch, plus an optional PR line), so the
+	// window math cannot assume one line per item.
+	rows := make([]string, len(s.visibleItems))
+	heights := make([]int, len(s.visibleItems))
+	totalLines := 0
+	for i, item := range s.visibleItems {
+		isSelected := i == s.selectedIdx
+		if item.IsHeader {
+			rows[i] = s.renderHeader(item.Kind, isSelected)
+		} else {
+			switch item.Kind {
+			case SectionInstances:
+				rows[i] = s.renderInstance(item.ItemIndex, isSelected)
+			}
+		}
+		heights[i] = lipgloss.Height(rows[i])
+		totalLines += heights[i]
+	}
+
+	avail := s.height - chromeLines
+	start, end := 0, len(rows)
+	hiddenAbove, hiddenBelow := 0, 0
+	if s.height > 0 && totalLines > avail {
+		s.scrollToSelection(heights, avail)
+		start = s.scrollOffset
+		end, _, _ = fitWindow(heights, start, avail)
+		hiddenAbove = start
+		hiddenBelow = len(rows) - end
+	} else {
+		s.scrollOffset = 0
+	}
+
 	var b strings.Builder
 	b.WriteString("\n")
 
@@ -521,22 +572,117 @@ func (s *Sidebar) String() string {
 			titleWidth-(titleWidth/2), 1, lipgloss.Right, lipgloss.Bottom, autoYesStyle.Render(" auto-yes "))
 		b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, title, autoYes))
 	}
-	b.WriteString("\n")
 
-	for i, item := range s.visibleItems {
-		isSelected := i == s.selectedIdx
-		if item.IsHeader {
-			b.WriteString(s.renderHeader(item.Kind, isSelected))
-		} else {
-			switch item.Kind {
-			case SectionInstances:
-				b.WriteString(s.renderInstance(item.ItemIndex, isSelected))
-			}
-		}
+	if hiddenAbove > 0 {
 		b.WriteString("\n")
+		b.WriteString(s.renderWindowIndicator("▲", hiddenAbove))
+	}
+	for i := start; i < end; i++ {
+		b.WriteString("\n")
+		b.WriteString(rows[i])
+	}
+	if hiddenBelow > 0 {
+		b.WriteString("\n")
+		b.WriteString(s.renderWindowIndicator("▼", hiddenBelow))
 	}
 
-	return lipgloss.Place(s.width, s.height, lipgloss.Left, lipgloss.Top, b.String())
+	out := lipgloss.Place(s.width, s.height, lipgloss.Left, lipgloss.Top, b.String())
+	// Safety clamp: fitWindow force-includes the first windowed row even when
+	// it alone exceeds the budget (e.g. a tall PR row at a tiny height), and
+	// lipgloss.Place will not truncate the overflow.
+	if s.height > 0 {
+		if lines := strings.Split(out, "\n"); len(lines) > s.height {
+			out = strings.Join(lines[:s.height], "\n")
+		}
+	}
+	return out
+}
+
+// scrollToSelection clamps scrollOffset and moves it minimally so the selected
+// row is fully inside the rendered window. Only called when the list overflows
+// the allocation.
+func (s *Sidebar) scrollToSelection(heights []int, avail int) {
+	n := len(heights)
+	if s.scrollOffset > n-1 {
+		s.scrollOffset = n - 1
+	}
+	if s.scrollOffset < 0 {
+		s.scrollOffset = 0
+	}
+	if s.selectedIdx < s.scrollOffset {
+		s.scrollOffset = s.selectedIdx
+	}
+	for s.scrollOffset < s.selectedIdx {
+		end, _, _ := fitWindow(heights, s.scrollOffset, avail)
+		if s.selectedIdx < end {
+			break
+		}
+		s.scrollOffset++
+	}
+	// Fill from the bottom: when the tail of the list fits starting one row
+	// earlier (items were removed or the selection sits at the end), scroll
+	// up to use the slack rather than render dead space below the last item.
+	for s.scrollOffset > 0 {
+		if end, _, _ := fitWindow(heights, s.scrollOffset-1, avail); end < n {
+			break
+		}
+		s.scrollOffset--
+	}
+}
+
+// fitWindow returns the exclusive end index of the rows that fit when
+// rendering starts at offset within avail lines, plus whether "▲"/"▼"
+// indicator rows (one line each) are needed. heights[i] is the rendered line
+// count of visibleItems[i].
+func fitWindow(heights []int, offset, avail int) (end int, topInd, botInd bool) {
+	n := len(heights)
+	topInd = offset > 0
+	for {
+		budget := avail
+		if topInd {
+			budget--
+		}
+		if botInd {
+			budget--
+		}
+		end = offset
+		used := 0
+		for end < n && used+heights[end] <= budget {
+			used += heights[end]
+			end++
+		}
+		if end == offset && offset < n {
+			// Force at least one row so scrolling can always reach the
+			// selection; String()'s final clamp bounds any overflow.
+			end = offset + 1
+		}
+		if end == n || botInd {
+			return end, topInd, botInd
+		}
+		// Rows remain below: reserve a line for the "▼" indicator and refit.
+		// Shrinking the budget can only shrink end, so this converges in one
+		// extra pass.
+		botInd = true
+	}
+}
+
+// renderWindowIndicator renders the one-line "▲ N more" / "▼ N more" marker
+// shown in place of rows scrolled out of the window.
+func (s *Sidebar) renderWindowIndicator(arrow string, hidden int) string {
+	w := AdjustPreviewWidth(s.width)
+	text := fmt.Sprintf("%s %d more", arrow, hidden)
+	if w > 0 && runewidth.StringWidth(text) > w {
+		// Same narrow-width handling as renderHeader: drop the "..." tail when
+		// it would itself overflow, since lipgloss.Place won't clip oversize
+		// content.
+		tail := "..."
+		if w < runewidth.StringWidth(tail) {
+			tail = ""
+		}
+		text = runewidth.Truncate(text, w, tail)
+	}
+	return windowIndicatorStyle.Padding(0, 1).Render(
+		lipgloss.Place(w, 1, lipgloss.Left, lipgloss.Center, text))
 }
 
 func (s *Sidebar) renderHeader(kind SidebarSectionKind, selected bool) string {

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -309,6 +310,137 @@ func TestSidebarRender(t *testing.T) {
 	rendered := s.String()
 	assert.Contains(t, rendered, "Instances (1)")
 	assert.NotEmpty(t, rendered)
+}
+
+// indicatorArrows reports which "▲/▼ N more" scroll-indicator rows are present
+// in the rendered output. Detection keys on the "more" text because expanded
+// section headers also use a "▼ " arrow.
+func indicatorArrows(out string) (up, down bool) {
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "more") {
+			continue
+		}
+		if strings.Contains(line, "▲") {
+			up = true
+		}
+		if strings.Contains(line, "▼") {
+			down = true
+		}
+	}
+	return up, down
+}
+
+// newWindowingSidebar builds a sidebar with n instances titled win-00..win-NN
+// for the #787 windowing tests.
+func newWindowingSidebar(t *testing.T, n int) *Sidebar {
+	t.Helper()
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false)
+	dir := t.TempDir()
+	for i := 0; i < n; i++ {
+		inst, err := session.NewInstance(session.InstanceOptions{
+			Title: fmt.Sprintf("win-%02d", i), Path: dir, Program: "test",
+		})
+		require.NoError(t, err)
+		s.AddInstance(inst)
+	}
+	return s
+}
+
+// TestSidebarWindowsLongInstanceListToAllocation is the regression test for
+// #787: lipgloss.Place pads but never truncates, so before windowing 25
+// instances at a 20-line allocation rendered ~100 lines and pushed the menu
+// and error box below the fold. The sidebar must render exactly its allocated
+// height regardless of instance count, with the selected row always inside
+// the rendered window.
+func TestSidebarWindowsLongInstanceListToAllocation(t *testing.T) {
+	const w, h = 40, 20
+
+	cases := []struct {
+		name    string
+		sel     func(s *Sidebar)
+		visible string
+	}{
+		{"top (Instances header)", func(s *Sidebar) {}, "Instances (25)"},
+		{"middle instance", func(s *Sidebar) { s.SetSelectedInstance(12) }, "win-12"},
+		{"bottom instance", func(s *Sidebar) { s.SetSelectedInstance(24) }, "win-24"},
+		{"trailing Hooks header", func(s *Sidebar) {
+			s.SetSelectedInstance(24)
+			s.Down() // Tasks header
+			s.Down() // Hooks header
+		}, "Hooks"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newWindowingSidebar(t, 25)
+			s.SetSize(w, h)
+			tc.sel(s)
+
+			out := s.String()
+			require.Equal(t, h, renderedLineCount(out),
+				"sidebar must render exactly the allocated height")
+			assert.Contains(t, out, tc.visible,
+				"selected row must be inside the rendered window")
+		})
+	}
+}
+
+// TestSidebarWindowScrollsWithSelection walks the selection from the top of
+// the list to the bottom and back. At every step the rendered output must
+// stay at the allocated height and contain the selected row, and the ▲/▼
+// indicators must only appear when rows are actually hidden on that side.
+func TestSidebarWindowScrollsWithSelection(t *testing.T) {
+	const w, h = 40, 20
+
+	s := newWindowingSidebar(t, 25)
+	s.SetSize(w, h)
+
+	check := func(step string) {
+		out := s.String()
+		require.Equal(t, h, renderedLineCount(out), "%s: height must stay at the allocation", step)
+		if inst := s.GetSelectedInstance(); inst != nil {
+			assert.Contains(t, out, inst.Title, "%s: selected instance must be visible", step)
+		}
+	}
+
+	// Walk down through every row (1 header + 25 instances + 2 headers).
+	check("initial")
+	for i := 0; i < len(s.visibleItems)-1; i++ {
+		s.Down()
+		check(fmt.Sprintf("down %d", i))
+	}
+	// At the very bottom nothing is hidden below, so only ▲ may show.
+	up, down := indicatorArrows(s.String())
+	assert.True(t, up, "rows above must be indicated at the bottom")
+	assert.False(t, down, "nothing is hidden below at the bottom")
+
+	// Walk back up to the top.
+	for i := 0; i < len(s.visibleItems)-1; i++ {
+		s.Up()
+		check(fmt.Sprintf("up %d", i))
+	}
+	top := s.String()
+	assert.Contains(t, top, "win-00", "first instance must be visible at the top")
+	up, down = indicatorArrows(top)
+	assert.False(t, up, "nothing is hidden above at the top")
+	assert.True(t, down, "rows below must be indicated at the top")
+}
+
+// TestSidebarShortListRendersUnwindowed verifies the fast path: when the list
+// fits the allocation the sidebar renders as before — every row visible, no
+// scroll indicators, output padded to exactly the allocated height.
+func TestSidebarShortListRendersUnwindowed(t *testing.T) {
+	const w, h = 40, 30
+
+	s := newWindowingSidebar(t, 2)
+	s.SetSize(w, h)
+
+	out := s.String()
+	require.Equal(t, h, renderedLineCount(out))
+	assert.Contains(t, out, "win-00")
+	assert.Contains(t, out, "win-01")
+	assert.NotContains(t, out, "more", "short lists must not show scroll indicators")
 }
 
 // renderForTerminal renders an instance at the sidebar width app.go derives


### PR DESCRIPTION
Fixes #787

## Root cause (from the #786 audit)

`Sidebar.String()` built one rendered block per visible item and handed the result to `lipgloss.Place(s.width, s.height, ...)`. `Place` pads short content but never truncates tall content, so once the instance list plus headers exceeded the allocation the sidebar overflowed and pushed the menu and error box below the fold — the same symptom as #700. Measured: **25 instances rendered 106 lines into a 20-line allocation** (the new regression test fails with exactly that on `master`).

This site was deliberately excluded from PR #786 because the content pane's blind clamp would be wrong here: while navigating with arrow keys the selected row can sit below the fold, and a clamp would simply hide it.

## Windowing design

- `String()` renders every visible row up front and measures **real rendered heights** (`lipgloss.Height`) — instance rows are multi-line (2-line title + 2-line branch + optional 2-line PR row), so the issue's nominal "one line per item" model would under-count by 4–6×.
- A `scrollOffset` field tracks the first rendered row. On each render it is clamped (rebuilds can shift indices) and moved **minimally** so the selected row is fully inside the window — standard list-window behavior, no jumps.
- Hidden rows are marked with one-line `▲ N more` / `▼ N more` indicator rows (dim, header-style width handling including the narrow-width `...`-tail rules from #466/#646). Indicator lines are budgeted inside the fit computation.
- A fill-from-bottom normalization scrolls up when the tail of the list fits with slack (e.g. after deleting sessions while scrolled down), so no dead space renders below the last item.
- Section headers scroll with their items — not pinned, per the keep-it-simple call in the issue.
- Safety clamp after `Place`: if a single row alone exceeds the budget (tall PR row at a tiny height), the forced-include row is truncated to the allocation rather than overflowing. With windowing doing the real work this is a backstop, not the fix.
- Short lists take the unwindowed fast path: identical rendering to before, no indicators, `scrollOffset` reset to 0.

## Adjacent-site audit (one-line-per-instance indexing / sidebar render+height paths)

| Site | Verdict |
|---|---|
| Selection math (`Down`/`Up`/`JumpNextSection`/`SetSelectedInstance`/`GetSelection`) | **Unaffected** — operates on `visibleItems` indices; windowing is render-only and never changes indices |
| Mouse hit-testing | **None exists** — the only `tea.MouseMsg` handling is wheel events routed to the content pane (`app/app.go:365`); no click-to-row mapping to re-window |
| `rebuildVisibleItems` selection clamp | **Unaffected** — `scrollOffset` is re-clamped lazily in `String()`, so index shifts from add/remove/collapse self-heal on the next frame |
| `renderHeader` / `renderInstance` width truncation (#466/#646) | **Unchanged** — reused as-is; the new indicator row follows the same narrow-width rules |
| Other `InstanceRenderer` / `visibleItems` consumers | **None** — grep confirms both are internal to `ui/sidebar.go` |
| `app.go:1059` `PaddingTop(1)` wrapper | **Unaffected** — sidebar now always emits ≤ its `SetSize` height, which is what the wrapper assumes |

## Tests

All in `ui/sidebar_test.go`; the allocation test fails on `master` (106 ≠ 20):

- `TestSidebarWindowsLongInstanceListToAllocation` — 25 instances at 40×20: rendered line count **equals** the allocation with the selection at top (header), middle instance, bottom instance, and trailing Hooks header; selected row visible in every case.
- `TestSidebarWindowScrollsWithSelection` — walks the selection through all 28 rows down and back up; every step stays at exactly 20 lines with the selected instance visible; `▲`-only at the bottom, `▼`-only at the top.
- `TestSidebarShortListRendersUnwindowed` — 2 instances at 40×30: padded to exact height, both titles visible, no indicators.

## Verification

- `go build ./...` ✅
- `gofmt -l .` clean ✅
- `golangci-lint run --timeout=3m --fast` ✅
- `deadcode -test ./...` clean ✅
- `go test ./...` ✅ (only failures: `daemon/TestSigtermFallback_DeadPID` — the known dev-box flake from live `af --daemon` processes — and two `integration/` daemon tests that pass when re-run individually; both re-verified green with this change applied)
- `GOFLAGS="-p=1" go test -race -parallel 2 ./ui` ✅

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)