### PR TITLE
feat: container harness for tests and TUI play-tests (#1123)

### DIFF
--- a/.claude/skills/tui-playtest.md
+++ b/.claude/skills/tui-playtest.md
@@ -15,6 +15,36 @@ You are driving a live TUI. Interact with it through a private tmux server
 using `send-keys` / `capture-pane`; read the screen after every action and
 judge what a human would think of it.
 
+## Sandbox: container first (#1123)
+
+**On a dev box with docker (or podman), run the play-test inside the
+container sandbox** — it satisfies every isolation rule below structurally
+(the container has its own tmux server, a throwaway AF home, a pre-built
+mock repo, pids/memory caps, and teardown is one `docker rm -f`). See
+[docs/container-testing.md](../../docs/container-testing.md).
+
+```bash
+WORK="/tmp/af-playtest-$(date +%Y%m%d-%H%M%S)" && mkdir -p "$WORK"
+git clone --depth 1 https://github.com/sachiniyer/agent-factory "$WORK/src"   # play-test master, not a dirty checkout
+make -C "$WORK/src" playtest-container-detached                               # container name: af-playtest
+docker exec af-playtest sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'   # af builds on boot
+
+# Drive the TUI exactly as in section 2, but through docker exec — no -L
+# socket needed; the container's default tmux server IS the private server:
+docker exec af-playtest tmux new-session -d -s drive -x 80 -y 24
+docker exec af-playtest tmux send-keys -t drive 'cd ~/sandbox/mock-repo && af' Enter
+docker exec af-playtest tmux capture-pane -p -t drive
+
+# Teardown (replaces section 4's script — one command reaps everything):
+docker rm -f af-playtest && rm -rf "$WORK"
+```
+
+`gh` issue filing (section 3) still happens on the host. Stress
+generators must still be BOUNDED — the caps turn a runaway into a
+contained failure, not a non-event. Sections 1 and 4 below are the
+**fallback for boxes without docker/podman**; the rules underneath apply
+to every run, containerized or not.
+
 ## Hard isolation rules (non-negotiable)
 
 These rules exist because a previous play-test took down the whole dev box
@@ -126,12 +156,20 @@ git add -A && git commit -m "initial project"
 ```
 
 **Cheap instances** — write `$AGENT_FACTORY_HOME/config.json` before first
-launch so instances run bash instead of a real agent
+launch so instances run a shell instead of a real agent
 (`default_program` must be a supported agent name; the override supplies
-the actual command):
+the actual command). The override must be a flag-swallowing wrapper, NOT
+bare `bash`: af appends claude flags (`--plugin-dir …`) to whatever the
+claude program resolves to, bash dies on the unknown option, and every
+instance create fails with "timed out waiting for tmux session":
 
-```json
-{ "default_program": "claude", "program_overrides": { "claude": "bash" } }
+```bash
+mkdir -p "$WORK/bin"
+printf '#!/bin/bash\n# swallow the flags af appends (--plugin-dir ...) and run a shell\nexec bash\n' > "$WORK/bin/fake-agent"
+chmod +x "$WORK/bin/fake-agent"
+cat > "$AGENT_FACTORY_HOME/config.json" <<EOF
+{ "default_program": "claude", "program_overrides": { "claude": "$WORK/bin/fake-agent" } }
+EOF
 ```
 
 **Verify isolation before launching anything**: `"$AF" debug` must print

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ Thumbs.db
 
 # Test
 *.test
+# *.test is for compiled Go test binaries — keep the container image recipe
+!Dockerfile.test
 *.out
 coverage.txt
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,9 @@ Working style:
 - Use `af-preview` to spot-check, `af-send` to refine, `af-kill` to tear down
   immediately on completion or abandonment. Don't let sessions accumulate.
 - Run `golangci-lint run --timeout=3m --fast`, `gofmt -l .`, `go build ./...`,
-  and `go test ./...` before opening a PR — CI blocks on all four.
+  and the full test suite before opening a PR — CI blocks on all four. On a
+  shared dev box run the suite as `make test-container` (never bare
+  `go test ./...` on the host; see docs/container-testing.md).
 - Captain Claude is fully autonomous: ship without waiting for greenlight,
   merge own PRs after CI green, close issues that aren't worth doing. The
   audit trail is in PR descriptions and issue close-out comments, not
@@ -67,11 +69,17 @@ Working style:
 # Build
 go build ./...
 
-# Run tests
-go test ./...
+# Run the full test suite — inside a container, isolated from the host
+# tmux server and real AF home (see docs/container-testing.md)
+make test-container
 
-# Run tests verbose
-go test -v ./...
+# Host-side runs: never bare `go test ./...` on a shared dev box — the
+# daemon package spawns real af daemons. Skip it, or use the container.
+go test $(go list ./... | grep -v '/daemon')
+
+# TUI play-testing — containerized sandbox (throwaway home, mock repo,
+# private tmux); see docs/container-testing.md
+make playtest-container
 
 # Install locally
 ./dev-install.sh    # installs to ~/.local/bin/af

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,38 @@
+# Test/playtest container for agent-factory (#1123).
+#
+# Toolchain-only image: the source tree is bind-mounted read-only at run
+# time by scripts/testbox.sh, so this image rebuilds only when the
+# toolchain or system packages change — never on code changes. Build it
+# with no context (`docker build - < Dockerfile.test`); there is no COPY.
+FROM golang:1.24-bookworm
+
+# tmux + git are what the suite drives; procps provides pgrep for the
+# daemon's SIGTERM fallback path.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tmux git procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# Give the container a stable git identity so no test or mock-repo commit
+# depends on host git config leaking in.
+RUN git config --system user.name "AF Testbox" \
+    && git config --system user.email "testbox@localhost" \
+    && git config --system init.defaultBranch master
+
+# Non-root: several tests inject failures by chmod-ing dirs read-only
+# (e.g. app/handle_overlay_test.go), which root silently ignores. The
+# /cache and /work dirs are created dev-owned here so docker initializes
+# the named cache volumes with the right ownership on first mount.
+RUN useradd -m -u 1000 dev \
+    && mkdir -p /cache/gomod /cache/gobuild /work \
+    && chown -R dev:dev /cache /work
+
+# SHELL/TERM mirror an interactive dev box (the TUI needs a real TERM);
+# caches live on named volumes mounted at /cache by testbox.sh.
+ENV TERM=xterm-256color \
+    SHELL=/bin/bash \
+    GOMODCACHE=/cache/gomod \
+    GOCACHE=/cache/gobuild \
+    PATH=/home/dev/bin:$PATH
+
+USER dev
+WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Container test/playtest harness (#1123). These targets are the safe way
+# to run the full suite or a TUI play-test on a shared dev box: everything
+# runs inside docker/podman with no access to the host tmux server, the
+# real ~/.agent-factory, or this repo's worktrees.
+# See docs/container-testing.md.
+
+.PHONY: test-container playtest-container playtest-container-detached testbox-image
+
+# Full `go test ./...` inside the container — the one sanctioned way to run
+# the bare full suite on a shared box. Narrow or extend the run with
+# GOTESTARGS, e.g.: make test-container GOTESTARGS="-race ./daemon/..."
+test-container:
+	scripts/testbox.sh test $(GOTESTARGS)
+
+# Interactive TUI play-test sandbox: builds af inside, scaffolds a
+# throwaway AF home + mock project repo, drops you in a shell with a
+# private tmux server. Exiting the shell tears everything down.
+playtest-container:
+	scripts/testbox.sh playtest
+
+# Same sandbox parked in the background for `docker exec` driving (used by
+# the tui-playtest skill). Tear down with: docker rm -f af-playtest
+playtest-container-detached:
+	scripts/testbox.sh playtest -d
+
+# (Re)build the toolchain image only.
+testbox-image:
+	scripts/testbox.sh build

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ See [docs/configuration.md](docs/configuration.md) for every key, the precedence
 - [docs/remote-hooks.md](docs/remote-hooks.md) — remote backend script protocol
 - [docs/release-process.md](docs/release-process.md) — release channels: manual stable `1.x.y` (the auto-update default), opt-in auto preview `1.x.y-preview-z`
 - [docs/release-testing-plan.md](docs/release-testing-plan.md) — release gate and smoke checks
+- [docs/container-testing.md](docs/container-testing.md) — running the test suite and TUI play-tests safely in a container (`make test-container` / `make playtest-container`)
 - [examples/](examples/) — runnable task watch-scripts and remote-hook skeletons
 
 ## Maintenance

--- a/docs/container-testing.md
+++ b/docs/container-testing.md
@@ -1,0 +1,85 @@
+# Running tests safely on a shared box
+
+`af`'s test suite and play-tests drive **real tmux servers and real `af`
+daemons**. The tests themselves are hermetic (every tmux-touching package
+runs on a private tmux server via `internal/testguard`, so plain
+`go test ./...` is safe on a normal machine and in CI) — but on a shared
+dev box where a real `af` daemon and other people's tmux sessions are
+running, one escaped process or one environment mistake is an outage.
+This repo ships a container harness that makes that whole class
+structurally impossible: the suite and play-tests run inside docker (or
+podman) with **no access to the host tmux server, the real
+`~/.agent-factory`, or the repo checkout** (mounted read-only).
+
+Requirements: docker or podman on `PATH`. Everything else lives in the
+image (`Dockerfile.test`: golang 1.24 + tmux + git).
+
+## `make test-container` — the full suite
+
+```bash
+make test-container
+# narrow or extend the run:
+make test-container GOTESTARGS="-race ./daemon/..."
+```
+
+Runs `go test -count=1 ./...` inside the container. This is the **one
+sanctioned way to run the bare full suite on a shared box** — on the host,
+skip the daemon package (`go test $(go list ./... | grep -v '/daemon')`)
+or use this target.
+
+What the harness does:
+
+- mounts the repo **read-only** at `/src` and copies it to a writable tree
+  inside the container before running, so no test can modify the checkout;
+- caches modules and build artifacts in named volumes
+  (`af-testbox-gomod`, `af-testbox-gobuild`) so the second run is fast;
+- if the host has a warm Go module cache, exposes it as a read-only
+  `file://` module proxy, so runs need no network (`go.sum` still verifies
+  every module);
+- caps pids and memory (`AF_TESTBOX_PIDS`, `AF_TESTBOX_MEMORY`) so a
+  runaway process generator suffocates inside the container instead of
+  taking the box down.
+
+## `make playtest-container` — TUI play-testing
+
+```bash
+make playtest-container
+```
+
+Builds `af` from your checkout inside the container and drops you into a
+shell with a ready-made sandbox: a throwaway `AGENT_FACTORY_HOME` (with
+`program_overrides` so instances run `bash`, not real agents), a small
+mock project repo to drive sessions against, and the container's own tmux
+server — `tmux kill-server` in there is harmless. Exiting the shell tears
+down everything: the daemon, the tmux server, and every process the
+play-test spawned. Teardown is container exit, not a checklist.
+
+For scripted/agent-driven play-tests (the `tui-playtest` skill), park the
+sandbox in the background and drive it with `docker exec`:
+
+```bash
+make playtest-container-detached
+docker exec af-playtest sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'
+docker exec af-playtest tmux new-session -d -s drive -x 80 -y 24
+docker exec af-playtest tmux send-keys -t drive 'cd ~/sandbox/mock-repo && af' Enter
+docker exec af-playtest tmux capture-pane -p -t drive
+docker rm -f af-playtest        # teardown: one command reaps everything
+```
+
+## Known limitations
+
+- **No systemd inside** — autostart-unit flows (`af daemon install`) still
+  need CI or careful host testing.
+- **Network-dependent flows** (`gh`, pushing branches) need an explicitly
+  injected token; the sandbox has none by default, which keeps external
+  access opt-in and visible.
+- The first image build downloads the golang base image (a few minutes);
+  every run after that reuses cached layers.
+
+## Where the container is NOT the answer
+
+CI runs the suite bare on GitHub runners (already isolated) and external
+contributors will always run plain `go test ./...` — both fine, because
+the in-tree isolation (`internal/testguard`, #1122/#1125) makes the tests
+themselves safe. The container is the belt-and-suspenders outer wall for
+shared dev boxes, not a substitute for hermetic tests.

--- a/scripts/container/playtest-entry.sh
+++ b/scripts/container/playtest-entry.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Runs INSIDE the testbox container (see scripts/testbox.sh playtest):
+# build af from the mounted source, scaffold the play-test sandbox that the
+# tui-playtest skill needs (throwaway AF home with cheap-instance config +
+# a small mock project repo), then hand over an interactive shell — or park
+# with `hold` so a driver can work the sandbox via `docker exec`.
+#
+# Everything here — the tmux server, the daemon, the AF home, every process
+# a play-test spawns — dies with the container. Teardown is `exit` /
+# `docker rm -f`, not a checklist.
+set -euo pipefail
+
+SANDBOX="$HOME/sandbox"
+export AGENT_FACTORY_HOME="${AGENT_FACTORY_HOME:-$SANDBOX/home}"
+mkdir -p "$AGENT_FACTORY_HOME" "$HOME/bin"
+
+echo ">>> building af from /src ..."
+(cd /src && go build -o "$HOME/bin/af" .)
+
+# Cheap instances: run a plain shell instead of a real agent. The override
+# must be a wrapper, not bare "bash": af appends claude-specific flags
+# (--plugin-dir ...) to whatever the claude program resolves to, and bash
+# exits instantly on the unknown option — the session then dies before the
+# existence poll sees it ("timed out waiting for tmux session").
+cat >"$HOME/bin/fake-agent" <<'EOF'
+#!/bin/bash
+# Swallow the agent flags af appends (--plugin-dir ...) and run a shell.
+exec bash
+EOF
+chmod +x "$HOME/bin/fake-agent"
+cat >"$AGENT_FACTORY_HOME/config.json" <<EOF
+{ "default_program": "claude", "program_overrides": { "claude": "$HOME/bin/fake-agent" } }
+EOF
+
+# Mock project repo — small but real, so worktrees/diffs have something to
+# show. Never a real repo: the real repos aren't in this container at all.
+MOCK="$SANDBOX/mock-repo"
+if [ ! -d "$MOCK" ]; then
+    mkdir -p "$MOCK"
+    cd "$MOCK"
+    git init -q -b master
+    printf '#!/bin/bash\n# todo: list, add <text>, done <n>\nTODO_FILE="${TODO_FILE:-todo.txt}"\ntouch "$TODO_FILE"\ncase "$1" in\n  add) shift; echo "$*" >> "$TODO_FILE";;\n  done) sed -i "${2}d" "$TODO_FILE";;\n  *) nl -ba "$TODO_FILE";;\nesac\n' >todo.sh
+    chmod +x todo.sh
+    printf '# todo\nA tiny shell todo app.\n\nUsage: ./todo.sh [add <text> | done <n>]\n' >README.md
+    printf '#!/bin/bash\nset -e\nexport TODO_FILE=$(mktemp)\n./todo.sh add "first item"\n./todo.sh | grep -q "first item"\nrm -f "$TODO_FILE"\necho ok\n' >test.sh
+    chmod +x test.sh
+    git add -A && git commit -qm "initial project"
+fi
+
+cat <<EOF
+
+=== af play-test sandbox (container) ==========================
+  binary:   $HOME/bin/af  ($(af version 2>/dev/null || echo 'af version unavailable'))
+  AF home:  $AGENT_FACTORY_HOME  (throwaway)
+  mock repo: $MOCK
+  tmux:     this container's own server — kill-server is harmless here
+
+  start playing:   cd $MOCK && af
+  teardown:        exit the shell (or: docker rm -f <container>)
+===============================================================
+
+EOF
+
+if [ "${1:-}" = "hold" ]; then
+    # Detached mode: park so the driver can `docker exec` tmux commands.
+    exec sleep infinity
+fi
+cd "$MOCK"
+exec bash

--- a/scripts/container/run-tests.sh
+++ b/scripts/container/run-tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Runs INSIDE the testbox container (see scripts/testbox.sh): copy the
+# read-only source mount to a writable tree, then run the full suite.
+# Bare `go test ./...` is safe here — the container has its own tmux
+# server and a throwaway home, so nothing can leak onto the host.
+set -euo pipefail
+
+# Copy without .git: dev checkouts are often linked worktrees whose .git is
+# a pointer to a host path that does not exist in the container.
+mkdir -p /work
+(cd /src && tar -c --exclude=.git .) | tar -x -C /work
+cd /work
+
+if [ $# -eq 0 ]; then
+    set -- ./...
+fi
+exec go test -count=1 "$@"

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# testbox.sh — run the agent-factory test suite or a TUI play-test sandbox
+# inside a container, fenced off from the host tmux server, the real
+# ~/.agent-factory, and this repo's worktrees (#1123).
+#
+# Usage:
+#   scripts/testbox.sh test [go-test-args...]  full suite (default ./...)
+#   scripts/testbox.sh playtest                interactive sandbox shell
+#   scripts/testbox.sh playtest -d             detached; drive via `docker exec`
+#   scripts/testbox.sh build                   (re)build the image only
+#
+# The container gets: its own tmux server, a throwaway AF home, pids/memory
+# caps so a runaway generator (the 2026-07-03 outage class) suffocates
+# inside the container instead of taking the box down, and the source
+# mounted READ-ONLY. Nothing it does can touch the host environment.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="${AF_TESTBOX_IMAGE:-agent-factory-testbox}"
+PLAYTEST_NAME="${AF_PLAYTEST_NAME:-af-playtest}"
+
+# docker-or-podman autodetect (docker on the current dev box; podman kept
+# as a fallback for other boxes).
+if command -v docker >/dev/null 2>&1; then
+    ENGINE=docker
+elif command -v podman >/dev/null 2>&1; then
+    ENGINE=podman
+else
+    echo "testbox: need docker or podman on PATH" >&2
+    exit 1
+fi
+
+build_image() {
+    # Dockerfile via stdin: no build context is sent (the Dockerfile has no
+    # COPY), so this is instant when layers are cached.
+    "$ENGINE" build -q -t "$IMAGE" - <"$REPO_ROOT/Dockerfile.test" >/dev/null
+}
+
+# Flags shared by every run:
+# - source mounted read-only; in-container scripts copy it before writing
+# - named volumes for module/build caches so the second run is fast
+# - no host $HOME, $TMUX, or TMUX_TMPDIR passthrough; no published ports
+# - bounded pids + memory (override: AF_TESTBOX_PIDS / AF_TESTBOX_MEMORY)
+RUN_FLAGS=(
+    --rm
+    # --init: a real PID 1 (tini) that reaps orphans. Without it, processes
+    # the suite kills linger as zombies and the reaping tests see them as
+    # "still alive".
+    --init
+    -v "$REPO_ROOT":/src:ro
+    -v af-testbox-gomod:/cache/gomod
+    -v af-testbox-gobuild:/cache/gobuild
+    --pids-limit "${AF_TESTBOX_PIDS:-1024}"
+    --memory "${AF_TESTBOX_MEMORY:-8g}"
+)
+
+# Speed: when the host has a warm Go module cache, expose its download dir
+# as a read-only file:// module proxy — the first container run then needs
+# no network at all. go.sum still verifies every module.
+if command -v go >/dev/null 2>&1; then
+    HOST_MODCACHE="$(go env GOMODCACHE 2>/dev/null || true)"
+    if [ -n "$HOST_MODCACHE" ] && [ -d "$HOST_MODCACHE/cache/download" ]; then
+        RUN_FLAGS+=(
+            -v "$HOST_MODCACHE/cache/download":/hostproxy:ro
+            -e "GOPROXY=file:///hostproxy,https://proxy.golang.org,direct"
+        )
+    fi
+fi
+
+# Cache volumes created by older harness versions (or manual root runs)
+# can be root-owned, which the non-root test user can't write to. A
+# one-shot root chown makes the harness self-healing.
+fix_cache_perms() {
+    "$ENGINE" run --rm --user 0 \
+        -v af-testbox-gomod:/cache/gomod \
+        -v af-testbox-gobuild:/cache/gobuild \
+        "$IMAGE" chown -R dev:dev /cache >/dev/null
+}
+
+cmd="${1:-test}"
+[ $# -gt 0 ] && shift
+
+case "$cmd" in
+build)
+    "$ENGINE" build -t "$IMAGE" - <"$REPO_ROOT/Dockerfile.test"
+    ;;
+test)
+    build_image
+    fix_cache_perms
+    # The one sanctioned home for a bare full-suite run on a shared box.
+    exec "$ENGINE" run "${RUN_FLAGS[@]}" "$IMAGE" \
+        bash /src/scripts/container/run-tests.sh "$@"
+    ;;
+playtest)
+    build_image
+    fix_cache_perms
+    RUN_FLAGS+=(
+        --name "$PLAYTEST_NAME"
+        # docker exec inherits env set at create time, so the sandbox home
+        # is visible to every exec'd command, not just the entry script.
+        -e AGENT_FACTORY_HOME=/home/dev/sandbox/home
+    )
+    if [ "${1:-}" = "-d" ]; then
+        "$ENGINE" run -d "${RUN_FLAGS[@]}" "$IMAGE" \
+            bash /src/scripts/container/playtest-entry.sh hold >/dev/null
+        echo "playtest sandbox '$PLAYTEST_NAME' is starting (af builds on boot)."
+        echo "  wait for it:  $ENGINE exec $PLAYTEST_NAME sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'"
+        echo "  drive it:     $ENGINE exec $PLAYTEST_NAME tmux new-session -d -s drive -x 80 -y 24"
+        echo "                $ENGINE exec $PLAYTEST_NAME tmux send-keys -t drive 'cd ~/sandbox/mock-repo && af' Enter"
+        echo "                $ENGINE exec $PLAYTEST_NAME tmux capture-pane -p -t drive"
+        echo "  tear down:    $ENGINE rm -f $PLAYTEST_NAME"
+    else
+        exec "$ENGINE" run -it "${RUN_FLAGS[@]}" "$IMAGE" \
+            bash /src/scripts/container/playtest-entry.sh
+    fi
+    ;;
+*)
+    echo "testbox: unknown command '$cmd' (want: test | playtest | build)" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Closes #1123.

In-repo docker/podman tooling so the full test suite and interactive TUI play-tests run inside a container with **zero access to the host tmux server, the real `~/.agent-factory`, or the repo checkout** — the structural answer to the three tmux outages on the shared dev box. Implements the plan-of-record + design input posted on #1123 (in-tree isolation landed separately in #1125; this is the outer wall).

## What's in it

- **`Dockerfile.test`** — toolchain-only image (`golang:1.24-bookworm` + tmux + git + procps, non-root `dev` user). No `COPY`: source is bind-mounted read-only at run time, so the image never rebuilds on code changes and `docker build` sends no context.
- **`scripts/testbox.sh`** — docker-or-podman harness shared by the make targets: named volumes for module/build caches, host Go module cache exposed as a **read-only `file://` GOPROXY** (warm-cache runs need no network; `go.sum` still verifies), `--init` for zombie reaping, and **pids/memory caps** so a runaway generator (the `yes`-orphan outage class) suffocates inside the container.
- **`make test-container`** — full `go test -count=1 ./...` inside the container; the one sanctioned home for a bare full-suite run on a shared box. `GOTESTARGS` narrows/extends (e.g. `GOTESTARGS="-race ./daemon/..."`).
- **`make playtest-container` / `playtest-container-detached`** — play-test sandbox: builds `af` from the mounted checkout, scaffolds a throwaway AF home (cheap-instance config) + mock project repo, private container tmux. Interactive shell, or parked for `docker exec` driving. **Teardown is container exit** — the process-tree reaper you can't forget.
- **Docs** — `docs/container-testing.md` ("running tests safely on a shared box"), README pointer, CLAUDE.md Build & Development now points local full-suite runs at `make test-container`.
- **tui-playtest skill** — container sandbox is now the preferred path on dev boxes; the bare-host recipe stays as fallback. CI stays bare (already isolated; the tests themselves are hermetic per #1125).

## Verification (all run on this box)

- `make test-container` end-to-end **twice**: full suite green both times, including `daemon` and `integration` (which flake on the host from real-daemon contention — they pass cleanly in the container). Second, cache-warm run: **~31 s wall**.
- `make playtest-container` (detached mode): `af` built inside, TUI launched under the container's tmux at 80×24, screen captured rendering correctly, and an instance created through the TUI (`n` → named → sidebar shows it running) — daemon, worktree, and tmux-session paths all exercised in-container.
- Host gates: `golangci-lint run --timeout=3m --fast` clean, `gofmt -l .` empty, `go build ./...` OK. (No Go code changed.)

## Findings made along the way (fixed in this PR)

1. **No-init zombies**: without `--init`, every process-reaping test (`session/tmux` reap tests, `session/git` hook-cancellation tests, daemon watcher test) fails inside a container — killed grandchildren linger as zombies that `kill -0` sees as alive. `--init` fixes the whole class; baked into the harness with a comment.
2. **Root ignores chmod**: `app/handle_overlay_test.go` injects a save failure via `os.Chmod(dir, 0o500)`, which root silently bypasses — hence the non-root `dev` user in the image (plus a self-healing chown for cache volumes created by older/root runs).
3. **Play-test recipe bug (pre-existing, also affects host runs)**: the skill's cheap-instance override `"claude": "bash"` is broken on current master — af appends `--plugin-dir <dir>` to whatever the claude program resolves to, bash exits instantly on the unknown option, and every instance create fails with "timed out waiting for tmux session". Fixed in both the container entry script and the skill doc with a flag-swallowing wrapper (`exec bash`). Worth knowing for the daily TUI-playtest task: any recent run using the documented recipe could not have created instances.

## Known limitations (documented, not solved)

- No systemd inside → autostart-unit flows still need CI or careful host testing.
- `gh`/network flows need an explicitly injected token — external access stays opt-in and visible.
- First image build pulls the golang base image (a few minutes); cached after.

Not merging per dispatch — parent verifies and merges.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)