### PR TITLE
fix(daemon): guard socket cleanup against stop/start races and close the spawn ping-bind window (#718, #767)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -418,9 +418,63 @@ func (s *controlServer) ImportRemoteHookSessions(req ImportRemoteHookSessionsReq
 	return nil
 }
 
+// daemonSpawnLockTarget returns the lock target whose adjacent flock file
+// (daemon.spawn.lock, via config.WithFileLock) serializes the daemon spawn
+// window across processes.
+func daemonSpawnLockTarget() (string, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "daemon.spawn"), nil
+}
+
+// testHookSpawnPingPassed runs between the under-lock ping re-check and the
+// socket bind in bindControlServerExclusive. Tests substitute it to hold a
+// spawner inside that window and prove a concurrent spawner cannot enter it
+// at the same time. No-op in production.
+var testHookSpawnPingPassed = func() {}
+
+// bindControlServerExclusive re-checks for a live daemon and binds the
+// control socket while holding an exclusive cross-process file lock, making
+// the ping→bind sequence atomic across processes. RunDaemon's top-of-function
+// ping guard rejects the common duplicate-daemon cases, but two daemons
+// starting near-simultaneously can both pass that ping before either binds;
+// the second startControlServer would then unlink and rebind the socket path,
+// orphaning the first daemon — alive and looping, but unreachable (#718).
+//
+// The lock is held only for the ping+bind window, not the daemon lifetime,
+// and flock is released by the kernel if the holder dies, so a crashed
+// spawner cannot wedge future spawns.
+//
+// Returns alreadyRunning=true when a live daemon answered the under-lock
+// ping; the caller must exit cleanly (a non-zero exit would trip the
+// autostart unit's Restart=on-failure into a retry loop against the live
+// daemon).
+func bindControlServerExclusive(manager *Manager, scheduler *taskScheduler, shutdownCh chan struct{}) (closeFn func() error, alreadyRunning bool, err error) {
+	lockTarget, lockTargetErr := daemonSpawnLockTarget()
+	if lockTargetErr != nil {
+		return nil, false, lockTargetErr
+	}
+	lockErr := config.WithFileLock(lockTarget, func() error {
+		if pingErr := pingDaemon(); pingErr == nil {
+			alreadyRunning = true
+			return nil
+		}
+		testHookSpawnPingPassed()
+		var serverErr error
+		closeFn, serverErr = startControlServer(manager, scheduler, shutdownCh)
+		return serverErr
+	})
+	if lockErr != nil {
+		return nil, false, lockErr
+	}
+	return closeFn, alreadyRunning, nil
+}
+
 // startControlServer registers the control RPC service on the Unix socket and
-// returns a cleanup function that closes the listener and removes the socket
-// file. When shutdownCh is non-nil, the Shutdown RPC will close it on the
+// returns a cleanup function that closes the listener (which also unlinks the
+// socket file). When shutdownCh is non-nil, the Shutdown RPC will close it on the
 // first invocation, allowing the daemon main loop to exit on RPC request.
 // scheduler may be nil for servers that do not host task schedules (tests);
 // the ReloadTasks RPC then returns an error.
@@ -464,9 +518,13 @@ func startControlServer(manager *Manager, scheduler *taskScheduler, shutdownCh c
 	}()
 
 	return func() error {
-		err := listener.Close()
-		_ = os.Remove(socketPath)
-		return err
+		// Closing the listener also unlinks the socket file (net's default
+		// unlink-on-close for unix listeners it created). Deliberately no
+		// explicit os.Remove here: between the close-unlink and an explicit
+		// Remove, a new daemon can pass its ping check and bind a fresh
+		// socket at the same path, and the Remove would delete the new
+		// daemon's socket, orphaning it — the same race class as #718/#767.
+		return listener.Close()
 	}, nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -50,9 +50,17 @@ func RunDaemon(cfg *config.Config) error {
 	}
 
 	shutdownCh := make(chan struct{})
