### PR TITLE
refactor(ui/tasks): streamline the task pane — trigger selector, grouped form, tighter list rows (#801)

### DIFF
--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -114,11 +114,11 @@ func TestHandleContentPaneFocus_PendingCreateFlushesDirtyTaskState(t *testing.T)
 	require.True(t, tp.IsCreating(), "'n' must open the inline create form")
 
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("new-task")})
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector (cron stays selected)
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> cron value
+	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do other thing")})
-	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> cron
-	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
-	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> watch cmd
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> target session
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> path
 	_, _, _ = h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyTab}) // -> program

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -18,12 +18,17 @@ import (
 // string (the daemon then falls back to the user's configured default_program).
 const programDefaultLabel = "(use config default)"
 
-// Edit-form focus stops, in tab order.
+// Edit-form focus stops, in tab order. The form is grouped: Essentials
+// (name, trigger, prompt) then Delivery (target session, path, program).
+// The trigger is a two-step stop: a cron|watch type selector followed by the
+// matching value input — only the selected trigger's field is shown, which
+// makes the exactly-one-trigger contract (#782) structural instead of a
+// validation error.
 const (
-	taskFocusName = iota
+	taskFocusName         = iota
+	taskFocusTrigger      // trigger-type selector: cron | watch
+	taskFocusTriggerValue // cron expression or watch command, per the selector
 	taskFocusPrompt
-	taskFocusCron
-	taskFocusWatch
 	taskFocusTarget
 	taskFocusPath
 	taskFocusProgram
@@ -40,10 +45,15 @@ type TaskPane struct {
 	editing    bool
 	editName   textinput.Model
 	editPrompt textarea.Model
-	editCron   textinput.Model
-	editWatch  textinput.Model
-	editTarget textinput.Model
-	editPath   textinput.Model
+	// Trigger state: editTriggerIsWatch selects which of the two buffers is
+	// shown, edited, and saved. Both buffers stay alive so flipping the
+	// selector back and forth never loses typed input; save resolves to
+	// exactly one via triggerValues.
+	editTriggerIsWatch bool
+	editCron           textinput.Model
+	editWatch          textinput.Model
+	editTarget         textinput.Model
+	editPath           textinput.Model
 	// Program selector state. editProgramOptions is the list of choices shown
 	// inline (index 0 is always the "use config default" entry, followed by
 	// tmux.SupportedPrograms). Per-task Program is restricted to the agent
@@ -51,7 +61,8 @@ type TaskPane struct {
 	editProgramOptions []string
 	editProgramIdx     int
 	editError          string // last validation error shown to the user
-	focusIndex         int    // 0=name, 1=prompt, 2=cron, 3=watch, 4=target, 5=path, 6=program, 7=save button
+	editErrorField     int    // focus stop the error is rendered under (-1 = none)
+	focusIndex         int
 
 	// Create mode
 	creating       bool
@@ -135,10 +146,10 @@ func (s *TaskPane) IsCreating() bool {
 	return s.creating
 }
 
-// EnterCreateMode initializes empty edit fields for creating a new task.
-func (s *TaskPane) EnterCreateMode(defaultPath string) {
-	s.createPath = defaultPath
-
+// initForm builds the shared create/edit field set. A nil task initializes an
+// empty create form (path prefilled with defaultPath); otherwise the fields
+// are seeded from the task being edited.
+func (s *TaskPane) initForm(tsk *task.Task, defaultPath string) {
 	name := textinput.New()
 	name.Placeholder = "Task name"
 	name.CharLimit = 64
@@ -151,7 +162,6 @@ func (s *TaskPane) EnterCreateMode(defaultPath string) {
 	prompt.FocusedStyle.CursorLine = lipgloss.NewStyle()
 	prompt.CharLimit = 0
 	prompt.MaxHeight = 0
-	prompt.Placeholder = "Enter task prompt..."
 
 	cron := textinput.New()
 	cron.Placeholder = "0 9 * * 1-5"
@@ -169,9 +179,23 @@ func (s *TaskPane) EnterCreateMode(defaultPath string) {
 	target.Blur()
 
 	path := textinput.New()
-	path.SetValue(defaultPath)
 	path.CharLimit = 256
 	path.Blur()
+
+	if tsk != nil {
+		name.SetValue(tsk.Name)
+		prompt.SetValue(tsk.Prompt)
+		cron.SetValue(tsk.CronExpr)
+		watch.SetValue(tsk.WatchCmd)
+		target.SetValue(tsk.TargetSession)
+		path.SetValue(tsk.ProjectPath)
+		s.editTriggerIsWatch = tsk.IsWatch()
+		s.setProgramFromValue(tsk.Program)
+	} else {
+		path.SetValue(defaultPath)
+		s.editTriggerIsWatch = false
+		s.setProgramFromValue("")
+	}
 
 	s.editName = name
 	s.editPrompt = prompt
@@ -179,11 +203,17 @@ func (s *TaskPane) EnterCreateMode(defaultPath string) {
 	s.editWatch = watch
 	s.editTarget = target
 	s.editPath = path
-	s.setProgramFromValue("")
 	s.focusIndex = taskFocusName
+	s.editError = ""
+	s.editErrorField = -1
+}
+
+// EnterCreateMode initializes empty edit fields for creating a new task.
+func (s *TaskPane) EnterCreateMode(defaultPath string) {
+	s.createPath = defaultPath
+	s.initForm(nil, defaultPath)
 	s.creating = true
 	s.hasFocus = true
-	s.editError = ""
 }
 
 // setProgramFromValue initializes the selector state from a stored Program
@@ -222,6 +252,16 @@ func (s *TaskPane) programValue() string {
 	return s.editProgramOptions[s.editProgramIdx]
 }
 
+// triggerValues resolves the two trigger buffers to the exactly-one contract:
+// only the selected trigger type's value is returned; the inactive buffer is
+// discarded regardless of content, so a save can never produce both.
+func (s *TaskPane) triggerValues() (cron, watch string) {
+	if s.editTriggerIsWatch {
+		return "", strings.TrimSpace(s.editWatch.Value())
+	}
+	return strings.TrimSpace(s.editCron.Value()), ""
+}
+
 // HasPendingCreate returns true if a new task was submitted and needs saving.
 func (s *TaskPane) HasPendingCreate() bool {
 	return s.pendingCreate
@@ -231,8 +271,9 @@ func (s *TaskPane) HasPendingCreate() bool {
 // program is the user-supplied program override; empty means "use the caller's default".
 func (s *TaskPane) ConsumePendingCreate() (name, prompt, cron, watchCmd, targetSession, path, program string) {
 	s.pendingCreate = false
+	cronVal, watchVal := s.triggerValues()
 	return s.editName.Value(), s.editPrompt.Value(),
-		strings.TrimSpace(s.editCron.Value()), strings.TrimSpace(s.editWatch.Value()),
+		cronVal, watchVal,
 		s.editTarget.Value(), s.editPath.Value(), s.programValue()
 }
 
@@ -346,81 +387,38 @@ func (s *TaskPane) handleNormalMode(msg tea.KeyMsg) bool {
 
 func (s *TaskPane) enterEditMode() {
 	tsk := s.tasks[s.selectedIdx]
-
-	name := textinput.New()
-	name.SetValue(tsk.Name)
-	name.CharLimit = 64
-	name.Focus()
-
-	prompt := textarea.New()
-	prompt.ShowLineNumbers = false
-	prompt.Prompt = ""
-	prompt.Blur()
-	prompt.FocusedStyle.CursorLine = lipgloss.NewStyle()
-	prompt.CharLimit = 0
-	prompt.MaxHeight = 0
-	prompt.SetValue(tsk.Prompt)
-
-	cron := textinput.New()
-	cron.SetValue(tsk.CronExpr)
-	cron.CharLimit = 64
-	cron.Blur()
-
-	watch := textinput.New()
-	watch.SetValue(tsk.WatchCmd)
-	watch.Placeholder = "long-running cmd; 1 stdout line = 1 event"
-	watch.CharLimit = 256
-	watch.Blur()
-
-	target := textinput.New()
-	target.SetValue(tsk.TargetSession)
-	target.Placeholder = "(new session per run)"
-	target.CharLimit = 64
-	target.Blur()
-
-	path := textinput.New()
-	path.SetValue(tsk.ProjectPath)
-	path.CharLimit = 256
-	path.Blur()
-
-	s.editName = name
-	s.editPrompt = prompt
-	s.editCron = cron
-	s.editWatch = watch
-	s.editTarget = target
-	s.editPath = path
-	s.setProgramFromValue(tsk.Program)
-	s.focusIndex = taskFocusName
+	s.initForm(&tsk, "")
 	s.editing = true
-	s.editError = ""
 }
 
 // validateForm enforces the shared create/edit form contract, mirroring
-// `af tasks add` (api/tasks.go): a name, exactly one of cron / watch cmd
-// (#782), and — for cron tasks only — a non-empty prompt plus a valid cron
-// expression. Watch tasks may omit the prompt: each event defaults to the raw
-// emitted line. Returns the inline error to surface, or "" when valid.
-func (s *TaskPane) validateForm() string {
+// `af tasks add` (api/tasks.go). The trigger-type selector already guarantees
+// at most one trigger, so validation reduces to: a name, a non-empty value
+// for the selected trigger, and — for cron tasks only — a valid cron
+// expression plus a non-empty prompt. Watch tasks may omit the prompt: each
+// event defaults to the raw emitted line. Returns the inline error and the
+// focus stop to render it under, or ("", -1) when valid.
+func (s *TaskPane) validateForm() (string, int) {
 	if s.editName.Value() == "" {
-		return "name is required"
+		return "name is required", taskFocusName
 	}
-	hasCron := strings.TrimSpace(s.editCron.Value()) != ""
-	hasWatch := strings.TrimSpace(s.editWatch.Value()) != ""
-	if hasCron && hasWatch {
-		return "cron and watch cmd are mutually exclusive; set exactly one"
-	}
-	if !hasCron && !hasWatch {
-		return "exactly one of cron or watch cmd is required"
-	}
-	if hasCron {
-		if strings.TrimSpace(s.editPrompt.Value()) == "" {
-			return "prompt must be non-empty"
+	if s.editTriggerIsWatch {
+		if strings.TrimSpace(s.editWatch.Value()) == "" {
+			return "watch command is required", taskFocusTriggerValue
 		}
-		if err := task.ValidateCronExpr(strings.TrimSpace(s.editCron.Value())); err != nil {
-			return fmt.Sprintf("invalid cron: %v", err)
-		}
+		return "", -1
 	}
-	return ""
+	cron := strings.TrimSpace(s.editCron.Value())
+	if cron == "" {
+		return "cron expression is required", taskFocusTriggerValue
+	}
+	if err := task.ValidateCronExpr(cron); err != nil {
+		return fmt.Sprintf("invalid cron: %v", err), taskFocusTriggerValue
+	}
+	if strings.TrimSpace(s.editPrompt.Value()) == "" {
+		return "prompt must be non-empty", taskFocusPrompt
+	}
+	return "", -1
 }
 
 func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
@@ -435,14 +433,18 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 		s.editing = false
 		s.creating = false
 		s.editError = ""
+		s.editErrorField = -1
 	case tea.KeyEnter:
 		if s.focusIndex == taskFocusSave {
-			if errMsg := s.validateForm(); errMsg != "" {
+			if errMsg, errField := s.validateForm(); errMsg != "" {
 				s.editError = errMsg
+				s.editErrorField = errField
 				return true
 			}
+			s.editError = ""
+			s.editErrorField = -1
+			cron, watch := s.triggerValues()
 			if s.creating {
-				s.editError = ""
 				s.pendingCreate = true
 				s.creating = false
 			} else {
@@ -453,13 +455,13 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 				absPath, err := filepath.Abs(s.editPath.Value())
 				if err != nil {
 					s.editError = fmt.Sprintf("invalid path: %v", err)
+					s.editErrorField = taskFocusPath
 					return true
 				}
-				s.editError = ""
 				s.tasks[s.selectedIdx].Name = s.editName.Value()
 				s.tasks[s.selectedIdx].Prompt = s.editPrompt.Value()
-				s.tasks[s.selectedIdx].CronExpr = strings.TrimSpace(s.editCron.Value())
-				s.tasks[s.selectedIdx].WatchCmd = strings.TrimSpace(s.editWatch.Value())
+				s.tasks[s.selectedIdx].CronExpr = cron
+				s.tasks[s.selectedIdx].WatchCmd = watch
 				s.tasks[s.selectedIdx].TargetSession = s.editTarget.Value()
 				s.tasks[s.selectedIdx].ProjectPath = absPath
 				s.tasks[s.selectedIdx].Program = s.programValue()
@@ -475,12 +477,16 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 		switch s.focusIndex {
 		case taskFocusName:
 			s.editName, _ = s.editName.Update(msg)
+		case taskFocusTrigger:
+			s.handleTriggerKey(msg)
+		case taskFocusTriggerValue:
+			if s.editTriggerIsWatch {
+				s.editWatch, _ = s.editWatch.Update(msg)
+			} else {
+				s.editCron, _ = s.editCron.Update(msg)
+			}
 		case taskFocusPrompt:
 			s.editPrompt, _ = s.editPrompt.Update(msg)
-		case taskFocusCron:
-			s.editCron, _ = s.editCron.Update(msg)
-		case taskFocusWatch:
-			s.editWatch, _ = s.editWatch.Update(msg)
 		case taskFocusTarget:
 			s.editTarget, _ = s.editTarget.Update(msg)
 		case taskFocusPath:
@@ -492,9 +498,21 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 	return true
 }
 
+// handleTriggerKey moves the trigger-type selector: cron sits on the left,
+// watch on the right. Other keys are ignored so the selector behaves like a
+// list, not a free-text input.
+func (s *TaskPane) handleTriggerKey(msg tea.KeyMsg) {
+	switch msg.String() {
+	case "left", "h", "up", "k":
+		s.editTriggerIsWatch = false
+	case "right", "l", "down", "j":
+		s.editTriggerIsWatch = true
+	}
+}
+
 // handleProgramKey moves the selector cursor when the Program field has focus.
-// Up/k and down/j navigate; other keys are ignored so the selector behaves
-// like a list, not a free-text input (#492).
+// Left/h and right/l step the selection (up/down work too); other keys are
+// ignored so the selector behaves like a list, not a free-text input (#492).
 func (s *TaskPane) handleProgramKey(msg tea.KeyMsg) {
 	if len(s.editProgramOptions) == 0 {
 		return
@@ -522,12 +540,14 @@ func (s *TaskPane) updateEditFocus() {
 	switch s.focusIndex {
 	case taskFocusName:
 		s.editName.Focus()
+	case taskFocusTriggerValue:
+		if s.editTriggerIsWatch {
+			s.editWatch.Focus()
+		} else {
+			s.editCron.Focus()
+		}
 	case taskFocusPrompt:
 		s.editPrompt.Focus()
-	case taskFocusCron:
-		s.editCron.Focus()
-	case taskFocusWatch:
-		s.editWatch.Focus()
 	case taskFocusTarget:
 		s.editTarget.Focus()
 	case taskFocusPath:
@@ -547,9 +567,9 @@ func (s *TaskPane) String() string {
 // the fields the daemon persists (#782 phase 2): the watcher supervisor
 // records "stopped" (script exited 0) and "errored" (crash loop) in
 // LastRunStatus — since #797 the latter as "errored: <why>", which the
-// detail row renders in full; any other value on an enabled watch task means
-// the daemon (re-)arms its watcher on start/reload, i.e. "watching". A
-// disabled watch task has no watcher, so it reads "stopped".
+// errored detail row renders in full; any other value on an enabled watch
+// task means the daemon (re-)arms its watcher on start/reload, i.e.
+// "watching". A disabled watch task has no watcher, so it reads "stopped".
 func watchTaskStatus(tsk task.Task) string {
 	if !tsk.Enabled {
 		return "stopped"
@@ -563,6 +583,26 @@ func watchTaskStatus(tsk task.Task) string {
 	return "watching"
 }
 
+// taskTriggerSummary is the one-line trigger column for a list row: the cron
+// expression, or the watch command with its supervision status.
+func taskTriggerSummary(tsk task.Task) string {
+	if tsk.IsWatch() {
+		return fmt.Sprintf("watch: %s [%s]", tsk.WatchCmd, watchTaskStatus(tsk))
+	}
+	if tsk.CronExpr == "" {
+		return "(no trigger)"
+	}
+	return tsk.CronExpr
+}
+
+// taskDeliverySummary is the one-line delivery column: where a fire lands.
+func taskDeliverySummary(tsk task.Task) string {
+	if tsk.TargetSession != "" {
+		return "→ " + tsk.TargetSession
+	}
+	return "new session"
+}
+
 func (s *TaskPane) renderListMode() string {
 	tStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7D56F4"))
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
@@ -570,8 +610,7 @@ func (s *TaskPane) renderListMode() string {
 	disabledStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
 	detailStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
-	promptStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFFFF"))
-	sepLineStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3C3C3C"))
+	erroredStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
 
 	var b strings.Builder
 	b.WriteString(tStyle.Render("Tasks"))
@@ -582,19 +621,13 @@ func (s *TaskPane) renderListMode() string {
 		b.WriteString("\n")
 	}
 
-	// Available width for word-wrapping prompt text (account for indent)
-	wrapWidth := s.width - 6
-	if wrapWidth < 20 {
-		wrapWidth = 20
+	// Width available to the indented detail lines under the selected row.
+	detailWidth := s.width - 8
+	if detailWidth < 20 {
+		detailWidth = 20
 	}
 
 	for i, tsk := range s.tasks {
-		if i > 0 {
-			// Visual separator between tasks
-			sep := strings.Repeat("─", wrapWidth)
-			b.WriteString("  " + sepLineStyle.Render(sep) + "\n")
-		}
-
 		status := "[✓]"
 		style := enabledStyle
 		if !tsk.Enabled {
@@ -602,20 +635,15 @@ func (s *TaskPane) renderListMode() string {
 			style = disabledStyle
 		}
 
-		isSelected := i == s.selectedIdx
-		// Watch tasks have no cron expression; show their trigger and the
-		// watcher's supervision status instead (#782).
-		trigger := tsk.CronExpr
-		if tsk.IsWatch() {
-			trigger = fmt.Sprintf("watch: %s [%s]", tsk.WatchCmd, watchTaskStatus(tsk))
-		}
-		var header string
+		// One line per task: status, name, trigger, delivery.
+		parts := []string{status}
 		if tsk.Name != "" {
-			header = fmt.Sprintf("%s %s  %s", status, tsk.Name, trigger)
-		} else {
-			header = fmt.Sprintf("%s %s", status, trigger)
+			parts = append(parts, tsk.Name)
 		}
+		parts = append(parts, taskTriggerSummary(tsk), taskDeliverySummary(tsk))
+		header := strings.Join(parts, "  ")
 
+		isSelected := i == s.selectedIdx
 		if isSelected && s.hasFocus {
 			b.WriteString(selectedStyle.Render("▸ " + header))
 		} else {
@@ -623,36 +651,45 @@ func (s *TaskPane) renderListMode() string {
 		}
 		b.WriteString("\n")
 
-		// Full prompt text, word-wrapped
-		wrapped := taskPaneWordWrap(tsk.Prompt, wrapWidth)
-		for _, line := range wrapped {
-			b.WriteString(promptStyle.Render("    " + line))
+		// A crash-looped watcher gets its full #797 failure summary on a
+		// detail line — the only always-on detail, and only when errored.
+		if tsk.IsWatch() && strings.HasPrefix(tsk.LastRunStatus, "errored:") {
+			b.WriteString(erroredStyle.Render("      " + tsk.LastRunStatus))
 			b.WriteString("\n")
 		}
 
-		// Program and last run info for all items
-		lastRun := "never"
-		if tsk.LastRunAt != nil {
-			lastRun = tsk.LastRunAt.Format("Jan 02 15:04")
+		// The selected row expands with prompt + agent + last-run detail.
+		if isSelected {
+			if snippet := promptSnippet(tsk.Prompt, detailWidth); snippet != "" {
+				b.WriteString(detailStyle.Render("      " + snippet))
+				b.WriteString("\n")
+			}
+			lastRun := "never"
+			if tsk.LastRunAt != nil {
+				lastRun = tsk.LastRunAt.Format("Jan 02 15:04")
+			}
+			programLabel := tsk.Program
+			if programLabel == "" {
+				programLabel = programDefaultLabel
+			}
+			detail := fmt.Sprintf("      %s • last: %s", programLabel, lastRun)
+			if tsk.LastRunStatus != "" {
+				// The full errored summary already has its own line above;
+				// keep this column short.
+				statusLabel := tsk.LastRunStatus
+				if strings.HasPrefix(statusLabel, "errored:") {
+					statusLabel = "errored"
+				}
+				detail += " (" + statusLabel + ")"
+			}
+			b.WriteString(detailStyle.Render(detail))
+			b.WriteString("\n")
 		}
-		programLabel := tsk.Program
-		if programLabel == "" {
-			programLabel = programDefaultLabel
-		}
-		detail := fmt.Sprintf("    %s • last: %s", programLabel, lastRun)
-		if tsk.LastRunStatus != "" {
-			detail += " (" + tsk.LastRunStatus + ")"
-		}
-		if tsk.TargetSession != "" {
-			detail += " • → " + tsk.TargetSession
-		}
-		b.WriteString(detailStyle.Render(detail))
-		b.WriteString("\n")
 	}
 
 	b.WriteString("\n")
 	if s.hasFocus {
-		b.WriteString(hintStyle.Render("n new • enter edit • r run now • x toggle • D delete • esc back"))
+		b.WriteString(hintStyle.Render("↑/↓ select • n new • enter edit • r run now • x toggle • D delete • esc back"))
 	} else {
 		b.WriteString(hintStyle.Render("enter to focus and edit tasks"))
 	}
@@ -667,6 +704,9 @@ func (s *TaskPane) renderEditMode() string {
 		MarginBottom(1)
 
 	labelStyle := lipgloss.NewStyle().Bold(true)
+	groupStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7F7A7A"))
+	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+	errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
 
 	buttonStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
 	focusedButtonStyle := buttonStyle.
@@ -687,6 +727,26 @@ func (s *TaskPane) renderEditMode() string {
 	s.editTarget.Width = inputWidth
 	s.editPath.Width = inputWidth
 
+	// The prompt's role depends on the trigger: cron tasks require it, watch
+	// tasks default each event to the raw emitted line.
+	if s.editTriggerIsWatch {
+		s.editPrompt.Placeholder = "(optional) {{line}} expands to the event line"
+	} else {
+		s.editPrompt.Placeholder = "Enter task prompt..."
+	}
+
+	label := func(text string) string {
+		return labelStyle.Render(fmt.Sprintf("%-9s", text))
+	}
+	// fieldErr renders the inline validation message directly under the
+	// field it belongs to, instead of a global error footer.
+	fieldErr := func(field int) string {
+		if s.editError != "" && s.editErrorField == field {
+			return errorStyle.Render("  ! "+s.editError) + "\n"
+		}
+		return ""
+	}
+
 	var b strings.Builder
 	if s.creating {
 		b.WriteString(editTitleStyle.Render("New Task"))
@@ -695,106 +755,119 @@ func (s *TaskPane) renderEditMode() string {
 		b.WriteString(editTitleStyle.Render(fmt.Sprintf("Edit Task %s", tsk.ID)))
 	}
 	b.WriteString("\n")
-	b.WriteString(labelStyle.Render("Name:"))
-	b.WriteString("  ")
+
+	b.WriteString(groupStyle.Render("Essentials"))
+	b.WriteString("\n")
+	b.WriteString(label("Name:"))
 	b.WriteString(s.editName.View())
 	b.WriteString("\n")
+	b.WriteString(fieldErr(taskFocusName))
+	b.WriteString(label("Trigger:"))
+	b.WriteString(s.renderTriggerSelector())
+	b.WriteString("\n")
+	if s.editTriggerIsWatch {
+		b.WriteString(label("Watch:"))
+		b.WriteString(s.editWatch.View())
+	} else {
+		b.WriteString(label("Cron:"))
+		b.WriteString(s.editCron.View())
+	}
+	b.WriteString("\n")
+	b.WriteString(fieldErr(taskFocusTriggerValue))
 	b.WriteString(labelStyle.Render("Prompt:"))
+	if s.editTriggerIsWatch {
+		b.WriteString(hintStyle.Render(" (optional)"))
+	}
 	b.WriteString("\n")
 	b.WriteString(s.editPrompt.View())
-	b.WriteString("\n\n")
-	b.WriteString(labelStyle.Render("Cron:"))
-	b.WriteString("  ")
-	b.WriteString(s.editCron.View())
 	b.WriteString("\n")
-	b.WriteString(labelStyle.Render("Watch:"))
-	b.WriteString(" ")
-	b.WriteString(s.editWatch.View())
+	b.WriteString(fieldErr(taskFocusPrompt))
 	b.WriteString("\n")
-	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
-	b.WriteString(hintStyle.Render("       trigger: set exactly one of Cron / Watch"))
+
+	b.WriteString(groupStyle.Render("Delivery"))
 	b.WriteString("\n")
-	b.WriteString(labelStyle.Render("Target:"))
-	b.WriteString(" ")
+	b.WriteString(label("Target:"))
 	b.WriteString(s.editTarget.View())
 	b.WriteString("\n")
-	b.WriteString(labelStyle.Render("Path:"))
-	b.WriteString("  ")
+	b.WriteString(label("Path:"))
 	b.WriteString(s.editPath.View())
 	b.WriteString("\n")
-	b.WriteString(labelStyle.Render("Program:"))
-	b.WriteString("\n")
+	b.WriteString(fieldErr(taskFocusPath))
+	b.WriteString(label("Program:"))
 	b.WriteString(s.renderProgramSelector())
-	b.WriteString("\n")
+	b.WriteString("\n\n")
 
 	submitLabel := " Save "
 	if s.creating {
 		submitLabel = " Create "
 	}
 	if s.focusIndex == taskFocusSave {
-		b.WriteString("       " + focusedButtonStyle.Render(submitLabel))
+		b.WriteString(focusedButtonStyle.Render(submitLabel))
 	} else {
-		b.WriteString("       " + buttonStyle.Render(submitLabel))
+		b.WriteString(buttonStyle.Render(submitLabel))
 	}
-
-	if s.editError != "" {
-		errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
-		b.WriteString("\n\n")
-		b.WriteString(errorStyle.Render("! " + s.editError))
-	}
+	b.WriteString("\n\n")
+	b.WriteString(hintStyle.Render("tab next • shift+tab prev • enter save • esc cancel"))
 
 	return b.String()
 }
 
-// renderProgramSelector renders the inline agent selector. Focused selection
-// is highlighted in yellow with a ▸ marker; the unfocused row gets the
-// dim/focus-hint treatment used by the rest of the edit form.
+// renderTriggerSelector renders the inline cron|watch type selector on one
+// line. The selected type gets the ▸ marker (yellow when focused, dim
+// otherwise), matching the Program selector's treatment.
+func (s *TaskPane) renderTriggerSelector() string {
+	focused := s.focusIndex == taskFocusTrigger
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
+	dimSelectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
+	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+
+	option := func(name string, sel bool) string {
+		switch {
+		case sel && focused:
+			return selectedStyle.Render("▸ " + name)
+		case sel:
+			return dimSelectedStyle.Render("▸ " + name)
+		default:
+			return normalStyle.Render("  " + name)
+		}
+	}
+	out := option("cron", !s.editTriggerIsWatch) + "  " + option("watch", s.editTriggerIsWatch)
+	if focused {
+		out += hintStyle.Render("   ←/→ switch")
+	}
+	return out
+}
+
+// renderProgramSelector renders the agent selector as a single line showing
+// the current choice; ←/→ steps through the options when focused.
 func (s *TaskPane) renderProgramSelector() string {
 	focused := s.focusIndex == taskFocusProgram
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
-	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
 	dimSelectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
 
-	var b strings.Builder
-	for i, opt := range s.editProgramOptions {
-		isSel := i == s.editProgramIdx
-		switch {
-		case isSel && focused:
-			b.WriteString("    " + selectedStyle.Render("▸ "+opt))
-		case isSel:
-			b.WriteString("    " + dimSelectedStyle.Render("▸ "+opt))
-		default:
-			b.WriteString("    " + normalStyle.Render("  "+opt))
-		}
-		b.WriteString("\n")
+	value := programDefaultLabel
+	if s.editProgramIdx >= 0 && s.editProgramIdx < len(s.editProgramOptions) {
+		value = s.editProgramOptions[s.editProgramIdx]
 	}
 	if focused {
-		hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
-		b.WriteString("    " + hintStyle.Render("↑/↓ change agent"))
-		b.WriteString("\n")
+		return selectedStyle.Render("◂ "+value+" ▸") + hintStyle.Render("   ←/→ change agent")
 	}
-	return b.String()
+	return dimSelectedStyle.Render(value)
 }
 
-// taskPaneWordWrap wraps text to fit within maxWidth, breaking on word boundaries.
-func taskPaneWordWrap(text string, maxWidth int) []string {
-	if maxWidth <= 0 {
-		return []string{text}
+// promptSnippet collapses a prompt to a single line truncated to maxWidth,
+// for the selected list row's detail line.
+func promptSnippet(prompt string, maxWidth int) string {
+	fields := strings.Fields(prompt)
+	if len(fields) == 0 {
+		return ""
 	}
-	words := strings.Fields(text)
-	if len(words) == 0 {
-		return []string{}
+	line := strings.Join(fields, " ")
+	runes := []rune(line)
+	if maxWidth > 1 && len(runes) > maxWidth {
+		return string(runes[:maxWidth-1]) + "…"
 	}
-	var lines []string
-	current := words[0]
-	for _, word := range words[1:] {
-		if len(current)+1+len(word) > maxWidth {
-			lines = append(lines, current)
-			current = word
-		} else {
-			current += " " + word
-		}
-	}
-	lines = append(lines, current)
-	return lines
+	return line
 }

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -85,53 +85,60 @@ func TestTaskPaneNormalModeAllowsQuitKeysToPropagate(t *testing.T) {
 	assert.False(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlC}))
 }
 
-// fillCreateForm types a name, prompt, and cron into the create form so
-// submitting via the Save button doesn't trip validation. Leaves focus on
-// index 0 (Name) so callers can walk to whichever field they want to drive
-// next.
+// tabTo advances the edit-form focus from its current position by pressing
+// Tab the given number of times.
+func tabTo(tp *TaskPane, presses int) {
+	for i := 0; i < presses; i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	}
+}
+
+// fillCreateForm types a name, cron expression, and prompt into the create
+// form (the trigger selector defaults to cron) so submitting via the Save
+// button doesn't trip validation. Leaves focus back on index 0 (Name) so
+// callers can walk to whichever field they want to drive next.
 func fillCreateForm(t *testing.T, tp *TaskPane, name string) {
 	t.Helper()
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(name)})
+	tabTo(tp, 2) // name -> trigger selector (cron stays selected) -> cron value
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do something")})
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> cron
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
 	// Walk back to name (index 0) so callers can navigate forward consistently.
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
+	for i := 0; i < taskFocusPrompt; i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
+	}
 }
 
 // TestTaskPaneCreateModeRejectsEmptyPrompt is the regression guard for #517:
-// submitting the create form with no prompt (or whitespace-only) must surface
-// an inline validation error instead of marking a pending create with a blank
-// prompt that no-ops when the scheduler fires.
+// submitting the create form for a cron task with no prompt (or
+// whitespace-only) must surface an inline validation error instead of marking
+// a pending create with a blank prompt that no-ops when the scheduler fires.
 func TestTaskPaneCreateModeRejectsEmptyPrompt(t *testing.T) {
 	for _, prompt := range []string{"", "   "} {
 		t.Run("prompt="+prompt, func(t *testing.T) {
 			tp := NewTaskPane()
 			tp.EnterCreateMode("/tmp/repo")
 
-			// Fill name, leave prompt empty/whitespace, fill cron.
+			// Fill name and cron, leave prompt empty/whitespace.
 			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("daily")})
+			tabTo(tp, 2) // -> trigger -> cron value
+			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
 			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
 			if prompt != "" {
 				tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(prompt)})
 			}
-			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> cron
-			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
 
 			// Walk to Save and submit.
-			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> watch
-			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> target
-			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> path
-			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> program
-			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> save
+			tabTo(tp, taskFocusSave-taskFocusPrompt)
 			tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 			assert.False(t, tp.HasPendingCreate(), "empty prompt must not produce a pending create")
 			assert.True(t, tp.IsCreating(), "form must stay open so user can fix the error")
 			assert.Equal(t, "prompt must be non-empty", tp.editError,
 				"inline validation error must surface to the user")
+			assert.Equal(t, taskFocusPrompt, tp.editErrorField,
+				"the error must render under the Prompt field")
 		})
 	}
 }
@@ -145,9 +152,7 @@ func TestTaskPaneCreateModeSelectorDefaultsToConfigDefault(t *testing.T) {
 	fillCreateForm(t, tp, "daily")
 
 	// Walk to the Save button without touching the Program selector.
-	for i := 0; i < taskFocusCount-1; i++ {
-		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
-	}
+	tabTo(tp, taskFocusCount-1)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.True(t, tp.HasPendingCreate(), "submit should mark a pending create")
@@ -165,9 +170,7 @@ func TestTaskPaneCreateModeSelectorPicksCanonicalAgent(t *testing.T) {
 
 	// Walk to the Program field and step the selector to "claude"
 	// (option index 1: 0 is the default sentinel, 1 is the first supported).
-	for i := 0; i < taskFocusProgram; i++ {
-		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
-	}
+	tabTo(tp, taskFocusProgram)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyDown})
 	// Advance to the Save button and submit.
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
@@ -198,9 +201,7 @@ func TestTaskPaneEditModePresetFromExistingProgram(t *testing.T) {
 	assert.True(t, tp.IsEditing())
 
 	// Tab to Save and submit without touching the selector.
-	for i := 0; i < taskFocusCount-1; i++ {
-		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
-	}
+	tabTo(tp, taskFocusCount-1)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.False(t, tp.IsEditing(), "save should exit edit mode")
@@ -235,9 +236,7 @@ func TestTaskPaneEditModeCollapsesLegacyProgramToDefault(t *testing.T) {
 	assert.True(t, tp.IsEditing())
 
 	// Tab to Save and submit without touching the selector.
-	for i := 0; i < taskFocusCount-1; i++ {
-		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
-	}
+	tabTo(tp, taskFocusCount-1)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.False(t, tp.IsEditing(), "save should exit edit mode")
@@ -304,10 +303,8 @@ func editPathTo(t *testing.T, tp *TaskPane, newPath string) {
 	if !tp.IsEditing() {
 		t.Fatalf("expected edit mode")
 	}
-	// Tab Name -> Prompt -> Cron -> Watch -> Target -> Path
-	for i := 0; i < taskFocusPath; i++ {
-		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
-	}
+	// Tab Name -> Trigger -> Trigger value -> Prompt -> Target -> Path
+	tabTo(tp, taskFocusPath)
 	// Clear current value then type the new one.
 	for range tp.editPath.Value() {
 		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyBackspace})
@@ -316,8 +313,7 @@ func editPathTo(t *testing.T, tp *TaskPane, newPath string) {
 		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(newPath)})
 	}
 	// Tab Path -> Program -> Save, then submit.
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
+	tabTo(tp, taskFocusSave-taskFocusPath)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 }
 
@@ -417,9 +413,9 @@ func TestTaskPaneEditModeKeepsAbsolutePath(t *testing.T) {
 	}
 }
 
-// TestTaskPaneListShowsAgentName confirms the list view renders the per-task
-// agent enum name (#658 collapsed Program to the enum, so the rendering is
-// now a straight lookup).
+// TestTaskPaneListShowsAgentName confirms the selected row's detail line
+// renders the per-task agent enum name (#658 collapsed Program to the enum,
+// so the rendering is now a straight lookup).
 func TestTaskPaneListShowsAgentName(t *testing.T) {
 	tp := NewTaskPane()
 	tp.SetSize(80, 24)
@@ -434,7 +430,7 @@ func TestTaskPaneListShowsAgentName(t *testing.T) {
 	}})
 
 	out := tp.String()
-	assert.Contains(t, out, "aider", "list view should render the agent name")
+	assert.Contains(t, out, "aider", "selected row detail should render the agent name")
 }
 
 // TestTaskPaneListShowsConfigDefaultWhenProgramEmpty confirms a task with no
@@ -455,7 +451,7 @@ func TestTaskPaneListShowsConfigDefaultWhenProgramEmpty(t *testing.T) {
 
 	out := tp.String()
 	assert.Contains(t, out, programDefaultLabel,
-		"list view should render the config-default sentinel for empty Program")
+		"selected row detail should render the config-default sentinel for empty Program")
 }
 
 // TestTaskPaneConsumeDeletedClearsState verifies that deleting a task and then
@@ -496,64 +492,83 @@ func TestTaskPaneConsumeDeletedClearsState(t *testing.T) {
 		"second save must not reprocess an already-deleted task (#763)")
 }
 
-// tabTo advances the edit-form focus from its current position to the given
-// focus stop by pressing Tab. Assumes focus starts at taskFocusName.
-func tabTo(tp *TaskPane, target int) {
-	for i := 0; i < target; i++ {
-		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab})
-	}
-}
-
-// TestTaskPaneCreateModeRejectsBothTriggers covers the exactly-one trigger
-// contract from #782 on the create form: filling both Cron and Watch must
-// surface an inline validation error and keep the form open, mirroring the
-// `af tasks add` CLI validation.
-func TestTaskPaneCreateModeRejectsBothTriggers(t *testing.T) {
+// TestTaskPaneCreateModeInactiveTriggerNotSaved pins the structural
+// exactly-one trigger contract (#782): the trigger-type selector decides
+// which buffer is saved, so a stale value left in the inactive trigger's
+// buffer can never leak into the created task — the old "mutually exclusive"
+// validation error is unrepresentable.
+func TestTaskPaneCreateModeInactiveTriggerNotSaved(t *testing.T) {
 	tp := NewTaskPane()
 	tp.EnterCreateMode("/tmp/repo")
-	fillCreateForm(t, tp, "both") // name, prompt, cron
+	fillCreateForm(t, tp, "both") // name, cron, prompt — cron type selected
 
-	tabTo(tp, taskFocusWatch)
+	// Flip the trigger type to watch and fill the watch command. The cron
+	// buffer still holds "* * * * *".
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRight})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> watch value
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("tail -F log")})
-	tabTo(tp, taskFocusSave-taskFocusWatch)
+	tabTo(tp, taskFocusSave-taskFocusTriggerValue)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
-	assert.False(t, tp.HasPendingCreate(), "two triggers must not produce a pending create")
-	assert.True(t, tp.IsCreating(), "form must stay open so user can fix the error")
-	assert.Equal(t, "cron and watch cmd are mutually exclusive; set exactly one", tp.editError)
+	assert.True(t, tp.HasPendingCreate(), "a valid watch task must submit")
+	_, _, cron, watchCmd, _, _, _ := tp.ConsumePendingCreate()
+	assert.Equal(t, "", cron, "the inactive cron buffer must not be saved")
+	assert.Equal(t, "tail -F log", watchCmd)
 }
 
-// TestTaskPaneCreateModeRejectsNoTrigger covers the other half of the
-// exactly-one contract: submitting with neither Cron nor Watch filled must
-// surface an inline error instead of creating an unfireable task.
-func TestTaskPaneCreateModeRejectsNoTrigger(t *testing.T) {
+// TestTaskPaneCreateModeRejectsEmptyCron covers the cron half of the trigger
+// contract: submitting a cron-type task with no expression must surface an
+// inline error under the trigger field instead of creating an unfireable task.
+func TestTaskPaneCreateModeRejectsEmptyCron(t *testing.T) {
 	tp := NewTaskPane()
 	tp.EnterCreateMode("/tmp/repo")
 
-	// Name and prompt only — no trigger.
+	// Name and prompt only — no cron expression.
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("untriggered")})
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+	tabTo(tp, taskFocusPrompt)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do something")})
 	tabTo(tp, taskFocusSave-taskFocusPrompt)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.False(t, tp.HasPendingCreate(), "no trigger must not produce a pending create")
 	assert.True(t, tp.IsCreating(), "form must stay open so user can fix the error")
-	assert.Equal(t, "exactly one of cron or watch cmd is required", tp.editError)
+	assert.Equal(t, "cron expression is required", tp.editError)
+	assert.Equal(t, taskFocusTriggerValue, tp.editErrorField)
 }
 
-// TestTaskPaneCreateModeWatchTask drives a full watch-task create: watch cmd
-// and target session filled, prompt left empty (a watch task may omit it —
-// each event defaults to the raw emitted line). The pending create must carry
-// the new fields and no cron.
+// TestTaskPaneCreateModeRejectsEmptyWatch covers the watch half: a watch-type
+// task with no command must surface the inline error under the trigger field.
+func TestTaskPaneCreateModeRejectsEmptyWatch(t *testing.T) {
+	tp := NewTaskPane()
+	tp.EnterCreateMode("/tmp/repo")
+
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("untriggered")})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRight})
+	tabTo(tp, taskFocusSave-taskFocusTrigger)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.False(t, tp.HasPendingCreate(), "no trigger must not produce a pending create")
+	assert.True(t, tp.IsCreating(), "form must stay open so user can fix the error")
+	assert.Equal(t, "watch command is required", tp.editError)
+	assert.Equal(t, taskFocusTriggerValue, tp.editErrorField)
+}
+
+// TestTaskPaneCreateModeWatchTask drives a full watch-task create: trigger
+// type switched to watch, watch cmd and target session filled, prompt left
+// empty (a watch task may omit it — each event defaults to the raw emitted
+// line). The pending create must carry the new fields and no cron.
 func TestTaskPaneCreateModeWatchTask(t *testing.T) {
 	tp := NewTaskPane()
 	tp.EnterCreateMode("/tmp/repo")
 
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("gh-issues")})
-	tabTo(tp, taskFocusWatch)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRight})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> watch value
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("gh-issue-watch.sh")})
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> target
+	tabTo(tp, taskFocusTarget-taskFocusTriggerValue)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("captain")})
 	tabTo(tp, taskFocusSave-taskFocusTarget)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
@@ -568,8 +583,9 @@ func TestTaskPaneCreateModeWatchTask(t *testing.T) {
 }
 
 // TestTaskPaneEditModeSwitchCronToWatch verifies the edit form can retrigger
-// an existing cron task as a watch task: clearing Cron and filling Watch must
-// save WatchCmd and leave CronExpr empty (phase 3 of #782 replaced the
+// an existing cron task as a watch task: flipping the trigger selector to
+// watch and filling the command must save WatchCmd and clear CronExpr — the
+// stale cron buffer must not leak into the save (phase 3 of #782 replaced the
 // phase-2 stopgap that froze watch-task triggers in the TUI).
 func TestTaskPaneEditModeSwitchCronToWatch(t *testing.T) {
 	tp := NewTaskPane()
@@ -586,13 +602,11 @@ func TestTaskPaneEditModeSwitchCronToWatch(t *testing.T) {
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}) // enter edit mode
 	assert.True(t, tp.IsEditing())
 
-	tabTo(tp, taskFocusCron)
-	for range tp.editCron.Value() {
-		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyBackspace})
-	}
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> watch
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRight})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> watch value
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("tail -F app.log")})
-	tabTo(tp, taskFocusSave-taskFocusWatch)
+	tabTo(tp, taskFocusSave-taskFocusTriggerValue)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.False(t, tp.IsEditing(), "save should exit edit mode")
@@ -604,10 +618,38 @@ func TestTaskPaneEditModeSwitchCronToWatch(t *testing.T) {
 	}
 }
 
