### PR TITLE
fix(config): resolve symlinks in the in-repo save collision guard (#812)

### DIFF
--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -227,6 +227,28 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 	return &cfg, data, nil
 }
 
+// resolveSymlinksForCompare resolves symlinks in a path that may not exist
+// yet, for path-identity comparisons: the deepest existing ancestor is
+// resolved with filepath.EvalSymlinks and the non-existent remainder is
+// re-joined. Falls back to the cleaned input when nothing resolves, so a
+// comparison built on it is never weaker than comparing Clean-ed paths.
+func resolveSymlinksForCompare(path string) string {
+	path = filepath.Clean(path)
+	suffix := ""
+	for {
+		resolved, err := filepath.EvalSymlinks(path)
+		if err == nil {
+			return filepath.Join(resolved, suffix)
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return filepath.Join(path, suffix)
+		}
+		suffix = filepath.Join(filepath.Base(path), suffix)
+		path = parent
+	}
+}
+
 // SaveInRepoPostWorktreeCommands writes the given post-worktree commands into
 // the repo's in-repo config file — the canonical location for this field
 // since #800 — creating the file if needed and preserving every other field
@@ -238,13 +260,26 @@ func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 		return fmt.Errorf("repo root is required to save in-repo config")
 	}
 	path := InRepoConfigPath(repoRoot)
+	// Compare resolved paths, not Clean-ed strings (#812): a symlinked
+	// AGENT_FACTORY_HOME (or a symlinked .agent-factory dir) makes distinct
+	// strings name the same file, and these guards exist precisely for the
+	// aliased cases.
+	resolvedPath := resolveSymlinksForCompare(path)
 	// A repo rooted at the user's home directory makes the in-repo path
 	// collide with the global config file; writing hooks there would clobber
 	// the user's global settings.
 	if configDir, dirErr := GetConfigDir(); dirErr == nil {
-		if filepath.Clean(path) == filepath.Clean(filepath.Join(configDir, ConfigFileName)) {
-			return fmt.Errorf("in-repo config path %s collides with the global config file; not saving", prettyHomePath(path))
+		globalPath := filepath.Join(configDir, ConfigFileName)
+		if resolvedPath == resolveSymlinksForCompare(globalPath) {
+			return fmt.Errorf("in-repo config path %s collides with the global config file %s; not saving — run this from a repo whose root is not the config home", prettyHomePath(path), prettyHomePath(globalPath))
 		}
+	}
+	// Mirror the read-path containment guard for writes: a .agent-factory
+	// dir symlinked outside the repo must not receive the save. The read
+	// guard alone can't cover this — it only fires when the config file
+	// already exists at the resolved location.
+	if !strings.HasPrefix(resolvedPath, resolveSymlinksForCompare(repoRoot)+string(filepath.Separator)) {
+		return fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to save it", prettyHomePath(path), prettyHomePath(resolvedPath))
 	}
 	data, err := readInRepoConfigFile(repoRoot)
 	if err != nil {

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -201,6 +201,51 @@ func TestLoadInRepoConfigHomeRepoCollision(t *testing.T) {
 	assert.Contains(t, err.Error(), "collides")
 }
 
+// TestSaveInRepoSymlinkedConfigHomeCollision is the regression test for #812:
+// AGENT_FACTORY_HOME pointing at the repo's .agent-factory dir through a
+// symlink must still trip the save collision guard — filepath.Clean alone
+// compares the unequal strings and lets the save overwrite the global config.
+func TestSaveInRepoSymlinkedConfigHomeCollision(t *testing.T) {
+	repoRoot := t.TempDir()
+	realHome := filepath.Join(repoRoot, InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(realHome, 0755))
+	globalContent := `{"default_program": "claude", "auto_yes": true}`
+	globalFile := filepath.Join(realHome, ConfigFileName)
+	require.NoError(t, os.WriteFile(globalFile, []byte(globalContent), 0644))
+
+	linkHome := filepath.Join(t.TempDir(), "af-home-link")
+	require.NoError(t, os.Symlink(realHome, linkHome))
+	t.Setenv("AGENT_FACTORY_HOME", linkHome)
+
+	err := SaveInRepoPostWorktreeCommands(repoRoot, []string{"echo hi"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collides")
+
+	data, err := os.ReadFile(globalFile)
+	require.NoError(t, err)
+	assert.JSONEq(t, globalContent, string(data), "global config must be untouched by the refused save")
+
+	// The read path must keep treating this layout as "no in-repo config".
+	cfg, raw, err := LoadInRepoConfig(repoRoot)
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+	assert.Nil(t, raw)
+}
+
+func TestSaveInRepoRefusesSymlinkDirOutsideRepo(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	outsideDir := t.TempDir()
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(repoRoot, InRepoConfigDirName)))
+
+	err := SaveInRepoPostWorktreeCommands(repoRoot, []string{"echo hi"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside the repository")
+
+	_, statErr := os.Stat(filepath.Join(outsideDir, ConfigFileName))
+	assert.True(t, os.IsNotExist(statErr), "nothing must be written outside the repo")
+}
+
 func TestSaveInRepoPostWorktreeCommands(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
@@ -234,5 +279,18 @@ func TestSaveInRepoPostWorktreeCommands(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, cfg.IsSet("post_worktree_commands"))
 		assert.Empty(t, cfg.PostWorktreeCommands)
+	})
+
+	t.Run("dir symlink that stays inside the repo still saves", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		realDir := filepath.Join(repoRoot, "cfg")
+		require.NoError(t, os.MkdirAll(realDir, 0755))
+		require.NoError(t, os.Symlink(realDir, filepath.Join(repoRoot, InRepoConfigDirName)))
+
+		require.NoError(t, SaveInRepoPostWorktreeCommands(repoRoot, []string{"make setup"}))
+
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"make setup"}, cfg.PostWorktreeCommands)
 	})
 }


### PR DESCRIPTION
Fixes #812 — a regression of the in-repo config feature (#805), security-relevant data loss.

## Bug

`SaveInRepoPostWorktreeCommands` guards against the in-repo config path colliding with the global config file, but compared the two paths with `filepath.Clean` only. `Clean` is a pure string normalization — it does not resolve symlinks. When `AGENT_FACTORY_HOME` is a symlink, `GetConfigDir()` returns the symlink path while the repo root (from git, which resolves to real paths) yields the real path; the strings differ, the guard passes, and the in-repo hook save silently **overwrites the user's global config**, dropping settings like `default_program` and `auto_yes`.

The read path (`readInRepoConfigFile`) already does this correctly — it runs `filepath.EvalSymlinks` on both sides before its global-collision comparison. The save path missed the same treatment.

## Fix

- New helper `resolveSymlinksForCompare`: resolves symlinks for a path that may not exist yet by resolving its deepest existing ancestor and re-joining the remainder; falls back to the `Clean`-ed input, so comparisons built on it are never weaker than before.
- The save-path global-collision guard now compares resolved paths, with an error naming both paths.
- The audit (below) surfaced a second write-side hole, also fixed here: the read path's repo-containment guard only fires when the in-repo file already *exists* at the resolved location. A `.agent-factory` dir symlinked outside the repo with no `config.json` at the target slipped past it, and the save would write into the external directory. The save now refuses any target that resolves outside the resolved repo root, mirroring the read-path containment guard.

## Adjacent-call-site audit

Every path-comparison guard reachable from this code path, plus a repo-wide sweep for `filepath.Clean`-based comparisons:

| Site | Kind | Verdict |
|---|---|---|
| `config/inrepo.go` read containment (`readInRepoConfigFile`) | cross-base identity/containment | already resolves symlinks — correct |
| `config/inrepo.go` read global-collision | cross-base identity | already resolves symlinks — correct |
| `config/inrepo.go` save global-collision | cross-base identity | **was `Clean`-only — fixed** |
| `config/inrepo.go` save containment | cross-base containment | **was missing — added** |
| `config/repo_config.go:72` (`repoStateDir`) | lexical containment of validated `repoID` against the same string base | not affected — `ValidateRepoID` rejects separators and `..`; both sides share the prefix string, so symlinks cannot diverge them |
| `config/state.go:139` (`repoInstancesPath`) | same pattern | not affected, same reasoning |
| `daemon/taskrun.go:146` (lock path) | same pattern on validated task ID | not affected, same reasoning |
| `session/git/worktree_ops.go:290` | path normalization for `worktree list` matching | already resolves symlinks best-effort |
| `config/repo.go:84,96` | `Clean` of git output for normalization, not a guard | not affected |

## Tests

- `TestSaveInRepoSymlinkedConfigHomeCollision` — the exact #812 scenario (symlinked `AGENT_FACTORY_HOME` pointing into the repo): save refused with the `collides` error, global config asserted byte-identical after the refusal, read path still treats the layout as "no in-repo config".
- `TestSaveInRepoRefusesSymlinkDirOutsideRepo` — `.agent-factory` dir symlinked outside the repo, no file at target: save refused with `outside the repository`, nothing written externally.
- `TestSaveInRepoPostWorktreeCommands/dir symlink that stays inside the repo still saves` — no false positives for legitimate in-repo symlinks.
- Both new guard tests verified to **fail against the pre-fix code** and pass with it. All existing in-repo read-path tests unchanged and green.

Verification: `gofmt -l` clean, `golangci-lint run --timeout=3m --fast` clean, `go build ./...`, `deadcode -test ./...` clean, `go test ./...` green (two `integration/` daemon-socket tests fail identically on a clean master checkout on this dev box — environmental, unrelated), plus `-race` runs for `config`, `ui`, and `app`.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)