### PR TITLE
fix(daemon): binary-name-agnostic daemon-stop guidance and honest af reset (#937)

### DIFF
--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -169,7 +169,7 @@ func InstallAutostart() (string, error) {
 			return "", fmt.Errorf("failed to reload systemd user daemon: %w\n%s", err, strings.TrimSpace(string(out)))
 		}
 		// Hand over from any ad-hoc daemon to the supervised one.
-		if err := StopDaemon(); err != nil {
+		if _, err := StopDaemon(); err != nil {
 			return "", fmt.Errorf("failed to stop the running daemon before enabling the service: %w", err)
 		}
 		if out, err := exec.Command("systemctl", "--user", "enable", "--now", autostartUnitName).CombinedOutput(); err != nil {
@@ -199,7 +199,7 @@ func InstallAutostart() (string, error) {
 			return "", fmt.Errorf("failed to write plist file: %w", err)
 		}
 		// Hand over from any ad-hoc daemon to the supervised one.
-		if err := StopDaemon(); err != nil {
+		if _, err := StopDaemon(); err != nil {
 			return "", fmt.Errorf("failed to stop the running daemon before loading the agent: %w", err)
 		}
 		if out, err := exec.Command("launchctl", "load", plistPath).CombinedOutput(); err != nil {

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -161,7 +161,7 @@ func EnsureDaemon() error {
 	// A previous daemon version may have a PID file but no control socket. Stop
 	// it before launching the control-plane daemon so we do not run duplicate
 	// AutoYes loops.
-	if err := StopDaemon(); err != nil {
+	if _, err := StopDaemon(); err != nil {
 		log.WarningLog.Printf("failed to stop stale daemon before launch: %v", err)
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -408,39 +408,45 @@ var (
 	stopDaemonPoll  = sigtermFallbackPoll
 )
 
-// StopDaemon attempts to stop a running daemon process if it exists. Returns no error if the daemon is not found
-// (assumes the daemon does not exist). It verifies the PID actually belongs to an agent-factory daemon before
-// signaling it, so a stale or reused PID in the PID file can't take down an unrelated process.
+// StopDaemon attempts to stop a running daemon process if it exists. The bool
+// return reports whether a live agent-factory daemon was actually signaled: it
+// is false (with a nil error) when there was nothing to stop — no PID file, an
+// invalid/stale PID, a dead process, or a PID that doesn't look like an
+// agent-factory daemon. Callers that surface a user-facing "stopped" message
+// must gate on it (#937): a daemon predating the PID file (pre-1.0.69) leaves
+// no daemon.pid, so a true success line here would be a lie. It verifies the
+// PID actually belongs to an agent-factory daemon before signaling it, so a
+// stale or reused PID in the PID file can't take down an unrelated process.
 //
 // Shutdown is graceful by default: SIGTERM gives the daemon's signal handler a
 // chance to run SaveInstances() and clean up the PID file (see RunDaemon). We
 // only escalate to SIGKILL if the daemon does not exit within stopDaemonGrace,
 // matching the SIGTERM-first pattern in signalAndWait (#571).
-func StopDaemon() error {
+func StopDaemon() (bool, error) {
 	pidDir, err := config.GetConfigDir()
 	if err != nil {
-		return fmt.Errorf("failed to get config directory: %w", err)
+		return false, fmt.Errorf("failed to get config directory: %w", err)
 	}
 
 	pidFile := filepath.Join(pidDir, "daemon.pid")
 	data, err := os.ReadFile(pidFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("failed to read PID file: %w", err)
+		return false, fmt.Errorf("failed to read PID file: %w", err)
 	}
 
 	var pid int
 	if _, err := fmt.Sscanf(string(data), "%d", &pid); err != nil {
-		return fmt.Errorf("invalid PID file format: %w", err)
+		return false, fmt.Errorf("invalid PID file format: %w", err)
 	}
 
 	// Defensively refuse to kill our own process or obviously invalid PIDs.
 	if pid <= 1 || pid == os.Getpid() {
 		log.InfoLog.Printf("daemon PID file contained invalid PID %d; removing stale file", pid)
 		_ = os.Remove(pidFile)
-		return nil
+		return false, nil
 	}
 
 	proc, err := os.FindProcess(pid)
@@ -448,14 +454,14 @@ func StopDaemon() error {
 		// On unix, FindProcess never returns an error, but handle it defensively anyway.
 		log.InfoLog.Printf("daemon process (PID: %d) not found; removing stale PID file", pid)
 		_ = os.Remove(pidFile)
-		return nil
+		return false, nil
 	}
 
 	// Check the process exists at all. Signal 0 is a no-op that just validates permissions/existence.
 	if err := proc.Signal(syscall.Signal(0)); err != nil {
 		log.InfoLog.Printf("daemon process (PID: %d) is not running (%v); removing stale PID file", pid, err)
 		_ = os.Remove(pidFile)
-		return nil
+		return false, nil
 	}
 
 	// Verify the process is actually an agent-factory daemon before signaling it. If we can't verify,
@@ -463,7 +469,7 @@ func StopDaemon() error {
 	if !isAgentFactoryDaemon(pid) {
 		log.InfoLog.Printf("PID %d does not look like an agent-factory daemon; removing stale PID file", pid)
 		_ = os.Remove(pidFile)
-		return nil
+		return false, nil
 	}
 
 	// Send SIGTERM so the daemon's signal handler can SaveInstances() before
@@ -474,9 +480,9 @@ func StopDaemon() error {
 		if errIsProcessGone(err) {
 			log.InfoLog.Printf("daemon process (PID: %d) exited before SIGTERM landed; cleaning up", pid)
 			cleanupDaemonRuntimeFiles(pidFile)
-			return nil
+			return true, nil
 		}
-		return fmt.Errorf("failed to signal daemon process: %w", err)
+		return false, fmt.Errorf("failed to signal daemon process: %w", err)
 	}
 
 	// Poll for graceful exit.
@@ -495,13 +501,13 @@ func StopDaemon() error {
 	} else {
 		log.WarningLog.Printf("daemon process (PID: %d) did not exit within %s of SIGTERM; escalating to SIGKILL", pid, stopDaemonGrace)
 		if err := proc.Signal(syscall.SIGKILL); err != nil && !errIsProcessGone(err) {
-			return fmt.Errorf("failed to stop daemon process: %w", err)
+			return false, fmt.Errorf("failed to stop daemon process: %w", err)
 		}
 	}
 
 	cleanupDaemonRuntimeFiles(pidFile)
 	log.InfoLog.Printf("daemon process (PID: %d) stopped successfully", pid)
-	return nil
+	return true, nil
 }
 
 // cleanupDaemonRuntimeFiles removes the PID file and (best-effort) the control
@@ -563,6 +569,26 @@ func cmdlineHasDaemonFlag(cmdline string) bool {
 		}
 	}
 	return false
+}
+
+// cmdlineIsDaemonBinary reports whether the executable in cmdline is an
+// agent-factory daemon binary: installed as "af" or built from source
+// (`go build .`) as "agent-factory". The host-wide pgrep scan in
+// sigterm_fallback.go matches any process carrying a "--daemon" token, so this
+// restores the binary-name specificity that the old "af --daemon" substring
+// pattern provided — while still catching source-built `agent-factory --daemon`
+// daemons that the old pattern missed (#937).
+func cmdlineIsDaemonBinary(cmdline string) bool {
+	fields := strings.Fields(cmdline)
+	if len(fields) == 0 {
+		return false
+	}
+	switch filepath.Base(fields[0]) {
+	case "af", "agent-factory":
+		return true
+	default:
+		return false
+	}
 }
 
 // readProcCmdline returns the full command line for pid via /proc/<pid>/cmdline (Linux).

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -66,8 +66,12 @@ func TestStopDaemon_DoesNotKillUnrelatedPID(t *testing.T) {
 		t.Fatalf("failed to write PID file: %v", err)
 	}
 
-	if err := StopDaemon(); err != nil {
+	stopped, err := StopDaemon()
+	if err != nil {
 		t.Fatalf("StopDaemon returned error: %v", err)
+	}
+	if stopped {
+		t.Fatalf("StopDaemon reported stopped=true for an unrelated PID; expected false")
 	}
 
 	// Give the process a brief moment; if StopDaemon killed it (the bug), it will have exited.
@@ -83,13 +87,21 @@ func TestStopDaemon_DoesNotKillUnrelatedPID(t *testing.T) {
 	}
 }
 
-// TestStopDaemon_NoPIDFile verifies StopDaemon succeeds silently when there is no PID file.
+// TestStopDaemon_NoPIDFile verifies StopDaemon succeeds silently when there is
+// no PID file AND reports stopped=false so callers don't claim a phantom
+// success (#937). Pre-1.0.69 daemons write no PID file, so this no-op path is
+// exactly the case `af reset` must not describe as "daemon has been stopped".
+// Hermetic: a fresh temp config dir, no real daemon involved, nothing signaled.
 func TestStopDaemon_NoPIDFile(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
 
-	if err := StopDaemon(); err != nil {
+	stopped, err := StopDaemon()
+	if err != nil {
 		t.Fatalf("StopDaemon with no PID file should succeed, got: %v", err)
+	}
+	if stopped {
+		t.Fatalf("StopDaemon with no PID file should report stopped=false (did nothing), got true")
 	}
 }
 
@@ -108,8 +120,12 @@ func TestStopDaemon_NonExistentPID(t *testing.T) {
 		t.Fatalf("failed to write PID file: %v", err)
 	}
 
-	if err := StopDaemon(); err != nil {
+	stopped, err := StopDaemon()
+	if err != nil {
 		t.Fatalf("StopDaemon returned error for dead PID: %v", err)
+	}
+	if stopped {
+		t.Fatalf("StopDaemon reported stopped=true for a dead PID; expected false")
 	}
 
 	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
@@ -137,6 +153,34 @@ func TestCmdlineHasDaemonFlag(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := cmdlineHasDaemonFlag(tt.cmdline); got != tt.want {
 				t.Errorf("cmdlineHasDaemonFlag(%q) = %v, want %v", tt.cmdline, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCmdlineIsDaemonBinary verifies the host-wide pgrep scan keeps only
+// agent-factory daemon binaries — installed `af` or source-built
+// `agent-factory` — so broadening the pgrep pattern to a bare `--daemon` can't
+// claim an unrelated `--daemon` process (#937). Pure string logic; nothing is
+// signaled.
+func TestCmdlineIsDaemonBinary(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdline string
+		want    bool
+	}{
+		{name: "empty", cmdline: "", want: false},
+		{name: "installed af binary", cmdline: "/home/u/.local/bin/af --daemon", want: true},
+		{name: "source-built agent-factory binary", cmdline: "/home/u/src/agent-factory --daemon", want: true},
+		{name: "bare af in PATH", cmdline: "af --daemon", want: true},
+		{name: "bare agent-factory in PATH", cmdline: "agent-factory --daemon", want: true},
+		{name: "unrelated daemon", cmdline: "/usr/bin/dockerd --daemon", want: false},
+		{name: "lookalike suffix", cmdline: "/usr/bin/not-agent-factory --daemon", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cmdlineIsDaemonBinary(tt.cmdline); got != tt.want {
+				t.Errorf("cmdlineIsDaemonBinary(%q) = %v, want %v", tt.cmdline, got, tt.want)
 			}
 		})
 	}
@@ -190,8 +234,12 @@ func TestStopDaemon_SIGTERMFirst(t *testing.T) {
 	}
 
 	start := time.Now()
-	if err := StopDaemon(); err != nil {
+	stopped, err := StopDaemon()
+	if err != nil {
 		t.Fatalf("StopDaemon: %v", err)
+	}
+	if !stopped {
+		t.Fatalf("StopDaemon reported stopped=false after signaling a live fake daemon; expected true")
 	}
 	elapsed := time.Since(start)
 
@@ -288,8 +336,12 @@ func TestStopDaemon_EscalatesToSIGKILL(t *testing.T) {
 	}
 
 	start := time.Now()
-	if err := StopDaemon(); err != nil {
+	stopped, err := StopDaemon()
+	if err != nil {
 		t.Fatalf("StopDaemon: %v", err)
+	}
+	if !stopped {
+		t.Fatalf("StopDaemon reported stopped=false after signaling a live fake daemon; expected true")
 	}
 	elapsed := time.Since(start)
 
@@ -558,8 +610,12 @@ func TestStopDaemon_RefusesSelfPID(t *testing.T) {
 	}
 
 	// If StopDaemon killed us, the test binary would exit with signal: killed.
-	if err := StopDaemon(); err != nil {
+	stopped, err := StopDaemon()
+	if err != nil {
 		t.Fatalf("StopDaemon returned error: %v", err)
+	}
+	if stopped {
+		t.Fatalf("StopDaemon reported stopped=true for our own PID; expected false")
 	}
 
 	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {

--- a/daemon/sigterm_fallback.go
+++ b/daemon/sigterm_fallback.go
@@ -22,9 +22,11 @@ import (
 //  1. If ~/.config/agent-factory/daemon.pid exists, parse it. Verify the PID
 //     is alive AND its command line contains "--daemon" as a discrete token
 //     (defensive against PID reuse — the file may be stale).
-//  2. Otherwise (or if the PID file is missing), scan with `pgrep -f
-//     "af --daemon"`, filter out /tmp/Test* paths (Go test binaries) and the
-//     current process, and require exactly one candidate.
+//  2. Otherwise (or if the PID file is missing), scan with `pgrep -f --
+//     '--daemon'`, keep only processes whose binary is `af` or
+//     `agent-factory` (#937 — source builds run under the latter name),
+//     filter out /tmp/Test* paths (Go test binaries) and the current
+//     process, and require exactly one candidate.
 //
 // Returns ShutdownViaSIGTERM when a signal was delivered, or ShutdownFailed
 // with an actionable error when the daemon (which is provably running — the
@@ -36,14 +38,14 @@ func sigtermFallback() (ShutdownResult, error) {
 	pid, source, err := locateDaemonPID()
 	if err != nil {
 		return ShutdownFailed, fmt.Errorf(
-			"sigterm fallback failed: %w; run 'pkill -f \"af --daemon\"' to stop the old daemon manually before retrying `af upgrade`",
+			"sigterm fallback failed: %w; run \"pkill -f -- '--daemon'\" to stop the old daemon manually before retrying `af upgrade`",
 			err,
 		)
 	}
 	if pid == 0 {
 		return ShutdownFailed, fmt.Errorf(
 			"sigterm fallback: daemon is running on the control socket but no PID candidate was found (%s); "+
-				"run 'pkill -f \"af --daemon\"' to stop the old daemon manually before retrying `af upgrade`",
+				"run \"pkill -f -- '--daemon'\" to stop the old daemon manually before retrying `af upgrade`",
 			source,
 		)
 	}
@@ -51,7 +53,7 @@ func sigtermFallback() (ShutdownResult, error) {
 	log.InfoLog.Printf("sigterm fallback: signaling pre-#501 daemon (pid=%d source=%s)", pid, source)
 	if err := signalAndWait(pid); err != nil {
 		return ShutdownFailed, fmt.Errorf(
-			"sigterm fallback for daemon pid %d: %w; run 'pkill -f \"af --daemon\"' to stop the old daemon manually before retrying `af upgrade`",
+			"sigterm fallback for daemon pid %d: %w; run \"pkill -f -- '--daemon'\" to stop the old daemon manually before retrying `af upgrade`",
 			pid, err,
 		)
 	}
@@ -93,7 +95,7 @@ func locateDaemonPID() (int, string, error) {
 		return pids[0], "pgrep", nil
 	default:
 		return 0, "", fmt.Errorf(
-			"sigterm fallback: ambiguous, found %d `af --daemon` processes (%s) — "+
+			"sigterm fallback: ambiguous, found %d `--daemon` processes (%s) — "+
 				"kill the right one manually then re-run `af upgrade`",
 			len(pids), formatPIDList(pids),
 		)
@@ -166,17 +168,22 @@ var scanDaemonCandidatesFn = pgrepDaemonCandidates
 // daemon as absent (#553).
 var errPgrepUnavailable = errors.New("pgrep not found in PATH")
 
-// pgrepDaemonCandidates scans for processes whose full command line contains
-// "af --daemon", excluding Go test binaries living under /tmp/Test* and the
-// current process. We rely on pgrep -f rather than parsing /proc directly so
-// the path works on both Linux and macOS.
+// pgrepDaemonCandidates scans for processes whose full command line carries a
+// "--daemon" token, then keeps only those whose binary is `af` or
+// `agent-factory`. The `--` before the pattern stops pgrep from treating the
+// leading-dash pattern as a flag. We match the bare `--daemon` token rather
+// than "af --daemon" so source-built daemons running as `agent-factory
+// --daemon` are found too (#937); cmdlineIsDaemonBinary restores the
+// binary-name specificity the old substring gave. Go test binaries living
+// under /tmp/Test* and the current process are excluded. We rely on pgrep -f
+// rather than parsing /proc directly so the path works on both Linux and macOS.
 func pgrepDaemonCandidates() ([]int, error) {
 	pgrep, err := exec.LookPath("pgrep")
 	if err != nil {
 		log.WarningLog.Printf("sigterm fallback: pgrep not found in PATH; cannot scan for daemons: %v", err)
 		return nil, fmt.Errorf("%w: %v", errPgrepUnavailable, err)
 	}
-	out, err := exec.Command(pgrep, "-f", "af --daemon").Output()
+	out, err := exec.Command(pgrep, "-f", "--", "--daemon").Output()
 	if err != nil {
 		// pgrep exits 1 when there are no matches. Treat that as zero
 		// candidates rather than an error.
@@ -202,8 +209,10 @@ func pgrepDaemonCandidates() ([]int, error) {
 		}
 		// Defensive: re-read the cmdline and require it to (a) contain
 		// "--daemon" as a discrete token (pgrep -f does substring matching,
-		// not token matching) and (b) not be a Go test binary (these live
-		// under /tmp/Test... when invoked from `go test`).
+		// not token matching), (b) belong to an `af`/`agent-factory` binary so
+		// the broad `--daemon` pattern can't match an unrelated daemon (#937),
+		// and (c) not be a Go test binary (these live under /tmp/Test... when
+		// invoked from `go test`).
 		cmdline := readProcCmdline(pid)
 		if cmdline == "" {
 			cmdline = readPsArgs(pid)
@@ -212,6 +221,9 @@ func pgrepDaemonCandidates() ([]int, error) {
 			continue
 		}
 		if !cmdlineHasDaemonFlag(cmdline) {
+			continue
+		}
+		if !cmdlineIsDaemonBinary(cmdline) {
 			continue
 		}
 		if isTestBinaryCmdline(cmdline) {

--- a/daemon/sigterm_fallback_test.go
+++ b/daemon/sigterm_fallback_test.go
@@ -17,6 +17,21 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 )
 
+// assertBinaryAgnosticDaemonHint checks that a SIGTERM-fallback recovery
+// message points at a binary-name-agnostic kill command (#937). The old hint
+// `pkill -f "af --daemon"` does not match daemons built from source as
+// `agent-factory --daemon`, so we both require the new form and assert the
+// stale binary-specific one is gone.
+func assertBinaryAgnosticDaemonHint(t *testing.T, msg string) {
+	t.Helper()
+	if !strings.Contains(msg, `pkill -f -- '--daemon'`) {
+		t.Errorf("error %q missing binary-agnostic recovery hint `pkill -f -- '--daemon'`", msg)
+	}
+	if strings.Contains(msg, `pkill -f "af --daemon"`) {
+		t.Errorf("error %q still uses the binary-specific hint `pkill -f \"af --daemon\"`, which misses `agent-factory --daemon` (#937)", msg)
+	}
+}
+
 // TestWriteDaemonPIDFile_AtomicAndPermissions verifies that writing the PID
 // file produces a 0600 file containing the current process's PID (#504).
 func TestWriteDaemonPIDFile_AtomicAndPermissions(t *testing.T) {
@@ -335,9 +350,7 @@ func TestSigtermFallback_DeadPID(t *testing.T) {
 		t.Fatalf("sigtermFallback returned nil error for dead PID; expected one carrying the recovery hint")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, `pkill -f "af --daemon"`) {
-		t.Errorf("sigtermFallback error %q missing recovery hint with `pkill -f \"af --daemon\"`", msg)
-	}
+	assertBinaryAgnosticDaemonHint(t, msg)
 	if !strings.Contains(msg, strconv.Itoa(deadPID)) {
 		t.Errorf("sigtermFallback error %q missing stale PID-file pid=%d in source", msg, deadPID)
 	}
@@ -374,8 +387,8 @@ func TestSigtermFallback_AmbiguousCandidates(t *testing.T) {
 // proved the daemon is listening on the socket, but the fallback path has
 // no PID file to consult AND pgrep is unavailable. Returning ShutdownNoDaemon
 // would contradict the established state and leave the stale daemon running;
-// the fix is to return ShutdownFailed with an actionable error pointing at
-// `pkill -f "af --daemon"`.
+// the fix is to return ShutdownFailed with an actionable error pointing at a
+// binary-name-agnostic `pkill -f -- '--daemon'`.
 func TestSigtermFallback_NoPIDFileAndNoPgrep(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", home)
@@ -392,9 +405,7 @@ func TestSigtermFallback_NoPIDFileAndNoPgrep(t *testing.T) {
 		t.Fatalf("sigtermFallback returned nil error; expected one carrying the recovery hint")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, `pkill -f "af --daemon"`) {
-		t.Errorf("sigtermFallback error %q missing recovery hint with `pkill -f \"af --daemon\"`", msg)
-	}
+	assertBinaryAgnosticDaemonHint(t, msg)
 	if !strings.Contains(msg, "pgrep unavailable") {
 		t.Errorf("sigtermFallback error %q missing `pgrep unavailable` source", msg)
 	}

--- a/daemon/spawn_stop_race_test.go
+++ b/daemon/spawn_stop_race_test.go
@@ -83,7 +83,7 @@ func TestStopDaemon_PreservesNewDaemonSocket(t *testing.T) {
 		t.Fatalf("write PID file: %v", err)
 	}
 
-	if err := StopDaemon(); err != nil {
+	if _, err := StopDaemon(); err != nil {
 		t.Fatalf("StopDaemon: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -110,11 +110,20 @@ var (
 			log.Initialize(false)
 			defer log.Close()
 
-			// Kill any daemon that's running first.
-			if err := daemon.StopDaemon(); err != nil {
+			// Kill any daemon that's running first. StopDaemon only finds
+			// daemons that wrote a PID file; a pre-1.0.69 daemon leaves none,
+			// so only claim success when we actually stopped one (#937).
+			stopped, err := daemon.StopDaemon()
+			if err != nil {
 				return err
 			}
-			fmt.Println("daemon has been stopped")
+			if stopped {
+				fmt.Println("daemon has been stopped")
+			} else {
+				fmt.Println("No managed daemon was stopped (no PID file, or the recorded process was already gone). " +
+					"If an old daemon is still running (e.g. one built from source as `agent-factory --daemon`), " +
+					"stop it with: pkill -f -- '--daemon'")
+			}
 
 			// Clean up resources before deleting storage records
 			if err := tmux.CleanupSessions(cmdutil.MakeExecutor()); err != nil {


### PR DESCRIPTION
## Summary

Stopping an **old** daemon during `af upgrade` failed two ways for daemons built from source as `agent-factory --daemon` (`go build .`) rather than the installed `af` binary. Regression of #557.

### Defect 1 — wrong `pkill` guidance (and a matching scan bug)

The three SIGTERM-fallback error strings in `daemon/sigterm_fallback.go` told users to run `pkill -f "af --daemon"`. That is a contiguous-substring match and never matches `agent-factory --daemon`. All three now suggest:

```
pkill -f -- '--daemon'
```

The leading `--` stops pkill's flag parsing so the bare `--daemon` pattern is treated as the pattern (not an option) and matches **both** binary names.

While fixing the guidance I followed the adjacent-call-site audit and found the **pgrep scan that locates the daemon shared the same `af --daemon` pattern** — the actual reason the fallback could never find a source-built daemon (called out in the issue's history section). The scan now uses `pgrep -f -- '--daemon'`. To keep the broadened pattern safe, a new `cmdlineIsDaemonBinary` filter keeps only processes whose binary is `af` or `agent-factory`, restoring the binary-name specificity the old substring gave. The existing `--daemon`-discrete-token and test-binary filters are unchanged.

### Defect 2 — `af reset` lied about stopping the daemon

`af reset` printed `daemon has been stopped` unconditionally, but `StopDaemon()` returns `nil` silently when the PID file is absent (pre-1.0.69 daemons don't write one), so it claimed success having done nothing.

`StopDaemon()` now returns `(stopped bool, err error)`. `stopped` is `true` only when a live agent-factory daemon was actually signaled. `af reset` prints the success line only then; otherwise it prints an honest message:

> No managed daemon was stopped (no PID file, or the recorded process was already gone). If an old daemon is still running (e.g. one built from source as `agent-factory --daemon`), stop it with: `pkill -f -- '--daemon'`

## Chosen pkill form

`pkill -f -- '--daemon'` over listing both explicit patterns: one command covers every binary name (including non-`af`/`agent-factory` installs), and `--` is portable across procps-ng (Linux) and BSD/macOS pkill. The same form is used for the internal `pgrep` scan.

## Adjacent-call-site audit

- **pgrep scan** (`sigterm_fallback.go`) — fixed (above).
- **All `StopDaemon()` callers** updated for the new signature: `autostart.go` (linux/darwin handover) and `control.go` (`EnsureDaemon` stale-daemon stop) ignore the bool; only `af reset` consumes it.
- **`session/tmux/tmux.go` pgrep usage** — unrelated (matches tmux session names, not the daemon binary); left as-is.

## Tests (hermetic — no real daemon started, signaled, or `pkill`'d)

- `TestStopDaemon_NoPIDFile` now asserts `stopped == false` (the "did nothing" signal); dead-PID / self-PID / unrelated-PID paths assert `false`; SIGTERM/SIGKILL paths assert `true`.
- Guidance assertions require `pkill -f -- '--daemon'` **and** assert the old `pkill -f "af --daemon"` hint is gone.
- New `TestCmdlineIsDaemonBinary` covers the binary-name filter.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./daemon/ .` green.

Fixes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude