### PR TITLE
fix(daemon): quote autostart-unit Environment values so spaces in PATH/SHELL/HOME survive (#893)

### DIFF
--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -35,17 +35,33 @@ func quoteExecStartPath(p string) string {
 	return `"` + escaped + `"`
 }
 
-// sanitizeEnvValue makes a value safe for an Environment= assignment.
-// systemd does not apply shell-style quote parsing to Environment= values,
-// so surrounding quotes would be preserved literally. Newlines are also
-// disallowed by systemd in Environment= values; replace them with spaces
-// rather than emitting a syntactically invalid unit file.
-func sanitizeEnvValue(v string) string {
-	v = strings.ReplaceAll(v, "\n", " ")
-	v = strings.ReplaceAll(v, "\r", " ")
-	v = strings.ReplaceAll(v, `$`, `$$`)
-	v = strings.ReplaceAll(v, `%`, `%%`)
-	return v
+// formatSystemdEnvLine renders one `Environment=NAME=value` line so systemd
+// parses the whole value, spaces and all.
+//
+// systemd tokenizes Environment= with quote-aware, C-unescaping parsing
+// (systemd.exec(5)): unquoted whitespace splits a single line into several
+// independent assignments, and an unquoted backslash or quote is consumed as
+// an escape. So when the value contains whitespace, a quote, or a backslash,
+// the entire NAME=value is wrapped in double quotes with backslashes and
+// double quotes escaped C-style inside. Values with no such characters are
+// emitted bare to avoid needless churn.
+//
+// '%' is a systemd specifier and is always doubled. '$' is left literal:
+// unlike ExecStart=, Environment= performs no variable expansion (verified
+// with `systemctl show` / `systemd-analyze verify`), so doubling it would
+// corrupt the value into a literal "$$". Newlines and carriage returns, which
+// systemd rejects in unit files, are folded to spaces.
+func formatSystemdEnvLine(name, value string) string {
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, `%`, `%%`)
+	assignment := name + "=" + value
+	if !strings.ContainsAny(value, " \t\"'\\") {
+		return "Environment=" + assignment
+	}
+	assignment = strings.ReplaceAll(assignment, `\`, `\\`)
+	assignment = strings.ReplaceAll(assignment, `"`, `\"`)
+	return `Environment="` + assignment + `"`
 }
 
 // systemdAutostartUnit renders the user-level systemd service that keeps the
@@ -56,9 +72,9 @@ func sanitizeEnvValue(v string) string {
 // shell has it set: without it the unit's daemon would serve the default
 // home instead of the custom one (#782).
 func systemdAutostartUnit(execPath, pathEnv, shellEnv, agentFactoryHome string) string {
-	envLines := fmt.Sprintf("Environment=PATH=%s\nEnvironment=SHELL=%s", sanitizeEnvValue(pathEnv), sanitizeEnvValue(shellEnv))
+	envLines := formatSystemdEnvLine("PATH", pathEnv) + "\n" + formatSystemdEnvLine("SHELL", shellEnv)
 	if agentFactoryHome != "" {
-		envLines += "\nEnvironment=AGENT_FACTORY_HOME=" + sanitizeEnvValue(agentFactoryHome)
+		envLines += "\n" + formatSystemdEnvLine("AGENT_FACTORY_HOME", agentFactoryHome)
 	}
 	return fmt.Sprintf(`[Unit]
 Description=Agent Factory daemon (task scheduler + autoyes)
@@ -79,6 +95,11 @@ WantedBy=default.target
 // Restart=on-failure behavior; logPath captures crashes that happen before
 // the daemon's own logging is up. AGENT_FACTORY_HOME is captured when set,
 // matching the systemd unit (#782).
+//
+// Unlike the systemd Environment= line (#893), no extra quoting is needed for
+// values with spaces: each value is its own XML <string> element, so spaces
+// are ordinary text content. html.EscapeString only needs to neutralize the
+// XML metacharacters (& < > " ') that would otherwise break the markup.
 func launchdAutostartPlist(execPath, pathEnv, shellEnv, agentFactoryHome, logPath string) string {
 	esc := html.EscapeString
 	homeEntry := ""

--- a/daemon/autostart_test.go
+++ b/daemon/autostart_test.go
@@ -30,15 +30,51 @@ WantedBy=default.target
 }
 
 // TestSystemdAutostartUnitEscapesSpecials pins the systemd quoting rules: a
-// binary path with spaces must stay one ExecStart argument, and % / $ must
-// be doubled so systemd does not expand them as specifiers/variables.
+// binary path with spaces must stay one ExecStart argument; '%' must be
+// doubled in Environment values so systemd does not expand it as a specifier;
+// '$' must be left literal because Environment= (unlike ExecStart=) performs
+// no variable expansion, so doubling it would corrupt the value (#893).
 func TestSystemdAutostartUnitEscapesSpecials(t *testing.T) {
 	got := systemdAutostartUnit("/opt/my tools/af", "/usr/bin:/home/u/100%path:$HOME/bin", "/bin/bash", "")
 	if !strings.Contains(got, `ExecStart="/opt/my tools/af" --daemon`) {
 		t.Errorf("path with spaces must be quoted in ExecStart, got:\n%s", got)
 	}
-	if !strings.Contains(got, "Environment=PATH=/usr/bin:/home/u/100%%path:$$HOME/bin") {
-		t.Errorf("%% and $ must be escaped in Environment values, got:\n%s", got)
+	if !strings.Contains(got, "Environment=PATH=/usr/bin:/home/u/100%%path:$HOME/bin") {
+		t.Errorf("%% must be doubled and $ left literal in Environment values, got:\n%s", got)
+	}
+}
+
+// TestSystemdAutostartUnitQuotesSpacedEnvValues is the #893 regression guard:
+// PATH/SHELL/AGENT_FACTORY_HOME values containing spaces must wrap the whole
+// NAME=value in double quotes so systemd parses one assignment instead of
+// splitting on the space and truncating the value.
+func TestSystemdAutostartUnitQuotesSpacedEnvValues(t *testing.T) {
+	got := systemdAutostartUnit("/home/user/.local/bin/af", "/usr/bin:/My Apps/bin", "/bin/zsh", "/srv/af home")
+	for _, want := range []string{
+		`Environment="PATH=/usr/bin:/My Apps/bin"`,
+		"Environment=SHELL=/bin/zsh",
+		`Environment="AGENT_FACTORY_HOME=/srv/af home"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	// The unquoted, truncating form must not appear for the spaced PATH.
+	if strings.Contains(got, "Environment=PATH=/usr/bin:/My Apps/bin") &&
+		!strings.Contains(got, `Environment="PATH=/usr/bin:/My Apps/bin"`) {
+		t.Errorf("spaced PATH must be quoted, got:\n%s", got)
+	}
+}
+
+// TestSystemdAutostartUnitEscapesQuotesAndBackslashes pins the in-quote
+// C-escaping: a value carrying a double quote or backslash (alongside a space,
+// which triggers quoting) must escape those characters so the wrapped value
+// round-trips through systemd's unescaping parser.
+func TestSystemdAutostartUnitEscapesQuotesAndBackslashes(t *testing.T) {
+	got := systemdAutostartUnit("/home/user/.local/bin/af", `/usr/bin:/a "b"/x:/c\d/y`, "/bin/zsh", "")
+	want := `Environment="PATH=/usr/bin:/a \"b\"/x:/c\\d/y"`
+	if !strings.Contains(got, want) {
+		t.Errorf("expected escaped+quoted PATH %q in:\n%s", want, got)
 	}
 }
 


### PR DESCRIPTION
## Problem

`af daemon install` writes a systemd user unit whose `Environment=` lines were emitted **unquoted**. systemd tokenizes `Environment=` with quote-aware parsing, so an unquoted space splits one assignment into several: a `PATH`, `SHELL`, or `AGENT_FACTORY_HOME` value containing a space was truncated at the first space, and the remainder was dropped as an invalid assignment (`systemd-analyze verify` reports `Invalid environment assignment, ignoring: ...`). If a directory holding `tmux` or an agent binary lived after the space, the supervised daemon couldn't find it.

The old `sanitizeEnvValue` never quoted, and its doc comment was factually wrong — it claimed systemd keeps surrounding quotes literal for `Environment=`. That's true for `WorkingDirectory=` but **false** for `Environment=`, which is exactly the confusion that introduced the bug (see #893 history).

## Fix

Replace `sanitizeEnvValue` with `formatSystemdEnvLine`, modeled on the existing `quoteExecStartPath`:

- Wraps the whole `NAME=value` in double quotes (escaping `\` and `"` C-style) when the value contains whitespace, a quote, or a backslash.
- Emits bare values otherwise, so no-space `PATH`/`SHELL` lines are byte-for-byte unchanged (no churn).
- Keeps `%` → `%%` (a genuine systemd specifier).
- **Stops** doubling `$`: `Environment=` performs no variable expansion (unlike `ExecStart=`), so the previous `$`→`$$` silently corrupted any value containing `$` into a literal `$$`. Confirmed against real systemd via `systemctl show`.

**launchd** needs no change — each value is its own XML `<string>`, so spaces are ordinary text content. Documented inline; the existing spaced-value plist test already covers it.

## Audit (per CLAUDE.md adjacent-call-sites)

`Environment=` is emitted in exactly one place (`systemdAutostartUnit`); `legacy_units.go` emits none. All three captured vars (`PATH`, `SHELL`, `AGENT_FACTORY_HOME`) now route through the formatter.

## Verification

- New golden tests: spaced `PATH`/`HOME` are quoted, no-space `SHELL` stays bare, and quote/backslash values escape correctly. Corrected the `$`-doubling test that encoded the latent bug.
- Round-tripped the **generated** unit through real systemd: `systemctl show` parses `PATH=/usr/bin:/My Apps/bin` and `AGENT_FACTORY_HOME=/srv/af home` as single values with spaces intact.
- CI gates green locally: `go build ./...`, `go test ./...`, `golangci-lint run --fast`, `gofmt -l .` (clean), `deadcode -test ./...` (clean), plus `-race` on `./daemon/`.

Fixes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)