### PR TITLE
feat(config): resolve relative in-repo remote_hooks paths against the repo root (#834)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ A repository can carry its own configuration in `<repo-root>/.agent-factory/conf
 | `post_worktree_commands`, `remote_hooks` | **In-repo only.** The legacy `~/.agent-factory/repos/<repoID>/config.json` location keeps working for one more release (a deprecation warning in the log points at the new file) and is shadowed whenever the in-repo file sets the same key — including by an explicit empty value like `"post_worktree_commands": []`. |
 | `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `detach_keys` | Global only. Setting them in-repo is rejected with an error naming the key. |
 
+Relative `remote_hooks` paths (like `./infra/launch.sh` above) resolve against the repository root — the repo whose `.agent-factory/config.json` was loaded; for sessions in linked worktrees that is the main repository root — so checked-in hook scripts work no matter what the working directory of `af` or its daemon is. Bare names without a path separator (e.g. `bash`) keep normal `$PATH` lookup. See [docs/remote-hooks.md](docs/remote-hooks.md#command-path-resolution) for the full rules.
+
 Note that an in-repo config executes what it configures: `post_worktree_commands` run after each worktree is created, `remote_hooks` and `program_overrides` values are invoked as shell commands. Cloning a repository and running `af` in it implies trusting that repo's `.agent-factory/config.json`. The first time a config carrying such fields loads (and whenever its content changes), `af` records one log line naming the fields and the file's content hash.
 
 ## Upstream

--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -32,6 +32,10 @@ type RemoteHooks struct {
 // (#738). list_cmd is intentionally not required here: import/sync paths treat
 // an empty list_cmd as "no remote sessions to enumerate" (see app/sync.go and
 // daemon/control.go), so requiring it would break that documented behavior.
+//
+// Callers receive hooks whose relative paths were already rewritten by
+// resolveCommandPaths, but resolution leaves empty values empty, so these
+// errors always reflect the value the user wrote in the config file.
 func (h RemoteHooks) Validate() error {
 	if strings.TrimSpace(h.LaunchCmd) == "" {
 		return fmt.Errorf("remote_hooks.launch_cmd is required")
@@ -43,6 +47,42 @@ func (h RemoteHooks) Validate() error {
 		return fmt.Errorf("remote_hooks.delete_cmd is required")
 	}
 	return nil
+}
+
+// resolveCommandPaths returns a copy of h with every command value that is a
+// relative filesystem path rewritten to an absolute path under repoRoot, so
+// the hooks execute correctly no matter what the process cwd is — the daemon
+// in particular runs hook commands with a cwd unrelated to the repo (#834).
+// The value receiver makes the copy: the loaded config struct is never
+// mutated.
+func (h RemoteHooks) resolveCommandPaths(repoRoot string) *RemoteHooks {
+	h.LaunchCmd = resolveHookCommandPath(repoRoot, h.LaunchCmd)
+	h.ListCmd = resolveHookCommandPath(repoRoot, h.ListCmd)
+	h.AttachCmd = resolveHookCommandPath(repoRoot, h.AttachCmd)
+	h.DeleteCmd = resolveHookCommandPath(repoRoot, h.DeleteCmd)
+	return &h
+}
+
+// resolveHookCommandPath rewrites a single hook command value that is a
+// relative filesystem path ("./infra/launch.sh", "infra/launch.sh",
+// "../shared/hooks/launch.sh") into an absolute path under repoRoot.
+//
+// Two kinds of values pass through unchanged, mirroring how exec.Command
+// treats its first argument (the whole string is the executable path; hook
+// commands are never shell-parsed):
+//   - absolute paths, which need no base directory;
+//   - bare names without any path separator ("bash", "coder-launch.sh"),
+//     which keep exec's $PATH lookup semantics — a separator is exactly what
+//     makes exec skip $PATH, so it is also what opts a value into repo-root
+//     resolution.
+//
+// Empty stays empty so RemoteHooks.Validate reports the missing field, not a
+// phantom path.
+func resolveHookCommandPath(repoRoot, cmd string) string {
+	if cmd == "" || filepath.IsAbs(cmd) || !strings.ContainsRune(cmd, filepath.Separator) {
+		return cmd
+	}
+	return filepath.Join(repoRoot, cmd)
 }
 
 // RepoConfig holds per-repository configuration.

--- a/config/repo_config_test.go
+++ b/config/repo_config_test.go
@@ -278,3 +278,47 @@ func TestRemoteHooksValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveHookCommandPath(t *testing.T) {
+	const root = "/srv/repos/detail"
+	cases := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"absolute unchanged", "/usr/local/bin/launch.sh", "/usr/local/bin/launch.sh"},
+		{"dot-slash relative resolved", "./.agent-factory/hooks/coder-launch.sh", root + "/.agent-factory/hooks/coder-launch.sh"},
+		{"bare relative resolved", "infra/launch.sh", root + "/infra/launch.sh"},
+		{"parent-relative resolved and cleaned", "../shared/launch.sh", "/srv/repos/shared/launch.sh"},
+		{"bare name keeps $PATH lookup", "coder-launch.sh", "coder-launch.sh"},
+		{"plain command keeps $PATH lookup", "bash", "bash"},
+		{"empty stays empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveHookCommandPath(root, tc.cmd))
+		})
+	}
+}
+
+// TestRemoteHooksResolveCommandPaths verifies the copy semantics: the
+// returned hooks carry resolved paths while the receiver is untouched, so
+// ResolveConfig can never write rewritten values back through a loaded
+// config struct.
+func TestRemoteHooksResolveCommandPaths(t *testing.T) {
+	orig := RemoteHooks{
+		LaunchCmd: "./hooks/launch.sh",
+		ListCmd:   "/abs/list.sh",
+		AttachCmd: "ssh-attach",
+		DeleteCmd: "hooks/delete.sh",
+	}
+	resolved := orig.resolveCommandPaths("/repo")
+
+	assert.Equal(t, "/repo/hooks/launch.sh", resolved.LaunchCmd)
+	assert.Equal(t, "/abs/list.sh", resolved.ListCmd)
+	assert.Equal(t, "ssh-attach", resolved.AttachCmd)
+	assert.Equal(t, "/repo/hooks/delete.sh", resolved.DeleteCmd)
+
+	assert.Equal(t, "./hooks/launch.sh", orig.LaunchCmd, "receiver must not be mutated")
+	assert.Equal(t, "hooks/delete.sh", orig.DeleteCmd, "receiver must not be mutated")
+}

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -38,7 +38,10 @@ type ResolvedConfig struct {
 	// legacy ~/.agent-factory/repos/<id>/config.json value.
 	PostWorktreeCommands []string
 	// RemoteHooks is the effective remote hook backend config, with the
-	// same in-repo-then-legacy resolution as PostWorktreeCommands.
+	// same in-repo-then-legacy resolution as PostWorktreeCommands. Command
+	// values that were relative filesystem paths have been rewritten to
+	// absolute paths under repoRoot (#834); consumers can exec them without
+	// caring about the process cwd.
 	RemoteHooks *RemoteHooks
 }
 
@@ -94,6 +97,19 @@ func ResolveConfig(repoRoot string) (*ResolvedConfig, error) {
 			res.RemoteHooks = inRepo.RemoteHooks
 		}
 		logInRepoConfigLoaded(repoID, repoRoot, inRepo, raw)
+	}
+
+	// Rewrite relative hook command paths to absolute against repoRoot
+	// (#834). This is the single chokepoint for the rewrite: every exec of a
+	// hook command — launch/list/attach/delete, startup import, restore
+	// liveness, preview — receives its RemoteHooks from ResolveConfig, so
+	// resolving here covers them all. repoRoot is the main worktree root, so
+	// sessions in linked worktrees resolve hooks against the repository whose
+	// config file was loaded, never against a worktree path. The rewrite
+	// applies to the legacy-location value too, so both sources behave
+	// identically.
+	if res.RemoteHooks != nil {
+		res.RemoteHooks = res.RemoteHooks.resolveCommandPaths(repoRoot)
 	}
 
 	warnLegacyRepoConfig(repoID, repoRoot, legacy, inRepo)

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -152,6 +152,57 @@ func TestResolveConfigRepoFields(t *testing.T) {
 	})
 }
 
+// TestResolveConfigResolvesHookPaths covers the #834 chokepoint: relative
+// remote_hooks command paths leave ResolveConfig as absolute paths under the
+// repo root, regardless of which config location supplied them, while
+// absolute paths and bare $PATH names pass through untouched.
+func TestResolveConfigResolvesHookPaths(t *testing.T) {
+	t.Run("in-repo relative paths resolve against repo root", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+		writeInRepoConfig(t, repoRoot, `{"remote_hooks": {
+			"launch_cmd": "./.agent-factory/hooks/launch.sh",
+			"list_cmd": "infra/list.sh",
+			"attach_cmd": "/abs/attach.sh",
+			"delete_cmd": "bash"
+		}}`)
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		require.NotNil(t, res.RemoteHooks)
+		assert.Equal(t, filepath.Join(repoRoot, ".agent-factory/hooks/launch.sh"), res.RemoteHooks.LaunchCmd)
+		assert.Equal(t, filepath.Join(repoRoot, "infra/list.sh"), res.RemoteHooks.ListCmd)
+		assert.Equal(t, "/abs/attach.sh", res.RemoteHooks.AttachCmd, "absolute path passes through")
+		assert.Equal(t, "bash", res.RemoteHooks.DeleteCmd, "bare name keeps $PATH lookup")
+	})
+
+	t.Run("legacy-location relative paths get the same resolution", func(t *testing.T) {
+		repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+		repoID := RepoIDFromRoot(repoRoot)
+		require.NoError(t, SaveRepoConfig(repoID, &RepoConfig{
+			RemoteHooks: &RemoteHooks{
+				LaunchCmd: "./hooks/launch.sh",
+				ListCmd:   "/abs/list.sh",
+				AttachCmd: "hooks/attach.sh",
+				DeleteCmd: "coder-delete",
+			},
+		}))
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		require.NotNil(t, res.RemoteHooks)
+		assert.Equal(t, filepath.Join(repoRoot, "hooks/launch.sh"), res.RemoteHooks.LaunchCmd)
+		assert.Equal(t, "/abs/list.sh", res.RemoteHooks.ListCmd)
+		assert.Equal(t, filepath.Join(repoRoot, "hooks/attach.sh"), res.RemoteHooks.AttachCmd)
+		assert.Equal(t, "coder-delete", res.RemoteHooks.DeleteCmd)
+
+		// The rewrite operates on a copy; a fresh load of the legacy config
+		// still sees the values the user wrote.
+		legacy, err := LoadRepoConfig(repoID)
+		require.NoError(t, err)
+		assert.Equal(t, "./hooks/launch.sh", legacy.RemoteHooks.LaunchCmd)
+	})
+}
+
 func TestResolveConfigLegacyDeprecationLog(t *testing.T) {
 	buf := captureLog(t, &aflog.WarningLog)
 	repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -9,13 +9,23 @@ Add remote hooks to the repo's own config file at `<repo-root>/.agent-factory/co
 ```json
 {
   "remote_hooks": {
-    "launch_cmd": "/path/to/launch.sh",
-    "list_cmd": "/path/to/list.sh",
-    "attach_cmd": "/path/to/attach.sh",
-    "delete_cmd": "/path/to/delete.sh"
+    "launch_cmd": "./.agent-factory/hooks/launch.sh",
+    "list_cmd": "./.agent-factory/hooks/list.sh",
+    "attach_cmd": "./.agent-factory/hooks/attach.sh",
+    "delete_cmd": "./.agent-factory/hooks/delete.sh"
   }
 }
 ```
+
+### Command path resolution
+
+Each command value is the path of one executable — it is run directly, not through a shell. Where that path may point:
+
+- **Relative paths resolve against the repository root** — the root of the repository whose `.agent-factory/config.json` was loaded. `./infra/launch.sh`, `infra/launch.sh`, and `../shared/launch.sh` all work no matter what the current working directory of `af` or its daemon is, so hook scripts can be checked into the repo without machine-specific absolute paths. For sessions created from a linked worktree, the base is still the **main** repository root (where the config file lives), never the worktree's own path.
+- **Absolute paths** are used as-is.
+- **Bare names without any path separator** (`coder-launch`, `bash`) are looked up on `$PATH`, exactly like `exec`. A separator is what opts a value into repo-root resolution — so a script at the repo root must be written `./launch.sh`, not `launch.sh`.
+
+The same rules apply to `remote_hooks` values still read from the deprecated legacy location.
 
 `remote_hooks` is an in-repo-only setting — it describes the repository, so it is not accepted in the global `~/.agent-factory/config.json`. The previous location, `~/.agent-factory/repos/<repoID>/config.json`, is **deprecated**: it keeps working for one more release as a fallback (with a warning in the log pointing here), and is ignored whenever the in-repo file sets `remote_hooks`. See the README's [Configuration](../README.md#configuration) section for the full precedence rules.
 

--- a/session/backend_e2e_test.go
+++ b/session/backend_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -409,6 +410,193 @@ func readStateFile(t *testing.T, _ string) []map[string]interface{} {
 	var sessions []map[string]interface{}
 	require.NoError(t, json.Unmarshal(raw, &sessions))
 	return sessions
+}
+
+// setupE2ERelativeHooksRepo creates a real git repo whose in-repo config
+// declares remote_hooks as repo-relative paths (#834), with the hook scripts
+// checked into the repo under .agent-factory/hooks/. The scripts track
+// sessions in a plain-text state file (one name per line) so the test needs
+// no python3. Returns the repo dir and the state file path.
+func setupE2ERelativeHooksRepo(t *testing.T) (string, string) {
+	t.Helper()
+
+	afHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "--local", "user.email", "test@rel.com")
+	runGit(t, repoDir, "config", "--local", "user.name", "Rel Test")
+
+	stateFile := filepath.Join(t.TempDir(), "sessions.txt")
+	require.NoError(t, os.WriteFile(stateFile, nil, 0644))
+
+	hooksDir := filepath.Join(repoDir, config.InRepoConfigDirName, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0755))
+
+	writeE2EScript(t, hooksDir, "launch.sh", `
+STATE_FILE="`+stateFile+`"
+NAME=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name) NAME="$2"; shift 2;;
+    *) shift;;
+  esac
+done
+if [ -z "$NAME" ]; then echo "error: --name required" >&2; exit 1; fi
+echo "$NAME" >> "$STATE_FILE"
+echo "{\"name\": \"$NAME\", \"status\": \"running\"}"
+`)
+
+	writeE2EScript(t, hooksDir, "list.sh", `
+STATE_FILE="`+stateFile+`"
+OUT="["
+SEP=""
+while IFS= read -r n; do
+  [ -z "$n" ] && continue
+  OUT="$OUT$SEP{\"name\": \"$n\", \"status\": \"running\"}"
+  SEP=","
+done < "$STATE_FILE"
+echo "$OUT]"
+`)
+
+	writeE2EScript(t, hooksDir, "attach.sh", `
+NAME="$1"
+echo "=== Remote Session: $NAME ==="
+sleep 0.2
+`)
+
+	writeE2EScript(t, hooksDir, "delete.sh", `
+STATE_FILE="`+stateFile+`"
+NAME=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name) NAME="$2"; shift 2;;
+    *) shift;;
+  esac
+done
+if [ -z "$NAME" ]; then echo "error: --name required" >&2; exit 1; fi
+grep -v -x -F "$NAME" "$STATE_FILE" > "$STATE_FILE.tmp" || true
+mv "$STATE_FILE.tmp" "$STATE_FILE"
+echo "{\"name\": \"$NAME\", \"deleted\": true}"
+`)
+
+	// The whole point: the config carries repo-relative commands.
+	require.NoError(t, os.WriteFile(config.InRepoConfigPath(repoDir), []byte(`{
+  "remote_hooks": {
+    "launch_cmd": "./.agent-factory/hooks/launch.sh",
+    "list_cmd": "./.agent-factory/hooks/list.sh",
+    "attach_cmd": "./.agent-factory/hooks/attach.sh",
+    "delete_cmd": "./.agent-factory/hooks/delete.sh"
+  }
+}`), 0644))
+
+	runGit(t, repoDir, "add", "-A")
+	runGit(t, repoDir, "commit", "-m", "init with relative remote_hooks")
+
+	return repoDir, stateFile
+}
+
+// readLineStateFile reads the one-name-per-line session state file kept by
+// the relative-hooks scripts.
+func readLineStateFile(t *testing.T, stateFile string) []string {
+	t.Helper()
+	raw, err := os.ReadFile(stateFile)
+	require.NoError(t, err)
+	var names []string
+	for _, line := range strings.Split(string(raw), "\n") {
+		if line != "" {
+			names = append(names, line)
+		}
+	}
+	return names
+}
+
+// TestE2ERemoteHooksRelativePaths is the acceptance test for #834: an in-repo
+// remote_hooks config written with repo-relative paths must work even though
+// the process cwd is not the repo root (the daemon's cwd is unrelated to the
+// repo). Before the fix, exec resolved "./..." against the cwd and every hook
+// failed with "no such file or directory".
+func TestE2ERemoteHooksRelativePaths(t *testing.T) {
+	repoDir, stateFile := setupE2ERelativeHooksRepo(t)
+
+	repo, err := config.RepoFromPath(repoDir)
+	require.NoError(t, err)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NotEqual(t, repo.Root, cwd, "test must run with cwd outside the repo for the relative paths to be meaningful")
+
+	// Backend resolution rewrites the commands to absolute paths under the
+	// repo root before they reach any exec site.
+	hook, err := loadHookBackendForPath(repoDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(repo.Root, ".agent-factory/hooks/launch.sh"), hook.Hooks.LaunchCmd)
+	assert.Equal(t, filepath.Join(repo.Root, ".agent-factory/hooks/list.sh"), hook.Hooks.ListCmd)
+	assert.Equal(t, filepath.Join(repo.Root, ".agent-factory/hooks/attach.sh"), hook.Hooks.AttachCmd)
+	assert.Equal(t, filepath.Join(repo.Root, ".agent-factory/hooks/delete.sh"), hook.Hooks.DeleteCmd)
+
+	// Full lifecycle: launch_cmd, list_cmd (liveness), attach_cmd (preview),
+	// and delete_cmd all execute from a cwd outside the repo.
+	instance, err := NewInstance(InstanceOptions{
+		Title:       "rel-hooks",
+		Path:        repoDir,
+		Program:     "claude",
+		ForceRemote: true,
+	})
+	require.NoError(t, err)
+	require.True(t, instance.IsRemote())
+
+	require.NoError(t, instance.Start(true))
+	assert.Equal(t, []string{slugify("rel-hooks")}, readLineStateFile(t, stateFile), "launch_cmd must have run")
+	assert.True(t, instance.TmuxAlive(), "list_cmd must report the session as running")
+
+	// Startup import goes through the same resolved config.
+	imported, err := ListRemoteHookInstanceData(repo.Root, hook.Hooks, time.Now())
+	require.NoError(t, err)
+	require.Len(t, imported, 1)
+	assert.Equal(t, slugify("rel-hooks"), imported[0].Branch)
+
+	require.NoError(t, instance.Kill())
+	assert.Empty(t, readLineStateFile(t, stateFile), "delete_cmd must have run")
+}
+
+// TestE2ERemoteHooksRelativePathsLinkedWorktree pins the linked-worktree rule
+// from #834: relative hook paths resolve against the main repository root —
+// the root whose .agent-factory/config.json was loaded — never against the
+// linked worktree's own path.
+func TestE2ERemoteHooksRelativePathsLinkedWorktree(t *testing.T) {
+	repoDir, stateFile := setupE2ERelativeHooksRepo(t)
+
+	worktreeDir := filepath.Join(t.TempDir(), "linked-wt")
+	runGit(t, repoDir, "worktree", "add", worktreeDir, "-b", "wt-branch")
+
+	repo, err := config.RepoFromPath(worktreeDir)
+	require.NoError(t, err)
+	mainRepo, err := config.RepoFromPath(repoDir)
+	require.NoError(t, err)
+	require.Equal(t, mainRepo.Root, repo.Root, "linked worktree must resolve to the main repo root")
+
+	hook, err := loadHookBackendForPath(worktreeDir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(mainRepo.Root, ".agent-factory/hooks/launch.sh"), hook.Hooks.LaunchCmd,
+		"hooks must resolve against the main repo root, not the worktree")
+	assert.NotContains(t, hook.Hooks.LaunchCmd, worktreeDir)
+
+	// And they execute: launch + delete through an instance rooted at the
+	// linked worktree.
+	instance, err := NewInstance(InstanceOptions{
+		Title:       "wt-session",
+		Path:        worktreeDir,
+		Program:     "claude",
+		ForceRemote: true,
+	})
+	require.NoError(t, err)
+	require.True(t, instance.IsRemote())
+
+	require.NoError(t, instance.Start(true))
+	assert.Equal(t, []string{slugify("wt-session")}, readLineStateFile(t, stateFile))
+	require.NoError(t, instance.Kill())
+	assert.Empty(t, readLineStateFile(t, stateFile))
 }
 
 // TestE2EBackendResolutionWithInRepoConfig verifies that backendForPath reads


