### PR TITLE
fix(config,log): correct deprecation-warning path and gate the wrote-logs message on an open file (#890, #894)

### DIFF
--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -188,6 +188,14 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 	}
 
 	prettyPath := prettyHomePath(InRepoConfigPath(repoRoot))
+	// Name the real global config file rather than a hardcoded
+	// ~/.agent-factory/config.json, which is wrong when AGENT_FACTORY_HOME
+	// relocates the config dir (same class of bug as #890). Fall back to a
+	// generic phrase if the config dir cannot be resolved.
+	globalConfigLocation := "the global config file"
+	if configDir, dirErr := GetConfigDir(); dirErr == nil {
+		globalConfigLocation = prettyHomePath(filepath.Join(configDir, ConfigFileName))
+	}
 	if len(data) == 0 {
 		return nil, nil, fmt.Errorf("in-repo config %s is empty; delete it or add valid JSON", prettyPath)
 	}
@@ -198,7 +206,7 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 	}
 	for key := range rawKeys {
 		if inRepoGlobalOnlyKeys[key] {
-			return nil, nil, fmt.Errorf("in-repo config %s: %q is a global setting and cannot be set per-repo; move it to ~/.agent-factory/config.json and remove it from this file", prettyPath, key)
+			return nil, nil, fmt.Errorf("in-repo config %s: %q is a global setting and cannot be set per-repo; move it to %s and remove it from this file", prettyPath, key, globalConfigLocation)
 		}
 		allowed := false
 		for _, k := range inRepoAllowedKeys {

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -68,7 +68,8 @@ func TestLoadInRepoConfigEmptyValueIsSet(t *testing.T) {
 func TestLoadInRepoConfigRejectsGlobalOnlyKeys(t *testing.T) {
 	for _, key := range []string{"auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "worktree_root"} {
 		t.Run(key, func(t *testing.T) {
-			t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+			home := t.TempDir()
+			t.Setenv("AGENT_FACTORY_HOME", home)
 			repoRoot := t.TempDir()
 			writeInRepoConfig(t, repoRoot, `{"`+key+`": "x"}`)
 
@@ -76,7 +77,11 @@ func TestLoadInRepoConfigRejectsGlobalOnlyKeys(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), key)
 			assert.Contains(t, err.Error(), "global setting")
-			assert.Contains(t, err.Error(), "~/.agent-factory/config.json")
+			// The message must name the real global config file under the
+			// active config dir, not a hardcoded ~/.agent-factory path that
+			// AGENT_FACTORY_HOME has relocated (#890).
+			assert.Contains(t, err.Error(), prettyHomePath(filepath.Join(home, ConfigFileName)))
+			assert.NotContains(t, err.Error(), "~/.agent-factory/config.json")
 		})
 	}
 }

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -163,7 +162,17 @@ func warnLegacyRepoConfig(repoID, repoRoot string, legacy *RepoConfig, inRepo *I
 	if _, loaded := legacyDeprecationLogged.LoadOrStore(repoID, true); loaded {
 		return
 	}
-	legacyPath := fmt.Sprintf("~/.agent-factory/repos/%s/%s", repoID, RepoConfigFileName)
+	// Derive the legacy path from the same resolver the read uses
+	// (repoConfigPath -> repoStateDir -> GetConfigDir) so the warning names
+	// the real file even when AGENT_FACTORY_HOME relocates the config dir
+	// (#890). If resolution fails, still warn but omit the now-unknown source
+	// path rather than printing a wrong one.
+	_, legacyPath, err := repoConfigPath(repoID)
+	if err != nil {
+		log.WarningLog.Printf("deprecated: %s is still read from the legacy per-repo config location; move it to %s — the legacy location stops working in a future release",
+			strings.Join(fields, ", "), InRepoConfigPath(repoRoot))
+		return
+	}
 	log.WarningLog.Printf("deprecated: %s is still read from %s; move it to %s — the legacy location stops working in a future release",
-		strings.Join(fields, ", "), legacyPath, InRepoConfigPath(repoRoot))
+		strings.Join(fields, ", "), prettyHomePath(legacyPath), InRepoConfigPath(repoRoot))
 }

--- a/config/resolve_test.go
+++ b/config/resolve_test.go
@@ -235,6 +235,14 @@ func TestResolveConfigLegacyDeprecationLog(t *testing.T) {
 	assert.Contains(t, buf.String(), "post_worktree_commands")
 	assert.Contains(t, buf.String(), InRepoConfigPath(repoRoot))
 
+	// The warning must name the real legacy file, derived from the active
+	// config dir, not a hardcoded ~/.agent-factory path — AGENT_FACTORY_HOME
+	// relocates it here (#890).
+	_, legacyPath, lerr := repoConfigPath(repoID)
+	require.NoError(t, lerr)
+	assert.Contains(t, buf.String(), prettyHomePath(legacyPath))
+	assert.NotContains(t, buf.String(), "~/.agent-factory")
+
 	// Once per repo per process: a second resolve stays quiet.
 	buf.Reset()
 	_, err = ResolveConfig(repoRoot)

--- a/log/log.go
+++ b/log/log.go
@@ -122,11 +122,17 @@ func Close() {
 	if ErrorLog != nil {
 		ErrorLog.SetOutput(os.Stderr)
 	}
+	// Only claim a file was written when one was actually opened. When
+	// Initialize fell back to stderr (or was never called), globalLogFile is
+	// nil and there is no file to point at (#894).
+	fileWasOpened := globalLogFile != nil
 	if globalLogFile != nil {
 		_ = globalLogFile.Close()
 		globalLogFile = nil
 	}
-	fmt.Fprintln(os.Stderr, "wrote logs to "+logFileName)
+	if fileWasOpened {
+		fmt.Fprintln(os.Stderr, "wrote logs to "+logFileName)
+	}
 }
 
 // Every is used to log at most once every timeout duration.

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -89,4 +90,67 @@ func TestCloseRedirectsToStderr(t *testing.T) {
 	if globalLogFile != nil {
 		t.Fatalf("expected globalLogFile to be nil after Close")
 	}
+}
+
+// TestCloseClaimsFileOnlyWhenOpened is the regression for
+// sachiniyer/agent-factory#894: Close() must print "wrote logs to <file>" only
+// when Initialize actually opened a log file. When the open fails (e.g. an
+// unwritable path) logging falls back to stderr, globalLogFile stays nil, and
+// claiming a file was written points the user at a file that does not exist.
+func TestCloseClaimsFileOnlyWhenOpened(t *testing.T) {
+	origName := logFileName
+	t.Cleanup(func() {
+		logFileName = origName
+		globalLogFile = nil
+	})
+
+	captureStderr := func(t *testing.T, fn func()) string {
+		t.Helper()
+		origStderr := os.Stderr
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("os.Pipe failed: %v", err)
+		}
+		os.Stderr = w
+		fn()
+		if err := w.Close(); err != nil {
+			t.Fatalf("close pipe writer: %v", err)
+		}
+		os.Stderr = origStderr
+		out, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("read pipe: %v", err)
+		}
+		return string(out)
+	}
+
+	t.Run("no file opened: no wrote-logs claim", func(t *testing.T) {
+		// Parent directory does not exist, so OpenFile fails and Initialize
+		// falls back to stderr without setting globalLogFile.
+		logFileName = filepath.Join(t.TempDir(), "missing-dir", "agent-factory.log")
+		globalLogFile = nil
+		out := captureStderr(t, func() {
+			Initialize(false)
+			Close()
+		})
+		if globalLogFile != nil {
+			t.Fatalf("expected globalLogFile to stay nil after a failed Initialize")
+		}
+		if strings.Contains(out, "wrote logs to") {
+			t.Fatalf("Close() claimed logs were written though no file opened; stderr: %q", out)
+		}
+	})
+
+	t.Run("file opened: wrote-logs claim present", func(t *testing.T) {
+		logFileName = filepath.Join(t.TempDir(), "agent-factory.log")
+		globalLogFile = nil
+		out := captureStderr(t, func() {
+			Initialize(false)
+			Close()
+		})
+		want := "wrote logs to " + logFileName
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected Close() to print %q; stderr: %q", want, out)
+		}
+	})
 }


### PR DESCRIPTION
Two small honesty fixes in distinct files, kept as two commits.

## #890 — deprecation warning shows wrong legacy path under `AGENT_FACTORY_HOME`
`warnLegacyRepoConfig` (`config/resolve.go`) hardcoded the legacy source path as `~/.agent-factory/repos/<id>/config.json` while the *destination* was computed dynamically via `InRepoConfigPath`. With `AGENT_FACTORY_HOME` set, the config dir is relocated, so the warning pointed users at a file that does not exist.

- Derive the legacy path from the same resolver the read uses (`repoConfigPath` → `repoStateDir` → `GetConfigDir`) and render it with `prettyHomePath`. If resolution fails, still warn but omit the now-unknown source path rather than printing a wrong one.
- **Adjacent-call-site audit (per CLAUDE.md):** grep for hardcoded `~/.agent-factory` in user-facing messages found one more instance — `LoadInRepoConfig`'s global-only-key rejection error (`config/inrepo.go`) hardcoded `~/.agent-factory/config.json`. Same class of bug; it now names the real global config file under the active config dir. No other user-facing hardcoded paths remained.

## #894 — `Close()` claims logs were written even when no file opened
`Close()` (`log/log.go`) printed `wrote logs to <file>` unconditionally, even when `Initialize` failed to open the log file (permission denied, read-only fs, bad `AGENT_FACTORY_HOME`) and logging fell back to stderr — or when `Initialize` was never called. Gate the message on `globalLogFile != nil` so it is only emitted when a file was actually opened.

- **Adjacent-call-site audit:** the only other stderr status line in the package (`logging to stderr` on open failure) is already honest; no other unconditional file-claim prints exist.

## Tests
- `TestResolveConfigLegacyDeprecationLog`: now asserts the warning contains the real `prettyHomePath(legacyPath)` and does **not** contain `~/.agent-factory` (AGENT_FACTORY_HOME is set in the harness).
- `TestLoadInRepoConfigRejectsGlobalOnlyKeys`: updated to assert the real global config path and reject the old hardcoded string.
- `TestCloseClaimsFileOnlyWhenOpened` (new): with no file opened, `Close()` does not print the wrote-logs line; with a file, it does.

## Gates
`go build ./...`, `gofmt -l .`, `go test ./...`, `go test -race ./config/... ./log/...`, `golangci-lint run --timeout=3m --fast`, and `deadcode -test ./...` all clean. Hermetic; no dev-install.

Fixes #890
Fixes #894

— Captain Claude