### PR TITLE
fix(daemon): InstallAutostart never leaves a present-but-not-enabled unit when daemon handover fails (#974)

### DIFF
--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // The daemon autostart unit is the single OS-level unit agent-factory
@@ -142,21 +143,37 @@ func launchdAutostartPlist(execPath, pathEnv, shellEnv, agentFactoryHome, logPat
 
 // InstallAutostart registers the daemon for autostart at login: a systemd
 // user service on Linux, a launchd agent on macOS. Any daemon started ad hoc
-// (by EnsureDaemon) is stopped first so the supervised unit's daemon is the
-// only one running. Returns the path of the installed unit file.
+// (by EnsureDaemon) is handed over to the supervised unit. Returns the path of
+// the installed unit file.
+//
+// The invariant this function guarantees (#974): on success the unit is
+// ENABLED/LOADED, never merely written. Enabling (and `--now` starting) the
+// unit is the thing that makes autostart real and supervises future runs, so
+// it must not be skipped. Two failure modes used to break that:
+//
+//   - The ad-hoc→supervised handover stop is best-effort. A StopDaemon failure
+//     no longer aborts before enabling: the unit's `--now` start takes over the
+//     control socket per the #796/#798 handover, and the secondary ad-hoc
+//     daemon is left at worst enabled-but-inactive until the next login — far
+//     better than a present-but-not-enabled unit. (Previously a stop failure
+//     returned early, leaving the file on disk but never enabled.)
+//   - On a hard failure of the reload/enable/load step the just-written unit
+//     file is removed, so AutostartInstalled — which reports on file existence —
+//     can never misreport a not-enabled unit as installed and mislead the
+//     upgrade respawn path into RestartAutostartUnit on a unit that was never
+//     enabled.
 func InstallAutostart() (string, error) {
 	execPath, err := os.Executable()
 	if err != nil {
 		return "", fmt.Errorf("failed to get executable path: %w", err)
 	}
 
-	switch runtime.GOOS {
+	switch autostartGOOS {
 	case "linux":
-		home, err := os.UserHomeDir()
+		dir, err := autostartSystemdUserDir()
 		if err != nil {
-			return "", fmt.Errorf("failed to get home directory: %w", err)
+			return "", fmt.Errorf("failed to resolve systemd user directory: %w", err)
 		}
-		dir := filepath.Join(home, ".config", "systemd", "user")
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return "", fmt.Errorf("failed to create systemd user directory: %w", err)
 		}
@@ -165,24 +182,26 @@ func InstallAutostart() (string, error) {
 		if err := config.AtomicWriteFile(unitPath, []byte(content), 0644); err != nil {
 			return "", fmt.Errorf("failed to write unit file: %w", err)
 		}
-		if out, err := exec.Command("systemctl", "--user", "daemon-reload").CombinedOutput(); err != nil {
+		if out, err := autostartUnitCommand("systemctl", "--user", "daemon-reload"); err != nil {
+			removeAutostartUnitFile(unitPath)
 			return "", fmt.Errorf("failed to reload systemd user daemon: %w\n%s", err, strings.TrimSpace(string(out)))
 		}
-		// Hand over from any ad-hoc daemon to the supervised one.
-		if _, err := StopDaemon(); err != nil {
-			return "", fmt.Errorf("failed to stop the running daemon before enabling the service: %w", err)
+		// Hand any ad-hoc daemon over to the supervised one, but never let a
+		// stop failure block enabling — see the function comment (#974).
+		if _, err := autostartStopDaemon(); err != nil {
+			log.WarningLog.Printf("failed to stop the running daemon before enabling the autostart unit; enabling anyway: %v", err)
 		}
-		if out, err := exec.Command("systemctl", "--user", "enable", "--now", autostartUnitName).CombinedOutput(); err != nil {
+		if out, err := autostartUnitCommand("systemctl", "--user", "enable", "--now", autostartUnitName); err != nil {
+			removeAutostartUnitFile(unitPath)
 			return "", fmt.Errorf("failed to enable daemon service: %w\n%s", err, strings.TrimSpace(string(out)))
 		}
 		return unitPath, nil
 
 	case "darwin":
-		home, err := os.UserHomeDir()
+		dir, err := autostartLaunchAgentsDir()
 		if err != nil {
-			return "", fmt.Errorf("failed to get home directory: %w", err)
+			return "", fmt.Errorf("failed to resolve LaunchAgents directory: %w", err)
 		}
-		dir := filepath.Join(home, "Library", "LaunchAgents")
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return "", fmt.Errorf("failed to create LaunchAgents directory: %w", err)
 		}
@@ -194,34 +213,48 @@ func InstallAutostart() (string, error) {
 		logPath := filepath.Join(configDir, "daemon-launchd.log")
 		content := launchdAutostartPlist(execPath, os.Getenv("PATH"), os.Getenv("SHELL"), os.Getenv("AGENT_FACTORY_HOME"), logPath)
 		// Unload a previous agent first so launchctl load picks up the new file.
-		_ = exec.Command("launchctl", "unload", plistPath).Run()
+		_, _ = autostartUnitCommand("launchctl", "unload", plistPath)
 		if err := config.AtomicWriteFile(plistPath, []byte(content), 0644); err != nil {
 			return "", fmt.Errorf("failed to write plist file: %w", err)
 		}
-		// Hand over from any ad-hoc daemon to the supervised one.
-		if _, err := StopDaemon(); err != nil {
-			return "", fmt.Errorf("failed to stop the running daemon before loading the agent: %w", err)
+		// Hand any ad-hoc daemon over to the supervised one, but never let a
+		// stop failure block loading — see the function comment (#974).
+		if _, err := autostartStopDaemon(); err != nil {
+			log.WarningLog.Printf("failed to stop the running daemon before loading the autostart agent; loading anyway: %v", err)
 		}
-		if out, err := exec.Command("launchctl", "load", plistPath).CombinedOutput(); err != nil {
+		if out, err := autostartUnitCommand("launchctl", "load", plistPath); err != nil {
+			removeAutostartUnitFile(plistPath)
 			return "", fmt.Errorf("failed to load launch agent: %w\n%s", err, strings.TrimSpace(string(out)))
 		}
 		return plistPath, nil
 
 	default:
-		return "", fmt.Errorf("daemon autostart is not supported on %s (the daemon still starts automatically whenever you run af)", runtime.GOOS)
+		return "", fmt.Errorf("daemon autostart is not supported on %s (the daemon still starts automatically whenever you run af)", autostartGOOS)
 	}
 }
 
-// Injection points for tests, mirroring legacy_units.go: the GOOS the
-// restart helpers act on, the unit-directory resolvers, and the external
-// command runner, so the upgrade respawn path can be exercised hermetically
-// without touching the host's real autostart unit or invoking
-// systemctl/launchctl.
+// removeAutostartUnitFile deletes a just-written autostart unit/plist after a
+// later install step fails, so a hard failure never leaves a present-but-not-
+// enabled file that AutostartInstalled would misreport as installed (#974).
+// Best-effort: a cleanup failure is logged, not surfaced, since the original
+// install error is the one the caller must act on.
+func removeAutostartUnitFile(path string) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.WarningLog.Printf("failed to clean up autostart unit %s after a failed install: %v", path, err)
+	}
+}
+
+// Injection points for tests, mirroring legacy_units.go: the GOOS the install
+// and restart helpers act on, the unit-directory resolvers, the external
+// command runner, and the ad-hoc daemon stop, so the install and upgrade
+// respawn paths can be exercised hermetically without touching the host's real
+// autostart unit, invoking systemctl/launchctl, or signaling a real daemon.
 var (
 	autostartGOOS            = runtime.GOOS
 	autostartSystemdUserDir  = defaultSystemdUserDir
 	autostartLaunchAgentsDir = defaultLaunchAgentsDir
 	autostartUnitCommand     = runAutostartUnitCommand
+	autostartStopDaemon      = StopDaemon
 )
 
 func runAutostartUnitCommand(name string, args ...string) ([]byte, error) {

--- a/daemon/autostart_restart_test.go
+++ b/daemon/autostart_restart_test.go
@@ -54,6 +54,143 @@ func stubAutostartUnitCommand(t *testing.T, runErr error) *[][]string {
 	return &calls
 }
 
+// stubAutostartStopDaemon replaces the ad-hoc daemon stop InstallAutostart runs
+// during the handover with one that returns the given result, restoring the
+// production value on cleanup. Lets the install path be exercised without
+// signaling a real daemon.
+func stubAutostartStopDaemon(t *testing.T, stopped bool, err error) {
+	t.Helper()
+	prev := autostartStopDaemon
+	t.Cleanup(func() { autostartStopDaemon = prev })
+	autostartStopDaemon = func() (bool, error) { return stopped, err }
+}
+
+// stubAutostartUnitCommandFunc replaces the external command runner with fn,
+// recording each invocation, restoring the production value on cleanup. Use it
+// when a test needs a step (e.g. enable/load) to fail while the others succeed.
+func stubAutostartUnitCommandFunc(t *testing.T, fn func(name string, args ...string) ([]byte, error)) *[][]string {
+	t.Helper()
+	prev := autostartUnitCommand
+	t.Cleanup(func() { autostartUnitCommand = prev })
+	var calls [][]string
+	autostartUnitCommand = func(name string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string{name}, args...))
+		return fn(name, args...)
+	}
+	return &calls
+}
+
+// calledWith reports whether the recorded invocations include an exact match
+// for the given command and arguments.
+func calledWith(calls [][]string, want ...string) bool {
+	for _, c := range calls {
+		if strings.Join(c, " ") == strings.Join(want, " ") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestInstallAutostartEnablesUnitWhenStopDaemonFailsLinux is the core #974
+// guard: a failed ad-hoc→supervised daemon handover must NOT abort the install
+// before the unit is enabled. After InstallAutostart returns successfully the
+// unit file must be present AND the enable command must have run, so
+// AutostartInstalled does not later report a never-enabled unit as installed.
+func TestInstallAutostartEnablesUnitWhenStopDaemonFailsLinux(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+	calls := stubAutostartUnitCommand(t, nil)
+	stubAutostartStopDaemon(t, false, errors.New("could not stop ad-hoc daemon"))
+
+	unitPath, err := InstallAutostart()
+	if err != nil {
+		t.Fatalf("InstallAutostart returned error despite a recoverable stop failure: %v", err)
+	}
+	if want := filepath.Join(dir, autostartUnitName); unitPath != want {
+		t.Fatalf("unit path = %q, want %q", unitPath, want)
+	}
+	if _, statErr := os.Stat(unitPath); statErr != nil {
+		t.Fatalf("unit file missing after install: %v", statErr)
+	}
+	if !AutostartInstalled() {
+		t.Fatalf("AutostartInstalled() = false after a successful install")
+	}
+	if !calledWith(*calls, "systemctl", "--user", "enable", "--now", autostartUnitName) {
+		t.Fatalf("enable did not run after the stop failure; calls = %v", *calls)
+	}
+}
+
+// TestInstallAutostartLoadsAgentWhenStopDaemonFailsDarwin is the macOS variant:
+// a stop failure must not block the launchctl load that makes autostart real.
+func TestInstallAutostartLoadsAgentWhenStopDaemonFailsDarwin(t *testing.T) {
+	dir := withAutostartTestEnv(t, "darwin")
+	calls := stubAutostartUnitCommand(t, nil)
+	stubAutostartStopDaemon(t, false, errors.New("could not stop ad-hoc daemon"))
+
+	plistPath, err := InstallAutostart()
+	if err != nil {
+		t.Fatalf("InstallAutostart returned error despite a recoverable stop failure: %v", err)
+	}
+	if want := filepath.Join(dir, autostartLaunchdLabel+".plist"); plistPath != want {
+		t.Fatalf("plist path = %q, want %q", plistPath, want)
+	}
+	if _, statErr := os.Stat(plistPath); statErr != nil {
+		t.Fatalf("plist missing after install: %v", statErr)
+	}
+	if !AutostartInstalled() {
+		t.Fatalf("AutostartInstalled() = false after a successful install")
+	}
+	if !calledWith(*calls, "launchctl", "load", plistPath) {
+		t.Fatalf("load did not run after the stop failure; calls = %v", *calls)
+	}
+}
+
+// TestInstallAutostartRemovesUnitWhenEnableFailsLinux pins the #974 cleanup:
+// a hard enable failure must not leave a present-but-not-enabled unit file that
+// AutostartInstalled would misreport as installed.
+func TestInstallAutostartRemovesUnitWhenEnableFailsLinux(t *testing.T) {
+	dir := withAutostartTestEnv(t, "linux")
+	stubAutostartStopDaemon(t, true, nil)
+	stubAutostartUnitCommandFunc(t, func(name string, args ...string) ([]byte, error) {
+		if len(args) > 1 && args[1] == "enable" {
+			return []byte("enable failed"), errors.New("exit status 1")
+		}
+		return nil, nil
+	})
+
+	if _, err := InstallAutostart(); err == nil {
+		t.Fatalf("InstallAutostart succeeded despite a failing enable")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, autostartUnitName)); !os.IsNotExist(statErr) {
+		t.Fatalf("unit file should be cleaned up after enable failure; stat err = %v", statErr)
+	}
+	if AutostartInstalled() {
+		t.Fatalf("AutostartInstalled() = true after a failed install left no enabled unit")
+	}
+}
+
+// TestInstallAutostartRemovesPlistWhenLoadFailsDarwin is the macOS cleanup
+// variant: a hard launchctl load failure must not leave an orphaned plist.
+func TestInstallAutostartRemovesPlistWhenLoadFailsDarwin(t *testing.T) {
+	dir := withAutostartTestEnv(t, "darwin")
+	stubAutostartStopDaemon(t, true, nil)
+	stubAutostartUnitCommandFunc(t, func(name string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "load" {
+			return []byte("load failed"), errors.New("exit status 1")
+		}
+		return nil, nil
+	})
+
+	if _, err := InstallAutostart(); err == nil {
+		t.Fatalf("InstallAutostart succeeded despite a failing load")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, autostartLaunchdLabel+".plist")); !os.IsNotExist(statErr) {
+		t.Fatalf("plist should be cleaned up after load failure; stat err = %v", statErr)
+	}
+	if AutostartInstalled() {
+		t.Fatalf("AutostartInstalled() = true after a failed install left no loaded agent")
+	}
+}
+
 func TestAutostartInstalledLinux(t *testing.T) {
 	dir := withAutostartTestEnv(t, "linux")
 


### PR DESCRIPTION
Closes #974

## Root cause

`daemon/autostart.go::InstallAutostart` ran, on **both** the Linux (systemd)
and macOS (launchd) branches:

1. write the unit/plist file
2. `daemon-reload` (Linux)
3. `StopDaemon()` — **return early on error**
4. enable (`systemctl --user enable --now`) / load (`launchctl load`)

The stop in step 3 is only the ad-hoc→supervised *handover* (stop any daemon
EnsureDaemon started so the supervised unit owns the socket). But returning
early on its error left the unit file **on disk but never enabled**.

`AutostartInstalled()` reports purely on file existence, so after a failed
handover it returned `true` while *nothing actually starts at login*. That lie
misleads the upgrade respawn path: `respawnDaemonAfterUpgrade`
(`daemoncmd.go:115`) gates on `AutostartInstalled()` and, believing the unit is
supervised, calls `RestartAutostartUnit()` on a unit that was never enabled —
demoting the daemon instead of supervising it.

## Fix

Keep the primitive strong: **after `InstallAutostart` returns success the unit
is enabled/loaded; on any hard failure no orphaned not-enabled file is left.**
Applied identically to both OS branches:

- **Handover stop is best-effort.** A `StopDaemon()` failure is now logged and
  the install **proceeds to enable/load**. Enabling (and `--now` starting) the
  unit is the thing that makes autostart real and takes over the control socket
  per the existing #796/#798 handover; the leftover ad-hoc daemon is secondary
  (enabled-but-inactive at worst, only until the next login — strictly better
  than a present-but-not-enabled unit).
- **Roll back on hard failure.** If `daemon-reload` / `enable` / `load` fails,
  the just-written unit file is removed (`removeAutostartUnitFile`), so
  `AutostartInstalled()` can never misreport a not-enabled unit as installed.

The install path now also flows through the existing test seams
(`autostartGOOS`, the unit-directory resolvers, `autostartUnitCommand`) plus a
new `autostartStopDaemon` seam, so the failure behavior is tested hermetically
— no real `systemctl`/`launchctl`, no signaling a real daemon.

## Adjacent-site audit

- **`InstallAutostart`** — one caller, `daemoncmd.go:36` (`af daemon install`).
  It prints the returned path on success; that path now denotes a genuinely
  enabled unit, not merely a written file.
- **`AutostartInstalled`** — consumed via `autostartInstalledFn` at
  `daemoncmd.go:115` inside `respawnDaemonAfterUpgrade`. A `true` result now
  reliably means the unit is enabled on **both** OS branches, so the
  `RestartAutostartUnit()` it guards is sound.
- `UninstallAutostart` was left as-is (out of scope; it removes the file and is
  not part of the present-but-not-enabled class).

## Tests (hermetic — no real daemon / systemd / launchd touched)

- `TestInstallAutostartEnablesUnitWhenStopDaemonFailsLinux` /
  `…LoadsAgentWhenStopDaemonFailsDarwin` — when `StopDaemon` fails, install
  still succeeds, the unit is present, the **enable/load command ran**, and
  `AutostartInstalled()` is `true`.
- `TestInstallAutostartRemovesUnitWhenEnableFailsLinux` /
  `…RemovesPlistWhenLoadFailsDarwin` — a hard enable/load failure leaves **no**
  unit file and `AutostartInstalled()` is `false`.

## Verification

`gofmt -l .` (clean) · `go build ./...` · `golangci-lint run --timeout=3m
--fast` (clean) · `go test ./...` · `deadcode -test ./...` (clean) · bounded
race `GOFLAGS="-p=1" go test -race -parallel 2 ./daemon/...` — all green.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
