### PR TITLE
refactor(session): model the agent session as Tab[0] behind an internal Tab type (#930, PR 1/7)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -66,7 +66,7 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 
 	var tmuxSession *tmux.TmuxSession
 	i.mu.RLock()
-	existingSession := i.tmuxSession
+	existingSession := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if existingSession != nil {
@@ -81,7 +81,7 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 	}
 
 	i.mu.Lock()
-	i.tmuxSession = tmuxSession
+	i.setTmuxLocked(tmuxSession)
 	i.mu.Unlock()
 
 	if firstTimeSetup {
@@ -116,8 +116,8 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 				// local attach resources this object opened and leaves the
 				// server session and its worktree intact for a later retry.
 				i.mu.Lock()
-				ts := i.tmuxSession
-				i.tmuxSession = nil
+				ts := i.tmuxLocked()
+				i.setTmuxLocked(nil)
 				i.started = false
 				i.mu.Unlock()
 				if ts != nil {
@@ -171,12 +171,12 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 		}
 
 		// Inject Agent Factory instructions into the session.
-		i.tmuxSession.SetProgram(
+		tmuxSession.SetProgram(
 			injectSystemPrompt(i.Program, resolveProgramForInstance(i), i.Title, gw.GetWorktreePath()),
 		)
 
 		// Create new session
-		if err := i.tmuxSession.Start(gw.GetWorktreePath()); err != nil {
+		if err := tmuxSession.Start(gw.GetWorktreePath()); err != nil {
 			// Cleanup git worktree if tmux session creation fails
 			if cleanupErr := gw.Cleanup(); cleanupErr != nil {
 				err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
@@ -195,7 +195,7 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 // caller can always proceed to remove the persisted record. See issue #478.
 func (b *LocalBackend) Kill(i *Instance) error {
 	i.mu.Lock()
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	gw := i.gitWorktree
 	title := i.Title
 	i.started = false
@@ -219,8 +219,8 @@ func (b *LocalBackend) Kill(i *Instance) error {
 	}
 
 	i.mu.Lock()
-	if i.tmuxSession == ts {
-		i.tmuxSession = nil
+	if i.tmuxLocked() == ts {
+		i.setTmuxLocked(nil)
 	}
 	if i.gitWorktree == gw {
 		i.gitWorktree = nil
@@ -239,7 +239,7 @@ func (b *LocalBackend) Kill(i *Instance) error {
 // without tearing down the live session the canonical Instance shares.
 func (b *LocalBackend) CloseAttachOnly(i *Instance) error {
 	i.mu.Lock()
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.started = false
 	i.mu.Unlock()
 
@@ -250,8 +250,8 @@ func (b *LocalBackend) CloseAttachOnly(i *Instance) error {
 	err := ts.CloseAttachOnly()
 
 	i.mu.Lock()
-	if i.tmuxSession == ts {
-		i.tmuxSession = nil
+	if i.tmuxLocked() == ts {
+		i.setTmuxLocked(nil)
 	}
 	i.mu.Unlock()
 	return err
@@ -260,7 +260,7 @@ func (b *LocalBackend) CloseAttachOnly(i *Instance) error {
 func (b *LocalBackend) Preview(i *Instance) (string, error) {
 	i.mu.RLock()
 	s := i.started
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if !s || ts == nil {
@@ -272,7 +272,7 @@ func (b *LocalBackend) Preview(i *Instance) (string, error) {
 func (b *LocalBackend) PreviewFullHistory(i *Instance) (string, error) {
 	i.mu.RLock()
 	s := i.started
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if !s || ts == nil {
@@ -284,7 +284,7 @@ func (b *LocalBackend) PreviewFullHistory(i *Instance) (string, error) {
 func (b *LocalBackend) Attach(i *Instance) (chan struct{}, error) {
 	i.mu.RLock()
 	s := i.started
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if !s || ts == nil {
@@ -296,7 +296,7 @@ func (b *LocalBackend) Attach(i *Instance) (chan struct{}, error) {
 func (b *LocalBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool) {
 	i.mu.RLock()
 	s := i.started
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if !s || ts == nil {
@@ -308,7 +308,7 @@ func (b *LocalBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool) {
 func (b *LocalBackend) SendPrompt(i *Instance, prompt string) error {
 	i.mu.RLock()
 	s := i.started
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if !s {
@@ -332,7 +332,7 @@ func (b *LocalBackend) SendPrompt(i *Instance, prompt string) error {
 func (b *LocalBackend) SendPromptCommand(i *Instance, prompt string) error {
 	i.mu.RLock()
 	s := i.started
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if !s {
@@ -347,7 +347,7 @@ func (b *LocalBackend) SendPromptCommand(i *Instance, prompt string) error {
 func (b *LocalBackend) SendKeys(i *Instance, keys string) error {
 	i.mu.RLock()
 	s := i.started
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if !s {
@@ -362,7 +362,7 @@ func (b *LocalBackend) SendKeys(i *Instance, keys string) error {
 func (b *LocalBackend) SetPreviewSize(i *Instance, width, height int) error {
 	i.mu.RLock()
 	s := i.started
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if !s || ts == nil {
@@ -373,7 +373,7 @@ func (b *LocalBackend) SetPreviewSize(i *Instance, width, height int) error {
 
 func (b *LocalBackend) IsAlive(i *Instance) bool {
 	i.mu.RLock()
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if ts == nil {
@@ -385,7 +385,7 @@ func (b *LocalBackend) IsAlive(i *Instance) bool {
 func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {
 	i.mu.RLock()
 	s := i.started
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if !s || ts == nil {
@@ -406,7 +406,7 @@ func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {
 func (b *LocalBackend) TapEnter(i *Instance) {
 	i.mu.RLock()
 	s := i.started
-	ts := i.tmuxSession
+	ts := i.tmuxLocked()
 	autoYes := i.AutoYes
 	i.mu.RUnlock()
 

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -70,17 +70,17 @@ func TestLocalBackendKillBestEffort_TmuxFails(t *testing.T) {
 	}
 	ts := tmux.NewTmuxSessionWithDeps("best-effort-tmux", "bash", nil, cmdExec)
 	inst := &Instance{
-		Title:       "best-effort-tmux",
-		backend:     &LocalBackend{},
-		started:     true,
-		tmuxSession: ts,
+		Title:   "best-effort-tmux",
+		backend: &LocalBackend{},
+		started: true,
+		Tabs:    []*Tab{newAgentTab(ts)},
 	}
 
 	buf := captureWarningLog(t)
 
 	require.NoError(t, inst.Kill(), "tmux cleanup failure must not block deletion")
 	assert.False(t, inst.Started(), "started flag should be cleared")
-	assert.Nil(t, inst.tmuxSession, "tmux pointer should be cleared so a retry is a clean no-op")
+	assert.Nil(t, inst.tmuxLocked(), "tmux pointer should be cleared so a retry is a clean no-op")
 
 	logged := buf.String()
 	assert.Contains(t, logged, "best-effort-tmux", "warning must include instance title for correlation in agent-factory.log")
@@ -192,14 +192,14 @@ func TestLocalBackendKillBestEffort_BothFail(t *testing.T) {
 		Title:       "both-fail",
 		backend:     &LocalBackend{},
 		started:     true,
-		tmuxSession: ts,
+		Tabs:        []*Tab{newAgentTab(ts)},
 		gitWorktree: gw,
 	}
 
 	buf := captureWarningLog(t)
 
 	require.NoError(t, inst.Kill())
-	assert.Nil(t, inst.tmuxSession)
+	assert.Nil(t, inst.tmuxLocked())
 	assert.Nil(t, inst.gitWorktree)
 
 	logged := buf.String()
@@ -946,11 +946,11 @@ func TestLocalBackendCheckAndHandleTrustPromptDispatch(t *testing.T) {
 			}
 			ts := tmux.NewTmuxSessionWithDeps("trust-dispatch", tc.program, nil, cmdExec)
 			inst := &Instance{
-				Title:       "trust-dispatch",
-				Program:     tc.program,
-				backend:     &LocalBackend{},
-				started:     true,
-				tmuxSession: ts,
+				Title:   "trust-dispatch",
+				Program: tc.program,
+				backend: &LocalBackend{},
+				started: true,
+				Tabs:    []*Tab{newAgentTab(ts)},
 			}
 
 			inst.CheckAndHandleTrustPrompt()
@@ -1889,7 +1889,7 @@ func TestLocalBackendStartRestoreReinjectsSystemPrompt(t *testing.T) {
 		Path:        repoRoot,
 		Program:     "claude",
 		backend:     &LocalBackend{},
-		tmuxSession: ts,
+		Tabs:        []*Tab{newAgentTab(ts)},
 		gitWorktree: gw,
 	}
 
@@ -2060,10 +2060,10 @@ func TestLocalBackendRestorePtyFailureDoesNotKillSession(t *testing.T) {
 	ts := tmux.NewTmuxSessionWithDeps("restore-pty-fail", "claude",
 		errPtyFactory{err: fmt.Errorf("pty allocation failed")}, cmdExec)
 	inst := &Instance{
-		Title:       "restore-pty-fail",
-		backend:     &LocalBackend{},
-		started:     true,
-		tmuxSession: ts,
+		Title:   "restore-pty-fail",
+		backend: &LocalBackend{},
+		started: true,
+		Tabs:    []*Tab{newAgentTab(ts)},
 	}
 
 	// firstTimeSetup=false → restore path. No gitWorktree is attached, so
@@ -2082,7 +2082,7 @@ func TestLocalBackendRestorePtyFailureDoesNotKillSession(t *testing.T) {
 
 	// The local attach was still torn down: the instance no longer holds the
 	// session and is marked not-started so a later retry is clean.
-	assert.Nil(t, inst.tmuxSession, "attach resources should be released on restore failure")
+	assert.Nil(t, inst.tmuxLocked(), "attach resources should be released on restore failure")
 	assert.False(t, inst.Started(), "instance should be marked not-started after a failed restore")
 }
 
@@ -2106,10 +2106,10 @@ func TestLocalBackendKillRunsKillSession(t *testing.T) {
 
 	ts := tmux.NewTmuxSessionWithDeps("genuine-kill", "claude", nil, cmdExec)
 	inst := &Instance{
-		Title:       "genuine-kill",
-		backend:     &LocalBackend{},
-		started:     true,
-		tmuxSession: ts,
+		Title:   "genuine-kill",
+		backend: &LocalBackend{},
+		started: true,
+		Tabs:    []*Tab{newAgentTab(ts)},
 	}
 
 	require.NoError(t, inst.Kill())

--- a/session/instance.go
+++ b/session/instance.go
@@ -41,7 +41,8 @@ const (
 type Instance struct {
 	// mu protects fields that are accessed concurrently by async Start()
 	// goroutines (writers) and the main bubbletea loop (readers):
-	// started, Status, tmuxSession, gitWorktree, prInfo, diffStats.
+	// started, Status, Tabs (and the agent tab's tmux session), gitWorktree,
+	// prInfo, diffStats.
 	mu sync.RWMutex
 
 	// Title is the title of the instance.
@@ -83,10 +84,41 @@ type Instance struct {
 	// The below fields are initialized upon calling Start().
 
 	started bool
-	// tmuxSession is the tmux session for the instance.
-	tmuxSession *tmux.TmuxSession
+	// Tabs is the instance's ordered list of tabs. In PR 1 of the #930
+	// ephemeral-tabs epic this holds exactly one Agent-kind tab (Tabs[0]) that
+	// wraps the instance's single tmux session; every tmux-touching method
+	// routes through it via tmuxLocked/setTmuxLocked. Remote/hook-backed
+	// instances drive their agent session through hook commands and so carry no
+	// tmux-backed tab. Later PRs add shell/process tabs, lifecycle, and per-tab
+	// persistence.
+	Tabs []*Tab
 	// gitWorktree is the git worktree for the instance.
 	gitWorktree *git.GitWorktree
+}
+
+// tmuxLocked returns the agent tab's tmux session, or nil when the instance has
+// no agent tab yet (not started) or is remote. Callers must hold i.mu (read or
+// write).
+func (i *Instance) tmuxLocked() *tmux.TmuxSession {
+	if len(i.Tabs) == 0 {
+		return nil
+	}
+	return i.Tabs[0].tmux
+}
+
+// setTmuxLocked stores ts as the agent tab's tmux session, materializing the
+// single Agent tab on first assignment so the agent session is always Tabs[0].
+// Passing nil clears the session but leaves the tab in place (and is a no-op
+// before the agent tab exists). Callers must hold i.mu for writing.
+func (i *Instance) setTmuxLocked(ts *tmux.TmuxSession) {
+	if len(i.Tabs) == 0 {
+		if ts == nil {
+			return
+		}
+		i.Tabs = []*Tab{newAgentTab(ts)}
+		return
+	}
+	i.Tabs[0].tmux = ts
 }
 
 // ToInstanceData converts an Instance to its serializable form
@@ -114,9 +146,11 @@ func (i *Instance) ToInstanceData() InstanceData {
 		data.RemoteMeta = i.remoteMeta
 	}
 
-	// Persist the tmux session name so we can restore it exactly
-	if i.tmuxSession != nil {
-		data.TmuxName = i.tmuxSession.SanitizedName()
+	// Persist the tmux session name so we can restore it exactly. The agent
+	// tab's session is the instance's single persisted session in PR 1 — the
+	// on-disk format is unchanged (no Tabs field yet).
+	if ts := i.tmuxLocked(); ts != nil {
+		data.TmuxName = ts.SanitizedName()
 	}
 
 	// Only include worktree data if gitWorktree is initialized
@@ -199,10 +233,11 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		// Pre-set the tmux session with the correct name for backward compat.
 		// If TmuxName was persisted, use it exactly; otherwise fall back to
 		// the legacy naming scheme (no repo hash) so old sessions still restore.
+		// The reconstructed session becomes the instance's single Agent tab.
 		if data.TmuxName != "" {
-			instance.tmuxSession = tmux.NewTmuxSessionFromSanitizedName(data.TmuxName, data.Program)
+			instance.setTmuxLocked(tmux.NewTmuxSessionFromSanitizedName(data.TmuxName, data.Program))
 		} else {
-			instance.tmuxSession = tmux.NewTmuxSession(data.Title, data.Program)
+			instance.setTmuxLocked(tmux.NewTmuxSession(data.Title, data.Program))
 		}
 	}
 
@@ -393,7 +428,7 @@ func (i *Instance) StartWithExistingWorktree(worktreePath, branchName string) er
 	tmuxSession := tmux.NewTmuxSessionForRepo(i.Title, i.Path, program)
 
 	i.mu.Lock()
-	i.tmuxSession = tmuxSession
+	i.setTmuxLocked(tmuxSession)
 	i.mu.Unlock()
 
 	// Start is I/O; do not hold the lock.
@@ -572,9 +607,10 @@ func (i *Instance) PreviewFullHistory() (string, error) {
 	return i.backend.PreviewFullHistory(i)
 }
 
-// SetTmuxSession sets the tmux session for testing purposes
+// SetTmuxSession sets the agent tab's tmux session for testing purposes,
+// materializing the single Agent tab if needed.
 func (i *Instance) SetTmuxSession(session *tmux.TmuxSession) {
-	i.tmuxSession = session
+	i.setTmuxLocked(session)
 }
 
 // SetStartedForTest toggles the started flag for testing purposes. Prefer

--- a/session/tab.go
+++ b/session/tab.go
@@ -1,0 +1,52 @@
+package session
+
+import "github.com/sachiniyer/agent-factory/session/tmux"
+
+// agentTabName is the display label of the default Agent tab.
+const agentTabName = "agent"
+
+// TabKind enumerates the kinds of process a Tab can host within an instance's
+// worktree. PR 1 of the #930 ephemeral-tabs epic only materializes the Agent
+// kind (the single per-instance agent session); Shell and Process are defined
+// here so later PRs can add the human-spawned terminal tab and CLI-spawned
+// process tabs without reshaping the type. See issue #930.
+type TabKind int
+
+const (
+	// TabKindAgent is the agent session: the resolved agent program with
+	// system-prompt injection, trust-prompt handling, and autoyes. Exactly one
+	// per instance today, at Tabs[0].
+	TabKindAgent TabKind = iota
+	// TabKindShell is a plain $SHELL session in the worktree (the future
+	// human-spawned terminal tab). Not created in PR 1.
+	TabKindShell
+	// TabKindProcess runs an arbitrary command in the worktree (the future
+	// CLI-spawned tab). Not created in PR 1.
+	TabKindProcess
+)
+
+// Tab is one process running in an instance's worktree, backed by a single tmux
+// session. It is an internal wrapper introduced in PR 1 of #930: an instance
+// holds exactly one Agent tab that wraps today's single tmux session, and the
+// instance's tmux-touching methods route through it. Tab lifecycle
+// (create/close) and per-tab persistence land in later PRs; PR 1 keeps the
+// on-disk format and all behavior unchanged.
+type Tab struct {
+	// Name is the display label (e.g. "agent").
+	Name string
+	// Kind selects the tab's process behavior.
+	Kind TabKind
+	// Command is the process to run; empty means the kind's default. Unused in
+	// PR 1 — the agent program is still resolved by the local backend.
+	Command string
+	// tmux is the tab's tmux session. nil until the instance is started, and
+	// always nil for remote/hook-backed instances, which drive their agent
+	// session through hook commands rather than a local tmux session.
+	tmux *tmux.TmuxSession
+}
+
+// newAgentTab returns the single Agent-kind tab that wraps an instance's tmux
+// session.
+func newAgentTab(ts *tmux.TmuxSession) *Tab {
+	return &Tab{Name: agentTabName, Kind: TabKindAgent, tmux: ts}
+}

--- a/session/tab_test.go
+++ b/session/tab_test.go
@@ -1,0 +1,83 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewAgentTab_WrapsSession confirms the agent-tab constructor produces an
+// Agent-kind tab named "agent" that wraps the given tmux session — the single
+// default tab introduced in PR 1 of #930.
+func TestNewAgentTab_WrapsSession(t *testing.T) {
+	ts := tmux.NewTmuxSession("agent-tab", "claude")
+	tab := newAgentTab(ts)
+
+	assert.Equal(t, agentTabName, tab.Name)
+	assert.Equal(t, TabKindAgent, tab.Kind)
+	assert.Empty(t, tab.Command)
+	assert.Same(t, ts, tab.tmux)
+}
+
+// TestInstanceTmuxAccessors_MaterializeSingleAgentTab verifies the Instance
+// tmux accessors route the single agent session through Tabs[0]: the first
+// assignment materializes exactly one Agent tab, later reads/writes reuse it,
+// and clearing leaves the tab in place with a nil session (so a restored
+// instance still has its agent tab, matching the old i.tmuxSession == nil
+// semantics).
+func TestInstanceTmuxAccessors_MaterializeSingleAgentTab(t *testing.T) {
+	i := &Instance{Title: "accessor"}
+
+	// Before any assignment there is no agent tab and no session.
+	assert.Empty(t, i.Tabs)
+	assert.Nil(t, i.tmuxLocked())
+
+	// Clearing before the tab exists is a no-op (no empty tab is created).
+	i.setTmuxLocked(nil)
+	assert.Empty(t, i.Tabs)
+
+	// First non-nil assignment materializes exactly one Agent tab.
+	ts := tmux.NewTmuxSession("accessor", "claude")
+	i.setTmuxLocked(ts)
+	require.Len(t, i.Tabs, 1)
+	assert.Equal(t, TabKindAgent, i.Tabs[0].Kind)
+	assert.Same(t, ts, i.tmuxLocked())
+
+	// Reassignment reuses the same tab rather than appending a second one.
+	ts2 := tmux.NewTmuxSession("accessor", "claude")
+	i.setTmuxLocked(ts2)
+	require.Len(t, i.Tabs, 1)
+	assert.Same(t, ts2, i.tmuxLocked())
+
+	// Clearing leaves the agent tab in place but drops the session.
+	i.setTmuxLocked(nil)
+	require.Len(t, i.Tabs, 1)
+	assert.Nil(t, i.tmuxLocked())
+}
+
+// TestSetTmuxSession_RoutesThroughAgentTab confirms the public test helper
+// SetTmuxSession routes through the agent tab so existing white-box tests and
+// UI tests keep working after the field was replaced by Tabs[0].
+func TestSetTmuxSession_RoutesThroughAgentTab(t *testing.T) {
+	i := &Instance{Title: "helper"}
+	ts := tmux.NewTmuxSession("helper", "claude")
+
+	i.SetTmuxSession(ts)
+	require.Len(t, i.Tabs, 1)
+	assert.Equal(t, TabKindAgent, i.Tabs[0].Kind)
+	assert.Same(t, ts, i.tmuxLocked())
+}
+
+// TestToInstanceData_PersistsAgentTabSessionName confirms the agent tab's tmux
+// session name is what ToInstanceData serializes as the single TmuxName — the
+// on-disk format is unchanged in PR 1 (no Tabs field yet).
+func TestToInstanceData_PersistsAgentTabSessionName(t *testing.T) {
+	i := &Instance{Title: "persist", backend: &LocalBackend{}}
+	ts := tmux.NewTmuxSessionForRepo("persist", t.TempDir(), "claude")
+	i.SetTmuxSession(ts)
+
+	data := i.ToInstanceData()
+	assert.Equal(t, ts.SanitizedName(), data.TmuxName)
+}


### PR DESCRIPTION
**Part of #930** — the greenlit [ephemeral-tabs redesign](https://github.com/sachiniyer/agent-factory/issues/930). This is **PR 1 of 7** from the "Migration / phasing" section of the canonical plan. The epic stays open across all 7 PRs.

## What this is

A **pure structural refactor with zero user-visible or on-disk behavior change.** It lays the data-model spine for the redesign — the `Tab` type — without touching any surface. The TUI looks and behaves identically; no new hotkeys, no UI changes, no feature deletions (those are later PRs).

## Changes

- **New `session/tab.go`** — defines:
  - `TabKind` enum: `TabKindAgent`, `TabKindShell`, `TabKindProcess`. Only `Agent` is materialized in this PR; `Shell`/`Process` are defined so later PRs (human "new tab" hotkey, CLI `tab-create`) slot in without reshaping the type.
  - `Tab{Name, Kind, Command, tmux}` — one process in the worktree backed by a single tmux session. `Command` is unused in PR 1 (the agent program is still resolved by the local backend).
  - `newAgentTab(ts)` constructor.
- **`Instance` now holds `Tabs []*Tab`** containing **exactly one Agent-kind tab** that wraps today's single tmux session. The old `tmuxSession` field is **deleted**; every reader/writer routes through two locked helpers:
  - `tmuxLocked()` → `Tabs[0].tmux` (nil when not started / remote).
  - `setTmuxLocked(ts)` → materializes the single Agent tab on first assignment; `nil` clears the session but leaves the tab in place — matching the old `i.tmuxSession == nil` semantics exactly.
- **`HookBackend` (remote) is unchanged** — it never touched `i.tmuxSession`; it drives its agent session through hook commands (`attach_cmd` etc.). Its agent tab conceptually wraps that session with `tmux == nil`. Remote behavior is identical. `terminal_cmd` is **not** modeled as a tab yet (later PR).

## Persistence: on-disk format byte-for-byte unchanged

`storage.go` / `InstanceData` are **untouched**. `ToInstanceData` still serializes the single `TmuxName` (now read from the agent tab); `FromInstanceData` reconstructs the single Agent tab from the persisted `TmuxName`/`Program`. **No `Tabs` field is added to `InstanceData`** (that's PR 3). An `instances.json` written by current `master` loads identically.

## Adjacent-call-site audit

Grepped every reader of the instance's tmux session across `session/`, `app/`, `ui/`, `daemon/`, `api/`, `task/`, `cmd/`:

- **`session/instance.go`** — `ToInstanceData`, `FromInstanceData`, `StartWithExistingWorktree`, `SetTmuxSession` → all route through `tmuxLocked`/`setTmuxLocked`. ✅
- **`session/backend_local.go`** — `Start`, `Kill`, `CloseAttachOnly`, `Preview`, `PreviewFullHistory`, `Attach`, `HasUpdated`, `SendPrompt`, `SendPromptCommand`, `SendKeys`, `SetPreviewSize`, `IsAlive`, `CheckAndHandleTrustPrompt`, `TapEnter` → all route through the accessor. ✅
- **`session/backend_hook.go`** — does **not** read `i.tmuxSession` (drives the session via hooks). No change. ✅
- **`ui/terminal.go`** — its `tmuxSession` references belong to the UI-owned terminal-pane *cache* (a separate mechanism), **not** the instance's session. Untouched here; it's merged into the unified `TabPane` in PR 2 per the plan. ✅
- **`task/runner.go`, `api/sessions.go`, `daemon/control.go`** — these construct *fresh* `tmux.TmuxSession` objects from names (existence checks / cleanup); none read the instance's session field. No change. ✅

White-box tests in `session/backend_test.go` that referenced the deleted field were mechanically routed through the same-package helper (`Tabs: []*Tab{newAgentTab(ts)}` for setup, `inst.tmuxLocked()` for the nil-assertions) — **every assertion's meaning is preserved unchanged.**

## Verification

- `gofmt -l .` clean
- `go build ./...` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `go test ./...` green (all packages; existing tests unchanged)
- `GOFLAGS="-p=1" go test -race -parallel 2 ./session/... ./app/... ./ui/...` green
- Added `session/tab_test.go` covering the agent-tab constructor, accessor materialization/clear semantics, `SetTmuxSession` routing, and `ToInstanceData` name persistence.

— Captain Claude