### PR TITLE
fix(session): HasUpdated is panic-safe for restored Dead instances with no tmux monitor (#999)

### DIFF
--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -2,11 +2,19 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
+	"os/exec"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
+
+// errSessionAbsent makes the mock executor's has-session probe report "no such
+// session", driving DoesSessionExist to false for the #999 nil-monitor test.
+var errSessionAbsent = errors.New("no such session")
 
 // deadTmuxBackend is a FakeBackend whose IsAlive reports false, modelling a
 // tmux/remote session that vanished out from under the daemon — the #935
@@ -147,6 +155,44 @@ func TestRefreshStatuses_DeadSessionMarkedDeadNotReady(t *testing.T) {
 	}
 	if got := persistedStatus(t, repoID, "gone"); got != session.Dead {
 		t.Fatalf("persisted status = %v, want Dead", got)
+	}
+}
+
+// nilMonitorBackend routes HasUpdated and IsAlive through a REAL TmuxSession
+// that never had Restore called, so its monitor field is nil — the exact shape
+// of a persisted Dead instance reloaded after a daemon restart (#999). It
+// reproduces the production deref through RefreshStatuses; before the fix this
+// panicked and killed the refresh goroutine, zombifying the daemon.
+type nilMonitorBackend struct {
+	*session.FakeBackend
+	ts *tmux.TmuxSession
+}
+
+func (b nilMonitorBackend) HasUpdated(*session.Instance) (bool, bool) { return b.ts.HasUpdated() }
+func (b nilMonitorBackend) IsAlive(*session.Instance) bool            { return b.ts.DoesSessionExist() }
+
+// TestRefreshStatuses_DeadNilMonitorDoesNotPanic is the #999 regression at the
+// daemon poll layer: a persisted Dead instance whose TmuxSession has a nil
+// monitor (Start skipped Restore, #970) must survive a RefreshStatuses pass
+// without panicking. HasUpdated returns (false,false) and the idle liveness
+// probe confirms the vanished session, leaving it Dead.
+func TestRefreshStatuses_DeadNilMonitorDoesNotPanic(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// has-session reports "gone" so the idle-branch liveness probe keeps it Dead;
+	// the nil monitor would panic HasUpdated before the fix regardless.
+	mockExec := cmd_test.MockCmdExec{
+		RunFunc:    func(*exec.Cmd) error { return errSessionAbsent },
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+	ts := tmux.NewTmuxSessionFromSanitizedNameWithDeps("af_999_nil_monitor", "claude", tmux.MakePtyFactory(), mockExec)
+	backend := nilMonitorBackend{FakeBackend: session.NewFakeBackend(), ts: ts}
+	registerStarted(t, manager, repoID, repoPath, "corpse", backend, true, session.Dead)
+
+	manager.RefreshStatuses() // must not panic on the nil monitor
+
+	inst := manager.instances[daemonInstanceKey(repoID, "corpse")]
+	if got := inst.GetStatus(); got != session.Dead {
+		t.Fatalf("in-memory status = %v, want Dead (a restored corpse stays Dead)", got)
 	}
 }
 

--- a/session/dead_respawn_test.go
+++ b/session/dead_respawn_test.go
@@ -129,6 +129,46 @@ func TestDeadInstance_NotRespawnedOnLoad(t *testing.T) {
 		"the Dead agent session must not exist server-side after load")
 }
 
+// TestDeadInstance_HasUpdatedNilMonitor is the #999 regression, exercised
+// through the production path. A persisted Dead instance loads with
+// started=true but LocalBackend.Start returns before TmuxSession.Restore (the
+// only place the tmux monitor is initialized) so the corpse is not re-spawned
+// (#970). The daemon's refreshInstanceStatus still polls every started
+// instance via instance.HasUpdated(); before the fix that dereferenced a nil
+// monitor and panicked, killing the refresh goroutine and zombifying the
+// daemon. HasUpdated must instead return (false,false) — a session with no live
+// monitor has nothing to report.
+func TestDeadInstance_HasUpdatedNilMonitor(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_dead_hasupdated"
+	shellName := agentName + shellTmuxSuffix
+
+	// Both sessions are GONE (the kill that produced Dead): Start(false) returns
+	// at the Dead guard before Restore, so the agent TmuxSession's monitor is nil.
+	var newSessions int
+	exec := countingExec(map[string]bool{}, &newSessions)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	restored, err := FromInstanceData(deadInstanceData(t, Dead, agentName, shellName))
+	require.NoError(t, err)
+	require.Equal(t, Dead, restored.GetStatus())
+	require.True(t, restored.Started())
+
+	// This is the exact call refreshInstanceStatus makes every daemon tick.
+	// Before the nil-monitor guard it panicked here.
+	updated, hasPrompt := restored.HasUpdated()
+	assert.False(t, updated, "a restored Dead instance has nothing to report")
+	assert.False(t, hasPrompt)
+}
+
 // failFirstNewSessionPty is a PtyFactory that fails the first `tmux new-session`
 // it sees and forwards every other command to the mock executor (like
 // persistPtyFactory). It reproduces a persisted shell tab whose re-spawn fails

--- a/session/tmux/hasupdated_nil_monitor_test.go
+++ b/session/tmux/hasupdated_nil_monitor_test.go
@@ -1,0 +1,29 @@
+package tmux
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHasUpdated_NilMonitor pins the #999 fix at its source. A TmuxSession that
+// never had Start/Restore called (the shape of a persisted Dead instance whose
+// LocalBackend.Start returns before Restore initializes the monitor, #970) has a
+// nil monitor field. HasUpdated must treat that as nothing-to-report and return
+// (false,false) rather than panic on the nil deref, which would kill the
+// daemon's refresh goroutine and zombify the daemon.
+func TestHasUpdated_NilMonitor(t *testing.T) {
+	exec := cmd_test.MockCmdExec{
+		// Should never be reached: the nil-monitor guard returns before any
+		// capture-pane. Fail loudly if the guard regresses and we fall through.
+		RunFunc:    func(*exec.Cmd) error { return nil },
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+	ts := NewTmuxSessionFromSanitizedNameWithDeps("af_nil_monitor", "claude", MakePtyFactory(), exec)
+
+	updated, hasPrompt := ts.HasUpdated()
+	assert.False(t, updated, "a session with no live monitor has nothing to report")
+	assert.False(t, hasPrompt)
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -629,9 +629,17 @@ func (t *TmuxSession) SendKeysCommand(text string) error {
 // HasUpdated checks if the tmux pane content has changed since the last tick. It also returns true if
 // the tmux pane has a prompt for aider or claude code.
 func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
+	// A nil monitor means Restore never ran for this session: a persisted Dead
+	// instance is loaded with started=true but LocalBackend.Start returns before
+	// Restore (which is the only place monitor is initialized) so the corpse is
+	// not re-spawned (#970). The daemon's refreshInstanceStatus still polls every
+	// started instance, so HasUpdated must treat "no live monitor" as
+	// nothing-to-report rather than panic on a nil deref and kill the refresh
+	// goroutine, zombifying the daemon (#999).
+	//
 	// Once the underlying tmux session has been confirmed gone, stay silent
 	// instead of relogging capture-pane failures every daemon tick (#489).
-	if t.monitor.dead {
+	if t.monitor == nil || t.monitor.dead {
 		return false, false
 	}
 


### PR DESCRIPTION
## Problem

A daemon-crash regression introduced by #982 (`00bd716`).

When a persisted **Dead** instance is reloaded, `LocalBackend.Start` returns at
the Dead guard (`if i.GetStatus() == Dead { return nil }`) **before**
`TmuxSession.Restore` — and `Restore` is the only place the tmux `monitor` field
is initialized. The instance still loads `started=true`, so the daemon's
`refreshInstanceStatus` goroutine polls it via `HasUpdated`, which dereferenced
`t.monitor.dead` on a **nil** monitor and panicked.

The refresh loop has no panic recovery, so the goroutine died permanently. The
main daemon process kept running (blocked in its signal `select`), becoming a
**zombie**: still serving RPCs, but no status updates, no AutoYes, no
dead-session detection.

## Fix

Make `HasUpdated` panic-safe — a session with no live monitor has nothing to
report:

```go
func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
	if t.monitor == nil || t.monitor.dead {
		return false, false
	}
	...
```

This matches the documented Dead behavior from #970 (`HasUpdated → (false,false)`)
and is identical for live instances.

## Monitor-deref audit (`session/`)

`t.monitor`'s fields are dereferenced **only inside `HasUpdated`** — the gated
`t.monitor.dead` check plus the dead-latch write and hash read/writes it guards.
The single nil-guard covers all of them.

Every other `TmuxSession` method the daemon poll loop (`refreshInstanceStatus`)
can reach is monitor-free:

| Method (poll-loop reachable) | Deref | Safe because |
|---|---|---|
| `HasUpdated` | `t.monitor.*` | **fixed** — nil-guard added |
| `DoesSessionExist` / `CapturePaneContent` (via `Preview`, trust-prompt) | `t.cmdExec`, `t.sanitizedName` | set in `newTmuxSession`, never nil |
| `TmuxAlive` → `IsAlive` → `DoesSessionExist` | same as above | safe |
| `TapEnter` / `SendKeys` / `SetDetachedSize` | `t.ptmx` | each guards `t.ptmx == nil` → `ErrSessionGone` |

`refreshInstanceStatus` Dead-skip: **not added.** Once the panic is removed, the
existing `idle → !TmuxAlive() → Dead` branch correctly re-confirms a restored
corpse as Dead (no-op transition, no disk write). A blanket Dead-skip would mask
a session that genuinely comes back, so the nil-guard alone is the right scope.

## Tests (hermetic, no real tmux)

Each confirmed **fail-before (panic) / pass-after**:

- `session/tmux` — `HasUpdated` on a nil-monitor `TmuxSession` returns `(false,false)`.
- `session` — production path: `FromInstanceData(Dead)` → `Start` skips `Restore`
  → `instance.HasUpdated()` (the exact call `refreshInstanceStatus` makes) does
  not panic.
- `daemon` — `RefreshStatuses` over a Dead instance backed by a **real**
  nil-monitor `TmuxSession` does not panic and stays Dead.

## Verification

`gofmt -l .`, `go build ./...`, `golangci-lint run --timeout=3m --fast`,
`go test ./...`, `deadcode -test ./...` all clean; bounded race
`GOFLAGS="-p=1" go test -race -parallel 2 ./session/... ./daemon/...` green.

Closes #999

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
