### PR TITLE
tui: layout engine — Rect/Grid, Pane interface, focus ring, zone registry (#1024, epic PR 1)

### DIFF
--- a/ui/layout/clamp.go
+++ b/ui/layout/clamp.go
@@ -1,0 +1,52 @@
+package layout
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
+)
+
+// ClampToRect pads and truncates s to exactly r.W×r.H terminal cells: the
+// result is exactly r.H lines, each exactly r.W printable columns. This is
+// the shared enforcement helper for the Pane contract "View() is exactly
+// Rect-sized" (RFC §2.6), replacing the per-pane ad-hoc clamps.
+//
+// Truncation keeps the first r.H lines and the leading r.W columns of each
+// line — a View renders top-down, so overflow is always trailing chrome;
+// callers with keep-newest semantics (scrollback) trim before clamping.
+// Width handling is ANSI- and wide-rune-aware: escape sequences are
+// preserved and measured at zero width, and a truncated styled line gets a
+// reset appended so leaked styles cannot bleed into the padding or the
+// neighboring region. Only r's size is used; its position is ignored.
+//
+// An empty rect clamps everything to "".
+func ClampToRect(s string, r Rect) string {
+	if r.Empty() {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) > r.H {
+		lines = lines[:r.H]
+	}
+	out := make([]string, r.H)
+	for i := range out {
+		var line string
+		if i < len(lines) {
+			line = lines[i]
+		}
+		width := lipgloss.Width(line)
+		if width > r.W {
+			line = xansi.Truncate(line, r.W, "")
+			if strings.Contains(line, "\x1b") {
+				line += "\x1b[0m"
+			}
+			width = lipgloss.Width(line)
+		}
+		if width < r.W {
+			line += strings.Repeat(" ", r.W-width)
+		}
+		out[i] = line
+	}
+	return strings.Join(out, "\n")
+}

--- a/ui/layout/clamp_test.go
+++ b/ui/layout/clamp_test.go
@@ -1,0 +1,113 @@
+package layout_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+)
+
+// requireExactSize asserts the ClampToRect contract: exactly h lines, each
+// exactly w printable columns.
+func requireExactSize(t *testing.T, s string, w, h int) {
+	t.Helper()
+	lines := strings.Split(s, "\n")
+	require.Len(t, lines, h)
+	for i, line := range lines {
+		require.Equal(t, w, lipgloss.Width(line), "line %d: %q", i, line)
+	}
+}
+
+func TestClampToRectPadsUndersized(t *testing.T) {
+	r := layout.Rect{W: 10, H: 4}
+
+	out := layout.ClampToRect("hi", r)
+	requireExactSize(t, out, 10, 4)
+	lines := strings.Split(out, "\n")
+	assert.Equal(t, "hi        ", lines[0])
+	assert.Equal(t, strings.Repeat(" ", 10), lines[1], "missing lines pad as blanks")
+
+	requireExactSize(t, layout.ClampToRect("", r), 10, 4)
+}
+
+func TestClampToRectTruncatesOversized(t *testing.T) {
+	r := layout.Rect{W: 5, H: 2}
+
+	out := layout.ClampToRect("abcdefghij\nklm\nnop\nqrs", r)
+	requireExactSize(t, out, 5, 2)
+	lines := strings.Split(out, "\n")
+	assert.Equal(t, "abcde", lines[0], "over-wide line truncates to width")
+	assert.Equal(t, "klm  ", lines[1], "over-tall input keeps the first H lines")
+}
+
+func TestClampToRectExactFitUnchanged(t *testing.T) {
+	in := "abcde\nfghij"
+	out := layout.ClampToRect(in, layout.Rect{W: 5, H: 2})
+	assert.Equal(t, in, out, "exactly-sized content passes through untouched")
+}
+
+func TestClampToRectMultilineMixed(t *testing.T) {
+	// Simultaneously over-wide, under-wide, and under-tall.
+	out := layout.ClampToRect("way-too-long-line\nok", layout.Rect{W: 8, H: 3})
+	requireExactSize(t, out, 8, 3)
+	lines := strings.Split(out, "\n")
+	assert.Equal(t, "way-too-", lines[0])
+	assert.Equal(t, "ok      ", lines[1])
+	assert.Equal(t, "        ", lines[2])
+}
+
+func TestClampToRectWideRunes(t *testing.T) {
+	// Each CJK rune is 2 columns; "日本語のテスト" is 14 columns.
+	out := layout.ClampToRect("日本語のテスト", layout.Rect{W: 5, H: 1})
+	requireExactSize(t, out, 5, 1)
+	assert.True(t, strings.HasPrefix(out, "日本"),
+		"wide runes survive truncation intact: %q", out)
+	assert.NotContains(t, out, "語",
+		"the rune straddling the boundary is dropped, not split")
+
+	// A wide rune straddling the edge leaves a 1-column gap that must be
+	// padded to the exact width.
+	requireExactSize(t, layout.ClampToRect("ああ", layout.Rect{W: 3, H: 1}), 3, 1)
+}
+
+func TestClampToRectANSIStyled(t *testing.T) {
+	styled := "\x1b[31mred\x1b[0m plain \x1b[1;32mbold-green\x1b[0m"
+
+	// Padding: ANSI is zero-width, styling preserved.
+	out := layout.ClampToRect(styled, layout.Rect{W: 30, H: 2})
+	requireExactSize(t, out, 30, 2)
+	assert.Contains(t, out, "\x1b[31mred\x1b[0m", "styling survives padding")
+
+	// Truncation mid-styled-run: width exact, style terminated so it cannot
+	// bleed into padding or the neighboring region.
+	out = layout.ClampToRect(styled, layout.Rect{W: 6, H: 1})
+	requireExactSize(t, out, 6, 1)
+	assert.Contains(t, out, "\x1b[31m", "styling survives truncation")
+	assert.True(t, strings.HasSuffix(out, "\x1b[0m") || strings.HasSuffix(out, "m"),
+		"truncated styled line is reset-terminated: %q", out)
+	trailing := out[strings.LastIndex(out, "m")+1:]
+	assert.Equal(t, strings.Repeat(" ", len(trailing)), trailing, "padding is unstyled")
+}
+
+func TestClampToRectEmptyRect(t *testing.T) {
+	assert.Equal(t, "", layout.ClampToRect("content", layout.Rect{}))
+	assert.Equal(t, "", layout.ClampToRect("content", layout.Rect{W: 5}))
+	assert.Equal(t, "", layout.ClampToRect("content", layout.Rect{H: 5}))
+	assert.Equal(t, "", layout.ClampToRect("content", layout.Rect{W: -2, H: 3}))
+}
+
+// TestClampToRectMatchesGridRegions ties the two halves of the §2.6
+// contract together: content clamped to a solved region renders exactly
+// that region's size.
+func TestClampToRectMatchesGridRegions(t *testing.T) {
+	l := layout.Grid{Split: true}.Solve(140, 40)
+	require.False(t, l.Fallback)
+	for id, r := range l.VisibleRegions() {
+		out := layout.ClampToRect("some\ncontent\nfor "+id, r)
+		requireExactSize(t, out, r.W, r.H)
+	}
+}

--- a/ui/layout/doc.go
+++ b/ui/layout/doc.go
@@ -1,0 +1,13 @@
+// Package layout is the TUI layout engine for the multi-pane rewrite
+// (docs/design/tui-rewrite.md, epic #1024).
+//
+// It is pure, self-contained infrastructure: the Rect/Point geometry core,
+// the Grid region solver with the §2.6 degradation ladder, the Pane
+// interface every workspace region implements (§2.2), the focus Ring
+// (§2.3), and the shared exact-Rect ClampToRect sizing helper. Mouse
+// hit-testing lives in the zones subpackage (§2.5).
+//
+// Nothing here is wired into app/ yet — that happens in the later PRs of
+// the phased plan (§4). Until then the package is kept alive by its own
+// tests.
+package layout

--- a/ui/layout/grid.go
+++ b/ui/layout/grid.go
@@ -1,0 +1,147 @@
+package layout
+
+// Region identifiers for the named layout regions. These double as focus
+// ring ids (§2.3) and as the pane component of zone ids (§2.5).
+const (
+	RegionTree        = "tree"
+	RegionPaneA       = "paneA"
+	RegionPaneB       = "paneB"
+	RegionDivider     = "divider"
+	RegionAutomations = "automations"
+	RegionStatusBar   = "status"
+)
+
+// Sizing constants and degradation-ladder thresholds (RFC §2.6). A feature
+// named by a *Min* threshold is available at sizes >= the threshold and
+// degrades below it.
+const (
+	// TreeMinWidth / TreeMaxWidth clamp the left rail: clamp(24, 30%·W, 44).
+	TreeMinWidth = 24
+	TreeMaxWidth = 44
+
+	// StatusBarRows is the fixed status-bar height.
+	StatusBarRows = 2
+
+	// AutomationsRows is the full automations-strip height;
+	// AutomationsCompactRows is its 1-line-summary height when the terminal
+	// is tight.
+	AutomationsRows        = 3
+	AutomationsCompactRows = 1
+
+	// SplitMinWidth: below this a requested split collapses to pane A (the
+	// caller retains pane B's binding and restores it on grow).
+	SplitMinWidth = 110
+
+	// AutomationsFullMinWidth / AutomationsFullMinHeight: below either the
+	// automations strip collapses to the 1-line summary.
+	AutomationsFullMinWidth  = 80
+	AutomationsFullMinHeight = 20
+
+	// MinimalWidth / MinimalHeight: below either the layout drops to
+	// minimal mode — tree + single pane + status bar only (no automations
+	// strip, split never honored).
+	MinimalWidth  = 60
+	MinimalHeight = 15
+
+	// HardMinWidth / HardMinHeight: below either no layout is produced;
+	// Layout.Fallback signals the caller to render the fallback banner
+	// (ui/fallback.go).
+	HardMinWidth  = 40
+	HardMinHeight = 10
+)
+
+// Grid is the single sizing authority for the multi-pane TUI (§2.6): it
+// turns a terminal size into the set of region rects, applying the
+// degradation ladder as the terminal shrinks.
+type Grid struct {
+	// Split requests a two-pane workspace. It is honored only when the
+	// terminal is wide enough (>= SplitMinWidth) and not in minimal mode;
+	// otherwise the workspace is pane A alone and the caller keeps pane B's
+	// binding for when the terminal grows back.
+	Split bool
+}
+
+// Layout is a solved arrangement: the named region rects plus which regions
+// are visible at this size. Hidden regions have zero rects. Unless Fallback
+// is set, the visible regions exactly tile the Width×Height screen.
+type Layout struct {
+	Width  int
+	Height int
+
+	// Fallback is set below the hard minimum size: no regions are laid
+	// out and the caller should render the fallback banner instead.
+	Fallback bool
+
+	Tree        Rect
+	PaneA       Rect
+	Divider     Rect
+	PaneB       Rect
+	Automations Rect
+	StatusBar   Rect
+
+	// SplitActive reports whether the split was honored (PaneB and Divider
+	// are visible).
+	SplitActive bool
+	// AutomationsVisible reports whether the automations strip is shown at
+	// all; AutomationsCompact whether it is the 1-line summary.
+	AutomationsVisible bool
+	AutomationsCompact bool
+}
+
+// Solve lays out a width×height terminal.
+func (g Grid) Solve(width, height int) Layout {
+	l := Layout{Width: width, Height: height}
+	if width < HardMinWidth || height < HardMinHeight {
+		l.Fallback = true
+		return l
+	}
+
+	minimal := width < MinimalWidth || height < MinimalHeight
+
+	rem, statusBar := Rect{X: 0, Y: 0, W: width, H: height}.CutBottom(StatusBarRows)
+	l.StatusBar = statusBar
+
+	if !minimal {
+		l.AutomationsVisible = true
+		l.AutomationsCompact = width < AutomationsFullMinWidth || height < AutomationsFullMinHeight
+		rows := AutomationsRows
+		if l.AutomationsCompact {
+			rows = AutomationsCompactRows
+		}
+		rem, l.Automations = rem.CutBottom(rows)
+	}
+
+	treeWidth := clampInt(width*30/100, TreeMinWidth, TreeMaxWidth)
+	tree, workspace := rem.CutLeft(treeWidth)
+	l.Tree = tree
+
+	if g.Split && !minimal && width >= SplitMinWidth {
+		l.SplitActive = true
+		paneA, rest := workspace.CutLeft((workspace.W - 1) / 2)
+		l.PaneA = paneA
+		l.Divider, l.PaneB = rest.CutLeft(1)
+	} else {
+		l.PaneA = workspace
+	}
+	return l
+}
+
+// VisibleRegions returns the regions visible at this size, keyed by region
+// id. Fallback layouts have none.
+func (l Layout) VisibleRegions() map[string]Rect {
+	regions := make(map[string]Rect)
+	if l.Fallback {
+		return regions
+	}
+	regions[RegionTree] = l.Tree
+	regions[RegionPaneA] = l.PaneA
+	regions[RegionStatusBar] = l.StatusBar
+	if l.SplitActive {
+		regions[RegionDivider] = l.Divider
+		regions[RegionPaneB] = l.PaneB
+	}
+	if l.AutomationsVisible {
+		regions[RegionAutomations] = l.Automations
+	}
+	return regions
+}

