### PR TITLE
fix(tmux): idempotent teardown — a kill-session on an already-dead session is success, not an error (#967)

### DIFF
--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -61,7 +61,13 @@ func TestHookBackendType(t *testing.T) {
 // (including the instance title) for diagnosis.
 func TestLocalBackendKillBestEffort_TmuxFails(t *testing.T) {
 	cmdExec := cmd_test.MockCmdExec{
-		RunFunc: func(*exec.Cmd) error {
+		RunFunc: func(c *exec.Cmd) error {
+			// has-session reports the session still present, so the failed
+			// kill-session is a GENUINE teardown failure rather than the
+			// idempotent already-gone no-op (#967). Everything else fails.
+			if strings.Contains(c.String(), "has-session") {
+				return nil
+			}
 			return errors.New("kill failed")
 		},
 		OutputFunc: func(*exec.Cmd) ([]byte, error) {
@@ -170,7 +176,12 @@ func TestLocalBackendKill_RecoversStaleWorktreeDir(t *testing.T) {
 // nil with a warning per component.
 func TestLocalBackendKillBestEffort_BothFail(t *testing.T) {
 	cmdExec := cmd_test.MockCmdExec{
-		RunFunc: func(*exec.Cmd) error {
+		RunFunc: func(c *exec.Cmd) error {
+			// has-session reports present so the failed kill-session is a
+			// genuine teardown failure, not the #967 idempotent no-op.
+			if strings.Contains(c.String(), "has-session") {
+				return nil
+			}
 			return errors.New("kill failed")
 		},
 		OutputFunc: func(*exec.Cmd) ([]byte, error) {

--- a/session/tab_close_idempotent_test.go
+++ b/session/tab_close_idempotent_test.go
@@ -1,0 +1,106 @@
+package session
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/require"
+)
+
+// deadAwareExec is like nameKeyedExec but models tmux's real kill-session
+// behavior: killing a live session succeeds and removes it; killing a session
+// that is already gone exits 1 ("can't find session"). This is what lets the
+// #967 regression actually fire — nameKeyedExec makes every kill-session
+// succeed, so it can't reproduce the spurious-error path.
+func deadAwareExec(alive map[string]bool) cmd_test.MockCmdExec {
+	existing := map[string]bool{}
+	for k, v := range alive {
+		existing[k] = v
+	}
+	nameOf := func(c *exec.Cmd) string {
+		for i, a := range c.Args {
+			switch {
+			case (a == "-t" || a == "-s") && i+1 < len(c.Args):
+				return c.Args[i+1]
+			case strings.HasPrefix(a, "-t="):
+				return strings.TrimPrefix(a, "-t=")
+			case strings.HasPrefix(a, "-s="):
+				return strings.TrimPrefix(a, "-s=")
+			}
+		}
+		return ""
+	}
+	return cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			s := c.String()
+			n := nameOf(c)
+			switch {
+			case strings.Contains(s, "has-session"):
+				if existing[n] {
+					return nil
+				}
+				return errors.New("can't find session")
+			case strings.Contains(s, "new-session"):
+				existing[n] = true
+				return nil
+			case strings.Contains(s, "kill-session"):
+				if existing[n] {
+					delete(existing, n)
+					return nil
+				}
+				return errors.New("exit status 1") // already gone -> tmux exits 1
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			return []byte("content"), nil
+		},
+	}
+}
+
+// TestCloseTab_StaleSessionAlreadyDead is the #967 end-to-end check: a tab whose
+// tmux session died externally (box reboot, manual kill-server) is surfaced from
+// the daemon Snapshot, the user presses close, and kill-session exits 1. CloseTab
+// must still return nil and remove the tab — a dead session is the goal of a
+// close, not an error to wedge the tab list.
+func TestCloseTab_StaleSessionAlreadyDead(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_stale_close"
+	deadShell := agentName + shellTmuxSuffix
+	// Agent session is alive; the shell tab's session is already dead.
+	exec := deadAwareExec(map[string]bool{agentName: true})
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+
+	gw, err := git.NewGitWorktreeFromStorage(
+		"/tmp/stale-close-"+agentName, filepath.Join(t.TempDir(), "wt"),
+		agentName, agentName+"-branch", "", false, true)
+	require.NoError(t, err)
+
+	agentTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps(agentName, "claude", pty, exec)
+	deadTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps(deadShell, "/bin/sh", pty, exec)
+	inst := &Instance{
+		Title:       agentName,
+		Path:        "/tmp/stale-close-" + agentName,
+		Program:     "claude",
+		backend:     &LocalBackend{},
+		started:     true,
+		gitWorktree: gw,
+		Tabs:        []*Tab{newAgentTab(agentTs), newShellTab(deadTs)},
+	}
+	require.Equal(t, 2, inst.TabCount())
+
+	require.NoError(t, inst.CloseTab(1),
+		"closing a tab whose tmux already died must succeed, not error (#967)")
+	require.Equal(t, 1, inst.TabCount(), "the stale tab must be removed")
+}

--- a/session/tmux/idempotent_close_test.go
+++ b/session/tmux/idempotent_close_test.go
@@ -1,0 +1,153 @@
+package tmux
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/stretchr/testify/require"
+)
+
+// errExit1 stands in for tmux's "can't find session" failure, which exits with
+// status 1. Close must not key off this string — it probes has-session — but
+// the mock returns it so the test mirrors the real failure shape.
+var errExit1 = errors.New("exit status 1")
+
+// killSessionProbeExec mocks the two commands Close issues on its teardown path:
+// `tmux kill-session` (which fails when the session is already gone) and the
+// `tmux has-session` probe that decides whether the failure was real. `present`
+// controls what has-session reports — i.e. whether the session survived the
+// kill. killCalls counts kill-session invocations so tests can assert the kill
+// was actually attempted.
+func killSessionProbeExec(present bool, killCalls *int) cmd_test.MockCmdExec {
+	return cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			s := strings.Join(c.Args, " ")
+			switch {
+			case strings.Contains(s, "kill-session"):
+				if killCalls != nil {
+					*killCalls++
+				}
+				// tmux exits 1 when the target session no longer exists.
+				return errExit1
+			case strings.Contains(s, "has-session"):
+				if present {
+					return nil
+				}
+				return errExit1
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			return []byte(""), nil
+		},
+	}
+}
+
+// TestClose_AlreadyDeadSession_ReturnsNil is the #967 fix: closing a session
+// whose tmux process already died must succeed. kill-session exits 1, but the
+// has-session probe confirms the session is gone — the desired end state of
+// Close — so Close swallows the error and returns nil.
+func TestClose_AlreadyDeadSession_ReturnsNil(t *testing.T) {
+	var killCalls int
+	exec := killSessionProbeExec(false /* session gone */, &killCalls)
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_dead", "claude", NewMockPtyFactory(t), exec)
+
+	require.NoError(t, session.Close(),
+		"a kill-session on an already-dead session is success, not an error (#967)")
+	require.Equal(t, 1, killCalls, "Close must still attempt the kill-session")
+}
+
+// TestClose_SessionSurvivesKill_StillErrors is the negative half of the #967
+// fix: a genuine teardown failure — kill-session errors AND the session is
+// still present afterward — must still surface as an error, so the idempotency
+// shortcut can't mask a session that refuses to die.
+func TestClose_SessionSurvivesKill_StillErrors(t *testing.T) {
+	exec := killSessionProbeExec(true /* session still present */, nil)
+	session := NewTmuxSessionFromSanitizedNameWithDeps("af_stuck", "claude", NewMockPtyFactory(t), exec)
+
+	err := session.Close()
+	require.Error(t, err, "a session that survives kill-session is a real failure")
+	require.Contains(t, err.Error(), "error killing tmux session")
+}
+
+// TestCleanupSessions_ToleratesVanishedSession covers the same papercut on the
+// by-name path: a session can disappear between `tmux ls` and kill-session
+// (TOCTOU). A gone session is the goal of cleanup, so the vanished one must not
+// fail the sweep, while a survivor still does.
+func TestCleanupSessions_ToleratesVanishedSession(t *testing.T) {
+	const lsOutput = `af_gone: 1 windows (created Wed May 20 12:00:00 2026) [179x47]
+af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
+
+	// af_stuck survives its kill; af_gone vanished before we got to it.
+	stillPresent := map[string]bool{"af_stuck": true}
+	nameOf := func(c *exec.Cmd) string {
+		for i, a := range c.Args {
+			if a == "-t" && i+1 < len(c.Args) {
+				return c.Args[i+1]
+			}
+			if strings.HasPrefix(a, "-t=") {
+				return strings.TrimPrefix(a, "-t=")
+			}
+		}
+		return ""
+	}
+
+	t.Run("vanished session is tolerated", func(t *testing.T) {
+		exec := cmd_test.MockCmdExec{
+			RunFunc: func(c *exec.Cmd) error {
+				s := strings.Join(c.Args, " ")
+				switch {
+				case strings.Contains(s, "kill-session"):
+					if nameOf(c) == "af_gone" {
+						return errExit1
+					}
+					return nil
+				case strings.Contains(s, "has-session"):
+					if stillPresent[nameOf(c)] {
+						return nil
+					}
+					return errExit1
+				}
+				return nil
+			},
+			OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+				if strings.Contains(strings.Join(c.Args, " "), "ls") {
+					return []byte(lsOutput), nil
+				}
+				return []byte(""), nil
+			},
+		}
+		require.NoError(t, CleanupSessions(exec),
+			"a session that vanished between ls and kill must not fail cleanup (#967)")
+	})
+
+	t.Run("surviving session still errors", func(t *testing.T) {
+		exec := cmd_test.MockCmdExec{
+			RunFunc: func(c *exec.Cmd) error {
+				s := strings.Join(c.Args, " ")
+				switch {
+				case strings.Contains(s, "kill-session"):
+					return errExit1 // both kills fail
+				case strings.Contains(s, "has-session"):
+					if stillPresent[nameOf(c)] {
+						return nil
+					}
+					return errExit1
+				}
+				return nil
+			},
+			OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+				if strings.Contains(strings.Join(c.Args, " "), "ls") {
+					return []byte(lsOutput), nil
+				}
+				return []byte(""), nil
+			},
+		}
+		err := CleanupSessions(exec)
+		require.Error(t, err, "a session that survives kill-session must still fail cleanup")
+		require.Contains(t, err.Error(), "af_stuck")
+	})
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -929,7 +929,15 @@ func (t *TmuxSession) Close() error {
 
 	cmd := exec.Command("tmux", "kill-session", "-t", t.sanitizedName)
 	if err := t.cmdExec.Run(cmd); err != nil {
-		errs = append(errs, fmt.Errorf("error killing tmux session: %w", err))
+		// Idempotent teardown (#967): a kill-session that fails because the
+		// session is already gone has achieved Close's goal — a dead session
+		// is the desired end state. Only a session that survives the kill is a
+		// genuine failure. Probe has-session rather than matching tmux's bare
+		// "exit status 1", which it reuses for unrelated errors. Mirrors the
+		// `_`-ignored cleanup kill in Start (above).
+		if t.DoesSessionExist() {
+			errs = append(errs, fmt.Errorf("error killing tmux session: %w", err))
+		}
 	}
 
 	if len(errs) == 0 {
@@ -1106,9 +1114,16 @@ func (t *TmuxSession) updateWindowSize(cols, rows int) error {
 }
 
 func (t *TmuxSession) DoesSessionExist() bool {
+	return sessionExists(t.cmdExec, t.sanitizedName)
+}
+
+// sessionExists reports whether a tmux session with the exact name `name`
+// currently exists. Shared by DoesSessionExist and the receiver-less
+// CleanupSessions path so both probe identically.
+func sessionExists(cmdExec cmd.Executor, name string) bool {
 	// Using "-t name" does a prefix match, which is wrong. `-t=` does an exact match.
-	existsCmd := exec.Command("tmux", "has-session", fmt.Sprintf("-t=%s", t.sanitizedName))
-	return t.cmdExec.Run(existsCmd) == nil
+	existsCmd := exec.Command("tmux", "has-session", fmt.Sprintf("-t=%s", name))
+	return cmdExec.Run(existsCmd) == nil
 }
 
 // CapturePaneContent captures the content of the tmux pane. When the
@@ -1170,7 +1185,12 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	for _, match := range matches {
 		log.InfoLog.Printf("cleaning up session: %s", match)
 		if err := cmdExec.Run(exec.Command("tmux", "kill-session", "-t", match)); err != nil {
-			return fmt.Errorf("failed to kill tmux session %s: %v", match, err)
+			// Idempotent teardown (#967): a session can vanish between the
+			// `tmux ls` above and this kill (TOCTOU). A gone session is the
+			// goal of cleanup, so only a survivor is a real failure.
+			if sessionExists(cmdExec, match) {
+				return fmt.Errorf("failed to kill tmux session %s: %v", match, err)
+			}
 		}
 	}
 	return nil

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -300,17 +300,29 @@ func TestStartTimeoutCleanupSucceeds(t *testing.T) {
 }
 
 // TestStartTimeoutCleanupFails is the companion to the #696 guard: when
-// cleanup also fails, the timeout error must include the cleanup cause.
+// cleanup GENUINELY fails, the timeout error must include the cleanup cause.
+// Post-#967 a kill-session failure only counts as a cleanup failure if the
+// session survives the kill, so has-session reports the session present once
+// the cleanup kill is attempted (the poll loop still times out because the
+// session never appeared in time).
 func TestStartTimeoutCleanupFails(t *testing.T) {
 	ptyFactory := NewMockPtyFactory(t)
 
+	killAttempted := false
 	cmdExec := cmd_test.MockCmdExec{
 		RunFunc: func(cmd *exec.Cmd) error {
-			if strings.Contains(cmd.String(), "has-session") {
-				return fmt.Errorf("session not found")
-			}
 			if strings.Contains(cmd.String(), "kill-session") {
+				killAttempted = true
 				return fmt.Errorf("kill-session exploded")
+			}
+			if strings.Contains(cmd.String(), "has-session") {
+				// The poll loop sees the session missing (so Start times
+				// out); the post-kill Close probe sees it present, so the
+				// failed kill is a genuine cleanup failure that must surface.
+				if killAttempted {
+					return nil
+				}
+				return fmt.Errorf("session not found")
 			}
 			return nil
 		},


### PR DESCRIPTION
Closes #967

## Root cause

`Tmux.Close` (`session/tmux/tmux.go`) runs `tmux kill-session -t <name>` and turned **any** non-zero exit into `error killing tmux session: %w`. When the session is already gone, tmux exits status 1 (`can't find session`), so closing a tab whose tmux process already died surfaced a spurious error box:

```
ERROR app.go:1162: failed to close tab "task-board": error killing tmux session: exit status 1
```

But the close has already *succeeded* by then: `Instance.CloseTab` removes the tab from `i.Tabs` **before** teardown, and a dead tmux session is the desired end state of a close. The error contradicted `CloseTab`'s own "best-effort teardown" doc comment. Post-#960 the TUI cold-starts its sidebar from the daemon `Snapshot`, which can list a tab whose tmux died externally (reboot, manual `tmux kill-server`, crash) — pressing close on such a stale tab reliably reproduced this.

## Fix

Make tmux teardown **idempotent**: after a failed `kill-session`, probe `has-session`; only treat it as a real error if the session is **still present**. A session that's gone means the goal is achieved → return success. This uses a robust signal (the existing `has-session` exact-match probe) rather than a brittle `"exit status 1"` string match, and mirrors the existing precedent where `Start`'s deferred cleanup kill already `_`-ignores its error.

The same papercut is fixed on the receiver-less `CleanupSessions` by-name path, which has a TOCTOU window between `tmux ls` and `kill-session`. `DoesSessionExist`'s probe is extracted into a shared `sessionExists(cmdExec, name)` helper so both paths probe identically.

## Adjacent-call-site audit

`Tmux.Close` is shared teardown — fixing the primitive covers every caller. Audit of all `kill-session` sites:

| Call site | Path | Disposition |
| --- | --- | --- |
| `tmux.go` `Close()` (kill-session) | tab close (`instance.go` `CloseTab`), instance kill (`LocalBackend.Kill` → `CloseAndWaitForPaneExit` → `Close`), `Start` timeout/restore cleanup (`tmux.go:255/285`) | **Fixed at the primitive.** All callers want best-effort teardown; none relied on "session missing = error". A genuine failure (session survives kill) still errors. |
| `Start` deferred cleanup kill (`tmux.go:239`) | partial-session cleanup on PTY-start failure | **Already idempotent** — error is `_`-ignored; the precedent this fix follows. Left as-is. |
| `CleanupSessions` kill-by-name (`tmux.go:~1185`) | startup/global sweep of `af_`-prefixed sessions | **Fixed.** TOCTOU between `tmux ls` and the kill; a vanished session is the goal of cleanup. Only a survivor now fails the sweep. |
| `CloseAndWaitForPaneExit` (`tmux.go:1028`) | worktree-delete teardown | Delegates to `Close` — inherits the fix. `panePID` is queried *before* the kill, so no change needed. |
| `CloseAttachOnly` | daemon PTY reclaim | Does **not** run `kill-session` by design (#867) — out of scope, unaffected. |

## Tests (hermetic, no real tmux)

All mock `cmdExec` so `kill-session` returns exit-1 / "can't find session" — no reattach to real sessions:

- `TestClose_AlreadyDeadSession_ReturnsNil` — kill-session exits 1, has-session confirms gone → `Close` returns nil and still attempts the kill.
- `TestClose_SessionSurvivesKill_StillErrors` — kill-session exits 1, has-session reports present → `Close` still errors.
- `TestCleanupSessions_ToleratesVanishedSession` — a session that vanished between `ls` and kill is tolerated; one that survives still fails the sweep.
- `TestCloseTab_StaleSessionAlreadyDead` — end-to-end: a tab whose tmux died externally closes cleanly (nil) and is removed from the tab list.
- Updated `TestStartTimeoutCleanupFails`, `TestLocalBackendKillBestEffort_TmuxFails`, `TestLocalBackendKillBestEffort_BothFail` to model a *genuine* teardown failure (session survives kill) under the new semantics — their old mocks erred on every command, which now correctly reads as already-gone.

## Verification

`gofmt -l .` (clean) · `go build ./...` · `golangci-lint run --timeout=3m --fast` · `go test ./...` · `deadcode -test ./...` (clean) · `GOFLAGS="-p=1" go test -race -parallel 2 ./session/... ./app/...` (clean) — all green.

— Captain Claude