### PR TITLE
feat(daemon): rotate per-task watch-script logs, reusing the #1059 rotation (#1062)

### DIFF
--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -27,7 +27,8 @@ import (
 //
 //   - each newline-terminated stdout line = one event; lines over 64KB are
 //     truncated with a logged note
-//   - stderr appends to ~/.agent-factory/logs/task-<id>.log
+//   - stderr appends to ~/.agent-factory/logs/task-<id>.log, size-capped by
+//     the same log_max_size_mb/log_max_backups rotation as the main log (#1062)
 //   - env: AF_TASK_ID, AF_TASK_NAME, AF_PROJECT_PATH
 //   - exit 0 = intentional stop (status "stopped"; re-armed by the next
 //     reload or re-enable); non-zero = restart with exponential backoff
@@ -494,17 +495,23 @@ func (w *taskWatcher) runOnce() (*tailBuffer, error) {
 	// mirroring the post-worktree hook runner (#610, #769).
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	// stderr appends to the per-task log. A logging failure must not take the
-	// watcher down — the failure tail below still captures stderr for this
-	// run even when the file can't be opened.
-	var stderrFile *os.File
+	// stderr appends to the per-task log, size-capped by the same rotation
+	// policy as the main log (#1062): NewRotatingFile rotates on open when the
+	// file already exceeds the cap and again on the write path, which is what
+	// bounds a continuous watch task whose log this run holds open for weeks.
+	// A logging failure must not take the watcher down — the failure tail
+	// below still captures stderr for this run even when the file can't be
+	// opened.
+	var stderrLog io.WriteCloser
+	var stderrLogPath string
 	if logPath, err := w.sup.logPath(w.taskID); err != nil {
 		log.WarningLog.Printf("watch task %s: cannot resolve stderr log path: %v", w.taskID, err)
-	} else if f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err != nil {
+	} else if lw, err := log.NewRotatingFile(logPath, 0644); err != nil {
 		log.WarningLog.Printf("watch task %s: cannot open stderr log: %v", w.taskID, err)
 	} else {
-		stderrFile = f
-		defer f.Close()
+		stderrLog = lw
+		stderrLogPath = logPath
+		defer lw.Close()
 	}
 
 	// Hand the child the write end of a pipe we own instead of using
@@ -524,8 +531,22 @@ func (w *taskWatcher) runOnce() (*tailBuffer, error) {
 	var stderrR, stderrW *os.File
 	if er, ew, perr := os.Pipe(); perr != nil {
 		log.WarningLog.Printf("watch task %s: cannot create stderr pipe (stderr won't appear in failure logs): %v", w.taskID, perr)
-		if stderrFile != nil {
-			cmd.Stderr = stderrFile
+		// Degrade to the pre-#797 direct-to-file wiring. cmd.Stderr must be a
+		// real *os.File here: for any other writer os/exec inserts a copy
+		// goroutine that Wait blocks on, and a backgrounded grandchild holding
+		// stderr open would wedge Wait forever — the group SIGKILL that
+		// guarantees EOF only runs after Wait returns. Child writes bypass the
+		// rotating writer's size accounting, so on this path growth is bounded
+		// by NewRotatingFile's rotate-on-open in the next runOnce instead.
+		if stderrLog != nil {
+			_ = stderrLog.Close()
+			stderrLog = nil
+			if f, ferr := os.OpenFile(stderrLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); ferr != nil {
+				log.WarningLog.Printf("watch task %s: cannot reopen stderr log: %v", w.taskID, ferr)
+			} else {
+				cmd.Stderr = f
+				defer f.Close()
+			}
 		}
 	} else {
 		stderrR, stderrW = er, ew
@@ -558,8 +579,8 @@ func (w *taskWatcher) runOnce() (*tailBuffer, error) {
 		close(stderrDone)
 	} else {
 		var sink io.Writer
-		if stderrFile != nil {
-			sink = stderrFile
+		if stderrLog != nil {
+			sink = stderrLog
 		}
 		go func() {
 			defer close(stderrDone)

--- a/daemon/watcher_test.go
+++ b/daemon/watcher_test.go
@@ -345,6 +345,63 @@ func TestWatcherStderrGoesToTaskLog(t *testing.T) {
 	}
 }
 
+// TestWatcherTaskLogRotates pins #1062: a watch script whose stderr output
+// crosses the configured size cap rotates the per-task log mid-run — .1 is
+// created, the active file is reset under the cap, the keep count is honored,
+// and no line is lost across the rotation. Hermetic per the #1057/#1061
+// pattern: the rotation policy is read from a sandboxed AGENT_FACTORY_HOME.
+func TestWatcherTaskLogRotates(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "config.json"), []byte(`{"log_max_size_mb": 1, "log_max_backups": 1}`), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+
+	dir := t.TempDir()
+	// ~1.25 MB of stderr in ~1 KB numbered lines crosses the 1 MB cap mid-run.
+	script := `payload=$(printf '%01024d' 0)
+i=0
+while [ $i -lt 1200 ]; do
+  echo "RMARK $i $payload" >&2
+  i=$((i+1))
+done
+exit 0`
+	s, rec := newTestSupervisor(t, staticTasks(watchTask("cdcd0001", script, dir)))
+	logDir := t.TempDir()
+	s.logPath = func(taskID string) (string, error) {
+		return filepath.Join(logDir, "task-"+taskID+".log"), nil
+	}
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "watcher to stop", func() bool {
+		return len(rec.statusesSnapshot()) > 0
+	})
+
+	logPath := filepath.Join(logDir, "task-cdcd0001.log")
+	rotated, err := os.ReadFile(logPath + ".1")
+	if err != nil {
+		t.Fatalf("expected rotation to produce %s.1: %v", logPath, err)
+	}
+	current, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read active task log: %v", err)
+	}
+	if len(current) > 1<<20 {
+		t.Fatalf("active task log exceeds the cap after rotation: %d bytes", len(current))
+	}
+	if _, err := os.Stat(logPath + ".2"); !os.IsNotExist(err) {
+		t.Fatalf("log_max_backups=1 must keep a single rotated file; stat .2 err = %v", err)
+	}
+	combined := string(rotated) + string(current)
+	for i := 0; i < 1200; i++ {
+		if !strings.Contains(combined, fmt.Sprintf("RMARK %d ", i)) {
+			t.Fatalf("stderr line %d lost across task-log rotation", i)
+		}
+	}
+}
+
 // TestWatcherReloadReconciles drives the supervisor through config changes:
 // disabled tasks stop their watcher, removed tasks stop it, and a changed
 // watch command restarts the script with the new config while an unchanged

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,8 +34,8 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
 | `daemon_poll_interval` | Daemon polling interval in ms. |
 | `branch_prefix` | Prefix for worktree branches (defaults to `username/`). |
 | `detach_keys` | Key combination that detaches from an attached session (defaults to `ctrl-w`). |
-| `log_max_size_mb` | Size cap in MB for `agent-factory.log` before it is rotated (defaults to 50). Must be positive. |
-| `log_max_backups` | How many rotated logs (`agent-factory.log.1`, `.2`, ...) to keep; older ones are deleted (defaults to 2). `0` keeps none. |
+| `log_max_size_mb` | Size cap in MB for `agent-factory.log` and the per-task watch-script logs before they are rotated (defaults to 50). Must be positive. |
+| `log_max_backups` | How many rotated logs (`agent-factory.log.1`, `.2`, ...) to keep per log file; older ones are deleted (defaults to 2). `0` keeps none. |
 
 ### Choosing the agent
 
@@ -93,7 +93,7 @@ All data (sessions, tasks) is scoped to the current git repository — the TUI s
 | `~/.agent-factory/config.json` | Global config. |
 | `~/.agent-factory/instances/<repoID>/instances.json` | Persisted sessions, per repo. |
 | `~/.agent-factory/tasks.json` | Tasks (see [tasks.md](tasks.md)). |
-| `~/.agent-factory/logs/task-<id>.log` | Per-task watch-script logs. |
+| `~/.agent-factory/logs/task-<id>.log` | Per-task watch-script logs. Rotated with the same `log_max_size_mb`/`log_max_backups` policy as the application log (`task-<id>.log.1`, `.2`). |
 | `~/.config/agent-factory/agent-factory.log` | Application log (`os.UserConfigDir` on other platforms). Rotated once it exceeds `log_max_size_mb` (default 50 MB); the most recent `log_max_backups` rotations (default 2) are kept as `agent-factory.log.1`, `.2`. |
 
 Setting the `AGENT_FACTORY_HOME` environment variable relocates the `~/.agent-factory` state directory — useful for sandboxed or test setups. When it is set, the application log also moves into that directory (`$AGENT_FACTORY_HOME/agent-factory.log`) so a relocated home is fully self-contained.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -56,7 +56,7 @@ af tasks add --name "gh-issues" --watch-cmd "./watch-issues.sh" \
 
 - The script is **long-lived**. The daemon runs it via `$SHELL -c <watch_cmd>` with the task's `project_path` as the working directory, and keeps it running while the task is enabled.
 - **Each newline-terminated stdout line is one event.** Lines over 64KB are truncated to the cap (the remainder is discarded with a logged note). Unterminated trailing output at exit is not an event. Silence is fine — a quiet watcher is healthy; there is no output timeout.
-- **stderr** appends to `~/.agent-factory/logs/task-<id>.log`. Use it for all logging — anything on stdout becomes an event.
+- **stderr** appends to `~/.agent-factory/logs/task-<id>.log`, size-capped by the same `log_max_size_mb`/`log_max_backups` rotation as the main log. Use it for all logging — anything on stdout becomes an event.
 - **Environment**: the script receives `AF_TASK_ID`, `AF_TASK_NAME`, and `AF_PROJECT_PATH` on top of the daemon's environment.
 - **Exit 0 = intentional stop.** The task's status becomes `stopped` and the script is not restarted until the next daemon start, task edit, or re-enable.
 - **Non-zero exit = failure.** The script is restarted with exponential backoff, 1s doubling to a 5-minute cap. A run that stays healthy for 10 minutes resets the backoff.

--- a/log/log.go
+++ b/log/log.go
@@ -210,6 +210,7 @@ type rotatingWriter struct {
 	size     int64
 	maxBytes int64
 	backups  int
+	mode     os.FileMode // permission for the fresh file each rotation creates
 }
 
 func (w *rotatingWriter) Write(p []byte) (int, error) {
@@ -242,7 +243,7 @@ func (w *rotatingWriter) rotateLocked() {
 	_ = w.file.Close()
 	w.file = nil
 	rotateFiles(w.path, w.backups)
-	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, w.mode)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not reopen log file %s after rotation: %v, logging to stderr\n", w.path, err)
 		return
@@ -260,6 +261,31 @@ func (w *rotatingWriter) Close() error {
 	err := w.file.Close()
 	w.file = nil
 	return err
+}
+
+// NewRotatingFile opens path for appending, wrapped in the same size-capped
+// rotation as the main agent-factory.log (#1059): a file already over the
+// configured cap is rotated before opening, and a write that would push it
+// past the cap rotates in place first — the property that bounds callers who
+// hold the returned writer long-term, like the daemon's per-task watch-script
+// logs (#1062). The cap and keep-count come from the same "log_max_size_mb" /
+// "log_max_backups" config keys as the main log, resolved once at open. perm
+// applies both to the initial open and to the fresh file each rotation
+// creates. The writer is safe for concurrent use; Close is idempotent.
+func NewRotatingFile(path string, perm os.FileMode) (io.WriteCloser, error) {
+	maxBytes, backups := rotationPolicy()
+	if fi, err := os.Stat(path); err == nil && fi.Size() > maxBytes {
+		rotateFiles(path, backups)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, perm)
+	if err != nil {
+		return nil, err
+	}
+	w := &rotatingWriter{file: f, path: path, maxBytes: maxBytes, backups: backups, mode: perm}
+	if fi, err := f.Stat(); err == nil {
+		w.size = fi.Size()
+	}
+	return w, nil
 }
 
 // logFileName is the path the most recent Initialize resolved and attempted
@@ -324,7 +350,7 @@ func Initialize(daemon bool) {
 	// Set log format to include timestamp and file/line number
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
-	w := &rotatingWriter{file: f, path: logFileName, maxBytes: maxBytes, backups: backups}
+	w := &rotatingWriter{file: f, path: logFileName, maxBytes: maxBytes, backups: backups, mode: 0600}
 	if fi, err := f.Stat(); err == nil {
 		w.size = fi.Size()
 	}

--- a/log/rotate_test.go
+++ b/log/rotate_test.go
@@ -185,6 +185,81 @@ func TestWritePathRotation(t *testing.T) {
 	}
 }
 
+// The NewRotatingFile tests pin the exported per-file rotation seam (#1062):
+// the daemon's per-task watch-script logs reuse the same policy keys and
+// mechanics as the main log, both at open time and on the write path.
+
+func TestNewRotatingFileRotatesOverCapOnOpen(t *testing.T) {
+	logPath := setupRotationHome(t, `{"log_max_size_mb": 1, "log_max_backups": 2}`)
+	path := filepath.Join(filepath.Dir(logPath), "task-open.log")
+	fillFile(t, path, "OLD-TASK-CONTENT", 1<<20+512) // just over the 1 MB cap
+
+	w, err := NewRotatingFile(path, 0644)
+	if err != nil {
+		t.Fatalf("NewRotatingFile: %v", err)
+	}
+	defer w.Close()
+	if _, err := w.Write([]byte("fresh-line\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	rotated, err := os.ReadFile(path + ".1")
+	if err != nil {
+		t.Fatalf("expected rotated file %s.1 to exist: %v", path, err)
+	}
+	if !strings.HasPrefix(string(rotated), "OLD-TASK-CONTENT") {
+		t.Fatalf("rotated file does not carry the old content; starts with %q", string(rotated[:32]))
+	}
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fresh file: %v", err)
+	}
+	if string(current) != "fresh-line\n" {
+		t.Fatalf("fresh file should hold only the post-open write; got %d bytes", len(current))
+	}
+}
+
+func TestNewRotatingFileWritePathRotation(t *testing.T) {
+	logPath := setupRotationHome(t, `{"log_max_size_mb": 1, "log_max_backups": 1}`)
+	path := filepath.Join(filepath.Dir(logPath), "task-write.log")
+
+	w, err := NewRotatingFile(path, 0644)
+	if err != nil {
+		t.Fatalf("NewRotatingFile: %v", err)
+	}
+	defer w.Close()
+
+	// Each line is ~1 KB; 1200 of them cross the 1 MB cap mid-run.
+	payload := strings.Repeat("q", 1024)
+	const writes = 1200
+	for i := 0; i < writes; i++ {
+		if _, err := fmt.Fprintf(w, "TMARK %d %s\n", i, payload); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	rotated, err := os.ReadFile(path + ".1")
+	if err != nil {
+		t.Fatalf("expected write-path rotation to produce %s.1: %v", path, err)
+	}
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read current file: %v", err)
+	}
+	if len(current) > 1<<20 {
+		t.Fatalf("current file exceeds the cap after write-path rotation: %d bytes", len(current))
+	}
+	if _, err := os.Stat(path + ".2"); !os.IsNotExist(err) {
+		t.Fatalf("log_max_backups=1 must keep a single rotated file; stat .2 err = %v", err)
+	}
+	combined := string(rotated) + string(current)
+	for i := 0; i < writes; i++ {
+		if !strings.Contains(combined, fmt.Sprintf("TMARK %d ", i)) {
+			t.Fatalf("write %d lost across rotation", i)
+		}
+	}
+}
+
 // TestRotationPolicyDefaults pins the policy resolution: defaults when no
 // config exists, overrides applied when present, invalid values ignored.
 func TestRotationPolicyDefaults(t *testing.T) {


### PR DESCRIPTION
Closes #1062

## Root cause

#1061 capped the main `agent-factory.log`, but its adjacent-site audit flagged one remaining unbounded append-writer: `daemon/watcher.go` opens `~/.agent-factory/logs/task-<id>.log` with `O_APPEND` and holds that fd for the lifetime of the watch-script run. A continuous watch task (e.g. `captain-events`) therefore grows its per-task log forever — the same disk-fill class as #1059, just per-task. Because the fd is held long-term, rotate-on-write is the mechanism that actually bounds it (open-time rotation alone would never fire for a script that runs for weeks).

## Fix

- **`log/`**: export the #1061 primitive as `log.NewRotatingFile(path, perm)` — rotate-on-open when the file already exceeds the cap, rotate-on-write via the existing `rotatingWriter`, policy from the same `log_max_size_mb` / `log_max_backups` config keys (no new keys). `rotatingWriter` gains a `mode` field so a rotation recreates the file with the caller's permission (0600 main log, 0644 task logs) instead of hardcoded 0600.
- **`daemon/watcher.go`**: the per-task stderr log is opened through `NewRotatingFile`. Same path, same content, still appends across restarts — only the bounded-growth wrapper is new. Concurrency mirrors #1061: `rotatingWriter` serializes writes internally, and rotation happens in-process on the write path.
- **Fallback subtlety**: the stderr-pipe-failure fallback keeps handing `cmd.Stderr` a raw `*os.File`. For any non-`*os.File` writer, `os/exec` inserts a copy goroutine that `Wait` blocks on — a backgrounded grandchild holding stderr open would wedge `Wait` forever, since the group SIGKILL that guarantees EOF only runs *after* `Wait` returns. That degraded path bypasses write-path accounting and is bounded by rotate-on-open of the next run instead (commented in code).

## Adjacent-site audit (every file-append writer in the repo)

| Writer | File | Disposition |
|---|---|---|
| Main `agent-factory.log` | `log/log.go` | Rotated since #1061 (open path + write path). |
| Per-task watch logs `task-<id>.log` | `daemon/watcher.go` | **This PR** — was the last unbounded af-managed log writer. |
| `detach-slow.log` goroutine dumps | `app/detach_trace.go` | Re-confirmed negligible/out of scope: event-driven regression tripwire that appends one dump (≤1 MB stack buffer + header) only when a detach exceeds 2 s. Silent in the steady state; growth requires repeated real hangs, which are themselves bug reports. Left as-is. |

No other `O_APPEND` opens exist in non-test code, and no other repeated-append patterns (`os.Create` loops, tee'd `io.Copy` to log files) surfaced in the sweep.

## Tests

- `log/rotate_test.go`: `TestNewRotatingFileRotatesOverCapOnOpen` (over-cap file rotates to `.1` on open, fresh file holds only new writes) and `TestNewRotatingFileWritePathRotation` (1200 × ~1 KB writes across a 1 MB cap: `.1` created, active file under the cap, keep-count 1 honored — no `.2`, zero lines lost).
- `daemon/watcher_test.go`: `TestWatcherTaskLogRotates` — end-to-end through the real watcher: a watch script emits ~1.25 MB of stderr, the per-task log rotates mid-run, `.1` created, active file reset under the cap, keep-count honored, all 1200 numbered lines present across `.1` + active.
- All hermetic per the #1057/#1061 pattern: sandboxed `AGENT_FACTORY_HOME` temp dir carries the 1 MB test policy; nothing touches the real `~/.agent-factory`.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `AGENT_FACTORY_HOME=$(mktemp -d) go test ./...` — all green
- `AGENT_FACTORY_HOME=$(mktemp -d) GOFLAGS="-p=1" go test -race -parallel 2 ./daemon/... ./log/...` — green

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)