### PR TITLE
fix(session): TUI overwrites corrupted instances.json on save so quit isn't blocked (#938)

### DIFF
--- a/app/quit_corruption_test.go
+++ b/app/quit_corruption_test.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleQuit_ReachesQuitWithCorruptedInstances is the app-level half of
+// sachiniyer/agent-factory#938. Both `q` and `Ctrl+C` route through
+// handleQuit, which saves session state before exiting and returns early
+// (showing an error overlay, no tea.Quit) on save failure. Before the fix, a
+// corrupted instances.json made the save fail every time, so the user could
+// never quit cleanly — force-kill was the only escape.
+//
+// With the TUI save path now overwriting unparseable disk state (mirroring the
+// daemon), handleQuit's save succeeds and it must return a tea.Quit command,
+// not an error overlay.
+func TestHandleQuit_ReachesQuitWithCorruptedInstances(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(500, 1)
+
+	// Corrupt instances.json mid-session: successfully readable bytes that fail
+	// json.Unmarshal (not a read error). newTestHome redirects
+	// AGENT_FACTORY_HOME, so this writes to the same hermetic file the home's
+	// storage reads back.
+	require.NoError(t, config.DefaultState().SaveInstances(h.repoID, []byte(`{not valid json`)))
+
+	_, cmd := h.handleQuit()
+
+	require.NotNil(t, cmd, "handleQuit must return a command even with corrupted instances.json")
+	msg := cmd()
+	_, isQuit := msg.(tea.QuitMsg)
+	assert.True(t, isQuit, "handleQuit must reach tea.Quit (got %T) instead of trapping the user in an error loop (#938)", msg)
+	assert.Empty(t, strings.TrimSpace(h.errBox.String()), "a recoverable corruption must not surface a blocking error overlay")
+}

--- a/session/storage.go
+++ b/session/storage.go
@@ -268,7 +268,14 @@ func (s *Storage) saveRepoInstances(instances []*Instance) error {
 		var diskData []InstanceData
 		if raw != nil && string(raw) != "[]" && string(raw) != "null" {
 			if err := json.Unmarshal(raw, &diskData); err != nil {
-				return fmt.Errorf("failed to parse existing instances for repo %s: %w", s.repoID, err)
+				// Corruption is recoverable session state, not a reason to
+				// trap the user: mirror the daemon's SaveInstances branch and
+				// overwrite the unparseable file with in-memory state. A parse
+				// failure here previously aborted the save, and since both quit
+				// keys route through handleQuit (which returns early without
+				// tea.Quit on save error), it left the TUI unable to exit (#938).
+				log.WarningLog.Printf("failed to parse existing instances for repo %s, overwriting: %v", s.repoID, err)
+				diskData = nil
 			}
 		}
 

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -348,6 +348,59 @@ func TestRepoSaveAbortsOnReadError(t *testing.T) {
 		"on-disk session data must be preserved when the existing file cannot be read (#766)")
 }
 
+// TestRepoSaveOverwritesCorruptedInstances verifies that when instances.json
+// becomes corrupted mid-session (unparseable JSON, NOT a read error), the TUI
+// save path recovers by warning and overwriting with in-memory state instead
+// of returning an error. A returned error would propagate up through
+// handleQuit, which aborts the quit (no tea.Quit) on save failure — trapping
+// the user in an infinite error loop with force-kill the only escape (#938).
+// This mirrors the daemon's SaveInstances corruption recovery exactly.
+func TestRepoSaveOverwritesCorruptedInstances(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	repoID := config.RepoIDFromRoot(repoPath)
+	ms := newMockStorage()
+
+	// Disk holds garbage that fails json.Unmarshal — not a read error, but a
+	// successfully-read-yet-unparseable file (corruption mid-session).
+	ms.data[repoID] = json.RawMessage(`{not valid json`)
+
+	// Alive so the #819 dead-and-disk-missing drop doesn't remove it once the
+	// corrupted disk is treated as empty.
+	inMem := makeAliveInstance("in-memory", repoPath)
+	storage, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{inMem})
+	require.NoError(t, err, "corrupted instances.json must not block the save (and thus quit) — it should be overwritten (#938)")
+
+	// In-memory state must now be persisted over the corruption.
+	result := readDisk(t, ms, repoPath)
+	require.Len(t, result, 1, "in-memory instance should be written over the corrupted file")
+	assert.Equal(t, "in-memory", result[0].Title)
+}
+
+// TestDaemonSaveOverwritesCorruptedInstances is the adjacent-call-site mirror
+// of the TUI test above: the daemon path already recovered from corruption,
+// and this pins that behavior so the two save paths stay in lockstep (#938).
+func TestDaemonSaveOverwritesCorruptedInstances(t *testing.T) {
+	const repoPath = "/tmp/test-repo"
+	repoID := config.RepoIDFromRoot(repoPath)
+	ms := newMockStorage()
+
+	ms.data[repoID] = json.RawMessage(`{not valid json`)
+
+	inMem := makeAliveInstance("in-memory", repoPath)
+	storage, err := NewStorage(ms, "") // daemon mode (empty repoID)
+	require.NoError(t, err)
+
+	err = storage.SaveInstances([]*Instance{inMem})
+	require.NoError(t, err, "daemon must overwrite corrupted instances.json rather than abort")
+
+	result := readDisk(t, ms, repoPath)
+	require.Len(t, result, 1)
+	assert.Equal(t, "in-memory", result[0].Title)
+}
+
 func TestDaemonSaveNoInstances(t *testing.T) {
 	ms := newMockStorage()
 


### PR DESCRIPTION
## Problem

If `instances.json` becomes corrupted mid-session, the TUI **cannot quit**. The save-on-quit path `saveRepoInstances` (`session/storage.go`) returned an error on `json.Unmarshal` failure of the existing disk file. Both `q` and `Ctrl+C` route through `handleQuit` (`app/app.go`), which returns early **without** calling `tea.Quit` on save error:

```go
if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
    return m, m.handleError(err)   // no tea.Quit — user stuck
}
```

So the user is trapped in an infinite error loop, with force-kill from another terminal the only escape. Regression of #434 (introduced when the read-merge-write pattern was added to the TUI path but with error-return semantics instead of the daemon's warn-and-continue).

## Fix

The **daemon** path (`SaveInstances`, same file) already recovers from identical corruption by logging a warning and overwriting (`diskData = nil`). This makes the TUI `saveRepoInstances` match it **exactly**: on an unmarshal/parse error of the existing disk data, warn and treat disk state as empty so in-memory state is written over the corruption and the save succeeds — letting `handleQuit` reach `tea.Quit`.

Scope, deliberately narrow:
- **Only** the parse/unmarshal error becomes warn-and-overwrite. Real read errors (#766) and write/marshal errors still abort the save unchanged — recovery is **not** broadened to write errors.
- Touches `instances.json` persistence only (recoverable session state). The `config.json` tripwire/materialization safety (#837) is a different file and code path, untouched here.

## Adjacent-call-site audit

- Daemon `SaveInstances` and TUI `saveRepoInstances` now handle unmarshal errors identically (warn + `diskData = nil`).
- `handleQuit` reaches `tea.Quit` after the now-successful save.
- Both quit keys (`q`, `ctrl+c`) route through `handleQuit` and exit cleanly even with pre-corrupted `instances.json`.

## Tests (all hermetic, tempdir-scoped `AGENT_FACTORY_HOME`)

- `TestRepoSaveOverwritesCorruptedInstances` — TUI path: corrupted disk → save succeeds and overwrites with in-memory state.
- `TestDaemonSaveOverwritesCorruptedInstances` — mirror, pinning the daemon's existing recovery so the two paths stay in lockstep.
- `TestHandleQuit_ReachesQuitWithCorruptedInstances` — app-level: with a corrupted `instances.json`, `handleQuit` returns a `tea.Quit` command, not an error overlay.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./session/... ./app/...` green · `GOFLAGS="-p=1" go test -race -parallel 2 ./app/...` green.

Fixes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude