### PR TITLE
fix(session): reject whitespace-only session titles in TUI and daemon validation (#973)

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -39,7 +40,10 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	switch msg.Type {
 	case tea.KeyEnter:
-		if len(instance.Title) == 0 {
+		// Reject whitespace-only titles too: len()/== "" pass a "   " title
+		// through to session creation, producing an invisible name in the
+		// sidebar (#973). TrimSpace mirrors the daemon's validateTitleAvailableLocked.
+		if strings.TrimSpace(instance.Title) == "" {
 			return m, m.handleError(fmt.Errorf("title cannot be empty"))
 		}
 		for _, other := range m.sidebar.GetInstances() {

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -224,6 +224,39 @@ func TestHandleStateNewRejectsDuplicateTitle(t *testing.T) {
 	assert.Contains(t, h.errBox.String(), "fix-bug")
 }
 
+// TestHandleStateNewWhitespaceViaRealInput is the regression guard for #973: a
+// title built entirely from spaces is non-empty (len > 0 and != ""), so the old
+// len()==0 check let it through to session creation, producing an invisible name
+// in the sidebar. Typing spaces and then Enter must leave the naming overlay open
+// and the namingInstance pointer intact (i.e. not submitted).
+func TestHandleStateNewWhitespaceViaRealInput(t *testing.T) {
+	h := newTestHome(t)
+	h.state = stateNew
+	h.errBox.SetSize(120, 1)
+
+	naming, err := session.NewInstance(session.InstanceOptions{
+		Title:   "",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	h.namingInstance = naming
+
+	// Simulate the user typing three spaces in the naming flow: each KeySpace
+	// appends " " to instance.Title (the KeySpace branch in handle_input.go).
+	for i := 0; i < 3; i++ {
+		_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeySpace})
+	}
+	require.Equal(t, "   ", h.namingInstance.Title, "precondition: title is whitespace-only")
+
+	// Submit with Enter — must be rejected, keeping the flow open.
+	_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, stateNew, h.state, "naming flow must stay open for whitespace-only title")
+	require.NotNil(t, h.namingInstance, "naming instance must not be submitted")
+	assert.Contains(t, h.errBox.String(), "title cannot be empty")
+}
+
 // TestHandleStateNewRejectsCaseVariantTitle covers #936: the naming pre-check
 // must reject a case variant of an existing title (e.g. "myapp" when "MyApp"
 // exists), mirroring the daemon's case-insensitive collision rule. Before the

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1277,7 +1277,10 @@ func (m *Manager) nextAvailableTitleLocked(repoID, repoPath, baseTitle, program 
 }
 
 func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program string, remote bool, diskData []session.InstanceData) error {
-	if title == "" {
+	// Whitespace-only titles (e.g. "   ") are non-empty and so slip past a bare
+	// == "" check, creating sessions with effectively blank names (#973). Trim
+	// before the emptiness gate; the TUI naming flow applies the same check.
+	if strings.TrimSpace(title) == "" {
 		return fmt.Errorf("session title is required")
 	}
 	// Titles are sanitized into git branch names (git.SanitizeBranchName

--- a/daemon/control_test.go
+++ b/daemon/control_test.go
@@ -290,6 +290,30 @@ func TestManagerCreateSessionRejectsCaseVariantTitle(t *testing.T) {
 	}
 }
 
+// TestValidateTitleAvailableLockedRejectsWhitespace covers the daemon side of
+// #973: a whitespace-only title is non-empty, so the bare title == "" gate let it
+// through, letting the daemon create a session with an effectively blank name.
+// TrimSpace closes the gap and mirrors the TUI naming flow's check.
+func TestValidateTitleAvailableLockedRejectsWhitespace(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	manager, err := newManagerShell(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("newManagerShell: %v", err)
+	}
+
+	for _, title := range []string{"", " ", "   ", "\t", "\n  \t"} {
+		manager.mu.Lock()
+		err := manager.validateTitleAvailableLocked("repo-id", "/tmp/repo", title, "claude", false, nil)
+		manager.mu.Unlock()
+		if err == nil {
+			t.Fatalf("expected whitespace-only title %q to be rejected", title)
+		}
+		if !strings.Contains(err.Error(), "session title is required") {
+			t.Fatalf("title %q: expected \"session title is required\", got: %v", title, err)
+		}
+	}
+}
+
 // TestManagerCreateSessionRejectsCaseVariantTitleFromDisk covers the disk-side
 // branch of the #605 fix: a case-variant title persisted to disk from a prior
 // daemon run must still be rejected when the manager loads fresh and a new

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -151,7 +151,7 @@ func hookNameForInstance(i *Instance) string {
 func (b *HookBackend) Type() string { return "remote" }
 
 func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
-	if i.Title == "" {
+	if strings.TrimSpace(i.Title) == "" {
 		return fmt.Errorf("instance title cannot be empty")
 	}
 

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -60,7 +60,7 @@ type LocalBackend struct{}
 func (b *LocalBackend) Type() string { return "local" }
 
 func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
-	if i.Title == "" {
+	if strings.TrimSpace(i.Title) == "" {
 		return fmt.Errorf("instance title cannot be empty")
 	}
 


### PR DESCRIPTION
Closes #973

## Root cause
Whitespace-only titles (e.g. `"   "`) are **non-empty**: they have `len > 0` and are `!= ""`. Both emptiness gates only rejected the empty string:

- TUI naming flow (`app/handle_input.go`): `len(instance.Title) == 0`
- Daemon (`daemon/control.go` `validateTitleAvailableLocked`): `title == ""`

So a title of all spaces sailed through both checks into session creation, producing sessions with effectively blank names — confusing sidebar rows that look empty, and collision errors that reference titles which look identical. (Introduced in c276a65, copied to the daemon in d0afe1c.)

## Fix
Close the gap at each emptiness gate with `strings.TrimSpace(...) == ""`, keeping the existing error messages and behavior (TUI keeps the naming overlay open; daemon returns `"session title is required"`). No otherwise-valid title is mutated — the trim is only applied inside the emptiness test.

- `app/handle_input.go` — TUI `KeyEnter` handler.
- `daemon/control.go` — `validateTitleAvailableLocked`. This also covers CLI `af sessions create`, whose title routes through `daemon.CreateSession` → `reserveCreate` → `validateTitleAvailableLocked`.
- `session/backend_local.go`, `session/backend_hook.go` — the `Start` guards (`instance title cannot be empty`) get the same trim for defense-in-depth consistency on the session-start path.

## Adjacent-site audit
- `control.go:1228` (`title == ""` → fall back to `TitleBase`): a whitespace title is non-empty, so it correctly routes into the `else` branch and is rejected by `validateTitleAvailableLocked`. No change needed.
- `control.go` `findSession` (`title == ""`): a session **lookup**, not a creation gate; after the create-side fix no whitespace-titled session can exist, so trimming there would only change a "not found" into a different error. Left as-is.
- Task-name validation (`ui/task_pane.go`, `app/app.go`): a separate domain (tasks, not session titles) and already `strings.TrimSpace`-validated upstream in the form. Left as-is.

## Tests
- `TestHandleStateNewWhitespaceViaRealInput` (app): types three spaces then Enter via the real input handler; asserts the naming flow stays open and `namingInstance` is not submitted.
- `TestValidateTitleAvailableLockedRejectsWhitespace` (daemon): asserts the validator rejects `""`, `" "`, `"   "`, `"\t"`, `"\n  \t"` with `"session title is required"`.

Both confirmed **fail-before / pass-after** by reverting the production checks.

## Verification
`gofmt -l .` (clean), `go build ./...`, `golangci-lint run --timeout=3m --fast` (clean), `go test ./...` (all green), `deadcode -test ./...` (clean), and bounded race `GOFLAGS="-p=1" go test -race -parallel 2 ./app/... ./session/...` (green).

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)