### PR TITLE
session: reap the whole process tree on teardown + af doctor (#1104)

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// HealthStatus is a read-only snapshot of daemon liveness for `af doctor`.
+// Collecting it never spawns a daemon and never signals anything.
+type HealthStatus struct {
+	// SocketPath is the control socket location; empty when the config dir
+	// cannot be resolved (SocketErr says why).
+	SocketPath string
+	SocketErr  error
+	// SocketExists reports whether the socket file is present on disk.
+	SocketExists bool
+	// PingErr is nil when a daemon answered the control-socket ping.
+	PingErr error
+	// AutostartUnit reports whether the supervised autostart unit (systemd
+	// user service / launchd agent) is installed — i.e. whether a running
+	// daemon is expected to be unit-managed rather than an ad-hoc child.
+	AutostartUnit bool
+	// PIDFilePID is the PID recorded in daemon.pid, 0 when absent/unreadable.
+	PIDFilePID int
+	// PIDVerified reports whether PIDFilePID is a live process whose
+	// cmdline identifies an agent-factory daemon (the #1004 guard against
+	// recycled PIDs).
+	PIDVerified bool
+	// BinaryDeleted reports whether the verified daemon process is
+	// executing a binary that has since been deleted or replaced on disk
+	// (/proc/<pid>/exe ends in " (deleted)") — i.e. an install happened and
+	// the daemon has not been restarted onto the new binary.
+	BinaryDeleted bool
+}
+
+// Health collects a HealthStatus. Best-effort on every axis: unavailable
+// facts (no /proc, unreadable pid file) simply leave their fields zeroed.
+func Health() HealthStatus {
+	var h HealthStatus
+	h.SocketPath, h.SocketErr = DaemonSocketPath()
+	if h.SocketPath != "" {
+		if _, err := os.Stat(h.SocketPath); err == nil {
+			h.SocketExists = true
+		}
+	}
+	h.PingErr = pingDaemon()
+	h.AutostartUnit = AutostartInstalled()
+
+	pidPath, err := daemonPIDFilePath()
+	if err == nil {
+		if data, err := os.ReadFile(pidPath); err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid > 0 {
+				h.PIDFilePID = pid
+			}
+		}
+	}
+	if h.PIDFilePID > 0 && pidLooksAlive(h.PIDFilePID) && isAgentFactoryDaemon(h.PIDFilePID) {
+		h.PIDVerified = true
+		// Linux-only freshness probe; on other platforms Readlink fails and
+		// the field stays false.
+		if target, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", h.PIDFilePID)); err == nil {
+			h.BinaryDeleted = strings.HasSuffix(target, " (deleted)")
+		}
+	}
+	return h
+}
+
+// LooksLikeDaemonCmdline reports whether a command line names an
+// agent-factory daemon process (an `af`/`agent-factory` binary carrying a
+// discrete --daemon flag). Exported for `af doctor`'s host-wide scan so its
+// matching stays in lockstep with the daemon's own PID-validation rules
+// (#1004).
+func LooksLikeDaemonCmdline(cmdline string) bool {
+	return cmdlineHasDaemonFlag(cmdline) && cmdlineIsDaemonBinary(cmdline)
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,7 +72,18 @@ af daemon uninstall    # remove the autostart unit (the daemon still starts on d
 af version             # print the version and the release URL
 af debug               # print the resolved config and its path
 af upgrade             # self-upgrade to the latest GitHub release (Linux/macOS)
+af doctor              # diagnose leaked processes/sessions/temp homes and daemon health
+af doctor --fix        # also apply the safe remediations
 af reset               # nuclear option — see below
 ```
+
+`af doctor` is read-only by default: it reports orphaned processes left behind
+by dead sessions, processes pegging a CPU core inside live sessions, `af_` tmux
+sessions with no backing record, abandoned temp agent-factory homes, and daemon
+problems (stale socket, stale pid file, a daemon still running a replaced
+binary). With `--fix` it kills orphans whose ancestry markers prove they came
+from a dead Agent Factory session and removes stale temp homes, logging each
+action; anything it cannot verify is reported, never touched. Exits 1 when
+unresolved issues remain.
 
 `af reset` attempts to stop the daemon (and reports honestly if it couldn't — e.g. a source-built `agent-factory --daemon` that left no PID file), kills **all** Agent Factory tmux sessions, removes **every linked git worktree (and its branch)** from each repo that has stored sessions — including worktrees you created by hand — and deletes all stored session records. Use it to recover from a corrupted state, not for day-to-day cleanup — `af sessions kill <title>` (or `D` in the TUI) removes a single session cleanly.

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -1,0 +1,542 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+func selfPID() int { return os.Getpid() }
+
+func tempDirDefault() string { return os.TempDir() }
+
+// runawayCPUFraction and runawayMinAge define "pegging a core for an
+// extended period": lifetime-average CPU ≥ 80% of a core for a process at
+// least 30 minutes old. A legitimate build rarely sustains that average; the
+// leaked `yes` processes from the outage sat at ~100% for 15 days.
+const (
+	runawayCPUFraction = 0.8
+	runawayMinAge      = 30 * time.Minute
+)
+
+// listTmuxSessions returns every session name on the current tmux server.
+// A missing server (exit 1) is an empty list, mirroring CleanupSessions.
+func listTmuxSessions(ctx *scanContext) []string {
+	out, err := ctx.opts.Exec.Output(exec.Command("tmux", "ls", "-F", "#{session_name}"))
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			names = append(names, line)
+		}
+	}
+	return names
+}
+
+// describeProc renders "pid 123 (yes, 99% CPU over 15d2h): yes" for findings.
+func describeProc(p proctree.Process) string {
+	desc := fmt.Sprintf("pid %d (%s", p.PID, p.Comm)
+	if frac, age, err := proctree.CPUFraction(p); err == nil {
+		desc += fmt.Sprintf(", %.0f%% CPU over %s", frac*100, formatAge(age))
+	}
+	desc += ")"
+	if cmdline := proctree.Cmdline(p.PID); cmdline != "" {
+		if len(cmdline) > 120 {
+			cmdline = cmdline[:120] + "…"
+		}
+		desc += ": " + cmdline
+	}
+	return desc
+}
+
+func formatAge(seconds float64) string {
+	d := time.Duration(seconds) * time.Second
+	switch {
+	case d >= 48*time.Hour:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+}
+
+// killFix builds a --fix action that terminates one verified process with
+// TERM→KILL escalation. Fails if the process survives SIGKILL.
+func killFix(ctx *scanContext, p proctree.Process) func() error {
+	return func() error {
+		remaining := proctree.KillEscalating(
+			[]proctree.Process{p}, ctx.opts.killGrace, ctx.opts.killTermWait, nil)
+		if len(remaining) > 0 {
+			return fmt.Errorf("process %d survived SIGKILL", p.PID)
+		}
+		return nil
+	}
+}
+
+// checkDaemonHealth reports on the active install's daemon: socket, ping,
+// autostart unit, pid file, and binary freshness. Read-only; never fixable
+// (restarting the daemon is a user decision).
+func checkDaemonHealth(ctx *scanContext, report *Report) {
+	h := daemon.Health()
+	if h.SocketErr != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "daemon-health",
+			Detail: fmt.Sprintf("cannot resolve daemon socket path: %v", h.SocketErr),
+		})
+		return
+	}
+	unit := "ad-hoc (no autostart unit; `af daemon install` sets one up)"
+	if h.AutostartUnit {
+		unit = "autostart unit installed"
+	}
+	switch {
+	case h.PingErr == nil:
+		report.OK = append(report.OK, fmt.Sprintf("daemon: responding on %s; %s", h.SocketPath, unit))
+	case !h.SocketExists:
+		report.OK = append(report.OK, "daemon: not running (starts on demand); "+unit)
+	default:
+		report.Findings = append(report.Findings, Finding{
+			Check: "daemon-health",
+			Detail: fmt.Sprintf("socket %s exists but the daemon is not responding (%v) — "+
+				"likely a stale socket from a crashed daemon", h.SocketPath, h.PingErr),
+		})
+	}
+	if h.PIDFilePID > 0 && !h.PIDVerified && h.PingErr != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check: "daemon-health",
+			Detail: fmt.Sprintf("daemon.pid records pid %d but no agent-factory daemon is running under it "+
+				"(stale pid file)", h.PIDFilePID),
+		})
+	}
+	if h.BinaryDeleted {
+		report.Findings = append(report.Findings, Finding{
+			Check: "daemon-health",
+			Detail: fmt.Sprintf("daemon pid %d is running a binary that was since replaced on disk — "+
+				"it will keep running the old version until restarted", h.PIDFilePID),
+		})
+	}
+}
+
+// checkOrphanedProcesses finds processes carrying the AF_SESSION ancestry
+// marker. Marker + dead session = verified orphan (killable with --fix);
+// marker + live session but outside its pane trees = escaped (report-only);
+// no marker but a TMUX env var pointing at a dead server = possible orphan
+// (report-only — could belong to any tmux, not necessarily agent-factory).
+func checkOrphanedProcesses(ctx *scanContext, report *Report) {
+	if ctx.snap == nil {
+		return
+	}
+	live := map[string]bool{}
+	for _, name := range listTmuxSessions(ctx) {
+		live[name] = true
+	}
+
+	marked := map[string][]proctree.Process{}
+	var possibles []proctree.Process
+	for pid, p := range ctx.snap {
+		if ctx.selfAncestors[pid] {
+			continue
+		}
+		if name, ok := proctree.EnvValue(pid, tmux.EnvMarkerSession); ok && name != "" {
+			marked[name] = append(marked[name], p)
+			continue
+		}
+		if tmuxEnv, ok := proctree.EnvValue(pid, "TMUX"); ok && tmuxServerDead(ctx, tmuxEnv) {
+			possibles = append(possibles, p)
+		}
+	}
+
+	for _, name := range sortedKeys(marked) {
+		procs := marked[name]
+		sort.Slice(procs, func(i, j int) bool { return procs[i].PID < procs[j].PID })
+		if live[name] {
+			inSession := map[int]bool{}
+			for _, p := range tmux.SessionProcessTrees(ctx.opts.Exec, name) {
+				inSession[p.PID] = true
+			}
+			for _, p := range procs {
+				if inSession[p.PID] {
+					continue
+				}
+				report.Findings = append(report.Findings, Finding{
+					Check: "escaped-process",
+					Detail: fmt.Sprintf("%s escaped the pane tree of live session %s "+
+						"(left alone while the session is alive)", describeProc(p), name),
+				})
+			}
+			continue
+		}
+		home, _ := proctree.EnvValue(procs[0].PID, tmux.EnvMarkerHome)
+		origin := name
+		if home != "" {
+			origin += " (home " + home + ")"
+		}
+		for _, p := range procs {
+			report.Findings = append(report.Findings, Finding{
+				Check:     "orphaned-process",
+				Detail:    fmt.Sprintf("%s was spawned by dead session %s", describeProc(p), origin),
+				FixAction: fmt.Sprintf("kill pid %d", p.PID),
+				fix:       killFix(ctx, p),
+			})
+		}
+	}
+
+	// Sort by CPU so a core-burning `yes` outranks fifty idle shells, and
+	// cap the listing — on a long-lived dev box this class is numerous and
+	// mostly idle, and it is report-only by definition.
+	type ranked struct {
+		p    proctree.Process
+		frac float64
+	}
+	rankedPossibles := make([]ranked, 0, len(possibles))
+	for _, p := range possibles {
+		frac, _, _ := proctree.CPUFraction(p)
+		rankedPossibles = append(rankedPossibles, ranked{p, frac})
+	}
+	sort.Slice(rankedPossibles, func(i, j int) bool {
+		if rankedPossibles[i].frac != rankedPossibles[j].frac {
+			return rankedPossibles[i].frac > rankedPossibles[j].frac
+		}
+		return rankedPossibles[i].p.PID < rankedPossibles[j].p.PID
+	})
+	const maxPossibleOrphans = 15
+	for i, r := range rankedPossibles {
+		if i == maxPossibleOrphans {
+			report.Findings = append(report.Findings, Finding{
+				Check: "possible-orphan",
+				Detail: fmt.Sprintf("… and %d more processes of dead tmux servers (all idle or near-idle; "+
+					"none carry an agent-factory marker, so none are killed)", len(rankedPossibles)-maxPossibleOrphans),
+			})
+			break
+		}
+		report.Findings = append(report.Findings, Finding{
+			Check: "possible-orphan",
+			Detail: fmt.Sprintf("%s belongs to a dead tmux server (no agent-factory marker — "+
+				"cannot verify ownership, so it is reported, not killed)", describeProc(r.p)),
+		})
+	}
+}
+
+// tmuxServerDead parses a TMUX env value ("socketPath,serverPID,sessionIdx")
+// and reports whether the server it names is gone. Unparseable values are
+// treated as alive (never accuse on garbage).
+func tmuxServerDead(ctx *scanContext, tmuxEnv string) bool {
+	parts := strings.Split(tmuxEnv, ",")
+	if len(parts) < 2 {
+		return false
+	}
+	serverPID, err := strconv.Atoi(parts[1])
+	if err != nil || serverPID <= 0 {
+		return false
+	}
+	server, alive := ctx.snap[serverPID]
+	if alive && strings.HasPrefix(server.Comm, "tmux") {
+		return false
+	}
+	// PID gone or recycled to a non-tmux process; confirm via the socket.
+	if _, err := os.Stat(parts[0]); err == nil && alive {
+		// Socket still present and some process holds the PID — too
+		// ambiguous to call dead.
+		return false
+	}
+	return true
+}
+
+// checkRunawayChildren reports (never kills) descendants of live af_
+// sessions that have averaged a pegged core for an extended period.
+func checkRunawayChildren(ctx *scanContext, report *Report) {
+	if ctx.snap == nil {
+		return
+	}
+	for _, name := range listTmuxSessions(ctx) {
+		if !strings.HasPrefix(name, tmux.TmuxPrefix) {
+			continue
+		}
+		procs := tmux.SessionProcessTrees(ctx.opts.Exec, name)
+		sort.Slice(procs, func(i, j int) bool { return procs[i].PID < procs[j].PID })
+		for _, p := range procs {
+			if ctx.selfAncestors[p.PID] {
+				continue
+			}
+			frac, age, err := proctree.CPUFraction(p)
+			if err != nil || frac < runawayCPUFraction || age < runawayMinAge.Seconds() {
+				continue
+			}
+			report.Findings = append(report.Findings, Finding{
+				Check: "runaway-cpu",
+				Detail: fmt.Sprintf("%s in live session %s has averaged a pegged core — "+
+					"check the session; doctor never kills children of live sessions", describeProc(p), name),
+			})
+		}
+	}
+}
+
+// checkLeakedTmuxSessions reports af_ tmux sessions with no backing record
+// in this home's storage. Report-only even under --fix: a session with no
+// record here may be owned by another agent-factory home on the same tmux
+// server, and killing someone else's live session is worse than a leak.
+func checkLeakedTmuxSessions(ctx *scanContext, report *Report) {
+	recorded := recordedTmuxNames(ctx.opts.ConfigDir)
+	var leaked []string
+	for _, name := range listTmuxSessions(ctx) {
+		if strings.HasPrefix(name, tmux.TmuxPrefix) && !recorded[name] {
+			leaked = append(leaked, name)
+		}
+	}
+	sort.Strings(leaked)
+	for _, name := range leaked {
+		origin := "no ancestry marker"
+		if procs := tmux.SessionProcessTrees(ctx.opts.Exec, name); len(procs) > 0 {
+			if home, ok := proctree.EnvValue(procs[0].PID, tmux.EnvMarkerHome); ok {
+				if filepath.Clean(home) == filepath.Clean(ctx.opts.ConfigDir) {
+					origin = "created by this install"
+				} else {
+					origin = "created by another agent-factory home: " + home
+				}
+			}
+		}
+		report.Findings = append(report.Findings, Finding{
+			Check: "leaked-tmux-session",
+			Detail: fmt.Sprintf("tmux session %s has no backing record in %s (%s); "+
+				"kill it with: tmux kill-session -t '=%s:'", name, ctx.opts.ConfigDir, origin, name),
+		})
+	}
+}
+
+// recordedTmuxNames loads every persisted tmux session name (agent + tabs)
+// from this home's storage, read-only. Legacy records without an explicit
+// TmuxName fall back to the derived repo-scoped name.
+func recordedTmuxNames(configDir string) map[string]bool {
+	names := map[string]bool{}
+	// Doctor may be pointed at a ConfigDir other than the ambient one only
+	// in tests, which also set AGENT_FACTORY_HOME — LoadAllRepoInstances
+	// always reads the ambient home.
+	all, err := config.LoadAllRepoInstances()
+	if err != nil {
+		return names
+	}
+	type tabRec struct {
+		TmuxName string `json:"tmux_name"`
+	}
+	type instRec struct {
+		Title    string   `json:"title"`
+		Path     string   `json:"path"`
+		TmuxName string   `json:"tmux_name"`
+		Tabs     []tabRec `json:"tabs"`
+	}
+	for _, raw := range all {
+		var instances []instRec
+		if err := json.Unmarshal(raw, &instances); err != nil {
+			continue
+		}
+		for _, inst := range instances {
+			if inst.TmuxName != "" {
+				names[inst.TmuxName] = true
+			} else if inst.Title != "" {
+				names[tmux.NewTmuxSessionForRepo(inst.Title, inst.Path, "").SanitizedName()] = true
+			}
+			for _, tab := range inst.Tabs {
+				if tab.TmuxName != "" {
+					names[tab.TmuxName] = true
+				}
+			}
+		}
+	}
+	return names
+}
+
+// afHomeMarkers are the files/dirs whose presence identifies a directory as
+// an agent-factory home. Two or more must match before doctor will even
+// report a directory, let alone remove it.
+var afHomeMarkers = []string{
+	config.ConfigFileName, "state.json", "instances", "daemon.sock", "daemon.pid", "agent-factory.log",
+}
+
+// checkStaleTempHomes finds abandoned agent-factory homes under the temp
+// dir (leaked by tests/debug runs — the #1093 immortal-daemon fuel). A home
+// is stale only when nothing references it: no live process has it as
+// AGENT_FACTORY_HOME, its daemon.pid (if any) is dead, and it has not been
+// touched for MinTempHomeAge.
+func checkStaleTempHomes(ctx *scanContext, report *Report) {
+	tempDir := filepath.Clean(ctx.opts.TempDir)
+	activeHome := filepath.Clean(ctx.opts.ConfigDir)
+
+	homesInUse := map[string]bool{}
+	if ctx.snap != nil {
+		for pid := range ctx.snap {
+			if home, ok := proctree.EnvValue(pid, "AGENT_FACTORY_HOME"); ok && home != "" {
+				homesInUse[filepath.Clean(home)] = true
+			}
+		}
+	}
+
+	for _, dir := range candidateTempHomes(tempDir) {
+		dir = filepath.Clean(dir)
+		if dir == activeHome || !isAFHome(dir) {
+			continue
+		}
+		if homesInUse[dir] || tempHomeDaemonAlive(dir) {
+			report.OK = append(report.OK, fmt.Sprintf("temp home %s is in use (live process references it)", dir))
+			continue
+		}
+		age := timeSince(newestMtime(dir))
+		if age < ctx.opts.MinTempHomeAge {
+			continue
+		}
+		// Containment re-check before offering an rm -rf.
+		rel, err := filepath.Rel(tempDir, dir)
+		if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		removeDir := dir
+		report.Findings = append(report.Findings, Finding{
+			Check: "stale-temp-home",
+			Detail: fmt.Sprintf("abandoned agent-factory home %s (untouched for %s)",
+				dir, formatAge(age.Seconds())),
+			FixAction: "remove " + dir,
+			fix:       func() error { return os.RemoveAll(removeDir) },
+		})
+	}
+}
+
+// timeSince is time.Since, indirected so tests can pin the clock if needed.
+var timeSince = time.Since
+
+// candidateTempHomes lists directories one and two levels below tempDir —
+// Go tests produce /tmp/TestName123/001-style homes, manual runs
+// /tmp/tmp.XXXX ones.
+func candidateTempHomes(tempDir string) []string {
+	var out []string
+	level1, err := os.ReadDir(tempDir)
+	if err != nil {
+		return nil
+	}
+	for _, e := range level1 {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(tempDir, e.Name())
+		out = append(out, dir)
+		level2, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e2 := range level2 {
+			if e2.IsDir() {
+				out = append(out, filepath.Join(dir, e2.Name()))
+			}
+		}
+	}
+	return out
+}
+
+func isAFHome(dir string) bool {
+	found := 0
+	for _, marker := range afHomeMarkers {
+		if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
+			found++
+		}
+	}
+	return found >= 2
+}
+
+// tempHomeDaemonAlive reports whether the home's daemon.pid names a live
+// agent-factory daemon.
+func tempHomeDaemonAlive(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "daemon.pid"))
+	if err != nil {
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return false
+	}
+	return daemon.LooksLikeDaemonCmdline(proctree.Cmdline(pid))
+}
+
+// newestMtime returns the most recent mtime among the dir itself and its
+// marker files — a fair "last touched" signal without a full tree walk.
+func newestMtime(dir string) time.Time {
+	newest := time.Time{}
+	consider := func(path string) {
+		if info, err := os.Stat(path); err == nil && info.ModTime().After(newest) {
+			newest = info.ModTime()
+		}
+	}
+	consider(dir)
+	for _, marker := range afHomeMarkers {
+		consider(filepath.Join(dir, marker))
+	}
+	return newest
+}
+
+// checkForeignDaemons finds agent-factory daemon processes serving a home
+// other than the active one. A daemon whose home directory no longer exists
+// is unambiguously broken (it can only burn CPU and run stale cron tasks —
+// #1093) and is killable with --fix; one whose home still exists might be an
+// intentional second install, so it is reported only.
+func checkForeignDaemons(ctx *scanContext, report *Report) {
+	if ctx.snap == nil {
+		return
+	}
+	defaultHome := ""
+	if home, err := os.UserHomeDir(); err == nil {
+		defaultHome = filepath.Join(home, ".agent-factory")
+	}
+	activeHome := filepath.Clean(ctx.opts.ConfigDir)
+
+	pids := make([]int, 0, len(ctx.snap))
+	for pid := range ctx.snap {
+		pids = append(pids, pid)
+	}
+	sort.Ints(pids)
+	for _, pid := range pids {
+		if ctx.selfAncestors[pid] {
+			continue
+		}
+		p := ctx.snap[pid]
+		cmdline := proctree.Cmdline(pid)
+		if cmdline == "" || !daemon.LooksLikeDaemonCmdline(cmdline) {
+			continue
+		}
+		home, ok := proctree.EnvValue(pid, "AGENT_FACTORY_HOME")
+		if !ok || home == "" {
+			home = defaultHome
+		}
+		home = filepath.Clean(home)
+		if home == activeHome || home == "" {
+			continue // this install's daemon; covered by checkDaemonHealth
+		}
+		if _, err := os.Stat(home); err != nil {
+			report.Findings = append(report.Findings, Finding{
+				Check: "foreign-daemon",
+				Detail: fmt.Sprintf("%s serves agent-factory home %s which no longer exists "+
+					"(abandoned daemon will run its cron tasks forever)", describeProc(p), home),
+				FixAction: fmt.Sprintf("kill pid %d", pid),
+				fix:       killFix(ctx, p),
+			})
+		} else {
+			report.Findings = append(report.Findings, Finding{
+				Check: "foreign-daemon",
+				Detail: fmt.Sprintf("%s serves a different agent-factory home (%s) — "+
+					"left alone in case it is intentional", describeProc(p), home),
+			})
+		}
+	}
+}

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -182,18 +182,39 @@ func checkOrphanedProcesses(ctx *scanContext, report *Report) {
 			}
 			continue
 		}
-		home, _ := proctree.EnvValue(procs[0].PID, tmux.EnvMarkerHome)
-		origin := name
-		if home != "" {
-			origin += " (home " + home + ")"
-		}
 		for _, p := range procs {
-			report.Findings = append(report.Findings, Finding{
-				Check:     "orphaned-process",
-				Detail:    fmt.Sprintf("%s was spawned by dead session %s", describeProc(p), origin),
-				FixAction: fmt.Sprintf("kill pid %d", p.PID),
-				fix:       killFix(ctx, p),
-			})
+			// A kill requires a PROVEN home match, not just a dead-looking
+			// session: another agent-factory home (e.g. a play-test sandbox
+			// on a private `tmux -L` server) has sessions that are invisible
+			// to this server's live list, so its perfectly healthy processes
+			// would otherwise masquerade as verified orphans here. Foreign
+			// or missing AF_HOME downgrades to report-only.
+			home, hasHome := proctree.EnvValue(p.PID, tmux.EnvMarkerHome)
+			switch {
+			case hasHome && filepath.Clean(home) == filepath.Clean(ctx.opts.ConfigDir):
+				report.Findings = append(report.Findings, Finding{
+					Check: "orphaned-process",
+					Detail: fmt.Sprintf("%s was spawned by dead session %s (home %s)",
+						describeProc(p), name, home),
+					FixAction: fmt.Sprintf("kill pid %d", p.PID),
+					fix:       killFix(ctx, p),
+				})
+			case hasHome:
+				report.Findings = append(report.Findings, Finding{
+					Check: "orphaned-process",
+					Detail: fmt.Sprintf("%s marks dead session %s but belongs to another "+
+						"agent-factory home (%s) — its session may be live on that install's "+
+						"private tmux server, so it is not fixed from here; run `af doctor` "+
+						"with that home active", describeProc(p), name, home),
+				})
+			default:
+				report.Findings = append(report.Findings, Finding{
+					Check: "orphaned-process",
+					Detail: fmt.Sprintf("%s marks dead session %s but carries no readable "+
+						"home marker — cannot prove which install owns it, so it is "+
+						"reported, not killed", describeProc(p), name),
+				})
+			}
 		}
 	}
 

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -1,0 +1,241 @@
+// Package doctor implements `af doctor` (#1044, #1104): a read-only sweep
+// that detects the leak classes behind the 2026-07-03 outage — orphaned
+// session descendants burning CPU forever, runaway children of live
+// sessions, af_ tmux sessions with no backing record, stale temp
+// agent-factory homes, and unhealthy daemons — and, with --fix, applies only
+// the remediations whose ancestry is verified.
+//
+// The safety stance is asymmetric by design: detection is generous,
+// remediation is conservative. A process is only ever killed when its
+// AF_SESSION env marker proves it was spawned inside an af tmux session that
+// no longer exists, and every signal re-verifies the (pid, starttime)
+// identity. Anything ambiguous — a process that merely looks orphaned, a
+// session that might belong to another agent-factory home — is reported,
+// never touched.
+package doctor
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// Finding is one detected problem. FixAction is empty for report-only
+// findings; when set, applying opts.Fix runs the attached fix.
+type Finding struct {
+	// Check is the detector that produced this finding (stable slug).
+	Check string
+	// Detail is the human-readable description.
+	Detail string
+	// FixAction describes what --fix will do; empty means report-only.
+	FixAction string
+	fix       func() error
+	// Fixed / FixErr record the outcome when a fix was attempted.
+	Fixed  bool
+	FixErr error
+}
+
+// Report is the result of a doctor run.
+type Report struct {
+	// OK holds informational healthy lines, grouped by section.
+	OK []string
+	// Findings holds detected problems in detection order.
+	Findings []Finding
+}
+
+// UnresolvedCount returns how many findings remain un-remediated (either
+// report-only, fix not requested, or fix failed).
+func (r *Report) UnresolvedCount() int {
+	n := 0
+	for _, f := range r.Findings {
+		if !f.Fixed {
+			n++
+		}
+	}
+	return n
+}
+
+// Options configures a doctor run. Zero values resolve to production
+// defaults; tests override ConfigDir/TempDir/Exec to stay hermetic.
+type Options struct {
+	// Fix applies the safe remediations instead of only reporting.
+	Fix bool
+	// ConfigDir is the active agent-factory home; defaults to
+	// config.GetConfigDir().
+	ConfigDir string
+	// TempDir is the temp root scanned for stale AF homes; defaults to
+	// os.TempDir().
+	TempDir string
+	// Exec runs tmux commands; defaults to cmd.MakeExecutor().
+	Exec cmd.Executor
+	// MinTempHomeAge is how old an unused temp home must be before it
+	// counts as stale; defaults to 7 days (long enough that no plausible
+	// test or debug run is still coming back for it).
+	MinTempHomeAge time.Duration
+
+	// Escalation windows for --fix kills; default to 2s/2s.
+	killGrace    time.Duration
+	killTermWait time.Duration
+
+	// snapshot overrides the /proc scan; tests inject a snapshot containing
+	// only their own spawned processes so a --fix run can never act on
+	// anything outside the test.
+	snapshot func() (map[int]proctree.Process, error)
+}
+
+// scanContext carries the shared, immutable inputs of one run.
+type scanContext struct {
+	opts Options
+	// snap is the /proc snapshot; nil when /proc is unavailable, in which
+	// case the process-based checks degrade to no-ops.
+	snap map[int]proctree.Process
+	// selfAncestors holds our own PID and every ancestor — never proposed
+	// for a kill, no matter what markers they carry.
+	selfAncestors map[int]bool
+}
+
+// Run executes all checks and (when opts.Fix) applies the safe remediations.
+func Run(opts Options) (*Report, error) {
+	if opts.ConfigDir == "" {
+		dir, err := config.GetConfigDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolving agent-factory home: %w", err)
+		}
+		opts.ConfigDir = dir
+	}
+	if opts.TempDir == "" {
+		opts.TempDir = tempDirDefault()
+	}
+	if opts.Exec == nil {
+		opts.Exec = cmd.MakeExecutor()
+	}
+	if opts.MinTempHomeAge == 0 {
+		opts.MinTempHomeAge = 7 * 24 * time.Hour
+	}
+	if opts.killGrace == 0 {
+		opts.killGrace = 2 * time.Second
+	}
+	if opts.killTermWait == 0 {
+		opts.killTermWait = 2 * time.Second
+	}
+
+	if opts.snapshot == nil {
+		opts.snapshot = proctree.Snapshot
+	}
+
+	ctx := &scanContext{opts: opts, selfAncestors: map[int]bool{}}
+	if snap, err := opts.snapshot(); err == nil {
+		ctx.snap = snap
+		for pid := range selfAndAncestors(snap) {
+			ctx.selfAncestors[pid] = true
+		}
+	}
+
+	report := &Report{}
+	checkDaemonHealth(ctx, report)
+	checkOrphanedProcesses(ctx, report)
+	checkRunawayChildren(ctx, report)
+	checkLeakedTmuxSessions(ctx, report)
+	checkStaleTempHomes(ctx, report)
+	checkForeignDaemons(ctx, report)
+
+	if opts.Fix {
+		for i := range report.Findings {
+			f := &report.Findings[i]
+			if f.fix == nil {
+				continue
+			}
+			if err := f.fix(); err != nil {
+				f.FixErr = err
+				log.WarningLog.Printf("doctor --fix: %s: %s: %v", f.Check, f.FixAction, err)
+			} else {
+				f.Fixed = true
+				log.InfoLog.Printf("doctor --fix: %s: %s", f.Check, f.FixAction)
+			}
+		}
+	}
+	return report, nil
+}
+
+// selfAndAncestors walks from our own PID to init, collecting every PID on
+// the way. Bounded by snapshot lookups, so a cyclic/garbled snapshot cannot
+// loop forever.
+func selfAndAncestors(snap map[int]proctree.Process) map[int]bool {
+	out := map[int]bool{}
+	pid := selfPID()
+	for i := 0; i < 128; i++ {
+		if pid <= 0 || out[pid] {
+			break
+		}
+		out[pid] = true
+		p, ok := snap[pid]
+		if !ok {
+			break
+		}
+		pid = p.PPID
+	}
+	return out
+}
+
+// Render writes the human-readable report. fixMode changes the trailing
+// hints (no "--fix would..." when fixes were just applied).
+func Render(w io.Writer, r *Report, fixMode bool) {
+	if len(r.OK) > 0 {
+		for _, line := range r.OK {
+			fmt.Fprintf(w, "ok: %s\n", line)
+		}
+	}
+	if len(r.Findings) == 0 {
+		fmt.Fprintf(w, "\nNo problems found.\n")
+		return
+	}
+	fmt.Fprintln(w)
+	for _, f := range r.Findings {
+		switch {
+		case f.Fixed:
+			fmt.Fprintf(w, "fixed: [%s] %s (%s)\n", f.Check, f.Detail, f.FixAction)
+		case f.FixErr != nil:
+			fmt.Fprintf(w, "fix-failed: [%s] %s (%s: %v)\n", f.Check, f.Detail, f.FixAction, f.FixErr)
+		case f.FixAction != "" && !fixMode:
+			fmt.Fprintf(w, "issue: [%s] %s (--fix will %s)\n", f.Check, f.Detail, f.FixAction)
+		default:
+			fmt.Fprintf(w, "issue: [%s] %s\n", f.Check, f.Detail)
+		}
+	}
+	unresolved := r.UnresolvedCount()
+	fixed := len(r.Findings) - unresolved
+	switch {
+	case fixMode && fixed > 0:
+		fmt.Fprintf(w, "\n%d issue(s) found, %d fixed, %d remaining.\n", len(r.Findings), fixed, unresolved)
+	case !fixMode && hasFixable(r):
+		fmt.Fprintf(w, "\n%d issue(s) found. Re-run with --fix to apply the safe remediations.\n", len(r.Findings))
+	default:
+		fmt.Fprintf(w, "\n%d issue(s) found.\n", len(r.Findings))
+	}
+}
+
+func hasFixable(r *Report) bool {
+	for _, f := range r.Findings {
+		if f.FixAction != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedKeys returns m's keys in stable order so report output is
+// deterministic.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -1,0 +1,379 @@
+package doctor
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/stretchr/testify/require"
+)
+
+// Every test here is hermetic by construction (#1104 hard rules): the AF
+// home is a temp dir (TestMain sandbox + per-test overrides), tmux runs on a
+// private server (testguard.IsolateTmux), the /proc snapshot handed to Run
+// is filtered to processes this test spawned, and every spawned process is
+// killed on cleanup. Nothing here can observe — let alone signal — the real
+// daemon, the real ~/.agent-factory, or the developer's tmux server.
+
+func TestMain(m *testing.M) {
+	verifyRealConfig := testguard.ConfigTripwire()
+	restoreHome := testguard.SandboxHome()
+	code := m.Run()
+	restoreHome()
+	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	os.Exit(code)
+}
+
+// testOptions returns Options scoped entirely to this test: temp home, temp
+// scan root, fast kill windows, and a snapshot containing only pids.
+func testOptions(t *testing.T, fix bool, pids ...int) Options {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	return Options{
+		Fix:            fix,
+		ConfigDir:      home,
+		TempDir:        t.TempDir(),
+		Exec:           cmd.MakeExecutor(),
+		MinTempHomeAge: time.Hour,
+		killGrace:      100 * time.Millisecond,
+		killTermWait:   200 * time.Millisecond,
+		snapshot:       snapshotOf(t, pids...),
+	}
+}
+
+// snapshotOf builds a snapshot function restricted to the given pids (read
+// from the real /proc), so Run can never act outside the test's processes.
+func snapshotOf(t *testing.T, pids ...int) func() (map[int]proctree.Process, error) {
+	t.Helper()
+	return func() (map[int]proctree.Process, error) {
+		full, err := proctree.Snapshot()
+		if err != nil {
+			return nil, err
+		}
+		out := map[int]proctree.Process{}
+		for _, pid := range pids {
+			if p, ok := full[pid]; ok {
+				out[pid] = p
+			}
+		}
+		return out, nil
+	}
+}
+
+// spawnWithEnv starts a long-lived child owned by this test, with argv0 and
+// args controlling how its cmdline reads and env appended to the test's
+// environment. The child is a shell blocked on its `read` builtin against a
+// pipe this test holds open — a single process with NO descendants, so the
+// cleanup Kill can never orphan anything (a forked `sleep` here once leaked
+// the very orphans this suite hunts). Waits until the child's /proc environ
+// is readable (the fork→exec window would otherwise race the scan).
+func spawnWithEnv(t *testing.T, argv0 string, extraArgs []string, env map[string]string) proctree.Process {
+	t.Helper()
+	stdinR, stdinW, err := os.Pipe()
+	require.NoError(t, err)
+	args := append([]string{argv0, "-c", "read line"}, extraArgs...)
+	c := &exec.Cmd{Path: "/bin/sh", Args: args, Env: os.Environ(), Stdin: stdinR}
+	for k, v := range env {
+		c.Env = append(c.Env, k+"="+v)
+	}
+	require.NoError(t, c.Start())
+	_ = stdinR.Close() // child holds its own copy
+	t.Cleanup(func() {
+		_ = c.Process.Kill()
+		_ = stdinW.Close()
+		_, _ = c.Process.Wait()
+	})
+	// Reap promptly when a doctor --fix kills the child mid-test so the pid
+	// doesn't linger as a zombie in later snapshots (zombies still answer
+	// signal 0).
+	go func() { _, _ = c.Process.Wait() }()
+
+	require.Eventually(t, func() bool {
+		_, ok := proctree.EnvValue(c.Process.Pid, "PATH")
+		if len(env) > 0 {
+			for k := range env {
+				_, ok2 := proctree.EnvValue(c.Process.Pid, k)
+				return ok2
+			}
+		}
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "child environ never became readable")
+
+	snap, err := proctree.Snapshot()
+	require.NoError(t, err)
+	p, ok := snap[c.Process.Pid]
+	require.True(t, ok, "spawned child %d missing from snapshot", c.Process.Pid)
+	require.Zero(t, len(proctree.TreeOf(snap, c.Process.Pid))-1,
+		"test child must have no descendants — cleanup would orphan them")
+	return p
+}
+
+func alive(p proctree.Process) bool { return proctree.AliveSame(p) }
+
+func findByCheck(r *Report, check string) []Finding {
+	var out []Finding
+	for _, f := range r.Findings {
+		if f.Check == check {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// TestOrphanedProcessDetectedAndFixed is the doctor half of the #1104
+// regression: a process whose AF_SESSION marker names a dead session is a
+// verified orphan — reported without --fix, killed with it.
+func TestOrphanedProcessDetectedAndFixed(t *testing.T) {
+	testguard.IsolateTmux(t) // private server: the marked session is dead by construction
+
+	orphan := spawnWithEnv(t, "sh", nil, map[string]string{
+		"AF_SESSION": "af_doctor-dead-session",
+		"AF_HOME":    "/tmp/some-old-home",
+	})
+
+	// Read-only pass: reported, not touched.
+	report, err := Run(testOptions(t, false, orphan.PID))
+	require.NoError(t, err)
+	findings := findByCheck(report, "orphaned-process")
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Detail, "af_doctor-dead-session")
+	require.NotEmpty(t, findings[0].FixAction)
+	require.False(t, findings[0].Fixed)
+	require.True(t, alive(orphan), "read-only doctor run must not signal anything")
+
+	// --fix pass: killed, with the outcome recorded.
+	report, err = Run(testOptions(t, true, orphan.PID))
+	require.NoError(t, err)
+	findings = findByCheck(report, "orphaned-process")
+	require.Len(t, findings, 1)
+	require.True(t, findings[0].Fixed, "fix outcome: %v", findings[0].FixErr)
+	require.Eventually(t, func() bool { return !alive(orphan) }, 5*time.Second, 25*time.Millisecond,
+		"verified orphan must be dead after --fix")
+	require.Zero(t, report.UnresolvedCount())
+}
+
+// TestMarkedProcessOfLiveSessionIsNeverKilled: a marker pointing at a LIVE
+// session means the process escaped its pane but the session still owns it —
+// report-only even under --fix.
+func TestMarkedProcessOfLiveSessionIsNeverKilled(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	const name = "af_doctor-live-session"
+	out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sleep 300").CombinedOutput()
+	require.NoError(t, err, "tmux new-session: %s", out)
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", "="+name+":").Run() })
+
+	escapee := spawnWithEnv(t, "sh", nil, map[string]string{"AF_SESSION": name})
+
+	report, err := Run(testOptions(t, true, escapee.PID))
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "orphaned-process"))
+	escaped := findByCheck(report, "escaped-process")
+	require.Len(t, escaped, 1)
+	require.Empty(t, escaped[0].FixAction, "escaped processes of live sessions are report-only")
+	require.True(t, alive(escapee), "process of a live session must never be killed")
+}
+
+// TestLeakedTmuxSessionReportedNotKilled: an af_ session with no backing
+// record is reported with a suggested command, and --fix must NOT kill it
+// (it may belong to another agent-factory home).
+func TestLeakedTmuxSessionReportedNotKilled(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	const name = "af_doctor-leaked"
+	out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sleep 300").CombinedOutput()
+	require.NoError(t, err, "tmux new-session: %s", out)
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", "="+name+":").Run() })
+
+	report, err := Run(testOptions(t, true))
+	require.NoError(t, err)
+	leaked := findByCheck(report, "leaked-tmux-session")
+	require.Len(t, leaked, 1)
+	require.Contains(t, leaked[0].Detail, name)
+	require.Empty(t, leaked[0].FixAction)
+	require.NoError(t, exec.Command("tmux", "has-session", "-t", "="+name+":").Run(),
+		"leaked session must survive --fix")
+}
+
+// TestStaleTempHomeRemovedWithFix: an abandoned AF home under the temp root
+// is detected by its structural markers and removed by --fix; a fresh or
+// referenced home is spared.
+func TestStaleTempHomeRemovedWithFix(t *testing.T) {
+	testguard.IsolateTmux(t)
+	opts := testOptions(t, true)
+
+	old := time.Now().Add(-48 * time.Hour)
+	makeHome := func(name string) string {
+		dir := filepath.Join(opts.TempDir, name)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte("{}"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "state.json"), []byte("{}"), 0644))
+		for _, p := range []string{filepath.Join(dir, "config.json"), filepath.Join(dir, "state.json"), dir} {
+			require.NoError(t, os.Chtimes(p, old, old))
+		}
+		return dir
+	}
+	stale := makeHome("tmp.stale-home")
+	fresh := filepath.Join(opts.TempDir, "tmp.fresh-home")
+	require.NoError(t, os.MkdirAll(fresh, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(fresh, "config.json"), []byte("{}"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(fresh, "state.json"), []byte("{}"), 0644))
+	notAHome := filepath.Join(opts.TempDir, "random-dir")
+	require.NoError(t, os.MkdirAll(notAHome, 0755))
+	require.NoError(t, os.Chtimes(notAHome, old, old))
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+	findings := findByCheck(report, "stale-temp-home")
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Detail, stale)
+	require.True(t, findings[0].Fixed, "fix outcome: %v", findings[0].FixErr)
+
+	require.NoDirExists(t, stale, "stale home must be removed by --fix")
+	require.DirExists(t, fresh, "recently-touched home must be spared")
+	require.DirExists(t, notAHome, "a plain directory without AF markers must never be touched")
+}
+
+// TestInUseTempHomeSpared: a temp home referenced by a live process's
+// AGENT_FACTORY_HOME is in use, no matter how old it is.
+func TestInUseTempHomeSpared(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	// Spawn first so the home exists before the options' TempDir scan.
+	tempRoot := t.TempDir()
+	dir := filepath.Join(tempRoot, "tmp.in-use-home")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte("{}"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "state.json"), []byte("{}"), 0644))
+	old := time.Now().Add(-48 * time.Hour)
+	for _, p := range []string{filepath.Join(dir, "config.json"), filepath.Join(dir, "state.json"), dir} {
+		require.NoError(t, os.Chtimes(p, old, old))
+	}
+	user := spawnWithEnv(t, "sh", nil, map[string]string{"AGENT_FACTORY_HOME": dir})
+
+	opts := testOptions(t, true, user.PID)
+	opts.TempDir = tempRoot
+	report, err := Run(opts)
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "stale-temp-home"))
+	require.DirExists(t, dir, "an in-use home must never be removed")
+}
+
+// TestForeignDaemonHandling: a daemon serving a deleted home is killable
+// with --fix; one serving an existing (but different) home is report-only.
+func TestForeignDaemonHandling(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	// argv0 "af" + a --daemon token makes the cmdline match the daemon
+	// shape while really just being our own sleeping shell.
+	deadHome := filepath.Join(t.TempDir(), "gone")
+	broken := spawnWithEnv(t, "af", []string{"--daemon"}, map[string]string{"AGENT_FACTORY_HOME": deadHome})
+
+	liveHome := t.TempDir()
+	intentional := spawnWithEnv(t, "af", []string{"--daemon"}, map[string]string{"AGENT_FACTORY_HOME": liveHome})
+
+	report, err := Run(testOptions(t, true, broken.PID, intentional.PID))
+	require.NoError(t, err)
+	findings := findByCheck(report, "foreign-daemon")
+	require.Len(t, findings, 2)
+
+	var fixed, reported int
+	for _, f := range findings {
+		if f.Fixed {
+			fixed++
+			require.Contains(t, f.Detail, deadHome)
+		} else {
+			reported++
+			require.Empty(t, f.FixAction)
+			require.Contains(t, f.Detail, liveHome)
+		}
+	}
+	require.Equal(t, 1, fixed, "the daemon with a deleted home must be killed")
+	require.Equal(t, 1, reported, "the daemon with an existing home must be left alone")
+	require.Eventually(t, func() bool { return !alive(broken) }, 5*time.Second, 25*time.Millisecond)
+	require.True(t, alive(intentional))
+}
+
+// TestCleanRunHasNoFindings: an empty environment yields a clean bill of
+// health and exit-0 semantics.
+func TestCleanRunHasNoFindings(t *testing.T) {
+	testguard.IsolateTmux(t)
+	report, err := Run(testOptions(t, false))
+	require.NoError(t, err)
+	require.Empty(t, report.Findings)
+	require.Zero(t, report.UnresolvedCount())
+
+	var buf bytes.Buffer
+	Render(&buf, report, false)
+	require.Contains(t, buf.String(), "No problems found")
+}
+
+// TestRenderShapes covers the three finding render states.
+func TestRenderShapes(t *testing.T) {
+	r := &Report{
+		OK: []string{"daemon: not running (starts on demand)"},
+		Findings: []Finding{
+			{Check: "orphaned-process", Detail: "pid 1234 (yes)", FixAction: "kill pid 1234"},
+			{Check: "leaked-tmux-session", Detail: "tmux session af_x has no backing record"},
+			{Check: "stale-temp-home", Detail: "abandoned home /tmp/x", FixAction: "remove /tmp/x", Fixed: true},
+		},
+	}
+	var buf bytes.Buffer
+	Render(&buf, r, false)
+	out := buf.String()
+	require.Contains(t, out, "ok: daemon: not running")
+	require.Contains(t, out, "--fix will kill pid 1234")
+	require.Contains(t, out, "issue: [leaked-tmux-session]")
+	require.Contains(t, out, "fixed: [stale-temp-home]")
+	require.Contains(t, out, "Re-run with --fix")
+}
+
+// TestTmuxServerDeadParsing pins the conservative TMUX-env heuristics.
+func TestTmuxServerDeadParsing(t *testing.T) {
+	self, err := proctree.Snapshot()
+	require.NoError(t, err)
+	ctx := &scanContext{snap: self}
+
+	require.False(t, tmuxServerDead(ctx, "garbage"), "unparseable TMUX values are never accused")
+	require.False(t, tmuxServerDead(ctx, "/tmp/sock,notanumber,0"))
+	// A PID that certainly exists but is not tmux, with no socket on disk.
+	require.True(t, tmuxServerDead(ctx, fmt.Sprintf("/nonexistent-sock-%d,%d,0", os.Getpid(), os.Getpid())))
+	// A dead PID.
+	c := exec.Command("true")
+	require.NoError(t, c.Run())
+	require.True(t, tmuxServerDead(ctx, fmt.Sprintf("/nonexistent-sock,%d,0", c.Process.Pid)))
+}
+
+// TestOrphanSignalIdentityGuard: even a fixable finding must refuse to fire
+// when the pid has been recycled (the fix closure re-verifies identity).
+func TestOrphanSignalIdentityGuard(t *testing.T) {
+	testguard.IsolateTmux(t)
+	orphan := spawnWithEnv(t, "sh", nil, map[string]string{"AF_SESSION": "af_doctor-recycle"})
+
+	opts := testOptions(t, false, orphan.PID)
+	report, err := Run(opts)
+	require.NoError(t, err)
+	require.Len(t, findByCheck(report, "orphaned-process"), 1)
+
+	// Kill the orphan out from under doctor, then apply the recorded fix:
+	// the identity check must turn it into a no-op rather than a signal to
+	// whoever owns the pid next.
+	require.NoError(t, proctree.Signal(orphan, syscall.SIGKILL))
+	require.Eventually(t, func() bool { return !alive(orphan) }, 5*time.Second, 10*time.Millisecond)
+
+	f := findByCheck(report, "orphaned-process")[0]
+	require.NotNil(t, f.fix)
+	require.NoError(t, f.fix(), "a vanished process is a successfully-reaped process")
+}

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -39,7 +40,14 @@ func TestMain(m *testing.M) {
 // scan root, fast kill windows, and a snapshot containing only pids.
 func testOptions(t *testing.T, fix bool, pids ...int) Options {
 	t.Helper()
-	home := t.TempDir()
+	return testOptionsWithHome(t, t.TempDir(), fix, pids...)
+}
+
+// testOptionsWithHome is testOptions with a caller-chosen home, for tests
+// whose spawned processes must carry an AF_HOME marker that matches (or
+// deliberately mismatches) the run's ConfigDir.
+func testOptionsWithHome(t *testing.T, home string, fix bool, pids ...int) Options {
+	t.Helper()
 	t.Setenv("AGENT_FACTORY_HOME", home)
 	return Options{
 		Fix:            fix,
@@ -138,13 +146,16 @@ func findByCheck(r *Report, check string) []Finding {
 func TestOrphanedProcessDetectedAndFixed(t *testing.T) {
 	testguard.IsolateTmux(t) // private server: the marked session is dead by construction
 
+	// The orphan's AF_HOME must match the run's ConfigDir — a kill requires
+	// a proven home match, not just a dead-looking session.
+	home := t.TempDir()
 	orphan := spawnWithEnv(t, "sh", nil, map[string]string{
 		"AF_SESSION": "af_doctor-dead-session",
-		"AF_HOME":    "/tmp/some-old-home",
+		"AF_HOME":    home,
 	})
 
 	// Read-only pass: reported, not touched.
-	report, err := Run(testOptions(t, false, orphan.PID))
+	report, err := Run(testOptionsWithHome(t, home, false, orphan.PID))
 	require.NoError(t, err)
 	findings := findByCheck(report, "orphaned-process")
 	require.Len(t, findings, 1)
@@ -154,7 +165,7 @@ func TestOrphanedProcessDetectedAndFixed(t *testing.T) {
 	require.True(t, alive(orphan), "read-only doctor run must not signal anything")
 
 	// --fix pass: killed, with the outcome recorded.
-	report, err = Run(testOptions(t, true, orphan.PID))
+	report, err = Run(testOptionsWithHome(t, home, true, orphan.PID))
 	require.NoError(t, err)
 	findings = findByCheck(report, "orphaned-process")
 	require.Len(t, findings, 1)
@@ -162,6 +173,46 @@ func TestOrphanedProcessDetectedAndFixed(t *testing.T) {
 	require.Eventually(t, func() bool { return !alive(orphan) }, 5*time.Second, 25*time.Millisecond,
 		"verified orphan must be dead after --fix")
 	require.Zero(t, report.UnresolvedCount())
+}
+
+// TestOrphanWithoutProvenHomeSurvivesFix pins the home-match gate: a process
+// marking a dead session is killed ONLY when its AF_HOME matches the active
+// home. A foreign home (e.g. a concurrent play-test sandbox whose sessions
+// live on a private `tmux -L` server and are invisible here) and a missing
+// home marker (pre-marker spawn, unreadable environ) are both report-only.
+func TestOrphanWithoutProvenHomeSurvivesFix(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	foreign := spawnWithEnv(t, "sh", nil, map[string]string{
+		"AF_SESSION": "af_doctor-foreign-home",
+		"AF_HOME":    t.TempDir(), // some other install's home
+	})
+	unmarked := spawnWithEnv(t, "sh", nil, map[string]string{
+		"AF_SESSION": "af_doctor-no-home",
+	})
+
+	report, err := Run(testOptions(t, true, foreign.PID, unmarked.PID))
+	require.NoError(t, err)
+	findings := findByCheck(report, "orphaned-process")
+	require.Len(t, findings, 2)
+	for _, f := range findings {
+		require.Empty(t, f.FixAction, "without a proven home match the finding must be report-only: %s", f.Detail)
+		require.False(t, f.Fixed)
+	}
+	var foreignDetail, unmarkedDetail bool
+	for _, f := range findings {
+		if strings.Contains(f.Detail, "another agent-factory home") {
+			foreignDetail = true
+		}
+		if strings.Contains(f.Detail, "no readable home marker") {
+			unmarkedDetail = true
+		}
+	}
+	require.True(t, foreignDetail, "foreign-home orphan must say whose it is")
+	require.True(t, unmarkedDetail, "unmarked orphan must say why it is not killed")
+
+	require.True(t, alive(foreign), "a foreign home's process must survive --fix")
+	require.True(t, alive(unmarked), "an unproven orphan must survive --fix")
 }
 
 // TestMarkedProcessOfLiveSessionIsNeverKilled: a marker pointing at a LIVE
@@ -360,9 +411,13 @@ func TestTmuxServerDeadParsing(t *testing.T) {
 // when the pid has been recycled (the fix closure re-verifies identity).
 func TestOrphanSignalIdentityGuard(t *testing.T) {
 	testguard.IsolateTmux(t)
-	orphan := spawnWithEnv(t, "sh", nil, map[string]string{"AF_SESSION": "af_doctor-recycle"})
+	home := t.TempDir()
+	orphan := spawnWithEnv(t, "sh", nil, map[string]string{
+		"AF_SESSION": "af_doctor-recycle",
+		"AF_HOME":    home,
+	})
 
-	opts := testOptions(t, false, orphan.PID)
+	opts := testOptionsWithHome(t, home, false, orphan.PID)
 	report, err := Run(opts)
 	require.NoError(t, err)
 	require.Len(t, findByCheck(report, "orphaned-process"), 1)

--- a/doctorcmd.go
+++ b/doctorcmd.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+
+	"github.com/sachiniyer/agent-factory/doctor"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/spf13/cobra"
+)
+
+var doctorFixFlag bool
+
+// doctorCmd is `af doctor` (#1044, #1104): detect orphaned session
+// processes, runaway CPU children, leaked af_ tmux sessions, stale temp
+// agent-factory homes, and daemon problems. Read-only by default; --fix
+// applies only the remediations whose ancestry is verified (killing marked
+// orphans of dead sessions, removing abandoned temp homes, killing daemons
+// whose home was deleted). Anything ambiguous is reported, never touched.
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Diagnose leaked processes, sessions, temp homes, and daemon health",
+	Long: `Diagnose problems that accumulate silently on a machine running agent-factory:
+
+  - orphaned processes spawned by sessions that no longer exist
+  - processes that escaped a live session's pane, or peg a CPU core for hours
+  - af_ tmux sessions with no backing session record
+  - abandoned agent-factory homes under the temp dir (leaked by tests/debug runs)
+  - daemon health: control socket, autostart unit, pid file, binary freshness
+
+Read-only by default. With --fix, applies the safe remediations — killing
+orphans whose ancestry markers prove they came from a dead af session, and
+removing stale temp homes — logging each action. Ambiguous cases are always
+reported rather than acted on.
+
+Exits 1 when unresolved issues remain, 0 when healthy.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		report, err := doctor.Run(doctor.Options{Fix: doctorFixFlag})
+		if err != nil {
+			return err
+		}
+		doctor.Render(os.Stdout, report, doctorFixFlag)
+		if report.UnresolvedCount() > 0 {
+			// Distinguish "problems found" from cobra usage errors without
+			// printing a redundant error line.
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			os.Exit(1)
+		}
+		return nil
+	},
+}
+
+func init() {
+	doctorCmd.Flags().BoolVar(&doctorFixFlag, "fix", false,
+		"apply safe remediations (kill verified orphans, remove stale temp homes)")
+	rootCmd.AddCommand(doctorCmd)
+}

--- a/internal/proctree/proctree.go
+++ b/internal/proctree/proctree.go
@@ -1,0 +1,306 @@
+// Package proctree inspects the local process table via /proc. It exists so
+// session teardown can reap every descendant of a tmux pane (#1104) and so
+// `af doctor` can trace leaked processes back to the session that spawned
+// them.
+//
+// Every operation that signals a process guards against PID reuse by pairing
+// the PID with its kernel start time (/proc/<pid>/stat field 22): a
+// (pid, starttime) pair names a process *instance*, not just a slot. A PID
+// that has been recycled since the snapshot fails the identity check and is
+// never signalled.
+//
+// On non-Linux platforms (no /proc) Snapshot returns an error and callers
+// degrade to doing nothing — reaping and doctor scans are best-effort
+// diagnostics, never load-bearing for correctness.
+package proctree
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// clkTck is the kernel clock-tick rate (_SC_CLK_TCK) used to convert
+// /proc stat fields to seconds. It is 100 on every mainstream Linux
+// configuration; Go's runtime makes the same assumption. Only used for
+// approximate CPU/age reporting, never for identity checks.
+const clkTck = 100
+
+// Process identifies one live process at snapshot time.
+type Process struct {
+	PID  int
+	PPID int
+	// StartTicks is /proc/<pid>/stat field 22 (starttime): clock ticks
+	// between boot and process start. Together with PID it uniquely
+	// identifies a process instance until reboot.
+	StartTicks uint64
+	// SID is the kernel session id (stat field 6). Every process spawned
+	// inside a tmux pane shares the pane root's SID unless it called
+	// setsid, so SID membership proves pane ancestry even after a process
+	// is reparented to init.
+	SID int
+	// Comm is the kernel task name (stat field 2, max 15 chars).
+	Comm string
+	// UTicks and STicks are cumulative user/system CPU ticks (stat
+	// fields 14/15) at snapshot time.
+	UTicks uint64
+	STicks uint64
+}
+
+// Snapshot reads the whole process table once. The result is a point-in-time
+// view: processes may die (or PIDs be recycled) immediately after. Callers
+// must use Signal/AliveSame — which re-verify identity — before acting on an
+// entry.
+func Snapshot() (map[int]Process, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("reading /proc: %w", err)
+	}
+	procs := make(map[int]Process, len(entries))
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		p, err := readStat(pid)
+		if err != nil {
+			// Process exited between ReadDir and the stat read; skip.
+			continue
+		}
+		procs[pid] = p
+	}
+	return procs, nil
+}
+
+// readStat parses /proc/<pid>/stat. Format: `pid (comm) state ppid ...`.
+// Comm may itself contain spaces and ')' — the parse anchors on the LAST ')'.
+func readStat(pid int) (Process, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return Process{}, err
+	}
+	open := bytes.IndexByte(data, '(')
+	close_ := bytes.LastIndexByte(data, ')')
+	if open < 0 || close_ < open || close_+2 > len(data) {
+		return Process{}, fmt.Errorf("malformed stat for pid %d", pid)
+	}
+	comm := string(data[open+1 : close_])
+	fields := strings.Fields(string(data[close_+2:]))
+	// fields[0] is stat field 3 (state); stat field N lives at fields[N-3].
+	const (
+		idxPPID  = 4 - 3
+		idxSID   = 6 - 3
+		idxUtime = 14 - 3
+		idxStime = 15 - 3
+		idxStart = 22 - 3
+	)
+	if len(fields) <= idxStart {
+		return Process{}, fmt.Errorf("truncated stat for pid %d", pid)
+	}
+	ppid, err := strconv.Atoi(fields[idxPPID])
+	if err != nil {
+		return Process{}, fmt.Errorf("bad ppid for pid %d: %w", pid, err)
+	}
+	sid, err := strconv.Atoi(fields[idxSID])
+	if err != nil {
+		return Process{}, fmt.Errorf("bad sid for pid %d: %w", pid, err)
+	}
+	start, err := strconv.ParseUint(fields[idxStart], 10, 64)
+	if err != nil {
+		return Process{}, fmt.Errorf("bad starttime for pid %d: %w", pid, err)
+	}
+	// CPU counters are for reporting only; a parse failure degrades to 0.
+	utime, _ := strconv.ParseUint(fields[idxUtime], 10, 64)
+	stime, _ := strconv.ParseUint(fields[idxStime], 10, 64)
+	return Process{PID: pid, PPID: ppid, SID: sid, StartTicks: start, Comm: comm, UTicks: utime, STicks: stime}, nil
+}
+
+// TreeOf returns root plus every descendant of root present in snap, in BFS
+// order (root first). Returns nil when root is not in the snapshot.
+func TreeOf(snap map[int]Process, root int) []Process {
+	rp, ok := snap[root]
+	if !ok {
+		return nil
+	}
+	children := make(map[int][]int, len(snap))
+	for pid, p := range snap {
+		children[p.PPID] = append(children[p.PPID], pid)
+	}
+	tree := []Process{rp}
+	queue := []int{root}
+	seen := map[int]bool{root: true}
+	for len(queue) > 0 {
+		pid := queue[0]
+		queue = queue[1:]
+		for _, c := range children[pid] {
+			if seen[c] {
+				continue
+			}
+			seen[c] = true
+			tree = append(tree, snap[c])
+			queue = append(queue, c)
+		}
+	}
+	return tree
+}
+
+// SessionMembers returns every process in snap whose kernel session id is
+// sid. Complements TreeOf: a pane descendant that was reparented to init
+// (its spawner exited first) drops out of the ppid tree but keeps the pane
+// root's SID unless it called setsid.
+func SessionMembers(snap map[int]Process, sid int) []Process {
+	var members []Process
+	for _, p := range snap {
+		if p.SID == sid {
+			members = append(members, p)
+		}
+	}
+	return members
+}
+
+// AliveSame reports whether the same process instance (matching PID and
+// start time) is still running.
+func AliveSame(p Process) bool {
+	cur, err := readStat(p.PID)
+	if err != nil {
+		return false
+	}
+	return cur.StartTicks == p.StartTicks
+}
+
+// ErrIdentityChanged is returned by Signal when the PID no longer names the
+// snapshotted process instance (it exited, or the PID was recycled).
+var ErrIdentityChanged = errors.New("process exited or pid was recycled")
+
+// Signal delivers sig to p only if the PID still names the same process
+// instance. The verify-then-kill pair has an unavoidable microsecond TOCTOU
+// window; PID recycling within it would require the kernel to cycle through
+// the entire PID space between the two syscalls, which does not happen in
+// practice.
+func Signal(p Process, sig syscall.Signal) error {
+	if p.PID <= 1 || p.PID == os.Getpid() {
+		return fmt.Errorf("refusing to signal pid %d", p.PID)
+	}
+	if !AliveSame(p) {
+		return ErrIdentityChanged
+	}
+	return syscall.Kill(p.PID, sig)
+}
+
+// WaitForExits polls until every process in procs is gone (or its PID was
+// recycled — same thing for our purposes) or the timeout elapses, and
+// returns the ones still alive.
+func WaitForExits(procs []Process, timeout time.Duration) []Process {
+	deadline := time.Now().Add(timeout)
+	for {
+		var alive []Process
+		for _, p := range procs {
+			if AliveSame(p) {
+				alive = append(alive, p)
+			}
+		}
+		if len(alive) == 0 || time.Now().After(deadline) {
+			return alive
+		}
+		procs = alive
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// KillEscalating gives procs the grace period to exit on their own, SIGTERMs
+// survivors, waits termWait, SIGKILLs what remains, and returns anything
+// still alive after a final bounded wait (should be empty). Every signal is
+// identity-verified (see Signal) and reported through logf, one line per
+// process. logf may be nil.
+func KillEscalating(procs []Process, grace, termWait time.Duration, logf func(format string, args ...any)) []Process {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	survivors := WaitForExits(procs, grace)
+	if len(survivors) == 0 {
+		return nil
+	}
+	for _, p := range survivors {
+		err := Signal(p, syscall.SIGTERM)
+		switch {
+		case err == nil:
+			logf("reaping leaked process %d (%s) with SIGTERM: %s", p.PID, p.Comm, Cmdline(p.PID))
+		case !errors.Is(err, ErrIdentityChanged):
+			logf("failed to SIGTERM leaked process %d (%s): %v", p.PID, p.Comm, err)
+		}
+	}
+	survivors = WaitForExits(survivors, termWait)
+	for _, p := range survivors {
+		err := Signal(p, syscall.SIGKILL)
+		switch {
+		case err == nil:
+			logf("leaked process %d (%s) ignored SIGTERM; sent SIGKILL", p.PID, p.Comm)
+		case !errors.Is(err, ErrIdentityChanged):
+			logf("failed to SIGKILL leaked process %d (%s): %v", p.PID, p.Comm, err)
+		}
+	}
+	remaining := WaitForExits(survivors, time.Second)
+	for _, p := range remaining {
+		logf("leaked process %d (%s) survived SIGKILL", p.PID, p.Comm)
+	}
+	return remaining
+}
+
+// CPUFraction returns the process's lifetime-average CPU usage as a fraction
+// of one core (1.0 = a full core since it started), plus its age in seconds.
+// Uses /proc/uptime; returns (0, 0, error) when that is unreadable. A brand
+// new process (age < 1s) reports 0 to avoid a noisy division.
+func CPUFraction(p Process) (frac float64, ageSeconds float64, err error) {
+	data, err := os.ReadFile("/proc/uptime")
+	if err != nil {
+		return 0, 0, fmt.Errorf("reading /proc/uptime: %w", err)
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0, 0, errors.New("malformed /proc/uptime")
+	}
+	uptime, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("malformed /proc/uptime: %w", err)
+	}
+	age := uptime - float64(p.StartTicks)/clkTck
+	if age < 1 {
+		return 0, age, nil
+	}
+	busy := float64(p.UTicks+p.STicks) / clkTck
+	return busy / age, age, nil
+}
+
+// EnvValue reads key from /proc/<pid>/environ. Returns ("", false) when the
+// variable is absent or the environ is unreadable (different UID, kernel
+// thread, or the process exited). The environ reflects the process's
+// *initial* environment — exactly what we want for ancestry markers, since a
+// process cannot retroactively lose the marker it inherited.
+func EnvValue(pid int, key string) (string, bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err != nil {
+		return "", false
+	}
+	prefix := []byte(key + "=")
+	for _, kv := range bytes.Split(data, []byte{0}) {
+		if bytes.HasPrefix(kv, prefix) {
+			return string(kv[len(prefix):]), true
+		}
+	}
+	return "", false
+}
+
+// Cmdline returns the process's argv joined with spaces, or "" when
+// unreadable. For kernel threads (empty cmdline) it returns "".
+func Cmdline(pid int) string {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(bytes.ReplaceAll(data, []byte{0}, []byte{' '})))
+}

--- a/internal/proctree/proctree_test.go
+++ b/internal/proctree/proctree_test.go
@@ -1,0 +1,213 @@
+package proctree
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// startSleeper spawns a `sleep` child owned by this test and returns its
+// Process entry. The child is killed on cleanup regardless of test outcome.
+func startSleeper(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("sleep", "300")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting sleeper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd
+}
+
+func TestSnapshotIncludesSelfAndChild(t *testing.T) {
+	child := startSleeper(t)
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	self, ok := snap[os.Getpid()]
+	if !ok {
+		t.Fatalf("snapshot missing our own pid %d", os.Getpid())
+	}
+	if self.StartTicks == 0 {
+		t.Errorf("self StartTicks = 0, want nonzero")
+	}
+	cp, ok := snap[child.Process.Pid]
+	if !ok {
+		t.Fatalf("snapshot missing child pid %d", child.Process.Pid)
+	}
+	if cp.PPID != os.Getpid() {
+		t.Errorf("child PPID = %d, want %d", cp.PPID, os.Getpid())
+	}
+	if cp.Comm != "sleep" {
+		t.Errorf("child Comm = %q, want %q", cp.Comm, "sleep")
+	}
+}
+
+func TestTreeOfFindsGrandchild(t *testing.T) {
+	// sh -c spawns sleep as a grandchild of the test process.
+	cmd := exec.Command("sh", "-c", "sleep 300 & wait")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting sh: %v", err)
+	}
+	t.Cleanup(func() {
+		snap, _ := Snapshot()
+		for _, p := range TreeOf(snap, cmd.Process.Pid) {
+			_ = syscall.Kill(p.PID, syscall.SIGKILL)
+		}
+		_, _ = cmd.Process.Wait()
+	})
+
+	// The shell needs a moment to fork the sleep.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		snap, err := Snapshot()
+		if err != nil {
+			t.Fatalf("Snapshot: %v", err)
+		}
+		tree := TreeOf(snap, cmd.Process.Pid)
+		if len(tree) >= 2 {
+			if tree[0].PID != cmd.Process.Pid {
+				t.Errorf("tree root = %d, want %d", tree[0].PID, cmd.Process.Pid)
+			}
+			foundSleep := false
+			for _, p := range tree[1:] {
+				if p.Comm == "sleep" {
+					foundSleep = true
+				}
+			}
+			if !foundSleep {
+				t.Errorf("tree %v missing the sleep grandchild", tree)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sleep grandchild never appeared under pid %d", cmd.Process.Pid)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestTreeOfMissingRoot(t *testing.T) {
+	snap := map[int]Process{2: {PID: 2, PPID: 1}}
+	if tree := TreeOf(snap, 999999); tree != nil {
+		t.Errorf("TreeOf(missing root) = %v, want nil", tree)
+	}
+}
+
+func TestSessionMembers(t *testing.T) {
+	snap := map[int]Process{
+		10: {PID: 10, PPID: 1, SID: 10},
+		11: {PID: 11, PPID: 1, SID: 10}, // reparented but same kernel session
+		12: {PID: 12, PPID: 1, SID: 12},
+	}
+	members := SessionMembers(snap, 10)
+	if len(members) != 2 {
+		t.Fatalf("SessionMembers = %v, want 2 members", members)
+	}
+	for _, m := range members {
+		if m.SID != 10 {
+			t.Errorf("member %d has SID %d, want 10", m.PID, m.SID)
+		}
+	}
+}
+
+func TestSignalVerifiesIdentity(t *testing.T) {
+	child := startSleeper(t)
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	p := snap[child.Process.Pid]
+
+	// Wrong start time must refuse to signal.
+	stale := p
+	stale.StartTicks++
+	if err := Signal(stale, syscall.SIGTERM); err != ErrIdentityChanged {
+		t.Errorf("Signal(stale identity) = %v, want ErrIdentityChanged", err)
+	}
+	if !AliveSame(p) {
+		t.Fatalf("child died from a stale-identity signal — identity guard failed")
+	}
+
+	// Correct identity kills it.
+	if err := Signal(p, syscall.SIGKILL); err != nil {
+		t.Fatalf("Signal(valid identity) = %v", err)
+	}
+	_, _ = child.Process.Wait()
+	if AliveSame(p) {
+		t.Errorf("child still alive after SIGKILL")
+	}
+}
+
+func TestSignalRefusesSelfAndInit(t *testing.T) {
+	if err := Signal(Process{PID: 1}, syscall.SIGTERM); err == nil {
+		t.Errorf("Signal(pid 1) succeeded, want refusal")
+	}
+	if err := Signal(Process{PID: os.Getpid()}, syscall.SIGTERM); err == nil {
+		t.Errorf("Signal(self) succeeded, want refusal")
+	}
+}
+
+func TestEnvValue(t *testing.T) {
+	cmd := exec.Command("sleep", "300")
+	cmd.Env = append(os.Environ(), "AF_TEST_MARKER=hello")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting sleeper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	// /proc/<pid>/environ is empty in the window between fork and exec;
+	// poll briefly rather than racing it.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if got, ok := EnvValue(cmd.Process.Pid, "AF_TEST_MARKER"); ok && got == "hello" {
+			break
+		}
+		if time.Now().After(deadline) {
+			got, ok := EnvValue(cmd.Process.Pid, "AF_TEST_MARKER")
+			t.Fatalf("EnvValue = (%q, %v), want (\"hello\", true)", got, ok)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, ok := EnvValue(cmd.Process.Pid, "AF_TEST_ABSENT"); ok {
+		t.Errorf("EnvValue found an absent variable")
+	}
+}
+
+func TestCPUFractionIdleSleeper(t *testing.T) {
+	child := startSleeper(t)
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	frac, _, err := CPUFraction(snap[child.Process.Pid])
+	if err != nil {
+		t.Fatalf("CPUFraction: %v", err)
+	}
+	if frac > 0.5 {
+		t.Errorf("idle sleeper CPU fraction = %v, want near 0", frac)
+	}
+}
+
+func TestCmdline(t *testing.T) {
+	child := startSleeper(t)
+	// /proc/<pid>/cmdline is empty in the window between fork and exec;
+	// poll briefly rather than racing it.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if got := Cmdline(child.Process.Pid); got == "sleep 300" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Cmdline = %q, want %q", Cmdline(child.Process.Pid), "sleep 300")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/session/tmux/envmarker.go
+++ b/session/tmux/envmarker.go
@@ -1,0 +1,124 @@
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Ancestry env markers (#1104). Every process spawned inside an af tmux pane
+// inherits these variables, and /proc/<pid>/environ preserves a process's
+// *initial* environment — so even after a leaked child is orphaned and
+// reparented to init, `af doctor` can still prove which session (and which
+// agent-factory home) spawned it. Without the marker that ancestry is
+// unrecoverable, which is exactly what made the 2026-07-03 `yes` orphans
+// ambiguous.
+const (
+	// EnvMarkerSession holds the sanitized tmux session name (af_...).
+	EnvMarkerSession = "AF_SESSION"
+	// EnvMarkerHome holds the agent-factory config dir that owns the
+	// session, so doctor never confuses sessions from another install or a
+	// test's temp home with its own.
+	EnvMarkerHome = "AF_HOME"
+)
+
+// newSessionEnvSupportedOverride forces the `-e` support probe's answer in
+// tests (mock executors can't answer a real `tmux -V`); nil probes the real
+// tmux binary.
+var newSessionEnvSupportedOverride *bool
+
+// sessionEnvFlags returns the `-e VAR=value` arguments for `tmux
+// new-session`, or nil when the running tmux predates `-e` (added in 3.2) —
+// passing it there would fail session creation outright, which is far worse
+// than a missing diagnostic marker.
+func sessionEnvFlags(sanitizedName string) []string {
+	supported := tmuxSupportsNewSessionEnv
+	if newSessionEnvSupportedOverride != nil {
+		supported = func() bool { return *newSessionEnvSupportedOverride }
+	}
+	if !supported() {
+		return nil
+	}
+	flags := []string{"-e", EnvMarkerSession + "=" + sanitizedName}
+	if home, err := afHomeDir(); err == nil {
+		flags = append(flags, "-e", EnvMarkerHome+"="+home)
+	}
+	return flags
+}
+
+var (
+	newSessionEnvOnce      sync.Once
+	newSessionEnvSupported bool
+)
+
+// tmuxSupportsNewSessionEnv probes `tmux -V` once per process. Unparseable
+// versions ("openbsd-7.4", exotic builds) conservatively report false.
+func tmuxSupportsNewSessionEnv() bool {
+	newSessionEnvOnce.Do(func() {
+		out, err := exec.Command("tmux", "-V").Output()
+		if err != nil {
+			return
+		}
+		newSessionEnvSupported = versionSupportsNewSessionEnv(strings.TrimSpace(string(out)))
+	})
+	return newSessionEnvSupported
+}
+
+// versionSupportsNewSessionEnv parses a `tmux -V` string ("tmux 3.4",
+// "tmux 3.3a", "tmux next-3.6", "tmux master") and reports whether
+// `new-session -e` (tmux >= 3.2) is available.
+func versionSupportsNewSessionEnv(version string) bool {
+	v := strings.TrimPrefix(version, "tmux ")
+	v = strings.TrimPrefix(v, "next-")
+	if v == "master" {
+		// Development builds trail no released feature this old.
+		return true
+	}
+	parts := strings.SplitN(v, ".", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	// Strip any suffix after the minor digits ("3a" -> "3", "5-rc" -> "5").
+	minorStr := parts[1]
+	end := 0
+	for end < len(minorStr) && minorStr[end] >= '0' && minorStr[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return false
+	}
+	minor, err := strconv.Atoi(minorStr[:end])
+	if err != nil {
+		return false
+	}
+	return major > 3 || (major == 3 && minor >= 2)
+}
+
+// afHomeDir mirrors config.GetConfigDir — $AGENT_FACTORY_HOME (tilde-expanded)
+// or ~/.agent-factory. Duplicated because config imports session/tmux, so
+// this package cannot import config without a cycle (same trade-off as
+// internal/testguard, which documents the same mirroring).
+func afHomeDir() (string, error) {
+	if envDir := os.Getenv("AGENT_FACTORY_HOME"); envDir != "" {
+		if envDir == "~" || strings.HasPrefix(envDir, "~/") {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(home, strings.TrimPrefix(envDir[1:], "/")), nil
+		}
+		return envDir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".agent-factory"), nil
+}

--- a/session/tmux/envmarker_test.go
+++ b/session/tmux/envmarker_test.go
@@ -1,0 +1,96 @@
+package tmux
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	cmd2 "github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/stretchr/testify/require"
+)
+
+// forceNewSessionEnvMarkers pins the `-e` support probe for the duration of
+// a test so assertions on the exact new-session argv are deterministic
+// regardless of which tmux (if any) is installed on the box.
+func forceNewSessionEnvMarkers(t *testing.T, supported bool) {
+	t.Helper()
+	newSessionEnvSupportedOverride = &supported
+	t.Cleanup(func() { newSessionEnvSupportedOverride = nil })
+}
+
+func TestVersionSupportsNewSessionEnv(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"tmux 3.2", true},
+		{"tmux 3.2a", true},
+		{"tmux 3.4", true},
+		{"tmux 3.5-rc2", true},
+		{"tmux 4.0", true},
+		{"tmux next-3.6", true},
+		{"tmux master", true},
+		{"tmux 3.1c", false},
+		{"tmux 3.0", false},
+		{"tmux 2.9a", false},
+		{"tmux 1.8", false},
+		{"tmux openbsd-7.4", false},
+		{"garbage", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := versionSupportsNewSessionEnv(c.version); got != c.want {
+			t.Errorf("versionSupportsNewSessionEnv(%q) = %v, want %v", c.version, got, c.want)
+		}
+	}
+}
+
+func TestSessionEnvFlagsIncludeMarkers(t *testing.T) {
+	forceNewSessionEnvMarkers(t, true)
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	flags := sessionEnvFlags("af_abc_mysession")
+	require.Equal(t, []string{
+		"-e", "AF_SESSION=af_abc_mysession",
+		"-e", "AF_HOME=" + home,
+	}, flags)
+}
+
+func TestSessionEnvFlagsEmptyWhenUnsupported(t *testing.T) {
+	forceNewSessionEnvMarkers(t, false)
+	require.Nil(t, sessionEnvFlags("af_abc_mysession"))
+}
+
+// TestStartInjectsEnvMarkers verifies the markers reach the actual
+// new-session command line (#1104): they are what lets `af doctor` trace an
+// orphaned pane descendant back to its session after teardown.
+func TestStartInjectsEnvMarkers(t *testing.T) {
+	forceNewSessionEnvMarkers(t, true)
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	ptyFactory := NewMockPtyFactory(t)
+	created := false
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") && !created {
+				created = true
+				return fmt.Errorf("session not found")
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+	}
+
+	workdir := t.TempDir()
+	session := newTmuxSession(toTmuxName("marked", ""), "claude", ptyFactory, cmdExec)
+	require.NoError(t, session.Start(workdir))
+	require.NotEmpty(t, ptyFactory.cmds)
+	require.Equal(t,
+		fmt.Sprintf("tmux new-session -d -s af_marked -c %s -e AF_SESSION=af_marked -e AF_HOME=%s claude",
+			workdir, home),
+		cmd2.ToString(ptyFactory.cmds[0]))
+}

--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -1,0 +1,112 @@
+package tmux
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// Process-tree reaping (#1104). `tmux kill-session` only SIGHUPs the pane's
+// foreground process group; anything that detached from it (a backgrounded
+// `yes`, an agent-spawned helper in its own process group) survives teardown
+// as an orphan and can burn a core forever — eight of those starved the tmux
+// server on the dev box. So every teardown path captures the pane's full
+// descendant tree BEFORE kill-session (afterwards orphans reparent to init
+// and the ancestry is unrecoverable) and, after a grace period for SIGHUP
+// handlers, SIGTERMs then SIGKILLs whatever is still alive.
+//
+// Safety properties:
+//   - Only processes captured from the session's own panes are ever
+//     signalled: a pane PID is trusted only if it is a live child of a tmux
+//     server, and the capture set is its ppid-descendants plus processes
+//     sharing its kernel session id (tmux makes each pane root a session
+//     leader, so SID membership proves pane ancestry even for processes
+//     already reparented to init).
+//   - Every signal re-verifies the (pid, starttime) identity via
+//     proctree.Signal, so a recycled PID is never signalled.
+//   - If kill-session fails and the tmux session survives, nothing is
+//     reaped — a live session's processes are not leaks.
+//
+// Best-effort by design: capture failures (no /proc, session already gone,
+// mock executors in tests) degrade to a no-op, and reap outcomes are logged,
+// never returned as errors.
+
+var (
+	// reapGraceWait is how long leaked processes get to exit on their own
+	// after kill-session (SIGHUP) before being SIGTERMed. Matches
+	// paneExitWait's reasoning: long enough for an agent to flush state,
+	// short enough to bound the sweep. var, not const, so tests can lower it.
+	reapGraceWait = 3 * time.Second
+	// reapTermWait is how long a SIGTERMed process gets before SIGKILL.
+	reapTermWait = 2 * time.Second
+)
+
+// SessionProcessTrees enumerates every live process belonging to the named
+// tmux session's panes: each pane root (verified to be a live child of a
+// tmux server), its ppid-descendants, and its kernel-session members. The
+// teardown paths call it BEFORE kill-session; `af doctor` uses it to map a
+// live session's legitimate processes. Returns nil on any failure — callers
+// treat it as strictly best-effort.
+func SessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) []proctree.Process {
+	out, err := cmdExec.Output(exec.Command(
+		"tmux", "list-panes", "-s", "-t", exactTarget(sanitizedName), "-F", "#{pane_pid}"))
+	if err != nil {
+		return nil
+	}
+	snap, err := proctree.Snapshot()
+	if err != nil {
+		return nil
+	}
+	seen := make(map[int]bool)
+	var procs []proctree.Process
+	add := func(p proctree.Process) {
+		if !seen[p.PID] {
+			seen[p.PID] = true
+			procs = append(procs, p)
+		}
+	}
+	for _, field := range strings.Fields(string(out)) {
+		panePID, err := strconv.Atoi(field)
+		if err != nil || panePID <= 1 {
+			continue
+		}
+		root, ok := snap[panePID]
+		if !ok {
+			continue
+		}
+		// A real pane root is a direct child of a tmux server. Anything
+		// else (stale output, a mock executor's canned reply that happens
+		// to parse as a PID) is rejected so we can never sweep a tree that
+		// isn't ours.
+		parent, ok := snap[root.PPID]
+		if !ok || !strings.HasPrefix(parent.Comm, "tmux") {
+			continue
+		}
+		for _, p := range proctree.TreeOf(snap, panePID) {
+			add(p)
+		}
+		// tmux makes the pane root a session leader, so members of its
+		// kernel session are pane descendants even when their spawner
+		// already exited and they were reparented to init.
+		for _, p := range proctree.SessionMembers(snap, root.SID) {
+			add(p)
+		}
+	}
+	return procs
+}
+
+// reapLeakedProcesses waits for the captured processes to exit after
+// kill-session, then escalates SIGTERM → SIGKILL on survivors (identity
+// verified — see proctree.KillEscalating). Runs synchronously; teardown
+// paths that must stay snappy call it in a goroutine. Every signal is logged
+// per-process.
+func reapLeakedProcesses(sanitizedName string, procs []proctree.Process, grace, termWait time.Duration) {
+	proctree.KillEscalating(procs, grace, termWait, func(format string, args ...any) {
+		log.WarningLog.Printf("tmux "+sanitizedName+": "+format, args...)
+	})
+}

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -1,0 +1,162 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/stretchr/testify/require"
+)
+
+// shrinkReapWaits lowers the grace periods so reap tests finish in
+// milliseconds instead of seconds.
+func shrinkReapWaits(t *testing.T) {
+	t.Helper()
+	oldGrace, oldTerm := reapGraceWait, reapTermWait
+	reapGraceWait, reapTermWait = 200*time.Millisecond, 300*time.Millisecond
+	t.Cleanup(func() { reapGraceWait, reapTermWait = oldGrace, oldTerm })
+}
+
+// spawnSessionWithEscapee creates a real tmux session (on the test's private
+// server) whose pane backgrounds a SIGHUP-immune sleeper — the exact shape of
+// the leaked `yes` processes from the 2026-07-03 outage — and returns the
+// session name and the escapee's process identity.
+func spawnSessionWithEscapee(t *testing.T, name string) proctree.Process {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "escapee.pid")
+	// nohup makes the sleeper ignore the SIGHUP that `tmux kill-session`
+	// delivers, so without reaping it would outlive the session forever.
+	script := fmt.Sprintf("nohup sleep 300 >/dev/null 2>&1 & echo $! > %s; exec sleep 300", pidFile)
+	out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "-c", dir, script).CombinedOutput()
+	require.NoError(t, err, "tmux new-session: %s", out)
+
+	var pid int
+	require.Eventually(t, func() bool {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return false
+		}
+		pid, err = strconv.Atoi(strings.TrimSpace(string(data)))
+		return err == nil && pid > 1
+	}, 5*time.Second, 20*time.Millisecond, "escapee pid file never appeared")
+
+	snap, err := proctree.Snapshot()
+	require.NoError(t, err)
+	escapee, ok := snap[pid]
+	require.True(t, ok, "escapee %d not in process snapshot", pid)
+	t.Cleanup(func() {
+		// Belt-and-suspenders: never leak the sleeper past the test even if
+		// the assertion fails.
+		_ = proctree.Signal(escapee, syscall.SIGKILL)
+	})
+	return escapee
+}
+
+// TestCloseReapsEscapedPaneProcesses is the end-to-end #1104 regression
+// test: a pane child that ignores SIGHUP must not survive Close().
+func TestCloseReapsEscapedPaneProcesses(t *testing.T) {
+	testguard.IsolateTmux(t)
+	shrinkReapWaits(t)
+
+	const name = "af_reap-close-test"
+	escapee := spawnSessionWithEscapee(t, name)
+	require.True(t, proctree.AliveSame(escapee), "escapee must be alive before Close")
+
+	session := NewTmuxSessionFromSanitizedName(name, "sh")
+	require.NoError(t, session.Close())
+	require.False(t, session.DoesSessionExist(), "session must be gone after Close")
+
+	// Close reaps asynchronously; the escapee ignores SIGHUP, so only the
+	// reaper's SIGTERM/SIGKILL can end it.
+	require.Eventually(t, func() bool { return !proctree.AliveSame(escapee) },
+		5*time.Second, 25*time.Millisecond,
+		"SIGHUP-immune pane child survived Close — process tree was not reaped")
+}
+
+// TestCleanupSessionsReapsEscapedProcesses covers the `af reset` sweep: it
+// must reap synchronously (the CLI process exits right after).
+func TestCleanupSessionsReapsEscapedProcesses(t *testing.T) {
+	testguard.IsolateTmux(t)
+	shrinkReapWaits(t)
+
+	escapee := spawnSessionWithEscapee(t, "af_reap-reset-test")
+	require.NoError(t, CleanupSessions(cmd.MakeExecutor()))
+
+	// Synchronous contract: by the time CleanupSessions returns, the sweep
+	// has run to completion.
+	require.False(t, proctree.AliveSame(escapee),
+		"SIGHUP-immune pane child survived CleanupSessions")
+}
+
+// TestCaptureRejectsNonTmuxPaneRoots is the safety property that keeps
+// mock-backed tests (and any confused tmux output) from ever capturing a
+// process tree that is not rooted in a real tmux pane: a claimed pane PID
+// whose parent is not a tmux server must be ignored.
+func TestCaptureRejectsNonTmuxPaneRoots(t *testing.T) {
+	// Our own PID is alive but its parent is the go test runner, not tmux.
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return []byte(fmt.Sprintf("%d\n", os.Getpid())), nil
+		},
+	}
+	procs := SessionProcessTrees(cmdExec, "af_bogus")
+	require.Empty(t, procs, "a pane root whose parent is not tmux must never be captured")
+}
+
+// TestCaptureIgnoresGarbageOutput: mock executors routinely return
+// non-numeric canned output; capture must degrade to a no-op.
+func TestCaptureIgnoresGarbageOutput(t *testing.T) {
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("output"), nil },
+	}
+	require.Empty(t, SessionProcessTrees(cmdExec, "af_bogus"))
+}
+
+// TestCloseDoesNotReapWhenSessionSurvives: if kill-session fails and the
+// session is still alive, its processes are not leaks and must be left
+// alone.
+func TestCloseDoesNotReapWhenSessionSurvives(t *testing.T) {
+	shrinkReapWaits(t)
+
+	// A live child of this test stands in for a pane process. The mock
+	// reports it as a pane root — but with a non-tmux parent it would be
+	// rejected anyway, so this test asserts at the Close level: kill-session
+	// fails, has-session says alive, and the child must remain untouched.
+	child := exec.Command("sleep", "300")
+	require.NoError(t, child.Start())
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		_, _ = child.Process.Wait()
+	})
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "kill-session") {
+				return fmt.Errorf("server wedged")
+			}
+			return nil // has-session succeeds -> session still exists
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return []byte(fmt.Sprintf("%d\n", child.Process.Pid)), nil
+		},
+	}
+	session := newTmuxSession("af_survivor", "sh", NewMockPtyFactory(t), cmdExec)
+	require.Error(t, session.Close(), "a surviving session must surface the kill failure")
+
+	time.Sleep(3 * reapGraceWait)
+	require.NoError(t, child.Process.Signal(syscall.Signal(0)),
+		"processes of a session that survived kill-session must not be reaped")
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"github.com/sachiniyer/agent-factory/log"
 	"io"
 	"os"
