### PR TITLE
session,daemon: restore Lost sessions — explicit Recover + never-give-up loop (#1108 PR 2)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -943,6 +943,16 @@ type Manager struct {
 	// restore loop (#1108 PR 2), keyed by daemon instance key — the general
 	// sibling of rootEnsureStates.
 	lostRestoreStates map[string]*lostRestoreState
+	// instanceOpLocks serializes the mutually-exclusive per-session
+	// operations — kill teardown and Lost-recovery — by daemon instance key.
+	// killsInFlight alone is a point-in-time signal; this lock is what makes
+	// a KillSession arriving mid-Recover WAIT for the recover attempt and
+	// then tear the restored session down, instead of interleaving a teardown
+	// with a re-spawn. The recover side only TryLocks (the poll goroutine
+	// must never stall behind a slow teardown). Lazily populated like
+	// repoStartLocks; entries are never removed (a few bytes per session ever
+	// touched).
+	instanceOpLocks map[string]*sync.Mutex
 }
 
 // NewManager constructs a manager and synchronously restores all persisted
@@ -982,6 +992,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		rootKilledByUser:    make(map[string]struct{}),
 		killsInFlight:       make(map[string]struct{}),
 		lostRestoreStates:   make(map[string]*lostRestoreState),
+		instanceOpLocks:     make(map[string]*sync.Mutex),
 	}, nil
 }
 
@@ -1284,6 +1295,20 @@ func (m *Manager) startLockForRepo(repoID string) *sync.Mutex {
 	return lock
 }
 
+// opLockFor returns the per-session operation lock serializing kill teardown
+// against Lost-recovery for one daemon instance key (#1108 PR 2).
+func (m *Manager) opLockFor(key string) *sync.Mutex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	lock := m.instanceOpLocks[key]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		m.instanceOpLocks[key] = lock
+	}
+	return lock
+}
+
 func (m *Manager) reserveCreate(req CreateSessionRequest) (*config.RepoContext, string, func(), error) {
 	if req.RepoPath == "" {
 		return nil, "", nil, fmt.Errorf("repo path is required")
@@ -1500,6 +1525,16 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 		m.mu.Unlock()
 	}()
 
+	// Serialize against a Lost-recovery in flight for this session (#1108
+	// PR 2): a kill arriving mid-Recover waits for the recover attempt to
+	// finish and then tears the (possibly just-restored) session down —
+	// never an interleaved teardown-vs-respawn. killsInFlight is registered
+	// BEFORE this acquire, so the restore loop's in-lock re-check sees the
+	// kill intent and aborts instead of racing to go first.
+	opLock := m.opLockFor(key)
+	opLock.Lock()
+	defer opLock.Unlock()
+
 	// Persist the kill-intent tombstone BEFORE teardown begins (#1108): if the
 	// daemon dies or the teardown errors between here and DeleteInstance, the
 	// surviving record is provably a user kill — the status poll finishes the
@@ -1586,6 +1621,16 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 		delete(m.killsInFlight, key)
 		m.mu.Unlock()
 	}()
+
+	// TryLock, not Lock: this runs on the poll goroutine, which must not
+	// stall behind a concurrent slow operation on this session; the next
+	// poll retries. (A KillSession in flight was already skipped above, so
+	// contention here is only a still-releasing lock.)
+	opLock := m.opLockFor(key)
+	if !opLock.TryLock() {
+		return
+	}
+	defer opLock.Unlock()
 
 	log.WarningLog.Printf("finishing interrupted kill of session %q (tombstoned record survived its teardown)", instance.Title)
 	// Best-effort: the backing tmux session is typically already gone; Kill

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -939,6 +939,10 @@ type Manager struct {
 	// the same session, and a duplicate KillSession RPC is rejected instead of
 	// double-killing.
 	killsInFlight map[string]struct{}
+	// lostRestoreStates tracks per-session retry state for the Lost-session
+	// restore loop (#1108 PR 2), keyed by daemon instance key — the general
+	// sibling of rootEnsureStates.
+	lostRestoreStates map[string]*lostRestoreState
 }
 
 // NewManager constructs a manager and synchronously restores all persisted
@@ -977,6 +981,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		rootEnsureStates:    make(map[string]*rootEnsureState),
 		rootKilledByUser:    make(map[string]struct{}),
 		killsInFlight:       make(map[string]struct{}),
