### PR TITLE
fix(session/git): only report git network timeout when the command actually failed (#914)

### DIFF
--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -53,7 +53,13 @@ func (g *GitWorktree) runGitNetworkCommand(path string, args ...string) (string,
 	ctx, cancel := context.WithTimeout(context.Background(), networkGitTimeout)
 	defer cancel()
 	output, err := g.runGitCommandContext(ctx, path, args...)
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+	// Only treat a tripped deadline as a timeout when the command actually
+	// failed. runGitCommandContext converts an exec.ErrWaitDelay (git itself
+	// exited successfully, only a transport child held the capture pipe open
+	// past the deadline) into err == nil; without the err != nil guard that
+	// race would surface as a false timeout even though the fetch succeeded
+	// (#914). github.go's FetchPRInfo guards the same way.
+	if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return output, fmt.Errorf("git %s timed out after %s (remote unreachable or stalled): %w",
 			strings.Join(args, " "), networkGitTimeout, ctx.Err())
 	}

--- a/session/git/worktree_network_test.go
+++ b/session/git/worktree_network_test.go
@@ -126,3 +126,31 @@ func TestRunGitNetworkCommand_NormalFetchSucceeds(t *testing.T) {
 	out, err := (&GitWorktree{}).runGitNetworkCommand(repoRoot, "fetch", "origin")
 	require.NoError(t, err, "a healthy fetch must succeed: %s", out)
 }
+
+// TestRunGitNetworkCommand_NoFalseTimeoutWhenGitSucceeds verifies that a
+// successful git command does not return a timeout error even if the context
+// deadline expires during pipe cleanup. This guards against the race where git
+// exits before the deadline but a transport child holds stdout open, so
+// cmd.Output returns exec.ErrWaitDelay which runGitCommandContext converts to a
+// nil error; runGitNetworkCommand must not then report a false timeout (#914).
+func TestRunGitNetworkCommand_NoFalseTimeoutWhenGitSucceeds(t *testing.T) {
+	sandboxHome(t)
+
+	// Create a repo and a local origin to fetch from (hermetic, no network).
+	origin := createGitRepo(t)
+	runGit(t, origin, "commit", "--allow-empty", "-m", "initial")
+
+	repoRoot := createGitRepo(t)
+	runGit(t, repoRoot, "remote", "add", "origin", origin)
+
+	// A tight timeout: longer than the local fetch needs, but short enough to
+	// keep the test fast.
+	shortenNetworkTimeout(t, 5*time.Second)
+
+	// Run the fetch repeatedly to widen the window for the (rare) ErrWaitDelay
+	// race; with the err != nil guard every successful fetch is error-free.
+	for i := 0; i < 10; i++ {
+		out, err := (&GitWorktree{}).runGitNetworkCommand(repoRoot, "fetch", "origin")
+		require.NoError(t, err, "a successful fetch must not return a timeout error: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

`runGitNetworkCommand` in `session/git/worktree_git.go` checked `errors.Is(ctx.Err(), context.DeadlineExceeded)` **without first checking `err != nil`**, so it could return a timeout error even when the git command succeeded (regression introduced with `runGitNetworkCommand` in #902).

### The ErrWaitDelay race

`git fetch` spawns a transport child (ssh / git-remote-https) that can keep the capture pipe open after git itself exits. When that happens:

1. git exits **successfully** before the deadline.
2. The transport child keeps stdout open.
3. The deadline expires; `cmd.Output()` returns `exec.ErrWaitDelay` after `WaitDelay`.
4. `runGitCommandContext` deliberately converts that `ErrWaitDelay` into `err == nil` (the command's output is already complete — #676 precedent).
5. `runGitNetworkCommand` then saw `err == nil` but `ctx.Err() == DeadlineExceeded` and wrongly reported a timeout.

### The fix (one line)

```go
if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
```

A tripped deadline is only a timeout when the command actually failed. This matches the correct pattern already used by `FetchPRInfo` in `github.go` (`if err != nil { if errors.Is(ctx.Err(), ...) {`). The existing error message and `%w` wrapping are unchanged.

## Adjacent-call-site audit

Grepped every `ctx.Err()` / `context.DeadlineExceeded` check after a command in `session/git/`:

- **`github.go:64`** (`FetchPRInfo`) — already correct; the deadline check is nested inside `if err != nil`. No change.
- **`worktree_git.go:56`** — the buggy unguarded site. **Fixed.**
- **`hooks.go:103`** — a different pattern: `ctx.Err() != nil` gates a batch-cancellation log + early-`return` for the post-worktree hook runner, not a timeout error returned to a caller. `ErrWaitDelay` is already handled correctly in the subsequent `switch`. Not the same bug; no change.

## Test

Added `TestRunGitNetworkCommand_NoFalseTimeoutWhenGitSucceeds` (the test from the issue, adapted to the repo's existing helpers: `sandboxHome`, `createGitRepo`, `runGit`, `shortenNetworkTimeout`). It is fully hermetic — a local-filesystem origin, no network — and asserts that a successful fetch never returns a timeout error.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./session/git/...` — green
- New test with `-count=20` — green, not flaky

Fixes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)