### PR TITLE
feat(session): model remote terminal_cmd as a tab; complete ephemeral-tabs docs (#930, PR 6/7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,21 @@ Each session is one agent running in its own git worktree on its own branch — 
 | Key | Action |
 |-----|--------|
 | `n` | Create a new session |
-| `Enter` / `o` | Attach to the selected session |
+| `Enter` / `o` | Attach to the selected session's active tab |
 | `Ctrl-w` | Detach (configurable via `detach_keys`) |
 | `D` | Kill the session and clean up its worktree |
-| `Tab` | Switch between the preview and terminal panes |
+| `Tab` / `Shift-Tab` | Cycle forward / back through the session's tabs |
+| `1`–`9` | Jump straight to a tab by number |
+| `t` | Open a new shell tab in the session's worktree |
+| `w` | Close the active tab (the agent tab can't be closed) |
 
 When a session's branch has an open pull request, `p` opens it in the browser and `P` copies its URL.
+
+#### Tabs
+
+Every session opens with two tabs: an **agent** tab (the AI agent, shown as *Preview*) and a **shell** tab (*Terminal*) running `$SHELL` in the worktree. Press `t` to spawn more shell tabs (up to nine per session), `w` to close the active one, and `Tab` / `1`–`9` to move between them. Attaching (`Enter`) drops you into whichever tab is active. Tabs are ephemeral but persisted: they survive an `af`/daemon restart, reconnecting to their live processes. You can also spawn a tab running an arbitrary command from the CLI with `af sessions tab-create` (see below).
+
+Remote sessions are tab-driven too, with one limitation: the hook protocol can't run arbitrary commands on the remote host, so a remote session has an agent tab always and a single terminal tab **only when** its repo configures `remote_hooks.terminal_cmd` (`t` and `tab-create` are rejected for remote sessions). See [docs/remote-hooks.md](docs/remote-hooks.md).
 
 ### Tasks
 

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -377,7 +377,9 @@ The tab persists and reconnects across a daemon/af restart like every other tab.
 If --name is omitted, a name is derived from the command's basename; the name is
 made unique within the session (auto-suffixed -2, -3, …). The resolved tab name
 is printed on success so scripts/agents can address it. Not available for remote
-sessions, which have no local worktree.`,
+sessions: they have no local worktree and the hook protocol can't run arbitrary
+commands — a remote session's only terminal tab comes from
+remote_hooks.terminal_cmd.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -331,11 +331,12 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 
 // handleNewTab spawns a new shell tab in the selected instance and selects it
 // (#930 PR 4). Single keypress, no prompt: the tab runs $SHELL in the instance's
-// worktree. Remote instances have no local worktree, so new-tab is unsupported
-// there and surfaces the same "not available for remote" guidance as the remote
-// terminal tab. The soft cap (max 9 tabs) is enforced by Instance.AddShellTab,
-// whose error is surfaced verbatim. The grown tab list is persisted so the new
-// tab survives a restart (Sachin's #930 requirement).
+// worktree. Remote instances have no local worktree and the hook protocol has no
+// run-arbitrary-command verb, so new-tab is unsupported there: a remote session's
+// only terminal tab is the one derived from remote_hooks.terminal_cmd (#930 PR 6).
+// The soft cap (max 9 tabs) is enforced by Instance.AddShellTab, whose error is
+// surfaced verbatim. The grown tab list is persisted so the new tab survives a
+// restart (Sachin's #930 requirement).
 func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 	if m.contentPane.GetMode() != ui.ContentModeInstance {
 		return m, nil
@@ -348,7 +349,7 @@ func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if selected.IsRemote() {
-		return m, m.handleError(fmt.Errorf("new tabs are not available for remote sessions"))
+		return m, m.handleError(fmt.Errorf("remote sessions don't support new process tabs; their terminal tab comes from remote_hooks.terminal_cmd and arbitrary remote processes aren't supported"))
 	}
 	if _, err := selected.AddShellTab(); err != nil {
 		return m, m.handleError(err)
@@ -364,9 +365,10 @@ func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 
 // handleCloseTab closes the active tab of the selected instance and selects the
 // previous (left) tab (#930 PR 4). The agent tab (index 0) is unclosable — w on
-// it is a gentle no-op message pointing at D for killing the whole session.
-// Remote instances carry only the synthetic agent/terminal slots, neither of
-// which is a real closable Tab. The shrunk tab list is persisted.
+// it is a gentle no-op message pointing at D for killing the whole session. A
+// remote instance's tabs (agent + optional terminal_cmd terminal) are fixed by
+// its hook config, not user-managed, so closing any of them is refused. The
+// shrunk tab list is persisted.
 func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
 	if m.contentPane.GetMode() != ui.ContentModeInstance {
 		return m, nil

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1175,8 +1175,10 @@ func (m *Manager) SendPrompt(req SendPromptRequest) error {
 // is persisted immediately (ToInstanceData serializes its command + tmux name,
 // and restoreLocalTabs reconnects it by exact name on reload) so it survives a
 // daemon/af restart — Sachin's hard #930 requirement. Rejected for remote/hook
-// instances (no local worktree to run a command in), an empty command, or an
-// instance already at the soft cap (maxTabs, enforced by AddProcessTab).
+// instances (no local worktree, and the hook protocol can't run arbitrary
+// commands — a remote session's only terminal tab is the terminal_cmd one), an
+// empty command, or an instance already at the soft cap (maxTabs, enforced by
+// AddProcessTab).
 func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 	if strings.TrimSpace(req.Command) == "" {
 		return "", fmt.Errorf("a process tab requires a non-empty command (--command)")
@@ -1190,7 +1192,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 		return "", fmt.Errorf("failed to restore instance %q", req.Title)
 	}
 	if instance.IsRemote() {
-		return "", fmt.Errorf("cannot create a process tab on remote session %q: it has no local worktree to run a command in", req.Title)
+		return "", fmt.Errorf("cannot create a process tab on remote session %q: remote sessions have no local worktree and the hook protocol can't run arbitrary commands; their terminal tab comes from remote_hooks.terminal_cmd", req.Title)
 	}
 
 	// Serialize against other create/tab mutations on this repo, mirroring

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,7 @@ Flags:
 
 - `create`: `--name` (required), `--prompt` (initial prompt to send), `--program` (agent enum, defaults to the configured `default_program`).
 - `send-prompt`: `--create` auto-creates the session if it doesn't exist; `--program` picks the agent when creating.
-- `tab-create`: `--command` (required) is run in the session's git worktree as a new tab; `--name` sets the tab's display name (defaults to the command's basename, auto-suffixed `-2`, `-3`, … on collision). The resolved tab name is printed as `{"name": "..."}` so scripts/agents can address it. The tab persists and reconnects across a daemon/`af` restart like every other tab. Not available for remote sessions (no local worktree); refused once a session already holds 9 tabs.
+- `tab-create`: `--command` (required) is run in the session's git worktree as a new tab; `--name` sets the tab's display name (defaults to the command's basename, auto-suffixed `-2`, `-3`, … on collision). The resolved tab name is printed as `{"name": "..."}` so scripts/agents can address it. The tab persists and reconnects across a daemon/`af` restart like every other tab. Refused once a session already holds 9 tabs. **Not available for remote sessions:** they have no local worktree and the hook protocol can't run arbitrary commands — a remote session's only terminal tab comes from `remote_hooks.terminal_cmd` (see [remote-hooks.md](remote-hooks.md)).
 
 ## `af tasks`
 

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -138,7 +138,7 @@ Each iteration becomes the new preview frame. `capture-pane -e` keeps colors; th
 
 ### `terminal_cmd` (optional)
 
-Opens an interactive terminal on the machine hosting a session — this is what the TUI's **Terminal tab** runs for remote sessions. Where `attach_cmd` connects to the *agent's* session (e.g. `ssh -t host "tmux attach"`), `terminal_cmd` should drop the user into a *plain shell* in the session's workspace, the remote analogue of the local worktree terminal.
+Opens an interactive terminal on the machine hosting a session. This is what backs a remote session's **Terminal tab**: where `attach_cmd` connects to the *agent's* session (e.g. `ssh -t host "tmux attach"`), `terminal_cmd` should drop the user into a *plain shell* in the session's workspace, the remote analogue of the local worktree terminal.
 
 **Arguments:** `<name>`
 
@@ -146,7 +146,15 @@ Opens an interactive terminal on the machine hosting a session — this is what 
 
 Agent Factory runs this command behind a local PTY with the same detach-key handling as `attach_cmd`: the configured detach key terminates the local `terminal_cmd` process and returns to the TUI. The remote shell receives a hangup when the SSH client dies; use a remote tmux/screen session inside your script if you want the shell to survive detach. Terminal reset sequences are emitted on exit, just as with `attach_cmd` (#845).
 
-When `terminal_cmd` is not configured, the Terminal tab shows a "not available" fallback for remote sessions and nothing else changes. Unlike `attach_cmd`, this command is never used for preview capture — it only runs when the user attaches from the Terminal tab.
+#### `terminal_cmd` and the tab model
+
+Remote sessions follow the same ephemeral-tab model as local ones (see the README "Tabs" section), with one structural difference driven by the protocol:
+
+- A remote session **always** has an agent tab (driven by `attach_cmd` and the preview loop above).
+- It has a **terminal tab if and only if `terminal_cmd` is configured.** Attaching to that tab runs `terminal_cmd`; previewing it shows a "Press Enter to open a terminal" prompt (the surface is interactive-only — `terminal_cmd` is never used for preview capture).
+- When `terminal_cmd` is **not** configured, a remote session has only its agent tab, and the would-be Terminal tab shows a "not available — configure `remote_hooks.terminal_cmd`" fallback.
+
+Because the protocol has no run-arbitrary-command verb, remote sessions **cannot** host extra process tabs: the `t` new-tab key and `af sessions tab-create` are rejected for remote sessions with a message pointing at `terminal_cmd`. A remote session's terminal tab is the one defined by `terminal_cmd` and nothing else. These tabs persist across an `af`/daemon restart like local tabs, but are reconstructed from your live `terminal_cmd` config on restore rather than from any saved local session — so adding or removing `terminal_cmd` while `af` is down is honored on the next start.
 
 ## Example
 

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -189,6 +189,7 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 		i.mu.Lock()
 		i.started = true
 		i.mu.Unlock()
+		b.syncRemoteTabs(i)
 		return nil
 	}
 
@@ -232,6 +233,8 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 	}
 	i.started = true
 	i.mu.Unlock()
+
+	b.syncRemoteTabs(i)
 
 	if err := b.ensurePTY(i); err != nil {
 		// launch_cmd succeeded so the remote session itself is alive; we
@@ -450,10 +453,29 @@ func (b *HookBackend) Attach(i *Instance) (chan struct{}, error) {
 }
 
 // HasTerminalCmd reports whether the optional terminal_cmd hook is configured.
-// When false, the Terminal tab keeps its "not available" fallback for remote
-// sessions (#843).
+// When false, a remote instance carries only its agent tab and AttachTerminal /
+// SupportsRemoteTerminal report the "not available" guidance (#843).
 func (b *HookBackend) HasTerminalCmd() bool {
 	return strings.TrimSpace(b.Hooks.TerminalCmd) != ""
+}
+
+// syncRemoteTabs rebuilds i.Tabs to the uniform remote tab model: the agent tab
+// always, plus a terminal tab when terminal_cmd is configured (#930 PR 6).
+// Remote tabs carry no tmux session — the agent tab is driven by attach_cmd and
+// the hook preview process, the terminal tab by terminal_cmd — so the list is
+// derived from the live hook config here rather than restored from a persisted
+// tmux name. Both Start paths call it (fresh launch and restore), and it is
+// idempotent: a re-run after a terminal_cmd config change re-derives the
+// correct tabs, which is exactly why a restore reconstructs the terminal tab
+// from config instead of from whatever was serialized.
+func (b *HookBackend) syncRemoteTabs(i *Instance) {
+	tabs := []*Tab{newRemoteAgentTab()}
+	if b.HasTerminalCmd() {
+		tabs = append(tabs, newRemoteTerminalTab())
+	}
+	i.mu.Lock()
+	i.Tabs = tabs
+	i.mu.Unlock()
 }
 
 // AttachTerminal gives interactive terminal access to the remote workspace by

--- a/session/instance.go
+++ b/session/instance.go
@@ -437,10 +437,12 @@ func (i *Instance) ToInstanceData() InstanceData {
 
 	// Persist each tab so the full agent+shell tab list survives a restart
 	// (Sachin's hard requirement for #930): on reload FromInstanceData restores
-	// each tab's tmux session by its exact persisted name, reconnecting live
-	// sessions across an af/daemon restart. Remote instances carry no tmux-
-	// backed tabs, so this serializes nothing for them (their tabs are
-	// synthesized on load).
+	// each local tab's tmux session by its exact persisted name, reconnecting
+	// live sessions across an af/daemon restart. Remote tabs (agent + optional
+	// terminal) carry no tmux session, so they serialize with an empty TmuxName;
+	// on restore HookBackend.Start re-derives them from the live terminal_cmd
+	// config (syncRemoteTabs) rather than from this serialized list, so a
+	// terminal_cmd added or removed while af was down is honored.
 	for _, tab := range i.Tabs {
 		td := TabData{Name: tab.Name, Kind: tab.Kind, Command: tab.Command}
 		if tab.tmux != nil {

--- a/session/tab.go
+++ b/session/tab.go
@@ -74,6 +74,24 @@ func newShellTab(ts *tmux.TmuxSession) *Tab {
 	return &Tab{Name: shellTabName, Kind: TabKindShell, tmux: ts}
 }
 
+// newRemoteAgentTab returns the Agent tab for a remote/hook-backed instance
+// (#930 PR 6). Like every remote tab it carries no tmux session: the agent
+// surface is driven by attach_cmd and the hook preview process, not a local
+// tmux session. It lets remote instances be tab-driven through the same Tabs
+// list as local ones.
+func newRemoteAgentTab() *Tab {
+	return &Tab{Name: agentTabName, Kind: TabKindAgent}
+}
+
+// newRemoteTerminalTab returns the Shell-kind terminal tab for a remote instance
+// whose terminal_cmd hook is configured (#930 PR 6). It has no tmux session;
+// attaching and previewing route through the terminal_cmd hook flow
+// (HookBackend.AttachTerminal). Only created when HasTerminalCmd() is true, so a
+// remote instance without terminal_cmd carries just the agent tab.
+func newRemoteTerminalTab() *Tab {
+	return &Tab{Name: shellTabName, Kind: TabKindShell}
+}
+
 // tabKindForData clamps a persisted TabKind to a known value, defaulting to
 // TabKindShell for any unexpected value written by a newer binary so a forward-
 // incompatible record degrades to a plain shell tab rather than an agent tab.

--- a/session/tab_remote_test.go
+++ b/session/tab_remote_test.go
@@ -1,0 +1,199 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertRemoteTabs asserts that inst carries the uniform remote tab model
+// (#930 PR 6): an Agent tab always, plus a Shell (terminal) tab iff wantTerminal.
+// Remote tabs are hook-driven, so neither tab carries a tmux session.
+func assertRemoteTabs(t *testing.T, inst *Instance, wantTerminal bool) {
+	t.Helper()
+	tabs := inst.GetTabs()
+	require.NotEmpty(t, tabs, "remote instance must have at least the agent tab")
+	assert.Equal(t, TabKindAgent, tabs[0].Kind, "Tabs[0] must be the agent tab")
+	assert.Nil(t, tabs[0].tmux, "remote agent tab carries no local tmux session")
+	if wantTerminal {
+		require.Len(t, tabs, 2, "terminal_cmd configured: expected agent + terminal tabs")
+		assert.Equal(t, TabKindShell, tabs[1].Kind, "Tabs[1] must be the terminal (shell) tab")
+		assert.Nil(t, tabs[1].tmux, "remote terminal tab carries no local tmux session")
+	} else {
+		require.Len(t, tabs, 1, "no terminal_cmd: expected only the agent tab")
+	}
+}
+
+// hooksWithTerminal returns a HookBackend built from makeHooks, optionally with a
+// terminal_cmd script wired in so the remote instance gains a terminal tab.
+func hooksWithTerminal(t *testing.T, withTerminal bool) *HookBackend {
+	t.Helper()
+	b := makeHooks(t)
+	if withTerminal {
+		dir := t.TempDir()
+		b.Hooks.TerminalCmd = writeScript(t, dir, "terminal.sh", `echo "terminal $1"; sleep 0.1`)
+	}
+	return b
+}
+
+// TestRemoteStartPopulatesTabs: a freshly launched remote instance gets an agent
+// tab always, and a terminal tab only when terminal_cmd is configured.
+func TestRemoteStartPopulatesTabs(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		withTerminal bool
+	}{
+		{"with terminal_cmd", true},
+		{"without terminal_cmd", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := hooksWithTerminal(t, tc.withTerminal)
+			i := &Instance{Title: "test-session", Path: t.TempDir(), backend: b}
+
+			require.NoError(t, b.Start(i, true))
+			defer b.closePTY(i.Title)
+
+			assertRemoteTabs(t, i, tc.withTerminal)
+		})
+	}
+}
+
+// TestRemoteRestorePopulatesTabs: the restore Start path (firstTimeSetup=false)
+// reconstructs the same tab model from the live hook config.
+func TestRemoteRestorePopulatesTabs(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		withTerminal bool
+	}{
+		{"with terminal_cmd", true},
+		{"without terminal_cmd", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := hooksWithTerminal(t, tc.withTerminal)
+			i := &Instance{Title: "test-session", Path: t.TempDir(), backend: b}
+
+			require.NoError(t, b.Start(i, false))
+			defer b.closePTY(i.Title)
+
+			assertRemoteTabs(t, i, tc.withTerminal)
+		})
+	}
+}
+
+// TestRemoteTabsReconstructedFromConfigOnRestore proves the terminal tab is
+// derived from the live terminal_cmd config on restore, NOT from whatever tab
+// list was serialized — so a terminal_cmd added or removed while af was down is
+// honored. It drives both directions across a restart.
+func TestRemoteTabsReconstructedFromConfigOnRestore(t *testing.T) {
+	t.Run("terminal_cmd removed while down drops the terminal tab", func(t *testing.T) {
+		// Save: terminal_cmd present -> agent + terminal tabs serialized.
+		saved := hooksWithTerminal(t, true)
+		i := &Instance{Title: "test-session", Path: t.TempDir(), backend: saved}
+		require.NoError(t, saved.Start(i, true))
+		defer saved.closePTY(i.Title)
+		assertRemoteTabs(t, i, true)
+		data := i.ToInstanceData()
+		require.Len(t, data.Tabs, 2, "both tabs must serialize")
+
+		// Restore against a config WITHOUT terminal_cmd: only the agent tab.
+		restoredBackend := hooksWithTerminal(t, false)
+		rebuilt := &Instance{Title: "test-session", Path: t.TempDir(), backend: restoredBackend, remoteMeta: data.RemoteMeta}
+		restoreLocalTabsForRemoteTest(rebuilt, data)
+		require.NoError(t, restoredBackend.Start(rebuilt, false))
+		defer restoredBackend.closePTY(rebuilt.Title)
+		assertRemoteTabs(t, rebuilt, false)
+	})
+
+	t.Run("terminal_cmd added while down gains the terminal tab", func(t *testing.T) {
+		saved := hooksWithTerminal(t, false)
+		i := &Instance{Title: "test-session", Path: t.TempDir(), backend: saved}
+		require.NoError(t, saved.Start(i, true))
+		defer saved.closePTY(i.Title)
+		assertRemoteTabs(t, i, false)
+		data := i.ToInstanceData()
+		require.Len(t, data.Tabs, 1, "only the agent tab serializes")
+
+		restoredBackend := hooksWithTerminal(t, true)
+		rebuilt := &Instance{Title: "test-session", Path: t.TempDir(), backend: restoredBackend, remoteMeta: data.RemoteMeta}
+		restoreLocalTabsForRemoteTest(rebuilt, data)
+		require.NoError(t, restoredBackend.Start(rebuilt, false))
+		defer restoredBackend.closePTY(rebuilt.Title)
+		assertRemoteTabs(t, rebuilt, true)
+	})
+}
+
+// restoreLocalTabsForRemoteTest mimics what FromInstanceData's local branch does
+// to data.Tabs, seeding the rebuilt instance's Tabs from the persisted list. For
+// remote instances HookBackend.Start then overwrites this from the live config —
+// which is exactly the property the test asserts. Seeding a non-empty list first
+// makes the "Start re-derives, ignoring persisted tabs" behavior observable.
+func restoreLocalTabsForRemoteTest(inst *Instance, data InstanceData) {
+	for _, td := range data.Tabs {
+		inst.Tabs = append(inst.Tabs, &Tab{Name: td.Name, Kind: tabKindForData(td.Kind), Command: td.Command})
+	}
+}
+
+// TestRemoteTabsPersistRoundTrip is the headline persistence test: a remote
+// instance's tabs survive a full ToInstanceData -> FromInstanceData restart,
+// reconstructed from the repo's terminal_cmd config (not a local tmux name).
+func TestRemoteTabsPersistRoundTrip(t *testing.T) {
+	repoDir := setupRemoteTabRepo(t, "remote-persist", true)
+
+	inst, err := NewInstance(InstanceOptions{Title: "remote-persist", Path: repoDir, Program: "claude", ForceRemote: true})
+	require.NoError(t, err)
+	require.True(t, inst.IsRemote())
+	require.NoError(t, inst.Start(true))
+	if hb, ok := inst.GetBackend().(*HookBackend); ok {
+		defer hb.closePTY(inst.Title)
+	}
+	assertRemoteTabs(t, inst, true)
+
+	data := inst.ToInstanceData()
+	require.Equal(t, "remote", data.BackendType)
+	require.Len(t, data.Tabs, 2, "agent + terminal tabs must persist")
+
+	rebuilt, err := FromInstanceData(data)
+	require.NoError(t, err)
+	if hb, ok := rebuilt.GetBackend().(*HookBackend); ok {
+		defer hb.closePTY(rebuilt.Title)
+	}
+	require.True(t, rebuilt.IsRemote())
+	assertRemoteTabs(t, rebuilt, true)
+}
+
+// setupRemoteTabRepo creates a git repo whose config declares remote_hooks with
+// static (python-free) scripts. list_cmd always reports the given slug as
+// running so the restore liveness check passes. terminal_cmd is wired iff
+// withTerminal.
+func setupRemoteTabRepo(t *testing.T, slug string, withTerminal bool) string {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "--local", "user.email", "test@af.com")
+	runGit(t, repoDir, "config", "--local", "user.name", "AF Test")
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("x"), 0644))
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "init")
+
+	dir := t.TempDir()
+	hooks := &config.RemoteHooks{
+		LaunchCmd: writeScript(t, dir, "launch.sh", `echo '{"name": "'"$2"'", "status": "running"}'`),
+		ListCmd:   writeScript(t, dir, "list.sh", `echo '[{"name": "`+slug+`", "status": "running"}]'`),
+		AttachCmd: writeScript(t, dir, "attach.sh", `echo "attached $1"; sleep 0.1`),
+		DeleteCmd: writeScript(t, dir, "delete.sh", `echo '{"name": "'"$2"'", "deleted": true}'`),
+	}
+	if withTerminal {
+		hooks.TerminalCmd = writeScript(t, dir, "terminal.sh", `echo "terminal $1"; sleep 0.1`)
+	}
+
+	repo, err := config.RepoFromPath(repoDir)
+	require.NoError(t, err)
+	require.NoError(t, config.SaveRepoConfig(repo.ID, &config.RepoConfig{RemoteHooks: hooks}))
+	return repoDir
+}

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -33,10 +33,10 @@ var (
 			Border(lipgloss.NormalBorder(), false, true, true, true)
 )
 
-// defaultTabLabels are the labels shown before an instance is selected (or for
-// remote instances, which carry no tmux-backed tabs). They preserve the exact
-// pre-#930 two-tab bar so the UX is identical: slot 0 is the agent ("Preview")
-// tab, slot 1 the terminal tab.
+// defaultTabLabels are the labels shown before an instance is selected, or for
+// one whose tabs haven't materialized yet. They preserve the exact pre-#930
+// two-tab bar so the UX is identical: slot 0 is the agent ("Preview") tab, slot
+// 1 the terminal tab.
 var defaultTabLabels = []string{"Preview", "Terminal"}
 
 // TabbedWindow has tabs at the top of a pane which can be selected. The tabs
@@ -109,11 +109,28 @@ func (w *TabbedWindow) SelectLastTab() {
 	w.SelectTab(len(w.tabLabels()) - 1)
 }
 
-// tabLabels returns the labels for the current instance's tabs, always at least
-// the two default slots so the bar is identical to the pre-#930 UX. Agent tabs
-// render as "Preview", shell tabs as "Terminal"; any future Process tab renders
-// under its own name.
+// tabLabels returns the labels for the current instance's tabs. Agent tabs
+// render as "Preview", shell tabs as "Terminal"; any Process tab renders under
+// its own name.
+//
+// Remote instances are tab-driven too (#930 PR 6): their real tab set is the
+// agent tab plus a terminal tab only when terminal_cmd is configured, so the
+// bar reflects exactly those tabs — a terminal_cmd-less remote shows a single
+// tab rather than the local two-tab default. Local instances keep the
+// default-padded bar (always at least the two slots) so the header count never
+// dips below two mid-start, identical to the pre-#930 UX.
 func (w *TabbedWindow) tabLabels() []string {
+	if w.instance != nil && w.instance.IsRemote() {
+		if tabs := w.instance.GetTabs(); len(tabs) > 0 {
+			labels := make([]string, len(tabs))
+			for i, tab := range tabs {
+				labels[i] = labelForTab(tab)
+			}
+			return labels
+		}
+		// Pre-start remote (no tabs yet): fall through to the default bar.
+	}
+
 	labels := append([]string(nil), defaultTabLabels...)
 	if w.instance == nil {
 		return labels

--- a/ui/tabbed_window_remote_test.go
+++ b/ui/tabbed_window_remote_test.go
@@ -1,0 +1,79 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeRemoteHookScript writes an executable shell script and returns its path.
+func writeRemoteHookScript(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0755))
+	return path
+}
+
+// startedRemoteInstance builds and starts a remote (hook-backed) instance with
+// (optionally) a terminal_cmd hook configured, so its Tabs are populated by the
+// real HookBackend.Start path (#930 PR 6). It registers cleanup that releases the
+// preview process without deleting any remote session.
+func startedRemoteInstance(t *testing.T, withTerminal bool) *session.Instance {
+	t.Helper()
+	dir := t.TempDir()
+	hooks := config.RemoteHooks{
+		LaunchCmd: writeRemoteHookScript(t, dir, "launch.sh", `echo '{"name": "'"$2"'", "status": "running"}'`),
+		ListCmd:   writeRemoteHookScript(t, dir, "list.sh", `echo '[{"name": "remote-tabbar", "status": "running"}]'`),
+		AttachCmd: writeRemoteHookScript(t, dir, "attach.sh", `echo "attached $1"; sleep 0.1`),
+		DeleteCmd: writeRemoteHookScript(t, dir, "delete.sh", `echo '{"deleted": true}'`),
+	}
+	if withTerminal {
+		hooks.TerminalCmd = writeRemoteHookScript(t, dir, "terminal.sh", `echo "terminal $1"; sleep 0.1`)
+	}
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "remote-tabbar", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	inst.SetBackend(&session.HookBackend{Hooks: hooks})
+	require.True(t, inst.IsRemote())
+	require.NoError(t, inst.Start(true))
+	t.Cleanup(func() { _ = inst.CloseAttachOnly() })
+	return inst
+}
+
+// TestTabbedWindowRemoteTabBar verifies a remote instance is tab-driven: the bar
+// shows the agent (Preview) tab plus a Terminal tab only when terminal_cmd is
+// configured — never the local two-tab default when terminal_cmd is absent.
+func TestTabbedWindowRemoteTabBar(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	for _, tc := range []struct {
+		name       string
+		withTerm   bool
+		wantLabels []string
+	}{
+		{"with terminal_cmd shows agent + terminal", true, []string{"Preview", "Terminal"}},
+		{"without terminal_cmd shows only the agent tab", false, []string{"Preview"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := startedRemoteInstance(t, tc.withTerm)
+			w := NewTabbedWindow(NewTabPane())
+			w.SetInstance(inst)
+			require.Equal(t, tc.wantLabels, w.tabLabels())
+
+			// Toggle wraps within the real tab count, never a phantom slot.
+			w.Toggle()
+			if tc.withTerm {
+				require.Equal(t, 1, w.GetActiveTab(), "Toggle advances onto the terminal tab")
+			} else {
+				require.Equal(t, 0, w.GetActiveTab(), "single-tab remote: Toggle stays on the agent tab")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #930.

Final PR of the #930 **ephemeral tabs** redesign. With this merged, the full epic is delivered.

## The redesign, end to end (PRs 1–6)

- **Instance ⇄ worktree is 1:1** and an instance owns an ordered list of **tabs**, each a process in the worktree (PR 1: internal `Tab` type; PR 3: removed the old create-on-existing-worktree / `a`-key path).
- Every session opens with two **default tabs** — an **agent** tab (*Preview*) and a **shell** tab (*Terminal*, `$SHELL` in the worktree) — rendered through one unified `TabPane`, and **persisted** so they survive an `af`/daemon restart, reconnecting to their live tmux sessions (PR 2).
- **Human tab management** from the TUI: `t` new shell tab, `w` close tab, `1`–`9` jump, `Tab`/`Shift-Tab` cycle (PR 4).
- **CLI/agent tab creation**: `af sessions tab-create <title> --command …` spawns a persisted process tab in the worktree (PR 5).
- **Remote terminal as a tab** + **docs completion** (this PR).

## This PR (6/7)

A remote/hook-backed instance is now tab-driven through the **same `Tabs` list** as a local one, instead of being special-cased:

- **Always** an Agent tab (`Tabs[0]`, driven by `attach_cmd` + the hook preview loop — unchanged behavior).
- A Shell-kind **Terminal tab** (`Tabs[1]`) **only when `remote_hooks.terminal_cmd` is configured**, wired to the existing `terminal_cmd` hook flow for attach/preview (no reinvention). Without `terminal_cmd`, the remote instance has **just the agent tab**, and the "configure `terminal_cmd`" guidance is preserved.
- `HookBackend.Start` (fresh-launch **and** restore paths) populates the list via `syncRemoteTabs`, derived from the **live hook config** — so on restore the terminal tab is **reconstructed from `terminal_cmd`**, not from a saved local tmux name (a `terminal_cmd` added/removed while `af` was down is honored).
- The UI tab bar now reflects the **real remote tab set** (one tab vs two) rather than always padding to the local two-tab default. **Local tab behavior (PR 2/4/5) is unchanged.**
- **No mixing**: backend stays an instance-level property. Arbitrary process tabs remain unsupported on remote (the hook protocol has no run-arbitrary-command verb): the `t` key and `tab-create` reject remote with a message that now names `terminal_cmd` and the limitation.

### Docs
README (tab keys + a new **Tabs** section), `docs/remote-hooks.md` (`terminal_cmd`-as-a-tab and its limits), `docs/cli.md`, and `af sessions tab-create --help`.

### Adjacent-call-site audit
- Swept docs/README/help/overlays for stale **create-on-existing-worktree** / **`a`-key** / **attach-existing-worktree** references — **none remain**.
- Remote **attach** (`Enter` → `AttachTerminalForInstance` → `terminal_cmd`), **preview** (`UpdateContent` → hook), and **kill** all flow through the tab/instance model.
- `HasTerminalCmd` / `terminal_cmd` callers (`SupportsRemoteTerminal`, `AttachTerminal`, `syncRemoteTabs`, the `updateShellLocked` fallback) are consistent with the tab model.
- Remote-rejection messages for `t` (PR 4) and `tab-create` (PR 5) verified and updated for accuracy.
- No production caller assumes remote instances have zero tabs.

### Tests
Remote `Start`/restore populate agent(+terminal) tabs; tabs reconstructed from config across a restart (both directions); full `ToInstanceData`→`FromInstanceData` round-trip; UI tab bar shows the right count and `Toggle` wraps within the real count. Existing remote/hook + terminal-attach tests stay green.

### Verification
`gofmt -l .` clean · `go build ./...` · `golangci-lint run --fast` clean · `deadcode -test ./...` clean · `go test ./...` green (incl. integration) · `GOFLAGS=-p=1 go test -race -parallel 2 ./ui/... ./app/... ./session/...` green.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)