-// TestTaskPaneEditModeRejectsBothTriggers verifies the edit form surfaces the
-// exactly-one inline error when a cron task gains a watch cmd without the
-// cron being cleared.
-func TestTaskPaneEditModeRejectsBothTriggers(t *testing.T) {
+// TestTaskPaneEditModeSelectorPresetsFromWatchTask verifies that opening edit
+// mode on a watch task pre-selects the watch trigger type, so saving without
+// touching the selector round-trips the trigger unchanged.
+func TestTaskPaneEditModeSelectorPresetsFromWatchTask(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "gh-issues",
+		WatchCmd:    "gh-issue-watch.sh",
+		ProjectPath: "/tmp/repo",
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, tp.IsEditing())
+	assert.True(t, tp.editTriggerIsWatch, "watch task must preset the watch trigger type")
+
+	tabTo(tp, taskFocusCount-1)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.False(t, tp.IsEditing(), "save should exit edit mode")
+	tasks := tp.GetTasks()
+	if assert.Len(t, tasks, 1) {
+		assert.Equal(t, "", tasks[0].CronExpr)
+		assert.Equal(t, "gh-issue-watch.sh", tasks[0].WatchCmd)
+	}
+}
+
+// TestTaskPaneEditModeRejectsEmptyWatch verifies the edit form surfaces an
+// inline error when the trigger type is flipped to watch without a command,
+// and the rejected edit is not written back.
+func TestTaskPaneEditModeRejectsEmptyWatch(t *testing.T) {
 	tp := NewTaskPane()
 	tp.SetTasks([]task.Task{{
 		ID:          "abc",
@@ -621,37 +663,40 @@ func TestTaskPaneEditModeRejectsBothTriggers(t *testing.T) {
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 	assert.True(t, tp.IsEditing())
 
-	tabTo(tp, taskFocusWatch)
-	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("tail -F app.log")})
-	tabTo(tp, taskFocusSave-taskFocusWatch)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRight})
+	tabTo(tp, taskFocusSave-taskFocusTrigger)
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.True(t, tp.IsEditing(), "form must stay open so user can fix the error")
-	assert.Equal(t, "cron and watch cmd are mutually exclusive; set exactly one", tp.editError)
+	assert.Equal(t, "watch command is required", tp.editError)
 	tasks := tp.GetTasks()
 	if assert.Len(t, tasks, 1) {
+		assert.Equal(t, "0 0 * * *", tasks[0].CronExpr, "rejected edit must not be written back")
 		assert.Equal(t, "", tasks[0].WatchCmd, "rejected edit must not be written back")
 	}
 }
 
 // TestTaskPaneListRendersWatchStatus pins the list-row surface for watch
-// tasks (#782 phase 3): the trigger column shows the watch command, and the
-// status derived from the daemon-persisted fields reads watching (enabled,
-// no terminal status), errored (crash loop), or stopped (clean exit or
-// disabled).
+// tasks (#782 phase 3, tightened by #801): the trigger column shows the watch
+// command and the status derived from the daemon-persisted fields — watching
+// (enabled, no terminal status), errored (crash loop), or stopped (clean exit
+// or disabled). The #797 failure summary gets its own detail line only when
+// errored; other statuses appear in short form on the selected row's detail.
 func TestTaskPaneListRendersWatchStatus(t *testing.T) {
 	cases := []struct {
 		name          string
 		enabled       bool
 		lastRunStatus string
 		want          string
+		wantDetail    string // short status on the selected row's detail line
 	}{
-		{"enabled fresh", true, "", "[watching]"},
-		{"enabled delivering", true, "sent", "[watching]"},
-		{"crash loop", true, "errored", "[errored]"},
-		{"crash loop with summary", true, "errored: exit status 1: WARN lock held", "[errored]"},
-		{"clean exit", true, "stopped", "[stopped]"},
-		{"disabled", false, "sent", "[stopped]"},
+		{"enabled fresh", true, "", "[watching]", ""},
+		{"enabled delivering", true, "sent", "[watching]", "(sent)"},
+		{"crash loop", true, "errored", "[errored]", "(errored)"},
+		{"crash loop with summary", true, "errored: exit status 1: WARN lock held", "[errored]", "(errored)"},
+		{"clean exit", true, "stopped", "[stopped]", "(stopped)"},
+		{"disabled", false, "sent", "[stopped]", "(sent)"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -673,16 +718,35 @@ func TestTaskPaneListRendersWatchStatus(t *testing.T) {
 			assert.Contains(t, out, c.want)
 			assert.Contains(t, out, "→ captain",
 				"rows must surface the target session delivery")
-			if c.lastRunStatus != "" {
-				assert.Contains(t, out, "("+c.lastRunStatus+")",
-					"the detail row must render the raw status — including the #797 failure summary — in full")
+			if c.wantDetail != "" {
+				assert.Contains(t, out, c.wantDetail,
+					"the selected row's detail must show the short status")
 			}
 		})
 	}
 }
 
-// TestTaskPaneListCronRowHasNoWatchStatus confirms cron rows are unchanged:
-// they render the cron expression and no watch-status bracket.
+// TestTaskPaneListShowsErroredSummaryLine pins the #797 surface: a
+// crash-looped watcher's full failure summary renders on its own detail line.
+func TestTaskPaneListShowsErroredSummaryLine(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(120, 24)
+	tp.SetTasks([]task.Task{{
+		ID:            "abc",
+		Name:          "gh-issues",
+		WatchCmd:      "gh-issue-watch.sh",
+		ProjectPath:   "/tmp/repo",
+		Enabled:       true,
+		LastRunStatus: "errored: exit status 1: WARN lock held",
+	}})
+
+	out := tp.String()
+	assert.Contains(t, out, "errored: exit status 1: WARN lock held",
+		"the errored detail line must render the #797 failure summary in full")
+}
+
+// TestTaskPaneListCronRowHasNoWatchStatus confirms cron rows render the cron
+// expression, the create-per-run delivery label, and no watch-status bracket.
 func TestTaskPaneListCronRowHasNoWatchStatus(t *testing.T) {
 	tp := NewTaskPane()
 	tp.SetSize(120, 24)
@@ -696,6 +760,26 @@ func TestTaskPaneListCronRowHasNoWatchStatus(t *testing.T) {
 
 	out := tp.String()
 	assert.Contains(t, out, "0 0 * * *")
+	assert.Contains(t, out, "new session")
 	assert.NotContains(t, out, "[watching]")
 	assert.NotContains(t, out, "→ ")
+}
+
+// TestTaskPaneListPromptOnlyOnSelectedRow pins the #801 cleanup: list rows
+// are one line each; the prompt renders only as the selected row's detail
+// snippet, not for every task.
+func TestTaskPaneListPromptOnlyOnSelectedRow(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(120, 24)
+	tp.SetTasks([]task.Task{
+		{ID: "a", Name: "first", Prompt: "selected prompt body", CronExpr: "0 0 * * *", Enabled: true},
+		{ID: "b", Name: "second", Prompt: "unselected prompt body", CronExpr: "0 1 * * *", Enabled: true},
+	})
+	tp.selectedIdx = 0
+
+	out := tp.String()
+	assert.Contains(t, out, "selected prompt body",
+		"the selected row must show its prompt snippet")
+	assert.NotContains(t, out, "unselected prompt body",
+		"unselected rows must stay one line — no prompt body")
 }


### PR DESCRIPTION
Fixes #801

Sachin asked for a pass over "all the options" in the Tasks UI. Below is the full inventory of every field, key, and state the pane exposed (before), what changed and why (after), and before/after layout sketches. Pure presentation/flow — no changes to the task schema, CRUD semantics, the pending-create contract, or the daemon reload pokes.

## The audit — every option in the pane (before)

### Edit/create form — 8 flat tab stops

| # | Field | Widget | Notes |
|---|---|---|---|
| 1 | Name | text input | required |
| 2 | Prompt | textarea | enter = newline |
| 3 | Cron | text input | **always visible** |
| 4 | Watch | text input | **always visible**, plus a permanent hint line "trigger: set exactly one of Cron / Watch" |
| 5 | Target | text input | placeholder "(new session per run)" |
| 6 | Path | text input | |
| 7 | Program | vertical selector | **all 5 options always expanded** (~6 lines) |
| 8 | Save/Create | button | enter submits |

- Validation: a **global error footer** at the bottom of the form — `name is required`, `cron and watch cmd are mutually exclusive; set exactly one`, `exactly one of cron or watch cmd is required`, `prompt must be non-empty`, `invalid cron: …`, `invalid path: …`.
- Keys: tab/shift+tab cycle, enter on Save submits, esc/ctrl+c cancel. Program selector accepted **two duplicate key axes** (up/k/left/h and down/j/right/l) for a vertical list. **No key legend** in edit mode.

### List view — per task, every row

- Header: `[✓]/[✗]` enabled marker, name, trigger (cron expr, or `watch: cmd [watching|stopped|errored]`).
- **The full prompt body, word-wrapped, unbounded lines — for every task.** With a few tasks the list scrolled off-screen.
- An always-on detail line: program (the `(use config default)` sentinel even when meaningless) `• last: <time|never>` (raw status — including the full #797 errored summary inline) `• → target` (when set).
- A separator rule between rows (needed only because rows were multi-line).
- Keys: ↑/k ↓/j select, `x` toggle, `D` delete, `enter` edit, `r` run now, `n` new, `esc` back; q/ctrl+c propagate to quit; shift+↑/↓ and mouse wheel scroll without focus. Footer legend present.

### What didn't hold up

1. Both trigger fields always visible although the contract is exactly-one — the rule lived in validation errors instead of the structure.
2. A 6-line always-expanded selector for a single-value choice (Program).
3. Full prompt bodies dominating the list.
4. Always-on noise: `(use config default)`, `last: never`, separators.
5. Global error footer far from the offending field.
6. No key legend in edit mode; a permanent hint line standing in for one.
7. Duplicate key axes on the Program selector.

## What changed (after)

1. **Trigger-type selector** (`cron | watch`, ←/→) is a form field; only the selected trigger's value input renders. The exactly-one rule is now structural — the "mutually exclusive" error is unrepresentable. Both buffers stay alive so flipping the selector never loses typed input; save writes only the active one and clears the other (same on-disk semantics as before).
2. **Grouped form**: `Essentials` (Name, Trigger, Prompt) then `Delivery` (Target, Path, Program), in the existing inline-form idiom. The Prompt is labeled `(optional)` for watch tasks with a `{{line}}` placeholder.
3. **Program selector collapsed to one line**: `◂ value ▸`, ←/→ steps (up/down still work; same keys as before, same enum semantics, #658/#492 behavior unchanged).
4. **Inline validation**: errors render directly under the field they belong to (name / trigger value / prompt / path), not in a global footer.
5. **One-line list rows**: `[✓] name  <trigger>  <delivery>` where delivery is `→ session` or `new session`. The #797 errored summary gets its own detail line **only when errored**. The **selected** row expands with a one-line prompt snippet and `program • last: <time> (<status>)` — so nothing is lost, it's just not repeated for every row. Separators dropped.
6. **Key legends**: edit mode gained `tab next • shift+tab prev • enter save • esc cancel`; the list legend gained `↑/↓ select`. The permanent "set exactly one" hint line is gone (structural now).

## Layouts

### Form — before

```
Edit Task abc12345
Name:   [nightly                 ]
Prompt:
[ ...                            ]
Cron:   [0 3 * * 1-5             ]
Watch:  [                        ]
        trigger: set exactly one of Cron / Watch
Target: [                        ]
Path:   [/home/user/repo         ]
Program:
      ▸ (use config default)
        claude
        codex
        aider
        gemini
        Save

! cron and watch cmd are mutually exclusive; set exactly one
```

### Form — after

```
Edit Task abc12345
Essentials
Name:    [nightly                 ]
Trigger: ▸ cron    watch          ←/→ switch
Cron:    [0 3 * * 1-5             ]
  ! invalid cron: …               <- inline, under its field
Prompt:
[ ...                             ]

Delivery
Target:  [(new session per run)   ]
Path:    [/home/user/repo         ]
Program: ◂ (use config default) ▸  ←/→ change agent

 Save

tab next • shift+tab prev • enter save • esc cancel
```

### List — before

```
▸ [✓] nightly  0 3 * * 1-5
    Triage open issues and post a summary comment on each, then
    update the tracking board with anything new since yesterday.
    claude • last: Jun 09 03:00 (started)
  ─────────────────────────────────────────────────────────────
  [✓] gh-issues  watch: gh-issue-watch.sh [errored]
    Triage: {{line}}
    (use config default) • last: never (errored: exit status 1: WARN lock held) • → captain
```

### List — after

```
▸ [✓] nightly  0 3 * * 1-5  new session
      Triage open issues and post a summary comment on each, then update…
      claude • last: Jun 09 03:00 (started)
  [✓] gh-issues  watch: gh-issue-watch.sh [errored]  → captain
      errored: exit status 1: WARN lock held
```

## Tests

- Regression tests kept green through the refactor: #251, #492, #517, #526, #578 (app-level, key walk updated to the new tab order), #641, #658, **#763 ConsumeDeleted**, #782 phase-3 validation, #797.
- The "mutually exclusive" / "exactly one" validation tests are replaced by their structural equivalents: `InactiveTriggerNotSaved` (a stale buffer in the unselected trigger can never leak into a save), `RejectsEmptyCron` / `RejectsEmptyWatch` (the per-type required errors, pinned to render under the trigger field).
- New pins: watch tasks preset the selector on edit; the #797 summary renders on its own line only when errored; prompt bodies render only on the selected row.

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `deadcode -test ./...` — all clean.
- `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/... ./app/...` — clean.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)