### PR TITLE
fix(session): persisted Dead instances stay Dead and are not re-spawned on daemon restart (#970)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -134,6 +134,21 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 	}()
 
 	if !firstTimeSetup {
+		// A persisted Dead instance's tmux session was killed out from under it
+		// and the daemon explicitly recorded Dead status (#935). Loading it must
+		// NOT silently re-spawn that session: TmuxSession.Restore re-spawns a
+		// missing session when workDir is non-empty (the #386 reboot-recovery
+		// path) and setupTabs would likewise re-spawn the shell tab — together
+		// resurrecting a corpse the user killed, contradicting its persisted
+		// state (#970). Return before both. The deferred handler still flips
+		// started=true, so the corpse keeps rendering Dead, survives the next
+		// SaveInstances checkpoint (which skips !Started instances), and stays
+		// killable; the daemon liveness poll re-confirms Dead because the bound
+		// session does not exist server-side.
+		if i.GetStatus() == Dead {
+			return nil
+		}
+
 		// Reuse existing session. Pass the worktree path so Restore can
 		// re-spawn the tmux session if the server died across a reboot
 		// (see #386). When the worktree is unavailable (e.g. tests inject

--- a/session/dead_respawn_test.go
+++ b/session/dead_respawn_test.go
@@ -1,0 +1,157 @@
+package session
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingExec is nameKeyedExec with a new-session counter. Sessions named in
+// `alive` report existing immediately; others are absent until their
+// new-session call (which bumps *newSessions), so a test can assert exactly
+// whether a missing session was re-spawned during restore.
+func countingExec(alive map[string]bool, newSessions *int) cmd_test.MockCmdExec {
+	existing := map[string]bool{}
+	for k, v := range alive {
+		existing[k] = v
+	}
+	nameOf := func(cmd *exec.Cmd) string {
+		for i, a := range cmd.Args {
+			switch {
+			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
+				return cmd.Args[i+1]
+			case strings.HasPrefix(a, "-t="):
+				return strings.TrimPrefix(a, "-t=")
+			case strings.HasPrefix(a, "-s="):
+				return strings.TrimPrefix(a, "-s=")
+			}
+		}
+		return ""
+	}
+	return cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			s := cmd.String()
+			n := nameOf(cmd)
+			switch {
+			case strings.Contains(s, "has-session"):
+				if existing[n] {
+					return nil
+				}
+				return assertNoSession
+			case strings.Contains(s, "new-session"):
+				*newSessions++
+				existing[n] = true
+				return nil
+			case strings.Contains(s, "kill-session"):
+				delete(existing, n)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return []byte("content"), nil
+		},
+	}
+}
+
+// deadInstanceData builds a persisted record for a local instance with the given
+// status, an agent + shell tab, and non-empty worktree data — the exact shape
+// (worktree present) that lets TmuxSession.Restore re-spawn a missing session.
+func deadInstanceData(t *testing.T, status Status, agentName, shellName string) InstanceData {
+	t.Helper()
+	const repoPath = "/tmp/dead-respawn-repo"
+	return InstanceData{
+		Title:    "dead-respawn",
+		Path:     repoPath,
+		Program:  "claude",
+		Status:   status,
+		TmuxName: agentName,
+		Tabs: []TabData{
+			{Name: agentTabName, Kind: TabKindAgent, TmuxName: agentName},
+			{Name: shellTabName, Kind: TabKindShell, TmuxName: shellName},
+		},
+		Worktree: GitWorktreeData{
+			RepoPath:     repoPath,
+			WorktreePath: filepath.Join(t.TempDir(), "wt"), // non-empty: enables re-spawn
+			SessionName:  "dead-respawn",
+			BranchName:   "dead-branch",
+		},
+	}
+}
+
+// TestDeadInstance_NotRespawnedOnLoad is the #970 regression: an instance
+// persisted as Dead (its tmux session was killed out from under it) must reload
+// as a Dead corpse and must NOT re-spawn any tmux session — neither the agent
+// session (TmuxSession.Restore's #386 re-spawn-when-missing path) nor the shell
+// tab (setupTabs). It must still load as started=true so the daemon's
+// SaveInstances checkpoint (which skips !Started instances) keeps the corpse on
+// disk and the user can still kill it.
+func TestDeadInstance_NotRespawnedOnLoad(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	// Isolate config reads from the developer's real ~/.agent-factory (see
+	// tab_persist_test.go for the full rationale).
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_dead_agent"
+	shellName := agentName + shellTmuxSuffix
+
+	// Both sessions are GONE (the kill that produced Dead): a Restore would hit
+	// the missing-session branch and re-spawn via new-session.
+	var newSessions int
+	exec := countingExec(map[string]bool{}, &newSessions)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	restored, err := FromInstanceData(deadInstanceData(t, Dead, agentName, shellName))
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, newSessions,
+		"a Dead instance must NOT re-spawn any tmux session on load (#970)")
+	assert.Equal(t, Dead, restored.GetStatus(), "the corpse must stay Dead")
+	assert.True(t, restored.Started(),
+		"a Dead instance must load started=true so SaveInstances keeps it on disk")
+	assert.False(t, restored.TabAlive(0),
+		"the Dead agent session must not exist server-side after load")
+}
+
+// TestLiveInstance_RespawnsMissingSessionOnLoad guards the seam from the other
+// side: the #970 fix must NOT regress the #386/#930 re-spawn-across-reboot path.
+// A non-Dead (Running) instance whose tmux server died across a reboot must
+// still re-spawn its missing sessions on load.
+func TestLiveInstance_RespawnsMissingSessionOnLoad(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_live_agent"
+	shellName := agentName + shellTmuxSuffix
+
+	var newSessions int
+	exec := countingExec(map[string]bool{}, &newSessions)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	restored, err := FromInstanceData(deadInstanceData(t, Running, agentName, shellName))
+	require.NoError(t, err)
+
+	assert.Greater(t, newSessions, 0,
+		"a live instance with a missing session must still re-spawn on load (#386/#930)")
+	assert.True(t, restored.Started())
+}


