### PR TITLE
fix(app): mirror the daemon's case-insensitive title collision check in TUI naming (#936)

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
@@ -47,8 +48,13 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if other == instance {
 				continue
 			}
-			if other.Title == instance.Title {
-				return m, m.handleError(fmt.Errorf("a session titled %q already exists", instance.Title))
+			// Mirror the daemon's authoritative collision rule (git.TitlesCollide:
+			// case-insensitive equality OR same sanitized branch) so the naming
+			// flow rejects what the daemon would reject after submit, instead of
+			// only catching exact duplicates and deferring case/branch variants
+			// to a post-Start error (#936).
+			if git.TitlesCollide(other.Title, instance.Title, m.appConfig.BranchPrefix) {
+				return m, m.handleError(fmt.Errorf("a session titled %q conflicts with existing session %q", instance.Title, other.Title))
 			}
 		}
 		if instance.IsRemote() {

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -224,6 +224,53 @@ func TestHandleStateNewRejectsDuplicateTitle(t *testing.T) {
 	assert.Contains(t, h.errBox.String(), "fix-bug")
 }
 
+// TestHandleStateNewRejectsCaseVariantTitle covers #936: the naming pre-check
+// must reject a case variant of an existing title (e.g. "myapp" when "MyApp"
+// exists), mirroring the daemon's case-insensitive collision rule. Before the
+// fix the TUI compared titles with == and would accept this, only for the
+// daemon to reject it after submit.
+func TestHandleStateNewRejectsCaseVariantTitle(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing string
+		naming   string
+	}{
+		{name: "case variant (#605)", existing: "MyApp", naming: "myapp"},
+		{name: "space vs dash sanitize collision (#741)", existing: "fix bug", naming: "fix-bug"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			h.state = stateNew
+			h.errBox.SetSize(120, 1)
+
+			existing, err := session.NewInstance(session.InstanceOptions{
+				Title:   tc.existing,
+				Path:    t.TempDir(),
+				Program: "claude",
+			})
+			require.NoError(t, err)
+			h.sidebar.AddInstance(existing)
+
+			naming, err := session.NewInstance(session.InstanceOptions{
+				Title:   tc.naming,
+				Path:    t.TempDir(),
+				Program: "claude",
+			})
+			require.NoError(t, err)
+			h.namingInstance = naming
+
+			_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+
+			assert.Equal(t, stateNew, h.state, "naming flow must stay open on a collision")
+			require.NotNil(t, h.namingInstance, "naming instance must not be submitted")
+			assert.Equal(t, tc.naming, h.namingInstance.Title)
+			assert.Contains(t, h.errBox.String(), tc.existing,
+				"error must name the conflicting existing session")
+		})
+	}
+}
+
 func TestHandleStateNewRejectsRemoteSlugCollision(t *testing.T) {
 	h := newTestHome(t)
 	h.state = stateNew

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1074,23 +1074,18 @@ func (m *Manager) findTitleConflictLocked(repoID, title string, diskData []sessi
 }
 
 // titlesCollide reports whether two session titles cannot coexist in the same
-// repo because they would derive the same git branch. Exact (case-insensitive)
-// duplicates always collide; beyond that, the titles collide when they sanitize
-// to the same branch name (e.g. "A B" and "a-b" -> "af-a-b"). The EqualFold
-// guard also covers titles made only of unsafe characters, whose sanitized
-// branch is a random fallback that would otherwise never compare equal.
+// repo because they would derive the same git branch. It delegates to the shared
+// git.TitlesCollide helper so the daemon's authoritative validation and the
+// TUI's naming pre-check stay in lockstep (#936).
 func (m *Manager) titlesCollide(a, b string) bool {
-	if strings.EqualFold(a, b) {
-		return true
-	}
-	return m.branchForTitle(a) == m.branchForTitle(b)
+	return git.TitlesCollide(a, b, m.cfg.BranchPrefix)
 }
 
 // branchForTitle derives the git branch name for a session title using the same
 // prefix and sanitization the git worktree layer applies, so the daemon can
 // detect branch collisions before worktree setup runs.
 func (m *Manager) branchForTitle(title string) string {
-	return git.SanitizeBranchName(m.cfg.BranchPrefix + title)
+	return git.BranchForTitle(m.cfg.BranchPrefix, title)
 }
 
 func (m *Manager) KillSession(req KillSessionRequest) error {

--- a/session/git/util.go
+++ b/session/git/util.go
@@ -72,6 +72,33 @@ func SanitizeBranchName(s string) string {
 	return s
 }
 
+// BranchForTitle derives the git branch name a session title would receive,
+// applying the same prefix + sanitization the worktree layer uses when it
+// actually creates the branch (see worktree.go's "<prefix><title>" ->
+// SanitizeBranchName). Exported so both the daemon's authoritative create-time
+// validation and the TUI's pre-submit naming check derive branches identically.
+func BranchForTitle(branchPrefix, title string) string {
+	return SanitizeBranchName(branchPrefix + title)
+}
+
+// TitlesCollide reports whether two session titles cannot coexist in the same
+// repo because they would derive the same git branch. Exact (case-insensitive)
+// duplicates always collide (#605); beyond that, titles collide when they
+// sanitize to the same branch name, e.g. "A B" and "a-b" -> "af-a-b" (#741).
+// The EqualFold guard also covers titles made only of unsafe characters, whose
+// sanitized branch is a random fallback that would otherwise never compare
+// equal.
+//
+// This is the single source of truth for title collisions: the daemon calls it
+// at create time and the TUI calls it in its naming pre-check, so the two can
+// never drift apart again (#936).
+func TitlesCollide(a, b, branchPrefix string) bool {
+	if strings.EqualFold(a, b) {
+		return true
+	}
+	return BranchForTitle(branchPrefix, a) == BranchForTitle(branchPrefix, b)
+}
+
 // randomHex returns a hex string of n random bytes (2n hex characters).
 func randomHex(n int) string {
 	b := make([]byte, n)

--- a/session/git/util_test.go
+++ b/session/git/util_test.go
@@ -156,6 +156,56 @@ func TestSanitizeBranchName_FallbackIsUnique(t *testing.T) {
 	}
 }
 
+func TestBranchForTitle(t *testing.T) {
+	if got := BranchForTitle("af-", "MyApp"); got != "af-myapp" {
+		t.Errorf("BranchForTitle(\"af-\", \"MyApp\") = %q, want %q", got, "af-myapp")
+	}
+	if got := BranchForTitle("af-", "A B"); got != "af-a-b" {
+		t.Errorf("BranchForTitle(\"af-\", \"A B\") = %q, want %q", got, "af-a-b")
+	}
+	if got := BranchForTitle("", "feature"); got != "feature" {
+		t.Errorf("BranchForTitle(\"\", \"feature\") = %q, want %q", got, "feature")
+	}
+}
+
+// TestTitlesCollide pins the shared collision rule used by both the daemon's
+// authoritative create-time check and the TUI's naming pre-check (#936). The
+// rule is: case-insensitive equality OR sanitize-to-the-same-branch.
+func TestTitlesCollide(t *testing.T) {
+	tests := []struct {
+		name   string
+		a      string
+		b      string
+		prefix string
+		want   bool
+	}{
+		{name: "exact match collides", a: "myapp", b: "myapp", prefix: "af-", want: true},
+		{name: "case variant collides (#605)", a: "MyApp", b: "myapp", prefix: "af-", want: true},
+		{name: "uppercase vs mixed case collides", a: "MYAPP", b: "MyApp", prefix: "af-", want: true},
+		{name: "space vs dash sanitize collision (#741)", a: "a b", b: "a-b", prefix: "af-", want: true},
+		{name: "space-and-case sanitize collision", a: "My App", b: "my-app", prefix: "af-", want: true},
+		{name: "distinct names do not collide", a: "alpha", b: "beta", prefix: "af-", want: false},
+		{name: "substring is not a collision", a: "app", b: "myapp", prefix: "af-", want: false},
+		// With an empty prefix, unsafe-only titles sanitize to a random
+		// "session-<hex>" fallback that never compares equal across calls. The
+		// EqualFold guard is what still makes two identical such titles collide,
+		// and keeps two different ones from colliding by accident.
+		{name: "identical unsafe-only titles collide via EqualFold guard", a: "!!!", b: "!!!", prefix: "", want: true},
+		{name: "distinct unsafe-only titles do not collide via random fallback", a: "!!!", b: "???", prefix: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TitlesCollide(tt.a, tt.b, tt.prefix); got != tt.want {
+				t.Errorf("TitlesCollide(%q, %q, %q) = %v, want %v", tt.a, tt.b, tt.prefix, got, tt.want)
+			}
+			// Collision is symmetric.
+			if got := TitlesCollide(tt.b, tt.a, tt.prefix); got != tt.want {
+				t.Errorf("TitlesCollide(%q, %q, %q) = %v, want %v (symmetry)", tt.b, tt.a, tt.prefix, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestEnsureRepo_DistinguishesMissingGit verifies the #737 fix: when git is not
 // on PATH, EnsureRepo reports a "git is not installed" error rather than the
 // misleading "must be run from within a git repository" message.


### PR DESCRIPTION
## Problem

The TUI's new-session naming pre-check (`handleStateNew` in `app/handle_input.go`) compared titles with case-sensitive `==`:

```go
if other.Title == instance.Title { ...already exists... }
```

That check exists to give a clean error *in the naming flow* rather than after Start (commit 8811c8e, #435). But the daemon's authoritative validation (`daemon/control.go`) is case-**insensitive** and *also* rejects titles that sanitize to the same git branch:

```go
func (m *Manager) titlesCollide(a, b string) bool {
    if strings.EqualFold(a, b) { return true }          // #605
    return m.branchForTitle(a) == m.branchForTitle(b)   // #741: "A B" / "a-b"
}
```

So the TUI accepted `myapp` when `MyApp` existed (and `fix bug` when `fix-bug` existed), only for the daemon to reject it after submit — exactly the post-Start error the pre-check was designed to prevent. The mismatch crept in when the daemon went case-insensitive (#605) and the TUI was never updated to match.

## Fix — one shared collision helper

Factor a single source of truth into `session/git` (which already owns branch-name sanitization, so both `app` and `daemon` import it with no cycle):

```go
func BranchForTitle(branchPrefix, title string) string
func TitlesCollide(a, b, branchPrefix string) bool   // EqualFold(a,b) || same sanitized branch
```

- **Daemon** `titlesCollide`/`branchForTitle` now delegate to `git.TitlesCollide`/`git.BranchForTitle` — same behavior, proving parity.
- **TUI** naming validation calls `git.TitlesCollide(other.Title, instance.Title, m.appConfig.BranchPrefix)` in place of `==`, and the error now names the conflicting session.

Because both call sites share one implementation, they can't drift apart again.

## Adjacent-call-site audit (per CLAUDE.md)

Grepped `.Title ==`, `EqualFold`, `branchForTitle`, `SanitizeBranchName` across `app/`, `daemon/`, `session/`, `ui/`:

- **Collision checks** (two titles can't coexist): only the daemon `titlesCollide` and the TUI naming pre-check. Both now route through `git.TitlesCollide`. ✅
- **All other `.Title ==`** (`app/handle_actions.go`, `daemon/control.go:1316/1463/1486`, `session/storage.go`, `ui/sidebar.go`, `daemon/taskrun.go`, `session/backend_hook.go`) are exact *identity lookups* — "find the session whose title is X" against an already-uniqued set. Exact match is correct there; not a collision check.
- **Remote slug collision** (`session.FindSlugCollision`/`Slugify`) is a separate namespace (remote hook names) with its own helper — intentionally kept separate.
- **`SanitizeBranchName` direct callers**: `worktree.go` (the actual branch creation the helper mirrors) and the new helper itself.

## Tests (hermetic)

- `session/git`: `TestTitlesCollide` (exact, case-variant, `a b`/`a-b` branch-sanitize collision, distinct names, substring non-collision, EqualFold fallback guard, symmetry) and `TestBranchForTitle`.
- `app`: `TestHandleStateNewRejectsCaseVariantTitle` — the naming flow now rejects a case variant (`myapp` vs `MyApp`) and a sanitize collision (`fix bug` vs `fix-bug`) that the old `==` check accepted, and stays open with an error naming the conflict.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./app/... ./daemon/... ./session/...` green.

Fixes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude
