### PR TITLE
fix(task): normalize DOW 7-alias before step expansion so 7/N keeps its step (#888)

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -39,10 +39,25 @@ func ParseCron(expr string) (cron.Schedule, error) {
 // collapsed back to "*" even when it covers all seven days: a syntactically
 // restricted DOW participates in cron's DOM/DOW OR semantics, and rewriting
 // it to a wildcard would change which days match when DOM is also restricted.
+//
+// The 7→0 alias is applied to each comma-separated part *before* expansion
+// when 7 is the base of a step (e.g. "7/2" → "0/2"). Expanding first would
+// collapse "7/2" to the single value {7} — its step starts at the field's max
+// (7) so no further values follow — and then map it to {0}, silently turning
+// "every 2 days from Sunday" into "Sunday only" (#888). For every other shape
+// (a bare 7, a range bound of 7, a step that merely lands on 7) expansion
+// followed by normalizeDOWValues preserves the meaning, so those are left for
+// the expand path below.
 func normalizeDOWField(field string) string {
 	if field == "*" || !strings.Contains(field, "7") {
 		return field
 	}
+	listParts := strings.Split(field, ",")
+	for i, part := range listParts {
+		listParts[i] = normalizeDOWStepBase(part)
+	}
+	field = strings.Join(listParts, ",")
+
 	vals, err := expandCronField(field, 0, 7)
 	if err != nil || vals == nil {
 		return field
@@ -53,6 +68,22 @@ func normalizeDOWField(field string) string {
 		parts[i] = strconv.Itoa(v)
 	}
 	return strings.Join(parts, ",")
+}
+
+// normalizeDOWStepBase rewrites the Sunday alias 7→0 when it is the single-value
+// base of a step expression ("7/2" → "0/2", "07/2" → "0/2") so the step
+// survives expansion. Parts without a step, or whose step base is a wildcard or
+// a range, are returned unchanged: expandCronField enumerates them and
+// normalizeDOWValues maps any resulting 7 to 0 without losing information.
+func normalizeDOWStepBase(part string) string {
+	idx := strings.Index(part, "/")
+	if idx == -1 {
+		return part
+	}
+	if base := part[:idx]; base == "7" || base == "07" {
+		return "0" + part[idx:]
+	}
+	return part
 }
 
 // normalizeDOWValues maps weekday value 7 to 0 (both mean Sunday)

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -183,19 +183,53 @@ func TestParseCronDOMWithDOWRangeEndingAtSeven(t *testing.T) {
 	assert.Equal(t, time.Date(2026, 2, 8, 0, 0, 0, 0, time.UTC), schedule.Next(fromSat))
 }
 
+// TestParseCronDOWStepFromSevenPreservesStep is the regression for #888: the
+// Sunday alias 7 used as a step base ("7/2") must keep its step and fire
+// Sun,Tue,Thu,Sat (≡ "0/2"), not collapse to Sunday-only.
+func TestParseCronDOWStepFromSevenPreservesStep(t *testing.T) {
+	seven, err := ParseCron("0 0 * * 7/2")
+	require.NoError(t, err)
+	zero, err := ParseCron("0 0 * * 0/2")
+	require.NoError(t, err)
+
+	// Walk a full week from a Saturday and confirm 7/2 fires on the same days
+	// as 0/2: Sun, Tue, Thu, Sat. 2026-06-13 is a Saturday.
+	from := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	want := []time.Time{
+		time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC), // Sunday
+		time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC), // Tuesday
+		time.Date(2026, 6, 18, 0, 0, 0, 0, time.UTC), // Thursday
+		time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC), // Saturday
+	}
+	cur7, cur0 := from, from
+	for _, w := range want {
+		cur7 = seven.Next(cur7)
+		cur0 = zero.Next(cur0)
+		assert.Equal(t, w, cur7, "7/2 must fire %s", w.Weekday())
+		assert.Equal(t, w, cur0, "0/2 must fire %s", w.Weekday())
+	}
+}
+
 func TestNormalizeDOWField(t *testing.T) {
 	cases := []struct {
 		in   string
 		want string
 	}{
 		{"*", "*"},
-		{"1-5", "1-5"}, // untouched: no 7 present
-		{"7", "0"},
-		{"07", "0"},
-		{"5-7", "0,5,6"},
-		{"1,7", "0,1"},
-		{"*/7", "0"},
-		{"0-7", "0,1,2,3,4,5,6"},
+		{"1-5", "1-5"},           // untouched: no 7 present
+		{"0/2", "0/2"},           // untouched: no 7, step preserved for robfig
+		{"*/2", "*/2"},           // untouched: no 7, step preserved for robfig
+		{"7", "0"},               // bare Sunday alias
+		{"07", "0"},              // leading-zero Sunday alias (#743)
+		{"5-7", "0,5,6"},         // range ending at 7
+		{"1,7", "0,1"},           // list containing 7
+		{"*/7", "0"},             // step that only lands on 0 and 7
+		{"7/2", "0,2,4,6"},       // step base 7 must keep its step (#888): Sun,Tue,Thu,Sat
+		{"07/2", "0,2,4,6"},      // leading-zero step base 7 (#888 + #743)
+		{"1/2", "1/2"},           // no 7 present; passes through untouched
+		{"3,7/2", "0,2,3,4,6"},   // 7-step base inside a list still keeps its step (#888)
+		{"0-7", "0,1,2,3,4,5,6"}, // full range incl. both Sunday aliases (#770: explicit list, never "*")
+		{"1-7", "0,1,2,3,4,5,6"}, // range to the 7 alias covers the whole week as a list (#770)
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.want, normalizeDOWField(tc.in), "normalizeDOWField(%q)", tc.in)


### PR DESCRIPTION
## Problem

`normalizeDOWField` (in `task/cron.go`) translates the Vixie Sunday alias `7` to `0` because the robfig parser bounds day-of-week to `0-6`. It did so by **expanding the field first, then mapping `7→0`**. That loses the step on a single-value step base:

- `7/2` expanded with `max=7` starts at the field max, so no further values follow → `{7}` → mapped to `{0}` → output `"0"`.
- Result: `7/2` fired **Sunday only (1×/week)** instead of the expected **Sun/Tue/Thu/Sat (4×/week)**, i.e. `≡ 0/2`.

Introduced in #791 (the #782 cron-normalization family: #522/#535/#743/#770).

## Fix

Apply the `7→0` alias to each comma-separated part **before** expansion, but only when `7` is the single-value base of a step (`7/2` → `0/2`, `07/2` → `0/2`, and list members like `3,7/2`). Every other shape — a bare `7`, a range bound of `7` (`5-7`), a step that merely lands on `7` (`*/7`) — is unchanged and still handled by the existing expand-then-map path, which enumerates and maps `7→0` without losing information.

This is more robust than scanning only the first `/` in the field (which would miss list cases like `3,7/2`).

## Audit (CLAUDE.md adjacent-call-sites)

The old `convertDOW`/`convertSingleDOW` conversion layer was deleted in #782 — `normalizeDOWField` is now the single DOW-normalization path. The #743 (leading-zero) and #770 (full-range stays an explicit list, never collapses to `*`) behaviors are preserved and pinned by tests below.

## Tests (table-driven + firing semantics)

- `7/2` → `0,2,4,6`, `07/2` → `0,2,4,6`, `3,7/2` → `0,2,3,4,6` (#888)
- `7` → `0`, `5-7` → `0,5,6`, `*/7` → `0` (unchanged)
- `0/2`/`*/2`/`1/2` pass through untouched (no `7`)
- `0-7` and `1-7` → `0,1,2,3,4,5,6` explicit list (#770), `07` (#743) green
- `TestParseCronDOWStepFromSevenPreservesStep`: walks a week and confirms `7/2` fires the same days as `0/2` — Sun, Tue, Thu, Sat

All four CI gates pass (`go build`, `go test ./...`, `golangci-lint --fast`, `gofmt -l`), plus `deadcode -test ./...` clean and `go test -race ./task/...` green.

Fixes #888

— Captain Claude