### PR TITLE
fix(config): bound the claude shell probe against pipe-holding children (#856)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -23,6 +25,16 @@ const (
 )
 
 var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|->|^[^/=\s]+\s*=)\s*(.+)`)
+
+// probeWaitDelay bounds how long the claude shell probe's Output() call keeps
+// waiting for stdout/stderr EOF after the probe shell has exited (or the
+// context deadline has killed it). Interactive rc files commonly background
+// processes that inherit the capture pipes; without this bound Output()
+// blocks until those grandchildren exit — the context timeout kills only the
+// shell, not the pipe readers — hanging first-run config generation (#856).
+// It only elapses when something outlives the shell; a normal probe completes
+// its I/O at shell exit and returns instantly.
+const probeWaitDelay = time.Second
 
 // bashTypeOutputRegex matches the bash `type` builtin's output for a
 // PATH-resolved command, e.g. "claude is /usr/local/bin/claude".
@@ -232,7 +244,45 @@ func GetClaudeCommand() (string, error) {
 	// don't let first-run config generation hang on them.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	output, err := exec.CommandContext(ctx, shell, args...).Output()
+	cmd := exec.CommandContext(ctx, shell, args...)
+	// Own process group so the whole probe tree — including processes the rc
+	// file backgrounded with `&` or `disown` — can be signaled together,
+	// mirroring the post-worktree hook runner (#610, #769).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// On the context deadline, SIGKILL the group rather than just the
+		// shell (the default Cancel), so a foreground rc command that is
+		// itself the thing hanging dies along with anything it spawned. A
+		// group already gone (ESRCH) maps to os.ErrProcessDone, which Wait
+		// ignores instead of reporting as a probe failure.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
+	// Bound the post-exit wait: a process backgrounded by the rc file
+	// inherits the stdout/stderr capture pipes, and without a bound Output()
+	// blocks on pipe EOF until that grandchild exits — even after the
+	// context deadline killed the shell (#856).
+	cmd.WaitDelay = probeWaitDelay
+	output, err := cmd.Output()
+	if cmd.Process != nil {
+		// Reap rc-file children that outlived the shell on every exit path —
+		// normal completion or timeout — so the probe never leaks processes
+		// (#769 pattern).
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	if errors.Is(err, exec.ErrWaitDelay) {
+		// The shell itself exited successfully, so the probe's output is
+		// already complete on the pipe; a backgrounded rc-file child merely
+		// held it open past probeWaitDelay. Not a probe failure — parse what
+		// arrived (#676 precedent).
+		log.WarningLog.Printf("claude probe: %s rc file left background processes holding the probe pipes; killed them", shell)
+		err = nil
+	}
 	if err == nil && len(output) > 0 {
 		if path := parseCommandProbeOutput(string(output)); path != "" {
 			return path, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/log"
@@ -42,6 +43,19 @@ func requireBash(t *testing.T) string {
 		t.Skip("bash not available on this system")
 	}
 	return bashPath
+}
+
+// requireSleep skips the test when no sleep binary is on PATH, and returns
+// its absolute path. The #856 regression tests embed it into a .bashrc that
+// runs under a deliberately emptied PATH, where a bare `sleep` would not
+// start and the pipe-holding scenario would silently not be exercised.
+func requireSleep(t *testing.T) string {
+	t.Helper()
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skip("sleep not available on this system")
+	}
+	return sleepPath
 }
 
 // writeGuardedBashrc writes a .bashrc into homeDir that mimics the standard
@@ -130,6 +144,75 @@ func TestGetClaudeCommand(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "/custom/bin/claude --model opus", result)
+	})
+
+	t.Run("returns within bound when rc file backgrounds a pipe-holding child", func(t *testing.T) {
+		// Regression test for #856: a .bashrc that backgrounds a process
+		// inheriting the shell's stdout/stderr leaves the probe's capture
+		// pipes open after the shell exits. Without cmd.WaitDelay, Output()
+		// blocks on pipe EOF until that child exits — past the 5s context
+		// timeout — hanging first-run config generation.
+		if testing.Short() {
+			t.Skip("skipping timeout-bound test in short mode")
+		}
+		bashPath := requireBash(t)
+		sleepPath := requireSleep(t)
+		homeDir := t.TempDir()
+		// Sleep well past the probe's context timeout so the WaitDelay
+		// bound, not the child exiting, is what unblocks the call. The
+		// absolute sleep path matters: the test PATH below is an empty dir,
+		// so a bare `sleep` would silently fail to start and nothing would
+		// hold the pipe. No claude alias and no claude on PATH → the probe
+		// must still fall through to the not-found error instead of hanging.
+		bashrc := "case $- in\n    *i*) ;;\n      *) return;;\nesac\n" +
+			sleepPath + " 30 &\n"
+		require.NoError(t, os.WriteFile(filepath.Join(homeDir, ".bashrc"), []byte(bashrc), 0644))
+
+		t.Setenv("HOME", homeDir)
+		t.Setenv("SHELL", bashPath)
+		t.Setenv("PATH", t.TempDir())
+
+		start := time.Now()
+		result, err := GetClaudeCommand()
+		elapsed := time.Since(start)
+
+		assert.Error(t, err)
+		assert.Equal(t, "", result)
+		// The shell exits immediately, so the probe should return after
+		// probeWaitDelay (1s), not the child's 30s sleep and not even the
+		// 5s context deadline. Allow generous scheduling slack for CI.
+		assert.Less(t, elapsed, 4*time.Second,
+			"probe must not block on a pipe-holding background child (got %v)", elapsed)
+	})
+
+	t.Run("parses alias output produced before a pipe-holding child", func(t *testing.T) {
+		// #856 companion: when the rc file both defines the alias and
+		// backgrounds a pipe-holder, the probe output is complete at shell
+		// exit — exec.ErrWaitDelay must be treated as non-fatal and the
+		// already-produced output parsed (#676 precedent).
+		if testing.Short() {
+			t.Skip("skipping timeout-bound test in short mode")
+		}
+		bashPath := requireBash(t)
+		sleepPath := requireSleep(t)
+		homeDir := t.TempDir()
+		bashrc := "case $- in\n    *i*) ;;\n      *) return;;\nesac\n" +
+			"alias claude='/custom/bin/claude --model opus'\n" +
+			sleepPath + " 30 &\n"
+		require.NoError(t, os.WriteFile(filepath.Join(homeDir, ".bashrc"), []byte(bashrc), 0644))
+
+		t.Setenv("HOME", homeDir)
+		t.Setenv("SHELL", bashPath)
+		t.Setenv("PATH", t.TempDir()) // no claude on PATH — alias is the only source
+
+		start := time.Now()
+		result, err := GetClaudeCommand()
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		assert.Equal(t, "/custom/bin/claude --model opus", result)
+		assert.Less(t, elapsed, 4*time.Second,
+			"probe must surface the alias without waiting for the background child (got %v)", elapsed)
 	})
 
 	t.Run("handles probe output parsing", func(t *testing.T) {


### PR DESCRIPTION
Fixes #856

## Problem

`GetClaudeCommand`'s first-run shell probe (`config/config.go`) ran `exec.CommandContext(ctx, shell, args...).Output()` with a 5s context timeout but **no `cmd.WaitDelay`**. The context cancel kills only the shell process; `Output()` keeps blocking on stdout/stderr pipe EOF. An interactive rc file that backgrounds a process inheriting those fds (ssh-agent, prompt daemons, ...) holds the pipes open after the shell exits, so the probe — and with it first-run default-config generation, i.e. the install path — hung indefinitely. The `exec.LookPath("claude")` fallback was never reached.

This is the same `ErrWaitDelay` failure class already fixed in `session/git/hooks.go` (#769) and `session/backend_hook.go` (#645/#676); the probe added in #785/#688 missed the pattern.

## Fix

Mirror the established pattern:

- **`cmd.WaitDelay = 1s`** bounds the post-exit pipe wait. It starts when the shell exits or the context deadline fires, whichever is first, so the probe now returns within ~1s of shell exit (normal probes are unaffected — their pipes close at exit and `Output()` returns instantly).
- **`Setpgid` + group-killing `cmd.Cancel` + post-`Wait` group kill** reap rc-file children on every exit path (normal completion or timeout), so the probe never leaks processes. `ESRCH` in `Cancel` maps to `os.ErrProcessDone` per the documented contract.
- **`exec.ErrWaitDelay` is non-fatal** (#676 precedent): it is only returned when the shell itself exited successfully, meaning the probe output is already complete on the pipe — parse what arrived instead of discarding a detected alias just because a background child outlived the shell.

## Adjacent-call-site audit (per repo policy)

Swept the tree for `exec.CommandContext(...).Output()/CombinedOutput()` without `WaitDelay`:
- `session/backend_hook.go:566` — already sets `WaitDelay` (#645). ✅
- `session/git/hooks.go` — already uses `WaitDelay` + group kill (#769). ✅
- `config/config.go:235` — this PR. ✅

The remaining plain `exec.Command(...).Output()` sites (git, tmux, systemctl, pgrep, ps) run fast local binaries with no context at all — a different, pre-existing class, not the context-kill-vs-pipe-EOF bug.

## Tests

Two regression tests following the #666 timing-assertion pattern:
- A guarded `.bashrc` that backgrounds a 30s pipe-holding child: `GetClaudeCommand` must return well within the timeout bound. **Verified the test catches the bug**: against the unfixed code it blocks the full 30s; with the fix it returns in 1.0s.
- The same rc file with a `claude` alias defined before the pipe-holder: the alias must still be detected and parsed (`ErrWaitDelay` non-fatal path).

The tests resolve an absolute `sleep` path before emptying `PATH` — with the test's empty `PATH` a bare `sleep` silently fails to start and the scenario wouldn't be exercised.

## Verification

- `golangci-lint run --timeout=3m --fast` ✅
- `gofmt -l .` clean ✅
- `go build ./...` ✅
- `go test ./...` ✅
- `deadcode -test ./...` clean ✅
- `go test -race ./config/ ./session/...` ✅ and bounded `go test -race ./ui/... ./app/...` ✅

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)