### PR DESCRIPTION
Fixes #834

## Problem

The README's in-repo config example shows relative `remote_hooks` commands like `./infra/launch.sh`, but every hook exec site runs `exec.Command(hooks.LaunchCmd, ...)` without setting `cmd.Dir` or normalizing the path. exec resolves `./...` against the process cwd — and the daemon's cwd (e.g. `/home/siyer`) has nothing to do with the repo — so checked-in relative hook paths fail with "no such file or directory". Sachin hit exactly this trying to switch the `detail` repo to repo-relative coder hooks.

## Design

**Resolve at config-resolution time, not at exec sites.** `ResolveConfig` is already the mandated chokepoint for per-repo config (its doc comment requires all consumers to go through it, and an audit confirms no non-test code reads `LoadRepoConfig`/`LoadInRepoConfig` directly). The rewrite happens there once, so all five exec surfaces — launch/list/attach/delete (`HookBackend`), startup import (`ListRemoteHookInstanceData` via `daemon/control.go`), restore liveness (#645/#753), and preview — receive resolved values with no per-site changes.

Resolution rule for each command value (`config.resolveHookCommandPath`), mirroring `exec.Command`'s own PATH-vs-path semantics:

| Value | Behavior |
|---|---|
| Absolute (`/opt/launch.sh`) | unchanged |
| Contains a separator, not absolute (`./infra/launch.sh`, `infra/launch.sh`, `../shared/launch.sh`) | `filepath.Join(repoRoot, value)` (Join cleans) |
| Bare name, no separator (`bash`, `coder-launch`) | unchanged — keeps `$PATH` lookup |
| Empty | unchanged — so `RemoteHooks.Validate` errors keep reporting what the user wrote |

**Base directory:** `repoRoot` as passed to `ResolveConfig`, which is the resolved **main** repository root (`config.RepoFromPath`). That is the linked-worktree answer the issue asks for: hooks resolve against the repository whose `.agent-factory/config.json` was loaded, never against a worktree path.

**Legacy location** (`~/.agent-factory/repos/<id>/config.json`): gets the **same** resolution against the same repo root. Rationale: zero surprise — both sources behave identically, and a user migrating values between locations sees no behavior change. (The alternative — requiring absolute paths in the legacy file — would make the deprecation migration a behavior change.)

`resolveCommandPaths` operates on a copy (value receiver), so loaded config structs are never mutated and rewritten values can never be written back to disk (nothing saves a `ResolvedConfig`, but the copy makes it structurally impossible).

**Validation:** `Validate()` runs on resolved values at backend resolution, but it only checks for empty strings and resolution maps empty→empty, so its error messages always show the user's own value.

## Adjacent call-site audit (per CLAUDE.md)

Every `exec` of a hook command receives `b.Hooks` from a `HookBackend` constructed in `session/backend_resolve.go` (both constructors call `ResolveConfig`), or the `hooks` argument of `ListRemoteHookInstanceData`, whose only production caller (`daemon/control.go:975`) passes `repoCfg.RemoteHooks` from `ResolveConfig`. `app/sync.go` only gates on `ListCmd != ""` (also from `ResolveConfig`) and goes through the daemon RPC. No site re-reads raw config.

## Tests

- `TestResolveHookCommandPath` / `TestRemoteHooksResolveCommandPaths` — the rule table + copy semantics.
- `TestResolveConfigResolvesHookPaths` — in-repo and legacy sources through `ResolveConfig`; absolute and bare-name pass-through; fresh legacy load still shows the user's raw values.
- `TestE2ERemoteHooksRelativePaths` (acceptance criterion) — real git repo, hook scripts checked in under `.agent-factory/hooks/`, in-repo config with `./...` paths, **process cwd asserted ≠ repo root**; full lifecycle: launch → list liveness → startup import → delete.
- `TestE2ERemoteHooksRelativePathsLinkedWorktree` — `git worktree add`, backend resolved from the worktree path; commands assert-equal absolute paths under the **main** root, plus a launch/delete lifecycle from the worktree.

## Docs

- `docs/remote-hooks.md` — new "Command path resolution" section (relative → repo root, linked-worktree rule, bare-name `$PATH` rule, applies to legacy too); example switched to checked-in relative paths.
- README per-repo configuration section — base-directory rule + link to the docs section.

## Verification

- `gofmt -l .` clean, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` all clean.
- `go test ./...` green except the documented dev-box flake `integration/TestConcurrentCLIClientsUseDaemonCoordinator` (real-daemon contention; passes in isolation on this branch).
- `go test -race ./config ./session` and bounded `GOFLAGS=-p=1 go test -race -parallel 2 ./ui/... ./app/...` green.

A live relative-path check against the detail repo coder hooks + release cut to follow after merge per the issue.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)