+		lostRestoreStates:   make(map[string]*lostRestoreState),
 	}, nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -178,6 +178,13 @@ func RunDaemon(cfg *config.Config) error {
 			// changing it takes effect on the next daemon restart.
 			manager.EnsureRootAgents()
 
+			// Best-effort restore of Lost sessions (#1108): the general form
+			// of the root self-heal, for every session whose tmux vanished
+			// with no kill on record. Runs after RefreshStatuses (which marks
+			// them Lost) and after EnsureRootAgents (which owns the reserved
+			// root title). Backoff-throttled per session, like root-ensure.
+			manager.RestoreLostSessions()
+
 			// Handle stop before ticker.
 			select {
 			case <-stopCh:

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -86,7 +86,11 @@ func (m *Manager) RestoreLostSessions() {
 
 // restoreLostSession attempts recovery of one session when it is eligible:
 // Lost, local, not tombstoned, not the reserved root (EnsureRootAgents owns
-// that), and no kill in flight.
+// that), and no kill in flight. Recover runs under the per-session operation
+// lock KillSession takes, so a kill arriving mid-attempt waits for the
+// attempt and then tears down — the two operations never interleave. This
+// side only TryLocks: the poll goroutine must never stall behind a slow
+// teardown, and the next tick retries.
 func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance) {
 	if inst == nil || !inst.Started() || inst.GetStatus() != session.Lost {
 		return
@@ -119,6 +123,26 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		if logIt {
 			log.InfoLog.Printf("session %q is Lost but remote; not auto-restoring (reconnect is not supported) — kill it to clear the row", inst.Title)
 		}
+		return
+	}
+
+	opLock := m.opLockFor(key)
+	if !opLock.TryLock() {
+		// A kill (or its finish pass) holds the session; skip this tick.
+		return
+	}
+	defer opLock.Unlock()
+
+	// Re-verify under the lock: everything checked above was point-in-time,
+	// and a KillSession that beat us to the lock may have torn the session
+	// down (map entry gone / replaced), tombstoned it, or a racing kill may
+	// have registered its intent after our killsInFlight read. Recover only
+	// what is still provably a wanted Lost session.
+	m.mu.Lock()
+	current := m.instances[key]
+	_, killing := m.killsInFlight[key]
+	m.mu.Unlock()
+	if killing || current != inst || inst.UserKilled() || inst.GetStatus() != session.Lost {
 		return
 	}
 

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -1,0 +1,159 @@
+package daemon
+
+import (
+	"sort"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The Lost-session restore loop (#1108 PR 2): the general form of the
+// root-agent self-heal. Every daemon poll, each local session marked Lost —
+// its tmux vanished with no kill intent on record (outage, OOM, reboot; see
+// #1104/#1122) — gets a best-effort Instance.Recover, re-spawning the program
+// in its worktree. Root keeps its stronger always-ensure semantics
+// (reap-and-recreate in EnsureRootAgents); everyone else is restored in place
+// here. The retry discipline is #1128's verbatim: exponential backoff settling
+// at the cap, never a permanent give-up, one ERROR escalation when the cause
+// looks persistent. The user's off-ramp from a permanently failing restore is
+// killing the session (which tombstones it).
+
+// lostRestoreEscalationThreshold mirrors rootEnsureEscalationThreshold: the
+// consecutive-failure count at which one ERROR log marks the cause as
+// persistent-looking (deleted worktree, unresolvable program). The loop keeps
+// retrying at the cap cadence regardless.
+const lostRestoreEscalationThreshold = 6
+
+// Backoff between failed restore attempts for one session. Package vars so
+// tests can shorten them (same pattern as rootEnsureBackoff*).
+var (
+	lostRestoreBackoffBase = 10 * time.Second
+	lostRestoreBackoffMax  = 5 * time.Minute
+)
+
+// lostRestoreState is the per-session retry state. Guarded by Manager.mu (the
+// loop runs on the daemon poll goroutine; tests drive RestoreLostSessions
+// directly).
+type lostRestoreState struct {
+	consecutiveFailures int
+	nextAttempt         time.Time
+	// remoteLogged dedupes the "not restoring a remote session" note to once
+	// per Lost episode.
+	remoteLogged bool
+}
+
+// RestoreLostSessions runs one restore pass over every Lost session the
+// manager owns. Called from the daemon poll loop after EnsureRootAgents (which
+// owns the reserved root title); a no-op until the initial restore finishes.
+func (m *Manager) RestoreLostSessions() {
+	if !m.Ready() {
+		return
+	}
+
+	type entry struct {
+		key      string
+		repoID   string
+		instance *session.Instance
+	}
+	m.mu.Lock()
+	entries := make([]entry, 0, len(m.instances))
+	for key, inst := range m.instances {
+		repoID, _ := splitDaemonInstanceKey(key)
+		entries = append(entries, entry{key: key, repoID: repoID, instance: inst})
+	}
+	// Drop retry state for sessions that are gone or no longer Lost (healed,
+	// killed, or replaced) so the map never grows unbounded.
+	for key, inst := range m.instances {
+		if st := m.lostRestoreStates[key]; st != nil && inst.GetStatus() != session.Lost {
+			delete(m.lostRestoreStates, key)
+		}
+	}
+	for key := range m.lostRestoreStates {
+		if _, live := m.instances[key]; !live {
+			delete(m.lostRestoreStates, key)
+		}
+	}
+	m.mu.Unlock()
+
+	// Stable order so multi-session recovery after an outage is deterministic
+	// and the logs read coherently (same rationale as EnsureRootAgents).
+	sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
+	for _, e := range entries {
+		m.restoreLostSession(e.key, e.repoID, e.instance)
+	}
+}
+
+// restoreLostSession attempts recovery of one session when it is eligible:
+// Lost, local, not tombstoned, not the reserved root (EnsureRootAgents owns
+// that), and no kill in flight.
+func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance) {
+	if inst == nil || !inst.Started() || inst.GetStatus() != session.Lost {
+		return
+	}
+	if inst.UserKilled() || session.IsReservedTitle(inst.Title) {
+		return
+	}
+
+	m.mu.Lock()
+	if _, killing := m.killsInFlight[key]; killing {
+		m.mu.Unlock()
+		return
+	}
+	st := m.lostRestoreStates[key]
+	if st == nil {
+		st = &lostRestoreState{}
+		m.lostRestoreStates[key] = st
+	}
+	skip := time.Now().Before(st.nextAttempt)
+	m.mu.Unlock()
+	if skip {
+		return
+	}
+
+	if inst.IsRemote() {
+		m.mu.Lock()
+		logIt := !st.remoteLogged
+		st.remoteLogged = true
+		m.mu.Unlock()
+		if logIt {
+			log.InfoLog.Printf("session %q is Lost but remote; not auto-restoring (reconnect is not supported) — kill it to clear the row", inst.Title)
+		}
+		return
+	}
+
+	if err := inst.Recover(); err != nil {
+		m.lostRestoreFailed(key, st, inst.Title, err)
+		return
+	}
+
+	log.InfoLog.Printf("restored lost session %q (repo %s): tmux re-spawned in its worktree", inst.Title, repoID)
+	m.mu.Lock()
+	delete(m.lostRestoreStates, key)
+	m.mu.Unlock()
+}
+
+// lostRestoreFailed records a failed restore attempt: exponential backoff to
+// lostRestoreBackoffMax where the cadence settles for as long as the failure
+// persists — never a permanent give-up (#1128: an outage is indistinguishable
+// from a broken worktree while it lasts; only a later retry can tell). One
+// ERROR at the escalation threshold makes a persistent cause visible.
+func (m *Manager) lostRestoreFailed(key string, st *lostRestoreState, title string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st.consecutiveFailures++
+	backoff := lostRestoreBackoffMax
+	// Guard the shift: past ~16 doublings the exponential form has no meaning
+	// and would overflow.
+	if shift := st.consecutiveFailures - 1; shift < 16 {
+		if b := lostRestoreBackoffBase << shift; b < backoff {
+			backoff = b
+		}
+	}
+	st.nextAttempt = time.Now().Add(backoff)
+	if st.consecutiveFailures == lostRestoreEscalationThreshold {
+		log.ErrorLog.Printf("restore of lost session %q failed %d consecutive times; the cause looks persistent — will keep retrying every %s (kill the session to stop): %v", title, st.consecutiveFailures, lostRestoreBackoffMax, err)
+		return
+	}
+	log.WarningLog.Printf("restore of lost session %q failed (attempt %d), retrying in %s: %v", title, st.consecutiveFailures, backoff, err)
+}

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -191,6 +192,189 @@ func TestRestoreLostSessions_SkipsIneligible(t *testing.T) {
 			t.Fatalf("the reserved root is EnsureRootAgents' job, got %d recover calls", got)
 		}
 	})
+}
+
+// raceBackend is a readyFakeBackend whose Recover and Kill can each be held
+// open on channels, and which counts both, so kill-vs-recover interleaving can
+// be pinned exactly.
+type raceBackend struct {
+	readyFakeBackend
+	mu             sync.Mutex
+	kills          int
+	recovers       int
+	recoverStarted chan struct{}
+	recoverBlock   chan struct{}
+	killStarted    chan struct{}
+	killBlock      chan struct{}
+}
+
+func (b *raceBackend) Recover(inst *session.Instance) error {
+	b.mu.Lock()
+	b.recovers++
+	b.mu.Unlock()
+	if b.recoverStarted != nil {
+		close(b.recoverStarted)
+		b.recoverStarted = nil
+	}
+	if b.recoverBlock != nil {
+		<-b.recoverBlock
+	}
+	inst.SetStatusIfNotDeleting(session.Running)
+	return nil
+}
+
+func (b *raceBackend) Kill(inst *session.Instance) error {
+	b.mu.Lock()
+	b.kills++
+	b.mu.Unlock()
+	if b.killStarted != nil {
+		close(b.killStarted)
+		b.killStarted = nil
+	}
+	if b.killBlock != nil {
+		<-b.killBlock
+	}
+	return b.readyFakeBackend.Kill(inst)
+}
+
+func (b *raceBackend) counts() (kills, recovers int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.kills, b.recovers
+}
+
+// installRaceBackend registers backend as the factory product and creates a
+// tracked session titled title, returning the manager, repoID, and instance.
+func installRaceBackend(t *testing.T, backend *raceBackend, title string) (*Manager, string, *session.Instance) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	restore := session.SetBackendFactoryForTest(func(opts session.InstanceOptions, absPath string) (session.Backend, error) {
+		fake := session.NewFakeBackend()
+		fake.CompleteStart()
+		backend.readyFakeBackend = readyFakeBackend{fake}
+		return backend, nil
+	})
+	t.Cleanup(restore)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := manager.CreateSession(CreateSessionRequest{
+		Title:    title,
+		RepoPath: repoPath,
+		Program:  "claude",
+	}); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	manager.mu.Lock()
+	inst := manager.instances[daemonInstanceKey(repo.ID, title)]
+	manager.mu.Unlock()
+	if inst == nil {
+		t.Fatal("created instance not tracked")
+	}
+	return manager, repo.ID, inst
+}
+
+// TestKillSession_WaitsForInFlightRecover is the Greptile P1 on #1137: a
+// KillSession arriving while the restore loop is mid-Recover must WAIT for
+// the recover attempt to finish and then tear the freshly-restored session
+// down — never interleave. End state: record deleted, instance dropped,
+// exactly one teardown, exactly one recover.
+func TestKillSession_WaitsForInFlightRecover(t *testing.T) {
+	backend := &raceBackend{
+		recoverStarted: make(chan struct{}),
+		recoverBlock:   make(chan struct{}),
+	}
+	manager, repoID, inst := installRaceBackend(t, backend, "contested")
+	zeroRestoreBackoff(t)
+	inst.SetStatus(session.Lost)
+
+	recoverStarted := backend.recoverStarted
+	restoreDone := make(chan struct{})
+	go func() {
+		manager.RestoreLostSessions()
+		close(restoreDone)
+	}()
+	<-recoverStarted // the loop is inside Recover, holding the op lock
+
+	killDone := make(chan error, 1)
+	go func() {
+		killDone <- manager.KillSession(KillSessionRequest{Title: "contested", RepoID: repoID})
+	}()
+
+	// The kill must be blocked behind the in-flight recover attempt.
+	select {
+	case err := <-killDone:
+		t.Fatalf("KillSession completed mid-Recover (err=%v); it must wait for the attempt", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(backend.recoverBlock) // recover finishes (session "restored")
+	<-restoreDone
+	select {
+	case err := <-killDone:
+		if err != nil {
+			t.Fatalf("KillSession after recover: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("KillSession never proceeded after the recover attempt finished")
+	}
+
+	kills, recovers := backend.counts()
+	if kills != 1 || recovers != 1 {
+		t.Fatalf("want exactly one teardown and one recover, got kills=%d recovers=%d", kills, recovers)
+	}
+	if rec := recordFor(t, repoID, "contested"); rec != nil {
+		t.Fatalf("killed session's record must be deleted, still present: %+v", rec)
+	}
+	manager.mu.Lock()
+	_, tracked := manager.instances[daemonInstanceKey(repoID, "contested")]
+	manager.mu.Unlock()
+	if tracked {
+		t.Fatal("killed session must be dropped from the manager")
+	}
+}
+
+// TestRestoreLostSessions_SkipsDuringInFlightKill is the reverse ordering: a
+// restore pass arriving while a KillSession teardown is in flight must not
+// touch the session — no recover call, ever — and after the kill completes
+// the session is gone for good.
+func TestRestoreLostSessions_SkipsDuringInFlightKill(t *testing.T) {
+	backend := &raceBackend{
+		killStarted: make(chan struct{}),
+		killBlock:   make(chan struct{}),
+	}
+	manager, repoID, inst := installRaceBackend(t, backend, "doomed")
+	zeroRestoreBackoff(t)
+	inst.SetStatus(session.Lost)
+
+	killStarted := backend.killStarted
+	killDone := make(chan error, 1)
+	go func() {
+		killDone <- manager.KillSession(KillSessionRequest{Title: "doomed", RepoID: repoID})
+	}()
+	<-killStarted // teardown in flight, op lock + killsInFlight held
+
+	manager.RestoreLostSessions() // must return promptly without recovering
+
+	close(backend.killBlock)
+	if err := <-killDone; err != nil {
+		t.Fatalf("KillSession: %v", err)
+	}
+
+	manager.RestoreLostSessions() // session is gone; still nothing to recover
+
+	if _, recovers := backend.counts(); recovers != 0 {
+		t.Fatalf("a session being killed must never be recovered, got %d recover calls", recovers)
+	}
+	if rec := recordFor(t, repoID, "doomed"); rec != nil {
+		t.Fatalf("killed session's record must be deleted, still present: %+v", rec)
+	}
 }
 
 // TestRestoreLostSessions_StateCleanedForGoneSessions: retry state for

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -1,0 +1,225 @@
+package daemon
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// recoverFakeBackend counts Recover calls and emulates LocalBackend.Recover's
+// success contract (flip to Running) or a configured failure. Type is
+// overridable so the remote-skip rule can be exercised.
+type recoverFakeBackend struct {
+	*session.FakeBackend
+	mu       sync.Mutex
+	failWith error
+	recovers int
+	typeName string
+}
+
+func (b *recoverFakeBackend) Recover(inst *session.Instance) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.recovers++
+	if b.failWith != nil {
+		return b.failWith
+	}
+	inst.SetStatusIfNotDeleting(session.Running)
+	return nil
+}
+
+func (b *recoverFakeBackend) recoverCalls() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.recovers
+}
+
+func (b *recoverFakeBackend) Type() string {
+	if b.typeName != "" {
+		return b.typeName
+	}
+	return "local"
+}
+
+// zeroRestoreBackoff makes every RestoreLostSessions pass an attempt.
+func zeroRestoreBackoff(t *testing.T) {
+	t.Helper()
+	prev := lostRestoreBackoffBase
+	lostRestoreBackoffBase = 0
+	t.Cleanup(func() { lostRestoreBackoffBase = prev })
+}
+
+// TestRestoreLostSessions_RecoversLostInstance: the core loop — a Lost local
+// session gets exactly one Recover, comes back Running, and its retry state is
+// dropped.
+func TestRestoreLostSessions_RecoversLostInstance(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "stranded", backend, true, session.Lost)
+
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("recover calls = %d, want 1", got)
+	}
+	if got := inst.GetStatus(); got != session.Running {
+		t.Fatalf("status = %v, want Running after recovery", got)
+	}
+	manager.mu.Lock()
+	_, hasState := manager.lostRestoreStates[daemonInstanceKey(repoID, "stranded")]
+	manager.mu.Unlock()
+	if hasState {
+		t.Fatal("successful recovery must drop the retry state")
+	}
+
+	// A healed session must not be touched again.
+	manager.RestoreLostSessions()
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("recover calls after heal = %d, want still 1", got)
+	}
+}
+
+// TestRestoreLostSessions_KeepsRetryingAndHeals mirrors the #1128 root-ensure
+// guarantee for the general loop: failures past the escalation threshold never
+// park the retry permanently, and the first pass after the cause clears heals.
+func TestRestoreLostSessions_KeepsRetryingAndHeals(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	zeroRestoreBackoff(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend(), failWith: errors.New("worktree unavailable")}
+	inst := registerStarted(t, manager, repoID, repoPath, "unlucky", backend, true, session.Lost)
+
+	attempts := lostRestoreEscalationThreshold + 3
+	for i := 0; i < attempts; i++ {
+		manager.RestoreLostSessions()
+	}
+	if got := backend.recoverCalls(); got != attempts {
+		t.Fatalf("loop must keep attempting past the escalation threshold: want %d attempts, got %d", attempts, got)
+	}
+
+	// The cause clears (the outage ends): the very next pass must heal.
+	backend.mu.Lock()
+	backend.failWith = nil
+	backend.mu.Unlock()
+	manager.RestoreLostSessions()
+
+	if got := inst.GetStatus(); got != session.Running {
+		t.Fatalf("status = %v, want Running on the first pass after the cause cleared", got)
+	}
+}
+
+// TestRestoreLostSessions_BacksOffBetweenFailures: passes inside the backoff
+// window must not re-attempt (the cheap-retry discipline, not a hot loop).
+func TestRestoreLostSessions_BacksOffBetweenFailures(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	prev := lostRestoreBackoffBase
+	lostRestoreBackoffBase = time.Hour
+	t.Cleanup(func() { lostRestoreBackoffBase = prev })
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend(), failWith: errors.New("still down")}
+	registerStarted(t, manager, repoID, repoPath, "waiting", backend, true, session.Lost)
+
+	manager.RestoreLostSessions()
+	manager.RestoreLostSessions()
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("passes inside the backoff window must not re-attempt: want 1, got %d", got)
+	}
+}
+
+// TestRestoreLostSessions_SkipsIneligible: tombstoned records (their only
+// future is a finished kill), sessions with a kill in flight, remote sessions
+// (flagged, not auto-restored), non-Lost sessions, and the reserved root
+// (EnsureRootAgents owns it) are never Recover'd.
+func TestRestoreLostSessions_SkipsIneligible(t *testing.T) {
+	t.Run("tombstoned", func(t *testing.T) {
+		manager, repoID, repoPath := newStatusTestManager(t)
+		backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+		inst := registerStarted(t, manager, repoID, repoPath, "corpse", backend, true, session.Lost)
+		inst.MarkUserKilled()
+		manager.RestoreLostSessions()
+		if got := backend.recoverCalls(); got != 0 {
+			t.Fatalf("a tombstoned session must never be restored, got %d recover calls", got)
+		}
+	})
+
+	t.Run("kill in flight", func(t *testing.T) {
+		manager, repoID, repoPath := newStatusTestManager(t)
+		backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+		registerStarted(t, manager, repoID, repoPath, "dying", backend, true, session.Lost)
+		key := daemonInstanceKey(repoID, "dying")
+		manager.mu.Lock()
+		manager.killsInFlight[key] = struct{}{}
+		manager.mu.Unlock()
+		manager.RestoreLostSessions()
+		if got := backend.recoverCalls(); got != 0 {
+			t.Fatalf("a session mid-kill must not be restored, got %d recover calls", got)
+		}
+	})
+
+	t.Run("remote", func(t *testing.T) {
+		manager, repoID, repoPath := newStatusTestManager(t)
+		backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend(), typeName: "remote"}
+		registerStarted(t, manager, repoID, repoPath, "faraway", backend, true, session.Lost)
+		manager.RestoreLostSessions()
+		manager.RestoreLostSessions()
+		if got := backend.recoverCalls(); got != 0 {
+			t.Fatalf("remote sessions are not auto-restored in v1, got %d recover calls", got)
+		}
+	})
+
+	t.Run("non-lost statuses", func(t *testing.T) {
+		for _, status := range []session.Status{session.Running, session.Ready, session.Loading, session.Deleting} {
+			manager, repoID, repoPath := newStatusTestManager(t)
+			backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+			registerStarted(t, manager, repoID, repoPath, "healthy", backend, true, status)
+			manager.RestoreLostSessions()
+			if got := backend.recoverCalls(); got != 0 {
+				t.Fatalf("status %v must not be restored, got %d recover calls", status, got)
+			}
+		}
+	})
+
+	t.Run("reserved root", func(t *testing.T) {
+		manager, repoID, repoPath := newStatusTestManager(t)
+		backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+		registerStarted(t, manager, repoID, repoPath, session.RootSessionTitle, backend, true, session.Lost)
+		manager.RestoreLostSessions()
+		if got := backend.recoverCalls(); got != 0 {
+			t.Fatalf("the reserved root is EnsureRootAgents' job, got %d recover calls", got)
+		}
+	})
+}
+
+// TestRestoreLostSessions_StateCleanedForGoneSessions: retry state for
+// sessions that were killed or healed does not accumulate.
+func TestRestoreLostSessions_StateCleanedForGoneSessions(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	zeroRestoreBackoff(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend(), failWith: errors.New("down")}
+	registerStarted(t, manager, repoID, repoPath, "doomed", backend, true, session.Lost)
+
+	manager.RestoreLostSessions()
+	key := daemonInstanceKey(repoID, "doomed")
+	manager.mu.Lock()
+	_, hasState := manager.lostRestoreStates[key]
+	manager.mu.Unlock()
+	if !hasState {
+		t.Fatal("a failed attempt must record retry state")
+	}
+
+	// The session disappears (user killed it; record + map entry gone).
+	manager.mu.Lock()
+	delete(manager.instances, key)
+	manager.mu.Unlock()
+	manager.RestoreLostSessions()
+
+	manager.mu.Lock()
+	_, hasState = manager.lostRestoreStates[key]
+	manager.mu.Unlock()
+	if hasState {
+		t.Fatal("retry state for a gone session must be dropped")
+	}
+}

--- a/session/backend.go
+++ b/session/backend.go
@@ -58,6 +58,15 @@ type Backend interface {
 	// TapEnter sends an Enter keystroke (used with AutoYes).
 	TapEnter(instance *Instance)
 
+	// Recover re-establishes a Lost session's backing resources — the tmux
+	// session vanished out from under a live record with no kill on record
+	// (#1108) — re-spawning the program in the instance's worktree. It is
+	// invoked ONLY by the daemon's explicit restore loop, never as a load-time
+	// side effect (the #970 guard in Start stays authoritative for loads).
+	// Remote backends return ErrRecoverUnsupported in v1: a Lost remote
+	// session is flagged but reconnect semantics are their own design.
+	Recover(instance *Instance) error
+
 	// Type returns the backend type identifier ("local" or "remote").
 	Type() string
 }

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -631,6 +631,11 @@ func (b *HookBackend) CheckAndHandleTrustPrompt(_ *Instance) bool {
 
 func (b *HookBackend) TapEnter(_ *Instance) {}
 
+// Recover is unsupported for remote sessions in v1 (#1108): a vanished remote
+// session is flagged Lost so it is visible, but reconnect semantics are a
+// design of their own — the restore loop skips remote instances.
+func (b *HookBackend) Recover(_ *Instance) error { return ErrRecoverUnsupported }
+
 // ListRemoteHookInstanceData converts running sessions reported by list_cmd
 // into persistable remote InstanceData records for the current repo.
 func ListRemoteHookInstanceData(repoPath string, hooks config.RemoteHooks, now time.Time) ([]InstanceData, error) {

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -3,6 +3,7 @@ package session
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -233,6 +234,69 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 	// tmux deps).
 	b.setupTabs(i)
 
+	return nil
+}
+
+// ErrRecoverUnsupported marks a backend without Lost-session recovery (#1108):
+// remote sessions are flagged Lost but not auto-reconnected in v1.
+var ErrRecoverUnsupported = fmt.Errorf("backend does not support recovery")
+
+// Recover re-establishes a Lost instance's tmux sessions (#1108): re-spawn the
+// agent program in its worktree with the same resolved-program flag injection
+// as a first-time launch (#1132 choke-point — never hand-rolled flag logic),
+// then bring the other tabs back through the same setupTabs path a restore
+// uses. Invoked ONLY by the daemon's restore loop; the #970 guard in Start
+// keeps loads side-effect free.
+//
+// Idempotence across retries: the injected program is recomputed from the
+// clean persisted i.Program on every attempt (SetProgram replaces, never
+// appends), so repeated failures never accumulate duplicate flags. On failure
+// only the agent tab's attach resources are released (the #1065 rule: no other
+// tab has opened a PTY yet on this path) and the tmux refs are kept, so the
+// next tick's retry reconnects each tab by its exact persisted name; the
+// instance stays a killable Lost row throughout.
+func (b *LocalBackend) Recover(i *Instance) error {
+	if status := i.GetStatus(); status != Lost {
+		return fmt.Errorf("recover: session %q is %v, not Lost", i.Title, status)
+	}
+	if i.UserKilled() {
+		return fmt.Errorf("recover: session %q carries a kill tombstone", i.Title)
+	}
+
+	i.mu.RLock()
+	ts := i.tmuxLocked()
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+	if ts == nil {
+		return fmt.Errorf("recover: session %q has no tmux binding", i.Title)
+	}
+	var workDir string
+	if gw != nil {
+		workDir = gw.GetWorktreePath()
+	}
+	if workDir == "" {
+		return fmt.Errorf("recover: session %q has no worktree to re-spawn into", i.Title)
+	}
+	if _, err := os.Stat(workDir); err != nil {
+		// Surface the real cause instead of a generic tmux new-session error:
+		// a deleted worktree is the expected permanent-failure shape, and the
+		// restore loop's escalation log should say so.
+		return fmt.Errorf("recover: session %q worktree unavailable: %w", i.Title, err)
+	}
+
+	ts.SetProgram(injectSystemPrompt(resolveProgramForInstance(i)))
+	if err := ts.Restore(workDir); err != nil {
+		if cleanupErr := ts.CloseAttachOnly(); cleanupErr != nil {
+			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
+		}
+		return fmt.Errorf("recover: failed to re-spawn session %q: %w", i.Title, err)
+	}
+	b.setupTabs(i)
+
+	// The program was just re-spawned and is booting: Running, exactly like a
+	// fresh create. The daemon poll re-derives Ready/Running from the live
+	// session from here on and persists the transition.
+	i.SetStatusIfNotDeleting(Running)
 	return nil
 }
 

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -107,4 +107,5 @@ func (b *FakeBackend) SetPreviewSize(*Instance, int, int) error  { return nil }
 func (b *FakeBackend) IsAlive(*Instance) bool                    { return true }
 func (b *FakeBackend) CheckAndHandleTrustPrompt(*Instance) bool  { return false }
 func (b *FakeBackend) TapEnter(*Instance)                        {}
+func (b *FakeBackend) Recover(*Instance) error                   { return nil }
 func (b *FakeBackend) Type() string                              { return "local" }

--- a/session/instance.go
+++ b/session/instance.go
@@ -1090,6 +1090,12 @@ func (i *Instance) Kill() error {
 	return i.backend.Kill(i)
 }
 
+// Recover re-establishes a Lost instance's backing session (#1108). Only the
+// daemon's restore loop calls this; loads stay side-effect free (#970).
+func (i *Instance) Recover() error {
+	return i.backend.Recover(i)
+}
+
 // CloseAttachOnly releases the resources this instance opened to view or drive
 // its session (a tmux attach PTY, a remote preview process) without destroying
 // the session, worktree, or remote record. Use it — never Kill — to discard a

--- a/session/recover_test.go
+++ b/session/recover_test.go
@@ -1,0 +1,184 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingExec wraps countingExec and additionally captures every
+// new-session command string, so tests can assert on the spawned program.
+func recordingExec(alive map[string]bool, newSessions *int, spawns *[]string) cmd_test.MockCmdExec {
+	inner := countingExec(alive, newSessions)
+	return cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "new-session") {
+				*spawns = append(*spawns, cmd.String())
+			}
+			return inner.Run(cmd)
+		},
+		OutputFunc: inner.Output,
+	}
+}
+
+// lostInstanceForRecover loads a Lost instance through the production path
+// (FromInstanceData → Start(false) → #970 guard, no re-spawn) with an
+// EXISTING worktree directory, ready for Recover.
+func lostInstanceForRecover(t *testing.T, agentName, shellName string, exec cmd_test.MockCmdExec) *Instance {
+	t.Helper()
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	t.Cleanup(func() { restoreTmuxSession = prev })
+
+	data := deadInstanceData(t, Lost, agentName, shellName)
+	require.NoError(t, os.MkdirAll(data.Worktree.WorktreePath, 0755))
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+	require.Equal(t, Lost, restored.GetStatus())
+	return restored
+}
+
+// TestRecover_RespawnsLostSession: the daemon's explicit Recover (#1108 PR 2)
+// re-spawns a Lost instance's tmux session in its worktree — the operation the
+// #970 guard forbids at load time — and flips the instance Running like a
+// fresh create. The spawned program must carry the resolved-program injection
+// (#1132 choke-point) exactly once.
+func TestRecover_RespawnsLostSession(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_recover_agent"
+	shellName := agentName + shellTmuxSuffix
+	var newSessions int
+	var spawns []string
+	exec := recordingExec(map[string]bool{}, &newSessions, &spawns)
+	restored := lostInstanceForRecover(t, agentName, shellName, exec)
+
+	require.NoError(t, restored.Recover())
+
+	assert.Greater(t, newSessions, 0, "Recover must re-spawn the missing tmux session")
+	assert.Equal(t, Running, restored.GetStatus(),
+		"a recovered session is booting its program: Running, like a fresh create")
+	assert.True(t, restored.TabAlive(0), "the agent session must exist server-side after Recover")
+
+	// The #1132 choke-point injected claude's --plugin-dir into the spawn —
+	// exactly once, recomputed from the clean persisted Program (repeated
+	// attempts must never accumulate flags).
+	require.NotEmpty(t, spawns)
+	agentSpawn := spawns[0]
+	assert.Equal(t, 1, strings.Count(agentSpawn, "--plugin-dir"),
+		"resolved-program injection must appear exactly once in the spawn: %s", agentSpawn)
+}
+
+// TestRecover_RetryAfterFailureInjectsFlagsOnce: a failed first attempt (the
+// outage still biting) must leave the instance retryable — still Lost, tmux
+// refs intact — and the eventual successful spawn must still carry the
+// injected flags exactly once.
+func TestRecover_RetryAfterFailureInjectsFlagsOnce(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_recover_retry"
+	shellName := agentName + shellTmuxSuffix
+	var newSessions, ptyNewSessions int
+	var spawns []string
+	exec := recordingExec(map[string]bool{}, &newSessions, &spawns)
+
+	// First new-session fails (server still hostile), later ones succeed.
+	pty := failFirstNewSessionPty{t: t, cmdExec: exec, count: &ptyNewSessions}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	t.Cleanup(func() { restoreTmuxSession = prev })
+
+	data := deadInstanceData(t, Lost, agentName, shellName)
+	require.NoError(t, os.MkdirAll(data.Worktree.WorktreePath, 0755))
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+
+	require.Error(t, restored.Recover(), "first attempt must surface the spawn failure")
+	assert.Equal(t, Lost, restored.GetStatus(), "a failed recover leaves the session Lost")
+	assert.True(t, restored.Started(), "a failed recover must keep the row killable")
+
+	require.NoError(t, restored.Recover(), "retry must succeed once the server behaves")
+	assert.Equal(t, Running, restored.GetStatus())
+	for _, spawn := range spawns {
+		if strings.Contains(spawn, agentName) && !strings.Contains(spawn, shellTmuxSuffix) {
+			assert.Equal(t, 1, strings.Count(spawn, "--plugin-dir"),
+				"every attempt recomputes injection from the clean Program: %s", spawn)
+		}
+	}
+}
+
+// TestRecover_FailsWithoutWorktree: a deleted worktree is the expected
+// permanent-failure shape; Recover must name it (the restore loop's
+// escalation log leans on this) and leave the session Lost and killable.
+func TestRecover_FailsWithoutWorktree(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_recover_nowt"
+	shellName := agentName + shellTmuxSuffix
+	var newSessions int
+	exec := countingExec(map[string]bool{}, &newSessions)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	t.Cleanup(func() { restoreTmuxSession = prev })
+
+	// Worktree path deliberately NOT created.
+	restored, err := FromInstanceData(deadInstanceData(t, Lost, agentName, shellName))
+	require.NoError(t, err)
+
+	err = restored.Recover()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "worktree", "the failure must name the missing worktree")
+	assert.Equal(t, 0, newSessions, "no spawn may happen without a worktree")
+	assert.Equal(t, Lost, restored.GetStatus())
+}
+
+// TestRecover_RefusesNonLostAndTombstoned: Recover is for Lost sessions only —
+// a live session must never be re-spawned over (adopt, never clobber), and a
+// tombstoned record's only future is having its kill finished.
+func TestRecover_RefusesNonLostAndTombstoned(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_recover_guard"
+	shellName := agentName + shellTmuxSuffix
+	var newSessions int
+	exec := countingExec(map[string]bool{agentName: true, shellName: true}, &newSessions)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	t.Cleanup(func() { restoreTmuxSession = prev })
+
+	live, err := FromInstanceData(deadInstanceData(t, Running, agentName, shellName))
+	require.NoError(t, err)
+	require.Error(t, live.Recover(), "a non-Lost session must be refused")
+
+	tombstoned := lostInstanceForRecover(t, "af_recover_guard2", "af_recover_guard2"+shellTmuxSuffix,
+		countingExec(map[string]bool{}, &newSessions))
+	tombstoned.MarkUserKilled()
+	require.Error(t, tombstoned.Recover(), "a tombstoned session must be refused")
+}

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -57,8 +57,9 @@ func (b *startBackend) CheckAndHandleTrustPrompt(*session.Instance) bool {
 	b.trustPrompts--
 	return true
 }
-func (b *startBackend) TapEnter(*session.Instance) {}
-func (b *startBackend) Type() string               { return "local" }
+func (b *startBackend) TapEnter(*session.Instance)      {}
+func (b *startBackend) Recover(*session.Instance) error { return nil }
+func (b *startBackend) Type() string                    { return "local" }
 
 func newStartTestInstance(t *testing.T, backend *startBackend) *session.Instance {
 	t.Helper()


### PR DESCRIPTION
PR 2 of the approved #1108/#1129 joint design ([design comment](https://github.com/sachiniyer/agent-factory/issues/1108#issuecomment-4880318833)): the restore loop. Builds on PR 1 (#1134, merged — Lost classification + tombstone) and consumes the #1132 resolved-program choke-point as required. Closes the loop the 2026-07-03 outages exposed: sessions stranded by a tmux-server death now come back on their own.

## What this does

- **`Backend.Recover` / `Instance.Recover`** (`session/`): the explicit recovery operation the #970 guard forbids at load time. `LocalBackend.Recover` re-derives the worktree dir (failing with a named "worktree unavailable" error when it's gone — the expected permanent-failure shape), injects the program through the **same #1132 choke-point as a fresh launch** (`injectSystemPrompt(resolveProgramForInstance(i))` — no hand-rolled flag logic), re-spawns via `TmuxSession.Restore` (which routes the resume-flag rewrite), brings the other tabs back through `setupTabs`, and flips the instance Running like a fresh create (the poll re-derives and persists from there). Injection is idempotent across retries: recomputed from the clean persisted `Program` each attempt, so repeated failures never accumulate flags. On failure only the agent tab's attach resources are released (the #1065 rule) and the tmux refs are kept, so the next retry reconnects each tab by its exact persisted name; the row stays a killable Lost throughout. `HookBackend.Recover` returns `ErrRecoverUnsupported` — remote reconnect is its own design; Lost remote sessions stay visible and killable.
- **`Manager.RestoreLostSessions`** (`daemon/lostrestore.go`): runs each poll tick after `RefreshStatuses` (which marks Lost) and `EnsureRootAgents` (which owns the reserved root via reap-and-recreate — the adopt/reap Lost handling shipped in PR 1). Per-session retry state clones the #1128 root-ensure discipline exactly: 10s→5m exponential backoff, **never a permanent give-up** (retries settle at the 5m cadence — an outage is indistinguishable from a deleted worktree while it lasts), one ERROR escalation at 6 consecutive failures that names the off-ramp ("kill the session to stop"). State is dropped on heal/kill/disappearance so the map never grows.
- **Eligibility**: local-backend, `Lost`, not tombstoned, not the reserved root, no kill in flight (the PR-1 `killsInFlight` guard is consulted, so a restore can't race an explicit kill's teardown). Remote Lost sessions log one informational note per episode and are left alone.

Together with PR 1 and the #1129 queue (PR 3, #1136): server dies → sessions marked Lost, events queue per task → next ticks re-spawn every Lost session in its worktree → queued events replay in order into the restored sessions. No daemon restart, no operator action.

## Tests

- `session/recover_test.go` (production-path harness from the #970 tests): Lost session re-spawns with `--plugin-dir` injected **exactly once**; failed first attempt leaves a retryable Lost row and the eventual spawn still carries flags exactly once; missing worktree fails with a named error and zero spawns; non-Lost and tombstoned sessions are refused.
- `daemon/lostrestore_test.go`: one-shot recovery + state cleanup + no-touch-after-heal; `KeepsRetryingAndHeals` past the escalation threshold (mirror of the #1128 root-ensure test); backoff-window suppression; skip matrix (tombstoned / kill-in-flight / remote / all non-Lost statuses / reserved root); retry-state cleanup for gone sessions.
- `task/start_test.go`'s bespoke backend gained the new interface method (the only non-embedding implementor; everything else embeds `FakeBackend`).

## Gates

`go build ./...`, `golangci-lint run --fast`, `gofmt -l` (empty), `deadcode -test` (empty), full suite under `make test-container` — green. Not merging — root verifies and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
