### PR TITLE
fix(session/storage): stop daemon save from resurrecting externally-killed sessions (#819)

### DIFF
--- a/session/storage.go
+++ b/session/storage.go
@@ -98,6 +98,74 @@ func dedupeInstanceData(data []InstanceData) []InstanceData {
 	return out
 }
 
+// mergeInstancesWithDisk applies the save-merge rules shared by the TUI and
+// daemon save paths to one repo's worth of state. It returns the records to
+// persist; callers still dedupe (#808), marshal, and write under the lock.
+//
+//   - In-memory instances take precedence over their disk records.
+//   - Loading instances are never persisted — their worktree is not yet
+//     populated, so FromInstanceData cannot restore them, and an orphaned
+//     record would block title reuse via the daemon's collision check (#551).
+//   - Non-started instances are dropped.
+//   - An in-memory instance whose disk record was removed by another process
+//     AND whose backing session is dead is dropped instead of being
+//     resurrected from stale memory (#819). If the session is still alive,
+//     the record is rewritten — an externally wiped or truncated file must
+//     not take live sessions down with it.
+//   - Disk-only records are preserved as externally-added, except legacy
+//     Loading ghosts (#551) and titles in knownTitles.
+//
+// knownTitles is the set of ALL in-memory titles for this repo, including
+// non-started ones. It distinguishes "killed in this process" (the stale
+// disk record must not be preserved) from "added externally on disk". The
+// daemon passes its per-repo title set; the TUI passes nil because it
+// deletes killed sessions from disk explicitly rather than via save-merge.
+func mergeInstancesWithDisk(instances []*Instance, diskData []InstanceData, knownTitles map[string]bool) []InstanceData {
+	diskTitles := make(map[string]bool, len(diskData))
+	for _, disk := range diskData {
+		diskTitles[disk.Title] = true
+	}
+
+	merged := make([]InstanceData, 0, len(instances)+len(diskData))
+	memTitles := make(map[string]bool, len(instances))
+	for _, instance := range instances {
+		if instance.GetStatus() == Loading {
+			continue
+		}
+		if !instance.Started() {
+			continue
+		}
+		// If another process deleted the disk record and the backing
+		// session is gone, don't resurrect it from stale memory.
+		if !diskTitles[instance.Title] && !instance.TmuxAlive() {
+			continue
+		}
+		merged = append(merged, instance.ToInstanceData())
+		memTitles[instance.Title] = true
+	}
+
+	for _, disk := range diskData {
+		if memTitles[disk.Title] {
+			// Already covered by the in-memory version.
+			continue
+		}
+		if knownTitles[disk.Title] {
+			// Known in memory but filtered out above (e.g. killed).
+			// Don't preserve the stale disk record.
+			continue
+		}
+		// Disk-only Loading entries are stale pre-save records from a
+		// start that never completed. External CLI/task creates are only
+		// persisted after startup succeeds, so they arrive as non-Loading.
+		if disk.Status == Loading {
+			continue
+		}
+		// Externally added instance — keep it.
+		merged = append(merged, disk)
+	}
+	return merged
+}
+
 // SaveInstances saves the list of instances to disk under file locks.
 // Loading instances are excluded — they represent in-flight TUI session
 // creations whose worktree is not yet populated, so they cannot be
@@ -110,62 +178,36 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 		return s.saveRepoInstances(instances)
 	}
 
-	// Convert instances to InstanceData
-	data := make([]InstanceData, 0)
-	for _, instance := range instances {
-		if instance.Started() {
-			data = append(data, instance.ToInstanceData())
-		}
-	}
-
 	// Daemon mode: group in-memory instances by repo root.
 	// Prefer the worktree's resolved repo path so we share a repo ID with
 	// the TUI even when the instance was created from a symlinked path;
 	// fall back to Path for remote backends where Worktree.RepoPath is
-	// empty. This mirrors CollectRepoRoots (#667).
-	grouped := make(map[string][]InstanceData)
-	for _, d := range data {
-		root := d.Worktree.RepoPath
-		if root == "" {
-			root = d.Path
-		}
-		rid := config.RepoIDFromRoot(root)
-		grouped[rid] = append(grouped[rid], d)
-	}
-
-	// Collect repo IDs that the daemon knows about so we visit repos
-	// that had all their in-memory instances killed (group would be empty).
-	knownRepoIDs := make(map[string]bool)
+	// empty. This mirrors CollectRepoRoots (#667). All instances are
+	// grouped — including non-started ones — so repos whose sessions were
+	// all killed are still visited and their records removed.
+	//
+	// The per-repo title sets must be scoped per-repo, not global: a
+	// global set across all repos causes cross-repo title collisions to
+	// drop legitimate externally-added instances from other repos (#198).
+	grouped := make(map[string][]*Instance)
+	repoTitles := make(map[string]map[string]bool)
 	for _, inst := range instances {
 		root := inst.GetRepoPath()
 		if root == "" {
 			root = inst.Path
 		}
 		rid := config.RepoIDFromRoot(root)
-		knownRepoIDs[rid] = true
+		grouped[rid] = append(grouped[rid], inst)
+		if repoTitles[rid] == nil {
+			repoTitles[rid] = make(map[string]bool)
+		}
+		repoTitles[rid][inst.Title] = true
 	}
 
-	// Merge each repo's in-memory state with disk state.
-	for rid := range knownRepoIDs {
-		group := grouped[rid] // may be nil if all instances for this repo were killed
-
-		// Build a per-repo set of ALL in-memory instance titles (including
-		// non-started/non-loading ones) belonging to THIS repo. This is used
-		// to distinguish "killed in daemon" from "added externally on disk".
-		// IMPORTANT: this must be scoped per-repo. Using a global set across
-		// all repos causes cross-repo title collisions to drop legitimate
-		// externally-added instances from other repos (issue #198).
-		repoMemTitlesAll := make(map[string]bool)
-		for _, inst := range instances {
-			root := inst.GetRepoPath()
-			if root == "" {
-				root = inst.Path
-			}
-			if config.RepoIDFromRoot(root) == rid {
-				repoMemTitlesAll[inst.Title] = true
-			}
-		}
-
+	// Merge each repo's in-memory state with disk state. Repos that exist
+	// ONLY on disk (no in-memory instances at all) were never loaded by
+	// the daemon; we never write to them, so they are naturally preserved.
+	for rid, group := range grouped {
 		path, pathErr := config.RepoInstancesPath(rid)
 		if pathErr != nil {
 			return pathErr
@@ -189,40 +231,7 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 				}
 			}
 
-			// Build set of in-memory titles for this repo's group for
-			// quick lookup when replacing disk entries.
-			memTitles := make(map[string]bool, len(group))
-			for _, d := range group {
-				memTitles[d.Title] = true
-			}
-
-			// Start with the in-memory instances (they take precedence).
-			merged := make([]InstanceData, 0, len(group)+len(diskData))
-			merged = append(merged, group...)
-
-			// Preserve disk-only instances that were NOT known to the
-			// daemon (i.e. added externally while the daemon was running).
-			for _, dd := range diskData {
-				if memTitles[dd.Title] {
-					// Already covered by the in-memory version.
-					continue
-				}
-				if repoMemTitlesAll[dd.Title] {
-					// The daemon knew about this instance in THIS repo but
-					// it is no longer started/loading (e.g. killed). Don't
-					// preserve it.
-					continue
-				}
-				// Legacy Loading ghosts (#551) left by older binaries
-				// would block title reuse via the daemon's collision
-				// check. Drop them on the next save instead of
-				// preserving them as "external".
-				if dd.Status == Loading {
-					continue
-				}
-				// Externally added instance — keep it.
-				merged = append(merged, dd)
-			}
+			merged := mergeInstancesWithDisk(group, diskData, repoTitles[rid])
 
 			jsonData, err := json.Marshal(dedupeInstanceData(merged))
 			if err != nil {
@@ -233,11 +242,6 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 			return err
 		}
 	}
