### PR TITLE
fix(ui): enterScrollMode shows dead-session fallback instead of stale content for an already-dead shell (#998)

### DIFF
--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -382,7 +382,15 @@ func (p *TabPane) enterScrollModeLocked(instance *session.Instance, activeTab in
 	if activeTab == 0 {
 		content, err = instance.PreviewFullHistory()
 	} else {
+		// An already-dead shell tab must transition to the fallback, not bare
+		// return: a bare return leaves p.content (fallback==false) holding the
+		// last-rendered capture and isScrolling==false, so String() renders stale
+		// terminal output instead of the dead-session message. This mirrors
+		// updateShellLocked's !TabAlive branch and the ErrSessionGone path below,
+		// which both set the same fallback — the early-return was the inconsistency
+		// (#998, sibling of #977/#984).
 		if !instance.TabAlive(activeTab) {
+			p.setFallbackState("Terminal session not available.")
 			return nil
 		}
 		content, err = instance.PreviewTabFullHistory(activeTab)

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -496,6 +496,98 @@ func TestTabPaneShellScrollModeSessionGoneExternally(t *testing.T) {
 		"stale scrollback must not remain on screen after the session dies (#977)")
 }
 
+// TestTabPaneShellScrollModeAlreadyDead is the #998 regression (sibling of
+// #977): entering scroll mode on a shell tab whose tmux session is ALREADY dead
+// before entry must transition to the "Terminal session not available." fallback
+// instead of leaving the last live capture pinned on screen. enterScrollModeLocked's
+// !TabAlive branch used to bare-return, leaving p.content (fallback==false) holding
+// stale terminal output and isScrolling==false, so String() rendered the stale
+// content. It must call setFallbackState, mirroring updateShellLocked's !TabAlive
+// branch and the ErrSessionGone capture path.
+func TestTabPaneShellScrollModeAlreadyDead(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	const liveCapture = "live-shell-output-before-death"
+	var gone atomic.Bool
+	existing := map[string]bool{}
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			s := cmd.String()
+			name := tmuxTargetName(cmd)
+			switch {
+			case strings.Contains(s, "has-session"):
+				if gone.Load() {
+					return fmt.Errorf("session gone")
+				}
+				if existing[name] {
+					return nil
+				}
+				return fmt.Errorf("session does not exist")
+			case strings.Contains(s, "new-session"):
+				existing[name] = true
+				return nil
+			case strings.Contains(s, "kill-session"):
+				delete(existing, name)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			if strings.Contains(cmd.String(), "capture-pane") {
+				return []byte(liveCapture), nil
+			}
+			return []byte(""), nil
+		},
+	}
+
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	workdir := t.TempDir()
+	setupGitRepo(t, workdir)
+	name := fmt.Sprintf("test-shell-scroll-dead-%d", time.Now().UnixNano())
+	inst, err := session.NewInstance(session.InstanceOptions{Title: name, Path: workdir, Program: "bash"})
+	require.NoError(t, err)
+	pty := &MockPtyFactory{t: t, cmdExec: cmdExec}
+	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps(name, "bash", pty, cmdExec))
+	require.NoError(t, inst.Start(true))
+	defer func() { _ = inst.Kill() }()
+
+	p := NewTabPane()
+	p.SetSize(80, 30)
+
+	// Render the live shell tab so p.content holds the last capture (stale content
+	// once the session dies) and currentInstance/currentTab are adopted (so the
+	// dropStaleView guard does not reset state on the ScrollUp path below).
+	require.NoError(t, p.UpdateContent(inst, 1))
+	require.False(t, p.IsScrolling(), "precondition: not yet scrolling")
+	require.Contains(t, p.String(), liveCapture,
+		"precondition: pane renders the live shell capture")
+
+	// The shell session is already dead before the user attempts to scroll.
+	gone.Store(true)
+
+	require.NoError(t, p.ScrollUp(inst, 1),
+		"entering scroll mode on a dead shell must not bubble an error")
+
+	p.mu.Lock()
+	stillScrolling := p.isScrolling
+	hasFallback := p.content.fallback
+	fallbackText := p.content.text
+	p.mu.Unlock()
+
+	require.False(t, stillScrolling,
+		"entering scroll mode on an already-dead shell must not leave the pane scrolling (#998)")
+	require.True(t, hasFallback,
+		"an already-dead shell must show a fallback on scroll-mode entry, not stale content (#998)")
+	require.Contains(t, fallbackText, "Terminal session not available.")
+
+	rendered := p.String()
+	require.Contains(t, rendered, "Terminal session not available.",
+		"rendered frame must show the dead-session fallback (#998)")
+	require.NotContains(t, rendered, liveCapture,
+		"stale terminal content must not remain on screen for an already-dead shell (#998)")
+}
+
 // TestTabPaneRemoteFallbackStates covers the #843 Terminal-tab UX for remote
 // sessions on the merged pane.
 func TestTabPaneRemoteFallbackStates(t *testing.T) {


### PR DESCRIPTION
Closes #998

## Root cause

`TabPane.enterScrollModeLocked` (`ui/tab_pane.go`) has two "dead session" timing paths for a **shell** tab (`activeTab != 0`):

- **Session dies *during* capture** → `PreviewTabFullHistory` returns `tmux.ErrSessionGone` → the code calls `setFallbackState(...)`. ✅
- **Session *already* dead before entry** → `!instance.TabAlive(activeTab)` was a bare `return nil`. ❌

The bare return left `p.content` holding the last live capture (`fallback==false`) and `isScrolling==false`, so `String()` rendered **stale terminal output** instead of the dead-session fallback. This violated the pane invariant that a dead session must show the fallback, not stale content — and it disagreed with `updateShellLocked`, whose `!TabAlive` branch already sets `"Terminal session not available."`.

Introduced by #953, which merged `PreviewPane`/`TerminalPane` into `TabPane`: the shell slot inherited the old `TerminalPane.enterScrollMode()` guard that returned on `!DoesSessionExist()` without a fallback. Sibling of #977/#984.

## Fix

Replace the bare `return nil` with the same fallback transition used by `updateShellLocked` and the `ErrSessionGone` path:

```go
if !instance.TabAlive(activeTab) {
    p.setFallbackState("Terminal session not available.")
    return nil
}
```

`setFallbackState` clears scroll state and the stale viewport, so `String()` (which checks `isScrolling` before `fallback`) renders the message.

## Adjacent-site audit

Swept every early return in the scroll-entry flow for the same "return without fallback leaves stale content" hazard:

- **Agent slot (`activeTab == 0`) in `enterScrollModeLocked`** — no bare-return path: its only `return nil`s are the `ErrSessionGone` fallback or success (viewport set + `isScrolling=true`); other errors propagate via `return err`. No stale-content hazard. Consistent.
- **`ScrollUp`/`ScrollDown`** — the `instance == nil` guard returns before any scroll entry; nil-instance content is owned by `UpdateContent`'s welcome fallback. Not a scroll-entry stale-content path.
- **`updateShellLocked` / `updateAgentLocked` / `ResetToNormalMode`** — already set fallbacks for `!TabAlive` / Dead / Deleting / Loading / `ErrSessionGone`. The shell scroll-entry path was the sole offender; it now matches.

## Tests

Added `TestTabPaneShellScrollModeAlreadyDead` (hermetic, existing tab-pane mock seams, no real tmux): render a live shell tab so stale capture is on screen, mark the session dead **before** entry, then `ScrollUp` → assert the fallback message renders, scroll mode is not entered, and the stale capture is gone. Confirmed **fail-before / pass-after**. Mirrors the #977 `TestTabPaneShellScrollModeSessionGoneExternally`.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — OK
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — all green
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/...` — green

Signed, Captain Claude 🫡

🤖 Generated with [Claude Code](https://claude.com/claude-code)