### PR TITLE
fix(app): fail closed on git status errors before worktree deletion (#815)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -176,21 +176,37 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 
 	// Check for uncommitted changes in the worktree (skip for remote sessions
 	// which have no local worktree).
-	hasChanges := false
+	warning := ""
 	if !selected.IsRemote() {
 		if wt := selected.GetWorktreePath(); wt != "" {
-			out, err := exec.Command("git", "-C", wt, "status", "--porcelain").Output()
-			if err == nil && len(strings.TrimSpace(string(out))) > 0 {
-				hasChanges = true
-			}
+			warning = killConfirmationWarning(wt)
 		}
 	}
 
 	message := fmt.Sprintf("[!] Kill session '%s'?", selectedTitle)
-	if hasChanges {
-		message = fmt.Sprintf("[!] Kill session '%s'?\n\nWARNING: This worktree has uncommitted changes that will be lost!", selectedTitle)
+	if warning != "" {
+		message += "\n\n" + warning
 	}
 	return m, m.confirmAction(message, killAction)
+}
+
+// killConfirmationWarning returns the data-loss warning line for the kill
+// confirmation dialog, or "" if the worktree at wt is verifiably clean. Kill
+// tears the worktree down with `git worktree remove -f`, which bypasses git's
+// own refusal to delete a dirty worktree, so this check is the only warning
+// the user gets. If `git status` itself fails we cannot prove the worktree is
+// clean — fail closed and warn that changes may be lost rather than silently
+// skipping the warning (#815).
+func killConfirmationWarning(wt string) string {
+	out, err := exec.Command("git", "-C", wt, "status", "--porcelain").Output()
+	if err != nil {
+		log.WarningLog.Printf("could not verify worktree status for %s before kill: %v", wt, err)
+		return fmt.Sprintf("WARNING: Could not verify worktree status (%v); it may contain uncommitted changes that will be lost!", err)
+	}
+	if len(strings.TrimSpace(string(out))) > 0 {
+		return "WARNING: This worktree has uncommitted changes that will be lost!"
+	}
+	return ""
 }
 
 // handleEnter handles the enter/open key action.

--- a/app/handle_actions_test.go
+++ b/app/handle_actions_test.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -78,4 +81,47 @@ func TestHandleEnterAttachesCapturedInstanceAfterSelectionDrift(t *testing.T) {
 
 	require.Equal(t, []string{"instance-a"}, attachLog,
 		"attach must target the instance captured at Enter-press time, not the drifted selection")
+}
+
+// TestKillConfirmationWarning is the regression guard for issue #815. Kill
+// force-removes the worktree (`git worktree remove -f`), bypassing git's own
+// refusal to delete a dirty worktree, so the confirmation dialog's warning is
+// the only safety gate. The old code only warned when `git status` succeeded
+// AND reported changes; a failing status check (corrupted worktree, missing
+// git metadata) silently produced no warning while deletion still proceeded.
+// The check must fail closed: a status error yields a could-not-verify
+// warning, not silence.
+func TestKillConfirmationWarning(t *testing.T) {
+	gitInit := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		cmd := exec.Command("git", "-C", dir, "init")
+		require.NoError(t, cmd.Run(), "git init failed")
+		return dir
+	}
+
+	t.Run("clean worktree produces no warning", func(t *testing.T) {
+		dir := gitInit(t)
+		require.Empty(t, killConfirmationWarning(dir))
+	})
+
+	t.Run("dirty worktree warns about uncommitted changes", func(t *testing.T) {
+		dir := gitInit(t)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("data"), 0o644))
+		warning := killConfirmationWarning(dir)
+		require.Contains(t, warning, "uncommitted changes that will be lost")
+		require.NotContains(t, warning, "Could not verify")
+	})
+
+	t.Run("status check failure fails closed with could-not-verify warning", func(t *testing.T) {
+		// A plain directory that is not a git repository makes `git status` fail.
+		warning := killConfirmationWarning(t.TempDir())
+		require.Contains(t, warning, "Could not verify worktree status")
+		require.Contains(t, warning, "uncommitted changes that will be lost")
+	})
+
+	t.Run("nonexistent worktree path fails closed", func(t *testing.T) {
+		warning := killConfirmationWarning(filepath.Join(t.TempDir(), "gone"))
+		require.Contains(t, warning, "Could not verify worktree status")
+	})
 }

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1107,6 +1107,10 @@ var ghostKillTmuxByName = func(sanitizedName string) error {
 
 // ghostCleanupWorktree performs best-effort worktree teardown for a ghost
 // session whose live restore failed. Package-level so tests can stub it.
+// Deliberately no uncommitted-changes check here, unlike the TUI kill path
+// (#815): this runs daemon-side with no user to warn, only for sessions whose
+// records are already unrestorable, and the caller has already committed to
+// deleting the record — a status probe could only block cleanup, not save data.
 var ghostCleanupWorktree = func(data *session.InstanceData, title string) {
 	if data.Worktree.RepoPath == "" || data.Worktree.WorktreePath == "" || data.Worktree.ExternalWorktree {
 		return


### PR DESCRIPTION
Fixes #815

## Problem

Kill tears the worktree down with `git worktree remove -f`, which bypasses git's own refusal to delete a dirty worktree — so the kill confirmation dialog's warning is the only safety gate users get. The old check in `handleKill` only warned when `git status --porcelain` succeeded **and** reported changes:

```go
if err == nil && len(strings.TrimSpace(string(out))) > 0 {
    hasChanges = true
}
```

If the status command failed (corrupted worktree, missing git metadata, permission issues), the error was silently discarded, no warning was shown, and the forced deletion proceeded — exactly the scenarios where git itself would have refused to remove the worktree.

## Fix

The check is extracted into `killConfirmationWarning` and fails closed: a status error now produces

> WARNING: Could not verify worktree status (\<err\>); it may contain uncommitted changes that will be lost!

in the confirmation dialog, plus a warning log line. Clean and dirty worktree behavior is unchanged (no warning / existing uncommitted-changes warning). The confirmation overlay itself was always shown; only the warning line failed open.

## Adjacent-site audit (pre-delete dirty checks)

Per the repo convention of auditing adjacent call-sites:

- **TUI kill** (`app/handle_actions.go`) — fixed here; the only fail-open dirty check in the codebase (`grep -rn porcelain` confirms it was the sole pre-delete `git status` probe).
- **CLI kill** (`af sessions kill`) — non-interactive JSON command with no confirmation prompts by design; there is no dirty check to fail open.
- **`af reset`** — explicit tear-everything-down semantics (#802 audit); no dirty check by design.
- **Daemon ghost cleanup** (`daemon/control.go`) — best-effort by design: runs daemon-side with no user to warn, only for sessions whose records are already unrestorable. Documented in a comment; no behavior change.

## Tests

`TestKillConfirmationWarning` (hermetic, real temp git repos):
- clean worktree → no warning (unchanged behavior)
- dirty worktree → uncommitted-changes warning (unchanged behavior)
- non-git directory → could-not-verify warning (the #815 regression case)
- nonexistent path → could-not-verify warning

## Verification

- `gofmt -l .` clean, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` all clean
- `go test ./...` green (one unrelated daemon-socket flake on first run, green on rerun)
- `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/... ./app/...` green

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)