### PR TITLE
fix(daemon): operate on the tracked instance, not an untracked disk duplicate, in SendPrompt/KillSession (#867)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1112,10 +1112,36 @@ func (m *Manager) findSession(title, repoID string) (*session.Instance, string, 
 	if err != nil {
 		return nil, "", nil, err
 	}
-	instance, restoreErr := session.FromInstanceData(*data)
+	instance, restoreErr := fromInstanceDataForRefresh(*data)
 	if restoreErr != nil {
 		return nil, rid, data, nil
 	}
+
+	// We built `instance` from disk with m.mu released, so a concurrent
+	// refresh (or another RPC) may have restored and registered the canonical
+	// Instance for this session during the window (#867). Returning our freshly
+	// built duplicate would hand the caller an *untracked* Instance: SendPrompt
+	// would leak its restore-time attach PTY, and KillSession would call
+	// instance.Kill() — tearing down the tmux session and worktree that the
+	// canonical, still-tracked Instance shares. Re-acquire the lock and:
+	//   - if a tracked Instance now exists, drop our duplicate (closing only
+	//     its attach resources, never the shared session) and operate on the
+	//     tracked one; otherwise
+	//   - register our Instance so callers operate on a tracked Instance, just
+	//     as the refresh loop would have, instead of an orphan.
+	key := daemonInstanceKey(rid, title)
+	m.mu.Lock()
+	if tracked := m.instances[key]; tracked != nil {
+		m.mu.Unlock()
+		if err := instance.CloseAttachOnly(); err != nil {
+			log.WarningLog.Printf("findSession %q: closing duplicate instance attach failed: %v", title, err)
+		}
+		return tracked, rid, data, nil
+	}
+	// Match the refresh loop: instances the daemon tracks always run AutoYes.
+	instance.SetAutoYes(true)
+	m.instances[key] = instance
+	m.mu.Unlock()
 	return instance, rid, data, nil
 }
 

--- a/daemon/find_session_test.go
+++ b/daemon/find_session_test.go
@@ -1,0 +1,258 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// attachCountingBackend records how many times an instance was torn down via
+// Kill (destructive: kills the tmux session and removes the worktree) versus
+// CloseAttachOnly (non-destructive: releases only this client's attach PTY).
+// It lets the findSession tests assert that a duplicate Instance built from
+// disk is discarded with CloseAttachOnly and is never Kill'd (#867) — a Kill
+// on a duplicate would tear down the live session the canonical, tracked
+// Instance shares.
+type attachCountingBackend struct {
+	*session.FakeBackend
+	kills           atomic.Int32
+	closeAttachOnly atomic.Int32
+}
+
+func (b *attachCountingBackend) Kill(i *session.Instance) error {
+	b.kills.Add(1)
+	return b.FakeBackend.Kill(i)
+}
+
+func (b *attachCountingBackend) CloseAttachOnly(i *session.Instance) error {
+	b.closeAttachOnly.Add(1)
+	return b.FakeBackend.CloseAttachOnly(i)
+}
+
+func newCountingInstance(t *testing.T, title, repoPath string) (*session.Instance, *attachCountingBackend) {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    repoPath,
+		Program: "claude",
+	})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	backend := &attachCountingBackend{FakeBackend: session.NewFakeBackend()}
+	inst.SetBackend(backend)
+	inst.SetStartedForTest(true)
+	inst.SetStatus(session.Running)
+	return inst, backend
+}
+
+// seedDiskInstance writes a single Running instance to the repo's on-disk
+// store without registering it in any manager's in-memory map, modelling the
+// issue's precondition: a session that exists on disk but is not (yet) tracked
+// because an earlier restore failed transiently.
+func seedDiskInstance(t *testing.T, repoID, title, repoPath string) {
+	t.Helper()
+	seeded, err := json.Marshal([]session.InstanceData{
+		{Title: title, Path: repoPath, Status: session.Running},
+	})
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := config.LoadState().SaveInstances(repoID, seeded); err != nil {
+		t.Fatalf("seed disk: %v", err)
+	}
+}
+
+// TestFindSessionDiscardsDuplicateWhenCanonicalRaced is the regression test for
+// sachiniyer/agent-factory#867. findSession releases m.mu before building an
+// Instance from disk, so a concurrent refresh can restore and register the
+// canonical Instance during that window. The pre-fix code returned the
+// freshly-built duplicate anyway — an untracked Instance owning its own attach
+// PTY. SendPrompt then leaked that PTY, and KillSession called instance.Kill()
+// on it, tearing down the tmux session and worktree the canonical Instance
+// still owned.
+//
+// The race is driven deterministically through the fromInstanceDataForRefresh
+// seam: the first call (the initial refreshLocked) fails, modelling the
+// transient restore failure that leaves the session disk-only; the second call
+// (the disk build after m.mu is released) registers the canonical Instance —
+// simulating the concurrent refresh winning — and returns the duplicate. We
+// assert findSession returns the tracked canonical, discards the duplicate via
+// CloseAttachOnly (not Kill), and never Kills the canonical.
+func TestFindSessionDiscardsDuplicateWhenCanonicalRaced(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	seedDiskInstance(t, repo.ID, "raced", repoPath)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	key := daemonInstanceKey(repo.ID, "raced")
+	canonical, canonicalBackend := newCountingInstance(t, "raced", repoPath)
+	duplicate, duplicateBackend := newCountingInstance(t, "raced", repoPath)
+
+	var calls atomic.Int32
+	prev := fromInstanceDataForRefresh
+	fromInstanceDataForRefresh = func(d session.InstanceData) (*session.Instance, error) {
+		switch calls.Add(1) {
+		case 1:
+			// The initial refreshLocked inside findSession: model the
+			// transient restore failure so the session stays disk-only.
+			return nil, fmt.Errorf("transient restore failure")
+		default:
+			// The disk build after m.mu was released: a concurrent refresh
+			// has just won the race and registered the canonical Instance.
+			manager.mu.Lock()
+			manager.instances[key] = canonical
+			manager.mu.Unlock()
+			return duplicate, nil
+		}
+	}
+	t.Cleanup(func() { fromInstanceDataForRefresh = prev })
+
+	inst, rid, _, err := manager.findSession("raced", repo.ID)
+	if err != nil {
+		t.Fatalf("findSession: %v", err)
+	}
+	if rid != repo.ID {
+		t.Fatalf("rid = %q, want %q", rid, repo.ID)
+	}
+	if inst != canonical {
+		t.Fatalf("findSession returned a non-canonical instance; want the tracked one")
+	}
+	if got := duplicateBackend.closeAttachOnly.Load(); got != 1 {
+		t.Fatalf("duplicate CloseAttachOnly calls = %d, want 1 (PTY must be released)", got)
+	}
+	if got := duplicateBackend.kills.Load(); got != 0 {
+		t.Fatalf("duplicate Kill calls = %d, want 0 (Kill would tear down the shared session)", got)
+	}
+	if got := canonicalBackend.kills.Load(); got != 0 {
+		t.Fatalf("canonical Kill calls = %d, want 0", got)
+	}
+
+	manager.mu.Lock()
+	tracked := manager.instances[key]
+	manager.mu.Unlock()
+	if tracked != canonical {
+		t.Fatalf("canonical instance is no longer tracked after findSession")
+	}
+}
+
+// TestFindSessionRegistersRestoredInstanceWhenUntracked covers the other side
+// of the #867 fix: when no canonical Instance won the race, findSession must
+// register the Instance it built from disk so callers operate on a *tracked*
+// Instance (just as the refresh loop would have) rather than an orphan whose
+// PTY leaks. The restored Instance is left tracked, AutoYes-enabled, and is not
+// torn down.
+func TestFindSessionRegistersRestoredInstanceWhenUntracked(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	seedDiskInstance(t, repo.ID, "lonely", repoPath)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	key := daemonInstanceKey(repo.ID, "lonely")
+	restored, restoredBackend := newCountingInstance(t, "lonely", repoPath)
+
+	var calls atomic.Int32
+	prev := fromInstanceDataForRefresh
+	fromInstanceDataForRefresh = func(d session.InstanceData) (*session.Instance, error) {
+		switch calls.Add(1) {
+		case 1:
+			return nil, fmt.Errorf("transient restore failure")
+		default:
+			return restored, nil
+		}
+	}
+	t.Cleanup(func() { fromInstanceDataForRefresh = prev })
+
+	inst, rid, _, err := manager.findSession("lonely", repo.ID)
+	if err != nil {
+		t.Fatalf("findSession: %v", err)
+	}
+	if rid != repo.ID {
+		t.Fatalf("rid = %q, want %q", rid, repo.ID)
+	}
+	if inst != restored {
+		t.Fatalf("findSession returned an unexpected instance")
+	}
+	if got := restoredBackend.closeAttachOnly.Load(); got != 0 {
+		t.Fatalf("restored CloseAttachOnly calls = %d, want 0", got)
+	}
+	if got := restoredBackend.kills.Load(); got != 0 {
+		t.Fatalf("restored Kill calls = %d, want 0", got)
+	}
+	if !inst.AutoYes {
+		t.Fatalf("restored instance should be AutoYes-enabled to match the refresh loop")
+	}
+
+	manager.mu.Lock()
+	tracked := manager.instances[key]
+	manager.mu.Unlock()
+	if tracked != restored {
+		t.Fatalf("restored instance was not registered in m.instances")
+	}
+}
+
+// TestFindSessionReturnsTrackedInstanceWithoutDiskBuild asserts the common,
+// non-racing path is unchanged: when the canonical Instance is already tracked,
+// findSession returns it without ever building an Instance from disk.
+func TestFindSessionReturnsTrackedInstanceWithoutDiskBuild(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	seedDiskInstance(t, repo.ID, "tracked", repoPath)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	key := daemonInstanceKey(repo.ID, "tracked")
+	canonical, _ := newCountingInstance(t, "tracked", repoPath)
+	manager.mu.Lock()
+	manager.instances[key] = canonical
+	manager.mu.Unlock()
+
+	var diskBuilds atomic.Int32
+	prev := fromInstanceDataForRefresh
+	fromInstanceDataForRefresh = func(d session.InstanceData) (*session.Instance, error) {
+		diskBuilds.Add(1)
+		return prev(d)
+	}
+	t.Cleanup(func() { fromInstanceDataForRefresh = prev })
+
+	inst, rid, _, err := manager.findSession("tracked", repo.ID)
+	if err != nil {
+		t.Fatalf("findSession: %v", err)
+	}
+	if rid != repo.ID {
+		t.Fatalf("rid = %q, want %q", rid, repo.ID)
+	}
+	if inst != canonical {
+		t.Fatalf("findSession did not return the tracked instance")
+	}
+	if got := diskBuilds.Load(); got != 0 {
+		t.Fatalf("fromInstanceDataForRefresh called %d times; the tracked path must not build from disk", got)
+	}
+}

