### PR TITLE
fix(app/session): full terminal reset + repaint after remote attach returns (#845)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -813,11 +814,53 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 	return m.handleDefaultKeyPress(msg, name)
 }
 
+// remoteDetachTerminalReassert re-establishes the terminal modes bubbletea
+// set at startup (see Run: WithAltScreen + WithMouseCellMotion, plus the
+// hidden cursor and the bracketed paste bubbletea enables by default) after a
+// remote attach stream has scribbled over them. The hook backend's neutral
+// restore (session.hookAttachTerminalRestore) hands the terminal back on the
+// MAIN screen with the cursor visible and all reporting modes off — correct
+// for the CLI attach path, but not the state this TUI runs in.
+//
+// Hand-rolled rather than bubbletea-native, for two reasons (#845):
+//   - bubbletea cannot re-assert state it believes is already set: the
+//     renderer's enterAltScreen() is a no-op while its altScreenActive
+//     bookkeeping is true, and that bookkeeping never saw the remote PTY's
+//     writes. An ExitAltScreen/EnterAltScreen dance defeats the guard, but
+//     runs as queued program msgs racing the post-detach msg backlog — diff
+//     frames could land on the main screen first, leaking TUI content into
+//     the shell's scrollback.
+//   - Writing synchronously here, while the Update goroutine is still blocked
+//     inside the onDismiss callback, guarantees the terminal is back in the
+//     state the renderer assumes before it can emit a single frame.
+//
+// The renderer's diff cache is still stale after this (it thinks the
+// pre-attach frame is on screen; the 1049h re-entry cleared it), so the
+// caller follows up with tea.ClearScreen — the native lever for "invalidate
+// the cache and repaint everything".
+const remoteDetachTerminalReassert = "" +
+	"\x1b[?1049h" + // re-enter the alt screen (terminal clears it)
+	"\x1b[?25l" + // bubbletea hid the cursor at startup; re-hide it
+	"\x1b[?1002h\x1b[?1006h" + // WithMouseCellMotion + SGR encoding
+	"\x1b[?2004h" // bracketed paste (bubbletea default-on)
+
+// remoteDetachResetWriter is where remoteDetachTerminalReassert is written —
+// the real terminal in production, swappable so tests can capture it.
+var remoteDetachResetWriter io.Writer = os.Stdout
+
 // attachOverlayCallback runs the attach-overlay onDismiss lifecycle: emits
 // the detach-trace markers, invokes attach, arms the attached flag for the
 // duration of `<-ch`, then returns the tea.Cmd to emit the
 // repaintAfterDetachMsg{}. Returns nil when attach itself fails so the
 // callback can be passed directly to showHelpScreen's onDismiss.
+//
+// remote selects the post-detach terminal handling. A local tmux detach
+// leaves the terminal exactly as the TUI expects (the long-lived tmux client
+// never replays its setup/teardown sequences across attach cycles), so the
+// flow is the plain repaint it has always been. A remote detach hands the
+// terminal back in the neutral state described on
+// remoteDetachTerminalReassert, so the TUI's modes are re-asserted before the
+// event loop resumes, and the repaint is preceded by tea.ClearScreen (#845).
 //
 // The defer on m.attached.Store(false) is load-bearing: it guarantees the
 // flag clears even if `<-ch` is woken by an abnormal close or a panic
@@ -830,7 +873,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 // terminal-tab) all funnel through one place — and so the pause-while-attached
 // gating + the flag-clears-on-error path are testable without spinning up
 // real tmux.
-func (m *home) attachOverlayCallback(label, traceSuffix string, attach func() (chan struct{}, error)) tea.Cmd {
+func (m *home) attachOverlayCallback(label, traceSuffix string, remote bool, attach func() (chan struct{}, error)) tea.Cmd {
 	detachTraceMark(label + "-onDismiss-entry" + traceSuffix)
 	ch, err := attach()
 	if err != nil {
@@ -852,10 +895,21 @@ func (m *home) attachOverlayCallback(label, traceSuffix string, attach func() (c
 	// goroutine dump is appended to detach-slow.log so we can see which
 	// goroutine is blocked.
 	beginDetachWatchdog(label + traceSuffix)
-	return func() tea.Msg {
+	repaintCmd := func() tea.Msg {
 		detachTrace(detachStart, label+"-repaintAfterDetachMsg-emitted")
 		return repaintAfterDetachMsg{}
 	}
+	if remote {
+		// The hook backend wrote its neutral restore before closing ch, so
+		// this lands strictly after it. The Update goroutine is still blocked
+		// in this callback, so no renderer write can interleave (#845).
+		_, _ = io.WriteString(remoteDetachResetWriter, remoteDetachTerminalReassert)
+		// ClearScreen first so the renderer's stale diff cache is invalidated
+		// before the repaint flow runs; then the usual repaintAfterDetachMsg
+		// path, watchdog semantics (#683) included.
+		return tea.Sequence(tea.ClearScreen, repaintCmd)
+	}
+	return repaintCmd
 }
 
 // navigateToSection moves the sidebar selection to the header of the given section.

--- a/app/attached_pause_test.go
+++ b/app/attached_pause_test.go
@@ -187,7 +187,7 @@ func TestAttachOverlayCallback_ClearsFlagOnDetach(t *testing.T) {
 
 	done := make(chan tea.Cmd, 1)
 	go func() {
-		done <- h.attachOverlayCallback("test-attach", " title=t1", attach)
+		done <- h.attachOverlayCallback("test-attach", " title=t1", false, attach)
 	}()
 
 	// While the callback is blocked on <-ch the flag must be set.
@@ -224,7 +224,7 @@ func TestAttachOverlayCallback_LeavesFlagAloneWhenAttachErrors(t *testing.T) {
 	attachErr := errors.New("simulated attach failure")
 	attach := func() (chan struct{}, error) { return nil, attachErr }
 
-	cmd := h.attachOverlayCallback("test-attach", "", attach)
+	cmd := h.attachOverlayCallback("test-attach", "", false, attach)
 
 	assert.Nil(t, cmd, "attachOverlayCallback must return nil when attach fails")
 	assert.False(t, h.attached.Load(),

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -232,14 +232,18 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		// callbacks must attach to this captured instance, not re-read the live
 		// selection (#716).
 		if tw.IsInTerminalTab() {
+			// The terminal tab always attaches a local tmux session (remote
+			// instances have no worktree to host one), so remote=false: the
+			// post-detach terminal handling is keyed to what was attached,
+			// not to the instance kind (#845).
 			return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-				return m.attachOverlayCallback("handleEnter-terminal", "", func() (chan struct{}, error) {
+				return m.attachOverlayCallback("handleEnter-terminal", "", false, func() (chan struct{}, error) {
 					return tw.AttachTerminalForInstance(selected)
 				})
 			})
 		}
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-			return m.attachOverlayCallback("handleEnter-sidebar", "", func() (chan struct{}, error) {
+			return m.attachOverlayCallback("handleEnter-sidebar", "", selected.IsRemote(), func() (chan struct{}, error) {
 				return m.sidebar.AttachInstance(selected)
 			})
 		})

--- a/app/remote_detach_reset_test.go
+++ b/app/remote_detach_reset_test.go
@@ -1,0 +1,150 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// swapRemoteDetachResetWriter points the post-remote-detach mode re-assert at
+// a buffer for the duration of a test.
+func swapRemoteDetachResetWriter(t *testing.T, w io.Writer) {
+	t.Helper()
+	prev := remoteDetachResetWriter
+	remoteDetachResetWriter = w
+	t.Cleanup(func() { remoteDetachResetWriter = prev })
+}
+
+// runAttachOverlayCallback drives the blocking attach lifecycle helper off
+// the test goroutine, simulates a detach by closing ch, and returns the
+// post-detach cmd.
+func runAttachOverlayCallback(t *testing.T, h *home, remote bool) tea.Cmd {
+	t.Helper()
+	ch := make(chan struct{})
+	done := make(chan tea.Cmd, 1)
+	go func() {
+		done <- h.attachOverlayCallback("test-attach", "", remote, func() (chan struct{}, error) {
+			return ch, nil
+		})
+	}()
+	require.Eventually(t, func() bool { return h.attached.Load() },
+		time.Second, time.Millisecond, "attached flag must arm before <-ch blocks")
+	close(ch)
+	select {
+	case cmd := <-done:
+		return cmd
+	case <-time.After(2 * time.Second):
+		t.Fatalf("attachOverlayCallback did not return after detach")
+		return nil
+	}
+}
+
+// TestAttachOverlayCallback_RemoteReassertsTerminalModes is the app half of
+// the #845 fix. After a remote attach returns, the hook backend has handed
+// the terminal back in a neutral state (main screen, cursor visible, all
+// reporting modes off — see session.hookAttachTerminalRestore), which is NOT
+// the state this TUI's renderer assumes. The callback must re-assert
+// bubbletea's startup modes synchronously — while the Update goroutine is
+// still blocked here, before the renderer can emit a frame — and then route
+// through tea.ClearScreen + the usual repaintAfterDetachMsg flow so the stale
+// diff cache is invalidated and the screen fully repainted.
+func TestAttachOverlayCallback_RemoteReassertsTerminalModes(t *testing.T) {
+	resetDetachWatchdog(t)
+	h := newTestHome(t)
+
+	var out bytes.Buffer
+	swapRemoteDetachResetWriter(t, &out)
+
+	cmd := runAttachOverlayCallback(t, h, true)
+	require.NotNil(t, cmd)
+
+	// The re-assert was written before the callback returned (i.e. before the
+	// bubbletea event loop could resume), in full.
+	require.Equal(t, remoteDetachTerminalReassert, out.String(),
+		"remote detach must synchronously re-assert the TUI's terminal modes")
+	for _, seq := range []struct{ esc, what string }{
+		{"\x1b[?1049h", "re-enter the alt screen"},
+		{"\x1b[?25l", "re-hide the cursor"},
+		{"\x1b[?1002h", "re-enable cell-motion mouse"},
+		{"\x1b[?1006h", "re-enable SGR mouse encoding"},
+		{"\x1b[?2004h", "re-enable bracketed paste"},
+	} {
+		assert.Contains(t, out.String(), seq.esc,
+			"re-assert must %s — bubbletea set this at startup and cannot "+
+				"re-assert state its renderer believes is already active", seq.what)
+	}
+
+	// The returned cmd is tea.Sequence(tea.ClearScreen, repaint). sequenceMsg
+	// is unexported, so unpack it reflectively: it is a slice of tea.Cmd.
+	msg := cmd()
+	seq := reflect.ValueOf(msg)
+	require.Equal(t, reflect.Slice, seq.Kind(),
+		"remote post-detach cmd must be a tea.Sequence, got %T", msg)
+	require.Equal(t, 2, seq.Len(), "sequence must be exactly ClearScreen + repaint")
+
+	first, ok := seq.Index(0).Interface().(tea.Cmd)
+	require.True(t, ok)
+	assert.Equal(t, tea.ClearScreen(), first(),
+		"first sequenced cmd must be tea.ClearScreen so the renderer's stale "+
+			"diff cache is invalidated before the repaint (#845)")
+
+	second, ok := seq.Index(1).Interface().(tea.Cmd)
+	require.True(t, ok)
+	_, isRepaint := second().(repaintAfterDetachMsg)
+	assert.True(t, isRepaint,
+		"second sequenced cmd must emit repaintAfterDetachMsg — the remote "+
+			"path converges on the same repaint flow (and #683 watchdog "+
+			"semantics) as a local detach")
+
+	require.False(t, h.attached.Load(), "attached flag must clear on the remote path too")
+	endDetachWatchdog()
+}
+
+// TestAttachOverlayCallback_LocalDetachWritesNoReset pins the local flow
+// unchanged: a local tmux detach leaves the terminal exactly as the TUI
+// expects, so no mode bytes are written and the post-detach cmd is the plain
+// repaintAfterDetachMsg emitter (#579/#683 flow) — no ClearScreen flicker.
+func TestAttachOverlayCallback_LocalDetachWritesNoReset(t *testing.T) {
+	resetDetachWatchdog(t)
+	h := newTestHome(t)
+
+	var out bytes.Buffer
+	swapRemoteDetachResetWriter(t, &out)
+
+	cmd := runAttachOverlayCallback(t, h, false)
+	require.NotNil(t, cmd)
+
+	assert.Zero(t, out.Len(),
+		"local detach must not write any terminal reset — the tmux client "+
+			"hands the terminal back untouched")
+	_, isRepaint := cmd().(repaintAfterDetachMsg)
+	assert.True(t, isRepaint,
+		"local post-detach cmd must remain the bare repaintAfterDetachMsg emitter")
+	endDetachWatchdog()
+}
+
+// TestAttachOverlayCallback_NoResetWhenRemoteAttachErrors: when the attach
+// itself fails the terminal was never handed to the remote stream, so
+// re-asserting modes (which re-enters and clears the alt screen) would
+// pointlessly wipe the current frame.
+func TestAttachOverlayCallback_NoResetWhenRemoteAttachErrors(t *testing.T) {
+	h := newTestHome(t)
+
+	var out bytes.Buffer
+	swapRemoteDetachResetWriter(t, &out)
+
+	cmd := h.attachOverlayCallback("test-attach", "", true, func() (chan struct{}, error) {
+		return nil, assert.AnError
+	})
+
+	assert.Nil(t, cmd)
+	assert.Zero(t, out.Len(),
+		"no terminal reset may be written when the attach never started")
+	assert.False(t, h.attached.Load())
+}

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -604,6 +604,44 @@ func ListRemoteHookInstanceData(repoPath string, hooks config.RemoteHooks, now t
 	return imported, nil
 }
 
+// hookAttachTerminalRestore is written to stdout after an interactive
+// attach_cmd stream ends, returning the terminal to the neutral state a
+// well-behaved full-screen program leaves behind on exit: main screen,
+// cursor visible, no scroll region, no mouse/focus/paste reporting.
+//
+// The attach stream is a raw remote PTY copied byte-for-byte to the local
+// terminal, so whatever modes the remote program set (tmux enters the alt
+// screen, sets a scroll region, enables mouse and focus reporting) are set
+// on the local terminal too. On a graceful exit the remote emits its own
+// restore sequences, but the detach key kills the attach_cmd process
+// mid-stream and nothing ever resets those modes — the TUI then repaints
+// into a terminal with a stale scroll region and screen buffer, which is the
+// "messed up UI until I resize" of #845.
+//
+// The restore is deliberately caller-agnostic: this path serves both the TUI
+// (which re-asserts its own bubbletea modes afterwards, see
+// app.attachOverlayCallback) and `af sessions attach` (a plain CLI, for which
+// this neutral state is exactly right). Hand-rolled escapes are the only
+// option here — there is no bubbletea program at this layer.
+//
+// Order matters: reporting modes off first (so nothing new arrives while we
+// restore), then keyboard modes, then geometry, then the buffer switch, and
+// finally cosmetics on the buffer we land on. The scroll region is reset on
+// both sides of the 1049l switch because emulators disagree on whether
+// DECSTBM margins are shared or per-buffer.
+const hookAttachTerminalRestore = "" +
+	"\x1b[?1003l\x1b[?1002l\x1b[?1000l" + // all mouse tracking variants off
+	"\x1b[?1015l\x1b[?1006l\x1b[?1005l" + // all mouse encoding extensions off
+	"\x1b[?1004l" + // focus reporting off
+	"\x1b[?2004l" + // bracketed paste off
+	"\x1b[?1l\x1b>" + // cursor keys and keypad back to normal mode
+	"\x1b[?7h" + // autowrap back on (xterm default)
+	"\x1b[r" + // scroll region = full screen (current buffer)
+	"\x1b[?1049l" + // back to the main screen buffer (no-op if already there)
+	"\x1b[r" + // scroll region again on the main buffer
+	"\x1b[0m" + // SGR attributes reset
+	"\x1b[?25h" // cursor visible
+
 func runHookAttachWithDetach(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.Writer) error {
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
@@ -656,6 +694,13 @@ func runHookAttachWithDetach(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.W
 	err = <-waitDone
 	_ = ptmx.Close()
 	<-copyDone
+
+	// Every byte of the remote stream has been flushed (copyDone), so this
+	// lands strictly after any modes the remote set. Emitted on every exit
+	// path — detach kill, graceful exit, and error exit — because the remote
+	// may have touched the terminal in all three (#845). Best-effort: if
+	// stdout is gone there is no terminal left to restore.
+	_, _ = io.WriteString(stdout, hookAttachTerminalRestore)
 
 	select {
 	case <-detached:

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -1621,6 +1622,121 @@ func TestRunHookAttachWithDetachKey(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatalf("remote attach did not exit after detach key")
 	}
+}
+
+// remoteJunk is what a remote tmux client typically sets on the local
+// terminal through the raw attach stream: alt screen, a scroll region, a
+// hidden cursor, and mouse reporting. Used by the #845 restore tests below.
+const remoteJunk = "\x1b[?1049h\x1b[5;20r\x1b[?25l\x1b[?1002h"
+
+// syncBuffer is a mutex-guarded bytes.Buffer: the PTY→stdout io.Copy
+// goroutine inside runHookAttachWithDetach writes concurrently with the
+// test's readiness polling.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Len()
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestRunHookAttachWithDetach_EmitsTerminalRestoreOnDetachKill is the
+// regression test for #845's worst case: the detach key SIGKILLs attach_cmd
+// mid-stream, so the remote program never gets to emit its own restore
+// sequences and the terminal is stranded with the remote's alt screen,
+// scroll region, and mouse modes. runHookAttachWithDetach must append the
+// neutral restore to stdout after the last remote byte.
+func TestRunHookAttachWithDetach_EmitsTerminalRestoreOnDetachKill(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+
+	var out syncBuffer
+	done := make(chan error, 1)
+	go func() {
+		// printf the junk like a remote tmux client would, then hang like a
+		// live remote session until the detach key kills us.
+		cmd := exec.Command("sh", "-c", `printf '\033[?1049h\033[5;20r\033[?25l\033[?1002h'; sleep 10`)
+		done <- runHookAttachWithDetach(cmd, stdinR, &out, io.Discard)
+	}()
+
+	// Wait until the junk has been copied to stdout so the detach kill is
+	// guaranteed to land mid-stream, after the remote set its modes.
+	require.Eventually(t, func() bool { return out.Len() >= len(remoteJunk) },
+		2*time.Second, 5*time.Millisecond, "remote junk never arrived on stdout")
+
+	_, err := stdinW.Write([]byte{tmux.DetachKeyByte})
+	require.NoError(t, err)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("remote attach did not exit after detach key")
+	}
+
+	got := out.String()
+	assert.Contains(t, got, remoteJunk, "test premise: the remote stream was copied raw")
+	require.True(t, strings.HasSuffix(got, hookAttachTerminalRestore),
+		"stdout must END with the neutral terminal restore so it lands after "+
+			"every remote byte (#845); got tail %q", got[max(0, len(got)-120):])
+}
+
+// TestRunHookAttachWithDetach_EmitsTerminalRestoreOnNaturalExit covers the
+// other half of #845: attach_cmd exits on its own (remote session ended, SSH
+// dropped). Even a graceful remote exit can leave the local terminal on the
+// main screen buffer while the TUI's renderer believes it owns the alt
+// screen, so the restore must be emitted on this path too.
+func TestRunHookAttachWithDetach_EmitsTerminalRestoreOnNaturalExit(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+
+	var out bytes.Buffer
+	cmd := exec.Command("sh", "-c", `printf '\033[?1049h\033[5;20r\033[?25l\033[?1002h'`)
+	err := runHookAttachWithDetach(cmd, stdinR, &out, io.Discard)
+	require.NoError(t, err)
+
+	got := out.String()
+	assert.Contains(t, got, remoteJunk, "test premise: the remote stream was copied raw")
+	require.True(t, strings.HasSuffix(got, hookAttachTerminalRestore),
+		"stdout must end with the neutral terminal restore on natural exit too (#845); got tail %q",
+		got[max(0, len(got)-120):])
+}
+
+// TestRunHookAttachWithDetach_NoRestoreWhenPTYNeverStarted: if pty.Start
+// fails, nothing was ever streamed to the terminal, so writing the restore
+// would clear modes the TUI legitimately has set. The early-error path must
+// leave stdout untouched.
+func TestRunHookAttachWithDetach_NoRestoreWhenPTYNeverStarted(t *testing.T) {
+	var out bytes.Buffer
+	cmd := exec.Command("/nonexistent-binary-for-845-test")
+	err := runHookAttachWithDetach(cmd, strings.NewReader(""), &out, io.Discard)
+	require.Error(t, err)
+	assert.Zero(t, out.Len(),
+		"stdout must be untouched when the attach PTY never started — the "+
+			"terminal was never written to, so there is nothing to restore")
 }
 
 // recordingPtyFactory is a tmux.PtyFactory that records each exec.Cmd passed


### PR DESCRIPTION
Fixes #845

## Problem

Exiting a remote instance left the UI garbled until a window resize. The interactive remote attach (`runHookAttachWithDetach`) copies the remote PTY byte-for-byte to stdout, so every mode the remote program sets — alt screen (`\e[?1049h`), DECSTBM scroll region, hidden cursor, mouse/focus reporting — is set on the local terminal too. Both exit shapes corrupt state:

- **Detach key** kills `attach_cmd` mid-stream, so the remote never emits its restore sequences: the terminal is stranded with the remote's scroll region and modes.
- **Graceful remote exit** emits `\e[?1049l`, dropping the terminal to the *main* screen while bubbletea's renderer still believes it owns the alt screen.

Either way, bubbletea only diff-repaints against stale renderer bookkeeping — its `enterAltScreen()` is a no-op while `altScreenActive` is true, so it never re-asserts the modes the remote clobbered. A resize triggers the renderer's full `repaint()`, which is exactly why resizing "fixed" it.

## Fix (two layers, split by who knows what)

**session (`runHookAttachWithDetach`)** — after the last remote byte is flushed (`<-copyDone`), append a neutral, caller-agnostic terminal restore to stdout on every exit path: all mouse/focus/paste reporting off, cursor keys/keypad/autowrap to defaults, scroll region reset (both sides of the buffer switch — emulators disagree on whether margins are per-buffer), back to the main screen, SGR reset, cursor visible. This is the state a well-behaved full-screen program leaves behind, and it is exactly right for the **CLI** path (`af sessions attach`), which previously suffered the same corruption in a plain shell. Hand-rolled escapes are the only option at this layer — there is no bubbletea program below the TUI.

**app (`attachOverlayCallback`)** — for a remote attach, re-assert the TUI's startup modes (`1049h`, `25l`, `1002h/1006h`, `2004h` — mirroring `WithAltScreen`/`WithMouseCellMotion`/bubbletea's default bracketed paste) **synchronously, while the Update goroutine is still blocked in the onDismiss callback**, then return `tea.Sequence(tea.ClearScreen, repaintAfterDetachMsg)`. Why not bubbletea-native for the re-assert: the renderer cannot re-assert state its bookkeeping says is already set (`enterAltScreen` no-ops), and an Exit/Enter-alt-screen dance runs as queued program msgs racing the post-detach msg backlog — diff frames could land on the main screen first, leaking TUI content into the shell's scrollback. The synchronous write guarantees the terminal is back in the renderer's assumed state before it can emit a single frame; `tea.ClearScreen` is the native lever used for the cache invalidation + full repaint. The flow then converges on the same `repaintAfterDetachMsg` path as local, watchdog semantics (#683) included.

## Adjacent call-site audit (per CLAUDE.md)

Every attach-return path:

- **Local sidebar attach** — the long-lived local tmux client never replays setup/teardown across attach cycles, so the terminal comes back exactly as the TUI expects. Flow unchanged (bare repaint cmd); pinned by `TestAttachOverlayCallback_LocalDetachWritesNoReset` and the untouched #579/#683 tests.
- **Terminal-tab attach** — always a local tmux session (remote instances have no worktree to host one); passes `remote=false`, keyed to *what was attached*, not the instance kind.
- **CLI `af sessions attach`** (`api/sessions.go`) — reaches the same `runHookAttachWithDetach` for remote instances with no bubbletea program after; the neutral restore is precisely its desired end state. Bonus fix for the same corruption class.
- **#843 `terminal_cmd`** — still open/unmerged; no call site exists yet. Flagged for the sibling session: if its attach path streams a raw PTY, it should converge on this same restore.

## Tests

- `TestRunHookAttachWithDetach_EmitsTerminalRestoreOnDetachKill` — fake attach_cmd emits alt-screen/scroll-region/mouse junk, detach key kills it mid-stream; stdout must *end* with the neutral restore (writer seam).
- `TestRunHookAttachWithDetach_EmitsTerminalRestoreOnNaturalExit` — same, for self-exit.
- `TestRunHookAttachWithDetach_NoRestoreWhenPTYNeverStarted` — failed `pty.Start` leaves stdout untouched.
- `TestAttachOverlayCallback_RemoteReassertsTerminalModes` — remote detach writes the full mode re-assert before the callback returns, and the returned cmd is exactly `Sequence(ClearScreen, repaintAfterDetachMsg)`.
- `TestAttachOverlayCallback_LocalDetachWritesNoReset`, `TestAttachOverlayCallback_NoResetWhenRemoteAttachErrors` — local flow and the failed-attach path write nothing.

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `deadcode -test ./...` all clean.
- `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/... ./app/...` and `go test -race ./session/ -run TestRunHookAttach` clean.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)