### PR TITLE
fix(api): surface instances.json corruption in send-prompt instead of bare not-found (#861)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -51,6 +52,14 @@ func resolveRepo() (*config.RepoContext, error) {
 	return config.CurrentRepo()
 }
 
+// errTitleNotFound marks a definitive not-found from findInstanceByTitle: the
+// title matched no instance and every repo's instances.json parsed cleanly. A
+// corruption-tainted search returns a different (un-wrapped) error so callers
+// like the send-prompt pre-check can tell "not present anywhere" apart from
+// "may be hidden behind a corrupted instances.json" and surface the latter
+// loudly instead of a misleading bare not-found (#861, follow-up to #730/#752).
+var errTitleNotFound = errors.New("not found")
+
 // findInstanceByTitle scans all repos for an instance matching the given title.
 // Returns the InstanceData and the repoID it belongs to.
 func findInstanceByTitle(title string) (*session.InstanceData, string, error) {
@@ -79,7 +88,9 @@ func findInstanceByTitle(title string) (*session.InstanceData, string, error) {
 	if len(corrupted) > 0 {
 		return nil, "", fmt.Errorf("instance %q not found; %s", title, corruptedReposSuffix(corrupted))
 	}
-	return nil, "", fmt.Errorf("instance %q not found", title)
+	// Wrap the sentinel so a clean miss stays distinguishable from a
+	// corruption-tainted miss (#861); the user-facing text is unchanged.
+	return nil, "", fmt.Errorf("instance %q %w", title, errTitleNotFound)
 }
 
 // corruptedReposSuffix builds a sorted, human-readable clause naming the repos
@@ -167,13 +178,20 @@ func instanceTitleExistsInScope(repoID, title string) (bool, error) {
 	if repoID != "" {
 		return repoHasInstanceTitle(repoID, title)
 	}
-	if _, _, err := findInstanceByTitle(title); err != nil {
-		// findInstanceByTitle errors only on not-found / corruption; treat
-		// either as "not present in scope", matching the prior all-repo
-		// behavior where the pre-check error drove the create-vs-error branch.
+	_, _, err := findInstanceByTitle(title)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, errTitleNotFound) {
+		// Definitive not-found with no corruption: report "not present" so the
+		// caller drives the create-vs-friendly-error branch as before.
 		return false, nil
 	}
-	return true, nil
+	// Corruption (or a load failure): propagate so send-prompt surfaces the
+	// corruption-aware message naming the bad repo instead of a misleading bare
+	// not-found (#861). The session may be hidden behind the unreadable file, so
+	// even --create must not silently make a duplicate.
+	return false, err
 }
 
 // jsonOut marshals v to JSON and writes to stdout.

--- a/api/storage_inconsistency_test.go
+++ b/api/storage_inconsistency_test.go
@@ -135,6 +135,93 @@ func TestFindInstanceByTitle_NamesCorruptedRepoOnNotFound(t *testing.T) {
 	}
 }
 
+// TestInstanceTitleExistsInScope_AllRepoSurfacesCorruption is the regression
+// test for #861: in all-repo mode the send-prompt pre-check must propagate the
+// corruption-aware error from findInstanceByTitle (naming the bad repo) instead
+// of collapsing every miss to (false, nil) and letting the caller emit a bare
+// "not found." Otherwise users never learn a session may be hidden behind a
+// corrupted instances.json.
+func TestInstanceTitleExistsInScope_AllRepoSurfacesCorruption(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	_ = captureWarnings(t)
+
+	corruptedRepoID := "corrupted-repo"
+	if err := config.SaveRepoInstances(corruptedRepoID, json.RawMessage("{not valid json")); err != nil {
+		t.Fatalf("save corrupted repo: %v", err)
+	}
+
+	exists, err := instanceTitleExistsInScope("", "ghost-title")
+	if err == nil {
+		t.Fatalf("expected corruption error in all-repo mode, got nil")
+	}
+	if exists {
+		t.Fatalf("expected exists=false when the title is missing")
+	}
+	if !strings.Contains(err.Error(), corruptedRepoID) {
+		t.Fatalf("expected error to name corrupted repo %q; got: %v", corruptedRepoID, err)
+	}
+}
+
+// TestInstanceTitleExistsInScope_AllRepoCleanNotFound verifies that a clean
+// miss (no corruption anywhere) still reports (false, nil) so the send-prompt
+// caller keeps driving the --create / friendly "not found" branch (#861).
+func TestInstanceTitleExistsInScope_AllRepoCleanNotFound(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	_ = captureWarnings(t)
+
+	validJSON, err := json.Marshal([]session.InstanceData{{Title: "other-session"}})
+	if err != nil {
+		t.Fatalf("marshal valid: %v", err)
+	}
+	if err := config.SaveRepoInstances("valid-repo", validJSON); err != nil {
+		t.Fatalf("save valid repo: %v", err)
+	}
+
+	exists, err := instanceTitleExistsInScope("", "ghost-title")
+	if err != nil {
+		t.Fatalf("clean not-found must not error in all-repo mode; got: %v", err)
+	}
+	if exists {
+		t.Fatalf("expected exists=false for a missing title")
+	}
+}
+
+// TestInstanceTitleExistsInScope_ScopedUnaffectedByCorruption verifies that
+// --repo scoped mode (non-empty repoID) keeps checking only that repo: a clean
+// repo reports presence/absence without being tainted by corruption elsewhere,
+// preserving the #776 scoping behavior (#861).
+func TestInstanceTitleExistsInScope_ScopedUnaffectedByCorruption(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	_ = captureWarnings(t)
+
+	if err := config.SaveRepoInstances("corrupted-repo", json.RawMessage("{not valid json")); err != nil {
+		t.Fatalf("save corrupted repo: %v", err)
+	}
+	validJSON, err := json.Marshal([]session.InstanceData{{Title: "scoped-session"}})
+	if err != nil {
+		t.Fatalf("marshal valid: %v", err)
+	}
+	if err := config.SaveRepoInstances("clean-repo", validJSON); err != nil {
+		t.Fatalf("save clean repo: %v", err)
+	}
+
+	exists, err := instanceTitleExistsInScope("clean-repo", "scoped-session")
+	if err != nil {
+		t.Fatalf("scoped lookup of a clean repo must not error: %v", err)
+	}
+	if !exists {
+		t.Fatalf("expected the scoped title to be found")
+	}
+
+	exists, err = instanceTitleExistsInScope("clean-repo", "ghost-title")
+	if err != nil {
+		t.Fatalf("scoped miss in a clean repo must not error: %v", err)
+	}
+	if exists {
+		t.Fatalf("expected a missing scoped title to report absent")
+	}
+}
+
 // TestFindInstanceByTitle_PositiveLookupNotBlockedByCorruption verifies that a
 // corrupted repo does not prevent a successful lookup of a title that lives in
 // a healthy repo — corruption is warned about, not fatal to findable sessions.


