### PR TITLE
fix(daemon): wait-and-deliver instead of dropping prompts on shared target-session create races (#865)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -27,6 +27,7 @@ var (
 	createSessionViaDaemon = daemon.CreateSession
 	killSessionViaDaemon   = daemon.KillSession
 	sendPromptViaDaemon    = daemon.SendPrompt
+	deliverPromptViaDaemon = daemon.DeliverPrompt
 )
 
 // ghostKillTmuxByName issues a tmux kill-session for a persisted sanitized
@@ -296,16 +297,13 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 			return jsonError(err)
 		}
 
-		exists, err := instanceTitleExistsInScope(repoID, title)
-		if err != nil {
-			return jsonError(err)
-		}
-		if !exists {
-			if !sendPromptCreateFlag {
-				return jsonError(fmt.Errorf("instance %q not found. Use --create to auto-create the session, or run: af sessions create --name %q --prompt <prompt>", title, title))
-			}
-
-			// Auto-create the session
+		// --create routes through the daemon's serialized create-or-send path
+		// so a session that pops into existence concurrently (another
+		// --create, or a task delivering into the same target_session) is
+		// delivered into rather than racing creation and dropping a prompt
+		// (#865). The daemon decides create-vs-send under its per-target lock,
+		// so no existence pre-check is needed here.
+		if sendPromptCreateFlag {
 			repo, repoErr := resolveRepo()
 			if repoErr != nil {
 				return jsonError(fmt.Errorf("--repo is required when using --create: %w", repoErr))
@@ -313,14 +311,6 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 
 			if !git.IsGitRepo(repo.Root) {
 				return jsonError(fmt.Errorf("path %s is not a git repository", repo.Root))
-			}
-
-			exists, err := repoHasInstanceTitle(repo.ID, title)
-			if err != nil {
-				return jsonError(err)
-			}
-			if exists {
-				return jsonError(fmt.Errorf("session with title %q already exists", title))
 			}
 
 			cfg, err := config.ResolveConfig(repo.Root)
@@ -335,17 +325,24 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 				return jsonError(err)
 			}
 
-			_, err = createSessionViaDaemon(daemon.CreateSessionRequest{
+			if _, err := deliverPromptViaDaemon(daemon.DeliverPromptRequest{
 				Title:    title,
 				RepoPath: repo.Root,
 				Program:  program,
 				Prompt:   prompt,
 				AutoYes:  cfg.AutoYes,
-			})
-			if err != nil {
+			}); err != nil {
 				return jsonError(err)
 			}
 			return jsonOut(map[string]bool{"ok": true})
+		}
+
+		exists, err := instanceTitleExistsInScope(repoID, title)
+		if err != nil {
+			return jsonError(err)
+		}
+		if !exists {
+			return jsonError(fmt.Errorf("instance %q not found. Use --create to auto-create the session, or run: af sessions create --name %q --prompt <prompt>", title, title))
 		}
 
 		if err := sendPromptViaDaemon(daemon.SendPromptRequest{Title: title, RepoID: repoID, Prompt: prompt}); err != nil {

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -510,6 +510,77 @@ func TestSessionsSendPrompt_HonorsRepoScoping(t *testing.T) {
 	}
 }
 
+// TestSessionsSendPrompt_CreateRoutesThroughDeliverPrompt pins the
+// adjacent-call-site fix for #865: `af sessions send-prompt --create` must
+// hand the whole create-or-send decision to the daemon's serialized
+// DeliverPrompt path (so a target that pops into existence concurrently is
+// delivered into, not dropped) rather than doing its own check-then-create.
+func TestSessionsSendPrompt_CreateRoutesThroughDeliverPrompt(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoRoot := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoRoot, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoRoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+
+	const title = "captain"
+	const prompt = "triage the new issue"
+
+	prevRepoFlag := repoFlag
+	repoFlag = repoRoot
+	prevCreate := sendPromptCreateFlag
+	sendPromptCreateFlag = true
+	defer func() {
+		repoFlag = prevRepoFlag
+		sendPromptCreateFlag = prevCreate
+	}()
+
+	var gotReq daemon.DeliverPromptRequest
+	called := false
+	prevDeliver := deliverPromptViaDaemon
+	prevSend := sendPromptViaDaemon
+	deliverPromptViaDaemon = func(req daemon.DeliverPromptRequest) (string, error) {
+		gotReq = req
+		called = true
+		return "started", nil
+	}
+	sendPromptViaDaemon = func(req daemon.SendPromptRequest) error {
+		t.Fatalf("--create must not fall back to the plain send path; got %+v", req)
+		return nil
+	}
+	defer func() {
+		deliverPromptViaDaemon = prevDeliver
+		sendPromptViaDaemon = prevSend
+	}()
+
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devnull.Close()
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout = devnull
+	os.Stderr = devnull
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	if err := sessionsSendPromptCmd.RunE(sessionsSendPromptCmd, []string{title, prompt}); err != nil {
+		t.Fatalf("sessionsSendPromptCmd --create returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("--create did not route through DeliverPrompt")
+	}
+	if gotReq.Title != title || gotReq.Prompt != prompt || gotReq.RepoPath != repoRoot {
+		t.Fatalf("unexpected DeliverPrompt request: %+v", gotReq)
+	}
+}
+
 func stubKillSessionDirect() func() {
 	prev := killSessionViaDaemon
 	killSessionViaDaemon = func(req daemon.KillSessionRequest) error {

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -73,6 +73,28 @@ type SendPromptResponse struct {
 	OK bool
 }
 
+// DeliverPromptRequest asks the daemon to deliver a prompt to a target session,
+// auto-creating that session when it does not exist yet. It is the race-safe
+// successor to the deliverTaskPrompt "check existence, then create-or-send"
+// sequence that dropped a prompt whenever two deliveries to the same missing
+// target ran concurrently (#865). RepoPath (not RepoID) is required because a
+// create needs the worktree root; the repo ID is resolved from it.
+type DeliverPromptRequest struct {
+	Title    string
+	RepoPath string
+	Program  string
+	Prompt   string
+	AutoYes  bool
+}
+
+// DeliverPromptResponse reports how the prompt was delivered. Status is
+// "started" when this call created the target session (the prompt was its
+// initial prompt) and "sent" when it was sent into a session that already
+// existed — the same status vocabulary deliverTaskPrompt records on a task.
+type DeliverPromptResponse struct {
+	Status string
+}
+
 type ImportRemoteHookSessionsRequest struct {
 	RepoPath string
 }
@@ -233,6 +255,19 @@ func SendPrompt(req SendPromptRequest) error {
 		return err
 	}
 	return nil
+}
+
+// DeliverPrompt asks the daemon to deliver a prompt to a target session,
+// auto-creating it when missing. It returns the recorded status ("started" or
+// "sent"). Unlike a bare CreateSession-then-SendPrompt from the caller, the
+// whole create-or-send decision runs under the daemon's per-target lock, so
+// concurrent deliveries to the same shared target never drop a prompt (#865).
+func DeliverPrompt(req DeliverPromptRequest) (string, error) {
+	var resp DeliverPromptResponse
+	if err := callDaemon("DeliverPrompt", req, &resp); err != nil {
+		return "", err
+	}
+	return resp.Status, nil
 }
 
 // ReloadTasks asks the daemon to re-read tasks.json and rebuild its cron
@@ -528,6 +563,18 @@ func validateRPCRepoID(repoID string) error {
 	return nil
 }
 
+func (s *controlServer) DeliverPrompt(req DeliverPromptRequest, resp *DeliverPromptResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
+	status, err := s.manager.DeliverPrompt(req)
+	if err != nil {
+		return err
+	}
+	resp.Status = status
+	return nil
+}
+
 func (s *controlServer) ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest, resp *ImportRemoteHookSessionsResponse) error {
 	if err := s.requireManagerReady(); err != nil {
 		return err
@@ -668,6 +715,11 @@ type Manager struct {
 	reservedTitles      map[string]struct{}
 	reservedRemoteNames map[string]struct{}
 	repoStartLocks      map[string]*sync.Mutex
+	// targetLocks serializes DeliverPrompt per (repo, title) so concurrent
+	// deliveries to the same shared target session create it once and deliver
+	// the rest in arrival order instead of racing creation and dropping the
+	// losers' prompts (#865). Lazily populated like repoStartLocks.
+	targetLocks map[string]*sync.Mutex
 }
 
 // NewManager constructs a manager and synchronously restores all persisted
@@ -702,6 +754,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		reservedTitles:      make(map[string]struct{}),
 		reservedRemoteNames: make(map[string]struct{}),
 		repoStartLocks:      make(map[string]*sync.Mutex),
+		targetLocks:         make(map[string]*sync.Mutex),
 	}, nil
 }
 
@@ -1079,6 +1132,156 @@ func (m *Manager) SendPrompt(req SendPromptRequest) error {
 		return fmt.Errorf("failed to send prompt: %w", err)
 	}
 	return nil
+}
+
+// targetDeliverWait bounds how long DeliverPrompt waits for a target session to
+// materialize after losing a creation race to a process outside this daemon
+// (e.g. `af sessions create`); targetDeliverPoll is the retry cadence. The wait
+// only matters on that cross-process path — in-daemon deliveries serialize on
+// the per-target lock and never enter it.
+var (
+	targetDeliverWait = 30 * time.Second
+	targetDeliverPoll = 100 * time.Millisecond
+)
+
+// DeliverPrompt delivers a prompt to a target session, auto-creating that
+// session when it does not exist. The whole create-or-send decision runs under
+// a per-(repo, title) lock, so concurrent deliveries to the same shared target
+// serialize: the first creates the session, the rest send into it in arrival
+// order. This is the fix for #865, where the pre-lock path let two deliveries
+// both observe "missing", both attempt creation, and dropped the loser's prompt
+// when reserveCreate rejected the duplicate. Returns "started" when this call
+// created the session and "sent" when it delivered into an existing one.
+func (m *Manager) DeliverPrompt(req DeliverPromptRequest) (string, error) {
+	if req.Prompt == "" {
+		return "", fmt.Errorf("prompt is required")
+	}
+	if req.RepoPath == "" {
+		return "", fmt.Errorf("repo path is required")
+	}
+	repo, err := config.RepoFromPath(req.RepoPath)
+	if err != nil {
+		return "", err
+	}
+
+	unlock := m.lockTarget(repo.ID, req.Title)
+	defer unlock()
+
+	exists, deleting, err := m.targetSessionState(repo.ID, req.Title)
+	if err != nil {
+		return "", err
+	}
+	if deleting {
+		return "", fmt.Errorf("target session %q is being deleted; prompt not delivered", req.Title)
+	}
+	if exists {
+		if err := m.SendPrompt(SendPromptRequest{Title: req.Title, RepoID: repo.ID, Prompt: req.Prompt}); err != nil {
+			return "", err
+		}
+		return "sent", nil
+	}
+
+	// The session is absent and, because deliveries to this target serialize on
+	// the per-target lock, no other in-daemon delivery is creating it. Create it
+	// now and deliver the prompt as its initial prompt.
+	if _, err := m.CreateSession(CreateSessionRequest{
+		Title:    req.Title,
+		RepoPath: req.RepoPath,
+		Program:  req.Program,
+		Prompt:   req.Prompt,
+		AutoYes:  req.AutoYes,
+	}); err != nil {
+		// A creator outside this daemon (a plain `af sessions create`, the API)
+		// can still claim the title between our check and reserveCreate. Rather
+		// than drop the prompt (#865), wait for the session to materialize and
+		// send into it. Genuine conflicts (branch collisions, config errors)
+		// are not retryable and surface as-is.
+		if isConcurrentCreateErr(err) {
+			if werr := m.waitForTargetSession(repo.ID, req.Title); werr != nil {
+				return "", werr
+			}
+			if serr := m.SendPrompt(SendPromptRequest{Title: req.Title, RepoID: repo.ID, Prompt: req.Prompt}); serr != nil {
+				return "", serr
+			}
+			return "sent", nil
+		}
+		return "", fmt.Errorf("failed to auto-create target session %q: %w", req.Title, err)
+	}
+	return "started", nil
+}
+
+// lockTarget acquires the per-(repo, title) delivery lock, creating it on first
+// use, and returns the unlock function. Mirrors startLockForRepo: the map is
+// guarded by m.mu but the returned mutex is held outside it, so a long-running
+// delivery never blocks unrelated manager operations.
+func (m *Manager) lockTarget(repoID, title string) func() {
+	m.mu.Lock()
+	key := daemonInstanceKey(repoID, title)
+	lock := m.targetLocks[key]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		m.targetLocks[key] = lock
+	}
+	m.mu.Unlock()
+
+	lock.Lock()
+	return lock.Unlock
+}
+
+// targetSessionState reports whether a session with the given title exists for
+// the repo (in memory or persisted) and whether its live instance is mid-
+// teardown. Deleting is transient in-memory state that is never persisted
+// (#844/#847), so only a live in-memory instance can carry it — a disk-only
+// record is treated as a normal existing session.
+func (m *Manager) targetSessionState(repoID, title string) (exists, deleting bool, err error) {
+	m.mu.Lock()
+	if rerr := m.refreshLocked(); rerr != nil {
+		m.mu.Unlock()
+		return false, false, rerr
+	}
+	inst := m.instances[daemonInstanceKey(repoID, title)]
+	m.mu.Unlock()
+	if inst != nil {
+		return true, inst.GetStatus() == session.Deleting, nil
+	}
+
+	exists, err = repoHasSessionTitle(repoID, title)
+	return exists, false, err
+}
+
+// waitForTargetSession blocks until the target session exists, surfacing a
+// Deleting session rather than delivering into it, bounded by targetDeliverWait.
+func (m *Manager) waitForTargetSession(repoID, title string) error {
+	deadline := time.Now().Add(targetDeliverWait)
+	for {
+		exists, deleting, err := m.targetSessionState(repoID, title)
+		if err != nil {
+			return err
+		}
+		if deleting {
+			return fmt.Errorf("target session %q is being deleted; prompt not delivered", title)
+		}
+		if exists {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("timed out waiting for target session %q to be created", title)
+		}
+		time.Sleep(targetDeliverPoll)
+	}
+}
+
+// isConcurrentCreateErr reports whether a CreateSession failure means another
+// creator already claimed the exact title — the retryable race in #865. It
+// matches reserveCreate's "already reserved"/"already exists" rejections but
+// deliberately not the branch-collision error ("conflicts with existing
+// session"), which is a genuine configuration problem, not a transient race.
+func isConcurrentCreateErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "already reserved") || strings.Contains(s, "already exists")
 }
 
 func (m *Manager) findSession(title, repoID string) (*session.Instance, string, *session.InstanceData, error) {

--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -1,0 +1,323 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// promptRecorder collects every prompt that reaches a session's backend, across
+// both the create path (StartAndSendPrompt) and the send path
+// (SendPromptCommand), so a delivery test can prove no prompt was dropped and
+// observe the order they landed in.
+type promptRecorder struct {
+	mu      sync.Mutex
+	prompts []string
+}
+
+func (r *promptRecorder) add(prompt string) {
+	r.mu.Lock()
+	r.prompts = append(r.prompts, prompt)
+	r.mu.Unlock()
+}
+
+func (r *promptRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.prompts))
+	copy(out, r.prompts)
+	return out
+}
+
+// recordingBackend is a ready fake backend that records the prompts sent to it.
+type recordingBackend struct {
+	readyFakeBackend
+	rec *promptRecorder
+}
+
+func (b recordingBackend) SendPromptCommand(_ *session.Instance, prompt string) error {
+	b.rec.add(prompt)
+	return nil
+}
+
+// installRecordingBackend wires a backend factory whose Start completes
+// immediately (so creates do not block) and that records delivered prompts.
+func installRecordingBackend(t *testing.T) *promptRecorder {
+	t.Helper()
+	rec := &promptRecorder{}
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, absPath string) (session.Backend, error) {
+		fake := session.NewFakeBackend()
+		fake.CompleteStart()
+		return recordingBackend{readyFakeBackend{fake}, rec}, nil
+	})
+	t.Cleanup(restore)
+	return rec
+}
+
+// TestDeliverPrompt_ConcurrentDeliveriesCreateOnceDeliverAll is the regression
+// test for #865: several deliveries fired at the same missing target session
+// must create that session exactly once and deliver EVERY prompt — the pre-fix
+// path let the loser of the creation race surface "already reserved" and
+// dropped its prompt entirely.
+func TestDeliverPrompt_ConcurrentDeliveriesCreateOnceDeliverAll(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	rec := installRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const n = 6
+	prompts := make([]string, n)
+	for i := range prompts {
+		prompts[i] = fmt.Sprintf("prompt-%d", i)
+	}
+
+	var wg sync.WaitGroup
+	statuses := make([]string, n)
+	errs := make([]error, n)
+	release := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-release // fire as close to simultaneously as the scheduler allows
+			statuses[i], errs[i] = manager.DeliverPrompt(DeliverPromptRequest{
+				Title:    "captain",
+				RepoPath: repoPath,
+				Program:  "claude",
+				Prompt:   prompts[i],
+			})
+		}(i)
+	}
+	close(release)
+	wg.Wait()
+
+	for i, e := range errs {
+		if e != nil {
+			t.Fatalf("delivery %d returned an error (a dropped prompt — #865 regression): %v", i, e)
+		}
+	}
+
+	// Exactly one session was created for the shared target.
+	stored, err := loadRepoInstanceData(repo.ID)
+	if err != nil {
+		t.Fatalf("loadRepoInstanceData: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Title != "captain" {
+		t.Fatalf("expected exactly one persisted session titled captain, got %+v", stored)
+	}
+
+	// Exactly one delivery created it ("started"); the rest sent into it.
+	started := 0
+	for _, s := range statuses {
+		switch s {
+		case "started":
+			started++
+		case "sent":
+		default:
+			t.Fatalf("unexpected status %q", s)
+		}
+	}
+	if started != 1 {
+		t.Fatalf("expected exactly one create (started), got %d; statuses=%v", started, statuses)
+	}
+
+	// Every prompt was delivered — none dropped.
+	got := rec.snapshot()
+	if len(got) != n {
+		t.Fatalf("expected %d delivered prompts, got %d: %v", n, len(got), got)
+	}
+	seen := make(map[string]bool, len(got))
+	for _, p := range got {
+		seen[p] = true
+	}
+	for _, want := range prompts {
+		if !seen[want] {
+			t.Fatalf("prompt %q was not delivered; delivered set: %v", want, got)
+		}
+	}
+}
+
+// TestDeliverPrompt_SerializesDeliveryInOrder pins that two deliveries to the
+// same target are serialized: the first creates the session and delivers its
+// prompt, the second sends into it, and the prompts land in lock-acquisition
+// order rather than interleaving.
+func TestDeliverPrompt_SerializesDeliveryInOrder(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	rec := &promptRecorder{}
+
+	// One create happens (the winner); its Start blocks until we release it so
+	// we can guarantee the first delivery holds the per-target lock before the
+	// second is launched.
+	backendCh := make(chan *session.FakeBackend, 1)
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, absPath string) (session.Backend, error) {
+		fake := session.NewFakeBackend()
+		backendCh <- fake
+		return recordingBackend{readyFakeBackend{fake}, rec}, nil
+	})
+	t.Cleanup(restore)
+
+	repoPath := setupControlRepo(t)
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	deliver := func(prompt string) (string, error) {
+		return manager.DeliverPrompt(DeliverPromptRequest{
+			Title:    "captain",
+			RepoPath: repoPath,
+			Program:  "claude",
+			Prompt:   prompt,
+		})
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if _, err := deliver("first"); err != nil {
+			t.Errorf("first delivery: %v", err)
+		}
+	}()
+
+	// Wait until the first delivery is inside CreateSession — at which point it
+	// already holds the per-target lock — then let it proceed and launch the
+	// second delivery, which must block on that lock.
+	fake := <-backendCh
+	<-fake.StartCalled()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Give the first delivery a head start on the lock; even without this
+		// the happens-before (first records its prompt before unlocking, second
+		// can only send after locking) guarantees order, but launching after
+		// StartCalled keeps the create-vs-send roles deterministic.
+		if _, err := deliver("second"); err != nil {
+			t.Errorf("second delivery: %v", err)
+		}
+	}()
+
+	fake.CompleteStart()
+	wg.Wait()
+
+	got := rec.snapshot()
+	want := []string{"first", "second"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("prompts delivered out of order or dropped: got %v, want %v", got, want)
+	}
+}
+
+// TestDeliverPrompt_RefusesDeletingTarget pins that delivery into a session
+// that is mid-teardown is surfaced as an error rather than silently dropped or
+// delivered into a dying session (#847 must be respected).
+func TestDeliverPrompt_RefusesDeletingTarget(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	rec := installRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	if _, err := manager.DeliverPrompt(DeliverPromptRequest{
+		Title:    "captain",
+		RepoPath: repoPath,
+		Program:  "claude",
+		Prompt:   "init",
+	}); err != nil {
+		t.Fatalf("initial create: %v", err)
+	}
+
+	manager.mu.Lock()
+	inst := manager.instances[daemonInstanceKey(repo.ID, "captain")]
+	manager.mu.Unlock()
+	if inst == nil {
+		t.Fatal("expected the created session to be in the manager's instance map")
+	}
+	inst.SetStatus(session.Deleting)
+
+	before := len(rec.snapshot())
+	_, err = manager.DeliverPrompt(DeliverPromptRequest{
+		Title:    "captain",
+		RepoPath: repoPath,
+		Program:  "claude",
+		Prompt:   "during-delete",
+	})
+	if err == nil || !strings.Contains(err.Error(), "being deleted") {
+		t.Fatalf("expected a 'being deleted' error, got: %v", err)
+	}
+	if got := len(rec.snapshot()); got != before {
+		t.Fatalf("prompt was delivered into a Deleting session: recorded count went %d -> %d", before, got)
+	}
+}
+
+// TestWaitForTargetSession_ReturnsWhenSessionAppears covers the cross-process
+// fallback's wait: a session that materializes after a brief delay is picked up
+// rather than timing out, while a Deleting one is surfaced as an error.
+func TestWaitForTargetSession_ReturnsWhenSessionAppears(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		if _, err := manager.CreateSession(CreateSessionRequest{
+			Title:    "captain",
+			RepoPath: repoPath,
+			Program:  "claude",
+			Prompt:   "init",
+		}); err != nil {
+			t.Errorf("background create: %v", err)
+		}
+	}()
+
+	if err := manager.waitForTargetSession(repo.ID, "captain"); err != nil {
+		t.Fatalf("waitForTargetSession should have seen the session appear: %v", err)
+	}
+}
+
+// TestIsConcurrentCreateErr pins which CreateSession failures DeliverPrompt
+// treats as a retryable creation race (wait-then-send) versus a hard error.
+func TestIsConcurrentCreateErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"reserved", fmt.Errorf("session with title %q is already reserved", "captain"), true},
+		{"exists", fmt.Errorf("session with title %q already exists", "captain"), true},
+		{"branch collision", fmt.Errorf("session titled %q conflicts with existing session %q: both sanitize to the same git branch %q", "A B", "a-b", "af-a-b"), false},
+		{"nil", nil, false},
+		{"unrelated", fmt.Errorf("git is not installed"), false},
+	}
+	for _, tc := range cases {
+		if got := isConcurrentCreateErr(tc.err); got != tc.want {
+			t.Errorf("%s: isConcurrentCreateErr = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/daemon/taskrun.go
+++ b/daemon/taskrun.go
@@ -19,7 +19,7 @@ import (
 // own control socket when called from inside the daemon process.
 var (
 	createSessionForTask = CreateSession
-	sendPromptForTask    = SendPrompt
+	deliverPromptForTask = DeliverPrompt
 )
 
 // deliverTaskPrompt delivers one rendered prompt for a task and returns the
@@ -51,36 +51,22 @@ func deliverTaskPrompt(t *task.Task, prompt string) (string, error) {
 		return "started", nil
 	}
 
-	repo, err := config.RepoFromPath(t.ProjectPath)
+	// Route through the daemon's serialized create-or-send path. When several
+	// tasks fire at the same missing target_session, the daemon creates it once
+	// and delivers every prompt in order instead of dropping the losers of the
+	// creation race (#865). A Deleting target is surfaced, not silently dropped.
+	status, err := deliverPromptForTask(DeliverPromptRequest{
+		Title:    t.TargetSession,
+		RepoPath: t.ProjectPath,
+		Program:  t.Program,
+		Prompt:   prompt,
+		AutoYes:  cfg.AutoYes,
+	})
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve repo for task path: %w", err)
+		return "", fmt.Errorf("failed to deliver prompt to target session %q: %w", t.TargetSession, err)
 	}
-	exists, err := repoHasSessionTitle(repo.ID, t.TargetSession)
-	if err != nil {
-		return "", err
-	}
-	if !exists {
-		if _, err := createSessionForTask(CreateSessionRequest{
-			Title:    t.TargetSession,
-			RepoPath: t.ProjectPath,
-			Program:  t.Program,
-			Prompt:   prompt,
-			AutoYes:  cfg.AutoYes,
-		}); err != nil {
-			return "", fmt.Errorf("failed to auto-create target session %q: %w", t.TargetSession, err)
-		}
-		log.InfoLog.Printf("task %s auto-created target session %q and delivered the prompt", t.ID, t.TargetSession)
-		return "started", nil
-	}
-	if err := sendPromptForTask(SendPromptRequest{
-		Title:  t.TargetSession,
-		RepoID: repo.ID,
-		Prompt: prompt,
-	}); err != nil {
-		return "", fmt.Errorf("failed to send prompt to target session %q: %w", t.TargetSession, err)
-	}
-	log.InfoLog.Printf("task %s sent prompt to target session %q", t.ID, t.TargetSession)
-	return "sent", nil
+	log.InfoLog.Printf("task %s delivered prompt to target session %q (%s)", t.ID, t.TargetSession, status)
+	return status, nil
 }
 
 // repoHasSessionTitle reports whether a persisted session with the given

--- a/daemon/taskrun_test.go
+++ b/daemon/taskrun_test.go
@@ -102,14 +102,18 @@ func setupTaskRepo(t *testing.T) string {
 	return repo
 }
 
-// stubTaskDelivery swaps the daemon RPC indirections used by
-// deliverTaskPrompt for in-memory recorders and restores them on cleanup.
-func stubTaskDelivery(t *testing.T) (*[]CreateSessionRequest, *[]SendPromptRequest) {
+// stubTaskDelivery swaps the daemon RPC indirections used by deliverTaskPrompt
+// for in-memory recorders and restores them on cleanup. createSessionForTask
+// backs the no-target path (a fresh session per run); deliverPromptForTask
+// backs the target_session path (the serialized create-or-send the daemon owns
+// since #865). The deliver recorder reports "sent" when the seeded target
+// exists and "started" otherwise, mirroring Manager.DeliverPrompt.
+func stubTaskDelivery(t *testing.T) (*[]CreateSessionRequest, *[]DeliverPromptRequest) {
 	t.Helper()
 	var creates []CreateSessionRequest
-	var sends []SendPromptRequest
+	var delivers []DeliverPromptRequest
 	origCreate := createSessionForTask
-	origSend := sendPromptForTask
+	origDeliver := deliverPromptForTask
 	createSessionForTask = func(req CreateSessionRequest) (*session.InstanceData, error) {
 		creates = append(creates, req)
 		title := req.Title
@@ -118,15 +122,26 @@ func stubTaskDelivery(t *testing.T) (*[]CreateSessionRequest, *[]SendPromptReque
 		}
 		return &session.InstanceData{Title: title}, nil
 	}
-	sendPromptForTask = func(req SendPromptRequest) error {
-		sends = append(sends, req)
-		return nil
+	deliverPromptForTask = func(req DeliverPromptRequest) (string, error) {
+		delivers = append(delivers, req)
+		repo, err := config.RepoFromPath(req.RepoPath)
+		if err != nil {
+			return "", err
+		}
+		exists, err := repoHasSessionTitle(repo.ID, req.Title)
+		if err != nil {
+			return "", err
+		}
+		if exists {
+			return "sent", nil
+		}
+		return "started", nil
 	}
 	t.Cleanup(func() {
 		createSessionForTask = origCreate
-		sendPromptForTask = origSend
+		deliverPromptForTask = origDeliver
 	})
-	return &creates, &sends
+	return &creates, &delivers
 }
 
 // seedTargetSession persists a bare instance record so the delivery path sees
@@ -174,7 +189,7 @@ func TestRunTask_RefusesWatchTask(t *testing.T) {
 func TestDeliverTaskPrompt_CreatesSessionWithoutTarget(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repo := setupTaskRepo(t)
-	creates, sends := stubTaskDelivery(t)
+	creates, delivers := stubTaskDelivery(t)
 
 	tsk := &task.Task{ID: "ffff0002", Name: "nightly", Prompt: "do it", CronExpr: "0 3 * * *", ProjectPath: repo, Enabled: true}
 	status, err := deliverTaskPrompt(tsk, tsk.Prompt)
@@ -184,8 +199,8 @@ func TestDeliverTaskPrompt_CreatesSessionWithoutTarget(t *testing.T) {
 	if status != "started" {
 		t.Fatalf("status = %q, want started", status)
 	}
-	if len(*sends) != 0 {
-		t.Fatalf("expected no SendPrompt calls, got %d", len(*sends))
+	if len(*delivers) != 0 {
+		t.Fatalf("expected no DeliverPrompt calls, got %d", len(*delivers))
 	}
 	if len(*creates) != 1 {
 		t.Fatalf("expected 1 CreateSession call, got %d", len(*creates))
@@ -205,7 +220,7 @@ func TestDeliverTaskPrompt_CreatesSessionWithoutTarget(t *testing.T) {
 func TestDeliverTaskPrompt_SendsIntoExistingTargetSession(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repo := setupTaskRepo(t)
-	creates, sends := stubTaskDelivery(t)
+	creates, delivers := stubTaskDelivery(t)
 	seedTargetSession(t, repo, "captain")
 
 	tsk := &task.Task{ID: "ffff0003", Name: "gh-issues", Prompt: "Triage: {{line}}", WatchCmd: "watch.sh", TargetSession: "captain", ProjectPath: repo, Enabled: true}
@@ -219,27 +234,24 @@ func TestDeliverTaskPrompt_SendsIntoExistingTargetSession(t *testing.T) {
 	if len(*creates) != 0 {
 		t.Fatalf("expected no CreateSession calls, got %d", len(*creates))
 	}
-	if len(*sends) != 1 {
-		t.Fatalf("expected 1 SendPrompt call, got %d", len(*sends))
+	if len(*delivers) != 1 {
+		t.Fatalf("expected 1 DeliverPrompt call, got %d", len(*delivers))
 	}
-	got := (*sends)[0]
-	repoCtx, err := config.RepoFromPath(repo)
-	if err != nil {
-		t.Fatalf("RepoFromPath: %v", err)
-	}
-	if got.Title != "captain" || got.RepoID != repoCtx.ID || got.Prompt != "Triage: new issue" {
-		t.Fatalf("unexpected SendPrompt request: %+v", got)
+	got := (*delivers)[0]
+	if got.Title != "captain" || got.RepoPath != repo || got.Prompt != "Triage: new issue" {
+		t.Fatalf("unexpected DeliverPrompt request: %+v", got)
 	}
 }
 
 // TestDeliverTaskPrompt_AutoCreatesMissingTargetSession pins the
-// Sachin-approved missing-target behavior (#782): auto-create the session
-// with the task's project_path/program and deliver the prompt as its initial
-// prompt, mirroring `af sessions send-prompt --create`.
+// Sachin-approved missing-target behavior (#782): route the delivery through
+// the daemon's create-or-send path with the task's project_path/program so a
+// missing target_session is auto-created and the prompt delivered as its
+// initial prompt, mirroring `af sessions send-prompt --create`.
 func TestDeliverTaskPrompt_AutoCreatesMissingTargetSession(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repo := setupTaskRepo(t)
-	creates, sends := stubTaskDelivery(t)
+	creates, delivers := stubTaskDelivery(t)
 
 	tsk := &task.Task{ID: "ffff0004", Name: "gh-issues", WatchCmd: "watch.sh", TargetSession: "captain", ProjectPath: repo, Program: "claude", Enabled: true}
 	status, err := deliverTaskPrompt(tsk, "new issue #9")
@@ -249,18 +261,18 @@ func TestDeliverTaskPrompt_AutoCreatesMissingTargetSession(t *testing.T) {
 	if status != "started" {
 		t.Fatalf("status = %q, want started", status)
 	}
-	if len(*sends) != 0 {
-		t.Fatalf("expected no SendPrompt calls, got %d", len(*sends))
+	if len(*creates) != 0 {
+		t.Fatalf("expected no direct CreateSession calls (delivery is serialized in the daemon), got %d", len(*creates))
 	}
-	if len(*creates) != 1 {
-		t.Fatalf("expected 1 CreateSession call, got %d", len(*creates))
+	if len(*delivers) != 1 {
+		t.Fatalf("expected 1 DeliverPrompt call, got %d", len(*delivers))
 	}
-	got := (*creates)[0]
+	got := (*delivers)[0]
 	if got.Title != "captain" {
-		t.Fatalf("auto-create must use the exact target title, got %q", got.Title)
+		t.Fatalf("delivery must use the exact target title, got %q", got.Title)
 	}
 	if got.RepoPath != repo || got.Program != "claude" || got.Prompt != "new issue #9" {
-		t.Fatalf("unexpected CreateSession request: %+v", got)
+		t.Fatalf("unexpected DeliverPrompt request: %+v", got)
 	}
 }
 
@@ -270,7 +282,7 @@ func TestDeliverTaskPrompt_AutoCreatesMissingTargetSession(t *testing.T) {
 func TestRunTask_CronTaskHonorsTargetSession(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repo := setupTaskRepo(t)
-	_, sends := stubTaskDelivery(t)
+	_, delivers := stubTaskDelivery(t)
 	seedTargetSession(t, repo, "captain")
 
 	if err := task.AddTask(task.Task{
@@ -289,8 +301,8 @@ func TestRunTask_CronTaskHonorsTargetSession(t *testing.T) {
 	if err := RunTask("ffff0005"); err != nil {
 		t.Fatalf("RunTask: %v", err)
 	}
-	if len(*sends) != 1 || (*sends)[0].Prompt != "scheduled check-in" {
-		t.Fatalf("expected one scheduled send, got %+v", *sends)
+	if len(*delivers) != 1 || (*delivers)[0].Prompt != "scheduled check-in" {
+		t.Fatalf("expected one scheduled delivery, got %+v", *delivers)
 	}
 	got, err := task.GetTask("ffff0005")
 	if err != nil {


### PR DESCRIPTION
## Problem

When two task runs deliver into the same `target_session` that doesn't exist yet, both observe "doesn't exist" on disk, both attempt to auto-create it, and the daemon's `reserveCreate` lets exactly one win the title reservation. The loser got an `already reserved`/`already exists` error back from `deliverTaskPrompt` and **returned without ever sending its prompt** — permanent data loss for watch-task events (no retry), deferred delivery for cron tasks. Introduced in #794 (`target_session`, phase 2 of #782).

The whole point of `target_session` is delivery *into* a shared session, so losing the creation race should never mean losing the prompt.

## Fix

Centralize the create-or-send decision in a new serialized daemon path, `Manager.DeliverPrompt`, exposed as a control RPC:

- **Per-`(repo, title)` lock** serializes every delivery to a shared target. Concurrent deliveries now create the session exactly once and send the rest into it **in arrival order** — no interleaving, no drops.
- **Deleting targets respected (#847):** delivery into a session that's mid-teardown is surfaced as an error, never silently dropped or delivered into a dying session.
- **Cross-process race fallback:** if a creator outside the daemon (a plain `af sessions create`) claims the title between our existence check and `reserveCreate`, `DeliverPrompt` waits (bounded poll) for the session to materialize and then sends, rather than erroring. Branch-collision/config errors are *not* retried.
- The new RPC honors the warm-up retry contract (#829) via `requireManagerReady` + `callDaemon`.

## Adjacent-call-site audit (per CLAUDE.md)

Every prompt-delivery + auto-create site now routes through `DeliverPrompt` for consistent wait-then-send:

- `deliverTaskPrompt` — cron + watch task delivery.
- `af sessions send-prompt --create` (#776) — previously did its own check-then-create that could race identically.

## Tests

- Concurrent deliveries to one missing target → session created **once**, **all** prompts delivered (none dropped) — the #865 regression.
- Two deliveries serialize **in order** (deterministic via create-path gating).
- Delivery into a **Deleting** target is surfaced as an error and not delivered.
- `waitForTargetSession` picks up a session that appears after a delay; `isConcurrentCreateErr` classification pinned.
- Existing `send-prompt --create` routing covered in `api/`.

All four CI gates (`go build`, `go test ./...`, `golangci-lint --fast`, `gofmt -l`) + `deadcode` + bounded `-race` on the daemon delivery paths pass. Hermetic — fake backends, no dev-install.

Fixes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)
