### PR TITLE
fix(config): recover from empty/partial config files instead of wedging startup (#864)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -339,12 +339,16 @@ func parseCommandProbeOutput(output string) string {
 // Error handling distinguishes "no config yet" from "config present but
 // unusable" so a user whose settings are being ignored gets told why instead
 // of silently inheriting defaults (#734):
-//   - File does not exist → DefaultConfig() is materialized and saved, with no
-//     error. This is the first-run path and must keep working.
-//   - File exists but cannot be read (permission denied, disk error), is empty,
-//     or fails to parse → an error naming the file and the underlying cause is
-//     returned. Defaults are NOT substituted, since doing so would hide the
-//     user's broken config behind a working-looking app.
+//   - File does not exist, or exists but is zero-byte → DefaultConfig() is
+//     materialized and saved, with no error. This is the first-run path and
+//     must keep working. An empty file is never a valid config; it is the
+//     fingerprint of a failed/partial first-run write (#864, a regression of
+//     #838), so the stub is removed and defaults regenerated rather than
+//     wedging every future startup.
+//   - File exists but cannot be read (permission denied, disk error), or is
+//     non-empty yet fails to parse → an error naming the file and the
+//     underlying cause is returned. Defaults are NOT substituted, since doing
+//     so would hide the user's broken config behind a working-looking app.
 //   - File parses but fails enum validation → an actionable migration error is
 //     returned (there is no implicit migration from legacy "path with flags"
 //     values; the user must rewrite their config).
@@ -366,6 +370,20 @@ func LoadConfig() (*Config, error) {
 		}
 
 		return nil, fmt.Errorf("failed to read config file %s: %w", prettyConfigPath, err)
+	}
+
+	// A zero-byte config.json is never something a user wrote on purpose: it is
+	// the fingerprint of a config write that created the file (O_EXCL) but died
+	// before its JSON body landed (#864, a regression of #838). Treat it like a
+	// missing file — drop the stub and re-materialize defaults — instead of
+	// wedging every future startup on the #758 "config is empty" hard error.
+	// Non-empty-but-corrupt files still fall through to parseConfig's loud
+	// error, since those may carry a user's salvageable settings (#734/#758).
+	if len(data) == 0 {
+		if rmErr := os.Remove(configPath); rmErr != nil && !os.IsNotExist(rmErr) {
+			return nil, fmt.Errorf("failed to remove empty config file %s: %w", prettyConfigPath, rmErr)
+		}
+		return materializeDefaultConfig(configDir, configPath, prettyConfigPath)
 	}
 
 	return parseConfig(data, prettyConfigPath)
@@ -423,6 +441,13 @@ func configDirInitialized(configDir string) bool {
 	return err == nil
 }
 
+// writeConfigForceFailForTest, when non-nil, replaces the f.Write call in
+// writeConfigIfMissing with the returned error. Tests use it to exercise the
+// "write failed after O_EXCL created the file" path and assert the zero-byte
+// stub is cleaned up (#864) — a failure the real os.File.Write cannot be
+// induced to produce deterministically.
+var writeConfigForceFailForTest func() error
+
 // writeConfigIfMissing persists config to configPath with O_CREATE|O_EXCL
 // semantics. Returns created=false (and no error) when the file already
 // exists, so a concurrently recreated config is never overwritten.
@@ -442,9 +467,22 @@ func writeConfigIfMissing(configPath string, config *Config) (bool, error) {
 		}
 		return false, fmt.Errorf("failed to create config file: %w", err)
 	}
