### PR TITLE
refactor(ui): single shared accent constant; finish the #7cb8bb swap (Color 62 banner) (#950)

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -110,7 +110,7 @@ func (h helpTypeInstanceAttach) mask() uint32 {
 }
 
 var (
-	titleStyle  = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(lipgloss.Color("#7cb8bb"))
+	titleStyle  = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(ui.AccentColor)
 	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#36CFC9"))
 	keyStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	descStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFFFF"))

--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -171,7 +171,7 @@ func (h *HooksPane) handleEditMode(msg tea.KeyMsg) bool {
 }
 
 func (h *HooksPane) String() string {
-	tStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7cb8bb"))
+	tStyle := lipgloss.NewStyle().Bold(true).Foreground(AccentColor)
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))

--- a/ui/list.go
+++ b/ui/list.go
@@ -48,7 +48,7 @@ var selectedDescStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#1a1a1a"})
 
 var mainTitle = lipgloss.NewStyle().
-	Background(lipgloss.Color("62")).
+	Background(AccentColor).
 	Foreground(lipgloss.Color("230"))
 
 var autoYesStyle = lipgloss.NewStyle().

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -24,7 +24,7 @@ var sepStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
 	Dark:  "#3C3C3C",
 })
 
-var actionGroupStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#7cb8bb"))
+var actionGroupStyle = lipgloss.NewStyle().Foreground(AccentColor)
 
 var separator = " • "
 var verticalSeparator = " │ "

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -5,6 +5,7 @@ import (
 	"unicode"
 
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -165,7 +166,7 @@ func runeEqualFold(a, b rune) bool {
 
 // Render renders the search overlay.
 func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7cb8bb"))
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.AccentColor)
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
@@ -246,7 +247,7 @@ func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
 
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#7cb8bb")).
+		BorderForeground(ui.AccentColor).
 		Padding(1, 2).
 		Width(s.width)
 

--- a/ui/overlay/selectionOverlay.go
+++ b/ui/overlay/selectionOverlay.go
@@ -3,6 +3,8 @@ package overlay
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/sachiniyer/agent-factory/ui"
 )
 
 // SelectionOverlay represents a selection list overlay for choosing from items
@@ -76,7 +78,7 @@ func (s *SelectionOverlay) SetWidth(width int) {
 
 // Render renders the selection overlay
 func (s *SelectionOverlay) Render(opts ...WhitespaceOption) string {
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7cb8bb"))
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.AccentColor)
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
@@ -95,7 +97,7 @@ func (s *SelectionOverlay) Render(opts ...WhitespaceOption) string {
 
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#7cb8bb")).
+		BorderForeground(ui.AccentColor).
 		Padding(1, 2).
 		Width(s.width)
 

--- a/ui/overlay/textOverlay.go
+++ b/ui/overlay/textOverlay.go
@@ -3,6 +3,8 @@ package overlay
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/sachiniyer/agent-factory/ui"
 )
 
 // TextOverlay represents a text screen overlay
@@ -50,7 +52,7 @@ func (t *TextOverlay) Render(opts ...WhitespaceOption) string {
 	// Create styles
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("62")).
+		BorderForeground(ui.AccentColor).
 		Padding(1, 2).
 		Width(t.width)
 

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -20,16 +20,15 @@ func tabBorderWithBottom(left, middle, right string) lipgloss.Border {
 var (
 	inactiveTabBorder = tabBorderWithBottom("┴", "─", "┴")
 	activeTabBorder   = tabBorderWithBottom("┘", " ", "└")
-	highlightColor    = lipgloss.AdaptiveColor{Light: "#7cb8bb", Dark: "#7cb8bb"}
 	inactiveTabStyle  = lipgloss.NewStyle().
 				Border(inactiveTabBorder, true).
-				BorderForeground(highlightColor).
+				BorderForeground(AccentColor).
 				AlignHorizontal(lipgloss.Center)
 	activeTabStyle = inactiveTabStyle.
 			Border(activeTabBorder, true).
 			AlignHorizontal(lipgloss.Center)
 	windowStyle = lipgloss.NewStyle().
-			BorderForeground(highlightColor).
+			BorderForeground(AccentColor).
 			Border(lipgloss.NormalBorder(), false, true, true, true)
 )
 

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -636,7 +636,7 @@ func taskDeliverySummary(tsk task.Task) string {
 }
 
 func (s *TaskPane) renderListMode() string {
-	tStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7cb8bb"))
+	tStyle := lipgloss.NewStyle().Bold(true).Foreground(AccentColor)
 	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
 	enabledStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#36CFC9"))
 	disabledStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
@@ -731,7 +731,7 @@ func (s *TaskPane) renderListMode() string {
 
 func (s *TaskPane) renderEditMode() string {
 	editTitleStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("62")).
+		Foreground(AccentColor).
 		Bold(true).
 		MarginBottom(1)
 
@@ -742,7 +742,7 @@ func (s *TaskPane) renderEditMode() string {
 
 	buttonStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
 	focusedButtonStyle := buttonStyle.
-		Background(lipgloss.Color("62")).
+		Background(AccentColor).
 		Foreground(lipgloss.Color("0"))
 
 	inputWidth := s.width - 6

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -1,0 +1,17 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+// AccentColor is the single source of truth for the UI accent (teal #7cb8bb,
+// introduced in #932). Every accent surface — the sidebar title banner, active
+// tab/window borders, overlay borders, menu action groups, task edit-mode
+// chrome, and the help screen titles — routes through this constant so the
+// accent can never drift again the way the old purple Color("62") banner did
+// (#950). It is intentionally a plain lipgloss.Color: #932 used the same hex
+// for both light and dark, so no AdaptiveColor split is needed, and a single
+// Color drops in cleanly at every Foreground/Background/BorderForeground site.
+//
+// This is the accent and nothing else. Semantic colors — success green
+// (#51bd73), error red, menu pink (Color("205")), and the recede/muted greys —
+// are deliberately NOT part of the accent and must not be folded in here.
+const AccentColor = lipgloss.Color("#7cb8bb")

--- a/ui/theme_test.go
+++ b/ui/theme_test.go
@@ -1,0 +1,37 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TestAccentColorValue pins the shared accent to the teal introduced in #932.
+// If someone changes the accent, they change it here in one place and this test
+// records the intent — the whole point of the constant (#950).
+func TestAccentColorValue(t *testing.T) {
+	if got := string(AccentColor); got != "#7cb8bb" {
+		t.Fatalf("AccentColor = %q, want %q", got, "#7cb8bb")
+	}
+}
+
+// TestAccentSitesUseConstant guards against the half-finished migration that
+// left the sidebar title banner purple (Color("62")) while everything else went
+// teal. These are the most prominent accent surfaces; assert they resolve to
+// AccentColor so a future literal can't silently drift them apart again.
+func TestAccentSitesUseConstant(t *testing.T) {
+	cases := []struct {
+		name string
+		got  lipgloss.TerminalColor
+	}{
+		{"sidebar title banner background", mainTitle.GetBackground()},
+		{"active tab border", activeTabStyle.GetBorderTopForeground()},
+		{"window border", windowStyle.GetBorderBottomForeground()},
+		{"menu action group", actionGroupStyle.GetForeground()},
+	}
+	for _, c := range cases {
+		if c.got != lipgloss.TerminalColor(AccentColor) {
+			t.Errorf("%s = %v, want AccentColor (%s)", c.name, c.got, AccentColor)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

#932 swapped the UI accent purple → teal `#7cb8bb`, but its grep only covered `7D56F4 / 874BFD / Color("99") / Color("5") / Color("13")` and **missed `lipgloss.Color("62")`** (256-color ≈ `#5f5fd7`, the old bubbletea purple). That left the most prominent header in the TUI — the **"Agent Factory" sidebar title banner** — plus task edit-mode chrome and the text-overlay border still rendering **purple** while borders, active tabs, menu action groups, and overlays were teal. The migration looked half-finished.

## Fix

1. **Introduce one shared accent constant** — `ui.AccentColor` in a new `ui/theme.go`:
   ```go
   const AccentColor = lipgloss.Color("#7cb8bb")
   ```
   A plain `lipgloss.Color` (not `AdaptiveColor`) because #932 used the same hex for light and dark; it drops in cleanly at every `Foreground`/`Background`/`BorderForeground` site. The next accent change is one edit instead of a repo-wide grep.

2. **Route every accent surface through it.**

### Full accent-site inventory (all → `ui.AccentColor`)

| Site | Was | Surface |
|------|-----|---------|
| `ui/theme.go` | — | **definition** |
| `ui/list.go` `mainTitle` bg | `Color("62")` 🟣 | **sidebar title banner** (the bug) |
| `ui/task_pane.go` `editTitleStyle` fg | `Color("62")` 🟣 | task edit-mode title |
| `ui/task_pane.go` `focusedButtonStyle` bg | `Color("62")` 🟣 | task edit-mode focused button |
| `ui/task_pane.go` `renderListMode` title | `#7cb8bb` | task list title |
| `ui/overlay/textOverlay.go` border | `Color("62")` 🟣 | text overlay border |
| `ui/tabbed_window.go` tab + window borders | `#7cb8bb` (`highlightColor` var, now removed) | tabs/window |
| `ui/menu.go` `actionGroupStyle` | `#7cb8bb` | menu action groups |
| `ui/hooks_pane.go` title | `#7cb8bb` | hooks pane title |
| `ui/overlay/searchOverlay.go` title + border | `#7cb8bb` | search overlay |
| `ui/overlay/selectionOverlay.go` title + border | `#7cb8bb` | selection overlay |
| `app/help.go` `titleStyle` | `#7cb8bb` | help screen titles (reuses exported `ui.AccentColor`) |

🟣 = previously-purple sites the #932 grep missed.

The `ui/overlay` subpackage now imports `ui` for the constant (no cycle — `ui` does not depend on `ui/overlay`). `app` already imported `ui`.

## Contrast check

The task edit-mode focused button is `Color("0")` (black) text on the teal background. `#7cb8bb` has relative luminance ≈ 0.42, giving **≈ 9.4 : 1** against black — well above WCAG AA (4.5:1). No foreground adjustment needed.

## Not touched (semantic, intentionally not the accent)

Success green `#51bd73`, error red, menu pink `Color("205")`, recede/muted greys (`#A49FA5`/`#777777`/etc.), dead/deleting gray.

## Audit

`grep -rn 'Color("62")\|#7cb8bb' ui/ app/` → no `Color("62")` and no raw `#7cb8bb` literal remains outside `ui/theme.go`. No other purple ANSI accent (`57/63/93/99/5/13`) or old hex purple (`7D56F4`/`874BFD`/`5f5fd7`) is present.

## Tests / verification

- New `ui/theme_test.go`: pins `AccentColor == "#7cb8bb"` and asserts the banner background, tab/window borders, and menu action group resolve to `AccentColor`.
- `gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./ui/... ./app/...` green.

Fixes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)