### PR TITLE
fix(app): give feedback when attaching to a dead session and stop labeling it Ready (#935)

### DIFF
--- a/app/dead_session_test.go
+++ b/app/dead_session_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// deadBackend is a FakeBackend whose IsAlive reports false, simulating a tmux
+// (or remote) session that has vanished out from under the TUI — the #935
+// scenario. HasUpdated inherits FakeBackend's (false,false), the same value a
+// healthy idle session returns, so it exercises the exact ambiguity the fix
+// has to resolve via the liveness probe.
+type deadBackend struct {
+	*session.FakeBackend
+}
+
+func (b *deadBackend) IsAlive(*session.Instance) bool { return false }
+
+// newDeadInstance returns a started instance backed by deadBackend with the
+// given starting status. It does not spin up tmux/git, so it is hermetic.
+func newDeadInstance(t *testing.T, title string, status session.Status) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	inst.SetBackend(&deadBackend{FakeBackend: session.NewFakeBackend()})
+	inst.SetStartedForTest(true)
+	inst.SetStatus(status)
+	return inst
+}
+
+// TestHandleEnter_DeadSessionShowsError is the primary #935 guard: pressing
+// Enter on a session whose backing tmux session is gone must surface an
+// actionable error rather than silently swallowing the keypress (which left the
+// user unsure whether Enter registered while the sidebar still showed a green
+// Ready dot).
+func TestHandleEnter_DeadSessionShowsError(t *testing.T) {
+	h := newTestHome(t)
+
+	// Ready is the deceptive starting status the bug report describes — the
+	// sidebar still paints it green even though the session is gone.
+	inst := newDeadInstance(t, "dead-session", session.Ready)
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, cmd := h.handleEnter()
+	h = model.(*home)
+
+	// The attach must NOT proceed: no help/attach overlay is installed and the
+	// state stays default. The Deleting path in handleEnter behaves the same
+	// way — error, no attach.
+	require.Equal(t, stateDefault, h.state, "a dead session must not open the attach help overlay")
+	require.Nil(t, h.textOverlay, "no help overlay should be installed for a dead session")
+
+	// handleError returns the hide-error timer command and records the message.
+	require.NotNil(t, cmd, "handleEnter must return the error-hide command, not a silent nil")
+	h.errBox.SetSize(200, 1)
+	require.Contains(t, h.errBox.String(), "no longer running",
+		"the error must explain why Enter did nothing")
+	require.Contains(t, h.errBox.String(), "dead-session",
+		"the error must name the offending session")
+}
+
+// TestRunMetadataTick_DeadSessionNotMarkedReady is the status half of #935: the
+// periodic metadata tick must not repaint a session whose backing session has
+// vanished as Ready (green dot). HasUpdated latches (false,false) for a dead
+// session, which is indistinguishable from a healthy idle one, so the tick has
+// to probe liveness and mark it Dead instead.
+func TestRunMetadataTick_DeadSessionNotMarkedReady(t *testing.T) {
+	// Start from Running to prove the tick actively transitions it to Dead
+	// rather than merely leaving a pre-set status untouched.
+	inst := newDeadInstance(t, "dead-session", session.Running)
+
+	runMetadataTick([]*session.Instance{inst})
+
+	require.Equal(t, session.Dead, inst.GetStatus(),
+		"a dead session must be marked Dead, never Ready, by the metadata tick")
+}
+
+// TestRunMetadataTick_AliveIdleSessionStaysReady is the control for the test
+// above: a live, idle session (HasUpdated false,false but IsAlive true) must
+// still be marked Ready, proving the liveness probe didn't break the normal
+// idle path.
+func TestRunMetadataTick_AliveIdleSessionStaysReady(t *testing.T) {
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "live-session", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	// FakeBackend.IsAlive returns true and HasUpdated returns (false,false) —
+	// a healthy idle session.
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStartedForTest(true)
+	inst.SetStatus(session.Running)
+
+	runMetadataTick([]*session.Instance{inst})
+
+	require.Equal(t, session.Ready, inst.GetStatus(),
+		"a live idle session must still be marked Ready by the metadata tick")
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -282,7 +282,12 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 			return m, m.handleError(fmt.Errorf("session '%s' is being deleted", selected.Title))
 		}
 		if !selected.TmuxAlive() {
-			return m, nil
+			// The backing session has vanished, so attaching is impossible.
+			// Surface an actionable error instead of swallowing Enter, mirroring
+			// the Deleting path above — a silent return left the user unsure
+			// whether the keypress registered while the sidebar still showed a
+			// green Ready dot (#935).
+			return m, m.handleError(fmt.Errorf("session '%s' is no longer running", selected.Title))
 		}
 		// Capture the instance at Enter-press time — the synchronous moment the
 		// selection is provably current. For first-time attachers the attach is

