### PR TITLE
tui: interactive mode — keystrokes forward into embedded panes (#1089, PR 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ Each session is one agent running in its own git worktree on its own branch — 
 | Key | Action |
 |-----|--------|
 | `n` | Create a new session |
-| `Enter` / `o` | Attach to the selected session's active tab |
-| `Ctrl-w` | Detach (configurable via `detach_keys`) |
+| `Enter` | Interact with the session in its pane — every key (including `Tab`) goes to the agent; the sessions rail stays visible |
+| `Ctrl-]` | Leave interactive mode, back to navigation |
+| `o` | Attach to the selected session's active tab full-screen |
+| `Ctrl-w` | Detach from a full-screen attach (configurable via `detach_keys`) |
 | `D` | Kill the session and clean up its worktree |
-| `Tab` / `Shift-Tab` | Cycle forward / back through the session's tabs |
+| `Tab` / `Shift-Tab` | Cycle focus forward / back: tree → open panes → automations |
 | `1`–`9` | Jump straight to a tab by number |
 | `t` | Open a new shell tab in the session's worktree |
 | `w` | Close the active tab (the agent tab can't be closed) |
@@ -76,7 +78,7 @@ When a session's branch has an open pull request, `p` opens it in the browser an
 
 #### Tabs
 
-Every session opens with a single **agent** tab (the AI agent, shown as *Preview*). Press `t` to spawn **shell** tabs (*Terminal*) running `$SHELL` in the worktree (up to nine tabs per session), `w` to close the active one, and `Tab` / `1`–`9` to move between them. Attaching (`Enter`) drops you into whichever tab is active. Tabs are ephemeral but persisted: they survive an `af`/daemon restart, reconnecting to their live processes. You can also spawn a tab running an arbitrary command from the CLI with `af sessions tab-create`, and delete a single tab with `af sessions tab-delete` (see below).
+Every session opens with a single **agent** tab (the AI agent, shown as *Preview*). Press `t` to spawn **shell** tabs (*Terminal*) running `$SHELL` in the worktree (up to nine tabs per session), `w` to close the active one, and `1`–`9` to jump between them. `Enter` types into whichever tab is active, in place (`o` for a full-screen attach). Tabs are ephemeral but persisted: they survive an `af`/daemon restart, reconnecting to their live processes. You can also spawn a tab running an arbitrary command from the CLI with `af sessions tab-create`, and delete a single tab with `af sessions tab-delete` (see below).
 
 Remote sessions are tab-driven too, with one limitation: the hook protocol can't run arbitrary commands on the remote host, so a remote session has an agent tab always and a single terminal tab **only when** its repo configures `remote_hooks.terminal_cmd` (`t`, `tab-create`, and `tab-delete` are rejected for remote sessions). See [docs/remote-hooks.md](docs/remote-hooks.md).
 

--- a/app/app.go
+++ b/app/app.go
@@ -180,6 +180,18 @@ type home struct {
 	liveDeathLogKey string
 	liveDeathLogAt  time.Time
 
+	// interactive is the two-mode keyboard switch (#1089 PR 2, RFC §2.3).
+	// Nav mode (false): the host owns the keyboard — focus ring, verbs,
+	// overlays, exactly as before. Interactive mode (true): EVERY keystroke
+	// (including Tab) forwards down the focused pane's live attachment; the
+	// only host-reserved key is Ctrl-], which returns to nav. The mode is
+	// only ever true while liveTerm is bound to the focused pane —
+	// enforceInteractiveInvariant drops it the moment that premise breaks.
+	// Orthogonal to `state`: overlays opened by async events still own the
+	// keyboard (handleKeyPress checks state alongside this flag). Event-loop
+	// only; the pane's green frame and the status bar mirror it.
+	interactive bool
+
 	// initialPaneOpened latches the one-time startup auto-open: the first
 	// instance selection opens its pane so the workspace isn't empty on
 	// launch. Never reset — once the user has hidden every pane, the
@@ -621,6 +633,13 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(cmds...)
 	case tea.MouseMsg:
+		// Mouse forwarding into an interactive pane is out of scope for this
+		// PR (RFC §2.5 leaves in-pane wheel ownership to the mouse PR) — and
+		// host wheel-scroll would flip the live pane into capture scroll mode
+		// mid-typing, so the wheel is inert while interactive.
+		if m.interactive {
+			return m, nil
+		}
 		if msg.Action == tea.MouseActionPress {
 			if msg.Button == tea.MouseButtonWheelDown || msg.Button == tea.MouseButtonWheelUp {
 				// The wheel scrolls whatever the focus ring points at: the
@@ -668,6 +687,10 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case instanceChangedMsg:
 		return m, m.selectionChanged()
+	case enterInteractiveMsg:
+		// Deferred by the first-time interactive help screen's dismiss cmd
+		// (#1089 PR 2); the pane pointer is re-validated inside.
+		return m, m.activateInteractive(msg.pane)
 	case startKillMsg:
 		// The row was already flipped to Deleting synchronously by the kill
 		// confirmation; dispatch the slow teardown off the event loop (#844).
@@ -1134,6 +1157,15 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 }
 
 func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
+	// Interactive mode owns the keyboard before anything else — menu
+	// highlighting, quit keys, the global key map (#1089 PR 2, RFC §2.3).
+	// The state gate matters: an overlay opened by an async event (e.g. the
+	// instance-started help screen) is modal and keeps the keyboard until
+	// dismissed, exactly as in nav mode.
+	if m.interactive && m.state == stateDefault {
+		return m.handleInteractiveKey(msg)
+	}
+
 	cmd, returnEarly := m.handleMenuHighlighting(msg)
 	if returnEarly {
 		return m, cmd

--- a/app/dead_session_test.go
+++ b/app/dead_session_test.go
@@ -62,3 +62,30 @@ func TestHandleEnter_DeadSessionShowsError(t *testing.T) {
 	require.Contains(t, h.errBox.String(), "dead-session",
 		"the error must name the offending session")
 }
+
+// TestHandleEnter_LostSessionShowsError pins the #1108 × #1089-PR-2
+// interaction: Enter on a Lost session must take the explicit lost-error path
+// — never enter interactive mode on a dead binding, and never the generic
+// dead-tmux message (Lost is checked before TmuxAlive in interactiveGuard so
+// the specific "expected back" wording wins).
+func TestHandleEnter_LostSessionShowsError(t *testing.T) {
+	h := newTestHome(t)
+
+	inst := newDeadInstance(t, "lost-session", session.Lost)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, cmd := h.handleEnter()
+	h = model.(*home)
+
+	require.Equal(t, stateDefault, h.state, "a lost session must not open any overlay")
+	require.Nil(t, h.textOverlay, "no help overlay should be installed for a lost session")
+	require.False(t, h.interactive, "Enter on a lost session must not enter interactive mode")
+
+	require.NotNil(t, cmd, "handleEnter must return the error-hide command, not a silent nil")
+	h.errBox.SetSize(200, 1)
+	require.Contains(t, h.errBox.String(), "was lost",
+		"the error must say the session was lost, not the generic dead message")
+	require.Contains(t, h.errBox.String(), "lost-session",
+		"the error must name the offending session")
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -108,6 +108,8 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 		return m.handleKill()
 	case keys.KeyEnter:
 		return m.handleEnter()
+	case keys.KeyAttach:
+		return m.handleAttach()
 
 	default:
 		return m, nil
@@ -243,14 +245,27 @@ func killConfirmationWarning(wt string) string {
 	return ""
 }
 
-// handleEnter handles the enter/open key action. Enter attaches the FOCUSED
-// pane's (instance, tab) full-screen (#1088): with a workspace pane focused
-// it attaches that pane's binding; everywhere else the tree selection, as
-// before. The attach path itself is untouched: the same
-// attachOverlayCallbackFn seam, `attached` gate, and SIGKILL-bounded detach.
+// handleEnter is the Enter verb (#1089 PR 2, RFC §2.3): enter INTERACTIVE
+// mode on the pane — every keystroke forwards to the agent/shell in place,
+// no full-screen takeover, Ctrl-] returns to nav. With a workspace pane
+// focused it enters that pane; on a tree instance/tab row it opens (or
+// focuses) the selection's pane first, exactly like `s`, then enters it.
+// Bindings that cannot embed — remote instances, whose only local terminal
+// is the full-screen hook PTY — fall back to the full-screen attach Enter
+// used to do; dead/transitional sessions keep their guard errors.
 func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 	if p := m.focusedOpenPane(); p != nil {
-		return m.handleEnterPane(p)
+		if instErr := interactiveGuard(p.Instance()); instErr != nil {
+			return m, m.handleError(instErr)
+		}
+		if p.Instance() == nil || p.Instance().GetStatus() == session.Loading {
+			return m, nil
+		}
+		if liveSessionName(p.Instance(), p.Tab()) == "" {
+			// Not embeddable (remote): the old full-screen behavior.
+			return m.handleEnterPane(p)
+		}
+		return m.requestInteractive(p)
 	}
 	sel := m.sidebar.GetSelection()
 
@@ -265,56 +280,110 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		if selected == nil || selected.GetStatus() == session.Loading {
 			return m, nil
 		}
-		if selected.GetStatus() == session.Deleting {
-			return m, m.handleError(fmt.Errorf("session '%s' is being deleted", selected.Title))
+		if err := interactiveGuard(selected); err != nil {
+			return m, m.handleError(err)
 		}
-		if selected.GetStatus() == session.Lost {
-			// Lost (#1108): the backing tmux session vanished with no kill on
-			// record. Attach is impossible right now; say what happened —
-			// same explicit-feedback contract as the Deleting path (#935).
-			return m, m.handleError(fmt.Errorf("session '%s' was lost — its tmux session is gone", selected.Title))
+		if liveSessionName(selected, m.store.ActiveTab()) == "" {
+			// Not embeddable (remote): the old full-screen attach flow.
+			return m.attachSelected(selected)
 		}
-		if !selected.TmuxAlive() {
-			// The backing session has vanished, so attaching is impossible.
-			// Surface an actionable error instead of swallowing Enter, mirroring
-			// the Deleting path above — a silent return left the user unsure
-			// whether the keypress registered while the sidebar still showed a
-			// green Ready dot (#935).
-			return m, m.handleError(fmt.Errorf("session '%s' is no longer running", selected.Title))
+		// Open (or focus) the selection's pane — the `s` semantics — then
+		// enter it. The pane pointer is captured here, at Enter-press time
+		// (#716), for the deferred activation.
+		_, cmd := m.openOrFocusPane(selected, m.store.ActiveTab())
+		p := m.store.FindOpenPane(selected, m.store.ActiveTab())
+		if p == nil {
+			return m, cmd
 		}
-		// Capture the instance at Enter-press time — the synchronous moment the
-		// selection is provably current. For first-time attachers the attach is
-		// deferred until the help overlay is dismissed, and a background refresh
-		// can drift the selection onto a different instance in the meantime; the
-		// callbacks must attach to this captured instance, not re-read the live
-		// selection (#716).
-		if activeTab := m.store.ActiveTab(); activeTab != 0 {
-			// The terminal tab attaches a local tmux session for local
-			// instances, but a remote instance's terminal_cmd PTY for remote
-			// ones (#843) — and that remote PTY hands the terminal back via
-			// session.hookAttachTerminalRestore (main screen, modes off), the
-			// same neutral state the sidebar remote attach leaves. So the
-			// post-detach handling must key off the instance's real
-			// remote-ness, exactly like the sidebar path below: a remote
-			// terminal_cmd detach needs the #845/#848 full reset + reassert,
-			// or the TUI keeps rendering on the main screen (#889).
-			// Capture the active tab index at Enter-press time alongside the
-			// instance (#716): a background refresh could otherwise drift the
-			// selection — or the user could change tabs while the help overlay is
-			// open — before the deferred attach callback runs.
-			return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-				return attachOverlayCallbackFn(m, "handleEnter-terminal", "", selected.IsRemote(), func() (chan struct{}, error) {
-					return ui.AttachTerminalTab(selected, activeTab)
-				})
-			})
-		}
+		mod, interactCmd := m.requestInteractive(p)
+		return mod, tea.Batch(cmd, interactCmd)
+	}
+	return m, nil
+}
+
+// interactiveGuard returns the user-facing error that fences Enter off a
+// session in a state it cannot be entered or attached in — shared by the
+// interactive and full-screen paths (the #935 dead-tmux error, the Deleting
+// fence, the #1108 Lost fence). A nil error does NOT mean embeddable (see
+// liveSessionName); nil instance and Loading are the caller's silent no-op
+// cases.
+func interactiveGuard(inst *session.Instance) error {
+	if inst == nil || inst.GetStatus() == session.Loading {
+		return nil
+	}
+	if inst.GetStatus() == session.Deleting {
+		return fmt.Errorf("session '%s' is being deleted", inst.Title)
+	}
+	if inst.GetStatus() == session.Lost {
+		// Lost (#1108): the backing tmux session vanished with no kill on
+		// record. Entering or attaching is impossible right now; say what
+		// happened — same explicit-feedback contract as the Deleting path
+		// (#935). Checked before TmuxAlive so the specific message wins.
+		return fmt.Errorf("session '%s' was lost — its tmux session is gone", inst.Title)
+	}
+	if !inst.TmuxAlive() {
+		return fmt.Errorf("session '%s' is no longer running", inst.Title)
+	}
+	return nil
+}
+
+// handleAttach is the full-screen attach verb (`o`; the pre-#1089-PR-2
+// Enter): attach the FOCUSED pane's (instance, tab) full-screen (#1088), or
+// the tree selection's. The attach path itself is untouched: the same
+// attachOverlayCallbackFn seam, `attached` gate, and SIGKILL-bounded detach.
+func (m *home) handleAttach() (tea.Model, tea.Cmd) {
+	if p := m.focusedOpenPane(); p != nil {
+		return m.handleEnterPane(p)
+	}
+	sel := m.sidebar.GetSelection()
+	if sel.IsHeader || sel.Kind != ui.SectionInstances {
+		return m, nil
+	}
+	selected := m.sidebar.GetSelectedInstance()
+	if selected == nil || selected.GetStatus() == session.Loading {
+		return m, nil
+	}
+	if err := interactiveGuard(selected); err != nil {
+		return m, m.handleError(err)
+	}
+	return m.attachSelected(selected)
+}
+
+// attachSelected runs the tree-selection full-screen attach flow for a
+// guarded (non-nil, non-Loading, non-Deleting, tmux-alive) instance.
+//
+// The instance is captured at keypress time — the synchronous moment the
+// selection is provably current. For first-time attachers the attach is
+// deferred until the help overlay is dismissed, and a background refresh can
+// drift the selection onto a different instance in the meantime; the
+// callbacks must attach to this captured instance, not re-read the live
+// selection (#716).
+func (m *home) attachSelected(selected *session.Instance) (tea.Model, tea.Cmd) {
+	if activeTab := m.store.ActiveTab(); activeTab != 0 {
+		// The terminal tab attaches a local tmux session for local
+		// instances, but a remote instance's terminal_cmd PTY for remote
+		// ones (#843) — and that remote PTY hands the terminal back via
+		// session.hookAttachTerminalRestore (main screen, modes off), the
+		// same neutral state the sidebar remote attach leaves. So the
+		// post-detach handling must key off the instance's real
+		// remote-ness, exactly like the sidebar path below: a remote
+		// terminal_cmd detach needs the #845/#848 full reset + reassert,
+		// or the TUI keeps rendering on the main screen (#889).
+		// Capture the active tab index at keypress time alongside the
+		// instance (#716): a background refresh could otherwise drift the
+		// selection — or the user could change tabs while the help overlay is
+		// open — before the deferred attach callback runs.
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-			return attachOverlayCallbackFn(m, "handleEnter-sidebar", "", selected.IsRemote(), func() (chan struct{}, error) {
-				return m.store.AttachInstance(selected)
+			return attachOverlayCallbackFn(m, "handleEnter-terminal", "", selected.IsRemote(), func() (chan struct{}, error) {
+				return ui.AttachTerminalTab(selected, activeTab)
 			})
 		})
 	}
-	return m, nil
+	return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
+		return attachOverlayCallbackFn(m, "handleEnter-sidebar", "", selected.IsRemote(), func() (chan struct{}, error) {
+			return m.store.AttachInstance(selected)
+		})
+	})
 }
 
 // handleNewTab spawns a new shell tab in the selected instance and selects it

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -112,6 +112,9 @@ func (m *home) closePaneWindow(p *store.OpenPane) {
 	// its (pane, window) binding is about to dangle (#1089).
 	if p == m.livePane {
 		m.closeLiveTermPane()
+		// If the user was typing INTO that pane, the mode's premise just
+		// left with it: drop to nav now rather than a tick later.
+		m.enforceInteractiveInvariant()
 	}
 	m.store.CloseOpenPane(p)
 	delete(m.paneWindows, p.ID())

--- a/app/help.go
+++ b/app/help.go
@@ -28,6 +28,11 @@ type helpTypeInstanceStart struct {
 
 type helpTypeInstanceAttach struct{}
 
+// helpTypeInteractive is shown once, the first time the user enters a pane
+// (#1089 PR 2): the sharpest edge of the interaction change is that every
+// key now types into the agent, so the escape hatch leads (RFC §5.7).
+type helpTypeInteractive struct{}
+
 func helpStart(instance *session.Instance) helpText {
 	return helpTypeInstanceStart{instance: instance}
 }
@@ -45,8 +50,10 @@ func (h helpTypeGeneral) toContent() string {
 		keyStyle.Render("r")+descStyle.Render("         - Run selected task now"),
 		keyStyle.Render("D")+descStyle.Render("         - Kill (delete) the selected session"),
 		keyStyle.Render("↑/k, ↓/j")+descStyle.Render("  - Navigate between sessions"),
-		keyStyle.Render("↵/o")+descStyle.Render("       - Attach to the selected session"),
-		keyStyle.Render(tmux.DetachKeyDisplay)+descStyle.Render("    - Detach from session"),
+		keyStyle.Render("↵")+descStyle.Render("         - Interact with the session in its pane (all keys go to it)"),
+		keyStyle.Render("ctrl+]")+descStyle.Render("    - Leave interactive mode (back to navigation)"),
+		keyStyle.Render("o")+descStyle.Render("         - Attach to the selected session full-screen"),
+		keyStyle.Render(tmux.DetachKeyDisplay)+descStyle.Render("    - Detach from a full-screen session"),
 		"",
 		headerStyle.Render("Workspace:"),
 		keyStyle.Render("tab")+descStyle.Render("       - Cycle focus: tree → open panes → automations"),
@@ -96,7 +103,8 @@ func (h helpTypeInstanceStart) toContent() string {
 			lipgloss.NewStyle().Bold(true).Render(h.instance.Program))),
 		"",
 		headerStyle.Render("Managing:"),
-		keyStyle.Render("↵/o")+descStyle.Render("   - Attach to the session to interact with it directly"),
+		keyStyle.Render("↵")+descStyle.Render("     - Interact with the session in its pane (ctrl+] returns to nav)"),
+		keyStyle.Render("o")+descStyle.Render("     - Attach to the session full-screen"),
 		tabHelp,
 		keyStyle.Render("D")+descStyle.Render("     - Kill (delete) the selected session"),
 	)
@@ -112,6 +120,20 @@ func (h helpTypeInstanceAttach) toContent() string {
 	return content
 }
 
+func (h helpTypeInteractive) toContent() string {
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		titleStyle.Render("Interactive Pane"),
+		"",
+		descStyle.Render("You are typing INTO this pane's terminal: every key — including tab —"),
+		descStyle.Render("goes to the agent/shell. The pane's frame turns green while it has the"),
+		descStyle.Render("keyboard, and the instances rail stays visible."),
+		"",
+		descStyle.Render("Press ")+keyStyle.Render("ctrl+]")+descStyle.Render(" to return to navigation."),
+		descStyle.Render("Full-screen attach is still available on ")+keyStyle.Render("o")+descStyle.Render(" (from nav mode)."),
+	)
+	return content
+}
+
 func (h helpTypeGeneral) mask() uint32 {
 	return 1
 }
@@ -121,6 +143,10 @@ func (h helpTypeInstanceStart) mask() uint32 {
 }
 func (h helpTypeInstanceAttach) mask() uint32 {
 	return 1 << 2
+}
+
+func (h helpTypeInteractive) mask() uint32 {
+	return 1 << 3
 }
 
 var (
@@ -147,8 +173,10 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 		// over the session size, and our render client must never sit in an
 		// interactive client's way (#598 class; #1089). The tick-driven sync
 		// won't rebind while an overlay is open, and re-establishes the
-		// attachment after the eventual detach.
+		// attachment after the eventual detach. Interactive mode (if a stray
+		// path ever got here in it) cannot survive its attachment.
 		m.closeLiveTermPane()
+		m.enforceInteractiveInvariant()
 	}
 
 	flag := helpType.mask()

--- a/app/interactive.go
+++ b/app/interactive.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/store"
+)
+
+// This file hosts interactive mode's entry and key routing (#1089 PR 2, RFC
+// §2.3). Enter on a live-eligible pane enters the pane: every keystroke —
+// including Tab — forwards down the pane's termpane attachment to the
+// agent/shell, in place, with the instances rail still visible. Ctrl-] (and
+// ONLY Ctrl-]) returns to nav mode. Full-screen attach stays reachable on
+// `o` (handleAttach); panes that cannot embed (remote instances, dead
+// sessions) fall back to it from Enter too.
+//
+// The mode itself is the `interactive` flag on home (see its doc), flipped
+// through setInteractive and policed by enforceInteractiveInvariant
+// (live_termpane.go).
+
+// enterInteractiveMsg asks the event loop to activate interactive mode on a
+// pane. It exists because the first-time help screen defers the activation
+// to its dismiss callback, which runs as a tea.Cmd — off the event loop,
+// where model state must not be touched (#716 capture discipline: the pane
+// is captured at Enter-press time, then re-validated on arrival).
+type enterInteractiveMsg struct {
+	pane *store.OpenPane
+}
+
+// requestInteractive routes Enter-on-a-live-eligible-pane through the
+// first-time interactive help screen (seen-bitmask, like the attach help)
+// into activation.
+func (m *home) requestInteractive(p *store.OpenPane) (tea.Model, tea.Cmd) {
+	return m.showHelpScreen(helpTypeInteractive{}, func() tea.Cmd {
+		return func() tea.Msg { return enterInteractiveMsg{pane: p} }
+	})
+}
+
+// activateInteractive focuses the pane, binds its live attachment
+// immediately (no waiting for the 100ms tick), and flips the mode on. The
+// pane pointer was captured at Enter-press time; it is re-validated against
+// the store because the help overlay (or an async event) may have closed it
+// in the meantime (#716 class).
+func (m *home) activateInteractive(p *store.OpenPane) tea.Cmd {
+	stillOpen := false
+	for _, q := range m.store.OpenPanes() {
+		if q == p {
+			stillOpen = true
+			break
+		}
+	}
+	if !stillOpen {
+		return nil
+	}
+	// The session may have changed state while the help overlay was up
+	// (e.g. gone Lost, #1108): re-run the Enter guard so the user gets the
+	// same truthful error Enter would give now, not a generic bind failure.
+	if err := interactiveGuard(p.Instance()); err != nil {
+		return m.handleError(err)
+	}
+
+	// Focus (and, via the recency touch, un-auto-hide) the pane, then force
+	// the live bind for it now.
+	m.store.TouchOpenPane(p)
+	m.focusRegion(layout.PaneRegion(p.ID()))
+	m.syncLiveTermPane()
+
+	if m.liveTerm == nil || m.livePane != p {
+		inst := p.Instance()
+		title := ""
+		if inst != nil {
+			title = inst.Title
+		}
+		return m.handleError(fmt.Errorf("couldn't open an embedded terminal for '%s' — try again, or press o to attach full-screen", title))
+	}
+	m.setInteractive(true)
+	return nil
+}
+
+// handleInteractiveKey is the whole keyboard while interactive: Ctrl-] pops
+// back to nav; everything else forwards down the live attachment. A key the
+// translation table cannot encode is IGNORED — never a guessed byte
+// sequence (the #1089 input contract; the honest not-forwarded list lives on
+// termpane.translateKey).
+func (m *home) handleInteractiveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.Type == tea.KeyCtrlCloseBracket {
+		m.setInteractive(false)
+		return m, nil
+	}
+	// The attachment may have died since the last tick (client killed, pane
+	// pruned). Re-check before forwarding; a broken premise drops to nav and
+	// swallows this one keystroke rather than typing into nothing.
+	m.enforceInteractiveInvariant()
+	if !m.interactive {
+		return m, nil
+	}
+	m.liveTerm.SendKey(msg)
+	return m, nil
+}

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -1,0 +1,264 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/keys"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// ----------------------------------------------------------------------------
+// Interactive mode (#1089 PR 2, RFC §2.3): Enter on a live pane forwards ALL
+// keystrokes (including Tab) to the pane's attachment; Ctrl-] — and only
+// Ctrl-] — returns to nav mode; `o` keeps the full-screen attach; bindings
+// that cannot embed fall back to full-screen.
+// ----------------------------------------------------------------------------
+
+// interactiveTestHome is liveTestHome with the first-time interactive help
+// screen marked seen, so Enter activates synchronously through the deferred
+// enterInteractiveMsg instead of parking on the overlay.
+func interactiveTestHome(t *testing.T) (*home, *session.Instance, *[]*fakeLiveTerm) {
+	t.Helper()
+	h, inst := liveTestHome(t)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	fakes, _ := stubLiveTermFactory(t)
+	return h, inst, fakes
+}
+
+// runHermeticCmd executes a cmd tree (unpacking batch/sequence slices
+// reflectively — both are unexported []tea.Cmd types) and feeds every
+// produced msg back into Update. Only for cmds known to be hermetic (the
+// deferred interactive activation, WindowSize) — never selectionChanged's
+// capture/PR-fetch dispatches.
+func runHermeticCmd(t *testing.T, h *home, cmd tea.Cmd, depth int) {
+	t.Helper()
+	require.Less(t, depth, 8, "cmd tree too deep — unexpected recursion")
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if msg == nil {
+		return
+	}
+	v := reflect.ValueOf(msg)
+	if v.Kind() == reflect.Slice {
+		for i := 0; i < v.Len(); i++ {
+			if c, ok := v.Index(i).Interface().(tea.Cmd); ok {
+				runHermeticCmd(t, h, c, depth+1)
+			}
+		}
+		return
+	}
+	_, next := h.Update(msg)
+	runHermeticCmd(t, h, next, depth+1)
+}
+
+// enterInteractive presses Enter on the focused pane and drives the deferred
+// activation to completion.
+func enterInteractive(t *testing.T, h *home) {
+	t.Helper()
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	runHermeticCmd(t, h, cmd, 0)
+}
+
+func TestEnterOnFocusedLivePaneEntersInteractive(t *testing.T) {
+	h, _, fakes := interactiveTestHome(t)
+
+	enterInteractive(t, h)
+
+	assert.True(t, h.interactive, "Enter on a live-eligible focused pane must enter interactive mode")
+	require.Len(t, *fakes, 1, "activation must bind the live attachment immediately, not on the next tick")
+	p := h.focusedOpenPane()
+	require.NotNil(t, p)
+	assert.Equal(t, p, h.livePane)
+	assert.True(t, h.paneWindows[p.ID()].Interactive(), "the pane must carry the interactive visual cue")
+	assert.Contains(t, h.menu.String(), "ctrl+]", "the status bar must show the escape hatch")
+}
+
+func TestInteractiveForwardsAllKeysIncludingTab(t *testing.T) {
+	h, _, fakes := interactiveTestHome(t)
+	enterInteractive(t, h)
+	require.Len(t, *fakes, 1)
+	fake := (*fakes)[0]
+
+	ringBefore := h.ring.Active()
+	for _, msg := range []tea.KeyMsg{
+		{Type: tea.KeyTab},                       // host focus key in nav — forwards here
+		{Type: tea.KeyRunes, Runes: []rune("q")}, // nav quit key — forwards here
+		{Type: tea.KeyRunes, Runes: []rune("1")}, // nav tab-jump digit — forwards here
+		{Type: tea.KeyCtrlC},                     // forwards (quit still reachable via nav)
+		{Type: tea.KeyRunes, Runes: []rune("x")}, // nav hide-pane key — forwards here
+		{Type: tea.KeyEnter},                     //
+		{Type: tea.KeyCtrlW},                     // the full-screen detach key — not host-reserved here
+	} {
+		_, cmd := h.handleKeyPress(msg)
+		assert.Nil(t, cmd, "forwarded keys must not trigger host actions (%s)", msg.String())
+	}
+
+	assert.Equal(t, []string{"tab", "q", "1", "ctrl+c", "x", "enter", "ctrl+w"}, fake.keys,
+		"every keystroke must forward to the pane's attachment")
+	assert.True(t, h.interactive, "forwarding must not leave interactive mode")
+	assert.Equal(t, ringBefore, h.ring.Active(), "Tab must not cycle host focus while interactive")
+	assert.Equal(t, 1, h.store.NumOpenPanes(), "x must not hide the pane while interactive")
+}
+
+func TestCtrlCloseBracketReturnsToNav(t *testing.T) {
+	h, _, fakes := interactiveTestHome(t)
+	enterInteractive(t, h)
+	fake := (*fakes)[0]
+
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
+
+	assert.False(t, h.interactive, "Ctrl-] must return to nav mode")
+	assert.Empty(t, fake.keys, "Ctrl-] is host-reserved: it must never forward")
+	p := h.focusedOpenPane()
+	require.NotNil(t, p, "focus stays on the pane after leaving interactive (RFC §2.3)")
+	assert.False(t, h.paneWindows[p.ID()].Interactive(), "the visual cue must clear")
+	assert.False(t, (*fakes)[0].closed, "leaving interactive keeps the live attachment (render continues)")
+
+	// Nav keys work again: Tab cycles the focus ring instead of forwarding.
+	// (Direct dispatch, like pressTab — handleKeyPress would take the menu
+	// highlight re-emit detour first.)
+	before := h.ring.Active()
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyTab}, keys.KeyTab)
+	assert.NotEqual(t, before, h.ring.Active(), "Tab must cycle focus again in nav mode")
+	assert.Empty(t, fake.keys)
+}
+
+func TestInteractiveEndsWhenClientDies(t *testing.T) {
+	h, _, fakes := interactiveTestHome(t)
+	enterInteractive(t, h)
+	fake := (*fakes)[0]
+
+	close(fake.done)
+	h.syncLiveTermPane()
+
+	assert.False(t, h.interactive, "a dead attach client must drop the TUI back to nav mode")
+
+	// A keystroke racing the death (before the next tick) is swallowed, not
+	// mistyped: re-enter interactive, kill the client, then type.
+	h.liveBindFailedAt = h.liveBindFailedAt.Add(-2 * liveBindRetryInterval)
+	enterInteractive(t, h)
+	require.Len(t, *fakes, 2)
+	second := (*fakes)[1]
+	close(second.done)
+	// The tick hasn't run yet — the very next key must detect the breakage.
+	h.reconcileLiveTermPane()
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("z")})
+	assert.False(t, h.interactive)
+	assert.Empty(t, second.keys, "keys must never forward into a dead attachment")
+}
+
+func TestInteractiveEndsWhenPaneCloses(t *testing.T) {
+	h, _, _ := interactiveTestHome(t)
+	enterInteractive(t, h)
+	p := h.focusedOpenPane()
+	require.NotNil(t, p)
+
+	h.hidePane(p)
+
+	assert.False(t, h.interactive, "closing/hiding the pane must end interactive mode")
+}
+
+func TestEnterFromTreeOpensPaneAndEntersInteractive(t *testing.T) {
+	h := newTestHome(t)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	inst := startedLocalInstance(t, "tree-live")
+	selectInstance(h, inst)
+	resizeHome(h, 120, 40)
+	fakes, _ := stubLiveTermFactory(t)
+	require.Zero(t, h.store.NumOpenPanes())
+
+	// Enter on the tree row: opens the selection's pane (the `s` semantics),
+	// then enters it. The activation itself arrives as the deferred
+	// enterInteractiveMsg; drive it directly — the batched cmd also carries
+	// selectionChanged's capture dispatches, which are not hermetic.
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	p := h.store.FindOpenPane(inst, 0)
+	require.NotNil(t, p, "Enter from the tree must open the selection's pane")
+	assert.Equal(t, p, h.focusedOpenPane(), "the opened pane must take focus")
+
+	_, cmd := h.Update(enterInteractiveMsg{pane: p})
+	runHermeticCmd(t, h, cmd, 0)
+	assert.True(t, h.interactive)
+	require.Len(t, *fakes, 1)
+}
+
+func TestEnterOnRemotePaneFallsBackToFullScreenAttach(t *testing.T) {
+	h := newTestHome(t)
+	require.NoError(t, h.appState.SetHelpScreensSeen(
+		helpTypeInteractive{}.mask()|helpTypeInstanceAttach{}.mask()))
+	inst := instanceWithFakeBackend(t, "remote-inst")
+	inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
+	inst.SetStatus(session.Running)
+	require.True(t, inst.IsRemote())
+	selectInstance(h, inst)
+	resizeHome(h, 120, 40)
+	openTestPane(t, h, inst, 0)
+
+	attached := 0
+	swapAttachOverlayCallbackFn(t, func(m *home, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+		attached++
+		assert.True(t, rem, "the remote flag must reach the attach path")
+		return nil
+	})
+
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+
+	assert.Equal(t, 1, attached, "a remote pane cannot embed: Enter must fall back to full-screen attach")
+	assert.False(t, h.interactive)
+}
+
+func TestAttachKeyKeepsFullScreenAttach(t *testing.T) {
+	h, _, fakes := interactiveTestHome(t)
+	require.NoError(t, h.appState.SetHelpScreensSeen(
+		helpTypeInteractive{}.mask()|helpTypeInstanceAttach{}.mask()))
+
+	attached := 0
+	swapAttachOverlayCallbackFn(t, func(m *home, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+		attached++
+		return nil
+	})
+
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")}, keys.KeyAttach)
+
+	assert.Equal(t, 1, attached, "`o` must run the full-screen attach flow")
+	assert.False(t, h.interactive, "`o` must not enter interactive mode")
+	assert.Empty(t, *fakes, "no live bind may happen on the way into a full-screen attach")
+}
+
+func TestFirstInteractiveEntryShowsHelpScreenOnce(t *testing.T) {
+	h, _ := liveTestHome(t)
+	_, _ = stubLiveTermFactory(t)
+
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+
+	require.Equal(t, stateHelp, h.state, "first Enter must show the interactive help screen")
+	require.NotNil(t, h.textOverlay)
+	assert.Contains(t, h.textOverlay.Render(), "ctrl+]",
+		"the help screen must lead with the escape hatch (RFC §5.7)")
+	assert.False(t, h.interactive, "activation waits for the overlay dismissal")
+
+	// Any key dismisses the overlay; the deferred activation then runs.
+	_, cmd := h.handleHelpState(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, stateDefault, h.state)
+	runHermeticCmd(t, h, cmd, 0)
+	assert.True(t, h.interactive, "dismissing the help screen must complete the activation")
+}
+
+func TestWheelIsInertWhileInteractive(t *testing.T) {
+	h, _, _ := interactiveTestHome(t)
+	enterInteractive(t, h)
+	p := h.focusedOpenPane()
+	require.NotNil(t, p)
+
+	_, _ = h.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelUp})
+
+	assert.False(t, h.paneWindows[p.ID()].IsInScrollMode(),
+		"host wheel-scroll must not flip the live pane into capture scroll mode mid-typing")
+}

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/store"
@@ -37,15 +39,19 @@ const liveBindRetryInterval = 5 * time.Second
 // without a warning every 5s retry.
 const liveDeathLogInterval = time.Minute
 
-// liveTermAttachment is what the sync needs from a termpane: ui.LiveView
-// (render + resize) plus the lifecycle half (close, death signal). It exists
-// so tests can drive the bind/unbind state machine with a fake instead of
-// spawning real `tmux attach-session` clients.
+// liveTermAttachment is what the app needs from a termpane: ui.LiveView
+// (render + resize) plus the lifecycle half (close, death signal) and the
+// interactive-mode key sink (#1089 PR 2). It exists so tests can drive the
+// bind/unbind/forward state machine with a fake instead of spawning real
+// `tmux attach-session` clients.
 type liveTermAttachment interface {
-	Render(width, height int) string
+	Render(width, height int, showCursor bool) string
 	Resize(width, height int)
 	Close() error
 	Done() <-chan struct{}
+	// SendKey forwards one keystroke down the attachment's PTY, reporting
+	// false when the key has no safe encoding (ignored, never guessed).
+	SendKey(msg tea.KeyMsg) bool
 }
 
 // newLiveTermPaneFn is the termpane creation seam. Production points it at
@@ -55,9 +61,16 @@ var newLiveTermPaneFn = func(sessionName string, width, height int) (liveTermAtt
 }
 
 // syncLiveTermPane reconciles the live attachment with the current focus,
-// pane visibility, and instance health. Called from the 100ms preview tick;
-// steady-state cost is pointer compares plus one non-blocking channel read.
+// pane visibility, and instance health, then re-checks the interactive-mode
+// invariant against the outcome (#1089 PR 2: the mode cannot outlive its
+// attachment). Called from the 100ms preview tick; steady-state cost is
+// pointer compares plus one non-blocking channel read.
 func (m *home) syncLiveTermPane() {
+	m.reconcileLiveTermPane()
+	m.enforceInteractiveInvariant()
+}
+
+func (m *home) reconcileLiveTermPane() {
 	// While the user is inside a full-screen attach our render client must
 	// not hold the same session (size fight) or generate tmux traffic
 	// (#598). The attach dispatch path already closed it; this covers any
@@ -156,6 +169,33 @@ func (m *home) syncLiveTermPane() {
 	w.SetLive(tp)
 }
 
+// enforceInteractiveInvariant drops back to nav mode whenever interactive
+// mode's premise breaks: the mode means "keystrokes forward into the FOCUSED
+// pane's live attachment", so a dead client, a closed/hidden pane, or focus
+// moved by a relayout (auto-hide on shrink) each end it. Every keystroke and
+// every sync tick funnels through this, so the stale-mode window is at most
+// one 100ms tick. Idempotent.
+func (m *home) enforceInteractiveInvariant() {
+	if !m.interactive {
+		return
+	}
+	if m.liveTerm == nil || m.livePane == nil || m.livePane != m.focusedOpenPane() {
+		m.setInteractive(false)
+	}
+}
+
+// setInteractive flips interactive mode (#1089, RFC §2.3) and keeps every
+// dependent surface coherent: the status bar collapses to (or restores from)
+// the Ctrl-] escape hatch, and the pane windows' green interactive cue
+// follows the live pane. Idempotent; event-loop only.
+func (m *home) setInteractive(on bool) {
+	m.interactive = on
+	m.menu.SetInteractive(on)
+	for id, w := range m.paneWindows {
+		w.SetInteractive(on && m.livePane != nil && id == m.livePane.ID())
+	}
+}
+
 // liveBindCandidate resolves the pane to a bind key + tmux session name, or
 // ("", "") when the pane is not eligible for a live attachment: remote
 // instances (no local session), not-started/transitional/dead instances, and
@@ -166,20 +206,30 @@ func (m *home) liveBindCandidate(target *store.OpenPane) (key, sessionName strin
 	if target == nil {
 		return "", ""
 	}
-	inst := target.Instance()
-	if inst == nil || inst.IsRemote() || !inst.Started() {
-		return "", ""
-	}
-	switch inst.GetStatus() {
-	case session.Loading, session.Deleting, session.Dead, session.Lost:
-		return "", ""
-	}
 	tab := target.Tab()
-	name := inst.TabTmuxName(tab)
+	name := liveSessionName(target.Instance(), tab)
 	if name == "" {
 		return "", ""
 	}
 	return fmt.Sprintf("%d/%d/%s", target.ID(), tab, name), name
+}
+
+// liveSessionName resolves an (instance, tab) to the tmux session a live
+// attachment would target, or "" when embedding is not possible: remote
+// instances (no local session), not-started/transitional/dead/lost instances,
+// and tabs with no session. Of the "" cases, remote is the one where Enter
+// falls back to the full-screen attach path (#1089 PR 2);
+// dead/lost/transitional instances are fenced off earlier by
+// interactiveGuard's explicit errors.
+func liveSessionName(inst *session.Instance, tab int) string {
+	if inst == nil || inst.IsRemote() || !inst.Started() {
+		return ""
+	}
+	switch inst.GetStatus() {
+	case session.Loading, session.Deleting, session.Dead, session.Lost:
+		return ""
+	}
+	return inst.TabTmuxName(tab)
 }
 
 // closeLiveTermPane releases the live attachment: unbind the window's render

--- a/app/live_termpane_test.go
+++ b/app/live_termpane_test.go
@@ -7,24 +7,34 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/sachiniyer/agent-factory/session"
 )
 
