### PR TITLE
fix(task): expand ~ in TUI task paths, validate path on save, and persist cron failure status (#924)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -621,7 +621,10 @@ func (m *home) handleTaskCreate() tea.Cmd {
 			return m.handleError(fmt.Errorf("invalid cron: %v", err))
 		}
 	}
-	absPath, err := filepath.Abs(projectPath)
+	// Expand a leading ~ before resolving to absolute — filepath.Abs does not
+	// expand "~", so "~/project" would otherwise become "<cwd>/~/project"
+	// (#924). validateForm already normalized the field, so this is idempotent.
+	absPath, err := filepath.Abs(config.ExpandTilde(projectPath))
 	if err != nil {
 		return m.handleError(fmt.Errorf("invalid path: %v", err))
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -41,25 +41,46 @@ const probeWaitDelay = time.Second
 // PATH-resolved command, e.g. "claude is /usr/local/bin/claude".
 var bashTypeOutputRegex = regexp.MustCompile(`^\S+ is (/.+)$`)
 
+// ExpandTilde expands a leading "~" or "~/" in path to the current user's home
+// directory: a bare "~" becomes the home dir and "~/foo" becomes <home>/foo.
+// Every other input is returned unchanged — absolute paths, relative paths, the
+// empty string, and "~user" forms (which the Go standard library cannot
+// resolve). If the home directory cannot be determined, path is returned as-is.
+// filepath.Abs does NOT expand "~", so callers resolving user-entered paths
+// must run them through this helper first (#924).
+func ExpandTilde(path string) string {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return homeDir
+	}
+	return filepath.Join(homeDir, path[2:])
+}
+
 // GetConfigDir returns the path to the application's configuration directory.
 // If AGENT_FACTORY_HOME is set, it is used as the config directory.
 // Otherwise, defaults to ~/.agent-factory.
 func GetConfigDir() (string, error) {
 	if envDir := os.Getenv("AGENT_FACTORY_HOME"); envDir != "" {
-		if strings.HasPrefix(envDir, "~") {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return "", fmt.Errorf("failed to expand home directory: %w", err)
-			}
-			if envDir == "~" {
-				return homeDir, nil
-			}
-			if !strings.HasPrefix(envDir, "~/") {
-				return "", fmt.Errorf("AGENT_FACTORY_HOME: invalid tilde format %q (expected ~ or ~/path)", envDir)
-			}
-			envDir = filepath.Join(homeDir, envDir[2:])
+		// "~user" forms are unresolvable; reject them explicitly rather than
+		// treating "~user" as a literal directory name.
+		if strings.HasPrefix(envDir, "~") && envDir != "~" && !strings.HasPrefix(envDir, "~/") {
+			return "", fmt.Errorf("AGENT_FACTORY_HOME: invalid tilde format %q (expected ~ or ~/path)", envDir)
 		}
-		return envDir, nil
+		expanded := ExpandTilde(envDir)
+		// ExpandTilde returns the input unchanged when the home directory
+		// cannot be resolved; for a "~"/"~/" prefix that is a hard failure
+		// here (unlike user-supplied project paths, the config dir must be a
+		// real location), so surface it rather than using a literal "~" path.
+		if strings.HasPrefix(envDir, "~") && expanded == envDir {
+			return "", fmt.Errorf("failed to expand home directory in AGENT_FACTORY_HOME %q", envDir)
+		}
+		return expanded, nil
 	}
 
 	homeDir, err := os.UserHomeDir()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -887,3 +887,32 @@ func TestSaveConfig(t *testing.T) {
 		assert.Equal(t, testConfig.BranchPrefix, loadedConfig.BranchPrefix)
 	})
 }
+
+// TestExpandTilde pins the #924 tilde helper: a bare "~" and "~/x" expand to
+// the home directory (filepath.Abs does not), while absolute paths, relative
+// paths, the empty string, and unresolvable "~user" forms pass through
+// unchanged. The AGENT_FACTORY_HOME inline expansion in GetConfigDir is built
+// on this helper, so the cases below also pin that path's behavior.
+func TestExpandTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"~", home},
+		{"~/project", filepath.Join(home, "project")},
+		{"~/a/b/c", filepath.Join(home, "a", "b", "c")},
+		{"/abs/path", "/abs/path"},
+		{"relative/path", "relative/path"},
+		{"", ""},
+		{"~user", "~user"},     // Go cannot resolve "~user"; left untouched.
+		{"foo~bar", "foo~bar"}, // a tilde that is not a leading prefix is literal.
+	}
+	for _, c := range cases {
+		if got := ExpandTilde(c.in); got != c.want {
+			t.Errorf("ExpandTilde(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/daemon/taskrun.go
+++ b/daemon/taskrun.go
@@ -91,7 +91,7 @@ func repoHasSessionTitle(repoID, title string) (bool, error) {
 // trigger` CLI both land here. Watch tasks are refused — they fire from
 // their watch command's stdout, and a manual trigger has no event line to
 // render the prompt with.
-func RunTask(taskID string) error {
+func RunTask(taskID string) (err error) {
 	// Validate the task ID before it flows into any filesystem path. The
 	// CLI boundary also validates, but this is the shared chokepoint that
 	// protects every caller.
@@ -143,6 +143,25 @@ func RunTask(taskID string) error {
 		return fmt.Errorf("another run is already active for task %s", taskID)
 	}
 	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+
+	// Once this fire holds the lock it owns the task's run status: every
+	// failure from here on — git missing, project path not a repo, or a
+	// delivery error — must be recorded so a cron task's LastRunStatus
+	// reflects the failure instead of going stale. Previously only the success
+	// path reached UpdateTaskStatus, so a bad project path left the TUI showing
+	// the prior run forever while the scheduler merely logged the error (#924).
+	// The success path writes its own status below; this defer fires only when
+	// err is non-nil, so the status is never double-written. The "errored:"
+	// prefix matches the watcher convention the TUI keys on (#797).
+	defer func() {
+		if err == nil {
+			return
+		}
+		now := time.Now()
+		if uerr := task.UpdateTaskStatus(taskID, &now, "errored: "+err.Error()); uerr != nil {
+			log.ErrorLog.Printf("failed to record errored status for task %s: %v", taskID, uerr)
+		}
+	}()
 
 	// Validate project path. Distinguish a missing git binary from a path that
 	// simply is not a repo so the daemon surfaces an actionable error (#737).

--- a/daemon/taskrun_test.go
+++ b/daemon/taskrun_test.go
@@ -312,3 +312,50 @@ func TestRunTask_CronTaskHonorsTargetSession(t *testing.T) {
 		t.Fatalf("expected LastRunStatus=sent with LastRunAt set, got status=%q at=%v", got.LastRunStatus, got.LastRunAt)
 	}
 }
+
+// TestRunTask_PersistsFailureStatusOnBadRepo is the #924 regression: a cron
+// task whose project path is not a git repo used to return early from RunTask
+// before reaching UpdateTaskStatus, so the scheduler only logged the error and
+// the TUI showed a stale LastRunStatus forever. RunTask must now record an
+// "errored" status on every failure that occurs once it owns the task's run.
+func TestRunTask_PersistsFailureStatusOnBadRepo(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	// A real directory that is deliberately NOT a git repo. A prior successful
+	// run is simulated by seeding LastRunStatus so we can prove it is replaced,
+	// not merely left untouched.
+	notARepo := t.TempDir()
+	now := time.Now()
+	if err := task.AddTask(task.Task{
+		ID:            "dddd0001",
+		Name:          "broken",
+		Prompt:        "do it",
+		CronExpr:      "0 3 * * *",
+		ProjectPath:   notARepo,
+		Enabled:       true,
+		CreatedAt:     now,
+		LastRunAt:     &now,
+		LastRunStatus: "started",
+	}); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+
+	err := RunTask("dddd0001")
+	if err == nil {
+		t.Fatalf("expected RunTask to fail on a non-git project path")
+	}
+	if !strings.Contains(err.Error(), "not a valid git repository") {
+		t.Fatalf("error should explain the git-repo failure, got: %v", err)
+	}
+
+	got, gerr := task.GetTask("dddd0001")
+	if gerr != nil {
+		t.Fatalf("GetTask: %v", gerr)
+	}
+	if !strings.HasPrefix(got.LastRunStatus, "errored") {
+		t.Fatalf("LastRunStatus must record the failure, got %q (must not stay stale at \"started\")", got.LastRunStatus)
+	}
+	if got.LastRunAt == nil || !got.LastRunAt.After(now) {
+		t.Fatalf("LastRunAt must advance to the failed run, got %v", got.LastRunAt)
+	}
+}

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -2,9 +2,12 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 
@@ -208,8 +211,17 @@ func (s *TaskPane) initForm(tsk *task.Task, defaultPath string) {
 	s.editErrorField = -1
 }
 
-// EnterCreateMode initializes empty edit fields for creating a new task.
+// EnterCreateMode initializes empty edit fields for creating a new task. An
+// empty defaultPath (e.g. the in-pane "n" handler before any explicit create
+// entry set s.createPath) falls back to the current working directory so the
+// path field is prefilled with a sensible, usually-valid value rather than an
+// empty string the #924 path validation would immediately reject.
 func (s *TaskPane) EnterCreateMode(defaultPath string) {
+	if defaultPath == "" {
+		if cwd, err := os.Getwd(); err == nil {
+			defaultPath = cwd
+		}
+	}
 	s.createPath = defaultPath
 	s.initForm(nil, defaultPath)
 	s.creating = true
@@ -396,8 +408,10 @@ func (s *TaskPane) enterEditMode() {
 // at most one trigger, so validation reduces to: a name, a non-empty value
 // for the selected trigger, and — for cron tasks only — a valid cron
 // expression plus a non-empty prompt. Watch tasks may omit the prompt: each
-// event defaults to the raw emitted line. Returns the inline error and the
-// focus stop to render it under, or ("", -1) when valid.
+// event defaults to the raw emitted line. The project path is validated for
+// BOTH trigger types (#924): a corrupt or non-existent repo path used to be
+// saved silently and only surfaced when the scheduler fired. Returns the
+// inline error and the focus stop to render it under, or ("", -1) when valid.
 func (s *TaskPane) validateForm() (string, int) {
 	if strings.TrimSpace(s.editName.Value()) == "" {
 		return "name is required", taskFocusName
@@ -406,18 +420,35 @@ func (s *TaskPane) validateForm() (string, int) {
 		if strings.TrimSpace(s.editWatch.Value()) == "" {
 			return "watch command is required", taskFocusTriggerValue
 		}
-		return "", -1
+	} else {
+		cron := strings.TrimSpace(s.editCron.Value())
+		if cron == "" {
+			return "cron expression is required", taskFocusTriggerValue
+		}
+		if err := task.ValidateCronExpr(cron); err != nil {
+			return fmt.Sprintf("invalid cron: %v", err), taskFocusTriggerValue
+		}
+		if strings.TrimSpace(s.editPrompt.Value()) == "" {
+			return "prompt must be non-empty", taskFocusPrompt
+		}
 	}
-	cron := strings.TrimSpace(s.editCron.Value())
-	if cron == "" {
-		return "cron expression is required", taskFocusTriggerValue
+
+	// Expand a leading ~ (filepath.Abs does not), resolve to absolute, and
+	// require a real git repo — the same check RunTask/the watcher apply at
+	// fire time (git.IsGitRepo). Persist the normalized value back into the
+	// field so what we validate is exactly what gets stored (#924).
+	rawPath := strings.TrimSpace(s.editPath.Value())
+	if rawPath == "" {
+		return "project path is required", taskFocusPath
 	}
-	if err := task.ValidateCronExpr(cron); err != nil {
-		return fmt.Sprintf("invalid cron: %v", err), taskFocusTriggerValue
+	absPath, err := filepath.Abs(config.ExpandTilde(rawPath))
+	if err != nil {
+		return fmt.Sprintf("invalid path: %v", err), taskFocusPath
 	}
-	if strings.TrimSpace(s.editPrompt.Value()) == "" {
-		return "prompt must be non-empty", taskFocusPrompt
+	if !git.IsGitRepo(absPath) {
+		return fmt.Sprintf("%s is not a git repository", absPath), taskFocusPath
 	}
+	s.editPath.SetValue(absPath)
 	return "", -1
 }
 
@@ -448,11 +479,12 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 				s.pendingCreate = true
 				s.creating = false
 			} else {
-				// Mirror the create path (app.handleTaskCreate): resolve
-				// the user-entered path to an absolute form so an empty
-				// or relative value behaves the same when the scheduler
-				// fires as it does in the TUI trigger (#641).
-				absPath, err := filepath.Abs(s.editPath.Value())
+				// Mirror the create path (app.handleTaskCreate): expand a
+				// leading ~ then resolve to an absolute form so an empty or
+				// relative value behaves the same when the scheduler fires
+				// as it does in the TUI trigger (#641, #924). validateForm
+				// already normalized editPath, so this is idempotent.
+				absPath, err := filepath.Abs(config.ExpandTilde(s.editPath.Value()))
 				if err != nil {
 					s.editError = fmt.Sprintf("invalid path: %v", err)
 					s.editErrorField = taskFocusPath

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -9,6 +10,19 @@ import (
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/stretchr/testify/assert"
 )
+
+// newGitRepo creates a throwaway git repository and returns its absolute path.
+// validateForm now requires a task's project path to be a real git repo (#924),
+// so the create/edit success-path tests need a genuine repo rather than a
+// literal placeholder like "/tmp/repo".
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	return dir
+}
 
 // TestTaskPaneSetTasksEmptyResetsSelectedIdx verifies that calling SetTasks
 // with an empty slice leaves selectedIdx at a valid value (0) rather than -1.
@@ -173,7 +187,7 @@ func TestTaskPaneCreateModeRejectsWhitespaceName(t *testing.T) {
 // uses the configured default_program. Regression test for #492.
 func TestTaskPaneCreateModeSelectorDefaultsToConfigDefault(t *testing.T) {
 	tp := NewTaskPane()
-	tp.EnterCreateMode("/tmp/repo")
+	tp.EnterCreateMode(newGitRepo(t))
 	fillCreateForm(t, tp, "daily")
 
 	// Walk to the Save button without touching the Program selector.
@@ -190,7 +204,7 @@ func TestTaskPaneCreateModeSelectorDefaultsToConfigDefault(t *testing.T) {
 // bare name (no path, no flags). Regression test for #492.
 func TestTaskPaneCreateModeSelectorPicksCanonicalAgent(t *testing.T) {
 	tp := NewTaskPane()
-	tp.EnterCreateMode("/tmp/repo")
+	tp.EnterCreateMode(newGitRepo(t))
 	fillCreateForm(t, tp, "daily")
 
 	// Walk to the Program field and step the selector to "claude"
@@ -217,7 +231,7 @@ func TestTaskPaneEditModePresetFromExistingProgram(t *testing.T) {
 		Name:        "nightly",
 		Prompt:      "do it",
 		CronExpr:    "* * * * *",
-		ProjectPath: "/tmp/repo",
+		ProjectPath: newGitRepo(t),
 		Program:     "aider",
 		Enabled:     true,
 	}})
@@ -252,7 +266,7 @@ func TestTaskPaneEditModeCollapsesLegacyProgramToDefault(t *testing.T) {
 		Name:        "nightly",
 		Prompt:      "do it",
 		CronExpr:    "* * * * *",
-		ProjectPath: "/tmp/repo",
+		ProjectPath: newGitRepo(t),
 		Program:     legacy,
 		Enabled:     true,
 	}})
@@ -342,57 +356,48 @@ func editPathTo(t *testing.T, tp *TaskPane, newPath string) {
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
 }
 
-// TestTaskPaneEditModeNormalizesEmptyPath is the regression guard for #641:
-// editing ProjectPath to "" must normalize to the CWD (via filepath.Abs)
-// so the scheduler receives the same absolute path the TUI trigger would
-// produce. Prior to the fix the empty value was stored verbatim, causing
-// scheduled runs to fail with "repo path is required" while TUI triggers
-// silently fell back to CWD.
-func TestTaskPaneEditModeNormalizesEmptyPath(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	expected, err := filepath.Abs(cwd)
-	if err != nil {
-		t.Fatalf("abs: %v", err)
-	}
-
+// TestTaskPaneEditModeRejectsEmptyPath supersedes the #641 empty→CWD behavior:
+// since #924 the form validates the path on save, so clearing ProjectPath now
+// surfaces an inline error under the Path field instead of silently defaulting
+// to the CWD. The rejected edit must not be written back.
+func TestTaskPaneEditModeRejectsEmptyPath(t *testing.T) {
+	repo := newGitRepo(t)
 	tp := NewTaskPane()
 	tp.SetTasks([]task.Task{{
 		ID:          "abc",
 		Name:        "nightly",
 		Prompt:      "do it",
 		CronExpr:    "0 0 * * *",
-		ProjectPath: "/tmp/repo",
+		ProjectPath: repo,
 		Program:     "claude",
 		Enabled:     true,
 	}})
 
 	editPathTo(t, tp, "")
 
-	assert.False(t, tp.IsEditing(), "save should exit edit mode")
-	assert.Equal(t, "", tp.editError, "empty path must normalize, not surface an error")
+	assert.True(t, tp.IsEditing(), "form must stay open so the user can fix the error")
+	assert.Equal(t, "project path is required", tp.editError)
+	assert.Equal(t, taskFocusPath, tp.editErrorField)
 	tasks := tp.GetTasks()
 	if assert.Len(t, tasks, 1) {
-		assert.Equal(t, expected, tasks[0].ProjectPath,
-			"empty ProjectPath must be normalized to absolute CWD on save, matching the create path")
+		assert.Equal(t, repo, tasks[0].ProjectPath,
+			"rejected edit must not overwrite the stored path")
 	}
 }
 
 // TestTaskPaneEditModeNormalizesRelativePath verifies that editing
 // ProjectPath to a relative value resolves it via filepath.Abs at save
-// time, mirroring the create path (#641). Without this, the scheduler
-// would pass a relative path that resolves against the daemon's CWD
-// rather than the user's CWD.
+// time, mirroring the create path (#641). Since #924 the resolved path must
+// also be a real git repo, so the relative input points into a temp repo.
 func TestTaskPaneEditModeNormalizesRelativePath(t *testing.T) {
+	repo := newGitRepo(t)
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	expected, err := filepath.Abs(filepath.Join(cwd, "relative"))
+	rel, err := filepath.Rel(cwd, repo)
 	if err != nil {
-		t.Fatalf("abs: %v", err)
+		t.Fatalf("rel: %v", err)
 	}
 
 	tp := NewTaskPane()
@@ -401,39 +406,44 @@ func TestTaskPaneEditModeNormalizesRelativePath(t *testing.T) {
 		Name:        "nightly",
 		Prompt:      "do it",
 		CronExpr:    "0 0 * * *",
-		ProjectPath: "/tmp/repo",
+		ProjectPath: repo,
 		Program:     "claude",
 		Enabled:     true,
 	}})
 
-	editPathTo(t, tp, "./relative")
+	editPathTo(t, tp, rel)
 
+	assert.False(t, tp.IsEditing(), "a relative path into a git repo must save")
+	assert.Equal(t, "", tp.editError)
 	tasks := tp.GetTasks()
 	if assert.Len(t, tasks, 1) {
-		assert.Equal(t, expected, tasks[0].ProjectPath,
+		assert.Equal(t, repo, tasks[0].ProjectPath,
 			"relative ProjectPath must be resolved via filepath.Abs on save")
 	}
 }
 
 // TestTaskPaneEditModeKeepsAbsolutePath verifies that an already-absolute
-// ProjectPath is preserved verbatim across edit/save (#641).
+// ProjectPath pointing at a git repo is preserved verbatim across edit/save
+// (#641, tightened by #924's git-repo validation).
 func TestTaskPaneEditModeKeepsAbsolutePath(t *testing.T) {
+	oldRepo := newGitRepo(t)
+	newRepo := newGitRepo(t)
 	tp := NewTaskPane()
 	tp.SetTasks([]task.Task{{
 		ID:          "abc",
 		Name:        "nightly",
 		Prompt:      "do it",
 		CronExpr:    "0 0 * * *",
-		ProjectPath: "/tmp/old",
+		ProjectPath: oldRepo,
 		Program:     "claude",
 		Enabled:     true,
 	}})
 
-	editPathTo(t, tp, "/tmp/new-repo")
+	editPathTo(t, tp, newRepo)
 
 	tasks := tp.GetTasks()
 	if assert.Len(t, tasks, 1) {
-		assert.Equal(t, "/tmp/new-repo", tasks[0].ProjectPath,
+		assert.Equal(t, newRepo, tasks[0].ProjectPath,
 			"absolute ProjectPath must be preserved verbatim across edit/save")
 	}
 }
@@ -524,7 +534,7 @@ func TestTaskPaneConsumeDeletedClearsState(t *testing.T) {
 // validation error is unrepresentable.
 func TestTaskPaneCreateModeInactiveTriggerNotSaved(t *testing.T) {
 	tp := NewTaskPane()
-	tp.EnterCreateMode("/tmp/repo")
+	tp.EnterCreateMode(newGitRepo(t))
 	fillCreateForm(t, tp, "both") // name, cron, prompt — cron type selected
 
 	// Flip the trigger type to watch and fill the watch command. The cron
@@ -586,7 +596,7 @@ func TestTaskPaneCreateModeRejectsEmptyWatch(t *testing.T) {
 // line). The pending create must carry the new fields and no cron.
 func TestTaskPaneCreateModeWatchTask(t *testing.T) {
 	tp := NewTaskPane()
-	tp.EnterCreateMode("/tmp/repo")
+	tp.EnterCreateMode(newGitRepo(t))
 
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("gh-issues")})
 	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector
@@ -607,6 +617,68 @@ func TestTaskPaneCreateModeWatchTask(t *testing.T) {
 	assert.Equal(t, "captain", targetSession)
 }
 
+// TestValidateFormPathValidation pins the #924 path contract: validateForm
+// rejects an empty, non-git, or unresolved-tilde project path for BOTH cron
+// and watch tasks, and accepts a real git repo — storing the expanded absolute
+// form so what is validated is exactly what gets persisted.
+func TestValidateFormPathValidation(t *testing.T) {
+	repo := newGitRepo(t)
+	nonRepo := t.TempDir() // a real directory that is not a git repo
+
+	newForm := func(trigger, path string) *TaskPane {
+		tp := NewTaskPane()
+		tsk := task.Task{Name: "t", ProjectPath: path}
+		if trigger == "watch" {
+			tsk.WatchCmd = "watch.sh"
+		} else {
+			tsk.CronExpr = "0 0 * * *"
+			tsk.Prompt = "do it"
+		}
+		tp.initForm(&tsk, "")
+		return tp
+	}
+
+	for _, trigger := range []string{"cron", "watch"} {
+		t.Run(trigger, func(t *testing.T) {
+			// Empty path rejected with focus on the path field.
+			msg, field := newForm(trigger, "").validateForm()
+			assert.Equal(t, "project path is required", msg)
+			assert.Equal(t, taskFocusPath, field)
+
+			// A tilde path that expands to a non-repo (home dir) is rejected —
+			// proving the value is expanded (not treated literally) and then
+			// validated.
+			msg, field = newForm(trigger, "~/definitely-not-a-repo-924").validateForm()
+			assert.NotEqual(t, "", msg, "a non-git tilde path must be rejected")
+			assert.Equal(t, taskFocusPath, field)
+
+			// A non-git absolute path is rejected.
+			msg, field = newForm(trigger, nonRepo).validateForm()
+			assert.NotEqual(t, "", msg, "a non-git path must be rejected")
+			assert.Equal(t, taskFocusPath, field)
+
+			// A valid git repo is accepted and stored normalized.
+			tp := newForm(trigger, repo)
+			msg, field = tp.validateForm()
+			assert.Equal(t, "", msg, "a valid git repo path must be accepted")
+			assert.Equal(t, -1, field)
+			assert.Equal(t, repo, tp.editPath.Value(),
+				"the validated path must be persisted in its normalized form")
+
+			// A "~" path expanding to a git repo is accepted, proving tilde
+			// expansion flows through validateForm and the stored value is the
+			// expanded absolute path.
+			t.Setenv("HOME", repo)
+			tp = newForm(trigger, "~")
+			msg, field = tp.validateForm()
+			assert.Equal(t, "", msg, "a tilde path resolving to a git repo must be accepted")
+			assert.Equal(t, -1, field)
+			assert.Equal(t, repo, tp.editPath.Value(),
+				"a leading ~ must be expanded to the home dir before storing")
+		})
+	}
+}
+
 // TestTaskPaneEditModeSwitchCronToWatch verifies the edit form can retrigger
 // an existing cron task as a watch task: flipping the trigger selector to
 // watch and filling the command must save WatchCmd and clear CronExpr — the
@@ -619,7 +691,7 @@ func TestTaskPaneEditModeSwitchCronToWatch(t *testing.T) {
 		Name:        "nightly",
 		Prompt:      "do it",
 		CronExpr:    "0 0 * * *",
-		ProjectPath: "/tmp/repo",
+		ProjectPath: newGitRepo(t),
 		Program:     "claude",
 		Enabled:     true,
 	}})
@@ -652,7 +724,7 @@ func TestTaskPaneEditModeSelectorPresetsFromWatchTask(t *testing.T) {
 		ID:          "abc",
 		Name:        "gh-issues",
 		WatchCmd:    "gh-issue-watch.sh",
-		ProjectPath: "/tmp/repo",
+		ProjectPath: newGitRepo(t),
 		Enabled:     true,
 	}})
 	tp.SetFocus(true)


### PR DESCRIPTION
## Summary

Detail Bug #924 reported three related defects in the TUI task flow. This PR fixes all three and introduces a shared tilde-expansion helper.

### Sub-bug 1 — tilde paths corrupted
`filepath.Abs` does **not** expand `~`, so entering `~/project` in the task form stored `<cwd>/~/project`. There was no shared tilde helper; `config.go` expanded `~` inline only for `AGENT_FACTORY_HOME`.

- New exported **`config.ExpandTilde(path string) string`**: a leading `~` or `~/` expands to the home dir; everything else — absolute paths, relative paths, `""`, and unresolvable `~user` — is returned unchanged.
- `config.GetConfigDir`'s `AGENT_FACTORY_HOME` expansion is refactored onto the helper (DRY), keeping its explicit `~user` / unresolvable-home error surfacing.
- `ExpandTilde` is now called **before `filepath.Abs`** in both the **create** (`app/app.go`) and **edit** (`ui/task_pane.go`) flows.

### Sub-bug 2 — TUI form never validated the path
`validateForm` returned early for watch tasks and never checked the path for cron tasks, so a corrupt / non-existent / non-git path was saved silently.

- `validateForm` now validates the project path for **both** trigger types: non-empty, expanded, resolved to absolute, and a **real git repo** (`git.IsGitRepo`) — the same check the runtime applies at fire time — with focus set to the path field on failure.
- The normalized absolute path is written back into the field so **what is validated is exactly what gets persisted**.
- `EnterCreateMode` now defaults an empty path to the CWD, so the in-pane `n` form is prefilled with a usually-valid path instead of an empty one the new validation would reject.

### Sub-bug 3 — cron failures didn't update status
`RunTask` returned early on a `git.IsGitRepo` failure before reaching `UpdateTaskStatus`, and the scheduler only logged the error — so a cron task's `LastRunStatus` stayed stale instead of showing `errored`.

- `RunTask` installs a **single deferred status recorder** once it holds the per-task lock. Every failure that occurs while this fire owns the task (git missing, path not a repo, delivery error) records `errored: <why>` — matching the watcher convention the TUI keys on (#797).
- The success path writes its own status and the defer no-ops on `nil` error, so status is **never double-written**.
- Pre-lock guards (invalid id, disabled, watch task, lock contention) intentionally do **not** record — they aren't this fire's run to own.

## Adjacent-call-site audit
- The CLI (`api/tasks.go`) stores the resolved `repo.Root` and takes `--repo`, which the **shell** tilde-expands — so only the TUI text-input sites needed the fix. The runtime resolves `ProjectPath` via `RepoFromPath` at fire time, so the TUI now normalizes equivalently.
- Grepped every `filepath.Abs`: no other call on user-entered paths skips tilde expansion.
- Grepped every early return in `RunTask`: each failure after lock acquisition now records status.

## Tests
- `config.ExpandTilde`: `~`/`~/x` expand to home; `/abs`, `rel`, `""`, `~user` unchanged.
- `validateForm`: rejects empty / non-git / unresolved-tilde paths and accepts a real git repo (incl. a `~`→repo case proving expansion flows through) for **both** cron and watch.
- `RunTask`: persists an `errored` status when the project path is not a git repo (hermetic temp `AGENT_FACTORY_HOME`; no real daemon touched).
- Existing TUI tests updated to use real temp git repos; the `#641` empty-path test is superseded by an explicit rejection test.

## Verification
`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./config/... ./ui/... ./daemon/... ./task/... ./app/...` green.

Fixes #924

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)