### PR TITLE
session: home-scope the af reset tmux sweep via the AF_HOME marker (#1122)

### DIFF
--- a/session/tmux/cleanup_bug_test.go
+++ b/session/tmux/cleanup_bug_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
@@ -14,6 +15,7 @@ import (
 // destroyed. After the fix, only sessions whose names start with the `af_`
 // prefix are killed.
 func TestCleanupSessionsOnlyKillsPrefixedSessions(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", "/owned-home")
 	tmuxOutput := `my_af_project: 1 windows (created Wed May 20 12:00:00 2026) [179x47]
 af_real_session: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 
@@ -28,6 +30,11 @@ af_real_session: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 			return nil
 		},
 		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			// Every session carries this home's ownership marker (#1122) so
+			// the test isolates the prefix-anchoring behavior.
+			if len(cmd.Args) > 1 && cmd.Args[1] == "show-environment" {
+				return []byte("AF_HOME=/owned-home\n"), nil
+			}
 			return []byte(tmuxOutput), nil
 		},
 	}
@@ -44,6 +51,7 @@ af_real_session: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 // but the cleanup path should still extract the name through the first ':'
 // without duplicating the kill).
 func TestCleanupSessionsHandlesMixedAndColonNames(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", "/owned-home")
 	tmuxOutput := `my_af_personal: 1 windows (created Wed May 20 12:00:00 2026) [179x47]
 af_real_session: 1 windows (created Wed May 20 12:01:00 2026) [179x47]
 prefix_af_other: 1 windows (created Wed May 20 12:02:00 2026) [179x47]
@@ -60,6 +68,9 @@ af_a:b:c: 1 windows (created Wed May 20 12:03:00 2026) [179x47]`
 			return nil
 		},
 		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			if len(cmd.Args) > 1 && cmd.Args[1] == "show-environment" {
+				return []byte("AF_HOME=/owned-home\n"), nil
+			}
 			return []byte(tmuxOutput), nil
 		},
 	}
@@ -68,4 +79,48 @@ af_a:b:c: 1 windows (created Wed May 20 12:03:00 2026) [179x47]`
 	require.NoError(t, err)
 	require.Equal(t, []string{"=af_real_session:", "=af_a:"}, killedSessions,
 		"only `af_`-prefixed sessions should be killed via `=name:` exact-match targets (#1006), with `af_a:b:c` truncated to `af_a` and killed exactly once")
+}
+
+// TestCleanupSessionsOnlyKillsOwnedSessions guards the #1122 home-scoping:
+// the af_ prefix alone is not ownership. A session stamped with another
+// agent-factory home's AF_HOME marker (a second install, or a test sandbox
+// whose sweep escaped onto this server) and a session with no marker at all
+// (pre-marker build, tmux <3.2) must both survive the sweep; only sessions
+// carrying THIS home's marker die.
+func TestCleanupSessionsOnlyKillsOwnedSessions(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", "/owned-home")
+	tmuxOutput := `af_mine: 1 windows (created Wed May 20 12:00:00 2026) [179x47]
+af_theirs: 1 windows (created Wed May 20 12:01:00 2026) [179x47]
+af_legacy: 1 windows (created Wed May 20 12:02:00 2026) [179x47]`
+
+	var killedSessions []string
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			for i, arg := range cmd.Args {
+				if arg == "-t" && i+1 < len(cmd.Args) {
+					killedSessions = append(killedSessions, cmd.Args[i+1])
+				}
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			if len(cmd.Args) > 1 && cmd.Args[1] == "show-environment" {
+				switch {
+				case strings.Contains(strings.Join(cmd.Args, " "), "af_mine"):
+					return []byte("AF_HOME=/owned-home\n"), nil
+				case strings.Contains(strings.Join(cmd.Args, " "), "af_theirs"):
+					return []byte("AF_HOME=/another-home\n"), nil
+				default:
+					// tmux exits non-zero when the variable is unset.
+					return nil, errExit1
+				}
+			}
+			return []byte(tmuxOutput), nil
+		},
+	}
+
+	err := CleanupSessions(cmdExec)
+	require.NoError(t, err)
+	require.Equal(t, []string{"=af_mine:"}, killedSessions,
+		"only the session carrying this home's AF_HOME marker may be killed; foreign-home and marker-less sessions must survive (#1122)")
 }

--- a/session/tmux/envmarker.go
+++ b/session/tmux/envmarker.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/sachiniyer/agent-factory/cmd"
 )
 
 // Ancestry env markers (#1104). Every process spawned inside an af tmux pane
@@ -47,6 +49,21 @@ func sessionEnvFlags(sanitizedName string) []string {
 		flags = append(flags, "-e", EnvMarkerHome+"="+home)
 	}
 	return flags
+}
+
+// sessionHomeMarker reads the AF_HOME ancestry marker from a tmux session's
+// environment (stamped via `new-session -e` at creation). Returns ("", false)
+// when the session carries no marker — created by a pre-marker build or by a
+// tmux older than 3.2, which cannot set session environment at creation.
+func sessionHomeMarker(cmdExec cmd.Executor, sanitizedName string) (string, bool) {
+	out, err := cmdExec.Output(exec.Command("tmux", "show-environment", "-t", exactTarget(sanitizedName), EnvMarkerHome))
+	if err != nil {
+		// show-environment exits non-zero when the variable is unset.
+		return "", false
+	}
+	// One line of the form AF_HOME=/path; a leading '-' (variable marked for
+	// removal) or any other shape counts as no marker.
+	return strings.CutPrefix(strings.TrimSpace(string(out)), EnvMarkerHome+"=")
 }
 
 var (

--- a/session/tmux/idempotent_close_test.go
+++ b/session/tmux/idempotent_close_test.go
@@ -78,6 +78,7 @@ func TestClose_SessionSurvivesKill_StillErrors(t *testing.T) {
 // (TOCTOU). A gone session is the goal of cleanup, so the vanished one must not
 // fail the sweep, while a survivor still does.
 func TestCleanupSessions_ToleratesVanishedSession(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", "/owned-home")
 	const lsOutput = `af_gone: 1 windows (created Wed May 20 12:00:00 2026) [179x47]
 af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 
@@ -116,6 +117,10 @@ af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 				return nil
 			},
 			OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+				if len(c.Args) > 1 && c.Args[1] == "show-environment" {
+					// Both sessions carry this home's marker (#1122).
+					return []byte("AF_HOME=/owned-home\n"), nil
+				}
 				if strings.Contains(strings.Join(c.Args, " "), "ls") {
 					return []byte(lsOutput), nil
 				}
@@ -142,6 +147,10 @@ af_stuck: 1 windows (created Wed May 20 12:01:00 2026) [179x47]`
 				return nil
 			},
 			OutputFunc: func(c *exec.Cmd) ([]byte, error) {
+				if len(c.Args) > 1 && c.Args[1] == "show-environment" {
+					// Both sessions carry this home's marker (#1122).
+					return []byte("AF_HOME=/owned-home\n"), nil
+				}
 				if strings.Contains(strings.Join(c.Args, " "), "ls") {
 					return []byte(lsOutput), nil
 				}

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -91,6 +91,15 @@ func TestCleanupSessionsReapsEscapedProcesses(t *testing.T) {
 	shrinkReapWaits(t)
 
 	escapee := spawnSessionWithEscapee(t, "af_reap-reset-test")
+
+	// Stamp this home's ownership marker: the sweep only kills sessions it
+	// can prove it owns (#1122), and the raw `tmux new-session` above does
+	// not go through the af creation path that stamps it.
+	home, err := afHomeDir()
+	require.NoError(t, err)
+	out, err := exec.Command("tmux", "set-environment", "-t", "=af_reap-reset-test", EnvMarkerHome, home).CombinedOutput()
+	require.NoError(t, err, "set-environment: %s", out)
+
 	require.NoError(t, CleanupSessions(cmd.MakeExecutor()))
 
 	// Synchronous contract: by the time CleanupSessions returns, the sweep

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1188,7 +1189,14 @@ func (t *TmuxSession) CapturePaneContentWithOptions(start, end string) (string, 
 	return string(output), nil
 }
 
-// CleanupSessions kills all tmux sessions that start with "session-"
+// CleanupSessions kills every af_-prefixed tmux session owned by THIS
+// agent-factory home, ownership proven by the AF_HOME session-environment
+// marker stamped at creation (#1120). Sessions carrying another home's marker
+// (a second install, a test's sandbox home) and sessions with no marker at
+// all (pre-marker builds, tmux <3.2) are skipped and logged: killing a
+// session this home cannot prove it owns is worse than leaving it, and a
+// test sweep that escapes onto the developer's real server must be a no-op
+// (#1122). `af doctor` lists unowned af_ sessions with a manual kill command.
 func CleanupSessions(cmdExec cmd.Executor) error {
 	// First try to list sessions
 	cmd := exec.Command("tmux", "ls")
@@ -1206,9 +1214,29 @@ func CleanupSessions(cmdExec cmd.Executor) error {
 	// Anchor to start-of-line so `af_` embedded in a non-agent session name
 	// (e.g. `my_af_project:`) is never matched and killed (#613).
 	re := regexp.MustCompile(fmt.Sprintf(`(?m)^%s[^:]*:`, regexp.QuoteMeta(TmuxPrefix)))
-	matches := re.FindAllString(string(output), -1)
-	for i, match := range matches {
-		matches[i] = match[:strings.Index(match, ":")]
+	prefixed := re.FindAllString(string(output), -1)
+	for i, match := range prefixed {
+		prefixed[i] = match[:strings.Index(match, ":")]
+	}
+
+	// Home-scope the sweep (#1122): the af_ prefix alone does not prove this
+	// home owns the session — another install or an escaped test process can
+	// see the same server. Only the AF_HOME marker match does.
+	ownHome, err := afHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot resolve this agent-factory home; refusing to sweep tmux sessions: %w", err)
+	}
+	matches := make([]string, 0, len(prefixed))
+	for _, match := range prefixed {
+		home, ok := sessionHomeMarker(cmdExec, match)
+		switch {
+		case !ok:
+			log.InfoLog.Printf("leaving tmux session %s: no AF_HOME ownership marker (pre-marker build or tmux <3.2); kill manually with: tmux kill-session -t '=%s'", match, match)
+		case filepath.Clean(home) != filepath.Clean(ownHome):
+			log.InfoLog.Printf("leaving tmux session %s: owned by another agent-factory home (%s)", match, home)
+		default:
+			matches = append(matches, match)
+		}
 	}
 
 	// Capture every session's pane process trees before any kill (#1104);


### PR DESCRIPTION
Part of the #1122 P0 workstream (PR B of A/B/C; PR A = #1125).

## Problem

`tmux.CleanupSessions` (the `af reset` sweep) killed every `af_`-prefixed session on whatever tmux server the process could reach. The prefix is not ownership: a second agent-factory install shares it, and a test process whose sweep escaped its sandbox onto the developer's real server shares it too — the destructive half of the 2026-07-03 outage.

## Fix

The sweep now proves per-session ownership with the `AF_HOME` session-environment marker stamped at `new-session` time (#1120), read via `tmux show-environment`:

- marker matches this home → killed and reaped, as before
- marker names another home → skipped, logged
- no marker (pre-marker build, or tmux < 3.2 which cannot stamp session env at creation) → skipped, logged with a manual `kill-session` command; `af doctor` already lists unowned `af_` sessions with the same guidance

An escaped test sweep is now structurally a no-op: a sandboxed temp home can never match a production session's marker. Roll-forward semantics per repo precedent: marker-less legacy sessions are not swept — the log line and `af doctor` give the manual path.

## Audit of every bare `af_` name-scan (adjacent call sites)

| Site | Verdict |
|---|---|
| `tmux.CleanupSessions` | **fixed here** — was the only prefix-scoped *kill* path |
| `doctor.checkLeakedTmuxSessions` | excluded: report-only by design, and already marker-aware (attributes each session to its `AF_HOME` origin) |
| `doctor.checkRunawayChildren` | excluded: report-only, never kills |
| `daemon.ghostKillTmuxByName` | excluded: kills exact names read from **this home's own** instances.json; the prefix check there is a refuse-guard against corrupted stores, not a scan |
| `testguard.ambientAFSessions` | excluded: leak tripwire — deliberately observes the ambient server, report-only |

## Testing

- New `TestCleanupSessionsOnlyKillsOwnedSessions`: owned / foreign-home / marker-less matrix — only the owned session dies
- Existing mock tests updated to answer the `show-environment` ownership probe; `TestCleanupSessionsReapsEscapedProcesses` stamps the marker on its raw-created session
- `go build ./...`, full test suite (non-daemon + daemon, on a private tmux socket), `golangci-lint --fast`, `gofmt -l`, `deadcode -test` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)