-// fakeLiveTerm drives the live-termpane state machine (#1089 PR 1) without
-// spawning tmux attach clients.
+// fakeLiveTerm drives the live-termpane state machine (#1089 PR 1) and the
+// interactive-mode key forwarding (#1089 PR 2) without spawning tmux attach
+// clients.
 type fakeLiveTerm struct {
 	closed bool
 	done   chan struct{}
+	// keys records every message forwarded through SendKey, as
+	// tea.KeyMsg.String() values.
+	keys []string
 }
 
 func newFakeLiveTerm() *fakeLiveTerm {
 	return &fakeLiveTerm{done: make(chan struct{})}
 }
 
-func (f *fakeLiveTerm) Render(width, height int) string { return "FAKE-LIVE-GRID" }
-func (f *fakeLiveTerm) Resize(width, height int)        {}
-func (f *fakeLiveTerm) Close() error                    { f.closed = true; return nil }
-func (f *fakeLiveTerm) Done() <-chan struct{}           { return f.done }
+func (f *fakeLiveTerm) Render(width, height int, showCursor bool) string { return "FAKE-LIVE-GRID" }
+func (f *fakeLiveTerm) Resize(width, height int)                         {}
+func (f *fakeLiveTerm) Close() error                                     { f.closed = true; return nil }
+func (f *fakeLiveTerm) Done() <-chan struct{}                            { return f.done }
+func (f *fakeLiveTerm) SendKey(msg tea.KeyMsg) bool {
+	f.keys = append(f.keys, msg.String())
+	return true
+}
 
 // stubLiveTermFactory points the bind seam at fake attachments and returns
 // the created fakes + attempted session names.

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -57,6 +57,17 @@ const (
 	// manager overlay. Dispatch is root-routed (handleAutomationsFocus), so
 	// this name never appears in GlobalKeyStringsMap.
 	KeyManageAutomations
+
+	// Interactive mode (#1089, RFC §2.3): Enter on a live pane enters it —
+	// every subsequent keystroke (including Tab) forwards to the agent/shell
+	// in-pane, no full-screen takeover. KeyAttach keeps the full-screen tmux
+	// attach reachable on its own key (`o`, previously an Enter alias).
+	KeyAttach
+	// KeyExitInteractive is the ONLY host-reserved key while interactive
+	// (menu/help display only): Ctrl-] returns to nav mode. Dispatch is
+	// root-routed before any key map (handleInteractiveKey), so this name
+	// never appears in GlobalKeyStringsMap.
+	KeyExitInteractive
 )
 
 // GlobalKeyStringsMap is a global, immutable map string to keybinding.
