### PR TITLE
feat(sessions): --here to create a session in-place on the current repo (no worktree) (#1104-adjacent)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -282,6 +282,8 @@ func init() {
 	sessionsCreateCmd.Flags().StringVar(&createNameFlag, "name", "", "Session name (required)")
 	sessionsCreateCmd.Flags().StringVar(&createPromptFlag, "prompt", "", "Initial prompt to send")
 	sessionsCreateCmd.Flags().StringVar(&createProgramFlag, "program", "", "Program to run (defaults to config default)")
+	sessionsCreateCmd.Flags().BoolVar(&createHereFlag, "here", false, "Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both)")
+	sessionsCreateCmd.Flags().BoolVar(&createInPlaceFlag, "in-place", false, "Alias for --here")
 	sessionsCreateCmd.MarkFlagRequired("name")
 
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptCreateFlag, "create", false, "Auto-create the session if it doesn't exist")

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -94,14 +94,25 @@ var (
 	createNameFlag    string
 	createPromptFlag  string
 	createProgramFlag string
+	createHereFlag    bool
+	createInPlaceFlag bool
 )
 
 var sessionsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new session",
+	Long: `Create a new session running an agent in its own git worktree.
+
+With --here (alias --in-place) the session instead attaches to the repo's
+existing working tree at its current branch: no worktree or branch is created,
+the agent runs in the repo root, and killing the session never removes the
+working tree or branch. Requires running inside a git repository (or --repo
+pointing at one).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
+
+		inPlace := createHereFlag || createInPlaceFlag
 
 		// resolveRepo already differentiates "--repo is required" (absent) from a
 		// provided-but-invalid path and names the offending path (#892), so
@@ -109,6 +120,9 @@ var sessionsCreateCmd = &cobra.Command{
 		// "required".
 		repo, err := resolveRepo()
 		if err != nil {
+			if inPlace {
+				return jsonError(fmt.Errorf("--here requires a git repository to attach to: %w", err))
+			}
 			return jsonError(err)
 		}
 
@@ -146,6 +160,7 @@ var sessionsCreateCmd = &cobra.Command{
 			Program:  program,
 			Prompt:   createPromptFlag,
 			AutoYes:  cfg.AutoYes,
+			InPlace:  inPlace,
 		})
 		if err != nil {
 			return jsonError(err)

--- a/api/sessions_inplace_test.go
+++ b/api/sessions_inplace_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// silenceStdio redirects stdout/stderr to /dev/null for the duration of the
+// test so jsonOut/jsonError don't pollute `go test` output.
+func silenceStdio(t *testing.T) {
+	t.Helper()
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout = devnull
+	os.Stderr = devnull
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		devnull.Close()
+	})
+}
+
+// setSessionsCreateFlags sets the package-level flag vars used by
+// sessionsCreateCmd and restores them afterwards.
+func setSessionsCreateFlags(t *testing.T, name, repo string, here, inPlace bool) {
+	t.Helper()
+	prevName, prevPrompt, prevProgram := createNameFlag, createPromptFlag, createProgramFlag
+	prevHere, prevInPlace, prevRepo := createHereFlag, createInPlaceFlag, repoFlag
+	createNameFlag, createPromptFlag, createProgramFlag = name, "do the thing", ""
+	createHereFlag, createInPlaceFlag, repoFlag = here, inPlace, repo
+	t.Cleanup(func() {
+		createNameFlag, createPromptFlag, createProgramFlag = prevName, prevPrompt, prevProgram
+		createHereFlag, createInPlaceFlag, repoFlag = prevHere, prevInPlace, prevRepo
+	})
+}
+
+// TestSessionsCreate_HereSetsInPlace verifies the CLI contract for
+// `af sessions create --here` (and its --in-place alias): the flag must reach
+// the daemon's CreateSessionRequest, and a plain create must not set it.
+func TestSessionsCreate_HereSetsInPlace(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		here        bool
+		inPlace     bool
+		wantInPlace bool
+	}{
+		{name: "here", here: true, wantInPlace: true},
+		{name: "in-place alias", inPlace: true, wantInPlace: true},
+		{name: "plain", wantInPlace: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+			silenceStdio(t)
+
+			repoRoot := filepath.Join(t.TempDir(), "repo")
+			if err := os.MkdirAll(repoRoot, 0755); err != nil {
+				t.Fatalf("mkdir repo: %v", err)
+			}
+			if out, err := exec.Command("git", "-C", repoRoot, "init").CombinedOutput(); err != nil {
+				t.Fatalf("git init: %v (%s)", err, out)
+			}
+
+			var got *daemon.CreateSessionRequest
+			prevCreate := createSessionViaDaemon
+			createSessionViaDaemon = func(req daemon.CreateSessionRequest) (*session.InstanceData, error) {
+				got = &req
+				return &session.InstanceData{Title: req.Title}, nil
+			}
+			t.Cleanup(func() { createSessionViaDaemon = prevCreate })
+
+			setSessionsCreateFlags(t, "here-test", repoRoot, tc.here, tc.inPlace)
+
+			if err := sessionsCreateCmd.RunE(sessionsCreateCmd, nil); err != nil {
+				t.Fatalf("sessions create: %v", err)
+			}
+			if got == nil {
+				t.Fatalf("daemon create was never called")
+			}
+			if got.InPlace != tc.wantInPlace {
+				t.Fatalf("CreateSessionRequest.InPlace = %v, want %v", got.InPlace, tc.wantInPlace)
+			}
+			if got.Prompt != "do the thing" {
+				t.Fatalf("--here must compose with --prompt; got prompt %q", got.Prompt)
+			}
+		})
+	}
+}
+
+// TestSessionsCreate_HereOutsideRepoErrors: --here without a git repo (no
+// --repo flag, cwd not a repo) must fail with a message that names --here and
+// the git-repo requirement rather than a generic create failure.
+func TestSessionsCreate_HereOutsideRepoErrors(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	silenceStdio(t)
+
+	// Run from a directory that is not a git repository.
+	notARepo := t.TempDir()
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(notARepo); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+
+	prevCreate := createSessionViaDaemon
+	createSessionViaDaemon = func(req daemon.CreateSessionRequest) (*session.InstanceData, error) {
+		return nil, errors.New("daemon must not be reached")
+	}
+	t.Cleanup(func() { createSessionViaDaemon = prevCreate })
+
+	setSessionsCreateFlags(t, "here-no-repo", "", true, false)
+
+	err = sessionsCreateCmd.RunE(sessionsCreateCmd, nil)
+	if err == nil {
+		t.Fatalf("expected --here outside a git repo to fail")
+	}
+	if !strings.Contains(err.Error(), "--here") || !strings.Contains(err.Error(), "git repository") {
+		t.Fatalf("error must name --here and the git-repo requirement, got: %v", err)
+	}
+}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -39,12 +39,17 @@ var ensureDaemonMu sync.Mutex
 // CreateSessionRequest is the daemon-owned session creation contract used by
 // the TUI, CLI, and scheduled task runner.
 type CreateSessionRequest struct {
-	Title       string
-	TitleBase   string
-	RepoPath    string
-	Program     string
-	Prompt      string
-	AutoYes     bool
+	Title     string
+	TitleBase string
+	RepoPath  string
+	Program   string
+	Prompt    string
+	AutoYes   bool
+	// InPlace attaches the session to the repo's existing working tree at its
+	// current branch (`af sessions create --here`) instead of creating a new
+	// git worktree+branch; kill/cleanup leaves the user's tree and branch
+	// intact. Incompatible with ForceRemote.
+	InPlace     bool
 	ForceRemote bool
 }
 
@@ -1179,14 +1184,16 @@ func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData,
 		Path:        repo.Root,
 		Program:     req.Program,
 		AutoYes:     req.AutoYes,
+		InPlace:     req.InPlace,
 		ForceRemote: req.ForceRemote,
 	})
 	if err != nil {
 		return session.InstanceData{}, err
 	}
 
-	// Every instance now owns a fresh worktree 1:1 (#930 PR 3 removed the
-	// create-on-existing-worktree path): there is a single creation flow.
+	// Single creation flow (#930 PR 3): every instance owns its worktree 1:1.
+	// InPlace only changes WHICH worktree that is — the repo's own working
+	// tree, marked external — not the flow itself.
 	if err = task.StartAndSendPrompt(instance, req.Prompt); err != nil {
 		_ = instance.Kill()
 		return session.InstanceData{}, fmt.Errorf("failed to start instance: %w", err)

--- a/daemon/create_inplace_test.go
+++ b/daemon/create_inplace_test.go
@@ -1,0 +1,129 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// installOptionsRecordingBackend is installInstantBackend plus a recorder: it
+// returns a pointer to the slice of InstanceOptions the daemon handed to
+// session.NewInstance, so tests can assert request fields (InPlace) survive
+// the CreateSession plumbing without spinning up real tmux/git worktrees.
+func installOptionsRecordingBackend(t *testing.T) *[]session.InstanceOptions {
+	t.Helper()
+	var seen []session.InstanceOptions
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, absPath string) (session.Backend, error) {
+		seen = append(seen, opts)
+		backend := session.NewFakeBackend()
+		backend.CompleteStart()
+		return readyFakeBackend{backend}, nil
+	})
+	t.Cleanup(restore)
+	return &seen
+}
+
+// TestManagerCreateSessionCarriesInPlace verifies the daemon's CreateSession
+// contract for `af sessions create --here`: the request's InPlace flag reaches
+// session.NewInstance so the instance attaches to the repo working tree
+// instead of cutting a fresh worktree.
+func TestManagerCreateSessionCarriesInPlace(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	seen := installOptionsRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "captain-here",
+		RepoPath: repoPath,
+		Program:  "claude",
+		InPlace:  true,
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("expected 1 NewInstance call, got %d", len(*seen))
+	}
+	if !(*seen)[0].InPlace {
+		t.Fatalf("InPlace was dropped between CreateSessionRequest and session.NewInstance")
+	}
+
+	// A plain create must stay on the fresh-worktree path.
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "normal",
+		RepoPath: repoPath,
+		Program:  "claude",
+	}); err != nil {
+		t.Fatalf("CreateSession (normal): %v", err)
+	}
+	if (*seen)[1].InPlace {
+		t.Fatalf("plain create must not set InPlace")
+	}
+}
+
+// TestManagerCreateSessionRejectsInPlaceRemote mirrors the pre-#930 guard:
+// a remote session has no local worktree, so combining it with --here must
+// fail instead of silently ignoring one of the flags.
+func TestManagerCreateSessionRejectsInPlaceRemote(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	_, err = manager.CreateSession(CreateSessionRequest{
+		Title:       "here-remote",
+		RepoPath:    repoPath,
+		Program:     "claude",
+		InPlace:     true,
+		ForceRemote: true,
+	})
+	if err == nil {
+		t.Fatalf("expected InPlace+ForceRemote to be rejected")
+	}
+	if !strings.Contains(err.Error(), "in-place") {
+		t.Fatalf("rejection must name the in-place conflict, got: %v", err)
+	}
+}
+
+// TestCreateSessionRPCCarriesInPlace exercises the actual control-socket RPC
+// (net/rpc over the daemon's unix socket), so `af sessions create --here`
+// against a RUNNING daemon carries the flag across the wire — not just the
+// in-process Manager path.
+func TestCreateSessionRPCCarriesInPlace(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	seen := installOptionsRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	closeServer, err := startControlServer(manager, nil, nil, make(chan struct{}))
+	if err != nil {
+		t.Fatalf("startControlServer: %v", err)
+	}
+	t.Cleanup(func() { _ = closeServer() })
+
+	var resp CreateSessionResponse
+	if err := callDaemonNoEnsure("CreateSession", CreateSessionRequest{
+		Title:    "captain-here-rpc",
+		RepoPath: repoPath,
+		Program:  "claude",
+		InPlace:  true,
+	}, &resp); err != nil {
+		t.Fatalf("CreateSession RPC: %v", err)
+	}
+	if resp.Instance.Title != "captain-here-rpc" {
+		t.Fatalf("unexpected instance data: %+v", resp.Instance)
+	}
+	if len(*seen) != 1 || !(*seen)[0].InPlace {
+		t.Fatalf("InPlace did not survive the control-socket round-trip: %+v", *seen)
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,7 +23,7 @@ All subcommands accept `--repo <path>` to target a repository other than the cur
 ```bash
 af sessions list                                          # list sessions in the repo
 af sessions get <title>                                   # fetch one session
-af sessions create --name <title> [--prompt "..."] [--program <agent>]
+af sessions create --name <title> [--prompt "..."] [--program <agent>] [--here]
 af sessions send-prompt <title> "..."                     # append a prompt to a session
 af sessions send-prompt <title> "..." --create            # send-or-create
 af sessions tab-create <title> --command "<cmd>"          # spawn a process tab in the session's worktree
@@ -36,7 +36,7 @@ af sessions kill <title>                                  # kill the session, cl
 
 Flags:
 
-- `create`: `--name` (required), `--prompt` (initial prompt to send), `--program` (agent enum, defaults to the configured `default_program`).
+- `create`: `--name` (required), `--prompt` (initial prompt to send), `--program` (agent enum, defaults to the configured `default_program`). `--here` (alias `--in-place`) attaches the session to the repo's **existing working tree at its current branch** instead of cutting a new worktree+branch: the agent runs in the repo root, no branch is created, and killing the session never removes the working tree or branch. Requires a git repository (the current directory, or `--repo`); incompatible with remote sessions.
 - `send-prompt`: `--create` auto-creates the session if it doesn't exist; `--program` picks the agent when creating.
 - `tab-create`: `--command` (required) is run in the session's git worktree as a new tab; `--name` sets the tab's display name (defaults to the command's basename, auto-suffixed `-2`, `-3`, … on collision). The resolved tab name is printed as `{"name": "..."}` so scripts/agents can address it. The tab persists and reconnects across a daemon/`af` restart like every other tab. Refused once a session already holds 9 tabs. **Not available for remote sessions:** they have no local worktree and the hook protocol can't run arbitrary commands — a remote session's only terminal tab comes from `remote_hooks.terminal_cmd` (see [remote-hooks.md](remote-hooks.md)).
 - `tab-delete`: the counterpart of `tab-create` — `--name` (required) selects the tab to delete. The tab is removed from the daemon's session state and its tmux window is killed; the removal is persistent (the daemon won't respawn it, and it doesn't return on restart). The deleted tab's name is printed as `{"name": "..."}`. The agent tab can't be deleted — use `af sessions kill` to tear down the whole session. Targeting a missing tab or session is an error. Not available for remote sessions (their tabs are fixed by `remote_hooks` config).

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -86,7 +86,19 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 	i.mu.Unlock()
 
 	if firstTimeSetup {
-		gitWorktree, branchName, err := git.NewGitWorktree(i.Path, i.Title)
+		var (
+			gitWorktree *git.GitWorktree
+			branchName  string
+			err         error
+		)
+		if i.inPlace {
+			// --here: attach to the repo's own working tree at its current
+			// branch. The worktree is external, so Setup() below is a no-op
+			// and Cleanup()/Kill never removes the user's tree or branch.
+			gitWorktree, branchName, err = git.NewGitWorktreeInPlace(i.Path)
+		} else {
+			gitWorktree, branchName, err = git.NewGitWorktree(i.Path, i.Title)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to create git worktree: %w", err)
 		}

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -56,13 +56,13 @@ type GitWorktree struct {
 	baseCommitSHA string
 	// externalWorktree is true if the worktree was not created by agent-factory.
 	//
-	// Legacy back-compat (#930 PR 3): this was only ever set true by the
-	// removed create-on-existing-worktree feature. No code path sets it true
-	// anymore, so every newly created worktree has it false. It is still read
-	// from storage and honored by Cleanup() (which no-ops for external
-	// worktrees) so pre-existing instances created by the old feature do not
-	// have their user-owned worktree/branch destroyed on kill. A future PR
-	// drops this field once no persisted instance carries it.
+	// Set true by two producers: instances persisted by the pre-#930-PR-3
+	// create-on-existing-worktree feature (legacy records restored via
+	// NewGitWorktreeFromStorage), and in-place sessions created with
+	// `af sessions create --here` (NewGitWorktreeInPlace), which attach to the
+	// repo's own working tree. Either way the worktree and branch are
+	// user-owned: Setup() must not create anything and Cleanup() must not
+	// remove the worktree or delete the branch.
 	externalWorktree bool
 	// branchCreatedByUs is true if this session created the underlying branch
 	// itself (via setupNewWorktree). When false, Cleanup() must NOT delete the
@@ -188,6 +188,63 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		hooksCtx:     ctx,
 		hooksCancel:  cancel,
 	}, branchName, nil
+}
+
+// NewGitWorktreeInPlace creates a GitWorktree attached to the repo's own
+// working tree at its current branch — the `af sessions create --here` path,
+// reinstating (as an explicit opt-in) the create side of the external-worktree
+// capability removed in #930 PR 3. The worktree path IS the resolved repo
+// root, no branch or worktree is created, and externalWorktree=true /
+// branchCreatedByUs=false so Setup() and Cleanup() never touch the user's
+// working tree or branch. Returns the worktree and the current branch name.
+func NewGitWorktreeInPlace(repoPath string) (*GitWorktree, string, error) {
+	absPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		log.ErrorLog.Printf("git worktree path abs error, falling back to repoPath %s: %s", repoPath, err)
+		absPath = repoPath
+	}
+
+	repoRoot, err := findGitRepoRoot(absPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("an in-place session must be created inside a git repository: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	g := &GitWorktree{
+		repoPath:          repoRoot,
+		worktreePath:      repoRoot,
+		worktreeDir:       filepath.Dir(repoRoot),
+		branchName:        "",
+		externalWorktree:  true,
+		branchCreatedByUs: false,
+		hooksCtx:          ctx,
+		hooksCancel:       cancel,
+	}
+
+	// Record the repo's current branch verbatim ("HEAD" when detached): the
+	// session runs on whatever is checked out, and since Cleanup() never
+	// deletes it the name is purely informational (sidebar, PR lookup).
+	branchName, err := g.runGitCommand(repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		cancel()
+		if strings.Contains(err.Error(), "ambiguous argument 'HEAD'") ||
+			strings.Contains(err.Error(), "not a valid object name") {
+			return nil, "", fmt.Errorf("this appears to be a brand new repository: please create an initial commit before creating an in-place session")
+		}
+		return nil, "", fmt.Errorf("failed to resolve current branch for in-place session: %w", err)
+	}
+	g.branchName = strings.TrimSpace(branchName)
+
+	// The base commit is the current HEAD: diffs for an in-place session show
+	// what the agent changed on top of where the user already was.
+	head, err := g.runGitCommand(repoRoot, "rev-parse", "HEAD")
+	if err != nil {
+		cancel()
+		return nil, "", fmt.Errorf("failed to resolve HEAD for in-place session: %w", err)
+	}
+	g.baseCommitSHA = strings.TrimSpace(head)
+
+	return g, g.branchName, nil
 }
 
 // GetWorktreePath returns the path to the worktree

--- a/session/git/worktree_inplace_test.go
+++ b/session/git/worktree_inplace_test.go
@@ -1,0 +1,100 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runGitInPlaceTest runs a git command in dir and returns trimmed stdout,
+// failing the test on error.
+func runGitInPlaceTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, string(out))
+	return strings.TrimSpace(string(out))
+}
+
+// TestNewGitWorktreeInPlace covers the `af sessions create --here` git layer:
+// the returned worktree is attached to the repo's own working tree at its
+// current branch, marked external, and neither Setup() nor Cleanup() touches
+// the user's tree or branch. This reinstates the create side of the
+// external-worktree capability removed in #930 PR 3, so it mirrors the
+// invariants of TestCleanup_LegacyExternalWorktreeIsPreserved.
+func TestNewGitWorktreeInPlace(t *testing.T) {
+	sandboxHome(t)
+
+	repoRoot := createGitRepo(t)
+	runGitInPlaceTest(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+	runGitInPlaceTest(t, repoRoot, "checkout", "-b", "user/current-work")
+	headSHA := runGitInPlaceTest(t, repoRoot, "rev-parse", "HEAD")
+	branchesBefore := runGitInPlaceTest(t, repoRoot, "branch", "--list")
+
+	gw, branch, err := NewGitWorktreeInPlace(repoRoot)
+	require.NoError(t, err)
+
+	assert.Equal(t, "user/current-work", branch, "must report the repo's current branch")
+	assert.Equal(t, "user/current-work", gw.GetBranchName())
+	assert.True(t, gw.IsExternalWorktree(), "an in-place worktree is user-owned and must be external")
+	assert.False(t, gw.BranchCreatedByUs(), "af did not create the current branch")
+	assert.Equal(t, gw.GetRepoPath(), gw.GetWorktreePath(),
+		"in-place: the worktree IS the repo root")
+	assert.Equal(t, normalizeWorktreePath(repoRoot), normalizeWorktreePath(gw.GetWorktreePath()))
+	assert.Equal(t, headSHA, gw.GetBaseCommitSHA(), "base commit must be the current HEAD")
+
+	// Setup must be a no-op: no new worktree registered, no branch created,
+	// still on the same branch.
+	require.NoError(t, gw.Setup())
+	assert.Equal(t, "user/current-work",
+		runGitInPlaceTest(t, repoRoot, "rev-parse", "--abbrev-ref", "HEAD"),
+		"Setup must not switch branches")
+	assert.Equal(t, branchesBefore, runGitInPlaceTest(t, repoRoot, "branch", "--list"),
+		"Setup must not create or delete any branch")
+	worktreeList := runGitInPlaceTest(t, repoRoot, "worktree", "list", "--porcelain")
+	assert.Equal(t, 1, strings.Count(worktreeList, "worktree "),
+		"Setup must not register a linked worktree")
+
+	// Cleanup (the kill path) must leave the user's working tree and branch
+	// intact — exactly the legacy external-worktree behavior.
+	require.NoError(t, gw.Cleanup())
+	_, statErr := os.Stat(repoRoot)
+	require.NoError(t, statErr, "Cleanup must NOT remove the repo working tree")
+	_, statErr = os.Stat(filepath.Join(repoRoot, ".git"))
+	require.NoError(t, statErr, "Cleanup must NOT touch the repo's .git")
+	runGitInPlaceTest(t, repoRoot, "show-ref", "--verify", "refs/heads/user/current-work")
+}
+
+// TestNewGitWorktreeInPlace_NotARepo verifies the clear-error contract:
+// --here outside a git repository must fail with an actionable message.
+func TestNewGitWorktreeInPlace_NotARepo(t *testing.T) {
+	sandboxHome(t)
+
+	notARepo := t.TempDir()
+	_, _, err := NewGitWorktreeInPlace(notARepo)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "git repository",
+		"error must tell the user --here needs a git repo")
+}
+
+// TestNewGitWorktreeInPlace_EmptyRepo verifies that a repo without any commit
+// is rejected with the same actionable guidance the fresh-worktree path gives.
+func TestNewGitWorktreeInPlace_EmptyRepo(t *testing.T) {
+	sandboxHome(t)
+
+	repoRoot := createGitRepo(t)
+	_, _, err := NewGitWorktreeInPlace(repoRoot)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initial commit",
+		"error must point at the missing initial commit")
+}

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -12,6 +12,15 @@ import (
 
 // Setup creates a new worktree for the session
 func (g *GitWorktree) Setup() error {
+	// An external worktree (an in-place `--here` session, or a legacy
+	// pre-#930-PR-3 record) IS the user's existing working tree: there is
+	// nothing to create, and post-worktree hooks are deliberately skipped —
+	// they provision fresh checkouts and must not run unasked inside the
+	// user's live tree. Mirrors the Cleanup() no-op below.
+	if g.externalWorktree {
+		return nil
+	}
+
 	// Ensure worktrees directory exists early (can be done in parallel with branch check)
 	if g.worktreeDir == "" {
 		return fmt.Errorf("failed to get worktree directory: empty worktree directory")

--- a/session/inplace_test.go
+++ b/session/inplace_test.go
@@ -1,0 +1,202 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// inPlaceTmuxWorld is a hermetic tmux double for full first-time-start flows:
+// the pty factory records every `tmux new-session -s NAME` and marks NAME as
+// created, and the executor answers `has-session -t =NAME` from that set. This
+// lets LocalBackend.Start(true) — agent session AND the default shell tab —
+// run end-to-end with no real tmux server.
+type inPlaceTmuxWorld struct {
+	t  *testing.T
+	mu sync.Mutex
+	// created holds sanitized session names spawned via new-session.
+	created map[string]bool
+}
+
+func newInPlaceTmuxWorld(t *testing.T) *inPlaceTmuxWorld {
+	return &inPlaceTmuxWorld{t: t, created: make(map[string]bool)}
+}
+
+// argAfter returns the argument following flag in args, or "".
+func argAfter(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func (w *inPlaceTmuxWorld) Start(c *exec.Cmd) (*os.File, error) {
+	if name := argAfter(c.Args, "-s"); name != "" {
+		w.mu.Lock()
+		w.created[name] = true
+		w.mu.Unlock()
+	}
+	path := filepath.Join(w.t.TempDir(), fmt.Sprintf("pty-%d", rand.Int31()))
+	return os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+}
+
+func (w *inPlaceTmuxWorld) Close() {}
+
+func (w *inPlaceTmuxWorld) exec() cmd_test.MockCmdExec {
+	return cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			if strings.Contains(c.String(), "has-session") {
+				// has-session passes the exact-match target as one arg: -t=NAME
+				name := argAfter(c.Args, "-t")
+				for _, a := range c.Args {
+					if strings.HasPrefix(a, "-t=") {
+						name = strings.TrimPrefix(a, "-t=")
+					}
+				}
+				name = strings.TrimPrefix(name, "=")
+				name = strings.TrimSuffix(name, ":")
+				w.mu.Lock()
+				defer w.mu.Unlock()
+				if !w.created[name] {
+					return fmt.Errorf("can't find session: %s", name)
+				}
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+			return []byte(""), nil
+		},
+	}
+}
+
+// initInPlaceRepo creates a temp git repo with an initial commit, checked out
+// on a user-owned branch, and returns its root.
+func initInPlaceRepo(t *testing.T, branch string) string {
+	t.Helper()
+	repoRoot := initTempGitRepo(t)
+	for _, args := range [][]string{
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "test"},
+		{"commit", "--allow-empty", "-m", "initial"},
+		{"checkout", "-b", branch},
+	} {
+		c := exec.Command("git", args...)
+		c.Dir = repoRoot
+		out, err := c.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, string(out))
+	}
+	return repoRoot
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	out, err := c.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, string(out))
+	return strings.TrimSpace(string(out))
+}
+
+// TestInPlaceInstanceLifecycle drives the full `--here` create path through
+// NewInstance → LocalBackend.Start(true) → ToInstanceData → Kill against a
+// real temp git repo (tmux mocked): the session attaches to the repo's own
+// working tree at its current branch with external_worktree=true, creates no
+// branch or worktree, and Kill leaves the user's tree and branch intact.
+func TestInPlaceInstanceLifecycle(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const branch = "user/current-work"
+	repoRoot := initInPlaceRepo(t, branch)
+	branchesBefore := gitOut(t, repoRoot, "branch", "--list")
+
+	inst, err := NewInstance(InstanceOptions{
+		Title:   "captain-here",
+		Path:    repoRoot,
+		Program: "claude",
+		InPlace: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "local", inst.GetBackend().Type(),
+		"--here sessions use the plain local backend")
+
+	world := newInPlaceTmuxWorld(t)
+	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps("captain-here", "claude", world, world.exec()))
+
+	require.NoError(t, inst.Start(true))
+	require.True(t, inst.Started())
+
+	// The worktree is the repo root itself, external, on the current branch.
+	gw, err := inst.GetGitWorktree()
+	require.NoError(t, err)
+	assert.True(t, gw.IsExternalWorktree(),
+		"--here must persist external_worktree=true so cleanup skips the user's tree")
+	assert.False(t, gw.BranchCreatedByUs())
+	assert.Equal(t, gw.GetRepoPath(), gw.GetWorktreePath(),
+		"--here: worktree_path must equal repo_path")
+	wantRoot, _ := filepath.EvalSymlinks(repoRoot)
+	gotRoot, _ := filepath.EvalSymlinks(inst.GetWorktreePath())
+	assert.Equal(t, wantRoot, gotRoot, "worktree must be the repo root the session was created in")
+	assert.Equal(t, branch, inst.GetBranch(), "current branch must be preserved")
+
+	// No branch was created and no linked worktree was registered.
+	assert.Equal(t, branchesBefore, gitOut(t, repoRoot, "branch", "--list"),
+		"--here must not create a branch")
+	assert.Equal(t, branch, gitOut(t, repoRoot, "rev-parse", "--abbrev-ref", "HEAD"),
+		"--here must not switch the checked-out branch")
+	assert.Equal(t, 1, strings.Count(gitOut(t, repoRoot, "worktree", "list", "--porcelain"), "worktree "),
+		"--here must not register a linked worktree")
+
+	// Persisted form carries the external-worktree semantics, and they
+	// survive a JSON round-trip (what instances.json stores).
+	data := inst.ToInstanceData()
+	require.True(t, data.Worktree.ExternalWorktree)
+	assert.Equal(t, data.Worktree.RepoPath, data.Worktree.WorktreePath)
+	assert.Equal(t, branch, data.Branch)
+	require.NotNil(t, data.Worktree.BranchCreatedByUs)
+	assert.False(t, *data.Worktree.BranchCreatedByUs)
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+	var restored InstanceData
+	require.NoError(t, json.Unmarshal(raw, &restored))
+	assert.True(t, restored.Worktree.ExternalWorktree,
+		"external_worktree must survive the instances.json round-trip")
+
+	// Kill must tear down only the session — the user's working tree and
+	// branch survive (mirrors TestCleanup_LegacyExternalWorktreeIsPreserved).
+	require.NoError(t, inst.Kill())
+	_, statErr := os.Stat(filepath.Join(repoRoot, ".git"))
+	require.NoError(t, statErr, "Kill must NOT remove the repo working tree")
+	gitOut(t, repoRoot, "show-ref", "--verify", "refs/heads/"+branch)
+	assert.Equal(t, branchesBefore, gitOut(t, repoRoot, "branch", "--list"),
+		"Kill must not delete any branch")
+}
+
+// TestInPlaceRejectsRemote: an in-place session runs in the local working
+// tree; combining it with a remote backend is contradictory and must fail
+// fast at NewInstance (mirrors the pre-#930 "remote sessions cannot use an
+// existing local worktree" guard).
+func TestInPlaceRejectsRemote(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	_, err := NewInstance(InstanceOptions{
+		Title:       "here-remote",
+		Path:        t.TempDir(),
+		Program:     "claude",
+		InPlace:     true,
+		ForceRemote: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "in-place")
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -71,6 +71,13 @@ type Instance struct {
 	AutoYes bool
 	// Prompt is the initial prompt to pass to the instance on startup
 	Prompt string
+	// inPlace is true when the instance was created with `--here`: on first
+	// start it attaches to the repo's existing working tree at its current
+	// branch (external worktree) instead of creating a fresh worktree+branch.
+	// Set once by NewInstance and only read by LocalBackend.Start's first-time
+	// setup; restored instances don't need it (the persisted
+	// external_worktree flag carries the semantics from then on).
+	inPlace bool
 
 	// prInfo stores the associated GitHub PR info
 	prInfo *git.PRInfo
@@ -682,15 +689,13 @@ func (i *Instance) ToInstanceData() InstanceData {
 	// Only include worktree data if gitWorktree is initialized
 	if i.gitWorktree != nil {
 		branchCreatedByUs := i.gitWorktree.BranchCreatedByUs()
-		// ExternalWorktree is legacy back-compat (#930 PR 3): the create-on-
-		// existing-worktree feature that set it true was removed, so new
-		// instances always serialize false here. We still write/read whatever
-		// the worktree reports so pre-existing instances created by the old
-		// feature keep externalWorktree=true and Cleanup() keeps skipping
-		// their user-owned worktree+branch. A future PR drops the field once
-		// no persisted instance carries it. (BranchCreatedByUs is NOT legacy —
-		// it still flips false on the normal path when Setup reuses an existing
-		// branch; see git/worktree_ops.go setupFromExistingBranch.)
+		// ExternalWorktree is true for in-place sessions (`af sessions create
+		// --here`, which attach to the repo's own working tree) and for
+		// instances persisted by the pre-#930-PR-3 create-on-existing-worktree
+		// feature. Cleanup() honors it by skipping removal of the user-owned
+		// worktree+branch. (BranchCreatedByUs is independent — it also flips
+		// false on the normal path when Setup reuses an existing branch; see
+		// git/worktree_ops.go setupFromExistingBranch.)
 		data.Worktree = GitWorktreeData{
 			RepoPath:          i.gitWorktree.GetRepoPath(),
 			WorktreePath:      i.gitWorktree.GetWorktreePath(),
@@ -869,6 +874,11 @@ type InstanceOptions struct {
 	// ForceRemote forces the instance to use the remote hook backend,
 	// even if the repo config would default to local.
 	ForceRemote bool
+	// InPlace attaches the session to the repo's existing working tree at its
+	// current branch (`af sessions create --here`) instead of creating a new
+	// git worktree+branch. The worktree is marked external so kill/cleanup
+	// never removes the user's tree or branch. Local backend only.
+	InPlace bool
 }
 
 // backendFactory constructs the Backend used by a new Instance. It is a
@@ -900,6 +910,12 @@ func SetBackendFactoryForTest(f func(opts InstanceOptions, absPath string) (Back
 func NewInstance(opts InstanceOptions) (*Instance, error) {
 	t := time.Now()
 
+	// An in-place session runs in the repo's local working tree; a remote
+	// session has no local worktree at all — the two are contradictory.
+	if opts.InPlace && opts.ForceRemote {
+		return nil, fmt.Errorf("remote sessions cannot run in-place in the local repo working tree")
+	}
+
 	// Convert path to absolute
 	absPath, err := filepath.Abs(opts.Path)
 	if err != nil {
@@ -921,6 +937,7 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		CreatedAt: t,
 		UpdatedAt: t,
 		AutoYes:   opts.AutoYes,
+		inPlace:   opts.InPlace,
 		backend:   backend,
 	}, nil
 }


### PR DESCRIPTION
## What

Re-adds the ability to create a session **attached to the repo's existing working tree** — removed in #930 PR 3 (#954) — as an explicit opt-in flag:

```bash
af sessions create --name captain --here [--program <agent>] [--prompt "..."]
# --in-place is accepted as an alias
```

Semantics (exactly the legacy external-worktree behavior, now creatable again):

- `worktree_path == repo_path`: the agent runs in the repo root you point it at, on the **current branch**.
- af creates **no** branch and **no** worktree; `external_worktree=true` is persisted (`branch_created_by_us=false`).
- Kill/cleanup of a `--here` session tears down only the tmux sessions — the user's working tree and branch are always left intact (`Cleanup()` no-op in `session/git/worktree_ops.go`, unchanged; `Setup()` now mirrors it with an early return so nothing is created and post-worktree hooks never run inside the user's live tree).
- Must be run inside a git repository (or `--repo` pointing at one); errors clearly otherwise, including the brand-new-repo (no initial commit) case.
- Incompatible with remote sessions (`NewInstance` rejects `InPlace+ForceRemote`, mirroring the removed pre-#930 guard).

## Why

This is the missing piece for the #1104 self-heal theme: when the persistent Captain session's tmux dies and the record goes Dead, there is currently **no way to recreate it in-place on the repo root** — the only creation path cuts a fresh worktree+branch. With `--here`, the Captain session can be (re)created attached to the repo's own working tree without af ever owning (or deleting) that tree.

## How

Reuses the existing external-worktree plumbing end to end rather than inventing a parallel path — this is a targeted reinstatement of the create capability #930 PR 3 deleted, not a revert:

- `session/git/worktree.go`: new `NewGitWorktreeInPlace(repoPath)` — resolves the main repo root, records the current branch (`rev-parse --abbrev-ref HEAD`) and HEAD as the base commit, and returns a `GitWorktree` with `externalWorktree=true` / `branchCreatedByUs=false` (the same shape `NewGitWorktreeFromStorage` restores for legacy records). Updated the stale "legacy, future PR drops this" comments on `externalWorktree` — it now has a live producer.
- `session/backend_local.go`: `Start(firstTimeSetup)` picks `NewGitWorktreeInPlace` vs `NewGitWorktree` off the new `Instance.inPlace` flag; everything downstream (Setup, tmux start, tabs, error-path cleanup) is the shared flow.
- `daemon/control.go`: `CreateSessionRequest.InPlace` carries the flag through the CreateSession control RPC into `session.NewInstance`, so `af sessions create --here` works against the running daemon, not just in-process.
- `api/`: `--here` / `--in-place` flags on `sessions create`, composing with `--program` and `--prompt`; a `--here`-specific error when no git repo is resolvable.
- TUI create, task-fired creates, and `send-prompt --create` intentionally stay on the fresh-worktree path (zero-value `InPlace`).

## Tests (hermetic — t.TempDir repos, mocked tmux, no real daemon)

- `session/git/worktree_inplace_test.go`: in-place worktree is external, `worktree_path == repo_path`, current branch + HEAD base; `Setup()` creates nothing; `Cleanup()` preserves tree+branch (mirrors `TestCleanup_LegacyExternalWorktreeIsPreserved`); clear errors outside a repo and in a commit-less repo.
- `session/inplace_test.go`: full `NewInstance → Start(true) → ToInstanceData → Kill` lifecycle against a real temp repo with a tmux double — `external_worktree=true` persisted and JSON-round-tripped, no branch created, branch/tree survive Kill; `InPlace+ForceRemote` rejected.
- `daemon/create_inplace_test.go`: `Manager.CreateSession` passes `InPlace` into `InstanceOptions` (and not for plain creates); rejection of in-place+remote; **real control-socket net/rpc round-trip** carries the flag.
- `api/sessions_inplace_test.go`: `--here` and the `--in-place` alias set `InPlace` on the daemon request (plain create doesn't), composes with `--prompt`; `--here` outside a repo fails with an actionable message.

## Verification

- `gofmt -l .` clean, `go build ./...` clean
- `go test ./...` fully green (api, app, daemon, integration, session, session/git, ui, …)
- `golangci-lint run --timeout=3m --fast` clean, `deadcode -test ./...` clean
- No dev-install, no real-daemon interaction — hermetic only, per task constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)