### PR TITLE
fix(session): AddProcessTab/AddShellTab re-check started after spawn to avoid leaking a tmux session that races KillSession (#990)

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
@@ -255,8 +256,27 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 	tab := newShellTab(shellTmux)
 	tab.Name = displayName
 	i.mu.Lock()
-	i.Tabs = append(i.Tabs, tab)
+	// Re-check started under the write lock before appending: we released the
+	// lock to spawn, and Kill (which does NOT take repoStartLock, so it is not
+	// serialized against CreateTab) can have flipped started=false and snapshotted
+	// Tabs for teardown in that window. Appending now would leak a tmux session
+	// that escapes Kill's teardown while its worktree is deleted (#990). Make the
+	// recheck and append atomic under one acquisition so no further race opens.
+	killed := !i.started
+	title := i.Title
+	if !killed {
+		i.Tabs = append(i.Tabs, tab)
+	}
 	i.mu.Unlock()
+	if killed {
+		// Tear down the just-spawned session so it does not outlive the worktree
+		// Kill is removing. Close is best-effort/idempotent (#967): a kill-session
+		// on an already-gone session is not an error.
+		if cerr := shellTmux.Close(); cerr != nil {
+			log.WarningLog.Printf("add shell tab to %q: closing orphaned tmux after kill race: %v", title, cerr)
+		}
+		return nil, fmt.Errorf("session was killed during tab creation")
+	}
 	return tab, nil
 }
 
@@ -307,8 +327,24 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 
 	tab := &Tab{Name: displayName, Kind: TabKindProcess, Command: command, tmux: procTmux}
 	i.mu.Lock()
-	i.Tabs = append(i.Tabs, tab)
+	// Re-check started under the write lock before appending (see AddShellTab):
+	// Kill can have flipped started=false and snapshotted Tabs for teardown while
+	// we spawned outside the lock, so appending now would leak a tmux session whose
+	// worktree Kill then deletes (#990). Recheck + append are atomic under one
+	// acquisition.
+	killed := !i.started
+	title := i.Title
+	if !killed {
+		i.Tabs = append(i.Tabs, tab)
+	}
 	i.mu.Unlock()
+	if killed {
+		// Best-effort/idempotent teardown of the orphaned session (#967).
+		if cerr := procTmux.Close(); cerr != nil {
+			log.WarningLog.Printf("add process tab to %q: closing orphaned tmux after kill race: %v", title, cerr)
+		}
+		return nil, fmt.Errorf("session was killed during tab creation")
+	}
 	return tab, nil
 }
 

