### PR TITLE
fix(task): reject enabling a cron task with an empty prompt (#1000)

### DIFF
--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -281,7 +281,7 @@ func TestTasksUpdate_DisablePersistsAndPokesDaemon(t *testing.T) {
 	resetUpdateFlags(t)
 	calls := stubDaemon(t)
 
-	seedTask(t, task.Task{ID: "t1", CronExpr: "0 9 * * *", Enabled: true})
+	seedTask(t, task.Task{ID: "t1", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
 
 	taskUpdateEnabledFlag = "false"
 	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t1"})
@@ -298,7 +298,7 @@ func TestTasksUpdate_CronChangePersistsAndPokesDaemon(t *testing.T) {
 	resetUpdateFlags(t)
 	calls := stubDaemon(t)
 
-	seedTask(t, task.Task{ID: "t2", CronExpr: "0 9 * * *", Enabled: true})
+	seedTask(t, task.Task{ID: "t2", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
 
 	taskUpdateCronFlag = "30 6 * * 1"
 	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t2"})
@@ -315,7 +315,7 @@ func TestTasksUpdate_RejectsInvalidCron(t *testing.T) {
 	resetUpdateFlags(t)
 	calls := stubDaemon(t)
 
-	seedTask(t, task.Task{ID: "t3", CronExpr: "0 9 * * *", Enabled: true})
+	seedTask(t, task.Task{ID: "t3", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
 
 	taskUpdateCronFlag = "not a cron"
 	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t3"})
@@ -451,7 +451,7 @@ func TestTasksUpdate_RejectsBadEnabledValue(t *testing.T) {
 	resetUpdateFlags(t)
 	calls := stubDaemon(t)
 
-	seedTask(t, task.Task{ID: "t4", CronExpr: "0 9 * * *", Enabled: true})
+	seedTask(t, task.Task{ID: "t4", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
 
 	taskUpdateEnabledFlag = "yes"
 	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t4"})
@@ -464,7 +464,7 @@ func TestTasksRemove_RemovesTaskAndPokesDaemon(t *testing.T) {
 	useTempConfig(t)
 	calls := stubDaemon(t)
 
-	seedTask(t, task.Task{ID: "t5", CronExpr: "0 9 * * *", Enabled: true})
+	seedTask(t, task.Task{ID: "t5", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
 
 	err := tasksRemoveCmd.RunE(tasksRemoveCmd, []string{"t5"})
 	require.NoError(t, err)

--- a/daemon/scheduler_test.go
+++ b/daemon/scheduler_test.go
@@ -58,7 +58,7 @@ func TestSchedulerReloadFollowsTaskCRUD(t *testing.T) {
 	s := newTaskScheduler()
 
 	mk := func(id string) task.Task {
-		return task.Task{ID: id, CronExpr: "0 3 * * *", Enabled: true, CreatedAt: time.Now()}
+		return task.Task{ID: id, Prompt: "p", CronExpr: "0 3 * * *", Enabled: true, CreatedAt: time.Now()}
 	}
 
 	// Add two tasks.

--- a/task/task.go
+++ b/task/task.go
@@ -79,6 +79,12 @@ func (t Task) IsWatch() bool {
 // task must have exactly one of the two. A disabled task with neither is
 // tolerated as a draft so hand-edited or legacy records never brick the
 // store.
+//
+// An enabled cron task must additionally carry a non-empty prompt (#1000). A
+// cron fire has no event line to fall back to, so the runtime skips an empty
+// prompt and produces a session that silently does nothing. Watch tasks are
+// exempt: an empty prompt defaults to the emitted line (see RenderWatchPrompt).
+// Disabled drafts are still tolerated regardless of prompt.
 func (t Task) ValidateTrigger() error {
 	hasCron := strings.TrimSpace(t.CronExpr) != ""
 	hasWatch := strings.TrimSpace(t.WatchCmd) != ""
@@ -87,6 +93,9 @@ func (t Task) ValidateTrigger() error {
 	}
 	if t.Enabled && !hasCron && !hasWatch {
 		return fmt.Errorf("task %s is enabled but has neither cron_expr nor watch_cmd; exactly one trigger is required", t.ID)
+	}
+	if t.Enabled && hasCron && strings.TrimSpace(t.Prompt) == "" {
+		return fmt.Errorf("task %s is an enabled cron task but has an empty prompt; a prompt is required", t.ID)
 	}
 	return nil
 }

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -266,7 +266,7 @@ func TestLoadTaskWithoutProgramFieldFallsBackToEmpty(t *testing.T) {
 // through the TUI must survive a SaveTasks -> LoadTasks round-trip.
 func TestUpdateTaskPersistsProgram(t *testing.T) {
 	tasks := []Task{
-		{ID: "p1", Name: "Original", Program: "claude", CronExpr: "0 3 * * *", Enabled: true},
+		{ID: "p1", Name: "Original", Prompt: "do the thing", Program: "claude", CronExpr: "0 3 * * *", Enabled: true},
 	}
 	setupTestTasks(t, tasks)
 
@@ -409,7 +409,7 @@ func TestUpdateTaskStatus_NotFound(t *testing.T) {
 // reject a non-enum Program so the TUI/CLI editor flows fail fast.
 func TestUpdateTask_RejectsBadProgram(t *testing.T) {
 	stored := []Task{
-		{ID: "edit1", Name: "Editable", Program: "claude", CronExpr: "0 3 * * *", Enabled: true},
+		{ID: "edit1", Name: "Editable", Prompt: "do the thing", Program: "claude", CronExpr: "0 3 * * *", Enabled: true},
 	}
 	setupTestTasks(t, stored)
 
@@ -435,28 +435,39 @@ func TestTaskNameInJSON(t *testing.T) {
 
 // TestValidateTrigger pins the #782 trigger contract: both triggers set is
 // always invalid, an enabled task needs exactly one, and a disabled task with
-// neither is tolerated as a draft.
+// neither is tolerated as a draft. It also pins the #1000 rule: an enabled cron
+// task must carry a non-empty prompt, while watch tasks and disabled drafts may
+// have an empty prompt.
 func TestValidateTrigger(t *testing.T) {
 	cases := []struct {
 		name    string
 		cron    string
 		watch   string
+		prompt  string
 		enabled bool
 		wantErr bool
 	}{
-		{"enabled cron only", "0 3 * * *", "", true, false},
-		{"enabled watch only", "", "tail -f log", true, false},
-		{"enabled both", "0 3 * * *", "tail -f log", true, true},
-		{"enabled neither", "", "", true, true},
-		{"enabled whitespace counts as unset", "   ", "  ", true, true},
-		{"disabled cron only", "0 3 * * *", "", false, false},
-		{"disabled watch only", "", "tail -f log", false, false},
-		{"disabled both", "0 3 * * *", "tail -f log", false, true},
-		{"disabled neither (draft)", "", "", false, false},
+		{"enabled cron only", "0 3 * * *", "", "do the thing", true, false},
+		{"enabled watch only", "", "tail -f log", "", true, false},
+		{"enabled both", "0 3 * * *", "tail -f log", "p", true, true},
+		{"enabled neither", "", "", "p", true, true},
+		{"enabled whitespace counts as unset", "   ", "  ", "p", true, true},
+		{"disabled cron only", "0 3 * * *", "", "", false, false},
+		{"disabled watch only", "", "tail -f log", "", false, false},
+		{"disabled both", "0 3 * * *", "tail -f log", "p", false, true},
+		{"disabled neither (draft)", "", "", "", false, false},
+		// #1000: enabling a cron task with an empty/whitespace prompt is a
+		// silent no-op at run time, so the model layer rejects it.
+		{"enabled cron empty prompt", "0 3 * * *", "", "", true, true},
+		{"enabled cron whitespace prompt", "0 3 * * *", "", "   ", true, true},
+		// Watch tasks legitimately default an empty prompt to the emitted line.
+		{"enabled watch empty prompt ok", "", "tail -f log", "", true, false},
+		// Disabled cron drafts with an empty prompt are tolerated.
+		{"disabled cron empty prompt (draft)", "0 3 * * *", "", "", false, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tsk := Task{ID: "aaaa0001", CronExpr: tc.cron, WatchCmd: tc.watch, Enabled: tc.enabled}
+			tsk := Task{ID: "aaaa0001", CronExpr: tc.cron, WatchCmd: tc.watch, Prompt: tc.prompt, Enabled: tc.enabled}
 			err := tsk.ValidateTrigger()
 			if tc.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
Closes #1000

## Root cause

`Task.ValidateTrigger()` (task/task.go) — the chokepoint `AddTask`/`UpdateTask` both call — only enforced the #782 trigger contract (cron XOR watch, enabled needs a trigger), **not** prompt completeness. The store tolerates *disabled* draft cron tasks with an empty prompt. But nothing stopped a draft from being **enabled** with the prompt still empty — via `af tasks update --enabled true`, the TUI enable toggle, or a hand-edited `tasks.json`. When the scheduler fired such a task, the runtime skips an empty prompt and creates a session that receives no instructions → a silent no-op.

Introduced in #794 (`f6c5463`): `ValidateTrigger` added the "exactly one trigger" rule but missed the non-empty-prompt check that had existed only at the CLI layer (`925720b`).

## Fix

Add one branch to `ValidateTrigger`:

```go
if t.Enabled && hasCron && strings.TrimSpace(t.Prompt) == "" {
    return fmt.Errorf("task %s is an enabled cron task but has an empty prompt; a prompt is required", t.ID)
}
```

- **Enabled cron + empty/whitespace prompt → rejected.**
- **Watch tasks are exempt** — an empty prompt legitimately defaults to the emitted line (`RenderWatchPrompt`).
- **Disabled drafts remain tolerated** regardless of prompt.
- The existing cron-XOR-watch and enabled-needs-a-trigger checks are unchanged.

Error-message style matches the existing api/tasks.go message ("switching to a cron trigger needs a prompt").

## Adjacent-site audit

All enable/create paths funnel through the model-layer chokepoint, so the single check covers them with no double error or contradiction:

| Path | Reaches `ValidateTrigger`? | Notes |
|------|---------------------------|-------|
| `af tasks update --enabled true` (CLI/API) | ✅ via `UpdateTask` | Was the primary gap. |
| TUI enable toggle | ✅ via `UpdateTask` | Same chokepoint. |
| Hand-edited `tasks.json` + any subsequent update | ✅ via `UpdateTask` | Rejected on next write. |
| `af tasks add` | ✅ via `AddTask` | Also had a CLI-layer prompt guard (api/tasks.go:116). |
| api watch→cron switch (`--cron`) | ✅ + pre-existing api guard (api/tasks.go:289) | The api guard fires first with its own message; if bypassed, `UpdateTask`'s `ValidateTrigger` still catches it. Composes — no contradiction. |

No surface enables a task without going through `AddTask`/`UpdateTask`.

## Tests

Hermetic, table-driven additions to `TestValidateTrigger` (task/task_test.go):
- enabled cron + empty prompt → errors
- enabled cron + whitespace prompt → errors
- enabled cron + non-empty prompt → ok
- enabled **watch** + empty prompt → ok (still allowed)
- disabled cron + empty prompt (draft) → ok

Confirmed **fail-before / pass-after**: with the production branch removed, the two new empty-prompt subtests FAIL; with it in place, all pass. Pre-existing fixtures that seeded enabled cron tasks without a prompt (and went through `AddTask`/`UpdateTask`) were given a valid prompt so their original intent is preserved.

## Verification

`gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --timeout=3m --fast` clean · `go test ./...` green · `deadcode -test ./...` clean · `GOFLAGS="-p=1" go test -race -parallel 2 ./task/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude