### PR TITLE
fix(session/hook): take preview teardown off the event loop so remote attach does not freeze the TUI (#817)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -343,8 +343,15 @@ func (b *HookBackend) Attach(i *Instance) (chan struct{}, error) {
 		return nil, fmt.Errorf("cannot attach instance that has not been started")
 	}
 
-	// Stop the background preview process so it doesn't compete.
-	b.closePTY(i.Title)
+	// Stop the background preview process so it doesn't compete, but reap it
+	// in the background: Attach runs on the bubbletea event loop, and waiting
+	// out the 2s grace period here froze the whole TUI whenever the preview
+	// process didn't exit promptly (#817). The dying preview only writes into
+	// its own buffer via its own pipe (see stopPreview), so it cannot
+	// interleave output with the interactive attach_cmd started below.
+	if hp := b.stopPreview(i.Title); hp != nil {
+		go hp.reap()
+	}
 
 	done := make(chan struct{})
 	go func() {
@@ -661,10 +668,11 @@ func (b *HookBackend) ensurePTY(i *Instance) error {
 		}
 		// The reader has hit EOF or an error, which means the attach_cmd
 		// child has closed its stdout (typically because it exited).
-		// If closePTY already marked us closed, it owns the Wait() call
-		// (and may need to Kill the process); otherwise the child exited
-		// on its own, so we Wait() here to reap it and mark the entry
-		// closed so a subsequent ensurePTY call can recreate it.
+		// If stopPreview already marked us closed, the detaching caller
+		// owns the Wait() call via reap (and may need to Kill the
+		// process); otherwise the child exited on its own, so we Wait()
+		// here to reap it and mark the entry closed so a subsequent
+		// ensurePTY call can recreate it.
 		hp.mu.Lock()
 		alreadyClosed := hp.closed
 		hp.mu.Unlock()
@@ -681,27 +689,56 @@ func (b *HookBackend) ensurePTY(i *Instance) error {
 	return nil
 }
 
-func (b *HookBackend) closePTY(title string) {
+// stopPreview removes the preview entry for title and signals its process to
+// stop, without waiting for it to exit. It returns the detached hookPTY (nil
+// if none was registered) so the caller decides where to pay the grace-period
+// wait in reap: Kill reaps synchronously so the preview process is gone before
+// delete_cmd tears down the remote session it is connected to; Attach reaps in
+// a background goroutine because it runs on the bubbletea event loop, where a
+// blocking wait freezes the TUI (#817).
+//
+// The entry is deleted from b.ptys before the process exits. That is safe:
+// once detached, the dying process can only write into its own hp.buf via its
+// own pipe — Preview no longer finds the entry, and a replacement started by
+// ensurePTY gets a fresh pipe and buffer, so output cannot interleave.
+// Closing the pipe's read end makes the process's next write fail with EPIPE,
+// nudging well-behaved attach scripts to exit during the grace period.
+func (b *HookBackend) stopPreview(title string) *hookPTY {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	hp, ok := b.ptys[title]
 	if !ok {
-		return
+		return nil
 	}
+	delete(b.ptys, title)
+
 	hp.mu.Lock()
 	hp.closed = true
 	hp.mu.Unlock()
 
 	_ = hp.stdout.Close()
-	// Give the process a moment to exit, then kill if needed.
-	done := hp.waitAsync()
+	return hp
+}
+
+// reap gives the detached preview process a moment to exit, then kills it.
+// It blocks for up to the 2s grace period, so it must never run on the TUI
+// event loop — see stopPreview for which callers reap where.
+func (hp *hookPTY) reap() {
 	select {
-	case <-done:
+	case <-hp.waitAsync():
 	case <-time.After(2 * time.Second):
 		_ = hp.cmd.Process.Kill()
 	}
-	delete(b.ptys, title)
+}
+
+// closePTY synchronously stops and reaps the preview process for title.
+// Used by Kill (delete_cmd must not race a live preview connection) and by
+// test cleanup; Attach uses stopPreview + a background reap instead (#817).
+func (b *HookBackend) closePTY(title string) {
+	if hp := b.stopPreview(title); hp != nil {
+		hp.reap()
+	}
 }
 
 func (hp *hookPTY) waitAsync() <-chan struct{} {

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1088,6 +1090,154 @@ func TestHookBackendEnsurePTYReturnsEarlyWhenAlive(t *testing.T) {
 		"ensurePTY must reuse a live entry rather than spawning a duplicate")
 
 	b.closePTY(i.Title)
+}
+
+// TestHookBackendAttachReturnsImmediatelyWhenPreviewIsSlowToDie is a
+// regression test for #817: Attach runs on the bubbletea event loop, and it
+// used to call closePTY synchronously, blocking the TUI for the full 2s
+// grace period whenever the preview process did not exit promptly after its
+// stdout pipe was closed. Attach must return well within the grace period
+// and must drop the preview entry immediately so ensurePTY after detach
+// starts a fresh process.
+func TestHookBackendAttachReturnsImmediatelyWhenPreviewIsSlowToDie(t *testing.T) {
+	dir := t.TempDir()
+	// The interactive attach (under a real PTY, stdout is a tty) exits
+	// immediately. The preview invocation (stdout is a pipe) prints once and
+	// then sleeps without writing again, so closing the pipe's read end
+	// delivers no EPIPE and the process outlives the 2s grace period unless
+	// the reaper kills it.
+	attachCmd := writeScript(t, dir, "attach.sh",
+		`if [ -t 1 ]; then exit 0; fi
+echo "preview for $1"
+sleep 3`)
+	b := &HookBackend{Hooks: config.RemoteHooks{AttachCmd: attachCmd}}
+	i := &Instance{
+		Title:   "slow-preview-test",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+	i.started = true
+
+	require.NoError(t, b.ensurePTY(i))
+	require.NotNil(t, b.getPTY(i.Title))
+	// Wait until the banner has been written. Before that point the preview
+	// is NOT slow-dying: its first echo would hit the closed pipe and kill it
+	// with SIGPIPE immediately, so attaching too early would pass even
+	// against the synchronous pre-#817 code.
+	require.Eventually(t, func() bool {
+		out, _ := b.Preview(i)
+		return strings.Contains(out, "preview for")
+	}, 2*time.Second, 10*time.Millisecond, "preview process never produced its banner")
+
+	start := time.Now()
+	done, err := b.Attach(i)
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"Attach must not wait out the preview grace period on the event loop (#817), took %v", elapsed)
+	assert.Nil(t, b.getPTY(i.Title),
+		"Attach must drop the preview entry immediately so a fresh one can start after detach")
+
+	// Cleanup: wait for the interactive attach goroutine to finish (it also
+	// restarts the preview process on detach), then reap that preview.
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("interactive attach did not exit")
+	}
+	b.closePTY(i.Title)
+}
+
+// TestHookBackendReapKillsStubbornPreviewProcess verifies that the
+// background reap Attach hands the detached preview to (#817) actually
+// terminates a process that ignores the closed pipe, so detached previews
+// cannot accumulate as leaked processes.
+func TestHookBackendReapKillsStubbornPreviewProcess(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "preview.pid")
+	// exec replaces the shell, so the PID written here is the PID reap kills.
+	// The process never writes after the banner, so it ignores the pipe close
+	// and only dies when reap's grace period expires and it gets killed.
+	attachCmd := writeScript(t, dir, "attach.sh",
+		`echo $$ > `+pidFile+`
+exec sleep 30`)
+	b := &HookBackend{Hooks: config.RemoteHooks{AttachCmd: attachCmd}}
+	i := &Instance{
+		Title:   "stubborn-preview-test",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	require.NoError(t, b.ensurePTY(i))
+	pid := waitForPidFile(t, pidFile)
+
+	hp := b.stopPreview(i.Title)
+	require.NotNil(t, hp)
+	assert.Nil(t, b.getPTY(i.Title))
+	hp.reap()
+
+	// reap returns right after sending the kill; give the kernel and the
+	// reaping Wait goroutine a moment to finish the death.
+	require.Eventually(t, func() bool {
+		return syscall.Kill(pid, 0) != nil
+	}, 2*time.Second, 20*time.Millisecond,
+		"stubborn preview process %d should be dead after reap", pid)
+}
+
+// TestHookBackendKillReapsPreviewBeforeDeleteCmd pins the synchronous half of
+// the #817 split: Kill must still wait for the preview process to die before
+// invoking delete_cmd, so the user's cleanup script never races a preview
+// attach_cmd that is still connected to the remote session being deleted.
+func TestHookBackendKillReapsPreviewBeforeDeleteCmd(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "preview.pid")
+	sentinel := filepath.Join(dir, "preview-was-alive")
+	// The preview writes continuously, so the pipe close from stopPreview
+	// kills it with SIGPIPE within one loop iteration and Kill's reap sees a
+	// clean (fully reaped) exit before delete_cmd starts.
+	attachCmd := writeScript(t, dir, "attach.sh",
+		`echo $$ > `+pidFile+`
+while true; do echo tick; sleep 0.05; done`)
+	// delete_cmd records whether the preview process was still alive when it ran.
+	deleteCmd := writeScript(t, dir, "delete.sh",
+		`if kill -0 "$(cat `+pidFile+`)" 2>/dev/null; then touch `+sentinel+`; fi
+echo '{"deleted": true}'`)
+	b := &HookBackend{Hooks: config.RemoteHooks{AttachCmd: attachCmd, DeleteCmd: deleteCmd}}
+	i := &Instance{
+		Title:   "kill-sync-test",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+	i.started = true
+	i.remoteMeta = map[string]interface{}{"name": "kill-sync-test"}
+
+	require.NoError(t, b.ensurePTY(i))
+	waitForPidFile(t, pidFile)
+
+	require.NoError(t, b.Kill(i))
+
+	_, statErr := os.Stat(sentinel)
+	assert.True(t, os.IsNotExist(statErr),
+		"delete_cmd must not run while the preview process is still alive (statErr: %v)", statErr)
+}
+
+// waitForPidFile polls until the hook script has written its PID and returns it.
+func waitForPidFile(t *testing.T, path string) int {
+	t.Helper()
+	var pid int
+	require.Eventually(t, func() bool {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return false
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil || n <= 0 {
+			return false
+		}
+		pid = n
+		return true
+	}, 2*time.Second, 20*time.Millisecond, "hook script never wrote its pid to %s", path)
+	return pid
 }
 
 // --- Instance delegation ---


### PR DESCRIPTION
Fixes #817

## Problem

`HookBackend.Attach()` called `closePTY()` synchronously. `closePTY` waits up to 2 seconds for the preview `attach_cmd` process to exit after closing its stdout pipe, then kills it. Since `Attach` runs on the bubbletea event loop (`app/handle_actions.go` → `sidebar.AttachInstance` → `Instance.Attach` → `HookBackend.Attach`), the entire TUI froze for up to 2s on every attach to a remote session whose preview process didn't die promptly — which is the common case, because closing the pipe's read end only signals the process (via EPIPE) on its *next write*; a preview sitting idle between writes never notices and always eats the full grace period.

A second freeze vector hid in the same function: `closePTY` held `b.mu` across the 2s wait, so concurrent `Preview()`/`getPTY()` calls from background render ticks stalled behind any teardown in progress.

## Fix

Split `closePTY` into two parts:

- **`stopPreview(title)`** — non-blocking detach: removes the entry from `b.ptys`, marks it closed, closes the pipe read end, and returns the detached `hookPTY`. Releases `b.mu` before any waiting happens.
- **`hookPTY.reap()`** — the blocking part: waits up to the 2s grace period, then kills.

The caller decides where the wait is paid:

| Caller | Teardown | Why |
|---|---|---|
| `Attach` | `stopPreview` + `go reap()` | Runs on the TUI event loop; must not block (#817) |
| `Kill` | synchronous `closePTY` (= `stopPreview` + `reap`) | `delete_cmd` must not race a preview process still connected to the remote session being deleted |
| tests | synchronous `closePTY` | deterministic cleanup |

These are all the `closePTY` call sites in the tree (audited; no other production callers exist).

**Ordering safety.** The preview entry is now removed from `b.ptys` *before* the old process exits. This is safe: the dying preview only writes into its own `hp.buf` through its own pipe, `Preview()` can no longer find the entry, and a replacement started by `ensurePTY` (after detach) gets a fresh pipe and buffer — so the dying preview cannot interleave output with the interactive `attach_cmd` or the fresh preview. Documented on `stopPreview`.

## Tests

- `TestHookBackendAttachReturnsImmediatelyWhenPreviewIsSlowToDie` — regression test for the bug: with a preview that has finished writing (so pipe close delivers no EPIPE), `Attach` must return in <500ms. **Verified to fail against the pre-fix code** (took 2.0005s). The test deliberately waits for the preview's banner first; attaching earlier would let the preview die instantly from SIGPIPE on its first write and pass even on the old code.
- `TestHookBackendReapKillsStubbornPreviewProcess` — the background reap actually kills a process that ignores the pipe close, so detached previews can't leak.
- `TestHookBackendKillReapsPreviewBeforeDeleteCmd` — pins the synchronous half: `delete_cmd` observes the preview process already dead. (Passes on the old code too, as expected — this guards the split from regressing `Kill`.)
- Existing preview-restart-after-detach and `Kill` tests stay green.

## Verification

- `go build ./...`, `gofmt -l .` (clean), `golangci-lint run --timeout=3m --fast` (clean), `deadcode -test ./...` (clean)
- `go test ./...` — all green except `integration/TestConcurrentCLIClientsUseDaemonCoordinator`, which also fails intermittently on a clean checkout of `master` on the same box (known dev-box contention flake, local-tmux-only test that never touches `HookBackend`)
- `go test -race ./session/...` and bounded `-race` on `ui`/`app` — green

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)