### PR TITLE
fix(daemon): self-shutdown when AF home is deleted (#1093)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -177,23 +177,103 @@ func RunDaemon(cfg *config.Config) error {
 		}
 	}()
 
-	// Block until a signal or a Shutdown RPC ends the daemon (sigChan and
-	// shutdownCh were armed before the restore above).
+	// Watch our own AF home directory (the dir holding tasks.json, the
+	// control socket, and state). If it is deleted out from under us — an
+	// abandoned temp/test home, or a user rm -rf'ing the install — nothing
+	// can reach this daemon via the control plane anymore, yet it would keep
+	// firing cron schedules forever (#1093: a leaked debug daemon spawned a
+	// session nightly for 23 days). Self-terminating is the only safe move.
+	homeGoneCh := make(chan struct{})
+	if homeDir, homeErr := config.GetConfigDir(); homeErr != nil {
+		// Without a resolvable home there is nothing to watch; the daemon
+		// could not have started its manager against one either, so this is
+		// effectively unreachable — log and run without the self-check.
+		log.WarningLog.Printf("cannot resolve agent-factory home for the abandoned-daemon self-check: %v", homeErr)
+	} else {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			watchDaemonHome(homeDir, stopCh, homeGoneCh)
+		}()
+	}
+
+	// Block until a signal, a Shutdown RPC, or the home-deleted self-check
+	// ends the daemon (sigChan and shutdownCh were armed before the restore
+	// above).
+	homeGone := false
 	select {
 	case sig := <-sigChan:
 		log.InfoLog.Printf("received signal %s", sig.String())
 	case <-shutdownCh:
 		log.InfoLog.Printf("received shutdown request via control socket")
+	case <-homeGoneCh:
+		homeGone = true
 	}
 
-	// Stop the goroutine so we don't race.
+	// Stop the goroutines so we don't race.
 	close(stopCh)
 	wg.Wait()
+
+	if homeGone {
+		// Skip the final save: the home directory was deleted out from under
+		// us, so there is no installation left to persist into — saving would
+		// recreate a skeleton of the deleted home and resurrect the abandoned
+		// state the deletion was meant to remove.
+		return nil
+	}
 
 	if err := manager.SaveInstances(); err != nil {
 		log.ErrorLog.Printf("failed to save instances when terminating daemon: %v", err)
 	}
 	return nil
+}
+
+// homeCheckInterval is how often watchDaemonHome verifies the daemon's own AF
+// home directory still exists. A package var so tests can shorten it.
+var homeCheckInterval = 60 * time.Second
+
+// homeMissingChecksToExit is how many consecutive missing observations
+// watchDaemonHome requires before declaring the home deleted. Requiring two
+// keeps a single transient stat blip from taking down a healthy daemon.
+const homeMissingChecksToExit = 2
+
+// watchDaemonHome periodically stats homeDir and closes homeGone once the
+// directory has been missing for homeMissingChecksToExit consecutive checks,
+// signaling RunDaemon to shut down (#1093). Only a definite ENOENT counts as
+// missing: any other stat error (EACCES, EIO) leaves the directory's fate
+// unknown, and a false-positive shutdown of a healthy daemon is worse than
+// letting an abandoned one linger until the next check. The daemon's binary
+// path is deliberately NOT checked — upgrades replace the binary while the
+// daemon legitimately keeps running.
+func watchDaemonHome(homeDir string, stopCh <-chan struct{}, homeGone chan<- struct{}) {
+	ticker := time.NewTicker(homeCheckInterval)
+	defer ticker.Stop()
+	misses := 0
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-ticker.C:
+		}
+		var exit bool
+		if misses, exit = applyHomeCheck(homeDir, misses); exit {
+			log.WarningLog.Printf("agent-factory home %s no longer exists; shutting down abandoned daemon", homeDir)
+			close(homeGone)
+			return
+		}
+	}
+}
+
+// applyHomeCheck folds one stat of homeDir into the running consecutive-miss
+// counter and reports whether the exit threshold was reached. A present home
+// (or an indeterminate stat error) resets the counter — only an unbroken run
+// of definite ENOENTs counts as a deletion.
+func applyHomeCheck(homeDir string, misses int) (int, bool) {
+	if _, err := os.Stat(homeDir); err == nil || !os.IsNotExist(err) {
+		return 0, false
+	}
+	misses++
+	return misses, misses >= homeMissingChecksToExit
 }
 
 // fromInstanceDataForRefresh is the entry point refreshDaemonInstances uses