@@ -229,16 +230,24 @@ func (t *TmuxSession) Start(workDir string) error {
 		return fmt.Errorf("tmux session already exists: %s", t.sanitizedName)
 	}
 
-	// Create a new detached tmux session and start claude in it
-	cmd := exec.Command("tmux", "new-session", "-d", "-s", t.sanitizedName, "-c", workDir, t.program)
+	// Create a new detached tmux session and start claude in it. The -e
+	// markers (when supported) let `af doctor` trace any process the pane
+	// spawns back to this session even after it is orphaned (#1104).
+	args := []string{"new-session", "-d", "-s", t.sanitizedName, "-c", workDir}
+	args = append(args, sessionEnvFlags(t.sanitizedName)...)
+	args = append(args, t.program)
+	cmd := exec.Command("tmux", args...)
 
 	ptmx, err := t.ptyFactory.Start(cmd)
 	if err != nil {
 		// Cleanup any partially created session if any exists.
 		if t.DoesSessionExist() {
+			leaked := SessionProcessTrees(t.cmdExec, t.sanitizedName)
 			cleanupCmd := exec.Command("tmux", "kill-session", "-t", exactTarget(t.sanitizedName))
 			if cleanupErr := t.cmdExec.Run(cleanupCmd); cleanupErr != nil {
 				err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
+			} else if len(leaked) > 0 {
+				go reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
 			}
 		}
 		return fmt.Errorf("error starting tmux session: %w", err)
@@ -908,6 +917,11 @@ func (t *TmuxSession) Close() error {
 		t.attachCh = nil
 	}
 
+	// Capture the panes' process trees before kill-session — afterwards any
+	// survivor is reparented to init and its ancestry is unrecoverable
+	// (#1104).
+	leaked := SessionProcessTrees(t.cmdExec, t.sanitizedName)
+
 	cmd := exec.Command("tmux", "kill-session", "-t", exactTarget(t.sanitizedName))
 	if err := t.cmdExec.Run(cmd); err != nil {
 		// Idempotent teardown (#967): a kill-session that fails because the
@@ -918,7 +932,16 @@ func (t *TmuxSession) Close() error {
 		// `_`-ignored cleanup kill in Start (above).
 		if t.DoesSessionExist() {
 			errs = append(errs, fmt.Errorf("error killing tmux session: %w", err))
+			// The session survived — its processes are not leaks. Do not reap.
+			leaked = nil
 		}
+	}
+
+	// Async so the SIGHUP grace period never adds latency to user-driven
+	// teardown; the daemon and TUI processes are long-lived, so the sweep
+	// always gets to finish. CLI kills run daemon-side (KillSession RPC).
+	if len(leaked) > 0 {
+		go reapLeakedProcesses(t.sanitizedName, leaked, reapGraceWait, reapTermWait)
 	}
 
 	if len(errs) == 0 {
@@ -1188,6 +1211,18 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 		matches[i] = match[:strings.Index(match, ":")]
 	}
 
+	// Capture every session's pane process trees before any kill (#1104);
+	// reap synchronously at the end because `af reset` is a short-lived CLI
+	// process — a goroutine would die with it before the sweep ran.
+	leakedBySession := make(map[string][]proctree.Process, len(matches))
+	for _, match := range matches {
+		leakedBySession[match] = SessionProcessTrees(cmdExec, match)
+	}
+
+	// Only sessions that are actually gone get their captured trees reaped —
+	// a session that survives its kill still owns its processes.
+	killed := make([]string, 0, len(matches))
+	var killErr error
 	for _, match := range matches {
 		log.InfoLog.Printf("cleaning up session: %s", match)
 		// `=` forces an exact session match so a name extracted from `tmux ls`
@@ -1197,9 +1232,27 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 			// `tmux ls` above and this kill (TOCTOU). A gone session is the
 			// goal of cleanup, so only a survivor is a real failure.
 			if sessionExists(cmdExec, match) {
-				return fmt.Errorf("failed to kill tmux session %s: %v", match, err)
+				killErr = fmt.Errorf("failed to kill tmux session %s: %v", match, err)
+				break
 			}
 		}
+		killed = append(killed, match)
 	}
-	return nil
+
+	// Sweep concurrently: the grace waits overlap instead of serializing,
+	// and the whole reset still blocks until every sweep finishes.
+	var wg sync.WaitGroup
+	for _, match := range killed {
+		leaked := leakedBySession[match]
+		if len(leaked) == 0 {
+			continue
+		}
+		wg.Add(1)
+		go func(match string, leaked []proctree.Process) {
+			defer wg.Done()
+			reapLeakedProcesses(match, leaked, reapGraceWait, reapTermWait)
+		}(match, leaked)
+	}
+	wg.Wait()
+	return killErr
 }

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -166,6 +166,9 @@ func TestRestoreAttachesWhenSessionExists(t *testing.T) {
 // the worktree on disk is fine. Restore must transparently re-spawn the
 // session in workDir using the same program.
 func TestRestoreRespawnsWhenSessionMissing(t *testing.T) {
+	// Pin the exact new-session argv regardless of the box's tmux version;
+	// marker injection is covered by TestStartInjectsEnvMarkers.
+	forceNewSessionEnvMarkers(t, false)
 	ptyFactory := NewMockPtyFactory(t)
 
 	// First two has-session calls report missing (the outer Restore check, then
@@ -248,6 +251,9 @@ func TestRestoreReturnsErrorWhenSessionMissingAndNoWorkDir(t *testing.T) {
 }
 
 func TestStartTmuxSession(t *testing.T) {
+	// Pin the exact new-session argv regardless of the box's tmux version;
+	// marker injection is covered by TestStartInjectsEnvMarkers.
+	forceNewSessionEnvMarkers(t, false)
 	ptyFactory := NewMockPtyFactory(t)
 
 	created := false


### PR DESCRIPTION
Implements the **reap** and **detect** halves of #1104 (the 2026-07-03 outage: 8 orphaned `yes` processes leaked by session children pegged 8 of 16 cores for 15 days, then starved the tmux server and took down every session). The restore-outage-killed-sessions half is deliberately **not** here — it's tracked separately under #1108; this PR only leaves clean seams (the `Dead`-state handling is untouched).

## 1. Process-tree reaping on teardown

`tmux kill-session` only SIGHUPs the pane's foreground process group. Anything that detached from it — a backgrounded `yes`, an agent-spawned helper in its own process group — survived teardown forever. Now every teardown path:

1. **Captures the pane's full process tree before kill-session** (`tmux.SessionProcessTrees`): all pane roots (`list-panes -s`), their ppid-descendants, **plus** every process sharing the pane root's kernel session id — tmux makes each pane root a session leader, so SID membership proves pane ancestry even for children already reparented to init because their spawner exited first. Capture must happen before the kill; afterwards orphans reparent to init and ancestry is unrecoverable.
2. **After kill-session, waits a 3s SIGHUP grace period, then SIGTERM → 2s → SIGKILLs survivors** (`internal/proctree.KillEscalating`), logging one line per signalled process.

Safety properties (all enforced in code, all tested):
- A claimed pane PID is trusted **only if it is a live direct child of a tmux server** — a mock executor's canned output or garbled tmux output can never cause a capture outside a real pane tree (`TestCaptureRejectsNonTmuxPaneRoots`).
- Every signal re-verifies the **(pid, starttime) identity** from `/proc/<pid>/stat`, so a recycled PID is never signalled (`TestSignalVerifiesIdentity`); pid 1 and self are refused unconditionally.
- If kill-session fails and the session **survives**, nothing is reaped — a live session's processes are not leaks (`TestCloseDoesNotReapWhenSessionSurvives`).
- Best-effort by design: no /proc (non-Linux), dead session, capture failure → silent no-op; teardown latency is unchanged (the sweep runs async in long-lived processes, synchronously in `af reset`).

### Teardown call-site audit (per the #1104 requirement)

Every production `tmux kill-session` path was traced (there is no daemon background loop that kills sessions — teardown always flows through these):

| # | Path | Trigger | Coverage |
|---|------|---------|----------|
| 1 | `TmuxSession.Close()` (tmux.go) | the primitive everything funnels into | **reaps** (capture before kill, async sweep after) |
| 2 | `LocalBackend.Kill` → `CloseAndWaitForPaneExit` per tab | TUI `d` / CLI `af sessions kill` via daemon KillSession RPC; daemon CreateSession rollbacks; first-time-setup error cleanup; TUI naming-abort direct kill | inherits #1 |
| 3 | `Instance.CloseTab` | CloseTab RPC (TUI `w`), CreateTab rollback | inherits #1 |
| 4/5 | `AddShellTab`/`AddProcessTab` race cleanup (#990) | kill-during-tab-creation race | inherits #1 |
| 6 | `Start()` partial-create rollback kill | pty spawn failure | **reaps** (patched explicitly — this was a raw kill) |
| 7 | `Start()` poll-timeout / Restore-failure cleanup | session bring-up failure | inherits #1 |
| 8 | `ghostKillTmuxByName` → `CloseAndWaitForPaneExit` | KillSession RPC on a session with no in-memory instance | inherits #1 (by-name capture works identically) |
| 9 | `CleanupSessions` (`af reset`) | CLI reset name-scan | **reaps** (patched explicitly; synchronous + concurrent sweeps because the CLI process exits right after; only sessions whose kill actually succeeded are swept) |

Justified exclusions: `CloseAttachOnly` (non-destructive by contract — detaches the client, never kills the session, used precisely to *avoid* destroying live sessions #867/#895), `killTmuxAttachByName` (SIGKILLs only the attach *client* as the #598 drain fallback; not session teardown), `testguard` `kill-server` (test-only package).

### Ancestry markers (the doctor seam)

`Start()` now injects `-e AF_SESSION=<tmux-name> -e AF_HOME=<config-dir>` into `new-session`, **version-gated on tmux ≥ 3.2** (`-e`'s introduction; older tmux simply gets no markers rather than a failed session creation — README only promises "tmux"). `/proc/<pid>/environ` preserves a process's *initial* environment, so even after an orphan is reparented to init, `af doctor` can prove which session and which agent-factory home spawned it. The lazy-respawn path (#386/#595) funnels through `Start()`, so respawned sessions are marked too.

## 2. `af doctor` (read-only by default, `--fix` for verified remediations)

Detection is generous, remediation is conservative — **every kill requires verified ancestry; ambiguity always downgrades to report-only**:

| Check | Detects | `--fix` |
|-------|---------|---------|
| `orphaned-process` | AF_SESSION marker names a session that no longer exists | **kills** (TERM→KILL, identity-guarded, per-item logged) |
| `escaped-process` | marker names a *live* session but the process left its pane tree | report-only (the session still owns it) |
| `possible-orphan` | `TMUX` env points at a dead tmux server, no af marker (this is what the incident's `yes` processes look like pre-markers) | report-only — could belong to any tmux; sorted by CPU so core-burners top the list, capped at 15 + summary |
| `runaway-cpu` | descendant of a live `af_` session averaging ≥80% of a core for ≥30min | report-only (never kills children of live sessions) |
| `leaked-tmux-session` | `af_` session with no backing record in this home's storage | report-only + suggested command — a recordless session may belong to *another* agent-factory home on the same tmux server, and killing someone else's live session is worse than a leak |
| `stale-temp-home` | AF home under the temp dir (≥2 structural markers: config.json/state.json/instances/…), unreferenced by any live process or daemon.pid, untouched ≥7 days (#1093's immortal-daemon fuel) | **removes** (containment-checked under the temp dir, per-item logged) |
| `foreign-daemon` | `af --daemon` process serving a home other than the active one | **kills only when its home directory no longer exists** (unambiguously broken, the #1093 case); an existing foreign home is report-only (may be intentional) |
| `daemon-health` | stale socket, stale pid file, and **replaced-binary detection** (`/proc/<pid>/exe` → " (deleted)": daemon still running a pre-upgrade binary); reports unit-vs-ad-hoc | report-only (restarting the daemon is a user decision) |

Exit code: 1 when unresolved issues remain, 0 when healthy. Documented in `docs/cli.md`.

Verified on the dev box (read-only run): correctly reported the daemon running a since-replaced binary, 62 possible-orphans of dead tmux servers (top-CPU first, capped), and 14 genuinely stale temp AF homes from June's test runs — and correctly proposed kills for nothing it couldn't prove.

## Tests (all hermetic per the #1104 hard rules)

- `internal/proctree`: stat parsing, tree/SID walks, identity-guarded signalling (stale identity **refuses** and the process survives), CPU accounting, environ/cmdline reads — all against the test's own spawned children.
- `session/tmux`: the end-to-end regression — a **SIGHUP-immune (`nohup`) pane child on a private tmux server survives kill-session but not `Close()`**, and not `CleanupSessions()`; mock-safety (non-tmux pane roots and garbage output never captured); surviving sessions never reaped; env-marker injection pinned by exact argv, version gate table-tested.
- `doctor`: every check exercised with a private tmux server (`testguard.IsolateTmux`), temp `AGENT_FACTORY_HOME`, and a **/proc snapshot filtered to the test's own children** so a `--fix` run can act on nothing outside the test; read-only runs signal nothing; live-session processes never killed; leaked sessions survive `--fix`; recycled-pid fix closures no-op; in-use/fresh temp homes spared. Test children are single processes blocked on a `read` builtin (no descendants), so test teardown itself cannot orphan anything — the first draft used `sh -c "sleep 300"`, whose forked sleep leaked exactly the way #1104 describes, and `af doctor` caught its own test suite doing it.

## Gates

`gofmt -l .` clean · `go build ./...` · `go test ./...` green (incl. the two known box-flaky tests) · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean.

Related: #1093 (leaked daemons), #1044 (doctor), #1108 (restore half — not in scope here).

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
