### PR TITLE
fix(config): Rel-based containment so repos rooted at / pass the in-repo path check (#852)

### DIFF
--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -88,6 +88,24 @@ var inRepoGlobalOnlyKeys = map[string]bool{
 	"worktree_root":        true,
 }
 
+// isPathStrictlyInside reports whether absBase is a strict descendant of
+// absDir (absBase != absDir and absBase is not outside absDir). Both
+// arguments must be absolute, cleaned paths. Built on filepath.Rel rather
+// than strings.HasPrefix(path, dir+Separator) because the latter constructs
+// "//" when dir is the filesystem root, rejecting valid children of a repo
+// rooted at "/" (#852). Duplicates session/git.isPathStrictlyInside, which
+// this package cannot import without a cycle.
+func isPathStrictlyInside(absBase, absDir string) bool {
+	rel, err := filepath.Rel(absDir, absBase)
+	if err != nil {
+		return false
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
 // InRepoConfigPath returns the path of the in-repo config file for a repo
 // root. The file is optional; callers should use LoadInRepoConfig rather than
 // reading this path directly so symlink and file-type guards apply.
@@ -132,7 +150,7 @@ func readInRepoConfigFile(repoRoot string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve repo root %s: %w", repoRoot, err)
 	}
-	if !strings.HasPrefix(resolved, filepath.Clean(resolvedRoot)+string(filepath.Separator)) {
+	if !isPathStrictlyInside(resolved, filepath.Clean(resolvedRoot)) {
 		return nil, fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to read it", prettyHomePath(path), prettyHomePath(resolved))
 	}
 
@@ -278,7 +296,7 @@ func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 	// dir symlinked outside the repo must not receive the save. The read
 	// guard alone can't cover this — it only fires when the config file
 	// already exists at the resolved location.
-	if !strings.HasPrefix(resolvedPath, resolveSymlinksForCompare(repoRoot)+string(filepath.Separator)) {
+	if !isPathStrictlyInside(resolvedPath, resolveSymlinksForCompare(repoRoot)) {
 		return fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to save it", prettyHomePath(path), prettyHomePath(resolvedPath))
 	}
 	data, err := readInRepoConfigFile(repoRoot)

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -132,6 +132,35 @@ func TestLoadInRepoConfigMalformed(t *testing.T) {
 	})
 }
 
+// TestIsPathStrictlyInside is the regression test for #852: the previous
+// strings.HasPrefix(path, root+Separator) check built the prefix "//" for a
+// repo rooted at the filesystem root (real in containers with WORKDIR /),
+// rejecting every valid child. The Rel-based helper must accept children of
+// "/" while still rejecting equality, siblings, and traversal escapes.
+func TestIsPathStrictlyInside(t *testing.T) {
+	sep := string(filepath.Separator)
+	cases := []struct {
+		name    string
+		absBase string
+		absDir  string
+		want    bool
+	}{
+		{"child of filesystem root", filepath.Join(sep, ".agent-factory", "config.json"), sep, true},
+		{"filesystem root is not inside itself", sep, sep, false},
+		{"child of normal repo", filepath.Join(sep, "repo", InRepoConfigDirName, "config.json"), filepath.Join(sep, "repo"), true},
+		{"repo root is not inside itself", filepath.Join(sep, "repo"), filepath.Join(sep, "repo"), false},
+		{"sibling sharing a string prefix", filepath.Join(sep, "repo2"), filepath.Join(sep, "repo"), false},
+		{"parent of the repo", sep, filepath.Join(sep, "repo"), false},
+		{"path outside the repo", filepath.Join(sep, "outside", "config.json"), filepath.Join(sep, "repo"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isPathStrictlyInside(tc.absBase, tc.absDir),
+				"isPathStrictlyInside(%q, %q)", tc.absBase, tc.absDir)
+		})
+	}
+}
+
 func TestLoadInRepoConfigTraversalSafety(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 


### PR DESCRIPTION
Fixes #852

## Problem

Both path-containment guards in `config/inrepo.go` (the read guard in `readInRepoConfigFile` and the write guard in `SaveInRepoPostWorktreeCommands`, introduced in #805) built their containment prefix as `root + filepath.Separator`. When the repo root is the filesystem root `"/"` — a real layout in containers with `WORKDIR /` — the prefix becomes `"//"`, so `strings.HasPrefix` rejects every valid child like `/.agent-factory/config.json` and any command that loads in-repo config fails with a spurious "outside the repository" error.

## Fix

Replaced both `HasPrefix` checks with a `filepath.Rel`-based `isPathStrictlyInside` helper — the same approach `session/git/worktree.go` already uses (added in the earlier fix of this exact bug class). The helper is duplicated into `config` with a cross-reference comment because `session/git` imports `config`, so the reverse import would be a cycle; the helper is 10 lines, so duplication beat introducing a shared package for it.

The new check is behavior-identical for all non-root repo roots: it still rejects equality (root itself), string-prefix siblings (`/repo2` vs `/repo`), and traversal escapes.

## Adjacent-call-site audit

Grepped the tree for other `HasPrefix` containment checks built with `+ Separator`:

- `config/repo_config.go:123` (`repoStateDir`) — correct as is: the parent is always `<configDir>/repos`, which is structurally never `"/"`, and the separator is appended to both sides of the comparison.
- `config/config.go:128` (`prettyHomePath`) — display-only `~` collapsing; a home dir of `"/"` would merely skip the cosmetic substitution and print the absolute path, which is the safe fallback the function already documents.
- `config/config.go:279` — checks whether a text line is an absolute path, not containment.

## Tests

- New `TestIsPathStrictlyInside` table test covering the `#852` case (child of `"/"` accepted), equality, siblings sharing a string prefix, parents, and outside paths — no real `/`-rooted repo needed.
- The #805/#812 traversal and config-home-collision security tests are untouched and stay green.

## Verification

`gofmt -l .`, `go build ./...`, `go test ./...`, `golangci-lint run --timeout=3m --fast`, and `deadcode -test ./...` all clean; `go test -race` green on `config`, `session/git`, and (bounded) `ui`/`app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude