### PR TITLE
fix(daemon): legacy-unit sweep also removes pre-rename claude-squad-sched-* units (#1058)

### DIFF
--- a/daemon/legacy_units.go
+++ b/daemon/legacy_units.go
@@ -54,10 +54,13 @@ func sweepLegacyTaskUnits() {
 }
 
 // legacySystemdUnitPrefixes are the unit-name prefixes previous versions used
-// for per-task timers: "agent-factory-task-" for every v1.0.x release, and
-// "agent-factory-sched-" for the short-lived pre-rename nightly builds
-// (Schedules became Tasks in 6ec0996).
-var legacySystemdUnitPrefixes = []string{"agent-factory-task-", "agent-factory-sched-"}
+// for per-task timers: "agent-factory-task-" for every v1.0.x release,
+// "agent-factory-sched-" for the builds between the repo rename and the
+// Schedules→Tasks rename (6ec0996), and "claude-squad-sched-" for builds
+// before the claude-squad→agent-factory repo rename (8e55df0). These are the
+// only three prefixes any released scheduler ever wrote; launchd support
+// postdates the repo rename, so "com.agent-factory.task-" below is complete.
+var legacySystemdUnitPrefixes = []string{"agent-factory-task-", "agent-factory-sched-", "claude-squad-sched-"}
 
 func sweepLegacySystemdUnits() {
 	dir, err := legacySystemdUserDir()

--- a/daemon/legacy_units_test.go
+++ b/daemon/legacy_units_test.go
@@ -64,18 +64,24 @@ func TestSweepLegacyTaskUnits_RemovesOldPerTaskUnits(t *testing.T) {
 	// Pre-rename nightly builds used the "agent-factory-sched-" prefix.
 	oldPrefixTimer := filepath.Join(stub.systemdDir, "agent-factory-sched-12345678.timer")
 	oldPrefixService := filepath.Join(stub.systemdDir, "agent-factory-sched-12345678.service")
+	// Builds before the claude-squad→agent-factory repo rename used the
+	// "claude-squad-sched-" prefix (#1058).
+	preRenameTimer := filepath.Join(stub.systemdDir, "claude-squad-sched-235b8c0b.timer")
+	preRenameService := filepath.Join(stub.systemdDir, "claude-squad-sched-235b8c0b.service")
+	// An orphaned pre-rename timer without its service must also be swept.
+	preRenameOrphanTimer := filepath.Join(stub.systemdDir, "claude-squad-sched-a288118f.timer")
 	unrelatedUnit := filepath.Join(stub.systemdDir, "syncthing.service")
 	// The daemon's own autostart unit must never be swept.
 	daemonUnit := filepath.Join(stub.systemdDir, "agent-factory-daemon.service")
 	plist := filepath.Join(stub.launchAgentsDir, "com.agent-factory.task-abc12345.plist")
 	unrelatedPlist := filepath.Join(stub.launchAgentsDir, "com.example.other.plist")
-	for _, p := range []string{timer, service, orphanService, oldPrefixTimer, oldPrefixService, unrelatedUnit, daemonUnit, plist, unrelatedPlist} {
+	for _, p := range []string{timer, service, orphanService, oldPrefixTimer, oldPrefixService, preRenameTimer, preRenameService, preRenameOrphanTimer, unrelatedUnit, daemonUnit, plist, unrelatedPlist} {
 		writeTestFile(t, p)
 	}
 
 	sweepLegacyTaskUnits()
 
-	for _, p := range []string{timer, service, orphanService, oldPrefixTimer, oldPrefixService, plist} {
+	for _, p := range []string{timer, service, orphanService, oldPrefixTimer, oldPrefixService, preRenameTimer, preRenameService, preRenameOrphanTimer, plist} {
 		if _, err := os.Stat(p); !os.IsNotExist(err) {
 			t.Errorf("expected legacy unit %s to be removed, stat err=%v", p, err)
 		}
@@ -91,7 +97,13 @@ func TestSweepLegacyTaskUnits_RemovesOldPerTaskUnits(t *testing.T) {
 		t.Errorf("expected the legacy timer to be disabled, commands:\n%s", joined)
 	}
 	if !strings.Contains(joined, "systemctl --user disable --now agent-factory-sched-12345678.timer") {
-		t.Errorf("expected the pre-rename legacy timer to be disabled, commands:\n%s", joined)
+		t.Errorf("expected the old-prefix legacy timer to be disabled, commands:\n%s", joined)
+	}
+	if !strings.Contains(joined, "systemctl --user disable --now claude-squad-sched-235b8c0b.timer") {
+		t.Errorf("expected the pre-rename claude-squad timer to be disabled, commands:\n%s", joined)
+	}
+	if !strings.Contains(joined, "systemctl --user disable --now claude-squad-sched-a288118f.timer") {
+		t.Errorf("expected the orphaned pre-rename claude-squad timer to be disabled, commands:\n%s", joined)
 	}
 	if !strings.Contains(joined, "systemctl --user daemon-reload") {
 		t.Errorf("expected a systemd daemon-reload after removals, commands:\n%s", joined)


### PR DESCRIPTION
Closes #1058

## Root cause

`sweepLegacyTaskUnits` (runs once at daemon start, `daemon/daemon.go:130`) removes obsolete per-task scheduler units, but `legacySystemdUnitPrefixes` only listed `agent-factory-task-` and `agent-factory-sched-`. Units written before the claude-squad→agent-factory repo rename used the prefix **`claude-squad-sched-`** and were never matched, so 5 stale timers on the dev box fire daily, fail `203/EXEC` (their `~/.local/bin/cs` ExecStart binary is gone), and 3 of their ids match live daemon task ids — a double-fire risk anywhere an old `cs` binary still exists.

## Fix

Add `claude-squad-sched-` to `legacySystemdUnitPrefixes`. The existing removal path already does the right thing per prefix: `systemctl --user disable --now` each `.timer`, remove both `.timer` and `.service` files, then `daemon-reload`. Prefix matching cannot touch `agent-factory-daemon.service` or any live unit.

## Adjacent-site audit: full legacy-prefix set

Traced every scheduler unit name the repo ever shipped via git pickaxe:

| Prefix | Era | Status |
|---|---|---|
| `claude-squad-sched-` | 759ca06 (2026-03-03) → rename 8e55df0 (2026-03-08) | **was missing — added here** |
| `agent-factory-sched-` | rename → Schedules→Tasks rename (6ec0996) | already swept |
| `agent-factory-task-` | 6ec0996 → daemon scheduling (#782) | already swept |
| `com.agent-factory.task-*.plist` (launchd) | added 44a17ee (2026-03-15), **after** the rename | already swept; no `com.claude-squad.*` label ever existed |

Pickaxe for `claude-squad-task-`, `claude-squad-daemon`, and `cs-sched` across all history returns zero hits — those names never shipped. The matcher now covers the complete set; the code comment on `legacySystemdUnitPrefixes` documents this so future renames know the list is closed.

## Tests (hermetic)

The package already had an injection seam (`legacySystemdUserDir`/`legacyUnitCommand` vars + `stubLegacyUnitSweep` pointing at `t.TempDir()`), so no real systemd is touched. Extended `TestSweepLegacyTaskUnits_RemovesOldPerTaskUnits` to seed `claude-squad-sched-*` timer+service pairs (ids taken from the real stale units in #1058) plus an orphaned timer, asserting they are disabled and removed while `agent-factory-daemon.service` and unrelated units survive.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — all green
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./daemon/...` — ok

No real user units were enumerated, stopped, or removed; the running daemon was untouched.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)