### PR TITLE
feat(daemon/watcher): surface last script output on watch-task failure (#797)

### DIFF
--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -33,6 +33,11 @@ import (
 //   - ≥5 non-zero exits within 10 minutes = crash loop (status "errored",
 //     restarts stop until the next reload)
 //   - events above 10/min per task are dropped with a logged warning
+//   - each run buffers its recent output (last 10 lines / 2KB: stdout lines
+//     that did not become delivered events, plus stderr). Non-zero exits log
+//     that tail, and the crash-loop breaker persists "errored: <exit>:
+//     <first line>" into last_run_status so `af tasks list` and the TUI
+//     show why the task errored (#797)
 const (
 	// maxWatchLineBytes caps how much of a single stdout line becomes an
 	// event; the rest of the line is discarded with a logged note.
@@ -48,6 +53,18 @@ const (
 	// before escalating to a process-group SIGKILL. Mirrors
 	// sigtermFallbackGrace on the daemon-shutdown path.
 	watcherStopGrace = 5 * time.Second
+
+	// watcherTailMaxLines/watcherTailMaxBytes bound the per-run buffer of
+	// recent script output kept for failure diagnostics (#797): stdout
+	// lines that did not become delivered events, plus stderr. The byte cap
+	// applies both per line and to the buffer total.
+	watcherTailMaxLines = 10
+	watcherTailMaxBytes = 2 * 1024
+
+	// watcherStatusSummaryMax caps the failure summary the crash-loop
+	// breaker persists into the task's last_run_status, so tasks.json and
+	// the TUI detail row stay readable.
+	watcherStatusSummaryMax = 256
 )
 
 // watcherSupervisor owns the running watch-task processes. Reload reconciles
@@ -219,6 +236,76 @@ func stopWatchers(ws []*taskWatcher) {
 	wg.Wait()
 }
 
+// tailBuffer is a small bounded ring of one script run's most recent output
+// lines — stdout lines that did not become delivered events, plus stderr —
+// kept so a failing run's log line can show WHY the script died instead of a
+// bare exit status (#797). Bounded to watcherTailMaxLines lines and
+// watcherTailMaxBytes total bytes, always retaining at least the newest line.
+type tailBuffer struct {
+	mu    sync.Mutex
+	lines []string
+	size  int
+}
+
+// add records one output line, trimming the line terminator and capping the
+// line at watcherTailMaxBytes. Blank lines are skipped — they carry no
+// diagnostics and would evict lines that do.
+func (b *tailBuffer) add(line string) {
+	line = strings.TrimRight(line, "\r\n")
+	if strings.TrimSpace(line) == "" {
+		return
+	}
+	if len(line) > watcherTailMaxBytes {
+		line = line[:watcherTailMaxBytes]
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.lines = append(b.lines, line)
+	b.size += len(line)
+	for len(b.lines) > 1 && (len(b.lines) > watcherTailMaxLines || b.size > watcherTailMaxBytes) {
+		b.size -= len(b.lines[0])
+		b.lines = b.lines[1:]
+	}
+}
+
+// logSuffix renders the buffered output for appending to a failure log line:
+// "; last output:" plus one indented line each, or "" when the run produced
+// nothing to show (so failure logs never grow an empty trailer).
+func (b *tailBuffer) logSuffix() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.lines) == 0 {
+		return ""
+	}
+	return "; last output:\n  " + strings.Join(b.lines, "\n  ")
+}
+
+// firstLine returns the oldest buffered line — usually the script's initial
+// complaint — for the persisted status summary.
+func (b *tailBuffer) firstLine() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.lines) == 0 {
+		return ""
+	}
+	return b.lines[0]
+}
+
+// failureSummary builds the status the crash-loop breaker persists:
+// "errored: <exit error>: <first buffered line>", capped at
+// watcherStatusSummaryMax. The "errored" prefix is what the TUI keys the
+// supervision state off (ui.watchTaskStatus), so it must come first.
+func failureSummary(runErr error, tail *tailBuffer) string {
+	summary := "errored: " + runErr.Error()
+	if first := tail.firstLine(); first != "" {
+		summary += ": " + first
+	}
+	if len(summary) > watcherStatusSummaryMax {
+		summary = summary[:watcherStatusSummaryMax] + "…"
+	}
+	return summary
+}
+
 // taskWatcher supervises one watch task: it restarts the script with backoff
 // on failure and feeds its stdout lines to the supervisor's deliver hook.
 // Deliveries are serialized in emission order — the single reader goroutine
@@ -282,8 +369,11 @@ func (w *taskWatcher) run() {
 		}
 
 		started := time.Now()
-		runErr := w.runOnce()
+		tail, runErr := w.runOnce()
 		if w.stopRequested() {
+			if runErr != nil {
+				log.InfoLog.Printf("watch task %s: watch command terminated during stop/reload (%v); not a failure", w.taskID, runErr)
+			}
 			return
 		}
 
@@ -291,6 +381,21 @@ func (w *taskWatcher) run() {
 			log.InfoLog.Printf("watch task %s: watch command exited cleanly; stopped until the next reload or re-enable", w.taskID)
 			w.sup.setStatus(w.taskID, "stopped")
 			return
+		}
+
+		// A SIGTERM-shaped death is often daemon shutdown or a unit restart
+		// reaching the child before the stop request reaches this loop — unit
+		// managers signal the whole control group, not just the daemon. Give
+		// the stop channel a grace before treating it as a script failure, so
+		// shutdown doesn't log spurious failed/restarting warnings or count
+		// toward the crash-loop breaker.
+		if exitedFromSignal(runErr, syscall.SIGTERM) {
+			select {
+			case <-w.stopCh:
+				log.InfoLog.Printf("watch task %s: watch command terminated during stop/reload; not a failure", w.taskID)
+				return
+			case <-time.After(w.sup.stopGrace):
+			}
 		}
 
 		now := time.Now()
@@ -301,8 +406,8 @@ func (w *taskWatcher) run() {
 		}
 		failures = failures[cut:]
 		if len(failures) >= w.sup.crashMaxExits {
-			log.ErrorLog.Printf("watch task %s: %d failures within %s (last: %v); giving up until the next reload or re-enable", w.taskID, len(failures), w.sup.crashWindow, runErr)
-			w.sup.setStatus(w.taskID, "errored")
+			log.ErrorLog.Printf("watch task %s: %d failures within %s (last: %v); giving up until the next reload or re-enable%s", w.taskID, len(failures), w.sup.crashWindow, runErr, tail.logSuffix())
+			w.sup.setStatus(w.taskID, failureSummary(runErr, tail))
 			return
 		}
 
@@ -311,7 +416,7 @@ func (w *taskWatcher) run() {
 		if now.Sub(started) >= w.sup.crashWindow {
 			backoff = w.sup.baseBackoff
 		}
-		log.WarningLog.Printf("watch task %s: watch command failed (%v); restarting in %s", w.taskID, runErr, backoff)
+		log.WarningLog.Printf("watch task %s: watch command failed (%v); restarting in %s%s", w.taskID, runErr, backoff, tail.logSuffix())
 		select {
 		case <-w.stopCh:
 			return
@@ -324,9 +429,22 @@ func (w *taskWatcher) run() {
 	}
 }
 
+// exitedFromSignal reports whether err is an exec exit caused by the given
+// signal (as opposed to a non-zero exit code or a start failure).
+func exitedFromSignal(err error, sig syscall.Signal) bool {
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		return false
+	}
+	ws, ok := ee.Sys().(syscall.WaitStatus)
+	return ok && ws.Signaled() && ws.Signal() == sig
+}
+
 // runOnce spawns the script once and consumes its stdout until the shell
