### PR TITLE
tui: extract snapshot projection store; panes become views (#1024, epic PR 2)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
+	"github.com/sachiniyer/agent-factory/ui/store"
 	"io"
 	"os"
 	"path/filepath"
@@ -94,6 +95,13 @@ type home struct {
 
 	// -- UI Components --
 
+	// store is the single read-only projection of daemon-owned state that the
+	// panes render (#1024 PR 2): the instance list + repo bookkeeping + tasks +
+	// hook count, plus the cross-pane selection (selected instance, active tab
+	// index). Written on the bubbletea event loop by reconcileSnapshot and the
+	// session-control handlers; read by the sidebar and tabbed window, which
+	// keep only their own local UI state (cursor, scroll, expansion).
+	store *store.Projection
 	// sidebar is the unified left navigation pane with collapsible sections
 	sidebar *ui.Sidebar
 	// contentPane wraps the tabbed window and other contextual panes
@@ -156,11 +164,13 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 	// longer reads instances.json — the daemon owns it and answers Snapshot).
 	appState := config.LoadState()
 
-	tabbedWindow := ui.NewTabbedWindow(ui.NewTabPane())
+	proj := store.NewProjection()
+	tabbedWindow := ui.NewTabbedWindow(ui.NewTabPane(), proj)
 
 	h := &home{
 		ctx:             ctx,
 		spinner:         spinner.New(spinner.WithSpinner(spinner.MiniDot)),
+		store:           proj,
 		menu:            ui.NewMenu(),
 		contentPane:     ui.NewContentPane(tabbedWindow),
 		errBox:          ui.NewErrBox(),
@@ -173,9 +183,9 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 		state:           stateDefault,
 		appState:        appState,
 	}
-	h.sidebar = ui.NewSidebar(&h.spinner, autoYes)
+	h.sidebar = ui.NewSidebar(&h.spinner, autoYes, proj)
 
-	// Cold-start the sidebar from the daemon's authoritative Snapshot (#960 PR 6).
+	// Cold-start the projection from the daemon's authoritative Snapshot (#960 PR 6).
 	// The TUI no longer reads instances.json — the daemon is the sole writer/owner
 	// of session state, so startup mirrors the same projection the refresh tick
 	// reconciles against. A warming daemon (#829) is waited out, not raced.
@@ -191,7 +201,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 	if err != nil {
 		log.WarningLog.Printf("failed to load tasks: %v", err)
 	} else {
-		h.sidebar.SetTasks(tasks)
+		h.store.SetTasks(tasks)
 	}
 
 	// Load tasks into task pane
@@ -205,7 +215,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 	if err != nil {
 		log.WarningLog.Printf("failed to resolve repo config: %v", err)
 	} else {
-		h.sidebar.SetHookCount(len(repoCfg.PostWorktreeCommands))
+		h.store.SetHookCount(len(repoCfg.PostWorktreeCommands))
 		h.contentPane.HooksPane().SetCommands(repoCfg.PostWorktreeCommands)
 	}
 
@@ -235,7 +245,7 @@ func (m *home) updateHandleWindowSizeEvent(msg tea.WindowSizeMsg) {
 
 	tw := m.contentPane.TabbedWindow()
 	previewWidth, previewHeight := tw.GetPreviewSize()
-	if err := m.sidebar.SetSessionPreviewSize(previewWidth, previewHeight); err != nil {
+	if err := m.store.SetSessionPreviewSize(previewWidth, previewHeight); err != nil {
 		log.ErrorLog.Print(err)
 	}
 	m.menu.SetSize(msg.Width, menuHeight)
@@ -303,8 +313,8 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// represents this session. If the session is gone entirely, drop the
 		// stale fetch result (#862).
 		target := msg.instance
-		if !m.sidebar.ContainsInstance(target) {
-			target = m.sidebar.GetInstanceByTitle(msg.instance.Title)
+		if !m.store.ContainsInstance(target) {
+			target = m.store.GetInstanceByTitle(msg.instance.Title)
 		}
 		if target == nil {
 			return m, nil
@@ -465,7 +475,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// instances slice, which can bump selectedIdx onto a different
 			// row when the removed instance preceded the selected one.
 			priorSelection := m.sidebar.GetSelectedInstance()
-			m.sidebar.RemoveInstanceByTitle(msg.instance.Title)
+			m.store.RemoveInstanceByTitle(msg.instance.Title)
 			if priorSelection != nil && priorSelection != msg.instance {
 				m.sidebar.SelectInstance(priorSelection)
 			}
@@ -490,9 +500,9 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// runs here to register it now.
 		swapped := false
 		if started != msg.instance {
-			if m.sidebar.ReplaceInstance(msg.instance, started) {
+			if m.store.ReplaceInstance(msg.instance, started) {
 				swapped = true
-			} else if !m.sidebar.ContainsInstance(started) {
+			} else if !m.store.ContainsInstance(started) {
 				// The Loading placeholder may have been swapped for a
 				// disk-built copy of this same session by a background sync
 				// while the start RPC was in flight; both Replace and
@@ -500,19 +510,19 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// unconditionally would leave two sidebar rows — and two
 				// persisted records — for one session (#808), so replace any
 				// same-title row instead.
-				if m.sidebar.ReplaceInstanceByTitle(started.Title, started) {
+				if m.store.ReplaceInstanceByTitle(started.Title, started) {
 					swapped = true
 				} else {
-					m.sidebar.AddInstance(started)
+					m.store.AddInstance(started)
 				}
 			}
-		} else if !m.sidebar.ContainsInstance(started) {
-			m.sidebar.AddInstance(started)
+		} else if !m.store.ContainsInstance(started) {
+			m.store.AddInstance(started)
 		}
 
 		started.SetStatus(session.Running)
 		if !swapped && !started.IsRemote() {
-			m.sidebar.RegisterRepoForInstance(started)
+			m.store.RegisterRepoForInstance(started)
 		}
 		started.SetAutoYes(m.autoYes)
 
@@ -597,7 +607,7 @@ func (m *home) saveContentPaneState() error {
 			// the recovery note above) so the in-memory edit survives for retry.
 			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save hooks: %w", err))
 		} else {
-			m.sidebar.SetHookCount(len(hp.GetCommands()))
+			m.store.SetHookCount(len(hp.GetCommands()))
 		}
 	}
 
@@ -628,7 +638,7 @@ func (m *home) saveContentPaneState() error {
 	// (#934): whatever actually committed, both panes now show it.
 	tasks, err := task.LoadTasksForCurrentRepo()
 	if err == nil {
-		m.sidebar.SetTasks(tasks)
+		m.store.SetTasks(tasks)
 		sp.SetTasks(tasks)
 	} else {
 		saveErr = errors.Join(saveErr, fmt.Errorf("failed to reload tasks after save: %w", err))
@@ -711,7 +721,7 @@ func (m *home) handleTaskCreate() tea.Cmd {
 	// Refresh sidebar and task pane
 	tasks, err := task.LoadTasksForCurrentRepo()
 	if err == nil {
-		m.sidebar.SetTasks(tasks)
+		m.store.SetTasks(tasks)
 		sp.SetTasks(tasks)
 	}
 	return nil
@@ -749,8 +759,8 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 		return m.handleError(fmt.Errorf("failed to create instance: %w", err))
 	}
 
-	m.sidebar.AddInstance(instance)
-	m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
+	m.store.AddInstance(instance)
+	m.sidebar.SetSelectedInstance(m.store.NumInstances() - 1)
 	instance.SetStatus(session.Loading)
 	m.menu.SetState(ui.StateDefault)
 
@@ -1070,7 +1080,12 @@ func (m *home) selectionChanged() tea.Cmd {
 	case sel.Kind == ui.SectionInstances && !sel.IsHeader:
 		m.contentPane.SetMode(ui.ContentModeInstance)
 		selected := m.sidebar.GetSelectedInstance()
-		tw.SetInstance(selected)
+		// Bind the workspace panes to the cursor's instance — the store's
+		// display binding replaces the pre-#1024 TabbedWindow.instance pointer,
+		// including the nil case — then re-clamp the active tab index against
+		// the new instance's tab count.
+		m.store.SetSelectedInstance(selected)
+		tw.ClampActiveTab()
 		m.menu.SetInstance(selected)
 		m.menu.SetSidebarContext(sel.Kind, sel.IsHeader)
 		if !attachedNow {
@@ -1094,7 +1109,7 @@ func (m *home) selectionChanged() tea.Cmd {
 	default:
 		// On section headers, show the instance preview if available
 		if sel.Kind == ui.SectionInstances {
-			if m.sidebar.NumInstances() > 0 {
+			if m.store.NumInstances() > 0 {
 				m.contentPane.SetMode(ui.ContentModeInstance)
 			} else {
 				m.contentPane.SetMode(ui.ContentModeEmpty)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
+	"github.com/sachiniyer/agent-factory/ui/store"
 	"os"
 	"testing"
 
@@ -126,8 +127,9 @@ func TestConfirmationModalStateTransitions(t *testing.T) {
 // TestConfirmationModalKeyHandling tests the actual key handling in confirmation state
 func TestConfirmationModalKeyHandling(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	sidebar := ui.NewSidebar(&spin, false)
-	tw := ui.NewTabbedWindow(ui.NewTabPane())
+	proj := store.NewProjection()
+	sidebar := ui.NewSidebar(&spin, false, proj)
+	tw := ui.NewTabbedWindow(ui.NewTabPane(), proj)
 	cp := ui.NewContentPane(tw)
 
 	// Create enough of home struct to test handleKeyPress in confirmation state
@@ -135,6 +137,7 @@ func TestConfirmationModalKeyHandling(t *testing.T) {
 		ctx:                 context.Background(),
 		state:               stateConfirm,
 		appConfig:           config.DefaultConfig(),
+		store:               proj,
 		sidebar:             sidebar,
 		contentPane:         cp,
 		menu:                ui.NewMenu(),
@@ -249,8 +252,9 @@ func TestConfirmationMessageFormatting(t *testing.T) {
 // TestConfirmationFlowSimulation tests the confirmation flow by simulating the state changes
 func TestConfirmationFlowSimulation(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	sidebar := ui.NewSidebar(&spin, false)
-	tw := ui.NewTabbedWindow(ui.NewTabPane())
+	proj := store.NewProjection()
+	sidebar := ui.NewSidebar(&spin, false, proj)
+	tw := ui.NewTabbedWindow(ui.NewTabPane(), proj)
 	cp := ui.NewContentPane(tw)
 
 	// Add test instance
@@ -261,13 +265,14 @@ func TestConfirmationFlowSimulation(t *testing.T) {
 		AutoYes: false,
 	})
 	require.NoError(t, err)
-	_ = sidebar.AddInstance(instance)
+	_ = proj.AddInstance(instance)
 	sidebar.SetSelectedInstance(0)
 
 	h := &home{
 		ctx:         context.Background(),
 		state:       stateDefault,
 		appConfig:   config.DefaultConfig(),
+		store:       proj,
 		sidebar:     sidebar,
 		contentPane: cp,
 		menu:        ui.NewMenu(),
@@ -461,14 +466,16 @@ func TestMultipleConfirmationsDontInterfere(t *testing.T) {
 // content pane after a session is killed). Regression test for #259.
 func TestConfirmActionForwardsNonErrorMsg(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	sidebar := ui.NewSidebar(&spin, false)
-	tw := ui.NewTabbedWindow(ui.NewTabPane())
+	proj := store.NewProjection()
+	sidebar := ui.NewSidebar(&spin, false, proj)
+	tw := ui.NewTabbedWindow(ui.NewTabPane(), proj)
 	cp := ui.NewContentPane(tw)
 
 	h := &home{
 		ctx:         context.Background(),
 		state:       stateDefault,
 		appConfig:   config.DefaultConfig(),
+		store:       proj,
 		sidebar:     sidebar,
 		contentPane: cp,
 		menu:        ui.NewMenu(),

--- a/app/attached_pause_test.go
+++ b/app/attached_pause_test.go
@@ -19,7 +19,7 @@ import (
 func TestPreviewTick_PausedWhileAttached(t *testing.T) {
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "a")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	h.attached.Store(true)
@@ -47,7 +47,7 @@ func TestPreviewTick_PausedWhileAttached(t *testing.T) {
 func TestSelectionChanged_SkipsRefreshWhileAttached(t *testing.T) {
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "a")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	h.attached.Store(true)
@@ -68,7 +68,7 @@ func TestSelectionChanged_SkipsRefreshWhileAttached(t *testing.T) {
 func TestTickUpdatePRInfo_PausedWhileAttached(t *testing.T) {
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "a")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	// Count fetch invocations to prove fetchPRInfoCmd was NOT dispatched.

--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -104,7 +104,7 @@ func TestTUIRefreshSwapsKillRecreatedSameTitle(t *testing.T) {
 	// Exactly one "recreated" instance, and it must be the new live one — not
 	// the dead corpse we started with.
 	var matches []*session.Instance
-	for _, inst := range h.sidebar.GetInstances() {
+	for _, inst := range h.store.GetInstances() {
 		if inst.Title == "recreated" {
 			matches = append(matches, inst)
 		}
@@ -116,7 +116,7 @@ func TestTUIRefreshSwapsKillRecreatedSameTitle(t *testing.T) {
 }
 
 func findSidebarInstance(h *home, title string) *session.Instance {
-	for _, inst := range h.sidebar.GetInstances() {
+	for _, inst := range h.store.GetInstances() {
 		if inst.Title == title {
 			return inst
 		}
@@ -249,7 +249,7 @@ func TestTUIRefreshDoesNotSwapLoadingPlaceholder(t *testing.T) {
 	})
 	require.NoError(t, err)
 	placeholder.SetStatus(session.Loading)
-	h.sidebar.AddInstance(placeholder)
+	h.store.AddInstance(placeholder)
 
 	// The daemon persists the session record mid-create — emulated by a CLI
 	// create, which goes through the same daemon CreateSession path the TUI
@@ -282,7 +282,7 @@ func TestTUIRefreshDoesNotSwapLoadingPlaceholder(t *testing.T) {
 	_, _ = h.Update(instanceStartedMsg{instance: placeholder, started: started})
 
 	var matches []*session.Instance
-	for _, inst := range h.sidebar.GetInstances() {
+	for _, inst := range h.store.GetInstances() {
 		if inst.Title == "scripts" {
 			matches = append(matches, inst)
 		}

--- a/app/cold_start_test.go
+++ b/app/cold_start_test.go
@@ -87,5 +87,5 @@ func TestColdStartFromSnapshot_HardErrorAborts(t *testing.T) {
 
 	err := h.coldStartFromSnapshot()
 	require.Error(t, err, "a hard daemon failure must abort cold start, not fall back to disk")
-	require.Empty(t, h.sidebar.GetInstances(), "no sidebar rows on a failed cold start")
+	require.Empty(t, h.store.GetInstances(), "no sidebar rows on a failed cold start")
 }

--- a/app/cold_start_test.go
+++ b/app/cold_start_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui"
 )
 
 // errDaemonStarting mimics the daemon's typed "up but still restoring sessions"
@@ -73,6 +74,71 @@ func TestColdStartFromSnapshot_WaitsOutWarmingDaemon(t *testing.T) {
 	require.Equal(t, 3, calls, "cold start must retry while the daemon is warming")
 	require.NotNil(t, findSidebarInstance(h, "restored"),
 		"the session must appear once the warming daemon answers")
+}
+
+// TestColdStartFromSnapshot_LaunchSelectionParity pins the launch selection
+// state after a cold start, byte-for-byte with the pre-store TUI (#1024 PR 2
+// review follow-up). The TUI has NEVER auto-selected the first restored
+// instance at launch: the sidebar cursor starts on the Instances HEADER
+// (ui/sidebar_test.go's TestSidebarInitialState pins the same on the pre-store
+// Sidebar, and newHome issues no SetSelectedInstance/SelectInstance at
+// startup), so no instance is bound to the workspace panes — the pre-store
+// TabbedWindow.instance also started nil — and the active tab starts at 0.
+// The panes bind on the first cursor move: Down lands on the first restored
+// instance and selectionChanged binds it, exactly the old
+// selectionChanged→TabbedWindow.SetInstance first-keypress behavior.
+func TestColdStartFromSnapshot_LaunchSelectionParity(t *testing.T) {
+	h := newTestHome(t)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+	h.snapshotFetcher = func(string) ([]session.InstanceData, error) {
+		return []session.InstanceData{{Title: "first"}, {Title: "second"}, {Title: "third"}}, nil
+	}
+
+	require.NoError(t, h.coldStartFromSnapshot())
+	// The launch paint path must run cleanly with nothing bound yet.
+	_ = h.selectionChanged()
+
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsHeader, "launch cursor rests on the Instances header, as before the store")
+	require.Equal(t, ui.SectionInstances, sel.Kind)
+	require.Nil(t, h.sidebar.GetSelectedInstance(), "no cursor-selected instance at launch")
+	require.Nil(t, h.store.GetSelectedInstance(),
+		"no instance bound to the workspace panes at launch (TabbedWindow.instance started nil pre-store)")
+	require.Equal(t, 0, h.store.ActiveTab(), "active tab starts on the agent tab")
+	require.Equal(t, ui.ContentModeInstance, h.contentPane.GetMode(),
+		"instances exist, so the content pane is in instance mode showing the default empty pane")
+
+	// First keypress: Down moves onto the first restored instance and binds it.
+	h.sidebar.Down()
+	_ = h.selectionChanged()
+	first := h.store.GetInstances()[0]
+	require.Equal(t, "first", first.Title)
+	require.Same(t, first, h.sidebar.GetSelectedInstance(),
+		"the first Down must land on the first restored instance")
+	require.Same(t, first, h.store.GetSelectedInstance(),
+		"the store must bind the first instance to the panes, as SetInstance did pre-store")
+	require.Equal(t, 0, h.store.ActiveTab())
+}
+
+// TestColdStartFromSnapshot_EmptySnapshotNoSelection pins the empty cold
+// start: no instances → no selection anywhere and the empty content mode,
+// with the launch paint path running clean — matching the pre-store TUI.
+func TestColdStartFromSnapshot_EmptySnapshotNoSelection(t *testing.T) {
+	h := newTestHome(t)
+	h.snapshotFetcher = func(string) ([]session.InstanceData, error) {
+		return nil, nil
+	}
+
+	require.NoError(t, h.coldStartFromSnapshot())
+	_ = h.selectionChanged()
+
+	require.Equal(t, 0, h.store.NumInstances())
+	require.Nil(t, h.sidebar.GetSelectedInstance())
+	require.Nil(t, h.store.GetSelectedInstance())
+	require.Equal(t, 0, h.store.ActiveTab())
+	require.Equal(t, ui.ContentModeEmpty, h.contentPane.GetMode())
 }
 
 // TestColdStartFromSnapshot_HardErrorAborts proves a non-warming daemon failure

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,8 +50,9 @@ func newTestHome(t *testing.T) *home {
 	}))
 
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	sidebar := ui.NewSidebar(&spin, false)
-	tw := ui.NewTabbedWindow(ui.NewTabPane())
+	proj := store.NewProjection()
+	sidebar := ui.NewSidebar(&spin, false, proj)
+	tw := ui.NewTabbedWindow(ui.NewTabPane(), proj)
 	cp := ui.NewContentPane(tw)
 
 	state := config.DefaultState()
@@ -73,6 +75,7 @@ func newTestHome(t *testing.T) *home {
 		snapshotFetcher: func(string) ([]session.InstanceData, error) {
 			return nil, fmt.Errorf("snapshot fetcher not stubbed in test")
 		},
+		store:       proj,
 		sidebar:     sidebar,
 		contentPane: cp,
 		menu:        ui.NewMenu(),
@@ -125,7 +128,7 @@ func newLoadingInstance(t *testing.T, title string) *session.Instance {
 func TestInstanceStarted_Success_UserStillWatching(t *testing.T) {
 	h := newTestHome(t)
 	inst := newLoadingInstance(t, "new-session")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	_, _ = h.Update(instanceStartedMsg{instance: inst, err: nil})
@@ -143,8 +146,8 @@ func TestInstanceStarted_Success_UserMovedToAnotherInstance(t *testing.T) {
 	creating := newLoadingInstance(t, "still-creating")
 	other := newLoadingInstance(t, "other")
 	other.SetStatus(session.Running)
-	h.sidebar.AddInstance(creating)
-	h.sidebar.AddInstance(other)
+	h.store.AddInstance(creating)
+	h.store.AddInstance(other)
 	// User navigated to `other` while `creating` was still starting.
 	h.sidebar.SetSelectedInstance(1)
 
@@ -165,8 +168,8 @@ func TestInstanceStarted_Success_UserCreatingAnotherInstance(t *testing.T) {
 	h := newTestHome(t)
 	first := newLoadingInstance(t, "first")
 	second := newLoadingInstance(t, "second")
-	h.sidebar.AddInstance(first)
-	h.sidebar.AddInstance(second)
+	h.store.AddInstance(first)
+	h.store.AddInstance(second)
 	// Simulate the user having typed a name and entered stateNew for `second`.
 	h.sidebar.SetSelectedInstance(1)
 	h.namingInstance = second
@@ -189,14 +192,14 @@ func TestInstanceStarted_Failure_RemovesByTitleNotBySelection(t *testing.T) {
 	failing := newLoadingInstance(t, "failing")
 	innocent := newLoadingInstance(t, "innocent")
 	innocent.SetStatus(session.Running)
-	h.sidebar.AddInstance(failing)
-	h.sidebar.AddInstance(innocent)
+	h.store.AddInstance(failing)
+	h.store.AddInstance(innocent)
 	// User moved to `innocent` while `failing` was still starting.
 	h.sidebar.SetSelectedInstance(1)
 
 	_, _ = h.Update(instanceStartedMsg{instance: failing, err: errors.New("boom")})
 
-	titles := collectTitles(h.sidebar.GetInstances())
+	titles := collectTitles(h.store.GetInstances())
 	assert.NotContains(t, titles, "failing", "failed instance must be removed")
 	assert.Contains(t, titles, "innocent", "unrelated instance must NOT be killed")
 	assert.Same(t, innocent, h.sidebar.GetSelectedInstance(),
@@ -208,12 +211,12 @@ func TestInstanceStarted_Failure_RemovesByTitleNotBySelection(t *testing.T) {
 func TestInstanceStarted_Failure_OnFailedInstance(t *testing.T) {
 	h := newTestHome(t)
 	failing := newLoadingInstance(t, "failing")
-	h.sidebar.AddInstance(failing)
+	h.store.AddInstance(failing)
 	h.sidebar.SetSelectedInstance(0)
 
 	_, _ = h.Update(instanceStartedMsg{instance: failing, err: errors.New("boom")})
 
-	assert.Empty(t, h.sidebar.GetInstances(), "failed instance must be removed")
+	assert.Empty(t, h.store.GetInstances(), "failed instance must be removed")
 	assert.Nil(t, h.sidebar.GetSelectedInstance(), "no instance should remain selected")
 }
 
@@ -223,7 +226,7 @@ func TestInstanceStarted_Success_AutoYesApplied(t *testing.T) {
 	h := newTestHome(t)
 	h.autoYes = true
 	inst := newLoadingInstance(t, "auto-yes")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	_, _ = h.Update(instanceStartedMsg{instance: inst, err: nil})
@@ -272,13 +275,13 @@ func TestInstanceStartedRegistersRepoAfterStart(t *testing.T) {
 	inst.SetStartedForTest(true)
 	inst.SetGitWorktreeForTest(gw)
 
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
-	require.Equal(t, 0, h.sidebar.NumRepos())
+	require.Equal(t, 0, h.store.NumRepos())
 
 	_, _ = h.Update(instanceStartedMsg{instance: inst, err: nil})
 
-	assert.Equal(t, 1, h.sidebar.NumRepos())
+	assert.Equal(t, 1, h.store.NumRepos())
 }
 
 func collectTitles(instances []*session.Instance) []string {
@@ -296,7 +299,7 @@ func collectTitles(instances []*session.Instance) []string {
 func TestInstanceStarted_TimeoutError_SurfacesPaneSnippet(t *testing.T) {
 	h := newTestHome(t)
 	failing := newLoadingInstance(t, "stalled")
-	h.sidebar.AddInstance(failing)
+	h.store.AddInstance(failing)
 	h.sidebar.SetSelectedInstance(0)
 	h.errBox.SetSize(500, 1)
 
@@ -316,7 +319,7 @@ func TestInstanceStarted_TimeoutError_SurfacesPaneSnippet(t *testing.T) {
 func TestInstanceStarted_TimeoutError_EmptyContentOmitsHeader(t *testing.T) {
 	h := newTestHome(t)
 	failing := newLoadingInstance(t, "stalled-empty")
-	h.sidebar.AddInstance(failing)
+	h.store.AddInstance(failing)
 	h.sidebar.SetSelectedInstance(0)
 	h.errBox.SetSize(500, 1)
 
@@ -347,14 +350,14 @@ func TestInstanceStarted_ReplacesSwappedSameTitleRow(t *testing.T) {
 	diskCopy := newLoadingInstance(t, "scripts")
 	diskCopy.SetStartedForTest(true)
 	diskCopy.SetStatus(session.Running)
-	h.sidebar.AddInstance(diskCopy)
+	h.store.AddInstance(diskCopy)
 
 	started := newLoadingInstance(t, "scripts")
 	started.SetStartedForTest(true)
 
 	_, _ = h.Update(instanceStartedMsg{instance: placeholder, started: started})
 
-	instances := h.sidebar.GetInstances()
+	instances := h.store.GetInstances()
 	require.Len(t, instances, 1, "one logical session must occupy exactly one sidebar row (#808)")
 	assert.Same(t, started, instances[0], "the started instance must replace the disk-built copy")
 	assert.Equal(t, session.Running, started.Status)

--- a/app/daemon_mutation_routing_test.go
+++ b/app/daemon_mutation_routing_test.go
@@ -97,7 +97,7 @@ func TestHandleCloseTab_AgentTabSkipsDaemon(t *testing.T) {
 func TestPrInfoUpdatedMsg_RoutesWriteThroughDaemon(t *testing.T) {
 	h := newTestHome(t)
 	inst := newLoadingInstance(t, "pr-target")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	var gotTitle, gotRepo string
@@ -131,7 +131,7 @@ func TestPrInfoUpdatedMsg_BranchMismatchSkipsDaemon(t *testing.T) {
 	h := newTestHome(t)
 	inst := newLoadingInstance(t, "pr-branch")
 	inst.Branch = "feature-x"
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	called := false

--- a/app/dead_session_test.go
+++ b/app/dead_session_test.go
@@ -42,7 +42,7 @@ func TestHandleEnter_DeadSessionShowsError(t *testing.T) {
 	// Ready is the deceptive starting status the bug report describes — the
 	// sidebar still paints it green even though the session is gone.
 	inst := newDeadInstance(t, "dead-session", session.Ready)
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	model, cmd := h.handleEnter()

--- a/app/detach_paint_test.go
+++ b/app/detach_paint_test.go
@@ -21,7 +21,7 @@ import (
 func TestSelectionChanged_DispatchesPaneRefreshOffEventLoop(t *testing.T) {
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "a")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	start := time.Now()
@@ -46,7 +46,7 @@ func TestSelectionChanged_DispatchesPaneRefreshOffEventLoop(t *testing.T) {
 func TestRepaintAfterDetachMsg_KicksOffRefresh(t *testing.T) {
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "a")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	start := time.Now()
@@ -67,7 +67,7 @@ func TestRepaintAfterDetachMsg_KicksOffRefresh(t *testing.T) {
 func TestRefreshPanesCmd_ProducesPanesRefreshedMsg(t *testing.T) {
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "a")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	tw := h.contentPane.TabbedWindow()

--- a/app/detach_watchdog_test.go
+++ b/app/detach_watchdog_test.go
@@ -35,7 +35,7 @@ func TestWatchdogCanceled_WhenLastInstanceRemovedWhileAttached(t *testing.T) {
 
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "only-instance")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	require.False(t, h.sidebar.GetSelection().IsHeader,
@@ -43,7 +43,7 @@ func TestWatchdogCanceled_WhenLastInstanceRemovedWhileAttached(t *testing.T) {
 
 	// Simulate: attached, then the only instance is removed out from under us.
 	h.attached.Store(true)
-	h.sidebar.RemoveInstanceByTitle("only-instance")
+	h.store.RemoveInstanceByTitle("only-instance")
 	require.True(t, h.sidebar.GetSelection().IsHeader,
 		"after removing the only instance, selection falls back to the header")
 
@@ -103,10 +103,10 @@ func TestWatchdog_NoSpuriousDumpAfterHeaderDetach(t *testing.T) {
 
 	// --- Regression: the header-selection detach must NOT write a dump.
 	inst := instanceWithFakeBackend(t, "only-instance")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 	h.attached.Store(true)
-	h.sidebar.RemoveInstanceByTitle("only-instance")
+	h.store.RemoveInstanceByTitle("only-instance")
 	require.True(t, h.sidebar.GetSelection().IsHeader)
 	h.attached.Store(false)
 

--- a/app/e2e_test.go
+++ b/app/e2e_test.go
@@ -50,7 +50,7 @@ type prFetchCall struct {
 
 // newE2EHarness constructs the home and installs the seams, but does NOT
 // start the tea.Program. Tests should preload any instances via
-// eh.home.sidebar.AddInstance(...) before calling eh.start() — once the
+// eh.home.store.AddInstance(...) before calling eh.start() — once the
 // Program is running, its goroutine owns the sidebar and direct mutation
 // from the test goroutine would race.
 func newE2EHarness(t *testing.T) *e2eHarness {
@@ -136,7 +136,7 @@ func (eh *e2eHarness) addStartedInstance(title string) *session.Instance {
 	}
 	inst.SetStartedForTest(true)
 	inst.SetStatus(session.Running)
-	eh.home.sidebar.AddInstance(inst)
+	eh.home.store.AddInstance(inst)
 	return inst
 }
 
@@ -240,7 +240,7 @@ func TestE2E_HarnessBoots(t *testing.T) {
 	// returns a batch of tickers).
 	time.Sleep(100 * time.Millisecond)
 	// Sidebar should be empty (no preloaded instances).
-	if got := len(eh.home.sidebar.GetInstances()); got != 0 {
+	if got := len(eh.home.store.GetInstances()); got != 0 {
 		t.Fatalf("expected empty sidebar, got %d instances", got)
 	}
 }
@@ -267,7 +267,7 @@ func (eh *e2eHarness) query(f func(h *home)) {
 func (eh *e2eHarness) findInstance(title string) *session.Instance {
 	var found *session.Instance
 	eh.query(func(h *home) {
-		for _, inst := range h.sidebar.GetInstances() {
+		for _, inst := range h.store.GetInstances() {
 			if inst.Title == title {
 				found = inst
 				return

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -163,7 +163,7 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	// cmd) guarantees the row is visibly deleting and kill/attach are fenced
 	// off before any other event can be processed.
 	killAction := func() tea.Msg {
-		for _, inst := range m.sidebar.GetInstances() {
+		for _, inst := range m.store.GetInstances() {
 			if inst.Title == selectedTitle {
 				inst.SetStatus(session.Deleting)
 				return startKillMsg{title: selectedTitle}
@@ -222,7 +222,7 @@ func (m *home) killInstanceCmd(title string) tea.Cmd {
 // error box.
 func (m *home) handleInstanceKilled(msg instanceKilledMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
-		for _, inst := range m.sidebar.GetInstances() {
+		for _, inst := range m.store.GetInstances() {
 			if inst.Title == msg.title && inst.GetStatus() == session.Deleting {
 				inst.SetStatus(session.Ready)
 				break
@@ -237,16 +237,16 @@ func (m *home) handleInstanceKilled(msg instanceKilledMsg) (tea.Model, tea.Cmd) 
 	// deleted disk record first — both removals are no-ops then.
 	var repoName string
 	var repoErr error = fmt.Errorf("instance not found")
-	for _, inst := range m.sidebar.GetInstances() {
+	for _, inst := range m.store.GetInstances() {
 		if inst.Title == msg.title {
 			repoName, repoErr = inst.RepoName()
 			break
 		}
 	}
 	if repoErr == nil {
-		m.sidebar.RemoveInstanceByTitleWithRepo(msg.title, repoName)
+		m.store.RemoveInstanceByTitleWithRepo(msg.title, repoName)
 	} else {
-		m.sidebar.RemoveInstanceByTitle(msg.title)
+		m.store.RemoveInstanceByTitle(msg.title)
 	}
 	return m, m.selectionChanged()
 }
@@ -326,7 +326,7 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		}
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
 			return attachOverlayCallbackFn(m, "handleEnter-sidebar", "", selected.IsRemote(), func() (chan struct{}, error) {
-				return m.sidebar.AttachInstance(selected)
+				return m.store.AttachInstance(selected)
 			})
 		})
 	}

--- a/app/handle_actions_test.go
+++ b/app/handle_actions_test.go
@@ -60,8 +60,8 @@ func TestHandleEnterAttachesCapturedInstanceAfterSelectionDrift(t *testing.T) {
 	require.NoError(t, err)
 	b.SetStatus(session.Running)
 
-	h.sidebar.AddInstance(a)
-	h.sidebar.AddInstance(b)
+	h.store.AddInstance(a)
+	h.store.AddInstance(b)
 	// User presses Enter on instance-a.
 	h.sidebar.SetSelectedInstance(0)
 

--- a/app/handle_enter_remote_terminal_test.go
+++ b/app/handle_enter_remote_terminal_test.go
@@ -63,7 +63,7 @@ func driveHandleEnterAttach(t *testing.T, terminalTab, remote bool) (tea.Cmd, st
 	require.True(t, inst.TmuxAlive(),
 		"precondition: instance must be attachable so handleEnter reaches the attach path")
 
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	tw := h.contentPane.TabbedWindow()

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -22,7 +22,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// background sync may have drifted the selection off the naming row, in
 		// which case selection-based Kill() silently no-ops and leaves a
 		// "Loading" zombie behind (#717). Kill before clearing the pointer.
-		if err := m.sidebar.KillInstance(m.namingInstance); err != nil {
+		if err := m.store.KillInstance(m.namingInstance); err != nil {
 			log.ErrorLog.Printf("failed to clean up instance on cancel: %v", err)
 		}
 		m.state = stateDefault
@@ -46,7 +46,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if strings.TrimSpace(instance.Title) == "" {
 			return m, m.handleError(fmt.Errorf("title cannot be empty"))
 		}
-		for _, other := range m.sidebar.GetInstances() {
+		for _, other := range m.store.GetInstances() {
 			if other == instance {
 				continue
 			}
@@ -60,8 +60,8 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if instance.IsRemote() {
-			existing := make([]*session.Instance, 0, m.sidebar.NumInstances())
-			for _, other := range m.sidebar.GetInstances() {
+			existing := make([]*session.Instance, 0, m.store.NumInstances())
+			for _, other := range m.store.GetInstances() {
 				if other == instance || !other.IsRemote() {
 					continue
 				}
@@ -146,7 +146,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyEsc:
 		// Kill by the captured namingInstance pointer, not the live selection
 		// (#717) — see the ctrl+c branch above for the full rationale.
-		if err := m.sidebar.KillInstance(m.namingInstance); err != nil {
+		if err := m.store.KillInstance(m.namingInstance); err != nil {
 			log.ErrorLog.Printf("failed to clean up instance on cancel: %v", err)
 		}
 		m.namingInstance = nil
@@ -177,8 +177,8 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 		return m, m.handleError(err)
 	}
 	instance.SetStatus(session.Loading)
-	m.sidebar.AddInstance(instance)
-	m.sidebar.SetSelectedInstance(m.sidebar.NumInstances() - 1)
+	m.store.AddInstance(instance)
+	m.sidebar.SetSelectedInstance(m.store.NumInstances() - 1)
 	m.namingInstance = instance
 	m.state = stateNew
 	m.menu.SetState(ui.StateNewInstance)

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -162,7 +162,7 @@ func TestCancelNamingRemovesZombieAfterSelectionDrift(t *testing.T) {
 			// it (Loading rows are protected as in-flight creations).
 			preceding := newLoadingInstance(t, "preceding")
 			preceding.SetStatus(session.Running)
-			h.sidebar.AddInstance(preceding)
+			h.store.AddInstance(preceding)
 
 			// The naming instance: Loading, empty title — exactly what
 			// startNewInstance creates. It is selected (last row).
@@ -173,15 +173,15 @@ func TestCancelNamingRemovesZombieAfterSelectionDrift(t *testing.T) {
 			})
 			require.NoError(t, err)
 			naming.SetStatus(session.Loading)
-			h.sidebar.AddInstance(naming)
-			h.sidebar.SetSelectedInstance(h.sidebar.NumInstances() - 1)
+			h.store.AddInstance(naming)
+			h.sidebar.SetSelectedInstance(h.store.NumInstances() - 1)
 			h.namingInstance = naming
 
 			// A background mutation removes `preceding` (a daemon-owned row the
 			// snapshot no longer lists). RemoveInstanceByTitle rebuilds
 			// visibleItems without adjusting selectedIdx, drifting the selection
 			// off the naming row onto a section header.
-			h.sidebar.RemoveInstanceByTitle("preceding")
+			h.store.RemoveInstanceByTitle("preceding")
 			require.Nil(t, h.sidebar.GetSelectedInstance(),
 				"precondition: selection must have drifted off the naming row onto a header")
 
@@ -189,9 +189,9 @@ func TestCancelNamingRemovesZombieAfterSelectionDrift(t *testing.T) {
 
 			assert.Equal(t, stateDefault, h.state, "cancel must return to the default state")
 			assert.Nil(t, h.namingInstance, "namingInstance pointer must be cleared on cancel")
-			assert.Equal(t, 0, h.sidebar.NumInstances(),
+			assert.Equal(t, 0, h.store.NumInstances(),
 				"the naming instance must be removed on cancel, not left as a Loading zombie; remaining titles: %v",
-				collectTitles(h.sidebar.GetInstances()))
+				collectTitles(h.store.GetInstances()))
 		})
 	}
 }
@@ -207,7 +207,7 @@ func TestHandleStateNewRejectsDuplicateTitle(t *testing.T) {
 		Program: "claude",
 	})
 	require.NoError(t, err)
-	h.sidebar.AddInstance(existing)
+	h.store.AddInstance(existing)
 
 	naming, err := session.NewInstance(session.InstanceOptions{
 		Title:   "fix-bug",
@@ -283,7 +283,7 @@ func TestHandleStateNewRejectsCaseVariantTitle(t *testing.T) {
 				Program: "claude",
 			})
 			require.NoError(t, err)
-			h.sidebar.AddInstance(existing)
+			h.store.AddInstance(existing)
 
 			naming, err := session.NewInstance(session.InstanceOptions{
 				Title:   tc.naming,
@@ -324,7 +324,7 @@ func TestHandleStateNewRejectsRemoteSlugCollision(t *testing.T) {
 		ForceRemote: true,
 	})
 	require.NoError(t, err)
-	h.sidebar.AddInstance(existing)
+	h.store.AddInstance(existing)
 
 	naming, err := session.NewInstance(session.InstanceOptions{
 		Title:       "my_app",

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -67,10 +67,10 @@ func (m *home) handleStateSearch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m *home) showSearchOverlay() (tea.Model, tea.Cmd) {
 	// The overlay outlives this call and holds onto the slice, while a
 	// background snapshotFetchedMsg reconcile can remove instances from the
-	// sidebar in place (append-shift on the shared backing array). Hand the
+	// projection in place (append-shift on the shared backing array). Hand the
 	// overlay a stable copy so a later removal can't corrupt its list with
 	// duplicate/ghost entries (#1008).
-	instances := m.sidebar.GetInstancesSnapshot()
+	instances := m.store.GetInstancesSnapshot()
 	if len(instances) == 0 {
 		return m, m.handleError(fmt.Errorf("no sessions to search"))
 	}

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -194,7 +194,7 @@ func TestHandleContentPaneFocus_ValidationFailureLeavesTaskPaneStale(t *testing.
 	require.Len(t, loaded, 1)
 	tp := h.contentPane.TaskPane()
 	tp.SetTasks(loaded)
-	h.sidebar.SetTasks(loaded)
+	h.store.SetTasks(loaded)
 	h.contentPane.SetMode(ui.ContentModeTasks)
 	tp.SetFocus(true)
 	h.errBox.SetSize(500, 1)
@@ -233,8 +233,8 @@ func TestHandleContentPaneFocus_ValidationFailureLeavesTaskPaneStale(t *testing.
 	require.Len(t, tp.GetTasks(), 1)
 	assert.True(t, tp.GetTasks()[0].Enabled,
 		"BUG: TaskPane must reload from disk after a failed save, not keep its stale toggle")
-	require.Len(t, h.sidebar.GetTasks(), 1)
-	assert.True(t, h.sidebar.GetTasks()[0].Enabled,
+	require.Len(t, h.store.GetTasks(), 1)
+	assert.True(t, h.store.GetTasks()[0].Enabled,
 		"sidebar must agree with the TaskPane (both reflect disk)")
 
 	// (c) State is not left silently "saved": reloading cleared dirty, but the
@@ -356,7 +356,7 @@ func TestHandleQuit_HooksSaveSuccessQuitsAndUpdatesHookCount(t *testing.T) {
 	_, isQuit := msg.(tea.QuitMsg)
 	assert.True(t, isQuit, "a successful save must proceed to tea.Quit")
 
-	assert.Equal(t, 1, h.sidebar.GetHookCount(),
+	assert.Equal(t, 1, h.store.GetHookCount(),
 		"the sidebar hook count must reflect the saved hook")
 
 	// The save actually landed on disk.

--- a/app/kill_async_test.go
+++ b/app/kill_async_test.go
@@ -72,7 +72,7 @@ func TestHandleKill_MarksDeletingWithoutBlockingEventLoop(t *testing.T) {
 
 	h := newTestHome(t)
 	inst := newKillableInstance(t, "slow-remote")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	// The synchronous part of the flow: confirm + the startKillMsg hop. Bound
@@ -109,7 +109,7 @@ func TestHandleKill_MarksDeletingWithoutBlockingEventLoop(t *testing.T) {
 		t.Fatal("kill cmd completed before the daemon RPC was released")
 	default:
 	}
-	assert.Equal(t, []string{"slow-remote"}, collectTitles(h.sidebar.GetInstances()),
+	assert.Equal(t, []string{"slow-remote"}, collectTitles(h.store.GetInstances()),
 		"row must stay in the sidebar while deletion is in flight")
 	assert.Equal(t, session.Deleting, inst.GetStatus())
 
@@ -126,7 +126,7 @@ func TestHandleKill_MarksDeletingWithoutBlockingEventLoop(t *testing.T) {
 	require.NoError(t, killed.err)
 
 	_, _ = h.Update(killed)
-	assert.Empty(t, h.sidebar.GetInstances(), "row must be removed once teardown completes")
+	assert.Empty(t, h.store.GetInstances(), "row must be removed once teardown completes")
 }
 
 // TestHandleKill_FailureRevertsToReadyAndAllowsRetry: a failed teardown must
@@ -139,7 +139,7 @@ func TestHandleKill_FailureRevertsToReadyAndAllowsRetry(t *testing.T) {
 	h := newTestHome(t)
 	h.errBox.SetSize(500, 1)
 	inst := newKillableInstance(t, "doomed")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	cmd := confirmKill(t, h)
@@ -154,7 +154,7 @@ func TestHandleKill_FailureRevertsToReadyAndAllowsRetry(t *testing.T) {
 
 	_, _ = h.Update(killed)
 
-	assert.Equal(t, []string{"doomed"}, collectTitles(h.sidebar.GetInstances()),
+	assert.Equal(t, []string{"doomed"}, collectTitles(h.store.GetInstances()),
 		"failed kill must keep the row so the user can retry")
 	assert.Equal(t, session.Ready, inst.GetStatus(),
 		"failed kill must revert Deleting so kill is enabled again")
@@ -181,7 +181,7 @@ func TestHandleKill_DeletingInstanceIsNoOp(t *testing.T) {
 	h.errBox.SetSize(500, 1)
 	inst := newKillableInstance(t, "going-away")
 	inst.SetStatus(session.Deleting)
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	model, _ := h.handleKill()
@@ -198,7 +198,7 @@ func TestHandleEnter_DeletingInstanceIsNoOp(t *testing.T) {
 	h.errBox.SetSize(500, 1)
 	inst := newKillableInstance(t, "going-away")
 	inst.SetStatus(session.Deleting)
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	model, _ := h.handleEnter()
@@ -214,5 +214,5 @@ func TestHandleEnter_DeletingInstanceIsNoOp(t *testing.T) {
 func TestInstanceKilled_RowAlreadyRemoved(t *testing.T) {
 	h := newTestHome(t)
 	_, _ = h.Update(instanceKilledMsg{title: "already-gone"})
-	assert.Empty(t, h.sidebar.GetInstances())
+	assert.Empty(t, h.store.GetInstances())
 }

--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -163,8 +163,8 @@ func TestTickUpdatePRInfo_DispatchesForSelectedOnly(t *testing.T) {
 
 	a := newLoadingInstance(t, "a")
 	b := newLoadingInstance(t, "b")
-	h.sidebar.AddInstance(a)
-	h.sidebar.AddInstance(b)
+	h.store.AddInstance(a)
+	h.store.AddInstance(b)
 	h.sidebar.SetSelectedInstance(1)
 
 	_, cmd := h.Update(tickUpdatePRInfoMessage{})
@@ -183,7 +183,7 @@ func TestTickUpdatePRInfo_DispatchesForSelectedOnly(t *testing.T) {
 func TestPrInfoUpdatedMsg_Success_AppliesInfoAndBumpsTimestamp(t *testing.T) {
 	h := newTestHome(t)
 	inst := newLoadingInstance(t, "target")
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 	assert.Nil(t, inst.GetPRInfo(), "precondition: no cached PR info")
 
@@ -206,7 +206,7 @@ func TestPrInfoUpdatedMsg_Error_PreservesCacheAndDebounces(t *testing.T) {
 	inst := newLoadingInstance(t, "target")
 	cached := &git.PRInfo{Number: 7, Title: "cached", State: "OPEN"}
 	inst.SetPRInfo(cached)
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	// Simulate the prInfoLastFetched timestamp being old by clearing it via
@@ -231,7 +231,7 @@ func TestSelectionChanged_DoesNotRefetchFreshInstance(t *testing.T) {
 	h := newTestHome(t)
 	inst := newStartedInstance(t, "fresh")
 	inst.SetPRInfo(&git.PRInfo{Number: 1, Title: "fresh"}) // bumps timestamp to now
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
 	// selectionChanged now also dispatches an off-loop pane refresh cmd
@@ -338,14 +338,14 @@ func TestPrInfoUpdatedMsg_InstanceSwappedDuringFetch_AppliesToLiveInstance(t *te
 	h := newTestHome(t)
 
 	orphan := newStartedInstance(t, "swapped")
-	h.sidebar.AddInstance(orphan)
+	h.store.AddInstance(orphan)
 	h.sidebar.SetSelectedInstance(0)
 
 	// Simulate the #765 swap: remove the captured instance and add a fresh
 	// same-title copy (as FromInstanceData would build).
 	live := newStartedInstance(t, "swapped")
-	h.sidebar.RemoveInstanceByTitle("swapped")
-	h.sidebar.AddInstance(live)
+	h.store.RemoveInstanceByTitle("swapped")
+	h.store.AddInstance(live)
 	require.NotSame(t, orphan, live, "sanity: swap must produce a distinct pointer")
 
 	info := &git.PRInfo{Number: 42, Title: "add feature", URL: "https://x/42", State: "OPEN"}
@@ -364,9 +364,9 @@ func TestPrInfoUpdatedMsg_InstanceGoneDuringFetch_DropsUpdate(t *testing.T) {
 	h := newTestHome(t)
 
 	orphan := newStartedInstance(t, "gone")
-	h.sidebar.AddInstance(orphan)
+	h.store.AddInstance(orphan)
 	h.sidebar.SetSelectedInstance(0)
-	h.sidebar.RemoveInstanceByTitle("gone")
+	h.store.RemoveInstanceByTitle("gone")
 
 	info := &git.PRInfo{Number: 7, Title: "lost", State: "OPEN"}
 	_, cmd := h.Update(prInfoUpdatedMsg{instance: orphan, info: info})
@@ -383,12 +383,12 @@ func TestPrInfoUpdatedMsg_Error_SwappedDuringFetch_MarksLiveInstance(t *testing.
 	h := newTestHome(t)
 
 	orphan := newStartedInstance(t, "swapped")
-	h.sidebar.AddInstance(orphan)
+	h.store.AddInstance(orphan)
 	h.sidebar.SetSelectedInstance(0)
 
 	live := newStartedInstance(t, "swapped")
-	h.sidebar.RemoveInstanceByTitle("swapped")
-	h.sidebar.AddInstance(live)
+	h.store.RemoveInstanceByTitle("swapped")
+	h.store.AddInstance(live)
 	require.Greater(t, live.PRInfoAge(), 365*24*time.Hour,
 		"precondition: live instance is never-fetched")
 
@@ -422,15 +422,15 @@ func TestPrInfoUpdatedMsg_BranchMismatch_DropsUpdate(t *testing.T) {
 	// The instance the fetch was kicked off for, on branch X.
 	orphan := newStartedInstance(t, "reused")
 	orphan.Branch = "feature/x"
-	h.sidebar.AddInstance(orphan)
+	h.store.AddInstance(orphan)
 	h.sidebar.SetSelectedInstance(0)
 
 	// User killed it and recreated a same-title instance on branch Y while the
 	// gh fetch was still running.
 	recreated := newStartedInstance(t, "reused")
 	recreated.Branch = "feature/y"
-	h.sidebar.RemoveInstanceByTitle("reused")
-	h.sidebar.AddInstance(recreated)
+	h.store.RemoveInstanceByTitle("reused")
+	h.store.AddInstance(recreated)
 
 	info := &git.PRInfo{Number: 42, Title: "branch X PR", State: "OPEN"}
 	_, cmd := h.Update(prInfoUpdatedMsg{instance: orphan, branch: "feature/x", info: info})
@@ -450,13 +450,13 @@ func TestPrInfoUpdatedMsg_BranchMatch_AppliesUpdate(t *testing.T) {
 
 	orphan := newStartedInstance(t, "reused")
 	orphan.Branch = "feature/x"
-	h.sidebar.AddInstance(orphan)
+	h.store.AddInstance(orphan)
 	h.sidebar.SetSelectedInstance(0)
 
 	live := newStartedInstance(t, "reused")
 	live.Branch = "feature/x"
-	h.sidebar.RemoveInstanceByTitle("reused")
-	h.sidebar.AddInstance(live)
+	h.store.RemoveInstanceByTitle("reused")
+	h.store.AddInstance(live)
 	require.NotSame(t, orphan, live, "sanity: swap must produce a distinct pointer")
 
 	info := &git.PRInfo{Number: 42, Title: "branch X PR", State: "OPEN"}

--- a/app/search_overlay_snapshot_test.go
+++ b/app/search_overlay_snapshot_test.go
@@ -35,9 +35,9 @@ func TestShowSearchOverlay_StableAcrossSnapshotRemoval(t *testing.T) {
 	xa := newSnapshotTestInstance(t, "xa")
 	xb := newSnapshotTestInstance(t, "xb")
 	xc := newSnapshotTestInstance(t, "xc")
-	h.sidebar.AddInstance(xa)
-	h.sidebar.AddInstance(xb)
-	h.sidebar.AddInstance(xc)
+	h.store.AddInstance(xa)
+	h.store.AddInstance(xb)
+	h.store.AddInstance(xc)
 
 	// Open the overlay exactly as the key handler does.
 	_, _ = h.showSearchOverlay()

--- a/app/snapshot_test.go
+++ b/app/snapshot_test.go
@@ -36,7 +36,7 @@ func TestReconcileSnapshot_AddsAndRemovesSessions(t *testing.T) {
 	}))
 
 	keep := newSnapshotTestInstance(t, "keep")
-	h.sidebar.AddInstance(keep)
+	h.store.AddInstance(keep)
 
 	// Snapshot adds "new" alongside the existing "keep" (matched by CreatedAt).
 	added := h.reconcileSnapshot([]session.InstanceData{
@@ -67,9 +67,9 @@ func TestReconcileSnapshot_PreservesSelectionAndActiveTab(t *testing.T) {
 	a := newSnapshotTestInstance(t, "a")
 	b := newSnapshotTestInstance(t, "b")
 	c := newSnapshotTestInstance(t, "c")
-	h.sidebar.AddInstance(a)
-	h.sidebar.AddInstance(b)
-	h.sidebar.AddInstance(c)
+	h.store.AddInstance(a)
+	h.store.AddInstance(b)
+	h.store.AddInstance(c)
 	h.sidebar.SelectInstance(b)
 	require.Same(t, b, h.sidebar.GetSelectedInstance())
 
@@ -112,9 +112,9 @@ func TestReconcileSnapshot_SelectionDriftAfterSwapAndRemoval(t *testing.T) {
 	a := newSnapshotTestInstance(t, "a")
 	b := newSnapshotTestInstance(t, "b")
 	c := newSnapshotTestInstance(t, "c")
-	h.sidebar.AddInstance(a)
-	h.sidebar.AddInstance(b)
-	h.sidebar.AddInstance(c)
+	h.store.AddInstance(a)
+	h.store.AddInstance(b)
+	h.store.AddInstance(c)
 	h.sidebar.SelectInstance(b)
 	require.Same(t, b, h.sidebar.GetSelectedInstance(), "initial selection must be on b")
 
@@ -139,7 +139,7 @@ func TestReconcileSnapshot_SelectionDriftAfterSwapAndRemoval(t *testing.T) {
 func TestReconcileSnapshot_NoChangeWhenUnchanged(t *testing.T) {
 	h := newTestHome(t)
 	a := newSnapshotTestInstance(t, "a")
-	h.sidebar.AddInstance(a)
+	h.store.AddInstance(a)
 
 	changed := h.reconcileSnapshot([]session.InstanceData{a.ToInstanceData()})
 	assert.False(t, changed, "an unchanged snapshot must not report a change (no repaint/flicker)")
@@ -153,7 +153,7 @@ func TestReconcileSnapshot_SwapsKillRecreatedSameTitle(t *testing.T) {
 	h := newTestHome(t)
 
 	stale := newSnapshotTestInstance(t, "dup")
-	h.sidebar.AddInstance(stale)
+	h.store.AddInstance(stale)
 
 	recreated := newSnapshotTestInstance(t, "dup") // distinct pointer + CreatedAt
 	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
@@ -164,7 +164,7 @@ func TestReconcileSnapshot_SwapsKillRecreatedSameTitle(t *testing.T) {
 	assert.True(t, changed)
 
 	var matches []*session.Instance
-	for _, inst := range h.sidebar.GetInstances() {
+	for _, inst := range h.store.GetInstances() {
 		if inst.Title == "dup" {
 			matches = append(matches, inst)
 		}
@@ -207,7 +207,7 @@ func TestFetchSnapshotCmd_UsesFetcherSeam(t *testing.T) {
 func TestHandleSnapshot_WarmingDaemonLeavesSidebarIntact(t *testing.T) {
 	h := newTestHome(t)
 	a := newSnapshotTestInstance(t, "a")
-	h.sidebar.AddInstance(a)
+	h.store.AddInstance(a)
 
 	changed := h.handleSnapshot(snapshotFetchedMsg{
 		err: errors.New("agent-factory daemon is starting (restoring sessions); retry shortly"),

--- a/app/sync.go
+++ b/app/sync.go
@@ -22,8 +22,8 @@ type tickUpdatePRInfoMessage struct{}
 type tickRefreshExternalMessage struct{}
 
 // snapshotFetchedMsg carries the result of an off-loop daemon Snapshot fetch
-// back to the event loop, where reconcileSnapshot mutates the sidebar (sidebar
-// mutation must stay on the bubbletea loop — #682). err is non-nil on a failed
+// back to the event loop, where reconcileSnapshot mutates the projection store
+// (store mutation must stay on the bubbletea loop — #682). err is non-nil on a failed
 // fetch; the handler retries (daemon warming) or falls back to the disk refresh
 // (version-skewed daemon without the Snapshot RPC).
 type snapshotFetchedMsg struct {
@@ -99,7 +99,7 @@ var coldStartWarmupPoll = 250 * time.Millisecond
 // the daemon is wedged reporting "starting".
 var coldStartWarmupWait = 2 * time.Minute
 
-// coldStartFromSnapshot populates the sidebar from the daemon's authoritative
+// coldStartFromSnapshot populates the projection store from the daemon's authoritative
 // Snapshot at startup, replacing the legacy instances.json disk read (#960 PR 6:
 // the TUI no longer reads the store — the daemon is the source of truth). Each
 // record is materialized the same way FromInstanceData restored a disk row,
@@ -121,7 +121,7 @@ func (m *home) coldStartFromSnapshot() error {
 			log.WarningLog.Printf("skipping session %q from snapshot: %v", d.Title, err)
 			continue
 		}
-		m.sidebar.AddInstance(inst)()
+		m.store.AddInstance(inst)()
 		inst.SetAutoYes(m.autoYes)
 	}
 	return nil
@@ -216,7 +216,7 @@ func fetchPRInfoCmd(inst *session.Instance, force bool) tea.Cmd {
 
 // -- Sync methods --
 
-// handleSnapshot applies a fetched daemon snapshot to the sidebar and reports
+// handleSnapshot applies a fetched daemon snapshot to the projection store and reports
 // whether anything changed (the caller repaints only on a diff). On a fetch
 // error it degrades rather than dropping the sidebar: a warming daemon (#829) is
 // retried on the next tick (callDaemon already waited out the warm-up window),
@@ -237,9 +237,9 @@ func (m *home) handleSnapshot(msg snapshotFetchedMsg) bool {
 	return m.reconcileSnapshot(msg.data)
 }
 
-// reconcileSnapshot mirrors the sidebar to the daemon's authoritative snapshot
-// (#960 PR 3). The daemon is the single owner of session/tab state, so the TUI
-// renders a projection of it:
+// reconcileSnapshot mirrors the projection store to the daemon's authoritative
+// snapshot (#960 PR 3). The daemon is the single owner of session/tab state, so
+// the TUI renders a projection of it:
 //   - sessions in the snapshot but missing locally are built (FromInstanceData,
 //     reconnecting tabs by tmux name) and added;
 //   - sessions gone from the snapshot are removed;
@@ -251,9 +251,10 @@ func (m *home) handleSnapshot(msg snapshotFetchedMsg) bool {
 //     instance so the dead corpse never shadows the live session.
 //
 // Local-only view state is preserved: existing rows keep their pointer (so the
-// TabbedWindow's active tab and the content pane's scroll/overlay are untouched),
-// and the selected instance is re-pinned by title after the reconcile so neither a
-// removal of a preceding row nor a same-title swap of the selected row can drift the
+// active tab and the content pane's scroll/overlay are untouched), and the
+// store's selected instance is re-pinned by title after the reconcile — the
+// sidebar re-derives its cursor from that selection, so neither a removal of a
+// preceding row nor a same-title swap of the selected row can drift the
 // cursor (#969). Transient TUI-owned rows
 // (Loading creation #808, Deleting kill #844) are left entirely alone: the
 // daemon may not yet know about an in-flight create, and a mid-teardown row must
@@ -278,7 +279,7 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 	}
 
 	existing := make(map[string]*session.Instance, len(data))
-	for _, inst := range m.sidebar.GetInstances() {
+	for _, inst := range m.store.GetInstances() {
 		existing[inst.Title] = inst
 	}
 
@@ -290,6 +291,10 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 	// pointer-equality re-pin would miss it and selection would drift (#969). The
 	// title survives the swap because the rebuilt instance keeps it — the same
 	// title-based re-resolution the async handlers already use (GetInstanceByTitle).
+	// The capture reads the sidebar's cursor-derived selection (nil while the
+	// cursor rests on a section header), not the store's sticky display
+	// binding: a reconcile must only re-pin the cursor when the cursor was
+	// actually on an instance row, never yank it off a header.
 	var selectedTitle string
 	if selected := m.sidebar.GetSelectedInstance(); selected != nil {
 		selectedTitle = selected.Title
@@ -326,7 +331,7 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 	// Remove sessions the daemon no longer owns. Skip transient rows (an
 	// in-flight create the daemon doesn't list yet; a mid-teardown kill).
 	var toRemove []*session.Instance
-	for _, inst := range m.sidebar.GetInstances() {
+	for _, inst := range m.store.GetInstances() {
 		if _, ok := snapByTitle[inst.Title]; ok {
 			continue
 		}
@@ -336,17 +341,19 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 		toRemove = append(toRemove, inst)
 	}
 	for _, inst := range toRemove {
-		m.sidebar.RemoveInstanceByTitle(inst.Title)
+		m.store.RemoveInstanceByTitle(inst.Title)
 		changed = true
 	}
 
-	// Re-pin the selection to the same logical instance (by title) if it survived
-	// the reconcile. Re-resolving by title correctly re-pins across a swap because
-	// the rebuilt instance keeps the same title (#969). If the selected title is
-	// gone from the snapshot, leave the sidebar's own clamp behavior as-is.
+	// Re-pin the selection to the same logical instance (by title) if it
+	// survived the reconcile. Re-resolving by title correctly re-pins across a
+	// swap because the rebuilt instance keeps the same title (#969). The store's
+	// SelectInstance records the assertion; the sidebar moves its cursor onto
+	// the asserted row on its next read. If the selected title is gone from the
+	// snapshot, leave the sidebar's own clamp behavior as-is.
 	if selectedTitle != "" {
-		if inst := m.sidebar.GetInstanceByTitle(selectedTitle); inst != nil {
-			m.sidebar.SelectInstance(inst)
+		if inst := m.store.GetInstanceByTitle(selectedTitle); inst != nil {
+			m.store.SelectInstance(inst)
 		}
 	}
 
@@ -354,22 +361,22 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 }
 
 // addInstanceFromSnapshot builds a live instance from a snapshot record and adds
-// it to the sidebar. Returns true on success (a real change). A build failure is
-// logged and skipped — a single unrestorable record must not abort the whole
-// reconcile.
+// it to the projection store. Returns true on success (a real change). A build
+// failure is logged and skipped — a single unrestorable record must not abort
+// the whole reconcile.
 func (m *home) addInstanceFromSnapshot(d session.InstanceData) bool {
 	inst, err := buildInstanceFromSnapshot(d)
 	if err != nil {
 		log.WarningLog.Printf("failed to build instance %q from snapshot: %v", d.Title, err)
 		return false
 	}
-	m.sidebar.AddInstance(inst)()
+	m.store.AddInstance(inst)()
 	inst.SetAutoYes(m.autoYes)
 	return true
 }
 
-// swapInstanceFromSnapshot replaces a stale same-title sidebar row with a freshly
-// built instance for the recreated session (#765), preserving the selected row.
+// swapInstanceFromSnapshot replaces a stale same-title row with a freshly
+// built instance for the recreated session (#765), preserving the selection.
 // Built BEFORE the swap so a transient build failure leaves the existing row in
 // place rather than dropping it.
 func (m *home) swapInstanceFromSnapshot(d session.InstanceData) bool {
@@ -378,15 +385,15 @@ func (m *home) swapInstanceFromSnapshot(d session.InstanceData) bool {
 		log.WarningLog.Printf("failed to build recreated instance %q from snapshot: %v", d.Title, err)
 		return false
 	}
-	if !m.sidebar.ReplaceInstanceByTitle(d.Title, inst) {
+	if !m.store.ReplaceInstanceByTitle(d.Title, inst) {
 		// The row vanished between read and swap; add it fresh.
-		m.sidebar.AddInstance(inst)()
+		m.store.AddInstance(inst)()
 	}
 	inst.SetAutoYes(m.autoYes)
 	return true
 }
 
-// updateInstanceFromSnapshot reconciles an existing sidebar row's tab list and
+// updateInstanceFromSnapshot reconciles an existing row's tab list and
 // PR badge to the snapshot IN PLACE (same pointer, so view state survives).
 // Returns whether anything changed.
 func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.InstanceData) bool {
@@ -443,7 +450,7 @@ func prInfoDiffersFromData(inst *session.Instance, d session.PRInfoData) bool {
 	return cur.Number != d.Number || cur.Title != d.Title || cur.URL != d.URL || cur.State != d.State
 }
 
-// isTransientStatus reports whether an in-memory sidebar instance is in a
+// isTransientStatus reports whether an in-memory instance is in a
 // state owned by an in-flight TUI operation — Loading (creation, #808) or
 // Deleting (async kill, #844) — during which the snapshot reconcile must
 // neither replace nor reap it.
@@ -480,9 +487,9 @@ func (m *home) importRemoteHookSessions() int {
 		return 0
 	}
 
-	existingTitles := m.sidebar.GetInstanceTitles()
+	existingTitles := m.store.GetInstanceTitles()
 	existingHookNames := make(map[string]bool)
-	for _, inst := range m.sidebar.GetInstances() {
+	for _, inst := range m.store.GetInstances() {
 		if !inst.IsRemote() {
 			continue
 		}
@@ -502,7 +509,7 @@ func (m *home) importRemoteHookSessions() int {
 			log.WarningLog.Printf("failed to import remote hook session %q: %v", data.Title, err)
 			continue
 		}
-		m.sidebar.AddInstance(inst)()
+		m.store.AddInstance(inst)()
 		inst.SetAutoYes(m.autoYes)
 		existingTitles[data.Title] = true
 		existingHookNames[name] = true

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -99,7 +99,7 @@ func instanceWithFakeBackend(t *testing.T, title string) *session.Instance {
 func TestReconcileSnapshot_MirrorsStatusOntoExistingRow(t *testing.T) {
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "a") // starts Running, started=true
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 
 	// The daemon's snapshot reports this session is now Dead. The TUI must adopt
 	// it verbatim — it does not re-derive Ready/Dead from a local probe.
@@ -120,7 +120,7 @@ func TestReconcileSnapshot_LeavesTransientRowStatusAlone(t *testing.T) {
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "a")
 	inst.SetStatus(session.Deleting)
-	h.sidebar.AddInstance(inst)
+	h.store.AddInstance(inst)
 
 	data := inst.ToInstanceData()
 	data.Status = session.Ready // daemon doesn't know about the in-flight kill
@@ -178,9 +178,9 @@ func TestImportRemoteHookSessionsAddsListCmdSessions(t *testing.T) {
 
 	imported := h.importRemoteHookSessions()
 	require.Equal(t, 1, imported)
-	require.Equal(t, 1, h.sidebar.NumInstances())
+	require.Equal(t, 1, h.store.NumInstances())
 
-	inst := h.sidebar.GetInstances()[0]
+	inst := h.store.GetInstances()[0]
 	require.True(t, inst.IsRemote())
 	require.Equal(t, "remote-one", inst.Title)
 

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -121,10 +121,11 @@ func startedLocalInstance(t *testing.T, title string) *session.Instance {
 // selectInstance wires the instance into the sidebar + tabbed window and puts the
 // content pane into instance mode, mirroring what selectionChanged would do.
 func selectInstance(h *home, inst *session.Instance) {
-	h.sidebar.AddInstance(inst)
-	h.sidebar.SetSelectedInstance(h.sidebar.NumInstances() - 1)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(h.store.NumInstances() - 1)
 	h.contentPane.SetMode(ui.ContentModeInstance)
-	h.contentPane.TabbedWindow().SetInstance(inst)
+	h.store.SetSelectedInstance(inst)
+	h.contentPane.TabbedWindow().ClampActiveTab()
 }
 
 // nextShellTabName mirrors session.uniqueShellName ("shell", "shell-2", …) so a

--- a/ui/content_pane_test.go
+++ b/ui/content_pane_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestContentPaneModeSwitch(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 	cp := NewContentPane(tw)
 
 	assert.Equal(t, ContentModeEmpty, cp.GetMode())
@@ -23,7 +23,7 @@ func TestContentPaneModeSwitch(t *testing.T) {
 }
 
 func TestContentPaneFocus(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 	cp := NewContentPane(tw)
 
 	// No focus initially
@@ -47,7 +47,7 @@ func TestContentPaneFocus(t *testing.T) {
 }
 
 func TestContentPaneTaskFocus(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 	cp := NewContentPane(tw)
 
 	cp.SetMode(ContentModeTasks)
@@ -61,7 +61,7 @@ func TestContentPaneTaskFocus(t *testing.T) {
 }
 
 func TestContentPaneModeSwitchUnfocuses(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 	cp := NewContentPane(tw)
 
 	// Focus task pane
@@ -75,7 +75,7 @@ func TestContentPaneModeSwitchUnfocuses(t *testing.T) {
 }
 
 func TestContentPaneSetSizeMatchesRenderHeight(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 	cp := NewContentPane(tw)
 
 	const w, h = 80, 30
@@ -96,7 +96,7 @@ func TestContentPaneSetSizeMatchesRenderHeight(t *testing.T) {
 // rather than being a no-op as in #524. Both shift+up/down keys and mouse
 // wheel events feed into these same methods.
 func TestContentPaneScrollRoutesToTaskPane(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 	cp := NewContentPane(tw)
 	cp.SetMode(ContentModeTasks)
 	cp.TaskPane().SetTasks([]task.Task{
@@ -127,7 +127,7 @@ func TestContentPaneScrollRoutesToTaskPane(t *testing.T) {
 // TestContentPaneScrollRoutesToHooksPane is the hooks-mode counterpart of the
 // task-pane test above. Regression test for #524.
 func TestContentPaneScrollRoutesToHooksPane(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 	cp := NewContentPane(tw)
 	cp.SetMode(ContentModeHooks)
 	cp.HooksPane().SetCommands([]string{"make build", "make test", "make lint"})
@@ -152,7 +152,7 @@ func TestContentPaneScrollRoutesToHooksPane(t *testing.T) {
 // TestContentPaneScrollEmptyModeNoOp verifies scroll in modes without lists
 // remains a safe no-op (no panics, no side-effects on other panes).
 func TestContentPaneScrollEmptyModeNoOp(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 	cp := NewContentPane(tw)
 	cp.TaskPane().SetTasks([]task.Task{{ID: "a"}, {ID: "b"}})
 	cp.HooksPane().SetCommands([]string{"x", "y"})
@@ -201,7 +201,7 @@ func TestHooksPaneScrollNoOpDuringEdit(t *testing.T) {
 }
 
 func TestContentPaneRender(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 	tw.SetSize(80, 30)
 	cp := NewContentPane(tw)
 	cp.SetSize(80, 30)

--- a/ui/layout_height_test.go
+++ b/ui/layout_height_test.go
@@ -143,7 +143,7 @@ func TestContentPaneRendersExactlyAllocatedHeight(t *testing.T) {
 		hooks = append(hooks, strings.Repeat("hook-cmd ", 20))
 	}
 
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 	cp := NewContentPane(tw)
 	cp.SetSize(w, h)
 
@@ -195,7 +195,7 @@ func TestContentPaneInlinePanesMatchAllocatedWidth(t *testing.T) {
 		// width out of the allocation the same way.
 		want := AdjustPreviewWidth(tc.w)
 
-		tw := NewTabbedWindow(NewTabPane())
+		tw := newTestTabbedWindow()
 		cp := NewContentPane(tw)
 		cp.SetSize(tc.w, tc.h)
 

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -1,14 +1,12 @@
 package ui
 
 import (
-	"errors"
 	"fmt"
-	"github.com/sachiniyer/agent-factory/log"
-	"github.com/sachiniyer/agent-factory/session"
-	"github.com/sachiniyer/agent-factory/session/tmux"
-	"github.com/sachiniyer/agent-factory/task"
 	"strconv"
 	"strings"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/store"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/lipgloss"
@@ -50,11 +48,26 @@ var sectionHeaderSelectedStyle = lipgloss.NewStyle().
 var windowIndicatorStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
 
-// Sidebar is the unified left navigation pane with collapsible sections.
+// Sidebar is the unified left navigation pane with collapsible sections. It is
+// a VIEW over the store.Projection (#1024 PR 2): the instance/task/hook data —
+// and the cross-pane selection — live in the store, written by the snapshot
+// reconcile and the session-control handlers. The sidebar owns only its local
+// UI state: the flattened row list, the cursor over it, section expansion, and
+// the scroll window.
 type Sidebar struct {
+	proj *store.Projection
+
 	sections     []SidebarSection
 	visibleItems []SidebarItem
 	selectedIdx  int
+
+	// seenVersion is the store version visibleItems (and the cursor re-pin)
+	// were last derived from. The store is written directly by event-loop
+	// handlers without notifying the sidebar, so every public method lazily
+	// re-derives via syncFromStore before touching the row list. seenSelSeq
+	// tracks the store's SelectInstance assertions the cursor has honored.
+	seenVersion uint64
+	seenSelSeq  uint64
 
 	// scrollOffset is the index into visibleItems of the first rendered row
 	// when the list is too tall for the allocation. It is adjusted lazily in
@@ -62,32 +75,27 @@ type Sidebar struct {
 	// minimally so the selected row stays visible.
 	scrollOffset int
 
-	// Data
-	instances []*session.Instance
-	tasks     []task.Task
-	hookCount int
-
 	// Rendering
 	renderer *InstanceRenderer
 	autoyes  bool
 	height   int
 	width    int
-	repos    map[string]int
 }
 
-// NewSidebar creates a new sidebar.
-func NewSidebar(spin *spinner.Model, autoYes bool) *Sidebar {
+// NewSidebar creates a new sidebar rendering the given projection.
+func NewSidebar(spin *spinner.Model, autoYes bool, proj *store.Projection) *Sidebar {
 	s := &Sidebar{
+		proj: proj,
 		sections: []SidebarSection{
 			{Kind: SectionInstances, Title: "Instances", Expanded: true},
 			{Kind: SectionTasks, Title: "Tasks", Expanded: false},
 			{Kind: SectionHooks, Title: "Hooks", Expanded: false},
 		},
 		renderer: &InstanceRenderer{spinner: spin},
-		repos:    make(map[string]int),
 		autoyes:  autoYes,
 	}
 	s.rebuildVisibleItems()
+	s.seenVersion = proj.Version()
 	return s
 }
 
@@ -98,46 +106,73 @@ func (s *Sidebar) SetSize(width, height int) {
 	s.renderer.setWidth(width)
 }
 
-// SetSessionPreviewSize sets the tmux session preview sizes. Instances whose
-// underlying tmux session has vanished (ErrSessionGone) are skipped silently
-// — the daemon-side latch already covers ongoing polling and the resize itself
-// has no useful work to do on a dead session (#496).
-func (s *Sidebar) SetSessionPreviewSize(width, height int) error {
-	var err error
-	for i, item := range s.instances {
-		if !item.Started() {
+// syncFromStore re-derives the flattened row list when the projection changed
+// since the last derivation, then re-pins the cursor. The cursor rules
+// preserve the pre-store mutation behavior exactly:
+//   - by default the cursor keeps its flat index, clamped by the rebuild —
+//     the same drift-then-clamp the old mutation-time rebuild applied (a
+//     removal can legitimately drift the cursor, e.g. onto a header while
+//     naming an instance — the #717 reality the cancel path defends against);
+//   - a pending SelectInstance assertion (the reconcile's #969 re-pin, the
+//     search overlay, an explicit re-select) moves the cursor onto the
+//     asserted instance's row; a dangling or nil assertion leaves the clamped
+//     cursor as-is, matching the old "selected title gone → sidebar clamp
+//     behavior" rule.
+//
+// Afterwards the cursor's row (if it rests on an instance) is pushed back
+// into the store so the display binding and the cursor can never disagree at
+// a read boundary.
+func (s *Sidebar) syncFromStore() {
+	if s.proj.Version() == s.seenVersion {
+		return
+	}
+	s.rebuildVisibleItems()
+	if s.proj.SelectionSeq() != s.seenSelSeq {
+		if inst := s.proj.GetSelectedInstance(); inst != nil {
+			s.moveCursorToInstance(inst)
+		}
+		s.seenSelSeq = s.proj.SelectionSeq()
+	}
+	s.pushSelection()
+	s.seenVersion = s.proj.Version()
+}
+
+// moveCursorToInstance places the cursor on the row of target, if it is in
+// the projection and its row is visible. No-op otherwise.
+func (s *Sidebar) moveCursorToInstance(target *session.Instance) {
+	for i, inst := range s.proj.GetInstances() {
+		if inst != target {
 			continue
 		}
-		if innerErr := item.SetPreviewSize(width, height); innerErr != nil {
-			if errors.Is(innerErr, tmux.ErrSessionGone) {
-				continue
+		for j, item := range s.visibleItems {
+			if item.Kind == SectionInstances && !item.IsHeader && item.ItemIndex == i {
+				s.selectedIdx = j
+				return
 			}
-			err = fmt.Errorf("could not set preview size for instance %d: %v", i, innerErr)
 		}
+		return
 	}
-	return err
 }
 
-// SetTasks updates the task data.
-func (s *Sidebar) SetTasks(tasks []task.Task) {
-	s.tasks = tasks
-	s.rebuildVisibleItems()
-}
-
-// SetHookCount updates the displayed hook count.
-func (s *Sidebar) SetHookCount(count int) {
-	s.hookCount = count
-	s.rebuildVisibleItems()
-}
-
-// GetHookCount returns the currently displayed hook count.
-func (s *Sidebar) GetHookCount() int {
-	return s.hookCount
-}
-
-// GetTasks returns the current tasks.
-func (s *Sidebar) GetTasks() []task.Task {
-	return s.tasks
+// pushSelection records the cursor's instance (when it rests on an instance
+// row) as the store's display binding. Header rows deliberately do NOT clear
+// the binding: the workspace panes keep displaying the last selected instance
+// while the cursor tours headers, exactly as the pre-store TabbedWindow kept
+// its instance pointer. Callers run this after a sync, so folding the
+// resulting version move into the seen markers is safe (single-threaded event
+// loop; nothing else can write between).
+func (s *Sidebar) pushSelection() {
+	sel := s.rawSelection()
+	if sel.Kind != SectionInstances || sel.IsHeader {
+		return
+	}
+	instances := s.proj.GetInstances()
+	if sel.ItemIndex < 0 || sel.ItemIndex >= len(instances) {
+		return
+	}
+	s.proj.SetSelectedInstance(instances[sel.ItemIndex])
+	s.seenVersion = s.proj.Version()
+	s.seenSelSeq = s.proj.SelectionSeq()
 }
 
 // rebuildVisibleItems rebuilds the flat list of visible items based on expand/collapse state.
@@ -148,7 +183,7 @@ func (s *Sidebar) rebuildVisibleItems() {
 		if sec.Expanded {
 			switch sec.Kind {
 			case SectionInstances:
-				for i := range s.instances {
+				for i := 0; i < s.proj.NumInstances(); i++ {
 					items = append(items, SidebarItem{Kind: SectionInstances, ItemIndex: i})
 				}
 			}
@@ -164,31 +199,44 @@ func (s *Sidebar) rebuildVisibleItems() {
 	}
 }
 
-// GetSelection returns the currently selected sidebar item.
-func (s *Sidebar) GetSelection() SidebarItem {
+// rawSelection returns the currently selected item without syncing against
+// the store — for internal use where visibleItems is already current (or
+// deliberately pre-sync, as in syncFromStore).
+func (s *Sidebar) rawSelection() SidebarItem {
 	if len(s.visibleItems) == 0 {
 		return SidebarItem{Kind: SectionInstances, IsHeader: true}
 	}
 	return s.visibleItems[s.selectedIdx]
 }
 
+// GetSelection returns the currently selected sidebar item.
+func (s *Sidebar) GetSelection() SidebarItem {
+	s.syncFromStore()
+	return s.rawSelection()
+}
+
 // Down moves the cursor down.
 func (s *Sidebar) Down() {
+	s.syncFromStore()
 	if s.selectedIdx < len(s.visibleItems)-1 {
 		s.selectedIdx++
 	}
+	s.pushSelection()
 }
 
 // Up moves the cursor up.
 func (s *Sidebar) Up() {
+	s.syncFromStore()
 	if s.selectedIdx > 0 {
 		s.selectedIdx--
 	}
+	s.pushSelection()
 }
 
 // ToggleSection expands or collapses the section of the current selection.
 func (s *Sidebar) ToggleSection() {
-	sel := s.GetSelection()
+	s.syncFromStore()
+	sel := s.rawSelection()
 	if !sel.IsHeader {
 		return
 	}
@@ -199,6 +247,7 @@ func (s *Sidebar) ToggleSection() {
 		}
 	}
 	s.rebuildVisibleItems()
+	s.pushSelection()
 }
 
 // ExpandInstancesSection ensures the Instances section is expanded.
@@ -214,7 +263,8 @@ func (s *Sidebar) ExpandInstancesSection() {
 
 // ExpandSection expands the section of the current selection.
 func (s *Sidebar) ExpandSection() {
-	sel := s.GetSelection()
+	s.syncFromStore()
+	sel := s.rawSelection()
 	if !sel.IsHeader {
 		return
 	}
@@ -225,11 +275,13 @@ func (s *Sidebar) ExpandSection() {
 		}
 	}
 	s.rebuildVisibleItems()
+	s.pushSelection()
 }
 
 // CollapseSection collapses the section of the current selection.
 func (s *Sidebar) CollapseSection() {
-	sel := s.GetSelection()
+	s.syncFromStore()
+	sel := s.rawSelection()
 	if !sel.IsHeader {
 		// If on a child, jump to parent header
 		for i, item := range s.visibleItems {
@@ -246,10 +298,12 @@ func (s *Sidebar) CollapseSection() {
 		}
 	}
 	s.rebuildVisibleItems()
+	s.pushSelection()
 }
 
 // JumpNextSection jumps to the next section header.
 func (s *Sidebar) JumpNextSection() {
+	s.syncFromStore()
 	for i := s.selectedIdx + 1; i < len(s.visibleItems); i++ {
 		if s.visibleItems[i].IsHeader {
 			s.selectedIdx = i
@@ -260,6 +314,7 @@ func (s *Sidebar) JumpNextSection() {
 
 // JumpPrevSection jumps to the previous section header.
 func (s *Sidebar) JumpPrevSection() {
+	s.syncFromStore()
 	for i := s.selectedIdx - 1; i >= 0; i-- {
 		if s.visibleItems[i].IsHeader {
 			s.selectedIdx = i
@@ -268,115 +323,29 @@ func (s *Sidebar) JumpPrevSection() {
 	}
 }
 
-// --- Instance management (delegates to underlying data) ---
-
-// NumInstances returns the number of instances.
-func (s *Sidebar) NumInstances() int {
-	return len(s.instances)
-}
-
-// NumRepos returns the number of repositories represented in the sidebar.
-func (s *Sidebar) NumRepos() int {
-	return len(s.repos)
-}
-
-// AddInstance adds a new instance. Returns a finalizer to register the repo.
-func (s *Sidebar) AddInstance(instance *session.Instance) (finalize func()) {
-	s.instances = append(s.instances, instance)
-	s.rebuildVisibleItems()
-	return func() { s.RegisterRepoForInstance(instance) }
-}
-
-// RegisterRepoForInstance records the instance's repo after the instance has
-// started and its worktree is available.
-func (s *Sidebar) RegisterRepoForInstance(instance *session.Instance) {
-	repoName, err := instance.RepoName()
-	if err != nil {
-		log.ErrorLog.Printf("could not get repo name: %v", err)
-		return
-	}
-	s.addRepo(repoName)
-}
-
-// Kill kills the currently selected instance. It returns an error if the
-// underlying kill fails, in which case the instance is NOT removed from the
-// sidebar so the user can retry. See KillInstance for the pointer-based
-// variant that deferred/cancel flows must use.
-func (s *Sidebar) Kill() error {
-	return s.KillInstance(s.GetSelectedInstance())
-}
-
-// KillInstance kills the given instance by pointer identity, independent of the
-// current selection. Deferred flows — most notably canceling a new instance
-// via Escape/ctrl+c — must use this rather than Kill(): background sync can
-// rebuild visibleItems and drift the selection off the target row between the
-// time the operation is initiated and the time it runs. Selection-based Kill()
-// would then silently no-op (selection landed on a section header) and leave
-// the naming instance behind as a "Loading" zombie (#717).
-//
-// A nil target or an instance no longer in the sidebar is a no-op, mirroring
-// Kill()'s tolerance for a stale selection.
-func (s *Sidebar) KillInstance(target *session.Instance) error {
-	if target == nil {
-		return nil
-	}
-	idx := -1
-	for i, inst := range s.instances {
-		if inst == target {
-			idx = i
-			break
-		}
-	}
-	if idx < 0 {
-		return nil
-	}
-	// Capture repo name before Kill(), because Kill() sets started=false
-	// which causes RepoName() to fail.
-	repoName, repoErr := target.RepoName()
-	if err := target.Kill(); err != nil {
-		return fmt.Errorf("could not kill instance: %w", err)
-	}
-	if repoErr != nil {
-		log.ErrorLog.Printf("could not get repo name: %v", repoErr)
-	} else {
-		s.rmRepo(repoName)
-	}
-	s.instances = append(s.instances[:idx], s.instances[idx+1:]...)
-	s.rebuildVisibleItems()
-	return nil
-}
-
-// AttachInstance attaches to the given instance by pointer identity, but only
-// if it is still present in the sidebar. Deferred attach flows — the first-time
-// attach help screen, whose onDismiss callback runs after the overlay is
-// dismissed — must capture the instance at key-press time and attach through
-// this method rather than re-reading the live selection: a background refresh
-// can drift the selection onto a different instance while the help overlay is
-// open, so Attach() would connect to the wrong session (#716).
-func (s *Sidebar) AttachInstance(target *session.Instance) (chan struct{}, error) {
-	if target == nil || !s.ContainsInstance(target) {
-		return nil, fmt.Errorf("instance no longer exists")
-	}
-	return target.Attach()
-}
-
-// GetSelectedInstance returns the currently selected instance, or nil.
+// GetSelectedInstance returns the instance under the cursor, or nil when the
+// cursor rests on a section header. Note this is the cursor-derived selection;
+// the store's GetSelectedInstance is the sticky display selection the
+// workspace panes render.
 func (s *Sidebar) GetSelectedInstance() *session.Instance {
-	sel := s.GetSelection()
+	s.syncFromStore()
+	sel := s.rawSelection()
 	if sel.Kind != SectionInstances || sel.IsHeader {
 		return nil
 	}
-	if sel.ItemIndex < 0 || sel.ItemIndex >= len(s.instances) {
+	instances := s.proj.GetInstances()
+	if sel.ItemIndex < 0 || sel.ItemIndex >= len(instances) {
 		return nil
 	}
-	return s.instances[sel.ItemIndex]
+	return instances[sel.ItemIndex]
 }
 
-// SetSelectedInstance sets the selected index to point at the given instance index.
-// If the Instances section is collapsed, it is expanded first so the target row
-// is always reachable.
+// SetSelectedInstance sets the cursor to point at the given instance index.
+// If the Instances section is collapsed, it is expanded first so the target
+// row is always reachable.
 func (s *Sidebar) SetSelectedInstance(idx int) {
-	if idx >= len(s.instances) {
+	s.syncFromStore()
+	if idx >= s.proj.NumInstances() {
 		return
 	}
 	// Ensure the Instances section is expanded so the target row is part of
@@ -386,186 +355,20 @@ func (s *Sidebar) SetSelectedInstance(idx int) {
 	for i, item := range s.visibleItems {
 		if item.Kind == SectionInstances && !item.IsHeader && item.ItemIndex == idx {
 			s.selectedIdx = i
-			return
+			break
 		}
 	}
+	s.pushSelection()
 }
 
 // SelectInstance finds and selects the given instance.
 func (s *Sidebar) SelectInstance(target *session.Instance) {
-	for i, inst := range s.instances {
+	s.syncFromStore()
+	for i, inst := range s.proj.GetInstances() {
 		if inst == target {
 			s.SetSelectedInstance(i)
 			return
 		}
-	}
-}
-
-// ContainsInstance reports whether target is currently in the sidebar.
-func (s *Sidebar) ContainsInstance(target *session.Instance) bool {
-	for _, inst := range s.instances {
-		if inst == target {
-			return true
-		}
-	}
-	return false
-}
-
-// ReplaceInstance swaps an existing sidebar instance for replacement while
-// preserving the selected row when the replaced instance was selected, and keeps
-// the repos map (which drives the multi-repo indicator) correct: the outgoing
-// instance's repo is decremented and the replacement's repo registered. A
-// kill+recreate can swap in an instance from a DIFFERENT repo (#971), so doing the
-// bookkeeping here — at the primitive — means every caller (ReplaceInstanceByTitle,
-// swapInstanceFromSnapshot, the instanceStartedMsg start path) stays correct
-// without remembering a separate RegisterRepoForInstance call. RepoName() errors
-// are skipped silently rather than logged: the outgoing row may be an unstarted
-// Loading placeholder (never registered, nothing to decrement) and either side may
-// be a remote instance with no local repo — both are normal, not failures.
-func (s *Sidebar) ReplaceInstance(target, replacement *session.Instance) bool {
-	for i, inst := range s.instances {
-		if inst != target {
-			continue
-		}
-		wasSelected := s.GetSelectedInstance() == inst
-		if repoName, err := inst.RepoName(); err == nil {
-			s.rmRepo(repoName)
-		}
-		s.instances[i] = replacement
-		if repoName, err := replacement.RepoName(); err == nil {
-			s.addRepo(repoName)
-		}
-		s.rebuildVisibleItems()
-		if wasSelected {
-			s.SetSelectedInstance(i)
-		}
-		return true
-	}
-	return false
-}
-
-// ReplaceInstanceByTitle swaps the sidebar instance carrying the given title
-// for replacement, preserving the selected row. Returns false when no
-// instance has that title. Used by the instance-start handler when its
-// pointer-based ReplaceInstance misses: a background sync may have swapped
-// the Loading placeholder for a disk-built copy of the same session while
-// the start RPC was in flight, and re-adding the started instance would
-// leave two sidebar rows — and two persisted records — with one title (#808).
-func (s *Sidebar) ReplaceInstanceByTitle(title string, replacement *session.Instance) bool {
-	for _, inst := range s.instances {
-		if inst.Title == title {
-			return s.ReplaceInstance(inst, replacement)
-		}
-	}
-	return false
-}
-
-// GetInstanceByTitle returns the sidebar instance carrying the given title, or
-// nil when none matches. Async handlers that captured an *Instance pointer
-// before awaiting a background fetch use this to re-resolve the live instance:
-// a background sync may have removed the captured instance and rebuilt a fresh
-// same-title copy via FromInstanceData while the fetch was in flight (#765),
-// orphaning the original pointer. Re-resolving by title lands the update on the
-// instance that currently represents the session (#862).
-func (s *Sidebar) GetInstanceByTitle(title string) *session.Instance {
-	for _, inst := range s.instances {
-		if inst.Title == title {
-			return inst
-		}
-	}
-	return nil
-}
-
-// GetInstances returns all instances. The returned slice shares the sidebar's
-// backing array, so callers must only read it inline on the bubbletea event
-// loop and must NOT store it beyond the immediate call — never hand it to a
-// goroutine that outlives the call, and never stash it in an overlay or struct
-// field that survives past this call. A later append/remove mutates the shared
-// backing array in place, corrupting any retained slice (#1008). Use
-// GetInstancesSnapshot for anything that keeps the slice around.
-func (s *Sidebar) GetInstances() []*session.Instance {
-	return s.instances
-}
-
-// GetInstancesSnapshot returns a copy of the instances slice for handing off
-// to a background goroutine. The metadata tick (#682) iterates the list on a
-// separate goroutine while the event loop may append/remove instances; copying
-// the slice header here (on the event loop, where mutations also happen) gives
-// the goroutine a private backing array so the two cannot race on the same
-// memory. The *session.Instance elements are shared, but each guards its own
-// fields with a mutex, so reading them across goroutines is safe.
-func (s *Sidebar) GetInstancesSnapshot() []*session.Instance {
-	out := make([]*session.Instance, len(s.instances))
-	copy(out, s.instances)
-	return out
-}
-
-// GetInstanceTitles returns a set of all instance titles for quick comparison.
-func (s *Sidebar) GetInstanceTitles() map[string]bool {
-	titles := make(map[string]bool, len(s.instances))
-	for _, inst := range s.instances {
-		titles[inst.Title] = true
-	}
-	return titles
-}
-
-// RemoveInstanceByTitle removes an instance from the sidebar by title without
-// killing it (the external process already cleaned up tmux/worktree).
-// Note: the instance may already have been killed (started=false), so we fall
-// back to looking up the repo name from the gitWorktree directly.
-func (s *Sidebar) RemoveInstanceByTitle(title string) bool {
-	for i, inst := range s.instances {
-		if inst.Title == title {
-			repoName, err := inst.RepoName()
-			if err != nil {
-				// If RepoName() fails (e.g. instance already killed/not started),
-				// try to find and remove the repo by scanning remaining instances.
-				// We cannot decrement the repo count without the name, so log and
-				// continue — the repo map will be corrected on next full rebuild.
-				log.ErrorLog.Printf("could not get repo name: %v", err)
-			} else {
-				s.rmRepo(repoName)
-			}
-			s.instances = append(s.instances[:i], s.instances[i+1:]...)
-			s.rebuildVisibleItems()
-			return true
-		}
-	}
-	return false
-}
-
-// RemoveInstanceByTitleWithRepo removes an instance from the sidebar by title
-// using the supplied repoName instead of calling RepoName() on the instance.
-// This is useful when the caller has already killed the instance (which causes
-// RepoName() to fail) but captured the repo name beforehand, ensuring the repo
-// count is still decremented correctly.
-func (s *Sidebar) RemoveInstanceByTitleWithRepo(title, repoName string) bool {
-	for i, inst := range s.instances {
-		if inst.Title == title {
-			s.rmRepo(repoName)
-			s.instances = append(s.instances[:i], s.instances[i+1:]...)
-			s.rebuildVisibleItems()
-			return true
-		}
-	}
-	return false
-}
-
-func (s *Sidebar) addRepo(repo string) {
-	if _, ok := s.repos[repo]; !ok {
-		s.repos[repo] = 0
-	}
-	s.repos[repo]++
-}
-
-func (s *Sidebar) rmRepo(repo string) {
-	if _, ok := s.repos[repo]; !ok {
-		log.ErrorLog.Printf("repo %s not found", repo)
-		return
-	}
-	s.repos[repo]--
-	if s.repos[repo] == 0 {
-		delete(s.repos, repo)
 	}
 }
 
@@ -577,6 +380,8 @@ func (s *Sidebar) rmRepo(repo string) {
 // fold while navigating — instead the rendered slice scrolls so the selection
 // is always visible, with "▲/▼ N more" rows marking hidden items.
 func (s *Sidebar) String() string {
+	s.syncFromStore()
+
 	// Chrome above the item list: one leading blank line plus the title row.
 	const chromeLines = 2
 
@@ -758,13 +563,13 @@ func (s *Sidebar) renderHeader(kind SidebarSectionKind, selected bool) string {
 	var label string
 	switch kind {
 	case SectionInstances:
-		label = fmt.Sprintf("Instances (%d)", len(s.instances))
+		label = fmt.Sprintf("Instances (%d)", s.proj.NumInstances())
 	case SectionTasks:
-		label = fmt.Sprintf("Tasks (%d)", len(s.tasks))
+		label = fmt.Sprintf("Tasks (%d)", len(s.proj.GetTasks()))
 		arrow = "  " // no expand arrow for leaf sections
 	case SectionHooks:
-		if s.hookCount > 0 {
-			label = fmt.Sprintf("Hooks (%d)", s.hookCount)
+		if s.proj.GetHookCount() > 0 {
+			label = fmt.Sprintf("Hooks (%d)", s.proj.GetHookCount())
 		} else {
 			label = "Hooks"
 		}
@@ -793,12 +598,13 @@ func (s *Sidebar) renderHeader(kind SidebarSectionKind, selected bool) string {
 }
 
 func (s *Sidebar) renderInstance(idx int, selected bool) string {
-	if idx < 0 || idx >= len(s.instances) {
+	instances := s.proj.GetInstances()
+	if idx < 0 || idx >= len(instances) {
 		return ""
 	}
 	// Pad the index to the digit width of the largest 1-based index in the list
 	// so every row's prefix is the same width and the branch/PR lines align,
 	// without widening the common small-list case (#871, #923, #939).
-	s.renderer.indexWidth = len(strconv.Itoa(len(s.instances)))
-	return s.renderer.Render(s.instances[idx], idx+1, selected, len(s.repos) > 1)
+	s.renderer.indexWidth = len(strconv.Itoa(len(instances)))
+	return s.renderer.Render(instances[idx], idx+1, selected, s.proj.NumRepos() > 1)
 }

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui/store"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -20,7 +21,7 @@ import (
 
 func TestSidebarInitialState(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	// Should have 3 sections
 	assert.Equal(t, 3, len(s.sections))
@@ -38,7 +39,7 @@ func TestSidebarInitialState(t *testing.T) {
 
 func TestSidebarNavigation(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	// Add some instances
 	inst1, _ := session.NewInstance(session.InstanceOptions{
@@ -47,8 +48,8 @@ func TestSidebarNavigation(t *testing.T) {
 	inst2, _ := session.NewInstance(session.InstanceOptions{
 		Title: "inst2", Path: t.TempDir(), Program: "test",
 	})
-	s.AddInstance(inst1)
-	s.AddInstance(inst2)
+	addTestInstance(s, inst1)
+	addTestInstance(s, inst2)
 
 	// Start on Instances header
 	sel := s.GetSelection()
@@ -86,12 +87,12 @@ func TestSidebarNavigation(t *testing.T) {
 
 func TestSidebarExpandCollapse(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	inst, _ := session.NewInstance(session.InstanceOptions{
 		Title: "inst", Path: t.TempDir(), Program: "test",
 	})
-	s.AddInstance(inst)
+	addTestInstance(s, inst)
 
 	// Initially Instances is expanded, so we should see header + 1 instance + other headers
 	initialCount := len(s.visibleItems)
@@ -112,7 +113,7 @@ func TestSidebarExpandCollapse(t *testing.T) {
 
 func TestSidebarToggleSection(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	// Toggle Instances (starts expanded)
 	s.ToggleSection()
@@ -124,12 +125,12 @@ func TestSidebarToggleSection(t *testing.T) {
 
 func TestSidebarJumpSections(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	inst, _ := session.NewInstance(session.InstanceOptions{
 		Title: "inst", Path: t.TempDir(), Program: "test",
 	})
-	s.AddInstance(inst)
+	addTestInstance(s, inst)
 
 	// Start on Instances header
 	sel := s.GetSelection()
@@ -152,12 +153,12 @@ func TestSidebarJumpSections(t *testing.T) {
 
 func TestSidebarCollapseFromChild(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	inst, _ := session.NewInstance(session.InstanceOptions{
 		Title: "inst", Path: t.TempDir(), Program: "test",
 	})
-	s.AddInstance(inst)
+	addTestInstance(s, inst)
 
 	// Navigate to instance child
 	s.Down()
@@ -174,17 +175,17 @@ func TestSidebarCollapseFromChild(t *testing.T) {
 
 func TestSidebarInstanceManagement(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
-	assert.Equal(t, 0, s.NumInstances())
+	assert.Equal(t, 0, s.proj.NumInstances())
 
 	inst, _ := session.NewInstance(session.InstanceOptions{
 		Title: "test", Path: t.TempDir(), Program: "test",
 	})
-	s.AddInstance(inst)
-	assert.Equal(t, 1, s.NumInstances())
+	addTestInstance(s, inst)
+	assert.Equal(t, 1, s.proj.NumInstances())
 
-	instances := s.GetInstances()
+	instances := s.proj.GetInstances()
 	assert.Len(t, instances, 1)
 	assert.Equal(t, "test", instances[0].Title)
 }
@@ -208,7 +209,7 @@ func (b *goneSetPreviewSizeBackend) SetPreviewSize(*session.Instance, int, int) 
 // at ERROR on every window-resize.
 func TestSidebarSetSessionPreviewSizeSkipsErrSessionGone(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title: "dead", Path: t.TempDir(), Program: "test",
@@ -216,15 +217,15 @@ func TestSidebarSetSessionPreviewSizeSkipsErrSessionGone(t *testing.T) {
 	require.NoError(t, err)
 	inst.SetBackend(&goneSetPreviewSizeBackend{FakeBackend: session.NewFakeBackend()})
 	inst.SetStartedForTest(true)
-	s.AddInstance(inst)
+	addTestInstance(s, inst)
 
-	require.NoError(t, s.SetSessionPreviewSize(80, 24),
+	require.NoError(t, s.proj.SetSessionPreviewSize(80, 24),
 		"ErrSessionGone from a single instance must not propagate as a returned error")
 }
 
 func TestSidebarSelectInstance(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	inst1, _ := session.NewInstance(session.InstanceOptions{
 		Title: "first", Path: t.TempDir(), Program: "test",
@@ -232,8 +233,8 @@ func TestSidebarSelectInstance(t *testing.T) {
 	inst2, _ := session.NewInstance(session.InstanceOptions{
 		Title: "second", Path: t.TempDir(), Program: "test",
 	})
-	s.AddInstance(inst1)
-	s.AddInstance(inst2)
+	addTestInstance(s, inst1)
+	addTestInstance(s, inst2)
 
 	s.SetSelectedInstance(1)
 	selected := s.GetSelectedInstance()
@@ -251,7 +252,7 @@ func TestSidebarSelectInstance(t *testing.T) {
 // expands the section and selects the target instance (regression for #275).
 func TestSetSelectedInstanceExpandsCollapsedSection(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	inst1, _ := session.NewInstance(session.InstanceOptions{
 		Title: "first", Path: t.TempDir(), Program: "test",
@@ -259,8 +260,8 @@ func TestSetSelectedInstanceExpandsCollapsedSection(t *testing.T) {
 	inst2, _ := session.NewInstance(session.InstanceOptions{
 		Title: "second", Path: t.TempDir(), Program: "test",
 	})
-	s.AddInstance(inst1)
-	s.AddInstance(inst2)
+	addTestInstance(s, inst1)
+	addTestInstance(s, inst2)
 
 	// Sanity check: SetSelectedInstance works when expanded.
 	s.SetSelectedInstance(1)
@@ -287,27 +288,27 @@ func TestSetSelectedInstanceExpandsCollapsedSection(t *testing.T) {
 
 func TestSidebarTaskData(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	tasks := []task.Task{
 		{ID: "1", Prompt: "backup", CronExpr: "0 0 * * *", Enabled: true, CreatedAt: time.Now()},
 		{ID: "2", Prompt: "health check", CronExpr: "*/5 * * * *", Enabled: false, CreatedAt: time.Now()},
 	}
-	s.SetTasks(tasks)
+	s.proj.SetTasks(tasks)
 
-	result := s.GetTasks()
+	result := s.proj.GetTasks()
 	assert.Len(t, result, 2)
 }
 
 func TestSidebarRender(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 	s.SetSize(40, 20)
 
 	inst, _ := session.NewInstance(session.InstanceOptions{
 		Title: "my-feature", Path: t.TempDir(), Program: "test",
 	})
-	s.AddInstance(inst)
+	addTestInstance(s, inst)
 
 	rendered := s.String()
 	assert.Contains(t, rendered, "Instances (1)")
@@ -337,14 +338,14 @@ func indicatorArrows(out string) (up, down bool) {
 func newWindowingSidebar(t *testing.T, n int) *Sidebar {
 	t.Helper()
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 	dir := t.TempDir()
 	for i := 0; i < n; i++ {
 		inst, err := session.NewInstance(session.InstanceOptions{
 			Title: fmt.Sprintf("win-%02d", i), Path: dir, Program: "test",
 		})
 		require.NoError(t, err)
-		s.AddInstance(inst)
+		addTestInstance(s, inst)
 	}
 	return s
 }
@@ -684,21 +685,21 @@ func newRepoInstance(t *testing.T, title, repoName string) *session.Instance {
 // repo entry and shows a phantom multi-repo indicator (#971).
 func TestReplaceInstanceRepoTrackingStaleEntry(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	a := newRepoInstance(t, "a", "repo-A")
 	c := newRepoInstance(t, "c", "repo-C")
-	s.AddInstance(a)()
-	s.AddInstance(c)()
-	require.Equal(t, 2, s.NumRepos())
+	addTestInstance(s, a)()
+	addTestInstance(s, c)()
+	require.Equal(t, 2, s.proj.NumRepos())
 
 	// Replace the repo-A instance with one from repo-B.
 	b := newRepoInstance(t, "b", "repo-B")
-	require.True(t, s.ReplaceInstance(a, b))
+	require.True(t, s.proj.ReplaceInstance(a, b))
 
-	_, staleA := s.repos["repo-A"]
+	staleA := s.proj.HasRepo("repo-A")
 	assert.False(t, staleA, "outgoing instance's repo (repo-A) must be dropped after a cross-repo replace")
-	assert.Equal(t, 2, s.NumRepos(), "repos must be {repo-B, repo-C} after the replace")
+	assert.Equal(t, 2, s.proj.NumRepos(), "repos must be {repo-B, repo-C} after the replace")
 }
 
 // TestReplaceInstanceRepoTrackingMissingNew: replacing an instance with one from a
@@ -706,19 +707,19 @@ func TestReplaceInstanceRepoTrackingStaleEntry(t *testing.T) {
 // repo is invisible to the multi-repo indicator until the next full reload (#971).
 func TestReplaceInstanceRepoTrackingMissingNew(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	s := NewSidebar(&spin, false)
+	s := NewSidebar(&spin, false, store.NewProjection())
 
 	a := newRepoInstance(t, "a", "repo-A")
-	s.AddInstance(a)()
-	require.Equal(t, 1, s.NumRepos())
+	addTestInstance(s, a)()
+	require.Equal(t, 1, s.proj.NumRepos())
 
 	// Replace the only instance with one from repo-B.
 	b := newRepoInstance(t, "b", "repo-B")
-	require.True(t, s.ReplaceInstance(a, b))
+	require.True(t, s.proj.ReplaceInstance(a, b))
 
-	_, hasB := s.repos["repo-B"]
+	hasB := s.proj.HasRepo("repo-B")
 	assert.True(t, hasB, "incoming instance's repo (repo-B) must be registered after a cross-repo replace")
-	_, staleA := s.repos["repo-A"]
+	staleA := s.proj.HasRepo("repo-A")
 	assert.False(t, staleA, "outgoing repo-A must not linger")
-	assert.Equal(t, 1, s.NumRepos(), "repos must be exactly {repo-B} after the replace")
+	assert.Equal(t, 1, s.proj.NumRepos(), "repos must be exactly {repo-B} after the replace")
 }

--- a/ui/store/projection.go
+++ b/ui/store/projection.go
@@ -1,0 +1,466 @@
+// Package store holds the TUI's single read-only projection of daemon-owned
+// state (#1024 PR 2).
+//
+// Under the #960 single-writer architecture the daemon is the sole owner and
+// writer of session/tab state: the TUI renders a projection of the daemon's
+// Snapshot RPC and mutates only via daemon RPCs. Projection is where that
+// projection lives client-side. Before this package the Sidebar owned the
+// instance list (plus repo bookkeeping) and the TabbedWindow held instance
+// pointers — the sidebar was a model, not a view. Now reconcileSnapshot
+// (app/sync.go) and the session-control handlers write the Projection, and
+// the panes (Sidebar, TabbedWindow, ContentPane) read it, keeping only their
+// own local UI state (cursor, scroll offset, section expansion).
+//
+// "Write" here always means mirroring daemon state — or TUI-transient rows
+// (Loading creation #808, Deleting kill #844) — into the in-memory model,
+// never persisting: the TUI has no disk write path for session state (#959).
+//
+// Concurrency contract: every method must be called on the bubbletea event
+// loop, with two deliberate exceptions — ActiveTab/SetActiveTab are backed by
+// an atomic because the background capture goroutine reads the active tab
+// index while the event loop writes it (#684), and the *session.Instance
+// elements themselves guard their fields with their own mutexes so a
+// goroutine holding a captured pointer may read them (#682).
+package store
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// Projection is the TUI's in-memory model of daemon-owned state plus the
+// cross-pane selection. There is exactly one per home model.
+type Projection struct {
+	// Data mirrored from the daemon Snapshot (instances) and from tasks.json /
+	// repo config (tasks, hookCount), plus the repo bookkeeping that drives
+	// the multi-repo indicator.
+	instances []*session.Instance
+	repos     map[string]int
+	tasks     []task.Task
+	hookCount int
+
+	// selected is the instance the workspace panes are bound to. This is
+	// DISPLAY selection, not the sidebar cursor: it is set when the cursor
+	// lands on an instance row and deliberately kept ("sticky") while the
+	// cursor visits section headers, mirroring the pre-store behavior where
+	// the TabbedWindow kept its instance pointer until the next instance row
+	// was selected. It may briefly point at an instance that was removed from
+	// the projection (exactly as the old TabbedWindow.instance could dangle);
+	// consumers that need containment must check ContainsInstance.
+	selected *session.Instance
+
+	// activeTab is the 0-based selected tab index of the selected instance.
+	// It is read from the background refreshPanesCmd goroutine (UpdateContent)
+	// while the bubbletea event loop writes it via tab navigation, so it is an
+	// atomic to avoid a data race (#684).
+	activeTab atomic.Int32
+
+	// version counts mutations. Views cache structures derived from the
+	// projection (the sidebar's flattened row list) keyed on this value and
+	// lazily rebuild when it moves.
+	version uint64
+
+	// selectionSeq counts SelectInstance calls — explicit "move the cursor
+	// here" assertions (the reconcile's #969 re-pin). It is separate from
+	// version because most mutations must NOT move the sidebar cursor: the
+	// pre-store sidebar only clamped its flat cursor index on rebuild (so a
+	// removal could drift the cursor, e.g. onto a header while naming — the
+	// #717 reality), and only an explicit re-pin/select moved it back.
+	selectionSeq uint64
+}
+
+// NewProjection creates an empty projection.
+func NewProjection() *Projection {
+	return &Projection{repos: make(map[string]int)}
+}
+
+// Version returns the mutation counter. See the version field.
+func (p *Projection) Version() uint64 {
+	return p.version
+}
+
+func (p *Projection) bump() {
+	p.version++
+}
+
+// -- Instances --
+
+// NumInstances returns the number of instances.
+func (p *Projection) NumInstances() int {
+	return len(p.instances)
+}
+
+// GetInstances returns all instances. The returned slice shares the
+// projection's backing array, so callers must only read it inline on the
+// bubbletea event loop and must NOT store it beyond the immediate call —
+// never hand it to a goroutine that outlives the call, and never stash it in
+// an overlay or struct field that survives past this call. A later
+// append/remove mutates the shared backing array in place, corrupting any
+// retained slice (#1008). Use GetInstancesSnapshot for anything that keeps
+// the slice around.
+func (p *Projection) GetInstances() []*session.Instance {
+	return p.instances
+}
+
+// GetInstancesSnapshot returns a copy of the instances slice for handing off
+// to a background goroutine or an overlay that outlives the call. Copying the
+// slice header here (on the event loop, where mutations also happen) gives
+// the holder a private backing array so the two cannot race on the same
+// memory (#682/#1008). The *session.Instance elements are shared, but each
+// guards its own fields with a mutex, so reading them across goroutines is
+// safe.
+func (p *Projection) GetInstancesSnapshot() []*session.Instance {
+	out := make([]*session.Instance, len(p.instances))
+	copy(out, p.instances)
+	return out
+}
+
+// GetInstanceTitles returns a set of all instance titles for quick comparison.
+func (p *Projection) GetInstanceTitles() map[string]bool {
+	titles := make(map[string]bool, len(p.instances))
+	for _, inst := range p.instances {
+		titles[inst.Title] = true
+	}
+	return titles
+}
+
+// GetInstanceByTitle returns the instance carrying the given title, or nil
+// when none matches. Async handlers that captured an *Instance pointer before
+// awaiting a background fetch use this to re-resolve the live instance: a
+// background sync may have removed the captured instance and rebuilt a fresh
+// same-title copy via FromInstanceData while the fetch was in flight (#765),
+// orphaning the original pointer. Re-resolving by title lands the update on
+// the instance that currently represents the session (#862).
+func (p *Projection) GetInstanceByTitle(title string) *session.Instance {
+	for _, inst := range p.instances {
+		if inst.Title == title {
+			return inst
+		}
+	}
+	return nil
+}
+
+// ContainsInstance reports whether target is currently in the projection.
+func (p *Projection) ContainsInstance(target *session.Instance) bool {
+	for _, inst := range p.instances {
+		if inst == target {
+			return true
+		}
+	}
+	return false
+}
+
+// AddInstance adds a new instance. Returns a finalizer to register the repo.
+func (p *Projection) AddInstance(instance *session.Instance) (finalize func()) {
+	p.instances = append(p.instances, instance)
+	p.bump()
+	return func() { p.RegisterRepoForInstance(instance) }
+}
+
+// RegisterRepoForInstance records the instance's repo after the instance has
+// started and its worktree is available.
+func (p *Projection) RegisterRepoForInstance(instance *session.Instance) {
+	repoName, err := instance.RepoName()
+	if err != nil {
+		log.ErrorLog.Printf("could not get repo name: %v", err)
+		return
+	}
+	p.addRepo(repoName)
+}
+
+// KillInstance kills the given instance by pointer identity, independent of
+// the current selection. It returns an error if the underlying kill fails, in
+// which case the instance is NOT removed so the user can retry. Deferred
+// flows — most notably canceling a new instance via Escape/ctrl+c — must pass
+// the captured pointer rather than re-reading the live selection: background
+// sync can drift the selection off the target row between the time the
+// operation is initiated and the time it runs, and a selection-based kill
+// would then silently no-op and leave the naming instance behind as a
+// "Loading" zombie (#717).
+//
+// A nil target or an instance no longer in the projection is a no-op,
+// preserving the old Kill()'s tolerance for a stale selection.
+func (p *Projection) KillInstance(target *session.Instance) error {
+	if target == nil {
+		return nil
+	}
+	idx := -1
+	for i, inst := range p.instances {
+		if inst == target {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil
+	}
+	// Capture repo name before Kill(), because Kill() sets started=false
+	// which causes RepoName() to fail.
+	repoName, repoErr := target.RepoName()
+	if err := target.Kill(); err != nil {
+		return fmt.Errorf("could not kill instance: %w", err)
+	}
+	if repoErr != nil {
+		log.ErrorLog.Printf("could not get repo name: %v", repoErr)
+	} else {
+		p.rmRepo(repoName)
+	}
+	p.instances = append(p.instances[:idx], p.instances[idx+1:]...)
+	p.bump()
+	return nil
+}
+
+// AttachInstance attaches to the given instance by pointer identity, but only
+// if it is still present in the projection. Deferred attach flows — the
+// first-time attach help screen, whose onDismiss callback runs after the
+// overlay is dismissed — must capture the instance at key-press time and
+// attach through this method rather than re-reading the live selection: a
+// background refresh can drift the selection onto a different instance while
+// the help overlay is open, so a selection-based attach would connect to the
+// wrong session (#716).
+func (p *Projection) AttachInstance(target *session.Instance) (chan struct{}, error) {
+	if target == nil || !p.ContainsInstance(target) {
+		return nil, errors.New("instance no longer exists")
+	}
+	return target.Attach()
+}
+
+// ReplaceInstance swaps an existing instance for replacement, re-pointing the
+// selection when the replaced instance was selected, and keeps the repos map
+// (which drives the multi-repo indicator) correct: the outgoing instance's
+// repo is decremented and the replacement's repo registered. A kill+recreate
+// can swap in an instance from a DIFFERENT repo (#971), so doing the
+// bookkeeping here — at the primitive — means every caller
+// (ReplaceInstanceByTitle, swapInstanceFromSnapshot, the instanceStartedMsg
+// start path) stays correct without remembering a separate
+// RegisterRepoForInstance call. RepoName() errors are skipped silently rather
+// than logged: the outgoing row may be an unstarted Loading placeholder
+// (never registered, nothing to decrement) and either side may be a remote
+// instance with no local repo — both are normal, not failures.
+//
+// The selection re-point is the store half of the #969 fix: when the selected
+// row is swapped (same title, different CreatedAt — a kill+recreate, #765),
+// the rebuilt instance becomes the selected one, so the sidebar cursor
+// re-pins onto it instead of drifting.
+func (p *Projection) ReplaceInstance(target, replacement *session.Instance) bool {
+	for i, inst := range p.instances {
+		if inst != target {
+			continue
+		}
+		if repoName, err := inst.RepoName(); err == nil {
+			p.rmRepo(repoName)
+		}
+		p.instances[i] = replacement
+		if repoName, err := replacement.RepoName(); err == nil {
+			p.addRepo(repoName)
+		}
+		if p.selected == target {
+			// Silent re-point: keep the panes bound to the live replacement
+			// (the swapped-in row occupies the same index, so the sidebar
+			// cursor needs no move). Deliberately not a SelectInstance
+			// assertion — when the cursor rests elsewhere (e.g. a section
+			// header) a swap must not yank it, matching the pre-store
+			// wasSelected behavior.
+			p.selected = replacement
+		}
+		p.bump()
+		return true
+	}
+	return false
+}
+
+// ReplaceInstanceByTitle swaps the instance carrying the given title for
+// replacement, preserving the selection. Returns false when no instance has
+// that title. Used by the instance-start handler when its pointer-based
+// ReplaceInstance misses: a background sync may have swapped the Loading
+// placeholder for a rebuilt copy of the same session while the start RPC was
+// in flight, and re-adding the started instance would leave two rows — and
+// two persisted records — with one title (#808).
+func (p *Projection) ReplaceInstanceByTitle(title string, replacement *session.Instance) bool {
+	for _, inst := range p.instances {
+		if inst.Title == title {
+			return p.ReplaceInstance(inst, replacement)
+		}
+	}
+	return false
+}
+
+// RemoveInstanceByTitle removes an instance by title without killing it (the
+// external process already cleaned up tmux/worktree).
+// Note: the instance may already have been killed (started=false), so we fall
+// back to looking up the repo name from the gitWorktree directly.
+func (p *Projection) RemoveInstanceByTitle(title string) bool {
+	for i, inst := range p.instances {
+		if inst.Title == title {
+			repoName, err := inst.RepoName()
+			if err != nil {
+				// If RepoName() fails (e.g. instance already killed/not started),
+				// we cannot decrement the repo count without the name, so log and
+				// continue — the repo map will be corrected on next full rebuild.
+				log.ErrorLog.Printf("could not get repo name: %v", err)
+			} else {
+				p.rmRepo(repoName)
+			}
+			p.instances = append(p.instances[:i], p.instances[i+1:]...)
+			p.bump()
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveInstanceByTitleWithRepo removes an instance by title using the
+// supplied repoName instead of calling RepoName() on the instance. This is
+// useful when the caller has already killed the instance (which causes
+// RepoName() to fail) but captured the repo name beforehand, ensuring the
+// repo count is still decremented correctly.
+func (p *Projection) RemoveInstanceByTitleWithRepo(title, repoName string) bool {
+	for i, inst := range p.instances {
+		if inst.Title == title {
+			p.rmRepo(repoName)
+			p.instances = append(p.instances[:i], p.instances[i+1:]...)
+			p.bump()
+			return true
+		}
+	}
+	return false
+}
+
+// SetSessionPreviewSize sets the tmux session preview sizes. Instances whose
+// underlying tmux session has vanished (ErrSessionGone) are skipped silently
+// — the daemon-side latch already covers ongoing polling and the resize
+// itself has no useful work to do on a dead session (#496).
+func (p *Projection) SetSessionPreviewSize(width, height int) error {
+	var err error
+	for i, item := range p.instances {
+		if !item.Started() {
+			continue
+		}
+		if innerErr := item.SetPreviewSize(width, height); innerErr != nil {
+			if errors.Is(innerErr, tmux.ErrSessionGone) {
+				continue
+			}
+			err = fmt.Errorf("could not set preview size for instance %d: %v", i, innerErr)
+		}
+	}
+	return err
+}
+
+// -- Repos --
+
+// NumRepos returns the number of repositories represented in the projection.
+func (p *Projection) NumRepos() int {
+	return len(p.repos)
+}
+
+// HasRepo reports whether the given repo is currently registered.
+func (p *Projection) HasRepo(repo string) bool {
+	_, ok := p.repos[repo]
+	return ok
+}
+
+func (p *Projection) addRepo(repo string) {
+	if _, ok := p.repos[repo]; !ok {
+		p.repos[repo] = 0
+	}
+	p.repos[repo]++
+	p.bump()
+}
+
+func (p *Projection) rmRepo(repo string) {
+	if _, ok := p.repos[repo]; !ok {
+		log.ErrorLog.Printf("repo %s not found", repo)
+		return
+	}
+	p.repos[repo]--
+	if p.repos[repo] == 0 {
+		delete(p.repos, repo)
+	}
+	p.bump()
+}
+
+// -- Tasks and hooks --
+
+// SetTasks updates the task data.
+func (p *Projection) SetTasks(tasks []task.Task) {
+	p.tasks = tasks
+	p.bump()
+}
+
+// GetTasks returns the current tasks.
+func (p *Projection) GetTasks() []task.Task {
+	return p.tasks
+}
+
+// SetHookCount updates the displayed hook count.
+func (p *Projection) SetHookCount(count int) {
+	p.hookCount = count
+	p.bump()
+}
+
+// GetHookCount returns the currently displayed hook count.
+func (p *Projection) GetHookCount() int {
+	return p.hookCount
+}
+
+// -- Selection --
+
+// GetSelectedInstance returns the instance the workspace panes are bound to,
+// or nil. See the selected field for the sticky display-selection semantics;
+// the sidebar's cursor-derived selection (nil while the cursor rests on a
+// section header) lives on the Sidebar, which keeps this in sync whenever the
+// cursor lands on an instance row.
+func (p *Projection) GetSelectedInstance() *session.Instance {
+	return p.selected
+}
+
+// SetSelectedInstance binds the workspace panes to the given instance (nil to
+// clear) WITHOUT requesting a sidebar cursor move. A no-op — no version bump —
+// when the binding is unchanged, so the 100ms selectionChanged tick doesn't
+// force views to re-derive constantly.
+func (p *Projection) SetSelectedInstance(instance *session.Instance) {
+	if p.selected == instance {
+		return
+	}
+	p.selected = instance
+	p.bump()
+}
+
+// SelectInstance binds the workspace panes to the given instance AND requests
+// a sidebar cursor re-pin: the sidebar moves its cursor onto the instance's
+// row on its next sync, even when the bound instance is unchanged. This is
+// the store half of the reconcile's #969 selection re-pin — removals in the
+// same reconcile may have drifted the cursor's flat index off the (pointer-
+// unchanged) selected instance, so the assertion must fire unconditionally.
+func (p *Projection) SelectInstance(instance *session.Instance) {
+	p.selected = instance
+	p.selectionSeq++
+	p.bump()
+}
+
+// SelectionSeq returns the SelectInstance assertion counter. See selectionSeq.
+func (p *Projection) SelectionSeq() uint64 {
+	return p.selectionSeq
+}
+
+// -- Active tab --
+
+// ActiveTab returns the 0-based selected tab index of the selected instance.
+// Backed by an atomic: the background refreshPanesCmd goroutine reads it
+// while the event loop writes it (#684).
+func (p *Projection) ActiveTab() int {
+	return int(p.activeTab.Load())
+}
+
+// SetActiveTab stores the 0-based selected tab index. Range clamping against
+// the selected instance's tab count stays with the TabbedWindow, which knows
+// how tab slots are labeled and padded.
+func (p *Projection) SetActiveTab(idx int) {
+	p.activeTab.Store(int32(idx))
+}

--- a/ui/store_helpers_test.go
+++ b/ui/store_helpers_test.go
@@ -1,0 +1,29 @@
+package ui
+
+import (
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/store"
+)
+
+// newTestTabbedWindow builds a TabbedWindow over a fresh projection. The
+// projection is reachable via tw.proj for tests that need to seed data.
+func newTestTabbedWindow() *TabbedWindow {
+	return NewTabbedWindow(NewTabPane(), store.NewProjection())
+}
+
+// setWindowInstance is the test wiring for the pre-store TabbedWindow.SetInstance:
+// bind the projection's display selection to inst and re-clamp the active tab,
+// exactly what selectionChanged does in production.
+func setWindowInstance(tw *TabbedWindow, inst *session.Instance) {
+	tw.proj.SetSelectedInstance(inst)
+	tw.ClampActiveTab()
+}
+
+// addTestInstance adds inst to the sidebar's projection and syncs the row
+// list eagerly, mirroring the pre-store Sidebar.AddInstance which rebuilt the
+// visible items at mutation time (production syncs lazily on the next read).
+func addTestInstance(s *Sidebar, inst *session.Instance) func() {
+	finalize := s.proj.AddInstance(inst)
+	s.syncFromStore()
+	return finalize
+}

--- a/ui/tab_nav_test.go
+++ b/ui/tab_nav_test.go
@@ -23,8 +23,8 @@ func instanceWithTabs(n int) *session.Instance {
 // TestTabbedWindowJumpToTab covers the number-key jump: in-range indices select
 // the tab, out-of-range indices are a no-op (#930 PR 4).
 func TestTabbedWindowJumpToTab(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
-	tw.SetInstance(instanceWithTabs(3))
+	tw := newTestTabbedWindow()
+	setWindowInstance(tw, instanceWithTabs(3))
 
 	require.True(t, tw.JumpToTab(2))
 	require.Equal(t, 2, tw.GetActiveTab())
@@ -42,8 +42,8 @@ func TestTabbedWindowJumpToTab(t *testing.T) {
 // TestTabbedWindowSelectLastAndNeighbor covers SelectLastTab (used after a new
 // tab is appended) and SelectTab (used to land on a neighbor after a close).
 func TestTabbedWindowSelectLastAndNeighbor(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
-	tw.SetInstance(instanceWithTabs(4))
+	tw := newTestTabbedWindow()
+	setWindowInstance(tw, instanceWithTabs(4))
 
 	tw.SelectLastTab()
 	require.Equal(t, 3, tw.GetActiveTab(), "SelectLastTab selects the final tab")
@@ -62,12 +62,12 @@ func TestTabbedWindowSelectLastAndNeighbor(t *testing.T) {
 // to an instance with fewer tabs must not leave activeTab pointing past the end
 // (which would make isAgentSlot() lie and capture a phantom slot).
 func TestTabbedWindowClampsActiveTabOnInstanceSwitch(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
-	tw.SetInstance(instanceWithTabs(4))
+	tw := newTestTabbedWindow()
+	setWindowInstance(tw, instanceWithTabs(4))
 	require.True(t, tw.JumpToTab(3))
 	require.Equal(t, 3, tw.GetActiveTab())
 
-	tw.SetInstance(instanceWithTabs(2))
+	setWindowInstance(tw, instanceWithTabs(2))
 	require.LessOrEqual(t, tw.GetActiveTab(), 1,
 		"activeTab must be clamped when switching to an instance with fewer tabs")
 	require.GreaterOrEqual(t, tw.GetActiveTab(), 0)

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -2,10 +2,10 @@ package ui
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/store"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -43,45 +43,50 @@ var defaultTabLabels = []string{"Preview", "Terminal"}
 // take up one rune of height. The tab list is sourced from the selected
 // instance's Tabs (#930 PR 2): every tab renders through one shared TabPane by
 // capturing the selected tab's session.
+//
+// The window is a VIEW over the store.Projection (#1024 PR 2): both the
+// selected instance and the active tab index live in the store, so the window
+// no longer holds an instance pointer of its own. The active tab is an atomic
+// in the store because the background refreshPanesCmd goroutine reads it via
+// UpdateContent while the bubbletea event loop writes it via Toggle/ToggleBack
+// (#684); every other store read here happens on the event loop only.
 type TabbedWindow struct {
-	// activeTab is read from the background refreshPanesCmd goroutine
-	// (UpdateContent) while the bubbletea event loop writes it via
-	// Toggle/ToggleBack, so it is an atomic to avoid a data race (#684).
-	activeTab atomic.Int32
-	height    int
-	width     int
+	proj   *store.Projection
+	height int
+	width  int
 
-	tab      *TabPane
-	instance *session.Instance
+	tab *TabPane
 }
 
-func NewTabbedWindow(tab *TabPane) *TabbedWindow {
+func NewTabbedWindow(tab *TabPane, proj *store.Projection) *TabbedWindow {
 	return &TabbedWindow{
-		tab: tab,
+		proj: proj,
+		tab:  tab,
 	}
 }
 
-func (w *TabbedWindow) SetInstance(instance *session.Instance) {
-	w.instance = instance
-	// Tab counts vary per instance (#930 PR 4): switching to an instance with
-	// fewer tabs must not leave activeTab pointing past the end, which would make
-	// isAgentSlot() lie and the number/Toggle math operate on a phantom slot.
-	w.clampActiveTab()
+// selectedInstance returns the instance the window renders — the store's
+// (sticky) display selection. Event-loop only.
+func (w *TabbedWindow) selectedInstance() *session.Instance {
+	return w.proj.GetSelectedInstance()
 }
 
-// clampActiveTab bounds activeTab into [0, len(tabLabels())-1]. Called whenever
-// the tab set may have shrunk (instance switch, tab close) so the index never
-// dangles out of range.
-func (w *TabbedWindow) clampActiveTab() {
-	n := int32(len(w.tabLabels()))
+// ClampActiveTab bounds the active tab index into [0, len(tabLabels())-1].
+// Called whenever the tab set may have shrunk (instance switch, tab close) so
+// the index never dangles out of range: tab counts vary per instance (#930
+// PR 4), and switching to an instance with fewer tabs must not leave the
+// index pointing past the end, which would make isAgentSlot() lie and the
+// number/Toggle math operate on a phantom slot.
+func (w *TabbedWindow) ClampActiveTab() {
+	n := len(w.tabLabels())
 	if n <= 0 {
-		w.activeTab.Store(0)
+		w.proj.SetActiveTab(0)
 		return
 	}
-	if cur := w.activeTab.Load(); cur >= n {
-		w.activeTab.Store(n - 1)
+	if cur := w.proj.ActiveTab(); cur >= n {
+		w.proj.SetActiveTab(n - 1)
 	} else if cur < 0 {
-		w.activeTab.Store(0)
+		w.proj.SetActiveTab(0)
 	}
 }
 
@@ -92,15 +97,15 @@ func (w *TabbedWindow) JumpToTab(idx int) bool {
 	if idx < 0 || idx >= len(w.tabLabels()) {
 		return false
 	}
-	w.activeTab.Store(int32(idx))
+	w.proj.SetActiveTab(idx)
 	return true
 }
 
 // SelectTab sets the active tab to idx, clamped into range. Used after a tab
 // close to land on a neighbor.
 func (w *TabbedWindow) SelectTab(idx int) {
-	w.activeTab.Store(int32(idx))
-	w.clampActiveTab()
+	w.proj.SetActiveTab(idx)
+	w.ClampActiveTab()
 }
 
 // SelectLastTab selects the final tab. Used after a new tab is appended so the
@@ -109,7 +114,7 @@ func (w *TabbedWindow) SelectLastTab() {
 	w.SelectTab(len(w.tabLabels()) - 1)
 }
 
-// tabLabels returns the labels for the current instance's tabs. Agent tabs
+// tabLabels returns the labels for the selected instance's tabs. Agent tabs
 // render as "Preview", shell tabs as "Terminal"; any Process tab renders under
 // its own name.
 //
@@ -120,8 +125,9 @@ func (w *TabbedWindow) SelectLastTab() {
 // default-padded bar (always at least the two slots) so the header count never
 // dips below two mid-start, identical to the pre-#930 UX.
 func (w *TabbedWindow) tabLabels() []string {
-	if w.instance != nil && w.instance.IsRemote() {
-		if tabs := w.instance.GetTabs(); len(tabs) > 0 {
+	instance := w.selectedInstance()
+	if instance != nil && instance.IsRemote() {
+		if tabs := instance.GetTabs(); len(tabs) > 0 {
 			labels := make([]string, len(tabs))
 			for i, tab := range tabs {
 				labels[i] = labelForTab(tab)
@@ -132,10 +138,10 @@ func (w *TabbedWindow) tabLabels() []string {
 	}
 
 	labels := append([]string(nil), defaultTabLabels...)
-	if w.instance == nil {
+	if instance == nil {
 		return labels
 	}
-	for idx, tab := range w.instance.GetTabs() {
+	for idx, tab := range instance.GetTabs() {
 		label := labelForTab(tab)
 		if idx < len(labels) {
 			labels[idx] = label
@@ -163,7 +169,7 @@ func labelForTab(tab *session.Tab) string {
 // isAgentSlot reports whether the active tab index is the agent tab (index 0).
 // Index 0 is always the agent tab; every other slot is a shell/terminal tab.
 func (w *TabbedWindow) isAgentSlot() bool {
-	return int(w.activeTab.Load()) == 0
+	return w.proj.ActiveTab() == 0
 }
 
 // AdjustPreviewWidth adjusts the width of the preview pane to be 90% of the provided width.
@@ -200,41 +206,44 @@ func (w *TabbedWindow) GetPreviewSize() (width, height int) {
 }
 
 func (w *TabbedWindow) Toggle() {
-	n := int32(len(w.tabLabels()))
+	n := len(w.tabLabels())
 	if n <= 0 {
 		return
 	}
-	w.activeTab.Store((w.activeTab.Load() + 1) % n)
+	w.proj.SetActiveTab((w.proj.ActiveTab() + 1) % n)
 }
 
 func (w *TabbedWindow) ToggleBack() {
-	n := int32(len(w.tabLabels()))
+	n := len(w.tabLabels())
 	if n <= 0 {
 		return
 	}
-	w.activeTab.Store((w.activeTab.Load() - 1 + n) % n)
+	w.proj.SetActiveTab((w.proj.ActiveTab() - 1 + n) % n)
 }
 
 // UpdateContent updates the content of the active tab's pane. instance may be
-// nil. Replaces the former UpdatePreview/UpdateTerminal split now that one pane
-// renders whichever tab is selected.
+// nil. It is called from the refreshPanesCmd goroutine with the instance
+// captured on the event loop at dispatch time — deliberately a parameter, not
+// a store read, so the capture is keyed to the selection the refresh was
+// dispatched for; only the active tab index is read here, through the store's
+// atomic (#684).
 func (w *TabbedWindow) UpdateContent(instance *session.Instance) error {
-	return w.tab.UpdateContent(instance, int(w.activeTab.Load()))
+	return w.tab.UpdateContent(instance, w.proj.ActiveTab())
 }
 
 // ResetToNormalMode resets the active tab's pane to normal (non-scroll) mode.
 func (w *TabbedWindow) ResetToNormalMode(instance *session.Instance) error {
-	return w.tab.ResetToNormalMode(instance, int(w.activeTab.Load()))
+	return w.tab.ResetToNormalMode(instance, w.proj.ActiveTab())
 }
 
 func (w *TabbedWindow) ScrollUp() {
-	if err := w.tab.ScrollUp(w.instance, int(w.activeTab.Load())); err != nil {
+	if err := w.tab.ScrollUp(w.selectedInstance(), w.proj.ActiveTab()); err != nil {
 		log.InfoLog.Printf("tabbed window failed to scroll up: %v", err)
 	}
 }
 
 func (w *TabbedWindow) ScrollDown() {
-	if err := w.tab.ScrollDown(w.instance, int(w.activeTab.Load())); err != nil {
+	if err := w.tab.ScrollDown(w.selectedInstance(), w.proj.ActiveTab()); err != nil {
 		log.InfoLog.Printf("tabbed window failed to scroll down: %v", err)
 	}
 }
@@ -252,7 +261,7 @@ func (w *TabbedWindow) IsInTerminalTab() bool {
 
 // GetActiveTab returns the currently active tab index.
 func (w *TabbedWindow) GetActiveTab() int {
-	return int(w.activeTab.Load())
+	return w.proj.ActiveTab()
 }
 
 // AttachTerminalForInstance attaches to the terminal (shell) tab of the given
@@ -291,7 +300,7 @@ func (w *TabbedWindow) String() string {
 
 	var renderedTabs []string
 
-	activeTab := int(w.activeTab.Load())
+	activeTab := w.proj.ActiveTab()
 	totalTabWidth := w.width
 	tabWidth := totalTabWidth / len(labels)
 	lastTabWidth := totalTabWidth - tabWidth*(len(labels)-1)

--- a/ui/tabbed_window_race_test.go
+++ b/ui/tabbed_window_race_test.go
@@ -20,7 +20,7 @@ import (
 // Run with `go test -race`: reports a DATA RACE on master and passes after the
 // fix.
 func TestTabbedWindowActiveTabRace(t *testing.T) {
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})

--- a/ui/tabbed_window_remote_test.go
+++ b/ui/tabbed_window_remote_test.go
@@ -63,8 +63,8 @@ func TestTabbedWindowRemoteTabBar(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			inst := startedRemoteInstance(t, tc.withTerm)
-			w := NewTabbedWindow(NewTabPane())
-			w.SetInstance(inst)
+			w := newTestTabbedWindow()
+			setWindowInstance(w, inst)
 			require.Equal(t, tc.wantLabels, w.tabLabels())
 
 			// Toggle wraps within the real tab count, never a phantom slot.

--- a/ui/tabbed_window_single_tab_test.go
+++ b/ui/tabbed_window_single_tab_test.go
@@ -19,8 +19,8 @@ func TestTabbedWindowSingleTabBorderRendering(t *testing.T) {
 	defer log.Close()
 
 	inst := startedRemoteInstance(t, false)
-	w := NewTabbedWindow(NewTabPane())
-	w.SetInstance(inst)
+	w := newTestTabbedWindow()
+	setWindowInstance(w, inst)
 	require.Equal(t, []string{"Preview"}, w.tabLabels(), "remote without terminal_cmd has a single tab")
 	require.Equal(t, 0, w.GetActiveTab(), "the lone tab is active")
 

--- a/ui/tabbed_window_test.go
+++ b/ui/tabbed_window_test.go
@@ -27,7 +27,7 @@ func TestTabbedWindowSetSizeClampsNegativeDimensions(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			w := NewTabbedWindow(NewTabPane())
+			w := newTestTabbedWindow()
 			w.SetSize(tc.width, tc.height)
 
 			previewW, previewH := w.GetPreviewSize()
@@ -42,7 +42,7 @@ func TestTabbedWindowSetSizeClampsNegativeDimensions(t *testing.T) {
 // TestTabbedWindowSetSizeNormal sanity-checks that reasonable sizes still
 // produce positive content dimensions.
 func TestTabbedWindowSetSizeNormal(t *testing.T) {
-	w := NewTabbedWindow(NewTabPane())
+	w := newTestTabbedWindow()
 	w.SetSize(200, 100)
 
 	previewW, previewH := w.GetPreviewSize()
@@ -51,7 +51,7 @@ func TestTabbedWindowSetSizeNormal(t *testing.T) {
 }
 
 func TestTabbedWindowStringDoesNotExceedConfiguredWidth(t *testing.T) {
-	w := NewTabbedWindow(NewTabPane())
+	w := newTestTabbedWindow()
 	w.SetSize(100, 30)
 	w.tab.content = tabContentState{text: "content"}
 

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -627,7 +627,7 @@ func TestTabbedWindowAttachTerminalRemote(t *testing.T) {
 	log.Initialize(false)
 	defer log.Close()
 
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 
 	t.Run("not configured refuses with actionable error", func(t *testing.T) {
 		inst := makeRemoteInstance(t, "remote-843-noattach", config.RemoteHooks{})
@@ -666,7 +666,7 @@ func TestTabbedWindowAttachTerminalRefusesNil(t *testing.T) {
 	log.Initialize(false)
 	defer log.Close()
 
-	tw := NewTabbedWindow(NewTabPane())
+	tw := newTestTabbedWindow()
 
 	_, err := tw.AttachTerminalForInstance(nil, 1)
 	require.Error(t, err, "AttachTerminalForInstance(nil) must error, not attach")


### PR DESCRIPTION
Epic PR 2 of the multi-pane TUI rewrite (#1024, RFC `docs/design/tui-rewrite.md` §2.2 / §4). Pure data-ownership refactor — **no visual change**; the old 30/70 layout, tab bar, and all rendering output stay byte-identical.

## The data-ownership move

Before this PR the `Sidebar` **owned** the instance model — `instances []*session.Instance` plus the repo bookkeeping that drives the multi-repo indicator — and `TabbedWindow` held its own instance pointer and `activeTab` atomic. The sidebar was a model, not a view.

Now there is exactly one client-side model, the new **`ui/store.Projection`**, owning:

- `instances []*session.Instance` + repo bookkeeping (add/replace/remove/kill primitives, #971 repo accounting kept at the `ReplaceInstance` primitive),
- `tasks []task.Task` and the hook count,
- the cross-pane selection: the selected instance and the active tab index.

`reconcileSnapshot` (`app/sync.go`) and the session-control handlers **write** the store; `Sidebar` and `TabbedWindow` **read** it, keeping only local UI state (row cursor, scroll window, section expansion). `ContentPane` and `TabPane` continue to receive the instance as an event-loop-captured parameter and hold no model state.

## #960 reconcile path — behavior preserved exactly

The single-writer flow (Snapshot projection in, RPC mutations out) is untouched; this only changes *where* the mirrored data lives. All reconcile rules hold with their existing tests' **assertions unchanged** (only construction/wiring was adapted):

- add / **swap-by-CreatedAt** (#765) / update-in-place (#959) / remove, and the transient-status skip (Loading #808, Deleting #844);
- **selection re-pin by title** (#969): the reconcile still captures the cursor's selected title and re-pins after mutating — now via `store.SelectInstance`, an explicit re-pin assertion the sidebar honors on its next sync. The store deliberately distinguishes this from `SetSelectedInstance` (the display binding, sticky across header visits — the old `TabbedWindow.instance` semantics), so the pre-store drift-then-clamp cursor behavior is reproduced exactly, including the #717 naming-row drift that `TestCancelNamingRemovesZombieAfterSelectionDrift` pins as a precondition;
- cold start (`coldStartFromSnapshot`) and every mutation seam in `app/session_control.go` are unchanged.

## TabPane.mu concurrency contract — untouched

`ui/tab_pane.go` has **zero diffs**: the `mu`-serialized capture-vs-render contract (#579) and the view-key reset rules (#702/#746) are as before. The `activeTab` index stays an atomic — it just lives in the store now — preserving the #684 contract (event loop writes via Toggle/jump keys, `refreshPanesCmd` goroutine reads during capture). `refreshPanesCmd` still passes the instance captured on the event loop; background goroutines never read the store's non-atomic fields.

## Test evidence

- `app/sync_test.go`, `app/snapshot_test.go`, `ui/sidebar_test.go`, `ui/preview_test.go` (and the rest of the suite) pass with assertions intact; changes are construction wiring only (`NewSidebar`/`NewTabbedWindow` now take the projection; data calls go to `h.store`).
- `gofmt -l .` clean, `go build ./...` ok, `golangci-lint run --timeout=3m --fast` clean, `deadcode -test ./...` clean.
- `go test ./...` fully green under a scratch `AGENT_FACTORY_HOME`, including the `integration/` real-daemon+tmux suite and the teatest real-TUI e2e flows.
- Bounded race run per dev-box constraints: `GOFLAGS="-p=1" go test -race -parallel 2 ./app/... ./ui/...` — race-clean, including the #684 regression test.

Sets up PR 3 (left-rail tree) and PR 4 (layout cutover), which add new views over this same store.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)