### PR TITLE
feat(release): two-channel releases — manual stable 1.x.y + auto preview 1.x.y-preview-z (#1041)

### DIFF
--- a/.github/scripts/next-preview-version.sh
+++ b/.github/scripts/next-preview-version.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# next-preview-version.sh — compute the next preview release version.
+#
+# Usage: git tag | next-preview-version.sh
+#
+# Reads existing git tags (one per line) on stdin and prints the next preview
+# version without a leading "v", e.g. "1.0.138-preview-3".
+#
+# Release scheme (#1041): stable releases are vX.Y.Z and are cut manually.
+# Previews are cut automatically off master as vX.Y.(Z+1)-preview-N, where
+# X.Y.Z is the latest stable tag. Basing previews on the *next* patch keeps
+# standard semver precedence across both channels:
+#   1.2.0 < 1.2.1-preview-1 < 1.2.1-preview-2 < 1.2.1 <= any newer stable
+# N increments per preview and resets to 1 whenever a new stable changes the
+# base. Tags that match neither shape are ignored.
+set -eu
+
+tags=$(cat)
+
+# Latest stable: highest vX.Y.Z tag by numeric (not lexical) comparison.
+stable=$(printf '%s\n' "$tags" | awk '
+	/^v[0-9]+\.[0-9]+\.[0-9]+$/ {
+		split(substr($0, 2), p, ".")
+		a = p[1] + 0; b = p[2] + 0; c = p[3] + 0
+		if (!found || a > M || (a == M && (b > m || (b == m && c > s)))) {
+			M = a; m = b; s = c; found = 1
+		}
+	}
+	END { if (found) print M "." m "." s; else print "0.0.0" }
+')
+
+base=$(printf '%s\n' "$stable" | awk -F. '{ print $1 "." $2 "." $3 + 1 }')
+
+next=$(printf '%s\n' "$tags" | awk -v base="$base" '
+	BEGIN { pre = "v" base "-preview-" }
+	index($0, pre) == 1 {
+		n = substr($0, length(pre) + 1)
+		if (n ~ /^[0-9]+$/ && n + 0 > z) z = n + 0
+	}
+	END { print z + 1 }
+')
+
+echo "${base}-preview-${next}"

--- a/.github/scripts/validate-stable-version.sh
+++ b/.github/scripts/validate-stable-version.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# validate-stable-version.sh — validate a manually requested stable version.
+#
+# Usage: git tag | validate-stable-version.sh <version>
+#
+# <version> is the bare semver, no leading "v" (e.g. "1.1.0"). Existing git
+# tags are read one per line on stdin. Exits 0 if the version is well-formed,
+# not already tagged, and strictly greater than the latest stable tag;
+# exits 1 with a reason on stderr otherwise.
+#
+# Preview tags (vX.Y.Z-preview-N, see next-preview-version.sh) are ignored
+# when finding the latest stable: releasing the current preview base as a
+# stable (e.g. 1.0.138 while 1.0.138-preview-9 exists) is a supported way to
+# promote what the preview channel has been testing.
+set -eu
+
+new="${1:?usage: git tag | validate-stable-version.sh <version>}"
+tags=$(cat)
+
+if ! printf '%s\n' "$new" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+	echo "error: version '$new' must be X.Y.Z with no leading v (e.g. 1.1.0)" >&2
+	exit 1
+fi
+
+if printf '%s\n' "$tags" | grep -qx "v$new"; then
+	echo "error: tag v$new already exists" >&2
+	exit 1
+fi
+
+# Latest stable: highest vX.Y.Z tag by numeric (not lexical) comparison.
+stable=$(printf '%s\n' "$tags" | awk '
+	/^v[0-9]+\.[0-9]+\.[0-9]+$/ {
+		split(substr($0, 2), p, ".")
+		a = p[1] + 0; b = p[2] + 0; c = p[3] + 0
+		if (!found || a > M || (a == M && (b > m || (b == m && c > s)))) {
+			M = a; m = b; s = c; found = 1
+		}
+	}
+	END { if (found) print M "." m "." s; else print "0.0.0" }
+')
+
+newer=$(awk -v n="$new" -v s="$stable" 'BEGIN {
+	split(n, a, "."); split(s, b, ".")
+	for (i = 1; i <= 3; i++) {
+		if (a[i] + 0 > b[i] + 0) { print "yes"; exit }
+		if (a[i] + 0 < b[i] + 0) { print "no"; exit }
+	}
+	print "no"
+}')
+
+if [ "$newer" != "yes" ]; then
+	echo "error: version $new must be greater than the latest stable $stable" >&2
+	exit 1
+fi
+
+echo "ok: v$new (latest stable: v$stable)"

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -3,6 +3,16 @@ name: Stable Release
 # Manually cuts a stable release vX.Y.Z off master. The maintainer picks the
 # version (which digit to bump); previews then automatically rebase onto it
 # as vX.Y.(Z+1)-preview-N. See docs/release-process.md (#1041).
+#
+# Job order is deliberate: validate and build are read-only, and every
+# mutation (main.go bump commit, tag push, release publish) happens in the
+# final job only after all four artifacts exist — a failed preflight or
+# build must never leave a dangling commit or tag on master. All jobs pin
+# github.sha so a master push racing the workflow cannot desync what was
+# validated, what was built, and what gets tagged. The artifacts are built
+# from github.sha while the tag points at the bump commit one ahead; the
+# binaries are identical in behavior because their version comes from
+# -ldflags, and the bump commit only rewrites the main.go fallback string.
 
 on:
   workflow_dispatch:
@@ -16,16 +26,14 @@ permissions:
   contents: write
 
 jobs:
-  validate-and-tag:
-    name: Validate, bump main.go, and tag
+  validate:
+    name: Validate version and preflight
     runs-on: ubuntu-latest
-    outputs:
-      new_version: ${{ steps.bump.outputs.new_version }}
     steps:
     - uses: actions/checkout@v6
       with:
+        ref: ${{ github.sha }}
         fetch-depth: 0
-        ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -51,35 +59,9 @@ jobs:
         go test -v -race -count=1 ./...
         go build ./...
 
-    - name: Bump version and tag
-      id: bump
-      env:
-        NEW_VERSION: ${{ inputs.version }}
-      run: |
-        CURRENT=$(grep -oP 'version\s+=\s+"\K[^"]+' main.go)
-        echo "Current main.go version: $CURRENT, releasing: $NEW_VERSION"
-        sed -i "s/version     = \"${CURRENT}\"/version     = \"${NEW_VERSION}\"/" main.go
-
-        # Fail loudly if the substitution missed (e.g. formatting drift in
-        # main.go) instead of tagging a release with a stale embedded version.
-        if ! grep -q "version     = \"${NEW_VERSION}\"" main.go; then
-          echo "::error::Failed to update version in main.go"
-          exit 1
-        fi
-
-        echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add main.go
-        git commit -m "chore: release v${NEW_VERSION}"
-        git tag "v${NEW_VERSION}"
-        git push origin HEAD:master
-        git push origin "v${NEW_VERSION}"
-
   build:
     name: Build
-    needs: validate-and-tag
+    needs: validate
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -88,7 +70,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: v${{ needs.validate-and-tag.outputs.new_version }}
+        ref: ${{ github.sha }}
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -100,8 +82,8 @@ jobs:
       env:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
+        VERSION: ${{ inputs.version }}
       run: |
-        VERSION="${{ needs.validate-and-tag.outputs.new_version }}"
         ARCHIVE_NAME=agent-factory-${{ matrix.goos }}-${{ matrix.goarch }}
         mkdir -p dist
         go build -v -ldflags "-X main.version=${VERSION}" -o dist/agent-factory
@@ -116,25 +98,60 @@ jobs:
         if-no-files-found: error
         retention-days: 1
 
-  release:
-    name: Release
-    needs: [validate-and-tag, build]
+  publish:
+    name: Tag and publish
+    needs: [validate, build]
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+        ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+
+    # Fetch the artifacts before touching git so a failed download cannot
+    # leave a pushed commit or tag with no release behind it.
     - name: Download build artifacts
       uses: actions/download-artifact@v7
       with:
         path: dist
         merge-multiple: true
 
+    - name: Bump version, commit, and tag
+      env:
+        NEW_VERSION: ${{ inputs.version }}
+      run: |
+        CURRENT=$(grep -oP 'version\s+=\s+"\K[^"]+' main.go)
+        echo "Current main.go version: $CURRENT, releasing: $NEW_VERSION"
+        sed -i "s/version     = \"${CURRENT}\"/version     = \"${NEW_VERSION}\"/" main.go
+
+        # Fail loudly if the substitution missed (e.g. formatting drift in
+        # main.go) instead of tagging a release with a stale embedded version.
+        if ! grep -q "version     = \"${NEW_VERSION}\"" main.go; then
+          echo "::error::Failed to update version in main.go"
+          exit 1
+        fi
+
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add main.go
+        # No-op when main.go already carries the version (e.g. re-running
+        # after a failure that landed the bump commit but not the tag).
+        if ! git diff --cached --quiet; then
+          git commit -m "chore: release v${NEW_VERSION}"
+        fi
+        git tag "v${NEW_VERSION}"
+        git push origin HEAD:master
+        git push origin "v${NEW_VERSION}"
+
     # Immutable releases require all assets to be attached before the release
     # is published: create as draft, upload assets into the draft, then publish.
     # Stable releases are marked --latest so the releases/latest redirect
-    # (install.sh, fresh installs) serves the stable channel.
+    # (install.sh, fresh installs, the stable update channel) serves them.
     - name: Publish release
       env:
         GH_TOKEN: ${{ github.token }}
-        VERSION: ${{ needs.validate-and-tag.outputs.new_version }}
+        VERSION: ${{ inputs.version }}
         GH_REPO: ${{ github.repository }}
       run: |
         gh release create "v${VERSION}" \

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,24 +1,26 @@
-name: Auto Preview Release
+name: Stable Release
 
-# Cuts a preview release (vX.Y.Z-preview-N, GitHub prerelease) off master
-# every 3 hours when there are new commits. Stable releases are cut manually
-# via stable-release.yml. See docs/release-process.md (#1041).
+# Manually cuts a stable release vX.Y.Z off master. The maintainer picks the
+# version (which digit to bump); previews then automatically rebase onto it
+# as vX.Y.(Z+1)-preview-N. See docs/release-process.md (#1041).
 
 on:
-  schedule:
-    - cron: '0 */3 * * *'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Stable version to release, no leading v (e.g. 1.1.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
-  check-and-tag:
-    name: Check for changes and tag preview
+  validate-and-tag:
+    name: Validate, bump main.go, and tag
     runs-on: ubuntu-latest
     outputs:
-      should_release: ${{ steps.check.outputs.should_release }}
-      new_version: ${{ steps.compute.outputs.new_version }}
+      new_version: ${{ steps.bump.outputs.new_version }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -31,26 +33,12 @@ jobs:
         go-version: '1.24'
         cache: true
 
-    - name: Check for new commits since last tag
-      id: check
-      run: |
-        LATEST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
-        if [ -z "$LATEST_TAG" ]; then
-          echo "No tags found, should release"
-          echo "should_release=true" >> "$GITHUB_OUTPUT"
-        else
-          COMMITS_SINCE=$(git rev-list "${LATEST_TAG}..HEAD" --count)
-          if [ "$COMMITS_SINCE" -gt 0 ]; then
-            echo "Found $COMMITS_SINCE new commits since $LATEST_TAG"
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No new commits since $LATEST_TAG"
-            echo "should_release=false" >> "$GITHUB_OUTPUT"
-          fi
-        fi
+    - name: Validate requested version
+      env:
+        NEW_VERSION: ${{ inputs.version }}
+      run: git tag | .github/scripts/validate-stable-version.sh "$NEW_VERSION"
 
     - name: Release preflight
-      if: steps.check.outputs.should_release == 'true'
       run: |
         unformatted=$(gofmt -l .)
         if [ -n "$unformatted" ]; then
@@ -63,26 +51,35 @@ jobs:
         go test -v -race -count=1 ./...
         go build ./...
 
-    - name: Compute preview version and tag
-      id: compute
-      if: steps.check.outputs.should_release == 'true'
+    - name: Bump version and tag
+      id: bump
+      env:
+        NEW_VERSION: ${{ inputs.version }}
       run: |
-        NEW_VERSION=$(git tag | .github/scripts/next-preview-version.sh)
-        echo "New preview version: $NEW_VERSION"
-        echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+        CURRENT=$(grep -oP 'version\s+=\s+"\K[^"]+' main.go)
+        echo "Current main.go version: $CURRENT, releasing: $NEW_VERSION"
+        sed -i "s/version     = \"${CURRENT}\"/version     = \"${NEW_VERSION}\"/" main.go
 
-        # Previews never touch main.go or master history (#1041): the release
-        # binaries get their version stamped at build time via -ldflags. Just
-        # tag the current master commit.
+        # Fail loudly if the substitution missed (e.g. formatting drift in
+        # main.go) instead of tagging a release with a stale embedded version.
+        if ! grep -q "version     = \"${NEW_VERSION}\"" main.go; then
+          echo "::error::Failed to update version in main.go"
+          exit 1
+        fi
+
+        echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add main.go
+        git commit -m "chore: release v${NEW_VERSION}"
         git tag "v${NEW_VERSION}"
+        git push origin HEAD:master
         git push origin "v${NEW_VERSION}"
 
   build:
     name: Build
-    needs: check-and-tag
-    if: needs.check-and-tag.outputs.should_release == 'true'
+    needs: validate-and-tag
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -91,7 +88,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: v${{ needs.check-and-tag.outputs.new_version }}
+        ref: v${{ needs.validate-and-tag.outputs.new_version }}
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -104,7 +101,7 @@ jobs:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
       run: |
-        VERSION="${{ needs.check-and-tag.outputs.new_version }}"
+        VERSION="${{ needs.validate-and-tag.outputs.new_version }}"
         ARCHIVE_NAME=agent-factory-${{ matrix.goos }}-${{ matrix.goarch }}
         mkdir -p dist
         go build -v -ldflags "-X main.version=${VERSION}" -o dist/agent-factory
@@ -121,7 +118,7 @@ jobs:
 
   release:
     name: Release
-    needs: [check-and-tag, build]
+    needs: [validate-and-tag, build]
     runs-on: ubuntu-latest
     steps:
     - name: Download build artifacts
@@ -132,19 +129,17 @@ jobs:
 
     # Immutable releases require all assets to be attached before the release
     # is published: create as draft, upload assets into the draft, then publish.
-    # Previews are prereleases and must NOT be marked --latest: the
-    # releases/latest redirect (install.sh, fresh installs) stays pinned to
-    # the newest stable release; auto-update resolves previews via the API.
+    # Stable releases are marked --latest so the releases/latest redirect
+    # (install.sh, fresh installs) serves the stable channel.
     - name: Publish release
       env:
         GH_TOKEN: ${{ github.token }}
-        VERSION: ${{ needs.check-and-tag.outputs.new_version }}
+        VERSION: ${{ needs.validate-and-tag.outputs.new_version }}
         GH_REPO: ${{ github.repository }}
       run: |
         gh release create "v${VERSION}" \
           --title "v${VERSION}" \
           --generate-notes \
-          --prerelease \
           --draft \
           dist/*.tar.gz
-        gh release edit "v${VERSION}" --draft=false
+        gh release edit "v${VERSION}" --draft=false --latest

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prerequisites: **tmux**, **git**, and at least one AI coding agent (e.g. [Claude
 curl -fsSL https://raw.githubusercontent.com/sachiniyer/agent-factory/master/install.sh | sh
 ```
 
-Installs the `af` binary (Linux/macOS, amd64/arm64) to `~/.local/bin` — override with `AF_INSTALL_DIR`, pin a release with `--version`. Re-run the script or `af upgrade` to update.
+Installs the `af` binary (Linux/macOS, amd64/arm64) to `~/.local/bin` — override with `AF_INSTALL_DIR`, pin a release with `--version`. Re-run the script or `af upgrade` to update. Installed binaries also auto-update themselves along the preview channel (see [docs/release-process.md](docs/release-process.md)).
 
 **Other ways:** grab a tarball from the [Releases page](https://github.com/sachiniyer/agent-factory/releases/latest), or build from source (needs **Go 1.24+**) with `git clone https://github.com/sachiniyer/agent-factory.git && cd agent-factory && ./dev-install.sh`.
 
@@ -97,12 +97,13 @@ See [docs/configuration.md](docs/configuration.md) for every key, the precedence
 - [docs/configuration.md](docs/configuration.md) — config keys, global vs. in-repo precedence, state locations
 - [docs/tasks.md](docs/tasks.md) — task triggers, the watch-script contract, daemon lifecycle
 - [docs/remote-hooks.md](docs/remote-hooks.md) — remote backend script protocol
+- [docs/release-process.md](docs/release-process.md) — release channels: manual stable `1.x.y`, auto preview `1.x.y-preview-z`, how updates reach users
 - [docs/release-testing-plan.md](docs/release-testing-plan.md) — release gate and smoke checks
 - [examples/](examples/) — runnable task watch-scripts and remote-hook skeletons
 
 ## Maintenance
 
-This repo is autonomously maintained by Captain Claude, an AI maintainer running on Claude Code; the operating contract lives in [CLAUDE.md](CLAUDE.md). Every open issue gets a response — a fix, specific questions, or a reasoned close — and merged work auto-releases from `master` every 3 hours.
+This repo is autonomously maintained by Captain Claude, an AI maintainer running on Claude Code; the operating contract lives in [CLAUDE.md](CLAUDE.md). Every open issue gets a response — a fix, specific questions, or a reasoned close — and merged work reaches the preview channel (`1.x.y-preview-z`) from `master` every 3 hours; stable releases (`1.x.y`) are cut manually (see [docs/release-process.md](docs/release-process.md)).
 
 When filing an issue, include: steps to reproduce, expected vs. actual behavior, `af version` output and your platform, and (when relevant) logs from the application log (see `docs/configuration.md` for path resolution).
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prerequisites: **tmux**, **git**, and at least one AI coding agent (e.g. [Claude
 curl -fsSL https://raw.githubusercontent.com/sachiniyer/agent-factory/master/install.sh | sh
 ```
 
-Installs the `af` binary (Linux/macOS, amd64/arm64) to `~/.local/bin` — override with `AF_INSTALL_DIR`, pin a release with `--version`. Re-run the script or `af upgrade` to update. Installed binaries also auto-update themselves along the preview channel (see [docs/release-process.md](docs/release-process.md)).
+Installs the `af` binary (Linux/macOS, amd64/arm64) to `~/.local/bin` — override with `AF_INSTALL_DIR`, pin a release with `--version`. Re-run the script or `af upgrade` to update. Installed binaries also auto-update themselves along the stable channel; set `"update_channel": "preview"` in the global config to track preview builds instead (see [docs/release-process.md](docs/release-process.md)).
 
 **Other ways:** grab a tarball from the [Releases page](https://github.com/sachiniyer/agent-factory/releases/latest), or build from source (needs **Go 1.24+**) with `git clone https://github.com/sachiniyer/agent-factory.git && cd agent-factory && ./dev-install.sh`.
 
@@ -97,7 +97,7 @@ See [docs/configuration.md](docs/configuration.md) for every key, the precedence
 - [docs/configuration.md](docs/configuration.md) — config keys, global vs. in-repo precedence, state locations
 - [docs/tasks.md](docs/tasks.md) — task triggers, the watch-script contract, daemon lifecycle
 - [docs/remote-hooks.md](docs/remote-hooks.md) — remote backend script protocol
-- [docs/release-process.md](docs/release-process.md) — release channels: manual stable `1.x.y`, auto preview `1.x.y-preview-z`, how updates reach users
+- [docs/release-process.md](docs/release-process.md) — release channels: manual stable `1.x.y` (the auto-update default), opt-in auto preview `1.x.y-preview-z`
 - [docs/release-testing-plan.md](docs/release-testing-plan.md) — release gate and smoke checks
 - [examples/](examples/) — runnable task watch-scripts and remote-hook skeletons
 

--- a/autoupdate.go
+++ b/autoupdate.go
@@ -19,7 +19,10 @@ import (
 const (
 	autoUpdateCheckInterval = 24 * time.Hour
 	lastCheckFile           = "last_update_check"
-	githubAPILatestRelease  = "https://api.github.com/repos/sachiniyer/agent-factory/releases/latest"
+	// The /releases/latest endpoint only ever reports the newest STABLE
+	// release — it never returns prereleases. Auto-update tracks the preview
+	// channel (#1041), so we list releases and pick the newest tag ourselves.
+	githubAPIReleases = "https://api.github.com/repos/sachiniyer/agent-factory/releases?per_page=100"
 )
 
 // runtimeGOOS is a variable so tests can override the value reported by
@@ -63,9 +66,13 @@ func autoUpdate() error {
 	// retry on every launch and flood GitHub's rate limit. See issue #459.
 	recordCheck()
 
-	latestTag, err := fetchLatestReleaseTagFn()
+	// Windows already returned above, before any network call (#1002).
+	goos := runtimeGOOS
+	goarch := runtime.GOARCH
+
+	latestTag, downloadURL, err := latestDownloadURL(goos, goarch)
 	if err != nil {
-		return fmt.Errorf("failed to fetch latest release: %w", err)
+		return err
 	}
 
 	// Strip leading "v" from tags for comparison
@@ -75,14 +82,7 @@ func autoUpdate() error {
 		return nil
 	}
 
-	// Windows already returned above, before any network call (#1002).
-	goos := runtimeGOOS
-	goarch := runtime.GOARCH
-
 	log.InfoLog.Printf("auto-update: updating from %s to %s", version, latestVersion)
-
-	downloadURL := fmt.Sprintf("%s/latest/download/agent-factory-%s-%s.tar.gz",
-		releaseBaseURL, goos, goarch)
 
 	binary, err := downloadBinaryFn(downloadURL)
 	if err != nil {
@@ -130,10 +130,36 @@ func autoUpdate() error {
 	return nil
 }
 
-// fetchLatestReleaseTag queries the GitHub API for the latest release tag name.
+// latestDownloadURL resolves the newest release across both channels (#1041)
+// and returns its tag plus the tarball URL for goos/goarch. Previews are not
+// served by the releases/latest/download redirect (GitHub pins that to the
+// newest stable), so the download must address the tag directly.
+func latestDownloadURL(goos, goarch string) (tag, url string, err error) {
+	tag, err = fetchLatestReleaseTagFn()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to fetch latest release: %w", err)
+	}
+	url = fmt.Sprintf("%s/download/%s/agent-factory-%s-%s.tar.gz",
+		releaseBaseURL, tag, goos, goarch)
+	return tag, url, nil
+}
+
+// releaseEntry is the subset of the GitHub release object needed to pick an
+// update target.
+type releaseEntry struct {
+	TagName string `json:"tag_name"`
+	Draft   bool   `json:"draft"`
+}
+
+// fetchLatestReleaseTag queries the GitHub API for the newest release tag by
+// version order, across both channels (#1041): stable releases vX.Y.Z and
+// preview prereleases vX.Y.Z-preview-N. This makes auto-update track the
+// preview channel — previews are based on the next patch after the latest
+// stable (1.2.0 < 1.2.1-preview-1), so the newest tag is normally the newest
+// preview, and is the stable itself right after a manual stable release.
 func fetchLatestReleaseTag() (string, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest("GET", githubAPILatestRelease, nil)
+	req, err := http.NewRequest("GET", githubAPIReleases, nil)
 	if err != nil {
 		return "", err
 	}
@@ -149,48 +175,100 @@ func fetchLatestReleaseTag() (string, error) {
 		return "", fmt.Errorf("GitHub API returned %d", resp.StatusCode)
 	}
 
-	var release struct {
-		TagName string `json:"tag_name"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+	var releases []releaseEntry
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
 		return "", err
 	}
-	return release.TagName, nil
+	tag := pickLatestReleaseTag(releases)
+	if tag == "" {
+		return "", fmt.Errorf("no published release with a parseable version tag found")
+	}
+	return tag, nil
 }
 
-// isNewer returns true if latestVersion is newer than currentVersion.
-// Both should be semver strings like "1.0.16".
+// pickLatestReleaseTag returns the version-newest non-draft release tag, or
+// "" when no release carries a parseable version tag.
+func pickLatestReleaseTag(releases []releaseEntry) string {
+	best := ""
+	for _, r := range releases {
+		if r.Draft {
+			continue
+		}
+		v := strings.TrimPrefix(r.TagName, "v")
+		if parseSemver(v) == nil {
+			continue
+		}
+		if best == "" || isNewer(v, strings.TrimPrefix(best, "v")) {
+			best = r.TagName
+		}
+	}
+	return best
+}
+
+// semver is a parsed version under the two-channel scheme (#1041):
+// MAJOR.MINOR.PATCH with an optional "-preview-N" prerelease suffix.
+type semver struct {
+	nums    [3]int
+	preview bool
+	z       int
+}
+
+// isNewer returns true if latest is strictly newer than current under the
+// two-channel scheme (#1041). MAJOR.MINOR.PATCH compare numerically; on a
+// tie a stable release is newer than any of its previews (standard semver
+// precedence), and previews order by their preview number:
+// 1.2.0 < 1.2.1-preview-1 < 1.2.1-preview-2 < 1.2.1.
 func isNewer(latest, current string) bool {
-	lParts := parseSemver(latest)
-	cParts := parseSemver(current)
-	if lParts == nil || cParts == nil {
+	l := parseSemver(latest)
+	c := parseSemver(current)
+	if l == nil || c == nil {
 		return false
 	}
 	for i := 0; i < 3; i++ {
-		if lParts[i] > cParts[i] {
-			return true
-		}
-		if lParts[i] < cParts[i] {
-			return false
+		if l.nums[i] != c.nums[i] {
+			return l.nums[i] > c.nums[i]
 		}
 	}
-	return false
+	if l.preview != c.preview {
+		// Equal base: the stable release outranks its previews.
+		return c.preview
+	}
+	return l.preview && l.z > c.z
 }
 
-func parseSemver(v string) []int {
-	parts := strings.SplitN(v, ".", 3)
+// parseSemver parses "X.Y.Z" or "X.Y.Z-preview-N". Any other shape —
+// including unknown prerelease suffixes — returns nil so that unrecognized
+// tags are never treated as update targets.
+func parseSemver(v string) *semver {
+	core := v
+	var preview bool
+	var z int
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		core = v[:i]
+		numStr, ok := strings.CutPrefix(v[i+1:], "preview-")
+		if !ok {
+			return nil
+		}
+		n, err := strconv.Atoi(numStr)
+		if err != nil || n < 0 {
+			return nil
+		}
+		preview = true
+		z = n
+	}
+	parts := strings.Split(core, ".")
 	if len(parts) != 3 {
 		return nil
 	}
-	nums := make([]int, 3)
+	out := &semver{preview: preview, z: z}
 	for i, p := range parts {
 		n, err := strconv.Atoi(p)
-		if err != nil {
+		if err != nil || n < 0 {
 			return nil
 		}
-		nums[i] = n
+		out.nums[i] = n
 	}
-	return nums
+	return out
 }
 
 func lastCheckPath() string {

--- a/autoupdate.go
+++ b/autoupdate.go
@@ -70,7 +70,7 @@ func autoUpdate() error {
 	goos := runtimeGOOS
 	goarch := runtime.GOARCH
 
-	latestTag, downloadURL, err := latestDownloadURL(goos, goarch)
+	latestTag, downloadURL, err := latestDownloadURL(updateChannel(), goos, goarch)
 	if err != nil {
 		return err
 	}
@@ -130,12 +130,25 @@ func autoUpdate() error {
 	return nil
 }
 
-// latestDownloadURL resolves the newest release across both channels (#1041)
+// updateChannel returns the release channel auto-update and `af upgrade`
+// follow: config.UpdateChannelStable unless the user opted into
+// config.UpdateChannelPreview via the update_channel key (#1041). A config
+// that fails to load must never block or redirect an update check, so any
+// error falls back to the stable channel.
+func updateChannel() string {
+	cfg, err := config.LoadConfig()
+	if err != nil || cfg == nil {
+		return config.UpdateChannelStable
+	}
+	return cfg.UpdateChannel
+}
+
+// latestDownloadURL resolves the newest release on the given channel (#1041)
 // and returns its tag plus the tarball URL for goos/goarch. Previews are not
 // served by the releases/latest/download redirect (GitHub pins that to the
 // newest stable), so the download must address the tag directly.
-func latestDownloadURL(goos, goarch string) (tag, url string, err error) {
-	tag, err = fetchLatestReleaseTagFn()
+func latestDownloadURL(channel, goos, goarch string) (tag, url string, err error) {
+	tag, err = fetchLatestReleaseTagFn(channel)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to fetch latest release: %w", err)
 	}
@@ -147,17 +160,18 @@ func latestDownloadURL(goos, goarch string) (tag, url string, err error) {
 // releaseEntry is the subset of the GitHub release object needed to pick an
 // update target.
 type releaseEntry struct {
-	TagName string `json:"tag_name"`
-	Draft   bool   `json:"draft"`
+	TagName    string `json:"tag_name"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
 }
 
 // fetchLatestReleaseTag queries the GitHub API for the newest release tag by
-// version order, across both channels (#1041): stable releases vX.Y.Z and
-// preview prereleases vX.Y.Z-preview-N. This makes auto-update track the
-// preview channel — previews are based on the next patch after the latest
-// stable (1.2.0 < 1.2.1-preview-1), so the newest tag is normally the newest
-// preview, and is the stable itself right after a manual stable release.
-func fetchLatestReleaseTag() (string, error) {
+// version order on the given channel (#1041): stable-channel updates only
+// consider stable releases vX.Y.Z; preview-channel updates also consider the
+// vX.Y.Z-preview-N prereleases. The /releases/latest endpoint never returns
+// prereleases, so we list releases and pick the newest ourselves on both
+// channels.
+func fetchLatestReleaseTag(channel string) (string, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequest("GET", githubAPIReleases, nil)
 	if err != nil {
@@ -179,23 +193,30 @@ func fetchLatestReleaseTag() (string, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
 		return "", err
 	}
-	tag := pickLatestReleaseTag(releases)
+	tag := pickLatestReleaseTag(channel, releases)
 	if tag == "" {
-		return "", fmt.Errorf("no published release with a parseable version tag found")
+		return "", fmt.Errorf("no published release with a parseable version tag found on the %s channel", channel)
 	}
 	return tag, nil
 }
 
-// pickLatestReleaseTag returns the version-newest non-draft release tag, or
-// "" when no release carries a parseable version tag.
-func pickLatestReleaseTag(releases []releaseEntry) string {
+// pickLatestReleaseTag returns the version-newest non-draft release tag on
+// the given channel, or "" when none qualifies. On the stable channel a
+// release is skipped when either GitHub's prerelease flag or the tag's
+// -preview-N suffix marks it as a preview; the preview channel includes
+// everything.
+func pickLatestReleaseTag(channel string, releases []releaseEntry) string {
 	best := ""
 	for _, r := range releases {
 		if r.Draft {
 			continue
 		}
 		v := strings.TrimPrefix(r.TagName, "v")
-		if parseSemver(v) == nil {
+		parsed := parseSemver(v)
+		if parsed == nil {
+			continue
+		}
+		if channel != config.UpdateChannelPreview && (r.Prerelease || parsed.preview) {
 			continue
 		}
 		if best == "" || isNewer(v, strings.TrimPrefix(best, "v")) {

--- a/autoupdate.go
+++ b/autoupdate.go
@@ -19,10 +19,26 @@ import (
 const (
 	autoUpdateCheckInterval = 24 * time.Hour
 	lastCheckFile           = "last_update_check"
-	// The /releases/latest endpoint only ever reports the newest STABLE
-	// release — it never returns prereleases. Auto-update tracks the preview
-	// channel (#1041), so we list releases and pick the newest tag ourselves.
-	githubAPIReleases = "https://api.github.com/repos/sachiniyer/agent-factory/releases?per_page=100"
+)
+
+// GitHub API endpoints for release discovery, one per channel (#1041).
+// Variables so tests can point them at a local httptest server.
+var (
+	// githubAPILatestReleaseURL answers the stable channel: GitHub pins
+	// /releases/latest to the newest non-prerelease release, with no
+	// pagination to overflow. Listing /releases and filtering would break
+	// here — with a preview cut every 3 hours, page 1 fills with
+	// prereleases within days and the newest stable falls off it, so a
+	// stable-channel client would resolve nothing (Greptile review, #1078).
+	githubAPILatestReleaseURL = "https://api.github.com/repos/sachiniyer/agent-factory/releases/latest"
+	// githubAPIReleasesURL answers the preview channel: /releases/latest
+	// never returns prereleases, so previews must come from the list. One
+	// page of 100 suffices: under the release scheme versions are only ever
+	// created in increasing order (preview z/base move forward, stable
+	// releases are validated strictly greater), so the version-newest
+	// release is always among the most recently created — and the whole
+	// page is scanned for the max rather than trusting item order.
+	githubAPIReleasesURL = "https://api.github.com/repos/sachiniyer/agent-factory/releases?per_page=100"
 )
 
 // runtimeGOOS is a variable so tests can override the value reported by
@@ -165,39 +181,68 @@ type releaseEntry struct {
 	Prerelease bool   `json:"prerelease"`
 }
 
-// fetchLatestReleaseTag queries the GitHub API for the newest release tag by
-// version order on the given channel (#1041): stable-channel updates only
-// consider stable releases vX.Y.Z; preview-channel updates also consider the
-// vX.Y.Z-preview-N prereleases. The /releases/latest endpoint never returns
-// prereleases, so we list releases and pick the newest ourselves on both
-// channels.
+// fetchLatestReleaseTag queries the GitHub API for the newest release tag on
+// the given channel (#1041): the stable channel resolves directly through
+// /releases/latest, the preview channel through the release list (see the
+// endpoint docs above for why each channel needs its own endpoint).
 func fetchLatestReleaseTag(channel string) (string, error) {
-	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest("GET", githubAPIReleases, nil)
-	if err != nil {
+	if channel == config.UpdateChannelPreview {
+		return fetchLatestPreviewChannelTag()
+	}
+	return fetchLatestStableTag()
+}
+
+// fetchLatestStableTag resolves the newest stable release via
+// /releases/latest. The endpoint already excludes prereleases and drafts;
+// the shape checks below are a tripwire against a stable release published
+// with an off-scheme tag, which must fail loudly rather than become an
+// update target.
+func fetchLatestStableTag() (string, error) {
+	var release releaseEntry
+	if err := getGitHubJSON(githubAPILatestReleaseURL, &release); err != nil {
 		return "", err
+	}
+	parsed := parseSemver(strings.TrimPrefix(release.TagName, "v"))
+	if parsed == nil || parsed.preview || release.Prerelease || release.Draft {
+		return "", fmt.Errorf("releases/latest returned unusable tag %q for the stable channel", release.TagName)
+	}
+	return release.TagName, nil
+}
+
+// fetchLatestPreviewChannelTag resolves the newest release including
+// prereleases from the release list.
+func fetchLatestPreviewChannelTag() (string, error) {
+	var releases []releaseEntry
+	if err := getGitHubJSON(githubAPIReleasesURL, &releases); err != nil {
+		return "", err
+	}
+	tag := pickLatestReleaseTag(config.UpdateChannelPreview, releases)
+	if tag == "" {
+		return "", fmt.Errorf("no published release with a parseable version tag found on the preview channel")
+	}
+	return tag, nil
+}
+
+// getGitHubJSON fetches url from the GitHub API and decodes the JSON
+// response into out.
+func getGitHubJSON(url string, out any) error {
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+		return fmt.Errorf("GitHub API returned %d", resp.StatusCode)
 	}
-
-	var releases []releaseEntry
-	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
-		return "", err
-	}
-	tag := pickLatestReleaseTag(channel, releases)
-	if tag == "" {
-		return "", fmt.Errorf("no published release with a parseable version tag found on the %s channel", channel)
-	}
-	return tag, nil
+	return json.NewDecoder(resp.Body).Decode(out)
 }
 
 // pickLatestReleaseTag returns the version-newest non-draft release tag on

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	aflog "github.com/sachiniyer/agent-factory/log"
@@ -95,7 +96,7 @@ func TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable(t *testing.T) {
 	runtimeGOOS = "windows"
 	version = "1.0.0"
 	fetchCalls := 0
-	fetchLatestReleaseTagFn = func() (string, error) {
+	fetchLatestReleaseTagFn = func(string) (string, error) {
 		fetchCalls++
 		return "v1.0.1", nil
 	}
@@ -144,7 +145,7 @@ func TestAutoUpdateWindowsSkipsNetworkRegardlessOfVersion(t *testing.T) {
 
 	runtimeGOOS = "windows"
 	version = "1.0.1"
-	fetchLatestReleaseTagFn = func() (string, error) {
+	fetchLatestReleaseTagFn = func(string) (string, error) {
 		t.Fatalf("fetchLatestReleaseTagFn must not be called on Windows (#1002)")
 		return "", nil
 	}
@@ -170,7 +171,7 @@ func TestAutoUpdateRecordsCheckOnFetchFailure(t *testing.T) {
 		fetchLatestReleaseTagFn = prevFetch
 	})
 
-	fetchLatestReleaseTagFn = func() (string, error) {
+	fetchLatestReleaseTagFn = func(string) (string, error) {
 		return "", errors.New("simulated network failure")
 	}
 
@@ -206,7 +207,7 @@ func TestAutoUpdateRecordsCheckOnDownloadFailure(t *testing.T) {
 
 	runtimeGOOS = "linux"
 	version = "1.0.0"
-	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.1", nil }
+	fetchLatestReleaseTagFn = func(string) (string, error) { return "v1.0.1", nil }
 	downloadBinaryFn = func(string) ([]byte, error) {
 		return nil, errors.New("simulated download failure")
 	}
@@ -258,7 +259,7 @@ func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
 
 	runtimeGOOS = "linux"
 	version = "1.0.0"
-	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.1", nil }
+	fetchLatestReleaseTagFn = func(string) (string, error) { return "v1.0.1", nil }
 	// Bypass the tarball extract by returning the raw binary directly.
 	downloadBinaryFn = func(string) ([]byte, error) { return []byte("new-binary"), nil }
 	osExecutableFn = func() (string, error) { return tempBin, nil }
@@ -328,7 +329,7 @@ func TestAutoUpdateSucceedsWhenShutdownErrors(t *testing.T) {
 
 	runtimeGOOS = "linux"
 	version = "1.0.0"
-	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.1", nil }
+	fetchLatestReleaseTagFn = func(string) (string, error) { return "v1.0.1", nil }
 	downloadBinaryFn = func(string) ([]byte, error) { return []byte("new-binary"), nil }
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
@@ -396,37 +397,70 @@ func TestIsNewer(t *testing.T) {
 func TestPickLatestReleaseTag(t *testing.T) {
 	cases := []struct {
 		name     string
+		channel  string
 		releases []releaseEntry
 		want     string
 	}{
 		{
-			name: "newest preview wins over older stable",
+			name:    "preview channel: newest preview wins over older stable",
+			channel: config.UpdateChannelPreview,
 			releases: []releaseEntry{
-				{TagName: "v1.0.138-preview-2"},
-				{TagName: "v1.0.138-preview-1"},
+				{TagName: "v1.0.138-preview-2", Prerelease: true},
+				{TagName: "v1.0.138-preview-1", Prerelease: true},
 				{TagName: "v1.0.137"},
 			},
 			want: "v1.0.138-preview-2",
 		},
 		{
-			name: "fresh stable wins over previews of the old base",
+			name:    "stable channel: previews are skipped entirely",
+			channel: config.UpdateChannelStable,
+			releases: []releaseEntry{
+				{TagName: "v1.0.138-preview-2", Prerelease: true},
+				{TagName: "v1.0.138-preview-1", Prerelease: true},
+				{TagName: "v1.0.137"},
+			},
+			want: "v1.0.137",
+		},
+		{
+			name:    "stable channel: preview-shaped tag is skipped even without the prerelease flag",
+			channel: config.UpdateChannelStable,
+			releases: []releaseEntry{
+				{TagName: "v1.0.138-preview-2"},
+				{TagName: "v1.0.137"},
+			},
+			want: "v1.0.137",
+		},
+		{
+			name:    "stable channel: stable-shaped tag flagged prerelease is skipped",
+			channel: config.UpdateChannelStable,
+			releases: []releaseEntry{
+				{TagName: "v1.0.138", Prerelease: true},
+				{TagName: "v1.0.137"},
+			},
+			want: "v1.0.137",
+		},
+		{
+			name:    "preview channel: fresh stable wins over previews of the old base",
+			channel: config.UpdateChannelPreview,
 			releases: []releaseEntry{
 				{TagName: "v1.1.0"},
-				{TagName: "v1.0.138-preview-9"},
+				{TagName: "v1.0.138-preview-9", Prerelease: true},
 				{TagName: "v1.0.137"},
 			},
 			want: "v1.1.0",
 		},
 		{
-			name: "promoted base outranks its own previews",
+			name:    "preview channel: promoted base outranks its own previews",
+			channel: config.UpdateChannelPreview,
 			releases: []releaseEntry{
-				{TagName: "v1.0.138-preview-9"},
+				{TagName: "v1.0.138-preview-9", Prerelease: true},
 				{TagName: "v1.0.138"},
 			},
 			want: "v1.0.138",
 		},
 		{
-			name: "drafts and unparseable tags are skipped",
+			name:    "drafts and unparseable tags are skipped",
+			channel: config.UpdateChannelPreview,
 			releases: []releaseEntry{
 				{TagName: "v9.9.9", Draft: true},
 				{TagName: "nightly"},
@@ -435,24 +469,102 @@ func TestPickLatestReleaseTag(t *testing.T) {
 			want: "v1.0.137",
 		},
 		{
-			name: "API order does not matter",
+			name:    "API order does not matter",
+			channel: config.UpdateChannelPreview,
 			releases: []releaseEntry{
 				{TagName: "v1.0.137"},
-				{TagName: "v1.0.138-preview-10"},
-				{TagName: "v1.0.138-preview-9"},
+				{TagName: "v1.0.138-preview-10", Prerelease: true},
+				{TagName: "v1.0.138-preview-9", Prerelease: true},
 			},
 			want: "v1.0.138-preview-10",
 		},
 		{
 			name:     "no usable releases",
+			channel:  config.UpdateChannelPreview,
 			releases: []releaseEntry{{TagName: "junk"}, {TagName: "v1.0.0", Draft: true}},
 			want:     "",
 		},
+		{
+			name:    "stable channel: only previews published means no target",
+			channel: config.UpdateChannelStable,
+			releases: []releaseEntry{
+				{TagName: "v1.0.138-preview-1", Prerelease: true},
+			},
+			want: "",
+		},
 	}
 	for _, c := range cases {
-		if got := pickLatestReleaseTag(c.releases); got != c.want {
+		if got := pickLatestReleaseTag(c.channel, c.releases); got != c.want {
 			t.Errorf("%s: pickLatestReleaseTag = %q, want %q", c.name, got, c.want)
 		}
+	}
+}
+
+// TestAutoUpdateChannelFromConfig exercises the real config read path:
+// update_channel in the global config.json decides which channel the fetch
+// seam is asked for — stable when the key is absent (the default), preview
+// when opted in.
+func TestAutoUpdateChannelFromConfig(t *testing.T) {
+	cases := []struct {
+		name        string
+		configJSON  string // empty = no config.json (first run, materialized defaults)
+		wantChannel string
+	}{
+		{
+			name:        "no config defaults to stable",
+			wantChannel: config.UpdateChannelStable,
+		},
+		{
+			name:        "config without the key defaults to stable",
+			configJSON:  `{"default_program": "claude"}`,
+			wantChannel: config.UpdateChannelStable,
+		},
+		{
+			name:        "preview opt-in is honored",
+			configJSON:  `{"default_program": "claude", "update_channel": "preview"}`,
+			wantChannel: config.UpdateChannelPreview,
+		},
+		{
+			name:        "invalid value falls back to stable",
+			configJSON:  `{"default_program": "claude", "update_channel": "nightly"}`,
+			wantChannel: config.UpdateChannelStable,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := withTestHome(t)
+			captureLogs(t)
+			if c.configJSON != "" {
+				if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(c.configJSON), 0644); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+			}
+
+			prevGOOS := runtimeGOOS
+			prevFetch := fetchLatestReleaseTagFn
+			prevVersion := version
+			t.Cleanup(func() {
+				runtimeGOOS = prevGOOS
+				fetchLatestReleaseTagFn = prevFetch
+				version = prevVersion
+			})
+
+			runtimeGOOS = "linux"
+			version = "1.0.0"
+			gotChannel := ""
+			fetchLatestReleaseTagFn = func(channel string) (string, error) {
+				gotChannel = channel
+				// Same version as current: no download or install follows.
+				return "v1.0.0", nil
+			}
+
+			if err := autoUpdate(); err != nil {
+				t.Fatalf("autoUpdate: %v", err)
+			}
+			if gotChannel != c.wantChannel {
+				t.Fatalf("channel = %q, want %q", gotChannel, c.wantChannel)
+			}
+		})
 	}
 }
 
@@ -488,7 +600,7 @@ func TestAutoUpdateDownloadsByTag(t *testing.T) {
 
 	runtimeGOOS = "linux"
 	version = "1.0.137"
-	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.138-preview-2", nil }
+	fetchLatestReleaseTagFn = func(string) (string, error) { return "v1.0.138-preview-2", nil }
 	var gotURL string
 	downloadBinaryFn = func(url string) ([]byte, error) {
 		gotURL = url

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -497,6 +500,96 @@ func TestPickLatestReleaseTag(t *testing.T) {
 		if got := pickLatestReleaseTag(c.channel, c.releases); got != c.want {
 			t.Errorf("%s: pickLatestReleaseTag = %q, want %q", c.name, got, c.want)
 		}
+	}
+}
+
+// TestFetchLatestReleaseTagChannels mirrors the Greptile repro on #1078:
+// with a preview cut every 3 hours, page 1 of /releases fills up with 100
+// prereleases and the newest stable release is NOT in the list response —
+// it is only reachable via /releases/latest. The stable channel (the
+// default) must still resolve it; resolving nothing would silently stop
+// auto-update for every default-channel user. The preview channel must keep
+// resolving the newest preview from the list.
+func TestFetchLatestReleaseTagChannels(t *testing.T) {
+	previews := make([]releaseEntry, 0, 100)
+	for i := 100; i >= 1; i-- {
+		previews = append(previews, releaseEntry{
+			TagName:    fmt.Sprintf("v1.9.10-preview-%d", i),
+			Prerelease: true,
+		})
+	}
+	mux := http.NewServeMux()
+	listCalls := 0
+	mux.HandleFunc("/releases", func(w http.ResponseWriter, r *http.Request) {
+		listCalls++
+		if err := json.NewEncoder(w).Encode(previews); err != nil {
+			t.Errorf("encode releases list: %v", err)
+		}
+	})
+	latestCalls := 0
+	mux.HandleFunc("/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		latestCalls++
+		if err := json.NewEncoder(w).Encode(releaseEntry{TagName: "v1.9.9"}); err != nil {
+			t.Errorf("encode latest release: %v", err)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	prevLatestURL := githubAPILatestReleaseURL
+	prevListURL := githubAPIReleasesURL
+	githubAPILatestReleaseURL = srv.URL + "/releases/latest"
+	githubAPIReleasesURL = srv.URL + "/releases?per_page=100"
+	t.Cleanup(func() {
+		githubAPILatestReleaseURL = prevLatestURL
+		githubAPIReleasesURL = prevListURL
+	})
+
+	tag, err := fetchLatestReleaseTag(config.UpdateChannelStable)
+	if err != nil {
+		t.Fatalf("stable channel: %v", err)
+	}
+	if tag != "v1.9.9" {
+		t.Fatalf("stable channel resolved %q, want v1.9.9", tag)
+	}
+	if listCalls != 0 {
+		t.Fatalf("stable channel hit the paginated /releases list %d times; it must use /releases/latest only", listCalls)
+	}
+
+	tag, err = fetchLatestReleaseTag(config.UpdateChannelPreview)
+	if err != nil {
+		t.Fatalf("preview channel: %v", err)
+	}
+	if tag != "v1.9.10-preview-100" {
+		t.Fatalf("preview channel resolved %q, want v1.9.10-preview-100", tag)
+	}
+	if listCalls != 1 {
+		t.Fatalf("preview channel should list /releases exactly once, got %d", listCalls)
+	}
+	if latestCalls != 1 {
+		t.Fatalf("/releases/latest should be hit exactly once (by the stable channel), got %d", latestCalls)
+	}
+}
+
+// TestFetchLatestStableTagRejectsOffSchemeTag pins the tripwire: a
+// /releases/latest response whose tag does not parse as a stable X.Y.Z must
+// error rather than become an update target.
+func TestFetchLatestStableTagRejectsOffSchemeTag(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(releaseEntry{TagName: "nightly-2026-07-02"}); err != nil {
+			t.Errorf("encode latest release: %v", err)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	prevLatestURL := githubAPILatestReleaseURL
+	githubAPILatestReleaseURL = srv.URL + "/releases/latest"
+	t.Cleanup(func() { githubAPILatestReleaseURL = prevLatestURL })
+
+	if _, err := fetchLatestReleaseTag(config.UpdateChannelStable); err == nil {
+		t.Fatalf("expected error for off-scheme releases/latest tag, got nil")
 	}
 }
 

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -353,10 +354,159 @@ func TestIsNewer(t *testing.T) {
 		{"1.0.0", "1.0.0", false},
 		{"1.0.0", "1.0.1", false},
 		{"bogus", "1.0.0", false},
+
+		// Numeric, not lexical, comparison of the base.
+		{"1.0.10", "1.0.9", true},
+
+		// Preview channel ordering (#1041): z is monotonic within a base.
+		{"1.2.0-preview-3", "1.2.0-preview-2", true},
+		{"1.2.0-preview-2", "1.2.0-preview-3", false},
+		{"1.2.0-preview-10", "1.2.0-preview-9", true},
+		{"1.2.0-preview-2", "1.2.0-preview-2", false},
+
+		// Stable outranks its own previews (standard semver precedence),
+		// never the other way around.
+		{"1.2.0", "1.2.0-preview-9", true},
+		{"1.2.0-preview-1", "1.2.0", false},
+
+		// A preview off a newer base outranks an older stable, and any
+		// newer stable outranks old previews.
+		{"1.2.1-preview-1", "1.2.0", true},
+		{"1.3.0", "1.2.1-preview-9", true},
+		{"1.2.0", "1.2.1-preview-1", false},
+
+		// Migration from the pre-#1041 scheme: the first preview off the
+		// last auto-bumped stable must be seen as an update.
+		{"1.0.138-preview-1", "1.0.137", true},
+
+		// Unknown or malformed prerelease suffixes are never update targets.
+		{"1.2.0-rc-1", "1.0.0", false},
+		{"1.2.0-preview-", "1.0.0", false},
+		{"1.2.0-preview-x", "1.0.0", false},
+		{"1.2.0-preview--3", "1.0.0", false},
+		{"1.2.0.4", "1.0.0", false},
 	}
 	for _, c := range cases {
 		if got := isNewer(c.latest, c.current); got != c.want {
 			t.Errorf("isNewer(%q, %q) = %v, want %v", c.latest, c.current, got, c.want)
 		}
+	}
+}
+
+func TestPickLatestReleaseTag(t *testing.T) {
+	cases := []struct {
+		name     string
+		releases []releaseEntry
+		want     string
+	}{
+		{
+			name: "newest preview wins over older stable",
+			releases: []releaseEntry{
+				{TagName: "v1.0.138-preview-2"},
+				{TagName: "v1.0.138-preview-1"},
+				{TagName: "v1.0.137"},
+			},
+			want: "v1.0.138-preview-2",
+		},
+		{
+			name: "fresh stable wins over previews of the old base",
+			releases: []releaseEntry{
+				{TagName: "v1.1.0"},
+				{TagName: "v1.0.138-preview-9"},
+				{TagName: "v1.0.137"},
+			},
+			want: "v1.1.0",
+		},
+		{
+			name: "promoted base outranks its own previews",
+			releases: []releaseEntry{
+				{TagName: "v1.0.138-preview-9"},
+				{TagName: "v1.0.138"},
+			},
+			want: "v1.0.138",
+		},
+		{
+			name: "drafts and unparseable tags are skipped",
+			releases: []releaseEntry{
+				{TagName: "v9.9.9", Draft: true},
+				{TagName: "nightly"},
+				{TagName: "v1.0.137"},
+			},
+			want: "v1.0.137",
+		},
+		{
+			name: "API order does not matter",
+			releases: []releaseEntry{
+				{TagName: "v1.0.137"},
+				{TagName: "v1.0.138-preview-10"},
+				{TagName: "v1.0.138-preview-9"},
+			},
+			want: "v1.0.138-preview-10",
+		},
+		{
+			name:     "no usable releases",
+			releases: []releaseEntry{{TagName: "junk"}, {TagName: "v1.0.0", Draft: true}},
+			want:     "",
+		},
+	}
+	for _, c := range cases {
+		if got := pickLatestReleaseTag(c.releases); got != c.want {
+			t.Errorf("%s: pickLatestReleaseTag = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestAutoUpdateDownloadsByTag verifies that the update tarball is fetched by
+// tag rather than through the releases/latest/download redirect: that
+// redirect never serves prereleases, so the preview channel (#1041) would be
+// unreachable through it.
+func TestAutoUpdateDownloadsByTag(t *testing.T) {
+	withTestHome(t)
+	captureLogs(t)
+
+	tempBin := filepath.Join(t.TempDir(), "agent-factory")
+	if err := os.WriteFile(tempBin, []byte("old-binary"), 0755); err != nil {
+		t.Fatalf("seed binary: %v", err)
+	}
+
+	prevGOOS := runtimeGOOS
+	prevFetch := fetchLatestReleaseTagFn
+	prevDownload := downloadBinaryFn
+	prevVersion := version
+	prevExe := osExecutableFn
+	prevShutdown := requestDaemonShutdownFn
+	prevRespawn := respawnDaemonFn
+	t.Cleanup(func() {
+		runtimeGOOS = prevGOOS
+		fetchLatestReleaseTagFn = prevFetch
+		downloadBinaryFn = prevDownload
+		version = prevVersion
+		osExecutableFn = prevExe
+		requestDaemonShutdownFn = prevShutdown
+		respawnDaemonFn = prevRespawn
+	})
+
+	runtimeGOOS = "linux"
+	version = "1.0.137"
+	fetchLatestReleaseTagFn = func() (string, error) { return "v1.0.138-preview-2", nil }
+	var gotURL string
+	downloadBinaryFn = func(url string) ([]byte, error) {
+		gotURL = url
+		return []byte("new-binary"), nil
+	}
+	osExecutableFn = func() (string, error) { return tempBin, nil }
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
+		return daemon.ShutdownNoDaemon, nil
+	}
+	respawnDaemonFn = func() {}
+
+	if err := autoUpdate(); err != nil {
+		t.Fatalf("autoUpdate: %v", err)
+	}
+	wantURL := fmt.Sprintf(
+		"https://github.com/sachiniyer/agent-factory/releases/download/v1.0.138-preview-2/agent-factory-linux-%s.tar.gz",
+		runtime.GOARCH)
+	if gotURL != wantURL {
+		t.Fatalf("download URL = %q, want %q", gotURL, wantURL)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,15 @@ const (
 	defaultDaemonPollInterval = 1000
 )
 
+// Release channels selectable via the update_channel config key (#1041).
+const (
+	// UpdateChannelStable tracks manual stable releases (1.x.y) only.
+	UpdateChannelStable = "stable"
+	// UpdateChannelPreview additionally tracks the automatic
+	// 1.x.y-preview-z prereleases cut every 3 hours.
+	UpdateChannelPreview = "preview"
+)
+
 // aliasOutputRegex extracts the command value from a shell alias-probe line.
 // Each alternative is anchored to a real alias shape so that interactive rc
 // files printing unrelated text cannot poison first-run config (#1003):
@@ -128,6 +137,12 @@ type Config struct {
 	BranchPrefix string `json:"branch_prefix"`
 	// DetachKeys is the key combination used to detach from an attached session (e.g. "ctrl-w", "ctrl-q").
 	DetachKeys string `json:"detach_keys"`
+	// UpdateChannel selects which release channel auto-update and
+	// `af upgrade` follow (#1041): UpdateChannelStable (the default)
+	// tracks manual stable releases (1.x.y) only; UpdateChannelPreview
+	// additionally tracks the automatic 1.x.y-preview-z prereleases.
+	// Any other value falls back to stable with a warning.
+	UpdateChannel string `json:"update_channel"`
 }
 
 // ValidateProgramEnum returns nil when name is one of tmux.SupportedPrograms.
@@ -211,6 +226,7 @@ func DefaultConfig() *Config {
 		DaemonPollInterval: defaultDaemonPollInterval,
 		LogMaxSizeMB:       log.DefaultMaxSizeMB,
 		LogMaxBackups:      log.DefaultMaxBackups,
+		UpdateChannel:      UpdateChannelStable,
 		BranchPrefix: func() string {
 			user, err := user.Current()
 			if err != nil || user == nil || user.Username == "" {
@@ -620,6 +636,12 @@ func parseConfig(data []byte, prettyConfigPath string) (*Config, error) {
 	if config.LogMaxBackups < 0 {
 		log.WarningLog.Printf("log_max_backups=%d is negative; using default %d", config.LogMaxBackups, log.DefaultMaxBackups)
 		config.LogMaxBackups = log.DefaultMaxBackups
+	}
+
+	if config.UpdateChannel != UpdateChannelStable && config.UpdateChannel != UpdateChannelPreview {
+		log.WarningLog.Printf("update_channel=%q is not one of [%s, %s]; using default %q",
+			config.UpdateChannel, UpdateChannelStable, UpdateChannelPreview, UpdateChannelStable)
+		config.UpdateChannel = UpdateChannelStable
 	}
 
 	return config, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -338,6 +338,7 @@ func TestDefaultConfig(t *testing.T) {
 		assert.Equal(t, tmux.ProgramClaude, cfg.DefaultProgram)
 		assert.False(t, cfg.AutoYes)
 		assert.Equal(t, 1000, cfg.DaemonPollInterval)
+		assert.Equal(t, UpdateChannelStable, cfg.UpdateChannel)
 		assert.NotEmpty(t, cfg.BranchPrefix)
 		assert.True(t, strings.HasSuffix(cfg.BranchPrefix, "/"))
 
@@ -842,6 +843,52 @@ func TestLoadConfig(t *testing.T) {
 				assert.Equal(t, tc.expectedBackups, cfg.LogMaxBackups)
 			})
 		}
+	})
+
+	t.Run("validates update_channel and falls back to stable", func(t *testing.T) {
+		cases := []struct {
+			name     string
+			content  string
+			expected string
+		}{
+			{"missing key -> stable", `{"default_program": "claude"}`, UpdateChannelStable},
+			{"stable -> as-is", `{"default_program": "claude", "update_channel": "stable"}`, UpdateChannelStable},
+			{"preview opt-in -> as-is", `{"default_program": "claude", "update_channel": "preview"}`, UpdateChannelPreview},
+			{"unknown value -> stable", `{"default_program": "claude", "update_channel": "nightly"}`, UpdateChannelStable},
+			{"empty string -> stable", `{"default_program": "claude", "update_channel": ""}`, UpdateChannelStable},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+				configDir, err := GetConfigDir()
+				require.NoError(t, err)
+				require.NoError(t, os.MkdirAll(configDir, 0755))
+
+				configPath := filepath.Join(configDir, ConfigFileName)
+				require.NoError(t, os.WriteFile(configPath, []byte(tc.content), 0644))
+
+				cfg, err := LoadConfig()
+				require.NoError(t, err)
+				require.NotNil(t, cfg)
+				assert.Equal(t, tc.expected, cfg.UpdateChannel)
+			})
+		}
+	})
+
+	t.Run("materializes update_channel into a first-run config.json", func(t *testing.T) {
+		// The key must be visible in the generated file so users discover it
+		// without reading docs, like the other global keys.
+		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+		configDir, err := GetConfigDir()
+		require.NoError(t, err)
+
+		_, err = LoadConfig()
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(filepath.Join(configDir, ConfigFileName))
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"update_channel": "stable"`)
 	})
 
 	t.Run("surfaces parse error on invalid JSON instead of using defaults", func(t *testing.T) {

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -87,6 +87,7 @@ var inRepoGlobalOnlyKeys = map[string]bool{
 	"detach_keys":          true,
 	"log_max_backups":      true,
 	"log_max_size_mb":      true,
+	"update_channel":       true,
 	"worktree_root":        true,
 }
 

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -66,7 +66,7 @@ func TestLoadInRepoConfigEmptyValueIsSet(t *testing.T) {
 }
 
 func TestLoadInRepoConfigRejectsGlobalOnlyKeys(t *testing.T) {
-	for _, key := range []string{"auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "log_max_backups", "log_max_size_mb", "worktree_root"} {
+	for _, key := range []string{"auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "log_max_backups", "log_max_size_mb", "update_channel", "worktree_root"} {
 		t.Run(key, func(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("AGENT_FACTORY_HOME", home)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,8 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
   "branch_prefix": "username/",
   "detach_keys": "ctrl-w",
   "log_max_size_mb": 50,
-  "log_max_backups": 2
+  "log_max_backups": 2,
+  "update_channel": "stable"
 }
 ```
 
@@ -36,6 +37,7 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
 | `detach_keys` | Key combination that detaches from an attached session (defaults to `ctrl-w`). |
 | `log_max_size_mb` | Size cap in MB for `agent-factory.log` and the per-task watch-script logs before they are rotated (defaults to 50). Must be positive. |
 | `log_max_backups` | How many rotated logs (`agent-factory.log.1`, `.2`, ...) to keep per log file; older ones are deleted (defaults to 2). `0` keeps none. |
+| `update_channel` | Release channel that auto-update and `af upgrade` follow: `stable` (default) tracks manual `1.x.y` releases only; `preview` opts into the automatic `1.x.y-preview-z` prereleases cut every 3 hours. Any other value falls back to `stable` with a warning. See [release-process.md](release-process.md). |
 
 ### Choosing the agent
 
@@ -72,7 +74,7 @@ A repository can carry its own configuration in `<repo-root>/.agent-factory/conf
 |-------|-------|
 | `default_program`, `program_overrides` | Valid globally **and** in-repo (in-repo wins). |
 | `post_worktree_commands`, `remote_hooks` | **In-repo only.** The legacy `~/.agent-factory/repos/<repoID>/config.json` location keeps working for one more release (a deprecation warning in the log points at the new file) and is shadowed whenever the in-repo file sets the same key — including by an explicit empty value like `"post_worktree_commands": []`. |
-| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `detach_keys`, `log_max_size_mb`, `log_max_backups` | Global only. Setting them in-repo is rejected with an error naming the key. |
+| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `detach_keys`, `log_max_size_mb`, `log_max_backups`, `update_channel` | Global only. Setting them in-repo is rejected with an error naming the key. |
 
 `post_worktree_commands` are shell commands run after each new worktree is created (e.g. `npm install`, `make build`) — they can also be edited from the TUI via the `H` (worktree hooks) key. `remote_hooks` configures a remote-machine backend; see [remote-hooks.md](remote-hooks.md) for the script protocol.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -56,16 +56,18 @@ channel has been testing, and subsequent previews move to `1.0.139-preview-1`.
 ## How updates flow to users
 
 - **Auto-update follows the stable channel by default.** On launch
-  (throttled to once per 24h), `af` lists GitHub releases, picks the newest
-  tag on the configured channel, and swaps the binary in place. With the
-  default `update_channel: "stable"` only stable `1.x.y` releases are
-  considered; prereleases are skipped.
+  (throttled to once per 24h), `af` resolves the newest release on the
+  configured channel and swaps the binary in place. With the default
+  `update_channel: "stable"` it asks GitHub's `releases/latest` endpoint,
+  which is pinned to the newest non-prerelease release — previews never
+  appear there, and there is no release list to page through.
 - **Preview tracking is opt-in** via the global config key
   `update_channel: "preview"` (see
-  [configuration.md](configuration.md)) — the updater then also considers
-  `1.x.y-preview-z` prereleases, which are normally the newest tag.
-  Prereleases are invisible to the `releases/latest` API/redirect, so the
-  updater addresses release assets by tag.
+  [configuration.md](configuration.md)) — the updater then lists releases
+  and picks the version-newest tag including `1.x.y-preview-z`
+  prereleases, which are normally the newest. Prereleases are invisible to
+  the `releases/latest` API/redirect, so the updater addresses release
+  assets by tag.
 - **`af upgrade`** resolves through the same configured channel, so a manual
   upgrade never downgrades a preview build back to an older stable.
 - **`install.sh` and fresh installs** use the `releases/latest/download/...`

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,69 @@
+# Release Process
+
+Agent Factory ships on two channels (#1041):
+
+| Channel | Version shape | Cut by | GitHub release |
+| --- | --- | --- | --- |
+| **Stable** | `1.x.y` (e.g. `1.1.0`) | Maintainer, manually | Normal release, marked **latest** |
+| **Preview** | `1.x.y-preview-z` (e.g. `1.1.1-preview-3`) | CI, automatically every 3 hours | **Prerelease**, never marked latest |
+
+## Version scheme
+
+Previews are based on the **next patch after the latest stable**: if the
+latest stable is `1.1.0`, previews are `1.1.1-preview-1`, `1.1.1-preview-2`,
+… — each cut from the current `master` HEAD. Because a prerelease sorts
+below its own release in semver, this keeps ordering standard across both
+channels:
+
+```
+1.1.0  <  1.1.1-preview-1  <  1.1.1-preview-2  <  1.1.1  ≤  any newer stable
+```
+
+`z` increments on every preview and resets to 1 whenever a new stable
+changes the base. Version computation lives in
+[`.github/scripts/next-preview-version.sh`](../.github/scripts/next-preview-version.sh)
+and is unit-tested in `release_scripts_test.go`.
+
+## Preview releases (automatic)
+
+The [`auto-release.yml`](../.github/workflows/auto-release.yml) workflow runs
+every 3 hours (and on manual dispatch). When `master` has new commits since
+the last tag, it runs the release preflight (gofmt, vet, race tests, build),
+tags `v1.x.y-preview-z`, builds the four platform tarballs with the version
+stamped via `-ldflags "-X main.version=..."`, and publishes a GitHub
+**prerelease**.
+
+Previews never commit to `master` — the old per-release
+"chore: bump version" commits are gone. The `version` var in `main.go` is
+only the dev-build fallback and holds the latest stable base.
+
+## Stable releases (manual)
+
+To cut a stable release, run the **Stable Release** workflow
+([`stable-release.yml`](../.github/workflows/stable-release.yml)) from the
+Actions tab (`workflow_dispatch`) and enter the version with no leading `v`,
+e.g. `1.1.0`. The maintainer chooses which digit to bump; the workflow
+validates the version (well-formed, untagged, strictly greater than the
+latest stable — see
+[`.github/scripts/validate-stable-version.sh`](../.github/scripts/validate-stable-version.sh)),
+runs the same preflight, commits the version bump to `main.go`, tags,
+builds, and publishes the release marked **latest**.
+
+Releasing the current preview base as-is (e.g. `1.0.138` while
+`1.0.138-preview-9` exists) is supported — it "promotes" what the preview
+channel has been testing, and subsequent previews move to `1.0.139-preview-1`.
+
+## How updates flow to users
+
+- **Auto-update follows the preview channel.** On launch (throttled to once
+  per 24h), `af` lists GitHub releases, picks the newest tag across both
+  channels — normally the newest preview; the stable itself right after a
+  stable release — and swaps the binary in place. Prereleases are invisible
+  to the `releases/latest` API/redirect, so the updater addresses release
+  assets by tag.
+- **`af upgrade`** resolves the same way, so a manual upgrade never
+  downgrades a preview build back to an older stable.
+- **`install.sh` and fresh installs** use the `releases/latest/download/...`
+  redirect, which GitHub pins to the newest **stable** — new users start on
+  stable, then auto-update onto the preview channel. A specific version
+  (stable or preview) can be pinned with `install.sh --version <tag>`.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -46,8 +46,10 @@ e.g. `1.1.0`. The maintainer chooses which digit to bump; the workflow
 validates the version (well-formed, untagged, strictly greater than the
 latest stable — see
 [`.github/scripts/validate-stable-version.sh`](../.github/scripts/validate-stable-version.sh)),
-runs the same preflight, commits the version bump to `main.go`, tags,
-builds, and publishes the release marked **latest**.
+runs the same preflight, and builds all four artifacts **before mutating
+anything**; only then does it commit the version bump to `main.go`, tag,
+and publish the release marked **latest**. A failed preflight or build
+therefore never leaves a dangling commit or tag on `master`.
 
 Releasing the current preview base as-is (e.g. `1.0.138` while
 `1.0.138-preview-9` exists) is supported — it "promotes" what the preview

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -55,15 +55,20 @@ channel has been testing, and subsequent previews move to `1.0.139-preview-1`.
 
 ## How updates flow to users
 
-- **Auto-update follows the preview channel.** On launch (throttled to once
-  per 24h), `af` lists GitHub releases, picks the newest tag across both
-  channels — normally the newest preview; the stable itself right after a
-  stable release — and swaps the binary in place. Prereleases are invisible
-  to the `releases/latest` API/redirect, so the updater addresses release
-  assets by tag.
-- **`af upgrade`** resolves the same way, so a manual upgrade never
-  downgrades a preview build back to an older stable.
+- **Auto-update follows the stable channel by default.** On launch
+  (throttled to once per 24h), `af` lists GitHub releases, picks the newest
+  tag on the configured channel, and swaps the binary in place. With the
+  default `update_channel: "stable"` only stable `1.x.y` releases are
+  considered; prereleases are skipped.
+- **Preview tracking is opt-in** via the global config key
+  `update_channel: "preview"` (see
+  [configuration.md](configuration.md)) — the updater then also considers
+  `1.x.y-preview-z` prereleases, which are normally the newest tag.
+  Prereleases are invisible to the `releases/latest` API/redirect, so the
+  updater addresses release assets by tag.
+- **`af upgrade`** resolves through the same configured channel, so a manual
+  upgrade never downgrades a preview build back to an older stable.
 - **`install.sh` and fresh installs** use the `releases/latest/download/...`
-  redirect, which GitHub pins to the newest **stable** — new users start on
-  stable, then auto-update onto the preview channel. A specific version
-  (stable or preview) can be pinned with `install.sh --version <tag>`.
+  redirect, which GitHub pins to the newest **stable** — new users start
+  (and by default stay) on stable. A specific version (stable or preview)
+  can be pinned with `install.sh --version <tag>`.

--- a/docs/release-testing-plan.md
+++ b/docs/release-testing-plan.md
@@ -17,8 +17,9 @@ go build ./...
 ```
 
 The PR workflow also runs lint, dependency review, CodeQL, and a build job.
-The auto-release workflow runs the release preflight before bumping
-`main.go`, tagging, or publishing artifacts. Workflow linting with
+Both release workflows (auto preview releases and manual stable releases —
+see [release-process.md](release-process.md)) run the release preflight
+before tagging or publishing artifacts. Workflow linting with
 `actionlint` is part of the local release review because broken workflow
 syntax or retired action runtimes can block CI/release automation.
 
@@ -93,10 +94,11 @@ Expected result:
 
 ## Release Artifact Verification
 
-After the release workflow publishes:
+After the release workflow publishes (`--latest` only sees the stable
+channel; verify a preview release by its `vX.Y.Z-preview-N` tag instead):
 
 ```bash
-gh release view --repo sachiniyer/agent-factory --latest
+gh release view --repo sachiniyer/agent-factory --latest   # or: gh release view <tag>
 gh release download --repo sachiniyer/agent-factory --latest --pattern 'agent-factory-*.tar.gz' --dir /tmp/af-release
 for archive in /tmp/af-release/*.tar.gz; do
   tar tzf "$archive"
@@ -118,7 +120,8 @@ AF_INSTALL_DIR="$(mktemp -d)" sh install.sh
 Expected result:
 - `install.sh` downloads `agent-factory-<os>-<arch>.tar.gz` via the
   `releases/latest/download/...` redirect, installs `af`, and the printed
-  `af version` reports the new tag.
+  `af version` reports the newest stable tag (the redirect never serves
+  preview prereleases; pin one explicitly with `install.sh --version <tag>`).
 
 ## Go/No-Go Criteria
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,11 @@ import (
 )
 
 var (
+	// version is the dev-build fallback. Released binaries are stamped at
+	// build time via -ldflags "-X main.version=..." (see .github/workflows);
+	// stable releases also commit the new number here so dev builds report
+	// the latest stable base. Preview releases (vX.Y.Z-preview-N, #1041)
+	// never rewrite this value.
 	version     = "1.0.137"
 	programFlag string
 	autoYesFlag bool

--- a/release_scripts_test.go
+++ b/release_scripts_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// These tests exercise the release version-computation scripts used by the
+// GitHub workflows (#1041). They are hermetic: tags are fed on stdin, no git
+// or network involved.
+
+// runVersionScript runs .github/scripts/<script> with args, feeding tags
+// (one per line) on stdin. Returns trimmed stdout and any error.
+func runVersionScript(t *testing.T, script string, args []string, tags []string) (string, error) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("release scripts are POSIX sh; not run on Windows")
+	}
+	path := filepath.Join(".github", "scripts", script)
+	cmd := exec.Command("sh", append([]string{path}, args...)...)
+	cmd.Stdin = strings.NewReader(strings.Join(tags, "\n") + "\n")
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+func TestNextPreviewVersionScript(t *testing.T) {
+	cases := []struct {
+		name string
+		tags []string
+		want string
+	}{
+		{
+			name: "first preview after a stable",
+			tags: []string{"v1.0.136", "v1.0.137"},
+			want: "1.0.138-preview-1",
+		},
+		{
+			name: "increments z within a base",
+			tags: []string{"v1.0.137", "v1.0.138-preview-1", "v1.0.138-preview-2"},
+			want: "1.0.138-preview-3",
+		},
+		{
+			name: "z compares numerically not lexically",
+			tags: []string{"v1.0.137", "v1.0.138-preview-9", "v1.0.138-preview-10"},
+			want: "1.0.138-preview-11",
+		},
+		{
+			name: "stable compares numerically not lexically",
+			tags: []string{"v1.0.9", "v1.0.10"},
+			want: "1.0.11-preview-1",
+		},
+		{
+			name: "z resets when a new stable changes the base",
+			tags: []string{"v1.0.137", "v1.0.138-preview-5", "v1.1.0"},
+			want: "1.1.1-preview-1",
+		},
+		{
+			name: "promoted preview base moves previews to the next patch",
+			tags: []string{"v1.0.137", "v1.0.138-preview-3", "v1.0.138"},
+			want: "1.0.139-preview-1",
+		},
+		{
+			name: "ignores tags matching neither channel",
+			tags: []string{"foo", "v1.2", "v1.0.138-rc-1", "v1.0.137", "v1.0.138-preview-x"},
+			want: "1.0.138-preview-1",
+		},
+		{
+			name: "no tags at all",
+			tags: []string{},
+			want: "0.0.1-preview-1",
+		},
+	}
+	for _, c := range cases {
+		got, err := runVersionScript(t, "next-preview-version.sh", nil, c.tags)
+		if err != nil {
+			t.Errorf("%s: script failed: %v", c.name, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("%s: next preview = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestValidateStableVersionScript(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		tags    []string
+		wantOK  bool
+	}{
+		{
+			name:    "valid bump over latest stable",
+			version: "1.1.0",
+			tags:    []string{"v1.0.136", "v1.0.137"},
+			wantOK:  true,
+		},
+		{
+			name:    "promoting the current preview base is allowed",
+			version: "1.0.138",
+			tags:    []string{"v1.0.137", "v1.0.138-preview-9"},
+			wantOK:  true,
+		},
+		{
+			name:    "equal to latest stable is rejected",
+			version: "1.0.137",
+			tags:    []string{"v1.0.136", "v1.0.137"},
+			wantOK:  false,
+		},
+		{
+			name:    "lower than latest stable is rejected",
+			version: "1.0.100",
+			tags:    []string{"v1.0.137"},
+			wantOK:  false,
+		},
+		{
+			name:    "leading v is rejected",
+			version: "v1.1.0",
+			tags:    []string{"v1.0.137"},
+			wantOK:  false,
+		},
+		{
+			name:    "two-part version is rejected",
+			version: "1.1",
+			tags:    []string{"v1.0.137"},
+			wantOK:  false,
+		},
+		{
+			name:    "already-tagged version is rejected",
+			version: "1.1.0",
+			tags:    []string{"v1.0.137", "v1.1.0"},
+			wantOK:  false,
+		},
+		{
+			name:    "numeric comparison against latest stable",
+			version: "1.0.11",
+			tags:    []string{"v1.0.9", "v1.0.10"},
+			wantOK:  true,
+		},
+	}
+	for _, c := range cases {
+		_, err := runVersionScript(t, "validate-stable-version.sh", []string{c.version}, c.tags)
+		if ok := err == nil; ok != c.wantOK {
+			t.Errorf("%s: validate %q ok=%v, want ok=%v (err: %v)", c.name, c.version, ok, c.wantOK, err)
+		}
+	}
+}

--- a/upgrade.go
+++ b/upgrade.go
@@ -100,9 +100,16 @@ var upgradeCmd = &cobra.Command{
 			return fmt.Errorf("af upgrade is not supported on Windows; download manually from %s", releaseBaseURL)
 		}
 
-		downloadURL := fmt.Sprintf("%s/latest/download/agent-factory-%s-%s.tar.gz", releaseBaseURL, goos, goarch)
+		// Resolve the newest release across both channels (#1041). The
+		// releases/latest/download redirect only serves the stable channel;
+		// auto-update tracks previews, so using it here would silently
+		// downgrade a preview build back to the older stable.
+		latestTag, downloadURL, err := latestDownloadURL(goos, goarch)
+		if err != nil {
+			return err
+		}
 
-		fmt.Printf("Downloading latest release for %s/%s...\n", goos, goarch)
+		fmt.Printf("Downloading %s for %s/%s...\n", latestTag, goos, goarch)
 		return runUpgrade(downloadURL)
 	},
 }

--- a/upgrade.go
+++ b/upgrade.go
@@ -100,11 +100,11 @@ var upgradeCmd = &cobra.Command{
 			return fmt.Errorf("af upgrade is not supported on Windows; download manually from %s", releaseBaseURL)
 		}
 
-		// Resolve the newest release across both channels (#1041). The
-		// releases/latest/download redirect only serves the stable channel;
-		// auto-update tracks previews, so using it here would silently
-		// downgrade a preview build back to the older stable.
-		latestTag, downloadURL, err := latestDownloadURL(goos, goarch)
+		// Resolve the newest release on the configured update channel
+		// (#1041). The releases/latest/download redirect only serves the
+		// stable channel; a preview-channel user upgraded through it would
+		// silently downgrade back to the older stable.
+		latestTag, downloadURL, err := latestDownloadURL(updateChannel(), goos, goarch)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes #1041

Implements Sachin's directive (as revised): stop the automatic `y` bumps; keep the 3-hour cadence but have it produce **preview prereleases**; stable releases become **manual**; **auto-update defaults to the stable channel**, with preview tracking as an explicit opt-in.

## The two channels

| Channel | Version | Cut by | GitHub release |
| --- | --- | --- | --- |
| Stable | `1.x.y` | Sachin, manually (Actions → **Stable Release** → enter e.g. `1.1.0`) | normal, marked **latest** |
| Preview | `1.x.y-preview-z` | CI, every 3h off `master` when there are new commits | **prerelease**, never latest |

## Update behavior (revised per Sachin)

- **Default: stable.** Auto-update and `af upgrade` only consider stable `1.x.y` releases. Existing installs and fresh `install.sh` installs stay on stable and only move when Sachin cuts a stable release. Nobody is switched to preview builds without opting in.
- **Opt-in: preview.** Setting the new global config key `"update_channel": "preview"` makes auto-update and `af upgrade` also consider `1.x.y-preview-z` prereleases (normally the newest tag — this is the 3h auto-update path). `update_channel` is validated like the other global keys (`stable` default; unknown values warn and fall back to `stable`), materialized into first-run `config.json`, and **rejected in in-repo configs** (global-only — a repo must not be able to flip a host's update channel).
- On the stable channel a release is skipped if *either* GitHub's prerelease flag *or* a `-preview-N` tag suffix marks it as a preview (belt and braces). A preview-channel user switching back to stable is never downgraded: `isNewer` won't move `1.1.1-preview-3` back to `1.1.0`; they pick up the next stable when it lands.

### Version scheme (the one deliberate design choice)

Previews are based on the **next patch after the latest stable**: after stable `1.1.0`, previews are `1.1.1-preview-1`, `1.1.1-preview-2`, … This keeps ordering **standard semver** (a prerelease sorts below its own release), so no custom "preview beats its base" hacks are needed anywhere:

```
1.1.0 < 1.1.1-preview-1 < 1.1.1-preview-2 < 1.1.1 ≤ any newer stable
```

`z` resets to 1 automatically when a new stable changes the base. Bonus: releasing the current preview base as-is (e.g. stable `1.0.138` while `1.0.138-preview-9` exists) cleanly **promotes** what the preview channel has been testing. First preview after this merges: `1.0.138-preview-1`.

## Changes

- **`.github/workflows/auto-release.yml`** — no longer bumps `main.go`/commits to master. Computes the next preview tag via `.github/scripts/next-preview-version.sh`, tags, builds with `-ldflags -X main.version=…`, publishes with `--prerelease` and **without** `--latest`. Preflight (gofmt/vet/race tests/build) unchanged.
- **`.github/workflows/stable-release.yml`** (new) — `workflow_dispatch` with a `version` input. Validates via `.github/scripts/validate-stable-version.sh` (well-formed, untagged, strictly greater than the latest stable), runs the same preflight, commits the `main.go` bump (`chore: release v1.x.y`), tags, publishes with `--latest`. Version input passed via `env` (no expression injection); `sed` result is grep-verified so formatting drift fails loudly instead of shipping a stale embedded version.
- **`config/`** — new `update_channel` key on the global config (`stable` | `preview`, default `stable`): defaulted in `DefaultConfig`, validated in `parseConfig` (warn + fall back like `log_max_size_mb`), added to `inRepoGlobalOnlyKeys` so in-repo files reject it by name.
- **`autoupdate.go`** — `releases/latest` only ever returns stable releases and its `latest/download` redirect can't serve prereleases, so the updater lists `/releases?per_page=100`, picks the version-newest non-draft tag **on the configured channel** (`pickLatestReleaseTag`), and downloads **by tag**. `updateChannel()` reads the config tolerantly — any load error falls back to stable so a broken config never blocks or redirects an update. `parseSemver` handles the `-preview-N` suffix (anything else non-empty fails to parse → never an update target); `isNewer` implements the ordering above. Throttle, #459 record-before-fetch, Windows skip (#1002), and shutdown+respawn after swap (#498/#813) are untouched — the existing regression tests pass with only the seam-signature change.
- **`upgrade.go`** — `af upgrade` resolves through the same configured channel; leaving it on `latest/download` would have silently **downgraded** preview-channel users back to the older stable.
- **`main.go`** — `version` var documented as the dev-build fallback; stable releases keep committing it, previews never touch it.
- **Docs** — new `docs/release-process.md` (scheme, both workflows, channel semantics); `docs/configuration.md` documents `update_channel` (global-only table updated); README install/maintenance blurbs; release-testing-plan updated for the two workflows and channel-aware artifact verification.

## Tests (hermetic — no network, no real releases)

- `TestIsNewer` extended: `-preview-z` monotonic (incl. 9→10 numeric), stable-beats-its-previews and never the reverse, preview-off-newer-base beats old stable, migration case `1.0.138-preview-1 > 1.0.137`, malformed/unknown suffixes rejected.
- `TestPickLatestReleaseTag` (channel-aware): stable channel skips previews by flag **and** by tag shape, returns nothing when only previews exist; preview channel includes prereleases; drafts/junk skipped; order-independent; fresh-stable-wins; promoted-base-wins.
- `TestAutoUpdateChannelFromConfig`: end-to-end through the real config read — no config / key absent / invalid value → `stable`; `"preview"` → preview.
- `config`: `update_channel` default + validation fallback table, materialization into first-run `config.json`, and in-repo rejection (added to the global-only-keys test loop).
- `TestAutoUpdateDownloadsByTag`: asserts the tag-addressed download URL.
- `release_scripts_test.go`: drives both shell scripts with tag fixtures on stdin — z-increment, z-reset on new stable, numeric-not-lexical ordering, junk-tag immunity, and all validate-reject paths.

## Verification

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --fast` · `deadcode -test ./...` clean · `go test ./...` green with `AGENT_FACTORY_HOME=$(mktemp -d)` · `go test -race` on the touched packages (root, config) · `actionlint` v1.7.12 clean on all workflows. No releases/tags were created; the real daemon was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude
