### PR TITLE
fix(task): normalize DOW range-step expressions ending in 7 (e.g. 0-7/2) so ParseCron accepts everything ValidateCronExpr does (#1064)

### DIFF
--- a/task/cron.go
+++ b/task/cron.go
@@ -55,16 +55,29 @@ func ParseCron(expr string) (cron.Schedule, error) {
 // is itself treated as denoting Sunday so it still normalizes to an explicit
 // list. For every other shape (a bare 7, a range bound of 7, a step that merely
 // lands on 7) expansion followed by normalizeDOWValues preserves the meaning.
+//
+// A range whose *end bound* is 7 must normalize even when its expansion omits
+// 7: robfig rejects the raw text of any DOW range ending in 7 ("end of range
+// (7) above maximum (6)"), and a stepped range can skip its own end bound —
+// "0-7/2" expands to [0,2,4,6], so neither containsSeven nor the step-base
+// rewrite fires and the rejected raw form leaked through to robfig (#1064).
+// Such parts are detected syntactically (rangeEndsAtSeven) and rewritten via
+// the same expansion→explicit-list path, which keeps the semantics exact:
+// "0-7/2" → "0,2,4,6" and "5-7" → "0,5,6" (Sunday mapped to 0, not dropped).
 func normalizeDOWField(field string) string {
 	if field == "*" {
 		return field
 	}
 	listParts := strings.Split(field, ",")
 	rewroteStepBase := false
+	rangeToSeven := false
 	for i, part := range listParts {
 		if norm := normalizeDOWStepBase(part); norm != part {
 			listParts[i] = norm
 			rewroteStepBase = true
+		}
+		if rangeEndsAtSeven(part) {
+			rangeToSeven = true
 		}
 	}
 	field = strings.Join(listParts, ",")
@@ -73,12 +86,13 @@ func normalizeDOWField(field string) string {
 	if err != nil || vals == nil {
 		return field
 	}
-	// Only rewrite into an explicit 0-based list when the field actually denotes
-	// Sunday: either its expansion includes the alias 7, or a "7/N" step base was
-	// rewritten to "0/N" above (whose expansion no longer shows a 7). Otherwise
+	// Only rewrite into an explicit 0-based list when the field needs it: its
+	// expansion includes the alias 7, a "7/N" step base was rewritten to "0/N"
+	// above (whose expansion no longer shows a 7), or a range part ends at 7
+	// (whose raw text robfig rejects even when a step skips the 7). Otherwise
 	// leave "*", ranges, and steps that never reach 7 untouched so they pass to
 	// robfig in their original shape.
-	if !containsSeven(vals) && !rewroteStepBase {
+	if !containsSeven(vals) && !rewroteStepBase && !rangeToSeven {
 		return field
 	}
 	vals = normalizeDOWValues(vals)
@@ -123,6 +137,25 @@ func normalizeDOWStepBase(part string) string {
 		return "0" + part[idx:]
 	}
 	return part
+}
+
+// rangeEndsAtSeven reports whether a single comma-separated part is a range —
+// with or without a step suffix — whose end bound is the Sunday alias 7
+// ("5-7", "0-7/2", "0-07/3"). robfig rejects the raw text of such ranges (its
+// DOW max is 6) regardless of whether the stepped expansion actually reaches 7,
+// so they must always be rewritten to an explicit list (#1064). The end bound
+// is parsed numerically to match ValidateCronExpr, which accepts leading zeros
+// via strconv.Atoi (#915) — a literal "-7" suffix check would miss "0-07".
+func rangeEndsAtSeven(part string) bool {
+	if idx := strings.Index(part, "/"); idx != -1 {
+		part = part[:idx]
+	}
+	idx := strings.Index(part, "-")
+	if idx == -1 {
+		return false
+	}
+	end, err := strconv.Atoi(part[idx+1:])
+	return err == nil && end == 7
 }
 
 // normalizeDOWValues maps weekday value 7 to 0 (both mean Sunday)

--- a/task/cron_test.go
+++ b/task/cron_test.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -108,6 +110,11 @@ var validCronCorpus = []string{
 	"0 0 * * 1/2",    // step expanding to include 7 (Sunday) (#1007)
 	"0 0 * * 1/3",    // step expanding to include 7 (Sunday) (#1007)
 	"0 0 * * 2/5",    // step expanding to include 7 (Sunday) (#1007)
+	"0 0 * * 0-7/2",  // range-step ending at 7 whose expansion skips the 7 (#1064)
+	"0 0 * * 4-7/2",  // range-step ending at 7, expansion [4,6] — no Sunday (#1064)
+	"0 0 * * 1-7/3",  // range-step ending at 7 whose expansion lands on 7 (#1064)
+	"0 0 * * 0-07/2", // leading zero on the range end bound (#1064 + #915)
+	"0 0 * * 1,5-7",  // list mixing a plain value with a range ending at 7
 }
 
 // TestParseCronAcceptsEverythingValidateAccepts is the agreement gate between
@@ -120,6 +127,40 @@ func TestParseCronAcceptsEverythingValidateAccepts(t *testing.T) {
 		schedule, err := ParseCron(expr)
 		require.NoError(t, err, "ParseCron must accept %q (ValidateCronExpr does)", expr)
 		require.NotNil(t, schedule)
+	}
+}
+
+// TestParseCronAcceptsAllValidatedDOWParts exhaustively enumerates every DOW
+// part shape ValidateCronExpr accepts — single values, steps, ranges,
+// range-steps, wildcard steps, leading-zero variants, and two-part lists —
+// and asserts ParseCron schedules each one. This closes the whole class
+// behind #888/#915/#1007/#1064 (DOW forms the validator accepts but robfig
+// rejects or misschedules) rather than pinning individual reproductions: any
+// future normalization gap for a 0-7-bounded DOW shape fails here.
+func TestParseCronAcceptsAllValidatedDOWParts(t *testing.T) {
+	var parts []string
+	for v := 0; v <= 7; v++ {
+		parts = append(parts, strconv.Itoa(v), fmt.Sprintf("0%d", v))
+		for s := 1; s <= 7; s++ {
+			parts = append(parts, fmt.Sprintf("%d/%d", v, s))
+		}
+		for b := v; b <= 7; b++ {
+			parts = append(parts, fmt.Sprintf("%d-%d", v, b), fmt.Sprintf("%d-0%d", v, b))
+			for s := 1; s <= 7; s++ {
+				parts = append(parts, fmt.Sprintf("%d-%d/%d", v, b, s))
+			}
+		}
+	}
+	for s := 1; s <= 7; s++ {
+		parts = append(parts, fmt.Sprintf("*/%d", s))
+	}
+	for _, part := range parts {
+		for _, field := range []string{part, "1," + part, part + ",5-7"} {
+			expr := "0 0 * * " + field
+			require.NoError(t, ValidateCronExpr(expr), "corpus generator produced invalid %q", expr)
+			_, err := ParseCron(expr)
+			require.NoError(t, err, "ParseCron must accept %q (ValidateCronExpr does)", expr)
+		}
 	}
 }
 
@@ -271,6 +312,62 @@ func TestParseCronDOWStepExpandingToSevenFiresSunday(t *testing.T) {
 	}
 }
 
+// TestParseCronDOWRangeStepEndingAtSevenFiresCorrectDays is the regression for
+// #1064: a DOW range-step whose end bound is 7 but whose stepped expansion
+// skips the 7 (e.g. "0-7/2" → [0,2,4,6]) evaded both normalization guards, so
+// the raw "0-7/2" reached robfig and was rejected ("end of range (7) above
+// maximum (6)") — a validated cron the daemon could never schedule. The
+// normalized form must fire exactly the expansion's days: Sun,Tue,Thu,Sat for
+// "0-7/2", and Thu,Sat only for "4-7/2" (no Sunday invented by the rewrite).
+func TestParseCronDOWRangeStepEndingAtSevenFiresCorrectDays(t *testing.T) {
+	sched, err := ParseCron("0 0 * * 0-7/2")
+	require.NoError(t, err)
+	explicit, err := ParseCron("0 0 * * 0,2,4,6")
+	require.NoError(t, err)
+	// Walk two weeks from a Saturday: 2026-06-13.
+	from := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	cur, curExplicit := from, from
+	for i := 0; i < 8; i++ {
+		cur = sched.Next(cur)
+		curExplicit = explicit.Next(curExplicit)
+		assert.Equal(t, curExplicit, cur, "0-7/2 firing %d must match 0,2,4,6", i)
+	}
+
+	// "4-7/2" expands to {Thu,Sat}; the rewrite must not add Sunday.
+	sched47, err := ParseCron("0 0 * * 4-7/2")
+	require.NoError(t, err)
+	want := []time.Time{
+		time.Date(2026, 6, 18, 0, 0, 0, 0, time.UTC), // Thursday
+		time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC), // Saturday
+		time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC), // Thursday
+	}
+	cur = from
+	for i, w := range want {
+		cur = sched47.Next(cur)
+		assert.Equal(t, w, cur, "4-7/2 firing %d must be %s", i, w.Weekday())
+	}
+}
+
+// TestParseCronDOWListWithRangeEndingAtSevenKeepsSunday pins the mixed-list
+// shape from the #1064 audit: "1,5-7" must schedule Mon,Fri,Sat,Sun — the
+// range's Sunday (7) mapped to 0, never dropped by rewriting "5-7" to "5-6".
+func TestParseCronDOWListWithRangeEndingAtSevenKeepsSunday(t *testing.T) {
+	sched, err := ParseCron("0 0 * * 1,5-7")
+	require.NoError(t, err)
+	// 2026-06-13 is a Saturday; the very next firing must be Sunday 2026-06-14.
+	from := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	assert.Equal(t, time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC), sched.Next(from),
+		"1,5-7 must fire on Sunday")
+	explicit, err := ParseCron("0 0 * * 0,1,5,6")
+	require.NoError(t, err)
+	cur, curExplicit := from, from
+	for i := 0; i < 8; i++ {
+		cur = sched.Next(cur)
+		curExplicit = explicit.Next(curExplicit)
+		assert.Equal(t, curExplicit, cur, "1,5-7 firing %d must match 0,1,5,6", i)
+	}
+}
+
 func TestNormalizeDOWField(t *testing.T) {
 	cases := []struct {
 		in   string
@@ -295,6 +392,11 @@ func TestNormalizeDOWField(t *testing.T) {
 		{"3,7/2", "0,2,3,4,6"},   // 7-step base inside a list still keeps its step (#888)
 		{"0-7", "0,1,2,3,4,5,6"}, // full range incl. both Sunday aliases (#770: explicit list, never "*")
 		{"1-7", "0,1,2,3,4,5,6"}, // range to the 7 alias covers the whole week as a list (#770)
+		{"0-7/2", "0,2,4,6"},     // range-step ending at 7 whose expansion skips 7 — raw "0-7/2" fails robfig (#1064)
+		{"0-07/2", "0,2,4,6"},    // leading zero on the range end bound: parsed numerically, not by substring (#1064 + #915)
+		{"4-7/2", "4,6"},         // range-step ending at 7 that never reaches Sunday: rewritten without inventing a 0 (#1064)
+		{"1-7/3", "0,1,4"},       // range-step ending at 7 that lands on 7: Sunday mapped to 0 (#1064)
+		{"1,5-7", "0,1,5,6"},     // list mixing a plain value with a range ending at 7
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.want, normalizeDOWField(tc.in), "normalizeDOWField(%q)", tc.in)


### PR DESCRIPTION
Closes #1064

## Problem

`ValidateCronExpr` accepts DOW range-step expressions ending in `7` (e.g. `0 0 * * 0-7/2`), but `ParseCron` passed the raw field through to robfig/cron, which bounds DOW to 0–6 and rejects any range ending in 7: `end of range (7) above maximum (6): 0-7/2`. A user could save such a cron via the CLI and the daemon would then fail to parse it — the task silently never fires, breaking the #782 validator↔scheduler agreement gate.

## Root cause

Follow-up gap from #1016. `normalizeDOWField` decides whether to rewrite via two guards:

```go
if !containsSeven(vals) && !rewroteStepBase {
    return field
}
```

For `0-7/2` the expansion is `[0,2,4,6]` — the step skips the range's own end bound, so `containsSeven` is false — and `normalizeDOWStepBase` only rewrites *single-number* step bases, so `rewroteStepBase` is false too. The raw `0-7/2` (which robfig rejects on its text, regardless of expansion) leaked through.

## Fix

Add a third, **syntactic** trigger: `rangeEndsAtSeven` fires for any comma-separated part that is a range (with or without a step suffix) whose end bound parses numerically to 7. Numeric parsing matches how `ValidateCronExpr` accepts leading zeros (`0-07/2`), per the #915 lesson — a `-7` substring check would miss those.

Rewriting reuses the existing expansion → explicit-0-based-list machinery from #1016 (no parallel path), so semantics are preserved exactly:

| input | normalized | note |
|---|---|---|
| `0-7` | `0,1,2,3,4,5,6` | all days, explicit list (never `*` — DOM/DOW OR semantics) |
| `0-7/2` | `0,2,4,6` | the reported bug |
| `5-7` | `0,5,6` | Sunday mapped 7→0 — **not** rewritten to `5-6`, which would drop Sunday (the issue's suggested `0-7/2`→`0-6/2` rewrite has this trap for odd bases) |
| `4-7/2` | `4,6` | expansion never reaches Sunday; rewrite doesn't invent a 0 |
| `1,5-7` | `0,1,5,6` | mixed list |

All previously-correct behavior is untouched: bare `7`→`0`, `7/N` step-base rewrite (#888), leading-zero bases (#915), steps expanding onto 7 like `1/2` (#1007), `*`, and plain ranges without 7 pass through in their original shape.

## Adjacent-site audit — why the guard set is now complete

robfig rejects a DOW field iff its raw text contains a numeric token > 6; the only such token `ValidateCronExpr` can admit is 7 (incl. leading zeros). Every position a 7 can occupy is now covered:

- **bare value / list member** (`7`, `07`, `1,7`) → expansion contains 7 → `containsSeven` ✔
- **range end** (`a-7`, `a-7/N`, `a-07`) → `rangeEndsAtSeven`, regardless of whether the step lands on 7 ✔ *(the fixed gap)*
- **range start** (`7-b`) → validation requires start ≤ end ≤ 7, so end is also 7 → `rangeEndsAtSeven` ✔
- **single-number step base** (`7/N`, `007/N`) → `normalizeDOWStepBase` → `rewroteStepBase` ✔
- **no literal 7 but expansion reaches it** (`1/2`, `*/7`) — robfig parses these but would drop Sunday → `containsSeven` ✔
- any one trigger rewrites the **whole field** to an explicit 0-based list, which robfig always accepts, so mixed lists (`1,5-7`) are safe ✔

Beyond the case-by-case argument, a new exhaustive contract test (`TestParseCronAcceptsAllValidatedDOWParts`) mechanically enumerates every DOW part shape the validator accepts — all values, steps, ranges, range-steps, wildcard steps, leading-zero variants, each alone and inside two-part lists — and asserts `ParseCron` schedules every one. Any future normalization gap in this class fails that test, not production.

## Tests

- `TestNormalizeDOWField`: added `0-7/2`, `0-07/2`, `4-7/2`, `1-7/3`, `1,5-7`
- Contract corpus (`TestParseCronAcceptsEverythingValidateAccepts`): added `0-7/2`, `4-7/2`, `1-7/3`, `0-07/2`, `1,5-7` (`0-7` and `5-7` were already present)
- `TestParseCronDOWRangeStepEndingAtSevenFiresCorrectDays`: `0-7/2` fires Sun/Tue/Thu/Sat (matches explicit `0,2,4,6` over two weeks); `4-7/2` fires Thu/Sat only — no Sunday invented
- `TestParseCronDOWListWithRangeEndingAtSevenKeepsSunday`: `1,5-7` fires on Sunday and matches `0,1,5,6` over two weeks
- `TestParseCronAcceptsAllValidatedDOWParts`: exhaustive sweep described above
- **Fail-before/pass-after confirmed**: with `task/cron.go` stashed to the pre-fix state, the new tests fail with robfig's `end of range (7) above maximum (6)` / raw-field pass-through; with the fix they pass

## Verification

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — all green
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./task/...` — green

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)