### PR TITLE
fix(app): apply PR-info updates by title to survive async-refresh instance swaps (#862)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -308,14 +308,30 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(tickUpdatePRInfoCmd, fetchPRInfoCmd(selected, true))
 	case prInfoUpdatedMsg:
 		detachTraceMark("prInfoUpdatedMsg-handler-entry")
+		// msg.instance is the pointer captured when the async gh fetch kicked
+		// off. A background refresh can swap it out of the sidebar while the
+		// fetch is in flight — RemoveInstanceByTitle + a rebuilt
+		// FromInstanceData pointer (#765) — orphaning it. Writing the result to
+		// that orphan loses the update from the UI and from persisted state.
+		// Re-resolve the live instance by title (mirroring the #808 fix to
+		// instanceStartedMsg) so the update lands on whatever instance now
+		// represents this session. If the session is gone entirely, drop the
+		// stale fetch result (#862).
+		target := msg.instance
+		if !m.sidebar.ContainsInstance(target) {
+			target = m.sidebar.GetInstanceByTitle(msg.instance.Title)
+		}
+		if target == nil {
+			return m, nil
+		}
 		if msg.err != nil {
 			log.WarningLog.Printf("PR info fetch failed for %q: %v", msg.instance.Title, msg.err)
 			// Mark as fetched anyway so we don't thrash retries on every
 			// selection change when the network is unreachable.
-			msg.instance.MarkPRInfoFetched()
+			target.MarkPRInfoFetched()
 			return m, nil
 		}
-		msg.instance.SetPRInfo(msg.info)
+		target.SetPRInfo(msg.info)
 		saveStart := time.Now()
 		if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
 			log.WarningLog.Printf("failed to save instances after PR update: %v", err)

--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -321,6 +321,85 @@ func TestFetchPRInfoCmd_Force_StillRunsWhileFetchInFlight(t *testing.T) {
 		"force=true must bypass the kickoff-debounce the previous call set")
 }
 
