### PR TITLE
fix(api): add --program to tasks update for CLI/TUI parity (#866)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -231,6 +231,7 @@ func init() {
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateWatchCmdFlag, "watch-cmd", "", "New watch command (clears cron)")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateTargetSessionFlag, "target-session", "", "New target session; pass an empty value to revert to a new session per run")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateEnabledFlag, "enabled", "", "Enable or disable the task (true/false)")
+	tasksUpdateCmd.Flags().StringVar(&taskUpdateProgramFlag, "program", "", "New program to run (leave unset to keep the current one)")
 
 	TasksCmd.AddCommand(tasksListCmd)
 	TasksCmd.AddCommand(tasksGetCmd)

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -224,6 +224,7 @@ var (
 	taskUpdateWatchCmdFlag      string
 	taskUpdateTargetSessionFlag string
 	taskUpdateEnabledFlag       string
+	taskUpdateProgramFlag       string
 )
 
 var tasksUpdateCmd = &cobra.Command{
@@ -308,6 +309,19 @@ var tasksUpdateCmd = &cobra.Command{
 			// not changed
 		default:
 			return jsonError(fmt.Errorf("--enabled must be 'true' or 'false'"))
+		}
+
+		// Partial-update semantics: "" means "leave unchanged" (mirroring
+		// --name and the add path's taskAddProgramFlag != "" guard). There is
+		// no "clear program" state — a task always runs *some* program — so an
+		// empty value is never a request to wipe it. Any non-empty value is
+		// validated against the same enum tasks add uses, keeping CLI/TUI
+		// parity (#866).
+		if taskUpdateProgramFlag != "" {
+			if err := config.ValidateProgramEnum("--program flag", "--program flag", taskUpdateProgramFlag, ""); err != nil {
+				return jsonError(err)
+			}
+			s.Program = taskUpdateProgramFlag
 		}
 
 		if err := task.UpdateTask(*s); err != nil {

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -64,6 +66,7 @@ func resetUpdateFlags(t *testing.T) {
 		taskUpdateWatchCmdFlag = ""
 		taskUpdateTargetSessionFlag = ""
 		taskUpdateEnabledFlag = ""
+		taskUpdateProgramFlag = ""
 		// --target-session uses Changed() semantics ("" is a meaningful
 		// value), so the cobra-level Changed marker must reset too.
 		tasksUpdateCmd.Flags().Lookup("target-session").Changed = false
@@ -87,6 +90,24 @@ func resetAddFlags(t *testing.T) {
 	}
 	t.Cleanup(reset)
 	reset()
+}
+
+// captureStdout redirects os.Stdout while fn runs and returns what jsonOut
+// printed, so a test can assert on the command's JSON output.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(data)
 }
 
 // seedTask persists a single task for update tests.
@@ -593,4 +614,65 @@ func TestTasksUpdate_TargetSessionSetAndClear(t *testing.T) {
 	got, err = task.GetTask("ts1")
 	require.NoError(t, err)
 	assert.Empty(t, got.TargetSession, "explicit empty value must clear target_session")
+}
+
+// TestTasksUpdate_ProgramChange is the regression guard for #866: the CLI
+// `tasks update` gained a --program flag so the program field is editable from
+// the CLI, matching the TUI and the backend that already persisted it.
+func TestTasksUpdate_ProgramChange(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubDaemon(t)
+
+	seedTask(t, task.Task{ID: "pr1", Prompt: "p", CronExpr: "0 9 * * *", Program: "claude", Enabled: true})
+
+	out := captureStdout(t, func() {
+		taskUpdateProgramFlag = "codex"
+		require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"pr1"}))
+	})
+
+	got, err := task.GetTask("pr1")
+	require.NoError(t, err)
+	assert.Equal(t, "codex", got.Program, "program must persist through update")
+	assert.Equal(t, 1, calls.reloads, "update must poke the daemon to reload schedules")
+	assert.Contains(t, out, `"program": "codex"`, "JSON output must reflect the new program")
+}
+
+// TestTasksUpdate_RejectsInvalidProgram pins that --program is validated
+// against the same enum the add path uses, and a bad value leaves the task
+// untouched.
+func TestTasksUpdate_RejectsInvalidProgram(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubDaemon(t)
+
+	seedTask(t, task.Task{ID: "pr2", Prompt: "p", CronExpr: "0 9 * * *", Program: "claude", Enabled: true})
+
+	taskUpdateProgramFlag = "not-a-real-agent"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"pr2"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--program flag must be one of")
+
+	got, err := task.GetTask("pr2")
+	require.NoError(t, err)
+	assert.Equal(t, "claude", got.Program, "program must remain unchanged on validation failure")
+	assert.Zero(t, calls.reloads, "no daemon poke when validation fails")
+}
+
+// TestTasksUpdate_OmittingProgramLeavesUnchanged pins the partial-update
+// contract: an update that does not pass --program must not touch the program.
+func TestTasksUpdate_OmittingProgramLeavesUnchanged(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	stubDaemon(t)
+
+	seedTask(t, task.Task{ID: "pr3", Prompt: "p", CronExpr: "0 9 * * *", Program: "aider", Enabled: true})
+
+	taskUpdateNameFlag = "renamed"
+	require.NoError(t, tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"pr3"}))
+
+	got, err := task.GetTask("pr3")
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", got.Name)
+	assert.Equal(t, "aider", got.Program, "absent --program must not change the program")
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,12 +46,12 @@ af tasks list
 af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
 af tasks add --name <n> --watch-cmd <cmd> [--prompt "... {{line}} ..."] [--target-session <title>]
 af tasks get <id>