### PR DESCRIPTION
## Problem

`sessions send-prompt` in **all-repo mode** swallowed the corruption-aware error and showed a bare "not found" — a regression of #730/#752.

`instanceTitleExistsInScope` (api/api.go) collapsed *every* `findInstanceByTitle` error to `(false, nil)`, discarding the `"N repo(s) have a corrupted instances.json and may be hiding it: <repo>"` suffix that #752 added for #730. `sessionsSendPromptCmd` then constructed a fresh `"instance %q not found. Use --create..."` message, so users whose `instances.json` was corrupted never learned their session might be hidden behind an unreadable file — and could create a duplicate instead.

Other commands (`get`/`kill`/`attach`/`preview`) call `findInstanceByTitle`/`findLiveInstanceByTitle` directly and already surface the corruption-aware error; only the send-prompt pre-check layer swallowed it.

## Fix

The pre-check can't simply propagate *all* errors — a clean not-found must still fall through to the `--create` / friendly-message branch. So we distinguish the two:

- `findInstanceByTitle` wraps a sentinel (`errTitleNotFound`) on a **definitive** not-found (no repo corrupted). The corruption case keeps its existing un-wrapped, repo-naming error. User-facing text is byte-for-byte unchanged.
- `instanceTitleExistsInScope` returns `(false, nil)` **only** for that sentinel; any other error (corruption, load failure) propagates, so send-prompt surfaces `"instance \"X\" not found; 1 repo(s) have a corrupted instances.json and may be hiding it: <repo>"`.

Even `--create` now refuses to silently make a duplicate when the title may be hidden behind a corrupted file.

## Audit (per CLAUDE.md adjacent-call-sites)

All `api/` callers of `findInstanceByTitle` / `findLiveInstanceByTitle` / `repoHasInstanceTitle` / `loadAllInstancesAggregate` reviewed: every one already surfaces corruption directly. `instanceTitleExistsInScope` was the sole swallower. `--repo` scoped mode (`repoHasInstanceTitle`) is untouched. Diff kept entirely within `api/` to avoid conflicting with the sibling #868 `GetAllInstances` storage-aggregation work.

## Tests

- `TestInstanceTitleExistsInScope_AllRepoSurfacesCorruption` — all-repo mode with a corrupted repo → error names the corrupted repo (not bare not-found).
- `TestInstanceTitleExistsInScope_AllRepoCleanNotFound` — clean miss still reports `(false, nil)` so the `--create`/friendly branch stays reachable.
- `TestInstanceTitleExistsInScope_ScopedUnaffectedByCorruption` — `--repo` scoped mode unaffected by corruption elsewhere.

## Gates

`go build ./...`, `gofmt -l`, `golangci-lint --fast`, `deadcode -test ./...`, `go test ./...` (only the pre-existing dev-box flake `TestConcurrentCLIClientsUseDaemonCoordinator` fails — box contention, unrelated), and `-race` on `./api/...` all green.

Fixes #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude