### PR TITLE
refactor: remove create-on-existing-worktree; one creation path now that instance⇄worktree is 1:1 (#930, PR 3/7)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
-	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui"
@@ -50,8 +49,6 @@ const (
 	stateHelp
 	// stateConfirm is the state when a confirmation modal is displayed.
 	stateConfirm
-	// stateSelectWorktree is the state when the user is selecting an existing worktree.
-	stateSelectWorktree
 	// stateSearch is the state when the user is searching sessions.
 	stateSearch
 	// stateSelectProgram is the state when the user is selecting a program during naming.
@@ -109,14 +106,10 @@ type home struct {
 	// action so that handleStateConfirm can forward it to the Bubble Tea
 	// event loop after OnConfirm runs.
 	pendingConfirmMsg tea.Msg
-	// selectionOverlay handles worktree selection
+	// selectionOverlay handles program selection during new-instance naming
 	selectionOverlay *overlay.SelectionOverlay
 	// searchOverlay handles session search
 	searchOverlay *overlay.SearchOverlay
-	// selectedWorktree stores the worktree info selected by the user for attach
-	selectedWorktree *git.WorktreeInfo
-	// availableWorktrees stores the worktrees shown in the selection overlay
-	availableWorktrees []git.WorktreeInfo
 	// pendingProgram tracks the program selected during new instance naming
 	pendingProgram string
 
@@ -796,7 +789,7 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 			func() tea.Msg { return msg },
 			m.keydownCallback(name)), true
 	}
-	if m.state == stateHelp || m.state == stateConfirm || m.state == stateSelectWorktree ||
+	if m.state == stateHelp || m.state == stateConfirm ||
 		m.state == stateSearch || m.state == stateSelectProgram {
 		return nil, false
 	}
@@ -835,8 +828,6 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m.handleHelpState(msg)
 	case stateNew:
 		return m.handleStateNew(msg)
-	case stateSelectWorktree:
-		return m.handleStateSelectWorktree(msg)
 	case stateConfirm:
 		return m.handleStateConfirm(msg)
 	case stateSearch:
@@ -1230,11 +1221,6 @@ func (m *home) View() string {
 			log.ErrorLog.Printf("confirmation overlay is nil")
 		}
 		return overlay.PlaceOverlay(0, 0, m.confirmationOverlay.Render(), mainView, true)
-	} else if m.state == stateSelectWorktree {
-		if m.selectionOverlay == nil {
-			log.ErrorLog.Printf("selection overlay is nil")
-		}
-		return overlay.PlaceOverlay(0, 0, m.selectionOverlay.Render(), mainView, true)
 	} else if m.state == stateSearch {
 		if m.searchOverlay == nil {
 			log.ErrorLog.Printf("search overlay is nil")

--- a/app/e2e_test.go
+++ b/app/e2e_test.go
@@ -97,13 +97,7 @@ func installDirectSessionStarter(t *testing.T) {
 			}
 		}
 		inst.Program = req.Program
-		var err error
-		if req.ExistingWorktreePath != "" {
-			err = inst.StartWithExistingWorktree(req.ExistingWorktreePath, req.ExistingWorktreeBranch)
-		} else {
-			err = inst.Start(true)
-		}
-		if err != nil {
+		if err := inst.Start(true); err != nil {
 			return nil, err
 		}
 		if req.Prompt != "" {

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -89,9 +89,6 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 	case keys.KeySearch:
 		return m.showSearchOverlay()
 
-	case keys.KeyAttach:
-		return m.showAttachWorktreeOverlay()
-
 	// Hooks configuration
 	case keys.KeyHooks:
 		m.navigateToSection(ui.SectionHooks)

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -26,8 +26,6 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.state = stateDefault
 		m.namingInstance = nil
-		m.selectedWorktree = nil
-		m.availableWorktrees = nil
 		// Menu.SetState rebuilds the options slice; call it synchronously
 		// on the event-loop goroutine rather than from a tea.Cmd closure
 		// that runs off-loop and races with home.View -> Menu.String.
@@ -80,9 +78,6 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.state = stateDefault
 		m.menu.SetState(ui.StateDefault)
 
-		selectedWt := m.selectedWorktree
-		m.selectedWorktree = nil
-		m.availableWorktrees = nil
 		startCmd := func() tea.Msg {
 			req := sessionStartRequest{
 				Title:       instance.Title,
@@ -90,10 +85,6 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				Program:     instance.Program,
 				AutoYes:     m.autoYes,
 				ForceRemote: instance.IsRemote(),
-			}
-			if selectedWt != nil {
-				req.ExistingWorktreePath = selectedWt.Path
-				req.ExistingWorktreeBranch = selectedWt.Branch
 			}
 			started, err := startSessionThroughDaemon(instance, req)
 			return instanceStartedMsg{
@@ -151,8 +142,6 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.namingInstance = nil
 		m.state = stateDefault
-		m.selectedWorktree = nil
-		m.availableWorktrees = nil
 		cmd := m.selectionChanged()
 
 		// Menu.SetState rebuilds the options slice; call it synchronously

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -4,55 +4,12 @@ import (
 	"fmt"
 
 	"github.com/sachiniyer/agent-factory/keys"
-	"github.com/sachiniyer/agent-factory/session"
-	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
-
-// handleStateSelectWorktree handles key events during worktree selection.
-func (m *home) handleStateSelectWorktree(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	shouldClose := m.selectionOverlay.HandleKeyPress(msg)
-	if shouldClose {
-		if m.selectionOverlay.IsSubmitted() {
-			idx := m.selectionOverlay.GetSelectedIndex()
-			wt := m.availableWorktrees[idx]
-			m.selectedWorktree = &wt
-			m.selectionOverlay = nil
-			m.pendingProgram = m.program
-
-			instance, err := session.NewInstance(session.InstanceOptions{
-				Title:   "",
-				Path:    ".",
-				Program: m.pendingProgram,
-			})
-			if err != nil {
-				m.selectedWorktree = nil
-				m.state = stateDefault
-				m.menu.SetState(ui.StateDefault)
-				return m, m.handleError(err)
-			}
-
-			instance.SetStatus(session.Loading)
-			m.sidebar.AddInstance(instance)
-			m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
-			m.namingInstance = instance
-			m.state = stateNew
-			m.menu.SetState(ui.StateNewInstance)
-			return m, nil
-		}
-		m.selectionOverlay = nil
-		m.selectedWorktree = nil
-		m.availableWorktrees = nil
-		m.state = stateDefault
-		m.menu.SetState(ui.StateDefault)
-		return m, nil
-	}
-	return m, nil
-}
 
 // handleStateSelectProgram handles key events during program selection.
 func (m *home) handleStateSelectProgram(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -103,45 +60,6 @@ func (m *home) handleStateSearch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.state = stateDefault
 		return m, tea.Sequence(tea.WindowSize(), m.selectionChanged())
 	}
-	return m, nil
-}
-
-// showAttachWorktreeOverlay displays the worktree selection overlay.
-func (m *home) showAttachWorktreeOverlay() (tea.Model, tea.Cmd) {
-	worktrees, err := git.ListWorktrees(".")
-	if err != nil {
-		return m, m.handleError(fmt.Errorf("failed to list worktrees: %v", err))
-	}
-	if len(worktrees) == 0 {
-		return m, m.handleError(fmt.Errorf("no worktrees found"))
-	}
-
-	trackedPaths := make(map[string]bool)
-	for _, inst := range m.sidebar.GetInstances() {
-		if p := inst.GetWorktreePath(); p != "" {
-			trackedPaths[p] = true
-		}
-	}
-
-	items := make([]string, len(worktrees))
-	for i, wt := range worktrees {
-		label := wt.Path
-		if wt.Branch != "" {
-			label = fmt.Sprintf("%s (%s)", wt.Branch, wt.Path)
-		}
-		if wt.IsMainWorktree {
-			label += " [root]"
-		}
-		if trackedPaths[wt.Path] {
-			label += " [has session]"
-		}
-		items[i] = label
-	}
-
-	m.availableWorktrees = worktrees
-	m.selectionOverlay = overlay.NewSelectionOverlay("Attach to existing worktree", items)
-	m.selectionOverlay.SetWidth(60)
-	m.state = stateSelectWorktree
 	return m, nil
 }
 

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -6,28 +6,24 @@ import (
 )
 
 type sessionStartRequest struct {
-	Title                  string
-	TitleBase              string
-	RepoPath               string
-	Program                string
-	Prompt                 string
-	AutoYes                bool
-	ForceRemote            bool
-	ExistingWorktreePath   string
-	ExistingWorktreeBranch string
+	Title       string
+	TitleBase   string
+	RepoPath    string
+	Program     string
+	Prompt      string
+	AutoYes     bool
+	ForceRemote bool
 }
 
 var startSessionThroughDaemon = func(_ *session.Instance, req sessionStartRequest) (*session.Instance, error) {
 	data, err := daemon.CreateSession(daemon.CreateSessionRequest{
-		Title:                  req.Title,
-		TitleBase:              req.TitleBase,
-		RepoPath:               req.RepoPath,
-		Program:                req.Program,
-		Prompt:                 req.Prompt,
-		AutoYes:                req.AutoYes,
-		ForceRemote:            req.ForceRemote,
-		ExistingWorktreePath:   req.ExistingWorktreePath,
-		ExistingWorktreeBranch: req.ExistingWorktreeBranch,
+		Title:       req.Title,
+		TitleBase:   req.TitleBase,
+		RepoPath:    req.RepoPath,
+		Program:     req.Program,
+		Prompt:      req.Prompt,
+		AutoYes:     req.AutoYes,
+		ForceRemote: req.ForceRemote,
 	})
 	if err != nil {
 		return nil, err

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -39,15 +39,13 @@ var ensureDaemonMu sync.Mutex
 // CreateSessionRequest is the daemon-owned session creation contract used by
 // the TUI, CLI, and scheduled task runner.
 type CreateSessionRequest struct {
-	Title                  string
-	TitleBase              string
-	RepoPath               string
-	Program                string
-	Prompt                 string
-	AutoYes                bool
-	ForceRemote            bool
-	ExistingWorktreePath   string
-	ExistingWorktreeBranch string
+	Title       string
+	TitleBase   string
+	RepoPath    string
+	Program     string
+	Prompt      string
+	AutoYes     bool
+	ForceRemote bool
 }
 
 type CreateSessionResponse struct {
@@ -849,16 +847,9 @@ func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData,
 		return session.InstanceData{}, err
 	}
 
-	if req.ExistingWorktreePath != "" && req.ForceRemote {
-		return session.InstanceData{}, fmt.Errorf("remote sessions cannot use an existing local worktree")
-	}
-
-	if req.ExistingWorktreePath != "" {
-		err = instance.StartWithExistingWorktree(req.ExistingWorktreePath, req.ExistingWorktreeBranch)
-	} else {
-		err = task.StartAndSendPrompt(instance, req.Prompt)
-	}
-	if err != nil {
+	// Every instance now owns a fresh worktree 1:1 (#930 PR 3 removed the
+	// create-on-existing-worktree path): there is a single creation flow.
+	if err = task.StartAndSendPrompt(instance, req.Prompt); err != nil {
 		_ = instance.Kill()
 		return session.InstanceData{}, fmt.Errorf("failed to start instance: %w", err)
 	}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -27,7 +27,6 @@ const (
 
 	KeyTask
 	KeyTaskList
-	KeyAttach
 
 	KeySearch      // Key for searching sessions
 	KeyTriggerTask // Key for triggering a task immediately
@@ -64,7 +63,6 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"?":          KeyHelp,
 	"s":          KeyTask,
 	"S":          KeyTaskList,
-	"a":          KeyAttach,
 	"/":          KeySearch,
 	"r":          KeyTriggerTask,
 	"p":          KeyOpenPR,
@@ -135,10 +133,6 @@ var GlobalKeyBindings = map[KeyName]key.Binding{
 	KeyTaskList: key.NewBinding(
 		key.WithKeys("S"),
 		key.WithHelp("S", "list tasks"),
-	),
-	KeyAttach: key.NewBinding(
-		key.WithKeys("a"),
-		key.WithHelp("a", "attach worktree"),
 	),
 	KeySearch: key.NewBinding(
 		key.WithKeys("/"),

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -55,7 +54,15 @@ type GitWorktree struct {
 	branchName string
 	// Base commit hash for the worktree
 	baseCommitSHA string
-	// externalWorktree is true if the worktree was not created by agent-factory
+	// externalWorktree is true if the worktree was not created by agent-factory.
+	//
+	// Legacy back-compat (#930 PR 3): this was only ever set true by the
+	// removed create-on-existing-worktree feature. No code path sets it true
+	// anymore, so every newly created worktree has it false. It is still read
+	// from storage and honored by Cleanup() (which no-ops for external
+	// worktrees) so pre-existing instances created by the old feature do not
+	// have their user-owned worktree/branch destroyed on kill. A future PR
+	// drops this field once no persisted instance carries it.
 	externalWorktree bool
 	// branchCreatedByUs is true if this session created the underlying branch
 	// itself (via setupNewWorktree). When false, Cleanup() must NOT delete the
@@ -66,13 +73,6 @@ type GitWorktree struct {
 	// outlive the worktree itself.
 	hooksCtx    context.Context
 	hooksCancel context.CancelFunc
-}
-
-// WorktreeInfo holds information about an existing git worktree
-type WorktreeInfo struct {
-	Path           string
-	Branch         string
-	IsMainWorktree bool
 }
 
 // IsExternalWorktree returns true if this worktree was not created by agent-factory
@@ -213,104 +213,4 @@ func (g *GitWorktree) GetRepoName() string {
 // GetBaseCommitSHA returns the base commit SHA for the worktree
 func (g *GitWorktree) GetBaseCommitSHA() string {
 	return g.baseCommitSHA
-}
-
-// NewGitWorktreeFromExistingWorktree creates a GitWorktree that points at an existing worktree
-// not created by agent-factory. It determines the baseCommitSHA via git merge-base.
-func NewGitWorktreeFromExistingWorktree(repoPath, worktreePath, branchName string) (*GitWorktree, error) {
-	// Resolve the repo root
-	absRepo, err := filepath.Abs(repoPath)
-	if err != nil {
-		absRepo = repoPath
-	}
-	repoRoot, err := findGitRepoRoot(absRepo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find git repo root: %w", err)
-	}
-
-	// Get the base commit SHA via merge-base between HEAD and the branch
-	cmd := exec.Command("git", "-C", repoRoot, "merge-base", "HEAD", branchName)
-	output, err := cmd.Output()
-	baseCommitSHA := ""
-	if err == nil {
-		baseCommitSHA = strings.TrimSpace(string(output))
-	} else {
-		// Fallback: use HEAD if merge-base fails (e.g. detached HEAD)
-		cmd2 := exec.Command("git", "-C", repoRoot, "rev-parse", "HEAD")
-		out2, err2 := cmd2.Output()
-		if err2 == nil {
-			baseCommitSHA = strings.TrimSpace(string(out2))
-		}
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	return &GitWorktree{
-		repoPath:          repoRoot,
-		worktreePath:      worktreePath,
-		worktreeDir:       filepath.Dir(worktreePath),
-		branchName:        branchName,
-		baseCommitSHA:     baseCommitSHA,
-		externalWorktree:  true,
-		branchCreatedByUs: false,
-		hooksCtx:          ctx,
-		hooksCancel:       cancel,
-	}, nil
-}
-
-// ListWorktrees returns all worktrees for the given repo, including the main worktree.
-// The main worktree (root tree) is marked with IsMainWorktree=true.
-func ListWorktrees(repoPath string) ([]WorktreeInfo, error) {
-	absPath, err := filepath.Abs(repoPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get absolute path: %w", err)
-	}
-
-	repoRoot, err := findGitRepoRoot(absPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find git repo root: %w", err)
-	}
-
-	cmd := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list worktrees: %w", err)
-	}
-
-	var worktrees []WorktreeInfo
-	currentPath := ""
-	currentBranch := ""
-	isFirst := true
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if strings.HasPrefix(line, "worktree ") {
-			currentPath = strings.TrimPrefix(line, "worktree ")
-		} else if strings.HasPrefix(line, "branch ") {
-			branchPath := strings.TrimPrefix(line, "branch ")
-			currentBranch = strings.TrimPrefix(branchPath, "refs/heads/")
-		} else if line == "" {
-			if currentPath != "" {
-				worktrees = append(worktrees, WorktreeInfo{
-					Path:           currentPath,
-					Branch:         currentBranch,
-					IsMainWorktree: isFirst,
-				})
-				isFirst = false
-			}
-			currentPath = ""
-			currentBranch = ""
-		}
-	}
-	// Handle last entry if output doesn't end with a blank line
-	if currentPath != "" {
-		worktrees = append(worktrees, WorktreeInfo{
-			Path:           currentPath,
-			Branch:         currentBranch,
-			IsMainWorktree: isFirst,
-		})
-	}
-
-	if len(worktrees) == 0 {
-		return nil, nil
-	}
-	return worktrees, nil
 }

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -328,6 +328,65 @@ func TestCleanup_DeletesBranchWeCreated(t *testing.T) {
 		"branch created by the session should be deleted by Cleanup")
 }
 
+// TestCleanup_LegacyExternalWorktreeIsPreserved is the #930 PR 3 back-compat
+// safety. PR 3 removed the create-on-existing-worktree feature, but instances
+// persisted by the OLD feature carry externalWorktree=true /
+// branchCreatedByUs=false on disk. When such a record is restored via
+// NewGitWorktreeFromStorage and later killed, Cleanup() must remain a no-op:
+// it must NOT remove the user's worktree directory or delete their branch.
+// Removing the legacy field handling now would destroy user data on kill — so
+// it stays until a future PR confirms no persisted instance carries it.
+func TestCleanup_LegacyExternalWorktreeIsPreserved(t *testing.T) {
+	sandboxHome(t)
+
+	repoRoot := createGitRepo(t)
+	env := append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+
+	// Initial commit so HEAD is valid.
+	commitCmd := exec.Command("git", "-C", repoRoot, "commit", "--allow-empty", "-m", "initial")
+	commitCmd.Env = env
+	out, err := commitCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	// A user-owned branch + worktree, exactly what the removed feature would
+	// have attached an instance to.
+	branchCmd := exec.Command("git", "-C", repoRoot, "branch", "user/keep-me")
+	out, err = branchCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	externalWtPath := filepath.Join(t.TempDir(), "external-wt")
+	addCmd := exec.Command("git", "-C", repoRoot, "worktree", "add", externalWtPath, "user/keep-me")
+	out, err = addCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	// Restore the instance from disk the way FromInstanceData does for a record
+	// written by the old feature: externalWorktree=true, branchCreatedByUs=false.
+	gw, err := NewGitWorktreeFromStorage(
+		repoRoot, externalWtPath, "legacy", "user/keep-me", "",
+		true,  // externalWorktree (legacy)
+		false, // branchCreatedByUs
+	)
+	require.NoError(t, err)
+	require.True(t, gw.IsExternalWorktree(), "restored legacy worktree must report external")
+
+	// Cleanup must be a no-op for an external worktree.
+	require.NoError(t, gw.Cleanup())
+
+	// The worktree directory must still exist.
+	_, statErr := os.Stat(externalWtPath)
+	require.NoError(t, statErr,
+		"external worktree directory must NOT be removed by Cleanup (#930 PR 3 back-compat)")
+
+	// The branch must still exist.
+	verifyCmd := exec.Command("git", "-C", repoRoot, "show-ref", "--verify", "refs/heads/user/keep-me")
+	out, err = verifyCmd.CombinedOutput()
+	require.NoError(t, err,
+		"user-owned branch must NOT be deleted by Cleanup; output: %s", string(out))
+}
+
 // TestCleanup_PrunesBeforeBranchDelete is a regression test for #611. When
 // `git worktree remove -f` fails (e.g. the worktree's `.git` pointer file
 // has been removed externally), git retains internal worktree metadata.

--- a/session/instance.go
+++ b/session/instance.go
@@ -259,6 +259,15 @@ func (i *Instance) ToInstanceData() InstanceData {
 	// Only include worktree data if gitWorktree is initialized
 	if i.gitWorktree != nil {
 		branchCreatedByUs := i.gitWorktree.BranchCreatedByUs()
+		// ExternalWorktree is legacy back-compat (#930 PR 3): the create-on-
+		// existing-worktree feature that set it true was removed, so new
+		// instances always serialize false here. We still write/read whatever
+		// the worktree reports so pre-existing instances created by the old
+		// feature keep externalWorktree=true and Cleanup() keeps skipping
+		// their user-owned worktree+branch. A future PR drops the field once
+		// no persisted instance carries it. (BranchCreatedByUs is NOT legacy —
+		// it still flips false on the normal path when Setup reuses an existing
+		// branch; see git/worktree_ops.go setupFromExistingBranch.)
 		data.Worktree = GitWorktreeData{
 			RepoPath:          i.gitWorktree.GetRepoPath(),
 			WorktreePath:      i.gitWorktree.GetWorktreePath(),
@@ -572,42 +581,6 @@ func (i *Instance) GetTitle() string {
 // firstTimeSetup is true if this is a new instance. Otherwise, it's one loaded from storage.
 func (i *Instance) Start(firstTimeSetup bool) error {
 	return i.backend.Start(i, firstTimeSetup)
-}
-
-// StartWithExistingWorktree starts the instance using an existing worktree
-// instead of creating a new one. The worktree and branch are not deleted on kill.
-func (i *Instance) StartWithExistingWorktree(worktreePath, branchName string) error {
-	if i.Title == "" {
-		return fmt.Errorf("instance title cannot be empty")
-	}
-
-	gitWorktree, err := git.NewGitWorktreeFromExistingWorktree(i.Path, worktreePath, branchName)
-	if err != nil {
-		return fmt.Errorf("failed to create git worktree reference: %w", err)
-	}
-
-	i.mu.Lock()
-	i.gitWorktree = gitWorktree
-	i.Branch = branchName
-	i.mu.Unlock()
-
-	program := injectSystemPrompt(i.Program, resolveProgramForInstance(i), i.Title, worktreePath)
-	tmuxSession := tmux.NewTmuxSessionForRepo(i.Title, i.Path, program)
-
-	i.mu.Lock()
-	i.setTmuxLocked(tmuxSession)
-	i.mu.Unlock()
-
-	// Start is I/O; do not hold the lock.
-	if err := tmuxSession.Start(worktreePath); err != nil {
-		return fmt.Errorf("failed to start tmux session: %w", err)
-	}
-
-	i.mu.Lock()
-	i.started = true
-	i.mu.Unlock()
-
-	return nil
 }
 
 // Kill terminates the instance and cleans up all resources

--- a/session/instance_test.go
+++ b/session/instance_test.go
@@ -97,7 +97,7 @@ func TestGetGitWorktree_RaceWithStart(t *testing.T) {
 	wg.Add(2)
 
 	// Writer goroutine: mirrors the lock-protected writes in
-	// StartWithExistingWorktree (i.gitWorktree, then i.started).
+	// LocalBackend.Start (i.gitWorktree, then i.started).
 	go func() {
 		defer wg.Done()
 		for n := 0; n < iterations; n++ {

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -60,7 +60,7 @@ type Menu struct {
 	keyDown keys.KeyName
 }
 
-var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyNewRemote, keys.KeyAttach, keys.KeySearch, keys.KeyHelp, keys.KeyQuit}
+var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyNewRemote, keys.KeySearch, keys.KeyHelp, keys.KeyQuit}
 var newInstanceMenuOptions = []keys.KeyName{keys.KeySubmitName, keys.KeyChangeProgram}
 
 func NewMenu() *Menu {
@@ -173,7 +173,7 @@ func (m *Menu) addInstanceOptions() {
 	}
 
 	// Instance management group
-	mgmtGroup := []keys.KeyName{keys.KeyNew, keys.KeyAttach, keys.KeyKill}
+	mgmtGroup := []keys.KeyName{keys.KeyNew, keys.KeyKill}
 
 	// Action group
 	actionGroup := []keys.KeyName{keys.KeyEnter}


### PR DESCRIPTION
Part of #930 (PR 3 of 7 in the ephemeral-tabs epic).

Now that an instance is effectively 1:1 with a worktree, this removes the parallel **"create an instance on an existing worktree"** feature, collapsing session creation to a single fresh-worktree path. This is a deletion PR — the "less code" dividend. No new behavior (the new-tab hotkey that reuses `a` is PR 4).

## Deleted
- **TUI binding/handler:** `KeyAttach` (`a`) and `showAttachWorktreeOverlay` — the `a` key is now free (PR 4 reuses it).
- **FSM/overlay:** `stateSelectWorktree`, `handleStateSelectWorktree`, and the `selectedWorktree` / `availableWorktrees` fields on `home` (plus their render branch and key-routing).
- **Request plumbing:** `sessionStartRequest.ExistingWorktreePath`/`ExistingWorktreeBranch`, `daemon.CreateSessionRequest.ExistingWorktreePath`/`ExistingWorktreeBranch`, and the `Manager.CreateSession` branch that called `StartWithExistingWorktree` — leaving one creation flow (`task.StartAndSendPrompt`).
- **Core:** `Instance.StartWithExistingWorktree`, `git.NewGitWorktreeFromExistingWorktree`, and the now-unused `git.ListWorktrees` + `git.WorktreeInfo` (grep-confirmed no remaining callers).
- **Menu/help:** the management menu no longer advertises "attach worktree".

**Net: 107 insertions, 310 deletions (≈ −200 lines).**

## Data-safety (back-compat deliberately kept)
The `ExternalWorktree` / `BranchCreatedByUs` fields and their `Cleanup()` handling are **NOT** removed. Instances persisted by the old feature carry `externalWorktree=true` / `branchCreatedByUs=false` on disk, and `Cleanup()` uses those to **avoid** deleting a user's reused branch or removing an external worktree. Dropping that handling now would destroy user data on kill.

So: new code no longer **writes** external/reused state (the feature that set it is gone — new instances are always created-by-us with their own worktree), but still **reads and honors** stored values so pre-existing instances clean up correctly. The surviving field is marked legacy with a `#930 PR 3` comment; a future PR removes it once no persisted instance carries it. (`BranchCreatedByUs` is *not* legacy — it still flips false on the normal path when `Setup` reuses an existing branch.)

## Adjacent-call-site audit
Grepped the whole repo for `StartWithExistingWorktree`, `NewGitWorktreeFromExistingWorktree`, `stateSelectWorktree`, `ExistingWorktree`, `showAttachWorktreeOverlay`, `availableWorktrees`, `selectedWorktree`, `KeyAttach`, `ListWorktrees`, `WorktreeInfo` → all removed/updated, no dangling references. Confirmed `a` maps to nothing stale, the menu/help no longer mention attach-worktree, and docs/`af --help` don't reference it.

## Tests
- Removed the deleted-feature branches from the e2e direct session-starter and updated a stale comment in `instance_test.go`.
- Added `TestCleanup_LegacyExternalWorktreeIsPreserved`: restores a legacy external worktree via `NewGitWorktreeFromStorage` (`externalWorktree=true`, `branchCreatedByUs=false`) and asserts `Cleanup()` is a no-op — the user's branch and worktree directory both survive.
- Existing fresh-worktree-creation and cleanup tests stay green.

## Verification
- `gofmt -l .` clean; `go build ./...` clean; `golangci-lint run --timeout=3m --fast` clean; `deadcode -test ./...` clean.
- `env -u SHELL TERM=dumb go test ./ui/ ./session/ ./app/` → all pass.
- Full `go test ./...` green except the two known `cli_daemon_integration_test.go` daemon-readiness flakes (real-daemon contention under full-suite load on the dev box); both pass in isolation.

— Captain Claude