--- a/daemon/home_selfcheck_test.go
+++ b/daemon/home_selfcheck_test.go
@@ -1,0 +1,154 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// The tests in this file cover the #1093 abandoned-daemon self-check: a daemon
+// whose own AF home directory has been deleted (an abandoned temp/test home,
+// or an rm -rf'd install) is unreachable via the control plane yet used to
+// keep firing cron schedules forever. RunDaemon now watches its home and shuts
+// down cleanly once the directory has been missing on two consecutive checks.
+
+// TestRunDaemon_ExitsWhenHomeDeleted drives the fix end to end in-process:
+// start a daemon against a temp home, verify it stays up while the home
+// exists, delete the home, and assert RunDaemon returns within a bounded time
+// without recreating the deleted directory.
+func TestRunDaemon_ExitsWhenHomeDeleted(t *testing.T) {
+	// The home lives one level below t.TempDir() so deleting it cannot break
+	// the testing package's own tempdir cleanup.
+	home := filepath.Join(t.TempDir(), "af-home")
+	if err := os.MkdirAll(home, 0755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	// This test runs RunDaemon to full readiness, which sweeps legacy task
+	// units — point the sweep at empty temp dirs so it can never touch the
+	// host's real systemd/launchd directories.
+	stubLegacyUnitSweep(t)
+
+	prevInterval := homeCheckInterval
+	homeCheckInterval = 25 * time.Millisecond
+	t.Cleanup(func() { homeCheckInterval = prevInterval })
+
+	runDone := make(chan error, 1)
+	runExited := make(chan struct{})
+	go func() {
+		runDone <- RunDaemon(config.DefaultConfig())
+		close(runExited)
+	}()
+
+	// Failsafe teardown: if the test fails before the home deletion below,
+	// the in-process daemon is still serving its socket — end it via the
+	// Shutdown RPC so it cannot bleed into later tests in the package.
+	// runExited (closed, so readable forever) rather than runDone (its one
+	// buffered value is consumed by the assertions below) tells us whether
+	// RunDaemon already returned.
+	t.Cleanup(func() {
+		select {
+		case <-runExited:
+			return
+		default:
+		}
+		var resp ShutdownResponse
+		_ = callDaemonNoEnsure("Shutdown", ShutdownRequest{}, &resp)
+		select {
+		case <-runExited:
+		case <-time.After(5 * time.Second):
+			t.Errorf("in-process daemon did not exit during cleanup")
+		}
+	})
+
+	// Wait past warm-up: Snapshot is gated on the instance restore (#829), so
+	// a success means RunDaemon reached its main loop and armed the watcher.
+	waitForReady(t, "daemon ready (Snapshot RPC passes the warm-up gate)", func() bool {
+		var resp SnapshotResponse
+		return callDaemonNoEnsure("Snapshot", SnapshotRequest{}, &resp) == nil
+	})
+
+	// While the home exists the daemon must ride out many check intervals —
+	// a false-positive self-shutdown here is the failure mode the two-strike
+	// rule exists to prevent.
+	select {
+	case err := <-runDone:
+		t.Fatalf("daemon exited while its home still existed: %v", err)
+	case <-time.After(10 * homeCheckInterval):
+	}
+
+	if err := os.RemoveAll(home); err != nil {
+		t.Fatalf("delete home: %v", err)
+	}
+
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("RunDaemon returned an error on the home-deleted self-shutdown: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("daemon did not shut down within 10s of its home directory being deleted (#1093)")
+	}
+
+	// The exit path must not resurrect the deleted home (the normal shutdown
+	// SaveInstances would recreate a skeleton of it).
+	if _, err := os.Stat(home); !os.IsNotExist(err) {
+		t.Fatalf("daemon recreated its deleted home on shutdown, stat err = %v", err)
+	}
+}
+
+// TestApplyHomeCheck_RequiresTwoConsecutiveMisses unit-tests the two-strike
+// rule deterministically, one observation at a time: a home that disappears
+// for a single check and is back for the next (a transient stat blip, a
+// racing restore) must reset the counter and never reach the threshold, while
+// two consecutive misses must.
+func TestApplyHomeCheck_RequiresTwoConsecutiveMisses(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "af-home")
+	mkHome := func() {
+		t.Helper()
+		if err := os.MkdirAll(home, 0755); err != nil {
+			t.Fatalf("mkdir home: %v", err)
+		}
+	}
+	rmHome := func() {
+		t.Helper()
+		if err := os.RemoveAll(home); err != nil {
+			t.Fatalf("delete home: %v", err)
+		}
+	}
+
+	// Present home: counter stays at zero.
+	mkHome()
+	misses, exit := applyHomeCheck(home, 0)
+	if misses != 0 || exit {
+		t.Fatalf("present home: got (misses=%d, exit=%v), want (0, false)", misses, exit)
+	}
+
+	// First miss: counted, but one strike must not fire.
+	rmHome()
+	misses, exit = applyHomeCheck(home, misses)
+	if misses != 1 || exit {
+		t.Fatalf("first miss: got (misses=%d, exit=%v), want (1, false)", misses, exit)
+	}
+
+	// Transient blip: the home is back on the next check, so the counter
+	// resets instead of accumulating toward the threshold.
+	mkHome()
+	misses, exit = applyHomeCheck(home, misses)
+	if misses != 0 || exit {
+		t.Fatalf("home restored after one miss: got (misses=%d, exit=%v), want (0, false)", misses, exit)
+	}
+
+	// A real deletion: two consecutive misses reach the threshold.
+	rmHome()
+	misses, exit = applyHomeCheck(home, misses)
+	if misses != 1 || exit {
+		t.Fatalf("first miss of real deletion: got (misses=%d, exit=%v), want (1, false)", misses, exit)
+	}
+	if _, exit = applyHomeCheck(home, misses); !exit {
+		t.Fatalf("second consecutive miss did not trigger the self-shutdown")
+	}
+}


### PR DESCRIPTION
Fixes #1093.

An `af --daemon` whose AF home directory has been deleted (an abandoned temp/test home, or an `rm -rf`'d install) kept running forever: unreachable via the control socket (deleted with the home), yet still evaluating cron schedules. On the dev box a leaked debug daemon spawned a `claude --dangerously-skip-permissions` session every night for 23 days.

## 1. Daemon home self-check (`daemon/daemon.go`)

`RunDaemon` now runs a `watchDaemonHome` goroutine alongside the existing status-poll loop. Every 60s it stats the daemon's **own** AF home — resolved via `config.GetConfigDir()`, exactly like `daemon.pid`/`daemon.sock`/`tasks.json`, so `AGENT_FACTORY_HOME` relocations are honored, nothing is hardcoded. When the home is gone it logs

```
WARNING: agent-factory home <path> no longer exists; shutting down abandoned daemon
```

and signals the main select, which exits through the same teardown as SIGTERM (stop poll loop, stop scheduler/watchers, close socket, remove PID file).

Deliberately conservative:

- **Two consecutive misses required** before exiting — a single transient stat blip resets the counter (`applyHomeCheck`).
- **Only a definite `ENOENT` counts as missing.** `EACCES`/`EIO`/anything indeterminate resets the counter; a false-positive shutdown of a healthy daemon is worse than an abandoned one lingering until the next check.
- **The binary path is NOT checked** — upgrades replace the binary while the daemon legitimately keeps running.
- The home-gone exit **skips the final `SaveInstances`**: saving would recreate a skeleton of the deleted home and resurrect exactly the abandoned state the deletion was meant to remove.
- No changes to the #960 single-writer ownership model, the RPC surface, or normal shutdown semantics — this only adds one more way to reach the existing graceful exit.

Tests (`daemon/home_selfcheck_test.go`, hermetic — temp `AGENT_FACTORY_HOME`, in-process `RunDaemon`, legacy-unit sweep stubbed, failsafe `t.Cleanup` shutdown so the test can't itself leak a daemon):

- `TestRunDaemon_ExitsWhenHomeDeleted` — end to end: start a daemon against a temp home, verify it rides out 10 check intervals while the home exists (no false positive), delete the home, assert `RunDaemon` returns within a bounded time and does **not** recreate the deleted directory.
- `TestApplyHomeCheck_RequiresTwoConsecutiveMisses` — deterministic unit test of the two-strike rule, including the transient-blip reset.

## 2. Test/dev-script daemon-teardown audit

Grepped every site that spawns or could spawn a daemon (`--daemon`, `startDaemonChild`, `RunDaemon`, `EnsureDaemon`, shell scripts). **No changes were needed** — all sites are already failure-safe, mostly thanks to the #1056 hermeticity work:

| Site | Status |
|---|---|
| `integration/cli_daemon_test.go` (only place a **real** daemon binary is spawned) | already safe — harness registers `t.Cleanup(killDaemonFromHome(home))` at construction, runs even on `t.Fatal`/panic; `TestMain` adds the #1056 sandbox-home + tripwires |
| `daemon/` package tests (`warmup_test`, `spawn_stop_race_test`, `shutdown_wait_test`, …) | already safe — `RunDaemon` runs **in-process** (dies with the test binary); "fake daemons" are `bash exec -a 'af --daemon …' sleep 60` stubs with `defer Kill`/`t.Cleanup` registered immediately after `Start`, and are self-limiting (`sleep 60`) besides |
| `daemon/spawn_reap_test.go` | already safe — spawns `true`, exits immediately |
| `daemoncmd_test.go` (root) | already safe — all spawn collaborators stubbed |
| shell scripts (`clean.sh`, `dev-install.sh`, `install.sh`, CI scripts) | none spawn a daemon in a test context |

The leaked PIDs in #1093 predate #1056, which is consistent with the audit finding no live gaps — the self-check in part 1 is the backstop for anything that still slips through (or for users deleting `~/.agent-factory` by hand).

## Not in this PR

`af doctor` orphan detection (proposed fix 2 in #1093) is intentionally left out — it is bigger and overlaps the roadmap diagnostics item (#1044); tracked separately.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — clean
- `go test ./...` — all green (new tests run twice via `-count=2` for stability)
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)