### PR TITLE
fix(ui): show a teardown message in the preview pane while a session is Deleting (#920)

### DIFF
--- a/ui/preview.go
+++ b/ui/preview.go
@@ -126,6 +126,16 @@ func (p *PreviewPane) UpdateContent(instance *session.Instance) error {
 	case instance.GetStatus() == session.Loading:
 		p.setFallbackState("Setting up workspace...")
 		return nil
+	case instance.GetStatus() == session.Deleting:
+		// Mirror the Loading case for the other transient status (#920,
+		// regression of #847). During teardown a backend's Kill() can drop the
+		// PTY before the (possibly slow, 10-60s for remote) delete_cmd runs, so
+		// Preview() returns ("", nil) and Started()==false — without this the
+		// generic "Please enter a name for the instance." fallback below would
+		// claim throughout the delete. isTransientStatus already pairs
+		// Loading+Deleting; the preview pane was the last place that didn't.
+		p.setFallbackState("Tearing down session...")
+		return nil
 	}
 
 	var content string
@@ -347,6 +357,13 @@ func (p *PreviewPane) ResetToNormalMode(instance *session.Instance) error {
 		// the "Setting up workspace..." fallback instead.
 		if instance.GetStatus() == session.Loading {
 			p.setFallbackState("Setting up workspace...")
+			return nil
+		}
+		// Same blank-pane hazard for the other transient status: exiting scroll
+		// mode on a Deleting instance must keep the teardown fallback rather
+		// than blank the pane on an empty Preview() (#920).
+		if instance.GetStatus() == session.Deleting {
+			p.setFallbackState("Tearing down session...")
 			return nil
 		}
 

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -565,6 +565,46 @@ func TestPreviewResetToNormalModeLoadingShowsFallback(t *testing.T) {
 		"rendered frame must show the Loading fallback, not a blank pane")
 }
 
+// TestPreviewUpdateContentDeletingShowsTeardownFallback is the regression test
+// for issue #920 (regression of #847). The UpdateContent switch handled the
+// Loading transient status but not Deleting, so a Deleting instance — whose
+// backend Kill() drops the PTY before the (possibly slow) delete_cmd, leaving
+// Preview() == ("", nil) and Started() == false — fell through to the generic
+// "Please enter a name for the instance." fallback. That message is misleading
+// during teardown and, for remote sessions, can persist for the whole 10-60s
+// delete. UpdateContent must show the "Tearing down session..." fallback for a
+// Deleting instance instead.
+func TestPreviewUpdateContentDeletingShowsTeardownFallback(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: "deleting", Path: t.TempDir(), Program: "test",
+	})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStatus(session.Deleting)
+
+	// Precondition: this instance has empty preview content and is not started,
+	// exactly the state that previously produced the wrong "Please enter a
+	// name" fallback.
+	require.False(t, inst.Started(),
+		"precondition: a Deleting instance reports Started()==false")
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+	require.NoError(t, p.UpdateContent(inst))
+
+	require.True(t, p.previewState.fallback,
+		"Deleting instance must render a fallback")
+	require.Contains(t, p.previewState.text, "Tearing down session...",
+		"Deleting instance must show the teardown fallback")
+	require.NotContains(t, p.previewState.text, "Please enter a name",
+		"Deleting instance must NOT show the not-started fallback (#920)")
+	require.Contains(t, p.String(), "Tearing down session...",
+		"rendered frame must show the teardown fallback")
+}
+
 // TestPreviewFallbackHeightNoDoubleCounting ensures that the fallback welcome
 // screen does not over-subtract lines for borders/margins that
 // TabbedWindow.SetSize has already stripped. Previously it subtracted 7, which

--- a/ui/terminal.go
+++ b/ui/terminal.go
@@ -112,6 +112,14 @@ func (t *TerminalPane) UpdateContent(instance *session.Instance) error {
 		t.setFallbackState("Select an instance to open a terminal")
 		return nil
 	}
