### PR TITLE
feat(daemon,task): watch_cmd trigger and target_session delivery (phase 2 of #782)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,20 +110,30 @@ af sessions kill <title>                                       # kill + clean up
 
 ### Tasks
 
+A task fires either on a schedule (`--cron`) or whenever a long-running watch
+script emits a stdout line (`--watch-cmd`) — exactly one of the two. By
+default each fire creates a fresh session; `--target-session` instead sends
+the prompt into an existing session by title (auto-created if missing). Watch
+prompts may reference the emitted line as `{{line}}`; with no prompt the raw
+line is delivered.
+
 ```bash
-af tasks list                                                  # list scheduled tasks
+af tasks list                                                  # list tasks
 af tasks add --name "Daily triage" --prompt "..." --cron "0 9 * * *" --program claude
+af tasks add --name "gh-issues" --watch-cmd "gh-issue-watch.sh" \
+  --prompt "Triage: {{line}}" --target-session captain         # event-driven task
 af tasks get <id>                                              # fetch one task
-af tasks trigger <id>                                          # run task immediately
+af tasks trigger <id>                                          # run a cron task immediately
 af tasks update <id> --cron "..." --prompt "..." --enabled true
 af tasks remove <id>                                           # delete a task
 ```
 
 ### Daemon
 
-The background daemon hosts task cron schedules and autoyes mode. It starts on
-demand; installing it as a user-level autostart unit (systemd user service on
-Linux, launchd agent on macOS) keeps scheduled tasks firing after reboots.
+The background daemon hosts task cron schedules, watch-task scripts, and
+autoyes mode. It starts on demand; installing it as a user-level autostart
+unit (systemd user service on Linux, launchd agent on macOS) keeps scheduled
+tasks firing after reboots.
 
 ```bash
 af daemon install                                              # register autostart at login

--- a/api/api.go
+++ b/api/api.go
@@ -218,16 +218,18 @@ func init() {
 
 	// Tasks
 	tasksAddCmd.Flags().StringVar(&taskAddNameFlag, "name", "", "Task name (required)")
-	tasksAddCmd.Flags().StringVar(&taskAddPromptFlag, "prompt", "", "Prompt to send (required)")
-	tasksAddCmd.Flags().StringVar(&taskAddCronFlag, "cron", "", "Cron expression (required)")
+	tasksAddCmd.Flags().StringVar(&taskAddPromptFlag, "prompt", "", "Prompt to send (required for --cron tasks; --watch-cmd tasks default to the emitted line, with {{line}} substituted when present)")
+	tasksAddCmd.Flags().StringVar(&taskAddCronFlag, "cron", "", "Cron expression (exactly one of --cron / --watch-cmd)")
+	tasksAddCmd.Flags().StringVar(&taskAddWatchCmdFlag, "watch-cmd", "", "Long-running watch command; each stdout line triggers the task (exactly one of --cron / --watch-cmd)")
+	tasksAddCmd.Flags().StringVar(&taskAddTargetSessionFlag, "target-session", "", "Deliver the prompt into this session (auto-created if missing); empty creates a new session per run")
 	tasksAddCmd.Flags().StringVar(&taskAddProgramFlag, "program", "", "Program to run (defaults to config default)")
 	tasksAddCmd.MarkFlagRequired("name")
-	tasksAddCmd.MarkFlagRequired("prompt")
-	tasksAddCmd.MarkFlagRequired("cron")
 
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateNameFlag, "name", "", "New task name")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdatePromptFlag, "prompt", "", "New prompt")
-	tasksUpdateCmd.Flags().StringVar(&taskUpdateCronFlag, "cron", "", "New cron expression")
+	tasksUpdateCmd.Flags().StringVar(&taskUpdateCronFlag, "cron", "", "New cron expression (clears watch-cmd)")
+	tasksUpdateCmd.Flags().StringVar(&taskUpdateWatchCmdFlag, "watch-cmd", "", "New watch command (clears cron)")
+	tasksUpdateCmd.Flags().StringVar(&taskUpdateTargetSessionFlag, "target-session", "", "New target session; pass an empty value to revert to a new session per run")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateEnabledFlag, "enabled", "", "Enable or disable the task (true/false)")
 
 	TasksCmd.AddCommand(tasksListCmd)

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -79,10 +79,12 @@ var tasksListCmd = &cobra.Command{
 }
 
 var (
-	taskAddNameFlag    string
-	taskAddPromptFlag  string
-	taskAddCronFlag    string
-	taskAddProgramFlag string
+	taskAddNameFlag          string
+	taskAddPromptFlag        string
+	taskAddCronFlag          string
+	taskAddWatchCmdFlag      string
+	taskAddTargetSessionFlag string
+	taskAddProgramFlag       string
 )
 
 var tasksAddCmd = &cobra.Command{
@@ -97,15 +99,24 @@ var tasksAddCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("--repo is required: %w", err))
 		}
 
-		// MarkFlagRequired only enforces presence, so --prompt "" or
-		// whitespace-only values slip past Cobra and create tasks that
-		// no-op when triggered (#517).
-		if strings.TrimSpace(taskAddPromptFlag) == "" {
-			return jsonError(errors.New("prompt must be non-empty"))
+		hasCron := strings.TrimSpace(taskAddCronFlag) != ""
+		hasWatch := strings.TrimSpace(taskAddWatchCmdFlag) != ""
+		if hasCron == hasWatch {
+			return jsonError(errors.New("exactly one of --cron or --watch-cmd is required"))
 		}
 
-		if err := task.ValidateCronExpr(taskAddCronFlag); err != nil {
-			return jsonError(fmt.Errorf("invalid cron expression: %w", err))
+		if hasCron {
+			// Cron tasks need a prompt — there is no event line to fall back
+			// to. Trim-validate because MarkFlagRequired-style presence checks
+			// let whitespace-only values create no-op tasks (#517). Watch
+			// tasks may omit the prompt: each delivery defaults to the raw
+			// emitted line (#782).
+			if strings.TrimSpace(taskAddPromptFlag) == "" {
+				return jsonError(errors.New("prompt must be non-empty"))
+			}
+			if err := task.ValidateCronExpr(taskAddCronFlag); err != nil {
+				return jsonError(fmt.Errorf("invalid cron expression: %w", err))
+			}
 		}
 
 		program := taskAddProgramFlag
@@ -121,14 +132,16 @@ var tasksAddCmd = &cobra.Command{
 
 		id := task.GenerateID()
 		s := task.Task{
-			ID:          id,
-			Name:        taskAddNameFlag,
-			Prompt:      taskAddPromptFlag,
-			CronExpr:    taskAddCronFlag,
-			ProjectPath: repo.Root,
-			Program:     program,
-			Enabled:     true,
-			CreatedAt:   time.Now(),
+			ID:            id,
+			Name:          taskAddNameFlag,
+			Prompt:        taskAddPromptFlag,
+			CronExpr:      strings.TrimSpace(taskAddCronFlag),
+			WatchCmd:      strings.TrimSpace(taskAddWatchCmdFlag),
+			TargetSession: taskAddTargetSessionFlag,
+			ProjectPath:   repo.Root,
+			Program:       program,
+			Enabled:       true,
+			CreatedAt:     time.Now(),
 		}
 
 		if err := task.AddTask(s); err != nil {
@@ -205,10 +218,12 @@ var tasksRunCmd = &cobra.Command{
 }
 
 var (
-	taskUpdateNameFlag    string
-	taskUpdatePromptFlag  string
-	taskUpdateCronFlag    string
-	taskUpdateEnabledFlag string
+	taskUpdateNameFlag          string
+	taskUpdatePromptFlag        string
+	taskUpdateCronFlag          string
+	taskUpdateWatchCmdFlag      string
+	taskUpdateTargetSessionFlag string
+	taskUpdateEnabledFlag       string
 )
 
 var tasksUpdateCmd = &cobra.Command{
@@ -243,11 +258,33 @@ var tasksUpdateCmd = &cobra.Command{
 			s.Prompt = taskUpdatePromptFlag
 		}
 
+		if taskUpdateCronFlag != "" && taskUpdateWatchCmdFlag != "" {
+			return jsonError(errors.New("--cron and --watch-cmd are mutually exclusive; a task has exactly one trigger"))
+		}
 		if taskUpdateCronFlag != "" {
 			if err := task.ValidateCronExpr(taskUpdateCronFlag); err != nil {
 				return jsonError(fmt.Errorf("invalid cron expression: %w", err))
 			}
+			// Watch tasks may have an empty prompt (events default to the raw
+			// line), but a cron fire has no line to fall back to — switching
+			// triggers must supply one.
+			if s.WatchCmd != "" && strings.TrimSpace(s.Prompt) == "" {
+				return jsonError(errors.New("switching to a cron trigger needs a prompt; set one with --prompt"))
+			}
+			// Setting one trigger clears the other so the exactly-one rule
+			// holds when switching a watch task back to a schedule.
 			s.CronExpr = taskUpdateCronFlag
+			s.WatchCmd = ""
+		}
+		if taskUpdateWatchCmdFlag != "" {
+			s.WatchCmd = strings.TrimSpace(taskUpdateWatchCmdFlag)
+			s.CronExpr = ""
+		}
+		// --target-session "" is a meaningful value (revert to
+		// create-a-session-per-run), so distinguish "flag not given" from
+		// "given as empty" instead of treating "" as unchanged.
+		if cmd.Flags().Changed("target-session") {
+			s.TargetSession = taskUpdateTargetSessionFlag
 		}
 
 		switch taskUpdateEnabledFlag {

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -57,16 +57,19 @@ func useTempConfig(t *testing.T) {
 // tests don't leak state into each other.
 func resetUpdateFlags(t *testing.T) {
 	t.Helper()
-	t.Cleanup(func() {
+	reset := func() {
 		taskUpdateNameFlag = ""
 		taskUpdatePromptFlag = ""
 		taskUpdateCronFlag = ""
+		taskUpdateWatchCmdFlag = ""
+		taskUpdateTargetSessionFlag = ""
 		taskUpdateEnabledFlag = ""
-	})
-	taskUpdateNameFlag = ""
-	taskUpdatePromptFlag = ""
-	taskUpdateCronFlag = ""
-	taskUpdateEnabledFlag = ""
+		// --target-session uses Changed() semantics ("" is a meaningful
+		// value), so the cobra-level Changed marker must reset too.
+		tasksUpdateCmd.Flags().Lookup("target-session").Changed = false
+	}
+	t.Cleanup(reset)
+	reset()
 }
 
 // resetAddFlags clears the package-level add flag variables so tests don't
@@ -77,6 +80,8 @@ func resetAddFlags(t *testing.T) {
 		taskAddNameFlag = ""
 		taskAddPromptFlag = ""
 		taskAddCronFlag = ""
+		taskAddWatchCmdFlag = ""
+		taskAddTargetSessionFlag = ""
 		taskAddProgramFlag = ""
 		repoFlag = ""
 	}
@@ -338,4 +343,165 @@ func TestTasksTrigger_RejectsInvalidTaskID(t *testing.T) {
 	err := tasksRunCmd.RunE(tasksRunCmd, []string{"../evil"})
 	require.Error(t, err)
 	assert.Empty(t, calls.triggered, "invalid IDs must be rejected before reaching the daemon")
+}
+
+// TestTasksAdd_ExactlyOneTrigger pins the #782 CLI contract: --cron and
+// --watch-cmd are mutually exclusive and one of them is required.
+func TestTasksAdd_ExactlyOneTrigger(t *testing.T) {
+	cases := []struct {
+		name  string
+		cron  string
+		watch string
+	}{
+		{"neither", "", ""},
+		{"both", "0 3 * * *", "tail -f log"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			useTempConfig(t)
+			resetAddFlags(t)
+			calls := stubDaemon(t)
+			setupAddRepo(t)
+
+			taskAddNameFlag = "trigger-shape"
+			taskAddPromptFlag = "p"
+			taskAddCronFlag = tc.cron
+			taskAddWatchCmdFlag = tc.watch
+
+			err := tasksAddCmd.RunE(tasksAddCmd, nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "exactly one of --cron or --watch-cmd")
+			assert.Zero(t, calls.reloads)
+
+			tasks, err := task.LoadTasks()
+			require.NoError(t, err)
+			assert.Empty(t, tasks)
+		})
+	}
+}
+
+// TestTasksAdd_WatchTaskAllowsEmptyPrompt verifies the watch-task defaults:
+// no prompt is fine (each event delivers the raw emitted line) and the new
+// fields persist.
+func TestTasksAdd_WatchTaskAllowsEmptyPrompt(t *testing.T) {
+	useTempConfig(t)
+	resetAddFlags(t)
+	calls := stubDaemon(t)
+	setupAddRepo(t)
+
+	taskAddNameFlag = "gh-issues"
+	taskAddWatchCmdFlag = "gh-issue-watch.sh"
+	taskAddTargetSessionFlag = "captain"
+	taskAddProgramFlag = "claude"
+
+	err := tasksAddCmd.RunE(tasksAddCmd, nil)
+	require.NoError(t, err)
+
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "gh-issue-watch.sh", tasks[0].WatchCmd)
+	assert.Equal(t, "captain", tasks[0].TargetSession)
+	assert.Empty(t, tasks[0].CronExpr)
+	assert.Empty(t, tasks[0].Prompt)
+	assert.True(t, tasks[0].Enabled)
+	assert.Equal(t, 1, calls.reloads, "add must poke the daemon so the watcher starts")
+}
+
+// TestTasksUpdate_SwitchingTriggersClearsTheOther verifies that setting one
+// trigger via update clears the other, keeping the exactly-one invariant.
+func TestTasksUpdate_SwitchingTriggersClearsTheOther(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	stubDaemon(t)
+
+	seedTask(t, task.Task{ID: "sw1", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
+
+	// cron → watch
+	taskUpdateWatchCmdFlag = "tail -f errors.log"
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"sw1"}))
+	got, err := task.GetTask("sw1")
+	require.NoError(t, err)
+	assert.Equal(t, "tail -f errors.log", got.WatchCmd)
+	assert.Empty(t, got.CronExpr, "switching to watch must clear cron")
+
+	// watch → cron
+	resetUpdateFlags(t)
+	taskUpdateCronFlag = "0 4 * * *"
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"sw1"}))
+	got, err = task.GetTask("sw1")
+	require.NoError(t, err)
+	assert.Equal(t, "0 4 * * *", got.CronExpr)
+	assert.Empty(t, got.WatchCmd, "switching to cron must clear watch-cmd")
+}
+
+// TestTasksUpdate_RejectsBothTriggerFlags pins that one update cannot set
+// both triggers at once.
+func TestTasksUpdate_RejectsBothTriggerFlags(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	stubDaemon(t)
+
+	seedTask(t, task.Task{ID: "bt1", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
+
+	taskUpdateCronFlag = "0 4 * * *"
+	taskUpdateWatchCmdFlag = "tail -f x"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"bt1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestTasksUpdate_SwitchToCronRequiresPrompt covers the watch→cron edge: a
+// watch task may have no prompt, but a cron task cannot run without one.
+func TestTasksUpdate_SwitchToCronRequiresPrompt(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	stubDaemon(t)
+
+	seedTask(t, task.Task{ID: "sc1", WatchCmd: "tail -f x", Enabled: true})
+
+	taskUpdateCronFlag = "0 4 * * *"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"sc1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "needs a prompt")
+
+	// With a prompt in the same update it succeeds.
+	resetUpdateFlags(t)
+	taskUpdateCronFlag = "0 4 * * *"
+	taskUpdatePromptFlag = "scheduled sweep"
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"sc1"}))
+}
+
+// TestTasksUpdate_TargetSessionSetAndClear pins the Changed() semantics:
+// --target-session is applied when given — including an explicit empty value,
+// which reverts to a-new-session-per-run — and left untouched when absent.
+func TestTasksUpdate_TargetSessionSetAndClear(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	stubDaemon(t)
+
+	seedTask(t, task.Task{ID: "ts1", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
+
+	// Set it.
+	require.NoError(t, tasksUpdateCmd.Flags().Set("target-session", "captain"))
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"ts1"}))
+	got, err := task.GetTask("ts1")
+	require.NoError(t, err)
+	assert.Equal(t, "captain", got.TargetSession)
+
+	// An unrelated update leaves it alone.
+	resetUpdateFlags(t)
+	taskUpdateNameFlag = "renamed"
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"ts1"}))
+	got, err = task.GetTask("ts1")
+	require.NoError(t, err)
+	assert.Equal(t, "captain", got.TargetSession, "absent flag must not clear target_session")
+
+	// An explicit empty value clears it.
+	resetUpdateFlags(t)
+	require.NoError(t, tasksUpdateCmd.Flags().Set("target-session", ""))
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"ts1"}))
+	got, err = task.GetTask("ts1")
+	require.NoError(t, err)
+	assert.Empty(t, got.TargetSession, "explicit empty value must clear target_session")
 }

--- a/app/app.go
+++ b/app/app.go
@@ -607,6 +607,12 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 		return m.handleError(fmt.Errorf("no task selected"))
 	}
 
+	// Watch tasks fire from their watch command's stdout; a manual trigger
+	// has no event line to render the prompt with. Mirrors daemon.RunTask.
+	if tsk.IsWatch() {
+		return m.handleError(fmt.Errorf("task %q is a watch task; it fires when its watch command emits output", task.TaskRunBaseTitle(*tsk)))
+	}
+
 	repo, err := config.RepoFromPath(tsk.ProjectPath)
 	if err != nil {
 		return m.handleError(fmt.Errorf("failed to resolve repo for task path: %w", err))

--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -52,7 +52,14 @@ func sanitizeEnvValue(v string) string {
 // daemon running. PATH and SHELL are captured at install time because the
 // systemd user manager starts services with a minimal environment, and the
 // daemon needs the user's real PATH to find tmux and the agent programs.
-func systemdAutostartUnit(execPath, pathEnv, shellEnv string) string {
+// AGENT_FACTORY_HOME is captured for the same reason when the installing
+// shell has it set: without it the unit's daemon would serve the default
+// home instead of the custom one (#782).
+func systemdAutostartUnit(execPath, pathEnv, shellEnv, agentFactoryHome string) string {
+	envLines := fmt.Sprintf("Environment=PATH=%s\nEnvironment=SHELL=%s", sanitizeEnvValue(pathEnv), sanitizeEnvValue(shellEnv))
+	if agentFactoryHome != "" {
+		envLines += "\nEnvironment=AGENT_FACTORY_HOME=" + sanitizeEnvValue(agentFactoryHome)
+	}
 	return fmt.Sprintf(`[Unit]
 Description=Agent Factory daemon (task scheduler + autoyes)
 
@@ -60,20 +67,24 @@ Description=Agent Factory daemon (task scheduler + autoyes)
 ExecStart=%s --daemon
 Restart=on-failure
 RestartSec=5
-Environment=PATH=%s
-Environment=SHELL=%s
+%s
 
 [Install]
 WantedBy=default.target
-`, quoteExecStartPath(execPath), sanitizeEnvValue(pathEnv), sanitizeEnvValue(shellEnv))
+`, quoteExecStartPath(execPath), envLines)
 }
 
 // launchdAutostartPlist renders the launchd agent that keeps the daemon
 // running on macOS. KeepAlive on unsuccessful exit mirrors the systemd
 // Restart=on-failure behavior; logPath captures crashes that happen before
-// the daemon's own logging is up.
-func launchdAutostartPlist(execPath, pathEnv, shellEnv, logPath string) string {
+// the daemon's own logging is up. AGENT_FACTORY_HOME is captured when set,
+// matching the systemd unit (#782).
+func launchdAutostartPlist(execPath, pathEnv, shellEnv, agentFactoryHome, logPath string) string {
 	esc := html.EscapeString
+	homeEntry := ""
+	if agentFactoryHome != "" {
+		homeEntry = fmt.Sprintf("        <key>AGENT_FACTORY_HOME</key>\n        <string>%s</string>\n", esc(agentFactoryHome))
+	}
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -98,14 +109,14 @@ func launchdAutostartPlist(execPath, pathEnv, shellEnv, logPath string) string {
         <string>%s</string>
         <key>SHELL</key>
         <string>%s</string>
-    </dict>
+%s    </dict>
     <key>StandardOutPath</key>
     <string>%s</string>
     <key>StandardErrorPath</key>
     <string>%s</string>
 </dict>
 </plist>
-`, autostartLaunchdLabel, esc(execPath), esc(pathEnv), esc(shellEnv), esc(logPath), esc(logPath))
+`, autostartLaunchdLabel, esc(execPath), esc(pathEnv), esc(shellEnv), homeEntry, esc(logPath), esc(logPath))
 }
 
 // InstallAutostart registers the daemon for autostart at login: a systemd
@@ -129,7 +140,7 @@ func InstallAutostart() (string, error) {
 			return "", fmt.Errorf("failed to create systemd user directory: %w", err)
 		}
 		unitPath := filepath.Join(dir, autostartUnitName)
-		content := systemdAutostartUnit(execPath, os.Getenv("PATH"), os.Getenv("SHELL"))
+		content := systemdAutostartUnit(execPath, os.Getenv("PATH"), os.Getenv("SHELL"), os.Getenv("AGENT_FACTORY_HOME"))
 		if err := config.AtomicWriteFile(unitPath, []byte(content), 0644); err != nil {
 			return "", fmt.Errorf("failed to write unit file: %w", err)
 		}
@@ -160,7 +171,7 @@ func InstallAutostart() (string, error) {
 			return "", fmt.Errorf("failed to get config directory: %w", err)
 		}
 		logPath := filepath.Join(configDir, "daemon-launchd.log")
-		content := launchdAutostartPlist(execPath, os.Getenv("PATH"), os.Getenv("SHELL"), logPath)
+		content := launchdAutostartPlist(execPath, os.Getenv("PATH"), os.Getenv("SHELL"), os.Getenv("AGENT_FACTORY_HOME"), logPath)
 		// Unload a previous agent first so launchctl load picks up the new file.
 		_ = exec.Command("launchctl", "unload", plistPath).Run()
 		if err := config.AtomicWriteFile(plistPath, []byte(content), 0644); err != nil {

--- a/daemon/autostart_test.go
+++ b/daemon/autostart_test.go
@@ -10,7 +10,7 @@ import (
 // functions are pinned here instead.
 
 func TestSystemdAutostartUnitContent(t *testing.T) {
-	got := systemdAutostartUnit("/home/user/.local/bin/af", "/usr/bin:/bin", "/bin/zsh")
+	got := systemdAutostartUnit("/home/user/.local/bin/af", "/usr/bin:/bin", "/bin/zsh", "")
 	want := `[Unit]
 Description=Agent Factory daemon (task scheduler + autoyes)
 
@@ -33,7 +33,7 @@ WantedBy=default.target
 // binary path with spaces must stay one ExecStart argument, and % / $ must
 // be doubled so systemd does not expand them as specifiers/variables.
 func TestSystemdAutostartUnitEscapesSpecials(t *testing.T) {
-	got := systemdAutostartUnit("/opt/my tools/af", "/usr/bin:/home/u/100%path:$HOME/bin", "/bin/bash")
+	got := systemdAutostartUnit("/opt/my tools/af", "/usr/bin:/home/u/100%path:$HOME/bin", "/bin/bash", "")
 	if !strings.Contains(got, `ExecStart="/opt/my tools/af" --daemon`) {
 		t.Errorf("path with spaces must be quoted in ExecStart, got:\n%s", got)
 	}
@@ -43,7 +43,7 @@ func TestSystemdAutostartUnitEscapesSpecials(t *testing.T) {
 }
 
 func TestLaunchdAutostartPlistContent(t *testing.T) {
-	got := launchdAutostartPlist("/Users/user/.local/bin/af", "/usr/bin:/bin", "/bin/zsh", "/Users/user/.agent-factory/daemon-launchd.log")
+	got := launchdAutostartPlist("/Users/user/.local/bin/af", "/usr/bin:/bin", "/bin/zsh", "", "/Users/user/.agent-factory/daemon-launchd.log")
 	want := `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -84,11 +84,50 @@ func TestLaunchdAutostartPlistContent(t *testing.T) {
 // TestLaunchdAutostartPlistEscapesXML guards against a path containing XML
 // metacharacters breaking the plist.
 func TestLaunchdAutostartPlistEscapesXML(t *testing.T) {
-	got := launchdAutostartPlist("/opt/a&b/af", "/usr/bin", "/bin/sh", "/tmp/<log>.log")
+	got := launchdAutostartPlist("/opt/a&b/af", "/usr/bin", "/bin/sh", "", "/tmp/<log>.log")
 	if !strings.Contains(got, "<string>/opt/a&amp;b/af</string>") {
 		t.Errorf("& must be XML-escaped in the binary path, got:\n%s", got)
 	}
 	if !strings.Contains(got, "<string>/tmp/&lt;log&gt;.log</string>") {
 		t.Errorf("< and > must be XML-escaped in the log path, got:\n%s", got)
+	}
+}
+
+// TestSystemdAutostartUnitCapturesAgentFactoryHome pins the #782 phase-2 nit:
+// when the installing shell has AGENT_FACTORY_HOME set, the unit must carry it
+// into the daemon's environment, or the supervised daemon would serve the
+// default home instead of the custom one.
+func TestSystemdAutostartUnitCapturesAgentFactoryHome(t *testing.T) {
+	got := systemdAutostartUnit("/home/user/.local/bin/af", "/usr/bin:/bin", "/bin/zsh", "/srv/af-home")
+	want := `[Unit]
+Description=Agent Factory daemon (task scheduler + autoyes)
+
+[Service]
+ExecStart="/home/user/.local/bin/af" --daemon
+Restart=on-failure
+RestartSec=5
+Environment=PATH=/usr/bin:/bin
+Environment=SHELL=/bin/zsh
+Environment=AGENT_FACTORY_HOME=/srv/af-home
+
+[Install]
+WantedBy=default.target
+`
+	if got != want {
+		t.Fatalf("systemd unit content mismatch.\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestLaunchdAutostartPlistCapturesAgentFactoryHome is the launchd variant of
+// the AGENT_FACTORY_HOME capture, including XML escaping of the value.
+func TestLaunchdAutostartPlistCapturesAgentFactoryHome(t *testing.T) {
+	got := launchdAutostartPlist("/Users/user/.local/bin/af", "/usr/bin:/bin", "/bin/zsh", "/Users/user/af homes/<a&b>", "/Users/user/.agent-factory/daemon-launchd.log")
+	wantEntry := `        <key>SHELL</key>
+        <string>/bin/zsh</string>
+        <key>AGENT_FACTORY_HOME</key>
+        <string>/Users/user/af homes/&lt;a&amp;b&gt;</string>
+    </dict>`
+	if !strings.Contains(got, wantEntry) {
+		t.Fatalf("plist must carry an escaped AGENT_FACTORY_HOME inside EnvironmentVariables, got:\n%s", got)
 	}
 }

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -327,6 +327,7 @@ func isRPCMethodNotFoundErr(err error) bool {
 type controlServer struct {
 	manager      *Manager
 	scheduler    *taskScheduler
+	watchers     *watcherSupervisor
 	shutdownCh   chan struct{}
 	shutdownOnce sync.Once
 }
@@ -342,6 +343,14 @@ func (s *controlServer) ReloadTasks(_ ReloadTasksRequest, resp *ReloadTasksRespo
 	}
 	if err := s.scheduler.Reload(); err != nil {
 		return err
+	}
+	// Watch tasks live in the watcher supervisor; one reload poke re-arms
+	// both trigger types (#782 phase 2). Nil only in tests that exercise the
+	// scheduler alone.
+	if s.watchers != nil {
+		if err := s.watchers.Reload(); err != nil {
+			return err
+		}
 	}
 	resp.OK = true
 	return nil
@@ -451,7 +460,7 @@ var testHookSpawnPingPassed = func() {}
 // ping; the caller must exit cleanly (a non-zero exit would trip the
 // autostart unit's Restart=on-failure into a retry loop against the live
 // daemon).
-func bindControlServerExclusive(manager *Manager, scheduler *taskScheduler, shutdownCh chan struct{}) (closeFn func() error, alreadyRunning bool, err error) {
+func bindControlServerExclusive(manager *Manager, scheduler *taskScheduler, watchers *watcherSupervisor, shutdownCh chan struct{}) (closeFn func() error, alreadyRunning bool, err error) {
 	lockTarget, lockTargetErr := daemonSpawnLockTarget()
 	if lockTargetErr != nil {
 		return nil, false, lockTargetErr
@@ -463,7 +472,7 @@ func bindControlServerExclusive(manager *Manager, scheduler *taskScheduler, shut
 		}
 		testHookSpawnPingPassed()
 		var serverErr error
-		closeFn, serverErr = startControlServer(manager, scheduler, shutdownCh)
+		closeFn, serverErr = startControlServer(manager, scheduler, watchers, shutdownCh)
 		return serverErr
 	})
 	if lockErr != nil {
@@ -477,8 +486,9 @@ func bindControlServerExclusive(manager *Manager, scheduler *taskScheduler, shut
 // socket file). When shutdownCh is non-nil, the Shutdown RPC will close it on the
 // first invocation, allowing the daemon main loop to exit on RPC request.
 // scheduler may be nil for servers that do not host task schedules (tests);
-// the ReloadTasks RPC then returns an error.
-func startControlServer(manager *Manager, scheduler *taskScheduler, shutdownCh chan struct{}) (func() error, error) {
+// the ReloadTasks RPC then returns an error. watchers may likewise be nil,
+// in which case ReloadTasks only refreshes cron entries.
+func startControlServer(manager *Manager, scheduler *taskScheduler, watchers *watcherSupervisor, shutdownCh chan struct{}) (func() error, error) {
 	socketPath, err := DaemonSocketPath()
 	if err != nil {
 		return nil, err
@@ -501,6 +511,7 @@ func startControlServer(manager *Manager, scheduler *taskScheduler, shutdownCh c
 	if err := server.RegisterName(controlServiceName, &controlServer{
 		manager:    manager,
 		scheduler:  scheduler,
+		watchers:   watchers,
 		shutdownCh: shutdownCh,
 	}); err != nil {
 		_ = listener.Close()

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -406,7 +406,7 @@ func TestControlServerCreateAndKillSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	closeServer, err := startControlServer(manager, nil, nil)
+	closeServer, err := startControlServer(manager, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("startControlServer: %v", err)
 	}
@@ -457,7 +457,7 @@ func TestControlServerShutdownClosesChannel(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 	shutdownCh := make(chan struct{})
-	closeServer, err := startControlServer(manager, nil, shutdownCh)
+	closeServer, err := startControlServer(manager, nil, nil, shutdownCh)
 	if err != nil {
 		t.Fatalf("startControlServer: %v", err)
 	}
@@ -542,7 +542,7 @@ func TestRequestShutdownSuccess(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 	shutdownCh := make(chan struct{})
-	closeServer, err := startControlServer(manager, nil, shutdownCh)
+	closeServer, err := startControlServer(manager, nil, nil, shutdownCh)
 	if err != nil {
 		t.Fatalf("startControlServer: %v", err)
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -48,9 +48,10 @@ func RunDaemon(cfg *config.Config) error {
 	if err := scheduler.Reload(); err != nil {
 		log.WarningLog.Printf("failed to load task schedules: %v", err)
 	}
+	watchers := newWatcherSupervisor()
 
 	shutdownCh := make(chan struct{})
-	closeControl, alreadyRunning, err := bindControlServerExclusive(manager, scheduler, shutdownCh)
+	closeControl, alreadyRunning, err := bindControlServerExclusive(manager, scheduler, watchers, shutdownCh)
 	if err != nil {
 		return fmt.Errorf("failed to start daemon control server: %w", err)
 	}
@@ -72,6 +73,16 @@ func RunDaemon(cfg *config.Config) error {
 	// firing immediately goes through the CreateSession RPC on our own socket.
 	scheduler.Start()
 	defer scheduler.Stop()
+
+	// Same ordering constraint for the watch-task supervisor: its event
+	// deliveries also loop back through our own control socket, so the first
+	// watcher spawns only once the server is accepting. The deferred Stop
+	// runs before the deferred closeControl (LIFO), so in-flight deliveries
+	// during shutdown still find a live socket.
+	if err := watchers.Reload(); err != nil {
+		log.WarningLog.Printf("failed to start task watchers: %v", err)
+	}
+	defer watchers.Stop()
 
 	// Write our PID so `af upgrade`'s SIGTERM fallback (#504) can find the
 	// running daemon. Both the SIGTERM and Shutdown-RPC exit paths fall

--- a/daemon/scheduler.go
+++ b/daemon/scheduler.go
@@ -78,6 +78,11 @@ func (s *taskScheduler) Reload() error {
 		if !t.Enabled {
 			continue
 		}
+		// Watch tasks are event-triggered: the watcher supervisor hosts them,
+		// not the cron scheduler (#782 phase 2).
+		if t.IsWatch() {
+			continue
+		}
 		schedule, err := s.parse(t.CronExpr)
 		if err != nil {
 			log.WarningLog.Printf("task %s has an invalid cron expression %q, not scheduling it: %v", t.ID, t.CronExpr, err)

--- a/daemon/scheduler_test.go
+++ b/daemon/scheduler_test.go
@@ -28,6 +28,9 @@ func TestSchedulerReloadRegistersEnabledValidTasks(t *testing.T) {
 			{ID: "aaaa0002", CronExpr: "*/5 * * * *", Enabled: false},
 			{ID: "aaaa0003", CronExpr: "not a cron", Enabled: true},
 			{ID: "aaaa0004", CronExpr: "0 0 * * 7", Enabled: true},
+			// Watch tasks are event-triggered and belong to the watcher
+			// supervisor, never the cron scheduler (#782 phase 2).
+			{ID: "aaaa0005", WatchCmd: "tail -f log", Enabled: true},
 		}, nil
 	}
 

--- a/daemon/spawn_stop_race_test.go
+++ b/daemon/spawn_stop_race_test.go
@@ -21,7 +21,7 @@ func startTestControlServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	closeServer, err := startControlServer(manager, nil, nil)
+	closeServer, err := startControlServer(manager, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("startControlServer: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestBindControlServerExclusive_ExactlyOneBinds(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-startBarrier
-			closeFn, alreadyRunning, err := bindControlServerExclusive(managers[i], nil, nil)
+			closeFn, alreadyRunning, err := bindControlServerExclusive(managers[i], nil, nil, nil)
 			results[i] = result{closeFn: closeFn, alreadyRunning: alreadyRunning, err: err}
 		}(i)
 	}

--- a/daemon/taskrun.go
+++ b/daemon/taskrun.go
@@ -14,12 +14,97 @@ import (
 	"github.com/sachiniyer/agent-factory/task"
 )
 
-// RunTask executes a task by creating a new session via the daemon's
-// CreateSession path and recording the run status on the task. It is the
-// single firing path for tasks: the in-daemon cron scheduler and the
-// `af tasks trigger` CLI both land here. When called from inside the daemon
-// the CreateSession RPC loops back through the daemon's own control socket,
-// so both callers share one code path.
+// Indirected so delivery tests can observe the daemon RPCs without dialing —
+// or spawning — a real daemon. Both helpers loop back through the daemon's
+// own control socket when called from inside the daemon process.
+var (
+	createSessionForTask = CreateSession
+	sendPromptForTask    = SendPrompt
+)
+
+// deliverTaskPrompt delivers one rendered prompt for a task and returns the
+// status string to record on it. With TargetSession empty it creates a fresh
+// session per run (the historical task behavior, status "started"). With
+// TargetSession set it sends the prompt into that session (status "sent"),
+// auto-creating the session with the task's ProjectPath/Program when it does
+// not exist yet (Sachin-approved in #782, mirroring `af sessions send-prompt
+// --create`). The target session is looked up in the task's own repo so a
+// same-titled session in an unrelated repo can never receive the prompt.
+func deliverTaskPrompt(t *task.Task, prompt string) (string, error) {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if t.TargetSession == "" {
+		data, err := createSessionForTask(CreateSessionRequest{
+			TitleBase: task.TaskRunBaseTitle(*t),
+			RepoPath:  t.ProjectPath,
+			Program:   t.Program,
+			Prompt:    prompt,
+			AutoYes:   cfg.AutoYes,
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to start task session: %w", err)
+		}
+		log.InfoLog.Printf("task %s started successfully as instance %s", t.ID, data.Title)
+		return "started", nil
+	}
+
+	repo, err := config.RepoFromPath(t.ProjectPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve repo for task path: %w", err)
+	}
+	exists, err := repoHasSessionTitle(repo.ID, t.TargetSession)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		if _, err := createSessionForTask(CreateSessionRequest{
+			Title:    t.TargetSession,
+			RepoPath: t.ProjectPath,
+			Program:  t.Program,
+			Prompt:   prompt,
+			AutoYes:  cfg.AutoYes,
+		}); err != nil {
+			return "", fmt.Errorf("failed to auto-create target session %q: %w", t.TargetSession, err)
+		}
+		log.InfoLog.Printf("task %s auto-created target session %q and delivered the prompt", t.ID, t.TargetSession)
+		return "started", nil
+	}
+	if err := sendPromptForTask(SendPromptRequest{
+		Title:  t.TargetSession,
+		RepoID: repo.ID,
+		Prompt: prompt,
+	}); err != nil {
+		return "", fmt.Errorf("failed to send prompt to target session %q: %w", t.TargetSession, err)
+	}
+	log.InfoLog.Printf("task %s sent prompt to target session %q", t.ID, t.TargetSession)
+	return "sent", nil
+}
+
+// repoHasSessionTitle reports whether a persisted session with the given
+// title exists in the repo. Mirrors api.repoHasInstanceTitle, which daemon/
+// cannot import without a cycle.
+func repoHasSessionTitle(repoID, title string) (bool, error) {
+	data, err := loadRepoInstanceData(repoID)
+	if err != nil {
+		return false, err
+	}
+	for i := range data {
+		if data[i].Title == title {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// RunTask executes a cron task by delivering its prompt (create a session,
+// or send into TargetSession) and recording the run status. It is the single
+// firing path for cron tasks: the in-daemon scheduler and the `af tasks
+// trigger` CLI both land here. Watch tasks are refused — they fire from
+// their watch command's stdout, and a manual trigger has no event line to
+// render the prompt with.
 func RunTask(taskID string) error {
 	// Validate the task ID before it flows into any filesystem path. The
 	// CLI boundary also validates, but this is the shared chokepoint that
@@ -38,6 +123,10 @@ func RunTask(taskID string) error {
 
 	if !t.Enabled {
 		return fmt.Errorf("task %s is disabled", taskID)
+	}
+
+	if t.IsWatch() {
+		return fmt.Errorf("task %s is a watch task; it fires when its watch command emits output, not on manual trigger", taskID)
 	}
 
 	// Create lock file to prevent overlapping runs.
@@ -78,30 +167,17 @@ func RunTask(taskID string) error {
 		return fmt.Errorf("project path %s is not a valid git repository", t.ProjectPath)
 	}
 
-	baseTitle := task.TaskRunBaseTitle(*t)
-	cfg, err := config.LoadConfig()
+	status, err := deliverTaskPrompt(t, t.Prompt)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-	data, err := CreateSession(CreateSessionRequest{
-		TitleBase: baseTitle,
-		RepoPath:  t.ProjectPath,
-		Program:   t.Program,
-		Prompt:    t.Prompt,
-		AutoYes:   cfg.AutoYes,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to start task session: %w", err)
+		return err
 	}
 
 	// Update task status. Use UpdateTaskStatus so we don't re-validate Program
-	// — the task already ran via CreateSession, and the stored Program value
-	// may predate current enum validation (see #664).
+	// — the task already ran via deliverTaskPrompt, and the stored Program
+	// value may predate current enum validation (see #664).
 	now := time.Now()
-	if err := task.UpdateTaskStatus(taskID, &now, "started"); err != nil {
+	if err := task.UpdateTaskStatus(taskID, &now, status); err != nil {
 		log.ErrorLog.Printf("failed to update task status: %v", err)
 	}
-
-	log.InfoLog.Printf("task %s started successfully as instance %s", taskID, data.Title)
 	return nil
 }

--- a/daemon/taskrun_test.go
+++ b/daemon/taskrun_test.go
@@ -1,11 +1,16 @@
 package daemon
 
 import (
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
 )
 
@@ -76,5 +81,222 @@ func TestRunTask_RefusesDisabledTask(t *testing.T) {
 	err := RunTask("eeee0001")
 	if err == nil {
 		t.Fatalf("expected error running a disabled task")
+	}
+}
+
+// setupTaskRepo creates a throwaway git repo so config.RepoFromPath inside
+// the delivery path succeeds. Returns the repo path.
+func setupTaskRepo(t *testing.T) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	for _, args := range [][]string{
+		{"init", repo},
+		{"-C", repo, "config", "user.email", "test@example.com"},
+		{"-C", repo, "config", "user.name", "Test User"},
+		{"-C", repo, "commit", "--allow-empty", "-m", "init"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return repo
+}
+
+// stubTaskDelivery swaps the daemon RPC indirections used by
+// deliverTaskPrompt for in-memory recorders and restores them on cleanup.
+func stubTaskDelivery(t *testing.T) (*[]CreateSessionRequest, *[]SendPromptRequest) {
+	t.Helper()
+	var creates []CreateSessionRequest
+	var sends []SendPromptRequest
+	origCreate := createSessionForTask
+	origSend := sendPromptForTask
+	createSessionForTask = func(req CreateSessionRequest) (*session.InstanceData, error) {
+		creates = append(creates, req)
+		title := req.Title
+		if title == "" {
+			title = req.TitleBase
+		}
+		return &session.InstanceData{Title: title}, nil
+	}
+	sendPromptForTask = func(req SendPromptRequest) error {
+		sends = append(sends, req)
+		return nil
+	}
+	t.Cleanup(func() {
+		createSessionForTask = origCreate
+		sendPromptForTask = origSend
+	})
+	return &creates, &sends
+}
+
+// seedTargetSession persists a bare instance record so the delivery path sees
+// the target session as existing.
+func seedTargetSession(t *testing.T, repoPath, title string) {
+	t.Helper()
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	raw, err := json.Marshal([]session.InstanceData{{Title: title}})
+	if err != nil {
+		t.Fatalf("marshal instance data: %v", err)
+	}
+	if err := config.SaveRepoInstances(repo.ID, raw); err != nil {
+		t.Fatalf("SaveRepoInstances: %v", err)
+	}
+}
+
+// TestRunTask_RefusesWatchTask pins that a watch task can never be fired
+// manually: there is no event line to render the prompt with.
+func TestRunTask_RefusesWatchTask(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	if err := task.AddTask(task.Task{
+		ID:        "ffff0001",
+		WatchCmd:  "tail -f log",
+		Enabled:   true,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	err := RunTask("ffff0001")
+	if err == nil {
+		t.Fatalf("expected error running a watch task manually")
+	}
+	if !strings.Contains(err.Error(), "watch task") {
+		t.Fatalf("error should explain the watch-task refusal, got: %v", err)
+	}
+}
+
+// TestDeliverTaskPrompt_CreatesSessionWithoutTarget pins the historical
+// delivery mode: no target_session means a fresh session per run, titled from
+// the task name.
+func TestDeliverTaskPrompt_CreatesSessionWithoutTarget(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupTaskRepo(t)
+	creates, sends := stubTaskDelivery(t)
+
+	tsk := &task.Task{ID: "ffff0002", Name: "nightly", Prompt: "do it", CronExpr: "0 3 * * *", ProjectPath: repo, Enabled: true}
+	status, err := deliverTaskPrompt(tsk, tsk.Prompt)
+	if err != nil {
+		t.Fatalf("deliverTaskPrompt: %v", err)
+	}
+	if status != "started" {
+		t.Fatalf("status = %q, want started", status)
+	}
+	if len(*sends) != 0 {
+		t.Fatalf("expected no SendPrompt calls, got %d", len(*sends))
+	}
+	if len(*creates) != 1 {
+		t.Fatalf("expected 1 CreateSession call, got %d", len(*creates))
+	}
+	got := (*creates)[0]
+	if got.TitleBase != "nightly" || got.Title != "" {
+		t.Fatalf("create should use TitleBase=nightly (collision-suffixed by the daemon), got Title=%q TitleBase=%q", got.Title, got.TitleBase)
+	}
+	if got.Prompt != "do it" {
+		t.Fatalf("create prompt = %q, want %q", got.Prompt, "do it")
+	}
+}
+
+// TestDeliverTaskPrompt_SendsIntoExistingTargetSession verifies the new
+// delivery mode: with target_session set and the session present, the prompt
+// is sent into it (repo-scoped) instead of creating a session.
+func TestDeliverTaskPrompt_SendsIntoExistingTargetSession(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupTaskRepo(t)
+	creates, sends := stubTaskDelivery(t)
+	seedTargetSession(t, repo, "captain")
+
+	tsk := &task.Task{ID: "ffff0003", Name: "gh-issues", Prompt: "Triage: {{line}}", WatchCmd: "watch.sh", TargetSession: "captain", ProjectPath: repo, Enabled: true}
+	status, err := deliverTaskPrompt(tsk, "Triage: new issue")
+	if err != nil {
+		t.Fatalf("deliverTaskPrompt: %v", err)
+	}
+	if status != "sent" {
+		t.Fatalf("status = %q, want sent", status)
+	}
+	if len(*creates) != 0 {
+		t.Fatalf("expected no CreateSession calls, got %d", len(*creates))
+	}
+	if len(*sends) != 1 {
+		t.Fatalf("expected 1 SendPrompt call, got %d", len(*sends))
+	}
+	got := (*sends)[0]
+	repoCtx, err := config.RepoFromPath(repo)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	if got.Title != "captain" || got.RepoID != repoCtx.ID || got.Prompt != "Triage: new issue" {
+		t.Fatalf("unexpected SendPrompt request: %+v", got)
+	}
+}
+
+// TestDeliverTaskPrompt_AutoCreatesMissingTargetSession pins the
+// Sachin-approved missing-target behavior (#782): auto-create the session
+// with the task's project_path/program and deliver the prompt as its initial
+// prompt, mirroring `af sessions send-prompt --create`.
+func TestDeliverTaskPrompt_AutoCreatesMissingTargetSession(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupTaskRepo(t)
+	creates, sends := stubTaskDelivery(t)
+
+	tsk := &task.Task{ID: "ffff0004", Name: "gh-issues", WatchCmd: "watch.sh", TargetSession: "captain", ProjectPath: repo, Program: "claude", Enabled: true}
+	status, err := deliverTaskPrompt(tsk, "new issue #9")
+	if err != nil {
+		t.Fatalf("deliverTaskPrompt: %v", err)
+	}
+	if status != "started" {
+		t.Fatalf("status = %q, want started", status)
+	}
+	if len(*sends) != 0 {
+		t.Fatalf("expected no SendPrompt calls, got %d", len(*sends))
+	}
+	if len(*creates) != 1 {
+		t.Fatalf("expected 1 CreateSession call, got %d", len(*creates))
+	}
+	got := (*creates)[0]
+	if got.Title != "captain" {
+		t.Fatalf("auto-create must use the exact target title, got %q", got.Title)
+	}
+	if got.RepoPath != repo || got.Program != "claude" || got.Prompt != "new issue #9" {
+		t.Fatalf("unexpected CreateSession request: %+v", got)
+	}
+}
+
+// TestRunTask_CronTaskHonorsTargetSession verifies the scheduled-send mode
+// end to end through RunTask: a cron task with target_session sends its
+// prompt into the live session and records the "sent" status.
+func TestRunTask_CronTaskHonorsTargetSession(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupTaskRepo(t)
+	_, sends := stubTaskDelivery(t)
+	seedTargetSession(t, repo, "captain")
+
+	if err := task.AddTask(task.Task{
+		ID:            "ffff0005",
+		Name:          "ping",
+		Prompt:        "scheduled check-in",
+		CronExpr:      "0 3 * * *",
+		TargetSession: "captain",
+		ProjectPath:   repo,
+		Enabled:       true,
+		CreatedAt:     time.Now(),
+	}); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+
+	if err := RunTask("ffff0005"); err != nil {
+		t.Fatalf("RunTask: %v", err)
+	}
+	if len(*sends) != 1 || (*sends)[0].Prompt != "scheduled check-in" {
+		t.Fatalf("expected one scheduled send, got %+v", *sends)
+	}
+	got, err := task.GetTask("ffff0005")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.LastRunStatus != "sent" || got.LastRunAt == nil {
+		t.Fatalf("expected LastRunStatus=sent with LastRunAt set, got status=%q at=%v", got.LastRunStatus, got.LastRunAt)
 	}
 }

--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -1,0 +1,544 @@
+package daemon
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// The watcher supervisor hosts watch tasks (#782 phase 2): for every enabled
+// task with a watch_cmd it keeps `$SHELL -c watch_cmd` running, turns each
+// newline-terminated stdout line into one event, and delivers the rendered
+// prompt through the same path cron fires use (create a session, or send into
+// target_session). The script contract:
+//
+//   - each newline-terminated stdout line = one event; lines over 64KB are
+//     truncated with a logged note
+//   - stderr appends to ~/.agent-factory/logs/task-<id>.log
+//   - env: AF_TASK_ID, AF_TASK_NAME, AF_PROJECT_PATH
+//   - exit 0 = intentional stop (status "stopped"; re-armed by the next
+//     reload or re-enable); non-zero = restart with exponential backoff
+//   - ≥5 non-zero exits within 10 minutes = crash loop (status "errored",
+//     restarts stop until the next reload)
+//   - events above 10/min per task are dropped with a logged warning
+const (
+	// maxWatchLineBytes caps how much of a single stdout line becomes an
+	// event; the rest of the line is discarded with a logged note.
+	maxWatchLineBytes = 64 * 1024
+
+	watcherEventsPerMinute = 10
+	watcherBaseBackoff     = time.Second
+	watcherMaxBackoff      = 5 * time.Minute
+	watcherCrashWindow     = 10 * time.Minute
+	watcherCrashMaxExits   = 5
+
+	// watcherStopGrace bounds how long a stop request waits after SIGTERM
+	// before escalating to a process-group SIGKILL. Mirrors
+	// sigtermFallbackGrace on the daemon-shutdown path.
+	watcherStopGrace = 5 * time.Second
+)
+
+// watcherSupervisor owns the running watch-task processes. Reload reconciles
+// them against tasks.json the same way taskScheduler.Reload reconciles cron
+// entries; the ReloadTasks RPC drives both so CLI/TUI edits take effect live.
+type watcherSupervisor struct {
+	mu       sync.Mutex
+	watchers map[string]*taskWatcher // task ID → supervised watcher
+
+	// Injection points for tests: loadTasks substitutes fixture task lists,
+	// deliver observes events without spawning sessions, and setStatus
+	// observes lifecycle statuses without a task store.
+	loadTasks func() ([]task.Task, error)
+	deliver   func(taskID, line string) error
+	setStatus func(taskID, status string)
+	logPath   func(taskID string) (string, error)
+
+	shell           string
+	baseBackoff     time.Duration
+	maxBackoff      time.Duration
+	crashWindow     time.Duration
+	crashMaxExits   int
+	eventsPerMinute int
+	stopGrace       time.Duration
+}
+
+func newWatcherSupervisor() *watcherSupervisor {
+	return &watcherSupervisor{
+		watchers:        make(map[string]*taskWatcher),
+		loadTasks:       task.LoadTasks,
+		deliver:         deliverWatchEvent,
+		setStatus:       persistWatcherStatus,
+		logPath:         watcherLogPath,
+		shell:           watcherShell(),
+		baseBackoff:     watcherBaseBackoff,
+		maxBackoff:      watcherMaxBackoff,
+		crashWindow:     watcherCrashWindow,
+		crashMaxExits:   watcherCrashMaxExits,
+		eventsPerMinute: watcherEventsPerMinute,
+		stopGrace:       watcherStopGrace,
+	}
+}
+
+// Reload re-reads tasks.json and reconciles the running watcher set: enabled
+// watch tasks without a live watcher are started — including ones whose
+// script previously exited or crash-looped, so a reload (or re-enable) is the
+// re-arm path. Watchers whose task was disabled or removed are stopped, and a
+// watcher whose process-defining fields changed is restarted with the new
+// config. Delivery-only fields (prompt, target_session, program) are not part
+// of that signature: deliverWatchEvent re-loads the task per event, so editing
+// them takes effect without killing a long-lived watch script.
+func (s *watcherSupervisor) Reload() error {
+	tasks, err := s.loadTasks()
+	if err != nil {
+		return err
+	}
+
+	desired := make(map[string]task.Task)
+	for _, t := range tasks {
+		if !t.Enabled || !t.IsWatch() {
+			continue
+		}
+		// The ID flows into the stderr log path; reject hand-edited IDs the
+		// same way RunTask does before any filesystem path is built.
+		if err := task.ValidateTaskID(t.ID); err != nil {
+			log.WarningLog.Printf("not watching task with invalid id %q: %v", t.ID, err)
+			continue
+		}
+		desired[t.ID] = t
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var stale []*taskWatcher
+	for id, w := range s.watchers {
+		t, ok := desired[id]
+		if ok && watcherSignature(t) == w.sig && !w.finished() {
+			continue
+		}
+		stale = append(stale, w)
+		delete(s.watchers, id)
+	}
+	// Wait for stale watchers to die before starting replacements so two
+	// processes for the same task never overlap. Bounded by stopGrace via
+	// the per-watcher SIGKILL escalation.
+	stopWatchers(stale)
+
+	for id, t := range desired {
+		if _, running := s.watchers[id]; running {
+			continue
+		}
+		w := s.newTaskWatcher(t)
+		s.watchers[id] = w
+		go w.run()
+	}
+	return nil
+}
+
+// Stop terminates every watcher: SIGTERM to each process group, group SIGKILL
+// after the grace. Blocks until all watcher goroutines have returned.
+func (s *watcherSupervisor) Stop() {
+	s.mu.Lock()
+	stale := make([]*taskWatcher, 0, len(s.watchers))
+	for _, w := range s.watchers {
+		stale = append(stale, w)
+	}
+	s.watchers = make(map[string]*taskWatcher)
+	s.mu.Unlock()
+	stopWatchers(stale)
+}
+
+// watchingTaskIDs returns the IDs with a live (not yet finished) watcher, for
+// tests and status reporting.
+func (s *watcherSupervisor) watchingTaskIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ids := make([]string, 0, len(s.watchers))
+	for id, w := range s.watchers {
+		if !w.finished() {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// droppedEvents returns the rate-limit drop counter for a task's watcher, or
+// 0 if no watcher is registered.
+func (s *watcherSupervisor) droppedEvents(taskID string) int {
+	s.mu.Lock()
+	w := s.watchers[taskID]
+	s.mu.Unlock()
+	if w == nil {
+		return 0
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.dropped
+}
+
+func (s *watcherSupervisor) newTaskWatcher(t task.Task) *taskWatcher {
+	return &taskWatcher{
+		taskID: t.ID,
+		name:   t.Name,
+		cmdStr: t.WatchCmd,
+		dir:    t.ProjectPath,
+		sig:    watcherSignature(t),
+		sup:    s,
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+	}
+}
+
+// watcherSignature captures the fields that define the watch process itself;
+// a change to any of them restarts the script on reload.
+func watcherSignature(t task.Task) string {
+	return t.WatchCmd + "\x00" + t.ProjectPath + "\x00" + t.Name
+}
+
+func stopWatchers(ws []*taskWatcher) {
+	var wg sync.WaitGroup
+	for _, w := range ws {
+		wg.Add(1)
+		go func(w *taskWatcher) {
+			defer wg.Done()
+			w.stop()
+		}(w)
+	}
+	wg.Wait()
+}
+
+// taskWatcher supervises one watch task: it restarts the script with backoff
+// on failure and feeds its stdout lines to the supervisor's deliver hook.
+// Deliveries are serialized in emission order — the single reader goroutine
+// delivers synchronously, so a slow delivery backpressures the script's
+// stdout pipe rather than reordering events.
+type taskWatcher struct {
+	taskID string
+	name   string
+	cmdStr string
+	dir    string
+	sig    string
+
+	sup *watcherSupervisor
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	doneCh   chan struct{}
+
+	mu          sync.Mutex
+	dropped     int
+	eventTimes  []time.Time
+	lastDropLog time.Time
+}
+
+// stop requests termination and blocks until the run goroutine returns.
+func (w *taskWatcher) stop() {
+	w.stopOnce.Do(func() { close(w.stopCh) })
+	<-w.doneCh
+}
+
+func (w *taskWatcher) finished() bool {
+	select {
+	case <-w.doneCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (w *taskWatcher) stopRequested() bool {
+	select {
+	case <-w.stopCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// run is the supervision loop: spawn the script, restart on non-zero exit
+// with exponential backoff, stop for good on exit 0 ("stopped") or on a
+// crash loop ("errored").
+func (w *taskWatcher) run() {
+	defer close(w.doneCh)
+
+	backoff := w.sup.baseBackoff
+	var failures []time.Time
+
+	for {
+		if w.stopRequested() {
+			return
+		}
+
+		started := time.Now()
+		runErr := w.runOnce()
+		if w.stopRequested() {
+			return
+		}
+
+		if runErr == nil {
+			log.InfoLog.Printf("watch task %s: watch command exited cleanly; stopped until the next reload or re-enable", w.taskID)
+			w.sup.setStatus(w.taskID, "stopped")
+			return
+		}
+
+		now := time.Now()
+		failures = append(failures, now)
+		cut := 0
+		for cut < len(failures) && now.Sub(failures[cut]) > w.sup.crashWindow {
+			cut++
+		}
+		failures = failures[cut:]
+		if len(failures) >= w.sup.crashMaxExits {
+			log.ErrorLog.Printf("watch task %s: %d failures within %s (last: %v); giving up until the next reload or re-enable", w.taskID, len(failures), w.sup.crashWindow, runErr)
+			w.sup.setStatus(w.taskID, "errored")
+			return
+		}
+
+		// A run that stayed healthy for a whole crash window earns a fresh
+		// backoff; otherwise keep doubling toward the cap.
+		if now.Sub(started) >= w.sup.crashWindow {
+			backoff = w.sup.baseBackoff
+		}
+		log.WarningLog.Printf("watch task %s: watch command failed (%v); restarting in %s", w.taskID, runErr, backoff)
+		select {
+		case <-w.stopCh:
+			return
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > w.sup.maxBackoff {
+			backoff = w.sup.maxBackoff
+		}
+	}
+}
+
+// runOnce spawns the script once and consumes its stdout until the shell
+// exits. Returns nil on exit 0, the exit/start error otherwise.
+func (w *taskWatcher) runOnce() error {
+	cmd := exec.Command(w.sup.shell, "-c", w.cmdStr)
+	cmd.Dir = w.dir
+	cmd.Env = append(os.Environ(),
+		"AF_TASK_ID="+w.taskID,
+		"AF_TASK_NAME="+w.name,
+		"AF_PROJECT_PATH="+w.dir,
+	)
+	// Own process group so the whole tree — including grandchildren the
+	// script backgrounded with `&` or `disown` — can be signaled together,
+	// mirroring the post-worktree hook runner (#610, #769).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// stderr appends to the per-task log. A logging failure must not take the
+	// watcher down — stderr just goes to the void for this run.
+	if logPath, err := w.sup.logPath(w.taskID); err != nil {
+		log.WarningLog.Printf("watch task %s: cannot resolve stderr log path: %v", w.taskID, err)
+	} else if f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err != nil {
+		log.WarningLog.Printf("watch task %s: cannot open stderr log: %v", w.taskID, err)
+	} else {
+		cmd.Stderr = f
+		defer f.Close()
+	}
+
+	// Hand the child the write end of a pipe we own instead of using
+	// cmd.StdoutPipe(): Wait must not manage the pipe, because backgrounded
+	// grandchildren inherit the write end and we want to (a) keep reading
+	// their lines while the shell lives and (b) get a guaranteed EOF once the
+	// group-kill below reaps them.
+	r, pw, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+	cmd.Stdout = pw
+
+	if err := cmd.Start(); err != nil {
+		_ = r.Close()
+		_ = pw.Close()
+		return err
+	}
+	_ = pw.Close() // the child holds its own dup
+
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		defer r.Close()
+		w.consumeLines(r)
+	}()
+
+	// Watchdog for stop requests: SIGTERM the group so the script can clean
+	// up, escalate to a group SIGKILL after the grace.
+	waitDone := make(chan struct{})
+	go func(pgid int) {
+		select {
+		case <-w.stopCh:
+			_ = syscall.Kill(-pgid, syscall.SIGTERM)
+			select {
+			case <-waitDone:
+			case <-time.After(w.sup.stopGrace):
+				_ = syscall.Kill(-pgid, syscall.SIGKILL)
+			}
+		case <-waitDone:
+		}
+	}(cmd.Process.Pid)
+
+	waitErr := cmd.Wait()
+	close(waitDone)
+
+	// Group-kill on every exit path (#769): backgrounded grandchildren must
+	// not outlive the watcher. This also closes any inherited stdout write
+	// ends, so the reader goroutine is guaranteed to reach EOF.
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	<-readerDone
+
+	return waitErr
+}
+
+// consumeLines turns newline-terminated stdout lines into events. Lines over
+// maxWatchLineBytes are truncated to the cap and the remainder discarded with
+// a logged note; unterminated trailing output at EOF is not an event.
+func (w *taskWatcher) consumeLines(r io.Reader) {
+	br := bufio.NewReaderSize(r, maxWatchLineBytes)
+	for {
+		chunk, err := br.ReadSlice('\n')
+		switch {
+		case err == nil:
+			w.handleEvent(strings.TrimRight(string(chunk), "\r\n"))
+		case errors.Is(err, bufio.ErrBufferFull):
+			// ReadSlice's buffer filled before a newline: keep the first
+			// maxWatchLineBytes as the event and discard the rest of the line.
+			line := string(chunk)
+			discarded := 0
+			var tailErr error
+			for {
+				var more []byte
+				more, tailErr = br.ReadSlice('\n')
+				discarded += len(more)
+				if !errors.Is(tailErr, bufio.ErrBufferFull) {
+					break
+				}
+			}
+			if tailErr != nil {
+				// The stream ended before the line did — never
+				// newline-terminated, so not an event.
+				return
+			}
+			log.WarningLog.Printf("watch task %s: stdout line exceeded %d bytes; truncated (%d bytes discarded)", w.taskID, maxWatchLineBytes, discarded)
+			w.handleEvent(line)
+		case errors.Is(err, io.EOF):
+			if len(chunk) > 0 {
+				log.WarningLog.Printf("watch task %s: discarding %d bytes of unterminated stdout output (events must be newline-terminated lines)", w.taskID, len(chunk))
+			}
+			return
+		default:
+			return
+		}
+	}
+}
+
+// handleEvent applies the per-task rate limit and delivers the event. Called
+// from the single reader goroutine, so deliveries stay serialized in order.
+func (w *taskWatcher) handleEvent(line string) {
+	now := time.Now()
+	w.mu.Lock()
+	cut := 0
+	for cut < len(w.eventTimes) && now.Sub(w.eventTimes[cut]) >= time.Minute {
+		cut++
+	}
+	w.eventTimes = w.eventTimes[cut:]
+	if len(w.eventTimes) >= w.sup.eventsPerMinute {
+		w.dropped++
+		dropped := w.dropped
+		logIt := now.Sub(w.lastDropLog) >= time.Minute
+		if logIt {
+			w.lastDropLog = now
+		}
+		w.mu.Unlock()
+		// One warning per window, not per drop — a flooding script must not
+		// also flood the daemon log. The counter keeps the exact total.
+		if logIt {
+			log.WarningLog.Printf("watch task %s: event rate exceeded %d/min; dropping excess events (%d dropped so far)", w.taskID, w.sup.eventsPerMinute, dropped)
+		}
+		return
+	}
+	w.eventTimes = append(w.eventTimes, now)
+	w.mu.Unlock()
+
+	if err := w.sup.deliver(w.taskID, line); err != nil {
+		log.ErrorLog.Printf("watch task %s: failed to deliver event: %v", w.taskID, err)
+	}
+}
+
+// deliverWatchEvent is the production delivery hook: it re-loads the task (so
+// prompt/target_session edits apply without restarting the script), renders
+// {{line}}, and routes through the same delivery path cron fires use, then
+// records the run status (#664 path).
+func deliverWatchEvent(taskID, line string) error {
+	t, err := task.GetTask(taskID)
+	if err != nil {
+		return fmt.Errorf("failed to load task: %w", err)
+	}
+	if !t.Enabled {
+		return fmt.Errorf("task %s is disabled", taskID)
+	}
+	prompt := task.RenderWatchPrompt(t.Prompt, line)
+	if strings.TrimSpace(prompt) == "" {
+		return fmt.Errorf("event rendered an empty prompt (line %q)", line)
+	}
+	status, err := deliverTaskPrompt(t, prompt)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	if err := task.UpdateTaskStatus(taskID, &now, status); err != nil {
+		log.ErrorLog.Printf("failed to update task status: %v", err)
+	}
+	return nil
+}
+
+// persistWatcherStatus records a watcher lifecycle status ("stopped",
+// "errored") on the task. LastRunAt is preserved — it tracks event
+// deliveries, not supervision changes. UpdateTaskStatus skips Program enum
+// validation so legacy task records still receive status bumps (#664).
+func persistWatcherStatus(taskID, status string) {
+	t, err := task.GetTask(taskID)
+	if err != nil {
+		log.WarningLog.Printf("failed to load task %s to record watcher status %q: %v", taskID, status, err)
+		return
+	}
+	if err := task.UpdateTaskStatus(taskID, t.LastRunAt, status); err != nil {
+		log.WarningLog.Printf("failed to record watcher status %q on task %s: %v", status, taskID, err)
+	}
+}
+
+// watcherLogPath resolves (and creates the directory for) the per-task
+// stderr log, ~/.agent-factory/logs/task-<id>.log.
+func watcherLogPath(taskID string) (string, error) {
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(configDir, "logs")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "task-"+taskID+".log"), nil
+}
+
+// watcherShell returns the shell watch commands run under: the user's $SHELL,
+// falling back to sh when unset (e.g. under a supervised unit missing it).
+func watcherShell() string {
+	if sh := os.Getenv("SHELL"); sh != "" {
+		return sh
+	}
+	return "sh"
+}

--- a/daemon/watcher_test.go
+++ b/daemon/watcher_test.go
@@ -1,0 +1,480 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// watchRecorder collects deliveries and lifecycle statuses from a supervisor
+// under test.
+type watchRecorder struct {
+	mu       sync.Mutex
+	events   []string // "<taskID>:<line>"
+	statuses []string // "<taskID>:<status>"
+}
+
+func (r *watchRecorder) deliver(taskID, line string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, taskID+":"+line)
+	return nil
+}
+
+func (r *watchRecorder) setStatus(taskID, status string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.statuses = append(r.statuses, taskID+":"+status)
+}
+
+func (r *watchRecorder) eventsSnapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.events...)
+}
+
+func (r *watchRecorder) statusesSnapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.statuses...)
+}
+
+// newTestSupervisor builds a supervisor with fast timings, an injected task
+// list, and recorder-backed hooks, so no test touches the real task store or
+// home directory.
+func newTestSupervisor(t *testing.T, tasks func() ([]task.Task, error)) (*watcherSupervisor, *watchRecorder) {
+	t.Helper()
+	rec := &watchRecorder{}
+	logDir := t.TempDir()
+	s := newWatcherSupervisor()
+	s.loadTasks = tasks
+	s.deliver = rec.deliver
+	s.setStatus = rec.setStatus
+	s.logPath = func(taskID string) (string, error) {
+		return filepath.Join(logDir, "task-"+taskID+".log"), nil
+	}
+	s.shell = "sh"
+	s.baseBackoff = 40 * time.Millisecond
+	s.maxBackoff = time.Second
+	s.stopGrace = 250 * time.Millisecond
+	t.Cleanup(s.Stop)
+	return s, rec
+}
+
+func staticTasks(tasks ...task.Task) func() ([]task.Task, error) {
+	return func() ([]task.Task, error) { return tasks, nil }
+}
+
+func watchTask(id, cmd, dir string) task.Task {
+	return task.Task{ID: id, Name: "watch-" + id, WatchCmd: cmd, ProjectPath: dir, Enabled: true}
+}
+
+// waitUntil polls cond until it returns true or the timeout elapses.
+func waitUntil(t *testing.T, timeout time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// TestWatcherDeliversLinesInOrderAndStopsOnExitZero covers the core event
+// contract: each stdout line is one event, deliveries arrive in emission
+// order with the script env applied, and exit 0 parks the watcher as
+// "stopped" without a restart. The trailing unterminated chunk must not
+// become an event.
+func TestWatcherDeliversLinesInOrderAndStopsOnExitZero(t *testing.T) {
+	dir := t.TempDir()
+	script := `echo one; echo two; echo "$AF_TASK_ID|$AF_TASK_NAME|$AF_PROJECT_PATH"; pwd; printf incomplete; exit 0`
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("aaaa0001", script, dir)))
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "watcher to stop", func() bool {
+		return len(rec.statusesSnapshot()) > 0
+	})
+
+	want := []string{
+		"aaaa0001:one",
+		"aaaa0001:two",
+		"aaaa0001:aaaa0001|watch-aaaa0001|" + dir,
+		"aaaa0001:" + dir,
+	}
+	got := rec.eventsSnapshot()
+	if len(got) != len(want) {
+		t.Fatalf("events = %v, want %v", got, want)
+	}
+	for i := range want {
+		// pwd may resolve through symlinks (e.g. /tmp on macOS), so compare
+		// the trailing path component for the cwd line.
+		if i == 3 {
+			if filepath.Base(got[i]) != filepath.Base(want[i]) {
+				t.Fatalf("event %d = %q, want cwd %q", i, got[i], want[i])
+			}
+			continue
+		}
+		if got[i] != want[i] {
+			t.Fatalf("event %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	if statuses := rec.statusesSnapshot(); len(statuses) != 1 || statuses[0] != "aaaa0001:stopped" {
+		t.Fatalf("statuses = %v, want [aaaa0001:stopped]", statuses)
+	}
+
+	// Exit 0 is an intentional stop: no respawn, no further deliveries.
+	time.Sleep(200 * time.Millisecond)
+	if got := rec.eventsSnapshot(); len(got) != len(want) {
+		t.Fatalf("watcher restarted after a clean exit: events = %v", got)
+	}
+	if ids := s.watchingTaskIDs(); len(ids) != 0 {
+		t.Fatalf("stopped watcher still reported live: %v", ids)
+	}
+}
+
+// TestWatcherBackoffAndCrashLoopBreaker pins the failure contract: non-zero
+// exits restart with exponential backoff, and the fifth failure inside the
+// crash window marks the task "errored" and stops restarting.
+func TestWatcherBackoffAndCrashLoopBreaker(t *testing.T) {
+	dir := t.TempDir()
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("bbbb0001", "echo run; exit 3", dir)))
+
+	start := time.Now()
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "crash-loop breaker to trip", func() bool {
+		statuses := rec.statusesSnapshot()
+		return len(statuses) > 0 && statuses[len(statuses)-1] == "bbbb0001:errored"
+	})
+	elapsed := time.Since(start)
+
+	events := rec.eventsSnapshot()
+	if len(events) != s.crashMaxExits {
+		t.Fatalf("expected exactly %d runs before the breaker tripped, got %d (%v)", s.crashMaxExits, len(events), events)
+	}
+	// Four backoff sleeps separate the five runs: 40+80+160+320ms. A lower
+	// bound proves the delays grew without flaking on scheduler jitter.
+	if minimum := 600 * time.Millisecond; elapsed < minimum {
+		t.Fatalf("five failing runs finished in %s; exponential backoff should make this take at least %s", elapsed, minimum)
+	}
+
+	// Errored watchers stay down until the next reload.
+	time.Sleep(150 * time.Millisecond)
+	if got := rec.eventsSnapshot(); len(got) != s.crashMaxExits {
+		t.Fatalf("watcher restarted after the breaker tripped: %v", got)
+	}
+
+	// A reload is the re-arm path for errored watchers.
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload after errored: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "errored watcher to re-arm on reload", func() bool {
+		return len(rec.eventsSnapshot()) > s.crashMaxExits
+	})
+}
+
+// TestWatcherRateLimitDropsExcess pins the flood contract: events over the
+// per-minute budget are dropped (not queued, not delivered) and counted.
+func TestWatcherRateLimitDropsExcess(t *testing.T) {
+	dir := t.TempDir()
+	script := `i=1; while [ $i -le 15 ]; do echo "line $i"; i=$((i+1)); done; sleep 60`
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("cccc0001", script, dir)))
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "rate limit to engage", func() bool {
+		return s.droppedEvents("cccc0001") == 5
+	})
+
+	events := rec.eventsSnapshot()
+	if len(events) != s.eventsPerMinute {
+		t.Fatalf("delivered %d events, want the %d/min budget (%v)", len(events), s.eventsPerMinute, events)
+	}
+	for i, e := range events {
+		if want := fmt.Sprintf("cccc0001:line %d", i+1); e != want {
+			t.Fatalf("event %d = %q, want %q (in-order delivery)", i, e, want)
+		}
+	}
+}
+
+// TestWatcherTruncatesLongLines pins the 64KB line cap: the first
+// maxWatchLineBytes become the event, the rest of the line is discarded, and
+// the following line still arrives intact.
+func TestWatcherTruncatesLongLines(t *testing.T) {
+	dir := t.TempDir()
+	script := `head -c 100000 /dev/zero | tr '\0' 'x'; echo; echo next; exit 0`
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("dddd0001", script, dir)))
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "watcher to finish", func() bool {
+		return len(rec.statusesSnapshot()) > 0
+	})
+
+	events := rec.eventsSnapshot()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (truncated + next), got %d", len(events))
+	}
+	long := strings.TrimPrefix(events[0], "dddd0001:")
+	if len(long) != maxWatchLineBytes {
+		t.Fatalf("truncated event length = %d, want %d", len(long), maxWatchLineBytes)
+	}
+	if strings.Trim(long, "x") != "" {
+		t.Fatalf("truncated event corrupted: %.80q...", long)
+	}
+	if events[1] != "dddd0001:next" {
+		t.Fatalf("event after the long line = %q, want %q", events[1], "dddd0001:next")
+	}
+}
+
+// TestWatcherGroupKillsGrandchildren is the #769 regression guard for watch
+// scripts: a process the script backgrounded with `&` must not outlive the
+// watcher — the supervisor SIGKILLs the whole process group when the shell
+// exits.
+func TestWatcherGroupKillsGrandchildren(t *testing.T) {
+	dir := t.TempDir()
+	script := `sleep 300 & echo $!; exit 0`
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("eeee0001", script, dir)))
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "watcher to stop", func() bool {
+		return len(rec.statusesSnapshot()) > 0
+	})
+
+	events := rec.eventsSnapshot()
+	if len(events) != 1 {
+		t.Fatalf("expected the grandchild PID as the only event, got %v", events)
+	}
+	pid, err := strconv.Atoi(strings.TrimPrefix(events[0], "eeee0001:"))
+	if err != nil {
+		t.Fatalf("event is not a PID: %v", err)
+	}
+	waitUntil(t, 3*time.Second, "backgrounded grandchild to be killed", func() bool {
+		return syscall.Kill(pid, 0) != nil
+	})
+}
+
+// TestWatcherStopEscalatesToGroupKill pins the shutdown contract: Stop sends
+// SIGTERM, and a script that ignores it is SIGKILLed (whole group) after the
+// grace instead of blocking daemon shutdown forever.
+func TestWatcherStopEscalatesToGroupKill(t *testing.T) {
+	dir := t.TempDir()
+	script := `trap '' TERM; echo $$; while true; do sleep 0.1; done`
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("ffff0001", script, dir)))
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "script to report its PID", func() bool {
+		return len(rec.eventsSnapshot()) == 1
+	})
+	pid, err := strconv.Atoi(strings.TrimPrefix(rec.eventsSnapshot()[0], "ffff0001:"))
+	if err != nil {
+		t.Fatalf("event is not a PID: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Stop did not return; SIGKILL escalation failed")
+	}
+	waitUntil(t, 2*time.Second, "TERM-ignoring script to be killed", func() bool {
+		return syscall.Kill(pid, 0) != nil
+	})
+}
+
+// TestWatcherStderrGoesToTaskLog verifies the script contract's logging leg:
+// stderr appends to the per-task log file.
+func TestWatcherStderrGoesToTaskLog(t *testing.T) {
+	dir := t.TempDir()
+	script := `echo "diagnostic detail" >&2; exit 0`
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("abab0001", script, dir)))
+	logDir := t.TempDir()
+	s.logPath = func(taskID string) (string, error) {
+		return filepath.Join(logDir, "task-"+taskID+".log"), nil
+	}
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "watcher to stop", func() bool {
+		return len(rec.statusesSnapshot()) > 0
+	})
+
+	data, err := os.ReadFile(filepath.Join(logDir, "task-abab0001.log"))
+	if err != nil {
+		t.Fatalf("read task log: %v", err)
+	}
+	if !strings.Contains(string(data), "diagnostic detail") {
+		t.Fatalf("task log missing stderr output, got: %q", data)
+	}
+}
+
+// TestWatcherReloadReconciles drives the supervisor through config changes:
+// disabled tasks stop their watcher, removed tasks stop it, and a changed
+// watch command restarts the script with the new config while an unchanged
+// live watcher is left alone.
+func TestWatcherReloadReconciles(t *testing.T) {
+	dir := t.TempDir()
+	current := struct {
+		mu    sync.Mutex
+		tasks []task.Task
+	}{}
+	setTasks := func(ts ...task.Task) {
+		current.mu.Lock()
+		current.tasks = ts
+		current.mu.Unlock()
+	}
+	s, rec := newTestSupervisor(t, func() ([]task.Task, error) {
+		current.mu.Lock()
+		defer current.mu.Unlock()
+		return append([]task.Task(nil), current.tasks...), nil
+	})
+
+	longRunning := func(marker string) string {
+		return fmt.Sprintf(`echo %s; sleep 60`, marker)
+	}
+
+	// Two enabled watch tasks plus a cron task and a disabled watch task that
+	// must be ignored.
+	setTasks(
+		watchTask("a1a1a1a1", longRunning("first"), dir),
+		watchTask("b2b2b2b2", longRunning("second"), dir),
+		task.Task{ID: "c3c3c3c3", CronExpr: "0 3 * * *", Prompt: "p", ProjectPath: dir, Enabled: true},
+		task.Task{ID: "d4d4d4d4", WatchCmd: longRunning("never"), ProjectPath: dir, Enabled: false},
+	)
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "both watchers to start", func() bool {
+		return len(rec.eventsSnapshot()) == 2
+	})
+	if ids := s.watchingTaskIDs(); len(ids) != 2 {
+		t.Fatalf("watching IDs = %v, want the two enabled watch tasks", ids)
+	}
+
+	// Disable one, change the other's command: the disabled watcher stops,
+	// the changed one restarts and emits its new marker.
+	disabled := watchTask("a1a1a1a1", longRunning("first"), dir)
+	disabled.Enabled = false
+	setTasks(disabled, watchTask("b2b2b2b2", longRunning("second-v2"), dir))
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "changed watcher to restart", func() bool {
+		events := rec.eventsSnapshot()
+		return len(events) == 3 && events[2] == "b2b2b2b2:second-v2"
+	})
+	if ids := s.watchingTaskIDs(); len(ids) != 1 || ids[0] != "b2b2b2b2" {
+		t.Fatalf("watching IDs = %v, want [b2b2b2b2]", ids)
+	}
+
+	// Remove everything: the supervisor winds down to zero watchers.
+	setTasks()
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if ids := s.watchingTaskIDs(); len(ids) != 0 {
+		t.Fatalf("watching IDs = %v, want none after removal", ids)
+	}
+}
+
+// TestDeliverWatchEvent_RendersTemplateAndRecordsStatus exercises the
+// production delivery hook against the real task store: {{line}} renders into
+// the prompt, the rendered prompt is sent to the target session, and the
+// run status lands on the task via the #664 path.
+func TestDeliverWatchEvent_RendersTemplateAndRecordsStatus(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupTaskRepo(t)
+	_, sends := stubTaskDelivery(t)
+	seedTargetSession(t, repo, "captain")
+
+	if err := task.AddTask(task.Task{
+		ID:            "cafe0001",
+		Name:          "gh-issues",
+		Prompt:        "Triage: {{line}}",
+		WatchCmd:      "watch.sh",
+		TargetSession: "captain",
+		ProjectPath:   repo,
+		Enabled:       true,
+		CreatedAt:     time.Now(),
+	}); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+
+	if err := deliverWatchEvent("cafe0001", "new issue #9"); err != nil {
+		t.Fatalf("deliverWatchEvent: %v", err)
+	}
+	if len(*sends) != 1 || (*sends)[0].Prompt != "Triage: new issue #9" {
+		t.Fatalf("expected one rendered send, got %+v", *sends)
+	}
+	got, err := task.GetTask("cafe0001")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.LastRunStatus != "sent" || got.LastRunAt == nil {
+		t.Fatalf("expected LastRunStatus=sent with LastRunAt set, got %q at %v", got.LastRunStatus, got.LastRunAt)
+	}
+
+	// An event for a task that was disabled after the watcher spawned must
+	// not deliver.
+	got.Enabled = false
+	if err := task.UpdateTask(*got); err != nil {
+		t.Fatalf("disable task: %v", err)
+	}
+	if err := deliverWatchEvent("cafe0001", "late event"); err == nil {
+		t.Fatalf("expected delivery to a disabled task to error")
+	}
+	if len(*sends) != 1 {
+		t.Fatalf("disabled task still received an event: %+v", *sends)
+	}
+}
+
+// TestControlServerReloadTasksRPC_ReloadsWatchers verifies the RPC handler
+// re-arms both trigger hosts: a watch task added to the store starts its
+// watcher on the same poke that refreshes cron entries.
+func TestControlServerReloadTasksRPC_ReloadsWatchers(t *testing.T) {
+	dir := t.TempDir()
+	sched := newTaskScheduler()
+	sched.loadTasks = staticTasks(task.Task{ID: "feed0001", CronExpr: "30 2 * * *", Prompt: "p", Enabled: true})
+	watchers, rec := newTestSupervisor(t, staticTasks(watchTask("feed0002", "echo hi; sleep 60", dir)))
+	server := &controlServer{scheduler: sched, watchers: watchers}
+
+	var resp ReloadTasksResponse
+	if err := server.ReloadTasks(ReloadTasksRequest{}, &resp); err != nil {
+		t.Fatalf("ReloadTasks: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("expected OK response")
+	}
+	if got := sched.scheduledTaskIDs(); len(got) != 1 || got[0] != "feed0001" {
+		t.Fatalf("scheduled IDs = %v, want [feed0001]", got)
+	}
+	waitUntil(t, 5*time.Second, "watcher to start via RPC reload", func() bool {
+		events := rec.eventsSnapshot()
+		return len(events) == 1 && events[0] == "feed0002:hi"
+	})
+}

--- a/task/task.go
+++ b/task/task.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -45,16 +46,62 @@ func ValidateTaskID(taskID string) error {
 }
 
 type Task struct {
-	ID            string     `json:"id"`
-	Name          string     `json:"name,omitempty"`
-	Prompt        string     `json:"prompt"`
-	CronExpr      string     `json:"cron_expr"`
+	ID     string `json:"id"`
+	Name   string `json:"name,omitempty"`
+	Prompt string `json:"prompt"`
+	// Exactly one of CronExpr (time trigger) and WatchCmd (event trigger) is
+	// set on an enabled task — see ValidateTrigger. A watch task runs WatchCmd
+	// as a long-lived script under the daemon; each stdout line it emits is one
+	// event (#782 phase 2).
+	CronExpr string `json:"cron_expr,omitempty"`
+	WatchCmd string `json:"watch_cmd,omitempty"`
+	// TargetSession routes deliveries into an existing session by title
+	// (auto-created with ProjectPath/Program if missing). Empty keeps the
+	// historical behavior of creating a fresh session per run.
+	TargetSession string     `json:"target_session,omitempty"`
 	ProjectPath   string     `json:"project_path"`
 	Program       string     `json:"program"`
 	Enabled       bool       `json:"enabled"`
 	CreatedAt     time.Time  `json:"created_at"`
 	LastRunAt     *time.Time `json:"last_run_at,omitempty"`
 	LastRunStatus string     `json:"last_run_status,omitempty"`
+}
+
+// IsWatch reports whether the task is event-triggered (WatchCmd) rather than
+// time-triggered (CronExpr).
+func (t Task) IsWatch() bool {
+	return strings.TrimSpace(t.WatchCmd) != ""
+}
+
+// ValidateTrigger enforces the trigger contract from #782: a task with both
+// CronExpr and WatchCmd set is always invalid (ambiguous), and an enabled
+// task must have exactly one of the two. A disabled task with neither is
+// tolerated as a draft so hand-edited or legacy records never brick the
+// store.
+func (t Task) ValidateTrigger() error {
+	hasCron := strings.TrimSpace(t.CronExpr) != ""
+	hasWatch := strings.TrimSpace(t.WatchCmd) != ""
+	if hasCron && hasWatch {
+		return fmt.Errorf("task %s sets both cron_expr and watch_cmd; exactly one trigger is allowed", t.ID)
+	}
+	if t.Enabled && !hasCron && !hasWatch {
+		return fmt.Errorf("task %s is enabled but has neither cron_expr nor watch_cmd; exactly one trigger is required", t.ID)
+	}
+	return nil
+}
+
+// watchLinePlaceholder is the template token in a watch task's prompt that is
+// replaced with the emitted stdout line at delivery time.
+const watchLinePlaceholder = "{{line}}"
+
+// RenderWatchPrompt renders the prompt for one watch event. An empty (or
+// whitespace-only) prompt defaults to the raw emitted line; otherwise every
+// {{line}} occurrence in the prompt is substituted with the line.
+func RenderWatchPrompt(prompt, line string) string {
+	if strings.TrimSpace(prompt) == "" {
+		return line
+	}
+	return strings.ReplaceAll(prompt, watchLinePlaceholder, line)
 }
 
 // getTasksPathFn is the function used to resolve the tasks file path.
@@ -122,6 +169,9 @@ func saveTasks(tasks []Task) error {
 
 func AddTask(t Task) error {
 	if err := ValidateTaskID(t.ID); err != nil {
+		return err
+	}
+	if err := t.ValidateTrigger(); err != nil {
 		return err
 	}
 	// Empty Program means "fall back to the configured default_program at
@@ -261,6 +311,9 @@ func UpdateTaskStatus(taskID string, lastRunAt *time.Time, lastRunStatus string)
 
 func UpdateTask(t Task) error {
 	if err := ValidateTaskID(t.ID); err != nil {
+		return err
+	}
+	if err := t.ValidateTrigger(); err != nil {
 		return err
 	}
 	// Empty Program means "fall back to the configured default_program at

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -239,7 +239,7 @@ func TestLoadTaskWithoutProgramFieldFallsBackToEmpty(t *testing.T) {
 // through the TUI must survive a SaveTasks -> LoadTasks round-trip.
 func TestUpdateTaskPersistsProgram(t *testing.T) {
 	tasks := []Task{
-		{ID: "p1", Name: "Original", Program: "claude", Enabled: true},
+		{ID: "p1", Name: "Original", Program: "claude", CronExpr: "0 3 * * *", Enabled: true},
 	}
 	setupTestTasks(t, tasks)
 
@@ -380,7 +380,7 @@ func TestUpdateTaskStatus_NotFound(t *testing.T) {
 // reject a non-enum Program so the TUI/CLI editor flows fail fast.
 func TestUpdateTask_RejectsBadProgram(t *testing.T) {
 	stored := []Task{
-		{ID: "edit1", Name: "Editable", Program: "claude", Enabled: true},
+		{ID: "edit1", Name: "Editable", Program: "claude", CronExpr: "0 3 * * *", Enabled: true},
 	}
 	setupTestTasks(t, stored)
 
@@ -402,4 +402,103 @@ func TestTaskNameInJSON(t *testing.T) {
 	data2, err := json.Marshal(s2)
 	require.NoError(t, err)
 	assert.NotContains(t, string(data2), `"name"`)
+}
+
+// TestValidateTrigger pins the #782 trigger contract: both triggers set is
+// always invalid, an enabled task needs exactly one, and a disabled task with
+// neither is tolerated as a draft.
+func TestValidateTrigger(t *testing.T) {
+	cases := []struct {
+		name    string
+		cron    string
+		watch   string
+		enabled bool
+		wantErr bool
+	}{
+		{"enabled cron only", "0 3 * * *", "", true, false},
+		{"enabled watch only", "", "tail -f log", true, false},
+		{"enabled both", "0 3 * * *", "tail -f log", true, true},
+		{"enabled neither", "", "", true, true},
+		{"enabled whitespace counts as unset", "   ", "  ", true, true},
+		{"disabled cron only", "0 3 * * *", "", false, false},
+		{"disabled watch only", "", "tail -f log", false, false},
+		{"disabled both", "0 3 * * *", "tail -f log", false, true},
+		{"disabled neither (draft)", "", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tsk := Task{ID: "aaaa0001", CronExpr: tc.cron, WatchCmd: tc.watch, Enabled: tc.enabled}
+			err := tsk.ValidateTrigger()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestAddTask_EnforcesTriggerContract verifies the store-level chokepoint:
+// AddTask and UpdateTask refuse tasks that violate the trigger rule, whatever
+// surface produced them.
+func TestAddTask_EnforcesTriggerContract(t *testing.T) {
+	setupTestTasks(t, []Task{})
+
+	bad := Task{ID: "bbbb0001", Prompt: "p", CronExpr: "0 3 * * *", WatchCmd: "tail -f x", Enabled: true, CreatedAt: time.Now()}
+	require.Error(t, AddTask(bad))
+
+	noTrigger := Task{ID: "bbbb0002", Prompt: "p", Enabled: true, CreatedAt: time.Now()}
+	require.Error(t, AddTask(noTrigger))
+
+	watch := Task{ID: "bbbb0003", WatchCmd: "tail -f x", Enabled: true, CreatedAt: time.Now()}
+	require.NoError(t, AddTask(watch))
+
+	// Updating the watch task to also carry a cron must be refused.
+	watch.CronExpr = "0 3 * * *"
+	require.Error(t, UpdateTask(watch))
+}
+
+// TestWatchFieldsJSONRoundTrip pins the wire contract: the new fields are
+// omitted when empty (backward-compatible JSON for existing cron tasks) and
+// round-trip when set.
+func TestWatchFieldsJSONRoundTrip(t *testing.T) {
+	cronTask := Task{ID: "cccc0001", Prompt: "p", CronExpr: "0 3 * * *", Enabled: true}
+	data, err := json.Marshal(cronTask)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "watch_cmd")
+	assert.NotContains(t, string(data), "target_session")
+
+	watchTask := Task{ID: "cccc0002", WatchCmd: "tail -f x", TargetSession: "captain", Enabled: true}
+	data, err = json.Marshal(watchTask)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "cron_expr")
+
+	var back Task
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, "tail -f x", back.WatchCmd)
+	assert.Equal(t, "captain", back.TargetSession)
+}
+
+// TestRenderWatchPrompt pins the {{line}} templating contract for watch
+// events: empty prompt defaults to the raw line; otherwise every {{line}}
+// occurrence is substituted.
+func TestRenderWatchPrompt(t *testing.T) {
+	cases := []struct {
+		name   string
+		prompt string
+		line   string
+		want   string
+	}{
+		{"empty prompt defaults to line", "", "new issue #9", "new issue #9"},
+		{"whitespace prompt defaults to line", "   ", "new issue #9", "new issue #9"},
+		{"substitutes line", "Triage: {{line}}", "new issue #9", "Triage: new issue #9"},
+		{"substitutes all occurrences", "{{line}} and {{line}}", "x", "x and x"},
+		{"no placeholder leaves prompt as-is", "fixed prompt", "ignored", "fixed prompt"},
+		{"empty line with placeholder", "Triage: {{line}}", "", "Triage: "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, RenderWatchPrompt(tc.prompt, tc.line))
+		})
+	}
 }

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -387,13 +387,26 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 					s.editError = "name is required"
 					return true
 				}
-				if strings.TrimSpace(s.editPrompt.Value()) == "" {
-					s.editError = "prompt must be non-empty"
-					return true
-				}
-				if err := task.ValidateCronExpr(s.editCron.Value()); err != nil {
-					s.editError = fmt.Sprintf("invalid cron: %v", err)
-					return true
+				// Watch tasks (#782 phase 2) have no cron expression and may
+				// have an empty prompt (each event defaults to the raw line).
+				// The edit form gains watch-cmd/target-session fields in
+				// phase 3; until then the cron field must stay empty so the
+				// save can't produce a task with two triggers.
+				isWatch := s.tasks[s.selectedIdx].WatchCmd != ""
+				if isWatch {
+					if strings.TrimSpace(s.editCron.Value()) != "" {
+						s.editError = "this is a watch task; cron must stay empty (edit the trigger with af tasks update)"
+						return true
+					}
+				} else {
+					if strings.TrimSpace(s.editPrompt.Value()) == "" {
+						s.editError = "prompt must be non-empty"
+						return true
+					}
+					if err := task.ValidateCronExpr(s.editCron.Value()); err != nil {
+						s.editError = fmt.Sprintf("invalid cron: %v", err)
+						return true
+					}
 				}
 				// Mirror the create path (app.handleTaskCreate): resolve
 				// the user-entered path to an absolute form so an empty
@@ -520,11 +533,17 @@ func (s *TaskPane) renderListMode() string {
 		}
 
 		isSelected := i == s.selectedIdx
+		// Watch tasks have no cron expression; show their trigger instead.
+		// Editing the watch fields in the TUI lands in phase 3 of #782.
+		trigger := tsk.CronExpr
+		if tsk.WatchCmd != "" {
+			trigger = "watch: " + tsk.WatchCmd
+		}
 		var header string
 		if tsk.Name != "" {
-			header = fmt.Sprintf("%s %s  %s", status, tsk.Name, tsk.CronExpr)
+			header = fmt.Sprintf("%s %s  %s", status, tsk.Name, trigger)
 		} else {
-			header = fmt.Sprintf("%s %s", status, tsk.CronExpr)
+			header = fmt.Sprintf("%s %s", status, trigger)
 		}
 
 		if isSelected && s.hasFocus {


### PR DESCRIPTION
Phase 2 of the plan locked in on #782 ([final shape](https://github.com/sachiniyer/agent-factory/issues/782)): tasks gain an event trigger (`watch_cmd`) and a session-routing delivery mode (`target_session`), hosted by the always-on daemon that phase 1 (#791) established. Part of #782 — phase 3 (TUI fields, `docs/tasks.md` rewrite, examples) remains.

## Trigger × delivery matrix

| | `target_session` empty | `target_session` set |
|---|---|---|
| **`cron_expr`** | create a session per fire (unchanged) | send `prompt` into the session at schedule (NEW) |
| **`watch_cmd`** | each stdout line → create a session with the rendered prompt (NEW) | each stdout line → send the rendered prompt into the session (NEW) |

- Exactly one of `cron_expr` / `watch_cmd` per enabled task, enforced at the store chokepoint (`Task.ValidateTrigger` in `AddTask`/`UpdateTask`) and at the CLI. Disabled tasks with neither are tolerated as drafts; both set is always invalid.
- `target_session` is looked up in the task's own repo; if missing it is **auto-created** with the task's `project_path`/`program` and the rendered prompt as its initial prompt (Sachin-approved, mirrors `af sessions send-prompt --create`).
- Watch prompts render `{{line}}` → the emitted stdout line; an empty prompt delivers the raw line. Cron and watch fires share one delivery path (`deliverTaskPrompt`); statuses recorded via the #664 `UpdateTaskStatus` path: `started` (created), `sent` (delivered into a session), plus watcher lifecycle `stopped`/`errored`.

## Watcher contract (`daemon/watcher.go`)

- On daemon start and on every `ReloadTasks` poke, the supervisor reconciles `$SHELL -c watch_cmd` processes (cwd = `project_path`, env `AF_TASK_ID`/`AF_TASK_NAME`/`AF_PROJECT_PATH`) against the enabled watch tasks. Reload re-arms `stopped`/`errored` watchers; delivery-field edits (prompt/target/program) apply live without restarting the script (the task is re-loaded per event), while command/path changes restart it.
- Each newline-terminated stdout line = one event; lines >64KB truncated with a logged note; unterminated trailing output is not an event.
- stderr appends to `~/.agent-factory/logs/task-<id>.log` (rotation deferred to phase 3/polish, as planned).
- Exit 0 → `stopped`, no restart until reload/re-enable. Non-zero → restart with exponential backoff 1s→5min cap (reset after a 10-min healthy run). ≥5 non-zero exits in 10min → `errored`, restarts stop, logged once.
- Rate limit 10 events/min/task; excess dropped with a counter and a once-per-window warning (so a flooding script can't also flood the daemon log).
- Deliveries serialized per task in order: the single reader goroutine delivers synchronously, backpressuring the script's stdout instead of reordering.
- Process group per watcher (`Setpgid`); group-SIGKILL on every shell exit so backgrounded grandchildren never outlive the watcher (#769 pattern, mirrors `session/git/hooks.go`). Shutdown: SIGTERM, group-SIGKILL after 5s; supervisor stops before the control socket closes so in-flight deliveries still land.
- `af tasks trigger` / TUI `r` on a watch task → clear error (no event line to render with).

## Phase-1 nit

`af daemon install` now captures `AGENT_FACTORY_HOME` into the unit environment when set — both the systemd unit and the launchd plist — so custom-home setups get a daemon serving the right home. Golden tests cover presence, absence, and escaping.

## Audit — every Task consumer

| Consumer | Handling |
|---|---|
| `daemon/scheduler.go` | skips watch tasks (would otherwise warn "invalid cron") — changed + tested |
| `daemon/taskrun.go` `RunTask` | cron-only; refuses watch tasks; honors `target_session` — changed + tested |
| `daemon/watcher.go` | new host for watch tasks |
| `app/app.go` `handleTaskTrigger` (TUI `r`) | guards watch tasks with the same refusal as `RunTask` |
| `app/app.go` `handleTaskCreate` (TUI `n`) | unchanged — TUI creates cron tasks only until phase 3 |
| `ui/task_pane.go` list | displays `watch: <cmd>` as the trigger; `last:`/status line shows `sent`/`stopped`/`errored` for free |
| `ui/task_pane.go` edit form | watch tasks editable for name/prompt/path/program; the cron field must stay empty (validated) so a save can't produce two triggers — full field editing is phase 3 |
| `ui/sidebar.go` | renders only a task count — unaffected |
| `task.TaskRunBaseTitle` / `NextTaskRunTitle` | unaffected (create-delivery path only) |
| `api/tasks.go` | `--watch-cmd`/`--target-session` on add/update with exactly-one validation; `list`/`get` carry the new fields automatically (omitempty → JSON contract backward compatible) |
| `daemon/legacy_units.go`, `task/start.go`, integration tests | don't consume the new fields — unaffected, full suite green |

CLI semantics worth noting: on `update`, setting one trigger clears the other (switching watch→cron requires a prompt); `--target-session` uses Changed() semantics so an explicit `--target-session ""` reverts to create-per-run while an absent flag leaves it untouched.

## Tests

- Schema matrix: cron×watch×enabled/disabled (`TestValidateTrigger`), store chokepoint, JSON round-trip/omitempty, `{{line}}` templating table.
- Watcher (all hermetic, injected hooks, real `sh` processes in temp dirs): in-order delivery + env + cwd + exit-0 stop; backoff growth lower-bound + crash-loop breaker at exactly 5 runs + reload re-arm; rate-limit (15 lines → 10 delivered, 5 counted dropped); 64KB truncation; **group-kill of a backgrounded grandchild** (PID emitted as the event, asserted dead); TERM-ignoring script SIGKILLed within the stop grace; stderr→task log; reload reconciliation (disable/remove/command-change/unchanged-kept); RPC reload re-arms watchers.
- Delivery: create-without-target, send-into-existing (repo-scoped), auto-create-missing, cron+target end-to-end through `RunTask` with `sent` status persisted, watch-event render+status+disabled-task refusal.
- Autostart golden tests for `AGENT_FACTORY_HOME` (systemd + launchd, incl. XML escaping).
- Everything uses temp `AGENT_FACTORY_HOME` — never the real home (a supervised daemon runs on this host).

## Gates

`go build ./...` ✓ · `gofmt -l` clean ✓ · `golangci-lint run --fast` clean ✓ · `deadcode -test` clean ✓ · `go test ./...` green ✓ (sole exception: `TestSigtermFallback_DeadPID`, the known dev-box environmental flake caused by real daemons running on this host) · `go test -race` green on daemon/task/api and on ui/app with `GOFLAGS="-p=1" -parallel 2` ✓ · CLI smoke-tested against a temp home (watch-task add/list round-trip, both-triggers rejection).

Per the conflict note: no changes to `StopDaemon`/`RunDaemon` spawn guards (`daemon.go` only gains the supervisor start/stop next to the scheduler lines).

Not merging — leaving the live watcher e2e verification and merge to Captain Claude.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
