### PR TITLE
fix(session): restore creates a fresh shell when the persisted shell tab is not live (#991)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -244,7 +244,13 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 		if err := tab.tmux.Restore(worktreePath); err != nil {
 			log.WarningLog.Printf("restore tab %q for %q failed: %v", tab.Name, i.Title, err)
 		}
-		if tab.Kind == TabKindShell {
+		// Only count a shell tab as live when its tmux session actually exists
+		// server-side after Restore. Restore (and its re-spawn) can fail — e.g.
+		// the worktree was removed so `tmux new-session -c $workdir` errors —
+		// leaving a dead shell tab. Gating on presence alone (the old behavior)
+		// suppressed the fresh-shell fallback below and stranded the user with a
+		// dead terminal (#991).
+		if tab.Kind == TabKindShell && tab.tmux.DoesSessionExist() {
 			hasLiveShell = true
 		}
 	}

--- a/session/dead_respawn_test.go
+++ b/session/dead_respawn_test.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -125,6 +127,76 @@ func TestDeadInstance_NotRespawnedOnLoad(t *testing.T) {
 		"a Dead instance must load started=true so SaveInstances keeps it on disk")
 	assert.False(t, restored.TabAlive(0),
 		"the Dead agent session must not exist server-side after load")
+}
+
+// failFirstNewSessionPty is a PtyFactory that fails the first `tmux new-session`
+// it sees and forwards every other command to the mock executor (like
+// persistPtyFactory). It reproduces a persisted shell tab whose re-spawn fails
+// — e.g. the worktree was removed so `tmux new-session -c $workdir` errors —
+// while letting a subsequent fresh-shell creation succeed.
+type failFirstNewSessionPty struct {
+	t       *testing.T
+	cmdExec cmd_test.MockCmdExec
+	count   *int
+}
+
+func (p failFirstNewSessionPty) Start(cmd *exec.Cmd) (*os.File, error) {
+	if strings.Contains(cmd.String(), "new-session") {
+		*p.count++
+		if *p.count == 1 {
+			// Simulate the dead shell's re-spawn failing (vanished worktree).
+			// Returning an error here makes TmuxSession.Start fail fast without
+			// marking the session live, so the session stays absent server-side.
+			return nil, fmt.Errorf("new-session failed: worktree gone")
+		}
+	}
+	f, err := os.CreateTemp(p.t.TempDir(), "pty-")
+	if err == nil {
+		_ = p.cmdExec.Run(cmd)
+	}
+	return f, err
+}
+
+func (p failFirstNewSessionPty) Close() {}
+
+// TestRunningInstance_DeadShellTabReplacedWithFreshShellOnLoad is the #991
+// regression, exercised through the production path (FromInstanceData ->
+// Start(false) -> setupTabs). A Running instance restores with a live agent tab
+// but a shell tab whose tmux session is gone and whose re-spawn fails. Restore
+// must NOT leave that dead shell tab in place: with no LIVE shell after restore,
+// setupTabs must create a fresh default shell so the user lands on a working
+// terminal. Before the fix, hasLiveShell was set on tab presence alone, the
+// fallback was skipped, and TabAlive(1) stayed false (a dead terminal).
+func TestRunningInstance_DeadShellTabReplacedWithFreshShellOnLoad(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_991_agent"
+	shellName := agentName + shellTmuxSuffix
+
+	// The agent session is alive (reconnect path); the shell session is gone, so
+	// its restore hits the re-spawn branch — which the PTY fails on the first
+	// new-session. A later fresh-shell new-session succeeds.
+	var newSessions, ptyNewSessions int
+	exec := countingExec(map[string]bool{agentName: true}, &newSessions)
+	pty := failFirstNewSessionPty{t: t, cmdExec: exec, count: &ptyNewSessions}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	restored, err := FromInstanceData(deadInstanceData(t, Running, agentName, shellName))
+	require.NoError(t, err)
+
+	assert.True(t, restored.TabAlive(0), "the live agent tab must stay reconnected")
+	assert.True(t, restored.TabAlive(1),
+		"restore must replace the dead shell tab with a freshly-created live shell (#991)")
+	assert.Equal(t, 1, newSessions,
+		"exactly one fresh shell session must be spawned (the failed re-spawn never counted)")
+	assert.Equal(t, Running, restored.GetStatus())
+	assert.True(t, restored.Started())
 }
 
 // TestLiveInstance_RespawnsMissingSessionOnLoad guards the seam from the other


### PR DESCRIPTION
## Summary

During session restore, `setupTabs` set `hasLiveShell = true` for **any** persisted shell tab, regardless of whether its tmux session actually came back. For a `Running` instance whose shell tab restore — and its re-spawn — failed (e.g. the worktree was removed, so `tmux new-session -c $workdir` errors), the presence-based flag took the early-return path and **suppressed the fresh-shell fallback**, stranding the user on a dead terminal that they had to manually close and recreate. This violated the documented restore behavior (when no live shell exists, create a fresh default `$SHELL` tab).

Introduced in #955.

## Root cause

`session/backend_local.go` `setupTabs`:

```go
if tab.Kind == TabKindShell {   // counts a shell tab as live even if Restore() failed
    hasLiveShell = true
}
```

`hasLiveShell` is meant to skip duplicate-shell creation only when a **live** shell exists, but it was gated on tab *presence*, not session *liveness*.

## Fix

Gate on `DoesSessionExist()` so a shell counts as live only when its tmux session exists server-side after `Restore`:

```go
if tab.Kind == TabKindShell && tab.tmux.DoesSessionExist() {
    hasLiveShell = true
}
```

(The `tab.tmux != nil` check from the issue's suggestion is redundant — the loop already `continue`s when `tab.tmux == nil`.) When no live shell remains, the fallback creates a fresh default `$SHELL` tab as documented.

## Interaction with #970

This composes cleanly with the #970 Dead-instance guard at the top of `LocalBackend.Start` (`if i.GetStatus() == Dead { return }`): the `setupTabs` restore path only runs for **non-Dead (Running)** instances — exactly the repro. A Dead corpse is never resurrected; a Running instance with a dead shell tab now gets a fresh live one.

## Adjacent-site audit

The "presence counts as live → suppress fallback" anti-pattern is **unique to `setupTabs`**. The other `Restore` call sites handle failure correctly:

- **`backend_local.go:173` (agent tab restore)** — a failed restore sets `setupErr` and fails the whole `Start` (deferred `CloseAttachOnly`); there is no presence-based fallback to suppress.
- **`instance.go:385` (`AddTab` shell)** — propagates the `Restore` error to the caller; no liveness gate.
- **`instance.go:482` (reconcile / sync-from-daemon)** — only appends the tab **after** a successful `Restore`; on failure it records the error and `continue`s, never inserting a dead tab.

## Test

Added `TestRunningInstance_DeadShellTabReplacedWithFreshShellOnLoad` — the production path `FromInstanceData()` → `Start(false)` → `setupTabs()`. A `Running` instance restores with a live agent tab but a shell tab whose session is gone and whose re-spawn fails; after restore the shell tab must be a freshly-created **live** shell (`TabAlive(1) == true`), with exactly one fresh shell session spawned. Hermetic via a `PtyFactory` that fails the first `new-session` (the dead shell's re-spawn) and lets the fallback's `new-session` succeed; `restoreTmuxSession` is overridden to keep all tmux interactions mock-backed.

Confirmed **fails before** the fix (`TabAlive(1) == false`, no fresh shell) and **passes after**.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — green
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./session/...` — green

Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude
