### PR TITLE
test: structural tmux isolation — SandboxTmux package fence + IsolateTmux audit (#1122 PR A)

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -30,11 +30,16 @@ func TestMain(m *testing.M) {
 	// snapshot the real environment, BEFORE logging resolves its file path.
 	verifyTmux := testguard.TmuxTripwire()
 	restoreHome := testguard.SandboxHome()
+	// #1122: default the whole package onto a private tmux server so a test
+	// that forgets IsolateTmux can never create or sweep sessions on the
+	// developer's real server.
+	restoreTmux := testguard.SandboxTmux()
 	log.Initialize(false)
 
 	// Run all tests
 	exitCode := m.Run()
 	log.Close()
+	restoreTmux()
 	restoreHome()
 	if err := verifyRealConfig(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -225,6 +225,11 @@ func killIntegrationDaemon(home string) {
 // by skipping transient (Loading/Deleting) rows entirely.
 func TestTUIRefreshDoesNotSwapLoadingPlaceholder(t *testing.T) {
 	skipIfRealBackendDepsMissing(t)
+	// #1122: this test runs a real `af sessions create` (real daemon, real
+	// tmux). Without a private server the "scripts" session lives on the
+	// ambient server for the test's lifetime — the #1121 CI run's daemon
+	// package tripwired on exactly that transient session.
+	testguard.IsolateTmux(t)
 
 	bin := buildIntegrationBinary(t)
 	repoDir := setupRealRepo(t)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -29,9 +29,14 @@ func TestMain(m *testing.M) {
 	// snapshot the real environment, BEFORE logging resolves its file path.
 	verifyTmux := testguard.TmuxTripwire()
 	restoreHome := testguard.SandboxHome()
+	// #1122: default the whole package onto a private tmux server so a test
+	// that forgets IsolateTmux can never create or sweep sessions on the
+	// developer's real server.
+	restoreTmux := testguard.SandboxTmux()
 	log.Initialize(false)
 	code := m.Run()
 	log.Close()
+	restoreTmux()
 	restoreHome()
 	if err := verifyRealConfig(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -26,10 +26,22 @@ import (
 
 func TestMain(m *testing.M) {
 	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: fail loudly if a test leaks an af_ session onto the ambient tmux
+	// server (doctor tests drive real tmux via IsolateTmux).
+	verifyTmux := testguard.TmuxTripwire()
 	restoreHome := testguard.SandboxHome()
+	// #1122: default the whole package onto a private tmux server so a test
+	// that forgets IsolateTmux can never create or sweep sessions on the
+	// developer's real server.
+	restoreTmux := testguard.SandboxTmux()
 	code := m.Run()
+	restoreTmux()
 	restoreHome()
 	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	if err := verifyTmux(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		code = 1
 	}

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -20,7 +20,12 @@ func TestMain(m *testing.M) {
 	// in-process config/state/log access outside a per-test home stays out
 	// of the developer's real one.
 	restoreHome := testguard.SandboxHome()
+	// #1122: default the whole package onto a private tmux server so a test
+	// that forgets IsolateTmux can never create or sweep sessions on the
+	// developer's real server.
+	restoreTmux := testguard.SandboxTmux()
 	code := m.Run()
+	restoreTmux()
 	restoreHome()
 	if err := verifyRealConfig(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/internal/testguard/testguard.go
+++ b/internal/testguard/testguard.go
@@ -6,8 +6,10 @@
 // user discovering days later that their settings were silently replaced
 // (#837). TmuxTripwire does the same for real tmux sessions leaked onto the
 // developer's tmux server, SandboxHome defaults a whole package into a
-// throwaway AGENT_FACTORY_HOME, and IsolateTmux gives a test a private tmux
-// server so nothing it creates can outlive it (#1056).
+// throwaway AGENT_FACTORY_HOME, SandboxTmux defaults a whole package onto a
+// private tmux server so no test can even see the developer's real one
+// (#1122), and IsolateTmux gives a single test a private server of its own so
+// nothing it creates can outlive it (#1056).
 //
 // This package deliberately has no dependency on the config package — config
 // imports session/tmux, and the tripwire must be usable from that package's
@@ -171,6 +173,14 @@ func TmuxTripwire() func() error {
 // instead of the production daemon log — #1056). Individual tests that
 // t.Setenv their own home still win for their duration; this is the default
 // for tests that never set one.
+//
+// It also scrubs the AF_SESSION/AF_HOME ancestry markers (#1120,
+// session/tmux/envmarker.go — string literals here because testguard stays
+// dependency-free). A test run launched from inside a production af pane
+// inherits the pane's markers, so every child a test spawns would otherwise
+// carry the production install's identity — which breaks any test asserting
+// on marker absence (e.g. doctor's home-match gate) and misattributes test
+// children to the real install.
 func SandboxHome() func() {
 	dir, err := os.MkdirTemp("", "af-test-home-")
 	if err != nil {
@@ -180,13 +190,77 @@ func SandboxHome() func() {
 	if err := os.Setenv("AGENT_FACTORY_HOME", dir); err != nil {
 		panic("testguard: cannot set sandbox AGENT_FACTORY_HOME: " + err.Error())
 	}
+	prevSession, hadSession := os.LookupEnv("AF_SESSION")
+	prevAFHome, hadAFHome := os.LookupEnv("AF_HOME")
+	_ = os.Unsetenv("AF_SESSION")
+	_ = os.Unsetenv("AF_HOME")
 	return func() {
 		if had {
 			_ = os.Setenv("AGENT_FACTORY_HOME", prev)
 		} else {
 			_ = os.Unsetenv("AGENT_FACTORY_HOME")
 		}
+		if hadSession {
+			_ = os.Setenv("AF_SESSION", prevSession)
+		}
+		if hadAFHome {
+			_ = os.Setenv("AF_HOME", prevAFHome)
+		}
 		_ = os.RemoveAll(dir)
+	}
+}
+
+// SandboxTmux points the WHOLE package run at a private tmux server, exactly
+// like SandboxHome does for AGENT_FACTORY_HOME: a fresh TMUX_TMPDIR socket dir
+// with $TMUX cleared, set before any test runs. It is the structural backstop
+// for #1122: a test that forgets IsolateTmux now runs against the package's
+// private server instead of the developer's real one, so an escaped create or
+// a CleanupSessions-style sweep cannot touch production af_ sessions. Tests
+// that need a server of their own still call IsolateTmux; its t.Setenv wins
+// for the test's duration and nests another level down, never back up to the
+// ambient server.
+//
+// Call it from TestMain AFTER TmuxTripwire (which must snapshot the ambient
+// server) and call the returned restore BEFORE the tripwire's verify (so the
+// verify probes the ambient server again). The restore kills the package's
+// private server, so anything a test leaked onto it dies there.
+//
+// No-op (returns a no-op restore) when tmux is not installed — there is no
+// server to fence off, and resolving a socket dir would only mask that.
+func SandboxTmux() func() {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		return func() {}
+	}
+	dir, err := os.MkdirTemp("", "af-tmux-pkg-")
+	if err != nil {
+		panic("testguard: cannot create package tmux socket dir: " + err.Error())
+	}
+	prevTmpdir, hadTmpdir := os.LookupEnv("TMUX_TMPDIR")
+	prevTmux, hadTmux := os.LookupEnv("TMUX")
+	if err := os.Setenv("TMUX_TMPDIR", dir); err != nil {
+		panic("testguard: cannot set package TMUX_TMPDIR: " + err.Error())
+	}
+	// Empty counts as unset for tmux's "am I inside tmux" check; keeping the
+	// real value would make tmux ignore TMUX_TMPDIR entirely ($TMUX wins in
+	// socket resolution).
+	if err := os.Setenv("TMUX", ""); err != nil {
+		panic("testguard: cannot clear TMUX: " + err.Error())
+	}
+	return func() {
+		// Kill the package server BEFORE restoring the env so the kill
+		// targets the private socket dir, then drop it.
+		_ = exec.Command("tmux", "kill-server").Run()
+		_ = os.RemoveAll(dir)
+		if hadTmpdir {
+			_ = os.Setenv("TMUX_TMPDIR", prevTmpdir)
+		} else {
+			_ = os.Unsetenv("TMUX_TMPDIR")
+		}
+		if hadTmux {
+			_ = os.Setenv("TMUX", prevTmux)
+		} else {
+			_ = os.Unsetenv("TMUX")
+		}
 	}
 }
 

--- a/internal/testguard/testguard.go
+++ b/internal/testguard/testguard.go
@@ -202,9 +202,13 @@ func SandboxHome() func() {
 		}
 		if hadSession {
 			_ = os.Setenv("AF_SESSION", prevSession)
+		} else {
+			_ = os.Unsetenv("AF_SESSION")
 		}
 		if hadAFHome {
 			_ = os.Setenv("AF_HOME", prevAFHome)
+		} else {
+			_ = os.Unsetenv("AF_HOME")
 		}
 		_ = os.RemoveAll(dir)
 	}

--- a/internal/testguard/testguard_test.go
+++ b/internal/testguard/testguard_test.go
@@ -153,6 +153,47 @@ func TestSandboxHome_SetsAndRestores(t *testing.T) {
 	}
 }
 
+// TestSandboxTmux_SetsAndRestores pins the #1122 backstop: SandboxTmux must
+// repoint TMUX_TMPDIR at a fresh socket dir, clear TMUX, and put both back on
+// restore — so a whole package runs against a private tmux server and a test
+// that forgets IsolateTmux still cannot reach the developer's real one.
+func TestSandboxTmux_SetsAndRestores(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("tmux not available: %v", err)
+	}
+	t.Setenv("TMUX_TMPDIR", "/pre-sandbox-tmpdir")
+	t.Setenv("TMUX", "/pre-sandbox-socket,123,0")
+
+	restore := SandboxTmux()
+	dir := os.Getenv("TMUX_TMPDIR")
+	if dir == "/pre-sandbox-tmpdir" || dir == "" {
+		t.Fatalf("SandboxTmux did not repoint TMUX_TMPDIR; got %q", dir)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("sandbox socket dir %q not usable: %v", dir, err)
+	}
+	if got := os.Getenv("TMUX"); got != "" {
+		t.Fatalf("SandboxTmux must clear TMUX (it wins over TMUX_TMPDIR in socket resolution); got %q", got)
+	}
+
+	// A session created inside the sandbox must die with it on restore.
+	const name = "af_sandboxtmux_test"
+	if out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sleep", "60").CombinedOutput(); err != nil {
+		t.Skipf("cannot start tmux session on sandbox server: %v: %s", err, out)
+	}
+
+	restore()
+	if got := os.Getenv("TMUX_TMPDIR"); got != "/pre-sandbox-tmpdir" {
+		t.Fatalf("restore did not put TMUX_TMPDIR back; got %q", got)
+	}
+	if got := os.Getenv("TMUX"); got != "/pre-sandbox-socket,123,0" {
+		t.Fatalf("restore did not put TMUX back; got %q", got)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("restore did not remove sandbox socket dir %q; stat err=%v", dir, err)
+	}
+}
+
 // TestTmuxTripwire_FiresOnLeakedSession exercises the tripwire against the
 // private server IsolateTmux provides, so the test itself is hermetic: the
 // "ambient" server the tripwire snapshots is the throwaway one.

--- a/internal/testguard/testguard_test.go
+++ b/internal/testguard/testguard_test.go
@@ -153,6 +153,43 @@ func TestSandboxHome_SetsAndRestores(t *testing.T) {
 	}
 }
 
+// TestSandboxHome_ScrubsAndRestoresMarkers pins the #1120 marker contract:
+// SandboxHome scrubs AF_SESSION/AF_HOME for the package run, and restore puts
+// each marker back to its exact pre-sandbox state — including unsetting a
+// marker that was absent before but got set during the run, so nothing set
+// mid-package leaks past restore.
+func TestSandboxHome_ScrubsAndRestoresMarkers(t *testing.T) {
+	// Present before: must be scrubbed during the run and restored after.
+	t.Setenv("AF_SESSION", "pre-sandbox-session")
+	// Absent before: t.Setenv registers restoration of the original value,
+	// then Unsetenv makes it genuinely absent for SandboxHome to observe.
+	t.Setenv("AF_HOME", "placeholder")
+	if err := os.Unsetenv("AF_HOME"); err != nil {
+		t.Fatalf("unset AF_HOME: %v", err)
+	}
+
+	restore := SandboxHome()
+	if v, ok := os.LookupEnv("AF_SESSION"); ok {
+		t.Fatalf("SandboxHome must scrub AF_SESSION; still set to %q", v)
+	}
+	if v, ok := os.LookupEnv("AF_HOME"); ok {
+		t.Fatalf("SandboxHome must scrub AF_HOME; still set to %q", v)
+	}
+
+	// Simulate a test (or child-env plumbing) setting a marker mid-run.
+	if err := os.Setenv("AF_HOME", "set-during-run"); err != nil {
+		t.Fatalf("set AF_HOME: %v", err)
+	}
+
+	restore()
+	if got := os.Getenv("AF_SESSION"); got != "pre-sandbox-session" {
+		t.Fatalf("restore did not put AF_SESSION back; got %q", got)
+	}
+	if v, ok := os.LookupEnv("AF_HOME"); ok {
+		t.Fatalf("restore must unset AF_HOME (absent pre-sandbox); still set to %q", v)
+	}
+}
+
 // TestSandboxTmux_SetsAndRestores pins the #1122 backstop: SandboxTmux must
 // repoint TMUX_TMPDIR at a fresh socket dir, clear TMUX, and put both back on
 // restore — so a whole package runs against a private tmux server and a test

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -39,9 +39,14 @@ func TestMain(m *testing.M) {
 	// snapshot the real environment, BEFORE logging resolves its file path.
 	verifyTmux := testguard.TmuxTripwire()
 	restoreHome := testguard.SandboxHome()
+	// #1122: default the whole package onto a private tmux server so a test
+	// that forgets IsolateTmux can never create or sweep sessions on the
+	// developer's real server.
+	restoreTmux := testguard.SandboxTmux()
 	log.Initialize(false)
 	code := m.Run()
 	log.Close()
+	restoreTmux()
 	restoreHome()
 	if err := verifyRealConfig(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -32,9 +32,15 @@ func TestMain(m *testing.M) {
 	// snapshot the real environment, BEFORE logging resolves its file path.
 	verifyTmux := testguard.TmuxTripwire()
 	restoreHome := testguard.SandboxHome()
+	// #1122: default the whole package onto a private tmux server so a test
+	// that forgets IsolateTmux can never create or sweep sessions on the
+	// developer's real server. CleanupSessions runs in this package's tests —
+	// exactly the sweep that killed every production session in outage #3.
+	restoreTmux := testguard.SandboxTmux()
 	aflog.Initialize(false)
 	code := m.Run()
 	aflog.Close()
+	restoreTmux()
 	restoreHome()
 	if err := verifyRealConfig(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/ui/main_test.go
+++ b/ui/main_test.go
@@ -11,14 +11,26 @@ import (
 func TestMain(m *testing.M) {
 	// #837: fail the package loudly if any test touches the real config.json.
 	verifyRealConfig := testguard.ConfigTripwire()
+	// #1056: fail loudly if a test leaks an af_ session onto the ambient tmux
+	// server (preview tests issue real tmux kill-session commands).
+	verifyTmux := testguard.TmuxTripwire()
 	// #1056: default the whole package into a sandboxed AGENT_FACTORY_HOME.
 	// Many tests here call log.Initialize without setting a home of their
 	// own; the sandbox routes those log files (and any stray config/state
 	// writes) into a temp dir instead of the developer's real one.
 	restoreHome := testguard.SandboxHome()
+	// #1122: default the whole package onto a private tmux server so a test
+	// that forgets IsolateTmux can never create or sweep sessions on the
+	// developer's real server.
+	restoreTmux := testguard.SandboxTmux()
 	code := m.Run()
+	restoreTmux()
 	restoreHome()
 	if err := verifyRealConfig(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		code = 1
+	}
+	if err := verifyTmux(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		code = 1
 	}


### PR DESCRIPTION
## What

Structural test isolation for the #1122 P0: **no test can reach the developer's real tmux server anymore**, whether or not it remembers `testguard.IsolateTmux`.

- **`testguard.SandboxTmux()`** — package-level analogue of `SandboxHome`: `TestMain` points the whole package at a fresh private `TMUX_TMPDIR` with `$TMUX` cleared before any test runs; the restore kills the private server and removes the socket dir. A test that forgets `IsolateTmux` now escapes onto a throwaway package server that dies with the run — never onto the ambient one. `IsolateTmux` still nests inside it (`t.Setenv` wins for the test's duration) for tests that need a server of their own.
- Wired into `TestMain` of every package that can touch tmux: **daemon, app, integration, session, session/tmux, doctor, ui**. doctor and ui also gain the #1056 `TmuxTripwire` they were missing.
- **`TestTUIRefreshDoesNotSwapLoadingPlaceholder`** (`app/cli_daemon_integration_test.go`) now calls `IsolateTmux` — it was the one test in that file missing it (its two siblings both call it). It runs a real `af sessions create --name scripts` through a real daemon, i.e. it is the origin of the `af_d16f407b_scripts` ambient session.
- **`SandboxHome` now scrubs the #1120 `AF_SESSION`/`AF_HOME` ancestry markers.** Since #1120, every process in an af pane carries them — so a test run launched from inside a production af session stamped the production install's identity onto every child a test spawned. That broke doctor's home-match-gate test (`TestOrphanWithoutProvenHomeSurvivesFix` fails on unmodified master when run from an af pane — reproduced) and is the same "test inherits production identity" class as the tmux gap.

## Root cause of the #1121 CI tripwire failure

CI run 28672862153 failed with `tmux tripwire: ... [af_d16f407b_scripts] ... FAIL github.com/sachiniyer/agent-factory/daemon` — but **every daemon test passed**, and the daemon package has no `scripts`-titled test. What happened:

1. `go test ./...` runs package test binaries **concurrently**, and all of them shared CI's ambient tmux server.
2. The app package's `TestTUIRefreshDoesNotSwapLoadingPlaceholder` (its **last** test, per the log ordering) created the real session `af_<hash(tempRepoDir)>_scripts` on that shared server for its ~1.4s lifetime.
3. The daemon package's binary happened to finish inside that window: its `TmuxTripwire` verify saw a session that wasn't in its start-of-package snapshot and correctly reported a leak — attributed to the wrong package. The app package's own verify ran after its cleanup had killed the session, so app passed.

So the tripwire did its job (a test touched the ambient server), but cross-package attribution made it look like a daemon flake. With this PR the ambient server is unreachable from every package, which fixes both the leak and the misattribution class.

## Audit trail (fix all / justify exclusions)

Every `TestMain` in the repo was reviewed, plus a repo-wide grep for `exec.Command("tmux"` and real-`TmuxSession` construction in tests:

| Package | tmux exposure | Action |
|---|---|---|
| daemon | spawns real processes; tripwire fired here on CI | SandboxTmux (its own tests were already mock/stub-based — `stubTaskDelivery`, `installInstantBackend`, renamed-`sleep` fake daemons) |
| app | real `af` binary + real daemon + real tmux in 3 integration tests | SandboxTmux + `IsolateTmux` on the missing test |
| integration | real daemons + tmux (already `IsolateTmux` everywhere) | SandboxTmux as backstop |
| session | backend e2e spawns real processes | SandboxTmux as backstop |
| session/tmux | real tmux + `CleanupSessions` sweeps (reap tests) | SandboxTmux as backstop — this is the package whose sweep class killed the box |
| doctor | real tmux via `IsolateTmux`; **no TmuxTripwire before** | SandboxTmux + TmuxTripwire added |
| ui | `preview_test.go` issues a real best-effort `tmux kill-session -t af_<name>` (bare `-t` = prefix match) against ambient | SandboxTmux + TmuxTripwire added |
| internal/testguard | hermetic by design (its tmux tests run under their own `IsolateTmux`) | tests added for SandboxTmux |
| config, task, api, session/git, ui/layout, ui/tree, ui/layout/zones, cmd, keys, log, root pkg | no tmux reach (mock executors or no process spawning) | excluded — nothing to fence |

## Verification

- `go build ./...`, `gofmt -l .` (clean), `golangci-lint run --timeout=3m --fast` (clean), `deadcode -test ./...` (clean).
- Full `go test ./... -count=1` green under an outer `TMUX_TMPDIR` guard.
- Ambient-server safety verified directly on a box with **live production af sessions**: snapshotted `tmux ls` before/after the previously-leaking app test and again after the full suite — zero ambient change (the only diffs were new production sessions the real daemon created mid-run, which is the documented tripwire caveat).
- The doctor marker-scrub fix reproduced red on unmodified master (run from inside an af pane) and green with this PR.

Part of #1122 (fix 1 of 3). PR B (home-scoped `CleanupSessions`) and PR C (root-ensure re-arm) follow.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
