### PR TITLE
fix(ui): detect shell tab session death during scroll mode (#977)

### DIFF
--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -256,17 +256,24 @@ func (p *TabPane) updateShellLocked(instance *session.Instance, activeTab int) e
 		return nil
 	}
 
-	// Skip content updates while scrolling (the shell slot fills its viewport
-	// eagerly in enterScrollMode, not here).
-	if p.isScrolling {
-		return nil
-	}
-
 	// The tab's session is owned by the Instance and created at start (or by the
 	// new-tab hotkey). If it is not alive, show a fallback rather than leaving the
 	// previous view's content on screen (#747, generalized to the persisted tab).
+	//
+	// This runs BEFORE the scroll-mode guard below so a shell session killed
+	// externally while the user is scrolling transitions to the fallback instead
+	// of leaving stale scrollback pinned on screen forever (#977). setFallbackState
+	// clears scroll state, so String() (which checks isScrolling first) renders the
+	// fallback message. This mirrors the agent slot, whose Dead check also precedes
+	// its scroll guard in updateAgentLocked.
 	if !instance.TabAlive(activeTab) {
 		p.setFallbackState("Terminal session not available.")
+		return nil
+	}
+
+	// Skip content updates while scrolling (the shell slot fills its viewport
+	// eagerly in enterScrollMode, not here).
+	if p.isScrolling {
 		return nil
 	}
 

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -410,6 +410,92 @@ func TestTabPaneShellSessionGoneFallback(t *testing.T) {
 	require.Empty(t, errBuf.String(), "no ERROR log line on the session-gone fallback path")
 }
 
+// TestTabPaneShellScrollModeSessionGoneExternally is the #977 regression: a shell
+// tab in scroll mode whose tmux session is killed externally must transition to
+// the "Terminal session not available." fallback instead of leaving the captured
+// scrollback pinned on screen forever. updateShellLocked must run the TabAlive
+// liveness check BEFORE its scroll-mode early-return, mirroring the agent slot.
+func TestTabPaneShellScrollModeSessionGoneExternally(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	const scrollback = "scrollback-line-from-live-shell"
+	var gone atomic.Bool
+	existing := map[string]bool{}
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			s := cmd.String()
+			name := tmuxTargetName(cmd)
+			switch {
+			case strings.Contains(s, "has-session"):
+				// A session killed externally fails has-session, which is what
+				// DoesSessionExist()/TabAlive keys off of (#977).
+				if gone.Load() {
+					return fmt.Errorf("session gone")
+				}
+				if existing[name] {
+					return nil
+				}
+				return fmt.Errorf("session does not exist")
+			case strings.Contains(s, "new-session"):
+				existing[name] = true
+				return nil
+			case strings.Contains(s, "kill-session"):
+				delete(existing, name)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			if strings.Contains(cmd.String(), "capture-pane") {
+				return []byte(scrollback), nil
+			}
+			return []byte(""), nil
+		},
+	}
+
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	workdir := t.TempDir()
+	setupGitRepo(t, workdir)
+	name := fmt.Sprintf("test-shell-scroll-gone-%d", time.Now().UnixNano())
+	inst, err := session.NewInstance(session.InstanceOptions{Title: name, Path: workdir, Program: "bash"})
+	require.NoError(t, err)
+	pty := &MockPtyFactory{t: t, cmdExec: cmdExec}
+	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps(name, "bash", pty, cmdExec))
+	require.NoError(t, inst.Start(true))
+	defer func() { _ = inst.Kill() }()
+
+	p := NewTabPane()
+	p.SetSize(80, 30)
+
+	// Enter scroll mode on the live shell tab: the viewport fills with scrollback.
+	require.NoError(t, p.ScrollUp(inst, 1))
+	require.True(t, p.IsScrolling(), "precondition: shell tab is in scroll mode")
+	require.Contains(t, p.viewport.View(), scrollback,
+		"precondition: viewport holds the live shell's scrollback")
+
+	// The shell session is killed externally while the user keeps scrolling.
+	gone.Store(true)
+
+	require.NoError(t, p.UpdateContent(inst, 1),
+		"a gone shell session must NOT bubble an error up to handleError")
+
+	p.mu.Lock()
+	stillScrolling := p.isScrolling
+	hasFallback := p.content.fallback
+	fallbackText := p.content.text
+	p.mu.Unlock()
+
+	require.False(t, stillScrolling, "scroll mode must exit when shell session dies (#977)")
+	require.True(t, hasFallback, "must show fallback when shell session is gone (#977)")
+	require.Contains(t, fallbackText, "Terminal session not available.")
+
+	rendered := p.String()
+	require.Contains(t, rendered, "Terminal session not available.")
+	require.NotContains(t, rendered, scrollback,
+		"stale scrollback must not remain on screen after the session dies (#977)")
+}
+
 // TestTabPaneRemoteFallbackStates covers the #843 Terminal-tab UX for remote
 // sessions on the merged pane.
 func TestTabPaneRemoteFallbackStates(t *testing.T) {


### PR DESCRIPTION
Closes #977

## Root cause

In `ui/tab_pane.go` `updateShellLocked`, the scroll-mode early return ran **before** the liveness check:

```go
if p.isScrolling {           // <-- returned here first
    return nil
}
if !instance.TabAlive(activeTab) {
    p.setFallbackState("Terminal session not available.")
    return nil
}
```

So when a shell tab's tmux session was killed externally while the user was scrolling, `UpdateContent` bailed out at the scroll guard and never reached `TabAlive`. The pane kept the captured viewport pinned on screen indefinitely — the user scrolled stale content from a dead session forever, with no fallback.

The agent slot (`updateAgentLocked`) already checks death (`status == Dead`, plus an `ErrSessionGone` check on its lazy scroll-fill, #940) **before** its `isScrolling` guard, so it transitions to the fallback even mid-scroll. The shell path was the lone inconsistency.

## Fix

Move the `TabAlive(activeTab)` check ahead of the `isScrolling` guard in `updateShellLocked`. `setFallbackState` clears scroll state, and `String()` checks `isScrolling` before `fallback`, so the fallback message renders correctly even when entered mid-scroll. Non-scroll behavior is byte-for-byte unchanged (same checks, same order relative to each other; only the scroll guard moved below them).

## Adjacent-site audit

All tab-render paths were checked for consistent session-death-during-scroll handling:

- **`updateAgentLocked` (agent tab, index 0)** — already correct: `Dead`/`Deleting`/`Loading` fallbacks precede the scroll guard, and the lazy scroll-fill path handles `ErrSessionGone` (#940). No change needed.
- **`enterScrollModeLocked`** — already correct: for shell tabs it short-circuits on `!TabAlive` before capturing, and both slots map `ErrSessionGone` to a fallback, so you can never *enter* scroll mode on a dead session.
- **`ResetToNormalMode`** — agent slot re-checks transient/Dead status and `ErrSessionGone`; shell slot returns to live capture on the next refresh, which now hits the relocated `TabAlive` check.

`updateShellLocked` was the only path where death-during-scroll went undetected. After this change the shell slot mirrors the agent slot.

## Test

Adds `TestTabPaneShellScrollModeSessionGoneExternally` to `ui/terminal_test.go` (hermetic — mock tmux via the existing `MockCmdExec`/`MockPtyFactory` seams, no real tmux). It enters scroll mode on a live shell tab, kills the session externally (`has-session` starts failing), then calls `UpdateContent` and asserts scroll mode exits, the `"Terminal session not available."` fallback is set, and the stale scrollback is no longer rendered.

Verified **fail-before / pass-after**: the test fails on the pre-fix ordering (`scroll mode must exit when shell session dies`) and passes after the reorder.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — all packages pass
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/...` — pass

Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)