### PR TITLE
fix(tree): closing an instance's last tab drifts selection to the trailing instance (#1084)

### DIFF
--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -673,15 +673,25 @@ func (s *Sidebar) SelectInstance(target *session.Instance) {
 // tab-key muscle memory with the cursor on the instance row behaves exactly as
 // before the tree (the cursor stays put; the tree's "*" marker moves).
 //
-// The intended target MUST be captured before syncFromStore runs: when the
-// tab-slot count changed (t create / w close), the sync's structure rebuild
-// fires and pushSelection re-asserts the CURSOR row's tab index into the
-// store, clobbering the active tab the caller just set. Reading ActiveTab()
-// after the sync returned that clobbered value, so the method saw
-// cursor==active and no-oped — t didn't select the new tab and a following w
-// silently closed the wrong tab (PR #1081 play-test). Bare tab jumps/cycles
-// don't change the structure signature, so they never hit the rebuild; both
-// paths now go through the same capture-first flow.
+// The intended target MUST be captured before the row list is rebuilt: when
+// the tab-slot count changed (t create / w close), the structure rebuild fires
+// and its blind index clamp drifts the stale tab-row flat index. Two failures
+// follow if that drift is allowed to reach the store: pushSelection re-asserts
+// the drifted row's tab index, clobbering the active tab the caller just set
+// (t didn't select the new tab and a following w silently closed the wrong tab
+// — PR #1081 play-test); and, when a TRAILING instance sits just below, closing
+// the last tab shrinks the list so the drift lands on that neighbor's row —
+// pushSelection then commits it as the display selection, folding the acting
+// instance's subtree so the re-pin can no longer find its tab rows (#1084).
+//
+// Both are avoided by rebuilding here — while the store still selects the
+// acting instance, so its subtree stays expanded — and re-pinning the cursor
+// by captured title BEFORE any selection is pushed, rather than routing through
+// syncFromStore and trying to undo the drift afterward. Bare tab jumps/cycles
+// don't change the structure, so the rebuild is a no-op for them; both paths go
+// through the same capture-first flow. Any pending #969 SelectInstance
+// assertion has already been consumed by the GetSelectedInstance sync at the
+// top of the tab handler, so bypassing syncFromStore here drops nothing.
 func (s *Sidebar) SyncCursorToActiveTab() {
 	want := s.proj.ActiveTab()
 	pre := s.rawSelection()
@@ -692,10 +702,10 @@ func (s *Sidebar) SyncCursorToActiveTab() {
 	if pre.ItemIndex < 0 || pre.ItemIndex >= len(instances) {
 		return
 	}
-	// Key the parent instance by title: the sync below rebuilds the row list
-	// and flat/instance indices are only stable across it by identity.
+	// Key the parent instance by title: the rebuild below re-derives the row
+	// list and flat/instance indices are only stable across it by identity.
 	title := instances[pre.ItemIndex].Title
-	s.syncFromStore()
+	s.rebuildVisibleItems()
 	instances = s.proj.GetInstances()
 	found := false
 	for j, item := range s.visibleItems {
@@ -708,12 +718,23 @@ func (s *Sidebar) SyncCursorToActiveTab() {
 		}
 	}
 	if found {
-		// Re-assert the captured target: the sync's pushSelection may have
-		// overwritten it with the pre-move cursor row's index.
+		// Re-assert the captured target: the rebuild's clamp may have moved the
+		// cursor, and afterCursorMove's pushSelection reads it back.
 		s.proj.SetActiveTab(want)
+	} else {
+		// The wanted tab row is gone (e.g. a concurrent reconcile shrank the tab
+		// set). Fall back to the acting instance's own row so the cursor stays
+		// within its subtree instead of drifting onto a neighbor; if the
+		// instance itself vanished, no row matches and the clamp position wins.
+		for j, item := range s.visibleItems {
+			if item.Kind == SectionInstances && !item.IsHeader && !item.IsTab &&
+				item.ItemIndex >= 0 && item.ItemIndex < len(instances) &&
+				instances[item.ItemIndex].Title == title {
+				s.selectedIdx = j
+				break
+			}
+		}
 	}
-	// When the wanted row is gone (e.g. a concurrent reconcile shrank the tab
-	// set), the cursor keeps the sync's clamped position and its row wins.
 	s.afterCursorMove()
 }
 

--- a/ui/sidebar_tree_test.go
+++ b/ui/sidebar_tree_test.go
@@ -228,6 +228,42 @@ func TestSidebarTreeSyncCursorSurvivesStructureRebuild(t *testing.T) {
 	assert.Equal(t, 1, sel.TabIndex)
 }
 
+// TestSidebarTreeCloseLastTabStaysOnInstance is the #1084 regression: with the
+// cursor on the LAST tab row of the selected instance and ANOTHER instance
+// below it, closing that tab (what handleCloseTab does: DropClosedTab +
+// SetActiveTab(idx-1) + SyncCursorToActiveTab) must keep the selection within
+// the acting instance's subtree — the shrunk row list drops the old tab-row
+// flat index onto the trailing instance's row, and the pre-fix code committed
+// that drift as the display selection before it could re-pin by title.
+func TestSidebarTreeCloseLastTabStaysOnInstance(t *testing.T) {
+	s := newTreeSidebar(t, 2)
+	s.SetSelectedInstance(0)
+	s.Down() // tab row 0 of t-00
+	s.Down() // tab row 1 of t-00 (the last tab), active tab = 1
+	require.True(t, s.GetSelection().IsTab)
+	require.Equal(t, 1, s.GetSelection().TabIndex)
+
+	// Simulate handleCloseTab on the last tab: the daemon-authoritative drop
+	// removes the slot in place, the handler selects the left neighbor, then
+	// re-pins the tree cursor.
+	inst := s.proj.GetInstances()[0]
+	require.NoError(t, inst.DropClosedTab(1))
+	s.proj.SetActiveTab(0)
+	s.SyncCursorToActiveTab()
+
+	// Selection must stay on the acting instance (t-00), not drift to t-01.
+	require.NotNil(t, s.GetSelectedInstance())
+	assert.Equal(t, "t-00", s.GetSelectedInstance().Title,
+		"closing the last tab must not drift the selection to the trailing instance")
+	sel := s.GetSelection()
+	assert.Equal(t, 0, sel.ItemIndex, "cursor stays on t-00's row/subtree")
+	assert.True(t, sel.IsTab, "cursor lands on the surviving (agent) tab row")
+	assert.Equal(t, 0, sel.TabIndex)
+	assert.Equal(t, 0, s.proj.ActiveTab(), "the intended active tab survives the rebuild")
+	// The acting instance stays expanded; the trailing one stays folded.
+	assert.Equal(t, 1, tabRowCount(s), "only t-00's surviving tab row is present")
+}
+
 // TestSidebarTreeRepinPreservesTabSelection is the tree extension of the #969
 // re-pin: a reconcile that removes a preceding instance re-pins the selection
 // by title, and the cursor must return to the SAME TAB ROW it was on, not just


### PR DESCRIPTION
## Summary

Closes #1084.

With the tree cursor parked on the **last tab row** of the selected instance and **another instance below it**, pressing `w` closed the correct tab (data-safe — the #1081 wrong-tab fix stays intact) but the tree cursor/selection **drifted onto the next instance**: its subtree folded and the workspace content pane retargeted (e.g. `alpha · Terminal` → the neighbor). Disorienting, though never destructive.

## Root cause

`handleCloseTab` shrinks the acting instance's tab list, sets the active tab to the left neighbor, then calls `Sidebar.SyncCursorToActiveTab`. That method routed through `syncFromStore`, whose rebuild applies a **blind index clamp** (drift-then-clamp) to the stale flat cursor index. Closing the last tab shortens the row list, so the old tab-row index lands on the **trailing instance's row**, and `syncFromStore`'s `afterCursorMove → pushSelection` **committed that drift as the display selection** — folding the acting instance's subtree — *before* the by-title re-pin could run. The re-pin then couldn't find the (now-folded) tab rows and the drift stuck.

## Fix

`SyncCursorToActiveTab` now rebuilds the row list and re-pins the cursor **by captured title itself**, while the store still selects the acting instance (so its subtree stays expanded and its `want`-tab row is present), instead of letting `syncFromStore`'s blind clamp reach the store first. If the wanted tab row is gone (a concurrent reconcile shrank the set) it falls back to the acting instance's own row, so the cursor still can't drift onto a neighbor. Any pending #969 `SelectInstance` assertion is already consumed by the `GetSelectedInstance` sync at the top of the tab handler, so bypassing `syncFromStore` here drops nothing.

## Tests

- Adds `TestSidebarTreeCloseLastTabStaysOnInstance` — a **two-instance** reproduction. The existing `TestSidebarTreeSyncCursorSurvivesStructureRebuild` missed this because it used a single instance (no trailing row to drift onto), exactly as the issue predicted. The new test fails on `master` (`t-00` → `t-01`) and passes with the fix.

## Verification

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — empty
- `go build ./...` — ok
- `make test-container` — full suite green
- **Real TUI play-test** (`make playtest-container`): two instances `alpha`/`beta`, `t` on alpha to add a Terminal tab (cursor lands on the last tab), `w` to close it → alpha stays selected/expanded showing `└ 1 Preview *`, content pane stays on `alpha · Preview`, no drift to beta.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)