### PR TITLE
fix(task): fail loudly when ID generation entropy is unavailable instead of emitting a zero ID (#897)

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -130,7 +130,10 @@ var tasksAddCmd = &cobra.Command{
 			return jsonError(err)
 		}
 
-		id := task.GenerateID()
+		id, err := task.GenerateID()
+		if err != nil {
+			return jsonError(fmt.Errorf("failed to generate task id: %w", err))
+		}
 		s := task.Task{
 			ID:            id,
 			Name:          taskAddNameFlag,

--- a/app/app.go
+++ b/app/app.go
@@ -628,8 +628,12 @@ func (m *home) handleTaskCreate() tea.Cmd {
 	if program == "" {
 		program = m.program
 	}
+	id, err := task.GenerateID()
+	if err != nil {
+		return m.handleError(fmt.Errorf("failed to generate task id: %v", err))
+	}
 	t := task.Task{
-		ID:            task.GenerateID(),
+		ID:            id,
 		Name:          name,
 		Prompt:        prompt,
 		CronExpr:      cronExpr,

--- a/task/task.go
+++ b/task/task.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -245,10 +246,23 @@ func GetTask(id string) (*Task, error) {
 	return nil, fmt.Errorf("task with id %q not found", id)
 }
 
-func GenerateID() string {
+// randReader is the entropy source for GenerateID. It is a package variable so
+// tests can substitute a failing reader; production reads from crypto/rand.
+var randReader io.Reader = rand.Reader
+
+// GenerateID returns a random 8-character (4-byte) hex task ID. It returns an
+// error when the system entropy source is unavailable instead of silently
+// emitting the all-zero "00000000" ID: task IDs are the handle users pass to
+// `af tasks get/remove/update <id>`, and duplicate IDs make GetTask/RemoveTask/
+// UpdateTask (all first-match) operate on the wrong task — silent data loss.
+// Callers must fail the operation loudly rather than persist a zero/colliding
+// ID. See #897.
+func GenerateID() (string, error) {
 	b := make([]byte, 4)
-	rand.Read(b)
-	return hex.EncodeToString(b)
+	if _, err := io.ReadFull(randReader, b); err != nil {
+		return "", fmt.Errorf("failed to generate random task ID: %w", err)
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // LoadTasksForCurrentRepo returns only tasks whose ProjectPath

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -204,11 +205,37 @@ func TestUpdateTaskPreservesSchedulerOwnedFields(t *testing.T) {
 }
 
 func TestGenerateID(t *testing.T) {
-	id1 := GenerateID()
-	id2 := GenerateID()
+	id1, err := GenerateID()
+	require.NoError(t, err)
+	id2, err := GenerateID()
+	require.NoError(t, err)
 	assert.Len(t, id1, 8) // 4 bytes = 8 hex chars
 	assert.Len(t, id2, 8)
 	assert.NotEqual(t, id1, id2)
+	assert.NotEqual(t, "00000000", id1, "a successful generation must never produce the all-zero ID")
+}
+
+// failingReader is an io.Reader that always fails, used to simulate an
+// unavailable system entropy source.
+type failingReader struct{}
+
+func (failingReader) Read(p []byte) (int, error) {
+	return 0, errors.New("entropy unavailable")
+}
+
+// TestGenerateIDEntropyFailure is the regression test for #897: when the
+// entropy source fails, GenerateID must return an error rather than silently
+// emit the predictable, collision-prone "00000000" ID that breaks first-match
+// get/remove/update semantics.
+func TestGenerateIDEntropyFailure(t *testing.T) {
+	orig := randReader
+	randReader = failingReader{}
+	t.Cleanup(func() { randReader = orig })
+
+	id, err := GenerateID()
+	require.Error(t, err, "GenerateID must surface the entropy failure")
+	assert.Empty(t, id, "no ID may be returned when entropy is unavailable")
+	assert.NotEqual(t, "00000000", id, "GenerateID must never emit the all-zero ID")
 }
 
 // TestLoadTaskWithoutProgramFieldFallsBackToEmpty verifies that a task record
@@ -293,8 +320,10 @@ func TestValidateTaskID_PathTraversalRejected(t *testing.T) {
 // GenerateID and the fixture IDs already used elsewhere in the test suite
 // continue to validate.
 func TestValidateTaskID_LegitimateAccepted(t *testing.T) {
+	genID, err := GenerateID()
+	require.NoError(t, err)
 	cases := []string{
-		GenerateID(), // 8 hex chars from production helper
+		genID, // 8 hex chars from production helper
 		"a1b2",
 		"abc1",
 		"x1",


### PR DESCRIPTION
## Problem

`task.GenerateID()` ignored the error from `crypto/rand.Read`. When the system entropy source fails, the 4-byte buffer stays zeroed and `hex.EncodeToString` returns the constant ID `"00000000"` for every task created during the failure.

Task IDs are the handle users pass to `af tasks get/remove/update <id>`, and `GetTask`/`RemoveTask`/`UpdateTask` are all **first-match**. Duplicate IDs therefore silently operate on the wrong task (data loss), and the scheduler only schedules the first occurrence — later tasks never run.

## Fix

- `GenerateID()` now returns `(string, error)` and reads via `io.ReadFull` from an injectable `randReader` (defaulting to `crypto/rand.Reader`), surfacing any entropy failure instead of emitting a zero ID.
- Both callers fail the operation loudly rather than persist a zero/colliding ID:
  - `af tasks add` API path (`api/tasks.go`) → `jsonError`
  - TUI task-create path (`app/app.go`) → `handleError`

## Adjacent-call-site audit

The only other dropped-error `rand.Read` site is `randomHex` in `session/git/util.go`. It is **intentionally left as-is**: it produces a fallback *branch-name suffix* (not an identity used for get/remove/update), and a zero/duplicate suffix surfaces loudly as a git branch-creation error rather than silent data loss — out of scope for this fix.

## Tests

- `TestGenerateIDEntropyFailure` (regression for #897): a failing entropy reader makes `GenerateID` return an error and never `"00000000"`.
- `TestGenerateID`: normal path returns a valid 8-hex-char, non-zero ID.

## Verification

`go build ./...`, `gofmt -l .`, `go test ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` all clean; `-race` (bounded) green on `task`/`api`/`app`.

Fixes #897

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)