### PR TITLE
daemon: durable per-task watch-event queue — enqueue on failure, replay in order (#1129 PR 3)

### DIFF
--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -120,7 +120,11 @@ func (q *eventQueue) load() {
 	}
 
 	// Count the pending events and recover the sequence counter. The pending
-	// suffix is bounded by watcherQueueMaxBytes, so this scan is cheap.
+	// suffix is bounded by watcherQueueMaxBytes, so this scan is cheap. A
+	// bufio.Reader (not a Scanner) on purpose: JSON-escaping can inflate a
+	// maxWatchLineBytes line severalfold, and a Scanner's token cap would make
+	// the count silently stop at the first oversized record — losing exactly
+	// the events durability promised to keep.
 	f, err := os.Open(q.path)
 	if err != nil {
 		return
@@ -129,12 +133,29 @@ func (q *eventQueue) load() {
 	if _, err := f.Seek(q.offset, 0); err != nil {
 		return
 	}
-	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 0, 64*1024), maxWatchLineBytes+1024)
-	for sc.Scan() {
+	br := bufio.NewReaderSize(f, 64*1024)
+	scanned := q.offset
+	for {
+		raw, err := br.ReadBytes('\n')
+		if err != nil {
+			if len(raw) > 0 {
+				// A trailing record with no newline is a torn append (daemon
+				// died mid-write). It was never fully enqueued; truncate it
+				// away so the next append starts on a record boundary instead
+				// of gluing two records into one corrupt line.
+				log.WarningLog.Printf("watch task %s: discarding %d bytes of torn trailing event-queue record", q.taskID, len(raw))
+				if terr := os.Truncate(q.path, scanned); terr != nil {
+					log.WarningLog.Printf("watch task %s: failed to truncate torn event-queue tail: %v", q.taskID, terr)
+				} else {
+					q.size = scanned
+				}
+			}
+			return
+		}
+		scanned += int64(len(raw))
 		q.pending++
 		var ev queuedEvent
-		if err := json.Unmarshal(sc.Bytes(), &ev); err == nil && ev.Seq > q.seq {
+		if uerr := json.Unmarshal(raw, &ev); uerr == nil && ev.Seq > q.seq {
 			q.seq = ev.Seq
 		}
 	}
@@ -167,10 +188,20 @@ func (q *eventQueue) enqueue(line string) error {
 	if closeErr := f.Close(); err == nil {
 		err = closeErr
 	}
-	q.size += int64(n)
 	if err != nil {
+		// A short write would leave a torn record that corrupts the NEXT
+		// append; truncate back to the last record boundary so the file stays
+		// record-aligned (the caller drops this event — same degradation as
+		// enqueue failing outright).
+		if n > 0 {
+			if terr := os.Truncate(q.path, q.size); terr != nil {
+				log.WarningLog.Printf("watch task %s: failed to truncate short-written event record: %v", q.taskID, terr)
+				q.size += int64(n)
+			}
+		}
 		return err
 	}
+	q.size += int64(n)
 	q.pending++
 
 	return q.dropOldestOverCapsLocked()

--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -1,0 +1,280 @@
+package daemon
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// Durable per-task event queue (#1129). When a watch-task event's delivery
+// fails — e.g. every event fired while sessions were unreachable during a tmux
+// outage (#1104/#1122) — the event is appended here instead of dropped, and a
+// stop-aware drainer replays the backlog in emission order once deliveries
+// succeed again. The healthy path never touches the queue: the first delivery
+// attempt stays synchronous on the watcher's reader goroutine, preserving the
+// backpressure/ordering contract.
+//
+// Layout: <AF home>/events/<taskID>.jsonl holds one JSON event per line;
+// <taskID>.cursor holds the byte offset of the first undelivered event, so a
+// pop is a cursor advance, not a file rewrite. Both files are removed whenever
+// the queue fully drains. The cursor is written AFTER the delivery it
+// acknowledges, so a daemon crash mid-replay redelivers at most one event —
+// at-least-once by design; exactly-once machinery is not worth building for a
+// prompt-delivery system.
+//
+// Only the owning daemon touches these files (one daemon per AF home), and
+// within it the reader goroutine enqueues while the drainer dequeues — q.mu
+// serializes them, no cross-process file lock needed.
+
+const (
+	// watcherQueueMaxEvents/watcherQueueMaxBytes bound one task's undelivered
+	// backlog across a long outage. On overflow the OLDEST events are dropped:
+	// after an outage the newest events are the actionable ones, and the
+	// oldest are the most likely to have been re-swept by the script's next
+	// poll. Drops are logged with the same one-warning-per-minute pattern as
+	// the rate limiter, with a running counter.
+	watcherQueueMaxEvents = 500
+	watcherQueueMaxBytes  = 256 * 1024
+)
+
+// queuedEvent is the on-disk record: the raw stdout line plus a per-queue
+// sequence number and enqueue timestamp for diagnostics (and the PR-4
+// age-based retention).
+type queuedEvent struct {
+	Seq  int64     `json:"seq"`
+	TS   time.Time `json:"ts"`
+	Line string    `json:"line"`
+}
+
+// eventQueue is one task's durable backlog. Zero pending events is the steady
+// state: no files on disk, every field zero.
+type eventQueue struct {
+	taskID  string
+	path    string // <dir>/<taskID>.jsonl
+	curPath string // <dir>/<taskID>.cursor
+
+	mu      sync.Mutex
+	offset  int64 // byte offset of the first undelivered event
+	size    int64 // total bytes in the jsonl file
+	pending int   // undelivered event count
+	seq     int64 // last sequence number handed out
+
+	dropped     int // events dropped to the overflow caps, for the drop log
+	lastDropLog time.Time
+}
+
+// eventQueueDir resolves the queue directory, creating it on first use.
+func eventQueueDir() (string, error) {
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(configDir, "events")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// newEventQueue opens (or initializes) the queue for taskID under dir,
+// recovering offset/pending from any files a previous daemon left behind —
+// which is what lets a backlog survive a daemon restart or reload.
+func newEventQueue(dir, taskID string) *eventQueue {
+	q := &eventQueue{
+		taskID:  taskID,
+		path:    filepath.Join(dir, taskID+".jsonl"),
+		curPath: filepath.Join(dir, taskID+".cursor"),
+	}
+	q.load()
+	return q
+}
+
+// load recovers the queue state from disk. A missing file is an empty queue; a
+// corrupt cursor resets to 0 (redelivering pending events — at-least-once,
+// never silent loss).
+func (q *eventQueue) load() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	info, err := os.Stat(q.path)
+	if err != nil {
+		return // no queue file: empty queue
+	}
+	q.size = info.Size()
+
+	if raw, err := os.ReadFile(q.curPath); err == nil {
+		if off, err := strconv.ParseInt(strings.TrimSpace(string(raw)), 10, 64); err == nil && off >= 0 && off <= q.size {
+			q.offset = off
+		} else {
+			log.WarningLog.Printf("watch task %s: corrupt event-queue cursor; replaying the queue from the start", q.taskID)
+		}
+	}
+
+	// Count the pending events and recover the sequence counter. The pending
+	// suffix is bounded by watcherQueueMaxBytes, so this scan is cheap.
+	f, err := os.Open(q.path)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Seek(q.offset, 0); err != nil {
+		return
+	}
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), maxWatchLineBytes+1024)
+	for sc.Scan() {
+		q.pending++
+		var ev queuedEvent
+		if err := json.Unmarshal(sc.Bytes(), &ev); err == nil && ev.Seq > q.seq {
+			q.seq = ev.Seq
+		}
+	}
+}
+
+// pendingCount reports how many undelivered events the queue holds.
+func (q *eventQueue) pendingCount() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.pending
+}
+
+// enqueue appends one event and enforces the overflow caps by dropping oldest
+// pending events past them.
+func (q *eventQueue) enqueue(line string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.seq++
+	rec, err := json.Marshal(queuedEvent{Seq: q.seq, TS: time.Now(), Line: line})
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(q.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	rec = append(rec, '\n')
+	n, err := f.Write(rec)
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	q.size += int64(n)
+	if err != nil {
+		return err
+	}
+	q.pending++
+
+	return q.dropOldestOverCapsLocked()
+}
+
+// dropOldestOverCapsLocked advances the cursor past the oldest pending events
+// until the backlog fits the count/byte caps. Callers hold q.mu.
+func (q *eventQueue) dropOldestOverCapsLocked() error {
+	droppedNow := 0
+	for q.pending > watcherQueueMaxEvents || q.size-q.offset > watcherQueueMaxBytes {
+		if q.pending <= 1 {
+			// Always retain the newest event, even one over the byte cap on
+			// its own (enqueue callers cap lines at maxWatchLineBytes).
+			break
+		}
+		_, n, err := q.readEventAtLocked(q.offset)
+		if err != nil {
+			return err
+		}
+		q.offset += n
+		q.pending--
+		droppedNow++
+	}
+	if droppedNow == 0 {
+		return nil
+	}
+	q.dropped += droppedNow
+	if now := time.Now(); now.Sub(q.lastDropLog) >= time.Minute {
+		q.lastDropLog = now
+		// One warning per window, not per drop — mirroring the rate limiter's
+		// log discipline; the counter keeps the exact total.
+		log.WarningLog.Printf("watch task %s: event queue over its cap (%d events / %d bytes); dropped %d oldest queued events (%d dropped total)",
+			q.taskID, watcherQueueMaxEvents, watcherQueueMaxBytes, droppedNow, q.dropped)
+	}
+	return q.persistCursorLocked()
+}
+
+// peek returns the oldest undelivered event and its on-disk length without
+// consuming it. ok is false when the queue is empty.
+func (q *eventQueue) peek() (ev queuedEvent, n int64, ok bool, err error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.pending == 0 {
+		return queuedEvent{}, 0, false, nil
+	}
+	ev, n, err = q.readEventAtLocked(q.offset)
+	if err != nil {
+		return queuedEvent{}, 0, false, err
+	}
+	return ev, n, true, nil
+}
+
+// advance consumes the oldest event AFTER its successful delivery: cursor
+// forward by the length peek reported, files removed once fully drained.
+func (q *eventQueue) advance(n int64) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.pending == 0 {
+		return nil
+	}
+	q.offset += n
+	q.pending--
+	if q.pending == 0 {
+		// Fully drained: reclaim the delivered prefix by removing both files —
+		// the steady healthy state is no queue files at all.
+		q.offset, q.size = 0, 0
+		if err := os.Remove(q.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.Remove(q.curPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	return q.persistCursorLocked()
+}
+
+// readEventAtLocked reads and parses one JSONL record at the given offset,
+// returning the record and its length including the newline. Callers hold
+// q.mu. A corrupt or truncated record is an error — the drainer logs and
+// parks rather than guessing at boundaries.
+func (q *eventQueue) readEventAtLocked(off int64) (queuedEvent, int64, error) {
+	f, err := os.Open(q.path)
+	if err != nil {
+		return queuedEvent{}, 0, err
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Seek(off, 0); err != nil {
+		return queuedEvent{}, 0, err
+	}
+	br := bufio.NewReaderSize(f, 64*1024)
+	raw, err := br.ReadBytes('\n')
+	if err != nil {
+		return queuedEvent{}, 0, fmt.Errorf("truncated event record at offset %d: %w", off, err)
+	}
+	var ev queuedEvent
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		return queuedEvent{}, 0, fmt.Errorf("corrupt event record at offset %d: %w", off, err)
+	}
+	return ev, int64(len(raw)), nil
+}
+
+// persistCursorLocked writes the cursor file. Atomic (write+rename) so a torn
+// write can never yield a cursor pointing mid-record. Callers hold q.mu.
+func (q *eventQueue) persistCursorLocked() error {
+	return config.AtomicWriteFile(q.curPath, []byte(strconv.FormatInt(q.offset, 10)), 0644)
+}

--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -1,0 +1,297 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// TestEventQueue_EnqueuePeekAdvanceRoundTrip pins the queue's core contract:
+// strict FIFO across enqueue/peek/advance, and both files removed once the
+// backlog fully drains (the steady healthy state is no queue files at all).
+func TestEventQueue_EnqueuePeekAdvanceRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab120001")
+
+	for i := 0; i < 3; i++ {
+		if err := q.enqueue(fmt.Sprintf("event-%d", i)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	if got := q.pendingCount(); got != 3 {
+		t.Fatalf("pending = %d, want 3", got)
+	}
+
+	for i := 0; i < 3; i++ {
+		ev, n, ok, err := q.peek()
+		if err != nil || !ok {
+			t.Fatalf("peek %d: ok=%v err=%v", i, ok, err)
+		}
+		if want := fmt.Sprintf("event-%d", i); ev.Line != want {
+			t.Fatalf("peek %d = %q, want %q (FIFO order)", i, ev.Line, want)
+		}
+		if err := q.advance(n); err != nil {
+			t.Fatalf("advance %d: %v", i, err)
+		}
+	}
+
+	if got := q.pendingCount(); got != 0 {
+		t.Fatalf("pending after drain = %d, want 0", got)
+	}
+	for _, p := range []string{q.path, q.curPath} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("drained queue must remove %s", filepath.Base(p))
+		}
+	}
+}
+
+// TestEventQueue_RecoversAcrossReopen: a partially drained backlog written by
+// one eventQueue is recovered by a fresh one over the same files — the daemon
+// restart / reload shape. The cursor keeps delivered events delivered.
+func TestEventQueue_RecoversAcrossReopen(t *testing.T) {
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab120002")
+	for i := 0; i < 3; i++ {
+		if err := q.enqueue(fmt.Sprintf("event-%d", i)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	_, n, ok, err := q.peek()
+	if err != nil || !ok {
+		t.Fatalf("peek: ok=%v err=%v", ok, err)
+	}
+	if err := q.advance(n); err != nil { // deliver event-0
+		t.Fatalf("advance: %v", err)
+	}
+
+	reopened := newEventQueue(dir, "ab120002")
+	if got := reopened.pendingCount(); got != 2 {
+		t.Fatalf("recovered pending = %d, want 2", got)
+	}
+	ev, _, ok, err := reopened.peek()
+	if err != nil || !ok {
+		t.Fatalf("reopened peek: ok=%v err=%v", ok, err)
+	}
+	if ev.Line != "event-1" {
+		t.Fatalf("reopened head = %q, want event-1 (cursor must survive reopen)", ev.Line)
+	}
+}
+
+// TestEventQueue_CorruptCursorReplaysFromStart: an unparseable cursor resets
+// to 0 — redelivering pending events (at-least-once) rather than guessing or
+// silently losing the backlog.
+func TestEventQueue_CorruptCursorReplaysFromStart(t *testing.T) {
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab120003")
+	for i := 0; i < 2; i++ {
+		if err := q.enqueue(fmt.Sprintf("event-%d", i)); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	if err := os.WriteFile(q.curPath, []byte("not-a-number"), 0644); err != nil {
+		t.Fatalf("corrupt cursor: %v", err)
+	}
+
+	reopened := newEventQueue(dir, "ab120003")
+	if got := reopened.pendingCount(); got != 2 {
+		t.Fatalf("pending after corrupt cursor = %d, want 2 (replay from start)", got)
+	}
+	ev, _, ok, err := reopened.peek()
+	if err != nil || !ok || ev.Line != "event-0" {
+		t.Fatalf("head after corrupt cursor = %q ok=%v err=%v, want event-0", ev.Line, ok, err)
+	}
+}
+
+// TestEventQueue_DropsOldestOverEventCap: the backlog is bounded; overflow
+// drops the OLDEST pending events (newest are the actionable ones after an
+// outage) and counts the drops.
+func TestEventQueue_DropsOldestOverEventCap(t *testing.T) {
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab120004")
+	for i := 0; i < watcherQueueMaxEvents+7; i++ {
+		if err := q.enqueue(fmt.Sprintf("event-%d", i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+	if got := q.pendingCount(); got != watcherQueueMaxEvents {
+		t.Fatalf("pending = %d, want the %d cap", got, watcherQueueMaxEvents)
+	}
+	ev, _, ok, err := q.peek()
+	if err != nil || !ok {
+		t.Fatalf("peek: ok=%v err=%v", ok, err)
+	}
+	if ev.Line != "event-7" {
+		t.Fatalf("head = %q, want event-7 (the 7 oldest must have been dropped)", ev.Line)
+	}
+	q.mu.Lock()
+	dropped := q.dropped
+	q.mu.Unlock()
+	if dropped != 7 {
+		t.Fatalf("dropped counter = %d, want 7", dropped)
+	}
+}
+
+// flakyDeliver fails every delivery until healed, then records successes. It
+// drives the outage→recovery shape end to end through a real watcher.
+type flakyDeliver struct {
+	mu      sync.Mutex
+	healed  atomic.Bool
+	success []string
+}
+
+func (d *flakyDeliver) deliver(taskID, line string) error {
+	if !d.healed.Load() {
+		return errors.New("target unreachable (outage)")
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.success = append(d.success, line)
+	return nil
+}
+
+func (d *flakyDeliver) delivered() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.success...)
+}
+
+// TestWatcherQueuesFailedDeliveriesAndReplaysInOrder is the #1129 core: events
+// fired while deliveries fail are queued — including newer events emitted
+// while a backlog exists (FIFO gating; they must never jump the queue) — and
+// once deliveries succeed the whole backlog replays in emission order. The
+// drained queue leaves no files behind.
+func TestWatcherQueuesFailedDeliveriesAndReplaysInOrder(t *testing.T) {
+	dir := t.TempDir()
+	script := `echo e1; echo e2; echo e3; sleep 60`
+	s, _ := newTestSupervisor(t, staticTasks(watchTask("ab130001", script, dir)))
+	fd := &flakyDeliver{}
+	s.deliver = fd.deliver
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	// All three events fire during the outage; nothing may be delivered.
+	queueDir, _ := s.queueDir()
+	waitUntil(t, 10*time.Second, "all three events to be queued", func() bool {
+		return newEventQueue(queueDir, "ab130001").pendingCount() == 3
+	})
+	if got := fd.delivered(); len(got) != 0 {
+		t.Fatalf("nothing must be delivered during the outage, got %v", got)
+	}
+
+	// Outage ends: the drainer replays the backlog in emission order.
+	fd.healed.Store(true)
+	waitUntil(t, 10*time.Second, "backlog to replay in order", func() bool {
+		got := fd.delivered()
+		return len(got) == 3 && got[0] == "e1" && got[1] == "e2" && got[2] == "e3"
+	})
+
+	waitUntil(t, 10*time.Second, "drained queue files to be removed", func() bool {
+		_, err1 := os.Stat(filepath.Join(queueDir, "ab130001.jsonl"))
+		_, err2 := os.Stat(filepath.Join(queueDir, "ab130001.cursor"))
+		return os.IsNotExist(err1) && os.IsNotExist(err2)
+	})
+}
+
+// TestWatcherBacklogSurvivesRestart: a backlog left behind by one supervisor
+// (daemon lifetime) is recovered and replayed by the next — even though the
+// script emits nothing new. This is the outage-spans-a-daemon-restart shape.
+func TestWatcherBacklogSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+
+	// First daemon lifetime: deliveries fail, three events queue, then stop.
+	s1, _ := newTestSupervisor(t, staticTasks(watchTask("ab130002", `echo e1; echo e2; echo e3; sleep 60`, dir)))
+	fd1 := &flakyDeliver{}
+	s1.deliver = fd1.deliver
+	queueDir, _ := s1.queueDir()
+	if err := s1.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "backlog to persist", func() bool {
+		return newEventQueue(queueDir, "ab130002").pendingCount() == 3
+	})
+	s1.Stop()
+
+	// Second daemon lifetime: same queue dir, healthy deliveries, and a
+	// script that emits nothing — replay must come purely from the recovered
+	// backlog.
+	s2, _ := newTestSupervisor(t, staticTasks(watchTask("ab130002", `sleep 60`, dir)))
+	fd2 := &flakyDeliver{}
+	fd2.healed.Store(true)
+	s2.deliver = fd2.deliver
+	s2.queueDir = func() (string, error) { return queueDir, nil }
+	if err := s2.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "recovered backlog to replay in order", func() bool {
+		got := fd2.delivered()
+		return len(got) == 3 && got[0] == "e1" && got[1] == "e2" && got[2] == "e3"
+	})
+}
+
+// TestWatcherStopJoinsDrainer: a stop/reload arriving mid-backoff must return
+// promptly — the drainer's waits are all stop-aware, extending the #769/#797
+// nothing-wedges-a-stop contract to the replay path.
+func TestWatcherStopJoinsDrainer(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := newTestSupervisor(t, staticTasks(watchTask("ab130003", `echo e1; sleep 60`, dir)))
+	fd := &flakyDeliver{} // never healed: the drainer is stuck retrying
+	s.deliver = fd.deliver
+	s.drainBaseBackoff = time.Hour // park the drainer deep in a backoff wait
+	s.drainMaxBackoff = time.Hour
+	queueDir, _ := s.queueDir()
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "event to be queued", func() bool {
+		return newEventQueue(queueDir, "ab130003").pendingCount() == 1
+	})
+
+	done := make(chan struct{})
+	go func() {
+		s.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop wedged on the drainer's backoff wait")
+	}
+}
+
+// TestWatcherReloadRemovesDeletedTaskQueue: a deleted task's backlog is
+// removed on reload (it must not replay into a recreated namesake), while a
+// merely-disabled task keeps its backlog for re-enable.
+func TestWatcherReloadRemovesDeletedTaskQueue(t *testing.T) {
+	dir := t.TempDir()
+	disabled := task.Task{ID: "ab130004", Name: "w", WatchCmd: "sleep 60", ProjectPath: dir, Enabled: false}
+	s, _ := newTestSupervisor(t, staticTasks(disabled))
+	queueDir, _ := s.queueDir()
+
+	for _, id := range []string{"ab130004", "deadbeef"} {
+		q := newEventQueue(queueDir, id)
+		if err := q.enqueue("pending"); err != nil {
+			t.Fatalf("seed queue %s: %v", id, err)
+		}
+	}
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(queueDir, "ab130004.jsonl")); err != nil {
+		t.Fatalf("disabled task's backlog must survive reload: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(queueDir, "deadbeef.jsonl")); !os.IsNotExist(err) {
+		t.Fatal("deleted task's backlog must be removed on reload")
+	}
+}

--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -106,6 +107,105 @@ func TestEventQueue_CorruptCursorReplaysFromStart(t *testing.T) {
 	ev, _, ok, err := reopened.peek()
 	if err != nil || !ok || ev.Line != "event-0" {
 		t.Fatalf("head after corrupt cursor = %q ok=%v err=%v, want event-0", ev.Line, ok, err)
+	}
+}
+
+// TestEventQueue_MaxLineEscapeHeavyRoundTrip is the Greptile P1 regression on
+// #1136: a maxWatchLineBytes line whose JSON-escaped record is several times
+// larger (quotes, backslashes, control chars, multibyte at the boundary) must
+// survive enqueue → reopen → peek → advance intact. The original load() used a
+// bufio.Scanner whose token cap sat just above the RAW line size, so an
+// escape-inflated record silently ended the recovery scan — losing exactly the
+// events durability promised to keep.
+func TestEventQueue_MaxLineEscapeHeavyRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab120005")
+
+	// Escape-heavy body: every 4-byte unit escapes to ~14 JSON bytes
+	// (`"` → \", `\` → \\, tab → \t, 0x01 → ), inflating well past any
+	// 64KB token cap; a multibyte rune lands at the very end of the cap.
+	unit := "\"\\\t\x01"
+	body := strings.Repeat(unit, (maxWatchLineBytes-4)/len(unit))
+	line := body + "…" // 3-byte rune at the tail
+	if len(line) > maxWatchLineBytes {
+		t.Fatalf("test bug: line %d bytes exceeds the %d cap", len(line), maxWatchLineBytes)
+	}
+
+	if err := q.enqueue("first"); err != nil {
+		t.Fatalf("enqueue first: %v", err)
+	}
+	if err := q.enqueue(line); err != nil {
+		t.Fatalf("enqueue max line: %v", err)
+	}
+	if err := q.enqueue("last"); err != nil {
+		t.Fatalf("enqueue last: %v", err)
+	}
+
+	// Reopen: recovery must count all three records despite the oversized one.
+	reopened := newEventQueue(dir, "ab120005")
+	if got := reopened.pendingCount(); got != 3 {
+		t.Fatalf("recovered pending = %d, want 3 (oversized record must not end the scan)", got)
+	}
+	for _, want := range []string{"first", line, "last"} {
+		ev, n, ok, err := reopened.peek()
+		if err != nil || !ok {
+			t.Fatalf("peek: ok=%v err=%v", ok, err)
+		}
+		if ev.Line != want {
+			t.Fatalf("replayed line corrupted: got %d bytes, want %d bytes (first divergence at %d)",
+				len(ev.Line), len(want), firstDivergence(ev.Line, want))
+		}
+		if err := reopened.advance(n); err != nil {
+			t.Fatalf("advance: %v", err)
+		}
+	}
+}
+
+func firstDivergence(a, b string) int {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return min(len(a), len(b))
+}
+
+// TestEventQueue_TornTrailingRecordTruncated: a torn append (daemon died
+// mid-write, no trailing newline) is discarded on reopen and the file
+// truncated back to a record boundary, so the next enqueue cannot glue two
+// records into one corrupt line.
+func TestEventQueue_TornTrailingRecordTruncated(t *testing.T) {
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab120006")
+	if err := q.enqueue("whole"); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	f, err := os.OpenFile(q.path, os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := f.WriteString(`{"seq":2,"ts":"2026-07-04T`); err != nil { // no newline: torn
+		t.Fatalf("write torn tail: %v", err)
+	}
+	_ = f.Close()
+
+	reopened := newEventQueue(dir, "ab120006")
+	if got := reopened.pendingCount(); got != 1 {
+		t.Fatalf("pending = %d, want 1 (torn tail is not an event)", got)
+	}
+	if err := reopened.enqueue("after"); err != nil {
+		t.Fatalf("enqueue after torn tail: %v", err)
+	}
+	ev, n, ok, err := reopened.peek()
+	if err != nil || !ok || ev.Line != "whole" {
+		t.Fatalf("head = %q ok=%v err=%v, want whole", ev.Line, ok, err)
+	}
+	if err := reopened.advance(n); err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	ev, _, ok, err = reopened.peek()
+	if err != nil || !ok || ev.Line != "after" {
+		t.Fatalf("second record = %q ok=%v err=%v, want intact %q", ev.Line, ok, err, "after")
 	}
 }
 

--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -35,6 +35,11 @@ import (
 //   - ≥5 non-zero exits within 10 minutes = crash loop (status "errored",
 //     restarts stop until the next reload)
 //   - events above 10/min per task are dropped with a logged warning
+//   - a failed delivery queues the event durably and a stop-aware drainer
+//     replays the backlog in order — before newer live events — once
+//     deliveries succeed again, rate-limited by the same 10/min window;
+//     the backlog is bounded (oldest dropped past 500 events / 256KB, with
+//     a logged count) and survives daemon restarts (#1129)
 //   - each run buffers its recent output (last 10 lines / 2KB: stdout lines
 //     that did not become delivered events, plus stderr). Non-zero exits log
 //     that tail, and the crash-loop breaker persists "errored: <exit>:
@@ -67,6 +72,14 @@ const (
 	// breaker persists into the task's last_run_status, so tasks.json and
 	// the TUI detail row stay readable.
 	watcherStatusSummaryMax = 256
+
+	// watcherDrainBaseBackoff/watcherDrainMaxBackoff pace the event-queue
+	// drainer's retries after a failed replay delivery (#1129): 10s doubling
+	// to 5m, then settling at the 5m cadence for as long as the failure
+	// persists — the #1128 never-give-up discipline, because an outage is
+	// indistinguishable from a broken target while it lasts.
+	watcherDrainBaseBackoff = 10 * time.Second
+	watcherDrainMaxBackoff  = 5 * time.Minute
 )
 
 // truncateRunes returns s limited to at most maxBytes bytes, cut on a UTF-8
@@ -96,36 +109,43 @@ type watcherSupervisor struct {
 	watchers map[string]*taskWatcher // task ID → supervised watcher
 
 	// Injection points for tests: loadTasks substitutes fixture task lists,
-	// deliver observes events without spawning sessions, and setStatus
-	// observes lifecycle statuses without a task store.
+	// deliver observes events without spawning sessions, setStatus observes
+	// lifecycle statuses without a task store, and queueDir redirects the
+	// durable event queues to a scratch directory.
 	loadTasks func() ([]task.Task, error)
 	deliver   func(taskID, line string) error
 	setStatus func(taskID, status string)
 	logPath   func(taskID string) (string, error)
+	queueDir  func() (string, error)
 
-	shell           string
-	baseBackoff     time.Duration
-	maxBackoff      time.Duration
-	crashWindow     time.Duration
-	crashMaxExits   int
-	eventsPerMinute int
-	stopGrace       time.Duration
+	shell            string
+	baseBackoff      time.Duration
+	maxBackoff       time.Duration
+	crashWindow      time.Duration
+	crashMaxExits    int
+	eventsPerMinute  int
+	stopGrace        time.Duration
+	drainBaseBackoff time.Duration
+	drainMaxBackoff  time.Duration
 }
 
 func newWatcherSupervisor() *watcherSupervisor {
 	return &watcherSupervisor{
-		watchers:        make(map[string]*taskWatcher),
-		loadTasks:       task.LoadTasks,
-		deliver:         deliverWatchEvent,
-		setStatus:       persistWatcherStatus,
-		logPath:         watcherLogPath,
-		shell:           watcherShell(),
-		baseBackoff:     watcherBaseBackoff,
-		maxBackoff:      watcherMaxBackoff,
-		crashWindow:     watcherCrashWindow,
-		crashMaxExits:   watcherCrashMaxExits,
-		eventsPerMinute: watcherEventsPerMinute,
-		stopGrace:       watcherStopGrace,
+		watchers:         make(map[string]*taskWatcher),
+		loadTasks:        task.LoadTasks,
+		deliver:          deliverWatchEvent,
+		setStatus:        persistWatcherStatus,
+		logPath:          watcherLogPath,
+		queueDir:         eventQueueDir,
+		shell:            watcherShell(),
+		baseBackoff:      watcherBaseBackoff,
+		maxBackoff:       watcherMaxBackoff,
+		crashWindow:      watcherCrashWindow,
+		crashMaxExits:    watcherCrashMaxExits,
+		eventsPerMinute:  watcherEventsPerMinute,
+		stopGrace:        watcherStopGrace,
+		drainBaseBackoff: watcherDrainBaseBackoff,
+		drainMaxBackoff:  watcherDrainMaxBackoff,
 	}
 }
 
@@ -182,7 +202,43 @@ func (s *watcherSupervisor) Reload() error {
 		s.watchers[id] = w
 		go w.run()
 	}
+
+	// Queue files for tasks that no longer exist at all are removed — a
+	// deleted task's backlog must not replay into a recreated namesake. A
+	// merely-disabled task keeps its backlog for re-enable (#1129). Runs after
+	// stopWatchers so no stale drainer is mid-replay on a file being removed.
+	s.cleanOrphanQueues(tasks)
 	return nil
+}
+
+// cleanOrphanQueues removes event-queue files whose task ID is absent from
+// tasks.json entirely.
+func (s *watcherSupervisor) cleanOrphanQueues(tasks []task.Task) {
+	dir, err := s.queueDir()
+	if err != nil {
+		return
+	}
+	known := make(map[string]struct{}, len(tasks))
+	for _, t := range tasks {
+		known[t.ID] = struct{}{}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		id := strings.TrimSuffix(strings.TrimSuffix(name, ".jsonl"), ".cursor")
+		if id == name { // neither suffix matched
+			continue
+		}
+		if _, ok := known[id]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, name)); err != nil && !os.IsNotExist(err) {
+			log.WarningLog.Printf("failed to remove orphan event-queue file %s: %v", name, err)
+		}
+	}
 }
 
 // Stop terminates every watcher: SIGTERM to each process group, group SIGKILL
@@ -227,7 +283,7 @@ func (s *watcherSupervisor) droppedEvents(taskID string) int {
 }
 
 func (s *watcherSupervisor) newTaskWatcher(t task.Task) *taskWatcher {
-	return &taskWatcher{
+	w := &taskWatcher{
 		taskID: t.ID,
 		name:   t.Name,
 		cmdStr: t.WatchCmd,
@@ -237,6 +293,15 @@ func (s *watcherSupervisor) newTaskWatcher(t task.Task) *taskWatcher {
 		stopCh: make(chan struct{}),
 		doneCh: make(chan struct{}),
 	}
+	// Recover any backlog a previous watcher/daemon left behind (#1129); the
+	// run loop starts the drainer if the queue is non-empty. A queue-dir
+	// failure disables durability, never the watcher itself.
+	if dir, err := s.queueDir(); err != nil {
+		log.WarningLog.Printf("watch task %s: event queue unavailable (failed deliveries will be dropped): %v", t.ID, err)
+	} else {
+		w.queue = newEventQueue(dir, t.ID)
+	}
+	return w
 }
 
 // watcherSignature captures the fields that define the watch process itself;
@@ -341,20 +406,35 @@ type taskWatcher struct {
 
 	sup *watcherSupervisor
 
+	// queue is the task's durable event backlog (#1129); nil when the queue
+	// directory is unavailable, in which case failed deliveries fall back to
+	// the pre-queue drop-with-log behavior.
+	queue *eventQueue
+
 	stopCh   chan struct{}
 	stopOnce sync.Once
 	doneCh   chan struct{}
+	// wg counts the drainer goroutine so stop() can join it; drainers spawn
+	// lazily via ensureDrainer.
+	wg sync.WaitGroup
 
 	mu          sync.Mutex
 	dropped     int
 	eventTimes  []time.Time
 	lastDropLog time.Time
+	// draining marks a live drainLoop goroutine, so at most one drains the
+	// queue at a time and replay order is preserved.
+	draining bool
 }
 
-// stop requests termination and blocks until the run goroutine returns.
+// stop requests termination and blocks until the run goroutine returns. The
+// drainer is joined too: Reload starts a replacement watcher for the same task
+// only after stop returns, so two drainers can never interleave one task's
+// replay.
 func (w *taskWatcher) stop() {
 	w.stopOnce.Do(func() { close(w.stopCh) })
 	<-w.doneCh
+	w.wg.Wait()
 }
 
 func (w *taskWatcher) finished() bool {
@@ -380,6 +460,13 @@ func (w *taskWatcher) stopRequested() bool {
 // crash loop ("errored").
 func (w *taskWatcher) run() {
 	defer close(w.doneCh)
+
+	// A backlog recovered from disk (daemon restart, reload, or a prior
+	// crash-looped run) starts replaying immediately, independent of the
+	// script's own lifecycle (#1129).
+	if w.queue != nil && w.queue.pendingCount() > 0 {
+		w.ensureDrainer()
+	}
 
 	backoff := w.sup.baseBackoff
 	var failures []time.Time
@@ -693,19 +780,26 @@ func (w *taskWatcher) consumeStderr(r io.Reader, logFile io.Writer, tail *tailBu
 	}
 }
 
-// handleEvent applies the per-task rate limit and delivers the event. Called
-// from the single reader goroutine, so deliveries stay serialized in order.
-// Lines that do not become a delivered event — rate-dropped or failed
-// deliveries — go to the failure tail instead (#797).
+// handleEvent routes one stdout line: with a backlog pending it is queued
+// behind it (delivering directly would reorder the stream, #1129); otherwise
+// it is rate-limited and delivered synchronously exactly as before, with a
+// failed delivery queued for replay instead of dropped. Called from the single
+// reader goroutine, so direct deliveries stay serialized in order. Lines that
+// do not become a delivered event this run — rate-dropped, failed, or queued —
+// go to the failure tail (#797).
 func (w *taskWatcher) handleEvent(line string, tail *tailBuffer) {
-	now := time.Now()
-	w.mu.Lock()
-	cut := 0
-	for cut < len(w.eventTimes) && now.Sub(w.eventTimes[cut]) >= time.Minute {
-		cut++
+	// FIFO gating: once a backlog exists, every newer event goes through the
+	// queue until it drains. Backlogged enqueues bypass the rate limiter —
+	// the limiter gates deliveries to the target (the drainer reserves a slot
+	// per replayed event); the queue's own count/byte caps bound the backlog.
+	if w.queue != nil && w.queue.pendingCount() > 0 {
+		w.enqueueEvent(line, tail)
+		return
 	}
-	w.eventTimes = w.eventTimes[cut:]
-	if len(w.eventTimes) >= w.sup.eventsPerMinute {
+
+	if !w.tryReserveEventSlot() {
+		now := time.Now()
+		w.mu.Lock()
 		w.dropped++
 		dropped := w.dropped
 		logIt := now.Sub(w.lastDropLog) >= time.Minute
@@ -715,18 +809,157 @@ func (w *taskWatcher) handleEvent(line string, tail *tailBuffer) {
 		w.mu.Unlock()
 		// One warning per window, not per drop — a flooding script must not
 		// also flood the daemon log. The counter keeps the exact total.
+		// Rate-dropped events are deliberately NOT queued: the limiter is
+		// protective policy against a chatty script, not an outage signal.
 		if logIt {
 			log.WarningLog.Printf("watch task %s: event rate exceeded %d/min; dropping excess events (%d dropped so far)", w.taskID, w.sup.eventsPerMinute, dropped)
 		}
 		tail.add(line)
 		return
 	}
-	w.eventTimes = append(w.eventTimes, now)
-	w.mu.Unlock()
 
 	if err := w.sup.deliver(w.taskID, line); err != nil {
 		log.ErrorLog.Printf("watch task %s: failed to deliver event: %v", w.taskID, err)
-		tail.add(line)
+		w.enqueueEvent(line, tail)
+	}
+}
+
+// tryReserveEventSlot applies the per-task delivery rate limit: prune the
+// sliding window, then reserve one slot if the window has room. Live
+// deliveries and the drainer's replays reserve through the same window, so
+// combined delivery pressure on the target session never exceeds
+// eventsPerMinute — a burst replay after an outage trickles in.
+func (w *taskWatcher) tryReserveEventSlot() bool {
+	now := time.Now()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	cut := 0
+	for cut < len(w.eventTimes) && now.Sub(w.eventTimes[cut]) >= time.Minute {
+		cut++
+	}
+	w.eventTimes = w.eventTimes[cut:]
+	if len(w.eventTimes) >= w.sup.eventsPerMinute {
+		return false
+	}
+	w.eventTimes = append(w.eventTimes, now)
+	return true
+}
+
+// enqueueEvent appends the line to the durable backlog and wakes the drainer.
+// The line also lands in the run's failure tail — it did not become a
+// delivered event this run (#797). When the queue is unavailable or the append
+// fails, this degrades to the pre-#1129 behavior: logged and dropped.
+func (w *taskWatcher) enqueueEvent(line string, tail *tailBuffer) {
+	tail.add(line)
+	if w.queue == nil {
+		return
+	}
+	if err := w.queue.enqueue(line); err != nil {
+		log.ErrorLog.Printf("watch task %s: failed to queue event for replay; dropping it: %v", w.taskID, err)
+		return
+	}
+	w.ensureDrainer()
+}
+
+// ensureDrainer starts the drain goroutine unless one is live or a stop is in
+// flight. Callers: enqueueEvent (an event just queued) and run (a backlog
+// recovered from disk).
+func (w *taskWatcher) ensureDrainer() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.draining || w.stopRequested() {
+		return
+	}
+	w.draining = true
+	w.wg.Add(1)
+	go w.drainLoop()
+}
+
+// stopDraining clears the draining flag so a later enqueue can start a fresh
+// drainer.
+func (w *taskWatcher) stopDraining() {
+	w.mu.Lock()
+	w.draining = false
+	w.mu.Unlock()
+}
+
+// sleepStopAware waits d, or returns false immediately when a stop arrives —
+// the drainer must never be the thing a stop/reload waits on (the same
+// stop-awareness discipline as the run loop's backoff waits).
+func (w *taskWatcher) sleepStopAware(d time.Duration) bool {
+	select {
+	case <-w.stopCh:
+		return false
+	case <-time.After(d):
+		return true
+	}
+}
+
+// drainLoop replays the backlog oldest-first through the same deliver hook as
+// live events. Strictly FIFO: live events enqueue behind the backlog (see
+// handleEvent), so emission order survives an outage. Every wait is
+// stop-aware; a failed replay backs off drainBaseBackoff→drainMaxBackoff and
+// then holds that cadence for as long as the failure persists — never a
+// permanent give-up (#1128 discipline), because an outage is indistinguishable
+// from a broken target while it lasts. A corrupt queue parks the replay with
+// an ERROR rather than guessing at record boundaries.
+func (w *taskWatcher) drainLoop() {
+	defer w.wg.Done()
+	backoff := w.sup.drainBaseBackoff
+	replayed := 0
+	for {
+		if w.stopRequested() {
+			w.stopDraining()
+			return
+		}
+		ev, n, ok, err := w.queue.peek()
+		if err != nil {
+			log.ErrorLog.Printf("watch task %s: cannot read queued event; replay parked until the next reload: %v", w.taskID, err)
+			w.stopDraining()
+			return
+		}
+		if !ok {
+			if replayed > 0 {
+				log.InfoLog.Printf("watch task %s: replayed %d queued event(s)", w.taskID, replayed)
+			}
+			w.stopDraining()
+			// Close the wake-up race: an event enqueued after the empty peek
+			// but before draining cleared would otherwise strand until the
+			// next enqueue. Our wg slot is still held, so the re-spawn's Add
+			// can never race a stop's Wait.
+			if w.queue.pendingCount() > 0 {
+				w.ensureDrainer()
+			}
+			return
+		}
+		if !w.tryReserveEventSlot() {
+			// The shared rate window is full (live deliveries count too);
+			// wait for it to roll, stop-aware.
+			if !w.sleepStopAware(w.sup.drainBaseBackoff) {
+				w.stopDraining()
+				return
+			}
+			continue
+		}
+		if err := w.sup.deliver(w.taskID, ev.Line); err != nil {
+			log.WarningLog.Printf("watch task %s: replay delivery failed (%d event(s) pending); retrying in %s: %v", w.taskID, w.queue.pendingCount(), backoff, err)
+			if !w.sleepStopAware(backoff) {
+				w.stopDraining()
+				return
+			}
+			backoff *= 2
+			if backoff > w.sup.drainMaxBackoff {
+				backoff = w.sup.drainMaxBackoff
+			}
+			continue
+		}
+		if err := w.queue.advance(n); err != nil {
+			log.ErrorLog.Printf("watch task %s: failed to advance the event queue; replay parked until the next reload: %v", w.taskID, err)
+			w.stopDraining()
+			return
+		}
+		replayed++
+		backoff = w.sup.drainBaseBackoff
 	}
 }
 

--- a/daemon/watcher_test.go
+++ b/daemon/watcher_test.go
@@ -65,6 +65,12 @@ func newTestSupervisor(t *testing.T, tasks func() ([]task.Task, error)) (*watche
 	s.logPath = func(taskID string) (string, error) {
 		return filepath.Join(logDir, "task-"+taskID+".log"), nil
 	}
+	// Every test gets a private queue directory (#1129): the default resolves
+	// under the real AF home, and drain retries must be test-fast.
+	queueDir := t.TempDir()
+	s.queueDir = func() (string, error) { return queueDir, nil }
+	s.drainBaseBackoff = 20 * time.Millisecond
+	s.drainMaxBackoff = 200 * time.Millisecond
 	s.shell = "sh"
 	s.baseBackoff = 40 * time.Millisecond
 	s.maxBackoff = time.Second


### PR DESCRIPTION
PR 3 of the approved #1108/#1129 joint design ([design comment](https://github.com/sachiniyer/agent-factory/issues/1129#issuecomment-4880319042)): the durable event-queue core. PR 1 (#1134, Lost classification) is merged; PR 2 (restore loop) and PR 4 (retention/docs/e2e) follow.

## What this does

`handleEvent`'s delivery-failure path was log-ERROR + tail + **drop forever** — during the 2026-07-03 outages every watch event fired while sessions were unreachable was lost, including `captain-events` GitHub notifications. This PR makes failed deliveries durable and replayable:

- **Healthy path byte-identical**: the first delivery attempt stays synchronous on the watcher's single reader goroutine — the backpressure/emission-order contract (`watcher.go` doc) is untouched, as is the `runOnce` guaranteed-EOF/reader-drain machinery. Durability engages only on failure.
- **Queue**: `<AF home>/events/<taskID>.jsonl` (one JSON event per line: `seq`, `ts`, `line`) + `<taskID>.cursor` (byte offset of the first undelivered event — pop is a cursor advance, not a rewrite). Files are removed when the queue fully drains; the steady healthy state is no files at all. Cursor writes are atomic (write+rename) and land **after** the delivery they acknowledge → a daemon crash mid-replay redelivers at most one event (at-least-once, per the design).
- **Strict FIFO**: once a backlog exists, newer live events enqueue behind it (`handleEvent` gating) — replay lands before live, emission order survives the outage.
- **Stop-aware drainer**: one lazy goroutine per task replays oldest-first through the same `deliverWatchEvent` hook (task re-loaded per event, so disabled-task and edited-target semantics hold for replays too). Every wait selects on `stopCh`; `stop()` joins the drainer after the run goroutine, so `Reload`'s stop-then-start sequencing extends "two processes never overlap" to "two drainers never overlap". Failed replays back off 10s→5m and settle at the cap — the #1128 never-give-up discipline, verbatim rationale: an outage is indistinguishable from a broken target while it lasts.
- **Shared rate budget**: live deliveries and replays reserve from the same per-task 10/min sliding window (`tryReserveEventSlot`), so a 300-event backlog trickles into the restored session. Rate-dropped events are still dropped, never queued — the limiter is protective policy, not an outage signal. (One deliberate nuance: while a backlog exists, enqueues bypass the emission limiter and are bounded by the queue caps instead — the limiter gates *deliveries*, and every replayed event reserves a slot.)
- **Bounds**: 500 events / 256 KiB per task; overflow drops the **oldest** (newest are the actionable ones after an outage) with the rate-limiter's one-warning-per-minute log pattern plus a running counter.
- **Restart/reload recovery**: `newTaskWatcher` recovers the backlog from disk and `run()` starts the drainer immediately — an outage spanning a daemon restart replays after the restart. This fell out of the design naturally, so PR 4's replay scope shrinks to retention/docs/e2e. A corrupt cursor resets to 0 (redeliver, never lose); a corrupt record parks the replay with an ERROR rather than guessing at boundaries.
- **Deleted vs disabled tasks**: reload removes queue files for task IDs absent from tasks.json entirely (a deleted task's backlog must not replay into a recreated namesake); a merely-disabled task keeps its backlog for re-enable.
- **Degradation**: queue-dir or append failure falls back to exactly the pre-#1129 behavior (log + tail + drop) — the queue can never block the reader or fail a watcher.

The #797 tail contract is preserved: queued lines still land in the per-run failure tail ("stdout lines that did not become delivered events"), so crash-loop diagnostics (`TestWatcherFailureLogsIncludeOutputTail`, `TestWatcherTailCapturesNonDeliveredStdout`) are unchanged.

## What this deliberately does not do

Age-based retention (72h expiry at drain time), the `docs/tasks.md` rewrite ("No replay" is now false), and the end-to-end container test with the #1108 restore loop are PR 4. The #1108-side guarantee that a delivery into an *existing-but-Lost* target fails cleanly (rather than auto-creating a duplicate session) already holds on master via `DeliverPrompt`'s exists-check + `SendPrompt` failure.

## Tests

Unit (no tmux, via the existing supervisor seams): FIFO round-trip + file removal on drain; state recovery across reopen (cursor honored); corrupt-cursor replay-from-start; oldest-dropped over the event cap with counter. Watcher-level (real scripts on the private sandbox server): outage→heal replays all events in emission order with FIFO gating asserted (`TestWatcherQueuesFailedDeliveriesAndReplaysInOrder`); backlog survives a supervisor stop + fresh supervisor with an emit-nothing script (`TestWatcherBacklogSurvivesRestart`); `Stop()` returns promptly with the drainer parked in an hour-long backoff (`TestWatcherStopJoinsDrainer`); reload removes deleted tasks' queues but keeps disabled tasks' (`TestWatcherReloadRemovesDeletedTaskQueue`). Test supervisors get a private queue dir + fast drain backoffs via new injection seams.

## Gates

`go build ./...`, `golangci-lint run --fast`, `gofmt -l` (empty), `deadcode -test` (empty), full suite under `make test-container` — all green (20 packages ok, zero failures). Not merging — root verifies and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
