### PR TITLE
fix(ui): pad sidebar index to fixed width instead of trimming, preserving the dot and full number (#939)

### DIFF
--- a/ui/list.go
+++ b/ui/list.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -52,6 +53,14 @@ var deletingTitleColor = lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777
 type InstanceRenderer struct {
 	spinner *spinner.Model
 	width   int
+	// indexWidth is the number of digits to left-pad the 1-based row index to,
+	// so every row in a list shares one prefix width and the branch/PR lines
+	// stay aligned across power-of-10 boundaries (9→10, 99→100, …). The caller
+	// sets it to the digit count of the largest index in the list; a small list
+	// keeps the original single-digit prefix and pays no extra width. When it is
+	// 0 (or smaller than idx's own digit count) Render falls back to idx's width
+	// so the index is never truncated (#871, #923, #939).
+	indexWidth int
 }
 
 func (r *InstanceRenderer) setWidth(width int) {
@@ -62,16 +71,22 @@ func (r *InstanceRenderer) setWidth(width int) {
 const branchIcon = "Ꮧ"
 
 func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, hasMultipleRepos bool) string {
-	prefix := fmt.Sprintf(" %d. ", idx)
 	// Each extra digit grows the prefix by one cell, which shifts the
 	// len(prefix)-derived branch/PR indentation and misaligns adjacent visible
-	// rows at every power-of-10 boundary (9→10, 99→100, 999→1000, …). Trim one
-	// trailing space per extra digit tier so the prefix width holds steady at
-	// any magnitude — the app generates titles up to 10000, so 4-digit indices
-	// are reachable (#871, #923).
-	for tier := 10; tier <= idx; tier *= 10 {
-		prefix = prefix[:len(prefix)-1]
+	// rows at every power-of-10 boundary (9→10, 99→100, 999→1000, …). Left-pad
+	// the NUMBER (right-justified) to a width derived from the largest index in
+	// the list so every row's prefix is the same width while the dot and full
+	// index are always preserved. An earlier trim-loop (#923) held width by
+	// deleting the rightmost char per tier, which corrupted content — dropping
+	// the dot at idx≥100 and a digit at idx≥1000 (e.g. 1000 rendered as "100").
+	// Padding keeps the same alignment without eating content, and because the
+	// width tracks the list size a small list still renders the original
+	// single-digit prefix (#871, #923, #939).
+	digits := r.indexWidth
+	if d := len(strconv.Itoa(idx)); d > digits {
+		digits = d
 	}
+	prefix := fmt.Sprintf(" %*d. ", digits, idx)
 	titleS := selectedTitleStyle
 	descS := selectedDescStyle
 	if !selected {

--- a/ui/list_align_test.go
+++ b/ui/list_align_test.go
@@ -18,7 +18,9 @@ var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 // returns the number of leading whitespace cells in front of the "PR #" text.
 // The PR line is indented by strings.Repeat(" ", len(prefix)) plus a constant
 // style padding, so any idx-dependent change in the indent reflects a change
-// in the numbered prefix width (#871).
+// in the numbered prefix width (#871). indexWidth is pinned to 5 to model a
+// list large enough to contain idx=10000: every row in that list pads to 5
+// digits, so all indices must share one indent (#923).
 func prLineIndent(t *testing.T, idx int, spin *spinner.Model) int {
 	t.Helper()
 	inst, err := session.NewInstance(session.InstanceOptions{
@@ -30,7 +32,8 @@ func prLineIndent(t *testing.T, idx int, spin *spinner.Model) int {
 	inst.SetPRInfo(&git.PRInfo{Number: 42, Title: "do a thing", State: "OPEN"})
 
 	r := &InstanceRenderer{spinner: spin}
-	r.setWidth(60) // wide enough to render the full PR line
+	r.setWidth(60)   // wide enough to render the full PR line
+	r.indexWidth = 5 // model a list whose largest index is 10000 (5 digits)
 
 	out := r.Render(inst, idx, false, false)
 	for _, line := range strings.Split(out, "\n") {
@@ -56,6 +59,52 @@ func TestInstanceRendererPrefixAlignment(t *testing.T) {
 		require.Equalf(t, base, got,
 			"PR line indent at idx=%d (%d) must match idx=1 (%d); prefix width drifted",
 			idx, got, base)
+	}
+}
+
+// renderRow renders an instance at the given 1-based display index and returns
+// the ANSI-stripped rendered output.
+func renderRow(t *testing.T, idx int, spin *spinner.Model) string {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "feature",
+		Path:    t.TempDir(),
+		Program: "test",
+	})
+	require.NoError(t, err)
+
+	r := &InstanceRenderer{spinner: spin}
+	r.setWidth(60) // wide enough to render the full index prefix and title
+
+	out := r.Render(inst, idx, false, false)
+	return ansiEscape.ReplaceAllString(out, "")
+}
+
+// TestInstanceRendererPrefixContent guards against the regression in #939: the
+// trim-loop introduced by #923 held the prefix width constant by deleting the
+// rightmost char per digit tier, which corrupted content — the dot vanished at
+// idx≥100 and a digit at idx≥1000 ("1000" rendered as "100"). The fixed-width
+// pad must show the full index followed by a dot at every magnitude.
+func TestInstanceRendererPrefixContent(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+
+	for _, tc := range []struct {
+		idx  int
+		want string
+	}{
+		{1, "1. "},
+		{9, "9. "},
+		{99, "99. "},
+		{100, "100. "},
+		{999, "999. "},
+		{1000, "1000. "},
+		{9999, "9999. "},
+		{10000, "10000. "},
+	} {
+		out := renderRow(t, tc.idx, &spin)
+		require.Containsf(t, out, tc.want,
+			"rendered row for idx=%d must contain %q (full number + dot), got:\n%s",
+			tc.idx, tc.want, out)
 	}
 }
 

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -772,5 +773,9 @@ func (s *Sidebar) renderInstance(idx int, selected bool) string {
 	if idx < 0 || idx >= len(s.instances) {
 		return ""
 	}
+	// Pad the index to the digit width of the largest 1-based index in the list
+	// so every row's prefix is the same width and the branch/PR lines align,
+	// without widening the common small-list case (#871, #923, #939).
+	s.renderer.indexWidth = len(strconv.Itoa(len(s.instances)))
 	return s.renderer.Render(s.instances[idx], idx+1, selected, len(s.repos) > 1)
 }


### PR DESCRIPTION
## Problem

The numbered prefix in the session sidebar (`ui/list.go`, `InstanceRenderer.Render`) is rendered incorrectly for `idx >= 100`:

- `idx=100` / `idx=999`: the dot after the index disappears (`100` instead of `100.`)
- `idx=1000`: the number itself is wrong — it shows `100` instead of `1000`

### Root cause

The trim-loop introduced by #925/#923 kept the prefix a constant width by deleting the **rightmost character** once per digit tier:

```go
prefix := fmt.Sprintf(" %d. ", idx)
for tier := 10; tier <= idx; tier *= 10 {
    prefix = prefix[:len(prefix)-1] // eats the dot, then digits
}
```

That achieves constant width but corrupts content because the last character is the dot (then a digit), not padding:

- `idx=100`: `" 100. "` → `" 100."` → `" 100"` (dot removed)
- `idx=1000`: `" 1000. "` → `" 1000."` → `" 1000"` → `" 100"` (digit removed → wrong number)

## Fix

Pad the **number** instead of deleting content, using a right-justified fixed-width format:

```go
digits := r.indexWidth
if d := len(strconv.Itoa(idx)); d > digits {
    digits = d
}
prefix := fmt.Sprintf(" %*d. ", digits, idx)
```

The dot and every digit always survive. Right-justification keeps the dot adjacent to the number (matching how single digits already render) and keeps the dots aligned down the column.

### Width tracks the list, not a hardcoded max

`indexWidth` is the digit count of the **largest index actually in the list**, set once from `len(instances)` in `Sidebar.renderInstance`. This matters:

- A list with `< 10` sessions (the overwhelmingly common case) renders the original `" 1. "` prefix — **zero common-case regression**. A hardcoded `%5d` pad would instead steal 4 columns from *every* title at *every* width, truncating titles that previously fit and overflowing narrow terminals.
- A list with 100+/1000+ sessions widens the prefix only as far as needed, and because every row shares that one width the branch/PR indentation (`len(prefix)`) stays aligned across every power-of-10 boundary — the #923 alignment invariant is preserved.
- `Render` also floors the width at `idx`'s own digit count, so the index can never be truncated even if a caller leaves `indexWidth` unset.

## Tests

- The #923 alignment/boundary tests (`TestInstanceRendererPrefixAlignment` / `TestInstanceRendererPrefixBoundaries`) stay **green**. `prLineIndent` now pins `indexWidth=5` to model a 10000-row list, the faithful representation of the invariant: in a list large enough to reach idx=10000, every row 1..10000 shares one indent.
- New `TestInstanceRendererPrefixContent` asserts the rendered row contains the full number followed by `"."` at idx `1, 9, 99, 100, 999, 1000, 9999, 10000` — the content-correctness guard #939 is about. Under the old trim-loop, idx=1000 would render `100` and fail this test.

## Adjacent-call-site audit (per CLAUDE.md)

Grepped `ui/` for the same "trim a char to hold display width" anti-pattern — none found:

- `list.go` `len(prefix)` uses (branch/PR indent, `prMaxWidth`) are **consumers** of the prefix width, now constant per list — correct, not bugs.
- `terminal.go:424` / `preview.go:226` `lines[:len(lines)-1]` drop a trailing **empty** line (guarded by `== ""`).
- `hooks_pane.go:163` `runes[:len(runes)-1]` is backspace handling in an edit buffer.

The trim-loop was the only width-fit content-corruption site.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./...` — all green (including #923 alignment, new #939 content, #646 narrow-overflow, and the deleting-marker tests)

Fixes #939

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