-af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--enabled true|false]
+af tasks update <id> [--cron ...|--watch-cmd ...] [--prompt ...] [--target-session ...] [--program <agent>] [--enabled true|false]
 af tasks trigger <id>          # run a cron task immediately (cron tasks only)
 af tasks remove <id>
 ```
 
-Exactly one of `--cron` / `--watch-cmd` per task. On `update`, setting one trigger clears the other. `--target-session ""` explicitly reverts to create-a-session-per-run; omitting the flag leaves it untouched.
+Exactly one of `--cron` / `--watch-cmd` per task. On `update`, setting one trigger clears the other. `--target-session ""` explicitly reverts to create-a-session-per-run; omitting the flag leaves it untouched. `--program` accepts the same agent enum as `tasks add`; omitting it keeps the task's current program.
 
 ## `af daemon`
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -106,12 +106,12 @@ af tasks list
 af tasks add --name <n> --prompt <p> --cron "0 9 * * *" [--target-session <title>] [--program <agent>]
 af tasks add --name <n> --watch-cmd <cmd> [--prompt "… {{line}} …"] [--target-session <title>]
 af tasks get <id>
-af tasks update <id> [--cron …|--watch-cmd …] [--prompt …] [--target-session …] [--enabled true|false]
+af tasks update <id> [--cron …|--watch-cmd …] [--prompt …] [--target-session …] [--program <agent>] [--enabled true|false]
 af tasks trigger <id>          # cron tasks only
 af tasks remove <id>
 ```
 
-On `update`, setting one trigger clears the other (switching watch→cron requires a prompt). `--target-session ""` explicitly reverts to create-per-run; omitting the flag leaves it untouched.
+On `update`, setting one trigger clears the other (switching watch→cron requires a prompt). `--target-session ""` explicitly reverts to create-per-run; omitting the flag leaves it untouched. `--program` accepts the same agent enum as `tasks add`; omitting it keeps the task's current program.
 
 ## Examples
 


### PR DESCRIPTION
## Problem

`af tasks update` could change every task field *except* `program`. The TUI gained per-task program editing (97edeb9 / #454) and the backend `UpdateTask` already persists `Program`, but the CLI `tasks update` command never exposed a `--program` flag — so CLI users had no way to change a task's program despite the backend and TUI supporting it.

Fixes #866

## Fix

- Add `--program` to `tasksUpdateCmd`, mirroring `tasks add`:
  - Any **non-empty** value is validated against the same `config.ValidateProgramEnum` enum and applied to the task.
  - An **omitted/empty** flag leaves the program unchanged — consistent with `--name` and the partial-update semantics of the other update flags. There is no "clear program" state (a task always runs *some* program), so empty is never a wipe request.
- Docs (`docs/cli.md`, `docs/tasks.md`) updated to list `--program` on the `tasks update` synopsis.

## Adjacent-call-site audit (per CLAUDE.md)

Reviewed every `tasks update` field flag for unset-means-unchanged consistency: `--name`/`--prompt` use `!= ""`; `--target-session` uses `Changed()` because `""` is meaningful there; `--cron`/`--watch-cmd` keep the #814 blank-trigger rejection. `--program` follows the `!= ""` pattern (matching `--name` and the add path) since an empty program is invalid, not a meaningful clear. No other gaps found.

## Tests

- `TestTasksUpdate_ProgramChange` — `--program codex` changes the program, persists, pokes the daemon, and the JSON output reflects the new value.
- `TestTasksUpdate_RejectsInvalidProgram` — invalid program is rejected via the shared enum; task left untouched; no daemon poke.
- `TestTasksUpdate_OmittingProgramLeavesUnchanged` — an unrelated update leaves the program alone.

## Verification

- `go build ./...` ✅
- `gofmt -l .` ✅ (clean)
- `go test ./...` ✅ (only the known dev-box flake `integration/TestConcurrentCLIClientsUseDaemonCoordinator` failed under full-parallel contention; passes in isolation)
- `golangci-lint run --timeout=3m --fast` ✅
- `deadcode -test ./...` ✅ (clean)
- `go test -race ./api/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude