### PR TITLE
fix(app): surface task-save failures and keep TaskPane consistent with disk (#934)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
@@ -544,8 +545,13 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *home) handleQuit() (tea.Model, tea.Cmd) {
-	// Save any dirty task/hooks state
-	m.saveContentPaneState()
+	// Save any dirty task/hooks state. On failure the panes were reloaded to
+	// match disk; abort the quit and surface the error (mirroring the
+	// SaveInstances path below) so the user sees the dropped edit instead of
+	// losing it silently on the way out.
+	if err := m.saveContentPaneState(); err != nil {
+		return m, m.handleError(err)
+	}
 
 	if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
 		return m, m.handleError(err)
@@ -555,8 +561,20 @@ func (m *home) handleQuit() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
-// saveContentPaneState persists any changes from the task/hooks panes.
-func (m *home) saveContentPaneState() {
+// saveContentPaneState persists any changes from the task/hooks panes and
+// returns a non-nil error if any task persist operation failed.
+//
+// Recovery semantics on a task-save failure (#934): we reload BOTH the sidebar
+// and the TaskPane from disk so the two panes always agree and always reflect
+// the committed on-disk state — never a mix of stale in-memory edits in one
+// pane and disk state in the other. Reloading clears the TaskPane's dirty flag,
+// which means a failed edit is discarded rather than left dangling; we
+// therefore return the error so callers surface it (via handleError) and the
+// dropped edit is never silent. We deliberately do NOT keep dirty=true for an
+// in-place retry: after the reload the in-memory edits are gone, so a lingering
+// dirty flag would point at nothing. The user re-applies the edit from a
+// known-consistent state instead.
+func (m *home) saveContentPaneState() error {
 	hp := m.contentPane.HooksPane()
 	if hp.IsDirty() {
 		// Hook edits are written to the in-repo .agent-factory/config.json —
@@ -572,26 +590,39 @@ func (m *home) saveContentPaneState() {
 	}
 
 	sp := m.contentPane.TaskPane()
-	if sp.IsDirty() {
-		for _, tsk := range sp.GetTasks() {
-			if err := task.UpdateTask(tsk); err != nil {
-				log.ErrorLog.Printf("failed to update task: %v", err)
-			}
-		}
-		for _, tsk := range sp.ConsumeDeleted() {
-			if err := task.RemoveTask(tsk.ID); err != nil {
-				log.ErrorLog.Printf("failed to remove task: %v", err)
-			}
-		}
-		// Schedules live in the daemon (#782): a single reload poke after
-		// the batched writes brings its cron entries in sync.
-		reloadDaemonTaskSchedules()
-		// Refresh sidebar
-		tasks, err := task.LoadTasksForCurrentRepo()
-		if err == nil {
-			m.sidebar.SetTasks(tasks)
+	if !sp.IsDirty() {
+		return nil
+	}
+
+	// Collect every persist failure instead of swallowing them: a partial
+	// failure must still surface so the user knows their edit didn't fully
+	// land (matches api/tasks.go, which propagates these errors).
+	var saveErr error
+	for _, tsk := range sp.GetTasks() {
+		if err := task.UpdateTask(tsk); err != nil {
+			log.ErrorLog.Printf("failed to update task: %v", err)
+			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save task %q: %w", tsk.Name, err))
 		}
 	}
+	for _, tsk := range sp.ConsumeDeleted() {
+		if err := task.RemoveTask(tsk.ID); err != nil {
+			log.ErrorLog.Printf("failed to remove task: %v", err)
+			saveErr = errors.Join(saveErr, fmt.Errorf("failed to remove task %q: %w", tsk.Name, err))
+		}
+	}
+	// Schedules live in the daemon (#782): a single reload poke after
+	// the batched writes brings its cron entries in sync.
+	reloadDaemonTaskSchedules()
+	// Reload BOTH panes from disk so the TaskPane and sidebar can never diverge
+	// (#934): whatever actually committed, both panes now show it.
+	tasks, err := task.LoadTasksForCurrentRepo()
+	if err == nil {
+		m.sidebar.SetTasks(tasks)
+		sp.SetTasks(tasks)
+	} else {
+		saveErr = errors.Join(saveErr, fmt.Errorf("failed to reload tasks after save: %w", err))
+	}
+	return saveErr
 }
 
 // reloadDaemonTaskSchedulesFn is indirected so TUI tests can observe the poke

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -168,9 +168,12 @@ func (m *home) handleContentPaneFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 		return m, nil, false
 	}
 
-	// If focus was released (Esc), save state
+	// If focus was released (Esc), save state. A failed save reloads both panes
+	// to match disk and is surfaced inline so the dropped edit isn't silent.
 	if !m.contentPane.HasFocus() {
-		m.saveContentPaneState()
+		if err := m.saveContentPaneState(); err != nil {
+			return m, m.handleError(err), true
+		}
 	}
 
 	// Check if a new task was submitted via the inline form
@@ -181,8 +184,12 @@ func (m *home) handleContentPaneFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 		// handleTaskCreate writes the new task to disk and then reloads
 		// every task via SetTasks, which clears the dirty flag and any
 		// unsaved toggle/edit/delete. Flush those changes first so the
-		// reload picks them up (#578).
-		m.saveContentPaneState()
+		// reload picks them up (#578). If that flush fails, surface it and
+		// skip the create: the pending toggle/edit didn't persist, so we
+		// don't want handleTaskCreate's reload to silently discard it (#934).
+		if err := m.saveContentPaneState(); err != nil {
+			return m, m.handleError(err), true
+		}
 		return m, m.handleTaskCreate(), true
 	}
 	if sp.HasPendingTrigger() {

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -143,4 +144,101 @@ func TestHandleContentPaneFocus_PendingCreateFlushesDirtyTaskState(t *testing.T)
 	assert.False(t, found.Enabled,
 		"toggle must be persisted to disk before handleTaskCreate reloads "+
 			"(regression for #578: handler now calls saveContentPaneState first)")
+}
+
+// TestHandleContentPaneFocus_ValidationFailureLeavesTaskPaneStale is the
+// regression guard for #934.
+//
+// The bug: saveContentPaneState swallowed task.UpdateTask/RemoveTask errors
+// (log-only), cleared the TaskPane's dirty flag unconditionally via
+// ConsumeDeleted, and reloaded ONLY the sidebar from disk. On a save failure
+// the user's edit was silently dropped, the TaskPane kept stale in-memory
+// state while the sidebar showed disk state (divergence), and dirty was
+// cleared so the user couldn't tell anything went wrong.
+//
+// The fix's chosen recovery semantics (documented on saveContentPaneState):
+// reload BOTH panes from disk so they can never diverge, and surface the
+// persist failure via handleError so the dropped edit is never silent. We do
+// NOT keep dirty=true — after reloading from disk the in-memory edit is gone,
+// so a lingering dirty flag would point at nothing.
+//
+// We inject a real UpdateTask failure by making the config dir unwritable
+// after seeding: the file-lock/atomic-write both need to create files in that
+// dir, so the persist fails, while reads (LoadTasksForCurrentRepo) still
+// succeed and return the committed disk state.
+func TestHandleContentPaneFocus_ValidationFailureLeavesTaskPaneStale(t *testing.T) {
+	h := newTestHome(t)
+
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+
+	// Seed an existing, enabled task on disk and load it into the TaskPane.
+	existing := task.Task{
+		ID:          "existing-934",
+		Name:        "nightly",
+		Prompt:      "do something",
+		CronExpr:    "* * * * *",
+		ProjectPath: repo.Root,
+		Program:     "claude",
+		Enabled:     true,
+		CreatedAt:   time.Now(),
+	}
+	require.NoError(t, task.AddTask(existing))
+
+	loaded, err := task.LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	tp := h.contentPane.TaskPane()
+	tp.SetTasks(loaded)
+	h.sidebar.SetTasks(loaded)
+	h.contentPane.SetMode(ui.ContentModeTasks)
+	tp.SetFocus(true)
+	h.errBox.SetSize(500, 1)
+
+	// User presses 'x' to toggle the task off — dirty in memory, not yet saved.
+	_, _, consumed := h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	require.True(t, consumed, "'x' must route through the focus handler")
+	require.True(t, tp.IsDirty(), "toggle must mark the pane dirty")
+	require.False(t, tp.GetTasks()[0].Enabled, "in-memory state reflects the toggle")
+
+	// Make the persist fail: strip write permission from the config dir so the
+	// file lock / atomic write that UpdateTask performs cannot create files,
+	// while existing files stay readable (read+execute bits retained).
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(configDir, 0o500))
+	// Restore before the tempdir cleanup so RemoveAll can delete the dir.
+	t.Cleanup(func() { _ = os.Chmod(configDir, 0o700) })
+
+	// Pressing Esc releases focus, which triggers saveContentPaneState. The
+	// UpdateTask write fails; the handler surfaces it via handleError.
+	_, cmd, consumed := h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyEsc})
+	require.True(t, consumed, "Esc must route through the focus handler")
+	require.NotNil(t, cmd, "a failed save must return an error-surfacing command")
+
+	// (a) The user is notified — the failure is surfaced inline, not swallowed.
+	assert.NotEmpty(t, h.errBox.String(),
+		"BUG: save failure must be surfaced to the user, not silently swallowed")
+
+	// (b) TaskPane and sidebar agree, and both reflect committed disk state.
+	disk, err := task.LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	require.Len(t, disk, 1)
+	assert.True(t, disk[0].Enabled,
+		"the failed write must not have changed disk: it still holds the pre-toggle value")
+	require.Len(t, tp.GetTasks(), 1)
+	assert.True(t, tp.GetTasks()[0].Enabled,
+		"BUG: TaskPane must reload from disk after a failed save, not keep its stale toggle")
+	require.Len(t, h.sidebar.GetTasks(), 1)
+	assert.True(t, h.sidebar.GetTasks()[0].Enabled,
+		"sidebar must agree with the TaskPane (both reflect disk)")
+
+	// (c) State is not left silently "saved": reloading cleared dirty, but the
+	// error surfaced above means the user knows the edit was dropped. A
+	// lingering dirty flag would point at edits the reload already discarded.
+	assert.False(t, tp.IsDirty(),
+		"reloading from disk clears dirty; the dropped edit is communicated via the error, not a dangling dirty flag")
 }


### PR DESCRIPTION
Fixes #934.

## Problem

`saveContentPaneState` had no error-recovery path. It:
- swallowed `task.UpdateTask` / `task.RemoveTask` errors (log-only),
- cleared the TaskPane's dirty flag unconditionally via `ConsumeDeleted`,
- reloaded **only** the sidebar from disk — not the TaskPane.

So on a save failure the user's edit was silently dropped, the TaskPane kept
stale in-memory state while the sidebar showed disk state (the two panes
diverged), and `dirty` was cleared so the user got no signal that anything
went wrong.

## Fix — coherent recovery semantics

Documented on `saveContentPaneState`:

1. **Don't swallow errors.** Accumulate a non-nil error across every
   `UpdateTask`/`RemoveTask` failure (and a failed reload). This matches
   `api/tasks.go`'s `tasksUpdateCmd`, which already propagates these errors.
2. **Reload BOTH panes from disk** (`m.sidebar.SetTasks` **and**
   `sp.SetTasks`) so the TaskPane and sidebar can never diverge — both always
   reflect committed on-disk state.
3. **Surface the failure.** `saveContentPaneState` now returns the error;
   callers route it through `handleError`. `handleQuit` aborts the quit on
   failure, mirroring the existing `SaveInstances` path.

### Reconciling consistency-vs-retry

The reload clears the dirty flag, so the dropped edit is communicated through
the **inline error**, not a dangling `dirty=true`. Keeping `dirty=true` after
reloading from disk would point at edits the reload already discarded — that
would be incoherent. The user re-applies the edit from a known-consistent
state. This trade-off is documented in a comment.

## Adjacent-call-site audit (per CLAUDE.md)

- `UpdateTask`/`RemoveTask` swallowed-error sites: only `saveContentPaneState`.
  `api/tasks.go` (lines 174, 332) already propagate via `jsonError()`. Daemon
  sites use `UpdateTaskStatus` (a different, status-only path) and handle/log
  appropriately.
- Reload-one-pane-not-the-other sites: only the bug site. `handleTaskCreate`
  (`app.go:667`) and startup (`app.go:207/212`) already reload both panes.

No other offenders.

## Regression test

`TestHandleContentPaneFocus_ValidationFailureLeavesTaskPaneStale` (the test
named in the issue) injects a real `UpdateTask` failure by making the config
dir unwritable after seeding (writes fail at the file-lock/atomic-write;
reads still succeed). It asserts: (a) the user is notified (errBox non-empty
+ error-surfacing command returned), (b) TaskPane and sidebar agree and both
reflect disk, (c) state is not left silently "saved". Verified to fail against
the pre-fix source and pass with the fix.

## Verification (hermetic; no dev-install)

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./app/...` — green
- `GOFLAGS="-p=1" go test -race -parallel 2 ./app/...` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude