### PR TITLE
feat(ui): human new-tab (t) / close-tab (w) / number-jump hotkeys for ephemeral tabs (#930, PR 4/7)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -860,6 +860,17 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m.handleQuit()
 	}
 
+	// Number-key tab jump (1-9): jump directly to that tab in the instance
+	// tabbed window (#930 PR 4). Handled here, before the GlobalKeyStringsMap
+	// lookup, because digits are dispatched manually rather than mapped to a
+	// KeyName. Gated to the instance view so digits typed into a focused
+	// task/hooks pane (handled above) or elsewhere pass through untouched.
+	if m.contentPane.GetMode() == ui.ContentModeInstance && len(msg.Runes) == 1 {
+		if r := msg.Runes[0]; r >= '1' && r <= '9' {
+			return m.handleTabJump(int(r - '0'))
+		}
+	}
+
 	name, ok := keys.GlobalKeyStringsMap[msg.String()]
 	if !ok {
 		return m, nil

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -124,6 +124,12 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 		}
 		return m, nil
 
+	// Tab lifecycle (instance mode only)
+	case keys.KeyNewTab:
+		return m.handleNewTab()
+	case keys.KeyCloseTab:
+		return m.handleCloseTab()
+
 	// Instance actions
 	case keys.KeyKill:
 		return m.handleKill()
@@ -303,9 +309,14 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 			// remote-ness, exactly like the sidebar path below: a remote
 			// terminal_cmd detach needs the #845/#848 full reset + reassert,
 			// or the TUI keeps rendering on the main screen (#889).
+			// Capture the active tab index at Enter-press time alongside the
+			// instance (#716): a background refresh could otherwise drift the
+			// selection — or the user could change tabs while the help overlay is
+			// open — before the deferred attach callback runs.
+			activeTab := tw.GetActiveTab()
 			return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
 				return attachOverlayCallbackFn(m, "handleEnter-terminal", "", selected.IsRemote(), func() (chan struct{}, error) {
-					return tw.AttachTerminalForInstance(selected)
+					return tw.AttachTerminalForInstance(selected, activeTab)
 				})
 			})
 		}
@@ -316,6 +327,84 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		})
 	}
 	return m, nil
+}
+
+// handleNewTab spawns a new shell tab in the selected instance and selects it
+// (#930 PR 4). Single keypress, no prompt: the tab runs $SHELL in the instance's
+// worktree. Remote instances have no local worktree, so new-tab is unsupported
+// there and surfaces the same "not available for remote" guidance as the remote
+// terminal tab. The soft cap (max 9 tabs) is enforced by Instance.AddShellTab,
+// whose error is surfaced verbatim. The grown tab list is persisted so the new
+// tab survives a restart (Sachin's #930 requirement).
+func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
+	if m.contentPane.GetMode() != ui.ContentModeInstance {
+		return m, nil
+	}
+	selected := m.sidebar.GetSelectedInstance()
+	if selected == nil {
+		return m, nil
+	}
+	if status := selected.GetStatus(); status == session.Loading || status == session.Deleting {
+		return m, nil
+	}
+	if selected.IsRemote() {
+		return m, m.handleError(fmt.Errorf("new tabs are not available for remote sessions"))
+	}
+	if _, err := selected.AddShellTab(); err != nil {
+		return m, m.handleError(err)
+	}
+	tw := m.contentPane.TabbedWindow()
+	tw.SelectLastTab()
+	m.menu.SetActiveTab(tw.GetActiveTab())
+	if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
+		log.ErrorLog.Printf("failed to persist new tab: %v", err)
+	}
+	return m, m.selectionChanged()
+}
+
+// handleCloseTab closes the active tab of the selected instance and selects the
+// previous (left) tab (#930 PR 4). The agent tab (index 0) is unclosable — w on
+// it is a gentle no-op message pointing at D for killing the whole session.
+// Remote instances carry only the synthetic agent/terminal slots, neither of
+// which is a real closable Tab. The shrunk tab list is persisted.
+func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
+	if m.contentPane.GetMode() != ui.ContentModeInstance {
+		return m, nil
+	}
+	selected := m.sidebar.GetSelectedInstance()
+	if selected == nil {
+		return m, nil
+	}
+	tw := m.contentPane.TabbedWindow()
+	idx := tw.GetActiveTab()
+	if idx <= 0 {
+		return m, m.handleError(fmt.Errorf("the agent tab can't be closed; use D to kill the session"))
+	}
+	if selected.IsRemote() {
+		return m, m.handleError(fmt.Errorf("remote session tabs can't be closed"))
+	}
+	if err := selected.CloseTab(idx); err != nil {
+		return m, m.handleError(err)
+	}
+	// Prefer the left/previous neighbor; SelectTab clamps so this is always in
+	// range (idx >= 1, so idx-1 >= 0).
+	tw.SelectTab(idx - 1)
+	m.menu.SetActiveTab(tw.GetActiveTab())
+	if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
+		log.ErrorLog.Printf("failed to persist tab close: %v", err)
+	}
+	return m, m.selectionChanged()
+}
+
+// handleTabJump jumps the tabbed window to a 1-based tab number (the 1-9 number
+// keys). Out-of-range numbers are a no-op (#930 PR 4).
+func (m *home) handleTabJump(oneBased int) (tea.Model, tea.Cmd) {
+	tw := m.contentPane.TabbedWindow()
+	if !tw.JumpToTab(oneBased - 1) {
+		return m, nil
+	}
+	m.menu.SetActiveTab(tw.GetActiveTab())
+	return m, m.selectionChanged()
 }
 
 // handleOpenPR opens the PR URL in the browser.

--- a/app/help.go
+++ b/app/help.go
@@ -62,10 +62,15 @@ func (h helpTypeGeneral) toContent() string {
 		keyStyle.Render("p")+descStyle.Render("         - Open PR in browser"),
 		keyStyle.Render("P")+descStyle.Render("         - Copy PR URL to clipboard"),
 		"",
+		headerStyle.Render("Tabs:"),
+		keyStyle.Render("tab")+descStyle.Render("       - Switch to the next tab"),
+		keyStyle.Render("shift+tab")+descStyle.Render(" - Switch to the previous tab"),
+		keyStyle.Render("1-9")+descStyle.Render("       - Jump directly to a tab by number"),
+		keyStyle.Render("t")+descStyle.Render("         - Open a new terminal tab"),
+		keyStyle.Render("w")+descStyle.Render("         - Close the current tab (the agent tab can't be closed)"),
+		keyStyle.Render("shift-↓/↑")+descStyle.Render(" - Scroll in the current tab"),
+		"",
 		headerStyle.Render("Other:"),
-		keyStyle.Render("tab")+descStyle.Render("       - Switch between preview and terminal tabs"),
-		keyStyle.Render("shift+tab")+descStyle.Render(" - Switch tabs in reverse"),
-		keyStyle.Render("shift-↓/↑")+descStyle.Render(" - Scroll in preview/terminal view"),
 		keyStyle.Render("q")+descStyle.Render("         - Quit the application"),
 	)
 	return content