+// ----------------------------------------------------------------------------
+// Regression tests for issue #862 (sachiniyer/agent-factory):
+// "PR info updates can be lost when an instance is swapped during async
+// refresh". Same race class as #777/#808: refreshExternalInstances swaps a
+// sidebar instance (RemoveInstanceByTitle + a rebuilt FromInstanceData pointer,
+// #765) while a PR fetch is in flight, orphaning the pointer the
+// prInfoUpdatedMsg handler captured at kickoff.
+// ----------------------------------------------------------------------------
+
+// TestPrInfoUpdatedMsg_InstanceSwappedDuringFetch_AppliesToLiveInstance — the
+// captured instance is swapped out for a fresh same-title copy while the fetch
+// is in flight. The completed update must land on the live sidebar instance,
+// not the orphan.
+func TestPrInfoUpdatedMsg_InstanceSwappedDuringFetch_AppliesToLiveInstance(t *testing.T) {
+	h := newTestHome(t)
+
+	orphan := newStartedInstance(t, "swapped")
+	h.sidebar.AddInstance(orphan)
+	h.sidebar.SetSelectedInstance(0)
+
+	// Simulate the #765 swap: remove the captured instance and add a fresh
+	// same-title copy (as FromInstanceData would build).
+	live := newStartedInstance(t, "swapped")
+	h.sidebar.RemoveInstanceByTitle("swapped")
+	h.sidebar.AddInstance(live)
+	require.NotSame(t, orphan, live, "sanity: swap must produce a distinct pointer")
+
+	info := &git.PRInfo{Number: 42, Title: "add feature", URL: "https://x/42", State: "OPEN"}
+	_, _ = h.Update(prInfoUpdatedMsg{instance: orphan, info: info})
+
+	got := live.GetPRInfo()
+	require.NotNil(t, got, "PR info must be applied to the live sidebar instance")
+	assert.Equal(t, 42, got.Number)
+	assert.Nil(t, orphan.GetPRInfo(), "the orphaned pointer must not receive the update")
+}
+
+// TestPrInfoUpdatedMsg_InstanceGoneDuringFetch_DropsUpdate — the session was
+// killed (no same-title replacement) while the fetch was in flight. The handler
+// must drop the stale result without panicking or resurrecting state.
+func TestPrInfoUpdatedMsg_InstanceGoneDuringFetch_DropsUpdate(t *testing.T) {
+	h := newTestHome(t)
+
+	orphan := newStartedInstance(t, "gone")
+	h.sidebar.AddInstance(orphan)
+	h.sidebar.SetSelectedInstance(0)
+	h.sidebar.RemoveInstanceByTitle("gone")
+
+	info := &git.PRInfo{Number: 7, Title: "lost", State: "OPEN"}
+	_, cmd := h.Update(prInfoUpdatedMsg{instance: orphan, info: info})
+
+	assert.Nil(t, cmd)
+	assert.Nil(t, orphan.GetPRInfo(),
+		"an update for a session no longer in the sidebar must be dropped")
+}
+
+// TestPrInfoUpdatedMsg_Error_SwappedDuringFetch_MarksLiveInstance — the error
+// path must also re-resolve by title: MarkPRInfoFetched should debounce the
+// live instance, not the orphan.
+func TestPrInfoUpdatedMsg_Error_SwappedDuringFetch_MarksLiveInstance(t *testing.T) {
+	h := newTestHome(t)
+
+	orphan := newStartedInstance(t, "swapped")
+	h.sidebar.AddInstance(orphan)
+	h.sidebar.SetSelectedInstance(0)
+
+	live := newStartedInstance(t, "swapped")
+	h.sidebar.RemoveInstanceByTitle("swapped")
+	h.sidebar.AddInstance(live)
+	require.Greater(t, live.PRInfoAge(), 365*24*time.Hour,
+		"precondition: live instance is never-fetched")
+
+	_, _ = h.Update(prInfoUpdatedMsg{instance: orphan, err: errors.New("gh timeout")})
+
+	assert.Less(t, live.PRInfoAge(), time.Second,
+		"the live instance must be marked fetched to debounce retries")
+	assert.Greater(t, orphan.PRInfoAge(), 365*24*time.Hour,
+		"the orphaned pointer must be left untouched")
+}
+
 // sanity: exercise config.DefaultConfig / AppState wiring so a compile
 // regression in newTestHome stays within this package.
 func TestNewTestHome_BuildsSuccessfully(t *testing.T) {

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -439,6 +439,22 @@ func (s *Sidebar) ReplaceInstanceByTitle(title string, replacement *session.Inst
 	return false
 }
 
+// GetInstanceByTitle returns the sidebar instance carrying the given title, or
+// nil when none matches. Async handlers that captured an *Instance pointer
+// before awaiting a background fetch use this to re-resolve the live instance:
+// a background sync may have removed the captured instance and rebuilt a fresh
+// same-title copy via FromInstanceData while the fetch was in flight (#765),
+// orphaning the original pointer. Re-resolving by title lands the update on the
+// instance that currently represents the session (#862).
+func (s *Sidebar) GetInstanceByTitle(title string) *session.Instance {
+	for _, inst := range s.instances {
+		if inst.Title == title {
+			return inst
+		}
+	}
+	return nil
+}
+
 // GetInstances returns all instances. The returned slice shares the sidebar's
 // backing array, so callers must only read it on the bubbletea event loop —
 // never hand it to a goroutine that outlives the call (see


### PR DESCRIPTION
## Problem

`prInfoUpdatedMsg` wrote the completed PR-info fetch to the `*Instance` pointer captured at fetch kickoff, with **none** of the swap protection #808 added to `instanceStartedMsg`. A background `refreshExternalInstances` tick can swap that instance out of the sidebar while the `gh` fetch is in flight — `RemoveInstanceByTitle` + a rebuilt `FromInstanceData` pointer (the #765 swap path) — orphaning the captured pointer. The handler then wrote `SetPRInfo`/`MarkPRInfoFetched` to an instance no longer in `m.sidebar`, so the update was lost from both the UI and persisted state.

Same regression class as #777 / #808.

## Fix

`app/app.go` `prInfoUpdatedMsg` now re-resolves the live instance **by title** when the captured pointer is no longer in the sidebar, mirroring the #808 pattern:

- If `ContainsInstance(msg.instance)` → apply to it (unchanged fast path).
- Else look it up via the new `Sidebar.GetInstanceByTitle` helper → apply to the live same-title instance.
- If the session is gone entirely (`nil`) → drop the stale result.

The error path (`MarkPRInfoFetched`) re-resolves identically, so retry debouncing also lands on the live instance.

## Adjacent-call-site audit (per CLAUDE.md)

Every async handler that touches an `*Instance` across an await:

- `instanceStartedMsg` — already re-resolves by title (#808).
- `prInfoUpdatedMsg` — **fixed here**; was the only handler persisting durable state to a captured pointer across a network await.
- metadata tick (`runMetadataTickCmd`) — mutates a snapshot off-loop via mutex-guarded status setters; a mid-tick swap only loses a cosmetic `Running`/`Ready` write that is re-derived from a fresh snapshot on the next 500ms tick. Self-healing.
- `refreshPanesCmd` — reads capture-pane into the panes' own mutex-guarded buffers; `panesRefreshedMsg` carries no payload and writes nothing back to the instance. A mid-capture swap shows stale preview for ~100ms until the next preview tick re-resolves the selection. Self-healing.

## Tests

Added to `app/pr_info_test.go`:

- `TestPrInfoUpdatedMsg_InstanceSwappedDuringFetch_AppliesToLiveInstance` — swap mid-fetch → live instance gets the PR info, orphan does not.
- `TestPrInfoUpdatedMsg_InstanceGoneDuringFetch_DropsUpdate` — session killed mid-fetch → update dropped, no panic.
- `TestPrInfoUpdatedMsg_Error_SwappedDuringFetch_MarksLiveInstance` — error path re-resolves; live instance debounced, orphan untouched.

Existing happy-path/error tests cover the unchanged (non-swap) flow.

## Gates

`go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `go test ./app/ ./ui/`, and a bounded `-race` run all pass locally.

Fixes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude