### PR TITLE
feat: add Snapshot RPC; TUI mirrors daemon state live (#960, PR 3)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -372,20 +372,26 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.mergePendingInstances()
 		return m, tickPendingInstancesCmd
 	case tickRefreshExternalMessage:
-		// Logged even when the tick is a no-op so we can spot it racing
-		// with detach in the trace tail.
+		// The tick only PACES the loop; the actual Snapshot fetch runs off the
+		// event loop (it can block while a daemon warms up — #829) and comes back
+		// as snapshotFetchedMsg, which reconciles and re-arms the tick. Deliberately
+		// no reschedule here: re-arming from snapshotFetchedMsg keeps exactly one
+		// fetch in flight.
 		detachTraceMark("tickRefreshExternalMessage-handler-entry")
+		return m, m.fetchSnapshotCmd()
+	case snapshotFetchedMsg:
+		// Reconcile the sidebar to the daemon's authoritative snapshot on the
+		// event loop (sidebar mutation must stay here — #682), then re-arm the
+		// pacing tick. No TUI SaveInstances: the snapshot is a read-only mirror of
+		// state the daemon already persists, so there is nothing for the TUI to
+		// write back — and writing its whole-list view back is exactly the clobber
+		// the single-writer model retires (#959/#960).
+		detachTraceMark("snapshotFetchedMsg-handler-entry")
 		tickStart := time.Now()
-		changed := m.refreshExternalInstances()
-		detachTrace(tickStart, "tickRefreshExternalMessage-refreshExternalInstances-returned")
-		var cmds []tea.Cmd
-		cmds = append(cmds, tickRefreshExternalCmd)
+		changed := m.handleSnapshot(msg)
+		detachTrace(tickStart, "snapshotFetchedMsg-reconcile-returned")
+		cmds := []tea.Cmd{tickRefreshExternalCmd}
 		if changed {
-			saveStart := time.Now()
-			if err := m.storage.SaveInstances(m.sidebar.GetInstances()); err != nil {
-				log.WarningLog.Printf("failed to save instances after refresh: %v", err)
-			}
-			detachTrace(saveStart, "tickRefreshExternalMessage-SaveInstances-returned")
 			cmds = append(cmds, m.selectionChanged())
 		}
 		return m, tea.Batch(cmds...)

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -63,6 +63,21 @@ var setPRInfoThroughDaemon = func(title, repoID string, info session.PRInfoData)
 	return daemon.SetPRInfo(daemon.SetPRInfoRequest{Title: title, RepoID: repoID, PRInfo: info})
 }
 
+// snapshotThroughDaemon fetches the daemon's authoritative session list for a
+// repo (#960 PR 3). It is the TUI's read path under the single-writer model: the
+// sidebar mirrors this projection instead of re-reading instances.json. A
+// package-level var so tests can inject a fake snapshot without a real daemon.
+var snapshotThroughDaemon = func(repoID string) ([]session.InstanceData, error) {
+	return daemon.Snapshot(daemon.SnapshotRequest{RepoID: repoID})
+}
+
+// buildInstanceFromSnapshot materializes a live, tab-reconnected *session.Instance
+// from a snapshot record — the same restore FromInstanceData performs, reconnecting
+// every tab to its persisted tmux session by name so a snapshot-discovered session
+// is immediately attachable. A package-level var so reconcile tests can inject a
+// fake builder and stay tmux-reattach-free (the #961 flake lesson).
+var buildInstanceFromSnapshot = session.FromInstanceData
+
 func SetSessionStarterForTest(f func(*session.Instance, sessionStartRequest) (*session.Instance, error)) func() {
 	prev := startSessionThroughDaemon
 	startSessionThroughDaemon = f
@@ -91,4 +106,16 @@ func SetPRInfoSetterForTest(f func(title, repoID string, info session.PRInfoData
 	prev := setPRInfoThroughDaemon
 	setPRInfoThroughDaemon = f
 	return func() { setPRInfoThroughDaemon = prev }
+}
+
+func SetSnapshotFetcherForTest(f func(repoID string) ([]session.InstanceData, error)) func() {
+	prev := snapshotThroughDaemon
+	snapshotThroughDaemon = f
+	return func() { snapshotThroughDaemon = prev }
+}
+
+func SetInstanceBuilderForTest(f func(session.InstanceData) (*session.Instance, error)) func() {
+	prev := buildInstanceFromSnapshot
+	buildInstanceFromSnapshot = f
+	return func() { buildInstanceFromSnapshot = prev }
 }

--- a/app/snapshot_test.go
+++ b/app/snapshot_test.go
@@ -1,0 +1,178 @@
+package app
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSnapshotTestInstance builds an unstarted, non-transient sidebar instance.
+// Unstarted is fine for the reconcile-orchestration tests: ReconcileTabsFromData
+// no-ops on a not-started instance, so these tests stay hermetic (no tmux), and
+// the tab-reconnect path is covered in the session package
+// (TestReconcileTabsFromData_AddsOutOfBandTab).
+func newSnapshotTestInstance(t *testing.T, title string) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	inst.SetStatus(session.Running)
+	return inst
+}
+
+// TestReconcileSnapshot_AddsAndRemovesSessions: whole sessions appearing in /
+// disappearing from the daemon snapshot are added to / removed from the sidebar.
+func TestReconcileSnapshot_AddsAndRemovesSessions(t *testing.T) {
+	h := newTestHome(t)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+
+	keep := newSnapshotTestInstance(t, "keep")
+	h.sidebar.AddInstance(keep)
+
+	// Snapshot adds "new" alongside the existing "keep" (matched by CreatedAt).
+	added := h.reconcileSnapshot([]session.InstanceData{
+		keep.ToInstanceData(),
+		{Title: "new", CreatedAt: time.Now()},
+	})
+	assert.True(t, added, "a new session in the snapshot is a change")
+	require.NotNil(t, findSidebarInstance(h, "keep"))
+	require.NotNil(t, findSidebarInstance(h, "new"), "out-of-band session must appear in the sidebar")
+
+	// Snapshot drops "keep"; only "new" remains.
+	newInst := findSidebarInstance(h, "new")
+	removed := h.reconcileSnapshot([]session.InstanceData{newInst.ToInstanceData()})
+	assert.True(t, removed, "a session gone from the snapshot is a change")
+	assert.Nil(t, findSidebarInstance(h, "keep"), "session gone from the snapshot must leave the sidebar")
+	require.NotNil(t, findSidebarInstance(h, "new"))
+}
+
+// TestReconcileSnapshot_PreservesSelectionAndActiveTab: reconciling (including a
+// removal that shifts indices) must not drift the user's selected instance or
+// the active tab index (#684) — local-only view state survives a snapshot.
+func TestReconcileSnapshot_PreservesSelectionAndActiveTab(t *testing.T) {
+	h := newTestHome(t)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+
+	a := newSnapshotTestInstance(t, "a")
+	b := newSnapshotTestInstance(t, "b")
+	c := newSnapshotTestInstance(t, "c")
+	h.sidebar.AddInstance(a)
+	h.sidebar.AddInstance(b)
+	h.sidebar.AddInstance(c)
+	h.sidebar.SelectInstance(b)
+	require.Same(t, b, h.sidebar.GetSelectedInstance())
+
+	tw := h.contentPane.TabbedWindow()
+	require.True(t, tw.JumpToTab(1), "set a non-zero active tab")
+	require.Equal(t, 1, tw.GetActiveTab())
+
+	// Drop "a" (precedes the selection, so its removal shifts indices) and add
+	// "d"; keep "b" and "c".
+	changed := h.reconcileSnapshot([]session.InstanceData{
+		b.ToInstanceData(),
+		c.ToInstanceData(),
+		{Title: "d", CreatedAt: time.Now()},
+	})
+	assert.True(t, changed)
+
+	require.Same(t, b, h.sidebar.GetSelectedInstance(),
+		"selection must stay pinned to b even though removing a preceding row shifted indices")
+	assert.Equal(t, 1, tw.GetActiveTab(),
+		"the active tab index must be preserved across a reconcile (reconcileSnapshot never touches the tabbed window)")
+	assert.Nil(t, findSidebarInstance(h, "a"))
+	require.NotNil(t, findSidebarInstance(h, "d"))
+}
+
+// TestReconcileSnapshot_NoChangeWhenUnchanged: an identical snapshot reports no
+// change (so the caller skips the repaint) and updates rows IN PLACE rather than
+// rebuilding them.
+func TestReconcileSnapshot_NoChangeWhenUnchanged(t *testing.T) {
+	h := newTestHome(t)
+	a := newSnapshotTestInstance(t, "a")
+	h.sidebar.AddInstance(a)
+
+	changed := h.reconcileSnapshot([]session.InstanceData{a.ToInstanceData()})
+	assert.False(t, changed, "an unchanged snapshot must not report a change (no repaint/flicker)")
+	require.Same(t, a, findSidebarInstance(h, "a"), "an existing row is updated in place, not rebuilt")
+}
+
+// TestReconcileSnapshot_SwapsKillRecreatedSameTitle: a same-title row whose
+// identity (CreatedAt) differs from the snapshot is a kill+recreate (#765); the
+// stale row is swapped for the recreated one rather than mutated in place.
+func TestReconcileSnapshot_SwapsKillRecreatedSameTitle(t *testing.T) {
+	h := newTestHome(t)
+
+	stale := newSnapshotTestInstance(t, "dup")
+	h.sidebar.AddInstance(stale)
+
+	recreated := newSnapshotTestInstance(t, "dup") // distinct pointer + CreatedAt
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return recreated, nil
+	}))
+
+	changed := h.reconcileSnapshot([]session.InstanceData{recreated.ToInstanceData()})
+	assert.True(t, changed)
+
+	var matches []*session.Instance
+	for _, inst := range h.sidebar.GetInstances() {
+		if inst.Title == "dup" {
+			matches = append(matches, inst)
+		}
+	}
+	require.Len(t, matches, 1, "exactly one row for the reused title")
+	require.Same(t, recreated, matches[0], "the recreated instance must replace the stale corpse")
+}
+
+// TestFetchSnapshotCmd_UsesFetcherSeam exercises the full off-loop fetch →
+// on-loop reconcile path through the injected SetSnapshotFetcherForTest seam: the
+// fetch command is scoped to the home's repo, and its result reconciles into the
+// sidebar — the #959 live-display flow with no real daemon.
+func TestFetchSnapshotCmd_UsesFetcherSeam(t *testing.T) {
+	h := newTestHome(t)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+
+	called := false
+	t.Cleanup(SetSnapshotFetcherForTest(func(repoID string) ([]session.InstanceData, error) {
+		called = true
+		require.Equal(t, h.repoID, repoID, "the snapshot fetch must be scoped to this repo")
+		return []session.InstanceData{{Title: "viaseam", CreatedAt: time.Now()}}, nil
+	}))
+
+	msg := h.fetchSnapshotCmd()()
+	require.True(t, called, "fetchSnapshotCmd must call the snapshot fetcher seam")
+	snap, ok := msg.(snapshotFetchedMsg)
+	require.True(t, ok, "fetchSnapshotCmd must return a snapshotFetchedMsg")
+	require.NoError(t, snap.err)
+
+	require.True(t, h.handleSnapshot(snap), "the fetched session is a change")
+	require.NotNil(t, findSidebarInstance(h, "viaseam"),
+		"the snapshot fetched through the seam must reconcile into the sidebar")
+}
+
+// TestHandleSnapshot_WarmingDaemonLeavesSidebarIntact: a warming-daemon fetch
+// error is retryable, not a reason to drop the cold-start sidebar (#829).
+func TestHandleSnapshot_WarmingDaemonLeavesSidebarIntact(t *testing.T) {
+	h := newTestHome(t)
+	a := newSnapshotTestInstance(t, "a")
+	h.sidebar.AddInstance(a)
+
+	changed := h.handleSnapshot(snapshotFetchedMsg{
+		err: errors.New("agent-factory daemon is starting (restoring sessions); retry shortly"),
+	})
+	assert.False(t, changed)
+	require.Same(t, a, findSidebarInstance(h, "a"),
+		"a warming-daemon snapshot fetch must leave the sidebar intact for a retry")
+}

--- a/app/sync.go
+++ b/app/sync.go
@@ -25,6 +25,16 @@ type tickUpdatePRInfoMessage struct{}
 type tickPendingInstancesMessage struct{}
 type tickRefreshExternalMessage struct{}
 
+// snapshotFetchedMsg carries the result of an off-loop daemon Snapshot fetch
+// back to the event loop, where reconcileSnapshot mutates the sidebar (sidebar
+// mutation must stay on the bubbletea loop — #682). err is non-nil on a failed
+// fetch; the handler retries (daemon warming) or falls back to the disk refresh
+// (version-skewed daemon without the Snapshot RPC).
+type snapshotFetchedMsg struct {
+	data []session.InstanceData
+	err  error
+}
+
 // prInfoUpdatedMsg is returned by an async PR info fetch.
 // info is nil when the fetch resolved to "no PR for this branch".
 // err is set for transient errors — the handler keeps the cached value.
@@ -120,12 +130,34 @@ var tickPendingInstancesCmd = func() tea.Msg {
 	return tickPendingInstancesMessage{}
 }
 
-// tickRefreshExternalCmd reconciles the sidebar with on-disk state
-// to pick up changes made via the CLI (e.g. `af sessions create/kill`).
-// Runs every 3s.
+// snapshotRefreshInterval is how often the TUI polls the daemon for the
+// authoritative session snapshot and reconciles its sidebar to it (#960 PR 3).
+// Tightened from the old 3s disk poll toward the ~500ms–1s the single-writer
+// design approved, so an out-of-band tab/session appears near-instantly. The
+// sleep is the gap BETWEEN reconciles (it precedes each tick), so a slow fetch
+// extends the period rather than overlapping the next one.
+const snapshotRefreshInterval = 750 * time.Millisecond
+
+// tickRefreshExternalCmd paces the snapshot reconcile loop: it sleeps one
+// interval, then emits tickRefreshExternalMessage, whose handler kicks off an
+// off-loop Snapshot fetch (fetchSnapshotCmd). The loop re-arms from the
+// snapshotFetchedMsg handler after each reconcile, so only one fetch is ever in
+// flight.
 var tickRefreshExternalCmd = func() tea.Msg {
-	time.Sleep(3 * time.Second)
+	time.Sleep(snapshotRefreshInterval)
 	return tickRefreshExternalMessage{}
+}
+
+// fetchSnapshotCmd fetches the daemon's authoritative session list off the event
+// loop (the RPC may briefly block while a daemon warms up — #829) and returns it
+// as a snapshotFetchedMsg for on-loop reconciliation. Mirrors runMetadataTickCmd:
+// the work runs in the tea.Cmd goroutine, the mutation happens in the handler.
+func (m *home) fetchSnapshotCmd() tea.Cmd {
+	repoID := m.repoID
+	return func() tea.Msg {
+		data, err := snapshotThroughDaemon(repoID)
+		return snapshotFetchedMsg{data: data, err: err}
+	}
 }
 
 // prInfoFetcher is the function used by fetchPRInfoCmd to retrieve PR info.
@@ -370,6 +402,214 @@ func (m *home) refreshExternalInstances() bool {
 	}
 
 	return changed
