### PR TITLE
fix(daemon): bind control socket before instance restore to close the minutes-long no-socket window (#829)

### DIFF
--- a/app/sync.go
+++ b/app/sync.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
@@ -425,6 +426,14 @@ func (m *home) importRemoteHookSessions() int {
 
 	listed, err := importRemoteSessionsThroughDaemon(repo.Root)
 	if err != nil {
+		if daemon.IsDaemonStartingErr(err) {
+			// The daemon is up but still restoring instances (#829); not a
+			// failure. Already-persisted remote sessions were loaded from
+			// storage above, and newly-discovered ones import on the next
+			// TUI launch once the daemon is warm.
+			log.InfoLog.Printf("daemon still restoring instances; skipping remote hook import this launch")
+			return 0
+		}
 		log.WarningLog.Printf("failed to list remote hook sessions: %v", err)
 		return 0
 	}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -96,6 +96,27 @@ type ShutdownResponse struct {
 	OK bool
 }
 
+// daemonStartingErrText is the wire-visible text of the warm-up error. net/rpc
+// flattens server-side errors into plain strings, so clients cannot errors.Is
+// against a sentinel value; IsDaemonStartingErr matches this text instead.
+const daemonStartingErrText = "agent-factory daemon is starting (restoring sessions); retry shortly"
+
+// errDaemonStarting is returned by state-dependent RPC handlers in the window
+// between the control-socket bind and the completion of the instance restore
+// (#829). The socket now binds before the restore, which can take minutes on
+// remote-hook repos, so this window is user-visible.
+func errDaemonStarting() error {
+	return errors.New(daemonStartingErrText)
+}
+
+// IsDaemonStartingErr reports whether an RPC client error means the daemon is
+// up but still restoring instances. Callers should treat it as retryable: the
+// daemon is alive (EnsureDaemon's ping succeeds, so it must NOT spawn another)
+// and the same request succeeds once the restore finishes.
+func IsDaemonStartingErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), daemonStartingErrText)
+}
+
 // DaemonSocketPath returns the Unix socket path used by the local control
 // plane.
 func DaemonSocketPath() (string, error) {
@@ -122,7 +143,7 @@ func EnsureDaemon() error {
 		log.WarningLog.Printf("failed to stop stale daemon before launch: %v", err)
 	}
 
-	if err := launchDaemonProcess(); err != nil {
+	if err := launchDaemonProcessFn(); err != nil {
 		return err
 	}
 
@@ -144,11 +165,33 @@ func pingDaemon() error {
 	return callDaemonNoEnsure("Ping", PingRequest{}, &resp)
 }
 
+// daemonWarmupWait bounds how long RPC clients wait for a warming daemon
+// (socket bound, instance restore still running — #829) before surfacing the
+// typed starting error. It mirrors daemonReadyTimeout, the wait callers
+// already tolerated pre-#829 when EnsureDaemon polled for the socket: a local
+// restore completes well inside this window so CLI/TUI calls just work, while
+// a minutes-long remote-hook restore fails fast with an actionable message
+// instead of hanging the caller. daemonWarmupPoll is the retry cadence.
+const (
+	daemonWarmupWait = daemonReadyTimeout
+	daemonWarmupPoll = 100 * time.Millisecond
+)
+
 func callDaemon(method string, req any, resp any) error {
 	if err := EnsureDaemon(); err != nil {
 		return err
 	}
-	return callDaemonNoEnsure(method, req, resp)
+	err := callDaemonNoEnsure(method, req, resp)
+	// A warming daemon rejects state-dependent RPCs until its instance
+	// restore completes (#829). Retry briefly so callers that race a fresh
+	// daemon spawn (CLI create right after boot, task runs after an upgrade
+	// respawn) succeed without every call site growing retry logic.
+	deadline := time.Now().Add(daemonWarmupWait)
+	for IsDaemonStartingErr(err) && time.Now().Before(deadline) {
+		time.Sleep(daemonWarmupPoll)
+		err = callDaemonNoEnsure(method, req, resp)
+	}
+	return err
 }
 
 func callDaemonNoEnsure(method string, req any, resp any) error {
@@ -341,6 +384,15 @@ func (s *controlServer) ReloadTasks(_ ReloadTasksRequest, resp *ReloadTasksRespo
 	if s.scheduler == nil {
 		return fmt.Errorf("this daemon does not host a task scheduler")
 	}
+	// During warm-up (#829) the scheduler and watcher supervisor have not
+	// started yet; RunDaemon reloads both from tasks.json right after the
+	// restore completes, so a change the caller just wrote is picked up then.
+	// Ack instead of erroring — the write is already durable and there is
+	// nothing running to reload.
+	if s.manager != nil && !s.manager.Ready() {
+		resp.OK = true
+		return nil
+	}
 	if err := s.scheduler.Reload(); err != nil {
 		return err
 	}
@@ -373,7 +425,23 @@ func (s *controlServer) Shutdown(_ ShutdownRequest, resp *ShutdownResponse) erro
 	return nil
 }
 
+// requireManagerReady gates RPC handlers that read or mutate restored session
+// state. During warm-up (socket bound, restore still running — #829) they fail
+// fast with errDaemonStarting rather than operating on an empty instance map:
+// a CreateSession could race the restore into duplicate Instances, and a
+// KillSession/SendPrompt would construct throwaway instances from disk that
+// the restore then orphans. Ping and Shutdown stay available throughout.
+func (s *controlServer) requireManagerReady() error {
+	if s.manager == nil || s.manager.Ready() {
+		return nil
+	}
+	return errDaemonStarting()
+}
+
 func (s *controlServer) CreateSession(req CreateSessionRequest, resp *CreateSessionResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
 	data, err := s.manager.CreateSession(req)
 	if err != nil {
 		return err
@@ -383,6 +451,9 @@ func (s *controlServer) CreateSession(req CreateSessionRequest, resp *CreateSess
 }
 
 func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
@@ -394,6 +465,9 @@ func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionRes
 }
 
 func (s *controlServer) SendPrompt(req SendPromptRequest, resp *SendPromptResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
@@ -419,6 +493,9 @@ func validateRPCRepoID(repoID string) error {
 }
 
 func (s *controlServer) ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest, resp *ImportRemoteHookSessionsResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
 	data, err := s.manager.ImportRemoteHookSessions(req)
 	if err != nil {
 		return err
@@ -543,6 +620,12 @@ func startControlServer(manager *Manager, scheduler *taskScheduler, watchers *wa
 type Manager struct {
 	cfg *config.Config
 
+	// ready is closed once the initial instance restore has completed. Until
+	// then the daemon is "warming up": the control socket is already bound
+	// (#829) but state-dependent RPCs return errDaemonStarting.
+	ready     chan struct{}
+	readyOnce sync.Once
+
 	mu                  sync.Mutex
 	storage             *session.Storage
 	instances           map[string]*session.Instance
@@ -551,24 +634,68 @@ type Manager struct {
 	repoStartLocks      map[string]*sync.Mutex
 }
 
+// NewManager constructs a manager and synchronously restores all persisted
+// instances into it, returning only once the manager is ready. RunDaemon
+// deliberately does NOT use this: it builds the shell with newManagerShell,
+// binds the control socket, and only then runs RestoreInstances — the restore
+// can take minutes on remote-hook repos and must not delay the bind (#829).
 func NewManager(cfg *config.Config) (*Manager, error) {
+	manager, err := newManagerShell(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := manager.RestoreInstances(); err != nil {
+		return nil, err
+	}
+	return manager, nil
+}
+
+// newManagerShell constructs a Manager with no instances loaded. The manager
+// reports !Ready() until RestoreInstances completes.
+func newManagerShell(cfg *config.Config) (*Manager, error) {
 	state := config.LoadState()
 	storage, err := session.NewStorage(state, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize storage: %w", err)
 	}
-	instances, err := refreshDaemonInstances(nil)
-	if err != nil {
-		return nil, err
-	}
 	return &Manager{
 		cfg:                 cfg,
+		ready:               make(chan struct{}),
 		storage:             storage,
-		instances:           instances,
+		instances:           make(map[string]*session.Instance),
 		reservedTitles:      make(map[string]struct{}),
 		reservedRemoteNames: make(map[string]struct{}),
 		repoStartLocks:      make(map[string]*sync.Mutex),
 	}, nil
+}
+
+// RestoreInstances loads every repo's persisted instances into the manager
+// and marks it ready. This is the slow part of daemon startup — restoring a
+// remote-hook session shells out to the repo's list_cmd (often ssh) per
+// session — which is why RunDaemon runs it only after the control socket is
+// bound (#829). Replacing the instance map wholesale is safe: every RPC that
+// mutates it is gated on Ready, and the refresh poll loop starts after the
+// restore completes.
+func (m *Manager) RestoreInstances() error {
+	instances, err := refreshDaemonInstances(nil)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.instances = instances
+	m.mu.Unlock()
+	m.readyOnce.Do(func() { close(m.ready) })
+	return nil
+}
+
+// Ready reports whether the initial instance restore has completed.
+func (m *Manager) Ready() bool {
+	select {
+	case <-m.ready:
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *Manager) RefreshInstances() error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -18,9 +18,23 @@ import (
 	"time"
 )
 
+// restoreManagerForStartup is the warm-up restore entry point RunDaemon uses.
+// Package-level so tests can inject a slow or gated restore and prove the
+// control socket binds and serves before the restore completes (#829).
+var restoreManagerForStartup = func(m *Manager) error { return m.RestoreInstances() }
+
 // RunDaemon runs the daemon process: it serves the local control plane,
 // evaluates task cron schedules in-process, supervises watch-task scripts,
 // and iterates over all sessions to run AutoYes mode on them.
+//
+// Startup ordering matters (#829): the control socket binds BEFORE the
+// instance restore, which can take minutes on remote-hook repos (list_cmd /
+// ssh per session). Pre-#829 the restore ran first, so every concurrent
+// EnsureDaemon found no socket and spawned another daemon that burned a full
+// restore before losing the bind race. During the warm-up window Ping and
+// Shutdown work and state-dependent RPCs return errDaemonStarting; the
+// scheduler, watcher supervisor, and AutoYes poll loop start only after the
+// restore because they act on restored state.
 func RunDaemon(cfg *config.Config) error {
 	log.InfoLog.Printf("starting daemon")
 
@@ -35,19 +49,14 @@ func RunDaemon(cfg *config.Config) error {
 		return nil
 	}
 
-	manager, err := NewManager(cfg)
+	// Shell only — no restore yet, so the bind below happens within
+	// milliseconds of process start.
+	manager, err := newManagerShell(cfg)
 	if err != nil {
 		return err
 	}
 
-	// Remove per-task timer units left behind by pre-#782 versions; the
-	// in-process scheduler below replaces them.
-	sweepLegacyTaskUnits()
-
 	scheduler := newTaskScheduler()
-	if err := scheduler.Reload(); err != nil {
-		log.WarningLog.Printf("failed to load task schedules: %v", err)
-	}
 	watchers := newWatcherSupervisor()
 
 	shutdownCh := make(chan struct{})
@@ -69,8 +78,62 @@ func RunDaemon(cfg *config.Config) error {
 		}
 	}()
 
-	// Start schedule evaluation only after the control server is up: a task
-	// firing immediately goes through the CreateSession RPC on our own socket.
+	// Write our PID as soon as the socket is bound so `af upgrade`'s SIGTERM
+	// fallback (#504) and StopDaemon can find a still-warming daemon. Both
+	// the SIGTERM and Shutdown-RPC exit paths fall through to the deferred
+	// cleanup, so the file is removed on any graceful shutdown. A stale file
+	// is harmless — readers verify the live process's cmdline before
+	// signaling it.
+	if err := writeDaemonPIDFile(); err != nil {
+		log.WarningLog.Printf("failed to write daemon PID file: %v", err)
+	} else {
+		defer removeDaemonPIDFile()
+	}
+
+	// Notify on SIGINT (Ctrl+C) and SIGTERM, and watch for a Shutdown RPC.
+	// The RPC path is used by `af upgrade` / autoUpdate after writing a new
+	// binary so the next RPC respawns the daemon from the fresh image (#498).
+	// Registered before the restore so both exit paths work during warm-up.
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Run the restore concurrently so a shutdown or signal during warm-up
+	// exits promptly instead of hanging behind minutes of list_cmd/ssh. The
+	// warm-up exit paths deliberately skip SaveInstances: nothing has been
+	// restored, and saving the empty instance map would wipe every persisted
+	// session.
+	log.InfoLog.Printf("control socket bound; restoring instances")
+	restoreDone := make(chan error, 1)
+	// Capture the seam on the main flow: reading the package var inside the
+	// goroutine would race with tests restoring it after RunDaemon returns.
+	restore := restoreManagerForStartup
+	go func() { restoreDone <- restore(manager) }()
+	select {
+	case restoreErr := <-restoreDone:
+		if restoreErr != nil {
+			// Same outcome as a pre-#829 NewManager failure: exit non-zero
+			// and let the autostart unit's Restart=on-failure retry.
+			return fmt.Errorf("failed to restore instances: %w", restoreErr)
+		}
+	case sig := <-sigChan:
+		log.InfoLog.Printf("received signal %s during instance restore; exiting", sig.String())
+		return nil
+	case <-shutdownCh:
+		log.InfoLog.Printf("received shutdown request via control socket during instance restore; exiting")
+		return nil
+	}
+	log.InfoLog.Printf("instance restore complete; daemon ready")
+
+	// Remove per-task timer units left behind by pre-#782 versions; the
+	// in-process scheduler below replaces them.
+	sweepLegacyTaskUnits()
+
+	// Start schedule evaluation only after the control server is up and the
+	// restore has finished: a task firing immediately goes through the
+	// CreateSession RPC on our own socket, which requires a ready manager.
+	if err := scheduler.Reload(); err != nil {
+		log.WarningLog.Printf("failed to load task schedules: %v", err)
+	}
 	scheduler.Start()
 	defer scheduler.Stop()
 
@@ -83,17 +146,6 @@ func RunDaemon(cfg *config.Config) error {
 		log.WarningLog.Printf("failed to start task watchers: %v", err)
 	}
 	defer watchers.Stop()
-
-	// Write our PID so `af upgrade`'s SIGTERM fallback (#504) can find the
-	// running daemon. Both the SIGTERM and Shutdown-RPC exit paths fall
-	// through to the deferred cleanup, so the file is removed on any graceful
-	// shutdown. A stale file is harmless — readers verify the live process's
-	// cmdline before signaling it.
-	if err := writeDaemonPIDFile(); err != nil {
-		log.WarningLog.Printf("failed to write daemon PID file: %v", err)
-	} else {
-		defer removeDaemonPIDFile()
-	}
 
 	pollInterval := time.Duration(cfg.DaemonPollInterval) * time.Millisecond
 
@@ -127,11 +179,8 @@ func RunDaemon(cfg *config.Config) error {
 		}
 	}()
 
-	// Notify on SIGINT (Ctrl+C) and SIGTERM, and watch for a Shutdown RPC.
-	// The RPC path is used by `af upgrade` / autoUpdate after writing a new
-	// binary so the next RPC respawns the daemon from the fresh image (#498).
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	// Block until a signal or a Shutdown RPC ends the daemon (sigChan and
+	// shutdownCh were armed before the restore above).
 	select {
 	case sig := <-sigChan:
 		log.InfoLog.Printf("received signal %s", sig.String())
@@ -261,6 +310,11 @@ func daemonInstances(instanceMap map[string]*session.Instance) []*session.Instan
 func LaunchDaemon() error {
 	return EnsureDaemon()
 }
+
+// launchDaemonProcessFn is the spawn entry point EnsureDaemon uses.
+// Package-level so tests can record or suppress real daemon spawns and prove
+// a bound-but-warming daemon is treated as running, never respawned (#829).
+var launchDaemonProcessFn = launchDaemonProcess
 
 func launchDaemonProcess() error {
 	// Find the agent-factory binary.

--- a/daemon/warmup_test.go
+++ b/daemon/warmup_test.go
@@ -1,0 +1,328 @@
+package daemon
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// The tests in this file cover the #829 startup reorder: the control socket
+// binds before the (potentially minutes-long) instance restore, so during the
+// warm-up window Ping and Shutdown must work, state-dependent RPCs must fail
+// fast with the typed "daemon is starting" error, and EnsureDaemon must treat
+// the bound-but-warming daemon as running rather than spawning another.
+
+// TestControlServer_WarmupGatesStateRPCs drives the warm-up window at the
+// control-server level: a manager shell with no restore answers Ping, rejects
+// every state-dependent RPC with the typed starting error, and acks
+// ReloadTasks (RunDaemon reloads tasks.json after the restore anyway). Once
+// RestoreInstances completes, the same RPCs pass the gate.
+func TestControlServer_WarmupGatesStateRPCs(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+
+	manager, err := newManagerShell(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("newManagerShell: %v", err)
+	}
+	if manager.Ready() {
+		t.Fatalf("manager shell must not report ready before RestoreInstances")
+	}
+	scheduler := newTaskScheduler()
+	closeServer, err := startControlServer(manager, scheduler, nil, nil)
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	t.Cleanup(func() { _ = closeServer() })
+
+	// Ping must work during warm-up — it is what stops EnsureDaemon callers
+	// from spawning duplicate daemons.
+	if err := pingDaemon(); err != nil {
+		t.Fatalf("Ping during warm-up: %v", err)
+	}
+
+	// Every state-dependent RPC must return the typed starting error.
+	var createResp CreateSessionResponse
+	err = callDaemonNoEnsure("CreateSession", CreateSessionRequest{
+		Title: "warmup", RepoPath: repoPath, Program: "claude",
+	}, &createResp)
+	if !IsDaemonStartingErr(err) {
+		t.Fatalf("CreateSession during warm-up: want daemon-starting error, got: %v", err)
+	}
+	var killResp KillSessionResponse
+	err = callDaemonNoEnsure("KillSession", KillSessionRequest{Title: "warmup"}, &killResp)
+	if !IsDaemonStartingErr(err) {
+		t.Fatalf("KillSession during warm-up: want daemon-starting error, got: %v", err)
+	}
+	var promptResp SendPromptResponse
+	err = callDaemonNoEnsure("SendPrompt", SendPromptRequest{Title: "warmup", Prompt: "hi"}, &promptResp)
+	if !IsDaemonStartingErr(err) {
+		t.Fatalf("SendPrompt during warm-up: want daemon-starting error, got: %v", err)
+	}
+	var importResp ImportRemoteHookSessionsResponse
+	err = callDaemonNoEnsure("ImportRemoteHookSessions", ImportRemoteHookSessionsRequest{RepoPath: repoPath}, &importResp)
+	if !IsDaemonStartingErr(err) {
+		t.Fatalf("ImportRemoteHookSessions during warm-up: want daemon-starting error, got: %v", err)
+	}
+
+	// ReloadTasks acks during warm-up: the caller's tasks.json write is
+	// durable and RunDaemon reloads it right after the restore completes.
+	var reloadResp ReloadTasksResponse
+	if err := callDaemonNoEnsure("ReloadTasks", ReloadTasksRequest{}, &reloadResp); err != nil {
+		t.Fatalf("ReloadTasks during warm-up: %v", err)
+	}
+	if !reloadResp.OK {
+		t.Fatalf("ReloadTasks during warm-up returned OK=false")
+	}
+
+	// After the restore the gate opens and the same RPC path works end to end.
+	if err := manager.RestoreInstances(); err != nil {
+		t.Fatalf("RestoreInstances: %v", err)
+	}
+	if !manager.Ready() {
+		t.Fatalf("manager must report ready after RestoreInstances")
+	}
+	if err := callDaemonNoEnsure("CreateSession", CreateSessionRequest{
+		Title: "warmup", RepoPath: repoPath, Program: "claude",
+	}, &createResp); err != nil {
+		t.Fatalf("CreateSession after restore: %v", err)
+	}
+	if createResp.Instance.Title != "warmup" {
+		t.Fatalf("unexpected create response after restore: %+v", createResp.Instance)
+	}
+}
+
+// TestCallDaemon_RetriesThroughWarmup verifies the client side of the warm-up
+// contract: a state-dependent call that lands during the warm-up window keeps
+// retrying (bounded by daemonWarmupWait) and succeeds once the restore
+// completes, so call sites racing a fresh daemon spawn — CLI create right
+// after boot, task runs after an upgrade respawn — need no retry logic of
+// their own.
+func TestCallDaemon_RetriesThroughWarmup(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installInstantBackend(t)
+	repoPath := setupControlRepo(t)
+
+	prevLaunch := launchDaemonProcessFn
+	launchDaemonProcessFn = func() error { return nil }
+	t.Cleanup(func() { launchDaemonProcessFn = prevLaunch })
+
+	manager, err := newManagerShell(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("newManagerShell: %v", err)
+	}
+	closeServer, err := startControlServer(manager, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	t.Cleanup(func() { _ = closeServer() })
+
+	restored := make(chan struct{})
+	go func() {
+		defer close(restored)
+		time.Sleep(300 * time.Millisecond)
+		if err := manager.RestoreInstances(); err != nil {
+			t.Errorf("RestoreInstances: %v", err)
+		}
+	}()
+	t.Cleanup(func() { <-restored })
+
+	data, err := CreateSession(CreateSessionRequest{
+		Title: "retry-through-warmup", RepoPath: repoPath, Program: "claude",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession across warm-up: %v", err)
+	}
+	if data.Title != "retry-through-warmup" {
+		t.Fatalf("unexpected created session: %+v", data)
+	}
+}
+
+// TestControlServer_ShutdownWorksDuringWarmup verifies the Shutdown RPC is
+// not gated: `af upgrade` must be able to stop a daemon that is still
+// restoring instances.
+func TestControlServer_ShutdownWorksDuringWarmup(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	manager, err := newManagerShell(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("newManagerShell: %v", err)
+	}
+	shutdownCh := make(chan struct{})
+	closeServer, err := startControlServer(manager, nil, nil, shutdownCh)
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	t.Cleanup(func() { _ = closeServer() })
+
+	var resp ShutdownResponse
+	if err := callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &resp); err != nil {
+		t.Fatalf("Shutdown during warm-up: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("Shutdown during warm-up returned OK=false")
+	}
+	select {
+	case <-shutdownCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("shutdownCh was not closed within 2s of a warm-up Shutdown RPC")
+	}
+}
+
+// TestEnsureDaemon_TreatsWarmingDaemonAsRunning is the doomed-spawn-race
+// regression test for #829: with a warming daemon bound on the socket,
+// EnsureDaemon's ping succeeds, so it must return nil without launching a
+// second daemon process.
+func TestEnsureDaemon_TreatsWarmingDaemonAsRunning(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	var launches atomic.Int32
+	prevLaunch := launchDaemonProcessFn
+	launchDaemonProcessFn = func() error {
+		launches.Add(1)
+		return nil
+	}
+	t.Cleanup(func() { launchDaemonProcessFn = prevLaunch })
+
+	manager, err := newManagerShell(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("newManagerShell: %v", err)
+	}
+	closeServer, err := startControlServer(manager, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	t.Cleanup(func() { _ = closeServer() })
+
+	if err := EnsureDaemon(); err != nil {
+		t.Fatalf("EnsureDaemon against warming daemon: %v", err)
+	}
+	if got := launches.Load(); got != 0 {
+		t.Fatalf("EnsureDaemon spawned %d daemon(s) while a warming daemon held the socket — the #829 doomed-spawn race", got)
+	}
+}
+
+// TestRunDaemon_BindsSocketBeforeRestoreCompletes exercises the full RunDaemon
+// startup with a restore that never finishes until the test releases it. If
+// RunDaemon still bound the socket after the restore (the pre-#829 ordering),
+// the ping poll below would never succeed and the test would time out — so a
+// passing run proves the bind happens strictly before the restore completes,
+// regardless of how slow the restore is. It also pins the warm-up contract at
+// the daemon level: PID file present, EnsureDaemon does not spawn, state RPCs
+// return the typed starting error, and a Shutdown RPC ends a warming daemon
+// promptly without saving (or wiping) instance state.
+func TestRunDaemon_BindsSocketBeforeRestoreCompletes(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	restoreStarted := make(chan struct{})
+	restoreGate := make(chan struct{})
+	restoreReturned := make(chan struct{})
+	prevRestore := restoreManagerForStartup
+	restoreManagerForStartup = func(m *Manager) error {
+		close(restoreStarted)
+		<-restoreGate
+		close(restoreReturned)
+		return nil
+	}
+	var launches atomic.Int32
+	prevLaunch := launchDaemonProcessFn
+	launchDaemonProcessFn = func() error {
+		launches.Add(1)
+		return nil
+	}
+	t.Cleanup(func() {
+		restoreManagerForStartup = prevRestore
+		launchDaemonProcessFn = prevLaunch
+		close(restoreGate)
+		// Join the gated goroutine only if the stub actually ran — on an
+		// early test failure RunDaemon may not have reached the restore.
+		select {
+		case <-restoreStarted:
+		default:
+			return
+		}
+		select {
+		case <-restoreReturned:
+		case <-time.After(2 * time.Second):
+			t.Errorf("gated restore goroutine did not exit after release")
+		}
+	})
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- RunDaemon(config.DefaultConfig()) }()
+
+	// The socket must come up while the restore is still blocked. Generous
+	// deadline for CI; on a healthy box this completes in a few milliseconds.
+	bindDeadline := time.Now().Add(5 * time.Second)
+	for pingDaemon() != nil {
+		if time.Now().After(bindDeadline) {
+			t.Fatalf("control socket did not bind while restore was in progress (#829 ordering regressed)")
+		}
+		select {
+		case err := <-runDone:
+			t.Fatalf("RunDaemon exited before binding the socket: %v", err)
+		default:
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	select {
+	case <-restoreReturned:
+		t.Fatalf("restore completed before the socket answered — the gate is broken and this test proves nothing")
+	default:
+	}
+	// Wait for the warm-up goroutine to enter the restore: in RunDaemon's
+	// program order that is strictly after the PID-file write, making the
+	// assertions below deterministic.
+	select {
+	case <-restoreStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("RunDaemon never started the instance restore")
+	}
+
+	// PID file is written right after the bind so StopDaemon and the upgrade
+	// SIGTERM fallback can find a warming daemon.
+	pidPath, err := daemonPIDFilePath()
+	if err != nil {
+		t.Fatalf("daemonPIDFilePath: %v", err)
+	}
+	if _, err := os.Stat(pidPath); err != nil {
+		t.Fatalf("daemon PID file missing during warm-up: %v", err)
+	}
+
+	// EnsureDaemon must see the warming daemon as RUNNING — no second spawn.
+	if err := EnsureDaemon(); err != nil {
+		t.Fatalf("EnsureDaemon during warm-up: %v", err)
+	}
+	if got := launches.Load(); got != 0 {
+		t.Fatalf("EnsureDaemon spawned %d daemon(s) during warm-up", got)
+	}
+
+	// State-dependent RPCs fail fast with the typed starting error.
+	var promptResp SendPromptResponse
+	rpcErr := callDaemonNoEnsure("SendPrompt", SendPromptRequest{Title: "x", Prompt: "hi"}, &promptResp)
+	if !IsDaemonStartingErr(rpcErr) {
+		t.Fatalf("SendPrompt during warm-up: want daemon-starting error, got: %v", rpcErr)
+	}
+
+	// Shutdown must end a warming daemon promptly — it cannot wait for the
+	// restore (which this test never releases until cleanup).
+	result, err := RequestShutdown()
+	if err != nil {
+		t.Fatalf("RequestShutdown during warm-up: %v", err)
+	}
+	if result != ShutdownViaRPC {
+		t.Fatalf("RequestShutdown during warm-up returned %v, want ShutdownViaRPC", result)
+	}
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("RunDaemon returned error on warm-up shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("RunDaemon did not exit within 5s of a warm-up Shutdown RPC")
+	}
+}


### PR DESCRIPTION
Fixes #829

## Problem

`RunDaemon` ran the full instance restore (`NewManager`) **before** binding the control socket. On remote-hook repos the restore shells out to `list_cmd`/ssh per session, stretching the no-socket window from ~1s to **minutes**. During that window every concurrent `EnsureDaemon` (TUI ticks, CLI commands, sessions) pinged, found nothing, and spawned another daemon — each of which ran its own full restore before losing the #792 flock bind race and exiting (~30s CPU per doomed cycle, several cycles deep), while the TUI logged `daemon did not become ready` / `failed to list remote hook sessions` the whole time.

## Fix

**Startup reorder** (`daemon/daemon.go`): construct the manager shell only (`newManagerShell`, fast), bind the control socket — `bindControlServerExclusive` is unchanged, the #792 flock just runs earlier — write the PID file, arm SIGTERM/Shutdown handling, and **then** run the restore. The no-socket window is back to milliseconds regardless of restore duration.

**Warm-up gate** (`daemon/control.go`):
- `Manager` is split into shell + `RestoreInstances` (marks ready). `NewManager` keeps the old synchronous semantics, so existing tests and the integration harness are untouched.
- State-dependent RPCs (`CreateSession`, `KillSession`, `SendPrompt`, `ImportRemoteHookSessions`) return a typed "daemon is starting (restoring sessions); retry shortly" error during warm-up — operating on the empty pre-restore instance map could race the restore into duplicate Instances. `Ping` and `Shutdown` work throughout.
- `ReloadTasks` acks during warm-up: the caller's `tasks.json` write is durable and RunDaemon reloads the scheduler + watchers right after the restore completes.
- The restore runs concurrently with a select on `sigChan`/`shutdownCh`, so `af upgrade`'s Shutdown RPC and SIGTERM end a warming daemon promptly instead of hanging behind minutes of ssh. Warm-up exits deliberately skip `SaveInstances` — saving the empty map would wipe persisted sessions.
- Scheduler, watcher supervisor, and the AutoYes poll loop start only **after** the restore (they act on restored state and loop back through our own socket), preserving the pre-existing ordering constraints, now documented in `RunDaemon`.

**Client side**:
- `callDaemon` retries the typed starting error for up to 5s (same bound callers already tolerated pre-#829 inside `EnsureDaemon`'s socket poll), so CLI/TUI/task calls racing a fresh spawn just work — caught live by `TestDaemonLifecycleRecoversFromStaleSocketAndDeadDaemon`, which passes again. Restores longer than 5s surface the actionable typed error instead of a hang.
- `app/sync.go` recognizes the starting error on the TUI's remote-hook import and logs it as info ("skipping remote hook import this launch") instead of a warning — already-persisted sessions still load from storage.

## Adjacent call-site audit (per repo conventions)

- All daemon RPC client call sites (`api/`, `app/`, `task` CRUD via `ReloadTasks`) funnel through `callDaemon` — the retry covers every one; none needed individual changes.
- `EnsureDaemon` treats a bound-but-warming daemon as RUNNING (ping answers), so the doomed-spawn race is gone by construction — pinned by test.
- #792 spawn-lock semantics hold: flock around ping→bind unchanged, just earlier; `TestBindControlServerExclusive_ExactlyOneBinds` green.
- #767 cleanup guard: a warming daemon answers ping, so `cleanupDaemonRuntimeFiles` correctly leaves its socket/PID file alone; the PID file now exists during warm-up so `StopDaemon` and the #504 SIGTERM fallback can find a warming daemon too.

## Tests (`daemon/warmup_test.go`)

- `TestRunDaemon_BindsSocketBeforeRestoreCompletes` — gates the restore behind a channel the test controls; a passing run structurally proves the bind precedes restore completion (pre-#829 ordering would time out). Also pins: PID file present during warm-up, `EnsureDaemon` performs zero spawns (recorded via seam), state RPC returns the typed error, Shutdown ends a warming daemon promptly. Stressed 20× under `-race`.
- `TestControlServer_WarmupGatesStateRPCs` — Ping OK, all four state RPCs return `IsDaemonStartingErr`, `ReloadTasks` acks; after `RestoreInstances` the same `CreateSession` succeeds end-to-end.
- `TestControlServer_ShutdownWorksDuringWarmup`, `TestEnsureDaemon_TreatsWarmingDaemonAsRunning`, `TestCallDaemon_RetriesThroughWarmup`.

## Verification

- `go build ./...`, `gofmt -l .` (clean), `golangci-lint run --timeout=3m --fast` (clean), `deadcode -test ./...` (clean)
- `go test ./...` green (incl. integration); `go test -race ./daemon/` green; bounded `-race` for `ui/`/`app/` green
- Hermetic: all tests run against temp `AGENT_FACTORY_HOME`; the supervised dev-box unit was not touched. Real unit-restart timing check deliberately left for the maintainer's pre-merge verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)