### PR TITLE
fix(tui): attach shell tabs attach-only — never respawn during a kill race (#1152)

### DIFF
--- a/app/daemon_mutation_routing_test.go
+++ b/app/daemon_mutation_routing_test.go
@@ -21,7 +21,7 @@ func TestHandleNewTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 	var gotTitle, gotRepo string
 	restore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
 		gotTitle, gotRepo = title, repoID
-		return nextShellTabName(inst.GetTabs()), nil
+		return spawnDaemonTab(inst), nil
 	})
 	defer restore()
 
@@ -47,7 +47,7 @@ func TestHandleCloseTab_RoutesThroughDaemon_NoLocalSave(t *testing.T) {
 
 	var gotTitle, gotRepo, gotTab string
 	createRestore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return nextShellTabName(inst.GetTabs()), nil
+		return spawnDaemonTab(inst), nil
 	})
 	defer createRestore()
 	closeRestore := SetTabCloserForTest(func(title, repoID, tabName string) error {

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -337,7 +337,7 @@ func TestPane_CloseTabRebindsPanes(t *testing.T) {
 	resizeHome(h, 200, 40)
 
 	restore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return nextShellTabName(inst.GetTabs()), nil
+		return spawnDaemonTab(inst), nil
 	})
 	defer restore()
 	_, _ = h.handleNewTab() // agent + shell + shell-2
@@ -377,7 +377,7 @@ func TestPane_SnapshotTabRemovalRebindsPanes(t *testing.T) {
 	resizeHome(h, 200, 40)
 
 	restore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return nextShellTabName(inst.GetTabs()), nil
+		return spawnDaemonTab(inst), nil
 	})
 	defer restore()
 	_, _ = h.handleNewTab() // agent + shell + shell-2; opens the slot-2 pane
@@ -414,7 +414,7 @@ func TestPane_SnapshotTabRemovalKeepsUnaffectedPaneBinding(t *testing.T) {
 	resizeHome(h, 200, 40)
 
 	restore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return nextShellTabName(inst.GetTabs()), nil
+		return spawnDaemonTab(inst), nil
 	})
 	defer restore()
 	_, _ = h.handleNewTab() // agent + shell + shell-2; opens the slot-2 pane

--- a/app/single_writer_test.go
+++ b/app/single_writer_test.go
@@ -30,7 +30,7 @@ func TestTUIHasNoInstancesWritePath(t *testing.T) {
 
 	// new shell tab: routed through the daemon (stubbed), reflected locally only.
 	createRestore := SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return nextShellTabName(inst.GetTabs()), nil
+		return spawnDaemonTab(inst), nil
 	})
 	defer createRestore()
 	_, _ = h.handleNewTab()

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -36,8 +36,12 @@ func (p tabHotkeysPty) Start(cmd *exec.Cmd) (*os.File, error) {
 func (p tabHotkeysPty) Close() {}
 
 // nameKeyedTmuxExec tracks tmux session existence per name so an instance's
-// agent session and any shell siblings are independent.
-func nameKeyedTmuxExec() cmd_test.MockCmdExec {
+// agent session and any shell siblings are independent. It also returns a spawn
+// hook that marks a session alive WITHOUT a new-session, modeling the real
+// daemon spawning a tab's tmux session server-side before the TUI attaches:
+// since #1152 AttachShellTab is attach-only and no longer resurrects a missing
+// session, so the session must already exist when the TUI reflects the tab.
+func nameKeyedTmuxExec() (cmd_test.MockCmdExec, func(sessionName string)) {
 	existing := map[string]bool{}
 	nameOf := func(cmd *exec.Cmd) string {
 		for i, a := range cmd.Args {
@@ -54,7 +58,7 @@ func nameKeyedTmuxExec() cmd_test.MockCmdExec {
 		}
 		return ""
 	}
-	return cmd_test.MockCmdExec{
+	exec := cmd_test.MockCmdExec{
 		RunFunc: func(cmd *exec.Cmd) error {
 			s := cmd.String()
 			n := nameOf(cmd)
@@ -77,6 +81,8 @@ func nameKeyedTmuxExec() cmd_test.MockCmdExec {
 			return []byte("content"), nil
 		},
 	}
+	spawn := func(sessionName string) { existing[sessionName] = true }
+	return exec, spawn
 }
 
 func setupGitRepoForTabs(t *testing.T, workdir string) {
@@ -108,7 +114,7 @@ func freshLocalInstance(t *testing.T, title string) *session.Instance {
 	setupGitRepoForTabs(t, workdir)
 
 	name := fmt.Sprintf("af-tabs-%s-%d", title, time.Now().UnixNano())
-	cmdExec := nameKeyedTmuxExec()
+	cmdExec, spawn := nameKeyedTmuxExec()
 	pty := tabHotkeysPty{t: t, cmdExec: cmdExec}
 
 	inst, err := session.NewInstance(session.InstanceOptions{Title: name, Path: workdir, Program: "bash"})
@@ -116,7 +122,33 @@ func freshLocalInstance(t *testing.T, title string) *session.Instance {
 	inst.SetTmuxSession(tmux.NewTmuxSessionWithDeps(name, "bash", pty, cmdExec))
 	require.NoError(t, inst.Start(true))
 	require.Equal(t, 1, inst.TabCount(), "a fresh start must yield only the agent tab (#1100)")
+	registerDaemonSpawn(t, inst, spawn)
 	return inst
+}
+
+// daemonSpawnHooks maps a test instance to the closure that marks a tmux session
+// alive in its mock exec. A stubbed daemon CreateTab uses it to model the real
+// daemon spawning a tab's session server-side BEFORE the TUI attaches — required
+// since #1152 made AttachShellTab attach-only (it no longer resurrects a missing
+// session, so the session must already exist when the TUI reflects the tab).
+// Package-level rather than threaded through the many builder call sites; these
+// tests use t.Setenv so none run in parallel, making the shared map race-free.
+var daemonSpawnHooks = map[*session.Instance]func(string){}
+
+func registerDaemonSpawn(t *testing.T, inst *session.Instance, spawn func(string)) {
+	daemonSpawnHooks[inst] = spawn
+	t.Cleanup(func() { delete(daemonSpawnHooks, inst) })
+}
+
+// spawnDaemonTab is the shared body of every stubbed daemon CreateTab: derive
+// the next shell tab name, mark that sibling session alive in the mock (the
+// daemon's server-side spawn), and return the name for the TUI to attach to.
+func spawnDaemonTab(inst *session.Instance) string {
+	name := nextShellTabName(inst.GetTabs())
+	if spawn := daemonSpawnHooks[inst]; spawn != nil {
+		spawn(inst.TabTmuxName(0) + "__" + name)
+	}
+	return name
 }
 
 // startedLocalInstance is freshLocalInstance plus one on-demand shell tab
@@ -172,7 +204,7 @@ func stubTabDaemonSeams(t *testing.T, inst *session.Instance) (created, closed *
 	var c, d int
 	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, error) {
 		c++
-		return nextShellTabName(inst.GetTabs()), nil
+		return spawnDaemonTab(inst), nil
 	}))
 	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
 		d++

--- a/app/tree_nav_test.go
+++ b/app/tree_nav_test.go
@@ -133,7 +133,7 @@ func TestTreeNav_TabCreateCloseFromTabRow(t *testing.T) {
 
 	var closedNames []string
 	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, error) {
-		return nextShellTabName(inst.GetTabs()), nil
+		return spawnDaemonTab(inst), nil
 	}))
 	t.Cleanup(SetTabCloserForTest(func(title, repoID, tabName string) error {
 		closedNames = append(closedNames, tabName)

--- a/session/instance.go
+++ b/session/instance.go
@@ -461,21 +461,42 @@ func (i *Instance) AttachShellTab(name string) (*Tab, error) {
 		return nil, fmt.Errorf("cannot attach a tab without a worktree")
 	}
 
-	// Bind to the exact session name the daemon derived and reconnect to it. The
-	// sibling inherits the agent session's PTY factory / executor (real in
-	// production, mock in tests). Restore re-spawns only if the session is
-	// genuinely missing (its workDir is non-empty), matching setupTabs.
+	// Bind to the exact session name the daemon derived and ATTACH-ONLY to it —
+	// never spawn. Pass empty workDir so a session that is missing surfaces as an
+	// error instead of re-spawning (#1152). The daemon is the single writer that
+	// owns every tmux spawn (#960); this is a pure TUI-side projection of a tab
+	// the daemon already created. If the daemon killed the instance in the window
+	// since our RLock, the session is gone, and re-spawning it here would create a
+	// tmux session that escapes the daemon's Kill teardown and orphans over the
+	// about-to-be-deleted worktree — the same #990 leak AddShellTab guards. Fail
+	// cleanly and let the daemon's next Snapshot reconcile the tab away.
 	tmuxName := agentTmux.SanitizedName() + "__" + name
 	shellTmux := agentTmux.NewSiblingSession(tmuxName, defaultShell())
-	if err := shellTmux.Restore(worktreePath); err != nil {
+	if err := shellTmux.Restore(""); err != nil {
 		return nil, fmt.Errorf("failed to reconnect shell tab: %w", err)
 	}
 
 	tab := newShellTab(shellTmux)
 	tab.Name = name
 	i.mu.Lock()
-	i.Tabs = append(i.Tabs, tab)
+	// Re-check started under the write lock before appending, mirroring
+	// AddShellTab: Kill is not serialized against attach and can have flipped
+	// started=false (snapshotting Tabs for teardown) in the window since our
+	// RLock. Nothing was spawned above (attach-only), so a lost race only needs to
+	// release the local attach client we opened and drop the projection; the next
+	// reconcile re-adds the tab if it still exists server-side.
+	killed := !i.started
+	title := i.Title
+	if !killed {
+		i.Tabs = append(i.Tabs, tab)
+	}
 	i.mu.Unlock()
+	if killed {
+		if cerr := shellTmux.CloseAttachOnly(); cerr != nil {
+			log.WarningLog.Printf("attach shell tab to %q: releasing attach client after kill race: %v", title, cerr)
+		}
+		return nil, fmt.Errorf("session was killed during tab attach")
+	}
 	return tab, nil
 }
 
@@ -561,10 +582,14 @@ func (i *Instance) ReconcileTabsFromData(target []TabData) (bool, error) {
 		kind := tabKindForData(td.Kind)
 		// The sibling inherits the agent session's PTY factory / executor (real
 		// in production, mock in tests), binding to the EXACT persisted name.
-		// Restore reconnects (re-spawning only if the session is genuinely gone),
-		// mirroring restoreLocalTabs + LocalBackend.setupTabs.
+		// ATTACH-ONLY: pass empty workDir so a missing session errors instead of
+		// re-spawning (#1152). Like AttachShellTab, this is a pure TUI-side
+		// projection of daemon-owned tabs; the daemon is the single writer that
+		// owns every spawn (#960). If the daemon killed the session in the race
+		// window, re-spawning here would orphan a tmux session over the deleted
+		// worktree. Skip the tab on failure and let the next snapshot reconcile it.
 		ts := agentTmux.NewSiblingSession(td.TmuxName, tabProgram(kind, td.Command, program))
-		if err := ts.Restore(worktreePath); err != nil {
+		if err := ts.Restore(""); err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("failed to reconnect tab %q: %w", td.Name, err)
 			}

--- a/session/tab_kill_race_test.go
+++ b/session/tab_kill_race_test.go
@@ -160,6 +160,112 @@ func TestAddProcessTab_KillRaceDoesNotLeakSession(t *testing.T) {
 	assert.False(t, isAlive(orphan), "the spawned tmux session must be torn down (no orphan)")
 }
 
+// TestAttachShellTab_KilledSessionDoesNotSpawn is the #1152 regression: the
+// daemon spawned the shell session out-of-band and then killed the instance
+// before the TUI reflects the tab. AttachShellTab is a pure TUI-side projection
+// of daemon-owned state and must ATTACH ONLY — it must NOT re-spawn the missing
+// session. Re-spawning would create a tmux session in the TUI process that
+// escapes the daemon's Kill teardown and orphans over the about-to-be-deleted
+// worktree, violating the single-writer model (#960) — the same #990 leak class
+// AddShellTab guards. It must fail cleanly, spawn nothing, and append nothing.
+func TestAttachShellTab_KilledSessionDoesNotSpawn(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	const agentName = "af_attach_killed"
+	// Seed only the agent session alive: the shell session the daemon created
+	// was already killed, so has-session for it reports missing. onNewSession
+	// fires iff a tmux new-session is ever issued — the bug's fingerprint.
+	spawned := false
+	inst, isAlive := raceMockInstance(t, agentName, func() { spawned = true })
+
+	tab, err := inst.AttachShellTab(shellTabName)
+	require.Error(t, err, "attaching to a killed session must fail, not resurrect it")
+	assert.Contains(t, err.Error(), "failed to reconnect shell tab")
+	assert.Nil(t, tab)
+	assert.False(t, spawned, "AttachShellTab must never issue tmux new-session (#1152)")
+	assert.False(t, isAlive(agentName+"__"+shellTabName),
+		"no orphan shell session may exist after a failed attach")
+	assert.Equal(t, 1, inst.TabCount(), "the un-attachable tab must not be appended")
+}
+
+// TestAttachShellTab_KillRaceDropsProjection covers the append guard: the shell
+// session is live when the attach begins (so Restore reconnects), but a
+// concurrent Kill flips started=false in the window between AttachShellTab
+// releasing its read lock and re-locking to append — exactly the #990 window.
+// AttachShellTab must then drop the projection (append nothing) and return an
+// error, releasing only the local attach client it opened (never killing the
+// session — the daemon owns that).
+func TestAttachShellTab_KillRaceDropsProjection(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_attach_race"
+	shellName := agentName + "__" + shellTabName
+
+	var inst *Instance
+	spawned := false
+	flipped := false
+	killedSession := false
+	exec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			s := cmd.String()
+			switch {
+			case strings.Contains(s, "new-session"):
+				spawned = true
+				return nil
+			case strings.Contains(s, "kill-session"):
+				if strings.Contains(s, shellName) {
+					killedSession = true
+				}
+				return nil
+			case strings.Contains(s, "has-session"):
+				// The shell session is live when the attach begins. On its first
+				// existence probe (inside Restore, after AttachShellTab released
+				// its RLock) simulate a concurrent Kill landing: flip started=false
+				// so the write-lock recheck observes the teardown.
+				if strings.Contains(s, shellName) && !flipped {
+					flipped = true
+					inst.mu.Lock()
+					inst.started = false
+					inst.mu.Unlock()
+				}
+				return nil // agent + shell both report alive
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+
+	repoPath := "/tmp/tab-attach-race-" + agentName
+	gw, err := git.NewGitWorktreeFromStorage(
+		repoPath, filepath.Join(t.TempDir(), "wt"), agentName,
+		agentName+"-branch", "", false, true)
+	require.NoError(t, err)
+
+	agentTs := tmux.NewTmuxSessionFromSanitizedNameWithDeps(agentName, "claude", pty, exec)
+	inst = &Instance{
+		Title:       agentName,
+		Path:        repoPath,
+		Program:     "claude",
+		backend:     &LocalBackend{},
+		started:     true,
+		gitWorktree: gw,
+		Tabs:        []*Tab{newAgentTab(agentTs)},
+	}
+
+	tab, err := inst.AttachShellTab(shellTabName)
+	require.Error(t, err, "a tab attached during teardown must be refused")
+	assert.Contains(t, err.Error(), "session was killed during tab attach")
+	assert.Nil(t, tab)
+	assert.False(t, spawned, "the attach path must never spawn a session (#1152)")
+	assert.False(t, killedSession,
+		"the projection must not kill the daemon-owned session; only release its own attach client")
+	assert.Equal(t, 1, inst.TabCount(), "the raced tab must not be appended")
+}
+
 // TestAddTab_NoKillRaceStillAppends verifies the fix does not regress the happy
 // path: with no concurrent kill, both AddShellTab and AddProcessTab still spawn,
 // append, and return a live tab.


### PR DESCRIPTION
## Summary

`AttachShellTab` (session/instance.go) — the TUI-side path that reflects a
daemon-created shell tab locally — called `Restore(worktreePath)`, which
**re-spawns** a missing tmux session (the #386 reboot-recovery behavior). When
the daemon killed an instance in the window between the `CreateTab` RPC
returning and the TUI reflecting the tab, the session was already gone, so
`Restore` re-spawned it **in the TUI process**, outside the daemon's `Kill`
snapshot. That session escaped teardown and orphaned over the about-to-be-deleted
worktree — exactly the #990 leak class, and a violation of the #960 single-writer
model (only the daemon may spawn tmux sessions). Introduced in #962.

## Fix

The TUI-side projection paths **attach only, never spawn**. Passing empty
`workDir` to `Restore` makes a missing session surface as a clean error instead
of a respawn; the daemon's next `Snapshot` reconciles the tab away.

- **`AttachShellTab`** — `Restore("")` + a `started` recheck under the write lock
  before appending, mirroring `AddShellTab`'s #990 guard. Nothing is spawned, so
  a lost race only releases the local attach client (`CloseAttachOnly` — which
  **never** kills the daemon-owned session) and drops the projection.
- **`ReconcileTabsFromData`** — the sibling projection path for daemon-listed
  tabs; same `Restore("")` change. A missing session skips that tab and the next
  reconcile retries.

## Single-writer audit (#960 class — weighted heavily)

Every spawn-capable `Restore` / `Start` / `new-session` call site, classified
TUI-side vs daemon-side:

| Call site | Path | Classification |
|---|---|---|
| `AttachShellTab` → `Restore` | `app/handle_actions.go` (`t`) | **FIXED** — `Restore(worktreePath)`→`Restore("")` |
| `ReconcileTabsFromData` → `Restore` | `app/sync.go` snapshot reconcile | **FIXED** — same |
| `tmux Restore("")` in `Start`/`Detach` | post-create / re-attach | already attach-only |
| `AddShellTab` / `AddProcessTab` `new-session` | `daemon/control.go` CreateTab RPC only | daemon-side legitimate |
| `LocalBackend.Start` firstTimeSetup `new-session` | `Instance.Start(true)` via daemon CreateSession RPC / task runner | daemon-side legitimate |
| `LocalBackend.Recover` `Restore(workDir)` | daemon Lost-restore loop only | daemon-side legitimate |
| `LocalBackend.Start(false)` restore + `setupTabs` `Restore(workDir)` | daemon #386/#1108 recovery; TUI reaches it via `FromInstanceData` snapshot materialization | **justified / follow-up** (see below) |

No direct tmux spawner exists anywhere in `app/` or `ui/`.

**Follow-up (not in this PR):** `LocalBackend.Start(false)` + `setupTabs`
re-spawn a missing session (the daemon's #386 reboot / #1108 Lost recovery,
guarded by the #970 Dead/Lost early-return). The TUI reaches this only when
materializing the daemon's authoritative snapshot, where the session is live by
construction. Closing the narrow residual (snapshot fetched live → killed →
materialized) needs a daemon-vs-TUI no-spawn signal threaded through `Start` — a
larger change to the #960 hot path, deliberately kept out of this focused fix and
tracked separately.

## Tests

`session/tab_kill_race_test.go` (run under `make test-container`, SandboxTmux-fenced):

- **`TestAttachShellTab_KilledSessionDoesNotSpawn`** — attaching after the backing
  session is killed issues **no** `new-session`, leaves no orphan, appends
  nothing, and errors cleanly. Confirmed to **fail** against the pre-fix
  `Restore(worktreePath)`.
- **`TestAttachShellTab_KillRaceDropsProjection`** — a kill flipping `started`
  mid-attach drops the projection and releases only the attach client, never
  killing the daemon-owned session.

App tab-lifecycle tests were updated so the stubbed daemon `CreateTab` marks the
sibling session alive (modeling the daemon's server-side spawn), giving the TUI's
attach-only reconnect a live session to bind to — faithful to production.

## Gates

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — empty
- `go build ./...` — ok
- `make test-container` — full suite green
- `deadcode -test ./...` — clean

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)