### PR TITLE
fix(tmux): gate leftover [detach-trace] markers behind AF_DETACH_TRACE (#1157 part 1)

### DIFF
--- a/session/tmux/detach_trace_gate_test.go
+++ b/session/tmux/detach_trace_gate_test.go
@@ -1,0 +1,154 @@
+package tmux
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	aflog "github.com/sachiniyer/agent-factory/log"
+)
+
+// newDrainableSession builds a TmuxSession wired up like a live Attach so
+// Detach() has bookkeeping to tear down, but with an empty WaitGroup so
+// wg.Wait returns immediately and the SIGKILL fallback never runs. This is
+// the ordinary "user hits the detach key on a healthy session" path — the
+// one that must be silent in the WARN stream (#1157).
+func newDrainableSession(t *testing.T, name string) *TmuxSession {
+	t.Helper()
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+	session := newTmuxSession(toTmuxName(name, ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+	return session
+}
+
+// TestDetach_NoTraceWarnByDefault is the direct regression guard for #1157:
+// the leftover #599 [detach-trace] instrumentation logged ~13 WARN lines on
+// every detach and grew to 93% of all WARN volume in production logs. With
+// AF_DETACH_TRACE unset (the default for every external user), a normal
+// detach must emit ZERO [detach-trace] lines on the WARN stream — and, since
+// the markers now live at INFO, none on INFO either while the gate is off.
+func TestDetach_NoTraceWarnByDefault(t *testing.T) {
+	t.Setenv("AF_DETACH_TRACE", "")
+
+	prevWarn := aflog.WarningLog
+	var warnBuf bytes.Buffer
+	aflog.WarningLog = log.New(&warnBuf, "WARN: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = prevWarn })
+
+	prevInfo := aflog.InfoLog
+	var infoBuf bytes.Buffer
+	aflog.InfoLog = log.New(&infoBuf, "INFO: ", 0)
+	t.Cleanup(func() { aflog.InfoLog = prevInfo })
+
+	session := newDrainableSession(t, "trace-off")
+	session.Detach()
+
+	if strings.Contains(warnBuf.String(), "[detach-trace]") {
+		t.Fatalf("detach with AF_DETACH_TRACE unset must emit no [detach-trace] WARN lines; got %q", warnBuf.String())
+	}
+	if strings.Contains(infoBuf.String(), "[detach-trace]") {
+		t.Fatalf("detach with AF_DETACH_TRACE unset must emit no [detach-trace] INFO lines; got %q", infoBuf.String())
+	}
+}
+
+// TestDetach_TraceGoesToInfoWhenEnabled is the paired positive case: with
+// AF_DETACH_TRACE=1 the step-level breakdown that localized the #598 stall
+// returns — but on the INFO stream, never WARN. This keeps the diagnostic
+// one flag away (matching the #788/#790 app-layer gate) without polluting
+// the WARN stream that log triage and af bug-report rely on.
+func TestDetach_TraceGoesToInfoWhenEnabled(t *testing.T) {
+	t.Setenv("AF_DETACH_TRACE", "1")
+
+	prevWarn := aflog.WarningLog
+	var warnBuf bytes.Buffer
+	aflog.WarningLog = log.New(&warnBuf, "WARN: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = prevWarn })
+
+	prevInfo := aflog.InfoLog
+	var infoBuf bytes.Buffer
+	aflog.InfoLog = log.New(&infoBuf, "INFO: ", 0)
+	t.Cleanup(func() { aflog.InfoLog = prevInfo })
+
+	session := newDrainableSession(t, "trace-on")
+	session.Detach()
+
+	info := infoBuf.String()
+	for _, marker := range []string{
+		"[detach-trace] tmux.Detach-entry",
+		"[detach-trace] tmux.Detach-wg.Wait-done",
+		"[detach-trace] tmux.Detach-exit",
+	} {
+		if !strings.Contains(info, marker) {
+			t.Fatalf("expected INFO trace to contain %q when AF_DETACH_TRACE=1; got %q", marker, info)
+		}
+	}
+	if strings.Contains(warnBuf.String(), "[detach-trace]") {
+		t.Fatalf("even when enabled, [detach-trace] must stay off the WARN stream; got %q", warnBuf.String())
+	}
+}
+
+// TestDetachTraceEnabled_ParsesEnv pins the gate's env contract: exactly
+// "1" enables it; everything else (unset, "0", "true", "yes") leaves it
+// off. This mirrors app.detachTraceEnabledFromEnv so the two [detach-trace]
+// layers share one opt-in convention.
+func TestDetachTraceEnabled_ParsesEnv(t *testing.T) {
+	cases := map[string]bool{
+		"":     false,
+		"0":    false,
+		"true": false,
+		"yes":  false,
+		"1":    true,
+	}
+	for value, want := range cases {
+		t.Setenv("AF_DETACH_TRACE", value)
+		if got := detachTraceEnabled(); got != want {
+			t.Errorf("detachTraceEnabled() with AF_DETACH_TRACE=%q = %v; want %v", value, got, want)
+		}
+	}
+}
+
+// TestDetachTracef_RespectsGate is a unit-level guard on the helper itself,
+// independent of the full Detach path: it must be silent when the gate is
+// off and emit on INFO (never WARN) when on. Guards against a future refactor
+// re-pointing the helper at WarningLog and quietly reintroducing the spam.
+func TestDetachTracef_RespectsGate(t *testing.T) {
+	prevWarn := aflog.WarningLog
+	var warnBuf bytes.Buffer
+	aflog.WarningLog = log.New(&warnBuf, "WARN: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = prevWarn })
+
+	prevInfo := aflog.InfoLog
+	var infoBuf bytes.Buffer
+	aflog.InfoLog = log.New(&infoBuf, "INFO: ", 0)
+	t.Cleanup(func() { aflog.InfoLog = prevInfo })
+
+	t.Setenv("AF_DETACH_TRACE", "")
+	detachTracef("marker-off elapsed=%v", time.Millisecond)
+	if warnBuf.Len() != 0 || infoBuf.Len() != 0 {
+		t.Fatalf("detachTracef must be silent when gated off; warn=%q info=%q", warnBuf.String(), infoBuf.String())
+	}
+
+	t.Setenv("AF_DETACH_TRACE", "1")
+	detachTracef("marker-on elapsed=%v", time.Millisecond)
+	if !strings.Contains(infoBuf.String(), "[detach-trace] marker-on") {
+		t.Fatalf("detachTracef must emit on INFO when enabled; got %q", infoBuf.String())
+	}
+	if warnBuf.Len() != 0 {
+		t.Fatalf("detachTracef must never write to WARN; got %q", warnBuf.String())
+	}
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -804,8 +804,7 @@ func (t *TmuxSession) Attach() (chan struct{}, error) {
 				// Closest point to "user pressed detach" we can observe —
 				// the elapsed in this trace is whatever Detach() itself
 				// took, which matches what blocks the app-side <-ch.
-				log.WarningLog.Printf("[detach-trace] tmux-stdin-reader-saw-detach-key name=%s",
-					t.sanitizedName)
+				detachTracef("tmux-stdin-reader-saw-detach-key name=%s", t.sanitizedName)
 				// Detach from the session
 				t.Detach()
 				return
@@ -820,14 +819,37 @@ func (t *TmuxSession) Attach() (chan struct{}, error) {
 	return t.attachCh, nil
 }
 
+// detachTraceEnabled reports whether the opt-in [detach-trace] step markers
+// on the Detach hot path should be emitted. Off by default so a routine
+// detach produces ZERO WARN lines; set AF_DETACH_TRACE=1 to restore the
+// step-level breakdown that localized the #598 stall to the wg.Wait step.
+// This completes the #788/#790 gating, which moved the app-layer sibling
+// markers (app/detach_trace.go) behind the same env var but left this
+// tmux-layer set — added by #599 to catch the #598 hang — logging
+// unconditionally at WARNING, where it grew to 93% of all WARN volume (#1157).
+func detachTraceEnabled() bool {
+	return os.Getenv("AF_DETACH_TRACE") == "1"
+}
+
+// detachTracef emits a [detach-trace] step marker, and only when
+// AF_DETACH_TRACE=1. It logs at INFO rather than WARNING so that even the
+// opt-in traces stay out of the WARN stream that log triage and af
+// bug-report (#1048) rely on — the only detach event worth a WARN is the
+// SIGKILL backstop actually firing (see waitForAttachDrain).
+func detachTracef(format string, args ...any) {
+	if !detachTraceEnabled() {
+		return
+	}
+	log.InfoLog.Printf("[detach-trace] "+format, args...)
+}
+
 // Detach disconnects from the current tmux session. Logs errors instead of panicking
 // so the application can attempt graceful recovery.
 func (t *TmuxSession) Detach() {
 	detachStart := time.Now()
-	log.WarningLog.Printf("[detach-trace] tmux.Detach-entry name=%s", t.sanitizedName)
+	detachTracef("tmux.Detach-entry name=%s", t.sanitizedName)
 	defer func() {
-		log.WarningLog.Printf("[detach-trace] tmux.Detach-exit name=%s total=%v",
-			t.sanitizedName, time.Since(detachStart))
+		detachTracef("tmux.Detach-exit name=%s total=%v", t.sanitizedName, time.Since(detachStart))
 		close(t.attachCh)
 		t.attachCh = nil
 		t.cancel = nil
@@ -850,14 +872,12 @@ func (t *TmuxSession) Detach() {
 	// "Session terminated without detaching" warning.
 	stepStart := time.Now()
 	t.cancel()
-	log.WarningLog.Printf("[detach-trace] tmux.Detach-cancel-done name=%s elapsed=%v",
-		t.sanitizedName, time.Since(stepStart))
+	detachTracef("tmux.Detach-cancel-done name=%s elapsed=%v", t.sanitizedName, time.Since(stepStart))
 
 	// Close the attached pty session so the io.Copy goroutine returns.
 	stepStart = time.Now()
 	closeErr := t.ptmx.Close()
-	log.WarningLog.Printf("[detach-trace] tmux.Detach-ptmx.Close-done name=%s elapsed=%v",
-		t.sanitizedName, time.Since(stepStart))
+	detachTracef("tmux.Detach-ptmx.Close-done name=%s elapsed=%v", t.sanitizedName, time.Since(stepStart))
 
 	// Wait for the attach goroutines (io.Copy + monitorWindowSize x2) to
 	// finish before mutating t.ptmx. monitorWindowSize reads t.ptmx via
@@ -866,8 +886,7 @@ func (t *TmuxSession) Detach() {
 	// the attach-session child if wg.Wait exceeds wgWaitSigkillDeadline —
 	// see #598 follow-up for the diagnosis.
 	waitElapsed := t.waitForAttachDrain()
-	log.WarningLog.Printf("[detach-trace] tmux.Detach-wg.Wait-done name=%s elapsed=%v",
-		t.sanitizedName, waitElapsed)
+	detachTracef("tmux.Detach-wg.Wait-done name=%s elapsed=%v", t.sanitizedName, waitElapsed)
 	// Defense-in-depth: if wg.Wait still exceeded the slow threshold after
 	// the SIGKILL fallback ran, that means killAttach didn't unstick the
 	// goroutine — a deeper bug than what this fix targets. Keep the loud
@@ -902,8 +921,7 @@ func (t *TmuxSession) Detach() {
 	if err := t.Restore(""); err != nil {
 		log.ErrorLog.Printf("error restoring pty after detach: %v", err)
 	}
-	log.WarningLog.Printf("[detach-trace] tmux.Detach-Restore-done name=%s elapsed=%v",
-		t.sanitizedName, time.Since(stepStart))
+	detachTracef("tmux.Detach-Restore-done name=%s elapsed=%v", t.sanitizedName, time.Since(stepStart))
 }
 
 // Close terminates the tmux session and cleans up resources


### PR DESCRIPTION
## What

Removes the leftover `[detach-trace]` WARNING spam from every detach by gating the #599 instrumentation behind `AF_DETACH_TRACE=1` (off by default) and moving it to INFO.

Part of #1157 (part 1 of 2).

## Why

The #599 detach-path instrumentation (`13d1834`, *"instrumentation to catch #598 hang in the wild"*) was never removed after #598 shipped. It logs ~13 `WARNING` lines on **every** detach and now accounts for **784 of 839 (93%)** of all WARN volume in the dev-box log — burying real warnings and dominating any `af bug-report` (#1048) bundle for every external user.

## Decision: complete the gating (not remove outright)

PRs #788/#790 already moved the **app-layer** sibling markers (`app/detach_trace.go`) behind an `AF_DETACH_TRACE=1` opt-in and kept the always-on slow-detach watchdog as the regression tripwire. But that work **never touched `session/tmux/tmux.go`** — the original #599 markers there kept logging unconditionally at `WARNING`. So the gating exists but was **incomplete**. This PR completes it rather than deleting the traces, because the step-level breakdown (`Detach-entry` → `cancel-done` → `ptmx.Close-done` → `wg.Wait-done` → `Restore-done`) is exactly what localized the residual #598 stall to the `wg.Wait` step — the part-2 investigation wants that one flag away, not gone.

Two deviations from a literal "gate at DEBUG":
- The `log` package has no DEBUG level (only Info/Warning/Error), so the markers now emit at **INFO** — the lowest, debug-tier stream — instead of WARNING.
- Even when opted in, traces stay **off the WARN stream entirely**, so an `AF_DETACH_TRACE=1` run never pollutes the warnings that log triage / `af bug-report` surface.

## Changes

- New `detachTracef` helper + `detachTraceEnabled()` gate in `tmux.go`; all seven `[detach-trace]` call sites routed through it.
- **Kept untouched**: the `"wg.Wait exceeded ...; SIGKILLing tmux attach-session"` WARN in `waitForAttachDrain` — that's a real event (the #601 backstop firing) and the signal the part-2 diagnosis is built on.

Net: a normal detach now produces **ZERO** routine WARN lines.

## Tests

`session/tmux/detach_trace_gate_test.go`:
- `TestDetach_NoTraceWarnByDefault` — default (unset) detach emits no `[detach-trace]` on WARN **or** INFO.
- `TestDetach_TraceGoesToInfoWhenEnabled` — `AF_DETACH_TRACE=1` restores the step markers on INFO, never WARN.
- `TestDetachTraceEnabled_ParsesEnv` — only `"1"` enables (matches `app.detachTraceEnabledFromEnv`).
- `TestDetachTracef_RespectsGate` — helper unit guard against a future refactor re-pointing it at WarningLog.

## Gates

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — empty
- `go build ./...` — clean
- `make test-container` — full suite green (incl. `session/tmux`)

## Scope

Part 2 of #1157 — the residual ~32% of detaches still hitting the 1s SIGKILL fallback — is **not** addressed here; it's diagnosed in a comment on #1157 and stays open until its fix lands. This PR does not close the issue.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
