### PR TITLE
test(daemon): de-flake the sigterm-fallback family by removing wall-clock dependence (#878)

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -168,17 +168,12 @@ func TestStopDaemon_SIGTERMFirst(t *testing.T) {
 		_, _ = cmd.Process.Wait()
 	}()
 
-	// Wait for the post-exec cmdline to be readable.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if isAgentFactoryDaemon(pid) {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if !isAgentFactoryDaemon(pid) {
-		t.Fatalf("fake daemon pid=%d not recognized as agent-factory daemon", pid)
-	}
+	// Wait for the post-exec cmdline to be readable. Event-driven with a
+	// generous bound so a loaded runner cannot expire the old fixed 2s wait
+	// before the exec lands (#878).
+	waitForReady(t, fmt.Sprintf("fake daemon pid=%d cmdline exposes --daemon", pid), func() bool {
+		return isAgentFactoryDaemon(pid)
+	})
 
 	// Reap in a goroutine so /proc/<pid>/cmdline clears once the process
 	// exits — otherwise pidLooksAlive keeps seeing the zombie as alive and
@@ -271,19 +266,15 @@ func TestStopDaemon_EscalatesToSIGKILL(t *testing.T) {
 		_, _ = cmd.Process.Wait()
 	}()
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(readyFile); err == nil && isAgentFactoryDaemon(pid) {
-			break
+	// Wait until the trap is installed (sentinel present) AND the rewritten
+	// cmdline is visible. Event-driven with a generous bound so a loaded runner
+	// cannot expire the old fixed 2s wait before the child is ready (#878).
+	waitForReady(t, fmt.Sprintf("trap-ready sentinel + pid=%d cmdline exposes --daemon", pid), func() bool {
+		if _, err := os.Stat(readyFile); err != nil {
+			return false
 		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if _, err := os.Stat(readyFile); err != nil {
-		t.Fatalf("ready sentinel never appeared (trap not installed): %v", err)
-	}
-	if !isAgentFactoryDaemon(pid) {
-		t.Fatalf("fake daemon pid=%d cmdline does not match --daemon", pid)
-	}
+		return isAgentFactoryDaemon(pid)
+	})
 
 	exited := make(chan *os.ProcessState, 1)
 	go func() {

--- a/daemon/sigterm_fallback_test.go
+++ b/daemon/sigterm_fallback_test.go
@@ -186,15 +186,14 @@ func spawnFakeDaemonWithDaemonFlag(t *testing.T) *exec.Cmd {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start fake daemon: %v", err)
 	}
-	// Wait briefly for bash to exec into sleep so the cmdline we read is
-	// the post-exec one with the rewritten argv[0]. Re-check up to ~500ms.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		if isAgentFactoryDaemon(cmd.Process.Pid) {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	// Wait for bash to exec into sleep so the cmdline we read is the post-exec
+	// one with the rewritten argv[0]. Event-driven with a generous bound so a
+	// loaded CI runner cannot miss the window — the old fixed ~500ms wait could
+	// expire just before the exec landed, failing the caller's cmdline sanity
+	// check spuriously (#878).
+	waitForReady(t, "fake daemon cmdline exposes --daemon", func() bool {
+		return isAgentFactoryDaemon(cmd.Process.Pid)
+	})
 	return cmd
 }
 

--- a/daemon/spawn_reap_test.go
+++ b/daemon/spawn_reap_test.go
@@ -2,10 +2,10 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"syscall"
 	"testing"
-	"time"
 )
 
 // TestStartDaemonChildReapsExitedChild pins the #816 fix: startDaemonChild
@@ -29,12 +29,12 @@ func TestStartDaemonChildReapsExitedChild(t *testing.T) {
 		t.Fatalf("startDaemonChild: %v", err)
 	}
 
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
-			return // child exited and was reaped
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("child PID %d still occupies a process-table slot 5s after exit; daemon child was not reaped (#816)", pid)
+	// `true` exits immediately; once startDaemonChild reaps it the kernel
+	// releases the PID and signal 0 returns ESRCH. Event-driven with a generous
+	// bound so a loaded runner cannot expire the wait before the reap lands
+	// (#878) — a genuine reap regression (#816) still fails, just after the
+	// generous timeout.
+	waitForReady(t, fmt.Sprintf("daemon child PID %d reaped (signal 0 -> ESRCH)", pid), func() bool {
+		return errors.Is(syscall.Kill(pid, 0), syscall.ESRCH)
+	})
 }

