### PR TITLE
tui: first-class mouse — click/scroll/interact + in-pane forwarding (#1024 R4, closes #1025)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/sachiniyer/agent-factory/ui/tree"
@@ -134,6 +135,17 @@ type home struct {
 	// rebuilt by relayout as panes open, close, and auto-hide, and regions
 	// hidden by the degradation ladder are skipped.
 	ring *layout.Ring
+	// zones is the mouse hit-test registry (#1024 R4, RFC §2.5): View()
+	// resets it every frame and each pane re-registers its interactive rects
+	// while rendering, so the registry always mirrors what is actually on
+	// screen. handleMouse resolves every tea.MouseMsg through it.
+	zones *zones.Registry
+	// lastClickZone/lastClickAt implement double-click detection: a second
+	// press on the same zone within doubleClickInterval reads as a double
+	// click. mouseClock is time.Now, swapped by tests for determinism.
+	lastClickZone string
+	lastClickAt   time.Time
+	mouseClock    func() time.Time
 
 	// sidebar is the left-rail instances+tabs tree
 	sidebar *ui.Sidebar
@@ -281,6 +293,8 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 		statusBar:       ui.NewStatusBar(menu, errBox),
 		hooksPane:       ui.NewHooksPane(),
 		ring:            layout.NewRing(layout.RegionTree, layout.RegionAutomations),
+		zones:           zones.NewRegistry(),
+		mouseClock:      time.Now,
 		snapshotFetcher: snapshotThroughDaemon,
 		appConfig:       appConfig,
 		program:         program,
@@ -291,6 +305,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 		appState:        appState,
 	}
 	h.sidebar = ui.NewSidebar(&h.spinner, autoYes, proj)
+	h.wireZoneRegistry()
 	// No panes are open at startup: the focus ring is tree → automations
 	// until the first pane opens (relayout rebuilds the ring's pane entries
 	// thereafter; the first instance selection auto-opens its pane).
@@ -633,45 +648,14 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(cmds...)
 	case tea.MouseMsg:
-		// Mouse forwarding into an interactive pane is out of scope for this
-		// PR (RFC §2.5 leaves in-pane wheel ownership to the mouse PR) — and
-		// host wheel-scroll would flip the live pane into capture scroll mode
-		// mid-typing, so the wheel is inert while interactive.
-		if m.interactive {
-			return m, nil
-		}
-		if msg.Action == tea.MouseActionPress {
-			if msg.Button == tea.MouseButtonWheelDown || msg.Button == tea.MouseButtonWheelUp {
-				// The wheel scrolls whatever the focus ring points at: the
-				// focused automations section moves its own cursor
-				// independent of the sidebar selection (#524); everywhere
-				// else it scrolls the workspace pane, which needs a bound
-				// instance. Hit-tested wheel routing is #1024 PR 6.
-				if m.ring.Active() == layout.RegionAutomations {
-					switch msg.Button {
-					case tea.MouseButtonWheelUp:
-						m.automations.ScrollUp()
-					case tea.MouseButtonWheelDown:
-						m.automations.ScrollDown()
-					}
-					return m, nil
-				}
-				// The wheel scrolls the focused pane's own view (#1088); with
-				// the tree focused it drives the selection's open pane, when
-				// one is visible.
-				pane, bound := m.focusedContentPane()
-				if pane == nil || bound == nil {
-					return m, nil
-				}
-				switch msg.Button {
-				case tea.MouseButtonWheelUp:
-					pane.ScrollUp()
-				case tea.MouseButtonWheelDown:
-					pane.ScrollDown()
-				}
-			}
-		}
-		return m, nil
+		// First-class mouse (#1024 R4, closes #1025): every event is
+		// resolved through the zone registry the last View() rebuilt and
+		// dispatched to the region actually under the cursor — clicks
+		// select/focus/interact/act, the wheel scrolls the hovered region,
+		// and while interactive, events over the live pane's grid forward
+		// to the embedded terminal. Purely additive: the keyboard remains
+		// fully sufficient.
+		return m.handleMouse(msg)
 	case tea.KeyMsg:
 		return m.handleKeyPress(msg)
 	case tea.WindowSizeMsg:
@@ -1655,8 +1639,16 @@ func (m *home) confirmAction(message string, action tea.Cmd) tea.Cmd {
 // View composes the workspace from the solved layout (#1024 PR 4): every pane
 // renders exactly its rect, so the regions tile the full window with no
 // padding math. Modal overlays composite on top exactly as before.
+// View composes the workspace from the solved layout. The mouse zone
+// registry is rebuilt here every frame (#1024 R4): Reset at the top, then
+// each pane registers its interactive rects while rendering and the active
+// overlay registers its buttons on top. The registry therefore always
+// mirrors exactly what this frame put on screen.
 func (m *home) View() string {
-	// Below the hard minimum no layout exists; render the banner alone.
+	m.zones.Reset()
+
+	// Below the hard minimum no layout exists; render the banner alone (and
+	// register nothing — there is nothing to click).
 	if m.lastLayout.Fallback {
 		return ui.TerminalTooSmall(m.termWidth, m.termHeight)
 	}
@@ -1695,17 +1687,23 @@ func (m *home) View() string {
 		if m.confirmationOverlay == nil {
 			log.ErrorLog.Printf("confirmation overlay is nil")
 		}
-		return overlay.PlaceOverlay(0, 0, m.confirmationOverlay.Render(), mainView, true)
+		fg := m.confirmationOverlay.Render()
+		m.confirmationOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
+		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
 	} else if m.state == stateSearch {
 		if m.searchOverlay == nil {
 			log.ErrorLog.Printf("search overlay is nil")
 		}
-		return overlay.PlaceOverlay(0, 0, m.searchOverlay.Render(), mainView, true)
+		fg := m.searchOverlay.Render()
+		m.searchOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
+		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
 	} else if m.state == stateSelectProgram {
 		if m.selectionOverlay == nil {
 			log.ErrorLog.Printf("selection overlay is nil")
 		}
-		return overlay.PlaceOverlay(0, 0, m.selectionOverlay.Render(), mainView, true)
+		fg := m.selectionOverlay.Render()
+		m.selectionOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
+		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
 	} else if m.state == stateHooks {
 		return overlay.PlaceOverlay(0, 0, m.renderHooksOverlay(), mainView, true)
 	} else if m.state == stateTasks {

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -16,6 +16,7 @@ import (
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,6 +115,9 @@ func wireTestPanes(h *home, proj *store.Projection) {
 	h.statusBar = ui.NewStatusBar(h.menu, h.errBox)
 	h.hooksPane = ui.NewHooksPane()
 	h.ring = layout.NewRing(layout.RegionTree, layout.RegionAutomations)
+	h.zones = zones.NewRegistry()
+	h.mouseClock = time.Now
+	h.wireZoneRegistry()
 	h.syncFocus()
 }
 

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -1,0 +1,383 @@
+package app
+
+import (
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+	"github.com/sachiniyer/agent-factory/ui/store"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// This file is the root mouse router (#1024 R4, RFC §2.5 — closes #1025).
+// Every tea.MouseMsg is resolved to a zone id through the registry the last
+// View() rebuilt, then dispatched to the same handlers the keyboard drives —
+// the mouse is purely additive and the keyboard remains fully sufficient.
+//
+// Interactive mode (#1089, RFC §2.3) splits the screen in two: events over
+// the live pane's terminal grid FORWARD into the embedded terminal (the
+// emulator only passes them to the inner app if it enabled mouse tracking);
+// events over the rest of the pane are suppressed — never a host action —
+// and everywhere outside the pane the host gestures apply as usual (§2.5).
+//
+// While full-screen ATTACHED none of this runs: bubbletea's Update loop is
+// blocked and tmux owns stdin, so tmux's own mouse mode applies — unchanged.
+
+// doubleClickInterval is how close two presses on the same zone must land to
+// read as a double click (interact on tree rows, open the manager on task
+// rows).
+const doubleClickInterval = 400 * time.Millisecond
+
+// wireZoneRegistry hands the shared registry to every long-lived
+// zone-producing pane. Called once at construction (newHome / test wiring);
+// pane windows are wired at creation (openPaneWindow) instead, since they
+// come and go with the open-pane list.
+func (m *home) wireZoneRegistry() {
+	m.sidebar.SetZoneRegistry(m.zones)
+	m.automations.SetZoneRegistry(m.zones)
+	m.menu.SetZoneRegistry(m.zones)
+}
+
+// handleMouse routes a mouse event: wheel scrolls the region under the
+// cursor, a left press clicks the zone under it, and interactive mode
+// forwards in-pane events to the embedded terminal. Release/motion events
+// matter only to the forwarding path (drags, button-up); host gestures all
+// act on the press.
+func (m *home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if m.interactive && m.state == stateDefault {
+		if done := m.forwardInteractiveMouse(msg); done {
+			return m, nil
+		}
+		// The event landed outside the live pane: host gestures apply
+		// (§2.5). A gesture that moves focus off the pane implicitly ends
+		// the mode — enforceInteractiveInvariant runs after dispatch below.
+		defer m.enforceInteractiveInvariant()
+	}
+	if msg.Action != tea.MouseActionPress {
+		return m, nil
+	}
+	switch msg.Button {
+	case tea.MouseButtonWheelUp, tea.MouseButtonWheelDown:
+		return m, m.handleWheel(msg)
+	case tea.MouseButtonLeft:
+		return m.handleClick(msg)
+	}
+	return m, nil
+}
+
+// forwardInteractiveMouse implements the RFC §2.5 in-pane ownership rule
+// while interactive: any event over the live pane's rect belongs to the
+// embedded terminal — grid-cell events forward through the emulator's
+// mode-aware SendMouse (translated to pane-local coordinates by the zone
+// resolve), and events over the pane's frame/header are suppressed so a
+// stray click can never trigger a host action under the user's typing.
+// Reports whether the event was consumed (forwarded or suppressed).
+func (m *home) forwardInteractiveMouse(msg tea.MouseMsg) bool {
+	if m.liveTerm == nil || m.livePane == nil {
+		return false
+	}
+	id, local, ok := m.zones.Resolve(msg.X, msg.Y)
+	if !ok {
+		// A miss is outside every pane; nothing to do either way.
+		return true
+	}
+	region, kind, isPane := zones.PaneZone(id)
+	if !isPane || region != layout.PaneRegion(m.livePane.ID()) {
+		return false
+	}
+	if kind == zones.PaneKindTerm {
+		m.liveTerm.SendMouse(msg, local.X, local.Y)
+	}
+	return true
+}
+
+// handleWheel scrolls the region UNDER THE CURSOR (RFC §2.5) — before this
+// PR the wheel scrolled whatever the focus ring pointed at. Tree zones map
+// to cursor movement (the tree's only scroll primitive, same as j/k), pane
+// zones to that pane's capture scroll, the automations section to its task
+// cursor. Modal overlays own the screen, so the wheel is inert under them.
+func (m *home) handleWheel(msg tea.MouseMsg) tea.Cmd {
+	if m.state != stateDefault {
+		return nil
+	}
+	id, _, ok := m.zones.Resolve(msg.X, msg.Y)
+	if !ok {
+		return nil
+	}
+	up := msg.Button == tea.MouseButtonWheelUp
+	if region, _, isPane := zones.PaneZone(id); isPane {
+		p, w := m.paneByRegion(region)
+		if p == nil || w == nil || p.Instance() == nil {
+			return nil
+		}
+		if up {
+			w.ScrollUp()
+		} else {
+			w.ScrollDown()
+		}
+		return nil
+	}
+	switch {
+	case strings.HasPrefix(id, "tree:"):
+		if up {
+			m.sidebar.Up()
+		} else {
+			m.sidebar.Down()
+		}
+		return m.selectionChanged()
+	case strings.HasPrefix(id, "auto:"):
+		if up {
+			m.automations.ScrollUp()
+		} else {
+			m.automations.ScrollDown()
+		}
+	}
+	return nil
+}
+
+// handleClick dispatches a left press by zone id — the §2.5 gesture table.
+func (m *home) handleClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	id, _, ok := m.zones.Resolve(msg.X, msg.Y)
+	if !ok {
+		return m, nil
+	}
+	double := m.trackClick(id)
+
+	// Modal states: the overlay owns the screen, so only its buttons (and,
+	// while naming, the status-bar hints that ARE the form's verbs) react.
+	if m.state != stateDefault {
+		return m.handleModalClick(id)
+	}
+
+	switch id {
+	case zones.TreeHeader:
+		// Click the section header: toggle it, like Enter on the row.
+		m.sidebar.ClickHeader()
+		m.focusRegionClick(layout.RegionTree)
+		return m, m.selectionChanged()
+	case zones.TreeBG:
+		m.focusRegionClick(layout.RegionTree)
+		return m, nil
+	case zones.AutoBG:
+		m.focusRegionClick(layout.RegionAutomations)
+		return m, nil
+	}
+
+	if title, ok := zones.TreeArrowTitle(id); ok {
+		// Click ▸/▾: expand/collapse the instance's tab children.
+		m.sidebar.ToggleInstanceTree(title)
+		m.focusRegionClick(layout.RegionTree)
+		return m, m.selectionChanged()
+	}
+	if title, ok := zones.TreeInstanceTitle(id); ok {
+		// Click an instance row: select (retargets the workspace binding);
+		// double-click interacts, exactly like Enter on the selected row.
+		m.focusRegionClick(layout.RegionTree)
+		if inst := m.store.GetInstanceByTitle(title); inst != nil {
+			m.sidebar.SelectInstance(inst)
+		}
+		if double {
+			selCmd := m.selectionChanged()
+			_, enterCmd := m.handleEnter()
+			return m, tea.Batch(selCmd, enterCmd)
+		}
+		return m, m.selectionChanged()
+	}
+	if title, idx, ok := zones.TreeTabParts(id); ok {
+		// Click a tab row: select it (drives the active tab); double-click
+		// interacts with that tab.
+		m.focusRegionClick(layout.RegionTree)
+		m.sidebar.SelectTabRow(title, idx)
+		if double {
+			selCmd := m.selectionChanged()
+			_, enterCmd := m.handleEnter()
+			return m, tea.Batch(selCmd, enterCmd)
+		}
+		return m, m.selectionChanged()
+	}
+	if region, kind, ok := zones.PaneZone(id); ok {
+		// Click a pane header (or an unfocused pane's body): focus that pane
+		// — how the mouse picks one of the N panes. Click the FOCUSED pane's
+		// body: enter it, exactly like Enter (§2.5).
+		if p, _ := m.paneByRegion(region); p == nil {
+			return m, nil
+		}
+		if kind == zones.PaneKindHeader || m.ring.Active() != region {
+			m.focusRegionClick(region)
+			return m, nil
+		}
+		return m.handleEnter()
+	}
+	if taskID, ok := zones.AutoTaskID(id); ok {
+		// Click a task row: focus the automations section and select the
+		// task; double-click opens the task-manager overlay on it (§2.5).
+		m.focusRegionClick(layout.RegionAutomations)
+		if m.automations.SelectTaskByID(taskID) && double {
+			return m.showTasksOverlay()
+		}
+		return m, nil
+	}
+	if key, ok := zones.StatusHintKey(id); ok {
+		// Click a status-bar hint: press its key (the menu already knows its
+		// bindings; the full handleKeyPress path keeps every gate identical).
+		return m.handleHintClick(key)
+	}
+	return m, nil
+}
+
+// handleModalClick handles clicks while an overlay owns the screen: overlay
+// buttons act as their keys; everything else is swallowed so a stray click
+// can never mutate state behind a modal.
+func (m *home) handleModalClick(id string) (tea.Model, tea.Cmd) {
+	switch m.state {
+	case stateConfirm:
+		if m.confirmationOverlay == nil {
+			return m, nil
+		}
+		var key string
+		switch id {
+		case zones.OverlayConfirmYes:
+			key = m.confirmationOverlay.ConfirmKey
+		case zones.OverlayConfirmNo:
+			key = m.confirmationOverlay.CancelKey
+		default:
+			return m, nil
+		}
+		if msg, ok := keyMsgFromString(key); ok {
+			return m.handleStateConfirm(msg)
+		}
+	case stateSelectProgram:
+		if m.selectionOverlay == nil {
+			return m, nil
+		}
+		if idx, ok := zones.OverlaySelectIdx(id); ok {
+			m.selectionOverlay.SetSelectedIndex(idx)
+			return m.handleStateSelectProgram(tea.KeyMsg{Type: tea.KeyEnter})
+		}
+	case stateSearch:
+		if m.searchOverlay == nil {
+			return m, nil
+		}
+		if idx, ok := zones.OverlaySearchIdx(id); ok {
+			m.searchOverlay.SetSelectedIndex(idx)
+			return m.handleStateSearch(tea.KeyMsg{Type: tea.KeyEnter})
+		}
+	case stateNew:
+		// The naming form's status-bar hints (enter submit / tab change
+		// program) stay clickable; handleKeyPress routes them to the form.
+		if key, ok := zones.StatusHintKey(id); ok {
+			return m.handleHintClick(key)
+		}
+	}
+	return m, nil
+}
+
+// handleHintClick presses the key a status-bar hint advertises, through the
+// full handleKeyPress path so state gating, interactive-mode routing (the
+// ctrl+] hint), and the keydown highlight behave exactly as if the user had
+// typed it.
+func (m *home) handleHintClick(key string) (tea.Model, tea.Cmd) {
+	msg, ok := keyMsgFromString(key)
+	if !ok {
+		return m, nil
+	}
+	return m.handleKeyPress(msg)
+}
+
+// trackClick records a press on zone id and reports whether it completed a
+// double click. A completed double resets the tracker so a triple click
+// can't read as two doubles.
+func (m *home) trackClick(id string) bool {
+	now := m.mouseClock()
+	double := id == m.lastClickZone && now.Sub(m.lastClickAt) <= doubleClickInterval
+	if double {
+		m.lastClickZone = ""
+		m.lastClickAt = time.Time{}
+	} else {
+		m.lastClickZone = id
+		m.lastClickAt = now
+	}
+	return double
+}
+
+// focusRegionClick moves focus to region for a mouse click, mirroring the
+// Tab-cycle contract (cycleFocus): the ring refuses hidden/unknown regions,
+// and a click on the already-focused region changes nothing (so it can't
+// trigger a needless relayout).
+func (m *home) focusRegionClick(region string) {
+	if m.ring.Active() == region {
+		return
+	}
+	if !m.ring.Focus(region) {
+		return
+	}
+	m.relayout()
+}
+
+// paneByRegion resolves a pane zone's region id back to the visible open
+// pane and its window. Both nil when the pane vanished since the frame the
+// zone was registered on (a click racing a close).
+func (m *home) paneByRegion(region string) (*store.OpenPane, *ui.TabbedWindow) {
+	for _, p := range m.visiblePanes {
+		if layout.PaneRegion(p.ID()) == region {
+			return p, m.paneWindows[p.ID()]
+		}
+	}
+	return nil, nil
+}
+
+// keyMsgFromString synthesizes the tea.KeyMsg a click stands in for, from a
+// binding's primary key string (keys.GlobalKeyBindings[…].Keys()[0]). ok is
+// false for strings with no single-key equivalent.
+func keyMsgFromString(s string) (tea.KeyMsg, bool) {
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}, true
+	case "tab":
+		return tea.KeyMsg{Type: tea.KeyTab}, true
+	case "shift+tab":
+		return tea.KeyMsg{Type: tea.KeyShiftTab}, true
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}, true
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}, true
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}, true
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}, true
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}, true
+	case "shift+up":
+		return tea.KeyMsg{Type: tea.KeyShiftUp}, true
+	case "shift+down":
+		return tea.KeyMsg{Type: tea.KeyShiftDown}, true
+	case "ctrl+]":
+		return tea.KeyMsg{Type: tea.KeyCtrlCloseBracket}, true
+	}
+	if r := []rune(s); len(r) == 1 {
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: r}, true
+	}
+	return tea.KeyMsg{}, false
+}
+
+// overlayOrigin computes where overlay.PlaceOverlay(0, 0, fg, bg, true) puts
+// fg's top-left: centered on bg (or 0,0 when fg exceeds bg, matching
+// PlaceOverlay's clamp). The overlays register their button zones relative
+// to this origin.
+func overlayOrigin(fg, bg string) layout.Point {
+	fgW, fgH := lipgloss.Width(fg), lipgloss.Height(fg)
+	bgW, bgH := lipgloss.Width(bg), lipgloss.Height(bg)
+	x := (bgW - fgW) / 2
+	y := (bgH - fgH) / 2
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+	return layout.Point{X: x, Y: y}
+}

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -27,7 +27,13 @@ func (m *home) openPaneWindow(instance *session.Instance, tab int) *store.OpenPa
 	if p == nil {
 		return nil
 	}
-	m.paneWindows[p.ID()] = ui.NewTabbedWindow(ui.NewTabPane(), p)
+	w := ui.NewTabbedWindow(ui.NewTabPane(), p)
+	// Wire the pane's mouse identity (#1024 R4): its zone ids are keyed by
+	// the same region id the focus ring and layout use, stable for the
+	// window's life.
+	w.SetRegion(layout.PaneRegion(p.ID()))
+	w.SetZoneRegistry(m.zones)
+	m.paneWindows[p.ID()] = w
 	return p
 }
 

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -52,6 +52,11 @@ type liveTermAttachment interface {
 	// SendKey forwards one keystroke down the attachment's PTY, reporting
 	// false when the key has no safe encoding (ignored, never guessed).
 	SendKey(msg tea.KeyMsg) bool
+	// SendMouse forwards one mouse event at grid cell (x, y) — the
+	// interactive-mode in-pane mouse path (#1024 R4, RFC §2.5). The
+	// emulator is mode-aware: the event reaches the inner app only if it
+	// enabled mouse tracking, and is dropped otherwise.
+	SendMouse(msg tea.MouseMsg, x, y int) bool
 }
 
 // newLiveTermPaneFn is the termpane creation seam. Production points it at

--- a/app/live_termpane_test.go
+++ b/app/live_termpane_test.go
@@ -21,6 +21,15 @@ type fakeLiveTerm struct {
 	// keys records every message forwarded through SendKey, as
 	// tea.KeyMsg.String() values.
 	keys []string
+	// mice records every event forwarded through SendMouse with its
+	// grid-local coordinates (#1024 R4 interactive forwarding).
+	mice []forwardedMouse
+}
+
+// forwardedMouse is one SendMouse call as the fake recorded it.
+type forwardedMouse struct {
+	msg  tea.MouseMsg
+	x, y int
 }
 
 func newFakeLiveTerm() *fakeLiveTerm {
@@ -33,6 +42,11 @@ func (f *fakeLiveTerm) Close() error                                     { f.clo
 func (f *fakeLiveTerm) Done() <-chan struct{}                            { return f.done }
 func (f *fakeLiveTerm) SendKey(msg tea.KeyMsg) bool {
 	f.keys = append(f.keys, msg.String())
+	return true
+}
+
+func (f *fakeLiveTerm) SendMouse(msg tea.MouseMsg, x, y int) bool {
+	f.mice = append(f.mice, forwardedMouse{msg: msg, x: x, y: y})
 	return true
 }
 

--- a/app/mouse_test.go
+++ b/app/mouse_test.go
@@ -1,0 +1,528 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/keys"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+	"github.com/sachiniyer/agent-factory/ui/overlay"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ----------------------------------------------------------------------------
+// Root mouse routing (#1024 R4, closes #1025): the RFC §2.5 gesture table,
+// driven hermetically — click coordinates are derived FROM the zone registry
+// the last View() rebuilt (never hardcoded), so a layout change moves the
+// tests with it or fails loudly.
+// ----------------------------------------------------------------------------
+
+// fakeClock drives the double-click detector deterministically.
+type fakeClock struct{ now time.Time }
+
+func (c *fakeClock) Now() time.Time          { return c.now }
+func (c *fakeClock) advance(d time.Duration) { c.now = c.now.Add(d) }
+func newFakeClock(h *home) *fakeClock {
+	c := &fakeClock{now: time.Unix(1000, 0)}
+	h.mouseClock = c.Now
+	return c
+}
+
+// mouseTestHome is a home with two started (mock tmux) instances and two
+// tasks at a real layout size, selection on the first instance.
+func mouseTestHome(t *testing.T) (*home, *session.Instance, *session.Instance) {
+	t.Helper()
+	h := newTestHome(t)
+	alpha := startedLocalInstance(t, "alpha")
+	beta := startedLocalInstance(t, "beta")
+	h.store.AddInstance(alpha)
+	h.store.AddInstance(beta)
+	tasks := []task.Task{
+		{ID: "task-aaa", Name: "nightly-sweep", CronExpr: "0 3 * * *", Enabled: true},
+		{ID: "task-bbb", Name: "log-watch", WatchCmd: "tail -f x", Enabled: true},
+	}
+	h.store.SetTasks(tasks)
+	h.automations.TaskPane().SetTasks(tasks)
+	h.sidebar.SetSelectedInstance(0)
+	resizeHome(h, 140, 40)
+	return h, alpha, beta
+}
+
+// zoneRect renders a frame (rebuilding the registry) and returns id's rect.
+func zoneRect(t *testing.T, h *home, id string) layout.Rect {
+	t.Helper()
+	_ = h.View()
+	r, ok := h.zones.Find(id)
+	require.True(t, ok, "zone %q must be registered; frame has %v", id, h.zones.IDs())
+	return r
+}
+
+// press injects a left press at (x, y) through the root mouse router.
+func press(h *home, x, y int) tea.Cmd {
+	_, cmd := h.handleMouse(tea.MouseMsg{
+		X: x, Y: y, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft,
+	})
+	return cmd
+}
+
+// clickZone renders, resolves id's rect, and clicks its top-left cell.
+func clickZone(t *testing.T, h *home, id string) tea.Cmd {
+	t.Helper()
+	r := zoneRect(t, h, id)
+	return press(h, r.X, r.Y)
+}
+
+// wheel injects a wheel event at (x, y).
+func wheel(h *home, x, y int, up bool) {
+	b := tea.MouseButtonWheelDown
+	if up {
+		b = tea.MouseButtonWheelUp
+	}
+	_, _ = h.handleMouse(tea.MouseMsg{X: x, Y: y, Action: tea.MouseActionPress, Button: b})
+}
+
+// TestMouse_ClickInstanceRowSelects: clicking a tree instance row selects it
+// (retargeting the workspace binding) and focuses the tree, from wherever
+// focus was.
+func TestMouse_ClickInstanceRowSelects(t *testing.T) {
+	h, _, beta := mouseTestHome(t)
+	newFakeClock(h)
+	h.focusRegion(layout.RegionAutomations)
+
+	clickZone(t, h, zones.TreeInstance(beta.Title))
+
+	require.NotNil(t, h.store.GetSelectedInstance())
+	assert.Equal(t, beta.Title, h.store.GetSelectedInstance().Title,
+		"clicking an instance row retargets the selection")
+	assert.Equal(t, layout.RegionTree, h.ring.Active(), "the click focuses the tree")
+}
+
+// TestMouse_ClickTreeTabRowSelectsTab: clicking a tab child row drives the
+// store's active tab, exactly like landing the tree cursor on it.
+func TestMouse_ClickTreeTabRowSelectsTab(t *testing.T) {
+	h, alpha, _ := mouseTestHome(t)
+	newFakeClock(h)
+
+	clickZone(t, h, zones.TreeTab(alpha.Title, 1))
+
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsTab, "the cursor lands on the tab row")
+	assert.Equal(t, 1, sel.TabIndex)
+	assert.Equal(t, 1, h.store.ActiveTab(), "the click drives the active tab")
+}
+
+// TestMouse_ClickArrowTogglesExpansion: the ▸/▾ arrow collapses/expands the
+// instance's tab children without entering it or moving the selection off it.
+func TestMouse_ClickArrowTogglesExpansion(t *testing.T) {
+	h, alpha, beta := mouseTestHome(t)
+	clock := newFakeClock(h)
+
+	// alpha is selected and expanded: its tab rows have zones.
+	_ = zoneRect(t, h, zones.TreeTab(alpha.Title, 0))
+
+	clickZone(t, h, zones.TreeArrow(alpha.Title))
+	_ = h.View()
+	_, ok := h.zones.Find(zones.TreeTab(alpha.Title, 0))
+	assert.False(t, ok, "arrow click collapses the expanded selection")
+
+	clock.advance(time.Second) // not a double click
+	clickZone(t, h, zones.TreeArrow(alpha.Title))
+	_ = h.View()
+	_, ok = h.zones.Find(zones.TreeTab(alpha.Title, 0))
+	assert.True(t, ok, "second arrow click re-expands")
+
+	// Arrow on a collapsed non-selected instance selects it, which
+	// auto-expands its subtree.
+	clock.advance(time.Second)
+	clickZone(t, h, zones.TreeArrow(beta.Title))
+	assert.Equal(t, beta.Title, h.store.GetSelectedInstance().Title)
+	_ = h.View()
+	_, ok = h.zones.Find(zones.TreeTab(beta.Title, 0))
+	assert.True(t, ok, "selecting via the arrow expands the new selection")
+}
+
+// TestMouse_DoubleClickTreeRowEntersInteractive: two quick clicks on a tree
+// row take the exact Enter path — open (or focus) the selection's pane, then
+// enter interactive mode; a slow second click stays a plain re-select.
+func TestMouse_DoubleClickTreeRowEntersInteractive(t *testing.T) {
+	h, _, beta := mouseTestHome(t)
+	clock := newFakeClock(h)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	fakes, _ := stubLiveTermFactory(t)
+
+	// Slow clicks: select only — no pane opens.
+	clickZone(t, h, zones.TreeInstance(beta.Title))
+	clock.advance(time.Second)
+	clickZone(t, h, zones.TreeInstance(beta.Title))
+	assert.Zero(t, h.store.NumOpenPanes(), "clicks slower than the double-click interval must not enter")
+
+	// Fast second click: the Enter path — pane opens focused; the deferred
+	// activation arrives as enterInteractiveMsg (driven directly: the batched
+	// cmd also carries selectionChanged's capture dispatches, which are not
+	// hermetic — the TestEnterFromTreeOpensPaneAndEntersInteractive pattern).
+	clock.advance(time.Second)
+	clickZone(t, h, zones.TreeInstance(beta.Title))
+	clock.advance(50 * time.Millisecond)
+	clickZone(t, h, zones.TreeInstance(beta.Title))
+	p := h.store.FindOpenPane(beta, 0)
+	require.NotNil(t, p, "double-click must open the selection's pane, like Enter")
+	assert.Equal(t, p, h.focusedOpenPane(), "the opened pane takes focus")
+	_, cmd := h.Update(enterInteractiveMsg{pane: p})
+	runHermeticCmd(t, h, cmd, 0)
+	assert.True(t, h.interactive, "double-click enters interactive mode through the Enter seam")
+	require.Len(t, *fakes, 1)
+}
+
+// TestMouse_PaneClicksFocusThenInteract: a header click focuses the pane; a
+// body click on an unfocused pane focuses it; a click on the already-focused
+// pane's body enters it (the §2.5 "click a focused pane body → interactive"
+// row).
+func TestMouse_PaneClicksFocusThenInteract(t *testing.T) {
+	h, alpha, beta := mouseTestHome(t)
+	clock := newFakeClock(h)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	_, _ = stubLiveTermFactory(t)
+	pa := openTestPane(t, h, alpha, 0)
+	pb := openTestPane(t, h, beta, 0) // focused last
+	regionA := layout.PaneRegion(pa.ID())
+	regionB := layout.PaneRegion(pb.ID())
+	require.Equal(t, regionB, h.ring.Active())
+
+	// Header click picks pane A out of the split.
+	clickZone(t, h, zones.PaneHeader(regionA))
+	assert.Equal(t, regionA, h.ring.Active(), "pane A header click focuses pane A")
+
+	// Body click on the unfocused pane B focuses it — and only focuses.
+	clock.advance(time.Second)
+	body := zoneRect(t, h, zones.PaneBody(regionB))
+	press(h, body.X+2, body.Y+4) // below the header row
+	assert.Equal(t, regionB, h.ring.Active(), "body click on an unfocused pane focuses it")
+	assert.False(t, h.interactive, "the focusing click must not enter the pane")
+
+	// A later click on the focused pane's body enters it, like Enter.
+	clock.advance(time.Second)
+	body = zoneRect(t, h, zones.PaneBody(regionB))
+	press(h, body.X+2, body.Y+4)
+	p := h.focusedOpenPane()
+	require.Equal(t, pb, p)
+	_, cmd := h.Update(enterInteractiveMsg{pane: p})
+	runHermeticCmd(t, h, cmd, 0)
+	assert.True(t, h.interactive, "click on the focused pane body enters interactive mode")
+}
+
+// TestMouse_ClickTaskRowFocusesAndSelects: a task-row click focuses the rail's
+// automations section and selects that task; a double click opens the
+// task-manager overlay on it (§2.5).
+func TestMouse_ClickTaskRowFocusesAndSelects(t *testing.T) {
+	h, _, _ := mouseTestHome(t)
+	clock := newFakeClock(h)
+
+	clickZone(t, h, zones.AutoTask("task-bbb"))
+	assert.Equal(t, layout.RegionAutomations, h.ring.Active(), "the click focuses the section")
+	assert.Equal(t, 1, h.automations.SelectedTaskIndex(), "the click selects the row's task")
+	assert.Equal(t, stateDefault, h.state, "a single click must not open the manager")
+
+	clock.advance(time.Second)
+	clickZone(t, h, zones.AutoTask("task-bbb"))
+	clock.advance(50 * time.Millisecond)
+	clickZone(t, h, zones.AutoTask("task-bbb"))
+	assert.Equal(t, stateTasks, h.state, "double-click opens the task-manager overlay")
+	sel, ok := selectedManagerTask(h)
+	require.True(t, ok)
+	assert.Equal(t, "task-bbb", sel, "the manager opens preselecting the clicked task")
+}
+
+func selectedManagerTask(h *home) (string, bool) {
+	sp := h.automations.TaskPane()
+	tasks := sp.GetTasks()
+	idx := h.automations.SelectedTaskIndex()
+	if idx < 0 || idx >= len(tasks) {
+		return "", false
+	}
+	return tasks[idx].ID, true
+}
+
+// TestMouse_ClickSectionBackgroundFocusesAutomations: clicking the section
+// anywhere off a task row (its title line) just focuses it.
+func TestMouse_ClickSectionBackgroundFocusesAutomations(t *testing.T) {
+	h, _, _ := mouseTestHome(t)
+	newFakeClock(h)
+
+	clickZone(t, h, zones.AutoBG) // top-left: the title line, no task row
+	assert.Equal(t, layout.RegionAutomations, h.ring.Active())
+	assert.Equal(t, stateDefault, h.state)
+}
+
+// TestMouse_ClickStatusHintRunsAction: clicking a status-bar hint presses its
+// key through the full handleKeyPress path. With the automations section
+// focused the bar advertises "tab focus"; the click must cycle the ring
+// exactly like pressing Tab.
+func TestMouse_ClickStatusHintRunsAction(t *testing.T) {
+	h, _, _ := mouseTestHome(t)
+	newFakeClock(h)
+	h.focusRegion(layout.RegionAutomations)
+
+	clickZone(t, h, zones.StatusHint("tab"))
+	assert.Equal(t, layout.RegionTree, h.ring.Active(),
+		"clicking the 'tab focus' hint cycles the focus ring, like the key")
+}
+
+// TestMouse_WheelScrollsRegionUnderCursor: the wheel drives whatever region
+// is under the cursor — tree cursor movement, pane capture scroll, task
+// selection — regardless of where the focus ring points (before this PR it
+// always scrolled the focused pane).
+func TestMouse_WheelScrollsRegionUnderCursor(t *testing.T) {
+	h, alpha, _ := mouseTestHome(t)
+	newFakeClock(h)
+	p := openTestPane(t, h, alpha, 0)
+	region := layout.PaneRegion(p.ID())
+	h.focusRegion(layout.RegionTree)
+	require.False(t, h.sidebar.GetSelection().IsTab)
+
+	// Over the tree: the cursor walks down (alpha → its first tab row).
+	tree := zoneRect(t, h, zones.TreeBG)
+	wheel(h, tree.X+1, tree.Y+3, false)
+	assert.True(t, h.sidebar.GetSelection().IsTab,
+		"wheel over the tree moves the tree cursor, like j/k")
+
+	// Over the automations section: the task cursor moves — even though the
+	// section is NOT focused — and the tree cursor stays put.
+	preSel := h.sidebar.GetSelection()
+	require.Equal(t, 0, h.automations.SelectedTaskIndex())
+	auto := zoneRect(t, h, zones.AutoBG)
+	wheel(h, auto.X+1, auto.Y, false)
+	assert.Equal(t, 1, h.automations.SelectedTaskIndex(),
+		"wheel over the section moves the task cursor")
+	assert.Equal(t, preSel, h.sidebar.GetSelection(), "the tree cursor must not move")
+	assert.Equal(t, layout.RegionTree, h.ring.Active(), "wheel never moves focus")
+
+	// Over the pane's body: the pane enters capture scroll mode.
+	body := zoneRect(t, h, zones.PaneBody(region))
+	wheel(h, body.X+2, body.Y+4, true)
+	assert.True(t, h.paneWindows[p.ID()].IsInScrollMode(),
+		"wheel over the pane scrolls the pane")
+	assert.Equal(t, 1, h.automations.SelectedTaskIndex(),
+		"pane scroll must not leak into the task selection")
+}
+
+// TestMouse_ConfirmOverlayClicks: the kill confirmation's y/n words act as
+// their keys — n cancels, y confirms (row flips to Deleting) — and while the
+// modal is up, clicks on background zones are swallowed.
+func TestMouse_ConfirmOverlayClicks(t *testing.T) {
+	h, alpha, beta := mouseTestHome(t)
+	clock := newFakeClock(h)
+
+	// Open the kill dialog and click background, then "n or esc to cancel".
+	_, _ = h.handleKill()
+	require.Equal(t, stateConfirm, h.state)
+
+	clickZone(t, h, zones.TreeInstance(beta.Title))
+	assert.Equal(t, stateConfirm, h.state, "a background click must not close the modal")
+	assert.Equal(t, alpha.Title, h.store.GetSelectedInstance().Title,
+		"a background click must not move the selection behind the modal")
+
+	clock.advance(time.Second)
+	clickZone(t, h, zones.OverlayConfirmNo)
+	assert.Equal(t, stateDefault, h.state, "clicking n cancels the dialog")
+	assert.NotEqual(t, session.Deleting, alpha.GetStatus(), "cancel must not kill")
+
+	// Re-open and click "y to confirm".
+	clock.advance(time.Second)
+	_, _ = h.handleKill()
+	require.Equal(t, stateConfirm, h.state)
+	cmd := clickZone(t, h, zones.OverlayConfirmYes)
+	assert.Equal(t, stateDefault, h.state)
+	assert.Equal(t, session.Deleting, alpha.GetStatus(),
+		"clicking y runs the confirm action, like pressing y")
+	assert.NotNil(t, cmd, "the confirm action's startKillMsg must be forwarded")
+}
+
+// TestMouse_SelectionOverlayRowClick: clicking a program row selects and
+// submits it, like ↓ + enter.
+func TestMouse_SelectionOverlayRowClick(t *testing.T) {
+	h, _, _ := mouseTestHome(t)
+	newFakeClock(h)
+	// The submit handler maps the row index into tmux.SupportedPrograms, so
+	// the overlay must carry the real list (as handleStateNew builds it).
+	h.selectionOverlay = overlay.NewSelectionOverlay("Select Program", tmux.SupportedPrograms)
+	h.selectionOverlay.SetWidth(60)
+	h.state = stateSelectProgram
+
+	clickZone(t, h, zones.OverlaySelectRow(2))
+	assert.Equal(t, stateNew, h.state, "a row click submits the selection")
+	assert.Equal(t, tmux.SupportedPrograms[2], h.pendingProgram,
+		"the clicked row's program is chosen")
+}
+
+// TestMouse_SearchOverlayRowClick: clicking a search result selects it and
+// closes the overlay, like ↓ + enter.
+func TestMouse_SearchOverlayRowClick(t *testing.T) {
+	h, _, beta := mouseTestHome(t)
+	newFakeClock(h)
+	_, _ = h.showSearchOverlay()
+	require.Equal(t, stateSearch, h.state)
+
+	clickZone(t, h, zones.OverlaySearchRow(1))
+	assert.Equal(t, stateDefault, h.state, "a row click submits and closes the search")
+	assert.Equal(t, beta.Title, h.sidebar.GetSelectedInstance().Title,
+		"the clicked result becomes the selection")
+}
+
+// TestMouse_MissAndFallbackAreInert: presses outside every zone, non-left
+// buttons, and releases must all no-op; below the hard minimum there are no
+// zones at all.
+func TestMouse_MissAndFallbackAreInert(t *testing.T) {
+	h, _, _ := mouseTestHome(t)
+	newFakeClock(h)
+	_ = h.View()
+
+	// Motion / release / right-button events are ignored in nav mode.
+	_, cmd := h.handleMouse(tea.MouseMsg{X: 1, Y: 1, Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft})
+	assert.Nil(t, cmd)
+	_, cmd = h.handleMouse(tea.MouseMsg{X: 1, Y: 1, Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft})
+	assert.Nil(t, cmd)
+	_, cmd = h.handleMouse(tea.MouseMsg{X: 1, Y: 1, Action: tea.MouseActionPress, Button: tea.MouseButtonRight})
+	assert.Nil(t, cmd)
+
+	// A press past the frame edge resolves nothing and changes nothing.
+	before := h.ring.Active()
+	press(h, h.termWidth+5, h.termHeight+5)
+	assert.Equal(t, before, h.ring.Active())
+
+	// Below the hard minimum the fallback banner renders and registers nothing.
+	resizeHome(h, layout.HardMinWidth-1, layout.HardMinHeight-1)
+	_ = h.View()
+	assert.Empty(t, h.zones.IDs(), "the fallback banner has no clickable zones")
+	press(h, 1, 1) // must not panic
+}
+
+// TestMouse_ZoneInventoryAtFullLayout pins the expected zone families all
+// registering together in a two-pane layout with tasks — the "each pane
+// registers the expected zones" contract at the frame level.
+func TestMouse_ZoneInventoryAtFullLayout(t *testing.T) {
+	h, alpha, beta := mouseTestHome(t)
+	newFakeClock(h)
+	pa := openTestPane(t, h, alpha, 0)
+	pb := openTestPane(t, h, beta, 0)
+	_ = h.View()
+
+	for _, id := range []string{
+		zones.TreeBG,
+		zones.TreeHeader,
+		zones.TreeInstance(alpha.Title),
+		zones.TreeInstance(beta.Title),
+		zones.TreeArrow(alpha.Title),
+		zones.PaneBody(layout.PaneRegion(pa.ID())),
+		zones.PaneHeader(layout.PaneRegion(pa.ID())),
+		zones.PaneBody(layout.PaneRegion(pb.ID())),
+		zones.PaneHeader(layout.PaneRegion(pb.ID())),
+		zones.AutoBG,
+		zones.AutoTask("task-aaa"),
+		zones.StatusHint("q"),
+	} {
+		_, ok := h.zones.Find(id)
+		assert.True(t, ok, "expected zone %q in the full-layout frame; got %v", id, h.zones.IDs())
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Interactive mode × mouse (RFC §2.5 in-pane ownership): events over the live
+// pane forward into the embedded terminal (grid) or are suppressed (frame/
+// header); host gestures still apply outside the pane and drop the mode when
+// they move focus.
+// ----------------------------------------------------------------------------
+
+// interactiveMouseHome enters interactive mode on a live pane and returns the
+// bound fake attachment.
+func interactiveMouseHome(t *testing.T) (*home, *fakeLiveTerm, string) {
+	t.Helper()
+	h, _, fakes := interactiveTestHome(t)
+	enterInteractive(t, h)
+	require.True(t, h.interactive)
+	require.Len(t, *fakes, 1)
+	region := layout.PaneRegion(h.livePane.ID())
+	newFakeClock(h)
+	return h, (*fakes)[0], region
+}
+
+// TestMouse_InteractiveForwardsGridEvents: press/wheel/release over the live
+// pane's terminal grid forward through SendMouse with GRID-LOCAL coordinates
+// (the zone resolve's local point), and never trigger host actions.
+func TestMouse_InteractiveForwardsGridEvents(t *testing.T) {
+	h, fake, region := interactiveMouseHome(t)
+
+	term := zoneRect(t, h, zones.PaneTerm(region))
+	press(h, term.X+5, term.Y+3)
+	require.Len(t, fake.mice, 1, "a grid press must forward to the attachment")
+	assert.Equal(t, 5, fake.mice[0].x, "coordinates forward grid-local")
+	assert.Equal(t, 3, fake.mice[0].y)
+	assert.Equal(t, tea.MouseButtonLeft, fake.mice[0].msg.Button)
+	assert.True(t, h.interactive, "a forwarded press must not leave the mode")
+
+	wheel(h, term.X+5, term.Y+3, true)
+	require.Len(t, fake.mice, 2, "the wheel forwards too — the inner app owns scroll (§2.5)")
+	assert.Equal(t, tea.MouseButtonWheelUp, fake.mice[1].msg.Button)
+	assert.False(t, h.paneWindows[h.livePane.ID()].IsInScrollMode(),
+		"a forwarded wheel must not flip the live pane into host capture scroll")
+
+	_, _ = h.handleMouse(tea.MouseMsg{
+		X: term.X + 5, Y: term.Y + 3, Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft,
+	})
+	require.Len(t, fake.mice, 3, "releases forward so the inner app sees complete clicks")
+}
+
+// TestMouse_InteractiveSuppressesPaneChrome: clicks on the live pane's header
+// or frame are suppressed — no host focus/enter action, nothing forwarded
+// (they are outside the grid).
+func TestMouse_InteractiveSuppressesPaneChrome(t *testing.T) {
+	h, fake, region := interactiveMouseHome(t)
+
+	header := zoneRect(t, h, zones.PaneHeader(region))
+	press(h, header.X+2, header.Y)
+	assert.Empty(t, fake.mice, "chrome clicks must not forward")
+	assert.True(t, h.interactive, "chrome clicks must not drop the mode")
+	assert.Equal(t, region, h.ring.Active(), "chrome clicks must not move focus")
+}
+
+// TestMouse_InteractiveHostGesturesOutsidePane: outside the live pane the
+// host gestures apply (§2.5) — a tree click selects, moves focus to the tree,
+// and thereby ends interactive mode (the mode's premise is "keystrokes go to
+// the FOCUSED pane").
+func TestMouse_InteractiveHostGesturesOutsidePane(t *testing.T) {
+	h, fake, _ := interactiveMouseHome(t)
+	inst := h.store.GetSelectedInstance()
+	require.NotNil(t, inst)
+
+	clickZone(t, h, zones.TreeInstance(inst.Title))
+	assert.Empty(t, fake.mice, "a tree click is a host gesture, not a forward")
+	assert.Equal(t, layout.RegionTree, h.ring.Active(), "the click focuses the tree")
+	assert.False(t, h.interactive, "focus moving off the pane ends interactive mode")
+}
+
+// TestMouse_InteractiveStatusHintExits: the interactive status bar advertises
+// only ctrl+] — clicking it exits to nav mode through the normal key path.
+func TestMouse_InteractiveStatusHintExits(t *testing.T) {
+	h, _, _ := interactiveMouseHome(t)
+
+	clickZone(t, h, zones.StatusHint("ctrl+]"))
+	assert.False(t, h.interactive, "clicking the ctrl+] hint exits interactive mode")
+}
+
+// TestMouse_HintClickMatchesKeyGates: keyMsgFromString covers every primary
+// key the menu can advertise, so a rendered hint is always clickable.
+func TestMouse_HintClickMatchesKeyGates(t *testing.T) {
+	for _, binding := range keys.GlobalKeyBindings {
+		primary := binding.Keys()[0]
+		if primary == "1" { // KeyJumpTab renders no zone by design
+			continue
+		}
+		_, ok := keyMsgFromString(primary)
+		assert.True(t, ok, "primary key %q must synthesize a tea.KeyMsg", primary)
+	}
+}

--- a/ui/automations.go
+++ b/ui/automations.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -82,6 +83,10 @@ type AutomationsPane struct {
 	// now returns the current time for next-run derivation; a fixed value in
 	// tests so rendered "next" columns are deterministic.
 	now func() time.Time
+
+	// zones is the shared mouse hit-test registry (#1024 R4); String()
+	// registers the section plus its task rows every frame. Nil skips.
+	zones *zones.Registry
 }
 
 // NewAutomationsPane creates the section over the given projection.
@@ -153,8 +158,27 @@ func (a *AutomationsPane) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	return nil, false
 }
 
-// HandleMouse implements layout.Pane. Mouse support is #1024 PR 6.
+// HandleMouse implements layout.Pane. Mouse dispatch is zone-id-based at the
+// root (#1024 R4): the section/task-row zones registered by String() resolve
+// to focus/select actions there, so the pane-local fallback consumes nothing.
 func (a *AutomationsPane) HandleMouse(tea.MouseMsg, layout.Point) tea.Cmd { return nil }
+
+// SetZoneRegistry wires the shared mouse hit-test registry (#1024 R4).
+func (a *AutomationsPane) SetZoneRegistry(reg *zones.Registry) {
+	a.zones = reg
+}
+
+// SelectTaskByID moves the section cursor onto the task with the given id —
+// the click action for a task row. Reports whether the task was found.
+func (a *AutomationsPane) SelectTaskByID(id string) bool {
+	for i, tsk := range a.proj.GetTasks() {
+		if tsk.ID == id {
+			a.selected = i
+			return true
+		}
+	}
+	return false
+}
 
 // ScrollUp moves the section cursor up (wheel/key routing).
 func (a *AutomationsPane) ScrollUp() {
@@ -263,6 +287,11 @@ func (a *AutomationsPane) String() string {
 	if a.rect.Empty() {
 		return ""
 	}
+	// The section's base zone: any click inside it that lands on no task row
+	// focuses the automations region. Task rows register on top (later wins).
+	if a.zones != nil {
+		a.zones.Register(zones.AutoBG, a.rect)
+	}
 
 	tasks := a.proj.GetTasks()
 	if a.selected >= len(tasks) {
@@ -314,6 +343,11 @@ func (a *AutomationsPane) String() string {
 	for i := a.offset; i < len(tasks); i++ {
 		if len(lines) >= a.rect.H {
 			break
+		}
+		if a.zones != nil {
+			a.zones.Register(zones.AutoTask(tasks[i].ID), layout.Rect{
+				X: a.rect.X, Y: a.rect.Y + len(lines), W: a.rect.W, H: 1,
+			})
 		}
 		lines = append(lines, a.compactRow(tasks[i], a.focused && i == a.selected))
 	}

--- a/ui/automations_zones_test.go
+++ b/ui/automations_zones_test.go
@@ -1,0 +1,105 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+// TestAutomationsRegistersRowZones (#1024 R4): the rail section registers its
+// rect plus one row zone per rendered task, each sitting on the line that
+// renders that task; rows win the overlap, the title line falls through to
+// the section background.
+func TestAutomationsRegistersRowZones(t *testing.T) {
+	tasks := stripTasks()
+	a := newTestAutomations(tasks)
+	reg := zones.NewRegistry()
+	a.SetZoneRegistry(reg)
+	rect := layout.Rect{X: 2, Y: 40, W: 90, H: 3}
+	a.SetRect(rect)
+
+	reg.Reset()
+	lines := plainLines(a.String())
+
+	bg, ok := reg.Find(zones.AutoBG)
+	require.True(t, ok)
+	assert.Equal(t, rect, bg)
+
+	for _, tsk := range tasks {
+		r, ok := reg.Find(zones.AutoTask(tsk.ID))
+		require.True(t, ok, "row zone for %s; got %v", tsk.Name, reg.IDs())
+		assert.Equal(t, 1, r.H)
+		assert.Contains(t, lines[r.Y-rect.Y], tsk.Name,
+			"the zone must sit on the row rendering its task")
+	}
+
+	// Task rows win over the section background where they overlap.
+	r, _ := reg.Find(zones.AutoTask(tasks[0].ID))
+	id, _, ok := reg.Resolve(r.X+1, r.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.AutoTask(tasks[0].ID), id)
+	// The title line above them falls through to the background.
+	id, _, ok = reg.Resolve(rect.X+1, rect.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.AutoBG, id)
+}
+
+// TestAutomationsCompactSummaryRegistersBGOnly: the 1-line degraded summary
+// has no task rows, so only the background zone exists.
+func TestAutomationsCompactSummaryRegistersBGOnly(t *testing.T) {
+	a := newTestAutomations(stripTasks())
+	reg := zones.NewRegistry()
+	a.SetZoneRegistry(reg)
+	a.SetRect(layout.Rect{X: 0, Y: 40, W: 70, H: 1})
+	a.SetCompact(true)
+
+	reg.Reset()
+	_ = a.String()
+	assert.Equal(t, []string{zones.AutoBG}, reg.IDs(),
+		"the compact summary registers only the section background")
+}
+
+// TestAutomationsScrolledWindowRegistersVisibleRowsOnly: rows scrolled out of
+// the section's window register no zones, so a click can never land on a task
+// that isn't on screen.
+func TestAutomationsScrolledWindowRegistersVisibleRowsOnly(t *testing.T) {
+	tasks := stripTasks()
+	extra := stripTasks()
+	extra[0].ID, extra[0].Name = "3", "third-task"
+	extra[1].ID, extra[1].Name = "4", "fourth-task"
+	tasks = append(tasks, extra...)
+	a := newTestAutomations(tasks)
+	reg := zones.NewRegistry()
+	a.SetZoneRegistry(reg)
+	a.SetRect(layout.Rect{X: 0, Y: 30, W: 90, H: 3}) // title + 2 rows for 4 tasks
+	a.Focus()
+	// Walk the cursor to the last task so the window slides past the first.
+	for range tasks {
+		a.ScrollDown()
+	}
+
+	reg.Reset()
+	_ = a.String()
+
+	_, first := reg.Find(zones.AutoTask("1"))
+	assert.False(t, first, "rows scrolled above the window must not register zones")
+	r, ok := reg.Find(zones.AutoTask("4"))
+	require.True(t, ok, "the cursor's row is inside the window; got %v", reg.IDs())
+	assert.LessOrEqual(t, r.Bottom(), a.rect.Bottom())
+}
+
+// TestAutomationsSelectTaskByID covers the click primitive the mouse router
+// calls: the section cursor lands on the clicked task.
+func TestAutomationsSelectTaskByID(t *testing.T) {
+	tasks := stripTasks()
+	a := newTestAutomations(tasks)
+
+	require.True(t, a.SelectTaskByID(tasks[1].ID))
+	assert.Equal(t, 1, a.SelectedTaskIndex(), "the click selects the row's task")
+	assert.False(t, a.SelectTaskByID("nope"), "unknown ids are refused")
+	assert.Equal(t, 1, a.SelectedTaskIndex(), "a refused click must not move the cursor")
+}

--- a/ui/layout/zones/ids.go
+++ b/ui/layout/zones/ids.go
@@ -1,0 +1,153 @@
+package zones
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Zone id constructors and parsers (#1024 R4, RFC §2.5). The panes build ids
+// while registering rects during View(); the root mouse router parses them
+// back to dispatch. Both sides live here so producer and consumer can't
+// drift.
+//
+// The id grammar is colon-separated: "<region>:<kind>[:<payload>...]". Titles
+// may themselves contain colons, so every parser that extracts a title keeps
+// it as the FINAL variable-length segment (or, for tree tab rows, pairs it
+// with a trailing numeric index parsed from the right).
+const (
+	// TreeHeader is the Instances section header row (click toggles the
+	// section, like Enter on it).
+	TreeHeader = "tree:header"
+	// TreeBG is the tree pane's background: any click inside the rail's tree
+	// region that lands on no finer zone (focuses the tree).
+	TreeBG = "tree:bg"
+	// AutoBG is the rail's automations-section background (focuses the
+	// section).
+	AutoBG = "auto:bg"
+	// OverlayConfirmYes / OverlayConfirmNo are the confirmation dialog's
+	// clickable y/n words.
+	OverlayConfirmYes = "overlay:confirm:yes"
+	OverlayConfirmNo  = "overlay:confirm:no"
+)
+
+// TreeInstance is the zone id of an instance row in the left-rail tree.
+func TreeInstance(title string) string { return "tree:instance:" + title }
+
+// TreeInstanceTitle parses a TreeInstance id back to its title.
+func TreeInstanceTitle(id string) (title string, ok bool) {
+	return strings.CutPrefix(id, "tree:instance:")
+}
+
+// TreeArrow is the zone id of an instance row's expand/collapse arrow glyph.
+func TreeArrow(title string) string { return "tree:arrow:" + title }
+
+// TreeArrowTitle parses a TreeArrow id back to its title.
+func TreeArrowTitle(id string) (title string, ok bool) {
+	return strings.CutPrefix(id, "tree:arrow:")
+}
+
+// TreeTab is the zone id of a tab child row: the parent instance's title plus
+// the 0-based tab slot.
+func TreeTab(title string, idx int) string {
+	return "tree:tab:" + title + ":" + strconv.Itoa(idx)
+}
+
+// TreeTabParts parses a TreeTab id. The index is the final segment (parsed
+// from the right) so titles containing colons survive the round-trip.
+func TreeTabParts(id string) (title string, idx int, ok bool) {
+	rest, found := strings.CutPrefix(id, "tree:tab:")
+	if !found {
+		return "", 0, false
+	}
+	cut := strings.LastIndex(rest, ":")
+	if cut < 0 {
+		return "", 0, false
+	}
+	idx, err := strconv.Atoi(rest[cut+1:])
+	if err != nil {
+		return "", 0, false
+	}
+	return rest[:cut], idx, true
+}
+
+// Workspace pane zone kinds (#1088 N-pane model): region is the pane's
+// layout region id (layout.PaneRegion(paneID), e.g. "pane:3").
+const (
+	// PaneKindHeader is the one-line `title · tab` header inside the frame.
+	PaneKindHeader = "header"
+	// PaneKindBody is the pane's whole rect (frame included).
+	PaneKindBody = "body"
+	// PaneKindTerm is the embedded terminal's content grid — the rect whose
+	// zone-local coordinates ARE emulator grid cells, registered only while
+	// the live view is what the pane renders (#1089). Interactive-mode mouse
+	// forwarding targets exactly this zone.
+	PaneKindTerm = "term"
+)
+
+// PaneHeader is the zone id of a workspace pane's header line.
+func PaneHeader(region string) string { return region + ":" + PaneKindHeader }
+
+// PaneBody is the zone id of a workspace pane's full rect.
+func PaneBody(region string) string { return region + ":" + PaneKindBody }
+
+// PaneTerm is the zone id of a workspace pane's live terminal grid.
+func PaneTerm(region string) string { return region + ":" + PaneKindTerm }
+
+// PaneZone parses a PaneHeader/PaneBody/PaneTerm id, returning the layout
+// region and the kind (PaneKind*).
+func PaneZone(id string) (region, kind string, ok bool) {
+	for _, k := range []string{PaneKindHeader, PaneKindBody, PaneKindTerm} {
+		if r, found := strings.CutSuffix(id, ":"+k); found {
+			return r, k, true
+		}
+	}
+	return "", "", false
+}
+
+// AutoTask is the zone id of one task row in the rail's automations section,
+// keyed by the task's persistent id.
+func AutoTask(taskID string) string { return "auto:task:" + taskID }
+
+// AutoTaskID parses an AutoTask id back to the task id.
+func AutoTaskID(id string) (taskID string, ok bool) {
+	return strings.CutPrefix(id, "auto:task:")
+}
+
+// StatusHint is the zone id of one status-bar key hint; key is the binding's
+// primary key string (e.g. "n", "enter", "ctrl+]") — clicking is equivalent
+// to pressing it.
+func StatusHint(key string) string { return "status:hint:" + key }
+
+// StatusHintKey parses a StatusHint id back to its key string.
+func StatusHintKey(id string) (key string, ok bool) {
+	return strings.CutPrefix(id, "status:hint:")
+}
+
+// OverlaySelectRow is the zone id of row idx in the selection overlay's list.
+func OverlaySelectRow(idx int) string { return "overlay:select:" + strconv.Itoa(idx) }
+
+// OverlaySelectIdx parses an OverlaySelectRow id back to its row index.
+func OverlaySelectIdx(id string) (idx int, ok bool) {
+	return overlayRowIdx(id, "overlay:select:")
+}
+
+// OverlaySearchRow is the zone id of result idx in the search overlay's list
+// (the index is into the full result list, not the visible window).
+func OverlaySearchRow(idx int) string { return "overlay:search:" + strconv.Itoa(idx) }
+
+// OverlaySearchIdx parses an OverlaySearchRow id back to its result index.
+func OverlaySearchIdx(id string) (idx int, ok bool) {
+	return overlayRowIdx(id, "overlay:search:")
+}
+
+func overlayRowIdx(id, prefix string) (int, bool) {
+	rest, found := strings.CutPrefix(id, prefix)
+	if !found {
+		return 0, false
+	}
+	idx, err := strconv.Atoi(rest)
+	if err != nil {
+		return 0, false
+	}
+	return idx, true
+}

--- a/ui/layout/zones/registry.go
+++ b/ui/layout/zones/registry.go
@@ -50,3 +50,24 @@ func (r *Registry) Resolve(x, y int) (id string, local layout.Point, ok bool) {
 
 // Reset clears all registrations for a new frame, retaining capacity.
 func (r *Registry) Reset() { r.zones = r.zones[:0] }
+
+// Find returns the most recently registered rect for id. Tests use it to
+// derive click coordinates FROM the registry (never hardcoded), so layout
+// changes cannot silently break mouse tests (RFC §5.6).
+func (r *Registry) Find(id string) (layout.Rect, bool) {
+	for i := len(r.zones) - 1; i >= 0; i-- {
+		if r.zones[i].id == id {
+			return r.zones[i].rect, true
+		}
+	}
+	return layout.Rect{}, false
+}
+
+// IDs returns the registered zone ids in registration (paint) order.
+func (r *Registry) IDs() []string {
+	out := make([]string, len(r.zones))
+	for i, z := range r.zones {
+		out[i] = z.id
+	}
+	return out
+}

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -1,11 +1,13 @@
 package ui
 
 import (
+	"math"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -70,6 +72,13 @@ type Menu struct {
 
 	// keyDown is the key which is pressed. The default is -1.
 	keyDown keys.KeyName
+
+	// zones is the shared mouse hit-test registry (#1024 R4); String()
+	// registers a clickable rect per rendered hint every frame. origin is the
+	// menu's top-left on screen (the status-bar rect, via SetOrigin), since
+	// the registry works in absolute cells.
+	zones  *zones.Registry
+	origin layout.Point
 }
 
 var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyNewRemote, keys.KeySearch, keys.KeyHelp, keys.KeyQuit}
@@ -295,6 +304,27 @@ func (m *Menu) SetSize(width, height int) {
 	m.height = height
 }
 
+// SetZoneRegistry wires the shared mouse hit-test registry (#1024 R4).
+func (m *Menu) SetZoneRegistry(reg *zones.Registry) {
+	m.zones = reg
+}
+
+// SetOrigin records the menu's top-left screen cell for zone registration.
+func (m *Menu) SetOrigin(p layout.Point) {
+	m.origin = p
+}
+
+// centerStart is where centered content of the given size starts inside a
+// box: lipgloss.Place(…, Center, …) computes left = gap - round(gap·0.5), and
+// the hint zones must land on exactly the cells Place put the hints on.
+func centerStart(box, content int) int {
+	gap := box - content
+	if gap <= 0 {
+		return 0
+	}
+	return gap - int(math.Round(float64(gap)*0.5))
+}
+
 // hintDropOrder lists the options that may be dropped when the hint row is
 // wider than the status bar, least valuable first; options in the same inner
 // slice drop together (a lone "⇧↓ scroll" without its ⇧↑ twin reads like a
@@ -329,7 +359,7 @@ func (m *Menu) String() string {
 	// in priority order and re-render. Whatever still doesn't fit after the
 	// drop list is exhausted is clamped by the status bar as before.
 	drop := make(map[keys.KeyName]bool)
-	line := m.renderHints(drop)
+	line, spans := m.renderHints(drop)
 	for _, ks := range hintDropOrder {
 		if lipgloss.Width(line) <= m.width {
 			break
@@ -337,16 +367,37 @@ func (m *Menu) String() string {
 		for _, k := range ks {
 			drop[k] = true
 		}
-		line = m.renderHints(drop)
+		line, spans = m.renderHints(drop)
+	}
+
+	// Register a click zone per surviving hint (#1024 R4), on the exact
+	// cells lipgloss.Place is about to center the row onto.
+	if m.zones != nil {
+		x0 := m.origin.X + centerStart(m.width, lipgloss.Width(line))
+		y := m.origin.Y + centerStart(m.height, 1)
+		for _, span := range spans {
+			m.zones.Register(zones.StatusHint(span.key),
+				layout.Rect{X: x0 + span.x, Y: y, W: span.w, H: 1})
+		}
 	}
 
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, line)
 }
 
-// renderHints renders the option row, skipping dropped options. Separators
-// follow group membership of the options actually rendered: a bullet within a
-// group, a vertical bar between groups.
-func (m *Menu) renderHints(drop map[keys.KeyName]bool) string {
+// hintSpan is one rendered hint's horizontal extent within the (un-centered)
+// hint row: x is the printable-cell offset where its key text starts, w spans
+// through the end of its description. key is the binding's primary key
+// string — the StatusHint zone id payload, i.e. what a click "presses".
+type hintSpan struct {
+	key  string
+	x, w int
+}
+
+// renderHints renders the option row, skipping dropped options, and reports
+// each rendered hint's cell extent for the click zones. Separators follow
+// group membership of the options actually rendered: a bullet within a group,
+// a vertical bar between groups.
+func (m *Menu) renderHints(drop map[keys.KeyName]bool) (string, []hintSpan) {
 	groupOf := func(i int) int {
 		for gi, g := range m.groups {
 			if i >= g.start && i < g.end {
@@ -357,6 +408,12 @@ func (m *Menu) renderHints(drop map[keys.KeyName]bool) string {
 	}
 
 	var s strings.Builder
+	var spans []hintSpan
+	col := 0
+	write := func(chunk string) {
+		s.WriteString(chunk)
+		col += lipgloss.Width(chunk)
+	}
 	prevGroup := -1
 	first := true
 	for i, k := range m.options {
@@ -381,24 +438,32 @@ func (m *Menu) renderHints(drop map[keys.KeyName]bool) string {
 
 		if !first {
 			if group != prevGroup {
-				s.WriteString(sepStyle.Render(verticalSeparator))
+				write(sepStyle.Render(verticalSeparator))
 			} else {
-				s.WriteString(sepStyle.Render(separator))
+				write(sepStyle.Render(separator))
 			}
 		}
 		first = false
 		prevGroup = group
 
+		start := col
 		if inActionGroup {
-			s.WriteString(localActionStyle.Render(binding.Help().Key))
-			s.WriteString(" ")
-			s.WriteString(localActionStyle.Render(binding.Help().Desc))
+			write(localActionStyle.Render(binding.Help().Key))
+			write(" ")
+			write(localActionStyle.Render(binding.Help().Desc))
 		} else {
-			s.WriteString(localKeyStyle.Render(binding.Help().Key))
-			s.WriteString(" ")
-			s.WriteString(localDescStyle.Render(binding.Help().Desc))
+			write(localKeyStyle.Render(binding.Help().Key))
+			write(" ")
+			write(localDescStyle.Render(binding.Help().Desc))
+		}
+		// KeyJumpTab's "1-9" chip names nine keys, not one action — it gets
+		// no click zone. Everything else is clickable by its primary key.
+		if k != keys.KeyJumpTab {
+			if bkeys := binding.Keys(); len(bkeys) > 0 {
+				spans = append(spans, hintSpan{key: bkeys[0], x: start, w: col - start})
+			}
 		}
 	}
 
-	return menuStyle.Render(s.String())
+	return menuStyle.Render(s.String()), spans
 }

--- a/ui/menu_zones_test.go
+++ b/ui/menu_zones_test.go
@@ -1,0 +1,120 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/keys"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+// cellSlice returns the terminal cells [from, to) of a plain line as a
+// string. All menu hint glyphs are single-cell, so rune slicing suffices.
+func cellSlice(line string, from, to int) string {
+	runes := []rune(line)
+	if from > len(runes) {
+		return ""
+	}
+	if to > len(runes) {
+		to = len(runes)
+	}
+	return string(runes[from:to])
+}
+
+// TestMenuHintZonesMatchRenderedHints (#1024 R4): every rendered hint
+// registers a StatusHint zone, and the zone's cells hold exactly that hint's
+// "key desc" text in the centered output — derived from the registry, so a
+// change to the centering or separator math moves the zones with it or fails
+// here.
+func TestMenuHintZonesMatchRenderedHints(t *testing.T) {
+	menu := NewMenu()
+	reg := zones.NewRegistry()
+	menu.SetZoneRegistry(reg)
+	origin := layout.Point{X: 0, Y: 46}
+	menu.SetOrigin(origin)
+	menu.SetSize(120, 1)
+	menu.SetState(StateEmpty)
+
+	reg.Reset()
+	out := xansi.Strip(menu.String())
+	line := strings.Split(out, "\n")[0]
+
+	for _, k := range defaultMenuOptions {
+		binding := keys.GlobalKeyBindings[k]
+		id := zones.StatusHint(binding.Keys()[0])
+		r, ok := reg.Find(id)
+		require.True(t, ok, "zone for hint %q; got %v", binding.Help().Key, reg.IDs())
+		assert.Equal(t, origin.Y, r.Y, "hints render on the menu row")
+		want := binding.Help().Key + " " + binding.Help().Desc
+		assert.Equal(t, want, cellSlice(line, r.X-origin.X, r.X-origin.X+r.W),
+			"the zone must cover exactly the rendered hint text")
+	}
+}
+
+// TestMenuDroppedHintsRegisterNoZones: hints dropped by the narrow-width
+// priority list must not leave clickable ghosts.
+func TestMenuDroppedHintsRegisterNoZones(t *testing.T) {
+	menu := NewMenu()
+	reg := zones.NewRegistry()
+	menu.SetZoneRegistry(reg)
+	menu.SetOrigin(layout.Point{})
+	menu.SetSize(30, 1) // too narrow for the full default row
+	menu.SetState(StateEmpty)
+
+	reg.Reset()
+	_ = menu.String()
+
+	// The drop order sheds "/" and "N" before help/quit; at 30 cols they are
+	// gone, and their zones with them.
+	_, hasSearch := reg.Find(zones.StatusHint("/"))
+	assert.False(t, hasSearch, "dropped hints must not register zones")
+	_, hasHelp := reg.Find(zones.StatusHint("?"))
+	assert.True(t, hasHelp, "help is never dropped and keeps its zone")
+	_, hasQuit := reg.Find(zones.StatusHint("q"))
+	assert.True(t, hasQuit, "quit is never dropped and keeps its zone")
+}
+
+// TestMenuJumpTabHintHasNoZone: the "1-9" chip names nine keys, not one
+// action, so it is deliberately not clickable.
+func TestMenuJumpTabHintHasNoZone(t *testing.T) {
+	menu := NewMenu()
+	reg := zones.NewRegistry()
+	menu.SetZoneRegistry(reg)
+	menu.SetOrigin(layout.Point{})
+	menu.SetSize(200, 1)
+	menu.options = []keys.KeyName{keys.KeyJumpTab, keys.KeyHelp}
+	menu.groups = []menuGroup{{start: 0, end: 2}}
+
+	reg.Reset()
+	_ = menu.String()
+	for _, id := range reg.IDs() {
+		key, ok := zones.StatusHintKey(id)
+		require.True(t, ok)
+		assert.NotEqual(t, "1", key, "the 1-9 jump chip must not register a zone")
+	}
+	_, hasHelp := reg.Find(zones.StatusHint("?"))
+	assert.True(t, hasHelp)
+}
+
+// TestMenuInteractiveHintZone: while interactive the whole bar is the ctrl+]
+// escape hatch, and its zone must carry the ctrl+] key so a click exits the
+// mode through the normal key path.
+func TestMenuInteractiveHintZone(t *testing.T) {
+	menu := NewMenu()
+	reg := zones.NewRegistry()
+	menu.SetZoneRegistry(reg)
+	menu.SetOrigin(layout.Point{Y: 30})
+	menu.SetSize(100, 1)
+	menu.SetInteractive(true)
+
+	reg.Reset()
+	_ = menu.String()
+	r, ok := reg.Find(zones.StatusHint("ctrl+]"))
+	require.True(t, ok, "the interactive bar's escape hatch must be clickable; got %v", reg.IDs())
+	assert.Equal(t, 30, r.Y)
+}

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -175,6 +175,22 @@ func runeEqualFold(a, b rune) bool {
 	return false
 }
 
+// visibleWindow returns the [start, end) result window Render shows: at most
+// maxVisible rows, slid so the selected item is always included. Shared with
+// the mouse zone registration (zones.go) so the rows registered are exactly
+// the rows rendered.
+func (s *SearchOverlay) visibleWindow() (startIdx, endIdx int) {
+	const maxVisible = 10
+	if s.selectedIdx >= maxVisible {
+		startIdx = s.selectedIdx - maxVisible + 1
+	}
+	endIdx = startIdx + maxVisible
+	if endIdx > len(s.results) {
+		endIdx = len(s.results)
+	}
+	return startIdx, endIdx
+}
+
 // Render renders the search overlay.
 func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.AccentColor)
@@ -197,17 +213,7 @@ func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
 		}
 	}
 
-	maxVisible := 10
-
-	// Compute the visible window so it always includes the selected item.
-	startIdx := 0
-	if s.selectedIdx >= maxVisible {
-		startIdx = s.selectedIdx - maxVisible + 1
-	}
-	endIdx := startIdx + maxVisible
-	if endIdx > len(s.results) {
-		endIdx = len(s.results)
-	}
+	startIdx, endIdx := s.visibleWindow()
 
 	if startIdx > 0 {
 		content += normalStyle.Render(

--- a/ui/overlay/zones.go
+++ b/ui/overlay/zones.go
@@ -1,0 +1,149 @@
+package overlay
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+// Mouse zone registration for the modal overlays (#1024 R4): clicking a
+// confirmation's y/n words or a selection/search row is equivalent to the
+// key. Zones are derived by scanning the overlay's own rendered output — not
+// by replicating the border/padding/wrap math — so a rendering change moves
+// the zones with it instead of leaving them pointing at stale cells. origin
+// is the overlay's top-left on screen (the root computes it from the same
+// centering PlaceOverlay applies).
+
+// cellColumn is the terminal-cell column of byte offset idx within the
+// ANSI-stripped line (border glyphs are multibyte but one cell wide, so byte
+// offsets are not columns).
+func cellColumn(plain string, idx int) int {
+	return runewidth.StringWidth(plain[:idx])
+}
+
+// RegisterZones registers the confirmation dialog's clickable y/n words. The
+// instruction line is scanned from the bottom (the message could conceivably
+// contain the same words); a wrapped instruction line registers nothing and
+// the keyboard remains fully sufficient.
+func (c *ConfirmationOverlay) RegisterZones(reg *zones.Registry, origin layout.Point) {
+	if reg == nil {
+		return
+	}
+	yesNeedle := c.ConfirmKey + " to confirm"
+	noNeedle := c.CancelKey + " or esc to cancel"
+	lines := strings.Split(c.Render(), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		plain := xansi.Strip(lines[i])
+		yi := strings.Index(plain, yesNeedle)
+		ni := strings.Index(plain, noNeedle)
+		if yi < 0 && ni < 0 {
+			continue
+		}
+		if yi >= 0 {
+			reg.Register(zones.OverlayConfirmYes, layout.Rect{
+				X: origin.X + cellColumn(plain, yi), Y: origin.Y + i,
+				W: runewidth.StringWidth(yesNeedle), H: 1,
+			})
+		}
+		if ni >= 0 {
+			reg.Register(zones.OverlayConfirmNo, layout.Rect{
+				X: origin.X + cellColumn(plain, ni), Y: origin.Y + i,
+				W: runewidth.StringWidth(noNeedle), H: 1,
+			})
+		}
+		return
+	}
+}
+
+// RegisterZones registers one full-width clickable zone per selection row;
+// clicking a row selects and submits it, like ↓/↑ + enter.
+func (s *SelectionOverlay) RegisterZones(reg *zones.Registry, origin layout.Point) {
+	if reg == nil {
+		return
+	}
+	rendered := s.Render()
+	width := lipglossWidth(rendered)
+	lines := strings.Split(rendered, "\n")
+	next := 0
+	for i, line := range lines {
+		if next >= len(s.items) {
+			break
+		}
+		t := strings.Trim(xansi.Strip(line), "│ ")
+		if t == "▸ "+s.items[next] || t == s.items[next] {
+			reg.Register(zones.OverlaySelectRow(next), layout.Rect{
+				X: origin.X, Y: origin.Y + i, W: width, H: 1,
+			})
+			next++
+		}
+	}
+}
+
+// RegisterZones registers one full-width clickable zone per visible search
+// result, keyed by the result's index in the full result list; clicking a
+// row selects and submits it. The scan walks the same window Render shows
+// (Render slides a maxVisible-row window to keep the selection visible), so
+// a scrolled list registers exactly the rows on screen — matching the first
+// visible row against results[0] instead used to register nothing once the
+// selection moved past the first page (Greptile P1 on the original PR).
+func (s *SearchOverlay) RegisterZones(reg *zones.Registry, origin layout.Point) {
+	if reg == nil {
+		return
+	}
+	rendered := s.Render()
+	width := lipglossWidth(rendered)
+	lines := strings.Split(rendered, "\n")
+	startIdx, endIdx := s.visibleWindow()
+	next := startIdx
+	for i, line := range lines {
+		if next >= endIdx {
+			break
+		}
+		title, ok := searchRowTitle(line)
+		if !ok {
+			continue
+		}
+		want := s.results[next].Instance.Title
+		if title == want || strings.HasPrefix(title, want+" (") {
+			reg.Register(zones.OverlaySearchRow(next), layout.Rect{
+				X: origin.X, Y: origin.Y + i, W: width, H: 1,
+			})
+			next++
+		}
+	}
+}
+
+// searchRowTitle parses a rendered search-result line down to its title text
+// (plus the optional " (branch)" suffix the caller strips by prefix match).
+// Result rows are the only lines that begin with a status glyph after the
+// border/padding, which is what distinguishes them from the query and hint
+// lines.
+func searchRowTitle(line string) (string, bool) {
+	t := strings.Trim(xansi.Strip(line), "│ ")
+	r, size := utf8.DecodeRuneInString(t)
+	if r != '●' && r != '○' && r != '◌' {
+		return "", false
+	}
+	t = strings.TrimLeft(t[size:], " ")
+	t = strings.TrimPrefix(t, "▸ ")
+	return t, true
+}
+
+// SetSelectedIndex moves the search selection onto the given result index
+// (the click action for a result row). Out-of-range indices no-op.
+func (s *SearchOverlay) SetSelectedIndex(idx int) {
+	if idx >= 0 && idx < len(s.results) {
+		s.selectedIdx = idx
+	}
+}
+
+// lipglossWidth is the widest printable line width of a rendered block.
+func lipglossWidth(rendered string) int {
+	_, w := getLines(rendered)
+	return w
+}

--- a/ui/overlay/zones_test.go
+++ b/ui/overlay/zones_test.go
@@ -1,0 +1,186 @@
+package overlay
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+func keyEnter() tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyEnter} }
+
+// ----------------------------------------------------------------------------
+// Overlay button zones (#1024 R4): clicking the confirmation's y/n words or a
+// selection/search row is equivalent to the key. The zones are derived by
+// scanning the rendered output, and these tests verify each zone lands on the
+// rendered text it stands for.
+// ----------------------------------------------------------------------------
+
+// cellSliceAt returns the w terminal cells starting at absolute column x of a
+// rendered line, given the overlay was registered at origin.
+func cellSliceAt(line string, x, w int) string {
+	plain := xansi.Strip(line)
+	// All confirm/selection glyphs are single-cell, so walk runes by width.
+	col, start := 0, -1
+	var out []rune
+	for i, r := range []rune(plain) {
+		if col == x && start < 0 {
+			start = i
+		}
+		if start >= 0 && col < x+w {
+			out = append(out, r)
+		}
+		col += runewidth.RuneWidth(r)
+	}
+	return string(out)
+}
+
+func TestConfirmationOverlayRegistersYesNoZones(t *testing.T) {
+	c := NewConfirmationOverlay("[!] Kill session 'alpha'?")
+	c.SetWidth(50)
+	reg := zones.NewRegistry()
+	origin := layout.Point{X: 12, Y: 5}
+	c.RegisterZones(reg, origin)
+
+	lines := strings.Split(c.Render(), "\n")
+
+	yes, ok := reg.Find(zones.OverlayConfirmYes)
+	require.True(t, ok, "yes zone; got %v", reg.IDs())
+	no, ok := reg.Find(zones.OverlayConfirmNo)
+	require.True(t, ok, "no zone")
+
+	assert.Equal(t, yes.Y, no.Y, "both buttons sit on the instruction line")
+	line := lines[yes.Y-origin.Y]
+	assert.Equal(t, "y to confirm", cellSliceAt(line, yes.X-origin.X, yes.W),
+		"the yes zone covers exactly its rendered words")
+	assert.Equal(t, "n or esc to cancel", cellSliceAt(line, no.X-origin.X, no.W),
+		"the no zone covers exactly its rendered words")
+
+	// Resolve precedence sanity: a click on each zone resolves to it.
+	id, _, ok := reg.Resolve(yes.X, yes.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.OverlayConfirmYes, id)
+	id, _, ok = reg.Resolve(no.X+2, no.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.OverlayConfirmNo, id)
+}
+
+// TestConfirmationOverlayZonesFollowCustomKeys: overlays with a custom
+// confirm key register the zone over the custom instruction text.
+func TestConfirmationOverlayZonesFollowCustomKeys(t *testing.T) {
+	c := NewConfirmationOverlay("proceed?")
+	c.SetWidth(50)
+	c.SetConfirmKey("d")
+	reg := zones.NewRegistry()
+	c.RegisterZones(reg, layout.Point{})
+
+	yes, ok := reg.Find(zones.OverlayConfirmYes)
+	require.True(t, ok)
+	line := strings.Split(c.Render(), "\n")[yes.Y]
+	assert.Equal(t, "d to confirm", cellSliceAt(line, yes.X, yes.W))
+}
+
+func TestSelectionOverlayRegistersRowZones(t *testing.T) {
+	items := []string{"claude", "aider", "codex"}
+	s := NewSelectionOverlay("Select Program", items)
+	s.SetWidth(50)
+	reg := zones.NewRegistry()
+	origin := layout.Point{X: 8, Y: 4}
+	s.RegisterZones(reg, origin)
+
+	lines := strings.Split(s.Render(), "\n")
+	for i, item := range items {
+		r, ok := reg.Find(zones.OverlaySelectRow(i))
+		require.True(t, ok, "row zone for %q; got %v", item, reg.IDs())
+		assert.Equal(t, origin.X, r.X, "row zones span the full overlay width")
+		assert.Contains(t, xansi.Strip(lines[r.Y-origin.Y]), item,
+			"row %d's zone must sit on the line rendering %q", i, item)
+	}
+}
+
+func TestSearchOverlayRegistersRowZonesAndSetSelectedIndex(t *testing.T) {
+	instances := []*session.Instance{
+		{Title: "alpha"},
+		{Title: "alpha-2"},
+		{Title: "beta"},
+	}
+	s := NewSearchOverlay(instances)
+	reg := zones.NewRegistry()
+	origin := layout.Point{X: 10, Y: 3}
+	s.RegisterZones(reg, origin)
+
+	lines := strings.Split(s.Render(), "\n")
+	for i, inst := range instances {
+		r, ok := reg.Find(zones.OverlaySearchRow(i))
+		require.True(t, ok, "row zone for %q; got %v", inst.Title, reg.IDs())
+		assert.Contains(t, xansi.Strip(lines[r.Y-origin.Y]), inst.Title,
+			"result %d's zone must sit on the line rendering %q", i, inst.Title)
+	}
+	// "alpha" is a prefix of "alpha-2": the ordered scan must not have bound
+	// both zones to the same line.
+	r0, _ := reg.Find(zones.OverlaySearchRow(0))
+	r1, _ := reg.Find(zones.OverlaySearchRow(1))
+	assert.NotEqual(t, r0.Y, r1.Y, "prefix-colliding titles must map to distinct rows")
+
+	// SetSelectedIndex is the click primitive: it moves the selection the
+	// subsequent enter submits.
+	s.SetSelectedIndex(2)
+	require.True(t, s.HandleKeyPress(keyEnter()))
+	assert.Same(t, instances[2], s.GetSelectedInstance())
+
+	// Out-of-range clicks are refused.
+	s2 := NewSearchOverlay(instances)
+	s2.SetSelectedIndex(99)
+	require.True(t, s2.HandleKeyPress(keyEnter()))
+	assert.Same(t, instances[0], s2.GetSelectedInstance())
+}
+
+// TestSearchOverlayScrolledWindowRegistersVisibleRows pins the Greptile P1 on
+// the original mouse PR (#1086): once the selection scrolls past the first
+// page, Render windows the results — and the registered zones must be the
+// rows actually on screen, keyed by their FULL-LIST indices, instead of
+// matching the visible rows against results[0] and registering nothing.
+func TestSearchOverlayScrolledWindowRegistersVisibleRows(t *testing.T) {
+	var instances []*session.Instance
+	for i := 1; i <= 12; i++ {
+		instances = append(instances, &session.Instance{Title: sessionTitle(i)})
+	}
+	s := NewSearchOverlay(instances)
+	// Walk the selection to the last result: the visible window is now
+	// results[2..12).
+	for range instances {
+		_ = s.HandleKeyPress(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	reg := zones.NewRegistry()
+	origin := layout.Point{X: 5, Y: 2}
+	s.RegisterZones(reg, origin)
+
+	_, hasFirst := reg.Find(zones.OverlaySearchRow(0))
+	assert.False(t, hasFirst, "rows scrolled above the window must not register")
+
+	lines := strings.Split(s.Render(), "\n")
+	for i := 2; i < 12; i++ {
+		r, ok := reg.Find(zones.OverlaySearchRow(i))
+		require.True(t, ok, "visible row %d must register; got %v", i, reg.IDs())
+		assert.Contains(t, xansi.Strip(lines[r.Y-origin.Y]), sessionTitle(i+1),
+			"row %d's zone must sit on the line rendering it", i)
+	}
+
+	// The click primitive round-trips: clicking the row registered for index
+	// 5 selects session-06.
+	s.SetSelectedIndex(5)
+	require.True(t, s.HandleKeyPress(keyEnter()))
+	assert.Same(t, instances[5], s.GetSelectedInstance())
+}
+
+func sessionTitle(i int) string {
+	return "session-" + string(rune('0'+i/10)) + string(rune('0'+i%10))
+}

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/sachiniyer/agent-factory/ui/tree"
 
@@ -136,6 +137,14 @@ type Sidebar struct {
 	height   int
 	width    int
 	focused  bool
+
+	// rect is the pane's screen rect (SetRect); zone registration needs the
+	// absolute origin, not just the size.
+	rect layout.Rect
+	// zones is the shared mouse hit-test registry (#1024 R4). String()
+	// registers a rect per interactive row every frame; nil (ui unit tests
+	// that never wire a registry) skips registration.
+	zones *zones.Registry
 }
 
 // NewSidebar creates a new sidebar rendering the given projection.
@@ -175,7 +184,13 @@ func (s *Sidebar) contentWidth() int {
 
 // SetRect implements layout.Pane.
 func (s *Sidebar) SetRect(r layout.Rect) {
+	s.rect = r
 	s.SetSize(r.W, r.H)
+}
+
+// SetZoneRegistry wires the shared mouse hit-test registry (#1024 R4).
+func (s *Sidebar) SetZoneRegistry(reg *zones.Registry) {
+	s.zones = reg
 }
 
 // Focused implements layout.Pane.
@@ -192,7 +207,10 @@ func (s *Sidebar) Blur() { s.focused = false }
 // pane has focus); per-pane routing arrives with the split (#1024 PR 5).
 func (s *Sidebar) HandleKey(tea.KeyMsg) (tea.Cmd, bool) { return nil, false }
 
-// HandleMouse implements layout.Pane. Mouse support is #1024 PR 6.
+// HandleMouse implements layout.Pane. Mouse dispatch is zone-id-based at the
+// root (#1024 R4): String() registers per-row zones and the root router
+// calls the click primitives (SelectTabRow, ToggleInstanceTree, …) directly,
+// so the pane-local fallback consumes nothing.
 func (s *Sidebar) HandleMouse(tea.MouseMsg, layout.Point) tea.Cmd { return nil }
 
 // View implements layout.Pane.
@@ -706,11 +724,13 @@ func (s *Sidebar) SyncCursorToActiveTab() {
 // content pane) would be wrong here because the selected row can sit below the
 // fold while navigating — instead the rendered slice scrolls so the selection
 // is always visible, with "▲/▼ N more" rows marking hidden items.
+// chromeLines is the fixed chrome above the sidebar's item list: one leading
+// blank line plus the title row. Shared by String()'s window budget and the
+// zone registration's y origin so the two can't drift.
+const chromeLines = 2
+
 func (s *Sidebar) String() string {
 	s.syncFromStore()
-
-	// Chrome above the item list: one leading blank line plus the title row.
-	const chromeLines = 2
 
 	// Render every visible row up front and measure real heights: instance
 	// rows are multi-line (title + branch, plus an optional PR line) while tab
@@ -748,6 +768,8 @@ func (s *Sidebar) String() string {
 	} else {
 		s.scrollOffset = 0
 	}
+
+	s.registerZones(heights, start, end, hiddenAbove > 0)
 
 	var b strings.Builder
 	b.WriteString("\n")
@@ -808,6 +830,120 @@ func (s *Sidebar) String() string {
 		}
 	}
 	return out
+}
+
+// registerZones records the mouse hit-test rects for this frame (#1024 R4):
+// the pane background, the section header, and — for every row inside the
+// rendered window — the instance/tab row plus the instance's ▸/▾ arrow cell.
+// Coordinates mirror String()'s exact line budget (the leading blank + title
+// chrome, then the "▲ N more" indicator when the window is scrolled), and
+// every zone is clipped to the pane rect since the final ClampToRect clips
+// any partially fitting last row the same way.
+func (s *Sidebar) registerZones(heights []int, start, end int, topIndicator bool) {
+	if s.zones == nil || s.rect.Empty() {
+		return
+	}
+	s.zones.Register(zones.TreeBG, s.rect)
+
+	instances := s.proj.GetInstances()
+	y := s.rect.Y + chromeLines
+	if topIndicator {
+		y++
+	}
+	bottom := s.rect.Bottom()
+	for i := start; i < end && y < bottom; i++ {
+		item := s.visibleItems[i]
+		h := heights[i]
+		if y+h > bottom {
+			h = bottom - y
+		}
+		row := layout.Rect{X: s.rect.X, Y: y, W: s.rect.W, H: h}
+		switch {
+		case item.IsHeader:
+			s.zones.Register(zones.TreeHeader, row)
+		case item.Kind == SectionInstances && item.ItemIndex >= 0 && item.ItemIndex < len(instances):
+			inst := instances[item.ItemIndex]
+			if item.IsTab {
+				s.zones.Register(zones.TreeTab(inst.Title, item.TabIndex), row)
+			} else {
+				s.zones.Register(zones.TreeInstance(inst.Title), row)
+				// The arrow cell registers ON TOP of the row (later wins) so
+				// clicking it expands/collapses instead of selecting.
+				if ax, ay, ok := tree.ArrowCell(s.contentWidth()); ok && tree.Expandable(inst) && ay < h {
+					s.zones.Register(zones.TreeArrow(inst.Title),
+						layout.Rect{X: s.rect.X + ax, Y: y + ay, W: 1, H: 1})
+				}
+			}
+		}
+		y += heights[i]
+	}
+}
+
+// ClickHeader moves the cursor onto the Instances section header and toggles
+// its expansion — the click equivalent of Enter on the header row.
+func (s *Sidebar) ClickHeader() {
+	s.syncFromStore()
+	for i, item := range s.visibleItems {
+		if item.IsHeader {
+			s.selectedIdx = i
+			break
+		}
+	}
+	s.ToggleSection()
+}
+
+// SelectTabRow moves the cursor onto tab slot idx of the instance titled
+// title — the click action for a tree tab row, which (via pushSelection)
+// retargets the workspace onto that tab. Tab rows only render for the
+// expanded instance, so a click that races a structure change and finds no
+// such row no-ops rather than guessing.
+func (s *Sidebar) SelectTabRow(title string, idx int) {
+	s.syncFromStore()
+	instances := s.proj.GetInstances()
+	for j, item := range s.visibleItems {
+		if item.Kind == SectionInstances && !item.IsHeader && item.IsTab &&
+			item.ItemIndex >= 0 && item.ItemIndex < len(instances) &&
+			instances[item.ItemIndex].Title == title && item.TabIndex == idx {
+			s.selectedIdx = j
+			s.afterCursorMove()
+			return
+		}
+	}
+}
+
+// ToggleInstanceTree is the click action for an instance row's ▸/▾ arrow: the
+// cursor lands on the clicked row (a click always selects), and the arrow
+// meaning follows the tree's expansion policy — selecting a different
+// instance auto-expands it (that IS the ▸ action), while the already-selected
+// instance toggles its explicit h/← collapse override.
+func (s *Sidebar) ToggleInstanceTree(title string) {
+	s.syncFromStore()
+	instances := s.proj.GetInstances()
+	instIdx := -1
+	for i, inst := range instances {
+		if inst.Title == title {
+			instIdx = i
+			break
+		}
+	}
+	if instIdx < 0 {
+		return
+	}
+	sel := s.proj.GetSelectedInstance()
+	wasSelected := sel != nil && sel.Title == title
+	wasExpanded := s.instanceExpanded(instances[instIdx])
+	s.SetSelectedInstance(instIdx)
+	if !wasSelected {
+		return
+	}
+	if wasExpanded {
+		s.treeCollapsed = title
+	} else {
+		s.treeCollapsed = ""
+	}
+	s.rebuildVisibleItems()
+	s.moveCursorToInstanceRow(instIdx)
+	s.afterCursorMove()
 }
 
 // scrollToSelection clamps scrollOffset and moves it minimally so the selected

--- a/ui/sidebar_zones_test.go
+++ b/ui/sidebar_zones_test.go
@@ -1,0 +1,190 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+// ----------------------------------------------------------------------------
+// Mouse zone registration (#1024 R4): the sidebar registers a hit rect per
+// interactive row while rendering, and the rects must line up with the actual
+// rendered output — the tests derive expectations from the registry and check
+// them against the frame, never against hardcoded coordinates.
+// ----------------------------------------------------------------------------
+
+// plainLines strips ANSI and splits a rendered frame into lines.
+func plainLines(out string) []string {
+	return strings.Split(xansi.Strip(out), "\n")
+}
+
+// runeAtCell returns the rune occupying terminal cell col of a plain line.
+func runeAtCell(line string, col int) rune {
+	w := 0
+	for _, r := range line {
+		if w == col {
+			return r
+		}
+		w += runewidth.RuneWidth(r)
+	}
+	return 0
+}
+
+// lineAt maps an absolute zone row back into the pane-local rendered line.
+func lineAt(t *testing.T, lines []string, rect layout.Rect, y int) string {
+	t.Helper()
+	local := y - rect.Y
+	require.GreaterOrEqual(t, local, 0)
+	require.Less(t, local, len(lines), "zone row must exist in the rendered output")
+	return lines[local]
+}
+
+func TestSidebarRegistersRowZones(t *testing.T) {
+	s := newTreeSidebar(t, 3)
+	reg := zones.NewRegistry()
+	s.SetZoneRegistry(reg)
+	rect := layout.Rect{X: 7, Y: 3, W: 40, H: 24}
+	s.SetRect(rect)
+	s.SetSelectedInstance(0)
+
+	reg.Reset()
+	out := s.String()
+	lines := plainLines(out)
+
+	// The pane background is the whole rect (any stray click focuses the tree).
+	bg, ok := reg.Find(zones.TreeBG)
+	require.True(t, ok)
+	assert.Equal(t, rect, bg)
+
+	// The section header row renders the section title on its zone's row.
+	header, ok := reg.Find(zones.TreeHeader)
+	require.True(t, ok, "header zone must be registered")
+	assert.Contains(t, lineAt(t, lines, rect, header.Y), "Instances",
+		"the header zone must sit on the rendered header row")
+
+	// Every instance row has a zone whose block contains its title.
+	for _, title := range []string{"t-00", "t-01", "t-02"} {
+		r, ok := reg.Find(zones.TreeInstance(title))
+		require.True(t, ok, "instance zone for %s; got %v", title, reg.IDs())
+		assert.Equal(t, rect.X, r.X)
+		assert.Equal(t, rect.W, r.W)
+		block := strings.Join(lines[r.Y-rect.Y:r.Y-rect.Y+r.H], "\n")
+		assert.Contains(t, block, title, "the zone block must contain the row it targets")
+	}
+
+	// The selected (expanded) instance registers its tab child rows, and each
+	// zone's row renders that tab's label.
+	for idx, label := range []string{"1 Preview", "2 Terminal"} {
+		r, ok := reg.Find(zones.TreeTab("t-00", idx))
+		require.True(t, ok, "tab zone for slot %d; got %v", idx, reg.IDs())
+		assert.Equal(t, 1, r.H, "tab rows are single-line")
+		assert.Contains(t, lineAt(t, lines, rect, r.Y), label)
+	}
+	// Collapsed instances register no tab zones.
+	_, ok = reg.Find(zones.TreeTab("t-01", 0))
+	assert.False(t, ok, "collapsed instances must not register tab zones")
+}
+
+func TestSidebarArrowZoneMatchesRenderedGlyph(t *testing.T) {
+	s := newTreeSidebar(t, 2)
+	reg := zones.NewRegistry()
+	s.SetZoneRegistry(reg)
+	rect := layout.Rect{X: 4, Y: 2, W: 38, H: 22}
+	s.SetRect(rect)
+	s.SetSelectedInstance(0)
+
+	reg.Reset()
+	lines := plainLines(s.String())
+
+	// Expanded selected instance: its arrow zone must sit exactly on the ▾.
+	r, ok := reg.Find(zones.TreeArrow("t-00"))
+	require.True(t, ok, "arrow zone for the expanded instance")
+	assert.Equal(t, '▾', runeAtCell(lineAt(t, lines, rect, r.Y), r.X-rect.X),
+		"the arrow zone must cover the rendered ▾ glyph")
+
+	// Collapsed instance: same contract for ▸.
+	r2, ok := reg.Find(zones.TreeArrow("t-01"))
+	require.True(t, ok, "arrow zone for the collapsed instance")
+	assert.Equal(t, '▸', runeAtCell(lineAt(t, lines, rect, r2.Y), r2.X-rect.X))
+
+	// The arrow registers on top of the instance row: resolving its cell must
+	// hit the arrow, while the cell next to it hits the row.
+	id, _, ok := reg.Resolve(r.X, r.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.TreeArrow("t-00"), id)
+	id, _, ok = reg.Resolve(r.X+3, r.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.TreeInstance("t-00"), id)
+}
+
+// TestSidebarZonesClippedToRect: rows scrolled out of the window register no
+// zones, and no registered zone extends past the pane rect (String()'s final
+// clamp cuts partially fitting rows the same way).
+func TestSidebarZonesClippedToRect(t *testing.T) {
+	s := newTreeSidebar(t, 12)
+	reg := zones.NewRegistry()
+	s.SetZoneRegistry(reg)
+	rect := layout.Rect{X: 0, Y: 0, W: 30, H: 12}
+	s.SetRect(rect)
+	s.SetSelectedInstance(0)
+
+	reg.Reset()
+	_ = s.String()
+
+	registered := 0
+	for _, id := range reg.IDs() {
+		r, ok := reg.Find(id)
+		require.True(t, ok)
+		assert.LessOrEqual(t, r.Bottom(), rect.Bottom(), "zone %s must not extend past the pane", id)
+		if title, isInst := zones.TreeInstanceTitle(id); isInst && title != "" {
+			registered++
+		}
+	}
+	assert.Less(t, registered, 12, "rows scrolled out of the window must not register zones")
+	assert.Greater(t, registered, 0, "visible rows must register zones")
+}
+
+// TestSidebarClickPrimitives covers the click actions the mouse router calls:
+// SelectTabRow retargets the active tab, ToggleInstanceTree drives the
+// expansion policy, ClickHeader toggles the section.
+func TestSidebarClickPrimitives(t *testing.T) {
+	s := newTreeSidebar(t, 2)
+	s.SetSize(40, 24)
+	s.SetSelectedInstance(0)
+
+	// Click a tab row: cursor lands on it, store's active tab follows.
+	s.SelectTabRow("t-00", 1)
+	sel := s.GetSelection()
+	require.True(t, sel.IsTab)
+	assert.Equal(t, 1, sel.TabIndex)
+	assert.Equal(t, 1, s.proj.ActiveTab())
+
+	// Arrow on the selected instance: collapse, then expand again.
+	s.ToggleInstanceTree("t-00")
+	assert.Equal(t, 0, tabRowCount(s), "arrow click on the expanded selection collapses it")
+	sel = s.GetSelection()
+	assert.False(t, sel.IsTab, "the fold lands the cursor on the instance row")
+	s.ToggleInstanceTree("t-00")
+	assert.Equal(t, 2, tabRowCount(s), "second arrow click re-expands")
+
+	// Arrow on a non-selected instance selects it (which auto-expands).
+	s.ToggleInstanceTree("t-01")
+	require.NotNil(t, s.GetSelectedInstance())
+	assert.Equal(t, "t-01", s.GetSelectedInstance().Title)
+	assert.Equal(t, 2, tabRowCount(s), "selecting via the arrow auto-expands the new selection")
+
+	// Header click folds the whole section; a second click reopens it.
+	s.ClickHeader()
+	assert.Equal(t, 0, tabRowCount(s))
+	assert.True(t, s.GetSelection().IsHeader)
+	s.ClickHeader()
+	assert.False(t, s.visibleItems[len(s.visibleItems)-1].IsHeader,
+		"reopened section shows instance rows again")
+}

--- a/ui/statusbar.go
+++ b/ui/statusbar.go
@@ -37,6 +37,9 @@ func (s *StatusBar) SetRect(r layout.Rect) {
 		menuRows = 0
 	}
 	s.menu.SetSize(r.W, menuRows)
+	// The menu registers per-hint click zones during render (#1024 R4); it
+	// sits at the top of the status-bar rect, so that is its zone origin.
+	s.menu.SetOrigin(layout.Point{X: r.X, Y: r.Y})
 	s.errBox.SetSize(r.W, 1)
 }
 

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
 	"github.com/sachiniyer/agent-factory/ui/tree"
 
@@ -82,6 +83,14 @@ type TabbedWindow struct {
 	interactive bool
 
 	tab *TabPane
+
+	// region is the pane's layout/focus-ring region id
+	// (layout.PaneRegion(paneID)), doubling as the pane component of its
+	// mouse zone ids; zones is the shared hit-test registry (#1024 R4).
+	// String() registers the body/header (and, while the live view renders,
+	// the terminal grid) every frame. Either unset skips registration.
+	region string
+	zones  *zones.Registry
 
 	// live is the pane's embedded-terminal render source (#1089 PR 1), set
 	// by the root model while a termpane attachment is bound to this pane's
@@ -271,8 +280,49 @@ func (w *TabbedWindow) Interactive() bool { return w.interactive }
 // consumes nothing; interactive-mode key forwarding is #1089.
 func (w *TabbedWindow) HandleKey(tea.KeyMsg) (tea.Cmd, bool) { return nil, false }
 
-// HandleMouse implements layout.Pane. Mouse support is #1024 PR 6.
+// HandleMouse implements layout.Pane. Mouse dispatch is zone-id-based at the
+// root (#1024 R4): the body/header/term zones registered by String() resolve
+// to focus/interact/scroll/forward actions there, so the pane-local fallback
+// consumes nothing.
 func (w *TabbedWindow) HandleMouse(tea.MouseMsg, layout.Point) tea.Cmd { return nil }
+
+// SetZoneRegistry wires the shared mouse hit-test registry (#1024 R4).
+func (w *TabbedWindow) SetZoneRegistry(reg *zones.Registry) {
+	w.zones = reg
+}
+
+// SetRegion records the pane's layout region id (layout.PaneRegion(paneID))
+// for zone registration. The root model sets it when the pane window is
+// created; the pane id — and therefore the region — is stable for the
+// window's whole life.
+func (w *TabbedWindow) SetRegion(region string) {
+	w.region = region
+}
+
+// registerZones records this frame's hit-test rects: the whole pane as the
+// body (click focuses; click focused interacts; wheel scrolls), the one-line
+// `title · tab` header inside the frame on top of it, and — exactly while the
+// live embedded terminal is what renders — the terminal content grid, whose
+// zone-local coordinates ARE emulator grid cells (the interactive-mode
+// forwarding target, RFC §2.5). liveShowing must equal the render branch
+// String() takes so a scroll-mode pane never advertises a term zone.
+func (w *TabbedWindow) registerZones(liveShowing bool) {
+	if w.zones == nil || w.region == "" || w.rect.Empty() {
+		return
+	}
+	w.zones.Register(zones.PaneBody(w.region), w.rect)
+	if w.rect.W > 2 && w.rect.H > 2 {
+		w.zones.Register(zones.PaneHeader(w.region), layout.Rect{
+			X: w.rect.X + 1, Y: w.rect.Y + 1, W: w.rect.W - 2, H: paneHeaderRows,
+		})
+		if liveShowing {
+			iw, ih := w.innerSize()
+			w.zones.Register(zones.PaneTerm(w.region), layout.Rect{
+				X: w.rect.X + 1, Y: w.rect.Y + 1 + paneHeaderRows, W: iw, H: ih,
+			})
+		}
+	}
+}
 
 // UpdateContent updates the content of the pane's tab view. instance may be
 // nil. It is called from the refreshPanesCmd goroutine with the instance
@@ -381,12 +431,14 @@ func (w *TabbedWindow) String() string {
 		return ""
 	}
 	iw, ih := w.innerSize()
+	liveShowing := w.live != nil && !w.tab.IsScrolling()
+	w.registerZones(liveShowing)
 	// The live embedded terminal renders instead of the capture when bound
 	// (#1089 PR 1). Scroll mode still renders the TabPane's viewport: the
 	// host-side scrollback UX stays capture-based until the interactive-mode
 	// PR decides who owns scrolling (RFC §2.4).
 	content := ""
-	if w.live != nil && !w.tab.IsScrolling() {
+	if liveShowing {
 		// The cursor overlays only while this pane's terminal owns the
 		// keyboard — the interactive typing cue (#1089 PR 2).
 		content = w.live.Render(iw, ih, w.interactive)

--- a/ui/tabbed_window_zones_test.go
+++ b/ui/tabbed_window_zones_test.go
@@ -1,0 +1,113 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+)
+
+// TestTabbedWindowRegistersBodyAndHeaderZones (#1024 R4): the pane registers
+// its whole rect as the body and the one-line header on top of it, with the
+// header zone sitting on the row that actually renders the header text.
+func TestTabbedWindowRegistersBodyAndHeaderZones(t *testing.T) {
+	w := NewTabbedWindow(NewTabPane(), nil)
+	region := layout.PaneRegion(3)
+	w.SetRegion(region)
+	reg := zones.NewRegistry()
+	w.SetZoneRegistry(reg)
+	rect := layout.Rect{X: 30, Y: 2, W: 60, H: 20}
+	w.SetRect(rect)
+
+	reg.Reset()
+	lines := plainLines(w.String())
+
+	body, ok := reg.Find(zones.PaneBody(region))
+	require.True(t, ok, "body zone; got %v", reg.IDs())
+	assert.Equal(t, rect, body, "the body zone is the whole pane rect")
+
+	header, ok := reg.Find(zones.PaneHeader(region))
+	require.True(t, ok, "header zone")
+	assert.Equal(t, layout.Rect{X: rect.X + 1, Y: rect.Y + 1, W: rect.W - 2, H: 1}, header,
+		"the header sits inside the frame border")
+	// The header zone's row renders the header text (nil binding here, so
+	// the placeholder header).
+	assert.Contains(t, lines[header.Y-rect.Y], "no session selected",
+		"the header zone must sit on the rendered header line")
+
+	// No live view bound: there must be no term zone to forward into.
+	_, hasTerm := reg.Find(zones.PaneTerm(region))
+	assert.False(t, hasTerm, "capture panes must not advertise a terminal grid")
+
+	// Precedence: a point on the header row resolves to the header, a point
+	// below it to the body.
+	id, _, ok := reg.Resolve(header.X+2, header.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.PaneHeader(region), id)
+	id, _, ok = reg.Resolve(header.X+2, header.Y+3)
+	require.True(t, ok)
+	assert.Equal(t, zones.PaneBody(region), id)
+}
+
+// TestTabbedWindowRegistersTermZoneWhileLive: exactly while the live embedded
+// terminal is what renders, the content grid registers as the term zone —
+// whose zone-local coordinates are emulator grid cells (the interactive
+// forwarding target). Scroll mode swaps back to the capture viewport and the
+// term zone must vanish with it.
+func TestTabbedWindowRegistersTermZoneWhileLive(t *testing.T) {
+	w := NewTabbedWindow(NewTabPane(), nil)
+	region := layout.PaneRegion(0)
+	w.SetRegion(region)
+	reg := zones.NewRegistry()
+	w.SetZoneRegistry(reg)
+	rect := layout.Rect{X: 25, Y: 0, W: 50, H: 16}
+	w.SetRect(rect)
+	w.SetLive(&fakeLiveView{content: "LIVE"})
+
+	reg.Reset()
+	_ = w.String()
+
+	term, ok := reg.Find(zones.PaneTerm(region))
+	require.True(t, ok, "live pane must register its terminal grid; got %v", reg.IDs())
+	iw, ih := w.innerSize()
+	assert.Equal(t, layout.Rect{X: rect.X + 1, Y: rect.Y + 2, W: iw, H: ih}, term,
+		"the term zone is the content area inside frame + header")
+
+	// The grid's local coordinates are emulator cells: its top-left resolves
+	// to (0, 0).
+	id, local, ok := reg.Resolve(term.X, term.Y)
+	require.True(t, ok)
+	assert.Equal(t, zones.PaneTerm(region), id)
+	assert.Equal(t, layout.Point{X: 0, Y: 0}, local)
+
+	// Unbind: the term zone must not survive the live view.
+	w.SetLive(nil)
+	reg.Reset()
+	_ = w.String()
+	_, hasTerm := reg.Find(zones.PaneTerm(region))
+	assert.False(t, hasTerm, "no term zone once the live view is unbound")
+}
+
+// TestTabbedWindowNoZonesWhenHiddenOrUnwired: a zero rect (auto-hidden pane)
+// registers nothing, and a window never given a region (defensive) skips
+// registration rather than emitting unparseable ids.
+func TestTabbedWindowNoZonesWhenHiddenOrUnwired(t *testing.T) {
+	w := NewTabbedWindow(NewTabPane(), nil)
+	w.SetRegion(layout.PaneRegion(1))
+	reg := zones.NewRegistry()
+	w.SetZoneRegistry(reg)
+	w.SetRect(layout.Rect{})
+	reg.Reset()
+	_ = w.String()
+	assert.Empty(t, reg.IDs(), "a hidden pane must not register hit zones")
+
+	w2 := NewTabbedWindow(NewTabPane(), nil)
+	w2.SetZoneRegistry(reg)
+	w2.SetRect(layout.Rect{W: 40, H: 12})
+	reg.Reset()
+	_ = w2.String()
+	assert.Empty(t, reg.IDs(), "a window with no region must not register zones")
+}

--- a/ui/termpane/mouse.go
+++ b/ui/termpane/mouse.go
@@ -1,0 +1,108 @@
+package termpane
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/vt"
+)
+
+// Mouse forwarding into the embedded terminal (#1024 R4, RFC §2.5): while
+// interactive, mouse events over the pane's terminal grid forward through the
+// emulator's SendMouse — which is MODE-AWARE: it encodes and writes to the
+// PTY only when the inner application enabled a mouse tracking mode (tmux
+// mirrors the inner app's request onto its client), and no-ops otherwise. So
+// forwarding degrades to suppression exactly when the inner app doesn't want
+// the mouse, and the host never has to guess who owns the wheel.
+
+// SendMouse forwards one mouse event to the embedded terminal at grid cell
+// (x, y) — pane-content-local coordinates, which the zone registry's local
+// point already is. It reports whether the event had a translation; false
+// means the event type has no encoding and was ignored (never a guessed
+// sequence), mirroring SendKey's contract. Whether a translated event
+// actually reaches the inner app is the emulator's mode-aware call. The lock
+// is required even though this only writes input: the encoder reads terminal
+// modes (mouse tracking, SGR encoding) that the PTY reader pump mutates
+// through emu.Write.
+func (t *TermPane) SendMouse(msg tea.MouseMsg, x, y int) bool {
+	ev, ok := translateMouse(msg, x, y)
+	if !ok {
+		return false
+	}
+	t.gridMu.RLock()
+	defer t.gridMu.RUnlock()
+	t.emu.SendMouse(ev)
+	return true
+}
+
+// translateMouse maps a bubbletea v1 mouse message to the emulator's event
+// model at grid cell (x, y). Wheel presses become wheel events; other presses
+// clicks; releases and (drag) motions their own kinds — the same taxonomy
+// the SGR protocol distinguishes.
+func translateMouse(msg tea.MouseMsg, x, y int) (vt.Mouse, bool) {
+	btn, ok := translateMouseButton(msg.Button)
+	if !ok {
+		return nil, false
+	}
+	m := vt.MouseClick{X: x, Y: y, Button: btn, Mod: translateMouseMod(msg)}
+	switch msg.Action {
+	case tea.MouseActionPress:
+		if isWheelButton(btn) {
+			return vt.MouseWheel(m), true
+		}
+		return m, true
+	case tea.MouseActionRelease:
+		return vt.MouseRelease(m), true
+	case tea.MouseActionMotion:
+		return vt.MouseMotion(m), true
+	}
+	return nil, false
+}
+
+// translateMouseButton maps the bubbletea button to the emulator's X11-based
+// codes. ok is false for buttons the encoder doesn't support.
+func translateMouseButton(b tea.MouseButton) (vt.MouseButton, bool) {
+	switch b {
+	case tea.MouseButtonNone:
+		return vt.MouseNone, true
+	case tea.MouseButtonLeft:
+		return vt.MouseLeft, true
+	case tea.MouseButtonMiddle:
+		return vt.MouseMiddle, true
+	case tea.MouseButtonRight:
+		return vt.MouseRight, true
+	case tea.MouseButtonWheelUp:
+		return vt.MouseWheelUp, true
+	case tea.MouseButtonWheelDown:
+		return vt.MouseWheelDown, true
+	case tea.MouseButtonWheelLeft:
+		return vt.MouseWheelLeft, true
+	case tea.MouseButtonWheelRight:
+		return vt.MouseWheelRight, true
+	case tea.MouseButtonBackward:
+		return vt.MouseBackward, true
+	case tea.MouseButtonForward:
+		return vt.MouseForward, true
+	}
+	return vt.MouseNone, false
+}
+
+func isWheelButton(b vt.MouseButton) bool {
+	switch b {
+	case vt.MouseWheelUp, vt.MouseWheelDown, vt.MouseWheelLeft, vt.MouseWheelRight:
+		return true
+	}
+	return false
+}
+
+func translateMouseMod(msg tea.MouseMsg) vt.KeyMod {
+	var mod vt.KeyMod
+	if msg.Shift {
+		mod |= vt.ModShift
+	}
+	if msg.Alt {
+		mod |= vt.ModAlt
+	}
+	if msg.Ctrl {
+		mod |= vt.ModCtrl
+	}
+	return mod
+}

--- a/ui/termpane/mouse_test.go
+++ b/ui/termpane/mouse_test.go
@@ -1,0 +1,83 @@
+package termpane
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/vt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sgrMouseModes is what an inner application that wants the mouse emits:
+// button-event tracking + SGR extended encoding — the modes tmux mirrors to
+// its client when the app inside it (vim, an agent CLI) requests them.
+const sgrMouseModes = "\x1b[?1002h\x1b[?1006h"
+
+func mouseMsg(action tea.MouseAction, button tea.MouseButton, x, y int) tea.MouseMsg {
+	return tea.MouseMsg{X: x, Y: y, Action: action, Button: button}
+}
+
+func sendMouse(emu *vt.Emulator, msg tea.MouseMsg, x, y int) bool {
+	ev, ok := translateMouse(msg, x, y)
+	if !ok {
+		return false
+	}
+	emu.SendMouse(ev)
+	return true
+}
+
+// TestMouseForwardingEncodesSGR pins the tea.MouseMsg → PTY-bytes mapping
+// (#1024 R4): with the inner app requesting SGR button-event tracking, the
+// forwarded press/release/wheel/drag arrive as the exact sequences vim/tmux
+// expect, with 1-based coordinates.
+func TestMouseForwardingEncodesSGR(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  tea.MouseMsg
+		x, y int
+		want string
+	}{
+		{"left press", mouseMsg(tea.MouseActionPress, tea.MouseButtonLeft, 99, 99), 4, 2, "\x1b[<0;5;3M"},
+		{"left release", mouseMsg(tea.MouseActionRelease, tea.MouseButtonLeft, 0, 0), 4, 2, "\x1b[<0;5;3m"},
+		{"right press", mouseMsg(tea.MouseActionPress, tea.MouseButtonRight, 0, 0), 0, 0, "\x1b[<2;1;1M"},
+		{"wheel up", mouseMsg(tea.MouseActionPress, tea.MouseButtonWheelUp, 0, 0), 10, 5, "\x1b[<64;11;6M"},
+		{"wheel down", mouseMsg(tea.MouseActionPress, tea.MouseButtonWheelDown, 0, 0), 10, 5, "\x1b[<65;11;6M"},
+		{"drag motion", mouseMsg(tea.MouseActionMotion, tea.MouseButtonLeft, 0, 0), 7, 8, "\x1b[<32;8;9M"},
+		{"ctrl+left press", func() tea.MouseMsg {
+			m := mouseMsg(tea.MouseActionPress, tea.MouseButtonLeft, 0, 0)
+			m.Ctrl = true
+			return m
+		}(), 1, 1, "\x1b[<16;2;2M"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := emuBytes(t, sgrMouseModes, func(emu *vt.Emulator) {
+				require.True(t, sendMouse(emu, tc.msg, tc.x, tc.y))
+			})
+			assert.Equal(t, tc.want, got,
+				"forwarded event must arrive as its SGR sequence with 1-based grid coords")
+		})
+	}
+}
+
+// TestMouseForwardingSuppressedWithoutInnerMouseMode is the ownership rule
+// the RFC's in-pane decision rests on (#1024 R4, RFC §2.5): the emulator is
+// mode-aware, so an inner app that never requested the mouse receives
+// NOTHING — forwarding degrades to suppression, and stray clicks can't leak
+// escape sequences into a shell prompt.
+func TestMouseForwardingSuppressedWithoutInnerMouseMode(t *testing.T) {
+	got := emuBytes(t, "", func(emu *vt.Emulator) {
+		require.True(t, sendMouse(emu, mouseMsg(tea.MouseActionPress, tea.MouseButtonLeft, 0, 0), 3, 3),
+			"the event translates; the emulator decides it goes nowhere")
+		require.True(t, sendMouse(emu, mouseMsg(tea.MouseActionPress, tea.MouseButtonWheelDown, 0, 0), 3, 3))
+	})
+	assert.Empty(t, got, "no mouse mode set → no bytes reach the PTY")
+}
+
+// TestTranslateMouseUnknownButton: buttons with no encoding are refused, not
+// guessed — SendKey's ignore contract, extended to the mouse.
+func TestTranslateMouseUnknownButton(t *testing.T) {
+	msg := mouseMsg(tea.MouseActionPress, tea.MouseButton(99), 0, 0)
+	_, ok := translateMouse(msg, 0, 0)
+	assert.False(t, ok)
+}

--- a/ui/tree/arrow_test.go
+++ b/ui/tree/arrow_test.go
@@ -1,0 +1,63 @@
+package tree
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/mattn/go-runewidth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// runeAtCell returns the rune occupying terminal cell col of a plain line.
+func runeAtCell(line string, col int) rune {
+	w := 0
+	for _, r := range line {
+		if w == col {
+			return r
+		}
+		w += runewidth.RuneWidth(r)
+	}
+	return 0
+}
+
+// TestArrowCellMatchesRenderedArrow pins ArrowCell — the sidebar's mouse hit
+// target for the ▸/▾ glyph (#1024 R4) — against Render's actual output, so a
+// prefix layout change moves the hit target with it or fails here.
+func TestArrowCellMatchesRenderedArrow(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: "arrow-pin", Path: t.TempDir(), Program: "test",
+	})
+	require.NoError(t, err)
+
+	r := NewInstanceRenderer(&spin)
+	r.SetWidth(30)
+	r.SetIndexWidth(1)
+
+	x, y, ok := ArrowCell(30)
+	require.True(t, ok)
+
+	for _, tc := range []struct {
+		name     string
+		expanded bool
+		want     rune
+	}{
+		{"expanded", true, '▾'},
+		{"collapsed", false, '▸'},
+	} {
+		out := r.Render(inst, 1, false, false, tc.expanded)
+		lines := strings.Split(ansiEscape.ReplaceAllString(out, ""), "\n")
+		require.Greater(t, len(lines), y)
+		assert.Equal(t, tc.want, runeAtCell(lines[y], x),
+			"%s: ArrowCell must point at the rendered arrow glyph", tc.name)
+	}
+
+	// Ultra-narrow widths drop the arrow from the prefix, and ArrowCell must
+	// report that (the sidebar registers no arrow zone then).
+	_, _, ok = ArrowCell(9)
+	assert.False(t, ok, "no arrow cell at the narrow-width fallback")
+}

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -126,6 +126,22 @@ func (r *InstanceRenderer) SetIndexWidth(digits int) {
 // ɹ and ɻ are other options.
 const branchIcon = "Ꮧ"
 
+// ArrowCell returns the (x, y) cell of the ▾/▸ expand/collapse arrow within
+// an instance row block rendered at content width w, for mouse hit-testing
+// (#1024 R4): block line 0 is the title style's top-padding line, so the
+// arrow sits on line 1, one cell after the row's left padding + the prefix's
+// leading space. ok is false at ultra-narrow widths, where Render drops the
+// arrow from the prefix entirely (the #646 fallback) — the sidebar registers
+// no arrow zone then. Kept next to Render so the prefix layout and the hit
+// target can't drift apart; the render test pins them together against
+// actual output.
+func ArrowCell(w int) (x, y int, ok bool) {
+	if w <= 9 {
+		return 0, 0, false
+	}
+	return 2, 1, true
+}
+
 // Render renders an instance row. expanded selects the ▾/▸ tree arrow; a
 // non-expandable instance (see Expandable) renders a blank arrow cell so its
 // title stays aligned with its siblings.


### PR DESCRIPTION
Epic R4 of the multi-pane TUI rewrite ([#1024](https://github.com/sachiniyer/agent-factory/issues/1024), RFC `docs/design/tui-rewrite.md` §2.5) — first-class mouse support, **reworked for the post-redesign layout** (N-pane workspace #1099, in-rail automations #1096, embedded live panes #1121, interactive mode #1135). Supersedes the held #1086; closes #1025.

## What this does

Everywhere a key works, a click or wheel now works too — and in interactive mode, the mouse forwards into the embedded terminal. Three pieces:

**1. Per-frame zone registration.** `View()` resets the PR-1 `zones.Registry` at the top of every frame and each pane registers its interactive rects while rendering, so the hit-test map always mirrors exactly what's on screen:

- tree: `tree:instance:<title>` (row block), `tree:tab:<title>:<idx>`, `tree:arrow:<title>` (the ▸/▾ cell, on top of the row), `tree:header`, `tree:bg`
- workspace: per open pane, keyed by its stable `layout.PaneRegion(id)` — `pane:<id>:body` (whole rect), `pane:<id>:header`, and `pane:<id>:term` (the live terminal grid, registered **exactly while the live view is what renders**; its zone-local coordinates are emulator grid cells)
- rail automations: `auto:bg` plus `auto:task:<taskID>` per rendered compact row (windowed rows only — scrolled-out tasks register nothing)
- status bar: `status:hint:<key>` per rendered hint on its exact centered cells (dropped hints register nothing; the `1-9` chip is deliberately not clickable; the interactive bar's `ctrl+]` hint is)
- overlays: `overlay:confirm:yes|no`, `overlay:select:<idx>`, `overlay:search:<idx>` — derived by scanning the overlay's own rendered output, so border/wrap changes move the zones instead of stranding them

Zone id constructors + parsers live together in `ui/layout/zones/ids.go` so producers (ui) and the consumer (app router) can't drift.

**2. Root `MouseMsg` router** (`app/handle_mouse.go`), replacing the focus-ring-based wheel handling. The RFC §2.5 gesture table, adapted to the current layout:

| Gesture | Effect |
|---|---|
| Click tree instance/tab row | Select (retargets the workspace binding / active tab) |
| Double-click tree row | Enter interactive mode via the exact `handleEnter` path (opens/focuses the pane first, `s` semantics) |
| Click ▸/▾ arrow | Expand/collapse (selecting a different instance auto-expands; the selected one toggles its explicit collapse) |
| Click pane header (or unfocused pane body) | Focus that pane — picks one of the N panes |
| Click the FOCUSED pane's body (nav mode) | Enter interactive mode, like Enter |
| Click automation row (rail) | Focus the section + select the task; double-click opens the task-manager overlay preselected on it |
| Click status-bar hint | Presses that key through the full `handleKeyPress` path (all state gates + keydown highlight identical to typing it) |
| Wheel | Scrolls the region **under the cursor**: tree cursor movement, per-pane capture scroll, task cursor — previously it scrolled whatever the focus ring pointed at |
| Click overlay buttons | `y`/`n` words on the confirmation; selection/search rows = select + enter |

In modal states only the overlay's own zones react — a stray click can never mutate state behind a modal (naming keeps its submit/change-program hints clickable). Double-click detection is a 400 ms same-zone window behind a swappable clock. Divider columns and misses are inert.

**3. In-pane mouse forwarding (the §2.5 open decision — implemented as full forwarding, not suppression).** The spike flagged mouse forwarding as unimplemented long-tail; it turned out to be short: the pinned `x/vt` emulator's `SendMouse` is **mode-aware** — it encodes SGR and writes to the PTY only when the inner application actually enabled a mouse-tracking mode (tmux mirrors the inner app's request onto its client), and no-ops otherwise. So while interactive:

- events over the live pane's **grid** forward through `termpane.SendMouse` with grid-local coordinates (press/release/wheel/drag, with modifiers). If the inner app never asked for the mouse, the emulator drops them — forwarding degrades to suppression automatically, and stray clicks can't leak escape bytes into a shell prompt;
- events over the live pane's **frame/header** are suppressed — never a host action under the user's typing;
- outside the pane, host gestures apply as usual (RFC §2.5), and any gesture that moves focus off the pane ends interactive mode through the existing `enforceInteractiveInvariant` — the same contract as Ctrl-].

This resolves the RFC's "who owns the wheel" question with no policy of our own: the inner app owns the mouse exactly when it asked for it. Host capture-scroll over a live pane stays a nav-mode gesture.

**Nothing else moves.** Keyboard behavior is byte-for-byte untouched. `session/`, `session/tmux/`, and `daemon/` have **zero diffs**; the #960 snapshot/RPC data flow and the #1135 key-forwarding path are exactly as they were.

## Greptile findings from #1086 folded in

The single P1 (scrolled `SearchOverlay` registering rows against `results[0]` instead of the visible window, leaving a scrolled list unclickable) is fixed structurally: the window math is factored into `SearchOverlay.visibleWindow()`, shared by `Render` and `RegisterZones` so they cannot drift, and pinned by `TestSearchOverlayScrolledWindowRegistersVisibleRows`.

## Deviations from the RFC noted

- **Task-row double-click opens the task-manager overlay** (not an in-rail editor): the #1087 amendment made the in-rail section a compact summary permanently, so the manager overlay is the double-click target.
- **Pane hide glyph**: the current pane header has no hide glyph, so §2.5's "click the header's hide glyph" row has no target; `x` remains the hide verb. Can be added when/if the header grows the glyph.
- **No drag/resize** — not in the RFC's v1 scope.

## Tests (hermetic, race-clean)

- **Zone-vs-render pins**: every zone family is checked against the actual rendered frame — the arrow zone must sit on the rendered ▸/▾ glyph (`tree.ArrowCell` pinned against `Render` output), hint zones must cover exactly their "key desc" cells, task/tree/overlay row zones must sit on the lines rendering their targets, the term zone's local origin must be grid (0,0). Coordinates are derived **from the registry**, never hardcoded.
- **Routing**: 20 model-level tests inject `tea.MouseMsg` at registry-derived coordinates and assert selection/focus/interact/scroll/action per gesture — incl. wheel-by-region, modal click blocking, overlay button = key equivalence, double-click vs slow-click, miss/fallback inertness, and a full-layout zone inventory.
- **Interactive forwarding**: grid events forward with grid-local coords and complete click lifecycles; chrome clicks suppress; outside-pane gestures apply and drop the mode; the `ctrl+]` hint click exits. `termpane` pins the exact SGR bytes per event (`\x1b[<0;5;3M`…) and the **suppressed-without-inner-mouse-mode** contract against a bare emulator.
- Gates: `gofmt -l` clean, `go build ./...`, `golangci-lint run --timeout=3m --fast` clean, `deadcode -test ./...` clean, `make test-container` green (full suite), and `GOFLAGS="-p=1" go test -race -parallel 2` green over the touched packages.

## Play-test (containerized, real SGR bytes injected into the TUI's stdin)

Ran the full flow in `make playtest-container-detached` at 140×40 with two bash instances, driving the TUI with raw SGR mouse sequences:

1. Click tree row → selects + auto-expands; click ▸/▾ → folds/unfolds ✅
2. Click pane header → focus ring + hints follow; click focused pane body → interactive (green double border, `ctrl+] nav mode` bar) ✅
3. **Interactive wheel over the grid → forwarded into the inner session (entered its scrollback view; wheel-down scrolled back out); prompt stayed byte-clean — no escape leakage** ✅
4. Click tree row while interactive → selects, exits interactive ✅; click the `ctrl+]` hint → exits ✅
5. Wheel over tree → cursor walks; click automations section → focuses (hints swap) ✅
6. Kill confirm: background click inert behind the modal; clicking "n or esc to cancel" cancels ✅
7. Keyboard sweep: j/k, Tab ring, D, n naming — unchanged ✅

Closes #1025

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
