### PR TITLE
fix(ui): inline pane width accounting and scroll-exit on Loading instances (#821, #823)

### DIFF
--- a/ui/content_pane.go
+++ b/ui/content_pane.go
@@ -181,6 +181,9 @@ func (c *ContentPane) renderInlinePane(content string) string {
 	}
 
 	innerWidth := w - windowStyle.GetHorizontalFrameSize()
+	if innerWidth < 0 {
+		innerWidth = 0
+	}
 	// The -2 budgets for the two spacer lines the JoinVertical("\n", ...)
 	// below emits, mirroring TabbedWindow.String's height math so inline
 	// panes line up with the tabbed window.
@@ -189,17 +192,20 @@ func (c *ContentPane) renderInlinePane(content string) string {
 		innerHeight = 0
 	}
 
-	// lipgloss.Place pads short content but never truncates tall content, and
-	// the window border's Width re-wraps lines wider than the frame. Wrap to
-	// the frame width first, then clamp to the height budget, so the pane can
-	// never render taller than its SetSize allocation and push the menu and
-	// error box off-screen (#700).
+	// lipgloss.Place pads short content but never truncates or wraps:
+	// over-tall content pushes the menu and error box off-screen (#700) and
+	// over-wide lines stretch the border box past the allocation. Wrap to the
+	// frame width first, then clamp to the height budget.
 	wrapped := strings.Split(lipgloss.NewStyle().Width(innerWidth).Render(content), "\n")
 	if len(wrapped) > innerHeight {
 		wrapped = wrapped[:innerHeight]
 	}
 
-	window := windowStyle.Width(w).Render(
+	// windowStyle is bordered, and Style.Width sets the *inner* width — so
+	// .Width(w) here rendered w+frame total columns, 2 wider than allocated
+	// (#821). Match TabbedWindow.String: size the content via lipgloss.Place
+	// and let the border add the frame on top.
+	window := windowStyle.Render(
 		lipgloss.Place(
 			innerWidth, innerHeight,
 			lipgloss.Left, lipgloss.Top,

--- a/ui/layout_height_test.go
+++ b/ui/layout_height_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/stretchr/testify/require"
 )
@@ -166,4 +167,62 @@ func TestContentPaneRendersExactlyAllocatedHeight(t *testing.T) {
 	// the layout does not jump when switching sidebar selections.
 	cp.SetMode(ContentModeInstance)
 	require.Equal(t, h, renderedLineCount(tw.String()), "tabbed window")
+}
+
+// renderedWidth returns the widest line of a component's output, measured in
+// terminal cells (lipgloss.Width is ANSI- and wide-rune-aware).
+func renderedWidth(s string) int {
+	widest := 0
+	for _, line := range strings.Split(s, "\n") {
+		if lw := lipgloss.Width(line); lw > widest {
+			widest = lw
+		}
+	}
+	return widest
+}
+
+// TestContentPaneInlinePanesMatchAllocatedWidth is the regression test for
+// #821, the width counterpart of the #786 height fix above. windowStyle is
+// bordered, and lipgloss Style.Width sets the *inner* content width — so
+// renderInlinePane's .Width(w) call rendered w+frame total columns, making
+// the tasks/hooks/empty panes 2 columns wider than the tabbed window and
+// shifting the layout when switching between sidebar selections.
+func TestContentPaneInlinePanesMatchAllocatedWidth(t *testing.T) {
+	for _, tc := range []struct{ w, h int }{
+		{56, 21}, // 80x24 terminal (see TestContentPaneRendersExactlyAllocatedHeight)
+		{84, 27}, // 120x30 terminal
+	} {
+		// Both the inline panes and the tabbed window carve their window
+		// width out of the allocation the same way.
+		want := AdjustPreviewWidth(tc.w)
+
+		tw := NewTabbedWindow(NewPreviewPane(), NewTerminalPane())
+		cp := NewContentPane(tw)
+		cp.SetSize(tc.w, tc.h)
+
+		cp.SetMode(ContentModeEmpty)
+		require.Equal(t, want, renderedWidth(cp.String()),
+			"%dx%d: empty mode", tc.w, tc.h)
+
+		cp.SetMode(ContentModeTasks)
+		require.Equal(t, want, renderedWidth(cp.String()),
+			"%dx%d: tasks mode, no tasks", tc.w, tc.h)
+
+		cp.TaskPane().SetTasks([]task.Task{
+			{ID: "t", Name: strings.Repeat("long-task-name-", 8), Prompt: "p"},
+		})
+		require.Equal(t, want, renderedWidth(cp.String()),
+			"%dx%d: tasks mode with over-wide content", tc.w, tc.h)
+
+		cp.HooksPane().SetCommands([]string{strings.Repeat("hook-cmd ", 20)})
+		cp.SetMode(ContentModeHooks)
+		require.Equal(t, want, renderedWidth(cp.String()),
+			"%dx%d: hooks mode with over-wide content", tc.w, tc.h)
+
+		// Inline panes must render exactly as wide as the tabbed window so
+		// the border column does not move when switching sidebar selections.
+		cp.SetMode(ContentModeInstance)
+		require.Equal(t, want, renderedWidth(tw.String()),
+			"%dx%d: tabbed window", tc.w, tc.h)
+	}
 }

--- a/ui/preview.go
+++ b/ui/preview.go
@@ -341,6 +341,15 @@ func (p *PreviewPane) ResetToNormalMode(instance *session.Instance) error {
 	}
 
 	if wasScrolling {
+		// Mirror UpdateContent's Loading guard (#823): a Loading instance's
+		// Preview() returns empty content, and writing {fallback:false, text:""}
+		// here blanks the pane for a frame until the next async refresh. Keep
+		// the "Setting up workspace..." fallback instead.
+		if instance.GetStatus() == session.Loading {
+			p.setFallbackState("Setting up workspace...")
+			return nil
+		}
+
 		// Immediately update content instead of waiting for next UpdateContent call
 		content, err := instance.Preview()
 		if err != nil {

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -527,6 +527,44 @@ func TestPreviewResetToNormalModeNilInstance(t *testing.T) {
 		"rendered content must not be the stale scroll-mode viewport after reset")
 }
 
+// TestPreviewResetToNormalModeLoadingShowsFallback is a regression test for
+// issue #823. Exiting scroll mode on a Loading instance wrote
+// {fallback:false, text:""} into previewState — Preview() returns empty
+// content while the workspace is still being set up — so the pane rendered
+// completely blank for at least one frame until the next async UpdateContent
+// tick. ResetToNormalMode must keep the same "Setting up workspace..."
+// fallback that UpdateContent shows for Loading instances.
+func TestPreviewResetToNormalModeLoadingShowsFallback(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: "loading", Path: t.TempDir(), Program: "test",
+	})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStatus(session.Loading)
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+	require.NoError(t, p.UpdateContent(inst))
+	require.True(t, p.previewState.fallback,
+		"precondition: Loading instance shows the fallback in normal mode")
+
+	require.NoError(t, p.ScrollUp(inst))
+	require.True(t, p.isScrolling, "precondition: ScrollUp enters scroll mode")
+
+	require.NoError(t, p.ResetToNormalMode(inst))
+	require.False(t, p.isScrolling,
+		"isScrolling must be false after ResetToNormalMode")
+	require.True(t, p.previewState.fallback,
+		"exiting scroll mode on a Loading instance must keep the fallback state")
+	require.Contains(t, p.previewState.text, "Setting up workspace...",
+		"fallback text must be the Loading message")
+	require.Contains(t, p.String(), "Setting up workspace...",
+		"rendered frame must show the Loading fallback, not a blank pane")
+}
+
 // TestPreviewFallbackHeightNoDoubleCounting ensures that the fallback welcome
 // screen does not over-subtract lines for borders/margins that
 // TabbedWindow.SetSize has already stripped. Previously it subtracted 7, which


### PR DESCRIPTION
Fixes #821
Fixes #823

Two small UI rendering bugs, both one-conceptual-line fixes with regression tests.

## #821 — inline content pane renders 2 columns wider than allocated

`windowStyle` is a bordered lipgloss style, and `Style.Width` sets the **inner** content width — so `renderInlinePane`'s `.Width(w)` produced `w + GetHorizontalFrameSize()` (= w+2) total columns. The tasks/hooks/empty panes were 2 columns wider than the tabbed window, shifting the layout when switching sidebar selections. This is the width counterpart of the #786 height fix, which refactored the same function but kept the `.Width(w)` call.

Fix: drop `.Width(w)` and let `lipgloss.Place(innerWidth, ...)` size the content, exactly the pattern `TabbedWindow.String()` uses; also clamp `innerWidth` at 0 to mirror `TabbedWindow`'s guard. The explicit wrap-to-innerWidth before `Place` stays — it is now load-bearing for width as well as height (Place never wraps over-wide lines), and the comment is updated to say so.

### Adjacent-call-site audit (bordered styles with `.Width`/`.Height` in `ui/`)

| Site | Verdict |
|---|---|
| `ui/content_pane.go` `renderInlinePane` | **the bug — fixed** |
| `ui/tabbed_window.go:252` tab styles | already subtracts `GetHorizontalFrameSize()` — correct |
| `ui/tabbed_window.go:268` window | no `.Width` on the bordered style — correct (the pattern this fix adopts) |
| `ui/overlay/{text,selection,confirmation,search}Overlay.go` | `.Width` on bordered styles, but intentional: these are free-floating centered boxes (fixed 40/50/60 or 60% widths, placed via `PlaceOverlay`), not panes carving a shared row allocation — there is no adjacent component to misalign with, and "shrinking" them by their frame size would be a gratuitous visual change. Excluded. |

## #823 — exiting scroll mode on a Loading instance blanks the preview for a frame

`ResetToNormalMode`'s scroll-exit path unconditionally wrote `previewState{fallback: false, text: content}`. For a Loading instance, `Preview()` returns empty content, so the pane rendered completely blank until the next async `UpdateContent` tick (~100ms). `UpdateContent` already guards this case; the guard was missed when #577's whole-struct-replacement fix touched this path.

Fix: mirror `UpdateContent`'s Loading guard inside the scroll-exit branch — keep the "Setting up workspace..." fallback and return. Placed inside the `wasScrolling` block so a no-op ESC (not scrolling) still doesn't touch `previewState`.

Audit: `TerminalPane.ResetToNormalMode` only clears scroll state and never rewrites content, so it has no equivalent bug; the other `fallback = false` writers in `terminal.go` run after successful live captures or in teardown paths.

## Tests

- `TestContentPaneInlinePanesMatchAllocatedWidth` (`ui/layout_height_test.go`) — width counterpart of the #786/#700 assertions: every inline mode (empty / tasks / hooks, including over-wide content) must render exactly `AdjustPreviewWidth(w)` columns, and equal to the tabbed window's rendered width, at the issue dimensions (56×21, i.e. an 80×24 terminal) and 84×27. **Fails on pre-fix code with 52 ≠ 50 — the exact +2 overflow from the report.**
- `TestPreviewResetToNormalModeLoadingShowsFallback` (`ui/preview_test.go`) — Loading instance (FakeBackend, empty previews): enter scroll mode, ESC out, assert the fallback state survives and the rendered frame shows "Setting up workspace..." instead of a blank pane. **Fails on pre-fix code** (`fallback=false`).

## Verification

- `go build ./...`, `gofmt -l .` (clean), `golangci-lint run --timeout=3m --fast` (clean), `deadcode -test ./...` (clean)
- `go test ./...` — green except `integration/TestConcurrentCLIClientsUseDaemonCoordinator`, which fails identically on a clean `master` checkout on this box (known dev-box daemon contention flake; this PR touches only `ui/`)
- Bounded `go test -race` on `./ui/...` and `./app/...` — green

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)