-
-	// Handle repos that exist ONLY on disk (no in-memory instances at all).
-	// These repos were never loaded by the daemon, so we must not touch them.
-	// Since we only iterate knownRepoIDs above, disk-only repos are
-	// naturally preserved (we never write to them).
 
 	return nil
 }
@@ -262,48 +266,7 @@ func (s *Storage) saveRepoInstances(instances []*Instance) error {
 			}
 		}
 
-		diskTitles := make(map[string]bool, len(diskData))
-		for _, disk := range diskData {
-			diskTitles[disk.Title] = true
-		}
-
-		data := make([]InstanceData, 0)
-		memTitles := make(map[string]bool)
-		for _, instance := range instances {
-			// Loading is transient TUI state — its worktree is not yet
-			// populated, so FromInstanceData cannot restore it. Persisting
-			// it would leave an orphan that the daemon's title-collision
-			// check would treat as live (#551).
-			if instance.GetStatus() == Loading {
-				continue
-			}
-			if !instance.Started() {
-				continue
-			}
-			// If another process deleted the disk record and the backing
-			// session is gone, don't resurrect it from stale TUI memory.
-			if !diskTitles[instance.Title] && !instance.TmuxAlive() {
-				continue
-			}
-			d := instance.ToInstanceData()
-			data = append(data, d)
-			memTitles[d.Title] = true
-		}
-
-		merged := make([]InstanceData, 0, len(data)+len(diskData))
-		merged = append(merged, data...)
-		for _, disk := range diskData {
-			if memTitles[disk.Title] {
-				continue
-			}
-			// Disk-only Loading entries are stale pre-save records from a TUI
-			// start that never completed. External CLI/task creates are only
-			// persisted after startup succeeds, so they arrive as non-Loading.
-			if disk.Status == Loading {
-				continue
-			}
-			merged = append(merged, disk)
-		}
+		merged := mergeInstancesWithDisk(instances, diskData, nil)
 
 		jsonData, err := json.Marshal(dedupeInstanceData(merged))
 		if err != nil {

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -83,6 +83,8 @@ func readDisk(t *testing.T, ms *mockInstanceStorage, repoPath string) []Instance
 
 // makeInstance creates a minimal Instance for testing.
 // started controls whether the instance appears started.
+// Its backend is a LocalBackend with no tmux session, so TmuxAlive()
+// reports false — the shape of a session that died or was killed.
 func makeInstance(title, repoPath string, started bool) *Instance {
 	i := &Instance{
 		Title:     title,
@@ -92,6 +94,16 @@ func makeInstance(title, repoPath string, started bool) *Instance {
 		backend:   &LocalBackend{},
 		started:   started,
 	}
+	return i
+}
+
+// makeAliveInstance creates a minimal started Instance whose backend reports
+// the session alive, for tests modeling live sessions. Live sessions must be
+// persisted even when their disk record is missing (#736 territory); only
+// dead-AND-deleted instances are dropped by the save merge (#819).
+func makeAliveInstance(title, repoPath string) *Instance {
+	i := makeInstance(title, repoPath, true)
+	i.backend = &FakeBackend{}
 	return i
 }
 
@@ -229,8 +241,9 @@ func TestDaemonSaveEmptyDisk(t *testing.T) {
 	const repoPath = "/tmp/test-repo"
 	ms := newMockStorage()
 
-	// No existing disk state.
-	instanceA := makeInstance("instance-A", repoPath, true)
+	// No existing disk state. The instance must be alive to be persisted —
+	// a dead instance with no disk record is treated as externally killed (#819).
+	instanceA := makeAliveInstance("instance-A", repoPath)
 
 	storage, err := NewStorage(ms, "")
 	require.NoError(t, err)
@@ -266,7 +279,7 @@ func TestDaemonSaveCrossRepoTitleCollision(t *testing.T) {
 	// visit repo B).
 	instanceAShared := makeInstance("shared", repoPathA, true)
 	instanceAShared.Branch = "branch-a"
-	instanceBOther := makeInstance("other-b", repoPathB, true)
+	instanceBOther := makeAliveInstance("other-b", repoPathB)
 
 	storage, err := NewStorage(ms, "")
 	require.NoError(t, err)
@@ -383,6 +396,83 @@ func TestRepoSaveDoesNotResurrectDeadDiskMissingInstance(t *testing.T) {
 
 	result := readDisk(t, ms, repoPath)
 	assert.Empty(t, result, "stale TUI memory must not recreate a deleted instance record")
+}
+
+// TestDaemonSaveDoesNotResurrectDeadDiskMissingInstance is the daemon-mode
+// counterpart of the TUI test above (#819). If tmux is killed externally and
+// the disk record is deleted by another process before the daemon's next
+// refresh tick, a shutdown-triggered save runs with stale memory — it must
+// not write the dead session back to disk, where it would block title reuse
+// and fail to restore.
+func TestDaemonSaveDoesNotResurrectDeadDiskMissingInstance(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	ms := newMockStorage()
+
+	// The repo has another live session on disk, so the daemon's save
+	// definitely visits and rewrites this repo's file.
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "other-session", Path: repoPath, Status: Running},
+	})
+
+	// Looks started in daemon memory, but its tmux session is dead and its
+	// disk record was deleted by another process.
+	stale := makeInstance("stale", repoPath, true)
+	other := makeInstance("other-session", repoPath, true)
+
+	storage, err := NewStorage(ms, "") // daemon mode
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{other, stale})
+	require.NoError(t, err)
+
+	result := readDisk(t, ms, repoPath)
+	titles := make(map[string]bool)
+	for _, d := range result {
+		titles[d.Title] = true
+	}
+	assert.False(t, titles["stale"], "stale daemon memory must not recreate a deleted instance record (#819)")
+	assert.True(t, titles["other-session"], "the surviving session must still be saved")
+}
+
+// TestDaemonSavePreservesAliveDiskMissingInstance is the #819 counter-case:
+// when the disk record is missing but the tmux session is still ALIVE (e.g.
+// instances.json was wiped externally, #736 territory), the daemon must
+// rewrite the record, not drop the live session.
+func TestDaemonSavePreservesAliveDiskMissingInstance(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	ms := newMockStorage()
+
+	alive := makeAliveInstance("alive", repoPath)
+
+	storage, err := NewStorage(ms, "") // daemon mode
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{alive})
+	require.NoError(t, err)
+
+	result := readDisk(t, ms, repoPath)
+	require.Len(t, result, 1, "live session with a missing disk record must be re-persisted")
+	assert.Equal(t, "alive", result[0].Title)
+}
+
+// TestRepoSavePreservesAliveDiskMissingInstance mirrors the counter-case for
+// the TUI path, guarding the shared merge helper from both call sites.
+func TestRepoSavePreservesAliveDiskMissingInstance(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	repoID := config.RepoIDFromRoot(repoPath)
+	ms := newMockStorage()
+
+	alive := makeAliveInstance("alive", repoPath)
+
+	storage, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{alive})
+	require.NoError(t, err)
+
+	result := readDisk(t, ms, repoPath)
+	require.Len(t, result, 1, "live session with a missing disk record must be re-persisted")
+	assert.Equal(t, "alive", result[0].Title)
 }
 
 // TestRepoSaveDropsLoadingFromMemory is a regression test for
