### PR TITLE
feat(app,session): async kill with a visible deleting state (#844)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -401,6 +401,12 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case instanceChangedMsg:
 		return m, m.selectionChanged()
+	case startKillMsg:
+		// The row was already flipped to Deleting synchronously by the kill
+		// confirmation; dispatch the slow teardown off the event loop (#844).
+		return m, m.killInstanceCmd(msg.title)
+	case instanceKilledMsg:
+		return m.handleInstanceKilled(msg)
 	case repaintAfterDetachMsg:
 		// Trigger an immediate repaint with whatever content is already
 		// cached on the panes (rendered when bubbletea's main loop calls
@@ -1012,6 +1018,22 @@ func (m *home) keydownCallback(name keys.KeyName) tea.Cmd {
 type hideErrMsg struct{}
 type previewTickMsg struct{}
 type instanceChangedMsg struct{}
+
+// startKillMsg is emitted by the kill confirmation action right after the
+// target row has been marked Deleting on the event loop. Its handler
+// dispatches killInstanceCmd, which runs the slow teardown in a background
+// goroutine (#844).
+type startKillMsg struct {
+	title string
+}
+
+// instanceKilledMsg reports completion of an async kill. A nil err means the
+// daemon tore the session down and deleted its record; a non-nil err means
+// the session is still alive and the row must become retryable again.
+type instanceKilledMsg struct {
+	title string
+	err   error
+}
 
 // runOnEventLoopMsg is a test-only primitive: when received by Update, it
 // runs fn with the home pointer on the tea goroutine, then closes done.

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -138,40 +138,37 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 	}
 }
 
-// handleKill handles the kill/delete session action.
+// handleKill handles the kill/delete session action. The confirmation only
+// flips the row to Deleting; the slow teardown (remote delete_cmd over ssh,
+// tmux kill, worktree removal) runs in killInstanceCmd's background goroutine
+// so the event loop never blocks on it (#844).
 func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
 	if selected == nil || selected.GetStatus() == session.Loading {
 		return m, nil
+	}
+	if selected.GetStatus() == session.Deleting {
+		return m, m.handleError(fmt.Errorf("session '%s' is already being deleted", selected.Title))
 	}
 
 	// Capture the title at confirmation time so that background tick events
 	// cannot change which instance we operate on.
 	selectedTitle := selected.Title
 
-	tw := m.contentPane.TabbedWindow()
+	// Runs synchronously in the confirmation overlay's OnConfirm, on the
+	// event loop — keep it fast. Marking Deleting here (not in the background
+	// cmd) guarantees the row is visibly deleting and kill/attach are fenced
+	// off before any other event can be processed.
 	killAction := func() tea.Msg {
-		tw.CleanupTerminalForInstance(selectedTitle)
-
-		var repoName string
-		var repoErr error = fmt.Errorf("instance not found")
 		for _, inst := range m.sidebar.GetInstances() {
 			if inst.Title == selectedTitle {
-				repoName, repoErr = inst.RepoName()
-				break
+				inst.SetStatus(session.Deleting)
+				return startKillMsg{title: selectedTitle}
 			}
 		}
-		if err := killSessionThroughDaemon(selectedTitle, m.repoID); err != nil {
-			log.ErrorLog.Printf("could not kill instance: %v", err)
-			return fmt.Errorf("failed to kill session '%s': %w", selectedTitle, err)
-		}
-		if repoErr == nil {
-			m.sidebar.RemoveInstanceByTitleWithRepo(selectedTitle, repoName)
-		} else {
-			m.sidebar.RemoveInstanceByTitle(selectedTitle)
-		}
-
-		return instanceChangedMsg{}
+		// The row was removed (e.g. by an external kill picked up by the
+		// background refresh) while the dialog was open; nothing to do.
+		return nil
 	}
 
 	// Check for uncommitted changes in the worktree (skip for remote sessions
@@ -188,6 +185,62 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		message += "\n\n" + warning
 	}
 	return m, m.confirmAction(message, killAction)
+}
+
+// killInstanceCmd returns a tea.Cmd that performs the actual session teardown
+// off the event loop. The daemon RPC blocks for the whole teardown — for
+// remote instances delete_cmd often runs over ssh and takes tens of seconds —
+// which is exactly why this must not run on the Update goroutine (#844). The
+// teardown itself (delete_cmd → tmux kill → worktree removal, #802 ordering)
+// is unchanged: it still goes through daemon.KillSession, which also keeps
+// the title blocked against reuse until the teardown completes.
+func (m *home) killInstanceCmd(title string) tea.Cmd {
+	tw := m.contentPane.TabbedWindow()
+	repoID := m.repoID
+	return func() tea.Msg {
+		tw.CleanupTerminalForInstance(title)
+		if err := killSessionThroughDaemon(title, repoID); err != nil {
+			log.ErrorLog.Printf("could not kill instance: %v", err)
+			return instanceKilledMsg{title: title, err: err}
+		}
+		return instanceKilledMsg{title: title}
+	}
+}
+
+// handleInstanceKilled finalizes an async kill on the event loop. On success
+// the row is removed from the sidebar (the daemon already deleted the disk
+// record). On failure the row flips back to Ready so the user can retry the
+// kill, and the underlying error — the evidence, per #797 — lands in the
+// error box.
+func (m *home) handleInstanceKilled(msg instanceKilledMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		for _, inst := range m.sidebar.GetInstances() {
+			if inst.Title == msg.title && inst.GetStatus() == session.Deleting {
+				inst.SetStatus(session.Ready)
+				break
+			}
+		}
+		return m, m.handleError(fmt.Errorf("failed to kill session '%s': %w", msg.title, msg.err))
+	}
+
+	// The TUI's in-memory instance is untouched by the daemon-side teardown,
+	// so its repo name is still resolvable here for repo-section bookkeeping.
+	// The row may already be gone when the background refresh noticed the
+	// deleted disk record first — both removals are no-ops then.
+	var repoName string
+	var repoErr error = fmt.Errorf("instance not found")
+	for _, inst := range m.sidebar.GetInstances() {
+		if inst.Title == msg.title {
+			repoName, repoErr = inst.RepoName()
+			break
+		}
+	}
+	if repoErr == nil {
+		m.sidebar.RemoveInstanceByTitleWithRepo(msg.title, repoName)
+	} else {
+		m.sidebar.RemoveInstanceByTitle(msg.title)
+	}
+	return m, m.selectionChanged()
 }
 
 // killConfirmationWarning returns the data-loss warning line for the kill
@@ -222,7 +275,13 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 	// Instance selected
 	if sel.Kind == ui.SectionInstances {
 		selected := m.sidebar.GetSelectedInstance()
-		if selected == nil || selected.GetStatus() == session.Loading || !selected.TmuxAlive() {
+		if selected == nil || selected.GetStatus() == session.Loading {
+			return m, nil
+		}
+		if selected.GetStatus() == session.Deleting {
+			return m, m.handleError(fmt.Errorf("session '%s' is being deleted", selected.Title))
+		}
+		if !selected.TmuxAlive() {
 			return m, nil
 		}
 		// Capture the instance at Enter-press time — the synchronous moment the

--- a/app/kill_async_test.go
+++ b/app/kill_async_test.go
@@ -1,0 +1,232 @@
+package app
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// ----------------------------------------------------------------------------
+// Regression tests for issue #844: "make deletion async".
+//
+// Before the fix, the kill confirmation's OnConfirm ran the whole teardown —
+// including the daemon RPC, whose remote delete_cmd often runs over ssh and
+// takes tens of seconds — synchronously on the bubbletea Update goroutine,
+// freezing the entire TUI. The fix marks the row Deleting synchronously and
+// hands the teardown to a background tea.Cmd (killInstanceCmd).
+// ----------------------------------------------------------------------------
+
+// setKillerForTest swaps killSessionThroughDaemon and restores it on cleanup.
+func setKillerForTest(t *testing.T, f func(title, repoID string) error) {
+	t.Helper()
+	prev := killSessionThroughDaemon
+	killSessionThroughDaemon = f
+	t.Cleanup(func() { killSessionThroughDaemon = prev })
+}
+
+// newKillableInstance returns a Ready instance backed by a FakeBackend so no
+// real tmux/git resources exist to tear down.
+func newKillableInstance(t *testing.T, title string) *session.Instance {
+	t.Helper()
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, _ string) (session.Backend, error) {
+		return session.NewFakeBackend(), nil
+	})
+	defer restore()
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	inst.SetStatus(session.Ready)
+	return inst
+}
+
+// confirmKill drives handleKill through the confirmation overlay's 'y' key and
+// returns the tea.Cmd produced by the confirm (the pendingConfirmMsg forward).
+func confirmKill(t *testing.T, h *home) tea.Cmd {
+	t.Helper()
+	model, _ := h.handleKill()
+	hm := model.(*home)
+	require.Equal(t, stateConfirm, hm.state, "kill must open the confirmation dialog")
+	require.NotNil(t, hm.confirmationOverlay)
+	model, cmd := hm.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	require.Equal(t, stateDefault, model.(*home).state, "confirm must close the dialog")
+	return cmd
+}
+
+// TestHandleKill_MarksDeletingWithoutBlockingEventLoop is the core #844 fix:
+// confirming a kill must return control to the event loop immediately — with
+// the row flipped to Deleting — while the slow daemon teardown is still in
+// flight on a background goroutine.
+func TestHandleKill_MarksDeletingWithoutBlockingEventLoop(t *testing.T) {
+	killStarted := make(chan struct{})
+	killBlock := make(chan struct{})
+	setKillerForTest(t, func(title, repoID string) error {
+		close(killStarted)
+		<-killBlock
+		return nil
+	})
+
+	h := newTestHome(t)
+	inst := newKillableInstance(t, "slow-remote")
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	// The synchronous part of the flow: confirm + the startKillMsg hop. Bound
+	// its wall-clock so a regression back to a blocking RPC fails loudly even
+	// though the fake kill would deadlock the test anyway (#817-style guard).
+	syncStart := time.Now()
+	cmd := confirmKill(t, h)
+	require.NotNil(t, cmd, "confirm must forward the start-kill message")
+	assert.Equal(t, session.Deleting, inst.GetStatus(),
+		"row must be marked Deleting synchronously at confirm time")
+
+	msg := cmd()
+	startMsg, ok := msg.(startKillMsg)
+	require.True(t, ok, "confirm action must emit startKillMsg, got %T", msg)
+	_, killCmd := h.Update(startMsg)
+	require.NotNil(t, killCmd, "startKillMsg must dispatch the background kill cmd")
+	require.Less(t, time.Since(syncStart), 2*time.Second,
+		"the event-loop side of kill must not wait for the teardown")
+
+	// Run the teardown cmd the way bubbletea would: on its own goroutine.
+	done := make(chan tea.Msg, 1)
+	go func() { done <- killCmd() }()
+
+	select {
+	case <-killStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("background kill cmd never invoked the daemon kill")
+	}
+
+	// Teardown is in flight: the event loop is free, the row is still visible
+	// and still Deleting.
+	select {
+	case <-done:
+		t.Fatal("kill cmd completed before the daemon RPC was released")
+	default:
+	}
+	assert.Equal(t, []string{"slow-remote"}, collectTitles(h.sidebar.GetInstances()),
+		"row must stay in the sidebar while deletion is in flight")
+	assert.Equal(t, session.Deleting, inst.GetStatus())
+
+	// Release the teardown and complete the flow.
+	close(killBlock)
+	var killedMsg tea.Msg
+	select {
+	case killedMsg = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("kill cmd did not complete after the daemon RPC returned")
+	}
+	killed, ok := killedMsg.(instanceKilledMsg)
+	require.True(t, ok, "kill cmd must emit instanceKilledMsg, got %T", killedMsg)
+	require.NoError(t, killed.err)
+
+	_, _ = h.Update(killed)
+	assert.Empty(t, h.sidebar.GetInstances(), "row must be removed once teardown completes")
+}
+
+// TestHandleKill_FailureRevertsToReadyAndAllowsRetry: a failed teardown must
+// keep the row (so nothing is silently lost), make it retryable again, and
+// surface the underlying error to the user.
+func TestHandleKill_FailureRevertsToReadyAndAllowsRetry(t *testing.T) {
+	killErr := errors.New("delete_cmd failed: ssh: connect to host refused")
+	setKillerForTest(t, func(title, repoID string) error { return killErr })
+
+	h := newTestHome(t)
+	h.errBox.SetSize(500, 1)
+	inst := newKillableInstance(t, "doomed")
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	cmd := confirmKill(t, h)
+	require.NotNil(t, cmd)
+	require.Equal(t, session.Deleting, inst.GetStatus())
+
+	_, killCmd := h.Update(cmd())
+	require.NotNil(t, killCmd)
+	killed, ok := killCmd().(instanceKilledMsg)
+	require.True(t, ok)
+	require.ErrorIs(t, killed.err, killErr)
+
+	_, _ = h.Update(killed)
+
+	assert.Equal(t, []string{"doomed"}, collectTitles(h.sidebar.GetInstances()),
+		"failed kill must keep the row so the user can retry")
+	assert.Equal(t, session.Ready, inst.GetStatus(),
+		"failed kill must revert Deleting so kill is enabled again")
+	rendered := h.errBox.String()
+	assert.Contains(t, rendered, "failed to kill session 'doomed'")
+	assert.Contains(t, rendered, "connect to host refused",
+		"the underlying cause must be surfaced, not swallowed (#797)")
+
+	// Retry must reach the confirmation dialog again.
+	model, _ := h.handleKill()
+	assert.Equal(t, stateConfirm, model.(*home).state, "retry kill must work after a failure")
+}
+
+// TestHandleKill_DeletingInstanceIsNoOp: pressing D on a row that is already
+// mid-deletion must not open a second confirmation or dispatch a second
+// teardown — it surfaces a brief message instead.
+func TestHandleKill_DeletingInstanceIsNoOp(t *testing.T) {
+	setKillerForTest(t, func(title, repoID string) error {
+		t.Error("kill must not be dispatched for an already-deleting instance")
+		return nil
+	})
+
+	h := newTestHome(t)
+	h.errBox.SetSize(500, 1)
+	inst := newKillableInstance(t, "going-away")
+	inst.SetStatus(session.Deleting)
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, _ := h.handleKill()
+	hm := model.(*home)
+	assert.Equal(t, stateDefault, hm.state, "no confirmation dialog for a deleting row")
+	assert.Nil(t, hm.confirmationOverlay)
+	assert.Contains(t, h.errBox.String(), "already being deleted")
+}
+
+// TestHandleEnter_DeletingInstanceIsNoOp: attaching to a mid-deletion session
+// would race the teardown; Enter must refuse with a brief message.
+func TestHandleEnter_DeletingInstanceIsNoOp(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(500, 1)
+	inst := newKillableInstance(t, "going-away")
+	inst.SetStatus(session.Deleting)
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, _ := h.handleEnter()
+	hm := model.(*home)
+	assert.Equal(t, stateDefault, hm.state, "no attach flow for a deleting row")
+	assert.Nil(t, hm.textOverlay)
+	assert.Contains(t, h.errBox.String(), "is being deleted")
+}
+
+// TestInstanceKilled_RowAlreadyRemoved: the 3s external refresh can notice the
+// deleted disk record and remove the row before instanceKilledMsg arrives.
+// The handler must tolerate the missing row.
+func TestInstanceKilled_RowAlreadyRemoved(t *testing.T) {
+	h := newTestHome(t)
+	_, _ = h.Update(instanceKilledMsg{title: "already-gone"})
+	assert.Empty(t, h.sidebar.GetInstances())
+}
+
+// TestRunMetadataTick_SkipsDeletingInstances: the metadata tick must neither
+// shell into a mid-teardown session nor clobber its Deleting status with
+// Running/Ready (#844).
+func TestRunMetadataTick_SkipsDeletingInstances(t *testing.T) {
+	inst := newKillableInstance(t, "mid-teardown")
+	inst.SetStartedForTest(true)
+	inst.SetStatus(session.Deleting)
+
+	runMetadataTick([]*session.Instance{inst})
+
+	assert.Equal(t, session.Deleting, inst.GetStatus(),
+		"metadata tick must not overwrite the Deleting status")
+}

