### PR TITLE
fix(session/storage): dedup session records by title on save (#808)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -470,7 +470,16 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if started != msg.instance {
 			if !m.sidebar.ReplaceInstance(msg.instance, started) && !m.sidebar.ContainsInstance(started) {
-				m.sidebar.AddInstance(started)
+				// The Loading placeholder may have been swapped for a
+				// disk-built copy of this same session by a background sync
+				// while the start RPC was in flight; both Replace and
+				// Contains are pointer-based and miss it. Adding
+				// unconditionally would leave two sidebar rows — and two
+				// persisted records — for one session (#808), so replace any
+				// same-title row instead.
+				if !m.sidebar.ReplaceInstanceByTitle(started.Title, started) {
+					m.sidebar.AddInstance(started)
+				}
 			}
 		} else if !m.sidebar.ContainsInstance(started) {
 			m.sidebar.AddInstance(started)

--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -192,4 +193,96 @@ func killIntegrationDaemon(home string) {
 	if proc, err := os.FindProcess(pid); err == nil {
 		_ = proc.Kill()
 	}
+}
+
+// TestTUIRefreshDoesNotSwapLoadingPlaceholder is the regression test for #808.
+//
+// The daemon persists a new session to instances.json BEFORE the create RPC
+// returns, so while the TUI's Loading placeholder is still in the sidebar,
+// the on-disk record for the same title already exists with a newer
+// CreatedAt. The #765 swap logic treated that newer record as a CLI
+// kill+recreate and swapped the placeholder out; the instanceStartedMsg
+// handler then missed it (pointer-based ReplaceInstance/ContainsInstance)
+// and re-added the started instance, leaving two same-title sidebar rows
+// that SaveInstances persisted as byte-identical duplicate records.
+func TestTUIRefreshDoesNotSwapLoadingPlaceholder(t *testing.T) {
+	skipIfRealBackendDepsMissing(t)
+
+	bin := buildIntegrationBinary(t)
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+	h.storage, err = session.NewStorage(config.DefaultState(), repo.ID)
+	require.NoError(t, err)
+	writeIntegrationConfig(t, os.Getenv("AGENT_FACTORY_HOME"))
+
+	t.Cleanup(func() {
+		_, _ = runIntegrationAF(t, bin, repoDir, "sessions", "kill", "scripts")
+		killIntegrationDaemon(os.Getenv("AGENT_FACTORY_HOME"))
+	})
+
+	// The TUI's placeholder for an in-flight create of "scripts".
+	placeholder, err := session.NewInstance(session.InstanceOptions{
+		Title:   "scripts",
+		Path:    repoDir,
+		Program: tmux.ProgramClaude,
+	})
+	require.NoError(t, err)
+	placeholder.SetStatus(session.Loading)
+	h.sidebar.AddInstance(placeholder)
+
+	// The daemon persists the session record mid-create — emulated by a CLI
+	// create, which goes through the same daemon CreateSession path the TUI
+	// start RPC uses.
+	runIntegrationAFOK(t, bin, repoDir, "sessions", "--repo", repoDir, "create", "--name", "scripts", "--program", tmux.ProgramClaude)
+
+	// A refresh tick fires while the placeholder is still Loading. It must
+	// not swap the placeholder out from under the in-flight create.
+	require.False(t, h.refreshExternalInstances(), "refresh must leave the Loading placeholder alone")
+	require.Same(t, placeholder, findSidebarInstance(h, "scripts"),
+		"the Loading placeholder must stay in the sidebar until its start completes (#808)")
+
+	// The start RPC completes, returning a freshly-built instance — exactly
+	// what startSessionThroughDaemon produces via FromInstanceData.
+	diskData, err := h.storage.LoadInstanceData()
+	require.NoError(t, err)
+	var rec *session.InstanceData
+	for i := range diskData {
+		if diskData[i].Title == "scripts" {
+			rec = &diskData[i]
+		}
+	}
+	require.NotNil(t, rec, "daemon must have persisted the session before the RPC returned")
+	started, err := session.FromInstanceData(*rec)
+	require.NoError(t, err)
+
+	_, _ = h.Update(instanceStartedMsg{instance: placeholder, started: started})
+
+	var matches []*session.Instance
+	for _, inst := range h.sidebar.GetInstances() {
+		if inst.Title == "scripts" {
+			matches = append(matches, inst)
+		}
+	}
+	require.Len(t, matches, 1, "one logical session must occupy exactly one sidebar row (#808)")
+	require.Same(t, started, matches[0])
+
+	// The next save must persist exactly one record. Read the raw file (not
+	// LoadInstanceData, which now dedupes on load) to assert the on-disk state.
+	require.NoError(t, h.storage.SaveInstances(h.sidebar.GetInstances()))
+	raw, err := config.DefaultState().GetInstances(repo.ID)
+	require.NoError(t, err)
+	var onDisk []session.InstanceData
+	require.NoError(t, json.Unmarshal(raw, &onDisk))
+	count := 0
+	for _, d := range onDisk {
+		if d.Title == "scripts" {
+			count++
+		}
+	}
+	require.Equal(t, 1, count, "instances.json must hold exactly one record for the title (#808)")
 }

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -287,3 +287,35 @@ func TestInstanceStarted_TimeoutError_EmptyContentOmitsHeader(t *testing.T) {
 	assert.Contains(t, rendered, "timed out waiting for program to start")
 	assert.NotContains(t, rendered, "last pane content:")
 }
+
+// TestInstanceStarted_ReplacesSwappedSameTitleRow is the #808 regression.
+//
+// While a start RPC is in flight, the daemon persists the new session to
+// instances.json before responding, so a background sync can swap the
+// Loading placeholder for a disk-built copy of that same session. When the
+// start then completes, ReplaceInstance(placeholder, started) misses (the
+// placeholder pointer is gone) and ContainsInstance(started) is also
+// pointer-based — re-adding unconditionally left two sidebar rows with one
+// title, which SaveInstances persisted as byte-identical duplicate records.
+// The handler must fall back to replacing the same-title row.
+func TestInstanceStarted_ReplacesSwappedSameTitleRow(t *testing.T) {
+	h := newTestHome(t)
+
+	// The placeholder the user created; a background sync already swapped it
+	// out of the sidebar for a disk-built copy of the same session.
+	placeholder := newLoadingInstance(t, "scripts")
+	diskCopy := newLoadingInstance(t, "scripts")
+	diskCopy.SetStartedForTest(true)
+	diskCopy.SetStatus(session.Running)
+	h.sidebar.AddInstance(diskCopy)
+
+	started := newLoadingInstance(t, "scripts")
+	started.SetStartedForTest(true)
+
+	_, _ = h.Update(instanceStartedMsg{instance: placeholder, started: started})
+
+	instances := h.sidebar.GetInstances()
+	require.Len(t, instances, 1, "one logical session must occupy exactly one sidebar row (#808)")
+	assert.Same(t, started, instances[0], "the started instance must replace the disk-built copy")
+	assert.Equal(t, session.Running, started.Status)
+}

--- a/app/sync.go
+++ b/app/sync.go
@@ -201,7 +201,7 @@ func (m *home) mergePendingInstances() int {
 				if existing.Title != data.Title {
 					continue
 				}
-				if instanceCollisionShouldSkip(existing.GetWorktreePath(), data.Worktree.WorktreePath, existing.CreatedAt, data.CreatedAt, existing.TmuxAlive()) {
+				if instanceCollisionShouldSkip(existing.GetWorktreePath(), data.Worktree.WorktreePath, existing.CreatedAt, data.CreatedAt, existing.TmuxAlive(), existing.GetStatus() == session.Loading) {
 					log.WarningLog.Printf("skipping pending instance %q: already exists and is alive", data.Title)
 					skip = true
 				} else {
@@ -304,7 +304,7 @@ func (m *home) refreshExternalInstances() bool {
 				if existing.Title != d.Title {
 					continue
 				}
-				if !instanceCollisionShouldSkip(existing.GetWorktreePath(), d.Worktree.WorktreePath, existing.CreatedAt, d.CreatedAt, existing.TmuxAlive()) {
+				if !instanceCollisionShouldSkip(existing.GetWorktreePath(), d.Worktree.WorktreePath, existing.CreatedAt, d.CreatedAt, existing.TmuxAlive(), existing.GetStatus() == session.Loading) {
 					skip = false
 					shouldReplace = true
 				}
@@ -358,6 +358,15 @@ func (m *home) refreshExternalInstances() bool {
 // instance is still the authoritative live session), false when the sidebar
 // instance is stale and must be replaced.
 //
+// A Loading sidebar instance is never replaced (#808): it is the placeholder
+// for an in-flight TUI creation of this very session — the daemon persists
+// the record to instances.json before the start RPC returns, so the on-disk
+// row appearing while the placeholder is still Loading is the normal
+// mid-create state, not a stale corpse. Its CreatedAt also predates the
+// daemon-side record, so the #765 newer-CreatedAt rule below would otherwise
+// always swap it, orphaning the pointer the instanceStartedMsg handler later
+// passes to ReplaceInstance and leaving two same-title sidebar rows.
+//
 // The incoming instance supersedes the existing one when:
 //   - both worktree paths are known and differ — a scheduled task rerun
 //     creates a new worktree with a numeric suffix while reusing the tmux
@@ -370,7 +379,10 @@ func (m *home) refreshExternalInstances() bool {
 //     TmuxAlive() can then distinguish them; the newer CreatedAt can (#765).
 //
 // Otherwise, fall back to the tmuxAlive signal.
-func instanceCollisionShouldSkip(existingWorktreePath, incomingWorktreePath string, existingCreatedAt, incomingCreatedAt time.Time, tmuxAlive bool) bool {
+func instanceCollisionShouldSkip(existingWorktreePath, incomingWorktreePath string, existingCreatedAt, incomingCreatedAt time.Time, tmuxAlive, existingLoading bool) bool {
+	if existingLoading {
+		return true
+	}
 	if existingWorktreePath != "" && incomingWorktreePath != "" && existingWorktreePath != incomingWorktreePath {
 		return false
 	}

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -38,8 +38,29 @@ func TestInstanceCollisionShouldSkip(t *testing.T) {
 		existingCreated  time.Time
 		incomingCreated  time.Time
 		tmuxAlive        bool
+		existingLoading  bool
 		wantSkip         bool
 	}{
+		{
+			name:             "existing Loading, incoming newer -> skip (in-flight create, issue #808)",
+			existingWorktree: "",
+			incomingWorktree: "/repo/worktrees/task",
+			existingCreated:  base,
+			incomingCreated:  base.Add(time.Second),
+			tmuxAlive:        false,
+			existingLoading:  true,
+			wantSkip:         true,
+		},
+		{
+			name:             "existing Loading, differing worktrees and tmux dead -> skip (issue #808)",
+			existingWorktree: "/repo/worktrees/task",
+			incomingWorktree: "/repo/worktrees/task-2",
+			existingCreated:  base,
+			incomingCreated:  base,
+			tmuxAlive:        false,
+			existingLoading:  true,
+			wantSkip:         true,
+		},
 		{
 			name:             "worktree paths differ and tmux alive -> replace (issue #255)",
 			existingWorktree: "/repo/worktrees/task",
@@ -125,10 +146,10 @@ func TestInstanceCollisionShouldSkip(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := instanceCollisionShouldSkip(tc.existingWorktree, tc.incomingWorktree, tc.existingCreated, tc.incomingCreated, tc.tmuxAlive)
+			got := instanceCollisionShouldSkip(tc.existingWorktree, tc.incomingWorktree, tc.existingCreated, tc.incomingCreated, tc.tmuxAlive, tc.existingLoading)
 			if got != tc.wantSkip {
-				t.Fatalf("instanceCollisionShouldSkip(%q, %q, %v, %v, %v) = %v; want %v",
-					tc.existingWorktree, tc.incomingWorktree, tc.existingCreated, tc.incomingCreated, tc.tmuxAlive, got, tc.wantSkip)
+				t.Fatalf("instanceCollisionShouldSkip(%q, %q, %v, %v, %v, %v) = %v; want %v",
+					tc.existingWorktree, tc.incomingWorktree, tc.existingCreated, tc.incomingCreated, tc.tmuxAlive, tc.existingLoading, got, tc.wantSkip)
 			}
 		})
 	}

--- a/session/storage.go
+++ b/session/storage.go
@@ -71,6 +71,33 @@ func NewStorage(state config.InstanceStorage, repoID string) (*Storage, error) {
 	}, nil
 }
 
+// dedupeInstanceData collapses records that share a title, keeping the one
+// with the newest UpdatedAt (ties keep the earliest occurrence, so in-memory
+// records — which both save paths place ahead of disk-only records — win).
+// Titles are unique per repo (the daemon's findTitleConflictLocked enforces
+// this on create), so two same-title records in one repo's list are always
+// the same logical session written twice (#808). Deduping at the save/load
+// chokepoints prevents new duplicates from persisting and collapses any
+// existing on-disk duplicate on the next clean save.
+func dedupeInstanceData(data []InstanceData) []InstanceData {
+	if len(data) < 2 {
+		return data
+	}
+	index := make(map[string]int, len(data))
+	out := make([]InstanceData, 0, len(data))
+	for _, d := range data {
+		if i, ok := index[d.Title]; ok {
+			if d.UpdatedAt.After(out[i].UpdatedAt) {
+				out[i] = d
+			}
+			continue
+		}
+		index[d.Title] = len(out)
+		out = append(out, d)
+	}
+	return out
+}
+
 // SaveInstances saves the list of instances to disk under file locks.
 // Loading instances are excluded — they represent in-flight TUI session
 // creations whose worktree is not yet populated, so they cannot be
@@ -197,7 +224,7 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 				merged = append(merged, dd)
 			}
 
-			jsonData, err := json.Marshal(merged)
+			jsonData, err := json.Marshal(dedupeInstanceData(merged))
 			if err != nil {
 				return fmt.Errorf("failed to marshal instances for repo %s: %w", rid, err)
 			}
@@ -278,7 +305,7 @@ func (s *Storage) saveRepoInstances(instances []*Instance) error {
 			merged = append(merged, disk)
 		}
 
-		jsonData, err := json.Marshal(merged)
+		jsonData, err := json.Marshal(dedupeInstanceData(merged))
 		if err != nil {
 			return fmt.Errorf("failed to marshal instances: %w", err)
 		}
@@ -312,6 +339,10 @@ func (s *Storage) LoadInstances() ([]*Instance, error) {
 		if err := json.Unmarshal(jsonData, &instancesData); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal instances: %w", err)
 		}
+		// Collapse duplicate records written before the dedup-on-save fix
+		// (#808) so a dup-containing file yields one sidebar row per session
+		// immediately, not just after the next save rewrites the file.
+		instancesData = dedupeInstanceData(instancesData)
 		for _, data := range instancesData {
 			instance, err := FromInstanceData(data)
 			if err != nil {
@@ -387,7 +418,7 @@ func (s *Storage) LoadInstanceData() ([]InstanceData, error) {
 	if err := json.Unmarshal(raw, &data); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal instances: %w", err)
 	}
-	return data, nil
+	return dedupeInstanceData(data), nil
 }
 
 // DeleteAllInstances removes all stored instances

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -612,3 +612,121 @@ func TestCollectRepoRootsSkipsEmpty(t *testing.T) {
 	_, hasEmpty := roots[""]
 	assert.False(t, hasEmpty, "empty repo root should be skipped")
 }
+
+// --- Issue #808: instances.json held byte-identical duplicate records -----
+//
+// One logical session can be written twice when the sidebar briefly holds two
+// Instance objects with the same title (a disk-built copy swapped in by
+// refreshExternalInstances plus the started instance re-added by the
+// instanceStartedMsg handler). The storage layer dedupes by title at every
+// save/load chokepoint so neither mode can persist a duplicate, and an
+// existing on-disk duplicate collapses on the next clean save.
+
+func TestDedupeInstanceDataKeepsFreshest(t *testing.T) {
+	base := time.Date(2026, 6, 10, 11, 38, 47, 75861804, time.UTC)
+	older := InstanceData{Title: "scripts", Path: "/repo/stale", UpdatedAt: base}
+	newer := InstanceData{Title: "scripts", Path: "/repo/fresh", UpdatedAt: base.Add(time.Second)}
+	other := InstanceData{Title: "other", Path: "/repo", UpdatedAt: base}
+
+	out := dedupeInstanceData([]InstanceData{older, newer, other})
+	require.Len(t, out, 2)
+	assert.Equal(t, "scripts", out[0].Title)
+	assert.Equal(t, "/repo/fresh", out[0].Path, "the record with the newest UpdatedAt must win")
+	assert.Equal(t, "other", out[1].Title)
+
+	// Byte-identical duplicates (equal UpdatedAt) collapse to the first
+	// occurrence — the order both save paths put in-memory records first.
+	out = dedupeInstanceData([]InstanceData{older, older})
+	require.Len(t, out, 1)
+	assert.Equal(t, "/repo/stale", out[0].Path)
+}
+
+// TestTUISaveCollapsesOnDiskDuplicate is the one-time collapse: a file
+// already containing a byte-identical duplicate is rewritten clean by the
+// next save, even with nothing in memory.
+func TestTUISaveCollapsesOnDiskDuplicate(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	const repoPath = "/tmp/test-repo-808"
+	ms := newMockStorage()
+
+	created := time.Date(2026, 6, 10, 11, 38, 47, 75861804, time.UTC)
+	dup := InstanceData{Title: "scripts", Path: repoPath, CreatedAt: created, UpdatedAt: created}
+	seedDisk(t, ms, repoPath, []InstanceData{dup, dup})
+
+	storage, err := NewStorage(ms, config.RepoIDFromRoot(repoPath))
+	require.NoError(t, err)
+	require.NoError(t, storage.SaveInstances(nil))
+
+	result := readDisk(t, ms, repoPath)
+	require.Len(t, result, 1, "byte-identical duplicate must collapse on save")
+	assert.Equal(t, "scripts", result[0].Title)
+}
+
+// TestTUISaveCollapsesDuplicateInMemoryInstances covers the #808 write path:
+// the sidebar holds two live Instance objects for one session; TUI-mode save
+// must persist exactly one record.
+func TestTUISaveCollapsesDuplicateInMemoryInstances(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	const repoPath = "/tmp/test-repo-808"
+	ms := newMockStorage()
+
+	// The daemon persisted the session before the TUI's start RPC returned.
+	seedDisk(t, ms, repoPath, []InstanceData{{Title: "scripts", Path: repoPath}})
+
+	storage, err := NewStorage(ms, config.RepoIDFromRoot(repoPath))
+	require.NoError(t, err)
+
+	diskCopy := makeInstance("scripts", repoPath, true)
+	startedTwin := makeInstance("scripts", repoPath, true)
+	require.NoError(t, storage.SaveInstances([]*Instance{diskCopy, startedTwin}))
+
+	result := readDisk(t, ms, repoPath)
+	require.Len(t, result, 1, "two in-memory objects for one session must persist as one record")
+	assert.Equal(t, "scripts", result[0].Title)
+}
+
+// TestDaemonSaveCollapsesOnDiskDuplicate covers daemon-mode save: an
+// externally-added session that exists twice on disk (and is unknown to the
+// daemon) must be preserved exactly once.
+func TestDaemonSaveCollapsesOnDiskDuplicate(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	const repoPath = "/tmp/test-repo-808"
+	ms := newMockStorage()
+
+	created := time.Date(2026, 6, 10, 11, 38, 47, 75861804, time.UTC)
+	dup := InstanceData{Title: "scripts", Path: repoPath, CreatedAt: created, UpdatedAt: created}
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "instance-A", Path: repoPath},
+		dup,
+		dup,
+	})
+
+	storage, err := NewStorage(ms, "") // daemon mode
+	require.NoError(t, err)
+	require.NoError(t, storage.SaveInstances([]*Instance{makeInstance("instance-A", repoPath, true)}))
+
+	result := readDisk(t, ms, repoPath)
+	counts := make(map[string]int)
+	for _, d := range result {
+		counts[d.Title]++
+	}
+	assert.Equal(t, map[string]int{"instance-A": 1, "scripts": 1}, counts)
+}
+
+// TestLoadInstanceDataCollapsesDuplicates: the data feed used by
+// refreshExternalInstances must never present the same title twice.
+func TestLoadInstanceDataCollapsesDuplicates(t *testing.T) {
+	const repoPath = "/tmp/test-repo-808"
+	ms := newMockStorage()
+
+	dup := InstanceData{Title: "scripts", Path: repoPath}
+	seedDisk(t, ms, repoPath, []InstanceData{dup, dup})
+
+	storage, err := NewStorage(ms, config.RepoIDFromRoot(repoPath))
+	require.NoError(t, err)
+
+	data, err := storage.LoadInstanceData()
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+	assert.Equal(t, "scripts", data[0].Title)
+}

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -423,6 +423,22 @@ func (s *Sidebar) ReplaceInstance(target, replacement *session.Instance) bool {
 	return false
 }
 
+// ReplaceInstanceByTitle swaps the sidebar instance carrying the given title
+// for replacement, preserving the selected row. Returns false when no
+// instance has that title. Used by the instance-start handler when its
+// pointer-based ReplaceInstance misses: a background sync may have swapped
+// the Loading placeholder for a disk-built copy of the same session while
+// the start RPC was in flight, and re-adding the started instance would
+// leave two sidebar rows — and two persisted records — with one title (#808).
+func (s *Sidebar) ReplaceInstanceByTitle(title string, replacement *session.Instance) bool {
+	for _, inst := range s.instances {
+		if inst.Title == title {
+			return s.ReplaceInstance(inst, replacement)
+		}
+	}
+	return false
+}
+
 // GetInstances returns all instances. The returned slice shares the sidebar's
 // backing array, so callers must only read it on the bubbletea event loop —
 // never hand it to a goroutine that outlives the call (see


### PR DESCRIPTION
Fixes #808

## Root cause

The duplicate is one logical session written twice by the TUI, via a three-step race between the daemon-side create, the TUI's external-refresh tick, and the start-completion handler:

1. **Daemon persists before the RPC returns.** `Manager.CreateSession` (`daemon/control.go`) registers the instance and writes it to `instances.json` via `appendInstanceData` *before* responding — while the TUI still shows its Loading placeholder (session start takes seconds: worktree + tmux + program boot).
2. **The #765 swap steals the Loading placeholder.** The 3s `tickRefreshExternal` calls `refreshExternalInstances`, which finds the new on-disk record colliding with the placeholder's title. `instanceCollisionShouldSkip`'s newer-CreatedAt rule (#765) fires — the daemon-built record is always newer than the TUI placeholder — so the placeholder (pointer A) is swapped out for a disk-built copy (pointer B). The existing Loading protection only guarded the *remove* pass, not the swap pass.
3. **Start completion re-adds a second row.** `instanceStartedMsg` arrives with `msg.instance = A` and `started = C` (`startSessionThroughDaemon` always returns a fresh pointer via `FromInstanceData`). `ReplaceInstance(A, C)` misses (A is gone) and `ContainsInstance(C)` is pointer-identity, so the handler did `AddInstance(C)`. The sidebar now holds B and C — same title, same worktree, same `created_at` to the nanosecond, both round-tripped from the same daemon record.

Neither save path deduped *within* the in-memory list (only disk-vs-memory by title), so the next save persisted both records — exactly the byte-identical pair observed on the dev box.

## Fix

- **`app/sync.go`** — `instanceCollisionShouldSkip` gains an `existingLoading` flag and never replaces a Loading sidebar instance: the placeholder *is* the in-flight create, not a stale corpse. Applies to both call sites (`refreshExternalInstances`, `mergePendingInstances`). This closes the race at step 2.
- **`app/app.go` + `ui/sidebar.go`** — when the pointer-based replace misses, `instanceStartedMsg` falls back to `Sidebar.ReplaceInstanceByTitle` instead of appending, so any future path that swaps the placeholder still cannot produce two same-title rows. This closes step 3 independently.
- **`session/storage.go`** — defense in depth regardless of root cause: `dedupeInstanceData` collapses same-title records (titles are unique per repo, enforced by the daemon's `findTitleConflictLocked`), keeping the newest `UpdatedAt` (ties keep the first occurrence, preserving in-memory precedence). Applied at all four chokepoints: daemon-mode `SaveInstances`, TUI-mode `saveRepoInstances`, `LoadInstances`, and `LoadInstanceData`. **One-time collapse:** an existing on-disk duplicate is rewritten clean by the next save, and `LoadInstances` dedupes so the sidebar never shows the phantom row even before that save.

## Audit of every append-to-instances + persist site

| Site | Verdict |
|---|---|
| `Storage.SaveInstances` (daemon mode) | dedup chokepoint added |
| `Storage.saveRepoInstances` (TUI mode) | dedup chokepoint added |
| `Storage.DeleteInstance` | filter-only; cannot duplicate |
| daemon `appendInstanceData` | title-checked upsert, errors on conflict; cannot duplicate |
| daemon `ImportRemoteHookSessions` writer | `existingTitles` guard; cannot duplicate |
| `mergePendingInstances` other-repo writer | `upsertInstanceDataByTitle`; cannot duplicate |
| startup load → `AddInstance` (`app.go`) | fed by `LoadInstances`, now deduped |
| `instanceStartedMsg` handler | **was the duplicating append** — fixed (title fallback) |
| `startNewInstance` / `handleStateSelectWorktree` / `handleTaskTrigger` | Loading placeholders, excluded from persistence; completion routes through fixed handler |
| `mergePendingInstances` sidebar add | title set + collision check (now with Loading guard) |
| `refreshExternalInstances` add/swap | title set + collision check (now with Loading guard); disk feed deduped |
| `importRemoteHookSessions` sidebar add | `existingTitles` guard; cannot duplicate |
| `daemonInstances` | map keyed `repoID+title`; structurally incapable |
| `api loadAllInstancesAggregate` | read-only listing; never persisted |

## Tests

- `TestTUIRefreshDoesNotSwapLoadingPlaceholder` (integration, real tmux + daemon): drives the exact race — placeholder in sidebar, daemon persists, refresh tick, start completes, save — and asserts one sidebar row and one on-disk record. **Verified to fail at the swap with the guard disabled.**
- `TestInstanceStarted_ReplacesSwappedSameTitleRow`: hermetic handler regression — **fails pre-fix** (two rows), passes post-fix.
- `TestInstanceCollisionShouldSkip`: two new Loading cases in the existing #255/#765 table.
- Storage: `TestTUISaveCollapsesOnDiskDuplicate` (byte-identical dup file collapses on save — the one-time cleanup for the record on the dev box), `TestTUISaveCollapsesDuplicateInMemoryInstances`, `TestDaemonSaveCollapsesOnDiskDuplicate` (external dup preserved exactly once), `TestLoadInstanceDataCollapsesDuplicates`, `TestDedupeInstanceDataKeepsFreshest`.
- No regressions: #765 (`TestTUIRefreshSwapsKillRecreatedSameTitle` — kill+recreate swap still works; the guard only exempts Loading), #730/#766 read-error paths, full suite green.

## Verification

`golangci-lint run --fast`, `gofmt -l .`, `go build ./...`, `go test ./...`, `deadcode -test ./...` all clean; `-race` green for `session`, `ui`, `app` (`GOFLAGS="-p=1" -parallel 2`).

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)