### PR TITLE
feat(config): in-repo .agent-factory/config.json with precedence and scoping (#800)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This repo is autonomously maintained by Captain Claude, an AI maintainer running
 
 ## Configuration
 
-Configuration lives at `~/.agent-factory/config.json`:
+Global configuration lives at `~/.agent-factory/config.json`:
 
 ```json
 {
@@ -195,6 +195,34 @@ af -p aider
 `-p` and the per-task `program` field both accept a bare agent enum only. To
 pass a custom path or flags for an agent, set `program_overrides.<agent>` in
 your config — every session that launches that agent will use the override.
+
+### Per-repo configuration
+
+A repository can carry its own configuration in `<repo-root>/.agent-factory/config.json`. Precedence is **app defaults → global config → in-repo config**, merged field by field: an in-repo field overrides the global value only when it is set, and `program_overrides` merges per key (an in-repo entry wins for that agent; global entries for other agents still apply).
+
+```json
+{
+  "default_program": "codex",
+  "program_overrides": {
+    "codex": "/usr/local/bin/codex --profile work"
+  },
+  "post_worktree_commands": ["npm install"],
+  "remote_hooks": {
+    "launch_cmd": "./infra/launch.sh",
+    "list_cmd": "./infra/list.sh",
+    "attach_cmd": "./infra/attach.sh",
+    "delete_cmd": "./infra/delete.sh"
+  }
+}
+```
+
+| Field | Scope |
+|-------|-------|
+| `default_program`, `program_overrides` | Valid globally **and** in-repo (in-repo wins). |
+| `post_worktree_commands`, `remote_hooks` | **In-repo only.** The legacy `~/.agent-factory/repos/<repoID>/config.json` location keeps working for one more release (a deprecation warning in the log points at the new file) and is shadowed whenever the in-repo file sets the same key — including by an explicit empty value like `"post_worktree_commands": []`. |
+| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `detach_keys` | Global only. Setting them in-repo is rejected with an error naming the key. |
+
+Note that an in-repo config executes what it configures: `post_worktree_commands` run after each worktree is created, `remote_hooks` and `program_overrides` values are invoked as shell commands. Cloning a repository and running `af` in it implies trusting that repo's `.agent-factory/config.json`. The first time a config carrying such fields loads (and whenever its content changes), `af` records one log line naming the fields and the file's content hash.
 
 ## Upstream
 

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -174,7 +174,7 @@ var sessionsCreateCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("session with title %q already exists", createNameFlag))
 		}
 
-		cfg, err := config.LoadConfig()
+		cfg, err := config.ResolveConfig(repo.Root)
 		if err != nil {
 			return jsonError(err)
 		}
@@ -321,7 +321,7 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 				return jsonError(fmt.Errorf("session with title %q already exists", title))
 			}
 
-			cfg, err := config.LoadConfig()
+			cfg, err := config.ResolveConfig(repo.Root)
 			if err != nil {
 				return jsonError(err)
 			}

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -121,7 +121,7 @@ var tasksAddCmd = &cobra.Command{
 
 		program := taskAddProgramFlag
 		if program == "" {
-			cfg, err := config.LoadConfig()
+			cfg, err := config.ResolveConfig(repo.Root)
 			if err != nil {
 				return jsonError(err)
 			}

--- a/app/app.go
+++ b/app/app.go
@@ -28,9 +28,9 @@ import (
 var Version string
 
 // Run is the main entrypoint into the application.
-func Run(ctx context.Context, program string, autoYes bool, repoID string) error {
+func Run(ctx context.Context, program string, autoYes bool, repo *config.RepoContext) error {
 	p := tea.NewProgram(
-		newHome(ctx, program, autoYes, repoID),
+		newHome(ctx, program, autoYes, repo),
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(), // Mouse scroll
 	)
@@ -64,6 +64,9 @@ type home struct {
 	program string
 	autoYes bool
 	repoID  string
+	// repoRoot is the main-worktree root of the repo this TUI run is scoped
+	// to. Used to resolve and persist the in-repo .agent-factory/config.json.
+	repoRoot string
 
 	// storage is the interface for saving/loading data to/from the app's state
 	storage *session.Storage
@@ -129,7 +132,8 @@ type home struct {
 	attached atomic.Bool
 }
 
-func newHome(ctx context.Context, program string, autoYes bool, repoID string) *home {
+func newHome(ctx context.Context, program string, autoYes bool, repo *config.RepoContext) *home {
+	repoID := repo.ID
 	// Load application config
 	appConfig, err := config.LoadConfig()
 	if err != nil {
@@ -170,6 +174,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repoID string) *
 		program:     program,
 		autoYes:     autoYes,
 		repoID:      repoID,
+		repoRoot:    repo.Root,
 		state:       stateDefault,
 		appState:    appState,
 	}
@@ -206,10 +211,11 @@ func newHome(ctx context.Context, program string, autoYes bool, repoID string) *
 		h.contentPane.TaskPane().SetTasks(tasks)
 	}
 
-	// Load hooks for sidebar display and hooks pane
-	repoCfg, err := config.LoadRepoConfig(repoID)
+	// Load hooks for sidebar display and hooks pane. ResolveConfig applies
+	// the in-repo .agent-factory/config.json over the legacy per-repo file.
+	repoCfg, err := config.ResolveConfig(repo.Root)
 	if err != nil {
-		log.WarningLog.Printf("failed to load repo config: %v", err)
+		log.WarningLog.Printf("failed to resolve repo config: %v", err)
 	} else {
 		h.sidebar.SetHookCount(len(repoCfg.PostWorktreeCommands))
 		h.contentPane.HooksPane().SetCommands(repoCfg.PostWorktreeCommands)
@@ -511,14 +517,14 @@ func (m *home) handleQuit() (tea.Model, tea.Cmd) {
 func (m *home) saveContentPaneState() {
 	hp := m.contentPane.HooksPane()
 	if hp.IsDirty() {
-		repoCfg, err := config.LoadRepoConfig(m.repoID)
-		if err != nil {
-			log.ErrorLog.Printf("failed to save hooks: could not load repo config: %v", err)
+		// Hook edits are written to the in-repo .agent-factory/config.json —
+		// the canonical location for post_worktree_commands since #800. The
+		// legacy ~/.agent-factory/repos/<id>/config.json stays untouched as a
+		// read-only fallback; the saved in-repo key (even when emptied)
+		// shadows it.
+		if err := config.SaveInRepoPostWorktreeCommands(m.repoRoot, hp.GetCommands()); err != nil {
+			log.ErrorLog.Printf("failed to save hooks: %v", err)
 		} else {
-			repoCfg.PostWorktreeCommands = hp.GetCommands()
-			if err := config.SaveRepoConfig(m.repoID, repoCfg); err != nil {
-				log.ErrorLog.Printf("failed to save hooks: %v", err)
-			}
 			m.sidebar.SetHookCount(len(hp.GetCommands()))
 		}
 	}

--- a/app/sync.go
+++ b/app/sync.go
@@ -397,18 +397,17 @@ func upsertInstanceDataByTitle(existing, incoming []session.InstanceData) []sess
 }
 
 func (m *home) importRemoteHookSessions() int {
-	repoCfg, err := config.LoadRepoConfig(m.repoID)
-	if err != nil {
-		log.WarningLog.Printf("failed to load repo config for remote import: %v", err)
-		return 0
-	}
-	if repoCfg.RemoteHooks == nil || repoCfg.RemoteHooks.ListCmd == "" {
-		return 0
-	}
-
 	repo, err := config.CurrentRepo()
 	if err != nil {
 		log.WarningLog.Printf("failed to resolve repo for remote import: %v", err)
+		return 0
+	}
+	repoCfg, err := config.ResolveConfig(repo.Root)
+	if err != nil {
+		log.WarningLog.Printf("failed to resolve repo config for remote import: %v", err)
+		return 0
+	}
+	if repoCfg.RemoteHooks == nil || repoCfg.RemoteHooks.ListCmd == "" {
 		return 0
 	}
 

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -1,0 +1,277 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// InRepoConfigDirName is the directory at a repository root that holds the
+// repo's own agent-factory configuration. It deliberately matches the name of
+// the global config directory (~/.agent-factory) so the two locations read as
+// the same concept at different scopes.
+const InRepoConfigDirName = ".agent-factory"
+
+// InRepoConfig is the subset of configuration a repository may declare for
+// itself in <repo-root>/.agent-factory/config.json. Repo-describing fields
+// (remote_hooks, post_worktree_commands) live here exclusively going forward;
+// preference fields (default_program, program_overrides) are valid both here
+// and in the global config, with the in-repo value winning. Global/daemon-only
+// keys are rejected by LoadInRepoConfig with an error naming the key.
+type InRepoConfig struct {
+	// DefaultProgram overrides the global default agent for sessions in this
+	// repo. Must be one of tmux.SupportedPrograms.
+	DefaultProgram string `json:"default_program,omitempty"`
+	// ProgramOverrides entries are merged key-wise over the global map: a key
+	// set here wins, global keys without an in-repo counterpart still apply.
+	ProgramOverrides map[string]string `json:"program_overrides,omitempty"`
+	// PostWorktreeCommands replaces (not appends to) any legacy per-repo
+	// value when the key is present in the file — including an explicit
+	// empty array, which disables legacy commands.
+	PostWorktreeCommands []string `json:"post_worktree_commands,omitempty"`
+	// RemoteHooks configures the remote hook backend for this repo.
+	RemoteHooks *RemoteHooks `json:"remote_hooks,omitempty"`
+
+	// setKeys records which top-level keys were present in the JSON file so
+	// the resolver can distinguish "set to an empty value" (overrides) from
+	// "absent" (falls through to the legacy/global value).
+	setKeys map[string]bool
+}
+
+// IsSet reports whether the given top-level JSON key was present in the
+// in-repo config file, even if its value was empty.
+func (c *InRepoConfig) IsSet(key string) bool {
+	return c != nil && c.setKeys[key]
+}
+
+// CommandBearingFields returns the sorted names of fields present in the
+// in-repo file whose values are executed as shell commands. Used for the
+// one-time "loaded in-repo config" observability log.
+func (c *InRepoConfig) CommandBearingFields() []string {
+	if c == nil {
+		return nil
+	}
+	var fields []string
+	for _, key := range []string{"post_worktree_commands", "program_overrides", "remote_hooks"} {
+		if c.setKeys[key] {
+			fields = append(fields, key)
+		}
+	}
+	sort.Strings(fields)
+	return fields
+}
+
+// inRepoAllowedKeys is the full set of top-level keys an in-repo config may
+// contain. Anything else is rejected so typos fail loudly instead of being
+// silently ignored in a file that can execute shell commands.
+var inRepoAllowedKeys = []string{
+	"default_program",
+	"post_worktree_commands",
+	"program_overrides",
+	"remote_hooks",
+}
+
+// inRepoGlobalOnlyKeys maps keys that configure the host or daemon — not the
+// repository — to rejection reasons. They are only meaningful machine-wide,
+// so an in-repo value would either silently do nothing or, worse, let a repo
+// flip host-level behavior like autoyes.
+var inRepoGlobalOnlyKeys = map[string]bool{
+	"auto_yes":             true,
+	"branch_prefix":        true,
+	"daemon_poll_interval": true,
+	"detach_keys":          true,
+	"worktree_root":        true,
+}
+
+// InRepoConfigPath returns the path of the in-repo config file for a repo
+// root. The file is optional; callers should use LoadInRepoConfig rather than
+// reading this path directly so symlink and file-type guards apply.
+func InRepoConfigPath(repoRoot string) string {
+	return filepath.Join(repoRoot, InRepoConfigDirName, ConfigFileName)
+}
+
+// InRepoConfigHash returns the sha256 hex digest of the raw in-repo config
+// file bytes. Used to detect content changes for the one-time load log.
+func InRepoConfigHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// readInRepoConfigFile locates and reads <repoRoot>/.agent-factory/config.json
+// with the path safety guards the location demands — the file ships inside a
+// repository, so it is attacker-influenced relative to the user's filesystem:
+//   - symlinks are resolved and the resolved file must still live inside the
+//     (resolved) repo root, so a link to ~/.ssh or /etc can never be read and
+//     reported back in error messages;
+//   - the resolved path must be a regular file;
+//   - a repo rooted at the user's home directory (dotfiles repos) would make
+//     the in-repo path collide with the global ~/.agent-factory/config.json —
+//     that case is treated as "no in-repo config" instead of re-reading the
+//     global file with in-repo scoping rules and rejecting its global keys.
+//
+// Returns (nil, nil) when the file does not exist.
+func readInRepoConfigFile(repoRoot string) ([]byte, error) {
+	path := InRepoConfigPath(repoRoot)
+	if _, err := os.Lstat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to stat in-repo config %s: %w", prettyHomePath(path), err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve in-repo config %s: %w", prettyHomePath(path), err)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve repo root %s: %w", repoRoot, err)
+	}
+	if !strings.HasPrefix(resolved, filepath.Clean(resolvedRoot)+string(filepath.Separator)) {
+		return nil, fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to read it", prettyHomePath(path), prettyHomePath(resolved))
+	}
+
+	if configDir, dirErr := GetConfigDir(); dirErr == nil {
+		globalPath := filepath.Join(configDir, ConfigFileName)
+		if resolvedGlobal, evalErr := filepath.EvalSymlinks(globalPath); evalErr == nil && resolvedGlobal == resolved {
+			return nil, nil
+		}
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat in-repo config %s: %w", prettyHomePath(path), err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("in-repo config %s is not a regular file", prettyHomePath(path))
+	}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read in-repo config %s: %w", prettyHomePath(path), err)
+	}
+	return data, nil
+}
+
+// LoadInRepoConfig reads and validates the in-repo config for a repo root.
+// Returns (nil, nil, nil) when the repo has no in-repo config file. When the
+// file exists it is returned together with its raw bytes (for content-hash
+// tracking). Mirroring the LoadConfig contract (#734), a file that exists but
+// cannot be read, parsed, or validated is an error — never silently ignored.
+func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
+	data, err := readInRepoConfigFile(repoRoot)
+	if err != nil || data == nil {
+		return nil, nil, err
+	}
+
+	prettyPath := prettyHomePath(InRepoConfigPath(repoRoot))
+	if len(data) == 0 {
+		return nil, nil, fmt.Errorf("in-repo config %s is empty; delete it or add valid JSON", prettyPath)
+	}
+
+	var rawKeys map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawKeys); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse in-repo config %s: %w", prettyPath, err)
+	}
+	for key := range rawKeys {
+		if inRepoGlobalOnlyKeys[key] {
+			return nil, nil, fmt.Errorf("in-repo config %s: %q is a global setting and cannot be set per-repo; move it to ~/.agent-factory/config.json and remove it from this file", prettyPath, key)
+		}
+		allowed := false
+		for _, k := range inRepoAllowedKeys {
+			if key == k {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return nil, nil, fmt.Errorf("in-repo config %s: unknown key %q (allowed keys: %s)", prettyPath, key, strings.Join(inRepoAllowedKeys, ", "))
+		}
+	}
+
+	var cfg InRepoConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse in-repo config %s: %w", prettyPath, err)
+	}
+	cfg.setKeys = make(map[string]bool, len(rawKeys))
+	for key := range rawKeys {
+		cfg.setKeys[key] = true
+	}
+
+	if cfg.DefaultProgram != "" {
+		if err := ValidateProgramEnum(
+			fmt.Sprintf("Config issue in %s: default_program", prettyPath),
+			"default_program",
+			cfg.DefaultProgram,
+			"",
+		); err != nil {
+			return nil, nil, err
+		}
+	}
+	for key, value := range cfg.ProgramOverrides {
+		if err := ValidateProgramEnum(
+			fmt.Sprintf("Config issue in %s: program_overrides key", prettyPath),
+			"program_overrides key",
+			key,
+			value,
+		); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return &cfg, data, nil
+}
+
+// SaveInRepoPostWorktreeCommands writes the given post-worktree commands into
+// the repo's in-repo config file — the canonical location for this field
+// since #800 — creating the file if needed and preserving every other field
+// verbatim. The key is always written, even for an empty list, because a
+// present-but-empty key is how an in-repo file overrides (disables) commands
+// still lingering in the legacy ~/.agent-factory/repos/<id>/config.json.
+func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
+	if repoRoot == "" {
+		return fmt.Errorf("repo root is required to save in-repo config")
+	}
+	path := InRepoConfigPath(repoRoot)
+	// A repo rooted at the user's home directory makes the in-repo path
+	// collide with the global config file; writing hooks there would clobber
+	// the user's global settings.
+	if configDir, dirErr := GetConfigDir(); dirErr == nil {
+		if filepath.Clean(path) == filepath.Clean(filepath.Join(configDir, ConfigFileName)) {
+			return fmt.Errorf("in-repo config path %s collides with the global config file; not saving", prettyHomePath(path))
+		}
+	}
+	data, err := readInRepoConfigFile(repoRoot)
+	if err != nil {
+		return err
+	}
+	rawKeys := map[string]json.RawMessage{}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &rawKeys); err != nil {
+			return fmt.Errorf("failed to parse in-repo config %s: %w", prettyHomePath(InRepoConfigPath(repoRoot)), err)
+		}
+	}
+	if commands == nil {
+		commands = []string{}
+	}
+	encoded, err := json.Marshal(commands)
+	if err != nil {
+		return fmt.Errorf("failed to marshal post_worktree_commands: %w", err)
+	}
+	rawKeys["post_worktree_commands"] = encoded
+
+	out, err := json.MarshalIndent(rawKeys, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal in-repo config: %w", err)
+	}
+	dir := filepath.Join(repoRoot, InRepoConfigDirName)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create %s: %w", dir, err)
+	}
+	return AtomicWriteFile(InRepoConfigPath(repoRoot), out, 0644)
+}

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -1,0 +1,238 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeInRepoConfig materializes <repoRoot>/.agent-factory/config.json with
+// the given content and returns its path.
+func writeInRepoConfig(t *testing.T, repoRoot, content string) string {
+	t.Helper()
+	dir := filepath.Join(repoRoot, InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	path := filepath.Join(dir, ConfigFileName)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}
+
+func TestLoadInRepoConfigAbsent(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	cfg, raw, err := LoadInRepoConfig(t.TempDir())
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+	assert.Nil(t, raw)
+}
+
+func TestLoadInRepoConfigFields(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	writeInRepoConfig(t, repoRoot, `{
+		"default_program": "aider",
+		"program_overrides": {"codex": "/opt/codex --fast"},
+		"post_worktree_commands": ["npm install"],
+		"remote_hooks": {"launch_cmd": "l", "list_cmd": "ls", "attach_cmd": "a", "delete_cmd": "d"}
+	}`)
+
+	cfg, raw, err := LoadInRepoConfig(repoRoot)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.NotEmpty(t, raw)
+	assert.Equal(t, "aider", cfg.DefaultProgram)
+	assert.Equal(t, "/opt/codex --fast", cfg.ProgramOverrides["codex"])
+	assert.Equal(t, []string{"npm install"}, cfg.PostWorktreeCommands)
+	require.NotNil(t, cfg.RemoteHooks)
+	assert.Equal(t, "l", cfg.RemoteHooks.LaunchCmd)
+	for _, key := range []string{"default_program", "program_overrides", "post_worktree_commands", "remote_hooks"} {
+		assert.True(t, cfg.IsSet(key), "expected %s to be marked set", key)
+	}
+	assert.Equal(t, []string{"post_worktree_commands", "program_overrides", "remote_hooks"}, cfg.CommandBearingFields())
+}
+
+func TestLoadInRepoConfigEmptyValueIsSet(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	writeInRepoConfig(t, repoRoot, `{"post_worktree_commands": []}`)
+
+	cfg, _, err := LoadInRepoConfig(repoRoot)
+	require.NoError(t, err)
+	assert.True(t, cfg.IsSet("post_worktree_commands"))
+	assert.Empty(t, cfg.PostWorktreeCommands)
+	assert.False(t, cfg.IsSet("remote_hooks"))
+}
+
+func TestLoadInRepoConfigRejectsGlobalOnlyKeys(t *testing.T) {
+	for _, key := range []string{"auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "worktree_root"} {
+		t.Run(key, func(t *testing.T) {
+			t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+			repoRoot := t.TempDir()
+			writeInRepoConfig(t, repoRoot, `{"`+key+`": "x"}`)
+
+			_, _, err := LoadInRepoConfig(repoRoot)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), key)
+			assert.Contains(t, err.Error(), "global setting")
+			assert.Contains(t, err.Error(), "~/.agent-factory/config.json")
+		})
+	}
+}
+
+func TestLoadInRepoConfigRejectsUnknownKeys(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	writeInRepoConfig(t, repoRoot, `{"post_worktree_cmds": ["typo"]}`)
+
+	_, _, err := LoadInRepoConfig(repoRoot)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "post_worktree_cmds")
+	assert.Contains(t, err.Error(), "allowed keys")
+}
+
+func TestLoadInRepoConfigValidatesProgramEnums(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("default_program with flags", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoConfig(t, repoRoot, `{"default_program": "claude --model opus"}`)
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "program_overrides")
+	})
+
+	t.Run("program_overrides unknown agent key", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoConfig(t, repoRoot, `{"program_overrides": {"not-an-agent": "/bin/x"}}`)
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not-an-agent")
+	})
+}
+
+func TestLoadInRepoConfigMalformed(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("empty file", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoConfig(t, repoRoot, "")
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoConfig(t, repoRoot, "{not json")
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse")
+	})
+}
+
+func TestLoadInRepoConfigTraversalSafety(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("symlinked file outside repo is rejected", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		outside := filepath.Join(t.TempDir(), "outside.json")
+		require.NoError(t, os.WriteFile(outside, []byte(`{"post_worktree_commands": ["evil"]}`), 0644))
+		require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, InRepoConfigDirName), 0755))
+		require.NoError(t, os.Symlink(outside, InRepoConfigPath(repoRoot)))
+
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the repository")
+	})
+
+	t.Run("symlinked .agent-factory dir outside repo is rejected", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		outsideDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(outsideDir, ConfigFileName), []byte(`{}`), 0644))
+		require.NoError(t, os.Symlink(outsideDir, filepath.Join(repoRoot, InRepoConfigDirName)))
+
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the repository")
+	})
+
+	t.Run("config path that is a directory is rejected", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		require.NoError(t, os.MkdirAll(InRepoConfigPath(repoRoot), 0755))
+
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a regular file")
+	})
+
+	t.Run("symlink that stays inside the repo is allowed", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		real := filepath.Join(repoRoot, "shared-config.json")
+		require.NoError(t, os.WriteFile(real, []byte(`{"default_program": "codex"}`), 0644))
+		require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, InRepoConfigDirName), 0755))
+		require.NoError(t, os.Symlink(real, InRepoConfigPath(repoRoot)))
+
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, "codex", cfg.DefaultProgram)
+	})
+}
+
+// TestLoadInRepoConfigHomeRepoCollision covers a dotfiles-style repo rooted at
+// the config home: the in-repo path coincides with the global config file,
+// which must be treated as "no in-repo config" — not parsed under in-repo
+// scoping rules (which would reject its global keys).
+func TestLoadInRepoConfigHomeRepoCollision(t *testing.T) {
+	repoRoot := t.TempDir()
+	configHome := filepath.Join(repoRoot, InRepoConfigDirName)
+	t.Setenv("AGENT_FACTORY_HOME", configHome)
+	require.NoError(t, os.MkdirAll(configHome, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(configHome, ConfigFileName), []byte(`{"default_program": "claude", "auto_yes": true}`), 0644))
+
+	cfg, raw, err := LoadInRepoConfig(repoRoot)
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+	assert.Nil(t, raw)
+
+	err = SaveInRepoPostWorktreeCommands(repoRoot, []string{"echo hi"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collides")
+}
+
+func TestSaveInRepoPostWorktreeCommands(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("creates file and round-trips", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		require.NoError(t, SaveInRepoPostWorktreeCommands(repoRoot, []string{"make setup"}))
+
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"make setup"}, cfg.PostWorktreeCommands)
+	})
+
+	t.Run("preserves other fields", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoConfig(t, repoRoot, `{"default_program": "gemini", "remote_hooks": {"launch_cmd": "l", "attach_cmd": "a", "delete_cmd": "d"}}`)
+		require.NoError(t, SaveInRepoPostWorktreeCommands(repoRoot, []string{"go generate ./..."}))
+
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, "gemini", cfg.DefaultProgram)
+		require.NotNil(t, cfg.RemoteHooks)
+		assert.Equal(t, "l", cfg.RemoteHooks.LaunchCmd)
+		assert.Equal(t, []string{"go generate ./..."}, cfg.PostWorktreeCommands)
+	})
+
+	t.Run("empty list is written as an explicit key", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		require.NoError(t, SaveInRepoPostWorktreeCommands(repoRoot, nil))
+
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.True(t, cfg.IsSet("post_worktree_commands"))
+		assert.Empty(t, cfg.PostWorktreeCommands)
+	})
+}

--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -55,29 +55,43 @@ type RepoConfig struct {
 	RemoteHooks *RemoteHooks `json:"remote_hooks,omitempty"`
 }
 
-// repoConfigPath validates repoID and returns the per-repo config file path.
-// Mirrors the validation + containment guard from repoInstancesPath so the
-// "repos/" tree is held to the same boundary as "instances/".
-func repoConfigPath(repoID string) (string, string, error) {
+// repoStateDir validates repoID and returns the per-repo state directory
+// (~/.agent-factory/repos/<id>). Mirrors the validation + containment guard
+// from repoInstancesPath so the "repos/" tree is held to the same boundary as
+// "instances/".
+func repoStateDir(repoID string) (string, error) {
 	if err := ValidateRepoID(repoID); err != nil {
-		return "", "", err
+		return "", err
 	}
 	configDir, err := GetConfigDir()
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get config dir: %w", err)
+		return "", fmt.Errorf("failed to get config dir: %w", err)
 	}
 	parent := filepath.Join(configDir, "repos")
 	dir := filepath.Join(parent, repoID)
-	path := filepath.Join(dir, RepoConfigFileName)
 	cleanParent := filepath.Clean(parent) + string(filepath.Separator)
-	if !strings.HasPrefix(filepath.Clean(path), cleanParent) {
-		return "", "", fmt.Errorf("invalid repo id: resolved path escapes repos directory")
+	if !strings.HasPrefix(filepath.Clean(dir)+string(filepath.Separator), cleanParent) {
+		return "", fmt.Errorf("invalid repo id: resolved path escapes repos directory")
 	}
-	return dir, path, nil
+	return dir, nil
+}
+
+// repoConfigPath validates repoID and returns the per-repo config file path.
+func repoConfigPath(repoID string) (string, string, error) {
+	dir, err := repoStateDir(repoID)
+	if err != nil {
+		return "", "", err
+	}
+	return dir, filepath.Join(dir, RepoConfigFileName), nil
 }
 
 // LoadRepoConfig loads the per-repo config for the given repo ID.
 // Returns an empty config (not an error) if none exists.
+//
+// Legacy location: ~/.agent-factory/repos/<id>/config.json is superseded by
+// the in-repo .agent-factory/config.json (#800) and is read for one more
+// release as a fallback. Consumers must use ResolveConfig, which applies the
+// in-repo file over this one; do not read this directly.
 func LoadRepoConfig(repoID string) (*RepoConfig, error) {
 	_, path, err := repoConfigPath(repoID)
 	if err != nil {
@@ -98,6 +112,9 @@ func LoadRepoConfig(repoID string) (*RepoConfig, error) {
 }
 
 // SaveRepoConfig saves the per-repo config for the given repo ID.
+//
+// Legacy location: see LoadRepoConfig — new code writes the in-repo file
+// (e.g. SaveInRepoPostWorktreeCommands) instead of this legacy location.
 func SaveRepoConfig(repoID string, cfg *RepoConfig) error {
 	dir, path, err := repoConfigPath(repoID)
 	if err != nil {

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// inRepoHashFileName is the per-repo state file holding the sha256 of the
+// last in-repo config content that was announced in the log. Observability
+// only — it gates nothing.
+const inRepoHashFileName = "inrepo-config-hash"
+
+// legacyDeprecationLogged dedupes the legacy-location deprecation warning to
+// once per repo per process.
+var legacyDeprecationLogged sync.Map
+
+// ResolvedConfig is the effective configuration for one repository: app
+// defaults overlaid by the global ~/.agent-factory/config.json overlaid by
+// the repo's own .agent-factory/config.json. Every consumer of per-repo
+// configuration (programs, remote hooks, post-worktree commands) must go
+// through ResolveConfig rather than reading LoadConfig/LoadRepoConfig
+// directly, so the precedence and scoping rules apply uniformly.
+type ResolvedConfig struct {
+	// Config carries the effective app-level fields. DefaultProgram and
+	// ProgramOverrides may have been overridden/merged from the in-repo
+	// file; the global-only fields (AutoYes, DaemonPollInterval,
+	// BranchPrefix, DetachKeys) always come from the global config because
+	// LoadInRepoConfig rejects them per-repo.
+	Config
+
+	// PostWorktreeCommands are the effective post-worktree hooks: the
+	// in-repo value when its key is present (even empty), otherwise the
+	// legacy ~/.agent-factory/repos/<id>/config.json value.
+	PostWorktreeCommands []string
+	// RemoteHooks is the effective remote hook backend config, with the
+	// same in-repo-then-legacy resolution as PostWorktreeCommands.
+	RemoteHooks *RemoteHooks
+}
+
+// ResolveConfig returns the effective configuration for the repository
+// rooted at repoRoot (the main worktree root, as returned by
+// config.RepoFromPath / CurrentRepo).
+//
+// Precedence is app defaults -> global config -> in-repo config, merged
+// field-wise: an in-repo field overrides the lower layers only when set.
+// program_overrides merges key-wise — an in-repo entry wins per agent,
+// global entries without an in-repo counterpart still apply.
+//
+// remote_hooks and post_worktree_commands are in-repo-only going forward;
+// values still in the legacy per-repo location keep working for one release
+// (with a deprecation warning) and are shadowed whenever the in-repo file
+// sets the same key.
+func ResolveConfig(repoRoot string) (*ResolvedConfig, error) {
+	global, err := LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	res := &ResolvedConfig{Config: *global}
+	// The overrides map is merged into below; copy it so a resolved config
+	// never aliases (and can never mutate) the loaded global config.
+	res.ProgramOverrides = make(map[string]string, len(global.ProgramOverrides))
+	for k, v := range global.ProgramOverrides {
+		res.ProgramOverrides[k] = v
+	}
+
+	repoID := RepoIDFromRoot(repoRoot)
+	legacy, err := LoadRepoConfig(repoID)
+	if err != nil {
+		return nil, err
+	}
+	res.PostWorktreeCommands = legacy.PostWorktreeCommands
+	res.RemoteHooks = legacy.RemoteHooks
+
+	inRepo, raw, err := LoadInRepoConfig(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if inRepo != nil {
+		if inRepo.DefaultProgram != "" {
+			res.DefaultProgram = inRepo.DefaultProgram
+		}
+		for k, v := range inRepo.ProgramOverrides {
+			res.ProgramOverrides[k] = v
+		}
+		if inRepo.IsSet("post_worktree_commands") {
+			res.PostWorktreeCommands = inRepo.PostWorktreeCommands
+		}
+		if inRepo.IsSet("remote_hooks") {
+			res.RemoteHooks = inRepo.RemoteHooks
+		}
+		logInRepoConfigLoaded(repoID, repoRoot, inRepo, raw)
+	}
+
+	warnLegacyRepoConfig(repoID, repoRoot, legacy, inRepo)
+	return res, nil
+}
+
+// logInRepoConfigLoaded emits one INFO line the first time a command-bearing
+// in-repo config is seen for a repo, and again whenever its content hash
+// changes. The last-announced hash is tracked in the per-repo state dir
+// purely to decide when to re-log; it gates nothing.
+func logInRepoConfigLoaded(repoID, repoRoot string, inRepo *InRepoConfig, raw []byte) {
+	fields := inRepo.CommandBearingFields()
+	if len(fields) == 0 {
+		return
+	}
+	hash := InRepoConfigHash(raw)
+	dir, err := repoStateDir(repoID)
+	if err != nil {
+		log.WarningLog.Printf("failed to resolve state dir for repo %s: %v", repoID, err)
+		return
+	}
+	hashPath := filepath.Join(dir, inRepoHashFileName)
+	if prev, err := os.ReadFile(hashPath); err == nil && strings.TrimSpace(string(prev)) == hash {
+		return
+	}
+	log.InfoLog.Printf("loaded in-repo config for %s: %s (sha256 %s)", repoRoot, strings.Join(fields, ", "), hash[:8])
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.WarningLog.Printf("failed to create repo state dir %s: %v", dir, err)
+		return
+	}
+	if err := AtomicWriteFile(hashPath, []byte(hash+"\n"), 0644); err != nil {
+		log.WarningLog.Printf("failed to record in-repo config hash for %s: %v", repoRoot, err)
+	}
+}
+
+// warnLegacyRepoConfig logs (once per repo per process) when fields from the
+// deprecated legacy location are still in effect — i.e. present there and not
+// shadowed by the in-repo file. The legacy location keeps working for one
+// release so existing setups don't break mid-upgrade (#800).
+func warnLegacyRepoConfig(repoID, repoRoot string, legacy *RepoConfig, inRepo *InRepoConfig) {
+	var fields []string
+	if len(legacy.PostWorktreeCommands) > 0 && !inRepo.IsSet("post_worktree_commands") {
+		fields = append(fields, "post_worktree_commands")
+	}
+	if legacy.RemoteHooks != nil && !inRepo.IsSet("remote_hooks") {
+		fields = append(fields, "remote_hooks")
+	}
+	if len(fields) == 0 {
+		return
+	}
+	if _, loaded := legacyDeprecationLogged.LoadOrStore(repoID, true); loaded {
+		return
+	}
+	legacyPath := fmt.Sprintf("~/.agent-factory/repos/%s/%s", repoID, RepoConfigFileName)
+	log.WarningLog.Printf("deprecated: %s is still read from %s; move it to %s — the legacy location stops working in a future release",
+		strings.Join(fields, ", "), legacyPath, InRepoConfigPath(repoRoot))
+}

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -1,0 +1,223 @@
+package config
+
+import (
+	"bytes"
+	stdlog "log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	aflog "github.com/sachiniyer/agent-factory/log"
+)
+
+// setupResolveTest gives the test a hermetic config home with an explicit
+// global config (so LoadConfig never materializes machine-detected defaults
+// into assertions) and a fresh repo root.
+func setupResolveTest(t *testing.T, globalConfig string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	// LoadConfig probes the user's shell for a claude alias on every call;
+	// an interactive bash probe costs seconds. A plain sh takes the fast
+	// `which` path and keeps the resolver tests snappy.
+	t.Setenv("SHELL", "/bin/sh")
+	require.NoError(t, os.WriteFile(filepath.Join(home, ConfigFileName), []byte(globalConfig), 0644))
+	return t.TempDir()
+}
+
+// captureLog redirects the given project logger to a buffer for the test.
+func captureLog(t *testing.T, logger **stdlog.Logger) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	old := *logger
+	*logger = stdlog.New(&buf, "", 0)
+	t.Cleanup(func() { *logger = old })
+	return &buf
+}
+
+func TestResolveConfigPrecedence(t *testing.T) {
+	t.Run("global applies when no in-repo file", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "codex"}`)
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, "codex", res.DefaultProgram)
+	})
+
+	t.Run("in-repo default_program overrides global", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "codex"}`)
+		writeInRepoConfig(t, repoRoot, `{"default_program": "aider"}`)
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, "aider", res.DefaultProgram)
+	})
+
+	t.Run("in-repo file without default_program keeps global", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "codex"}`)
+		writeInRepoConfig(t, repoRoot, `{"post_worktree_commands": ["true"]}`)
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, "codex", res.DefaultProgram)
+	})
+
+	t.Run("program_overrides merge key-wise", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "claude", "program_overrides": {"codex": "/opt/codex", "aider": "/opt/aider"}}`)
+		writeInRepoConfig(t, repoRoot, `{"program_overrides": {"codex": "/repo/codex --fast", "gemini": "/repo/gemini"}}`)
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, "/repo/codex --fast", res.ProgramOverrides["codex"], "in-repo entry wins per key")
+		assert.Equal(t, "/opt/aider", res.ProgramOverrides["aider"], "global entry without in-repo counterpart survives")
+		assert.Equal(t, "/repo/gemini", res.ProgramOverrides["gemini"], "in-repo-only entry applies")
+	})
+
+	t.Run("global-only fields always come from global", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "claude", "auto_yes": true, "branch_prefix": "team/", "detach_keys": "ctrl-q"}`)
+		writeInRepoConfig(t, repoRoot, `{"default_program": "gemini"}`)
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.True(t, res.AutoYes)
+		assert.Equal(t, "team/", res.BranchPrefix)
+		assert.Equal(t, "ctrl-q", res.DetachKeys)
+	})
+
+	t.Run("in-repo validation errors propagate", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+		writeInRepoConfig(t, repoRoot, `{"auto_yes": true}`)
+
+		_, err := ResolveConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auto_yes")
+	})
+}
+
+func TestResolveConfigRepoFields(t *testing.T) {
+	hooks := &RemoteHooks{LaunchCmd: "l", ListCmd: "ls", AttachCmd: "a", DeleteCmd: "d"}
+
+	t.Run("in-repo values apply", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+		writeInRepoConfig(t, repoRoot, `{"post_worktree_commands": ["npm ci"], "remote_hooks": {"launch_cmd": "l2", "attach_cmd": "a2", "delete_cmd": "d2"}}`)
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"npm ci"}, res.PostWorktreeCommands)
+		require.NotNil(t, res.RemoteHooks)
+		assert.Equal(t, "l2", res.RemoteHooks.LaunchCmd)
+	})
+
+	t.Run("legacy location still works as fallback", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+		repoID := RepoIDFromRoot(repoRoot)
+		require.NoError(t, SaveRepoConfig(repoID, &RepoConfig{
+			PostWorktreeCommands: []string{"legacy-cmd"},
+			RemoteHooks:          hooks,
+		}))
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"legacy-cmd"}, res.PostWorktreeCommands)
+		require.NotNil(t, res.RemoteHooks)
+		assert.Equal(t, "l", res.RemoteHooks.LaunchCmd)
+	})
+
+	t.Run("in-repo shadows legacy", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+		repoID := RepoIDFromRoot(repoRoot)
+		require.NoError(t, SaveRepoConfig(repoID, &RepoConfig{
+			PostWorktreeCommands: []string{"legacy-cmd"},
+			RemoteHooks:          hooks,
+		}))
+		writeInRepoConfig(t, repoRoot, `{"post_worktree_commands": ["new-cmd"], "remote_hooks": {"launch_cmd": "l2", "attach_cmd": "a2", "delete_cmd": "d2"}}`)
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"new-cmd"}, res.PostWorktreeCommands)
+		assert.Equal(t, "l2", res.RemoteHooks.LaunchCmd)
+	})
+
+	t.Run("explicit empty in-repo key disables legacy value", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+		repoID := RepoIDFromRoot(repoRoot)
+		require.NoError(t, SaveRepoConfig(repoID, &RepoConfig{PostWorktreeCommands: []string{"legacy-cmd"}}))
+		writeInRepoConfig(t, repoRoot, `{"post_worktree_commands": []}`)
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Empty(t, res.PostWorktreeCommands)
+	})
+}
+
+func TestResolveConfigLegacyDeprecationLog(t *testing.T) {
+	buf := captureLog(t, &aflog.WarningLog)
+	repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+	repoID := RepoIDFromRoot(repoRoot)
+	require.NoError(t, SaveRepoConfig(repoID, &RepoConfig{PostWorktreeCommands: []string{"legacy-cmd"}}))
+
+	_, err := ResolveConfig(repoRoot)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "deprecated")
+	assert.Contains(t, buf.String(), "post_worktree_commands")
+	assert.Contains(t, buf.String(), InRepoConfigPath(repoRoot))
+
+	// Once per repo per process: a second resolve stays quiet.
+	buf.Reset()
+	_, err = ResolveConfig(repoRoot)
+	require.NoError(t, err)
+	assert.NotContains(t, buf.String(), "deprecated")
+}
+
+func TestResolveConfigInRepoLoadLog(t *testing.T) {
+	t.Run("command-bearing config logs once and again on change", func(t *testing.T) {
+		buf := captureLog(t, &aflog.InfoLog)
+		repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+		writeInRepoConfig(t, repoRoot, `{"post_worktree_commands": ["npm ci"]}`)
+
+		_, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "loaded in-repo config for "+repoRoot)
+		assert.Contains(t, buf.String(), "post_worktree_commands")
+
+		// Same content: no re-log.
+		buf.Reset()
+		_, err = ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.NotContains(t, buf.String(), "loaded in-repo config")
+
+		// Changed content: logs again with the new field list.
+		writeInRepoConfig(t, repoRoot, `{"post_worktree_commands": ["npm ci"], "remote_hooks": {"launch_cmd": "l", "attach_cmd": "a", "delete_cmd": "d"}}`)
+		_, err = ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "loaded in-repo config")
+		assert.Contains(t, buf.String(), "remote_hooks")
+	})
+
+	t.Run("preference-only config does not log", func(t *testing.T) {
+		buf := captureLog(t, &aflog.InfoLog)
+		repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+		writeInRepoConfig(t, repoRoot, `{"default_program": "codex"}`)
+
+		_, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		assert.NotContains(t, buf.String(), "loaded in-repo config")
+	})
+}
+
+// TestResolveConfigDoesNotMutateGlobal guards the map copy in ResolveConfig:
+// merging in-repo program_overrides must never write through to the global
+// config that LoadConfig callers see.
+func TestResolveConfigDoesNotMutateGlobal(t *testing.T) {
+	repoRoot := setupResolveTest(t, `{"default_program": "claude", "program_overrides": {"codex": "/opt/codex"}}`)
+	writeInRepoConfig(t, repoRoot, `{"program_overrides": {"codex": "/repo/codex"}}`)
+
+	_, err := ResolveConfig(repoRoot)
+	require.NoError(t, err)
+
+	global, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "/opt/codex", global.ProgramOverrides["codex"])
+}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -598,7 +598,19 @@ func (m *Manager) refreshLocked() error {
 
 func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData, error) {
 	if req.Program == "" {
+		// Default from the repo-resolved config so an in-repo
+		// default_program applies to daemon-created sessions (task runs,
+		// API creates) too. Falls back to the daemon's global config when
+		// the repo path can't be resolved — reserveCreate will surface
+		// that error with more context right after.
 		req.Program = m.cfg.DefaultProgram
+		if req.RepoPath != "" {
+			if repo, err := config.RepoFromPath(req.RepoPath); err == nil {
+				if resolved, rerr := config.ResolveConfig(repo.Root); rerr == nil {
+					req.Program = resolved.DefaultProgram
+				}
+			}
+		}
 	}
 	repo, title, release, err := m.reserveCreate(req)
 	if err != nil {
@@ -952,7 +964,7 @@ func (m *Manager) ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest) 
 	if err != nil {
 		return nil, err
 	}
-	repoCfg, err := config.LoadRepoConfig(repo.ID)
+	repoCfg, err := config.ResolveConfig(repo.Root)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -4,7 +4,7 @@ Agent Factory supports remote machine backends via user-provided hook scripts. W
 
 ## Configuration
 
-Add remote hooks to your per-repo config at `~/.agent-factory/repos/<repoID>/config.json`:
+Add remote hooks to the repo's own config file at `<repo-root>/.agent-factory/config.json` (check it into the repo so every clone gets the same backend):
 
 ```json
 {
@@ -16,6 +16,8 @@ Add remote hooks to your per-repo config at `~/.agent-factory/repos/<repoID>/con
   }
 }
 ```
+
+`remote_hooks` is an in-repo-only setting — it describes the repository, so it is not accepted in the global `~/.agent-factory/config.json`. The previous location, `~/.agent-factory/repos/<repoID>/config.json`, is **deprecated**: it keeps working for one more release as a fallback (with a warning in the log pointing here), and is ignored whenever the in-repo file sets `remote_hooks`. See the README's [Configuration](../README.md#configuration) section for the full precedence rules.
 
 Configuring `remote_hooks` enables the remote backend for that repo, but using it is explicit opt-in: press `N` in the TUI to create a remote session. Pressing `n` still creates a local tmux+git worktree session. When `remote_hooks` is absent, `N` is unavailable and all sessions are local.
 

--- a/examples/remote-hooks/README.md
+++ b/examples/remote-hooks/README.md
@@ -21,7 +21,7 @@ chmod +x /path/to/your/hooks/*.sh
 # Edit each script to add your infrastructure logic
 ```
 
-Then configure your repo to use them:
+Then configure your repo to use them in `<repo-root>/.agent-factory/config.json`:
 
 ```json
 {

--- a/main.go
+++ b/main.go
@@ -61,7 +61,10 @@ var (
 				return fmt.Errorf("failed to determine repo context: %w", err)
 			}
 
-			cfg, err := config.LoadConfig()
+			// Resolve the effective config for this repo: app defaults ->
+			// global ~/.agent-factory/config.json -> the repo's own
+			// .agent-factory/config.json (#800).
+			cfg, err := config.ResolveConfig(repo.Root)
 			if err != nil {
 				return err
 			}
@@ -96,7 +99,7 @@ var (
 			autoUpdateInBackground()
 
 			app.Version = version
-			return app.Run(ctx, program, autoYes, repo.ID)
+			return app.Run(ctx, program, autoYes, repo)
 		},
 	}
 

--- a/session/backend_e2e_test.go
+++ b/session/backend_e2e_test.go
@@ -410,3 +410,44 @@ func readStateFile(t *testing.T, _ string) []map[string]interface{} {
 	require.NoError(t, json.Unmarshal(raw, &sessions))
 	return sessions
 }
+
+// TestE2EBackendResolutionWithInRepoConfig verifies that backendForPath reads
+// the in-repo .agent-factory/config.json (#800) and that it shadows the
+// legacy per-repo location.
+func TestE2EBackendResolutionWithInRepoConfig(t *testing.T) {
+	afHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "--local", "user.email", "test@inrepo.com")
+	runGit(t, repoDir, "config", "--local", "user.name", "InRepo Test")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "f.txt"), []byte("x"), 0644))
+	runGit(t, repoDir, "add", "f.txt")
+	runGit(t, repoDir, "commit", "-m", "init")
+
+	// In-repo remote_hooks alone resolve the remote backend.
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, config.InRepoConfigDirName), 0755))
+	require.NoError(t, os.WriteFile(config.InRepoConfigPath(repoDir),
+		[]byte(`{"remote_hooks": {"launch_cmd": "/bin/echo in-repo", "list_cmd": "/bin/echo", "attach_cmd": "/bin/echo", "delete_cmd": "/bin/echo"}}`), 0644))
+
+	b, err := backendForPath(repoDir)
+	require.NoError(t, err)
+	require.Equal(t, "remote", b.Type())
+
+	// A conflicting legacy config is shadowed by the in-repo file.
+	repo, err := config.RepoFromPath(repoDir)
+	require.NoError(t, err)
+	require.NoError(t, config.SaveRepoConfig(repo.ID, &config.RepoConfig{
+		RemoteHooks: &config.RemoteHooks{
+			LaunchCmd: "/bin/echo legacy",
+			ListCmd:   "/bin/echo",
+			AttachCmd: "/bin/echo",
+			DeleteCmd: "/bin/echo",
+		},
+	}))
+
+	hook, err := loadHookBackendForPath(repoDir)
+	require.NoError(t, err)
+	assert.Equal(t, "/bin/echo in-repo", hook.Hooks.LaunchCmd)
+}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -12,17 +12,32 @@ import (
 
 // resolveProgramForInstance returns the actual tmux command for an instance.
 // Resolution chain: agent enum -> cfg.ProgramOverrides[agent] (if set) ->
-// bare agent name. When AutoYes is set on a claude instance, the
-// --permission-mode bypassPermissions flag is appended to the resolved
-// command — claude needs the flag at exec time, and Instance.Program now
-// holds only the bare enum so the append can no longer happen in main.go.
-// A nil cfg (e.g. tests that don't materialize a config) falls back to the
-// raw Program string so legacy free-form values still reach tmux verbatim.
+// bare agent name. The overrides come from the repo-resolved config (global
+// program_overrides merged with the repo's .agent-factory/config.json) when
+// the instance path belongs to a git repo; outside a repo, or when repo
+// resolution fails, the global config alone applies. When AutoYes is set on a
+// claude instance, the --permission-mode bypassPermissions flag is appended
+// to the resolved command — claude needs the flag at exec time, and
+// Instance.Program now holds only the bare enum so the append can no longer
+// happen in main.go. A nil cfg (e.g. tests that don't materialize a config)
+// falls back to the raw Program string so legacy free-form values still
+// reach tmux verbatim.
 func resolveProgramForInstance(i *Instance) string {
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		log.WarningLog.Printf("failed to load config when resolving program for %q: %v", i.Title, err)
-		cfg = nil
+	var cfg *config.Config
+	if repo, err := config.RepoFromPath(i.Path); err == nil {
+		if resolved, rerr := config.ResolveConfig(repo.Root); rerr == nil {
+			cfg = &resolved.Config
+		} else {
+			log.WarningLog.Printf("failed to resolve repo config when resolving program for %q: %v", i.Title, rerr)
+		}
+	}
+	if cfg == nil {
+		loaded, err := config.LoadConfig()
+		if err != nil {
+			log.WarningLog.Printf("failed to load config when resolving program for %q: %v", i.Title, err)
+			loaded = nil
+		}
+		cfg = loaded
 	}
 	resolved := config.ResolveProgram(cfg, i.Program)
 	if i.AutoYes && DetectAgentFromProgram(i.Program) == tmux.ProgramClaude {

--- a/session/backend_resolve.go
+++ b/session/backend_resolve.go
@@ -7,21 +7,17 @@ import (
 )
 
 // backendForPath returns the appropriate Backend for the given workspace path
-// by checking whether a remote hooks config exists for the repo.
+// by resolving the repo's effective config (in-repo .agent-factory/config.json
+// over the legacy per-repo location) and checking for remote hooks.
 func backendForPath(absPath string) (Backend, error) {
 	repo, err := config.RepoFromPath(absPath)
 	if err != nil {
 		// Not a git repo or can't resolve — default to local.
 		return &LocalBackend{}, nil
 	}
-	return backendForRepoID(repo.ID)
-}
-
-// backendForRepoID returns the appropriate Backend for a given repo ID.
-func backendForRepoID(repoID string) (Backend, error) {
-	cfg, err := config.LoadRepoConfig(repoID)
+	cfg, err := config.ResolveConfig(repo.Root)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load repo config: %w", err)
+		return nil, fmt.Errorf("failed to resolve repo config: %w", err)
 	}
 	if cfg.RemoteHooks != nil {
 		if err := cfg.RemoteHooks.Validate(); err != nil {
@@ -39,9 +35,9 @@ func loadHookBackendForPath(absPath string) (*HookBackend, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve repo: %w", err)
 	}
-	cfg, err := config.LoadRepoConfig(repo.ID)
+	cfg, err := config.ResolveConfig(repo.Root)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load repo config: %w", err)
+		return nil, fmt.Errorf("failed to resolve repo config: %w", err)
 	}
 	if cfg.RemoteHooks == nil {
 		return nil, fmt.Errorf("no remote hooks configured for repo %s", repo.ID)

--- a/session/git/hooks.go
+++ b/session/git/hooks.go
@@ -32,10 +32,9 @@ const hookWaitDelay = 2 * time.Second
 // outlive their parent hook.
 // Errors are logged but do not propagate.
 func RunPostWorktreeHooksAsync(ctx context.Context, repoPath, worktreePath string) {
-	repoID := config.RepoIDFromRoot(repoPath)
-	repoCfg, err := config.LoadRepoConfig(repoID)
+	repoCfg, err := config.ResolveConfig(repoPath)
 	if err != nil {
-		log.WarningLog.Printf("failed to load repo config for hooks: %v", err)
+		log.WarningLog.Printf("failed to resolve repo config for hooks: %v", err)
 		return
 	}
 	if len(repoCfg.PostWorktreeCommands) == 0 {


### PR DESCRIPTION
Fixes #800

## Design recap

A repository can now carry its own configuration in a single file, `<repo-root>/.agent-factory/config.json`, resolved as **app defaults → global `~/.agent-factory/config.json` → in-repo file** with field-wise merge (an in-repo field overrides global only when set; `program_overrides` merges per key). Per Sachin's follow-up on #800, there is **no trust gate**: cloning a repo onto the machine is the trust boundary, so an in-repo config — including command-bearing fields — applies as-is. For observability, `af` logs one INFO line the first time a command-bearing in-repo config loads for a repo (and again whenever its content hash changes), tracking the last-seen sha256 in the existing per-repo state dir. The hash gates nothing.

All resolution goes through a single new helper, `config.ResolveConfig(repoRoot)`, and every former consumer of `Config`/`RepoConfig` fields was routed through it (audit below).

## Precedence and scoping

| Key | Global | In-repo | Notes |
|---|---|---|---|
| `default_program` | ✓ | ✓ | In-repo wins when set; enum-validated in both places. |
| `program_overrides` | ✓ | ✓ | Key-wise merge; in-repo entry wins per agent. |
| `post_worktree_commands` | ✗ | ✓ | In-repo only. Legacy `~/.agent-factory/repos/<id>/config.json` keeps working **one release** as a fallback, with a once-per-process deprecation warning naming the new location; shadowed whenever the in-repo key is present — including an explicit `[]`. |
| `remote_hooks` | ✗ | ✓ | Same legacy-fallback window as above. |
| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `detach_keys`, `worktree_root` | ✓ | rejected | Actionable error naming the key and pointing at the global file. Unknown keys are rejected too, listing the allowed set, so typos in a command-executing file fail loudly. |

## Path safety

The in-repo path ships inside a repository, so reads are guarded: symlinks are resolved and the resolved file must be a regular file inside the (resolved) repo root — a link to `~/.ssh` or `/etc` is refused. A dotfiles-style repo rooted at the config home (where the in-repo path collides with the global config file) is treated as having no in-repo config, and saves there are refused rather than clobbering global settings.

## Call-site audit (per CLAUDE.md adjacent-call-sites)

| Call site | Field(s) | Now |
|---|---|---|
| `session/backend_resolve.go` `backendForPath` / `loadHookBackendForPath` | `remote_hooks` | `ResolveConfig(repo.Root)` (`backendForRepoID` folded in) |
| `session/git/hooks.go` `RunPostWorktreeHooksAsync` | `post_worktree_commands` | `ResolveConfig(repoPath)` |
| `session/backend_local.go` `resolveProgramForInstance` | `program_overrides` | repo-resolved config when the instance path is a git repo; global fallback otherwise (preserves test/legacy behavior) |
| `app/app.go` `newHome` hooks pane | `post_worktree_commands` | `ResolveConfig(repo.Root)`; `app.Run` now takes the `RepoContext` |
| `app/app.go` `saveContentPaneState` | hooks save | writes the **in-repo** file via `SaveInRepoPostWorktreeCommands` (preserves all other fields; an emptied list is written as an explicit `[]` so it shadows legacy) |
| `app/sync.go` `importRemoteHookSessions` | `remote_hooks` | `ResolveConfig(repo.Root)` |
| `daemon/control.go` `CreateSession` | `default_program` | repo-resolved default so task runs/API creates honor in-repo `default_program`; daemon global config as fallback |
| `daemon/control.go` `ImportRemoteHookSessions` | `remote_hooks` | `ResolveConfig(repo.Root)` |
| `main.go` root command | `default_program` | `ResolveConfig(repo.Root)` |
| `api/sessions.go` create / send-prompt `--create`, `api/tasks.go` add | `default_program` | `ResolveConfig(repo.Root)` |
| `session/git/worktree.go`, `task/runner.go`, `daemon/taskrun.go`, `af debug` | `branch_prefix` / `auto_yes` / global view | unchanged — global-only fields |

`LoadRepoConfig`/`SaveRepoConfig` have no production readers left outside the resolver's legacy fallback and are documented as the legacy location.

## Tests

- Precedence matrix: defaults/global/in-repo per field, key-wise `program_overrides` merge, global-only fields untouched by in-repo files, no mutation of the loaded global config.
- Scoping: each global-only key rejected with an actionable error; unknown keys rejected listing allowed keys; enum validation for `default_program`/`program_overrides` in the in-repo file.
- Traversal safety: symlinked file/dir escaping the repo refused, directory-as-config refused, in-repo symlinks allowed, home-rooted-repo collision treated as absent (and save refused).
- Legacy window: fallback applies, in-repo shadows it (incl. explicit `[]`), deprecation warning logged once per process.
- Observability log: first load logs fields + 8-char hash, unchanged content stays quiet, changed content re-logs; preference-only configs never log.
- E2E: `backendForPath` resolves the remote backend from the in-repo file and prefers it over a conflicting legacy config.

All four CI gates pass locally (`golangci-lint run --fast`, `gofmt -l`, `go build ./...`, `go test ./...`), plus `deadcode -test ./...` and `-race` (constrained `-p=1 -parallel 2` for ui/app per the dev box). Smoke-tested with a `/tmp` binary in a hermetic home: scoping rejection, the one-time load log, and the legacy deprecation warning all verified end-to-end.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)