--- a/app/sync.go
+++ b/app/sync.go
@@ -53,19 +53,26 @@ func runMetadataTick(instances []*session.Instance) {
 	tickStart := time.Now()
 	detachTraceMark("runMetadataTick-entry")
 	for _, instance := range instances {
-		if !instance.Started() || instance.GetStatus() == session.Loading {
+		// Deleting instances are skipped like Loading ones: their backing
+		// session is being torn down, so the capture-pane/status shell-outs
+		// would poke a dying session, and a status write would clobber the
+		// Deleting marker (#844).
+		if status := instance.GetStatus(); !instance.Started() || status == session.Loading || status == session.Deleting {
 			continue
 		}
 		instStart := time.Now()
 		instance.CheckAndHandleTrustPrompt()
 		updated, prompt := instance.HasUpdated()
+		// SetStatusIfNotDeleting, not SetStatus: the user can confirm a kill
+		// between this tick's status check above and the write below, and an
+		// unconditional write would un-mark the deleting row (#844).
 		if updated {
-			instance.SetStatus(session.Running)
+			instance.SetStatusIfNotDeleting(session.Running)
 		} else {
 			if prompt {
 				instance.TapEnter()
 			} else {
-				instance.SetStatus(session.Ready)
+				instance.SetStatusIfNotDeleting(session.Ready)
 			}
 		}
 		// Per-instance elapsed makes contention visible: if 1 of N tmux
@@ -202,7 +209,7 @@ func (m *home) mergePendingInstances() int {
 				if existing.Title != data.Title {
 					continue
 				}
-				if instanceCollisionShouldSkip(existing.GetWorktreePath(), data.Worktree.WorktreePath, existing.CreatedAt, data.CreatedAt, existing.TmuxAlive(), existing.GetStatus() == session.Loading) {
+				if instanceCollisionShouldSkip(existing.GetWorktreePath(), data.Worktree.WorktreePath, existing.CreatedAt, data.CreatedAt, existing.TmuxAlive(), isTransientStatus(existing.GetStatus())) {
 					log.WarningLog.Printf("skipping pending instance %q: already exists and is alive", data.Title)
 					skip = true
 				} else {
@@ -305,7 +312,7 @@ func (m *home) refreshExternalInstances() bool {
 				if existing.Title != d.Title {
 					continue
 				}
-				if !instanceCollisionShouldSkip(existing.GetWorktreePath(), d.Worktree.WorktreePath, existing.CreatedAt, d.CreatedAt, existing.TmuxAlive(), existing.GetStatus() == session.Loading) {
+				if !instanceCollisionShouldSkip(existing.GetWorktreePath(), d.Worktree.WorktreePath, existing.CreatedAt, d.CreatedAt, existing.TmuxAlive(), isTransientStatus(existing.GetStatus())) {
 					skip = false
 					shouldReplace = true
 				}
@@ -368,6 +375,12 @@ func (m *home) refreshExternalInstances() bool {
 // always swap it, orphaning the pointer the instanceStartedMsg handler later
 // passes to ReplaceInstance and leaving two same-title sidebar rows.
 //
+// A Deleting sidebar instance is likewise never replaced (#844): its on-disk
+// record legitimately still exists until the background teardown finishes,
+// and swapping the row for a disk-built copy would erase the Deleting marker —
+// resurrecting a kill-enabled row for a session that is mid-teardown. The
+// transient flag below covers both states.
+//
 // The incoming instance supersedes the existing one when:
 //   - both worktree paths are known and differ — a scheduled task rerun
 //     creates a new worktree with a numeric suffix while reusing the tmux
@@ -380,8 +393,8 @@ func (m *home) refreshExternalInstances() bool {
 //     TmuxAlive() can then distinguish them; the newer CreatedAt can (#765).
 //
 // Otherwise, fall back to the tmuxAlive signal.
-func instanceCollisionShouldSkip(existingWorktreePath, incomingWorktreePath string, existingCreatedAt, incomingCreatedAt time.Time, tmuxAlive, existingLoading bool) bool {
-	if existingLoading {
+func instanceCollisionShouldSkip(existingWorktreePath, incomingWorktreePath string, existingCreatedAt, incomingCreatedAt time.Time, tmuxAlive, existingTransient bool) bool {
+	if existingTransient {
 		return true
 	}
 	if existingWorktreePath != "" && incomingWorktreePath != "" && existingWorktreePath != incomingWorktreePath {
@@ -391,6 +404,14 @@ func instanceCollisionShouldSkip(existingWorktreePath, incomingWorktreePath stri
 		return false
 	}
 	return tmuxAlive
+}
+
+// isTransientStatus reports whether an in-memory sidebar instance is in a
+// state owned by an in-flight TUI operation — Loading (creation, #808) or
+// Deleting (async kill, #844) — during which background syncs must neither
+// replace nor reap it.
+func isTransientStatus(status session.Status) bool {
+	return status == session.Loading || status == session.Deleting
 }
 
 func upsertInstanceDataByTitle(existing, incoming []session.InstanceData) []session.InstanceData {

--- a/daemon/kill_inflight_conflict_test.go
+++ b/daemon/kill_inflight_conflict_test.go
@@ -1,0 +1,104 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// slowKillBackend is a readyFakeBackend whose Kill blocks until released, so
+// tests can hold a session inside its teardown window.
+type slowKillBackend struct {
+	readyFakeBackend
+	killStarted chan struct{}
+	killBlock   chan struct{}
+}
+
+func (b *slowKillBackend) Kill(inst *session.Instance) error {
+	close(b.killStarted)
+	<-b.killBlock
+	return b.readyFakeBackend.Kill(inst)
+}
+
+// TestKillSessionBlocksTitleReuseDuringTeardown pins the title-reservation
+// property the async TUI kill (#844) leans on: while Manager.KillSession is
+// still tearing a session down, its instance stays in the manager's map and
+// its record stays on disk, so a CreateSession reusing the title must be
+// rejected. Only after the teardown completes may the title be reused.
+func TestKillSessionBlocksTitleReuseDuringTeardown(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	backend := &slowKillBackend{
+		killStarted: make(chan struct{}),
+		killBlock:   make(chan struct{}),
+	}
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, absPath string) (session.Backend, error) {
+		fake := session.NewFakeBackend()
+		fake.CompleteStart()
+		backend.readyFakeBackend = readyFakeBackend{fake}
+		return backend, nil
+	})
+	t.Cleanup(restore)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "busy",
+		RepoPath: repoPath,
+		Program:  "claude",
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	killDone := make(chan error, 1)
+	go func() {
+		killDone <- manager.KillSession(KillSessionRequest{Title: "busy", RepoID: repo.ID})
+	}()
+	select {
+	case <-backend.killStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("KillSession never reached the backend teardown")
+	}
+
+	// Mid-teardown: the title must still be blocked against reuse.
+	_, err = manager.CreateSession(CreateSessionRequest{
+		Title:    "busy",
+		RepoPath: repoPath,
+		Program:  "claude",
+	})
+	if err == nil {
+		t.Fatal("expected title reuse to be rejected while teardown is in flight")
+	}
+	if !strings.Contains(err.Error(), "busy") {
+		t.Fatalf("conflict error should name the title, got: %v", err)
+	}
+
+	close(backend.killBlock)
+	select {
+	case err := <-killDone:
+		if err != nil {
+			t.Fatalf("KillSession: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("KillSession did not complete after the teardown was released")
+	}
+
+	// Teardown finished: the title is free again.
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "busy",
+		RepoPath: repoPath,
+		Program:  "claude",
+	}); err != nil {
+		t.Fatalf("expected title reuse to succeed after teardown, got: %v", err)
+	}
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -19,6 +19,11 @@ const (
 	Ready
 	// Loading is if the instance is loading (if we are setting it up).
 	Loading
+	// Deleting is if the instance is being torn down asynchronously after the
+	// user confirmed a kill. Like Loading it is transient in-memory state: it
+	// is never persisted (see mergeInstancesWithDisk) and the row is removed
+	// or reverted when the background teardown finishes (#844).
+	Deleting
 )
 
 // Instance is a running instance of claude code.
@@ -295,6 +300,22 @@ func (i *Instance) RepoName() (string, error) {
 func (i *Instance) SetStatus(status Status) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+	i.Status = status
+}
+
+// SetStatusIfNotDeleting sets the status under the instance mutex unless the
+// instance is mid-deletion. The metadata tick runs off the event loop and
+// races the async kill flow (#844): between its own status check and its
+// store, the user can confirm a kill, and an unconditional Running/Ready
+// write would clobber the Deleting marker — re-enabling kill/attach on a
+// session whose teardown is already in flight. Only the kill completion
+// handler may move an instance out of Deleting, via SetStatus.
+func (i *Instance) SetStatusIfNotDeleting(status Status) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.Status == Deleting {
+		return
+	}
 	i.Status = status
 }
 

--- a/session/instance_test.go
+++ b/session/instance_test.go
@@ -116,3 +116,23 @@ func TestGetGitWorktree_RaceWithStart(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestSetStatusIfNotDeleting guards the #844 status fence: the metadata tick's
+// Running/Ready writes must not clobber a Deleting marker, while normal status
+// flow stays unaffected and the kill completion handler (which uses SetStatus)
+// can still move the instance out of Deleting.
+func TestSetStatusIfNotDeleting(t *testing.T) {
+	i := &Instance{Status: Ready}
+
+	i.SetStatusIfNotDeleting(Running)
+	require.Equal(t, Running, i.GetStatus(), "non-deleting status updates must pass through")
+
+	i.SetStatus(Deleting)
+	i.SetStatusIfNotDeleting(Running)
+	require.Equal(t, Deleting, i.GetStatus(), "tick writes must not clobber Deleting")
+	i.SetStatusIfNotDeleting(Ready)
+	require.Equal(t, Deleting, i.GetStatus())
+
+	i.SetStatus(Ready)
+	require.Equal(t, Ready, i.GetStatus(), "the kill handler's unconditional SetStatus must still work")
+}

--- a/session/storage.go
+++ b/session/storage.go
@@ -106,6 +106,12 @@ func dedupeInstanceData(data []InstanceData) []InstanceData {
 //   - Loading instances are never persisted — their worktree is not yet
 //     populated, so FromInstanceData cannot restore them, and an orphaned
 //     record would block title reuse via the daemon's collision check (#551).
+//   - Deleting instances are likewise never persisted (#844): their teardown
+//     is in flight, and writing them back would resurrect the record after
+//     the daemon deletes it from disk. While teardown is still running the
+//     existing disk record (written before the kill) survives via the
+//     disk-only branch below, so a TUI crash mid-deletion does not lose the
+//     session; once the daemon removes the record, nothing rewrites it.
 //   - Non-started instances are dropped.
 //   - An in-memory instance whose disk record was removed by another process
 //     AND whose backing session is dead is dropped instead of being
@@ -129,7 +135,7 @@ func mergeInstancesWithDisk(instances []*Instance, diskData []InstanceData, know
 	merged := make([]InstanceData, 0, len(instances)+len(diskData))
 	memTitles := make(map[string]bool, len(instances))
 	for _, instance := range instances {
-		if instance.GetStatus() == Loading {
+		if status := instance.GetStatus(); status == Loading || status == Deleting {
 			continue
 		}
 		if !instance.Started() {

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -499,6 +499,60 @@ func TestRepoSaveDropsLoadingFromMemory(t *testing.T) {
 	assert.Empty(t, result, "Loading instance must not be persisted to disk (#551)")
 }
 
+// TestRepoSaveDropsDeletingFromMemory is the #844 resurrection guard. While
+// an async kill is in flight the TUI's in-memory instance is Deleting and its
+// backing session can still look alive. Once the daemon finishes the teardown
+// and deletes the disk record, a TUI save must NOT re-persist the instance —
+// the "alive but disk-missing" rule (#819) that protects live sessions from
+// external file wipes would otherwise resurrect the killed session's record.
+func TestRepoSaveDropsDeletingFromMemory(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	repoID := config.RepoIDFromRoot(repoPath)
+	ms := newMockStorage()
+
+	// Alive backend + started + empty disk: exactly the shape #819 preserves —
+	// unless the instance is Deleting.
+	deleting := makeAliveInstance("mid-teardown", repoPath)
+	deleting.Status = Deleting
+
+	storage, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+
+	require.NoError(t, storage.SaveInstances([]*Instance{deleting}))
+
+	result := readDisk(t, ms, repoPath)
+	assert.Empty(t, result, "Deleting instance must never be persisted (#844)")
+}
+
+// TestRepoSavePreservesDiskRecordWhileDeleting covers the in-flight window of
+// an async kill: the daemon has not yet deleted the disk record, and a TUI
+// save runs. The record must survive untouched (so a TUI crash mid-deletion
+// loses nothing) and must keep its pre-kill status — Deleting itself is never
+// written to disk.
+func TestRepoSavePreservesDiskRecordWhileDeleting(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	repoID := config.RepoIDFromRoot(repoPath)
+	ms := newMockStorage()
+
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "mid-teardown", Path: repoPath, Status: Running},
+	})
+
+	deleting := makeAliveInstance("mid-teardown", repoPath)
+	deleting.Status = Deleting
+
+	storage, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+
+	require.NoError(t, storage.SaveInstances([]*Instance{deleting}))
+
+	result := readDisk(t, ms, repoPath)
+	require.Len(t, result, 1, "the pre-kill disk record must survive the save")
+	assert.Equal(t, "mid-teardown", result[0].Title)
+	assert.Equal(t, Running, result[0].Status,
+		"the Deleting marker is in-memory only and must not reach disk")
+}
+
 // TestRepoSaveReapsLegacyLoadingGhost verifies that an older binary's
 // orphaned Loading record on disk is reaped on the next TUI save, even
 // when the in-memory state does not include a same-titled instance. The

--- a/ui/list.go
+++ b/ui/list.go
@@ -43,6 +43,10 @@ var autoYesStyle = lipgloss.NewStyle().
 	Background(lipgloss.Color("#dde4f0")).
 	Foreground(lipgloss.Color("#1a1a1a"))
 
+// deletingTitleColor dims a mid-deletion row's title to the description gray
+// so it visually recedes while its teardown runs in the background (#844).
+var deletingTitleColor = lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"}
+
 // InstanceRenderer handles rendering of session.Instance objects
 type InstanceRenderer struct {
 	spinner *spinner.Model
@@ -69,9 +73,10 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	}
 
 	// add spinner next to title if it's running
+	status := i.GetStatus()
 	var join string
-	switch i.GetStatus() {
-	case session.Running, session.Loading:
+	switch status {
+	case session.Running, session.Loading, session.Deleting:
 		join = fmt.Sprintf("%s ", r.spinner.View())
 	case session.Ready:
 		join = readyStyle.Render(readyIcon)
@@ -82,6 +87,12 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	titleText := i.Title
 	if i.IsRemote() {
 		titleText = "[remote] " + titleText
+	}
+	// A deleting row keeps spinning but is explicitly marked and dimmed so it
+	// reads as "going away", not "busy working" (#844).
+	if status == session.Deleting {
+		titleText = "[deleting] " + titleText
+		titleS = titleS.Foreground(deletingTitleColor)
 	}
 	widthAvail := r.width - 3 - runewidth.StringWidth(prefix) - 1
 	if widthAvail <= 0 {

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -569,3 +569,25 @@ func TestInstanceRendererNarrowTerminalPRNoTail(t *testing.T) {
 			terminalW, prLine)
 	}
 }
+
+// TestInstanceRendererDeletingMarker pins the #844 sidebar treatment: a row
+// whose teardown is running in the background must carry an explicit
+// "[deleting]" marker (the spinner alone reads as "busy working").
+func TestInstanceRendererDeletingMarker(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "going-away",
+		Path:    t.TempDir(),
+		Program: "test",
+	})
+	require.NoError(t, err)
+
+	inst.SetStatus(session.Ready)
+	before, _, _ := renderForTerminal(t, 120, inst, &spin)
+	assert.NotContains(t, before, "[deleting]")
+
+	inst.SetStatus(session.Deleting)
+	after, _, _ := renderForTerminal(t, 120, inst, &spin)
+	assert.Contains(t, after, "[deleting]", "deleting rows must be explicitly marked")
+	assert.Contains(t, after, "going-away", "the title must remain visible while deleting")
+}


### PR DESCRIPTION
Fixes #844

## Problem

Sachin: "deletion takes too long on remote instances. Can we make it async and then put the instance in a deletion state of some sort instead of blocking in the kill session ui."

The root cause is in the confirmation plumbing: `confirmAction.OnConfirm` invokes the kill action **synchronously on the bubbletea Update goroutine** (`app/app.go`). That action ran the whole teardown — terminal cleanup plus the blocking `daemon.KillSession` RPC, whose remote `delete_cmd` typically runs over ssh and takes tens of seconds — so the entire TUI froze from the moment the user pressed `y` until the remote teardown finished.

## Design

**New `session.Deleting` status, set synchronously at confirm time.** Confirming a kill now only marks the row Deleting and emits `startKillMsg`; its handler dispatches `killInstanceCmd`, a background `tea.Cmd` (the same async pattern as the #765 create flow) that runs the unchanged teardown — still through `daemon.KillSession`, so the #802 teardown ordering and ghost cleanup are untouched. Local and remote backends share this one code path; local worktree removal can also be slow, so both benefit.

**Visible state.** Deleting rows keep the spinner but get an explicit `[deleting]` marker and a dimmed title (the spinner alone reads as "busy working"). Kill (`D`) and attach (`Enter`) on a Deleting row are no-ops with a brief message.

**Completion.** On success the row is removed from the sidebar (the daemon already deleted the disk record). On failure the row reverts to Ready — so kill is retryable — and the underlying error (e.g. the ssh failure) lands in the error box, per the #797 surface-the-evidence philosophy. No new persistent "errored" enum value: statuses serialize as ints, and a persisted error state would wedge restores; the evidence goes to the errBox + log instead.

**Concurrency safety (the #809/#819 lessons).** Deleting is in-memory-only, treated like Loading everywhere it matters:

- `mergeInstancesWithDisk` never persists a Deleting instance. Without this, the #819 "alive but disk-missing" protection would *resurrect* the record right after the daemon deletes it (the dying remote session can still report alive). While teardown is still in flight, the pre-kill disk record survives via the existing disk-only branch, so a TUI crash mid-deletion loses nothing.
- `instanceCollisionShouldSkip` treats Deleting like Loading (param renamed to `existingTransient`): the 3s external refresh must not swap a Deleting row for a disk-built copy, which would erase the marker and re-enable kill/attach mid-teardown.
- The metadata tick skips Deleting instances (no capture-pane/status shell-outs into a dying session) and writes status through a new CAS-style `SetStatusIfNotDeleting`, closing the check-then-act race where a tick in flight at confirm time could clobber the marker.
- **Title reuse stays blocked without any new reservation mechanism**: the daemon's `Manager.KillSession` keeps the instance in `m.instances` (and its record on disk) until teardown completes, so `findTitleConflictLocked` rejects same-title creates for the whole window. Pinned by a new daemon test.

## Kill-path audit (per the adjacent-call-sites rule)

| Entry point | Behavior |
|---|---|
| TUI `D` (`handleKill`) | **async** (this PR) |
| TUI naming-cancel Esc (`sidebar.KillInstance` on the placeholder) | stays sync — the placeholder has no started session; teardown is a fast no-op |
| CLI `af sessions kill` (`api/sessions.go`) | stays sync — a CLI command should print when the work is done; it shares the same daemon teardown |
| Daemon ghost cleanup / `Manager.KillSession` / `af reset` | stay sync — daemon-side and batch paths, no event loop to block |

## Tests

- `app/kill_async_test.go`: confirm returns immediately with the row Deleting while a channel-blocked fake teardown is still in flight (#817-style guard); success removes the row; failure reverts to Ready, surfaces the cause, and retry re-opens the dialog; `D`/`Enter` no-op on Deleting rows; late `instanceKilledMsg` after the refresh already removed the row; metadata tick leaves Deleting untouched.
- `session/storage_test.go`: a Deleting instance with an alive backend and missing disk record is **not** re-persisted (the resurrection guard); the pre-kill disk record survives a mid-flight save with its pre-kill status.
- `session/instance_test.go`: `SetStatusIfNotDeleting` fence semantics.
- `ui/sidebar_test.go`: `[deleting]` marker renders, title stays visible.
- `daemon/kill_inflight_conflict_test.go`: same-title create is rejected while `KillSession` teardown is in flight and succeeds after it completes.

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `deadcode -test ./...` — all clean
- `go test -race` on `session/...`, `daemon`, and (bounded) `ui/...` + `app` — clean; #802/#815 regression tests stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude