### PR TITLE
fix(app/ui): correct sidebar selection re-pin and repo bookkeeping across snapshot reconcile swaps (#969, #971)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -480,8 +480,19 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.started != nil {
 			started = msg.started
 		}
+		// A successful Replace now maintains the repos map itself (#971: it
+		// decrements the outgoing row's repo and registers the replacement's), so
+		// the explicit RegisterRepoForInstance below must be skipped on that path or
+		// it would double-count. The other paths (in-place start of an already-present
+		// Loading row, or a fresh add) need the explicit registration: the placeholder
+		// was added before it was started, so its AddInstance finalize registered
+		// nothing (RepoName fails until started), and no presence-changing primitive
+		// runs here to register it now.
+		swapped := false
 		if started != msg.instance {
-			if !m.sidebar.ReplaceInstance(msg.instance, started) && !m.sidebar.ContainsInstance(started) {
+			if m.sidebar.ReplaceInstance(msg.instance, started) {
+				swapped = true
+			} else if !m.sidebar.ContainsInstance(started) {
 				// The Loading placeholder may have been swapped for a
 				// disk-built copy of this same session by a background sync
 				// while the start RPC was in flight; both Replace and
@@ -489,7 +500,9 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// unconditionally would leave two sidebar rows — and two
 				// persisted records — for one session (#808), so replace any
 				// same-title row instead.
-				if !m.sidebar.ReplaceInstanceByTitle(started.Title, started) {
+				if m.sidebar.ReplaceInstanceByTitle(started.Title, started) {
+					swapped = true
+				} else {
 					m.sidebar.AddInstance(started)
 				}
 			}
@@ -498,7 +511,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		started.SetStatus(session.Running)
-		if !started.IsRemote() {
+		if !swapped && !started.IsRemote() {
 			m.sidebar.RegisterRepoForInstance(started)
 		}
 		started.SetAutoYes(m.autoYes)

--- a/app/snapshot_test.go
+++ b/app/snapshot_test.go
@@ -94,6 +94,45 @@ func TestReconcileSnapshot_PreservesSelectionAndActiveTab(t *testing.T) {
 	require.NotNil(t, findSidebarInstance(h, "d"))
 }
 
+// TestReconcileSnapshot_SelectionDriftAfterSwapAndRemoval: when the selected
+// instance is swapped (kill+recreate with same title) AND another preceding
+// instance is removed in the same reconcile cycle, the selection must stay on
+// the recreated instance, not drift to the wrong row (#969). The pre-fix re-pin
+// used pointer equality, which missed the rebuilt instance after the swap.
+func TestReconcileSnapshot_SelectionDriftAfterSwapAndRemoval(t *testing.T) {
+	h := newTestHome(t)
+
+	var rebuilt *session.Instance
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		inst := newSnapshotTestInstance(t, d.Title)
+		rebuilt = inst
+		return inst, nil
+	}))
+
+	a := newSnapshotTestInstance(t, "a")
+	b := newSnapshotTestInstance(t, "b")
+	c := newSnapshotTestInstance(t, "c")
+	h.sidebar.AddInstance(a)
+	h.sidebar.AddInstance(b)
+	h.sidebar.AddInstance(c)
+	h.sidebar.SelectInstance(b)
+	require.Same(t, b, h.sidebar.GetSelectedInstance(), "initial selection must be on b")
+
+	// Snapshot: b was recreated (same title, different CreatedAt), a is gone, c unchanged
+	bData := b.ToInstanceData()
+	bData.CreatedAt = time.Now().Add(time.Hour)
+	cData := c.ToInstanceData()
+
+	changed := h.reconcileSnapshot([]session.InstanceData{bData, cData})
+	assert.True(t, changed)
+
+	// Selection must follow the rebuilt "b" instance, not drift to c.
+	selected := h.sidebar.GetSelectedInstance()
+	require.NotNil(t, selected, "selection must not be nil")
+	assert.Same(t, rebuilt, selected,
+		"selection must stay on the recreated instance (b'), not drift to c")
+}
+
 // TestReconcileSnapshot_NoChangeWhenUnchanged: an identical snapshot reports no
 // change (so the caller skips the repaint) and updates rows IN PLACE rather than
 // rebuilding them.

--- a/app/sync.go
+++ b/app/sync.go
@@ -260,8 +260,9 @@ func (m *home) handleSnapshot(msg snapshotFetchedMsg) bool {
 //
 // Local-only view state is preserved: existing rows keep their pointer (so the
 // TabbedWindow's active tab and the content pane's scroll/overlay are untouched),
-// and the selected instance is re-pinned by pointer after the reconcile so a
-// removal of a preceding row can't drift the cursor. Transient TUI-owned rows
+// and the selected instance is re-pinned by title after the reconcile so neither a
+// removal of a preceding row nor a same-title swap of the selected row can drift the
+// cursor (#969). Transient TUI-owned rows
 // (Loading creation #808, Deleting kill #844) are left entirely alone: the
 // daemon may not yet know about an in-flight create, and a mid-teardown row must
 // keep its marker. Returns whether anything changed.
@@ -289,9 +290,18 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 		existing[inst.Title] = inst
 	}
 
-	// Capture the selected instance so we can re-pin it after removals shift
-	// indices — selection must never drift because a snapshot arrived.
-	selected := m.sidebar.GetSelectedInstance()
+	// Capture the selected instance's STABLE identity (title) so we can re-pin it
+	// after removals shift indices — selection must never drift because a snapshot
+	// arrived. Capturing the pointer would go stale when the selected row is itself
+	// swapped (same title, different CreatedAt) in this same cycle: swapInstanceFromSnapshot
+	// rebuilds a brand-new *session.Instance, orphaning the captured pointer, so a
+	// pointer-equality re-pin would miss it and selection would drift (#969). The
+	// title survives the swap because the rebuilt instance keeps it — the same
+	// title-based re-resolution the async handlers already use (GetInstanceByTitle).
+	var selectedTitle string
+	if selected := m.sidebar.GetSelectedInstance(); selected != nil {
+		selectedTitle = selected.Title
+	}
 
 	changed := false
 
@@ -338,9 +348,14 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 		changed = true
 	}
 
-	// Re-pin the selection to the same instance if it survived the reconcile.
-	if selected != nil && m.sidebar.ContainsInstance(selected) {
-		m.sidebar.SelectInstance(selected)
+	// Re-pin the selection to the same logical instance (by title) if it survived
+	// the reconcile. Re-resolving by title correctly re-pins across a swap because
+	// the rebuilt instance keeps the same title (#969). If the selected title is
+	// gone from the snapshot, leave the sidebar's own clamp behavior as-is.
+	if selectedTitle != "" {
+		if inst := m.sidebar.GetInstanceByTitle(selectedTitle); inst != nil {
+			m.sidebar.SelectInstance(inst)
+		}
 	}
 
 	return changed

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -407,14 +407,29 @@ func (s *Sidebar) ContainsInstance(target *session.Instance) bool {
 }
 
 // ReplaceInstance swaps an existing sidebar instance for replacement while
-// preserving the selected row when the replaced instance was selected.
+// preserving the selected row when the replaced instance was selected, and keeps
+// the repos map (which drives the multi-repo indicator) correct: the outgoing
+// instance's repo is decremented and the replacement's repo registered. A
+// kill+recreate can swap in an instance from a DIFFERENT repo (#971), so doing the
+// bookkeeping here — at the primitive — means every caller (ReplaceInstanceByTitle,
+// swapInstanceFromSnapshot, the instanceStartedMsg start path) stays correct
+// without remembering a separate RegisterRepoForInstance call. RepoName() errors
+// are skipped silently rather than logged: the outgoing row may be an unstarted
+// Loading placeholder (never registered, nothing to decrement) and either side may
+// be a remote instance with no local repo — both are normal, not failures.
 func (s *Sidebar) ReplaceInstance(target, replacement *session.Instance) bool {
 	for i, inst := range s.instances {
 		if inst != target {
 			continue
 		}
 		wasSelected := s.GetSelectedInstance() == inst
+		if repoName, err := inst.RepoName(); err == nil {
+			s.rmRepo(repoName)
+		}
 		s.instances[i] = replacement
+		if repoName, err := replacement.RepoName(); err == nil {
+			s.addRepo(repoName)
+		}
 		s.rebuildVisibleItems()
 		if wasSelected {
 			s.SetSelectedInstance(i)

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -648,4 +649,76 @@ func TestInstanceRendererDeletingDimsSelectedRow(t *testing.T) {
 	assert.Contains(t, after[1], dimFG, "selected deleting title must be dimmed")
 	assert.Contains(t, after[2], dimFG, "selected deleting branch line must be dimmed")
 	assert.Contains(t, after[4], dimFG, "selected deleting PR line must be dimmed")
+}
+
+// newRepoInstance builds a started sidebar instance whose RepoName() resolves to
+// repoName, so the sidebar's repo bookkeeping (which drives the multi-repo
+// indicator) can be exercised. GetRepoName() is filepath.Base(repoPath), so the
+// worktree's repoPath ends in repoName.
+func newRepoInstance(t *testing.T, title, repoName string) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	inst.SetStartedForTest(true)
+	gw, err := git.NewGitWorktreeFromStorage(
+		filepath.Join(t.TempDir(), repoName), // repoPath base = repoName
+		filepath.Join(t.TempDir(), "worktree"),
+		title,
+		"branch",
+		"deadbeef",
+		false,
+		true,
+	)
+	require.NoError(t, err)
+	inst.SetGitWorktreeForTest(gw)
+	return inst
+}
+
+// TestReplaceInstanceRepoTrackingStaleEntry: replacing an instance with one from a
+// DIFFERENT repo must drop the outgoing instance's repo from the bookkeeping —
+// otherwise a kill+recreate that moves a session to another repo leaves a stale
+// repo entry and shows a phantom multi-repo indicator (#971).
+func TestReplaceInstanceRepoTrackingStaleEntry(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false)
+
+	a := newRepoInstance(t, "a", "repo-A")
+	c := newRepoInstance(t, "c", "repo-C")
+	s.AddInstance(a)()
+	s.AddInstance(c)()
+	require.Equal(t, 2, s.NumRepos())
+
+	// Replace the repo-A instance with one from repo-B.
+	b := newRepoInstance(t, "b", "repo-B")
+	require.True(t, s.ReplaceInstance(a, b))
+
+	_, staleA := s.repos["repo-A"]
+	assert.False(t, staleA, "outgoing instance's repo (repo-A) must be dropped after a cross-repo replace")
+	assert.Equal(t, 2, s.NumRepos(), "repos must be {repo-B, repo-C} after the replace")
+}
+
+// TestReplaceInstanceRepoTrackingMissingNew: replacing an instance with one from a
+// DIFFERENT repo must register the incoming instance's repo — otherwise the new
+// repo is invisible to the multi-repo indicator until the next full reload (#971).
+func TestReplaceInstanceRepoTrackingMissingNew(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false)
+
+	a := newRepoInstance(t, "a", "repo-A")
+	s.AddInstance(a)()
+	require.Equal(t, 1, s.NumRepos())
+
+	// Replace the only instance with one from repo-B.
+	b := newRepoInstance(t, "b", "repo-B")
+	require.True(t, s.ReplaceInstance(a, b))
+
+	_, hasB := s.repos["repo-B"]
+	assert.True(t, hasB, "incoming instance's repo (repo-B) must be registered after a cross-repo replace")
+	_, staleA := s.repos["repo-A"]
+	assert.False(t, staleA, "outgoing repo-A must not linger")
+	assert.Equal(t, 1, s.NumRepos(), "repos must be exactly {repo-B} after the replace")
 }


### PR DESCRIPTION
Closes #969
Closes #971

Two regressions introduced by #963 (the snapshot-reconcile path), both in the
same kill+recreate-same-title swap code. Bundled because the fixes touch the same
`ReplaceInstance`/`swapInstanceFromSnapshot` machinery.

## #969 — selection drifts to the wrong session after a swap + removal

**Root cause.** `reconcileSnapshot` (`app/sync.go`) captured the selected row as a
`*session.Instance` **pointer** (`selected := m.sidebar.GetSelectedInstance()`) and
re-pinned it after the reconcile with **pointer equality**
(`if selected != nil && m.sidebar.ContainsInstance(selected)`).

When the selected row is itself swapped in the same cycle — same title, different
`CreatedAt`, a kill+recreate handled by `swapInstanceFromSnapshot` →
`ReplaceInstanceByTitle`, which builds a **brand-new** `*session.Instance` — the
captured pointer goes stale. `ContainsInstance` then fails to find the swapped-in
instance, the re-pin never runs, and if a preceding row was also removed in the same
cycle `selectedIdx` merely clamps, so selection drifts to the neighbour that now
occupies the shifted index (up to 750ms until the next tick).

**Fix.** Capture the selection by **stable identity (title)** and re-resolve via
`Sidebar.GetInstanceByTitle(selectedTitle)` after all swaps/removals, re-selecting it
if present. The title survives the rebuild because the recreated instance keeps it.
This mirrors the title-based re-resolution the async handlers already use (e.g. the
`prInfoUpdatedMsg` handler's `GetInstanceByTitle` fallback). If the selected title is
gone from the snapshot, the sidebar's own clamp behaviour is left as-is.

## #971 — repo indicator wrong after a cross-repo kill+recreate

**Root cause.** `Sidebar.ReplaceInstance` (`ui/sidebar.go`, called by
`ReplaceInstanceByTitle` → used by `swapInstanceFromSnapshot`) swapped the instance
pointer in `s.instances` but never updated the `repos` map. After a kill+recreate
swaps in an instance from a **different** repo, the outgoing repo entry lingered and
the incoming repo was never registered, so the `len(s.repos) > 1` multi-repo indicator
(and the per-row repo badge) showed phantom/missing repos. `RemoveInstanceByTitle`
already maintains the map via `rmRepo`, but `ReplaceInstance` did not.

**Fix.** Maintain the `repos` map **at the primitive**: decrement the outgoing
instance's repo and register the replacement's, reusing the existing `rmRepo`/`addRepo`
helpers. `RepoName()` errors are skipped silently (an unstarted Loading placeholder
was never registered; a remote instance has no local repo — both normal). This fixes
**every** `ReplaceInstance` caller, so `swapInstanceFromSnapshot` needs no extra
`RegisterRepoForInstance` call, and it also closes a latent same-title-replace repo
leak in the `instanceStartedMsg` start path.

## Adjacent-call-site audit (per CLAUDE.md)

**`ReplaceInstance` callers** — `app.go` (`instanceStartedMsg`, two branches via
`ReplaceInstance`/`ReplaceInstanceByTitle`) and `swapInstanceFromSnapshot`. With the
primitive now self-maintaining, the only required follow-up was the `instanceStartedMsg`
path, which previously did an **unconditional** `RegisterRepoForInstance(started)` after
the swap/add. That now double-counts the Replace branch, so it is gated behind a
`swapped` flag: registration is skipped when a Replace ran (the primitive did it) and
kept for the in-place-start / fresh-add paths (no presence-changing primitive runs there,
and the placeholder was added before it was started so its `AddInstance` finalize
registered nothing). `swapInstanceFromSnapshot` needs no change. Verified by the
existing `TestInstanceStartedRegistersRepoAfterStart` (in-place start still registers
exactly once).

**`ContainsInstance` dead-code disposition** — after switching the reconcile re-pin to
title-based, I checked whether `Sidebar.ContainsInstance` had become dead. It has
legitimate non-test callers (`ui/sidebar.go` `SetSelectedInstance` guard and `app/app.go`
`instanceStartedMsg`), so it stays. `deadcode -test ./...` is clean.

**Other pointer-identity selection/containment in background/reconcile paths** —
swept `app/` and `ui/`:
- `prInfoUpdatedMsg` (`app.go`) — already re-resolves by title via `GetInstanceByTitle`
  after the `ContainsInstance` fast-path. No hazard.
- `instanceStartedMsg`'s `priorSelection` re-select (`app.go`) — captures a pointer but
  does **no swap** in its own synchronous scope (only a `RemoveInstanceByTitle`), and the
  capture→use is on the event loop with no await between, so the pointer cannot go stale.
- The `Esc`/`selectionChanged` reads of `GetSelectedInstance` (`app.go`) use the live
  selection synchronously. No hazard.

## Tests

- **#969** — `app/snapshot_test.go`: `TestReconcileSnapshot_SelectionDriftAfterSwapAndRemoval`
  (the exact failing test from the issue). Selection must stay on the recreated same-title
  instance when a swap and a preceding removal happen in one reconcile cycle. Hermetic via
  the existing `SetInstanceBuilderForTest` / `newSnapshotTestInstance` seams (no tmux reattach).
  - **Before:** `FAIL` — selection drifts to `c`.
  - **After:** `PASS`.
- **#971** — `ui/sidebar_test.go`: `TestReplaceInstanceRepoTrackingStaleEntry` and
  `TestReplaceInstanceRepoTrackingMissingNew`, covering both failure modes (stale old repo
  removed; new repo present) after a cross-repo `ReplaceInstance`.
  - **Before:** both `FAIL` (`repo-A` lingers, `repo-B` missing).
  - **After:** both `PASS`.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — all packages ok
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./app/... ./ui/...` — ok

— Captain Claude
