### PR TITLE
fix(setup): anchor the alias-probe `->` regex so .bashrc noise cannot corrupt first-run config (#1003)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,15 @@ const (
 	defaultDaemonPollInterval = 1000
 )
 
-var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|->|^[^/=\s]+\s*=)\s*(.+)`)
+// aliasOutputRegex extracts the command value from a shell alias-probe line.
+// Each alternative is anchored to a real alias shape so that interactive rc
+// files printing unrelated text cannot poison first-run config (#1003):
+//   - "aliased to ..."    — zsh `which` / bash `type` alias output
+//   - "^\S+\s*-> ..."     — a "name -> value" alias line (command name at the
+//     line start before the arrow); the `->` is NOT matched mid-line, so noise
+//     like "Type help -> for assistance" no longer captures garbage
+//   - "^[^/=\s]+\s*= ..." — a "name=value" alias assignment at the line start
+var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|^\S+\s*->|^[^/=\s]+\s*=)\s*(.+)`)
 
 // probeWaitDelay bounds how long the claude shell probe's Output() call keeps
 // waiting for stdout/stderr EOF after the probe shell has exited (or the

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -241,6 +241,16 @@ func TestGetClaudeCommand(t *testing.T) {
 			// Interactive rc files may print noise (motd hints, echoes)
 			// before the probe result — the matching line must still win.
 			{"noise before alias", "To run a command as administrator, use sudo.\n\nclaude is aliased to `/opt/claude --fast'", "/opt/claude --fast"},
+			// #1003: an rc-file noise line with a mid-line "->" must NOT match
+			// the arrow alternative and capture garbage; the real alias line
+			// that follows must win instead.
+			{"mid-line arrow noise before alias", "Type help -> for assistance\nclaude: aliased to /usr/local/bin/claude", "/usr/local/bin/claude"},
+			// A noise line with a mid-line "->" and no real alias anywhere must
+			// fall through to "" so GetClaudeCommand uses the PATH fallback.
+			{"mid-line arrow noise only", "Type help -> for assistance", ""},
+			// Decorative rc banners with "=>" / "->" must not be mistaken for
+			// either the arrow or the equals alias form.
+			{"banner arrow noise", "  => Welcome -> shell", ""},
 			// A function carries no usable path; fall back to PATH lookup.
 			{"bash type function", "claude is a function\nclaude () \n{ \n    echo hi\n}", ""},
 			{"bash type builtin", "claude is a shell builtin", ""},


### PR DESCRIPTION
Closes #1003

## Root cause
`aliasOutputRegex` in `config/config.go` parses the shell alias-probe output during first-run config generation:

```go
var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|->|^[^/=\s]+\s*=)\s*(.+)`)
//                                                       ^^^ unanchored
```

The `->` alternative was **unanchored**, so it matched `->` *anywhere* in a line. The bash probe runs `bash -i -c "type claude"`, which sources `.bashrc`; any `.bashrc` stdout is captured *before* the real `type` output. A noise line with a mid-line `->` (e.g. `Type help -> for assistance`) matched first, and since `parseCommandProbeOutput` returns on the first matching line, it captured garbage (`for assistance`) and returned it as the claude path — silently poisoning `config.json`. Sessions then start a tmux pane but the command fails inside, showing a bare shell instead of Claude.

Introduced in #433: commit `f294e5b` anchored the `=` alternative (`^[^/=\s]+\s*=`) to stop false positives but left `->` unanchored, creating the asymmetry that made `->` the only false-positive-prone form.

## Fix
Anchor the `->` alternative to a real alias line — a command name at the start of the line, before the arrow:

```go
var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|^\S+\s*->|^[^/=\s]+\s*=)\s*(.+)`)
```

A noise line with only a mid-line `->` now fails to match and falls through, so `parseCommandProbeOutput` returns `""` and `GetClaudeCommand` engages the `exec.LookPath("claude")` PATH fallback as intended. Real alias forms still parse: zsh `claude: aliased to /path`, bash `claude is aliased to \`/path'`, `name -> /path`, and `name=/path`.

## Adjacent-site audit
- `GetClaudeCommand` is the **only** alias-probe path in the codebase — there is no separate Codex/Aider/Gemini probe that reuses this parsing, so the hazard is contained to this one regex.
- `bashTypeOutputRegex` (`^\S+ is (/.+)$`) — already anchored at line start; not vulnerable.
- Fallback ordering confirmed: `parseCommandProbeOutput` empty result → `exec.LookPath("claude")` PATH fallback (verified by the new `mid-line arrow noise only` case returning `""`).
- **Noted (not addressed, to keep this PR focused):** two pre-existing, lower-risk gaps remain — (1) the `strings.HasPrefix(line, "/")` fallback would still accept a noise line that literally starts with `/`, and (2) the parsed path is never `os.Stat`-validated before being written to `ProgramOverrides` (`os.Stat` is only consulted to decide shell-quoting). Adding a stat-based validation gate before persisting would be a sound follow-up hardening, but is out of scope for this regex anchor.

## Tests
Added hermetic, table-driven cases to `TestGetClaudeCommand/handles_probe_output_parsing`:
- `mid-line arrow noise before alias` — noise with mid-line `->` followed by a real alias → real path wins.
- `mid-line arrow noise only` — noise-only → `""` (PATH fallback engages).
- `banner arrow noise` — decorative `=>`/`->` banner → `""`.

Confirmed **fail-before / pass-after**: against the old unanchored regex all three new cases fail; with the anchor they pass, and every existing case (incl. `arrow format`, `equals format`) still passes.

## Verification
`gofmt -l .` (clean) · `go build ./...` · `golangci-lint run --timeout=3m --fast` (0 issues) · `go test ./...` (green) · `deadcode -test ./...` (clean) · bounded `-race` on `./config/` (green).

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