-	closeControl, err := startControlServer(manager, scheduler, shutdownCh)
+	closeControl, alreadyRunning, err := bindControlServerExclusive(manager, scheduler, shutdownCh)
 	if err != nil {
 		return fmt.Errorf("failed to start daemon control server: %w", err)
+	}
+	if alreadyRunning {
+		// A concurrent daemon won the ping→bind race while we were setting
+		// up: both of us passed the unsynchronized ping above before either
+		// bound (#718). Exit cleanly for the same Restart=on-failure reason
+		// as the guard at the top of this function.
+		log.InfoLog.Printf("another agent-factory daemon bound the control socket first; exiting")
+		return nil
 	}
 	defer func() {
 		if err := closeControl(); err != nil {
@@ -417,7 +425,23 @@ func StopDaemon() error {
 // already-gone because the daemon's own SIGTERM handler removes it via
 // removeDaemonPIDFile() before exiting — so on the SIGTERM-success path we
 // race with the daemon's own cleanup.
+//
+// A NEW daemon can also start during StopDaemon's signal/poll window (the
+// autostart unit racing `af daemon install`, or an upgrade respawn) and bind
+// the control socket before this cleanup runs. Removing the socket then would
+// unlink the live daemon's socket file: the daemon keeps serving the
+// unreachable inode, pings against the path fail, and the next EnsureDaemon
+// spawns yet another daemon while the first leaks (#767). So if anything
+// ANSWERS on the socket, the runtime files belong to a live daemon — leave
+// them all in place. The daemon we just stopped cannot answer: its listener
+// died with the process. The worst false positive (a ping answered by a
+// process still mid-SIGKILL) merely leaves a stale socket behind, which the
+// next spawn's bind path replaces.
 func cleanupDaemonRuntimeFiles(pidFile string) {
+	if err := pingDaemon(); err == nil {
+		log.InfoLog.Printf("a live daemon answered on the control socket after stop; leaving its runtime files in place")
+		return
+	}
 	if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
 		log.WarningLog.Printf("failed to remove daemon PID file: %v", err)
 	}

--- a/daemon/spawn_stop_race_test.go
+++ b/daemon/spawn_stop_race_test.go
@@ -1,0 +1,255 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// startTestControlServer binds a control server on the temp-home socket path
+// and registers its teardown. It stands in for a freshly-started "new" daemon
+// in the stop/start race tests below.
+func startTestControlServer(t *testing.T) {
+	t.Helper()
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	closeServer, err := startControlServer(manager, nil, nil)
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	t.Cleanup(func() { _ = closeServer() })
+}
+
+// TestStopDaemon_PreservesNewDaemonSocket is the regression test for #767.
+// Timeline it reproduces:
+//
+//  1. Old daemon A is running; its PID is in daemon.pid.
+//  2. StopDaemon SIGTERMs A and polls for its exit.
+//  3. During (or right after) that window a NEW daemon B starts and binds the
+//     control socket (autostart unit racing `af daemon install`, or an
+//     upgrade respawn).
+//  4. BUG (pre-fix): cleanupDaemonRuntimeFiles unconditionally removed the
+//     socket path, unlinking B's live socket — B kept serving an unreachable
+//     inode and the next EnsureDaemon spawned a third daemon while B leaked.
+//
+// Post-fix, cleanup pings the socket first and leaves the runtime files alone
+// when a live daemon answers.
+func TestStopDaemon_PreservesNewDaemonSocket(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not available: %v", err)
+	}
+	tmpHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
+
+	// Daemon B: a live control server already bound on the socket path.
+	startTestControlServer(t)
+	if err := pingDaemon(); err != nil {
+		t.Fatalf("control server not answering before StopDaemon: %v", err)
+	}
+
+	// Daemon A: a fake old daemon that exits on SIGTERM and exposes
+	// "--daemon" as a discrete cmdline token (same recipe as
+	// TestStopDaemon_SIGTERMFirst).
+	cmd := exec.Command("bash", "-c", "exec -a 'sleep --daemon af-test' sleep 60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon: %v", err)
+	}
+	pid := cmd.Process.Pid
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if isAgentFactoryDaemon(pid) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !isAgentFactoryDaemon(pid) {
+		t.Fatalf("fake daemon pid=%d not recognized as agent-factory daemon", pid)
+	}
+
+	// Reap A in a goroutine so /proc/<pid>/cmdline clears once it exits and
+	// the StopDaemon poll observes the death promptly.
+	go func() { _, _ = cmd.Process.Wait() }()
+
+	pidFile := filepath.Join(tmpHome, "daemon.pid")
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", pid)), 0600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	if err := StopDaemon(); err != nil {
+		t.Fatalf("StopDaemon: %v", err)
+	}
+
+	socketPath, err := DaemonSocketPath()
+	if err != nil {
+		t.Fatalf("DaemonSocketPath: %v", err)
+	}
+	if _, err := os.Stat(socketPath); err != nil {
+		t.Fatalf("StopDaemon removed the new daemon's socket file (#767): %v", err)
+	}
+	if err := pingDaemon(); err != nil {
+		t.Fatalf("new daemon no longer answers after StopDaemon (#767): %v", err)
+	}
+	// The whole runtime-file set is preserved when a live daemon answers —
+	// the PID file on disk may already be the new daemon's.
+	if _, err := os.Stat(pidFile); err != nil {
+		t.Fatalf("StopDaemon removed the PID file despite a live daemon answering: %v", err)
+	}
+}
+
+// TestCleanupDaemonRuntimeFiles_SkipsLiveDaemonFiles unit-tests the #767 guard
+// directly: with a live daemon answering on the socket, cleanup must leave
+// both runtime files in place.
+func TestCleanupDaemonRuntimeFiles_SkipsLiveDaemonFiles(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
+
+	startTestControlServer(t)
+
+	pidFile := filepath.Join(tmpHome, "daemon.pid")
+	if err := os.WriteFile(pidFile, []byte("12345"), 0600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	cleanupDaemonRuntimeFiles(pidFile)
+
+	socketPath, err := DaemonSocketPath()
+	if err != nil {
+		t.Fatalf("DaemonSocketPath: %v", err)
+	}
+	if _, err := os.Stat(socketPath); err != nil {
+		t.Fatalf("cleanup removed a live daemon's socket: %v", err)
+	}
+	if _, err := os.Stat(pidFile); err != nil {
+		t.Fatalf("cleanup removed the PID file despite a live daemon answering: %v", err)
+	}
+	if err := pingDaemon(); err != nil {
+		t.Fatalf("live daemon stopped answering after cleanup: %v", err)
+	}
+}
+
+// TestCleanupDaemonRuntimeFiles_RemovesDeadFiles is the companion negative
+// case: when nothing answers on the socket path (a stale file from a killed
+// daemon), cleanup must still remove both runtime files — the #767 guard must
+// not suppress legitimate cleanup.
+func TestCleanupDaemonRuntimeFiles_RemovesDeadFiles(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
+
+	socketPath, err := DaemonSocketPath()
+	if err != nil {
+		t.Fatalf("DaemonSocketPath: %v", err)
+	}
+	// A plain file at the socket path stands in for a SIGKILLed daemon's
+	// leftover socket: dialing it fails, so nothing answers the ping.
+	if err := os.WriteFile(socketPath, nil, 0600); err != nil {
+		t.Fatalf("write stale socket file: %v", err)
+	}
+	pidFile := filepath.Join(tmpHome, "daemon.pid")
+	if err := os.WriteFile(pidFile, []byte("12345"), 0600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	cleanupDaemonRuntimeFiles(pidFile)
+
+	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+		t.Fatalf("expected stale socket file to be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
+		t.Fatalf("expected stale PID file to be removed, stat err = %v", err)
+	}
+}
+
+// TestBindControlServerExclusive_ExactlyOneBinds closes out the residual of
+// #718 left after #791's RunDaemon ping-guard: two daemons could both pass
+// the ping (neither bound yet) and then both bind, with the second unlinking
+// and stealing the first's socket. The spawn flock makes ping→bind atomic, so
+// exactly one spawner binds and the other observes the winner and reports
+// alreadyRunning with no error (RunDaemon then exits 0 — no orphan, no steal).
+//
+// The flock is taken on separate file descriptors, so two goroutines in one
+// process contend on it exactly like two processes would.
+func TestBindControlServerExclusive_ExactlyOneBinds(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
+
+	// Hold the winner inside the ping→bind window so the loser provably
+	// arrives while the window is open. Without the lock the loser would
+	// pass its own ping during this sleep and steal the socket.
+	prevHook := testHookSpawnPingPassed
+	testHookSpawnPingPassed = func() { time.Sleep(150 * time.Millisecond) }
+	t.Cleanup(func() { testHookSpawnPingPassed = prevHook })
+
+	type result struct {
+		closeFn        func() error
+		alreadyRunning bool
+		err            error
+	}
+	results := make([]result, 2)
+
+	// Build the managers up front: NewManager can take the better part of a
+	// second, and constructing it inside the goroutines would skew the two
+	// spawners apart by more than the race window, letting the loser's ping
+	// trivially observe the winner even without the lock. The race under test
+	// is ping→bind, so only that part runs concurrently, released by a
+	// barrier.
+	managers := make([]*Manager, len(results))
+	for i := range managers {
+		manager, err := NewManager(config.DefaultConfig())
+		if err != nil {
+			t.Fatalf("NewManager: %v", err)
+		}
+		managers[i] = manager
+	}
+
+	startBarrier := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-startBarrier
+			closeFn, alreadyRunning, err := bindControlServerExclusive(managers[i], nil, nil)
+			results[i] = result{closeFn: closeFn, alreadyRunning: alreadyRunning, err: err}
+		}(i)
+	}
+	close(startBarrier)
+	wg.Wait()
+
+	var winners, losers int
+	for i, r := range results {
+		if r.err != nil {
+			t.Fatalf("spawner %d returned error: %v", i, r.err)
+		}
+		switch {
+		case r.closeFn != nil && !r.alreadyRunning:
+			winners++
+			t.Cleanup(func() { _ = r.closeFn() })
+		case r.closeFn == nil && r.alreadyRunning:
+			losers++
+		default:
+			t.Fatalf("spawner %d in inconsistent state: closeFn=%v alreadyRunning=%v", i, r.closeFn != nil, r.alreadyRunning)
+		}
+	}
+	if winners != 1 || losers != 1 {
+		t.Fatalf("expected exactly one spawner to bind and one to defer; got %d winners, %d losers", winners, losers)
+	}
+
+	// The surviving socket must belong to the winner and still answer — a
+	// steal would leave an unlinked listener and a path nothing serves.
+	if err := pingDaemon(); err != nil {
+		t.Fatalf("control socket does not answer after concurrent spawn: %v", err)
+	}
+}


### PR DESCRIPTION
## Post-#791 analysis

PR #791 rewrote `daemon/` and added a ping-guard at the top of `RunDaemon`, which fixed the *common* #718 case: a daemon started after a winner has already bound the socket now pings, sees the live daemon, and exits cleanly (exit 0 matters under the autostart unit's `Restart=on-failure`). Two race surfaces remained on master:

**#767 — still real.** `cleanupDaemonRuntimeFiles` (called from both `StopDaemon` cleanup paths) unconditionally removed `daemon.pid` and `daemon.sock`. A NEW daemon can start and bind the socket during StopDaemon's SIGTERM grace/poll window — e.g. the autostart unit racing `af daemon install` (`InstallAutostart` calls `StopDaemon` right before `systemctl enable --now`), or an upgrade respawn. The cleanup then unlinks the new daemon's socket: it keeps serving the unreachable inode, pings against the path fail, the next `EnsureDaemon` spawns yet another daemon, and the unlinked-socket daemon is orphaned — the #718-class breeding ground.

**#718 residual.** The #791 ping-guard is not atomic with the bind. Two daemons starting near-simultaneously can both pass the ping (neither bound yet), then both bind; `startControlServer` unlinks and rebinds the socket path, orphaning the first daemon — alive and running its AutoYes/scheduler loops, but unreachable and unkillable via the socket.

## Fixes

1. **`cleanupDaemonRuntimeFiles` pings before removing.** If anything answers on the socket, a live daemon owns the runtime files — skip removal and log. The daemon we just stopped cannot answer (its listener died with the process). Worst false positive (ping answered by a process mid-SIGKILL) leaves a stale socket that the next spawn's bind path replaces — strictly better than unlinking a live daemon's socket.
2. **`bindControlServerExclusive`**: `RunDaemon` now re-checks the ping and binds the socket under an exclusive cross-process flock (`daemon.spawn.lock`, via the existing `config.WithFileLock`), making ping→bind atomic across processes. Held only for that window, not the daemon lifetime; the kernel releases flock if the holder dies. The loser exits cleanly with the same log/exit semantics as the #791 guard. The original top-of-function ping stays as an unsynchronized fast path.
3. **Adjacent site (per cleanup-audit): dropped the redundant `os.Remove(socketPath)` in the control-server close closure.** Go's unix listener already unlinks the path on `Close()`; the extra `Remove` ran *after* the unlink, so a new daemon binding in between would have its fresh socket deleted — the same race class.

## Lifecycle audit (all socket-remove / daemon-spawn sites)

| Site | Action | Exposure | Status |
|---|---|---|---|
| `cleanupDaemonRuntimeFiles` (both `StopDaemon` paths) | remove `daemon.pid` + `daemon.sock` | new daemon binds during stop window (#767) | **fixed** — ping guard skips live daemon's files |
| `startControlServer` pre-bind `os.Remove` | unlink existing socket before bind | could steal a live socket if two spawners passed ping (#718) | **fixed** — only reachable under `daemon.spawn.lock` after the under-lock ping failed |
| `closeControl` closure `os.Remove` | unlink after `listener.Close()` | `Close()` already unlinks; the extra Remove could delete a successor's fresh socket | **fixed** — removed, rely on net's unlink-on-close |
| `RunDaemon` top ping guard (#791) | exit if daemon answers | fast path only, not atomic | kept; atomicity now comes from the locked re-check |
| `EnsureDaemon` ping→`StopDaemon`→launch | spawn `af --daemon` | process-local mutex only | safe by construction post-fix: a double-launched child exits 0 via the locked re-check, no steal |
| `InstallAutostart` (`StopDaemon` then `systemctl enable --now` / `launchctl load`) | hand over ad-hoc → supervised daemon | the canonical #767 interleaving | **fixed** by the cleanup ping guard |
| daemon's own deferred `removeDaemonPIDFile` | remove own PID file on exit | defers run LIFO: PID file removed while the listener still answers pings, so no successor can exist yet | safe (ordering) |
| `sigtermFallback` `removeDaemonPIDFile`; `StopDaemon` stale-PID removals | remove `daemon.pid` | microsecond read-vs-rewrite window could drop a successor's fresh PID file | accepted: PID file is advisory (readers verify cmdline, pgrep fallback exists); non-orphaning, self-healing |

Remaining accepted window: a wedged daemon that holds the socket but can't answer a ping within 250ms can still have its socket replaced by a new spawn — that is the intended recovery path for a hung daemon.

## Tests

All hermetic (temp `AGENT_FACTORY_HOME`, never the real home — this box runs a real supervised daemon):

- `TestStopDaemon_PreservesNewDaemonSocket` (#767, full flow): live control server B bound, fake SIGTERM-able daemon A in the PID file; `StopDaemon` runs end-to-end; asserts B's socket file survives and B still answers pings.
- `TestCleanupDaemonRuntimeFiles_SkipsLiveDaemonFiles` / `_RemovesDeadFiles`: the guard skips a live daemon's files and still removes genuinely dead ones.
- `TestBindControlServerExclusive_ExactlyOneBinds` (#718 residual): two concurrent spawners released by a barrier, with a test hook holding the winner inside the ping→bind window; asserts exactly one binds, the other reports already-running with nil error (→ clean exit, no orphan), and the surviving socket still answers. The flock is taken on separate fds, so in-process goroutines contend exactly like separate processes.

Each test was mutation-verified: with the cleanup ping-guard deleted, the #767 tests fail ("cleanup removed a live daemon's socket"); with the flock disabled, the spawn test fails with the actual steal symptoms (`bind: address already in use` / `chmod: no such file or directory`).

## Verification

- `go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` — all clean
- `go test ./...` — green except the known dev-box-only `TestSigtermFallback_DeadPID` flake ("ambiguous, found 2 `af --daemon` processes" — caused by the real supervised daemons running on this machine, not by this change)
- `go test -race ./daemon/ ./config/` and `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/... ./app/...` — green

Fixes #718
Fixes #767

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)