### PR TITLE
feat(ui,docs): task pane trigger fields, tasks docs, examples; hermetic sigterm test (phase 3 of #782)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,20 @@ Each session runs an AI agent in an isolated git worktree with its own branch. S
 
 ### Tasks
 
-Create recurring automated tasks with cron expressions. Tasks are scheduled by
-the agent-factory daemon, which starts automatically whenever `af` runs and an
-enabled task exists. To keep schedules firing across reboots without opening
-`af`, install the daemon's autostart unit with `af daemon install`.
+Automated tasks deliver a prompt to an agent on a trigger: a cron schedule, or
+each stdout line of a long-running watch script. Each fire either creates a
+fresh session or sends the prompt into an existing one (target session). Tasks
+are hosted by the agent-factory daemon, which starts automatically whenever
+`af` runs and an enabled task exists. To keep tasks firing across reboots
+without opening `af`, install the daemon's autostart unit with
+`af daemon install`. See [docs/tasks.md](docs/tasks.md) for the full trigger ×
+delivery matrix and the watch-script contract.
 
 | Key | Action |
 |-----|--------|
 | `s` | Create a new task |
 | `S` | List tasks |
-| `r` | Run selected task now |
+| `r` | Run selected cron task now |
 
 ### GitHub PR Integration
 
@@ -115,7 +119,8 @@ script emits a stdout line (`--watch-cmd`) — exactly one of the two. By
 default each fire creates a fresh session; `--target-session` instead sends
 the prompt into an existing session by title (auto-created if missing). Watch
 prompts may reference the emitted line as `{{line}}`; with no prompt the raw
-line is delivered.
+line is delivered. Full reference: [docs/tasks.md](docs/tasks.md); runnable
+watch-script skeletons: [examples/tasks/](examples/tasks/).
 
 ```bash
 af tasks list                                                  # list tasks

--- a/app/app.go
+++ b/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -561,13 +562,26 @@ func reloadDaemonTaskSchedules() {
 // handleTaskCreate processes a pending task creation from the inline form.
 func (m *home) handleTaskCreate() tea.Cmd {
 	sp := m.contentPane.TaskPane()
-	name, prompt, cronExpr, projectPath, program := sp.ConsumePendingCreate()
+	name, prompt, cronExpr, watchCmd, targetSession, projectPath, program := sp.ConsumePendingCreate()
 
 	if name == "" {
 		return m.handleError(fmt.Errorf("task name is required"))
 	}
-	if err := task.ValidateCronExpr(cronExpr); err != nil {
-		return m.handleError(fmt.Errorf("invalid cron: %v", err))
+	// Re-validate the trigger contract behind the form (#782): exactly one of
+	// cron / watch cmd, and cron tasks need a prompt — there is no event line
+	// to fall back to. Mirrors `af tasks add` (api/tasks.go).
+	hasCron := cronExpr != ""
+	hasWatch := watchCmd != ""
+	if hasCron == hasWatch {
+		return m.handleError(fmt.Errorf("exactly one of cron or watch cmd is required"))
+	}
+	if hasCron {
+		if strings.TrimSpace(prompt) == "" {
+			return m.handleError(fmt.Errorf("prompt must be non-empty"))
+		}
+		if err := task.ValidateCronExpr(cronExpr); err != nil {
+			return m.handleError(fmt.Errorf("invalid cron: %v", err))
+		}
 	}
 	absPath, err := filepath.Abs(projectPath)
 	if err != nil {
@@ -577,14 +591,16 @@ func (m *home) handleTaskCreate() tea.Cmd {
 		program = m.program
 	}
 	t := task.Task{
-		ID:          task.GenerateID(),
-		Name:        name,
-		Prompt:      prompt,
-		CronExpr:    cronExpr,
-		ProjectPath: absPath,
-		Program:     program,
-		Enabled:     true,
-		CreatedAt:   time.Now(),
+		ID:            task.GenerateID(),
+		Name:          name,
+		Prompt:        prompt,
+		CronExpr:      cronExpr,
+		WatchCmd:      watchCmd,
+		TargetSession: targetSession,
+		ProjectPath:   absPath,
+		Program:       program,
+		Enabled:       true,
+		CreatedAt:     time.Now(),
 	}
 	if err := task.AddTask(t); err != nil {
 		return m.handleError(fmt.Errorf("failed to save task: %v", err))

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -118,6 +118,8 @@ func TestHandleContentPaneFocus_PendingCreateFlushesDirtyTaskState(t *testing.T)
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do other thing")})
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> cron
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> watch cmd
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> target session
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> path
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> program
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> save button

--- a/daemon/sigterm_fallback.go
+++ b/daemon/sigterm_fallback.go
@@ -79,7 +79,7 @@ func locateDaemonPID() (int, string, error) {
 		pidFileSource = fmt.Sprintf("pid-file pid=%d stale", pid)
 	}
 
-	pids, err := pgrepDaemonCandidates()
+	pids, err := scanDaemonCandidatesFn()
 	if err != nil {
 		if errors.Is(err, errPgrepUnavailable) {
 			return 0, fmt.Sprintf("%s, pgrep unavailable", pidFileSource), nil
@@ -150,6 +150,15 @@ func pidLooksAlive(pid int) bool {
 	}
 	return true
 }
+
+// scanDaemonCandidatesFn is the process-scan entry point used by
+// locateDaemonPID. It is a function var so tests can substitute a controlled
+// candidate list: the real pgrep scan is host-wide, so on any machine running
+// the supervised daemon (`af daemon install`, the recommended setup since
+// #791) it finds that unrelated process and the stale-PID / no-candidates
+// branches become unreachable — and worse, a test exercising the fallback
+// could SIGTERM the host's real daemon (#793).
+var scanDaemonCandidatesFn = pgrepDaemonCandidates
 
 // errPgrepUnavailable signals that `pgrep` is not on PATH, distinct from
 // "pgrep ran and returned no matches". Surfaced by locateDaemonPID so the

--- a/daemon/sigterm_fallback_test.go
+++ b/daemon/sigterm_fallback_test.go
@@ -153,6 +153,19 @@ func TestIsDaemonAbsentErr_RejectsMethodNotFound(t *testing.T) {
 	}
 }
 
+// stubDaemonScan replaces the host-wide pgrep scan with a controlled
+// candidate list for the duration of the test (#793). Without this, any
+// developer machine running the supervised daemon (`af daemon install`)
+// contributes a real `af --daemon` process to the scan, making every branch
+// that depends on the candidate count nondeterministic — and letting a test
+// SIGTERM the host's real daemon.
+func stubDaemonScan(t *testing.T, pids []int, err error) {
+	t.Helper()
+	orig := scanDaemonCandidatesFn
+	scanDaemonCandidatesFn = func() ([]int, error) { return pids, err }
+	t.Cleanup(func() { scanDaemonCandidatesFn = orig })
+}
+
 // spawnFakeDaemonWithDaemonFlag launches a long-lived child process whose
 // /proc/<pid>/cmdline contains "--daemon" as a discrete token. We use
 // bash's `exec -a` to rewrite argv[0] of `sleep` so the cmdline carries
@@ -255,12 +268,14 @@ func TestSigtermFallback_KillsPIDFileDaemon(t *testing.T) {
 
 // TestSigtermFallback_IgnoresNonMatchingCmdline guards against killing an
 // unrelated process whose PID happens to be in the PID file (e.g. PID
-// reuse). The fallback should fall through to pgrep, which on a clean test
-// env finds zero candidates and returns ShutdownNoDaemon — the unrelated
-// process must remain alive.
+// reuse). The fallback must reject the PID-file candidate on its cmdline and
+// fall through to the process scan — stubbed to zero candidates (#793) — so
+// the outcome is deterministic: ShutdownFailed, and the unrelated process
+// remains alive.
 func TestSigtermFallback_IgnoresNonMatchingCmdline(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", home)
+	stubDaemonScan(t, nil, nil)
 
 	// sleep, no --daemon flag in its argv — cmdlineHasDaemonFlag must say no.
 	victim := exec.Command("sleep", "60")
@@ -277,10 +292,13 @@ func TestSigtermFallback_IgnoresNonMatchingCmdline(t *testing.T) {
 		t.Fatalf("write PID file: %v", err)
 	}
 
-	// We don't care which result the fallback returns (ShutdownNoDaemon or
-	// an ambiguous-pgrep error if the host has rogue `af --daemon` procs).
-	// We only require that the victim survives.
-	_, _ = sigtermFallback()
+	result, err := sigtermFallback()
+	if result != ShutdownFailed {
+		t.Errorf("sigtermFallback returned %v, want ShutdownFailed (PID-file candidate rejected, scan empty)", result)
+	}
+	if err == nil {
+		t.Errorf("sigtermFallback returned nil error; expected one carrying the recovery hint")
+	}
 
 	time.Sleep(100 * time.Millisecond)
 	if !pidLooksAlive(victim.Process.Pid) {
@@ -290,14 +308,17 @@ func TestSigtermFallback_IgnoresNonMatchingCmdline(t *testing.T) {
 }
 
 // TestSigtermFallback_DeadPID covers the dead-PID case: the PID file points
-// at a process that no longer exists, pgrep falls through to "no matches".
-// Per #553 the fallback's contract is invoked only after the Shutdown RPC
-// has proven the daemon is running, so "could not locate a PID" must be
-// reported as ShutdownFailed (not ShutdownNoDaemon) along with an actionable
-// recovery hint — anything else would silently leave the stale daemon up.
+// at a process that no longer exists, and the process scan finds no
+// candidates. Per #553 the fallback's contract is invoked only after the
+// Shutdown RPC has proven the daemon is running, so "could not locate a PID"
+// must be reported as ShutdownFailed (not ShutdownNoDaemon) along with an
+// actionable recovery hint — anything else would silently leave the stale
+// daemon up. The scan is stubbed to zero candidates so the stale-PID branch
+// is asserted deterministically regardless of host daemons (#793).
 func TestSigtermFallback_DeadPID(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", home)
+	stubDaemonScan(t, nil, nil)
 
 	// Pick a PID well above any realistic running PID. 0x7fffffff exceeds
 	// the default pid_max on both Linux (32768/4M) and macOS (99999).
@@ -320,6 +341,33 @@ func TestSigtermFallback_DeadPID(t *testing.T) {
 	}
 	if !strings.Contains(msg, strconv.Itoa(deadPID)) {
 		t.Errorf("sigtermFallback error %q missing stale PID-file pid=%d in source", msg, deadPID)
+	}
+}
+
+// TestSigtermFallback_AmbiguousCandidates covers the multiple-daemons branch,
+// previously untestable without real host daemons (#793): with no usable PID
+// file and a scan returning several candidates, the fallback must refuse to
+// guess, returning ShutdownFailed with an error naming every candidate PID.
+func TestSigtermFallback_AmbiguousCandidates(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	stubDaemonScan(t, []int{11111, 22222}, nil)
+
+	result, err := sigtermFallback()
+	if result != ShutdownFailed {
+		t.Fatalf("sigtermFallback returned %v for ambiguous candidates, want ShutdownFailed", result)
+	}
+	if err == nil {
+		t.Fatalf("sigtermFallback returned nil error for ambiguous candidates")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "ambiguous") {
+		t.Errorf("sigtermFallback error %q missing 'ambiguous'", msg)
+	}
+	for _, pid := range []string{"11111", "22222"} {
+		if !strings.Contains(msg, pid) {
+			t.Errorf("sigtermFallback error %q missing candidate pid %s", msg, pid)
+		}
 	}
 }
 
@@ -455,24 +503,27 @@ func TestRequestShutdown_PreShutdownDaemon(t *testing.T) {
 		t.Fatalf("ping fake daemon: %v", err)
 	}
 
-	// The fallback's pgrep step would, on a busy host, find a real
-	// `af --daemon` process and try to signal it. That host-state
-	// dependency belongs in an integration test, not a unit test —
-	// here we only need to assert RequestShutdown completes without
-	// a panic and surfaces a Result/error consistent with the routing
-	// having reached the fallback. The result space (post-#553) is:
-	//   - ShutdownFailed, non-nil error (clean test host: pgrep found
-	//       no matches; or ambiguous pgrep matches; both fold into the
-	//       "daemon is provably running but unsignaled" bucket)
-	//   - ShutdownViaSIGTERM, nil       (host has a real daemon — uncommon)
+	// The fallback's process scan is stubbed to zero candidates (#793):
+	// unstubbed it is host-wide, and a host running the supervised daemon
+	// would either get SIGTERMed by this test or make the result
+	// nondeterministic. With no PID file and an empty scan, the only
+	// acceptable outcome is ShutdownFailed with a non-nil error — the
+	// daemon is provably running (Ping succeeded) but cannot be signaled.
 	// What is NOT acceptable: a panic, ShutdownViaRPC (would mean the
 	// fake daemon answered Shutdown, which it does not implement), or
 	// ShutdownNoDaemon (would contradict the proven-alive socket).
+	stubDaemonScan(t, nil, nil)
 	result, err := RequestShutdown()
 	if result == ShutdownViaRPC {
 		t.Fatalf("RequestShutdown returned ShutdownViaRPC; fake daemon has no Shutdown method — routing into the SIGTERM fallback is broken (err=%v)", err)
 	}
 	if result == ShutdownNoDaemon {
 		t.Fatalf("RequestShutdown returned ShutdownNoDaemon after a successful Ping; the socket proved the daemon is alive, so #553's invariant is violated (err=%v)", err)
+	}
+	if result != ShutdownFailed {
+		t.Fatalf("RequestShutdown returned %v, want ShutdownFailed (no PID file, scan stubbed empty)", result)
+	}
+	if err == nil {
+		t.Fatalf("RequestShutdown returned nil error; expected one carrying the recovery hint")
 	}
 }

--- a/daemoncmd.go
+++ b/daemoncmd.go
@@ -18,11 +18,11 @@ import (
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "Manage the background daemon that schedules tasks",
-	Long: `The agent-factory daemon runs task cron schedules in-process and drives
-autoyes mode. It starts automatically when you run af and at least one
-enabled task exists. Install it as a user-level autostart unit (systemd user
-service on Linux, launchd agent on macOS) so scheduled tasks keep firing
-after reboots, even when af is never opened.`,
+	Long: `The agent-factory daemon runs task cron schedules in-process, supervises
+watch-task scripts, and drives autoyes mode. It starts automatically when you
+run af and at least one enabled task exists. Install it as a user-level
+autostart unit (systemd user service on Linux, launchd agent on macOS) so
+tasks keep firing after reboots, even when af is never opened.`,
 }
 
 var daemonInstallCmd = &cobra.Command{

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,118 @@
+# Tasks
+
+A task delivers a prompt to an AI agent session automatically. Every task has exactly one **trigger** — a cron schedule (`cron_expr`) or a long-running watch script (`watch_cmd`) — and one **delivery mode**: create a fresh session per fire, or send the prompt into an existing session (`target_session`).
+
+Tasks are hosted by the agent-factory daemon, which starts automatically whenever `af` runs and an enabled task exists. There are no per-task OS scheduler units — see [Daemon lifecycle](#daemon-lifecycle) and [Migration notes](#migration-notes).
+
+## Trigger × delivery matrix
+
+|  | `target_session` empty | `target_session` set |
+|---|---|---|
+| **`cron_expr`** | create a session per fire | send `prompt` into the session at schedule |
+| **`watch_cmd`** | each stdout line → create a session with the rendered prompt | each stdout line → send the rendered prompt into the session |
+
+When `target_session` is set, the session title is looked up in the task's own repo (a same-titled session in an unrelated repo can never receive the prompt). If no session with that title exists at fire time, it is **auto-created** with the task's `project_path`/`program` and the rendered prompt as its initial prompt — same behavior as `af sessions send-prompt --create`.
+
+## Task fields
+
+Tasks live in `~/.agent-factory/tasks.json`. Manage them via `af tasks` (JSON CLI) or the TUI Tasks pane (`s` to create, `S` to list).
+
+| Field | Meaning |
+|---|---|
+| `id` | 8-char hex identifier, generated on add |
+| `name` | Display name; also seeds created-session titles |
+| `prompt` | Prompt to deliver. Required for cron tasks. Optional for watch tasks: empty delivers the raw emitted line; otherwise every `{{line}}` occurrence is replaced with the line |
+| `cron_expr` | Time trigger — 5-field cron expression (exactly one of `cron_expr` / `watch_cmd`) |
+| `watch_cmd` | Event trigger — long-running command; each stdout line fires the task (exactly one of `cron_expr` / `watch_cmd`) |
+| `target_session` | Deliver into this session by title (auto-created if missing). Empty = create a new session per fire |
+| `project_path` | Repo the task operates on; also the watch script's working directory |
+| `program` | Agent to run (`claude`, `aider`, …). Empty = configured `default_program` |
+| `enabled` | Disabled tasks never fire; their watch script is stopped |
+| `last_run_at` / `last_run_status` | Set by the daemon: `started` (session created), `sent` (prompt delivered into a session), and for watch tasks `stopped` / `errored` (see below) |
+
+A task with both triggers set is always invalid. An enabled task must have exactly one; a disabled task with neither is tolerated as a draft.
+
+## Cron tasks
+
+`cron_expr` is a standard 5-field expression (`minute hour day-of-month month day-of-week`) with Vixie semantics, including the DOM/DOW OR rule when both fields are restricted. The daemon evaluates expressions in-process — what you write is exactly what is evaluated, with no conversion to OS timer formats.
+
+```bash
+af tasks add --name "Daily triage" --prompt "Triage open issues" --cron "0 9 * * 1-5"
+af tasks trigger <id>     # run a cron task immediately
+```
+
+`af tasks trigger` (and the TUI `r` key) work for cron tasks only — a watch task has no event line to render its prompt with, so manual triggers are refused.
+
+## Watch tasks
+
+A watch task keeps a script running and turns its output into events:
+
+```bash
+af tasks add --name "gh-issues" --watch-cmd "./watch-issues.sh" \
+  --prompt "Triage: {{line}}" --target-session captain
+```
+
+### Script contract
+
+- The script is **long-lived**. The daemon runs it via `$SHELL -c <watch_cmd>` with the task's `project_path` as the working directory, and keeps it running while the task is enabled.
+- **Each newline-terminated stdout line is one event.** Lines over 64KB are truncated to the cap (the remainder is discarded with a logged note). Unterminated trailing output at exit is not an event. Silence is fine — a quiet watcher is healthy; there is no output timeout.
+- **stderr** appends to `~/.agent-factory/logs/task-<id>.log`. Use it for all logging — anything on stdout becomes an event.
+- **Environment**: the script receives `AF_TASK_ID`, `AF_TASK_NAME`, and `AF_PROJECT_PATH` on top of the daemon's environment.
+- **Exit 0 = intentional stop.** The task's status becomes `stopped` and the script is not restarted until the next daemon start, task edit, or re-enable.
+- **Non-zero exit = failure.** The script is restarted with exponential backoff, 1s doubling to a 5-minute cap. A run that stays healthy for 10 minutes resets the backoff.
+- **Crash-loop breaker**: 5 or more non-zero exits within 10 minutes set the status to `errored` and stop restarts. Re-arm by editing the task, toggling it, or restarting the daemon.
+- **Rate limit**: at most 10 events per minute per task. Excess events are dropped — never silently: a warning is logged with a running drop counter.
+- **Prompt rendering**: an empty `prompt` delivers the raw line; otherwise `{{line}}` is substituted. An event whose rendered prompt is empty is dropped with an error log.
+- **Ordering**: deliveries are serialized per task in emission order. A slow delivery backpressures the script's stdout rather than reordering events.
+- **Process tree**: each script runs in its own process group. On stop the group gets SIGTERM, then SIGKILL after 5 seconds — backgrounded children do not outlive the watcher. Scripts should treat SIGTERM as "clean up and exit".
+- **No replay**: events are not persisted across daemon restarts. Scripts that poll should track their own cursor (see `examples/tasks/gh-issue-poll.sh`).
+
+Edits to delivery fields (`prompt`, `target_session`, `program`) apply from the next event without restarting the script; edits to `watch_cmd`, `project_path`, or `name` restart it.
+
+### Watch-task status
+
+The TUI Tasks pane shows each watch task's supervision state, derived from the persisted fields:
+
+- **watching** — enabled, script supervised by the daemon
+- **stopped** — script exited 0 (or the task is disabled)
+- **errored** — crash-loop breaker tripped; check `~/.agent-factory/logs/task-<id>.log`
+
+## Daemon lifecycle
+
+The daemon is the single scheduler host: it evaluates cron expressions, supervises watch scripts, and serves autoyes.
+
+- Every `af` invocation ensures the daemon is running whenever an enabled task exists, and the daemon keeps running after the TUI exits.
+- To keep tasks firing across **reboots** without opening `af`, register the user-level autostart unit (a systemd user service on Linux, a launchd agent on macOS):
+
+```bash
+af daemon install      # register autostart at login
+af daemon uninstall    # remove it (the daemon still starts on demand)
+```
+
+- Task edits made through `af tasks` or the TUI take effect live — the daemon is poked to reload `tasks.json`. If the poke fails, the change applies at the next daemon start.
+
+## Migration notes
+
+Versions before #791 installed one systemd timer / launchd plist **per task** (`agent-factory-task-*`, `agent-factory-sched-*` units). That conversion layer is gone:
+
+- The daemon evaluates cron expressions directly; the autostart unit registered by `af daemon install` is the only OS-level unit left.
+- On first start, the daemon **sweeps** any leftover per-task units from older versions (disabled, deleted, logged) so tasks cannot double-fire.
+- `tasks.json` is unchanged — existing tasks work as-is, and the new `watch_cmd` / `target_session` fields are optional extensions.
+
+## CLI quick reference
+
+```bash
+af tasks list
+af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
+af tasks add --name <n> --watch-cmd <cmd> [--prompt "… {{line}} …"] [--target-session <title>]
+af tasks get <id>
+af tasks update <id> [--cron …|--watch-cmd …] [--prompt …] [--target-session …] [--enabled true|false]
+af tasks trigger <id>          # cron tasks only
+af tasks remove <id>
+```
+
+On `update`, setting one trigger clears the other (switching watch→cron requires a prompt). `--target-session ""` explicitly reverts to create-per-run; omitting the flag leaves it untouched.
+
+## Examples
+
+See `examples/tasks/` for runnable watch-script skeletons: a log tailer (`log-tail.sh`) and a GitHub issue poller (`gh-issue-poll.sh`).

--- a/examples/github-issue-listener/README.md
+++ b/examples/github-issue-listener/README.md
@@ -30,7 +30,9 @@ The first run records the current UTC timestamp in the state file and only react
 
 ## Run it persistently
 
-The project's `task/` directory has fuller systemd / launchd integration for scheduled jobs; the snippets below are standalone and have no dependency on it.
+The recommended way to keep a poller like this running is a **watch task**: the agent-factory daemon supervises the script, restarts it with backoff on failure, and captures its stderr to a per-task log — see [docs/tasks.md](../../docs/tasks.md) and the leaner watch-task variant of this script at [examples/tasks/gh-issue-poll.sh](../tasks/gh-issue-poll.sh) (it emits events instead of calling `af sessions create` itself).
+
+If you'd rather not have the daemon supervise it, the snippets below run the script as a standalone OS unit with no dependency on Agent Factory's task system.
 
 ### Linux — systemd user unit
 

--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -1,0 +1,32 @@
+# Watch-task examples
+
+Runnable skeletons for the `watch_cmd` trigger ([docs/tasks.md](../../docs/tasks.md)): the daemon keeps the script running, and every newline-terminated stdout line becomes one event — a prompt delivered to an agent session, with `{{line}}` substituted in the task's prompt.
+
+| Script | Pattern |
+|---|---|
+| [`log-tail.sh`](log-tail.sh) | Stream a file: `tail -F` piped through a line-buffered `grep`. One event per matching log line. |
+| [`gh-issue-poll.sh`](gh-issue-poll.sh) | Poll an API with a since-cursor the script persists itself. One event per newly opened GitHub issue; survives daemon restarts without replaying or dropping. |
+
+## Quick start
+
+```bash
+chmod +x log-tail.sh gh-issue-poll.sh
+
+af tasks add --name "log-errors" \
+  --watch-cmd "LOG_FILE=/var/log/app.log $PWD/log-tail.sh" \
+  --prompt "Investigate this error: {{line}}" \
+  --target-session debugger
+
+af tasks add --name "gh-issues" \
+  --watch-cmd "REPO=owner/name $PWD/gh-issue-poll.sh" \
+  --prompt "Triage this new issue: {{line}}"
+```
+
+With `--target-session` the prompt is sent into that session (auto-created if missing); without it, every event creates a fresh session.
+
+## Rules of thumb
+
+- **stdout is the event stream** — one event per line. Send all logging to stderr; it lands in `~/.agent-factory/logs/task-<id>.log`.
+- **Exit 0 means "stop me"** (status `stopped`, no restart until re-enable). Exit non-zero on failure so the daemon restarts you with backoff — and so a persistent misconfiguration trips the crash-loop breaker (`errored`) instead of looping silently.
+- **Stay under 10 events/min** per task; excess events are dropped (with a logged warning).
+- **Own your cursor.** Events are not replayed across daemon restarts, so pollers should persist their resume point, like `gh-issue-poll.sh` does.

--- a/examples/tasks/gh-issue-poll.sh
+++ b/examples/tasks/gh-issue-poll.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Watch-task skeleton: poll a GitHub repo and emit one event per newly opened
+# issue. Demonstrates the polling-loop pattern with a since-cursor: the script
+# owns its own resume point, so daemon restarts never replay or drop issues.
+#
+#   af tasks add --name "gh-issues" \
+#     --watch-cmd "REPO=owner/name $PWD/gh-issue-poll.sh" \
+#     --prompt "Triage this new issue: {{line}}" \
+#     --target-session captain
+#
+# Contract reminders (see docs/tasks.md):
+#   - stdout = events, one per newline-terminated line. Log to stderr only.
+#   - stderr lands in ~/.agent-factory/logs/task-$AF_TASK_ID.log.
+#   - Events are rate-limited to 10/min per task; this poller stays far below.
+#   - The daemon does not replay events across restarts — the cursor file is
+#     what makes this script resumable.
+#
+# Requires: gh (authenticated), jq.
+#
+# Env:
+#   REPO            owner/name of the repo to watch (required)
+#   POLL_INTERVAL   seconds between polls (default: 60)
+#   STATE_FILE      cursor file (default: ~/.agent-factory/gh-issue-poll-<task id>.cursor)
+
+set -euo pipefail
+
+: "${REPO:?REPO is required (e.g. owner/name)}"
+POLL_INTERVAL="${POLL_INTERVAL:-60}"
+STATE_FILE="${STATE_FILE:-$HOME/.agent-factory/gh-issue-poll-${AF_TASK_ID:-default}.cursor}"
+
+log() { printf '[gh-issue-poll] %s\n' "$*" >&2; }
+
+now_utc() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+mkdir -p "$(dirname "$STATE_FILE")"
+if [[ ! -f "$STATE_FILE" ]]; then
+  now_utc > "$STATE_FILE"
+  log "initialized cursor at $(cat "$STATE_FILE"); only issues opened after that fire events"
+fi
+
+if ! gh api "repos/$REPO" --silent >/dev/null 2>&1; then
+  # Exit non-zero: misconfiguration is a failure, so the daemon retries with
+  # backoff and the crash-loop breaker surfaces a persistent problem as
+  # status "errored" instead of looping forever.
+  log "cannot read repos/$REPO via gh — check the owner/name spelling and gh auth"
+  exit 1
+fi
+
+log "task=${AF_TASK_NAME:-?} watching $REPO every ${POLL_INTERVAL}s"
+
+while true; do
+  since="$(cat "$STATE_FILE")"
+  next="$(now_utc)"
+
+  # One line per new issue: "#<number> <title> <url>". The whole line becomes
+  # {{line}} in the task prompt.
+  if issues="$(gh api "repos/$REPO/issues?since=$since&state=open&per_page=100" --paginate 2>/dev/null \
+      | jq -r --arg since "$since" \
+          '.[] | select(.pull_request | not) | select(.created_at >= $since)
+               | "#\(.number) \(.title) \(.html_url)"')"; then
+    if [[ -n "$issues" ]]; then
+      printf '%s\n' "$issues"
+    fi
+    # Advance the cursor only after a successful poll so a failed call
+    # never skips the window it would have covered.
+    printf '%s\n' "$next" > "$STATE_FILE"
+  else
+    log "gh api call failed; keeping cursor at $since and retrying next tick"
+  fi
+
+  sleep "$POLL_INTERVAL"
+done

--- a/examples/tasks/log-tail.sh
+++ b/examples/tasks/log-tail.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Watch-task skeleton: emit one event per matching line appended to a log file.
+#
+# Register it as a watch task (the daemon keeps it running and turns each
+# stdout line into one prompt delivery):
+#
+#   af tasks add --name "log-errors" \
+#     --watch-cmd "LOG_FILE=/var/log/app.log $PWD/log-tail.sh" \
+#     --prompt "Investigate this error: {{line}}" \
+#     --target-session debugger
+#
+# Contract reminders (see docs/tasks.md):
+#   - stdout = events, one per newline-terminated line. Log to stderr only.
+#   - stderr lands in ~/.agent-factory/logs/task-$AF_TASK_ID.log.
+#   - Exit 0 means "stop me until re-enabled"; non-zero gets a backoff restart.
+#   - SIGTERM is the daemon asking you to shut down; the default handler is fine.
+#
+# Env:
+#   LOG_FILE   file to tail (required)
+#   PATTERN    extended regex to match (default: ERROR)
+
+set -euo pipefail
+
+: "${LOG_FILE:?LOG_FILE is required}"
+PATTERN="${PATTERN:-ERROR}"
+
+echo "[log-tail] task=${AF_TASK_NAME:-?} watching $LOG_FILE for /$PATTERN/" >&2
+
+# -F follows across rotation/truncation; -n 0 skips history so only lines
+# written after the watcher starts become events. --line-buffered keeps grep
+# from batching matches — without it, events can sit in grep's stdout buffer
+# for a long time on a quiet log. grep exiting (e.g. the pipe breaking) ends
+# the pipeline non-zero, so the daemon restarts the watcher with backoff.
+tail -F -n 0 -- "$LOG_FILE" | grep --line-buffered -E -- "$PATTERN"

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -18,6 +18,19 @@ import (
 // string (the daemon then falls back to the user's configured default_program).
 const programDefaultLabel = "(use config default)"
 
+// Edit-form focus stops, in tab order.
+const (
+	taskFocusName = iota
+	taskFocusPrompt
+	taskFocusCron
+	taskFocusWatch
+	taskFocusTarget
+	taskFocusPath
+	taskFocusProgram
+	taskFocusSave
+	taskFocusCount
+)
+
 // TaskPane renders an inline task editor in the right pane.
 type TaskPane struct {
 	tasks       []task.Task
@@ -28,6 +41,8 @@ type TaskPane struct {
 	editName   textinput.Model
 	editPrompt textarea.Model
 	editCron   textinput.Model
+	editWatch  textinput.Model
+	editTarget textinput.Model
 	editPath   textinput.Model
 	// Program selector state. editProgramOptions is the list of choices shown
 	// inline (index 0 is always the "use config default" entry, followed by
@@ -36,7 +51,7 @@ type TaskPane struct {
 	editProgramOptions []string
 	editProgramIdx     int
 	editError          string // last validation error shown to the user
-	focusIndex         int    // 0=name, 1=prompt, 2=cron, 3=path, 4=program, 5=save button
+	focusIndex         int    // 0=name, 1=prompt, 2=cron, 3=watch, 4=target, 5=path, 6=program, 7=save button
 
 	// Create mode
 	creating       bool
@@ -143,6 +158,16 @@ func (s *TaskPane) EnterCreateMode(defaultPath string) {
 	cron.CharLimit = 64
 	cron.Blur()
 
+	watch := textinput.New()
+	watch.Placeholder = "long-running cmd; 1 stdout line = 1 event"
+	watch.CharLimit = 256
+	watch.Blur()
+
+	target := textinput.New()
+	target.Placeholder = "(new session per run)"
+	target.CharLimit = 64
+	target.Blur()
+
 	path := textinput.New()
 	path.SetValue(defaultPath)
 	path.CharLimit = 256
@@ -151,9 +176,11 @@ func (s *TaskPane) EnterCreateMode(defaultPath string) {
 	s.editName = name
 	s.editPrompt = prompt
 	s.editCron = cron
+	s.editWatch = watch
+	s.editTarget = target
 	s.editPath = path
 	s.setProgramFromValue("")
-	s.focusIndex = 0
+	s.focusIndex = taskFocusName
 	s.creating = true
 	s.hasFocus = true
 	s.editError = ""
@@ -202,9 +229,11 @@ func (s *TaskPane) HasPendingCreate() bool {
 
 // ConsumePendingCreate returns the submitted create data and clears the pending flag.
 // program is the user-supplied program override; empty means "use the caller's default".
-func (s *TaskPane) ConsumePendingCreate() (name, prompt, cron, path, program string) {
+func (s *TaskPane) ConsumePendingCreate() (name, prompt, cron, watchCmd, targetSession, path, program string) {
 	s.pendingCreate = false
-	return s.editName.Value(), s.editPrompt.Value(), s.editCron.Value(), s.editPath.Value(), s.programValue()
+	return s.editName.Value(), s.editPrompt.Value(),
+		strings.TrimSpace(s.editCron.Value()), strings.TrimSpace(s.editWatch.Value()),
+		s.editTarget.Value(), s.editPath.Value(), s.programValue()
 }
 
 // SetPendingTrigger marks the currently selected task to be triggered.
@@ -337,6 +366,18 @@ func (s *TaskPane) enterEditMode() {
 	cron.CharLimit = 64
 	cron.Blur()
 
+	watch := textinput.New()
+	watch.SetValue(tsk.WatchCmd)
+	watch.Placeholder = "long-running cmd; 1 stdout line = 1 event"
+	watch.CharLimit = 256
+	watch.Blur()
+
+	target := textinput.New()
+	target.SetValue(tsk.TargetSession)
+	target.Placeholder = "(new session per run)"
+	target.CharLimit = 64
+	target.Blur()
+
 	path := textinput.New()
 	path.SetValue(tsk.ProjectPath)
 	path.CharLimit = 256
@@ -345,69 +386,66 @@ func (s *TaskPane) enterEditMode() {
 	s.editName = name
 	s.editPrompt = prompt
 	s.editCron = cron
+	s.editWatch = watch
+	s.editTarget = target
 	s.editPath = path
 	s.setProgramFromValue(tsk.Program)
-	s.focusIndex = 0
+	s.focusIndex = taskFocusName
 	s.editing = true
 	s.editError = ""
+}
+
+// validateForm enforces the shared create/edit form contract, mirroring
+// `af tasks add` (api/tasks.go): a name, exactly one of cron / watch cmd
+// (#782), and — for cron tasks only — a non-empty prompt plus a valid cron
+// expression. Watch tasks may omit the prompt: each event defaults to the raw
+// emitted line. Returns the inline error to surface, or "" when valid.
+func (s *TaskPane) validateForm() string {
+	if s.editName.Value() == "" {
+		return "name is required"
+	}
+	hasCron := strings.TrimSpace(s.editCron.Value()) != ""
+	hasWatch := strings.TrimSpace(s.editWatch.Value()) != ""
+	if hasCron && hasWatch {
+		return "cron and watch cmd are mutually exclusive; set exactly one"
+	}
+	if !hasCron && !hasWatch {
+		return "exactly one of cron or watch cmd is required"
+	}
+	if hasCron {
+		if strings.TrimSpace(s.editPrompt.Value()) == "" {
+			return "prompt must be non-empty"
+		}
+		if err := task.ValidateCronExpr(strings.TrimSpace(s.editCron.Value())); err != nil {
+			return fmt.Sprintf("invalid cron: %v", err)
+		}
+	}
+	return ""
 }
 
 func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 	switch msg.Type {
 	case tea.KeyTab:
-		s.focusIndex = (s.focusIndex + 1) % 6
+		s.focusIndex = (s.focusIndex + 1) % taskFocusCount
 		s.updateEditFocus()
 	case tea.KeyShiftTab:
-		s.focusIndex = (s.focusIndex + 5) % 6
+		s.focusIndex = (s.focusIndex + taskFocusCount - 1) % taskFocusCount
 		s.updateEditFocus()
 	case tea.KeyEsc, tea.KeyCtrlC:
 		s.editing = false
 		s.creating = false
 		s.editError = ""
 	case tea.KeyEnter:
-		if s.focusIndex == 5 {
+		if s.focusIndex == taskFocusSave {
+			if errMsg := s.validateForm(); errMsg != "" {
+				s.editError = errMsg
+				return true
+			}
 			if s.creating {
-				if s.editName.Value() == "" {
-					s.editError = "name is required"
-					return true
-				}
-				if strings.TrimSpace(s.editPrompt.Value()) == "" {
-					s.editError = "prompt must be non-empty"
-					return true
-				}
-				if err := task.ValidateCronExpr(s.editCron.Value()); err != nil {
-					s.editError = fmt.Sprintf("invalid cron: %v", err)
-					return true
-				}
 				s.editError = ""
 				s.pendingCreate = true
 				s.creating = false
 			} else {
-				if s.editName.Value() == "" {
-					s.editError = "name is required"
-					return true
-				}
-				// Watch tasks (#782 phase 2) have no cron expression and may
-				// have an empty prompt (each event defaults to the raw line).
-				// The edit form gains watch-cmd/target-session fields in
-				// phase 3; until then the cron field must stay empty so the
-				// save can't produce a task with two triggers.
-				isWatch := s.tasks[s.selectedIdx].WatchCmd != ""
-				if isWatch {
-					if strings.TrimSpace(s.editCron.Value()) != "" {
-						s.editError = "this is a watch task; cron must stay empty (edit the trigger with af tasks update)"
-						return true
-					}
-				} else {
-					if strings.TrimSpace(s.editPrompt.Value()) == "" {
-						s.editError = "prompt must be non-empty"
-						return true
-					}
-					if err := task.ValidateCronExpr(s.editCron.Value()); err != nil {
-						s.editError = fmt.Sprintf("invalid cron: %v", err)
-						return true
-					}
-				}
 				// Mirror the create path (app.handleTaskCreate): resolve
 				// the user-entered path to an absolute form so an empty
 				// or relative value behaves the same when the scheduler
@@ -420,7 +458,9 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 				s.editError = ""
 				s.tasks[s.selectedIdx].Name = s.editName.Value()
 				s.tasks[s.selectedIdx].Prompt = s.editPrompt.Value()
-				s.tasks[s.selectedIdx].CronExpr = s.editCron.Value()
+				s.tasks[s.selectedIdx].CronExpr = strings.TrimSpace(s.editCron.Value())
+				s.tasks[s.selectedIdx].WatchCmd = strings.TrimSpace(s.editWatch.Value())
+				s.tasks[s.selectedIdx].TargetSession = s.editTarget.Value()
 				s.tasks[s.selectedIdx].ProjectPath = absPath
 				s.tasks[s.selectedIdx].Program = s.programValue()
 				s.dirty = true
@@ -428,20 +468,24 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 			}
 			return true
 		}
-		if s.focusIndex == 1 {
+		if s.focusIndex == taskFocusPrompt {
 			s.editPrompt, _ = s.editPrompt.Update(msg)
 		}
 	default:
 		switch s.focusIndex {
-		case 0:
+		case taskFocusName:
 			s.editName, _ = s.editName.Update(msg)
-		case 1:
+		case taskFocusPrompt:
 			s.editPrompt, _ = s.editPrompt.Update(msg)
-		case 2:
+		case taskFocusCron:
 			s.editCron, _ = s.editCron.Update(msg)
-		case 3:
+		case taskFocusWatch:
+			s.editWatch, _ = s.editWatch.Update(msg)
+		case taskFocusTarget:
+			s.editTarget, _ = s.editTarget.Update(msg)
+		case taskFocusPath:
 			s.editPath, _ = s.editPath.Update(msg)
-		case 4:
+		case taskFocusProgram:
 			s.handleProgramKey(msg)
 		}
 	}
@@ -471,16 +515,22 @@ func (s *TaskPane) updateEditFocus() {
 	s.editName.Blur()
 	s.editPrompt.Blur()
 	s.editCron.Blur()
+	s.editWatch.Blur()
+	s.editTarget.Blur()
 	s.editPath.Blur()
 
 	switch s.focusIndex {
-	case 0:
+	case taskFocusName:
 		s.editName.Focus()
-	case 1:
+	case taskFocusPrompt:
 		s.editPrompt.Focus()
-	case 2:
+	case taskFocusCron:
 		s.editCron.Focus()
-	case 3:
+	case taskFocusWatch:
+		s.editWatch.Focus()
+	case taskFocusTarget:
+		s.editTarget.Focus()
+	case taskFocusPath:
 		s.editPath.Focus()
 	}
 }
@@ -491,6 +541,23 @@ func (s *TaskPane) String() string {
 		return s.renderEditMode()
 	}
 	return s.renderListMode()
+}
+
+// watchTaskStatus derives the supervision state shown for a watch task from
+// the fields the daemon persists (#782 phase 2): the watcher supervisor
+// records "stopped" (script exited 0) and "errored" (crash loop) in
+// LastRunStatus; any other value on an enabled watch task means the daemon
+// (re-)arms its watcher on start/reload, i.e. "watching". A disabled watch
+// task has no watcher, so it reads "stopped".
+func watchTaskStatus(tsk task.Task) string {
+	if !tsk.Enabled {
+		return "stopped"
+	}
+	switch tsk.LastRunStatus {
+	case "stopped", "errored":
+		return tsk.LastRunStatus
+	}
+	return "watching"
 }
 
 func (s *TaskPane) renderListMode() string {
@@ -533,11 +600,11 @@ func (s *TaskPane) renderListMode() string {
 		}
 
 		isSelected := i == s.selectedIdx
-		// Watch tasks have no cron expression; show their trigger instead.
-		// Editing the watch fields in the TUI lands in phase 3 of #782.
+		// Watch tasks have no cron expression; show their trigger and the
+		// watcher's supervision status instead (#782).
 		trigger := tsk.CronExpr
-		if tsk.WatchCmd != "" {
-			trigger = "watch: " + tsk.WatchCmd
+		if tsk.IsWatch() {
+			trigger = fmt.Sprintf("watch: %s [%s]", tsk.WatchCmd, watchTaskStatus(tsk))
 		}
 		var header string
 		if tsk.Name != "" {
@@ -572,6 +639,9 @@ func (s *TaskPane) renderListMode() string {
 		detail := fmt.Sprintf("    %s • last: %s", programLabel, lastRun)
 		if tsk.LastRunStatus != "" {
 			detail += " (" + tsk.LastRunStatus + ")"
+		}
+		if tsk.TargetSession != "" {
+			detail += " • → " + tsk.TargetSession
 		}
 		b.WriteString(detailStyle.Render(detail))
 		b.WriteString("\n")
@@ -610,6 +680,8 @@ func (s *TaskPane) renderEditMode() string {
 		s.editPrompt.SetHeight(s.height / 4)
 	}
 	s.editCron.Width = inputWidth
+	s.editWatch.Width = inputWidth
+	s.editTarget.Width = inputWidth
 	s.editPath.Width = inputWidth
 
 	var b strings.Builder
@@ -632,6 +704,17 @@ func (s *TaskPane) renderEditMode() string {
 	b.WriteString("  ")
 	b.WriteString(s.editCron.View())
 	b.WriteString("\n")
+	b.WriteString(labelStyle.Render("Watch:"))
+	b.WriteString(" ")
+	b.WriteString(s.editWatch.View())
+	b.WriteString("\n")
+	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+	b.WriteString(hintStyle.Render("       trigger: set exactly one of Cron / Watch"))
+	b.WriteString("\n")
+	b.WriteString(labelStyle.Render("Target:"))
+	b.WriteString(" ")
+	b.WriteString(s.editTarget.View())
+	b.WriteString("\n")
 	b.WriteString(labelStyle.Render("Path:"))
 	b.WriteString("  ")
 	b.WriteString(s.editPath.View())
@@ -645,7 +728,7 @@ func (s *TaskPane) renderEditMode() string {
 	if s.creating {
 		submitLabel = " Create "
 	}
-	if s.focusIndex == 5 {
+	if s.focusIndex == taskFocusSave {
 		b.WriteString("       " + focusedButtonStyle.Render(submitLabel))
 	} else {
 		b.WriteString("       " + buttonStyle.Render(submitLabel))
@@ -664,7 +747,7 @@ func (s *TaskPane) renderEditMode() string {
 // is highlighted in yellow with a ▸ marker; the unfocused row gets the
 // dim/focus-hint treatment used by the rest of the edit form.
 func (s *TaskPane) renderProgramSelector() string {
-	focused := s.focusIndex == 4
+	focused := s.focusIndex == taskFocusProgram
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
 	dimSelectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -121,6 +121,8 @@ func TestTaskPaneCreateModeRejectsEmptyPrompt(t *testing.T) {
 			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
 
 			// Walk to Save and submit.
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> watch
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> target
 			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> path
 			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> program
 			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> save
@@ -142,14 +144,14 @@ func TestTaskPaneCreateModeSelectorDefaultsToConfigDefault(t *testing.T) {
 	tp.EnterCreateMode("/tmp/repo")
 	fillCreateForm(t, tp, "daily")
 
-	// Walk to the Save button (index 5) without touching the Program selector.
-	for i := 0; i < 5; i++ {
+	// Walk to the Save button without touching the Program selector.
+	for i := 0; i < taskFocusCount-1; i++ {
 		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
 	}
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.True(t, tp.HasPendingCreate(), "submit should mark a pending create")
-	_, _, _, _, program := tp.ConsumePendingCreate()
+	_, _, _, _, _, _, program := tp.ConsumePendingCreate()
 	assert.Equal(t, "", program, "default selector option must persist an empty Program")
 }
 
@@ -161,9 +163,9 @@ func TestTaskPaneCreateModeSelectorPicksCanonicalAgent(t *testing.T) {
 	tp.EnterCreateMode("/tmp/repo")
 	fillCreateForm(t, tp, "daily")
 
-	// Walk to the Program field (index 4) and step the selector to "claude"
+	// Walk to the Program field and step the selector to "claude"
 	// (option index 1: 0 is the default sentinel, 1 is the first supported).
-	for i := 0; i < 4; i++ {
+	for i := 0; i < taskFocusProgram; i++ {
 		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
 	}
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyDown})
@@ -172,7 +174,7 @@ func TestTaskPaneCreateModeSelectorPicksCanonicalAgent(t *testing.T) {
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.True(t, tp.HasPendingCreate(), "submit should mark a pending create")
-	_, _, _, _, program := tp.ConsumePendingCreate()
+	_, _, _, _, _, _, program := tp.ConsumePendingCreate()
 	assert.Equal(t, "claude", program, "selector must persist the canonical agent name")
 }
 
@@ -196,7 +198,7 @@ func TestTaskPaneEditModePresetFromExistingProgram(t *testing.T) {
 	assert.True(t, tp.IsEditing())
 
 	// Tab to Save and submit without touching the selector.
-	for i := 0; i < 5; i++ {
+	for i := 0; i < taskFocusCount-1; i++ {
 		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
 	}
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
@@ -233,7 +235,7 @@ func TestTaskPaneEditModeCollapsesLegacyProgramToDefault(t *testing.T) {
 	assert.True(t, tp.IsEditing())
 
 	// Tab to Save and submit without touching the selector.
-	for i := 0; i < 5; i++ {
+	for i := 0; i < taskFocusCount-1; i++ {
 		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
 	}
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
@@ -302,10 +304,10 @@ func editPathTo(t *testing.T, tp *TaskPane, newPath string) {
 	if !tp.IsEditing() {
 		t.Fatalf("expected edit mode")
 	}
-	// Tab Name -> Prompt -> Cron -> Path
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	// Tab Name -> Prompt -> Cron -> Watch -> Target -> Path
+	for i := 0; i < taskFocusPath; i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	}
 	// Clear current value then type the new one.
 	for range tp.editPath.Value() {
 		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyBackspace})
@@ -492,4 +494,203 @@ func TestTaskPaneConsumeDeletedClearsState(t *testing.T) {
 	second := tp.ConsumeDeleted()
 	assert.Empty(t, second,
 		"second save must not reprocess an already-deleted task (#763)")
+}
+
+// tabTo advances the edit-form focus from its current position to the given
+// focus stop by pressing Tab. Assumes focus starts at taskFocusName.
+func tabTo(tp *TaskPane, target int) {
+	for i := 0; i < target; i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	}
+}
+
+// TestTaskPaneCreateModeRejectsBothTriggers covers the exactly-one trigger
+// contract from #782 on the create form: filling both Cron and Watch must
+// surface an inline validation error and keep the form open, mirroring the
+// `af tasks add` CLI validation.
+func TestTaskPaneCreateModeRejectsBothTriggers(t *testing.T) {
+	tp := NewTaskPane()
+	tp.EnterCreateMode("/tmp/repo")
+	fillCreateForm(t, tp, "both") // name, prompt, cron
+
+	tabTo(tp, taskFocusWatch)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("tail -F log")})
+	tabTo(tp, taskFocusSave-taskFocusWatch)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.False(t, tp.HasPendingCreate(), "two triggers must not produce a pending create")
+	assert.True(t, tp.IsCreating(), "form must stay open so user can fix the error")
+	assert.Equal(t, "cron and watch cmd are mutually exclusive; set exactly one", tp.editError)
+}
+
+// TestTaskPaneCreateModeRejectsNoTrigger covers the other half of the
+// exactly-one contract: submitting with neither Cron nor Watch filled must
+// surface an inline error instead of creating an unfireable task.
+func TestTaskPaneCreateModeRejectsNoTrigger(t *testing.T) {
+	tp := NewTaskPane()
+	tp.EnterCreateMode("/tmp/repo")
+
+	// Name and prompt only — no trigger.
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("untriggered")})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do something")})
+	tabTo(tp, taskFocusSave-taskFocusPrompt)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.False(t, tp.HasPendingCreate(), "no trigger must not produce a pending create")
+	assert.True(t, tp.IsCreating(), "form must stay open so user can fix the error")
+	assert.Equal(t, "exactly one of cron or watch cmd is required", tp.editError)
+}
+
+// TestTaskPaneCreateModeWatchTask drives a full watch-task create: watch cmd
+// and target session filled, prompt left empty (a watch task may omit it —
+// each event defaults to the raw emitted line). The pending create must carry
+// the new fields and no cron.
+func TestTaskPaneCreateModeWatchTask(t *testing.T) {
+	tp := NewTaskPane()
+	tp.EnterCreateMode("/tmp/repo")
+
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("gh-issues")})
+	tabTo(tp, taskFocusWatch)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("gh-issue-watch.sh")})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> target
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("captain")})
+	tabTo(tp, taskFocusSave-taskFocusTarget)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.True(t, tp.HasPendingCreate(), "a watch task with an empty prompt is valid")
+	assert.Equal(t, "", tp.editError)
+	_, prompt, cron, watchCmd, targetSession, _, _ := tp.ConsumePendingCreate()
+	assert.Equal(t, "", prompt)
+	assert.Equal(t, "", cron)
+	assert.Equal(t, "gh-issue-watch.sh", watchCmd)
+	assert.Equal(t, "captain", targetSession)
+}
+
+// TestTaskPaneEditModeSwitchCronToWatch verifies the edit form can retrigger
+// an existing cron task as a watch task: clearing Cron and filling Watch must
+// save WatchCmd and leave CronExpr empty (phase 3 of #782 replaced the
+// phase-2 stopgap that froze watch-task triggers in the TUI).
+func TestTaskPaneEditModeSwitchCronToWatch(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "0 0 * * *",
+		ProjectPath: "/tmp/repo",
+		Program:     "claude",
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}) // enter edit mode
+	assert.True(t, tp.IsEditing())
+
+	tabTo(tp, taskFocusCron)
+	for range tp.editCron.Value() {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> watch
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("tail -F app.log")})
+	tabTo(tp, taskFocusSave-taskFocusWatch)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.False(t, tp.IsEditing(), "save should exit edit mode")
+	assert.Equal(t, "", tp.editError)
+	tasks := tp.GetTasks()
+	if assert.Len(t, tasks, 1) {
+		assert.Equal(t, "", tasks[0].CronExpr)
+		assert.Equal(t, "tail -F app.log", tasks[0].WatchCmd)
+	}
+}
+
+// TestTaskPaneEditModeRejectsBothTriggers verifies the edit form surfaces the
+// exactly-one inline error when a cron task gains a watch cmd without the
+// cron being cleared.
+func TestTaskPaneEditModeRejectsBothTriggers(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "0 0 * * *",
+		ProjectPath: "/tmp/repo",
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, tp.IsEditing())
+
+	tabTo(tp, taskFocusWatch)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("tail -F app.log")})
+	tabTo(tp, taskFocusSave-taskFocusWatch)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.True(t, tp.IsEditing(), "form must stay open so user can fix the error")
+	assert.Equal(t, "cron and watch cmd are mutually exclusive; set exactly one", tp.editError)
+	tasks := tp.GetTasks()
+	if assert.Len(t, tasks, 1) {
+		assert.Equal(t, "", tasks[0].WatchCmd, "rejected edit must not be written back")
+	}
+}
+
+// TestTaskPaneListRendersWatchStatus pins the list-row surface for watch
+// tasks (#782 phase 3): the trigger column shows the watch command, and the
+// status derived from the daemon-persisted fields reads watching (enabled,
+// no terminal status), errored (crash loop), or stopped (clean exit or
+// disabled).
+func TestTaskPaneListRendersWatchStatus(t *testing.T) {
+	cases := []struct {
+		name          string
+		enabled       bool
+		lastRunStatus string
+		want          string
+	}{
+		{"enabled fresh", true, "", "[watching]"},
+		{"enabled delivering", true, "sent", "[watching]"},
+		{"crash loop", true, "errored", "[errored]"},
+		{"clean exit", true, "stopped", "[stopped]"},
+		{"disabled", false, "sent", "[stopped]"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tp := NewTaskPane()
+			tp.SetSize(120, 24)
+			tp.SetTasks([]task.Task{{
+				ID:            "abc",
+				Name:          "gh-issues",
+				WatchCmd:      "gh-issue-watch.sh",
+				TargetSession: "captain",
+				ProjectPath:   "/tmp/repo",
+				Enabled:       c.enabled,
+				LastRunStatus: c.lastRunStatus,
+			}})
+
+			out := tp.String()
+			assert.Contains(t, out, "watch: gh-issue-watch.sh",
+				"watch rows must show the trigger kind and command")
+			assert.Contains(t, out, c.want)
+			assert.Contains(t, out, "→ captain",
+				"rows must surface the target session delivery")
+		})
+	}
+}
+
+// TestTaskPaneListCronRowHasNoWatchStatus confirms cron rows are unchanged:
+// they render the cron expression and no watch-status bracket.
+func TestTaskPaneListCronRowHasNoWatchStatus(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(120, 24)
+	tp.SetTasks([]task.Task{{
+		ID:       "abc",
+		Name:     "nightly",
+		Prompt:   "do it",
+		CronExpr: "0 0 * * *",
+		Enabled:  true,
+	}})
+
+	out := tp.String()
+	assert.Contains(t, out, "0 0 * * *")
+	assert.NotContains(t, out, "[watching]")
+	assert.NotContains(t, out, "→ ")
 }


### PR DESCRIPTION
Phase 3 — the final phase — of the plan locked in on #782 ([final shape locked in the issue thread](https://github.com/sachiniyer/agent-factory/issues/782)): TUI surface for the unified trigger × delivery task model, the `docs/tasks.md` rewrite, runnable examples, and the #793 test fix folded in as planned. Phases 1 (#791) and 2 (#794) are merged; this completes the feature.

Fixes #782. Fixes #793.

## TUI — Tasks pane (`ui/task_pane.go`)

The inline create/edit form gains **Watch** (`watch_cmd`) and **Target** (`target_session`) fields, with the same inline-validation UX as the existing fields. Validation is now one shared path for create and edit (`validateForm`), mirroring `af tasks add`:

- exactly one of Cron / Watch (both → `cron and watch cmd are mutually exclusive; set exactly one`; neither → `exactly one of cron or watch cmd is required`)
- cron tasks require a non-empty prompt and a valid expression; watch tasks may omit the prompt (each event defaults to the raw line)
- the phase-2 stopgap ("watch tasks: cron must stay empty, edit via CLI") is gone — watch tasks are fully editable in the TUI, including retriggering cron↔watch

List rows show the trigger kind and, for watch tasks, the supervision status derived from the fields the phase-2 daemon persists (`watching` / `errored` / `stopped`; disabled reads `stopped`), plus the target-session delivery:

```
▸ [✓] daily-triage  0 9 * * 1-5
    Triage open issues
    claude • last: Jun 09 14:30 (started)
  ──────────────────────────────────────────────
  [✓] gh-issues  watch: gh-issue-poll.sh [watching]
    Triage: {{line}}
    (use config default) • last: Jun 09 14:30 (sent) • → captain
  ──────────────────────────────────────────────
  [✓] log-errors  watch: log-tail.sh [errored]
    (use config default) • last: never (errored)
```

Form (create mode, with the inline exactly-one error shown after filling both triggers):

```
New Task
Name:   > both
Prompt: p
Cron:   > 0 9 * * *
Watch:  > tail -F x.log
        trigger: set exactly one of Cron / Watch
Target: > (new session per run)
Path:   > /home/user/repo
Program:  ▸ (use config default) / claude / codex / aider / gemini
        Create
! cron and watch cmd are mutually exclusive; set exactly one
```

`app.handleTaskCreate` re-validates the trigger contract behind the form and persists the new fields. No pane redesign — the form just grew two fields (focus stops are now named constants instead of magic indices).

## Docs

- **New `docs/tasks.md`** (same rigor as `remote-hooks.md`): trigger × delivery matrix, full field reference, the watch-script contract (line = event, 64KB truncation, stderr → `~/.agent-factory/logs/task-<id>.log`, `AF_TASK_ID`/`AF_TASK_NAME`/`AF_PROJECT_PATH`, exit-0 = stop, non-zero = backoff restart 1s→5min, crash-loop breaker at 5 exits/10min, 10 events/min rate limit, `{{line}}` templating, ordering/backpressure, process-group semantics, no-replay/cursor guidance), daemon lifecycle (`af daemon install`), and migration notes (per-task timers gone since #791; one-time upgrade sweep).
- README: TUI Tasks section rewritten to cover both triggers + link to the doc; CLI Tasks section links the doc and examples.
- `af daemon --help` long text now mentions watch-script supervision.

## Examples — `examples/tasks/`

Two runnable, shellcheck-clean skeletons + README:

- `log-tail.sh` — `tail -F -n 0 | grep --line-buffered` (rotation-safe, no history replay, no buffering stalls)
- `gh-issue-poll.sh` — polling loop with a persisted since-cursor; advances the cursor only after a successful poll so failures never skip a window

Both smoke-tested for real: `log-tail.sh` delivered only the matching line as an event; `gh-issue-poll.sh` ran against this repo and emitted `#793` and `#782` — the two issues this PR closes.

## #793 — hermetic sigterm-fallback tests

`locateDaemonPID`'s pgrep scan is host-wide, so on any box running the supervised daemon (the recommended setup since #791) `TestSigtermFallback_DeadPID` failed permanently — and worse, `TestRequestShutdown_PreShutdownDaemon` could SIGTERM the host's **real** daemon. Took the injectable option: the scan entry point is now a function var (`scanDaemonCandidatesFn`), and the tests stub it with a controlled candidate list:

- `TestSigtermFallback_DeadPID` asserts the stale-PID branch deterministically
- `TestSigtermFallback_IgnoresNonMatchingCmdline` now also asserts `ShutdownFailed` (previously it accepted any result)
- `TestRequestShutdown_PreShutdownDaemon` tightened from "anything but RPC/NoDaemon" to exactly `ShutdownFailed` + error — and can no longer kill the host daemon
- **New** `TestSigtermFallback_AmbiguousCandidates` covers the multiple-daemons branch, previously untestable without real host daemons
- `TestSigtermFallback_NoPIDFileAndNoPgrep` deliberately left unstubbed — it exercises the real pgrep-unavailable path (hermetic via empty `PATH`)

Verified on this host with the supervised daemon live: full daemon suite green, and the daemon (pid intact) survived the run.

## Audit (CLAUDE.md adjacent-call-sites)

| Site | Finding |
|---|---|
| `docs/*.md`, README, CLAUDE.md grep for timer/systemd/launchd/scheduler | README + release-testing-plan already post-#791 correct; `examples/github-issue-listener/README.md` referenced the deleted `task/` scheduling layer — **fixed**, now recommends the watch-task path and cross-links `examples/tasks/gh-issue-poll.sh` |
| `ui/` task-field displays | `task_pane.go` list/form updated (this PR); `sidebar.go` renders only a count — unaffected; no other task renderers |
| `af daemon --help` | said cron-only — **fixed** to mention watch supervision |
| `api/tasks.go` CLI | already complete from phase 2 — no changes needed |
| Other `ConsumePendingCreate` callers | one (`app.handleTaskCreate`) — updated with the same exactly-one validation |

## Tests & gates

New: exactly-one validation (both / neither, create + edit), watch-task create with empty prompt + new-field plumbing, cron→watch retrigger via the form, watch-row status table (watching/errored/stopped/disabled + `→ target`), cron-row regression, the four sigterm tests above. Existing pane/app tests updated for the new tab order.

`go build ./...` ✓ · `gofmt -l` clean ✓ · `golangci-lint run --fast` clean ✓ · `deadcode -test` clean ✓ · `go test ./...` green ✓ (including `TestSigtermFallback_DeadPID` on this supervised-daemon host — the #793 repro box) · `go test -race` green: daemon/task/api, and ui/app with `GOFLAGS="-p=1" -parallel 2` ✓ · examples shellcheck-clean and smoke-tested end-to-end.

Constraint check: `daemon/watcher.go` and scheduler logic untouched (status fields read-only from the TUI).

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
