### PR TITLE
fix(task): WaitForReady fails fast when the tmux session is gone instead of timing out (#976)

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -96,6 +96,14 @@ func WaitForReady(instance *session.Instance) error {
 		case <-ticker.C:
 			content, err := instance.Preview()
 			if err != nil {
+				// ErrSessionGone is a definitive, non-retryable failure: the
+				// tmux session no longer exists, so it can never become ready.
+				// Fail fast with a clear cause instead of polling the full
+				// timeout and returning a misleading "timed out" error (#976).
+				// Other errors are transient — keep polling.
+				if errors.Is(err, tmux.ErrSessionGone) {
+					return fmt.Errorf("session died while waiting for agent to start: %w", err)
+				}
 				continue
 			}
 			if isReadyContent(content, agent) {

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -2,10 +2,12 @@ package task
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // TestMain initializes the logger so that functions under test that write
@@ -288,4 +291,135 @@ func TestFormatWaitForReadyTimeoutError(t *testing.T) {
 			t.Errorf("snippet not capped: len=%d, want <=400", len(snippet))
 		}
 	})
+}
+
+// fakePreviewBackend embeds the package FakeBackend and overrides only
+// Preview so WaitForReady tests can drive the captured pane content (and the
+// error returned for it) without any real tmux session.
+type fakePreviewBackend struct {
+	*session.FakeBackend
+	previewFn func() (string, error)
+}
+
+func (b *fakePreviewBackend) Preview(*session.Instance) (string, error) {
+	return b.previewFn()
+}
+
+// newPreviewInstance returns an instance whose Preview() is driven by
+// previewFn, backed by a FakeBackend so no tmux/git resources are touched.
+func newPreviewInstance(t *testing.T, previewFn func() (string, error)) *session.Instance {
+	t.Helper()
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, _ string) (session.Backend, error) {
+		return &fakePreviewBackend{FakeBackend: session.NewFakeBackend(), previewFn: previewFn}, nil
+	})
+	defer restore()
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "wait-ready", Path: t.TempDir(), Program: "claude"})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	return inst
+}
+
+// setWaitForReadyTimingForTest shrinks the poll/timeout knobs so the polling
+// loop runs in milliseconds, and returns a restore func.
+func setWaitForReadyTimingForTest(timeout, poll time.Duration) func() {
+	prevTimeout, prevPoll := waitForReadyTimeout, waitForReadyPollInterval
+	waitForReadyTimeout, waitForReadyPollInterval = timeout, poll
+	return func() {
+		waitForReadyTimeout, waitForReadyPollInterval = prevTimeout, prevPoll
+	}
+}
+
+// TestWaitForReadyFailsFastWhenSessionGone is the core #976 fix: when
+// Preview() reports tmux.ErrSessionGone (a definitive, non-retryable death),
+// WaitForReady must return immediately with a clear "session died" error —
+// not poll the full timeout and return a misleading "timed out" message. The
+// 2s watchdog (well under the 10s timeout) fails the test if the loop is
+// still spinning, which is exactly the pre-fix behavior.
+func TestWaitForReadyFailsFastWhenSessionGone(t *testing.T) {
+	defer setWaitForReadyTimingForTest(10*time.Second, time.Millisecond)()
+
+	inst := newPreviewInstance(t, func() (string, error) {
+		return "", tmux.ErrSessionGone
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- WaitForReady(inst) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error when the session is gone, got nil")
+		}
+		if !errors.Is(err, tmux.ErrSessionGone) {
+			t.Fatalf("error must wrap tmux.ErrSessionGone, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "session died while waiting for agent to start") {
+			t.Fatalf("error must explain the session died, got %q", err.Error())
+		}
+		if strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("must not be a misleading timeout error, got %q", err.Error())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForReady did not fail fast on ErrSessionGone; it is still polling")
+	}
+}
+
+// TestWaitForReadyKeepsPollingThroughTransientErrors guards the other half of
+// the fix: a transient (non-ErrSessionGone) Preview error must NOT abort the
+// loop — it keeps polling until the agent becomes ready.
+func TestWaitForReadyKeepsPollingThroughTransientErrors(t *testing.T) {
+	defer setWaitForReadyTimingForTest(10*time.Second, time.Millisecond)()
+
+	var calls int32
+	inst := newPreviewInstance(t, func() (string, error) {
+		if atomic.AddInt32(&calls, 1) < 5 {
+			return "", errors.New("transient capture failure")
+		}
+		return "ready now\n❯ ", nil
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- WaitForReady(inst) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil once the agent is ready, got %v", err)
+		}
+		if got := atomic.LoadInt32(&calls); got < 5 {
+			t.Fatalf("expected polling to continue through transient errors (>=5 previews), got %d", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForReady never became ready despite transient-then-ready previews")
+	}
+}
+
+// TestWaitForReadyTimesOutOnPersistentTransientErrors confirms a persistent
+// transient error still falls through to the normal timeout path — it is not
+// misclassified as session death.
+func TestWaitForReadyTimesOutOnPersistentTransientErrors(t *testing.T) {
+	defer setWaitForReadyTimingForTest(50*time.Millisecond, time.Millisecond)()
+
+	inst := newPreviewInstance(t, func() (string, error) {
+		return "", errors.New("transient capture failure")
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- WaitForReady(inst) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a timeout error, got nil")
+		}
+		if errors.Is(err, tmux.ErrSessionGone) {
+			t.Fatalf("a transient error must not be reported as session-gone, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("expected a timeout error, got %q", err.Error())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForReady never timed out on persistent transient errors")
+	}
 }


### PR DESCRIPTION
## Root cause

`WaitForReady` (`task/runner.go`) polls the instance's tmux pane for up to 60s waiting for the agent's ready signal, and `continue`d on **any** `Preview()` error:

```go
case <-ticker.C:
    content, err := instance.Preview()
    if err != nil {
        continue  // ErrSessionGone treated the same as a transient error
    }
```

Commit `1e1326e` (#499) later introduced the `tmux.ErrSessionGone` sentinel — a *definitive, non-retryable* signal that the tmux session no longer exists — and audited `app/`, `ui/`, and `daemon/` to handle it via `errors.Is`. That audit **explicitly excluded `task/`**, leaving `WaitForReady` as the outlier. So when a session died during startup, `Preview()` returned `ErrSessionGone`, the loop swallowed it, polled the full 60s, and returned a misleading `"timed out"` error that hid the real cause.

## Fix

Check the sentinel in the ticker error branch and fail fast; keep `continue` for transient errors:

```go
if err != nil {
    if errors.Is(err, tmux.ErrSessionGone) {
        return fmt.Errorf("session died while waiting for agent to start: %w", err)
    }
    continue
}
```

(`errors`, `fmt`, and `tmux` were already imported.)

## Adjacent-site audit

Grepped `task/` for other `Preview()`/`CapturePaneContent` polling loops that swallow errors and could spin on `ErrSessionGone`. **`WaitForReady` is the only one.** The other `continue`s in `task/` are not error-swallowing poll loops and need no change:
- `task/task.go` `DeleteTask` — a slice-filter `continue` (skips the matched task).
- `task/runner.go` `NextTaskRunTitle` — title-collision `continue`s (skip taken candidates).

## Tests

Hermetic — no real tmux. `Preview()` is driven by a `FakeBackend` whose return is controlled per test:
- **`TestWaitForReadyFailsFastWhenSessionGone`** — `ErrSessionGone` returns promptly with the `session died…` error (wraps the sentinel, not a timeout). A 2s watchdog under the 10s test timeout fails if the loop still spins — i.e. it reproduces the pre-fix bug. Verified it FAILs with the fix reverted and PASSes with it.
- **`TestWaitForReadyKeepsPollingThroughTransientErrors`** — transient errors keep polling until ready.
- **`TestWaitForReadyTimesOutOnPersistentTransientErrors`** — a persistent transient error still falls through to the normal timeout path and is not misclassified as session death.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./task/...` — pass
- `GOFLAGS="-p=1" go test -race -parallel 2 ./task/...` — pass
- `go test ./...` — green except `integration/TestCLICreateCodexSessionBecomesReady`, a pre-existing dev-box flake (`daemon did not become ready: … connect: no such file or directory` — real-daemon/codex-binary environment issue, unrelated to `task/`).

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Captain Claude