--- a/session/tab_kill_race_test.go
+++ b/session/tab_kill_race_test.go
@@ -1,0 +1,183 @@
+package session
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// raceHookExec is nameKeyedExec plus a hook that fires the first time a tmux
+// session is created with `onNewSession`. It lets a test deterministically
+// inject a concurrent Kill (flipping started=false) in the exact window
+// AddShellTab/AddProcessTab open between spawning the sibling tmux session and
+// re-acquiring the lock to append the tab (#990). It also exposes session
+// existence so a test can assert the spawned session was torn down (no orphan).
+func raceHookExec(alive map[string]bool, onNewSession func()) (cmd_test.MockCmdExec, func(name string) bool) {
+	existing := map[string]bool{}
+	for k, v := range alive {
+		existing[k] = v
+	}
+	nameOf := func(cmd *exec.Cmd) string {
+		for i, a := range cmd.Args {
+			switch {
+			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
+				return cmd.Args[i+1]
+			case strings.HasPrefix(a, "-t="):
+				return strings.TrimPrefix(a, "-t=")
+			case strings.HasPrefix(a, "-s="):
+				return strings.TrimPrefix(a, "-s=")
+			}
+		}
+		return ""
+	}
+	fired := false
+	exec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			s := cmd.String()
+			n := nameOf(cmd)
+			switch {
+			case strings.Contains(s, "has-session"):
+				if existing[n] {
+					return nil
+				}
+				return assertNoSession
+			case strings.Contains(s, "new-session"):
+				existing[n] = true
+				// Simulate Kill racing in after the spawn but before the append.
+				if !fired && onNewSession != nil {
+					fired = true
+					onNewSession()
+				}
+				return nil
+			case strings.Contains(s, "kill-session"):
+				delete(existing, n)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return []byte("content"), nil
+		},
+	}
+	isAlive := func(name string) bool { return existing[name] }
+	return exec, isAlive
+}
+
+// raceMockInstance is startedMockInstance wired to raceHookExec: when the next
+// sibling session is spawned, onNewSession runs (a test uses this to flip
+// started=false, standing in for a concurrent KillSession). isAlive reports
+// whether a tmux session name currently exists, so the test can assert the
+// orphan was torn down.
+func raceMockInstance(t *testing.T, agentName string, onNewSession func()) (*Instance, func(name string) bool) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	exec, isAlive := raceHookExec(map[string]bool{agentName: true}, onNewSession)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+
+	repoPath := "/tmp/tab-kill-race-" + agentName
+	gw, err := git.NewGitWorktreeFromStorage(
+		repoPath, filepath.Join(t.TempDir(), "wt"), agentName,
+		agentName+"-branch", "", false, true)
+	require.NoError(t, err)
+
+	agentTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps(agentName, "claude", pty, exec)
+	inst := &Instance{
+		Title:       agentName,
+		Path:        repoPath,
+		Program:     "claude",
+		backend:     &LocalBackend{},
+		started:     true,
+		gitWorktree: gw,
+		Tabs:        []*Tab{newAgentTab(agentTs)},
+	}
+	return inst, isAlive
+}
+
+// flipStarted clears started under the same lock Kill uses, so the recheck in
+// AddShellTab/AddProcessTab observes a killed instance — the deterministic
+// stand-in for a concurrent KillSession (#990).
+func flipStarted(i *Instance) {
+	i.mu.Lock()
+	i.started = false
+	i.mu.Unlock()
+}
+
+// TestAddShellTab_KillRaceDoesNotLeakSession verifies the #990 fix: if the
+// session is killed (started flipped false) after the shell tab's tmux session
+// is spawned but before it is appended, AddShellTab must NOT append the tab,
+// MUST tear down the spawned tmux session (no orphan referencing the deleted
+// worktree), and MUST return an error.
+func TestAddShellTab_KillRaceDoesNotLeakSession(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	const agentName = "af_shell_killrace"
+	var inst *Instance
+	var isAlive func(string) bool
+	inst, isAlive = raceMockInstance(t, agentName, func() { flipStarted(inst) })
+
+	tab, err := inst.AddShellTab()
+	require.Error(t, err, "a tab created during teardown must be refused")
+	assert.Contains(t, err.Error(), "session was killed during tab creation")
+	assert.Nil(t, tab)
+	assert.Equal(t, 1, inst.TabCount(), "the raced tab must not be appended")
+
+	orphan := agentName + "__" + shellTabName
+	assert.False(t, isAlive(orphan), "the spawned tmux session must be torn down (no orphan)")
+}
+
+// TestAddProcessTab_KillRaceDoesNotLeakSession is the AddProcessTab counterpart
+// of the shell-tab kill-race test (#990): the same TOCTOU window was copied to
+// AddProcessTab, so it must enforce the same recheck-and-teardown.
+func TestAddProcessTab_KillRaceDoesNotLeakSession(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	const agentName = "af_proc_killrace"
+	var inst *Instance
+	var isAlive func(string) bool
+	inst, isAlive = raceMockInstance(t, agentName, func() { flipStarted(inst) })
+
+	tab, err := inst.AddProcessTab("btop", "")
+	require.Error(t, err, "a process tab created during teardown must be refused")
+	assert.Contains(t, err.Error(), "session was killed during tab creation")
+	assert.Nil(t, tab)
+	assert.Equal(t, 1, inst.TabCount(), "the raced tab must not be appended")
+
+	orphan := agentName + "__btop"
+	assert.False(t, isAlive(orphan), "the spawned tmux session must be torn down (no orphan)")
+}
+
+// TestAddTab_NoKillRaceStillAppends verifies the fix does not regress the happy
+// path: with no concurrent kill, both AddShellTab and AddProcessTab still spawn,
+// append, and return a live tab.
+func TestAddTab_NoKillRaceStillAppends(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, isAlive := raceMockInstance(t, "af_no_killrace", nil)
+
+	shell, err := inst.AddShellTab()
+	require.NoError(t, err)
+	require.NotNil(t, shell)
+	assert.Equal(t, shellTabName, shell.Name)
+	assert.Equal(t, 2, inst.TabCount())
+	assert.True(t, isAlive("af_no_killrace__"+shellTabName), "the shell tab session must be live")
+
+	proc, err := inst.AddProcessTab("btop", "")
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+	assert.Equal(t, "btop", proc.Name)
+	assert.Equal(t, 3, inst.TabCount())
+	assert.True(t, isAlive("af_no_killrace__btop"), "the process tab session must be live")
+}


### PR DESCRIPTION
## Root cause

`CreateTab` (daemon RPC) and `KillSession` (daemon RPC) race on the same authoritative `Instance`, producing an orphaned tmux session over a deleted worktree (#990, introduced in #955/#956).

Both `AddShellTab` and `AddProcessTab` followed the same shape:

1. read `i.started` under `RLock`, then **release** the lock,
2. spawn the sibling tmux session **outside** the lock (`tmux new-session` shells out and polls — must not block readers),
3. re-acquire `Lock` and `append` to `i.Tabs` — **without re-checking `i.started`**.

Meanwhile `LocalBackend.Kill` takes `Lock`, snapshots `i.Tabs`, sets `i.started = false`, unlocks, tears down **only the snapshot**, then deletes the worktree.

If the spawn finishes after Kill's snapshot but before the append, the new tab lands in `i.Tabs` after the snapshot, so it escapes teardown. The tmux session survives while its worktree is removed → orphan session + a broken tab on daemon restart.

`repoStartLock` does **not** serialize this: `CreateTab` takes `repoStartLock` but `KillSession` calls `instance.Kill()` directly without it.

## Fix (localized started-recheck)

After the spawn and before the append, re-check `i.started` under the **same** `Lock` used for the append. If the session was killed during the spawn, close the just-created tmux session (best-effort/idempotent teardown, #967) and return `"session was killed during tab creation"` instead of appending.

The recheck and append are atomic under one `i.mu` acquisition, and that is the **same lock** Kill uses to snapshot `i.Tabs` + flip `started`. So the two paths are fully serialized — whichever acquires first:

- **Add wins the lock first:** appends while `started` is still true; Kill's later snapshot sees the tab and tears it down. No orphan.
- **Kill wins the lock first:** `started` is already false when Add re-checks, so Add does not append and closes its own session. No orphan.

## Adjacent-site audit

- **`AddShellTab` + `AddProcessTab`** — the two sites with the bug (the pattern originated in `AddShellTab`, #955, and was copied to `AddProcessTab`, #956). Both fixed here. These are the only callers reachable from the daemon's `CreateTab` RPC (`daemon/control.go`), i.e. the only ones that race the daemon's `KillSession`.
- **`AttachShellTab` / `ReconcileTabsFromData`** — same check→unlock→spawn/restore→relock→append shape, **but** they are TUI-side projection paths (`app/handle_actions.go`, `app/sync.go`), not invoked by the daemon. In the single-writer model (#960) the daemon owns the worktree teardown; the TUI projection never deletes a worktree, so they cannot produce the #990 orphan-over-deleted-worktree class. (`ReconcileTabsFromData` already re-checks under the write lock for name collisions.) Left unchanged to keep the PR focused; noted for the record.

**Why not also serialize Kill under `repoStartLock`?** Unnecessary and riskier. The recheck fully closes the window because recheck+append share `i.mu` with Kill's snapshot+started-flip — adding `repoStartLock` to the kill path would broaden lock scope and invite ordering hazards without removing any remaining race.

## Tests (hermetic, no real tmux)

`session/tab_kill_race_test.go` — a mock `cmdExec` flips `started=false` (standing in for `KillSession`) on the sibling's `new-session`, i.e. exactly in the window after the spawn and before the append:

- `TestAddShellTab_KillRaceDoesNotLeakSession` / `TestAddProcessTab_KillRaceDoesNotLeakSession`: the raced tab is **not** appended, the spawned tmux session **is** torn down (asserted via the mock's session-existence map — no orphan), and an error is returned.
- `TestAddTab_NoKillRaceStillAppends`: the happy path still spawns, appends, and returns a live tab for both tab kinds.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — green
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./session/... ./daemon/...` — green (race detector matters here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)