### PR TITLE
fix(session): make AutoYes and developer_instructions flag injection idempotent (#818)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -40,7 +41,14 @@ func resolveProgramForInstance(i *Instance) string {
 		cfg = loaded
 	}
 	resolved := config.ResolveProgram(cfg, i.Program)
-	if i.AutoYes && DetectAgentFromProgram(i.Program) == tmux.ProgramClaude {
+	if i.AutoYes && DetectAgentFromProgram(i.Program) == tmux.ProgramClaude &&
+		// Sessions persisted by pre-#659 binaries got the flag appended at
+		// create-time in main.go (19c0dd9), so legacy Instance.Program values
+		// can already carry it; appending again duplicates the flag on every
+		// restore (#818). A substring check suffices: claude exposes no short
+		// form of --permission-mode, and the check also matches the
+		// =-attached spelling.
+		!strings.Contains(resolved, "--permission-mode") {
 		resolved = resolved + " --permission-mode bypassPermissions"
 	}
 	return resolved

--- a/session/legacy_program_test.go
+++ b/session/legacy_program_test.go
@@ -109,6 +109,38 @@ func TestResolveProgramForInstance_LegacyAutoYes(t *testing.T) {
 	}
 }
 
+// Regression for #818: pre-#659 binaries appended --permission-mode
+// bypassPermissions at create-time and persisted the full string into
+// Instance.Program, so a restored legacy AutoYes session already carries the
+// flag — the restore-time append must not duplicate it.
+func TestResolveProgramForInstance_LegacyAutoYesFlagAlreadyPresent(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	i := &Instance{
+		Program: "/home/foo/bin/claude --permission-mode bypassPermissions",
+		AutoYes: true,
+	}
+	result := resolveProgramForInstance(i)
+	if got := strings.Count(result, "--permission-mode"); got != 1 {
+		t.Errorf("expected exactly one --permission-mode flag, got %d in %q", got, result)
+	}
+}
+
+// Companion to the #818 case: the =-attached spelling must also suppress the
+// append.
+func TestResolveProgramForInstance_LegacyAutoYesEqualsFormAlreadyPresent(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	i := &Instance{
+		Program: "/home/foo/bin/claude --permission-mode=bypassPermissions",
+		AutoYes: true,
+	}
+	result := resolveProgramForInstance(i)
+	if got := strings.Count(result, "--permission-mode"); got != 1 {
+		t.Errorf("expected exactly one --permission-mode flag, got %d in %q", got, result)
+	}
+}
+
 // Defensive guard for the AutoYes branch: an unknown AutoYes program must NOT
 // get the Claude-only bypassPermissions flag.
 func TestResolveProgramForInstance_UnknownAutoYesNoFlag(t *testing.T) {

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -77,9 +77,21 @@ func injectSystemPrompt(agent, resolved, sessionTitle, worktreePath string) stri
 			log.WarningLog.Printf("failed to set up plugin directory, slash commands unavailable: %v", err)
 			return resolved
 		}
+		// Unconditional append is safe here, unlike the AutoYes (#818) and
+		// codex (#820) flags: no binary has ever persisted --plugin-dir into
+		// Instance.Program (the injected form only reaches tmux SetProgram),
+		// and claude's --plugin-dir is repeatable, so one in a user's
+		// program_overrides is additive rather than a conflict.
 		return resolved + " --plugin-dir " + shellQuote(pluginDir)
 	}
 	if agent == tmux.ProgramCodex {
+		// Skip when the resolved command already carries a
+		// developer_instructions override — e.g. a deliberate
+		// program_overrides entry (#820). codex's -c is last-wins for the
+		// same key, so appending ours would silently clobber the user's.
+		if strings.Contains(resolved, "developer_instructions=") {
+			return resolved
+		}
 		return resolved + " -c " + shellQuote("developer_instructions="+codexSystemPrompt)
 	}
 	return resolved

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -96,6 +96,22 @@ func TestInjectSystemPrompt_CodexWithResolvedFlags(t *testing.T) {
 	}
 }
 
+// Regression for #820: a user who deliberately sets developer_instructions in
+// their program_overrides must keep their value — codex's -c is last-wins per
+// key, so appending ours would clobber it.
+func TestInjectSystemPrompt_CodexExistingDeveloperInstructions(t *testing.T) {
+	dir := t.TempDir()
+	resolved := `codex -c 'developer_instructions=my custom prompt'`
+	result := injectSystemPrompt(tmux.ProgramCodex, resolved, "my-session", dir)
+
+	if result != resolved {
+		t.Errorf("expected resolved form unchanged, got %q", result)
+	}
+	if got := strings.Count(result, "developer_instructions="); got != 1 {
+		t.Errorf("expected exactly one developer_instructions flag, got %d in %q", got, result)
+	}
+}
+
 func TestInjectSystemPrompt_Aider(t *testing.T) {
 	dir := t.TempDir()
 	result := injectSystemPrompt(tmux.ProgramAider, "aider", "test-session", dir)


### PR DESCRIPTION
Fixes #818
References #820

## Problem

`resolveProgramForInstance` unconditionally appends `--permission-mode bypassPermissions` for AutoYes Claude sessions. Pre-#659 binaries appended that flag at create-time in `main.go` (19c0dd9) and persisted the full string into `Instance.Program`, so restoring a legacy AutoYes session on a current binary duplicates the flag — and a second time on every subsequent restore. Regression of the #677/#679 legacy-Program normalization work, introduced when #659 moved the append from create-time to restore-time.

## Fix

- **`resolveProgramForInstance`** (session/backend_local.go): skip the append when the resolved command already contains `--permission-mode`. A substring check suffices — claude has no short form of the flag, and the check also covers the `=`-attached spelling.
- **`injectSystemPrompt` codex branch** (session/systemprompt.go), per the #820 close-out commitment: skip appending `-c developer_instructions=...` when the resolved command already carries a `developer_instructions=` override. codex's `-c` is last-wins per key, so appending ours would silently clobber a deliberate `program_overrides` value.

## Adjacent-call-site audit

Swept every flag-append on resolved/persisted program strings:

| Site | Status |
| --- | --- |
| `resolveProgramForInstance` bypassPermissions | guarded (this PR, #818) |
| `injectSystemPrompt` codex `developer_instructions` | guarded (this PR, #820) |
| `injectSystemPrompt` claude `--plugin-dir` | safe unconditionally — no binary has ever persisted it into `Instance.Program` (the injected form only reaches tmux `SetProgram`), and the flag is repeatable so a user-supplied one in `program_overrides` is additive; now documented in place |
| `resumeProgram` resume flags (session/tmux/resume.go) | already position-aware idempotent per #742/#748; no change |
| `DefaultConfig` `--dangerously-skip-permissions` (config/config.go) | builds a fresh override string once at config creation, not an append to a persisted program; no dup vector |

## Tests

- `TestResolveProgramForInstance_LegacyAutoYesFlagAlreadyPresent` — legacy Program with the flag persisted → exactly one occurrence after resolve (the failing repro from #818).
- `TestResolveProgramForInstance_LegacyAutoYesEqualsFormAlreadyPresent` — `=`-attached spelling also suppresses the append.
- `TestInjectSystemPrompt_CodexExistingDeveloperInstructions` — codex resolved form with an existing `developer_instructions=` override is returned unchanged (#820).
- Existing append-when-absent coverage (`TestResolveProgramForInstance_LegacyAutoYes`, `TestInjectSystemPrompt_Codex`) and the resumeProgram idempotency suite stay green.

## Verification

- `go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` — all clean
- `go test ./...` — green except the known dev-box daemon-socket contention flake (`integration/TestCLICreateCodexWaitsPastTrustPrompt`), which passes in isolation
- `go test -race ./session/...` and bounded `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/... ./app/...` — green

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)