### PR TITLE
fix(ui): dim the branch/PR line on deleting rows (#853)

### DIFF
--- a/ui/list.go
+++ b/ui/list.go
@@ -43,8 +43,9 @@ var autoYesStyle = lipgloss.NewStyle().
 	Background(lipgloss.Color("#dde4f0")).
 	Foreground(lipgloss.Color("#1a1a1a"))
 
-// deletingTitleColor dims a mid-deletion row's title to the description gray
-// so it visually recedes while its teardown runs in the background (#844).
+// deletingTitleColor dims a mid-deletion row — title and branch/PR lines —
+// to the description gray so it visually recedes while its teardown runs in
+// the background (#844, #853).
 var deletingTitleColor = lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"}
 
 // InstanceRenderer handles rendering of session.Instance objects
@@ -93,6 +94,10 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	if status == session.Deleting {
 		titleText = "[deleting] " + titleText
 		titleS = titleS.Foreground(deletingTitleColor)
+		// Dim the branch/PR lines too: on a selected row descS is the
+		// high-contrast selectedDescStyle, and leaving it bright makes the
+		// secondary lines stand out more than the dimmed title (#853).
+		descS = descS.Foreground(deletingTitleColor)
 	}
 	widthAvail := r.width - 3 - runewidth.StringWidth(prefix) - 1
 	if widthAvail <= 0 {

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -590,4 +591,61 @@ func TestInstanceRendererDeletingMarker(t *testing.T) {
 	after, _, _ := renderForTerminal(t, 120, inst, &spin)
 	assert.Contains(t, after, "[deleting]", "deleting rows must be explicitly marked")
 	assert.Contains(t, after, "going-away", "the title must remain visible while deleting")
+}
+
+// TestInstanceRendererDeletingDimsSelectedRow pins the #853 fix: a SELECTED
+// deleting row must dim its branch and PR lines along with the title. Before
+// the fix only titleS picked up deletingTitleColor, so the high-contrast
+// selectedDescStyle left the secondary lines brighter than the dimmed title.
+// (Unselected rows never showed the bug: listDescStyle is already the same
+// gray as deletingTitleColor.)
+func TestInstanceRendererDeletingDimsSelectedRow(t *testing.T) {
+	// Force a real color profile and a fixed background so lipgloss emits the
+	// foreground escapes the assertions match on; the Ascii profile used by
+	// default in non-TTY test runs strips all styling.
+	prevProfile := lipgloss.ColorProfile()
+	prevDark := lipgloss.HasDarkBackground()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	lipgloss.SetHasDarkBackground(true)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(prevProfile)
+		lipgloss.SetHasDarkBackground(prevDark)
+	})
+
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "going-away",
+		Path:    t.TempDir(),
+		Program: "test",
+	})
+	require.NoError(t, err)
+	inst.SetPRInfo(&git.PRInfo{Number: 7, Title: "teardown", State: "OPEN"})
+
+	// SGR foreground params of the dark-background deleting gray, e.g.
+	// "38;2;119;119;119" under TrueColor.
+	dimFG := termenv.RGBColor(deletingTitleColor.Dark).Sequence(false)
+
+	r := &InstanceRenderer{spinner: &spin}
+	r.setWidth(36)
+
+	renderLines := func() []string {
+		out := r.Render(inst, 1, true, false)
+		lines := strings.Split(out, "\n")
+		// [0] title top padding, [1] title, [2] branch line, [3] branch
+		// bottom padding, [4] PR line, [5] PR bottom padding.
+		require.GreaterOrEqual(t, len(lines), 5, "expected title, branch, and PR rows")
+		return lines
+	}
+
+	inst.SetStatus(session.Ready)
+	before := renderLines()
+	require.NotContains(t, before[1], dimFG, "selected title must not be dimmed before deletion")
+	require.NotContains(t, before[2], dimFG, "selected branch line must not be dimmed before deletion")
+	require.NotContains(t, before[4], dimFG, "selected PR line must not be dimmed before deletion")
+
+	inst.SetStatus(session.Deleting)
+	after := renderLines()
+	assert.Contains(t, after[1], dimFG, "selected deleting title must be dimmed")
+	assert.Contains(t, after[2], dimFG, "selected deleting branch line must be dimmed")
+	assert.Contains(t, after[4], dimFG, "selected deleting PR line must be dimmed")
 }


### PR DESCRIPTION
Fixes #853

## Problem

When a sidebar row is both **selected and deleting**, only the title line picked up the deleting gray (`deletingTitleColor`). The branch line — and the PR line, when present — kept rendering in the high-contrast `selectedDescStyle`, so the secondary lines stood out *brighter* than the dimmed title on a row that's supposed to visually recede. Unselected rows never showed the bug because `listDescStyle` is already the same gray.

## Fix

One line in the `session.Deleting` block of `InstanceRenderer.Render` (`ui/list.go`): dim `descS` with the same `deletingTitleColor` applied to `titleS`, so the whole row recedes together.

## Test

Added `TestInstanceRendererDeletingDimsSelectedRow` as a sibling to `TestInstanceRendererDeletingMarker`. It forces a TrueColor lipgloss profile with a fixed dark background (same pattern as `app/handle_input_test.go`), renders a **selected** row with branch and PR lines, and asserts the deleting-gray SGR foreground appears on all three lines after `SetStatus(Deleting)` — and on none of them before. Confirmed the test fails against the unfixed code.

## Audit

Swept `ui/` for other per-status styling blocks that touch the title style but not the desc style. The `Deleting` block was the only conditional style mutation besides the narrow-width padding block, which already adjusts both styles. The other `session.Deleting` call sites (`app/sync.go`, `app/handle_actions.go`) are behavioral, not styling.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./...` — green
- `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/...` — green

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)