### PR TITLE
fix(ui): keep sidebar index-prefix width constant past 999 so branch/PR lines stay aligned (#923)

### DIFF
--- a/ui/list.go
+++ b/ui/list.go
@@ -65,12 +65,11 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	prefix := fmt.Sprintf(" %d. ", idx)
 	// Each extra digit grows the prefix by one cell, which shifts the
 	// len(prefix)-derived branch/PR indentation and misaligns adjacent visible
-	// rows at the 9→10 and 99→100 boundaries. Trim one trailing space per extra
-	// digit tier so the prefix width holds steady into the triple digits (#871).
-	if idx >= 10 {
-		prefix = prefix[:len(prefix)-1]
-	}
-	if idx >= 100 {
+	// rows at every power-of-10 boundary (9→10, 99→100, 999→1000, …). Trim one
+	// trailing space per extra digit tier so the prefix width holds steady at
+	// any magnitude — the app generates titles up to 10000, so 4-digit indices
+	// are reachable (#871, #923).
+	for tier := 10; tier <= idx; tier *= 10 {
 		prefix = prefix[:len(prefix)-1]
 	}
 	titleS := selectedTitleStyle

--- a/ui/list_align_test.go
+++ b/ui/list_align_test.go
@@ -51,7 +51,7 @@ func TestInstanceRendererPrefixAlignment(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 
 	base := prLineIndent(t, 1, &spin)
-	for _, idx := range []int{9, 10, 11, 99, 100, 101, 999} {
+	for _, idx := range []int{9, 10, 11, 99, 100, 101, 999, 1000, 1001, 9999, 10000} {
 		got := prLineIndent(t, idx, &spin)
 		require.Equalf(t, base, got,
 			"PR line indent at idx=%d (%d) must match idx=1 (%d); prefix width drifted",
@@ -59,9 +59,11 @@ func TestInstanceRendererPrefixAlignment(t *testing.T) {
 	}
 }
 
-// TestInstanceRendererPrefixBoundaries explicitly pins the two digit-tier
-// boundaries that shift the prefix width: 9→10 (already handled) and 99→100
-// (the #871 fix). Adjacent rows that straddle a boundary must align.
+// TestInstanceRendererPrefixBoundaries explicitly pins the digit-tier
+// boundaries that shift the prefix width: 9→10 (originally handled), 99→100
+// (the #871 fix), and 999→1000 / 9999→10000 (the #923 fix). Adjacent rows that
+// straddle a boundary must align. The app generates titles up to 10000, so the
+// 4-digit boundary is reachable.
 func TestInstanceRendererPrefixBoundaries(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 
@@ -69,4 +71,8 @@ func TestInstanceRendererPrefixBoundaries(t *testing.T) {
 		"rows 9 and 10 must share the same indent")
 	require.Equal(t, prLineIndent(t, 99, &spin), prLineIndent(t, 100, &spin),
 		"rows 99 and 100 must share the same indent")
+	require.Equal(t, prLineIndent(t, 999, &spin), prLineIndent(t, 1000, &spin),
+		"rows 999 and 1000 must share the same indent")
+	require.Equal(t, prLineIndent(t, 9999, &spin), prLineIndent(t, 10000, &spin),
+		"rows 9999 and 10000 must share the same indent")
 }


### PR DESCRIPTION
## Problem

`InstanceRenderer.Render` (`ui/list.go`) builds the sidebar row prefix as `fmt.Sprintf(" %d. ", idx)`, then trims one trailing space to hold the rendered prefix width constant as the index gains a digit — the branch and PR lines are indented by `strings.Repeat(" ", len(prefix))`, so any change in prefix width shifts their alignment.

The trims were hardcoded to two tiers:

```go
if idx >= 10  { prefix = prefix[:len(prefix)-1] }
if idx >= 100 { prefix = prefix[:len(prefix)-1] }
```

There was **no tier for `idx >= 1000`**, so at index 1000 the prefix widens by one cell and the branch/PR lines misalign between rows 999 and 1000 (PR indent jumps from 6 to 7). The app generates session titles up to **10000** (`daemon/control.go`, `task/runner.go`), so 4-digit indices are reachable in practice.

## Fix

Replace the capped, hardcoded tiers with a loop that trims once per power-of-10 tier, so the prefix width holds steady at **any** magnitude:

```go
prefix := fmt.Sprintf(" %d. ", idx)
for tier := 10; tier <= idx; tier *= 10 {
    prefix = prefix[:len(prefix)-1]
}
```

Behaviour is identical for idx 1–999 (1 trim at ≥10, 2 at ≥100) and now correct at 1000, 10000, and beyond. The explanatory comment is updated to describe the generalized loop.

## Adjacent-call-site audit

Per CLAUDE.md, grepped `ui/` for other indentation/alignment derived from a numbered-prefix width or hardcoded digit tiers:

- All three `len(prefix)` consumers in `Render` — `branchLine`, `prMaxWidth`, and `prLine` — flow from the single now-fixed `prefix`, so they inherit the fix.
- `ui/overlay/overlay.go` has a `code >= 100 && code <= 107` check, but that is ANSI SGR color-code parsing, not prefix-width alignment — unrelated.

No other site has the same capped-tier bug.

## Tests

Extended `ui/list_align_test.go`:
- `TestInstanceRendererPrefixAlignment` now also covers 1000, 1001, 9999, 10000.
- `TestInstanceRendererPrefixBoundaries` adds the issue's assertion `prLineIndent(999) == prLineIndent(1000)` plus `9999 == 10000`.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./ui/...` — green

Fixes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude