### PR TITLE
fix: proctree ESRCH sentinel (#1151) + in-repo config null crash (#1153)

### DIFF
--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -303,6 +303,14 @@ func LoadInRepoConfig(repoRoot string) (*InRepoConfig, []byte, error) {
 		if err := json.Unmarshal(data, &rawKeys); err != nil {
 			return nil, nil, fmt.Errorf("failed to parse in-repo config %s: %w", prettyPath, err)
 		}
+		// A bare JSON `null` unmarshals into a map as a no-op that leaves it
+		// nil — the one non-object top-level value encoding/json accepts
+		// (strings, numbers, arrays, and booleans already error above). Reject
+		// it explicitly so malformed input fails loudly instead of being
+		// silently treated as an empty config (#1153).
+		if rawKeys == nil {
+			return nil, nil, fmt.Errorf("in-repo config %s must be a JSON object, not null", prettyPath)
+		}
 		for key := range rawKeys {
 			presentKeys[key] = true
 		}
@@ -465,6 +473,12 @@ func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 		if len(data) > 0 {
 			if err := json.Unmarshal(data, &rawKeys); err != nil {
 				return fmt.Errorf("failed to parse in-repo config %s: %w", prettyHomePath(path), err)
+			}
+			// A bare JSON `null` nils out the map above; without this guard the
+			// key assignment below panics on a nil-map write. Reject it with the
+			// same actionable error the read path uses (#1153).
+			if rawKeys == nil {
+				return fmt.Errorf("in-repo config %s must be a JSON object, not null", prettyHomePath(path))
 			}
 		}
 		encoded, err := json.Marshal(commands)

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -143,6 +143,79 @@ func TestLoadInRepoConfigMalformed(t *testing.T) {
 	})
 }
 
+// TestLoadInRepoConfigRejectsNonObject covers #1153: a bare JSON `null`
+// unmarshals into a map as nil without error and was silently accepted as an
+// empty config; other non-object top-level values (string, number, array) were
+// already rejected by the decoder. All must fail loudly with the file named.
+func TestLoadInRepoConfigRejectsNonObject(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("null", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		path := writeInRepoConfig(t, repoRoot, "null")
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a JSON object")
+		assert.Contains(t, err.Error(), prettyHomePath(path))
+	})
+
+	t.Run("bare string", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoConfig(t, repoRoot, `"hello"`)
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse")
+	})
+
+	t.Run("bare number", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoConfig(t, repoRoot, "123")
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse")
+	})
+
+	t.Run("bare array", func(t *testing.T) {
+		repoRoot := t.TempDir()
+		writeInRepoConfig(t, repoRoot, "[]")
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse")
+	})
+}
+
+// TestLoadInRepoConfigEmptyObject confirms `{}` — a structurally valid object
+// with no keys — is accepted (distinct from `null`): a non-nil config with no
+// keys marked set.
+func TestLoadInRepoConfigEmptyObject(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	writeInRepoConfig(t, repoRoot, "{}")
+
+	cfg, raw, err := LoadInRepoConfig(repoRoot)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.NotEmpty(t, raw)
+	for _, key := range inRepoAllowedKeys {
+		assert.False(t, cfg.IsSet(key), "no key should be marked set for {}")
+	}
+}
+
+// TestSaveInRepoPostWorktreeCommandsNull is the regression test for the #1153
+// panic: SaveInRepoPostWorktreeCommands read a `null` config file, unmarshaled
+// it into a nil map, and panicked writing the key. It must now return an
+// actionable error naming the file instead of crashing.
+func TestSaveInRepoPostWorktreeCommandsNull(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	path := writeInRepoConfig(t, repoRoot, "null")
+
+	err := SaveInRepoPostWorktreeCommands(repoRoot, []string{"make setup"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a JSON object")
+	assert.Contains(t, err.Error(), prettyHomePath(path))
+}
+
 // TestIsPathStrictlyInside is the regression test for #852: the previous
 // strings.HasPrefix(path, root+Separator) check built the prefix "//" for a
 // repo rooted at the filesystem root (real in containers with WORKDIR /),

--- a/config/inrepo_toml_test.go
+++ b/config/inrepo_toml_test.go
@@ -173,6 +173,42 @@ func TestLoadInRepoConfigTOMLMalformed(t *testing.T) {
 	})
 }
 
+// TestLoadInRepoConfigTOMLRejectsNonObject is the TOML counterpart to the
+// #1153 JSON null hole. TOML has no `null` literal and a document must be a
+// table (key = value) at the top level, so a bare null / string / number is a
+// syntax error the decoder already rejects — this pins that guarantee so the
+// TOML path can never silently accept a non-object the way JSON did.
+func TestLoadInRepoConfigTOMLRejectsNonObject(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	for name, content := range map[string]string{
+		"null":        "null\n",
+		"bare string": `"hello"` + "\n",
+		"bare number": "123\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			repoRoot := t.TempDir()
+			writeInRepoTomlConfig(t, repoRoot, content)
+			_, _, err := LoadInRepoConfig(repoRoot)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), TomlConfigFileName)
+		})
+	}
+}
+
+// TestSaveInRepoPostWorktreeCommandsTOMLNonObject confirms the TOML save path
+// has no nil-map panic analog to the JSON one (#1153): a non-object existing
+// config.toml is a parse error the save surfaces cleanly rather than crashing.
+func TestSaveInRepoPostWorktreeCommandsTOMLNonObject(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	writeInRepoTomlConfig(t, repoRoot, "123\n")
+
+	err := SaveInRepoPostWorktreeCommands(repoRoot, []string{"make setup"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), TomlConfigFileName)
+}
+
 func TestLoadInRepoConfigTOMLTraversalSafety(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 

--- a/internal/proctree/proctree.go
+++ b/internal/proctree/proctree.go
@@ -177,11 +177,18 @@ func AliveSame(p Process) bool {
 // snapshotted process instance (it exited, or the PID was recycled).
 var ErrIdentityChanged = errors.New("process exited or pid was recycled")
 
+// kill is the syscall used to deliver signals. It is a package variable only
+// so tests can simulate the TOCTOU window (a process reaped between the
+// identity check and the signal, making the kernel return ESRCH).
+var kill = syscall.Kill
+
 // Signal delivers sig to p only if the PID still names the same process
 // instance. The verify-then-kill pair has an unavoidable microsecond TOCTOU
 // window; PID recycling within it would require the kernel to cycle through
 // the entire PID space between the two syscalls, which does not happen in
-// practice.
+// practice. If the process is reaped inside that window, syscall.Kill returns
+// ESRCH — indistinguishable from the AliveSame failure path, so it is coerced
+// to ErrIdentityChanged and callers treat "already gone" as success.
 func Signal(p Process, sig syscall.Signal) error {
 	if p.PID <= 1 || p.PID == os.Getpid() {
 		return fmt.Errorf("refusing to signal pid %d", p.PID)
@@ -189,7 +196,13 @@ func Signal(p Process, sig syscall.Signal) error {
 	if !AliveSame(p) {
 		return ErrIdentityChanged
 	}
-	return syscall.Kill(p.PID, sig)
+	if err := kill(p.PID, sig); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return ErrIdentityChanged
+		}
+		return err
+	}
+	return nil
 }
 
 // WaitForExits polls until every process in procs is gone (or its PID was

--- a/internal/proctree/proctree_test.go
+++ b/internal/proctree/proctree_test.go
@@ -1,8 +1,10 @@
 package proctree
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -141,6 +143,80 @@ func TestSignalVerifiesIdentity(t *testing.T) {
 	_, _ = child.Process.Wait()
 	if AliveSame(p) {
 		t.Errorf("child still alive after SIGKILL")
+	}
+}
+
+// TestSignalReapedInTOCTOUWindow simulates the process being reaped in the
+// unavoidable window between the identity check and the delivery of the
+// signal: AliveSame passes (the child is genuinely alive) but the kernel
+// returns ESRCH for the kill. Signal must map that to ErrIdentityChanged so
+// callers treat "already gone" as success, not a warnable failure (#1151).
+func TestSignalReapedInTOCTOUWindow(t *testing.T) {
+	child := startSleeper(t)
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	p := snap[child.Process.Pid]
+	if !AliveSame(p) {
+		t.Fatalf("child not alive at snapshot time")
+	}
+
+	orig := kill
+	t.Cleanup(func() { kill = orig })
+	kill = func(pid int, sig syscall.Signal) error { return syscall.ESRCH }
+
+	if err := Signal(p, syscall.SIGTERM); err != ErrIdentityChanged {
+		t.Errorf("Signal(reaped-in-window) = %v, want ErrIdentityChanged", err)
+	}
+}
+
+// TestSignalPropagatesNonESRCHErrors makes sure the ESRCH coercion does not
+// swallow genuine signal failures (e.g. EPERM): those must still surface.
+func TestSignalPropagatesNonESRCHErrors(t *testing.T) {
+	child := startSleeper(t)
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	p := snap[child.Process.Pid]
+
+	orig := kill
+	t.Cleanup(func() { kill = orig })
+	kill = func(pid int, sig syscall.Signal) error { return syscall.EPERM }
+
+	if err := Signal(p, syscall.SIGTERM); err != syscall.EPERM {
+		t.Errorf("Signal(EPERM) = %v, want EPERM", err)
+	}
+}
+
+// TestKillEscalatingNoWarnOnTOCTOUExit is the end-to-end contract: when a
+// survivor is reaped in the TOCTOU window, KillEscalating must not log a
+// "failed to" warning for it (#1151).
+func TestKillEscalatingNoWarnOnTOCTOUExit(t *testing.T) {
+	child := startSleeper(t)
+	snap, err := Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	p := snap[child.Process.Pid]
+
+	orig := kill
+	t.Cleanup(func() { kill = orig })
+	kill = func(pid int, sig syscall.Signal) error { return syscall.ESRCH }
+
+	var logged []string
+	logf := func(format string, args ...any) {
+		logged = append(logged, fmt.Sprintf(format, args...))
+	}
+	// Zero grace so the alive child is treated as a survivor immediately,
+	// then its kill races-out to ESRCH.
+	KillEscalating([]Process{p}, 0, 10*time.Millisecond, logf)
+
+	for _, line := range logged {
+		if strings.Contains(line, "failed to") {
+			t.Errorf("KillEscalating logged a failure for a process gone in the TOCTOU window: %q", line)
+		}
 	}
 }
 


### PR DESCRIPTION
Two independent Detail Bugs in disjoint files, one commit each for clean separability. Both are consistency fixes that align new code with the codebase's established defensive patterns.

## Commit 1 — proctree: map ESRCH to `ErrIdentityChanged` in `Signal` (`Closes #1151`)

Introduced by #1120. `Signal` verifies process identity (PID + start time) via `AliveSame`, then delivers the signal. The verify→kill pair has an unavoidable TOCTOU window: if the process exits and is reaped in it, `syscall.Kill` returns `ESRCH`. `Signal` surfaced that raw `ESRCH`, so `KillEscalating` logged a spurious `"failed to SIGTERM leaked process"` **warning** for a process that had already exited cleanly.

This contradicts the documented `ErrIdentityChanged` contract ("process exited or pid was recycled") and every other `ESRCH` handler in the tree (`session/tmux/tmux.go`, `daemon/sigterm_fallback.go` treat it as benign). This race arises naturally: `WaitForExits` can report zombies as alive; once reaped, the subsequent `Kill` returns `ESRCH`.

**Fix:** coerce the "process is gone" case to `ErrIdentityChanged` — which the caller already treats as success, no warning. Non-`ESRCH` errors (e.g. `EPERM`) still propagate. A `kill` package var seams `syscall.Kill` so the TOCTOU race is tested deterministically instead of raced against a real process.

**Caller audit:** `KillEscalating` is the only caller in the teardown path; both its SIGTERM and SIGKILL `switch` arms already gate warnings on `!errors.Is(err, ErrIdentityChanged)`, so the coercion is sufficient — no caller change needed.

## Commit 2 — config: reject JSON `null` in-repo config (`Closes #1153`)

Introduced by #805. `encoding/json` unmarshals a bare `null` into a map as a no-op that leaves it **nil, without error** — the one non-object top-level value it accepts (strings/numbers/arrays/booleans already error). This slipped two guards in `config/inrepo.go`:

- `LoadInRepoConfig` silently accepted `null` as an empty config, despite empty files being a loud error.
- `SaveInRepoPostWorktreeCommands` re-read the file, unmarshaled `null` over its initialized map (niling it), then **panicked** on the nil-map key write.

**Fix:** reject `null` explicitly in both paths with an actionable error naming the file, matching how the sibling non-object values already fail and the defensive `null` checks elsewhere (`session/storage.go`, `daemon/daemon.go`).

**TOML path (#1140, merged today):** checked and has no analog — TOML has no `null` literal and requires a table top-level, so bare `null`/string/number are parse errors the decoder already rejects. Pinned with tests either way.

## Tests
- proctree: reaped-in-TOCTOU-window → `ErrIdentityChanged`; non-ESRCH errors propagate; `KillEscalating` logs no failure for a window-exit.
- config json + toml: `null`, bare string/number/array rejected with the file named; empty-object `{}` accepted as a keyless config; `Save` on a `null`/non-object file errors instead of panicking.

## Gates
- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go build ./...` — OK
- `make test-container` — full suite green (incl. `config`, `internal/proctree`)
- `deadcode -test ./...` — clean

Do not merge — root verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Captain Claude