### PR TITLE
fix(session): detect Ctrl-W detach key in batched multi-byte stdin reads (#975)

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -781,7 +781,19 @@ func runHookAttachWithDetach(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.W
 		for {
 			n, err := stdin.Read(buf)
 			if n > 0 {
-				if n == 1 && buf[0] == tmux.DetachKeyByte {
+				// stdin.Read can batch the detach key with preceding bytes in a
+				// single read (buffered terminal input), so check the last byte
+				// rather than requiring it to be the sole byte — otherwise
+				// Ctrl-W is forwarded to the PTY and the detach is silently
+				// missed (#975). Forward any preceding bytes first so they still
+				// reach the remote session, preserving the surrounding
+				// write-error handling.
+				if buf[n-1] == tmux.DetachKeyByte {
+					if n > 1 {
+						if _, writeErr := ptmx.Write(buf[:n-1]); writeErr != nil {
+							return
+						}
+					}
 					detach()
 					return
 				}

--- a/session/pty_detach_test.go
+++ b/session/pty_detach_test.go
@@ -1,0 +1,136 @@
+package session
+
+import (
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The remote attach_cmd PTY proxy (runHookAttachWithDetach) reads stdin in
+// chunks and intercepts the detach key (Ctrl-W / tmux.DetachKeyByte) before
+// forwarding bytes to the PTY. stdin.Read can batch the detach key together
+// with preceding bytes in a single read (buffered terminal input), so the
+// interception must look at the LAST byte of the read rather than requiring the
+// detach key to be the sole byte — the #975 regression, where the old
+// `n == 1 && buf[0] == DetachKeyByte` guard silently forwarded a batched Ctrl-W
+// to the PTY and never detached.
+//
+// io.Pipe delivers each Write in a single Read on the other side (the proxy's
+// 32-byte buffer is larger than every payload here), so a one-shot
+// stdinW.Write reproduces the "batched into one read" condition exactly.
+
+// TestRunHookAttach_DetachKeyBatchedAfterPrecedingBytes is the #975 regression:
+// a multi-byte read ENDING in the detach key must detach. Before the fix this
+// read was forwarded to the PTY and the proxy never exited, so the test timed
+// out.
+func TestRunHookAttach_DetachKeyBatchedAfterPrecedingBytes(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		cmd := exec.Command("sh", "-c", "sleep 10")
+		done <- runHookAttachWithDetach(cmd, stdinR, io.Discard, io.Discard)
+	}()
+
+	// Printable bytes ahead of the detach key, all in one read.
+	if _, err := stdinW.Write(append([]byte("abc"), tmux.DetachKeyByte)); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("attach did not detach when the detach key was batched after preceding bytes (#975)")
+	}
+}
+
+// TestRunHookAttach_DetachKeyAsSoleByte locks in that the single-byte detach
+// case the old guard handled still detaches after the fix.
+func TestRunHookAttach_DetachKeyAsSoleByte(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		cmd := exec.Command("sh", "-c", "sleep 10")
+		done <- runHookAttachWithDetach(cmd, stdinR, io.Discard, io.Discard)
+	}()
+
+	if _, err := stdinW.Write([]byte{tmux.DetachKeyByte}); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("attach did not detach on a single-byte detach-key read")
+	}
+}
+
+// TestRunHookAttach_ReadNotEndingInDetachKeyForwards covers the inverse: a
+// multi-byte read that does NOT end in the detach key is forwarded to the PTY
+// untouched and does not trigger a detach. The child is `cat`, so the PTY's
+// line-discipline echo reflects the forwarded bytes back onto stdout, which is
+// how the test observes that they reached the PTY. (Forwarding of the bytes
+// PRECEDING a batched detach key uses this same ptmx.Write call but is not
+// asserted directly here — observing it would race the detach SIGKILL that
+// tears the PTY down.)
+func TestRunHookAttach_ReadNotEndingInDetachKeyForwards(t *testing.T) {
+	if _, err := exec.LookPath("cat"); err != nil {
+		t.Skip("cat not available")
+	}
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+
+	var out syncBuffer
+	done := make(chan error, 1)
+	go func() {
+		cmd := exec.Command("cat") // copies its PTY stdin back to stdout
+		done <- runHookAttachWithDetach(cmd, stdinR, &out, io.Discard)
+	}()
+
+	if _, err := stdinW.Write([]byte("hello world")); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+
+	// The forwarded bytes reach the PTY and are echoed back. No detach key was
+	// sent, so the proxy must still be attached while we observe them.
+	require.Eventually(t, func() bool {
+		return strings.Contains(out.String(), "hello world")
+	}, 2*time.Second, 5*time.Millisecond, "preceding bytes were not forwarded to the PTY")
+
+	select {
+	case err := <-done:
+		t.Fatalf("attach exited without a detach key: %v", err)
+	default:
+	}
+
+	// A subsequent read carrying the detach key tears it down cleanly.
+	if _, err := stdinW.Write([]byte{tmux.DetachKeyByte}); err != nil {
+		t.Fatalf("write detach key: %v", err)
+	}
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("attach did not detach after the detach key")
+	}
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -738,8 +738,17 @@ func (t *TmuxSession) Attach() (chan struct{}, error) {
 				continue
 			}
 
-			// Check for detach key
-			if nr == 1 && buf[0] == DetachKeyByte {
+			// Check for detach key. stdin.Read can batch the detach key with
+			// preceding bytes in a single read (buffered terminal input), so
+			// check the last byte rather than requiring it to be the sole byte
+			// — otherwise the detach key is forwarded to tmux and the detach is
+			// silently missed (#975). Forward any preceding bytes first so they
+			// still reach the session, matching the surrounding (best-effort)
+			// write-error handling.
+			if nr > 0 && buf[nr-1] == DetachKeyByte {
+				if nr > 1 {
+					_, _ = t.ptmx.Write(buf[:nr-1])
+				}
 				// Closest point to "user pressed detach" we can observe —
 				// the elapsed in this trace is whatever Detach() itself
 				// took, which matches what blocks the app-side <-ch.


### PR DESCRIPTION
## Root cause

The remote `attach_cmd` PTY proxy intercepts the detach key (Ctrl-W / `tmux.DetachKeyByte`, `0x17`) before forwarding stdin to the PTY, but it only recognized the key when it was the **sole byte** of a read:

```go
if n == 1 && buf[0] == tmux.DetachKeyByte { detach(); return }
```

`stdin.Read` can return the detach key **batched with preceding bytes** in a single read (buffered terminal input). When that happens `n != 1`, the guard misses, and the Ctrl-W is forwarded straight to the PTY — detach silently never fires. Introduced in #435.

## Fix

Check the **last byte** of the read instead, and forward any preceding bytes through to the PTY first so they still reach the session:

```go
if buf[n-1] == tmux.DetachKeyByte {
    if n > 1 {
        if _, writeErr := ptmx.Write(buf[:n-1]); writeErr != nil { return }
    }
    detach(); return
}
```

The preceding-bytes write preserves the surrounding `ptmx.Write` error handling at each site (hook backend: return on error; tmux backend: best-effort, matching its existing `_, _ =` forwarding).

## Adjacent-site audit (all copies)

The issue notes the single-byte pattern was **copied** from the tmux backend. Grepping `n == 1 && buf[... ] == ...DetachKeyByte` across the tree found exactly two live copies, both fixed identically:

- `session/backend_hook.go` — the remote hook attach/terminal PTY proxy (`runHookAttachWithDetach`), the #975 site.
- `session/tmux/tmux.go` — the original tmux backend the pattern was copied from (same bug). Adds a `nr > 0` guard since that loop can observe a zero-length read.

No other `DetachKeyByte` interception sites exist.

## Tests

New hermetic tests in `session/pty_detach_test.go` (no real tmux/SSH hardware — they drive the proxy with `sh`/`cat` over a real local PTY, as the existing detach tests do):

- **batched read ending in the detach key detaches** — the regression; verified to time out on `master` and pass with the fix.
- **single-byte detach still detaches** — the case the old guard handled.
- **read not ending in the detach key forwards normally** without detaching (observed via PTY echo), then a later detach-key read tears it down cleanly.

The tmux-backend copy isn't separately unit-tested: its reader is embedded in `Attach()` against a hardcoded `os.Stdin` and a live tmux PTY, so it isn't hermetically reachable — but the fix is byte-for-byte the same logic the hook tests exercise.

## Verification

`gofmt -l .` (clean), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `go test ./...` (only unrelated daemon-socket flake `TestTUIRefreshSeesCLIChangesThroughDaemon`, passes in isolation), and bounded `GOFLAGS="-p=1" go test -race -parallel 2 ./session/...` — all green.

Closes #975

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)