### PR TITLE
fix(task/cron): normalize DOW step base numerically so leading-zero forms like 007/2 schedule correctly (#915)

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -71,16 +71,24 @@ func normalizeDOWField(field string) string {
 }
 
 // normalizeDOWStepBase rewrites the Sunday alias 7→0 when it is the single-value
-// base of a step expression ("7/2" → "0/2", "07/2" → "0/2") so the step
-// survives expansion. Parts without a step, or whose step base is a wildcard or
-// a range, are returned unchanged: expandCronField enumerates them and
-// normalizeDOWValues maps any resulting 7 to 0 without losing information.
+// base of a step expression ("7/2" → "0/2", "07/2" → "0/2", "007/2" → "0/2") so
+// the step survives expansion. The base is parsed numerically to match
+// ValidateCronExpr, which accepts arbitrary leading zeros via strconv.Atoi: a
+// string-equality check against only "7"/"07" would let validated forms like
+// "007/2" bypass normalization and schedule Sunday-only (#915). Parts without a
+// step, or whose step base is non-numeric (a wildcard or a range), are returned
+// unchanged: expandCronField enumerates them and normalizeDOWValues maps any
+// resulting 7 to 0 without losing information.
 func normalizeDOWStepBase(part string) string {
 	idx := strings.Index(part, "/")
 	if idx == -1 {
 		return part
 	}
-	if base := part[:idx]; base == "7" || base == "07" {
+	val, err := strconv.Atoi(part[:idx])
+	if err != nil {
+		return part // non-numeric base such as "*" or a range like "1-7"
+	}
+	if val == 7 {
 		return "0" + part[idx:]
 	}
 	return part

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -101,6 +101,8 @@ var validCronCorpus = []string{
 	"0 0 * * 1,7",    // list containing 7
 	"0 0 * * */7",    // step landing on 0 and 7
 	"0 0 * * 7/2",    // single-with-step starting at 7
+	"0 0 * * 007/2",  // multi-leading-zero step base 7 (#915)
+	"0 0 * * 0007/2", // even more leading zeros on the step base (#915)
 	"0 0 * * 0-7",    // full range incl. both Sunday aliases
 	"0 0 1 * 5-7",    // DOM restricted + DOW range with 7 (OR semantics)
 }
@@ -210,6 +212,36 @@ func TestParseCronDOWStepFromSevenPreservesStep(t *testing.T) {
 	}
 }
 
+// TestParseCronDOWStepWithLeadingZeroBaseMatchesSeven is the regression for
+// #915: a DOW step base of 7 written with arbitrary leading zeros ("007/2",
+// "0007/2") must normalize numerically — exactly as ValidateCronExpr parses it —
+// and schedule the same days as "7/2" (Sun,Tue,Thu,Sat), not collapse to
+// Sunday-only. The pre-fix string-equality check matched only "7"/"07", so the
+// validator accepted these forms while the scheduler silently fired them wrong,
+// breaking the #782 validator↔scheduler agreement gate.
+func TestParseCronDOWStepWithLeadingZeroBaseMatchesSeven(t *testing.T) {
+	reference, err := ParseCron("0 0 * * 7/2")
+	require.NoError(t, err)
+
+	for _, expr := range []string{"0 0 * * 007/2", "0 0 * * 0007/2"} {
+		// The validator must accept it (it parses the base numerically)...
+		require.NoError(t, ValidateCronExpr(expr), "ValidateCronExpr must accept %q", expr)
+		// ...and the scheduler must too.
+		sched, err := ParseCron(expr)
+		require.NoError(t, err, "ParseCron must accept %q", expr)
+
+		// The first 7 firings must match "7/2" exactly (Sun,Tue,Thu,Sat,...),
+		// proving the leading-zero form is not interpreted as Sunday-only.
+		from := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC) // a Saturday
+		curRef, curTest := from, from
+		for i := 0; i < 7; i++ {
+			curRef = reference.Next(curRef)
+			curTest = sched.Next(curTest)
+			assert.Equal(t, curRef, curTest, "%q firing %d must match 7/2", expr, i)
+		}
+	}
+}
+
 func TestNormalizeDOWField(t *testing.T) {
 	cases := []struct {
 		in   string
@@ -226,6 +258,8 @@ func TestNormalizeDOWField(t *testing.T) {
 		{"*/7", "0"},             // step that only lands on 0 and 7
 		{"7/2", "0,2,4,6"},       // step base 7 must keep its step (#888): Sun,Tue,Thu,Sat
 		{"07/2", "0,2,4,6"},      // leading-zero step base 7 (#888 + #743)
+		{"007/2", "0,2,4,6"},     // multi-leading-zero step base 7 (#915): numeric parse, not string compare
+		{"0007/2", "0,2,4,6"},    // arbitrary leading zeros on the step base (#915)
 		{"1/2", "1/2"},           // no 7 present; passes through untouched
 		{"3,7/2", "0,2,3,4,6"},   // 7-step base inside a list still keeps its step (#888)
 		{"0-7", "0,1,2,3,4,5,6"}, // full range incl. both Sunday aliases (#770: explicit list, never "*")


### PR DESCRIPTION
## Problem

`normalizeDOWStepBase` (`task/cron.go`) normalized the day-of-week Sunday alias `7→0` for a step base using **string** comparison:

```go
if base := part[:idx]; base == "7" || base == "07" { ... }
```

But `ValidateCronExpr` parses the same step base **numerically** via `strconv.Atoi`, so it accepts arbitrary leading zeros. The two layers disagreed: multi-leading-zero forms like `007/2` and `0007/2` passed validation **and** `ParseCron`, but bypassed the `7→0` normalization. They then expanded to `{7}→{0}` and scheduled **Sunday-only** instead of **Sun/Tue/Thu/Sat** — the exact wrong behavior that #888 fixed for `7/2`.

This breaks the #782 validator↔scheduler **agreement gate**: anything `ValidateCronExpr` lets a user save must be schedulable by `ParseCron` *with the same semantics*. A user saving `0 0 * * 007/2` would silently get a Sunday-only task.

## Fix

Parse the step base with `strconv.Atoi` to match the validator, normalizing any value equal to `7`:

```go
val, err := strconv.Atoi(part[:idx])
if err != nil {
    return part // non-numeric base such as "*" or a range like "1-7"
}
if val == 7 {
    return "0" + part[idx:]
}
```

## Adjacent-call-site audit

`normalizeDOWStepBase` was the **only** place that distinguished DOW spellings by string equality. Everything else already parses numerically and is consistent with the validator:

- `normalizeDOWValues` compares the integer (`v == 7`).
- `validatePart`, `expandCronField`, `expandCronPart` all go through `strconv.Atoi`.
- `normalizeDOWField`'s `strings.Contains(field, "7")` is only a fast-path guard; bare leading-zero values like `007` already flow through the numeric expand path and normalize correctly.

So only the step-base path had the gap.

## Tests

- New `TestParseCronDOWStepWithLeadingZeroBaseMatchesSeven`: asserts `0 0 * * 007/2` and `0 0 * * 0007/2` are accepted by `ValidateCronExpr` and `ParseCron`, and that their first 7 firings match `7/2` exactly (Sun/Tue/Thu/Sat…), not Sunday-only. Confirmed this fails on `master`'s code and passes with the fix.
- Added `007/2` and `0007/2` to `validCronCorpus` so the `TestParseCronAcceptsEverythingValidateAccepts` agreement gate cross-checks them.
- Added `007/2` and `0007/2` rows to the `TestNormalizeDOWField` table.

## Verification

`gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./task/...` green.

Fixes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude
