### PR TITLE
fix(app): emit terminal reset when detaching a remote session from the Terminal tab (#889)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -870,6 +870,16 @@ const remoteDetachTerminalReassert = "" +
 // the real terminal in production, swappable so tests can capture it.
 var remoteDetachResetWriter io.Writer = os.Stdout
 
+// attachOverlayCallbackFn is the indirection handleEnter reaches
+// attachOverlayCallback through. Production points it at the method; tests swap
+// it to substitute a hermetic attach func (no real tmux client or remote
+// terminal_cmd PTY) while preserving the real `remote` argument the call site
+// computed. That keeps the call-site decision exercised end to end — the #889
+// regression is that the terminal-tab site passed a hardcoded false instead of
+// selected.IsRemote(), which can only be caught by a test that drives the real
+// handleEnter and observes the post-detach reset keyed off that argument.
+var attachOverlayCallbackFn = (*home).attachOverlayCallback
+
 // attachOverlayCallback runs the attach-overlay onDismiss lifecycle: emits
 // the detach-trace markers, invokes attach, arms the attached flag for the
 // duration of `<-ch`, then returns the tea.Cmd to emit the

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -291,18 +291,23 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		// callbacks must attach to this captured instance, not re-read the live
 		// selection (#716).
 		if tw.IsInTerminalTab() {
-			// The terminal tab always attaches a local tmux session (remote
-			// instances have no worktree to host one), so remote=false: the
-			// post-detach terminal handling is keyed to what was attached,
-			// not to the instance kind (#845).
+			// The terminal tab attaches a local tmux session for local
+			// instances, but a remote instance's terminal_cmd PTY for remote
+			// ones (#843) — and that remote PTY hands the terminal back via
+			// session.hookAttachTerminalRestore (main screen, modes off), the
+			// same neutral state the sidebar remote attach leaves. So the
+			// post-detach handling must key off the instance's real
+			// remote-ness, exactly like the sidebar path below: a remote
+			// terminal_cmd detach needs the #845/#848 full reset + reassert,
+			// or the TUI keeps rendering on the main screen (#889).
 			return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-				return m.attachOverlayCallback("handleEnter-terminal", "", false, func() (chan struct{}, error) {
+				return attachOverlayCallbackFn(m, "handleEnter-terminal", "", selected.IsRemote(), func() (chan struct{}, error) {
 					return tw.AttachTerminalForInstance(selected)
 				})
 			})
 		}
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-			return m.attachOverlayCallback("handleEnter-sidebar", "", selected.IsRemote(), func() (chan struct{}, error) {
+			return attachOverlayCallbackFn(m, "handleEnter-sidebar", "", selected.IsRemote(), func() (chan struct{}, error) {
 				return m.sidebar.AttachInstance(selected)
 			})
 		})

--- a/app/handle_enter_remote_terminal_test.go
+++ b/app/handle_enter_remote_terminal_test.go
@@ -1,0 +1,148 @@
+package app
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// remoteFakeBackend is a FakeBackend that reports itself as the remote hook
+// backend, so Instance.IsRemote() returns true without standing up a real
+// HookBackend (and its terminal_cmd PTY). Everything else — IsAlive() true so
+// the instance is attachable — is inherited.
+type remoteFakeBackend struct {
+	*session.FakeBackend
+}
+
+func (remoteFakeBackend) Type() string { return "remote" }
+
+// swapAttachOverlayCallbackFn redirects the handleEnter -> attachOverlayCallback
+// indirection for the duration of a test. The substitute forwards the real
+// `remote` flag the call site computed but replaces the attach closure with one
+// that detaches immediately (a pre-closed channel), so the real post-detach
+// lifecycle runs synchronously without a tmux client or a remote terminal_cmd
+// PTY.
+func swapAttachOverlayCallbackFn(t *testing.T, fn func(*home, string, string, bool, func() (chan struct{}, error)) tea.Cmd) {
+	t.Helper()
+	prev := attachOverlayCallbackFn
+	attachOverlayCallbackFn = fn
+	t.Cleanup(func() { attachOverlayCallbackFn = prev })
+}
+
+// driveHandleEnterAttach presses Enter on a single instance (remote or local)
+// with either the Terminal or the sidebar (Preview) tab active, and returns the
+// post-detach cmd plus whatever was written to the remote-detach reset writer.
+//
+// The first-time attach help overlay is marked seen so showHelpScreen runs the
+// onDismiss attach callback synchronously, and the real attachOverlayCallback is
+// driven (via the swapped indirection) with a hermetic, immediately-detaching
+// attach func. The only behaviour under observation is the `remote` argument the
+// handleEnter call site chose: it decides whether the #845/#848 terminal
+// reset+reassert is emitted.
+func driveHandleEnterAttach(t *testing.T, terminalTab, remote bool) (tea.Cmd, string) {
+	t.Helper()
+	resetDetachWatchdog(t)
+
+	h := newTestHome(t)
+	// Skip the first-time attach help overlay so the deferred attach callback
+	// runs synchronously inside handleEnter (see showHelpScreen, app/help.go).
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInstanceAttach{}.mask()))
+
+	inst := instanceWithFakeBackend(t, "inst")
+	if remote {
+		inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
+		inst.SetStatus(session.Running)
+	}
+	require.Equal(t, remote, inst.IsRemote(),
+		"precondition: instance remote-ness must match the case under test")
+	require.True(t, inst.TmuxAlive(),
+		"precondition: instance must be attachable so handleEnter reaches the attach path")
+
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	tw := h.contentPane.TabbedWindow()
+	if terminalTab {
+		tw.Toggle() // PreviewTab -> TerminalTab
+		require.True(t, tw.IsInTerminalTab(), "precondition: Terminal tab must be active")
+	} else {
+		require.False(t, tw.IsInTerminalTab(), "precondition: sidebar (Preview) tab must be active")
+	}
+
+	var out bytes.Buffer
+	swapRemoteDetachResetWriter(t, &out)
+	swapAttachOverlayCallbackFn(t, func(m *home, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+		return m.attachOverlayCallback(label, traceSuffix, rem, func() (chan struct{}, error) {
+			ch := make(chan struct{})
+			close(ch) // detach immediately, synchronously, no real PTY
+			return ch, nil
+		})
+	})
+
+	model, cmd := h.handleEnter()
+	require.Nil(t, model.(*home).textOverlay,
+		"the attach help overlay must be skipped so the attach callback ran")
+	endDetachWatchdog()
+	return cmd, out.String()
+}
+
+// TestHandleEnter_TerminalTabRemoteDetachEmitsReset is the regression guard for
+// issue #889. Detaching from a remote session in the Terminal tab streams the
+// terminal_cmd PTY (#843), which hands the terminal back via
+// session.hookAttachTerminalRestore — on the MAIN screen with reporting modes
+// off. The TUI runs in alt-screen, so the post-detach handling must re-assert
+// bubbletea's modes (remoteDetachTerminalReassert) + ClearScreen, exactly as
+// the sidebar remote attach already does.
+//
+// The bug was that the terminal-tab call site in handleEnter hardcoded
+// remote=false, so the reassert never fired and the TUI kept rendering on the
+// main screen (garbled UI). This drives the real handleEnter and pins that the
+// terminal-tab path now keys the reset off the instance's real remote-ness, for
+// every (tab, remote) combination — so a revert to the hardcoded false fails
+// the remote/Terminal-tab case.
+func TestHandleEnter_TerminalTabRemoteDetachEmitsReset(t *testing.T) {
+	cases := []struct {
+		name        string
+		terminalTab bool
+		remote      bool
+	}{
+		{"terminal-tab/remote emits reset (#889)", true, true},
+		{"terminal-tab/local emits no reset", true, false},
+		{"sidebar/remote emits reset", false, true},
+		{"sidebar/local emits no reset", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, out := driveHandleEnterAttach(t, tc.terminalTab, tc.remote)
+			require.NotNil(t, cmd, "attach callback must return a post-detach cmd")
+
+			if tc.remote {
+				require.Equal(t, remoteDetachTerminalReassert, out,
+					"a remote detach must synchronously re-assert the TUI's terminal "+
+						"modes — the terminal_cmd PTY left the terminal on the main screen")
+				// Remote post-detach cmd is tea.Sequence(ClearScreen, repaint);
+				// sequenceMsg is unexported, so unpack reflectively.
+				seq := reflect.ValueOf(cmd())
+				require.Equal(t, reflect.Slice, seq.Kind(),
+					"remote post-detach cmd must be a tea.Sequence, got %T", cmd())
+				require.Equal(t, 2, seq.Len(), "sequence must be ClearScreen + repaint")
+				first, ok := seq.Index(0).Interface().(tea.Cmd)
+				require.True(t, ok)
+				assert.Equal(t, tea.ClearScreen(), first(),
+					"first sequenced cmd must invalidate the renderer's stale diff cache")
+			} else {
+				assert.Zero(t, len(out),
+					"a local detach must write no terminal reset — the tmux client "+
+						"hands the terminal back untouched")
+				_, isRepaint := cmd().(repaintAfterDetachMsg)
+				assert.True(t, isRepaint,
+					"local post-detach cmd must be the bare repaintAfterDetachMsg emitter")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #889.

## Root cause
The Terminal-tab branch of `handleEnter` (`app/handle_actions.go`) hardcoded `remote=false` when calling `attachOverlayCallback`. That was correct before #843, when the Terminal tab only ever attached a **local tmux** session (the stale comment even said so).

#843 added the **remote terminal_cmd** path: a remote instance's Terminal tab streams `terminal_cmd` behind a PTY (`ui/terminal.go` `AttachForInstance` → `Instance.AttachRemoteTerminal` → `HookBackend.AttachTerminal` → `runHookAttachWithDetach`). On every detach that path unconditionally writes `session.hookAttachTerminalRestore`, which hands the terminal back on the **main screen** (`\x1b[?1049l`), cursor visible, reporting modes off.

The TUI runs in alt-screen (`tea.WithAltScreen()`). With `remote=false`, the #845/#848 `remoteDetachTerminalReassert` (`\x1b[?1049h` + cursor/mouse/paste re-assert) and the follow-up `tea.ClearScreen` never fired. Result: after detaching from a remote session **in the Terminal tab**, bubbletea still believed it owned alt-screen, so renders went to the main screen — garbled UI and TUI output leaked into scrollback, recoverable only by resize/restart.

## Fix
Pass `selected.IsRemote()` instead of `false`, matching the sidebar attach path and the #843 remote terminal path. The reset+reassert now runs whenever the attached stream was the remote `terminal_cmd` PTY, and the local-tmux case is unchanged (`IsRemote()==false` → no reset, exactly as before). The stale comment is corrected to describe the post-#843 reality.

## Adjacent call-site audit (per CLAUDE.md)
Every `attachOverlayCallback` invocation in the codebase:

| Call site | `remote` arg | Correct? |
|---|---|---|
| `handleEnter` — Terminal tab (`app/handle_actions.go`) | `selected.IsRemote()` | ✅ fixed (was hardcoded `false`) |
| `handleEnter` — sidebar (`app/handle_actions.go`) | `selected.IsRemote()` | ✅ already correct (#845) |

These are the only two call sites. Neither now hardcodes `false` for a path that can be remote.

## Tests
New regression test `TestHandleEnter_TerminalTabRemoteDetachEmitsReset` (`app/handle_enter_remote_terminal_test.go`) drives the **real** `handleEnter` across all four `(tab, remote)` combinations and asserts the post-detach reset keyed off the call-site's `remote` flag, via the existing `remoteDetachResetWriter` output seam (#848):

- **Terminal tab + remote → reset emitted** (`remoteDetachTerminalReassert` written, cmd = `tea.Sequence(ClearScreen, repaint)`) — the #889 guard.
- Terminal tab + local → no reset (unchanged).
- Sidebar + remote → reset emitted (already-correct path stays green).
- Sidebar + local → no reset.

A small swappable indirection (`attachOverlayCallbackFn`, matching the repo's existing `remoteDetachResetWriter` / `reloadDaemonTaskSchedulesFn` seam convention) lets the test substitute a hermetic, immediately-detaching attach func while preserving the real `remote` argument the call site computes — so the test exercises the actual `handleEnter` decision with no tmux client or remote `terminal_cmd` PTY. Confirmed the test **fails** when the fix is reverted to the hardcoded `false` and passes when restored. The existing #845 `TestAttachOverlayCallback_*` tests are untouched.

## CI
- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — no output
- `go build ./...` — clean
- `go test ./...` — all green
- `deadcode -test ./...` — no output
- `GOFLAGS="-p=1" go test -race -parallel 2 ./app/... ./ui/...` — green

— Captain Claude
