### PR TITLE
fix(app): surface hooks save failures so quit aborts instead of losing edits (#1001)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -555,8 +555,17 @@ func (m *home) handleQuit() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
-// saveContentPaneState persists any changes from the task/hooks panes and
-// returns a non-nil error if any task persist operation failed.
+// saveContentPaneState persists any changes from the hooks/task panes and
+// returns a non-nil error if any persist operation failed. Both panes'
+// failures are accumulated so neither is dropped when both are dirty at once.
+//
+// Recovery semantics on a hooks-save failure (#1001): we leave the HooksPane
+// dirty and deliberately do NOT reload it from disk. The edit the user is
+// trying to save lives only in memory, so reloading would discard the very
+// edit they care about — the silent data loss this fix exists to prevent.
+// Returning the error lets callers (handleQuit / focus release) abort the
+// destructive action and surface it via handleError; the dirty pane preserves
+// the edit so the user can retry from where they left off.
 //
 // Recovery semantics on a task-save failure (#934): we reload BOTH the sidebar
 // and the TaskPane from disk so the two panes always agree and always reflect
@@ -569,6 +578,10 @@ func (m *home) handleQuit() (tea.Model, tea.Cmd) {
 // dirty flag would point at nothing. The user re-applies the edit from a
 // known-consistent state instead.
 func (m *home) saveContentPaneState() error {
+	// Accumulate failures across both panes so a hooks error and a task error
+	// can never clobber one another (#1001).
+	var saveErr error
+
 	hp := m.contentPane.HooksPane()
 	if hp.IsDirty() {
 		// Hook edits are written to the in-repo .agent-factory/config.json —
@@ -576,8 +589,13 @@ func (m *home) saveContentPaneState() error {
 		// legacy ~/.agent-factory/repos/<id>/config.json stays untouched as a
 		// read-only fallback; the saved in-repo key (even when emptied)
 		// shadows it.
-		if err := config.SaveInRepoPostWorktreeCommands(m.repoRoot, hp.GetCommands()); err != nil {
+		if err := saveInRepoPostWorktreeCommandsFn(m.repoRoot, hp.GetCommands()); err != nil {
 			log.ErrorLog.Printf("failed to save hooks: %v", err)
+			// Surface the failure instead of swallowing it (#1001): callers
+			// abort the quit / focus release and show the error overlay rather
+			// than silently dropping the edit. The HooksPane stays dirty (see
+			// the recovery note above) so the in-memory edit survives for retry.
+			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save hooks: %w", err))
 		} else {
 			m.sidebar.SetHookCount(len(hp.GetCommands()))
 		}
@@ -585,13 +603,12 @@ func (m *home) saveContentPaneState() error {
 
 	sp := m.contentPane.TaskPane()
 	if !sp.IsDirty() {
-		return nil
+		return saveErr
 	}
 
 	// Collect every persist failure instead of swallowing them: a partial
 	// failure must still surface so the user knows their edit didn't fully
 	// land (matches api/tasks.go, which propagates these errors).
-	var saveErr error
 	for _, tsk := range sp.GetTasks() {
 		if err := task.UpdateTask(tsk); err != nil {
 			log.ErrorLog.Printf("failed to update task: %v", err)
@@ -622,6 +639,11 @@ func (m *home) saveContentPaneState() error {
 // reloadDaemonTaskSchedulesFn is indirected so TUI tests can observe the poke
 // without dialing (or spawning) a real daemon.
 var reloadDaemonTaskSchedulesFn = daemon.ReloadTasks
+
+// saveInRepoPostWorktreeCommandsFn is indirected so TUI tests can force a
+// hooks-save failure deterministically — without relying on filesystem
+// permission tricks that a root test runner would bypass (#1001).
+var saveInRepoPostWorktreeCommandsFn = config.SaveInRepoPostWorktreeCommands
 
 // reloadDaemonTaskSchedules asks the daemon to re-read tasks.json after a
 // TUI-side task edit. Best-effort: the daemon reloads all tasks at every

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -241,4 +242,172 @@ func TestHandleContentPaneFocus_ValidationFailureLeavesTaskPaneStale(t *testing.
 	// lingering dirty flag would point at edits the reload already discarded.
 	assert.False(t, tp.IsDirty(),
 		"reloading from disk clears dirty; the dropped edit is communicated via the error, not a dangling dirty flag")
+}
+
+// dirtyHooksHome returns a home wired to a real repo with a single dirty,
+// unsaved hook edit ("echo test") in the HooksPane. The hooks-save seam is
+// left at the caller's discretion (default real save, or a stub).
+func dirtyHooksHome(t *testing.T) *home {
+	t.Helper()
+	h := newTestHome(t)
+
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+	h.repoRoot = repo.Root
+
+	hp := h.contentPane.HooksPane()
+	hp.SetCommands([]string{})
+	h.contentPane.SetMode(ui.ContentModeHooks)
+	hp.SetFocus(true)
+	h.errBox.SetSize(500, 1)
+
+	// Add a hook: dirty in memory, not yet persisted.
+	hp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	hp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("echo test")})
+	hp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	require.True(t, hp.IsDirty(), "hooks should be dirty after edit")
+	require.Contains(t, hp.GetCommands(), "echo test")
+	return h
+}
+
+// stubHooksSaveFailure forces the hooks-save seam to fail and restores it after
+// the test. Returns the sentinel error it injects.
+func stubHooksSaveFailure(t *testing.T) error {
+	t.Helper()
+	wantErr := fmt.Errorf("injected hooks save failure")
+	orig := saveInRepoPostWorktreeCommandsFn
+	saveInRepoPostWorktreeCommandsFn = func(string, []string) error { return wantErr }
+	t.Cleanup(func() { saveInRepoPostWorktreeCommandsFn = orig })
+	return wantErr
+}
+
+// TestSaveContentPaneState_HooksSaveFailureReturnedAndPreserved is the core
+// regression guard for #1001. Before the fix, SaveInRepoPostWorktreeCommands
+// failures were only logged and saveContentPaneState returned nil, so the
+// caller never aborted the destructive action — the edit was lost silently.
+//
+// The fix returns the error AND deliberately leaves the HooksPane dirty (no
+// disk reload, unlike tasks) so the in-memory edit survives for the user to
+// retry.
+func TestSaveContentPaneState_HooksSaveFailureReturnedAndPreserved(t *testing.T) {
+	h := dirtyHooksHome(t)
+	wantErr := stubHooksSaveFailure(t)
+	hp := h.contentPane.HooksPane()
+
+	err := h.saveContentPaneState()
+	require.Error(t, err, "hooks save failure must be returned, not swallowed (#1001)")
+	assert.ErrorIs(t, err, wantErr)
+
+	assert.True(t, hp.IsDirty(),
+		"hooks pane must stay dirty so the edit survives for retry (#1001)")
+	assert.Contains(t, hp.GetCommands(), "echo test",
+		"the in-memory edit must be preserved, not reloaded away")
+}
+
+// TestHandleContentPaneFocus_HooksSaveFailureSurfacedOnEsc reproduces the exact
+// path from the issue's failing test: pressing Esc to release focus triggers
+// the save, and a hooks-save failure must now return an error-surfacing command
+// and show the error inline (previously cmd was nil and the errBox stayed empty).
+func TestHandleContentPaneFocus_HooksSaveFailureSurfacedOnEsc(t *testing.T) {
+	h := dirtyHooksHome(t)
+	stubHooksSaveFailure(t)
+	hp := h.contentPane.HooksPane()
+
+	_, cmd, consumed := h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyEsc})
+	require.True(t, consumed, "Esc must route through the focus handler")
+	require.NotNil(t, cmd, "a failed hooks save must return an error-surfacing command (#1001)")
+	assert.Contains(t, h.errBox.String(), "failed to save hooks",
+		"the hooks save failure must be surfaced to the user, not swallowed (#1001)")
+	assert.True(t, hp.IsDirty(), "the dropped edit must be preserved for retry (#1001)")
+}
+
+// TestHandleQuit_HooksSaveFailureAbortsQuit verifies the destructive path: a
+// hooks-save failure must abort the quit (surface the error via handleError)
+// rather than proceeding to tea.Quit and losing the edit. The errBox being set
+// is the discriminator — the tea.Quit path never touches it.
+func TestHandleQuit_HooksSaveFailureAbortsQuit(t *testing.T) {
+	h := dirtyHooksHome(t)
+	stubHooksSaveFailure(t)
+	hp := h.contentPane.HooksPane()
+
+	_, cmd := h.handleQuit()
+	require.NotNil(t, cmd, "a failed save must return a command (the handleError cmd)")
+	assert.Contains(t, h.errBox.String(), "failed to save hooks",
+		"quit must be aborted with the error surfaced, not proceed to tea.Quit (#1001)")
+	assert.True(t, hp.IsDirty(), "the edit must survive the aborted quit for retry (#1001)")
+}
+
+// TestHandleQuit_HooksSaveSuccessQuitsAndUpdatesHookCount verifies the success
+// path is unchanged: a clean save proceeds to tea.Quit and the sidebar hook
+// count reflects the saved edit.
+func TestHandleQuit_HooksSaveSuccessQuitsAndUpdatesHookCount(t *testing.T) {
+	h := dirtyHooksHome(t) // default seam performs a real, successful save
+
+	_, cmd := h.handleQuit()
+	require.NotNil(t, cmd, "handleQuit returns a command on the success path")
+	assert.NotContains(t, h.errBox.String(), "failed to save hooks",
+		"no error must be surfaced on a successful save")
+
+	// The returned command must be tea.Quit.
+	msg := cmd()
+	_, isQuit := msg.(tea.QuitMsg)
+	assert.True(t, isQuit, "a successful save must proceed to tea.Quit")
+
+	assert.Equal(t, 1, h.sidebar.GetHookCount(),
+		"the sidebar hook count must reflect the saved hook")
+
+	// The save actually landed on disk.
+	cfg, _, err := config.LoadInRepoConfig(h.repoRoot)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"echo test"}, cfg.PostWorktreeCommands,
+		"the hook edit must be persisted to the in-repo config")
+}
+
+// TestSaveContentPaneState_HooksAndTaskFailuresBothSurfaced verifies that when
+// BOTH panes are dirty and BOTH fail, neither error is dropped — the hooks fix
+// must not clobber the task error (and vice versa).
+func TestSaveContentPaneState_HooksAndTaskFailuresBothSurfaced(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod-based write-failure injection is bypassed when running as root")
+	}
+	h := dirtyHooksHome(t)
+	wantHooksErr := stubHooksSaveFailure(t)
+
+	// Seed a task on disk and load it, then toggle it dirty.
+	existing := task.Task{
+		ID:          "existing-1001",
+		Name:        "nightly",
+		Prompt:      "do something",
+		CronExpr:    "* * * * *",
+		ProjectPath: h.repoRoot,
+		Program:     "claude",
+		Enabled:     true,
+		CreatedAt:   time.Now(),
+	}
+	require.NoError(t, task.AddTask(existing))
+	loaded, err := task.LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	tp := h.contentPane.TaskPane()
+	tp.SetTasks(loaded)
+	h.contentPane.SetMode(ui.ContentModeTasks)
+	tp.SetFocus(true)
+	_, _, consumed := h.handleContentPaneFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	require.True(t, consumed)
+	require.True(t, tp.IsDirty(), "toggle must mark the task pane dirty")
+
+	// Make the task persist fail too: strip write permission from the config dir.
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(configDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(configDir, 0o700) })
+
+	err = h.saveContentPaneState()
+	require.Error(t, err, "both failures must surface")
+	assert.ErrorIs(t, err, wantHooksErr, "the hooks error must not be dropped")
+	assert.Contains(t, err.Error(), "failed to save task",
+		"the task error must not be dropped when hooks also fail")
 }

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -130,6 +130,11 @@ func (s *Sidebar) SetHookCount(count int) {
 	s.rebuildVisibleItems()
 }
 
+// GetHookCount returns the currently displayed hook count.
+func (s *Sidebar) GetHookCount() int {
+	return s.hookCount
+}
+
 // GetTasks returns the current tasks.
 func (s *Sidebar) GetTasks() []task.Task {
 	return s.tasks


### PR DESCRIPTION
Closes #1001

## Root cause

`saveContentPaneState` (`app/app.go`) persists both the hooks pane and the
task pane when the user releases content-pane focus or quits. The task pane
correctly **collected and returned** its persist errors so callers could
abort. The hooks branch did not:

```go
if err := config.SaveInRepoPostWorktreeCommands(m.repoRoot, hp.GetCommands()); err != nil {
    log.ErrorLog.Printf("failed to save hooks: %v", err) // logged, never returned
}
```

So when a hooks save failed, `saveContentPaneState` still returned `nil`,
`handleQuit` proceeded to `tea.Quit`, and the user's edit was lost **with no
error overlay** — the silent data loss reported in #1001.

## Fix

- Accumulate the hooks failure into the function's returned error (joined with
  any task error via `errors.Join`, so a simultaneous task failure is never
  dropped).
- On a hooks failure, **leave the HooksPane dirty and do NOT reload from disk**.
  The edit lives only in memory; reloading (the task-pane recovery model from
  #934) would discard the very edit the user is trying to save. Keeping it
  dirty preserves the edit for an in-place retry.
- Success path is unchanged: `SetHookCount` still runs on a clean save.

## Adjacent-site audit (required)

All callers of `saveContentPaneState` already abort + surface on a non-nil
return, so returning the error is sufficient at every site — no caller changes
needed:

| Caller | Path | Behavior on non-nil return |
| --- | --- | --- |
| `handleQuit` (`app.go:542`) | quit | `return m, m.handleError(err)` — aborts `tea.Quit`, shows overlay ✓ |
| `handleContentPaneFocus` Esc/focus-release (`handle_overlay.go:92`) | focus release | `return m, m.handleError(err), true` — surfaces inline ✓ |
| `handleContentPaneFocus` pending-create (`handle_overlay.go:108`) | task create flush | `return m, m.handleError(err), true` — skips create, surfaces ✓ |

No double-overlay: each site returns immediately on error, so `handleError`
fires once. No lost-task-error: the hooks error is `errors.Join`-ed with the
existing task error accumulator rather than replacing it; the task recovery
(reload-both-panes, clear dirty) is untouched.

## Tests (hermetic)

Added a `saveInRepoPostWorktreeCommandsFn` seam (mirrors the existing
`reloadDaemonTaskSchedulesFn`) so the hooks save can be forced to fail
deterministically — not dependent on filesystem-permission tricks that a root
test runner bypasses. New tests in `app/handle_overlay_test.go`:

- `TestSaveContentPaneState_HooksSaveFailureReturnedAndPreserved` — returns the
  error; HooksPane stays dirty; edit preserved.
- `TestHandleContentPaneFocus_HooksSaveFailureSurfacedOnEsc` — the issue's exact
  repro: Esc now returns a non-nil cmd and surfaces `failed to save hooks`.
- `TestHandleQuit_HooksSaveFailureAbortsQuit` — quit aborts (error surfaced,
  pane stays dirty) instead of proceeding to `tea.Quit`.
- `TestHandleQuit_HooksSaveSuccessQuitsAndUpdatesHookCount` — success still
  reaches `tea.Quit`, updates the sidebar hook count, persists to the in-repo
  config.
- `TestSaveContentPaneState_HooksAndTaskFailuresBothSurfaced` — both panes dirty
  and both fail: neither error is dropped (root-skipped, uses chmod for the task
  failure like the #934 test).

## Verification

`gofmt -l .` (clean), `go build ./...`, `golangci-lint run --timeout=3m --fast`
(clean), `go test ./...` (all green), `deadcode -test ./...` (clean), bounded
race `GOFLAGS="-p=1" go test -race -parallel 2 ./app/...` (green).

Did **not** run `./dev-install.sh` or touch the real daemon.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
