### PR TITLE
fix(config,test): find and fence the AGENT_FACTORY_HOME sandbox escape; harden default materialization (#837)

### DIFF
--- a/api/main_test.go
+++ b/api/main_test.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+func TestMain(m *testing.M) {
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
+	code := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
+}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui"
@@ -23,8 +24,15 @@ func TestMain(m *testing.M) {
 	log.Initialize(false)
 	defer log.Close()
 
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
+
 	// Run all tests
 	exitCode := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exitCode = 1
+	}
 
 	// Exit with the same code as the tests
 	os.Exit(exitCode)

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	aflog "github.com/sachiniyer/agent-factory/log"
 )
 
@@ -34,7 +36,14 @@ func TestMain(m *testing.M) {
 	// autoUpdate() calls log.ErrorLog.Printf, which panics if logging has not
 	// been initialized. Initialize once for the whole package test binary.
 	aflog.Initialize(false)
-	os.Exit(m.Run())
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
+	code := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
 }
 
 // withTestHome points config.GetConfigDir at a temp dir for the duration of

--- a/config/config.go
+++ b/config/config.go
@@ -312,17 +312,100 @@ func LoadConfig() (*Config, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Create and save default config if file doesn't exist
-			defaultCfg := DefaultConfig()
-			if saveErr := saveConfig(defaultCfg); saveErr != nil {
-				log.WarningLog.Printf("failed to save default config: %v", saveErr)
-			}
-			return defaultCfg, nil
+			return materializeDefaultConfig(configDir, configPath, prettyConfigPath)
 		}
 
 		return nil, fmt.Errorf("failed to read config file %s: %w", prettyConfigPath, err)
 	}
 
+	return parseConfig(data, prettyConfigPath)
+}
+
+// materializeRaceHookForTest, when non-nil, runs between LoadConfig observing
+// a missing config.json and the exclusive create below. Tests use it to
+// recreate the file in that window and pin the lost-race behavior.
+var materializeRaceHookForTest func()
+
+// materializeDefaultConfig handles the missing-config.json branch of
+// LoadConfig. A missing file is only expected on first run; when the config
+// dir visibly already carries state, the user's settings file was deleted out
+// from under us, and regenerating defaults silently would disguise the loss
+// as normal operation (#837) — so that case logs at ERROR level before
+// materializing (the app still needs a config to run). The write itself is
+// create-exclusive: if another process recreates config.json between our read
+// and our create, that file wins and is returned instead of being clobbered.
+func materializeDefaultConfig(configDir, configPath, prettyConfigPath string) (*Config, error) {
+	if configDirInitialized(configDir) {
+		log.ErrorLog.Printf("config.json missing from an initialized config dir (%s) — materializing defaults; previous settings are lost", prettyHomePath(configDir))
+	}
+	if materializeRaceHookForTest != nil {
+		materializeRaceHookForTest()
+	}
+
+	defaultCfg := DefaultConfig()
+	created, saveErr := writeConfigIfMissing(configPath, defaultCfg)
+	if saveErr != nil {
+		log.WarningLog.Printf("failed to save default config: %v", saveErr)
+		return defaultCfg, nil
+	}
+	if !created {
+		// Lost the create race: a concurrent process wrote config.json after
+		// our read. Treat its file as authoritative.
+		if data, err := os.ReadFile(configPath); err == nil && len(data) > 0 {
+			return parseConfig(data, prettyConfigPath)
+		}
+		// The concurrent file vanished or is empty; fall back to in-memory
+		// defaults without another write attempt.
+	}
+	return defaultCfg, nil
+}
+
+// configDirInitialized reports whether configDir already carries application
+// state — an instances/ or repos/ subdirectory, or a daemon.pid — meaning a
+// missing config.json there is a settings loss, not a first run.
+func configDirInitialized(configDir string) bool {
+	for _, marker := range []string{"instances", "repos"} {
+		if fi, err := os.Stat(filepath.Join(configDir, marker)); err == nil && fi.IsDir() {
+			return true
+		}
+	}
+	_, err := os.Stat(filepath.Join(configDir, "daemon.pid"))
+	return err == nil
+}
+
+// writeConfigIfMissing persists config to configPath with O_CREATE|O_EXCL
+// semantics. Returns created=false (and no error) when the file already
+// exists, so a concurrently recreated config is never overwritten.
+func writeConfigIfMissing(configPath string, config *Config) (bool, error) {
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		return false, fmt.Errorf("failed to create config directory: %w", err)
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	f, err := os.OpenFile(configPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		if os.IsExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to create config file: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return true, fmt.Errorf("failed to write config file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return true, fmt.Errorf("failed to close config file: %w", err)
+	}
+	return true, nil
+}
+
+// parseConfig validates and unmarshals raw config.json bytes on top of the
+// defaults. Split from LoadConfig so the materialize lost-race path can run
+// the identical validation on a concurrently written file.
+func parseConfig(data []byte, prettyConfigPath string) (*Config, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("config file %s is empty; delete it to regenerate defaults, or add valid JSON", prettyConfigPath)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 
@@ -21,7 +22,13 @@ func TestMain(m *testing.M) {
 	log.Initialize(false)
 	defer log.Close()
 
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
 	exitCode := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exitCode = 1
+	}
 	os.Exit(exitCode)
 }
 
@@ -408,11 +415,8 @@ func TestGetConfigDir(t *testing.T) {
 	})
 
 	t.Run("uses AGENT_FACTORY_HOME when set", func(t *testing.T) {
-		originalVal := os.Getenv("AGENT_FACTORY_HOME")
-		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
-
 		customDir := t.TempDir()
-		os.Setenv("AGENT_FACTORY_HOME", customDir)
+		t.Setenv("AGENT_FACTORY_HOME", customDir)
 
 		configDir, err := GetConfigDir()
 		assert.NoError(t, err)
@@ -420,10 +424,7 @@ func TestGetConfigDir(t *testing.T) {
 	})
 
 	t.Run("expands tilde in AGENT_FACTORY_HOME", func(t *testing.T) {
-		originalVal := os.Getenv("AGENT_FACTORY_HOME")
-		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
-
-		os.Setenv("AGENT_FACTORY_HOME", "~/.my-custom-config")
+		t.Setenv("AGENT_FACTORY_HOME", "~/.my-custom-config")
 
 		homeDir, err := os.UserHomeDir()
 		require.NoError(t, err)
@@ -434,10 +435,7 @@ func TestGetConfigDir(t *testing.T) {
 	})
 
 	t.Run("falls back to default when AGENT_FACTORY_HOME is empty", func(t *testing.T) {
-		originalVal := os.Getenv("AGENT_FACTORY_HOME")
-		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
-
-		os.Setenv("AGENT_FACTORY_HOME", "")
+		t.Setenv("AGENT_FACTORY_HOME", "")
 
 		configDir, err := GetConfigDir()
 		assert.NoError(t, err)
@@ -445,10 +443,7 @@ func TestGetConfigDir(t *testing.T) {
 	})
 
 	t.Run("returns home dir when AGENT_FACTORY_HOME is exactly ~", func(t *testing.T) {
-		originalVal := os.Getenv("AGENT_FACTORY_HOME")
-		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
-
-		os.Setenv("AGENT_FACTORY_HOME", "~")
+		t.Setenv("AGENT_FACTORY_HOME", "~")
 
 		homeDir, err := os.UserHomeDir()
 		require.NoError(t, err)
@@ -459,10 +454,7 @@ func TestGetConfigDir(t *testing.T) {
 	})
 
 	t.Run("expands ~/foo correctly", func(t *testing.T) {
-		originalVal := os.Getenv("AGENT_FACTORY_HOME")
-		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
-
-		os.Setenv("AGENT_FACTORY_HOME", "~/foo")
+		t.Setenv("AGENT_FACTORY_HOME", "~/foo")
 
 		homeDir, err := os.UserHomeDir()
 		require.NoError(t, err)
@@ -473,10 +465,7 @@ func TestGetConfigDir(t *testing.T) {
 	})
 
 	t.Run("returns error for malformed ~.config", func(t *testing.T) {
-		originalVal := os.Getenv("AGENT_FACTORY_HOME")
-		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
-
-		os.Setenv("AGENT_FACTORY_HOME", "~.config")
+		t.Setenv("AGENT_FACTORY_HOME", "~.config")
 
 		configDir, err := GetConfigDir()
 		assert.Error(t, err)
@@ -485,10 +474,7 @@ func TestGetConfigDir(t *testing.T) {
 	})
 
 	t.Run("returns error for malformed ~config", func(t *testing.T) {
-		originalVal := os.Getenv("AGENT_FACTORY_HOME")
-		defer os.Setenv("AGENT_FACTORY_HOME", originalVal)
-
-		os.Setenv("AGENT_FACTORY_HOME", "~config")
+		t.Setenv("AGENT_FACTORY_HOME", "~config")
 
 		configDir, err := GetConfigDir()
 		assert.Error(t, err)

--- a/config/materialize_test.go
+++ b/config/materialize_test.go
@@ -34,7 +34,11 @@ func TestLoadConfig_MaterializeSilentOnFirstRun(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Empty(t, errBuf.String(), "first-run materialization must not log at ERROR level")
+	// Don't assert an empty buffer: DefaultConfig() logs an unrelated ERROR
+	// ("failed to get claude command") on machines without claude on PATH
+	// (e.g. CI). First-run only has to skip the settings-loss warning.
+	assert.NotContains(t, errBuf.String(), "config.json missing from an initialized config dir",
+		"first-run materialization must not log the settings-loss error")
 	assert.FileExists(t, filepath.Join(home, ConfigFileName), "first run must persist the defaults")
 }
 

--- a/config/materialize_test.go
+++ b/config/materialize_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	aflog "github.com/sachiniyer/agent-factory/log"
+)
+
+// Regression tests for #837: the global config.json was silently replaced by
+// materialized defaults. The materialize-on-missing branch must (a) stay
+// silent on a genuine first run, (b) log loudly when the config dir visibly
+// already carries state, and (c) never clobber a concurrently recreated
+// config.json.
+
+// fastShell keeps DefaultConfig's claude-alias probe off the interactive
+// bash/zsh path so these tests don't pay seconds per LoadConfig call.
+func fastShell(t *testing.T) {
+	t.Helper()
+	t.Setenv("SHELL", "/bin/sh")
+}
+
+func TestLoadConfig_MaterializeSilentOnFirstRun(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	fastShell(t)
+	errBuf := captureLog(t, &aflog.ErrorLog)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Empty(t, errBuf.String(), "first-run materialization must not log at ERROR level")
+	assert.FileExists(t, filepath.Join(home, ConfigFileName), "first run must persist the defaults")
+}
+
+func TestLoadConfig_MaterializeLogsLoudlyOnInitializedDir(t *testing.T) {
+	markers := []struct {
+		name string
+		seed func(t *testing.T, home string)
+	}{
+		{"instances dir", func(t *testing.T, home string) {
+			require.NoError(t, os.MkdirAll(filepath.Join(home, "instances"), 0755))
+		}},
+		{"repos dir", func(t *testing.T, home string) {
+			require.NoError(t, os.MkdirAll(filepath.Join(home, "repos"), 0755))
+		}},
+		{"daemon.pid", func(t *testing.T, home string) {
+			require.NoError(t, os.WriteFile(filepath.Join(home, "daemon.pid"), []byte("12345"), 0600))
+		}},
+	}
+	for _, m := range markers {
+		t.Run(m.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("AGENT_FACTORY_HOME", home)
+			fastShell(t)
+			require.NoError(t, os.MkdirAll(home, 0755))
+			m.seed(t, home)
+			errBuf := captureLog(t, &aflog.ErrorLog)
+
+			cfg, err := LoadConfig()
+			require.NoError(t, err)
+			require.NotNil(t, cfg, "the app still needs a config — materialization proceeds")
+
+			assert.Contains(t, errBuf.String(), "materializing defaults",
+				"a missing config.json in an initialized dir must be a loud, diagnosable event")
+			assert.Contains(t, errBuf.String(), "previous settings are lost")
+			assert.FileExists(t, filepath.Join(home, ConfigFileName))
+		})
+	}
+}
+
+func TestLoadConfig_MaterializeLosesRaceToConcurrentWrite(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	fastShell(t)
+
+	configPath := filepath.Join(home, ConfigFileName)
+	concurrent := `{"default_program": "codex", "daemon_poll_interval": 2500}`
+	materializeRaceHookForTest = func() {
+		if err := os.WriteFile(configPath, []byte(concurrent), 0644); err != nil {
+			t.Errorf("concurrent write: %v", err)
+		}
+	}
+	t.Cleanup(func() { materializeRaceHookForTest = nil })
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, "codex", cfg.DefaultProgram, "the concurrently written config must win")
+	assert.Equal(t, 2500, cfg.DaemonPollInterval)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.JSONEq(t, concurrent, string(data), "the concurrent file must not be clobbered by defaults")
+}
+
+func TestWriteConfigIfMissing_RefusesExistingFile(t *testing.T) {
+	home := t.TempDir()
+	configPath := filepath.Join(home, ConfigFileName)
+	original := []byte(`{"detach_keys": "ctrl-]"}`)
+	require.NoError(t, os.WriteFile(configPath, original, 0644))
+
+	created, err := writeConfigIfMissing(configPath, &Config{DefaultProgram: "claude"})
+	require.NoError(t, err)
+	assert.False(t, created, "an existing config.json must never be replaced")
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, original, data)
+}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -14,13 +14,20 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
 func TestMain(m *testing.M) {
 	log.Initialize(false)
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
 	code := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
 	os.Exit(code)
 }
 

--- a/integration/cli_daemon_test.go
+++ b/integration/cli_daemon_test.go
@@ -290,9 +290,10 @@ func newHarness(t *testing.T) *harness {
 	requireTool(t, "tmux")
 
 	home := t.TempDir()
-	if err := os.Setenv("AGENT_FACTORY_HOME", home); err != nil {
-		t.Fatalf("setenv AGENT_FACTORY_HOME: %v", err)
-	}
+	// t.Setenv (not os.Setenv) so the variable is restored when the test
+	// ends; an unrestored value leaks the previous test's (deleted) tempdir
+	// into every later test in the package (#837 audit).
+	t.Setenv("AGENT_FACTORY_HOME", home)
 	// The enum-only program model (#658) routes session.Program through
 	// session.injectSystemPrompt, which appends agent-specific flags
 	// (e.g. --plugin-dir for claude) to the resolved command. Plain `cat`

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -1,0 +1,23 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+// TestMain guards the package with the #837 config tripwire. The tests here
+// build and exec real af binaries that spawn daemons, so they are the most
+// likely place for a sandbox escape to reach the developer's real
+// ~/.agent-factory/config.json.
+func TestMain(m *testing.M) {
+	verifyRealConfig := testguard.ConfigTripwire()
+	code := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
+}

--- a/internal/testguard/testguard.go
+++ b/internal/testguard/testguard.go
@@ -1,0 +1,102 @@
+// Package testguard fences test binaries off from the developer's real
+// agent-factory config. Test packages that can spawn af processes or write
+// config files call ConfigTripwire from TestMain; if any test (or a child
+// process it spawned) escapes its AGENT_FACTORY_HOME sandbox and touches the
+// real config.json, the package run fails loudly instead of the user
+// discovering days later that their settings were silently replaced (#837).
+//
+// This package deliberately has no dependency on the config package — config
+// imports session/tmux, and the tripwire must be usable from that package's
+// tests without an import cycle — so the config-dir resolution below mirrors
+// config.GetConfigDir.
+package testguard
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ambientConfigPath resolves the config.json the test process would touch
+// with its ambient (pre-test) environment: $AGENT_FACTORY_HOME when set,
+// otherwise ~/.agent-factory. Returns "" when the path cannot be resolved
+// (no HOME — e.g. some CI sandboxes), in which case the tripwire is a no-op.
+func ambientConfigPath() string {
+	dir := os.Getenv("AGENT_FACTORY_HOME")
+	if strings.HasPrefix(dir, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		switch {
+		case dir == "~":
+			dir = home
+		case strings.HasPrefix(dir, "~/"):
+			dir = filepath.Join(home, dir[2:])
+		default:
+			// Malformed tilde form; GetConfigDir would error out, so there
+			// is no real config at risk.
+			return ""
+		}
+	}
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".agent-factory")
+	}
+	return filepath.Join(dir, "config.json")
+}
+
+func hashFile(path string) ([]byte, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	sum := sha256.Sum256(data)
+	return sum[:], true, nil
+}
+
+// ConfigTripwire snapshots the real config.json and returns a verify func
+// for TestMain to call after m.Run(). Verify returns a non-nil error when:
+//   - the file existed at snapshot time and was modified or deleted, or
+//   - the file did not exist and a test materialized one.
+//
+// On boxes without a resolvable home (or with AF_DISABLE_CONFIG_TRIPWIRE=1)
+// both snapshot and verify are no-ops, so CI runs are unaffected.
+func ConfigTripwire() func() error {
+	if os.Getenv("AF_DISABLE_CONFIG_TRIPWIRE") == "1" {
+		return func() error { return nil }
+	}
+	path := ambientConfigPath()
+	if path == "" {
+		return func() error { return nil }
+	}
+	before, existed, err := hashFile(path)
+	if err != nil {
+		// Unreadable real config (permissions?) — nothing we can guard.
+		return func() error { return nil }
+	}
+	return func() error {
+		after, exists, err := hashFile(path)
+		if err != nil {
+			return fmt.Errorf("config tripwire: cannot re-read %s after the test run: %w", path, err)
+		}
+		switch {
+		case existed && !exists:
+			return fmt.Errorf("config tripwire: %s was DELETED during this package's test run — a test escaped its AGENT_FACTORY_HOME sandbox (#837)", path)
+		case existed && !bytes.Equal(before, after):
+			return fmt.Errorf("config tripwire: %s was MODIFIED during this package's test run — a test escaped its AGENT_FACTORY_HOME sandbox (#837)", path)
+		case !existed && exists:
+			return fmt.Errorf("config tripwire: %s was CREATED during this package's test run — a test materialized config into the real config dir (#837)", path)
+		}
+		return nil
+	}
+}

--- a/internal/testguard/testguard_test.go
+++ b/internal/testguard/testguard_test.go
@@ -1,0 +1,132 @@
+package testguard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sandbox points the tripwire's ambient resolution at a temp dir and returns
+// the config.json path inside it.
+func sandbox(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", dir)
+	return filepath.Join(dir, "config.json")
+}
+
+func TestConfigTripwire_FiresOnModification(t *testing.T) {
+	path := sandbox(t)
+	if err := os.WriteFile(path, []byte(`{"detach_keys":"ctrl-]"}`), 0644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	verify := ConfigTripwire()
+	if err := os.WriteFile(path, []byte(`{"detach_keys":"ctrl-w"}`), 0644); err != nil {
+		t.Fatalf("mutate config: %v", err)
+	}
+
+	err := verify()
+	if err == nil {
+		t.Fatalf("tripwire did not fire after the config was modified")
+	}
+	if !strings.Contains(err.Error(), "MODIFIED") {
+		t.Fatalf("tripwire error %q should name the modification", err)
+	}
+}
+
+func TestConfigTripwire_FiresOnDeletion(t *testing.T) {
+	path := sandbox(t)
+	if err := os.WriteFile(path, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	verify := ConfigTripwire()
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove config: %v", err)
+	}
+
+	err := verify()
+	if err == nil {
+		t.Fatalf("tripwire did not fire after the config was deleted")
+	}
+	if !strings.Contains(err.Error(), "DELETED") {
+		t.Fatalf("tripwire error %q should name the deletion", err)
+	}
+}
+
+func TestConfigTripwire_FiresOnCreationFromAbsent(t *testing.T) {
+	path := sandbox(t)
+
+	verify := ConfigTripwire()
+	if err := os.WriteFile(path, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("create config: %v", err)
+	}
+
+	err := verify()
+	if err == nil {
+		t.Fatalf("tripwire did not fire after a config was materialized into an empty real home")
+	}
+	if !strings.Contains(err.Error(), "CREATED") {
+		t.Fatalf("tripwire error %q should name the creation", err)
+	}
+}
+
+func TestConfigTripwire_SilentWhenUntouched(t *testing.T) {
+	path := sandbox(t)
+	if err := os.WriteFile(path, []byte(`{"auto_yes":true}`), 0644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	verify := ConfigTripwire()
+	if err := verify(); err != nil {
+		t.Fatalf("tripwire fired on an untouched config: %v", err)
+	}
+}
+
+func TestConfigTripwire_SilentWhenAbsentStaysAbsent(t *testing.T) {
+	sandbox(t)
+	verify := ConfigTripwire()
+	if err := verify(); err != nil {
+		t.Fatalf("tripwire fired on a home with no config at all: %v", err)
+	}
+}
+
+func TestConfigTripwire_DisabledByEnv(t *testing.T) {
+	path := sandbox(t)
+	if err := os.WriteFile(path, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	t.Setenv("AF_DISABLE_CONFIG_TRIPWIRE", "1")
+
+	verify := ConfigTripwire()
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove config: %v", err)
+	}
+	if err := verify(); err != nil {
+		t.Fatalf("disabled tripwire must not fire, got: %v", err)
+	}
+}
+
+func TestConfigTripwire_ExpandsTildeHome(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("AGENT_FACTORY_HOME", "~/af-home")
+	require := filepath.Join(fakeHome, "af-home", "config.json")
+
+	if got := ambientConfigPath(); got != require {
+		t.Fatalf("ambientConfigPath() = %q, want %q", got, require)
+	}
+}
+
+func TestConfigTripwire_FallsBackToDotAgentFactory(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("AGENT_FACTORY_HOME", "")
+
+	want := filepath.Join(fakeHome, ".agent-factory", "config.json")
+	if got := ambientConfigPath(); got != want {
+		t.Fatalf("ambientConfigPath() = %q, want %q", got, want)
+	}
+}

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sachiniyer/agent-factory/cmd"
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -30,7 +31,14 @@ import (
 func TestMain(m *testing.M) {
 	log.Initialize(false)
 	defer log.Close()
-	os.Exit(m.Run())
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
+	code := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
 }
 
 // --- Backend interface compliance ---

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"fmt"
 	stdlog "log"
 	"os"
 	"os/exec"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,12 +21,30 @@ import (
 func TestMain(m *testing.M) {
 	log.Initialize(false)
 	defer log.Close()
-	os.Exit(m.Run())
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
+	code := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
+}
+
+// sandboxHome points HOME and AGENT_FACTORY_HOME at a fresh temp dir.
+// Overriding HOME alone is not enough: config.GetConfigDir prefers
+// AGENT_FACTORY_HOME, so in any environment that exports it, the
+// config.SaveConfig calls below would write into the user's real config
+// dir (#837).
+func sandboxHome(t *testing.T) {
+	t.Helper()
+	tempHome := t.TempDir()
+	t.Setenv("HOME", tempHome)
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(tempHome, ".agent-factory"))
 }
 
 func TestGetWorktreeDirectoryForRepo(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 
@@ -39,8 +59,7 @@ func TestGetWorktreeDirectoryForRepo_RequiresRepoPath(t *testing.T) {
 }
 
 func TestNewGitWorktree_CleanName(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 	repoName := filepath.Base(repoRoot)
@@ -63,8 +82,7 @@ func TestNewGitWorktree_CleanName(t *testing.T) {
 }
 
 func TestNewGitWorktree_CollisionSuffix(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 	repoName := filepath.Base(repoRoot)
@@ -101,8 +119,7 @@ func TestNewGitWorktree_CollisionSuffix(t *testing.T) {
 }
 
 func TestNewGitWorktree_StatErrorReturns(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 	cfg := config.DefaultConfig()
@@ -125,8 +142,7 @@ func TestNewGitWorktree_StatErrorReturns(t *testing.T) {
 }
 
 func TestSetupFromExistingBranch_SetsBaseCommitSHA(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 
@@ -184,8 +200,7 @@ func TestSetupFromExistingBranch_SetsBaseCommitSHA(t *testing.T) {
 // and covers older git where `remove` errors on a missing worktree and leaves
 // the stale registration that blocks `worktree add`.
 func TestSetupFromExistingBranch_RecreatesAfterExternalDeletion(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 
@@ -235,8 +250,7 @@ func TestSetupFromExistingBranch_RecreatesAfterExternalDeletion(t *testing.T) {
 // Cleanup() always ran `git branch -D <branch>`, destroying user work on any
 // branch whose name happened to match the session's derived branch name.
 func TestCleanup_PreservesPreExistingBranch(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 
@@ -280,8 +294,7 @@ func TestCleanup_PreservesPreExistingBranch(t *testing.T) {
 // branch itself, Cleanup() still deletes it (preserving existing behavior for
 // branches that the session owns).
 func TestCleanup_DeletesBranchWeCreated(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 
@@ -323,8 +336,7 @@ func TestCleanup_DeletesBranchWeCreated(t *testing.T) {
 // CleanupWorktreesForRepo already prunes before branch deletion (#330);
 // this verifies GitWorktree.Cleanup() follows the same order.
 func TestCleanup_PrunesBeforeBranchDelete(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 
@@ -381,8 +393,7 @@ func TestCleanup_PrunesBeforeBranchDelete(t *testing.T) {
 // force the user into `af reset`. CleanupWorktreesForRepo already does this;
 // this verifies GitWorktree.Cleanup() follows the same fallback.
 func TestCleanup_RemovesOrphanedDirectory(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 
@@ -430,8 +441,7 @@ func TestCleanup_RemovesOrphanedDirectory(t *testing.T) {
 // real git: `worktree remove` fails ("is not a working tree") while the
 // registration is already gone and the directory is fully populated on disk.
 func TestCleanup_RemovesDirWhenGitDeregistered(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 
@@ -488,8 +498,7 @@ func TestCleanup_RemovesDirWhenGitDeregistered(t *testing.T) {
 // of that class: a single `-f` refuses to remove it and the registration
 // stays put.
 func TestCleanup_SurfacesErrorWhenGitStillOwnsWorktree(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 
@@ -573,8 +582,7 @@ func TestCleanup_EmptyWorktreePath(t *testing.T) {
 }
 
 func TestFindGitRepoRoot_ResolvesLinkedWorktree(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	// Create a main repo with an initial commit (required for worktree add)
 	repoRoot := createGitRepo(t)
@@ -600,8 +608,7 @@ func TestFindGitRepoRoot_ResolvesLinkedWorktree(t *testing.T) {
 }
 
 func TestGetWorktreeDirectoryForRepo_FromLinkedWorktree(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	// Create a main repo with an initial commit
 	repoRoot := createGitRepo(t)
@@ -672,8 +679,7 @@ func createGitRepo(t *testing.T) string {
 // Without an intervening `git worktree prune`, `git branch -D` reports the
 // branch is "in use" and the orphaned branch is left behind.
 func TestCleanupWorktreesForRepo_PrunesBeforeBranchDelete(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	repoRoot := createGitRepo(t)
 	env := append(os.Environ(),
@@ -729,8 +735,7 @@ func TestCleanupWorktreesForRepo_RejectsEmpty(t *testing.T) {
 // process's current working directory. This is the core of the #265 fix:
 // `af reset` must be able to clean worktrees in repos OTHER than the cwd.
 func TestCleanupWorktreesForRepo_CleansGivenRepo(t *testing.T) {
-	tempHome := t.TempDir()
-	t.Setenv("HOME", tempHome)
+	sandboxHome(t)
 
 	// Build a repo, make an initial commit, and add a linked worktree.
 	repoRoot := createGitRepo(t)

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	aflog "github.com/sachiniyer/agent-factory/log"
 
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,14 @@ import (
 func TestMain(m *testing.M) {
 	aflog.Initialize(false)
 	defer aflog.Close()
-	os.Exit(m.Run())
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
+	code := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
 }
 
 type MockPtyFactory struct {

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 )
@@ -18,7 +20,14 @@ import (
 func TestMain(m *testing.M) {
 	log.Initialize(false)
 	defer log.Close()
-	os.Exit(m.Run())
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
+	code := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
 }
 
 // codexYOLOBanner is the actual codex startup pane from

--- a/ui/main_test.go
+++ b/ui/main_test.go
@@ -1,0 +1,20 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+func TestMain(m *testing.M) {
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
+	code := m.Run()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
+}


### PR DESCRIPTION
Fixes #837

## Part 1 — the hunt

### What the forensics established

- The wiped file was a byte-exact `DefaultConfig()` materialization, and the only writer of that shape anywhere (production **or** tests — confirmed by audit) is `LoadConfig`'s materialize-on-missing branch. Tests that call `config.SaveConfig(config.DefaultConfig())` (the `session/git` worktree tests) always set `BranchPrefix: "test/"` first, which does not match the wiped bytes (`branch_prefix: "siyer/"`, re-derived from the username).
- `saveConfig` is atomic (temp + rename), `WithFileLock` only touches `.lock` files, and **no code in the tree — production or test — removes or renames a path ending in `config.json`**. So the materialize requires a prior out-of-band deletion of the file.
- The shared log (`~/.config/agent-factory/agent-factory.log`, whose path is captured at package init from `os.UserConfigDir` and is therefore shared by every test process — this is why test fixtures appear in it) shows a real daemon child spawned at **14:20:29** (`daemon.go:331`, PID 3894334) whose `LoadConfig` ran in the 14:20:29→14:20:31 gap — exactly bracketing the 14:20:30 wipe mtime. That child is almost certainly the (innocent) materializer.
- `startDaemonChild` passes no `cmd.Env`, so daemon children inherit their parent's environment; every harness that spawns af binaries (`integration/cli_daemon_test.go`, `app/cli_daemon_integration_test.go`, `integration/codex_ready_test.go`) sets `AGENT_FACTORY_HOME` to a tempdir before any spawn.

### Audit table

Every `*_test.go` (91 files) and helper that resolves `GetConfigDir`/`RepoInstancesPath`/`DaemonSocketPath`/pid-file/config paths was classified:

| Area | Verdict |
|---|---|
| `config/*_test.go` | sandboxed via `t.Setenv`, except `TestGetConfigDir` (`os.Setenv` + defer; read-only — **fixed**) |
| `daemon/*_test.go` (incl. #829 warmup, sigterm fallback, taskrun, watcher, spawn-reap) | sandboxed; spawn/restart/scan seams stubbed |
| root pkg (`autoupdate_test.go`, `upgrade_test.go`, `daemoncmd_test.go` — the #816/#813 reap/respawn area) | sandboxed or fully stubbed (`osExecutableFn`, `requestDaemonShutdownFn`, `respawnDaemonFn`, `restartAutostartUnitFn`); binary writes go to tempdirs |
| `app/`, `ui/`, `api/`, `task/`, `session/` | sandboxed (`newTestHome`, `t.Setenv`) |
| `integration/` | sandboxed, but `newHarness` used `os.Setenv` with **no restore** — cross-test contamination toward stale tempdirs (**fixed**; cannot point at the real home) |
| `session/git/worktree_test.go` | **defect**: sandboxed `HOME` only. `GetConfigDir` prefers `AGENT_FACTORY_HOME`, so in any environment that exports it, every `config.SaveConfig` in this file writes into the real config dir (**fixed**) |
| `TestMain`s | only `log.Initialize` — the one package-init path capture (`logFileName`) explains the shared-log fixture sightings and is benign for config.json |

### Verdict — stated plainly, no fabricated culprit

The three defects found are real and are fixed here, but **none of them can explain this wipe**: the dev box does not export `AGENT_FACTORY_HOME` (shell, daemon unit, and all af agent sessions verified unset), the worktree-test escape writes `branch_prefix: "test/"` (not the observed defaults), and the integration leak points at tempdirs, never at the real home. Combined with the fact that nothing in the committed tree deletes `config.json`, the deletion that triggered the 14:20:30 materialize most plausibly came from **outside the committed code** — in-flight test code in the fix-829 session's worktree that never landed, or shell activity in that session's window (e.g. moving the config aside to exercise first-run/daemon-warmup behavior and not restoring it). That cannot be proven from the repo, so this PR's job is to make any recurrence impossible to miss and impossible to clobber — which is part 2.

## Part 2 — hardening

1. **TestMain tripwire** (`internal/testguard.ConfigTripwire`, no deps — usable even from `session/tmux`, which `config` imports). Snapshots the SHA-256 of the ambient-env config.json before `m.Run()` and fails the package run loudly if it was **modified**, **deleted**, or **created-from-absent** afterwards. Wired into every package that can spawn af processes or write configs: root, `config`, `daemon`, `app`, `session`, `session/git`, `session/tmux`, `task`, `ui`, `api`, `integration`. No-op when no home is resolvable (CI) or with `AF_DISABLE_CONFIG_TRIPWIRE=1`.
2. **Loud materialize.** When `config.json` is missing but the config dir visibly is not first-run (`instances/` or `repos/` subdir, or `daemon.pid`), `LoadConfig` logs `config.json missing from an initialized config dir — materializing defaults; previous settings are lost` at ERROR level before materializing. Genuine first runs stay silent.
3. **Clobber-proof materialize.** The defaults are written with `O_CREATE|O_EXCL`; on `EEXIST` the concurrently recreated file is re-read, validated through the same `parseConfig` path, and returned instead of being overwritten.

## Tests

- `internal/testguard`: tripwire fires on modify/delete/create-from-absent, silent when untouched/absent, env kill-switch, tilde/fallback path resolution.
- `config/materialize_test.go`: loud ERROR log for each non-fresh marker (`instances/`, `repos/`, `daemon.pid`); silent first run that still persists defaults; lost-race returns and preserves the concurrent file (via a test-only hook between the ENOENT and the exclusive create); `writeConfigIfMissing` refuses an existing file.
- And the irony holds: the whole suite runs with the tripwire armed on a box where the real config.json exists, and passes.

## Verification

`go build ./...`, `gofmt -l .` (clean), `golangci-lint run --timeout=3m --fast` (clean), `deadcode -test ./...` (clean), `go test ./...` green across all packages including `./integration`; `go test -race` green on `config`, `internal/testguard`, `session/git`, and (memory-bounded) `ui` + `app`. No dev-install performed.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)