### PR DESCRIPTION
## Summary

Closes #970.

A local instance whose tmux session is killed out from under it is marked **Dead** (#935) and that status is persisted. On daemon restart, `FromInstanceData` loads every record via `Start(false)`; for a **Dead** record `LocalBackend.Start`'s restore path called `TmuxSession.Restore(workDir)`, whose `#386` reboot-recovery branch **re-spawns a missing session when `workDir` is non-empty** — and `setupTabs` likewise re-spawned the shell tab. Result: the corpse the user explicitly killed reappeared as **Running**, violating user intent, confusing the UI, and undoing external cleanup tooling.

## Root cause

`FromInstanceData → Start(false) → LocalBackend.Start` had no `Dead` guard:

- `tmuxSession.Restore(workDir)` → missing-session + non-empty `workDir` → `t.Start(workDir)` (re-spawn, by design for #386/#444 reboot recovery).
- `setupTabs` → no live shell tab → spawns a fresh `$SHELL` session.

A persisted Dead record always carries non-empty worktree data, so both fired.

## Fix

One guard at the single restore chokepoint — `LocalBackend.Start`, top of the `!firstTimeSetup` branch:

```go
if i.GetStatus() == Dead {
    return nil
}
```

This returns **before both** `Restore` (agent tab) and `setupTabs` (shell tabs), so neither re-spawns. The existing deferred handler still flips `started=true`, which matters:

- `Storage.SaveInstances` **skips `!Started()` instances**, so the corpse must stay `started=true` to survive the daemon's persistence checkpoint — otherwise the Dead row would silently vanish from disk.
- The instance keeps rendering Dead and stays killable (`Kill` works regardless of `started`).
- The daemon liveness poll (`refreshInstanceStatus`) re-confirms Dead: the bound session does not exist server-side, so `HasUpdated → (false,false)` and `!TmuxAlive()` → `SetStatusIfNotDeleting(Dead)`. It can never flip to Running.

## Adjacent-call-site audit

- **`FromInstanceData` callers** (`storage.LoadInstances`, `api/api.go` ×2, `app/sync.go`, `app/session_control.go`, `daemon` refresh): all funnel through `Start(false)`, so the single guard covers every restore path — no per-caller changes needed.
- **`LocalBackend.Start` callers**: `Start(true)` (`task/start.go`, `NewInstance` flows) is `firstTimeSetup` and never Dead (new instances are `Ready`); the guard lives inside `!firstTimeSetup` so live first-time setup is untouched.
- **`TmuxSession.Restore` callers**: `backend_local.go:158` (agent — now guarded) and `setupTabs` (shell — now skipped) are the only restore-path callers. `AttachShellTab` / `ReconcileTabsFromData` are live TUI/daemon-sync actions on already-running instances, not the Dead-load path, and were left unchanged. `Restore`'s legitimate re-spawn behavior for genuinely-live instances (the #930/#386 restore-across-restart feature) is preserved.
- **Remote `HookBackend.Start`**: never re-spawns on restore — it verifies liveness via `list_cmd` and a vanished remote session errors out and is skipped (#645). No re-spawn bug there; out of scope.

## Tests

Hermetic, no real tmux (mock `cmdExec` + temp PTY, via the existing `restoreTmuxSession` injection seam), in `session/dead_respawn_test.go`:

- `TestDeadInstance_NotRespawnedOnLoad` — a persisted **Dead** instance (with worktree + agent/shell tabs) loads as `Dead`, `started=true`, and issues **zero** `tmux new-session`.
- `TestLiveInstance_RespawnsMissingSessionOnLoad` — a persisted **Running** instance with a missing session **still re-spawns** on load, guarding against regressing the #386/#930 restore-across-reboot path.

## Verification

`gofmt -l .` (clean), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `go test ./...`, `deadcode -test ./...`, and `GOFLAGS="-p=1" go test -race -parallel 2 ./session/...` — all pass.

— Captain Claude