### PR TITLE
fix(ui): clear scroll mode when PreviewPane enters fallback so the message renders (#940)

### DIFF
--- a/ui/preview.go
+++ b/ui/preview.go
@@ -95,12 +95,22 @@ func (p *PreviewPane) dropStaleScrollState(instance *session.Instance) {
 	}
 }
 
-// setFallbackState sets the preview state with fallback text and a message
+// setFallbackState sets the preview state with fallback text and a message.
+// Caller must hold p.mu.
+//
+// Also resets scroll-mode state so fallback==true cannot coexist with
+// isScrolling==true. String() checks isScrolling before fallback, so leaving
+// scroll state intact when entering a fallback (nil/Loading/Deleting/
+// session-gone) would render the prior instance's stale viewport instead of
+// the fallback message. Mirrors the TerminalPane.setFallbackState invariant
+// established in #672.
 func (p *PreviewPane) setFallbackState(message string) {
 	p.previewState = previewState{
 		fallback: true,
 		text:     lipgloss.JoinVertical(lipgloss.Center, FallBackText, "", message),
 	}
+	p.isScrolling = false
+	p.viewport.SetContent("")
 }
 
 // Updates the preview pane content with the tmux pane content. Safe to call
@@ -147,7 +157,9 @@ func (p *PreviewPane) UpdateContent(instance *session.Instance) error {
 		content, err = instance.PreviewFullHistory()
 		if err != nil {
 			if errors.Is(err, tmux.ErrSessionGone) {
-				p.isScrolling = false
+				// setFallbackState now clears scroll state and the stale
+				// viewport, so the fallback renders even though we were mid-
+				// scroll-capture (#940).
 				p.setFallbackState("Session no longer running.")
 				return nil
 			}

--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -1,0 +1,224 @@
+package ui
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These are the regression tests for issue #940. TerminalPane established the
+// invariant `fallback==true ⇒ isScrolling==false` in #672 because String()
+// short-circuits on isScrolling BEFORE checking fallback — so any fallback
+// entered while scrolling must also clear scroll mode and the stale viewport,
+// or the prior viewport renders instead of the fallback message. PreviewPane's
+// setFallbackState was missing that enforcement; these tests drive each
+// fallback entry point while in scroll mode and assert the fallback message
+// renders, scroll mode is exited, and the viewport content is cleared.
+//
+// Mirrors TestTerminalScroll* / the TerminalPane setFallbackState invariant.
+
+const staleScrollMarker = "STALE-SCROLL-VIEWPORT-CONTENT"
+
+// enterScrollWithStaleViewport puts the pane into scroll mode holding stale
+// viewport content for the given instance, without going through ScrollUp (so
+// the test does not depend on tmux capture behavior). currentInstance is set to
+// `inst` so UpdateContent's dropStaleScrollState guard does not pre-emptively
+// reset scroll mode on its own — we want to prove setFallbackState is what
+// clears it.
+func enterScrollWithStaleViewport(p *PreviewPane, inst *session.Instance) {
+	p.currentInstance = inst
+	p.isScrolling = true
+	p.viewport.SetContent(staleScrollMarker)
+}
+
+// TestPreviewScrollModeThenDeletingFallback: a same-instance Running → Deleting
+// transition while scrolling must show "Tearing down session...", not the
+// stale viewport (#940 / #920).
+func TestPreviewScrollModeThenDeletingFallback(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: "deleting", Path: t.TempDir(), Program: "test",
+	})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStatus(session.Deleting)
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+	enterScrollWithStaleViewport(p, inst)
+
+	require.NoError(t, p.UpdateContent(inst))
+
+	require.False(t, p.isScrolling,
+		"entering the Deleting fallback must exit scroll mode")
+	require.True(t, p.previewState.fallback,
+		"Deleting instance must render a fallback")
+	require.NotContains(t, p.viewport.View(), staleScrollMarker,
+		"stale viewport content must be cleared on fallback")
+
+	rendered := p.String()
+	require.Contains(t, rendered, "Tearing down session...",
+		"rendered frame must show the teardown fallback, not stale scroll content")
+	require.NotContains(t, rendered, staleScrollMarker,
+		"rendered frame must not be the stale viewport")
+}
+
+// TestPreviewScrollModeThenNilInstanceFallback: deselecting to a nil instance
+// while scrolling must show the welcome fallback, not the stale viewport.
+func TestPreviewScrollModeThenNilInstanceFallback(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+	// currentInstance stays nil so UpdateContent(nil)'s dropStaleScrollState
+	// (nil == nil) does not reset scroll itself — setFallbackState must.
+	p.isScrolling = true
+	p.viewport.SetContent(staleScrollMarker)
+
+	require.NoError(t, p.UpdateContent(nil))
+
+	require.False(t, p.isScrolling,
+		"the nil-instance fallback must exit scroll mode")
+	require.True(t, p.previewState.fallback)
+	require.NotContains(t, p.viewport.View(), staleScrollMarker,
+		"stale viewport content must be cleared on fallback")
+
+	rendered := p.String()
+	require.Contains(t, rendered, "No agents running yet",
+		"rendered frame must show the welcome fallback, not stale scroll content")
+	require.NotContains(t, rendered, staleScrollMarker)
+}
+
+// TestPreviewScrollModeThenLoadingFallback: a Loading instance while scrolling
+// must show "Setting up workspace...", not the stale viewport.
+func TestPreviewScrollModeThenLoadingFallback(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: "loading", Path: t.TempDir(), Program: "test",
+	})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStatus(session.Loading)
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+	enterScrollWithStaleViewport(p, inst)
+
+	require.NoError(t, p.UpdateContent(inst))
+
+	require.False(t, p.isScrolling,
+		"entering the Loading fallback must exit scroll mode")
+	require.True(t, p.previewState.fallback)
+	require.NotContains(t, p.viewport.View(), staleScrollMarker)
+
+	rendered := p.String()
+	require.Contains(t, rendered, "Setting up workspace...",
+		"rendered frame must show the Loading fallback, not stale scroll content")
+	require.NotContains(t, rendered, staleScrollMarker)
+}
+
+// TestPreviewScrollModeViewportContentCleared focuses on the viewport-clearing
+// half of the invariant: after entering any fallback, viewport.View() must no
+// longer contain the captured scroll content. Without the fix the viewport is
+// left untouched and String() (which checks isScrolling first) renders it.
+func TestPreviewScrollModeViewportContentCleared(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: "deleting", Path: t.TempDir(), Program: "test",
+	})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStatus(session.Deleting)
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+	enterScrollWithStaleViewport(p, inst)
+	require.Contains(t, p.viewport.View(), staleScrollMarker,
+		"precondition: viewport holds stale scroll content")
+
+	require.NoError(t, p.UpdateContent(inst))
+
+	require.False(t, p.isScrolling, "scroll mode must be exited")
+	require.NotContains(t, p.viewport.View(), staleScrollMarker,
+		"viewport content must be cleared when entering a fallback (#940)")
+}
+
+// TestPreviewScrollModeThenSessionGoneFallback: when the user enters scroll
+// mode (ScrollUp) but the tmux session has vanished, the PreviewFullHistory
+// capture fails with ErrSessionGone and the pane enters the session-gone
+// fallback. setFallbackState must leave the pane with isScrolling==false and a
+// cleared viewport so the fallback renders.
+func TestPreviewScrollModeThenSessionGoneFallback(t *testing.T) {
+	var sessionCreated, sessionGone atomic.Bool
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			cmdStr := cmd.String()
+			if strings.Contains(cmdStr, "has-session") {
+				if sessionGone.Load() {
+					return fmt.Errorf("session gone")
+				}
+				if sessionCreated.Load() {
+					return nil
+				}
+				return fmt.Errorf("session does not exist")
+			}
+			if strings.Contains(cmdStr, "new-session") {
+				sessionCreated.Store(true)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			cmdStr := cmd.String()
+			if strings.Contains(cmdStr, "capture-pane") {
+				if sessionGone.Load() {
+					return nil, fmt.Errorf("exit status 1")
+				}
+				return []byte("hello world"), nil
+			}
+			return []byte(""), nil
+		},
+	}
+
+	setup := setupTestEnvironment(t, cmdExec)
+	defer setup.cleanupFn()
+
+	p := NewPreviewPane()
+	p.SetSize(80, 30)
+
+	// Register currentInstance via a live render so ScrollUp's dropStaleScrollState
+	// guard does not reset scroll on the instance-switch path.
+	require.NoError(t, p.UpdateContent(setup.instance))
+
+	// Session vanishes; entering scroll mode now fails the PreviewFullHistory
+	// capture with ErrSessionGone and routes through setFallbackState.
+	sessionGone.Store(true)
+
+	require.NoError(t, p.ScrollUp(setup.instance))
+
+	require.False(t, p.isScrolling,
+		"session-gone while entering scroll mode must not leave the pane scrolling")
+	require.True(t, p.previewState.fallback,
+		"preview must enter fallback state when the session is gone")
+	require.Contains(t, p.previewState.text, "Session no longer running")
+	require.NotContains(t, p.viewport.View(), "hello world",
+		"viewport must not retain stale captured content under the fallback")
+	require.Contains(t, p.String(), "Session no longer running",
+		"rendered frame must show the session-gone fallback")
+}


### PR DESCRIPTION
## Problem

`PreviewPane.String()` checks `if p.isScrolling { return p.viewport.View() }` **before** the fallback branch. So when a fallback is entered while the pane is in scroll mode, the stale viewport renders instead of the fallback message — e.g. a same-instance Running → Deleting transition keeps showing the old terminal output instead of "Tearing down session...", and the Loading / nil-instance / session-gone fallbacks are hidden the same way until the user manually exits scroll mode.

TerminalPane already enforces the invariant **`fallback==true ⇒ isScrolling==false`** inside its `setFallbackState` (fixed in #672: sets `isScrolling=false` and `viewport.SetContent("")`). `PreviewPane.setFallbackState` was the one place that didn't, leaving the #672 invariant gap. Introduced when `String()` was reordered to check `isScrolling` before `fallback`.

## Fix

Mirror TerminalPane in `PreviewPane.setFallbackState`: when entering a fallback, also set `p.isScrolling = false` and `p.viewport.SetContent("")` so the `String()` scroll short-circuit can't hide the fallback. Removed the now-redundant manual `isScrolling = false` in `UpdateContent`'s session-gone scroll-capture path (it duplicated what `setFallbackState` now does and would trip staticcheck's never-read assignment check).

## Adjacent-call-site audit

`setFallbackState` is the **only** writer of `fallback: true` in `ui/preview.go`, so the invariant now holds at every fallback entry point:

- `UpdateContent`: nil instance, `Loading`, `Deleting` (#920), not-started, and session-gone (#496) — all route through `setFallbackState`. ✅
- `ScrollUp` / `ScrollDown`: session-gone-on-entry fallback. ✅
- `ResetToNormalMode`: Loading (#823) / Deleting (#920) / session-gone fallbacks. ✅

Exiting scroll mode by other paths is unaffected: `ResetToNormalMode` still clears scroll at the top and writes real content for the non-fallback case (#577 guard intact); `dropStaleScrollState` (instance switch / mouse-scroll, #470/#702) still clears scroll and viewport. All existing preview/terminal scroll tests stay green.

## Tests

Added `ui/preview_scroll_fallback_test.go` (mirrors the TerminalPane scroll/fallback coverage). Each test enters scroll mode with stale viewport content, triggers a fallback, and asserts the fallback message renders (not the stale viewport), `isScrolling` is false, and the viewport is cleared:

- `TestPreviewScrollModeThenDeletingFallback`
- `TestPreviewScrollModeThenNilInstanceFallback`
- `TestPreviewScrollModeThenLoadingFallback`
- `TestPreviewScrollModeViewportContentCleared`
- `TestPreviewScrollModeThenSessionGoneFallback`

The first four fail on `master` and pass with this change; the session-gone case (entered via `ScrollUp`) guards the viewport-clearing + correct-render half of the invariant.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./ui/...` green. Hermetic; `dev-install.sh` not run.

Fixes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)