### PR TITLE
fix(daemon/watcher): truncate failure status on rune boundaries to keep tasks.json valid UTF-8 (#863)

### DIFF
--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
@@ -66,6 +67,25 @@ const (
 	// the TUI detail row stay readable.
 	watcherStatusSummaryMax = 256
 )
+
+// truncateRunes returns s limited to at most maxBytes bytes, cut on a UTF-8
+// rune boundary so the result is always valid UTF-8. Slicing a string by a
+// raw byte index can split a multi-byte rune, and encoding/json persists the
+// half rune as U+FFFD ("�"), corrupting non-ASCII failure diagnostics in
+// tasks.json (#863, a regression of #797/#799). Callers append any ellipsis
+// themselves so the cap covers only the retained content.
+func truncateRunes(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	// maxBytes may land inside a rune; back up to the start of that rune so
+	// the cut falls on a boundary and s[:end] holds only whole runes.
+	end := maxBytes
+	for end > 0 && !utf8.RuneStart(s[end]) {
+		end--
+	}
+	return s[:end]
+}
 
 // watcherSupervisor owns the running watch-task processes. Reload reconciles
 // them against tasks.json the same way taskScheduler.Reload reconciles cron
@@ -256,7 +276,7 @@ func (b *tailBuffer) add(line string) {
 		return
 	}
 	if len(line) > watcherTailMaxBytes {
-		line = line[:watcherTailMaxBytes]
+		line = truncateRunes(line, watcherTailMaxBytes)
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -301,7 +321,7 @@ func failureSummary(runErr error, tail *tailBuffer) string {
 		summary += ": " + first
 	}
 	if len(summary) > watcherStatusSummaryMax {
-		summary = summary[:watcherStatusSummaryMax] + "…"
+		summary = truncateRunes(summary, watcherStatusSummaryMax) + "…"
 	}
 	return summary
 }

--- a/daemon/watcher_test.go
+++ b/daemon/watcher_test.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	aflog "github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/task"
@@ -598,6 +599,93 @@ func TestTailBufferCaps(t *testing.T) {
 
 	if empty := (&tailBuffer{}); empty.logSuffix() != "" || empty.firstLine() != "" {
 		t.Fatalf("empty tail must render nothing, got %q / %q", empty.logSuffix(), empty.firstLine())
+	}
+}
+
+// TestTruncateRunesBoundary pins truncateRunes: it never cuts a multi-byte rune
+// in half (so the result is always valid UTF-8 with no U+FFFD), respects the
+// byte cap, and leaves content that already fits untouched.
+func TestTruncateRunesBoundary(t *testing.T) {
+	cases := []struct {
+		name string
+		rune string // a single rune, repeated to overflow the cap
+	}{
+		{"three-byte CJK", "世"},  // 3 bytes; cap not a multiple of 3
+		{"four-byte emoji", "🚀"}, // 4 bytes; cap lands mid-rune
+		{"two-byte latin", "é"},  // 2 bytes
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, cap := range []int{1, 5, 17, 256, 2048} {
+				s := strings.Repeat(tc.rune, cap) // far longer than cap bytes
+				got := truncateRunes(s, cap)
+				if len(got) > cap {
+					t.Fatalf("cap=%d: result %d bytes exceeds cap", cap, len(got))
+				}
+				if !utf8.ValidString(got) {
+					t.Fatalf("cap=%d: result is not valid UTF-8: %q", cap, got)
+				}
+				if strings.ContainsRune(got, utf8.RuneError) {
+					t.Fatalf("cap=%d: result contains U+FFFD: %q", cap, got)
+				}
+				// The retained bytes must be a whole-rune prefix of the input.
+				if !strings.HasPrefix(s, got) || len(got)%len(tc.rune) != 0 {
+					t.Fatalf("cap=%d: result %q is not a whole-rune prefix", cap, got)
+				}
+			}
+		})
+	}
+
+	// Content within the cap is returned verbatim, including the boundary case.
+	for _, s := range []string{"", "ascii ok", "世界", strings.Repeat("x", 256)} {
+		if got := truncateRunes(s, 256); got != s {
+			t.Fatalf("fitting input mutated: %q -> %q", s, got)
+		}
+	}
+}
+
+// TestFailureSummaryUTF8 guards the persisted crash-loop status (#863): a
+// multi-byte error message that overflows watcherStatusSummaryMax is cut on a
+// rune boundary, so tasks.json stores valid UTF-8 (no "�") and the cap still
+// holds once the ellipsis is appended.
+func TestFailureSummaryUTF8(t *testing.T) {
+	b := &tailBuffer{}
+	// A first line of emoji that, combined with the "errored: ..." prefix,
+	// pushes the summary well past the 256-byte cap with the boundary landing
+	// inside a 4-byte rune.
+	b.add(strings.Repeat("🚀", 200))
+	summary := failureSummary(errors.New("exit status 1"), b)
+
+	if !utf8.ValidString(summary) {
+		t.Fatalf("summary is not valid UTF-8: %q", summary)
+	}
+	if strings.ContainsRune(strings.TrimSuffix(summary, "…"), utf8.RuneError) {
+		t.Fatalf("summary contains U+FFFD: %q", summary)
+	}
+	if !strings.HasPrefix(summary, "errored: exit status 1: 🚀") {
+		t.Fatalf("summary lost its prefix: %.40q", summary)
+	}
+	if !strings.HasSuffix(summary, "…") {
+		t.Fatalf("truncated summary missing ellipsis: %.40q...", summary)
+	}
+	if len(summary) > watcherStatusSummaryMax+len("…") {
+		t.Fatalf("summary length %d exceeds cap %d", len(summary), watcherStatusSummaryMax+len("…"))
+	}
+
+	// A short multi-byte message fits and is persisted unchanged.
+	short := &tailBuffer{}
+	short.add("デプロイ失敗")
+	if got := failureSummary(errors.New("exit status 2"), short); got != "errored: exit status 2: デプロイ失敗" {
+		t.Fatalf("short multi-byte summary altered: %q", got)
+	}
+
+	// A multi-byte tail line longer than watcherTailMaxBytes is itself cut on a
+	// rune boundary by tailBuffer.add.
+	big := &tailBuffer{}
+	big.add(strings.Repeat("世", watcherTailMaxBytes)) // 3*2048 bytes in
+	first := big.firstLine()
+	if len(first) > watcherTailMaxBytes || !utf8.ValidString(first) || strings.ContainsRune(first, utf8.RuneError) {
+		t.Fatalf("tail line not rune-truncated: len=%d valid=%v", len(first), utf8.ValidString(first))
 	}
 }
 


