### PR TITLE
fix(config): write through symlinked in-repo config instead of clobbering it (#1092)

### DIFF
--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -284,6 +284,9 @@ func resolveSymlinksForCompare(path string) string {
 // verbatim. The key is always written, even for an empty list, because a
 // present-but-empty key is how an in-repo file overrides (disables) commands
 // still lingering in the legacy ~/.agent-factory/repos/<id>/config.json.
+// When the config file is a symlink (to elsewhere inside the repo), the
+// update is written to the resolved target and the symlink is preserved,
+// matching the read path's resolution.
 func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 	if repoRoot == "" {
 		return fmt.Errorf("repo root is required to save in-repo config")
@@ -337,5 +340,17 @@ func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create %s: %w", dir, err)
 	}
-	return AtomicWriteFile(InRepoConfigPath(repoRoot), out, 0644)
+	// Write through a symlinked config file to its resolved target (#1092):
+	// renaming the temp file onto the link path would replace the symlink with
+	// a new regular file and strand the old target with stale content, while
+	// the read path (readInRepoConfigFile) resolves the link before reading.
+	// Using resolvedPath keeps the temp+rename inside the target's own
+	// directory, so the link survives and readers still go through it; the
+	// containment guard above already proved the target lives inside the repo.
+	// A path that is not a symlink — the normal case — is written in place.
+	writePath := path
+	if info, lstatErr := os.Lstat(path); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		writePath = resolvedPath
+	}
+	return AtomicWriteFile(writePath, out, 0644)
 }

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -315,6 +315,38 @@ func TestSaveInRepoPostWorktreeCommands(t *testing.T) {
 		assert.Empty(t, cfg.PostWorktreeCommands)
 	})
 
+	// Regression test for #1092: a symlinked config.json must be written
+	// through to its target, not replaced by a new regular file at the link
+	// path (which would strand the target with stale content).
+	t.Run("writes through a symlinked config file", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		target := filepath.Join(repoRoot, "shared-config.json")
+		require.NoError(t, os.WriteFile(target, []byte(`{"default_program": "codex"}`), 0644))
+		require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, InRepoConfigDirName), 0755))
+		linkPath := InRepoConfigPath(repoRoot)
+		require.NoError(t, os.Symlink(target, linkPath))
+
+		require.NoError(t, SaveInRepoPostWorktreeCommands(repoRoot, []string{"make setup"}))
+
+		info, err := os.Lstat(linkPath)
+		require.NoError(t, err)
+		assert.NotZero(t, info.Mode()&os.ModeSymlink, "config path must still be a symlink after save")
+		dest, err := os.Readlink(linkPath)
+		require.NoError(t, err)
+		assert.Equal(t, target, dest, "symlink must still point at its original target")
+
+		data, err := os.ReadFile(target)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "make setup", "target file must receive the update")
+
+		// Read-after-write round-trips through the symlink, preserving the
+		// pre-existing field alongside the saved commands.
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"make setup"}, cfg.PostWorktreeCommands)
+		assert.Equal(t, "codex", cfg.DefaultProgram)
+	})
+
 	t.Run("dir symlink that stays inside the repo still saves", func(t *testing.T) {
 		repoRoot := t.TempDir()
 		realDir := filepath.Join(repoRoot, "cfg")


### PR DESCRIPTION
Fixes #1092

## Problem

`SaveInRepoPostWorktreeCommands` (config/inrepo.go) wrote the updated JSON via temp-file + `os.Rename` onto the literal `.agent-factory/config.json` path. When that path is a **symlink** (e.g. pointing at a shared config file elsewhere in the repo), the rename replaced the symlink with a new regular file and left the original target stranded with stale content. The read path (`readInRepoConfigFile`) already resolves the symlink before reading, so reads and writes disagreed about which file was canonical.

## Fix

Before writing, `Lstat` the config path; if it is a symlink, write to the already-computed `resolvedPath` (the same full resolution the guards use) instead of the link path. The temp+rename now lands in the resolved target's directory, so the symlink survives and the write stays atomic on the real file. The normal non-symlink case still writes to the literal path, and the existing collision/containment guards are unchanged — a link resolving outside the repo is still refused before any write.

A dangling symlink is rejected earlier by `readInRepoConfigFile`'s resolve step, so `resolvedPath` is always a genuine resolved file path when used as the write target.

## Test

Added a regression subtest to `TestSaveInRepoPostWorktreeCommands` ("writes through a symlinked config file"): creates `.agent-factory/config.json` as a symlink to a target file in the repo, saves, then asserts the path is still a symlink pointing at the original target, the target file received the update, and `LoadInRepoConfig` round-trips through the link preserving pre-existing fields. Existing subtests cover the non-symlink normal case, dir-symlink case, and outside-repo refusals.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `go test ./config/...` and `go test ./...` — pass
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude