### PR TITLE
daemon,docs: event-queue retention + compaction + the outage e2e (#1129 PR 4)

### DIFF
--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -44,7 +45,21 @@ const (
 	// the rate limiter, with a running counter.
 	watcherQueueMaxEvents = 500
 	watcherQueueMaxBytes  = 256 * 1024
+
+	// watcherQueueMaxAge is the retention bound (#1129 PR 4): a queued event
+	// older than this is expired at drain time instead of delivered — a
+	// prompt about a three-day-old notification is noise, and the sources
+	// worth watching re-emit on their next poll. Expiries are logged with a
+	// count, never silent.
+	watcherQueueMaxAge = 72 * time.Hour
 )
+
+// watcherQueueCompactBytes caps the delivered prefix a queue file may
+// accumulate before it is compacted (the pending suffix rewritten to a fresh
+// file). The pending backlog is bounded by watcherQueueMaxBytes, but during a
+// long partial drain with live enqueues the delivered prefix would otherwise
+// grow without limit. Package var so tests can shrink it.
+var watcherQueueCompactBytes = int64(1024 * 1024)
 
 // queuedEvent is the on-disk record: the raw stdout line plus a per-queue
 // sequence number and enqueue timestamp for diagnostics (and the PR-4
@@ -255,7 +270,8 @@ func (q *eventQueue) peek() (ev queuedEvent, n int64, ok bool, err error) {
 }
 
 // advance consumes the oldest event AFTER its successful delivery: cursor
-// forward by the length peek reported, files removed once fully drained.
+// forward by the length peek reported, files removed once fully drained, and
+// the delivered prefix compacted away once it outgrows its cap.
 func (q *eventQueue) advance(n int64) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -276,7 +292,53 @@ func (q *eventQueue) advance(n int64) error {
 		}
 		return nil
 	}
+	if q.offset > watcherQueueCompactBytes {
+		if err := q.compactLocked(); err != nil {
+			// Compaction is an optimization; a failure must not lose the
+			// event that was just consumed. Fall through to the cursor write.
+			log.WarningLog.Printf("watch task %s: event-queue compaction failed (will retry later): %v", q.taskID, err)
+		}
+	}
 	return q.persistCursorLocked()
+}
+
+// compactLocked rewrites the queue file to just its pending suffix, dropping
+// the delivered prefix: copy suffix → temp file → rename over the original,
+// then reset the in-memory offset (the caller persists the cursor). Crash
+// safety is rename-based: a crash before the rename leaves the old
+// consistent (file, cursor) pair; a crash after the rename but before the
+// cursor write leaves a stale cursor pointing past the smaller new file,
+// which load()'s off<=size validation rejects — resetting to 0 and
+// redelivering the pending suffix (at-least-once, never loss). Callers hold
+// q.mu.
+func (q *eventQueue) compactLocked() error {
+	src, err := os.Open(q.path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = src.Close() }()
+	if _, err := src.Seek(q.offset, 0); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(q.path), q.taskID+".compact-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	n, err := io.Copy(tmp, src)
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, q.path); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	q.offset, q.size = 0, n
+	return nil
 }
 
 // readEventAtLocked reads and parses one JSONL record at the given offset,

--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -238,6 +238,115 @@ func TestEventQueue_DropsOldestOverEventCap(t *testing.T) {
 	}
 }
 
+// TestEventQueue_CompactsDeliveredPrefix (#1129 PR 4): once the delivered
+// prefix outgrows watcherQueueCompactBytes, advance rewrites the file down to
+// its pending suffix — offset back to 0, remaining events intact and in
+// order, and the state survives a reopen (the crash-recovery path).
+func TestEventQueue_CompactsDeliveredPrefix(t *testing.T) {
+	prev := watcherQueueCompactBytes
+	watcherQueueCompactBytes = 128
+	t.Cleanup(func() { watcherQueueCompactBytes = prev })
+
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab120007")
+	for i := 0; i < 10; i++ {
+		if err := q.enqueue(fmt.Sprintf("event-%d", i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+	sizeBefore := q.size
+
+	// Consume until the delivered prefix crosses the threshold; compaction
+	// must kick in and reset the offset while events remain pending.
+	for i := 0; i < 5; i++ {
+		_, n, ok, err := q.peek()
+		if err != nil || !ok {
+			t.Fatalf("peek %d: ok=%v err=%v", i, ok, err)
+		}
+		if err := q.advance(n); err != nil {
+			t.Fatalf("advance %d: %v", i, err)
+		}
+	}
+
+	q.mu.Lock()
+	offset, size, pending := q.offset, q.size, q.pending
+	q.mu.Unlock()
+	if pending != 5 {
+		t.Fatalf("pending = %d, want 5", pending)
+	}
+	// Compaction fires whenever the delivered prefix crosses the threshold,
+	// so the surviving prefix is always bounded by it (advances after the
+	// last compaction may legitimately re-accumulate up to the threshold).
+	if offset > watcherQueueCompactBytes {
+		t.Fatalf("offset = %d, want <= %d (compaction must bound the delivered prefix)", offset, watcherQueueCompactBytes)
+	}
+	if size >= sizeBefore {
+		t.Fatalf("file did not shrink: %d -> %d bytes", sizeBefore, size)
+	}
+
+	// The compacted queue must survive a reopen and drain the survivors in
+	// order.
+	reopened := newEventQueue(dir, "ab120007")
+	if got := reopened.pendingCount(); got != 5 {
+		t.Fatalf("reopened pending = %d, want 5", got)
+	}
+	for i := 5; i < 10; i++ {
+		ev, n, ok, err := reopened.peek()
+		if err != nil || !ok {
+			t.Fatalf("reopened peek %d: ok=%v err=%v", i, ok, err)
+		}
+		if want := fmt.Sprintf("event-%d", i); ev.Line != want {
+			t.Fatalf("compaction reordered/corrupted: got %q, want %q", ev.Line, want)
+		}
+		if err := reopened.advance(n); err != nil {
+			t.Fatalf("reopened advance: %v", err)
+		}
+	}
+}
+
+// TestWatcherDrainExpiresAgedEvents (#1129 PR 4): queued events older than
+// the retention bound are expired at drain time — never delivered — and a
+// fresh event still replays. Expiry empties the queue files like a normal
+// drain.
+func TestWatcherDrainExpiresAgedEvents(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := newTestSupervisor(t, staticTasks(watchTask("ab130005", `sleep 60`, dir)))
+	fd := &flakyDeliver{}
+	fd.healed.Store(true)
+	s.deliver = fd.deliver
+	s.queueMaxAge = 150 * time.Millisecond
+	queueDir, _ := s.queueDir()
+
+	// Two events queued before the watcher exists; both age past the bound.
+	seed := newEventQueue(queueDir, "ab130005")
+	for _, line := range []string{"stale-1", "stale-2"} {
+		if err := seed.enqueue(line); err != nil {
+			t.Fatalf("seed enqueue: %v", err)
+		}
+	}
+	time.Sleep(200 * time.Millisecond)
+	// A fresh third event right at reload time must still be delivered.
+	if err := seed.enqueue("fresh"); err != nil {
+		t.Fatalf("seed enqueue fresh: %v", err)
+	}
+
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	waitUntil(t, 10*time.Second, "the fresh event to replay and stale ones to expire", func() bool {
+		got := fd.delivered()
+		return len(got) == 1 && got[0] == "fresh"
+	})
+	waitUntil(t, 10*time.Second, "the expired queue files to be removed", func() bool {
+		_, err := os.Stat(filepath.Join(queueDir, "ab130005.jsonl"))
+		return os.IsNotExist(err)
+	})
+	if got := fd.delivered(); len(got) != 1 {
+		t.Fatalf("stale events must never be delivered, got %v", got)
+	}
+}
+
 // flakyDeliver fails every delivery until healed, then records successes. It
 // drives the outage→recovery shape end to end through a real watcher.
 type flakyDeliver struct {

--- a/daemon/outage_e2e_test.go
+++ b/daemon/outage_e2e_test.go
@@ -1,0 +1,128 @@
+package daemon
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestOutageEndToEnd_LostRestoreAndReplay is the shared #1108/#1129 e2e: the
+// full 2026-07-03-outage story on a real (sandboxed, package-private) tmux
+// server, through the real LocalBackend — no fakes on the session side.
+//
+//  1. A real session is created (a cheap non-agent program via
+//     program_overrides; #1132's generic readiness accepts it).
+//  2. Its tmux session is killed out from under it — the outage.
+//  3. The daemon status pass classifies it Lost (#1108 PR 1): no kill
+//     intent on record, so recovery-eligible. Not Dead, not reaped.
+//  4. A watch task fires events during the outage; every delivery fails and
+//     lands in the durable per-task queue (#1129 PR 3) instead of dropping.
+//  5. The restore loop re-spawns the session in place (#1108 PR 2).
+//  6. The drainer replays the queued events into the RESTORED session, in
+//     emission order, and the queue files clean up (#1129 PR 3/4).
+//
+// Everything the joint design promised, observable in one pane capture.
+func TestOutageEndToEnd_LostRestoreAndReplay(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	// Cheap real "agent": prints a banner and idles. The resolved command has
+	// no agent token, so no agent flags are injected and readiness is the
+	// generic any-output heuristic (#1132) — at create AND at recover.
+	cfg := config.DefaultConfig()
+	cfg.ProgramOverrides = map[string]string{"claude": "sh -c 'echo agent-ready; exec sleep 600'"}
+	if err := config.SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	data, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "worker",
+		RepoPath: repoPath,
+		Program:  "claude",
+		InPlace:  true, // repo's own tree: kill/cleanup never touches it (#1107)
+	})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = manager.KillSession(KillSessionRequest{Title: "worker", RepoID: repo.ID})
+	})
+	key := daemonInstanceKey(repo.ID, "worker")
+	manager.mu.Lock()
+	inst := manager.instances[key]
+	manager.mu.Unlock()
+	if inst == nil || data.TmuxName == "" {
+		t.Fatalf("created session not tracked or missing tmux name: %+v", data)
+	}
+
+	// ---- The outage: the tmux session dies out from under the live record.
+	if out, err := exec.Command("tmux", "kill-session", "-t", "="+data.TmuxName).CombinedOutput(); err != nil {
+		t.Fatalf("kill-session: %v: %s", err, out)
+	}
+
+	// The status pass must classify it Lost — recovery-eligible, no tombstone.
+	waitUntil(t, 10*time.Second, "the vanished session to be classified Lost", func() bool {
+		manager.RefreshStatuses()
+		return inst.GetStatus() == session.Lost
+	})
+
+	// ---- Events fire DURING the outage: a real watch script, deliveries
+	// into the dead session via the real SendPrompt path (tmux send-keys),
+	// which fails and queues.
+	dir := t.TempDir()
+	script := `echo replay-e1; echo replay-e2; echo replay-e3; sleep 300`
+	s, _ := newTestSupervisor(t, staticTasks(watchTask("ab140001", script, dir)))
+	s.deliver = func(taskID, line string) error {
+		return manager.SendPrompt(SendPromptRequest{Title: "worker", RepoID: repo.ID, Prompt: line})
+	}
+	queueDir, _ := s.queueDir()
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "all outage events to be queued durably", func() bool {
+		return newEventQueue(queueDir, "ab140001").pendingCount() == 3
+	})
+
+	// ---- The outage ends: the restore loop re-spawns the session in place.
+	zeroRestoreBackoff(t)
+	waitUntil(t, 10*time.Second, "the Lost session to be restored", func() bool {
+		manager.RestoreLostSessions()
+		return inst.GetStatus() != session.Lost && inst.TmuxAlive()
+	})
+
+	// ---- The drainer replays into the restored session, in emission order.
+	// The sent text is echoed by the pane's tty line discipline, so the
+	// replayed lines are observable in a real capture of the restored pane.
+	waitUntil(t, 30*time.Second, "queued events to replay into the restored pane in order", func() bool {
+		content, err := inst.Preview()
+		if err != nil {
+			return false
+		}
+		i1 := strings.Index(content, "replay-e1")
+		i2 := strings.Index(content, "replay-e2")
+		i3 := strings.Index(content, "replay-e3")
+		return i1 >= 0 && i2 > i1 && i3 > i2
+	})
+	waitUntil(t, 10*time.Second, "the drained queue files to clean up", func() bool {
+		return newEventQueue(queueDir, "ab140001").pendingCount() == 0
+	})
+
+	// The restored pane is the SAME session identity: re-spawned under its
+	// exact persisted tmux name. A fresh capture by that name proving the
+	// replayed content is the strongest identity check available.
+	if got := inst.GetStatus(); got == session.Lost || got == session.Dead {
+		t.Fatalf("session status = %v after the full recovery story; want live", got)
+	}
+}

--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -39,7 +39,8 @@ import (
 //     replays the backlog in order — before newer live events — once
 //     deliveries succeed again, rate-limited by the same 10/min window;
 //     the backlog is bounded (oldest dropped past 500 events / 256KB, with
-//     a logged count) and survives daemon restarts (#1129)
+//     a logged count), survives daemon restarts, and events older than 72h
+//     are expired at replay time with a logged count (#1129)
 //   - each run buffers its recent output (last 10 lines / 2KB: stdout lines
 //     that did not become delivered events, plus stderr). Non-zero exits log
 //     that tail, and the crash-loop breaker persists "errored: <exit>:
@@ -127,6 +128,7 @@ type watcherSupervisor struct {
 	stopGrace        time.Duration
 	drainBaseBackoff time.Duration
 	drainMaxBackoff  time.Duration
+	queueMaxAge      time.Duration
 }
 
 func newWatcherSupervisor() *watcherSupervisor {
@@ -146,6 +148,7 @@ func newWatcherSupervisor() *watcherSupervisor {
 		stopGrace:        watcherStopGrace,
 		drainBaseBackoff: watcherDrainBaseBackoff,
 		drainMaxBackoff:  watcherDrainMaxBackoff,
+		queueMaxAge:      watcherQueueMaxAge,
 	}
 }
 
@@ -906,7 +909,7 @@ func (w *taskWatcher) sleepStopAware(d time.Duration) bool {
 func (w *taskWatcher) drainLoop() {
 	defer w.wg.Done()
 	backoff := w.sup.drainBaseBackoff
-	replayed := 0
+	replayed, expired := 0, 0
 	for {
 		if w.stopRequested() {
 			w.stopDraining()
@@ -918,9 +921,22 @@ func (w *taskWatcher) drainLoop() {
 			w.stopDraining()
 			return
 		}
+		if ok && w.sup.queueMaxAge > 0 && time.Since(ev.TS) > w.sup.queueMaxAge {
+			// Retention (#1129): an event older than the age bound is expired
+			// instead of delivered — a prompt about a days-old notification is
+			// noise, and re-sweepable sources re-emit on their next poll.
+			// Counted and logged below, never silent.
+			if err := w.queue.advance(n); err != nil {
+				log.ErrorLog.Printf("watch task %s: failed to expire aged queued event; replay parked until the next reload: %v", w.taskID, err)
+				w.stopDraining()
+				return
+			}
+			expired++
+			continue
+		}
 		if !ok {
-			if replayed > 0 {
-				log.InfoLog.Printf("watch task %s: replayed %d queued event(s)", w.taskID, replayed)
+			if replayed > 0 || expired > 0 {
+				log.InfoLog.Printf("watch task %s: replayed %d queued event(s), expired %d older than %s", w.taskID, replayed, expired, w.sup.queueMaxAge)
 			}
 			w.stopDraining()
 			// Close the wake-up race: an event enqueued after the empty peek

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -61,11 +61,14 @@ af tasks add --name "gh-issues" --watch-cmd "./watch-issues.sh" \
 - **Exit 0 = intentional stop.** The task's status becomes `stopped` and the script is not restarted until the next daemon start, task edit, or re-enable.
 - **Non-zero exit = failure.** The script is restarted with exponential backoff, 1s doubling to a 5-minute cap. A run that stays healthy for 10 minutes resets the backoff.
 - **Crash-loop breaker**: 5 or more non-zero exits within 10 minutes set the status to `errored` and stop restarts. Re-arm by editing the task, toggling it, or restarting the daemon.
-- **Rate limit**: at most 10 events per minute per task. Excess events are dropped — never silently: a warning is logged with a running drop counter.
+- **Rate limit**: at most 10 events per minute per task. Excess events are dropped — never silently: a warning is logged with a running drop counter. Rate-dropped events are not queued for replay (the limit is protective policy, not an outage signal).
 - **Prompt rendering**: an empty `prompt` delivers the raw line; otherwise `{{line}}` is substituted. An event whose rendered prompt is empty is dropped with an error log.
-- **Ordering**: deliveries are serialized per task in emission order. A slow delivery backpressures the script's stdout rather than reordering events.
+- **Ordering**: deliveries are serialized per task in emission order. A slow delivery backpressures the script's stdout rather than reordering events, and replayed events (below) land before newer live ones.
 - **Process tree**: each script runs in its own process group. On stop the group gets SIGTERM, then SIGKILL after 5 seconds — backgrounded children do not outlive the watcher. Scripts should treat SIGTERM as "clean up and exit".
-- **No replay**: events are not persisted across daemon restarts. Scripts that poll should track their own cursor (see `examples/tasks/gh-issue-poll.sh`).
+- **Delivery failures are queued and replayed**: an event whose delivery fails — the target session unreachable, e.g. during a tmux outage — is appended to a durable per-task queue under `~/.agent-factory/events/` instead of dropped, and replayed **in emission order, before newer live events**, once deliveries succeed again (rate-limited by the same 10/min window). The backlog survives daemon restarts and reloads. Semantics and bounds:
+  - **At-least-once**: a daemon crash mid-replay redelivers at most one event. Prompts should tolerate a rare duplicate.
+  - **Bounds**: at most 500 events / 256KB queued per task — overflow drops the *oldest* with a logged count; events older than **72h** are expired at replay time, also logged. Sources worth watching re-emit on their next poll, so scripts that poll should still track their own cursor (see `examples/tasks/gh-issue-poll.sh`).
+  - **Disabled vs deleted**: a disabled task keeps its backlog and replays it on re-enable; a deleted task's queue is removed.
 
 Edits to delivery fields (`prompt`, `target_session`, `program`) apply from the next event without restarting the script; edits to `watch_cmd`, `project_path`, or `name` restart it.
 


### PR DESCRIPTION
PR 4 — final PR of the approved #1108/#1129 joint design ([#1108 comment](https://github.com/sachiniyer/agent-factory/issues/1108#issuecomment-4880318833), [#1129 comment](https://github.com/sachiniyer/agent-factory/issues/1129#issuecomment-4880319042)). PRs 1–3 (#1134, #1136, #1137) are all merged; #1108 is closed. Closes #1129.

## Replay hardening

- **Retention (72h)**: a queued event older than `watcherQueueMaxAge` is expired at drain time instead of delivered — a prompt about a days-old notification is noise, and re-sweepable sources re-emit on their next poll. Expiries are counted and logged with the replay summary, never silent. Supervisor-injectable for tests.
- **Compaction**: the pending backlog was already bounded (500/256KiB), but the *delivered prefix* of the queue file could grow without limit during a long partial drain with live enqueues. `advance` now compacts (pending suffix → temp file → rename) once the prefix crosses 1MiB. Crash-safe by construction: a crash before the rename keeps the old consistent (file, cursor) pair; a crash after it leaves a stale cursor pointing past the smaller file, which `load()`'s bounds validation rejects — reset to 0, redeliver the suffix (at-least-once, never loss). A compaction failure degrades to a warning; the consumed event is never lost.
- **Restart/reload replay** shipped in PR 3 (backlog recovery in `newTaskWatcher` + drain-at-start in `run()`, `TestWatcherBacklogSurvivesRestart`); nothing further was needed here.

## docs/tasks.md

The "No replay" bullet — now false — is replaced by the full contract: durable per-task queue under `~/.agent-factory/events/`, replay in emission order before newer live events, same 10/min window, at-least-once (≤1 duplicate per crash), bounds (500 events / 256KiB drop-oldest, 72h expiry, all logged), disabled-keeps-backlog vs deleted-removes-queue. The ordering and rate-limit bullets got the matching one-line updates (rate-dropped events are *not* queued).

## The shared end-to-end test

`TestOutageEndToEnd_LostRestoreAndReplay` (daemon package, real LocalBackend, real tmux on the package-private SandboxTmux server — no fakes on the session side) plays the full 2026-07-03 story in ~3s:

1. Real session created via `Manager.CreateSession` (cheap non-agent program through `program_overrides`; #1132's generic readiness accepts it at create and at recover).
2. Its tmux session is killed out from under it — the outage.
3. `RefreshStatuses` classifies it **Lost** (#1108 PR 1).
4. A real watch script fires three events during the outage; every delivery goes through the real `SendPrompt`/send-keys path, fails, and lands in the durable queue (#1129 PR 3).
5. `RestoreLostSessions` re-spawns the session in place (#1108 PR 2).
6. The drainer replays all three events **in emission order into the restored pane** — asserted from an actual `capture-pane` of the re-spawned session by its exact persisted name — and the queue files clean up.

Green at `-count=3` and under `-race`.

## Other tests

- `TestEventQueue_CompactsDeliveredPrefix` — threshold-triggered compaction bounds the prefix, survivors intact and ordered across a reopen (the crash-recovery path).
- `TestWatcherDrainExpiresAgedEvents` — stale events expire (never delivered), a fresh one still replays, files clean up.

## Gates

`go build ./...`, `golangci-lint run --fast`, `gofmt -l` (empty), `deadcode -test` (empty), full `make test-container` — green. Not merging — root verifies and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
