### PR TITLE
feat: don't auto-create the terminal tab on new instances (#1100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When a session's branch has an open pull request, `p` opens it in the browser an
 
 #### Tabs
 
-Every session opens with two tabs: an **agent** tab (the AI agent, shown as *Preview*) and a **shell** tab (*Terminal*) running `$SHELL` in the worktree. Press `t` to spawn more shell tabs (up to nine per session), `w` to close the active one, and `Tab` / `1`–`9` to move between them. Attaching (`Enter`) drops you into whichever tab is active. Tabs are ephemeral but persisted: they survive an `af`/daemon restart, reconnecting to their live processes. You can also spawn a tab running an arbitrary command from the CLI with `af sessions tab-create`, and delete a single tab with `af sessions tab-delete` (see below).
+Every session opens with a single **agent** tab (the AI agent, shown as *Preview*). Press `t` to spawn **shell** tabs (*Terminal*) running `$SHELL` in the worktree (up to nine tabs per session), `w` to close the active one, and `Tab` / `1`–`9` to move between them. Attaching (`Enter`) drops you into whichever tab is active. Tabs are ephemeral but persisted: they survive an `af`/daemon restart, reconnecting to their live processes. You can also spawn a tab running an arbitrary command from the CLI with `af sessions tab-create`, and delete a single tab with `af sessions tab-delete` (see below).
 
 Remote sessions are tab-driven too, with one limitation: the hook protocol can't run arbitrary commands on the remote host, so a remote session has an agent tab always and a single terminal tab **only when** its repo configures `remote_hooks.terminal_cmd` (`t`, `tab-create`, and `tab-delete` are rejected for remote sessions). See [docs/remote-hooks.md](docs/remote-hooks.md).
 

--- a/app/layout_cutover_test.go
+++ b/app/layout_cutover_test.go
@@ -305,7 +305,7 @@ func TestE2E_LayoutCutover_FocusRingAndHooksOverlay(t *testing.T) {
 // works as before.
 func TestLayoutCutover_DigitJumpGatedByFocusRegion(t *testing.T) {
 	h := newTestHome(t)
-	addTreeInstance(t, h, "alpha") // two default tab slots
+	addTreeInstance(t, h, "alpha") // real agent + shell tab pair
 	h.sidebar.SetSelectedInstance(0)
 	_ = h.selectionChanged()
 	resizeHome(h, 100, 30)

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -21,13 +21,18 @@ import (
 // ----------------------------------------------------------------------------
 
 // paneTestHome is a home with three started instances at a three-pane-capable
-// size, with the selection on "alpha".
+// size, with the selection on "alpha". Each instance carries a real agent +
+// shell tab pair so tab-row walks and second-slot pane opens have two real
+// slots (#1100: fresh instances hold only the agent tab and no slot is padded).
 func paneTestHome(t *testing.T) *home {
 	t.Helper()
 	h := newTestHome(t)
-	h.store.AddInstance(instanceWithFakeBackend(t, "alpha"))
-	h.store.AddInstance(instanceWithFakeBackend(t, "beta"))
-	h.store.AddInstance(instanceWithFakeBackend(t, "gamma"))
+	for _, title := range []string{"alpha", "beta", "gamma"} {
+		inst := instanceWithFakeBackend(t, title)
+		inst.AddTabForTest("agent", session.TabKindAgent)
+		inst.AddTabForTest("shell", session.TabKindShell)
+		h.store.AddInstance(inst)
+	}
 	h.sidebar.SetSelectedInstance(0)
 	_ = h.selectionChanged()
 	resizeHome(h, 200, 40)

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/ui/tree"
 )
 
 // tabHotkeysPty is a minimal tmux.PtyFactory backed by a real temp file so the
@@ -97,12 +98,10 @@ func setupGitRepoForTabs(t *testing.T, workdir string) {
 	}
 }
 
-// startedLocalInstance returns a started local instance with a live mock-backed
-// agent session plus one on-demand shell tab (a fresh start yields only the
-// agent tab since #1100, so the shell tab is added via AddShellTab — the 't'
-// path), so handleNewTab / handleCloseTab exercise the real tab-lifecycle path
-// hermetically.
-func startedLocalInstance(t *testing.T, title string) *session.Instance {
+// freshLocalInstance returns a started local instance with a live mock-backed
+// agent session and nothing else — the exact shape a user's new instance has
+// since #1100: one agent tab, no shell tab until 't'.
+func freshLocalInstance(t *testing.T, title string) *session.Instance {
 	t.Helper()
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	workdir := t.TempDir()
@@ -117,7 +116,16 @@ func startedLocalInstance(t *testing.T, title string) *session.Instance {
 	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps(name, "bash", pty, cmdExec))
 	require.NoError(t, inst.Start(true))
 	require.Equal(t, 1, inst.TabCount(), "a fresh start must yield only the agent tab (#1100)")
-	_, err = inst.AddShellTab()
+	return inst
+}
+
+// startedLocalInstance is freshLocalInstance plus one on-demand shell tab
+// (added via AddShellTab — the 't' path), so handleNewTab / handleCloseTab
+// exercise the real tab-lifecycle path hermetically.
+func startedLocalInstance(t *testing.T, title string) *session.Instance {
+	t.Helper()
+	inst := freshLocalInstance(t, title)
+	_, err := inst.AddShellTab()
 	require.NoError(t, err)
 	return inst
 }
@@ -275,4 +283,42 @@ func TestNumberKeyRoutesToTabJump(t *testing.T) {
 	h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
 	require.Equal(t, 1, h.store.ActiveTab(),
 		"pressing '2' must jump to tab index 1")
+}
+
+// TestFreshInstanceSingleTabSlotUI pins the #1100 headline at the UI layer,
+// through the real start path: a fresh instance exposes exactly one tab slot
+// everywhere tree.TabLabels feeds (tree rows, pane targets, 1-9 jump range),
+// so no phantom "Terminal" slot exists to jump to, attach, or close. `t` then
+// grows the list to two real slots and the jump reaches the terminal.
+func TestFreshInstanceSingleTabSlotUI(t *testing.T) {
+	h := newTestHome(t)
+	inst := freshLocalInstance(t, "fresh-ui")
+	selectInstance(h, inst)
+
+	require.Equal(t, []string{"Preview"}, tree.TabLabels(inst),
+		"a fresh instance renders exactly one tab slot — the agent tab")
+
+	_, _ = h.handleTabJump(2)
+	require.Equal(t, 0, h.store.ActiveTab(),
+		"2 on a fresh instance must be a no-op — there is no second slot")
+
+	// w can only mean the agent tab now, so the user gets the actionable
+	// message — never the phantom slot's misleading "tab cannot be closed".
+	_, _ = h.handleCloseTab()
+	require.Equal(t, 1, inst.TabCount())
+	h.errBox.SetSize(200, 1)
+	require.Contains(t, h.errBox.String(), "agent tab can't be closed")
+
+	// t materializes the on-demand terminal as a real second slot.
+	stubTabDaemonSeams(t, inst)
+	_, _ = h.handleNewTab()
+	require.Equal(t, 2, inst.TabCount())
+	require.Equal(t, []string{"Preview", "Terminal"}, tree.TabLabels(inst),
+		"after t the terminal is a real second slot")
+	require.Equal(t, 1, h.store.ActiveTab(), "t selects the fresh terminal")
+
+	_, _ = h.handleTabJump(1)
+	require.Equal(t, 0, h.store.ActiveTab())
+	_, _ = h.handleTabJump(2)
+	require.Equal(t, 1, h.store.ActiveTab(), "2 now lands on the real terminal")
 }

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -98,8 +98,10 @@ func setupGitRepoForTabs(t *testing.T, workdir string) {
 }
 
 // startedLocalInstance returns a started local instance with a live mock-backed
-// agent session and (via LocalBackend.Start) a default shell tab, so handleNewTab
-// / handleCloseTab exercise the real tab-lifecycle path hermetically.
+// agent session plus one on-demand shell tab (a fresh start yields only the
+// agent tab since #1100, so the shell tab is added via AddShellTab — the 't'
+// path), so handleNewTab / handleCloseTab exercise the real tab-lifecycle path
+// hermetically.
 func startedLocalInstance(t *testing.T, title string) *session.Instance {
 	t.Helper()
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
@@ -114,6 +116,9 @@ func startedLocalInstance(t *testing.T, title string) *session.Instance {
 	require.NoError(t, err)
 	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps(name, "bash", pty, cmdExec))
 	require.NoError(t, inst.Start(true))
+	require.Equal(t, 1, inst.TabCount(), "a fresh start must yield only the agent tab (#1100)")
+	_, err = inst.AddShellTab()
+	require.NoError(t, err)
 	return inst
 }
 
@@ -175,7 +180,7 @@ func TestHandleNewTabAppendsAndSelects(t *testing.T) {
 	inst := startedLocalInstance(t, "new")
 	selectInstance(h, inst)
 	created, _ := stubTabDaemonSeams(t, inst)
-	require.Equal(t, 2, inst.TabCount(), "start gives an agent + default shell tab")
+	require.Equal(t, 2, inst.TabCount(), "helper gives an agent tab + one on-demand shell tab")
 
 	_, _ = h.handleNewTab()
 

--- a/app/tree_nav_test.go
+++ b/app/tree_nav_test.go
@@ -20,14 +20,18 @@ func pressNav(t *testing.T, h *home, key string) {
 	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}, name)
 }
 
-// addTreeInstance adds an unstarted instance (default two tab slots) to the
-// home's projection.
+// addTreeInstance adds an instance carrying a real agent + shell tab pair
+// (the shape of a started instance after `t`) to the home's projection, so
+// tree walks and tab jumps have two real slots to land on (#1100: fresh
+// instances hold only the agent tab and no slot is padded).
 func addTreeInstance(t *testing.T, h *home, title string) *session.Instance {
 	t.Helper()
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title: title, Path: t.TempDir(), Program: "test",
 	})
 	require.NoError(t, err)
+	inst.AddTabForTest("agent", session.TabKindAgent)
+	inst.AddTabForTest("shell", session.TabKindShell)
 	h.store.AddInstance(inst)
 	return inst
 }

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -236,9 +236,11 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 // live. On restore it reconnects every persisted tab (shell and any later
 // process tabs) to its exact tmux session by name so they survive an af/daemon
 // restart, re-spawning in the worktree only if the tmux server died across a
-// reboot (Restore handles both). On a fresh start — or a legacy restore that
-// predates persisted tabs — when no live shell tab exists it creates the default
-// $SHELL tab as a sibling of the agent session.
+// reboot (Restore handles both). A fresh instance comes up with only the agent
+// tab (#1100) — terminal tabs are created on demand ('t' / `af sessions
+// tab-create`), never automatically. The fresh-$SHELL fallback below only fires
+// when a PERSISTED shell tab restored dead (#991), replacing it so the user
+// lands on a working terminal instead of a corpse.
 func (b *LocalBackend) setupTabs(i *Instance) {
 	i.mu.RLock()
 	agentTmux := i.tmuxLocked()
@@ -255,11 +257,19 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 	}
 
 	// Reconnect every persisted non-agent tab that carries a session (Tabs[0] is
-	// the agent tab, already restored by Start). Track whether at least one live
-	// shell tab exists so we don't also create a duplicate default below.
+	// the agent tab, already restored by Start). Track whether a persisted shell
+	// tab exists at all, and whether at least one is live, to decide if the
+	// dead-shell replacement below applies.
+	hasShellTab := false
 	hasLiveShell := false
 	for idx, tab := range tabs {
-		if idx == 0 || tab.tmux == nil {
+		if idx == 0 {
+			continue
+		}
+		if tab.Kind == TabKindShell {
+			hasShellTab = true
+		}
+		if tab.tmux == nil {
 			continue
 		}
 		if err := tab.tmux.Restore(worktreePath); err != nil {
@@ -275,15 +285,18 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 			hasLiveShell = true
 		}
 	}
-	if hasLiveShell {
+	// No persisted shell tab means a fresh instance (or one whose user closed
+	// every shell tab): come up with just the agent tab — a terminal tab is
+	// never auto-created (#1100). With a live shell there is nothing to replace.
+	if !hasShellTab || hasLiveShell {
 		return
 	}
 
-	// Create a fresh shell session as a sibling of the agent session so it
-	// inherits the agent's PTY factory / executor — real in production, mock in
-	// tests — keeping the create path hermetic. The name extends the agent
-	// session's name deterministically so it is collision-free and restorable
-	// by exact name.
+	// A persisted shell tab restored dead (#991): create a fresh shell session
+	// as a sibling of the agent session so it inherits the agent's PTY factory /
+	// executor — real in production, mock in tests — keeping the create path
+	// hermetic. The name extends the agent session's name deterministically so
+	// it is collision-free and restorable by exact name.
 	shellTmux := agentTmux.NewSiblingSession(agentTmux.SanitizedName()+shellTmuxSuffix, defaultShell())
 	if err := shellTmux.Start(worktreePath); err != nil {
 		log.WarningLog.Printf("start shell tab for %q failed: %v", i.Title, err)

--- a/session/instance.go
+++ b/session/instance.go
@@ -805,8 +805,8 @@ var restoreTmuxSession = tmux.NewTmuxSessionFromSanitizedName
 //     LocalBackend.Start can reconnect it across a restart.
 //   - Legacy format (no data.Tabs, written before #930 PR 2): synthesize the
 //     single Agent tab from the legacy TmuxName/Program — keeping the EXACT
-//     legacy tmux name so an existing live agent session survives the upgrade —
-//     and leave the shell tab for LocalBackend.Start to create fresh.
+//     legacy tmux name so an existing live agent session survives the upgrade.
+//     No shell tab is synthesized: terminal tabs are on-demand only (#1100).
 func restoreLocalTabs(instance *Instance, data InstanceData) {
 	if len(data.Tabs) > 0 {
 		for _, td := range data.Tabs {

--- a/session/tab.go
+++ b/session/tab.go
@@ -5,8 +5,8 @@ import "github.com/sachiniyer/agent-factory/session/tmux"
 // agentTabName is the display label of the default Agent tab.
 const agentTabName = "agent"
 
-// shellTabName is the display label of the default Shell tab — the per-instance
-// terminal session promoted to a first-class tab in PR 2 of #930.
+// shellTabName is the display label of the first Shell tab — the on-demand
+// per-instance terminal session ('t' / `af sessions tab-create`).
 const shellTabName = "shell"
 
 // shellTmuxSuffix extends an instance's agent tmux session name to derive its
@@ -67,9 +67,10 @@ func newAgentTab(ts *tmux.TmuxSession) *Tab {
 }
 
 // newShellTab returns a Shell-kind tab named "shell" wrapping the given tmux
-// session (a $SHELL process in the worktree). PR 2 of #930 creates exactly one
-// of these per local instance, at Tabs[1], promoting the old lazily-cached UI
-// terminal session into a first-class persisted tab.
+// session (a $SHELL process in the worktree). Shell tabs are created on demand
+// ('t' / `af sessions tab-create`) — a fresh instance holds only its agent tab
+// (#1100); the only automatic use is setupTabs replacing a persisted shell tab
+// that restored dead (#991).
 func newShellTab(ts *tmux.TmuxSession) *Tab {
 	return &Tab{Name: shellTabName, Kind: TabKindShell, tmux: ts}
 }

--- a/session/tab_lifecycle_test.go
+++ b/session/tab_lifecycle_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -47,6 +48,52 @@ func startedMockInstance(t *testing.T, agentName string, extraAlive ...string) *
 		gitWorktree: gw,
 		Tabs:        []*Tab{newAgentTab(agentTs)},
 	}
+}
+
+// TestFreshStart_OnlyAgentTab is the #1100 headline test, through the
+// production path (NewInstance -> Start(true) -> setupTabs): creating a new
+// instance must bring up ONLY the agent tab — no terminal (shell) tab is
+// auto-created and no __shell tmux session is spawned. The terminal tab stays
+// available on demand via AddShellTab (the 't' hotkey / `af sessions
+// tab-create` path).
+func TestFreshStart_OnlyAgentTab(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	workdir := t.TempDir()
+	runGit(t, workdir, "init")
+	runGit(t, workdir, "config", "--local", "user.email", "test@example.com")
+	runGit(t, workdir, "config", "--local", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "f.txt"), []byte("x"), 0644))
+	runGit(t, workdir, "add", ".")
+	runGit(t, workdir, "commit", "-m", "init")
+
+	const agentName = "af_1100_fresh"
+	cmdExec := nameKeyedExec(map[string]bool{})
+	pty := persistPtyFactory{t: t, cmdExec: cmdExec}
+
+	inst, err := NewInstance(InstanceOptions{Title: "fresh-1100", Path: workdir, Program: "bash"})
+	require.NoError(t, err)
+	inst.SetTmuxSession(tmux.NewTmuxSessionFromSanitizedNameWithDeps(agentName, "bash", pty, cmdExec))
+	require.NoError(t, inst.Start(true))
+	defer func() { _ = inst.Kill() }()
+
+	tabs := inst.GetTabs()
+	require.Len(t, tabs, 1, "a fresh instance must come up with only the agent tab (#1100)")
+	assert.Equal(t, TabKindAgent, tabs[0].Kind)
+
+	shellTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps(
+		agentName+shellTmuxSuffix, defaultShell(), pty, cmdExec)
+	assert.False(t, shellTs.DoesSessionExist(),
+		"no __shell tmux session may be spawned on a fresh start (#1100)")
+
+	// The terminal tab is still available on demand.
+	tab, err := inst.AddShellTab()
+	require.NoError(t, err)
+	assert.Equal(t, TabKindShell, tab.Kind)
+	assert.Equal(t, 2, inst.TabCount())
+	assert.True(t, inst.TabAlive(1), "the on-demand shell tab must be live")
 }
 
 // TestAddShellTab_AppendsAndNamesUniquely verifies a human-created shell tab is

--- a/session/tab_persist_test.go
+++ b/session/tab_persist_test.go
@@ -177,9 +177,10 @@ func TestRestartSurvival_AgentAndShellTabsReconnect(t *testing.T) {
 }
 
 // TestRestartSurvival_BackCompatSynthesizesTabs covers the upgrade path: an OLD
-// instances.json (written before #930 PR 2, no Tabs field) must load into
-// [agent, shell]. The agent tab keeps the EXACT legacy tmux name (so an existing
-// live agent session survives the upgrade); the shell tab is created fresh.
+// instances.json (written before #930 PR 2, no Tabs field) must load into just
+// [agent]. The agent tab keeps the EXACT legacy tmux name (so an existing live
+// agent session survives the upgrade); no shell tab is synthesized — terminal
+// tabs are on-demand only (#1100).
 func TestRestartSurvival_BackCompatSynthesizesTabs(t *testing.T) {
 	log.Initialize(false)
 	defer log.Close()
@@ -190,9 +191,8 @@ func TestRestartSurvival_BackCompatSynthesizesTabs(t *testing.T) {
 
 	const repoPath = "/tmp/backcompat-repo"
 	const legacyName = "af_legacy_agent" // no repo hash form, exact legacy name
-	shellName := legacyName + shellTmuxSuffix
 
-	// Legacy record: agent reconnects (alive), shell is fresh-created (absent).
+	// Legacy record: the agent session reconnects (alive); nothing else exists.
 	restoreExec := nameKeyedExec(map[string]bool{legacyName: true})
 	restorePty := persistPtyFactory{t: t, cmdExec: restoreExec}
 	prev := restoreTmuxSession
@@ -220,12 +220,8 @@ func TestRestartSurvival_BackCompatSynthesizesTabs(t *testing.T) {
 	require.NoError(t, err)
 
 	tabs := restored.GetTabs()
-	require.Len(t, tabs, 2, "legacy record must synthesize [agent, shell]")
+	require.Len(t, tabs, 1, "legacy record must synthesize only the agent tab (#1100)")
 	assert.Equal(t, TabKindAgent, tabs[0].Kind)
 	assert.Equal(t, legacyName, tabs[0].tmux.SanitizedName(),
 		"agent tab must keep the EXACT legacy tmux name so a live agent session survives the upgrade")
-	assert.Equal(t, TabKindShell, tabs[1].Kind)
-	assert.Equal(t, shellName, tabs[1].tmux.SanitizedName(),
-		"shell tab must be created fresh with the derived __shell name")
-	assert.True(t, restored.TabAlive(1), "the synthesized shell tab must be live")
 }

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -39,13 +39,16 @@ func TestSidebarNavigation(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	s := NewSidebar(&spin, false, store.NewProjection())
 
-	// Add some instances
+	// Add some instances, each with a real agent + shell tab pair so the tree
+	// walk below has two child rows per instance (#1100: no padded slots).
 	inst1, _ := session.NewInstance(session.InstanceOptions{
 		Title: "inst1", Path: t.TempDir(), Program: "test",
 	})
 	inst2, _ := session.NewInstance(session.InstanceOptions{
 		Title: "inst2", Path: t.TempDir(), Program: "test",
 	})
+	addAgentShellTabs(inst1)
+	addAgentShellTabs(inst2)
 	addTestInstance(s, inst1)
 	addTestInstance(s, inst2)
 
@@ -363,7 +366,8 @@ func indicatorArrows(out string) (up, down bool) {
 }
 
 // newWindowingSidebar builds a sidebar with n instances titled win-00..win-NN
-// for the #787 windowing tests.
+// for the #787 windowing tests. Each carries a real agent + shell tab pair so
+// the selected instance contributes two tab child rows (#1100: no padded slots).
 func newWindowingSidebar(t *testing.T, n int) *Sidebar {
 	t.Helper()
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
@@ -374,6 +378,7 @@ func newWindowingSidebar(t *testing.T, n int) *Sidebar {
 			Title: fmt.Sprintf("win-%02d", i), Path: dir, Program: "test",
 		})
 		require.NoError(t, err)
+		addAgentShellTabs(inst)
 		addTestInstance(s, inst)
 	}
 	return s

--- a/ui/sidebar_tree_test.go
+++ b/ui/sidebar_tree_test.go
@@ -14,9 +14,10 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/store"
 )
 
-// newTreeSidebar builds a sidebar over a fresh projection with n unstarted
-// instances titled t-00..t-NN. Unstarted local instances carry the default two
-// tab slots (Preview/Terminal), which is exactly what the tree shows for them.
+// newTreeSidebar builds a sidebar over a fresh projection with n instances
+// titled t-00..t-NN, each carrying a real agent + shell tab pair (the shape of
+// a started instance after `t`) so the tree shows two tab slots per instance.
+// Since #1100 the slot list mirrors the real tabs — there is no padding.
 func newTreeSidebar(t *testing.T, n int) *Sidebar {
 	t.Helper()
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
@@ -27,6 +28,7 @@ func newTreeSidebar(t *testing.T, n int) *Sidebar {
 			Title: fmt.Sprintf("t-%02d", i), Path: dir, Program: "test",
 		})
 		require.NoError(t, err)
+		addAgentShellTabs(inst)
 		addTestInstance(s, inst)
 	}
 	return s
@@ -70,6 +72,33 @@ func TestSidebarTreeRendersTabChildren(t *testing.T) {
 	out = s.String()
 	assert.Contains(t, out, "└ 2 Terminal *")
 	assert.NotContains(t, out, "├ 1 Preview *")
+}
+
+// TestSidebarTreeFreshInstanceSingleTabRow pins the #1100 tree rendering: a
+// fresh instance holds only its agent tab, so its expanded subtree is exactly
+// one child row — no phantom "Terminal" row for a tab that doesn't exist —
+// and the on-demand shell tab (`t`) grows it to two.
+func TestSidebarTreeFreshInstanceSingleTabRow(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: "fresh", Path: t.TempDir(), Program: "test",
+	})
+	require.NoError(t, err)
+	inst.AddTabForTest("agent", session.TabKindAgent)
+	addTestInstance(s, inst)
+	s.SetSize(40, 24)
+	s.SetSelectedInstance(0)
+
+	require.Equal(t, 1, tabRowCount(s), "fresh instance: exactly one tab row")
+	out := s.String()
+	assert.Contains(t, out, "└ 1 Preview *", "the agent tab is the only — and last — child row")
+	assert.NotContains(t, out, "Terminal", "no phantom Terminal row before t is pressed")
+
+	// `t` materializes the shell tab; the tree grows a real second row.
+	inst.AddTabForTest("shell", session.TabKindShell)
+	assert.Equal(t, 2, tabRowCount(s), "after t: the on-demand terminal is the second row")
+	assert.Contains(t, s.String(), "└ 2 Terminal")
 }
 
 // TestSidebarTreeSelectionMoveCollapsesPrevious pins the collapse-by-default
@@ -179,8 +208,6 @@ func TestSidebarTreeSyncCursorSurvivesStructureRebuild(t *testing.T) {
 	// Simulate handleNewTab: the instance grows a third slot in place (no
 	// store version bump) and the handler selects the fresh tab.
 	inst := s.proj.GetInstances()[0]
-	inst.AddTabForTest("agent", session.TabKindAgent)
-	inst.AddTabForTest("shell", session.TabKindShell)
 	inst.AddTabForTest("proc", session.TabKindProcess)
 	s.proj.SetActiveTab(2)
 	s.SyncCursorToActiveTab()
@@ -241,6 +268,7 @@ func TestSidebarTreeSwapPreservesTabSelection(t *testing.T) {
 		Title: "t-00", Path: t.TempDir(), Program: "test",
 	})
 	require.NoError(t, err)
+	addAgentShellTabs(rebuilt)
 	require.True(t, s.proj.ReplaceInstanceByTitle("t-00", rebuilt))
 	s.proj.SelectInstance(rebuilt)
 
@@ -285,8 +313,6 @@ func TestSidebarTreeOutOfBandTabAppears(t *testing.T) {
 	require.Equal(t, 2, tabRowCount(s))
 
 	inst := s.proj.GetInstances()[0]
-	inst.AddTabForTest("agent", session.TabKindAgent)
-	inst.AddTabForTest("shell", session.TabKindShell)
 	inst.AddTabForTest("btop", session.TabKindProcess)
 
 	assert.Equal(t, 3, tabRowCount(s), "in-place tab growth must surface without a store bump")

--- a/ui/store_helpers_test.go
+++ b/ui/store_helpers_test.go
@@ -37,3 +37,12 @@ func addTestInstance(s *Sidebar, inst *session.Instance) func() {
 	s.syncFromStore()
 	return finalize
 }
+
+// addAgentShellTabs stamps a tmux-less agent + shell tab pair on inst — the
+// shape of a started instance after `t`. Since #1100 fresh instances carry
+// only the agent tab and TabLabels mirrors the real tab list, so fixtures
+// that exercise two tab slots must hold two real tabs.
+func addAgentShellTabs(inst *session.Instance) {
+	inst.AddTabForTest("agent", session.TabKindAgent)
+	inst.AddTabForTest("shell", session.TabKindShell)
+}

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -80,9 +80,9 @@ func shellMockExec(captureContent string) cmd_test.MockCmdExec {
 }
 
 // makeShellInstance creates a started local instance with a live agent + shell
-// tab pair. The shell tab is created by LocalBackend.Start as a sibling of the
-// injected mock agent session, so its capture returns captureContent and stays
-// hermetic.
+// tab pair. The shell tab is created on demand via AddShellTab (instances no
+// longer auto-create one, #1100) as a sibling of the injected mock agent
+// session, so its capture returns captureContent and stays hermetic.
 func makeShellInstance(t *testing.T, title, captureContent string) *session.Instance {
 	t.Helper()
 	// Isolate config reads from the developer's real ~/.agent-factory (#658).
@@ -103,6 +103,8 @@ func makeShellInstance(t *testing.T, title, captureContent string) *session.Inst
 	pty := &MockPtyFactory{t: t, cmdExec: cmdExec}
 	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps(name, "bash", pty, cmdExec))
 	require.NoError(t, inst.Start(true))
+	_, err = inst.AddShellTab()
+	require.NoError(t, err)
 	return inst
 }
 
@@ -382,6 +384,8 @@ func TestTabPaneShellSessionGoneFallback(t *testing.T) {
 	pty := &MockPtyFactory{t: t, cmdExec: cmdExec}
 	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps(name, "bash", pty, cmdExec))
 	require.NoError(t, inst.Start(true))
+	_, err = inst.AddShellTab()
+	require.NoError(t, err)
 	defer func() { _ = inst.Kill() }()
 
 	p := NewTabPane()
@@ -464,6 +468,8 @@ func TestTabPaneShellScrollModeSessionGoneExternally(t *testing.T) {
 	pty := &MockPtyFactory{t: t, cmdExec: cmdExec}
 	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps(name, "bash", pty, cmdExec))
 	require.NoError(t, inst.Start(true))
+	_, err = inst.AddShellTab()
+	require.NoError(t, err)
 	defer func() { _ = inst.Kill() }()
 
 	p := NewTabPane()
@@ -551,6 +557,8 @@ func TestTabPaneShellScrollModeAlreadyDead(t *testing.T) {
 	pty := &MockPtyFactory{t: t, cmdExec: cmdExec}
 	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps(name, "bash", pty, cmdExec))
 	require.NoError(t, inst.Start(true))
+	_, err = inst.AddShellTab()
+	require.NoError(t, err)
 	defer func() { _ = inst.Kill() }()
 
 	p := NewTabPane()

--- a/ui/tree/labels.go
+++ b/ui/tree/labels.go
@@ -4,28 +4,29 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
-// defaultTabLabels are the labels shown before an instance is selected, or for
-// one whose tabs haven't materialized yet. They preserve the exact pre-#930
-// two-tab bar so the UX is identical: slot 0 is the agent ("Preview") tab, slot
-// 1 the terminal tab.
-var defaultTabLabels = []string{"Preview", "Terminal"}
+// placeholderTabLabels is the bar shown before an instance is selected or
+// before its tabs have materialized (mid-start/Loading). It is a single slot:
+// the agent tab is the only tab every instance is guaranteed to have —
+// terminal tabs exist on demand only (#1100) — so promising a second slot
+// before the real tab list exists would manufacture a phantom jump/attach
+// target in every consumer of TabLabels.
+var placeholderTabLabels = []string{"Preview"}
 
 // TabLabels returns the display labels for an instance's tab slots — the
-// single source of truth shared by the TabbedWindow's tab bar and the sidebar
-// tree (#1024 PR 3), so the bar, the tree's child rows, and the 1-9 jump keys
-// always agree on slot numbering. Agent tabs render as "Preview", shell tabs
-// as "Terminal"; any Process tab renders under its own name. A nil instance
-// yields the default two-slot bar.
+// single source of truth shared by the TabbedWindow's header, the sidebar
+// tree (#1024 PR 3), and the 1-9 jump keys, so slot numbering can never
+// disagree between them. Agent tabs render as "Preview", shell tabs as
+// "Terminal"; any Process tab renders under its own name.
 //
-// Remote instances are tab-driven too (#930 PR 6): their real tab set is the
-// agent tab plus a terminal tab only when terminal_cmd is configured, so the
-// labels reflect exactly those tabs — a terminal_cmd-less remote shows a single
-// tab rather than the local two-tab default. Local instances keep the
-// default-padded list (always at least the two slots) so the slot count never
-// dips below two mid-start, identical to the pre-#930 UX. The result is never
-// empty.
+// Once an instance's tabs have materialized the labels mirror the real tab
+// list exactly, one slot per tab — local and remote alike. Since #1100 a
+// fresh local instance starts with only its agent tab, so a fresh instance
+// shows a single slot until `t` adds a terminal; padding to a two-slot
+// minimum (the pre-#1100 behavior) would advertise a dead "Terminal" slot.
+// A nil instance or one with no tabs yet yields the single-slot placeholder;
+// the result is never empty.
 func TabLabels(instance *session.Instance) []string {
-	if instance != nil && instance.IsRemote() {
+	if instance != nil {
 		if tabs := instance.GetTabs(); len(tabs) > 0 {
 			labels := make([]string, len(tabs))
 			for i, tab := range tabs {
@@ -33,22 +34,8 @@ func TabLabels(instance *session.Instance) []string {
 			}
 			return labels
 		}
-		// Pre-start remote (no tabs yet): fall through to the default bar.
 	}
-
-	labels := append([]string(nil), defaultTabLabels...)
-	if instance == nil {
-		return labels
-	}
-	for idx, tab := range instance.GetTabs() {
-		label := labelForTab(tab)
-		if idx < len(labels) {
-			labels[idx] = label
-		} else {
-			labels = append(labels, label)
-		}
-	}
-	return labels
+	return append([]string(nil), placeholderTabLabels...)
 }
 
 func labelForTab(tab *session.Tab) string {

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -350,21 +350,32 @@ func TestFlatten(t *testing.T) {
 	assert.True(t, rows[2].IsTab())
 }
 
-// TestTabLabelsDefaultsAndOverlay pins TabLabels: a nil or tab-less local
-// instance keeps the default two-slot bar; real tabs overlay it and extend it.
-func TestTabLabelsDefaultsAndOverlay(t *testing.T) {
-	assert.Equal(t, []string{"Preview", "Terminal"}, TabLabels(nil))
+// TestTabLabelsMirrorRealTabs pins TabLabels since #1100: once tabs have
+// materialized the labels mirror the real tab list exactly — a fresh local
+// instance has only its agent tab, so it renders exactly one slot; `t`
+// (AddShellTab) grows it to two. Before tabs materialize (nil instance or
+// mid-start) the placeholder is the single guaranteed slot, never a padded
+// two-slot bar that would advertise a phantom Terminal target.
+func TestTabLabelsMirrorRealTabs(t *testing.T) {
+	assert.Equal(t, []string{"Preview"}, TabLabels(nil),
+		"nil instance: single-slot placeholder, no phantom Terminal")
 
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title: "labeled", Path: t.TempDir(), Program: "test",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"Preview", "Terminal"}, TabLabels(inst),
-		"tab-less local instance keeps the default-padded slots")
+	assert.Equal(t, []string{"Preview"}, TabLabels(inst),
+		"mid-start (no tabs yet): single-slot placeholder")
 
 	inst.AddTabForTest("agent", session.TabKindAgent)
+	assert.Equal(t, []string{"Preview"}, TabLabels(inst),
+		"fresh instance (#1100): exactly one real slot, no padding to two")
+
 	inst.AddTabForTest("shell", session.TabKindShell)
+	assert.Equal(t, []string{"Preview", "Terminal"}, TabLabels(inst),
+		"after t: the on-demand terminal is the second slot")
+
 	inst.AddTabForTest("btop", session.TabKindProcess)
 	assert.Equal(t, []string{"Preview", "Terminal", "btop"}, TabLabels(inst),
-		"real tabs overlay the default slots and extend past them")
+		"process tabs extend the list under their own names")
 }


### PR DESCRIPTION
Closes #1100

## What

A fresh instance now comes up with **only its agent tab** — the terminal (shell) tab is no longer auto-created. Terminal tabs remain fully available **on demand** via the `t` hotkey and `af sessions tab-create` (both unchanged and still covered by their existing tests).

## How

- `LocalBackend.setupTabs` no longer spawns the default `$SHELL` tab on a fresh start (or on a pre-#930 legacy restore). The fresh-shell fallback is kept but narrowed to its #991 purpose: it now fires only when a **persisted** shell tab restored dead, replacing it so the user lands on a working terminal instead of a corpse.
- Remote sessions are untouched: their terminal tab is derived from `remote_hooks.terminal_cmd` (`syncRemoteTabs`), which is the only way a remote session can have one — removing that would remove the capability, not the auto-creation.
- README's "every session opens with two tabs" paragraph updated.

## Tests

- New `TestFreshStart_OnlyAgentTab` pins the headline behavior through the production path (`NewInstance → Start(true) → setupTabs`): one tab, no `__shell` tmux session spawned, and `AddShellTab` (the `t` path) still works afterwards.
- `TestRestartSurvival_BackCompatSynthesizesTabs` updated: a legacy record now loads as agent-only.
- The #991 dead-shell-replacement regression test passes unchanged (it persists a shell tab).
- Test helpers that need a shell tab (`app/startedLocalInstance`, `ui/makeShellInstance` and the inline #496/#977/#998 setups) now create it via `AddShellTab` — the on-demand path — keeping all downstream tab-count/9-tab-cap/scroll/fallback coverage intact; `startedLocalInstance` additionally asserts the fresh start yields exactly one tab.

All hermetic (temp `AGENT_FACTORY_HOME`, mock tmux). `gofmt`, `go build ./...`, `go test ./...`, `golangci-lint run --fast`, and `deadcode -test ./...` are clean.

**Do not merge yet** — pending play-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)