### PR TITLE
feat: add install.sh for no-Go binary installation + README rewrite (#884)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,50 @@ Fork of [claude-squad](https://github.com/smtg-ai/claude-squad) with per-repo sc
 
 ## Install
 
-Prerequisites: **Go 1.24+**, **tmux**, **git**, and at least one AI coding agent installed (e.g. [Claude Code](https://docs.anthropic.com/en/docs/claude-code)).
+Prerequisites: **tmux**, **git**, and at least one AI coding agent installed (e.g. [Claude Code](https://docs.anthropic.com/en/docs/claude-code)). **Go is not required** for the binary install below.
+
+Prebuilt binaries are published for Linux and macOS on amd64 and arm64.
 
 ```bash
-# From source (recommended)
+# Recommended: download and install the latest release binary
+curl -fsSL https://raw.githubusercontent.com/sachiniyer/agent-factory/master/install.sh | sh
+```
+
+This installs `af` to `~/.local/bin/af` (override with `AF_INSTALL_DIR`) and prints a PATH hint if that directory isn't on your `PATH`. To pin a release, pass `--version`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sachiniyer/agent-factory/master/install.sh | sh -s -- --version v1.0.114
+```
+
+Re-running the script upgrades in place; you can also run `af upgrade` later.
+
+### Manual download
+
+If you'd rather not pipe a script to your shell, grab the tarball for your platform from the [Releases page](https://github.com/sachiniyer/agent-factory/releases/latest) and install it yourself. Replace `linux-amd64` with `linux-arm64`, `darwin-amd64`, or `darwin-arm64` as appropriate:
+
+```bash
+curl -fsSL -o agent-factory.tar.gz \
+  https://github.com/sachiniyer/agent-factory/releases/latest/download/agent-factory-linux-amd64.tar.gz
+tar xzf agent-factory.tar.gz          # extracts a single binary named `agent-factory`
+mkdir -p ~/.local/bin
+mv agent-factory ~/.local/bin/af
+chmod +x ~/.local/bin/af
+```
+
+### Building from source
+
+For contributors, or if no prebuilt binary fits your platform. Requires **Go 1.24+** in addition to the prerequisites above.
+
+```bash
 git clone https://github.com/sachiniyer/agent-factory.git
 cd agent-factory
-./dev-install.sh
+./dev-install.sh    # builds `af` and installs it to ~/.local/bin/ (override with BIN_DIR)
 
-# Or build manually
+# Or build the binary manually
 go build -o af .
 ```
 
-The `dev-install.sh` script builds the `af` binary and installs it to `~/.local/bin/`.
+### Launch
 
 ```bash
 cd your-project    # must be a git repo

--- a/docs/release-testing-plan.md
+++ b/docs/release-testing-plan.md
@@ -56,7 +56,7 @@ Expected result:
 | Scheduled tasks | Unit tests cover cron parsing/validation agreement, the in-daemon scheduler (registration, CRUD reload, firing), the watcher supervisor (event delivery, backoff, crash-loop breaker, rate limiting, process-group kills), target-session delivery, the legacy-unit upgrade sweep, daemon autostart unit generation, task CRUD, and task runner storage. Integration tests run the same task twice and verify `name` then `name-2`. | Add a task with a cron one minute out, confirm the daemon fires it (a session appears), then remove the task and confirm the schedule is gone via another fire window. Verify `af daemon install`/`uninstall` on Linux (systemd user service) and macOS (launchd agent) before releases that change daemon lifecycle code. |
 | Remote hooks | Session and integration tests cover launch/list/import/attach/delete/terminal protocols, bad JSON, command failures, duplicate imports, and imported display-title deletion. | Configure `examples/remote-hooks` or a repo-local fake hook set, import, preview, and delete a remote session. |
 | Reset/cleanup | Unit tests cover ghost sessions and worktree cleanup helpers. | With temp `AGENT_FACTORY_HOME`, create two sessions, run `af reset`, then confirm tmux sessions, worktrees, and stored instances are gone. |
-| Upgrade/release artifacts | Unit tests cover binary download (success, non-200, stalled body, stalled headers), archive extraction, and daemon restart after binary swap; CI builds Linux/macOS artifacts. | Download the release tarball for the host platform, unpack it, run `af version`, and test `af upgrade` from the previous release binary. |
+| Upgrade/release artifacts | Unit tests cover binary download (success, non-200, stalled body, stalled headers), archive extraction, and daemon restart after binary swap; CI builds Linux/macOS artifacts. | Download the release tarball for the host platform, unpack it, run `af version`, and test `af upgrade` from the previous release binary. Run `install.sh` into a temp `AF_INSTALL_DIR` and confirm it fetches the latest release and `af version` reports the new tag. |
 | UI rendering | UI tests cover sidebar/menu/task pane/preview/terminal layout and overlay behavior. | Open the TUI in a narrow terminal and a normal terminal, verify text does not overlap, and check help/confirmation overlays. |
 
 ## Manual Smoke
@@ -108,6 +108,17 @@ Expected result:
   `darwin-arm64`.
 - Each archive contains one executable named `agent-factory`.
 - The host-platform binary runs `version` and reports the new tag.
+
+Then confirm the no-Go install path fetches the freshly published release:
+
+```bash
+AF_INSTALL_DIR="$(mktemp -d)" sh install.sh
+```
+
+Expected result:
+- `install.sh` downloads `agent-factory-<os>-<arch>.tar.gz` via the
+  `releases/latest/download/...` redirect, installs `af`, and the printed
+  `af version` reports the new tag.
 
 ## Go/No-Go Criteria
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+# install.sh — install the `af` (Agent Factory) binary without needing Go.
+#
+# Downloads the prebuilt release tarball for your OS/arch from GitHub and
+# installs `af` into ${AF_INSTALL_DIR:-$HOME/.local/bin}. No GitHub API call
+# or token is required: it fetches the stable "releases/latest/download/..."
+# redirect.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/sachiniyer/agent-factory/master/install.sh | sh
+#
+#   # install into a custom directory
+#   AF_INSTALL_DIR=/usr/local/bin sh install.sh
+#
+#   # pin a specific release tag (default: latest)
+#   sh install.sh --version v1.0.114
+#   AF_VERSION=v1.0.114 sh install.sh
+#
+# POSIX sh — no bashisms. Re-running upgrades in place.
+
+set -eu
+
+REPO="sachiniyer/agent-factory"
+INSTALL_DIR="${AF_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${AF_VERSION:-latest}"
+
+# --- argument parsing ------------------------------------------------------
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--version)
+			if [ $# -lt 2 ]; then
+				echo "error: --version requires a tag argument (e.g. --version v1.0.114)" >&2
+				exit 1
+			fi
+			VERSION="$2"
+			shift 2
+			;;
+		--version=*)
+			VERSION="${1#--version=}"
+			shift
+			;;
+		-h|--help)
+			# Print the header comment block (skip the shebang, stop at the
+			# first non-comment line).
+			awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
+			exit 0
+			;;
+		*)
+			echo "error: unknown argument: $1" >&2
+			echo "usage: install.sh [--version <tag>]" >&2
+			exit 1
+			;;
+	esac
+done
+
+# --- platform detection ----------------------------------------------------
+uname_s="$(uname -s)"
+case "$uname_s" in
+	Linux) os="linux" ;;
+	Darwin) os="darwin" ;;
+	*)
+		echo "error: unsupported operating system: $uname_s" >&2
+		echo "Prebuilt binaries are available for Linux and macOS only." >&2
+		echo "On other platforms, build from source: https://github.com/$REPO#building-from-source" >&2
+		exit 1
+		;;
+esac
+
+uname_m="$(uname -m)"
+case "$uname_m" in
+	x86_64|amd64) arch="amd64" ;;
+	arm64|aarch64) arch="arm64" ;;
+	*)
+		echo "error: unsupported architecture: $uname_m" >&2
+		echo "Prebuilt binaries are available for amd64 (x86_64) and arm64 only." >&2
+		echo "On other architectures, build from source: https://github.com/$REPO#building-from-source" >&2
+		exit 1
+		;;
+esac
+
+asset="agent-factory-${os}-${arch}.tar.gz"
+if [ "$VERSION" = "latest" ]; then
+	url="https://github.com/$REPO/releases/latest/download/$asset"
+else
+	url="https://github.com/$REPO/releases/download/$VERSION/$asset"
+fi
+
+# --- downloader (curl, falling back to wget) -------------------------------
+download() {
+	# download <url> <dest>
+	if command -v curl >/dev/null 2>&1; then
+		# -f: fail on HTTP error, -S: show errors, -L: follow redirects.
+		curl -fSL --connect-timeout 30 --max-time 300 -o "$2" "$1"
+	elif command -v wget >/dev/null 2>&1; then
+		wget --timeout=30 -O "$2" "$1"
+	else
+		echo "error: neither curl nor wget is installed; cannot download $1" >&2
+		exit 1
+	fi
+}
+
+# --- download into a temp dir, verify, install -----------------------------
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/af-install.XXXXXX")"
+cleanup() { rm -rf "$tmpdir"; }
+trap cleanup EXIT INT TERM
+
+tarball="$tmpdir/$asset"
+
+echo "Downloading $asset ($VERSION) for $os/$arch..."
+if ! download "$url" "$tarball"; then
+	echo "error: download failed from $url" >&2
+	echo "Check your network, or that the release/tag exists at https://github.com/$REPO/releases" >&2
+	exit 1
+fi
+
+# Verify the body is a real gzip/tar archive, not an HTML error page or a
+# truncated download. A broken install is worse than no install.
+if ! tar tzf "$tarball" >/dev/null 2>&1; then
+	echo "error: downloaded file is not a valid gzip/tar archive: $tarball" >&2
+	echo "The download may be incomplete or the URL may have returned an error page." >&2
+	echo "URL: $url" >&2
+	exit 1
+fi
+
+echo "Extracting..."
+tar xzf "$tarball" -C "$tmpdir"
+
+# The release tarball contains a single binary named `agent-factory`; we
+# install it under the friendlier name `af`.
+if [ ! -f "$tmpdir/agent-factory" ]; then
+	echo "error: archive did not contain the expected 'agent-factory' binary" >&2
+	exit 1
+fi
+
+mkdir -p "$INSTALL_DIR"
+chmod +x "$tmpdir/agent-factory"
+# Move into place (atomic when on the same filesystem); fall back to cp for
+# cross-filesystem temp dirs.
+if ! mv "$tmpdir/agent-factory" "$INSTALL_DIR/af" 2>/dev/null; then
+	cp "$tmpdir/agent-factory" "$INSTALL_DIR/af"
+fi
+chmod +x "$INSTALL_DIR/af"
+
+echo "Installed af to $INSTALL_DIR/af"
+
+# --- post-install: version + PATH hint -------------------------------------
+installed_version="$("$INSTALL_DIR/af" version 2>/dev/null || echo "unknown")"
+echo "Version: $installed_version"
+
+case ":$PATH:" in
+	*":$INSTALL_DIR:"*)
+		echo "Run 'af' in a git repository to launch the TUI."
+		;;
+	*)
+		echo ""
+		echo "NOTE: $INSTALL_DIR is not on your PATH."
+		echo "Add it to your shell profile, e.g.:"
+		echo "    export PATH=\"$INSTALL_DIR:\$PATH\""
+		echo "Then restart your shell, or run af directly: $INSTALL_DIR/af"
+		;;
+esac


### PR DESCRIPTION
## What

Adds a no-Go binary install path so users can install `af` without a Go toolchain — the gap called out in #884. Every release already publishes `agent-factory-{linux,darwin}-{amd64,arm64}.tar.gz` (and `af upgrade` consumes them); this just closes the install-time gap.

### 1. `install.sh` at repo root

A POSIX-sh (`#!/bin/sh`, `set -eu`, no bashisms) installer:

```
curl -fsSL https://raw.githubusercontent.com/sachiniyer/agent-factory/master/install.sh | sh
```

- Detects OS/arch via `uname` and maps to the release asset name.
- Downloads the **latest** release with **no GitHub API call or token**, via the stable redirect:
  `https://github.com/sachiniyer/agent-factory/releases/latest/download/agent-factory-<os>-<arch>.tar.gz`
- `curl -fSL` with connect/total timeouts; falls back to `wget` if curl is absent.
- Verifies the body is a real archive (`tar tzf`) before installing — a partial download or an HTML error page fails loudly instead of installing garbage.
- Downloads to a temp dir and moves into place (atomic on the same FS, `cp` fallback cross-FS); installs to `${AF_INSTALL_DIR:-$HOME/.local/bin}/af`, `chmod +x`.
- Prints the installed `af version` and a PATH hint when the install dir isn't on `PATH`.
- Idempotent — re-running upgrades in place.
- Nice-to-have: pin a release with `--version <tag>` or `AF_VERSION=<tag>` (default: latest).

### Platform matrix

| OS (`uname -s`) | Arch (`uname -m`) | Asset |
| --- | --- | --- |
| `Linux` | `x86_64`/`amd64` | `agent-factory-linux-amd64.tar.gz` |
| `Linux` | `aarch64`/`arm64` | `agent-factory-linux-arm64.tar.gz` |
| `Darwin` | `x86_64`/`amd64` | `agent-factory-darwin-amd64.tar.gz` |
| `Darwin` | `arm64` | `agent-factory-darwin-arm64.tar.gz` |

Anything else (Windows, 386/i686, etc.) errors clearly and points at the build-from-source instructions.

### Why no GitHub API is needed

GitHub serves a stable, unauthenticated redirect at `releases/latest/download/<asset>` that 302s to the current latest release's asset. No `/repos/.../releases/latest` API call (which is rate-limited and may need a token) — just `curl -fSL` following the redirect.

### Manual fallback (no pipe-to-shell)

For users who'd rather not pipe a script to a shell, the README documents grabbing the tarball from the Releases page, `tar xzf` (yields a single `agent-factory` binary), and moving it to `~/.local/bin/af`.

### 2. README Install rewrite

- Binary install is the recommended path; prerequisites are now **tmux, git, an agent — not Go**.
- Manual-download fallback documented.
- From-source (`dev-install.sh` / `go build`, Go 1.24+) retained as a "Building from source" subsection for contributors.

