### PR TITLE
fix(daemon): RequestShutdown returns an accurate result for contacted-but-errored RPCs instead of ShutdownNoDaemon (#978)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -431,6 +431,17 @@ const (
 	// daemon is still running the old binary; the caller must surface the
 	// recovery hint in the accompanying error. See #553.
 	ShutdownFailed
+	// ShutdownError means the control socket was present and a Shutdown RPC
+	// was attempted, but it failed with an error that does NOT prove the
+	// daemon absent and is NOT method-not-found: EACCES (socket exists but
+	// the caller lacks permission to connect), ECONNRESET/EPIPE (the
+	// connection was established then reset), or a dial timeout (the socket
+	// is bound but the listener is unresponsive). All of these imply a daemon
+	// WAS listening, so reporting ShutdownNoDaemon — documented as "no daemon
+	// was running" — would mislabel the outcome. The daemon's final state is
+	// unknown and it may still be running; the accompanying error carries the
+	// detail. See #978.
+	ShutdownError
 )
 
 // sigtermFallbackGrace is the max time we wait for a SIGTERM'd daemon to exit
@@ -450,10 +461,14 @@ const sigtermFallbackPoll = 100 * time.Millisecond
 // Returns (ShutdownNoDaemon, nil) when no daemon is running (no socket or
 // ECONNREFUSED), (ShutdownViaRPC, nil) when the Shutdown RPC acknowledged,
 // (ShutdownViaSIGTERM, nil) when the fallback signaled a real `af --daemon`
-// process, and (ShutdownFailed, err) when the daemon is provably running but
+// process, (ShutdownFailed, err) when the daemon is provably running but
 // the fallback could not locate or signal it (ambiguous pgrep matches, no
 // PID file with pgrep unavailable, permission denied on signal) — the
