### PR TITLE
feat(cli): sessions tab-create — spawn a process tab via CLI/agent (#930, PR 5/7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Everything the TUI does is scriptable — `af sessions` and `af tasks` print JSO
 ```bash
 af sessions create --name fix-auth-bug --prompt "Fix the login redirect loop"
 af sessions preview fix-auth-bug
+af sessions tab-create fix-auth-bug --command "btop"   # spawn a process tab in the worktree
 af tasks add --name "Daily triage" --prompt "Triage open issues" --cron "0 9 * * *"
 ```
 

--- a/api/api.go
+++ b/api/api.go
@@ -287,10 +287,15 @@ func init() {
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptCreateFlag, "create", false, "Auto-create the session if it doesn't exist")
 	sessionsSendPromptCmd.Flags().StringVar(&sendPromptProgramFlag, "program", "", "Program to run when creating a new session (defaults to config default)")
 
+	sessionsTabCreateCmd.Flags().StringVar(&tabCreateCommandFlag, "command", "", "Command to run in the new tab (required)")
+	sessionsTabCreateCmd.Flags().StringVar(&tabCreateNameFlag, "name", "", "Tab name (defaults to the command basename; auto-suffixed on collision)")
+	sessionsTabCreateCmd.MarkFlagRequired("command")
+
 	SessionsCmd.AddCommand(sessionsListCmd)
 	SessionsCmd.AddCommand(sessionsGetCmd)
 	SessionsCmd.AddCommand(sessionsCreateCmd)
 	SessionsCmd.AddCommand(sessionsSendPromptCmd)
+	SessionsCmd.AddCommand(sessionsTabCreateCmd)
 	SessionsCmd.AddCommand(sessionsPreviewCmd)
 	SessionsCmd.AddCommand(sessionsKillCmd)
 	SessionsCmd.AddCommand(sessionsAttachCmd)

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -28,6 +28,7 @@ var (
 	killSessionViaDaemon   = daemon.KillSession
 	sendPromptViaDaemon    = daemon.SendPrompt
 	deliverPromptViaDaemon = daemon.DeliverPrompt
+	createTabViaDaemon     = daemon.CreateTab
 )
 
 // ghostKillTmuxByName issues a tmux kill-session for a persisted sanitized
@@ -358,6 +359,53 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 			return jsonError(err)
 		}
 		return jsonOut(map[string]bool{"ok": true})
