### PR TITLE
fix(session): CloseAttachOnly releases every tab PTY, not just the agent tab, to stop the daemon fd leak (#1065)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -115,6 +116,14 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 				// failure into data loss. CloseAttachOnly releases only the
 				// local attach resources this object opened and leaves the
 				// server session and its worktree intact for a later retry.
+				//
+				// Releasing only the AGENT tab here is deliberate (#1065):
+				// every restore failure point precedes setupTabs, so no other
+				// tab has opened its attach PTY yet, and their tmux refs must
+				// survive for a later retry to reconnect each tab by its exact
+				// persisted name. The discard-duplicate path
+				// (LocalBackend.CloseAttachOnly) is different: there setupTabs
+				// has already run, so it must release EVERY tab's PTY.
 				i.mu.Lock()
 				ts := i.tmuxLocked()
 				i.setTmuxLocked(nil)
@@ -332,31 +341,53 @@ func (b *LocalBackend) Kill(i *Instance) error {
 	return nil
 }
 
-// CloseAttachOnly releases this instance's hold on the tmux session — the
-// attach PTY and the `tmux attach-session` child process — WITHOUT running
-// `tmux kill-session`. The server-side tmux session and the git worktree
-// behind it are left untouched. The daemon uses this to discard a duplicate
+// CloseAttachOnly releases this instance's hold on its tmux sessions — the
+// attach PTYs and the `tmux attach-session` child processes — WITHOUT running
+// `tmux kill-session`. The server-side tmux sessions and the git worktree
+// behind them are left untouched. The daemon uses this to discard a duplicate
 // Instance built from disk that turned out to already be tracked in memory
-// (#867): the duplicate must surrender the PTY it opened during restore
-// without tearing down the live session the canonical Instance shares.
+// (#867): the duplicate must surrender the PTYs it opened during restore
+// without tearing down the live sessions the canonical Instance shares.
 func (b *LocalBackend) CloseAttachOnly(i *Instance) error {
+	// Snapshot every tab's tmux session under the lock, mirroring Kill. Since
+	// #930 an instance holds N tabs (agent + shell/process), and restoring the
+	// duplicate opened an attach PTY for EVERY tab (Start restores the agent
+	// tab, setupTabs the rest), so releasing only the agent tab's PTY leaked
+	// one fd per extra tab each time the daemon discarded a duplicate —
+	// eventually EMFILE in the long-running daemon (#1065).
+	type tabSession struct {
+		tab *Tab
+		ts  *tmux.TmuxSession
+	}
 	i.mu.Lock()
-	ts := i.tmuxLocked()
+	sessions := make([]tabSession, 0, len(i.Tabs))
+	for _, tab := range i.Tabs {
+		if tab.tmux != nil {
+			sessions = append(sessions, tabSession{tab: tab, ts: tab.tmux})
+		}
+	}
 	i.started = false
 	i.mu.Unlock()
 
-	if ts == nil {
-		return nil
+	// Close outside the lock: CloseAttachOnly blocks draining the attach
+	// goroutines, and holding i.mu across it would stall every reader.
+	var errs []error
+	for _, s := range sessions {
+		if err := s.ts.CloseAttachOnly(); err != nil {
+			errs = append(errs, fmt.Errorf("tab %q: %w", s.tab.Name, err))
+		}
 	}
-
-	err := ts.CloseAttachOnly()
 
 	i.mu.Lock()
-	if i.tmuxLocked() == ts {
-		i.setTmuxLocked(nil)
+	for _, s := range sessions {
+		// Only clear a ref that is still the session we closed: a concurrent
+		// Start may have swapped in a fresh session while the lock was released.
+		if s.tab.tmux == s.ts {
+			s.tab.tmux = nil
+		}
 	}
 	i.mu.Unlock()
-	return err
+	return errors.Join(errs...)
 }
 
 func (b *LocalBackend) Preview(i *Instance) (string, error) {

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -2140,3 +2140,97 @@ func TestLocalBackendKillRunsKillSession(t *testing.T) {
 	defer mu.Unlock()
 	assert.True(t, killed, "a genuine Kill must run tmux kill-session")
 }
+
+// closeTrackingPtyFactory is a tmux.PtyFactory returning real temp files as
+// PTYs and recording every one it hands out, so a test can assert each was
+// closed (a second Close on an *os.File fails with os.ErrClosed).
+type closeTrackingPtyFactory struct {
+	t     *testing.T
+	mu    sync.Mutex
+	files []*os.File
+}
+
+func (f *closeTrackingPtyFactory) Start(_ *exec.Cmd) (*os.File, error) {
+	file, err := os.CreateTemp(f.t.TempDir(), "pty-")
+	if err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	f.files = append(f.files, file)
+	f.mu.Unlock()
+	return file, nil
+}
+
+func (f *closeTrackingPtyFactory) Close() {}
+
+// TestLocalBackendCloseAttachOnlyReleasesEveryTabPTY is the regression test
+// for issue #1065. The daemon discards a duplicate multi-tab Instance restored
+// from disk via CloseAttachOnly (#867); since #930 every tab owns its own
+// tmux session whose restore opened its own attach PTY, so CloseAttachOnly
+// must release the PTY of EVERY tab — not just the agent tab's — and it must
+// still never run `tmux kill-session`, because the server-side sessions are
+// shared with the canonical tracked Instance.
+func TestLocalBackendCloseAttachOnlyReleasesEveryTabPTY(t *testing.T) {
+	var mu sync.Mutex
+	var ran []string
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			mu.Lock()
+			ran = append(ran, strings.Join(c.Args, " "))
+			mu.Unlock()
+			// has-session succeeds → Restore takes the attach branch and opens
+			// a PTY for each session.
+			return nil
+		},
+		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+	}
+	pty := &closeTrackingPtyFactory{t: t}
+
+	agentTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps("af_dup_agent", "claude", pty, cmdExec)
+	shellTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps("af_dup_agent__shell", "/bin/sh", pty, cmdExec)
+	procTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps("af_dup_agent__btop", "btop", pty, cmdExec)
+	for _, ts := range []*tmux.TmuxSession{agentTs, shellTs, procTs} {
+		require.NoError(t, ts.Restore(""), "restore must attach and open a PTY")
+	}
+	pty.mu.Lock()
+	nOpened := len(pty.files)
+	pty.mu.Unlock()
+	require.Equal(t, 3, nOpened, "each tab's restore must have opened its own PTY")
+
+	inst := &Instance{
+		Title:   "dup",
+		backend: &LocalBackend{},
+		started: true,
+		Tabs: []*Tab{
+			newAgentTab(agentTs),
+			newShellTab(shellTs),
+			{Name: "btop", Kind: TabKindProcess, Command: "btop", tmux: procTs},
+		},
+	}
+
+	require.NoError(t, inst.CloseAttachOnly())
+
+	// Every tab's attach PTY was closed — the agent's AND the shell/process
+	// tabs' (the fds that leaked before the fix).
+	pty.mu.Lock()
+	files := append([]*os.File(nil), pty.files...)
+	pty.mu.Unlock()
+	for i, f := range files {
+		assert.ErrorIs(t, f.Close(), os.ErrClosed,
+			"PTY %d (%s) must already be closed by CloseAttachOnly", i, f.Name())
+	}
+
+	// No session was killed: they are shared with the canonical Instance.
+	mu.Lock()
+	for _, c := range ran {
+		assert.NotContains(t, c, "kill-session",
+			"CloseAttachOnly must never kill the shared tmux sessions; ran: %v", ran)
+	}
+	mu.Unlock()
+
+	// Every tab's tmux ref was cleared and the instance is not-started.
+	for _, tab := range inst.GetTabs() {
+		assert.Nil(t, tab.tmux, "tab %q tmux ref must be cleared", tab.Name)
+	}
+	assert.False(t, inst.Started(), "discarded duplicate must be marked not-started")
+}


### PR DESCRIPTION
Closes #1065

## Root cause

`LocalBackend.CloseAttachOnly` (`session/backend_local.go`) is the daemon's discard-duplicate path: when `findSession` (`daemon/control.go`) builds an Instance from disk and then finds the canonical instance already tracked (#867), the duplicate must surrender the attach PTYs it opened during restore **without** killing the tmux sessions it shares with the canonical instance.

Since the #930 multi-tab epic (introduced in #953, PR 2/7), restoring an instance opens **one attach PTY per tab**: `Start` restores the agent tab, then `setupTabs` calls `tab.tmux.Restore(...)` → `ptyFactory.Start(...)` for every shell/process tab. PR 2/7 updated `Kill` to iterate all tabs but left `CloseAttachOnly` on `tmuxLocked()`, which returns only `Tabs[0].tmux` (the agent tab). Every shell/process tab's PTY (and `tmux attach-session` child) therefore leaked each time the daemon discarded a multi-tab duplicate — an unbounded fd leak in the always-on daemon, eventually EMFILE.

## Fix

`CloseAttachOnly` now mirrors `Kill`'s shape:

- snapshot **every** tab's `*tmux.TmuxSession` under `i.mu` (and set `started=false`);
- release each attach outside the lock via `TmuxSession.CloseAttachOnly()` — the PTY-only release that closes the attach PTY and SIGKILLs the attach child but **never** runs `tmux kill-session` (verified: `session/tmux/tmux.go`), so the server-side sessions survive for the canonical instance;
- re-acquire the lock and clear each tab's `tmux` ref **only if it is still the session we closed** (preserving the original "only clear if unchanged" guard, now per tab);
- per-tab errors are collected with `errors.Join` instead of aborting at the first failure.

Lock discipline is preserved: `i.mu` is never held across the blocking per-tab close (it drains attach goroutines), matching the original code's intent.

## Adjacent-site audit (`tmuxLocked()` / `Tabs[0].tmux` in cleanup paths)

| Site | Verdict |
|---|---|
| `LocalBackend.CloseAttachOnly` | **The bug — fixed** (iterates all tabs). |
| `LocalBackend.Kill` | Already correct: snapshots all tabs, `CloseAndWaitForPaneExit` each, clears every ref (done in #953). Confirmed. |
| `LocalBackend.Start` restore-failure deferred handler | **Agent-only is correct, kept** — every restore failure point precedes `setupTabs` (which is best-effort and never sets `setupErr`), so no non-agent tab has opened its PTY when the handler runs; clearing non-agent refs there would break a later retry's reconnect-by-exact-name. Documented with a comment pointing at #1065. |
| `Instance.CloseTab` / `DropClosedTab` | Per-tab teardown by design; not instance-wide cleanup. |
| Non-teardown `tmuxLocked()` users (`Preview`, `Attach`, `SendKeys`, `SendPrompt*`, `HasUpdated`, `IsAlive`, `SetPreviewSize`, `TapEnter`, `CheckAndHandleTrustPrompt`, name-derivation in `AddShellTab`/`AddProcessTab`/`AttachShellTab`/`ReconcileTabsFromData`, legacy `TmuxName` in `ToInstanceData`) | Deliberately target the agent tab; per-tab ops route through `tabTmuxAtLocked`. Not cleanup paths. |
| `HookBackend.CloseAttachOnly` | Remote tabs carry no tmux sessions; the single hook preview process is already released. No equivalent leak. |
| Daemon refresh loop (`daemon.go`) | Checks `existing[key]` **before** restoring, so it never builds a duplicate; `findSession` is the only discard-duplicate site and routes through the fixed method. |

## Tests

`TestLocalBackendCloseAttachOnlyReleasesEveryTabPTY` (hermetic — `MockCmdExec` + a close-tracking PTY factory, no real tmux): builds a duplicate with agent + shell + process tabs, opens each tab's PTY via `Restore`, calls `CloseAttachOnly`, then asserts every PTY was closed (`os.ErrClosed` on re-close), every tab's `tmux` ref was cleared, the instance is not-started, and **zero** `kill-session` commands were issued. Verified the test fails on the pre-fix code (shell + process PTYs and refs survive) and passes with the fix.

## Verification

All run with `AGENT_FACTORY_HOME=$(mktemp -d)`:

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — all green
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./session/... ./daemon/...` — all green

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)