### PR TITLE
fix(ui): correct single-tab bottom-right border rendering (#972)

### DIFF
--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -310,12 +310,17 @@ func (w *TabbedWindow) String() string {
 		} else {
 			style = inactiveTabStyle
 		}
+		// A single tab is both first and last, so the bottom-left and
+		// bottom-right corners must be decided independently — a mutually
+		// exclusive if/else-if chain would set only BottomLeft and leave
+		// BottomRight at its wrong default (#972).
 		border, _, _, _, _ := style.GetBorder()
 		if isFirst && isActive {
 			border.BottomLeft = "│"
 		} else if isFirst {
 			border.BottomLeft = "├"
-		} else if isLast && isActive {
+		}
+		if isLast && isActive {
 			border.BottomRight = "│"
 		} else if isLast {
 			border.BottomRight = "┤"

--- a/ui/tabbed_window_single_tab_test.go
+++ b/ui/tabbed_window_single_tab_test.go
@@ -1,0 +1,51 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/log"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTabbedWindowSingleTabBorderRendering guards the single-tab corner case
+// (#972). A remote instance without terminal_cmd renders exactly one tab, which
+// is both first and last. The bottom border of an active single tab must show a
+// vertical bar on BOTH corners; the old mutually exclusive if/else-if chain set
+// only the bottom-left bar and left the bottom-right corner at its default "└".
+func TestTabbedWindowSingleTabBorderRendering(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedRemoteInstance(t, false)
+	w := NewTabbedWindow(NewTabPane())
+	w.SetInstance(inst)
+	require.Equal(t, []string{"Preview"}, w.tabLabels(), "remote without terminal_cmd has a single tab")
+	require.Equal(t, 0, w.GetActiveTab(), "the lone tab is active")
+
+	w.SetSize(120, 40)
+
+	lines := strings.Split(w.String(), "\n")
+
+	// The tab renders as three rows: top border, the label row, then the bottom
+	// border row. Anchor on the label row so the bottom-border index is robust to
+	// the leading blank line(s) JoinVertical emits.
+	labelIdx := -1
+	for i, ln := range lines {
+		if strings.Contains(ln, "Preview") {
+			labelIdx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, labelIdx, 0, "could not find the tab label row in:\n%s", strings.Join(lines, "\n"))
+	require.Greater(t, len(lines), labelIdx+1, "missing the tab bottom-border row")
+
+	border := []rune(lines[labelIdx+1])
+	require.NotEmpty(t, border, "expected a non-empty tab bottom-border line")
+
+	left := string(border[0])
+	right := string(border[len(border)-1])
+	require.Equalf(t, "│", left, "single active tab bottom-left corner; line=%q", lines[labelIdx+1])
+	require.Equalf(t, "│", right, "single active tab bottom-right corner; line=%q", lines[labelIdx+1])
+}


### PR DESCRIPTION
## Summary

Fixes a cosmetic TUI border bug: a single-tab view (a remote instance without `terminal_cmd`, since #957) renders the wrong bottom-right tab-border character — `└` instead of `│`, producing an asymmetric border.

## Root cause

`TabbedWindow.String()` (`ui/tabbed_window.go`) chose both bottom-border corners with one **mutually-exclusive** `if/else-if` chain:

```go
if isFirst && isActive {
    border.BottomLeft = "│"
} else if isFirst {
    border.BottomLeft = "├"
} else if isLast && isActive {
    border.BottomRight = "│"   // unreachable when a tab is both first AND last
} else if isLast {
    border.BottomRight = "┤"
}
```

The chain assumes a tab can't be both first and last. With exactly one tab, `isFirst && isLast && isActive` is true: the first branch sets `BottomLeft` and the `isLast` branches never run, so `BottomRight` keeps the active border's default `└`.

## Fix

Decide the two corners independently — `BottomLeft` from `isFirst`, `BottomRight` from `isLast` — so both apply when there's a single tab. Reuses the existing active/inactive corner characters. No behavior change for the 2+ tab cases.

## Test

Adds `TestTabbedWindowSingleTabBorderRendering` (ui), which drives the real single-tab remote render path and asserts both bottom corners render `│`. Verified failing before the fix (`right="└"`) and passing after.

## Verification

`gofmt -l .` (clean), `go build ./...`, `golangci-lint run --timeout=3m --fast` (clean), `go test ./...`, `deadcode -test ./...` (clean), and bounded race `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/...` — all green.

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude