### PR TITLE
session,daemon,tui: Lost vs user-killed classification — tombstone + rollforward (#1108 PR 1)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -268,6 +268,12 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		if selected.GetStatus() == session.Deleting {
 			return m, m.handleError(fmt.Errorf("session '%s' is being deleted", selected.Title))
 		}
+		if selected.GetStatus() == session.Lost {
+			// Lost (#1108): the backing tmux session vanished with no kill on
+			// record. Attach is impossible right now; say what happened —
+			// same explicit-feedback contract as the Deleting path (#935).
+			return m, m.handleError(fmt.Errorf("session '%s' was lost — its tmux session is gone", selected.Title))
+		}
 		if !selected.TmuxAlive() {
 			// The backing session has vanished, so attaching is impossible.
 			// Surface an actionable error instead of swallowing Enter, mirroring

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -200,6 +200,9 @@ func (m *home) handleEnterPane(p *store.OpenPane) (tea.Model, tea.Cmd) {
 	if instance.GetStatus() == session.Deleting {
 		return m, m.handleError(fmt.Errorf("session '%s' is being deleted", instance.Title))
 	}
+	if instance.GetStatus() == session.Lost {
+		return m, m.handleError(fmt.Errorf("session '%s' was lost — its tmux session is gone", instance.Title))
+	}
 	if !instance.TmuxAlive() {
 		return m, m.handleError(fmt.Errorf("session '%s' is no longer running", instance.Title))
 	}

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -171,7 +171,7 @@ func (m *home) liveBindCandidate(target *store.OpenPane) (key, sessionName strin
 		return "", ""
 	}
 	switch inst.GetStatus() {
-	case session.Loading, session.Deleting, session.Dead:
+	case session.Loading, session.Deleting, session.Dead, session.Lost:
 		return "", ""
 	}
 	tab := target.Tab()

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -933,6 +933,12 @@ type Manager struct {
 	// kill and stops re-creating that root until the daemon restarts —
 	// in-memory on purpose, so a restart re-asserts the configured state.
 	rootKilledByUser map[string]struct{}
+	// killsInFlight marks sessions (by daemon instance key) whose KillSession
+	// teardown is currently running, so the status poll's finish-kill pass for
+	// tombstoned records (#1108) never runs a second concurrent teardown of
+	// the same session, and a duplicate KillSession RPC is rejected instead of
+	// double-killing.
+	killsInFlight map[string]struct{}
 }
 
 // NewManager constructs a manager and synchronously restores all persisted
@@ -970,6 +976,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		targetLocks:         make(map[string]*sync.Mutex),
 		rootEnsureStates:    make(map[string]*rootEnsureState),
 		rootKilledByUser:    make(map[string]struct{}),
+		killsInFlight:       make(map[string]struct{}),
 	}, nil
 }
 
@@ -1050,9 +1057,12 @@ func (m *Manager) RefreshStatuses() {
 //     the TUI so it works whether or not a TUI is attached;
 //   - HasUpdated → Running; a waiting prompt → TapEnter (the AutoYes path, which
 //     this poll already owned — unchanged by #960);
-//   - otherwise probe liveness: a vanished tmux/remote session → Dead (never
-//     repainted Ready, the #935 invariant the hollow dead-dot rendering relies
-//     on), a live idle one → Ready.
+//   - otherwise probe liveness: a vanished tmux/remote session → Lost (never
+//     repainted Ready, the #935 invariant the hollow status-dot rendering
+//     relies on; Lost rather than Dead since #1108 — no kill intent on record
+//     means the session is recovery-eligible), a live idle one → Ready;
+//   - a session carrying the kill-intent tombstone (#1108) short-circuits all
+//     of the above: its interrupted teardown is finished instead.
 //
 // Status writes go through SetStatusIfNotDeleting so a concurrent kill's Deleting
 // marker is never clobbered. Only a real transition is persisted, and it persists
@@ -1062,6 +1072,14 @@ func (m *Manager) RefreshStatuses() {
 // instances.json.
 func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instance) {
 	if instance == nil || !instance.Started() {
+		return
+	}
+	if instance.UserKilled() {
+		// A surviving kill-intent tombstone (#1108) means a previous
+		// KillSession was interrupted after committing to the kill. The only
+		// valid future for this session is finishing that teardown — never
+		// probing it, never marking it Lost, never restoring it.
+		m.finishUserKill(repoID, instance)
 		return
 	}
 	if status := instance.GetStatus(); status == session.Loading || status == session.Deleting {
@@ -1091,10 +1109,13 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	case !instance.TmuxAlive():
 		// HasUpdated returned (false,false), which a healthy idle session and a
 		// dead one both produce — indistinguishable on their own. Probe liveness
-		// only on this idle branch so a vanished session is marked Dead and
+		// only on this idle branch so a vanished session is marked Lost and
 		// rendered distinctly rather than repainted as a green Ready dot it can
-		// no longer back (#935).
-		instance.SetStatusIfNotDeleting(session.Dead)
+		// no longer back (#935). Lost, not Dead (#1108): there is no kill
+		// intent on record, so the session vanished out from under a live
+		// record — an outage/reboot casualty that is recovery-eligible, not a
+		// corpse the user wanted gone.
+		instance.SetStatusIfNotDeleting(session.Lost)
 	default:
 		instance.SetStatusIfNotDeleting(session.Ready)
 	}
@@ -1460,6 +1481,28 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 		return err
 	}
 
+	key := daemonInstanceKey(repoID, req.Title)
+	m.mu.Lock()
+	if _, busy := m.killsInFlight[key]; busy {
+		m.mu.Unlock()
+		return fmt.Errorf("kill already in progress for session %q", req.Title)
+	}
+	m.killsInFlight[key] = struct{}{}
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		delete(m.killsInFlight, key)
+		m.mu.Unlock()
+	}()
+
+	// Persist the kill-intent tombstone BEFORE teardown begins (#1108): if the
+	// daemon dies or the teardown errors between here and DeleteInstance, the
+	// surviving record is provably a user kill — the status poll finishes the
+	// teardown instead of classifying the vanished session Lost and restoring
+	// it. Best-effort: a failed tombstone write degrades to today's crash
+	// window, which must not block the kill itself.
+	m.persistKillTombstone(repoID, instance, data)
+
 	if instance != nil {
 		if err := instance.Kill(); err != nil {
 			return fmt.Errorf("failed to kill instance: %w", err)
@@ -1478,7 +1521,7 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 	}
 
 	m.mu.Lock()
-	delete(m.instances, daemonInstanceKey(repoID, req.Title))
+	delete(m.instances, key)
 	if session.IsReservedTitle(req.Title) {
 		// An explicit kill of the root agent is a user decision the ensure
 		// loop must respect (#1106): suppress re-creation for this repo until
@@ -1491,6 +1534,72 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 	}
 	m.mu.Unlock()
 	return nil
+}
+
+// persistKillTombstone writes the kill-intent tombstone (#1108) for the session
+// KillSession is about to tear down, so a record surviving a crash or teardown
+// failure mid-kill is never classified Lost and restored. Best-effort by
+// design: a failed write only degrades to the pre-tombstone crash window.
+func (m *Manager) persistKillTombstone(repoID string, instance *session.Instance, data *session.InstanceData) {
+	var d session.InstanceData
+	switch {
+	case instance != nil:
+		instance.MarkUserKilled()
+		d = instance.ToInstanceData()
+	case data != nil:
+		d = *data
+		d.UserKilled = true
+	default:
+		return
+	}
+	repoStartLock := m.startLockForRepo(repoID)
+	repoStartLock.Lock()
+	err := persistInstanceData(repoID, d)
+	repoStartLock.Unlock()
+	if err != nil {
+		log.WarningLog.Printf("failed to persist kill tombstone for %q: %v", d.Title, err)
+	}
+}
+
+// finishUserKill completes the teardown of a session whose record carries the
+// kill-intent tombstone (#1108): the previous KillSession was interrupted by a
+// daemon crash or a teardown error after the tombstone write. Mirrors the tail
+// of KillSession — best-effort Kill, targeted record delete, map removal — and
+// retries on the next poll if the record delete fails. Skips while an explicit
+// KillSession for the same session is still in flight.
+func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
+	key := daemonInstanceKey(repoID, instance.Title)
+	m.mu.Lock()
+	if _, busy := m.killsInFlight[key]; busy {
+		m.mu.Unlock()
+		return
+	}
+	m.killsInFlight[key] = struct{}{}
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		delete(m.killsInFlight, key)
+		m.mu.Unlock()
+	}()
+
+	log.WarningLog.Printf("finishing interrupted kill of session %q (tombstoned record survived its teardown)", instance.Title)
+	// Best-effort: the backing tmux session is typically already gone; Kill
+	// failures here only mean there is less left to tear down.
+	if err := instance.Kill(); err != nil {
+		log.WarningLog.Printf("finishing kill of %q: teardown reported: %v", instance.Title, err)
+	}
+	storage, err := session.NewStorage(config.LoadState(), repoID)
+	if err != nil {
+		log.WarningLog.Printf("finishing kill of %q: %v", instance.Title, err)
+		return
+	}
+	if err := storage.DeleteInstance(instance.Title); err != nil {
+		log.WarningLog.Printf("finishing kill of %q: failed to delete record (will retry next poll): %v", instance.Title, err)
+		return
+	}
+	m.mu.Lock()
+	delete(m.instances, key)
+	m.mu.Unlock()
 }
 
 func (m *Manager) SendPrompt(req SendPromptRequest) error {

--- a/daemon/lost_kill_test.go
+++ b/daemon/lost_kill_test.go
@@ -1,0 +1,157 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// failKillBackend is a readyFakeBackend whose Kill always errors, modelling a
+// teardown that dies partway — the crash window the kill-intent tombstone
+// (#1108) exists for.
+type failKillBackend struct {
+	readyFakeBackend
+}
+
+func (failKillBackend) Kill(*session.Instance) error {
+	return errors.New("teardown interrupted")
+}
+
+// recordFor returns the persisted InstanceData for title, or nil.
+func recordFor(t *testing.T, repoID, title string) *session.InstanceData {
+	t.Helper()
+	data, err := loadRepoInstanceData(repoID)
+	if err != nil {
+		t.Fatalf("loadRepoInstanceData: %v", err)
+	}
+	for i := range data {
+		if data[i].Title == title {
+			return &data[i]
+		}
+	}
+	return nil
+}
+
+// TestKillSession_TombstoneSurvivesFailedTeardown pins the #1108 ordering
+// contract: KillSession persists the kill-intent tombstone BEFORE teardown
+// begins, so a teardown that errors (or a daemon crash) after that point
+// leaves a record that is provably a user kill — never a Lost session the
+// restore loop would resurrect.
+func TestKillSession_TombstoneSurvivesFailedTeardown(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, absPath string) (session.Backend, error) {
+		backend := session.NewFakeBackend()
+		backend.CompleteStart()
+		return failKillBackend{readyFakeBackend{backend}}, nil
+	})
+	t.Cleanup(restore)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "doomed",
+		RepoPath: repoPath,
+		Program:  "claude",
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	if err := manager.KillSession(KillSessionRequest{Title: "doomed", RepoID: repo.ID}); err == nil {
+		t.Fatal("expected KillSession to surface the teardown failure")
+	}
+
+	rec := recordFor(t, repo.ID, "doomed")
+	if rec == nil {
+		t.Fatal("the record must survive a failed teardown (KillSession returned before DeleteInstance)")
+	}
+	if !rec.UserKilled {
+		t.Fatal("the surviving record must carry the kill-intent tombstone (#1108)")
+	}
+}
+
+// TestRefreshStatuses_FinishesTombstonedKill: the status poll's finish-kill
+// pass (#1108). A tombstoned instance — a kill interrupted after its tombstone
+// write — must have its teardown finished on the next poll: record deleted,
+// instance dropped from the manager. It must never be probed, marked Lost, or
+// restored.
+func TestRefreshStatuses_FinishesTombstonedKill(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// A dead-tmux backend would flip an ordinary probed instance to Lost;
+	// using it proves the tombstone short-circuits the probe entirely.
+	inst := registerStarted(t, manager, repoID, repoPath, "half-killed", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
+	inst.MarkUserKilled()
+
+	manager.RefreshStatuses()
+
+	if rec := recordFor(t, repoID, "half-killed"); rec != nil {
+		t.Fatalf("tombstoned record must be deleted by the finish-kill pass, still present: %+v", rec)
+	}
+	manager.mu.Lock()
+	_, tracked := manager.instances[daemonInstanceKey(repoID, "half-killed")]
+	manager.mu.Unlock()
+	if tracked {
+		t.Fatal("finished kill must drop the instance from the manager's map")
+	}
+	if got := inst.GetStatus(); got == session.Lost {
+		t.Fatal("a tombstoned instance must never be classified Lost")
+	}
+}
+
+// TestKillSession_RejectsConcurrentDuplicate: while one KillSession's teardown
+// is in flight, a second KillSession for the same session is rejected instead
+// of running a concurrent double-teardown (#1108 killsInFlight guard).
+func TestKillSession_RejectsConcurrentDuplicate(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	backend := &slowKillBackend{
+		killStarted: make(chan struct{}),
+		killBlock:   make(chan struct{}),
+	}
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, absPath string) (session.Backend, error) {
+		fake := session.NewFakeBackend()
+		fake.CompleteStart()
+		backend.readyFakeBackend = readyFakeBackend{fake}
+		return backend, nil
+	})
+	t.Cleanup(restore)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "busy",
+		RepoPath: repoPath,
+		Program:  "claude",
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	killDone := make(chan error, 1)
+	go func() {
+		killDone <- manager.KillSession(KillSessionRequest{Title: "busy", RepoID: repo.ID})
+	}()
+	<-backend.killStarted
+
+	if err := manager.KillSession(KillSessionRequest{Title: "busy", RepoID: repo.ID}); err == nil {
+		t.Fatal("expected the duplicate kill to be rejected while the first teardown is in flight")
+	}
+
+	close(backend.killBlock)
+	if err := <-killDone; err != nil {
+		t.Fatalf("first KillSession: %v", err)
+	}
+}

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -78,7 +78,7 @@ func (m *Manager) EnsureRootAgents() {
 }
 
 // ensureRootAgent guarantees the root agent for one configured repo path:
-// adopt a live root untouched, heal a Dead one in place, create a missing
+// adopt a live root untouched, heal a Dead/Lost one in place, create a missing
 // one, and respect an explicit user kill. All outcomes are logged; failures
 // back off exponentially and settle at the rootEnsureBackoffMax cadence, so
 // the loop always heals eventually once the cause clears.
@@ -119,18 +119,20 @@ func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
 	}
 
 	if inst != nil {
-		if inst.GetStatus() != session.Dead {
+		if status := inst.GetStatus(); status != session.Dead && status != session.Lost {
 			// Adopt, never clobber: a live root — whatever program it runs
 			// and whoever created it — is the root agent. Nothing to do.
 			m.rootEnsureSucceeded(st)
 			return
 		}
 		// The root's tmux vanished (crash, tmux server death — the #1104
-		// outage class). Reap the dead record and fall through to re-create
-		// in place. Kill is best-effort teardown of already-dead tmux, and
-		// an in-place worktree's Cleanup never touches the user's tree
-		// (#1107), so this can only remove daemon-owned state.
-		log.WarningLog.Printf("root agent for %s is Dead (tmux gone); re-creating it in place", repo.Root)
+		// outage class; recorded as Lost since #1108, Dead by older builds).
+		// Reap the dead record and fall through to re-create in place — the
+		// root keeps its stronger always-ensure semantics rather than waiting
+		// for the general Lost-restore loop. Kill is best-effort teardown of
+		// already-dead tmux, and an in-place worktree's Cleanup never touches
+		// the user's tree (#1107), so this can only remove daemon-owned state.
+		log.WarningLog.Printf("root agent for %s is gone (tmux vanished); re-creating it in place", repo.Root)
 		if err := m.reapDeadRoot(repo.ID, inst); err != nil {
 			m.rootEnsureFailed(path, st, fmt.Errorf("failed to remove dead root record: %w", err))
 			return

--- a/daemon/rootagent_test.go
+++ b/daemon/rootagent_test.go
@@ -228,6 +228,43 @@ func TestEnsureRootAgentsHealsDeadRoot(t *testing.T) {
 	}
 }
 
+// TestEnsureRootAgentsHealsLostRoot mirrors the Dead heal for the Lost status
+// (#1108): the liveness probe records an outage-vanished root as Lost now, and
+// the ensure loop must treat it exactly like Dead — reap and re-create in
+// place — or the #1128 root self-heal would silently regress.
+func TestEnsureRootAgentsHealsLostRoot(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	seen := installOptionsRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+
+	manager, err := NewManager(rootTestConfig(repoPath, config.RootAgentConfig{}))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.EnsureRootAgents()
+	first := findRootInstance(t, manager, repoPath)
+	if first == nil {
+		t.Fatalf("root instance missing after first ensure")
+	}
+
+	first.SetStatus(session.Lost)
+	manager.EnsureRootAgents()
+
+	if len(*seen) != 2 {
+		t.Fatalf("expected a re-create after the root went Lost, got %d creates", len(*seen))
+	}
+	healed := findRootInstance(t, manager, repoPath)
+	if healed == nil {
+		t.Fatalf("root instance missing after heal")
+	}
+	if healed == first {
+		t.Fatalf("heal must replace the lost instance, not resurrect the same object")
+	}
+	if got := healed.GetStatus(); got == session.Lost || got == session.Dead {
+		t.Fatalf("healed root must be live, got %v", got)
+	}
+}
+
 // TestEnsureRootAgentsRespectsUserKill: an explicit KillSession of the root
 // suppresses re-creation for the rest of the daemon's life; a fresh manager
 // (daemon restart) re-asserts the configured root. This is the conservative

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -136,25 +136,26 @@ func TestRefreshStatuses_LiveIdleSessionBecomesReady(t *testing.T) {
 	}
 }
 
-// TestRefreshStatuses_DeadSessionMarkedDeadNotReady is the status half of #935:
-// the daemon must not repaint a session whose backing tmux/remote session has
-// vanished as Ready. HasUpdated latches (false,false), indistinguishable from a
-// healthy idle one, so the daemon probes liveness and marks it Dead — and
-// persists it so the hollow dead-dot survives a reload.
-func TestRefreshStatuses_DeadSessionMarkedDeadNotReady(t *testing.T) {
+// TestRefreshStatuses_VanishedSessionMarkedLostNotReady is the status half of
+// #935: the daemon must not repaint a session whose backing tmux/remote session
+// has vanished as Ready. HasUpdated latches (false,false), indistinguishable
+// from a healthy idle one, so the daemon probes liveness and marks it Lost —
+// not Dead, since there is no kill intent on record (#1108) — and persists it
+// so the status survives a reload and the restore loop can find it.
+func TestRefreshStatuses_VanishedSessionMarkedLostNotReady(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
-	// Start from Running to prove the pass actively transitions it to Dead
+	// Start from Running to prove the pass actively transitions it to Lost
 	// rather than merely leaving a pre-set status untouched.
 	registerStarted(t, manager, repoID, repoPath, "gone", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
 
 	manager.RefreshStatuses()
 
 	inst := manager.instances[daemonInstanceKey(repoID, "gone")]
-	if got := inst.GetStatus(); got != session.Dead {
-		t.Fatalf("in-memory status = %v, want Dead (a dead session must never be Ready)", got)
+	if got := inst.GetStatus(); got != session.Lost {
+		t.Fatalf("in-memory status = %v, want Lost (a vanished session must never be Ready, and is not user-killed)", got)
 	}
-	if got := persistedStatus(t, repoID, "gone"); got != session.Dead {
-		t.Fatalf("persisted status = %v, want Dead", got)
+	if got := persistedStatus(t, repoID, "gone"); got != session.Lost {
+		t.Fatalf("persisted status = %v, want Lost", got)
 	}
 }
 
@@ -172,27 +173,28 @@ func (b nilMonitorBackend) HasUpdated(*session.Instance) (bool, bool) { return b
 func (b nilMonitorBackend) IsAlive(*session.Instance) bool            { return b.ts.DoesSessionExist() }
 
 // TestRefreshStatuses_DeadNilMonitorDoesNotPanic is the #999 regression at the
-// daemon poll layer: a persisted Dead instance whose TmuxSession has a nil
+// daemon poll layer: a persisted Dead/Lost instance whose TmuxSession has a nil
 // monitor (Start skipped Restore, #970) must survive a RefreshStatuses pass
 // without panicking. HasUpdated returns (false,false) and the idle liveness
-// probe confirms the vanished session, leaving it Dead.
+// probe confirms the vanished session, marking it Lost (#1108).
 func TestRefreshStatuses_DeadNilMonitorDoesNotPanic(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
-	// has-session reports "gone" so the idle-branch liveness probe keeps it Dead;
-	// the nil monitor would panic HasUpdated before the fix regardless.
+	// has-session reports "gone" so the idle-branch liveness probe confirms the
+	// vanished session; the nil monitor would panic HasUpdated before the fix
+	// regardless.
 	mockExec := cmd_test.MockCmdExec{
 		RunFunc:    func(*exec.Cmd) error { return errSessionAbsent },
 		OutputFunc: func(*exec.Cmd) ([]byte, error) { return []byte("content"), nil },
 	}
 	ts := tmux.NewTmuxSessionFromSanitizedNameWithDeps("af_999_nil_monitor", "claude", tmux.MakePtyFactory(), mockExec)
 	backend := nilMonitorBackend{FakeBackend: session.NewFakeBackend(), ts: ts}
-	registerStarted(t, manager, repoID, repoPath, "corpse", backend, true, session.Dead)
+	registerStarted(t, manager, repoID, repoPath, "corpse", backend, true, session.Lost)
 
 	manager.RefreshStatuses() // must not panic on the nil monitor
 
 	inst := manager.instances[daemonInstanceKey(repoID, "corpse")]
-	if got := inst.GetStatus(); got != session.Dead {
-		t.Fatalf("in-memory status = %v, want Dead (a restored corpse stays Dead)", got)
+	if got := inst.GetStatus(); got != session.Lost {
+		t.Fatalf("in-memory status = %v, want Lost (a vanished session stays Lost)", got)
 	}
 }
 

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -158,18 +158,21 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 	}()
 
 	if !firstTimeSetup {
-		// A persisted Dead instance's tmux session was killed out from under it
-		// and the daemon explicitly recorded Dead status (#935). Loading it must
-		// NOT silently re-spawn that session: TmuxSession.Restore re-spawns a
-		// missing session when workDir is non-empty (the #386 reboot-recovery
-		// path) and setupTabs would likewise re-spawn the shell tab — together
-		// resurrecting a corpse the user killed, contradicting its persisted
-		// state (#970). Return before both. The deferred handler still flips
-		// started=true, so the corpse keeps rendering Dead, survives the next
-		// SaveInstances checkpoint (which skips !Started instances), and stays
-		// killable; the daemon liveness poll re-confirms Dead because the bound
-		// session does not exist server-side.
-		if i.GetStatus() == Dead {
+		// A persisted Dead/Lost instance's tmux session was killed out from
+		// under it and the daemon explicitly recorded that (#935/#1108).
+		// Loading it must NOT silently re-spawn that session: TmuxSession.Restore
+		// re-spawns a missing session when workDir is non-empty (the #386
+		// reboot-recovery path) and setupTabs would likewise re-spawn the shell
+		// tab — together resurrecting a session behind the daemon's back,
+		// contradicting its persisted state (#970). Return before both. The
+		// deferred handler still flips started=true, so the row keeps rendering
+		// its status, survives the next SaveInstances checkpoint (which skips
+		// !Started instances), and stays killable; the daemon liveness poll
+		// re-confirms the state because the bound session does not exist
+		// server-side. A Lost session's recovery is the daemon's explicit
+		// restore loop (#1108 PR 2), never a load-time side effect; a
+		// tombstoned record's only future is having its kill finished.
+		if status := i.GetStatus(); status == Dead || status == Lost || i.UserKilled() {
 			return nil
 		}
 

--- a/session/dead_respawn_test.go
+++ b/session/dead_respawn_test.go
@@ -91,14 +91,17 @@ func deadInstanceData(t *testing.T, status Status, agentName, shellName string) 
 	}
 }
 
-// TestDeadInstance_NotRespawnedOnLoad is the #970 regression: an instance
-// persisted as Dead (its tmux session was killed out from under it) must reload
-// as a Dead corpse and must NOT re-spawn any tmux session — neither the agent
-// session (TmuxSession.Restore's #386 re-spawn-when-missing path) nor the shell
-// tab (setupTabs). It must still load as started=true so the daemon's
-// SaveInstances checkpoint (which skips !Started instances) keeps the corpse on
+// TestDeadInstance_LoadsAsLostWithoutRespawn is the #970 regression updated for
+// the #1108 rollforward: an instance persisted as Dead by a pre-Lost build (its
+// tmux session vanished out from under it) reloads as Lost — recovery-eligible,
+// since only observed-death paths ever wrote persisted Dead — and must NOT
+// re-spawn any tmux session on load: neither the agent session
+// (TmuxSession.Restore's #386 re-spawn-when-missing path) nor the shell tab
+// (setupTabs). Recovery is the daemon's explicit restore loop, never a
+// load-time side effect. It must still load as started=true so the daemon's
+// SaveInstances checkpoint (which skips !Started instances) keeps the record on
 // disk and the user can still kill it.
-func TestDeadInstance_NotRespawnedOnLoad(t *testing.T) {
+func TestDeadInstance_LoadsAsLostWithoutRespawn(t *testing.T) {
 	log.Initialize(false)
 	defer log.Close()
 	// Isolate config reads from the developer's real ~/.agent-factory (see
@@ -108,7 +111,7 @@ func TestDeadInstance_NotRespawnedOnLoad(t *testing.T) {
 	const agentName = "af_dead_agent"
 	shellName := agentName + shellTmuxSuffix
 
-	// Both sessions are GONE (the kill that produced Dead): a Restore would hit
+	// Both sessions are GONE (the death that produced Dead): a Restore would hit
 	// the missing-session branch and re-spawn via new-session.
 	var newSessions int
 	exec := countingExec(map[string]bool{}, &newSessions)
@@ -123,23 +126,88 @@ func TestDeadInstance_NotRespawnedOnLoad(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, newSessions,
-		"a Dead instance must NOT re-spawn any tmux session on load (#970)")
-	assert.Equal(t, Dead, restored.GetStatus(), "the corpse must stay Dead")
+		"a Dead/Lost instance must NOT re-spawn any tmux session on load (#970)")
+	assert.Equal(t, Lost, restored.GetStatus(),
+		"persisted Dead must roll forward to Lost on load (#1108)")
 	assert.True(t, restored.Started(),
-		"a Dead instance must load started=true so SaveInstances keeps it on disk")
+		"a Lost instance must load started=true so SaveInstances keeps it on disk")
 	assert.False(t, restored.TabAlive(0),
-		"the Dead agent session must not exist server-side after load")
+		"the vanished agent session must not exist server-side after load")
+}
+
+// TestLostInstance_NotRespawnedOnLoad extends the #970 guard to the Lost status
+// itself (#1108): a record persisted as Lost must reload as Lost without any
+// re-spawn — the daemon's explicit restore loop owns recovery, not the loader.
+func TestLostInstance_NotRespawnedOnLoad(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_lost_agent"
+	shellName := agentName + shellTmuxSuffix
+
+	var newSessions int
+	exec := countingExec(map[string]bool{}, &newSessions)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	restored, err := FromInstanceData(deadInstanceData(t, Lost, agentName, shellName))
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, newSessions,
+		"a Lost instance must NOT re-spawn any tmux session on load (#970/#1108)")
+	assert.Equal(t, Lost, restored.GetStatus())
+	assert.True(t, restored.Started())
+}
+
+// TestTombstonedInstance_NotRespawnedOnLoad guards the kill-intent tombstone
+// (#1108): a record whose UserKilled flag survived a crash mid-kill must not be
+// re-spawned on load regardless of its persisted status — its only future is
+// having its teardown finished by the daemon poll. Status Running is the
+// realistic crash shape: KillSession tombstones BEFORE any status change, so an
+// interrupted kill leaves the pre-kill status behind — and Running is exactly
+// the status that would otherwise take the #386 re-spawn path.
+func TestTombstonedInstance_NotRespawnedOnLoad(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_tombstone_agent"
+	shellName := agentName + shellTmuxSuffix
+
+	var newSessions int
+	exec := countingExec(map[string]bool{}, &newSessions)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	data := deadInstanceData(t, Running, agentName, shellName)
+	data.UserKilled = true
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, newSessions,
+		"a tombstoned instance must NOT be re-spawned on load, whatever its status (#1108)")
+	assert.True(t, restored.UserKilled(), "the tombstone must survive the round-trip")
+	assert.True(t, restored.Started())
 }
 
 // TestDeadInstance_HasUpdatedNilMonitor is the #999 regression, exercised
-// through the production path. A persisted Dead instance loads with
-// started=true but LocalBackend.Start returns before TmuxSession.Restore (the
-// only place the tmux monitor is initialized) so the corpse is not re-spawned
-// (#970). The daemon's refreshInstanceStatus still polls every started
-// instance via instance.HasUpdated(); before the fix that dereferenced a nil
-// monitor and panicked, killing the refresh goroutine and zombifying the
-// daemon. HasUpdated must instead return (false,false) — a session with no live
-// monitor has nothing to report.
+// through the production path. A persisted Dead instance loads (as Lost, per
+// the #1108 rollforward) with started=true but LocalBackend.Start returns
+// before TmuxSession.Restore (the only place the tmux monitor is initialized)
+// so the session is not re-spawned (#970). The daemon's refreshInstanceStatus
+// still polls every started instance via instance.HasUpdated(); before the fix
+// that dereferenced a nil monitor and panicked, killing the refresh goroutine
+// and zombifying the daemon. HasUpdated must instead return (false,false) — a
+// session with no live monitor has nothing to report.
 func TestDeadInstance_HasUpdatedNilMonitor(t *testing.T) {
 	log.Initialize(false)
 	defer log.Close()
@@ -148,8 +216,9 @@ func TestDeadInstance_HasUpdatedNilMonitor(t *testing.T) {
 	const agentName = "af_dead_hasupdated"
 	shellName := agentName + shellTmuxSuffix
 
-	// Both sessions are GONE (the kill that produced Dead): Start(false) returns
-	// at the Dead guard before Restore, so the agent TmuxSession's monitor is nil.
+	// Both sessions are GONE (the death that produced Dead): Start(false)
+	// returns at the Dead/Lost guard before Restore, so the agent TmuxSession's
+	// monitor is nil.
 	var newSessions int
 	exec := countingExec(map[string]bool{}, &newSessions)
 	pty := persistPtyFactory{t: t, cmdExec: exec}
@@ -161,7 +230,7 @@ func TestDeadInstance_HasUpdatedNilMonitor(t *testing.T) {
 
 	restored, err := FromInstanceData(deadInstanceData(t, Dead, agentName, shellName))
 	require.NoError(t, err)
-	require.Equal(t, Dead, restored.GetStatus())
+	require.Equal(t, Lost, restored.GetStatus())
 	require.True(t, restored.Started())
 
 	// This is the exact call refreshInstanceStatus makes every daemon tick.

--- a/session/instance.go
+++ b/session/instance.go
@@ -38,7 +38,23 @@ const (
 	// masquerade as healthy (#935). Unlike Loading/Deleting this is NOT
 	// in-flight TUI state: it is persisted and background syncs may still reap
 	// or replace the row, so it is deliberately excluded from isTransientStatus.
+	//
+	// As of #1108 Dead is write-never: observed disappearance is recorded as
+	// Lost instead, and FromInstanceData rewrites persisted Dead to Lost on
+	// load (rollforward — the only writers of persisted Dead were
+	// observed-death paths; user kills delete the record). The value stays in
+	// the enum because Status serializes as an int: appending, never
+	// renumbering, is what keeps old records readable.
 	Dead
+	// Lost is when the underlying tmux/remote session vanished out from under
+	// a live session with no user kill on record — the tmux server was killed,
+	// an outage/OOM starved it (#1104), or the box rebooted while the daemon
+	// had already observed the death. Unlike a user-killed session (whose
+	// record is deleted, with a UserKilled tombstone covering the teardown
+	// crash window), a Lost session is wanted: it is recovery-eligible and the
+	// daemon restores it best-effort (#1108). Persisted, like Dead; excluded
+	// from isTransientStatus for the same reason.
+	Lost
 )
 
 // Instance is a running instance of claude code.
@@ -78,6 +94,14 @@ type Instance struct {
 	// setup; restored instances don't need it (the persisted
 	// external_worktree flag carries the semantics from then on).
 	inPlace bool
+
+	// userKilled is the kill-intent tombstone (#1108): set (and persisted)
+	// before an explicit kill's teardown begins, so a record that survives a
+	// daemon crash or teardown failure mid-kill is provably a corpse the user
+	// wanted dead — never classified Lost, never restored. The happy kill path
+	// deletes the record entirely, so the tombstone is normally invisible; the
+	// daemon poll finishes a tombstoned record's teardown instead of probing it.
+	userKilled bool
 
 	// prInfo stores the associated GitHub PR info
 	prInfo *git.PRInfo
@@ -662,16 +686,17 @@ func (i *Instance) ToInstanceData() InstanceData {
 	defer i.mu.RUnlock()
 
 	data := InstanceData{
-		Title:     i.Title,
-		Path:      i.Path,
-		Branch:    i.Branch,
-		Status:    i.Status,
-		Height:    i.Height,
-		Width:     i.Width,
-		CreatedAt: i.CreatedAt,
-		UpdatedAt: time.Now(),
-		Program:   i.Program,
-		AutoYes:   i.AutoYes,
+		Title:      i.Title,
+		Path:       i.Path,
+		Branch:     i.Branch,
+		Status:     i.Status,
+		Height:     i.Height,
+		Width:      i.Width,
+		CreatedAt:  i.CreatedAt,
+		UpdatedAt:  time.Now(),
+		Program:    i.Program,
+		AutoYes:    i.AutoYes,
+		UserKilled: i.userKilled,
 	}
 
 	if i.backend != nil {
@@ -740,17 +765,28 @@ func (i *Instance) ToInstanceData() InstanceData {
 
 // FromInstanceData creates a new Instance from serialized data
 func FromInstanceData(data InstanceData) (*Instance, error) {
+	status := data.Status
+	if status == Dead {
+		// Rollforward (#1108): records persisted as Dead by pre-Lost builds
+		// were all written by observed-death paths (a user kill deletes the
+		// record instead), so they load as Lost — recovery-eligible. This is
+		// what makes sessions stranded by an outage under an old build
+		// restorable after an upgrade. A tombstoned record keeps its status;
+		// the daemon finishes its teardown rather than restoring it.
+		status = Lost
+	}
 	instance := &Instance{
 		Title:      data.Title,
 		Path:       data.Path,
 		Branch:     data.Branch,
-		Status:     data.Status,
+		Status:     status,
 		Height:     data.Height,
 		Width:      data.Width,
 		CreatedAt:  data.CreatedAt,
 		UpdatedAt:  data.UpdatedAt,
 		Program:    data.Program,
 		AutoYes:    data.AutoYes,
+		userKilled: data.UserKilled,
 		remoteMeta: data.RemoteMeta,
 	}
 
@@ -1027,6 +1063,21 @@ func (i *Instance) GetStatus() Status {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	return i.Status
+}
+
+// MarkUserKilled records kill intent on the instance (#1108). Callers persist
+// the instance afterwards so the tombstone survives a daemon crash mid-kill.
+func (i *Instance) MarkUserKilled() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.userKilled = true
+}
+
+// UserKilled reports whether an explicit kill was recorded for this instance.
+func (i *Instance) UserKilled() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.userKilled
 }
 
 // firstTimeSetup is true if this is a new instance. Otherwise, it's one loaded from storage.

--- a/session/lost_status_test.go
+++ b/session/lost_status_test.go
@@ -1,0 +1,43 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatusEnumValuesPinned pins every Status value's integer encoding.
+// Status serializes as an int in instances.json, so these are an on-disk
+// format: values may only ever be APPENDED (Lost, #1108, went after Dead) —
+// reordering or inserting silently rewrites the meaning of every persisted
+// record.
+func TestStatusEnumValuesPinned(t *testing.T) {
+	assert.Equal(t, Status(0), Running)
+	assert.Equal(t, Status(1), Ready)
+	assert.Equal(t, Status(2), Loading)
+	assert.Equal(t, Status(3), Deleting)
+	assert.Equal(t, Status(4), Dead)
+	assert.Equal(t, Status(5), Lost)
+}
+
+// TestInstanceData_UserKilledTombstoneJSON pins the tombstone's wire format
+// (#1108): user_killed serializes when set, is omitted when false (so healthy
+// records don't grow), and defaults to false when absent — every record
+// written before the field existed reads as not-tombstoned.
+func TestInstanceData_UserKilledTombstoneJSON(t *testing.T) {
+	out, err := json.Marshal(InstanceData{Title: "t", UserKilled: true})
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"user_killed":true`)
+
+	out, err = json.Marshal(InstanceData{Title: "t"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "user_killed",
+		"the tombstone must be omitempty: it only exists inside a kill's crash window")
+
+	var legacy InstanceData
+	require.NoError(t, json.Unmarshal([]byte(`{"title":"old"}`), &legacy))
+	assert.False(t, legacy.UserKilled,
+		"records written before #1108 must read as not-tombstoned")
+}

--- a/session/storage.go
+++ b/session/storage.go
@@ -20,7 +20,12 @@ type InstanceData struct {
 	UpdatedAt time.Time `json:"updated_at"`
 	AutoYes   bool      `json:"auto_yes"`
 
-	Program     string                 `json:"program"`
+	Program string `json:"program"`
+	// UserKilled is the kill-intent tombstone (#1108): persisted by
+	// Manager.KillSession before teardown begins. Present only in the crash
+	// window between tombstone write and record deletion — a surviving
+	// tombstoned record means "finish this kill", never "restore this".
+	UserKilled  bool                   `json:"user_killed,omitempty"`
 	TmuxName    string                 `json:"tmux_name,omitempty"`
 	Tabs        []TabData              `json:"tabs,omitempty"`
 	Worktree    GitWorktreeData        `json:"worktree"`

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -183,6 +183,12 @@ func (p *TabPane) updateAgentLocked(instance *session.Instance) error {
 		// the sidebar's dead-dot so the panes never disagree.
 		p.setFallbackState("Session no longer running.")
 		return nil
+	case instance.GetStatus() == session.Lost:
+		// Lost (#1108): the tmux session vanished with no kill on record —
+		// same synchronous-with-the-sidebar treatment as Dead, but the message
+		// says what happened rather than implying a plain corpse.
+		p.setFallbackState("Session lost — its tmux session is gone.")
+		return nil
 	}
 
 	// If in scroll mode but the viewport hasn't been filled yet, capture the
@@ -456,6 +462,9 @@ func (p *TabPane) ResetToNormalMode(instance *session.Instance, activeTab int) e
 		return nil
 	case session.Dead:
 		p.setFallbackState("Session no longer running.")
+		return nil
+	case session.Lost:
+		p.setFallbackState("Session lost — its tmux session is gone.")
 		return nil
 	}
 	content, err := instance.Preview()

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -20,6 +20,12 @@ const readyIcon = "● "
 // contrast and color-blindness (#935).
 const deadIcon = "○ "
 
+// lostIcon marks a session whose tmux vanished with no kill on record (#1108)
+// — recovery-eligible, unlike a corpse. Hollow like deadIcon (it cannot be
+// attached right now, #935) but dotted + amber so "lost, coming back" reads
+// differently from "dead" by shape as well as color.
+const lostIcon = "◌ "
+
 // expandedArrow/collapsedArrow mark an instance row whose tab children are
 // shown/hidden; nonExpandableArrow keeps transient rows (never expandable, see
 // Expandable) aligned with their siblings.
@@ -37,6 +43,12 @@ var readyStyle = lipgloss.NewStyle().
 // for a deleting row — keeps a corpse from reading as a healthy green session.
 var deadStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+
+// lostStyle paints the status dot of a Lost session (#1108): amber, not the
+// corpse gray — the session is expected to come back, but must not read as a
+// healthy green either.
+var lostStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.AdaptiveColor{Light: "#C18401", Dark: "#E5C07B"})
 
 var titleStyle = lipgloss.NewStyle().
 	Padding(1, 1, 0, 1).
@@ -169,6 +181,8 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		join = readyStyle.Render(readyIcon)
 	case session.Dead:
 		join = deadStyle.Render(deadIcon)
+	case session.Lost:
+		join = lostStyle.Render(lostIcon)
 	default:
 	}
 
@@ -179,6 +193,13 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	}
 	// A deleting row keeps spinning but is explicitly marked and dimmed so it
 	// reads as "going away", not "busy working" (#844).
+	// A lost row is explicitly marked so "tmux vanished under it, no kill on
+	// record" (#1108) is readable without decoding the amber dot; the title
+	// keeps full contrast — unlike deleting/dead treatments, the session is
+	// expected back.
+	if status == session.Lost {
+		titleText = "[lost] " + titleText
+	}
 	if status == session.Deleting {
 		titleText = "[deleting] " + titleText
 		titleS = titleS.Foreground(deletingTitleColor)


### PR DESCRIPTION
PR 1 of the approved #1108/#1129 joint design ([design comment](https://github.com/sachiniyer/agent-factory/issues/1108#issuecomment-4880318833)): classification only — the restore loop is PR 2 (unblocked now that #1132's resolved-program choke-point is on master).

## What this does

The `Dead` status conflated "tmux died under a live session" with "user killed it", and the #970 guard stranded both forever (observed live in the 2026-07-03 outages: reopening AF restored nothing). This PR makes the distinction explicit and crash-safe:

- **New persisted status `Lost`** (`session/instance.go`) — *appended* to the enum; `Status` serializes as an int, so values never renumber (pinned by `TestStatusEnumValuesPinned`). The daemon's liveness probe (`refreshInstanceStatus`) now writes `Lost` where it wrote `Dead`: vanished with no kill intent on record → recovery-eligible.
- **Kill-intent tombstone** (`user_killed`, omitempty): `Manager.KillSession` persists it **before** teardown begins, for both live instances and ghost records. The happy path still deletes the record, so the tombstone only exists inside the crash window. A surviving tombstoned record short-circuits the status poll into `finishUserKill` — the teardown is finished (best-effort Kill → record delete → map removal, retried next poll on failure), never probed, never classified Lost, never restored. A `killsInFlight` guard keeps the poll's finish pass and a concurrent KillSession RPC from double-tearing-down, and rejects duplicate kill RPCs.
- **Rollforward migration** (repo precedent, no back-compat shims): `FromInstanceData` rewrites persisted `Dead` → `Lost`. Safe because only observed-death paths ever wrote persisted Dead — user kills delete records. Sessions stranded by pre-Lost builds become restore-eligible on upgrade, retroactively. `Dead` stays in the enum as a write-never legacy value.
- **#970 guard extended**: load-time `Start` early-returns for `Lost` and tombstoned records too — recovery is PR 2's explicit loop, never a load-time side effect. The #386/#444 reboot-respawn path for Running/Ready records is untouched (`TestLiveInstance_RespawnsMissingSessionOnLoad` still green).
- **Root-agent adopt/reap handles `Lost`** like `Dead` — without this, a Lost root would be "adopted" and the #1128 always-ensure self-heal would silently regress.
- **TUI**: amber dotted status dot (`◌`) + `[lost]` title prefix (full-contrast — the session is expected back, unlike the deleting/dead recede treatments); truthful pane fallbacks ("Session lost — its tmux session is gone."); #935-style explicit Enter errors in both the tree and pane attach paths; Lost excluded from live-termpane binding. Kill still works on Lost sessions — it's the user's off-ramp.

## What this deliberately does not do

No restore loop yet (PR 2, blocked on review of this PR; consumes the #1132 resolved-program injection choke-point). No event replay (#1129, PRs 3–4). Remote sessions get marked Lost and become visible; auto-reconnect stays out of scope per the design.

## Adjacent-callsite audit

Every non-test `session.Dead` site was enumerated and dispositioned: `refreshInstanceStatus` (now writes Lost), `rootagent.go` adopt/reap (handles both), `backend_local.go` guard (extended), `ui/tree/render.go` + `ui/tab_pane.go` ×2 + `app/live_termpane.go` + `app/handle_actions.go`/`handle_panes.go` (Lost cases added), `app/sync.go` (verbatim status mirror — no change needed, `isTransientStatus` untouched since Lost is durable). `searchOverlay`'s default case already renders Lost as a hollow dot. `af reset` deletes records wholesale (`DeleteAllInstances`) — no Lost ghosts.

## Tests

- `TestStatusEnumValuesPinned` — int encodings are an on-disk format; append-only pinned.
- `TestInstanceData_UserKilledTombstoneJSON` — wire format: set/omitted/absent-defaults-false.
- `TestDeadInstance_LoadsAsLostWithoutRespawn`, `TestLostInstance_NotRespawnedOnLoad`, `TestTombstonedInstance_NotRespawnedOnLoad` (tombstoned **Running** record — the realistic crash shape that would otherwise take the #386 respawn path) — the #970 guard across all three shapes.
- `TestRefreshStatuses_VanishedSessionMarkedLostNotReady` (was `..._DeadSessionMarkedDeadNotReady`) — probe writes + persists Lost.
- `TestKillSession_TombstoneSurvivesFailedTeardown` — tombstone-before-teardown ordering.
- `TestRefreshStatuses_FinishesTombstonedKill` — poll finishes the interrupted kill; record + map entry gone; never Lost.
- `TestKillSession_RejectsConcurrentDuplicate` — killsInFlight guard.
- `TestEnsureRootAgentsHealsLostRoot` — mirror of the Dead heal.

## Gates

`go build ./...`, `golangci-lint run --fast`, `gofmt -l` (empty), `deadcode -test` (empty), and the full suite under `make test-container` — all green (20 packages ok, zero failures). Not merging — root verifies and merges per the dispatch instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