+	// A Deleting instance reports Started()==false during teardown, so without
+	// this it would fall through to the "Instance is not started yet." fallback
+	// below — misleading while the session is going away (#920). Mirror the
+	// preview pane's transient-status handling.
+	if instance.GetStatus() == session.Deleting {
+		t.setFallbackState("Tearing down session...")
+		return nil
+	}
 	if !instance.Started() {
 		t.setFallbackState("Instance is not started yet.")
 		return nil

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -212,6 +212,33 @@ func TestTerminalFallbackStates(t *testing.T) {
 		require.Contains(t, tp.fallbackText, "not started", "fallback text should indicate not started")
 		tp.mu.Unlock()
 	})
+
+	// Regression for #920: a Deleting instance reports Started()==false during
+	// teardown. Without an explicit Deleting case it falls through to the
+	// "Instance is not started yet." fallback, which is misleading while the
+	// session is going away. UpdateContent must show "Tearing down session..."
+	// instead — mirroring the preview pane's transient-status handling.
+	t.Run("deleting instance", func(t *testing.T) {
+		instance, err := session.NewInstance(session.InstanceOptions{
+			Title:   "deleting-inst",
+			Path:    t.TempDir(),
+			Program: "bash",
+		})
+		require.NoError(t, err)
+		instance.SetBackend(session.NewFakeBackend())
+		instance.SetStatus(session.Deleting)
+
+		err = tp.UpdateContent(instance)
+		require.NoError(t, err)
+
+		tp.mu.Lock()
+		require.True(t, tp.fallback, "should be in fallback mode for deleting instance")
+		require.Contains(t, tp.fallbackText, "Tearing down session...",
+			"deleting instance must show the teardown fallback")
+		require.NotContains(t, tp.fallbackText, "not started",
+			"deleting instance must NOT show the not-started fallback (#920)")
+		tp.mu.Unlock()
+	})
 }
 
 func TestTerminalSessionCaching(t *testing.T) {


### PR DESCRIPTION
## Problem

`PreviewPane.UpdateContent` (called every ~100ms via `previewTickMsg` → `refreshPanesCmd`) had a `switch` that handled the `session.Loading` transient status but had **no case for `session.Deleting`** (regression of #847).

During teardown a backend's `Kill()` drops the PTY before the (possibly slow, 10–60s for remote `delete_cmd`) delete runs, so `Preview()` returns `("", nil)` while `Started() == false`. That combination fell through to the generic:

```go
if len(content) == 0 && !instance.Started() {
    p.setFallbackState("Please enter a name for the instance.")
}
```

So a session being deleted showed **"Please enter a name for the instance."** — misleading, and for remote sessions it could persist for the entire delete. The codebase already pairs the two transient statuses via `isTransientStatus(Loading || Deleting)`; the preview pane was the last place that didn't.

## Fix

Add a `case instance.GetStatus() == session.Deleting:` that sets the `"Tearing down session..."` fallback, matching the existing `Loading` case style.

## Adjacent-call-site audit

Per CLAUDE.md, I grepped every place that special-cases `session.Loading` and confirmed `Deleting` is handled wherever `Loading` is:

| Site | Status |
|------|--------|
| `ui/preview.go` `UpdateContent` | **FIXED** — the reported bug |
| `ui/preview.go` `ResetToNormalMode` | **FIXED** — exiting scroll mode on a Deleting instance had the same blank-pane hazard the Loading guard (#823) was added to prevent |
| `ui/terminal.go` `UpdateContent` | **FIXED** — a Deleting instance reports `Started()==false` and fell through to `"Instance is not started yet."`; now shows `"Tearing down session..."` |
| `ui/list.go` (sidebar) | already handles Deleting (`[deleting]` marker + spinner) |
| `app/sync.go` | already pairs them via `isTransientStatus` |
| `session/storage.go` | already excludes Deleting from persistence |
| `ui/overlay/searchOverlay.go`, `ui/menu.go` | only a neutral status glyph / menu-option gate, **not** a misleading fallback message — left unchanged |

## Tests

- `TestPreviewUpdateContentDeletingShowsTeardownFallback` — asserts `UpdateContent` on a Deleting instance (empty preview, not started) renders the `"Tearing down session..."` fallback and **not** `"Please enter a name"`.
- `TestTerminalFallbackStates/deleting_instance` — same assertion for the terminal pane.

## Verification

- `gofmt -l .` clean
- `go build ./...` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `go test ./ui/...` green

Fixes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)