### PR TITLE
fix(daemon): wait for shutdown completion before upgrade respawn; guard Reload against duplicate task IDs (#854, #855)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -331,6 +331,42 @@ func RequestShutdown() (ShutdownResult, error) {
 	return ShutdownViaRPC, nil
 }
 
+// shutdownCompleteGrace bounds how long WaitForShutdownCompletion polls for
+// the control socket to stop answering; shutdownCompletePoll is the cadence.
+// Package vars rather than constants so tests can shorten the timeout path,
+// mirroring stopDaemonGrace/stopDaemonPoll. The grace matches
+// sigtermFallbackGrace — the wait signalAndWait already imposes on the
+// SIGTERM path. The poll is tighter than sigtermFallbackPoll because the
+// normal RPC teardown completes just past shutdownAckGrace (50ms), so a 50ms
+// cadence usually resolves the wait on its first or second check.
+var (
+	shutdownCompleteGrace = sigtermFallbackGrace
+	shutdownCompletePoll  = shutdownAckGrace
+)
+
+// WaitForShutdownCompletion blocks until the daemon control socket stops
+// answering pings, bounded by shutdownCompleteGrace. The Shutdown RPC
+// acknowledges before the daemon tears down (shutdownAckGrace plus the
+// teardown tail), so a caller that respawns immediately after RequestShutdown
+// races the dying daemon: EnsureDaemon's liveness ping — or a unit-restarted
+// daemon's startup ping guard — can see the old socket still answering, skip
+// the spawn, and leave nothing running once the old daemon exits (#854).
+// Callers on the shutdown-then-respawn path must wait for this to return
+// before respawning. It mirrors signalAndWait's poll-until-dead discipline;
+// on the SIGTERM fallback path the process is already gone, so the first ping
+// fails and the wait returns immediately. Returns an error when the daemon is
+// still answering at the deadline — the caller should warn and proceed.
+func WaitForShutdownCompletion() error {
+	deadline := time.Now().Add(shutdownCompleteGrace)
+	for time.Now().Before(deadline) {
+		if pingDaemon() != nil {
+			return nil
+		}
+		time.Sleep(shutdownCompletePoll)
+	}
+	return fmt.Errorf("daemon control socket still answering %s after shutdown was acknowledged", shutdownCompleteGrace)
+}
+
 // isDaemonAbsentErr reports whether err from a dial/RPC call indicates that
 // no daemon is currently listening on the control socket (vs. some other
 // transport failure). Both ECONNREFUSED (stale socket, no listener) and

--- a/daemon/scheduler.go
+++ b/daemon/scheduler.go
@@ -57,9 +57,10 @@ func (s *taskScheduler) Stop() {
 
 // Reload re-reads tasks.json and replaces the scheduled entry set so it
 // reflects exactly the currently enabled tasks. A task whose cron expression
-// fails to parse is skipped with a warning rather than failing the whole
-// reload — the user-facing CRUD paths validate before saving, so this only
-// guards hand-edited files.
+// fails to parse, or whose ID duplicates one already scheduled in this pass,
+// is skipped with a warning rather than failing the whole reload — the
+// user-facing CRUD paths validate before saving, so this only guards
+// hand-edited files.
 func (s *taskScheduler) Reload() error {
 	tasks, err := s.loadTasks()
 	if err != nil {
@@ -74,6 +75,11 @@ func (s *taskScheduler) Reload() error {
 		delete(s.entries, id)
 	}
 
+	// s.entries is keyed by task ID, so a duplicate ID in a hand-edited
+	// tasks.json would overwrite the first entry ID and orphan its cron entry:
+	// untracked, it keeps firing and no later Reload can remove it until the
+	// daemon restarts (#855). Schedule only the first occurrence.
+	seen := make(map[string]struct{}, len(tasks))
 	for _, t := range tasks {
 		if !t.Enabled {
 			continue
@@ -83,6 +89,11 @@ func (s *taskScheduler) Reload() error {
 		if t.IsWatch() {
 			continue
 		}
+		if _, dup := seen[t.ID]; dup {
+			log.WarningLog.Printf("duplicate task ID %q in tasks.json, scheduling only its first occurrence", t.ID)
+			continue
+		}
+		seen[t.ID] = struct{}{}
 		schedule, err := s.parse(t.CronExpr)
 		if err != nil {
 			log.WarningLog.Printf("task %s has an invalid cron expression %q, not scheduling it: %v", t.ID, t.CronExpr, err)

--- a/daemon/scheduler_test.go
+++ b/daemon/scheduler_test.go
@@ -1,12 +1,16 @@
 package daemon
 
 import (
+	"bytes"
+	stdlog "log"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
 	cron "github.com/robfig/cron/v3"
 
+	aflog "github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/task"
 )
 
@@ -153,5 +157,62 @@ func TestControlServerReloadTasksRPC(t *testing.T) {
 	none := &controlServer{}
 	if err := none.ReloadTasks(ReloadTasksRequest{}, &ReloadTasksResponse{}); err == nil {
 		t.Fatalf("expected error from a control server without a scheduler")
+	}
+}
+
+// TestSchedulerReloadDuplicateTaskIDs pins the #855 fix: a hand-edited
+// tasks.json with duplicate task IDs must produce exactly one schedule per ID
+// with a logged warning. Pre-fix, the second occurrence overwrote the first
+// entry ID in s.entries, leaving an untracked cron entry that kept firing —
+// and because cleanup iterates s.entries, no later Reload could remove it, so
+// correcting the file did not recover without a daemon restart. The
+// s.cron.Entries() counts are the orphan detector: they must match the
+// tracked entry set after every reload.
+func TestSchedulerReloadDuplicateTaskIDs(t *testing.T) {
+	var warnings bytes.Buffer
+	prevWarn := aflog.WarningLog
+	aflog.WarningLog = stdlog.New(&warnings, "", 0)
+	t.Cleanup(func() { aflog.WarningLog = prevWarn })
+
+	s := newTaskScheduler()
+	tasks := []task.Task{
+		{ID: "ffff0001", CronExpr: "0 3 * * *", Enabled: true},
+		{ID: "ffff0001", CronExpr: "*/5 * * * *", Enabled: true},
+		{ID: "ffff0002", CronExpr: "0 4 * * *", Enabled: true},
+	}
+	s.loadTasks = func() ([]task.Task, error) { return tasks, nil }
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload with duplicate IDs: %v", err)
+	}
+	if got := sortedScheduledIDs(s); len(got) != 2 || got[0] != "ffff0001" || got[1] != "ffff0002" {
+		t.Fatalf("scheduled IDs = %v, want [ffff0001 ffff0002]", got)
+	}
+	if got := len(s.cron.Entries()); got != 2 {
+		t.Fatalf("cron entries = %d, want 2 (the duplicate must not schedule a second, untracked entry)", got)
+	}
+	if !strings.Contains(warnings.String(), `duplicate task ID "ffff0001"`) {
+		t.Fatalf("expected a duplicate-ID warning, got log output: %q", warnings.String())
+	}
+
+	// Correcting the file must recover fully without a daemon restart.
+	tasks = []task.Task{{ID: "ffff0002", CronExpr: "0 4 * * *", Enabled: true}}
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload after correction: %v", err)
+	}
+	if got := sortedScheduledIDs(s); len(got) != 1 || got[0] != "ffff0002" {
+		t.Fatalf("after correction: scheduled IDs = %v, want [ffff0002]", got)
+	}
+	if got := len(s.cron.Entries()); got != 1 {
+		t.Fatalf("after correction: cron entries = %d, want 1 (no orphaned entry may survive)", got)
+	}
+
+	// And an empty file leaves nothing behind to keep firing.
+	tasks = nil
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload to empty: %v", err)
+	}
+	if got := len(s.cron.Entries()); got != 0 {
+		t.Fatalf("after removing all tasks: cron entries = %d, want 0", got)
 	}
 }

--- a/daemon/shutdown_wait_test.go
+++ b/daemon/shutdown_wait_test.go
@@ -1,0 +1,123 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests for WaitForShutdownCompletion and the #854 upgrade-respawn race: the
+// Shutdown RPC acks before the daemon tears down, so a respawn that runs
+// immediately can ping the still-alive dying daemon, skip the spawn, and
+// leave nothing running. Every test points AGENT_FACTORY_HOME at a temp dir
+// so the control socket under test is private — the host's real supervised
+// daemon is never pinged, signaled, or spawned.
+
+// TestWaitForShutdownCompletionNoDaemon: with no socket at all (the SIGTERM
+// fallback path, or a daemon that already finished tearing down), the wait
+// must return nil on its first ping rather than burning the grace.
+func TestWaitForShutdownCompletionNoDaemon(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	start := time.Now()
+	if err := WaitForShutdownCompletion(); err != nil {
+		t.Fatalf("WaitForShutdownCompletion with no daemon: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("wait with no daemon took %s, want an immediate return", elapsed)
+	}
+}
+
+// TestUpgradeRespawnWaitsForDelayedTeardown reproduces the #854 race shape
+// end to end: a fake daemon acks the Shutdown RPC but holds its control
+// socket open well past the ack (shutdownAckGrace plus a stretched teardown
+// tail). The shutdown-then-respawn sequence — RequestShutdown, wait, then
+// EnsureDaemon — must end with exactly one spawn. Pre-fix, EnsureDaemon ran
+// without the wait, pinged the still-alive socket, and returned without
+// spawning anything.
+func TestUpgradeRespawnWaitsForDelayedTeardown(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	shutdownCh := make(chan struct{})
+	closeFn, err := startControlServer(nil, nil, nil, shutdownCh)
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	// The dying daemon's teardown tail: after the Shutdown handler closes
+	// shutdownCh (post shutdownAckGrace), keep answering on the socket a
+	// while longer before closing the listener.
+	teardownDone := make(chan struct{})
+	go func() {
+		<-shutdownCh
+		time.Sleep(300 * time.Millisecond)
+		_ = closeFn()
+		close(teardownDone)
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-teardownDone:
+		case <-time.After(5 * time.Second):
+			t.Errorf("fake daemon teardown goroutine never finished")
+		}
+	})
+
+	spawns := 0
+	var newDaemonClose func() error
+	prevLaunch := launchDaemonProcessFn
+	launchDaemonProcessFn = func() error {
+		spawns++
+		// The "new daemon": bind a fresh control server so EnsureDaemon's
+		// readiness poll sees it come up.
+		var bindErr error
+		newDaemonClose, bindErr = startControlServer(nil, nil, nil, nil)
+		return bindErr
+	}
+	t.Cleanup(func() {
+		launchDaemonProcessFn = prevLaunch
+		if newDaemonClose != nil {
+			_ = newDaemonClose()
+		}
+	})
+
+	result, err := RequestShutdown()
+	if err != nil {
+		t.Fatalf("RequestShutdown: %v", err)
+	}
+	if result != ShutdownViaRPC {
+		t.Fatalf("shutdown result = %v, want ShutdownViaRPC", result)
+	}
+
+	if err := WaitForShutdownCompletion(); err != nil {
+		t.Fatalf("WaitForShutdownCompletion: %v", err)
+	}
+	if pingDaemon() == nil {
+		t.Fatalf("old daemon still answering after WaitForShutdownCompletion returned")
+	}
+
+	if err := EnsureDaemon(); err != nil {
+		t.Fatalf("EnsureDaemon after the wait: %v", err)
+	}
+	if spawns != 1 {
+		t.Fatalf("daemon spawns = %d, want 1 — the respawn must spawn a new daemon after the old socket dies, not skip against the dying one (#854)", spawns)
+	}
+}
+
+// TestWaitForShutdownCompletionTimesOut: a daemon that never stops answering
+// (wedged teardown) must produce an error at the grace deadline so the caller
+// can warn — not hang forever or silently report success.
+func TestWaitForShutdownCompletionTimesOut(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	closeFn, err := startControlServer(nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	t.Cleanup(func() { _ = closeFn() })
+
+	prevGrace := shutdownCompleteGrace
+	shutdownCompleteGrace = 250 * time.Millisecond
+	t.Cleanup(func() { shutdownCompleteGrace = prevGrace })
+
+	if err := WaitForShutdownCompletion(); err == nil {
+		t.Fatalf("expected a timeout error while the daemon socket keeps answering")
+	}
+}

--- a/daemoncmd.go
+++ b/daemoncmd.go
@@ -77,9 +77,10 @@ var respawnDaemonFn = respawnDaemonAfterUpgrade
 // branch ran without touching the real systemctl/launchctl or spawning a
 // daemon process.
 var (
-	autostartInstalledFn   = daemon.AutostartInstalled
-	restartAutostartUnitFn = daemon.RestartAutostartUnit
-	ensureDaemonFn         = daemon.EnsureDaemon
+	autostartInstalledFn        = daemon.AutostartInstalled
+	restartAutostartUnitFn      = daemon.RestartAutostartUnit
+	ensureDaemonFn              = daemon.EnsureDaemon
+	waitForShutdownCompletionFn = daemon.WaitForShutdownCompletion
 )
 
 // respawnDaemonAfterUpgrade restores the daemon that the upgrade/auto-update
@@ -99,6 +100,18 @@ var (
 // task gate belongs only on the cold-start path (ensureDaemonForTasks), where
 // nothing was running and "no enabled tasks" means there is nothing to start.
 func respawnDaemonAfterUpgrade() {
+	// The Shutdown RPC acks before the daemon tears down, so the old daemon's
+	// control socket can still answer pings here. Respawning into that window
+	// makes EnsureDaemon — or the unit-restarted daemon's own startup ping
+	// guard — mistake the dying daemon for a live one and skip the spawn,
+	// leaving no daemon at all once it exits (#854). Wait for the socket to
+	// die first; the SIGTERM fallback already waited for process exit, so the
+	// wait returns immediately on that path. On timeout, warn and respawn
+	// anyway: a spawn skipped against a wedged daemon is no worse than not
+	// trying, and the next af invocation retries.
+	if err := waitForShutdownCompletionFn(); err != nil {
+		log.WarningLog.Printf("post-upgrade respawn: %v; respawning anyway, but the new daemon may see the old one as alive and exit — run af again if schedules stay dark", err)
+	}
 	if autostartInstalledFn() {
 		err := restartAutostartUnitFn()
 		if err == nil {

--- a/daemoncmd_test.go
+++ b/daemoncmd_test.go
@@ -11,17 +11,22 @@ import (
 // supervised daemon may be running on the machine executing these tests.
 
 // stubRespawnCollaborators replaces the autostart-detection, unit-restart,
-// and ad-hoc-spawn hooks used by respawnDaemonAfterUpgrade, restoring them on
-// cleanup. It returns counters for the restart and ad-hoc paths.
+// ad-hoc-spawn, and shutdown-wait hooks used by respawnDaemonAfterUpgrade,
+// restoring them on cleanup. The shutdown wait is stubbed to an immediate nil
+// so no test here pings the host's control socket — a real supervised daemon
+// answering it would stall the wait for its full grace. It returns counters
+// for the restart and ad-hoc paths.
 func stubRespawnCollaborators(t *testing.T, installed bool, restartErr error) (restartCalls, ensureCalls *int) {
 	t.Helper()
 	prevInstalled := autostartInstalledFn
 	prevRestart := restartAutostartUnitFn
 	prevEnsure := ensureDaemonFn
+	prevWait := waitForShutdownCompletionFn
 	t.Cleanup(func() {
 		autostartInstalledFn = prevInstalled
 		restartAutostartUnitFn = prevRestart
 		ensureDaemonFn = prevEnsure
+		waitForShutdownCompletionFn = prevWait
 	})
 	restartCalls = new(int)
 	ensureCalls = new(int)
@@ -34,6 +39,7 @@ func stubRespawnCollaborators(t *testing.T, installed bool, restartErr error) (r
 		*ensureCalls++
 		return nil
 	}
+	waitForShutdownCompletionFn = func() error { return nil }
 	return restartCalls, ensureCalls
 }
 
@@ -100,5 +106,49 @@ func TestRespawnAfterUpgradeSpawnsWithZeroEnabledTasks(t *testing.T) {
 
 	if *ensureCalls != 1 {
 		t.Fatalf("ad-hoc spawns = %d, want 1 even with zero enabled tasks (autoyes-only daemon must be restored, #813)", *ensureCalls)
+	}
+}
+
+// TestRespawnAfterUpgradeWaitsForShutdownFirst pins the #854 fix: the Shutdown
+// RPC acks before the old daemon tears down, so the respawn must wait for the
+// control socket to die before EITHER respawn branch runs — otherwise the new
+// daemon (ad-hoc EnsureDaemon ping or the unit-restarted daemon's startup ping
+// guard) sees the dying daemon as alive, skips the spawn, and nothing is left
+// running once it exits. Both branches are exercised; a wait timeout must
+// degrade to a respawn attempt, never a skipped one.
+func TestRespawnAfterUpgradeWaitsForShutdownFirst(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		installed bool
+		waitErr   error
+		wantStep  string
+	}{
+		{name: "ad-hoc branch", installed: false, wantStep: "ensure"},
+		{name: "unit branch", installed: true, wantStep: "restart"},
+		{name: "wait timeout still respawns", installed: false, waitErr: errors.New("daemon control socket still answering"), wantStep: "ensure"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stubRespawnCollaborators(t, tc.installed, nil)
+			var seq []string
+			waitForShutdownCompletionFn = func() error {
+				seq = append(seq, "wait")
+				return tc.waitErr
+			}
+			prevRestart, prevEnsure := restartAutostartUnitFn, ensureDaemonFn
+			restartAutostartUnitFn = func() error {
+				seq = append(seq, "restart")
+				return prevRestart()
+			}
+			ensureDaemonFn = func() error {
+				seq = append(seq, "ensure")
+				return prevEnsure()
+			}
+
+			respawnDaemonAfterUpgrade()
+
+			if len(seq) != 2 || seq[0] != "wait" || seq[1] != tc.wantStep {
+				t.Fatalf("call sequence = %v, want [wait %s]", seq, tc.wantStep)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #854
Fixes #855

Two daemon bugs from the Detail Bot reports, fixed together since both sit in the daemon lifecycle/scheduling layer.

## #854 — upgrade respawn races the asynchronous Shutdown RPC

The Shutdown RPC deliberately acks before teardown (`shutdownAckGrace`, 50ms, so the response can flush before the listener closes), but `runUpgrade`/`autoUpdate` invoked the respawn immediately after `RequestShutdown` returned. In that window `EnsureDaemon`'s liveness ping — or, on the unit branch, the restarted daemon's own startup ping guard — saw the dying daemon's socket still answering, skipped the spawn, and once the old daemon exited nothing was running. That regressed the #813/#828 guarantee that an upgrade always leaves a daemon behind (ad-hoc users lost task schedules and autoyes until the next `af` invocation).

**Fix:** new `daemon.WaitForShutdownCompletion()` polls `pingDaemon()` until the control socket stops answering, bounded by the same 5s grace `signalAndWait` already imposes on the SIGTERM fallback path (which is why that path never had this bug — it waits for process exit). The wait runs at the top of `respawnDaemonAfterUpgrade`, the shared shutdown-then-respawn path, so both `af upgrade` and the background auto-update get it, and it covers **both** respawn branches (unit restart and ad-hoc `EnsureDaemon`). On timeout it logs a clear warning and respawns anyway — a spawn attempt against a wedged daemon is no worse than not trying.

## #855 — Reload leaks cron entries on duplicate task IDs

`taskScheduler.Reload` keys `s.entries` by task ID. A hand-edited `tasks.json` with a duplicate ID made the second `Schedule` call overwrite the first `EntryID`, orphaning that cron entry: untracked, it kept firing, and because Reload's cleanup iterates `s.entries`, **no subsequent reload could remove it** — only a daemon restart. The function's doc explicitly promises to guard hand-edited files (it already skips invalid cron expressions).

**Fix:** a `seen`-map guard mirrors the watcher supervisor's defensive ID validation — duplicates are skipped with a warning, only the first occurrence is scheduled, and correcting the file recovers fully via the normal `ReloadTasks` RPC.

## Audit of adjacent sites

- **Shutdown-then-respawn callers:** `upgrade.go` and `autoupdate.go` are the only two, and both funnel through `respawnDaemonFn` → `respawnDaemonAfterUpgrade`, so the single wait covers everything. The other stop-then-start sequences (`InstallAutostart` on both OSes, `EnsureDaemon`'s stale-daemon stop) use `StopDaemon()`, which already polls for process exit synchronously before returning — no async-ack race there.
- **Scheduler entry-map writes:** `Reload` is the only writer of `s.entries`. The watcher supervisor's `s.watchers` map cannot orphan resources on duplicate IDs because its desired-set is itself a map (one watcher per ID, reconciled against the live set).

## Tests

- `TestUpgradeRespawnWaitsForDelayedTeardown`: end-to-end race shape — a fake in-process daemon acks Shutdown but holds its socket open 300ms past the ack; asserts `EnsureDaemon` spawns exactly once **after** the wait. Verified the test guards real behavior: without the wait, the same setup reproduces 0 spawns (the bug).
- `TestWaitForShutdownCompletionNoDaemon` / `TestWaitForShutdownCompletionTimesOut`: immediate return on the already-dead path; bounded error (not a hang) against a never-dying socket.
- `TestRespawnAfterUpgradeWaitsForShutdownFirst`: pins wait-before-respawn ordering on both branches, and that a wait timeout still respawns.
- `TestSchedulerReloadDuplicateTaskIDs`: duplicate IDs → one schedule + warning logged, `cron.Entries()` count proves no untracked entry exists, and a corrected reload cleans up fully without restart.

All tests are hermetic: every control socket lives under a temp `AGENT_FACTORY_HOME`, daemon spawns are stubbed, and the host's real supervised daemon is never pinged, signaled, or spawned.

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `deadcode -test ./...` — all clean
- `go test -race ./daemon/ .` and bounded `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/... ./app/...` — all pass

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)