### PR TITLE
docs: add minimal SECURITY.md pointing to contact page (#910)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Instead, report them privately via the contact page at https://sachiniyer.com/contact/.


### PR DESCRIPTION
Resolves #910 — adds a minimal `SECURITY.md` at the repo root so GitHub surfaces a security policy in the **Security** tab and the vulnerability-report flow.

## File content (`SECURITY.md`)

```markdown
# Security Policy

## Reporting a Vulnerability

Please do not report security vulnerabilities through public GitHub issues.

Instead, report them privately via the contact page at https://sachiniyer.com/contact/.
```

The contact URL is exactly `https://sachiniyer.com/contact/`, per the issue.

Kept deliberately minimal: no invented SLAs, PGP keys, bounty terms, or version-support table.

Fixes #910

Co-Authored-By: Captain Claude <noreply@anthropic.com>