### PR TITLE
test: make daemon/integration/session tests hermetic (isolated AGENT_FACTORY_HOME + tmux) so they stop polluting the prod log and leaking tmux (#1056)

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -20,16 +20,26 @@ import (
 
 // TestMain runs before all tests to set up the test environment
 func TestMain(m *testing.M) {
-	// Initialize the logger before any tests run
-	log.Initialize(false)
-	defer log.Close()
-
 	// #837: fail the package loudly if any test touches the real config.json.
 	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: fail loudly if a test leaks an af_ session onto the ambient tmux
+	// server, and default the whole package into a sandboxed
+	// AGENT_FACTORY_HOME so stray config/state/log writes land in a temp dir
+	// instead of the developer's real one. Sandbox AFTER the tripwires
+	// snapshot the real environment, BEFORE logging resolves its file path.
+	verifyTmux := testguard.TmuxTripwire()
+	restoreHome := testguard.SandboxHome()
+	log.Initialize(false)
 
 	// Run all tests
 	exitCode := m.Run()
+	log.Close()
+	restoreHome()
 	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exitCode = 1
+	}
+	if err := verifyTmux(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exitCode = 1
 	}

--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,11 @@ import (
 
 func TestTUIRefreshSeesCLIChangesThroughDaemon(t *testing.T) {
 	skipIfRealBackendDepsMissing(t)
+
+	// #1056: private tmux server for the exec'd af CLI, its daemon, and the
+	// in-process TmuxAlive probes (all inherit the environment), so no af_
+	// session can leak onto the developer's server.
+	testguard.IsolateTmux(t)
 
 	bin := buildIntegrationBinary(t)
 	repoDir := setupRealRepo(t)
@@ -58,6 +64,11 @@ func TestTUIRefreshSeesCLIChangesThroughDaemon(t *testing.T) {
 // recreated on-disk one.
 func TestTUIRefreshSwapsKillRecreatedSameTitle(t *testing.T) {
 	skipIfRealBackendDepsMissing(t)
+
+	// #1056: private tmux server for the exec'd af CLI, its daemon, and the
+	// in-process TmuxAlive probes (all inherit the environment), so no af_
+	// session can leak onto the developer's server.
+	testguard.IsolateTmux(t)
 
 	bin := buildIntegrationBinary(t)
 	repoDir := setupRealRepo(t)

--- a/app/real_e2e_test.go
+++ b/app/real_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/stretchr/testify/assert"
@@ -78,6 +79,9 @@ func mustRunGit(t *testing.T, dir string, args ...string) {
 // contract — not in our async plumbing.
 func TestRealLocalBackend_FullLifecycle(t *testing.T) {
 	skipIfRealBackendDepsMissing(t)
+	// #1056: private tmux server so the real LocalBackend's session dies with
+	// the test even when the Kill cleanup below fails.
+	testguard.IsolateTmux(t)
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
 	repoDir := setupRealRepo(t)

--- a/app/real_tui_e2e_test.go
+++ b/app/real_tui_e2e_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,11 @@ import (
 // promises" contract check.
 func TestRealTUI_CreateThroughKeypresses(t *testing.T) {
 	skipIfRealBackendDepsMissing(t)
+
+	// #1056: private tmux server so the session the real backend creates dies
+	// with the test even when the Kill-through-the-tea-goroutine path below
+	// never runs (wedged model, earlier failure).
+	testguard.IsolateTmux(t)
 
 	repoDir := setupRealRepo(t)
 

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -33,12 +33,19 @@ func captureLogs(t *testing.T) (info, errLog *bytes.Buffer) {
 }
 
 func TestMain(m *testing.M) {
+	// #837: fail the package loudly if any test touches the real config.json.
+	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: default the whole package into a sandboxed AGENT_FACTORY_HOME so
+	// stray config/state/log writes land in a temp dir instead of the
+	// developer's real one. Sandbox AFTER the tripwire snapshots the real
+	// environment, BEFORE logging resolves its file path.
+	restoreHome := testguard.SandboxHome()
 	// autoUpdate() calls log.ErrorLog.Printf, which panics if logging has not
 	// been initialized. Initialize once for the whole package test binary.
 	aflog.Initialize(false)
-	// #837: fail the package loudly if any test touches the real config.json.
-	verifyRealConfig := testguard.ConfigTripwire()
 	code := m.Run()
+	aflog.Close()
+	restoreHome()
 	if err := verifyRealConfig(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		code = 1

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,13 +19,18 @@ import (
 
 // TestMain runs before all tests to set up the test environment
 func TestMain(m *testing.M) {
-	// Initialize the logger before any tests run
-	log.Initialize(false)
-	defer log.Close()
-
 	// #837: fail the package loudly if any test touches the real config.json.
 	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: default the whole package into a sandboxed AGENT_FACTORY_HOME so
+	// stray config/state/log writes land in a temp dir instead of the
+	// developer's real one. Sandbox AFTER the tripwire snapshots the real
+	// environment, BEFORE logging resolves its file path. Tests that assert
+	// env-dependent resolution set AGENT_FACTORY_HOME themselves.
+	restoreHome := testguard.SandboxHome()
+	log.Initialize(false)
 	exitCode := m.Run()
+	log.Close()
+	restoreHome()
 	if err := verifyRealConfig(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		exitCode = 1
@@ -548,6 +553,11 @@ func TestResolveProgram(t *testing.T) {
 
 func TestGetConfigDir(t *testing.T) {
 	t.Run("returns valid config directory", func(t *testing.T) {
+		// Empty means unset for GetConfigDir; without this the assertion
+		// depends on the ambient environment (and fails under the #1056
+		// package-wide sandbox home).
+		t.Setenv("AGENT_FACTORY_HOME", "")
+
 		configDir, err := GetConfigDir()
 
 		assert.NoError(t, err)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -20,11 +20,24 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.Initialize(false)
 	// #837: fail the package loudly if any test touches the real config.json.
 	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: fail loudly if a test leaks an af_ session onto the ambient tmux
+	// server, and default the whole package into a sandboxed
+	// AGENT_FACTORY_HOME so stray config/state/log writes land in a temp dir
+	// instead of the developer's real one. Sandbox AFTER the tripwires
+	// snapshot the real environment, BEFORE logging resolves its file path.
+	verifyTmux := testguard.TmuxTripwire()
+	restoreHome := testguard.SandboxHome()
+	log.Initialize(false)
 	code := m.Run()
+	log.Close()
+	restoreHome()
 	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	if err := verifyTmux(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		code = 1
 	}

--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
@@ -341,6 +342,9 @@ func TestDeliverPrompt_TmuxOrphanReturnsImmediatelyWithError(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux not installed")
 	}
+	// #1056: private tmux server so the raw orphan session below dies with
+	// the test even when the kill-session cleanup fails.
+	testguard.IsolateTmux(t)
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
 	repoPath := setupControlRepo(t)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,4 +92,4 @@ All data (sessions, tasks) is scoped to the current git repository — the TUI s
 | `~/.agent-factory/logs/task-<id>.log` | Per-task watch-script logs. |
 | `~/.config/agent-factory/agent-factory.log` | Application log (`os.UserConfigDir` on other platforms). |
 
-Setting the `AGENT_FACTORY_HOME` environment variable relocates the `~/.agent-factory` state directory — useful for sandboxed or test setups.
+Setting the `AGENT_FACTORY_HOME` environment variable relocates the `~/.agent-factory` state directory — useful for sandboxed or test setups. When it is set, the application log also moves into that directory (`$AGENT_FACTORY_HOME/agent-factory.log`) so a relocated home is fully self-contained.

--- a/integration/cli_daemon_test.go
+++ b/integration/cli_daemon_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -288,6 +289,13 @@ func newHarness(t *testing.T) *harness {
 	t.Helper()
 	requireTool(t, "git")
 	requireTool(t, "tmux")
+
+	// #1056: run every tmux touch — the parent's has-session/kill-session
+	// probes, the exec'd af CLI, and the daemon it spawns (all inherit the
+	// environment) — against a private tmux server that is killed when the
+	// test ends, so no af_ session can leak onto the developer's server even
+	// when per-session cleanup below fails.
+	testguard.IsolateTmux(t)
 
 	home := t.TempDir()
 	// t.Setenv (not os.Setenv) so the variable is restored when the test

--- a/integration/codex_ready_test.go
+++ b/integration/codex_ready_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -29,6 +30,10 @@ import (
 func TestCLICreateCodexSessionBecomesReady(t *testing.T) {
 	requireTool(t, "git")
 	requireTool(t, "tmux")
+
+	// #1056: private tmux server so the exec'd af CLI and its daemon cannot
+	// leak af_ sessions onto the developer's server.
+	testguard.IsolateTmux(t)
 
 	home := t.TempDir()
 	repo := setupGitRepo(t)
@@ -112,6 +117,10 @@ func TestCLICreateCodexSessionBecomesReady(t *testing.T) {
 func TestCLICreateCodexWaitsPastTrustPrompt(t *testing.T) {
 	requireTool(t, "git")
 	requireTool(t, "tmux")
+
+	// #1056: private tmux server so the exec'd af CLI and its daemon cannot
+	// leak af_ sessions onto the developer's server.
+	testguard.IsolateTmux(t)
 
 	home := t.TempDir()
 	repo := setupGitRepo(t)

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -8,14 +8,25 @@ import (
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 )
 
-// TestMain guards the package with the #837 config tripwire. The tests here
-// build and exec real af binaries that spawn daemons, so they are the most
-// likely place for a sandbox escape to reach the developer's real
-// ~/.agent-factory/config.json.
+// TestMain guards the package with the #837 config tripwire and the #1056
+// tmux tripwire. The tests here build and exec real af binaries that spawn
+// daemons and real tmux sessions, so they are the most likely place for a
+// sandbox escape to reach the developer's real ~/.agent-factory/config.json
+// or leave orphaned af_ sessions on the developer's tmux server.
 func TestMain(m *testing.M) {
 	verifyRealConfig := testguard.ConfigTripwire()
+	verifyTmux := testguard.TmuxTripwire()
+	// #1056: default the package into a sandboxed AGENT_FACTORY_HOME so any
+	// in-process config/state/log access outside a per-test home stays out
+	// of the developer's real one.
+	restoreHome := testguard.SandboxHome()
 	code := m.Run()
+	restoreHome()
 	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	if err := verifyTmux(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		code = 1
 	}

--- a/internal/testguard/testguard.go
+++ b/internal/testguard/testguard.go
@@ -1,9 +1,13 @@
 // Package testguard fences test binaries off from the developer's real
-// agent-factory config. Test packages that can spawn af processes or write
-// config files call ConfigTripwire from TestMain; if any test (or a child
-// process it spawned) escapes its AGENT_FACTORY_HOME sandbox and touches the
-// real config.json, the package run fails loudly instead of the user
-// discovering days later that their settings were silently replaced (#837).
+// agent-factory environment. Test packages that can spawn af processes or
+// write config files call ConfigTripwire from TestMain; if any test (or a
+// child process it spawned) escapes its AGENT_FACTORY_HOME sandbox and
+// touches the real config.json, the package run fails loudly instead of the
+// user discovering days later that their settings were silently replaced
+// (#837). TmuxTripwire does the same for real tmux sessions leaked onto the
+// developer's tmux server, SandboxHome defaults a whole package into a
+// throwaway AGENT_FACTORY_HOME, and IsolateTmux gives a test a private tmux
+// server so nothing it creates can outlive it (#1056).
 //
 // This package deliberately has no dependency on the config package — config
 // imports session/tmux, and the tripwire must be usable from that package's
@@ -16,8 +20,11 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
+	"testing"
 )
 
 // ambientConfigPath resolves the config.json the test process would touch
@@ -99,4 +106,119 @@ func ConfigTripwire() func() error {
 		}
 		return nil
 	}
+}
+
+// ambientAFSessions lists the af_-prefixed session names on the tmux server
+// the current environment resolves to. A nil map means no reachable server —
+// nothing to leak against.
+func ambientAFSessions() map[string]bool {
+	out, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		return nil
+	}
+	sessions := make(map[string]bool)
+	for _, name := range strings.Split(string(out), "\n") {
+		// Anchor the prefix so a non-agent session like "my_af_project"
+		// never trips the wire (same anchoring as tmux.CleanupSessions).
+		if strings.HasPrefix(name, "af_") {
+			sessions[name] = true
+		}
+	}
+	return sessions
+}
+
+// TmuxTripwire snapshots the af_-prefixed sessions on the ambient tmux
+// server and returns a verify func for TestMain to call after m.Run().
+// Verify returns a non-nil error when the run left behind af_ sessions that
+// were not there before — i.e. a test created a real agent tmux session on
+// the developer's server and never killed it (#1056). Tests that need real
+// tmux should call IsolateTmux, whose private server this tripwire cannot
+// even see.
+//
+// Call it BEFORE any test changes TMUX_TMPDIR/TMUX so both snapshots target
+// the ambient server. No-ops when tmux is not installed or with
+// AF_DISABLE_TMUX_TRIPWIRE=1. Caveat for dev boxes running a real daemon:
+// an af_ session legitimately created by the real daemon DURING the package
+// run is indistinguishable from a leak; the error lists the session names so
+// that case is recognizable, and the escape hatch covers it.
+func TmuxTripwire() func() error {
+	if os.Getenv("AF_DISABLE_TMUX_TRIPWIRE") == "1" {
+		return func() error { return nil }
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		return func() error { return nil }
+	}
+	before := ambientAFSessions()
+	return func() error {
+		var leaked []string
+		for name := range ambientAFSessions() {
+			if !before[name] {
+				leaked = append(leaked, name)
+			}
+		}
+		if len(leaked) == 0 {
+			return nil
+		}
+		sort.Strings(leaked)
+		return fmt.Errorf("tmux tripwire: this package's test run left tmux session(s) %v on the ambient tmux server — a test created a real af_ session without testguard.IsolateTmux or cleanup (#1056)", leaked)
+	}
+}
+
+// SandboxHome points AGENT_FACTORY_HOME at a fresh temp dir for the whole
+// package run and returns a restore func. Call it from TestMain AFTER
+// ConfigTripwire (which must snapshot the real, pre-sandbox config) and
+// BEFORE log.Initialize (so the package's log file lands in the sandbox
+// instead of the production daemon log — #1056). Individual tests that
+// t.Setenv their own home still win for their duration; this is the default
+// for tests that never set one.
+func SandboxHome() func() {
+	dir, err := os.MkdirTemp("", "af-test-home-")
+	if err != nil {
+		panic("testguard: cannot create sandbox AGENT_FACTORY_HOME: " + err.Error())
+	}
+	prev, had := os.LookupEnv("AGENT_FACTORY_HOME")
+	if err := os.Setenv("AGENT_FACTORY_HOME", dir); err != nil {
+		panic("testguard: cannot set sandbox AGENT_FACTORY_HOME: " + err.Error())
+	}
+	return func() {
+		if had {
+			_ = os.Setenv("AGENT_FACTORY_HOME", prev)
+		} else {
+			_ = os.Unsetenv("AGENT_FACTORY_HOME")
+		}
+		_ = os.RemoveAll(dir)
+	}
+}
+
+// IsolateTmux points the test at a private tmux server: a fresh TMUX_TMPDIR
+// socket dir with $TMUX cleared, so a test run from inside a tmux pane does
+// not fall back to the surrounding server ($TMUX wins over TMUX_TMPDIR in
+// tmux's socket resolution). A cleanup kills the private server, so every
+// session the test created dies with it and nothing can leak onto the
+// developer's real server (#1056). Child processes — exec'd af binaries and
+// the daemons they spawn — inherit both variables through os.Environ().
+//
+// The socket dir lives under os.TempDir() rather than t.TempDir() because
+// unix socket paths are length-limited (~104 bytes) and t.TempDir() embeds
+// the full test name. Skips the test when tmux is not installed; must not be
+// used with t.Parallel (t.Setenv forbids it).
+func IsolateTmux(t testing.TB) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("tmux not available: %v", err)
+	}
+	dir, err := os.MkdirTemp("", "af-tmux-")
+	if err != nil {
+		t.Fatalf("testguard: cannot create private tmux socket dir: %v", err)
+	}
+	t.Setenv("TMUX_TMPDIR", dir)
+	// Empty counts as unset for tmux's "am I inside tmux" check; t.Setenv
+	// cannot fully unset a variable.
+	t.Setenv("TMUX", "")
+	t.Cleanup(func() {
+		// Runs before t.Setenv's env restore (cleanups are LIFO), so this
+		// kill targets the private server, then removes its socket dir.
+		_ = exec.Command("tmux", "kill-server").Run()
+		_ = os.RemoveAll(dir)
+	})
 }

--- a/internal/testguard/testguard_test.go
+++ b/internal/testguard/testguard_test.go
@@ -2,6 +2,7 @@ package testguard
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -128,5 +129,73 @@ func TestConfigTripwire_FallsBackToDotAgentFactory(t *testing.T) {
 	want := filepath.Join(fakeHome, ".agent-factory", "config.json")
 	if got := ambientConfigPath(); got != want {
 		t.Fatalf("ambientConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestSandboxHome_SetsAndRestores(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", "/pre-sandbox-value")
+
+	restore := SandboxHome()
+	dir := os.Getenv("AGENT_FACTORY_HOME")
+	if dir == "/pre-sandbox-value" || dir == "" {
+		t.Fatalf("SandboxHome did not repoint AGENT_FACTORY_HOME; got %q", dir)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("sandbox dir %q not usable: %v", dir, err)
+	}
+
+	restore()
+	if got := os.Getenv("AGENT_FACTORY_HOME"); got != "/pre-sandbox-value" {
+		t.Fatalf("restore did not put AGENT_FACTORY_HOME back; got %q", got)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("restore did not remove sandbox dir %q; stat err=%v", dir, err)
+	}
+}
+
+// TestTmuxTripwire_FiresOnLeakedSession exercises the tripwire against the
+// private server IsolateTmux provides, so the test itself is hermetic: the
+// "ambient" server the tripwire snapshots is the throwaway one.
+func TestTmuxTripwire_FiresOnLeakedSession(t *testing.T) {
+	IsolateTmux(t) // skips when tmux is unavailable
+
+	verify := TmuxTripwire()
+	if err := verify(); err != nil {
+		t.Fatalf("tripwire fired with no sessions created: %v", err)
+	}
+
+	const leak = "af_testguard_tripwire_leak"
+	if out, err := exec.Command("tmux", "new-session", "-d", "-s", leak, "sleep", "60").CombinedOutput(); err != nil {
+		t.Skipf("cannot start tmux session on private server: %v: %s", err, out)
+	}
+
+	err := verify()
+	if err == nil {
+		t.Fatal("tripwire did not fire on a leaked af_ session")
+	}
+	if !strings.Contains(err.Error(), leak) {
+		t.Fatalf("tripwire error should name the leaked session %q; got: %v", leak, err)
+	}
+
+	if err := exec.Command("tmux", "kill-session", "-t", "="+leak).Run(); err != nil {
+		t.Fatalf("kill leaked session: %v", err)
+	}
+	if err := verify(); err != nil {
+		t.Fatalf("tripwire fired after the session was cleaned up: %v", err)
+	}
+}
+
+func TestTmuxTripwire_IgnoresNonAFSessions(t *testing.T) {
+	IsolateTmux(t)
+
+	verify := TmuxTripwire()
+	const name = "my_af_project"
+	if out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sleep", "60").CombinedOutput(); err != nil {
+		t.Skipf("cannot start tmux session on private server: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", "="+name).Run() })
+
+	if err := verify(); err != nil {
+		t.Fatalf("tripwire must ignore sessions without the af_ prefix; got: %v", err)
 	}
 }

--- a/log/log.go
+++ b/log/log.go
@@ -6,7 +6,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
+	"testing"
 	"time"
 )
 
@@ -33,7 +35,64 @@ func init() {
 // thread-safe, so we do not take this lock on the logging hot path.
 var mu sync.Mutex
 
-func getLogPath() string {
+// logPathOverride, when non-empty, wins over all environment-based
+// resolution. Only this package's tests set it, to point the log at a
+// scratch file without touching the process environment.
+var logPathOverride string
+
+// expandTilde resolves a leading "~" or "~/" in dir. ok is false for the
+// unsupported "~user" form or when the home directory cannot be resolved.
+// Mirrors config.GetConfigDir's expansion; this package cannot import config
+// (config imports log).
+func expandTilde(dir string) (string, bool) {
+	if !strings.HasPrefix(dir, "~") {
+		return dir, true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	switch {
+	case dir == "~":
+		return home, true
+	case strings.HasPrefix(dir, "~/"):
+		return filepath.Join(home, dir[2:]), true
+	default:
+		return "", false
+	}
+}
+
+// resolveLogPath picks the log destination, in priority order:
+//
+//  1. logPathOverride (this package's tests);
+//  2. $AGENT_FACTORY_HOME/agent-factory.log — the same relocation override
+//     config.GetConfigDir honors, so a relocated agent-factory home keeps its
+//     log next to its config and state. This is the seam that lets sandboxed
+//     tests, and the af binaries they exec, log into a temp home instead of
+//     the developer's real log (#1056);
+//  3. inside a `go test` binary with no home override: a scratch file under
+//     os.TempDir(), never the real log — a test that forgot to sandbox its
+//     home must not pollute the production daemon's log (#1056);
+//  4. the historical default, os.UserConfigDir()/agent-factory/agent-factory.log.
+//
+// Resolved at Initialize time (not package init) so environment changes made
+// by test setup are respected.
+func resolveLogPath() string {
+	if logPathOverride != "" {
+		return logPathOverride
+	}
+	if home := os.Getenv("AGENT_FACTORY_HOME"); home != "" {
+		if dir, ok := expandTilde(home); ok {
+			if err := os.MkdirAll(dir, 0700); err == nil {
+				return filepath.Join(dir, "agent-factory.log")
+			}
+		}
+		// Unresolvable or uncreatable override: fall through to the defaults
+		// below rather than not logging at all.
+	}
+	if testing.Testing() {
+		return filepath.Join(os.TempDir(), "agent-factory-test.log")
+	}
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		return filepath.Join(os.TempDir(), "agent-factory.log")
@@ -43,7 +102,9 @@ func getLogPath() string {
 	return filepath.Join(dir, "agent-factory.log")
 }
 
-var logFileName = getLogPath()
+// logFileName is the path the most recent Initialize resolved and attempted
+// to open; Close uses it for the "wrote logs to" message.
+var logFileName string
 
 var globalLogFile *os.File
 
@@ -54,6 +115,8 @@ var globalLogFile *os.File
 func Initialize(daemon bool) {
 	mu.Lock()
 	defer mu.Unlock()
+
+	logFileName = resolveLogPath()
 
 	// Close any previously opened log file to avoid leaking file descriptors
 	// when Initialize is called multiple times (e.g. af tasks trigger -> RunTask).

--- a/log/log_race_test.go
+++ b/log/log_race_test.go
@@ -22,9 +22,8 @@ import (
 // Printfs in-flight at the moment Close runs globalLogFile.Close().
 func TestCloseRaceConcurrentPrintf(t *testing.T) {
 	tmpDir := t.TempDir()
-	origLogFileName := logFileName
-	logFileName = filepath.Join(tmpDir, "race.log")
-	t.Cleanup(func() { logFileName = origLogFileName })
+	logPathOverride = filepath.Join(tmpDir, "race.log")
+	t.Cleanup(func() { logPathOverride = "" })
 
 	origStderr := os.Stderr
 	r, w, err := os.Pipe()
@@ -90,9 +89,8 @@ func TestCloseRaceConcurrentPrintf(t *testing.T) {
 // summed loss reported by TestCloseRaceConcurrentPrintf.
 func TestCloseRaceSingleBurst(t *testing.T) {
 	tmpDir := t.TempDir()
-	origLogFileName := logFileName
-	logFileName = filepath.Join(tmpDir, "burst.log")
-	t.Cleanup(func() { logFileName = origLogFileName })
+	logPathOverride = filepath.Join(tmpDir, "burst.log")
+	t.Cleanup(func() { logPathOverride = "" })
 
 	origStderr := os.Stderr
 	r, w, err := os.Pipe()

--- a/log/log_realpath_test.go
+++ b/log/log_realpath_test.go
@@ -24,9 +24,8 @@ import (
 // Printfs at the moment Close races them.
 func TestRealPathActualLoss(t *testing.T) {
 	tmpDir := t.TempDir()
-	origLogFileName := logFileName
-	logFileName = filepath.Join(tmpDir, "actual.log")
-	t.Cleanup(func() { logFileName = origLogFileName })
+	logPathOverride = filepath.Join(tmpDir, "actual.log")
+	t.Cleanup(func() { logPathOverride = "" })
 
 	origStderr := os.Stderr
 	r, w, err := os.Pipe()

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -98,9 +98,8 @@ func TestCloseRedirectsToStderr(t *testing.T) {
 // unwritable path) logging falls back to stderr, globalLogFile stays nil, and
 // claiming a file was written points the user at a file that does not exist.
 func TestCloseClaimsFileOnlyWhenOpened(t *testing.T) {
-	origName := logFileName
 	t.Cleanup(func() {
-		logFileName = origName
+		logPathOverride = ""
 		globalLogFile = nil
 	})
 
@@ -127,7 +126,7 @@ func TestCloseClaimsFileOnlyWhenOpened(t *testing.T) {
 	t.Run("no file opened: no wrote-logs claim", func(t *testing.T) {
 		// Parent directory does not exist, so OpenFile fails and Initialize
 		// falls back to stderr without setting globalLogFile.
-		logFileName = filepath.Join(t.TempDir(), "missing-dir", "agent-factory.log")
+		logPathOverride = filepath.Join(t.TempDir(), "missing-dir", "agent-factory.log")
 		globalLogFile = nil
 		out := captureStderr(t, func() {
 			Initialize(false)
@@ -142,7 +141,7 @@ func TestCloseClaimsFileOnlyWhenOpened(t *testing.T) {
 	})
 
 	t.Run("file opened: wrote-logs claim present", func(t *testing.T) {
-		logFileName = filepath.Join(t.TempDir(), "agent-factory.log")
+		logPathOverride = filepath.Join(t.TempDir(), "agent-factory.log")
 		globalLogFile = nil
 		out := captureStderr(t, func() {
 			Initialize(false)

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -30,12 +30,24 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.Initialize(false)
-	defer log.Close()
 	// #837: fail the package loudly if any test touches the real config.json.
 	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: fail loudly if a test leaks an af_ session onto the ambient tmux
+	// server, and default the whole package into a sandboxed
+	// AGENT_FACTORY_HOME so stray config/state/log writes land in a temp dir
+	// instead of the developer's real one. Sandbox AFTER the tripwires
+	// snapshot the real environment, BEFORE logging resolves its file path.
+	verifyTmux := testguard.TmuxTripwire()
+	restoreHome := testguard.SandboxHome()
+	log.Initialize(false)
 	code := m.Run()
+	log.Close()
+	restoreHome()
 	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	if err := verifyTmux(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		code = 1
 	}

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -19,11 +19,17 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.Initialize(false)
-	defer log.Close()
 	// #837: fail the package loudly if any test touches the real config.json.
 	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: default the whole package into a sandboxed AGENT_FACTORY_HOME so
+	// stray config/state/log writes land in a temp dir instead of the
+	// developer's real one. Sandbox AFTER the tripwire snapshots the real
+	// environment, BEFORE logging resolves its file path.
+	restoreHome := testguard.SandboxHome()
+	log.Initialize(false)
 	code := m.Run()
+	log.Close()
+	restoreHome()
 	if err := verifyRealConfig(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		code = 1

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -23,12 +23,24 @@ import (
 // TestMain initializes the logger so tests that exercise paths writing to
 // InfoLog/ErrorLog (e.g. Restore's re-spawn fallback) do not nil-deref.
 func TestMain(m *testing.M) {
-	aflog.Initialize(false)
-	defer aflog.Close()
 	// #837: fail the package loudly if any test touches the real config.json.
 	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: fail loudly if a test leaks an af_ session onto the ambient tmux
+	// server, and default the whole package into a sandboxed
+	// AGENT_FACTORY_HOME so stray config/state/log writes land in a temp dir
+	// instead of the developer's real one. Sandbox AFTER the tripwires
+	// snapshot the real environment, BEFORE logging resolves its file path.
+	verifyTmux := testguard.TmuxTripwire()
+	restoreHome := testguard.SandboxHome()
+	aflog.Initialize(false)
 	code := m.Run()
+	aflog.Close()
+	restoreHome()
 	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	if err := verifyTmux(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		code = 1
 	}

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -21,11 +21,17 @@ import (
 // TestMain initializes the logger so that functions under test that write
 // WarningLog/ErrorLog messages do not nil-deref.
 func TestMain(m *testing.M) {
-	log.Initialize(false)
-	defer log.Close()
 	// #837: fail the package loudly if any test touches the real config.json.
 	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: default the whole package into a sandboxed AGENT_FACTORY_HOME so
+	// stray config/state/log writes land in a temp dir instead of the
+	// developer's real one. Sandbox AFTER the tripwire snapshots the real
+	// environment, BEFORE logging resolves its file path.
+	restoreHome := testguard.SandboxHome()
+	log.Initialize(false)
 	code := m.Run()
+	log.Close()
+	restoreHome()
 	if err := verifyRealConfig(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		code = 1

--- a/ui/main_test.go
+++ b/ui/main_test.go
@@ -11,7 +11,13 @@ import (
 func TestMain(m *testing.M) {
 	// #837: fail the package loudly if any test touches the real config.json.
 	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: default the whole package into a sandboxed AGENT_FACTORY_HOME.
+	// Many tests here call log.Initialize without setting a home of their
+	// own; the sandbox routes those log files (and any stray config/state
+	// writes) into a temp dir instead of the developer's real one.
+	restoreHome := testguard.SandboxHome()
 	code := m.Run()
+	restoreHome()
 	if err := verifyRealConfig(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		code = 1


### PR DESCRIPTION
Closes #1056

## Root cause — two independent leak seams

1. **The log path never honored `AGENT_FACTORY_HOME`.** `log/log.go` computed `logFileName` **once at package init** from `os.UserConfigDir()` → `~/.config/agent-factory/agent-factory.log`. Setting `AGENT_FACTORY_HOME` (which every well-behaved test already did) isolated config/state but **not the log**: every `log.Initialize` — 8 package `TestMain`s, ~50 test bodies, and every `af` binary exec'd by an integration test (plus the daemons those spawn) — appended to the developer's real production log. This is where `daemon.go:252 "tracked"`, `watcher.go:442 bbbb0001`, and the `/tmp/Test…` lines in the prod log came from.
2. **No tmux server isolation.** The six tests that create real tmux sessions all ran against the developer's default tmux server, with only best-effort per-session cleanup (`inst.Kill()` / `af sessions kill` / title-keyed `kill-session`). Any failure, timeout, or interrupted run orphaned `af_*` sessions — the `after-stale-socket`, `after-missing-socket`, `parallel-N`, `dig`, `cli-made` pile on the dev box.

## The fix

**Log seam** (`log/log.go`): the log path is now resolved lazily at `Initialize` time, in priority order: in-package test override → **`$AGENT_FACTORY_HOME/agent-factory.log`** (same relocation override `config.GetConfigDir` honors, so a sandboxed home gets a sandboxed log — including in exec'd `af` children, which inherit the env) → under `go test` (`testing.Testing()`) with no home set, a scratch file in `os.TempDir()` so a future non-sandboxed test **cannot** reach the real log by construction → the historical `os.UserConfigDir()` default, unchanged for production. Note: a user who runs `af` with `AGENT_FACTORY_HOME` set now gets the log inside that home rather than `~/.config` — coherent with what the variable promises (the dev box's real daemon unit does not set it, so its log does not move).

**tmux isolation** (`internal/testguard.IsolateTmux`): each real-tmux test now runs against a **private tmux server** — fresh `TMUX_TMPDIR` socket dir with `$TMUX` cleared (`$TMUX` wins over `TMUX_TMPDIR` in tmux's socket resolution, and the dev box runs tests from inside tmux panes) — and a `t.Cleanup` that `tmux kill-server`s it. Parent probes, the exec'd `af` CLI, and the daemon it spawns (`exec.Command(execPath, "--daemon")` inherits env) all land on the same private server, which dies with the test **even when per-session cleanup fails**. Existing best-effort cleanups are kept as a first, graceful pass.

**Regression guard** (`internal/testguard`):
- `TmuxTripwire()` — snapshots the ambient server's `af_*` sessions in `TestMain` and fails the package run if new ones remain after `m.Run()` (escape hatch `AF_DISABLE_TMUX_TRIPWIRE=1`; no-op without tmux). Wired into every package that can touch tmux: `app`, `daemon`, `integration`, `session`, `session/tmux`.
- `SandboxHome()` — points `AGENT_FACTORY_HOME` at a package-wide temp dir from `TestMain` (after the tripwires snapshot the real environment, before logging resolves its path), so tests that never set a home of their own still can't read/write the real one. Wired into all 10 `TestMain`s below.
- Deliberately **no prod-log-growth tripwire**: on a dev box the real daemon appends to that log concurrently, so a size check would false-positive; the `testing.Testing()` fallback in the log seam makes the in-process log-leak class structurally impossible instead.
- New tests cover all three helpers (the tmux ones exercise the tripwire against the private server `IsolateTmux` itself provides, so they are hermetic too).

Also fixed en route: the `defer log.Close()` in several `TestMain`s never ran (`os.Exit` skips defers) — now explicit; `TestGetConfigDir`'s first subtest asserted default resolution against ambient env (it now pins `AGENT_FACTORY_HOME=""`); `log`'s own race tests overrode the removed init-time var and now use the explicit test override.

## Adjacent-site audit — every test entry point that builds a daemon/backend/storage/tmux

| Package | Real tmux? | Logged to prod log? | State |
|---|---|---|---|
| `daemon` | yes — `deliver_prompt_test.go` #916 orphan test | yes (TestMain + bodies) | **fixed**: `IsolateTmux` on the orphan test; TestMain → tripwires + sandbox |
| `integration` | yes — `cli_daemon_test.go` harness (5 tests), `codex_ready_test.go` (2 tests), via exec'd `af` + daemon | yes (via children) | **fixed**: `IsolateTmux` in `newHarness` + both codex tests; TestMain → tripwires + sandbox; children now log under their temp `AGENT_FACTORY_HOME` |
| `app` | yes — `real_e2e_test.go`, `real_tui_e2e_test.go`, `cli_daemon_integration_test.go` (2 tests) | yes (TestMain + children) | **fixed**: `IsolateTmux` on all 4 tests; TestMain → tripwires + sandbox |
| `session` | no (all backends/tmux mocked) | yes (TestMain + ~20 bodies) | **fixed**: TestMain → tripwires + sandbox; body `log.Initialize` calls now resolve into the per-test/sandbox home |
| `session/tmux` | no (MockPtyFactory/MockCmdExec) | yes (TestMain) | **fixed**: TestMain → tripwires + sandbox |
| `session/git` | no | yes (TestMain) | **fixed**: TestMain → sandbox |
| `task` | no (FakeBackend) | yes (TestMain) | **fixed**: TestMain → sandbox |
| `config` | no (spawns bash, not tmux) | yes (TestMain) | **fixed**: TestMain → sandbox |
| `ui` | no (raw `tmux kill-session` calls are defensive no-ops on never-created names) | yes (~30 body `log.Initialize` calls) | **fixed**: TestMain → sandbox routes all of them |
| `.` (root) | no | yes (TestMain) | **fixed**: TestMain → sandbox |
| `log` | no | yes (2 tests didn't override the path) | **fixed**: explicit `logPathOverride` seam + `testing.Testing()` fallback |
| `api` | no | no (never initializes logging; all tests set `AGENT_FACTORY_HOME`) | already hermetic — unchanged |
| `internal/testguard`, `ui/overlay`, `cmd`, `keys` | no | no | already hermetic — unchanged |

The orphan name `af_*_term_TriageDetailBugs` from the issue is **not producible by any test** (no `term_` prefix exists in the codebase; tab sessions use `__shell`/`__<cmd>` suffixes) — it was a real `af` session whose user-supplied title was `term_TriageDetailBugs`, i.e. dev-box usage, not suite leakage.

## Before/after leak proof (dev box)

**Before** (master, `AGENT_FACTORY_HOME` pointed at a scratch temp dir — i.e. even a "sandboxed" run):
```
$ AGENT_FACTORY_HOME=$(mktemp -d) go test ./daemon/ -run 'TestWatcher…' → ok
prod log grew by 2580 bytes; appended region contains:
WARNING:… watcher.go:442: watch task bbbb0001: watch command failed (exit status 3); restarting in 40ms
… (6 fixture lines matching bbbb0001|/tmp/)
```

**After** (this branch, **ambient env — no `AGENT_FACTORY_HOME` at all**):
```
$ go test ./daemon/ -run 'TestWatcher…' → ok
prod log grew by 0 bytes
$ go test ./...   → all packages pass
tmux ls before/after: identical (94 sessions, no new af_*)
~/.config/agent-factory + ~/.agent-factory: no file created/modified by the run
```
(exact transcripts in the verification section below)

## Verification

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `go test ./...` — pass (ambient env, no sandbox var needed anymore)
- `GOFLAGS="-p=1" go test -race -parallel 2 ./daemon/... ./integration/... ./session/...` — pass
- tmux `ls` diff before/after the full suite — no new sessions
- prod log byte-size + fixture-grep — no test lines appended
- marker-file scan of the real `~/.agent-factory` and `~/.config/agent-factory` — untouched

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
