### PR TITLE
fix(app): search overlay uses a stable instance-list copy to avoid ghost/duplicate entries (#1008)

### DIFF
--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -65,7 +65,12 @@ func (m *home) handleStateSearch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // showSearchOverlay displays the session search overlay.
 func (m *home) showSearchOverlay() (tea.Model, tea.Cmd) {
-	instances := m.sidebar.GetInstances()
+	// The overlay outlives this call and holds onto the slice, while a
+	// background snapshotFetchedMsg reconcile can remove instances from the
+	// sidebar in place (append-shift on the shared backing array). Hand the
+	// overlay a stable copy so a later removal can't corrupt its list with
+	// duplicate/ghost entries (#1008).
+	instances := m.sidebar.GetInstancesSnapshot()
 	if len(instances) == 0 {
 		return m, m.handleError(fmt.Errorf("no sessions to search"))
 	}

--- a/app/search_overlay_snapshot_test.go
+++ b/app/search_overlay_snapshot_test.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShowSearchOverlay_StableAcrossSnapshotRemoval is the #1008 regression.
+//
+// showSearchOverlay must hand the overlay a stable COPY of the instance list.
+// Sidebar.GetInstances() returns a slice sharing the sidebar's backing array,
+// and a background snapshotFetchedMsg reconcile removes instances in place via
+// append(s.instances[:i], s.instances[i+1:]...). If the overlay retained that
+// shared header, the in-place shift would corrupt the slice it re-scans on the
+// next keystroke — a duplicated trailing entry plus a "ghost" (the removed
+// head dropped off the tail). Opening from GetInstancesSnapshot() gives the
+// overlay a private backing array, so a later removal leaves its list untouched.
+//
+// The corruption only surfaces when updateResults() re-runs (on a keystroke)
+// AFTER the mutation, so the test types a query that matches every session.
+//
+// Fail-before/pass-after: with the buggy GetInstances() call, after "xa" is
+// removed the overlay re-scans the corrupted backing array ["xb","xc","xc"]
+// (dup "xc", ghost: "xa" gone). With the snapshot copy it stays
+// ["xa","xb","xc"].
+func TestShowSearchOverlay_StableAcrossSnapshotRemoval(t *testing.T) {
+	h := newTestHome(t)
+
+	// Titles share the rune 'x' so a single-key query matches all of them,
+	// forcing updateResults to re-scan the (possibly corrupted) backing array.
+	xa := newSnapshotTestInstance(t, "xa")
+	xb := newSnapshotTestInstance(t, "xb")
+	xc := newSnapshotTestInstance(t, "xc")
+	h.sidebar.AddInstance(xa)
+	h.sidebar.AddInstance(xb)
+	h.sidebar.AddInstance(xc)
+
+	// Open the overlay exactly as the key handler does.
+	_, _ = h.showSearchOverlay()
+	require.NotNil(t, h.searchOverlay, "search overlay must open with sessions present")
+	require.Equal(t, stateSearch, h.state)
+
+	// A background reconcile drops "xa" (the head element, so its removal
+	// append-shifts the sidebar's backing array under the overlay).
+	removed := h.reconcileSnapshot([]session.InstanceData{
+		xb.ToInstanceData(),
+		xc.ToInstanceData(),
+	})
+	require.True(t, removed, "dropping a session from the snapshot is a change")
+	assert.Nil(t, findSidebarInstance(h, "xa"), "reconcile must remove 'xa' from the sidebar")
+
+	// User types 'x' — every session matches, so updateResults re-scans the
+	// overlay's whole list. A shared backing array would now read corrupted.
+	h.searchOverlay.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+
+	// The overlay was opened from a stable copy, so its list is unaffected by
+	// the sidebar removal: no duplicate, no ghost-induced drop.
+	titles := overlayResultTitles(h)
+	assert.Equal(t, []string{"xa", "xb", "xc"}, titles,
+		"overlay list must stay the stable copy captured at open time")
+
+	// Explicit no-duplicate assertion mirroring the bug symptom.
+	seen := map[string]int{}
+	for _, name := range titles {
+		seen[name]++
+	}
+	for name, n := range seen {
+		assert.Equalf(t, 1, n, "title %q must appear exactly once (no duplicates)", name)
+	}
+}
+
+func overlayResultTitles(h *home) []string {
+	insts := h.searchOverlay.ResultInstances()
+	titles := make([]string, len(insts))
+	for i, inst := range insts {
+		titles[i] = inst.Title
+	}
+	return titles
+}

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -55,6 +55,17 @@ func (s *SearchOverlay) IsSubmitted() bool {
 	return s.submitted
 }
 
+// ResultInstances returns the instances currently matching the query, in
+// display order. Exposed for tests that assert the overlay's list stays a
+// stable copy independent of later sidebar mutations (#1008).
+func (s *SearchOverlay) ResultInstances() []*session.Instance {
+	out := make([]*session.Instance, len(s.results))
+	for i, r := range s.results {
+		out[i] = r.Instance
+	}
+	return out
+}
+
 // GetSelectedInstance returns the instance the user selected, or nil.
 func (s *SearchOverlay) GetSelectedInstance() *session.Instance {
 	if s.submitted && len(s.results) > 0 && s.selectedIdx < len(s.results) {

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -472,9 +472,12 @@ func (s *Sidebar) GetInstanceByTitle(title string) *session.Instance {
 }
 
 // GetInstances returns all instances. The returned slice shares the sidebar's
-// backing array, so callers must only read it on the bubbletea event loop —
-// never hand it to a goroutine that outlives the call (see
-// GetInstancesSnapshot for that).
+// backing array, so callers must only read it inline on the bubbletea event
+// loop and must NOT store it beyond the immediate call — never hand it to a
+// goroutine that outlives the call, and never stash it in an overlay or struct
+// field that survives past this call. A later append/remove mutates the shared
+// backing array in place, corrupting any retained slice (#1008). Use
+// GetInstancesSnapshot for anything that keeps the slice around.
 func (s *Sidebar) GetInstances() []*session.Instance {
 	return s.instances
 }


### PR DESCRIPTION
## Root cause

`showSearchOverlay` opened the search overlay from `Sidebar.GetInstances()`, whose returned slice **shares the sidebar's backing array**. The overlay stores that slice (`SearchOverlay.all`) for its whole lifetime.

A background `snapshotFetchedMsg` reconcile (`app/sync.go`) runs unconditionally — even while the overlay is open — and removes instances in place:

```go
s.instances = append(s.instances[:i], s.instances[i+1:]...) // ui/sidebar.go RemoveInstanceByTitle
```

That append-shift mutates the shared backing array under the overlay's retained slice header. The corruption surfaces on the overlay's **next** `updateResults()` re-scan (i.e. the next keystroke): removing the head element leaves the backing array as `[b, c, c]` while the overlay's header still has the original length — so the list shows a **duplicated** trailing entry and a **ghost** (the removed session dropped off the tail). Selecting a ghost silently no-ops. Pure slice aliasing; no goroutines involved.

Introduced in `4a20576` (fuzzy search). The safe `GetInstancesSnapshot()` helper added later in `1f5ceba` (for a separate race fix) was never wired into the search overlay.

## Fix

Open the overlay from `Sidebar.GetInstancesSnapshot()`, which copies the slice header onto a private backing array (the `*session.Instance` elements are still shared, but each guards its own fields). Later sidebar mutations can no longer corrupt the overlay's list.

- **`app/handle_overlay.go`** — `showSearchOverlay` now opens from `GetInstancesSnapshot()`.
- **`ui/sidebar.go`** — tightened the `GetInstances()` doc to forbid storing the returned slice beyond the immediate call and point callers to `GetInstancesSnapshot`.
- **`ui/overlay/searchOverlay.go`** — added `ResultInstances()` accessor used by the regression test.

## `GetInstances()` caller audit

Every other caller reads the slice **inline within a single synchronous pass** and never stores it — none have the store-beyond-call aliasing hazard:

| Site | Usage | Verdict |
|------|-------|---------|
| `app/handle_overlay.go:68` | stored in `SearchOverlay.all` for the overlay's lifetime | **the bug — fixed** |
| `app/handle_input.go:49`, `:64` | inline `for range` (dup-title check / remote-list build) | safe |
| `app/handle_actions.go:166`, `:225`, `:240` | inline `for range` (kill / killed / repo lookup) | safe |
| `app/sync.go:289`, `:337`, `:493` | inline `for range` (build maps / `toRemove` / hook scan) | safe |

No other overlay (selection, confirmation, text) takes or stores an instance slice — `NewSearchOverlay` is the only constructor accepting `[]*session.Instance`.

> Note: `handle_actions.go:166` reads `GetInstances()` inside a `tea.Cmd` closure, but it calls and consumes it within that single execution rather than retaining it — not the store-aliasing class this issue covers.

## Test

`app/search_overlay_snapshot_test.go` — hermetic, no tmux/daemon:

1. Add three sessions (`xa`, `xb`, `xc`) to a sidebar.
2. Open the overlay via the real `showSearchOverlay()`.
3. Drop the head session `xa` via `reconcileSnapshot` (exercises the real `RemoveInstanceByTitle` append-shift).
4. Type a query that matches every session, forcing `updateResults()` to re-scan the list.
5. Assert the overlay still shows exactly `["xa","xb","xc"]` — **no duplicate, no ghost**.

Confirmed **fail-before** (sees `["xb","xc","xc"]`) / **pass-after**.

## Verification

`gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --timeout=3m --fast` clean · `go test ./...` green · `deadcode -test ./...` clean · bounded race `GOFLAGS="-p=1" go test -race -parallel 2 ./app/... ./ui/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)