### PR TITLE
fix(ui/terminal): stop dropping the oldest line on trailing-newline output (#898)

### DIFF
--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -408,6 +408,14 @@ func (t *TerminalPane) String() string {
 	// Normal mode: show captured content
 	lines := strings.Split(content, "\n")
 
+	// strings.Split produces a trailing empty element when content ends in "\n"
+	// (common for tmux capture-pane output). Drop it so the off-by-one does not
+	// trigger truncation when content actually fits, and so the truncate branch
+	// keeps the right slice of lines. Mirrors PreviewPane.String() (#649, #898).
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
 	if height > 0 {
 		if len(lines) > height {
 			lines = lines[len(lines)-height:]

--- a/ui/terminal_trailing_newline_test.go
+++ b/ui/terminal_trailing_newline_test.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests mirror the PreviewPane trailing-newline regression tests
+// (#649) for TerminalPane.String(). tmux capture-pane output commonly ends
+// in "\n", which makes strings.Split produce one extra (empty) element. Before
+// #898 TerminalPane.String() lacked the trailing-empty strip that
+// PreviewPane.String() has, so the off-by-one pushed exact/near-fit content
+// into the truncation branch and dropped the oldest visible line.
+
+// TestTerminalTrailingNewlineAtExactHeight checks the boundary: content that
+// fills exactly height lines but ends in "\n" must not be truncated. The
+// trailing-empty strip exists to handle this case.
+func TestTerminalTrailingNewlineAtExactHeight(t *testing.T) {
+	const paneHeight = 5
+	contentLines := []string{"a", "b", "c", "d", "e"}
+	text := strings.Join(contentLines, "\n") + "\n"
+
+	tp := NewTerminalPane()
+	tp.SetSize(80, paneHeight)
+	tp.content = text
+
+	rendered := tp.String()
+	for _, line := range contentLines {
+		require.Contains(t, rendered, line,
+			"line %q must remain visible at exact-fit boundary — trailing newline must not drop the oldest line", line)
+	}
+}
+
+// TestTerminalBottomTruncateShowsNewestLines is the regression analogue of
+// #649 for TerminalPane: when content exceeds the pane height, the newest
+// height lines (bottom) must be kept and the oldest dropped.
+func TestTerminalBottomTruncateShowsNewestLines(t *testing.T) {
+	const totalLines = 100
+	const paneHeight = 10
+
+	lines := make([]string, totalLines)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line-%03d", i+1)
+	}
+	text := strings.Join(lines, "\n")
+
+	tp := NewTerminalPane()
+	tp.SetSize(80, paneHeight)
+	tp.content = text
+
+	rendered := tp.String()
+
+	// The newest height lines must be present; the oldest must not.
+	for i := totalLines - paneHeight; i < totalLines; i++ {
+		require.Contains(t, rendered, lines[i],
+			"newest line %q must be visible after truncation", lines[i])
+	}
+	for i := 0; i < totalLines-paneHeight; i++ {
+		require.NotContains(t, rendered, lines[i],
+			"older line %q must NOT be visible after truncation", lines[i])
+	}
+}
+
+// TestTerminalTrailingNewlineWithMoreContentThanHeight is the core #898 case:
+// content that exceeds the pane height AND ends in "\n". The trailing empty
+// element must be stripped before truncation so the slice keeps the correct
+// newest height lines, not one line too few from the bottom.
+func TestTerminalTrailingNewlineWithMoreContentThanHeight(t *testing.T) {
+	const paneHeight = 5
+	// 6 real lines + trailing newline. With the trailing empty element stripped,
+	// the newest 5 lines (b..f) are shown and only the oldest real line ("a") is
+	// dropped. Without the strip, Split yields 7 elements and the truncation
+	// slices [c d e f ""], wrongly dropping "b" as well.
+	text := "a\nb\nc\nd\ne\nf\n"
+
+	tp := NewTerminalPane()
+	tp.SetSize(80, paneHeight)
+	tp.content = text
+
+	rendered := tp.String()
+	for _, line := range []string{"b", "c", "d", "e", "f"} {
+		require.Contains(t, rendered, line,
+			"newest line %q must be visible — trailing newline must not drop an extra real line", line)
+	}
+	require.NotContains(t, rendered, "a",
+		"only the single oldest real line should be dropped when content exceeds height")
+}
+
+// TestTerminalNoTrailingNewlineUnchanged guards that content without a trailing
+// newline behaves exactly as before: all lines that fit remain visible.
+func TestTerminalNoTrailingNewlineUnchanged(t *testing.T) {
+	tp := NewTerminalPane()
+	tp.SetSize(80, 10)
+	tp.content = "one\ntwo\nthree\nfour\nfive"
+
+	rendered := tp.String()
+	for _, line := range []string{"one", "two", "three", "four", "five"} {
+		require.Contains(t, rendered, line,
+			"line %q must remain visible when content fits and has no trailing newline", line)
+	}
+}


### PR DESCRIPTION
## Problem

`tmux capture-pane` output commonly ends in `\n`. `TerminalPane.String()` does `strings.Split(content, "\n")`, which yields a trailing empty element when content ends in a newline — inflating `len(lines)` by one. At exact/near pane-height fit, `len(lines) > height` then trips the truncation branch and slices an extra real line off the bottom, **dropping the oldest visible line** of terminal output.

`PreviewPane.String()` already strips this trailing empty element (#649); `TerminalPane.String()` was never given the equivalent fix when it was introduced in e69ff9c.

Minimal repro: `content := "a\nb\nc\nd\ne\n"` at `height := 5` → `Split` yields `[a b c d e ""]` (6 elements) → truncation keeps `[b c d e ""]` and wrongly drops `a`.

## Fix

Port the trailing-empty strip from `PreviewPane.String()` to `TerminalPane.String()`, mirroring it exactly:

```go
if len(lines) > 0 && lines[len(lines)-1] == "" {
    lines = lines[:len(lines)-1]
}
```

## Adjacent call-site audit (per CLAUDE.md)

Swept the other `ui` panes for the same split+truncate-on-tmux-capture assumption:

- `sidebar.go:626` and `content_pane.go:199` split-and-truncate too, but they clamp from the **top** of non-capture (rendered/wrapped) content, so a trailing empty element is harmless there.
- Only `PreviewPane` and `TerminalPane` keep the **bottom** N lines of raw tmux capture, where a trailing `\n` drops the oldest line. `PreviewPane` was already fixed; this PR fixes `TerminalPane`. No other call-site shares the assumption.

## Tests

Adds `ui/terminal_trailing_newline_test.go`, mirroring the `PreviewPane` regression tests:

- `TestTerminalTrailingNewlineAtExactHeight` — content ending in `\n` that exactly fills the pane is not truncated.
- `TestTerminalBottomTruncateShowsNewestLines` — over-tall content keeps the newest N lines.
- `TestTerminalTrailingNewlineWithMoreContentThanHeight` — the core #898 case: over-tall content ending in `\n` drops only the single oldest real line, not an extra one.
- `TestTerminalNoTrailingNewlineUnchanged` — content without a trailing newline behaves exactly as before.

Confirmed the trailing-newline tests fail without the fix and pass with it.

## Verification

- `gofmt -l .` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `go build ./...` ok
- `go test ./...` green
- `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/` green

Fixes #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)