### PR TITLE
fix(daemon): restart the autostart unit on upgrade instead of demoting to an ad-hoc daemon (#796)

### DIFF
--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -191,6 +191,79 @@ func InstallAutostart() (string, error) {
 	}
 }
 
+// Injection points for tests, mirroring legacy_units.go: the GOOS the
+// restart helpers act on, the unit-directory resolvers, and the external
+// command runner, so the upgrade respawn path can be exercised hermetically
+// without touching the host's real autostart unit or invoking
+// systemctl/launchctl.
+var (
+	autostartGOOS            = runtime.GOOS
+	autostartSystemdUserDir  = defaultSystemdUserDir
+	autostartLaunchAgentsDir = defaultLaunchAgentsDir
+	autostartUnitCommand     = runAutostartUnitCommand
+)
+
+func runAutostartUnitCommand(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
+// autostartUnitFilePath returns the path of the unit file InstallAutostart
+// writes for the current platform, or "" when autostart is unsupported here.
+func autostartUnitFilePath() (string, error) {
+	switch autostartGOOS {
+	case "linux":
+		dir, err := autostartSystemdUserDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(dir, autostartUnitName), nil
+	case "darwin":
+		dir, err := autostartLaunchAgentsDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(dir, autostartLaunchdLabel+".plist"), nil
+	default:
+		return "", nil
+	}
+}
+
+// AutostartInstalled reports whether the daemon autostart unit installed by
+// InstallAutostart is present on this machine.
+func AutostartInstalled() bool {
+	path, err := autostartUnitFilePath()
+	if err != nil || path == "" {
+		return false
+	}
+	_, err = os.Stat(path)
+	return err == nil
+}
+
+// RestartAutostartUnit restarts the daemon through the OS service manager —
+// `systemctl --user restart` on Linux, `launchctl kickstart -k` on macOS — so
+// the daemon stays supervised. Used by the upgrade/auto-update respawn path
+// (#796): the Shutdown RPC is a clean exit that Restart=on-failure
+// deliberately does not restart, so respawning via launchDaemonProcess would
+// leave the unit inactive and demote the daemon to an unsupervised ad-hoc
+// child until the next login.
+func RestartAutostartUnit() error {
+	switch autostartGOOS {
+	case "linux":
+		if out, err := autostartUnitCommand("systemctl", "--user", "restart", autostartUnitName); err != nil {
+			return fmt.Errorf("systemctl --user restart %s failed: %w\n%s", autostartUnitName, err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	case "darwin":
+		target := fmt.Sprintf("gui/%d/%s", os.Getuid(), autostartLaunchdLabel)
+		if out, err := autostartUnitCommand("launchctl", "kickstart", "-k", target); err != nil {
+			return fmt.Errorf("launchctl kickstart -k %s failed: %w\n%s", target, err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	default:
+		return fmt.Errorf("daemon autostart is not supported on %s", autostartGOOS)
+	}
+}
+
 // UninstallAutostart removes the daemon autostart unit installed by
 // InstallAutostart. The daemon itself keeps running until it exits or is
 // stopped; it just no longer restarts at login. Returns the path of the

--- a/daemon/autostart_restart_test.go
+++ b/daemon/autostart_restart_test.go
@@ -1,0 +1,142 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for the unit-aware daemon restart used by the upgrade/auto-update
+// respawn path (#796). Everything is exercised against temp directories and
+// an injected command runner — a real supervised daemon may be running on the
+// machine executing these tests, and they must never touch its actual
+// systemctl/launchctl unit.
+
+// withAutostartTestEnv points the autostart helpers at the given GOOS and a
+// temp unit directory, restoring the production values on cleanup. It returns
+// the unit directory.
+func withAutostartTestEnv(t *testing.T, goos string) string {
+	t.Helper()
+	dir := t.TempDir()
+	prevGOOS := autostartGOOS
+	prevSystemd := autostartSystemdUserDir
+	prevLaunchd := autostartLaunchAgentsDir
+	t.Cleanup(func() {
+		autostartGOOS = prevGOOS
+		autostartSystemdUserDir = prevSystemd
+		autostartLaunchAgentsDir = prevLaunchd
+	})
+	autostartGOOS = goos
+	autostartSystemdUserDir = func() (string, error) { return dir, nil }
+	autostartLaunchAgentsDir = func() (string, error) { return dir, nil }
+	return dir
+}
+
+// stubAutostartUnitCommand replaces the external command runner with one that
+// records each invocation, restoring it on cleanup. Each recorded call is the
+// command name followed by its arguments. The runner returns runErr (and, when
+// failing, some captured output so callers can assert it surfaces in errors).
+func stubAutostartUnitCommand(t *testing.T, runErr error) *[][]string {
+	t.Helper()
+	prev := autostartUnitCommand
+	t.Cleanup(func() { autostartUnitCommand = prev })
+	var calls [][]string
+	autostartUnitCommand = func(name string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string{name}, args...))
+		if runErr != nil {
+			return []byte("unit failure detail"), runErr
+		}
+		return nil, nil
+	}
+	return &calls
+}
+
+func TestAutostartInstalledLinux(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+
+	if AutostartInstalled() {
+		t.Fatalf("AutostartInstalled() = true with no unit file in %s", dir)
+	}
+	if err := os.WriteFile(filepath.Join(dir, autostartUnitName), []byte("[Unit]\n"), 0644); err != nil {
+		t.Fatalf("seed unit file: %v", err)
+	}
+	if !AutostartInstalled() {
+		t.Fatalf("AutostartInstalled() = false with unit file present in %s", dir)
+	}
+}
+
+func TestAutostartInstalledDarwin(t *testing.T) {
+	dir := withAutostartTestEnv(t, "darwin")
+
+	if AutostartInstalled() {
+		t.Fatalf("AutostartInstalled() = true with no plist in %s", dir)
+	}
+	if err := os.WriteFile(filepath.Join(dir, autostartLaunchdLabel+".plist"), []byte("<plist/>\n"), 0644); err != nil {
+		t.Fatalf("seed plist: %v", err)
+	}
+	if !AutostartInstalled() {
+		t.Fatalf("AutostartInstalled() = false with plist present in %s", dir)
+	}
+}
+
+func TestAutostartInstalledUnsupportedGOOS(t *testing.T) {
+	withAutostartTestEnv(t, "windows")
+	if AutostartInstalled() {
+		t.Fatalf("AutostartInstalled() = true on unsupported GOOS")
+	}
+}
+
+func TestRestartAutostartUnitLinux(t *testing.T) {
+	withAutostartTestEnv(t, "linux")
+	calls := stubAutostartUnitCommand(t, nil)
+
+	if err := RestartAutostartUnit(); err != nil {
+		t.Fatalf("RestartAutostartUnit: %v", err)
+	}
+	want := [][]string{{"systemctl", "--user", "restart", autostartUnitName}}
+	if len(*calls) != 1 || strings.Join((*calls)[0], " ") != strings.Join(want[0], " ") {
+		t.Fatalf("unit commands = %v, want %v", *calls, want)
+	}
+}
+
+func TestRestartAutostartUnitDarwin(t *testing.T) {
+	withAutostartTestEnv(t, "darwin")
+	calls := stubAutostartUnitCommand(t, nil)
+
+	if err := RestartAutostartUnit(); err != nil {
+		t.Fatalf("RestartAutostartUnit: %v", err)
+	}
+	wantTarget := fmt.Sprintf("gui/%d/%s", os.Getuid(), autostartLaunchdLabel)
+	want := []string{"launchctl", "kickstart", "-k", wantTarget}
+	if len(*calls) != 1 || strings.Join((*calls)[0], " ") != strings.Join(want, " ") {
+		t.Fatalf("unit commands = %v, want [%v]", *calls, want)
+	}
+}
+
+func TestRestartAutostartUnitFailureSurfacesOutput(t *testing.T) {
+	withAutostartTestEnv(t, "linux")
+	stubAutostartUnitCommand(t, errors.New("exit status 1"))
+
+	err := RestartAutostartUnit()
+	if err == nil {
+		t.Fatalf("RestartAutostartUnit succeeded with a failing service manager")
+	}
+	if !strings.Contains(err.Error(), "unit failure detail") {
+		t.Fatalf("error %q does not include the command output", err)
+	}
+}
+
+func TestRestartAutostartUnitUnsupportedGOOS(t *testing.T) {
+	withAutostartTestEnv(t, "windows")
+	calls := stubAutostartUnitCommand(t, nil)
+
+	if err := RestartAutostartUnit(); err == nil {
+		t.Fatalf("RestartAutostartUnit should fail on unsupported GOOS")
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("no service manager command should run on unsupported GOOS, got %v", *calls)
+	}
+}

--- a/daemoncmd.go
+++ b/daemoncmd.go
@@ -70,7 +70,39 @@ func init() {
 
 // respawnDaemonForTasksFn is indirected so upgrade/auto-update tests can
 // observe the respawn without launching a real daemon.
-var respawnDaemonForTasksFn = ensureDaemonForTasks
+var respawnDaemonForTasksFn = respawnDaemonAfterUpgrade
+
+// Indirection points so respawnDaemonAfterUpgrade tests can observe which
+// branch ran without touching the real systemctl/launchctl or spawning a
+// daemon process.
+var (
+	autostartInstalledFn   = daemon.AutostartInstalled
+	restartAutostartUnitFn = daemon.RestartAutostartUnit
+	ensureDaemonForTasksFn = ensureDaemonForTasks
+)
+
+// respawnDaemonAfterUpgrade restores the daemon that the upgrade/auto-update
+// path just stopped. The Shutdown RPC is a clean exit, and the autostart unit
+// uses Restart=on-failure (deliberately — Restart=always would make the
+// daemon unstoppable via RPC), so the service manager will not bring the
+// daemon back on its own. When the unit is installed, restart it through
+// systemctl/launchctl so the daemon stays supervised instead of being demoted
+// to an ad-hoc child that dies with the session and skips the next reboot
+// (#796). The unit runs unconditionally at login, so this branch is not gated
+// on enabled tasks — it restores exactly what was running before the upgrade.
+// Without a unit, or when the service manager call fails, fall back to the
+// task-gated ad-hoc spawn (the pre-#796 behavior).
+func respawnDaemonAfterUpgrade() {
+	if autostartInstalledFn() {
+		err := restartAutostartUnitFn()
+		if err == nil {
+			log.InfoLog.Printf("restarted the daemon autostart unit from the new binary")
+			return
+		}
+		log.WarningLog.Printf("failed to restart the daemon autostart unit; falling back to an ad-hoc daemon: %v", err)
+	}
+	ensureDaemonForTasksFn()
+}
 
 // ensureDaemonForTasks starts the daemon when any enabled task exists, so
 // cron schedules are evaluated even if the user never toggles autoyes.

--- a/daemoncmd_test.go
+++ b/daemoncmd_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// Tests for the unit-aware upgrade respawn (#796). All three collaborators
+// are stubbed so nothing here touches the real systemctl/launchctl or spawns
+// a daemon process — a real supervised daemon may be running on the machine
+// executing these tests.
+
+// stubRespawnCollaborators replaces the autostart-detection, unit-restart,
+// and ad-hoc-spawn hooks used by respawnDaemonAfterUpgrade, restoring them on
+// cleanup. It returns counters for the restart and ad-hoc paths.
+func stubRespawnCollaborators(t *testing.T, installed bool, restartErr error) (restartCalls, ensureCalls *int) {
+	t.Helper()
+	prevInstalled := autostartInstalledFn
+	prevRestart := restartAutostartUnitFn
+	prevEnsure := ensureDaemonForTasksFn
+	t.Cleanup(func() {
+		autostartInstalledFn = prevInstalled
+		restartAutostartUnitFn = prevRestart
+		ensureDaemonForTasksFn = prevEnsure
+	})
+	restartCalls = new(int)
+	ensureCalls = new(int)
+	autostartInstalledFn = func() bool { return installed }
+	restartAutostartUnitFn = func() error {
+		*restartCalls++
+		return restartErr
+	}
+	ensureDaemonForTasksFn = func() { *ensureCalls++ }
+	return restartCalls, ensureCalls
+}
+
+// TestRespawnAfterUpgradeRestartsInstalledUnit pins the #796 fix: when the
+// autostart unit is installed, the post-upgrade respawn must go through the
+// service manager so the daemon stays supervised, and must NOT spawn an
+// ad-hoc child.
+func TestRespawnAfterUpgradeRestartsInstalledUnit(t *testing.T) {
+	restartCalls, ensureCalls := stubRespawnCollaborators(t, true, nil)
+
+	respawnDaemonAfterUpgrade()
+
+	if *restartCalls != 1 {
+		t.Fatalf("unit restarts = %d, want 1", *restartCalls)
+	}
+	if *ensureCalls != 0 {
+		t.Fatalf("ad-hoc spawns = %d, want 0 (unit restart must not be demoted to an ad-hoc daemon)", *ensureCalls)
+	}
+}
+
+// TestRespawnAfterUpgradeWithoutUnitSpawnsAdHoc pins the pre-#796 behavior
+// for installs without an autostart unit: the task-gated ad-hoc spawn.
+func TestRespawnAfterUpgradeWithoutUnitSpawnsAdHoc(t *testing.T) {
+	restartCalls, ensureCalls := stubRespawnCollaborators(t, false, nil)
+
+	respawnDaemonAfterUpgrade()
+
+	if *restartCalls != 0 {
+		t.Fatalf("unit restarts = %d, want 0 when no unit is installed", *restartCalls)
+	}
+	if *ensureCalls != 1 {
+		t.Fatalf("ad-hoc spawns = %d, want 1", *ensureCalls)
+	}
+}
+
+// TestRespawnAfterUpgradeFallsBackWhenRestartFails: a failing
+// systemctl/launchctl invocation must not leave task schedules dark — the
+// respawn falls back to the ad-hoc spawn.
+func TestRespawnAfterUpgradeFallsBackWhenRestartFails(t *testing.T) {
+	restartCalls, ensureCalls := stubRespawnCollaborators(t, true, errors.New("systemctl exited 1"))
+
+	respawnDaemonAfterUpgrade()
+
+	if *restartCalls != 1 {
+		t.Fatalf("unit restarts = %d, want 1", *restartCalls)
+	}
+	if *ensureCalls != 1 {
+		t.Fatalf("ad-hoc spawns = %d, want 1 (fallback after a failed unit restart)", *ensureCalls)
+	}
+}


### PR DESCRIPTION
Fixes #796

## Incident

From `agent-factory.log` on 2026-06-09 (issue #796):

```
22:46:15 [DAEMON] received shutdown request via control socket   <- upgrade stopping the daemon
22:46:17 started daemon child process with PID: 3447769          <- autoupdate respawn (ad-hoc)
22:46:22 ERROR daemoncmd.go:88: failed to start daemon for scheduled tasks: daemon did not become ready: ...
22:46:22 started daemon child process with PID: 3453992          <- second EnsureDaemon retry
22:46:23 [DAEMON] another agent-factory daemon is already serving the control socket; exiting
```

End state: `agent-factory-daemon.service` **inactive**, an unsupervised ad-hoc daemon serving the socket. Every auto-update silently undid `af daemon install` until the next login — the daemon would not survive a reboot.

Root cause: the Shutdown RPC is a **clean exit**, and the unit uses `Restart=on-failure` (intentionally — `always` would make the daemon unstoppable via RPC), so systemd never restarts it; the respawn path then spawned a plain `af --daemon` child. The unit's `Restart=` policy is unchanged per the issue.

## Fix

The upgrade/auto-update respawn (`respawnDaemonForTasksFn`, shared by `upgrade.go` and `autoupdate.go`) is now unit-aware:

- New `daemon.AutostartInstalled()` — reports whether the unit file written by `af daemon install` exists (`~/.config/systemd/user/agent-factory-daemon.service` on Linux, `~/Library/LaunchAgents/com.agent-factory.daemon.plist` on macOS).
- New `daemon.RestartAutostartUnit()` — `systemctl --user restart agent-factory-daemon.service` (Linux) / `launchctl kickstart -k gui/<uid>/com.agent-factory.daemon` (macOS).
- `respawnDaemonAfterUpgrade()`: unit installed → restart it through the service manager (not gated on enabled tasks — the unit runs unconditionally, so this restores exactly the pre-upgrade state). No unit, or the service-manager call fails → log a warning and fall back to the previous task-gated ad-hoc spawn.

## Adjacent-call-site audit (all ad-hoc daemon spawn paths)

| Call site | Context | Behavior |
|---|---|---|
| `upgrade.go` → `respawnDaemonForTasksFn` | just stopped a daemon (Shutdown RPC) | **changed** — unit-aware restart, ad-hoc fallback |
| `autoupdate.go` → `respawnDaemonForTasksFn` | just stopped a daemon (Shutdown RPC) | **changed** — same path |
| `main.go` `go ensureDaemonForTasks()` | af startup, nothing was stopped | unchanged — `EnsureDaemon` pings first; a healthy unit daemon makes this a no-op, and if the unit is inactive (user stopped it) an ad-hoc spawn for enabled tasks is the correct fallback, not a forced unit restart |
| `main.go` autoyes `daemon.LaunchDaemon()` | TUI launch with autoyes, nothing was stopped | unchanged — same reasoning |
| `daemon/control.go` `callDaemon` → `EnsureDaemon` | on-demand RPC | unchanged — same reasoning |

The unit-aware restart belongs only on paths that just **stopped** a supervised daemon; `EnsureDaemon` keeps its current semantics everywhere else.

## Secondary item from the issue (left out, deliberately)

The transient `daemon did not become ready` happens because the control socket binds after `NewManager` finishes loading instances. Moving the bind earlier is **not** a small safe reorder: `bindControlServerExclusive` registers the RPC service with the fully-constructed `Manager` inside the #718/#792 cross-process flock window, and binding earlier would make `Ping` answer (and `EnsureDaemon` declare readiness) before the daemon can serve real RPCs. The retry + #792 duplicate-guard already converge correctly — and with this fix the upgrade respawn no longer races `EnsureDaemon` at all when a unit is installed. Leaving it as-is.

## Tests

All hermetic — injected directory resolvers and command runner (the `legacy_units.go` pattern); nothing touches the real systemctl/launchctl or spawns a daemon:

- `daemon/autostart_restart_test.go`: `AutostartInstalled` present/absent on linux + darwin + unsupported GOOS; `RestartAutostartUnit` invokes the exact systemctl/launchctl command per platform; failure surfaces the command output; unsupported GOOS runs nothing.
- `daemoncmd_test.go`: unit installed → service-manager restart, **no** ad-hoc spawn; no unit → ad-hoc spawn; restart fails → falls back to ad-hoc spawn.

## Verification

- `go build ./...`, `gofmt -l .`, `go test ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` — all clean
- `go test -race` on `daemon`, main, `ui/...`, `app/...` — all pass

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)