@@ -69,15 +80,17 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"shift+down": KeyShiftDown,
 	"N":          KeyNewRemote,
 	"enter":      KeyEnter,
-	"o":          KeyEnter,
-	"n":          KeyNew,
-	"D":          KeyKill,
-	"q":          KeyQuit,
-	"tab":        KeyTab,
-	"shift+tab":  KeyShiftTab,
-	"t":          KeyNewTab,
-	"w":          KeyCloseTab,
-	"?":          KeyHelp,
+	// "o" was an Enter alias until #1089 PR 2 split the verbs: Enter enters
+	// the pane (interactive), o keeps the old full-screen attach.
+	"o":         KeyAttach,
+	"n":         KeyNew,
+	"D":         KeyKill,
+	"q":         KeyQuit,
+	"tab":       KeyTab,
+	"shift+tab": KeyShiftTab,
+	"t":         KeyNewTab,
+	"w":         KeyCloseTab,
+	"?":         KeyHelp,
 	// "s" is the open-pane verb since #1024 PR 5/#1088 (RFC §2.3); the
 	// task-create jump it used to carry lives in the task manager (S → n).
 	"s":     KeyOpenPane,
@@ -114,8 +127,16 @@ var GlobalKeyBindings = map[KeyName]key.Binding{
 		key.WithHelp("⇧↓", "scroll"),
 	),
 	KeyEnter: key.NewBinding(
-		key.WithKeys("enter", "o"),
-		key.WithHelp("↵/o", "open"),
+		key.WithKeys("enter"),
+		key.WithHelp("↵", "interact"),
+	),
+	KeyAttach: key.NewBinding(
+		key.WithKeys("o"),
+		key.WithHelp("o", "attach"),
+	),
+	KeyExitInteractive: key.NewBinding(
+		key.WithKeys("ctrl+]"),
+		key.WithHelp("ctrl+]", "nav mode"),
 	),
 	KeyNew: key.NewBinding(
 		key.WithKeys("n"),

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -64,6 +64,10 @@ type Menu struct {
 	// verbs, while the tree shows the session actions.
 	focusRegion string
 
+	// interactive: every keystroke is forwarding into the focused pane's
+	// terminal (#1089, RFC §2.3), so the bar shows only the escape hatch.
+	interactive bool
+
 	// keyDown is the key which is pressed. The default is -1.
 	keyDown keys.KeyName
 }
@@ -80,13 +84,19 @@ var automationsMenuOptions = []keys.KeyName{
 }
 
 // paneMenuOptions are the status-bar hints while a workspace pane has focus
-// (#1088): attach/scroll act on the pane's own binding, s opens the selected
-// tab as another pane, x hides this pane back to the background.
+// (#1088): enter interacts in-pane / o attaches full-screen (#1089), scroll
+// acts on the pane's own binding, s opens the selected tab as another pane,
+// x hides this pane back to the background.
 var paneMenuOptions = []keys.KeyName{
-	keys.KeyEnter, keys.KeyShiftUp, keys.KeyShiftDown,
+	keys.KeyEnter, keys.KeyAttach, keys.KeyShiftUp, keys.KeyShiftDown,
 	keys.KeyOpenPane, keys.KeyHidePane,
 	keys.KeyTab, keys.KeyHelp, keys.KeyQuit,
 }
+
+// interactiveMenuOptions is the whole bar while interactive (#1089, RFC
+// §2.3): every other key — including these hints' own letters — forwards to
+// the pane's terminal, so advertising anything else would be a lie.
+var interactiveMenuOptions = []keys.KeyName{keys.KeyExitInteractive}
 
 func NewMenu() *Menu {
 	m := &Menu{
@@ -144,9 +154,25 @@ func (m *Menu) SetActiveTab(tab int) {
 	m.updateOptions()
 }
 
+// SetInteractive switches the hints to (or back from) interactive mode: only
+// the Ctrl-] escape hatch shows while keystrokes forward to the pane (#1089).
+func (m *Menu) SetInteractive(on bool) {
+	m.interactive = on
+	m.updateOptions()
+}
+
 // updateOptions updates the menu options based on current state, focus
 // region, and instance
 func (m *Menu) updateOptions() {
+	// Interactive mode outranks everything: the terminal owns the keyboard,
+	// the bar owns nothing but the way out.
+	if m.interactive {
+		m.options = interactiveMenuOptions
+		m.groups = []menuGroup{
+			{start: 0, end: len(interactiveMenuOptions), isAction: true},
+		}
+		return
+	}
 	// The automations strip owns the hints while focused, regardless of the
 	// selected instance — except during naming, whose submit/change-program
 	// hints must always win (the form has the keyboard).
@@ -164,9 +190,9 @@ func (m *Menu) updateOptions() {
 	if layout.IsPaneRegion(m.focusRegion) && m.state != StateNewInstance {
 		m.options = paneMenuOptions
 		m.groups = []menuGroup{
-			{start: 0, end: 3, isAction: true},
-			{start: 3, end: 5, isAction: false},
-			{start: 5, end: len(paneMenuOptions), isAction: false},
+			{start: 0, end: 4, isAction: true},
+			{start: 4, end: 6, isAction: false},
+			{start: 6, end: len(paneMenuOptions), isAction: false},
 		}
 		return
 	}
@@ -213,8 +239,8 @@ func (m *Menu) addInstanceOptions() {
 	// Instance management group
 	mgmtGroup := []keys.KeyName{keys.KeyNew, keys.KeyKill}
 
-	// Action group
-	actionGroup := []keys.KeyName{keys.KeyEnter}
+	// Action group: enter interacts in-pane, o attaches full-screen (#1089).
+	actionGroup := []keys.KeyName{keys.KeyEnter, keys.KeyAttach}
 
 	// Navigation group: every tab is a captured tmux session and supports
 	// scroll mode (#930 PR 2 — the agent "Preview" tab and the terminal tab

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -22,6 +22,14 @@ var windowStyle = lipgloss.NewStyle().
 var blurredWindowStyle = windowStyle.
 	BorderForeground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#555555"})
 
+// interactiveWindowStyle marks the pane that owns the keyboard in
+// interactive mode (#1089, RFC §2.3): a green DOUBLE border — unmistakably
+// distinct from the teal rounded nav-focus ring, and still distinct with
+// colors unavailable — signals "keystrokes go INTO this terminal".
+var interactiveWindowStyle = windowStyle.
+	Border(lipgloss.DoubleBorder()).
+	BorderForeground(lipgloss.AdaptiveColor{Light: "#1A7F37", Dark: "#3FB950"})
+
 var paneHeaderStyle = lipgloss.NewStyle().
 	Bold(true).
 	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#dddddd"})
@@ -33,6 +41,13 @@ var paneHeaderFocusedStyle = lipgloss.NewStyle().
 
 var paneHeaderDimStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+
+// paneHeaderInteractiveStyle matches the interactive frame: green header bar
+// on the pane whose terminal owns the keyboard.
+var paneHeaderInteractiveStyle = lipgloss.NewStyle().
+	Bold(true).
+	Background(lipgloss.AdaptiveColor{Light: "#D2F3DC", Dark: "#1A7F37"}).
+	Foreground(lipgloss.AdaptiveColor{Light: "#0A3D1E", Dark: "#EAFBEF"})
 
 // paneHeaderRows is the height of the `title · tab` header line rendered
 // inside the pane frame. With the tab bar gone (#1024 PR 4) the header is
@@ -61,6 +76,10 @@ type TabbedWindow struct {
 	pane    *store.OpenPane
 	rect    layout.Rect
 	focused bool
+	// interactive marks this pane as the one whose embedded terminal owns
+	// the keyboard (#1089, RFC §2.3). Set by the root model alongside the
+	// mode flag; drives the green frame/header cue and the cursor overlay.
+	interactive bool
 
 	tab *TabPane
 
@@ -78,8 +97,9 @@ type TabbedWindow struct {
 // without a PTY. Both methods are event-loop only.
 type LiveView interface {
 	// Render returns the live grid as exactly height ANSI lines of exactly
-	// width cells.
-	Render(width, height int) string
+	// width cells. showCursor overlays the terminal cursor — the
+	// interactive-mode typing cue; nav-mode renders pass false.
+	Render(width, height int, showCursor bool) string
 	// Resize propagates a pane-geometry change to the underlying PTY and
 	// emulator grid.
 	Resize(width, height int)
@@ -238,6 +258,14 @@ func (w *TabbedWindow) Focus() { w.focused = true }
 // Blur implements layout.Pane.
 func (w *TabbedWindow) Blur() { w.focused = false }
 
+// SetInteractive flags this pane's terminal as the keyboard owner
+// (interactive mode, #1089). The root model keeps it true on at most one
+// window at a time.
+func (w *TabbedWindow) SetInteractive(on bool) { w.interactive = on }
+
+// Interactive reports the interactive-mode flag.
+func (w *TabbedWindow) Interactive() bool { return w.interactive }
+
 // HandleKey implements layout.Pane. The root model routes all workspace keys
 // globally in nav mode (scroll, attach, pane verbs), so the pane itself
 // consumes nothing; interactive-mode key forwarding is #1089.
@@ -331,6 +359,8 @@ func (w *TabbedWindow) renderHeader(width int) string {
 	}
 	style := paneHeaderStyle
 	switch {
+	case w.interactive:
+		style = paneHeaderInteractiveStyle
 	case w.focused:
 		style = paneHeaderFocusedStyle
 	case w.boundInstance() == nil:
@@ -355,7 +385,9 @@ func (w *TabbedWindow) String() string {
 	// PR decides who owns scrolling (RFC §2.4).
 	content := ""
 	if w.live != nil && !w.tab.IsScrolling() {
-		content = w.live.Render(iw, ih)
+		// The cursor overlays only while this pane's terminal owns the
+		// keyboard — the interactive typing cue (#1089 PR 2).
+		content = w.live.Render(iw, ih, w.interactive)
 	} else {
 		content = w.tab.String()
 	}
@@ -364,7 +396,10 @@ func (w *TabbedWindow) String() string {
 		layout.ClampToRect(content, layout.Rect{W: iw, H: ih}),
 	)
 	frame := windowStyle
-	if !w.focused {
+	switch {
+	case w.interactive:
+		frame = interactiveWindowStyle
+	case !w.focused:
 		frame = blurredWindowStyle
 	}
 	return layout.ClampToRect(frame.Render(inner), w.rect)

--- a/ui/tabbed_window_live_test.go
+++ b/ui/tabbed_window_live_test.go
@@ -14,9 +14,15 @@ import (
 type fakeLiveView struct {
 	content string
 	resizes [][2]int
+	// cursorRenders records the showCursor flag of each Render call — the
+	// window must ask for the cursor exactly while interactive (#1089 PR 2).
+	cursorRenders []bool
 }
 
-func (f *fakeLiveView) Render(width, height int) string { return f.content }
+func (f *fakeLiveView) Render(width, height int, showCursor bool) string {
+	f.cursorRenders = append(f.cursorRenders, showCursor)
+	return f.content
+}
 func (f *fakeLiveView) Resize(width, height int) {
 	f.resizes = append(f.resizes, [2]int{width, height})
 }
@@ -56,4 +62,31 @@ func TestTabbedWindowResizesLiveViewWithRect(t *testing.T) {
 	// winsize at the live attachment — the root model closes it instead.
 	w.SetRect(layout.Rect{})
 	assert.Len(t, fake.resizes, 2, "zero rect must not resize the live view")
+}
+
+func TestTabbedWindowInteractiveCue(t *testing.T) {
+	w := NewTabbedWindow(NewTabPane(), nil)
+	w.SetRect(layout.Rect{W: 40, H: 12})
+	fake := &fakeLiveView{content: "LIVE"}
+	w.SetLive(fake)
+	w.Focus()
+
+	// Nav mode: focused teal frame, no cursor requested.
+	navFrame := w.String()
+	require.NotEmpty(t, fake.cursorRenders)
+	assert.False(t, fake.cursorRenders[len(fake.cursorRenders)-1],
+		"nav-mode render must not request the cursor")
+
+	// Interactive: the frame changes (the green keyboard-owner cue) and the
+	// live render is asked for the cursor overlay.
+	w.SetInteractive(true)
+	require.True(t, w.Interactive())
+	interactiveFrame := w.String()
+	assert.True(t, fake.cursorRenders[len(fake.cursorRenders)-1],
+		"interactive render must request the cursor")
+	assert.NotEqual(t, navFrame, interactiveFrame,
+		"interactive mode needs a visible cue distinct from nav focus")
+
+	w.SetInteractive(false)
+	assert.Equal(t, navFrame, w.String(), "leaving interactive restores the nav frame")
 }

--- a/ui/termpane/keymap.go
+++ b/ui/termpane/keymap.go
@@ -1,0 +1,203 @@
+package termpane
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// This file is the bubbletea-key → PTY-bytes boundary for interactive mode
+// (#1089 PR 2, RFC §2.3/§2.4). Every focused tea.KeyMsg is translated into
+// exactly one of:
+//
+//   - emulator key events (vt's SendKey encoder) — the default path, because
+//     the emulator knows the terminal's current modes: DECCKM flips arrows
+//     between CSI and SS3, bracketed paste wraps pastes, and so on. No
+//     hand-written escape sequences where a mode could change the answer.
+//   - a pre-encoded xterm sequence — ONLY for the modifier+navigation
+//     family (ctrl/alt/shift arrows, Home/End, PgUp/PgDn, Insert/Delete),
+//     which the pinned x/vt SendKey does not encode (its modifier support is
+//     an upstream TODO) and whose xterm encoding (`CSI 1;{mod}X` /
+//     `CSI {n};{mod}~`) is mode-INDEPENDENT, so pre-encoding cannot go stale
+//     against the emulator's state.
+//   - nothing — the input contract of #1089: a key this table does not cover
+//     is IGNORED, never guessed into a wrong byte sequence. The known
+//     ignored set (F13-F20, ctrl+? ) is listed on translateKey.
+//
+// The table is pinned byte-for-byte by TestKeyTranslationTable.
+
+// translated is the encoding decision for one key message: exactly one of
+// events/raw is set. events go through emu.SendKey (mode-aware); raw is
+// written to the emulator's input pipe verbatim.
+type translated struct {
+	events []uv.KeyEvent
+	raw    string
+}
+
+// modNavKey describes one member of the modifier+navigation family in xterm
+// terms: cursor-class keys encode as `CSI 1;{mod}{final}`, tilde-class keys
+// as `CSI {num};{mod}~`, where mod = 1 + shift(1) + alt(2) + ctrl(4).
+type modNavKey struct {
+	final byte // 'A'..'D', 'H', 'F' — cursor class; 0 for tilde class
+	num   int  // tilde class: 2 ins, 3 del, 5 pgup, 6 pgdn
+	shift bool
+	ctrl  bool
+}
+
+// modNavKeys maps every bubbletea modified-navigation KeyType (plus the
+// unmodified ones, for the msg.Alt variants) to its xterm encoding parts.
+// bubbletea v1 has no alt+nav KeyTypes — alt arrives as the Alt flag on the
+// base type — so alt contributes via the flag only, never the table.
+var modNavKeys = map[tea.KeyType]modNavKey{
+	tea.KeyUp:    {final: 'A'},
+	tea.KeyDown:  {final: 'B'},
+	tea.KeyRight: {final: 'C'},
+	tea.KeyLeft:  {final: 'D'},
+	tea.KeyHome:  {final: 'H'},
+	tea.KeyEnd:   {final: 'F'},
+
+	tea.KeyShiftUp:    {final: 'A', shift: true},
+	tea.KeyShiftDown:  {final: 'B', shift: true},
+	tea.KeyShiftRight: {final: 'C', shift: true},
+	tea.KeyShiftLeft:  {final: 'D', shift: true},
+	tea.KeyShiftHome:  {final: 'H', shift: true},
+	tea.KeyShiftEnd:   {final: 'F', shift: true},
+
+	tea.KeyCtrlUp:    {final: 'A', ctrl: true},
+	tea.KeyCtrlDown:  {final: 'B', ctrl: true},
+	tea.KeyCtrlRight: {final: 'C', ctrl: true},
+	tea.KeyCtrlLeft:  {final: 'D', ctrl: true},
+	tea.KeyCtrlHome:  {final: 'H', ctrl: true},
+	tea.KeyCtrlEnd:   {final: 'F', ctrl: true},
+
+	tea.KeyCtrlShiftUp:    {final: 'A', shift: true, ctrl: true},
+	tea.KeyCtrlShiftDown:  {final: 'B', shift: true, ctrl: true},
+	tea.KeyCtrlShiftRight: {final: 'C', shift: true, ctrl: true},
+	tea.KeyCtrlShiftLeft:  {final: 'D', shift: true, ctrl: true},
+	tea.KeyCtrlShiftHome:  {final: 'H', shift: true, ctrl: true},
+	tea.KeyCtrlShiftEnd:   {final: 'F', shift: true, ctrl: true},
+
+	tea.KeyInsert:     {num: 2},
+	tea.KeyDelete:     {num: 3},
+	tea.KeyPgUp:       {num: 5},
+	tea.KeyPgDown:     {num: 6},
+	tea.KeyCtrlPgUp:   {num: 5, ctrl: true},
+	tea.KeyCtrlPgDown: {num: 6, ctrl: true},
+}
+
+// xtermSeq renders the modNavKey as its xterm escape sequence, with alt from
+// the message's Alt flag folded into the modifier parameter.
+func (k modNavKey) xtermSeq(alt bool) string {
+	mod := 1
+	if k.shift {
+		mod++
+	}
+	if alt {
+		mod += 2
+	}
+	if k.ctrl {
+		mod += 4
+	}
+	if k.final != 0 {
+		return fmt.Sprintf("\x1b[1;%d%c", mod, k.final)
+	}
+	return fmt.Sprintf("\x1b[%d;%d~", k.num, mod)
+}
+
+// simpleKeys are the unmodified specials vt's SendKey encodes natively
+// (mode-aware where it matters: DECCKM arrows, keypad). The unmodified nav
+// keys appear BOTH here and in modNavKeys: without Alt they take this
+// mode-aware path, with Alt they take the pre-encoded modifier path.
+var simpleKeys = map[tea.KeyType]rune{
+	tea.KeyEnter:     uv.KeyEnter,
+	tea.KeyTab:       uv.KeyTab,
+	tea.KeyBackspace: uv.KeyBackspace,
+	tea.KeyEscape:    uv.KeyEscape,
+	tea.KeyUp:        uv.KeyUp,
+	tea.KeyDown:      uv.KeyDown,
+	tea.KeyRight:     uv.KeyRight,
+	tea.KeyLeft:      uv.KeyLeft,
+	tea.KeyHome:      uv.KeyHome,
+	tea.KeyEnd:       uv.KeyEnd,
+	tea.KeyPgUp:      uv.KeyPgUp,
+	tea.KeyPgDown:    uv.KeyPgDown,
+	tea.KeyInsert:    uv.KeyInsert,
+	tea.KeyDelete:    uv.KeyDelete,
+}
+
+// ctrlPunct maps the non-letter control KeyTypes vt's SendKey encodes from a
+// (rune, ModCtrl) event. ctrl+] (0x1d) is deliberately ABSENT: it is the
+// host's only reserved key while interactive (RFC §2.3) and the app router
+// never forwards it, so encoding it here would only mask a routing bug.
+// (ctrl+[ needs no entry — its KeyType IS tea.KeyEscape, covered above; same
+// for ctrl+? which IS tea.KeyBackspace.)
+var ctrlPunct = map[tea.KeyType]rune{
+	tea.KeyCtrlAt:         uv.KeySpace, // ctrl+@ / ctrl+space → NUL
+	tea.KeyCtrlBackslash:  '\\',
+	tea.KeyCtrlCaret:      '^',
+	tea.KeyCtrlUnderscore: '_',
+}
+
+// translateKey maps one bubbletea key message to its PTY encoding. ok=false
+// means the key has no safe encoding and must be ignored — the #1089 input
+// contract ("key ignored", never a wrong byte sequence). Known-ignored today:
+// F13-F20 (no portable xterm encoding for shifted F-keys across terminals),
+// ctrl+? (DEL collides with backspace handling), ctrl+] (host-reserved,
+// filtered by the app router before this is ever consulted), and pastes,
+// which the caller routes through the emulator's bracketed-paste-aware Paste
+// before translation.
+func translateKey(msg tea.KeyMsg) (translated, bool) {
+	mod := uv.KeyMod(0)
+	if msg.Alt {
+		mod |= uv.ModAlt
+	}
+
+	// Literal text: one event per rune. vt's SendKey emits the rune as-is,
+	// with the legacy ESC prefix when Alt is held.
+	if msg.Type == tea.KeyRunes {
+		events := make([]uv.KeyEvent, 0, len(msg.Runes))
+		for _, r := range msg.Runes {
+			events = append(events, uv.KeyPressEvent{Code: r, Mod: mod})
+		}
+		return translated{events: events}, true
+	}
+	if msg.Type == tea.KeySpace {
+		return translated{events: []uv.KeyEvent{uv.KeyPressEvent{Code: uv.KeySpace, Mod: mod}}}, true
+	}
+
+	// Modifier+navigation family (including Alt on a plain nav key):
+	// pre-encoded xterm sequences, because the pinned vt SendKey drops
+	// modified nav keys (upstream TODO) and their encoding is mode-free.
+	if nav, isNav := modNavKeys[msg.Type]; isNav && (msg.Alt || nav.shift || nav.ctrl) {
+		return translated{raw: nav.xtermSeq(msg.Alt)}, true
+	}
+
+	// Unmodified specials: the emulator's mode-aware encoder.
+	if code, isSimple := simpleKeys[msg.Type]; isSimple {
+		return translated{events: []uv.KeyEvent{uv.KeyPressEvent{Code: code, Mod: mod}}}, true
+	}
+
+	switch {
+	case msg.Type == tea.KeyShiftTab:
+		return translated{events: []uv.KeyEvent{uv.KeyPressEvent{Code: uv.KeyTab, Mod: mod | uv.ModShift}}}, true
+
+	// bubbletea's special KeyTypes are DESCENDING negative constants, so F12
+	// compares smaller than F1.
+	case msg.Type <= tea.KeyF1 && msg.Type >= tea.KeyF12:
+		return translated{events: []uv.KeyEvent{uv.KeyPressEvent{Code: uv.KeyF1 + rune(tea.KeyF1-msg.Type), Mod: mod}}}, true
+
+	// ctrl+letter: the tea v1 KeyType for these IS the ASCII control code
+	// (ctrl+a == 1 … ctrl+z == 26). Tab (ctrl+i), enter (ctrl+m) and escape
+	// (ctrl+[) were consumed by the cases above, so this range is exactly
+	// the remaining control letters.
+	case msg.Type >= tea.KeyCtrlA && msg.Type <= tea.KeyCtrlZ:
+		return translated{events: []uv.KeyEvent{uv.KeyPressEvent{Code: 'a' + rune(msg.Type-tea.KeyCtrlA), Mod: mod | uv.ModCtrl}}}, true
+	}
+
+	if code, isCtrl := ctrlPunct[msg.Type]; isCtrl {
+		return translated{events: []uv.KeyEvent{uv.KeyPressEvent{Code: code, Mod: mod | uv.ModCtrl}}}, true
+	}
+
+	return translated{}, false
+}

--- a/ui/termpane/keymap_test.go
+++ b/ui/termpane/keymap_test.go
@@ -1,0 +1,244 @@
+package termpane
+
+import (
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emuBytes runs f against a bare emulator (after feeding it prep — e.g. mode-
+// setting sequences the inner application would emit) and returns every byte
+// f pushed into the emulator's input pipe. The pipe is synchronous, so a
+// dedicated reader must be running before f writes; the sentinel written
+// afterwards proves the capture drained completely — including the
+// nothing-was-written case the ignore contract depends on.
+func emuBytes(t *testing.T, prep string, f func(emu *vt.Emulator)) string {
+	t.Helper()
+	emu := vt.NewEmulator(80, 24)
+	// Close the input pipe so the reader goroutine below exits — via the
+	// pipe's own writer end, NOT emu.Close(): the pinned x/vt Close sets an
+	// unsynchronized flag that races the reader's concurrent Read (the same
+	// upstream race TermPane.Close designs around).
+	t.Cleanup(func() {
+		if pw, ok := emu.InputPipe().(*io.PipeWriter); ok {
+			_ = pw.CloseWithError(io.EOF)
+		}
+	})
+	if prep != "" {
+		_, err := emu.Write([]byte(prep))
+		require.NoError(t, err)
+	}
+
+	var mu sync.Mutex
+	var got []byte
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, err := emu.Read(buf)
+			if n > 0 {
+				mu.Lock()
+				got = append(got, buf[:n]...)
+				mu.Unlock()
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	f(emu)
+
+	const sentinel = "\x00SENTINEL\x00"
+	emu.SendText(sentinel)
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(got) >= len(sentinel) && string(got[len(got)-len(sentinel):]) == sentinel
+	}, 5*time.Second, time.Millisecond, "input pipe never drained")
+
+	mu.Lock()
+	defer mu.Unlock()
+	return string(got[:len(got)-len(sentinel)])
+}
+
+func runes(s string, alt bool) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s), Alt: alt}
+}
+
+func typed(t tea.KeyType) tea.KeyMsg { return tea.KeyMsg{Type: t} }
+
+func typedAlt(t tea.KeyType) tea.KeyMsg { return tea.KeyMsg{Type: t, Alt: true} }
+
+// TestKeyTranslationTable pins the tea.KeyMsg → PTY-bytes mapping (#1089
+// PR 2): the exact sequences vim/less/agent CLIs will receive. prep feeds the
+// emulator mode-setting sequences first, standing in for the inner
+// application (DECCKM application cursor keys, bracketed paste).
+func TestKeyTranslationTable(t *testing.T) {
+	const (
+		appCursorKeys  = "\x1b[?1h"
+		bracketedPaste = "\x1b[?2004h"
+	)
+	cases := []struct {
+		name string
+		prep string
+		msg  tea.KeyMsg
+		want string
+	}{
+		// Literal text.
+		{name: "rune a", msg: runes("a", false), want: "a"},
+		{name: "rune A", msg: runes("A", false), want: "A"},
+		{name: "multi-rune with accents", msg: runes("héllo", false), want: "héllo"},
+		{name: "alt+x legacy ESC prefix", msg: runes("x", true), want: "\x1bx"},
+		{name: "space", msg: typed(tea.KeySpace), want: " "},
+
+		// Simple specials.
+		{name: "enter", msg: typed(tea.KeyEnter), want: "\r"},
+		{name: "tab forwards (not host focus)", msg: typed(tea.KeyTab), want: "\t"},
+		{name: "shift+tab", msg: typed(tea.KeyShiftTab), want: "\x1b[Z"},
+		{name: "backspace", msg: typed(tea.KeyBackspace), want: "\x7f"},
+		{name: "escape", msg: typed(tea.KeyEscape), want: "\x1b"},
+
+		// Arrows honor DECCKM (vim sets application cursor keys).
+		{name: "up normal", msg: typed(tea.KeyUp), want: "\x1b[A"},
+		{name: "up application mode", prep: appCursorKeys, msg: typed(tea.KeyUp), want: "\x1bOA"},
+		{name: "left normal", msg: typed(tea.KeyLeft), want: "\x1b[D"},
+
+		// Nav block.
+		{name: "home", msg: typed(tea.KeyHome), want: "\x1b[H"},
+		{name: "end", msg: typed(tea.KeyEnd), want: "\x1b[F"},
+		{name: "pgup", msg: typed(tea.KeyPgUp), want: "\x1b[5~"},
+		{name: "pgdown", msg: typed(tea.KeyPgDown), want: "\x1b[6~"},
+		{name: "insert", msg: typed(tea.KeyInsert), want: "\x1b[2~"},
+		{name: "delete", msg: typed(tea.KeyDelete), want: "\x1b[3~"},
+
+		// F-keys.
+		{name: "F1", msg: typed(tea.KeyF1), want: "\x1bOP"},
+		{name: "F5", msg: typed(tea.KeyF5), want: "\x1b[15~"},
+		{name: "F12", msg: typed(tea.KeyF12), want: "\x1b[24~"},
+
+		// Control keys.
+		{name: "ctrl+a", msg: typed(tea.KeyCtrlA), want: "\x01"},
+		{name: "ctrl+c", msg: typed(tea.KeyCtrlC), want: "\x03"},
+		{name: "ctrl+w (full-screen detach key forwards while interactive)", msg: typed(tea.KeyCtrlW), want: "\x17"},
+		{name: "ctrl+z", msg: typed(tea.KeyCtrlZ), want: "\x1a"},
+		{name: "ctrl+@", msg: typed(tea.KeyCtrlAt), want: "\x00"},
+		{name: "ctrl+backslash", msg: typed(tea.KeyCtrlBackslash), want: "\x1c"},
+		{name: "ctrl+underscore", msg: typed(tea.KeyCtrlUnderscore), want: "\x1f"},
+		{name: "alt+ctrl+b", msg: typedAlt(tea.KeyCtrlB), want: "\x1b\x02"},
+
+		// Modifier+navigation family: pre-encoded xterm CSI, the sequences
+		// the pinned x/vt SendKey drops (the spike's swallowed-Ctrl-Up
+		// gotcha). shift=1 alt=2 ctrl=4, param = 1+bits.
+		{name: "ctrl+up", msg: typed(tea.KeyCtrlUp), want: "\x1b[1;5A"},
+		{name: "ctrl+down", msg: typed(tea.KeyCtrlDown), want: "\x1b[1;5B"},
+		{name: "shift+down", msg: typed(tea.KeyShiftDown), want: "\x1b[1;2B"},
+		{name: "shift+right", msg: typed(tea.KeyShiftRight), want: "\x1b[1;2C"},
+		{name: "ctrl+shift+left", msg: typed(tea.KeyCtrlShiftLeft), want: "\x1b[1;6D"},
+		{name: "alt+up", msg: typedAlt(tea.KeyUp), want: "\x1b[1;3A"},
+		{name: "alt+ctrl+right", msg: typedAlt(tea.KeyCtrlRight), want: "\x1b[1;7C"},
+		{name: "shift+home", msg: typed(tea.KeyShiftHome), want: "\x1b[1;2H"},
+		{name: "ctrl+end", msg: typed(tea.KeyCtrlEnd), want: "\x1b[1;5F"},
+		{name: "ctrl+shift+home", msg: typed(tea.KeyCtrlShiftHome), want: "\x1b[1;6H"},
+		{name: "ctrl+pgup", msg: typed(tea.KeyCtrlPgUp), want: "\x1b[5;5~"},
+		{name: "ctrl+pgdown", msg: typed(tea.KeyCtrlPgDown), want: "\x1b[6;5~"},
+		{name: "alt+delete", msg: typedAlt(tea.KeyDelete), want: "\x1b[3;3~"},
+		{name: "alt+insert", msg: typedAlt(tea.KeyInsert), want: "\x1b[2;3~"},
+		// Modified arrows are mode-INDEPENDENT: DECCKM must not change them.
+		{name: "ctrl+up ignores DECCKM", prep: appCursorKeys, msg: typed(tea.KeyCtrlUp), want: "\x1b[1;5A"},
+
+		// Paste rides the emulator's bracketed-paste awareness.
+		{name: "paste plain", msg: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("hi there"), Paste: true}, want: "hi there"},
+		{name: "paste bracketed", prep: bracketedPaste,
+			msg:  tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("hi there"), Paste: true},
+			want: "\x1b[200~hi there\x1b[201~"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := emuBytes(t, tc.prep, func(emu *vt.Emulator) {
+				require.True(t, forwardKey(emu, tc.msg), "key must be encodable")
+			})
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestUncoveredKeysAreIgnoredNotGuessed pins the other half of the #1089
+// input contract: a key with no safe encoding produces NO bytes — never a
+// wrong sequence — and reports itself ignored. ctrl+] is in this set as a
+// tripwire: it is the host's only reserved key while interactive and the app
+// router never forwards it, so an encoding appearing here would silently
+// mask a routing bug.
+func TestUncoveredKeysAreIgnoredNotGuessed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  tea.KeyMsg
+	}{
+		{name: "F13", msg: typed(tea.KeyF13)},
+		{name: "F20", msg: typed(tea.KeyF20)},
+		{name: "ctrl+]", msg: typed(tea.KeyCtrlCloseBracket)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := emuBytes(t, "", func(emu *vt.Emulator) {
+				assert.False(t, forwardKey(emu, tc.msg), "key must report ignored")
+			})
+			assert.Empty(t, got, "an ignored key must emit no bytes")
+		})
+	}
+}
+
+// TestSendKeyReachesThePTY drives the full TermPane path: encoded keystrokes
+// must arrive at the attached process. The scripted PTY runs cat with
+// terminal echo on, so forwarded bytes come straight back through the
+// PTY → emulator pump and land in the grid.
+func TestSendKeyReachesThePTY(t *testing.T) {
+	tp := startScript(t, "cat", 40, 6)
+	for _, r := range "typed-1089" {
+		require.True(t, tp.SendKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}))
+	}
+	waitForRender(t, tp, 40, 6, "typed-1089")
+}
+
+// TestSendKeyNeverBlocksAfterClientDeath pins the pump-drain contract: the
+// emulator's input pipe is unbuffered, so if its pump exited when the attach
+// client died, the SECOND post-death SendKey would block the bubbletea event
+// loop forever (the 100ms reaping tick never getting to run — a frozen TUI).
+func TestSendKeyNeverBlocksAfterClientDeath(t *testing.T) {
+	tp := startScript(t, "printf gone", 20, 4)
+	select {
+	case <-tp.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("scripted client never exited")
+	}
+
+	sent := make(chan struct{})
+	go func() {
+		defer close(sent)
+		for i := 0; i < 50; i++ {
+			tp.SendKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+		}
+	}()
+	select {
+	case <-sent:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SendKey blocked after the attach client died")
+	}
+	require.NoError(t, tp.Close())
+
+	// And after Close (pipe torn down) SendKey still must not block.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tp.SendKey(tea.KeyMsg{Type: tea.KeyEnter})
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SendKey blocked after Close")
+	}
+}

--- a/ui/termpane/render.go
+++ b/ui/termpane/render.go
@@ -14,13 +14,24 @@ import (
 // The caller must hold the lock that guards the emulator against concurrent
 // writes (TermPane.gridMu): CellAt returns pointers into the live buffer.
 //
+// cursorAt marks the cell the terminal cursor occupies so renderGrid can
+// overlay it; cursorNone renders without an overlay.
+type cursorAt struct {
+	x, y int
+	show bool
+}
+
+var cursorNone = cursorAt{}
+
 // Style.Diff keeps the escape output minimal — the same technique as
 // vt.Render(); the row loop is re-implemented here so the pane can guarantee
 // its own width x height contract regardless of the emulator's current size,
-// and so PR 2 can overlay a cursor cell without another rewrite. Each styled
-// line ends with a reset so the styles can never bleed into the host TUI's
-// surrounding chrome.
-func renderGrid(emu *vt.Emulator, width, height int) string {
+// and so the cursor cell can be overlaid (interactive mode, #1089 PR 2): the
+// cursor's cell gets its reverse-video attribute flipped, which reads as a
+// block cursor over any content and any color scheme. Each styled line ends
+// with a reset so the styles can never bleed into the host TUI's surrounding
+// chrome.
+func renderGrid(emu *vt.Emulator, width, height int, cursor cursorAt) string {
 	if width <= 0 || height <= 0 {
 		return ""
 	}
@@ -41,6 +52,9 @@ func renderGrid(emu *vt.Emulator, width, height int) string {
 				// while the emulator is transiently larger than the pane)
 				// would overflow the row: blank it instead.
 				content, cellWidth = " ", 1
+			}
+			if cursor.show && y == cursor.y && x <= cursor.x && cursor.x < x+cellWidth {
+				style.Attrs ^= uv.AttrReverse
 			}
 			sb.WriteString(style.Diff(&prev))
 			prev = style

--- a/ui/termpane/render_test.go
+++ b/ui/termpane/render_test.go
@@ -27,7 +27,7 @@ func TestRenderGridPlainTextAndPadding(t *testing.T) {
 	_, err := emu.Write([]byte("hi"))
 	require.NoError(t, err)
 
-	lines := gridLines(t, renderGrid(emu, 10, 3), 10, 3)
+	lines := gridLines(t, renderGrid(emu, 10, 3, cursorNone), 10, 3)
 	assert.Equal(t, "hi        ", ansi.Strip(lines[0]), "content padded to full width")
 	assert.Equal(t, strings.Repeat(" ", 10), ansi.Strip(lines[1]), "empty rows render as blanks")
 }
@@ -37,7 +37,7 @@ func TestRenderGridCarriesStylesAndResets(t *testing.T) {
 	_, err := emu.Write([]byte("\x1b[31mred\x1b[m plain"))
 	require.NoError(t, err)
 
-	lines := gridLines(t, renderGrid(emu, 12, 2), 12, 2)
+	lines := gridLines(t, renderGrid(emu, 12, 2, cursorNone), 12, 2)
 	assert.Contains(t, lines[0], "31m", "SGR color must survive the grid round-trip")
 	assert.Equal(t, "red plain   ", ansi.Strip(lines[0]))
 }
@@ -49,7 +49,7 @@ func TestRenderGridResetsStyleActiveAtEndOfRow(t *testing.T) {
 	_, err := emu.Write([]byte("\x1b[31mABCDE"))
 	require.NoError(t, err)
 
-	lines := gridLines(t, renderGrid(emu, 5, 1), 5, 1)
+	lines := gridLines(t, renderGrid(emu, 5, 1, cursorNone), 5, 1)
 	assert.True(t, strings.HasSuffix(lines[0], "\x1b[m"), "row must end with a reset, got %q", lines[0])
 }
 
@@ -58,7 +58,7 @@ func TestRenderGridWideCharacters(t *testing.T) {
 	_, err := emu.Write([]byte("日本語"))
 	require.NoError(t, err)
 
-	lines := gridLines(t, renderGrid(emu, 10, 2), 10, 2)
+	lines := gridLines(t, renderGrid(emu, 10, 2, cursorNone), 10, 2)
 	assert.Equal(t, "日本語    ", ansi.Strip(lines[0]), "3 wide glyphs occupy 6 cells + 4 blanks")
 }
 
@@ -70,11 +70,11 @@ func TestRenderGridClipsAndPadsAroundResize(t *testing.T) {
 	_, err := emu.Write([]byte("abcdefghijkl\r\nsecond"))
 	require.NoError(t, err)
 
-	lines := gridLines(t, renderGrid(emu, 6, 2), 6, 2)
+	lines := gridLines(t, renderGrid(emu, 6, 2, cursorNone), 6, 2)
 	assert.Equal(t, "abcdef", ansi.Strip(lines[0]))
 	assert.Equal(t, "second", ansi.Strip(lines[1]))
 
-	gridLines(t, renderGrid(emu, 20, 6), 20, 6)
+	gridLines(t, renderGrid(emu, 20, 6, cursorNone), 20, 6)
 }
 
 func TestRenderGridBlanksWideGlyphStraddlingClipBoundary(t *testing.T) {
@@ -84,13 +84,53 @@ func TestRenderGridBlanksWideGlyphStraddlingClipBoundary(t *testing.T) {
 
 	// Clipping at width 5 lands mid-glyph: the straddling glyph must blank,
 	// never overflow the row.
-	lines := gridLines(t, renderGrid(emu, 5, 1), 5, 1)
+	lines := gridLines(t, renderGrid(emu, 5, 1, cursorNone), 5, 1)
 	assert.Equal(t, "日本 ", ansi.Strip(lines[0]))
 }
 
 func TestRenderGridDegenerateSizes(t *testing.T) {
 	emu := vt.NewEmulator(10, 2)
-	assert.Empty(t, renderGrid(emu, 0, 2))
-	assert.Empty(t, renderGrid(emu, 10, 0))
-	assert.Empty(t, renderGrid(emu, -1, -1))
+	assert.Empty(t, renderGrid(emu, 0, 2, cursorNone))
+	assert.Empty(t, renderGrid(emu, 10, 0, cursorNone))
+	assert.Empty(t, renderGrid(emu, -1, -1, cursorNone))
+}
+
+func TestRenderGridCursorOverlay(t *testing.T) {
+	emu := vt.NewEmulator(10, 2)
+	_, err := emu.Write([]byte("ab"))
+	require.NoError(t, err)
+
+	// Cursor sits at (2,0) after "ab". The overlay flips reverse video on
+	// exactly that cell; without it (nav mode / PR 1 behavior) no reverse
+	// attribute appears anywhere.
+	pos := emu.CursorPosition()
+	withCursor := renderGrid(emu, 10, 2, cursorAt{x: pos.X, y: pos.Y, show: true})
+	assert.Contains(t, withCursor, "\x1b[7m", "cursor cell must render reverse-video")
+	assert.NotContains(t, renderGrid(emu, 10, 2, cursorNone), "\x1b[7m")
+
+	// A cell already reverse-video under the cursor flips BACK, so the
+	// cursor stays visible on reverse-styled content (e.g. a selection bar).
+	emu2 := vt.NewEmulator(10, 1)
+	_, err = emu2.Write([]byte("\x1b[7mXY"))
+	require.NoError(t, err)
+	lines := gridLines(t, renderGrid(emu2, 10, 1, cursorAt{x: 0, y: 0, show: true}), 10, 1)
+	assert.NotContains(t, strings.Split(lines[0], "X")[0], "\x1b[7m",
+		"reverse content under the cursor must flip back to normal")
+}
+
+func TestTermPaneCursorVisibilityTracksDECTCM(t *testing.T) {
+	// The inner application hides the cursor (\x1b[?25l — htop, spinners):
+	// the interactive overlay must follow, or a phantom block cursor floats
+	// over the pane.
+	tp := startScript(t, "printf 'hide\\033[?25l'; sleep 30", 20, 4)
+	waitForRender(t, tp, 20, 4, "hide")
+	assert.NotContains(t, tp.Render(20, 4, true), "\x1b[7m",
+		"hidden cursor must not render even when the pane asks for it")
+
+	tp2 := startScript(t, "printf shown; sleep 30", 20, 4)
+	waitForRender(t, tp2, 20, 4, "shown")
+	assert.Contains(t, tp2.Render(20, 4, true), "\x1b[7m",
+		"visible cursor must overlay while interactive")
+	assert.NotContains(t, tp2.Render(20, 4, false), "\x1b[7m",
+		"nav-mode render stays cursorless")
 }

--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -18,10 +18,12 @@
 // one core (spike §2). Rendering is pulled by the TUI's existing tick/update
 // cycle — this package runs no repaint loop of its own.
 //
-// PR 1 (#1089) is render-only: keystroke forwarding into the PTY is the next
-// PR. The emulator's read side is already pumped back down the PTY, though,
-// so replies to terminal queries (DA, DSR, ...) reach tmux and the attach
-// handshake completes.
+// Interactive mode (#1089 PR 2) forwards focused keystrokes down the same
+// PTY: SendKey translates each bubbletea key message (keymap.go) and hands it
+// to the emulator's mode-aware encoder — or, for the modifier+navigation
+// family the pinned x/vt cannot encode, writes the pre-encoded xterm sequence
+// to the same input pipe — so keystrokes and terminal-query replies (DA, DSR,
+// ...) reach tmux in order through one channel.
 package termpane
 
 import (
@@ -33,6 +35,7 @@ import (
 	"sync"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/vt"
 	"github.com/creack/pty"
 
@@ -66,6 +69,11 @@ type TermPane struct {
 
 	gridMu sync.RWMutex
 	emu    *vt.Emulator
+	// cursorVisible mirrors the terminal's DECTCM state, maintained by the
+	// emulator's CursorVisibility callback — which fires inside emu.Write,
+	// i.e. under gridMu's write lock; Render reads it under the read lock.
+	// Starts true (terminals boot with the cursor shown).
+	cursorVisible bool
 
 	width, height int
 
@@ -123,13 +131,19 @@ func NewWithCommand(cmd *exec.Cmd, width, height int) (*TermPane, error) {
 	}
 
 	t := &TermPane{
-		cmd:    cmd,
-		ptmx:   ptmx,
-		emu:    vt.NewEmulator(width, height),
-		width:  width,
-		height: height,
-		done:   make(chan struct{}),
+		cmd:           cmd,
+		ptmx:          ptmx,
+		emu:           vt.NewEmulator(width, height),
+		cursorVisible: true,
+		width:         width,
+		height:        height,
+		done:          make(chan struct{}),
 	}
+	// The callback fires from emu.Write — always under gridMu's write lock —
+	// so the field write is ordered against Render's locked reads.
+	t.emu.SetCallbacks(vt.Callbacks{
+		CursorVisibility: func(visible bool) { t.cursorVisible = visible },
+	})
 
 	// Reap the client when it exits so it never lingers as a zombie. The
 	// pump goroutines detect exit through the PTY, not through Wait.
@@ -153,12 +167,70 @@ func NewWithCommand(cmd *exec.Cmd, width, height int) (*TermPane, error) {
 		}
 	}()
 
-	// Emulator → PTY: replies to terminal queries from tmux (DA, DSR, ...).
-	// PR 2 sends encoded keystrokes down this same path. Exits when Close
-	// closes the emulator's response pipe (Read then returns EOF).
-	go func() { _, _ = io.Copy(ptmx, t.emu) }()
+	// Emulator → PTY: replies to terminal queries from tmux (DA, DSR, ...)
+	// and the encoded keystrokes SendKey injects. This pump must keep
+	// DRAINING the emulator's pipe even after the PTY write side dies (the
+	// attach client exiting makes the next ptmx.Write fail): the pipe is
+	// unbuffered and synchronous, so a pump that exited on write error would
+	// leave the next SendKey — called on the bubbletea event loop — blocked
+	// on it forever. Discard-once-dead instead; the pump exits when Close
+	// closes the pipe (Read returns an error).
+	go func() {
+		buf := make([]byte, 4096)
+		ptyAlive := true
+		for {
+			n, rerr := t.emu.Read(buf)
+			if n > 0 && ptyAlive {
+				if _, werr := ptmx.Write(buf[:n]); werr != nil {
+					ptyAlive = false
+				}
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
 
 	return t, nil
+}
+
+// SendKey forwards one focused keystroke to the embedded terminal (#1089
+// PR 2, interactive mode): pastes go through the emulator's bracketed-paste-
+// aware Paste, everything else through the keymap.go translation. It reports
+// whether the key was forwarded — false means the key has no safe encoding
+// and was IGNORED (never a guessed byte sequence). Event-loop only; the
+// enclosed pipe write is synchronous but the pump above always drains it.
+//
+// The lock is required even though this only WRITES input: the emulator's
+// encoder reads terminal modes (DECCKM, bracketed paste) that the PTY reader
+// pump mutates through emu.Write.
+func (t *TermPane) SendKey(msg tea.KeyMsg) bool {
+	t.gridMu.RLock()
+	defer t.gridMu.RUnlock()
+	return forwardKey(t.emu, msg)
+}
+
+// forwardKey is SendKey without the pane: translate one key message and emit
+// its bytes into the emulator's input pipe. Factored out so the translation
+// table can be pinned against a bare emulator in tests. The caller holds the
+// lock that guards the emulator's mode state.
+func forwardKey(emu *vt.Emulator, msg tea.KeyMsg) bool {
+	if msg.Paste {
+		emu.Paste(string(msg.Runes))
+		return true
+	}
+	tr, ok := translateKey(msg)
+	if !ok {
+		return false
+	}
+	if tr.raw != "" {
+		_, _ = io.WriteString(emu.InputPipe(), tr.raw)
+		return true
+	}
+	for _, ev := range tr.events {
+		emu.SendKey(ev)
+	}
+	return true
 }
 
 // Resize propagates a new pane geometry: PTY winsize first (tmux reflows on
@@ -182,10 +254,19 @@ func (t *TermPane) Resize(width, height int) {
 // cadence; the TUI's existing tick drives it (no repaint loop here). After
 // the attach client dies the last grid keeps rendering, so a pane shows its
 // final frame until the owner notices Done and swaps render sources.
-func (t *TermPane) Render(width, height int) string {
+//
+// showCursor overlays the terminal cursor (reverse-video on its cell) when
+// the inner application has it visible — the interactive-mode typing cue
+// (#1089 PR 2). Nav-mode panes render without it, exactly like PR 1.
+func (t *TermPane) Render(width, height int, showCursor bool) string {
 	t.gridMu.RLock()
 	defer t.gridMu.RUnlock()
-	return renderGrid(t.emu, width, height)
+	cursor := cursorNone
+	if showCursor && t.cursorVisible {
+		pos := t.emu.CursorPosition()
+		cursor = cursorAt{x: pos.X, y: pos.Y, show: true}
+	}
+	return renderGrid(t.emu, width, height, cursor)
 }
 
 // Done reports attach-client death: the channel is closed once the PTY

--- a/ui/termpane/termpane_test.go
+++ b/ui/termpane/termpane_test.go
@@ -30,7 +30,7 @@ func startScript(t *testing.T, script string, width, height int) *TermPane {
 
 // plainRender is Render with the styling stripped, for content assertions.
 func plainRender(tp *TermPane, width, height int) string {
-	return ansi.Strip(tp.Render(width, height))
+	return ansi.Strip(tp.Render(width, height, false))
 }
 
 func waitForRender(t *testing.T, tp *TermPane, width, height int, want string) {
@@ -91,7 +91,7 @@ func TestScriptedPTYRendersIntoGrid(t *testing.T) {
 	waitForRender(t, tp, 40, 6, "MARKER-1089-preview")
 
 	// The width x height contract holds on live output too.
-	lines := strings.Split(tp.Render(40, 6), "\n")
+	lines := strings.Split(tp.Render(40, 6, false), "\n")
 	require.Len(t, lines, 6)
 	for i, line := range lines {
 		require.Equalf(t, 40, ansi.StringWidth(line), "line %d width", i)


### PR DESCRIPTION
Part of #1089 (PR 2 of the embedded-interactive chain; PR 1 was #1121). Implements the Sachin-confirmed two-mode model from the revised RFC (`docs/design/tui-rewrite.md` §2.3).

## What changes

**Enter on a live pane enters INTERACTIVE mode.** From then on **every** keystroke — including `Tab` — forwards down the pane's termpane PTY to the agent/shell, in place: no full-screen takeover, the instances rail stays visible the whole time. `Ctrl-]` (and only `Ctrl-]`) returns to nav mode. Nav mode is unchanged: `Tab` cycles focus, `1-9` jumps, `s`/`x` open/hide.

**Visual cue:** the keyboard-owning pane gets a green **double** border + green header bar (distinct from the teal rounded nav-focus ring, and still distinct in colorless terminals), the terminal cursor renders inside the pane (reverse-video block, tracking the inner app's DECTCM show/hide), and the status bar collapses to the single honest hint: `ctrl+] nav mode`. A one-time help screen (seen-bitmask, like the attach one) leads with the escape hatch per RFC §5.7.

**Where full-screen attach moved — explicit choice:** the RFC retires full-screen attach as the *primary* interaction (§2.4) and keeps the path intact until R5, but does not prescribe a binding for it once Enter becomes interactive. I chose **`o`**: it was already an Enter alias ("open"), so existing muscle memory keeps working — `o` does exactly what it did before, from the tree and from a focused pane. `Enter` on a binding that **cannot** embed (remote instances — their only local terminal is the hook PTY) also falls back to the full-screen flow, so remote workflows are unchanged.

## Input translation (the spike's long tail)

`ui/termpane/keymap.go` is the single tea.KeyMsg → PTY-bytes boundary, pinned byte-for-byte by `TestKeyTranslationTable` (~50 cases):

- **Default path:** the x/vt emulator's mode-aware `SendKey` encoder — arrows honor DECCKM (`CSI A` ↔ `SS3 A` under vim), pastes go through `Paste` and pick up bracketed-paste wrapping exactly when the inner app enabled it. No hand-written sequences where a terminal mode could change the answer.
- **Modifier+navigation family** (the spike's swallowed-Ctrl-Up gotcha): the pinned x/vt drops modified nav keys (upstream TODO), so `ctrl/shift/alt + arrows/Home/End/PgUp/PgDn/Ins/Del` are pre-encoded as standard xterm `CSI 1;{mod}X` / `CSI {n};{mod}~` — mode-independent by spec, so pre-encoding cannot go stale.
- **Honestly NOT forwarded** (ignored — zero bytes, never a wrong sequence; pinned by `TestUncoveredKeysAreIgnoredNotGuessed`):
  - `F13`–`F20` (no portable encoding across terminals)
  - `ctrl+]` — host-reserved by design; deliberately absent from the table as a tripwire
  - mouse events (explicitly out of scope; next PR per RFC §2.5)

## Robustness

- **Pump fix:** the emulator→PTY pump now keeps draining the (unbuffered, synchronous) input pipe after the attach client dies; previously a dead client would leave the next `SendKey` blocked on the pipe **forever — on the bubbletea event loop**. Pinned by `TestSendKeyNeverBlocksAfterClientDeath`.
- **Mode invariant:** interactive mode means "the focused pane's live attachment is healthy". A dead client, a hidden/pruned pane, or an auto-hide relayout drops back to nav (at most one 100ms tick; the very next keystroke also re-checks and is swallowed rather than mistyped). Overlays opened by async events (instance-started help) still own the keyboard, exactly as in nav.
- `go-runewidth` and the whole x/vt dep tree are **untouched** — zero `go.mod` changes in this PR.
- Wheel is inert while interactive (host scroll would flip the live pane into capture scroll-mode mid-typing; in-pane forwarding is the mouse PR's call).

## Tests

- `ui/termpane`: pinned translation table incl. DECCKM/bracketed-paste mode cases + ignore contract; PTY echo round-trip (`SendKey` → grid); no-block-after-death; cursor overlay + DECTCM tracking (`-race` clean).
- `app`: enter via pane focus / via tree row (opens pane first), all-keys-forward incl. `tab`/`q`/`1`/`ctrl+c`/`ctrl+w`, `ctrl+]` exit (focus stays on pane, attachment kept), client-death and pane-close mode exits, remote fallback to full-screen, `o` attach, first-time help gating, inert wheel.
- `ui`: interactive frame/header cue + cursor-request flag; menu escape-hatch bar.

## Gate

- `golangci-lint run --timeout=3m --fast` clean, `gofmt -l .` empty, `deadcode -test ./...` empty, `go build ./...` ok
- `make test-container`: full suite green (app/daemon/integration/session/tmux/ui all ok)
- targeted `-race` runs green (`-p=1 -parallel 2` per dev-box constraints)

Not merged pending root verification + the docker play-test gate (visible TUI PR).

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)