### PR TITLE
tui: clamp task form to overlay height, ellipsize pane titles, Enter submits from any field

### DIFF
--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -336,7 +336,9 @@ func (w *TabbedWindow) renderHeader(width int) string {
 	case w.boundInstance() == nil:
 		style = paneHeaderDimStyle
 	}
-	header := style.Render(text)
+	// Ellipsize before styling: ClampToRect's hard cut would render a narrow
+	// pane's header as `alpha · Termina` with no mark of the cut (#1098).
+	header := style.Render(fitLine(text, width))
 	return layout.ClampToRect(header, layout.Rect{W: width, H: paneHeaderRows})
 }
 

--- a/ui/tabbed_window_test.go
+++ b/ui/tabbed_window_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/stretchr/testify/assert"
 )
@@ -72,4 +73,22 @@ func TestTabbedWindowViewIsExactlyRectSized(t *testing.T) {
 	for i, line := range lines {
 		assert.Equalf(t, 100, lipgloss.Width(line), "line %d must be exactly rect.W cells", i)
 	}
+}
+
+// TestTabbedWindowHeaderEllipsizesAtNarrowWidth pins #1098 finding 2: at a
+// 40x10 terminal the pane header used to hard-cut (`alpha · Termina`); the
+// cut must be marked with an ellipsis instead.
+func TestTabbedWindowHeaderEllipsizesAtNarrowWidth(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst := startedRemoteInstance(t, false)
+	w := newTestTabbedWindow()
+	setWindowInstance(w, inst)
+
+	// " remote-tabbar · Preview " needs 25 cells; give it 16.
+	header := w.renderHeader(16)
+	assert.LessOrEqual(t, lipgloss.Width(header), 16, "header must fit the pane width")
+	assert.Contains(t, header, "…", "the cut must be marked with an ellipsis")
+	assert.NotContains(t, header, "Preview", "the tail is truncated")
 }

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -72,6 +72,10 @@ type TaskPane struct {
 	editError          string // last validation error shown to the user
 	editErrorField     int    // focus stop the error is rendered under (-1 = none)
 	focusIndex         int
+	// formScroll is the edit form's line offset when the pane is shorter than
+	// the rendered form (#1098): renderEditMode windows the form so the
+	// focused field stays in view instead of clipping off the top.
+	formScroll int
 
 	// Create mode
 	creating       bool
@@ -239,6 +243,7 @@ func (s *TaskPane) initForm(tsk *task.Task, defaultPath string) {
 	s.focusIndex = taskFocusName
 	s.editError = ""
 	s.editErrorField = -1
+	s.formScroll = 0
 }
 
 // EnterCreateMode initializes empty edit fields for creating a new task. An
@@ -496,45 +501,53 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 		s.editError = ""
 		s.editErrorField = -1
 	case tea.KeyEnter:
-		if s.focusIndex == taskFocusSave {
-			if errMsg, errField := s.validateForm(); errMsg != "" {
-				s.editError = errMsg
-				s.editErrorField = errField
-				return true
-			}
-			s.editError = ""
-			s.editErrorField = -1
-			cron, watch := s.triggerValues()
-			if s.creating {
-				s.pendingCreate = true
-				s.creating = false
-			} else {
-				// Mirror the create path (app.handleTaskCreate): expand a
-				// leading ~ then resolve to an absolute form so an empty or
-				// relative value behaves the same when the scheduler fires
-				// as it does in the TUI trigger (#641, #924). validateForm
-				// already normalized editPath, so this is idempotent.
-				absPath, err := filepath.Abs(config.ExpandTilde(s.editPath.Value()))
-				if err != nil {
-					s.editError = fmt.Sprintf("invalid path: %v", err)
-					s.editErrorField = taskFocusPath
-					return true
-				}
-				s.tasks[s.selectedIdx].Name = s.editName.Value()
-				s.tasks[s.selectedIdx].Prompt = s.editPrompt.Value()
-				s.tasks[s.selectedIdx].CronExpr = cron
-				s.tasks[s.selectedIdx].WatchCmd = watch
-				s.tasks[s.selectedIdx].TargetSession = s.editTarget.Value()
-				s.tasks[s.selectedIdx].ProjectPath = absPath
-				s.tasks[s.selectedIdx].Program = s.programValue()
-				s.dirty = true
-				s.editing = false
+		// The prompt keeps Enter for newlines; every other field submits, so
+		// the footer's blanket "enter save" holds wherever focus is (#1098 —
+		// Enter on the Name field used to be a dead key).
+		if s.focusIndex == taskFocusPrompt {
+			s.editPrompt, _ = s.editPrompt.Update(msg)
+			return true
+		}
+		if errMsg, errField := s.validateForm(); errMsg != "" {
+			s.editError = errMsg
+			s.editErrorField = errField
+			// Land focus on the offending field so its inline error is in
+			// view even when the clamped form has it scrolled off-screen.
+			if errField >= 0 && errField != s.focusIndex {
+				s.focusIndex = errField
+				s.updateEditFocus()
 			}
 			return true
 		}
-		if s.focusIndex == taskFocusPrompt {
-			s.editPrompt, _ = s.editPrompt.Update(msg)
+		s.editError = ""
+		s.editErrorField = -1
+		cron, watch := s.triggerValues()
+		if s.creating {
+			s.pendingCreate = true
+			s.creating = false
+		} else {
+			// Mirror the create path (app.handleTaskCreate): expand a
+			// leading ~ then resolve to an absolute form so an empty or
+			// relative value behaves the same when the scheduler fires
+			// as it does in the TUI trigger (#641, #924). validateForm
+			// already normalized editPath, so this is idempotent.
+			absPath, err := filepath.Abs(config.ExpandTilde(s.editPath.Value()))
+			if err != nil {
+				s.editError = fmt.Sprintf("invalid path: %v", err)
+				s.editErrorField = taskFocusPath
+				return true
+			}
+			s.tasks[s.selectedIdx].Name = s.editName.Value()
+			s.tasks[s.selectedIdx].Prompt = s.editPrompt.Value()
+			s.tasks[s.selectedIdx].CronExpr = cron
+			s.tasks[s.selectedIdx].WatchCmd = watch
+			s.tasks[s.selectedIdx].TargetSession = s.editTarget.Value()
+			s.tasks[s.selectedIdx].ProjectPath = absPath
+			s.tasks[s.selectedIdx].Program = s.programValue()
+			s.dirty = true
+			s.editing = false
 		}
+		return true
 	default:
 		switch s.focusIndex {
 		case taskFocusName:
@@ -815,6 +828,24 @@ func (s *TaskPane) renderEditMode() string {
 	}
 
 	var b strings.Builder
+	// Track the focused stop's line range while building, so the form can be
+	// windowed to the pane height with the focused field scrolled into view
+	// (#1098): below ~15 terminal rows the form is taller than the overlay,
+	// and without a window the top fields clip off-screen while still holding
+	// focus. markStart/markEnd bracket each focus stop's lines (including its
+	// inline error, so validation messages scroll into view too).
+	focusStart, focusEnd := -1, -1
+	markStart := func(stop int) {
+		if stop == s.focusIndex {
+			focusStart = strings.Count(b.String(), "\n")
+		}
+	}
+	markEnd := func(stop int) {
+		if stop == s.focusIndex {
+			focusEnd = strings.Count(b.String(), "\n")
+		}
+	}
+
 	if s.creating {
 		b.WriteString(editTitleStyle.Render("New Task"))
 	} else {
@@ -825,13 +856,18 @@ func (s *TaskPane) renderEditMode() string {
 
 	b.WriteString(groupStyle.Render("Essentials"))
 	b.WriteString("\n")
+	markStart(taskFocusName)
 	b.WriteString(label("Name:"))
 	b.WriteString(s.editName.View())
 	b.WriteString("\n")
 	b.WriteString(fieldErr(taskFocusName))
+	markEnd(taskFocusName)
+	markStart(taskFocusTrigger)
 	b.WriteString(label("Trigger:"))
 	b.WriteString(s.renderTriggerSelector())
 	b.WriteString("\n")
+	markEnd(taskFocusTrigger)
+	markStart(taskFocusTriggerValue)
 	if s.editTriggerIsWatch {
 		b.WriteString(label("Watch:"))
 		b.WriteString(s.editWatch.View())
@@ -841,6 +877,8 @@ func (s *TaskPane) renderEditMode() string {
 	}
 	b.WriteString("\n")
 	b.WriteString(fieldErr(taskFocusTriggerValue))
+	markEnd(taskFocusTriggerValue)
+	markStart(taskFocusPrompt)
 	b.WriteString(labelStyle.Render("Prompt:"))
 	if s.editTriggerIsWatch {
 		b.WriteString(hintStyle.Render(" (optional)"))
@@ -849,34 +887,98 @@ func (s *TaskPane) renderEditMode() string {
 	b.WriteString(s.editPrompt.View())
 	b.WriteString("\n")
 	b.WriteString(fieldErr(taskFocusPrompt))
+	markEnd(taskFocusPrompt)
 	b.WriteString("\n")
 
 	b.WriteString(groupStyle.Render("Delivery"))
 	b.WriteString("\n")
+	markStart(taskFocusTarget)
 	b.WriteString(label("Target:"))
 	b.WriteString(s.editTarget.View())
 	b.WriteString("\n")
+	markEnd(taskFocusTarget)
+	markStart(taskFocusPath)
 	b.WriteString(label("Path:"))
 	b.WriteString(s.editPath.View())
 	b.WriteString("\n")
 	b.WriteString(fieldErr(taskFocusPath))
+	markEnd(taskFocusPath)
+	markStart(taskFocusProgram)
 	b.WriteString(label("Program:"))
 	b.WriteString(s.renderProgramSelector())
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+	markEnd(taskFocusProgram)
+	b.WriteString("\n")
 
 	submitLabel := " Save "
 	if s.creating {
 		submitLabel = " Create "
 	}
+	markStart(taskFocusSave)
 	if s.focusIndex == taskFocusSave {
 		b.WriteString(focusedButtonStyle.Render(submitLabel))
 	} else {
 		b.WriteString(buttonStyle.Render(submitLabel))
 	}
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+	markEnd(taskFocusSave)
+	b.WriteString("\n")
 	b.WriteString(hintStyle.Render(fitLine("tab next • shift+tab prev • enter save • esc cancel", s.width)))
 
-	return b.String()
+	return s.clampFormToHeight(b.String(), focusStart, focusEnd)
+}
+
+// clampFormToHeight windows the rendered edit form to the pane height, keeping
+// the focused field's lines in view (#1098). The key-hint footer stays pinned
+// as the last visible line so tab/esc are always discoverable, and dim ↑/↓
+// markers flag fields scrolled out of the window. focusStart/focusEnd are the
+// focused stop's line range, end-exclusive; a form that already fits renders
+// unchanged.
+func (s *TaskPane) clampFormToHeight(content string, focusStart, focusEnd int) string {
+	maxH := s.height
+	lines := strings.Split(content, "\n")
+	if maxH <= 0 || len(lines) <= maxH {
+		return content
+	}
+	if maxH < 3 {
+		maxH = 3
+	}
+	hint := lines[len(lines)-1]
+	body := lines[:len(lines)-1]
+	visible := maxH - 1
+
+	off := s.formScroll
+	if off > len(body)-visible {
+		off = len(body) - visible
+	}
+	if off < 0 {
+		off = 0
+	}
+	if focusStart >= 0 {
+		// Bottom edge first, then top: when the range is taller than the
+		// window the field's first line wins.
+		if focusEnd > off+visible {
+			off = focusEnd - visible
+		}
+		if focusStart < off {
+			off = focusStart
+		}
+	}
+	s.formScroll = off
+
+	win := make([]string, visible)
+	copy(win, body[off:off+visible])
+	moreStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+	inFocusRange := func(line int) bool {
+		return focusStart >= 0 && line >= focusStart && line < focusEnd
+	}
+	if off > 0 && !inFocusRange(off) {
+		win[0] = moreStyle.Render("  ↑ more")
+	}
+	if last := off + visible - 1; last < len(body)-1 && !inFocusRange(last) {
+		win[visible-1] = moreStyle.Render("  ↓ more")
+	}
+	return strings.Join(append(win, hint), "\n")
 }
 
 // renderTriggerSelector renders the inline cron|watch type selector on one

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -27,6 +27,10 @@ var taskPlaceholderStyle = lipgloss.NewStyle().
 	Faint(true).
 	Foreground(lipgloss.AdaptiveColor{Light: "#B5B0B0", Dark: "#5C5757"})
 
+// taskFormMoreStyle dims the ↑/↓ markers flagging fields scrolled out of a
+// height-clamped edit form (#1098).
+var taskFormMoreStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+
 // Edit-form focus stops, in tab order. The form is grouped: Essentials
 // (name, trigger, prompt) then Delivery (target session, path, program).
 // The trigger is a two-step stop: a cron|watch type selector followed by the
@@ -946,6 +950,11 @@ func (s *TaskPane) clampFormToHeight(content string, focusStart, focusEnd int) s
 	hint := lines[len(lines)-1]
 	body := lines[:len(lines)-1]
 	visible := maxH - 1
+	if visible > len(body) {
+		// The raised floor can exceed a short body (degenerate heights); a
+		// window larger than the body would slice past its end.
+		visible = len(body)
+	}
 
 	off := s.formScroll
 	if off > len(body)-visible {
@@ -968,15 +977,14 @@ func (s *TaskPane) clampFormToHeight(content string, focusStart, focusEnd int) s
 
 	win := make([]string, visible)
 	copy(win, body[off:off+visible])
-	moreStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
 	inFocusRange := func(line int) bool {
 		return focusStart >= 0 && line >= focusStart && line < focusEnd
 	}
 	if off > 0 && !inFocusRange(off) {
-		win[0] = moreStyle.Render("  ↑ more")
+		win[0] = taskFormMoreStyle.Render("  ↑ more")
 	}
 	if last := off + visible - 1; last < len(body)-1 && !inFocusRange(last) {
-		win[visible-1] = moreStyle.Render("  ↓ more")
+		win[visible-1] = taskFormMoreStyle.Render("  ↓ more")
 	}
 	return strings.Join(append(win, hint), "\n")
 }

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -879,4 +880,112 @@ func TestTaskPaneListPromptOnlyOnSelectedRow(t *testing.T) {
 		"the selected row must show its prompt snippet")
 	assert.NotContains(t, out, "unselected prompt body",
 		"unselected rows must stay one line — no prompt body")
+}
+
+// TestTaskPaneCreateModeEnterSubmitsFromAnyField pins #1098 finding 3: the
+// footer promises a blanket "enter save", but Enter used to be a dead key on
+// every field except the Create/Save button. Submitting from the Name field
+// must work.
+func TestTaskPaneCreateModeEnterSubmitsFromAnyField(t *testing.T) {
+	repo := newGitRepo(t)
+	tp := NewTaskPane()
+	tp.SetSize(80, 24)
+	tp.EnterCreateMode(repo)
+	fillCreateForm(t, tp, "enter-on-name")
+
+	// fillCreateForm leaves focus on Name (index 0).
+	assert.Equal(t, taskFocusName, tp.focusIndex)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, tp.pendingCreate, "enter on the Name field must submit a valid form")
+	assert.False(t, tp.creating)
+}
+
+// TestTaskPaneCreateModeEnterMovesFocusToInvalidField: submitting an invalid
+// form from any field surfaces the inline error AND moves focus to the
+// offending field, so the error is in view even when the clamped form has it
+// scrolled off-screen (#1098).
+func TestTaskPaneCreateModeEnterMovesFocusToInvalidField(t *testing.T) {
+	repo := newGitRepo(t)
+	tp := NewTaskPane()
+	tp.SetSize(80, 24)
+	tp.EnterCreateMode(repo)
+	// Name typed, cron left empty.
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("half-filled")})
+
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.True(t, tp.creating, "invalid form must not submit")
+	assert.False(t, tp.pendingCreate)
+	assert.Equal(t, "cron expression is required", tp.editError)
+	assert.Equal(t, taskFocusTriggerValue, tp.editErrorField)
+	assert.Equal(t, taskFocusTriggerValue, tp.focusIndex,
+		"focus must land on the offending field")
+}
+
+// TestTaskPaneCreateModeEnterInPromptInsertsNewline: the prompt textarea keeps
+// Enter for newlines — the any-field submit (#1098) must not swallow it.
+func TestTaskPaneCreateModeEnterInPromptInsertsNewline(t *testing.T) {
+	repo := newGitRepo(t)
+	tp := NewTaskPane()
+	tp.SetSize(80, 24)
+	tp.EnterCreateMode(repo)
+	fillCreateForm(t, tp, "prompt-newline")
+
+	tabTo(tp, taskFocusPrompt)
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("line2")})
+	assert.True(t, tp.creating, "enter in the prompt must not submit")
+	assert.Contains(t, tp.editPrompt.Value(), "\n",
+		"enter in the prompt must insert a newline")
+}
+
+// TestTaskPaneEditFormClampsToHeightWithFocusInView pins #1098 finding 1: at
+// a 60x15 terminal the edit form is taller than the tasks overlay and used to
+// clip off the TOP — Name/Trigger invisible while Name silently held focus.
+// The form must window to the pane height, keep the focused field in view,
+// pin the key-hint footer, and flag hidden fields.
+func TestTaskPaneEditFormClampsToHeightWithFocusInView(t *testing.T) {
+	repo := newGitRepo(t)
+	tp := NewTaskPane()
+	// The task pane's share of a 60x15 terminal (app sizing: 52 wide, 0.6*15 tall).
+	tp.SetSize(52, 9)
+	tp.EnterCreateMode(repo)
+
+	out := tp.String()
+	lines := strings.Split(out, "\n")
+	assert.LessOrEqual(t, len(lines), 9, "form must clamp to the pane height")
+	assert.Contains(t, out, "Name:", "the focused first field must be visible")
+	assert.Contains(t, lines[len(lines)-1], "esc cancel", "key hints stay pinned")
+	assert.Contains(t, out, "↓ more", "hidden fields below are flagged")
+
+	// Walk to the Create button: it must scroll into view, pushing Name out.
+	tabTo(tp, taskFocusSave)
+	out = tp.String()
+	lines = strings.Split(out, "\n")
+	assert.LessOrEqual(t, len(lines), 9, "clamp holds while scrolled")
+	assert.Contains(t, out, "Create", "the focused Save button scrolled into view")
+	assert.NotContains(t, out, "Name:", "top fields scrolled out of the window")
+	assert.Contains(t, out, "↑ more", "hidden fields above are flagged")
+	assert.Contains(t, lines[len(lines)-1], "esc cancel", "key hints stay pinned")
+
+	// Walking back re-scrolls the top fields into view.
+	for i := 0; i < taskFocusSave; i++ {
+		tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyShiftTab})
+	}
+	out = tp.String()
+	assert.Contains(t, out, "Name:", "shift+tab back scrolls Name into view")
+}
+
+// TestTaskPaneEditFormUnclampedWhenItFits: at normal sizes the form renders
+// unchanged — no window, no more-markers.
+func TestTaskPaneEditFormUnclampedWhenItFits(t *testing.T) {
+	repo := newGitRepo(t)
+	tp := NewTaskPane()
+	tp.SetSize(80, 24)
+	tp.EnterCreateMode(repo)
+
+	out := tp.String()
+	assert.Contains(t, out, "Name:")
+	assert.Contains(t, out, "Create")
+	assert.NotContains(t, out, "↑ more")
+	assert.NotContains(t, out, "↓ more")
 }

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -989,3 +989,29 @@ func TestTaskPaneEditFormUnclampedWhenItFits(t *testing.T) {
 	assert.NotContains(t, out, "↑ more")
 	assert.NotContains(t, out, "↓ more")
 }
+
+// TestTaskPaneClampFormDegenerateHeights guards the clamp floor (Greptile on
+// #1133): a height-1/2 pane raises the window floor to 3 lines, and a body
+// shorter than the raised window must not slice past its end.
+func TestTaskPaneClampFormDegenerateHeights(t *testing.T) {
+	repo := newGitRepo(t)
+	tp := NewTaskPane()
+	tp.EnterCreateMode(repo)
+
+	for _, h := range []int{1, 2} {
+		tp.SetSize(52, h)
+		assert.NotPanicsf(t, func() {
+			out := tp.String()
+			assert.LessOrEqualf(t, len(strings.Split(out, "\n")), 3,
+				"height %d renders at most the 3-line floor", h)
+		}, "height %d must not panic", h)
+	}
+
+	// Body shorter than the raised window: 2-line content at height 1 used to
+	// slice body[0:2] on a 1-line body.
+	tp.SetSize(52, 1)
+	assert.NotPanics(t, func() {
+		got := tp.clampFormToHeight("only\nhint", 0, 1)
+		assert.Equal(t, "only\nhint", got, "a body shorter than the window renders unchanged")
+	})
+}


### PR DESCRIPTION
Closes #1098

Three fast-follows from the #1096 rev-2 play-test. All three findings were **re-verified to still reproduce on current master** (post-#1099 N-pane model and #1121 termpane) by driving the real TUI inside `make playtest-container` before fixing; none had been fixed en passant.

## 1. Task form clips off the top at small heights

At 60x15 the New Task form rendered taller than the tasks overlay and clipped off the **top** — Name/Trigger invisible while Name silently held focus, typing showed nothing. `renderEditMode` now tracks the focused stop's line range while building and windows the form to the pane height (`clampFormToHeight`): focused field scrolled into view (inline validation errors included in the range, so they scroll in too), the key-hint footer pinned as the last line, and dim `↑ more` / `↓ more` markers flagging hidden fields. Forms that fit render unchanged; `formScroll` resets whenever a form opens.

**Before (60x15, form just opened — focus is on the invisible Name field):**
```
│  Cron:    > e.g. 0 9 * * 1-5
│  Prompt:
│  Enter task prompt...
│
│
│  Delivery
│  Target:  > (new session per run)
│  Path:    > /home/dev/sandbox/mock-repo
│  Program: (use config default)
│
│   Create
│
│  tab next • shift+tab prev • enter save • esc cancel
│
╰───────────────────────────────────────────────────────────
```

**After (60x15, same state):**
```
╭───────────────────────────────────────────────────────────
│
│  New Task
│
│  Essentials
│  Name:    > Task name
│  Trigger: ▸ cron    watch
│  Cron:    > e.g. 0 9 * * 1-5
│  Prompt:
│    ↓ more
│  tab next • shift+tab prev • enter save • esc cancel
│
╰───────────────────────────────────────────────────────────
```

**After (60x15, tabbed to the Create button — scrolls into view):**
```
╭───────────────────────────────────────────────────────────
│
│    ↑ more
│
│  Delivery
│  Target:  > (new session per run)
│  Path:    > /home/dev/sandbox/mock-repo
│  Program: (use config default)
│
│   Create
│  tab next • shift+tab prev • enter save • esc cancel
│
╰───────────────────────────────────────────────────────────
```

**After (40x10 — the hard-minimum size — still clean):**
```
╭───────────────────────────────────────
│
│  New Task
│
│  Essentials
│  Name:    > Task name
│    ↓ more
│  tab next • shift+tab prev • ent…
│
╰───────────────────────────────────────
```

## 2. Pane title hard-cuts at narrow widths

The `title · tab` pane header went through `layout.ClampToRect`'s bare hard cut. It now ellipsizes via the existing `fitLine` helper before styling (ClampToRect stays as the backstop).

**Before (40x10):** `│ alpha · Termina│`
**After (40x10):** `│ alpha · Termin…│`

## 3. Enter on the Name field didn't submit

Enter was a dead key on every field except the Create/Save button, at odds with the footer's blanket "enter save". Enter now submits from **any** field except the prompt textarea (which keeps Enter for newlines). On validation failure, focus jumps to the offending field so its inline error is always scrolled into view — verified at 60x15: Enter on Name with an empty cron lands focus on the Cron field with `! cron expression is required` visible, and a valid form submitted from the Name field creates the task.

## #1084 assessed — separate, not included

Issue #1084 (cursor drifts to the trailing instance after `w` on an instance's last tab row) was also re-verified: it **still reproduces on current master** (closing alpha's last tab row with beta below folded alpha's subtree and rebound the cursor to beta; the tab close itself stays data-safe). Its fix lives in the tree-nav re-pin path (`ui/sidebar.go` `SyncCursorToActiveTab` + `app/tree_nav_test.go`), which shares no files with this overlay/pane-title change — so it is genuinely separate and left open rather than folded in here.

## Adjacent call-sites audited

- `HooksPane` (the other 0.6×0.6 overlay) renders a short flat list, not a fixed-height form — it can only overflow with an unusually long hook list, a different and much milder class; excluded.
- Other truncation sites (tree rows, list rows, inline errors, error footer) already ellipsize via `fitLine`/`runewidth.Truncate` with a tail; the pane header was the remaining bare hard cut.

## Testing

- `golangci-lint run --timeout=3m --fast` clean, `gofmt -l .` empty, `deadcode -test ./...` empty, `go build ./...` OK
- `make test-container`: full suite green (20/20 packages ok)
- New regression tests: form clamps to height with focus-follow scrolling in both directions + pinned hints (`TestTaskPaneEditFormClampsToHeightWithFocusInView`, `TestTaskPaneEditFormUnclampedWhenItFits`), Enter submits from any field / moves focus to the invalid field / stays a newline in the prompt (3 tests), header ellipsis (`TestTabbedWindowHeaderEllipsizesAtNarrowWidth`)
- Play-tested end-to-end in `make playtest-container` at 60x15, 40x10, and 80x24 (captures above; 80x24 unchanged)

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)