### PR TITLE
config: in-repo config.toml — both names accepted, never both at once (#1030 PR 3)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -700,12 +700,7 @@ func parseConfigTOML(data []byte, prettyConfigPath string) (*Config, error) {
 
 	config := DefaultConfig()
 	if err := toml.Unmarshal(data, config); err != nil {
-		var decodeErr *toml.DecodeError
-		if errors.As(err, &decodeErr) {
-			row, col := decodeErr.Position()
-			return nil, fmt.Errorf("failed to parse config file %s (line %d, column %d):\n%s", prettyConfigPath, row, col, decodeErr.String())
-		}
-		return nil, fmt.Errorf("failed to parse config file %s: %w", prettyConfigPath, err)
+		return nil, tomlParseError("config file "+prettyConfigPath, err)
 	}
 	warnUnknownTomlKeys(data, prettyConfigPath)
 
@@ -720,6 +715,19 @@ func parseConfigTOML(data []byte, prettyConfigPath string) (*Config, error) {
 func isEffectivelyEmptyToml(data []byte) bool {
 	trimmed := bytes.TrimPrefix(data, []byte("\xef\xbb\xbf"))
 	return len(bytes.TrimSpace(trimmed)) == 0
+}
+
+// tomlParseError renders a TOML decode failure for the file described by
+// what (e.g. "config file ~/.agent-factory/config.toml"), surfacing
+// pelletier's line/column and caret-annotated source snippet when available —
+// the error quality a hand-edited format owes its editors.
+func tomlParseError(what string, err error) error {
+	var decodeErr *toml.DecodeError
+	if errors.As(err, &decodeErr) {
+		row, col := decodeErr.Position()
+		return fmt.Errorf("failed to parse %s (line %d, column %d):\n%s", what, row, col, decodeErr.String())
+	}
+	return fmt.Errorf("failed to parse %s: %w", what, err)
 }
 
 // warnUnknownTomlKeys logs one warning per key in data that the Config

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 // InRepoConfigDirName is the directory at a repository root that holds the
@@ -18,24 +20,27 @@ import (
 const InRepoConfigDirName = ".agent-factory"
 
 // InRepoConfig is the subset of configuration a repository may declare for
-// itself in <repo-root>/.agent-factory/config.json. Repo-describing fields
-// (remote_hooks, post_worktree_commands) live here exclusively going forward;
-// preference fields (default_program, program_overrides) are valid both here
-// and in the global config, with the in-repo value winning. Global/daemon-only
-// keys are rejected by LoadInRepoConfig with an error naming the key.
+// itself in <repo-root>/.agent-factory/config.toml or config.json (#1030 —
+// both names are supported indefinitely: the file is checked into users'
+// repos, so a forced rename would break every collaborator still on an af
+// that only knows config.json). Repo-describing fields (remote_hooks,
+// post_worktree_commands) live here exclusively going forward; preference
+// fields (default_program, program_overrides) are valid both here and in the
+// global config, with the in-repo value winning. Global/daemon-only keys are
+// rejected by LoadInRepoConfig with an error naming the key.
 type InRepoConfig struct {
 	// DefaultProgram overrides the global default agent for sessions in this
 	// repo. Must be one of tmux.SupportedPrograms.
-	DefaultProgram string `json:"default_program,omitempty"`
+	DefaultProgram string `json:"default_program,omitempty" toml:"default_program,omitempty"`
 	// ProgramOverrides entries are merged key-wise over the global map: a key
 	// set here wins, global keys without an in-repo counterpart still apply.
-	ProgramOverrides map[string]string `json:"program_overrides,omitempty"`
+	ProgramOverrides map[string]string `json:"program_overrides,omitempty" toml:"program_overrides,omitempty"`
 	// PostWorktreeCommands replaces (not appends to) any legacy per-repo
 	// value when the key is present in the file — including an explicit
 	// empty array, which disables legacy commands.
-	PostWorktreeCommands []string `json:"post_worktree_commands,omitempty"`
+	PostWorktreeCommands []string `json:"post_worktree_commands,omitempty" toml:"post_worktree_commands,omitempty"`
 	// RemoteHooks configures the remote hook backend for this repo.
-	RemoteHooks *RemoteHooks `json:"remote_hooks,omitempty"`
+	RemoteHooks *RemoteHooks `json:"remote_hooks,omitempty" toml:"remote_hooks,omitempty"`
 
 	// setKeys records which top-level keys were present in the JSON file so
 	// the resolver can distinguish "set to an empty value" (overrides) from
@@ -110,11 +115,61 @@ func isPathStrictlyInside(absBase, absDir string) bool {
 	return true
 }
 
-// InRepoConfigPath returns the path of the in-repo config file for a repo
-// root. The file is optional; callers should use LoadInRepoConfig rather than
-// reading this path directly so symlink and file-type guards apply.
+// InRepoConfigPath returns the path of the in-repo JSON config file for a
+// repo root. The file is optional; callers should use LoadInRepoConfig rather
+// than reading this path directly so symlink and file-type guards apply.
 func InRepoConfigPath(repoRoot string) string {
 	return filepath.Join(repoRoot, InRepoConfigDirName, ConfigFileName)
+}
+
+// InRepoTomlConfigPath returns the path of the in-repo TOML config file for a
+// repo root (#1030). Exactly one of the two names may exist; LoadInRepoConfig
+// rejects a repo carrying both.
+func InRepoTomlConfigPath(repoRoot string) string {
+	return filepath.Join(repoRoot, InRepoConfigDirName, TomlConfigFileName)
+}
+
+// locateInRepoConfigFile picks the in-repo config file for a repo root:
+// config.toml or config.json, whichever exists ("" when neither does). A repo
+// carrying BOTH is a hard error rather than a precedence rule: this file
+// executes shell commands, the two copies are checked in by different people
+// at different times, and silently running one while a collaborator edits the
+// other is exactly the ambiguity the global-config toml-wins warning exists
+// to avoid — but in-repo there is no single owner to see a log line, so af
+// refuses to guess.
+func locateInRepoConfigFile(repoRoot string) (string, error) {
+	tomlPath := InRepoTomlConfigPath(repoRoot)
+	jsonPath := InRepoConfigPath(repoRoot)
+	tomlExists, err := lstatExists(tomlPath)
+	if err != nil {
+		return "", err
+	}
+	jsonExists, err := lstatExists(jsonPath)
+	if err != nil {
+		return "", err
+	}
+	switch {
+	case tomlExists && jsonExists:
+		return "", fmt.Errorf("both %s and %s exist; an in-repo config must have exactly one — delete one of them (they are never merged, and af will not guess which is live)",
+			prettyHomePath(tomlPath), prettyHomePath(jsonPath))
+	case tomlExists:
+		return tomlPath, nil
+	case jsonExists:
+		return jsonPath, nil
+	}
+	return "", nil
+}
+
+// lstatExists reports whether path exists (without following a final-symlink,
+// matching the read path's Lstat-then-resolve order).
+func lstatExists(path string) (bool, error) {
+	if _, err := os.Lstat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to stat in-repo config %s: %w", prettyHomePath(path), err)
+	}
+	return true, nil
 }
 
 // InRepoConfigHash returns the sha256 hex digest of the raw in-repo config
@@ -124,74 +179,81 @@ func InRepoConfigHash(data []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// readInRepoConfigFile locates and reads <repoRoot>/.agent-factory/config.json
-// with the path safety guards the location demands — the file ships inside a
-// repository, so it is attacker-influenced relative to the user's filesystem:
+// readInRepoConfigFile locates and reads the repo's in-repo config file
+// (config.toml or config.json — locateInRepoConfigFile rejects a repo with
+// both) with the path safety guards the location demands — the file ships
+// inside a repository, so it is attacker-influenced relative to the user's
+// filesystem:
 //   - symlinks are resolved and the resolved file must still live inside the
 //     (resolved) repo root, so a link to ~/.ssh or /etc can never be read and
 //     reported back in error messages;
 //   - the resolved path must be a regular file;
 //   - a repo rooted at the user's home directory (dotfiles repos) would make
-//     the in-repo path collide with the global ~/.agent-factory/config.json —
-//     that case is treated as "no in-repo config" instead of re-reading the
-//     global file with in-repo scoping rules and rejecting its global keys.
+//     the in-repo path collide with the global config file — that case is
+//     treated as "no in-repo config" instead of re-reading the global file
+//     with in-repo scoping rules and rejecting its global keys.
 //
-// Returns (nil, nil) when the file does not exist.
-func readInRepoConfigFile(repoRoot string) ([]byte, error) {
-	path := InRepoConfigPath(repoRoot)
-	if _, err := os.Lstat(path); err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to stat in-repo config %s: %w", prettyHomePath(path), err)
+// Returns (nil, "", nil) when no config file exists; otherwise the raw bytes
+// together with the (unresolved) path that was read, so callers know the
+// format and can name the real file in errors.
+func readInRepoConfigFile(repoRoot string) ([]byte, string, error) {
+	path, err := locateInRepoConfigFile(repoRoot)
+	if err != nil || path == "" {
+		return nil, "", err
 	}
 
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve in-repo config %s: %w", prettyHomePath(path), err)
+		return nil, "", fmt.Errorf("failed to resolve in-repo config %s: %w", prettyHomePath(path), err)
 	}
 	resolvedRoot, err := filepath.EvalSymlinks(repoRoot)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve repo root %s: %w", repoRoot, err)
+		return nil, "", fmt.Errorf("failed to resolve repo root %s: %w", repoRoot, err)
 	}
 	if !isPathStrictlyInside(resolved, filepath.Clean(resolvedRoot)) {
-		return nil, fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to read it", prettyHomePath(path), prettyHomePath(resolved))
+		return nil, "", fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to read it", prettyHomePath(path), prettyHomePath(resolved))
 	}
 
 	if configDir, dirErr := GetConfigDir(); dirErr == nil {
-		globalPath := filepath.Join(configDir, ConfigFileName)
-		if resolvedGlobal, evalErr := filepath.EvalSymlinks(globalPath); evalErr == nil && resolvedGlobal == resolved {
-			return nil, nil
+		for _, globalName := range []string{ConfigFileName, TomlConfigFileName} {
+			globalPath := filepath.Join(configDir, globalName)
+			if resolvedGlobal, evalErr := filepath.EvalSymlinks(globalPath); evalErr == nil && resolvedGlobal == resolved {
+				return nil, "", nil
+			}
 		}
 	}
 
 	info, err := os.Stat(resolved)
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat in-repo config %s: %w", prettyHomePath(path), err)
+		return nil, "", fmt.Errorf("failed to stat in-repo config %s: %w", prettyHomePath(path), err)
 	}
 	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("in-repo config %s is not a regular file", prettyHomePath(path))
+		return nil, "", fmt.Errorf("in-repo config %s is not a regular file", prettyHomePath(path))
 	}
 
 	data, err := os.ReadFile(resolved)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read in-repo config %s: %w", prettyHomePath(path), err)
+		return nil, "", fmt.Errorf("failed to read in-repo config %s: %w", prettyHomePath(path), err)
 	}
-	return data, nil
+	return data, path, nil
 }
 
-// LoadInRepoConfig reads and validates the in-repo config for a repo root.
+// LoadInRepoConfig reads and validates the in-repo config for a repo root —
+// <repo-root>/.agent-factory/config.toml or config.json, never both (#1030).
 // Returns (nil, nil, nil) when the repo has no in-repo config file. When the
 // file exists it is returned together with its raw bytes (for content-hash
 // tracking). Mirroring the LoadConfig contract (#734), a file that exists but
 // cannot be read, parsed, or validated is an error — never silently ignored.
+// Both formats run the identical key allowlist and enum validation; only the
+// decode step differs.
 func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
-	data, err := readInRepoConfigFile(repoRoot)
-	if err != nil || data == nil {
+	data, path, err := readInRepoConfigFile(repoRoot)
+	if err != nil || path == "" {
 		return nil, nil, err
 	}
+	isToml := filepath.Base(path) == TomlConfigFileName
 
-	prettyPath := prettyHomePath(InRepoConfigPath(repoRoot))
+	prettyPath := prettyHomePath(path)
 	// Name the real global config file rather than a hardcoded
 	// ~/.agent-factory/config.json, which is wrong when AGENT_FACTORY_HOME
 	// relocates the config dir (same class of bug as #890). Fall back to a
@@ -200,15 +262,40 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 	if configDir, dirErr := GetConfigDir(); dirErr == nil {
 		globalConfigLocation = prettyHomePath(filepath.Join(configDir, ConfigFileName))
 	}
-	if len(data) == 0 {
-		return nil, nil, fmt.Errorf("in-repo config %s is empty; delete it or add valid JSON", prettyPath)
+	if len(data) == 0 || (isToml && isEffectivelyEmptyToml(data)) {
+		// A contentless config.toml (zero bytes, whitespace, or a bare BOM)
+		// is valid TOML — an empty document — but an empty in-repo config is
+		// never something to declare on purpose; keep the loud contract for
+		// both formats (same guard as the global config, #1139 review).
+		format := "JSON"
+		if isToml {
+			format = "TOML"
+		}
+		return nil, nil, fmt.Errorf("in-repo config %s is empty; delete it or add valid %s", prettyPath, format)
 	}
 
-	var rawKeys map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawKeys); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse in-repo config %s: %w", prettyPath, err)
+	// Decode the top level twice: once shapeless for the key allowlist and
+	// setKeys presence tracking, once into the struct. The shapeless pass is
+	// what lets typos fail loudly in a file that can execute shell commands.
+	presentKeys := map[string]bool{}
+	if isToml {
+		var rawKeys map[string]any
+		if err := toml.Unmarshal(data, &rawKeys); err != nil {
+			return nil, nil, tomlParseError("in-repo config "+prettyPath, err)
+		}
+		for key := range rawKeys {
+			presentKeys[key] = true
+		}
+	} else {
+		var rawKeys map[string]json.RawMessage
+		if err := json.Unmarshal(data, &rawKeys); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse in-repo config %s: %w", prettyPath, err)
+		}
+		for key := range rawKeys {
+			presentKeys[key] = true
+		}
 	}
-	for key := range rawKeys {
+	for key := range presentKeys {
 		if inRepoGlobalOnlyKeys[key] {
 			return nil, nil, fmt.Errorf("in-repo config %s: %q is a global setting and cannot be set per-repo; move it to %s and remove it from this file", prettyPath, key, globalConfigLocation)
 		}
@@ -225,13 +312,16 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 	}
 
 	var cfg InRepoConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse in-repo config %s: %w", prettyPath, err)
+	if isToml {
+		if err := toml.Unmarshal(data, &cfg); err != nil {
+			return nil, nil, tomlParseError("in-repo config "+prettyPath, err)
+		}
+	} else {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse in-repo config %s: %w", prettyPath, err)
+		}
 	}
-	cfg.setKeys = make(map[string]bool, len(rawKeys))
-	for key := range rawKeys {
-		cfg.setKeys[key] = true
-	}
+	cfg.setKeys = presentKeys
 
 	if cfg.DefaultProgram != "" {
 		if err := ValidateProgramEnum(
@@ -288,11 +378,24 @@ func resolveSymlinksForCompare(path string) string {
 // When the config file is a symlink (to elsewhere inside the repo), the
 // update is written to the resolved target and the symlink is preserved,
 // matching the read path's resolution.
+//
+// Format follows the file (#1030): an existing config.json stays JSON — the
+// file is checked into the user's repo, and af never converts a checked-in
+// file out from under the user's collaborators — while an existing
+// config.toml is updated as TOML. Only when NO in-repo config exists yet is
+// a new file created, as config.toml.
 func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 	if repoRoot == "" {
 		return fmt.Errorf("repo root is required to save in-repo config")
 	}
-	path := InRepoConfigPath(repoRoot)
+	path, err := locateInRepoConfigFile(repoRoot)
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		path = InRepoTomlConfigPath(repoRoot)
+	}
+	isToml := filepath.Base(path) == TomlConfigFileName
 	// Compare resolved paths, not Clean-ed strings (#812): a symlinked
 	// AGENT_FACTORY_HOME (or a symlinked .agent-factory dir) makes distinct
 	// strings name the same file, and these guards exist precisely for the
@@ -302,9 +405,11 @@ func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 	// collide with the global config file; writing hooks there would clobber
 	// the user's global settings.
 	if configDir, dirErr := GetConfigDir(); dirErr == nil {
-		globalPath := filepath.Join(configDir, ConfigFileName)
-		if resolvedPath == resolveSymlinksForCompare(globalPath) {
-			return fmt.Errorf("in-repo config path %s collides with the global config file %s; not saving — run this from a repo whose root is not the config home", prettyHomePath(path), prettyHomePath(globalPath))
+		for _, globalName := range []string{ConfigFileName, TomlConfigFileName} {
+			globalPath := filepath.Join(configDir, globalName)
+			if resolvedPath == resolveSymlinksForCompare(globalPath) {
+				return fmt.Errorf("in-repo config path %s collides with the global config file %s; not saving — run this from a repo whose root is not the config home", prettyHomePath(path), prettyHomePath(globalPath))
+			}
 		}
 	}
 	// Mirror the read-path containment guard for writes: a .agent-factory
@@ -314,28 +419,42 @@ func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 	if !isPathStrictlyInside(resolvedPath, resolveSymlinksForCompare(repoRoot)) {
 		return fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to save it", prettyHomePath(path), prettyHomePath(resolvedPath))
 	}
-	data, err := readInRepoConfigFile(repoRoot)
+	data, _, err := readInRepoConfigFile(repoRoot)
 	if err != nil {
 		return err
-	}
-	rawKeys := map[string]json.RawMessage{}
-	if len(data) > 0 {
-		if err := json.Unmarshal(data, &rawKeys); err != nil {
-			return fmt.Errorf("failed to parse in-repo config %s: %w", prettyHomePath(InRepoConfigPath(repoRoot)), err)
-		}
 	}
 	if commands == nil {
 		commands = []string{}
 	}
-	encoded, err := json.Marshal(commands)
-	if err != nil {
-		return fmt.Errorf("failed to marshal post_worktree_commands: %w", err)
-	}
-	rawKeys["post_worktree_commands"] = encoded
-
-	out, err := json.MarshalIndent(rawKeys, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal in-repo config: %w", err)
+	var out []byte
+	if isToml {
+		rawKeys := map[string]any{}
+		if len(data) > 0 {
+			if err := toml.Unmarshal(data, &rawKeys); err != nil {
+				return tomlParseError("in-repo config "+prettyHomePath(path), err)
+			}
+		}
+		rawKeys["post_worktree_commands"] = commands
+		out, err = toml.Marshal(rawKeys)
+		if err != nil {
+			return fmt.Errorf("failed to marshal in-repo config: %w", err)
+		}
+	} else {
+		rawKeys := map[string]json.RawMessage{}
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &rawKeys); err != nil {
+				return fmt.Errorf("failed to parse in-repo config %s: %w", prettyHomePath(path), err)
+			}
+		}
+		encoded, err := json.Marshal(commands)
+		if err != nil {
+			return fmt.Errorf("failed to marshal post_worktree_commands: %w", err)
+		}
+		rawKeys["post_worktree_commands"] = encoded
+		out, err = json.MarshalIndent(rawKeys, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal in-repo config: %w", err)
+		}
 	}
 	dir := filepath.Join(repoRoot, InRepoConfigDirName)
 	if err := os.MkdirAll(dir, 0755); err != nil {

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -276,8 +276,10 @@ func TestSaveInRepoRefusesSymlinkDirOutsideRepo(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "outside the repository")
 
-	_, statErr := os.Stat(filepath.Join(outsideDir, ConfigFileName))
-	assert.True(t, os.IsNotExist(statErr), "nothing must be written outside the repo")
+	for _, name := range []string{ConfigFileName, TomlConfigFileName} {
+		_, statErr := os.Stat(filepath.Join(outsideDir, name))
+		assert.True(t, os.IsNotExist(statErr), "nothing must be written outside the repo (%s)", name)
+	}
 }
 
 func TestSaveInRepoPostWorktreeCommands(t *testing.T) {

--- a/config/inrepo_toml_test.go
+++ b/config/inrepo_toml_test.go
@@ -1,0 +1,269 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeInRepoTomlConfig materializes <repoRoot>/.agent-factory/config.toml
+// with the given content and returns its path.
+func writeInRepoTomlConfig(t *testing.T, repoRoot, content string) string {
+	t.Helper()
+	dir := filepath.Join(repoRoot, InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	path := filepath.Join(dir, TomlConfigFileName)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}
+
+func TestLoadInRepoConfigTOMLFields(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	writeInRepoTomlConfig(t, repoRoot, `
+default_program = "aider"
+post_worktree_commands = ["npm install"]
+
+[program_overrides]
+codex = "/opt/codex --fast"
+
+[remote_hooks]
+launch_cmd = "l"
+list_cmd = "ls"
+attach_cmd = "a"
+delete_cmd = "d"
+`)
+
+	cfg, raw, err := LoadInRepoConfig(repoRoot)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.NotEmpty(t, raw)
+	assert.Equal(t, "aider", cfg.DefaultProgram)
+	assert.Equal(t, "/opt/codex --fast", cfg.ProgramOverrides["codex"])
+	assert.Equal(t, []string{"npm install"}, cfg.PostWorktreeCommands)
+	require.NotNil(t, cfg.RemoteHooks)
+	assert.Equal(t, "l", cfg.RemoteHooks.LaunchCmd)
+	for _, key := range []string{"default_program", "program_overrides", "post_worktree_commands", "remote_hooks"} {
+		assert.True(t, cfg.IsSet(key), "expected %s to be marked set", key)
+	}
+	assert.Equal(t, []string{"post_worktree_commands", "program_overrides", "remote_hooks"}, cfg.CommandBearingFields())
+}
+
+func TestLoadInRepoConfigTOMLEmptyValueIsSet(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	writeInRepoTomlConfig(t, repoRoot, "post_worktree_commands = []\n")
+
+	cfg, _, err := LoadInRepoConfig(repoRoot)
+	require.NoError(t, err)
+	assert.True(t, cfg.IsSet("post_worktree_commands"))
+	assert.Empty(t, cfg.PostWorktreeCommands)
+	assert.False(t, cfg.IsSet("remote_hooks"))
+}
+
+func TestLoadInRepoConfigRejectsBothFormats(t *testing.T) {
+	// A repo carrying config.toml AND config.json is a hard error, not a
+	// precedence rule: the file executes shell commands and the two copies
+	// may be edited by different collaborators — af must not guess which is
+	// live (#1030).
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	writeInRepoConfig(t, repoRoot, `{"default_program": "codex"}`)
+	writeInRepoTomlConfig(t, repoRoot, `default_program = "aider"`+"\n")
+
+	_, _, err := LoadInRepoConfig(repoRoot)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), TomlConfigFileName)
+	assert.Contains(t, err.Error(), ConfigFileName)
+	assert.Contains(t, err.Error(), "exactly one")
+
+	// The save path must refuse identically instead of picking a side.
+	err = SaveInRepoPostWorktreeCommands(repoRoot, []string{"echo hi"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
+}
+
+func TestLoadInRepoConfigTOMLKeyPolicy(t *testing.T) {
+	t.Run("rejects global-only key", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("AGENT_FACTORY_HOME", home)
+		repoRoot := t.TempDir()
+		writeInRepoTomlConfig(t, repoRoot, `auto_yes = true`+"\n")
+
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "auto_yes")
+		assert.Contains(t, err.Error(), "global setting")
+	})
+
+	t.Run("rejects unknown key", func(t *testing.T) {
+		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+		repoRoot := t.TempDir()
+		writeInRepoTomlConfig(t, repoRoot, `post_worktree_cmds = ["typo"]`+"\n")
+
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "post_worktree_cmds")
+		assert.Contains(t, err.Error(), "allowed keys")
+	})
+
+	t.Run("validates program enums", func(t *testing.T) {
+		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+		repoRoot := t.TempDir()
+		writeInRepoTomlConfig(t, repoRoot, `default_program = "claude --model opus"`+"\n")
+
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "program_overrides")
+	})
+}
+
+func TestLoadInRepoConfigTOMLMalformed(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("contentless file", func(t *testing.T) {
+		// Zero bytes, whitespace-only, and BOM-only all decode as a valid
+		// empty TOML document; each must stay a loud error (#1139 review).
+		for name, content := range map[string]string{
+			"zero-byte":       "",
+			"whitespace-only": " \n\t\n",
+			"BOM-only":        "\xef\xbb\xbf",
+		} {
+			t.Run(name, func(t *testing.T) {
+				repoRoot := t.TempDir()
+				writeInRepoTomlConfig(t, repoRoot, content)
+				_, _, err := LoadInRepoConfig(repoRoot)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "empty")
+				assert.Contains(t, err.Error(), "TOML")
+			})
+		}
+	})
+
+	t.Run("invalid toml names file and line", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoTomlConfig(t, repoRoot, "default_program = \"codex\"\npost_worktree_commands = [\n")
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), TomlConfigFileName)
+		assert.Contains(t, err.Error(), "line")
+	})
+}
+
+func TestLoadInRepoConfigTOMLTraversalSafety(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("symlinked toml outside repo is rejected", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		outside := filepath.Join(t.TempDir(), "outside.toml")
+		require.NoError(t, os.WriteFile(outside, []byte(`default_program = "codex"`+"\n"), 0644))
+		require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, InRepoConfigDirName), 0755))
+		require.NoError(t, os.Symlink(outside, InRepoTomlConfigPath(repoRoot)))
+
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the repository")
+	})
+
+	t.Run("global config.toml symlinked as in-repo is treated as absent", func(t *testing.T) {
+		// The dotfiles-repo guard must cover the TOML global file too: a
+		// repo rooted at the config home would otherwise re-read the global
+		// config under in-repo scoping rules.
+		repoRoot := t.TempDir()
+		t.Setenv("AGENT_FACTORY_HOME", filepath.Join(repoRoot, InRepoConfigDirName))
+		writeInRepoTomlConfig(t, repoRoot, `default_program = "codex"`+"\n")
+
+		cfg, raw, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Nil(t, cfg)
+		assert.Nil(t, raw)
+	})
+}
+
+func TestSaveInRepoPostWorktreeCommandsTOML(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("a repo with no config gets a new config.toml", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		require.NoError(t, SaveInRepoPostWorktreeCommands(repoRoot, []string{"make setup"}))
+
+		_, statErr := os.Stat(InRepoTomlConfigPath(repoRoot))
+		require.NoError(t, statErr, "new in-repo configs are created as config.toml")
+		_, statErr = os.Stat(InRepoConfigPath(repoRoot))
+		assert.True(t, os.IsNotExist(statErr), "no config.json must appear alongside")
+
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"make setup"}, cfg.PostWorktreeCommands)
+	})
+
+	t.Run("an existing config.json stays JSON", func(t *testing.T) {
+		// The file is checked into the user's repo; converting it out from
+		// under collaborators on an older af is not af's call to make.
+		repoRoot := t.TempDir()
+		writeInRepoConfig(t, repoRoot, `{"default_program": "gemini"}`)
+		require.NoError(t, SaveInRepoPostWorktreeCommands(repoRoot, []string{"make setup"}))
+
+		_, statErr := os.Stat(InRepoTomlConfigPath(repoRoot))
+		assert.True(t, os.IsNotExist(statErr), "saving into a json repo must not create config.toml")
+
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, "gemini", cfg.DefaultProgram)
+		assert.Equal(t, []string{"make setup"}, cfg.PostWorktreeCommands)
+	})
+
+	t.Run("an existing config.toml is updated in place preserving fields", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoTomlConfig(t, repoRoot, `
+default_program = "gemini"
+
+[remote_hooks]
+launch_cmd = "l"
+attach_cmd = "a"
+delete_cmd = "d"
+`)
+		require.NoError(t, SaveInRepoPostWorktreeCommands(repoRoot, []string{"go generate ./..."}))
+
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, "gemini", cfg.DefaultProgram)
+		require.NotNil(t, cfg.RemoteHooks)
+		assert.Equal(t, "l", cfg.RemoteHooks.LaunchCmd)
+		assert.Equal(t, []string{"go generate ./..."}, cfg.PostWorktreeCommands)
+	})
+
+	t.Run("empty list is written as an explicit key", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoTomlConfig(t, repoRoot, `default_program = "codex"`+"\n")
+		require.NoError(t, SaveInRepoPostWorktreeCommands(repoRoot, nil))
+
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.True(t, cfg.IsSet("post_worktree_commands"))
+		assert.Empty(t, cfg.PostWorktreeCommands)
+	})
+
+	t.Run("writes through a symlinked config.toml", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		target := filepath.Join(repoRoot, "shared-config.toml")
+		require.NoError(t, os.WriteFile(target, []byte(`default_program = "codex"`+"\n"), 0644))
+		require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, InRepoConfigDirName), 0755))
+		linkPath := InRepoTomlConfigPath(repoRoot)
+		require.NoError(t, os.Symlink(target, linkPath))
+
+		require.NoError(t, SaveInRepoPostWorktreeCommands(repoRoot, []string{"make setup"}))
+
+		info, err := os.Lstat(linkPath)
+		require.NoError(t, err)
+		assert.NotZero(t, info.Mode()&os.ModeSymlink, "config path must still be a symlink after save")
+
+		cfg, _, err := LoadInRepoConfig(repoRoot)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"make setup"}, cfg.PostWorktreeCommands)
+		assert.Equal(t, "codex", cfg.DefaultProgram)
+	})
+}

--- a/config/repo_config.go
+++ b/config/repo_config.go
@@ -14,16 +14,16 @@ const RepoConfigFileName = "config.json"
 // sessions. When present in a repo config, sessions for that repo use the
 // remote hook backend instead of local tmux+git worktrees.
 type RemoteHooks struct {
-	LaunchCmd string `json:"launch_cmd"`
-	ListCmd   string `json:"list_cmd"`
-	AttachCmd string `json:"attach_cmd"`
-	DeleteCmd string `json:"delete_cmd"`
+	LaunchCmd string `json:"launch_cmd" toml:"launch_cmd"`
+	ListCmd   string `json:"list_cmd" toml:"list_cmd"`
+	AttachCmd string `json:"attach_cmd" toml:"attach_cmd"`
+	DeleteCmd string `json:"delete_cmd" toml:"delete_cmd"`
 	// TerminalCmd, when set, powers the Terminal tab for remote sessions: it
 	// is invoked with the session's hook name and should open an interactive
 	// shell in the remote workspace (vs attach_cmd, which attaches to the
 	// agent's own tmux session). Optional — empty means the Terminal tab
 	// keeps its "not available" fallback for remote sessions (#843).
-	TerminalCmd string `json:"terminal_cmd,omitempty"`
+	TerminalCmd string `json:"terminal_cmd,omitempty" toml:"terminal_cmd,omitempty"`
 }
 
 // Validate checks that the command strings required to operate a remote hook


### PR DESCRIPTION
Part of #1030 (design comment: https://github.com/sachiniyer/agent-factory/issues/1030#issuecomment-4880518994) — PR 3 of the approved breakdown. **Stacked on #1139** (base is its branch; retarget/rebase to master after it merges — the diff shown here is PR 3 only).

## What

- The in-repo config loads from `.agent-factory/config.toml` **or** `config.json` — both names accepted **indefinitely**. The file is checked into users' repos, so a forced rename would break every collaborator still on an af that only knows config.json; docs will advise keeping config.json while a team runs mixed af versions.
- A repo carrying **both** files is a hard error naming the two files (load AND save paths). Not a precedence rule, deliberately: this file executes shell commands and the two copies may be edited by different collaborators — unlike the global config there is no single owner to see a toml-wins log line, so af refuses to guess.
- Both formats share the identical semantics: key allowlist + global-only-key rejection (typos still fail loudly), `setKeys` presence tracking (`post_worktree_commands = []` still disables legacy commands), program-enum validation, and every path-safety guard — symlink containment, regular-file check, and the dotfiles-repo collision guard, which now also covers a global `config.toml`.
- `SaveInRepoPostWorktreeCommands` (the `H` hooks editor) is **format-preserving**: an existing config.json stays JSON — af never converts a checked-in file out from under a user's collaborators — an existing config.toml is updated as TOML (other fields preserved, symlink write-through per #1092), and only a repo with NO in-repo config gets a new file, created as config.toml.
- The contentless-TOML guard from the #1139 review (zero-byte / whitespace-only / BOM-only) applies to the in-repo file too.
- TOML parse errors use the shared `tomlParseError` rendering (line/column + caret-annotated snippet); the global-config parse path was refactored onto the same helper.

## Explicitly unchanged

- Legacy `~/.agent-factory/repos/<id>/config.json` stays JSON-only on its existing #800 deprecation clock.
- No docs/examples changes (PR 4, held).

## Tests

New `config/inrepo_toml_test.go`: field/table decoding incl. `[remote_hooks]`, setKeys/CommandBearingFields parity, both-files hard error on load and save, global-only + unknown-key + enum rejection in TOML, contentless-file variants, symlinked-toml-outside-repo rejection, global-toml-as-in-repo treated as absent, and the full save matrix (new repo → toml; json repo stays json; toml updated in place; explicit empty key; symlink write-through). Existing json tests untouched and green.

## Gates

- `go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` clean
- `make test-container` — full suite green (all packages ok)

Do not merge — root verifies and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)