### PR TITLE
fix(storage): surface unreadable/corrupted instances so reset cleans up and the daemon does not hide sessions (#868, #869)

### DIFF
--- a/config/state.go
+++ b/config/state.go
@@ -28,7 +28,17 @@ type InstanceStorage interface {
 	// then overwrite, disk state they failed to read (#766).
 	GetInstances(repoID string) (json.RawMessage, error)
 	// GetAllInstances returns instance data for all repos, keyed by repo ID.
-	GetAllInstances() map[string]json.RawMessage
+	//
+	// A missing instances directory yields an empty map with a nil error so
+	// first-run callers proceed normally. A genuine failure to read the
+	// instances directory (permission denied, I/O error) is PROPAGATED rather
+	// than masked as an empty map: callers like `af reset` and the daemon must
+	// distinguish "no sessions exist" from "sessions exist but are unreadable"
+	// so they don't skip worktree cleanup or silently hide live sessions
+	// (#868). This mirrors GetInstances' single-repo error propagation (#766).
+	// Per-repo files that individually fail to read are skipped-and-warned by
+	// LoadAllRepoInstances, so they never surface as an error here.
+	GetAllInstances() (map[string]json.RawMessage, error)
 	// DeleteAllInstances removes all stored instances across all repos.
 	DeleteAllInstances() error
 }
@@ -267,13 +277,14 @@ func (s *State) GetInstances(repoID string) (json.RawMessage, error) {
 	return LoadRepoInstances(repoID)
 }
 
-func (s *State) GetAllInstances() map[string]json.RawMessage {
-	data, err := LoadAllRepoInstances()
-	if err != nil {
-		log.ErrorLog.Printf("failed to load all repo instances: %v", err)
-		return make(map[string]json.RawMessage)
-	}
-	return data
+func (s *State) GetAllInstances() (map[string]json.RawMessage, error) {
+	// LoadAllRepoInstances already distinguishes "first run" (instances dir
+	// missing -> empty map, nil) from a genuine directory read error, and
+	// skips-and-warns per-repo files it cannot read. Surface its result
+	// verbatim: swallowing the error as an empty map is what let reset skip
+	// worktree cleanup and the daemon hide unreadable-but-present sessions
+	// (#868).
+	return LoadAllRepoInstances()
 }
 
 func (s *State) DeleteAllInstances() error {

--- a/session/storage.go
+++ b/session/storage.go
@@ -295,8 +295,15 @@ func (s *Storage) LoadInstances() ([]*Instance, error) {
 		}
 		allJSON = map[string]json.RawMessage{s.repoID: raw}
 	} else {
-		// Daemon mode: load all repos
-		allJSON = s.state.GetAllInstances()
+		// Daemon mode: load all repos. Surface a directory-level read error so
+		// the daemon reports "couldn't read your sessions" instead of silently
+		// presenting an empty list that looks like a fresh install while live
+		// sessions sit unreadable on disk (#868).
+		all, err := s.state.GetAllInstances()
+		if err != nil {
+			return nil, err
+		}
+		allJSON = all
 	}
 
 	var instances []*Instance
@@ -405,14 +412,27 @@ func (s *Storage) DeleteAllInstances() error {
 // skipped. Callers should treat the result as best-effort.
 func (s *Storage) CollectRepoRoots() (map[string]struct{}, error) {
 	roots := make(map[string]struct{})
-	allJSON := s.state.GetAllInstances()
-	for _, jsonData := range allJSON {
+	// A directory-level read failure (permission denied, I/O error) is
+	// surfaced so `af reset` aborts with a clear message instead of treating
+	// an unreadable instances directory as "no sessions" and silently
+	// skipping worktree cleanup for every repo (#868). A missing directory
+	// (first run) still comes back as an empty map with a nil error.
+	allJSON, err := s.state.GetAllInstances()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stored instances: %w", err)
+	}
+	for repoID, jsonData := range allJSON {
 		if jsonData == nil || string(jsonData) == "[]" || string(jsonData) == "null" {
 			continue
 		}
 		var instancesData []InstanceData
 		if err := json.Unmarshal(jsonData, &instancesData); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal instances: %w", err)
+			// One repo's corrupted instances.json must not abort the whole
+			// reset: skip-and-warn (naming the repo) and continue collecting
+			// roots for the others, matching the daemon's per-repo recovery.
+			// Reset is exactly when corruption recovery is needed (#869).
+			log.WarningLog.Printf("skipping repo %s: corrupted instances.json: %v", repoID, err)
+			continue
 		}
 		for _, data := range instancesData {
 			// Prefer the worktree's repo path; fall back to the

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -20,6 +20,9 @@ type mockInstanceStorage struct {
 	// readErr, when non-nil, makes GetInstances fail to simulate a transient
 	// read failure (permission denied, I/O error) on instances.json.
 	readErr error
+	// readAllErr, when non-nil, makes GetAllInstances fail to simulate an
+	// unreadable instances directory (permission denied, I/O error).
+	readAllErr error
 }
 
 func newMockStorage() *mockInstanceStorage {
@@ -42,14 +45,17 @@ func (m *mockInstanceStorage) GetInstances(repoID string) (json.RawMessage, erro
 	return m.data[repoID], nil
 }
 
-func (m *mockInstanceStorage) GetAllInstances() map[string]json.RawMessage {
+func (m *mockInstanceStorage) GetAllInstances() (map[string]json.RawMessage, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.readAllErr != nil {
+		return nil, m.readAllErr
+	}
 	out := make(map[string]json.RawMessage, len(m.data))
 	for k, v := range m.data {
 		out[k] = v
 	}
-	return out
+	return out, nil
 }
 
 func (m *mockInstanceStorage) DeleteAllInstances() error {
@@ -651,7 +657,8 @@ func TestDaemonSaveUsesResolvedRepoPathForSymlinkedRepo(t *testing.T) {
 	symlinkID := config.RepoIDFromRoot(symlinkPath)
 	require.NotEqual(t, resolvedID, symlinkID, "test fixture: paths must hash to distinct IDs")
 
-	all := ms.GetAllInstances()
+	all, err := ms.GetAllInstances()
+	require.NoError(t, err)
 	_, hasResolved := all[resolvedID]
 	_, hasSymlink := all[symlinkID]
 	assert.True(t, hasResolved, "instance must be saved under the resolved repo ID")
@@ -755,6 +762,67 @@ func TestCollectRepoRootsSkipsEmpty(t *testing.T) {
 	assert.Contains(t, roots, repoA)
 	_, hasEmpty := roots[""]
 	assert.False(t, hasEmpty, "empty repo root should be skipped")
+}
+
+// TestCollectRepoRootsSurfacesUnreadableDir verifies that an unreadable
+// instances directory is surfaced as an error rather than masquerading as
+// "no sessions". Before #868, GetAllInstances swallowed the directory read
+// error into an empty map, so `af reset` would skip worktree cleanup for
+// every repo and leave orphaned worktrees behind.
+func TestCollectRepoRootsSurfacesUnreadableDir(t *testing.T) {
+	ms := newMockStorage()
+	// Seed a repo so a silent-empty result would be observably wrong.
+	seedDisk(t, ms, "/tmp/repo-a", []InstanceData{
+		{Title: "a1", Path: "/tmp/repo-a", Worktree: GitWorktreeData{RepoPath: "/tmp/repo-a"}},
+	})
+	ms.readAllErr = errors.New("permission denied")
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	roots, err := storage.CollectRepoRoots()
+	require.Error(t, err, "an unreadable instances directory must surface an error")
+	assert.Nil(t, roots, "no roots should be returned when the directory is unreadable")
+}
+
+// TestCollectRepoRootsSkipsCorruptedRepo verifies that one repo's corrupted
+// instances.json does not abort the whole reset: CollectRepoRoots skips the
+// corrupted repo (with a warning) and still returns the roots for the others,
+// so `af reset` can clean up every other repo (#869).
+func TestCollectRepoRootsSkipsCorruptedRepo(t *testing.T) {
+	const repoA = "/tmp/repo-a"
+	const repoBad = "/tmp/repo-bad"
+	ms := newMockStorage()
+
+	seedDisk(t, ms, repoA, []InstanceData{
+		{Title: "a1", Path: repoA, Worktree: GitWorktreeData{RepoPath: repoA}},
+	})
+	// Corrupt the second repo's stored JSON.
+	ms.data[config.RepoIDFromRoot(repoBad)] = json.RawMessage(`{ this is not valid json`)
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	roots, err := storage.CollectRepoRoots()
+	require.NoError(t, err, "a single corrupted repo must not abort root collection")
+	assert.Len(t, roots, 1, "the healthy repo's root should still be collected")
+	assert.Contains(t, roots, repoA)
+}
+
+// TestLoadInstancesDaemonSurfacesUnreadableDir verifies that daemon-mode
+// LoadInstances (repoID == "") surfaces an unreadable instances directory as
+// an error rather than presenting an empty session list that looks like a
+// fresh install while live sessions sit unreadable on disk (#868).
+func TestLoadInstancesDaemonSurfacesUnreadableDir(t *testing.T) {
+	ms := newMockStorage()
+	ms.readAllErr = errors.New("permission denied")
+
+	storage, err := NewStorage(ms, "")
+	require.NoError(t, err)
+
+	instances, err := storage.LoadInstances()
+	require.Error(t, err, "the daemon must not hide an unreadable instances directory")
+	assert.Nil(t, instances)
 }
 
 // --- Issue #808: instances.json held byte-identical duplicate records -----


### PR DESCRIPTION
## Summary

Two coupled storage-aggregation bugs that both stem from collapsing "unreadable/corrupted" into "no sessions":

- **#868** — `GetAllInstances()` swallowed directory read errors into an empty map. An unreadable instances directory (permission denied, I/O error) looked identical to a fresh install, so `af reset` skipped worktree cleanup for **every** repo (orphaning worktrees) and the daemon presented an **empty session list** while live sessions sat unreadable on disk.
- **#869** — `CollectRepoRoots()` aborted the **entire** `af reset` on the first repo whose `instances.json` failed to unmarshal, blocking recovery exactly when corruption made a reset necessary.

These are coupled: the #868 signature change forces touching the #869 call site, so both are aligned on **skip-and-warn-with-repoID** for per-repo corruption while a directory-level read failure is surfaced.

## Changes

- `config/state.go`: `InstanceStorage.GetAllInstances()` now returns `(map[string]json.RawMessage, error)`, mirroring `GetInstances`' #766 error propagation. `LoadAllRepoInstances` already distinguishes first-run (missing dir → empty map, nil) from a genuine directory read error and already skips-and-warns individually unreadable per-repo files, so only a true **directory-level** failure surfaces.
- `session/storage.go`:
  - `CollectRepoRoots()` surfaces the directory-level error so `af reset` aborts with a clear message instead of doing a silent partial reset, but **skips-and-warns a single corrupted `instances.json` by repo ID** and continues — best-effort reset cleans every healthy repo (#869), matching the daemon's per-repo recovery in `daemon.go`.
  - Daemon-mode `LoadInstances()` surfaces the directory error instead of hiding sessions (#868).

## Behavior matrix

| Condition | Before | After |
| --- | --- | --- |
| Instances dir missing (first run) | empty map | empty map (unchanged) |
| Instances dir unreadable | silent empty → partial reset / empty daemon list | error surfaced → reset aborts clearly, daemon reports failure |
| One repo's `instances.json` corrupted | whole `af reset` aborts | that repo skipped+warned by ID, others cleaned |
| One per-repo file unreadable | already skipped+warned (unchanged) | skipped+warned (unchanged) |

## Tests

- `TestCollectRepoRootsSurfacesUnreadableDir` — unreadable directory surfaces an error, no roots returned.
- `TestCollectRepoRootsSkipsCorruptedRepo` — one corrupted `instances.json` is skipped, the healthy repo's root is still collected, no error.
- `TestLoadInstancesDaemonSurfacesUnreadableDir` — daemon does not hide an unreadable directory.
- Existing #730/#766/#808/#667 read-error and aggregation tests stay green.

## Gates

`go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, and `deadcode -test ./...` all clean. `go test ./...` green except the known dev-box flake `TestConcurrentCLIClientsUseDaemonCoordinator` (box contention, unrelated to this diff). Changed-area `-race` clean.

Fixes #868
Fixes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)