### PR TITLE
chore(app): gate [detach-trace] markers behind AF_DETACH_TRACE (#788)

### DIFF
--- a/app/detach_trace.go
+++ b/app/detach_trace.go
@@ -13,14 +13,21 @@ import (
 )
 
 // detachTraceEnabled gates the [detach-trace] markers emitted on the
-// post-detach hot path. Defaulting to true means real users hit by issue
-// #598 capture diagnostic markers in agent-factory.log automatically — the
-// prior two attempts at this bug (#560, #593) shipped synthetic
-// microbenches that did not reproduce what users actually hit, so we need
-// data from real slow detaches. log.WarningLog writes are buffered through
-// the Go log package and are cheap; gating still gives us a flip-the-switch
-// off in case it ever proves otherwise.
-var detachTraceEnabled = true
+// post-detach hot path. The default-on instrumentation existed to gather
+// data from real slow detaches during the #598 investigation; with #598
+// resolved (#601/#602 bounded detach via the SIGKILL fallback) the markers
+// only bloat agent-factory.log — they fire on every selection change, pane
+// refresh, and metadata tick (#788). Now opt-in via AF_DETACH_TRACE=1 so
+// the step-level diagnostics stay one flag away if detach perf regresses.
+// The slow-detach watchdog below is NOT gated by this — it is silent in
+// the steady state and remains the always-on regression tripwire.
+var detachTraceEnabled = detachTraceEnabledFromEnv()
+
+// detachTraceEnabledFromEnv reports whether AF_DETACH_TRACE=1 is set.
+// Split out from the var initializer so tests can exercise the env parsing.
+func detachTraceEnabledFromEnv() bool {
+	return os.Getenv("AF_DETACH_TRACE") == "1"
+}
 
 // slowDetachThreshold is the elapsed window above which startSlowDetachWatchdog
 // takes a goroutine dump. 2s is well above the post-detach paint budget
@@ -111,8 +118,12 @@ func dumpSlowDetach(label string, start time.Time) {
 		log.WarningLog.Printf("[detach-trace] failed to write slow-dump trailer: %v", err)
 		return
 	}
-	log.WarningLog.Printf("[detach-trace] SLOW DETACH (%s) elapsed=%v — goroutine dump appended to %s",
-		label, elapsed, dumpPath)
+	hint := ""
+	if !detachTraceEnabled {
+		hint = " — re-run with AF_DETACH_TRACE=1 for step-level tracing"
+	}
+	log.WarningLog.Printf("[detach-trace] SLOW DETACH (%s) elapsed=%v — goroutine dump appended to %s%s",
+		label, elapsed, dumpPath, hint)
 }
 
 // startSlowDetachWatchdog spawns a goroutine that waits up to
@@ -122,13 +133,12 @@ func dumpSlowDetach(label string, start time.Time) {
 // channel — callers MUST close it when the detach completes (or abandon
 // it, in which case the watchdog leaks for one cycle plus the wait).
 //
-// No-op when detachTraceEnabled is false: returns a non-nil channel so
-// callers' close(done) does not panic, but the goroutine never sleeps.
+// Deliberately NOT gated by detachTraceEnabled: the watchdog is silent
+// unless a detach actually exceeds the threshold, and a dump from a user
+// who never set AF_DETACH_TRACE is exactly how we detect a detach-perf
+// regression in the wild (#788).
 func startSlowDetachWatchdog(label string) chan struct{} {
 	done := make(chan struct{})
-	if !detachTraceEnabled {
-		return done
-	}
 	start := time.Now()
 	go func() {
 		select {

--- a/app/detach_trace_test.go
+++ b/app/detach_trace_test.go
@@ -1,0 +1,111 @@
+package app
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/stretchr/testify/require"
+)
+
+// captureWarningLog redirects log.WarningLog into a buffer for the duration
+// of the test and restores the previous writer on cleanup. Tests using it
+// must not run in parallel — WarningLog is package-global.
+func captureWarningLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := log.WarningLog.Writer()
+	log.WarningLog.SetOutput(&buf)
+	t.Cleanup(func() { log.WarningLog.SetOutput(prev) })
+	return &buf
+}
+
+// setDetachTraceEnabled overrides the marker gate for one test and restores
+// the prior value on cleanup.
+func setDetachTraceEnabled(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := detachTraceEnabled
+	detachTraceEnabled = enabled
+	t.Cleanup(func() { detachTraceEnabled = prev })
+}
+
+// TestDetachTraceEnabledFromEnv covers the AF_DETACH_TRACE parsing that
+// initializes detachTraceEnabled at package init (#788): off unless the
+// variable is exactly "1".
+func TestDetachTraceEnabledFromEnv(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"", false},
+		{"0", false},
+		{"true", false},
+		{"1", true},
+	} {
+		t.Setenv("AF_DETACH_TRACE", tc.value)
+		require.Equal(t, tc.want, detachTraceEnabledFromEnv(),
+			"AF_DETACH_TRACE=%q", tc.value)
+	}
+}
+
+// TestDetachTraceMarkers_SilentWhenDisabled asserts the steady-state #788
+// behavior: with the gate off (the default), none of the marker helpers
+// write anything to the warning log.
+func TestDetachTraceMarkers_SilentWhenDisabled(t *testing.T) {
+	buf := captureWarningLog(t)
+	setDetachTraceEnabled(t, false)
+
+	start := time.Now()
+	detachTrace(start, "marker-a")
+	detachTraceFields(start, "marker-b", "title=x")
+	detachTraceMark("marker-c")
+
+	require.Empty(t, buf.String(),
+		"[detach-trace] markers must not be emitted when AF_DETACH_TRACE is unset")
+}
+
+// TestDetachTraceMarkers_EmitWhenEnabled asserts the opt-in path: with the
+// gate on, every marker helper writes a [detach-trace] line.
+func TestDetachTraceMarkers_EmitWhenEnabled(t *testing.T) {
+	buf := captureWarningLog(t)
+	setDetachTraceEnabled(t, true)
+
+	start := time.Now()
+	detachTrace(start, "marker-a")
+	detachTraceFields(start, "marker-b", "title=x")
+	detachTraceMark("marker-c")
+
+	out := buf.String()
+	require.Equal(t, 3, strings.Count(out, "[detach-trace]"),
+		"each marker helper must emit exactly one [detach-trace] line:\n%s", out)
+	require.Contains(t, out, "marker-a")
+	require.Contains(t, out, "marker-b")
+	require.Contains(t, out, "title=x")
+	require.Contains(t, out, "marker-c")
+}
+
+// TestSlowDetachDump_HintsAtEnvVar asserts the SLOW DETACH log line points
+// users at AF_DETACH_TRACE=1 when the marker gate is off — that hint is how
+// someone who hits a slow detach in the wild learns to capture step-level
+// traces (#788) — and omits the hint when tracing is already on.
+func TestSlowDetachDump_HintsAtEnvVar(t *testing.T) {
+	// newTestHome points the config dir at a tempdir so the dump file from
+	// dumpSlowDetach lands somewhere disposable.
+	newTestHome(t)
+
+	buf := captureWarningLog(t)
+
+	setDetachTraceEnabled(t, false)
+	dumpSlowDetach("hint-test-disabled", time.Now())
+	require.Contains(t, buf.String(), "re-run with AF_DETACH_TRACE=1 for step-level tracing",
+		"slow-detach log line must carry the tracing hint when the gate is off")
+
+	buf.Reset()
+	setDetachTraceEnabled(t, true)
+	dumpSlowDetach("hint-test-enabled", time.Now())
+	require.Contains(t, buf.String(), "SLOW DETACH (hint-test-enabled)")
+	require.NotContains(t, buf.String(), "re-run with AF_DETACH_TRACE=1",
+		"hint is redundant when tracing is already enabled")
+}

--- a/app/detach_watchdog_test.go
+++ b/app/detach_watchdog_test.go
@@ -83,8 +83,11 @@ func TestWatchdog_NoSpuriousDumpAfterHeaderDetach(t *testing.T) {
 	require.NoError(t, err)
 	dumpPath := filepath.Join(configDir, detachSlowDumpFileName)
 
+	// Pin the marker gate OFF: the watchdog must arm and dump regardless of
+	// AF_DETACH_TRACE (#788) — a dump from a user who never set the env var
+	// is how detach-perf regressions get noticed in the wild.
 	prev := detachTraceEnabled
-	detachTraceEnabled = true
+	detachTraceEnabled = false
 	t.Cleanup(func() { detachTraceEnabled = prev })
 
 	// --- Control: an un-canceled watchdog DOES write a dump after the


### PR DESCRIPTION
## Summary

The per-step `[detach-trace]` WARNING markers (added in #599 as diagnostic instrumentation for the #598 post-detach slowness investigation) fire on every selection change, pane refresh, and metadata tick. #598 was resolved weeks ago — #601/#602 bounded detach to ~3s worst case via the SIGKILL fallback — so the markers now only bloat the log: `agent-factory.log` was past **9.4M lines** on the reporting dev box, the large majority `[detach-trace]` noise, with no rotation. WARNING level for routine ticks also misrepresents severity and forces log-scanning tools to special-case the markers.

Per the issue's preferred shape, the markers are **gated, not removed**: one env var keeps the step-level diagnostics a flag away if detach perf ever regresses.

## Changes

- `detachTraceEnabled` now initializes from `AF_DETACH_TRACE=1` (checked once at init), **default off**. All `detachTrace`/`detachTraceFields`/`detachTraceMark` call sites stay in place under the gate — only the default changes.
- The **slow-detach watchdog + goroutine dump** (`detach-slow.log`) is now **unconditional** (previously it was disabled along with the gate). Rationale: it is silent in the steady state and a dump from a user who never set the env var is exactly how a detach-perf regression gets noticed in the wild.
- When the watchdog fires with the gate off, the `SLOW DETACH` log line now appends: *"re-run with AF_DETACH_TRACE=1 for step-level tracing"*.

## Tests

- New `app/detach_trace_test.go`: env parsing (`AF_DETACH_TRACE` off by default / `"1"` enables), markers silent when disabled, markers emitted when enabled, and the hint present/absent on the slow-dump log line.
- The #683 watchdog regression tests now pin the gate **off**, proving the watchdog arms and dumps regardless of `AF_DETACH_TRACE`.

## Audit (adjacent call sites)

Grepped all `detachTrace*` / `detachTraceEnabled` / `beginDetachWatchdog` / `endDetachWatchdog` uses: 24 marker call sites across `app/app.go` and `app/sync.go` are all routed through the three gated helpers — no direct `[detach-trace]` Printf outside `detach_trace.go`. Tests that need the gate forced use the package var directly (existing #683 pattern).

## Verification

- `gofmt -l .` clean, `golangci-lint run --timeout=3m --fast` clean, `deadcode -test ./...` clean
- `go build ./...` and `go test ./...` pass (3 unrelated environmental failures on the dev box: the documented `daemon/TestSigtermFallback_DeadPID` flake from real running daemons, a pyenv-missing-python3 session E2E failure, and an integration timeout that passes in isolation)
- `go test -race ./app/ ./ui/` pass

Fixes #788

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)