### PR TITLE
fix(app): drop PR-info updates whose branch no longer matches the target instance (#921)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -324,6 +324,16 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if target == nil {
 			return m, nil
 		}
+		// The title-only re-resolution above can land on a different session
+		// than the fetch was kicked off for: a user can kill the original
+		// instance and recreate one with the same title on a *different*
+		// branch while the gh fetch is in flight (#921). PR info is
+		// branch-specific, so applying a branch-X result to a branch-Y
+		// instance would show the wrong PR badge and persist it. Gate the
+		// apply on the captured branch still matching the resolved target.
+		if target.GetBranch() != msg.branch {
+			return m, nil
+		}
 		if msg.err != nil {
 			log.WarningLog.Printf("PR info fetch failed for %q: %v", msg.instance.Title, msg.err)
 			// Mark as fetched anyway so we don't thrash retries on every

--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -400,6 +400,74 @@ func TestPrInfoUpdatedMsg_Error_SwappedDuringFetch_MarksLiveInstance(t *testing.
 		"the orphaned pointer must be left untouched")
 }
 
+// ----------------------------------------------------------------------------
+// Regression tests for issue #921 (sachiniyer/agent-factory):
+// "PR info updates can apply to the wrong worktree when an instance is
+// recreated with the same title on a different branch". The fetch captures the
+// branch at kickoff, but the title-only re-resolution in the prInfoUpdatedMsg
+// handler can land on a same-title instance now attached to a *different*
+// branch (kill + recreate while the fetch is in flight). PR info is
+// branch-specific, so the handler must drop the update when the resolved
+// target's branch no longer matches the captured one.
+// ----------------------------------------------------------------------------
+
+// TestPrInfoUpdatedMsg_BranchMismatch_DropsUpdate — the captured instance is
+// killed and a fresh same-title instance is created on a different branch while
+// the fetch is in flight. The title-only fallback resolves to that new
+// instance, but its branch differs from the fetch's branch, so the stale PR
+// info must NOT be applied.
+func TestPrInfoUpdatedMsg_BranchMismatch_DropsUpdate(t *testing.T) {
+	h := newTestHome(t)
+
+	// The instance the fetch was kicked off for, on branch X.
+	orphan := newStartedInstance(t, "reused")
+	orphan.Branch = "feature/x"
+	h.sidebar.AddInstance(orphan)
+	h.sidebar.SetSelectedInstance(0)
+
+	// User killed it and recreated a same-title instance on branch Y while the
+	// gh fetch was still running.
+	recreated := newStartedInstance(t, "reused")
+	recreated.Branch = "feature/y"
+	h.sidebar.RemoveInstanceByTitle("reused")
+	h.sidebar.AddInstance(recreated)
+
+	info := &git.PRInfo{Number: 42, Title: "branch X PR", State: "OPEN"}
+	_, cmd := h.Update(prInfoUpdatedMsg{instance: orphan, branch: "feature/x", info: info})
+
+	assert.Nil(t, cmd)
+	assert.Nil(t, recreated.GetPRInfo(),
+		"a fetch for branch X must not write its PR info onto a same-title instance now on branch Y")
+	assert.Nil(t, orphan.GetPRInfo(),
+		"the orphaned pointer must not receive the update either")
+}
+
+// TestPrInfoUpdatedMsg_BranchMatch_AppliesUpdate — same swap as above, but the
+// recreated same-title instance is back on the original branch. The captured
+// branch matches, so the update applies to the live instance.
+func TestPrInfoUpdatedMsg_BranchMatch_AppliesUpdate(t *testing.T) {
+	h := newTestHome(t)
+
+	orphan := newStartedInstance(t, "reused")
+	orphan.Branch = "feature/x"
+	h.sidebar.AddInstance(orphan)
+	h.sidebar.SetSelectedInstance(0)
+
+	live := newStartedInstance(t, "reused")
+	live.Branch = "feature/x"
+	h.sidebar.RemoveInstanceByTitle("reused")
+	h.sidebar.AddInstance(live)
+	require.NotSame(t, orphan, live, "sanity: swap must produce a distinct pointer")
+
+	info := &git.PRInfo{Number: 42, Title: "branch X PR", State: "OPEN"}
+	_, _ = h.Update(prInfoUpdatedMsg{instance: orphan, branch: "feature/x", info: info})
+
+	got := live.GetPRInfo()
+	require.NotNil(t, got, "matching-branch update must apply to the live instance")
+	assert.Equal(t, 42, got.Number)
+	assert.Nil(t, orphan.GetPRInfo(), "the orphaned pointer must not receive the update")
+}
+
 // sanity: exercise config.DefaultConfig / AppState wiring so a compile
 // regression in newTestHome stays within this package.
 func TestNewTestHome_BuildsSuccessfully(t *testing.T) {

--- a/app/sync.go
+++ b/app/sync.go
@@ -28,8 +28,12 @@ type tickRefreshExternalMessage struct{}
 // prInfoUpdatedMsg is returned by an async PR info fetch.
 // info is nil when the fetch resolved to "no PR for this branch".
 // err is set for transient errors — the handler keeps the cached value.
+// branch is the worktree branch captured at fetch kickoff (the same value
+// passed to prInfoFetcher); the handler drops the update if the re-resolved
+// target instance is no longer on that branch (#921).
 type prInfoUpdatedMsg struct {
 	instance *session.Instance
+	branch   string
 	info     *git.PRInfo
 	err      error
 }
@@ -163,7 +167,7 @@ func fetchPRInfoCmd(inst *session.Instance, force bool) tea.Cmd {
 		detachTraceMark("fetchPRInfoCmd-goroutine-entry")
 		info, err := prInfoFetcher(repoPath, branch)
 		detachTrace(fetchStart, "fetchPRInfoCmd-prInfoFetcher-returned")
-		return prInfoUpdatedMsg{instance: inst, info: info, err: err}
+		return prInfoUpdatedMsg{instance: inst, branch: branch, info: info, err: err}
 	}
 }
 


### PR DESCRIPTION
## Problem

The async PR-info fetch in `fetchPRInfoCmd` (`app/sync.go`) captures the worktree `branch` at kickoff and passes it to `prInfoFetcher`, but the resulting `prInfoUpdatedMsg` never carried that branch through to the apply site. At apply time (`app/app.go`, `prInfoUpdatedMsg` handler), if the originally-captured instance pointer is gone, the handler re-resolves the target **by title only** (the #808-style fallback):

```go
target := msg.instance
if !m.sidebar.ContainsInstance(target) {
    target = m.sidebar.GetInstanceByTitle(msg.instance.Title)
}
```

Because that fallback is title-only, a fetch kicked off for branch **X** can be applied to a same-title instance now attached to branch **Y**. PR info is branch-specific, so the user sees the wrong PR badge — and it gets persisted. This is the exact edge case from #921 (regression of #314): an in-flight fetch plus a kill + recreate-same-title-on-a-different-branch before the fetch returns.

## Fix

- Add a `branch string` field to `prInfoUpdatedMsg`.
- Populate it in `fetchPRInfoCmd` from the same `branch` value already passed to `prInfoFetcher`.
- In the handler, after the title re-resolution, drop the update when the resolved target is no longer on the captured branch:

```go
if target.GetBranch() != msg.branch {
    return m, nil
}
```

The title-fallback resolution is left intact (it still rescues the legitimate #862/#765 swap case where the same branch's instance was rebuilt under a new pointer); this only refuses to write branch-X PR info onto a branch-Y instance.

## Adjacent call-site audit (CLAUDE.md)

#808 added the same title-fallback to the `instanceStartedMsg` handler. Audited: it is **not** the same wrong-target class.

- `prInfoUpdatedMsg` applies *external state* (PR info fetched for a captured branch) onto a re-resolved target — so it needs a captured-vs-current branch check.
- `instanceStartedMsg` inserts the freshly-started instance itself (`started`) via `ReplaceInstanceByTitle(started.Title, started)`. `started` carries its own correct branch and *is* the source of truth; there is no separate "captured branch" to compare against. The Loading placeholder it replaces is also protected from background swaps by `isTransientStatus` (#808/#844).

So no guard is warranted there; documented here rather than changed.

## Tests

Added handler-level regression tests in `app/pr_info_test.go`:

- `TestPrInfoUpdatedMsg_BranchMismatch_DropsUpdate` — an in-flight update for branch X must be dropped when the live same-title instance is on branch Y (verified it fails without the guard).
- `TestPrInfoUpdatedMsg_BranchMatch_AppliesUpdate` — a matching-branch update still applies to the live instance.

## Verification

- `gofmt -l .` clean
- `go build ./...` ok
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `go test ./app/...` green
- `GOFLAGS="-p=1" go test -race -parallel 2 ./app/...` green

Fixes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)