### PR TITLE
feat(ui): change accent color from purple to #7cb8bb (#931)

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -110,7 +110,7 @@ func (h helpTypeInstanceAttach) mask() uint32 {
 }
 
 var (
-	titleStyle  = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(lipgloss.Color("#7D56F4"))
+	titleStyle  = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(lipgloss.Color("#7cb8bb"))
 	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#36CFC9"))
 	keyStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	descStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFFFF"))

--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -171,7 +171,7 @@ func (h *HooksPane) handleEditMode(msg tea.KeyMsg) bool {
 }
 
 func (h *HooksPane) String() string {
-	tStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7D56F4"))
+	tStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7cb8bb"))
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -24,7 +24,7 @@ var sepStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
 	Dark:  "#3C3C3C",
 })
 
-var actionGroupStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("99"))
+var actionGroupStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#7cb8bb"))
 
 var separator = " • "
 var verticalSeparator = " │ "

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -165,7 +165,7 @@ func runeEqualFold(a, b rune) bool {
 
 // Render renders the search overlay.
 func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7D56F4"))
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7cb8bb"))
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
@@ -246,7 +246,7 @@ func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
 
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#7D56F4")).
+		BorderForeground(lipgloss.Color("#7cb8bb")).
 		Padding(1, 2).
 		Width(s.width)
 

--- a/ui/overlay/selectionOverlay.go
+++ b/ui/overlay/selectionOverlay.go
@@ -76,7 +76,7 @@ func (s *SelectionOverlay) SetWidth(width int) {
 
 // Render renders the selection overlay
 func (s *SelectionOverlay) Render(opts ...WhitespaceOption) string {
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7D56F4"))
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7cb8bb"))
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
@@ -95,7 +95,7 @@ func (s *SelectionOverlay) Render(opts ...WhitespaceOption) string {
 
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#7D56F4")).
+		BorderForeground(lipgloss.Color("#7cb8bb")).
 		Padding(1, 2).
 		Width(s.width)
 

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -20,7 +20,7 @@ func tabBorderWithBottom(left, middle, right string) lipgloss.Border {
 var (
 	inactiveTabBorder = tabBorderWithBottom("┴", "─", "┴")
 	activeTabBorder   = tabBorderWithBottom("┘", " ", "└")
-	highlightColor    = lipgloss.AdaptiveColor{Light: "#874BFD", Dark: "#7D56F4"}
+	highlightColor    = lipgloss.AdaptiveColor{Light: "#7cb8bb", Dark: "#7cb8bb"}
 	inactiveTabStyle  = lipgloss.NewStyle().
 				Border(inactiveTabBorder, true).
 				BorderForeground(highlightColor).

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -636,7 +636,7 @@ func taskDeliverySummary(tsk task.Task) string {
 }
 
 func (s *TaskPane) renderListMode() string {
-	tStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7D56F4"))
+	tStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7cb8bb"))
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	enabledStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#36CFC9"))
 	disabledStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))


### PR DESCRIPTION
Closes the repo owner's request to swap the UI accent from the bubbletea purple to the teal **#7cb8bb**.

## Primary accent (purple → #7cb8bb)
- `ui/tabbed_window.go` — `highlightColor` (the primary accent: active-tab highlight + window border). Was `AdaptiveColor{Light: "#874BFD", Dark: "#7D56F4"}`; both Light and Dark set to `#7cb8bb` per the single color Sachin specified (mid-tone teal reads on both backgrounds).
- `ui/hooks_pane.go` — hooks-pane title style (bare `#7D56F4`).
- `ui/task_pane.go` — task list-mode title style (bare `#7D56F4`).
- `ui/overlay/selectionOverlay.go` — title style + border foreground (2 usages).
- `ui/overlay/searchOverlay.go` — title style + border foreground (2 usages).
- `app/help.go` — help overlay `titleStyle` (bare `#7D56F4`).

## Secondary-purple decisions
- `ui/menu.go` `actionGroupStyle = lipgloss.Color("99")` (ANSI-256 violet) — **converted** to `#7cb8bb`. This styles the action-group headers in the menu and is clearly part of the accent family, so it tracks the new accent.
- `ui/menu.go` `menuStyle = lipgloss.Color("205")` (pink) and `sepStyle` greys — **left alone**; not the purple accent.
- Grepped the repo for `7D56F4 / 874BFD / Color("99") / Color("5") / Color("13")`. Only `99` matched among the candidate secondary purples; the semantic colors (error red, success green `#51bd73`, greys, `#FFCC00`, `#36CFC9`, etc.) were left untouched.

No tests asserted the old hex values (grepped `*_test.go`), so none needed updating.

## README screenshot
README screenshot (`docs/assets/screenshot.png`) still shows the old accent and needs manual regeneration in a real terminal — not done here. It's a real capture of the live TUI and cannot be faithfully regenerated headless.

## Verification
- `gofmt -l .` — clean
- `go build ./...` — passes
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./ui/... ./app/...` — green

Fixes #931

— Captain Claude
