### PR TITLE
fix(daemon): isAgentFactoryDaemon requires the af/agent-factory binary name, not just --daemon (#1004)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -538,11 +538,17 @@ func cleanupDaemonRuntimeFiles(pidFile string) {
 	}
 }
 
-// isAgentFactoryDaemon checks whether the process at pid looks like an agent-factory daemon
-// (i.e. its command line contains the --daemon flag as a discrete argument). It tries
-// /proc/<pid>/cmdline first (Linux) and falls back to `ps -p <pid> -o args=` (macOS and other
-// unixes). If neither source yields a readable command line, returns false so callers treat the
-// PID as unverified.
+// isAgentFactoryDaemon checks whether the process at pid looks like an agent-factory daemon:
+// its command line must carry the --daemon flag as a discrete argument AND its executable must
+// be an agent-factory binary ("af" or "agent-factory"). It tries /proc/<pid>/cmdline first
+// (Linux) and falls back to `ps -p <pid> -o args=` (macOS and other unixes). If neither source
+// yields a readable command line, returns false so callers treat the PID as unverified.
+//
+// Both checks are required so that a stale PID file whose PID has been reused by an unrelated
+// process carrying a "--daemon" token (e.g. "sleep --daemon af-test") is not mistaken for our
+// daemon and signaled by StopDaemon/locateDaemonPID. This mirrors the host-wide pgrep scan in
+// sigterm_fallback.go, which already requires both cmdlineHasDaemonFlag and cmdlineIsDaemonBinary;
+// the two PID-validation paths must agree (#1004).
 //
 // We split the command line on whitespace and require an exact "--daemon" token (or a
 // "--daemon=..." form), so flags like --daemonize don't get matched as substrings.
@@ -554,7 +560,7 @@ func isAgentFactoryDaemon(pid int) bool {
 	if cmdline == "" {
 		return false
 	}
-	return cmdlineHasDaemonFlag(cmdline)
+	return cmdlineHasDaemonFlag(cmdline) && cmdlineIsDaemonBinary(cmdline)
 }
 
 // cmdlineHasDaemonFlag reports whether cmdline contains "--daemon" as a discrete argument

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -186,6 +186,67 @@ func TestCmdlineIsDaemonBinary(t *testing.T) {
 	}
 }
 
+// TestIsAgentFactoryDaemon_RequiresBinaryName is the regression test for
+// #1004. isAgentFactoryDaemon validates PIDs sourced from the PID file
+// (StopDaemon / locateDaemonPID) and previously checked only for a discrete
+// "--daemon" token — never the binary name. That let a stale PID file whose
+// PID had been reused by an unrelated process carrying "--daemon" in its argv
+// be mistaken for our daemon and signaled. It must now require BOTH the
+// "--daemon" flag AND an af/agent-factory binary name, mirroring the pgrep
+// scan path (pgrepDaemonCandidates). Hermetic: spawns long-lived sleeps and
+// reads /proc cmdline; never signals any real daemon.
+func TestIsAgentFactoryDaemon_RequiresBinaryName(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not available: %v", err)
+	}
+
+	// spawn launches `exec -a <argv0> sleep 60` and waits until the rewritten
+	// post-exec cmdline (carrying the af-test marker) is visible in /proc.
+	spawn := func(argv0 string) int {
+		t.Helper()
+		cmd := exec.Command("bash", "-c", fmt.Sprintf("exec -a %q sleep 60", argv0))
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start fake process: %v", err)
+		}
+		pid := cmd.Process.Pid
+		t.Cleanup(func() {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		})
+		// Wait for the post-exec cmdline: the rewritten argv carries the
+		// "af-test" marker, and the "bash -c"/"exec -a" wrapper is gone once
+		// exec replaces the shell. Matching on "af-test" alone would fire on
+		// the pre-exec bash process (whose argv embeds the same script text).
+		waitForReady(t, fmt.Sprintf("pid=%d post-exec cmdline visible", pid), func() bool {
+			cmdline := readProcCmdline(pid)
+			if cmdline == "" {
+				cmdline = readPsArgs(pid)
+			}
+			return strings.Contains(cmdline, "af-test") && !strings.Contains(cmdline, "exec")
+		})
+		return pid
+	}
+
+	// The exact #1004 repro: "--daemon" present but argv[0] base is "sleep",
+	// not af/agent-factory. Pre-fix this returned true (the bug); it must now
+	// be false so StopDaemon/locateDaemonPID refuse to signal it.
+	nonAFPID := spawn("sleep --daemon af-test")
+	if isAgentFactoryDaemon(nonAFPID) {
+		t.Errorf("isAgentFactoryDaemon(pid with cmdline %q) = true; "+
+			"want false — a non-af process carrying --daemon must not be treated as our daemon (#1004)",
+			readProcCmdline(nonAFPID))
+	}
+
+	// A genuine agent-factory daemon cmdline (af argv[0] + --daemon) must still
+	// validate true, so the fix doesn't break the real stop/reset path.
+	afPID := spawn("af --daemon af-test")
+	if !isAgentFactoryDaemon(afPID) {
+		t.Errorf("isAgentFactoryDaemon(pid with cmdline %q) = false; "+
+			"want true — a real af --daemon process must still validate",
+			readProcCmdline(afPID))
+	}
+}
+
 // TestStopDaemon_SIGTERMFirst verifies that StopDaemon sends SIGTERM (giving
 // the daemon's signal handler a chance to run SaveInstances) and only
 // escalates to SIGKILL after the grace period. Regression test for #571 —
@@ -199,10 +260,11 @@ func TestStopDaemon_SIGTERMFirst(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
 
 	// Spawn a process that responds to SIGTERM by exiting (sleep's default
-	// behavior) and exposes "--daemon" as a discrete token in /proc cmdline
-	// (via bash's `exec -a` argv[0] rewrite). This is the same recipe used
-	// in TestSigtermFallback_KillsPIDFileDaemon.
-	cmd := exec.Command("bash", "-c", "exec -a 'sleep --daemon af-test' sleep 60")
+	// behavior) and presents an agent-factory daemon cmdline: an "af" argv[0]
+	// plus a discrete "--daemon" token (via bash's `exec -a` argv[0] rewrite),
+	// so it satisfies both checks isAgentFactoryDaemon now requires (#1004).
+	// This is the same recipe used in TestSigtermFallback_KillsPIDFileDaemon.
+	cmd := exec.Command("bash", "-c", "exec -a 'af --daemon af-test' sleep 60")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start fake daemon: %v", err)
 	}
@@ -294,14 +356,14 @@ func TestStopDaemon_EscalatesToSIGKILL(t *testing.T) {
 	// Inner bash sets SIGTERM to SIG_IGN via `trap '' TERM` (the empty-string
 	// form, which truly ignores the signal — `trap : TERM` would run a no-op
 	// but bash still terminates non-interactively after the handler). Outer
-	// bash uses `exec -a` to rewrite argv[0] so the cmdline contains
-	// "--daemon" as a discrete token (passes isAgentFactoryDaemon). A
-	// ready-file sentinel proves the trap was installed before SIGTERM lands,
-	// closing a race where the cmdline becomes visible while bash is still
-	// parsing the script.
+	// bash uses `exec -a` to rewrite argv[0] to an "af" binary name with a
+	// discrete "--daemon" token, so it passes both checks isAgentFactoryDaemon
+	// requires (#1004). A ready-file sentinel proves the trap was installed
+	// before SIGTERM lands, closing a race where the cmdline becomes visible
+	// while bash is still parsing the script.
 	readyFile := filepath.Join(tmpHome, "trap-ready")
 	script := fmt.Sprintf(
-		`exec -a 'bash --daemon af-test' bash -c 'trap "" TERM; : > %q; while :; do sleep 1; done'`,
+		`exec -a 'af --daemon af-test' bash -c 'trap "" TERM; : > %q; while :; do sleep 1; done'`,
 		readyFile,
 	)
 	cmd := exec.Command("bash", "-c", script)

--- a/daemon/sigterm_fallback_test.go
+++ b/daemon/sigterm_fallback_test.go
@@ -182,12 +182,14 @@ func stubDaemonScan(t *testing.T, pids []int, err error) {
 }
 
 // spawnFakeDaemonWithDaemonFlag launches a long-lived child process whose
-// /proc/<pid>/cmdline contains "--daemon" as a discrete token. We use
-// bash's `exec -a` to rewrite argv[0] of `sleep` so the cmdline carries
-// "--daemon" without sleep actually being asked to parse it as a flag (it
-// would reject "--daemon" as an invalid time interval). The single process
-// is just sleep, which terminates cleanly on SIGTERM — making this the
-// minimum-moving-parts way to test the fallback's SIGTERM path.
+// /proc/<pid>/cmdline presents an agent-factory daemon: an "af" argv[0] plus a
+// discrete "--daemon" token, satisfying both checks isAgentFactoryDaemon
+// requires (#1004). We use bash's `exec -a` to rewrite argv[0] so the cmdline
+// carries both without the underlying `sleep` actually being asked to parse
+// "--daemon" as a flag (it would reject "--daemon" as an invalid time
+// interval). The single process is just sleep, which terminates cleanly on
+// SIGTERM — making this the minimum-moving-parts way to test the fallback's
+// SIGTERM path.
 //
 // Returns the *exec.Cmd so the test can call cmd.Wait() to reap the zombie
 // after SIGTERM. Without that, kill(pid, 0) keeps returning success against
@@ -197,7 +199,7 @@ func spawnFakeDaemonWithDaemonFlag(t *testing.T) *exec.Cmd {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skipf("bash not available, skipping SIGTERM-fallback test: %v", err)
 	}
-	cmd := exec.Command("bash", "-c", "exec -a 'sleep --daemon af-test' sleep 60")
+	cmd := exec.Command("bash", "-c", "exec -a 'af --daemon af-test' sleep 60")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start fake daemon: %v", err)
 	}

--- a/daemon/spawn_stop_race_test.go
+++ b/daemon/spawn_stop_race_test.go
@@ -55,10 +55,10 @@ func TestStopDaemon_PreservesNewDaemonSocket(t *testing.T) {
 		t.Fatalf("control server not answering before StopDaemon: %v", err)
 	}
 
-	// Daemon A: a fake old daemon that exits on SIGTERM and exposes
-	// "--daemon" as a discrete cmdline token (same recipe as
-	// TestStopDaemon_SIGTERMFirst).
-	cmd := exec.Command("bash", "-c", "exec -a 'sleep --daemon af-test' sleep 60")
+	// Daemon A: a fake old daemon that exits on SIGTERM and presents an "af"
+	// argv[0] with a discrete "--daemon" cmdline token, satisfying both checks
+	// isAgentFactoryDaemon requires (same recipe as TestStopDaemon_SIGTERMFirst).
+	cmd := exec.Command("bash", "-c", "exec -a 'af --daemon af-test' sleep 60")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start fake daemon: %v", err)
 	}


### PR DESCRIPTION
## Root cause

`isAgentFactoryDaemon` (daemon/daemon.go) validates PIDs read from the
daemon **PID file** — the `StopDaemon` and `locateDaemonPID`/reset paths.
It returned `cmdlineHasDaemonFlag(cmdline)` alone: it checked only for a
discrete `--daemon` token, never the binary name.

So a **stale PID file** whose PID has been reused by an unrelated process
carrying `--daemon` in its argv (e.g. `sleep --daemon af-test`) was
treated as our daemon — and `StopDaemon`/reset could SIGTERM it (and
escalate to SIGKILL). Introduced in #295 / commit `80e5b7e`: the original
intent was to "verify the PID actually belongs to an agent-factory
daemon," but only the flag was checked. `12bd551` later added
`cmdlineIsDaemonBinary` and applied it to the pgrep scan path — but not
here, leaving the two paths inconsistent.

## Fix

Require **both** checks, mirroring the pgrep path:

```go
return cmdlineHasDaemonFlag(cmdline) && cmdlineIsDaemonBinary(cmdline)
```

A PID now validates only when its executable is `af`/`agent-factory`
**and** its argv carries a discrete `--daemon` token.

## Adjacent-site audit

All PID-**file** validation funnels through the single
`isAgentFactoryDaemon` function. Its consumers:

| Path | Site | Validation |
|------|------|------------|
| Stop / reset | `StopDaemon` (daemon.go:467) — reached from the reset path in `main.go` and from `control.go` | `isAgentFactoryDaemon` ✅ now both checks |
| Upgrade SIGTERM fallback | `locateDaemonPID` (sigterm_fallback.go:77) | `isAgentFactoryDaemon` ✅ now both checks |
| Host-wide scan | `pgrepDaemonCandidates` (sigterm_fallback.go) | already required `cmdlineHasDaemonFlag` **and** `cmdlineIsDaemonBinary` ✅ |

No other `readProcCmdline`/`readPsArgs` consumer performs PID validation.
The pgrep path and the PID-file path now agree.

## Tests

- **`TestIsAgentFactoryDaemon_RequiresBinaryName`** (new): the exact
  #1004 repro — argv0 `sleep --daemon af-test` (flag present, binary
  wrong) must now return **false**; a real `af --daemon` cmdline must
  still return **true**. Hermetic: spawns long-lived `sleep`s and reads
  `/proc` cmdline; **signals no real process**.
- Existing fixtures (`TestStopDaemon_SIGTERMFirst`,
  `TestStopDaemon_EscalatesToSIGKILL`, `spawnFakeDaemonWithDaemonFlag`,
  `TestStopDaemon_PreservesNewDaemonSocket`'s race fixture) relied on a
  `sleep`/`bash` argv0 to pass `isAgentFactoryDaemon` — i.e. they encoded
  the buggy behavior. Updated to an `af` argv0 so they satisfy both
  checks.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — all packages pass
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./daemon/...` — pass

No `./dev-install.sh`, `af daemon install`, or systemctl run; the real
daemon on this box was not signaled.

Closes #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)