-// returned error carries the recovery hint the caller must surface.
+// returned error carries the recovery hint the caller must surface — and
+// (ShutdownError, err) when the socket was present but the Shutdown RPC
+// failed with a transport error that is neither daemon-absent nor
+// method-not-found (EACCES, ECONNRESET/EPIPE, dial timeout): a daemon was
+// listening but its final state is unknown (#978).
 func RequestShutdown() (ShutdownResult, error) {
 	socketPath, err := DaemonSocketPath()
 	if err != nil {
@@ -475,7 +490,12 @@ func RequestShutdown() (ShutdownResult, error) {
 			// (pre-#501 binary). Fall through to the PID-based fallback.
 			return sigtermFallback()
 		}
-		return ShutdownNoDaemon, rpcErr
+		// The socket was present (os.Stat above succeeded) and the error is
+		// neither daemon-absent (ECONNREFUSED/ENOENT) nor method-not-found:
+		// EACCES, ECONNRESET/EPIPE, or a dial timeout. Something was listening,
+		// so ShutdownNoDaemon would mislabel this — report the ambiguous
+		// contacted-but-errored outcome instead (#978).
+		return ShutdownError, rpcErr
 	}
 	if !resp.OK {
 		return ShutdownNoDaemon, fmt.Errorf("daemon Shutdown RPC returned OK=false")

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -562,6 +562,57 @@ func TestRequestShutdownSuccess(t *testing.T) {
 	}
 }
 
+// TestRequestShutdownContactedButErrored verifies that when the control
+// socket has a real listener but the Shutdown RPC fails with a transport
+// error that is neither daemon-absent (ECONNREFUSED/ENOENT) nor
+// method-not-found, RequestShutdown reports ShutdownError — not the
+// "no daemon was running" ShutdownNoDaemon — since something WAS listening
+// when the shutdown was attempted (#978). It is fully hermetic: the listener
+// binds the tempdir socket and never touches a real daemon.
+func TestRequestShutdownContactedButErrored(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	socketPath, err := DaemonSocketPath()
+	if err != nil {
+		t.Fatalf("DaemonSocketPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// A listener that accepts the dial and immediately closes the connection
+	// without speaking net/rpc. The dial succeeds (so this is NOT
+	// ECONNREFUSED/ENOENT — a daemon WAS listening) and the client's response
+	// decode fails with EOF (so this is NOT an rpc.ServerError method-not-found
+	// either) — exactly the contacted-but-errored case the catch-all must
+	// classify as ShutdownError instead of mislabeling as ShutdownNoDaemon.
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	result, err := RequestShutdown()
+	if err == nil {
+		t.Fatalf("RequestShutdown returned nil error for a contacted-but-errored RPC; want the transport error propagated")
+	}
+	if result == ShutdownNoDaemon {
+		t.Fatalf("RequestShutdown mislabeled a contacted-but-errored RPC as ShutdownNoDaemon (#978)")
+	}
+	if result != ShutdownError {
+		t.Fatalf("RequestShutdown returned %v for a contacted-but-errored RPC, want ShutdownError", result)
+	}
+}
+
 // stubGhostCleanup replaces both ghostCleanupWorktree and ghostKillTmuxByName
 // with recorders so tests can assert which teardown branches fired without
 // invoking real git / real tmux.


### PR DESCRIPTION
Closes #978

## Root cause

`RequestShutdown` in `daemon/control.go` maps RPC errors to a `ShutdownResult`. Only `ECONNREFUSED`/`ENOENT` are classified as "daemon absent" (`isDaemonAbsentErr`) and method-not-found routes to the SIGTERM fallback. Everything else hit the catch-all:

```go
return ShutdownNoDaemon, rpcErr
```

But that branch is reached for errors that prove a daemon **was** listening when the socket was contacted:
- `EACCES` — socket exists but the caller lacks permission to connect
- `ECONNRESET` / `EPIPE` — connection was established then reset/closed
- dial timeout — socket is bound but the listener is unresponsive

`ShutdownNoDaemon` is documented as "no daemon was running", so this mislabeled the outcome. No functional impact today (callers ignore the result on error), but it violates the enum contract and is misleading for future callers, logs, and debugging.

## Fix

- Add a distinct `ShutdownError` enum value with a clear doc comment for the contacted-but-errored case (socket present, RPC failed with a non-absent, non-method-not-found transport error; daemon's final state unknown).
- Return `ShutdownError, rpcErr` from the catch-all instead of `ShutdownNoDaemon, rpcErr`.
- `ShutdownNoDaemon` now stays strictly for the genuine daemon-absent path (`isDaemonAbsentErr`, ENOENT stat, no socket).
- Updated the enum block and the `RequestShutdown` doc comment to describe the new value.

`ShutdownError` is appended after `ShutdownFailed` so existing iota values are unchanged. It is kept distinct from `ShutdownFailed` (which specifically means "daemon provably listening but the SIGTERM fallback couldn't find/signal a PID").

## Adjacent-site audit (consumers of `RequestShutdown` / `ShutdownResult`)

Every consumer was reviewed; none breaks on the new value:

| Site | Handling | Effect of `ShutdownError` |
|------|----------|---------------------------|
| `upgrade.go:141-159` (`runUpgrade`) | `switch` branches on `shutdownErr != nil` **first**; respawn guarded by `if shutdownErr == nil && result != ShutdownNoDaemon` | Catch-all always returns a non-nil `rpcErr`, so the `shutdownErr != nil` case fires ("Failed to restart the running daemon: …") and the respawn guard is skipped. Result value is never compared on this path. ✅ unchanged |
| `autoupdate.go:104-121` (`runAutoUpdate`) | same pattern (logs warning on error, respawn guarded by `shutdownErr == nil`) | Same as above — error path logs the warning; respawn skipped. ✅ unchanged |
| `daemon/sigterm_fallback.go` | returns `ShutdownViaSIGTERM` / `ShutdownFailed` only; never the catch-all | Not on the new path. ✅ |

Both switches are tagless (`switch { case … }`), so there is no exhaustiveness lint to satisfy. Callers ignore the result on error today — confirmed safe.

## Tests

Added hermetic `TestRequestShutdownContactedButErrored`: binds a listener on the tempdir socket (`AGENT_FACTORY_HOME`) that accepts the dial then immediately closes the connection. The dial succeeds (not `ECONNREFUSED`/`ENOENT`) and the RPC response decode fails with EOF (not an `rpc.ServerError` method-not-found) — driving the catch-all. Asserts the result is `ShutdownError`, the error is propagated, and it is **not** `ShutdownNoDaemon`.

Existing tests continue to pin the absent cases: `TestRequestShutdownNoDaemon` (ENOENT → `ShutdownNoDaemon`) and `TestRequestShutdownStaleSocket` (ECONNREFUSED → `ShutdownNoDaemon`). No real daemon/socket is touched.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./...` — all packages pass (incl. daemon + integration)
- `GOFLAGS="-p=1" go test -race -parallel 2 ./daemon/...` — pass

Signed-off, Captain Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