--- a/daemon/spawn_stop_race_test.go
+++ b/daemon/spawn_stop_race_test.go
@@ -68,16 +68,11 @@ func TestStopDaemon_PreservesNewDaemonSocket(t *testing.T) {
 		_, _ = cmd.Process.Wait()
 	}()
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if isAgentFactoryDaemon(pid) {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if !isAgentFactoryDaemon(pid) {
-		t.Fatalf("fake daemon pid=%d not recognized as agent-factory daemon", pid)
-	}
+	// Event-driven readiness with a generous bound so a loaded runner cannot
+	// expire the old fixed 2s wait before the exec rewrites the cmdline (#878).
+	waitForReady(t, fmt.Sprintf("fake daemon pid=%d cmdline exposes --daemon", pid), func() bool {
+		return isAgentFactoryDaemon(pid)
+	})
 
 	// Reap A in a goroutine so /proc/<pid>/cmdline clears once it exits and
 	// the StopDaemon poll observes the death promptly.

--- a/daemon/spawn_wait_test.go
+++ b/daemon/spawn_wait_test.go
@@ -1,0 +1,38 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+// testSpawnReadyTimeout bounds how long the spawn/kill tests wait for a real
+// child process to reach an OBSERVABLE state — its rewritten cmdline becoming
+// visible (`exec -a` argv[0] rewrite) or a trap-ready sentinel file appearing.
+// It is deliberately far larger than the few milliseconds that transition takes
+// on a healthy box: the tests poll an observable condition, so an over-generous
+// bound costs nothing on success yet removes the wall-clock race that made the
+// TestSigtermFallback_* / TestStopDaemon_* family flake under CI runner load
+// (#878). This is a TEST wait bound only — production grace/timeouts
+// (sigtermFallbackGrace, stopDaemonGrace) are unchanged.
+const testSpawnReadyTimeout = 20 * time.Second
+
+// waitForReady polls cond until it returns true, sleeping briefly between
+// checks, and fails the test if cond is still false after testSpawnReadyTimeout.
+// It is the event-driven replacement for the family's old fixed-bound readiness
+// loops (500ms / 2s), which could expire just before a loaded runner finished
+// spawning the child and rewriting its cmdline. desc names what we were waiting
+// for so a genuine hang (as opposed to a too-tight bound) produces an
+// actionable failure rather than a misleading downstream assertion.
+func waitForReady(t *testing.T, desc string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(testSpawnReadyTimeout)
+	for {
+		if cond() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("waited %s but condition never held: %s", testSpawnReadyTimeout, desc)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Problem

The `TestSigtermFallback_*` / `TestStopDaemon_*` family spawns real child processes whose `/proc/<pid>/cmdline` only exposes `--daemon` *after* bash finishes an `exec -a` argv[0] rewrite. The tests waited for that observable state with **fixed bounds** — 500ms in `spawnFakeDaemonWithDaemonFlag`, 2s in the `StopDaemon` tests. Under CI runner load the rewrite can land just after the bound expires, so the follow-up `isAgentFactoryDaemon` sanity check fails and the test reports spurious red:

- PR #876 (an `api/`-only change) failed on `--- FAIL: TestSigtermFallback_KillsPIDFileDaemon` — a test it never touches.
- The 06-12 master **Build** flake (re-run passed green).

This is timing-based flake, not a real bug — exactly the class #878 calls out.

## Fix

Replace the fixed readiness bounds with a shared **event-driven** helper, `waitForReady` (`daemon/spawn_wait_test.go`), that polls the observable condition until it holds with a generous 20s bound and `t.Fatalf`s only on a genuine hang. On a healthy box it resolves on the first poll; under load it cannot miss the window.

Converted call sites:
- `spawnFakeDaemonWithDaemonFlag` (the helper behind `TestSigtermFallback_KillsPIDFileDaemon`) — the reported flake
- `TestStopDaemon_SIGTERMFirst`
- `TestStopDaemon_EscalatesToSIGKILL` (trap-ready sentinel + cmdline)
- `TestStopDaemon_PreservesNewDaemonSocket`
- `TestStartDaemonChildReapsExitedChild` ESRCH poll (#816), for uniformity

## Audit of the rest of the family

- **Post-spawn waits** (5s/8s exit channels) and `signalAndWait`'s liveness probe already resolve promptly and event-driven (a SIGTERM'd process has an empty cmdline → reported dead on the next poll). Left as-is.
- **Warm-up tests** (#829) retry bounded by `daemonWarmupWait = 5s` against a 300ms forced delay (16× headroom) and gate on channel closes — no wall-clock assertion. Left as-is.
- **Dev-box `TestSigtermFallback_DeadPID`** host-state concern is already hermetic via `stubDaemonScan` (#793) — separate from this CI flake, no change needed.

## No production behavior change

Only **test** wait bounds become generous / event-driven. `sigtermFallbackGrace` (5s) and `stopDaemonGrace` are untouched. Diff is test-only.

## Acceptance

```
$ go test -race -count=20 -timeout=30m ./daemon/
ok  	github.com/sachiniyer/agent-factory/daemon	749.177s
```

Green and reproducible. Note: the default 600s `go test` timeout is too short for 20 race iterations of the whole package (~40s/run × 20 ≈ 12.5min), so `-timeout=30m` is required — that earlier timeout, not any hang, was the only failure on the first attempt.

CI gates: `go build ./...`, `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `deadcode -test ./...`, and `go test -race` all pass.

Fixes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)