+	},
+}
+
+var (
+	tabCreateCommandFlag string
+	tabCreateNameFlag    string
+)
+
+var sessionsTabCreateCmd = &cobra.Command{
+	Use:   "tab-create <title>",
+	Short: "Spawn a process tab running a command in a session's worktree",
+	Long: `Create a new tab in an existing session that runs the given command in the
+session's git worktree (e.g. a data explorer TUI or a test watcher).
+
+The tab persists and reconnects across a daemon/af restart like every other tab.
+If --name is omitted, a name is derived from the command's basename; the name is
+made unique within the session (auto-suffixed -2, -3, …). The resolved tab name
+is printed on success so scripts/agents can address it. Not available for remote
+sessions, which have no local worktree.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		if strings.TrimSpace(tabCreateCommandFlag) == "" {
+			return jsonError(fmt.Errorf("--command is required"))
+		}
+
+		// Honor --repo scoping (#891, same class as kill/send-prompt/attach). An
+		// empty repoID preserves the all-repo search; a non-empty one confines the
+		// session lookup to that repo so a same-titled session in another repo
+		// never receives the tab.
+		repoID, err := resolveRepoID()
+		if err != nil {
+			return jsonError(err)
+		}
+
+		name, err := createTabViaDaemon(daemon.CreateTabRequest{
+			Title:   args[0],
+			RepoID:  repoID,
+			Command: tabCreateCommandFlag,
+			Name:    tabCreateNameFlag,
+		})
+		if err != nil {
+			return jsonError(err)
+		}
+		return jsonOut(map[string]string{"name": name})
 	},
 }
 

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -683,6 +684,118 @@ func TestSessionsSendPrompt_CreateRoutesThroughDeliverPrompt(t *testing.T) {
 	}
 	if gotReq.Title != title || gotReq.Prompt != prompt || gotReq.RepoPath != repoRoot {
 		t.Fatalf("unexpected DeliverPrompt request: %+v", gotReq)
+	}
+}
+
+// TestSessionsTabCreate_RequiresCommand verifies tab-create rejects an empty
+// --command before reaching the daemon.
+func TestSessionsTabCreate_RequiresCommand(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	prevRepoFlag, prevCmd := repoFlag, tabCreateCommandFlag
+	repoFlag = ""
+	tabCreateCommandFlag = "   "
+	defer func() { repoFlag, tabCreateCommandFlag = prevRepoFlag, prevCmd }()
+
+	called := false
+	prevCreate := createTabViaDaemon
+	createTabViaDaemon = func(req daemon.CreateTabRequest) (string, error) {
+		called = true
+		return "", nil
+	}
+	defer func() { createTabViaDaemon = prevCreate }()
+
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devnull.Close()
+	origStderr := os.Stderr
+	os.Stderr = devnull
+	defer func() { os.Stderr = origStderr }()
+
+	if err := sessionsTabCreateCmd.RunE(sessionsTabCreateCmd, []string{"sess"}); err == nil {
+		t.Fatal("expected error for empty --command, got nil")
+	} else if !strings.Contains(err.Error(), "--command is required") {
+		t.Fatalf("expected --command-required error, got: %v", err)
+	}
+	if called {
+		t.Fatal("an empty command must not reach the daemon")
+	}
+}
+
+// TestSessionsTabCreate_HonorsRepoScopingAndReturnsName verifies tab-create
+// passes the resolved RepoID (--repo scoping, #891 class), the title, and the
+// command to the daemon, and prints the resolved tab name as JSON.
+func TestSessionsTabCreate_HonorsRepoScopingAndReturnsName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoRoot := filepath.Join(tmp, "repo-a")
+	if err := os.MkdirAll(repoRoot, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoRoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	repo, err := config.RepoFromPath(repoRoot)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	const title = "worker"
+
+	prevRepoFlag, prevCmd, prevName := repoFlag, tabCreateCommandFlag, tabCreateNameFlag
+	repoFlag = repoRoot
+	tabCreateCommandFlag = "btop -t"
+	tabCreateNameFlag = ""
+	defer func() {
+		repoFlag, tabCreateCommandFlag, tabCreateNameFlag = prevRepoFlag, prevCmd, prevName
+	}()
+
+	var gotReq daemon.CreateTabRequest
+	prevCreate := createTabViaDaemon
+	createTabViaDaemon = func(req daemon.CreateTabRequest) (string, error) {
+		gotReq = req
+		if req.RepoID == "" {
+			return "", errors.New("RepoID empty: --repo scoping was dropped")
+		}
+		return "btop-2", nil // the resolved (collision-suffixed) name
+	}
+	defer func() { createTabViaDaemon = prevCreate }()
+
+	// Capture stdout so we can assert the resolved name is emitted as JSON.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+	runErr := sessionsTabCreateCmd.RunE(sessionsTabCreateCmd, []string{title})
+	w.Close()
+	os.Stdout = origStdout
+	out, _ := io.ReadAll(r)
+	if runErr != nil {
+		t.Fatalf("tab-create returned error: %v", runErr)
+	}
+
+	if gotReq.RepoID != repo.ID {
+		t.Fatalf("tab-create RepoID = %q, want %q", gotReq.RepoID, repo.ID)
+	}
+	if gotReq.Title != title {
+		t.Fatalf("tab-create Title = %q, want %q", gotReq.Title, title)
+	}
+	if gotReq.Command != "btop -t" {
+		t.Fatalf("tab-create Command = %q, want %q", gotReq.Command, "btop -t")
+	}
+
+	var parsed map[string]string
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("output is not JSON (%q): %v", string(out), err)
+	}
+	if parsed["name"] != "btop-2" {
+		t.Fatalf("JSON output name = %q, want %q (resolved tab name)", parsed["name"], "btop-2")
 	}
 }
 

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -93,6 +93,22 @@ type DeliverPromptResponse struct {
 	Status string
 }
 
+// CreateTabRequest asks the daemon to spawn a Process-kind tab running Command
+// in the target session's worktree (#930 PR 5). Title selects the session;
+// RepoID scopes the lookup like the other sessions verbs (empty = all-repo).
+// Name is the optional display name (a default is derived from Command's
+// basename when empty); the resolved, collision-suffixed name is returned.
+type CreateTabRequest struct {
+	Title   string
+	RepoID  string
+	Command string
+	Name    string
+}
+
+type CreateTabResponse struct {
+	Name string
+}
+
 type ImportRemoteHookSessionsRequest struct {
 	RepoPath string
 }
@@ -235,6 +251,17 @@ func CreateSession(req CreateSessionRequest) (*session.InstanceData, error) {
 		return nil, err
 	}
 	return &resp.Instance, nil
+}
+
+// CreateTab asks the daemon to spawn, persist, and report a new process tab on
+// an existing session. It returns the resolved (collision-suffixed) tab name so
+// scripts/agents can address the tab.
+func CreateTab(req CreateTabRequest) (string, error) {
+	var resp CreateTabResponse
+	if err := callDaemon("CreateTab", req, &resp); err != nil {
+		return "", err
+	}
+	return resp.Name, nil
 }
 
 // KillSession asks the daemon to kill a session and remove it from storage.
@@ -516,6 +543,21 @@ func (s *controlServer) CreateSession(req CreateSessionRequest, resp *CreateSess
 		return err
 	}
 	resp.Instance = data
+	return nil
+}
+
+func (s *controlServer) CreateTab(req CreateTabRequest, resp *CreateTabResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
+	if err := validateRPCRepoID(req.RepoID); err != nil {
+		return err
+	}
+	name, err := s.manager.CreateTab(req)
+	if err != nil {
+		return err
+	}
+	resp.Name = name
 	return nil
 }
 
@@ -1123,6 +1165,55 @@ func (m *Manager) SendPrompt(req SendPromptRequest) error {
 		return fmt.Errorf("failed to send prompt: %w", err)
 	}
 	return nil
+}
+
+// CreateTab spawns a Process-kind tab running req.Command in the target
+// session's worktree, persists the grown tab list, and returns the resolved tab
+// name (#930 PR 5). It mirrors CreateSession's discipline: the find+spawn+persist
+// runs under the per-repo start lock so a concurrent CreateSession/CreateTab on
+// the same repo can't race the tab list or derive a duplicate name. The new tab
+// is persisted immediately (ToInstanceData serializes its command + tmux name,
+// and restoreLocalTabs reconnects it by exact name on reload) so it survives a
+// daemon/af restart — Sachin's hard #930 requirement. Rejected for remote/hook
+// instances (no local worktree to run a command in), an empty command, or an
+// instance already at the soft cap (maxTabs, enforced by AddProcessTab).
+func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
+	if strings.TrimSpace(req.Command) == "" {
+		return "", fmt.Errorf("a process tab requires a non-empty command (--command)")
+	}
+
+	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+	if err != nil {
+		return "", err
+	}
+	if instance == nil {
+		return "", fmt.Errorf("failed to restore instance %q", req.Title)
+	}
+	if instance.IsRemote() {
+		return "", fmt.Errorf("cannot create a process tab on remote session %q: it has no local worktree to run a command in", req.Title)
+	}
+
+	// Serialize against other create/tab mutations on this repo, mirroring
+	// CreateSession, so two concurrent CreateTab calls never derive the same name
+	// or interleave a spawn-then-persist with another save.
+	repoStartLock := m.startLockForRepo(repoID)
+	repoStartLock.Lock()
+	defer repoStartLock.Unlock()
+
+	tab, err := instance.AddProcessTab(req.Command, req.Name)
+	if err != nil {
+		return "", err
+	}
+
+	if err := m.SaveInstances(); err != nil {
+		// Roll back the just-spawned tab so a persist failure does not leave a
+		// live tmux session that vanishes from the tab list on restart.
+		if closeErr := instance.CloseTab(instance.TabCount() - 1); closeErr != nil {
+			log.WarningLog.Printf("CreateTab %q: rolling back unpersisted tab failed: %v", req.Title, closeErr)
+		}
+		return "", fmt.Errorf("failed to persist new tab: %w", err)
+	}
+	return tab.Name, nil
 }
 
 // targetDeliverWait bounds how long DeliverPrompt waits for a target session to

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -1,0 +1,233 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// tabPtyFactory is a tmux.PtyFactory returning a real temp file as the PTY and
+// forwarding the command to the mock executor so session-existence bookkeeping
+// fires — the hermetic plumbing AddProcessTab needs to spawn a sibling session
+// without touching a real tmux server.
+type tabPtyFactory struct {
+	t       *testing.T
+	cmdExec cmd_test.MockCmdExec
+}
+
+func (p tabPtyFactory) Start(cmd *exec.Cmd) (*os.File, error) {
+	f, err := os.CreateTemp(p.t.TempDir(), "pty-")
+	if err == nil {
+		_ = p.cmdExec.Run(cmd)
+	}
+	return f, err
+}
+func (p tabPtyFactory) Close() {}
+
+// tabNameKeyedExec is a tmux mock tracking session existence per session name,
+// so an instance's agent session and its CLI-spawned process tab are
+// independent. Names in `alive` report existing immediately; others come into
+// existence after their new-session.
+func tabNameKeyedExec(alive map[string]bool) cmd_test.MockCmdExec {
+	existing := map[string]bool{}
+	for k, v := range alive {
+		existing[k] = v
+	}
+	nameOf := func(cmd *exec.Cmd) string {
+		for i, a := range cmd.Args {
+			switch {
+			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
+				return cmd.Args[i+1]
+			case strings.HasPrefix(a, "-t="):
+				return strings.TrimPrefix(a, "-t=")
+			case strings.HasPrefix(a, "-s="):
+				return strings.TrimPrefix(a, "-s=")
+			}
+		}
+		return ""
+	}
+	return cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			s := cmd.String()
+			n := nameOf(cmd)
+			switch {
+			case strings.Contains(s, "has-session"):
+				if existing[n] {
+					return nil
+				}
+				return &tabNoSessionErr{}
+			case strings.Contains(s, "new-session"):
+				existing[n] = true
+				return nil
+			case strings.Contains(s, "kill-session"):
+				delete(existing, n)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+}
+
+type tabNoSessionErr struct{}
+
+func (*tabNoSessionErr) Error() string { return "session does not exist" }
+
+// remoteTypeBackend is a FakeBackend that reports the "remote" type so
+// Instance.IsRemote() returns true, letting CreateTab's remote-rejection branch
+// be exercised without a real hook backend.
+type remoteTypeBackend struct {
+	*session.FakeBackend
+}
+
+func (remoteTypeBackend) Type() string { return "remote" }
+
+// startedLocalTabInstance builds a started local instance whose agent tab is a
+// mock-backed tmux session, registers it in the manager, and seeds a matching
+// on-disk record so the manager's refresh keeps the live in-memory instance.
+func startedLocalTabInstance(t *testing.T, m *Manager, repoID, repoPath, title, agentName string) *session.Instance {
+	t.Helper()
+	exec := tabNameKeyedExec(map[string]bool{agentName: true})
+	pty := tabPtyFactory{t: t, cmdExec: exec}
+
+	gw, err := git.NewGitWorktreeFromStorage(
+		repoPath, filepath.Join(t.TempDir(), "wt"), title,
+		title+"-branch", "", false, true)
+	if err != nil {
+		t.Fatalf("NewGitWorktreeFromStorage: %v", err)
+	}
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: repoPath, Program: "claude"})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	inst.SetGitWorktreeForTest(gw)
+	inst.SetTmuxSession(tmux.NewTmuxSessionFromSanitizedNameWithDeps(agentName, "claude", pty, exec))
+	inst.SetStartedForTest(true)
+	inst.SetStatus(session.Running)
+
+	seedDiskInstance(t, repoID, title, repoPath)
+	m.mu.Lock()
+	m.instances[daemonInstanceKey(repoID, title)] = inst
+	m.mu.Unlock()
+	return inst
+}
+
+// TestCreateTab_RejectsEmptyCommand verifies an empty command is refused before
+// any session lookup or tab spawn.
+func TestCreateTab_RejectsEmptyCommand(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	if _, err := manager.CreateTab(CreateTabRequest{Title: "x", Command: "   "}); err == nil {
+		t.Fatal("expected error for empty command, got nil")
+	}
+}
+
+// TestCreateTab_RejectsRemoteInstance verifies a process tab cannot be created on
+// a remote session — it has no local worktree to run a command in.
+func TestCreateTab_RejectsRemoteInstance(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "rem", Path: repoPath, Program: "claude"})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	inst.SetBackend(remoteTypeBackend{session.NewFakeBackend()})
+	inst.SetStartedForTest(true)
+	seedDiskInstance(t, repo.ID, "rem", repoPath)
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
+	manager.mu.Unlock()
+
+	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Command: "btop"})
+	if err == nil {
+		t.Fatal("expected error for remote instance, got nil")
+	}
+	if !strings.Contains(err.Error(), "remote") {
+		t.Fatalf("expected remote-rejection error, got: %v", err)
+	}
+}
+
+// TestCreateTab_SpawnsPersistsAndReturnsName is the headline daemon test: a
+// successful CreateTab spawns a Process tab, returns its resolved name, and
+// persists it to disk (with command + tmux name) so it survives a restart.
+func TestCreateTab_SpawnsPersistsAndReturnsName(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	agentName := "af_" + title + "_agent"
+	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, agentName)
+
+	name, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Command: "btop -t"})
+	if err != nil {
+		t.Fatalf("CreateTab: %v", err)
+	}
+	if name != "btop" {
+		t.Fatalf("resolved tab name = %q, want %q (derived from command basename)", name, "btop")
+	}
+
+	// The tab must be persisted to disk with its command + a derived tmux name so
+	// it reconnects across a restart.
+	raw, err := config.LoadRepoInstances(repo.ID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var data []session.InstanceData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("unmarshal instances: %v", err)
+	}
+	if len(data) != 1 {
+		t.Fatalf("expected 1 persisted instance, got %d", len(data))
+	}
+	var proc *session.TabData
+	for i := range data[0].Tabs {
+		if data[0].Tabs[i].Kind == session.TabKindProcess {
+			proc = &data[0].Tabs[i]
+		}
+	}
+	if proc == nil {
+		t.Fatalf("no persisted process tab found in %+v", data[0].Tabs)
+	}
+	if proc.Name != "btop" {
+		t.Fatalf("persisted process tab name = %q, want btop", proc.Name)
+	}
+	if proc.Command != "btop -t" {
+		t.Fatalf("persisted process tab command = %q, want %q", proc.Command, "btop -t")
+	}
+	if proc.TmuxName != agentName+"__btop" {
+		t.Fatalf("persisted process tab tmux name = %q, want %q", proc.TmuxName, agentName+"__btop")
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,7 @@ af sessions get <title>                                   # fetch one session
 af sessions create --name <title> [--prompt "..."] [--program <agent>]
 af sessions send-prompt <title> "..."                     # append a prompt to a session
 af sessions send-prompt <title> "..." --create            # send-or-create
+af sessions tab-create <title> --command "<cmd>"          # spawn a process tab in the session's worktree
 af sessions preview <title>                               # snapshot the session's pane
 af sessions attach <title>                                # attach interactively (foreground)
 af sessions whoami                                        # report the session this shell is inside
@@ -36,6 +37,7 @@ Flags:
 
 - `create`: `--name` (required), `--prompt` (initial prompt to send), `--program` (agent enum, defaults to the configured `default_program`).
 - `send-prompt`: `--create` auto-creates the session if it doesn't exist; `--program` picks the agent when creating.
+- `tab-create`: `--command` (required) is run in the session's git worktree as a new tab; `--name` sets the tab's display name (defaults to the command's basename, auto-suffixed `-2`, `-3`, … on collision). The resolved tab name is printed as `{"name": "..."}` so scripts/agents can address it. The tab persists and reconnects across a daemon/`af` restart like every other tab. Not available for remote sessions (no local worktree); refused once a session already holds 9 tabs.
 
 ## `af tasks`
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -258,6 +260,58 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 	return tab, nil
 }
 
+// AddProcessTab spawns a new Process-kind tab running command in the instance's
+// worktree, appends it to Tabs, and returns it (#930 PR 5). It is the
+// CLI/agent-driven counterpart of AddShellTab: instead of $SHELL it runs an
+// arbitrary command, so an agent can prompt-spawn a tab hosting a data explorer,
+// test watcher, etc. Local instances only — remote instances have no local
+// worktree, so callers must reject IsRemote() before calling. The display name is
+// requestedName when non-empty, otherwise derived from the command's basename;
+// it is sanitized and made unique within the instance ("btop", "btop-2", …) so
+// its derived tmux session name is collision-free and restorable by exact name
+// across a restart. Errors on an empty command, an instance that is not started /
+// has no worktree, or one already at maxTabs.
+func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
+	if strings.TrimSpace(command) == "" {
+		return nil, fmt.Errorf("a process tab requires a non-empty command")
+	}
+
+	i.mu.RLock()
+	started := i.started
+	agentTmux := i.tmuxLocked()
+	gw := i.gitWorktree
+	displayName := uniqueTabName(i.Tabs, processTabBaseName(requestedName, command))
+	nTabs := len(i.Tabs)
+	i.mu.RUnlock()
+
+	if !started || agentTmux == nil || gw == nil {
+		return nil, fmt.Errorf("cannot add a tab to an instance that is not started")
+	}
+	if nTabs >= maxTabs {
+		return nil, fmt.Errorf("max %d tabs per session", maxTabs)
+	}
+	worktreePath := gw.GetWorktreePath()
+	if worktreePath == "" {
+		return nil, fmt.Errorf("cannot add a tab without a worktree")
+	}
+
+	// Spawn outside the lock (see AddShellTab): the tmux name is derived from the
+	// agent session + the unique, sanitized display name so it is collision-free
+	// and restorable by exact name. The sibling inherits the agent session's PTY
+	// factory / executor — real in production, mock in tests.
+	tmuxName := agentTmux.SanitizedName() + "__" + displayName
+	procTmux := agentTmux.NewSiblingSession(tmuxName, command)
+	if err := procTmux.Start(worktreePath); err != nil {
+		return nil, fmt.Errorf("failed to start process tab: %w", err)
+	}
+
+	tab := &Tab{Name: displayName, Kind: TabKindProcess, Command: command, tmux: procTmux}
+	i.mu.Lock()
+	i.Tabs = append(i.Tabs, tab)
+	i.mu.Unlock()
+	return tab, nil
+}
+
 // CloseTab kills the tab at idx and removes it from Tabs. The agent tab (idx 0)
 // is unclosable; CloseTab errors on idx 0 or any out-of-range index. The tab is
 // removed from Tabs regardless of whether the tmux teardown succeeds (best-
@@ -284,22 +338,61 @@ func (i *Instance) CloseTab(idx int) error {
 }
 
 // uniqueShellName returns a shell-tab display name not already used by any tab
-// in tabs: "shell", then "shell-2", "shell-3", … Names are unique per instance
-// so each tab's derived tmux session name is collision-free.
+// in tabs: "shell", then "shell-2", "shell-3", …
 func uniqueShellName(tabs []*Tab) string {
+	return uniqueTabName(tabs, shellTabName)
+}
+
+// uniqueTabName returns base, or base with the lowest free "-N" suffix (N>=2),
+// such that the result is not already a tab name in tabs. Tab names are unique
+// per instance so each tab's derived tmux session name is collision-free. This
+// is the shared collision handling for both shell tabs (AddShellTab) and
+// CLI-spawned process tabs (AddProcessTab).
+func uniqueTabName(tabs []*Tab, base string) string {
 	used := make(map[string]bool, len(tabs))
 	for _, t := range tabs {
 		used[t.Name] = true
 	}
-	if !used[shellTabName] {
-		return shellTabName
+	if !used[base] {
+		return base
 	}
 	for n := 2; ; n++ {
-		candidate := fmt.Sprintf("%s-%d", shellTabName, n)
+		candidate := fmt.Sprintf("%s-%d", base, n)
 		if !used[candidate] {
 			return candidate
 		}
 	}
+}
+
+// tabNameUnsafe matches any run of characters that must not appear in a tab's
+// derived tmux session name (the agent session name + "__" + the tab name).
+// tmux silently rewrites '.', ':', '#', '$' in session names, so a name
+// containing them would not round-trip on restore; whitespace and path
+// separators are likewise collapsed. Anything outside [A-Za-z0-9_-] becomes a
+// single '-'.
+var tabNameUnsafe = regexp.MustCompile(`[^A-Za-z0-9_-]+`)
+
+// sanitizeTabName converts a requested or derived tab name into a token safe to
+// embed in a tmux session name and stable across a save/restore round-trip.
+// Returns "" when nothing usable remains so callers can fall back to a default.
+func sanitizeTabName(name string) string {
+	return strings.Trim(tabNameUnsafe.ReplaceAllString(name, "-"), "-")
+}
+
+// processTabBaseName picks the base display name for a new Process tab: the
+// sanitized requestedName when the caller passed --name, otherwise the sanitized
+// basename of the command's first word ("/usr/bin/btop -t" -> "btop"). Falls back
+// to "process" when neither yields a usable token.
+func processTabBaseName(requestedName, command string) string {
+	if base := sanitizeTabName(requestedName); base != "" {
+		return base
+	}
+	if fields := strings.Fields(command); len(fields) > 0 {
+		if base := sanitizeTabName(filepath.Base(fields[0])); base != "" {
+			return base
+		}
+	}
+	return "process"
 }
 
 // setTmuxLocked stores ts as the agent tab's tmux session, materializing the

--- a/session/tab_process_test.go
+++ b/session/tab_process_test.go
@@ -1,0 +1,187 @@
+package session
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddProcessTab_AppendsWithCommandAndName verifies a CLI-spawned process tab
+// is appended with the right kind, command, and explicit name, backed by a live
+// tmux session running that command (#930 PR 5).
+func TestAddProcessTab_AppendsWithCommandAndName(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_proc_add")
+
+	tab, err := inst.AddProcessTab("btop", "monitor")
+	require.NoError(t, err)
+	assert.Equal(t, "monitor", tab.Name, "explicit --name must be honored")
+	assert.Equal(t, TabKindProcess, tab.Kind)
+	assert.Equal(t, "btop", tab.Command, "the tab must record its command for persistence")
+	assert.Equal(t, 2, inst.TabCount())
+	assert.True(t, inst.TabAlive(1), "the new process tab session must be live")
+}
+
+// TestAddProcessTab_DefaultNameFromCommandBasename covers default-name
+// derivation: with no --name, the tab is named after the command's basename.
+func TestAddProcessTab_DefaultNameFromCommandBasename(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_proc_default")
+
+	tab, err := inst.AddProcessTab("/usr/bin/htop -t", "")
+	require.NoError(t, err)
+	assert.Equal(t, "htop", tab.Name, "default name is the basename of the command's first word")
+	assert.Equal(t, "/usr/bin/htop -t", tab.Command)
+}
+
+// TestAddProcessTab_CollisionSuffixing verifies a derived name that collides with
+// an existing tab is auto-suffixed (-2, -3, …), mirroring shell-tab collision
+// handling.
+func TestAddProcessTab_CollisionSuffixing(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_proc_collide")
+
+	first, err := inst.AddProcessTab("btop", "")
+	require.NoError(t, err)
+	assert.Equal(t, "btop", first.Name)
+
+	second, err := inst.AddProcessTab("btop --tree", "")
+	require.NoError(t, err)
+	assert.Equal(t, "btop-2", second.Name, "a colliding derived name must be suffixed")
+
+	third, err := inst.AddProcessTab("btop", "btop") // explicit name also collides
+	require.NoError(t, err)
+	assert.Equal(t, "btop-3", third.Name)
+
+	assert.NotEqual(t, first.tmux.SanitizedName(), second.tmux.SanitizedName(),
+		"each process tab must have a unique tmux session name")
+}
+
+// TestAddProcessTab_EmptyCommandRejected verifies an empty/whitespace command is
+// refused before any tab is created.
+func TestAddProcessTab_EmptyCommandRejected(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_proc_empty")
+
+	_, err := inst.AddProcessTab("   ", "name")
+	require.Error(t, err)
+	assert.Equal(t, 1, inst.TabCount(), "a rejected empty command must not create a tab")
+}
+
+// TestAddProcessTab_SoftCapAtNine verifies process-tab creation is refused once
+// the instance already holds maxTabs (9) tabs.
+func TestAddProcessTab_SoftCapAtNine(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_proc_cap")
+	for i := 0; i < maxTabs-1; i++ {
+		_, err := inst.AddProcessTab(fmt.Sprintf("cmd%d", i), "")
+		require.NoError(t, err)
+	}
+	require.Equal(t, maxTabs, inst.TabCount())
+
+	_, err := inst.AddProcessTab("overflow", "")
+	require.Error(t, err, "the 10th tab must be refused")
+	require.Contains(t, err.Error(), fmt.Sprintf("%d", maxTabs))
+	require.Equal(t, maxTabs, inst.TabCount(), "the cap must not create a tab")
+}
+
+// TestAddProcessTab_RejectedForUnstarted verifies AddProcessTab errors when the
+// instance has no live agent session/worktree.
+func TestAddProcessTab_RejectedForUnstarted(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, err := NewInstance(InstanceOptions{Title: "unstarted-proc", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	_, err = inst.AddProcessTab("btop", "")
+	require.Error(t, err)
+	require.Equal(t, 0, inst.TabCount())
+}
+
+// TestSanitizeTabName covers the name-token sanitization that keeps a tab's
+// derived tmux session name valid and round-trippable.
+func TestSanitizeTabName(t *testing.T) {
+	assert.Equal(t, "btop", sanitizeTabName("btop"))
+	assert.Equal(t, "explorer-py", sanitizeTabName("explorer.py"))
+	assert.Equal(t, "my-data-explorer", sanitizeTabName("my data explorer"))
+	assert.Equal(t, "tab", sanitizeTabName("  tab  "))
+	assert.Equal(t, "", sanitizeTabName("///"), "a name with no usable chars sanitizes to empty")
+}
+
+// TestProcessTabBaseName covers base-name selection: explicit name wins, else the
+// command basename, else the "process" fallback.
+func TestProcessTabBaseName(t *testing.T) {
+	assert.Equal(t, "monitor", processTabBaseName("monitor", "btop"))
+	assert.Equal(t, "btop", processTabBaseName("", "/usr/bin/btop -t"))
+	assert.Equal(t, "explorer", processTabBaseName("  ", "explorer --json"))
+	assert.Equal(t, "process", processTabBaseName("", "///"), "fall back to process when nothing usable remains")
+}
+
+// TestRestartSurvival_ProcessTab is the PR 5 restart-survival test: a CLI-created
+// process tab must persist through Storage and reconnect to its exact tmux
+// session across an af/daemon restart, with its Command intact — the load-bearing
+// #930 requirement applied to process tabs.
+func TestRestartSurvival_ProcessTab(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	const agentName = "af_proc_restart"
+	shellName := agentName + "__shell"
+	procName := agentName + "__btop"
+
+	// Mirror production layout: an instance always has agent+shell, and a process
+	// tab is added on top.
+	inst := startedMockInstance(t, agentName)
+	_, err := inst.AddShellTab()
+	require.NoError(t, err)
+	tab, err := inst.AddProcessTab("btop -t", "") // derives name "btop"
+	require.NoError(t, err)
+	require.Equal(t, "btop", tab.Name)
+	require.Equal(t, 3, inst.TabCount())
+
+	repoID := config.RepoIDFromRoot(inst.Path)
+	ms := newMockStorage()
+	saveStore, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+	require.NoError(t, saveStore.SaveInstances([]*Instance{inst}))
+
+	restoreExec := nameKeyedExec(map[string]bool{agentName: true, shellName: true, procName: true})
+	restorePty := persistPtyFactory{t: t, cmdExec: restoreExec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, restorePty, restoreExec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	loadStore, err := NewStorage(ms, repoID)
+	require.NoError(t, err)
+	loaded, err := loadStore.LoadInstances()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+
+	restored := loaded[0]
+	tabs := restored.GetTabs()
+	require.Len(t, tabs, 3, "agent, shell, and process tabs must all survive a restart")
+	assert.Equal(t, TabKindProcess, tabs[2].Kind)
+	assert.Equal(t, "btop", tabs[2].Name, "the process tab keeps its name")
+	assert.Equal(t, "btop -t", tabs[2].Command, "the process tab must restore its command intact")
+	assert.Equal(t, procName, tabs[2].tmux.SanitizedName(),
+		"the process tab must reconnect to its exact persisted tmux session")
+	assert.True(t, restored.TabAlive(2), "the restored process tab must be live")
+}


### PR DESCRIPTION
Part of #930 (ephemeral tabs epic). PR 5 of 7.

Gives agents/scripts a way to prompt-spawn a tab that runs a process in an
instance's worktree — e.g. a data-explorer TUI or a test watcher — exactly the
use case called out in the #930 plan. Human `t` new-tab (PR 4) is unchanged; this
is the CLI/process-command counterpart.

## CLI verb

```
af sessions tab-create <session-title> --command "<cmd>" [--name <tab-name>] [--repo <path>]
```

Creates a `TabKindProcess` tab running `<cmd>` in the instance's worktree. If
`--name` is omitted, the name is derived from the command's basename (`btop`,
`htop`, …), sanitized, and made unique within the instance (auto-suffixed `-2`,
`-3`, … on collision, mirroring shell-tab naming). The resolved tab name is
printed as `{"name": "..."}` so scripts/agents can address it. Refused for remote
sessions, empty commands, and once a session already holds 9 tabs.

## Daemon RPC

New `CreateTab` RPC on the `Manager`, structured like `CreateSession`:
- Finds the target instance by title with **RepoID scoping** (reuses
  `findSession`), consistent with `kill`/`send-prompt`/`attach` (#761/#776/#891).
- Spawns the Process tab via the existing `Instance.AddProcessTab` path (PR 2/4
  tab lifecycle), **persists it immediately** under the per-repo start lock
  (mirrors `CreateSession`'s locking discipline), and returns the resolved name.
- Rejects remote/hook instances (no local worktree to run a process in), empty
  commands, and the 9-tab soft cap (consistent with PR 4) — each with an
  actionable message.

## Persistence / restart-survival

A CLI-created Process tab round-trips through `InstanceData.Tabs` (PR 2): its
`Command` + derived tmux name are serialized, and on reload `restoreLocalTabs`
reconnects the session by its exact name, so the tab survives a daemon/`af`
restart like every other tab — Sachin's hard #930 requirement. Covered by a
session-level restart-survival test and a daemon-level persist test.

## Adjacent-call-site audit (CLAUDE.md)

- **Repo scoping**: `tab-create` resolves `--repo` via `resolveRepoID()` and
  passes `RepoID` to the daemon; `CreateTab` scopes the lookup through the same
  `findSession` the other verbs use — a same-titled session in another repo can
  never receive the tab. Matches #761/#776/#891.
- **Locking / no double-create**: `CreateTab` holds `startLockForRepo` across
  spawn+persist (same as `CreateSession`); it operates on the tracked instance
  returned by `findSession` (the #867 register-restored-instance path), so it
  introduces no new races or duplicate-Instance path.
- **Name uniqueness**: `AddShellTab` and `AddProcessTab` now share
  `uniqueTabName`, so process-tab collision suffixing matches shell-tab handling
  exactly; the derived tmux session name is kept collision-free and round-trips
  on restore via `sanitizeTabName`.

## Tests

- session: `AddProcessTab` appends with right command+name+kind+live session;
  default-name derivation from basename; collision suffixing; empty-command
  rejected; soft-cap rejected; unstarted rejected; `sanitizeTabName` /
  `processTabBaseName` units; restart-survival of a Process tab with `Command`
  intact (reconnects to exact tmux name).
- daemon: `CreateTab` rejects empty command and remote instances; success spawns
  the tab, returns the resolved name, and persists it to disk (command + tmux
  name) — all hermetic (temp `AGENT_FACTORY_HOME`, mock pty/exec; no real daemon
  touched).
- api: `tab-create` requires `--command`; honors `--repo` scoping (passes
  `RepoID`) and emits the resolved name as JSON.

Verified: `gofmt -l .` clean, `go build ./...`, `golangci-lint run --fast` clean,
`deadcode -test ./...` clean, `go test ./...` green.

## Non-goals

Remote `terminal_cmd`-as-tab (PR 6) and any TUI changes. `tab-list` was left out
to keep this PR focused on the required `tab-create` deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude