### PR TITLE
feat(session/hook): terminal_cmd powers the terminal tab for remote sessions (#843)

### DIFF
--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -18,6 +18,12 @@ type RemoteHooks struct {
 	ListCmd   string `json:"list_cmd"`
 	AttachCmd string `json:"attach_cmd"`
 	DeleteCmd string `json:"delete_cmd"`
+	// TerminalCmd, when set, powers the Terminal tab for remote sessions: it
+	// is invoked with the session's hook name and should open an interactive
+	// shell in the remote workspace (vs attach_cmd, which attaches to the
+	// agent's own tmux session). Optional — empty means the Terminal tab
+	// keeps its "not available" fallback for remote sessions (#843).
+	TerminalCmd string `json:"terminal_cmd,omitempty"`
 }
 
 // Validate checks that the command strings required to operate a remote hook
@@ -32,6 +38,9 @@ type RemoteHooks struct {
 // (#738). list_cmd is intentionally not required here: import/sync paths treat
 // an empty list_cmd as "no remote sessions to enumerate" (see app/sync.go and
 // daemon/control.go), so requiring it would break that documented behavior.
+// terminal_cmd is likewise optional (#843): it gates a single opt-in feature
+// (the Terminal tab for remote sessions), and when empty that tab shows its
+// "not available" fallback instead of erroring.
 //
 // Callers receive hooks whose relative paths were already rewritten by
 // resolveCommandPaths, but resolution leaves empty values empty, so these
@@ -60,6 +69,7 @@ func (h RemoteHooks) resolveCommandPaths(repoRoot string) *RemoteHooks {
 	h.ListCmd = resolveHookCommandPath(repoRoot, h.ListCmd)
 	h.AttachCmd = resolveHookCommandPath(repoRoot, h.AttachCmd)
 	h.DeleteCmd = resolveHookCommandPath(repoRoot, h.DeleteCmd)
+	h.TerminalCmd = resolveHookCommandPath(repoRoot, h.TerminalCmd)
 	return &h
 }
 

--- a/config/repo_config_test.go
+++ b/config/repo_config_test.go
@@ -106,10 +106,11 @@ func TestRepoConfigRemoteHooks(t *testing.T) {
 func TestRemoteHooksJSON(t *testing.T) {
 	t.Run("marshals correctly", func(t *testing.T) {
 		hooks := RemoteHooks{
-			LaunchCmd: "/path/to/launch.sh",
-			ListCmd:   "/path/to/list.sh",
-			AttachCmd: "/path/to/attach.sh",
-			DeleteCmd: "/path/to/delete.sh",
+			LaunchCmd:   "/path/to/launch.sh",
+			ListCmd:     "/path/to/list.sh",
+			AttachCmd:   "/path/to/attach.sh",
+			DeleteCmd:   "/path/to/delete.sh",
+			TerminalCmd: "/path/to/terminal.sh",
 		}
 
 		data, err := json.Marshal(hooks)
@@ -123,10 +124,19 @@ func TestRemoteHooksJSON(t *testing.T) {
 		assert.Equal(t, "/path/to/list.sh", parsed["list_cmd"])
 		assert.Equal(t, "/path/to/attach.sh", parsed["attach_cmd"])
 		assert.Equal(t, "/path/to/delete.sh", parsed["delete_cmd"])
+		assert.Equal(t, "/path/to/terminal.sh", parsed["terminal_cmd"])
+	})
+
+	t.Run("empty terminal_cmd is omitted from JSON", func(t *testing.T) {
+		// terminal_cmd is optional, so configs that never set it round-trip
+		// byte-identically to the pre-#843 format.
+		data, err := json.Marshal(RemoteHooks{LaunchCmd: "/a"})
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "terminal_cmd")
 	})
 
 	t.Run("unmarshals correctly", func(t *testing.T) {
-		jsonStr := `{"launch_cmd":"/a","list_cmd":"/b","attach_cmd":"/c","delete_cmd":"/d"}`
+		jsonStr := `{"launch_cmd":"/a","list_cmd":"/b","attach_cmd":"/c","delete_cmd":"/d","terminal_cmd":"/e"}`
 		var hooks RemoteHooks
 		err := json.Unmarshal([]byte(jsonStr), &hooks)
 		require.NoError(t, err)
@@ -134,6 +144,7 @@ func TestRemoteHooksJSON(t *testing.T) {
 		assert.Equal(t, "/b", hooks.ListCmd)
 		assert.Equal(t, "/c", hooks.AttachCmd)
 		assert.Equal(t, "/d", hooks.DeleteCmd)
+		assert.Equal(t, "/e", hooks.TerminalCmd)
 	})
 
 	t.Run("omitted when nil in RepoConfig", func(t *testing.T) {
@@ -258,6 +269,16 @@ func TestRemoteHooksValidate(t *testing.T) {
 		assert.NoError(t, h.Validate())
 	})
 
+	t.Run("empty terminal_cmd is allowed", func(t *testing.T) {
+		// terminal_cmd is optional (#843): empty just disables the Terminal
+		// tab for remote sessions, it is never a validation error. full()
+		// leaves it empty, and setting it must validate too.
+		assert.NoError(t, full().Validate())
+		h := full()
+		h.TerminalCmd = "/bin/terminal"
+		assert.NoError(t, h.Validate())
+	})
+
 	cases := []struct {
 		name    string
 		mutate  func(*RemoteHooks)
@@ -307,10 +328,11 @@ func TestResolveHookCommandPath(t *testing.T) {
 // config struct.
 func TestRemoteHooksResolveCommandPaths(t *testing.T) {
 	orig := RemoteHooks{
-		LaunchCmd: "./hooks/launch.sh",
-		ListCmd:   "/abs/list.sh",
-		AttachCmd: "ssh-attach",
-		DeleteCmd: "hooks/delete.sh",
+		LaunchCmd:   "./hooks/launch.sh",
+		ListCmd:     "/abs/list.sh",
+		AttachCmd:   "ssh-attach",
+		DeleteCmd:   "hooks/delete.sh",
+		TerminalCmd: "./hooks/terminal.sh",
 	}
 	resolved := orig.resolveCommandPaths("/repo")
 
@@ -318,7 +340,9 @@ func TestRemoteHooksResolveCommandPaths(t *testing.T) {
 	assert.Equal(t, "/abs/list.sh", resolved.ListCmd)
 	assert.Equal(t, "ssh-attach", resolved.AttachCmd)
 	assert.Equal(t, "/repo/hooks/delete.sh", resolved.DeleteCmd)
+	assert.Equal(t, "/repo/hooks/terminal.sh", resolved.TerminalCmd)
 
 	assert.Equal(t, "./hooks/launch.sh", orig.LaunchCmd, "receiver must not be mutated")
 	assert.Equal(t, "hooks/delete.sh", orig.DeleteCmd, "receiver must not be mutated")
+	assert.Equal(t, "./hooks/terminal.sh", orig.TerminalCmd, "receiver must not be mutated")
 }

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -101,8 +101,8 @@ func ResolveConfig(repoRoot string) (*ResolvedConfig, error) {
 
 	// Rewrite relative hook command paths to absolute against repoRoot
 	// (#834). This is the single chokepoint for the rewrite: every exec of a
-	// hook command — launch/list/attach/delete, startup import, restore
-	// liveness, preview — receives its RemoteHooks from ResolveConfig, so
+	// hook command — launch/list/attach/delete/terminal, startup import,
+	// restore liveness, preview — receives its RemoteHooks from ResolveConfig, so
 	// resolving here covers them all. repoRoot is the main worktree root, so
 	// sessions in linked worktrees resolve hooks against the repository whose
 	// config file was loaded, never against a worktree path. The rewrite

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -163,7 +163,8 @@ func TestResolveConfigResolvesHookPaths(t *testing.T) {
 			"launch_cmd": "./.agent-factory/hooks/launch.sh",
 			"list_cmd": "infra/list.sh",
 			"attach_cmd": "/abs/attach.sh",
-			"delete_cmd": "bash"
+			"delete_cmd": "bash",
+			"terminal_cmd": "./.agent-factory/hooks/terminal.sh"
 		}}`)
 
 		res, err := ResolveConfig(repoRoot)
@@ -173,6 +174,25 @@ func TestResolveConfigResolvesHookPaths(t *testing.T) {
 		assert.Equal(t, filepath.Join(repoRoot, "infra/list.sh"), res.RemoteHooks.ListCmd)
 		assert.Equal(t, "/abs/attach.sh", res.RemoteHooks.AttachCmd, "absolute path passes through")
 		assert.Equal(t, "bash", res.RemoteHooks.DeleteCmd, "bare name keeps $PATH lookup")
+		assert.Equal(t, filepath.Join(repoRoot, ".agent-factory/hooks/terminal.sh"), res.RemoteHooks.TerminalCmd)
+	})
+
+	t.Run("missing terminal_cmd stays empty after resolution", func(t *testing.T) {
+		// Empty must survive the rewrite untouched (#843): the Terminal tab
+		// treats empty as "feature off", and a phantom path here would flip
+		// it on against a non-existent script.
+		repoRoot := setupResolveTest(t, `{"default_program": "claude"}`)
+		writeInRepoConfig(t, repoRoot, `{"remote_hooks": {
+			"launch_cmd": "./hooks/launch.sh",
+			"list_cmd": "./hooks/list.sh",
+			"attach_cmd": "./hooks/attach.sh",
+			"delete_cmd": "./hooks/delete.sh"
+		}}`)
+
+		res, err := ResolveConfig(repoRoot)
+		require.NoError(t, err)
+		require.NotNil(t, res.RemoteHooks)
+		assert.Empty(t, res.RemoteHooks.TerminalCmd)
 	})
 
 	t.Run("legacy-location relative paths get the same resolution", func(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,8 @@ A repository can carry its own configuration in `<repo-root>/.agent-factory/conf
     "launch_cmd": "./infra/launch.sh",
     "list_cmd": "./infra/list.sh",
     "attach_cmd": "./infra/attach.sh",
-    "delete_cmd": "./infra/delete.sh"
+    "delete_cmd": "./infra/delete.sh",
+    "terminal_cmd": "./infra/terminal.sh"
   }
 }
 ```

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -12,7 +12,8 @@ Add remote hooks to the repo's own config file at `<repo-root>/.agent-factory/co
     "launch_cmd": "./.agent-factory/hooks/launch.sh",
     "list_cmd": "./.agent-factory/hooks/list.sh",
     "attach_cmd": "./.agent-factory/hooks/attach.sh",
-    "delete_cmd": "./.agent-factory/hooks/delete.sh"
+    "delete_cmd": "./.agent-factory/hooks/delete.sh",
+    "terminal_cmd": "./.agent-factory/hooks/terminal.sh"
   }
 }
 ```
@@ -31,7 +32,7 @@ The same rules apply to `remote_hooks` values still read from the deprecated leg
 
 Configuring `remote_hooks` enables the remote backend for that repo, but using it is explicit opt-in: press `N` in the TUI to create a remote session. Pressing `n` still creates a local tmux+git worktree session. When `remote_hooks` is absent, `N` is unavailable and all sessions are local.
 
-`launch_cmd`, `attach_cmd`, and `delete_cmd` are **required** — an empty value is rejected when the remote backend is resolved, with an error naming the missing field (e.g. `remote_hooks.launch_cmd is required`) rather than a cryptic `exec: no command` at operation time. `list_cmd` is **optional for import/sync only**: when it is empty, Agent Factory simply reports no remote sessions to enumerate (import/sync are skipped) and config validation does not reject it.
+`launch_cmd`, `attach_cmd`, and `delete_cmd` are **required** — an empty value is rejected when the remote backend is resolved, with an error naming the missing field (e.g. `remote_hooks.launch_cmd is required`) rather than a cryptic `exec: no command` at operation time. `list_cmd` is **optional for import/sync only**: when it is empty, Agent Factory simply reports no remote sessions to enumerate (import/sync are skipped) and config validation does not reject it. `terminal_cmd` is **optional**: when set it powers the Terminal tab for remote sessions; when empty that tab shows a "not available" fallback and nothing else changes.
 
 > **Note:** `list_cmd` is **required for restore**. To carry remote sessions across restarts, Agent Factory re-runs `list_cmd` at startup to confirm each persisted session is still alive (#645). If `list_cmd` is empty, restore cannot verify liveness and the session is dropped with an actionable error naming the missing field — so configure `list_cmd` whenever you want remote sessions to survive restarts.
 
@@ -55,7 +56,7 @@ The `<name>` value passed to hooks is a slug derived from the session title:
 
 Examples: `"Fix Auth Bug"` becomes `fix-auth-bug`, `"my_app"` becomes `myapp`, and `"af-test"` stays `af-test`.
 
-This slug is the stable remote identity. Agent Factory passes it to `launch_cmd --name`, expects `list_cmd` to report it as `name`, passes it to `delete_cmd --name`, and passes it as the positional argument to `attach_cmd`. There is no hidden hash suffix.
+This slug is the stable remote identity. Agent Factory passes it to `launch_cmd --name`, expects `list_cmd` to report it as `name`, passes it to `delete_cmd --name`, and passes it as the positional argument to `attach_cmd` and `terminal_cmd`. There is no hidden hash suffix.
 
 When Agent Factory imports an existing remote session from `list_cmd`, the reported `name` is stored in `remote_meta.name` and remains authoritative even if the display title differs.
 
@@ -132,6 +133,18 @@ done
 ```
 
 Each iteration becomes the new preview frame. `capture-pane -e` keeps colors; they are preserved in the pane.
+
+### `terminal_cmd` (optional)
+
+Opens an interactive terminal on the machine hosting a session — this is what the TUI's **Terminal tab** runs for remote sessions. Where `attach_cmd` connects to the *agent's* session (e.g. `ssh -t host "tmux attach"`), `terminal_cmd` should drop the user into a *plain shell* in the session's workspace, the remote analogue of the local worktree terminal.
+
+**Arguments:** `<name>`
+
+**No JSON output** — like `attach_cmd`, this command takes over the terminal. It should behave like `ssh -t host "cd /workspace/$NAME && exec \$SHELL -l"`.
+
+Agent Factory runs this command behind a local PTY with the same detach-key handling as `attach_cmd`: the configured detach key terminates the local `terminal_cmd` process and returns to the TUI. The remote shell receives a hangup when the SSH client dies; use a remote tmux/screen session inside your script if you want the shell to survive detach.
+
+When `terminal_cmd` is not configured, the Terminal tab shows a "not available" fallback for remote sessions and nothing else changes. Unlike `attach_cmd`, this command is never used for preview capture — it only runs when the user attaches from the Terminal tab.
 
 ## Example
 

--- a/examples/remote-hooks/README.md
+++ b/examples/remote-hooks/README.md
@@ -12,6 +12,7 @@ For the full protocol specification, see [docs/remote-hooks.md](../../docs/remot
 | `list.sh` | List all running remote sessions |
 | `attach.sh` | Attach interactively to a session |
 | `delete.sh` | Tear down a session and clean up |
+| `terminal.sh` | Open an interactive shell in a session's workspace (optional — powers the Terminal tab) |
 
 ## Quick start
 
@@ -29,7 +30,8 @@ Then configure your repo to use them in `<repo-root>/.agent-factory/config.json`
     "launch_cmd": "/path/to/your/hooks/launch.sh",
     "list_cmd": "/path/to/your/hooks/list.sh",
     "attach_cmd": "/path/to/your/hooks/attach.sh",
-    "delete_cmd": "/path/to/your/hooks/delete.sh"
+    "delete_cmd": "/path/to/your/hooks/delete.sh",
+    "terminal_cmd": "/path/to/your/hooks/terminal.sh"
   }
 }
 ```

--- a/examples/remote-hooks/terminal.sh
+++ b/examples/remote-hooks/terminal.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Skeleton terminal script for Agent Factory remote hooks (optional).
+# Opens an interactive shell in a session's remote workspace — this powers
+# the TUI's Terminal tab for remote sessions. Unlike attach.sh, which
+# connects to the agent's own session, this should drop the user into a
+# plain shell next to the agent's work.
+#
+# Required args: <name>
+# This command takes over the terminal (no JSON output).
+
+set -euo pipefail
+
+NAME="${1:?Usage: terminal.sh <session-name>}"
+
+# TODO: Replace with your connection logic
+# Examples:
+#   - ssh -t user@host "cd /workspace/$NAME && exec \$SHELL -l"
+#   - kubectl exec -it pod-$NAME -- /bin/bash
+
+echo "Error: terminal not implemented — replace this script with your connection logic" >&2
+exit 1

--- a/session/backend_e2e_test.go
+++ b/session/backend_e2e_test.go
@@ -466,6 +466,11 @@ echo "=== Remote Session: $NAME ==="
 sleep 0.2
 `)
 
+	writeE2EScript(t, hooksDir, "terminal.sh", `
+NAME="$1"
+echo "=== Remote Shell: $NAME ==="
+`)
+
 	writeE2EScript(t, hooksDir, "delete.sh", `
 STATE_FILE="`+stateFile+`"
 NAME=""
@@ -487,7 +492,8 @@ echo "{\"name\": \"$NAME\", \"deleted\": true}"
     "launch_cmd": "./.agent-factory/hooks/launch.sh",
     "list_cmd": "./.agent-factory/hooks/list.sh",
     "attach_cmd": "./.agent-factory/hooks/attach.sh",
-    "delete_cmd": "./.agent-factory/hooks/delete.sh"
+    "delete_cmd": "./.agent-factory/hooks/delete.sh",
+    "terminal_cmd": "./.agent-factory/hooks/terminal.sh"
   }
 }`), 0644))
 
@@ -534,6 +540,7 @@ func TestE2ERemoteHooksRelativePaths(t *testing.T) {
 	assert.Equal(t, filepath.Join(repo.Root, ".agent-factory/hooks/list.sh"), hook.Hooks.ListCmd)
 	assert.Equal(t, filepath.Join(repo.Root, ".agent-factory/hooks/attach.sh"), hook.Hooks.AttachCmd)
 	assert.Equal(t, filepath.Join(repo.Root, ".agent-factory/hooks/delete.sh"), hook.Hooks.DeleteCmd)
+	assert.Equal(t, filepath.Join(repo.Root, ".agent-factory/hooks/terminal.sh"), hook.Hooks.TerminalCmd)
 
 	// Full lifecycle: launch_cmd, list_cmd (liveness), attach_cmd (preview),
 	// and delete_cmd all execute from a cwd outside the repo.

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -92,9 +92,9 @@ func (hp *hookPTY) ingest(chunk []byte) {
 
 // Slugify converts a title to a slug-safe string for hook scripts.
 // The slug is part of the public remote hook protocol documented in
-// docs/remote-hooks.md: launch_cmd, list_cmd, attach_cmd, and delete_cmd all
-// receive this value unless the instance was imported with an explicit
-// remote_meta.name.
+// docs/remote-hooks.md: launch_cmd, list_cmd, attach_cmd, delete_cmd, and
+// terminal_cmd all receive this value unless the instance was imported with
+// an explicit remote_meta.name.
 func Slugify(title string) string {
 	s := strings.ToLower(title)
 	s = strings.ReplaceAll(s, " ", "-")
@@ -410,6 +410,46 @@ func (b *HookBackend) Attach(i *Instance) (chan struct{}, error) {
 		cmd := exec.Command(b.Hooks.AttachCmd, slug)
 		if err := runHookAttachWithDetach(cmd, os.Stdin, os.Stdout, os.Stderr); err != nil {
 			log.ErrorLog.Printf("attach_cmd error: %v", err)
+		}
+	}()
+	return done, nil
+}
+
+// HasTerminalCmd reports whether the optional terminal_cmd hook is configured.
+// When false, the Terminal tab keeps its "not available" fallback for remote
+// sessions (#843).
+func (b *HookBackend) HasTerminalCmd() bool {
+	return strings.TrimSpace(b.Hooks.TerminalCmd) != ""
+}
+
+// AttachTerminal gives interactive terminal access to the remote workspace by
+// running terminal_cmd behind a local PTY, with the same detach-key handling
+// as Attach. It powers the Terminal tab for remote sessions (#843): where
+// attach_cmd connects to the AGENT's session, terminal_cmd opens a plain
+// shell on the remote machine (typically `ssh <box>` into the workspace).
+//
+// Unlike Attach, the background preview process is left running: it captures
+// the agent's attach_cmd stream over its own pipe, while terminal_cmd talks to
+// a separate shell over its own PTY, so the two cannot compete for output.
+func (b *HookBackend) AttachTerminal(i *Instance) (chan struct{}, error) {
+	if !b.HasTerminalCmd() {
+		return nil, fmt.Errorf("remote terminal is not configured: add a terminal_cmd to remote_hooks to enable the Terminal tab for remote sessions")
+	}
+
+	i.mu.RLock()
+	s := i.started
+	i.mu.RUnlock()
+	if !s {
+		return nil, fmt.Errorf("cannot open remote terminal for instance that has not been started")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		slug := hookNameForInstance(i)
+		cmd := exec.Command(b.Hooks.TerminalCmd, slug)
+		if err := runHookAttachWithDetach(cmd, os.Stdin, os.Stdout, os.Stderr); err != nil {
+			log.ErrorLog.Printf("terminal_cmd error: %v", err)
 		}
 	}()
 	return done, nil

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -1710,3 +1710,124 @@ func TestLocalBackendStartRestoreReinjectsSystemPrompt(t *testing.T) {
 	require.Contains(t, newSessionCmd, "--plugin-dir",
 		"respawned session must include claude --plugin-dir injection so /af-* slash commands keep working (#511)")
 }
+
+// --- terminal_cmd (#843) ---
+
+func TestHookBackendAttachTerminalNotStarted(t *testing.T) {
+	b := &HookBackend{Hooks: config.RemoteHooks{TerminalCmd: "/bin/true"}}
+	i := &Instance{backend: b, started: false}
+	_, err := b.AttachTerminal(i)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not been started")
+}
+
+func TestHookBackendAttachTerminalNotConfigured(t *testing.T) {
+	for name, terminalCmd := range map[string]string{"empty": "", "whitespace": "   "} {
+		t.Run(name, func(t *testing.T) {
+			b := &HookBackend{Hooks: config.RemoteHooks{TerminalCmd: terminalCmd}}
+			i := &Instance{backend: b}
+			i.started = true
+			_, err := b.AttachTerminal(i)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "terminal_cmd",
+				"error must name the missing field so the fix is actionable")
+		})
+	}
+}
+
+// TestHookBackendAttachTerminalRunsTerminalCmdWithSlug verifies the
+// terminal_cmd contract (#843): the script is invoked with the session's hook
+// name as its only positional argument, behind a PTY (mirroring attach_cmd),
+// and the done channel closes when it exits. The attach_cmd-based preview
+// process must be left running — terminal_cmd opens a separate shell, so
+// unlike Attach there is nothing to stop.
+func TestHookBackendAttachTerminalRunsTerminalCmdWithSlug(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "terminal-args")
+	terminalCmd := writeScript(t, dir, "terminal.sh",
+		`echo "$1" > "`+argsFile+`"`)
+	// Preview attach_cmd prints once and lingers so we can observe that
+	// AttachTerminal does not tear it down.
+	attachCmd := writeScript(t, dir, "attach.sh",
+		`echo "preview for $1"
+sleep 5`)
+
+	b := &HookBackend{Hooks: config.RemoteHooks{AttachCmd: attachCmd, TerminalCmd: terminalCmd}}
+	i := &Instance{
+		Title:   "Terminal Cmd Test",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+	i.started = true
+
+	require.NoError(t, b.ensurePTY(i))
+	require.NotNil(t, b.getPTY(i.Title))
+	defer b.closePTY(i.Title)
+
+	done, err := b.AttachTerminal(i)
+	require.NoError(t, err)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("terminal_cmd did not exit")
+	}
+
+	raw, err := os.ReadFile(argsFile)
+	require.NoError(t, err, "terminal_cmd should have run and recorded its args")
+	assert.Equal(t, slugify("Terminal Cmd Test"), strings.TrimSpace(string(raw)),
+		"terminal_cmd must receive the session slug as its positional argument")
+
+	assert.NotNil(t, b.getPTY(i.Title),
+		"AttachTerminal must leave the attach_cmd preview process running")
+}
+
+// TestHookBackendAttachTerminalUsesRemoteMetaName mirrors the attach_cmd
+// behavior: an imported session's authoritative remote_meta.name wins over the
+// title-derived slug.
+func TestHookBackendAttachTerminalUsesRemoteMetaName(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "terminal-args")
+	terminalCmd := writeScript(t, dir, "terminal.sh",
+		`echo "$1" > "`+argsFile+`"`)
+
+	b := &HookBackend{Hooks: config.RemoteHooks{TerminalCmd: terminalCmd}}
+	i := &Instance{
+		Title:   "display title",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+	i.started = true
+	i.remoteMeta = map[string]interface{}{"name": "imported-name"}
+
+	done, err := b.AttachTerminal(i)
+	require.NoError(t, err)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("terminal_cmd did not exit")
+	}
+
+	raw, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	assert.Equal(t, "imported-name", strings.TrimSpace(string(raw)))
+}
+
+func TestInstanceSupportsRemoteTerminal(t *testing.T) {
+	t.Run("remote with terminal_cmd", func(t *testing.T) {
+		i := &Instance{backend: &HookBackend{Hooks: config.RemoteHooks{TerminalCmd: "/bin/true"}}}
+		assert.True(t, i.SupportsRemoteTerminal())
+	})
+
+	t.Run("remote without terminal_cmd", func(t *testing.T) {
+		i := &Instance{backend: &HookBackend{}}
+		assert.False(t, i.SupportsRemoteTerminal())
+	})
+
+	t.Run("non-hook backend", func(t *testing.T) {
+		i := &Instance{backend: &LocalBackend{}}
+		assert.False(t, i.SupportsRemoteTerminal())
+		_, err := i.AttachRemoteTerminal()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "remote sessions")
+	})
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -568,6 +568,26 @@ func (i *Instance) IsRemote() bool {
 	return i.backend.Type() == "remote"
 }
 
+// SupportsRemoteTerminal reports whether this instance can open an interactive
+// terminal on its remote machine — i.e. it uses the remote hook backend and
+// the optional terminal_cmd hook is configured (#843).
+func (i *Instance) SupportsRemoteTerminal() bool {
+	hb, ok := i.backend.(*HookBackend)
+	return ok && hb.HasTerminalCmd()
+}
+
+// AttachRemoteTerminal opens an interactive terminal on the remote machine via
+// the terminal_cmd hook. The returned channel is closed when the user detaches
+// or the terminal_cmd process exits. Errors when the instance is not backed by
+// remote hooks or terminal_cmd is not configured.
+func (i *Instance) AttachRemoteTerminal() (chan struct{}, error) {
+	hb, ok := i.backend.(*HookBackend)
+	if !ok {
+		return nil, fmt.Errorf("remote terminal is only available for remote sessions")
+	}
+	return hb.AttachTerminal(i)
+}
+
 // GetBackend returns the backend for the instance (mainly for testing).
 func (i *Instance) GetBackend() Backend {
 	return i.backend

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -117,10 +117,17 @@ func (t *TerminalPane) UpdateContent(instance *session.Instance) error {
 		return nil
 	}
 
-	// Remote instances have no local worktree, so there's no terminal
-	// session to open. Show the preview pane output instead.
+	// Remote instances have no local worktree, so there's no local tmux
+	// session to capture. When terminal_cmd is configured the tab is an
+	// interactive-only surface (#843): prompt the user to attach. Otherwise
+	// keep the "not available" fallback and name the config knob that
+	// enables it.
 	if instance.IsRemote() {
-		t.setFallbackState("Terminal tab not available for remote sessions.\nUse the Preview tab to see session output.")
+		if instance.SupportsRemoteTerminal() {
+			t.setFallbackState("Press Enter to open a terminal on the remote machine.")
+		} else {
+			t.setFallbackState("Terminal tab not available for remote sessions.\nConfigure remote_hooks.terminal_cmd to enable it.\nUse the Preview tab to see session output.")
+		}
 		return nil
 	}
 
@@ -289,6 +296,17 @@ func (t *TerminalPane) Attach() (chan struct{}, error) {
 func (t *TerminalPane) AttachForInstance(instance *session.Instance) (chan struct{}, error) {
 	if instance == nil {
 		return nil, fmt.Errorf("no terminal session to attach to")
+	}
+	// Remote instances bypass the local tmux session cache entirely: the
+	// terminal_cmd hook runs behind its own PTY with the same detach-key
+	// plumbing as the remote agent attach (#843). The captured-instance
+	// semantics of this method are preserved — the hook is invoked on the
+	// instance the user pressed Enter on, not a drifted selection (#716).
+	if instance.IsRemote() {
+		if !instance.SupportsRemoteTerminal() {
+			return nil, fmt.Errorf("remote terminal is not configured: add a terminal_cmd to remote_hooks to enable the Terminal tab for remote sessions")
+		}
+		return instance.AttachRemoteTerminal()
 	}
 	t.mu.Lock()
 	if err := t.ensureSessionLocked(instance); err != nil {

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -3,11 +3,13 @@ package ui
 import (
 	"fmt"
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -739,4 +741,101 @@ func TestTerminalAttachForInstanceRefusesUnboundInstance(t *testing.T) {
 	if _, err := tp.AttachForInstance(inst); err == nil {
 		t.Fatal("AttachForInstance must refuse to attach an instance it cannot bind")
 	}
+}
+
+// makeRemoteInstance creates a started instance backed by a HookBackend with
+// the given hooks, mirroring the preview_remote_test idiom.
+func makeRemoteInstance(t *testing.T, title string, hooks config.RemoteHooks) *session.Instance {
+	t.Helper()
+	instance, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	instance.SetBackend(&session.HookBackend{Hooks: hooks})
+	instance.SetStartedForTest(true)
+	require.True(t, instance.IsRemote(), "precondition: instance must report as remote")
+	return instance
+}
+
+// TestTerminalRemoteFallbackStates covers the #843 Terminal-tab UX for remote
+// sessions: with terminal_cmd configured the pane invites the user to attach;
+// without it the pane keeps the "not available" fallback and names the config
+// knob that enables the feature.
+func TestTerminalRemoteFallbackStates(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	t.Run("terminal_cmd configured shows attach prompt", func(t *testing.T) {
+		instance := makeRemoteInstance(t, "remote-843-on", config.RemoteHooks{TerminalCmd: "/bin/true"})
+
+		tp := NewTerminalPane()
+		tp.SetSize(80, 30)
+		require.NoError(t, tp.UpdateContent(instance))
+
+		tp.mu.Lock()
+		require.True(t, tp.fallback, "remote terminal is interactive-only; the pane stays in fallback mode")
+		tp.mu.Unlock()
+		rendered := tp.String()
+		require.Contains(t, rendered, "Press Enter to open a terminal",
+			"must invite the user to attach when terminal_cmd is configured")
+	})
+
+	t.Run("terminal_cmd absent keeps not-available fallback", func(t *testing.T) {
+		instance := makeRemoteInstance(t, "remote-843-off", config.RemoteHooks{})
+
+		tp := NewTerminalPane()
+		tp.SetSize(80, 30)
+		require.NoError(t, tp.UpdateContent(instance))
+
+		tp.mu.Lock()
+		require.True(t, tp.fallback)
+		require.Contains(t, tp.fallbackText, "not available for remote sessions")
+		require.Contains(t, tp.fallbackText, "terminal_cmd",
+			"fallback must name the config knob that enables the feature")
+		tp.mu.Unlock()
+	})
+}
+
+// TestTerminalAttachForInstanceRemote verifies the attach path for remote
+// instances (#843): with terminal_cmd configured AttachForInstance runs the
+// hook (bypassing the local tmux session cache); without it the attach is
+// refused with an error naming terminal_cmd.
+func TestTerminalAttachForInstanceRemote(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	t.Run("not configured refuses with actionable error", func(t *testing.T) {
+		instance := makeRemoteInstance(t, "remote-843-noattach", config.RemoteHooks{})
+
+		tp := NewTerminalPane()
+		_, err := tp.AttachForInstance(instance)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "terminal_cmd")
+	})
+
+	t.Run("configured runs terminal_cmd with the session slug", func(t *testing.T) {
+		dir := t.TempDir()
+		argsFile := filepath.Join(dir, "terminal-args")
+		script := filepath.Join(dir, "terminal.sh")
+		require.NoError(t, os.WriteFile(script,
+			[]byte("#!/bin/sh\necho \"$1\" > \""+argsFile+"\"\n"), 0755))
+
+		instance := makeRemoteInstance(t, "remote-843-attach", config.RemoteHooks{TerminalCmd: script})
+
+		tp := NewTerminalPane()
+		done, err := tp.AttachForInstance(instance)
+		require.NoError(t, err)
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("terminal_cmd did not exit")
+		}
+
+		raw, err := os.ReadFile(argsFile)
+		require.NoError(t, err, "terminal_cmd should have run")
+		require.Equal(t, session.Slugify("remote-843-attach"), strings.TrimSpace(string(raw)),
+			"terminal_cmd must receive the session slug")
+	})
 }


### PR DESCRIPTION
Fixes #843

Sachin: *"I want the terminal tab to work on the remote instances - I think that we should expose another command for this."*

## What

A new **optional** `remote_hooks` command, **`terminal_cmd`**. Where `attach_cmd` connects to the *agent's* session, `terminal_cmd` opens a *plain shell* in the session's remote workspace (typically `ssh <box>`) — the remote analogue of the local worktree terminal.

- **Contract mirrors `attach_cmd`:** invoked with the session's hook name (slug, or `remote_meta.name` for imported sessions) as the only positional argument, runs behind a local PTY via the existing `runHookAttachWithDetach` plumbing, so the configured detach key returns to the TUI.
- **TUI:** the Terminal tab for a remote instance now shows *"Press Enter to open a terminal on the remote machine."* and Enter attaches through the same captured-instance path as local terminal attach (#716 semantics preserved). The tab is interactive-only for v1 — no preview capture.
- **When unset:** the tab keeps its "not available" fallback (now naming `remote_hooks.terminal_cmd` so the feature is discoverable), and config validation does **not** reject the empty value — zero breaking change for existing hook setups.
- Unlike `Attach`, `AttachTerminal` leaves the background attach_cmd preview process running: terminal_cmd talks to a separate shell over its own PTY, so the two streams cannot compete.

## Config resolution

`terminal_cmd` gets the full treatment of the other four commands: in-repo + legacy-location resolution through the single `ResolveConfig` chokepoint, #834 relative-path rewriting against the repo root (`./.agent-factory/hooks/terminal.sh` works from any cwd, linked worktrees resolve against the main repo root), `omitempty` so untouched configs round-trip byte-identically, and empty-stays-empty so the feature-off state can never turn into a phantom path.

## Adjacent-call-site audit (per CLAUDE.md)

Every place the four hook commands are enumerated:

| Site | Action |
|---|---|
| `config.RemoteHooks` struct / `resolveCommandPaths` | `TerminalCmd` added |
| `RemoteHooks.Validate` (#738) | intentionally **not** required — comment documents that empty = feature off |
| `config/resolve.go` chokepoint comment (#834) | updated |
| `Slugify` protocol comment (`session/backend_hook.go`) | updated |
| #753 restore guard (`list_cmd` required for restore) | **excluded** — terminal_cmd plays no role in liveness/restore; nothing to verify at startup |
| `docs/remote-hooks.md` | config example, required/optional paragraph, slug paragraph, new `terminal_cmd` section with contract + example |
| `docs/configuration.md` in-repo example | updated |
| `examples/remote-hooks/` | new `terminal.sh` skeleton + README table/config rows |
| `app/sync.go` / `daemon/control.go` import paths | no change needed — they consume `list_cmd` only |
| `hook_preview_sanitize.go` | no change — preview is attach_cmd-only, and terminal_cmd is never used for preview capture |

## Tests

- `TestRemoteHooksValidate` — empty terminal_cmd is allowed (feature off, not an error).
- `TestRemoteHooksResolveCommandPaths` / `TestResolveConfigResolvesHookPaths` — relative resolution incl. terminal_cmd, plus *missing stays empty after resolution*.
- `TestRemoteHooksJSON` — round-trip incl. terminal_cmd; empty is omitted from JSON (pre-#843 configs unchanged on save).
- `TestHookBackendAttachTerminal{NotStarted,NotConfigured,RunsTerminalCmdWithSlug,UsesRemoteMetaName}` — fake terminal_cmd script records its argv; asserts slug / remote_meta.name, done-channel close, actionable errors, and that the preview process survives the attach.
- `TestInstanceSupportsRemoteTerminal` — hook backend with/without terminal_cmd, local backend.
- `TestTerminalRemoteFallbackStates` / `TestTerminalAttachForInstanceRemote` (ui) — press-Enter prompt vs not-available fallback naming the config knob; attach runs the hook with the slug; unconfigured attach refused with an actionable error.
- `TestE2ERemoteHooksRelativePaths` (#834 acceptance) — extended to cover terminal_cmd resolution end-to-end.

All hermetic (temp-dir scripts, no daemon, no dev-install).

## Gates

`go build ./...`, `gofmt -l .` (clean), `golangci-lint run --timeout=3m --fast`, `go test ./...`, `deadcode -test ./...`, and bounded `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/... ./app/...` — all green.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)