### PR TITLE
feat(log): size-capped log rotation to stop unbounded agent-factory.log growth (#1059)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -113,6 +113,17 @@ type Config struct {
 	AutoYes bool `json:"auto_yes"`
 	// DaemonPollInterval is the interval (ms) at which the daemon polls sessions for autoyes mode.
 	DaemonPollInterval int `json:"daemon_poll_interval"`
+	// LogMaxSizeMB is the size cap (MB) for agent-factory.log. When the log
+	// exceeds it, the file is rotated (renamed to .1, older backups shifted
+	// up). Must be positive; non-positive values fall back to the default.
+	// The rotation itself lives in the log package, which re-reads this key
+	// directly from config.json (log cannot import config, and logging is
+	// initialized before the config loads).
+	LogMaxSizeMB int `json:"log_max_size_mb"`
+	// LogMaxBackups is how many rotated log files (agent-factory.log.1,
+	// .log.2, ...) are kept; older ones are deleted. 0 keeps none (the log is
+	// deleted on rotation); negative values fall back to the default.
+	LogMaxBackups int `json:"log_max_backups"`
 	// BranchPrefix is the prefix used for git branches created by the application.
 	BranchPrefix string `json:"branch_prefix"`
 	// DetachKeys is the key combination used to detach from an attached session (e.g. "ctrl-w", "ctrl-q").
@@ -198,6 +209,8 @@ func DefaultConfig() *Config {
 		DefaultProgram:     defaultProgram,
 		AutoYes:            false,
 		DaemonPollInterval: defaultDaemonPollInterval,
+		LogMaxSizeMB:       log.DefaultMaxSizeMB,
+		LogMaxBackups:      log.DefaultMaxBackups,
 		BranchPrefix: func() string {
 			user, err := user.Current()
 			if err != nil || user == nil || user.Username == "" {
@@ -598,6 +611,15 @@ func parseConfig(data []byte, prettyConfigPath string) (*Config, error) {
 	if config.DaemonPollInterval <= 0 {
 		log.WarningLog.Printf("daemon_poll_interval=%d is non-positive; using default %dms", config.DaemonPollInterval, defaultDaemonPollInterval)
 		config.DaemonPollInterval = defaultDaemonPollInterval
+	}
+
+	if config.LogMaxSizeMB <= 0 {
+		log.WarningLog.Printf("log_max_size_mb=%d is non-positive; using default %d MB", config.LogMaxSizeMB, log.DefaultMaxSizeMB)
+		config.LogMaxSizeMB = log.DefaultMaxSizeMB
+	}
+	if config.LogMaxBackups < 0 {
+		log.WarningLog.Printf("log_max_backups=%d is negative; using default %d", config.LogMaxBackups, log.DefaultMaxBackups)
+		config.LogMaxBackups = log.DefaultMaxBackups
 	}
 
 	return config, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -811,6 +811,39 @@ func TestLoadConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("clamps invalid log rotation keys to defaults", func(t *testing.T) {
+		cases := []struct {
+			name            string
+			content         string
+			expectedSizeMB  int
+			expectedBackups int
+		}{
+			{"missing keys -> defaults", `{"default_program": "claude"}`, log.DefaultMaxSizeMB, log.DefaultMaxBackups},
+			{"non-positive size -> default", `{"default_program": "claude", "log_max_size_mb": 0}`, log.DefaultMaxSizeMB, log.DefaultMaxBackups},
+			{"negative backups -> default", `{"default_program": "claude", "log_max_backups": -1}`, log.DefaultMaxSizeMB, log.DefaultMaxBackups},
+			{"explicit zero backups is valid", `{"default_program": "claude", "log_max_backups": 0}`, log.DefaultMaxSizeMB, 0},
+			{"custom values -> as-is", `{"default_program": "claude", "log_max_size_mb": 10, "log_max_backups": 5}`, 10, 5},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+				configDir, err := GetConfigDir()
+				require.NoError(t, err)
+				require.NoError(t, os.MkdirAll(configDir, 0755))
+
+				configPath := filepath.Join(configDir, ConfigFileName)
+				require.NoError(t, os.WriteFile(configPath, []byte(tc.content), 0644))
+
+				cfg, err := LoadConfig()
+				require.NoError(t, err)
+				require.NotNil(t, cfg)
+				assert.Equal(t, tc.expectedSizeMB, cfg.LogMaxSizeMB)
+				assert.Equal(t, tc.expectedBackups, cfg.LogMaxBackups)
+			})
+		}
+	})
+
 	t.Run("surfaces parse error on invalid JSON instead of using defaults", func(t *testing.T) {
 		// A present-but-corrupt config must NOT be silently replaced by
 		// defaults — that hides a user's broken settings (#734).

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -85,6 +85,8 @@ var inRepoGlobalOnlyKeys = map[string]bool{
 	"branch_prefix":        true,
 	"daemon_poll_interval": true,
 	"detach_keys":          true,
+	"log_max_backups":      true,
+	"log_max_size_mb":      true,
 	"worktree_root":        true,
 }
 

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -66,7 +66,7 @@ func TestLoadInRepoConfigEmptyValueIsSet(t *testing.T) {
 }
 
 func TestLoadInRepoConfigRejectsGlobalOnlyKeys(t *testing.T) {
-	for _, key := range []string{"auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "worktree_root"} {
+	for _, key := range []string{"auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "log_max_backups", "log_max_size_mb", "worktree_root"} {
 		t.Run(key, func(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("AGENT_FACTORY_HOME", home)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,9 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
   "auto_yes": false,
   "daemon_poll_interval": 1000,
   "branch_prefix": "username/",
-  "detach_keys": "ctrl-w"
+  "detach_keys": "ctrl-w",
+  "log_max_size_mb": 50,
+  "log_max_backups": 2
 }
 ```
 
@@ -32,6 +34,8 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
 | `daemon_poll_interval` | Daemon polling interval in ms. |
 | `branch_prefix` | Prefix for worktree branches (defaults to `username/`). |
 | `detach_keys` | Key combination that detaches from an attached session (defaults to `ctrl-w`). |
+| `log_max_size_mb` | Size cap in MB for `agent-factory.log` before it is rotated (defaults to 50). Must be positive. |
+| `log_max_backups` | How many rotated logs (`agent-factory.log.1`, `.2`, ...) to keep; older ones are deleted (defaults to 2). `0` keeps none. |
 
 ### Choosing the agent
 
@@ -68,7 +72,7 @@ A repository can carry its own configuration in `<repo-root>/.agent-factory/conf
 |-------|-------|
 | `default_program`, `program_overrides` | Valid globally **and** in-repo (in-repo wins). |
 | `post_worktree_commands`, `remote_hooks` | **In-repo only.** The legacy `~/.agent-factory/repos/<repoID>/config.json` location keeps working for one more release (a deprecation warning in the log points at the new file) and is shadowed whenever the in-repo file sets the same key — including by an explicit empty value like `"post_worktree_commands": []`. |
-| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `detach_keys` | Global only. Setting them in-repo is rejected with an error naming the key. |
+| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `detach_keys`, `log_max_size_mb`, `log_max_backups` | Global only. Setting them in-repo is rejected with an error naming the key. |
 
 `post_worktree_commands` are shell commands run after each new worktree is created (e.g. `npm install`, `make build`) — they can also be edited from the TUI via the `H` (worktree hooks) key. `remote_hooks` configures a remote-machine backend; see [remote-hooks.md](remote-hooks.md) for the script protocol.
 
@@ -90,6 +94,6 @@ All data (sessions, tasks) is scoped to the current git repository — the TUI s
 | `~/.agent-factory/instances/<repoID>/instances.json` | Persisted sessions, per repo. |
 | `~/.agent-factory/tasks.json` | Tasks (see [tasks.md](tasks.md)). |
 | `~/.agent-factory/logs/task-<id>.log` | Per-task watch-script logs. |
-| `~/.config/agent-factory/agent-factory.log` | Application log (`os.UserConfigDir` on other platforms). |
+| `~/.config/agent-factory/agent-factory.log` | Application log (`os.UserConfigDir` on other platforms). Rotated once it exceeds `log_max_size_mb` (default 50 MB); the most recent `log_max_backups` rotations (default 2) are kept as `agent-factory.log.1`, `.2`. |
 
 Setting the `AGENT_FACTORY_HOME` environment variable relocates the `~/.agent-factory` state directory — useful for sandboxed or test setups. When it is set, the application log also moves into that directory (`$AGENT_FACTORY_HOME/agent-factory.log`) so a relocated home is fully self-contained.

--- a/log/log.go
+++ b/log/log.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -10,6 +11,17 @@ import (
 	"sync"
 	"testing"
 	"time"
+)
+
+// Log-rotation defaults (#1059). The log is rotated when it exceeds
+// DefaultMaxSizeMB; DefaultMaxBackups rotated files (agent-factory.log.1,
+// .log.2, ...) are kept and older ones deleted. Both are overridable in the
+// global config.json via "log_max_size_mb" and "log_max_backups"; the config
+// package reuses these constants so the two packages cannot drift (config
+// imports log, so the constants must live here).
+const (
+	DefaultMaxSizeMB  = 50
+	DefaultMaxBackups = 2
 )
 
 var (
@@ -102,11 +114,159 @@ func resolveLogPath() string {
 	return filepath.Join(dir, "agent-factory.log")
 }
 
+// rotationPolicy resolves the log-rotation cap and backup count from the
+// global config.json ("log_max_size_mb" / "log_max_backups"), falling back to
+// the package defaults. This package cannot import config (config imports
+// log) and Initialize runs before config.LoadConfig, so the two keys are read
+// here directly with a tolerant parse: a missing or unreadable file, invalid
+// JSON, or out-of-range values all silently yield the defaults —
+// config.LoadConfig is the layer that warns the user about bad values.
+//
+// The config file location mirrors config.GetConfigDir: $AGENT_FACTORY_HOME
+// when set, else ~/.agent-factory. Inside a `go test` binary with no home
+// override no file is read at all, so a developer's personal config can never
+// change test behavior (#1056/#1057 hermeticity).
+func rotationPolicy() (maxBytes int64, backups int) {
+	maxMB := DefaultMaxSizeMB
+	backups = DefaultMaxBackups
+
+	configPath := ""
+	if home := os.Getenv("AGENT_FACTORY_HOME"); home != "" {
+		if dir, ok := expandTilde(home); ok {
+			configPath = filepath.Join(dir, "config.json")
+		}
+	} else if !testing.Testing() {
+		if home, err := os.UserHomeDir(); err == nil {
+			configPath = filepath.Join(home, ".agent-factory", "config.json")
+		}
+	}
+	if configPath != "" {
+		// Pointers distinguish "key absent" from an explicit zero:
+		// log_max_backups=0 (keep no rotated files) is valid, an absent key
+		// means the default.
+		var cfg struct {
+			LogMaxSizeMB  *int `json:"log_max_size_mb"`
+			LogMaxBackups *int `json:"log_max_backups"`
+		}
+		if data, err := os.ReadFile(configPath); err == nil && json.Unmarshal(data, &cfg) == nil {
+			if cfg.LogMaxSizeMB != nil && *cfg.LogMaxSizeMB > 0 {
+				maxMB = *cfg.LogMaxSizeMB
+			}
+			if cfg.LogMaxBackups != nil && *cfg.LogMaxBackups >= 0 {
+				backups = *cfg.LogMaxBackups
+			}
+		}
+	}
+	return int64(maxMB) * 1024 * 1024, backups
+}
+
+// rotateFiles shifts the rotated-log chain one step: path.<backups-1> ->
+// path.<backups>, ..., path.1 -> path.2, path -> path.1. With backups == 0
+// the current file is simply deleted. Afterwards any contiguous run of
+// backups beyond the keep count (left over from a larger log_max_backups) is
+// pruned. Everything is best-effort: rotation must never prevent logging, so
+// rename/remove errors are ignored and the caller reopens path regardless.
+//
+// Cross-process note: rotation happens with no lock held against other af
+// processes. os.Rename is atomic on the same filesystem, so concurrent
+// writers never see a torn file; the worst race outcome is a writer holding
+// an fd appending to a file that is now path.1 (its O_APPEND writes still
+// land intact there). CLI invocations are short-lived so their fds close
+// almost immediately, and the long-lived daemon rotates its own fd via
+// rotatingWriter, so no process appends to a renamed file for long.
+func rotateFiles(path string, backups int) {
+	if backups <= 0 {
+		_ = os.Remove(path)
+	} else {
+		for i := backups - 1; i >= 1; i-- {
+			_ = os.Rename(fmt.Sprintf("%s.%d", path, i), fmt.Sprintf("%s.%d", path, i+1))
+		}
+		_ = os.Rename(path, path+".1")
+	}
+	for i := backups + 1; ; i++ {
+		if err := os.Remove(fmt.Sprintf("%s.%d", path, i)); err != nil {
+			break
+		}
+	}
+}
+
+// rotatingWriter is the io.Writer behind the exported loggers: an *os.File
+// plus a size counter that triggers an in-place rotation when a write would
+// push the file past maxBytes. Initialize's stat-and-rotate-on-open already
+// bounds every short-lived CLI invocation; this write-path check is what
+// bounds the always-on daemon, which otherwise holds one fd for weeks and —
+// worse — would keep appending to the renamed (and eventually deleted) inode
+// after another process rotated the file under it (#1059).
+//
+// The mutex serializes Write/Close because the three exported loggers share
+// one writer and *log.Logger only serializes writes through itself. size is
+// process-local: concurrent appends from another af process are not counted,
+// so a file can transiently exceed the cap until either process next rotates.
+// That slack is acceptable for a log; the cap is a bound, not an exact quota.
+type rotatingWriter struct {
+	mu       sync.Mutex
+	file     *os.File
+	path     string
+	size     int64
+	maxBytes int64
+	backups  int
+}
+
+func (w *rotatingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file == nil {
+		// Close redirects the loggers to stderr before closing this writer,
+		// so nothing should land here; if something does (or a rotation
+		// failed to reopen the file), surface it rather than dropping it —
+		// the #642 tests pin "every Printf lands somewhere".
+		return os.Stderr.Write(p)
+	}
+	// The size > 0 guard keeps a single oversized message from rotating an
+	// empty file on every write.
+	if w.size > 0 && w.size+int64(len(p)) > w.maxBytes {
+		w.rotateLocked()
+		if w.file == nil {
+			return os.Stderr.Write(p)
+		}
+	}
+	n, err := w.file.Write(p)
+	w.size += int64(n)
+	return n, err
+}
+
+// rotateLocked closes the current file, shifts the backup chain, and reopens
+// a fresh file at path. On reopen failure w.file is left nil and Write falls
+// back to stderr; the next Initialize will recover.
+func (w *rotatingWriter) rotateLocked() {
+	_ = w.file.Close()
+	w.file = nil
+	rotateFiles(w.path, w.backups)
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not reopen log file %s after rotation: %v, logging to stderr\n", w.path, err)
+		return
+	}
+	w.file = f
+	w.size = 0
+}
+
+func (w *rotatingWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file == nil {
+		return nil
+	}
+	err := w.file.Close()
+	w.file = nil
+	return err
+}
+
 // logFileName is the path the most recent Initialize resolved and attempted
 // to open; Close uses it for the "wrote logs to" message.
 var logFileName string
 
-var globalLogFile *os.File
+var globalLogFile *rotatingWriter
 
 // Initialize should be called once at the beginning of the program to set up logging.
 // defer Close() after calling this function. It sets the go log output to the file in
@@ -139,6 +299,15 @@ func Initialize(daemon bool) {
 		globalLogFile = nil
 	}
 
+	// Rotate before opening when the existing log already exceeds the cap
+	// (#1059). This is the seam every af process passes through — the daemon,
+	// the TUI, and each CLI invocation all call Initialize — so even a log
+	// grown huge by an old binary is trimmed on the next af command.
+	maxBytes, backups := rotationPolicy()
+	if fi, err := os.Stat(logFileName); err == nil && fi.Size() > maxBytes {
+		rotateFiles(logFileName, backups)
+	}
+
 	f, err := os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not open log file %s: %v, logging to stderr\n", logFileName, err)
@@ -155,15 +324,20 @@ func Initialize(daemon bool) {
 	// Set log format to include timestamp and file/line number
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
+	w := &rotatingWriter{file: f, path: logFileName, maxBytes: maxBytes, backups: backups}
+	if fi, err := f.Stat(); err == nil {
+		w.size = fi.Size()
+	}
+
 	fmtS := "%s"
 	if daemon {
 		fmtS = "[DAEMON] %s"
 	}
-	InfoLog = log.New(f, fmt.Sprintf(fmtS, "INFO:"), log.Ldate|log.Ltime|log.Lshortfile)
-	WarningLog = log.New(f, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
-	ErrorLog = log.New(f, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
+	InfoLog = log.New(w, fmt.Sprintf(fmtS, "INFO:"), log.Ldate|log.Ltime|log.Lshortfile)
+	WarningLog = log.New(w, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
+	ErrorLog = log.New(w, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
 
-	globalLogFile = f
+	globalLogFile = w
 }
 
 func Close() {

--- a/log/rotate_test.go
+++ b/log/rotate_test.go
@@ -1,0 +1,219 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The rotation tests (#1059) are hermetic: each one points AGENT_FACTORY_HOME
+// at a fresh temp dir, so both the log file (resolveLogPath) and the rotation
+// policy (rotationPolicy reads $AGENT_FACTORY_HOME/config.json) live entirely
+// in the sandbox and never touch the developer's real log or config. A 1 MB
+// cap keeps the fixtures small while still exercising the real MB-based
+// config keys.
+
+// setupRotationHome creates a sandboxed AGENT_FACTORY_HOME with the given
+// rotation config and returns the log path inside it.
+func setupRotationHome(t *testing.T, configJSON string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	if configJSON != "" {
+		if err := os.WriteFile(filepath.Join(home, "config.json"), []byte(configJSON), 0644); err != nil {
+			t.Fatalf("write config.json: %v", err)
+		}
+	}
+	return filepath.Join(home, "agent-factory.log")
+}
+
+// fillFile writes size bytes of marker-prefixed content to path.
+func fillFile(t *testing.T, path, marker string, size int) {
+	t.Helper()
+	content := append([]byte(marker+"\n"), bytes.Repeat([]byte("x"), size)...)
+	if err := os.WriteFile(path, content[:size], 0600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestInitializeRotatesOverCap(t *testing.T) {
+	logPath := setupRotationHome(t, `{"log_max_size_mb": 1, "log_max_backups": 2}`)
+	fillFile(t, logPath, "OLD-LOG-CONTENT", 1<<20+512) // just over the 1 MB cap
+
+	Initialize(false)
+	defer Close()
+
+	InfoLog.Printf("fresh-after-rotation")
+
+	rotated, err := os.ReadFile(logPath + ".1")
+	if err != nil {
+		t.Fatalf("expected rotated file %s.1 to exist: %v", logPath, err)
+	}
+	if !strings.HasPrefix(string(rotated), "OLD-LOG-CONTENT") {
+		t.Fatalf("rotated file does not carry the old log content; starts with %q", string(rotated[:32]))
+	}
+
+	current, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("expected fresh log file: %v", err)
+	}
+	if strings.Contains(string(current), "OLD-LOG-CONTENT") {
+		t.Fatalf("fresh log still contains pre-rotation content")
+	}
+	if !strings.Contains(string(current), "fresh-after-rotation") {
+		t.Fatalf("fresh log missing post-rotation write; got %q", string(current))
+	}
+	if len(current) >= 1<<20 {
+		t.Fatalf("fresh log is not fresh: %d bytes", len(current))
+	}
+}
+
+func TestInitializeNoRotateUnderCap(t *testing.T) {
+	logPath := setupRotationHome(t, `{"log_max_size_mb": 1, "log_max_backups": 2}`)
+	fillFile(t, logPath, "UNDER-CAP-CONTENT", 100<<10) // 100 KB, well under 1 MB
+
+	Initialize(false)
+	defer Close()
+
+	InfoLog.Printf("appended-after-init")
+
+	if _, err := os.Stat(logPath + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("expected no rotation under the cap; stat .1 err = %v", err)
+	}
+	current, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.HasPrefix(string(current), "UNDER-CAP-CONTENT") {
+		t.Fatalf("under-cap log was not preserved")
+	}
+	if !strings.Contains(string(current), "appended-after-init") {
+		t.Fatalf("expected append to the existing under-cap log")
+	}
+}
+
+func TestRotationRetentionPrunesBeyondKeepCount(t *testing.T) {
+	logPath := setupRotationHome(t, `{"log_max_size_mb": 1, "log_max_backups": 2}`)
+	fillFile(t, logPath, "CURRENT", 1<<20+512)
+	fillFile(t, logPath+".1", "BACKUP-1", 64)
+	fillFile(t, logPath+".2", "BACKUP-2", 64)
+	// A .3 left over from an earlier, larger log_max_backups must be pruned.
+	fillFile(t, logPath+".3", "BACKUP-3", 64)
+
+	Initialize(false)
+	defer Close()
+
+	one, err := os.ReadFile(logPath + ".1")
+	if err != nil {
+		t.Fatalf("read .1: %v", err)
+	}
+	if !strings.HasPrefix(string(one), "CURRENT") {
+		t.Fatalf(".1 should hold the pre-rotation current log; starts with %q", string(one[:16]))
+	}
+	two, err := os.ReadFile(logPath + ".2")
+	if err != nil {
+		t.Fatalf("read .2: %v", err)
+	}
+	if !strings.HasPrefix(string(two), "BACKUP-1") {
+		t.Fatalf(".2 should hold the old .1; got %q", string(two))
+	}
+	if _, err := os.Stat(logPath + ".3"); !os.IsNotExist(err) {
+		t.Fatalf("expected .3 to be pruned (keep count 2); stat err = %v", err)
+	}
+}
+
+func TestZeroBackupsDeletesOnRotation(t *testing.T) {
+	logPath := setupRotationHome(t, `{"log_max_size_mb": 1, "log_max_backups": 0}`)
+	fillFile(t, logPath, "DOOMED", 1<<20+512)
+
+	Initialize(false)
+	defer Close()
+
+	InfoLog.Printf("post-truncate-write")
+
+	if _, err := os.Stat(logPath + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("log_max_backups=0 must keep no rotated files; stat .1 err = %v", err)
+	}
+	current, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if strings.Contains(string(current), "DOOMED") {
+		t.Fatalf("old content survived a zero-backup rotation")
+	}
+	if len(current) >= 1<<20 {
+		t.Fatalf("log not truncated: %d bytes", len(current))
+	}
+}
+
+// TestWritePathRotation covers the long-running-daemon case: a process that
+// never re-runs Initialize must still rotate once its own writes push the
+// file past the cap, and no message may be lost across the rotation.
+func TestWritePathRotation(t *testing.T) {
+	logPath := setupRotationHome(t, `{"log_max_size_mb": 1, "log_max_backups": 1}`)
+
+	Initialize(false)
+	defer Close()
+
+	// Each line is ~1 KB; 1200 of them cross the 1 MB cap mid-run.
+	payload := strings.Repeat("p", 1024)
+	const writes = 1200
+	for i := 0; i < writes; i++ {
+		InfoLog.Printf("WPMARK %d %s", i, payload)
+	}
+
+	rotated, err := os.ReadFile(logPath + ".1")
+	if err != nil {
+		t.Fatalf("expected write-path rotation to produce %s.1: %v", logPath, err)
+	}
+	current, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read current log: %v", err)
+	}
+	if len(current) > 1<<20 {
+		t.Fatalf("current log exceeds the cap after write-path rotation: %d bytes", len(current))
+	}
+
+	combined := string(rotated) + string(current)
+	for i := 0; i < writes; i++ {
+		if !strings.Contains(combined, fmt.Sprintf("WPMARK %d ", i)) {
+			t.Fatalf("message %d lost across write-path rotation", i)
+		}
+	}
+}
+
+// TestRotationPolicyDefaults pins the policy resolution: defaults when no
+// config exists, overrides applied when present, invalid values ignored.
+func TestRotationPolicyDefaults(t *testing.T) {
+	t.Run("no config file -> defaults", func(t *testing.T) {
+		setupRotationHome(t, "")
+		maxBytes, backups := rotationPolicy()
+		if maxBytes != int64(DefaultMaxSizeMB)<<20 || backups != DefaultMaxBackups {
+			t.Fatalf("got maxBytes=%d backups=%d, want %d MB / %d", maxBytes, backups, DefaultMaxSizeMB, DefaultMaxBackups)
+		}
+	})
+	t.Run("config overrides", func(t *testing.T) {
+		setupRotationHome(t, `{"log_max_size_mb": 10, "log_max_backups": 5}`)
+		maxBytes, backups := rotationPolicy()
+		if maxBytes != 10<<20 || backups != 5 {
+			t.Fatalf("got maxBytes=%d backups=%d, want 10 MB / 5", maxBytes, backups)
+		}
+	})
+	t.Run("invalid values -> defaults", func(t *testing.T) {
+		setupRotationHome(t, `{"log_max_size_mb": -3, "log_max_backups": -1}`)
+		maxBytes, backups := rotationPolicy()
+		if maxBytes != int64(DefaultMaxSizeMB)<<20 || backups != DefaultMaxBackups {
+			t.Fatalf("got maxBytes=%d backups=%d, want defaults", maxBytes, backups)
+		}
+	})
+	t.Run("corrupt config -> defaults", func(t *testing.T) {
+		setupRotationHome(t, `{not json`)
+		maxBytes, backups := rotationPolicy()
+		if maxBytes != int64(DefaultMaxSizeMB)<<20 || backups != DefaultMaxBackups {
+			t.Fatalf("got maxBytes=%d backups=%d, want defaults", maxBytes, backups)
+		}
+	})
+}


### PR DESCRIPTION
Closes #1059

## Root cause

The `log/` package had no rotation of any kind: every af process — the always-on daemon, the TUI, and each CLI invocation — opened `agent-factory.log` with `O_APPEND` and grew it forever. On the dev box the file reached 2.6 GB / 23.4M lines. #1057 stopped the test-suite pollution, but production logging alone still grows without a ceiling.

## Design

**Rotate-on-open** (`log.Initialize`): before opening the log, if the existing file exceeds the cap it is rotated — current → `.1`, `.1` → `.2`, … up to the keep count; anything beyond is deleted (including stale higher-numbered backups left over from a larger keep count). Every af entry point passes through `Initialize`, so even a log grown huge by an old binary is trimmed by the next af command. Dependency-free — plain `os.Rename`/`os.Remove`.

**Rotate-on-write** (`rotatingWriter`): the three exported loggers now write through a small wrapper that counts bytes and rotates in-place when a write would cross the cap. This is what bounds the *daemon*, which holds one fd for weeks: rotation only at open would let the daemon's log grow unbounded between restarts — and worse, after another process rotated the file under it, the daemon would keep appending to the renamed (eventually deleted) inode, leaking disk invisibly until restart.

**Defaults & config**: cap **50 MB**, keep **2** backups (`agent-factory.log.1`, `.2`). Overridable via new global `config.json` keys `log_max_size_mb` (must be > 0) and `log_max_backups` (≥ 0; `0` = delete on rotation, keep nothing). Both documented in `docs/configuration.md`, materialized into fresh default configs, validated/clamped in `config.parseConfig` (same pattern as `daemon_poll_interval`), and rejected in in-repo configs (global-only, like the other host-level keys).

Because `config` imports `log` and `Initialize` runs before `config.LoadConfig`, the log package reads the two keys directly from the global `config.json` with a tolerant parse (missing/corrupt/invalid → defaults, silently; `config.LoadConfig` is the layer that warns the user). The defaults live in `log` as exported constants and `config` reuses them, so the packages can't drift. Precedent: `log.expandTilde` already mirrors config's home resolution for the same import-cycle reason. Inside `go test` with no `AGENT_FACTORY_HOME`, no config file is read at all, preserving #1056/#1057 hermeticity.

## Concurrency model

- Within a process: the three loggers share one `rotatingWriter`; its mutex serializes writes and rotation. The #642 no-loss guarantee is preserved (`Close` still redirects to stderr before closing; a write that ever reaches a closed writer falls back to stderr instead of being dropped) — the existing #642 burst-race tests still pass under `-race`.
- Across processes: rotation takes no cross-process lock. `os.Rename` is atomic, so concurrent writers never see a torn file; the worst race outcome is a short-lived CLI append landing in the just-renamed `.1` (its `O_APPEND` writes stay intact there). CLI opens are short; the daemon rotates its own fd via the write path, so no process appends to a renamed file for long. The per-process size counter doesn't see other processes' appends, so the file can transiently exceed the cap until either process next rotates — the cap is a bound, not an exact quota.

## Adjacent-site audit

- `agent-factory.log` is opened in exactly one place: `log.Initialize`. Every package (daemon, api, app, session, task, cli commands) logs through the shared `log.InfoLog`/`WarningLog`/`ErrorLog`, so rotation is universal — no bypasses found (`grep` for `agent-factory.log` and `O_APPEND` across the repo).
- Two other append-writers exist but target **different** files and are out of scope here: `daemon/watcher.go` (per-task `~/.agent-factory/logs/task-<id>.log`) and `app/detach_trace.go` (`detach-slow.log`, event-driven and tiny). The per-task watch-script logs are the one other unbounded-growth candidate; flagging for a follow-up issue rather than widening this PR.

## Tests

All hermetic — each test points `AGENT_FACTORY_HOME` at a fresh temp dir (log path *and* rotation config both resolve inside it; the real `~/.config` log is never touched), using a 1 MB cap to keep fixtures small while exercising the real MB-based keys:

- over-cap file at `Initialize` → rotated to `.1`, fresh file started
- under-cap → no rotation, appends preserved
- retention: `.1`→`.2` shift, stale `.3` pruned
- `log_max_backups: 0` → delete on rotation, no backups
- write-path rotation (the daemon case): 1200 logged lines cross the cap mid-run, `.1` appears, current file stays under cap, **zero messages lost** across the rotation
- `rotationPolicy` resolution: defaults / overrides / invalid values / corrupt JSON
- config layer: clamping table for both keys (mirrors the `daemon_poll_interval` test), in-repo rejection extended to the new global-only keys

## Verification

- `gofmt -l .` clean, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` all clean
- `go test ./...` green under a temp `AGENT_FACTORY_HOME`
- `GOFLAGS="-p=1" go test -race -parallel 2 ./log/... ./daemon/...` green (includes the #642 message-loss race tests against the new writer)
- End-to-end with the real binary: temp home + `log_max_size_mb: 1` + a 1.2 MB pre-seeded log → one `af sessions list` produced `agent-factory.log.1` (1.2 MB) and a fresh `agent-factory.log`

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)