### PR TITLE
fix(config): memoize the claude shell probe to cut startup latency (#883)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -212,13 +213,56 @@ func shellQuotePath(path string) string {
 	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
 }
 
+// claudeProbeResult caches a single (path, err) outcome of the claude shell
+// probe, keyed by the environment that determines it.
+type claudeProbeResult struct {
+	path string
+	err  error
+}
+
+var (
+	claudeProbeMu    sync.Mutex
+	claudeProbeCache = map[string]claudeProbeResult{}
+)
+
 // GetClaudeCommand attempts to find the "claude" command in the user's shell
 // It checks in the following order:
 // 1. Shell alias resolution (zsh's `which` builtin, bash's `type` builtin)
 // 2. PATH lookup
 //
 // If both fail, it returns an error.
+//
+// The result is memoized per process. A single TUI startup loads the config
+// up to four times (main's ResolveConfig, newHome's LoadConfig, the remote
+// hook import's ResolveConfig, and newHome's hooks ResolveConfig), and every
+// load rebuilds DefaultConfig — which ran this probe from scratch each time.
+// The probe spawns `bash -i` (or sources ~/.zshrc) to surface aliases, so on a
+// heavy interactive rc each call costs hundreds of milliseconds to seconds;
+// four of them dominated startup latency (#883). The claude resolution is a
+// pure function of SHELL, PATH, and HOME (HOME selects the rc file that can
+// define a claude alias), so caching on that triple collapses the four probes
+// into one while staying correct: any caller — or test — that changes those
+// vars gets a fresh probe under a new key.
 func GetClaudeCommand() (string, error) {
+	key := os.Getenv("SHELL") + "\x00" + os.Getenv("PATH") + "\x00" + os.Getenv("HOME")
+	claudeProbeMu.Lock()
+	cached, ok := claudeProbeCache[key]
+	claudeProbeMu.Unlock()
+	if ok {
+		return cached.path, cached.err
+	}
+
+	path, err := probeClaudeCommand()
+
+	claudeProbeMu.Lock()
+	claudeProbeCache[key] = claudeProbeResult{path: path, err: err}
+	claudeProbeMu.Unlock()
+	return path, err
+}
+
+// probeClaudeCommand performs the actual shell probe for the claude command.
+// GetClaudeCommand wraps it with per-environment memoization.
+func probeClaudeCommand() (string, error) {
 	shell := os.Getenv("SHELL")
 	if shell == "" {
 		shell = "/bin/bash" // Default to bash if SHELL is not set

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -254,6 +254,57 @@ func TestGetClaudeCommand(t *testing.T) {
 	})
 }
 
+// TestGetClaudeCommandMemoized pins the #883 fix: repeated probes that share
+// the same SHELL/PATH/HOME must source the rc only once, while a changed HOME
+// re-probes under a new cache key. A heavy interactive rc otherwise ran the
+// bash probe up to four times per TUI startup.
+func TestGetClaudeCommandMemoized(t *testing.T) {
+	bashPath := requireBash(t)
+
+	// A .bashrc that records every interactive sourcing into a marker file and
+	// defines a claude alias, so the probe both succeeds and is countable.
+	writeCountingBashrc := func(homeDir, marker string) {
+		bashrc := "case $- in\n    *i*) ;;\n      *) return;;\nesac\n" +
+			"echo x >> '" + marker + "'\n" +
+			"alias claude='/custom/bin/claude'\n"
+		require.NoError(t, os.WriteFile(filepath.Join(homeDir, ".bashrc"), []byte(bashrc), 0644))
+	}
+	sourceCount := func(marker string) int {
+		data, err := os.ReadFile(marker)
+		if os.IsNotExist(err) {
+			return 0
+		}
+		require.NoError(t, err)
+		return strings.Count(string(data), "x")
+	}
+
+	home1 := t.TempDir()
+	marker1 := filepath.Join(t.TempDir(), "sourced")
+	writeCountingBashrc(home1, marker1)
+
+	t.Setenv("SHELL", bashPath)
+	t.Setenv("PATH", t.TempDir()) // no claude on PATH — the alias is the only source
+	t.Setenv("HOME", home1)
+
+	for i := 0; i < 3; i++ {
+		result, err := GetClaudeCommand()
+		require.NoError(t, err)
+		assert.Equal(t, "/custom/bin/claude", result)
+	}
+	assert.Equal(t, 1, sourceCount(marker1), "stable env should probe (source the rc) exactly once")
+
+	// Changing HOME must invalidate the cache and probe again.
+	home2 := t.TempDir()
+	marker2 := filepath.Join(t.TempDir(), "sourced")
+	writeCountingBashrc(home2, marker2)
+	t.Setenv("HOME", home2)
+
+	result, err := GetClaudeCommand()
+	require.NoError(t, err)
+	assert.Equal(t, "/custom/bin/claude", result)
+	assert.Equal(t, 1, sourceCount(marker2), "a changed HOME should re-probe under a new cache key")
+}
+
 func TestDefaultConfig(t *testing.T) {
 	t.Run("default_program is the bare claude enum and override carries the detected command", func(t *testing.T) {
 		// Force GetClaudeCommand to find a stub claude in PATH so the test


### PR DESCRIPTION
Fixes #883

## What was slow

The `af` TUI loads the config **up to four times** during startup, each in service of a different consumer:

1. `main.go` — `ResolveConfig(repo.Root)` (resolve effective config before launching the TUI)
2. `app/newHome` — `LoadConfig()` (app config + detach key)
3. `app/newHome → importRemoteHookSessions` — `ResolveConfig(repo.Root)` (does this repo use remote hooks?)
4. `app/newHome` — `ResolveConfig(repo.Root)` (hook count for the sidebar/hooks pane)

Every one of those rebuilds `DefaultConfig()`, which calls `GetClaudeCommand()` — a shell probe that spawns `bash -i -c 'type claude'` (or sources `~/.zshrc`) to surface a `claude` alias (#688/#856). On a heavy interactive rc (nvm/pyenv/conda/completions) each probe costs hundreds of ms to seconds, and the four ran **serially before the TUI rendered**.

## Measurement

Built an instrumented binary and ran it in a temp `AGENT_FACTORY_HOME` with a simulated **0.5s** interactive rc:

| Phase | Plain repo | Remote-hooks repo |
|---|---|---|
| `LoadConfig` (probe ×1) | 0.51s | 0.51s |
| `importRemoteHookSessions` (probe ×1 + ssh `list_cmd`) | 0.51s | 3.58s |
| `ResolveConfig` hooks (probe ×1) | 0.51s | 0.51s |
| **`newHome` total** | **1.53s** | **4.60s** |

Plus the pre-`newHome` `ResolveConfig` in `main.go` adds a 4th probe (~0.5s). So **4 × rc-cost** is spent purely re-probing for claude. On a real maintainer machine where rc init is 1–2s, that's **4–8s** of avoidable startup latency.

The remote-hooks repo additionally pays a synchronous ssh `list_cmd` round-trip (~3s here). That cost is **inherent** — it's the user's own hook making a network call — and is already routed through the daemon and guarded by the #829 "daemon still restoring" early-return, so this PR does not touch it. (A future optimization could render the TUI first and fill remote sessions in asynchronously, like the daemon already does for restoration; not worth the risk here per the issue's "don't worry too much.")

## The fix

`GetClaudeCommand` is a pure function of `SHELL`, `PATH`, and `HOME` (HOME selects the rc file that can define a claude alias) — none of which change within one `af` process. Memoize the probe on that triple. The four probes collapse to **one per process**; any caller (or test) that changes those vars still gets a fresh probe under a new cache key, so behavior is otherwise identical.

### After

Verified with a throwaway harness against the same 0.5s rc:

```
call #1: 507ms   (real probe)
call #2: 7µs     (cached)
call #3: 3µs     (cached)
call #4: 0.4µs   (cached)
```

`newHome` on the plain repo drops from ~1.53s to ~0.51s; total avoidable probe cost goes from 4×rc to 1×rc.

## Tests / gates

- New `TestGetClaudeCommandMemoized`: stable env sources the rc exactly once across repeated calls; a changed `HOME` re-probes under a new key.
- `gofmt -l .`, `go build ./...`, `golangci-lint run --fast`, `deadcode -test ./...` all clean.
- `go test ./...` green; `-race` (bounded) green on `config` and `app`.
- Temporary timing instrumentation was removed — the diff is the fix + its test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)