### PR TITLE
config: json→toml conversion flag-day — config.toml canonical, config.json.bak (#1030 PR 2)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -510,28 +511,33 @@ func parseCommandProbeOutput(output string) string {
 // LoadConfig reads the user's config file, validates it, and returns the
 // resulting Config.
 //
-// Format resolution (#1030): config.toml, when it exists, is the canonical
-// config and config.json is ignored outright (with a warning naming the
-// ignored file) — the two are never merged, so there is never ambiguity
-// about which file a setting must be edited in. Only when config.toml does
-// not exist does the legacy config.json path below run, unchanged.
+// Format resolution (#1030): config.toml is the canonical global config.
+// When it exists it is authoritative and config.json is ignored (with a
+// warning naming the shadowed file) — the two are never merged. When only a
+// legacy config.json exists it is converted to config.toml once, on this
+// load (convertJSONToTOML); from then on config.toml is the file to edit.
+// First run, with neither file present, materializes config.toml directly.
 //
 // Error handling distinguishes "no config yet" from "config present but
 // unusable" so a user whose settings are being ignored gets told why instead
 // of silently inheriting defaults (#734):
-//   - File does not exist, or exists but is zero-byte → DefaultConfig() is
-//     materialized and saved, with no error. This is the first-run path and
-//     must keep working. An empty file is never a valid config; it is the
-//     fingerprint of a failed/partial first-run write (#864, a regression of
-//     #838), so the stub is removed and defaults regenerated rather than
-//     wedging every future startup.
-//   - File exists but cannot be read (permission denied, disk error), or is
+//   - Neither file exists → DefaultConfig() is materialized as config.toml,
+//     with no error. This is the first-run path and must keep working.
+//   - A contentless config file (zero-byte or, for TOML, whitespace/BOM-only)
+//     with no other config present is the fingerprint of a failed/partial
+//     first-run write (#864, a regression of #838): the stub is removed and
+//     defaults regenerated rather than wedging every future startup. A
+//     contentless config.toml sitting beside a real config.json is instead a
+//     hand-made shadow and stays a loud error, so re-materializing can never
+//     silently discard the config.json's settings.
+//   - A file exists but cannot be read (permission denied, disk error), or is
 //     non-empty yet fails to parse → an error naming the file and the
 //     underlying cause is returned. Defaults are NOT substituted, since doing
-//     so would hide the user's broken config behind a working-looking app.
-//   - File parses but fails enum validation → an actionable migration error is
-//     returned (there is no implicit migration from legacy "path with flags"
-//     values; the user must rewrite their config).
+//     so would hide the user's broken config behind a working-looking app; a
+//     config.json that fails to parse is also NOT converted (nothing is
+//     renamed), so the user can fix it in place.
+//   - A file parses but fails enum validation → an actionable migration error
+//     is returned.
 //
 // This mirrors the error-propagation contract already adopted by
 // LoadRepoConfig, where only os.IsNotExist yields defaults.
@@ -543,12 +549,31 @@ func LoadConfig() (*Config, error) {
 
 	configPath := filepath.Join(configDir, ConfigFileName)
 	prettyConfigPath := prettyHomePath(configPath)
-
 	tomlPath := filepath.Join(configDir, TomlConfigFileName)
 	prettyTomlPath := prettyHomePath(tomlPath)
+
+	// 1. config.toml is canonical whenever it exists.
 	tomlData, tomlErr := os.ReadFile(tomlPath)
 	if tomlErr == nil {
-		if _, statErr := os.Stat(configPath); statErr == nil {
+		jsonExists := fileExists(configPath)
+		if isEffectivelyEmptyToml(tomlData) {
+			// A contentless config.toml is ambiguous now that first run
+			// materializes TOML: it is either a failed first-run write (#864)
+			// or a hand-made stub. Disambiguate by config.json — with a real
+			// config.json beside it, re-materializing would silently discard
+			// those settings, so keep the loud shadow error; with no
+			// config.json it is a failed first-run stub, so drop it and
+			// re-materialize, exactly as the JSON path does for an empty
+			// config.json.
+			if jsonExists {
+				return parseConfigTOML(tomlData, prettyTomlPath)
+			}
+			if rmErr := os.Remove(tomlPath); rmErr != nil && !os.IsNotExist(rmErr) {
+				return nil, fmt.Errorf("failed to remove empty config file %s: %w", prettyTomlPath, rmErr)
+			}
+			return materializeDefaultConfig(configDir, tomlPath, prettyTomlPath)
+		}
+		if jsonExists {
 			log.WarningLog.Printf("both %s and %s exist; %s is canonical and %s is ignored — delete or rename %s to silence this warning",
 				prettyTomlPath, prettyConfigPath, prettyTomlPath, prettyConfigPath, prettyConfigPath)
 		}
@@ -558,64 +583,198 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("failed to read config file %s: %w", prettyTomlPath, tomlErr)
 	}
 
+	// 2. No config.toml. Read the legacy config.json.
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return materializeDefaultConfig(configDir, configPath, prettyConfigPath)
+			// Neither file exists → first run: materialize config.toml.
+			return materializeDefaultConfig(configDir, tomlPath, prettyTomlPath)
 		}
-
 		return nil, fmt.Errorf("failed to read config file %s: %w", prettyConfigPath, err)
 	}
 
-	// A zero-byte config.json is never something a user wrote on purpose: it is
-	// the fingerprint of a config write that created the file (O_EXCL) but died
-	// before its JSON body landed (#864, a regression of #838). Treat it like a
-	// missing file — drop the stub and re-materialize defaults — instead of
-	// wedging every future startup on the #758 "config is empty" hard error.
-	// Non-empty-but-corrupt files still fall through to parseConfig's loud
-	// error, since those may carry a user's salvageable settings (#734/#758).
+	// A zero-byte config.json with no config.toml is a failed first-run write
+	// from a pre-TOML af (#864). Drop the stub and materialize fresh defaults
+	// as config.toml rather than wedging on the #758 "config is empty" error.
 	if len(data) == 0 {
 		if rmErr := os.Remove(configPath); rmErr != nil && !os.IsNotExist(rmErr) {
 			return nil, fmt.Errorf("failed to remove empty config file %s: %w", prettyConfigPath, rmErr)
 		}
-		return materializeDefaultConfig(configDir, configPath, prettyConfigPath)
+		return materializeDefaultConfig(configDir, tomlPath, prettyTomlPath)
 	}
 
-	return parseConfig(data, prettyConfigPath)
+	// 3. A real config.json with no config.toml → one-time conversion.
+	return convertJSONToTOML(configDir, configPath, tomlPath, prettyConfigPath, prettyTomlPath)
+}
+
+// fileExists reports whether path exists (any stat error other than
+// not-exist — e.g. permission denied — counts as "exists" so a shadowed
+// config.json is still flagged rather than silently assumed gone).
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil || !os.IsNotExist(err)
+}
+
+// GlobalConfigPath returns the path of the global config file that LoadConfig
+// reads: config.toml when it exists, otherwise the legacy config.json when
+// that exists, otherwise the config.toml path (the file first run creates).
+// For display in `af debug` and diagnostics, so they name the real file
+// rather than a hardcoded one (#1030).
+func GlobalConfigPath() (string, error) {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	tomlPath := filepath.Join(configDir, TomlConfigFileName)
+	if fileExists(tomlPath) {
+		return tomlPath, nil
+	}
+	jsonPath := filepath.Join(configDir, ConfigFileName)
+	if fileExists(jsonPath) {
+		return jsonPath, nil
+	}
+	return tomlPath, nil
+}
+
+// convertRenameFailForTest, when non-nil, replaces the config.json → .bak
+// rename in convertJSONToTOML with the returned error. Tests use it to
+// simulate a crash after the config.toml write but before the rename, and to
+// assert the next load treats config.toml as canonical (both files present).
+var convertRenameFailForTest func() error
+
+// convertRaceHookForTest, when non-nil, runs at the top of the conversion
+// file-lock body — the point at which a concurrent process that won the lock
+// first would already have written config.toml (and renamed config.json).
+// Tests use it to materialize that winner state and pin the lost-race
+// behavior: this process must adopt the winner's config.toml, not re-convert.
+var convertRaceHookForTest func()
+
+// convertJSONToTOML performs the one-time json→toml migration (#1030): it
+// parses and validates the legacy config.json with the frozen JSON reader,
+// writes an equivalent config.toml atomically, then renames config.json to
+// config.json.bak so config.toml becomes the single canonical file. The whole
+// sequence runs under the config file lock so a CLI and the daemon racing the
+// first post-upgrade load produce exactly one conversion; the lock body
+// re-checks for a config.toml the winner already wrote and simply loads it.
+//
+// A config.json that fails to parse or validate is NOT converted and NOT
+// renamed: the error is returned so the user can fix the file in place.
+//
+// The write-then-rename order makes a crash mid-conversion safe: a crash
+// before the toml write changes nothing (config.json is still canonical next
+// run); a crash after it leaves both files, and LoadConfig's canonical-toml
+// rule resolves that to config.toml with a warning. The rename is therefore
+// best-effort — a failure is logged, not fatal.
+func convertJSONToTOML(configDir, configPath, tomlPath, prettyConfigPath, prettyTomlPath string) (*Config, error) {
+	var result *Config
+	lockErr := WithFileLock(tomlPath, func() error {
+		if convertRaceHookForTest != nil {
+			convertRaceHookForTest()
+		}
+		// The winner of a concurrent conversion already wrote config.toml.
+		// (Our writes are atomic, so a non-empty config.toml here is complete.)
+		if td, err := os.ReadFile(tomlPath); err == nil {
+			if !isEffectivelyEmptyToml(td) {
+				cfg, perr := parseConfigTOML(td, prettyTomlPath)
+				if perr != nil {
+					return perr
+				}
+				result = cfg
+				return nil
+			}
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read config file %s: %w", prettyTomlPath, err)
+		}
+
+		// Re-read config.json under the lock: a racer may have renamed it to
+		// .bak, or it may have changed since our pre-lock read.
+		data, err := os.ReadFile(configPath)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read config file %s: %w", prettyConfigPath, err)
+		}
+		if os.IsNotExist(err) || len(data) == 0 {
+			// The racer renamed config.json to .bak (and its config.toml is
+			// gone/incomplete), or the file is an empty first-run stub — either
+			// way there is nothing to convert, so materialize fresh defaults.
+			cfg, mErr := materializeDefaultConfig(configDir, tomlPath, prettyTomlPath)
+			if mErr != nil {
+				return mErr
+			}
+			result = cfg
+			return nil
+		}
+
+		cfg, err := parseConfig(data, prettyConfigPath)
+		if err != nil {
+			return err // invalid config.json: do not convert or rename it.
+		}
+
+		tomlBytes, err := toml.Marshal(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to marshal config %s as TOML: %w", prettyConfigPath, err)
+		}
+		if err := AtomicWriteFile(tomlPath, tomlBytes, 0644); err != nil {
+			return fmt.Errorf("failed to write %s during conversion: %w", prettyTomlPath, err)
+		}
+
+		bakPath := configPath + ".bak"
+		renameErr := func() error {
+			if convertRenameFailForTest != nil {
+				return convertRenameFailForTest()
+			}
+			return os.Rename(configPath, bakPath)
+		}()
+		if renameErr != nil {
+			// config.toml is already written and will be canonical next load;
+			// leaving config.json in place only costs a "both files" warning.
+			log.WarningLog.Printf("migrated config to %s, but could not move the original aside to %s: %v — %s is now canonical; delete %s yourself to silence the duplicate-config warning",
+				prettyTomlPath, prettyHomePath(bakPath), renameErr, prettyTomlPath, prettyConfigPath)
+		} else {
+			log.InfoLog.Printf("migrated config to TOML: wrote %s and moved the original to %s — edit %s from now on",
+				prettyTomlPath, prettyHomePath(bakPath), prettyTomlPath)
+		}
+		result = cfg
+		return nil
+	})
+	if lockErr != nil {
+		return nil, lockErr
+	}
+	return result, nil
 }
 
 // materializeRaceHookForTest, when non-nil, runs between LoadConfig observing
-// a missing config.json and the exclusive create below. Tests use it to
-// recreate the file in that window and pin the lost-race behavior.
+// no config file and the exclusive create below. Tests use it to recreate the
+// file in that window and pin the lost-race behavior.
 var materializeRaceHookForTest func()
 
-// materializeDefaultConfig handles the missing-config.json branch of
-// LoadConfig. A missing file is only expected on first run; when the config
-// dir visibly already carries state, the user's settings file was deleted out
-// from under us, and regenerating defaults silently would disguise the loss
-// as normal operation (#837) — so that case logs at ERROR level before
-// materializing (the app still needs a config to run). The write itself is
-// create-exclusive: if another process recreates config.json between our read
-// and our create, that file wins and is returned instead of being clobbered.
-func materializeDefaultConfig(configDir, configPath, prettyConfigPath string) (*Config, error) {
+// materializeDefaultConfig handles the no-config-file branch of LoadConfig,
+// writing DefaultConfig() to config.toml (#1030). A missing config is only
+// expected on first run; when the config dir visibly already carries state,
+// the user's settings file was deleted out from under us, and regenerating
+// defaults silently would disguise the loss as normal operation (#837) — so
+// that case logs at ERROR level before materializing (the app still needs a
+// config to run). The write itself is create-exclusive: if another process
+// writes config.toml between our read and our create, that file wins and is
+// returned instead of being clobbered.
+func materializeDefaultConfig(configDir, tomlPath, prettyTomlPath string) (*Config, error) {
 	if configDirInitialized(configDir) {
-		log.ErrorLog.Printf("config.json missing from an initialized config dir (%s) — materializing defaults; previous settings are lost", prettyHomePath(configDir))
+		log.ErrorLog.Printf("no config file (config.toml/config.json) in an initialized config dir (%s) — materializing defaults; previous settings are lost", prettyHomePath(configDir))
 	}
 	if materializeRaceHookForTest != nil {
 		materializeRaceHookForTest()
 	}
 
 	defaultCfg := DefaultConfig()
-	created, saveErr := writeConfigIfMissing(configPath, defaultCfg)
+	created, saveErr := writeConfigIfMissing(tomlPath, defaultCfg)
 	if saveErr != nil {
 		log.WarningLog.Printf("failed to save default config: %v", saveErr)
 		return defaultCfg, nil
 	}
 	if !created {
-		// Lost the create race: a concurrent process wrote config.json after
+		// Lost the create race: a concurrent process wrote config.toml after
 		// our read. Treat its file as authoritative.
-		if data, err := os.ReadFile(configPath); err == nil && len(data) > 0 {
-			return parseConfig(data, prettyConfigPath)
+		if data, err := os.ReadFile(tomlPath); err == nil && !isEffectivelyEmptyToml(data) {
+			return parseConfigTOML(data, prettyTomlPath)
 		}
 		// The concurrent file vanished or is empty; fall back to in-memory
 		// defaults without another write attempt.
@@ -625,7 +784,7 @@ func materializeDefaultConfig(configDir, configPath, prettyConfigPath string) (*
 
 // configDirInitialized reports whether configDir already carries application
 // state — an instances/ or repos/ subdirectory, or a daemon.pid — meaning a
-// missing config.json there is a settings loss, not a first run.
+// missing config file there is a settings loss, not a first run.
 func configDirInitialized(configDir string) bool {
 	for _, marker := range []string{"instances", "repos"} {
 		if fi, err := os.Stat(filepath.Join(configDir, marker)); err == nil && fi.IsDir() {
@@ -643,14 +802,15 @@ func configDirInitialized(configDir string) bool {
 // induced to produce deterministically.
 var writeConfigForceFailForTest func() error
 
-// writeConfigIfMissing persists config to configPath with O_CREATE|O_EXCL
-// semantics. Returns created=false (and no error) when the file already
-// exists, so a concurrently recreated config is never overwritten.
+// writeConfigIfMissing persists config to configPath (a config.toml path,
+// #1030) with O_CREATE|O_EXCL semantics. Returns created=false (and no error)
+// when the file already exists, so a concurrently written config is never
+// overwritten.
 func writeConfigIfMissing(configPath string, config *Config) (bool, error) {
 	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
 		return false, fmt.Errorf("failed to create config directory: %w", err)
 	}
-	data, err := json.MarshalIndent(config, "", "  ")
+	data, err := toml.Marshal(config)
 	if err != nil {
 		return false, fmt.Errorf("failed to marshal config: %w", err)
 	}
@@ -672,7 +832,7 @@ func writeConfigIfMissing(configPath string, config *Config) (bool, error) {
 	if writeErr != nil {
 		_ = f.Close()
 		// Remove the freshly created stub so a failed write never leaves a
-		// zero-byte (or partial) config.json behind to wedge the next startup
+		// zero-byte (or partial) config.toml behind to wedge the next startup
 		// (#864). Only the write path cleans up: a Close error means the bytes
 		// already reached the file, so it may be a complete config worth
 		// keeping rather than discarding.
@@ -686,8 +846,13 @@ func writeConfigIfMissing(configPath string, config *Config) (bool, error) {
 }
 
 // parseConfig validates and unmarshals raw config.json bytes on top of the
-// defaults. Split from LoadConfig so the materialize lost-race path can run
-// the identical validation on a concurrently written file.
+// defaults. This is the FROZEN legacy JSON reader (#1030): it stays at the
+// schema as of the TOML swap so an arbitrarily old install still converts,
+// but every key added after the swap (starting with [keys]) lives only in the
+// TOML decoder. Any key this reader does not recognize is warned about rather
+// than silently dropped, so "I added the new option to my old config.json"
+// fails loud. Reachable only from convertJSONToTOML now that first-run and
+// lost-race materialization write TOML.
 func parseConfig(data []byte, prettyConfigPath string) (*Config, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("config file %s is empty; delete it to regenerate defaults, or add valid JSON", prettyConfigPath)
@@ -698,18 +863,39 @@ func parseConfig(data []byte, prettyConfigPath string) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config file %s: %w", prettyConfigPath, err)
 	}
 
-	// The [keys] keymap is TOML-only (#1026) — the struct field is json:"-",
-	// so a "keys" object in config.json would be silently dead. Silently dead
-	// config is how users lose an afternoon, so name it and point at the
-	// TOML file.
+	// Warn about keys the frozen reader ignores so they are not silently lost
+	// on conversion. The [keys] keymap gets a specific message (it is a real,
+	// TOML-only setting, #1026); anything else is an unknown/newer key.
 	var topLevel map[string]json.RawMessage
 	if err := json.Unmarshal(data, &topLevel); err == nil {
-		if _, hasKeys := topLevel["keys"]; hasKeys {
-			log.WarningLog.Printf("config %s: \"keys\" is ignored in config.json — the keymap is TOML-only; move it to a [keys] table in %s", prettyConfigPath, TomlConfigFileName)
+		known := knownJSONConfigKeys()
+		for key := range topLevel {
+			switch {
+			case key == "keys":
+				log.WarningLog.Printf("config %s: \"keys\" is ignored in config.json — the keymap is TOML-only; move it to a [keys] table in %s", prettyConfigPath, TomlConfigFileName)
+			case !known[key]:
+				log.WarningLog.Printf("config %s: unknown key %q is not recognized by this version of af and will be dropped on conversion to %s", prettyConfigPath, key, TomlConfigFileName)
+			}
 		}
 	}
 
 	return validateConfig(config, prettyConfigPath)
+}
+
+// knownJSONConfigKeys returns the set of top-level JSON keys the frozen
+// Config schema recognizes, derived from the struct's json tags so it cannot
+// drift from the fields. Fields tagged json:"-" (e.g. the TOML-only keymap)
+// are deliberately excluded — they are not valid config.json keys.
+func knownJSONConfigKeys() map[string]bool {
+	out := map[string]bool{}
+	t := reflect.TypeOf(Config{})
+	for i := 0; i < t.NumField(); i++ {
+		name := strings.Split(t.Field(i).Tag.Get("json"), ",")[0]
+		if name != "" && name != "-" {
+			out[name] = true
+		}
+	}
+	return out
 }
 
 // parseConfigTOML validates and unmarshals raw config.toml bytes on top of
@@ -883,7 +1069,10 @@ func normalizeKeyOverrides(raw map[string]any, prettyConfigPath string) (map[str
 	return overrides, nil
 }
 
-// saveConfig saves the configuration to disk
+// saveConfig saves the configuration to disk as config.toml — the canonical
+// global config since #1030. It writes only the TOML file: writing config.json
+// would resurrect the "both files exist" shadow state that conversion exists
+// to retire.
 func saveConfig(config *Config) error {
 	configDir, err := GetConfigDir()
 	if err != nil {
@@ -894,13 +1083,13 @@ func saveConfig(config *Config) error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	configPath := filepath.Join(configDir, ConfigFileName)
-	data, err := json.MarshalIndent(config, "", "  ")
+	tomlPath := filepath.Join(configDir, TomlConfigFileName)
+	data, err := toml.Marshal(config)
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	return AtomicWriteFile(configPath, data, 0644)
+	return AtomicWriteFile(tomlPath, data, 0644)
 }
 
 // SaveConfig exports the saveConfig function for use by other packages

--- a/config/config.go
+++ b/config/config.go
@@ -615,6 +615,25 @@ func fileExists(path string) bool {
 	return err == nil || !os.IsNotExist(err)
 }
 
+// availableBackupPath returns the first backup path that does not yet exist:
+// base, then base.1, base.2, … so an existing backup is never overwritten.
+// The original backup (base) is left untouched, preserving the oldest — and
+// most likely real-settings — copy across repeated conversions. Returns an
+// error only if an absurd number of backups already exist, in which case the
+// caller leaves config.json in place with a warning rather than clobbering.
+func availableBackupPath(base string) (string, error) {
+	if !fileExists(base) {
+		return base, nil
+	}
+	for i := 1; i < 1000; i++ {
+		candidate := fmt.Sprintf("%s.%d", base, i)
+		if !fileExists(candidate) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("%s and %s.1..999 all exist; refusing to overwrite any backup", base, base)
+}
+
 // GlobalConfigPath returns the path of the global config file that LoadConfig
 // reads: config.toml when it exists, otherwise the legacy config.json when
 // that exists, otherwise the config.toml path (the file first run creates).
@@ -651,11 +670,12 @@ var convertRaceHookForTest func()
 
 // convertJSONToTOML performs the one-time json→toml migration (#1030): it
 // parses and validates the legacy config.json with the frozen JSON reader,
-// writes an equivalent config.toml atomically, then renames config.json to
-// config.json.bak so config.toml becomes the single canonical file. The whole
-// sequence runs under the config file lock so a CLI and the daemon racing the
-// first post-upgrade load produce exactly one conversion; the lock body
-// re-checks for a config.toml the winner already wrote and simply loads it.
+// writes an equivalent config.toml atomically, then moves config.json aside to
+// config.json.bak (or the first free config.json.bak.N — an existing backup is
+// never overwritten) so config.toml becomes the single canonical file. The
+// whole sequence runs under the config file lock so a CLI and the daemon
+// racing the first post-upgrade load produce exactly one conversion; the lock
+// body re-checks for a config.toml the winner already wrote and simply loads it.
 //
 // A config.json that fails to parse or validate is NOT converted and NOT
 // renamed: the error is returned so the user can fix the file in place.
@@ -717,18 +737,28 @@ func convertJSONToTOML(configDir, configPath, tomlPath, prettyConfigPath, pretty
 			return fmt.Errorf("failed to write %s during conversion: %w", prettyTomlPath, err)
 		}
 
-		bakPath := configPath + ".bak"
-		renameErr := func() error {
-			if convertRenameFailForTest != nil {
-				return convertRenameFailForTest()
-			}
-			return os.Rename(configPath, bakPath)
-		}()
+		// Never overwrite an existing backup: a downgrade can regenerate a
+		// defaults config.json that a *second* conversion would otherwise
+		// rename onto config.json.bak, clobbering the user's ORIGINAL
+		// real-settings backup from the first conversion (Greptile on #1148).
+		// Pick the first free config.json.bak / .bak.1 / .bak.2 … so the
+		// oldest backup — the one most likely to hold real settings — is
+		// preserved and each later conversion lands beside it.
+		bakPath, bakErr := availableBackupPath(configPath + ".bak")
+		renameErr := bakErr
+		if renameErr == nil {
+			renameErr = func() error {
+				if convertRenameFailForTest != nil {
+					return convertRenameFailForTest()
+				}
+				return os.Rename(configPath, bakPath)
+			}()
+		}
 		if renameErr != nil {
 			// config.toml is already written and will be canonical next load;
 			// leaving config.json in place only costs a "both files" warning.
-			log.WarningLog.Printf("migrated config to %s, but could not move the original aside to %s: %v — %s is now canonical; delete %s yourself to silence the duplicate-config warning",
-				prettyTomlPath, prettyHomePath(bakPath), renameErr, prettyTomlPath, prettyConfigPath)
+			log.WarningLog.Printf("migrated config to %s, but could not move the original %s aside: %v — %s is now canonical; delete %s yourself to silence the duplicate-config warning",
+				prettyTomlPath, prettyConfigPath, renameErr, prettyTomlPath, prettyConfigPath)
 		} else {
 			log.InfoLog.Printf("migrated config to TOML: wrote %s and moved the original to %s — edit %s from now on",
 				prettyTomlPath, prettyHomePath(bakPath), prettyTomlPath)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -876,19 +876,27 @@ func TestLoadConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("materializes update_channel into a first-run config.json", func(t *testing.T) {
-		// The key must be visible in the generated file so users discover it
-		// without reading docs, like the other global keys.
+	t.Run("first run materializes config.toml with update_channel visible", func(t *testing.T) {
+		// First run writes config.toml (#1030), not config.json, and the key
+		// must be visible in the generated file so users discover it without
+		// reading docs, like the other global keys.
 		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+		fastShell(t)
 		configDir, err := GetConfigDir()
 		require.NoError(t, err)
 
 		_, err = LoadConfig()
 		require.NoError(t, err)
 
-		data, err := os.ReadFile(filepath.Join(configDir, ConfigFileName))
+		assert.NoFileExists(t, filepath.Join(configDir, ConfigFileName), "first run must not write config.json anymore")
+		data, err := os.ReadFile(filepath.Join(configDir, TomlConfigFileName))
 		require.NoError(t, err)
-		assert.Contains(t, string(data), `"update_channel": "stable"`)
+		assert.Contains(t, string(data), `update_channel = 'stable'`)
+
+		// The materialized file must reload cleanly through the TOML path.
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		assert.Equal(t, UpdateChannelStable, cfg.UpdateChannel)
 	})
 
 	t.Run("surfaces parse error on invalid JSON instead of using defaults", func(t *testing.T) {
@@ -909,11 +917,12 @@ func TestLoadConfig(t *testing.T) {
 		assert.Contains(t, err.Error(), ConfigFileName)
 	})
 
-	t.Run("re-materializes defaults from an empty config file (#864)", func(t *testing.T) {
-		// An empty config.json is the fingerprint of a failed first-run write,
-		// not a user's settings. It must NOT wedge startup with the #758
-		// "config is empty" hard error; instead the stub is dropped and
-		// defaults regenerated so the next run parses cleanly.
+	t.Run("re-materializes defaults from an empty config.json stub (#864)", func(t *testing.T) {
+		// An empty config.json is the fingerprint of a failed first-run write
+		// from a pre-TOML af, not a user's settings. It must NOT wedge startup
+		// with the #758 "config is empty" hard error; instead the stub is
+		// dropped and defaults regenerated as config.toml so the next run
+		// parses cleanly.
 		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 		fastShell(t)
 		configDir, err := GetConfigDir()
@@ -928,11 +937,29 @@ func TestLoadConfig(t *testing.T) {
 		require.NotNil(t, cfg)
 		assert.Equal(t, defaultProgram, cfg.DefaultProgram)
 
-		// The empty stub must be replaced by a real, non-empty config so a
-		// subsequent startup does not hit the empty-file path again.
-		data, err := os.ReadFile(configPath)
+		// The empty stub is dropped and defaults land in config.toml; the
+		// stale config.json must not linger to trip the duplicate-config path.
+		assert.NoFileExists(t, configPath, "the empty config.json stub must be removed")
+		data, err := os.ReadFile(filepath.Join(configDir, TomlConfigFileName))
 		require.NoError(t, err)
-		assert.NotEmpty(t, data, "the empty stub must be regenerated, not left in place")
+		assert.NotEmpty(t, data, "defaults must be regenerated as a non-empty config.toml")
+	})
+
+	t.Run("empty config.json is NOT dropped when config.toml already exists", func(t *testing.T) {
+		// With config.toml canonical, an empty config.json beside it is just
+		// noise (rule 1 warns and ignores it); it must not be treated as a
+		// first-run stub, and config.toml must win.
+		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+		configDir, err := GetConfigDir()
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(configDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, TomlConfigFileName), []byte(`default_program = "codex"`+"\n"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, ConfigFileName), []byte(``), 0644))
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "codex", cfg.DefaultProgram)
 	})
 
 	t.Run("surfaces error when config file is unreadable", func(t *testing.T) {
@@ -1227,8 +1254,9 @@ func TestSaveConfig(t *testing.T) {
 
 		configDir, err := GetConfigDir()
 		require.NoError(t, err)
-		configPath := filepath.Join(configDir, ConfigFileName)
-		assert.FileExists(t, configPath)
+		// SaveConfig writes the canonical config.toml (#1030), never config.json.
+		assert.FileExists(t, filepath.Join(configDir, TomlConfigFileName))
+		assert.NoFileExists(t, filepath.Join(configDir, ConfigFileName))
 
 		loadedConfig, err := LoadConfig()
 		require.NoError(t, err)

--- a/config/conversion_test.go
+++ b/config/conversion_test.go
@@ -67,6 +67,36 @@ func TestConversion_MigratesLegacyJSON(t *testing.T) {
 	assert.NotContains(t, warnBuf.String(), "both", "a clean conversion leaves no duplicate-config warning")
 }
 
+func TestConversion_PreservesExistingBackup(t *testing.T) {
+	// Greptile on #1148: a second conversion must never clobber the backup
+	// from the first. Scenario — the user converted once (real settings →
+	// config.json.bak), later a downgrade regenerated a defaults config.json,
+	// and now a new af converts again. The ORIGINAL backup must survive; the
+	// new (defaults) backup lands beside it under a non-colliding name.
+	configDir := seedJSONHome(t, `{"default_program": "codex"}`)
+	original := []byte(`{"default_program": "aider", "auto_yes": true}`)
+	bakPath := filepath.Join(configDir, ConfigFileName+".bak")
+	require.NoError(t, os.WriteFile(bakPath, original, 0644))
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "codex", cfg.DefaultProgram)
+
+	// The original .bak is byte-for-byte intact.
+	got, err := os.ReadFile(bakPath)
+	require.NoError(t, err)
+	assert.Equal(t, original, got, "the original backup must never be overwritten")
+
+	// The just-converted config.json landed beside it as config.json.bak.1.
+	bak1, err := os.ReadFile(bakPath + ".1")
+	require.NoError(t, err)
+	assert.Contains(t, string(bak1), `"default_program": "codex"`)
+
+	// config.toml is canonical; the live config.json is gone.
+	assert.FileExists(t, filepath.Join(configDir, TomlConfigFileName))
+	assert.NoFileExists(t, filepath.Join(configDir, ConfigFileName))
+}
+
 func TestConversion_InvalidJSONIsNotConvertedOrRenamed(t *testing.T) {
 	// A config.json that fails to parse must NOT be converted and NOT renamed:
 	// the user needs to fix it in place, and clobbering it would lose data.
@@ -126,7 +156,7 @@ func TestConversion_CrashAfterWriteBeforeRenameLeavesTOMLCanonical(t *testing.T)
 	// config.toml written; config.json still present (rename "failed").
 	assert.FileExists(t, filepath.Join(configDir, TomlConfigFileName))
 	assert.FileExists(t, filepath.Join(configDir, ConfigFileName))
-	assert.Contains(t, warnBuf.String(), "could not move the original aside")
+	assert.Contains(t, warnBuf.String(), "could not move the original")
 
 	// Next load: config.toml wins, config.json flagged as ignored.
 	warn2 := captureLog(t, &aflog.WarningLog)

--- a/config/conversion_test.go
+++ b/config/conversion_test.go
@@ -1,0 +1,182 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	aflog "github.com/sachiniyer/agent-factory/log"
+)
+
+// Regression + behavior tests for the one-time json→toml conversion (#1030
+// PR 2). Sachin's decision: on conversion, config.toml becomes canonical and
+// the original config.json is renamed to config.json.bak.
+
+// seedJSONHome points a fresh AGENT_FACTORY_HOME at a temp dir holding only a
+// config.json with the given content, and returns the config dir.
+func seedJSONHome(t *testing.T, jsonContent string) string {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	fastShell(t)
+	configDir, err := GetConfigDir()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, ConfigFileName), []byte(jsonContent), 0644))
+	return configDir
+}
+
+func TestConversion_MigratesLegacyJSON(t *testing.T) {
+	configDir := seedJSONHome(t, `{
+		"default_program": "codex",
+		"auto_yes": true,
+		"daemon_poll_interval": 2500,
+		"program_overrides": {"claude": "/opt/claude --dsp"}
+	}`)
+	infoBuf := captureLog(t, &aflog.InfoLog)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// Settings are preserved through the conversion.
+	assert.Equal(t, "codex", cfg.DefaultProgram)
+	assert.True(t, cfg.AutoYes)
+	assert.Equal(t, 2500, cfg.DaemonPollInterval)
+	assert.Equal(t, "/opt/claude --dsp", cfg.ProgramOverrides["claude"])
+
+	// config.toml is now canonical; config.json is moved aside to .bak.
+	assert.FileExists(t, filepath.Join(configDir, TomlConfigFileName))
+	assert.NoFileExists(t, filepath.Join(configDir, ConfigFileName))
+	assert.FileExists(t, filepath.Join(configDir, ConfigFileName+".bak"))
+	assert.Contains(t, infoBuf.String(), "migrated config to TOML")
+
+	// The .bak still holds the original bytes, verbatim.
+	bak, err := os.ReadFile(filepath.Join(configDir, ConfigFileName+".bak"))
+	require.NoError(t, err)
+	assert.Contains(t, string(bak), `"default_program": "codex"`)
+
+	// Re-loading now reads config.toml canonically, with no duplicate-config
+	// warning (config.json is gone).
+	warnBuf := captureLog(t, &aflog.WarningLog)
+	cfg2, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "codex", cfg2.DefaultProgram)
+	assert.NotContains(t, warnBuf.String(), "both", "a clean conversion leaves no duplicate-config warning")
+}
+
+func TestConversion_InvalidJSONIsNotConvertedOrRenamed(t *testing.T) {
+	// A config.json that fails to parse must NOT be converted and NOT renamed:
+	// the user needs to fix it in place, and clobbering it would lose data.
+	configDir := seedJSONHome(t, `{"default_program": "codex", oops}`)
+
+	cfg, err := LoadConfig()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "parse config file")
+
+	assert.FileExists(t, filepath.Join(configDir, ConfigFileName), "invalid config.json must stay put")
+	assert.NoFileExists(t, filepath.Join(configDir, TomlConfigFileName), "no config.toml on a failed conversion")
+	assert.NoFileExists(t, filepath.Join(configDir, ConfigFileName+".bak"))
+}
+
+func TestConversion_EnumErrorIsNotConverted(t *testing.T) {
+	// A config.json that parses but fails validation (legacy path-in-program)
+	// is likewise left in place with an actionable error, never converted.
+	configDir := seedJSONHome(t, `{"default_program": "/usr/bin/claude --flag"}`)
+
+	cfg, err := LoadConfig()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "program_overrides")
+
+	assert.FileExists(t, filepath.Join(configDir, ConfigFileName))
+	assert.NoFileExists(t, filepath.Join(configDir, TomlConfigFileName))
+}
+
+func TestConversion_WarnsOnUnknownJSONKeyBeforeDropping(t *testing.T) {
+	// The frozen JSON reader must name a key it does not recognize, so a
+	// setting added to an old config.json is not silently lost on conversion.
+	seedJSONHome(t, `{"default_program": "codex", "some_future_key": "v"}`)
+	warnBuf := captureLog(t, &aflog.WarningLog)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "codex", cfg.DefaultProgram)
+	assert.Contains(t, warnBuf.String(), "some_future_key")
+	assert.Contains(t, warnBuf.String(), "unknown key")
+}
+
+func TestConversion_CrashAfterWriteBeforeRenameLeavesTOMLCanonical(t *testing.T) {
+	// Simulate a crash between the atomic config.toml write and the .bak
+	// rename: both files remain. The current load still returns the converted
+	// config, and the NEXT load treats config.toml as canonical (with the
+	// duplicate-config warning) — no data is lost in either state.
+	configDir := seedJSONHome(t, `{"default_program": "codex"}`)
+
+	convertRenameFailForTest = func() error { return assert.AnError }
+	warnBuf := captureLog(t, &aflog.WarningLog)
+	cfg, err := LoadConfig()
+	convertRenameFailForTest = nil
+	require.NoError(t, err)
+	assert.Equal(t, "codex", cfg.DefaultProgram)
+
+	// config.toml written; config.json still present (rename "failed").
+	assert.FileExists(t, filepath.Join(configDir, TomlConfigFileName))
+	assert.FileExists(t, filepath.Join(configDir, ConfigFileName))
+	assert.Contains(t, warnBuf.String(), "could not move the original aside")
+
+	// Next load: config.toml wins, config.json flagged as ignored.
+	warn2 := captureLog(t, &aflog.WarningLog)
+	cfg2, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "codex", cfg2.DefaultProgram)
+	assert.Contains(t, warn2.String(), "both")
+	assert.Contains(t, warn2.String(), "is canonical")
+}
+
+func TestConversion_DowngradeThenReupgradePreservesTOML(t *testing.T) {
+	// After conversion the user downgrades to a pre-TOML af, which finds no
+	// config.json and materializes a defaults config.json beside the user's
+	// config.toml (the #837 loud-materialize path in the old binary). On the
+	// next new-af run, config.toml must still win — the user's real settings
+	// survive the round trip; only a "both files" warning results.
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	fastShell(t)
+	configDir, err := GetConfigDir()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, TomlConfigFileName), []byte("default_program = 'codex'\n"), 0644))
+	// The stand-in for what an old binary would regenerate: a defaults JSON.
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, ConfigFileName), []byte(`{"default_program": "claude"}`), 0644))
+
+	warnBuf := captureLog(t, &aflog.WarningLog)
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "codex", cfg.DefaultProgram, "the user's config.toml must win over a downgrade-regenerated config.json")
+	assert.Contains(t, warnBuf.String(), "both")
+}
+
+func TestConversion_LostRaceAdoptsWinnersTOML(t *testing.T) {
+	// A concurrent process wins the conversion lock first: by the time this
+	// process enters the lock body, config.toml already exists and config.json
+	// has been renamed. This process must adopt the winner's config.toml and
+	// NOT re-convert or re-rename.
+	configDir := seedJSONHome(t, `{"default_program": "codex"}`)
+
+	convertRaceHookForTest = func() {
+		// The winner's effect: config.toml written, config.json moved to .bak.
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, TomlConfigFileName), []byte("default_program = 'aider'\n"), 0644))
+		require.NoError(t, os.Rename(filepath.Join(configDir, ConfigFileName), filepath.Join(configDir, ConfigFileName+".bak")))
+	}
+	t.Cleanup(func() { convertRaceHookForTest = nil })
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	// The winner wrote aider, not our codex — we adopted its file.
+	assert.Equal(t, "aider", cfg.DefaultProgram)
+	assert.FileExists(t, filepath.Join(configDir, TomlConfigFileName))
+	assert.NoFileExists(t, filepath.Join(configDir, ConfigFileName))
+}

--- a/config/materialize_test.go
+++ b/config/materialize_test.go
@@ -37,9 +37,10 @@ func TestLoadConfig_MaterializeSilentOnFirstRun(t *testing.T) {
 	// Don't assert an empty buffer: DefaultConfig() logs an unrelated ERROR
 	// ("failed to get claude command") on machines without claude on PATH
 	// (e.g. CI). First-run only has to skip the settings-loss warning.
-	assert.NotContains(t, errBuf.String(), "config.json missing from an initialized config dir",
+	assert.NotContains(t, errBuf.String(), "materializing defaults",
 		"first-run materialization must not log the settings-loss error")
-	assert.FileExists(t, filepath.Join(home, ConfigFileName), "first run must persist the defaults")
+	assert.FileExists(t, filepath.Join(home, TomlConfigFileName), "first run must persist the defaults as config.toml")
+	assert.NoFileExists(t, filepath.Join(home, ConfigFileName), "first run must not write config.json")
 }
 
 func TestLoadConfig_MaterializeLogsLoudlyOnInitializedDir(t *testing.T) {
@@ -71,9 +72,9 @@ func TestLoadConfig_MaterializeLogsLoudlyOnInitializedDir(t *testing.T) {
 			require.NotNil(t, cfg, "the app still needs a config — materialization proceeds")
 
 			assert.Contains(t, errBuf.String(), "materializing defaults",
-				"a missing config.json in an initialized dir must be a loud, diagnosable event")
+				"a missing config in an initialized dir must be a loud, diagnosable event")
 			assert.Contains(t, errBuf.String(), "previous settings are lost")
-			assert.FileExists(t, filepath.Join(home, ConfigFileName))
+			assert.FileExists(t, filepath.Join(home, TomlConfigFileName))
 		})
 	}
 }
@@ -83,10 +84,10 @@ func TestLoadConfig_MaterializeLosesRaceToConcurrentWrite(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", home)
 	fastShell(t)
 
-	configPath := filepath.Join(home, ConfigFileName)
-	concurrent := `{"default_program": "codex", "daemon_poll_interval": 2500}`
+	tomlPath := filepath.Join(home, TomlConfigFileName)
+	concurrent := "default_program = 'codex'\ndaemon_poll_interval = 2500\n"
 	materializeRaceHookForTest = func() {
-		if err := os.WriteFile(configPath, []byte(concurrent), 0644); err != nil {
+		if err := os.WriteFile(tomlPath, []byte(concurrent), 0644); err != nil {
 			t.Errorf("concurrent write: %v", err)
 		}
 	}
@@ -99,9 +100,9 @@ func TestLoadConfig_MaterializeLosesRaceToConcurrentWrite(t *testing.T) {
 	assert.Equal(t, "codex", cfg.DefaultProgram, "the concurrently written config must win")
 	assert.Equal(t, 2500, cfg.DaemonPollInterval)
 
-	data, err := os.ReadFile(configPath)
+	data, err := os.ReadFile(tomlPath)
 	require.NoError(t, err)
-	assert.JSONEq(t, concurrent, string(data), "the concurrent file must not be clobbered by defaults")
+	assert.Equal(t, concurrent, string(data), "the concurrent file must not be clobbered by defaults")
 }
 
 func TestWriteConfigIfMissing_RemovesStubOnWriteFailure(t *testing.T) {
@@ -126,17 +127,18 @@ func TestWriteConfigIfMissing_RemovesStubOnWriteFailure(t *testing.T) {
 }
 
 func TestLoadConfig_RecoversAfterFailedFirstRunWrite(t *testing.T) {
-	// End-to-end #864: a failed first-run write leaves an empty config.json;
-	// the NEXT startup must recover (re-materialize defaults), not wedge.
+	// End-to-end #864: a failed first-run write leaves an empty config.toml;
+	// the NEXT startup must recover (re-materialize defaults), not wedge on the
+	// contentless-TOML hard error.
 	home := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", home)
 	fastShell(t)
-	configPath := filepath.Join(home, ConfigFileName)
+	tomlPath := filepath.Join(home, TomlConfigFileName)
 
-	// Reproduce the bug state directly: O_EXCL created the file, then the write
-	// failed before defense-in-depth cleanup existed, leaving a 0-byte stub.
-	require.NoError(t, os.WriteFile(configPath, []byte(``), 0644))
-	info, err := os.Stat(configPath)
+	// Reproduce the bug state directly: O_EXCL created config.toml, then the
+	// process died before its body landed, leaving a 0-byte stub.
+	require.NoError(t, os.WriteFile(tomlPath, []byte(``), 0644))
+	info, err := os.Stat(tomlPath)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), info.Size(), "precondition: empty stub on disk")
 
@@ -145,22 +147,22 @@ func TestLoadConfig_RecoversAfterFailedFirstRunWrite(t *testing.T) {
 	require.NotNil(t, cfg)
 	assert.Equal(t, defaultProgram, cfg.DefaultProgram)
 
-	data, err := os.ReadFile(configPath)
+	data, err := os.ReadFile(tomlPath)
 	require.NoError(t, err)
 	assert.NotEmpty(t, data, "defaults must be re-materialized to a non-empty file")
 }
 
 func TestWriteConfigIfMissing_RefusesExistingFile(t *testing.T) {
 	home := t.TempDir()
-	configPath := filepath.Join(home, ConfigFileName)
-	original := []byte(`{"detach_keys": "ctrl-]"}`)
-	require.NoError(t, os.WriteFile(configPath, original, 0644))
+	tomlPath := filepath.Join(home, TomlConfigFileName)
+	original := []byte("detach_keys = 'ctrl-]'\n")
+	require.NoError(t, os.WriteFile(tomlPath, original, 0644))
 
-	created, err := writeConfigIfMissing(configPath, &Config{DefaultProgram: "claude"})
+	created, err := writeConfigIfMissing(tomlPath, &Config{DefaultProgram: "claude"})
 	require.NoError(t, err)
-	assert.False(t, created, "an existing config.json must never be replaced")
+	assert.False(t, created, "an existing config.toml must never be replaced")
 
-	data, err := os.ReadFile(configPath)
+	data, err := os.ReadFile(tomlPath)
 	require.NoError(t, err)
 	assert.Equal(t, original, data)
 }

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -386,7 +386,7 @@ func recordedTmuxNames(configDir string) map[string]bool {
 // an agent-factory home. Two or more must match before doctor will even
 // report a directory, let alone remove it.
 var afHomeMarkers = []string{
-	config.ConfigFileName, "state.json", "instances", "daemon.sock", "daemon.pid", "agent-factory.log",
+	config.TomlConfigFileName, config.ConfigFileName, "state.json", "instances", "daemon.sock", "daemon.pid", "agent-factory.log",
 }
 
 // checkStaleTempHomes finds abandoned agent-factory homes under the temp

--- a/main.go
+++ b/main.go
@@ -197,13 +197,16 @@ var (
 				return err
 			}
 
-			configDir, err := config.GetConfigDir()
+			// Name the file LoadConfig actually reads (config.toml once
+			// converted, else the legacy config.json), not a hardcoded name
+			// (#1030).
+			configPath, err := config.GlobalConfigPath()
 			if err != nil {
-				return fmt.Errorf("failed to get config directory: %w", err)
+				return fmt.Errorf("failed to resolve config path: %w", err)
 			}
 			configJson, _ := json.MarshalIndent(cfg, "", "  ")
 
-			fmt.Printf("Config: %s\n%s\n", filepath.Join(configDir, config.ConfigFileName), configJson)
+			fmt.Printf("Config: %s\n%s\n", configPath, configJson)
 
 			return nil
 		},


### PR DESCRIPTION
Part of #1030 (design comment: https://github.com/sachiniyer/agent-factory/issues/1030#issuecomment-4880518994) — PR 2 of the approved breakdown, the conversion flag-day. **Unblocked by Sachin's decision**: on auto-conversion, `config.json` → `config.json.bak` and `config.toml` becomes the single canonical global config.

## Behavior

**`LoadConfig` resolution:**
1. **`config.toml` present** → canonical; a `config.json` beside it is ignored with a warning (never merged). A contentless `config.toml` is treated as a failed first-run stub (drop + re-materialize) **only** when no `config.json` sits beside it; with a real `config.json` present it stays the loud shadow error, so re-materializing can never silently discard those settings.
2. **`config.toml` absent, valid `config.json` present** → **one-time conversion under the config file lock**: parse+validate with the frozen JSON reader, write `config.toml` atomically (temp+rename), **then** rename `config.json` → `config.json.bak`. Logs one INFO line.
3. **Neither present** → first run materializes `config.toml` (O_EXCL, all of #838/#864 semantics ported; #837 loud-materialize when the dir is already initialized).

## Failure modes (all tested)

- **Crash mid-conversion.** Write-then-rename order: crash *before* the toml write changes nothing (json still canonical); crash *after* it leaves both files, and rule 1 resolves that to config.toml + a duplicate-config warning. The rename is best-effort — a failure is logged, not fatal. Tested via a rename-fail hook.
- **Invalid / enum-failing `config.json`** is **not** converted and **not** renamed — it stays in place with an actionable error so the user fixes it there.
- **Unknown keys** in the frozen JSON reader are **named in a warning** (key set derived from struct tags), so a setting added to an old config.json isn't silently dropped on conversion.
- **Downgrade then re-upgrade.** An old binary that regenerates a defaults `config.json` beside the user's `config.toml` loses nothing: the next new-af run still picks config.toml (+ warning). Tested.
- **Lost race.** Two processes converting at once are serialized by the file lock; the loser re-reads and adopts the winner's `config.toml` rather than re-converting. Tested via a lock-entry hook.

## Also

- `saveConfig` now writes `config.toml`; `writeConfigIfMissing` marshals TOML (the only writers are first-run + lost-race materialization, both TOML).
- `af debug` names the real file via new `config.GlobalConfigPath`; `doctor` af-home markers learn `config.toml`.

## Not in this PR

Docs/examples sweep is PR 4 (next). The keymap (#1141) is an independent branch.

## Verification

- `go build`, `gofmt -l`, `golangci-lint --fast`, `deadcode -test` clean; `make test-container` full suite green.
- **Install-path e2e with the real binary**: empty home → `af debug` materializes `config.toml` (no config.json); a legacy `config.json` → converts to `config.toml` + `config.json.bak` with `default_program`/`auto_yes`/`program_overrides` intact and the `.bak` holding the original bytes verbatim.

Do not merge — root verifies and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)