### PR TITLE
fix(daemon): fail fast on tmux-orphan collision instead of waiting out the concurrent-create timeout (#916)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -990,9 +990,9 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 		switch {
 		case existing == title:
 			if kind == titleConflictReserved {
-				return fmt.Errorf("session with title %q is already reserved", title)
+				return fmt.Errorf("session with title %q is already reserved: %w", title, errConcurrentCreate)
 			}
-			return fmt.Errorf("session with title %q already exists", title)
+			return fmt.Errorf("session with title %q already exists: %w", title, errConcurrentCreate)
 		default:
 			return fmt.Errorf("session titled %q conflicts with existing session %q: both sanitize to the same git branch %q", title, existing, m.branchForTitle(title))
 		}
@@ -1012,8 +1012,13 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 		}
 		return nil
 	}
-	if tmux.NewTmuxSessionForRepo(title, repoPath, program).DoesSessionExist() {
-		return fmt.Errorf("tmux session for title %q already exists", title)
+	if tmuxSession := tmux.NewTmuxSessionForRepo(title, repoPath, program); tmuxSession.DoesSessionExist() {
+		// A tmux session exists with no daemon reservation, in-memory instance,
+		// or disk record — an orphan left by a crash or an external process.
+		// No creator will ever finish it, so this stays a plain error (not
+		// errConcurrentCreate): DeliverPrompt must fail fast with cleanup
+		// guidance rather than wait out waitForTargetSession's timeout (#916).
+		return fmt.Errorf("conflicting tmux session %q is already running; no agent-factory session owns it. Clean it up with: tmux kill-session -t %s", title, tmuxSession.SanitizedName())
 	}
 	return nil
 }
@@ -1271,17 +1276,23 @@ func (m *Manager) waitForTargetSession(repoID, title string) error {
 	}
 }
 
-// isConcurrentCreateErr reports whether a CreateSession failure means another
-// creator already claimed the exact title — the retryable race in #865. It
-// matches reserveCreate's "already reserved"/"already exists" rejections but
-// deliberately not the branch-collision error ("conflicts with existing
-// session"), which is a genuine configuration problem, not a transient race.
+// errConcurrentCreate marks the retryable race in #865: another creator already
+// claimed the exact title between DeliverPrompt's existence check and its
+// reserveCreate, so the session will materialize shortly and waiting-then-sending
+// is correct. Only the genuine in-flight reservation/record rejections wrap it
+// (see validateTitleAvailableLocked and appendInstanceData). Terminal conflicts
+// — a tmux orphan with no daemon/disk record (#916), a branch collision, or a
+// remote hook-name clash — stay plain so DeliverPrompt surfaces them immediately
+// instead of waiting out waitForTargetSession's timeout.
+var errConcurrentCreate = errors.New("concurrent create in progress")
+
+// isConcurrentCreateErr reports whether a CreateSession failure is the retryable
+// concurrent-create race in #865. Substring matching on "already exists" used to
+// also catch the tmux-orphan rejection (#916), which is terminal and would never
+// resolve by waiting; classification now keys off the errConcurrentCreate
+// sentinel so only genuinely-retryable rejections trigger wait-then-send.
 func isConcurrentCreateErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := err.Error()
-	return strings.Contains(s, "already reserved") || strings.Contains(s, "already exists")
+	return errors.Is(err, errConcurrentCreate)
 }
 
 func (m *Manager) findSession(title, repoID string) (*session.Instance, string, *session.InstanceData, error) {
@@ -1423,7 +1434,7 @@ func appendInstanceData(repoID string, data session.InstanceData) error {
 				existing[i] = data
 				return json.MarshalIndent(existing, "", "  ")
 			}
-			return nil, fmt.Errorf("session with title %q already exists", data.Title)
+			return nil, fmt.Errorf("session with title %q already exists: %w", data.Title, errConcurrentCreate)
 		}
 		existing = append(existing, data)
 		return json.MarshalIndent(existing, "", "  ")

--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
 	"sync"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // promptRecorder collects every prompt that reaches a session's backend, across
@@ -309,9 +311,15 @@ func TestIsConcurrentCreateErr(t *testing.T) {
 		err  error
 		want bool
 	}{
-		{"reserved", fmt.Errorf("session with title %q is already reserved", "captain"), true},
-		{"exists", fmt.Errorf("session with title %q already exists", "captain"), true},
+		{"reserved", fmt.Errorf("session with title %q is already reserved: %w", "captain", errConcurrentCreate), true},
+		{"exists", fmt.Errorf("session with title %q already exists: %w", "captain", errConcurrentCreate), true},
 		{"branch collision", fmt.Errorf("session titled %q conflicts with existing session %q: both sanitize to the same git branch %q", "A B", "a-b", "af-a-b"), false},
+		// #916: a tmux orphan is terminal, not a retryable concurrent-create —
+		// even though its message used to contain the "already exists" substring.
+		{"tmux orphan", fmt.Errorf("conflicting tmux session %q is already running; no agent-factory session owns it. Clean it up with: tmux kill-session -t %s", "captain", "af-abc_captain"), false},
+		// A plain "already exists" string with no sentinel must not be treated as
+		// retryable: classification keys off errConcurrentCreate, not the text.
+		{"unwrapped exists", fmt.Errorf("session with title %q already exists", "captain"), false},
 		{"nil", nil, false},
 		{"unrelated", fmt.Errorf("git is not installed"), false},
 	}
@@ -319,5 +327,73 @@ func TestIsConcurrentCreateErr(t *testing.T) {
 		if got := isConcurrentCreateErr(tc.err); got != tc.want {
 			t.Errorf("%s: isConcurrentCreateErr = %v, want %v", tc.name, got, tc.want)
 		}
+	}
+}
+
+// TestDeliverPrompt_TmuxOrphanReturnsImmediatelyWithError pins the #916 fix: a
+// tmux session with no daemon/disk record is a terminal conflict, not a
+// retryable concurrent-create. DeliverPrompt must fail fast with an actionable
+// message instead of waiting out waitForTargetSession's 30s timeout.
+func TestDeliverPrompt_TmuxOrphanReturnsImmediatelyWithError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires tmux; skipped in -short")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// Unique throwaway title so we never collide with a real af session, and
+	// derive the tmux name the SAME way the app does rather than hardcoding a
+	// format string (the app's scheme is not the issue's `af_<hash>_<title>`).
+	const program = "claude"
+	orphanTitle := fmt.Sprintf("orphan-916-%d", time.Now().UnixNano())
+	orphan := tmux.NewTmuxSessionForRepo(orphanTitle, repo.Root, program)
+	tmuxName := orphan.SanitizedName()
+
+	if out, err := exec.Command("tmux", "new-session", "-d", "-s", tmuxName).CombinedOutput(); err != nil {
+		t.Skipf("cannot create tmux session (no usable tmux server?): %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "kill-session", "-t", tmuxName).Run()
+	})
+
+	// The orphan must exist in tmux but carry no daemon/disk record.
+	if !tmux.NewTmuxSessionForRepo(orphanTitle, repo.Root, program).DoesSessionExist() {
+		t.Fatal("orphan tmux session should exist after creation")
+	}
+	if exists, _, err := manager.targetSessionState(repo.ID, orphanTitle); err != nil {
+		t.Fatalf("targetSessionState: %v", err)
+	} else if exists {
+		t.Fatal("orphan title should NOT exist in daemon state")
+	}
+
+	start := time.Now()
+	_, err = manager.DeliverPrompt(DeliverPromptRequest{
+		Title:    orphanTitle,
+		RepoPath: repoPath,
+		Program:  program,
+		Prompt:   "test",
+	})
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Errorf("DeliverPrompt took %v; expected immediate return for a tmux orphan, not a wait-out of the %v concurrent-create timeout", elapsed, targetDeliverWait)
+	}
+	if err == nil {
+		t.Fatal("expected a tmux-conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "tmux session") {
+		t.Errorf("expected error to mention the tmux conflict, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Problem

`DeliverPrompt` auto-creates a missing target session, and uses
`isConcurrentCreateErr` to decide whether a failed create is the retryable
concurrent-create race from #865 — in which case it waits up to **30s**
(`waitForTargetSession`) for the rival creator to finish, then sends.

The helper matched any error containing `"already exists"` or `"already
reserved"`. That substring match conflated two distinct rejections from
`validateTitleAvailableLocked`:

| Error | Meaning | Correct handling |
|-------|---------|------------------|
| `session with title %q already exists` | a daemon reservation/record exists **mid-create** | retryable — wait then send |
| `tmux session for title %q already exists` | a **tmux orphan** with no daemon/disk record | terminal — no creator will ever finish |

Because the tmux-orphan message also contained `"already exists"`, a stray
tmux session (left by a crash or an external process) was treated as
retryable. `waitForTargetSession` only consults daemon memory and disk —
never tmux — so the wait was guaranteed to time out after 30s and then
return a generic `timed out waiting for target session` error that **hid
the real cause**. Users saw a confusing 30s hang.

Regression of #877/#865; reported by Detail Bot as #916.

## Fix

Preferred **sentinel-error** approach (per the #782 robust-over-fragile
direction), rather than the issue's simpler message rename:

- Add `var errConcurrentCreate = errors.New("concurrent create in progress")`.
- Wrap **only** the genuinely in-flight reservation/record rejections with
  `%w`: the two `findTitleConflictLocked` cases (`reserved` / `exists`) and
  the `appendInstanceData` duplicate.
- `isConcurrentCreateErr` now uses `errors.Is(err, errConcurrentCreate)`
  instead of substring matching.
- The tmux-orphan (and remote maps-to) errors stay **plain** → no longer
  retryable → `DeliverPrompt` returns them **immediately**.
- The tmux-orphan message is rewritten to be actionable, naming the conflict
  and the exact cleanup command, deriving the real sanitized session name
  (not a guessed `af_<hash>_<title>` format):
  `conflicting tmux session %q is already running; no agent-factory session owns it. Clean it up with: tmux kill-session -t <name>`

Why the sentinel over a message rename: a future reword of any of these
messages can't silently reclassify an error. The human-readable prefixes
are unchanged, so existing substring assertions (e.g. integration tests
checking `"already exists"`) still hold.

## Adjacent-call-site audit

- `DeliverPrompt` is the **only** caller of both `isConcurrentCreateErr`
  and `waitForTargetSession`.
- The remote-hook reservation errors (`already reserved` / `already maps
  to`) are unreachable from `DeliverPrompt`, which auto-creates with
  `remote=false`; switching them to non-retryable is a no-op in practice.
- Consistent with `task/runner.go`, which already treats an existing tmux
  session as an orphan to **skip** when generating a title. `DeliverPrompt`
  targets an explicit title it cannot skip, so the equivalent move is to
  fail fast with cleanup guidance.

## Tests

- `TestDeliverPrompt_TmuxOrphanReturnsImmediatelyWithError` (new; requires
  tmux, skipped in `-short` and when tmux is absent): creates a real tmux
  session named via the app's own
  `NewTmuxSessionForRepo(...).SanitizedName()` with no daemon/disk record,
  asserts `DeliverPrompt` returns in **< 5s** with a tmux-conflict error.
  Hermetic `AGENT_FACTORY_HOME`, unique throwaway title, session torn down
  in `t.Cleanup`. Observed runtime ~0.2s (was ~30s before the fix).
- `TestIsConcurrentCreateErr` updated to pin the sentinel-based
  classification, including that an **unwrapped** `"already exists"` string
  and the tmux-orphan message are non-retryable.

## Verification

- `gofmt -l .` clean
- `go build ./...` ok
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `go test ./daemon/...` green; new test green, and skips cleanly under
  `-short`
- `go test ./...` green

Fixes #916

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)