--- a/session/backend.go
+++ b/session/backend.go
@@ -11,6 +11,16 @@ type Backend interface {
 	// Kill terminates the session and cleans up all associated resources.
 	Kill(instance *Instance) error
 
+	// CloseAttachOnly releases the resources this Instance opened to view or
+	// drive the session (a tmux attach PTY, a remote preview process) WITHOUT
+	// destroying the underlying session, worktree, or remote record. It is the
+	// non-destructive sibling of Kill, used to discard a duplicate Instance
+	// built from disk that lost a race to the canonical, still-tracked
+	// Instance — see the daemon's findSession (#867). Killing such a duplicate
+	// would tear down state the canonical Instance shares; closing only its
+	// attach resources reclaims the PTY without that collateral damage.
+	CloseAttachOnly(instance *Instance) error
+
 	// Preview returns the current visible output of the session.
 	Preview(instance *Instance) (string, error)
 

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -327,6 +327,20 @@ func (b *HookBackend) Kill(i *Instance) error {
 	return nil
 }
 
+// CloseAttachOnly stops this instance's preview process (closing its PTY/pipe)
+// WITHOUT invoking delete_cmd, so a duplicate Instance built from disk (#867)
+// can be discarded without deleting the live remote session that a canonical,
+// still-tracked Instance shares. It is the non-destructive sibling of Kill,
+// which additionally runs delete_cmd to tear the remote session down.
+func (b *HookBackend) CloseAttachOnly(i *Instance) error {
+	i.mu.Lock()
+	i.started = false
+	i.mu.Unlock()
+
+	b.closePTY(i.Title)
+	return nil
+}
+
 // runDeleteCmd invokes delete_cmd for the given hook name and returns its
 // combined output and error. Shared by Kill (which surfaces the error to the
 // user) and the orphan-cleanup path in Start (which logs it best-effort, #739)

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -223,6 +223,33 @@ func (b *LocalBackend) Kill(i *Instance) error {
 	return nil
 }
 
+// CloseAttachOnly releases this instance's hold on the tmux session — the
+// attach PTY and the `tmux attach-session` child process — WITHOUT running
+// `tmux kill-session`. The server-side tmux session and the git worktree
+// behind it are left untouched. The daemon uses this to discard a duplicate
+// Instance built from disk that turned out to already be tracked in memory
+// (#867): the duplicate must surrender the PTY it opened during restore
+// without tearing down the live session the canonical Instance shares.
+func (b *LocalBackend) CloseAttachOnly(i *Instance) error {
+	i.mu.Lock()
+	ts := i.tmuxSession
+	i.started = false
+	i.mu.Unlock()
+
+	if ts == nil {
+		return nil
+	}
+
+	err := ts.CloseAttachOnly()
+
+	i.mu.Lock()
+	if i.tmuxSession == ts {
+		i.tmuxSession = nil
+	}
+	i.mu.Unlock()
+	return err
+}
+
 func (b *LocalBackend) Preview(i *Instance) (string, error) {
 	i.mu.RLock()
 	s := i.started

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -94,6 +94,11 @@ func (b *FakeBackend) Kill(instance *Instance) error {
 	return nil
 }
 
+// CloseAttachOnly is a no-op for the fake backend: it holds no real PTY to
+// release. Tests that need to distinguish a non-destructive close from a Kill
+// embed FakeBackend and override this (and Kill) to record the call.
+func (b *FakeBackend) CloseAttachOnly(*Instance) error { return nil }
+
 func (b *FakeBackend) Preview(*Instance) (string, error)            { return "", nil }
 func (b *FakeBackend) PreviewFullHistory(*Instance) (string, error) { return "", nil }
 func (b *FakeBackend) Attach(*Instance) (chan struct{}, error) {

--- a/session/instance.go
+++ b/session/instance.go
@@ -402,6 +402,15 @@ func (i *Instance) Kill() error {
 	return i.backend.Kill(i)
 }
 
+// CloseAttachOnly releases the resources this instance opened to view or drive
+// its session (a tmux attach PTY, a remote preview process) without destroying
+// the session, worktree, or remote record. Use it — never Kill — to discard a
+// duplicate Instance built from disk that lost a race to the canonical tracked
+// Instance (#867); see Backend.CloseAttachOnly.
+func (i *Instance) CloseAttachOnly() error {
+	return i.backend.CloseAttachOnly(i)
+}
+
 func (i *Instance) Preview() (string, error) {
 	return i.backend.Preview(i)
 }

--- a/session/tmux/race_test.go
+++ b/session/tmux/race_test.go
@@ -333,3 +333,50 @@ func TestCloseWithoutAttach(t *testing.T) {
 		t.Fatalf("Close: %v", err)
 	}
 }
+
+// TestCloseAttachOnly_DoesNotKillSession verifies the non-destructive close
+// added for sachiniyer/agent-factory#867: CloseAttachOnly releases the attach
+// PTY this client opened in Restore but must NEVER run `tmux kill-session`.
+// The daemon uses it to discard a duplicate Instance built from disk while the
+// canonical, still-tracked Instance shares the same live tmux session — a
+// kill-session there would tear that session out from under the canonical.
+func TestCloseAttachOnly_DoesNotKillSession(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+	var killSessionCalls int
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "kill-session") {
+				killSessionCalls++
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("attach-only", ""), "claude", ptyFactory, cmdExec)
+	// Restore opens the attach PTY — the resource a daemon duplicate holds (#867).
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if session.ptmx == nil {
+		t.Fatalf("Restore should have opened a PTY")
+	}
+
+	if err := session.CloseAttachOnly(); err != nil {
+		t.Fatalf("CloseAttachOnly: %v", err)
+	}
+
+	if killSessionCalls != 0 {
+		t.Fatalf("CloseAttachOnly issued %d kill-session calls; want 0 (must not kill the shared session)", killSessionCalls)
+	}
+	if session.ptmx != nil {
+		t.Fatalf("CloseAttachOnly must release the attach PTY (ptmx still set)")
+	}
+	// The PTY file must actually be closed (fd reclaimed), not just nil'd out.
+	if len(ptyFactory.files) != 1 {
+		t.Fatalf("expected exactly one PTY file, got %d", len(ptyFactory.files))
+	}
+	if err := ptyFactory.files[0].Close(); err == nil {
+		t.Fatalf("PTY file should already be closed by CloseAttachOnly")
+	}
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -926,6 +926,71 @@ func (t *TmuxSession) Close() error {
 	return errors.New(errMsg)
 }
 
+// CloseAttachOnly tears down this client's connection to the tmux session — it
+// closes the attach PTY and SIGKILLs the `tmux attach-session` child process —
+// WITHOUT running `tmux kill-session`. The server-side session, and any
+// worktree behind it, are left running.
+//
+// It is the non-destructive sibling of Close: Close kills the session,
+// CloseAttachOnly only releases the resources this particular TmuxSession
+// object opened in Restore/Attach. The daemon uses it to reclaim the PTY held
+// by a throwaway TmuxSession built from disk (#867) when the canonical,
+// still-tracked instance shares the same live session — calling Close there
+// would kill that session out from under the canonical instance.
+func (t *TmuxSession) CloseAttachOnly() error {
+	var errs []error
+
+	// Mirror Close/Detach ordering: cancel any Attach goroutines before
+	// touching t.ptmx so monitorWindowSize can't race a nil PTY. In the
+	// daemon's Restore-only path these are nil and this is a no-op.
+	if t.cancel != nil {
+		t.cancel()
+		t.cancel = nil
+	}
+
+	if t.ptmx != nil {
+		if err := t.ptmx.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("error closing PTY: %w", err))
+		}
+	}
+
+	// Best-effort SIGKILL of the attach-session child so the client process
+	// doesn't linger. Closing the PTY master above already hangs up the
+	// client's controlling terminal, so this is belt-and-suspenders: a failure
+	// (process never started, or already exited) is benign and must not fail
+	// the close — the leaked-fd reclamation that #867 is about is the PTY close
+	// above, not this. It detaches the client only; it never kills the session.
+	if t.killAttach != nil {
+		if _, err := t.killAttach(); err != nil {
+			log.WarningLog.Printf("tmux %s: best-effort kill of attach process failed: %v", t.sanitizedName, err)
+		}
+	}
+
+	_ = t.waitForAttachDrain()
+	t.wg = nil
+
+	t.ptmx = nil
+	t.ctx = nil
+	t.killAttach = nil
+
+	if t.attachCh != nil {
+		close(t.attachCh)
+		t.attachCh = nil
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	errMsg := "multiple errors occurred during attach close:"
+	for _, err := range errs {
+		errMsg += "\n  - " + err.Error()
+	}
+	return errors.New(errMsg)
+}
+
 // paneExitWait bounds how long CloseAndWaitForPaneExit blocks for the pane
 // process to die. Long enough for an agent to handle SIGHUP and flush state,
 // short enough that teardown of a wedged process doesn't hang the caller.

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -24,6 +24,8 @@ func (b *startBackend) Kill(instance *session.Instance) error {
 	return nil
 }
 
+func (b *startBackend) CloseAttachOnly(*session.Instance) error { return nil }
+
 func (b *startBackend) Preview(*session.Instance) (string, error) {
 	return "ready\n❯", nil
 }


### PR DESCRIPTION
## Summary

`daemon.findSession` released `m.mu` before building a `session.Instance` from disk, so a concurrent refresh (or another RPC) could restore and register the **canonical** Instance during that window. The pre-fix code returned its freshly-built duplicate regardless — an **untracked** Instance owning its own restore-time attach PTY:

- **SendPrompt** sent the prompt to the duplicate and then dropped it, leaking the attach PTY + `tmux attach-session` child until GC.
- **KillSession** called `instance.Kill()` on the duplicate, running `tmux kill-session` and the worktree cleanup — tearing down the live session that the canonical, still-tracked Instance shared.

This is the same "construct throwaway instances from disk → refresh orphans them" race the `requireManagerReady` warm-up gate notes, and the same pattern the `CreateSession` fix closed for #509 — but `findSession` was never folded into that fix.

## Fix

`findSession` now re-acquires `m.mu` after building from disk and either:

- returns the **canonical** Instance when one is now tracked, discarding the duplicate via a new **non-destructive** `CloseAttachOnly` path (releases the PTY / attach child, **never** runs `kill-session`); or
- **registers** the Instance it built so callers always operate on a *tracked* Instance — exactly what the refresh loop would have produced — instead of an orphan.

The invariant "`findSession` never returns an untracked Instance" now holds under the periodic refresh race. The tracked-path behavior of `KillSession`/`SendPrompt` is unchanged.

### New non-destructive close

- `Backend.CloseAttachOnly` + `TmuxSession.CloseAttachOnly`: close the attach PTY master and best-effort SIGKILL the `attach-session` child **without** `tmux kill-session`. The PTY close is the leaked-fd reclamation; the SIGKILL is belt-and-suspenders (benign if the process never started or already exited).
- `LocalBackend` closes the tmux attach PTY; `HookBackend` stops the remote preview process **without** `delete_cmd` (so the live remote session survives); `FakeBackend` / test `startBackend` are no-ops.
- `findSession` now builds via the `fromInstanceDataForRefresh` seam shared with the refresh loop (consistent + testable), and AutoYes-enables registered instances to match how the daemon tracks every other session.

## Adjacent call-site audit (per CLAUDE.md)

The #867 race requires a long-lived **shared instance map mutated by a concurrent refresh goroutine** while a lock is released. That structure exists only in the daemon, and both `findSession` callers (`KillSession`, `SendPrompt`) are fixed centrally in `findSession`. The other `FromInstanceData` sites do **not** share it:

- `api/api.go` / `api/sessions.go` (`findLiveInstanceByTitle`, `killSessionDirect`): single-shot CLI commands in their own process — no shared map, no refresh loop. `sessions kill` routes through the daemon (`daemon.KillSession`) and so inherits this fix.
- `app/` (`sync.go`, `session_control.go`): the TUI's event-loop-owned list, already guarded against async-refresh instance swaps (#765).

## Tests

- `daemon/find_session_test.go` — deterministic race tests driving the window through the `fromInstanceDataForRefresh` seam:
  - canonical raced in → findSession returns the tracked instance, duplicate discarded via `CloseAttachOnly` (asserted), `Kill` **never** called on the duplicate or the canonical.
  - genuinely untracked → the restored instance is registered (tracked, AutoYes), no `CloseAttachOnly`/`Kill`, no leak.
  - already tracked → returns it without building from disk at all.
- `session/tmux` — `CloseAttachOnly` releases the PTY (fd closed) and asserts **zero** `kill-session` calls.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, and `deadcode -test ./...` all clean. `go test ./...` green; bounded `-race` (`GOFLAGS=-p=1 -parallel 2`) green on `session`, `session/tmux`, `daemon`, `task`.

Fixes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)