### PR TITLE
fix(task): normalizeDOWField expands step expressions so Sunday (7→0) is not dropped (#1007)

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -33,33 +33,52 @@ func ParseCron(expr string) (cron.Schedule, error) {
 	return cronParser.Parse(strings.Join(fields, " "))
 }
 
-// normalizeDOWField rewrites a day-of-week field that mentions 7 (Sunday
-// alias) into an explicit value list with 7 mapped to 0, e.g. "5-7" →
-// "0,5,6". The result is deliberately kept as an explicit list rather than
-// collapsed back to "*" even when it covers all seven days: a syntactically
-// restricted DOW participates in cron's DOM/DOW OR semantics, and rewriting
-// it to a wildcard would change which days match when DOM is also restricted.
+// normalizeDOWField rewrites a day-of-week field that denotes 7 (Sunday alias)
+// into an explicit value list with 7 mapped to 0, e.g. "5-7" → "0,5,6". The
+// result is deliberately kept as an explicit list rather than collapsed back to
+// "*" even when it covers all seven days: a syntactically restricted DOW
+// participates in cron's DOM/DOW OR semantics, and rewriting it to a wildcard
+// would change which days match when DOM is also restricted.
 //
-// The 7→0 alias is applied to each comma-separated part *before* expansion
-// when 7 is the base of a step (e.g. "7/2" → "0/2"). Expanding first would
-// collapse "7/2" to the single value {7} — its step starts at the field's max
-// (7) so no further values follow — and then map it to {0}, silently turning
-// "every 2 days from Sunday" into "Sunday only" (#888). For every other shape
-// (a bare 7, a range bound of 7, a step that merely lands on 7) expansion
-// followed by normalizeDOWValues preserves the meaning, so those are left for
-// the expand path below.
+// Whether a field denotes Sunday is decided by *expanding* it (with max=7) and
+// checking for the value 7 — not by a literal "7" substring test. A literal
+// check misses step expressions like "1/2" that contain no "7" but expand to
+// [1,3,5,7]; those were passed unchanged to robfig (which bounds DOW to 0-6),
+// silently dropping Sunday (#1007).
+//
+// The 7→0 alias is applied to each comma-separated part *before* expansion when
+// 7 is the base of a step (e.g. "7/2" → "0/2"). Expanding first would collapse
+// "7/2" to the single value {7} — its step starts at the field's max (7) so no
+// further values follow — and then map it to {0}, silently turning "every 2
+// days from Sunday" into "Sunday only" (#888). Because that rewrite erases the
+// 7 from the expansion ("0/2" → [0,2,4,6]), a part whose step base was rewritten
+// is itself treated as denoting Sunday so it still normalizes to an explicit
+// list. For every other shape (a bare 7, a range bound of 7, a step that merely
+// lands on 7) expansion followed by normalizeDOWValues preserves the meaning.
 func normalizeDOWField(field string) string {
-	if field == "*" || !strings.Contains(field, "7") {
+	if field == "*" {
 		return field
 	}
 	listParts := strings.Split(field, ",")
+	rewroteStepBase := false
 	for i, part := range listParts {
-		listParts[i] = normalizeDOWStepBase(part)
+		if norm := normalizeDOWStepBase(part); norm != part {
+			listParts[i] = norm
+			rewroteStepBase = true
+		}
 	}
 	field = strings.Join(listParts, ",")
 
 	vals, err := expandCronField(field, 0, 7)
 	if err != nil || vals == nil {
+		return field
+	}
+	// Only rewrite into an explicit 0-based list when the field actually denotes
+	// Sunday: either its expansion includes the alias 7, or a "7/N" step base was
+	// rewritten to "0/N" above (whose expansion no longer shows a 7). Otherwise
+	// leave "*", ranges, and steps that never reach 7 untouched so they pass to
+	// robfig in their original shape.
+	if !containsSeven(vals) && !rewroteStepBase {
 		return field
 	}
 	vals = normalizeDOWValues(vals)
@@ -68,6 +87,18 @@ func normalizeDOWField(field string) string {
 		parts[i] = strconv.Itoa(v)
 	}
 	return strings.Join(parts, ",")
+}
+
+// containsSeven reports whether the expanded value list includes the Sunday
+// alias 7. expandCronField returns sorted values, so 7 (the field max) can only
+// be the final element, but a linear scan keeps the intent obvious.
+func containsSeven(vals []int) bool {
+	for _, v := range vals {
+		if v == 7 {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeDOWStepBase rewrites the Sunday alias 7→0 when it is the single-value

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -105,6 +105,9 @@ var validCronCorpus = []string{
 	"0 0 * * 0007/2", // even more leading zeros on the step base (#915)
 	"0 0 * * 0-7",    // full range incl. both Sunday aliases
 	"0 0 1 * 5-7",    // DOM restricted + DOW range with 7 (OR semantics)
+	"0 0 * * 1/2",    // step expanding to include 7 (Sunday) (#1007)
+	"0 0 * * 1/3",    // step expanding to include 7 (Sunday) (#1007)
+	"0 0 * * 2/5",    // step expanding to include 7 (Sunday) (#1007)
 }
 
 // TestParseCronAcceptsEverythingValidateAccepts is the agreement gate between
@@ -242,6 +245,32 @@ func TestParseCronDOWStepWithLeadingZeroBaseMatchesSeven(t *testing.T) {
 	}
 }
 
+// TestParseCronDOWStepExpandingToSevenFiresSunday is the regression for #1007:
+// a DOW step expression that contains no literal "7" but expands to include it
+// (e.g. "1/2" → [1,3,5,7]) must still fire on Sunday. Before the fix the
+// literal-"7" guard skipped normalization, "1/2" reached robfig as [1,3,5]
+// (robfig bounds DOW to 0-6), and Sunday was silently dropped.
+func TestParseCronDOWStepExpandingToSevenFiresSunday(t *testing.T) {
+	schedule, err := ParseCron("0 0 * * 1/2")
+	require.NoError(t, err)
+	// "1/2" ≡ {Mon,Wed,Fri,Sun}. 2026-06-13 is a Saturday; the next match must
+	// be Sunday 2026-06-14 — proving the expanded 7 was normalized to 0 rather
+	// than dropped.
+	from := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	assert.Equal(t, time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC), schedule.Next(from),
+		"1/2 must fire on Sunday")
+
+	// And it agrees with the explicit 0-based equivalent across a full week.
+	explicit, err := ParseCron("0 0 * * 0,1,3,5")
+	require.NoError(t, err)
+	cur, curExplicit := from, from
+	for i := 0; i < 4; i++ {
+		cur = schedule.Next(cur)
+		curExplicit = explicit.Next(curExplicit)
+		assert.Equal(t, curExplicit, cur, "1/2 firing %d must match 0,1,3,5", i)
+	}
+}
+
 func TestNormalizeDOWField(t *testing.T) {
 	cases := []struct {
 		in   string
@@ -260,7 +289,9 @@ func TestNormalizeDOWField(t *testing.T) {
 		{"07/2", "0,2,4,6"},      // leading-zero step base 7 (#888 + #743)
 		{"007/2", "0,2,4,6"},     // multi-leading-zero step base 7 (#915): numeric parse, not string compare
 		{"0007/2", "0,2,4,6"},    // arbitrary leading zeros on the step base (#915)
-		{"1/2", "1/2"},           // no 7 present; passes through untouched
+		{"1/2", "0,1,3,5"},       // expands to [1,3,5,7]; the 7 must normalize to 0 — Sunday kept (#1007)
+		{"1/3", "0,1,4"},         // expands to [1,4,7]; the 7 must normalize to 0 (#1007)
+		{"2/5", "0,2"},           // expands to [2,7]; the 7 must normalize to 0 (#1007)
 		{"3,7/2", "0,2,3,4,6"},   // 7-step base inside a list still keeps its step (#888)
 		{"0-7", "0,1,2,3,4,5,6"}, // full range incl. both Sunday aliases (#770: explicit list, never "*")
 		{"1-7", "0,1,2,3,4,5,6"}, // range to the 7 alias covers the whole week as a list (#770)


### PR DESCRIPTION
Closes #1007

## Root cause

`task/cron.go` `normalizeDOWField` mapped the day-of-week Sunday alias `7 → 0` for robfig (which bounds DOW to `0-6`), but guarded the whole normalization with an early return:

```go
if field == "*" || !strings.Contains(field, "7") { return field }
```

The `!strings.Contains(field, "7")` test only inspects the **input string**, not what it **expands to**. Step expressions contain no literal `"7"` yet expand (with `max=7`) to a list that includes `7`:

- `1/2` → `[1,3,5,7]`
- `1/3` → `[1,4,7]`
- `2/5` → `[2,7]`

These returned early, reached robfig unchanged, and robfig dropped the out-of-range `7` — so **Sunday silently never fired** for those schedules.

Introduced in #791, which replaced the old `convertDOW` (always expanded step expressions before mapping `7→0`) with `normalizeDOWField` plus this string-containment optimization.

## Fix

Replace the literal-substring guard with the **expansion-based** check the issue recommends:

1. Apply the existing `7/N → 0/N` step-base rewrite up front (preserves "every N days from Sunday", #888).
2. Expand the field with `max=7`.
3. Rewrite into an explicit 0-based list **only** when the expansion actually includes `7`, **or** a `7/N` step base was just rewritten to `0/N` (whose expansion no longer shows a `7` but still denotes Sunday).
4. Otherwise leave `*`, ranges, and steps that never reach `7` in their original shape — single expansion, no double-expand, non-DOW fields untouched.

A small `containsSeven([]int) bool` helper makes the intent explicit.

## Adjacent-site audit

- `normalizeDOWField` has a single caller: `ParseCron` (`task/cron.go:32`), which `daemon/scheduler.go:35` uses as its parse function — the **entire DOW path funnels through this one function**, so the fix covers every scheduled task.
- Grepped for the same anti-pattern: the only literal-`"7"` cron-field guard was the buggy one. The other `strings.Contains` calls (`task/runner.go`) detect agent terminal output and are unrelated. Minute/hour/dom/month have no alias to remap, so no other field normalizer carries this class of bug.
- Confirmed every fixed/preserved form still parses cleanly in robfig via the validator↔scheduler agreement gate (`TestParseCronAcceptsEverythingValidateAccepts`), now extended with `1/2`, `1/3`, `2/5`.

## Tests

- Updated `TestNormalizeDOWField`: the case that **encoded the bug** (`{"1/2", "1/2"}`) now asserts `{"1/2", "0,1,3,5"}`; added `1/3 → 0,1,4` and `2/5 → 0,2`. Existing `7/2`/`07/2`/`007/2`/`*/2`/`0/2`/`1-5`/`7`/`*` cases all still hold (passthrough vs. normalize behavior preserved).
- New `TestParseCronDOWStepExpandingToSevenFiresSunday`: asserts the **schedule actually fires on Sunday** — `0 0 * * 1/2` from a Saturday lands on Sunday, and agrees with the explicit `0,1,3,5` equivalent across a full week.
- **Fail-before / pass-after** confirmed: the new tests fail against the old code (`1/3`→`1/3`, `2/5`→`2/5`, Sunday dropped) and pass with the fix.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` clean · `go test ./...` green · `deadcode -test ./...` clean · `GOFLAGS="-p=1" go test -race -parallel 2 ./task/...` ok.

Did not run `./dev-install.sh` or touch the real daemon.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
