### PR TITLE
fix(autostart): honor XDG_CONFIG_HOME for systemd user unit dir (#1091)

### DIFF
--- a/daemon/autostart.go
+++ b/daemon/autostart.go
@@ -322,44 +322,48 @@ func RestartAutostartUnit() error {
 // InstallAutostart. The daemon itself keeps running until it exits or is
 // stopped; it just no longer restarts at login. Returns the path of the
 // removed unit file, or "" if none was installed.
+//
+// The unit path comes from the same resolvers InstallAutostart uses, so both
+// always target the same real directory — with XDG_CONFIG_HOME set, systemd
+// units live under it, not under ~/.config (#1091).
 func UninstallAutostart() (string, error) {
-	switch runtime.GOOS {
+	switch autostartGOOS {
 	case "linux":
-		home, err := os.UserHomeDir()
+		dir, err := autostartSystemdUserDir()
 		if err != nil {
-			return "", fmt.Errorf("failed to get home directory: %w", err)
+			return "", fmt.Errorf("failed to resolve systemd user directory: %w", err)
 		}
-		unitPath := filepath.Join(home, ".config", "systemd", "user", autostartUnitName)
+		unitPath := filepath.Join(dir, autostartUnitName)
 		if _, err := os.Stat(unitPath); os.IsNotExist(err) {
 			return "", nil
 		}
-		if out, err := exec.Command("systemctl", "--user", "disable", "--now", autostartUnitName).CombinedOutput(); err != nil {
+		if out, err := autostartUnitCommand("systemctl", "--user", "disable", "--now", autostartUnitName); err != nil {
 			return "", fmt.Errorf("failed to disable daemon service: %w\n%s", err, strings.TrimSpace(string(out)))
 		}
 		if err := os.Remove(unitPath); err != nil && !os.IsNotExist(err) {
 			return "", fmt.Errorf("failed to remove unit file: %w", err)
 		}
-		if out, err := exec.Command("systemctl", "--user", "daemon-reload").CombinedOutput(); err != nil {
+		if out, err := autostartUnitCommand("systemctl", "--user", "daemon-reload"); err != nil {
 			return "", fmt.Errorf("failed to reload systemd user daemon: %w\n%s", err, strings.TrimSpace(string(out)))
 		}
 		return unitPath, nil
 
 	case "darwin":
-		home, err := os.UserHomeDir()
+		dir, err := autostartLaunchAgentsDir()
 		if err != nil {
-			return "", fmt.Errorf("failed to get home directory: %w", err)
+			return "", fmt.Errorf("failed to resolve LaunchAgents directory: %w", err)
 		}
-		plistPath := filepath.Join(home, "Library", "LaunchAgents", autostartLaunchdLabel+".plist")
+		plistPath := filepath.Join(dir, autostartLaunchdLabel+".plist")
 		if _, err := os.Stat(plistPath); os.IsNotExist(err) {
 			return "", nil
 		}
-		_ = exec.Command("launchctl", "unload", plistPath).Run()
+		_, _ = autostartUnitCommand("launchctl", "unload", plistPath)
 		if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
 			return "", fmt.Errorf("failed to remove plist file: %w", err)
 		}
 		return plistPath, nil
 
 	default:
-		return "", fmt.Errorf("daemon autostart is not supported on %s", runtime.GOOS)
+		return "", fmt.Errorf("daemon autostart is not supported on %s", autostartGOOS)
 	}
 }

--- a/daemon/autostart_restart_test.go
+++ b/daemon/autostart_restart_test.go
@@ -277,3 +277,89 @@ func TestRestartAutostartUnitUnsupportedGOOS(t *testing.T) {
 		t.Fatalf("no service manager command should run on unsupported GOOS, got %v", *calls)
 	}
 }
+
+// TestInstallUninstallRoundTripHonorsXDGConfigHomeLinux drives install and
+// uninstall through the REAL directory resolver (not a stubbed one) with
+// XDG_CONFIG_HOME pointing at a temp dir, pinning the #1091 contract: both
+// operations target $XDG_CONFIG_HOME/systemd/user — the directory systemd
+// actually scans — never ~/.config. Commands and the daemon stop are stubbed,
+// so no real unit is enabled and no real daemon is signaled.
+func TestInstallUninstallRoundTripHonorsXDGConfigHomeLinux(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	prevGOOS := autostartGOOS
+	t.Cleanup(func() { autostartGOOS = prevGOOS })
+	autostartGOOS = "linux"
+	calls := stubAutostartUnitCommand(t, nil)
+	stubAutostartStopDaemon(t, true, nil)
+
+	wantPath := filepath.Join(xdg, "systemd", "user", autostartUnitName)
+
+	unitPath, err := InstallAutostart()
+	if err != nil {
+		t.Fatalf("InstallAutostart: %v", err)
+	}
+	if unitPath != wantPath {
+		t.Fatalf("install wrote %q, want XDG-resolved %q", unitPath, wantPath)
+	}
+	if _, statErr := os.Stat(unitPath); statErr != nil {
+		t.Fatalf("unit file missing after install: %v", statErr)
+	}
+
+	removedPath, err := UninstallAutostart()
+	if err != nil {
+		t.Fatalf("UninstallAutostart: %v", err)
+	}
+	if removedPath != wantPath {
+		t.Fatalf("uninstall targeted %q, want the same XDG-resolved %q install wrote", removedPath, wantPath)
+	}
+	if _, statErr := os.Stat(wantPath); !os.IsNotExist(statErr) {
+		t.Fatalf("unit file should be gone after uninstall; stat err = %v", statErr)
+	}
+	if !calledWith(*calls, "systemctl", "--user", "disable", "--now", autostartUnitName) {
+		t.Fatalf("uninstall did not disable the unit; calls = %v", *calls)
+	}
+}
+
+// TestUninstallAutostartNoUnitInstalledLinux: uninstall with nothing installed
+// is a silent no-op that runs no service-manager commands.
+func TestUninstallAutostartNoUnitInstalledLinux(t *testing.T) {
+	withAutostartTestEnv(t, "linux")
+	calls := stubAutostartUnitCommand(t, nil)
+
+	path, err := UninstallAutostart()
+	if err != nil {
+		t.Fatalf("UninstallAutostart: %v", err)
+	}
+	if path != "" {
+		t.Fatalf("removed path = %q, want empty for a no-op uninstall", path)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("no commands should run when no unit is installed, got %v", *calls)
+	}
+}
+
+// TestUninstallAutostartDarwin verifies the launchd uninstall resolves the
+// plist through the injected LaunchAgents resolver and unloads before removing.
+func TestUninstallAutostartDarwin(t *testing.T) {
+	dir := withAutostartTestEnv(t, "darwin")
+	calls := stubAutostartUnitCommand(t, nil)
+	plistPath := filepath.Join(dir, autostartLaunchdLabel+".plist")
+	if err := os.WriteFile(plistPath, []byte("<plist/>\n"), 0644); err != nil {
+		t.Fatalf("seed plist: %v", err)
+	}
+
+	removedPath, err := UninstallAutostart()
+	if err != nil {
+		t.Fatalf("UninstallAutostart: %v", err)
+	}
+	if removedPath != plistPath {
+		t.Fatalf("removed path = %q, want %q", removedPath, plistPath)
+	}
+	if _, statErr := os.Stat(plistPath); !os.IsNotExist(statErr) {
+		t.Fatalf("plist should be gone after uninstall; stat err = %v", statErr)
+	}
+	if !calledWith(*calls, "launchctl", "unload", plistPath) {
+		t.Fatalf("uninstall did not unload the agent; calls = %v", *calls)
+	}
+}

--- a/daemon/legacy_units.go
+++ b/daemon/legacy_units.go
@@ -25,7 +25,16 @@ var (
 	legacyUnitCommand     = runLegacyUnitCommand
 )
 
+// defaultSystemdUserDir resolves the directory the systemd user manager scans
+// for user units, matching systemd's own rule (#1091): $XDG_CONFIG_HOME/systemd/user
+// when XDG_CONFIG_HOME is set to an absolute path, else ~/.config/systemd/user.
+// systemd ignores a relative XDG_CONFIG_HOME (per the XDG base-dir spec), so a
+// relative value falls through to the home default; diverging here would make
+// af write units to a directory systemd never reads.
 func defaultSystemdUserDir() (string, error) {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" && filepath.IsAbs(xdg) {
+		return filepath.Join(xdg, "systemd", "user"), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err

--- a/daemon/legacy_units_test.go
+++ b/daemon/legacy_units_test.go
@@ -126,3 +126,39 @@ func TestSweepLegacyTaskUnits_NoopWhenNothingInstalled(t *testing.T) {
 		t.Errorf("expected no external commands on a clean host, got: %v", stub.commands)
 	}
 }
+
+// TestDefaultSystemdUserDirHonorsXDGConfigHome pins the #1091 resolution rule:
+// systemd scans $XDG_CONFIG_HOME/systemd/user when XDG_CONFIG_HOME is set to
+// an absolute path, and ignores empty or relative values in favor of
+// ~/.config/systemd/user. af must match exactly, or it installs units into a
+// directory systemd never reads.
+func TestDefaultSystemdUserDirHonorsXDGConfigHome(t *testing.T) {
+	home := t.TempDir()
+	xdg := t.TempDir()
+	homeDefault := filepath.Join(home, ".config", "systemd", "user")
+
+	tests := []struct {
+		name string
+		xdg  string
+		want string
+	}{
+		{name: "unset falls back to home config", xdg: "", want: homeDefault},
+		{name: "absolute path is honored", xdg: xdg, want: filepath.Join(xdg, "systemd", "user")},
+		{name: "relative path is ignored like systemd does", xdg: "relative/config", want: homeDefault},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", home)
+			// t.Setenv cannot unset; empty counts as unset per the XDG spec,
+			// which is also how systemd treats it.
+			t.Setenv("XDG_CONFIG_HOME", tc.xdg)
+			got, err := defaultSystemdUserDir()
+			if err != nil {
+				t.Fatalf("defaultSystemdUserDir: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("defaultSystemdUserDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1091

## Problem

`defaultSystemdUserDir()` hardcoded `~/.config/systemd/user` via `os.UserHomeDir()`, ignoring `XDG_CONFIG_HOME`. systemd itself resolves its user-unit directory as `$XDG_CONFIG_HOME/systemd/user` when that variable is set, so with `XDG_CONFIG_HOME` pointing elsewhere, `af daemon autostart` wrote the unit into a directory systemd never scans — the unit was invisible and `systemctl --user enable agent-factory-daemon.service` failed.

## Fix

- `defaultSystemdUserDir()` (daemon/legacy_units.go) now returns `$XDG_CONFIG_HOME/systemd/user` when `XDG_CONFIG_HOME` is set, non-empty, **and absolute** — mirroring systemd's own rule, which ignores relative values per the XDG base-dir spec — else falls back to `~/.config/systemd/user` as before. This helper feeds `autostartSystemdUserDir` (install/installed-check/restart) and `legacySystemdUserDir` (legacy per-task unit sweep), so all of those pick up the fix.
- **Adjacent call-site**: `UninstallAutostart()` rebuilt the `~/.config/systemd/user` path inline with its own `os.UserHomeDir()` call, so install (XDG dir) and uninstall (`~/.config`) would have targeted different directories. It now goes through the same `autostartSystemdUserDir`/`autostartLaunchAgentsDir`/`autostartUnitCommand` injection points as `InstallAutostart`, guaranteeing both resolve identically (and making uninstall hermetically testable).
- Audited the remaining `os.UserHomeDir()+path` helpers: `defaultLaunchAgentsDir` (`~/Library/LaunchAgents`) is launchd, where XDG does not apply; the `config/` and `log/` uses resolve af's own `~/.agent-factory` home, not unit directories — all correctly untouched.

## Tests

All hermetic (`t.Setenv`/`t.TempDir`, stubbed command runner + daemon stop — no real unit installed, no real systemctl invoked):

- `TestDefaultSystemdUserDirHonorsXDGConfigHome` — table test: unset → `~/.config/systemd/user`; absolute → `$XDG_CONFIG_HOME/systemd/user`; relative → ignored, falls back to `~/.config/systemd/user`.
- `TestInstallUninstallRoundTripHonorsXDGConfigHomeLinux` — drives `InstallAutostart` → `UninstallAutostart` through the **real** resolver with `XDG_CONFIG_HOME` set, asserting both target the same `$XDG_CONFIG_HOME/systemd/user` path.
- `TestUninstallAutostartNoUnitInstalledLinux`, `TestUninstallAutostartDarwin` — cover the newly injectable uninstall paths.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `go test ./...` — all green
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)