+}
+
+// handleSnapshot applies a fetched daemon snapshot to the sidebar and reports
+// whether anything changed (the caller repaints only on a diff). On a fetch
+// error it degrades rather than dropping the sidebar: a warming daemon (#829) is
+// retried on the next tick (callDaemon already waited out the warm-up window), a
+// version-skewed daemon without the Snapshot RPC falls back to the legacy
+// disk-based refresh (mirroring the SetPRInfo method-not-found fallback in #960
+// PR 2), and any other error is logged and skipped, leaving the last-known
+// sidebar intact.
+func (m *home) handleSnapshot(msg snapshotFetchedMsg) bool {
+	if msg.err != nil {
+		if daemon.IsDaemonStartingErr(msg.err) {
+			// Daemon still restoring (#829); the cold-start LoadInstances already
+			// populated the sidebar. Retry next tick — nothing to reconcile yet.
+			return false
+		}
+		if daemon.IsRPCMethodNotFoundErr(msg.err) {
+			// Older daemon without the Snapshot RPC: fall back to the disk-based
+			// reconcile until it is upgraded. The on-disk format is frozen, so
+			// this stays correct across the rollout.
+			return m.refreshExternalInstances()
+		}
+		log.WarningLog.Printf("failed to fetch daemon snapshot: %v", msg.err)
+		return false
+	}
+	return m.reconcileSnapshot(msg.data)
+}
+
+// reconcileSnapshot mirrors the sidebar to the daemon's authoritative snapshot
+// (#960 PR 3). The daemon is the single owner of session/tab state, so the TUI
+// renders a projection of it:
+//   - sessions in the snapshot but missing locally are built (FromInstanceData,
+//     reconnecting tabs by tmux name) and added;
+//   - sessions gone from the snapshot are removed;
+//   - existing rows are updated IN PLACE — same *session.Instance pointer, only
+//     its tab list and PR info mutated — which is the #959 "live display" fix
+//     (an out-of-band tab now appears without a restart);
+//   - a same-title row whose identity (CreatedAt) differs from the snapshot is a
+//     kill+recreate of the title (#765); it is swapped for a freshly built
+//     instance so the dead corpse never shadows the live session.
+//
+// Local-only view state is preserved: existing rows keep their pointer (so the
+// TabbedWindow's active tab and the content pane's scroll/overlay are untouched),
+// and the selected instance is re-pinned by pointer after the reconcile so a
+// removal of a preceding row can't drift the cursor. Transient TUI-owned rows
+// (Loading creation #808, Deleting kill #844) are left entirely alone: the
+// daemon may not yet know about an in-flight create, and a mid-teardown row must
+// keep its marker. Returns whether anything changed.
+//
+// Because the snapshot IS the truth, this needs none of refreshExternalInstances'
+// dual-writer collision heuristics (instanceCollisionShouldSkip / the #765/#808
+// "is my in-memory row staler than disk" logic) — those defend the TUI's
+// *authoritative* copy against the daemon's writes; a pure mirror just needs an
+// identity check (CreatedAt) to tell "same session" from "title reused".
+//
+// STATUS is deliberately NOT mirrored onto existing rows here: the daemon does
+// not yet compute Ready/Dead (that moves to it in #960 PR 5), so its persisted
+// status is stale, and clobbering the locally-computed status would fight
+// runMetadataTick and flicker the dot. New rows still seed their status from the
+// snapshot (FromInstanceData carries it); full status mirroring lands in PR 5.
+func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
+	snapByTitle := make(map[string]session.InstanceData, len(data))
+	for _, d := range data {
+		snapByTitle[d.Title] = d
+	}
+
+	existing := make(map[string]*session.Instance, len(data))
+	for _, inst := range m.sidebar.GetInstances() {
+		existing[inst.Title] = inst
+	}
+
+	// Capture the selected instance so we can re-pin it after removals shift
+	// indices — selection must never drift because a snapshot arrived.
+	selected := m.sidebar.GetSelectedInstance()
+
+	changed := false
+
+	for _, d := range data {
+		inst := existing[d.Title]
+		if inst == nil {
+			if m.addInstanceFromSnapshot(d) {
+				changed = true
+			}
+			continue
+		}
+		// In-flight TUI operations own their row: leave Loading/Deleting alone.
+		if isTransientStatus(inst.GetStatus()) {
+			continue
+		}
+		if !inst.CreatedAt.Equal(d.CreatedAt) {
+			// Same title, different session — a kill+recreate reused the title
+			// (#765). Swap the stale row for the live one rather than mutating the
+			// corpse in place.
+			if m.swapInstanceFromSnapshot(d) {
+				changed = true
+			}
+			continue
+		}
+		if m.updateInstanceFromSnapshot(inst, d) {
+			changed = true
+		}
+	}
+
+	// Remove sessions the daemon no longer owns. Skip transient rows (an
+	// in-flight create the daemon doesn't list yet; a mid-teardown kill).
+	var toRemove []*session.Instance
+	for _, inst := range m.sidebar.GetInstances() {
+		if _, ok := snapByTitle[inst.Title]; ok {
+			continue
+		}
+		if isTransientStatus(inst.GetStatus()) {
+			continue
+		}
+		toRemove = append(toRemove, inst)
+	}
+	for _, inst := range toRemove {
+		m.sidebar.RemoveInstanceByTitle(inst.Title)
+		changed = true
+	}
+
+	// Re-pin the selection to the same instance if it survived the reconcile.
+	if selected != nil && m.sidebar.ContainsInstance(selected) {
+		m.sidebar.SelectInstance(selected)
+	}
+
+	return changed
+}
+
+// addInstanceFromSnapshot builds a live instance from a snapshot record and adds
+// it to the sidebar. Returns true on success (a real change). A build failure is
+// logged and skipped — a single unrestorable record must not abort the whole
+// reconcile.
+func (m *home) addInstanceFromSnapshot(d session.InstanceData) bool {
+	inst, err := buildInstanceFromSnapshot(d)
+	if err != nil {
+		log.WarningLog.Printf("failed to build instance %q from snapshot: %v", d.Title, err)
+		return false
+	}
+	m.sidebar.AddInstance(inst)()
+	inst.SetAutoYes(m.autoYes)
+	return true
+}
+
+// swapInstanceFromSnapshot replaces a stale same-title sidebar row with a freshly
+// built instance for the recreated session (#765), preserving the selected row.
+// Built BEFORE the swap so a transient build failure leaves the existing row in
+// place rather than dropping it.
+func (m *home) swapInstanceFromSnapshot(d session.InstanceData) bool {
+	inst, err := buildInstanceFromSnapshot(d)
+	if err != nil {
+		log.WarningLog.Printf("failed to build recreated instance %q from snapshot: %v", d.Title, err)
+		return false
+	}
+	if !m.sidebar.ReplaceInstanceByTitle(d.Title, inst) {
+		// The row vanished between read and swap; add it fresh.
+		m.sidebar.AddInstance(inst)()
+	}
+	inst.SetAutoYes(m.autoYes)
+	return true
+}
+
+// updateInstanceFromSnapshot reconciles an existing sidebar row's tab list and
+// PR badge to the snapshot IN PLACE (same pointer, so view state survives).
+// Returns whether anything changed.
+func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.InstanceData) bool {
+	changed := false
+	// Remote instances' tabs come from hook config (terminal_cmd), not the
+	// snapshot, so the backend owns them — skip the tab reconcile.
+	if !inst.IsRemote() {
+		if tabsChanged, err := inst.ReconcileTabsFromData(d.Tabs); err != nil {
+			log.WarningLog.Printf("failed to reconcile tabs for %q from snapshot: %v", d.Title, err)
+			changed = changed || tabsChanged
+		} else if tabsChanged {
+			changed = true
+		}
+	}
+	// PR info mirrors the daemon's recorded value. This runs on the event loop,
+	// serialized with prInfoUpdatedMsg, so it never races the TUI's own
+	// fetch-then-write of the same badge.
+	if prInfoDiffersFromData(inst, d.PRInfo) {
+		inst.SetPRInfo(prInfoFromData(d.PRInfo))
+		changed = true
+	}
+	return changed
+}
+
+// prInfoFromData rebuilds a *git.PRInfo from its serialized form, returning nil
+// for the zero value (Number 0 = "no PR"), matching FromInstanceData.
+func prInfoFromData(d session.PRInfoData) *git.PRInfo {
+	if d.Number == 0 {
+		return nil
+	}
+	return &git.PRInfo{Number: d.Number, Title: d.Title, URL: d.URL, State: d.State}
+}
+
+// prInfoDiffersFromData reports whether an instance's in-memory PR info differs
+// from the snapshot's, so the reconcile only writes (and reports a change) on an
+// actual diff.
+func prInfoDiffersFromData(inst *session.Instance, d session.PRInfoData) bool {
+	cur := inst.GetPRInfo()
+	if d.Number == 0 {
+		return cur != nil
+	}
+	if cur == nil {
+		return true
+	}
+	return cur.Number != d.Number || cur.Title != d.Title || cur.URL != d.URL || cur.State != d.State
 }
 
 // instanceCollisionShouldSkip decides whether to keep an existing sidebar

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -155,6 +155,19 @@ type SetPRInfoResponse struct {
 	OK bool
 }
 
+// SnapshotRequest asks the daemon for the authoritative session list of a repo
+// (#960 PR 3). RepoID scopes the read like the other sessions verbs (empty =
+// all repos). It is the read side of the single-writer model: the daemon's
+// in-memory instance map is the source of truth, so the TUI mirrors this
+// projection instead of re-reading instances.json off disk.
+type SnapshotRequest struct {
+	RepoID string
+}
+
+type SnapshotResponse struct {
+	Instances []session.InstanceData
+}
+
 type ImportRemoteHookSessionsRequest struct {
 	RepoPath string
 }
@@ -328,6 +341,19 @@ func SetPRInfo(req SetPRInfoRequest) error {
 		return err
 	}
 	return nil
+}
+
+// Snapshot asks the daemon for the authoritative session list of repoID (empty
+// = all repos). It is the TUI's read path under the single-writer model (#960
+// PR 3): the daemon owns session/tab state, so the TUI mirrors this projection
+// rather than re-reading instances.json. A warming daemon (#829) returns the
+// retryable starting error, which callDaemon already waits out.
+func Snapshot(req SnapshotRequest) ([]session.InstanceData, error) {
+	var resp SnapshotResponse
+	if err := callDaemon("Snapshot", req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Instances, nil
 }
 
 // KillSession asks the daemon to kill a session and remove it from storage.
@@ -665,6 +691,17 @@ func (s *controlServer) SetPRInfo(req SetPRInfoRequest, resp *SetPRInfoResponse)
 	return nil
 }
 
+func (s *controlServer) Snapshot(req SnapshotRequest, resp *SnapshotResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
+	if err := validateRPCRepoID(req.RepoID); err != nil {
+		return err
+	}
+	resp.Instances = s.manager.Snapshot(req.RepoID)
+	return nil
+}
+
 func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionResponse) error {
 	if err := s.requireManagerReady(); err != nil {
 		return err
@@ -945,6 +982,43 @@ func (m *Manager) InstancesSnapshot() []*session.Instance {
 
 func (m *Manager) SaveInstances() error {
 	return m.storage.SaveInstances(m.InstancesSnapshot())
+}
+
+// Snapshot returns the authoritative InstanceData for every session the manager
+// owns, scoped to repoID (all repos when repoID is empty). It is the read side
+// of the single-writer model (#960 PR 3): the manager's in-memory instance map
+// IS the source of truth, so the TUI mirrors this projection instead of
+// re-reading instances.json. Pure read — it copies the instance pointers under
+// m.mu, then serializes each via ToInstanceData (which takes the instance's own
+// lock) OUTSIDE m.mu so a slow serialize never blocks a concurrent mutation.
+// Results are ordered by (repo, title) key for a stable diff, so the TUI
+// reconcile does not repaint on map-iteration jitter.
+func (m *Manager) Snapshot(repoID string) []session.InstanceData {
+	m.mu.Lock()
+	keys := make([]string, 0, len(m.instances))
+	for key := range m.instances {
+		if repoID != "" {
+			rid, _ := splitDaemonInstanceKey(key)
+			if rid != repoID {
+				continue
+			}
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	insts := make([]*session.Instance, 0, len(keys))
+	for _, key := range keys {
+		if inst := m.instances[key]; inst != nil {
+			insts = append(insts, inst)
+		}
+	}
+	m.mu.Unlock()
+
+	data := make([]session.InstanceData, 0, len(insts))
+	for _, inst := range insts {
+		data = append(data, inst.ToInstanceData())
+	}
+	return data
 }
 
 func (m *Manager) refreshLocked() error {

--- a/daemon/snapshot_test.go
+++ b/daemon/snapshot_test.go
@@ -1,0 +1,69 @@
+package daemon
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// TestManagerSnapshot_RepoScopedAndOrdered verifies Manager.Snapshot returns the
+// in-memory instances for the requested repo only (empty = all repos), serialized
+// to InstanceData and ordered by (repo, title) key for a stable, flicker-free diff.
+func TestManagerSnapshot_RepoScopedAndOrdered(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	m, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const repoA = "/tmp/snap-repo-a"
+	const repoB = "/tmp/snap-repo-b"
+	ridA := config.RepoIDFromRoot(repoA)
+	ridB := config.RepoIDFromRoot(repoB)
+
+	startedLocalTabInstance(t, m, ridA, repoA, "a2", "af_a2_agent")
+	startedLocalTabInstance(t, m, ridA, repoA, "a1", "af_a1_agent")
+	startedLocalTabInstance(t, m, ridB, repoB, "b1", "af_b1_agent")
+
+	titlesOf := func(repoID string) []string {
+		data := m.Snapshot(repoID)
+		out := make([]string, 0, len(data))
+		for _, d := range data {
+			out = append(out, d.Title)
+		}
+		return out
+	}
+
+	// Repo A is scoped to its own sessions, ordered by key (title).
+	gotA := titlesOf(ridA)
+	wantA := []string{"a1", "a2"}
+	if !equalStrings(gotA, wantA) {
+		t.Fatalf("Snapshot(repoA) = %v, want %v (repo-scoped, key-ordered)", gotA, wantA)
+	}
+
+	gotB := titlesOf(ridB)
+	if !equalStrings(gotB, []string{"b1"}) {
+		t.Fatalf("Snapshot(repoB) = %v, want [b1]", gotB)
+	}
+
+	// Empty repoID returns every repo's instances.
+	gotAll := titlesOf("")
+	sortedAll := append([]string(nil), gotAll...)
+	sort.Strings(sortedAll)
+	if !equalStrings(sortedAll, []string{"a1", "a2", "b1"}) {
+		t.Fatalf("Snapshot(\"\") = %v, want all three sessions", gotAll)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -412,6 +412,116 @@ func (i *Instance) DropClosedTab(idx int) error {
 	return nil
 }
 
+// ReconcileTabsFromData updates this started local instance's tab list to match
+// `target`, the daemon's authoritative serialized tab list (#960 PR 3). The
+// daemon is the single owner of tab state, so the TUI mirrors it: tabs the
+// daemon added out-of-band (present in target, absent locally) are reconnected
+// to their EXACT persisted tmux session by name — like restoreLocalTabs — and
+// appended, so an out-of-band tab appears in the running TUI and is immediately
+// previewable/attachable (the #959 "live display" fix); tabs the daemon closed
+// (absent from target) are dropped locally WITHOUT re-killing their tmux session
+// (the daemon already tore it down — killing again would error on the gone
+// session). The agent tab (index 0) is never added or dropped: it is the
+// instance's own session and is always present. Returns whether the local list
+// changed. A no-op for a not-started instance, one without an agent session, or
+// a remote instance (callers skip IsRemote() — remote tabs come from hook
+// config, not the snapshot). Per-tab reconnect failures are collected into the
+// returned error after every other change is applied, so one bad tab can't wedge
+// the reconcile.
+func (i *Instance) ReconcileTabsFromData(target []TabData) (bool, error) {
+	i.mu.RLock()
+	started := i.started
+	agentTmux := i.tmuxLocked()
+	gw := i.gitWorktree
+	program := i.Program
+	localNames := make(map[string]bool, len(i.Tabs))
+	for _, t := range i.Tabs {
+		localNames[t.Name] = true
+	}
+	i.mu.RUnlock()
+
+	if !started || agentTmux == nil || gw == nil {
+		return false, nil
+	}
+	worktreePath := gw.GetWorktreePath()
+
+	targetNames := make(map[string]bool, len(target))
+	for _, td := range target {
+		targetNames[td.Name] = true
+	}
+
+	changed := false
+
+	// Drop local non-agent tabs the daemon no longer lists. No kill: the daemon
+	// owns the teardown and already closed the tmux session (#960 PR 3).
+	for name := range localNames {
+		if targetNames[name] {
+			continue
+		}
+		if i.dropTabByName(name) {
+			changed = true
+		}
+	}
+
+	// Add daemon-listed tabs missing locally, reconnecting each to its exact
+	// persisted tmux session by name so it is immediately attachable.
+	var firstErr error
+	for _, td := range target {
+		if td.Kind == TabKindAgent || localNames[td.Name] {
+			continue
+		}
+		if td.TmuxName == "" || worktreePath == "" {
+			continue
+		}
+		kind := tabKindForData(td.Kind)
+		// The sibling inherits the agent session's PTY factory / executor (real
+		// in production, mock in tests), binding to the EXACT persisted name.
+		// Restore reconnects (re-spawning only if the session is genuinely gone),
+		// mirroring restoreLocalTabs + LocalBackend.setupTabs.
+		ts := agentTmux.NewSiblingSession(td.TmuxName, tabProgram(kind, td.Command, program))
+		if err := ts.Restore(worktreePath); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("failed to reconnect tab %q: %w", td.Name, err)
+			}
+			continue
+		}
+		tab := &Tab{Name: td.Name, Kind: kind, Command: td.Command, tmux: ts}
+		i.mu.Lock()
+		// Re-check under the write lock: a concurrent reconcile/AddTab may have
+		// added this name while we reconnected outside the lock.
+		exists := false
+		for _, t := range i.Tabs {
+			if t.Name == td.Name {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			i.Tabs = append(i.Tabs, tab)
+			changed = true
+		}
+		i.mu.Unlock()
+	}
+	return changed, firstErr
+}
+
+// dropTabByName removes the named non-agent tab from the in-memory list WITHOUT
+// killing its tmux session — the no-kill counterpart of CloseTab used by
+// ReconcileTabsFromData when the daemon has already torn the session down (#960
+// PR 3). Returns whether a tab was removed. The agent tab (index 0) is never
+// dropped.
+func (i *Instance) dropTabByName(name string) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	for idx := 1; idx < len(i.Tabs); idx++ {
+		if i.Tabs[idx].Name == name {
+			i.Tabs = append(i.Tabs[:idx], i.Tabs[idx+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
 // uniqueShellName returns a shell-tab display name not already used by any tab
 // in tabs: "shell", then "shell-2", "shell-3", …
 func uniqueShellName(tabs []*Tab) string {

--- a/session/snapshot_reconcile_test.go
+++ b/session/snapshot_reconcile_test.go
@@ -1,0 +1,122 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newReconcileTestInstance builds a started local instance with a single mock-
+// backed agent tab and a worktree, hermetically (no real tmux server). The
+// shared persistPtyFactory/nameKeyedExec helpers (tab_persist_test.go) make the
+// agent session — and any sibling the reconcile reconnects — report alive so
+// Restore reconnects rather than spawning.
+func newReconcileTestInstance(t *testing.T, agentName string, alive map[string]bool) (*Instance, string) {
+	t.Helper()
+	log.Initialize(false)
+	t.Cleanup(log.Close)
+	// Isolate config reads from the developer's real ~/.agent-factory (see
+	// tab_persist_test.go for the full #837 rationale).
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	exec := nameKeyedExec(alive)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+
+	worktreePath := filepath.Join(t.TempDir(), "wt")
+	gw, err := git.NewGitWorktreeFromStorage(
+		"/tmp/snap-reconcile-repo", worktreePath, "snap",
+		"snap-branch", "", false, true)
+	require.NoError(t, err)
+
+	agentTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps(agentName, "claude", pty, exec)
+	inst := &Instance{
+		Title:       "snap",
+		Path:        "/tmp/snap-reconcile-repo",
+		Program:     "claude",
+		backend:     &LocalBackend{},
+		started:     true,
+		gitWorktree: gw,
+		Tabs:        []*Tab{newAgentTab(agentTs)},
+	}
+	return inst, worktreePath
+}
+
+// TestReconcileTabsFromData_AddsOutOfBandTab is the #959 live-display reconnect:
+// the daemon spawned a shell tab out-of-band, so the snapshot's tab list grows;
+// ReconcileTabsFromData must add the tab to the live instance and reconnect it to
+// its EXACT persisted tmux session by name, leaving it immediately attachable.
+func TestReconcileTabsFromData_AddsOutOfBandTab(t *testing.T) {
+	const agentName = "af_snap_agent"
+	shellName := agentName + shellTmuxSuffix
+	inst, _ := newReconcileTestInstance(t, agentName, map[string]bool{agentName: true, shellName: true})
+
+	require.Len(t, inst.GetTabs(), 1, "instance starts with only the agent tab")
+
+	target := []TabData{
+		{Name: inst.GetTabs()[0].Name, Kind: TabKindAgent, TmuxName: agentName},
+		{Name: "shell", Kind: TabKindShell, TmuxName: shellName},
+	}
+
+	changed, err := inst.ReconcileTabsFromData(target)
+	require.NoError(t, err)
+	assert.True(t, changed, "adding an out-of-band tab is a change")
+
+	tabs := inst.GetTabs()
+	require.Len(t, tabs, 2, "the out-of-band shell tab must appear on the live instance")
+	assert.Equal(t, TabKindShell, tabs[1].Kind)
+	assert.Equal(t, shellName, tabs[1].tmux.SanitizedName(),
+		"the added tab must bind to its EXACT persisted tmux session (reconnect by name)")
+	assert.True(t, inst.TabAlive(1), "the reconnected tab must be live (attachable) without a restart")
+
+	// Reconciling the same target again is a no-op (no flicker / repaint).
+	changedAgain, err := inst.ReconcileTabsFromData(target)
+	require.NoError(t, err)
+	assert.False(t, changedAgain, "an unchanged snapshot must not report a change")
+	assert.Len(t, inst.GetTabs(), 2, "no duplicate tab on a repeat reconcile")
+}
+
+// TestReconcileTabsFromData_DropsClosedTab covers the close side: the daemon
+// closed a tab out-of-band (it leaves the snapshot), so the live instance must
+// drop it locally WITHOUT re-killing the already-gone tmux session.
+func TestReconcileTabsFromData_DropsClosedTab(t *testing.T) {
+	const agentName = "af_snap_agent2"
+	shellName := agentName + shellTmuxSuffix
+	inst, _ := newReconcileTestInstance(t, agentName, map[string]bool{agentName: true, shellName: true})
+
+	// Add the shell tab first.
+	withShell := []TabData{
+		{Name: inst.GetTabs()[0].Name, Kind: TabKindAgent, TmuxName: agentName},
+		{Name: "shell", Kind: TabKindShell, TmuxName: shellName},
+	}
+	_, err := inst.ReconcileTabsFromData(withShell)
+	require.NoError(t, err)
+	require.Len(t, inst.GetTabs(), 2)
+
+	// The daemon closed it: the snapshot now lists only the agent tab.
+	agentOnly := []TabData{{Name: inst.GetTabs()[0].Name, Kind: TabKindAgent, TmuxName: agentName}}
+	changed, err := inst.ReconcileTabsFromData(agentOnly)
+	require.NoError(t, err)
+	assert.True(t, changed, "dropping a closed tab is a change")
+	require.Len(t, inst.GetTabs(), 1, "the closed tab must be dropped locally")
+	assert.Equal(t, TabKindAgent, inst.GetTabs()[0].Kind, "the agent tab is never dropped")
+}
+
+// TestReconcileTabsFromData_NotStartedIsNoOp guards the not-started branch: an
+// unstarted instance (e.g. a Loading placeholder) must never attempt a reconnect.
+func TestReconcileTabsFromData_NotStartedIsNoOp(t *testing.T) {
+	inst, err := NewInstance(InstanceOptions{Title: "pending", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+
+	changed, rerr := inst.ReconcileTabsFromData([]TabData{
+		{Name: "agent", Kind: TabKindAgent},
+		{Name: "shell", Kind: TabKindShell, TmuxName: "whatever__shell"},
+	})
+	require.NoError(t, rerr)
+	assert.False(t, changed, "a not-started instance reconcile is a no-op")
+}


### PR DESCRIPTION
Part of #960 (single-writer daemon epic). Builds on PR1 (#961: CloseTab/SetPRInfo RPCs + persistInstanceData) and PR2 (#962: TUI tab/PR-info mutations route through the daemon).

## What this PR does

Adds a repo-scoped **`Snapshot` RPC** and switches the TUI's **READ path** to mirror the daemon's authoritative in-memory session state instead of re-reading `instances.json`. This fixes the **"no live display" half of #959** — an out-of-band tab/session now appears in the running TUI without a restart — and, because the TUI's in-memory list now tracks the daemon, **stops its full-list saves from clobbering out-of-band tabs even before PR4 removes those saves**.

## The Snapshot RPC (daemon)

- `Manager.Snapshot(repoID)` serializes the manager's in-memory instance map — which **is** the source of truth — to `[]session.InstanceData`, repo-scoped (empty = all repos), ordered by `(repo, title)` key for a stable, flicker-free diff. Pure read: it copies the instance pointers under `m.mu`, then calls `ToInstanceData` (each instance's own lock) **outside** `m.mu` so a slow serialize never blocks a concurrent mutation.
- The RPC mirrors the existing verbs exactly: `requireManagerReady()` gating (returns `errDaemonStarting` during warm-up #829), `validateRPCRepoID`, a package-level client func, auto-registered via `RegisterName`.

## The reconcile (TUI)

- **`Instance.ReconcileTabsFromData`** updates a started local instance's tab list to the snapshot **in place**: tabs the daemon added out-of-band reconnect to their **exact persisted tmux session by name** (like `restoreLocalTabs`/`FromInstanceData`) so they're immediately previewable/attachable — the #959 live-display fix; tabs the daemon closed are dropped locally **without re-killing** (the daemon already tore them down).
- **`reconcileSnapshot`** mirrors the sidebar to the snapshot: add new sessions (built + tab-reconnected via `FromInstanceData`), remove gone ones, update existing rows' **tab list + PR badge** in place, and **swap** a same-title row whose `CreatedAt` differs (a kill+recreate of the title, #765) so a dead corpse never shadows the live session.
- **Local-only view state is preserved**: existing rows keep their `*session.Instance` pointer (so the TabbedWindow's **active tab** #684, content-pane **scroll**, and **overlay** state are untouched), and the **selected instance is re-pinned by pointer** after the reconcile so a removal of a preceding row can't drift the cursor. Reconciles in place and only repaint on an actual diff (the tick returns `changed`).
- The refresh tick now fetches the Snapshot **off the event loop** (it can briefly block while a daemon warms up) and reconciles **on** it (#682-safe). Interval tightened **3s → 750ms** per the approved poll design. Warm-up errors retry next tick; a version-skewed daemon without `Snapshot` falls back to the legacy disk refresh (mirroring the #960 PR 2 method-not-found fallback). The frozen on-disk format keeps mixed versions interoperable.

## Deferred (per the #960 plan)

- **PR4** — removing the TUI `SaveInstances` writes + `mergeInstancesWithDisk`. The disk-based `refreshExternalInstances` is kept untouched as the old-daemon fallback. (This PR already drops the *refresh-tick* full-list save: the snapshot is a read-only mirror, so there is nothing for the TUI to write back.)
- **PR5** — status ownership. The snapshot **does not** clobber existing rows' status: the daemon does not yet compute Ready/Dead, so `runMetadataTick` stays authoritative; clobbering with the daemon's stale persisted status would fight it and flicker the dot. New rows still seed their status from the snapshot via `FromInstanceData`. Full status mirroring lands in PR5.
- **PR6** — switching cold-start from `LoadInstances` to `Snapshot`. Kept as the safety net here.

## Adjacent-call-site audit

Every place the TUI learns about instances: **startup `LoadInstances`** (kept as cold-start safety net, PR6), **`refreshExternalInstances`** (now the version-skew/disk fallback; the snapshot path is primary), **`mergePendingInstances`** (task-created sessions — unchanged; folds into the daemon in PR4). Remote instances appear correctly in the snapshot (`ToInstanceData` serializes them) and skip the tab reconcile (their tabs come from hook config). Selection / active-tab / scroll survival is covered by tests.

## Tests (DI seams, no real daemon, hermetic, tmux-reattach-free)

- `session`: out-of-band tab reconnects by `TmuxName` and becomes `TabAlive` (the #959 reconnect); closed tab dropped without re-kill; not-started no-op.
- `app`: whole-session add/remove; selection + active-tab preserved across a reconcile that shifts indices; kill-recreate swap; **no change/repaint on an unchanged snapshot**; the `SetSnapshotFetcherForTest` fetch→reconcile path; warm-up + method-not-found fallbacks.
- `daemon`: `Manager.Snapshot` repo-scoping + key ordering.

## Verification

`gofmt -l .` clean · `go build ./...` clean · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `go test ./...` green · `GOFLAGS=-p=1 go test -race -parallel 2 ./app/... ./ui/... ./session/... ./daemon/...` green.

— Captain Claude