### PR TITLE
feat(app): route TUI tab + PR-info mutations through the daemon (#960, PR 2)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -335,10 +335,35 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			target.MarkPRInfoFetched()
 			return m, nil
 		}
+		// Apply the fetched PR info to the in-memory instance immediately so the
+		// sidebar badge updates without waiting on the daemon round-trip. The
+		// gh-pr-view fetch stays TUI-side (#921, per-selection, debounced); only
+		// the persisted WRITE moves to the daemon (#960 PR 2) so the daemon — the
+		// single writer — owns it and the TUI no longer originates a full-list
+		// save the daemon could clobber (#959).
 		target.SetPRInfo(msg.info)
+		var prData session.PRInfoData
+		if msg.info != nil {
+			prData = session.PRInfoData{
+				Number: msg.info.Number,
+				Title:  msg.info.Title,
+				URL:    msg.info.URL,
+				State:  msg.info.State,
+			}
+		}
 		saveStart := time.Now()
-		if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
-			log.WarningLog.Printf("failed to save instances after PR update: %v", err)
+		if err := setPRInfoThroughDaemon(target.Title, m.repoID, prData); err != nil {
+			if daemon.IsRPCMethodNotFoundErr(err) {
+				// Older daemon without the SetPRInfo RPC: keep the legacy
+				// full-list save so the write isn't lost.
+				if saveErr := m.storage.SaveInstances(m.sidebar.GetInstances()); saveErr != nil {
+					log.WarningLog.Printf("failed to save instances after PR update: %v", saveErr)
+				}
+			} else {
+				// In-memory update already applied for the UI; surface the
+				// persist failure but don't drop the badge.
+				log.WarningLog.Printf("failed to persist PR info for %q via daemon: %v", target.Title, err)
+			}
 		}
 		detachTrace(saveStart, "prInfoUpdatedMsg-SaveInstances-returned")
 		return m, nil

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,6 +31,22 @@ func newTestHome(t *testing.T) *home {
 	origReload := reloadDaemonTaskSchedulesFn
 	reloadDaemonTaskSchedulesFn = func() error { return nil }
 	t.Cleanup(func() { reloadDaemonTaskSchedulesFn = origReload })
+
+	// The tab + PR-info mutations now route through daemon RPCs (#960 PR 2).
+	// Stub the seams with safe defaults so tests that incidentally trigger them
+	// never dial — or spawn — a real daemon. Tests exercising these paths
+	// override the relevant seam. createTab/closeTab default to an error so an
+	// unstubbed mutation fails loudly rather than reaching the daemon; setPRInfo
+	// defaults to a no-op so the in-memory PR-badge path stays exercisable.
+	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, error) {
+		return "", fmt.Errorf("createShellTabThroughDaemon not stubbed in test")
+	}))
+	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
+		return fmt.Errorf("closeTabThroughDaemon not stubbed in test")
+	}))
+	t.Cleanup(SetPRInfoSetterForTest(func(title, repoID string, info session.PRInfoData) error {
+		return nil
+	}))
 
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	sidebar := ui.NewSidebar(&spin, false)

--- a/app/daemon_mutation_routing_test.go
+++ b/app/daemon_mutation_routing_test.go
@@ -1,0 +1,239 @@
+package app
+
+import (
+	"net/rpc"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
+)
+
+// rpcMethodNotFound returns an error that daemon.IsRPCMethodNotFoundErr matches,
+// simulating a version-skewed daemon that predates a given verb.
+func rpcMethodNotFound(method string) error {
+	return rpc.ServerError("rpc: can't find method Control." + method)
+}
+
+// TestHandleNewTab_RoutesThroughDaemon_NoLocalSave proves the `t` mutation goes
+// through the daemon CreateTab RPC and does NOT fall back to a local full-list
+// save when the RPC succeeds (#960 PR 2). The daemon owns the persist; the TUI
+// only reflects the tab locally via AttachShellTab.
+func TestHandleNewTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "route-create")
+	selectInstance(h, inst)
+
+	var gotTitle, gotRepo string
+	restore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
+		gotTitle, gotRepo = title, repoID
+		return nextShellTabName(inst.GetTabs()), nil
+	})
+	defer restore()
+
+	_, _ = h.handleNewTab()
+
+	require.Equal(t, inst.Title, gotTitle, "CreateTab must be called for the selected session")
+	require.Equal(t, h.repoID, gotRepo, "CreateTab must be scoped to the TUI's repo")
+	require.Equal(t, 3, inst.TabCount(), "the daemon-created tab must appear locally")
+
+	// On the daemon-success path nothing is written to the TUI's storage — the
+	// daemon is the single writer. The repo's instances file stays empty (the
+	// instance was never added to TUI storage in this test).
+	data, err := h.storage.LoadInstanceData()
+	require.NoError(t, err)
+	require.Empty(t, data, "daemon-success path must not write the TUI's storage")
+}
+
+// TestHandleNewTab_VersionSkewFallsBackToLocalSave proves that against an older
+// daemon lacking the shell-aware CreateTab RPC (method-not-found), `t` falls
+// back to the legacy local spawn + full-list save so the mutation isn't lost.
+func TestHandleNewTab_VersionSkewFallsBackToLocalSave(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "skew-create")
+	selectInstance(h, inst)
+
+	restore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
+		return "", rpcMethodNotFound("CreateTab")
+	})
+	defer restore()
+
+	_, _ = h.handleNewTab()
+
+	require.Equal(t, 3, inst.TabCount(), "fallback must still spawn the shell tab locally")
+
+	// The legacy path persists via the TUI's full-list save.
+	data, err := h.storage.LoadInstanceData()
+	require.NoError(t, err)
+	require.Len(t, data, 1, "fallback must persist the instance via the legacy save")
+	require.Len(t, data[0].Tabs, 3, "the persisted tab list must include the new shell tab")
+}
+
+// TestHandleCloseTab_RoutesThroughDaemon_NoLocalSave proves the `w` mutation
+// goes through the daemon CloseTab RPC and drops the tab locally without a
+// local full-list save when the RPC succeeds (#960 PR 2).
+func TestHandleCloseTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "route-close")
+	selectInstance(h, inst)
+
+	var gotTitle, gotRepo, gotTab string
+	createRestore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
+		return nextShellTabName(inst.GetTabs()), nil
+	})
+	defer createRestore()
+	closeRestore := SetTabCloserForTest(func(title, repoID, tabName string) error {
+		gotTitle, gotRepo, gotTab = title, repoID, tabName
+		return nil
+	})
+	defer closeRestore()
+
+	_, _ = h.handleNewTab() // agent + shell + shell-2, active = 2
+	require.Equal(t, 3, inst.TabCount())
+
+	_, _ = h.handleCloseTab()
+
+	require.Equal(t, inst.Title, gotTitle, "CloseTab must be called for the selected session")
+	require.Equal(t, h.repoID, gotRepo, "CloseTab must be scoped to the TUI's repo")
+	require.Equal(t, "shell-2", gotTab, "CloseTab must target the active tab by name")
+	require.Equal(t, 2, inst.TabCount(), "the closed tab must be dropped locally")
+
+	data, err := h.storage.LoadInstanceData()
+	require.NoError(t, err)
+	require.Empty(t, data, "daemon-success path must not write the TUI's storage")
+}
+
+// TestHandleCloseTab_VersionSkewFallsBackToLocalSave proves close falls back to
+// the legacy local kill + full-list save against an older daemon.
+func TestHandleCloseTab_VersionSkewFallsBackToLocalSave(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "skew-close")
+	selectInstance(h, inst)
+
+	createRestore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
+		return nextShellTabName(inst.GetTabs()), nil
+	})
+	defer createRestore()
+	closeRestore := SetTabCloserForTest(func(title, repoID, tabName string) error {
+		return rpcMethodNotFound("CloseTab")
+	})
+	defer closeRestore()
+
+	_, _ = h.handleNewTab()
+	require.Equal(t, 3, inst.TabCount())
+
+	_, _ = h.handleCloseTab()
+
+	require.Equal(t, 2, inst.TabCount(), "fallback must still close the tab locally")
+	data, err := h.storage.LoadInstanceData()
+	require.NoError(t, err)
+	require.Len(t, data, 1, "fallback must persist via the legacy save")
+	require.Len(t, data[0].Tabs, 2, "the persisted tab list must drop the closed tab")
+}
+
+// TestHandleCloseTab_AgentTabSkipsDaemon proves the agent-tab rule is enforced
+// TUI-side without a daemon round-trip: `w` on tab 0 is a friendly no-op and the
+// CloseTab RPC is never called.
+func TestHandleCloseTab_AgentTabSkipsDaemon(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "agentskip")
+	selectInstance(h, inst)
+	h.contentPane.TabbedWindow().JumpToTab(0)
+
+	called := false
+	restore := SetTabCloserForTest(func(title, repoID, tabName string) error {
+		called = true
+		return nil
+	})
+	defer restore()
+
+	_, _ = h.handleCloseTab()
+
+	require.False(t, called, "the agent tab must not round-trip to the daemon")
+	require.Equal(t, 2, inst.TabCount(), "the agent tab must never be closed")
+}
+
+// TestPrInfoUpdatedMsg_RoutesWriteThroughDaemon proves the PR-info write goes
+// through the daemon SetPRInfo RPC (the gh fetch stays TUI-side, #960 PR 2 §6)
+// and applies the badge in-memory for instant UX.
+func TestPrInfoUpdatedMsg_RoutesWriteThroughDaemon(t *testing.T) {
+	h := newTestHome(t)
+	inst := newLoadingInstance(t, "pr-target")
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	var gotTitle, gotRepo string
+	var gotInfo session.PRInfoData
+	restore := SetPRInfoSetterForTest(func(title, repoID string, info session.PRInfoData) error {
+		gotTitle, gotRepo, gotInfo = title, repoID, info
+		return nil
+	})
+	defer restore()
+
+	info := &sessiongit.PRInfo{Number: 42, Title: "add feature", URL: "https://x/42", State: "OPEN"}
+	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, info: info})
+
+	require.Equal(t, inst.Title, gotTitle, "SetPRInfo must target the resolved session")
+	require.Equal(t, h.repoID, gotRepo, "SetPRInfo must be scoped to the TUI's repo")
+	require.Equal(t, 42, gotInfo.Number, "SetPRInfo must carry the fetched PR number")
+	require.Equal(t, "add feature", gotInfo.Title)
+
+	got := inst.GetPRInfo()
+	require.NotNil(t, got, "the badge must be applied in-memory for instant UX")
+	require.Equal(t, 42, got.Number)
+}
+
+// TestPrInfoUpdatedMsg_BranchMismatchSkipsDaemon proves the #921 branch guard
+// still holds: when the captured fetch branch no longer matches the resolved
+// instance's branch, neither the in-memory badge nor the daemon write is applied.
+func TestPrInfoUpdatedMsg_BranchMismatchSkipsDaemon(t *testing.T) {
+	h := newTestHome(t)
+	inst := newLoadingInstance(t, "pr-branch")
+	inst.Branch = "feature-x"
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	called := false
+	restore := SetPRInfoSetterForTest(func(title, repoID string, info session.PRInfoData) error {
+		called = true
+		return nil
+	})
+	defer restore()
+
+	info := &sessiongit.PRInfo{Number: 99, Title: "wrong branch", State: "OPEN"}
+	// The fetch was kicked off for a different branch than the instance now has.
+	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, branch: "feature-y", info: info})
+
+	require.False(t, called, "a branch mismatch must not write PR info to the daemon")
+	require.Nil(t, inst.GetPRInfo(), "a branch mismatch must not apply the badge")
+}
+
+// TestPrInfoUpdatedMsg_VersionSkewFallsBackToLocalSave proves the PR-info write
+// falls back to the legacy full-list save against an older daemon, while still
+// applying the badge in-memory.
+func TestPrInfoUpdatedMsg_VersionSkewFallsBackToLocalSave(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "pr-skew")
+	h.sidebar.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	restore := SetPRInfoSetterForTest(func(title, repoID string, info session.PRInfoData) error {
+		return rpcMethodNotFound("SetPRInfo")
+	})
+	defer restore()
+
+	info := &sessiongit.PRInfo{Number: 7, Title: "legacy", URL: "https://x/7", State: "OPEN"}
+	// Match the captured branch to the instance's so the #921 guard lets the
+	// apply through (the focus here is the version-skew persist fallback).
+	_, _ = h.Update(prInfoUpdatedMsg{instance: inst, branch: inst.GetBranch(), info: info})
+
+	got := inst.GetPRInfo()
+	require.NotNil(t, got, "the badge must still be applied in-memory")
+	require.Equal(t, 7, got.Number)
+
+	data, err := h.storage.LoadInstanceData()
+	require.NoError(t, err)
+	require.Len(t, data, 1, "fallback must persist the PR info via the legacy save")
+	require.Equal(t, 7, data[0].PRInfo.Number, "the persisted record must carry the PR number")
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -334,9 +335,19 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 // worktree. Remote instances have no local worktree and the hook protocol has no
 // run-arbitrary-command verb, so new-tab is unsupported there: a remote session's
 // only terminal tab is the one derived from remote_hooks.terminal_cmd (#930 PR 6).
-// The soft cap (max 9 tabs) is enforced by Instance.AddShellTab, whose error is
-// surfaced verbatim. The grown tab list is persisted so the new tab survives a
-// restart (Sachin's #930 requirement).
+//
+// The spawn+persist is routed through the daemon's CreateTab RPC (#960 PR 2): the
+// daemon — the single writer — owns the new tab so its authoritative view holds
+// it and the TUI no longer originates a tab write that the daemon's next save
+// could clobber (#959). The TUI reflects the daemon-created tab locally via
+// AttachShellTab for instant display (it reconnects to the session the daemon
+// spawned, never a second colliding spawn); full live reconcile lands in PR 3.
+//
+// Version skew: against an older daemon that predates the shell-aware CreateTab,
+// the RPC reports method-not-found and we fall back to the legacy local spawn +
+// full-list save so a stale daemon can't drop the mutation (belt-and-suspenders
+// until PR 4 removes the TUI writer). The daemon's soft cap (max tabs) error is
+// surfaced verbatim.
 func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 	if m.contentPane.GetMode() != ui.ContentModeInstance {
 		return m, nil
@@ -351,15 +362,33 @@ func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 	if selected.IsRemote() {
 		return m, m.handleError(fmt.Errorf("remote sessions don't support new process tabs; their terminal tab comes from remote_hooks.terminal_cmd and arbitrary remote processes aren't supported"))
 	}
-	if _, err := selected.AddShellTab(); err != nil {
-		return m, m.handleError(err)
+
+	name, err := createShellTabThroughDaemon(selected.Title, m.repoID)
+	if err != nil {
+		if daemon.IsRPCMethodNotFoundErr(err) {
+			// Older daemon without the shell-aware CreateTab RPC: keep the legacy
+			// local-spawn + full-list save path so the mutation isn't lost.
+			if _, addErr := selected.AddShellTab(); addErr != nil {
+				return m, m.handleError(addErr)
+			}
+			if saveErr := m.storage.SaveInstances(m.sidebar.GetInstances()); saveErr != nil {
+				log.ErrorLog.Printf("failed to persist new tab: %v", saveErr)
+			}
+		} else {
+			return m, m.handleError(err)
+		}
+	} else {
+		// The daemon spawned and persisted the tab; reflect it locally for
+		// instant display without a second spawn. The daemon write is
+		// authoritative, so we do NOT save here.
+		if _, attachErr := selected.AttachShellTab(name); attachErr != nil {
+			return m, m.handleError(attachErr)
+		}
 	}
+
 	tw := m.contentPane.TabbedWindow()
 	tw.SelectLastTab()
 	m.menu.SetActiveTab(tw.GetActiveTab())
-	if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
-		log.ErrorLog.Printf("failed to persist new tab: %v", err)
-	}
 	return m, m.selectionChanged()
 }
 
@@ -367,8 +396,16 @@ func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 // previous (left) tab (#930 PR 4). The agent tab (index 0) is unclosable — w on
 // it is a gentle no-op message pointing at D for killing the whole session. A
 // remote instance's tabs (agent + optional terminal_cmd terminal) are fixed by
-// its hook config, not user-managed, so closing any of them is refused. The
-// shrunk tab list is persisted.
+// its hook config, not user-managed, so closing any of them is refused.
+//
+// The kill+persist is routed through the daemon's CloseTab RPC (#960 PR 2): the
+// daemon — the single writer — kills the tab's tmux and persists the shrunk
+// list, so the TUI no longer originates a tab write the daemon could clobber
+// (#959). The agent-tab and remote rules are still enforced TUI-side so the
+// friendly message shows without a round-trip (the RPC enforces them too). The
+// TUI drops the now-dead tab locally via DropClosedTab — a no-kill removal, since
+// the daemon already tore the tmux session down. Version skew falls back to the
+// legacy local CloseTab + full-list save on method-not-found.
 func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
 	if m.contentPane.GetMode() != ui.ContentModeInstance {
 		return m, nil
@@ -385,16 +422,38 @@ func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
 	if selected.IsRemote() {
 		return m, m.handleError(fmt.Errorf("remote session tabs can't be closed"))
 	}
-	if err := selected.CloseTab(idx); err != nil {
-		return m, m.handleError(err)
+	tabs := selected.GetTabs()
+	if idx >= len(tabs) {
+		return m, m.handleError(fmt.Errorf("tab cannot be closed"))
 	}
+	tabName := tabs[idx].Name
+
+	if err := closeTabThroughDaemon(selected.Title, m.repoID, tabName); err != nil {
+		if daemon.IsRPCMethodNotFoundErr(err) {
+			// Older daemon without the CloseTab RPC: keep the legacy local-kill +
+			// full-list save path so the mutation isn't lost.
+			if closeErr := selected.CloseTab(idx); closeErr != nil {
+				return m, m.handleError(closeErr)
+			}
+			if saveErr := m.storage.SaveInstances(m.sidebar.GetInstances()); saveErr != nil {
+				log.ErrorLog.Printf("failed to persist tab close: %v", saveErr)
+			}
+		} else {
+			return m, m.handleError(err)
+		}
+	} else {
+		// The daemon killed the tmux and persisted the shrunk list; drop the
+		// now-dead tab locally without re-killing. The daemon write is
+		// authoritative, so we do NOT save here.
+		if dropErr := selected.DropClosedTab(idx); dropErr != nil {
+			return m, m.handleError(dropErr)
+		}
+	}
+
 	// Prefer the left/previous neighbor; SelectTab clamps so this is always in
 	// range (idx >= 1, so idx-1 >= 0).
 	tw.SelectTab(idx - 1)
 	m.menu.SetActiveTab(tw.GetActiveTab())
-	if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
-		log.ErrorLog.Printf("failed to persist tab close: %v", err)
-	}
 	return m, m.selectionChanged()
 }
 

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -39,6 +39,30 @@ var importRemoteSessionsThroughDaemon = func(repoPath string) ([]session.Instanc
 	return daemon.ImportRemoteHookSessions(daemon.ImportRemoteHookSessionsRequest{RepoPath: repoPath})
 }
 
+// createShellTabThroughDaemon routes the TUI's `t` (new shell tab) mutation to
+// the daemon so the daemon — the single writer (#960) — owns the spawn and the
+// persist, returning the resolved tab name. The TUI reflects the new tab locally
+// for instant display via Instance.AttachShellTab.
+var createShellTabThroughDaemon = func(title, repoID string) (string, error) {
+	return daemon.CreateTab(daemon.CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
+}
+
+// closeTabThroughDaemon routes the TUI's `w` (close tab) mutation to the daemon,
+// which kills the tab's tmux session and persists the shrunk list. The TUI drops
+// the now-dead tab locally via Instance.DropClosedTab.
+var closeTabThroughDaemon = func(title, repoID, tabName string) error {
+	_, err := daemon.CloseTab(daemon.CloseTabRequest{Title: title, RepoID: repoID, TabName: tabName})
+	return err
+}
+
+// setPRInfoThroughDaemon routes the TUI's PR-info write (prInfoUpdatedMsg) to the
+// daemon for persistence (#921 write moved daemon-side, #960 PR 2). The gh fetch
+// stays TUI-side; only the persisted write moves. The TUI keeps its in-memory
+// SetPRInfo for instant UI feedback.
+var setPRInfoThroughDaemon = func(title, repoID string, info session.PRInfoData) error {
+	return daemon.SetPRInfo(daemon.SetPRInfoRequest{Title: title, RepoID: repoID, PRInfo: info})
+}
+
 func SetSessionStarterForTest(f func(*session.Instance, sessionStartRequest) (*session.Instance, error)) func() {
 	prev := startSessionThroughDaemon
 	startSessionThroughDaemon = f
@@ -49,4 +73,22 @@ func SetRemoteImporterForTest(f func(repoPath string) ([]session.InstanceData, e
 	prev := importRemoteSessionsThroughDaemon
 	importRemoteSessionsThroughDaemon = f
 	return func() { importRemoteSessionsThroughDaemon = prev }
+}
+
+func SetTabCreatorForTest(f func(title, repoID string) (string, error)) func() {
+	prev := createShellTabThroughDaemon
+	createShellTabThroughDaemon = f
+	return func() { createShellTabThroughDaemon = prev }
+}
+
+func SetTabCloserForTest(f func(title, repoID, tabName string) error) func() {
+	prev := closeTabThroughDaemon
+	closeTabThroughDaemon = f
+	return func() { closeTabThroughDaemon = prev }
+}
+
+func SetPRInfoSetterForTest(f func(title, repoID string, info session.PRInfoData) error) func() {
+	prev := setPRInfoThroughDaemon
+	setPRInfoThroughDaemon = f
+	return func() { setPRInfoThroughDaemon = prev }
 }

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -125,16 +125,60 @@ func selectInstance(h *home, inst *session.Instance) {
 	h.contentPane.TabbedWindow().SetInstance(inst)
 }
 
+// nextShellTabName mirrors session.uniqueShellName ("shell", "shell-2", …) so a
+// stubbed daemon CreateTab returns the same name the real daemon would derive
+// from the instance's current tab list — letting AttachShellTab reconnect by the
+// expected name. Kept here (not imported) so production stays free of a
+// test-only export.
+func nextShellTabName(tabs []*session.Tab) string {
+	used := map[string]bool{}
+	for _, t := range tabs {
+		used[t.Name] = true
+	}
+	if !used["shell"] {
+		return "shell"
+	}
+	for n := 2; ; n++ {
+		c := fmt.Sprintf("shell-%d", n)
+		if !used[c] {
+			return c
+		}
+	}
+}
+
+// stubTabDaemonSeams installs daemon CreateTab/CloseTab seam stubs that simulate
+// the daemon hermetically against the single in-process instance (#960 PR 2):
+// CreateTab returns the next shell name (the TUI then reconnects via
+// AttachShellTab); CloseTab is a no-op (the TUI then drops the tab locally via
+// DropClosedTab). Records the calls so tests can assert routing went through the
+// RPC rather than a local save. Returns pointers to the call counters and a
+// restore func.
+func stubTabDaemonSeams(t *testing.T, inst *session.Instance) (created, closed *int) {
+	t.Helper()
+	var c, d int
+	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, error) {
+		c++
+		return nextShellTabName(inst.GetTabs()), nil
+	}))
+	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
+		d++
+		return nil
+	}))
+	return &c, &d
+}
+
 // TestHandleNewTabAppendsAndSelects: the new-tab hotkey appends a shell tab and
 // selects it.
 func TestHandleNewTabAppendsAndSelects(t *testing.T) {
 	h := newTestHome(t)
 	inst := startedLocalInstance(t, "new")
 	selectInstance(h, inst)
+	created, _ := stubTabDaemonSeams(t, inst)
 	require.Equal(t, 2, inst.TabCount(), "start gives an agent + default shell tab")
 
 	_, _ = h.handleNewTab()
 
+	require.Equal(t, 1, *created, "new-tab must route through the daemon CreateTab RPC")
 	require.Equal(t, 3, inst.TabCount(), "new-tab must append a shell tab")
 	require.Equal(t, 2, h.contentPane.TabbedWindow().GetActiveTab(),
 		"the freshly created tab must be selected")
@@ -146,12 +190,14 @@ func TestHandleCloseTabSelectsNeighbor(t *testing.T) {
 	h := newTestHome(t)
 	inst := startedLocalInstance(t, "close")
 	selectInstance(h, inst)
+	_, closed := stubTabDaemonSeams(t, inst)
 	_, _ = h.handleNewTab() // now agent + shell + shell-2, active = 2
 	require.Equal(t, 3, inst.TabCount())
 	require.Equal(t, 2, h.contentPane.TabbedWindow().GetActiveTab())
 
 	_, _ = h.handleCloseTab()
 
+	require.Equal(t, 1, *closed, "close must route through the daemon CloseTab RPC")
 	require.Equal(t, 2, inst.TabCount(), "close must remove the active tab")
 	require.Equal(t, 1, h.contentPane.TabbedWindow().GetActiveTab(),
 		"close must select the left neighbor")
@@ -196,6 +242,7 @@ func TestHandleTabJump(t *testing.T) {
 	h := newTestHome(t)
 	inst := startedLocalInstance(t, "jump")
 	selectInstance(h, inst)
+	stubTabDaemonSeams(t, inst)
 	_, _ = h.handleNewTab() // agent + shell + shell-2 (3 tabs)
 	require.Equal(t, 3, inst.TabCount())
 
@@ -216,6 +263,7 @@ func TestNumberKeyRoutesToTabJump(t *testing.T) {
 	h := newTestHome(t)
 	inst := startedLocalInstance(t, "route")
 	selectInstance(h, inst)
+	stubTabDaemonSeams(t, inst)
 	_, _ = h.handleNewTab() // 3 tabs
 
 	h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -93,16 +93,26 @@ type DeliverPromptResponse struct {
 	Status string
 }
 
-// CreateTabRequest asks the daemon to spawn a Process-kind tab running Command
-// in the target session's worktree (#930 PR 5). Title selects the session;
-// RepoID scopes the lookup like the other sessions verbs (empty = all-repo).
-// Name is the optional display name (a default is derived from Command's
-// basename when empty); the resolved, collision-suffixed name is returned.
+// CreateTabRequest asks the daemon to spawn a tab in the target session's
+// worktree. Title selects the session; RepoID scopes the lookup like the other
+// sessions verbs (empty = all-repo).
+//
+// Two kinds of tab can be created:
+//   - Process tab (Shell=false, the #930 PR 5 default): runs Command in the
+//     worktree. Name is the optional display name (a default is derived from
+//     Command's basename when empty). Command must be non-empty.
+//   - Shell tab (Shell=true): runs $SHELL in the worktree, exactly like the TUI's
+//     `t` key (Instance.AddShellTab). Command/Name are ignored; the name is the
+//     auto-derived unique "shell"/"shell-2"/… The TUI routes its `t` mutation
+//     here so the daemon — not the TUI — owns the tab write (#960 PR 2).
+//
+// Either way the resolved, collision-suffixed name is returned.
 type CreateTabRequest struct {
 	Title   string
 	RepoID  string
 	Command string
 	Name    string
+	Shell   bool
 }
 
 type CreateTabResponse struct {
@@ -517,6 +527,15 @@ func isRPCMethodNotFoundErr(err error) bool {
 	}
 	s := string(serverErr)
 	return strings.Contains(s, "can't find method") || strings.Contains(s, "can't find service")
+}
+
+// IsRPCMethodNotFoundErr reports whether err is the net/rpc server's
+// method-not-found reply — the daemon is alive on the control socket but does
+// not register the requested verb (a version-skewed, older daemon). RPC clients
+// (the TUI) use this to fall back to a legacy local path for a single mutation
+// until the daemon is upgraded (#960 PR 2), mirroring the Shutdown fallback.
+func IsRPCMethodNotFoundErr(err error) bool {
+	return isRPCMethodNotFoundErr(err)
 }
 
 type controlServer struct {
@@ -1265,7 +1284,7 @@ func (m *Manager) SendPrompt(req SendPromptRequest) error {
 // empty command, or an instance already at the soft cap (maxTabs, enforced by
 // AddProcessTab).
 func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
-	if strings.TrimSpace(req.Command) == "" {
+	if !req.Shell && strings.TrimSpace(req.Command) == "" {
 		return "", fmt.Errorf("a process tab requires a non-empty command (--command)")
 	}
 
@@ -1277,7 +1296,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 		return "", fmt.Errorf("failed to restore instance %q", req.Title)
 	}
 	if instance.IsRemote() {
-		return "", fmt.Errorf("cannot create a process tab on remote session %q: remote sessions have no local worktree and the hook protocol can't run arbitrary commands; their terminal tab comes from remote_hooks.terminal_cmd", req.Title)
+		return "", fmt.Errorf("cannot create a tab on remote session %q: remote sessions have no local worktree and the hook protocol can't run arbitrary commands; their terminal tab comes from remote_hooks.terminal_cmd", req.Title)
 	}
 
 	// Serialize against other create/tab mutations on this repo, mirroring
@@ -1287,7 +1306,14 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 	repoStartLock.Lock()
 	defer repoStartLock.Unlock()
 
-	tab, err := instance.AddProcessTab(req.Command, req.Name)
+	// A shell tab runs $SHELL (the TUI `t` mutation, #960 PR 2); a process tab
+	// runs the requested command (the CLI/API path, #930 PR 5).
+	var tab *session.Tab
+	if req.Shell {
+		tab, err = instance.AddShellTab()
+	} else {
+		tab, err = instance.AddProcessTab(req.Command, req.Name)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -231,3 +231,97 @@ func TestCreateTab_SpawnsPersistsAndReturnsName(t *testing.T) {
 		t.Fatalf("persisted process tab tmux name = %q, want %q", proc.TmuxName, agentName+"__btop")
 	}
 }
+
+// TestCreateTab_ShellSpawnsPersistsAndReturnsName verifies the shell-tab path
+// the TUI's `t` mutation routes to (#960 PR 2): Shell=true creates a Shell-kind
+// tab running $SHELL (ignoring Command), returns its auto-derived name, and
+// persists it so it survives a restart.
+func TestCreateTab_ShellSpawnsPersistsAndReturnsName(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "shellworker"
+	agentName := "af_" + title + "_agent"
+	startedLocalTabInstance(t, manager, repo.ID, repoPath, title, agentName)
+
+	// Shell=true ignores Command and creates a $SHELL tab named "shell".
+	name, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repo.ID, Shell: true})
+	if err != nil {
+		t.Fatalf("CreateTab(shell): %v", err)
+	}
+	if name != "shell" {
+		t.Fatalf("resolved shell tab name = %q, want %q", name, "shell")
+	}
+
+	raw, err := config.LoadRepoInstances(repo.ID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var data []session.InstanceData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("unmarshal instances: %v", err)
+	}
+	if len(data) != 1 {
+		t.Fatalf("expected 1 persisted instance, got %d", len(data))
+	}
+	var shell *session.TabData
+	for i := range data[0].Tabs {
+		if data[0].Tabs[i].Kind == session.TabKindShell {
+			shell = &data[0].Tabs[i]
+		}
+	}
+	if shell == nil {
+		t.Fatalf("no persisted shell tab found in %+v", data[0].Tabs)
+	}
+	if shell.Name != "shell" {
+		t.Fatalf("persisted shell tab name = %q, want shell", shell.Name)
+	}
+	if shell.TmuxName != agentName+"__shell" {
+		t.Fatalf("persisted shell tab tmux name = %q, want %q", shell.TmuxName, agentName+"__shell")
+	}
+}
+
+// TestCreateTab_ShellRejectsRemoteInstance verifies the shell path also refuses
+// remote sessions (no local worktree), matching the process path and the TUI's
+// `t` rule.
+func TestCreateTab_ShellRejectsRemoteInstance(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "rem", Path: repoPath, Program: "claude"})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	inst.SetBackend(remoteTypeBackend{session.NewFakeBackend()})
+	inst.SetStartedForTest(true)
+	seedDiskInstance(t, repo.ID, "rem", repoPath)
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(repo.ID, "rem")] = inst
+	manager.mu.Unlock()
+
+	_, err = manager.CreateTab(CreateTabRequest{Title: "rem", RepoID: repo.ID, Shell: true})
+	if err == nil {
+		t.Fatal("expected error for remote instance, got nil")
+	}
+	if !strings.Contains(err.Error(), "remote") {
+		t.Fatalf("expected remote-rejection error, got: %v", err)
+	}
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -337,6 +337,81 @@ func (i *Instance) CloseTab(idx int) error {
 	return nil
 }
 
+// AttachShellTab reconnects this local instance's in-memory tab list to a shell
+// tab that already exists server-side — one the daemon's CreateTab RPC just
+// spawned out-of-band (#960 PR 2). It is the no-spawn counterpart of
+// AddShellTab: the daemon owns the spawn (so its authoritative view holds the
+// tab and can't be clobbered), and the TUI only needs to reflect the new tab
+// locally for instant display. It binds to the EXACT tmux session the daemon
+// derived (agent session name + "__" + name) and Restores (reconnects) it,
+// mirroring restoreLocalTabs + LocalBackend.setupTabs, so the tab is immediately
+// previewable/attachable without a second spawn that would collide on the name.
+//
+// name is the resolved tab name returned by the daemon. Local instances only —
+// callers reject IsRemote() first. If a tab with that name is already present
+// (e.g. a refresh raced ahead) this is a no-op returning the existing tab.
+// Errors when the instance is not started or has no agent session/worktree.
+func (i *Instance) AttachShellTab(name string) (*Tab, error) {
+	i.mu.RLock()
+	started := i.started
+	agentTmux := i.tmuxLocked()
+	gw := i.gitWorktree
+	var existing *Tab
+	for _, t := range i.Tabs {
+		if t.Name == name {
+			existing = t
+			break
+		}
+	}
+	i.mu.RUnlock()
+
+	if existing != nil {
+		return existing, nil
+	}
+	if !started || agentTmux == nil || gw == nil {
+		return nil, fmt.Errorf("cannot attach a tab to an instance that is not started")
+	}
+	worktreePath := gw.GetWorktreePath()
+	if worktreePath == "" {
+		return nil, fmt.Errorf("cannot attach a tab without a worktree")
+	}
+
+	// Bind to the exact session name the daemon derived and reconnect to it. The
+	// sibling inherits the agent session's PTY factory / executor (real in
+	// production, mock in tests). Restore re-spawns only if the session is
+	// genuinely missing (its workDir is non-empty), matching setupTabs.
+	tmuxName := agentTmux.SanitizedName() + "__" + name
+	shellTmux := agentTmux.NewSiblingSession(tmuxName, defaultShell())
+	if err := shellTmux.Restore(worktreePath); err != nil {
+		return nil, fmt.Errorf("failed to reconnect shell tab: %w", err)
+	}
+
+	tab := newShellTab(shellTmux)
+	tab.Name = name
+	i.mu.Lock()
+	i.Tabs = append(i.Tabs, tab)
+	i.mu.Unlock()
+	return tab, nil
+}
+
+// DropClosedTab removes the tab at idx from the in-memory list WITHOUT killing
+// its tmux session (#960 PR 2). It is the no-kill counterpart of CloseTab, used
+// when the daemon's CloseTab RPC has already torn the tmux session down: the
+// daemon owns the kill+persist, and the TUI only needs to drop the now-dead tab
+// from its local view for instant display. Killing again here would shell out a
+// second tmux kill-session that errors ("session not found") on the already-gone
+// session and surface a spurious failure. The agent tab (idx 0) is undroppable;
+// errors on idx 0 or any out-of-range index, mirroring CloseTab.
+func (i *Instance) DropClosedTab(idx int) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if idx <= 0 || idx >= len(i.Tabs) {
+		return fmt.Errorf("tab cannot be closed")
+	}
+	i.Tabs = append(i.Tabs[:idx], i.Tabs[idx+1:]...)
+	return nil
+}
+
 // uniqueShellName returns a shell-tab display name not already used by any tab
 // in tabs: "shell", then "shell-2", "shell-3", …
 func uniqueShellName(tabs []*Tab) string {

--- a/session/tab_lifecycle_test.go
+++ b/session/tab_lifecycle_test.go
@@ -130,6 +130,71 @@ func TestAddShellTab_RejectedForUnstarted(t *testing.T) {
 	require.Equal(t, 0, inst.TabCount())
 }
 
+// TestAttachShellTab_ReconnectsExistingSessionNoSpawn verifies the no-spawn
+// reconnect path (#960 PR 2): when the daemon has already created the shell
+// session, AttachShellTab binds to that exact session and appends the tab
+// without issuing a second new-session that would collide.
+func TestAttachShellTab_ReconnectsExistingSessionNoSpawn(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	const agentName = "af_tabs_attach"
+	// The daemon already spawned the sibling shell session.
+	inst := startedMockInstance(t, agentName, agentName+"__shell")
+
+	tab, err := inst.AttachShellTab("shell")
+	require.NoError(t, err)
+	assert.Equal(t, "shell", tab.Name)
+	assert.Equal(t, TabKindShell, tab.Kind)
+	assert.Equal(t, 2, inst.TabCount(), "the reconnected tab must be appended")
+	assert.True(t, inst.TabAlive(1), "the reconnected tab must be bound to the live session")
+	assert.Equal(t, agentName+"__shell", tab.tmux.SanitizedName(),
+		"the tab must bind to the exact daemon-derived session name")
+
+	// A second call for the same name is a no-op returning the existing tab —
+	// guards against a refresh racing ahead of the reconnect.
+	again, err := inst.AttachShellTab("shell")
+	require.NoError(t, err)
+	assert.Same(t, tab, again, "a duplicate attach must return the existing tab")
+	assert.Equal(t, 2, inst.TabCount(), "a duplicate attach must not append again")
+}
+
+// TestAttachShellTab_RejectedForUnstarted verifies AttachShellTab errors when the
+// instance has no live agent session/worktree.
+func TestAttachShellTab_RejectedForUnstarted(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, err := NewInstance(InstanceOptions{Title: "unstarted", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	_, err = inst.AttachShellTab("shell")
+	require.Error(t, err)
+	require.Equal(t, 0, inst.TabCount())
+}
+
+// TestDropClosedTab_RemovesWithoutKilling verifies the no-kill removal path
+// (#960 PR 2): DropClosedTab removes a tab from the list but does NOT tear down
+// its tmux session (the daemon already did), and still protects the agent tab.
+func TestDropClosedTab_RemovesWithoutKilling(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedMockInstance(t, "af_tabs_drop")
+	tab, err := inst.AddShellTab()
+	require.NoError(t, err)
+	require.Equal(t, 2, inst.TabCount())
+	require.True(t, tab.tmux.DoesSessionExist())
+
+	require.Error(t, inst.DropClosedTab(0), "the agent tab must be undroppable")
+	require.Equal(t, 2, inst.TabCount(), "a rejected drop must not mutate the list")
+	require.Error(t, inst.DropClosedTab(9), "an out-of-range index must be rejected")
+
+	require.NoError(t, inst.DropClosedTab(1))
+	require.Equal(t, 1, inst.TabCount(), "drop must remove the tab from the list")
+	require.True(t, tab.tmux.DoesSessionExist(),
+		"DropClosedTab must NOT kill the tmux session (the daemon owns the kill)")
+}
+
 // TestUniqueShellName covers the per-instance naming sequence in isolation.
 func TestUniqueShellName(t *testing.T) {
 	assert.Equal(t, "shell", uniqueShellName(nil))


### PR DESCRIPTION
Part of #960 — the single-writer-daemon epic. **PR 1** (#961, merged) added the
daemon mutation RPCs (`CloseTab`, `SetPRInfo`; `CreateTab` already existed).
**This is PR 2**: the TUI stops mutating tab + PR-info state locally and instead
calls those RPCs, so the **daemon — not the TUI — owns these writes**. That
fixes the #959 clobber even before the read path changes: the daemon (the source
of truth) performs the write, and the TUI no longer originates a full-list save
that the daemon's next save could overwrite.

## The three mutations moved to RPCs

1. **`handleNewTab` (`t`) → daemon `CreateTab`.** `CreateTab` gains a `Shell`
   flag so the daemon can create the same `$SHELL` tab the TUI used to spawn
   locally (`Instance.AddShellTab`). The daemon spawns **and** persists; the TUI
   reflects the new tab locally for instant display via the new no-spawn
   `Instance.AttachShellTab`, which **reconnects** to the session the daemon
   spawned rather than spawning a second one that would collide on the derived
   tmux name.
2. **`handleCloseTab` (`w`) → daemon `CloseTab`.** The daemon kills the tab's
   tmux and persists the shrunk list; the TUI drops the now-dead tab locally via
   the new no-kill `Instance.DropClosedTab` (re-killing would error on the
   already-gone session and surface a spurious failure). The agent-tab and remote
   rules stay enforced TUI-side so the friendly message shows without a
   round-trip — the RPC enforces them too.
3. **`prInfoUpdatedMsg` → daemon `SetPRInfo`.** Per the approved design (#960
   §6), the `gh pr view` **fetch stays TUI-side**; only the persisted **write**
   moves to the daemon. The #921 branch-match guard still gates the apply, and
   the in-memory `SetPRInfo` stays for instant badge feedback.

## Version-skew fallback (approved defensive design)

Each mutation keeps an in-memory update for instant UX and falls back to the
**legacy local-mutate + full-list save ONLY when the RPC reports
method-not-found** (an older daemon), via the new exported
`daemon.IsRPCMethodNotFoundErr` — the same discipline as the `Shutdown`
fallback. On RPC success there is **no double-persist**. Daemon-unavailable is
handled by `callDaemon`'s existing `IsDaemonStartingErr` retry; a hard failure
surfaces a clear error rather than silently dropping the mutation.

The in-memory reflection (`AttachShellTab` / `DropClosedTab` / `SetPRInfo`) also
keeps the TUI's full-list view consistent, so the **other** full-list savers
still present in PR 2 (quit, refresh tick, failed-start cleanup, pending merge)
can't drop the daemon's write before PR 4 removes them.

## Scope / what's deferred

The **full clobber fix completes in PR 3** (add the `Snapshot` RPC + switch TUI
reads to it, fixing the "no live display" half of #959) and **PR 4** (make the
daemon the sole writer; delete the TUI `SaveInstances` path and
`mergeInstancesWithDisk`). This PR deliberately does **not** touch the read path,
`mergeInstancesWithDisk`, or status ownership.

## Adjacent-call-site audit (CLAUDE.md)

- Every TUI tab/PR-info mutation now routes through the daemon on the success
  path; the only remaining `SaveInstances` calls on these paths are the
  scoped method-not-found fallbacks. The other full-list savers (handleQuit,
  refresh tick, failed-start cleanup, mergePendingInstances) are the
  out-of-scope writers explicitly retired in PR 4.
- Remote instances are rejected both TUI-side (before the call) and by the RPCs
  (`CreateTab`/`CloseTab` refuse remote sessions, whose tabs are fixed by
  `remote_hooks` config).
- The PR 1 client funcs (`daemon.CloseTab`, `daemon.SetPRInfo`) are now wired and
  reachable from the TUI via DI seams in `app/session_control.go`.

## Tests (hermetic, no real daemon — DI seams mirror `SetSessionStarterForTest`)

- **app:** `handleNewTab`/`handleCloseTab` route through the `CreateTab`/
  `CloseTab` seams (not a local save) and reflect the change locally;
  `prInfoUpdatedMsg` calls `SetPRInfo`, honors the #921 branch guard, and applies
  the badge; method-not-found version-skew falls back to the legacy local save
  for all three.
- **session:** `AttachShellTab` reconnects without a second spawn (and dedupes a
  raced double-attach); `DropClosedTab` removes a tab without killing its tmux
  session; both protect the agent tab.
- **daemon:** the shell-aware `CreateTab` spawns/persists a `Shell`-kind tab and
  rejects remote, alongside the existing process-tab coverage.

New daemon tests stay tmux-reattach-free / hermetic (no `FromInstanceData`
reattach), avoiding the #961 flake.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast`
clean · `deadcode -test ./...` clean · `env -u SHELL TERM=dumb go test ./...`
green · `GOFLAGS="-p=1" go test -race -parallel 2 ./app/... ./session/...
./daemon/...` green.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
