### PR TITLE
feat(cli): add `af sessions tab-delete` to remove a single tab (#1021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When a session's branch has an open pull request, `p` opens it in the browser an
 
 #### Tabs
 
-Every session opens with two tabs: an **agent** tab (the AI agent, shown as *Preview*) and a **shell** tab (*Terminal*) running `$SHELL` in the worktree. Press `t` to spawn more shell tabs (up to nine per session), `w` to close the active one, and `Tab` / `1`–`9` to move between them. Attaching (`Enter`) drops you into whichever tab is active. Tabs are ephemeral but persisted: they survive an `af`/daemon restart, reconnecting to their live processes. You can also spawn a tab running an arbitrary command from the CLI with `af sessions tab-create` (see below).
+Every session opens with two tabs: an **agent** tab (the AI agent, shown as *Preview*) and a **shell** tab (*Terminal*) running `$SHELL` in the worktree. Press `t` to spawn more shell tabs (up to nine per session), `w` to close the active one, and `Tab` / `1`–`9` to move between them. Attaching (`Enter`) drops you into whichever tab is active. Tabs are ephemeral but persisted: they survive an `af`/daemon restart, reconnecting to their live processes. You can also spawn a tab running an arbitrary command from the CLI with `af sessions tab-create`, and delete a single tab with `af sessions tab-delete` (see below).
 
 Remote sessions are tab-driven too, with one limitation: the hook protocol can't run arbitrary commands on the remote host, so a remote session has an agent tab always and a single terminal tab **only when** its repo configures `remote_hooks.terminal_cmd` (`t` and `tab-create` are rejected for remote sessions). See [docs/remote-hooks.md](docs/remote-hooks.md).
 
@@ -66,6 +66,7 @@ Everything the TUI does is scriptable — `af sessions` and `af tasks` print JSO
 af sessions create --name fix-auth-bug --prompt "Fix the login redirect loop"
 af sessions preview fix-auth-bug
 af sessions tab-create fix-auth-bug --command "btop"   # spawn a process tab in the worktree
+af sessions tab-delete fix-auth-bug --name btop        # delete that tab again (agent tab can't be deleted)
 af tasks add --name "Daily triage" --prompt "Triage open issues" --cron "0 9 * * *"
 ```
 

--- a/api/api.go
+++ b/api/api.go
@@ -291,11 +291,15 @@ func init() {
 	sessionsTabCreateCmd.Flags().StringVar(&tabCreateNameFlag, "name", "", "Tab name (defaults to the command basename; auto-suffixed on collision)")
 	sessionsTabCreateCmd.MarkFlagRequired("command")
 
+	sessionsTabDeleteCmd.Flags().StringVar(&tabDeleteNameFlag, "name", "", "Name of the tab to delete (required)")
+	sessionsTabDeleteCmd.MarkFlagRequired("name")
+
 	SessionsCmd.AddCommand(sessionsListCmd)
 	SessionsCmd.AddCommand(sessionsGetCmd)
 	SessionsCmd.AddCommand(sessionsCreateCmd)
 	SessionsCmd.AddCommand(sessionsSendPromptCmd)
 	SessionsCmd.AddCommand(sessionsTabCreateCmd)
+	SessionsCmd.AddCommand(sessionsTabDeleteCmd)
 	SessionsCmd.AddCommand(sessionsPreviewCmd)
 	SessionsCmd.AddCommand(sessionsKillCmd)
 	SessionsCmd.AddCommand(sessionsAttachCmd)

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -28,6 +28,7 @@ var (
 	sendPromptViaDaemon    = daemon.SendPrompt
 	deliverPromptViaDaemon = daemon.DeliverPrompt
 	createTabViaDaemon     = daemon.CreateTab
+	closeTabViaDaemon      = daemon.CloseTab
 )
 
 var sessionsListCmd = &cobra.Command{
@@ -312,6 +313,52 @@ remote_hooks.terminal_cmd.`,
 			RepoID:  repoID,
 			Command: tabCreateCommandFlag,
 			Name:    tabCreateNameFlag,
+		})
+		if err != nil {
+			return jsonError(err)
+		}
+		return jsonOut(map[string]string{"name": name})
+	},
+}
+
+var tabDeleteNameFlag string
+
+var sessionsTabDeleteCmd = &cobra.Command{
+	Use:   "tab-delete <title>",
+	Short: "Delete a single tab from a session",
+	Long: `Delete the named tab from an existing session — the counterpart of tab-create.
+
+The tab is removed from the daemon's session state and its tmux window is
+killed. The removal is persistent: the daemon will not respawn the tab, and it
+does not return on a daemon/af restart. The name to pass is the tab name
+tab-create printed (also visible in the TUI tab bar).
+
+The agent tab can't be deleted — use "af sessions kill" to tear down the whole
+session. Deleting a tab or session that doesn't exist is an error, not a
+silent success. Not available for remote sessions: their tabs are fixed by
+remote_hooks config.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		if strings.TrimSpace(tabDeleteNameFlag) == "" {
+			return jsonError(fmt.Errorf("--name is required"))
+		}
+
+		// Honor --repo scoping (#891 class), mirroring tab-create: an empty
+		// repoID preserves the all-repo search; a non-empty one confines the
+		// session lookup to that repo so a same-titled session in another repo
+		// never loses a tab.
+		repoID, err := resolveRepoID()
+		if err != nil {
+			return jsonError(err)
+		}
+
+		name, err := closeTabViaDaemon(daemon.CloseTabRequest{
+			Title:   args[0],
+			RepoID:  repoID,
+			TabName: tabDeleteNameFlag,
 		})
 		if err != nil {
 			return jsonError(err)

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -714,5 +715,151 @@ func TestSessionsTabCreate_HonorsRepoScopingAndReturnsName(t *testing.T) {
 	}
 	if parsed["name"] != "btop-2" {
 		t.Fatalf("JSON output name = %q, want %q (resolved tab name)", parsed["name"], "btop-2")
+	}
+}
+
+// TestSessionsTabDelete_RequiresName verifies tab-delete rejects an empty
+// --name before reaching the daemon.
+func TestSessionsTabDelete_RequiresName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	prevRepoFlag, prevName := repoFlag, tabDeleteNameFlag
+	repoFlag = ""
+	tabDeleteNameFlag = "   "
+	defer func() { repoFlag, tabDeleteNameFlag = prevRepoFlag, prevName }()
+
+	called := false
+	prevClose := closeTabViaDaemon
+	closeTabViaDaemon = func(req daemon.CloseTabRequest) (string, error) {
+		called = true
+		return "", nil
+	}
+	defer func() { closeTabViaDaemon = prevClose }()
+
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devnull.Close()
+	origStderr := os.Stderr
+	os.Stderr = devnull
+	defer func() { os.Stderr = origStderr }()
+
+	if err := sessionsTabDeleteCmd.RunE(sessionsTabDeleteCmd, []string{"sess"}); err == nil {
+		t.Fatal("expected error for empty --name, got nil")
+	} else if !strings.Contains(err.Error(), "--name is required") {
+		t.Fatalf("expected --name-required error, got: %v", err)
+	}
+	if called {
+		t.Fatal("an empty name must not reach the daemon")
+	}
+}
+
+// TestSessionsTabDelete_HonorsRepoScopingAndReturnsName verifies tab-delete
+// passes the resolved RepoID (--repo scoping, #891 class), the title, and the
+// tab name to the daemon's CloseTab RPC, and prints the deleted tab's name as
+// JSON.
+func TestSessionsTabDelete_HonorsRepoScopingAndReturnsName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoRoot := filepath.Join(tmp, "repo-a")
+	if err := os.MkdirAll(repoRoot, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoRoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	repo, err := config.RepoFromPath(repoRoot)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	const title = "worker"
+
+	prevRepoFlag, prevName := repoFlag, tabDeleteNameFlag
+	repoFlag = repoRoot
+	tabDeleteNameFlag = "watcher"
+	defer func() { repoFlag, tabDeleteNameFlag = prevRepoFlag, prevName }()
+
+	var gotReq daemon.CloseTabRequest
+	prevClose := closeTabViaDaemon
+	closeTabViaDaemon = func(req daemon.CloseTabRequest) (string, error) {
+		gotReq = req
+		if req.RepoID == "" {
+			return "", errors.New("RepoID empty: --repo scoping was dropped")
+		}
+		return req.TabName, nil
+	}
+	defer func() { closeTabViaDaemon = prevClose }()
+
+	// Capture stdout so we can assert the deleted name is emitted as JSON.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+	runErr := sessionsTabDeleteCmd.RunE(sessionsTabDeleteCmd, []string{title})
+	w.Close()
+	os.Stdout = origStdout
+	out, _ := io.ReadAll(r)
+	if runErr != nil {
+		t.Fatalf("tab-delete returned error: %v", runErr)
+	}
+
+	if gotReq.RepoID != repo.ID {
+		t.Fatalf("tab-delete RepoID = %q, want %q", gotReq.RepoID, repo.ID)
+	}
+	if gotReq.Title != title {
+		t.Fatalf("tab-delete Title = %q, want %q", gotReq.Title, title)
+	}
+	if gotReq.TabName != "watcher" {
+		t.Fatalf("tab-delete TabName = %q, want %q", gotReq.TabName, "watcher")
+	}
+
+	var parsed map[string]string
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("output is not JSON (%q): %v", string(out), err)
+	}
+	if parsed["name"] != "watcher" {
+		t.Fatalf("JSON output name = %q, want %q (deleted tab name)", parsed["name"], "watcher")
+	}
+}
+
+// TestSessionsTabDelete_SurfacesDaemonError verifies a daemon-side rejection
+// (unknown session, unknown tab, agent tab) is reported as an error — not a
+// panic and not a silent success.
+func TestSessionsTabDelete_SurfacesDaemonError(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	prevRepoFlag, prevName := repoFlag, tabDeleteNameFlag
+	repoFlag = ""
+	tabDeleteNameFlag = "ghost"
+	defer func() { repoFlag, tabDeleteNameFlag = prevRepoFlag, prevName }()
+
+	prevClose := closeTabViaDaemon
+	closeTabViaDaemon = func(req daemon.CloseTabRequest) (string, error) {
+		return "", fmt.Errorf("session %q has no tab named %q", req.Title, req.TabName)
+	}
+	defer func() { closeTabViaDaemon = prevClose }()
+
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devnull.Close()
+	origStderr := os.Stderr
+	os.Stderr = devnull
+	defer func() { os.Stderr = origStderr }()
+
+	err = sessionsTabDeleteCmd.RunE(sessionsTabDeleteCmd, []string{"sess"})
+	if err == nil {
+		t.Fatal("expected the daemon error to surface, got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("expected error naming the missing tab, got: %v", err)
 	}
 }

--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -98,6 +98,57 @@ func TestCloseTab_RejectsAgentTab(t *testing.T) {
 	}
 }
 
+// TestCloseTab_RejectsAgentTabByName verifies the agent tab is unclosable when
+// targeted by its name too, not just by index 0 — the name path is the one
+// `af sessions tab-delete --name` drives (#1021).
+func TestCloseTab_RejectsAgentTabByName(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const title = "worker"
+	inst := startedLocalTabInstance(t, manager, repo.ID, repoPath, title, "af_"+title+"_agent")
+	agentTab := inst.GetTabs()[0].Name
+
+	_, err = manager.CloseTab(CloseTabRequest{Title: title, RepoID: repo.ID, TabName: agentTab})
+	if err == nil {
+		t.Fatal("expected error closing the agent tab by name, got nil")
+	}
+	if !strings.Contains(err.Error(), "agent tab") {
+		t.Fatalf("expected agent-tab rejection, got: %v", err)
+	}
+	if inst.TabCount() != 1 {
+		t.Fatalf("agent tab must survive, got %d tabs", inst.TabCount())
+	}
+}
+
+// TestCloseTab_RejectsUnknownSession verifies targeting a session that doesn't
+// exist is a clear error, not a panic or silent success (#1021).
+func TestCloseTab_RejectsUnknownSession(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	_, err = manager.CloseTab(CloseTabRequest{Title: "ghost", TabName: "watcher"})
+	if err == nil {
+		t.Fatal("expected error for unknown session, got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("expected error naming the missing session, got: %v", err)
+	}
+}
+
 // TestCloseTab_RejectsUnknownTab verifies a name that matches no tab is
 // rejected rather than silently closing the wrong tab.
 func TestCloseTab_RejectsUnknownTab(t *testing.T) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,7 @@ af sessions create --name <title> [--prompt "..."] [--program <agent>]
 af sessions send-prompt <title> "..."                     # append a prompt to a session
 af sessions send-prompt <title> "..." --create            # send-or-create
 af sessions tab-create <title> --command "<cmd>"          # spawn a process tab in the session's worktree
+af sessions tab-delete <title> --name <tab>               # delete a single tab (the daemon won't respawn it)
 af sessions preview <title>                               # snapshot the session's pane
 af sessions attach <title>                                # attach interactively (foreground)
 af sessions whoami                                        # report the session this shell is inside
@@ -38,6 +39,7 @@ Flags:
 - `create`: `--name` (required), `--prompt` (initial prompt to send), `--program` (agent enum, defaults to the configured `default_program`).
 - `send-prompt`: `--create` auto-creates the session if it doesn't exist; `--program` picks the agent when creating.
 - `tab-create`: `--command` (required) is run in the session's git worktree as a new tab; `--name` sets the tab's display name (defaults to the command's basename, auto-suffixed `-2`, `-3`, … on collision). The resolved tab name is printed as `{"name": "..."}` so scripts/agents can address it. The tab persists and reconnects across a daemon/`af` restart like every other tab. Refused once a session already holds 9 tabs. **Not available for remote sessions:** they have no local worktree and the hook protocol can't run arbitrary commands — a remote session's only terminal tab comes from `remote_hooks.terminal_cmd` (see [remote-hooks.md](remote-hooks.md)).
+- `tab-delete`: the counterpart of `tab-create` — `--name` (required) selects the tab to delete. The tab is removed from the daemon's session state and its tmux window is killed; the removal is persistent (the daemon won't respawn it, and it doesn't return on restart). The deleted tab's name is printed as `{"name": "..."}`. The agent tab can't be deleted — use `af sessions kill` to tear down the whole session. Targeting a missing tab or session is an error. Not available for remote sessions (their tabs are fixed by `remote_hooks` config).
 
 ## `af tasks`
 


### PR DESCRIPTION
Closes #1021

## What

Adds `af sessions tab-delete <title> --name <tab>` — the counterpart of `tab-create` — to remove a single process/shell tab from a session.

```bash
af sessions tab-create mysess --name watcher --command ./foo.sh   # {"name": "watcher"}
af sessions tab-delete mysess --name watcher                      # {"name": "watcher"}
```

## How

The CLI is a thin client over the daemon's **existing `CloseTab` RPC** (added in #961), per the single-writer architecture (#960): the CLI never touches `instances.json`. `CloseTabRequest` already supports name-based tab resolution, so no daemon changes were needed — the daemon:

1. removes the tab from its owned state and persists the shrunk tab list through the targeted per-repo writer (so the tab is **never respawned** and doesn't return on restart),
2. kills the tab's tmux window,
3. serializes the mutate+persist under the per-repo start lock, mirroring `CreateTab`.

## Behavior

- **Errors are clear and no-op-safe** (not a panic, not a silent success): unknown session → `instance "x" not found`; unknown tab → `session "x" has no tab named "y"`; agent tab → `the agent tab of session "x" can't be closed; kill the session instead`; remote sessions rejected (tabs fixed by `remote_hooks` config).
- Honors `--repo` scoping like the other sessions verbs (#891 class) so a same-titled session in another repo never loses a tab.
- Prints the deleted tab's name as `{"name": "..."}`, mirroring tab-create's output shape.

## Help/Docs

- `tab-delete --help` long description mirrors tab-create: names it as the counterpart, states the agent tab is not deletable, and that removal is persistent.
- `docs/cli.md` and the README now document tab-create/tab-delete as a pair.

## Tests (hermetic — no daemon fork, no tmux)

- CLI (api/sessions_test.go, mirroring the tab-create seam tests): empty `--name` rejected before reaching the daemon; happy path passes Title/RepoID/TabName to the CloseTab RPC and emits the name as JSON; daemon-side errors surface to the caller.
- Daemon (daemon/close_tab_test.go, extending the existing #961 suite): agent tab rejected when targeted **by name** (the path tab-delete drives); unknown session is a clear error. Existing tests already cover name-based close+persist, unknown tab, index-0 rejection, remote rejection, and the client→RPC→Manager→persist round-trip on an in-process control server.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --timeout=3m --fast` clean · `go test ./...` green · `deadcode -test ./...` clean · bounded race `GOFLAGS="-p=1" go test -race -parallel 2 ./api/... ./session/... ./daemon/...` green. Help output exercised via `go run . sessions tab-delete --help`.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)