### PR TITLE
tui: first-class mouse — click/scroll selection, focus, attach, actions (#1024, epic PR 6; closes #1025)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 	"github.com/sachiniyer/agent-factory/ui/store"
 	"io"
@@ -125,6 +126,17 @@ type home struct {
 	// ring is the focus ring: tree → pane A → automations. Tab/Shift-Tab
 	// cycle it; regions hidden by the degradation ladder are skipped.
 	ring *layout.Ring
+	// zones is the mouse hit-test registry (#1024 PR 6, RFC §2.5): View()
+	// resets it every frame and each pane re-registers its interactive rects
+	// while rendering, so the registry always mirrors what is actually on
+	// screen. handleMouse resolves every tea.MouseMsg through it.
+	zones *zones.Registry
+	// lastClickZone/lastClickAt implement double-click detection: a second
+	// press on the same zone within doubleClickInterval reads as a double
+	// click. mouseClock is time.Now, swapped by tests for determinism.
+	lastClickZone string
+	lastClickAt   time.Time
+	mouseClock    func() time.Time
 
 	// sidebar is the left-rail instances+tabs tree
 	sidebar *ui.Sidebar
@@ -222,6 +234,8 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 		statusBar:       ui.NewStatusBar(menu, errBox),
 		hooksPane:       ui.NewHooksPane(),
 		ring:            layout.NewRing(layout.RegionTree, layout.RegionPaneA, layout.RegionPaneB, layout.RegionAutomations),
+		zones:           zones.NewRegistry(),
+		mouseClock:      time.Now,
 		snapshotFetcher: snapshotThroughDaemon,
 		appConfig:       appConfig,
 		program:         program,
@@ -232,6 +246,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 		appState:        appState,
 	}
 	h.sidebar = ui.NewSidebar(&h.spinner, autoYes, proj)
+	h.wireZoneRegistry()
 	// No split is open at startup: pane B starts hidden so the focus ring is
 	// tree → pane A → automations until a split opens (relayout keeps this in
 	// sync with Layout.SplitActive thereafter).
@@ -522,38 +537,12 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(cmds...)
 	case tea.MouseMsg:
-		if msg.Action == tea.MouseActionPress {
-			if msg.Button == tea.MouseButtonWheelDown || msg.Button == tea.MouseButtonWheelUp {
-				// The wheel scrolls whatever the focus ring points at: the
-				// expanded automations strip scrolls its own task list
-				// independent of the sidebar selection (#524); everywhere
-				// else it scrolls the workspace pane, which needs a bound
-				// instance. Hit-tested wheel routing is #1024 PR 6.
-				if m.ring.Active() == layout.RegionAutomations {
-					switch msg.Button {
-					case tea.MouseButtonWheelUp:
-						m.automations.ScrollUp()
-					case tea.MouseButtonWheelDown:
-						m.automations.ScrollDown()
-					}
-					return m, nil
-				}
-				// The focused split pane scrolls its own pinned view (#1024
-				// PR 5); everywhere else the wheel drives pane A off the
-				// selection binding, as before.
-				pane, bound := m.focusedContentPane()
-				if bound == nil {
-					return m, nil
-				}
-				switch msg.Button {
-				case tea.MouseButtonWheelUp:
-					pane.ScrollUp()
-				case tea.MouseButtonWheelDown:
-					pane.ScrollDown()
-				}
-			}
-		}
-		return m, nil
+		// First-class mouse (#1024 PR 6, closes #1025): every press is
+		// resolved through the zone registry the last View() rebuilt and
+		// dispatched to the region actually under the cursor — clicks select/
+		// focus/attach/act, the wheel scrolls the hovered region. Purely
+		// additive: the keyboard remains fully sufficient.
+		return m.handleMouse(msg)
 	case tea.KeyMsg:
 		return m.handleKeyPress(msg)
 	case tea.WindowSizeMsg:
@@ -1443,8 +1432,16 @@ func (m *home) confirmAction(message string, action tea.Cmd) tea.Cmd {
 // View composes the workspace from the solved layout (#1024 PR 4): every pane
 // renders exactly its rect, so the regions tile the full window with no
 // padding math. Modal overlays composite on top exactly as before.
+//
+// The mouse zone registry is rebuilt here every frame (#1024 PR 6): Reset at
+// the top, then each pane registers its interactive rects while rendering and
+// the active overlay registers its buttons on top. The registry therefore
+// always mirrors exactly what this frame put on screen.
 func (m *home) View() string {
-	// Below the hard minimum no layout exists; render the banner alone.
+	m.zones.Reset()
+
+	// Below the hard minimum no layout exists; render the banner alone (and
+	// register nothing — there is nothing to click).
 	if m.lastLayout.Fallback {
 		return ui.TerminalTooSmall(m.termWidth, m.termHeight)
 	}
@@ -1470,17 +1467,23 @@ func (m *home) View() string {
 		if m.confirmationOverlay == nil {
 			log.ErrorLog.Printf("confirmation overlay is nil")
 		}
-		return overlay.PlaceOverlay(0, 0, m.confirmationOverlay.Render(), mainView, true)
+		fg := m.confirmationOverlay.Render()
+		m.confirmationOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
+		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
 	} else if m.state == stateSearch {
 		if m.searchOverlay == nil {
 			log.ErrorLog.Printf("search overlay is nil")
 		}
-		return overlay.PlaceOverlay(0, 0, m.searchOverlay.Render(), mainView, true)
+		fg := m.searchOverlay.Render()
+		m.searchOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
+		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
 	} else if m.state == stateSelectProgram {
 		if m.selectionOverlay == nil {
 			log.ErrorLog.Printf("selection overlay is nil")
 		}
-		return overlay.PlaceOverlay(0, 0, m.selectionOverlay.Render(), mainView, true)
+		fg := m.selectionOverlay.Render()
+		m.selectionOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
+		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
 	} else if m.state == stateHooks {
 		return overlay.PlaceOverlay(0, 0, m.renderHooksOverlay(), mainView, true)
 	}

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -15,6 +16,7 @@ import (
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,6 +100,9 @@ func wireTestPanes(h *home, proj *store.Projection) {
 	h.hooksPane = ui.NewHooksPane()
 	h.ring = layout.NewRing(layout.RegionTree, layout.RegionPaneA, layout.RegionPaneB, layout.RegionAutomations)
 	h.ring.SetHidden(layout.RegionPaneB, true)
+	h.zones = zones.NewRegistry()
+	h.mouseClock = time.Now
+	h.wireZoneRegistry()
 	h.syncFocus()
 }
 

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -1,0 +1,324 @@
+package app
+
+import (
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// This file is the root mouse router (#1024 PR 6, RFC §2.5 — closes #1025).
+// Every tea.MouseMsg is resolved to a zone id through the registry the last
+// View() rebuilt, then dispatched to the same handlers the keyboard drives —
+// the mouse is purely additive and the keyboard remains fully sufficient.
+//
+// While ATTACHED none of this runs: bubbletea's Update loop is blocked on
+// `<-ch` and tmux owns stdin, so tmux's own mouse mode applies (§2.5) —
+// unchanged by this PR.
+
+// doubleClickInterval is how close two presses on the same zone must land to
+// read as a double click (attach on tree rows, open editor on task rows).
+const doubleClickInterval = 400 * time.Millisecond
+
+// wireZoneRegistry hands the shared registry to every zone-producing pane.
+// Called once at construction (newHome / test wiring).
+func (m *home) wireZoneRegistry() {
+	m.sidebar.SetZoneRegistry(m.zones)
+	m.paneA.SetZoneRegistry(m.zones)
+	m.paneB.SetZoneRegistry(m.zones)
+	m.automations.SetZoneRegistry(m.zones)
+	m.menu.SetZoneRegistry(m.zones)
+}
+
+// handleMouse routes a mouse event: wheel scrolls the region under the
+// cursor, a left press clicks the zone under it. Motion and release events
+// are ignored (cell-motion mode reports them, but every gesture here acts on
+// the press).
+func (m *home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if msg.Action != tea.MouseActionPress {
+		return m, nil
+	}
+	switch msg.Button {
+	case tea.MouseButtonWheelUp, tea.MouseButtonWheelDown:
+		return m, m.handleWheel(msg)
+	case tea.MouseButtonLeft:
+		return m.handleClick(msg)
+	}
+	return m, nil
+}
+
+// handleWheel scrolls the region UNDER THE CURSOR (RFC §2.5) — before this PR
+// the wheel scrolled the content pane regardless of position. Tree zones map
+// to cursor movement (the tree's only scroll primitive, same as j/k), pane
+// zones to that pane's capture scroll, the automations strip to its task
+// selection. Modal overlays own the screen, so the wheel is inert under them.
+func (m *home) handleWheel(msg tea.MouseMsg) tea.Cmd {
+	if m.state != stateDefault {
+		return nil
+	}
+	id, _, ok := m.zones.Resolve(msg.X, msg.Y)
+	if !ok {
+		return nil
+	}
+	up := msg.Button == tea.MouseButtonWheelUp
+	switch {
+	case strings.HasPrefix(id, "tree:"):
+		if up {
+			m.sidebar.Up()
+		} else {
+			m.sidebar.Down()
+		}
+		return m.selectionChanged()
+	case strings.HasPrefix(id, layout.RegionPaneA+":"):
+		if m.store.GetSelectedInstance() == nil {
+			return nil
+		}
+		if up {
+			m.paneA.ScrollUp()
+		} else {
+			m.paneA.ScrollDown()
+		}
+	case strings.HasPrefix(id, layout.RegionPaneB+":"):
+		if m.store.PaneBInstance() == nil {
+			return nil
+		}
+		if up {
+			m.paneB.ScrollUp()
+		} else {
+			m.paneB.ScrollDown()
+		}
+	case strings.HasPrefix(id, "auto:"):
+		if up {
+			m.automations.ScrollUp()
+		} else {
+			m.automations.ScrollDown()
+		}
+	}
+	return nil
+}
+
+// handleClick dispatches a left press by zone id — the §2.5 gesture table.
+func (m *home) handleClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	id, _, ok := m.zones.Resolve(msg.X, msg.Y)
+	if !ok {
+		return m, nil
+	}
+	double := m.trackClick(id)
+
+	// Modal states: the overlay owns the screen, so only its buttons (and,
+	// while naming, the status-bar hints that ARE the form's verbs) react.
+	if m.state != stateDefault {
+		return m.handleModalClick(id)
+	}
+
+	switch id {
+	case zones.TreeHeader:
+		// Click the section header: toggle it, like Enter on the row.
+		m.sidebar.ClickHeader()
+		return m, tea.Batch(m.focusRegionWithSave(layout.RegionTree), m.selectionChanged())
+	case zones.TreeBG:
+		return m, m.focusRegionWithSave(layout.RegionTree)
+	case zones.AutoStrip:
+		return m, m.focusRegionWithSave(layout.RegionAutomations)
+	}
+
+	if title, ok := zones.TreeArrowTitle(id); ok {
+		// Click ▸/▾: expand/collapse the instance's tab children.
+		m.sidebar.ToggleInstanceTree(title)
+		return m, tea.Batch(m.focusRegionWithSave(layout.RegionTree), m.selectionChanged())
+	}
+	if title, ok := zones.TreeInstanceTitle(id); ok {
+		// Click an instance row: select (retargets pane A); double-click
+		// attaches, exactly like Enter on the selected row.
+		focusCmd := m.focusRegionWithSave(layout.RegionTree)
+		if inst := m.store.GetInstanceByTitle(title); inst != nil {
+			m.sidebar.SelectInstance(inst)
+		}
+		if double {
+			_, attachCmd := m.handleEnter()
+			return m, tea.Batch(focusCmd, m.selectionChanged(), attachCmd)
+		}
+		return m, tea.Batch(focusCmd, m.selectionChanged())
+	}
+	if title, idx, ok := zones.TreeTabParts(id); ok {
+		// Click a tab row: select it (drives pane A's active tab); double-
+		// click attaches that tab.
+		focusCmd := m.focusRegionWithSave(layout.RegionTree)
+		m.sidebar.SelectTabRow(title, idx)
+		m.menu.SetActiveTab(m.paneA.GetActiveTab())
+		if double {
+			_, attachCmd := m.handleEnter()
+			return m, tea.Batch(focusCmd, m.selectionChanged(), attachCmd)
+		}
+		return m, tea.Batch(focusCmd, m.selectionChanged())
+	}
+	if region, header, ok := zones.PaneRegion(id); ok &&
+		(region == layout.RegionPaneA || region == layout.RegionPaneB) {
+		// Click a pane header (or an unfocused pane's body): focus that pane
+		// — in a split this is how the mouse picks A or B. Click the FOCUSED
+		// pane's body: attach, exactly like Enter (§2.5).
+		if header || m.ring.Active() != region {
+			return m, m.focusRegionWithSave(region)
+		}
+		return m.handleEnter()
+	}
+	if taskID, ok := zones.AutoTaskID(id); ok {
+		// Click a task row: focus the automations strip and select the task;
+		// double-click opens its editor.
+		focusCmd := m.focusRegionWithSave(layout.RegionAutomations)
+		sp := m.automations.TaskPane()
+		if sp.SelectTaskByID(taskID) && double {
+			sp.StartEditSelected()
+		}
+		return m, focusCmd
+	}
+	if key, ok := zones.StatusHintKey(id); ok {
+		// Click a status-bar hint: press its key (the menu already knows its
+		// bindings; the full handleKeyPress path keeps every gate identical).
+		return m.handleHintClick(key)
+	}
+	return m, nil
+}
+
+// handleModalClick handles clicks while an overlay owns the screen: overlay
+// buttons act as their keys; everything else is swallowed so a stray click
+// can never mutate state behind a modal.
+func (m *home) handleModalClick(id string) (tea.Model, tea.Cmd) {
+	switch m.state {
+	case stateConfirm:
+		if m.confirmationOverlay == nil {
+			return m, nil
+		}
+		var key string
+		switch id {
+		case zones.OverlayConfirmYes:
+			key = m.confirmationOverlay.ConfirmKey
+		case zones.OverlayConfirmNo:
+			key = m.confirmationOverlay.CancelKey
+		default:
+			return m, nil
+		}
+		if msg, ok := keyMsgFromString(key); ok {
+			return m.handleStateConfirm(msg)
+		}
+	case stateSelectProgram:
+		if m.selectionOverlay == nil {
+			return m, nil
+		}
+		if idx, ok := zones.OverlaySelectIdx(id); ok {
+			m.selectionOverlay.SetSelectedIndex(idx)
+			return m.handleStateSelectProgram(tea.KeyMsg{Type: tea.KeyEnter})
+		}
+	case stateSearch:
+		if m.searchOverlay == nil {
+			return m, nil
+		}
+		if idx, ok := zones.OverlaySearchIdx(id); ok {
+			m.searchOverlay.SetSelectedIndex(idx)
+			return m.handleStateSearch(tea.KeyMsg{Type: tea.KeyEnter})
+		}
+	case stateNew:
+		// The naming form's status-bar hints (enter submit / tab change
+		// program) stay clickable; handleKeyPress routes them to the form.
+		if key, ok := zones.StatusHintKey(id); ok {
+			return m.handleHintClick(key)
+		}
+	}
+	return m, nil
+}
+
+// handleHintClick presses the key a status-bar hint advertises, through the
+// full handleKeyPress path so state gating and the keydown highlight behave
+// exactly as if the user had typed it.
+func (m *home) handleHintClick(key string) (tea.Model, tea.Cmd) {
+	msg, ok := keyMsgFromString(key)
+	if !ok {
+		return m, nil
+	}
+	return m.handleKeyPress(msg)
+}
+
+// trackClick records a press on zone id and reports whether it completed a
+// double click. A completed double resets the tracker so a triple click
+// can't read as two doubles.
+func (m *home) trackClick(id string) bool {
+	now := m.mouseClock()
+	double := id == m.lastClickZone && now.Sub(m.lastClickAt) <= doubleClickInterval
+	if double {
+		m.lastClickZone = ""
+		m.lastClickAt = time.Time{}
+	} else {
+		m.lastClickZone = id
+		m.lastClickAt = now
+	}
+	return double
+}
+
+// focusRegionWithSave moves focus to region for a mouse click, mirroring
+// cycleFocus's contract: leaving the automations strip persists dirty task
+// edits, and a failed save surfaces in the error box instead of dropping the
+// edit silently. No-ops when the region already has focus or is hidden by
+// the degradation ladder.
+func (m *home) focusRegionWithSave(region string) tea.Cmd {
+	leaving := m.ring.Active()
+	if leaving == region || !m.ring.Focus(region) {
+		return nil
+	}
+	var cmd tea.Cmd
+	if leaving == layout.RegionAutomations {
+		if err := m.saveContentPaneState(); err != nil {
+			cmd = m.handleError(err)
+		}
+	}
+	m.relayout()
+	return cmd
+}
+
+// keyMsgFromString synthesizes the tea.KeyMsg a click stands in for, from a
+// binding's primary key string (keys.GlobalKeyBindings […].Keys()[0]). ok is
+// false for strings with no single-key equivalent.
+func keyMsgFromString(s string) (tea.KeyMsg, bool) {
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}, true
+	case "tab":
+		return tea.KeyMsg{Type: tea.KeyTab}, true
+	case "shift+tab":
+		return tea.KeyMsg{Type: tea.KeyShiftTab}, true
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}, true
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}, true
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}, true
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}, true
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}, true
+	case "shift+up":
+		return tea.KeyMsg{Type: tea.KeyShiftUp}, true
+	case "shift+down":
+		return tea.KeyMsg{Type: tea.KeyShiftDown}, true
+	}
+	if r := []rune(s); len(r) == 1 {
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: r}, true
+	}
+	return tea.KeyMsg{}, false
+}
+
+// overlayOrigin computes where overlay.PlaceOverlay(0, 0, fg, bg, true) puts
+// fg's top-left: centered on bg (or 0,0 when fg exceeds bg, where
+// PlaceOverlay returns fg alone). The overlays register their button zones
+// relative to this origin.
+func overlayOrigin(fg, bg string) layout.Point {
+	fgW, fgH := lipgloss.Width(fg), lipgloss.Height(fg)
+	bgW, bgH := lipgloss.Width(bg), lipgloss.Height(bg)
+	if fgW > bgW || fgH > bgH {
+		return layout.Point{}
+	}
+	return layout.Point{X: (bgW - fgW) / 2, Y: (bgH - fgH) / 2}
+}

--- a/app/mouse_test.go
+++ b/app/mouse_test.go
@@ -1,0 +1,463 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+	"github.com/sachiniyer/agent-factory/ui/overlay"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ----------------------------------------------------------------------------
+// Root mouse routing (#1024 PR 6, closes #1025): every gesture in the RFC
+// §2.5 table, driven hermetically — the click coordinates are derived FROM
+// the zone registry the last View() rebuilt (never hardcoded), so a layout
+// change moves the tests with it or fails loudly.
+// ----------------------------------------------------------------------------
+
+// fakeClock drives the double-click detector deterministically.
+type fakeClock struct{ now time.Time }
+
+func (c *fakeClock) Now() time.Time          { return c.now }
+func (c *fakeClock) advance(d time.Duration) { c.now = c.now.Add(d) }
+func newFakeClock(h *home) *fakeClock {
+	c := &fakeClock{now: time.Unix(1000, 0)}
+	h.mouseClock = c.Now
+	return c
+}
+
+// mouseTestHome is a home with two started instances and two tasks at a
+// split-capable size, selection on "alpha", tree focused.
+func mouseTestHome(t *testing.T) *home {
+	t.Helper()
+	h := newTestHome(t)
+	h.store.AddInstance(instanceWithFakeBackend(t, "alpha"))
+	h.store.AddInstance(instanceWithFakeBackend(t, "beta"))
+	tasks := []task.Task{
+		{ID: "task-aaa", Name: "nightly-sweep", CronExpr: "0 3 * * *", Enabled: true},
+		{ID: "task-bbb", Name: "log-watch", WatchCmd: "tail -f x", Enabled: true},
+	}
+	h.store.SetTasks(tasks)
+	h.automations.TaskPane().SetTasks(tasks)
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+	resizeHome(h, 140, 40)
+	return h
+}
+
+// zoneRect renders a frame (rebuilding the registry) and returns id's rect.
+func zoneRect(t *testing.T, h *home, id string) layout.Rect {
+	t.Helper()
+	_ = h.View()
+	r, ok := h.zones.Find(id)
+	require.True(t, ok, "zone %q must be registered; frame has %v", id, h.zones.IDs())
+	return r
+}
+
+// press injects a left press at (x, y) through the root mouse router.
+func press(h *home, x, y int) tea.Cmd {
+	_, cmd := h.handleMouse(tea.MouseMsg{
+		X: x, Y: y, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	return cmd
+}
+
+// clickZone renders, resolves id's rect, and clicks its top-left cell.
+func clickZone(t *testing.T, h *home, id string) tea.Cmd {
+	t.Helper()
+	r := zoneRect(t, h, id)
+	return press(h, r.X, r.Y)
+}
+
+// wheel injects a wheel event at (x, y).
+func wheel(h *home, x, y int, up bool) {
+	b := tea.MouseButtonWheelDown
+	if up {
+		b = tea.MouseButtonWheelUp
+	}
+	_, _ = h.handleMouse(tea.MouseMsg{X: x, Y: y, Action: tea.MouseActionPress, Button: b})
+}
+
+// TestMouse_ClickInstanceRowSelects: clicking a tree instance row selects it
+// (retargeting pane A) and focuses the tree, from wherever focus was.
+func TestMouse_ClickInstanceRowSelects(t *testing.T) {
+	h := mouseTestHome(t)
+	newFakeClock(h)
+	h.focusRegion(layout.RegionPaneA)
+
+	clickZone(t, h, zones.TreeInstance("beta"))
+
+	require.NotNil(t, h.store.GetSelectedInstance())
+	assert.Equal(t, "beta", h.store.GetSelectedInstance().Title,
+		"clicking an instance row retargets pane A")
+	assert.Equal(t, layout.RegionTree, h.ring.Active(), "the click focuses the tree")
+}
+
+// TestMouse_ClickTreeTabRowSelectsTab: clicking a tab child row drives the
+// store's active tab, exactly like landing the tree cursor on it.
+func TestMouse_ClickTreeTabRowSelectsTab(t *testing.T) {
+	h := mouseTestHome(t)
+	newFakeClock(h)
+
+	clickZone(t, h, zones.TreeTab("alpha", 1))
+
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsTab, "the cursor lands on the tab row")
+	assert.Equal(t, 1, sel.TabIndex)
+	assert.Equal(t, 1, h.store.ActiveTab(), "the click drives pane A's active tab")
+}
+
+// TestMouse_ClickArrowTogglesExpansion: the ▸/▾ arrow collapses/expands the
+// instance's tab children without attaching or moving pane A off it.
+func TestMouse_ClickArrowTogglesExpansion(t *testing.T) {
+	h := mouseTestHome(t)
+	clock := newFakeClock(h)
+
+	// alpha is selected and expanded: its tab rows have zones.
+	_ = zoneRect(t, h, zones.TreeTab("alpha", 0))
+
+	clickZone(t, h, zones.TreeArrow("alpha"))
+	_ = h.View()
+	_, ok := h.zones.Find(zones.TreeTab("alpha", 0))
+	assert.False(t, ok, "arrow click collapses the expanded selection")
+
+	clock.advance(time.Second) // not a double click
+	clickZone(t, h, zones.TreeArrow("alpha"))
+	_ = h.View()
+	_, ok = h.zones.Find(zones.TreeTab("alpha", 0))
+	assert.True(t, ok, "second arrow click re-expands")
+
+	// Arrow on a collapsed non-selected instance selects it, which
+	// auto-expands its subtree.
+	clock.advance(time.Second)
+	clickZone(t, h, zones.TreeArrow("beta"))
+	assert.Equal(t, "beta", h.store.GetSelectedInstance().Title)
+	_ = h.View()
+	_, ok = h.zones.Find(zones.TreeTab("beta", 0))
+	assert.True(t, ok, "selecting via the arrow expands the new selection")
+}
+
+// TestMouse_DoubleClickInstanceAttaches: two quick clicks on a tree row
+// attach it full-screen through the exact seam Enter uses; a slow second
+// click stays a plain re-select.
+func TestMouse_DoubleClickInstanceAttaches(t *testing.T) {
+	resetDetachWatchdog(t)
+	h := mouseTestHome(t)
+	clock := newFakeClock(h)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInstanceAttach{}.mask()))
+
+	var attachedLabel string
+	swapAttachOverlayCallbackFn(t, func(m *home, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+		attachedLabel = label
+		return m.attachOverlayCallback(label, traceSuffix, rem, func() (chan struct{}, error) {
+			ch := make(chan struct{})
+			close(ch)
+			return ch, nil
+		})
+	})
+
+	// Slow clicks: select only, no attach.
+	clickZone(t, h, zones.TreeInstance("beta"))
+	clock.advance(time.Second)
+	clickZone(t, h, zones.TreeInstance("beta"))
+	assert.Empty(t, attachedLabel, "clicks slower than the double-click interval must not attach")
+
+	// Fast second click: attach, same path as Enter on the selection.
+	clock.advance(time.Second)
+	clickZone(t, h, zones.TreeInstance("beta"))
+	clock.advance(50 * time.Millisecond)
+	clickZone(t, h, zones.TreeInstance("beta"))
+	assert.Equal(t, "handleEnter-sidebar", attachedLabel,
+		"double-click attaches through the exact Enter seam")
+	endDetachWatchdog()
+
+	// Double-click on a TAB row attaches that tab (the terminal path).
+	attachedLabel = ""
+	clock.advance(time.Second)
+	clickZone(t, h, zones.TreeTab("beta", 1))
+	clock.advance(50 * time.Millisecond)
+	clickZone(t, h, zones.TreeTab("beta", 1))
+	assert.Equal(t, "handleEnter-terminal", attachedLabel,
+		"double-click on a terminal tab row attaches that tab")
+	endDetachWatchdog()
+}
+
+// TestMouse_ClickPaneHeaderFocusesPane: header clicks pick the focused pane —
+// in a split, either A or B.
+func TestMouse_ClickPaneHeaderFocusesPane(t *testing.T) {
+	h := mouseTestHome(t)
+	newFakeClock(h)
+	pressKey(t, h, "s")
+	require.True(t, h.lastLayout.SplitActive)
+
+	clickZone(t, h, zones.PaneHeader(layout.RegionPaneB))
+	assert.Equal(t, layout.RegionPaneB, h.ring.Active(), "pane B header click focuses pane B")
+
+	clickZone(t, h, zones.PaneHeader(layout.RegionPaneA))
+	assert.Equal(t, layout.RegionPaneA, h.ring.Active(), "pane A header click focuses pane A")
+}
+
+// TestMouse_PaneBodyClickFocusesThenAttaches: a body click on an unfocused
+// pane focuses it; a click on the already-focused pane's body attaches (the
+// §2.5 "click a focused pane body → attach" row).
+func TestMouse_PaneBodyClickFocusesThenAttaches(t *testing.T) {
+	resetDetachWatchdog(t)
+	h := mouseTestHome(t)
+	clock := newFakeClock(h)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInstanceAttach{}.mask()))
+
+	var attachedLabel string
+	swapAttachOverlayCallbackFn(t, func(m *home, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+		attachedLabel = label
+		return m.attachOverlayCallback(label, traceSuffix, rem, func() (chan struct{}, error) {
+			ch := make(chan struct{})
+			close(ch)
+			return ch, nil
+		})
+	})
+
+	// Tree has focus: the first body click only focuses pane A. Click below
+	// the header row so the header zone can't win the hit test.
+	body := zoneRect(t, h, zones.PaneBody(layout.RegionPaneA))
+	press(h, body.X+2, body.Y+4)
+	assert.Equal(t, layout.RegionPaneA, h.ring.Active(), "body click on an unfocused pane focuses it")
+	assert.Empty(t, attachedLabel, "the focusing click must not attach")
+
+	// A later click on the focused pane's body attaches its binding.
+	clock.advance(time.Second)
+	body = zoneRect(t, h, zones.PaneBody(layout.RegionPaneA))
+	press(h, body.X+2, body.Y+4)
+	assert.Equal(t, "handleEnter-sidebar", attachedLabel,
+		"click on the focused pane body attaches, like Enter")
+	endDetachWatchdog()
+
+	// Same contract for the pinned pane: focus it by header, then click its
+	// body — the attach must take the pane-B path.
+	attachedLabel = ""
+	clock.advance(time.Second)
+	pressKey(t, h, "s")
+	require.True(t, h.lastLayout.SplitActive)
+	clickZone(t, h, zones.PaneHeader(layout.RegionPaneB))
+	require.Equal(t, layout.RegionPaneB, h.ring.Active())
+	clock.advance(time.Second)
+	bodyB := zoneRect(t, h, zones.PaneBody(layout.RegionPaneB))
+	press(h, bodyB.X+2, bodyB.Y+4)
+	assert.Equal(t, "handleEnter-paneB", attachedLabel,
+		"click on the focused pane B body attaches the pinned binding")
+	endDetachWatchdog()
+}
+
+// TestMouse_ClickTaskRowFocusesAndSelects: a task-row click focuses the
+// automations strip and selects that task; a double click opens its editor.
+func TestMouse_ClickTaskRowFocusesAndSelects(t *testing.T) {
+	h := mouseTestHome(t)
+	clock := newFakeClock(h)
+
+	clickZone(t, h, zones.AutoTask("task-bbb"))
+	assert.Equal(t, layout.RegionAutomations, h.ring.Active(), "the click focuses the strip")
+	sp := h.automations.TaskPane()
+	sel, ok := sp.SelectedTask()
+	require.True(t, ok)
+	assert.Equal(t, "task-bbb", sel.ID, "the click selects the row's task")
+	assert.False(t, sp.IsEditing(), "a single click must not open the editor")
+
+	// Double click (on the expanded manager's row this time): open the editor.
+	clock.advance(time.Second)
+	clickZone(t, h, zones.AutoTask("task-bbb"))
+	clock.advance(50 * time.Millisecond)
+	clickZone(t, h, zones.AutoTask("task-bbb"))
+	assert.True(t, sp.IsEditing(), "double-click opens the task editor")
+}
+
+// TestMouse_ClickStripBackgroundFocusesAutomations: clicking the strip
+// anywhere off a task row focuses (and expands) the automations region.
+func TestMouse_ClickStripBackgroundFocusesAutomations(t *testing.T) {
+	h := mouseTestHome(t)
+	newFakeClock(h)
+
+	clickZone(t, h, zones.AutoStrip) // top-left: the title line, no task row
+	assert.Equal(t, layout.RegionAutomations, h.ring.Active())
+	assert.True(t, h.lastLayout.AutomationsExpanded, "focusing the strip expands it in place")
+}
+
+// TestMouse_ClickStatusHintRunsAction: clicking a status-bar hint presses its
+// key through the full handleKeyPress path. With the automations strip
+// focused the bar advertises "tab focus"; the click must cycle the ring
+// exactly like pressing Tab.
+func TestMouse_ClickStatusHintRunsAction(t *testing.T) {
+	h := mouseTestHome(t)
+	newFakeClock(h)
+	h.focusRegion(layout.RegionAutomations)
+
+	clickZone(t, h, zones.StatusHint("tab"))
+	assert.Equal(t, layout.RegionTree, h.ring.Active(),
+		"clicking the 'tab focus' hint cycles the focus ring, like the key")
+}
+
+// TestMouse_WheelScrollsRegionUnderCursor: the wheel drives whatever region
+// is under the cursor — tree cursor movement, pane capture scroll, task
+// selection — regardless of where the focus ring points (before this PR it
+// always scrolled the content pane).
+func TestMouse_WheelScrollsRegionUnderCursor(t *testing.T) {
+	h := mouseTestHome(t)
+	newFakeClock(h)
+	require.False(t, h.sidebar.GetSelection().IsTab)
+
+	// Over the tree: the cursor walks down (alpha → its first tab row).
+	tree := zoneRect(t, h, zones.TreeBG)
+	wheel(h, tree.X+1, tree.Y+3, false)
+	assert.True(t, h.sidebar.GetSelection().IsTab,
+		"wheel over the tree moves the tree cursor, like j/k")
+
+	// Over the automations strip: the task selection moves — even though the
+	// strip is NOT focused — and the tree cursor stays put.
+	preSel := h.sidebar.GetSelection()
+	strip := zoneRect(t, h, zones.AutoStrip)
+	wheel(h, strip.X+1, strip.Y, false)
+	sel, ok := h.automations.TaskPane().SelectedTask()
+	require.True(t, ok)
+	assert.Equal(t, "task-bbb", sel.ID, "wheel over the strip moves the task selection")
+	assert.Equal(t, preSel, h.sidebar.GetSelection(), "the tree cursor must not move")
+	assert.Equal(t, layout.RegionTree, h.ring.Active(), "wheel never moves focus")
+
+	// Over pane A's body: the pane enters scroll mode (the capture is the
+	// hermetic fake backend's).
+	body := zoneRect(t, h, zones.PaneBody(layout.RegionPaneA))
+	wheel(h, body.X+2, body.Y+4, true)
+	assert.True(t, h.paneA.IsInScrollMode(), "wheel over the pane scrolls the pane")
+	assert.Equal(t, "task-bbb", mustSelectedTaskID(t, h),
+		"pane scroll must not leak into the task selection")
+}
+
+func mustSelectedTaskID(t *testing.T, h *home) string {
+	t.Helper()
+	sel, ok := h.automations.TaskPane().SelectedTask()
+	require.True(t, ok)
+	return sel.ID
+}
+
+// TestMouse_ConfirmOverlayClicks: the kill confirmation's y/n words act as
+// their keys — n cancels, y confirms (row flips to Deleting) — and while the
+// modal is up, clicks on background zones are swallowed.
+func TestMouse_ConfirmOverlayClicks(t *testing.T) {
+	h := mouseTestHome(t)
+	clock := newFakeClock(h)
+	alpha := h.store.GetInstanceByTitle("alpha")
+
+	// Open the kill dialog and click "n or esc to cancel".
+	_, _ = h.handleKill()
+	require.Equal(t, stateConfirm, h.state)
+
+	// Background zones are registered but must be inert behind the modal.
+	clickZone(t, h, zones.TreeInstance("beta"))
+	assert.Equal(t, stateConfirm, h.state, "a background click must not close the modal")
+	assert.Equal(t, "alpha", h.store.GetSelectedInstance().Title,
+		"a background click must not move the selection behind the modal")
+
+	clock.advance(time.Second)
+	clickZone(t, h, zones.OverlayConfirmNo)
+	assert.Equal(t, stateDefault, h.state, "clicking n cancels the dialog")
+	assert.NotEqual(t, session.Deleting, alpha.GetStatus(), "cancel must not kill")
+
+	// Re-open and click "y to confirm".
+	clock.advance(time.Second)
+	_, _ = h.handleKill()
+	require.Equal(t, stateConfirm, h.state)
+	cmd := clickZone(t, h, zones.OverlayConfirmYes)
+	assert.Equal(t, stateDefault, h.state)
+	assert.Equal(t, session.Deleting, alpha.GetStatus(),
+		"clicking y runs the confirm action, like pressing y")
+	assert.NotNil(t, cmd, "the confirm action's startKillMsg must be forwarded")
+}
+
+// TestMouse_SelectionOverlayRowClick: clicking a program row selects and
+// submits it, like ↓ + enter.
+func TestMouse_SelectionOverlayRowClick(t *testing.T) {
+	h := mouseTestHome(t)
+	newFakeClock(h)
+	items := []string{"claude", "aider", "codex"}
+	h.selectionOverlay = overlay.NewSelectionOverlay("Select Program", items)
+	h.selectionOverlay.SetWidth(60)
+	h.state = stateSelectProgram
+
+	clickZone(t, h, zones.OverlaySelectRow(2))
+	assert.Equal(t, stateNew, h.state, "a row click submits the selection")
+}
+
+// TestMouse_SearchOverlayRowClick: clicking a search result selects it and
+// closes the overlay, like ↓ + enter.
+func TestMouse_SearchOverlayRowClick(t *testing.T) {
+	h := mouseTestHome(t)
+	newFakeClock(h)
+	_, _ = h.showSearchOverlay()
+	require.Equal(t, stateSearch, h.state)
+
+	clickZone(t, h, zones.OverlaySearchRow(1))
+	assert.Equal(t, stateDefault, h.state, "a row click submits and closes the search")
+	assert.Equal(t, "beta", h.sidebar.GetSelectedInstance().Title,
+		"the clicked result becomes the selection")
+}
+
+// TestMouse_MissAndFallbackAreInert: presses outside every zone, non-left
+// buttons, and releases must all no-op; below the hard minimum there are no
+// zones at all.
+func TestMouse_MissAndFallbackAreInert(t *testing.T) {
+	h := mouseTestHome(t)
+	newFakeClock(h)
+	_ = h.View()
+
+	// Motion / release / right-button events are ignored.
+	_, cmd := h.handleMouse(tea.MouseMsg{X: 1, Y: 1, Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft})
+	assert.Nil(t, cmd)
+	_, cmd = h.handleMouse(tea.MouseMsg{X: 1, Y: 1, Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft})
+	assert.Nil(t, cmd)
+	_, cmd = h.handleMouse(tea.MouseMsg{X: 1, Y: 1, Action: tea.MouseActionPress, Button: tea.MouseButtonRight})
+	assert.Nil(t, cmd)
+
+	// A press past the frame edge resolves nothing and changes nothing.
+	before := h.ring.Active()
+	press(h, h.termWidth+5, h.termHeight+5)
+	assert.Equal(t, before, h.ring.Active())
+
+	// Below the hard minimum the fallback banner renders and registers nothing.
+	resizeHome(h, layout.HardMinWidth-1, layout.HardMinHeight-1)
+	_ = h.View()
+	assert.Empty(t, h.zones.IDs(), "the fallback banner has no clickable zones")
+	press(h, 1, 1) // must not panic
+}
+
+// TestMouse_ZoneInventoryAtFullLayout pins the expected zone families all
+// registering together in a split layout with tasks — the "each pane
+// registers the expected zones" contract at the frame level.
+func TestMouse_ZoneInventoryAtFullLayout(t *testing.T) {
+	h := mouseTestHome(t)
+	newFakeClock(h)
+	pressKey(t, h, "s")
+	require.True(t, h.lastLayout.SplitActive)
+	_ = h.View()
+
+	for _, id := range []string{
+		zones.TreeBG,
+		zones.TreeHeader,
+		zones.TreeInstance("alpha"),
+		zones.TreeInstance("beta"),
+		zones.TreeArrow("alpha"),
+		zones.TreeTab("alpha", 0),
+		zones.PaneBody(layout.RegionPaneA),
+		zones.PaneHeader(layout.RegionPaneA),
+		zones.PaneBody(layout.RegionPaneB),
+		zones.PaneHeader(layout.RegionPaneB),
+		zones.AutoStrip,
+		zones.AutoTask("task-aaa"),
+		zones.StatusHint("q"),
+	} {
+		_, ok := h.zones.Find(id)
+		assert.True(t, ok, "expected zone %q in the full-layout frame; got %v", id, h.zones.IDs())
+	}
+}

--- a/ui/automations.go
+++ b/ui/automations.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -49,6 +50,10 @@ type AutomationsPane struct {
 	rect    layout.Rect
 	compact bool
 	focused bool
+
+	// zones is the shared mouse hit-test registry (#1024 PR 6); String()
+	// registers the strip plus its task rows every frame. Nil skips.
+	zones *zones.Registry
 
 	// now returns the current time for next-run derivation; a fixed value in
 	// tests so rendered "next" columns are deterministic.
@@ -120,7 +125,10 @@ func (a *AutomationsPane) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	return nil, a.taskPane.HandleKeyPress(msg)
 }
 
-// HandleMouse implements layout.Pane. Mouse support is #1024 PR 6.
+// HandleMouse implements layout.Pane. Mouse dispatch is zone-id-based at the
+// root (#1024 PR 6): the strip/task-row zones registered by String() resolve
+// to focus/select/edit actions there, so the pane-local fallback consumes
+// nothing.
 func (a *AutomationsPane) HandleMouse(tea.MouseMsg, layout.Point) tea.Cmd { return nil }
 
 // ScrollUp moves the task selection up (wheel/shift-scroll routing).
@@ -184,14 +192,44 @@ func (a *AutomationsPane) enabledCount() int {
 // View implements layout.Pane: exactly rect-sized.
 func (a *AutomationsPane) View() string { return a.String() }
 
+// SetZoneRegistry wires the shared mouse hit-test registry (#1024 PR 6).
+func (a *AutomationsPane) SetZoneRegistry(reg *zones.Registry) {
+	a.zones = reg
+}
+
+// registerTaskZone records one task row's hit rect, clipped to the strip.
+func (a *AutomationsPane) registerTaskZone(id string, line, lines int) {
+	if a.zones == nil {
+		return
+	}
+	r := layout.Rect{X: a.rect.X, Y: a.rect.Y + line, W: a.rect.W, H: lines}
+	if r.Bottom() > a.rect.Bottom() {
+		r.H = a.rect.Bottom() - r.Y
+	}
+	if !r.Empty() {
+		a.zones.Register(zones.AutoTask(id), r)
+	}
+}
+
 func (a *AutomationsPane) String() string {
 	if a.rect.Empty() {
 		return ""
 	}
+	// The strip's base zone: any click inside it that lands on no task row
+	// focuses the automations region. Task rows register on top (later wins).
+	if a.zones != nil {
+		a.zones.Register(zones.AutoStrip, a.rect)
+	}
 
-	// Focused: the strip IS the task manager, expanded in place.
+	// Focused: the strip IS the task manager, expanded in place. The hosted
+	// TaskPane records where its list rows landed (nothing while the edit
+	// form is showing), and those spans become the click/double-click zones.
 	if a.focused {
-		return layout.ClampToRect(a.taskPane.String(), a.rect)
+		out := layout.ClampToRect(a.taskPane.String(), a.rect)
+		for _, span := range a.taskPane.ListRowSpans() {
+			a.registerTaskZone(span.ID, span.Line, span.Lines)
+		}
+		return out
 	}
 
 	tasks := a.proj.GetTasks()
@@ -212,6 +250,7 @@ func (a *AutomationsPane) String() string {
 		if len(lines) >= a.rect.H {
 			break
 		}
+		a.registerTaskZone(tsk.ID, len(lines), 1)
 		lines = append(lines, a.compactRow(tsk))
 	}
 	return layout.ClampToRect(strings.Join(lines, "\n"), a.rect)

--- a/ui/automations_zones_test.go
+++ b/ui/automations_zones_test.go
@@ -1,0 +1,141 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+	"github.com/sachiniyer/agent-factory/ui/store"
+)
+
+// zoneTestTasks builds a projection-backed automations pane with two tasks.
+func zoneTestTasks(t *testing.T) (*AutomationsPane, *zones.Registry, []task.Task) {
+	t.Helper()
+	tasks := []task.Task{
+		{ID: "task-aaa", Name: "nightly-sweep", CronExpr: "0 3 * * *", Enabled: true},
+		{ID: "task-bbb", Name: "log-watch", WatchCmd: "tail -f x", Enabled: false},
+	}
+	proj := store.NewProjection()
+	proj.SetTasks(tasks)
+	a := NewAutomationsPane(proj)
+	a.TaskPane().SetTasks(tasks)
+	a.now = func() time.Time { return time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC) }
+	reg := zones.NewRegistry()
+	a.SetZoneRegistry(reg)
+	return a, reg, tasks
+}
+
+// TestAutomationsRegistersCompactRowZones (#1024 PR 6): the unfocused strip
+// registers its rect plus one row zone per rendered task, each sitting on the
+// line that renders that task.
+func TestAutomationsRegistersCompactRowZones(t *testing.T) {
+	a, reg, tasks := zoneTestTasks(t)
+	rect := layout.Rect{X: 0, Y: 40, W: 100, H: 3}
+	a.SetRect(rect)
+
+	reg.Reset()
+	lines := plainLines(a.String())
+
+	strip, ok := reg.Find(zones.AutoStrip)
+	require.True(t, ok)
+	assert.Equal(t, rect, strip)
+
+	for _, tsk := range tasks {
+		r, ok := reg.Find(zones.AutoTask(tsk.ID))
+		require.True(t, ok, "row zone for %s; got %v", tsk.Name, reg.IDs())
+		assert.Equal(t, 1, r.H)
+		assert.Contains(t, lines[r.Y-rect.Y], tsk.Name,
+			"the zone must sit on the row rendering its task")
+	}
+
+	// Task rows win over the strip background where they overlap.
+	r, _ := reg.Find(zones.AutoTask("task-aaa"))
+	id, _, ok := reg.Resolve(r.X+1, r.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.AutoTask("task-aaa"), id)
+	// The title line above them falls through to the strip.
+	id, _, ok = reg.Resolve(rect.X+1, rect.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.AutoStrip, id)
+}
+
+// TestAutomationsRegistersExpandedRowZones: focused, the strip hosts the full
+// task manager and the row zones follow the manager's real row spans —
+// including the selected row's multi-line detail block.
+func TestAutomationsRegistersExpandedRowZones(t *testing.T) {
+	a, reg, tasks := zoneTestTasks(t)
+	rect := layout.Rect{X: 0, Y: 24, W: 100, H: 12}
+	a.SetRect(rect)
+	a.Focus()
+
+	reg.Reset()
+	lines := plainLines(a.String())
+
+	for _, tsk := range tasks {
+		r, ok := reg.Find(zones.AutoTask(tsk.ID))
+		require.True(t, ok, "expanded row zone for %s", tsk.Name)
+		assert.Contains(t, lines[r.Y-rect.Y], tsk.Name,
+			"the expanded zone must start on the row rendering its task")
+	}
+	// The selected task's block spans its detail lines.
+	sel, ok := a.TaskPane().SelectedTask()
+	require.True(t, ok)
+	r, _ := reg.Find(zones.AutoTask(sel.ID))
+	assert.Greater(t, r.H, 1, "the selected row's zone covers its detail lines")
+}
+
+// TestAutomationsCompactSummaryRegistersStripOnly: the 1-line degraded strip
+// has no task rows, so only the strip zone exists.
+func TestAutomationsCompactSummaryRegistersStripOnly(t *testing.T) {
+	a, reg, _ := zoneTestTasks(t)
+	rect := layout.Rect{X: 0, Y: 40, W: 70, H: 1}
+	a.SetRect(rect)
+	a.SetCompact(true)
+
+	reg.Reset()
+	_ = a.String()
+	assert.Equal(t, []string{zones.AutoStrip}, reg.IDs(),
+		"the compact summary registers only the strip zone")
+}
+
+// TestAutomationsEditFormRegistersNoRowZones: while the edit form owns the
+// expanded strip there are no task rows on screen, so a stale click can't
+// re-select a task behind the form.
+func TestAutomationsEditFormRegistersNoRowZones(t *testing.T) {
+	a, reg, _ := zoneTestTasks(t)
+	a.SetRect(layout.Rect{X: 0, Y: 24, W: 100, H: 12})
+	a.Focus()
+	a.TaskPane().StartEditSelected()
+	require.True(t, a.TaskPane().IsEditing())
+
+	reg.Reset()
+	_ = a.String()
+	for _, id := range reg.IDs() {
+		_, isTask := zones.AutoTaskID(id)
+		assert.False(t, isTask, "no task row zones while the edit form is up (got %s)", id)
+	}
+}
+
+// TestTaskPaneClickPrimitives covers the click actions the mouse router
+// calls: SelectTaskByID and the double-click editor open.
+func TestTaskPaneClickPrimitives(t *testing.T) {
+	a, _, tasks := zoneTestTasks(t)
+	sp := a.TaskPane()
+
+	require.True(t, sp.SelectTaskByID(tasks[1].ID))
+	sel, ok := sp.SelectedTask()
+	require.True(t, ok)
+	assert.Equal(t, tasks[1].ID, sel.ID)
+
+	assert.False(t, sp.SelectTaskByID("nope"), "unknown ids are refused")
+
+	sp.StartEditSelected()
+	assert.True(t, sp.IsEditing(), "double-click opens the editor for the selection")
+	assert.False(t, sp.SelectTaskByID(tasks[0].ID),
+		"selection is pinned while the edit form owns the pane")
+}

--- a/ui/layout/zones/ids.go
+++ b/ui/layout/zones/ids.go
@@ -1,0 +1,136 @@
+package zones
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Zone id constructors and parsers (#1024 PR 6). The panes build ids while
+// registering rects during View(); the root mouse router parses them back to
+// dispatch. Both sides live here so producer and consumer can't drift.
+//
+// The id grammar is colon-separated: "<region>:<kind>[:<payload>...]". Titles
+// may themselves contain colons, so every parser that extracts a title keeps
+// it as the FINAL variable-length segment (or, for tree tab rows, pairs it
+// with a trailing numeric index parsed from the right).
+const (
+	// TreeHeader is the Instances section header row (click toggles the
+	// section, like Enter on it).
+	TreeHeader = "tree:header"
+	// TreeBG is the tree pane's background: any click inside the left rail
+	// that lands on no finer zone (focuses the tree).
+	TreeBG = "tree:bg"
+	// AutoStrip is the automations strip background (focuses the strip).
+	AutoStrip = "auto:strip"
+	// OverlayConfirmYes / OverlayConfirmNo are the confirmation dialog's
+	// clickable y/n words.
+	OverlayConfirmYes = "overlay:confirm:yes"
+	OverlayConfirmNo  = "overlay:confirm:no"
+)
+
+// TreeInstance is the zone id of an instance row in the left-rail tree.
+func TreeInstance(title string) string { return "tree:instance:" + title }
+
+// TreeInstanceTitle parses a TreeInstance id back to its title.
+func TreeInstanceTitle(id string) (title string, ok bool) {
+	return strings.CutPrefix(id, "tree:instance:")
+}
+
+// TreeArrow is the zone id of an instance row's expand/collapse arrow glyph.
+func TreeArrow(title string) string { return "tree:arrow:" + title }
+
+// TreeArrowTitle parses a TreeArrow id back to its title.
+func TreeArrowTitle(id string) (title string, ok bool) {
+	return strings.CutPrefix(id, "tree:arrow:")
+}
+
+// TreeTab is the zone id of a tab child row: the parent instance's title plus
+// the 0-based tab slot.
+func TreeTab(title string, idx int) string {
+	return "tree:tab:" + title + ":" + strconv.Itoa(idx)
+}
+
+// TreeTabParts parses a TreeTab id. The index is the final segment (parsed
+// from the right) so titles containing colons survive the round-trip.
+func TreeTabParts(id string) (title string, idx int, ok bool) {
+	rest, found := strings.CutPrefix(id, "tree:tab:")
+	if !found {
+		return "", 0, false
+	}
+	cut := strings.LastIndex(rest, ":")
+	if cut < 0 {
+		return "", 0, false
+	}
+	idx, err := strconv.Atoi(rest[cut+1:])
+	if err != nil {
+		return "", 0, false
+	}
+	return rest[:cut], idx, true
+}
+
+// PaneHeader is the zone id of a workspace pane's header line. region is the
+// layout region id (layout.RegionPaneA / layout.RegionPaneB).
+func PaneHeader(region string) string { return region + ":header" }
+
+// PaneBody is the zone id of a workspace pane's full rect.
+func PaneBody(region string) string { return region + ":body" }
+
+// PaneRegion parses a PaneHeader/PaneBody id, returning the region and
+// whether the zone was the header.
+func PaneRegion(id string) (region string, header, ok bool) {
+	if r, found := strings.CutSuffix(id, ":header"); found {
+		return r, true, true
+	}
+	if r, found := strings.CutSuffix(id, ":body"); found {
+		return r, false, true
+	}
+	return "", false, false
+}
+
+// AutoTask is the zone id of one task row in the automations strip (compact
+// row or expanded manager row alike), keyed by the task's persistent id.
+func AutoTask(taskID string) string { return "auto:task:" + taskID }
+
+// AutoTaskID parses an AutoTask id back to the task id.
+func AutoTaskID(id string) (taskID string, ok bool) {
+	return strings.CutPrefix(id, "auto:task:")
+}
+
+// StatusHint is the zone id of one status-bar key hint; key is the binding's
+// primary key string (e.g. "n", "enter", "shift+up") — clicking is equivalent
+// to pressing it.
+func StatusHint(key string) string { return "status:hint:" + key }
+
+// StatusHintKey parses a StatusHint id back to its key string.
+func StatusHintKey(id string) (key string, ok bool) {
+	return strings.CutPrefix(id, "status:hint:")
+}
+
+// OverlaySelectRow is the zone id of row idx in the selection overlay's list.
+func OverlaySelectRow(idx int) string { return "overlay:select:" + strconv.Itoa(idx) }
+
+// OverlaySelectIdx parses an OverlaySelectRow id back to its row index.
+func OverlaySelectIdx(id string) (idx int, ok bool) {
+	return overlayRowIdx(id, "overlay:select:")
+}
+
+// OverlaySearchRow is the zone id of result idx in the search overlay's list
+// (the index is into the full result list, not the visible window).
+func OverlaySearchRow(idx int) string { return "overlay:search:" + strconv.Itoa(idx) }
+
+// OverlaySearchIdx parses an OverlaySearchRow id back to its result index.
+func OverlaySearchIdx(id string) (idx int, ok bool) {
+	return overlayRowIdx(id, "overlay:search:")
+}
+
+func overlayRowIdx(id, prefix string) (int, bool) {
+	rest, found := strings.CutPrefix(id, prefix)
+	if !found {
+		return 0, false
+	}
+	idx, err := strconv.Atoi(rest)
+	if err != nil {
+		return 0, false
+	}
+	return idx, true
+}

--- a/ui/layout/zones/registry.go
+++ b/ui/layout/zones/registry.go
@@ -50,3 +50,24 @@ func (r *Registry) Resolve(x, y int) (id string, local layout.Point, ok bool) {
 
 // Reset clears all registrations for a new frame, retaining capacity.
 func (r *Registry) Reset() { r.zones = r.zones[:0] }
+
+// Find returns the most recently registered rect for id. Tests use it to
+// derive click coordinates FROM the registry (never hardcoded), so layout
+// changes cannot silently break mouse tests (RFC §5.6).
+func (r *Registry) Find(id string) (layout.Rect, bool) {
+	for i := len(r.zones) - 1; i >= 0; i-- {
+		if r.zones[i].id == id {
+			return r.zones[i].rect, true
+		}
+	}
+	return layout.Rect{}, false
+}
+
+// IDs returns the registered zone ids in registration (paint) order.
+func (r *Registry) IDs() []string {
+	out := make([]string, len(r.zones))
+	for i, z := range r.zones {
+		out[i] = z.id
+	}
+	return out
+}

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -1,11 +1,13 @@
 package ui
 
 import (
+	"math"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -71,6 +73,13 @@ type Menu struct {
 
 	// keyDown is the key which is pressed. The default is -1.
 	keyDown keys.KeyName
+
+	// zones is the shared mouse hit-test registry (#1024 PR 6); String()
+	// registers a clickable rect per rendered hint every frame. origin is the
+	// menu's top-left on screen (the status-bar rect, via SetOrigin), since
+	// the registry works in absolute cells.
+	zones  *zones.Registry
+	origin layout.Point
 }
 
 var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyNewRemote, keys.KeySearch, keys.KeyHelp, keys.KeyQuit}
@@ -283,6 +292,27 @@ func (m *Menu) SetSize(width, height int) {
 	m.height = height
 }
 
+// SetZoneRegistry wires the shared mouse hit-test registry (#1024 PR 6).
+func (m *Menu) SetZoneRegistry(reg *zones.Registry) {
+	m.zones = reg
+}
+
+// SetOrigin records the menu's top-left screen cell for zone registration.
+func (m *Menu) SetOrigin(p layout.Point) {
+	m.origin = p
+}
+
+// centerStart is where centered content of the given size starts inside a
+// box: lipgloss.Place(…, Center, …) computes left = gap - round(gap·0.5), and
+// the hint zones must land on exactly the cells Place put the hints on.
+func centerStart(box, content int) int {
+	gap := box - content
+	if gap <= 0 {
+		return 0
+	}
+	return gap - int(math.Round(float64(gap)*0.5))
+}
+
 // hintDropOrder lists the options that may be dropped when the hint row is
 // wider than the status bar, least valuable first; options in the same inner
 // slice drop together (a lone "⇧↓ scroll" without its ⇧↑ twin reads like a
@@ -317,7 +347,7 @@ func (m *Menu) String() string {
 	// in priority order and re-render. Whatever still doesn't fit after the
 	// drop list is exhausted is clamped by the status bar as before.
 	drop := make(map[keys.KeyName]bool)
-	line := m.renderHints(drop)
+	line, spans := m.renderHints(drop)
 	for _, ks := range hintDropOrder {
 		if lipgloss.Width(line) <= m.width {
 			break
@@ -325,16 +355,37 @@ func (m *Menu) String() string {
 		for _, k := range ks {
 			drop[k] = true
 		}
-		line = m.renderHints(drop)
+		line, spans = m.renderHints(drop)
+	}
+
+	// Register a click zone per surviving hint (#1024 PR 6), on the exact
+	// cells lipgloss.Place is about to center the row onto.
+	if m.zones != nil {
+		x0 := m.origin.X + centerStart(m.width, lipgloss.Width(line))
+		y := m.origin.Y + centerStart(m.height, 1)
+		for _, span := range spans {
+			m.zones.Register(zones.StatusHint(span.key),
+				layout.Rect{X: x0 + span.x, Y: y, W: span.w, H: 1})
+		}
 	}
 
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, line)
 }
 
-// renderHints renders the option row, skipping dropped options. Separators
-// follow group membership of the options actually rendered: a bullet within a
-// group, a vertical bar between groups.
-func (m *Menu) renderHints(drop map[keys.KeyName]bool) string {
+// hintSpan is one rendered hint's horizontal extent within the (un-centered)
+// hint row: x is the printable-cell offset where its key text starts, w spans
+// through the end of its description. key is the binding's primary key
+// string — the StatusHint zone id payload, i.e. what a click "presses".
+type hintSpan struct {
+	key  string
+	x, w int
+}
+
+// renderHints renders the option row, skipping dropped options, and reports
+// each rendered hint's cell extent for the click zones. Separators follow
+// group membership of the options actually rendered: a bullet within a group,
+// a vertical bar between groups.
+func (m *Menu) renderHints(drop map[keys.KeyName]bool) (string, []hintSpan) {
 	groupOf := func(i int) int {
 		for gi, g := range m.groups {
 			if i >= g.start && i < g.end {
@@ -345,6 +396,12 @@ func (m *Menu) renderHints(drop map[keys.KeyName]bool) string {
 	}
 
 	var s strings.Builder
+	var spans []hintSpan
+	col := 0
+	write := func(chunk string) {
+		s.WriteString(chunk)
+		col += lipgloss.Width(chunk)
+	}
 	prevGroup := -1
 	first := true
 	for i, k := range m.options {
@@ -369,24 +426,32 @@ func (m *Menu) renderHints(drop map[keys.KeyName]bool) string {
 
 		if !first {
 			if group != prevGroup {
-				s.WriteString(sepStyle.Render(verticalSeparator))
+				write(sepStyle.Render(verticalSeparator))
 			} else {
-				s.WriteString(sepStyle.Render(separator))
+				write(sepStyle.Render(separator))
 			}
 		}
 		first = false
 		prevGroup = group
 
+		start := col
 		if inActionGroup {
-			s.WriteString(localActionStyle.Render(binding.Help().Key))
-			s.WriteString(" ")
-			s.WriteString(localActionStyle.Render(binding.Help().Desc))
+			write(localActionStyle.Render(binding.Help().Key))
+			write(" ")
+			write(localActionStyle.Render(binding.Help().Desc))
 		} else {
-			s.WriteString(localKeyStyle.Render(binding.Help().Key))
-			s.WriteString(" ")
-			s.WriteString(localDescStyle.Render(binding.Help().Desc))
+			write(localKeyStyle.Render(binding.Help().Key))
+			write(" ")
+			write(localDescStyle.Render(binding.Help().Desc))
+		}
+		// KeyJumpTab's "1-9" chip names nine keys, not one action — it gets
+		// no click zone. Everything else is clickable by its primary key.
+		if k != keys.KeyJumpTab {
+			if bkeys := binding.Keys(); len(bkeys) > 0 {
+				spans = append(spans, hintSpan{key: bkeys[0], x: start, w: col - start})
+			}
 		}
 	}
 
-	return menuStyle.Render(s.String())
+	return menuStyle.Render(s.String()), spans
 }

--- a/ui/menu_zones_test.go
+++ b/ui/menu_zones_test.go
@@ -1,0 +1,106 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/keys"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+// cellSlice returns the terminal cells [from, to) of a plain line as a
+// string. All menu hint glyphs are single-cell, so rune slicing suffices.
+func cellSlice(line string, from, to int) string {
+	runes := []rune(line)
+	if from > len(runes) {
+		return ""
+	}
+	if to > len(runes) {
+		to = len(runes)
+	}
+	return string(runes[from:to])
+}
+
+// TestMenuHintZonesMatchRenderedHints (#1024 PR 6): every rendered hint
+// registers a StatusHint zone, and the zone's cells hold exactly that hint's
+// "key desc" text in the centered output — derived from the registry, so a
+// change to the centering or separator math moves the zones with it or fails
+// here.
+func TestMenuHintZonesMatchRenderedHints(t *testing.T) {
+	menu := NewMenu()
+	reg := zones.NewRegistry()
+	menu.SetZoneRegistry(reg)
+	origin := layout.Point{X: 0, Y: 46}
+	menu.SetOrigin(origin)
+	menu.SetSize(120, 1)
+	menu.SetState(StateEmpty)
+
+	reg.Reset()
+	out := xansi.Strip(menu.String())
+	line := strings.Split(out, "\n")[0]
+
+	for _, k := range defaultMenuOptions {
+		binding := keys.GlobalKeyBindings[k]
+		id := zones.StatusHint(binding.Keys()[0])
+		r, ok := reg.Find(id)
+		require.True(t, ok, "zone for hint %q; got %v", binding.Help().Key, reg.IDs())
+		assert.Equal(t, origin.Y, r.Y, "hints render on the menu row")
+		want := binding.Help().Key + " " + binding.Help().Desc
+		assert.Equal(t, want, cellSlice(line, r.X-origin.X, r.X-origin.X+r.W),
+			"the zone must cover exactly the rendered hint text")
+	}
+}
+
+// TestMenuDroppedHintsRegisterNoZones: hints dropped by the narrow-width
+// priority list must not leave clickable ghosts.
+func TestMenuDroppedHintsRegisterNoZones(t *testing.T) {
+	menu := NewMenu()
+	reg := zones.NewRegistry()
+	menu.SetZoneRegistry(reg)
+	menu.SetOrigin(layout.Point{})
+	menu.SetSize(30, 1) // too narrow for the full default row
+	menu.SetState(StateEmpty)
+
+	reg.Reset()
+	_ = menu.String()
+
+	// The drop order sheds "/" and "N" before help/quit; at 30 cols they are
+	// gone, and their zones with them.
+	_, hasSearch := reg.Find(zones.StatusHint("/"))
+	assert.False(t, hasSearch, "dropped hints must not register zones")
+	_, hasHelp := reg.Find(zones.StatusHint("?"))
+	assert.True(t, hasHelp, "help is never dropped and keeps its zone")
+	_, hasQuit := reg.Find(zones.StatusHint("q"))
+	assert.True(t, hasQuit, "quit is never dropped and keeps its zone")
+}
+
+// TestMenuJumpTabHintHasNoZone: the "1-9" chip names nine keys, not one
+// action, so it is deliberately not clickable.
+func TestMenuJumpTabHintHasNoZone(t *testing.T) {
+	menu := NewMenu()
+	reg := zones.NewRegistry()
+	menu.SetZoneRegistry(reg)
+	menu.SetOrigin(layout.Point{})
+	menu.SetSize(200, 1)
+	menu.SetInstance(nil)
+	menu.SetState(StateDefault)
+	// Force the instance option set (which includes KeyJumpTab) by giving the
+	// menu an instance-shaped state: options are rebuilt via SetFocusRegion.
+	menu.options = []keys.KeyName{keys.KeyJumpTab, keys.KeyHelp}
+	menu.groups = []menuGroup{{start: 0, end: 2}}
+
+	reg.Reset()
+	_ = menu.String()
+	for _, id := range reg.IDs() {
+		key, ok := zones.StatusHintKey(id)
+		require.True(t, ok)
+		assert.NotEqual(t, "1", key, "the 1-9 jump chip must not register a zone")
+	}
+	_, hasHelp := reg.Find(zones.StatusHint("?"))
+	assert.True(t, hasHelp)
+}

--- a/ui/overlay/zones.go
+++ b/ui/overlay/zones.go
@@ -1,0 +1,144 @@
+package overlay
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+// Mouse zone registration for the modal overlays (#1024 PR 6): clicking a
+// confirmation's y/n words or a selection/search row is equivalent to the
+// key. Zones are derived by scanning the overlay's own rendered output — not
+// by replicating the border/padding/wrap math — so a rendering change moves
+// the zones with it instead of leaving them pointing at stale cells. origin
+// is the overlay's top-left on screen (the root computes it from the same
+// centering PlaceOverlay applies).
+
+// cellColumn is the terminal-cell column of byte offset idx within the
+// ANSI-stripped line (border glyphs are multibyte but one cell wide, so byte
+// offsets are not columns).
+func cellColumn(plain string, idx int) int {
+	return runewidth.StringWidth(plain[:idx])
+}
+
+// RegisterZones registers the confirmation dialog's clickable y/n words. The
+// instruction line is scanned from the bottom (the message could conceivably
+// contain the same words); a wrapped instruction line registers nothing and
+// the keyboard remains fully sufficient.
+func (c *ConfirmationOverlay) RegisterZones(reg *zones.Registry, origin layout.Point) {
+	if reg == nil {
+		return
+	}
+	yesNeedle := c.ConfirmKey + " to confirm"
+	noNeedle := c.CancelKey + " or esc to cancel"
+	lines := strings.Split(c.Render(), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		plain := xansi.Strip(lines[i])
+		yi := strings.Index(plain, yesNeedle)
+		ni := strings.Index(plain, noNeedle)
+		if yi < 0 && ni < 0 {
+			continue
+		}
+		if yi >= 0 {
+			reg.Register(zones.OverlayConfirmYes, layout.Rect{
+				X: origin.X + cellColumn(plain, yi), Y: origin.Y + i,
+				W: runewidth.StringWidth(yesNeedle), H: 1,
+			})
+		}
+		if ni >= 0 {
+			reg.Register(zones.OverlayConfirmNo, layout.Rect{
+				X: origin.X + cellColumn(plain, ni), Y: origin.Y + i,
+				W: runewidth.StringWidth(noNeedle), H: 1,
+			})
+		}
+		return
+	}
+}
+
+// RegisterZones registers one full-width clickable zone per selection row;
+// clicking a row selects and submits it, like ↓/↑ + enter.
+func (s *SelectionOverlay) RegisterZones(reg *zones.Registry, origin layout.Point) {
+	if reg == nil {
+		return
+	}
+	rendered := s.Render()
+	width := lipglossWidth(rendered)
+	lines := strings.Split(rendered, "\n")
+	next := 0
+	for i, line := range lines {
+		if next >= len(s.items) {
+			break
+		}
+		t := strings.Trim(xansi.Strip(line), "│ ")
+		if t == "▸ "+s.items[next] || t == s.items[next] {
+			reg.Register(zones.OverlaySelectRow(next), layout.Rect{
+				X: origin.X, Y: origin.Y + i, W: width, H: 1,
+			})
+			next++
+		}
+	}
+}
+
+// RegisterZones registers one full-width clickable zone per visible search
+// result, keyed by the result's index in the full result list; clicking a row
+// selects and submits it.
+func (s *SearchOverlay) RegisterZones(reg *zones.Registry, origin layout.Point) {
+	if reg == nil {
+		return
+	}
+	rendered := s.Render()
+	width := lipglossWidth(rendered)
+	lines := strings.Split(rendered, "\n")
+	next := 0
+	for i, line := range lines {
+		if next >= len(s.results) {
+			break
+		}
+		title, ok := searchRowTitle(line)
+		if !ok {
+			continue
+		}
+		want := s.results[next].Instance.Title
+		if title == want || strings.HasPrefix(title, want+" (") {
+			reg.Register(zones.OverlaySearchRow(next), layout.Rect{
+				X: origin.X, Y: origin.Y + i, W: width, H: 1,
+			})
+			next++
+		}
+	}
+}
+
+// searchRowTitle parses a rendered search-result line down to its title text
+// (plus the optional " (branch)" suffix the caller strips by prefix match).
+// Result rows are the only lines that begin with a status glyph after the
+// border/padding, which is what distinguishes them from the query and hint
+// lines.
+func searchRowTitle(line string) (string, bool) {
+	t := strings.Trim(xansi.Strip(line), "│ ")
+	r, size := utf8.DecodeRuneInString(t)
+	if r != '●' && r != '○' {
+		return "", false
+	}
+	t = strings.TrimLeft(t[size:], " ")
+	t = strings.TrimPrefix(t, "▸ ")
+	return t, true
+}
+
+// SetSelectedIndex moves the search selection onto the given result index
+// (the click action for a result row). Out-of-range indices no-op.
+func (s *SearchOverlay) SetSelectedIndex(idx int) {
+	if idx >= 0 && idx < len(s.results) {
+		s.selectedIdx = idx
+	}
+}
+
+// lipglossWidth is the widest printable line width of a rendered block.
+func lipglossWidth(rendered string) int {
+	_, w := getLines(rendered)
+	return w
+}

--- a/ui/overlay/zones_test.go
+++ b/ui/overlay/zones_test.go
@@ -1,0 +1,145 @@
+package overlay
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+func keyEnter() tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyEnter} }
+
+// ----------------------------------------------------------------------------
+// Overlay button zones (#1024 PR 6): clicking the confirmation's y/n words or
+// a selection/search row is equivalent to the key. The zones are derived by
+// scanning the rendered output, and these tests verify each zone lands on the
+// rendered text it stands for.
+// ----------------------------------------------------------------------------
+
+// cellSliceAt returns the w terminal cells starting at absolute column x of a
+// rendered line, given the overlay was registered at origin.
+func cellSliceAt(line string, x, w int) string {
+	plain := xansi.Strip(line)
+	runes := []rune(plain)
+	// All confirm/selection glyphs are single-cell, so walk runes by width.
+	col, start := 0, -1
+	var out []rune
+	for i, r := range runes {
+		if col == x && start < 0 {
+			start = i
+		}
+		if start >= 0 && col < x+w {
+			out = append(out, r)
+		}
+		col += runewidth.RuneWidth(r)
+	}
+	return string(out)
+}
+
+func TestConfirmationOverlayRegistersYesNoZones(t *testing.T) {
+	c := NewConfirmationOverlay("[!] Kill session 'alpha'?")
+	c.SetWidth(50)
+	reg := zones.NewRegistry()
+	origin := layout.Point{X: 12, Y: 5}
+	c.RegisterZones(reg, origin)
+
+	lines := strings.Split(c.Render(), "\n")
+
+	yes, ok := reg.Find(zones.OverlayConfirmYes)
+	require.True(t, ok, "yes zone; got %v", reg.IDs())
+	no, ok := reg.Find(zones.OverlayConfirmNo)
+	require.True(t, ok, "no zone")
+
+	assert.Equal(t, yes.Y, no.Y, "both buttons sit on the instruction line")
+	line := lines[yes.Y-origin.Y]
+	assert.Equal(t, "y to confirm", cellSliceAt(line, yes.X-origin.X, yes.W),
+		"the yes zone covers exactly its rendered words")
+	assert.Equal(t, "n or esc to cancel", cellSliceAt(line, no.X-origin.X, no.W),
+		"the no zone covers exactly its rendered words")
+
+	// Resolve precedence sanity: a click on each zone resolves to it.
+	id, _, ok := reg.Resolve(yes.X, yes.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.OverlayConfirmYes, id)
+	id, _, ok = reg.Resolve(no.X+2, no.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.OverlayConfirmNo, id)
+}
+
+// TestConfirmationOverlayZonesFollowCustomKeys: overlays with a custom
+// confirm key register the zone over the custom instruction text.
+func TestConfirmationOverlayZonesFollowCustomKeys(t *testing.T) {
+	c := NewConfirmationOverlay("proceed?")
+	c.SetWidth(50)
+	c.SetConfirmKey("d")
+	reg := zones.NewRegistry()
+	c.RegisterZones(reg, layout.Point{})
+
+	yes, ok := reg.Find(zones.OverlayConfirmYes)
+	require.True(t, ok)
+	line := strings.Split(c.Render(), "\n")[yes.Y]
+	assert.Equal(t, "d to confirm", cellSliceAt(line, yes.X, yes.W))
+}
+
+func TestSelectionOverlayRegistersRowZones(t *testing.T) {
+	items := []string{"claude", "aider", "codex"}
+	s := NewSelectionOverlay("Select Program", items)
+	s.SetWidth(50)
+	reg := zones.NewRegistry()
+	origin := layout.Point{X: 8, Y: 4}
+	s.RegisterZones(reg, origin)
+
+	lines := strings.Split(s.Render(), "\n")
+	for i, item := range items {
+		r, ok := reg.Find(zones.OverlaySelectRow(i))
+		require.True(t, ok, "row zone for %q; got %v", item, reg.IDs())
+		assert.Equal(t, origin.X, r.X, "row zones span the full overlay width")
+		assert.Contains(t, xansi.Strip(lines[r.Y-origin.Y]), item,
+			"row %d's zone must sit on the line rendering %q", i, item)
+	}
+}
+
+func TestSearchOverlayRegistersRowZonesAndSetSelectedIndex(t *testing.T) {
+	instances := []*session.Instance{
+		{Title: "alpha"},
+		{Title: "alpha-2"},
+		{Title: "beta"},
+	}
+	s := NewSearchOverlay(instances)
+	reg := zones.NewRegistry()
+	origin := layout.Point{X: 10, Y: 3}
+	s.RegisterZones(reg, origin)
+
+	lines := strings.Split(s.Render(), "\n")
+	for i, inst := range instances {
+		r, ok := reg.Find(zones.OverlaySearchRow(i))
+		require.True(t, ok, "row zone for %q; got %v", inst.Title, reg.IDs())
+		assert.Contains(t, xansi.Strip(lines[r.Y-origin.Y]), inst.Title,
+			"result %d's zone must sit on the line rendering %q", i, inst.Title)
+	}
+	// "alpha" is a prefix of "alpha-2": the ordered scan must not have bound
+	// both zones to the same line.
+	r0, _ := reg.Find(zones.OverlaySearchRow(0))
+	r1, _ := reg.Find(zones.OverlaySearchRow(1))
+	assert.NotEqual(t, r0.Y, r1.Y, "prefix-colliding titles must map to distinct rows")
+
+	// SetSelectedIndex is the click primitive: it moves the selection the
+	// subsequent enter submits.
+	s.SetSelectedIndex(2)
+	require.True(t, s.HandleKeyPress(keyEnter()))
+	assert.Same(t, instances[2], s.GetSelectedInstance())
+
+	// Out-of-range clicks are refused.
+	s2 := NewSearchOverlay(instances)
+	s2.SetSelectedIndex(99)
+	require.True(t, s2.HandleKeyPress(keyEnter()))
+	assert.Same(t, instances[0], s2.GetSelectedInstance())
+}

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/sachiniyer/agent-factory/ui/tree"
 
@@ -136,6 +137,14 @@ type Sidebar struct {
 	height   int
 	width    int
 	focused  bool
+
+	// rect is the pane's screen rect (SetRect); zone registration needs the
+	// absolute origin, not just the size.
+	rect layout.Rect
+	// zones is the shared mouse hit-test registry (#1024 PR 6). String()
+	// registers a rect per interactive row every frame; nil (ui unit tests
+	// that never wire a registry) skips registration.
+	zones *zones.Registry
 }
 
 // NewSidebar creates a new sidebar rendering the given projection.
@@ -175,7 +184,13 @@ func (s *Sidebar) contentWidth() int {
 
 // SetRect implements layout.Pane.
 func (s *Sidebar) SetRect(r layout.Rect) {
+	s.rect = r
 	s.SetSize(r.W, r.H)
+}
+
+// SetZoneRegistry wires the shared mouse hit-test registry (#1024 PR 6).
+func (s *Sidebar) SetZoneRegistry(reg *zones.Registry) {
+	s.zones = reg
 }
 
 // Focused implements layout.Pane.
@@ -192,7 +207,10 @@ func (s *Sidebar) Blur() { s.focused = false }
 // pane has focus); per-pane routing arrives with the split (#1024 PR 5).
 func (s *Sidebar) HandleKey(tea.KeyMsg) (tea.Cmd, bool) { return nil, false }
 
-// HandleMouse implements layout.Pane. Mouse support is #1024 PR 6.
+// HandleMouse implements layout.Pane. Mouse dispatch is zone-id-based at the
+// root (#1024 PR 6): String() registers per-row zones and the root router
+// calls the click primitives (SelectTabRow, ToggleInstanceTree, …) directly,
+// so the pane-local fallback consumes nothing.
 func (s *Sidebar) HandleMouse(tea.MouseMsg, layout.Point) tea.Cmd { return nil }
 
 // View implements layout.Pane.
@@ -706,11 +724,13 @@ func (s *Sidebar) SyncCursorToActiveTab() {
 // content pane) would be wrong here because the selected row can sit below the
 // fold while navigating — instead the rendered slice scrolls so the selection
 // is always visible, with "▲/▼ N more" rows marking hidden items.
+// chromeLines is the fixed chrome above the sidebar's item list: one leading
+// blank line plus the title row. Shared by String()'s window budget and the
+// zone registration's y origin so the two can't drift.
+const chromeLines = 2
+
 func (s *Sidebar) String() string {
 	s.syncFromStore()
-
-	// Chrome above the item list: one leading blank line plus the title row.
-	const chromeLines = 2
 
 	// Render every visible row up front and measure real heights: instance
 	// rows are multi-line (title + branch, plus an optional PR line) while tab
@@ -748,6 +768,8 @@ func (s *Sidebar) String() string {
 	} else {
 		s.scrollOffset = 0
 	}
+
+	s.registerZones(heights, start, end, hiddenAbove > 0)
 
 	var b strings.Builder
 	b.WriteString("\n")
@@ -808,6 +830,120 @@ func (s *Sidebar) String() string {
 		}
 	}
 	return out
+}
+
+// registerZones records the mouse hit-test rects for this frame (#1024 PR 6):
+// the pane background, the section header, and — for every row inside the
+// rendered window — the instance/tab row plus the instance's ▸/▾ arrow cell.
+// Coordinates mirror String()'s exact line budget (the leading blank + title
+// chrome, then the "▲ N more" indicator when the window is scrolled), and
+// every zone is clipped to the pane rect since the final ClampToRect clips
+// any partially fitting last row the same way.
+func (s *Sidebar) registerZones(heights []int, start, end int, topIndicator bool) {
+	if s.zones == nil || s.rect.Empty() {
+		return
+	}
+	s.zones.Register(zones.TreeBG, s.rect)
+
+	instances := s.proj.GetInstances()
+	y := s.rect.Y + chromeLines
+	if topIndicator {
+		y++
+	}
+	bottom := s.rect.Bottom()
+	for i := start; i < end && y < bottom; i++ {
+		item := s.visibleItems[i]
+		h := heights[i]
+		if y+h > bottom {
+			h = bottom - y
+		}
+		row := layout.Rect{X: s.rect.X, Y: y, W: s.rect.W, H: h}
+		switch {
+		case item.IsHeader:
+			s.zones.Register(zones.TreeHeader, row)
+		case item.Kind == SectionInstances && item.ItemIndex >= 0 && item.ItemIndex < len(instances):
+			inst := instances[item.ItemIndex]
+			if item.IsTab {
+				s.zones.Register(zones.TreeTab(inst.Title, item.TabIndex), row)
+			} else {
+				s.zones.Register(zones.TreeInstance(inst.Title), row)
+				// The arrow cell registers ON TOP of the row (later wins) so
+				// clicking it expands/collapses instead of selecting.
+				if ax, ay, ok := tree.ArrowCell(s.contentWidth()); ok && tree.Expandable(inst) && ay < h {
+					s.zones.Register(zones.TreeArrow(inst.Title),
+						layout.Rect{X: s.rect.X + ax, Y: y + ay, W: 1, H: 1})
+				}
+			}
+		}
+		y += heights[i]
+	}
+}
+
+// ClickHeader moves the cursor onto the Instances section header and toggles
+// its expansion — the click equivalent of Enter on the header row.
+func (s *Sidebar) ClickHeader() {
+	s.syncFromStore()
+	for i, item := range s.visibleItems {
+		if item.IsHeader {
+			s.selectedIdx = i
+			break
+		}
+	}
+	s.ToggleSection()
+}
+
+// SelectTabRow moves the cursor onto tab slot idx of the instance titled
+// title — the click action for a tree tab row, which (via pushSelection)
+// retargets pane A onto that tab. Tab rows only render for the expanded
+// instance, so a click that races a structure change and finds no such row
+// no-ops rather than guessing.
+func (s *Sidebar) SelectTabRow(title string, idx int) {
+	s.syncFromStore()
+	instances := s.proj.GetInstances()
+	for j, item := range s.visibleItems {
+		if item.Kind == SectionInstances && !item.IsHeader && item.IsTab &&
+			item.ItemIndex >= 0 && item.ItemIndex < len(instances) &&
+			instances[item.ItemIndex].Title == title && item.TabIndex == idx {
+			s.selectedIdx = j
+			s.afterCursorMove()
+			return
+		}
+	}
+}
+
+// ToggleInstanceTree is the click action for an instance row's ▸/▾ arrow: the
+// cursor lands on the clicked row (a click always selects), and the arrow
+// meaning follows the tree's expansion policy — selecting a different
+// instance auto-expands it (that IS the ▸ action), while the already-selected
+// instance toggles its explicit h/← collapse override.
+func (s *Sidebar) ToggleInstanceTree(title string) {
+	s.syncFromStore()
+	instances := s.proj.GetInstances()
+	instIdx := -1
+	for i, inst := range instances {
+		if inst.Title == title {
+			instIdx = i
+			break
+		}
+	}
+	if instIdx < 0 {
+		return
+	}
+	sel := s.proj.GetSelectedInstance()
+	wasSelected := sel != nil && sel.Title == title
+	wasExpanded := s.instanceExpanded(instances[instIdx])
+	s.SetSelectedInstance(instIdx)
+	if !wasSelected {
+		return
+	}
+	if wasExpanded {
+		s.treeCollapsed = title
+	} else {
+		s.treeCollapsed = ""
+	}
+	s.rebuildVisibleItems()
+	s.moveCursorToInstanceRow(instIdx)
+	s.afterCursorMove()
 }
 
 // scrollToSelection clamps scrollOffset and moves it minimally so the selected

--- a/ui/sidebar_zones_test.go
+++ b/ui/sidebar_zones_test.go
@@ -1,0 +1,191 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+// ----------------------------------------------------------------------------
+// Mouse zone registration (#1024 PR 6): the sidebar registers a hit rect per
+// interactive row while rendering, and the rects must line up with the actual
+// rendered output — the tests derive expectations from the registry and check
+// them against the frame, never against hardcoded coordinates.
+// ----------------------------------------------------------------------------
+
+// plainLines strips ANSI and splits a rendered frame into lines.
+func plainLines(out string) []string {
+	return strings.Split(xansi.Strip(out), "\n")
+}
+
+// runeAtCell returns the rune occupying terminal cell col of a plain line.
+func runeAtCell(line string, col int) rune {
+	w := 0
+	for _, r := range line {
+		rw := runewidth.RuneWidth(r)
+		if w == col {
+			return r
+		}
+		w += rw
+	}
+	return 0
+}
+
+// lineAt maps an absolute zone row back into the pane-local rendered line.
+func lineAt(t *testing.T, lines []string, rect layout.Rect, y int) string {
+	t.Helper()
+	local := y - rect.Y
+	require.GreaterOrEqual(t, local, 0)
+	require.Less(t, local, len(lines), "zone row must exist in the rendered output")
+	return lines[local]
+}
+
+func TestSidebarRegistersRowZones(t *testing.T) {
+	s := newTreeSidebar(t, 3)
+	reg := zones.NewRegistry()
+	s.SetZoneRegistry(reg)
+	rect := layout.Rect{X: 7, Y: 3, W: 40, H: 24}
+	s.SetRect(rect)
+	s.SetSelectedInstance(0)
+
+	reg.Reset()
+	out := s.String()
+	lines := plainLines(out)
+
+	// The pane background is the whole rect (any stray click focuses the tree).
+	bg, ok := reg.Find(zones.TreeBG)
+	require.True(t, ok)
+	assert.Equal(t, rect, bg)
+
+	// The section header row renders the section title on its zone's row.
+	header, ok := reg.Find(zones.TreeHeader)
+	require.True(t, ok, "header zone must be registered")
+	assert.Contains(t, lineAt(t, lines, rect, header.Y), "Instances",
+		"the header zone must sit on the rendered header row")
+
+	// Every instance row has a zone whose block contains its title.
+	for _, title := range []string{"t-00", "t-01", "t-02"} {
+		r, ok := reg.Find(zones.TreeInstance(title))
+		require.True(t, ok, "instance zone for %s; got %v", title, reg.IDs())
+		assert.Equal(t, rect.X, r.X)
+		assert.Equal(t, rect.W, r.W)
+		block := strings.Join(lines[r.Y-rect.Y:r.Y-rect.Y+r.H], "\n")
+		assert.Contains(t, block, title, "the zone block must contain the row it targets")
+	}
+
+	// The selected (expanded) instance registers its tab child rows, and each
+	// zone's row renders that tab's label.
+	for idx, label := range []string{"1 Preview", "2 Terminal"} {
+		r, ok := reg.Find(zones.TreeTab("t-00", idx))
+		require.True(t, ok, "tab zone for slot %d", idx)
+		assert.Equal(t, 1, r.H, "tab rows are single-line")
+		assert.Contains(t, lineAt(t, lines, rect, r.Y), label)
+	}
+	// Collapsed instances register no tab zones.
+	_, ok = reg.Find(zones.TreeTab("t-01", 0))
+	assert.False(t, ok, "collapsed instances must not register tab zones")
+}
+
+func TestSidebarArrowZoneMatchesRenderedGlyph(t *testing.T) {
+	s := newTreeSidebar(t, 2)
+	reg := zones.NewRegistry()
+	s.SetZoneRegistry(reg)
+	rect := layout.Rect{X: 4, Y: 2, W: 38, H: 22}
+	s.SetRect(rect)
+	s.SetSelectedInstance(0)
+
+	reg.Reset()
+	lines := plainLines(s.String())
+
+	// Expanded selected instance: its arrow zone must sit exactly on the ▾.
+	r, ok := reg.Find(zones.TreeArrow("t-00"))
+	require.True(t, ok, "arrow zone for the expanded instance")
+	assert.Equal(t, '▾', runeAtCell(lineAt(t, lines, rect, r.Y), r.X-rect.X),
+		"the arrow zone must cover the rendered ▾ glyph")
+
+	// Collapsed instance: same contract for ▸.
+	r2, ok := reg.Find(zones.TreeArrow("t-01"))
+	require.True(t, ok, "arrow zone for the collapsed instance")
+	assert.Equal(t, '▸', runeAtCell(lineAt(t, lines, rect, r2.Y), r2.X-rect.X))
+
+	// The arrow registers on top of the instance row: resolving its cell must
+	// hit the arrow, while the cell next to it hits the row.
+	id, _, ok := reg.Resolve(r.X, r.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.TreeArrow("t-00"), id)
+	id, _, ok = reg.Resolve(r.X+3, r.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.TreeInstance("t-00"), id)
+}
+
+// TestSidebarZonesClippedToRect: rows scrolled out of the window register no
+// zones, and no registered zone extends past the pane rect (String()'s final
+// clamp cuts partially fitting rows the same way).
+func TestSidebarZonesClippedToRect(t *testing.T) {
+	s := newTreeSidebar(t, 12)
+	reg := zones.NewRegistry()
+	s.SetZoneRegistry(reg)
+	rect := layout.Rect{X: 0, Y: 0, W: 30, H: 12}
+	s.SetRect(rect)
+	s.SetSelectedInstance(0)
+
+	reg.Reset()
+	_ = s.String()
+
+	registered := 0
+	for _, id := range reg.IDs() {
+		r, ok := reg.Find(id)
+		require.True(t, ok)
+		assert.LessOrEqual(t, r.Bottom(), rect.Bottom(), "zone %s must not extend past the pane", id)
+		if title, isInst := zones.TreeInstanceTitle(id); isInst && title != "" {
+			registered++
+		}
+	}
+	assert.Less(t, registered, 12, "rows scrolled out of the window must not register zones")
+	assert.Greater(t, registered, 0, "visible rows must register zones")
+}
+
+// TestSidebarClickPrimitives covers the click actions the mouse router calls:
+// SelectTabRow retargets the active tab, ToggleInstanceTree drives the
+// expansion policy, ClickHeader toggles the section.
+func TestSidebarClickPrimitives(t *testing.T) {
+	s := newTreeSidebar(t, 2)
+	s.SetSize(40, 24)
+	s.SetSelectedInstance(0)
+
+	// Click a tab row: cursor lands on it, store's active tab follows.
+	s.SelectTabRow("t-00", 1)
+	sel := s.GetSelection()
+	require.True(t, sel.IsTab)
+	assert.Equal(t, 1, sel.TabIndex)
+	assert.Equal(t, 1, s.proj.ActiveTab())
+
+	// Arrow on the selected instance: collapse, then expand again.
+	s.ToggleInstanceTree("t-00")
+	assert.Equal(t, 0, tabRowCount(s), "arrow click on the expanded selection collapses it")
+	sel = s.GetSelection()
+	assert.False(t, sel.IsTab, "the fold lands the cursor on the instance row")
+	s.ToggleInstanceTree("t-00")
+	assert.Equal(t, 2, tabRowCount(s), "second arrow click re-expands")
+
+	// Arrow on a non-selected instance selects it (which auto-expands).
+	s.ToggleInstanceTree("t-01")
+	require.NotNil(t, s.GetSelectedInstance())
+	assert.Equal(t, "t-01", s.GetSelectedInstance().Title)
+	assert.Equal(t, 2, tabRowCount(s), "selecting via the arrow auto-expands the new selection")
+
+	// Header click folds the whole section; a second click reopens it.
+	s.ClickHeader()
+	assert.Equal(t, 0, tabRowCount(s))
+	assert.True(t, s.GetSelection().IsHeader)
+	s.ClickHeader()
+	assert.False(t, s.visibleItems[len(s.visibleItems)-1].IsHeader,
+		"reopened section shows instance rows again")
+}

--- a/ui/statusbar.go
+++ b/ui/statusbar.go
@@ -37,6 +37,9 @@ func (s *StatusBar) SetRect(r layout.Rect) {
 		menuRows = 0
 	}
 	s.menu.SetSize(r.W, menuRows)
+	// The menu registers per-hint click zones during render (#1024 PR 6); it
+	// sits at the top of the status-bar rect, so that is its zone origin.
+	s.menu.SetOrigin(layout.Point{X: r.X, Y: r.Y})
 	s.errBox.SetSize(r.W, 1)
 }
 
@@ -52,7 +55,10 @@ func (s *StatusBar) Blur() {}
 // HandleKey implements layout.Pane (never consumes).
 func (s *StatusBar) HandleKey(tea.KeyMsg) (tea.Cmd, bool) { return nil, false }
 
-// HandleMouse implements layout.Pane. Clickable hints are #1024 PR 6.
+// HandleMouse implements layout.Pane. Hint clicks are zone-id-based at the
+// root (#1024 PR 6): the menu registers a StatusHint zone per rendered hint
+// and the root synthesizes that key, so the pane-local fallback consumes
+// nothing.
 func (s *StatusBar) HandleMouse(tea.MouseMsg, layout.Point) tea.Cmd { return nil }
 
 // View implements layout.Pane: exactly rect-sized.

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/sachiniyer/agent-factory/ui/tree"
 
@@ -67,6 +68,10 @@ type TabbedWindow struct {
 	rect    layout.Rect
 	focused bool
 	pinned  bool
+
+	// zones is the shared mouse hit-test registry (#1024 PR 6); String()
+	// registers the pane's body + header rects every frame. Nil skips.
+	zones *zones.Registry
 
 	tab *TabPane
 }
@@ -222,7 +227,10 @@ func (w *TabbedWindow) Blur() { w.focused = false }
 // (#1024 PR 5).
 func (w *TabbedWindow) HandleKey(tea.KeyMsg) (tea.Cmd, bool) { return nil, false }
 
-// HandleMouse implements layout.Pane. Mouse support is #1024 PR 6.
+// HandleMouse implements layout.Pane. Mouse dispatch is zone-id-based at the
+// root (#1024 PR 6): the body/header zones registered by String() resolve to
+// focus/attach/scroll actions there, so the pane-local fallback consumes
+// nothing.
 func (w *TabbedWindow) HandleMouse(tea.MouseMsg, layout.Point) tea.Cmd { return nil }
 
 // UpdateContent updates the content of the active tab's pane. instance may be
@@ -323,10 +331,43 @@ func (w *TabbedWindow) renderHeader(width int) string {
 // live capture view.
 func (w *TabbedWindow) View() string { return w.String() }
 
+// SetZoneRegistry wires the shared mouse hit-test registry (#1024 PR 6).
+func (w *TabbedWindow) SetZoneRegistry(reg *zones.Registry) {
+	w.zones = reg
+}
+
+// Region returns the layout region id this window renders as: pane B when
+// pinned, pane A otherwise. Doubles as the pane component of its zone ids.
+func (w *TabbedWindow) Region() string {
+	if w.pinned {
+		return layout.RegionPaneB
+	}
+	return layout.RegionPaneA
+}
+
+// registerZones records this frame's hit-test rects: the whole pane as the
+// body (click focuses; click focused attaches; wheel scrolls), with the
+// one-line `title · tab` header registered on top of it (click focuses the
+// pane). The header sits inside the frame border, so it needs at least a
+// 3×3 rect to exist.
+func (w *TabbedWindow) registerZones() {
+	if w.zones == nil || w.rect.Empty() {
+		return
+	}
+	region := w.Region()
+	w.zones.Register(zones.PaneBody(region), w.rect)
+	if w.rect.W > 2 && w.rect.H > 2 {
+		w.zones.Register(zones.PaneHeader(region), layout.Rect{
+			X: w.rect.X + 1, Y: w.rect.Y + 1, W: w.rect.W - 2, H: paneHeaderRows,
+		})
+	}
+}
+
 func (w *TabbedWindow) String() string {
 	if w.rect.Empty() {
 		return ""
 	}
+	w.registerZones()
 	iw, ih := w.innerSize()
 	inner := lipgloss.JoinVertical(lipgloss.Left,
 		w.renderHeader(iw),

--- a/ui/tabbed_window_zones_test.go
+++ b/ui/tabbed_window_zones_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+// TestTabbedWindowRegistersBodyAndHeaderZones (#1024 PR 6): the pane
+// registers its whole rect as the body and the one-line header on top of it,
+// with the header zone sitting on the row that actually renders the header
+// text — under both the pane-A and pinned pane-B identities.
+func TestTabbedWindowRegistersBodyAndHeaderZones(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		pinned bool
+		region string
+	}{
+		{"paneA", false, layout.RegionPaneA},
+		{"paneB", true, layout.RegionPaneB},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tw := newTestTabbedWindow()
+			if tc.pinned {
+				tw = NewPinnedTabbedWindow(NewTabPane(), tw.proj)
+			}
+			reg := zones.NewRegistry()
+			tw.SetZoneRegistry(reg)
+			rect := layout.Rect{X: 30, Y: 2, W: 60, H: 20}
+			tw.SetRect(rect)
+
+			reg.Reset()
+			out := tw.String()
+			lines := plainLines(out)
+
+			body, ok := reg.Find(zones.PaneBody(tc.region))
+			require.True(t, ok, "body zone; got %v", reg.IDs())
+			assert.Equal(t, rect, body, "the body zone is the whole pane rect")
+
+			header, ok := reg.Find(zones.PaneHeader(tc.region))
+			require.True(t, ok, "header zone")
+			assert.Equal(t, layout.Rect{X: rect.X + 1, Y: rect.Y + 1, W: rect.W - 2, H: 1}, header,
+				"the header sits inside the frame border")
+			// The header zone's row renders the header text (nil binding here,
+			// so the placeholder header).
+			assert.Contains(t, lines[header.Y-rect.Y], "no session selected",
+				"the header zone must sit on the rendered header line")
+
+			// Precedence: a point on the header row resolves to the header, a
+			// point below it to the body.
+			id, _, ok := reg.Resolve(header.X+2, header.Y)
+			require.True(t, ok)
+			assert.Equal(t, zones.PaneHeader(tc.region), id)
+			id, _, ok = reg.Resolve(header.X+2, header.Y+3)
+			require.True(t, ok)
+			assert.Equal(t, zones.PaneBody(tc.region), id)
+		})
+	}
+}
+
+// TestTabbedWindowNoZonesWhenHidden: a zero rect (pane B without a split)
+// renders nothing and must register nothing.
+func TestTabbedWindowNoZonesWhenHidden(t *testing.T) {
+	tw := newTestTabbedWindow()
+	reg := zones.NewRegistry()
+	tw.SetZoneRegistry(reg)
+	tw.SetRect(layout.Rect{})
+
+	reg.Reset()
+	_ = tw.String()
+	assert.Empty(t, reg.IDs(), "a hidden pane must not register hit zones")
+}

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -77,6 +77,21 @@ type TaskPane struct {
 	dirty         bool
 	deleted       []task.Task
 	hasFocus      bool
+
+	// rowSpans records where each task's row block landed in the last
+	// renderListMode output, so the hosting automations strip can register
+	// mouse zones over the real rendered rows (#1024 PR 6). Nil while the
+	// edit/create form is showing (no task rows on screen).
+	rowSpans []TaskRowSpan
+}
+
+// TaskRowSpan is one task's row block in the rendered list: the 0-based
+// start line within the pane's output and how many lines the block spans
+// (the selected row expands with detail lines).
+type TaskRowSpan struct {
+	ID    string
+	Line  int
+	Lines int
 }
 
 // NewTaskPane creates a new task pane.
@@ -332,6 +347,46 @@ func (s *TaskPane) ScrollDown() {
 	if s.selectedIdx < len(s.tasks)-1 {
 		s.selectedIdx++
 	}
+}
+
+// ListRowSpans returns where each task row landed in the last rendered list,
+// for mouse zone registration (#1024 PR 6). Empty while the edit/create form
+// is showing.
+func (s *TaskPane) ListRowSpans() []TaskRowSpan {
+	return s.rowSpans
+}
+
+// SelectTaskByID moves the selection onto the task with the given id — the
+// click action for a task row. Reports whether the task was found; ignored
+// while the edit form owns the pane (matching ScrollUp/Down).
+func (s *TaskPane) SelectTaskByID(id string) bool {
+	if s.editing || s.creating {
+		return false
+	}
+	for i, tsk := range s.tasks {
+		if tsk.ID == id {
+			s.selectedIdx = i
+			return true
+		}
+	}
+	return false
+}
+
+// SelectedTask returns the task the selection rests on, if any.
+func (s *TaskPane) SelectedTask() (task.Task, bool) {
+	if s.selectedIdx < 0 || s.selectedIdx >= len(s.tasks) {
+		return task.Task{}, false
+	}
+	return s.tasks[s.selectedIdx], true
+}
+
+// StartEditSelected opens the edit form for the current selection — the
+// double-click equivalent of enter on a task row.
+func (s *TaskPane) StartEditSelected() {
+	if s.editing || s.creating || len(s.tasks) == 0 {
+		return
+	}
+	s.enterEditMode()
 }
 
 // HandleKeyPress processes a key press. Returns true if consumed.
@@ -647,10 +702,15 @@ func (s *TaskPane) renderListMode() string {
 	var b strings.Builder
 	b.WriteString(tStyle.Render("Tasks"))
 	b.WriteString("\n\n")
+	// line tracks the 0-based output line about to be written, feeding the
+	// rowSpans the automations strip registers mouse zones from (#1024 PR 6).
+	line := 2
+	s.rowSpans = s.rowSpans[:0]
 
 	if len(s.tasks) == 0 {
 		b.WriteString(disabledStyle.Render("  No tasks. Press n to create one."))
 		b.WriteString("\n")
+		line++
 	}
 
 	// Width available to the indented detail lines under the selected row.
@@ -660,6 +720,7 @@ func (s *TaskPane) renderListMode() string {
 	}
 
 	for i, tsk := range s.tasks {
+		rowStart := line
 		status := "[✓]"
 		style := enabledStyle
 		if !tsk.Enabled {
@@ -682,12 +743,14 @@ func (s *TaskPane) renderListMode() string {
 			b.WriteString(style.Render("  " + header))
 		}
 		b.WriteString("\n")
+		line++
 
 		// A crash-looped watcher gets its full #797 failure summary on a
 		// detail line — the only always-on detail, and only when errored.
 		if tsk.IsWatch() && strings.HasPrefix(tsk.LastRunStatus, "errored:") {
 			b.WriteString(erroredStyle.Render("      " + tsk.LastRunStatus))
 			b.WriteString("\n")
+			line++
 		}
 
 		// The selected row expands with prompt + agent + last-run detail.
@@ -695,6 +758,7 @@ func (s *TaskPane) renderListMode() string {
 			if snippet := promptSnippet(tsk.Prompt, detailWidth); snippet != "" {
 				b.WriteString(detailStyle.Render("      " + snippet))
 				b.WriteString("\n")
+				line++
 			}
 			lastRun := "never"
 			if tsk.LastRunAt != nil {
@@ -716,7 +780,9 @@ func (s *TaskPane) renderListMode() string {
 			}
 			b.WriteString(detailStyle.Render(detail))
 			b.WriteString("\n")
+			line++
 		}
+		s.rowSpans = append(s.rowSpans, TaskRowSpan{ID: tsk.ID, Line: rowStart, Lines: line - rowStart})
 	}
 
 	b.WriteString("\n")
@@ -730,6 +796,8 @@ func (s *TaskPane) renderListMode() string {
 }
 
 func (s *TaskPane) renderEditMode() string {
+	// No task rows on screen: stale spans must not register phantom zones.
+	s.rowSpans = nil
 	editTitleStyle := lipgloss.NewStyle().
 		Foreground(AccentColor).
 		Bold(true).

--- a/ui/tree/arrow_test.go
+++ b/ui/tree/arrow_test.go
@@ -1,0 +1,63 @@
+package tree
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/mattn/go-runewidth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// runeAtCell returns the rune occupying terminal cell col of a plain line.
+func runeAtCell(line string, col int) rune {
+	w := 0
+	for _, r := range line {
+		if w == col {
+			return r
+		}
+		w += runewidth.RuneWidth(r)
+	}
+	return 0
+}
+
+// TestArrowCellMatchesRenderedArrow pins ArrowCell — the sidebar's mouse hit
+// target for the ▸/▾ glyph (#1024 PR 6) — against Render's actual output, so
+// a prefix layout change moves the hit target with it or fails here.
+func TestArrowCellMatchesRenderedArrow(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: "arrow-pin", Path: t.TempDir(), Program: "test",
+	})
+	require.NoError(t, err)
+
+	r := NewInstanceRenderer(&spin)
+	r.SetWidth(30)
+	r.SetIndexWidth(1)
+
+	x, y, ok := ArrowCell(30)
+	require.True(t, ok)
+
+	for _, tc := range []struct {
+		name     string
+		expanded bool
+		want     rune
+	}{
+		{"expanded", true, '▾'},
+		{"collapsed", false, '▸'},
+	} {
+		out := r.Render(inst, 1, false, false, tc.expanded)
+		lines := strings.Split(ansiEscape.ReplaceAllString(out, ""), "\n")
+		require.Greater(t, len(lines), y)
+		assert.Equal(t, tc.want, runeAtCell(lines[y], x),
+			"%s: ArrowCell must point at the rendered arrow glyph", tc.name)
+	}
+
+	// Ultra-narrow widths drop the arrow from the prefix, and ArrowCell must
+	// report that (the sidebar registers no arrow zone then).
+	_, _, ok = ArrowCell(9)
+	assert.False(t, ok, "no arrow cell at the narrow-width fallback")
+}

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -114,6 +114,21 @@ func (r *InstanceRenderer) SetIndexWidth(digits int) {
 // ɹ and ɻ are other options.
 const branchIcon = "Ꮧ"
 
+// ArrowCell returns the (x, y) cell of the ▾/▸ expand/collapse arrow within
+// an instance row block rendered at content width w, for mouse hit-testing
+// (#1024 PR 6): block line 0 is the title style's top-padding line, so the
+// arrow sits on line 1, one cell after the row's left padding + the prefix's
+// leading space. ok is false at ultra-narrow widths, where Render drops the
+// arrow from the prefix entirely (the #646 fallback). Kept next to Render so
+// the prefix layout and the hit target can't drift apart; the render test
+// pins them together against actual output.
+func ArrowCell(w int) (x, y int, ok bool) {
+	if w <= 9 {
+		return 0, 0, false
+	}
+	return 2, 1, true
+}
+
 // Render renders an instance row. expanded selects the ▾/▸ tree arrow; a
 // non-expandable instance (see Expandable) renders a blank arrow cell so its
 // title stays aligned with its siblings.


### PR DESCRIPTION
Epic PR 6 of the multi-pane TUI rewrite ([#1024](https://github.com/sachiniyer/agent-factory/issues/1024), RFC `docs/design/tui-rewrite.md` §2.5) — first-class mouse support. Folds in and **closes #1025**.

## What this does

Everywhere a key works, a click or wheel now works too. Three pieces:

**1. Per-frame zone registration.** `View()` resets the PR-1 `zones.Registry` at the top of every frame, and each pane registers its interactive rects while rendering, so the hit-test map always mirrors exactly what's on screen:

- tree: `tree:instance:<title>` (row block), `tree:tab:<title>:<idx>`, `tree:arrow:<title>` (the ▸/▾ cell, registered on top of the row), `tree:header`, `tree:bg`
- workspace: `paneA:body` / `paneA:header`, same for `paneB` (only while the split renders)
- automations: `auto:strip` plus `auto:task:<id>` per row — in both the compact strip and the expanded manager (`TaskPane` now records its real row spans, including the selected row's multi-line detail block)
- status bar: `status:hint:<key>` per rendered hint, on the exact centered cells (`Menu` tracks each hint's extent; dropped hints register nothing; the `1-9` chip is deliberately not clickable)
- overlays: `overlay:confirm:yes|no`, `overlay:select:<idx>`, `overlay:search:<idx>` — derived by scanning the overlay's own rendered output, so border/wrap changes move the zones instead of stranding them

Zone id constructors + parsers live together in `ui/layout/zones/ids.go` so producers (ui) and the consumer (app router) can't drift.

**2. Root `MouseMsg` router** (`app/handle_mouse.go`), replacing the wheel-only handling in `app/app.go`. The RFC §2.5 gesture table:

| Gesture | Effect |
|---|---|
| Click tree instance/tab row | Select (retargets pane A live) |
| Double-click tree row / click a focused pane body | Attach — through the exact `handleEnter` path, `attachOverlayCallbackFn` seam included |
| Click ▸/▾ arrow | Expand/collapse (selecting a different instance auto-expands; the selected one toggles its explicit collapse) |
| Click pane header (or unfocused pane body) | Focus that pane — picks A or B in a split |
| Click task row | Focus automations + select the task; double-click opens its editor |
| Click status-bar hint | Presses that key through the full `handleKeyPress` path (all state gates + keydown highlight identical to typing it) |
| Wheel | Scrolls the region **under the cursor**: tree cursor movement, pane capture scroll, task selection — previously it always scrolled the content pane |
| Click overlay buttons | `y`/`n` words on the confirmation, selection/search rows = select + enter |

Mouse-driven focus moves mirror `cycleFocus`'s contract: leaving the automations strip persists dirty task edits and surfaces a failed save. In modal states only the overlay's own zones react — a stray click can never mutate state behind a modal (naming keeps its submit/change-program hints clickable). Double-click detection is a 400ms same-zone window behind a swappable clock.

**3. Nothing else moves.** Keyboard behavior is byte-for-byte untouched (the menu's rendering is unchanged; only its internals track hint extents). `session/` and `session/tmux/` have **zero diffs**; the attach seam, #960 snapshot/RPC data flow, and the PR-5 split are exactly as they were. While attached, bubbletea stays blocked and tmux's own mouse mode applies, as before.

## Tests (hermetic, race-clean)

- **Zone-vs-render pins**: every zone family is checked against the actual rendered frame — the arrow zone must sit on the rendered ▸/▾ glyph, hint zones must cover exactly their "key desc" cells, task/tree/overlay row zones must sit on the lines rendering their targets. Coordinates are derived **from the registry / solved layout**, never hardcoded.
- **Routing**: 15 model-level tests inject `tea.MouseMsg` at registry-derived coordinates and assert selection/focus/attach/scroll/action per gesture, incl. wheel-by-region, modal click blocking, overlay button = key equivalence, double-click vs slow-click, and inertness of misses/releases/fallback-banner frames.
- Full suite: `gofmt -l` clean, `go build ./...`, `golangci-lint run --timeout=3m --fast`, `go test ./...` (isolated `AGENT_FACTORY_HOME`), `deadcode -test ./...` clean, and `GOFLAGS="-p=1" go test -race -parallel 2 ./app/... ./ui/...` green.

## Play-test guide (real mouse — teatest can't exercise terminal mouse reporting)

Run in a tmux/terminal with mouse support, several instances + a couple of tasks, ≥120 cols. What to look at:

1. **Click an instance row** → it selects and pane A retargets instantly; **click a tab child row** → that tab shows in pane A (header + tree `*` agree).
2. **Click the ▸/▾ arrow** → tabs fold/unfold without changing what pane A shows; arrow on a *different* instance selects + expands it.
3. **Double-click a tree row** (instance and tab) → attaches full-screen; detach returns with focus/split intact. **Click a focused pane's body** → also attaches.
4. **Open a split (`s`), click each pane's header** → focus ring follows the click (frame + hints update); click the *unfocused* pane's body → focuses it, second click attaches.
5. **Click a task row in the strip** → strip expands focused with that task selected; **double-click** → its edit form opens. Click the strip background → just focuses.
6. **Click status-bar hints** — e.g. `tab focus`, `s split`, `? help`, `q quit` — each runs its action with the same underline flash as the key.
7. **Wheel** over the tree (cursor walks), over each pane (that pane scrolls its capture, esc exits scroll mode), over the strip (task selection moves) — position decides, not focus.
8. **Overlays**: `D` kill → click `y`/`n`; `/` search → click a result row; program selection during `n` naming → click a program. Click anywhere else while a modal is up → nothing happens behind it.
9. **Keyboard regression sweep**: j/k/h/l, 1-9, t/w, Enter/detach, s/x, Tab ring, S, H, D, /, q — all unchanged.

Closes #1025

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)