### PR TITLE
fix(daemon): AutoYes taps Enter immediately on prompt detection even when output updated (#992)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1048,14 +1048,23 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	instance.CheckAndHandleTrustPrompt()
 	before := instance.GetStatus()
 	updated, hasPrompt := instance.HasUpdated()
+	if hasPrompt {
+		// Tap enter whenever a prompt is waiting (TapEnter is a no-op unless
+		// AutoYes is on), independent of `updated` — exactly as the pre-#965
+		// AutoYes loop did with `if _, hasPrompt := instance.HasUpdated(); …`.
+		// A prompt's text is itself fresh output, so a just-appeared prompt
+		// commonly reports (updated, hasPrompt) == (true, true); folding the tap
+		// into the switch below `case updated` swallowed it on that first tick
+		// and only tapped on the next poll — a one-interval AutoYes delay (#992).
+		instance.TapEnter()
+	}
 	switch {
 	case updated:
 		instance.SetStatusIfNotDeleting(session.Running)
 	case hasPrompt:
-		// A waiting prompt: tap enter when AutoYes is on (TapEnter is a no-op
-		// otherwise) and leave the status for the next tick to resolve, exactly
-		// as runMetadataTick did.
-		instance.TapEnter()
+		// A waiting prompt with otherwise-unchanged output: leave the status for
+		// the next tick to resolve, exactly as runMetadataTick did. The
+		// prompt-tap already fired above regardless of `updated`.
 	case !instance.TmuxAlive():
 		// HasUpdated returned (false,false), which a healthy idle session and a
 		// dead one both produce — indistinguishable on their own. Probe liveness

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -30,6 +30,31 @@ type promptTapBackend struct {
 func (b *promptTapBackend) HasUpdated(*session.Instance) (bool, bool) { return false, true }
 func (b *promptTapBackend) TapEnter(*session.Instance)                { b.tapped++ }
 
+// bothFlagsBackend reports (updated, hasPrompt) == (true, true) — the state a
+// freshly-appeared prompt commonly produces, because the prompt text is itself
+// new output — and counts TapEnter calls. It guards the #992 regression: the
+// pre-#965 AutoYes loop tapped Enter whenever hasPrompt was true regardless of
+// updated, but the merged switch matched `case updated` first and swallowed the
+// tap on that first tick.
+type bothFlagsBackend struct {
+	*session.FakeBackend
+	tapped int
+}
+
+func (b *bothFlagsBackend) HasUpdated(*session.Instance) (bool, bool) { return true, true }
+func (b *bothFlagsBackend) TapEnter(*session.Instance)                { b.tapped++ }
+
+// updatedOnlyBackend reports (updated, hasPrompt) == (true, false): live output
+// churn with no waiting prompt. It counts TapEnter so the status-only path can
+// be asserted to transition to Running WITHOUT tapping Enter.
+type updatedOnlyBackend struct {
+	*session.FakeBackend
+	tapped int
+}
+
+func (b *updatedOnlyBackend) HasUpdated(*session.Instance) (bool, bool) { return true, false }
+func (b *updatedOnlyBackend) TapEnter(*session.Instance)                { b.tapped++ }
+
 // registerStarted seeds a single on-disk record and registers a live in-memory
 // instance with the supplied backend and starting status under the daemon's key.
 // One instance per repo: seedDiskInstance overwrites the repo file, so callers
@@ -173,6 +198,48 @@ func TestRefreshStatuses_TapsEnterOnWaitingPrompt(t *testing.T) {
 	inst := manager.instances[daemonInstanceKey(repoID, "prompted")]
 	if got := inst.GetStatus(); got != session.Running {
 		t.Fatalf("status = %v, want Running (a waiting-prompt session keeps its status)", got)
+	}
+}
+
+// TestRefreshStatuses_TapsEnterWhenUpdatedAndPrompt is the #992 regression guard:
+// when HasUpdated reports (true, true) — the usual shape on the first tick a
+// prompt appears, since the prompt text is fresh output — AutoYes must still tap
+// Enter on that tick, not one poll interval later. The merged switch matched
+// `case updated` before `case hasPrompt`, so the tap was swallowed until the
+// next poll once output stabilized. Status is still set Running by the updated
+// branch (left as-is from before this fix).
+func TestRefreshStatuses_TapsEnterWhenUpdatedAndPrompt(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &bothFlagsBackend{FakeBackend: session.NewFakeBackend()}
+	registerStarted(t, manager, repoID, repoPath, "both-flags", backend, true, session.Running)
+
+	manager.RefreshStatuses()
+
+	if backend.tapped == 0 {
+		t.Fatal("BUG (#992): TapEnter was not called when HasUpdated returned (true, true)")
+	}
+	inst := manager.instances[daemonInstanceKey(repoID, "both-flags")]
+	if got := inst.GetStatus(); got != session.Running {
+		t.Fatalf("status = %v, want Running (the updated branch still sets Running)", got)
+	}
+}
+
+// TestRefreshStatuses_UpdatedWithoutPromptDoesNotTap is the complement: pure
+// output churn (true, false) must transition the session to Running WITHOUT
+// tapping Enter — only a waiting prompt drives AutoYes.
+func TestRefreshStatuses_UpdatedWithoutPromptDoesNotTap(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &updatedOnlyBackend{FakeBackend: session.NewFakeBackend()}
+	registerStarted(t, manager, repoID, repoPath, "updated-only", backend, true, session.Ready)
+
+	manager.RefreshStatuses()
+
+	if backend.tapped != 0 {
+		t.Fatalf("TapEnter called %d times for (updated, hasPrompt)==(true,false); AutoYes must only tap on a waiting prompt", backend.tapped)
+	}
+	inst := manager.instances[daemonInstanceKey(repoID, "updated-only")]
+	if got := inst.GetStatus(); got != session.Running {
+		t.Fatalf("status = %v, want Running (updated output drives Running)", got)
 	}
 }
 


### PR DESCRIPTION
## Root cause

#965 (commit `a584df6`) merged the daemon's separate AutoYes loop into `RefreshStatuses` / `refreshInstanceStatus`, with a commit message promising "AutoYes is unchanged." The merge put the prompt-tap inside a `switch`:

```go
updated, hasPrompt := instance.HasUpdated()
switch {
case updated:
    instance.SetStatusIfNotDeleting(session.Running) // matches first
case hasPrompt:
    instance.TapEnter()                              // shadowed
...
}
```

A freshly-appeared prompt's text **is** new output, so on the first tick a prompt shows, `HasUpdated()` commonly returns `(updated, hasPrompt) == (true, true)`. Because `case updated` matches first, `TapEnter()` was skipped on that tick and only fired on the **next** poll once output stabilized — a one-poll-interval AutoYes delay.

The pre-#965 loop tapped Enter whenever `hasPrompt` was true, explicitly discarding `updated`:

```go
if _, hasPrompt := instance.HasUpdated(); hasPrompt {
    instance.TapEnter()
}
```

## Fix

Hoist the prompt-tap out of the `switch` so it fires on `hasPrompt` regardless of `updated`. The status `switch` is otherwise untouched — the `hasPrompt` branch still leaves status for the next tick to resolve, so the Running/Ready/Dead transitions are preserved exactly. Only the tap timing is restored.

## Adjacent-site audit

`instance.TapEnter()` has exactly one production caller — `refreshInstanceStatus` — reached only through `RefreshStatuses`, which the daemon poll loop (`daemon/daemon.go`) invokes once per instance per tick. The old standalone AutoYes loop was deleted in #965, so no other AutoYes path survives. This change alters only **when** the single tap fires, never **how many times** — there is no double-tap or mis-order risk.

## Tests (hermetic, `daemon/status_test.go`)

- **`TestRefreshStatuses_TapsEnterWhenUpdatedAndPrompt`** — the failing test from the issue: a backend whose `HasUpdated` returns `(true, true)` must tap Enter and still transition to Running. Confirmed **fails before** the fix (`BUG (#992): TapEnter was not called…`), **passes after**.
- **`TestRefreshStatuses_UpdatedWithoutPromptDoesNotTap`** — `(true, false)` goes Running and must **not** tap.
- Existing **`TestRefreshStatuses_TapsEnterOnWaitingPrompt`** covers `(false, true)` (taps, status left as-is).

## Verification

`gofmt -l .` (clean), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `go test ./...`, `deadcode -test ./...` — all clean. Bounded race: `GOFLAGS="-p=1" go test -race -parallel 2 ./daemon/...` passes.

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude