### PR TITLE
fix(task): reject blank trigger values instead of silently clearing them (#814)

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -261,6 +261,18 @@ var tasksUpdateCmd = &cobra.Command{
 		if taskUpdateCronFlag != "" && taskUpdateWatchCmdFlag != "" {
 			return jsonError(errors.New("--cron and --watch-cmd are mutually exclusive; a task has exactly one trigger"))
 		}
+		// Under partial-update semantics "" means "leave unchanged", so a
+		// blank value is never a request to clear a trigger — the supported
+		// way to clear one is to set the other, which clears its counterpart
+		// below. Whitespace-only values used to pass the != "" presence
+		// checks, trim to "", and silently wipe both triggers on disabled
+		// tasks, where ValidateTrigger tolerates the draft state (#814).
+		if taskUpdateCronFlag != "" && strings.TrimSpace(taskUpdateCronFlag) == "" {
+			return jsonError(errors.New("cron expression must be non-empty"))
+		}
+		if taskUpdateWatchCmdFlag != "" && strings.TrimSpace(taskUpdateWatchCmdFlag) == "" {
+			return jsonError(errors.New("watch-cmd must be non-empty"))
+		}
 		if taskUpdateCronFlag != "" {
 			if err := task.ValidateCronExpr(taskUpdateCronFlag); err != nil {
 				return jsonError(fmt.Errorf("invalid cron expression: %w", err))
@@ -273,7 +285,7 @@ var tasksUpdateCmd = &cobra.Command{
 			}
 			// Setting one trigger clears the other so the exactly-one rule
 			// holds when switching a watch task back to a schedule.
-			s.CronExpr = taskUpdateCronFlag
+			s.CronExpr = strings.TrimSpace(taskUpdateCronFlag)
 			s.WatchCmd = ""
 		}
 		if taskUpdateWatchCmdFlag != "" {

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -288,6 +288,95 @@ func TestTasksUpdate_RejectsEmptyPrompt(t *testing.T) {
 	}
 }
 
+func TestTasksUpdate_RejectsBlankWatchCmd(t *testing.T) {
+	// Whitespace-only --watch-cmd used to pass the != "" presence check,
+	// trim to "", and silently clear BOTH triggers. On disabled tasks
+	// ValidateTrigger tolerates the no-trigger draft state, so the wipe
+	// persisted with no error (#814).
+	for _, enabled := range []bool{true, false} {
+		for _, watch := range []string{"   ", "\t\n"} {
+			t.Run(fmt.Sprintf("enabled=%v/watch=%q", enabled, watch), func(t *testing.T) {
+				useTempConfig(t)
+				resetUpdateFlags(t)
+				calls := stubDaemon(t)
+
+				seedTask(t, task.Task{
+					ID:       "wb1",
+					Name:     "nightly",
+					Prompt:   "sweep",
+					CronExpr: "0 3 * * *",
+					Enabled:  enabled,
+				})
+
+				taskUpdateWatchCmdFlag = watch
+				err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"wb1"})
+
+				require.Error(t, err, "blank watch-cmd must be rejected")
+				assert.Contains(t, err.Error(), "watch-cmd must be non-empty")
+
+				got, err := task.GetTask("wb1")
+				require.NoError(t, err)
+				assert.Equal(t, "0 3 * * *", got.CronExpr, "existing trigger must survive a rejected update")
+				assert.Empty(t, got.WatchCmd)
+				assert.Zero(t, calls.reloads)
+			})
+		}
+	}
+}
+
+func TestTasksUpdate_RejectsBlankCron(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		for _, cron := range []string{"   ", "\t\n"} {
+			t.Run(fmt.Sprintf("enabled=%v/cron=%q", enabled, cron), func(t *testing.T) {
+				useTempConfig(t)
+				resetUpdateFlags(t)
+				calls := stubDaemon(t)
+
+				seedTask(t, task.Task{
+					ID:       "cb1",
+					Name:     "log watch",
+					WatchCmd: "tail -f errors.log",
+					Enabled:  enabled,
+				})
+
+				taskUpdateCronFlag = cron
+				err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"cb1"})
+
+				require.Error(t, err, "blank cron must be rejected")
+				assert.Contains(t, err.Error(), "cron expression must be non-empty")
+
+				got, err := task.GetTask("cb1")
+				require.NoError(t, err)
+				assert.Equal(t, "tail -f errors.log", got.WatchCmd, "existing trigger must survive a rejected update")
+				assert.Empty(t, got.CronExpr)
+				assert.Zero(t, calls.reloads)
+			})
+		}
+	}
+}
+
+func TestTasksUpdate_TrimsCronAndWatchCmd(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	stubDaemon(t)
+
+	seedTask(t, task.Task{ID: "tr1", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
+
+	taskUpdateWatchCmdFlag = "  tail -f errors.log  "
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"tr1"}))
+	got, err := task.GetTask("tr1")
+	require.NoError(t, err)
+	assert.Equal(t, "tail -f errors.log", got.WatchCmd, "watch-cmd must be stored trimmed, matching the add path")
+
+	resetUpdateFlags(t)
+	taskUpdateCronFlag = "  30 6 * * 1  "
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"tr1"}))
+	got, err = task.GetTask("tr1")
+	require.NoError(t, err)
+	assert.Equal(t, "30 6 * * 1", got.CronExpr, "cron must be stored trimmed, matching the add path")
+	assert.Empty(t, got.WatchCmd)
+}
+
 func TestTasksUpdate_RejectsBadEnabledValue(t *testing.T) {
 	useTempConfig(t)
 	resetUpdateFlags(t)


### PR DESCRIPTION
Fixes #814

## Bug

`af tasks update <id> --watch-cmd "   "` passed the `!= ""` presence check, trimmed to `""` on assignment, and cleared **both** triggers (`WatchCmd` set to empty, `CronExpr` zeroed by the switch logic). On enabled tasks `ValidateTrigger()` caught the no-trigger state (with a confusing message); on **disabled** tasks the draft state is tolerated by design (#794), so the update persisted and silently wiped the task's trigger configuration. Regression introduced with the watch_cmd feature (`f6c5463`).

## Fix

Blank (whitespace-only) `--cron` / `--watch-cmd` values on `tasks update` now error up front:

- `--watch-cmd "   "` → `watch-cmd must be non-empty`
- `--cron "   "` → `cron expression must be non-empty`

This mirrors the `--prompt` trim-validation already in the update path (#568) and the trim-before-presence-check in the add path (#517). Under partial-update semantics an empty value means "leave unchanged", so a blank value is never a valid request to clear a trigger — the supported way to clear one remains setting the other flag, which switches the trigger atomically (already documented in the flag help: "clears watch-cmd" / "clears cron").

Also stores cron trimmed on update, matching the add path (previously `--cron " 30 6 * * 1 "` persisted with padding).

## Adjacent call-site audit

Every site that writes trigger fields:

- **add path** (`api/tasks.go`): trims before the exactly-one presence check — blank values can't count as a trigger. No gap.
- **update path** (`api/tasks.go`): fixed here.
- **TUI form** (`ui/task_pane.go`): `validateForm()` rejects blank watch/cron before save and `triggerValues()` trims + zeros the counterpart. No gap.

## Tests

- `TestTasksUpdate_RejectsBlankWatchCmd` — enabled × disabled × whitespace variants; asserts the error, that the existing cron trigger survives on disk, and that the daemon is not poked.
- `TestTasksUpdate_RejectsBlankCron` — same matrix for the cron flag against a watch task.
- `TestTasksUpdate_TrimsCronAndWatchCmd` — padded values stored trimmed, counterpart cleared.

## Verification

- `gofmt -l .`, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` all clean; `go test ./api/... ./task/...` green including `-race`.
- Full `go test ./...`: pre-existing environmental failures in `integration` (daemon-socket tests, reproduce identically on `master` on this box) and one load-sensitive `app` TUI e2e flake that passes with `-count=2` on this branch; nothing related to this change.
- Manual end-to-end against a built binary in a temp `AGENT_FACTORY_HOME`: the #814 repro (disabled cron task + blank `--watch-cmd`) now errors and the trigger survives on disk; legit trigger switching still works.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)