### PR TITLE
session: key agent-specific spawn behavior off the resolved program, not the config name

### DIFF
--- a/.claude/skills/tui-playtest.md
+++ b/.claude/skills/tui-playtest.md
@@ -158,17 +158,15 @@ git add -A && git commit -m "initial project"
 **Cheap instances** — write `$AGENT_FACTORY_HOME/config.json` before first
 launch so instances run a shell instead of a real agent
 (`default_program` must be a supported agent name; the override supplies
-the actual command). The override must be a flag-swallowing wrapper, NOT
-bare `bash`: af appends claude flags (`--plugin-dir …`) to whatever the
-claude program resolves to, bash dies on the unknown option, and every
-instance create fails with "timed out waiting for tmux session":
+the actual command). A bare `bash` override works: since #1116/#1131, af
+keys agent-specific flag injection and readiness detection off the program
+the override actually runs, so a non-agent command gets no claude flags
+appended and is considered ready as soon as the pane shows output — no
+flag-swallowing wrapper needed:
 
 ```bash
-mkdir -p "$WORK/bin"
-printf '#!/bin/bash\n# swallow the flags af appends (--plugin-dir ...) and run a shell\nexec bash\n' > "$WORK/bin/fake-agent"
-chmod +x "$WORK/bin/fake-agent"
 cat > "$AGENT_FACTORY_HOME/config.json" <<EOF
-{ "default_program": "claude", "program_overrides": { "claude": "$WORK/bin/fake-agent" } }
+{ "default_program": "claude", "program_overrides": { "claude": "bash" } }
 EOF
 ```
 

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // Root-agent always-ensure (#1106): for every repo opted in via the
@@ -230,7 +231,12 @@ func rootAgentProgram(repoRoot string, rc config.RootAgentConfig) string {
 	} else {
 		log.WarningLog.Printf("root agent for %s: failed to resolve repo config, using bare claude: %v", repoRoot, err)
 	}
-	if !strings.Contains(program, rootDangerouslySkipPermissionsFlag) {
+	// Only ensure the claude-only flag when the resolved command actually
+	// runs claude: a program_overrides entry may point "claude" at another
+	// program that exits on the unknown flag (#1116 defect class — e.g. the
+	// play-test sandbox's "claude": "bash" override).
+	if tmux.DetectAgentFromCommand(program) == tmux.ProgramClaude &&
+		!strings.Contains(program, rootDangerouslySkipPermissionsFlag) {
 		program += " " + rootDangerouslySkipPermissionsFlag
 	}
 	return program

--- a/daemon/rootagent_test.go
+++ b/daemon/rootagent_test.go
@@ -102,6 +102,45 @@ func TestEnsureRootAgentsHonorsProfileOverrides(t *testing.T) {
 	}
 }
 
+// TestRootAgentProgramOverrideMatrix pins the #1116-class fix in the root
+// profile: the claude-only --dangerously-skip-permissions flag is ensured
+// only when the RESOLVED command actually runs claude. A program_overrides
+// entry pointing "claude" at a non-claude program (e.g. the play-test
+// sandbox's "bash") must launch verbatim — the appended flag would make it
+// exit instantly and the root agent would flap forever.
+func TestRootAgentProgramOverrideMatrix(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string // program_overrides["claude"]
+		want     string
+	}{
+		{"bare enum appends flag", "claude", "claude --dangerously-skip-permissions"},
+		{"claude path override appends flag", "/opt/claude-next/bin/claude --model opus",
+			"/opt/claude-next/bin/claude --model opus --dangerously-skip-permissions"},
+		{"flag already present not duplicated", "claude --dangerously-skip-permissions",
+			"claude --dangerously-skip-permissions"},
+		{"non-agent override left verbatim (#1116)", "bash", "bash"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+			repoPath := setupControlRepo(t)
+			// Every row pins an explicit override entry: with none present,
+			// config loading auto-detects a machine-local claude path into
+			// ProgramOverrides, which would make the row nondeterministic.
+			cfg := config.DefaultConfig()
+			cfg.ProgramOverrides = map[string]string{"claude": tt.override}
+			if err := config.SaveConfig(cfg); err != nil {
+				t.Fatalf("SaveConfig: %v", err)
+			}
+			got := rootAgentProgram(repoPath, config.RootAgentConfig{})
+			if got != tt.want {
+				t.Fatalf("rootAgentProgram = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestEnsureRootAgentsAdoptsLiveRoot: with a live root already present —
 // whatever created it — ensure is a strict no-op. Never kill/recreate a live
 // root (#1106 adopt-never-clobber rule).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
 | Field | Description |
 |-------|-------------|
 | `default_program` | Default agent enum. Must be one of `claude`, `codex`, `aider`, `gemini`. |
-| `program_overrides` | Optional map from agent enum to the full command string used when launching that agent. Use this to pin a path or pass flags (e.g. `--dangerously-skip-permissions`). Keys must be one of `claude`, `codex`, `aider`, `gemini`. |
+| `program_overrides` | Optional map from agent enum to the full command string used when launching that agent. Use this to pin a path or pass flags (e.g. `--dangerously-skip-permissions`). Keys must be one of `claude`, `codex`, `aider`, `gemini`. Agent-specific launch flags (claude's `--plugin-dir`, codex's `developer_instructions`) and readiness detection follow the program the override actually runs, not the key: pointing an agent name at a different command (even a non-agent one like `bash`) launches it with no injected agent flags, and a command running no known agent counts as ready once its pane shows output. The agent is identified by command-token basename (`/opt/tools/claude --model opus` and `ionice -c 3 claude` are claude; `/opt/claude-wrapper/run` is not), so if you wrap an agent in a script, name the script after the agent to keep its flags and readiness behavior. |
 | `auto_yes` | Auto-accept agent prompts (experimental). |
 | `daemon_poll_interval` | Daemon polling interval in ms. |
 | `branch_prefix` | Prefix for worktree branches (defaults to `username/`). |

--- a/integration/codex_ready_test.go
+++ b/integration/codex_ready_test.go
@@ -40,8 +40,16 @@ func TestCLICreateCodexSessionBecomesReady(t *testing.T) {
 
 	// printf interprets the \n (backslash-n) into a newline; the "›" is the
 	// literal U+203A glyph. The wrapper ignores any injected flags
-	// (-c developer_instructions=…) exactly like the claude fixture.
-	wrapper := filepath.Join(home, "fake-codex.sh")
+	// (-c developer_instructions=…) exactly like the claude fixture. Its
+	// basename must be "codex": since #1116/#1131 the readiness heuristic is
+	// selected by the agent detected in the RESOLVED command (token-basename
+	// match), so an arbitrarily-named wrapper would get the generic
+	// any-output readiness instead of codex's "›" check.
+	wrapperDir := filepath.Join(home, "fakebin")
+	if err := os.MkdirAll(wrapperDir, 0755); err != nil {
+		t.Fatalf("mkdir wrapper dir: %v", err)
+	}
+	wrapper := filepath.Join(wrapperDir, "codex")
 	writeFile(t, wrapper, "#!/bin/sh\nprintf 'OpenAI Codex (vX)\\npermissions: YOLO mode\\n› '\nexec cat\n", 0755)
 
 	cfg := testConfig()
@@ -130,8 +138,15 @@ func TestCLICreateCodexWaitsPastTrustPrompt(t *testing.T) {
 	// alone must not satisfy waitForReady; only the trailing "›" does. The
 	// hold is set well above session-startup overhead (daemon launch + git
 	// worktree, observed ~6s) so the timing assertion below is unambiguous.
+	// The wrapper's basename must be "codex" so the resolved-command agent
+	// detection (#1116/#1131) selects codex's readiness heuristic — see the
+	// fixture comment in TestCLICreateCodexSessionBecomesReady.
 	const trustHold = 12 * time.Second
-	wrapper := filepath.Join(home, "fake-codex-trust.sh")
+	wrapperDir := filepath.Join(home, "fakebin")
+	if err := os.MkdirAll(wrapperDir, 0755); err != nil {
+		t.Fatalf("mkdir wrapper dir: %v", err)
+	}
+	wrapper := filepath.Join(wrapperDir, "codex")
 	writeFile(t, wrapper,
 		"#!/bin/sh\n"+
 			"printf 'OpenAI Codex (vX)\\nDo you trust this folder?\\n> 1. Yes\\n'\n"+

--- a/scripts/container/playtest-entry.sh
+++ b/scripts/container/playtest-entry.sh
@@ -17,19 +17,12 @@ mkdir -p "$AGENT_FACTORY_HOME" "$HOME/bin"
 echo ">>> building af from /src ..."
 (cd /src && go build -o "$HOME/bin/af" .)
 
-# Cheap instances: run a plain shell instead of a real agent. The override
-# must be a wrapper, not bare "bash": af appends claude-specific flags
-# (--plugin-dir ...) to whatever the claude program resolves to, and bash
-# exits instantly on the unknown option — the session then dies before the
-# existence poll sees it ("timed out waiting for tmux session").
-cat >"$HOME/bin/fake-agent" <<'EOF'
-#!/bin/bash
-# Swallow the agent flags af appends (--plugin-dir ...) and run a shell.
-exec bash
-EOF
-chmod +x "$HOME/bin/fake-agent"
+# Cheap instances: run a plain shell instead of a real agent. Since
+# #1116/#1131 af keys flag injection and readiness off the program the
+# override actually runs, so bare "bash" gets no claude flags appended and
+# counts as ready once the pane shows output — no wrapper needed.
 cat >"$AGENT_FACTORY_HOME/config.json" <<EOF
-{ "default_program": "claude", "program_overrides": { "claude": "$HOME/bin/fake-agent" } }
+{ "default_program": "claude", "program_overrides": { "claude": "bash" } }
 EOF
 
 # Mock project repo — small but real, so worktrees/diffs have something to

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -17,11 +17,11 @@ import (
 // bare agent name. The overrides come from the repo-resolved config (global
 // program_overrides merged with the repo's .agent-factory/config.json) when
 // the instance path belongs to a git repo; outside a repo, or when repo
-// resolution fails, the global config alone applies. When AutoYes is set on a
-// claude instance, the --permission-mode bypassPermissions flag is appended
-// to the resolved command — claude needs the flag at exec time, and
-// Instance.Program now holds only the bare enum so the append can no longer
-// happen in main.go. A nil cfg (e.g. tests that don't materialize a config)
+// resolution fails, the global config alone applies. When AutoYes is set and
+// the RESOLVED command actually runs claude, the --permission-mode
+// bypassPermissions flag is appended to it — claude needs the flag at exec
+// time, and Instance.Program now holds only the bare enum so the append can
+// no longer happen in main.go. A nil cfg (e.g. tests that don't materialize a config)
 // falls back to the raw Program string so legacy free-form values still
 // reach tmux verbatim.
 func resolveProgramForInstance(i *Instance) string {
@@ -42,7 +42,10 @@ func resolveProgramForInstance(i *Instance) string {
 		cfg = loaded
 	}
 	resolved := config.ResolveProgram(cfg, i.Program)
-	if i.AutoYes && DetectAgentFromProgram(i.Program) == tmux.ProgramClaude &&
+	// Key the claude-only flag off the agent the RESOLVED command actually
+	// runs, not the config-name enum: an override may point "claude" at a
+	// different program, which would exit on the unknown flag (#1116).
+	if i.AutoYes && tmux.DetectAgentFromCommand(resolved) == tmux.ProgramClaude &&
 		// Sessions persisted by pre-#659 binaries got the flag appended at
 		// create-time in main.go (19c0dd9), so legacy Instance.Program values
 		// can already carry it; appending again duplicates the flag on every
@@ -189,7 +192,7 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 		// Setting the program on the existing attach path is harmless:
 		// attach-session does not re-exec the program.
 		if workDir != "" {
-			tmuxSession.SetProgram(injectSystemPrompt(i.Program, resolveProgramForInstance(i), i.Title, workDir))
+			tmuxSession.SetProgram(injectSystemPrompt(resolveProgramForInstance(i)))
 		}
 		if err := tmuxSession.Restore(workDir); err != nil {
 			setupErr = fmt.Errorf("failed to restore existing session: %w", err)
@@ -207,9 +210,7 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 		}
 
 		// Inject Agent Factory instructions into the session.
-		tmuxSession.SetProgram(
-			injectSystemPrompt(i.Program, resolveProgramForInstance(i), i.Title, gw.GetWorktreePath()),
-		)
+		tmuxSession.SetProgram(injectSystemPrompt(resolveProgramForInstance(i)))
 
 		// Create new session
 		if err := tmuxSession.Start(gw.GetWorktreePath()); err != nil {
@@ -549,12 +550,15 @@ func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {
 	if !s || ts == nil {
 		return false
 	}
-	// Normalize so restored sessions with legacy free-form Program values
-	// (e.g. "/home/foo/bin/claude") still get trust-prompt auto-handling —
-	// same persisted-state class of regression as #677. Codex was added in
-	// #729: it was previously excluded here, so a codex trust/confirmation
-	// dialog was never dismissed even though isReadyContent could surface it.
-	switch DetectAgentFromProgram(i.Program) {
+	// Dispatch on the agent the pane actually runs (ResolvedAgent) so a
+	// program_overrides entry pointing an agent name at a non-agent binary
+	// never gets an agent's trust-prompt handling (#1116/#1131 defect class),
+	// while restored sessions with legacy free-form Program values (e.g.
+	// "/home/foo/bin/claude") still get it — same persisted-state class of
+	// regression as #677. Codex was added in #729: it was previously excluded
+	// here, so a codex trust/confirmation dialog was never dismissed even
+	// though isReadyContent could surface it.
+	switch i.ResolvedAgent() {
 	case tmux.ProgramClaude, tmux.ProgramCodex, tmux.ProgramAider, tmux.ProgramGemini:
 		return ts.CheckAndHandleTrustPrompt()
 	}

--- a/session/instance.go
+++ b/session/instance.go
@@ -1117,6 +1117,31 @@ func (i *Instance) TmuxAlive() bool {
 	return i.backend.IsAlive(i)
 }
 
+// ResolvedAgent returns the canonical agent (one of tmux.SupportedPrograms)
+// this instance's pane will actually run, or "" when the resolved command
+// runs no known agent — e.g. a program_overrides entry pointing an agent name
+// at a plain shell (#1131). Agent-specific behavior (readiness heuristics,
+// trust-prompt handling, flag injection) must key off this, never off
+// Instance.Program: Program is the config-name enum the instance was created
+// with, and an override may point it at a different program entirely (#1116).
+//
+// Once the tmux session exists, its program string (override-resolved and
+// flag-injected by Start) is the ground truth. Before Start — or in tests
+// that never attach a tmux session — detection falls back to the raw Program
+// value, which also covers legacy free-form persisted values like
+// "/home/foo/bin/claude --plugin-dir x" (#677).
+func (i *Instance) ResolvedAgent() string {
+	i.mu.RLock()
+	ts := i.tmuxLocked()
+	i.mu.RUnlock()
+	if ts != nil {
+		if p := ts.Program(); strings.TrimSpace(p) != "" {
+			return tmux.DetectAgentFromCommand(p)
+		}
+	}
+	return tmux.DetectAgentFromCommand(i.Program)
+}
+
 // GetPRInfo returns the associated GitHub PR info, or nil if none.
 func (i *Instance) GetPRInfo() *git.PRInfo {
 	i.mu.RLock()

--- a/session/legacy_program_test.go
+++ b/session/legacy_program_test.go
@@ -4,50 +4,23 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
-// DetectAgentFromProgram is the normalization seam that lets restored sessions
-// with legacy free-form Program values keep their agent-specific flags (#677).
-// It must recover the canonical agent for paths and path-plus-flags, leave the
-// bare enum untouched, and — critically — return unknown programs unchanged so
-// no agent flags leak into a non-agent session.
-func TestDetectAgentFromProgram(t *testing.T) {
-	tests := []struct {
-		name    string
-		program string
-		want    string
-	}{
-		{"bare claude enum", "claude", tmux.ProgramClaude},
-		{"bare codex enum", "codex", tmux.ProgramCodex},
-		{"bare aider enum", "aider", tmux.ProgramAider},
-		{"bare gemini enum", "gemini", tmux.ProgramGemini},
-		{"legacy claude path", "/home/foo/bin/claude", tmux.ProgramClaude},
-		{"legacy claude path with flags", "/home/foo/bin/claude --plugin-dir x", tmux.ProgramClaude},
-		{"legacy codex path", "/usr/local/bin/codex", tmux.ProgramCodex},
-		{"unknown tool path unchanged", "/usr/bin/some-other-tool", "/usr/bin/some-other-tool"},
-		{"unknown tool with flags unchanged", "/usr/bin/some-other-tool --foo", "/usr/bin/some-other-tool --foo"},
-		{"empty unchanged", "", ""},
-		{"substring-but-not-base unchanged", "/opt/claude-wrapper/run", "/opt/claude-wrapper/run"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := DetectAgentFromProgram(tt.program); got != tt.want {
-				t.Errorf("DetectAgentFromProgram(%q) = %q, want %q", tt.program, got, tt.want)
-			}
-		})
-	}
-}
+// Legacy free-form Program values (persisted by pre-#659 binaries: absolute
+// paths, optionally with flags) must keep their agent-specific flags on
+// restore (#677). With no program_overrides entry for them, the free-form
+// value resolves to itself, so the resolved-command detection (#1116) must
+// recover the agent from those shapes too.
 
 // Regression for #677: a restored Claude session whose persisted Program is a
 // legacy absolute path must still receive --plugin-dir, or /af-* slash commands
 // silently vanish after upgrade.
 func TestInjectSystemPrompt_LegacyClaudePath(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("AGENT_FACTORY_HOME", dir)
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
-	legacyPath := "/home/foo/bin/claude"
-	result := injectSystemPrompt(legacyPath, legacyPath, "legacy-session", dir)
+	result := injectSystemPrompt("/home/foo/bin/claude")
 
 	if !strings.Contains(result, "--plugin-dir") {
 		t.Errorf("expected --plugin-dir for legacy claude path, got %q", result)
@@ -57,9 +30,7 @@ func TestInjectSystemPrompt_LegacyClaudePath(t *testing.T) {
 // Companion to the Claude case: legacy Codex paths must still receive the
 // developer_instructions flag.
 func TestInjectSystemPrompt_LegacyCodexPath(t *testing.T) {
-	dir := t.TempDir()
-	legacyPath := "/usr/local/bin/codex"
-	result := injectSystemPrompt(legacyPath, legacyPath, "legacy-codex", dir)
+	result := injectSystemPrompt("/usr/local/bin/codex")
 
 	if !strings.Contains(result, "developer_instructions=") {
 		t.Errorf("expected developer_instructions for legacy codex path, got %q", result)
@@ -70,11 +41,10 @@ func TestInjectSystemPrompt_LegacyCodexPath(t *testing.T) {
 // injection — we must never append Claude/Codex flags to a session we don't
 // recognize.
 func TestInjectSystemPrompt_UnknownProgramNoInjection(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("AGENT_FACTORY_HOME", dir)
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
 	program := "/usr/bin/some-other-tool"
-	result := injectSystemPrompt(program, program, "mystery-session", dir)
+	result := injectSystemPrompt(program)
 
 	if result != program {
 		t.Errorf("expected unknown program left unchanged, got %q", result)
@@ -84,10 +54,9 @@ func TestInjectSystemPrompt_UnknownProgramNoInjection(t *testing.T) {
 // Regression guard: the bare enum value (what current binaries persist) must
 // keep working exactly as before the normalization seam was added.
 func TestInjectSystemPrompt_BareEnumStillInjects(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("AGENT_FACTORY_HOME", dir)
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
-	result := injectSystemPrompt(tmux.ProgramClaude, "claude", "enum-session", dir)
+	result := injectSystemPrompt("claude")
 	if !strings.Contains(result, "--plugin-dir") {
 		t.Errorf("expected --plugin-dir for bare claude enum, got %q", result)
 	}
@@ -153,5 +122,59 @@ func TestResolveProgramForInstance_UnknownAutoYesNoFlag(t *testing.T) {
 	result := resolveProgramForInstance(i)
 	if strings.Contains(result, "bypassPermissions") {
 		t.Errorf("expected no bypassPermissions for unknown program, got %q", result)
+	}
+}
+
+// saveOverrideConfig writes a global config whose program_overrides redirect
+// the claude enum to the given command, so resolveProgramForInstance exercises
+// the real override-resolution path (instance path outside any git repo →
+// global config applies).
+func saveOverrideConfig(t *testing.T, claudeOverride string) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	cfg := config.DefaultConfig()
+	cfg.ProgramOverrides = map[string]string{tmux.ProgramClaude: claudeOverride}
+	if err := config.SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+}
+
+// Regression for #1116/#1131: an AutoYes instance whose claude enum is
+// overridden to a NON-claude command must not get the claude-only
+// --permission-mode flag — the resolved program would exit on the unknown
+// option and the spawn would die as an opaque timeout.
+func TestResolveProgramForInstance_OverrideToNonAgentNoAutoYesFlag(t *testing.T) {
+	saveOverrideConfig(t, "bash")
+
+	i := &Instance{
+		Title:   "cheap-instance",
+		Program: tmux.ProgramClaude,
+		Path:    t.TempDir(),
+		AutoYes: true,
+	}
+	result := resolveProgramForInstance(i)
+	if result != "bash" {
+		t.Errorf("expected override resolved to bare %q with no injected flags, got %q", "bash", result)
+	}
+}
+
+// Companion: an override that still runs claude (custom path + flags) must
+// keep the AutoYes flag — keying off the resolved command must not LOSE
+// flags for claude-compatible overrides.
+func TestResolveProgramForInstance_OverrideToClaudePathKeepsAutoYesFlag(t *testing.T) {
+	saveOverrideConfig(t, "/opt/claude-next/bin/claude --model opus")
+
+	i := &Instance{
+		Title:   "custom-claude",
+		Program: tmux.ProgramClaude,
+		Path:    t.TempDir(),
+		AutoYes: true,
+	}
+	result := resolveProgramForInstance(i)
+	if !strings.HasPrefix(result, "/opt/claude-next/bin/claude --model opus") {
+		t.Errorf("expected override preserved as prefix, got %q", result)
+	}
+	if !strings.Contains(result, "--permission-mode bypassPermissions") {
+		t.Errorf("expected AutoYes flag for claude-running override, got %q", result)
 	}
 }

--- a/session/resolved_agent_test.go
+++ b/session/resolved_agent_test.go
@@ -1,0 +1,43 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// ResolvedAgent is the seam WaitForReady and the trust-prompt gate key off
+// (#1116, #1131): with a live tmux session it must report the agent from the
+// command the pane actually runs (override-resolved), and only fall back to
+// the persisted Program value when no tmux session exists yet.
+func TestResolvedAgent(t *testing.T) {
+	withTmuxProgram := func(program string) *Instance {
+		ts := tmux.NewTmuxSessionWithDeps("resolved-agent", program, nil, nil)
+		return &Instance{Program: tmux.ProgramClaude, Tabs: []*Tab{newAgentTab(ts)}}
+	}
+
+	tests := []struct {
+		name string
+		inst *Instance
+		want string
+	}{
+		// tmux program is ground truth, regardless of the config-name enum.
+		{"override to bash (#1131)", withTmuxProgram("bash"), ""},
+		{"override to unknown tool (#1116)", withTmuxProgram("/usr/bin/some-other-tool --foo"), ""},
+		{"override to codex", withTmuxProgram("/usr/local/bin/codex --full-auto"), tmux.ProgramCodex},
+		{"claude with injected flags", withTmuxProgram("claude --plugin-dir '/x/plugin'"), tmux.ProgramClaude},
+
+		// No tmux session yet: fall back to the Program value, including
+		// legacy free-form persisted shapes (#677).
+		{"no tmux, bare enum", &Instance{Program: tmux.ProgramGemini}, tmux.ProgramGemini},
+		{"no tmux, legacy claude path", &Instance{Program: "/home/foo/bin/claude --plugin-dir x"}, tmux.ProgramClaude},
+		{"no tmux, unknown program", &Instance{Program: "some-other-tool"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.inst.ResolvedAgent(); got != tt.want {
+				t.Errorf("ResolvedAgent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"path/filepath"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -29,50 +28,24 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
-// DetectAgentFromProgram maps a possibly-legacy Program value to its canonical
-// agent enum name (one of tmux.SupportedPrograms). Sessions persisted by
-// pre-#659 binaries may hold free-form Program strings — an absolute path
-// and/or trailing flags, e.g. "/home/foo/bin/claude --plugin-dir x" — rather
-// than the bare enum that current binaries write. On restore those legacy
-// values flow into the flag-injection layer, where strict enum equality
-// (added in #659) no longer recognizes them, silently dropping --plugin-dir,
-// bypassPermissions, and Codex developer_instructions (#677).
-//
-// The match is deliberately DEFENSIVE, not permissive: it returns a canonical
-// name only when filepath.Base of the first whitespace-split token equals a
-// tmux.SupportedPrograms entry verbatim. For anything else — unknown tools,
-// empty input, the bare enum (which maps to itself) — it returns the input
-// unchanged, so we never inject Claude flags into a non-Claude session. This
-// is scoped purely to flag injection on restore; it is NOT a general-purpose
-// command parser and must not be reused as one.
-func DetectAgentFromProgram(program string) string {
-	fields := strings.Fields(program)
-	if len(fields) == 0 {
-		return program
-	}
-	base := filepath.Base(fields[0])
-	for _, supported := range tmux.SupportedPrograms {
-		if base == supported {
-			return supported
-		}
-	}
-	return program
-}
-
 // injectSystemPrompt injects Agent Factory instructions into the session.
 //
-// agent is the Instance.Program value (normally the canonical enum, but
-// possibly a legacy free-form string on restored sessions) and resolved is
-// the actual command string to be passed to tmux (the agent name or the
-// configured program_overrides entry). agent is normalized via
-// DetectAgentFromProgram so legacy paths still match; flags are appended to
-// resolved.
+// resolved is the actual command string to be passed to tmux — the agent
+// name, the configured program_overrides entry, or a legacy free-form
+// persisted Program value ("/home/foo/bin/claude --plugin-dir x", #677).
+// Which flags to inject, if any, is decided by the agent detected IN that
+// resolved command (tmux.DetectAgentFromCommand), never by the config-name
+// enum the instance was created with: an override may point "claude" at a
+// different agent or at a non-agent binary, and injecting claude flags there
+// makes the program exit on the unknown option, so the spawn dies as an
+// opaque timeout (#1116, #1131).
 //
 // Strategy per tool:
 //   - Claude Code: --plugin-dir flag only (slash commands + /af-whoami for self-identification)
 //   - Codex: -c developer_instructions="..." flag (text-based, no plugin support)
-func injectSystemPrompt(agent, resolved, sessionTitle, worktreePath string) string {
-	agent = DetectAgentFromProgram(agent)
+//   - aider, gemini, and commands running no known agent: no injection.
+func injectSystemPrompt(resolved string) string {
+	agent := tmux.DetectAgentFromCommand(resolved)
 	if agent == tmux.ProgramClaude {
 		pluginDir, err := ensurePluginDir()
 		if err != nil {

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 func TestShellQuote(t *testing.T) {
@@ -31,7 +29,7 @@ func TestInjectSystemPrompt_Claude(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", dir)
 
-	result := injectSystemPrompt(tmux.ProgramClaude, "claude", "test-session", dir)
+	result := injectSystemPrompt("claude")
 
 	if !strings.Contains(result, "--plugin-dir") {
 		t.Errorf("expected --plugin-dir flag, got %q", result)
@@ -50,7 +48,7 @@ func TestInjectSystemPrompt_ClaudeWithResolvedFlags(t *testing.T) {
 
 	// The resolved form (from program_overrides) carries the path-and-flags;
 	// injectSystemPrompt appends --plugin-dir to it.
-	result := injectSystemPrompt(tmux.ProgramClaude, "/usr/local/bin/claude --model opus", "my-session", dir)
+	result := injectSystemPrompt("/usr/local/bin/claude --model opus")
 
 	if !strings.HasPrefix(result, "/usr/local/bin/claude --model opus") {
 		t.Errorf("expected resolved form preserved, got %q", result)
@@ -62,7 +60,7 @@ func TestInjectSystemPrompt_ClaudeWithResolvedFlags(t *testing.T) {
 
 func TestInjectSystemPrompt_Codex(t *testing.T) {
 	dir := t.TempDir()
-	result := injectSystemPrompt(tmux.ProgramCodex, "codex", "test-session", dir)
+	result := injectSystemPrompt("codex")
 
 	if !strings.Contains(result, "-c") {
 		t.Errorf("expected -c flag for codex, got %q", result)
@@ -85,8 +83,7 @@ func TestInjectSystemPrompt_Codex(t *testing.T) {
 }
 
 func TestInjectSystemPrompt_CodexWithResolvedFlags(t *testing.T) {
-	dir := t.TempDir()
-	result := injectSystemPrompt(tmux.ProgramCodex, "codex --full-auto", "my-session", dir)
+	result := injectSystemPrompt("codex --full-auto")
 
 	if !strings.HasPrefix(result, "codex --full-auto") {
 		t.Errorf("expected resolved form preserved, got %q", result)
@@ -100,9 +97,8 @@ func TestInjectSystemPrompt_CodexWithResolvedFlags(t *testing.T) {
 // their program_overrides must keep their value — codex's -c is last-wins per
 // key, so appending ours would clobber it.
 func TestInjectSystemPrompt_CodexExistingDeveloperInstructions(t *testing.T) {
-	dir := t.TempDir()
 	resolved := `codex -c 'developer_instructions=my custom prompt'`
-	result := injectSystemPrompt(tmux.ProgramCodex, resolved, "my-session", dir)
+	result := injectSystemPrompt(resolved)
 
 	if result != resolved {
 		t.Errorf("expected resolved form unchanged, got %q", result)
@@ -113,8 +109,7 @@ func TestInjectSystemPrompt_CodexExistingDeveloperInstructions(t *testing.T) {
 }
 
 func TestInjectSystemPrompt_Aider(t *testing.T) {
-	dir := t.TempDir()
-	result := injectSystemPrompt(tmux.ProgramAider, "aider", "test-session", dir)
+	result := injectSystemPrompt("aider")
 
 	if result != "aider" {
 		t.Errorf("expected aider unchanged (no system-prompt flag), got %q", result)
@@ -122,11 +117,70 @@ func TestInjectSystemPrompt_Aider(t *testing.T) {
 }
 
 func TestInjectSystemPrompt_Gemini(t *testing.T) {
-	dir := t.TempDir()
-	result := injectSystemPrompt(tmux.ProgramGemini, "gemini", "test-session", dir)
+	result := injectSystemPrompt("gemini")
 
 	if result != "gemini" {
 		t.Errorf("expected gemini unchanged (no system-prompt flag), got %q", result)
+	}
+}
+
+// TestInjectSystemPrompt_ResolvedCommandMatrix pins #1116/#1131: which flags
+// get injected is decided by the agent the RESOLVED command actually runs —
+// through every override shape (bare name, absolute path, path+flags,
+// redirect to a different agent, redirect to a non-agent binary) — never by
+// the config-name key the command was resolved from. The non-agent rows are
+// the class fix: injecting claude's --plugin-dir into e.g. bash makes it exit
+// instantly and the spawn dies as an opaque timeout.
+func TestInjectSystemPrompt_ResolvedCommandMatrix(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	tests := []struct {
+		name     string
+		resolved string
+		want     string // "" = resolved must come back unchanged
+	}{
+		// name→name (no override) for all four agents.
+		{"claude bare", "claude", "--plugin-dir"},
+		{"codex bare", "codex", "developer_instructions="},
+		{"aider bare", "aider", ""},
+		{"gemini bare", "gemini", ""},
+
+		// name→path and name→path+flags overrides.
+		{"claude override path", "/opt/claude-next/bin/claude", "--plugin-dir"},
+		{"claude override path with flags", "/opt/claude-next/bin/claude --model opus", "--plugin-dir"},
+		{"codex override path with flags", "/usr/local/bin/codex --full-auto", "developer_instructions="},
+		{"aider override path", "/usr/local/bin/aider --no-auto-commits", ""},
+		{"gemini override path", "/usr/local/bin/gemini", ""},
+
+		// name→other-agent: the RESOLVED agent's flags, not the key's.
+		{"claude key resolved to codex gets codex flags", "codex --full-auto", "developer_instructions="},
+		{"codex key resolved to claude gets claude flags", "/usr/bin/claude", "--plugin-dir"},
+
+		// name→non-agent binary: no injection at all (#1116, #1131).
+		{"claude key resolved to bash (#1131)", "bash", ""},
+		{"claude key resolved to unknown tool (#1116)", "/usr/bin/some-other-tool --foo", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := injectSystemPrompt(tt.resolved)
+			if tt.want == "" {
+				if got != tt.resolved {
+					t.Errorf("expected %q unchanged, got %q", tt.resolved, got)
+				}
+				return
+			}
+			if !strings.HasPrefix(got, tt.resolved) {
+				t.Errorf("expected resolved form preserved as prefix, got %q", got)
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("expected %q injected into %q, got %q", tt.want, tt.resolved, got)
+			}
+			// Exactly one agent's flags: claude's and codex's must never
+			// both appear.
+			if strings.Contains(got, "--plugin-dir") && strings.Contains(got, "developer_instructions=") {
+				t.Errorf("both agents' flags injected: %q", got)
+			}
+		})
 	}
 }
 

--- a/session/tmux/detect_agent_test.go
+++ b/session/tmux/detect_agent_test.go
@@ -1,0 +1,49 @@
+package tmux
+
+import "testing"
+
+// DetectAgentFromCommand is the seam every agent-conditional spawn/restore
+// behavior keys off (#1116, #1131): it must identify the agent a resolved
+// command will actually run — through override paths, trailing flags, and
+// wrapper prefixes — and return "" for anything that runs no known agent, so
+// no agent flags or readiness heuristics ever leak onto a non-agent command.
+func TestDetectAgentFromCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		// Bare enums (the common no-override case).
+		{"bare claude", "claude", ProgramClaude},
+		{"bare codex", "codex", ProgramCodex},
+		{"bare aider", "aider", ProgramAider},
+		{"bare gemini", "gemini", ProgramGemini},
+
+		// Override / legacy shapes: absolute paths, flags, quoting.
+		{"claude abs path", "/home/foo/bin/claude", ProgramClaude},
+		{"claude path with flags", "/home/foo/bin/claude --plugin-dir x", ProgramClaude},
+		{"codex path with flags", "/usr/local/bin/codex --full-auto", ProgramCodex},
+		{"quoted claude path", "'/opt/my tools/claude' --model opus", ProgramClaude},
+		{"uppercase base matches", "/opt/bin/Claude", ProgramClaude},
+
+		// Wrapper prefixes still match (#742 precedent from resumeProgram).
+		{"ionice wrapper", "ionice -c 3 claude", ProgramClaude},
+		{"env wrapper", "env FOO=1 gemini --resume latest", ProgramGemini},
+
+		// Non-agent commands: no agent behavior may attach to these.
+		{"bare shell (#1131)", "bash", ""},
+		{"unknown tool", "/usr/bin/some-other-tool", ""},
+		{"unknown tool with flags (#1116)", "/usr/bin/some-other-tool --foo", ""},
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"substring but not base", "/opt/claude-wrapper/run", ""},
+		{"agent name inside quoted arg", "bash -c 'claude --help'", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectAgentFromCommand(tt.command); got != tt.want {
+				t.Errorf("DetectAgentFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}

--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -36,25 +36,7 @@ import (
 // exists in cwd, so the rewrite is safe to apply unconditionally.
 func resumeProgram(program string) string {
 	tokens, ends := splitShellTokens(program)
-	if len(tokens) == 0 {
-		return program
-	}
-
-	agentIdx := -1
-	var agent string
-	for i, tok := range tokens {
-		base := strings.ToLower(filepath.Base(tok))
-		for _, supported := range SupportedPrograms {
-			if base == supported {
-				agentIdx = i
-				agent = supported
-				break
-			}
-		}
-		if agentIdx >= 0 {
-			break
-		}
-	}
+	agentIdx, agent := findAgentToken(tokens)
 	if agentIdx < 0 {
 		return program
 	}
@@ -117,6 +99,42 @@ func resumeProgram(program string) string {
 		return program + " --resume latest"
 	}
 	return program
+}
+
+// DetectAgentFromCommand returns the canonical agent name (one of
+// SupportedPrograms) that a resolved command string will actually run, or ""
+// when no agent token is present — e.g. a program_overrides entry that points
+// an agent name at a plain shell or an arbitrary tool (#1116, #1131).
+//
+// Every agent-specific spawn/restore behavior (flag injection, readiness
+// heuristics, trust-prompt handling) must key off THIS — what will actually
+// run — never off the config-name enum an instance was created with: the two
+// diverge exactly when program_overrides redirects an agent name, and keying
+// off the name injects flags the real program rejects (it exits instantly and
+// the spawn surfaces as an opaque timeout).
+//
+// The scan mirrors resumeProgram's: every shell token is checked, so wrapper
+// prefixes like `ionice -c 3 claude` still match (#742), and a token counts
+// only when filepath.Base equals a SupportedPrograms entry verbatim — a path
+// like /opt/claude-wrapper/run never matches on substring.
+func DetectAgentFromCommand(command string) string {
+	tokens, _ := splitShellTokens(command)
+	_, agent := findAgentToken(tokens)
+	return agent
+}
+
+// findAgentToken returns the index and canonical name of the first token whose
+// filepath.Base equals a SupportedPrograms entry, or (-1, "") when none does.
+func findAgentToken(tokens []string) (int, string) {
+	for i, tok := range tokens {
+		base := strings.ToLower(filepath.Base(tok))
+		for _, supported := range SupportedPrograms {
+			if base == supported {
+				return i, supported
+			}
+		}
+	}
+	return -1, ""
 }
 
 // isShortResumeWithAttachedValue reports whether tok is the POSIX

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -211,6 +211,14 @@ func (t *TmuxSession) SetProgram(program string) {
 	t.program = program
 }
 
+// Program returns the command this session's pane runs — after SetProgram,
+// the override-resolved, flag-injected string. This is the ground truth for
+// agent detection (DetectAgentFromCommand): what actually runs in the pane,
+// as opposed to the config-name enum the instance was created with (#1116).
+func (t *TmuxSession) Program() string {
+	return t.program
+}
+
 // NewSiblingSession builds a second TmuxSession in the same worktree that
 // shares this session's PTY factory and command executor. Used for the #930
 // per-tab sessions (e.g. an instance's shell tab alongside its agent tab):
@@ -261,7 +269,11 @@ func (t *TmuxSession) Start(workDir string) error {
 		select {
 		case <-timeout:
 			ptmx.Close()
-			timeoutErr := fmt.Errorf("timed out waiting for tmux session %s", t.sanitizedName)
+			// The pane program exiting instantly (bad path, rejected flag)
+			// takes the whole tmux session down before this existence poll
+			// ever sees it — name the likely cause and the exact command so
+			// the user isn't left with a bare timeout (#1116, #1131).
+			timeoutErr := fmt.Errorf("timed out waiting for tmux session %s; the pane program may have exited immediately after launch — check that it runs and accepts its flags (program: %q)", t.sanitizedName, t.program)
 			if cleanupErr := t.Close(); cleanupErr != nil {
 				timeoutErr = fmt.Errorf("%v (cleanup error: %v)", timeoutErr, cleanupErr)
 			}
@@ -292,8 +304,16 @@ func (t *TmuxSession) Start(workDir string) error {
 	// session here surfaces as an error rather than recursively re-spawning.
 	err = t.Restore("")
 	if err != nil {
+		// Probe BEFORE Close (which kills the session): the existence poll
+		// above saw the session, so if it is gone again by attach time the
+		// pane program exited within milliseconds of launch. Say so instead
+		// of the misleading "session does not exist" (#1116, #1131).
+		vanished := !t.DoesSessionExist()
 		if cleanupErr := t.Close(); cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
+		}
+		if vanished {
+			return fmt.Errorf("tmux session %s vanished before attach; the pane program likely exited immediately after launch — check that it runs and accepts its flags (program: %q): %w", t.sanitizedName, t.program, err)
 		}
 		return fmt.Errorf("error restoring tmux session: %w", err)
 	}
@@ -309,7 +329,10 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 		return false
 	}
 
-	if strings.Contains(t.program, ProgramClaude) {
+	// Key off the agent actually running in the pane, token-matched — a loose
+	// substring check would route e.g. /opt/claude-wrapper/run through the
+	// claude branch (#1116 defect class).
+	if DetectAgentFromCommand(t.program) == ProgramClaude {
 		if strings.Contains(content, "Do you trust the files in this folder?") ||
 			strings.Contains(content, "new MCP server") {
 			if err := t.TapEnter(); err != nil {
@@ -678,12 +701,15 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
 		return false, false
 	}
 
-	// Only set hasPrompt for claude and aider. Use these strings to check for a prompt.
-	if strings.Contains(t.program, ProgramClaude) {
+	// Only set hasPrompt for agents with a known confirmation dialog, keyed
+	// off the agent actually running in the pane (a non-agent override or a
+	// substring-matching path must not get an agent's prompt heuristic).
+	switch DetectAgentFromCommand(t.program) {
+	case ProgramClaude:
 		hasPrompt = strings.Contains(content, "No, and tell Claude what to do differently")
-	} else if strings.Contains(t.program, ProgramAider) {
+	case ProgramAider:
 		hasPrompt = strings.Contains(content, "(Y)es/(N)o/(D)on't ask again")
-	} else if strings.Contains(t.program, ProgramGemini) {
+	case ProgramGemini:
 		hasPrompt = strings.Contains(content, "Yes, allow once")
 	}
 

--- a/task/runner.go
+++ b/task/runner.go
@@ -24,12 +24,17 @@ var (
 // that downstream handlers know how to dismiss.
 //
 // The ready signals differ per agent, so callers resolve the canonical agent
-// name (session.DetectAgentFromProgram, which handles legacy free-form Program
-// paths) and pass it here. An empty or non-canonical agent falls through to
-// the Claude signals — the historical behavior before this became agent-aware
-// (#714). This is the single copy: the daemon reaches it via
-// task.StartAndSendPrompt (daemon imports task since #782 inverted the old
-// task→daemon dependency).
+// the pane actually runs (session.Instance.ResolvedAgent, which handles
+// program_overrides and legacy free-form Program values) and pass it here. An
+// empty agent means the resolved command runs no known agent — a
+// program_overrides entry pointing at a plain shell or arbitrary tool
+// (#1131) — so no agent's prompt glyph will ever appear; the generic signal
+// is any non-blank pane output (the process launched and rendered something;
+// WaitForReady separately fails fast if the session dies). This replaces the
+// pre-#1131 behavior of falling through to the Claude signals, which spun the
+// full 60s timeout for anything that never prints "❯". This is the single
+// copy: the daemon reaches it via task.StartAndSendPrompt (daemon imports
+// task since #782 inverted the old task→daemon dependency).
 func isReadyContent(content, agent string) bool {
 	switch agent {
 	case tmux.ProgramCodex:
@@ -53,14 +58,17 @@ func isReadyContent(content, agent string) bool {
 		// TODO(#714): replace with a confirmed gemini-specific ready string.
 		return strings.Contains(content, "╰") ||
 			isDocTrustPrompt(content)
-	default:
-		// claude and any unknown / legacy program (historical default).
+	case tmux.ProgramClaude:
 		if strings.Contains(content, "❯") ||
 			strings.Contains(content, "Do you trust") ||
 			strings.Contains(content, "new MCP server") {
 			return true
 		}
 		return isDocTrustPrompt(content)
+	default:
+		// No known agent in the resolved command (#1131): generic readiness —
+		// the pane rendered any non-blank output.
+		return strings.TrimSpace(content) != ""
 	}
 }
 
@@ -76,9 +84,12 @@ func isDocTrustPrompt(content string) bool {
 // input prompt or trust prompt, or times out after 60 seconds.
 func WaitForReady(instance *session.Instance) error {
 	// Resolve the canonical agent once so isReadyContent matches the right
-	// per-agent prompt signals; legacy free-form Program values normalize via
-	// DetectAgentFromProgram and unknown values fall through to claude (#714).
-	agent := session.DetectAgentFromProgram(instance.Program)
+	// per-agent prompt signals (#714). ResolvedAgent detects the agent from
+	// the command the pane actually runs — not the config-name enum — so a
+	// program_overrides entry pointing at a different program gets that
+	// program's readiness heuristic, and a non-agent override gets the
+	// generic one instead of waiting 60s for a claude glyph (#1116, #1131).
+	agent := instance.ResolvedAgent()
 	timeout := time.After(waitForReadyTimeout)
 	ticker := time.NewTicker(waitForReadyPollInterval)
 	defer ticker.Stop()

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -56,7 +56,7 @@ func TestIsReadyContent(t *testing.T) {
 		content string
 		want    bool
 	}{
-		// claude (and the default/legacy fallback)
+		// claude
 		{"empty", "claude", "", false},
 		{"claude input prompt", "claude", "some output\n\n❯ ", true},
 		{"claude trust prompt", "claude", "Do you trust the files in this folder?\n1. Yes\n2. No", true},
@@ -69,9 +69,16 @@ func TestIsReadyContent(t *testing.T) {
 			want: true,
 		},
 		{"claude not ready", "claude", "installing dependencies...\nready soon", false},
-		// An unknown / legacy program falls through to the claude signals.
-		{"unknown program uses claude signals", "/usr/bin/some-tool", "some output\n❯ ", true},
-		{"unknown program not ready", "/usr/bin/some-tool", "compiling…", false},
+
+		// No known agent in the resolved command (ResolvedAgent returned "",
+		// e.g. program_overrides pointing "claude" at bash, #1131): there is
+		// no prompt glyph to wait for, so any non-blank pane output counts as
+		// ready. Before #1131 this fell through to the claude signals and a
+		// bare shell spun out the full 60s timeout.
+		{"non-agent ready on shell prompt (#1131)", "", "sandbox$ ", true},
+		{"non-agent ready on any output", "", "hello from some tool", true},
+		{"non-agent empty pane not ready", "", "", false},
+		{"non-agent blank pane not ready", "", "\n   \n\n", false},
 
 		// codex — regression case from #714.
 		{"codex YOLO banner with prompt (#714)", "codex", codexYOLOBanner, true},
@@ -315,15 +322,48 @@ func (b *fakePreviewBackend) Preview(*session.Instance) (string, error) {
 // previewFn, backed by a FakeBackend so no tmux/git resources are touched.
 func newPreviewInstance(t *testing.T, previewFn func() (string, error)) *session.Instance {
 	t.Helper()
+	return newPreviewInstanceWithProgram(t, "claude", previewFn)
+}
+
+// newPreviewInstanceWithProgram is newPreviewInstance with an explicit
+// program, so tests can drive the non-agent readiness path (#1131).
+func newPreviewInstanceWithProgram(t *testing.T, program string, previewFn func() (string, error)) *session.Instance {
+	t.Helper()
 	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, _ string) (session.Backend, error) {
 		return &fakePreviewBackend{FakeBackend: session.NewFakeBackend(), previewFn: previewFn}, nil
 	})
 	defer restore()
-	inst, err := session.NewInstance(session.InstanceOptions{Title: "wait-ready", Path: t.TempDir(), Program: "claude"})
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "wait-ready", Path: t.TempDir(), Program: program})
 	if err != nil {
 		t.Fatalf("NewInstance: %v", err)
 	}
 	return inst
+}
+
+// TestWaitForReadyNonAgentBecomesReadyOnAnyOutput pins the #1131 fix at the
+// WaitForReady level: an instance whose program runs no known agent (e.g. the
+// play-test sandbox's "claude"→"bash" override) must become ready as soon as
+// the pane shows any non-blank content — not spin the full timeout waiting
+// for a claude prompt glyph. The 2s watchdog (well under the 10s timeout)
+// fails the test on the pre-fix behavior.
+func TestWaitForReadyNonAgentBecomesReadyOnAnyOutput(t *testing.T) {
+	defer setWaitForReadyTimingForTest(10*time.Second, time.Millisecond)()
+
+	inst := newPreviewInstanceWithProgram(t, "bash", func() (string, error) {
+		return "sandbox$ ", nil
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- WaitForReady(inst) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected non-agent pane with output to be ready, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForReady still polling a non-agent pane that already has output (#1131 pre-fix behavior)")
+	}
 }
 
 // setWaitForReadyTimingForTest shrinks the poll/timeout knobs so the polling


### PR DESCRIPTION
Closes #1116. Closes #1131.

## The defect class

Claude-specific (and generally agent-specific) spawn/restore behavior was keyed off the config **name** an instance was created with, not the **resolved** program that actually runs. With a `program_overrides` entry redirecting an agent name, the two diverge and every name-keyed site misbehaves:

- **#1116** — a non-claude override still got claude's `--plugin-dir` appended; a program that rejects unknown flags exits instantly and the user saw only a generic timeout / "session does not exist".
- **#1131** — the tui-playtest skill's documented cheap-instance recipe (`"claude": "bash"`) died the same way, and even with flags swallowed, the claude `❯`/trust-prompt readiness heuristic never matches a bare shell → 60s `waitForReady` timeout, instance reaped.

## The fix

One shared primitive: **`tmux.DetectAgentFromCommand`** — the token-basename scan `resumeProgram` has used since #742, now extracted and exported. It returns the canonical agent a resolved command will actually run, or `""` for a non-agent command. Every agent-conditional site on the spawn/restore path now keys off it:

| Site | Before | After |
|---|---|---|
| `session/systemprompt.go` `injectSystemPrompt` | config name (`DetectAgentFromProgram`, first-token only) | agent detected in the resolved command |
| `session/backend_local.go` AutoYes `--permission-mode` append | config name | resolved command |
| `session/backend_local.go` trust-prompt gate | config name | `Instance.ResolvedAgent()` (tmux pane program = ground truth, `Program` fallback pre-start) |
| `task/runner.go` `WaitForReady`/`isReadyContent` | config name; unknown → claude glyphs | resolved agent; non-agent → generic readiness (any non-blank pane output; session-death still fails fast per #976/#989) |
| `daemon/rootagent.go` `--dangerously-skip-permissions` append | unconditional on the resolved string | only when the resolved command runs claude |
| `session/tmux/tmux.go` trust-prompt + `HasUpdated` prompt heuristics | loose `strings.Contains` on the program (a `/opt/claude-wrapper/run` path false-positives) | token-basename detection |

`session.DetectAgentFromProgram` is deleted — all callers migrated; the new detector is a strict superset (scans all tokens, so `ionice -c 3 claude` wrappers match, mirroring #742).

**Non-agent readiness design**: generic signal = pane rendered any non-blank output, with the existing `ErrSessionGone` fast-fail covering death. No new config knob — this matches the codebase's content-heuristic pattern and adds no canonical surface; a program we can't identify has no prompt glyph to wait for, and "process alive + rendered something" is the strongest claim we can verify.

**Wrapper convention (documented in configuration.md)**: the agent is identified by command-token basename. If you wrap an agent in a script, name the script after the agent (the codex integration fixtures were renamed accordingly — an arbitrarily-named wrapper now correctly gets no agent behavior, which is exactly the #1116 semantics).

## Actionable errors (#1116's error-message ask)

Instant exit during startup no longer presents as a bare timeout, at both failure points:

- existence-poll timeout: `timed out waiting for tmux session …; the pane program may have exited immediately after launch — check that it runs and accepts its flags (program: "/bin/false")`
- vanished between poll and attach: `tmux session … vanished before attach; the pane program likely exited immediately after launch — … (program: "/bin/false")`

## Same-PR harness fixes

- `.claude/skills/tui-playtest.md` and `scripts/container/playtest-entry.sh` (both from the #1109/#1130 lineage) now use the plain `"claude": "bash"` recipe — the wrapper hack is gone and the skill text explains why the bare override works.

## Validation matrix

Pinned in unit tests across all 4 agents × override shapes:

- `TestInjectSystemPrompt_ResolvedCommandMatrix` (session): name→name, name→path, name→path+flags, name→other-agent, name→non-agent — asserts exactly the resolved agent's flags, never both, never any for non-agents.
- `TestDetectAgentFromCommand` (tmux): bare enums, paths, flags, quoting, wrappers, case, substring-not-base, quoted-arg non-matches.
- `TestResolvedAgent` (session): tmux program as ground truth incl. `#677` legacy free-form fallback.
- `TestResolveProgramForInstance_OverrideTo*` (session): AutoYes flag kept for claude-running overrides, dropped for non-agents, plus the existing #677/#818 legacy AutoYes suite.
- `isReadyContent` non-agent generic rows + `TestWaitForReadyNonAgentBecomesReadyOnAnyOutput` (task).
- `TestRootAgentProgramOverrideMatrix` (daemon).
- Existing regression suites untouched and green: #714/#715/#729 codex readiness (fixtures renamed to basename `codex`), #677/#818 legacy flags, #976/#989 session-death fast-fail.

## Verification

- `gofmt -l .` empty, `golangci-lint run --timeout=3m --fast` clean, `deadcode -test ./...` clean, `go build ./...` OK.
- **Full suite green in the container** (`make test-container`, #1130 harness): all packages incl. daemon.
- **End-to-end in the playtest container** (built from this branch): with `"claude": "bash"`, `af sessions create --prompt "echo hello-from-1131"` succeeds in ~1s, the pane runs bash in the worktree and executes the prompt (`hello-from-1131` observed), kill clean. With `"claude": "/bin/false"`, create fails immediately with the actionable vanished-before-attach message quoted above — no 60s hang, no bare timeout.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)