### PR TITLE
fix(session): keep remoteMeta until delete_cmd succeeds so a retried Kill still cleans up the remote (#922)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -296,20 +296,27 @@ func extractJSON(output string) string {
 func (b *HookBackend) Kill(i *Instance) error {
 	slug := hookNameForInstance(i)
 
-	// Snapshot whether a remote session was ever allocated before clearing
-	// state. If Start never ran successfully there is nothing for delete_cmd
-	// to clean up — invoking it would surface as a confusing failure against
-	// a slug the user-provided script has never heard of. Mirrors
-	// LocalBackend.Kill's tmuxSession/gitWorktree guards.
+	// Snapshot whether a remote session was ever allocated. If Start never ran
+	// successfully there is nothing for delete_cmd to clean up — invoking it
+	// would surface as a confusing failure against a slug the user-provided
+	// script has never heard of. Mirrors LocalBackend.Kill's
+	// tmuxSession/gitWorktree guards.
 	//
 	// Mark the instance as stopped BEFORE any resource cleanup so that the
 	// instance is in a consistent state even if delete_cmd fails. Otherwise
 	// the PTY could be closed while started=true, leaving the session
 	// appearing running but unusable (empty preview, broken attach).
+	//
+	// Crucially, do NOT clear remoteMeta here. The daemon retains and reuses
+	// the same *Instance pointer across RPC calls (a failed kill leaves the
+	// instance in m.instances), so if we cleared remoteMeta before delete_cmd
+	// succeeded, a retried Kill would compute hadRemote == false, skip
+	// delete_cmd, and return nil — silently leaking the remote session (#922).
+	// remoteMeta is only cleared once delete_cmd has actually torn the remote
+	// session down (below), so a retry after a delete_cmd failure runs it again.
 	i.mu.Lock()
 	hadRemote := i.remoteMeta != nil
 	i.started = false
-	i.remoteMeta = nil
 	i.mu.Unlock()
 
 	b.closePTY(i.Title)
@@ -319,10 +326,23 @@ func (b *HookBackend) Kill(i *Instance) error {
 		return nil
 	}
 
+	// runDeleteCmd is slow (network/SSH) so it runs WITHOUT the lock held.
 	out, err := b.runDeleteCmd(slug)
 	if err != nil {
+		// Leave remoteMeta intact so a subsequent Kill on this same Instance
+		// re-runs delete_cmd. The remote session may still be alive.
 		return fmt.Errorf("delete_cmd failed: %s: %w", string(out), err)
 	}
+
+	// delete_cmd succeeded: the remote session is gone, so clear remoteMeta.
+	// Concurrency: two Kills racing on the same Instance both read hadRemote
+	// == true before either clears it, so both may run delete_cmd. delete_cmd
+	// against an already-deleted session is the worst case (a redundant,
+	// typically idempotent call) — never a leak, which is the semantics we
+	// optimize for here. We re-take the lock only to clear the field.
+	i.mu.Lock()
+	i.remoteMeta = nil
+	i.mu.Unlock()
 
 	return nil
 }

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -637,6 +637,82 @@ func TestHookBackendKillUnallocatedSkipsDeleteCmd(t *testing.T) {
 	assert.Nil(t, i.remoteMeta)
 }
 
+// TestHookBackendKillRetryAfterFailure is the regression test for #922: when
+// delete_cmd fails, Kill must NOT clear remoteMeta, so a retried Kill on the
+// same *Instance (the daemon reuses the pointer across RPC calls) still sees a
+// remote allocation and re-runs delete_cmd. Before the fix, the early
+// remoteMeta = nil meant the retry computed hadRemote == false, skipped
+// delete_cmd, returned nil, and leaked the remote session.
+//
+// delete_cmd appends a line to a counter file on every invocation and exits
+// non-zero or zero depending on a "succeed" flag file, so the test can flip it
+// from failing to succeeding between the two Kill calls and count invocations.
+func TestHookBackendKillRetryAfterFailure(t *testing.T) {
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "delete-calls")
+	succeedFlag := filepath.Join(dir, "delete-should-succeed")
+
+	launchCmd := writeScript(t, dir, "launch.sh",
+		`echo '{"name": "'"$2"'", "status": "running"}'`)
+	attachCmd := writeScript(t, dir, "attach.sh",
+		`echo "attached to $1"; sleep 0.1`)
+	// Record the call, then succeed only once the flag file exists; otherwise
+	// fail so the first Kill returns an error.
+	deleteCmd := writeScript(t, dir, "delete.sh",
+		`echo x >> `+counter+`
+if [ -f `+succeedFlag+` ]; then
+  echo '{"deleted": true}'
+  exit 0
+fi
+echo "delete failed" >&2
+exit 1`)
+
+	b := &HookBackend{
+		Hooks: config.RemoteHooks{
+			LaunchCmd: launchCmd,
+			AttachCmd: attachCmd,
+			DeleteCmd: deleteCmd,
+		},
+	}
+	i := &Instance{
+		Title:   "test-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	// Start a remote session so remoteMeta is populated.
+	require.NoError(t, b.Start(i, true))
+	require.NotNil(t, i.remoteMeta)
+
+	deleteCalls := func() int {
+		data, err := os.ReadFile(counter)
+		if os.IsNotExist(err) {
+			return 0
+		}
+		require.NoError(t, err)
+		return strings.Count(string(data), "x")
+	}
+
+	// First Kill: delete_cmd fails. Kill must return an error, must have
+	// invoked delete_cmd exactly once, and must NOT have cleared remoteMeta.
+	err := b.Kill(i)
+	require.Error(t, err, "Kill should surface the delete_cmd failure")
+	assert.Equal(t, 1, deleteCalls(), "delete_cmd should have run once on the first Kill")
+	assert.NotNil(t, i.remoteMeta,
+		"remoteMeta must survive a failed delete_cmd so a retry can re-run it (#922)")
+
+	// Flip delete_cmd to succeed, then retry. The retry must re-run delete_cmd
+	// (total 2), return no error, and clear remoteMeta now that the remote
+	// session is actually gone.
+	require.NoError(t, os.WriteFile(succeedFlag, []byte("y"), 0644))
+
+	err = b.Kill(i)
+	require.NoError(t, err, "retried Kill should succeed once delete_cmd succeeds")
+	assert.Equal(t, 2, deleteCalls(),
+		"delete_cmd must run again on retry — skipping it would leak the remote session (#922)")
+	assert.Nil(t, i.remoteMeta, "remoteMeta should be cleared after delete_cmd succeeds")
+}
+
 func TestHookBackendPreview(t *testing.T) {
 	b := makeHooks(t)
 	i := &Instance{
@@ -1065,14 +1141,16 @@ func TestHookBackendKillDeleteCmdFails(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "delete_cmd failed")
 
-	// Even when delete_cmd fails, the instance must be marked stopped and
-	// its remote metadata cleared so that the UI doesn't show it as running
-	// while its PTY is already closed (see issue #266).
+	// Even when delete_cmd fails, the instance must be marked stopped so the
+	// UI doesn't show it as running while its PTY is already closed (#266).
+	// remoteMeta, however, must be PRESERVED on failure: it is the only record
+	// that a remote session was allocated, and a retried Kill needs it to
+	// re-run delete_cmd. Clearing it early leaked the remote session (#922).
 	assert.False(t, i.Started(), "instance should be stopped after failed Kill")
 	i.mu.RLock()
 	meta := i.remoteMeta
 	i.mu.RUnlock()
-	assert.Nil(t, meta, "remoteMeta should be cleared after failed Kill")
+	assert.NotNil(t, meta, "remoteMeta should be preserved after a failed Kill so a retry can re-run delete_cmd (#922)")
 	// The PTY should have been cleaned up too.
 	assert.Nil(t, b.getPTY(i.Title), "PTY should be closed after failed Kill")
 }


### PR DESCRIPTION
## Summary

`HookBackend.Kill` cleared `i.remoteMeta = nil` under the lock **before** running the slow, network-bound `delete_cmd`. If `delete_cmd` failed, `Kill` returned an error but the remote metadata was already gone.

The daemon retains and reuses the **same `*Instance` pointer** across RPC calls: a failed `KillSession` returns early (`daemon/control.go:1104`) *before* deleting the instance from `m.instances` and from storage. So when a user retried the kill from the UI, the retry hit `findSession` → the same `*Instance` → `Kill()` computed `hadRemote == false`, skipped `delete_cmd`, and returned `nil` — **silently leaking the live remote session** (regression of #289, commit `1443955`).

## Fix

Restructure `Kill` so `remoteMeta` survives a failed teardown:

- Snapshot `hadRemote` and set `started = false` under the lock, as before — local/UI consistency on failure is preserved.
- **Do not** clear `remoteMeta` at this point.
- Run `delete_cmd` **off the lock** (it may SSH and take tens of seconds).
- On `delete_cmd` failure: return the error with `remoteMeta` **intact**, so a retry re-runs `delete_cmd`.
- Only **after** `delete_cmd` succeeds: re-take the lock and clear `remoteMeta`.

### Locking / concurrency

The lock is taken to snapshot, released across the slow `delete_cmd`, then re-taken only to clear `remoteMeta` on success — never held across the network call. Two `Kill`s racing on the same `Instance` both read `hadRemote == true` before either clears `remoteMeta`, so both may run `delete_cmd`. A `delete_cmd` against an already-deleted session is the worst case (a redundant, typically idempotent call) — **never a leak**, which is the semantics we optimize for. Documented in a comment at the clear site.

## Adjacent-call-site audit (CLAUDE.md)

- **`LocalBackend.Kill`** returns `nil` unconditionally — cleanup failures are logged and swallowed — so the daemon always proceeds to drop the instance from `m.instances`. No retry occurs, so there is no retry-leak. It clears `tmuxSession`/`gitWorktree` only *after* cleanup, guarded by identity checks. Different design from the hook backend; **not the same bug**.
- **`HookBackend.CloseAttachOnly` / `LocalBackend.CloseAttachOnly`** are non-destructive (no `delete_cmd` / no `tmux kill`), so there is no teardown-state-before-cleanup concern.
- **`cleanupOrphanedLaunch`** (Start orphan path, #739) is best-effort, single-attempt, keyed on `slug` not `remoteMeta` — no retry semantics.

## #844 / #847 (async-kill `Deleting`) interaction

Confirmed the retry path is actually reachable: `handleInstanceKilled` (`app/handle_actions.go:219`) flips the row back to `Ready` on failure, and `KillSession` leaves the `*Instance` in `m.instances` on a failed `Kill`, so the retry operates on the same object whose `remoteMeta` we now preserve.

## Tests

- **`TestHookBackendKillRetryAfterFailure`** (new, from the issue): start a remote session; first `Kill` with a failing `delete_cmd` → assert error **and** `delete_cmd` called once **and** `remoteMeta` still set; flip `delete_cmd` to succeed and retry → assert no error **and** `delete_cmd` called again (total 2) **and** `remoteMeta` cleared. Uses the existing `writeScript`/hook harness with a counter file.
- **`TestHookBackendKillDeleteCmdFails`** updated: it previously asserted the buggy early-clear; it now requires `remoteMeta` is **preserved** on failure. The #266 UI "not running" guarantee is satisfied by `started = false`, not by clearing `remoteMeta`.

## Verification

- `gofmt -l .` clean
- `go build ./...` ✓
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `go test ./session/...` green
- `GOFLAGS="-p=1" go test -race -parallel 2 ./session/...` green

Fixes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)
