### PR TITLE
docs: pin deadcode install instruction to CI's v0.36.0 (#637 drift)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ gofmt -l .   # should produce no output
 deadcode -test ./...   # should produce no output
 ```
 
-Install the `deadcode` binary once with `go install golang.org/x/tools/cmd/deadcode@latest`; CI installs the same binary on every run.
+Install the `deadcode` binary once with `go install golang.org/x/tools/cmd/deadcode@v0.36.0`; CI pins the same version (`@latest` requires Go 1.25+, above this project's Go floor — see #637).
 
 ## Project Structure
 


### PR DESCRIPTION
CLAUDE.md told contributors to `go install …/deadcode@latest`, but CI pins `v0.36.0` (#637) because `@latest` needs Go 1.25+, above the project's Go floor. Following the doc gives a toolchain mismatch with CI. One-line doc fix.

Found during a historical-transcript audit of maintainer decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude