### PR TITLE
fix(config): trim whitespace in hook command paths before resolving (#933)

### DIFF
--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -88,7 +88,17 @@ func (h RemoteHooks) resolveCommandPaths(repoRoot string) *RemoteHooks {
 //
 // Empty stays empty so RemoteHooks.Validate reports the missing field, not a
 // phantom path.
+//
+// Surrounding whitespace is trimmed first so the IsAbs/separator decision and
+// the value handed to exec.Command both see the path the user intended:
+// without this, "   /bin/launch.sh" looks relative (IsAbs is false) and gets
+// joined onto repoRoot, while "/bin/launch.sh   " is returned untrimmed and
+// fails exec with "no such file or directory" (#933). Only the surrounding
+// whitespace of the command token is trimmed; a command's arguments are not
+// touched because hook commands are never shell-parsed (the whole string is
+// the executable path).
 func resolveHookCommandPath(repoRoot, cmd string) string {
+	cmd = strings.TrimSpace(cmd)
 	if cmd == "" || filepath.IsAbs(cmd) || !strings.ContainsRune(cmd, filepath.Separator) {
 		return cmd
 	}

--- a/config/repo_config_test.go
+++ b/config/repo_config_test.go
@@ -322,6 +322,33 @@ func TestResolveHookCommandPath(t *testing.T) {
 	}
 }
 
+// TestResolveHookCommandPathWhitespace covers leading/trailing whitespace
+// around the command token: it is trimmed before the IsAbs/separator decision
+// and the join, so absolute paths stay absolute, relative paths still resolve
+// under repoRoot, and bare names keep their $PATH lookup (#933).
+func TestResolveHookCommandPathWhitespace(t *testing.T) {
+	const root = "/srv/repos/detail"
+	cases := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"leading whitespace on absolute path", "   /usr/local/bin/launch.sh", "/usr/local/bin/launch.sh"},
+		{"trailing whitespace on absolute path", "/usr/local/bin/launch.sh   ", "/usr/local/bin/launch.sh"},
+		{"leading whitespace on relative path", "   ./hooks/launch.sh", root + "/hooks/launch.sh"},
+		{"trailing whitespace on relative path", "./hooks/launch.sh   ", root + "/hooks/launch.sh"},
+		{"leading whitespace on bare name", "   bash", "bash"},
+		{"trailing whitespace on bare name", "bash   ", "bash"},
+		{"whitespace-only stays empty", "   ", ""},
+		{"empty stays empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveHookCommandPath(root, tc.cmd))
+		})
+	}
+}
+
 // TestRemoteHooksResolveCommandPaths verifies the copy semantics: the
 // returned hooks carry resolved paths while the receiver is untouched, so
 // ResolveConfig can never write rewritten values back through a loaded


### PR DESCRIPTION
## Problem

`resolveHookCommandPath(repoRoot, cmd)` in `config/repo_config.go` made its
`filepath.IsAbs` / separator decision and its `filepath.Join` directly on the
raw config value. Surrounding whitespace therefore broke remote hook execution
two different ways:

- **Leading whitespace** — `"   /usr/local/bin/launch.sh"`: `filepath.IsAbs`
  returns `false`, so the path was treated as relative and joined onto the repo
  root (`"/srv/repos/detail/   /usr/local/bin/launch.sh"`).
- **Trailing whitespace** — `"/usr/local/bin/launch.sh   "`: `filepath.IsAbs`
  returns `true`, so the untrimmed string was returned and handed straight to
  `exec.Command`, failing with `no such file or directory`.

Either way the user (who only edited `.agent-factory/config.json` and added a
stray space) got a cryptic ENOENT with no hint at the cause. Regression of #836.

## Fix

`strings.TrimSpace` the command token **first**, then run the existing
empty/`IsAbs`/separator logic and join on the trimmed value. Already-clean
inputs are unchanged.

## Adjacent-call-site audit

- All five hook commands (`launch_cmd`/`list_cmd`/`attach_cmd`/`delete_cmd`/
  `terminal_cmd`) flow through `resolveHookCommandPath` via
  `resolveCommandPaths`, so the single trim covers every one of them.
- `RemoteHooks.Validate()` is a non-mutating value-receiver check that already
  `TrimSpace`s for its emptiness guard (whitespace-only is rejected). I left
  normalization at the resolve boundary rather than storing trimmed values in
  `Validate()`: this mirrors how relative paths are stored raw in the config
  and rewritten only at use, so `resolve` and `exec` always agree on the clean
  value without mutating the loaded/persisted config.
- Only the command-path token is trimmed, never a command's arguments — hook
  commands are never shell-parsed (the whole string is the executable path).

## Test

`TestResolveHookCommandPathWhitespace` covers all eight cases from the issue
(leading/trailing whitespace on absolute, relative, and bare-name commands,
plus whitespace-only and empty → `""`).

## Verification

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./config/...` — green

Fixes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)
