### PR TITLE
fix(tmux): use exact-match (-t =name:) targets for capture-pane/send-keys/kill-session to avoid sibling prefix collisions (#1006)

### DIFF
--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -43,7 +43,9 @@ func nameKeyedTmuxExec() cmd_test.MockCmdExec {
 		for i, a := range cmd.Args {
 			switch {
 			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
-				return cmd.Args[i+1]
+				// Strip the exact-match `=name:` wrapper (`-t =name:`) so the
+				// modeled session name matches the bare key tmux resolves to (#1006).
+				return strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
 			case strings.HasPrefix(a, "-t="):
 				return strings.TrimPrefix(a, "-t=")
 			case strings.HasPrefix(a, "-s="):

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -46,7 +46,9 @@ func tabNameKeyedExec(alive map[string]bool) cmd_test.MockCmdExec {
 		for i, a := range cmd.Args {
 			switch {
 			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
-				return cmd.Args[i+1]
+				// Strip the exact-match `=name:` wrapper (`-t =name:`) so the
+				// modeled session name matches the bare key tmux resolves to (#1006).
+				return strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
 			case strings.HasPrefix(a, "-t="):
 				return strings.TrimPrefix(a, "-t=")
 			case strings.HasPrefix(a, "-s="):

--- a/session/dead_respawn_test.go
+++ b/session/dead_respawn_test.go
@@ -29,7 +29,9 @@ func countingExec(alive map[string]bool, newSessions *int) cmd_test.MockCmdExec 
 		for i, a := range cmd.Args {
 			switch {
 			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
-				return cmd.Args[i+1]
+				// Strip the exact-match `=name:` wrapper (`-t =name:`) so the modeled
+				// session name matches the bare key tmux resolves to (#1006).
+				return strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
 			case strings.HasPrefix(a, "-t="):
 				return strings.TrimPrefix(a, "-t=")
 			case strings.HasPrefix(a, "-s="):

--- a/session/tab_close_idempotent_test.go
+++ b/session/tab_close_idempotent_test.go
@@ -29,7 +29,9 @@ func deadAwareExec(alive map[string]bool) cmd_test.MockCmdExec {
 		for i, a := range c.Args {
 			switch {
 			case (a == "-t" || a == "-s") && i+1 < len(c.Args):
-				return c.Args[i+1]
+				// Strip the exact-match `=name:` wrapper (`-t =name:`) so the modeled
+				// session name matches the bare key tmux resolves to (#1006).
+				return strings.TrimSuffix(strings.TrimPrefix(c.Args[i+1], "="), ":")
 			case strings.HasPrefix(a, "-t="):
 				return strings.TrimPrefix(a, "-t=")
 			case strings.HasPrefix(a, "-s="):

--- a/session/tab_kill_race_test.go
+++ b/session/tab_kill_race_test.go
@@ -30,7 +30,9 @@ func raceHookExec(alive map[string]bool, onNewSession func()) (cmd_test.MockCmdE
 		for i, a := range cmd.Args {
 			switch {
 			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
-				return cmd.Args[i+1]
+				// Strip the exact-match `=name:` wrapper (`-t =name:`) so the modeled
+				// session name matches the bare key tmux resolves to (#1006).
+				return strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
 			case strings.HasPrefix(a, "-t="):
 				return strings.TrimPrefix(a, "-t=")
 			case strings.HasPrefix(a, "-s="):

--- a/session/tab_persist_test.go
+++ b/session/tab_persist_test.go
@@ -48,7 +48,9 @@ func nameKeyedExec(alive map[string]bool) cmd_test.MockCmdExec {
 		for i, a := range cmd.Args {
 			switch {
 			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
-				return cmd.Args[i+1]
+				// Strip the exact-match `=name:` wrapper (`-t =name:`) so the modeled
+				// session name matches the bare key tmux resolves to (#1006).
+				return strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
 			case strings.HasPrefix(a, "-t="):
 				return strings.TrimPrefix(a, "-t=")
 			case strings.HasPrefix(a, "-s="):

--- a/session/tmux/cleanup_bug_test.go
+++ b/session/tmux/cleanup_bug_test.go
@@ -34,8 +34,8 @@ af_real_session: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 
 	err := CleanupSessions(cmdExec)
 	require.NoError(t, err)
-	require.Equal(t, []string{"af_real_session"}, killedSessions,
-		"only `af_`-prefixed sessions should be killed; `my_af_project` must be left alone")
+	require.Equal(t, []string{"=af_real_session:"}, killedSessions,
+		"only `af_`-prefixed sessions should be killed, each via an `=name:` exact-match target (#1006); `my_af_project` must be left alone")
 }
 
 // TestCleanupSessionsHandlesMixedAndColonNames covers the full matrix from
@@ -66,6 +66,6 @@ af_a:b:c: 1 windows (created Wed May 20 12:03:00 2026) [179x47]`
 
 	err := CleanupSessions(cmdExec)
 	require.NoError(t, err)
-	require.Equal(t, []string{"af_real_session", "af_a"}, killedSessions,
-		"only `af_`-prefixed sessions should be killed, with `af_a:b:c` truncated to `af_a` and killed exactly once")
+	require.Equal(t, []string{"=af_real_session:", "=af_a:"}, killedSessions,
+		"only `af_`-prefixed sessions should be killed via `=name:` exact-match targets (#1006), with `af_a:b:c` truncated to `af_a` and killed exactly once")
 }

--- a/session/tmux/exact_target_test.go
+++ b/session/tmux/exact_target_test.go
@@ -1,0 +1,155 @@
+package tmux
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/stretchr/testify/require"
+)
+
+// #1006: tmux resolves `-t name` by exact match first, then falls back to a
+// PREFIX match. The agent session `af_proj` is an exact prefix of its surviving
+// shell tab `af_proj__shell`, so once the agent dies a bare `-t af_proj` target
+// silently resolves to the shell session. Action commands must pass `-t =name`
+// to force an exact match and never prefix-collide with a sibling.
+
+// targetOf extracts the session target spec from a tmux argv, preserving the
+// exact-match `=` marker. It handles both the two-arg (`-t`, `=name:`) form and
+// the single-arg (`-t=name`) form; the latter is normalized to `=name` because
+// `-t=name` is itself an exact-match target.
+func targetOf(args []string) string {
+	for i, a := range args {
+		if a == "-t" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "-t=") {
+			return "=" + strings.TrimPrefix(a, "-t=")
+		}
+	}
+	return ""
+}
+
+// resolveTmuxTarget models tmux's real target resolution: an `=`-prefixed
+// target matches only the exact name; a bare target matches exactly first and
+// otherwise falls back to a unique prefix match. The trailing `:` window
+// separator that exact-match pane targets carry (`=name:`) is stripped before
+// matching. Returns the resolved session name and whether a session was found.
+func resolveTmuxTarget(target string, sessions map[string]bool) (string, bool) {
+	if strings.HasPrefix(target, "=") {
+		name := strings.TrimSuffix(strings.TrimPrefix(target, "="), ":")
+		return name, sessions[name]
+	}
+	if sessions[target] {
+		return target, true
+	}
+	var match string
+	n := 0
+	for s := range sessions {
+		if strings.HasPrefix(s, target) {
+			match, n = s, n+1
+		}
+	}
+	if n == 1 {
+		return match, true
+	}
+	return "", false
+}
+
+// TestActionCommandsUseExactMatchTargets asserts every tmux action command the
+// daemon and TUI issue against an agent session carries an `=name` exact-match
+// target. This fails before the #1006 fix (bare `-t name`) and passes after.
+func TestActionCommandsUseExactMatchTargets(t *testing.T) {
+	const name = "af_proj"
+	var targets []string
+	record := func(args []string) {
+		if strings.Contains(strings.Join(args, " "), "has-session") {
+			return // existence probe already uses -t=, asserted elsewhere
+		}
+		if tgt := targetOf(args); tgt != "" {
+			targets = append(targets, tgt)
+		}
+	}
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			record(c.Args)
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			record(c.Args)
+			return []byte("content"), nil
+		},
+	}
+
+	session := newTmuxSession(name, "claude", NewMockPtyFactory(t), cmdExec)
+
+	_, err := session.CapturePaneContent()
+	require.NoError(t, err)
+	_, err = session.CapturePaneContentWithOptions("-", "-")
+	require.NoError(t, err)
+	require.NoError(t, session.SendKeysCommand("hello"))
+
+	require.NotEmpty(t, targets)
+	for _, tgt := range targets {
+		require.Equal(t, fmt.Sprintf("=%s:", name), tgt,
+			"every action command must target the agent session by exact match (#1006); got %q", tgt)
+	}
+}
+
+// TestDeadAgentWithLiveShellSiblingIsNotPrefixMatched is the end-to-end #1006
+// regression: the agent session `af_proj` has died but its `af_proj__shell` tab
+// survives. With bare `-t af_proj` targets, capture-pane prefix-matches the
+// shell, returns shell output, and HasUpdated reports updated=true — masking
+// the dead agent and skipping the liveness check. With exact `-t =af_proj`
+// targets, capture and has-session both correctly miss, so the corpse is seen.
+func TestDeadAgentWithLiveShellSiblingIsNotPrefixMatched(t *testing.T) {
+	const agentName = "af_proj"
+	shellName := agentName + "__shell"
+	// Only the shell sibling is alive; the agent session is gone.
+	sessions := map[string]bool{shellName: true}
+
+	var capturedShell bool
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			if strings.Contains(strings.Join(c.Args, " "), "has-session") {
+				if _, ok := resolveTmuxTarget(targetOf(c.Args), sessions); ok {
+					return nil
+				}
+				return fmt.Errorf("can't find session")
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			if strings.Contains(strings.Join(c.Args, " "), "capture-pane") {
+				resolved, ok := resolveTmuxTarget(targetOf(c.Args), sessions)
+				if !ok {
+					return nil, fmt.Errorf("exit status 1")
+				}
+				if resolved == shellName {
+					capturedShell = true
+				}
+				return []byte("resolved:" + resolved), nil
+			}
+			return []byte("output"), nil
+		},
+	}
+
+	session := newTmuxSession(agentName, "claude", NewMockPtyFactory(t), cmdExec)
+	session.monitor = newStatusMonitor()
+
+	// Capturing the dead agent must surface ErrSessionGone, never the shell's
+	// content via a prefix match.
+	_, err := session.CapturePaneContent()
+	require.ErrorIs(t, err, ErrSessionGone,
+		"a dead agent with a live __shell sibling must report gone, not capture the shell (#1006)")
+	require.False(t, capturedShell, "capture-pane must not resolve to the sibling shell session")
+
+	// HasUpdated must not report the agent as updated/alive off the shell's
+	// content; it must latch the monitor dead.
+	updated, hasPrompt := session.HasUpdated()
+	require.False(t, updated, "a dead agent must not be marked updated via its shell sibling (#1006)")
+	require.False(t, hasPrompt)
+	require.True(t, session.monitor.dead, "monitor must latch dead once the agent session is confirmed gone")
+}

--- a/session/tmux/idempotent_close_test.go
+++ b/session/tmux/idempotent_close_test.go
@@ -86,7 +86,9 @@ af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 	nameOf := func(c *exec.Cmd) string {
 		for i, a := range c.Args {
 			if a == "-t" && i+1 < len(c.Args) {
-				return c.Args[i+1]
+				// Strip the exact-match `=name:` wrapper (`-t =name:`) so the modeled
+				// session name matches the bare key tmux resolves to (#1006).
+				return strings.TrimSuffix(strings.TrimPrefix(c.Args[i+1], "="), ":")
 			}
 			if strings.HasPrefix(a, "-t=") {
 				return strings.TrimPrefix(a, "-t=")

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -236,7 +236,7 @@ func (t *TmuxSession) Start(workDir string) error {
 	if err != nil {
 		// Cleanup any partially created session if any exists.
 		if t.DoesSessionExist() {
-			cleanupCmd := exec.Command("tmux", "kill-session", "-t", t.sanitizedName)
+			cleanupCmd := exec.Command("tmux", "kill-session", "-t", exactTarget(t.sanitizedName))
 			if cleanupErr := t.cmdExec.Run(cleanupCmd); cleanupErr != nil {
 				err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
 			}
@@ -267,13 +267,13 @@ func (t *TmuxSession) Start(workDir string) error {
 	ptmx.Close()
 
 	// Set history limit to enable scrollback (default is 2000, we'll use 10000 for more history)
-	historyCmd := exec.Command("tmux", "set-option", "-t", t.sanitizedName, "history-limit", "10000")
+	historyCmd := exec.Command("tmux", "set-option", "-t", exactTarget(t.sanitizedName), "history-limit", "10000")
 	if err := t.cmdExec.Run(historyCmd); err != nil {
 		log.InfoLog.Printf("Warning: failed to set history-limit for session %s: %v", t.sanitizedName, err)
 	}
 
 	// Enable mouse scrolling for the session
-	mouseCmd := exec.Command("tmux", "set-option", "-t", t.sanitizedName, "mouse", "on")
+	mouseCmd := exec.Command("tmux", "set-option", "-t", exactTarget(t.sanitizedName), "mouse", "on")
 	if err := t.cmdExec.Run(mouseCmd); err != nil {
 		log.InfoLog.Printf("Warning: failed to enable mouse scrolling for session %s: %v", t.sanitizedName, err)
 	}
@@ -343,7 +343,11 @@ func (t *TmuxSession) Restore(workDir string) error {
 		return t.Start(workDir)
 	}
 
-	attachCmd := exec.Command("tmux", "attach-session", "-t", t.sanitizedName)
+	// `=` forces an exact session match so a surviving sibling session (e.g.
+	// the `__shell` tab) can never be prefix-matched and attached instead of
+	// the agent session (#1006). killTmuxAttachByName's pgrep pattern must
+	// stay in lockstep with this argv.
+	attachCmd := exec.Command("tmux", "attach-session", "-t", exactTarget(t.sanitizedName))
 	ptmx, err := t.ptyFactory.Start(attachCmd)
 	if err != nil {
 		return fmt.Errorf("error opening PTY: %w", err)
@@ -481,15 +485,17 @@ var (
 // Returns the number of processes signalled and any error encountered.
 //
 // The pgrep pattern is anchored to the literal `tmux attach-session ... -t
-// <name>` invocation we run in Restore(), so the worst that can happen is
+// =<name>:` invocation we run in Restore(), so the worst that can happen is
 // missing a kill (graceful) — not killing the wrong process. A bare name
 // match could collide with other tmux invocations (e.g. `tmux kill-session
-// -t <name>`), which we explicitly do NOT want to interrupt mid-flight.
+// -t =<name>:`), which we explicitly do NOT want to interrupt mid-flight.
+// The `=<name>:` exact-match target must mirror exactTarget() / the
+// attach-session target in Restore() (#1006).
 //
 // Exit code 1 from pgrep means "no matches" and is treated as success
 // with 0 kills; any other exit code is surfaced as an error.
 func killTmuxAttachByName(sanitizedName string) (int, error) {
-	pattern := fmt.Sprintf(`tmux attach-session -t %s$`, regexp.QuoteMeta(sanitizedName))
+	pattern := fmt.Sprintf(`tmux attach-session -t =%s:$`, regexp.QuoteMeta(sanitizedName))
 	pids, err := pgrepRunnerVar(pattern)
 	if err != nil {
 		return 0, fmt.Errorf("pgrep -f %q: %w", pattern, err)
@@ -611,8 +617,10 @@ func (t *TmuxSession) SendKeys(keys string) error {
 // where the PTY connection may not persist. Text is sent literally (with -l flag)
 // followed by a pause to let terminal control sequences drain, then Enter to submit.
 func (t *TmuxSession) SendKeysCommand(text string) error {
-	// Send text literally to avoid key name interpretation
-	textCmd := exec.Command("tmux", "send-keys", "-t", t.sanitizedName, "-l", text)
+	// Send text literally to avoid key name interpretation. `=` forces an
+	// exact session match so input is never sent to a prefix-matched sibling
+	// session if the agent session has died (#1006).
+	textCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "-l", text)
 	if err := t.cmdExec.Run(textCmd); err != nil {
 		return fmt.Errorf("error sending text via send-keys: %w", err)
 	}
@@ -622,7 +630,7 @@ func (t *TmuxSession) SendKeysCommand(text string) error {
 	time.Sleep(500 * time.Millisecond)
 
 	// Send Enter separately to submit
-	enterCmd := exec.Command("tmux", "send-keys", "-t", t.sanitizedName, "Enter")
+	enterCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "Enter")
 	return t.cmdExec.Run(enterCmd)
 }
 
@@ -944,7 +952,7 @@ func (t *TmuxSession) Close() error {
 		t.attachCh = nil
 	}
 
-	cmd := exec.Command("tmux", "kill-session", "-t", t.sanitizedName)
+	cmd := exec.Command("tmux", "kill-session", "-t", exactTarget(t.sanitizedName))
 	if err := t.cmdExec.Run(cmd); err != nil {
 		// Idempotent teardown (#967): a kill-session that fails because the
 		// session is already gone has achieved Close's goal — a dead session
@@ -1066,8 +1074,10 @@ func (t *TmuxSession) CloseAndWaitForPaneExit() error {
 // (the agent program). Must be called before kill-session — afterwards there
 // is nothing left to query.
 func (t *TmuxSession) panePID() (int, error) {
-	// `-t=` forces an exact session match, mirroring DoesSessionExist.
-	cmd := exec.Command("tmux", "display-message", "-p", "-t", fmt.Sprintf("=%s", t.sanitizedName), "#{pane_pid}")
+	// exactTarget forces an exact session match, mirroring DoesSessionExist.
+	// (The bare `=name` form returns an empty pane_pid for display-message —
+	// the trailing `:` in exactTarget is what makes the pid resolve. See #1006.)
+	cmd := exec.Command("tmux", "display-message", "-p", "-t", exactTarget(t.sanitizedName), "#{pane_pid}")
 	output, err := t.cmdExec.Output(cmd)
 	if err != nil {
 		return 0, fmt.Errorf("failed to query pane pid: %w", err)
@@ -1143,13 +1153,35 @@ func sessionExists(cmdExec cmd.Executor, name string) bool {
 	return cmdExec.Run(existsCmd) == nil
 }
 
+// exactTarget builds an exact-match `-t` target spec for the named session.
+//
+// tmux resolves a bare `-t name` by exact match first and then PREFIX match, so
+// once an agent session dies a bare target silently resolves to a surviving
+// sibling — e.g. the shell tab `<name>__shell` of which `<name>` is an exact
+// prefix. Capturing or sending to that sibling masks the dead agent and skips
+// the liveness check (#1006).
+//
+// The leading `=` forces an exact session match. The trailing `:` is required
+// for the pane-target commands (capture-pane, send-keys, set-option): without
+// it tmux parses `=name` as a bare pane spec and reports "can't find pane:
+// =name" even when the session exists. Appending the (empty) window component
+// makes tmux parse `=name` as the session and resolve to its active pane. The
+// session-target commands (kill-session, attach-session) accept the same form,
+// so every action command shares one exact-match spelling.
+func exactTarget(name string) string {
+	return fmt.Sprintf("=%s:", name)
+}
+
 // CapturePaneContent captures the content of the tmux pane. When the
 // capture fails and DoesSessionExist confirms the session is gone, the
 // returned error wraps ErrSessionGone so non-daemon callers can degrade
 // gracefully instead of logging at ERROR (#496).
 func (t *TmuxSession) CapturePaneContent() (string, error) {
-	// Add -e flag to preserve escape sequences (ANSI color codes)
-	cmd := exec.Command("tmux", "capture-pane", "-p", "-e", "-J", "-t", t.sanitizedName)
+	// Add -e flag to preserve escape sequences (ANSI color codes). `=` forces
+	// an exact session match: without it tmux would prefix-match a surviving
+	// sibling session (e.g. the `__shell` tab) when the agent session has
+	// died, capturing the wrong pane and masking the dead agent (#1006).
+	cmd := exec.Command("tmux", "capture-pane", "-p", "-e", "-J", "-t", exactTarget(t.sanitizedName))
 	output, err := t.cmdExec.Output(cmd)
 	if err != nil {
 		if !t.DoesSessionExist() {
@@ -1164,8 +1196,9 @@ func (t *TmuxSession) CapturePaneContent() (string, error) {
 // start and end specify the starting and ending line numbers (use "-" for the start/end of history).
 // Wraps ErrSessionGone when the session has vanished, mirroring CapturePaneContent.
 func (t *TmuxSession) CapturePaneContentWithOptions(start, end string) (string, error) {
-	// Add -e flag to preserve escape sequences (ANSI color codes)
-	cmd := exec.Command("tmux", "capture-pane", "-p", "-e", "-J", "-S", start, "-E", end, "-t", t.sanitizedName)
+	// Add -e flag to preserve escape sequences (ANSI color codes). `=` forces
+	// an exact session match, mirroring CapturePaneContent (#1006).
+	cmd := exec.Command("tmux", "capture-pane", "-p", "-e", "-J", "-S", start, "-E", end, "-t", exactTarget(t.sanitizedName))
 	output, err := t.cmdExec.Output(cmd)
 	if err != nil {
 		if !t.DoesSessionExist() {
@@ -1201,7 +1234,9 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 
 	for _, match := range matches {
 		log.InfoLog.Printf("cleaning up session: %s", match)
-		if err := cmdExec.Run(exec.Command("tmux", "kill-session", "-t", match)); err != nil {
+		// `=` forces an exact session match so a name extracted from `tmux ls`
+		// kills exactly that session and never a prefix-matching sibling (#1006).
+		if err := cmdExec.Run(exec.Command("tmux", "kill-session", "-t", exactTarget(match))); err != nil {
 			// Idempotent teardown (#967): a session can vanish between the
 			// `tmux ls` above and this kill (TOCTOU). A gone session is the
 			// goal of cleanup, so only a survivor is a real failure.

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -146,7 +146,7 @@ func TestRestoreAttachesWhenSessionExists(t *testing.T) {
 	require.NoError(t, session.Restore("/some/work/dir"))
 
 	require.Equal(t, 1, len(ptyFactory.cmds), "expected exactly one PTY command (attach-session)")
-	require.Equal(t, "tmux attach-session -t af_existing", cmd2.ToString(ptyFactory.cmds[0]))
+	require.Equal(t, "tmux attach-session -t =af_existing:", cmd2.ToString(ptyFactory.cmds[0]))
 }
 
 // TestRestoreRespawnsWhenSessionMissing covers issue #386 case (b): when the
@@ -186,7 +186,7 @@ func TestRestoreRespawnsWhenSessionMissing(t *testing.T) {
 	require.Equal(t,
 		fmt.Sprintf("tmux new-session -d -s af_missing -c %s claude --continue", workdir),
 		cmd2.ToString(ptyFactory.cmds[0]))
-	require.Equal(t, "tmux attach-session -t af_missing", cmd2.ToString(ptyFactory.cmds[1]))
+	require.Equal(t, "tmux attach-session -t =af_missing:", cmd2.ToString(ptyFactory.cmds[1]))
 }
 
 // TestRestoreSurfacesPtyError covers issue #386 case (c): real failures
@@ -260,7 +260,7 @@ func TestStartTmuxSession(t *testing.T) {
 	require.Equal(t, 2, len(ptyFactory.cmds))
 	require.Equal(t, fmt.Sprintf("tmux new-session -d -s af_test-session -c %s claude", workdir),
 		cmd2.ToString(ptyFactory.cmds[0]))
-	require.Equal(t, "tmux attach-session -t af_test-session",
+	require.Equal(t, "tmux attach-session -t =af_test-session:",
 		cmd2.ToString(ptyFactory.cmds[1]))
 
 	require.Equal(t, 2, len(ptyFactory.files))

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -714,12 +714,13 @@ func setupTwoInstances(t *testing.T, previewA, previewB string) (*session.Instan
 
 	existing := map[string]bool{}
 	sessionFor := func(cmd *exec.Cmd) string {
-		// tmux targets can be passed as either "-t <name>" / "-s <name>"
-		// (two args) or "-t=<name>" / "-s=<name>" (one arg). Handle both.
+		// tmux targets can be passed as "-t <name>" / "-s <name>" (two args),
+		// "-t=<name>" / "-s=<name>" (one arg), or the exact-match
+		// "-t =<name>:" / "-s =<name>:" form (#1006). Handle all of them.
 		for i, a := range cmd.Args {
 			switch {
 			case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
-				return cmd.Args[i+1]
+				return strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
 			case strings.HasPrefix(a, "-t="):
 				return strings.TrimPrefix(a, "-t=")
 			case strings.HasPrefix(a, "-s="):

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -29,12 +29,13 @@ import (
 // terminal_cmd behavior.
 
 // tmuxTargetName extracts the tmux session name from a command's -t/-s flag,
-// handling both "-t name" / "-s name" and "-t=name" / "-s=name" spellings.
+// handling "-t name" / "-s name", "-t=name" / "-s=name", and the exact-match
+// "-t =name:" / "-s =name:" spellings (#1006).
 func tmuxTargetName(cmd *exec.Cmd) string {
 	for i, a := range cmd.Args {
 		switch {
 		case (a == "-t" || a == "-s") && i+1 < len(cmd.Args):
-			return cmd.Args[i+1]
+			return strings.TrimSuffix(strings.TrimPrefix(cmd.Args[i+1], "="), ":")
 		case strings.HasPrefix(a, "-t="):
 			return strings.TrimPrefix(a, "-t=")
 		case strings.HasPrefix(a, "-s="):


### PR DESCRIPTION
## Root cause

tmux resolves `-t name` by **exact match first, then PREFIX match**. An agent
session `af_<…>` is an exact prefix of its sibling shell tab
`af_<…>__shell` (`session/tab.go`). When the agent session dies but the shell
tab survives, a bare `-t af_<…>` target silently resolves to `af_<…>__shell`:

- **`capture-pane`** reads the shell's pane. `HasUpdated()` hashes that content,
  sees it "changed", marks the dead agent **Running**, and the daemon **skips
  the liveness check** (`DoesSessionExist` only runs on the capture error path).
- **`send-keys`** can deliver input to the wrong (shell) session.

`DoesSessionExist`/`has-session` already used `-t=` exact matching (#…/2756db7),
but the action commands were never updated — exactly the gap this fixes.

## Fix

A new `exactTarget()` helper centralizes the exact-match spelling, and every
`-t <session>` action command in `session/tmux/tmux.go` now routes through it.

The spelling is `=name:`:
- leading `=` → tmux's exact-session-match prefix
- trailing `:` → **required** for pane-target commands (`capture-pane`,
  `send-keys`, `set-option`). On tmux 3.x a bare `=name` is parsed as a *pane*
  spec and fails with `can't find pane: =name` even when the session exists
  (verified against tmux 3.4). The session-target commands (`kill-session`,
  `attach-session`) accept the same form, so one spelling covers every site.

## Full `-t` audit of `session/tmux/tmux.go`

| Site | Before | After |
|------|--------|-------|
| `capture-pane` (plain) | `-t name` (prefix) | `exactTarget` ✅ |
| `capture-pane` (`-S/-E` history) | `-t name` (prefix) | `exactTarget` ✅ |
| `send-keys` (`-l` text) | `-t name` (prefix) | `exactTarget` ✅ |
| `send-keys` (Enter) | `-t name` (prefix) | `exactTarget` ✅ |
| `kill-session` (Start cleanup) | `-t name` (prefix) | `exactTarget` ✅ |
| `kill-session` (`Close`) | `-t name` (prefix) | `exactTarget` ✅ |
| `kill-session` (`CleanupSessions` by-name) | `-t name` (prefix) | `exactTarget` ✅ |
| `set-option` (history-limit, mouse) | `-t name` (prefix) | `exactTarget` ✅ |
| `attach-session` (`Restore`) | `-t name` (prefix) | `exactTarget` ✅ |
| `display-message` (`panePID`) | `-t =name` (empty result!) | `exactTarget` ✅ |
| `has-session` (`sessionExists`) | `-t=name` (exact) | unchanged ✅ |
| `new-session` (`-s name`) | session **creation**, not a target | unchanged ✅ |

The `attach-session` change is mirrored in `killTmuxAttachByName`'s pgrep
pattern (`tmux attach-session -t =<name>:$`) so the detach safety-net still
finds the client.

**Bonus latent bug:** `panePID()` used the bare `=name` form, which returns an
**empty** `#{pane_pid}` from `display-message` — so `CloseAndWaitForPaneExit`
treated every session as "already gone" and skipped the pane-exit wait.
`exactTarget` (`=name:`) returns the real pid, restoring the intended #802 wait.

### Sibling-collision confirmation
Agent `af_<hash>_<title>` is an exact prefix of shell `af_<hash>_<title>__shell`
(`shellTmuxSuffix = "__shell"`). Exact matching makes the prefix collision
impossible for every action command.

## Tests (hermetic — mock `cmdExec` captures exact argv)

- **`TestActionCommandsUseExactMatchTargets`** — asserts `capture-pane` /
  `send-keys` carry `=name:` exact-match targets.
- **`TestDeadAgentWithLiveShellSiblingIsNotPrefixMatched`** — models tmux's
  real exact-vs-prefix resolution; a dead agent with a live `__shell` sibling
  reports `ErrSessionGone` and latches the monitor **dead**, instead of
  capturing the shell and reporting updated/alive.

Both **fail before** the fix and **pass after** (verified by reverting the two
core call sites). Existing tmux-argv assertions and the mock target-name
extractors across `session/`, `ui/`, `daemon/`, `app/` were updated for the
`=name:` spelling.

## Verification
`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast`
clean · `deadcode -test ./...` clean · `go test ./...` green (incl. the real-tmux
`app` e2e that the bare `=name` form would have broken) · bounded race
`GOFLAGS="-p=1" go test -race -parallel 2 ./session/... ./daemon/...` green.

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)