### PR TITLE
fix(session/hook): sanitize remote preview stream and treat ED2 as snapshot reset (#810)

### DIFF
--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -104,6 +104,25 @@ Agent Factory runs this command behind a local PTY and intercepts the configured
 
 Agent Factory also uses this script for the preview pane by running it in a background process and capturing its output.
 
+#### Preview output contract
+
+Preview output is rendered **inside a TUI pane**, not on a raw terminal. Two rules apply to the captured stream:
+
+- **Control sequences are stripped.** Cursor movement, erase, scroll-region, alt-screen, and mode sequences (e.g. `\033[H`, `\033[?1049h`, `\033[?25l`), OSC strings, and bare carriage returns are removed before rendering — only SGR color sequences (`\033[...m`) and plain text (with `\n`/`\t`) reach the pane. Scripts don't need to avoid emitting these, but they have no effect.
+- **`\033[2J` (clear screen) starts a fresh snapshot.** Everything captured before the last `\033[2J` is discarded, so a clear-then-capture loop replaces the previous frame instead of concatenating stale ones.
+
+A preview-friendly capture loop looks like:
+
+```bash
+while true; do
+  printf '\033[2J\033[H'
+  ssh user@host "tmux capture-pane -p -e -t $NAME"
+  sleep 1
+done
+```
+
+Each iteration becomes the new preview frame. `capture-pane -e` keeps colors; they are preserved in the pane.
+
 ## Example
 
 See `examples/remote-hooks/` for skeleton scripts that implement this protocol.

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -62,6 +63,32 @@ type hookPTY struct {
 }
 
 var slugRegexp = regexp.MustCompile(`[^a-z0-9-]`)
+
+// ed2Marker is ED2 (erase entire display). The documented remote preview
+// pattern (docs/remote-hooks.md) emits it at the top of every capture-loop
+// iteration, so hookPTY ingestion treats it as a snapshot boundary (#810).
+var ed2Marker = []byte("\x1b[2J")
+
+// ingest appends a chunk of attach_cmd output to the preview buffer.
+//
+// ED2 (\x1b[2J) marks the start of a fresh snapshot: the documented preview
+// contract is a clear-screen + capture loop, so everything up to and
+// including the last ED2 is a stale frame and is dropped instead of
+// concatenated (#810). The search runs over the accumulated buffer, not just
+// the incoming chunk, so a sequence split across read boundaries is detected
+// once its tail arrives — the head bytes are already in buf.
+func (hp *hookPTY) ingest(chunk []byte) {
+	const maxBuf = 64 * 1024
+	hp.mu.Lock()
+	defer hp.mu.Unlock()
+	hp.buf = append(hp.buf, chunk...)
+	if idx := bytes.LastIndex(hp.buf, ed2Marker); idx >= 0 {
+		hp.buf = hp.buf[idx+len(ed2Marker):]
+	}
+	if len(hp.buf) > maxBuf {
+		hp.buf = hp.buf[len(hp.buf)-maxBuf:]
+	}
+}
 
 // Slugify converts a title to a slug-safe string for hook scripts.
 // The slug is part of the public remote hook protocol documented in
@@ -325,8 +352,14 @@ func (b *HookBackend) Preview(i *Instance) (string, error) {
 		return "", nil
 	}
 	hp.mu.Lock()
-	defer hp.mu.Unlock()
-	return string(hp.buf), nil
+	raw := string(hp.buf)
+	hp.mu.Unlock()
+	// Never return the raw stream: attach_cmd output is a PTY stream whose
+	// control sequences would be executed by the real terminal when the
+	// preview pane is flushed, corrupting the whole TUI (#810). Sanitizing
+	// happens outside the lock so the ingestion goroutine is never blocked
+	// on it.
+	return sanitizeHookPreview(raw), nil
 }
 
 func (b *HookBackend) PreviewFullHistory(i *Instance) (string, error) {
@@ -641,19 +674,14 @@ func (b *HookBackend) ensurePTY(i *Instance) error {
 	hp := &hookPTY{cmd: cmd, stdout: stdoutR, waitDone: make(chan struct{})}
 	b.ptys[i.Title] = hp
 
-	// Background goroutine reads output into a ring buffer.
+	// Background goroutine reads output into a ring buffer with ED2
+	// snapshot-reset semantics (see hookPTY.ingest).
 	go func() {
 		buf := make([]byte, 4096)
-		const maxBuf = 64 * 1024
 		for {
 			n, err := stdoutR.Read(buf)
 			if n > 0 {
-				hp.mu.Lock()
-				hp.buf = append(hp.buf, buf[:n]...)
-				if len(hp.buf) > maxBuf {
-					hp.buf = hp.buf[len(hp.buf)-maxBuf:]
-				}
-				hp.mu.Unlock()
+				hp.ingest(buf[:n])
 			}
 			if err != nil {
 				break
@@ -717,6 +745,26 @@ func (hp *hookPTY) waitAsync() <-chan struct{} {
 func (hp *hookPTY) wait() error {
 	<-hp.waitAsync()
 	return hp.waitErr
+}
+
+// SetPreviewBufferForTest seeds the raw preview buffer for title, creating
+// the entry if needed. Exported in a non-test file (mirroring FakeBackend)
+// so ui tests can drive the hook preview path through PreviewPane without
+// spawning a real attach_cmd process.
+func (b *HookBackend) SetPreviewBufferForTest(title string, data []byte) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.ptys == nil {
+		b.ptys = make(map[string]*hookPTY)
+	}
+	hp, ok := b.ptys[title]
+	if !ok {
+		hp = &hookPTY{waitDone: make(chan struct{})}
+		b.ptys[title] = hp
+	}
+	hp.mu.Lock()
+	hp.buf = append([]byte(nil), data...)
+	hp.mu.Unlock()
 }
 
 func (b *HookBackend) getPTY(title string) *hookPTY {

--- a/session/hook_preview_sanitize.go
+++ b/session/hook_preview_sanitize.go
@@ -1,0 +1,80 @@
+package session
+
+import (
+	"strings"
+
+	xansi "github.com/charmbracelet/x/ansi"
+)
+
+// sanitizeHookPreview strips every escape/control sequence from a raw remote
+// preview stream except SGR color sequences and the \n/\t layout controls.
+//
+// HookBackend.Preview returns attach_cmd output that the preview pane embeds
+// verbatim in its lipgloss frame. Any control sequence that survives — the
+// documented preview pattern's own \x1b[2J\x1b[H, plus alt-screen
+// (\x1b[?1049h), scroll-region (\x1b[r), and cursor-positioning sequences
+// from the remote PTY — is executed by the real terminal when bubbletea
+// flushes the frame, erasing the screen and repositioning the cursor
+// mid-render (#810). SGR (\x1b[...m) is kept so remote output stays colored.
+//
+// Tokenize with xansi.DecodeSequence rather than a bespoke regex: the ErrBox
+// sanitizer went through three rounds of regex escape-variant whack-a-mole
+// (#525 → #552 → #565) before settling on the vetted xansi parser, and this
+// follows the same rule. xansi.Strip alone is not enough here because it
+// also removes SGR.
+//
+// Raw \r is dropped too — it would pull the cursor to column 0 and overwrite
+// pane padding (#668) — as are all other C0 controls except \n and \t.
+func sanitizeHookPreview(s string) string {
+	var out strings.Builder
+	out.Grow(len(s))
+	var state byte
+	for len(s) > 0 {
+		seq, _, n, newState := xansi.DecodeSequence(s, state, nil)
+		if n == 0 {
+			// Defensive: DecodeSequence always consumes at least one byte;
+			// bail rather than spin if that invariant ever breaks.
+			break
+		}
+		switch {
+		case isSGRSequence(seq):
+			out.WriteString(seq)
+		case seq[0] == '\x1b' || (seq[0] >= 0x80 && seq[0] <= 0x9f):
+			// Non-SGR escape sequence (CSI command, OSC/DCS string,
+			// single-char escape) or a C1-introduced sequence: drop. An
+			// incomplete sequence split at the end of the buffer lands here
+			// too — DecodeSequence returns the unterminated tail as one
+			// token, and it cannot match the complete-SGR check above.
+		case len(seq) == 1 && (seq[0] < 0x20 || seq[0] == 0x7f):
+			// C0 control / DEL: keep only the layout controls the pane
+			// renderer understands.
+			if seq[0] == '\n' || seq[0] == '\t' {
+				out.WriteByte(seq[0])
+			}
+		default:
+			out.WriteString(seq)
+		}
+		state = newState
+		s = s[n:]
+	}
+	return out.String()
+}
+
+// isSGRSequence reports whether seq is exactly one 7-bit SGR sequence:
+// ESC [ <numeric params> m. Private-prefix variants (\x1b[?4m) and sequences
+// with intermediate bytes are not SGR and return false, as are C1 (8-bit
+// CSI) forms — a UTF-8 terminal would not execute those bytes anyway, and
+// passing them through would emit invalid UTF-8 into the pane.
+func isSGRSequence(seq string) bool {
+	if len(seq) < 3 || !strings.HasPrefix(seq, "\x1b[") || seq[len(seq)-1] != 'm' {
+		return false
+	}
+	body := seq[2 : len(seq)-1]
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		if (c < '0' || c > '9') && c != ';' && c != ':' {
+			return false
+		}
+	}
+	return true
+}

--- a/session/hook_preview_sanitize_test.go
+++ b/session/hook_preview_sanitize_test.go
@@ -1,0 +1,278 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHookPTYIngestED2SnapshotReset exercises the snapshot-reset semantics
+// added for #810: ED2 (\x1b[2J) in the attach_cmd stream marks the start of
+// a fresh snapshot, so everything up to and including the last ED2 is
+// dropped instead of concatenated with stale frames.
+func TestHookPTYIngestED2SnapshotReset(t *testing.T) {
+	t.Run("two snapshots in one write keeps only the latest", func(t *testing.T) {
+		hp := &hookPTY{}
+		hp.ingest([]byte("\x1b[2J\x1b[Hframe one\x1b[2J\x1b[Hframe two"))
+		assert.Equal(t, "\x1b[Hframe two", string(hp.buf))
+	})
+
+	t.Run("snapshots across separate writes keep only the latest", func(t *testing.T) {
+		hp := &hookPTY{}
+		hp.ingest([]byte("\x1b[2J\x1b[Hfirst frame"))
+		hp.ingest([]byte("\x1b[2J\x1b[Hsecond frame"))
+		assert.Equal(t, "\x1b[Hsecond frame", string(hp.buf))
+	})
+
+	t.Run("ED2 split across read boundaries is still detected", func(t *testing.T) {
+		hp := &hookPTY{}
+		hp.ingest([]byte("stale frame\x1b["))
+		hp.ingest([]byte("2Jfresh frame"))
+		assert.Equal(t, "fresh frame", string(hp.buf))
+	})
+
+	t.Run("stream without ED2 accumulates", func(t *testing.T) {
+		hp := &hookPTY{}
+		hp.ingest([]byte("hello "))
+		hp.ingest([]byte("world"))
+		assert.Equal(t, "hello world", string(hp.buf))
+	})
+
+	t.Run("buffer without ED2 is still capped at 64KiB keeping the tail", func(t *testing.T) {
+		hp := &hookPTY{}
+		hp.ingest(bytes64k('a'))
+		hp.ingest([]byte("tail"))
+		require.Len(t, hp.buf, 64*1024)
+		assert.True(t, strings.HasSuffix(string(hp.buf), "tail"))
+	})
+}
+
+func bytes64k(c byte) []byte {
+	b := make([]byte, 64*1024)
+	for i := range b {
+		b[i] = c
+	}
+	return b
+}
+
+// TestSanitizeHookPreview exercises the read-side sanitizer added for #810:
+// every escape/control sequence except SGR colors (and \n/\t) must be
+// stripped before the preview pane embeds the string in its frame.
+func TestSanitizeHookPreview(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "clear screen and cursor home",
+			in:   "\x1b[2J\x1b[Hhello",
+			want: "hello",
+		},
+		{
+			name: "alt screen enter and leave",
+			in:   "\x1b[?1049hhi\x1b[?1049l",
+			want: "hi",
+		},
+		{
+			name: "cursor hide and show",
+			in:   "\x1b[?25lworking\x1b[?25h",
+			want: "working",
+		},
+		{
+			name: "cursor positioning and movement",
+			in:   "\x1b[10;5Hup\x1b[Adown\x1b[2Bleft\x1b[3Dright\x1b[4C",
+			want: "updownleftright",
+		},
+		{
+			name: "scroll region",
+			in:   "\x1b[r\x1b[1;24rtext",
+			want: "text",
+		},
+		{
+			name: "erase line variants",
+			in:   "a\x1b[Kb\x1b[2Kc",
+			want: "abc",
+		},
+		{
+			name: "OSC title BEL-terminated",
+			in:   "\x1b]0;window title\x07text",
+			want: "text",
+		},
+		{
+			name: "OSC 8 hyperlink ST-terminated",
+			in:   "\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\",
+			want: "link",
+		},
+		{
+			name: "single-char escapes and charset designation",
+			in:   "\x1b=a\x1b>b\x1b(Bc\x1bMd",
+			want: "abcd",
+		},
+		{
+			name: "device status query",
+			in:   "before\x1b[6nafter",
+			want: "beforeafter",
+		},
+		{
+			name: "basic SGR colors kept",
+			in:   "\x1b[31mred\x1b[0m plain \x1b[1;4mbold\x1b[m",
+			want: "\x1b[31mred\x1b[0m plain \x1b[1;4mbold\x1b[m",
+		},
+		{
+			name: "256-color and truecolor SGR kept",
+			in:   "\x1b[38;5;196mx\x1b[48;2;0;128;255my\x1b[0m",
+			want: "\x1b[38;5;196mx\x1b[48;2;0;128;255my\x1b[0m",
+		},
+		{
+			name: "colon subparameter SGR kept",
+			in:   "\x1b[4:3mcurly\x1b[0m",
+			want: "\x1b[4:3mcurly\x1b[0m",
+		},
+		{
+			name: "private-prefix m-final sequence is not SGR",
+			in:   "\x1b[?4mtext",
+			want: "text",
+		},
+		{
+			name: "SGR mixed with control sequences",
+			in:   "\x1b[2J\x1b[H\x1b[32mgreen\x1b[0m\x1b[5;1Hmore",
+			want: "\x1b[32mgreen\x1b[0mmore",
+		},
+		{
+			name: "bare carriage returns dropped",
+			in:   "progress 10%\rprogress 99%\rdone",
+			want: "progress 10%progress 99%done",
+		},
+		{
+			name: "CRLF collapses to LF",
+			in:   "line1\r\nline2\r\n",
+			want: "line1\nline2\n",
+		},
+		{
+			name: "C0 controls dropped except newline and tab",
+			in:   "a\x07b\x08c\td\ne\x0c",
+			want: "abc\td\ne",
+		},
+		{
+			name: "incomplete trailing CSI dropped",
+			in:   "text\x1b[3",
+			want: "text",
+		},
+		{
+			name: "lone trailing ESC dropped",
+			in:   "text\x1b",
+			want: "text",
+		},
+		{
+			name: "unterminated OSC dropped",
+			in:   "text\x1b]0;never terminated",
+			want: "text",
+		},
+		{
+			name: "UTF-8 text intact",
+			in:   "\x1b[2J╭─ box ❯ prompt › arrows ╰",
+			want: "╭─ box ❯ prompt › arrows ╰",
+		},
+		{
+			name: "empty input",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeHookPreview(tc.in)
+			assert.Equal(t, tc.want, got)
+			// Invariant for every case: no ESC byte survives except as the
+			// start of an SGR sequence, and no stray \r or other C0 controls
+			// besides \n and \t remain.
+			assertOnlySGREscapes(t, got)
+		})
+	}
+}
+
+// TestSanitizeHookPreviewKeepsReadySignals pins the contract that
+// task.WaitForReady depends on: the per-agent ready glyphs that
+// isReadyContent matches (codex "›", claude "❯", aider "\n> ", gemini "╰")
+// must survive sanitization of a realistic raw remote capture.
+func TestSanitizeHookPreviewKeepsReadySignals(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "codex prompt glyph",
+			raw:  "\x1b[2J\x1b[H\x1b[?25l\x1b[1mCodex\x1b[0m\r\n\r\n› ",
+			want: "›",
+		},
+		{
+			name: "claude prompt glyph",
+			raw:  "\x1b[?1049h\x1b[2J\x1b[HWelcome to Claude Code\r\n❯ \x1b[?25h",
+			want: "❯",
+		},
+		{
+			name: "aider line-start prompt",
+			raw:  "\x1b[2JAider v0.1\r\n> ",
+			want: "\n> ",
+		},
+		{
+			name: "gemini frame corner",
+			raw:  "\x1b[2J╭───╮\r\n╰───╯\r\n",
+			want: "╰",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeHookPreview(tc.raw)
+			assert.Contains(t, got, tc.want)
+		})
+	}
+}
+
+// TestHookBackendPreviewSanitizesBuffer covers the full read path: a raw
+// buffer seeded into the backend comes back sanitized from Preview and
+// PreviewFullHistory.
+func TestHookBackendPreviewSanitizesBuffer(t *testing.T) {
+	b := &HookBackend{}
+	i := &Instance{Title: "remote-test"}
+	b.SetPreviewBufferForTest("remote-test", []byte("\x1b[?1049h\x1b[2J\x1b[H\x1b[31mred\x1b[0m\r\nplain\x1b[5;1H"))
+
+	for name, fn := range map[string]func(*Instance) (string, error){
+		"Preview":            b.Preview,
+		"PreviewFullHistory": b.PreviewFullHistory,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := fn(i)
+			require.NoError(t, err)
+			assert.Equal(t, "\x1b[31mred\x1b[0m\nplain", got)
+			assertOnlySGREscapes(t, got)
+		})
+	}
+}
+
+// assertOnlySGREscapes fails if s contains any ESC byte that does not start
+// a well-formed SGR sequence (\x1b[<digits/;/:>m), any carriage return, or
+// any other C0 control besides \n and \t.
+func assertOnlySGREscapes(t *testing.T, s string) {
+	t.Helper()
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\x1b' {
+			rest := s[i:]
+			end := strings.IndexByte(rest, 'm')
+			require.True(t, end >= 2 && isSGRSequence(rest[:end+1]),
+				"non-SGR escape at byte %d: %q", i, rest)
+			i += end
+			continue
+		}
+		if c == '\n' || c == '\t' {
+			continue
+		}
+		require.False(t, c < 0x20 || c == 0x7f, "raw control byte %q at %d in %q", c, i, s)
+	}
+}

--- a/task/runner.go
+++ b/task/runner.go
@@ -83,7 +83,7 @@ func isReadyContent(content, agent string) bool {
 		// deliberately NOT a ready signal (#729): there is no codex-specific
 		// dismissal in CheckAndHandleTrustPrompt, so treating it as ready let
 		// the next user prompt get typed into the dialog. Wait for the real
-		// "›" prompt instead. Kept in sync with daemon.isReadyContent.
+		// "›" prompt instead.
 		return strings.Contains(content, "›")
 	case tmux.ProgramAider:
 		// aider prints an "Aider v…" banner, then a line-start "> " prompt.

--- a/ui/preview_remote_test.go
+++ b/ui/preview_remote_test.go
@@ -1,0 +1,69 @@
+package ui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
+)
+
+// sgrPrefixRe matches a well-formed SGR sequence (ESC [ <numeric params> m)
+// at the start of a string. Used to verify that any ESC byte reaching the
+// rendered pane belongs to a color sequence and nothing else.
+var sgrPrefixRe = regexp.MustCompile(`^\x1b\[[0-9;:]*m`)
+
+// TestPreviewRemoteHookStripsControlSequences is the #810 regression test:
+// a remote (hook-backend) preview whose raw stream contains clear-screen,
+// cursor-positioning, and alt-screen sequences must render through the
+// preview pane without any raw control bytes other than SGR colors. Before
+// the fix, the ESC[2J/ESC[H bytes in the pane's String() output were
+// executed by the real terminal on flush, corrupting the whole TUI.
+func TestPreviewRemoteHookStripsControlSequences(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	hook := &session.HookBackend{}
+	restore := session.SetBackendFactoryForTest(
+		func(opts session.InstanceOptions, absPath string) (session.Backend, error) {
+			return hook, nil
+		})
+	defer restore()
+
+	instance, err := session.NewInstance(session.InstanceOptions{
+		Title:   "remote-810",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	instance.SetStartedForTest(true)
+
+	// A realistic capture-loop frame: alt-screen, ED2 + cursor home, hidden
+	// cursor, colored text, CRLF line endings, and a final cursor move.
+	raw := "\x1b[?1049h\x1b[2J\x1b[H\x1b[?25l\x1b[31mhello\x1b[0m\r\nworld\r\n\x1b[5;1H"
+	hook.SetPreviewBufferForTest("remote-810", []byte(raw))
+
+	pane := NewPreviewPane()
+	pane.SetSize(80, 24)
+	require.NoError(t, pane.UpdateContent(instance))
+	out := pane.String()
+
+	require.Contains(t, out, "hello")
+	require.Contains(t, out, "world")
+
+	// Every ESC byte in the rendered pane must start an SGR sequence; no
+	// erase/cursor/mode sequences and no raw \r may survive.
+	for i := 0; i < len(out); i++ {
+		if out[i] == '\x1b' {
+			m := sgrPrefixRe.FindString(out[i:])
+			require.NotEmpty(t, m, "non-SGR escape sequence at byte %d: %q", i, out[i:min(i+16, len(out))])
+			i += len(m) - 1
+		}
+	}
+	require.NotContains(t, out, "\r")
+	require.NotContains(t, out, "\x1b[2J")
+	require.NotContains(t, out, "\x1b[H")
+	require.False(t, strings.Contains(out, "\x1b[?"), "private-mode sequence survived into pane output")
+}


### PR DESCRIPTION
Fixes #810

## Root cause

`HookBackend.Preview()` returned the raw `hookPTY` buffer verbatim — a raw PTY stream from `attach_cmd`. The documented preview pattern itself emits `\033[2J\033[H` every loop iteration, and the remote PTY adds alt-screen (`\033[?1049h`), scroll-region (`\033[r`), and cursor-positioning sequences. The preview pane embeds that string in its lipgloss frame, so when bubbletea flushes the frame the **real terminal executes those sequences** — erasing the screen and repositioning the cursor mid-render. Scrolling the sidebar past any remote instance corrupted the entire TUI. The local tmux backend is unaffected (`capture-pane -p` without `-e` emits plain text).

## Fix — two layers

**1. Snapshot semantics on ingestion** (`hookPTY.ingest`): ED2 (`\033[2J`) in the stream marks the start of a fresh snapshot — the buffer drops everything up to and including the last ED2 instead of concatenating stale frames. The search runs over the accumulated buffer, not just the incoming chunk, so a sequence split across read boundaries is detected once its tail arrives (the head bytes are already in the buffer). The existing 64 KiB cap is preserved.

**2. Sanitize on read** (`Preview()` → `sanitizeHookPreview`): strips every escape/control sequence except SGR colors (`\033[...m`) and `\n`/`\t` — CSI cursor/erase/scroll/mode commands (incl. `?1049h/l`, `?25l/h`), OSC strings (BEL- and ST-terminated), single-char escapes (`\033=`, `\033>`, `\033(B`, `\033M`), device queries, raw `\r` (per the #668 precedent), and all other C0 controls. Implemented as a tokenizing filter over `xansi.DecodeSequence` (already vendored via ui/err.go) rather than a bespoke regex, per the #525 → #552 → #565 ErrBox lesson; plain `xansi.Strip` is insufficient because it also removes SGR. Private-prefix `m`-final sequences (`\033[?4m`) and 8-bit C1 forms are *not* treated as SGR. Incomplete sequences split at the end of the buffer are dropped, not leaked.

## Adjacent-call-site audit (every consumer of `HookBackend.Preview`/`PreviewFullHistory`)

| Consumer | Path | After fix |
|---|---|---|
| `ui/preview.go` normal mode (`:155`) | `instance.Preview()` → backend | sanitized |
| `ui/preview.go` scroll viewport (`:137`, `:251`, `:295`) | `PreviewFullHistory()` → delegates to `Preview()` | sanitized |
| `ui/terminal.go` (`:123`) | remote sessions get an explicit "Terminal tab not available" fallback — no raw-PTY path | n/a |
| `api/sessions.go` preview command (`:371`) | `instance.Preview()` | sanitized — JSON consumers no longer receive control bytes |
| `task/runner.go` `WaitForReady`/`isReadyContent` (`:132`, `:140`) | `instance.Preview()` | sanitized; matchers are plain text and survive stripping (verified by test): codex `›`, claude `❯`, gemini `╰`, aider `\n> ` (remote `\r\n> ` collapses to `\n> `, which still matches) |
| daemon | reaches `isReadyContent` only via `task.StartAndSendPrompt` (single copy since #782) — same sanitized path | n/a |

Drive-by: removed the stale "Kept in sync with daemon.isReadyContent" comment in `task/runner.go` found during the audit (the daemon copy was deleted when #782 made `task` the single copy).

No other code reads `hookPTY.buf`. `LocalBackend` is untouched.

## Tests

- **Ingestion** (`TestHookPTYIngestED2SnapshotReset`): two ED2-separated snapshots in one write and across separate writes → buffer holds only the latest; ED2 split across two writes still detected; no-ED2 stream accumulates; 64 KiB cap keeps the tail.
- **Sanitize** (`TestSanitizeHookPreview`, 23 cases): 2J/H, alt-screen, cursor hide/show/moves, scroll region, erase, OSC (BEL + ST), single-char escapes, device query, `\r`/CRLF, C0 controls, incomplete trailing sequences → all stripped; basic/256-color/truecolor/colon-subparam SGR and UTF-8 text intact. Plus an every-case invariant check that output contains no non-SGR escapes or stray controls.
- **Ready signals** (`TestSanitizeHookPreviewKeepsReadySignals`): realistic raw remote captures for codex/claude/aider/gemini still contain their `isReadyContent` glyphs after sanitization.
- **Full read path** (`TestHookBackendPreviewSanitizesBuffer`): seeded raw buffer comes back clean from both `Preview` and `PreviewFullHistory`.
- **UI regression** (`TestPreviewRemoteHookStripsControlSequences`): a hook-backed instance with a raw alt-screen/ED2/cursor-move stream rendered through `PreviewPane.String()` leaves no escape bytes other than well-formed SGR, and no `\r`.

## Verification

- `go build ./...`, `gofmt -l .` (clean), `golangci-lint run --timeout=3m --fast` (clean), `deadcode -test ./...` (clean)
- `go test ./...` — one unrelated flake (`integration/TestConcurrentCLIClientsUseDaemonCoordinator` timed out under full-suite load; passes in isolation), everything else green
- `go test -race ./session/...` and `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/... ./app/...` — green

Not merging — Captain Claude to verify with a live scroll-past-remote check on the real detail repo before merge.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)