### PR TITLE
fix(session): drain remote-attach PTY before closing master to stop tail-truncation on natural exit (#912)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -696,6 +696,14 @@ const hookAttachTerminalRestore = "" +
 	"\x1b[0m" + // SGR attributes reset
 	"\x1b[?25h" // cursor visible
 
+// hookAttachDrainTimeout bounds how long we wait for the PTY copy goroutine to
+// drain after the child exits. On the natural-exit path the master returns the
+// child's remaining buffered output and then EIO once the slave is gone, so
+// io.Copy terminates on its own — but a grandchild that inherited and kept the
+// slave open would keep the master from ever EOFing. 2s is generous for a
+// genuine drain while still bounding that pathological case (#912).
+const hookAttachDrainTimeout = 2 * time.Second
+
 func runHookAttachWithDetach(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.Writer) error {
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
@@ -746,8 +754,22 @@ func runHookAttachWithDetach(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.W
 	}()
 
 	err = <-waitDone
-	_ = ptmx.Close()
-	<-copyDone
+
+	// Drain before closing. Now that the child (slave) has exited, io.Copy
+	// reads the master's remaining buffered output and then sees EIO, so it
+	// terminates on its own. Closing ptmx here — before copyDone — would race
+	// that final read and truncate the remote's last bytes (#912). The detach
+	// path already closed ptmx in detach(), so copyDone closes promptly there
+	// and this drain is a harmless no-op. Bound the wait in case a grandchild
+	// inherited the slave and is holding the master open: on timeout, force the
+	// close to unblock io.Copy, then still wait for copyDone.
+	select {
+	case <-copyDone:
+	case <-time.After(hookAttachDrainTimeout):
+		_ = ptmx.Close() // grandchild holding slave open; stop waiting
+		<-copyDone
+	}
+	_ = ptmx.Close() // idempotent; no-op if already closed
 
 	// Every byte of the remote stream has been flushed (copyDone), so this
 	// lands strictly after any modes the remote set. Emitted on every exit


### PR DESCRIPTION
## The race (#912)

`session` test `TestRunHookAttachWithDetach_EmitsTerminalRestoreOnNaturalExit` fails on the linux/arm64 CI shard (amd64 passed in the same run). It is a genuine race, not a flaky test: it reproduces locally on amd64 under CPU contention.

In `runHookAttachWithDetach` (`session/backend_hook.go`), the natural-exit path was:

```go
err = <-waitDone   // cmd.Wait() returned — child exited
_ = ptmx.Close()   // closes the PTY master
<-copyDone         // wait for io.Copy(stdout, ptmx) goroutine
```

The `io.Copy(stdout, ptmx)` goroutine reads the child's PTY output. When the child writes its bytes and exits immediately, those bytes sit buffered in the PTY. Closing the master **concurrently** with io.Copy's read truncates any bytes io.Copy hadn't read yet. On fast amd64 io.Copy usually wins; on the slower/contended arm64 shard the `Close` wins and the remote's final output is dropped. The old comment claiming "Every byte of the remote stream has been flushed" was false on this path.

## Production impact

Low-frequency but real: a remote attach session's **final output before a graceful exit can be silently lost** in production — not just in the test. The test asserts a real invariant (no truncation on natural exit), so it was fixed in the implementation, not papered over with a sleep/`Eventually` in the test.

## The fix

On the natural-exit path, drain *before* closing. Once the child (slave) has exited, the master returns its remaining buffered bytes and then `EIO`, so `io.Copy` terminates on its own — don't yank the fd out from under it:

```go
err = <-waitDone
select {
case <-copyDone:
case <-time.After(hookAttachDrainTimeout):
    _ = ptmx.Close() // grandchild holding slave open; stop waiting
    <-copyDone
}
_ = ptmx.Close() // idempotent; no-op if already closed
```

The drain is bounded by `hookAttachDrainTimeout = 2 * time.Second` to guard the pathological case where a grandchild inherited and is holding the slave open (master would never EOF). On timeout we force the close and still wait for `copyDone`.

The **detach path is unaffected**: `detach()` already closes `ptmx` and kills the process, so `copyDone` closes promptly there and the drain block is a harmless no-op. `ptmx.Close()` is safe to call twice (creack/pty wraps `*os.File`; the second close returns an error we ignore).

## Adjacent-site audit

`ensurePTY`'s preview-capture path uses **pipes, not a PTY**, and its reader goroutine drains to EOF *before* calling `hp.wait()`; the read end is only closed in `stopPreview` (the detach analog). No close-before-drain race there, so it is left unchanged.

## Verification

Repro loop (6× `yes >/dev/null` background load):

- **Before:** fails within 500 iterations (reproduced — `remoteJunk` missing from `out`).
- **After:** `-count=500 -race` under contention → **0 failures** (`ok ... 4.969s`).

Also green:
- `TestRunHookAttachWithDetach_EmitsTerminalRestoreOnNaturalExit`, `...OnDetachKill`, `...NoRestoreWhenPTYNeverStarted` — all pass.
- `go test ./session/...` — green.
- `GOFLAGS="-p=1" go test -race -parallel 2 ./session/...` — green.
- `gofmt -l .`, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` — all clean.

Fixes #912

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)