### PR TITLE
fix(task): WaitForReady timeout case also fails fast on ErrSessionGone (#989)

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -88,6 +88,15 @@ func WaitForReady(instance *session.Instance) error {
 		case <-timeout:
 			content, err := instance.Preview()
 			if err != nil {
+				// Mirror the ticker case: ErrSessionGone is a definitive,
+				// non-retryable death, so surface the actionable "session died"
+				// cause even when it happens right at the timeout boundary —
+				// never the misleading generic timeout error (#979 fixed only
+				// the ticker case; #989 closes this gap so both Preview() call
+				// sites handle the sentinel identically).
+				if errors.Is(err, tmux.ErrSessionGone) {
+					return fmt.Errorf("session died while waiting for agent to start: %w", err)
+				}
 				log.ErrorLog.Printf("waitForReady timed out (preview also failed: %v)", err)
 				return formatWaitForReadyTimeoutError(waitForReadyTimeout, "")
 			}

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -365,6 +365,41 @@ func TestWaitForReadyFailsFastWhenSessionGone(t *testing.T) {
 	}
 }
 
+// TestWaitForReadyTimeoutCaseChecksErrSessionGone guards the second Preview()
+// call site (#989): if the session dies right at the timeout boundary so the
+// timeout case observes ErrSessionGone, WaitForReady must surface the same
+// actionable "session died" error (wrapping the sentinel) as the ticker case —
+// not a misleading generic timeout. Timing is set so the timeout (50ms) fires
+// before the first ticker tick (100ms), forcing the timeout branch.
+func TestWaitForReadyTimeoutCaseChecksErrSessionGone(t *testing.T) {
+	defer setWaitForReadyTimingForTest(50*time.Millisecond, 100*time.Millisecond)()
+
+	inst := newPreviewInstance(t, func() (string, error) {
+		return "", tmux.ErrSessionGone
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- WaitForReady(inst) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error when the session is gone, got nil")
+		}
+		if !errors.Is(err, tmux.ErrSessionGone) {
+			t.Fatalf("error must wrap tmux.ErrSessionGone, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "session died while waiting for agent to start") {
+			t.Fatalf("error must explain the session died, got %q", err.Error())
+		}
+		if strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("must not be a misleading timeout error, got %q", err.Error())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForReady did not return on ErrSessionGone in the timeout case")
+	}
+}
+
 // TestWaitForReadyKeepsPollingThroughTransientErrors guards the other half of
 // the fix: a transient (non-ErrSessionGone) Preview error must NOT abort the
 // loop — it keeps polling until the agent becomes ready.


### PR DESCRIPTION
## Root cause

`WaitForReady` in `task/runner.go` calls `instance.Preview()` in **both** `select` cases. When the tmux session disappears, `Preview()` returns the sentinel `tmux.ErrSessionGone` — a definitive, non-retryable death.

The ticker case (added in #979, closing #976) correctly detects `ErrSessionGone` and fails fast with the actionable `"session died while waiting for agent to start"` error wrapping the sentinel. The **timeout case did not** — it always returned the generic `formatWaitForReadyTimeoutError(...)`. So if the session died right at the 60s timeout boundary, users saw a misleading `"timed out waiting for program to start"` instead of the truth, and callers relying on `errors.Is(err, tmux.ErrSessionGone)` got the wrong answer.

This is the gap #979 left: the fail-fast principle was applied to only one of the two `Preview()` call sites.

## Fix

In the timeout case, check `errors.Is(err, tmux.ErrSessionGone)` and return the identical session-died error **before** falling back to the generic timeout error. Non-`ErrSessionGone` (transient) errors keep the existing timeout behavior.

## Adjacent-site audit

Per the lesson from #979 missing this: I audited every `Preview()` / pane-capture call site and every polling loop in `task/`.

- `grep` for `.Preview()` / `Capture` / `for {` / `ErrSessionGone` across `task/` (non-test) returns **only** the two `Preview()` calls inside `WaitForReady` (timeout + ticker) and that single `for {` loop.
- Both call sites now handle `ErrSessionGone` identically. No other polling loop or capture site exists in `task/`.

## Tests

Adds `TestWaitForReadyTimeoutCaseChecksErrSessionGone` (the failing test from the issue): timing is set so the timeout (50ms) fires before the first ticker tick (100ms), forcing the **timeout** branch; `Preview()` returns `ErrSessionGone`; the test asserts the result wraps the sentinel and says `"session died"`, not `"timed out"`. Hermetic (FakeBackend, no tmux/git).

- **Fail-before** (fix reverted): `error must wrap tmux.ErrSessionGone, got timed out waiting for program to start (50ms)` — matches the issue's reported output.
- **Pass-after**: all four `WaitForReady` tests pass.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — all green
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./task/...` — ok

Closes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude