### PR TITLE
fix(daemon): watcher backoff does not double after a healthy-run reset (#1005)

### DIFF
--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -431,22 +431,39 @@ func (w *taskWatcher) run() {
 			return
 		}
 
-		// A run that stayed healthy for a whole crash window earns a fresh
-		// backoff; otherwise keep doubling toward the cap.
-		if now.Sub(started) >= w.sup.crashWindow {
-			backoff = w.sup.baseBackoff
-		}
-		log.WarningLog.Printf("watch task %s: watch command failed (%v); restarting in %s%s", w.taskID, runErr, backoff, tail.logSuffix())
+		// A run that stayed healthy for a whole crash window restarts the
+		// backoff chain at baseBackoff; an unhealthy run keeps doubling toward
+		// the cap. The healthy reset must NOT also advance the backoff this
+		// cycle — otherwise the next quick failure would wait 2*baseBackoff
+		// instead of restarting the documented 1s→2s→4s… chain at baseBackoff
+		// (#1005).
+		healthy := now.Sub(started) >= w.sup.crashWindow
+		wait, next := nextBackoff(backoff, w.sup.baseBackoff, w.sup.maxBackoff, healthy)
+		log.WarningLog.Printf("watch task %s: watch command failed (%v); restarting in %s%s", w.taskID, runErr, wait, tail.logSuffix())
 		select {
 		case <-w.stopCh:
 			return
-		case <-time.After(backoff):
+		case <-time.After(wait):
 		}
-		backoff *= 2
-		if backoff > w.sup.maxBackoff {
-			backoff = w.sup.maxBackoff
-		}
+		backoff = next
 	}
+}
+
+// nextBackoff computes the delay before the next restart and the backoff to
+// carry into the following cycle. A run that stayed healthy for a whole crash
+// window resets the chain: it waits baseBackoff and leaves the carried backoff
+// at baseBackoff, so the next failure restarts the documented 1s→2s→4s…
+// sequence from the base rather than from 2*baseBackoff (#1005). An unhealthy
+// run waits the current backoff and doubles it toward maxBackoff for next time.
+func nextBackoff(current, base, max time.Duration, healthy bool) (wait, next time.Duration) {
+	if healthy {
+		return base, base
+	}
+	next = current * 2
+	if next > max {
+		next = max
+	}
+	return current, next
 }
 
 // exitedFromSignal reports whether err is an exec exit caused by the given

--- a/daemon/watcher_backoff_test.go
+++ b/daemon/watcher_backoff_test.go
@@ -1,0 +1,92 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWatcherBackoffResetsAfterHealthyRun pins the restart-backoff state
+// machine (#1005). A run that stays healthy for a whole crash window resets the
+// chain to baseBackoff and must NOT advance it that cycle, so the next quick
+// failure restarts the documented 1s→2s→4s… sequence at baseBackoff instead of
+// jumping to 2*baseBackoff. The loop below mirrors taskWatcher.run: it carries
+// the backoff forward across runs and asserts the wait emitted for each
+// restart. Pure and hermetic — no watch processes, no wall-clock sleeps.
+func TestWatcherBackoffResetsAfterHealthyRun(t *testing.T) {
+	const (
+		base = time.Second
+		max  = 5 * time.Minute
+	)
+
+	type step struct {
+		healthy  bool
+		wantWait time.Duration
+	}
+	steps := []step{
+		// Fresh crash chain doubles from the base: 1s → 2s → 4s → 8s.
+		{false, 1 * time.Second},
+		{false, 2 * time.Second},
+		{false, 4 * time.Second},
+		{false, 8 * time.Second},
+		// A run that stayed healthy for the crash window resets the wait to
+		// the base …
+		{true, 1 * time.Second},
+		// … and the NEXT quick failure must restart the chain at the base.
+		// This is the #1005 regression: the old unconditional `backoff *= 2`
+		// made this wait 2s. It then doubles afresh.
+		{false, 1 * time.Second},
+		{false, 2 * time.Second},
+		{false, 4 * time.Second},
+	}
+
+	backoff := base
+	for i, s := range steps {
+		wait, next := nextBackoff(backoff, base, max, s.healthy)
+		if wait != s.wantWait {
+			t.Fatalf("step %d (healthy=%v): wait = %s, want %s", i, s.healthy, wait, s.wantWait)
+		}
+		backoff = next
+	}
+}
+
+// TestWatcherBackoffDoublesToCapOnUnhealthyRuns pins the unhealthy path:
+// repeated quick failures double the wait and saturate at maxBackoff, never
+// overshooting it.
+func TestWatcherBackoffDoublesToCapOnUnhealthyRuns(t *testing.T) {
+	const (
+		base = time.Second
+		max  = 5 * time.Minute
+	)
+
+	backoff := base
+	for i := 0; i < 20; i++ {
+		wait, next := nextBackoff(backoff, base, max, false)
+		if wait > max {
+			t.Fatalf("iteration %d: wait %s exceeded the %s cap", i, wait, max)
+		}
+		if next > max {
+			t.Fatalf("iteration %d: carried backoff %s exceeded the %s cap", i, next, max)
+		}
+		backoff = next
+	}
+	if backoff != max {
+		t.Fatalf("backoff settled at %s, want the %s cap", backoff, max)
+	}
+	// Once pinned at the cap, every further unhealthy cycle stays there.
+	if wait, next := nextBackoff(max, base, max, false); wait != max || next != max {
+		t.Fatalf("at cap: wait/next = %s/%s, want %s/%s", wait, next, max, max)
+	}
+}
+
+// TestWatcherBackoffHealthyRunResetsFromCap pins the reset even from the top of
+// the chain: a healthy run after the backoff has climbed to the cap still drops
+// the wait straight back to the base and carries the base forward.
+func TestWatcherBackoffHealthyRunResetsFromCap(t *testing.T) {
+	const (
+		base = time.Second
+		max  = 5 * time.Minute
+	)
+	if wait, next := nextBackoff(max, base, max, true); wait != base || next != base {
+		t.Fatalf("healthy reset from cap: wait/next = %s/%s, want %s/%s", wait, next, base, base)
+	}
+}


### PR DESCRIPTION
## Root cause

The watch-task supervision loop in `daemon/watcher.go` reset the restart backoff to `baseBackoff` after a run stayed healthy for a whole crash window, but then ran `backoff *= 2` **unconditionally**:

```go
if now.Sub(started) >= w.sup.crashWindow {
    backoff = w.sup.baseBackoff
}
... wait backoff ...
backoff *= 2   // <- runs even after the healthy-run reset
```

So a healthy run that fails waited `baseBackoff` (1s) but advanced the *carried* backoff to `2*baseBackoff`. The **next** quick failure then waited 2s instead of restarting the documented `1s→2s→4s…` chain at 1s. This contradicts both the code comment (“…earns a fresh backoff…”) and `docs/tasks.md` (“A run that stays healthy for 10 minutes resets the backoff”).

## Fix

Extract the backoff state transition into a pure, directly-testable helper:

```go
func nextBackoff(current, base, max time.Duration, healthy bool) (wait, next time.Duration) {
    if healthy {
        return base, base            // wait base, carry base — no doubling this cycle
    }
    next = current * 2
    if next > max {
        next = max
    }
    return current, next             // wait current, double toward the cap
}
```

`run()` now does `wait, next := nextBackoff(...)`, sleeps `wait` (stop-channel select preserved), and sets `backoff = next`. A healthy run restarts the chain fresh at `baseBackoff → 2x → 4x…`; an unhealthy run keeps doubling toward `maxBackoff` (cap preserved).

## Adjacent-site audit

`backoff` is now touched in exactly two places: initialized to `baseBackoff` at the top of `run()`, and advanced solely through `nextBackoff`. A repo-wide grep confirms no other reset/advance site. `docs/tasks.md` already described the intended behavior, so **no doc change is needed** — the code now matches the doc it was violating.

## Tests

New `daemon/watcher_backoff_test.go` — fully hermetic (no watch processes, no wall-clock sleeps):

- `TestWatcherBackoffResetsAfterHealthyRun` — pins the fresh-chain doubling (1s→2s→4s→8s), the healthy reset back to 1s, and the post-reset restart at `baseBackoff`. **Fails on the old code** at exactly `step 5 (healthy=false): wait = 2s, want 1s`; **passes after the fix** (verified by temporarily reintroducing the unconditional double).
- `TestWatcherBackoffDoublesToCapOnUnhealthyRuns` — unhealthy failures double and saturate at `maxBackoff`, never overshooting.
- `TestWatcherBackoffHealthyRunResetsFromCap` — a healthy run resets to base even from the cap.

The existing `TestWatcherBackoffAndCrashLoopBreaker` still exercises the real `run()` loop with live backoff sleeps and passes unchanged.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./...` — all packages pass
- `GOFLAGS="-p=1" go test -race -parallel 2 ./daemon/...` — ok

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)