--- a/ui/layout/grid_test.go
+++ b/ui/layout/grid_test.go
@@ -1,0 +1,298 @@
+package layout_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+)
+
+// ladderLevel orders the degradation ladder for monotonicity checks: higher
+// means more degraded. Levels follow RFC §2.6: full → split collapsed →
+// compact automations → minimal → fallback.
+func ladderLevel(l layout.Layout) int {
+	switch {
+	case l.Fallback:
+		return 4
+	case !l.AutomationsVisible:
+		return 3
+	case l.AutomationsCompact:
+		return 2
+	case !l.SplitActive:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// TestGridSolveTilesExactly sweeps the full supported size range, with and
+// without a split requested, and asserts the visible regions exactly tile
+// the terminal: no overlap, no gaps, no negative dimensions, nothing
+// outside the screen.
+func TestGridSolveTilesExactly(t *testing.T) {
+	for _, split := range []bool{false, true} {
+		grid := layout.Grid{Split: split}
+		for w := layout.HardMinWidth; w <= 220; w++ {
+			for h := layout.HardMinHeight; h <= 72; h++ {
+				l := grid.Solve(w, h)
+				require.False(t, l.Fallback, "unexpected fallback at %dx%d", w, h)
+
+				screen := layout.Rect{X: 0, Y: 0, W: w, H: h}
+				visible := l.VisibleRegions()
+				parts := make([]layout.Rect, 0, len(visible))
+				for id, r := range visible {
+					require.False(t, r.Empty(), "visible region %s is empty at %dx%d split=%v", id, w, h, split)
+					parts = append(parts, r)
+				}
+				requireTiles(t, screen, parts)
+			}
+		}
+	}
+}
+
+func TestGridSolveFallbackBelowHardMinimum(t *testing.T) {
+	tests := []struct {
+		w, h     int
+		fallback bool
+	}{
+		{layout.HardMinWidth, layout.HardMinHeight, false},
+		{layout.HardMinWidth - 1, 50, true},
+		{200, layout.HardMinHeight - 1, true},
+		{layout.HardMinWidth - 1, layout.HardMinHeight - 1, true},
+		{0, 0, true},
+		{-5, 24, true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%dx%d", tt.w, tt.h), func(t *testing.T) {
+			l := layout.Grid{Split: true}.Solve(tt.w, tt.h)
+			assert.Equal(t, tt.fallback, l.Fallback)
+			if tt.fallback {
+				assert.Empty(t, l.VisibleRegions(), "fallback layout must expose no regions")
+				assert.False(t, l.SplitActive)
+				assert.False(t, l.AutomationsVisible)
+			}
+		})
+	}
+}
+
+func TestGridSolveSplitThreshold(t *testing.T) {
+	at := layout.Grid{Split: true}.Solve(layout.SplitMinWidth, 40)
+	require.True(t, at.SplitActive, "split honored at %d cols", layout.SplitMinWidth)
+	assert.False(t, at.PaneB.Empty())
+	assert.Equal(t, 1, at.Divider.W, "divider is exactly one column")
+	assert.InDelta(t, at.PaneA.W, at.PaneB.W, 1, "split divides the workspace evenly")
+	assert.Equal(t, at.Width-at.Tree.W, at.PaneA.W+at.Divider.W+at.PaneB.W,
+		"panes plus divider fill the workspace")
+
+	below := layout.Grid{Split: true}.Solve(layout.SplitMinWidth-1, 40)
+	require.False(t, below.SplitActive, "split collapses below %d cols", layout.SplitMinWidth)
+	assert.True(t, below.PaneB.Empty())
+	assert.True(t, below.Divider.Empty())
+	assert.Equal(t, below.Width-below.Tree.W, below.PaneA.W, "pane A takes the whole workspace")
+
+	unrequested := layout.Grid{}.Solve(200, 40)
+	assert.False(t, unrequested.SplitActive, "no split unless requested")
+	assert.True(t, unrequested.PaneB.Empty())
+}
+
+func TestGridSolveAutomationsThresholds(t *testing.T) {
+	full := layout.Grid{}.Solve(layout.AutomationsFullMinWidth, 40)
+	require.True(t, full.AutomationsVisible)
+	assert.False(t, full.AutomationsCompact)
+	assert.Equal(t, layout.AutomationsRows, full.Automations.H)
+
+	narrowCompact := layout.Grid{}.Solve(layout.AutomationsFullMinWidth-1, 40)
+	require.True(t, narrowCompact.AutomationsVisible)
+	assert.True(t, narrowCompact.AutomationsCompact, "strip compacts below %d cols", layout.AutomationsFullMinWidth)
+	assert.Equal(t, layout.AutomationsCompactRows, narrowCompact.Automations.H)
+
+	shortCompact := layout.Grid{}.Solve(120, layout.AutomationsFullMinHeight-1)
+	require.True(t, shortCompact.AutomationsVisible)
+	assert.True(t, shortCompact.AutomationsCompact, "strip compacts below %d rows", layout.AutomationsFullMinHeight)
+	assert.Equal(t, layout.AutomationsCompactRows, shortCompact.Automations.H)
+}
+
+func TestGridSolveMinimalMode(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		w, h int
+	}{
+		{"narrow", layout.MinimalWidth - 1, 40},
+		{"short", 200, layout.MinimalHeight - 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			l := layout.Grid{Split: true}.Solve(tt.w, tt.h)
+			require.False(t, l.Fallback)
+			assert.False(t, l.AutomationsVisible, "minimal mode hides the automations strip")
+			assert.True(t, l.Automations.Empty())
+			assert.False(t, l.SplitActive, "minimal mode never honors a split")
+			assert.False(t, l.Tree.Empty(), "tree survives minimal mode")
+			assert.False(t, l.PaneA.Empty(), "pane A survives minimal mode")
+			assert.False(t, l.StatusBar.Empty(), "status bar survives minimal mode")
+		})
+	}
+
+	above := layout.Grid{}.Solve(layout.MinimalWidth, layout.MinimalHeight)
+	assert.True(t, above.AutomationsVisible, "automations return at exactly %dx%d",
+		layout.MinimalWidth, layout.MinimalHeight)
+}
+
+func TestGridSolveTreeWidthClamp(t *testing.T) {
+	tests := []struct {
+		w    int
+		want int
+	}{
+		{60, layout.TreeMinWidth},  // 30% = 18 → clamped up to 24
+		{80, layout.TreeMinWidth},  // 30% = 24 → exactly the minimum
+		{100, 30},                  // 30% in range
+		{120, 36},                  // 30% in range
+		{146, 43},                  // 30% = 43.8, integer math
+		{150, layout.TreeMaxWidth}, // 30% = 45 → clamped down to 44
+		{220, layout.TreeMaxWidth},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("w=%d", tt.w), func(t *testing.T) {
+			l := layout.Grid{}.Solve(tt.w, 40)
+			assert.Equal(t, tt.want, l.Tree.W)
+		})
+	}
+}
+
+func TestGridSolveStatusBarFixedHeight(t *testing.T) {
+	for _, size := range [][2]int{{40, 10}, {59, 14}, {80, 24}, {200, 60}} {
+		l := layout.Grid{Split: true}.Solve(size[0], size[1])
+		require.False(t, l.Fallback)
+		assert.Equal(t, layout.StatusBarRows, l.StatusBar.H, "at %v", size)
+		assert.Equal(t, size[0], l.StatusBar.W, "status bar spans the full width at %v", size)
+		assert.Equal(t, size[1], l.StatusBar.Bottom(), "status bar sits at the bottom at %v", size)
+	}
+}
+
+// TestGridSolveLadderMonotonic shrinks each axis one cell at a time and
+// asserts the degradation level never decreases: shrinking can never
+// re-enable a richer mode.
+func TestGridSolveLadderMonotonic(t *testing.T) {
+	grid := layout.Grid{Split: true}
+
+	prev := -1
+	for w := 220; w >= 1; w-- {
+		lvl := ladderLevel(grid.Solve(w, 40))
+		require.GreaterOrEqual(t, lvl, prev, "ladder regressed shrinking width to %d", w)
+		prev = lvl
+	}
+
+	prev = -1
+	for h := 72; h >= 1; h-- {
+		lvl := ladderLevel(grid.Solve(200, h))
+		require.GreaterOrEqual(t, lvl, prev, "ladder regressed shrinking height to %d", h)
+		prev = lvl
+	}
+}
+
+// TestGridSolveChromeNeverGrowsOnShrink asserts the global monotonicity
+// contract of the ladder: chrome (tree width, automations height, status
+// height) only ever gives way as the terminal shrinks — it never grows.
+// (Content panes CAN grow across ladder transitions: that is the point of
+// degradation — pane A absorbs pane B below SplitMinWidth, the workspace
+// reclaims the automations rows when the strip compacts.)
+func TestGridSolveChromeNeverGrowsOnShrink(t *testing.T) {
+	grid := layout.Grid{Split: true}
+
+	check := func(t *testing.T, cur, prev layout.Layout) {
+		t.Helper()
+		require.LessOrEqual(t, cur.Tree.W, prev.Tree.W,
+			"tree grew shrinking %dx%d→%dx%d", prev.Width, prev.Height, cur.Width, cur.Height)
+		require.LessOrEqual(t, cur.Automations.H, prev.Automations.H,
+			"automations grew shrinking %dx%d→%dx%d", prev.Width, prev.Height, cur.Width, cur.Height)
+		require.LessOrEqual(t, cur.StatusBar.H, prev.StatusBar.H,
+			"status bar grew shrinking %dx%d→%dx%d", prev.Width, prev.Height, cur.Width, cur.Height)
+	}
+
+	prev := grid.Solve(220, 40)
+	for w := 219; w >= 1; w-- {
+		cur := grid.Solve(w, 40)
+		check(t, cur, prev)
+		prev = cur
+	}
+
+	prev = grid.Solve(200, 72)
+	for h := 71; h >= 1; h-- {
+		cur := grid.Solve(200, h)
+		check(t, cur, prev)
+		prev = cur
+	}
+}
+
+// TestGridSolveRegionsMonotonicWithinLevel asserts that between two
+// adjacent sizes in the same degradation state, shrinking never grows any
+// region dimension. (Across ladder transitions content legitimately grows —
+// pane A absorbs pane B, the workspace reclaims automations rows — see
+// TestGridSolveChromeNeverGrowsOnShrink for the global invariant.)
+func TestGridSolveRegionsMonotonicWithinLevel(t *testing.T) {
+	grid := layout.Grid{Split: true}
+
+	sameState := func(a, b layout.Layout) bool {
+		return a.Fallback == b.Fallback &&
+			a.SplitActive == b.SplitActive &&
+			a.AutomationsVisible == b.AutomationsVisible &&
+			a.AutomationsCompact == b.AutomationsCompact
+	}
+	check := func(t *testing.T, cur, prev layout.Layout) {
+		t.Helper()
+		if !sameState(cur, prev) || cur.Fallback {
+			return
+		}
+		prevRegions := prev.VisibleRegions()
+		for id, r := range cur.VisibleRegions() {
+			pr, ok := prevRegions[id]
+			require.True(t, ok, "region %s appeared on shrink at %dx%d", id, cur.Width, cur.Height)
+			require.LessOrEqual(t, r.W, pr.W, "region %s width grew shrinking to %dx%d", id, cur.Width, cur.Height)
+			require.LessOrEqual(t, r.H, pr.H, "region %s height grew shrinking to %dx%d", id, cur.Width, cur.Height)
+		}
+	}
+
+	for h := 10; h <= 72; h += 7 {
+		prev := grid.Solve(220, h)
+		for w := 219; w >= layout.HardMinWidth; w-- {
+			cur := grid.Solve(w, h)
+			check(t, cur, prev)
+			prev = cur
+		}
+	}
+	for w := 40; w <= 220; w += 9 {
+		prev := grid.Solve(w, 72)
+		for h := 71; h >= layout.HardMinHeight; h-- {
+			cur := grid.Solve(w, h)
+			check(t, cur, prev)
+			prev = cur
+		}
+	}
+}
+
+func TestGridVisibleRegionsMatchFlags(t *testing.T) {
+	l := layout.Grid{Split: true}.Solve(160, 48)
+	require.True(t, l.SplitActive)
+	require.True(t, l.AutomationsVisible)
+	regions := l.VisibleRegions()
+	assert.Len(t, regions, 6)
+	assert.Equal(t, l.Tree, regions[layout.RegionTree])
+	assert.Equal(t, l.PaneA, regions[layout.RegionPaneA])
+	assert.Equal(t, l.PaneB, regions[layout.RegionPaneB])
+	assert.Equal(t, l.Divider, regions[layout.RegionDivider])
+	assert.Equal(t, l.Automations, regions[layout.RegionAutomations])
+	assert.Equal(t, l.StatusBar, regions[layout.RegionStatusBar])
+
+	single := layout.Grid{}.Solve(160, 48)
+	regions = single.VisibleRegions()
+	assert.Len(t, regions, 4)
+	assert.NotContains(t, regions, layout.RegionPaneB)
+	assert.NotContains(t, regions, layout.RegionDivider)
+
+	minimal := layout.Grid{}.Solve(50, 12)
+	regions = minimal.VisibleRegions()
+	assert.Len(t, regions, 3)
+	assert.NotContains(t, regions, layout.RegionAutomations)
+}

