### PR TITLE
fix(session/git): bound network git operations so session creation cannot hang forever (#896)

### DIFF
--- a/session/git/github.go
+++ b/session/git/github.go
@@ -1,11 +1,22 @@
 package git
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+// ghNetworkTimeout bounds the `gh` API call in FetchPRInfo. Like the git fetch
+// in resolveOriginHead (#896), this is a network operation with no timeout of
+// its own: a stalled GitHub API request would otherwise block the sidebar's PR
+// refresh goroutine indefinitely. gh runs as the leaf of its own short-lived
+// invocation here, so a plain context deadline (no process-group teardown) is
+// sufficient.
+const ghNetworkTimeout = 30 * time.Second
 
 // PRInfo holds information about a GitHub pull request associated with a branch.
 type PRInfo struct {
@@ -43,11 +54,16 @@ func FetchPRInfo(repoPath, branchName string) (*PRInfo, error) {
 		return nil, nil
 	}
 
-	cmd := exec.Command("gh", "pr", "list", "--head", branchName, "--state", "all",
+	ctx, cancel := context.WithTimeout(context.Background(), ghNetworkTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "pr", "list", "--head", branchName, "--state", "all",
 		"--json", "number,title,url,state", "--limit", "10")
 	cmd.Dir = repoPath
 	out, err := cmd.Output()
 	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("gh pr list timed out after %s (GitHub unreachable or stalled): %w", ghNetworkTimeout, ctx.Err())
+		}
 		return nil, fmt.Errorf("failed to fetch PR info: %w", err)
 	}
 

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -1,19 +1,116 @@
 package git
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
+	"syscall"
+	"time"
 )
 
-// runGitCommand executes a git command and returns any error.
+// networkGitTimeout bounds git operations that perform network I/O (currently
+// only `fetch`). A stalled remote — hung SSH/HTTP connection, dead proxy,
+// unroutable host — would otherwise block the git process forever; on the
+// session-creation path that hangs the daemon's RPC handler and the client
+// spins on a spinner indefinitely (#896). The bound is deliberately generous so
+// a slow-but-progressing fetch over a large repo still completes; it only trips
+// when the fetch makes no progress at all.
+//
+// A var (not a const) only so tests can shorten it; production never reassigns.
+var networkGitTimeout = 60 * time.Second
+
+// gitWaitDelay bounds how long cmd.Wait blocks after the git process exits (or
+// is killed on the deadline) before the inherited stdout/stderr pipes are
+// force-closed. `git fetch` spawns a transport child (ssh, git-remote-https)
+// that can keep the capture pipe open past git's own exit; without a bound,
+// Output() blocks on pipe EOF until that child dies — which would defeat the
+// timeout above (the #856 lesson from the claude shell probe).
+const gitWaitDelay = 2 * time.Second
+
+// runGitCommand executes a local git command and returns any error.
 // Only stdout is returned on success so callers parsing the output (e.g. SHAs
 // or porcelain status) are not corrupted by warnings git emits on stderr.
 // On error, stderr is folded into the returned error for diagnostics.
+//
+// It runs with a background context, so it is effectively unbounded. That is
+// intentional: every caller of runGitCommand performs a local-only operation
+// (rev-parse, show-ref, worktree add/remove/prune, branch -D, merge-base),
+// none of which touches the network and so cannot stall the way a fetch can.
+// Network operations must use runGitNetworkCommand instead (#896).
 func (g *GitWorktree) runGitCommand(path string, args ...string) (string, error) {
+	return g.runGitCommandContext(context.Background(), path, args...)
+}
+
+// runGitNetworkCommand runs a git command that performs network I/O under
+// networkGitTimeout, so a stalled remote returns an actionable timeout error
+// instead of hanging the caller forever (#896). The underlying process group is
+// SIGKILLed on the deadline so the transport child (ssh / git-remote-https) is
+// torn down with git rather than orphaned while still holding the connection.
+func (g *GitWorktree) runGitNetworkCommand(path string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), networkGitTimeout)
+	defer cancel()
+	output, err := g.runGitCommandContext(ctx, path, args...)
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return output, fmt.Errorf("git %s timed out after %s (remote unreachable or stalled): %w",
+			strings.Join(args, " "), networkGitTimeout, ctx.Err())
+	}
+	return output, err
+}
+
+// runGitCommandContext is the shared implementation behind runGitCommand and
+// runGitNetworkCommand. It runs git in its own process group so the whole
+// command tree — git plus any transport child it spawns — can be torn down
+// together when ctx is cancelled; GIT_TERMINAL_PROMPT=0 stops git from blocking
+// on an interactive credential/passphrase prompt (another way a fetch hangs
+// forever under the daemon, which has no terminal attached).
+func (g *GitWorktree) runGitCommandContext(ctx context.Context, path string, args ...string) (string, error) {
 	baseArgs := []string{"-C", path}
-	cmd := exec.Command("git", append(baseArgs, args...)...)
+	cmd := exec.CommandContext(ctx, "git", append(baseArgs, args...)...)
+	// Fail fast instead of blocking on a credential/passphrase prompt when a
+	// remote needs auth and no terminal is attached.
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	// Own process group so the deadline kills git AND its transport child
+	// together. exec.CommandContext's default Cancel SIGKILLs only the git
+	// process, leaving ssh / git-remote-https orphaned and still holding the
+	// network connection (mirrors config.go's claude probe and the hook
+	// runner, #610/#769/#856).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// Negative pid targets the whole group led by cmd.Process.Pid. A group
+		// already gone (ESRCH) maps to os.ErrProcessDone, which Wait ignores
+		// rather than reporting as a command failure.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
+	// Bound the post-exit wait: a transport child can inherit the capture pipes
+	// and, without a bound, Output() would block on pipe EOF until that child
+	// exits even after the deadline killed git (#856).
+	cmd.WaitDelay = gitWaitDelay
 
 	output, err := cmd.Output()
+	if cmd.Process != nil {
+		// Reap any transport child that outlived git on every exit path —
+		// normal completion or timeout — so a fetch never leaks a
+		// connection-holding process (#769 pattern). The group is led by git,
+		// which has already exited, so this is ESRCH (ignored) in the common
+		// case.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	if errors.Is(err, exec.ErrWaitDelay) {
+		// git itself exited (successfully — a non-zero exit would surface as an
+		// ExitError, not ErrWaitDelay); only a transport child held the capture
+		// pipe open past gitWaitDelay and was just killed above. The command's
+		// output is already complete, so this is not a failure (#676 precedent).
+		err = nil
+	}
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return string(output), fmt.Errorf("git command failed: %s (%w)", string(exitErr.Stderr), err)

--- a/session/git/worktree_network_test.go
+++ b/session/git/worktree_network_test.go
@@ -1,0 +1,128 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitEnv is the minimal identity git needs to commit in the hermetic test repos.
+var gitEnv = []string{
+	"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+	"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+}
+
+// runGit runs a git command in dir and fails the test on error.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), gitEnv...)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, string(out))
+}
+
+// shortenNetworkTimeout temporarily lowers networkGitTimeout so the stalled-fetch
+// tests resolve in ~a second instead of the production 60s, restoring it after.
+func shortenNetworkTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := networkGitTimeout
+	networkGitTimeout = d
+	t.Cleanup(func() { networkGitTimeout = orig })
+}
+
+// stallOriginViaFakeSSH points the repo's origin at an ssh:// remote whose
+// transport is a fake ssh that sleeps far longer than any test timeout. A
+// `git fetch origin` then blocks in our control without touching the real
+// network, simulating the hung connection from #896.
+func stallOriginViaFakeSSH(t *testing.T, repoRoot string) {
+	t.Helper()
+	fakeSSH := filepath.Join(t.TempDir(), "hang-ssh.sh")
+	require.NoError(t, os.WriteFile(fakeSSH, []byte("#!/bin/sh\nsleep 120\n"), 0o755))
+	t.Setenv("GIT_SSH_COMMAND", fakeSSH)
+	runGit(t, repoRoot, "remote", "add", "origin", "ssh://git@stalled.invalid/repo.git")
+}
+
+// TestRunGitNetworkCommand_TimesOutOnStalledFetch is the core #896 regression:
+// a fetch from a stalled remote must return a timeout error within the bound
+// instead of blocking forever.
+func TestRunGitNetworkCommand_TimesOutOnStalledFetch(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+	stallOriginViaFakeSSH(t, repoRoot)
+	shortenNetworkTimeout(t, time.Second)
+
+	type result struct {
+		out string
+		err error
+	}
+	done := make(chan result, 1)
+	start := time.Now()
+	go func() {
+		out, err := (&GitWorktree{}).runGitNetworkCommand(repoRoot, "fetch", "origin")
+		done <- result{out, err}
+	}()
+
+	select {
+	case r := <-done:
+		require.Error(t, r.err, "a stalled fetch must surface a timeout error")
+		assert.Contains(t, r.err.Error(), "timed out")
+		assert.Less(t, time.Since(start), 30*time.Second,
+			"fetch should be killed at the timeout, not wait for the fake ssh to exit")
+	case <-time.After(20 * time.Second):
+		t.Fatal("runGitNetworkCommand hung past the timeout on a stalled fetch (#896)")
+	}
+}
+
+// TestResolveOriginHead_DoesNotHangOnStalledFetch exercises the exact
+// session-creation path the bug report names: resolveOriginHead fetches first,
+// then falls back to local refs. With a stalled remote it must still return
+// promptly (best-effort: empty string when no origin refs are cached).
+func TestResolveOriginHead_DoesNotHangOnStalledFetch(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+	stallOriginViaFakeSSH(t, repoRoot)
+	shortenNetworkTimeout(t, time.Second)
+
+	gw := &GitWorktree{repoPath: repoRoot}
+
+	done := make(chan string, 1)
+	start := time.Now()
+	go func() { done <- gw.resolveOriginHead() }()
+
+	select {
+	case ref := <-done:
+		// No origin refs were fetched (the remote stalled), so the best-effort
+		// resolution yields an empty string — and crucially, it returned.
+		assert.Empty(t, ref)
+		assert.Less(t, time.Since(start), 30*time.Second)
+	case <-time.After(20 * time.Second):
+		t.Fatal("resolveOriginHead hung on a stalled fetch during session creation (#896)")
+	}
+}
+
+// TestRunGitNetworkCommand_NormalFetchSucceeds guards the happy path: a healthy
+// fetch (here from a local filesystem remote, fully hermetic) returns without
+// error and is unaffected by the timeout machinery.
+func TestRunGitNetworkCommand_NormalFetchSucceeds(t *testing.T) {
+	sandboxHome(t)
+
+	// A source repo with a commit acts as origin.
+	origin := createGitRepo(t)
+	runGit(t, origin, "commit", "--allow-empty", "-m", "initial")
+
+	// A separate repo whose origin points at the source on the local
+	// filesystem — no network, but the same `git fetch origin` code path.
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "remote", "add", "origin", origin)
+
+	out, err := (&GitWorktree{}).runGitNetworkCommand(repoRoot, "fetch", "origin")
+	require.NoError(t, err, "a healthy fetch must succeed: %s", out)
+}

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -92,8 +92,12 @@ func (g *GitWorktree) setupFromExistingBranch() error {
 // It fetches from origin first, then tries origin/HEAD, origin/main, and origin/master.
 // Returns the commit SHA if successful, or empty string if no remote ref is available.
 func (g *GitWorktree) resolveOriginHead() string {
-	// Fetch from origin to ensure we have the latest refs (best-effort)
-	_, _ = g.runGitCommand(g.repoPath, "fetch", "origin")
+	// Fetch from origin to ensure we have the latest refs (best-effort). This
+	// is the one network call on the session-creation path, so it is bounded
+	// by networkGitTimeout: a stalled remote must not hang creation forever
+	// (#896). The error is intentionally ignored — on timeout or failure we
+	// fall through to whatever origin refs are already cached locally.
+	_, _ = g.runGitNetworkCommand(g.repoPath, "fetch", "origin")
 
 	// Try origin/HEAD (symbolic ref pointing to the default branch)
 	for _, ref := range []string{"origin/HEAD", "origin/main", "origin/master"} {


### PR DESCRIPTION
## Problem

Session creation calls `resolveOriginHead()`, which runs `git fetch origin` to resolve origin's default branch. `runGitCommand` used `exec.Command` with **no context or timeout**, so a stalled remote (hung SSH/HTTP connection, dead proxy, unroutable host) blocks the `git` process forever — hanging the daemon's RPC handler and leaving the client spinning on a spinner indefinitely. Ctrl+C kills the daemon but leaves `git` running.

This is the timeout class from #645 / #676 / #856 applied to the one network call on the session-creation hot path.

## Fix

- **`runGitCommandContext`** — new shared `exec.CommandContext`-based core. Runs git in its own process group and SIGKILLs the **whole group** on the deadline so the transport child (`ssh` / `git-remote-https`) is torn down with git instead of orphaned while still holding the connection; sets `WaitDelay` so a child holding the capture pipe can't defeat the timeout (the #856 lesson from the claude shell probe); sets `GIT_TERMINAL_PROMPT=0` so git fails fast instead of blocking on a credential/passphrase prompt under the terminal-less daemon.
- **`runGitCommand`** now delegates with a background context. Every caller is a local-only op (`rev-parse`, `show-ref`, `worktree add/remove/prune`, `branch -D`, `merge-base`) — none touch the network, so they stay intentionally unbounded (documented in the code).
- **`runGitNetworkCommand`** wraps the core with a generous **60s** timeout and an actionable `git fetch origin timed out (remote unreachable or stalled)` error. `resolveOriginHead`'s fetch now uses it; the error is still best-effort (falls through to locally cached origin refs).

## Adjacent-call-site audit (CLAUDE.md)

Swept the repo for every network-touching invocation:
- `git fetch origin` in `resolveOriginHead` — **bounded** (the bug).
- `gh pr list` in `FetchPRInfo` (sidebar PR refresh) — same anti-pattern, **bounded** with a 30s context.
- No `git push` / `clone` / `ls-remote` / `pull` exists anywhere in the repo.
- All other `runGitCommand` / `exec.Command("git", ...)` call-sites are local-only — left unbounded by design and documented.

## Tests

Hermetic, no real network: a fake `GIT_SSH_COMMAND` that sleeps makes a fetch stall on demand.
- `TestRunGitNetworkCommand_TimesOutOnStalledFetch` — stalled fetch returns a timeout error within the (shortened) bound, not after the fake ssh exits.
- `TestResolveOriginHead_DoesNotHangOnStalledFetch` — the exact session-creation path returns promptly (empty best-effort result) instead of hanging.
- `TestRunGitNetworkCommand_NormalFetchSucceeds` — a healthy fetch from a local filesystem remote still succeeds, unaffected by the timeout machinery.

## Gates

`go build ./...`, `go test ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, and `-race` on `session/git/` all green.

Fixes #896

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude