### PR TITLE
fix(app): instance-start help only advertises supported tab keys for remote instances (#988)

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -77,6 +77,15 @@ func (h helpTypeGeneral) toContent() string {
 }
 
 func (h helpTypeInstanceStart) toContent() string {
+	// Remote instances block `t` (new tab) and `w` (close tab) — those actions
+	// surface a "not available for remote" error (see handleNewTab /
+	// handleCloseTab in app/handle_actions.go) — so only advertise the tab keys
+	// that actually work for the instance type. Tab cycling and 1-9 jump work
+	// for both (#988).
+	tabHelp := keyStyle.Render("tab") + descStyle.Render("   - Switch between tabs (t new tab, w close, 1-9 jump)")
+	if h.instance.IsRemote() {
+		tabHelp = keyStyle.Render("tab") + descStyle.Render("   - Switch between tabs (1-9 jump)")
+	}
 	content := lipgloss.JoinVertical(lipgloss.Left,
 		titleStyle.Render("Instance Created"),
 		"",
@@ -88,7 +97,7 @@ func (h helpTypeInstanceStart) toContent() string {
 		"",
 		headerStyle.Render("Managing:"),
 		keyStyle.Render("↵/o")+descStyle.Render("   - Attach to the session to interact with it directly"),
-		keyStyle.Render("tab")+descStyle.Render("   - Switch between tabs (t new tab, w close, 1-9 jump)"),
+		tabHelp,
 		keyStyle.Render("D")+descStyle.Render("     - Kill (delete) the selected session"),
 	)
 	return content

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -3,6 +3,9 @@ package app
 import (
 	"strings"
 	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
 )
 
 // TestGeneralHelpNavigationMatchesBindings guards against regressing #764, where
@@ -16,5 +19,32 @@ func TestGeneralHelpNavigationMatchesBindings(t *testing.T) {
 	}
 	if strings.Contains(content, "↑/j, ↓/k") {
 		t.Errorf("help content contains reversed navigation label \"↑/j, ↓/k\" (see #764); got:\n%s", content)
+	}
+}
+
+// TestInstanceStartHelpRemoteOmitsUnsupportedTabKeys guards against regressing
+// #988: remote instances block `t` (new tab) and `w` (close tab) — those
+// handlers reject IsRemote() with an error — so the instance-start help must
+// only advertise the tab keys that actually work (cycle / 1-9 jump). Local
+// instances keep the full hint.
+func TestInstanceStartHelpRemoteOmitsUnsupportedTabKeys(t *testing.T) {
+	remote := newStartedInstance(t, "remote")
+	remote.SetBackend(&session.HookBackend{})
+	require.True(t, remote.IsRemote(), "sanity: instance should report as remote")
+
+	remoteContent := helpStart(remote).toContent()
+	if strings.Contains(remoteContent, "t new tab") || strings.Contains(remoteContent, "w close") {
+		t.Errorf("remote instance-start help must not advertise unsupported t/w tab keys; got:\n%s", remoteContent)
+	}
+	if !strings.Contains(remoteContent, "1-9 jump") {
+		t.Errorf("remote instance-start help should still advertise the supported 1-9 jump; got:\n%s", remoteContent)
+	}
+
+	local := newStartedInstance(t, "local")
+	require.False(t, local.IsRemote(), "sanity: instance should report as local")
+
+	localContent := helpStart(local).toContent()
+	if !strings.Contains(localContent, "t new tab") || !strings.Contains(localContent, "w close") {
+		t.Errorf("local instance-start help should advertise the full t/w/1-9 tab hint; got:\n%s", localContent)
 	}
 }

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -184,8 +184,14 @@ func (m *Menu) addInstanceOptions() {
 	actionGroup = append(actionGroup, keys.KeyShiftUp)
 	actionGroup = append(actionGroup, keys.KeyShiftDown)
 
-	// Tab group: cycle, create, close, and number-jump (#930 PR 4).
+	// Tab group: cycle, create, close, and number-jump (#930 PR 4). Remote
+	// instances block `t` (new tab) and `w` (close tab) — those handlers reject
+	// IsRemote() with an error — so only advertise the tab keys that actually
+	// work: cycle and number-jump (#988).
 	tabGroup := []keys.KeyName{keys.KeyTab, keys.KeyNewTab, keys.KeyCloseTab, keys.KeyJumpTab}
+	if m.instance != nil && m.instance.IsRemote() {
+		tabGroup = []keys.KeyName{keys.KeyTab, keys.KeyJumpTab}
+	}
 
 	// System group
 	systemGroup := []keys.KeyName{keys.KeyHelp, keys.KeyQuit}

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -60,3 +60,57 @@ func TestMenuPreviewTabShowsBothScrollKeys(t *testing.T) {
 		t.Errorf("expected exactly 1 KeyShiftDown in preview tab menu, got %d", gotShiftDown)
 	}
 }
+
+// TestMenuRemoteInstanceOmitsUnsupportedTabKeys guards against regressing #988:
+// remote instances block `t` (new tab) and `w` (close tab) — those handlers
+// reject IsRemote() with an error — so the footer menu must only surface the
+// tab keys that actually work (cycle / 1-9 jump), while local instances keep
+// the full set.
+func TestMenuRemoteInstanceOmitsUnsupportedTabKeys(t *testing.T) {
+	remote := &session.Instance{Status: session.Ready}
+	remote.SetBackend(&session.HookBackend{})
+	if !remote.IsRemote() {
+		t.Fatal("sanity: instance should report as remote")
+	}
+
+	m := NewMenu()
+	m.SetInstance(remote)
+
+	var gotNewTab, gotCloseTab, gotTab, gotJump int
+	for _, k := range m.options {
+		switch k {
+		case keys.KeyNewTab:
+			gotNewTab++
+		case keys.KeyCloseTab:
+			gotCloseTab++
+		case keys.KeyTab:
+			gotTab++
+		case keys.KeyJumpTab:
+			gotJump++
+		}
+	}
+	if gotNewTab != 0 || gotCloseTab != 0 {
+		t.Errorf("remote menu must not surface t/w tab keys; got newTab=%d closeTab=%d", gotNewTab, gotCloseTab)
+	}
+	if gotTab != 1 || gotJump != 1 {
+		t.Errorf("remote menu should still surface tab cycle and 1-9 jump; got tab=%d jump=%d", gotTab, gotJump)
+	}
+
+	local := &session.Instance{Status: session.Ready}
+	if local.IsRemote() {
+		t.Fatal("sanity: instance should report as local")
+	}
+	m.SetInstance(local)
+	var localNewTab, localCloseTab int
+	for _, k := range m.options {
+		switch k {
+		case keys.KeyNewTab:
+			localNewTab++
+		case keys.KeyCloseTab:
+			localCloseTab++
+		}
+	}
+	if localNewTab != 1 || localCloseTab != 1 {
+		t.Errorf("local menu should surface t/w tab keys; got newTab=%d closeTab=%d", localNewTab, localCloseTab)
+	}
+}


### PR DESCRIPTION
## Root cause

`helpTypeInstanceStart.toContent()` (app/help.go) unconditionally printed:

> Switch between tabs (**t new tab, w close**, 1-9 jump)

But remote instances **block** `t` and `w` — `handleNewTab` and `handleCloseTab`
(app/handle_actions.go:360, :407) reject `IsRemote()` with a "not available for
remote" error. Tab cycling (`tab`) and `1-9` jump are not gated, so they work
for both instance types. Result: remote-session help advertised two keys that
only produce an error, adding avoidable friction at session start.

Introduced in #955 / commit e20f75d.

## Fix

- **app/help.go** — tab-help line is now conditional on `instance.IsRemote()`.
  Remote shows `Switch between tabs (1-9 jump)`; local keeps the full
  `(t new tab, w close, 1-9 jump)` hint. Same keyStyle/descStyle rendering.

## Adjacent-site audit

Grepped help/keybinding text for other places advertising `t`/`w`/tab actions
where remote gates them:

- **ui/menu.go (footer menu)** — FIXED. `addInstanceOptions` builds the tab
  group from `m.instance` (instance-contextual) and included
  `KeyNewTab`/`KeyCloseTab` unconditionally, so the footer advertised t/w even
  when the selected instance is remote — the exact same bug. Now drops t/w for
  remote instances, keeping cycle + 1-9 jump.
- **app/help.go `helpTypeGeneral` (main help screen)** — LEFT AS-IS
  (justified). This is global, instance-agnostic documentation of the full key
  set, not tied to a specific instance's remote-ness, so documenting `t`/`w` is
  correct there.
- **keys/keys.go** — binding definitions (`WithHelp`), not contextual surfaces;
  no change needed.

## Tests

- `app/help_test.go::TestInstanceStartHelpRemoteOmitsUnsupportedTabKeys` —
  remote instance-start help omits `t new tab`/`w close` and keeps `1-9 jump`;
  local keeps the full hint.
- `ui/menu_test.go::TestMenuRemoteInstanceOmitsUnsupportedTabKeys` — remote
  footer menu omits `KeyNewTab`/`KeyCloseTab` and keeps `KeyTab`/`KeyJumpTab`;
  local keeps t/w.

## Verification

`gofmt -l .` (clean), `go build ./...`, `golangci-lint run --timeout=3m --fast`
(clean), `go test ./...` (pass), `deadcode -test ./...` (clean), bounded race
`GOFLAGS="-p=1" go test -race -parallel 2 ./app/... ./ui/` (pass).

Closes #988

— Captain Claude