### PR TITLE
fix(api): honor --repo in sessions attach and distinguish invalid --repo from missing (#891, #892)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -19,16 +19,28 @@ var (
 	repoFlag string
 )
 
+// repoFromFlag resolves the --repo flag to a RepoContext. Its errors name the
+// offending path and distinguish "could not make the path absolute" from "the
+// path is not a git repository" so callers never mislabel a provided-but-invalid
+// --repo as missing (#892). Only call when repoFlag != "".
+func repoFromFlag() (*config.RepoContext, error) {
+	absPath, err := filepath.Abs(repoFlag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve --repo path %q: %w", repoFlag, err)
+	}
+	repo, err := config.RepoFromPath(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("--repo %q is not a valid git repository: %w", absPath, err)
+	}
+	return repo, nil
+}
+
 // resolveRepoID resolves a repo ID from flags, cwd, or returns "" for all-repo mode.
 func resolveRepoID() (string, error) {
 	if repoFlag != "" {
-		absPath, err := filepath.Abs(repoFlag)
+		repo, err := repoFromFlag()
 		if err != nil {
-			return "", fmt.Errorf("failed to resolve repo path: %w", err)
-		}
-		repo, err := config.RepoFromPath(absPath)
-		if err != nil {
-			return "", fmt.Errorf("failed to get repo from path: %w", err)
+			return "", err
 		}
 		return repo.ID, nil
 	}
@@ -40,16 +52,22 @@ func resolveRepoID() (string, error) {
 	return repo.ID, nil
 }
 
-// resolveRepo resolves a *config.RepoContext from flags. Returns error if no repo specified and cwd is not a repo.
+// resolveRepo resolves a *config.RepoContext for commands that require a repo
+// (sessions create, tasks add). It returns fully-formed, user-facing errors so
+// callers can surface them directly without re-deriving the cause: a provided
+// `--repo` that does not resolve names the path, while an absent `--repo` whose
+// cwd is also not a repo reports that `--repo is required` (#892). Wrapping any
+// resolution failure as "--repo is required" — as the callers used to — was
+// wrong precisely when the user did pass `--repo` but pointed it at a non-repo.
 func resolveRepo() (*config.RepoContext, error) {
 	if repoFlag != "" {
-		absPath, err := filepath.Abs(repoFlag)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve repo path: %w", err)
-		}
-		return config.RepoFromPath(absPath)
+		return repoFromFlag()
 	}
-	return config.CurrentRepo()
+	repo, err := config.CurrentRepo()
+	if err != nil {
+		return nil, fmt.Errorf("--repo is required: current directory is not a git repository: %w", err)
+	}
+	return repo, nil
 }
 
 // errTitleNotFound marks a definitive not-found from findInstanceByTitle: the

--- a/api/api.go
+++ b/api/api.go
@@ -165,6 +165,50 @@ func findLiveInstanceByTitle(title string) (*session.Instance, string, error) {
 	return instance, repoID, nil
 }
 
+// findInstanceByTitleInScope finds an instance by title within the resolved repo
+// scope (#891). An empty repoID preserves the prior all-repo search; a non-empty
+// one confines the lookup to that repo so a same-titled session in a different
+// repo can never be selected. Mirrors how resolveRepoID() scopes the other
+// sessions subcommands (list, kill, send-prompt).
+func findInstanceByTitleInScope(repoID, title string) (*session.InstanceData, string, error) {
+	if repoID == "" {
+		return findInstanceByTitle(title)
+	}
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to load instances for repo %s: %w", repoID, err)
+	}
+	var instances []session.InstanceData
+	if err := json.Unmarshal(raw, &instances); err != nil {
+		return nil, "", fmt.Errorf("failed to parse instances for repo %s: %w", repoID, err)
+	}
+	for i := range instances {
+		if instances[i].Title == title {
+			return &instances[i], repoID, nil
+		}
+	}
+	// Wrap the sentinel so a scoped clean miss stays distinguishable from a
+	// corruption-tainted miss, mirroring findInstanceByTitle (#861).
+	return nil, "", fmt.Errorf("instance %q %w", title, errTitleNotFound)
+}
+
+// findLiveInstanceByTitleInScope finds an instance by title within the resolved
+// repo scope and restores it as a live *Instance (#891). It is the repo-scoped
+// counterpart of findLiveInstanceByTitle, used by attach so `--repo` confines
+// the attach to that repo's session instead of connecting the terminal to a
+// same-titled session in another repo.
+func findLiveInstanceByTitleInScope(repoID, title string) (*session.Instance, string, error) {
+	data, repoID, err := findInstanceByTitleInScope(repoID, title)
+	if err != nil {
+		return nil, "", err
+	}
+	instance, err := session.FromInstanceData(*data)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to restore instance %q: %w", title, err)
+	}
+	return instance, repoID, nil
+}
+
 // instanceTitleExistsInScope reports whether a session with the given title
 // exists within the resolved repo scope (#776). An empty repoID preserves the
 // prior all-repo search; a non-empty one confines the check to that repo so a

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -410,7 +410,16 @@ var sessionsAttachCmd = &cobra.Command{
 		log.Initialize(false)
 		defer log.Close()
 
-		instance, _, err := findLiveInstanceByTitle(args[0])
+		// Honor --repo scoping (#891, same class as #761/#776). An empty repoID
+		// preserves the prior all-repo search; a non-empty one confines the
+		// attach to that repo so `attach <title> --repo <other>` can never
+		// connect the terminal to a same-titled session in a different repo.
+		repoID, err := resolveRepoID()
+		if err != nil {
+			return jsonError(err)
+		}
+
+		instance, _, err := findLiveInstanceByTitleInScope(repoID, args[0])
 		if err != nil {
 			return jsonError(err)
 		}

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -156,9 +156,13 @@ var sessionsCreateCmd = &cobra.Command{
 		log.Initialize(false)
 		defer log.Close()
 
+		// resolveRepo already differentiates "--repo is required" (absent) from a
+		// provided-but-invalid path and names the offending path (#892), so
+		// surface its error verbatim instead of relabeling every failure as
+		// "required".
 		repo, err := resolveRepo()
 		if err != nil {
-			return jsonError(fmt.Errorf("--repo is required: %w", err))
+			return jsonError(err)
 		}
 
 		if !git.IsGitRepo(repo.Root) {
@@ -304,9 +308,14 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 		// (#865). The daemon decides create-vs-send under its per-target lock,
 		// so no existence pre-check is needed here.
 		if sendPromptCreateFlag {
+			// resolveRepo distinguishes absent --repo ("--repo is required")
+			// from a provided-but-invalid path and names it (#892). --create is
+			// the only send-prompt mode that needs a resolvable repo, so surface
+			// that error directly rather than relabeling an invalid path as
+			// "required".
 			repo, repoErr := resolveRepo()
 			if repoErr != nil {
-				return jsonError(fmt.Errorf("--repo is required when using --create: %w", repoErr))
+				return jsonError(repoErr)
 			}
 
 			if !git.IsGitRepo(repo.Root) {

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -414,6 +414,111 @@ func TestSessionsKill_HonorsRepoScoping(t *testing.T) {
 	}
 }
 
+// TestSessionsAttach_HonorsRepoScoping is the regression test for issue #891
+// (same class as #761 kill / #776 send-prompt). Two repos each hold a session
+// with the same title but a distinct Path. Resolving the attach with
+// `--repo <repoA>` must select repo A's session, and `--repo <repoB>` repo B's,
+// so `attach <title> --repo <other>` can never connect the terminal to a
+// same-titled session in the wrong repo. Previously attach dropped --repo on the
+// floor and ran an all-repo lookup that could return either repo's session.
+//
+// The test exercises the resolveRepoID() + scoped-lookup steps attach's RunE now
+// runs, rather than RunE itself: the final findLiveInstanceByTitleInScope()
+// restores (and Starts) a live tmux session and instance.Attach() blocks on a
+// real terminal. The bug lived entirely in title selection — which repo's
+// instance is chosen — so pinning the data-level scoped lookup pins the fix.
+func TestSessionsAttach_HonorsRepoScoping(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	// Repo A is a real git repo so resolveRepoID(--repo) can compute its ID
+	// the same way the running CLI would.
+	repoARoot := filepath.Join(tmp, "repo-a")
+	if err := os.MkdirAll(repoARoot, 0755); err != nil {
+		t.Fatalf("mkdir repo A: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoARoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init repo A: %v (%s)", err, out)
+	}
+	repoA, err := config.RepoFromPath(repoARoot)
+	if err != nil {
+		t.Fatalf("RepoFromPath repo A: %v", err)
+	}
+
+	// Repo B is a distinct synthetic repo on disk holding a same-titled session.
+	repoBID := "repo-b-synthetic"
+	if repoBID == repoA.ID {
+		t.Fatalf("test setup: synthetic repo B ID collided with repo A")
+	}
+
+	const title = "shared-title"
+
+	// Each repo's instance carries a distinct Path so the selected instance is
+	// identifiable by which repo it came from.
+	mk := func(root string) []session.InstanceData {
+		return []session.InstanceData{{Title: title, Path: root}}
+	}
+	rawA, err := json.Marshal(mk(repoARoot))
+	if err != nil {
+		t.Fatalf("marshal repo A instances: %v", err)
+	}
+	rawB, err := json.Marshal(mk(tmp))
+	if err != nil {
+		t.Fatalf("marshal repo B instances: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoA.ID, rawA); err != nil {
+		t.Fatalf("save repo A instances: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoBID, rawB); err != nil {
+		t.Fatalf("save repo B instances: %v", err)
+	}
+
+	// Point --repo at repo A and resolve the scope exactly as attach's RunE does.
+	prevRepoFlag := repoFlag
+	repoFlag = repoARoot
+	defer func() { repoFlag = prevRepoFlag }()
+
+	repoID, err := resolveRepoID()
+	if err != nil {
+		t.Fatalf("resolveRepoID: %v", err)
+	}
+	if repoID != repoA.ID {
+		t.Fatalf("resolveRepoID = %q, want repo A %q", repoID, repoA.ID)
+	}
+
+	dataA, gotRepoA, err := findInstanceByTitleInScope(repoID, title)
+	if err != nil {
+		t.Fatalf("scoped lookup for repo A: %v", err)
+	}
+	if gotRepoA != repoA.ID {
+		t.Fatalf("scoped lookup returned repoID %q, want repo A %q", gotRepoA, repoA.ID)
+	}
+	if dataA.Path != repoARoot {
+		t.Fatalf("attach selected the wrong repo's session: Path = %q, want repo A %q", dataA.Path, repoARoot)
+	}
+
+	// Scoping to repo B must select repo B's same-titled session, proving --repo
+	// actually drives the selection (not a coincidental first-match).
+	dataB, gotRepoB, err := findInstanceByTitleInScope(repoBID, title)
+	if err != nil {
+		t.Fatalf("scoped lookup for repo B: %v", err)
+	}
+	if gotRepoB != repoBID {
+		t.Fatalf("scoped lookup returned repoID %q, want repo B %q", gotRepoB, repoBID)
+	}
+	if dataB.Path != tmp {
+		t.Fatalf("repo B scope selected the wrong session: Path = %q, want repo B %q", dataB.Path, tmp)
+	}
+
+	// A title that does not exist in the scoped repo must be a clean not-found,
+	// not a fallback into another repo's matching session.
+	if _, _, err := findInstanceByTitleInScope(repoA.ID, "does-not-exist"); err == nil {
+		t.Fatalf("expected not-found for missing title in scope, got nil")
+	} else if !errors.Is(err, errTitleNotFound) {
+		t.Fatalf("expected errTitleNotFound for missing title in scope, got: %v", err)
+	}
+}
+
 // TestSessionsSendPrompt_HonorsRepoScoping is the regression test for issue
 // #776 (follow-up to #761/#775). Two repos each hold a session with the same
 // title. Sending a prompt with `--repo <repoA>` must scope delivery to repo

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -721,6 +721,80 @@ func stubGhostCleanup() (wtCalls *[]string, tmuxCalls *[]string, restore func())
 // persisted worktree path is empty but TmuxName is populated, the ghost
 // cleanup path must still attempt to kill the tmux session. Previously, tmux
 // teardown was never attempted from the ghost path, leaving an orphan that
+// TestSessionsCreate_InvalidRepoNamesPath is half of the #892 regression for
+// the sessions create path: a provided-but-invalid --repo must name the path and
+// must not be relabeled "--repo is required".
+func TestSessionsCreate_InvalidRepoNamesPath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	notARepo := filepath.Join(tmp, "not-a-repo")
+	if err := os.MkdirAll(notARepo, 0755); err != nil {
+		t.Fatalf("mkdir not-a-repo: %v", err)
+	}
+
+	prevRepoFlag, prevName := repoFlag, createNameFlag
+	repoFlag = notARepo
+	createNameFlag = "sess"
+	defer func() { repoFlag, createNameFlag = prevRepoFlag, prevName }()
+
+	// jsonError writes to stderr; silence it.
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devnull.Close()
+	origStderr := os.Stderr
+	os.Stderr = devnull
+	defer func() { os.Stderr = origStderr }()
+
+	err = sessionsCreateCmd.RunE(sessionsCreateCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid --repo, got nil")
+	}
+	if !strings.Contains(err.Error(), notARepo) {
+		t.Fatalf("error must name the invalid --repo path %q, got: %v", notARepo, err)
+	}
+	if !strings.Contains(err.Error(), "not a valid git repository") {
+		t.Fatalf("error should explain the path is not a git repo, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "--repo is required") {
+		t.Fatalf("must not claim --repo is required when it was provided: %v", err)
+	}
+}
+
+// TestSessionsCreate_AbsentRepoInNonRepoCwdSaysRequired is the other half of
+// #892: no --repo and a non-repo cwd must report that --repo is required.
+func TestSessionsCreate_AbsentRepoInNonRepoCwdSaysRequired(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	prevRepoFlag, prevName := repoFlag, createNameFlag
+	repoFlag = ""
+	createNameFlag = "sess"
+	defer func() { repoFlag, createNameFlag = prevRepoFlag, prevName }()
+
+	// cwd must be outside any git repo so CurrentRepo() fails.
+	t.Chdir(t.TempDir())
+
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devnull.Close()
+	origStderr := os.Stderr
+	os.Stderr = devnull
+	defer func() { os.Stderr = origStderr }()
+
+	err = sessionsCreateCmd.RunE(sessionsCreateCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for absent --repo in non-repo cwd, got nil")
+	}
+	if !strings.Contains(err.Error(), "--repo is required") {
+		t.Fatalf("error should say --repo is required, got: %v", err)
+	}
+}
+
 // blocked recreation under the same title with "session already exists".
 func TestGhostCleanup_TmuxOrphan(t *testing.T) {
 	wtCalls, tmCalls, restore := stubGhostCleanup()

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -3,7 +3,6 @@ package api
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -52,15 +51,14 @@ var tasksListCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("failed to load tasks: %w", err))
 		}
 
-		// Filter by repo if --repo is set
+		// Filter by repo if --repo is set. --repo is an optional filter here (an
+		// absent flag lists every repo's tasks), but a provided-but-invalid path
+		// must still report the path it could not resolve rather than a generic
+		// message (#892). repoFromFlag supplies the path-naming error.
 		if repoFlag != "" {
-			absPath, err := filepath.Abs(repoFlag)
+			repo, err := repoFromFlag()
 			if err != nil {
-				return jsonError(fmt.Errorf("failed to resolve repo path: %w", err))
-			}
-			repo, err := config.RepoFromPath(absPath)
-			if err != nil {
-				return jsonError(fmt.Errorf("failed to get repo from path: %w", err))
+				return jsonError(err)
 			}
 			var filtered []task.Task
 			for _, s := range tasks {
@@ -94,9 +92,13 @@ var tasksAddCmd = &cobra.Command{
 		log.Initialize(false)
 		defer log.Close()
 
+		// resolveRepo already differentiates "--repo is required" (absent) from a
+		// provided-but-invalid path and names the offending path (#892), so
+		// surface its error verbatim instead of relabeling every failure as
+		// "required".
 		repo, err := resolveRepo()
 		if err != nil {
-			return jsonError(fmt.Errorf("--repo is required: %w", err))
+			return jsonError(err)
 		}
 
 		hasCron := strings.TrimSpace(taskAddCronFlag) != ""

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -228,6 +228,54 @@ func TestTasksAdd_RejectsInvalidCron(t *testing.T) {
 	assert.Zero(t, calls.reloads)
 }
 
+// TestTasksAdd_InvalidRepoNamesPathNotRequired is half of the #892 regression:
+// when --repo is provided but points at a non-git directory, the error must name
+// the offending path and must NOT claim "--repo is required" — the user did
+// provide it. Previously every resolveRepo() failure was relabeled "required",
+// contradicting the user's own command.
+func TestTasksAdd_InvalidRepoNamesPathNotRequired(t *testing.T) {
+	useTempConfig(t)
+	resetAddFlags(t)
+	calls := stubDaemon(t)
+
+	// An existing directory that is not a git repository.
+	notARepo := t.TempDir()
+	repoFlag = notARepo
+
+	taskAddNameFlag = "x"
+	taskAddPromptFlag = "do it"
+	taskAddCronFlag = "0 9 * * *"
+	taskAddProgramFlag = "claude"
+
+	err := tasksAddCmd.RunE(tasksAddCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), notARepo, "error must name the invalid --repo path")
+	assert.Contains(t, err.Error(), "not a valid git repository")
+	assert.NotContains(t, err.Error(), "--repo is required", "must not claim --repo is missing when it was provided")
+	assert.Zero(t, calls.reloads, "no daemon poke when repo resolution fails")
+}
+
+// TestTasksAdd_AbsentRepoInNonRepoCwdSaysRequired is the other half of #892:
+// with no --repo and a cwd that is not a git repo, the error must report that
+// --repo is required (the only case where that wording is accurate).
+func TestTasksAdd_AbsentRepoInNonRepoCwdSaysRequired(t *testing.T) {
+	useTempConfig(t)
+	resetAddFlags(t) // leaves repoFlag = ""
+	stubDaemon(t)
+
+	// cwd must be outside any git repo so CurrentRepo() fails.
+	t.Chdir(t.TempDir())
+
+	taskAddNameFlag = "x"
+	taskAddPromptFlag = "do it"
+	taskAddCronFlag = "0 9 * * *"
+	taskAddProgramFlag = "claude"
+
+	err := tasksAddCmd.RunE(tasksAddCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--repo is required")
+}
+
 func TestTasksUpdate_DisablePersistsAndPokesDaemon(t *testing.T) {
 	useTempConfig(t)
 	resetUpdateFlags(t)


### PR DESCRIPTION
## Summary

Two related `api/` `--repo` fixes, one commit each.

### `fix(api): honor --repo in `sessions attach` (#891)`
`sessions attach <title>` accepted the persistent `--repo` flag but called the all-repo `findLiveInstanceByTitle`, so when two repos held a same-titled session it could connect your terminal to the **wrong repo's** live session despite an explicit `--repo`. This is the same class as #761 (kill) and #776 (send-prompt).

Fix mirrors those PRs exactly: resolve the scope with `resolveRepoID()` and confine the lookup. Adds `findInstanceByTitleInScope` / `findLiveInstanceByTitleInScope` — empty `repoID` keeps the prior all-repo search; a non-empty one loads only that repo's instances and wraps `errTitleNotFound` on a clean miss (mirroring `findInstanceByTitle`, #861).

### `fix(api): distinguish invalid --repo from missing --repo (#892)`
`sessions create` and `tasks add` wrapped **every** `resolveRepo()` failure as `--repo is required` — wrong when the user *did* pass `--repo` but pointed it at a non-git directory. Fixed at the source:
- New `repoFromFlag()` resolves `--repo` with errors that **name the path** and split "couldn't make absolute" from "not a git repository". `resolveRepoID()` and the `tasks list` filter use it too.
- `resolveRepo()` now returns fully-formed messages: provided-but-invalid → `--repo %q is not a valid git repository`; absent + non-repo cwd → `--repo is required: current directory is not a git repository`.
- `sessions create`, `tasks add`, and `send-prompt --create` surface that error verbatim instead of relabeling it "required".

## Adjacent-call-site audit (per CLAUDE.md; same family as #761/#776)
Every `sessions`/`tasks` subcommand accepting `--repo`:

| Command | Handling | Status |
|---|---|---|
| `sessions list` | `resolveRepoID` | scoped ✓ |
| `sessions create` | `resolveRepo` | differentiated error ✓ (#892) |
| `sessions send-prompt` (+`--create`) | `resolveRepoID` / `resolveRepo` | scoped + differentiated ✓ |
| `sessions kill` | `resolveRepoID` | scoped ✓ |
| `sessions attach` | `resolveRepoID` + scoped lookup | **fixed ✓ (#891)** |
| `sessions whoami` | matches by tmux session name | repo-agnostic by design |
| `tasks list` | `repoFromFlag` filter | path-named error ✓ |
| `tasks add` | `resolveRepo` | differentiated error ✓ (#892) |
| `tasks get`/`remove`/`trigger`/`update <id>` | unique task ID | `--repo` not load-bearing |

`attach` was the last gap among **stateful/interactive** commands.

**Deliberate exclusion:** `sessions get` and `sessions preview` remain all-repo title lookups. They are pure read-only one-shot reads, consistent with the historical "excluded as read-only" boundary #891 itself references — distinct from `attach`, which connects your terminal to a live session (the harmful wrong-repo case). Scoping read-only lookups would change their behavior (cwd-based scoping would kick in) and is a separate product-contract decision rather than part of these two bug fixes; happy to open a follow-up if full read-path scoping is wanted.

## Tests
- `TestSessionsAttach_HonorsRepoScoping` — two repos, same title, distinct paths; scoping to each selects that repo's session; missing title in scope is a clean not-found (no cross-repo fallback). Mirrors `TestSessionsKill_HonorsRepoScoping`.
- `TestTasksAdd_InvalidRepoNamesPathNotRequired` / `TestSessionsCreate_InvalidRepoNamesPath` — provided-but-invalid `--repo` names the path, never says "required".
- `TestTasksAdd_AbsentRepoInNonRepoCwdSaysRequired` / `TestSessionsCreate_AbsentRepoInNonRepoCwdSaysRequired` — absent `--repo` in a non-repo cwd says "required".

## Verification
`gofmt -l .` (clean), `go build ./...`, `go test ./...` (all pass), `golangci-lint run --timeout=3m --fast` (clean), `deadcode -test ./...` (clean), and `-race` on `api`/`task`/`ui`/`app` (bounded per dev-box constraints) all green.

Fixes #891
Fixes #892

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)