--- a/ui/layout/main_test.go
+++ b/ui/layout/main_test.go
@@ -1,0 +1,24 @@
+package layout_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+func TestMain(m *testing.M) {
+	// Repo-wide test hygiene (#837/#1056): tripwire the real config.json and
+	// sandbox AGENT_FACTORY_HOME. This package is pure and touches neither,
+	// but the guards keep that a verified invariant rather than a hope.
+	verifyRealConfig := testguard.ConfigTripwire()
+	restoreHome := testguard.SandboxHome()
+	code := m.Run()
+	restoreHome()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
+}

--- a/ui/layout/pane.go
+++ b/ui/layout/pane.go
@@ -1,0 +1,28 @@
+package layout
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// Pane is the contract every workspace region implements (RFC §2.2). The
+// root model owns layout and routing; a pane only renders its rect and
+// reacts to the input the root dispatches to it.
+type Pane interface {
+	// SetRect tells the pane where it lives; View must render exactly this
+	// size (ClampToRect is the shared enforcement helper).
+	SetRect(r Rect)
+
+	Focused() bool
+	Focus()
+	Blur()
+
+	// HandleKey processes a key when the pane is focused. The bool reports
+	// whether the key was consumed; unconsumed keys bubble to the root's
+	// global bindings.
+	HandleKey(msg tea.KeyMsg) (tea.Cmd, bool)
+
+	// HandleMouse processes a mouse event hit-tested into this pane; p is
+	// in pane-local coordinates (see zones.Registry.Resolve).
+	HandleMouse(msg tea.MouseMsg, p Point) tea.Cmd
+
+	// View renders the pane, exactly Rect-sized (hard-clamped).
+	View() string
+}

--- a/ui/layout/pane_test.go
+++ b/ui/layout/pane_test.go
@@ -1,0 +1,121 @@
+package layout_test
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+// stubPane is a minimal Pane implementation exercising the §2.2 contract
+// the way real panes will: it records dispatched input and hard-clamps its
+// View to its rect via ClampToRect.
+type stubPane struct {
+	rect    layout.Rect
+	focused bool
+	content string
+	consume bool
+
+	keys  []string
+	mouse []layout.Point
+}
+
+var _ layout.Pane = (*stubPane)(nil)
+
+func (p *stubPane) SetRect(r layout.Rect) { p.rect = r }
+func (p *stubPane) Focused() bool         { return p.focused }
+func (p *stubPane) Focus()                { p.focused = true }
+func (p *stubPane) Blur()                 { p.focused = false }
+
+func (p *stubPane) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
+	p.keys = append(p.keys, msg.String())
+	return nil, p.consume
+}
+
+func (p *stubPane) HandleMouse(_ tea.MouseMsg, pt layout.Point) tea.Cmd {
+	p.mouse = append(p.mouse, pt)
+	return nil
+}
+
+func (p *stubPane) View() string {
+	return layout.ClampToRect(p.content, p.rect)
+}
+
+func TestPaneFocusLifecycle(t *testing.T) {
+	var pane layout.Pane = &stubPane{}
+
+	assert.False(t, pane.Focused())
+	pane.Focus()
+	assert.True(t, pane.Focused())
+	pane.Blur()
+	assert.False(t, pane.Focused())
+}
+
+func TestPaneHandleKeyConsumption(t *testing.T) {
+	stub := &stubPane{consume: true}
+	var pane layout.Pane = stub
+
+	cmd, consumed := pane.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	assert.Nil(t, cmd)
+	assert.True(t, consumed, "pane reports the key as consumed")
+
+	stub.consume = false
+	_, consumed = pane.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	assert.False(t, consumed, "unconsumed keys bubble to global bindings")
+
+	assert.Equal(t, []string{"j", "q"}, stub.keys)
+}
+
+// TestPaneViewIsExactlyRectSized is the Pane-contract check the RFC (§2.6)
+// makes shared test infrastructure: whatever the content, View() renders
+// exactly the rect handed to SetRect.
+func TestPaneViewIsExactlyRectSized(t *testing.T) {
+	contents := []string{
+		"",
+		"short",
+		strings.Repeat("very long line that overflows any pane width ", 8),
+		strings.Repeat("many\nlines\n", 30),
+	}
+
+	l := layout.Grid{Split: true}.Solve(132, 43)
+	require.False(t, l.Fallback)
+	for _, r := range l.VisibleRegions() {
+		for _, content := range contents {
+			var pane layout.Pane = &stubPane{content: content}
+			pane.SetRect(r)
+			requireExactSize(t, pane.View(), r.W, r.H)
+		}
+	}
+}
+
+// TestPaneMouseDispatchViaZones mirrors the root model's §2.5 mouse
+// routing: hit-test the click through a zone registry, then hand the pane
+// the zone-local point.
+func TestPaneMouseDispatchViaZones(t *testing.T) {
+	l := layout.Grid{}.Solve(120, 40)
+	require.False(t, l.Fallback)
+
+	panes := map[string]*stubPane{}
+	reg := zones.NewRegistry()
+	for id, r := range l.VisibleRegions() {
+		pane := &stubPane{}
+		pane.SetRect(r)
+		panes[id] = pane
+		reg.Register(id, r)
+	}
+
+	click := tea.MouseMsg{X: l.PaneA.X + 7, Y: l.PaneA.Y + 3, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft}
+	id, local, ok := reg.Resolve(click.X, click.Y)
+	require.True(t, ok)
+	require.Equal(t, layout.RegionPaneA, id)
+
+	var target layout.Pane = panes[id]
+	assert.Nil(t, target.HandleMouse(click, local))
+	assert.Equal(t, []layout.Point{{X: 7, Y: 3}}, panes[id].mouse,
+		"pane receives pane-local coordinates")
+}

--- a/ui/layout/rect.go
+++ b/ui/layout/rect.go
@@ -1,0 +1,81 @@
+package layout
+
+// Point is a screen position in terminal cell coordinates (column X, row Y).
+type Point struct {
+	X int
+	Y int
+}
+
+// Rect is an axis-aligned region of the terminal in cell coordinates. W and
+// H are sizes, not inclusive corners: the rect spans columns [X, X+W) and
+// rows [Y, Y+H).
+type Rect struct {
+	X int
+	Y int
+	W int
+	H int
+}
+
+// Empty reports whether the rect covers no cells.
+func (r Rect) Empty() bool { return r.W <= 0 || r.H <= 0 }
+
+// Right returns the exclusive right edge (first column past the rect).
+func (r Rect) Right() int { return r.X + r.W }
+
+// Bottom returns the exclusive bottom edge (first row past the rect).
+func (r Rect) Bottom() int { return r.Y + r.H }
+
+// Contains reports whether p falls inside the rect. Edges are half-open:
+// (X, Y) is inside, (Right(), Bottom()) is not.
+func (r Rect) Contains(p Point) bool {
+	return p.X >= r.X && p.X < r.Right() && p.Y >= r.Y && p.Y < r.Bottom()
+}
+
+// Local translates a screen point into rect-local coordinates.
+func (r Rect) Local(p Point) Point { return Point{X: p.X - r.X, Y: p.Y - r.Y} }
+
+// Intersects reports whether two rects share at least one cell. Empty rects
+// intersect nothing.
+func (r Rect) Intersects(o Rect) bool {
+	if r.Empty() || o.Empty() {
+		return false
+	}
+	return r.X < o.Right() && o.X < r.Right() && r.Y < o.Bottom() && o.Y < r.Bottom()
+}
+
+// CutLeft splits the rect into a left band of w columns and the remainder.
+// w is clamped to [0, r.W], so the two parts always tile r exactly.
+func (r Rect) CutLeft(w int) (left, rem Rect) {
+	w = clampInt(w, 0, r.W)
+	left = Rect{X: r.X, Y: r.Y, W: w, H: r.H}
+	rem = Rect{X: r.X + w, Y: r.Y, W: r.W - w, H: r.H}
+	return left, rem
+}
+
+// CutTop splits the rect into a top band of h rows and the remainder. h is
+// clamped to [0, r.H], so the two parts always tile r exactly.
+func (r Rect) CutTop(h int) (top, rem Rect) {
+	h = clampInt(h, 0, r.H)
+	top = Rect{X: r.X, Y: r.Y, W: r.W, H: h}
+	rem = Rect{X: r.X, Y: r.Y + h, W: r.W, H: r.H - h}
+	return top, rem
+}
+
+// CutBottom splits the rect into the remainder and a bottom band of h rows.
+// h is clamped to [0, r.H], so the two parts always tile r exactly.
+func (r Rect) CutBottom(h int) (rem, bottom Rect) {
+	h = clampInt(h, 0, r.H)
+	rem = Rect{X: r.X, Y: r.Y, W: r.W, H: r.H - h}
+	bottom = Rect{X: r.X, Y: r.Y + r.H - h, W: r.W, H: h}
+	return rem, bottom
+}
+
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/ui/layout/rect_test.go
+++ b/ui/layout/rect_test.go
@@ -1,0 +1,157 @@
+package layout_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+)
+
+func TestRectEmpty(t *testing.T) {
+	assert.False(t, layout.Rect{X: 0, Y: 0, W: 1, H: 1}.Empty())
+	assert.True(t, layout.Rect{}.Empty())
+	assert.True(t, layout.Rect{W: 5}.Empty())
+	assert.True(t, layout.Rect{H: 5}.Empty())
+	assert.True(t, layout.Rect{W: -1, H: 5}.Empty())
+	assert.True(t, layout.Rect{W: 5, H: -1}.Empty())
+}
+
+func TestRectRightBottom(t *testing.T) {
+	r := layout.Rect{X: 3, Y: 4, W: 10, H: 20}
+	assert.Equal(t, 13, r.Right())
+	assert.Equal(t, 24, r.Bottom())
+}
+
+func TestRectContains(t *testing.T) {
+	r := layout.Rect{X: 5, Y: 10, W: 4, H: 3} // cols 5..8, rows 10..12
+
+	tests := []struct {
+		name string
+		p    layout.Point
+		want bool
+	}{
+		{"top-left corner", layout.Point{X: 5, Y: 10}, true},
+		{"interior", layout.Point{X: 7, Y: 11}, true},
+		{"bottom-right inclusive cell", layout.Point{X: 8, Y: 12}, true},
+		{"right edge exclusive", layout.Point{X: 9, Y: 10}, false},
+		{"bottom edge exclusive", layout.Point{X: 5, Y: 13}, false},
+		{"left of rect", layout.Point{X: 4, Y: 11}, false},
+		{"above rect", layout.Point{X: 6, Y: 9}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, r.Contains(tt.p))
+		})
+	}
+
+	assert.False(t, layout.Rect{X: 5, Y: 5}.Contains(layout.Point{X: 5, Y: 5}),
+		"empty rect contains nothing")
+}
+
+func TestRectLocal(t *testing.T) {
+	r := layout.Rect{X: 5, Y: 10, W: 4, H: 3}
+	assert.Equal(t, layout.Point{X: 0, Y: 0}, r.Local(layout.Point{X: 5, Y: 10}))
+	assert.Equal(t, layout.Point{X: 3, Y: 2}, r.Local(layout.Point{X: 8, Y: 12}))
+}
+
+func TestRectIntersects(t *testing.T) {
+	base := layout.Rect{X: 0, Y: 0, W: 10, H: 10}
+
+	tests := []struct {
+		name  string
+		other layout.Rect
+		want  bool
+	}{
+		{"identical", base, true},
+		{"contained", layout.Rect{X: 2, Y: 2, W: 3, H: 3}, true},
+		{"corner overlap", layout.Rect{X: 9, Y: 9, W: 5, H: 5}, true},
+		{"touching right edge", layout.Rect{X: 10, Y: 0, W: 5, H: 10}, false},
+		{"touching bottom edge", layout.Rect{X: 0, Y: 10, W: 10, H: 5}, false},
+		{"disjoint", layout.Rect{X: 20, Y: 20, W: 5, H: 5}, false},
+		{"empty inside", layout.Rect{X: 5, Y: 5, W: 0, H: 3}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, base.Intersects(tt.other))
+			assert.Equal(t, tt.want, tt.other.Intersects(base), "intersection is symmetric")
+		})
+	}
+}
+
+// requireTiles asserts that parts exactly tile whole: pairwise disjoint,
+// each inside whole, and areas summing to whole's area.
+func requireTiles(t *testing.T, whole layout.Rect, parts []layout.Rect) {
+	t.Helper()
+	area := 0
+	for i, p := range parts {
+		require.GreaterOrEqual(t, p.W, 0, "part %d has negative width", i)
+		require.GreaterOrEqual(t, p.H, 0, "part %d has negative height", i)
+		if p.Empty() {
+			continue
+		}
+		require.GreaterOrEqual(t, p.X, whole.X, "part %d left of whole", i)
+		require.GreaterOrEqual(t, p.Y, whole.Y, "part %d above whole", i)
+		require.LessOrEqual(t, p.Right(), whole.Right(), "part %d overflows right", i)
+		require.LessOrEqual(t, p.Bottom(), whole.Bottom(), "part %d overflows bottom", i)
+		area += p.W * p.H
+		for j := i + 1; j < len(parts); j++ {
+			require.False(t, p.Intersects(parts[j]), "parts %d and %d overlap: %+v vs %+v", i, j, p, parts[j])
+		}
+	}
+	require.Equal(t, whole.W*whole.H, area, "parts do not cover the whole rect")
+}
+
+func TestRectCutLeft(t *testing.T) {
+	r := layout.Rect{X: 2, Y: 3, W: 10, H: 5}
+
+	left, rem := r.CutLeft(4)
+	assert.Equal(t, layout.Rect{X: 2, Y: 3, W: 4, H: 5}, left)
+	assert.Equal(t, layout.Rect{X: 6, Y: 3, W: 6, H: 5}, rem)
+	requireTiles(t, r, []layout.Rect{left, rem})
+
+	left, rem = r.CutLeft(99)
+	assert.Equal(t, r, left, "over-cut clamps to the whole rect")
+	assert.True(t, rem.Empty())
+	requireTiles(t, r, []layout.Rect{left, rem})
+
+	left, rem = r.CutLeft(-3)
+	assert.True(t, left.Empty(), "negative cut clamps to zero")
+	assert.Equal(t, r, rem)
+	requireTiles(t, r, []layout.Rect{left, rem})
+}
+
+func TestRectCutTop(t *testing.T) {
+	r := layout.Rect{X: 2, Y: 3, W: 10, H: 5}
+
+	top, rem := r.CutTop(2)
+	assert.Equal(t, layout.Rect{X: 2, Y: 3, W: 10, H: 2}, top)
+	assert.Equal(t, layout.Rect{X: 2, Y: 5, W: 10, H: 3}, rem)
+	requireTiles(t, r, []layout.Rect{top, rem})
+
+	top, rem = r.CutTop(99)
+	assert.Equal(t, r, top)
+	assert.True(t, rem.Empty())
+
+	top, rem = r.CutTop(-1)
+	assert.True(t, top.Empty())
+	assert.Equal(t, r, rem)
+}
+
+func TestRectCutBottom(t *testing.T) {
+	r := layout.Rect{X: 2, Y: 3, W: 10, H: 5}
+
+	rem, bottom := r.CutBottom(2)
+	assert.Equal(t, layout.Rect{X: 2, Y: 3, W: 10, H: 3}, rem)
+	assert.Equal(t, layout.Rect{X: 2, Y: 6, W: 10, H: 2}, bottom)
+	requireTiles(t, r, []layout.Rect{rem, bottom})
+
+	rem, bottom = r.CutBottom(99)
+	assert.True(t, rem.Empty())
+	assert.Equal(t, r, bottom)
+
+	rem, bottom = r.CutBottom(-1)
+	assert.Equal(t, r, rem)
+	assert.True(t, bottom.Empty())
+}

--- a/ui/layout/ring.go
+++ b/ui/layout/ring.go
@@ -1,0 +1,83 @@
+package layout
+
+// Ring is the focus ring (RFC §2.3): an ordered list of focusable ids with
+// one active entry. The canonical order is tree → pane A → pane B (if
+// split) → automations; regions hidden by the degradation ladder are marked
+// hidden and skipped when cycling.
+type Ring struct {
+	ids    []string
+	hidden map[string]bool
+	active int
+}
+
+// NewRing builds a ring over ids in cycling order. The first visible id is
+// active.
+func NewRing(ids ...string) *Ring {
+	return &Ring{
+		ids:    append([]string(nil), ids...),
+		hidden: make(map[string]bool),
+	}
+}
+
+// SetHidden marks an id hidden (skipped by cycling and unfocusable) or
+// visible again. Hiding the active id makes the next visible id active.
+func (r *Ring) SetHidden(id string, hidden bool) { r.hidden[id] = hidden }
+
+// Active returns the currently focused id, or "" when every id is hidden.
+// If the active id has been hidden, focus moves forward to the next visible
+// id.
+func (r *Ring) Active() string {
+	if !r.normalize() {
+		return ""
+	}
+	return r.ids[r.active]
+}
+
+// Next advances focus to the next visible id, wrapping around, and returns
+// it. Returns "" when every id is hidden.
+func (r *Ring) Next() string { return r.step(1) }
+
+// Prev moves focus to the previous visible id, wrapping around, and returns
+// it. Returns "" when every id is hidden.
+func (r *Ring) Prev() string { return r.step(-1) }
+
+// Focus moves focus directly to id. It reports whether it did; unknown and
+// hidden ids are refused and leave focus unchanged.
+func (r *Ring) Focus(id string) bool {
+	for i, s := range r.ids {
+		if s == id && !r.hidden[s] {
+			r.active = i
+			return true
+		}
+	}
+	return false
+}
+
+// normalize ensures active points at a visible id, scanning forward from
+// the current position. It reports whether any id is visible.
+func (r *Ring) normalize() bool {
+	n := len(r.ids)
+	for i := 0; i < n; i++ {
+		idx := (r.active + i) % n
+		if !r.hidden[r.ids[idx]] {
+			r.active = idx
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Ring) step(delta int) string {
+	n := len(r.ids)
+	if n == 0 || !r.normalize() {
+		return ""
+	}
+	for i := 1; i <= n; i++ {
+		idx := ((r.active+delta*i)%n + n) % n
+		if !r.hidden[r.ids[idx]] {
+			r.active = idx
+			return r.ids[idx]
+		}
+	}
+	return r.ids[r.active] // single visible id: stay put
+}

--- a/ui/layout/ring_test.go
+++ b/ui/layout/ring_test.go
@@ -1,0 +1,106 @@
+package layout_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+)
+
+// newWorkspaceRing builds the canonical §2.3 ring:
+// tree → pane A → pane B → automations.
+func newWorkspaceRing() *layout.Ring {
+	return layout.NewRing(layout.RegionTree, layout.RegionPaneA, layout.RegionPaneB, layout.RegionAutomations)
+}
+
+func TestRingCyclingOrder(t *testing.T) {
+	r := newWorkspaceRing()
+	assert.Equal(t, layout.RegionTree, r.Active(), "first id starts active")
+
+	assert.Equal(t, layout.RegionPaneA, r.Next())
+	assert.Equal(t, layout.RegionPaneB, r.Next())
+	assert.Equal(t, layout.RegionAutomations, r.Next())
+	assert.Equal(t, layout.RegionTree, r.Next(), "Next wraps around")
+
+	assert.Equal(t, layout.RegionAutomations, r.Prev(), "Prev wraps around backwards")
+	assert.Equal(t, layout.RegionPaneB, r.Prev())
+	assert.Equal(t, layout.RegionPaneA, r.Prev())
+	assert.Equal(t, layout.RegionTree, r.Prev())
+}
+
+func TestRingSkipsHidden(t *testing.T) {
+	r := newWorkspaceRing()
+	// No split: pane B leaves the ring.
+	r.SetHidden(layout.RegionPaneB, true)
+
+	assert.Equal(t, layout.RegionPaneA, r.Next())
+	assert.Equal(t, layout.RegionAutomations, r.Next(), "hidden pane B is skipped forward")
+	assert.Equal(t, layout.RegionTree, r.Next())
+	assert.Equal(t, layout.RegionAutomations, r.Prev(), "hidden pane B is skipped backward")
+
+	// Split reopens: pane B rejoins the ring in place.
+	r.SetHidden(layout.RegionPaneB, false)
+	require.True(t, r.Focus(layout.RegionPaneA))
+	assert.Equal(t, layout.RegionPaneB, r.Next())
+}
+
+func TestRingFocus(t *testing.T) {
+	r := newWorkspaceRing()
+
+	require.True(t, r.Focus(layout.RegionAutomations))
+	assert.Equal(t, layout.RegionAutomations, r.Active())
+	assert.Equal(t, layout.RegionTree, r.Next(), "cycling continues from the focused id")
+
+	assert.False(t, r.Focus("no-such-region"), "unknown id refused")
+	assert.Equal(t, layout.RegionTree, r.Active(), "failed Focus leaves focus unchanged")
+
+	r.SetHidden(layout.RegionPaneB, true)
+	assert.False(t, r.Focus(layout.RegionPaneB), "hidden id refused")
+	assert.Equal(t, layout.RegionTree, r.Active())
+}
+
+func TestRingHidingActiveAdvances(t *testing.T) {
+	r := newWorkspaceRing()
+	require.True(t, r.Focus(layout.RegionPaneB))
+
+	// The split closes while pane B holds focus: focus moves to the next
+	// visible id in ring order.
+	r.SetHidden(layout.RegionPaneB, true)
+	assert.Equal(t, layout.RegionAutomations, r.Active())
+}
+
+func TestRingAllHidden(t *testing.T) {
+	r := newWorkspaceRing()
+	for _, id := range []string{layout.RegionTree, layout.RegionPaneA, layout.RegionPaneB, layout.RegionAutomations} {
+		r.SetHidden(id, true)
+	}
+	assert.Equal(t, "", r.Active())
+	assert.Equal(t, "", r.Next())
+	assert.Equal(t, "", r.Prev())
+	assert.False(t, r.Focus(layout.RegionTree))
+
+	// Everything reappears: the ring recovers.
+	r.SetHidden(layout.RegionTree, false)
+	assert.Equal(t, layout.RegionTree, r.Active())
+}
+
+func TestRingSingleVisible(t *testing.T) {
+	r := newWorkspaceRing()
+	r.SetHidden(layout.RegionPaneA, true)
+	r.SetHidden(layout.RegionPaneB, true)
+	r.SetHidden(layout.RegionAutomations, true)
+
+	assert.Equal(t, layout.RegionTree, r.Active())
+	assert.Equal(t, layout.RegionTree, r.Next(), "Next on a single visible id stays put")
+	assert.Equal(t, layout.RegionTree, r.Prev(), "Prev on a single visible id stays put")
+}
+
+func TestRingEmpty(t *testing.T) {
+	r := layout.NewRing()
+	assert.Equal(t, "", r.Active())
+	assert.Equal(t, "", r.Next())
+	assert.Equal(t, "", r.Prev())
+	assert.False(t, r.Focus(layout.RegionTree))
+}

--- a/ui/layout/zones/main_test.go
+++ b/ui/layout/zones/main_test.go
@@ -1,0 +1,24 @@
+package zones_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+)
+
+func TestMain(m *testing.M) {
+	// Repo-wide test hygiene (#837/#1056): tripwire the real config.json and
+	// sandbox AGENT_FACTORY_HOME. This package is pure and touches neither,
+	// but the guards keep that a verified invariant rather than a hope.
+	verifyRealConfig := testguard.ConfigTripwire()
+	restoreHome := testguard.SandboxHome()
+	code := m.Run()
+	restoreHome()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
+}

--- a/ui/layout/zones/registry.go
+++ b/ui/layout/zones/registry.go
@@ -1,0 +1,52 @@
+// Package zones is the hand-rolled mouse hit-testing registry for the
+// multi-pane TUI rewrite (docs/design/tui-rewrite.md §2.5, epic #1024) —
+// deliberately not bubblezone, which post-processes ANSI markers out of
+// every frame; this registry works directly on the layout Rect model.
+//
+// During View() each pane registers a rect per interactive target (zone ids
+// like "tree:instance:api-fix" or "pane:A:header"). The root model resolves
+// every tea.MouseMsg through Resolve and dispatches to the owning pane with
+// pane-local coordinates. The registry is rebuilt every frame: Reset at the
+// top of View, Register while rendering.
+package zones
+
+import "github.com/sachiniyer/agent-factory/ui/layout"
+
+type zone struct {
+	id   string
+	rect layout.Rect
+}
+
+// Registry maps screen rects to zone ids for mouse hit-testing. It is not
+// goroutine-safe: registration and resolution both happen on the bubbletea
+// event loop.
+type Registry struct {
+	zones []zone
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry { return &Registry{} }
+
+// Register records that rect belongs to zone id for the current frame.
+// Registration order is paint order: when zones overlap, the most recently
+// registered one is "on top" and wins hit-testing. Empty rects are accepted
+// but can never be hit.
+func (r *Registry) Register(id string, rect layout.Rect) {
+	r.zones = append(r.zones, zone{id: id, rect: rect})
+}
+
+// Resolve hit-tests a screen coordinate. It returns the topmost zone
+// containing the point and the point in zone-local coordinates; ok is false
+// (with empty id) on a miss.
+func (r *Registry) Resolve(x, y int) (id string, local layout.Point, ok bool) {
+	p := layout.Point{X: x, Y: y}
+	for i := len(r.zones) - 1; i >= 0; i-- {
+		if z := r.zones[i]; z.rect.Contains(p) {
+			return z.id, z.rect.Local(p), true
+		}
+	}
+	return "", layout.Point{}, false
+}
+
+// Reset clears all registrations for a new frame, retaining capacity.
+func (r *Registry) Reset() { r.zones = r.zones[:0] }

--- a/ui/layout/zones/registry_test.go
+++ b/ui/layout/zones/registry_test.go
@@ -1,0 +1,132 @@
+package zones_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+func TestRegistryResolveBasic(t *testing.T) {
+	reg := zones.NewRegistry()
+	reg.Register("tree", layout.Rect{X: 0, Y: 0, W: 30, H: 40})
+	reg.Register("paneA", layout.Rect{X: 30, Y: 0, W: 70, H: 40})
+
+	id, local, ok := reg.Resolve(5, 7)
+	require.True(t, ok)
+	assert.Equal(t, "tree", id)
+	assert.Equal(t, layout.Point{X: 5, Y: 7}, local)
+
+	id, local, ok = reg.Resolve(35, 10)
+	require.True(t, ok)
+	assert.Equal(t, "paneA", id)
+	assert.Equal(t, layout.Point{X: 5, Y: 10}, local, "local coords are zone-relative")
+}
+
+func TestRegistryResolveBoundaries(t *testing.T) {
+	reg := zones.NewRegistry()
+	reg.Register("z", layout.Rect{X: 10, Y: 5, W: 20, H: 10})
+
+	// Half-open edges: last inside cell hits, first outside cell misses.
+	_, local, ok := reg.Resolve(10, 5)
+	require.True(t, ok, "top-left corner is inside")
+	assert.Equal(t, layout.Point{X: 0, Y: 0}, local)
+
+	_, local, ok = reg.Resolve(29, 14)
+	require.True(t, ok, "bottom-right cell is inside")
+	assert.Equal(t, layout.Point{X: 19, Y: 9}, local)
+
+	_, _, ok = reg.Resolve(30, 5)
+	assert.False(t, ok, "right edge is exclusive")
+	_, _, ok = reg.Resolve(10, 15)
+	assert.False(t, ok, "bottom edge is exclusive")
+	_, _, ok = reg.Resolve(9, 5)
+	assert.False(t, ok)
+}
+
+func TestRegistryResolveMiss(t *testing.T) {
+	reg := zones.NewRegistry()
+
+	id, local, ok := reg.Resolve(5, 5)
+	assert.False(t, ok, "empty registry misses everywhere")
+	assert.Equal(t, "", id)
+	assert.Equal(t, layout.Point{}, local)
+
+	reg.Register("z", layout.Rect{X: 0, Y: 0, W: 10, H: 10})
+	id, _, ok = reg.Resolve(50, 50)
+	assert.False(t, ok)
+	assert.Equal(t, "", id)
+}
+
+func TestRegistryOverlapLastRegisteredWins(t *testing.T) {
+	reg := zones.NewRegistry()
+	reg.Register("pane", layout.Rect{X: 0, Y: 0, W: 50, H: 20})
+	reg.Register("pane:header", layout.Rect{X: 0, Y: 0, W: 50, H: 1})
+	reg.Register("pane:header:close", layout.Rect{X: 48, Y: 0, W: 2, H: 1})
+
+	// Registration order is paint order: the innermost, last-registered
+	// target is on top.
+	id, local, ok := reg.Resolve(48, 0)
+	require.True(t, ok)
+	assert.Equal(t, "pane:header:close", id)
+	assert.Equal(t, layout.Point{X: 0, Y: 0}, local, "local coords are relative to the winning zone")
+
+	id, _, ok = reg.Resolve(10, 0)
+	require.True(t, ok)
+	assert.Equal(t, "pane:header", id, "header beats the pane beneath it")
+
+	id, _, ok = reg.Resolve(10, 5)
+	require.True(t, ok)
+	assert.Equal(t, "pane", id, "uncovered pane body still hits the pane")
+}
+
+func TestRegistryEmptyRectNeverHit(t *testing.T) {
+	reg := zones.NewRegistry()
+	reg.Register("ghost", layout.Rect{X: 5, Y: 5, W: 0, H: 10})
+	_, _, ok := reg.Resolve(5, 5)
+	assert.False(t, ok)
+}
+
+func TestRegistryReset(t *testing.T) {
+	reg := zones.NewRegistry()
+	reg.Register("a", layout.Rect{X: 0, Y: 0, W: 10, H: 10})
+	_, _, ok := reg.Resolve(5, 5)
+	require.True(t, ok)
+
+	// Per-frame rebuild: Reset clears everything…
+	reg.Reset()
+	_, _, ok = reg.Resolve(5, 5)
+	assert.False(t, ok, "Reset clears all registrations")
+
+	// …and the next frame's registrations take effect cleanly.
+	reg.Register("b", layout.Rect{X: 0, Y: 0, W: 10, H: 10})
+	id, _, ok := reg.Resolve(5, 5)
+	require.True(t, ok)
+	assert.Equal(t, "b", id)
+}
+
+// TestRegistryFromGridRegions exercises the intended per-frame usage:
+// register every visible region of a solved layout and verify any screen
+// cell resolves to exactly the region that contains it.
+func TestRegistryFromGridRegions(t *testing.T) {
+	l := layout.Grid{Split: true}.Solve(140, 40)
+	require.False(t, l.Fallback)
+
+	reg := zones.NewRegistry()
+	for id, r := range l.VisibleRegions() {
+		reg.Register(id, r)
+	}
+
+	for y := 0; y < l.Height; y++ {
+		for x := 0; x < l.Width; x++ {
+			id, local, ok := reg.Resolve(x, y)
+			require.True(t, ok, "cell (%d,%d) resolves — regions tile the screen", x, y)
+			r := l.VisibleRegions()[id]
+			require.True(t, r.Contains(layout.Point{X: x, Y: y}))
+			require.Equal(t, layout.Point{X: x - r.X, Y: y - r.Y}, local)
+		}
+	}
+}


### PR DESCRIPTION
PR 1 of the multi-pane TUI rewrite (epic #1024), implementing the "layout engine" row of the phased plan in [docs/design/tui-rewrite.md](https://github.com/sachiniyer/agent-factory/blob/master/docs/design/tui-rewrite.md) §4 — see §2.2 (component tree + `Pane` interface), §2.5 (mouse/zones), §2.6 (resize + degradation ladder).

## What it adds

A new `ui/layout` package (plus `ui/layout/zones`) — pure, dependency-free infrastructure:

- **`Rect` / `Point`** — cell-coordinate geometry core: `Contains`, `Local`, `Intersects`, `CutLeft/CutTop/CutBottom` sub-rect splitters that always tile exactly.
- **`Grid` solver** (§2.6) — the single sizing authority: terminal W×H → named region rects (tree, pane A/B, divider, automations, status bar) plus visibility flags. Left rail = `clamp(24, 30%·W, 44)` cols; automations strip 3 rows (1 when tight); status bar 2 rows; workspace = remainder, split evenly with a 1-col divider. Implements the degradation ladder: <110 cols → split collapses to pane A (caller retains B's binding); <80 cols (or <20 rows) → automations become a 1-line summary; <60×15 → tree + single pane + status only; below 40×10 → `Fallback` signals the existing fallback banner.
- **`Pane` interface** (§2.2) — `SetRect` / `Focused`/`Focus`/`Blur` / `HandleKey` (with consumed bool) / `HandleMouse` (pane-local `Point`) / `View`, the contract every workspace region implements from PR 4 on.
- **`Ring`** (§2.3) — the focus ring: ordered focusable ids, `Next`/`Prev`/`Focus(id)`/`Active`, skipping regions hidden by the ladder, wrap-around, and forward re-normalization when the active region hides (e.g. split closes under focus).
- **`zones.Registry`** (§2.5) — hand-rolled mouse hit-testing (no bubblezone): panes `Register(zoneID, Rect)` during `View()`, the root `Resolve(x,y)` → topmost zone + zone-local point, `Reset()` per frame.
- **`ClampToRect`** — the shared exact-Rect sizing helper (ANSI- and wide-rune-aware via `lipgloss.Width`/`x/ansi.Truncate`, with reset-termination so truncated styles can't bleed) that will replace the five ad-hoc per-pane clamps in later PRs. Provided here; existing panes are **not** rewired yet.

## Not wired in — by design

Per the RFC's in-place-morph strategy, this PR touches **no** existing `app/` or `ui/` files and causes **no visible change**. The package is kept alive for the `deadcode -test` gate by its own tests (every exported symbol is exercised). Wiring starts in PR 2 (projection store) and PR 4 (layout cutover).

## Tests (property-style, hermetic)

- **Grid**: full sweep of 40–220 × 10–72 with and without split asserting the visible regions **exactly tile** the screen (no overlap, no gaps, no negative dims); ladder transitions at the documented thresholds; ladder monotonicity (shrinking never re-enables a richer mode); chrome (tree width, strip/status height) never grows on shrink; region dims monotone within a degradation state; hard-minimum fallback.
- **Ring**: cycling order tree→A→B→automations, hidden-skip both directions, wrap-around, `Focus(id)` incl. hidden/unknown refusal, active-hidden re-normalization, all-hidden, empty ring.
- **zones.Registry**: hit-test resolution, half-open boundary semantics, overlapping-registration precedence (last registered = topmost wins), local-coordinate correctness, miss/empty-rect behavior, per-frame `Reset`, and an every-cell sweep over a solved grid layout.
- **ClampToRect**: exact W×H for over/under-sized, multi-line, wide-rune (CJK boundary straddle), and ANSI-styled input, incl. style containment under truncation.
- **Pane**: contract check that `View()` is exactly Rect-sized for arbitrary content across all solved regions, key-consumption semantics, and a §2.5-style mouse dispatch integration through the zone registry.

Follows the existing `ui/` test style (testify + `lipgloss.Width`, sandboxed `TestMain` tripwires per #1057).

## Verification

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go test ./...` — green (sandboxed `AGENT_FACTORY_HOME`)
- `deadcode -test ./...` — clean
- `GOFLAGS="-p=1" go test -race -parallel 2 ./ui/...` — green

Part of #1024 (epic stays open — this is PR 1 of ~8).

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