-// exits. Returns nil on exit 0, the exit/start error otherwise.
-func (w *taskWatcher) runOnce() error {
+// exits. Returns nil on exit 0, the exit/start error otherwise, plus the
+// run's output tail (never nil) for the caller's failure logging.
+func (w *taskWatcher) runOnce() (*tailBuffer, error) {
+	tail := &tailBuffer{}
 	cmd := exec.Command(w.sup.shell, "-c", w.cmdStr)
 	cmd.Dir = w.dir
 	cmd.Env = append(os.Environ(),
@@ -340,13 +458,15 @@ func (w *taskWatcher) runOnce() error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// stderr appends to the per-task log. A logging failure must not take the
-	// watcher down — stderr just goes to the void for this run.
+	// watcher down — the failure tail below still captures stderr for this
+	// run even when the file can't be opened.
+	var stderrFile *os.File
 	if logPath, err := w.sup.logPath(w.taskID); err != nil {
 		log.WarningLog.Printf("watch task %s: cannot resolve stderr log path: %v", w.taskID, err)
 	} else if f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err != nil {
 		log.WarningLog.Printf("watch task %s: cannot open stderr log: %v", w.taskID, err)
 	} else {
-		cmd.Stderr = f
+		stderrFile = f
 		defer f.Close()
 	}
 
@@ -357,23 +477,59 @@ func (w *taskWatcher) runOnce() error {
 	// group-kill below reaps them.
 	r, pw, err := os.Pipe()
 	if err != nil {
-		return fmt.Errorf("failed to create stdout pipe: %w", err)
+		return tail, fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 	cmd.Stdout = pw
+
+	// stderr flows through a pipe we own for the same reasons, teed to the
+	// per-task log and into the failure tail (#797). Pipe failure degrades to
+	// the pre-#797 direct-to-file wiring rather than failing the run.
+	var stderrR, stderrW *os.File
+	if er, ew, perr := os.Pipe(); perr != nil {
+		log.WarningLog.Printf("watch task %s: cannot create stderr pipe (stderr won't appear in failure logs): %v", w.taskID, perr)
+		if stderrFile != nil {
+			cmd.Stderr = stderrFile
+		}
+	} else {
+		stderrR, stderrW = er, ew
+		cmd.Stderr = stderrW
+	}
 
 	if err := cmd.Start(); err != nil {
 		_ = r.Close()
 		_ = pw.Close()
-		return err
+		if stderrR != nil {
+			_ = stderrR.Close()
+			_ = stderrW.Close()
+		}
+		return tail, err
 	}
 	_ = pw.Close() // the child holds its own dup
+	if stderrW != nil {
+		_ = stderrW.Close()
+	}
 
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
 		defer r.Close()
-		w.consumeLines(r)
+		w.consumeLines(r, tail)
 	}()
+
+	stderrDone := make(chan struct{})
+	if stderrR == nil {
+		close(stderrDone)
+	} else {
+		var sink io.Writer
+		if stderrFile != nil {
+			sink = stderrFile
+		}
+		go func() {
+			defer close(stderrDone)
+			defer stderrR.Close()
+			w.consumeStderr(stderrR, sink, tail)
+		}()
+	}
 
 	// Watchdog for stop requests: SIGTERM the group so the script can clean
 	// up, escalate to a group SIGKILL after the grace.
@@ -395,24 +551,26 @@ func (w *taskWatcher) runOnce() error {
 	close(waitDone)
 
 	// Group-kill on every exit path (#769): backgrounded grandchildren must
-	// not outlive the watcher. This also closes any inherited stdout write
-	// ends, so the reader goroutine is guaranteed to reach EOF.
+	// not outlive the watcher. This also closes any inherited stdout/stderr
+	// write ends, so both reader goroutines are guaranteed to reach EOF.
 	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 	<-readerDone
+	<-stderrDone
 
-	return waitErr
+	return tail, waitErr
 }
 
 // consumeLines turns newline-terminated stdout lines into events. Lines over
 // maxWatchLineBytes are truncated to the cap and the remainder discarded with
-// a logged note; unterminated trailing output at EOF is not an event.
-func (w *taskWatcher) consumeLines(r io.Reader) {
+// a logged note; unterminated trailing output at EOF is not an event but is
+// kept in the failure tail — it is often the script's death rattle (#797).
+func (w *taskWatcher) consumeLines(r io.Reader, tail *tailBuffer) {
 	br := bufio.NewReaderSize(r, maxWatchLineBytes)
 	for {
 		chunk, err := br.ReadSlice('\n')
 		switch {
 		case err == nil:
-			w.handleEvent(strings.TrimRight(string(chunk), "\r\n"))
+			w.handleEvent(strings.TrimRight(string(chunk), "\r\n"), tail)
 		case errors.Is(err, bufio.ErrBufferFull):
 			// ReadSlice's buffer filled before a newline: keep the first
 			// maxWatchLineBytes as the event and discard the rest of the line.
@@ -430,13 +588,15 @@ func (w *taskWatcher) consumeLines(r io.Reader) {
 			if tailErr != nil {
 				// The stream ended before the line did — never
 				// newline-terminated, so not an event.
+				tail.add(line)
 				return
 			}
 			log.WarningLog.Printf("watch task %s: stdout line exceeded %d bytes; truncated (%d bytes discarded)", w.taskID, maxWatchLineBytes, discarded)
-			w.handleEvent(line)
+			w.handleEvent(line, tail)
 		case errors.Is(err, io.EOF):
 			if len(chunk) > 0 {
 				log.WarningLog.Printf("watch task %s: discarding %d bytes of unterminated stdout output (events must be newline-terminated lines)", w.taskID, len(chunk))
+				tail.add(string(chunk))
 			}
 			return
 		default:
@@ -445,9 +605,41 @@ func (w *taskWatcher) consumeLines(r io.Reader) {
 	}
 }
 
+// consumeStderr tees the script's stderr to the per-task log file (when one
+// could be opened) and keeps complete lines in the failure tail, so a script
+// whose own redirections starve the log file is still diagnosable from the
+// daemon log on failure (#797).
+func (w *taskWatcher) consumeStderr(r io.Reader, logFile io.Writer, tail *tailBuffer) {
+	br := bufio.NewReaderSize(r, 4*1024)
+	atLineStart := true
+	for {
+		chunk, err := br.ReadSlice('\n')
+		if len(chunk) > 0 {
+			if logFile != nil {
+				_, _ = logFile.Write(chunk)
+			}
+			if atLineStart {
+				tail.add(string(chunk))
+			}
+		}
+		switch {
+		case err == nil:
+			atLineStart = true
+		case errors.Is(err, bufio.ErrBufferFull):
+			// Only an overlong line's first chunk lands in the tail (add caps
+			// it anyway); the rest still reaches the log file above.
+			atLineStart = false
+		default:
+			return
+		}
+	}
+}
+
 // handleEvent applies the per-task rate limit and delivers the event. Called
 // from the single reader goroutine, so deliveries stay serialized in order.
-func (w *taskWatcher) handleEvent(line string) {
+// Lines that do not become a delivered event — rate-dropped or failed
+// deliveries — go to the failure tail instead (#797).
+func (w *taskWatcher) handleEvent(line string, tail *tailBuffer) {
 	now := time.Now()
 	w.mu.Lock()
 	cut := 0
@@ -468,6 +660,7 @@ func (w *taskWatcher) handleEvent(line string) {
 		if logIt {
 			log.WarningLog.Printf("watch task %s: event rate exceeded %d/min; dropping excess events (%d dropped so far)", w.taskID, w.sup.eventsPerMinute, dropped)
 		}
+		tail.add(line)
 		return
 	}
 	w.eventTimes = append(w.eventTimes, now)
@@ -475,6 +668,7 @@ func (w *taskWatcher) handleEvent(line string) {
 
 	if err := w.sup.deliver(w.taskID, line); err != nil {
 		log.ErrorLog.Printf("watch task %s: failed to deliver event: %v", w.taskID, err)
+		tail.add(line)
 	}
 }
 
@@ -505,8 +699,9 @@ func deliverWatchEvent(taskID, line string) error {
 	return nil
 }
 
-// persistWatcherStatus records a watcher lifecycle status ("stopped",
-// "errored") on the task. LastRunAt is preserved — it tracks event
+// persistWatcherStatus records a watcher lifecycle status on the task:
+// "stopped", or "errored: <exit>: <first output line>" from the crash-loop
+// breaker (#797). LastRunAt is preserved — it tracks event
 // deliveries, not supervision changes. UpdateTaskStatus skips Program enum
 // validation so legacy task records still receive status bumps (#664).
 func persistWatcherStatus(taskID, status string) {

--- a/daemon/watcher_test.go
+++ b/daemon/watcher_test.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	aflog "github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/task"
 )
 
@@ -158,9 +161,17 @@ func TestWatcherBackoffAndCrashLoopBreaker(t *testing.T) {
 	}
 	waitUntil(t, 10*time.Second, "crash-loop breaker to trip", func() bool {
 		statuses := rec.statusesSnapshot()
-		return len(statuses) > 0 && statuses[len(statuses)-1] == "bbbb0001:errored"
+		return len(statuses) > 0 && strings.HasPrefix(statuses[len(statuses)-1], "bbbb0001:errored")
 	})
 	elapsed := time.Since(start)
+
+	// Every "run" line was delivered as an event, so the failure tail is
+	// empty: the persisted summary is just the errored prefix and exit status
+	// (#797), with no stray separator.
+	statuses := rec.statusesSnapshot()
+	if got := statuses[len(statuses)-1]; got != "bbbb0001:errored: exit status 3" {
+		t.Fatalf("breaker status = %q, want %q", got, "bbbb0001:errored: exit status 3")
+	}
 
 	events := rec.eventsSnapshot()
 	if len(events) != s.crashMaxExits {
@@ -450,6 +461,186 @@ func TestDeliverWatchEvent_RendersTemplateAndRecordsStatus(t *testing.T) {
 	}
 	if len(*sends) != 1 {
 		t.Fatalf("disabled task still received an event: %+v", *sends)
+	}
+}
+
+// syncBuffer is a mutex-guarded bytes.Buffer so tests can read captured log
+// output while watcher goroutines may still be writing it.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// captureWatcherLogs redirects the daemon's warning and error loggers into
+// buffers for the test's duration.
+func captureWatcherLogs(t *testing.T) (warn, errBuf *syncBuffer) {
+	t.Helper()
+	warn, errBuf = &syncBuffer{}, &syncBuffer{}
+	prevWarn, prevErr := aflog.WarningLog.Writer(), aflog.ErrorLog.Writer()
+	aflog.WarningLog.SetOutput(warn)
+	aflog.ErrorLog.SetOutput(errBuf)
+	t.Cleanup(func() {
+		aflog.WarningLog.SetOutput(prevWarn)
+		aflog.ErrorLog.SetOutput(prevErr)
+	})
+	return warn, errBuf
+}
+
+// TestWatcherFailureLogsIncludeOutputTail replays the #797 support case: a
+// script writes its complaint to stderr and exits non-zero, leaving nothing
+// in the event stream. The restart warning and the crash-loop breaker message
+// must carry the buffered output tail, and the breaker must persist
+// "errored: <exit>: <first line>" so `af tasks list` / the TUI show why.
+func TestWatcherFailureLogsIncludeOutputTail(t *testing.T) {
+	warn, errBuf := captureWatcherLogs(t)
+	dir := t.TempDir()
+	script := `echo "[iv-monitor] WARN another instance holds the lock; exiting" >&2; exit 1`
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("ab970001", script, dir)))
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "crash-loop breaker to trip", func() bool {
+		statuses := rec.statusesSnapshot()
+		return len(statuses) > 0 && strings.HasPrefix(statuses[len(statuses)-1], "ab970001:errored")
+	})
+
+	wantLine := "[iv-monitor] WARN another instance holds the lock; exiting"
+	if got := warn.String(); !strings.Contains(got, "restarting in") || !strings.Contains(got, "last output:\n  "+wantLine) {
+		t.Fatalf("restart warning missing the output tail, got:\n%s", got)
+	}
+	if got := errBuf.String(); !strings.Contains(got, "giving up until the next reload or re-enable; last output:\n  "+wantLine) {
+		t.Fatalf("breaker message missing the output tail, got:\n%s", got)
+	}
+	statuses := rec.statusesSnapshot()
+	if got, want := statuses[len(statuses)-1], "ab970001:errored: exit status 1: "+wantLine; got != want {
+		t.Fatalf("persisted status = %q, want %q", got, want)
+	}
+}
+
+// TestWatcherTailCapturesNonDeliveredStdout pins the stdout leg of the #797
+// tail: lines whose delivery failed and unterminated trailing output both
+// land in the failure tail (oldest first), while the tail stays out of the
+// way on the happy path — delivered events are never buffered.
+func TestWatcherTailCapturesNonDeliveredStdout(t *testing.T) {
+	_, errBuf := captureWatcherLogs(t)
+	dir := t.TempDir()
+	script := `echo "lock contention detected"; printf "death rattle"; exit 1`
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("ab970002", script, dir)))
+	s.deliver = func(taskID, line string) error {
+		_ = rec.deliver(taskID, line)
+		return errors.New("session spawn failed")
+	}
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "crash-loop breaker to trip", func() bool {
+		statuses := rec.statusesSnapshot()
+		return len(statuses) > 0 && strings.HasPrefix(statuses[len(statuses)-1], "ab970002:errored")
+	})
+
+	if got := errBuf.String(); !strings.Contains(got, "last output:\n  lock contention detected\n  death rattle") {
+		t.Fatalf("breaker message missing the stdout tail, got:\n%s", got)
+	}
+	statuses := rec.statusesSnapshot()
+	if got, want := statuses[len(statuses)-1], "ab970002:errored: exit status 1: lock contention detected"; got != want {
+		t.Fatalf("persisted status = %q, want %q", got, want)
+	}
+}
+
+// TestTailBufferCaps pins the ring-buffer bounds: at most watcherTailMaxLines
+// lines and watcherTailMaxBytes bytes are retained (newest win), a single
+// overlong line is truncated rather than evicting everything, blank lines are
+// skipped, and the persisted failure summary respects its own cap.
+func TestTailBufferCaps(t *testing.T) {
+	b := &tailBuffer{}
+	for i := 0; i < 100; i++ {
+		b.add(fmt.Sprintf("spam line %03d", i))
+	}
+	b.add("   ")
+	b.add("")
+	lines := strings.Split(strings.TrimPrefix(b.logSuffix(), "; last output:\n  "), "\n  ")
+	if len(lines) > watcherTailMaxLines {
+		t.Fatalf("tail kept %d lines, cap is %d", len(lines), watcherTailMaxLines)
+	}
+	if got := lines[len(lines)-1]; got != "spam line 099" {
+		t.Fatalf("newest line = %q, want the last one written", got)
+	}
+	if total := len(strings.Join(lines, "")); total > watcherTailMaxBytes {
+		t.Fatalf("tail holds %d bytes, cap is %d", total, watcherTailMaxBytes)
+	}
+
+	b.add(strings.Repeat("x", 3*watcherTailMaxBytes))
+	if first := b.firstLine(); len(first) != watcherTailMaxBytes || strings.Trim(first, "x") != "" {
+		t.Fatalf("overlong line not truncated to the byte cap: len=%d", len(first))
+	}
+
+	summary := failureSummary(errors.New("exit status 1"), b)
+	if !strings.HasPrefix(summary, "errored: exit status 1: xxx") {
+		t.Fatalf("summary = %.60q..., want errored prefix + first line", summary)
+	}
+	if len(summary) > watcherStatusSummaryMax+len("…") {
+		t.Fatalf("summary length %d exceeds cap %d", len(summary), watcherStatusSummaryMax)
+	}
+
+	if empty := (&tailBuffer{}); empty.logSuffix() != "" || empty.firstLine() != "" {
+		t.Fatalf("empty tail must render nothing, got %q / %q", empty.logSuffix(), empty.firstLine())
+	}
+}
+
+// TestWatcherShutdownSigtermIsNotAFailure covers the unit-restart race: a
+// supervising init system SIGTERMs the whole control group, so the watch
+// script can die before the daemon's own shutdown reaches the supervisor.
+// That death must not log a failed/restarting warning, count toward the
+// crash-loop breaker, or persist a status — it is a stop, not a failure.
+func TestWatcherShutdownSigtermIsNotAFailure(t *testing.T) {
+	warn, errBuf := captureWatcherLogs(t)
+	dir := t.TempDir()
+	script := `echo $$; while true; do sleep 0.1; done`
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("ab970003", script, dir)))
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 5*time.Second, "script to report its PID", func() bool {
+		return len(rec.eventsSnapshot()) == 1
+	})
+	pid, err := strconv.Atoi(strings.TrimPrefix(rec.eventsSnapshot()[0], "ab970003:"))
+	if err != nil {
+		t.Fatalf("event is not a PID: %v", err)
+	}
+
+	// The unit manager's group SIGTERM reaches the child directly; the
+	// daemon's shutdown (s.Stop) follows a beat later.
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		t.Fatalf("SIGTERM script: %v", err)
+	}
+	s.Stop()
+
+	if got := warn.String(); strings.Contains(got, "watch command failed") {
+		t.Fatalf("shutdown SIGTERM logged as a failure:\n%s", got)
+	}
+	if got := errBuf.String(); strings.Contains(got, "giving up") {
+		t.Fatalf("shutdown SIGTERM counted toward the crash-loop breaker:\n%s", got)
+	}
+	if statuses := rec.statusesSnapshot(); len(statuses) != 0 {
+		t.Fatalf("shutdown SIGTERM persisted a status: %v", statuses)
+	}
+	if events := rec.eventsSnapshot(); len(events) != 1 {
+		t.Fatalf("watcher restarted after shutdown SIGTERM: %v", events)
 	}
 }
 

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -546,16 +546,19 @@ func (s *TaskPane) String() string {
 // watchTaskStatus derives the supervision state shown for a watch task from
 // the fields the daemon persists (#782 phase 2): the watcher supervisor
 // records "stopped" (script exited 0) and "errored" (crash loop) in
-// LastRunStatus; any other value on an enabled watch task means the daemon
-// (re-)arms its watcher on start/reload, i.e. "watching". A disabled watch
-// task has no watcher, so it reads "stopped".
+// LastRunStatus — since #797 the latter as "errored: <why>", which the
+// detail row renders in full; any other value on an enabled watch task means
+// the daemon (re-)arms its watcher on start/reload, i.e. "watching". A
+// disabled watch task has no watcher, so it reads "stopped".
 func watchTaskStatus(tsk task.Task) string {
 	if !tsk.Enabled {
 		return "stopped"
 	}
-	switch tsk.LastRunStatus {
-	case "stopped", "errored":
-		return tsk.LastRunStatus
+	switch {
+	case tsk.LastRunStatus == "stopped":
+		return "stopped"
+	case tsk.LastRunStatus == "errored" || strings.HasPrefix(tsk.LastRunStatus, "errored:"):
+		return "errored"
 	}
 	return "watching"
 }

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -649,6 +649,7 @@ func TestTaskPaneListRendersWatchStatus(t *testing.T) {
 		{"enabled fresh", true, "", "[watching]"},
 		{"enabled delivering", true, "sent", "[watching]"},
 		{"crash loop", true, "errored", "[errored]"},
+		{"crash loop with summary", true, "errored: exit status 1: WARN lock held", "[errored]"},
 		{"clean exit", true, "stopped", "[stopped]"},
 		{"disabled", false, "sent", "[stopped]"},
 	}
@@ -672,6 +673,10 @@ func TestTaskPaneListRendersWatchStatus(t *testing.T) {
 			assert.Contains(t, out, c.want)
 			assert.Contains(t, out, "→ captain",
 				"rows must surface the target session delivery")
+			if c.lastRunStatus != "" {
+				assert.Contains(t, out, "("+c.lastRunStatus+")",
+					"the detail row must render the raw status — including the #797 failure summary — in full")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes #797

## Support case

A watch task crash-looped to `errored` with a bare `exit status 1` in the daemon log and an empty stderr file (2026-06-09 22:50). The cause — `[iv-monitor] WARN another instance holds the lock` — was only findable by re-running the script by hand: the line never became an event and the script's own redirections starved the stderr capture.

## What changed

**Failure tail (`daemon/watcher.go`).** Each run keeps a bounded ring buffer (last 10 lines / 2KB, both caps enforced, per-line and total) of output that did *not* become a delivered event: failed deliveries, rate-dropped lines, unterminated trailing stdout, and all of stderr. Stderr now flows through a supervisor-owned pipe (same ownership rules as the stdout pipe — guaranteed EOF via the group SIGKILL, no Wait-managed copier to deadlock on backgrounded grandchildren) and is teed to the per-task log file as before; a log-file open failure no longer loses stderr entirely.

**Log shape.** Non-zero exits and the crash-loop breaker append the tail:

```
ERROR: watch task 6c397e7f: 5 failures within 10m0s (last: exit status 1); giving up until the next reload or re-enable; last output:
  [iv-monitor] WARN another instance holds the lock; exiting
```

**Status shape.** The breaker persists `errored: <exit>: <first buffered line>` (capped at 256 bytes) into `last_run_status`, so `af tasks list` (JSON) and the TUI task pane show *why* a task errored. `ui.watchTaskStatus` now prefix-matches `errored:` for the `[errored]` badge; the detail row renders the full summary.

**Shutdown SIGTERM is not a failure.** Observed on the live daemon at 23:02:13 during a unit restart: unit managers signal the whole control group, so the watch script can die before the daemon's shutdown reaches the supervisor, logging a spurious `watch command failed (signal: terminated); restarting in 1s`. A SIGTERM-shaped death now waits a stop-grace on the stop channel before being counted: supervisor-initiated stops log at INFO (`terminated during stop/reload; not a failure`) with no restart, no breaker increment, no persisted status. A genuinely external SIGTERM of just the script still restarts after the grace.

## Adjacent-call-site audit

All watcher exit paths now route through the same tail: restart warning, breaker error + persisted summary, and start-failures (empty tail → no trailer, status is plain `errored: <err>`). Clean exit 0 (`stopped`) intentionally carries no tail. The cron path runs no script and is untouched.

## Tests

- `TestWatcherFailureLogsIncludeOutputTail` — replays the support case (stderr + exit 1): restart warning and breaker message carry the tail; persisted status is `errored: exit status 1: <line>`.
- `TestWatcherTailCapturesNonDeliveredStdout` — failed deliveries and unterminated trailing stdout land in the tail, in order; delivered events never do (pinned by the updated breaker test asserting `errored: exit status 3` with no trailer).
- `TestTailBufferCaps` — line/byte caps, newest-wins eviction, overlong-line truncation, blank-line skip, summary cap.
- `TestWatcherShutdownSigtermIsNotAFailure` — child SIGTERMed an instant before `Stop()`: no failure warning, no breaker count, no status, no restart.
- UI: `errored: …` summaries badge as `[errored]` and render in full on the detail row.

## Verification

`go build`, `go test ./...`, `golangci-lint run --fast`, `gofmt -l`, `deadcode -test`, and `-race` on daemon/task/ui/app all clean. Exercised hermetically with a real binary under a temp `AGENT_FACTORY_HOME`/`XDG_CONFIG_HOME`: a failing watch task produced exactly the log line above, `af tasks get` carried the summary, and SIGTERMing script+daemon together produced only the INFO line.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)