@@ -526,7 +616,7 @@ func TestDaemonSaveFallsBackToPathForRemoteBackend(t *testing.T) {
 	ms := newMockStorage()
 
 	// Remote-backend instance: no gitWorktree, Worktree.RepoPath empty.
-	inst := makeInstance("remote-1", repoPath, true)
+	inst := makeAliveInstance("remote-1", repoPath)
 	require.Empty(t, inst.GetRepoPath(), "test fixture: remote instance must have empty resolved repo path")
 
 	storage, err := NewStorage(ms, "")


### PR DESCRIPTION
## Problem

Daemon-mode `SaveInstances` persisted every in-memory instance with `started=true`, with no liveness or disk-record check. If a session's tmux was killed externally and another process deleted its disk record before the daemon's next refresh tick, a shutdown-triggered save (SIGTERM handler) wrote the dead session back to `instances.json` — blocking title reuse and leaving stale records that fail to restore. The TUI path already guarded against exactly this with `!diskTitles[instance.Title] && !instance.TmuxAlive()` (introduced alongside the path split in #434, but only on the TUI side).

## Fix

Rather than copy-pasting the guard, the save-merge rules the two paths shared are extracted into one helper, `mergeInstancesWithDisk`, called by both `SaveInstances` (daemon, per repo) and `saveRepoInstances` (TUI):

- In-memory instances take precedence over their disk records.
- Loading instances are never persisted (#551), and disk-only legacy Loading ghosts are reaped (#551).
- An in-memory instance whose disk record was removed by another process **and** whose session is dead is dropped instead of resurrected (**this fix, #819**). If the session is still alive (external file wipe — #736 territory), the record is rewritten.
- Disk-only records are preserved as externally-added, except titles the daemon knew in memory (killed sessions), still scoped per-repo (#198).

The daemon path now groups `*Instance` per repo (instead of pre-converted `InstanceData`) so the liveness check can run inside the per-repo file lock against that repo's actual disk state. `TmuxAlive()` is only consulted when the disk record is missing, so the common case adds no tmux round-trips. The #766 refuse-to-overwrite-on-read-error behavior and the differing parse-failure semantics (TUI errors out, daemon warns and overwrites) are intentionally unchanged.

## #809 dedup audit (adjacent call-sites)

Per the adjacent-call-sites rule, I audited every `Storage.SaveInstances` caller (daemon `Manager.SaveInstances`, TUI `app/app.go` + `app/sync.go` — all funnel into the two paths fixed here) and the #809 dedup chokepoints. `dedupeInstanceData` runs **after** the merge on its output, and the resurrection guard removes the dead record before merging, so the newest-`UpdatedAt` rule has nothing to resurrect; load-side dedup only sees what was persisted. All #808/#809 tests pass unchanged.

## Tests

- `TestDaemonSaveDoesNotResurrectDeadDiskMissingInstance` — the #819 repro: daemon holds a started record, tmux dead, record deleted from disk → not resurrected; surviving sessions still saved.
- `TestDaemonSavePreservesAliveDiskMissingInstance` / `TestRepoSavePreservesAliveDiskMissingInstance` — counter-case from both call sites: tmux alive but record missing on disk → rewritten, not dropped.
- New `makeAliveInstance` helper (FakeBackend, `IsAlive`=true); the three existing daemon tests that model live sessions saved onto a record-less disk now use it, since `makeInstance`'s nil-tmux `LocalBackend` is the dead-session shape.
- All pre-existing storage tests (#198, #551, #667, #736/#766, #808/#809) pass unchanged.

## Verification

`go build ./...`, `gofmt -l`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `go test ./...` all clean, plus `go test -race` on `./session/`, `./ui/...`, `./app/...`. The only failure on my box is `integration/TestConcurrentCLIClientsUseDaemonCoordinator`, which fails identically on the `master` checkout (dev-box daemon/tmux contention, same family as the known `TestSigtermFallback_DeadPID` flake) — not related to this change.

Fixes #819

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)