-	if _, err := f.Write(data); err != nil {
+	writeErr := func() error {
+		if writeConfigForceFailForTest != nil {
+			return writeConfigForceFailForTest()
+		}
+		_, err := f.Write(data)
+		return err
+	}()
+	if writeErr != nil {
 		_ = f.Close()
-		return true, fmt.Errorf("failed to write config file: %w", err)
+		// Remove the freshly created stub so a failed write never leaves a
+		// zero-byte (or partial) config.json behind to wedge the next startup
+		// (#864). Only the write path cleans up: a Close error means the bytes
+		// already reached the file, so it may be a complete config worth
+		// keeping rather than discarding.
+		_ = os.Remove(configPath)
+		return true, fmt.Errorf("failed to write config file: %w", writeErr)
 	}
 	if err := f.Close(); err != nil {
 		return true, fmt.Errorf("failed to close config file: %w", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -758,8 +758,13 @@ func TestLoadConfig(t *testing.T) {
 		assert.Contains(t, err.Error(), ConfigFileName)
 	})
 
-	t.Run("surfaces error on empty config file", func(t *testing.T) {
+	t.Run("re-materializes defaults from an empty config file (#864)", func(t *testing.T) {
+		// An empty config.json is the fingerprint of a failed first-run write,
+		// not a user's settings. It must NOT wedge startup with the #758
+		// "config is empty" hard error; instead the stub is dropped and
+		// defaults regenerated so the next run parses cleanly.
 		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+		fastShell(t)
 		configDir, err := GetConfigDir()
 		require.NoError(t, err)
 		require.NoError(t, os.MkdirAll(configDir, 0755))
@@ -768,10 +773,15 @@ func TestLoadConfig(t *testing.T) {
 		require.NoError(t, os.WriteFile(configPath, []byte(``), 0644))
 
 		cfg, err := LoadConfig()
-		require.Error(t, err)
-		assert.Nil(t, cfg)
-		assert.Contains(t, err.Error(), "empty")
-		assert.Contains(t, err.Error(), ConfigFileName)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, defaultProgram, cfg.DefaultProgram)
+
+		// The empty stub must be replaced by a real, non-empty config so a
+		// subsequent startup does not hit the empty-file path again.
+		data, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		assert.NotEmpty(t, data, "the empty stub must be regenerated, not left in place")
 	})
 
 	t.Run("surfaces error when config file is unreadable", func(t *testing.T) {

--- a/config/materialize_test.go
+++ b/config/materialize_test.go
@@ -104,6 +104,52 @@ func TestLoadConfig_MaterializeLosesRaceToConcurrentWrite(t *testing.T) {
 	assert.JSONEq(t, concurrent, string(data), "the concurrent file must not be clobbered by defaults")
 }
 
+func TestWriteConfigIfMissing_RemovesStubOnWriteFailure(t *testing.T) {
+	// Regression for #864: when the O_EXCL create succeeds but the write fails,
+	// writeConfigIfMissing must not leave a zero-byte config.json behind —
+	// otherwise the next LoadConfig sees a present-but-empty file and hard-errors.
+	home := t.TempDir()
+	configPath := filepath.Join(home, ConfigFileName)
+
+	writeConfigForceFailForTest = func() error {
+		return assert.AnError
+	}
+	t.Cleanup(func() { writeConfigForceFailForTest = nil })
+
+	created, err := writeConfigIfMissing(configPath, &Config{DefaultProgram: "claude"})
+	require.Error(t, err, "a failed write must surface an error")
+	assert.True(t, created, "the file was created (O_EXCL) before the write failed")
+	assert.Contains(t, err.Error(), "failed to write config file")
+
+	_, statErr := os.Stat(configPath)
+	assert.True(t, os.IsNotExist(statErr), "the zero-byte stub must be removed so the next run can retry")
+}
+
+func TestLoadConfig_RecoversAfterFailedFirstRunWrite(t *testing.T) {
+	// End-to-end #864: a failed first-run write leaves an empty config.json;
+	// the NEXT startup must recover (re-materialize defaults), not wedge.
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	fastShell(t)
+	configPath := filepath.Join(home, ConfigFileName)
+
+	// Reproduce the bug state directly: O_EXCL created the file, then the write
+	// failed before defense-in-depth cleanup existed, leaving a 0-byte stub.
+	require.NoError(t, os.WriteFile(configPath, []byte(``), 0644))
+	info, err := os.Stat(configPath)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), info.Size(), "precondition: empty stub on disk")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err, "the empty stub must not wedge startup")
+	require.NotNil(t, cfg)
+	assert.Equal(t, defaultProgram, cfg.DefaultProgram)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data, "defaults must be re-materialized to a non-empty file")
+}
+
 func TestWriteConfigIfMissing_RefusesExistingFile(t *testing.T) {
 	home := t.TempDir()
 	configPath := filepath.Join(home, ConfigFileName)


### PR DESCRIPTION
## Problem

A failed first-run config write left a zero-byte `config.json` on disk that **wedged every subsequent startup** — install-path data loss. Regression of #838.

`writeConfigIfMissing` creates the file with `O_CREATE|O_EXCL` (race-safe), then writes the JSON body. If `f.Write` failed, it closed the handle and returned an error **without removing the file**, leaving a 0-byte stub. The next `LoadConfig` saw a present-but-empty file and took the #758 `"config file ... is empty; delete it"` hard-error path instead of regenerating defaults. First run "succeeds" with a warning; the second run fails hard until the user manually deletes the file.

## Fix (both directions)

1. **`writeConfigIfMissing` cleans up on write failure** — `os.Remove(configPath)` after a failed `f.Write`, so no zero-byte stub is left to block retries. Only the write path cleans up: a `Close` error means the bytes already landed, so the file may be a complete config worth keeping.
2. **`LoadConfig` treats a zero-byte `config.json` as first-run** — drops the stub and re-materializes defaults rather than hard-erroring. An empty file is never a valid config. Non-empty-but-corrupt files still get the loud #758/#734 parse error, since those may carry a user's salvageable settings.

## Reconciliation with #837

An empty config on an **already-initialized** dir still fires the loud settings-loss `ERROR` via `materializeDefaultConfig` (it *is* a loss), while a genuine fresh first run stays silent. The #837 materialize tripwire tests remain green.

## Adjacent-call-site audit (per CLAUDE.md)

- `AtomicWriteFile` (used by `saveConfig`, `state.go`, `repo_config.go`, `inrepo.go`, `resolve.go`) — temp+rename with temp cleanup on error; never leaves an empty/partial file visible. Safe.
- `writeConfigIfMissing` — the only direct `O_EXCL` writer; fixed here.
- `inrepo.go` empty-file hard error — in-repo config is user-authored and written atomically, never produced by a failed materialize, so its loud error stays correct (justified exclusion).

## Tests

- `TestWriteConfigIfMissing_RemovesStubOnWriteFailure` — failed write leaves no stub (via a test seam mirroring `materializeRaceHookForTest`).
- `TestLoadConfig_RecoversAfterFailedFirstRunWrite` — end-to-end: empty stub → next startup re-materializes, does not wedge.
- `re-materializes defaults from an empty config file (#864)` — replaces the old empty→hard-error expectation.
- `surfaces parse error on invalid JSON` (#758) — unchanged, still green: non-empty corrupt files error loudly.

## Verification

`go build ./...`, `gofmt -l`, `golangci-lint run --fast`, `deadcode -test ./...`, `go test ./...`, and `go test -race ./config/` all clean.

Fixes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)