### PR TITLE
keys,config: [keys] keymap in config.toml — rebindable actions, hard-error validation, one binding source (#1026, #1030 PR 5)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1207,8 +1207,12 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		}
 	}
 
-	// Handle quit commands
-	if msg.String() == "ctrl+c" || msg.String() == "q" {
+	// Ctrl+C is an always-on hard exit — never rebindable, so it stays a
+	// hardcoded check ahead of the keymap. The quit VERB (default q, or
+	// whatever [keys].quit rebinds it to) dispatches through the generated
+	// table like every other rebindable action, via keys.KeyQuit in
+	// handleDefaultKeyPress (#1026).
+	if msg.String() == "ctrl+c" {
 		return m.handleQuit()
 	}
 

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -110,6 +110,8 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 		return m.handleEnter()
 	case keys.KeyAttach:
 		return m.handleAttach()
+	case keys.KeyQuit:
+		return m.handleQuit()
 
 	default:
 		return m, nil

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -3,11 +3,13 @@ package app
 import (
 	"fmt"
 
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -161,7 +163,7 @@ func (m *home) handleStateTasks(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if !consumed {
-		if msg.String() == "ctrl+c" || msg.String() == "q" {
+		if msg.String() == "ctrl+c" || key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit]) {
 			return m.handleQuit()
 		}
 	}
@@ -194,7 +196,7 @@ func (m *home) handleStateHooks(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if !consumed {
-		if msg.String() == "ctrl+c" || msg.String() == "q" {
+		if msg.String() == "ctrl+c" || key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit]) {
 			return m.handleQuit()
 		}
 	}

--- a/app/help.go
+++ b/app/help.go
@@ -2,6 +2,9 @@ package app
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -11,6 +14,62 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
+
+// helpKey renders the effective key glyph(s) for an action from the generated
+// binding table, so a [keys] rebind surfaces in the help overlay exactly as
+// it does in the bottom menu and dispatch (#1026 — one source of truth). The
+// help text is the single place these bindings are shown in full, so it must
+// never fall back to a hardcoded literal.
+func helpKey(name keys.KeyName) string {
+	return keys.GlobalKeyBindings[name].Help().Key
+}
+
+// helpRow is one key→description line in the help overlay. key is a
+// pre-rendered glyph string (usually from helpKey); literal is used for the
+// handful of entries with no rebindable action (e.g. the detach key or the
+// run-task shortcut).
+type helpRow struct {
+	key  string
+	desc string
+}
+
+// helpSection is a titled group of help rows.
+type helpSection struct {
+	title string
+	rows  []helpRow
+}
+
+// renderHelpSections lays the sections out with a single key column whose
+// width fits the widest effective key across ALL sections, so the dashes stay
+// aligned no matter how wide a rebind makes a key. Computing the width at
+// render time (rather than the old hardcoded padding) is what keeps the
+// overlay correct under arbitrary rebinds.
+func renderHelpSections(header string, sections []helpSection) string {
+	width := 0
+	for _, s := range sections {
+		for _, r := range s.rows {
+			if w := lipgloss.Width(r.key); w > width {
+				width = w
+			}
+		}
+	}
+
+	var lines []string
+	lines = append(lines, header, "")
+	for _, s := range sections {
+		lines = append(lines, headerStyle.Render(s.title))
+		for _, r := range s.rows {
+			pad := strings.Repeat(" ", width-lipgloss.Width(r.key)+2)
+			lines = append(lines, keyStyle.Render(r.key)+pad+descStyle.Render("- "+r.desc))
+		}
+		lines = append(lines, "")
+	}
+	// Drop the trailing blank so the overlay isn't bottom-padded.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+}
 
 type helpText interface {
 	// toContent returns the help UI content.
@@ -38,49 +97,55 @@ func helpStart(instance *session.Instance) helpText {
 }
 
 func (h helpTypeGeneral) toContent() string {
-	content := lipgloss.JoinVertical(lipgloss.Left,
+	// Every key glyph below is pulled from the generated binding table via
+	// helpKey, so [keys] rebinds appear here identically to the bottom menu
+	// (#1026). The two entries with no rebindable action — the run-task
+	// shortcut and the tmux detach key — stay literal.
+	navKeys := helpKey(keys.KeyUp) + ", " + helpKey(keys.KeyDown)
+	header := lipgloss.JoinVertical(lipgloss.Left,
 		titleStyle.Render(fmt.Sprintf("Agent Factory v%s", Version)),
 		"",
 		"A terminal UI that manages multiple Claude Code (and other local agents) in separate workspaces.",
-		"",
-		headerStyle.Render("Managing:"),
-		keyStyle.Render("n")+descStyle.Render("         - Create a new session"),
-		keyStyle.Render("N")+descStyle.Render("         - Create a new remote session (requires remote_hooks config)"),
-		keyStyle.Render("S")+descStyle.Render("         - Manage tasks (n inside the manager creates one)"),
-		keyStyle.Render("r")+descStyle.Render("         - Run selected task now"),
-		keyStyle.Render("D")+descStyle.Render("         - Kill (delete) the selected session"),
-		keyStyle.Render("↑/k, ↓/j")+descStyle.Render("  - Navigate between sessions"),
-		keyStyle.Render("↵")+descStyle.Render("         - Interact with the session in its pane (all keys go to it)"),
-		keyStyle.Render("ctrl+]")+descStyle.Render("    - Leave interactive mode (back to navigation)"),
-		keyStyle.Render("o")+descStyle.Render("         - Attach to the selected session full-screen"),
-		keyStyle.Render(tmux.DetachKeyDisplay)+descStyle.Render("    - Detach from a full-screen session"),
-		"",
-		headerStyle.Render("Workspace:"),
-		keyStyle.Render("tab")+descStyle.Render("       - Cycle focus: tree → open panes → automations"),
-		keyStyle.Render("shift+tab")+descStyle.Render(" - Cycle focus backwards"),
-		keyStyle.Render("s")+descStyle.Render("         - Open the selected tab as a pane (or focus its pane)"),
-		keyStyle.Render("x")+descStyle.Render("         - Hide the focused pane (the tab keeps running)"),
-		keyStyle.Render("↑/k, ↓/j")+descStyle.Render("  - Navigate the tree (instances and their tabs)"),
-		keyStyle.Render("h/←")+descStyle.Render("       - Collapse the selected instance's tabs"),
-		keyStyle.Render("l/→")+descStyle.Render("       - Expand the selected instance's tabs"),
-		"",
-		headerStyle.Render("Configuration:"),
-		keyStyle.Render("H")+descStyle.Render("         - Open the worktree hooks editor"),
-		"",
-		headerStyle.Render("GitHub PR:"),
-		keyStyle.Render("p")+descStyle.Render("         - Open PR in browser"),
-		keyStyle.Render("P")+descStyle.Render("         - Copy PR URL to clipboard"),
-		"",
-		headerStyle.Render("Tabs:"),
-		keyStyle.Render("1-9")+descStyle.Render("       - Select a tab by number (s opens it, enter attaches)"),
-		keyStyle.Render("t")+descStyle.Render("         - Open a new terminal tab"),
-		keyStyle.Render("w")+descStyle.Render("         - Close the current tab (the agent tab can't be closed)"),
-		keyStyle.Render("shift-↓/↑")+descStyle.Render(" - Scroll in the current tab"),
-		"",
-		headerStyle.Render("Other:"),
-		keyStyle.Render("q")+descStyle.Render("         - Quit the application"),
 	)
-	return content
+	return renderHelpSections(header, []helpSection{
+		{title: "Managing:", rows: []helpRow{
+			{helpKey(keys.KeyNew), "Create a new session"},
+			{helpKey(keys.KeyNewRemote), "Create a new remote session (requires remote_hooks config)"},
+			{helpKey(keys.KeyTaskList), "Manage tasks (n inside the manager creates one)"},
+			{"r", "Run selected task now"},
+			{helpKey(keys.KeyKill), "Kill (delete) the selected session"},
+			{navKeys, "Navigate between sessions"},
+			{helpKey(keys.KeyEnter), "Interact with the session in its pane (all keys go to it)"},
+			{helpKey(keys.KeyExitInteractive), "Leave interactive mode (back to navigation)"},
+			{helpKey(keys.KeyAttach), "Attach to the selected session full-screen"},
+			{tmux.DetachKeyDisplay, "Detach from a full-screen session"},
+		}},
+		{title: "Workspace:", rows: []helpRow{
+			{helpKey(keys.KeyTab), "Cycle focus: tree → open panes → automations"},
+			{helpKey(keys.KeyShiftTab), "Cycle focus backwards"},
+			{helpKey(keys.KeyOpenPane), "Open the selected tab as a pane (or focus its pane)"},
+			{helpKey(keys.KeyHidePane), "Hide the focused pane (the tab keeps running)"},
+			{navKeys, "Navigate the tree (instances and their tabs)"},
+			{helpKey(keys.KeyLeft), "Collapse the selected instance's tabs"},
+			{helpKey(keys.KeyRight), "Expand the selected instance's tabs"},
+		}},
+		{title: "Configuration:", rows: []helpRow{
+			{helpKey(keys.KeyHooks), "Open the worktree hooks editor"},
+		}},
+		{title: "GitHub PR:", rows: []helpRow{
+			{helpKey(keys.KeyOpenPR), "Open PR in browser"},
+			{helpKey(keys.KeyCopyPR), "Copy PR URL to clipboard"},
+		}},
+		{title: "Tabs:", rows: []helpRow{
+			{helpKey(keys.KeyJumpTab), "Select a tab by number (s opens it, enter attaches)"},
+			{helpKey(keys.KeyNewTab), "Open a new terminal tab"},
+			{helpKey(keys.KeyCloseTab), "Close the current tab (the agent tab can't be closed)"},
+			{helpKey(keys.KeyShiftDown) + "/" + helpKey(keys.KeyShiftUp), "Scroll in the current tab"},
+		}},
+		{title: "Other:", rows: []helpRow{
+			{helpKey(keys.KeyQuit), "Quit the application"},
+		}},
+	})
 }
 
 func (h helpTypeInstanceStart) toContent() string {
@@ -89,9 +154,10 @@ func (h helpTypeInstanceStart) toContent() string {
 	// handleCloseTab in app/handle_actions.go) — so only advertise the tab keys
 	// that actually work for the instance type. 1-9 jump works for both (#988);
 	// tabs also live in the left-rail tree since the layout cutover (#1024 PR 4).
-	tabHelp := keyStyle.Render("1-9 jump") + descStyle.Render(" - Select a tab (s opens it; t new tab, w close; tabs live in the tree)")
+	openPane, newTab, closeTab := helpKey(keys.KeyOpenPane), helpKey(keys.KeyNewTab), helpKey(keys.KeyCloseTab)
+	tabHelp := keyStyle.Render("1-9 jump") + descStyle.Render(fmt.Sprintf(" - Select a tab (%s opens it; %s new tab, %s close; tabs live in the tree)", openPane, newTab, closeTab))
 	if h.instance.IsRemote() {
-		tabHelp = keyStyle.Render("1-9 jump") + descStyle.Render(" - Select a tab (s opens it; tabs live in the tree)")
+		tabHelp = keyStyle.Render("1-9 jump") + descStyle.Render(fmt.Sprintf(" - Select a tab (%s opens it; tabs live in the tree)", openPane))
 	}
 	content := lipgloss.JoinVertical(lipgloss.Left,
 		titleStyle.Render("Instance Created"),
@@ -103,10 +169,10 @@ func (h helpTypeInstanceStart) toContent() string {
 			lipgloss.NewStyle().Bold(true).Render(h.instance.Program))),
 		"",
 		headerStyle.Render("Managing:"),
-		keyStyle.Render("↵")+descStyle.Render("     - Interact with the session in its pane (ctrl+] returns to nav)"),
-		keyStyle.Render("o")+descStyle.Render("     - Attach to the session full-screen"),
+		keyStyle.Render(helpKey(keys.KeyEnter))+descStyle.Render(fmt.Sprintf("     - Interact with the session in its pane (%s returns to nav)", helpKey(keys.KeyExitInteractive))),
+		keyStyle.Render(helpKey(keys.KeyAttach))+descStyle.Render("     - Attach to the session full-screen"),
 		tabHelp,
-		keyStyle.Render("D")+descStyle.Render("     - Kill (delete) the selected session"),
+		keyStyle.Render(helpKey(keys.KeyKill))+descStyle.Render("     - Kill (delete) the selected session"),
 	)
 	return content
 }
@@ -128,8 +194,8 @@ func (h helpTypeInteractive) toContent() string {
 		descStyle.Render("goes to the agent/shell. The pane's frame turns green while it has the"),
 		descStyle.Render("keyboard, and the instances rail stays visible."),
 		"",
-		descStyle.Render("Press ")+keyStyle.Render("ctrl+]")+descStyle.Render(" to return to navigation."),
-		descStyle.Render("Full-screen attach is still available on ")+keyStyle.Render("o")+descStyle.Render(" (from nav mode)."),
+		descStyle.Render("Press ")+keyStyle.Render(helpKey(keys.KeyExitInteractive))+descStyle.Render(" to return to navigation."),
+		descStyle.Render("Full-screen attach is still available on ")+keyStyle.Render(helpKey(keys.KeyAttach))+descStyle.Render(" (from nav mode)."),
 	)
 	return content
 }

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -4,9 +4,36 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/stretchr/testify/require"
 )
+
+// TestHelpReflectsKeymapRebinds is the regression guard for the #1141
+// play-test blocker 2: the help overlay rendered hardcoded key literals, so a
+// [keys] rebind showed everywhere EXCEPT help. It must now build from the same
+// generated binding table as dispatch and the bottom menu.
+func TestHelpReflectsKeymapRebinds(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{
+		"quit": {"Q"},
+		"new":  {"c"},
+		"up":   {"u", "ctrl+p"},
+	}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	content := helpTypeGeneral{}.toContent()
+
+	// Rebound keys must appear...
+	for _, want := range []string{"Q", "c", "u/ctrl+p"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("help must show rebound key %q; got:\n%s", want, content)
+		}
+	}
+	// ...and the replaced defaults must be gone from their action lines.
+	if strings.Contains(content, "q         - Quit") || strings.Contains(content, "↑/k, ↓/j") {
+		t.Errorf("help still shows default keys after a rebind; got:\n%s", content)
+	}
+}
 
 // TestGeneralHelpNavigationMatchesBindings guards against regressing #764, where
 // the help screen documented "↑/j, ↓/k" while the canonical bindings in

--- a/app/keymap_dispatch_test.go
+++ b/app/keymap_dispatch_test.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reachesQuit reports whether the command returned by the key handler resolves
+// to tea.Quit.
+func reachesQuit(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	_, isQuit := cmd().(tea.QuitMsg)
+	return isQuit
+}
+
+func runeKey(r rune) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}} }
+
+// dispatchKey drives one key through the real handler as the DISPATCH pass. A
+// mapped key press is first intercepted by handleMenuHighlighting (which sets
+// keySent and re-emits the same key); the action fires on the re-emitted pass,
+// when keySent is already true. Setting keySent here reproduces that second
+// pass so the test exercises the dispatch wiring, not the highlight animation.
+func dispatchKey(h *home, msg tea.KeyMsg) tea.Cmd {
+	h.keySent = true
+	_, cmd := h.handleKeyPress(msg)
+	return cmd
+}
+
+// TestQuitDispatchesThroughKeymap is the regression guard for the #1141
+// play-test blocker 1: quit was short-circuited on a hardcoded "q" before the
+// generated keymap lookup and had no KeyQuit dispatch case, so rebinding quit
+// was a no-op in both directions. Quit must now flow through the generated
+// table like every other rebindable action.
+func TestQuitDispatchesThroughKeymap(t *testing.T) {
+	t.Run("default q quits", func(t *testing.T) {
+		require.NoError(t, keys.ApplyOverrides(nil))
+		h := newTestHome(t)
+		assert.True(t, reachesQuit(dispatchKey(h, runeKey('q'))), "the default quit key must still quit")
+	})
+
+	t.Run("rebound quit works and the default goes dead", func(t *testing.T) {
+		require.NoError(t, keys.ApplyOverrides(map[string][]string{"quit": {"Q"}}))
+		t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+		h := newTestHome(t)
+
+		assert.True(t, reachesQuit(dispatchKey(h, runeKey('Q'))), "the rebound quit key must quit")
+		assert.False(t, reachesQuit(dispatchKey(h, runeKey('q'))), "the replaced default quit key must no longer quit")
+	})
+
+	t.Run("ctrl+c is an always-on hard exit regardless of rebinds", func(t *testing.T) {
+		require.NoError(t, keys.ApplyOverrides(map[string][]string{"quit": {"Q"}}))
+		t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+		h := newTestHome(t)
+
+		assert.True(t, reachesQuit(dispatchKey(h, tea.KeyMsg{Type: tea.KeyCtrlC})), "ctrl+c must always quit")
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -833,6 +833,15 @@ func validateConfig(config *Config, prettyConfigPath string) (*Config, error) {
 	// that silently falls back to defaults is indistinguishable from a dead
 	// keyboard binding at runtime, which is far harder to debug than a load
 	// error naming the file and action (#1026).
+	//
+	// This runs in every LoadConfig, so the error surfaces on the TUI and on
+	// `af keys` (which load the config). CLI subcommands that never load the
+	// config — e.g. `af sessions list`, which talks only to the daemon — do
+	// not validate the keymap, and that is intentional: the keymap is a
+	// TUI-only preference, and blocking an unrelated CLI command because of a
+	// keybinding typo would keep a user from running the very commands they'd
+	// use to debug it. The binding is validated wherever it is actually
+	// consumed.
 	overrides, err := normalizeKeyOverrides(config.Keys, prettyConfigPath)
 	if err != nil {
 		return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
@@ -165,6 +166,30 @@ type Config struct {
 	// in-repo config must never be able to opt a machine into an always-on
 	// agent just by being cloned.
 	RootAgents map[string]RootAgentConfig `json:"root_agents,omitempty" toml:"root_agents,omitempty"`
+	// Keys is the raw [keys] rebinding table (#1026): action name → a key
+	// string or list of key strings, replacing that action's default binding
+	// entirely (unlisted actions keep their defaults). TOML-ONLY by design —
+	// the first config surface that exists only in config.toml — hence
+	// json:"-"; parseConfig warns when a config.json carries the key.
+	// Values decode shapelessly (string or array) and are normalized and
+	// validated by validateConfig into keyOverrides; consumers use
+	// KeymapOverrides, never this field.
+	Keys map[string]any `json:"-" toml:"keys,omitempty"`
+
+	// keyOverrides is the normalized, validated form of Keys, set by
+	// validateConfig. Global-only and TUI-only: the daemon never reads it.
+	keyOverrides map[string][]string
+}
+
+// KeymapOverrides returns the validated [keys] rebinding table: action name →
+// key strings. Nil when the config carries no rebinds. Only configs that came
+// through LoadConfig/validateConfig have this populated; a hand-constructed
+// Config returns nil (defaults).
+func (c *Config) KeymapOverrides() map[string][]string {
+	if c == nil {
+		return nil
+	}
+	return c.keyOverrides
 }
 
 // RootAgentConfig is the per-repo agent profile for an always-ensured root
@@ -673,6 +698,17 @@ func parseConfig(data []byte, prettyConfigPath string) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config file %s: %w", prettyConfigPath, err)
 	}
 
+	// The [keys] keymap is TOML-only (#1026) — the struct field is json:"-",
+	// so a "keys" object in config.json would be silently dead. Silently dead
+	// config is how users lose an afternoon, so name it and point at the
+	// TOML file.
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(data, &topLevel); err == nil {
+		if _, hasKeys := topLevel["keys"]; hasKeys {
+			log.WarningLog.Printf("config %s: \"keys\" is ignored in config.json — the keymap is TOML-only; move it to a [keys] table in %s", prettyConfigPath, TomlConfigFileName)
+		}
+	}
+
 	return validateConfig(config, prettyConfigPath)
 }
 
@@ -792,7 +828,50 @@ func validateConfig(config *Config, prettyConfigPath string) (*Config, error) {
 		config.UpdateChannel = UpdateChannelStable
 	}
 
+	// The [keys] keymap hard-errors on any problem (unknown action, bad key
+	// string, reserved key, conflict) rather than warn-and-default: a keymap
+	// that silently falls back to defaults is indistinguishable from a dead
+	// keyboard binding at runtime, which is far harder to debug than a load
+	// error naming the file and action (#1026).
+	overrides, err := normalizeKeyOverrides(config.Keys, prettyConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := keys.ValidateOverrides(overrides); err != nil {
+		return nil, fmt.Errorf("Config issue in %s: %w", prettyConfigPath, err)
+	}
+	config.keyOverrides = overrides
+
 	return config, nil
+}
+
+// normalizeKeyOverrides converts the shapeless [keys] table into action →
+// key-list form: each value must be a single string or an array of strings.
+// Returns nil for an absent table so “no rebinds” stays a nil map.
+func normalizeKeyOverrides(raw map[string]any, prettyConfigPath string) (map[string][]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	overrides := make(map[string][]string, len(raw))
+	for action, value := range raw {
+		switch v := value.(type) {
+		case string:
+			overrides[action] = []string{v}
+		case []any:
+			list := make([]string, 0, len(v))
+			for _, item := range v {
+				s, ok := item.(string)
+				if !ok {
+					return nil, fmt.Errorf("Config issue in %s: keys.%s: expected a key string or a list of key strings, got a list containing %T", prettyConfigPath, action, item)
+				}
+				list = append(list, s)
+			}
+			overrides[action] = list
+		default:
+			return nil, fmt.Errorf("Config issue in %s: keys.%s: expected a key string or a list of key strings, got %T", prettyConfigPath, action, value)
+		}
+	}
+	return overrides, nil
 }
 
 // saveConfig saves the configuration to disk

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1125,6 +1125,73 @@ update_channel = "nightly"
 		assert.Equal(t, UpdateChannelStable, cfg.UpdateChannel)
 	})
 
+	t.Run("keys table: normalizes strings and lists", func(t *testing.T) {
+		writeToml(t, `
+default_program = "claude"
+
+[keys]
+quit = "Q"
+up = ["u", "ctrl+p"]
+`)
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		overrides := cfg.KeymapOverrides()
+		assert.Equal(t, []string{"Q"}, overrides["quit"])
+		assert.Equal(t, []string{"u", "ctrl+p"}, overrides["up"])
+	})
+
+	t.Run("keys table: absent means nil overrides", func(t *testing.T) {
+		writeToml(t, `default_program = "claude"`+"\n")
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		assert.Nil(t, cfg.KeymapOverrides())
+	})
+
+	t.Run("keys table: hard errors name the file and action", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			content string
+			wantErr string
+		}{
+			{"unknown action", "[keys]\nwarp = \"z\"\n", "unknown action"},
+			{"reserved key", "[keys]\nquit = \"enter\"\n", "reserved"},
+			{"conflict", "[keys]\nkill = \"q\"\n", "bound to both"},
+			{"invalid key string", "[keys]\nquit = \"space bar\"\n", "not a valid key"},
+			{"non-string value", "[keys]\nquit = 5\n", "expected a key string"},
+			{"non-string list item", "[keys]\nquit = [5]\n", "expected a key string"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				writeToml(t, "default_program = \"claude\"\n"+tc.content)
+
+				cfg, err := LoadConfig()
+				require.Error(t, err)
+				assert.Nil(t, cfg)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.Contains(t, err.Error(), "Config issue in")
+			})
+		}
+	})
+
+	t.Run("keys in config.json is ignored with a warning, never applied", func(t *testing.T) {
+		// The keymap is the first TOML-only surface (#1026): the json decoder
+		// does not know the field, so it must neither error nor rebind.
+		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+		configDir, err := GetConfigDir()
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(configDir, 0755))
+		jsonContent := `{"default_program": "claude", "keys": {"quit": "Q"}}`
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, ConfigFileName), []byte(jsonContent), 0644))
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Nil(t, cfg.KeymapOverrides(), "a json config must never rebind keys")
+	})
+
 	t.Run("decodes root_agents tables", func(t *testing.T) {
 		writeToml(t, `
 default_program = "claude"

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -100,6 +100,13 @@ var inRepoGlobalOnlyKeys = map[string]bool{
 	"worktree_root":   true,
 }
 
+// tomlOnlyGlobalKeys is the subset of inRepoGlobalOnlyKeys that exists only in
+// config.toml (#1026/#1030), so their in-repo rejection message must direct
+// the user to config.toml rather than the resolved global config file.
+var tomlOnlyGlobalKeys = map[string]bool{
+	"keys": true,
+}
+
 // isPathStrictlyInside reports whether absBase is a strict descendant of
 // absDir (absBase != absDir and absBase is not outside absDir). Both
 // arguments must be absolute, cleaned paths. Built on filepath.Rel rather
@@ -262,8 +269,10 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 	// relocates the config dir (same class of bug as #890). Fall back to a
 	// generic phrase if the config dir cannot be resolved.
 	globalConfigLocation := "the global config file"
+	tomlGlobalConfigLocation := globalConfigLocation
 	if configDir, dirErr := GetConfigDir(); dirErr == nil {
 		globalConfigLocation = prettyHomePath(filepath.Join(configDir, ConfigFileName))
+		tomlGlobalConfigLocation = prettyHomePath(filepath.Join(configDir, TomlConfigFileName))
 	}
 	if len(data) == 0 || (isToml && isEffectivelyEmptyToml(data)) {
 		// A contentless config.toml (zero bytes, whitespace, or a bare BOM)
@@ -300,7 +309,16 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 	}
 	for key := range presentKeys {
 		if inRepoGlobalOnlyKeys[key] {
-			return nil, nil, fmt.Errorf("in-repo config %s: %q is a global setting and cannot be set per-repo; move it to %s and remove it from this file", prettyPath, key, globalConfigLocation)
+			// TOML-only global keys (the [keys] keymap, #1026) must point at
+			// config.toml — a config.json carrying "keys" is ignored-with-
+			// warning, so directing the user there would land them in the
+			// dead path. Every other global-only key still lives in the
+			// resolved global config file.
+			dest := globalConfigLocation
+			if tomlOnlyGlobalKeys[key] {
+				dest = tomlGlobalConfigLocation
+			}
+			return nil, nil, fmt.Errorf("in-repo config %s: %q is a global setting and cannot be set per-repo; move it to %s and remove it from this file", prettyPath, key, dest)
 		}
 		allowed := false
 		for _, k := range inRepoAllowedKeys {

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -90,11 +90,14 @@ var inRepoGlobalOnlyKeys = map[string]bool{
 	"branch_prefix":        true,
 	"daemon_poll_interval": true,
 	"detach_keys":          true,
-	"log_max_backups":      true,
-	"log_max_size_mb":      true,
-	"root_agents":          true,
-	"update_channel":       true,
-	"worktree_root":        true,
+	// The [keys] keymap is a user/host preference: a cloned repo must never
+	// be able to rebind someone's terminal (#1026).
+	"keys":            true,
+	"log_max_backups": true,
+	"log_max_size_mb": true,
+	"root_agents":     true,
+	"update_channel":  true,
+	"worktree_root":   true,
 }
 
 // isPathStrictlyInside reports whether absBase is a strict descendant of

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -79,8 +79,14 @@ func TestLoadInRepoConfigRejectsGlobalOnlyKeys(t *testing.T) {
 			assert.Contains(t, err.Error(), "global setting")
 			// The message must name the real global config file under the
 			// active config dir, not a hardcoded ~/.agent-factory path that
-			// AGENT_FACTORY_HOME has relocated (#890).
-			assert.Contains(t, err.Error(), prettyHomePath(filepath.Join(home, ConfigFileName)))
+			// AGENT_FACTORY_HOME has relocated (#890). TOML-only keys (the
+			// keymap) point at config.toml; every other key at config.json
+			// (#1141 play-test minor 4).
+			wantFile := ConfigFileName
+			if tomlOnlyGlobalKeys[key] {
+				wantFile = TomlConfigFileName
+			}
+			assert.Contains(t, err.Error(), prettyHomePath(filepath.Join(home, wantFile)))
 			assert.NotContains(t, err.Error(), "~/.agent-factory/config.json")
 		})
 	}

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -66,7 +66,7 @@ func TestLoadInRepoConfigEmptyValueIsSet(t *testing.T) {
 }
 
 func TestLoadInRepoConfigRejectsGlobalOnlyKeys(t *testing.T) {
-	for _, key := range []string{"auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "log_max_backups", "log_max_size_mb", "root_agents", "update_channel", "worktree_root"} {
+	for _, key := range []string{"auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "keys", "log_max_backups", "log_max_size_mb", "root_agents", "update_channel", "worktree_root"} {
 		t.Run(key, func(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("AGENT_FACTORY_HOME", home)

--- a/config/inrepo_toml_test.go
+++ b/config/inrepo_toml_test.go
@@ -97,6 +97,26 @@ func TestLoadInRepoConfigTOMLKeyPolicy(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "auto_yes")
 		assert.Contains(t, err.Error(), "global setting")
+		// A non-TOML-only global key points at the resolved global config file.
+		assert.Contains(t, err.Error(), ConfigFileName)
+	})
+
+	t.Run("rejecting the TOML-only keys table points at config.toml", func(t *testing.T) {
+		// #1141 play-test minor 4: the keymap is TOML-only, so the "move it to
+		// the global config" message must name config.toml — a config.json
+		// carrying "keys" is ignored-with-warning, so directing the user there
+		// would land them in the dead path.
+		home := t.TempDir()
+		t.Setenv("AGENT_FACTORY_HOME", home)
+		repoRoot := t.TempDir()
+		writeInRepoTomlConfig(t, repoRoot, "[keys]\nquit = \"Q\"\n")
+
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "global setting")
+		assert.Contains(t, err.Error(), TomlConfigFileName)
+		assert.NotContains(t, err.Error(), prettyHomePath(filepath.Join(home, ConfigFileName)),
+			"the keys rejection must not point at the ignored config.json path")
 	})
 
 	t.Run("rejects unknown key", func(t *testing.T) {

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -1,6 +1,11 @@
 package keys
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
 	"github.com/charmbracelet/bubbles/key"
 )
 
@@ -70,171 +75,284 @@ const (
 	KeyExitInteractive
 )
 
-// GlobalKeyStringsMap is a global, immutable map string to keybinding.
-var GlobalKeyStringsMap = map[string]KeyName{
-	"up":         KeyUp,
-	"k":          KeyUp,
-	"down":       KeyDown,
-	"j":          KeyDown,
-	"shift+up":   KeyShiftUp,
-	"shift+down": KeyShiftDown,
-	"N":          KeyNewRemote,
-	"enter":      KeyEnter,
-	// "o" was an Enter alias until #1089 PR 2 split the verbs: Enter enters
-	// the pane (interactive), o keeps the old full-screen attach.
-	"o":         KeyAttach,
-	"n":         KeyNew,
-	"D":         KeyKill,
-	"q":         KeyQuit,
-	"tab":       KeyTab,
-	"shift+tab": KeyShiftTab,
-	"t":         KeyNewTab,
-	"w":         KeyCloseTab,
-	"?":         KeyHelp,
-	// "s" is the open-pane verb since #1024 PR 5/#1088 (RFC §2.3); the
-	// task-create jump it used to carry lives in the task manager (S → n).
-	"s":     KeyOpenPane,
-	"x":     KeyHidePane,
-	"S":     KeyTaskList,
-	"/":     KeySearch,
-	"p":     KeyOpenPR,
-	"P":     KeyCopyPR,
-	"H":     KeyHooks,
-	"h":     KeyLeft,
-	"left":  KeyLeft,
-	"l":     KeyRight,
-	"right": KeyRight,
-	"]":     KeyNextSection,
-	"[":     KeyPrevSection,
+// spec is one action's canonical binding definition: its default keys, help
+// rendering, and — when configKey is non-empty — the name under which the
+// `[keys]` table in config.toml may rebind it (#1030/#1026).
+type spec struct {
+	name KeyName
+	// configKey is the action's name in the [keys] config table; "" marks a
+	// fixed binding that config cannot touch (structural keys like enter/tab
+	// and root-routed keys like ctrl+]).
+	configKey string
+	// keys are the default key strings (bubbletea tea.KeyMsg.String() forms).
+	keys []string
+	// helpLabel, when non-empty, pins the help-column text for the DEFAULT
+	// binding where the generic rendering would differ (e.g. "1-9").
+	// Overridden bindings always derive their label from the actual keys.
+	helpLabel string
+	// desc is the help-column description.
+	desc string
+	// dispatch marks actions routed through GlobalKeyStringsMap. Display-only
+	// entries (KeyJumpTab, KeySubmitName, ...) never enter the strings map —
+	// their dispatch is root-routed or overlay-local.
+	dispatch bool
 }
 
-// GlobalKeyBindings is a global, immutable map of KeyName to keybinding.
-var GlobalKeyBindings = map[KeyName]key.Binding{
-	KeyUp: key.NewBinding(
-		key.WithKeys("up", "k"),
-		key.WithHelp("↑/k", "up"),
-	),
-	KeyDown: key.NewBinding(
-		key.WithKeys("down", "j"),
-		key.WithHelp("↓/j", "down"),
-	),
-	KeyShiftUp: key.NewBinding(
-		key.WithKeys("shift+up"),
-		key.WithHelp("⇧↑", "scroll"),
-	),
-	KeyShiftDown: key.NewBinding(
-		key.WithKeys("shift+down"),
-		key.WithHelp("⇧↓", "scroll"),
-	),
-	KeyEnter: key.NewBinding(
-		key.WithKeys("enter"),
-		key.WithHelp("↵", "interact"),
-	),
-	KeyAttach: key.NewBinding(
-		key.WithKeys("o"),
-		key.WithHelp("o", "attach"),
-	),
-	KeyExitInteractive: key.NewBinding(
-		key.WithKeys("ctrl+]"),
-		key.WithHelp("ctrl+]", "nav mode"),
-	),
-	KeyNew: key.NewBinding(
-		key.WithKeys("n"),
-		key.WithHelp("n", "new"),
-	),
-	KeyKill: key.NewBinding(
-		key.WithKeys("D"),
-		key.WithHelp("D", "kill"),
-	),
-	KeyHelp: key.NewBinding(
-		key.WithKeys("?"),
-		key.WithHelp("?", "help"),
-	),
-	KeyQuit: key.NewBinding(
-		key.WithKeys("q"),
-		key.WithHelp("q", "quit"),
-	),
-	KeyNewRemote: key.NewBinding(
-		key.WithKeys("N"),
-		key.WithHelp("N", "new remote"),
-	),
-	KeyTab: key.NewBinding(
-		key.WithKeys("tab"),
-		key.WithHelp("tab", "focus"),
-	),
-	KeyShiftTab: key.NewBinding(
-		key.WithKeys("shift+tab"),
-		key.WithHelp("shift+tab", "focus prev"),
-	),
-	KeyNewTab: key.NewBinding(
-		key.WithKeys("t"),
-		key.WithHelp("t", "tab"),
-	),
-	KeyCloseTab: key.NewBinding(
-		key.WithKeys("w"),
-		key.WithHelp("w", "close"),
-	),
-	KeyJumpTab: key.NewBinding(
-		key.WithKeys("1", "2", "3", "4", "5", "6", "7", "8", "9"),
-		key.WithHelp("1-9", "jump"),
-	),
-	KeyTaskList: key.NewBinding(
-		key.WithKeys("S"),
-		key.WithHelp("S", "tasks"),
-	),
-	KeyManageAutomations: key.NewBinding(
-		key.WithKeys("enter"),
-		key.WithHelp("↵", "manage"),
-	),
-	KeyOpenPane: key.NewBinding(
-		key.WithKeys("s"),
-		key.WithHelp("s", "open pane"),
-	),
-	KeyHidePane: key.NewBinding(
-		key.WithKeys("x"),
-		key.WithHelp("x", "hide pane"),
-	),
-	KeySearch: key.NewBinding(
-		key.WithKeys("/"),
-		key.WithHelp("/", "search"),
-	),
-	KeyOpenPR: key.NewBinding(
-		key.WithKeys("p"),
-		key.WithHelp("p", "open PR"),
-	),
-	KeyCopyPR: key.NewBinding(
-		key.WithKeys("P"),
-		key.WithHelp("P", "copy PR URL"),
-	),
-	KeyHooks: key.NewBinding(
-		key.WithKeys("H"),
-		key.WithHelp("H", "worktree hooks"),
-	),
-	KeyLeft: key.NewBinding(
-		key.WithKeys("h", "left"),
-		key.WithHelp("h/←", "collapse"),
-	),
-	KeyRight: key.NewBinding(
-		key.WithKeys("l", "right"),
-		key.WithHelp("l/→", "expand"),
-	),
-	KeyNextSection: key.NewBinding(
-		key.WithKeys("]"),
-		key.WithHelp("]", "next section"),
-	),
-	KeyPrevSection: key.NewBinding(
-		key.WithKeys("["),
-		key.WithHelp("[", "prev section"),
-	),
+// specs is the canonical binding table. Order is stable but carries no
+// meaning; lookups go through the generated maps.
+var specs = []spec{
+	{name: KeyUp, configKey: "up", keys: []string{"up", "k"}, desc: "up", dispatch: true},
+	{name: KeyDown, configKey: "down", keys: []string{"down", "j"}, desc: "down", dispatch: true},
+	{name: KeyShiftUp, configKey: "scroll_up", keys: []string{"shift+up"}, desc: "scroll", dispatch: true},
+	{name: KeyShiftDown, configKey: "scroll_down", keys: []string{"shift+down"}, desc: "scroll", dispatch: true},
+	{name: KeyEnter, keys: []string{"enter"}, desc: "interact", dispatch: true},
+	// "o" was an Enter alias until #1089 PR 2 split the verbs: Enter enters
+	// the pane (interactive), o keeps the old full-screen attach.
+	{name: KeyAttach, configKey: "attach", keys: []string{"o"}, desc: "attach", dispatch: true},
+	{name: KeyExitInteractive, keys: []string{"ctrl+]"}, desc: "nav mode"},
+	{name: KeyNew, configKey: "new", keys: []string{"n"}, desc: "new", dispatch: true},
+	{name: KeyKill, configKey: "kill", keys: []string{"D"}, desc: "kill", dispatch: true},
+	{name: KeyHelp, configKey: "help", keys: []string{"?"}, desc: "help", dispatch: true},
+	{name: KeyQuit, configKey: "quit", keys: []string{"q"}, desc: "quit", dispatch: true},
+	{name: KeyNewRemote, configKey: "new_remote", keys: []string{"N"}, desc: "new remote", dispatch: true},
+	{name: KeyTab, keys: []string{"tab"}, desc: "focus", dispatch: true},
+	{name: KeyShiftTab, keys: []string{"shift+tab"}, desc: "focus prev", dispatch: true},
+	{name: KeyNewTab, configKey: "new_tab", keys: []string{"t"}, desc: "tab", dispatch: true},
+	{name: KeyCloseTab, configKey: "close_tab", keys: []string{"w"}, desc: "close", dispatch: true},
+	{name: KeyJumpTab, keys: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}, helpLabel: "1-9", desc: "jump"},
+	{name: KeyTaskList, configKey: "tasks", keys: []string{"S"}, desc: "tasks", dispatch: true},
+	{name: KeyManageAutomations, keys: []string{"enter"}, desc: "manage"},
+	{name: KeyOpenPane, configKey: "open_pane", keys: []string{"s"}, desc: "open pane", dispatch: true},
+	{name: KeyHidePane, configKey: "hide_pane", keys: []string{"x"}, desc: "hide pane", dispatch: true},
+	{name: KeySearch, configKey: "search", keys: []string{"/"}, desc: "search", dispatch: true},
+	{name: KeyOpenPR, configKey: "open_pr", keys: []string{"p"}, desc: "open PR", dispatch: true},
+	{name: KeyCopyPR, configKey: "copy_pr", keys: []string{"P"}, desc: "copy PR URL", dispatch: true},
+	{name: KeyHooks, configKey: "hooks", keys: []string{"H"}, desc: "worktree hooks", dispatch: true},
+	{name: KeyLeft, configKey: "collapse", keys: []string{"h", "left"}, desc: "collapse", dispatch: true},
+	{name: KeyRight, configKey: "expand", keys: []string{"l", "right"}, desc: "expand", dispatch: true},
+	{name: KeyNextSection, configKey: "next_section", keys: []string{"]"}, desc: "next section", dispatch: true},
+	{name: KeyPrevSection, configKey: "prev_section", keys: []string{"["}, desc: "prev section", dispatch: true},
 
 	// -- Special keybindings --
+	{name: KeySubmitName, keys: []string{"enter"}, helpLabel: "enter", desc: "submit name"},
+	{name: KeyChangeProgram, keys: []string{"tab"}, desc: "change program"},
+}
 
-	KeySubmitName: key.NewBinding(
-		key.WithKeys("enter"),
-		key.WithHelp("enter", "submit name"),
-	),
-	KeyChangeProgram: key.NewBinding(
-		key.WithKeys("tab"),
-		key.WithHelp("tab", "change program"),
-	),
+// reservedKeys are key strings the config may never bind an action to: they
+// are either structural (enter/tab/shift+tab drive interaction and the focus
+// ring, esc is the root-routed overlay-cancel key), root-routed before any
+// key map (ctrl+], the one host-reserved key in interactive mode — rebinding
+// it could lock a user inside a forwarded pane), or dispatched manually (the
+// 1-9 tab jump).
+var reservedKeys = map[string]string{
+	"enter":     "it is the interact/submit key",
+	"tab":       "it cycles the focus ring",
+	"shift+tab": "it cycles the focus ring",
+	"esc":       "it cancels overlays",
+	"ctrl+]":    "it is the reserved exit from interactive mode",
+	"1":         "1-9 jump to tabs",
+	"2":         "1-9 jump to tabs",
+	"3":         "1-9 jump to tabs",
+	"4":         "1-9 jump to tabs",
+	"5":         "1-9 jump to tabs",
+	"6":         "1-9 jump to tabs",
+	"7":         "1-9 jump to tabs",
+	"8":         "1-9 jump to tabs",
+	"9":         "1-9 jump to tabs",
+}
+
+// keyDisplayNames maps key strings to their compact help-column glyphs.
+// Anything absent renders as itself.
+var keyDisplayNames = map[string]string{
+	"up":         "↑",
+	"down":       "↓",
+	"left":       "←",
+	"right":      "→",
+	"enter":      "↵",
+	"shift+up":   "⇧↑",
+	"shift+down": "⇧↓",
+}
+
+// namedKeys are the non-rune key names bubbletea produces (tea.KeyMsg.String()
+// forms) that a [keys] value may use, optionally behind ctrl+/alt+/shift+
+// modifiers.
+var namedKeys = map[string]bool{
+	"up": true, "down": true, "left": true, "right": true,
+	"home": true, "end": true, "pgup": true, "pgdown": true,
+	"space": true, "backspace": true, "delete": true, "insert": true,
+	// enter/tab/esc are valid key NAMES (so modifier combos parse) even
+	// though their bare forms sit in reservedKeys.
+	"enter": true, "tab": true, "esc": true,
+	"f1": true, "f2": true, "f3": true, "f4": true, "f5": true, "f6": true,
+	"f7": true, "f8": true, "f9": true, "f10": true, "f11": true, "f12": true,
+}
+
+// GlobalKeyStringsMap is a global map from key string to action, generated
+// from specs (plus any [keys] overrides applied at startup). Read-only after
+// ApplyOverrides; the TUI treats it as immutable.
+var GlobalKeyStringsMap map[string]KeyName
+
+// GlobalKeyBindings is a global map of KeyName to keybinding, generated from
+// specs (plus any [keys] overrides applied at startup). Read-only after
+// ApplyOverrides; the TUI treats it as immutable.
+var GlobalKeyBindings map[KeyName]key.Binding
+
+func init() {
+	// Defaults must always build; a panic here means the specs table itself
+	// is inconsistent, which no config can cause.
+	strings, bindings, err := buildMaps(nil)
+	if err != nil {
+		panic(fmt.Sprintf("keys: default binding table is invalid: %v", err))
+	}
+	GlobalKeyStringsMap, GlobalKeyBindings = strings, bindings
+}
+
+// ValidateOverrides checks a [keys] override table (action name → key list)
+// without applying it: unknown actions, empty or malformed key strings,
+// reserved keys, and key conflicts between actions are all hard errors, so a
+// bad keymap fails at config load with the file named — never as a dead key
+// at runtime.
+func ValidateOverrides(overrides map[string][]string) error {
+	_, _, err := buildMaps(overrides)
+	return err
+}
+
+// ApplyOverrides rebuilds the global binding maps with the given [keys]
+// overrides layered over the defaults. Call once at TUI startup, before the
+// bubbletea program runs — the maps are read concurrently afterwards. Help
+// and menu labels are regenerated from the effective keys, so rebinds are
+// reflected everywhere the binding is displayed.
+func ApplyOverrides(overrides map[string][]string) error {
+	stringsMap, bindings, err := buildMaps(overrides)
+	if err != nil {
+		return err
+	}
+	GlobalKeyStringsMap, GlobalKeyBindings = stringsMap, bindings
+	return nil
+}
+
+// RebindableActions returns the sorted [keys] table names of every action
+// config may rebind, for validation error messages.
+func RebindableActions() []string {
+	var names []string
+	for _, sp := range specs {
+		if sp.configKey != "" {
+			names = append(names, sp.configKey)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// buildMaps generates the strings and bindings maps from specs with
+// overrides applied, validating as it goes.
+func buildMaps(overrides map[string][]string) (map[string]KeyName, map[KeyName]key.Binding, error) {
+	byConfigKey := map[string]spec{}
+	for _, sp := range specs {
+		if sp.configKey != "" {
+			byConfigKey[sp.configKey] = sp
+		}
+	}
+	for action, keyList := range overrides {
+		if _, ok := byConfigKey[action]; !ok {
+			return nil, nil, fmt.Errorf("keys: unknown action %q (rebindable actions: %s)", action, strings.Join(RebindableActions(), ", "))
+		}
+		if len(keyList) == 0 {
+			return nil, nil, fmt.Errorf("keys: action %q has no keys; give it a key string or a list of key strings", action)
+		}
+		for _, k := range keyList {
+			if !validKeySpec(k) {
+				return nil, nil, fmt.Errorf("keys: action %q: %q is not a valid key (use a single character, a named key like \"up\" or \"f5\", or a ctrl+/alt+/shift+ combination)", action, k)
+			}
+			if reason, reserved := reservedKeys[k]; reserved {
+				return nil, nil, fmt.Errorf("keys: action %q: %q is reserved — %s", action, k, reason)
+			}
+		}
+	}
+
+	stringsMap := make(map[string]KeyName, 64)
+	bindings := make(map[KeyName]key.Binding, len(specs))
+	// boundBy tracks which action owns each dispatch key, to name both sides
+	// of a conflict. Fixed dispatch specs (enter/tab/shift+tab) participate,
+	// so an override cannot silently shadow them either (they are also in
+	// reservedKeys, which reports the clearer error first).
+	boundBy := map[string]string{}
+	for _, sp := range specs {
+		effective := sp.keys
+		overridden := false
+		if sp.configKey != "" {
+			if o, ok := overrides[sp.configKey]; ok {
+				effective = o
+				overridden = true
+			}
+		}
+
+		if sp.dispatch {
+			for _, k := range effective {
+				owner := sp.configKey
+				if owner == "" {
+					owner = sp.desc
+				}
+				if prev, taken := boundBy[k]; taken {
+					return nil, nil, fmt.Errorf("keys: %q is bound to both %q and %q; each key can trigger only one action", k, prev, owner)
+				}
+				boundBy[k] = owner
+				stringsMap[k] = sp.name
+			}
+		}
+
+		label := sp.helpLabel
+		if label == "" || overridden {
+			label = helpLabelFor(effective)
+		}
+		bindings[sp.name] = key.NewBinding(
+			key.WithKeys(effective...),
+			key.WithHelp(label, sp.desc),
+		)
+	}
+	return stringsMap, bindings, nil
+}
+
+// helpLabelFor renders a key list for the help/menu column: each key mapped
+// through keyDisplayNames and joined with "/" (e.g. ["up","k"] → "↑/k").
+func helpLabelFor(keyList []string) string {
+	parts := make([]string, len(keyList))
+	for i, k := range keyList {
+		if display, ok := keyDisplayNames[k]; ok {
+			parts[i] = display
+		} else {
+			parts[i] = k
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+// validKeySpec reports whether s is a key string bubbletea can produce:
+// an optional run of ctrl+/alt+/shift+ modifiers followed by a named key or
+// a single character. Whitespace never matches a tea.KeyMsg.String(), so it
+// is rejected outright (the classic mistake is "space", which IS the named
+// form bubbletea uses, vs " ").
+func validKeySpec(s string) bool {
+	if s == "" || strings.ContainsAny(s, " \t\n") {
+		return false
+	}
+	rest := s
+	for {
+		switch {
+		case strings.HasPrefix(rest, "ctrl+"):
+			rest = rest[len("ctrl+"):]
+		case strings.HasPrefix(rest, "alt+"):
+			rest = rest[len("alt+"):]
+		case strings.HasPrefix(rest, "shift+"):
+			rest = rest[len("shift+"):]
+		default:
+			if namedKeys[rest] {
+				return true
+			}
+			return utf8.RuneCountInString(rest) == 1
+		}
+		if rest == "" {
+			return false
+		}
+	}
 }

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -1,0 +1,202 @@
+package keys
+
+import (
+	"strings"
+	"testing"
+)
+
+// resetAfter restores the default maps when the test finishes, since
+// ApplyOverrides mutates package globals.
+func resetAfter(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := ApplyOverrides(nil); err != nil {
+			t.Fatalf("restoring default keymap: %v", err)
+		}
+	})
+}
+
+// TestDefaultMapsMatchLegacyTable pins the generated defaults to the exact
+// hand-written maps this package carried before the spec registry (#1026):
+// a regression here means a user's muscle memory changed without a rebind.
+func TestDefaultMapsMatchLegacyTable(t *testing.T) {
+	legacyStrings := map[string]KeyName{
+		"up":         KeyUp,
+		"k":          KeyUp,
+		"down":       KeyDown,
+		"j":          KeyDown,
+		"shift+up":   KeyShiftUp,
+		"shift+down": KeyShiftDown,
+		"N":          KeyNewRemote,
+		"enter":      KeyEnter,
+		"o":          KeyAttach,
+		"n":          KeyNew,
+		"D":          KeyKill,
+		"q":          KeyQuit,
+		"tab":        KeyTab,
+		"shift+tab":  KeyShiftTab,
+		"t":          KeyNewTab,
+		"w":          KeyCloseTab,
+		"?":          KeyHelp,
+		"s":          KeyOpenPane,
+		"x":          KeyHidePane,
+		"S":          KeyTaskList,
+		"/":          KeySearch,
+		"p":          KeyOpenPR,
+		"P":          KeyCopyPR,
+		"H":          KeyHooks,
+		"h":          KeyLeft,
+		"left":       KeyLeft,
+		"l":          KeyRight,
+		"right":      KeyRight,
+		"]":          KeyNextSection,
+		"[":          KeyPrevSection,
+	}
+	if len(GlobalKeyStringsMap) != len(legacyStrings) {
+		t.Fatalf("GlobalKeyStringsMap has %d entries, want %d", len(GlobalKeyStringsMap), len(legacyStrings))
+	}
+	for k, want := range legacyStrings {
+		if got, ok := GlobalKeyStringsMap[k]; !ok || got != want {
+			t.Fatalf("GlobalKeyStringsMap[%q] = %v (present=%v), want %v", k, got, ok, want)
+		}
+	}
+
+	helpChecks := map[KeyName]string{
+		KeyUp:                "↑/k",
+		KeyDown:              "↓/j",
+		KeyShiftUp:           "⇧↑",
+		KeyShiftDown:         "⇧↓",
+		KeyEnter:             "↵",
+		KeyManageAutomations: "↵",
+		KeyJumpTab:           "1-9",
+		KeySubmitName:        "enter",
+		KeyChangeProgram:     "tab",
+		KeyExitInteractive:   "ctrl+]",
+		KeyLeft:              "h/←",
+		KeyRight:             "l/→",
+		KeyQuit:              "q",
+	}
+	for name, want := range helpChecks {
+		if got := GlobalKeyBindings[name].Help().Key; got != want {
+			t.Fatalf("help label for %v = %q, want %q", name, got, want)
+		}
+	}
+	if len(GlobalKeyBindings) != len(specs) {
+		t.Fatalf("GlobalKeyBindings has %d entries, want one per spec (%d)", len(GlobalKeyBindings), len(specs))
+	}
+}
+
+func TestApplyOverridesRebindsDispatchAndHelp(t *testing.T) {
+	resetAfter(t)
+	err := ApplyOverrides(map[string][]string{
+		"quit": {"Q"},
+		"up":   {"u", "ctrl+p"},
+	})
+	if err != nil {
+		t.Fatalf("ApplyOverrides: %v", err)
+	}
+
+	if got := GlobalKeyStringsMap["Q"]; got != KeyQuit {
+		t.Fatalf("Q should dispatch KeyQuit, got %v", got)
+	}
+	if _, still := GlobalKeyStringsMap["q"]; still {
+		t.Fatalf("an override replaces the default binding entirely; q must be unbound")
+	}
+	if got := GlobalKeyStringsMap["ctrl+p"]; got != KeyUp {
+		t.Fatalf("ctrl+p should dispatch KeyUp, got %v", got)
+	}
+	if _, still := GlobalKeyStringsMap["k"]; still {
+		t.Fatalf("k must be unbound after the up override")
+	}
+
+	if got := GlobalKeyBindings[KeyQuit].Help().Key; got != "Q" {
+		t.Fatalf("help label must reflect the rebind, got %q", got)
+	}
+	if got := GlobalKeyBindings[KeyUp].Help().Key; got != "u/ctrl+p" {
+		t.Fatalf("multi-key help label = %q, want u/ctrl+p", got)
+	}
+	// Unlisted actions keep their defaults.
+	if got := GlobalKeyStringsMap["D"]; got != KeyKill {
+		t.Fatalf("unlisted actions must keep defaults; D = %v", got)
+	}
+}
+
+func TestValidateOverridesErrors(t *testing.T) {
+	cases := []struct {
+		name      string
+		overrides map[string][]string
+		wantErr   string
+	}{
+		{"unknown action", map[string][]string{"warp": {"z"}}, "unknown action"},
+		{"empty key list", map[string][]string{"quit": {}}, "no keys"},
+		{"invalid key string", map[string][]string{"quit": {"space bar"}}, "not a valid key"},
+		{"reserved enter", map[string][]string{"quit": {"enter"}}, "reserved"},
+		{"reserved tab-jump digit", map[string][]string{"quit": {"3"}}, "reserved"},
+		{"reserved interactive exit", map[string][]string{"quit": {"ctrl+]"}}, "reserved"},
+		{"conflict with another default", map[string][]string{"kill": {"q"}}, "bound to both"},
+		{"conflict between two overrides", map[string][]string{"kill": {"z"}, "quit": {"z"}}, "bound to both"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateOverrides(tc.overrides)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q should contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+
+	// Swapping two defaults in one table is legal: the conflict check runs
+	// on the effective keys, not the defaults.
+	if err := ValidateOverrides(map[string][]string{"quit": {"D"}, "kill": {"q"}}); err != nil {
+		t.Fatalf("swapping two bindings must validate, got: %v", err)
+	}
+}
+
+func TestValidateOverridesLeavesGlobalsUntouched(t *testing.T) {
+	if err := ValidateOverrides(map[string][]string{"quit": {"Q"}}); err != nil {
+		t.Fatalf("ValidateOverrides: %v", err)
+	}
+	if _, rebound := GlobalKeyStringsMap["Q"]; rebound {
+		t.Fatalf("ValidateOverrides must not mutate the global maps")
+	}
+	if got := GlobalKeyStringsMap["q"]; got != KeyQuit {
+		t.Fatalf("q must still dispatch KeyQuit after a validate-only call")
+	}
+}
+
+func TestValidKeySpec(t *testing.T) {
+	valid := []string{"q", "Q", "?", "/", "[", "å", "ctrl+a", "alt+x", "shift+up", "ctrl+shift+up", "f5", "space", "pgup", "ctrl+enter"}
+	for _, s := range valid {
+		if !validKeySpec(s) {
+			t.Fatalf("validKeySpec(%q) = false, want true", s)
+		}
+	}
+	invalid := []string{"", " ", "space bar", "qq", "ctrl+", "ctrl+alt+", "control+a", "\t"}
+	for _, s := range invalid {
+		if validKeySpec(s) {
+			t.Fatalf("validKeySpec(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestRebindableActionsSortedAndComplete(t *testing.T) {
+	actions := RebindableActions()
+	if len(actions) == 0 {
+		t.Fatal("no rebindable actions")
+	}
+	for i := 1; i < len(actions); i++ {
+		if actions[i-1] >= actions[i] {
+			t.Fatalf("actions not sorted/unique at %q >= %q", actions[i-1], actions[i])
+		}
+	}
+	// The structural/reserved actions must NOT be rebindable.
+	forbidden := map[string]bool{"enter": true, "tab": true, "shift_tab": true, "jump_tab": true, "submit_name": true, "change_program": true, "exit_interactive": true, "manage_automations": true}
+	for _, a := range actions {
+		if forbidden[a] {
+			t.Fatalf("action %q must not be rebindable", a)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	cmdutil "github.com/sachiniyer/agent-factory/cmd"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
@@ -72,6 +73,14 @@ var (
 			cfg, err := config.ResolveConfig(repo.Root)
 			if err != nil {
 				return err
+			}
+
+			// Apply [keys] rebinds before the TUI starts (#1026): the maps
+			// are read concurrently once bubbletea runs, and the config was
+			// already validated at load, so an error here is a programming
+			// error, not a user one.
+			if err := keys.ApplyOverrides(cfg.KeymapOverrides()); err != nil {
+				return fmt.Errorf("failed to apply [keys] rebinds: %w", err)
 			}
 
 			// Program flag overrides config. Both are restricted to bare


### PR DESCRIPTION
Part of #1030 and the config half of #1026 (design comment: https://github.com/sachiniyer/agent-factory/issues/1030#issuecomment-4880518994) — PR 5 of the approved breakdown. First TOML-only config surface.

## Schema

```toml
[keys]
quit = "Q"              # a single key string…
up   = ["u", "ctrl+p"]  # …or a list; replaces the action's default keys entirely
```

Unlisted actions keep their defaults. Key strings are bubbletea `tea.KeyMsg.String()` forms: a single character, a named key (`up`, `f5`, `space`, …), or `ctrl+`/`alt+`/`shift+` combinations.

## What changed structurally

`keys/keys.go`'s two hand-written literals (`GlobalKeyStringsMap` for dispatch, `GlobalKeyBindings` for help/menu) are now **generated from one spec registry**, so dispatch, menu hints, and the help overlay share a single source and rebinds are reflected in all three by construction — no per-view plumbing. `keys.ApplyOverrides` runs once in `main.go` after `ResolveConfig`, before bubbletea starts (the maps are read concurrently afterwards).

**Defaults are pinned**: `TestDefaultMapsMatchLegacyTable` asserts the generated maps equal the pre-refactor literals entry-for-entry (including help glyphs like `↑/k`, `⇧↑`, `1-9`), so no user's muscle memory changes without a rebind.

## Rules

- **Rebindable v1** — the user-intent verbs: `up down scroll_up scroll_down attach new kill quit help new_remote new_tab close_tab tasks search open_pr copy_pr hooks open_pane hide_pane collapse expand next_section prev_section`.
- **Reserved, never bindable**: `enter`, `tab`, `shift+tab` (structural), `esc` (root-routed overlay cancel), `1`–`9` (tab jump), and `ctrl+]` — the sole host-reserved key in interactive mode; rebinding it could lock a user inside a forwarded pane. `detach_keys` stays its own top-level key (tmux syntax, different grammar).
- **Every problem is a hard error at LoadConfig** naming the file and action — unknown action (message lists the valid ones), malformed key string, reserved key, or two actions on one key (both named). Rationale: a keymap that silently fell back to defaults presents as a dead keyboard at runtime, which is far harder to debug than a load error. Swapping two defaults in one table (`quit="D"`, `kill="q"`) validates fine — conflicts are checked on effective keys.
- **Scope**: `keys` is global-only (`inRepoGlobalOnlyKeys`) — a cloned repo must never rebind a terminal. It is TOML-only: a `config.json` carrying `"keys"` logs a warning pointing at the `[keys]` table and never applies.

## Tests

- `keys`: legacy-table parity pin; rebind updates dispatch + help and unbinds replaced defaults; validate-only never mutates globals; the full error matrix (unknown/empty/invalid/reserved×3/conflict×2); key-string grammar; rebindable-action list excludes structural actions.
- `config`: `[keys]` normalization (string + list), absent→nil, hard-error matrix with file named, json-`keys`-ignored-with-warning, and `keys` added to the in-repo global-only rejection loop.

## Gates

`go build`, `gofmt`, `golangci-lint --fast`, `deadcode -test` clean; `make test-container` full suite green. Visible-behavior PR — ready for the docker play-test gate (suggested script: rebind `quit="Q"`+`up=["u","ctrl+p"]` in the sandbox home's config.toml → menu/help show Q and u/ctrl+p, q is dead, Q quits; then `kill="q"` → startup error names kill/quit and the file).

`af keys` introspection follows as PR 6. Do not merge — root verifies and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)