### PR TITLE
fix(ui): reject blank post-worktree hooks and align sidebar rows at 100+ (#870, #871)

### DIFF
--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -138,7 +138,10 @@ func (h *HooksPane) handleNormalMode(msg tea.KeyMsg) bool {
 func (h *HooksPane) handleEditMode(msg tea.KeyMsg) bool {
 	switch msg.Type {
 	case tea.KeyEnter:
-		if h.editBuffer != "" {
+		// Reject blank/whitespace-only commands so they neither persist to the
+		// on-disk config nor overwrite a non-empty command on edit (#870),
+		// matching how watch/cron/remote-hook inputs are validated.
+		if strings.TrimSpace(h.editBuffer) != "" {
 			if h.adding {
 				h.commands = append(h.commands, h.editBuffer)
 				h.selectedIdx = len(h.commands) - 1

--- a/ui/hooks_pane_test.go
+++ b/ui/hooks_pane_test.go
@@ -64,3 +64,42 @@ func TestHooksPaneSetCommandsRoundtripKeepsSelectedIdxValid(t *testing.T) {
 	assert.True(t, h.editing)
 	assert.Equal(t, "newcmd", h.editBuffer)
 }
+
+// TestHooksPaneRejectsWhitespaceOnlyAddedCommand verifies the #870 fix: a
+// whitespace-only command typed while adding is rejected rather than persisted
+// to the on-disk config (matching how watch/cron/remote-hook inputs validate).
+func TestHooksPaneRejectsWhitespaceOnlyAddedCommand(t *testing.T) {
+	h := NewHooksPane()
+	h.SetFocus(true)
+
+	// Start adding, type only whitespace, then save.
+	h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	h.HandleKeyPress(tea.KeyMsg{Type: tea.KeySpace})
+	h.HandleKeyPress(tea.KeyMsg{Type: tea.KeySpace})
+	h.HandleKeyPress(tea.KeyMsg{Type: tea.KeySpace})
+	h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Empty(t, h.GetCommands(), "whitespace-only command must not be saved")
+	assert.False(t, h.IsDirty(), "rejecting a blank command must not dirty the pane")
+	assert.False(t, h.editing)
+	assert.False(t, h.adding)
+}
+
+// TestHooksPaneWhitespaceEditDoesNotClobberCommand verifies that editing an
+// existing command down to whitespace-only does not overwrite it with blank.
+func TestHooksPaneWhitespaceEditDoesNotClobberCommand(t *testing.T) {
+	h := NewHooksPane()
+	h.SetCommands([]string{"make test"})
+	h.SetFocus(true)
+
+	// Enter edit mode, clear the buffer, type whitespace, save.
+	h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	for range "make test" {
+		h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	h.HandleKeyPress(tea.KeyMsg{Type: tea.KeySpace})
+	h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, []string{"make test"}, h.GetCommands(),
+		"whitespace-only edit must leave the existing command untouched")
+}

--- a/ui/list.go
+++ b/ui/list.go
@@ -63,7 +63,14 @@ const branchIcon = "Ꮧ"
 
 func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, hasMultipleRepos bool) string {
 	prefix := fmt.Sprintf(" %d. ", idx)
+	// Each extra digit grows the prefix by one cell, which shifts the
+	// len(prefix)-derived branch/PR indentation and misaligns adjacent visible
+	// rows at the 9→10 and 99→100 boundaries. Trim one trailing space per extra
+	// digit tier so the prefix width holds steady into the triple digits (#871).
 	if idx >= 10 {
+		prefix = prefix[:len(prefix)-1]
+	}
+	if idx >= 100 {
 		prefix = prefix[:len(prefix)-1]
 	}
 	titleS := selectedTitleStyle

--- a/ui/list_align_test.go
+++ b/ui/list_align_test.go
@@ -1,0 +1,72 @@
+package ui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
+)
+
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// prLineIndent renders an instance at the given 1-based display index and
+// returns the number of leading whitespace cells in front of the "PR #" text.
+// The PR line is indented by strings.Repeat(" ", len(prefix)) plus a constant
+// style padding, so any idx-dependent change in the indent reflects a change
+// in the numbered prefix width (#871).
+func prLineIndent(t *testing.T, idx int, spin *spinner.Model) int {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "feature",
+		Path:    t.TempDir(),
+		Program: "test",
+	})
+	require.NoError(t, err)
+	inst.SetPRInfo(&git.PRInfo{Number: 42, Title: "do a thing", State: "OPEN"})
+
+	r := &InstanceRenderer{spinner: spin}
+	r.setWidth(60) // wide enough to render the full PR line
+
+	out := r.Render(inst, idx, false, false)
+	for _, line := range strings.Split(out, "\n") {
+		clean := ansiEscape.ReplaceAllString(line, "")
+		if pos := strings.Index(clean, "PR #"); pos >= 0 {
+			return len([]rune(clean[:pos]))
+		}
+	}
+	t.Fatalf("no PR line found in rendered output for idx=%d:\n%s", idx, out)
+	return -1
+}
+
+// TestInstanceRendererPrefixAlignment guards against the regression in #871:
+// the numbered prefix width must stay constant as the index grows so adjacent
+// visible rows keep the same branch/PR indentation. Before the fix the prefix
+// grew by a cell at the 99→100 boundary (and the 9→10 boundary already worked).
+func TestInstanceRendererPrefixAlignment(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+
+	base := prLineIndent(t, 1, &spin)
+	for _, idx := range []int{9, 10, 11, 99, 100, 101, 999} {
+		got := prLineIndent(t, idx, &spin)
+		require.Equalf(t, base, got,
+			"PR line indent at idx=%d (%d) must match idx=1 (%d); prefix width drifted",
+			idx, got, base)
+	}
+}
+
+// TestInstanceRendererPrefixBoundaries explicitly pins the two digit-tier
+// boundaries that shift the prefix width: 9→10 (already handled) and 99→100
+// (the #871 fix). Adjacent rows that straddle a boundary must align.
+func TestInstanceRendererPrefixBoundaries(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+
+	require.Equal(t, prLineIndent(t, 9, &spin), prLineIndent(t, 10, &spin),
+		"rows 9 and 10 must share the same indent")
+	require.Equal(t, prLineIndent(t, 99, &spin), prLineIndent(t, 100, &spin),
+		"rows 99 and 100 must share the same indent")
+}

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -399,7 +399,7 @@ func (s *TaskPane) enterEditMode() {
 // event defaults to the raw emitted line. Returns the inline error and the
 // focus stop to render it under, or ("", -1) when valid.
 func (s *TaskPane) validateForm() (string, int) {
-	if s.editName.Value() == "" {
+	if strings.TrimSpace(s.editName.Value()) == "" {
 		return "name is required", taskFocusName
 	}
 	if s.editTriggerIsWatch {

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -143,6 +143,31 @@ func TestTaskPaneCreateModeRejectsEmptyPrompt(t *testing.T) {
 	}
 }
 
+// TestTaskPaneCreateModeRejectsWhitespaceName guards the adjacent-call-site
+// audit for #870: like the watch/cron/prompt fields, a whitespace-only task
+// name must be rejected rather than persisted as a blank name.
+func TestTaskPaneCreateModeRejectsWhitespaceName(t *testing.T) {
+	tp := NewTaskPane()
+	tp.EnterCreateMode("/tmp/repo")
+
+	// Whitespace-only name, otherwise-valid cron + prompt.
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("   ")})
+	tabTo(tp, 2) // -> trigger -> cron value
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do work")})
+
+	tabTo(tp, taskFocusSave-taskFocusPrompt)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.False(t, tp.HasPendingCreate(), "whitespace-only name must not produce a pending create")
+	assert.True(t, tp.IsCreating(), "form must stay open so the user can fix the error")
+	assert.Equal(t, "name is required", tp.editError,
+		"inline validation error must surface to the user")
+	assert.Equal(t, taskFocusName, tp.editErrorField,
+		"the error must render under the Name field")
+}
+
 // TestTaskPaneCreateModeSelectorDefaultsToConfigDefault verifies that creating
 // a new task without touching the Program selector persists "" so the daemon
 // uses the configured default_program. Regression test for #492.


### PR DESCRIPTION
## Summary

Two trivial `ui/` fixes, both surfaced by Detail Bot.

### #870 — whitespace-only post-worktree hook commands were saved
`HooksPane.handleEditMode` saved a command whenever `editBuffer != ""`, so
`"   "` / `"\t"` / `"\n"` passed the check and were persisted to the on-disk
config (and could overwrite a real command when editing). Now validated with
`strings.TrimSpace(h.editBuffer) != ""`, matching how watch/cron/remote-hook
inputs are validated (same pattern as #814).

### #871 — sidebar rows misalign at index 100+
`InstanceRenderer.Render` only trimmed the numbered prefix for `idx >= 10`, so
the prefix grew a cell at the 99→100 boundary. Branch/PR line indentation is
derived from `len(prefix)`, so adjacent visible rows (e.g. 99 and 100) shifted
by one space when scrolling 100+ sessions. Added the `idx >= 100` trim tier so
the prefix width stays constant into the triple digits.

### Adjacent-call-site audit (per CLAUDE.md)
- **#870 class:** `TaskPane.validateForm` accepted a whitespace-only task name
  (`editName.Value() == ""`) while every sibling field (watch/cron/prompt)
  already trimmed. Same defect → fixed with `TrimSpace`. No other untrimmed
  pane edit-save sites found.
- **#871 class:** the branch/PR indents and PR-width math all derive from
  `len(prefix)`, so fixing the prefix fixes them together. No other fixed-width
  index/number formatting in the sidebar.

## Tests
- whitespace hook command rejected on add; whitespace edit does not clobber the
  existing command
- whitespace task name rejected with the inline "name is required" error
- sidebar PR/branch indent is constant across the 9→10 and 99→100 boundaries
  and at idx 100+/999

All four CI gates pass locally (`go build`, `go test ./...`, `golangci-lint
run --fast`, `gofmt -l`), plus `deadcode -test ./...` clean and `-race` green
on `./ui`. Each test was confirmed to fail before its fix.

Fixes #870
Fixes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude