### PR TITLE
tui: order instances by creation time, root pinned first (#1144)

### DIFF
--- a/ui/store/order.go
+++ b/ui/store/order.go
@@ -1,0 +1,26 @@
+package store
+
+import "github.com/sachiniyer/agent-factory/session"
+
+// LessInstanceOrder is the sidebar/tree instance ordering (#1144): the reserved
+// root agent (#1106) sorts first by IDENTITY, then non-root instances sort
+// oldest-first by CreatedAt.
+//
+// Root pins by IsReservedTitle, NOT by being oldest, so a root re-ensure with a
+// fresh CreatedAt after a tmux death (#1108 Lost → recreate) still lands on top.
+// A Lost root still pins; a Lost non-root sorts by its CreatedAt like any other
+// instance — Lost is not special to ordering. The Title tiebreak on equal
+// CreatedAt makes the order total and deterministic, so two identical snapshots
+// never jitter and re-sorting an already-sorted slice is a no-op.
+func LessInstanceOrder(a, b *session.Instance) bool {
+	aRoot := session.IsReservedTitle(a.Title)
+	bRoot := session.IsReservedTitle(b.Title)
+	if aRoot != bRoot {
+		// Root before non-root, regardless of either's CreatedAt.
+		return aRoot
+	}
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.Before(b.CreatedAt)
+	}
+	return a.Title < b.Title
+}

--- a/ui/store/order_test.go
+++ b/ui/store/order_test.go
@@ -1,0 +1,165 @@
+package store
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// fixed, deterministic timestamps (no time.Now nondeterminism in assertions).
+var (
+	tOldest = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tMid    = time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	tNewer  = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	tNewest = time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+)
+
+func inst(title string, created time.Time) *session.Instance {
+	return &session.Instance{Title: title, CreatedAt: created}
+}
+
+func titles(instances []*session.Instance) []string {
+	out := make([]string, len(instances))
+	for i, in := range instances {
+		out[i] = in.Title
+	}
+	return out
+}
+
+func sortCopy(instances []*session.Instance) []*session.Instance {
+	out := append([]*session.Instance(nil), instances...)
+	sort.SliceStable(out, func(i, j int) bool { return LessInstanceOrder(out[i], out[j]) })
+	return out
+}
+
+func assertOrder(t *testing.T, got []*session.Instance, want []string) {
+	t.Helper()
+	gotTitles := titles(got)
+	if len(gotTitles) != len(want) {
+		t.Fatalf("order length = %v, want %v", gotTitles, want)
+	}
+	for i := range want {
+		if gotTitles[i] != want[i] {
+			t.Fatalf("order = %v, want %v", gotTitles, want)
+		}
+	}
+}
+
+// Root pins first even when it is the NEWEST instance: the pin is by reserved
+// identity (#1106), not by being oldest.
+func TestLessInstanceOrder_RootPinsDespiteNewestCreatedAt(t *testing.T) {
+	in := []*session.Instance{
+		inst("bravo", tMid),
+		inst("root", tNewest), // newest — but reserved, so it must lead
+		inst("alpha", tOldest),
+	}
+	assertOrder(t, sortCopy(in), []string{"root", "alpha", "bravo"})
+}
+
+// Non-root instances order oldest-first by CreatedAt.
+func TestLessInstanceOrder_NonRootOldestFirst(t *testing.T) {
+	in := []*session.Instance{
+		inst("c", tNewest),
+		inst("a", tOldest),
+		inst("b", tMid),
+	}
+	assertOrder(t, sortCopy(in), []string{"a", "b", "c"})
+}
+
+// Equal CreatedAt breaks by Title, giving a total (and stable) order.
+func TestLessInstanceOrder_TitleTiebreakOnEqualCreatedAt(t *testing.T) {
+	in := []*session.Instance{
+		inst("charlie", tMid),
+		inst("alpha", tMid),
+		inst("bravo", tMid),
+	}
+	assertOrder(t, sortCopy(in), []string{"alpha", "bravo", "charlie"})
+}
+
+// The reserved predicate is case-insensitive (session.IsReservedTitle), so a
+// "Root"/" ROOT " row still pins.
+func TestLessInstanceOrder_RootPinCaseInsensitive(t *testing.T) {
+	in := []*session.Instance{
+		inst("alpha", tOldest),
+		inst(" ROOT ", tNewest),
+	}
+	assertOrder(t, sortCopy(in), []string{" ROOT ", "alpha"})
+}
+
+// Sorting is idempotent: an already-sorted slice does not change, so two
+// identical snapshots produce identical order (no jitter across poll ticks).
+func TestLessInstanceOrder_StableAcrossIdenticalSnapshots(t *testing.T) {
+	build := func() []*session.Instance {
+		// arbitrary input order
+		return []*session.Instance{
+			inst("delta", tNewest),
+			inst("root", tMid),
+			inst("alpha", tOldest),
+			inst("bravo", tNewer),
+		}
+	}
+	first := sortCopy(build())
+	want := []string{"root", "alpha", "bravo", "delta"}
+	assertOrder(t, first, want)
+
+	// A second identical poll sorts to the same order...
+	second := sortCopy(build())
+	assertOrder(t, second, want)
+
+	// ...and re-sorting the already-sorted slice is a no-op.
+	again := sortCopy(first)
+	assertOrder(t, again, want)
+}
+
+// A Lost root still pins top; a Lost non-root sorts by CreatedAt like any other
+// instance (Lost is not special to ordering, #1108).
+func TestLessInstanceOrder_LostStatusDoesNotAffectOrder(t *testing.T) {
+	lostRoot := &session.Instance{Title: "root", CreatedAt: tNewest, Status: session.Lost}
+	lostBravo := &session.Instance{Title: "bravo", CreatedAt: tMid, Status: session.Lost}
+	in := []*session.Instance{
+		lostBravo,
+		inst("charlie", tNewer),
+		lostRoot,
+		inst("alpha", tOldest),
+	}
+	assertOrder(t, sortCopy(in), []string{"root", "alpha", "bravo", "charlie"})
+}
+
+// Projection integration: GetInstances() returns root-first-then-CreatedAt
+// regardless of the order rows were added in.
+func TestProjection_GetInstancesSortedOnAdd(t *testing.T) {
+	p := NewProjection()
+	for _, in := range []*session.Instance{
+		inst("delta", tNewest),
+		inst("root", tMid),
+		inst("alpha", tOldest),
+		inst("bravo", tNewer),
+	} {
+		p.AddInstance(in) // finalizer intentionally not run (no repo/worktree)
+	}
+	assertOrder(t, p.GetInstances(), []string{"root", "alpha", "bravo", "delta"})
+}
+
+// A root re-ensure (#1108 Lost → recreate) rebuilds root with a NEWER CreatedAt.
+// The pin is by identity, so ReplaceInstance keeps root at index 0.
+func TestProjection_RootPinSurvivesReEnsure(t *testing.T) {
+	p := NewProjection()
+	oldRoot := inst("root", tOldest)
+	p.AddInstance(oldRoot)
+	p.AddInstance(inst("alpha", tMid))
+	p.AddInstance(inst("bravo", tNewer))
+	assertOrder(t, p.GetInstances(), []string{"root", "alpha", "bravo"})
+
+	// Recreated root carries a brand-new (newest) CreatedAt.
+	newRoot := inst("root", tNewest)
+	if !p.ReplaceInstance(oldRoot, newRoot) {
+		t.Fatalf("ReplaceInstance did not find the old root")
+	}
+	got := p.GetInstances()
+	assertOrder(t, got, []string{"root", "alpha", "bravo"})
+	if got[0] != newRoot {
+		t.Fatalf("root row = %p, want the rebuilt root %p", got[0], newRoot)
+	}
+}

--- a/ui/store/projection.go
+++ b/ui/store/projection.go
@@ -26,6 +26,7 @@ package store
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"sync/atomic"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -173,8 +174,29 @@ func (p *Projection) ContainsInstance(target *session.Instance) bool {
 // AddInstance adds a new instance. Returns a finalizer to register the repo.
 func (p *Projection) AddInstance(instance *session.Instance) (finalize func()) {
 	p.instances = append(p.instances, instance)
+	p.sortInstances() // keep root-first + CreatedAt order (#1144)
 	p.bump()
 	return func() { p.RegisterRepoForInstance(instance) }
+}
+
+// sortInstances re-establishes the deterministic sidebar/tree order on the
+// instance list: root-first by reserved identity, then oldest-first by
+// CreatedAt (see LessInstanceOrder, #1144). Keeping GetInstances() sorted at
+// the projection — the single slice every view indexes into — makes the
+// display order stable across daemon poll ticks, independent of the daemon
+// Snapshot's alphabetical-by-key order and of the reconcile's mutation history
+// (existing rows keep their pointer, new rows append). Removal preserves
+// relative order, so only additions (AddInstance) and #765 same-title swaps
+// (ReplaceInstance, which can carry a new CreatedAt) need to re-sort.
+//
+// sort.SliceStable keeps equal-key rows in their prior relative order so
+// nothing jitters when timestamps collide. Runs on the bubbletea event loop
+// like every other projection mutation, so sorting the shared backing array in
+// place is safe — background readers use GetInstancesSnapshot, which copies.
+func (p *Projection) sortInstances() {
+	sort.SliceStable(p.instances, func(i, j int) bool {
+		return LessInstanceOrder(p.instances[i], p.instances[j])
+	})
 }
 
 // RegisterRepoForInstance records the instance's repo after the instance has
@@ -291,6 +313,11 @@ func (p *Projection) ReplaceInstance(target, replacement *session.Instance) bool
 				pane.instance = replacement
 			}
 		}
+		// A #765 same-title swap can carry a new CreatedAt (and, on a root
+		// re-ensure, keep the root pin) — re-sort so the order invariant holds
+		// (#1144). The swap happens in place, so this only moves the row when the
+		// identity's key actually changed.
+		p.sortInstances()
 		p.bump()
 		return true
 	}


### PR DESCRIPTION
Closes #1144.

## What

Order the sidebar/tree instance list deterministically:

1. The reserved **`root`** agent (#1106) pins **first, always** — by reserved identity, not by being oldest.
2. All other instances sort **oldest-first by `CreatedAt`**.

## Order-direction choice

Non-root instances sort **oldest-first (ascending `CreatedAt`)**. The sidebar numbers instance rows `1..N` by position; oldest-first keeps number 1 = your first session and appends each new session at the bottom with the next number, so existing rows never reshuffle when you create or kill a session — the natural, stable convention for a numbered session list. (Today's order is alphabetical-by-daemon-key, i.e. effectively arbitrary and unrelated to creation time.)

## Where the sort lives — and why it's stable

At the **TUI's single Snapshot projection** (`ui/store/projection.go`), not in the daemon and not scattered across the views.

Every view — sidebar rows, `tree.Flatten`, the `idx+1` numbering, mouse-zone registration, click handlers — indexes into the one `Projection.instances` slice via `GetInstances()`. Sorting that slice once, on mutation, makes the display order stable across daemon poll ticks:

- independent of the daemon Snapshot's alphabetical-by-key order (`daemon/control.go` `sort.Strings(keys)`), and
- independent of the reconcile's mutation history (existing rows keep their pointer, new rows append, removals shift).

Sorting **only** in the daemon would *not* fix the TUI, because `reconcileSnapshot` preserves the projection's own order. So the daemon is deliberately untouched.

`sortInstances()` runs after the two mutations that can break the invariant:
- `AddInstance` (an append can land out of order), and
- `ReplaceInstance` (a #765 same-title swap can carry a new `CreatedAt`, and a root re-ensure must keep the pin).

Removal preserves relative order, so kill/remove paths need no re-sort. `sort.SliceStable` + a `Title` tiebreak on equal `CreatedAt` make the order total, deterministic, and jitter-free.

## Interaction with reserved-root & Lost (#1106 / #1108)

- Root is identified by the canonical `session.IsReservedTitle` predicate (case-insensitive), never an ad-hoc `"root"` string match.
- The pin is **by identity, not by being oldest** — so a root re-ensure (its tmux dies, the daemon recreates it with a **new, newest** `CreatedAt`) still lands root on top. Verified live below.
- A **Lost** root still pins top; a **Lost** non-root sorts by its `CreatedAt` like any other instance (Lost is not special to ordering).

## Sort key persistence

`CreatedAt` is persisted (`session.InstanceData` `json:"created_at"`) and carried onto the rebuilt instance by `FromInstanceData` / `buildInstanceFromSnapshot`, so the order is stable across a TUI/daemon restart. No change needed there — confirmed only.

## Before / after (from the play-test)

Four sessions created in the order `alpha`, `beta`, `gamma` (root ensured by the daemon):

```
Before (alphabetical-by-daemon-key, root not pinned):   After (root-first, then oldest-first CreatedAt):
  1. alpha                                                 1. root
  2. beta                                                  2. alpha
  3. gamma                                                 3. beta
  4. root        <- root wherever its title sorts          4. gamma
```

After a **root re-ensure** (killed root's tmux → daemon recreated it with the *newest* `CreatedAt` of all four), root **still** renders at position 1 — proving the pin is by identity, not by age:

```
  1. root      (created 06:04:59 — newest!)
  2. alpha     (created 06:04:25)
  3. beta      (created 06:04:28)
  4. gamma     (created 06:04:30)
```

## Tests

New `ui/store/order_test.go` on the comparator and the projection integration:
- root pins first even when it has the newest `CreatedAt`;
- non-root ordered oldest-first;
- `Title` tiebreak on equal `CreatedAt` (total order);
- stable/idempotent across two identical snapshots (no jitter);
- reserved-title pin is case-insensitive;
- root pin survives a `ReplaceInstance` re-ensure with a newer `CreatedAt`;
- Lost status doesn't affect ordering;
- `Projection.GetInstances()` is sorted after shuffled `AddInstance`s.

## Gates

- `gofmt -l .` — clean
- `go build ./...` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `make test-container` — full suite green (all packages)
- `make playtest-container` — visible sidebar order verified live (before/after above)

— Captain Claude
