### PR TITLE
fix(session): do not kill a live session when restore PTY allocation fails (#895)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -106,15 +106,22 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 					setupErr = fmt.Errorf("%v (cleanup error: %v)", setupErr, cleanupErr)
 				}
 			} else {
-				// Restore: only clean up tmux session, preserve the worktree
-				// to avoid data loss.
+				// Restore: the server-side tmux session may already be live
+				// (has-session passed) and we only failed to allocate the
+				// local attach PTY — e.g. EMFILE/ENOMEM in Restore (#895).
+				// Use CloseAttachOnly, NOT Close: Close runs `tmux
+				// kill-session` and would destroy a recoverable live session
+				// (scrollback + running processes), turning a transient attach
+				// failure into data loss. CloseAttachOnly releases only the
+				// local attach resources this object opened and leaves the
+				// server session and its worktree intact for a later retry.
 				i.mu.Lock()
 				ts := i.tmuxSession
 				i.tmuxSession = nil
 				i.started = false
 				i.mu.Unlock()
 				if ts != nil {
-					if cleanupErr := ts.Close(); cleanupErr != nil {
+					if cleanupErr := ts.CloseAttachOnly(); cleanupErr != nil {
 						setupErr = fmt.Errorf("%v (cleanup error: %v)", setupErr, cleanupErr)
 					}
 				}

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -1947,3 +1947,95 @@ func TestInstanceSupportsRemoteTerminal(t *testing.T) {
 		assert.Contains(t, err.Error(), "remote sessions")
 	})
 }
+
+// errPtyFactory is a tmux.PtyFactory whose Start always fails — it simulates a
+// PTY allocation failure (EMFILE/ENOMEM) on the attach path so a restore can
+// fail AFTER `tmux has-session` confirms the server-side session is alive.
+type errPtyFactory struct{ err error }
+
+func (e errPtyFactory) Start(_ *exec.Cmd) (*os.File, error) { return nil, e.err }
+func (e errPtyFactory) Close()                              {}
+
+// TestLocalBackendRestorePtyFailureDoesNotKillSession is the regression test
+// for issue #895. When restoring an existing instance, `tmux has-session`
+// confirms the server-side session is alive but the local attach PTY cannot be
+// allocated (EMFILE/ENOMEM), Restore returns an error. The deferred restore
+// cleanup in LocalBackend.Start must tear down only the local attach
+// resources (CloseAttachOnly) — it must NOT run `tmux kill-session`, which
+// would destroy a live, recoverable session (scrollback + running processes)
+// and turn a transient attach failure into data loss.
+func TestLocalBackendRestorePtyFailureDoesNotKillSession(t *testing.T) {
+	var mu sync.Mutex
+	var ran []string
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			mu.Lock()
+			ran = append(ran, strings.Join(c.Args, " "))
+			mu.Unlock()
+			// All commands (notably has-session) succeed → Restore takes the
+			// attach branch where the PTY allocation failure fires.
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+	}
+
+	ts := tmux.NewTmuxSessionWithDeps("restore-pty-fail", "claude",
+		errPtyFactory{err: fmt.Errorf("pty allocation failed")}, cmdExec)
+	inst := &Instance{
+		Title:       "restore-pty-fail",
+		backend:     &LocalBackend{},
+		started:     true,
+		tmuxSession: ts,
+	}
+
+	// firstTimeSetup=false → restore path. No gitWorktree is attached, so
+	// Restore is called with an empty workDir and a present session attaches
+	// (then fails at PTY) rather than re-spawning.
+	err := inst.backend.Start(inst, false)
+	require.Error(t, err, "restore must surface the PTY allocation failure")
+	assert.Contains(t, err.Error(), "pty allocation failed")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, c := range ran {
+		assert.NotContains(t, c, "kill-session",
+			"restore PTY failure must NOT kill the live tmux session (#895); ran: %v", ran)
+	}
+
+	// The local attach was still torn down: the instance no longer holds the
+	// session and is marked not-started so a later retry is clean.
+	assert.Nil(t, inst.tmuxSession, "attach resources should be released on restore failure")
+	assert.False(t, inst.Started(), "instance should be marked not-started after a failed restore")
+}
+
+// TestLocalBackendKillRunsKillSession is the counterpart to #895: a genuine
+// Kill must still run `tmux kill-session`. This guards against an
+// over-correction that would leak live sessions by never killing them.
+func TestLocalBackendKillRunsKillSession(t *testing.T) {
+	var mu sync.Mutex
+	var killed bool
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			if strings.Contains(strings.Join(c.Args, " "), "kill-session") {
+				mu.Lock()
+				killed = true
+				mu.Unlock()
+			}
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte(""), nil },
+	}
+
+	ts := tmux.NewTmuxSessionWithDeps("genuine-kill", "claude", nil, cmdExec)
+	inst := &Instance{
+		Title:       "genuine-kill",
+		backend:     &LocalBackend{},
+		started:     true,
+		tmuxSession: ts,
+	}
+
+	require.NoError(t, inst.Kill())
+	mu.Lock()
+	defer mu.Unlock()
+	assert.True(t, killed, "a genuine Kill must run tmux kill-session")
+}


### PR DESCRIPTION
## Problem

`TmuxSession.Restore()` can fail **after** `tmux has-session` confirms the server-side session is alive — specifically when the local attach client can't allocate a PTY (EMFILE/ENOMEM). In that case the live tmux session is still fully recoverable.

But `LocalBackend.Start`'s restore-failure cleanup called `ts.Close()`, which runs `tmux kill-session` and **destroys the live session**: terminal scrollback is lost and running processes are terminated. A transient attach failure becomes permanent data loss.

## Fix

On the restore-failure path, call `ts.CloseAttachOnly()` instead of `ts.Close()`. `CloseAttachOnly()` (added in #867) releases only the local attach resources this `TmuxSession` opened and leaves the server-side session — and its worktree — intact for a later retry. A genuine `Kill()` is untouched and still tears the session down.

## Adjacent-call-site audit (per CLAUDE.md)

Every `ts.Close()` / `kill-session` on a restore/attach-failure path was checked:

- **`tmux.go:235` (Start poll timeout)** and **`tmux.go:265` (Start's own attach failure)** — both operate on a **brand-new** session just created by `Start` (or a re-spawn where the prior session already died across a reboot). No live session/scrollback to preserve, so `Close()` is correct. Left as-is.
- **`backend_hook.go` restore path** — an `ensurePTY` failure simply returns an error and never invokes `delete_cmd`/`Kill`. Already non-destructive. Left as-is.

So `backend_local.go` was the only incorrect site.

## Tests

- `TestLocalBackendRestorePtyFailureDoesNotKillSession`: restore with a session that exists but a failing PTY factory → asserts **no `kill-session`** command is run and the local attach is still torn down (pointer cleared, instance marked not-started). Verified it **fails** against the pre-fix `ts.Close()` and passes with the fix.
- `TestLocalBackendKillRunsKillSession`: counterpart guard — a genuine `Kill()` still runs `tmux kill-session`.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `go test ./...` — green
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./session/...` — green

Fixes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)