--- a/app/sync.go
+++ b/app/sync.go
@@ -75,6 +75,14 @@ func runMetadataTick(instances []*session.Instance) {
 		} else {
 			if prompt {
 				instance.TapEnter()
+			} else if !instance.TmuxAlive() {
+				// HasUpdated returned (false,false), which a healthy idle
+				// session and a dead one (monitor.dead / ErrSessionGone) both
+				// produce — indistinguishable on their own. Probe liveness only
+				// on this idle branch (not every tick) so a vanished session is
+				// marked Dead and rendered distinctly rather than repainted as a
+				// green Ready dot it can no longer back (#935).
+				instance.SetStatusIfNotDeleting(session.Dead)
 			} else {
 				instance.SetStatusIfNotDeleting(session.Ready)
 			}

--- a/session/instance.go
+++ b/session/instance.go
@@ -24,6 +24,17 @@ const (
 	// is never persisted (see mergeInstancesWithDisk) and the row is removed
 	// or reverted when the background teardown finishes (#844).
 	Deleting
+	// Dead is when the underlying tmux/remote session has vanished out from
+	// under us (e.g. the tmux server was killed externally). The row is a
+	// corpse: the user can no longer attach to it (handleEnter surfaces an
+	// error instead of silently swallowing Enter) but can still kill it. A
+	// dead session's HasUpdated latches (false,false) — the same value a
+	// healthy idle session returns — so without an explicit liveness probe the
+	// metadata tick would repaint it Ready (green dot) forever, making a corpse
+	// masquerade as healthy (#935). Unlike Loading/Deleting this is NOT
+	// in-flight TUI state: it is persisted and background syncs may still reap
+	// or replace the row, so it is deliberately excluded from isTransientStatus.
+	Dead
 )
 
 // Instance is a running instance of claude code.

--- a/ui/list.go
+++ b/ui/list.go
@@ -15,8 +15,19 @@ import (
 
 const readyIcon = "● "
 
+// deadIcon is hollow (not the filled readyIcon) so a dead session differs from
+// a healthy Ready one by shape as well as color — the distinction survives low
+// contrast and color-blindness (#935).
+const deadIcon = "○ "
+
 var readyStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#51bd73", Dark: "#51bd73"})
+
+// deadStyle paints the status dot of a session whose backing tmux/remote
+// session has vanished (#935). A muted gray — the same recede treatment used
+// for a deleting row — keeps a corpse from reading as a healthy green session.
+var deadStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
 
 var titleStyle = lipgloss.NewStyle().
 	Padding(1, 1, 0, 1).
@@ -102,6 +113,8 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		join = fmt.Sprintf("%s ", r.spinner.View())
 	case session.Ready:
 		join = readyStyle.Render(readyIcon)
+	case session.Dead:
+		join = deadStyle.Render(deadIcon)
 	default:
 	}
 

--- a/ui/preview.go
+++ b/ui/preview.go
@@ -146,6 +146,14 @@ func (p *PreviewPane) UpdateContent(instance *session.Instance) error {
 		// Loading+Deleting; the preview pane was the last place that didn't.
 		p.setFallbackState("Tearing down session...")
 		return nil
+	case instance.GetStatus() == session.Dead:
+		// The metadata tick marks a session Dead once its backing tmux/remote
+		// session is gone (#935). The Preview() shell-out below already renders
+		// this fallback on the ErrSessionGone error path, but that races the
+		// async tick; keying off the status too makes the fallback synchronous
+		// with the sidebar's dead-dot so the panes never disagree.
+		p.setFallbackState("Session no longer running.")
+		return nil
 	}
 
 	var content string
@@ -376,6 +384,13 @@ func (p *PreviewPane) ResetToNormalMode(instance *session.Instance) error {
 		// than blank the pane on an empty Preview() (#920).
 		if instance.GetStatus() == session.Deleting {
 			p.setFallbackState("Tearing down session...")
+			return nil
+		}
+		// And for a dead session — exiting scroll mode must keep the
+		// session-gone fallback rather than blank the pane on an empty/erroring
+		// Preview() (#935), mirroring the Loading/Deleting guards above.
+		if instance.GetStatus() == session.Dead {
+			p.setFallbackState("Session no longer running.")
 			return nil
 		}
 


### PR DESCRIPTION
## Summary

Fixes #935. When a tmux session dies externally (e.g. the tmux server is killed), the session kept rendering a green **Ready** dot and pressing **Enter** on it silently did nothing — inconsistent with the `Deleting` case, which shows an error.

Two independent root causes:

1. **Silent Enter** — `handleEnter` (`app/handle_actions.go`) returned `(m, nil)` for `!TmuxAlive()` with zero user feedback.
2. **Fake "Ready"** — the metadata tick (`app/sync.go`) set `Ready` whenever `HasUpdated()` returned `(false, false)`. A dead session's latched monitor (`monitor.dead` / `ErrSessionGone` in `session/tmux/tmux.go`) returns the *same* `(false, false)` — indistinguishable from a healthy idle session — so a corpse got repainted green on every tick.

## Changes

- **`handleEnter`**: surfaces an actionable `session '%s' is no longer running` error, mirroring the existing `Deleting` error path in the same function.
- **New `Dead` status**: the metadata tick probes `TmuxAlive()` *only on the idle branch* (when `HasUpdated` is `(false,false)`) and marks a vanished session `Dead` instead of `Ready`.
- **Sidebar** (`ui/list.go`): `Dead` renders a muted, hollow `○` dot — distinct from the filled green Ready `●` by both color and shape (survives low contrast / color-blindness).
- **Preview pane** (`ui/preview.go`): shows the existing `Session no longer running.` fallback synchronously, keyed off the `Dead` status, so it no longer races the async `ErrSessionGone` path and the panes never disagree.

`Dead` is persisted and deliberately excluded from `isTransientStatus`, so background syncs can still reap or replace a corpse (unlike in-flight `Loading`/`Deleting` rows).

## Adjacent call-site audit

- `ui/list.go` status switch — handled (new `Dead` case).
- `ui/overlay/searchOverlay.go` status switch — has a `default` that renders `○`; `Dead` falls through to it (no green dot). ✓
- `storage.go` `mergeInstancesWithDisk` — `Dead` is persisted (only `Loading`/`Deleting` are skipped); a dead row absent from disk is not resurrected via the existing `!TmuxAlive()` guard. ✓
- `daemon.go` `HasUpdated` (autoyes) — a dead session has no prompt, so no autoyes interaction; the daemon does not own status display. ✓
- `ui/preview.go` already showed `Session no longer running.` on the async `ErrSessionGone` path — kept consistent and now also synchronous.

## Tests (hermetic)

- `TestHandleEnter_DeadSessionShowsError` — Enter on a dead-tmux instance produces a named, actionable error and does **not** open the attach overlay.
- `TestRunMetadataTick_DeadSessionNotMarkedReady` — the tick transitions a dead session to `Dead`, never `Ready`.
- `TestRunMetadataTick_AliveIdleSessionStaysReady` — control: a live idle session still goes `Ready` (the liveness probe didn't break the normal path).

Death is simulated via a `FakeBackend` whose `IsAlive` reports false — no real tmux/git.

## Verification

- `gofmt -l .` clean
- `go build ./...` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `go test ./app/... ./ui/... ./session/...` green
- `GOFLAGS="-p=1" go test -race -parallel 2 ./app/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)