### PR TITLE
cli,keys: af keys — introspect effective TUI key bindings (#1026, #1030 PR 6)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,6 +71,7 @@ af daemon uninstall    # remove the autostart unit (the daemon still starts on d
 ```bash
 af version             # print the version and the release URL
 af debug               # print the resolved config and its path
+af keys                # print the effective TUI key bindings (defaults + [keys] rebinds)
 af upgrade             # self-upgrade to the latest GitHub release (Linux/macOS)
 af doctor              # diagnose leaked processes/sessions/temp homes and daemon health
 af doctor --fix        # also apply the safe remediations

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -231,6 +231,48 @@ func ApplyOverrides(overrides map[string][]string) error {
 	return nil
 }
 
+// BindingInfo describes one action's effective binding for introspection
+// (`af keys`, #1026).
+type BindingInfo struct {
+	// Action is the [keys] table name; "" for fixed bindings config cannot
+	// touch.
+	Action string
+	// Desc is the help-column description.
+	Desc string
+	// Keys are the effective key strings (defaults or the override).
+	Keys []string
+	// Default are the built-in key strings.
+	Default []string
+	// Rebound reports whether an override replaced the default.
+	Rebound bool
+}
+
+// EffectiveBindings returns every action's effective binding with the given
+// [keys] overrides applied, in the canonical display order (rebindable
+// actions sorted by name, then the fixed bindings in table order). The
+// overrides are validated first, so a broken table reports the same error
+// the TUI would refuse to start with.
+func EffectiveBindings(overrides map[string][]string) ([]BindingInfo, error) {
+	if err := ValidateOverrides(overrides); err != nil {
+		return nil, err
+	}
+	var rebindable, fixed []BindingInfo
+	for _, sp := range specs {
+		info := BindingInfo{Action: sp.configKey, Desc: sp.desc, Keys: sp.keys, Default: sp.keys}
+		if sp.configKey != "" {
+			if o, ok := overrides[sp.configKey]; ok {
+				info.Keys = o
+				info.Rebound = true
+			}
+			rebindable = append(rebindable, info)
+			continue
+		}
+		fixed = append(fixed, info)
+	}
+	sort.Slice(rebindable, func(i, j int) bool { return rebindable[i].Action < rebindable[j].Action })
+	return append(rebindable, fixed...), nil
+}
+
 // RebindableActions returns the sorted [keys] table names of every action
 // config may rebind, for validation error messages.
 func RebindableActions() []string {

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -182,6 +182,57 @@ func TestValidKeySpec(t *testing.T) {
 	}
 }
 
+func TestEffectiveBindings(t *testing.T) {
+	infos, err := EffectiveBindings(map[string][]string{"quit": {"Q"}})
+	if err != nil {
+		t.Fatalf("EffectiveBindings: %v", err)
+	}
+	if len(infos) != len(specs) {
+		t.Fatalf("got %d infos, want one per spec (%d)", len(infos), len(specs))
+	}
+	// Rebindable actions come first, sorted; fixed bindings trail.
+	seenFixed := false
+	byAction := map[string]BindingInfo{}
+	var prev string
+	for _, info := range infos {
+		if info.Action == "" {
+			seenFixed = true
+			continue
+		}
+		if seenFixed {
+			t.Fatalf("rebindable action %q listed after a fixed binding", info.Action)
+		}
+		if prev != "" && info.Action <= prev {
+			t.Fatalf("rebindable actions not sorted: %q after %q", info.Action, prev)
+		}
+		prev = info.Action
+		byAction[info.Action] = info
+	}
+	if !seenFixed {
+		t.Fatal("fixed bindings missing from the output")
+	}
+
+	quit := byAction["quit"]
+	if !quit.Rebound || len(quit.Keys) != 1 || quit.Keys[0] != "Q" || len(quit.Default) != 1 || quit.Default[0] != "q" {
+		t.Fatalf("quit info = %+v, want rebound Q with default q", quit)
+	}
+	up := byAction["up"]
+	if up.Rebound || len(up.Keys) != 2 || up.Keys[0] != "up" || up.Keys[1] != "k" {
+		t.Fatalf("up info = %+v, want default up/k not rebound", up)
+	}
+
+	// A broken table reports the same error the TUI would refuse to start
+	// with, instead of printing a keymap that is not in effect.
+	if _, err := EffectiveBindings(map[string][]string{"kill": {"q"}}); err == nil {
+		t.Fatal("EffectiveBindings must reject a conflicting table")
+	}
+
+	// The global maps are untouched by introspection.
+	if got := GlobalKeyStringsMap["q"]; got != KeyQuit {
+		t.Fatalf("EffectiveBindings must not mutate the global maps")
+	}
+}
+
 func TestRebindableActionsSortedAndComplete(t *testing.T) {
 	actions := RebindableActions()
 	if len(actions) == 0 {

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/sachiniyer/agent-factory/api"
 	"github.com/sachiniyer/agent-factory/app"
@@ -217,6 +218,44 @@ var (
 			fmt.Printf("https://github.com/sachiniyer/agent-factory/releases/tag/v%s\n", version)
 		},
 	}
+
+	keysCmd = &cobra.Command{
+		Use:   "keys",
+		Short: "Show the effective TUI key bindings (defaults plus [keys] rebinds)",
+		Long: "Show every TUI action with its effective key binding: the built-in default,\n" +
+			"or the rebind from the [keys] table in config.toml (#1026). Fixed bindings —\n" +
+			"structural keys config cannot touch — are listed last.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Initialize(false)
+			defer log.Close()
+
+			// The keymap is a global-only setting, so LoadConfig (not
+			// ResolveConfig) is deliberate: the output is identical inside
+			// and outside a repository.
+			cfg, err := config.LoadConfig()
+			if err != nil {
+				return err
+			}
+			infos, err := keys.EffectiveBindings(cfg.KeymapOverrides())
+			if err != nil {
+				return err
+			}
+
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 0, 3, ' ', 0)
+			fmt.Fprintln(w, "ACTION\tKEYS\tDESCRIPTION\tSOURCE")
+			for _, info := range infos {
+				action, source := info.Action, "default"
+				switch {
+				case info.Action == "":
+					action, source = "-", "fixed"
+				case info.Rebound:
+					source = fmt.Sprintf("rebound (default: %s)", strings.Join(info.Default, ", "))
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", action, strings.Join(info.Keys, ", "), info.Desc, source)
+			}
+			return w.Flush()
+		},
+	}
 )
 
 func init() {
@@ -237,6 +276,7 @@ func init() {
 	}
 
 	rootCmd.AddCommand(debugCmd)
+	rootCmd.AddCommand(keysCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(resetCmd)
 	rootCmd.AddCommand(upgradeCmd)


### PR DESCRIPTION
Part of #1030, closing out the introspection half of #1026 — PR 6 of the approved breakdown. **Stacked on #1141** (base is its branch; retarget/rebase to master after it merges — the diff shown here is PR 6 only).

## What

`af keys` prints every TUI action with its effective key binding via `keys.EffectiveBindings`:

```
ACTION       KEYS         DESCRIPTION   SOURCE
attach       o            attach        default
quit         Q            quit          rebound (default: q)
up           u, ctrl+p    up            rebound (default: up, k)
...
-            enter        interact      fixed
-            ctrl+]       nav mode      fixed
```

- Rebindable actions first, sorted by name; fixed structural bindings (enter/tab/1-9/ctrl+]/…) trail, marked `fixed`, so users can see exactly what the `[keys]` table can and cannot touch.
- Rebound rows show the default they replaced.
- A broken `[keys]` table makes `af keys` fail with the **same** load error the TUI refuses to start with — it never prints a keymap that is not actually in effect.
- Uses `LoadConfig` (not `ResolveConfig`) deliberately: the keymap is global-only, so output is identical inside and outside a repo.
- `docs/cli.md` maintenance-commands list gains the entry (config-docs sweep remains the held PR 4).

## Verified end-to-end (sandbox `AGENT_FACTORY_HOME`)

- default table renders; `quit="Q"` + `up=["u","ctrl+p"]` show as rebound with defaults noted; `kill="q"` errors with `keys: "q" is bound to both "kill" and "quit"` naming the file.

## Tests

`TestEffectiveBindings`: one row per action, rebindable-sorted-then-fixed ordering, rebound flag + default preservation, conflicting-table rejection, and no mutation of the global maps.

## Gates

`go build`, `gofmt`, `golangci-lint --fast`, `deadcode -test` clean; `make test-container` full suite green.

Do not merge — root verifies and merges (after the #1141 play-test gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)