### 3. Docs

`docs/release-testing-plan.md` now includes an `install.sh` smoke check in the release-artifact verification.

## Testing (real runs)

`shellcheck install.sh` — clean. `gofmt -l .` clean, `go vet ./...` clean, `go build ./...` and `go test ./...` green (no Go files touched; `go.mod` untouched).

End-to-end against the **live** latest release into a temp `AF_INSTALL_DIR`:

```
$ AF_INSTALL_DIR=/tmp/tmp.XXXX/bin sh ./install.sh
Downloading agent-factory-linux-amd64.tar.gz (latest) for linux/amd64...
100 8495k  100 8495k    0     0  21.6M      0 --:--:-- --:--:-- --:--:-- 21.6M
Extracting...
Installed af to /tmp/tmp.XXXX/bin/af
Version: agent-factory version 1.0.114
https://github.com/sachiniyer/agent-factory/releases/tag/v1.0.114

NOTE: /tmp/tmp.XXXX/bin is not on your PATH.
...

$ /tmp/tmp.XXXX/bin/af version
agent-factory version 1.0.114
```

Also verified: idempotent re-run, `--version v1.0.114` pin, the on-PATH branch (prints the launch hint instead of the PATH note), a bad tag (`curl: (22) 404` → fails loudly, installs nothing), and `--version` with no argument (exits 1).

Fixes #884

— Captain Claude