### PR DESCRIPTION
## Problem

`failureSummary` and `tailBuffer.add` in `daemon/watcher.go` cap strings by raw byte index — `summary[:watcherStatusSummaryMax]` (256) and `line[:watcherTailMaxBytes]` (2048). Go strings are UTF-8, so a byte-index cut can land in the middle of a multi-byte rune. When the watch-task error output is non-ASCII (CJK, emoji, …) and exceeds the cap, the half rune is invalid UTF-8; `encoding/json` rewrites it as U+FFFD (`�`) when the crash-loop breaker persists `LastRunStatus`, corrupting the diagnostic in `tasks.json` (and every UI surface that reads it).

Regression of #797/#799 (the failure-tail diagnostics feature). Fixes #863.

## Fix

Add a shared `truncateRunes(s string, maxBytes int) string` helper that backs the cut up to the nearest UTF-8 rune boundary (`utf8.RuneStart`), so the result is always valid UTF-8 and never strands a half rune. Applied at **both** cap sites. Callers append their own ellipsis, so the 256-byte summary cap still holds once `…` is added.

## Adjacent call-site audit (per CLAUDE.md)

Grepped the tree for byte-index string truncation of user/script text:

- **`daemon/watcher.go` ×2** — the two sites fixed here. ✅
- `task/cron.go`, `daemon/control.go:1321`, `session/tmux/resume.go:96` — slice at a *found delimiter/index*, not a fixed byte cap; can't split a rune by construction. ✅ no change.
- `config/repo.go`, `config/resolve.go`, `session/tmux/tmux.go` — truncate hex-encoded hashes (ASCII only). ✅ no change.
- `session/backend_hook.go:545`, `ui/content_pane.go:201`, `ui/sidebar.go` — slice `[]string`/line slices, not byte content. ✅ no change.
- `ui/*` user-facing truncation already uses rune-aware `runewidth.Truncate` / `[]rune` slicing. ✅
- `consumeLines`' 64 KB `bufio.ReadSlice` chunk boundary (`maxWatchLineBytes`) **can** split a rune mid-stream, but that feeds the *event prompt*, not `tasks.json`; the persisted/buffered tail re-truncates rune-safely at 2 KB via the now-fixed `tailBuffer.add`. Fixing the stream-chunk boundary requires buffering across `ReadSlice` calls — a separate concern from this `tasks.json` regression, deliberately out of scope.

## Tests

`TestTruncateRunesBoundary` — 2/3/4-byte runes at caps {1,5,17,256,2048}: result is valid UTF-8, contains no U+FFFD, is a whole-rune prefix of the input, and never exceeds the cap; ASCII/short multi-byte input returned verbatim.

`TestFailureSummaryUTF8` — an emoji error message overflowing the 256-byte cap is cut on a rune boundary (valid UTF-8, keeps the `errored:` prefix, ends with `…`, length ≤ cap+`…`); a short CJK message persists unchanged; a 2 KB+ multi-byte tail line is rune-truncated by `tailBuffer.add`.

Existing `TestTailBufferCaps` still passes (ASCII path unaffected).

## Gates

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --fast` clean · `deadcode -test ./...` clean · `go test ./...` green except the known dev-box flake `integration/TestConcurrentCLIClientsUseDaemonCoordinator` (daemon process contention, unrelated — the `daemon` package itself passes fully) · `-race` on the changed daemon tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
