### PR TITLE
fix(session/hook): differentiate list_cmd failure from session-absent and show listed names (#841)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -165,15 +165,23 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 		// list_cmd is optional at config-validation time (import/sync treat
 		// an empty list_cmd as "no remote sessions to enumerate", #738), but
 		// restore has no other way to verify liveness. An empty list_cmd here
-		// would defer to exec.Command(""), which isAliveWithTimeout swallows
-		// into a false, surfacing the misleading "no longer exists" message
-		// below as if the session had been deleted remotely. Fail fast with an
-		// actionable message that names the missing field instead (#753).
+		// would surface as an opaque exec failure from isAliveWithTimeout.
+		// Fail fast with an actionable message that names the missing field
+		// instead (#753).
 		if strings.TrimSpace(b.Hooks.ListCmd) == "" {
 			return fmt.Errorf("cannot restore remote session %q: list_cmd is required for restore (currently empty in config; add a list_cmd to remote_hooks so the agent can verify the remote session is still alive)", i.Title)
 		}
-		if !b.isAliveWithTimeout(i, restoreAliveTimeout) {
-			return fmt.Errorf("remote session %q no longer exists in list_cmd output", i.Title)
+		// Distinguish "list_cmd could not be run" from "list_cmd ran and the
+		// session is absent" (#841): the first is a local config/network
+		// problem, the second a remote deletion or rename. For the absent
+		// case, naming what list_cmd DID return makes a hook-script rename
+		// self-diagnosing instead of requiring a manual list_cmd run.
+		alive, listed, aliveErr := b.isAliveWithTimeout(i, restoreAliveTimeout)
+		if aliveErr != nil {
+			return fmt.Errorf("cannot verify remote session %q: %w", i.Title, aliveErr)
+		}
+		if !alive {
+			return fmt.Errorf("remote session %q no longer exists in list_cmd output%s", i.Title, formatListedNames(listed))
 		}
 		if err := b.ensurePTY(i); err != nil {
 			return fmt.Errorf("failed to start preview process: %w", err)
@@ -429,46 +437,74 @@ func (b *HookBackend) SetPreviewSize(_ *Instance, _, _ int) error {
 }
 
 func (b *HookBackend) IsAlive(i *Instance) bool {
-	return b.isAliveWithTimeout(i, runtimeAliveTimeout)
+	alive, _, _ := b.isAliveWithTimeout(i, runtimeAliveTimeout)
+	return alive
 }
 
 // isAliveWithTimeout asks list_cmd whether the remote session backing i is
-// currently running. A non-zero timeout bounds the wait; zero falls through
-// to an unbounded exec, which no production caller should use because
-// IsAlive runs on the TUI event loop and a hanging list_cmd would freeze the
-// UI (#666). Callers must pass either restoreAliveTimeout or
-// runtimeAliveTimeout.
-func (b *HookBackend) isAliveWithTimeout(i *Instance, timeout time.Duration) bool {
-	out, err := runListCmd(b.Hooks.ListCmd, timeout)
+// currently running. The three outcomes are distinct (#841):
+//   - err != nil: list_cmd could not be run or its output was unparseable —
+//     this says nothing about whether the remote session exists, and callers
+//     that surface errors must NOT report it as "no longer exists".
+//   - alive false, err nil: list_cmd ran fine and the session is absent.
+//     listed carries the names list_cmd did report (nil for an empty list) so
+//     callers can make a rename mismatch self-diagnosing.
+//   - alive true: the session is listed with status "running".
+//
+// A non-zero timeout bounds the wait; zero falls through to an unbounded
+// exec, which no production caller should use because IsAlive runs on the
+// TUI event loop and a hanging list_cmd would freeze the UI (#666). Callers
+// must pass either restoreAliveTimeout or runtimeAliveTimeout.
+func (b *HookBackend) isAliveWithTimeout(i *Instance, timeout time.Duration) (alive bool, listed []string, err error) {
+	out, runErr := runListCmd(b.Hooks.ListCmd, timeout)
 	// exec.ErrWaitDelay is non-fatal here (#676). runListCmd sets
 	// cmd.WaitDelay, so CombinedOutput returns ErrWaitDelay when the list_cmd
 	// script itself exited (per docs/remote-hooks.md, with code 0 on success)
 	// but a backgrounded child still holds the stdout/stderr pipes open. In
 	// that case the script's output is already complete on stdout; fall
 	// through to extractJSON + json.Unmarshal, which validate it. A genuinely
-	// broken list_cmd produces no parseable JSON and still returns false.
-	if err != nil && !errors.Is(err, exec.ErrWaitDelay) {
-		return false
+	// broken list_cmd produces no parseable JSON and still errors below.
+	if runErr != nil && !errors.Is(runErr, exec.ErrWaitDelay) {
+		return false, nil, fmt.Errorf("list_cmd failed: %s: %w", strings.TrimSpace(string(out)), runErr)
 	}
 	// Mirror launch_cmd: list_cmd may write progress to stderr and JSON to
 	// stdout, so recover the JSON object from the combined output.
 	jsonStr := extractJSON(string(out))
 	if jsonStr == "" {
-		return false
+		return false, nil, fmt.Errorf("list_cmd returned no JSON in output: %s", strings.TrimSpace(string(out)))
 	}
 	var sessions []map[string]interface{}
 	if err := json.Unmarshal([]byte(jsonStr), &sessions); err != nil {
-		return false
+		return false, nil, fmt.Errorf("list_cmd returned invalid JSON: %s: %w", jsonStr, err)
 	}
 	slug := hookNameForInstance(i)
 	for _, s := range sessions {
 		name, _ := s["name"].(string)
 		status, _ := s["status"].(string)
+		if name != "" {
+			listed = append(listed, name)
+		}
 		if name == slug && status == "running" {
-			return true
+			alive = true
 		}
 	}
-	return false
+	return alive, listed, nil
+}
+
+// formatListedNames renders the names list_cmd reported, for appending to the
+// "no longer exists in list_cmd output" restore error so a hook-script rename
+// is self-diagnosing (#841). An empty list yields "" to preserve the original
+// message for genuinely-empty list_cmd output; longer lists are capped so a
+// busy remote host cannot bloat the error.
+func formatListedNames(listed []string) string {
+	if len(listed) == 0 {
+		return ""
+	}
+	const maxNames = 5
+	if len(listed) > maxNames {
+		return fmt.Sprintf(" (listed: %s, and %d more)", strings.Join(listed[:maxNames], ", "), len(listed)-maxNames)
+	}
+	return fmt.Sprintf(" (listed: %s)", strings.Join(listed, ", "))
 }
 
 // runListCmd executes the user-supplied list_cmd and returns its combined

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -332,6 +332,10 @@ func TestHookBackendStartRestore(t *testing.T) {
 // instance as Ready. Without this guard, deleted/expired remote sessions
 // were restored with a green Ready dot in the sidebar even though attaching
 // was a silent no-op.
+//
+// Since #841 the error must also name what list_cmd DID return, so a
+// hook-script rename (list_cmd reporting the session under a new name) is
+// self-diagnosing instead of requiring a manual list_cmd run.
 func TestHookBackendStartRestoreDeadSession(t *testing.T) {
 	// list_cmd reports a different session, so our instance looks "dead".
 	b := makeHooksWithListName(t, "some-other-session")
@@ -344,16 +348,17 @@ func TestHookBackendStartRestoreDeadSession(t *testing.T) {
 	err := b.Start(i, false)
 	require.Error(t, err, "restore must fail when list_cmd does not report the session")
 	assert.Contains(t, err.Error(), "no longer exists")
+	assert.Contains(t, err.Error(), "listed: some-other-session",
+		"error must include the names list_cmd did report so a rename mismatch is self-diagnosing (#841)")
 	assert.False(t, i.Started(), "instance must not be marked Started when remote session is gone")
 }
 
-// TestHookBackendStartRestoreListCmdFails covers the second leg of #645:
-// when list_cmd itself fails (e.g. network/auth error), we treat the
-// session as not-alive and refuse to mark it Started rather than
-// optimistically restoring a possibly-dead session.
-func TestHookBackendStartRestoreListCmdFails(t *testing.T) {
+// TestHookBackendStartRestoreEmptyList covers the genuinely-empty-list leg of
+// #841: when list_cmd runs fine but reports zero sessions, restore keeps the
+// plain "no longer exists" message without a bogus "(listed: ...)" suffix.
+func TestHookBackendStartRestoreEmptyList(t *testing.T) {
 	dir := t.TempDir()
-	listCmd := writeScript(t, dir, "list.sh", `exit 1`)
+	listCmd := writeScript(t, dir, "list.sh", `echo '[]'`)
 	attachCmd := writeScript(t, dir, "attach.sh", `echo "attached"; sleep 0.1`)
 	b := &HookBackend{
 		Hooks: config.RemoteHooks{
@@ -370,6 +375,87 @@ func TestHookBackendStartRestoreListCmdFails(t *testing.T) {
 	err := b.Start(i, false)
 	require.Error(t, err)
 	assert.False(t, i.Started())
+	assert.Contains(t, err.Error(), "no longer exists")
+	assert.NotContains(t, err.Error(), "listed:",
+		"an empty list must not grow a listed-names suffix")
+}
+
+// TestHookBackendStartRestoreListCmdFails covers the second leg of #645:
+// when list_cmd itself fails (e.g. network/auth error), we treat the
+// session as not-alive and refuse to mark it Started rather than
+// optimistically restoring a possibly-dead session.
+//
+// Since #841 the error must say that list_cmd failed — NOT the misleading
+// "no longer exists in list_cmd output", which implies list_cmd ran and the
+// session was deleted remotely when in fact nothing was verified.
+func TestHookBackendStartRestoreListCmdFails(t *testing.T) {
+	dir := t.TempDir()
+	listCmd := writeScript(t, dir, "list.sh", `echo "ssh: connect refused" >&2; exit 1`)
+	attachCmd := writeScript(t, dir, "attach.sh", `echo "attached"; sleep 0.1`)
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{
+			ListCmd:   listCmd,
+			AttachCmd: attachCmd,
+		},
+	}
+	i := &Instance{
+		Title:   "test-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	err := b.Start(i, false)
+	require.Error(t, err)
+	assert.False(t, i.Started())
+	assert.Contains(t, err.Error(), "cannot verify remote session")
+	assert.Contains(t, err.Error(), "list_cmd failed",
+		"an exec failure must be reported as a list_cmd failure (#841)")
+	assert.Contains(t, err.Error(), "ssh: connect refused",
+		"the failure tail must carry list_cmd's own output")
+	assert.NotContains(t, err.Error(), "no longer exists",
+		"an exec failure must not be reported as a remotely-deleted session (#841)")
+}
+
+// TestHookBackendStartRestoreListCmdNoJSON covers the unparseable-output leg
+// of #841: list_cmd exits 0 but emits no JSON. Nothing was verified, so the
+// error must blame list_cmd's output, not claim the session was deleted.
+func TestHookBackendStartRestoreListCmdNoJSON(t *testing.T) {
+	dir := t.TempDir()
+	listCmd := writeScript(t, dir, "list.sh", `echo "usage: mytool list [--json]"`)
+	attachCmd := writeScript(t, dir, "attach.sh", `echo "attached"; sleep 0.1`)
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{
+			ListCmd:   listCmd,
+			AttachCmd: attachCmd,
+		},
+	}
+	i := &Instance{
+		Title:   "test-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	err := b.Start(i, false)
+	require.Error(t, err)
+	assert.False(t, i.Started())
+	assert.Contains(t, err.Error(), "cannot verify remote session")
+	assert.Contains(t, err.Error(), "no JSON")
+	assert.NotContains(t, err.Error(), "no longer exists",
+		"unparseable list_cmd output must not be reported as a remotely-deleted session (#841)")
+}
+
+// TestFormatListedNames pins the listed-names suffix: empty (and nil) lists
+// keep the original bare message, short lists are joined verbatim, and lists
+// past the cap are truncated with a count so a busy remote host cannot bloat
+// the error (#841).
+func TestFormatListedNames(t *testing.T) {
+	assert.Equal(t, "", formatListedNames(nil))
+	assert.Equal(t, "", formatListedNames([]string{}))
+	assert.Equal(t, " (listed: a)", formatListedNames([]string{"a"}))
+	assert.Equal(t, " (listed: a, b, c, d, e)",
+		formatListedNames([]string{"a", "b", "c", "d", "e"}))
+	assert.Equal(t, " (listed: a, b, c, d, e, and 2 more)",
+		formatListedNames([]string{"a", "b", "c", "d", "e", "f", "g"}))
 }
 
 // TestHookBackendStartRestoreEmptyListCmd is the regression test for #753:
@@ -443,6 +529,10 @@ func TestHookBackendStartRestoreListCmdHangs(t *testing.T) {
 	// restoreAliveTimeout.
 	assert.Less(t, elapsed, 5*time.Second,
 		"restore must abort within timeout when list_cmd hangs (got %v)", elapsed)
+	// A timeout means nothing was verified, so it must be reported as a
+	// list_cmd failure, not as a remotely-deleted session (#841).
+	assert.NotContains(t, err.Error(), "no longer exists",
+		"a timed-out list_cmd must not be reported as a remotely-deleted session")
 }
 
 // TestHookBackendIsAliveListCmdHangs is the runtime analogue of


### PR DESCRIPTION
Fixes #841

## Problem

When restore liveness failed, the only message was:

```
skipping instance "sentry-node-ta": remote session "sentry-node-ta" no longer exists in list_cmd output
```

That one string masked two unrelated causes (#841 burned two debugging sessions on it within hours): a `list_cmd` whose exec failed entirely, and a hook-script rename where `list_cmd` ran fine but listed the session under a new name. #753 had fixed only the empty-`list_cmd` variant of this class.

## Fix

`isAliveWithTimeout` now returns `(alive bool, listed []string, err error)` instead of a bare bool:

- **`err != nil`** — list_cmd could not be run (exec error, timeout) or produced no parseable JSON. Restore reports `cannot verify remote session %q: list_cmd failed: <tail>` (or `list_cmd returned no JSON in output: <tail>`), carrying list_cmd's own output — never the misleading "no longer exists".
- **`alive=false, err=nil`** — list_cmd ran and the session is absent. The message now appends what list_cmd *did* return, capped at 5 names: `remote session "sentry-node-ta" no longer exists in list_cmd output (listed: siyer-code-9a57300c)` — a rename mismatch is self-diagnosing.
- **Genuinely-empty list** (incl. JSON `null`, nil-safe) — keeps the original bare message, no bogus `(listed: ...)` suffix.

`IsAlive` keeps its bool contract with unchanged semantics (every failure mode still reads as not-alive).

## Call-site audit (per CLAUDE.md adjacent-call-sites)

- `Start` restore (`session/backend_hook.go`) — formats the differentiated messages; the #753 empty-`list_cmd` fast-fail guard is untouched.
- `IsAlive` (runtime ticks) — discards the new fields, behavior unchanged.
- `session/storage.go` `LoadInstances`, `app/sync.go` pending-restore, `daemon/daemon.go` restore — all wrap the error from `Start` verbatim (`skipping instance %q: %v`), so they inherit the differentiated message with no change.
- `ListRemoteHookInstanceData` already returned differentiated `list_cmd failed / no JSON / invalid JSON` errors; its wording is now mirrored by the alive path.

## Tests

- `TestHookBackendStartRestoreDeadSession` — rename mismatch: asserts the listed name appears in the message.
- `TestHookBackendStartRestoreEmptyList` — empty list keeps the bare message, no `listed:` suffix.
- `TestHookBackendStartRestoreListCmdFails` — exec failure: asserts `list_cmd failed` + the script's stderr tail, and NOT "no longer exists".
- `TestHookBackendStartRestoreListCmdNoJSON` — exit-0-but-no-JSON: blames list_cmd output, NOT "no longer exists".
- `TestHookBackendStartRestoreListCmdHangs` — timeout now also asserts NOT "no longer exists".
- `TestFormatListedNames` — pins the suffix format incl. the 5-name cap (`, and N more`).

All hermetic (temp-dir hook scripts, no daemon/dev-install).

## Verification

`go build ./...`, `gofmt -l` (clean), `golangci-lint run --timeout=3m --fast`, `go test ./...`, `deadcode -test ./...`, `go test -race ./session/`, and bounded `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/... ./app/...` all pass. (One transient `TestRealTUI_CreateThroughKeypresses` failure under box contention reproduced identically against master and passes on rerun — pre-existing dev-box flake, unrelated to this diff.)

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)