### PR TITLE
fix(daemon): respawn unconditionally after upgrade and reap spawned daemon children (#813, #816)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -247,6 +247,11 @@ func (m *home) handleOpenPR() (tea.Model, tea.Cmd) {
 	if err := openCmd.Start(); err != nil {
 		return m, m.handleError(fmt.Errorf("failed to open PR: %w", err))
 	}
+	// Reap the opener when it exits so it doesn't linger as a zombie for the
+	// life of the TUI (#816).
+	go func() {
+		_ = openCmd.Wait()
+	}()
 	return m, nil
 }
 

--- a/autoupdate.go
+++ b/autoupdate.go
@@ -113,10 +113,11 @@ func autoUpdate() error {
 		log.InfoLog.Printf("auto-update: updated to %s (effective on next launch)", latestVersion)
 	}
 	if shutdownErr == nil && result != daemon.ShutdownNoDaemon {
-		// The daemon hosts task schedules (#782); respawn it from the
-		// freshly written binary when enabled tasks exist, instead of
-		// leaving schedules dark until the next af invocation.
-		respawnDaemonForTasksFn()
+		// The daemon hosts task schedules and autoyes mode (#782); we just
+		// stopped a running one, so respawn it unconditionally from the
+		// freshly written binary instead of leaving schedules and autoyes
+		// sessions dark until the next af invocation (#813).
+		respawnDaemonFn()
 	}
 	return nil
 }

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -220,10 +220,10 @@ func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
 		osExecutableFn = prevExe
 		requestDaemonShutdownFn = prevShutdown
 	})
-	prevRespawn := respawnDaemonForTasksFn
+	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonForTasksFn = func() { respawnCalls++ }
-	t.Cleanup(func() { respawnDaemonForTasksFn = prevRespawn })
+	respawnDaemonFn = func() { respawnCalls++ }
+	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 
 	runtimeGOOS = "linux"
 	version = "1.0.0"
@@ -290,10 +290,10 @@ func TestAutoUpdateSucceedsWhenShutdownErrors(t *testing.T) {
 		osExecutableFn = prevExe
 		requestDaemonShutdownFn = prevShutdown
 	})
-	prevRespawn := respawnDaemonForTasksFn
+	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonForTasksFn = func() { respawnCalls++ }
-	t.Cleanup(func() { respawnDaemonForTasksFn = prevRespawn })
+	respawnDaemonFn = func() { respawnCalls++ }
+	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 
 	runtimeGOOS = "linux"
 	version = "1.0.0"

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -269,6 +269,21 @@ func launchDaemonProcess() error {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
 
+	pid, err := startDaemonChild(execPath)
+	if err != nil {
+		return err
+	}
+
+	log.InfoLog.Printf("started daemon child process with PID: %d", pid)
+
+	// The child writes its own PID file from RunDaemon (#504).
+	return nil
+}
+
+// startDaemonChild starts execPath --daemon detached from the parent and
+// returns its PID. Split from launchDaemonProcess so tests can spawn a
+// short-lived stub instead of re-executing the real binary with --daemon.
+func startDaemonChild(execPath string) (int, error) {
 	cmd := exec.Command(execPath, "--daemon")
 
 	// Detach the process from the parent
@@ -280,14 +295,18 @@ func launchDaemonProcess() error {
 	cmd.SysProcAttr = getSysProcAttr()
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start child process: %w", err)
+		return 0, fmt.Errorf("failed to start child process: %w", err)
 	}
 
-	log.InfoLog.Printf("started daemon child process with PID: %d", cmd.Process.Pid)
+	// Setsid detaches the child's session but the kernel still parents it
+	// here, so it must be reaped or each exited daemon lingers as a zombie
+	// for the life of the TUI — one per upgrade/respawn cycle (#816). Same
+	// pattern as session/tmux/pty.go.
+	go func() {
+		_ = cmd.Wait()
+	}()
 
-	// The child writes its own PID file from RunDaemon (#504). Don't wait for
-	// the child to exit, it's detached.
-	return nil
+	return cmd.Process.Pid, nil
 }
 
 // daemonPIDFilePath returns the path to the daemon PID file, or "" if the

--- a/daemon/spawn_reap_test.go
+++ b/daemon/spawn_reap_test.go
@@ -1,0 +1,40 @@
+package daemon
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestStartDaemonChildReapsExitedChild pins the #816 fix: startDaemonChild
+// must reap its child once it exits, or every dead daemon lingers as an
+// `[af] <defunct>` zombie for the life of the TUI — one per upgrade/respawn
+// cycle. The test spawns `true` (which exits immediately, ignoring the
+// --daemon argument) instead of a real daemon, so it never touches the
+// control socket or any supervised daemon on the machine.
+//
+// Detection: a zombie still occupies its process-table slot, so signal 0
+// succeeds against it. Only after the parent Wait()s does the kernel release
+// the PID and signal 0 return ESRCH.
+func TestStartDaemonChildReapsExitedChild(t *testing.T) {
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Skipf("no `true` binary on PATH: %v", err)
+	}
+
+	pid, err := startDaemonChild(truePath)
+	if err != nil {
+		t.Fatalf("startDaemonChild: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return // child exited and was reaped
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("child PID %d still occupies a process-table slot 5s after exit; daemon child was not reaped (#816)", pid)
+}

--- a/daemoncmd.go
+++ b/daemoncmd.go
@@ -69,9 +69,9 @@ func init() {
 	daemonCmd.AddCommand(daemonUninstallCmd)
 }
 
-// respawnDaemonForTasksFn is indirected so upgrade/auto-update tests can
-// observe the respawn without launching a real daemon.
-var respawnDaemonForTasksFn = respawnDaemonAfterUpgrade
+// respawnDaemonFn is indirected so upgrade/auto-update tests can observe the
+// respawn without launching a real daemon.
+var respawnDaemonFn = respawnDaemonAfterUpgrade
 
 // Indirection points so respawnDaemonAfterUpgrade tests can observe which
 // branch ran without touching the real systemctl/launchctl or spawning a
@@ -79,7 +79,7 @@ var respawnDaemonForTasksFn = respawnDaemonAfterUpgrade
 var (
 	autostartInstalledFn   = daemon.AutostartInstalled
 	restartAutostartUnitFn = daemon.RestartAutostartUnit
-	ensureDaemonForTasksFn = ensureDaemonForTasks
+	ensureDaemonFn         = daemon.EnsureDaemon
 )
 
 // respawnDaemonAfterUpgrade restores the daemon that the upgrade/auto-update
@@ -89,10 +89,15 @@ var (
 // daemon back on its own. When the unit is installed, restart it through
 // systemctl/launchctl so the daemon stays supervised instead of being demoted
 // to an ad-hoc child that dies with the session and skips the next reboot
-// (#796). The unit runs unconditionally at login, so this branch is not gated
-// on enabled tasks — it restores exactly what was running before the upgrade.
-// Without a unit, or when the service manager call fails, fall back to the
-// task-gated ad-hoc spawn (the pre-#796 behavior).
+// (#796). Without a unit, or when the service manager call fails, spawn an
+// ad-hoc daemon.
+//
+// Both branches respawn unconditionally: callers only reach this function
+// after stopping a running daemon, and that daemon may have been serving
+// autoyes mode with zero enabled tasks. Gating the fallback on enabled tasks
+// left autoyes-only users without a daemon until the next af run (#813). The
+// task gate belongs only on the cold-start path (ensureDaemonForTasks), where
+// nothing was running and "no enabled tasks" means there is nothing to start.
 func respawnDaemonAfterUpgrade() {
 	if autostartInstalledFn() {
 		err := restartAutostartUnitFn()
@@ -102,13 +107,19 @@ func respawnDaemonAfterUpgrade() {
 		}
 		log.WarningLog.Printf("failed to restart the daemon autostart unit; falling back to an ad-hoc daemon: %v", err)
 	}
-	ensureDaemonForTasksFn()
+	if err := ensureDaemonFn(); err != nil {
+		log.ErrorLog.Printf("failed to respawn daemon after upgrade: %v", err)
+	}
 }
 
 // ensureDaemonForTasks starts the daemon when any enabled task exists, so
 // cron schedules are evaluated even if the user never toggles autoyes.
 // Failures are logged rather than surfaced: the TUI is fully usable without
 // the daemon, and the next af invocation retries.
+//
+// The enabled-task gate is correct here and only here: this is the cold-start
+// path (af launch), where no daemon was previously running. The post-upgrade
+// respawn path must not use it — see respawnDaemonAfterUpgrade (#813).
 func ensureDaemonForTasks() {
 	tasks, err := task.LoadTasks()
 	if err != nil {

--- a/daemoncmd_test.go
+++ b/daemoncmd_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-// Tests for the unit-aware upgrade respawn (#796). All three collaborators
-// are stubbed so nothing here touches the real systemctl/launchctl or spawns
-// a daemon process — a real supervised daemon may be running on the machine
-// executing these tests.
+// Tests for the unit-aware upgrade respawn (#796) and the unconditional
+// fallback (#813). All three collaborators are stubbed so nothing here
+// touches the real systemctl/launchctl or spawns a daemon process — a real
+// supervised daemon may be running on the machine executing these tests.
 
 // stubRespawnCollaborators replaces the autostart-detection, unit-restart,
 // and ad-hoc-spawn hooks used by respawnDaemonAfterUpgrade, restoring them on
@@ -17,11 +17,11 @@ func stubRespawnCollaborators(t *testing.T, installed bool, restartErr error) (r
 	t.Helper()
 	prevInstalled := autostartInstalledFn
 	prevRestart := restartAutostartUnitFn
-	prevEnsure := ensureDaemonForTasksFn
+	prevEnsure := ensureDaemonFn
 	t.Cleanup(func() {
 		autostartInstalledFn = prevInstalled
 		restartAutostartUnitFn = prevRestart
-		ensureDaemonForTasksFn = prevEnsure
+		ensureDaemonFn = prevEnsure
 	})
 	restartCalls = new(int)
 	ensureCalls = new(int)
@@ -30,7 +30,10 @@ func stubRespawnCollaborators(t *testing.T, installed bool, restartErr error) (r
 		*restartCalls++
 		return restartErr
 	}
-	ensureDaemonForTasksFn = func() { *ensureCalls++ }
+	ensureDaemonFn = func() error {
+		*ensureCalls++
+		return nil
+	}
 	return restartCalls, ensureCalls
 }
 
@@ -51,8 +54,8 @@ func TestRespawnAfterUpgradeRestartsInstalledUnit(t *testing.T) {
 	}
 }
 
-// TestRespawnAfterUpgradeWithoutUnitSpawnsAdHoc pins the pre-#796 behavior
-// for installs without an autostart unit: the task-gated ad-hoc spawn.
+// TestRespawnAfterUpgradeWithoutUnitSpawnsAdHoc: installs without an
+// autostart unit fall back to an ad-hoc daemon spawn.
 func TestRespawnAfterUpgradeWithoutUnitSpawnsAdHoc(t *testing.T) {
 	restartCalls, ensureCalls := stubRespawnCollaborators(t, false, nil)
 
@@ -79,5 +82,23 @@ func TestRespawnAfterUpgradeFallsBackWhenRestartFails(t *testing.T) {
 	}
 	if *ensureCalls != 1 {
 		t.Fatalf("ad-hoc spawns = %d, want 1 (fallback after a failed unit restart)", *ensureCalls)
+	}
+}
+
+// TestRespawnAfterUpgradeSpawnsWithZeroEnabledTasks pins the #813 fix: the
+// post-upgrade fallback must respawn unconditionally, not only when an
+// enabled task exists. Callers only invoke the respawn after stopping a
+// running daemon, and that daemon may have been serving autoyes mode alone.
+// AGENT_FACTORY_HOME points at an empty temp dir so the task store is
+// guaranteed empty — if the enabled-task gate ever creeps back into the
+// respawn path, this test fails.
+func TestRespawnAfterUpgradeSpawnsWithZeroEnabledTasks(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	_, ensureCalls := stubRespawnCollaborators(t, false, nil)
+
+	respawnDaemonAfterUpgrade()
+
+	if *ensureCalls != 1 {
+		t.Fatalf("ad-hoc spawns = %d, want 1 even with zero enabled tasks (autoyes-only daemon must be restored, #813)", *ensureCalls)
 	}
 }

--- a/upgrade.go
+++ b/upgrade.go
@@ -151,10 +151,11 @@ func runUpgrade(downloadURL string) error {
 		fmt.Println("Upgraded successfully!")
 	}
 	if shutdownErr == nil && result != daemon.ShutdownNoDaemon {
-		// The daemon hosts task schedules (#782); respawn it from the
-		// freshly written binary when enabled tasks exist, instead of
-		// leaving schedules dark until the next af invocation.
-		respawnDaemonForTasksFn()
+		// The daemon hosts task schedules and autoyes mode (#782); we just
+		// stopped a running one, so respawn it unconditionally from the
+		// freshly written binary instead of leaving schedules and autoyes
+		// sessions dark until the next af invocation (#813).
+		respawnDaemonFn()
 	}
 	return nil
 }

--- a/upgrade_test.go
+++ b/upgrade_test.go
@@ -217,10 +217,10 @@ func TestUpgradeCallsShutdownAfterBinarySwap(t *testing.T) {
 		osExecutableFn = prevExe
 		requestDaemonShutdownFn = prevShutdown
 	})
-	prevRespawn := respawnDaemonForTasksFn
+	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonForTasksFn = func() { respawnCalls++ }
-	t.Cleanup(func() { respawnDaemonForTasksFn = prevRespawn })
+	respawnDaemonFn = func() { respawnCalls++ }
+	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	shutdownCalls := 0
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
@@ -268,10 +268,10 @@ func TestUpgradeSucceedsWhenNoDaemon(t *testing.T) {
 		osExecutableFn = prevExe
 		requestDaemonShutdownFn = prevShutdown
 	})
-	prevRespawn := respawnDaemonForTasksFn
+	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonForTasksFn = func() { respawnCalls++ }
-	t.Cleanup(func() { respawnDaemonForTasksFn = prevRespawn })
+	respawnDaemonFn = func() { respawnCalls++ }
+	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
 		// Mirror what daemon.RequestShutdown returns when no daemon is
@@ -315,10 +315,10 @@ func TestUpgradeSucceedsWhenShutdownErrors(t *testing.T) {
 		osExecutableFn = prevExe
 		requestDaemonShutdownFn = prevShutdown
 	})
-	prevRespawn := respawnDaemonForTasksFn
+	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonForTasksFn = func() { respawnCalls++ }
-	t.Cleanup(func() { respawnDaemonForTasksFn = prevRespawn })
+	respawnDaemonFn = func() { respawnCalls++ }
+	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
 		return daemon.ShutdownNoDaemon, errors.New("simulated rpc failure")
@@ -358,10 +358,10 @@ func TestUpgradeReportsSIGTERMFallback(t *testing.T) {
 		osExecutableFn = prevExe
 		requestDaemonShutdownFn = prevShutdown
 	})
-	prevRespawn := respawnDaemonForTasksFn
+	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonForTasksFn = func() { respawnCalls++ }
-	t.Cleanup(func() { respawnDaemonForTasksFn = prevRespawn })
+	respawnDaemonFn = func() { respawnCalls++ }
+	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
 		return daemon.ShutdownViaSIGTERM, nil


### PR DESCRIPTION
Fixes #813
Fixes #816

Two daemon-lifecycle regressions in the upgrade/respawn path, fixed together because they live in the same spawn/respawn chain.

## #813 — autoyes-only daemon stays down after auto-update

`respawnDaemonAfterUpgrade()`'s ad-hoc fallback delegated to the task-gated `ensureDaemonForTasks()`, so a user whose daemon existed only for autoyes mode (zero enabled tasks, no autostart unit) was left without a daemon after an upgrade/auto-update — persisted autoyes sessions stopped receiving Enter keypresses until the next `af` run.

The key invariant: both callers (`runUpgrade`, `autoUpdate`) only invoke the respawn after `RequestShutdown` returned something other than `ShutdownNoDaemon` — a daemon was **provably running** moments ago. So the respawn must restore it unconditionally, whatever it was serving:

- unit installed → `RestartAutostartUnit()` (unchanged, #798)
- otherwise / unit restart failed → `daemon.EnsureDaemon()` directly, no task gate

The enabled-task gate now applies **only** on the cold-start path (`af` launch → `ensureDaemonForTasks`), where nothing was running and "no enabled tasks" genuinely means "nothing to start". (The autoyes cold-start case is separately handled by the `LaunchDaemon` defer in `main.go`.)

### Gate audit (per-call-site)

| Spawn/respawn entry | Gate | Why |
|---|---|---|
| `main.go` autoyes defer → `LaunchDaemon` | none | user just enabled autoyes |
| `main.go` launch → `ensureDaemonForTasks` | enabled-task gate | cold start; nothing was running |
| `runUpgrade` → `respawnDaemonAfterUpgrade` | **none (this PR)** | a running daemon was just stopped |
| `autoUpdate` → `respawnDaemonAfterUpgrade` | **none (this PR)** | same |
| `daemon install` (`InstallAutostart`) | none | unit runs unconditionally at login |

## #816 — `<defunct>` daemon zombies on every respawn cycle

`launchDaemonProcess()` called `cmd.Start()` and never `Wait()`ed. `Setsid` detaches the child's session but the kernel still parents it to the TUI/CLI process, so every exited ad-hoc daemon lingered as an `[af] <defunct>` zombie for the life of the parent — one per upgrade/respawn/crash cycle. Fixed with a background reaper goroutine (`go func() { _ = cmd.Wait() }()`), the same pattern as `session/tmux/pty.go`. The spawn is extracted into `startDaemonChild(execPath)` so the test can exercise it against a short-lived stub instead of re-executing the real binary with `--daemon`.

### Start-without-Wait audit

Swept every `exec` `.Start()` call site:

| Site | Status |
|---|---|
| `daemon/daemon.go` `launchDaemonProcess` | **fixed (this PR)** |
| `app/handle_actions.go` `handleOpenPR` (`xdg-open`/`open`) | **fixed (this PR)** — same anti-pattern, one zombie per PR-open in a long TUI session |
| `session/tmux/pty.go` | already reaps (goroutine `Wait`) |
| `session/backend_hook.go` | already reaps (`hp.wait()`/`waitAsync`) |
| `daemon/watcher.go` | already reaps (inline `cmd.Wait()`) |
| `session/git/hooks.go` | already reaps (inline `cmd.Wait()`) |
| `app/handle_actions.go` `handleCopyPR` | uses `Run()` |

## Tests

- `TestRespawnAfterUpgradeSpawnsWithZeroEnabledTasks` — points `AGENT_FACTORY_HOME` at an empty temp dir (guaranteed zero tasks) and asserts the fallback still spawns; fails if the task gate ever creeps back into the respawn path.
- `TestStartDaemonChildReapsExitedChild` — spawns `true` via `startDaemonChild` and asserts the exited child's PID leaves the process table (signal 0 → ESRCH), i.e. it was reaped. **Verified to fail (zombie persists) with the reaper goroutine removed.** Hermetic: never touches the control socket or any real daemon.
- Existing #796/#798 respawn-branch tests updated to the new `ensureDaemonFn` seam and stay green; `respawnDaemonForTasksFn` renamed to `respawnDaemonFn` since it is no longer task-gated.

## Verification

`go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `go test ./...` all clean; `go test -race` green on `./daemon`, `./app`, and the root package.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)