### PR TITLE
daemon: root-ensure never gives up permanently — retries settle at the backoff cap (#1122)

### DIFF
--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -30,12 +30,16 @@ import (
 // root-agent profile).
 const rootDangerouslySkipPermissionsFlag = "--dangerously-skip-permissions"
 
-// rootEnsureMaxConsecutiveFailures caps how many consecutive failed ensure
-// attempts a configured repo gets before the loop gives up on it until the
-// daemon restarts. Failures back off exponentially in between, so the cap is
-// a backstop against permanently broken configs (a deleted repo path, an
-// unparseable persisted root record), not a race against transient errors.
-const rootEnsureMaxConsecutiveFailures = 6
+// rootEnsureEscalationThreshold is the consecutive-failure count at which the
+// ensure loop escalates to a one-time ERROR log: the cause now looks
+// persistent (a deleted repo path, an unparseable persisted root record), not
+// transient. The loop never stops retrying — it settles at the
+// rootEnsureBackoffMax cadence instead. A permanent give-up here is what kept
+// root agents down for hours after the 2026-07-03 tmux-server outage: the
+// outage outlasted the six fast attempts, and recovery then depended on a
+// daemon restart. Any outage that ends must heal on the next retry, whatever
+// the failure looked like while it lasted (#1122).
+const rootEnsureEscalationThreshold = 6
 
 // Backoff between failed ensure attempts for one repo: base doubles per
 // consecutive failure, capped at max. Package vars so tests can shorten them.
@@ -50,7 +54,6 @@ var (
 type rootEnsureState struct {
 	consecutiveFailures int
 	nextAttempt         time.Time
-	gaveUp              bool
 	// suppressLogged dedupes the "not re-creating a user-killed root" log
 	// line to once per suppression.
 	suppressLogged bool
@@ -76,7 +79,8 @@ func (m *Manager) EnsureRootAgents() {
 // ensureRootAgent guarantees the root agent for one configured repo path:
 // adopt a live root untouched, heal a Dead one in place, create a missing
 // one, and respect an explicit user kill. All outcomes are logged; failures
-// back off and eventually give up (rootEnsureMaxConsecutiveFailures).
+// back off exponentially and settle at the rootEnsureBackoffMax cadence, so
+// the loop always heals eventually once the cause clears.
 func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
 	m.mu.Lock()
 	st := m.rootEnsureStates[path]
@@ -84,7 +88,7 @@ func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
 		st = &rootEnsureState{}
 		m.rootEnsureStates[path] = st
 	}
-	skip := st.gaveUp || time.Now().Before(st.nextAttempt)
+	skip := time.Now().Before(st.nextAttempt)
 	m.mu.Unlock()
 	if skip {
 		return
@@ -181,23 +185,33 @@ func (m *Manager) rootEnsureSucceeded(st *rootEnsureState) {
 }
 
 // rootEnsureFailed records a failed ensure attempt: exponential backoff up to
-// rootEnsureBackoffMax, and after rootEnsureMaxConsecutiveFailures in a row
-// the repo is dropped until the daemon restarts. Every outcome is logged.
+// rootEnsureBackoffMax, where the retry cadence stays for as long as the
+// failures do. Retrying forever (instead of giving up until restart) is what
+// guarantees a root heals after a tmux-server outage of any length — an
+// outage is indistinguishable from a broken config while it lasts, and only
+// a later retry can tell the difference (#1122). The cost for a genuinely
+// broken config is one cheap failed attempt per cadence interval, each
+// logged. Crossing rootEnsureEscalationThreshold logs one ERROR so a
+// persistent cause is visible without waiting for a user to notice the
+// missing root.
 func (m *Manager) rootEnsureFailed(path string, st *rootEnsureState, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	st.consecutiveFailures++
-	if st.consecutiveFailures >= rootEnsureMaxConsecutiveFailures {
-		st.gaveUp = true
-		log.ErrorLog.Printf("root agent ensure for %q failed %d consecutive times; giving up until the daemon restarts: %v", path, st.consecutiveFailures, err)
-		return
-	}
-	backoff := rootEnsureBackoffBase << (st.consecutiveFailures - 1)
-	if backoff > rootEnsureBackoffMax {
-		backoff = rootEnsureBackoffMax
+	backoff := rootEnsureBackoffMax
+	// Guard the shift: past ~16 doublings the exponential form has no
+	// meaning and would overflow.
+	if shift := st.consecutiveFailures - 1; shift < 16 {
+		if b := rootEnsureBackoffBase << shift; b < backoff {
+			backoff = b
+		}
 	}
 	st.nextAttempt = time.Now().Add(backoff)
-	log.WarningLog.Printf("root agent ensure for %q failed (attempt %d/%d), retrying in %s: %v", path, st.consecutiveFailures, rootEnsureMaxConsecutiveFailures, backoff, err)
+	if st.consecutiveFailures == rootEnsureEscalationThreshold {
+		log.ErrorLog.Printf("root agent ensure for %q failed %d consecutive times; the cause looks persistent — will keep retrying every %s: %v", path, st.consecutiveFailures, rootEnsureBackoffMax, err)
+		return
+	}
+	log.WarningLog.Printf("root agent ensure for %q failed (attempt %d), retrying in %s: %v", path, st.consecutiveFailures, backoff, err)
 }
 
 // rootAgentProgram resolves the command the root agent runs. An explicit

--- a/daemon/rootagent_test.go
+++ b/daemon/rootagent_test.go
@@ -1,6 +1,9 @@
 package daemon
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -234,10 +237,12 @@ func TestEnsureRootAgentsRespectsUserKill(t *testing.T) {
 	}
 }
 
-// TestEnsureRootAgentsBackoffAndGiveUp: a permanently failing entry (path
-// that is not a git repo) is retried with backoff and dropped after the cap,
-// never spinning forever.
-func TestEnsureRootAgentsBackoffAndGiveUp(t *testing.T) {
+// TestEnsureRootAgentsKeepsRetryingAndHeals is the #1122 outage regression
+// test: a failing entry must keep being retried PAST the escalation threshold
+// (never permanently dropped — that is what left roots down for hours after
+// the 2026-07-03 tmux-server outage), and the first attempt after the cause
+// clears must heal the root with no daemon restart.
+func TestEnsureRootAgentsKeepsRetryingAndHeals(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	installInstantBackend(t)
 
@@ -246,13 +251,17 @@ func TestEnsureRootAgentsBackoffAndGiveUp(t *testing.T) {
 	rootEnsureBackoffBase = 0
 	t.Cleanup(func() { rootEnsureBackoffBase = prevBase })
 
-	badPath := t.TempDir() // a directory, but not a git repo
+	badPath := filepath.Join(t.TempDir(), "repo") // does not exist yet
+	if err := os.MkdirAll(badPath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
 	manager, err := NewManager(rootTestConfig(badPath, config.RootAgentConfig{}))
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
 
-	for i := 0; i < rootEnsureMaxConsecutiveFailures+3; i++ {
+	attempts := rootEnsureEscalationThreshold + 3
+	for i := 0; i < attempts; i++ {
 		manager.EnsureRootAgents()
 	}
 
@@ -262,11 +271,32 @@ func TestEnsureRootAgentsBackoffAndGiveUp(t *testing.T) {
 	if st == nil {
 		t.Fatalf("expected ensure state for %q", badPath)
 	}
-	if !st.gaveUp {
-		t.Fatalf("expected ensure to give up after %d consecutive failures", rootEnsureMaxConsecutiveFailures)
+	if st.consecutiveFailures != attempts {
+		t.Fatalf("ensure must keep attempting past the escalation threshold: want %d failures, got %d", attempts, st.consecutiveFailures)
 	}
-	if st.consecutiveFailures != rootEnsureMaxConsecutiveFailures {
-		t.Fatalf("attempts must stop at the cap: want %d, got %d", rootEnsureMaxConsecutiveFailures, st.consecutiveFailures)
+
+	// The cause clears: the directory becomes a real git repo (stands in for
+	// "the tmux server outage ended"). The very next pass must heal.
+	for _, args := range [][]string{
+		{"init", badPath},
+		{"-C", badPath, "config", "user.email", "test@example.com"},
+		{"-C", badPath, "config", "user.name", "Test User"},
+		{"-C", badPath, "commit", "--allow-empty", "-m", "init"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	manager.EnsureRootAgents()
+
+	if findRootInstance(t, manager, badPath) == nil {
+		t.Fatalf("first ensure pass after the cause cleared must create the root without a daemon restart")
+	}
+	manager.mu.Lock()
+	failures := st.consecutiveFailures
+	manager.mu.Unlock()
+	if failures != 0 {
+		t.Fatalf("healing must reset the failure counter, got %d", failures)
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,7 @@ Behavior and guarantees:
 - **Adopt, never clobber.** If a session titled `root` already exists and is alive — however it was created — the daemon leaves it completely alone. Only a `root` whose tmux has died (status `Dead`) or that is missing entirely is (re-)created.
 - **The name `root` is reserved.** Normal session creation (TUI, `af sessions create`, the API, task spawns) rejects the title `root` (case-insensitively); auto-derived titles skip it.
 - **An explicit kill is respected.** If you kill the `root` session (TUI `D`, `af sessions kill root`), the daemon does not resurrect it until the next daemon restart, at which point the configured state is re-asserted.
-- **Failures back off and cap.** If ensuring a root repeatedly fails (e.g. the configured path is not a git repository), the daemon retries with exponential backoff and gives up for that repo after 6 consecutive failures until it restarts, logging each outcome to the application log.
+- **Failures back off but never give up.** If ensuring a root repeatedly fails (e.g. the configured path is not a git repository, or the tmux server is temporarily unusable), the daemon retries with exponential backoff that settles at one attempt every 5 minutes, logging each outcome to the application log (with an escalation to ERROR after 6 consecutive failures). The first attempt after the cause clears heals the root — no daemon restart needed.
 - Changes to `root_agents` are picked up on the next **daemon restart**.
 
 Because the default profile skips permission prompts and auto-accepts, only opt in repositories where you are comfortable with a fully autonomous agent running at the repo root.


### PR DESCRIPTION
Part of the #1122 P0 workstream (PR C of A/B/C; A = #1125, B = #1127, both merged).

## Problem

After 6 consecutive failed ensure attempts, the root-agent loop dropped the repo until the next daemon restart. The six attempts span only ~5 minutes of exponential backoff, so any tmux-server outage longer than that wedged the root permanently. In the 2026-07-03 outages this was timing-dependent: the 18:13 outage self-healed only because the server returned inside the backoff window; the morning outage did not, and root stayed down until a manual daemon restart.

## Why not a "server returned" probe

The original task framing was to reset the give-up when tmux server availability returns. But a probe can't reliably see this outage class: with the server killed, `tmux new-session` simply starts a fresh server — the ensure failures came from the hostile environment (kill-storms racing creates), not from a probeable "server absent" state. A probe-gated reset would have worked for neither of today's outages. An outage is indistinguishable from a broken config **while it lasts**; only a later retry can tell the difference.

## Fix

The loop never stops retrying. Backoff still grows 10s → 5min exponentially, then stays at the 5-minute cadence for as long as failures continue. The old cap (`rootEnsureMaxConsecutiveFailures`, now `rootEnsureEscalationThreshold`) becomes a one-time ERROR-log escalation so a genuinely persistent cause (deleted repo path, unparseable record) is visible in the log rather than silently parked. The first attempt after the cause clears heals the root — guaranteed, no restart, regardless of what the failure looked like.

Cost for a permanently broken config: one cheap failed attempt + one WARNING line per 5 minutes, which is also exactly the signal the log monitor needs.

## Watch-event replay (assessed, deferred)

During an outage, watch-task events whose delivery fails are logged and dropped (`handleEvent` → `deliver` error). A fix is **not contained**: deliveries are deliberately synchronous on the watcher's single reader goroutine (backpressure via the script's stdout pipe), so an in-place retry must become stop-aware or it wedges `runOnce`'s EOF-drain contract at shutdown, and true replay across an outage needs durable queueing with ordering/dedup decisions. Filed as a follow-up issue instead of riding along here.

## Testing

- New `TestEnsureRootAgentsKeepsRetryingAndHeals`: drives the loop past the escalation threshold (no permanent drop), then clears the failure cause and asserts the very next pass creates the root and resets the counter
- `TestEnsureRootAgentsBacksOffBetweenFailures` unchanged and green; full daemon suite, `go build ./...`, `golangci-lint --fast`, `gofmt -l`, `deadcode -test` all clean
- docs/configuration.md root-agents guarantees updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)