### PR TITLE
fix(session/git): RemoveAll the worktree dir whenever git has deregistered it after a failed remove (#802)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -37,7 +37,7 @@ var ghostKillTmuxByName = func(sanitizedName string) error {
 	if !strings.HasPrefix(sanitizedName, tmux.TmuxPrefix) {
 		return fmt.Errorf("refusing to kill tmux session without %q prefix: %q", tmux.TmuxPrefix, sanitizedName)
 	}
-	return tmux.NewTmuxSessionFromSanitizedName(sanitizedName, "").Close()
+	return tmux.NewTmuxSessionFromSanitizedName(sanitizedName, "").CloseAndWaitForPaneExit()
 }
 
 // ghostCleanupWorktree performs best-effort worktree teardown for a ghost
@@ -72,13 +72,15 @@ var ghostCleanupWorktree = func(data *session.InstanceData, title string) {
 // resources. Tmux teardown is independent of worktree state (#516): a ghost
 // record can have an empty worktree path while a tmux session with the
 // persisted name is still running, so the two branches share no condition.
+// Tmux goes FIRST: a still-running agent writing into the worktree while git
+// recursively deletes it leaks a half-deleted directory (#802).
 func ghostCleanup(data *session.InstanceData, title string) {
-	ghostCleanupWorktree(data, title)
 	if data.TmuxName != "" {
 		if killErr := ghostKillTmuxByName(data.TmuxName); killErr != nil {
 			log.WarningLog.Printf("ghost session %q: tmux cleanup failed: %v", title, killErr)
 		}
 	}
+	ghostCleanupWorktree(data, title)
 }
 
 var sessionsListCmd = &cobra.Command{

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -613,6 +613,44 @@ func TestGhostCleanup_AllEmpty(t *testing.T) {
 	}
 }
 
+// TestGhostCleanup_TmuxBeforeWorktree pins the teardown ordering required by
+// #802: the tmux session (and with it the agent process) must be killed
+// BEFORE the worktree directory is deleted, otherwise the agent's in-flight
+// writes race git's recursive delete and leak a half-deleted directory.
+func TestGhostCleanup_TmuxBeforeWorktree(t *testing.T) {
+	var order []string
+	prevWT := ghostCleanupWorktree
+	prevTmux := ghostKillTmuxByName
+	ghostCleanupWorktree = func(data *session.InstanceData, title string) {
+		order = append(order, "worktree")
+	}
+	ghostKillTmuxByName = func(name string) error {
+		order = append(order, "tmux")
+		return nil
+	}
+	defer func() {
+		ghostCleanupWorktree = prevWT
+		ghostKillTmuxByName = prevTmux
+	}()
+
+	data := &session.InstanceData{
+		Title:    "ghost",
+		Program:  "claude",
+		TmuxName: "af_ghost",
+		Worktree: session.GitWorktreeData{
+			RepoPath:     "/tmp/repo",
+			WorktreePath: "/tmp/wt",
+			SessionName:  "ghost",
+			BranchName:   "af/ghost",
+		},
+	}
+	ghostCleanup(data, "ghost")
+
+	if len(order) != 2 || order[0] != "tmux" || order[1] != "worktree" {
+		t.Fatalf("expected tmux teardown before worktree cleanup (#802), got: %v", order)
+	}
+}
+
 // TestGhostKillTmuxByName_RefusesNonAfPrefix guards the validation in the
 // real ghostKillTmuxByName: a sanitized name without the af_ prefix would
 // only appear via storage corruption, and silently killing whatever tmux

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1090,7 +1090,7 @@ var ghostKillTmuxByName = func(sanitizedName string) error {
 	if !strings.HasPrefix(sanitizedName, tmux.TmuxPrefix) {
 		return fmt.Errorf("refusing to kill tmux session without %q prefix: %q", tmux.TmuxPrefix, sanitizedName)
 	}
-	return tmux.NewTmuxSessionFromSanitizedName(sanitizedName, "").Close()
+	return tmux.NewTmuxSessionFromSanitizedName(sanitizedName, "").CloseAndWaitForPaneExit()
 }
 
 // ghostCleanupWorktree performs best-effort worktree teardown for a ghost
@@ -1125,13 +1125,15 @@ var ghostCleanupWorktree = func(data *session.InstanceData, title string) {
 // resources. Tmux teardown is independent of worktree state (#516/#549): a
 // ghost record can have an empty worktree path while a tmux session with the
 // persisted name is still running, so the two branches share no condition.
+// Tmux goes FIRST: a still-running agent writing into the worktree while git
+// recursively deletes it leaks a half-deleted directory (#802).
 func ghostCleanup(data *session.InstanceData, title string) {
-	ghostCleanupWorktree(data, title)
 	if data.TmuxName != "" {
 		if killErr := ghostKillTmuxByName(data.TmuxName); killErr != nil {
 			log.WarningLog.Printf("ghost session %q: tmux cleanup failed: %v", title, killErr)
 		}
 	}
+	ghostCleanupWorktree(data, title)
 }
 
 func splitDaemonInstanceKey(key string) (string, string) {

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -655,6 +655,44 @@ func TestGhostCleanup_AllEmpty(t *testing.T) {
 	}
 }
 
+// TestGhostCleanup_TmuxBeforeWorktree pins the teardown ordering required by
+// #802: the tmux session (and with it the agent process) must be killed
+// BEFORE the worktree directory is deleted, otherwise the agent's in-flight
+// writes race git's recursive delete and leak a half-deleted directory.
+func TestGhostCleanup_TmuxBeforeWorktree(t *testing.T) {
+	var order []string
+	prevWT := ghostCleanupWorktree
+	prevTmux := ghostKillTmuxByName
+	ghostCleanupWorktree = func(data *session.InstanceData, title string) {
+		order = append(order, "worktree")
+	}
+	ghostKillTmuxByName = func(name string) error {
+		order = append(order, "tmux")
+		return nil
+	}
+	t.Cleanup(func() {
+		ghostCleanupWorktree = prevWT
+		ghostKillTmuxByName = prevTmux
+	})
+
+	data := &session.InstanceData{
+		Title:    "ghost",
+		Program:  "claude",
+		TmuxName: "af_ghost",
+		Worktree: session.GitWorktreeData{
+			RepoPath:     "/tmp/repo",
+			WorktreePath: "/tmp/wt",
+			SessionName:  "ghost",
+			BranchName:   "af/ghost",
+		},
+	}
+	ghostCleanup(data, "ghost")
+
+	if len(order) != 2 || order[0] != "tmux" || order[1] != "worktree" {
+		t.Fatalf("expected tmux teardown before worktree cleanup (#802), got: %v", order)
+	}
+}
+
 // TestGhostKillTmuxByName_RefusesNonAfPrefix guards the validation in the
 // real ghostKillTmuxByName: a sanitized name without the af_ prefix would
 // only appear via storage corruption, and silently killing whatever tmux

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -172,7 +172,12 @@ func (b *LocalBackend) Kill(i *Instance) error {
 	i.mu.Unlock()
 
 	if ts != nil {
-		if err := ts.Close(); err != nil {
+		// Tear down tmux BEFORE the worktree cleanup below, and wait for the
+		// pane's agent process to actually exit: kill-session only SIGHUPs
+		// it, and an agent still flushing state mid-shutdown races git's
+		// recursive delete of the worktree, leaking a half-deleted directory
+		// ("Directory not empty", #802).
+		if err := ts.CloseAndWaitForPaneExit(); err != nil {
 			log.WarningLog.Printf("kill %q: tmux cleanup failed: %v", title, err)
 		}
 	}

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -78,21 +78,23 @@ func TestLocalBackendKillBestEffort_TmuxFails(t *testing.T) {
 	require.NoError(t, inst.Kill(), "second kill on a cleared instance must be a no-op")
 }
 
-// TestLocalBackendKillBestEffort_WorktreeFails reproduces the exact scenario
-// from issue #478: the git worktree cleanup fails because the path is no
-// longer a working tree, and the user is stuck unable to delete the session.
-// After the fix, Kill logs a warning and returns nil so the caller can
-// remove the row from the sidebar and the persisted record.
+// TestLocalBackendKillBestEffort_WorktreeFails covers the issue #478
+// guarantee: when worktree cleanup genuinely fails, Kill logs a warning and
+// returns nil so the caller can remove the row from the sidebar and the
+// persisted record. The original #478 scenario (path exists but is no longer
+// a working tree) now self-heals via the #802 ownership check — see
+// TestLocalBackendKill_RecoversStaleWorktreeDir — so this test provokes a
+// failure that still surfaces: the stored repo path is not a git repo, every
+// git command fails, and `git worktree list` being unreadable means Cleanup
+// cannot establish ownership and must NOT delete the directory.
 func TestLocalBackendKillBestEffort_WorktreeFails(t *testing.T) {
-	repoRoot := initTempGitRepo(t)
+	notARepo := filepath.Join(t.TempDir(), "not-a-repo")
+	require.NoError(t, os.MkdirAll(notARepo, 0755))
 
-	// Create a real directory that exists but is NOT a git worktree.
-	// `git worktree remove -f` on this path returns the "is not a working
-	// tree" error pattern users see in the issue.
 	stalePath := filepath.Join(t.TempDir(), "stale-worktree")
 	require.NoError(t, os.MkdirAll(stalePath, 0755))
 
-	gw, err := git.NewGitWorktreeFromStorage(repoRoot, stalePath, "issue-478", "issue-478-branch", "", false, false)
+	gw, err := git.NewGitWorktreeFromStorage(notARepo, stalePath, "issue-478", "issue-478-branch", "", false, false)
 	require.NoError(t, err)
 
 	inst := &Instance{
@@ -111,7 +113,45 @@ func TestLocalBackendKillBestEffort_WorktreeFails(t *testing.T) {
 	logged := buf.String()
 	assert.Contains(t, logged, "issue-478", "warning must include instance title")
 	assert.Contains(t, logged, "git worktree cleanup failed")
-	assert.Contains(t, logged, "is not a working tree", "warning should preserve the underlying git error so users can diagnose")
+	assert.Contains(t, logged, "not a git repository", "warning should preserve the underlying git error so users can diagnose")
+
+	// Safety: with ownership unknown (worktree list unreadable), the
+	// directory must be left alone.
+	_, statErr := os.Stat(stalePath)
+	assert.NoError(t, statErr, "Cleanup must not delete a directory whose git ownership it cannot establish")
+}
+
+// TestLocalBackendKill_RecoversStaleWorktreeDir pins the #802 behavior change
+// to the original #478 scenario: the stored path exists on disk but git does
+// not register it as a worktree (`worktree remove` fails, `worktree list`
+// omits it). Instead of surfacing "is not a working tree" and leaking the
+// directory, Kill now removes it and completes cleanly.
+func TestLocalBackendKill_RecoversStaleWorktreeDir(t *testing.T) {
+	repoRoot := initTempGitRepo(t)
+
+	stalePath := filepath.Join(t.TempDir(), "stale-worktree")
+	require.NoError(t, os.MkdirAll(stalePath, 0755))
+
+	gw, err := git.NewGitWorktreeFromStorage(repoRoot, stalePath, "stale-dir", "stale-dir-branch", "", false, false)
+	require.NoError(t, err)
+
+	inst := &Instance{
+		Title:       "stale-dir",
+		backend:     &LocalBackend{},
+		started:     true,
+		gitWorktree: gw,
+	}
+
+	buf := captureWarningLog(t)
+
+	require.NoError(t, inst.Kill())
+	assert.Nil(t, inst.gitWorktree)
+
+	_, statErr := os.Stat(stalePath)
+	assert.True(t, os.IsNotExist(statErr),
+		"Kill must remove a leftover directory git no longer registers as a worktree (#802)")
+	assert.NotContains(t, buf.String(), "git worktree cleanup failed",
+		"recovered cleanup should not warn")
 }
 
 // TestLocalBackendKillBestEffort_BothFail covers the multi-component failure
@@ -128,10 +168,13 @@ func TestLocalBackendKillBestEffort_BothFail(t *testing.T) {
 	}
 	ts := tmux.NewTmuxSessionWithDeps("both-fail", "bash", nil, cmdExec)
 
-	repoRoot := initTempGitRepo(t)
+	// Non-repo path: every git command fails, so the worktree cleanup error
+	// surfaces (ownership unknown — see TestLocalBackendKillBestEffort_WorktreeFails).
+	notARepo := filepath.Join(t.TempDir(), "not-a-repo")
+	require.NoError(t, os.MkdirAll(notARepo, 0755))
 	stalePath := filepath.Join(t.TempDir(), "stale")
 	require.NoError(t, os.MkdirAll(stalePath, 0755))
-	gw, err := git.NewGitWorktreeFromStorage(repoRoot, stalePath, "both-fail", "both-fail-branch", "", false, false)
+	gw, err := git.NewGitWorktreeFromStorage(notARepo, stalePath, "both-fail", "both-fail-branch", "", false, false)
 	require.NoError(t, err)
 
 	inst := &Instance{
@@ -151,7 +194,7 @@ func TestLocalBackendKillBestEffort_BothFail(t *testing.T) {
 	logged := buf.String()
 	assert.Contains(t, logged, "tmux cleanup failed")
 	assert.Contains(t, logged, "git worktree cleanup failed")
-	assert.Equal(t, 2, strings.Count(logged, "both-fail"), "title should appear in both component warnings")
+	assert.Equal(t, 2, strings.Count(logged, `kill "both-fail":`), "title should appear in both component warnings")
 }
 
 // captureWarningLog redirects log.WarningLog to a buffer for the duration of

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -46,8 +47,12 @@ func (g *GitWorktree) setupFromExistingBranch() error {
 	// We are reusing a pre-existing branch — Cleanup() must not delete it.
 	g.branchCreatedByUs = false
 
-	// Clean up any existing worktree first
-	_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath) // Ignore error if worktree doesn't exist
+	// Clean up any existing worktree first. Ignore the error (the worktree
+	// usually doesn't exist) and, unlike Cleanup(), do NOT fall back to
+	// deleting the directory: at this point the path has not been
+	// established as a session-owned worktree, and a path that stays
+	// blocked surfaces loudly via the `worktree add` below (#802 audit).
+	_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath)
 
 	// Prune stale worktree metadata BEFORE re-adding. If the worktree
 	// directory was deleted externally (rm -rf, disk cleanup, etc.), git
@@ -105,8 +110,12 @@ func (g *GitWorktree) setupNewWorktree() error {
 	// We are creating the branch ourselves — Cleanup() may delete it.
 	g.branchCreatedByUs = true
 
-	// Clean up any existing worktree first
-	_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath) // Ignore error if worktree doesn't exist
+	// Clean up any existing worktree first. Ignore the error (the worktree
+	// usually doesn't exist) and, unlike Cleanup(), do NOT fall back to
+	// deleting the directory: at this point the path has not been
+	// established as a session-owned worktree, and a path that stays
+	// blocked surfaces loudly via the `worktree add` below (#802 audit).
+	_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath)
 
 	// Prune stale worktree metadata BEFORE deleting the branch. If `worktree
 	// remove -f` above failed (corrupted .git pointer, etc.), git still tracks
@@ -173,23 +182,37 @@ func (g *GitWorktree) Cleanup() error {
 	if _, err := os.Stat(g.worktreePath); err == nil {
 		// Remove the worktree using git command
 		if _, err := g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath); err != nil {
-			// When the worktree's `.git` pointer is corrupted, `git worktree
-			// remove -f` fails with "validation failed, cannot remove working
-			// tree" and leaves the directory orphaned on disk — previously the
-			// only escape was `af reset`. Fall back to removing the directory
-			// manually, mirroring CleanupWorktreesForRepo (#719). The Prune()
-			// below reconciles git's internal worktree metadata.
-			//
-			// Gate on "validation failed": unlike CleanupWorktreesForRepo,
-			// which only ever sees paths emitted by `git worktree list` (all
-			// real worktrees), g.worktreePath is a stored value with no such
-			// guarantee. "validation failed" means git DOES recognize the path
-			// as one of its registered worktrees, so removing the directory is
-			// safe. Other failures — notably "is not a working tree" — mean git
-			// does not own the path, so we surface the error instead of
-			// deleting it (preserves the best-effort Kill behavior of #478).
 			log.ErrorLog.Printf("failed to remove worktree %s: %v", g.worktreePath, err)
-			if strings.Contains(err.Error(), "validation failed") {
+			// A failed `git worktree remove -f` may still have released the
+			// registration. Decide whether the directory is ours to delete
+			// by asking git, not by matching error strings (#802):
+			//
+			//   - Path no longer in `git worktree list`: git has let go of
+			//     the worktree but the directory survived. Observed when the
+			//     recursive delete aborts partway ("failed to delete ...:
+			//     Directory not empty") because the dying agent process wrote
+			//     into the tree mid-removal — git deregisters first, then
+			//     fails to finish deleting (#802). RemoveAll the leftovers;
+			//     the Prune() below reconciles any remaining metadata.
+			//   - Still registered + "validation failed": the worktree's
+			//     `.git` pointer is corrupted (#719/#726). git refuses to
+			//     remove it, but it is unambiguously one of our registered
+			//     worktrees, so deleting the directory is safe.
+			//   - Still registered + any other error (locked worktree,
+			//     submodules, permissions): git owns the path and we don't
+			//     know why removal failed — surface the error instead of
+			//     deleting data (preserves the best-effort Kill behavior of
+			//     #478).
+			removeDir := false
+			if registered, listErr := g.isWorktreeRegistered(); listErr == nil && !registered {
+				removeDir = true
+			} else if strings.Contains(err.Error(), "validation failed") {
+				// Also the path taken when `worktree list` itself failed
+				// (listErr != nil): without a readable registration we fall
+				// back to the conservative #726 string gate.
+				removeDir = true
+			}
+			if removeDir {
 				if removeErr := os.RemoveAll(g.worktreePath); removeErr != nil {
 					errs = append(errs, fmt.Errorf("failed to remove worktree directory %s: %w", g.worktreePath, removeErr))
 				}
@@ -236,6 +259,39 @@ func (g *GitWorktree) Cleanup() error {
 	}
 
 	return nil
+}
+
+// isWorktreeRegistered reports whether git still lists g.worktreePath as a
+// registered worktree of the repo. Used after a failed `git worktree remove`
+// to distinguish "git released the worktree but the directory survived"
+// (safe to delete manually, #802) from "git still owns the path" (not ours
+// to second-guess).
+func (g *GitWorktree) isWorktreeRegistered() (bool, error) {
+	output, err := g.runGitCommand(g.repoPath, "worktree", "list", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	target := normalizeWorktreePath(g.worktreePath)
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "worktree ") {
+			continue
+		}
+		if normalizeWorktreePath(strings.TrimPrefix(line, "worktree ")) == target {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// normalizeWorktreePath cleans the path and resolves symlinks (best-effort)
+// so `worktree list` output compares equal to a stored path even when one
+// side went through a symlinked parent (e.g. /tmp -> /private/tmp on macOS).
+func normalizeWorktreePath(p string) string {
+	p = filepath.Clean(p)
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return p
 }
 
 // Remove removes the worktree but keeps the branch
@@ -323,7 +379,11 @@ func CleanupWorktreesForRepo(repoRoot string) error {
 			removeCmd := exec.Command("git", "-C", repoRoot, "worktree", "remove", "-f", wt.path)
 			if err := removeCmd.Run(); err != nil {
 				log.ErrorLog.Printf("failed to remove worktree %s: %v", wt.path, err)
-				// Fallback: remove directory manually
+				// Fallback: remove directory manually. Unconditional — no
+				// registration re-check needed here, unlike Cleanup(): wt.path
+				// was emitted by `git worktree list` moments ago, so git
+				// ownership is already established, and `af reset` semantics
+				// are "tear everything down" (#802 audit).
 				if err := os.RemoveAll(wt.path); err != nil {
 					log.ErrorLog.Printf("failed to remove worktree directory %s: %v", wt.path, err)
 				}

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -417,6 +417,119 @@ func TestCleanup_RemovesOrphanedDirectory(t *testing.T) {
 		"Cleanup() must remove the orphaned worktree directory when `git worktree remove` fails validation")
 }
 
+// TestCleanup_RemovesDirWhenGitDeregistered is the regression test for #802.
+// When `git worktree remove -f` fails AFTER git has already released the
+// registration — observed in real usage when the dying agent process wrote
+// into the tree mid-removal, so git deregistered the worktree and then its
+// recursive delete aborted with "Directory not empty" — the directory must
+// not leak. Cleanup() decides by ownership, not error strings: the path is
+// absent from `git worktree list`, so it falls back to os.RemoveAll.
+//
+// Simulated here by deleting the worktree's admin entry
+// (.git/worktrees/<name>), which produces the same post-failure state with
+// real git: `worktree remove` fails ("is not a working tree") while the
+// registration is already gone and the directory is fully populated on disk.
+func TestCleanup_RemovesDirWhenGitDeregistered(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+
+	// Initial commit so HEAD is valid (required for `worktree add`).
+	cmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "initial")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, branchName, err := NewGitWorktree(repoRoot, "deregistered")
+	require.NoError(t, err)
+	require.NoError(t, gw.Setup())
+
+	worktreePath := gw.GetWorktreePath()
+
+	// Drop the worktree's admin entry so git no longer registers the path
+	// while the directory itself survives on disk untouched.
+	adminDir := filepath.Join(repoRoot, ".git", "worktrees", filepath.Base(worktreePath))
+	require.NoError(t, os.RemoveAll(adminDir))
+
+	// Sanity: git has let go, the directory is still there.
+	registered, err := gw.isWorktreeRegistered()
+	require.NoError(t, err)
+	require.False(t, registered, "worktree should be deregistered after its admin entry is removed")
+	_, err = os.Stat(worktreePath)
+	require.NoError(t, err)
+
+	// Full recovery is expected: no error, directory gone, branch gone.
+	require.NoError(t, gw.Cleanup())
+
+	_, err = os.Stat(worktreePath)
+	assert.True(t, os.IsNotExist(err),
+		"Cleanup() must remove the worktree directory once git has deregistered it (#802)")
+
+	branchCmd := exec.Command("git", "-C", repoRoot, "branch", "--list", branchName)
+	out, err = branchCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	assert.Empty(t, strings.TrimSpace(string(out)),
+		"session-owned branch should be deleted after the deregistered worktree is cleaned up")
+}
+
+// TestCleanup_SurfacesErrorWhenGitStillOwnsWorktree is the safety counterpart
+// to the #802 fallback: when git still registers the worktree and the removal
+// failure is not the known #726 "validation failed" class, Cleanup() must
+// surface the error and leave the directory alone instead of deleting data it
+// cannot account for. A locked worktree is the simplest deterministic member
+// of that class: a single `-f` refuses to remove it and the registration
+// stays put.
+func TestCleanup_SurfacesErrorWhenGitStillOwnsWorktree(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+
+	repoRoot := createGitRepo(t)
+
+	cmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "initial")
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, _, err := NewGitWorktree(repoRoot, "stillowned")
+	require.NoError(t, err)
+	require.NoError(t, gw.Setup())
+
+	worktreePath := gw.GetWorktreePath()
+
+	lockCmd := exec.Command("git", "-C", repoRoot, "worktree", "lock", worktreePath, "--reason", "still in use")
+	out, err = lockCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	err = gw.Cleanup()
+	require.Error(t, err,
+		"Cleanup() must surface the failure when git still owns the worktree and the cause is unknown")
+	assert.Contains(t, err.Error(), "locked")
+
+	// The directory must survive — it is still a registered git worktree.
+	_, statErr := os.Stat(worktreePath)
+	assert.NoError(t, statErr,
+		"Cleanup() must NOT delete a directory git still registers as a worktree")
+
+	registered, regErr := gw.isWorktreeRegistered()
+	require.NoError(t, regErr)
+	assert.True(t, registered)
+}
+
 func TestNewGitWorktreeFromStorage_EmptyWorktreePath(t *testing.T) {
 	_, err := NewGitWorktreeFromStorage("/some/repo", "", "session", "branch", "abc123", false, true)
 	require.Error(t, err)

--- a/session/tmux/close_wait_test.go
+++ b/session/tmux/close_wait_test.go
@@ -1,0 +1,96 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/stretchr/testify/require"
+)
+
+// deadPID returns a PID that is guaranteed to have exited and been reaped:
+// we spawn a trivial process and wait for it ourselves.
+func deadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	require.NoError(t, cmd.Run())
+	return cmd.Process.Pid
+}
+
+func TestWaitForPIDExit_ExitedProcess(t *testing.T) {
+	start := time.Now()
+	require.True(t, waitForPIDExit(deadPID(t), 2*time.Second),
+		"an already-exited PID must report exited")
+	require.Less(t, time.Since(start), time.Second,
+		"a dead PID must be detected without burning the timeout")
+}
+
+func TestWaitForPIDExit_AliveProcessTimesOut(t *testing.T) {
+	// Our own PID is alive for the duration of the test.
+	require.False(t, waitForPIDExit(os.Getpid(), 120*time.Millisecond),
+		"a live PID must report not-exited once the timeout elapses")
+}
+
+// TestCloseAndWaitForPaneExit_QueriesPaneBeforeKill verifies the #802
+// ordering contract: the pane PID is captured via display-message BEFORE
+// kill-session runs (afterwards there is nothing left to query), and the
+// wait happens on that PID after the session is gone.
+func TestCloseAndWaitForPaneExit_QueriesPaneBeforeKill(t *testing.T) {
+	pid := deadPID(t)
+	var calls []string
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "kill-session") {
+				calls = append(calls, "kill-session")
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			if strings.Contains(cmd.String(), "display-message") {
+				calls = append(calls, "display-message")
+				return []byte(fmt.Sprintf("%d\n", pid)), nil
+			}
+			return []byte(""), nil
+		},
+	}
+
+	session := newTmuxSession(toTmuxName("close-wait", ""), "claude", NewMockPtyFactory(t), cmdExec)
+
+	start := time.Now()
+	require.NoError(t, session.CloseAndWaitForPaneExit())
+	require.Less(t, time.Since(start), time.Second,
+		"wait on an already-dead agent process must return promptly")
+
+	require.Equal(t, []string{"display-message", "kill-session"}, calls,
+		"pane PID must be captured before kill-session destroys the session")
+}
+
+// TestCloseAndWaitForPaneExit_SessionGone: when the pane PID cannot be
+// queried (session already dead), the method must skip the wait and still
+// perform the Close teardown.
+func TestCloseAndWaitForPaneExit_SessionGone(t *testing.T) {
+	killed := false
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "kill-session") {
+				killed = true
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return nil, fmt.Errorf("can't find session")
+		},
+	}
+
+	session := newTmuxSession(toTmuxName("close-wait-gone", ""), "claude", NewMockPtyFactory(t), cmdExec)
+
+	start := time.Now()
+	require.NoError(t, session.CloseAndWaitForPaneExit())
+	require.Less(t, time.Since(start), time.Second)
+	require.True(t, killed, "kill-session must still run when the pane PID is unqueryable")
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -926,6 +926,71 @@ func (t *TmuxSession) Close() error {
 	return errors.New(errMsg)
 }
 
+// paneExitWait bounds how long CloseAndWaitForPaneExit blocks for the pane
+// process to die. Long enough for an agent to handle SIGHUP and flush state,
+// short enough that teardown of a wedged process doesn't hang the caller.
+const paneExitWait = 3 * time.Second
+
+// CloseAndWaitForPaneExit terminates the tmux session like Close, then waits
+// (bounded by paneExitWait) until the pane's root process has actually
+// exited. `tmux kill-session` only delivers SIGHUP and returns immediately;
+// an agent that is still flushing state files (.claude/, .turbo/, ...) races
+// any directory removal that follows and leaves a half-deleted worktree
+// behind ("Directory not empty", #802). Callers that delete the session's
+// worktree right after teardown must use this instead of Close.
+func (t *TmuxSession) CloseAndWaitForPaneExit() error {
+	pid, pidErr := t.panePID()
+	closeErr := t.Close()
+	if pidErr != nil {
+		// Session already gone (or unqueryable) — nothing to wait on.
+		return closeErr
+	}
+	if !waitForPIDExit(pid, paneExitWait) {
+		log.WarningLog.Printf("tmux session %s: pane process %d still alive %v after kill-session; "+
+			"worktree cleanup may race with its in-flight writes", t.sanitizedName, pid, paneExitWait)
+	}
+	return closeErr
+}
+
+// panePID returns the PID of the root process running in the session's pane
+// (the agent program). Must be called before kill-session — afterwards there
+// is nothing left to query.
+func (t *TmuxSession) panePID() (int, error) {
+	// `-t=` forces an exact session match, mirroring DoesSessionExist.
+	cmd := exec.Command("tmux", "display-message", "-p", "-t", fmt.Sprintf("=%s", t.sanitizedName), "#{pane_pid}")
+	output, err := t.cmdExec.Output(cmd)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query pane pid: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	if err != nil || pid <= 0 {
+		return 0, fmt.Errorf("unexpected pane pid output %q", string(output))
+	}
+	return pid, nil
+}
+
+// waitForPIDExit polls pid with signal 0 until the process is gone or the
+// timeout elapses. Returns true when the process exited within the timeout.
+// The tmux server reaps its dead children promptly, so a lingering zombie
+// (signal 0 succeeds on zombies) does not realistically pin this to the full
+// timeout.
+func waitForPIDExit(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return true
+		}
+		if err := proc.Signal(syscall.Signal(0)); err != nil {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
 // SetDetachedSize set the width and height of the session while detached. This makes the
 // tmux output conform to the specified shape.
 func (t *TmuxSession) SetDetachedSize(width, height int) error {


### PR DESCRIPTION
## Incident

Real usage on the dev box, 2026-06-10 00:11:

```
[DAEMON] WARNING backend_local.go:182: kill "remove-investigate-cli": git worktree cleanup failed: git command failed: error: failed to delete '/home/siyer/docs/detail-remove-investigate-cli': Directory not empty
```

git had already **deregistered** the worktree, but the directory survived with partial content (`.claude/`, `.turbo/`, `.idea/`) because the dying agent process wrote into the tree mid-delete. The #726 fallback never fired — it was gated on the error containing `"validation failed"`, and this failure is a different class. The leaked directory then forced the user's next same-name session onto a `-2` suffix.

## Design: ownership check instead of error-string matching

Per the audit note in #802, `Cleanup()` no longer decides by matching git error strings. After **any** failed `git worktree remove -f` it asks git who owns the path via `git worktree list --porcelain`:

- **Path no longer registered** → git has let go; the directory is no longer a worktree. `os.RemoveAll` it (the existing `Prune()` call reconciles metadata). This is exactly the post-failure state of the incident class — verified empirically that git deregisters *before* its recursive delete aborts.
- **Still registered + `"validation failed"`** → the #726 corrupted-`.git`-pointer class. git refuses to remove it but unambiguously owns it; still safe to delete. The old string-gate survives only as this subcase.
- **Still registered + anything else** (locked worktree, submodules, permissions) → git owns it and we don't know why removal failed; surface the error, **no** RemoveAll.
- **`worktree list` itself unreadable** → ownership unknown; fall back to the conservative #726 string gate only.

Behavior change vs #478: a stored path that exists on disk but that git does not register (formerly surfaced as `"is not a working tree"` and leaked) now self-heals — `Cleanup()` deletes it and returns clean. Cleanup is only invoked on paths a session's `Setup()` established, and the empty-path/stat guards remain.

## Kill-ordering finding (and two real bugs)

`LocalBackend.Kill` already ran tmux teardown before worktree cleanup, **but** `tmux kill-session` only SIGHUPs the pane process and returns — the agent can still be flushing state while git recursively deletes the tree, which is precisely how the incident happened. Added `TmuxSession.CloseAndWaitForPaneExit()`: capture the pane PID before kill-session, then bounded-wait (3s, signal-0 poll) for the process to actually exit; a wedged process logs a warning and proceeds (Kill stays best-effort, #478).

The audit also found the **ghost-cleanup paths** (`api/sessions.go`, `daemon/control.go`) ran worktree deletion **before** tmux kill — the reverse of safe. Both flipped to tmux-first and switched to `CloseAndWaitForPaneExit`; ordering pinned by new tests in both packages.

## Adjacent call-site audit (`worktree remove -f`)

| Site | Disposition |
|---|---|
| `GitWorktree.Cleanup()` | Ownership-check fallback (this PR) |
| `CleanupWorktreesForRepo` | Already unconditionally RemoveAlls on failure — paths come from `git worktree list` moments earlier, so ownership is established, and `af reset` semantics are tear-everything-down. Comment added. |
| `setupFromExistingBranch` / `setupNewWorktree` | No fallback, documented: the path is not yet established as session-owned (could be an unrelated colliding directory), and a blocked path fails loudly at the `worktree add` that follows. |
| `GitWorktree.Remove()` | Untouched; it has no callers in the tree (noted for a future dead-code sweep). |

## Tests

- `TestCleanup_RemovesDirWhenGitDeregistered` — #802 regression with real git: admin entry dropped so `worktree remove` fails while the registration is gone → directory and branch fully recovered, no error.
- `TestCleanup_SurfacesErrorWhenGitStillOwnsWorktree` — safety: locked worktree (deterministic still-registered failure) → error surfaced, directory untouched.
- `TestCleanup_RemovesOrphanedDirectory` / `TestCleanup_DeletesBranchWhenWorktreeRemoveFails` — #726 regressions stay green through the refactor.
- `TestLocalBackendKill_RecoversStaleWorktreeDir` — backend-level pin of the behavior change; `TestLocalBackendKillBestEffort_*` repurposed to a failure class that still surfaces (unreadable repo → ownership unknown → no delete).
- `TestCloseAndWaitForPaneExit_*` + `TestWaitForPIDExit_*` — PID captured before kill-session, prompt return on dead PID, bounded timeout on live PID, Close still runs when the session is already gone.
- `TestGhostCleanup_TmuxBeforeWorktree` (api + daemon) — ordering pinned.

Gates: `go build`, `go test ./...`, `golangci-lint run --fast`, `gofmt -l`, `deadcode -test`, plus `-race` on session/api/daemon and `GOFLAGS="-p=1" -race -parallel 2` on ui/app — all clean. Hermetic; no dev-install.

Fixes #802

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)