@@ -83,7 +88,7 @@ func (h helpTypeInstanceStart) toContent() string {
 		"",
 		headerStyle.Render("Managing:"),
 		keyStyle.Render("↵/o")+descStyle.Render("   - Attach to the session to interact with it directly"),
-		keyStyle.Render("tab")+descStyle.Render("   - Switch between preview and terminal tabs"),
+		keyStyle.Render("tab")+descStyle.Render("   - Switch between tabs (t new tab, w close, 1-9 jump)"),
 		keyStyle.Render("D")+descStyle.Render("     - Kill (delete) the selected session"),
 	)
 	return content

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -1,0 +1,224 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/ui"
+)
+
+// tabHotkeysPty is a minimal tmux.PtyFactory backed by a real temp file so the
+// attach path can open/close it, forwarding the command to the mock executor so
+// session-existence bookkeeping fires.
+type tabHotkeysPty struct {
+	t       *testing.T
+	cmdExec cmd_test.MockCmdExec
+}
+
+func (p tabHotkeysPty) Start(cmd *exec.Cmd) (*os.File, error) {
+	f, err := os.CreateTemp(p.t.TempDir(), "pty-")
+	if err == nil {
+		_ = p.cmdExec.Run(cmd)
+	}
+	return f, err
+}
+func (p tabHotkeysPty) Close() {}
+
+// nameKeyedTmuxExec tracks tmux session existence per name so an instance's
+// agent session and any shell siblings are independent.
+func nameKeyedTmuxExec() cmd_test.MockCmdExec {
+	existing := map[string]bool{}
+	nameOf := func(cmd *exec.Cmd) string {
+		for i, a := range cmd.Args {
+			switch {
+			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
+				return cmd.Args[i+1]
+			case strings.HasPrefix(a, "-t="):
+				return strings.TrimPrefix(a, "-t=")
+			case strings.HasPrefix(a, "-s="):
+				return strings.TrimPrefix(a, "-s=")
+			}
+		}
+		return ""
+	}
+	return cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			s := cmd.String()
+			n := nameOf(cmd)
+			switch {
+			case strings.Contains(s, "has-session"):
+				if existing[n] {
+					return nil
+				}
+				return fmt.Errorf("session does not exist")
+			case strings.Contains(s, "new-session"):
+				existing[n] = true
+				return nil
+			case strings.Contains(s, "kill-session"):
+				delete(existing, n)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return []byte("content"), nil
+		},
+	}
+}
+
+func setupGitRepoForTabs(t *testing.T, workdir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "--local", "user.email", "test@example.com"},
+		{"config", "--local", "user.name", "Test User"},
+	} {
+		c := exec.Command("git", args...)
+		c.Dir = workdir
+		require.NoError(t, c.Run())
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "test.txt"), []byte("x"), 0644))
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", "init"}} {
+		c := exec.Command("git", args...)
+		c.Dir = workdir
+		require.NoError(t, c.Run())
+	}
+}
+
+// startedLocalInstance returns a started local instance with a live mock-backed
+// agent session and (via LocalBackend.Start) a default shell tab, so handleNewTab
+// / handleCloseTab exercise the real tab-lifecycle path hermetically.
+func startedLocalInstance(t *testing.T, title string) *session.Instance {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	workdir := t.TempDir()
+	setupGitRepoForTabs(t, workdir)
+
+	name := fmt.Sprintf("af-tabs-%s-%d", title, time.Now().UnixNano())
+	cmdExec := nameKeyedTmuxExec()
+	pty := tabHotkeysPty{t: t, cmdExec: cmdExec}
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: name, Path: workdir, Program: "bash"})
+	require.NoError(t, err)
+	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps(name, "bash", pty, cmdExec))
+	require.NoError(t, inst.Start(true))
+	return inst
+}
+
+// selectInstance wires the instance into the sidebar + tabbed window and puts the
+// content pane into instance mode, mirroring what selectionChanged would do.
+func selectInstance(h *home, inst *session.Instance) {
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(h.sidebar.NumInstances() - 1)
+	h.contentPane.SetMode(ui.ContentModeInstance)
+	h.contentPane.TabbedWindow().SetInstance(inst)
+}
+
+// TestHandleNewTabAppendsAndSelects: the new-tab hotkey appends a shell tab and
+// selects it.
+func TestHandleNewTabAppendsAndSelects(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "new")
+	selectInstance(h, inst)
+	require.Equal(t, 2, inst.TabCount(), "start gives an agent + default shell tab")
+
+	_, _ = h.handleNewTab()
+
+	require.Equal(t, 3, inst.TabCount(), "new-tab must append a shell tab")
+	require.Equal(t, 2, h.contentPane.TabbedWindow().GetActiveTab(),
+		"the freshly created tab must be selected")
+}
+
+// TestHandleCloseTabSelectsNeighbor: closing a shell tab removes it and selects
+// the previous (left) tab.
+func TestHandleCloseTabSelectsNeighbor(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "close")
+	selectInstance(h, inst)
+	_, _ = h.handleNewTab() // now agent + shell + shell-2, active = 2
+	require.Equal(t, 3, inst.TabCount())
+	require.Equal(t, 2, h.contentPane.TabbedWindow().GetActiveTab())
+
+	_, _ = h.handleCloseTab()
+
+	require.Equal(t, 2, inst.TabCount(), "close must remove the active tab")
+	require.Equal(t, 1, h.contentPane.TabbedWindow().GetActiveTab(),
+		"close must select the left neighbor")
+}
+
+// TestHandleCloseTabAgentTabNoOp: w on the agent tab (index 0) is a gentle no-op
+// with a message, never closing it.
+func TestHandleCloseTabAgentTabNoOp(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "agentnoop")
+	selectInstance(h, inst)
+	h.contentPane.TabbedWindow().JumpToTab(0)
+	require.Equal(t, 2, inst.TabCount())
+
+	_, _ = h.handleCloseTab()
+
+	require.Equal(t, 2, inst.TabCount(), "the agent tab must never be closed")
+	h.errBox.SetSize(200, 1)
+	require.Contains(t, h.errBox.String(), "agent tab can't be closed")
+}
+
+// TestHandleNewTabRemoteShowsMessage: new-tab is unsupported for remote
+// instances and creates nothing.
+func TestHandleNewTabRemoteShowsMessage(t *testing.T) {
+	h := newTestHome(t)
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "remote", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	inst.SetBackend(&session.HookBackend{})
+	require.True(t, inst.IsRemote())
+	selectInstance(h, inst)
+
+	_, _ = h.handleNewTab()
+
+	require.Equal(t, 0, inst.TabCount(), "remote instances must not gain a local tab")
+	h.errBox.SetSize(200, 1)
+	require.Contains(t, h.errBox.String(), "remote")
+}
+
+// TestHandleTabJump covers the number-key jump handler: in range jumps, out of
+// range is a no-op.
+func TestHandleTabJump(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "jump")
+	selectInstance(h, inst)
+	_, _ = h.handleNewTab() // agent + shell + shell-2 (3 tabs)
+	require.Equal(t, 3, inst.TabCount())
+
+	_, _ = h.handleTabJump(1)
+	require.Equal(t, 0, h.contentPane.TabbedWindow().GetActiveTab(), "1 jumps to tab index 0")
+
+	_, _ = h.handleTabJump(3)
+	require.Equal(t, 2, h.contentPane.TabbedWindow().GetActiveTab(), "3 jumps to tab index 2")
+
+	_, _ = h.handleTabJump(9)
+	require.Equal(t, 2, h.contentPane.TabbedWindow().GetActiveTab(),
+		"an out-of-range number must be a no-op")
+}
+
+// TestNumberKeyRoutesToTabJump proves the digit dispatch in handleKeyPress routes
+// to the jump handler when viewing an instance.
+func TestNumberKeyRoutesToTabJump(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "route")
+	selectInstance(h, inst)
+	_, _ = h.handleNewTab() // 3 tabs
+
+	h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	require.Equal(t, 1, h.contentPane.TabbedWindow().GetActiveTab(),
+		"pressing '2' must jump to tab index 1")
+}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -18,6 +18,10 @@ const (
 	KeyShiftTab   // ShiftTab cycles panes in reverse.
 	KeySubmitName // SubmitName is a special keybinding for submitting the name of a new instance.
 
+	KeyNewTab   // NewTab spawns a new shell tab in the selected instance (#930 PR 4).
+	KeyCloseTab // CloseTab closes the active (non-agent) tab (#930 PR 4).
+	KeyJumpTab  // JumpTab is the 1-9 number-key jump hint; dispatched manually, menu/help only.
+
 	KeyNewRemote // Key for creating a new remote instance
 	KeyHelp      // Key for showing help screen
 
@@ -60,6 +64,8 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"q":          KeyQuit,
 	"tab":        KeyTab,
 	"shift+tab":  KeyShiftTab,
+	"t":          KeyNewTab,
+	"w":          KeyCloseTab,
 	"?":          KeyHelp,
 	"s":          KeyTask,
 	"S":          KeyTaskList,
@@ -125,6 +131,18 @@ var GlobalKeyBindings = map[KeyName]key.Binding{
 	KeyShiftTab: key.NewBinding(
 		key.WithKeys("shift+tab"),
 		key.WithHelp("shift+tab", "prev tab"),
+	),
+	KeyNewTab: key.NewBinding(
+		key.WithKeys("t"),
+		key.WithHelp("t", "new tab"),
+	),
+	KeyCloseTab: key.NewBinding(
+		key.WithKeys("w"),
+		key.WithHelp("w", "close tab"),
+	),
+	KeyJumpTab: key.NewBinding(
+		key.WithKeys("1", "2", "3", "4", "5", "6", "7", "8", "9"),
+		key.WithHelp("1-9", "jump tab"),
 	),
 	KeyTask: key.NewBinding(
 		key.WithKeys("s"),

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -186,26 +186,28 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 		}
 	}
 
-	// Promote the per-instance terminal into a real Shell tab (#930 PR 2). This
-	// is best-effort: a shell-tab failure leaves the instance fully usable with
-	// just the agent tab (the terminal tab renders a fallback), so it must not
-	// fail the whole start. Runs after the agent session is up so the shell tab
-	// can be a sibling of it (sharing tmux deps).
-	b.setupShellTab(i)
+	// Bring up the instance's non-agent tabs (#930 PR 2/4). This is best-effort:
+	// a tab failure leaves the instance fully usable with just the agent tab (the
+	// failed tab renders a fallback), so it must not fail the whole start. Runs
+	// after the agent session is up so each tab can be a sibling of it (sharing
+	// tmux deps).
+	b.setupTabs(i)
 
 	return nil
 }
 
-// setupShellTab ensures the instance has a live Shell tab. On a fresh start (or
-// a legacy restore that predates persisted tabs) it creates a $SHELL session as
-// a sibling of the agent session; on restore of a persisted shell tab it
-// reconnects to the exact tmux session by name so the terminal survives an
-// af/daemon restart.
-func (b *LocalBackend) setupShellTab(i *Instance) {
+// setupTabs brings up an instance's non-agent tabs after its agent session is
+// live. On restore it reconnects every persisted tab (shell and any later
+// process tabs) to its exact tmux session by name so they survive an af/daemon
+// restart, re-spawning in the worktree only if the tmux server died across a
+// reboot (Restore handles both). On a fresh start — or a legacy restore that
+// predates persisted tabs — when no live shell tab exists it creates the default
+// $SHELL tab as a sibling of the agent session.
+func (b *LocalBackend) setupTabs(i *Instance) {
 	i.mu.RLock()
 	agentTmux := i.tmuxLocked()
-	shell := i.shellTabLocked()
 	gw := i.gitWorktree
+	tabs := append([]*Tab(nil), i.Tabs...)
 	i.mu.RUnlock()
 
 	if agentTmux == nil || gw == nil {
@@ -216,12 +218,22 @@ func (b *LocalBackend) setupShellTab(i *Instance) {
 		return
 	}
 
-	// Restore a persisted shell session: reconnect, re-spawning in the worktree
-	// only if the tmux server died across a reboot (Restore handles both).
-	if shell != nil && shell.tmux != nil {
-		if err := shell.tmux.Restore(worktreePath); err != nil {
-			log.WarningLog.Printf("restore shell tab for %q failed: %v", i.Title, err)
+	// Reconnect every persisted non-agent tab that carries a session (Tabs[0] is
+	// the agent tab, already restored by Start). Track whether at least one live
+	// shell tab exists so we don't also create a duplicate default below.
+	hasLiveShell := false
+	for idx, tab := range tabs {
+		if idx == 0 || tab.tmux == nil {
+			continue
 		}
+		if err := tab.tmux.Restore(worktreePath); err != nil {
+			log.WarningLog.Printf("restore tab %q for %q failed: %v", tab.Name, i.Title, err)
+		}
+		if tab.Kind == TabKindShell {
+			hasLiveShell = true
+		}
+	}
+	if hasLiveShell {
 		return
 	}
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -130,69 +130,176 @@ func (i *Instance) GetTabs() []*Tab {
 	return out
 }
 
-// PreviewShellTab captures the detached content of the instance's shell tab.
-// Returns ("", nil) when the instance is not started or has no live shell tab
-// session, and tmux.ErrSessionGone when the session vanished — mirroring
-// Instance.Preview for the agent tab so the UI can degrade gracefully.
-func (i *Instance) PreviewShellTab() (string, error) {
-	i.mu.RLock()
-	started := i.started
-	tab := i.shellTabLocked()
-	i.mu.RUnlock()
-	if !started || tab == nil || tab.tmux == nil {
-		return "", nil
-	}
-	return tab.tmux.CapturePaneContent()
-}
-
-// PreviewShellTabFullHistory captures the shell tab's full scrollback, used
-// when entering scroll mode. Same nil/started guards as PreviewShellTab.
-func (i *Instance) PreviewShellTabFullHistory() (string, error) {
-	i.mu.RLock()
-	started := i.started
-	tab := i.shellTabLocked()
-	i.mu.RUnlock()
-	if !started || tab == nil || tab.tmux == nil {
-		return "", nil
-	}
-	return tab.tmux.CapturePaneContentWithOptions("-", "-")
-}
-
-// ShellTabAlive reports whether the instance has a live shell tab tmux session.
-func (i *Instance) ShellTabAlive() bool {
-	i.mu.RLock()
-	tab := i.shellTabLocked()
-	i.mu.RUnlock()
-	return tab != nil && tab.tmux != nil && tab.tmux.DoesSessionExist()
-}
-
-// AttachShellTab attaches (interactive PTY) to the instance's shell tab. The
-// captured-instance semantics that protect deferred attach flows from selection
-// drift (#716) are inherent here: the shell session belongs to this instance,
-// so there is no title-keyed cache to drift.
-func (i *Instance) AttachShellTab() (chan struct{}, error) {
-	i.mu.RLock()
-	tab := i.shellTabLocked()
-	i.mu.RUnlock()
-	if tab == nil || tab.tmux == nil {
-		return nil, fmt.Errorf("no terminal session to attach to")
-	}
-	if !tab.tmux.DoesSessionExist() {
-		return nil, fmt.Errorf("terminal session does not exist")
-	}
-	return tab.tmux.Attach()
-}
-
-// SetShellTabDetachedSize resizes the detached shell tab session so its capture
-// matches the pane dimensions. A no-op when there is no live shell tab.
-func (i *Instance) SetShellTabDetachedSize(width, height int) error {
-	i.mu.RLock()
-	tab := i.shellTabLocked()
-	i.mu.RUnlock()
-	if tab == nil || tab.tmux == nil {
+// tabTmuxAtLocked returns the tmux session of the tab at idx, or nil when idx
+// is out of range or the tab has no session. Callers must hold i.mu.
+func (i *Instance) tabTmuxAtLocked(idx int) *tmux.TmuxSession {
+	if idx < 0 || idx >= len(i.Tabs) {
 		return nil
 	}
-	return tab.tmux.SetDetachedSize(width, height)
+	return i.Tabs[idx].tmux
+}
+
+// PreviewTab captures the detached content of the tab at idx. Returns ("", nil)
+// when the instance is not started or the tab has no live session, and
+// tmux.ErrSessionGone when the session vanished — mirroring Instance.Preview for
+// the agent tab so the UI can degrade gracefully. idx is the same 0-based index
+// the UI tab bar uses (0 is the agent tab; 1+ are shell/process tabs).
+func (i *Instance) PreviewTab(idx int) (string, error) {
+	i.mu.RLock()
+	started := i.started
+	ts := i.tabTmuxAtLocked(idx)
+	i.mu.RUnlock()
+	if !started || ts == nil {
+		return "", nil
+	}
+	return ts.CapturePaneContent()
+}
+
+// PreviewTabFullHistory captures the full scrollback of the tab at idx, used
+// when entering scroll mode. Same nil/started guards as PreviewTab.
+func (i *Instance) PreviewTabFullHistory(idx int) (string, error) {
+	i.mu.RLock()
+	started := i.started
+	ts := i.tabTmuxAtLocked(idx)
+	i.mu.RUnlock()
+	if !started || ts == nil {
+		return "", nil
+	}
+	return ts.CapturePaneContentWithOptions("-", "-")
+}
+
+// TabAlive reports whether the tab at idx has a live tmux session.
+func (i *Instance) TabAlive(idx int) bool {
+	i.mu.RLock()
+	ts := i.tabTmuxAtLocked(idx)
+	i.mu.RUnlock()
+	return ts != nil && ts.DoesSessionExist()
+}
+
+// AttachTab attaches (interactive PTY) to the tab at idx. The captured-instance
+// semantics that protect deferred attach flows from selection drift (#716) are
+// inherent here: the tab's session belongs to this instance, so there is no
+// title-keyed cache to drift.
+func (i *Instance) AttachTab(idx int) (chan struct{}, error) {
+	i.mu.RLock()
+	ts := i.tabTmuxAtLocked(idx)
+	i.mu.RUnlock()
+	if ts == nil {
+		return nil, fmt.Errorf("no terminal session to attach to")
+	}
+	if !ts.DoesSessionExist() {
+		return nil, fmt.Errorf("terminal session does not exist")
+	}
+	return ts.Attach()
+}
+
+// SetTabDetachedSize resizes the detached session of the tab at idx so its
+// capture matches the pane dimensions. A no-op when the tab has no live session.
+func (i *Instance) SetTabDetachedSize(idx, width, height int) error {
+	i.mu.RLock()
+	ts := i.tabTmuxAtLocked(idx)
+	i.mu.RUnlock()
+	if ts == nil {
+		return nil
+	}
+	return ts.SetDetachedSize(width, height)
+}
+
+// TabCount returns the number of tabs the instance currently holds.
+func (i *Instance) TabCount() int {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return len(i.Tabs)
+}
+
+// AddShellTab spawns a new Shell-kind tab running $SHELL in the instance's
+// worktree, appends it to Tabs, and returns it. Local instances only — remote
+// instances have no local worktree, so callers must reject IsRemote() before
+// calling. The new tab's display name is unique within the instance ("shell",
+// then "shell-2", "shell-3", …) and its tmux session name is derived from it so
+// it is collision-free and restorable by exact name across a restart (#930 PR
+// 4). Errors when the instance is not started, has no agent session/worktree, or
+// already holds maxTabs tabs.
+func (i *Instance) AddShellTab() (*Tab, error) {
+	i.mu.RLock()
+	started := i.started
+	agentTmux := i.tmuxLocked()
+	gw := i.gitWorktree
+	displayName := uniqueShellName(i.Tabs)
+	nTabs := len(i.Tabs)
+	i.mu.RUnlock()
+
+	if !started || agentTmux == nil || gw == nil {
+		return nil, fmt.Errorf("cannot add a tab to an instance that is not started")
+	}
+	if nTabs >= maxTabs {
+		return nil, fmt.Errorf("max %d tabs per session", maxTabs)
+	}
+	worktreePath := gw.GetWorktreePath()
+	if worktreePath == "" {
+		return nil, fmt.Errorf("cannot add a tab without a worktree")
+	}
+
+	// Spawn outside the lock: Start shells out to `tmux new-session` and polls
+	// for the session to appear, which must not block other readers of i.mu. The
+	// tmux name is derived from the agent session + the unique display name so it
+	// is collision-free and restorable by exact name.
+	tmuxName := agentTmux.SanitizedName() + "__" + displayName
+	shellTmux := agentTmux.NewSiblingSession(tmuxName, defaultShell())
+	if err := shellTmux.Start(worktreePath); err != nil {
+		return nil, fmt.Errorf("failed to start shell tab: %w", err)
+	}
+
+	tab := newShellTab(shellTmux)
+	tab.Name = displayName
+	i.mu.Lock()
+	i.Tabs = append(i.Tabs, tab)
+	i.mu.Unlock()
+	return tab, nil
+}
+
+// CloseTab kills the tab at idx and removes it from Tabs. The agent tab (idx 0)
+// is unclosable; CloseTab errors on idx 0 or any out-of-range index. The tab is
+// removed from Tabs regardless of whether the tmux teardown succeeds (best-
+// effort, matching LocalBackend.Kill) so a broken session can't wedge the tab
+// list. Unlike Kill this does not wait for the pane to exit: the worktree is not
+// being removed, so there is no #802 delete race to guard against.
+func (i *Instance) CloseTab(idx int) error {
+	i.mu.Lock()
+	if idx <= 0 || idx >= len(i.Tabs) {
+		i.mu.Unlock()
+		return fmt.Errorf("tab cannot be closed")
+	}
+	tab := i.Tabs[idx]
+	i.Tabs = append(i.Tabs[:idx], i.Tabs[idx+1:]...)
+	i.mu.Unlock()
+
+	if tab.tmux == nil {
+		return nil
+	}
+	if err := tab.tmux.Close(); err != nil {
+		return fmt.Errorf("failed to close tab %q: %w", tab.Name, err)
+	}
+	return nil
+}
+
+// uniqueShellName returns a shell-tab display name not already used by any tab
+// in tabs: "shell", then "shell-2", "shell-3", … Names are unique per instance
+// so each tab's derived tmux session name is collision-free.
+func uniqueShellName(tabs []*Tab) string {
+	used := make(map[string]bool, len(tabs))
+	for _, t := range tabs {
+		used[t.Name] = true
+	}
+	if !used[shellTabName] {
+		return shellTabName
+	}
+	for n := 2; ; n++ {
+		candidate := fmt.Sprintf("%s-%d", shellTabName, n)
+		if !used[candidate] {
+			return candidate
+		}
+	}
 }
 
 // setTmuxLocked stores ts as the agent tab's tmux session, materializing the

--- a/session/tab.go
+++ b/session/tab.go
@@ -15,6 +15,11 @@ const shellTabName = "shell"
 // exact name across a restart.
 const shellTmuxSuffix = "__shell"
 
+// maxTabs is the soft cap on tabs per instance (#930 PR 4). It matches the 1-9
+// number-key jump range: a session can hold the agent tab plus up to eight
+// shell/process tabs, all reachable by a single number key.
+const maxTabs = 9
+
 // TabKind enumerates the kinds of process a Tab can host within an instance's
 // worktree. PR 1 of the #930 ephemeral-tabs epic only materializes the Agent
 // kind (the single per-instance agent session); Shell and Process are defined

--- a/session/tab_lifecycle_test.go
+++ b/session/tab_lifecycle_test.go
@@ -1,0 +1,194 @@
+package session
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startedMockInstance builds a started local instance whose agent tab is a
+// mock-backed tmux session (#930 PR 4). AddShellTab spawns siblings off that
+// session, so they inherit the mock PTY factory / executor and stay hermetic —
+// no real tmux server is touched. extraAlive marks additional session names as
+// already existing (used by the restart-survival test).
+func startedMockInstance(t *testing.T, agentName string, extraAlive ...string) *Instance {
+	t.Helper()
+	// Isolate config reads from the developer's real ~/.agent-factory (#837).
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	alive := map[string]bool{agentName: true}
+	for _, n := range extraAlive {
+		alive[n] = true
+	}
+	exec := nameKeyedExec(alive)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+
+	repoPath := "/tmp/tab-lifecycle-" + agentName
+	gw, err := git.NewGitWorktreeFromStorage(
+		repoPath, filepath.Join(t.TempDir(), "wt"), agentName,
+		agentName+"-branch", "", false, true)
+	require.NoError(t, err)
+
+	agentTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps(agentName, "claude", pty, exec)
+	return &Instance{
+		Title:       agentName,
+		Path:        repoPath,
+		Program:     "claude",
+		backend:     &LocalBackend{},
+		started:     true,
+		gitWorktree: gw,
+		Tabs:        []*Tab{newAgentTab(agentTs)},
+	}
+}
+
+// TestAddShellTab_AppendsAndNamesUniquely verifies a human-created shell tab is
+// appended, named uniquely per instance ("shell", then "shell-2"), and backed by
+// a distinct live tmux session.
+func TestAddShellTab_AppendsAndNamesUniquely(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_tabs_add")
+
+	tab, err := inst.AddShellTab()
+	require.NoError(t, err)
+	assert.Equal(t, shellTabName, tab.Name, "first shell tab is named %q", shellTabName)
+	assert.Equal(t, TabKindShell, tab.Kind)
+	assert.Equal(t, 2, inst.TabCount())
+	assert.True(t, inst.TabAlive(1), "the new shell tab session must be live")
+
+	tab2, err := inst.AddShellTab()
+	require.NoError(t, err)
+	assert.Equal(t, "shell-2", tab2.Name, "the second shell tab must get a unique name")
+	assert.Equal(t, 3, inst.TabCount())
+	assert.True(t, inst.TabAlive(2))
+	assert.NotEqual(t, tab.tmux.SanitizedName(), tab2.tmux.SanitizedName(),
+		"each shell tab must have a unique tmux session name")
+}
+
+// TestCloseTab_RemovesAndProtectsAgent verifies CloseTab removes a shell tab and
+// kills its session, but refuses to close the agent tab (index 0) or any
+// out-of-range index.
+func TestCloseTab_RemovesAndProtectsAgent(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_tabs_close")
+	_, err := inst.AddShellTab()
+	require.NoError(t, err)
+	require.Equal(t, 2, inst.TabCount())
+
+	require.Error(t, inst.CloseTab(0), "the agent tab must be unclosable")
+	require.Equal(t, 2, inst.TabCount(), "a rejected close must not mutate the tab list")
+
+	require.Error(t, inst.CloseTab(9), "an out-of-range index must be rejected")
+	require.Equal(t, 2, inst.TabCount())
+
+	require.NoError(t, inst.CloseTab(1))
+	require.Equal(t, 1, inst.TabCount(), "closing a shell tab removes it")
+	require.False(t, inst.TabAlive(1), "the closed tab's session must be gone")
+}
+
+// TestAddShellTab_SoftCapAtNine verifies new-tab is refused once the instance
+// already holds maxTabs (9) tabs — the number-key range can't address more.
+func TestAddShellTab_SoftCapAtNine(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_tabs_cap")
+	// Agent tab + 8 shell tabs = 9 == maxTabs.
+	for i := 0; i < maxTabs-1; i++ {
+		_, err := inst.AddShellTab()
+		require.NoError(t, err)
+	}
+	require.Equal(t, maxTabs, inst.TabCount())
+
+	_, err := inst.AddShellTab()
+	require.Error(t, err, "the 10th tab must be refused")
+	require.Contains(t, err.Error(), fmt.Sprintf("%d", maxTabs))
+	require.Equal(t, maxTabs, inst.TabCount(), "the cap must not create a tab")
+}
+
+// TestAddShellTab_RejectedForUnstarted verifies AddShellTab errors when the
+// instance has no live agent session/worktree (e.g. not started).
+func TestAddShellTab_RejectedForUnstarted(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, err := NewInstance(InstanceOptions{Title: "unstarted", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	_, err = inst.AddShellTab()
+	require.Error(t, err)
+	require.Equal(t, 0, inst.TabCount())
+}
+
+// TestUniqueShellName covers the per-instance naming sequence in isolation.
+func TestUniqueShellName(t *testing.T) {
+	assert.Equal(t, "shell", uniqueShellName(nil))
+	assert.Equal(t, "shell-2", uniqueShellName([]*Tab{{Name: "shell"}}))
+	assert.Equal(t, "shell-3", uniqueShellName([]*Tab{{Name: "shell"}, {Name: "shell-2"}}))
+	// A hole in the sequence is filled with the lowest free name.
+	assert.Equal(t, "shell-2", uniqueShellName([]*Tab{{Name: "shell"}, {Name: "shell-3"}}))
+}
+
+// TestRestartSurvival_HumanCreatedShellTab is the PR 4 restart-survival test: a
+// shell tab created by the new-tab hotkey must persist through Storage and
+// reconnect to its exact tmux session across an af/daemon restart, exactly like
+// the default agent+shell pair (PR 2). Builds a started instance, adds an extra
+// shell tab, round-trips it through Storage, and asserts all three tabs reload
+// and reconnect.
+func TestRestartSurvival_HumanCreatedShellTab(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	const agentName = "af_human_tab"
+	shellName := agentName + "__shell"
+	shell2Name := agentName + "__shell-2"
+
+	inst := startedMockInstance(t, agentName)
+	_, err := inst.AddShellTab() // shell
+	require.NoError(t, err)
+	third, err := inst.AddShellTab() // shell-2 — the "human-created" tab under test
+	require.NoError(t, err)
+	require.Equal(t, "shell-2", third.Name)
+	require.Equal(t, 3, inst.TabCount())
+
+	// Persist through Storage and reload with a fresh Storage, restoring sessions
+	// for the exact persisted names so reconnection stays hermetic.
+	repoID := config.RepoIDFromRoot(inst.Path)
+	ms := newMockStorage()
+	saveStore, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+	require.NoError(t, saveStore.SaveInstances([]*Instance{inst}))
+
+	restoreExec := nameKeyedExec(map[string]bool{agentName: true, shellName: true, shell2Name: true})
+	restorePty := persistPtyFactory{t: t, cmdExec: restoreExec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, restorePty, restoreExec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	loadStore, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+	loaded, err := loadStore.LoadInstances()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+
+	restored := loaded[0]
+	tabs := restored.GetTabs()
+	require.Len(t, tabs, 3, "all three tabs (agent + two shells) must survive a restart")
+	assert.Equal(t, TabKindShell, tabs[2].Kind)
+	assert.Equal(t, "shell-2", tabs[2].Name, "the human-created tab keeps its name")
+	assert.Equal(t, shell2Name, tabs[2].tmux.SanitizedName(),
+		"the human-created tab must reconnect to its exact persisted tmux session")
+	assert.True(t, restored.TabAlive(2), "the restored human-created tab must be live")
+}

--- a/session/tab_persist_test.go
+++ b/session/tab_persist_test.go
@@ -170,7 +170,7 @@ func TestRestartSurvival_AgentAndShellTabsReconnect(t *testing.T) {
 	assert.Equal(t, TabKindShell, tabs[1].Kind)
 	assert.Equal(t, shellName, tabs[1].tmux.SanitizedName(),
 		"shell tab must reconnect to its exact persisted tmux session")
-	assert.True(t, restored.ShellTabAlive(),
+	assert.True(t, restored.TabAlive(1),
 		"the restored shell tab session must be live (reconnected) after restart")
 }
 
@@ -225,5 +225,5 @@ func TestRestartSurvival_BackCompatSynthesizesTabs(t *testing.T) {
 	assert.Equal(t, TabKindShell, tabs[1].Kind)
 	assert.Equal(t, shellName, tabs[1].tmux.SanitizedName(),
 		"shell tab must be created fresh with the derived __shell name")
-	assert.True(t, restored.ShellTabAlive(), "the synthesized shell tab must be live")
+	assert.True(t, restored.TabAlive(1), "the synthesized shell tab must be live")
 }

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -135,11 +135,11 @@ func (m *Menu) updateOptions() {
 	switch m.state {
 	case StateEmpty:
 		m.options = defaultMenuOptions
-		// Groups: creation (n, N, a) | search (/) | system (?, q)
+		// Groups: creation (n, N) | search (/) | system (?, q)
 		m.groups = []menuGroup{
-			{start: 0, end: 3, isAction: true},
-			{start: 3, end: 4, isAction: false},
-			{start: 4, end: 6, isAction: false},
+			{start: 0, end: 2, isAction: true},
+			{start: 2, end: 3, isAction: false},
+			{start: 3, end: 5, isAction: false},
 		}
 	case StateDefault:
 		if m.instance != nil {
@@ -149,9 +149,9 @@ func (m *Menu) updateOptions() {
 			// When there is no instance, show the empty state
 			m.options = defaultMenuOptions
 			m.groups = []menuGroup{
-				{start: 0, end: 3, isAction: true},
-				{start: 3, end: 4, isAction: false},
-				{start: 4, end: 6, isAction: false},
+				{start: 0, end: 2, isAction: true},
+				{start: 2, end: 3, isAction: false},
+				{start: 3, end: 5, isAction: false},
 			}
 		}
 	case StateNewInstance:
@@ -184,24 +184,30 @@ func (m *Menu) addInstanceOptions() {
 	actionGroup = append(actionGroup, keys.KeyShiftUp)
 	actionGroup = append(actionGroup, keys.KeyShiftDown)
 
+	// Tab group: cycle, create, close, and number-jump (#930 PR 4).
+	tabGroup := []keys.KeyName{keys.KeyTab, keys.KeyNewTab, keys.KeyCloseTab, keys.KeyJumpTab}
+
 	// System group
-	systemGroup := []keys.KeyName{keys.KeyTab, keys.KeyHelp, keys.KeyQuit}
+	systemGroup := []keys.KeyName{keys.KeyHelp, keys.KeyQuit}
 
 	// Combine all groups and compute boundaries
 	mgmtEnd := len(mgmtGroup)
 	actionEnd := mgmtEnd + len(actionGroup)
-	systemEnd := actionEnd + len(systemGroup)
+	tabEnd := actionEnd + len(tabGroup)
+	systemEnd := tabEnd + len(systemGroup)
 
 	options := make([]keys.KeyName, 0, systemEnd)
 	options = append(options, mgmtGroup...)
 	options = append(options, actionGroup...)
+	options = append(options, tabGroup...)
 	options = append(options, systemGroup...)
 
 	m.options = options
 	m.groups = []menuGroup{
 		{start: 0, end: mgmtEnd, isAction: false},
 		{start: mgmtEnd, end: actionEnd, isAction: true},
-		{start: actionEnd, end: systemEnd, isAction: false},
+		{start: actionEnd, end: tabEnd, isAction: false},
+		{start: tabEnd, end: systemEnd, isAction: false},
 	}
 }
 

--- a/ui/preview_remote_test.go
+++ b/ui/preview_remote_test.go
@@ -47,7 +47,7 @@ func TestPreviewRemoteHookStripsControlSequences(t *testing.T) {
 
 	pane := NewTabPane()
 	pane.SetSize(80, 24)
-	require.NoError(t, pane.UpdateContent(instance, true))
+	require.NoError(t, pane.UpdateContent(instance, 0))
 	out := pane.String()
 
 	require.Contains(t, out, "hello")

--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -35,10 +35,10 @@ const staleScrollMarker = "STALE-SCROLL-VIEWPORT-CONTENT"
 // clears it.
 func enterScrollWithStaleViewport(p *TabPane, inst *session.Instance) {
 	p.currentInstance = inst
-	// Adopt the agent slot too, so dropStaleView sees no (instance, slot) change
-	// when UpdateContent(inst, true) runs — we want to prove setFallbackState is
+	// Adopt the agent slot too, so dropStaleView sees no (instance, tab) change
+	// when UpdateContent(inst, 0) runs — we want to prove setFallbackState is
 	// what clears scroll mode, not the view-change guard.
-	p.currentAgentSlot = true
+	p.currentTab = 0
 	p.isScrolling = true
 	p.viewport.SetContent(staleScrollMarker)
 }
@@ -61,7 +61,7 @@ func TestPreviewScrollModeThenDeletingFallback(t *testing.T) {
 	p.SetSize(80, 30)
 	enterScrollWithStaleViewport(p, inst)
 
-	require.NoError(t, p.UpdateContent(inst, true))
+	require.NoError(t, p.UpdateContent(inst, 0))
 
 	require.False(t, p.isScrolling,
 		"entering the Deleting fallback must exit scroll mode")
@@ -86,13 +86,13 @@ func TestPreviewScrollModeThenNilInstanceFallback(t *testing.T) {
 	p := NewTabPane()
 	p.SetSize(80, 30)
 	// currentInstance stays nil and we adopt the agent slot so dropStaleView
-	// (nil==nil, slot unchanged) does not reset scroll itself — setFallbackState
+	// (nil==nil, tab unchanged) does not reset scroll itself — setFallbackState
 	// must.
-	p.currentAgentSlot = true
+	p.currentTab = 0
 	p.isScrolling = true
 	p.viewport.SetContent(staleScrollMarker)
 
-	require.NoError(t, p.UpdateContent(nil, true))
+	require.NoError(t, p.UpdateContent(nil, 0))
 
 	require.False(t, p.isScrolling,
 		"the nil-instance fallback must exit scroll mode")
@@ -123,7 +123,7 @@ func TestPreviewScrollModeThenLoadingFallback(t *testing.T) {
 	p.SetSize(80, 30)
 	enterScrollWithStaleViewport(p, inst)
 
-	require.NoError(t, p.UpdateContent(inst, true))
+	require.NoError(t, p.UpdateContent(inst, 0))
 
 	require.False(t, p.isScrolling,
 		"entering the Loading fallback must exit scroll mode")
@@ -157,7 +157,7 @@ func TestPreviewScrollModeViewportContentCleared(t *testing.T) {
 	require.Contains(t, p.viewport.View(), staleScrollMarker,
 		"precondition: viewport holds stale scroll content")
 
-	require.NoError(t, p.UpdateContent(inst, true))
+	require.NoError(t, p.UpdateContent(inst, 0))
 
 	require.False(t, p.isScrolling, "scroll mode must be exited")
 	require.NotContains(t, p.viewport.View(), staleScrollMarker,
@@ -210,13 +210,13 @@ func TestPreviewScrollModeThenSessionGoneFallback(t *testing.T) {
 
 	// Register currentInstance via a live render so ScrollUp's dropStaleScrollState
 	// guard does not reset scroll on the instance-switch path.
-	require.NoError(t, p.UpdateContent(setup.instance, true))
+	require.NoError(t, p.UpdateContent(setup.instance, 0))
 
 	// Session vanishes; entering scroll mode now fails the PreviewFullHistory
 	// capture with ErrSessionGone and routes through setFallbackState.
 	sessionGone.Store(true)
 
-	require.NoError(t, p.ScrollUp(setup.instance, true))
+	require.NoError(t, p.ScrollUp(setup.instance, 0))
 
 	require.False(t, p.isScrolling,
 		"session-gone while entering scroll mode must not leave the pane scrolling")

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -238,7 +238,7 @@ func TestPreviewScrolling(t *testing.T) {
 	previewPane.SetSize(80, 30) // Set reasonable size for testing
 
 	// Step 1: Check initial content - should show normal preview mode
-	err = previewPane.UpdateContent(setup.instance, true)
+	err = previewPane.UpdateContent(setup.instance, 0)
 	require.NoError(t, err)
 
 	// Verify we're not in scrolling mode initially
@@ -253,7 +253,7 @@ func TestPreviewScrolling(t *testing.T) {
 	require.Contains(t, fullHistory, "1", "Full history should contain earliest output")
 
 	// Step 3: Enter scroll mode
-	err = previewPane.ScrollUp(setup.instance, true)
+	err = previewPane.ScrollUp(setup.instance, 0)
 	require.NoError(t, err)
 
 	// Verify we entered scrolling mode
@@ -268,7 +268,7 @@ func TestPreviewScrolling(t *testing.T) {
 
 	// Step 5: Scroll up multiple times to get to the top
 	for range 50 {
-		err = previewPane.ScrollUp(setup.instance, true)
+		err = previewPane.ScrollUp(setup.instance, 0)
 		require.NoError(t, err)
 	}
 
@@ -278,7 +278,7 @@ func TestPreviewScrolling(t *testing.T) {
 
 	// Step 6: Scroll down multiple times
 	for range 25 {
-		err = previewPane.ScrollDown(setup.instance, true)
+		err = previewPane.ScrollDown(setup.instance, 0)
 		require.NoError(t, err)
 	}
 
@@ -287,7 +287,7 @@ func TestPreviewScrolling(t *testing.T) {
 	t.Logf("Viewport after scrolling down: %q", viewportAfterScrollDown)
 
 	// Step 7: Reset to normal mode
-	err = previewPane.ResetToNormalMode(setup.instance, true)
+	err = previewPane.ResetToNormalMode(setup.instance, 0)
 	require.NoError(t, err)
 
 	// Verify we exited scrolling mode
@@ -372,7 +372,7 @@ func TestPreviewContentWithoutScrolling(t *testing.T) {
 	previewPane.SetSize(80, 30) // Set reasonable size for testing
 
 	// Update the preview content (this should display the content without scrolling)
-	err := previewPane.UpdateContent(setup.instance, true)
+	err := previewPane.UpdateContent(setup.instance, 0)
 	require.NoError(t, err)
 
 	// Verify we're not in scrolling mode
@@ -515,7 +515,7 @@ func TestPreviewResetToNormalModeNilInstance(t *testing.T) {
 		"precondition: viewport should hold stale content")
 
 	// Calling ResetToNormalMode with nil must still clear scroll state.
-	err := p.ResetToNormalMode(nil, true)
+	err := p.ResetToNormalMode(nil, 0)
 	require.NoError(t, err)
 
 	require.False(t, p.isScrolling,
@@ -547,14 +547,14 @@ func TestPreviewResetToNormalModeLoadingShowsFallback(t *testing.T) {
 
 	p := NewTabPane()
 	p.SetSize(80, 30)
-	require.NoError(t, p.UpdateContent(inst, true))
+	require.NoError(t, p.UpdateContent(inst, 0))
 	require.True(t, p.content.fallback,
 		"precondition: Loading instance shows the fallback in normal mode")
 
-	require.NoError(t, p.ScrollUp(inst, true))
+	require.NoError(t, p.ScrollUp(inst, 0))
 	require.True(t, p.isScrolling, "precondition: ScrollUp enters scroll mode")
 
-	require.NoError(t, p.ResetToNormalMode(inst, true))
+	require.NoError(t, p.ResetToNormalMode(inst, 0))
 	require.False(t, p.isScrolling,
 		"isScrolling must be false after ResetToNormalMode")
 	require.True(t, p.content.fallback,
@@ -593,7 +593,7 @@ func TestPreviewUpdateContentDeletingShowsTeardownFallback(t *testing.T) {
 
 	p := NewTabPane()
 	p.SetSize(80, 30)
-	require.NoError(t, p.UpdateContent(inst, true))
+	require.NoError(t, p.UpdateContent(inst, 0))
 
 	require.True(t, p.content.fallback,
 		"Deleting instance must render a fallback")
@@ -833,7 +833,7 @@ func TestPreviewUpdateContentSessionGoneRendersFallback(t *testing.T) {
 	p.SetSize(80, 30)
 
 	// Happy path first: session alive, normal content renders.
-	require.NoError(t, p.UpdateContent(setup.instance, true))
+	require.NoError(t, p.UpdateContent(setup.instance, 0))
 	require.False(t, p.content.fallback,
 		"happy path must not render fallback")
 	require.Contains(t, p.content.text, "hello world")
@@ -847,7 +847,7 @@ func TestPreviewUpdateContentSessionGoneRendersFallback(t *testing.T) {
 
 	sessionGone.Store(true)
 
-	err := p.UpdateContent(setup.instance, true)
+	err := p.UpdateContent(setup.instance, 0)
 	require.NoError(t, err,
 		"dead session must NOT bubble an error up to handleError")
 	require.True(t, p.content.fallback,
@@ -914,7 +914,7 @@ func TestResetToNormalModeDoesNotClearFallbackFlag(t *testing.T) {
 	// (our mock returns expectedContent) and must clear the stale fallback
 	// flag at the same time, otherwise String() would render the captured
 	// terminal output with centered fallback styling.
-	require.NoError(t, p.ResetToNormalMode(setup.instance, true))
+	require.NoError(t, p.ResetToNormalMode(setup.instance, 0))
 
 	require.False(t, p.isScrolling, "should exit scroll mode")
 	require.Equal(t, expectedContent, p.content.text,
@@ -949,18 +949,18 @@ func TestPreviewSwitchInstanceResetsScroll(t *testing.T) {
 	p.SetSize(80, 30)
 
 	// Render A normally, then enter scroll mode on A.
-	require.NoError(t, p.UpdateContent(instA, true))
-	require.NoError(t, p.ScrollUp(instA, true))
+	require.NoError(t, p.UpdateContent(instA, 0))
+	require.NoError(t, p.ScrollUp(instA, 0))
 	require.True(t, p.isScrolling, "should be scrolling after ScrollUp on A")
 
 	// Re-render the SAME instance while scrolling: scroll state must
 	// survive (this is the original behavior the #470 fix must not break).
-	require.NoError(t, p.UpdateContent(instA, true))
+	require.NoError(t, p.UpdateContent(instA, 0))
 	require.True(t, p.isScrolling,
 		"re-rendering the same instance must preserve scroll mode")
 
 	// Now switch to B. Scroll state must be cleared and B's content rendered.
-	require.NoError(t, p.UpdateContent(instB, true))
+	require.NoError(t, p.UpdateContent(instB, 0))
 	require.False(t, p.isScrolling,
 		"switching to a different instance must exit scroll mode")
 	require.False(t, p.content.fallback,
@@ -989,7 +989,7 @@ func TestScrollMouseDifferentInstanceResetsScrollMode(t *testing.T) {
 	p.SetSize(80, 30)
 
 	// Enter scroll mode on A via the mouse path (no prior UpdateContent).
-	require.NoError(t, p.ScrollUp(instA, true))
+	require.NoError(t, p.ScrollUp(instA, 0))
 	require.True(t, p.isScrolling, "should be scrolling A after ScrollUp(A)")
 	require.Contains(t, p.viewport.View(), previewA,
 		"precondition: viewport should hold A's captured content")
@@ -997,7 +997,7 @@ func TestScrollMouseDifferentInstanceResetsScrollMode(t *testing.T) {
 	// Selection switches to B, but UpdateContent(B) has not run yet. A
 	// wheel-up arrives for B. Before the fix this scrolled A's stale viewport;
 	// now it must drop scroll state and re-capture B's content.
-	require.NoError(t, p.ScrollUp(instB, true))
+	require.NoError(t, p.ScrollUp(instB, 0))
 	require.True(t, p.isScrolling,
 		"should re-enter scroll mode for B after the switch")
 	require.Contains(t, p.viewport.View(), previewB,
@@ -1006,7 +1006,7 @@ func TestScrollMouseDifferentInstanceResetsScrollMode(t *testing.T) {
 		"stale viewport content from A must be cleared on the scroll path")
 
 	// The same must hold for the ScrollDown entry point.
-	require.NoError(t, p.ScrollDown(instA, true))
+	require.NoError(t, p.ScrollDown(instA, 0))
 	require.Contains(t, p.viewport.View(), previewA,
 		"ScrollDown on a switched-to instance must re-capture its content")
 	require.NotContains(t, p.viewport.View(), previewB,

--- a/ui/tab_nav_test.go
+++ b/ui/tab_nav_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+
+	"github.com/stretchr/testify/require"
+)
+
+// instanceWithTabs builds a bare (unstarted) instance carrying n tabs so the tab
+// bar / navigation math can be exercised without a live tmux session. Tab[0] is
+// the agent tab; the rest are shell tabs.
+func instanceWithTabs(n int) *session.Instance {
+	tabs := make([]*session.Tab, 0, n)
+	tabs = append(tabs, &session.Tab{Name: "agent", Kind: session.TabKindAgent})
+	for i := 1; i < n; i++ {
+		tabs = append(tabs, &session.Tab{Name: "shell", Kind: session.TabKindShell})
+	}
+	return &session.Instance{Tabs: tabs}
+}
+
+// TestTabbedWindowJumpToTab covers the number-key jump: in-range indices select
+// the tab, out-of-range indices are a no-op (#930 PR 4).
+func TestTabbedWindowJumpToTab(t *testing.T) {
+	tw := NewTabbedWindow(NewTabPane())
+	tw.SetInstance(instanceWithTabs(3))
+
+	require.True(t, tw.JumpToTab(2))
+	require.Equal(t, 2, tw.GetActiveTab())
+
+	require.False(t, tw.JumpToTab(3), "jumping past the last tab is a no-op")
+	require.Equal(t, 2, tw.GetActiveTab(), "a no-op jump must not move the active tab")
+
+	require.False(t, tw.JumpToTab(-1), "a negative index is a no-op")
+	require.Equal(t, 2, tw.GetActiveTab())
+
+	require.True(t, tw.JumpToTab(0), "the agent tab is always jumpable")
+	require.Equal(t, 0, tw.GetActiveTab())
+}
+
+// TestTabbedWindowSelectLastAndNeighbor covers SelectLastTab (used after a new
+// tab is appended) and SelectTab (used to land on a neighbor after a close).
+func TestTabbedWindowSelectLastAndNeighbor(t *testing.T) {
+	tw := NewTabbedWindow(NewTabPane())
+	tw.SetInstance(instanceWithTabs(4))
+
+	tw.SelectLastTab()
+	require.Equal(t, 3, tw.GetActiveTab(), "SelectLastTab selects the final tab")
+
+	tw.SelectTab(2)
+	require.Equal(t, 2, tw.GetActiveTab())
+
+	// Out-of-range selections clamp into range rather than dangling.
+	tw.SelectTab(99)
+	require.Equal(t, 3, tw.GetActiveTab())
+	tw.SelectTab(-5)
+	require.Equal(t, 0, tw.GetActiveTab())
+}
+
+// TestTabbedWindowClampsActiveTabOnInstanceSwitch is the audit guard: switching
+// to an instance with fewer tabs must not leave activeTab pointing past the end
+// (which would make isAgentSlot() lie and capture a phantom slot).
+func TestTabbedWindowClampsActiveTabOnInstanceSwitch(t *testing.T) {
+	tw := NewTabbedWindow(NewTabPane())
+	tw.SetInstance(instanceWithTabs(4))
+	require.True(t, tw.JumpToTab(3))
+	require.Equal(t, 3, tw.GetActiveTab())
+
+	tw.SetInstance(instanceWithTabs(2))
+	require.LessOrEqual(t, tw.GetActiveTab(), 1,
+		"activeTab must be clamped when switching to an instance with fewer tabs")
+	require.GreaterOrEqual(t, tw.GetActiveTab(), 0)
+}

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -65,14 +65,15 @@ type TabPane struct {
 	isScrolling bool
 	viewport    viewport.Model
 
-	// currentInstance + currentAgentSlot identify the (instance, tab-slot) view
+	// currentInstance + currentTab identify the (instance, tab-index) view
 	// currently rendered. UpdateContent/ScrollUp/ScrollDown reset scroll-mode
 	// state when either changes so switching instances OR tabs while scrolling
 	// does not leave the viewport pinned on the previous view's content
-	// (#470/#702/#746). currentInstance is also used to resize the shell tab's
-	// detached session when the pane is resized.
-	currentInstance  *session.Instance
-	currentAgentSlot bool
+	// (#470/#702/#746). currentTab is the 0-based tab index (0 is the agent tab);
+	// it is also used to resize the active shell tab's detached session when the
+	// pane is resized.
+	currentInstance *session.Instance
+	currentTab      int
 }
 
 func NewTabPane() *TabPane {
@@ -96,11 +97,11 @@ func (p *TabPane) SetSize(width, maxHeight int) {
 	p.height = maxHeight
 	p.viewport.Width = width
 	p.viewport.Height = maxHeight
-	// Keep the detached shell session sized to the pane so its capture matches
-	// what the agent preview shows (the old TerminalPane.SetSize behavior,
-	// generalized onto the Instance).
-	if p.currentInstance != nil && !p.currentAgentSlot {
-		_ = p.currentInstance.SetShellTabDetachedSize(width, maxHeight)
+	// Keep the active shell tab's detached session sized to the pane so its
+	// capture matches what the agent preview shows (the old TerminalPane.SetSize
+	// behavior, generalized onto the Instance's tab index).
+	if p.currentInstance != nil && p.currentTab != 0 {
+		_ = p.currentInstance.SetTabDetachedSize(p.currentTab, width, maxHeight)
 	}
 }
 
@@ -114,15 +115,15 @@ func (p *TabPane) SetSize(width, maxHeight int) {
 // this guard a scroll would scroll the previous view's stale viewport instead
 // of resetting scroll mode (#702/#746). Consolidating the reset here keeps the
 // entry points consistent (the #669 motivation).
-func (p *TabPane) dropStaleView(instance *session.Instance, isAgentSlot bool) {
-	if instance != p.currentInstance || isAgentSlot != p.currentAgentSlot {
+func (p *TabPane) dropStaleView(instance *session.Instance, activeTab int) {
+	if instance != p.currentInstance || activeTab != p.currentTab {
 		if p.isScrolling {
 			p.isScrolling = false
 			p.viewport.SetContent("")
 			p.viewport.GotoTop()
 		}
 		p.currentInstance = instance
-		p.currentAgentSlot = isAgentSlot
+		p.currentTab = activeTab
 	}
 }
 
@@ -144,18 +145,19 @@ func (p *TabPane) setFallbackState(message string) {
 }
 
 // UpdateContent captures the selected tab's content. Safe to call from a
-// goroutine — it serialises against String() via p.mu (#579). isAgentSlot is
-// true when the selected tab is the agent tab (index 0): it selects the capture
-// source (backend preview vs the shell tab's tmux) and the fallback copy, so the
-// merged pane reproduces the old PreviewPane and TerminalPane behaviors exactly.
-func (p *TabPane) UpdateContent(instance *session.Instance, isAgentSlot bool) error {
+// goroutine — it serialises against String() via p.mu (#579). activeTab is the
+// 0-based selected tab index: index 0 is the agent tab (captured via the backend
+// preview), any other index is a shell/process tab captured straight from that
+// tab's tmux session. The slot selects the capture source and the fallback copy,
+// so the merged pane reproduces the old PreviewPane and TerminalPane behaviors.
+func (p *TabPane) UpdateContent(instance *session.Instance, activeTab int) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.dropStaleView(instance, isAgentSlot)
-	if isAgentSlot {
+	p.dropStaleView(instance, activeTab)
+	if activeTab == 0 {
 		return p.updateAgentLocked(instance)
 	}
-	return p.updateShellLocked(instance)
+	return p.updateShellLocked(instance, activeTab)
 }
 
 // updateAgentLocked reproduces the former PreviewPane.UpdateContent. Caller
@@ -223,9 +225,9 @@ func (p *TabPane) updateAgentLocked(instance *session.Instance) error {
 	return nil
 }
 
-// updateShellLocked reproduces the former TerminalPane.UpdateContent. Caller
-// must hold p.mu.
-func (p *TabPane) updateShellLocked(instance *session.Instance) error {
+// updateShellLocked reproduces the former TerminalPane.UpdateContent for the
+// shell/process tab at activeTab. Caller must hold p.mu.
+func (p *TabPane) updateShellLocked(instance *session.Instance, activeTab int) error {
 	if instance == nil {
 		p.setFallbackState("Select an instance to open a terminal")
 		return nil
@@ -260,15 +262,15 @@ func (p *TabPane) updateShellLocked(instance *session.Instance) error {
 		return nil
 	}
 
-	// The shell tab session is owned by the Instance and created at start. If it
-	// is not alive, show a fallback rather than leaving the previous view's
-	// content on screen (#747, generalized to the persisted shell tab).
-	if !instance.ShellTabAlive() {
+	// The tab's session is owned by the Instance and created at start (or by the
+	// new-tab hotkey). If it is not alive, show a fallback rather than leaving the
+	// previous view's content on screen (#747, generalized to the persisted tab).
+	if !instance.TabAlive(activeTab) {
 		p.setFallbackState("Terminal session not available.")
 		return nil
 	}
 
-	content, err := instance.PreviewShellTab()
+	content, err := instance.PreviewTab(activeTab)
 	if err != nil {
 		// The alive pre-check above can race an external kill: fall through to a
 		// fallback instead of propagating an error logged at ERROR (#496).
@@ -326,7 +328,7 @@ func (p *TabPane) String() string {
 }
 
 // ScrollUp enters scroll mode (if not already) and scrolls up.
-func (p *TabPane) ScrollUp(instance *session.Instance, isAgentSlot bool) error {
+func (p *TabPane) ScrollUp(instance *session.Instance, activeTab int) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if instance == nil {
@@ -334,9 +336,9 @@ func (p *TabPane) ScrollUp(instance *session.Instance, isAgentSlot bool) error {
 	}
 	// Reset scroll mode if the view changed out from under us, so we capture the
 	// newly selected view's content rather than scrolling stale content (#702).
-	p.dropStaleView(instance, isAgentSlot)
+	p.dropStaleView(instance, activeTab)
 	if !p.isScrolling {
-		if err := p.enterScrollModeLocked(instance, isAgentSlot); err != nil {
+		if err := p.enterScrollModeLocked(instance, activeTab); err != nil {
 			return err
 		}
 		return nil
@@ -346,15 +348,15 @@ func (p *TabPane) ScrollUp(instance *session.Instance, isAgentSlot bool) error {
 }
 
 // ScrollDown enters scroll mode (if not already) and scrolls down.
-func (p *TabPane) ScrollDown(instance *session.Instance, isAgentSlot bool) error {
+func (p *TabPane) ScrollDown(instance *session.Instance, activeTab int) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if instance == nil {
 		return nil
 	}
-	p.dropStaleView(instance, isAgentSlot)
+	p.dropStaleView(instance, activeTab)
 	if !p.isScrolling {
-		if err := p.enterScrollModeLocked(instance, isAgentSlot); err != nil {
+		if err := p.enterScrollModeLocked(instance, activeTab); err != nil {
 			return err
 		}
 		return nil
@@ -365,22 +367,22 @@ func (p *TabPane) ScrollDown(instance *session.Instance, isAgentSlot bool) error
 
 // enterScrollModeLocked captures the selected view's full scrollback and enters
 // scroll mode. Caller must hold p.mu. Capture is keyed off the passed instance
-// + slot, never a cached title, so the wrong view can never be captured
+// + tab index, never a cached title, so the wrong view can never be captured
 // (#746/#384).
-func (p *TabPane) enterScrollModeLocked(instance *session.Instance, isAgentSlot bool) error {
+func (p *TabPane) enterScrollModeLocked(instance *session.Instance, activeTab int) error {
 	var content string
 	var err error
-	if isAgentSlot {
+	if activeTab == 0 {
 		content, err = instance.PreviewFullHistory()
 	} else {
-		if !instance.ShellTabAlive() {
+		if !instance.TabAlive(activeTab) {
 			return nil
 		}
-		content, err = instance.PreviewShellTabFullHistory()
+		content, err = instance.PreviewTabFullHistory(activeTab)
 	}
 	if err != nil {
 		if errors.Is(err, tmux.ErrSessionGone) {
-			if isAgentSlot {
+			if activeTab == 0 {
 				p.setFallbackState("Session no longer running.")
 			} else {
 				p.setFallbackState("Terminal session no longer running.")
@@ -397,7 +399,7 @@ func (p *TabPane) enterScrollModeLocked(instance *session.Instance, isAgentSlot 
 }
 
 // ResetToNormalMode exits scroll mode and returns to normal content display.
-func (p *TabPane) ResetToNormalMode(instance *session.Instance, isAgentSlot bool) error {
+func (p *TabPane) ResetToNormalMode(instance *session.Instance, activeTab int) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	// Always clear scroll state first so pressing ESC while no instance is
@@ -414,9 +416,9 @@ func (p *TabPane) ResetToNormalMode(instance *session.Instance, isAgentSlot bool
 		return nil
 	}
 
-	// The shell slot simply returns to live capture on the next refresh — no
-	// re-capture here (the former TerminalPane.ResetToNormalMode behavior).
-	if !isAgentSlot {
+	// A shell/process slot simply returns to live capture on the next refresh —
+	// no re-capture here (the former TerminalPane.ResetToNormalMode behavior).
+	if activeTab != 0 {
 		return nil
 	}
 

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -63,6 +63,50 @@ func NewTabbedWindow(tab *TabPane) *TabbedWindow {
 
 func (w *TabbedWindow) SetInstance(instance *session.Instance) {
 	w.instance = instance
+	// Tab counts vary per instance (#930 PR 4): switching to an instance with
+	// fewer tabs must not leave activeTab pointing past the end, which would make
+	// isAgentSlot() lie and the number/Toggle math operate on a phantom slot.
+	w.clampActiveTab()
+}
+
+// clampActiveTab bounds activeTab into [0, len(tabLabels())-1]. Called whenever
+// the tab set may have shrunk (instance switch, tab close) so the index never
+// dangles out of range.
+func (w *TabbedWindow) clampActiveTab() {
+	n := int32(len(w.tabLabels()))
+	if n <= 0 {
+		w.activeTab.Store(0)
+		return
+	}
+	if cur := w.activeTab.Load(); cur >= n {
+		w.activeTab.Store(n - 1)
+	} else if cur < 0 {
+		w.activeTab.Store(0)
+	}
+}
+
+// JumpToTab selects the tab at the 0-based idx, returning true if it exists.
+// Out-of-range indices are a no-op (false) so an unused number key does nothing
+// (#930 PR 4).
+func (w *TabbedWindow) JumpToTab(idx int) bool {
+	if idx < 0 || idx >= len(w.tabLabels()) {
+		return false
+	}
+	w.activeTab.Store(int32(idx))
+	return true
+}
+
+// SelectTab sets the active tab to idx, clamped into range. Used after a tab
+// close to land on a neighbor.
+func (w *TabbedWindow) SelectTab(idx int) {
+	w.activeTab.Store(int32(idx))
+	w.clampActiveTab()
+}
+
+// SelectLastTab selects the final tab. Used after a new tab is appended so the
+// freshly created tab becomes active (#930 PR 4).
+func (w *TabbedWindow) SelectLastTab() {
+	w.SelectTab(len(w.tabLabels()) - 1)
 }
 
 // tabLabels returns the labels for the current instance's tabs, always at least
@@ -158,22 +202,22 @@ func (w *TabbedWindow) ToggleBack() {
 // nil. Replaces the former UpdatePreview/UpdateTerminal split now that one pane
 // renders whichever tab is selected.
 func (w *TabbedWindow) UpdateContent(instance *session.Instance) error {
-	return w.tab.UpdateContent(instance, w.isAgentSlot())
+	return w.tab.UpdateContent(instance, int(w.activeTab.Load()))
 }
 
 // ResetToNormalMode resets the active tab's pane to normal (non-scroll) mode.
 func (w *TabbedWindow) ResetToNormalMode(instance *session.Instance) error {
-	return w.tab.ResetToNormalMode(instance, w.isAgentSlot())
+	return w.tab.ResetToNormalMode(instance, int(w.activeTab.Load()))
 }
 
 func (w *TabbedWindow) ScrollUp() {
-	if err := w.tab.ScrollUp(w.instance, w.isAgentSlot()); err != nil {
+	if err := w.tab.ScrollUp(w.instance, int(w.activeTab.Load())); err != nil {
 		log.InfoLog.Printf("tabbed window failed to scroll up: %v", err)
 	}
 }
 
 func (w *TabbedWindow) ScrollDown() {
-	if err := w.tab.ScrollDown(w.instance, w.isAgentSlot()); err != nil {
+	if err := w.tab.ScrollDown(w.instance, int(w.activeTab.Load())); err != nil {
 		log.InfoLog.Printf("tabbed window failed to scroll down: %v", err)
 	}
 }
@@ -200,7 +244,7 @@ func (w *TabbedWindow) GetActiveTab() int {
 // overlay is open (#716): the shell session belongs to this instance, so there
 // is no title-keyed cache to drift. Remote instances route to the terminal_cmd
 // hook (#843).
-func (w *TabbedWindow) AttachTerminalForInstance(instance *session.Instance) (chan struct{}, error) {
+func (w *TabbedWindow) AttachTerminalForInstance(instance *session.Instance, tabIdx int) (chan struct{}, error) {
 	if instance == nil {
 		return nil, fmt.Errorf("no terminal session to attach to")
 	}
@@ -210,7 +254,7 @@ func (w *TabbedWindow) AttachTerminalForInstance(instance *session.Instance) (ch
 		}
 		return instance.AttachRemoteTerminal()
 	}
-	return instance.AttachShellTab()
+	return instance.AttachTab(tabIdx)
 }
 
 // IsInScrollMode returns true if the active tab's pane is in scroll mode.

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -132,7 +132,7 @@ func TestTabPaneShellUpdateContent(t *testing.T) {
 	p := NewTabPane()
 	p.SetSize(80, 30)
 
-	require.NoError(t, p.UpdateContent(inst, false))
+	require.NoError(t, p.UpdateContent(inst, 1))
 
 	p.mu.Lock()
 	require.False(t, p.content.fallback, "should not be in fallback after successful shell capture")
@@ -150,7 +150,7 @@ func TestTabPaneShellFallbackStates(t *testing.T) {
 	p.SetSize(80, 30)
 
 	t.Run("nil instance", func(t *testing.T) {
-		require.NoError(t, p.UpdateContent(nil, false))
+		require.NoError(t, p.UpdateContent(nil, 1))
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
 		require.Contains(t, p.content.text, "Select an instance")
@@ -163,7 +163,7 @@ func TestTabPaneShellFallbackStates(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.NoError(t, p.UpdateContent(inst, false))
+		require.NoError(t, p.UpdateContent(inst, 1))
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
 		require.Contains(t, p.content.text, "not started")
@@ -180,7 +180,7 @@ func TestTabPaneShellFallbackStates(t *testing.T) {
 		inst.SetBackend(session.NewFakeBackend())
 		inst.SetStatus(session.Deleting)
 
-		require.NoError(t, p.UpdateContent(inst, false))
+		require.NoError(t, p.UpdateContent(inst, 1))
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
 		require.Contains(t, p.content.text, "Tearing down session...")
@@ -207,14 +207,14 @@ func TestTabPaneShellScrolling(t *testing.T) {
 
 	require.False(t, p.IsScrolling(), "should not be scrolling initially")
 
-	require.NoError(t, p.ScrollUp(inst, false))
+	require.NoError(t, p.ScrollUp(inst, 1))
 	require.True(t, p.IsScrolling(), "ScrollUp should enter scroll mode")
 	require.NotEmpty(t, p.viewport.View(), "viewport should have content in scroll mode")
 
-	require.NoError(t, p.ScrollDown(inst, false))
+	require.NoError(t, p.ScrollDown(inst, 1))
 	require.True(t, p.IsScrolling(), "should still be scrolling after ScrollDown")
 
-	require.NoError(t, p.ResetToNormalMode(inst, false))
+	require.NoError(t, p.ResetToNormalMode(inst, 1))
 	require.False(t, p.IsScrolling(), "ResetToNormalMode should exit scroll mode")
 }
 
@@ -233,11 +233,11 @@ func TestTabPaneShellFallbackResetsScrollMode(t *testing.T) {
 	t.Run("nil instance", func(t *testing.T) {
 		p := NewTabPane()
 		p.SetSize(80, 30)
-		require.NoError(t, p.ScrollUp(prior, false))
+		require.NoError(t, p.ScrollUp(prior, 1))
 		require.True(t, p.IsScrolling(), "precondition: in scroll mode")
 		require.Contains(t, p.viewport.View(), priorContent)
 
-		require.NoError(t, p.UpdateContent(nil, false))
+		require.NoError(t, p.UpdateContent(nil, 1))
 
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
@@ -252,7 +252,7 @@ func TestTabPaneShellFallbackResetsScrollMode(t *testing.T) {
 	t.Run("not started instance", func(t *testing.T) {
 		p := NewTabPane()
 		p.SetSize(80, 30)
-		require.NoError(t, p.ScrollUp(prior, false))
+		require.NoError(t, p.ScrollUp(prior, 1))
 		require.True(t, p.IsScrolling())
 
 		notStarted, err := session.NewInstance(session.InstanceOptions{
@@ -260,7 +260,7 @@ func TestTabPaneShellFallbackResetsScrollMode(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.NoError(t, p.UpdateContent(notStarted, false))
+		require.NoError(t, p.UpdateContent(notStarted, 1))
 
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
@@ -293,10 +293,10 @@ func TestTabPaneShellScrollUsesSelectedView(t *testing.T) {
 	p.SetSize(80, 30)
 
 	// A is rendered first, so it becomes the current view.
-	require.NoError(t, p.UpdateContent(instA, false))
+	require.NoError(t, p.UpdateContent(instA, 1))
 
 	// User scrolls while B is the selected instance, before UpdateContent(B) ran.
-	require.NoError(t, p.ScrollUp(instB, false))
+	require.NoError(t, p.ScrollUp(instB, 1))
 	require.True(t, p.IsScrolling())
 	require.Contains(t, p.viewport.View(), contentB,
 		"scroll must capture the selected instance's (B) shell history")
@@ -304,7 +304,7 @@ func TestTabPaneShellScrollUsesSelectedView(t *testing.T) {
 		"scroll must not capture the previously rendered instance's (A) history (#746)")
 
 	// The scroll survives the next refresh for B.
-	require.NoError(t, p.UpdateContent(instB, false))
+	require.NoError(t, p.UpdateContent(instB, 1))
 	require.True(t, p.IsScrolling())
 	require.Contains(t, p.viewport.View(), contentB)
 }
@@ -324,11 +324,11 @@ func TestTabPaneSwitchTabResetsScroll(t *testing.T) {
 	p.SetSize(80, 30)
 
 	// Scroll on the agent slot.
-	require.NoError(t, p.ScrollUp(inst, true))
+	require.NoError(t, p.ScrollUp(inst, 0))
 	require.True(t, p.IsScrolling())
 
 	// Switch to the shell slot for the SAME instance: scroll must reset.
-	require.NoError(t, p.UpdateContent(inst, false))
+	require.NoError(t, p.UpdateContent(inst, 1))
 	require.False(t, p.IsScrolling(),
 		"switching tabs must drop the previous tab's scroll state")
 }
@@ -387,7 +387,7 @@ func TestTabPaneShellSessionGoneFallback(t *testing.T) {
 	p.SetSize(80, 30)
 
 	// Happy path: shell content renders.
-	require.NoError(t, p.UpdateContent(inst, false))
+	require.NoError(t, p.UpdateContent(inst, 1))
 	p.mu.Lock()
 	require.False(t, p.content.fallback)
 	require.Contains(t, p.content.text, "hello world")
@@ -401,7 +401,7 @@ func TestTabPaneShellSessionGoneFallback(t *testing.T) {
 
 	gone.Store(true)
 
-	require.NoError(t, p.UpdateContent(inst, false),
+	require.NoError(t, p.UpdateContent(inst, 1),
 		"a gone shell session must NOT bubble an error up to handleError (#496)")
 	p.mu.Lock()
 	require.True(t, p.content.fallback, "shell pane must enter a fallback when the session is gone")
@@ -420,7 +420,7 @@ func TestTabPaneRemoteFallbackStates(t *testing.T) {
 		inst := makeRemoteInstance(t, "remote-843-on", config.RemoteHooks{TerminalCmd: "/bin/true"})
 		p := NewTabPane()
 		p.SetSize(80, 30)
-		require.NoError(t, p.UpdateContent(inst, false))
+		require.NoError(t, p.UpdateContent(inst, 1))
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
 		p.mu.Unlock()
@@ -431,7 +431,7 @@ func TestTabPaneRemoteFallbackStates(t *testing.T) {
 		inst := makeRemoteInstance(t, "remote-843-off", config.RemoteHooks{})
 		p := NewTabPane()
 		p.SetSize(80, 30)
-		require.NoError(t, p.UpdateContent(inst, false))
+		require.NoError(t, p.UpdateContent(inst, 1))
 		p.mu.Lock()
 		require.True(t, p.content.fallback)
 		require.Contains(t, p.content.text, "not available for remote sessions")
@@ -452,7 +452,7 @@ func TestTabbedWindowAttachTerminalRemote(t *testing.T) {
 
 	t.Run("not configured refuses with actionable error", func(t *testing.T) {
 		inst := makeRemoteInstance(t, "remote-843-noattach", config.RemoteHooks{})
-		_, err := tw.AttachTerminalForInstance(inst)
+		_, err := tw.AttachTerminalForInstance(inst, 1)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "terminal_cmd")
 	})
@@ -465,7 +465,7 @@ func TestTabbedWindowAttachTerminalRemote(t *testing.T) {
 			[]byte("#!/bin/sh\necho \"$1\" > \""+argsFile+"\"\n"), 0755))
 
 		inst := makeRemoteInstance(t, "remote-843-attach", config.RemoteHooks{TerminalCmd: script})
-		done, err := tw.AttachTerminalForInstance(inst)
+		done, err := tw.AttachTerminalForInstance(inst, 1)
 		require.NoError(t, err)
 		select {
 		case <-done:
@@ -489,7 +489,7 @@ func TestTabbedWindowAttachTerminalRefusesNil(t *testing.T) {
 
 	tw := NewTabbedWindow(NewTabPane())
 
-	_, err := tw.AttachTerminalForInstance(nil)
+	_, err := tw.AttachTerminalForInstance(nil, 1)
 	require.Error(t, err, "AttachTerminalForInstance(nil) must error, not attach")
 
 	inst, err := session.NewInstance(session.InstanceOptions{
@@ -498,6 +498,6 @@ func TestTabbedWindowAttachTerminalRefusesNil(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, inst.Started(), "precondition: instance must not be started")
 
-	_, err = tw.AttachTerminalForInstance(inst)
+	_, err = tw.AttachTerminalForInstance(inst, 1)
 	require.Error(t, err, "an instance with no live shell tab must refuse to attach")
 }


### PR DESCRIPTION
Part of #930 (ephemeral tabs epic), PR 4 of 7. Builds on PR 1 (Tab type), PR 2 (unified TabPane + tab persistence), and PR 3 (1:1 instance⇄worktree, freed the `a` key).

## The keys

- **`t` — new tab:** one keypress spawns a `$SHELL` session (fallback `/bin/sh`) in the selected instance's worktree, appends it to `Tabs`, and selects it. No prompt (CLI custom names are PR 5).
- **`w` — close tab:** kills the active tab's tmux session, removes it from `Tabs`, and selects the **left/previous** neighbor.
- **`1`–`9` — jump:** jump directly to that 1-based tab index; out-of-range is a no-op. `Tab`/`Shift-Tab` cycling is unchanged.

## Rules

- **The agent tab (`Tabs[0]`) is uncloseable.** `w` on it is a gentle no-op message ("the agent tab can't be closed; use D to kill the session"). Killing the instance (`D`) still tears down all tabs (PR 2 already loops).
- **Soft cap of 9 tabs** per instance (matches the `1-9` range): a 10th new-tab shows "max 9 tabs" instead of creating.
- **Remote instances:** new-tab is unsupported (no local worktree) and surfaces the existing "not available for remote" style message, creating nothing.
- **Naming:** new shell tabs are `shell`, then `shell-2`, `shell-3`… unique per instance; the tmux session name is derived from the display name so it's collision-free and restorable by exact name.

## Restart persistence

New tabs ride PR 2's per-tab serialization. `setupTabs` (formerly `setupShellTab`) now reconnects **every** persisted non-agent tab to its exact tmux session on load — not just the first shell — so a human-created tab survives an af/daemon restart. Covered by a Storage round-trip test.

## Refactor

Per-tab capture/attach/scroll were keyed off an agent-vs-shell bool, which always rendered the *first* shell tab. They're now keyed off the active tab **index**, so each tab shows and attaches to its own session. The shell-specific `Instance` methods were replaced with index-based `PreviewTab`/`PreviewTabFullHistory`/`TabAlive`/`AttachTab`/`SetTabDetachedSize`.

## Adjacent-call-site audit

- `t`, `w`, `1`-`9` are free in every relevant binding/state. Digits are dispatched only in the instance view, **after** content-pane focus handling, so editing a task/hook/instance-name still types them.
- `activeTab` (the #684 atomic) is clamped on instance switch, new-tab, and close, so it never dangles out of range; an out-of-range index read degrades to a fallback rather than panicking.
- Menu + help advertise the new keys; the stale PR-3 `a` creation hint (and its off-by-one group boundaries) is removed.

## Tests

- **session:** `AddShellTab` append + unique naming, `CloseTab` remove + agent-protection + out-of-range, soft cap at 9, `uniqueShellName`, and restart-survival of a human-created shell tab through Storage.
- **ui:** `JumpToTab` (in/out of range), `SelectTab`/`SelectLastTab`, and `activeTab` clamping on instance switch.
- **app:** `handleNewTab` append+select, `handleCloseTab` neighbor-select, agent-tab no-op, remote message, `handleTabJump`, and number-key routing through `handleKeyPress`.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --fast` clean · `deadcode -test ./...` clean · `go test ./...` green · `GOFLAGS=-p=1 go test -race -parallel 2 ./ui/... ./app/... ./session/...` green.

— Captain Claude