### PR TITLE
fix(autoupdate): skip Windows before the GitHub network check (#1002)

### DIFF
--- a/autoupdate.go
+++ b/autoupdate.go
@@ -46,6 +46,17 @@ func autoUpdate() error {
 	if !shouldCheck() {
 		return nil
 	}
+
+	// Auto-update is not supported on Windows, so skip before any network
+	// operations — there is nothing to fetch, download, or install (#1002).
+	// Still record the check so the 24-hour throttle fires and we don't probe
+	// shouldCheck() on every launch (#262). Use the runtimeGOOS seam so tests
+	// can exercise this branch without building for Windows.
+	if runtimeGOOS == "windows" {
+		recordCheck()
+		return nil
+	}
+
 	// Record the check up front so failure-prone steps below (network fetch,
 	// download, install) still honor the 24-hour throttle. Without this,
 	// persistent failures (blocked api.github.com, corp proxy, DNS) would
@@ -64,12 +75,9 @@ func autoUpdate() error {
 		return nil
 	}
 
+	// Windows already returned above, before any network call (#1002).
 	goos := runtimeGOOS
 	goarch := runtime.GOARCH
-	if goos == "windows" {
-		// Auto-update is not supported on Windows.
-		return nil
-	}
 
 	log.InfoLog.Printf("auto-update: updating from %s to %s", version, latestVersion)
 

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -68,7 +68,9 @@ func withTestHome(t *testing.T) string {
 // TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable guards against the
 // regression tracked in issue #262: on Windows, when a newer release exists,
 // the early-return path must still call recordCheck() so the 24-hour throttle
-// fires and the GitHub API is not hit on every launch.
+// fires and the GitHub API is not hit on every launch. It also guards #1002:
+// the Windows skip must precede any network call, so the fetch seam here is a
+// tripwire that fails the test if invoked.
 func TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable(t *testing.T) {
 	dir := withTestHome(t)
 	infoBuf, errBuf := captureLogs(t)
@@ -84,12 +86,20 @@ func TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable(t *testing.T) {
 
 	runtimeGOOS = "windows"
 	version = "1.0.0"
-	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.1", nil }
+	fetchCalls := 0
+	fetchLatestReleaseTagFn = func() (string, error) {
+		fetchCalls++
+		return "v1.0.1", nil
+	}
 
 	if err := autoUpdate(); err != nil {
 		t.Fatalf("autoUpdate returned error: %v", err)
 	}
 
+	// #1002: Windows must skip before touching the network.
+	if fetchCalls != 0 {
+		t.Fatalf("fetchLatestReleaseTagFn called %d times on Windows; expected 0 (network must be skipped before the GitHub check)", fetchCalls)
+	}
 	// last_update_check must exist so shouldCheck() returns false.
 	if _, err := os.Stat(filepath.Join(dir, lastCheckFile)); err != nil {
 		t.Fatalf("expected %s to be written after Windows early-return, got: %v",
@@ -108,10 +118,11 @@ func TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable(t *testing.T) {
 	}
 }
 
-// TestAutoUpdateWindowsRecordsCheckWhenNoUpdate exercises the pre-existing
-// code path where no update is available, which already recorded the check.
-// Included so both Windows branches are covered.
-func TestAutoUpdateWindowsRecordsCheckWhenNoUpdate(t *testing.T) {
+// TestAutoUpdateWindowsSkipsNetworkRegardlessOfVersion covers the Windows skip
+// for an up-to-date build. Since the skip now precedes the fetch (#1002), the
+// fetch seam is a tripwire: Windows must record the throttle and return without
+// any network call regardless of what version it is running.
+func TestAutoUpdateWindowsSkipsNetworkRegardlessOfVersion(t *testing.T) {
 	dir := withTestHome(t)
 
 	prevGOOS := runtimeGOOS
@@ -125,7 +136,10 @@ func TestAutoUpdateWindowsRecordsCheckWhenNoUpdate(t *testing.T) {
 
 	runtimeGOOS = "windows"
 	version = "1.0.1"
-	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.1", nil }
+	fetchLatestReleaseTagFn = func() (string, error) {
+		t.Fatalf("fetchLatestReleaseTagFn must not be called on Windows (#1002)")
+		return "", nil
+	}
 
 	if err := autoUpdate(); err != nil {
 		t.Fatalf("autoUpdate returned error: %v", err)


### PR DESCRIPTION
Closes #1002

## Root cause

`autoUpdate()` runs silently on every `af` launch. Auto-update is unsupported on Windows, but the `runtimeGOOS == "windows"` early-return was placed *after* `fetchLatestReleaseTagFn()` (the GitHub Releases API call) and after semver parsing. So every Windows launch paid for a pointless network round-trip to `api.github.com` only to bail out immediately afterward.

Introduced in `df7a752`: the original intent was "Nightly builds and Windows are skipped," but only the nightly handling stayed cheap — the Windows gate landed below the network call and survived the later throttling/logging fixes (#262, #459, #519).

## Fix

Move the Windows skip to run immediately after the 24h throttle gate (`shouldCheck()`) and **before any network operation**:

```go
if !shouldCheck() {
    return nil
}

// Auto-update is not supported on Windows, so skip before any network ops (#1002).
if runtimeGOOS == "windows" {
    recordCheck()
    return nil
}

recordCheck()
latestTag, err := fetchLatestReleaseTagFn()
```

The now-redundant Windows guard further down (after fetch/`isNewer`) is removed.

### recordCheck() on the Windows path — deliberate

Kept. The Windows path neither fetches nor installs (that's the whole point), but `recordCheck()` writes `last_update_check` so the 24-hour throttle still fires — without it, `shouldCheck()` would be re-evaluated on every launch (the symptom tracked in #262). Non-Windows throttle/`recordCheck` semantics are unchanged. The skip uses the existing `runtimeGOOS` seam (not `runtime.GOOS`) so it stays hermetically testable.

## Adjacent-site audit

Reviewed every early-exit / gate in `autoUpdate()` for ordering relative to network work:

- **Throttle (`shouldCheck()`)** — already precedes all network ops. ✅
- **Windows (`runtimeGOOS == "windows"`)** — was misordered; now fixed to precede the fetch. ✅
- **Nightly / non-semver builds** — there is no separate early-exit for these. Nightly builds carry a non-semver `version`, so `parseSemver` returns `nil` and `isNewer` returns `false`, harmlessly short-circuiting *after* the fetch. This isn't an unsupported-*platform* gate and reordering it would change behavior (a nightly build still legitimately reports the latest tag), so it is intentionally left as-is. The only remaining network-fronting gate of the "platform should not auto-update" kind was Windows.

No other unsupported-platform or early-exit gate sits after a network call.

## Tests (hermetic — `autoupdate_test.go`)

- `TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable` — now wires the fetch seam as a **tripwire** (counts calls) and asserts it is invoked **0 times** on Windows, in addition to the existing #262/#519 throttle + log assertions.
- `TestAutoUpdateWindowsSkipsNetworkRegardlessOfVersion` (was `…WhenNoUpdate`) — fetch seam `t.Fatalf`s if called; asserts the throttle is still recorded for an up-to-date Windows build.
- Non-Windows paths (`TestAutoUpdateCallsShutdownAfterBinarySwap`, fetch/download-failure throttle tests) unchanged and still fetch as before.

**fail-before / pass-after confirmed:** with the old ordering both Windows tripwire tests fail (`fetchLatestReleaseTagFn called 1 times … expected 0`); with the fix the package passes.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — pass
- `deadcode -test ./...` — clean
- `go test -race .` — pass

Did not run `./dev-install.sh` and did not touch the daemon.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)