### PR TITLE
fix(tmux): unblock detach io.Copy with a proactive SIGTERM (#1157 part 2)

### DIFF
--- a/session/tmux/detach_slow_test.go
+++ b/session/tmux/detach_slow_test.go
@@ -402,6 +402,169 @@ func TestDetach_BoundsWaitWhenKillAttachNilAndWgHangs(t *testing.T) {
 	}
 }
 
+// TestDetach_ProactiveSIGTERMUnblocksWithoutSIGKILL is the primary #1157
+// regression guard: when the attach child exits on a SIGTERM (the healthy
+// case — a well-behaved tmux client detaches and closes the slave PTY), the
+// detach must complete off the back of that proactive signal WITHOUT ever
+// falling to the 1s SIGKILL race that used to hang ~32% of detaches. We keep
+// wgWaitSigkillDeadline deliberately high (2s): if the proactive path
+// regressed and we fell through to the SIGKILL backstop, the elapsed
+// assertion below would blow past its ceiling and fail. The stub termAttach
+// stands in for "SIGTERM → client exits → slave closes → io.Copy returns" by
+// releasing the simulated io.Copy goroutine.
+func TestDetach_ProactiveSIGTERMUnblocksWithoutSIGKILL(t *testing.T) {
+	prevDeadline := wgWaitSigkillDeadline
+	wgWaitSigkillDeadline = 2 * time.Second
+	t.Cleanup(func() { wgWaitSigkillDeadline = prevDeadline })
+
+	session := newDrainableSession(t, "proactive-sigterm")
+
+	var termCalls, killCalls atomic.Int32
+	released := make(chan struct{})
+	session.termAttach = func() (int, error) {
+		termCalls.Add(1)
+		close(released) // SIGTERM lands → child exits → io.Copy returns
+		return 4321, nil
+	}
+	session.killAttach = func() (int, error) {
+		killCalls.Add(1)
+		return 0, nil
+	}
+
+	session.wg.Add(1)
+	go func() {
+		defer session.wg.Done()
+		<-released
+	}()
+
+	start := time.Now()
+	session.Detach()
+	elapsed := time.Since(start)
+
+	if got := termCalls.Load(); got != 1 {
+		t.Fatalf("expected the proactive SIGTERM to be sent exactly once; got %d", got)
+	}
+	if got := killCalls.Load(); got != 0 {
+		t.Fatalf("SIGKILL backstop must NOT fire when SIGTERM unblocks io.Copy; got %d kill calls", got)
+	}
+	// The whole point of the fix: no 1s race. A generous 500ms ceiling — far
+	// under the 2s wgWaitSigkillDeadline — proves the detach rode the SIGTERM,
+	// not the SIGKILL fallback.
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("proactive-SIGTERM detach took %v; expected sub-grace — io.Copy should unblock on SIGTERM, not the ~1s SIGKILL race", elapsed)
+	}
+}
+
+// TestDetach_FallsBackToSIGKILLWhenSIGTERMIgnored is the paired backstop
+// guard required for the most regression-prone file in the repo: the
+// proactive SIGTERM is an OPTIMISTIC first step, never a replacement for the
+// #601 SIGKILL fallback. Here the stub termAttach reports success but the
+// simulated client ignores the signal (never releases the io.Copy goroutine);
+// only SIGKILL unsticks it. The detach must still bound itself, escalate to
+// SIGKILL after the grace + deadline, and emit the SIGKILL WARN unchanged.
+func TestDetach_FallsBackToSIGKILLWhenSIGTERMIgnored(t *testing.T) {
+	prevGrace := proactiveGraceDeadline
+	proactiveGraceDeadline = 30 * time.Millisecond
+	t.Cleanup(func() { proactiveGraceDeadline = prevGrace })
+
+	prevDeadline := wgWaitSigkillDeadline
+	wgWaitSigkillDeadline = 50 * time.Millisecond
+	t.Cleanup(func() { wgWaitSigkillDeadline = prevDeadline })
+
+	prevWarn := aflog.WarningLog
+	var warnBuf bytes.Buffer
+	aflog.WarningLog = log.New(&warnBuf, "WARN: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = prevWarn })
+
+	session := newDrainableSession(t, "sigterm-ignored")
+
+	var termCalls, killCalls atomic.Int32
+	killed := make(chan struct{})
+	session.termAttach = func() (int, error) {
+		termCalls.Add(1)
+		return 4321, nil // SIGTERM sent, but the client ignores it — no release
+	}
+	session.killAttach = func() (int, error) {
+		killCalls.Add(1)
+		close(killed) // only SIGKILL unsticks the io.Copy goroutine
+		return 4321, nil
+	}
+
+	session.wg.Add(1)
+	go func() {
+		defer session.wg.Done()
+		select {
+		case <-killed:
+		case <-time.After(2 * time.Second):
+		}
+	}()
+
+	detachDone := make(chan struct{})
+	go func() {
+		session.Detach()
+		close(detachDone)
+	}()
+
+	select {
+	case <-detachDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Detach did not return — the SIGKILL backstop did not fire after SIGTERM was ignored")
+	}
+
+	if got := termCalls.Load(); got != 1 {
+		t.Fatalf("expected the proactive SIGTERM to be attempted once; got %d", got)
+	}
+	if got := killCalls.Load(); got != 1 {
+		t.Fatalf("expected the SIGKILL backstop to fire exactly once when SIGTERM is ignored; got %d", got)
+	}
+	if !strings.Contains(warnBuf.String(), "SIGKILLing tmux attach-session pid=4321") {
+		t.Fatalf("expected the #601 SIGKILL backstop WARN to still fire; got %q", warnBuf.String())
+	}
+}
+
+// TestDetach_TermAttachSurvivesNextDetach is the #602 pairing guard extended
+// to the new closure: just as killAttach must survive a Detach so the next
+// attach lifecycle inherits a working escape hatch, termAttach — set in the
+// same Restore and cleared at the same inline site — must be non-nil after
+// Detach returns. If a future refactor moved either clear back into the defer
+// (which runs AFTER Restore installs the fresh closures), this fails, exactly
+// as the 2026-05-20 51s-hang incident would have.
+func TestDetach_TermAttachSurvivesNextDetach(t *testing.T) {
+	prevSigkill := wgWaitSigkillDeadline
+	wgWaitSigkillDeadline = 500 * time.Millisecond
+	t.Cleanup(func() { wgWaitSigkillDeadline = prevSigkill })
+
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return nil, nil },
+	}
+
+	session := newTmuxSession(toTmuxName("termattach-survives", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+	if session.termAttach == nil {
+		t.Fatal("Restore should have set termAttach")
+	}
+	if session.killAttach == nil {
+		t.Fatal("Restore should have set killAttach")
+	}
+
+	session.attachCh = make(chan struct{})
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+
+	session.Detach()
+
+	if session.termAttach == nil {
+		t.Fatal("Detach's post-Restore state should leave termAttach non-nil — #602 pairing regression")
+	}
+	if session.killAttach == nil {
+		t.Fatal("Detach's post-Restore state should leave killAttach non-nil")
+	}
+}
+
 // TestKillTmuxAttachByName_KillsMatchingPids verifies the pgrep fallback
 // actually invokes the kill hook for every pid pgrep returns. This is the
 // "what happens after we find a stuck attach client" half of the safety

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -72,6 +72,15 @@ type TmuxSession struct {
 	// "why" — this is the defensive escape hatch for #598 when the tmux
 	// server is too contended to let the client exit on its own.
 	killAttach func() (int, error)
+
+	// termAttach SIGTERMs that same attach-session child. Detach() signals it
+	// proactively (SIGTERM → short grace → SIGKILL backstop) so io.Copy
+	// unblocks without a tmux-server round-trip, instead of racing the 1s
+	// SIGKILL deadline against the daemon's capture-pane poll — the #1157
+	// fix for the ~32% of detaches that used to stall the full second. Set
+	// and cleared in lockstep with killAttach (same pairing invariant that
+	// the #602 regression broke — see Detach's inline clear).
+	termAttach func() (int, error)
 }
 
 const TmuxPrefix = "af_"
@@ -104,6 +113,16 @@ var wgWaitSigkillDeadline = 1 * time.Second
 // fallback was missing. Set to 2× wgWaitSigkillDeadline so the total
 // worst-case detach is ~3s. var, not const, so tests can lower it.
 var wgWaitAbandonDeadline = 2 * time.Second
+
+// proactiveGraceDeadline bounds how long Detach() waits for the attach
+// goroutines to drain after a proactive SIGTERM (termAttach) before falling
+// through to waitForAttachDrain's SIGKILL backstop. Signalling the child
+// directly bypasses the tmux server, so a healthy client's io.Copy unblocks
+// within a scheduler tick or two; 150ms is generous headroom over that while
+// keeping a wedged detach an order of magnitude faster than the old 1s
+// wgWaitSigkillDeadline race against the daemon's capture-pane poll (#1157).
+// var, not const, so tests can lower it.
+var proactiveGraceDeadline = 150 * time.Millisecond
 
 // ErrSessionGone is returned by PTY/tmux operations when the underlying tmux
 // session no longer exists. Non-daemon callers (preview pane, sidebar resize,
@@ -400,6 +419,17 @@ func (t *TmuxSession) Restore(workDir string) error {
 		}
 		return attachCmd.Process.Pid, attachCmd.Process.Kill()
 	}
+	// termAttach is the gentle sibling Detach() reaches for first: a SIGTERM
+	// lets a well-behaved tmux client detach and exit cleanly, closing the
+	// slave PTY so io.Copy returns — all without touching the (possibly
+	// contended) tmux server. Paired with killAttach and the same ptmx so the
+	// #602 invariant holds: both are set here and cleared together.
+	t.termAttach = func() (int, error) {
+		if attachCmd.Process == nil {
+			return 0, errors.New("attach process not started")
+		}
+		return attachCmd.Process.Pid, attachCmd.Process.Signal(syscall.SIGTERM)
+	}
 	return nil
 }
 
@@ -430,6 +460,57 @@ func (t *TmuxSession) Restore(workDir string) error {
 // wg.Wait (Detach) can do so without re-measuring. On the abandon path
 // returns wgWaitAbandonDeadline (not the literal elapsed) so the caller's
 // slowDetachWgWaitThreshold check still fires cleanly.
+// proactiveDetachDrain SIGTERMs the attach-session child and waits up to
+// proactiveGraceDeadline for the attach goroutines (io.Copy + monitorWindowSize)
+// to drain. It returns the elapsed wait and whether the drain completed within
+// the grace.
+//
+// This is the #1157 fix. The old detach path closed the PTY master and then
+// waited for the child to notice and exit on its own — an exit that round-trips
+// through the shared tmux server. When the daemon's 1s capture-pane poll had
+// that server busy (~32% of the time), the round-trip lost the race and wg.Wait
+// ran the full wgWaitSigkillDeadline until the SIGKILL fallback fired. SIGTERM
+// goes straight to the child process, no server round-trip, so a well-behaved
+// client detaches and exits within a scheduler tick regardless of server load —
+// and, unlike an immediate SIGKILL, lets the client tear its terminal state
+// down cleanly first. The session survives a client death (Detach re-attaches
+// via Restore), so this is always safe.
+//
+// drained=false (SIGTERM ignored, child never started, or already gone) falls
+// through to waitForAttachDrain's unchanged SIGKILL → pgrep → abandon backstop,
+// so every existing #598/#601/#602 escape hatch stays behind this proactive
+// signal exactly as before.
+func (t *TmuxSession) proactiveDetachDrain() (time.Duration, bool) {
+	wg := t.wg
+	if wg == nil {
+		// Nothing was attached; there's nothing to drain.
+		return 0, true
+	}
+	start := time.Now()
+	if t.termAttach == nil {
+		// No recorded child to signal — let the backstop handle it.
+		return 0, false
+	}
+	if _, err := t.termAttach(); err != nil {
+		// Child never started or already exited; nothing to unblock.
+		return 0, false
+	}
+	waitDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+		return time.Since(start), true
+	case <-time.After(proactiveGraceDeadline):
+		// SIGTERM didn't unblock io.Copy in time. The wg.Wait goroutine
+		// above stays parked until the SIGKILL backstop drains wg — a
+		// transient, self-completing goroutine, not the abandon-path leak.
+		return time.Since(start), false
+	}
+}
+
 func (t *TmuxSession) waitForAttachDrain() time.Duration {
 	// Capture the WaitGroup pointer locally so the helper goroutine below
 	// doesn't race against the Detach/Close defer that nils t.wg after
@@ -885,7 +966,15 @@ func (t *TmuxSession) Detach() {
 	// those reads (#512). waitForAttachDrain bounds the wait by SIGKILLing
 	// the attach-session child if wg.Wait exceeds wgWaitSigkillDeadline —
 	// see #598 follow-up for the diagnosis.
-	waitElapsed := t.waitForAttachDrain()
+	// Proactively SIGTERM the attach child so io.Copy unblocks without a
+	// tmux-server round-trip (#1157). On a healthy client this drains within
+	// the grace and we never touch the SIGKILL path; a client that ignores
+	// SIGTERM falls through to waitForAttachDrain's unchanged
+	// SIGKILL → pgrep → abandon backstop.
+	waitElapsed, drained := t.proactiveDetachDrain()
+	if !drained {
+		waitElapsed = t.waitForAttachDrain()
+	}
 	detachTracef("tmux.Detach-wg.Wait-done name=%s elapsed=%v", t.sanitizedName, waitElapsed)
 	// Defense-in-depth: if wg.Wait still exceeded the slow threshold after
 	// the SIGKILL fallback ran, that means killAttach didn't unstick the
@@ -901,13 +990,16 @@ func (t *TmuxSession) Detach() {
 	// means a Restore failure (or a Close failure) can't leave the closed
 	// handle dangling on the struct — a subsequent Attach would otherwise
 	// silently bind goroutines to a closed file and hang (#464).
-	// Pair the clear with t.killAttach: the closure references the dying
-	// attachCmd whose process is being torn down, so it must not survive
-	// past this point. Restore() below will assign both fields together
-	// for the next attach lifecycle; this is the invariant the #598
-	// follow-up regression broke.
+	// Pair the clear with t.killAttach AND t.termAttach: both closures
+	// reference the dying attachCmd whose process is being torn down, so
+	// neither must survive past this point. Restore() below reassigns all
+	// three fields together for the next attach lifecycle; this is the
+	// invariant the #598 follow-up regression broke — clearing here (before
+	// Restore), never in the defer (which runs after Restore), is what keeps
+	// the fresh closures alive (#602).
 	t.ptmx = nil
 	t.killAttach = nil
+	t.termAttach = nil
 
 	if closeErr != nil {
 		log.ErrorLog.Printf("error closing attach pty session: %v", closeErr)
@@ -956,6 +1048,7 @@ func (t *TmuxSession) Close() error {
 	t.ptmx = nil
 	t.ctx = nil
 	t.killAttach = nil
+	t.termAttach = nil
 
 	if t.attachCh != nil {
 		close(t.attachCh)
@@ -1049,6 +1142,7 @@ func (t *TmuxSession) CloseAttachOnly() error {
 	t.ptmx = nil
 	t.ctx = nil
 	t.killAttach = nil
+	t.termAttach = nil
 
 	if t.attachCh != nil {
 		close(t.attachCh)


### PR DESCRIPTION
Part 2 of #1157 — the structural fix for the residual detach hang. **Closes #1157.**

> **Stacked on #1158** (Part 1, the trace gating). Base is `siyer/fix-1157-detach` so this diff shows only Fix B; both touch `session/tmux/tmux.go`, so merge #1158 first — GitHub will auto-retarget this to `master`.

## The residual #598 hang (diagnosed on #1157)

The #599 trace showed **32% of detaches still stall the full 1s** `wgWaitSigkillDeadline` until the #601 SIGKILL forces `io.Copy` to return — #598 was **masked** by the force-kill, not fixed.

**Root cause:** the detach-key handler consumes the key locally and calls `Detach()` directly — it never asks the tmux client to detach. `Detach()` closes the PTY **master**, but that doesn't wake the blocking `io.Copy` Read (only the **slave** closing does, i.e. the `tmux attach-session` child exiting). The child's exit round-trips the shared tmux server, which the daemon's `capture-pane` poll hammers every `DaemonPollInterval` (**1000 ms** default). When a detach loses that race, `wg.Wait` runs the full second. The 1s deadline coinciding with the 1s daemon cadence is the tell.

## The fix: signal the child directly (no server round-trip)

Add a `termAttach` closure (SIGTERM of `attachCmd.Process`) — the gentle sibling of the existing `killAttach` (SIGKILL). After `cancel()` + `ptmx.Close()`, `Detach()` now proactively SIGTERMs the child and waits up to `proactiveGraceDeadline` (**150 ms**) for the goroutines to drain. Signalling the process **bypasses the tmux server**, so a well-behaved client detaches within a scheduler tick regardless of server load — collapsing the 32%×1s to ~ms. SIGTERM (not immediate SIGKILL) lets the client tear terminal state down cleanly; the session survives a client death (Detach re-attaches via Restore), so it's always safe.

## Backstops fully intact (non-negotiable, per root)

A client that ignores SIGTERM falls straight through to the **unchanged** `waitForAttachDrain`: 1s `wgWaitSigkillDeadline` → SIGKILL → pgrep fallback → abandon-and-leak. Every #598/#601/#602 escape hatch stays behind the proactive signal. `termAttach` is set in `Restore` and cleared **in lockstep with `killAttach`** at the inline pre-Restore site in Detach (and in Close/CloseAttachOnly) — preserving the #602 pairing invariant that the 2026-05-20 51s hang broke.

## Tests (extending `detach_slow_test.go`, per root's requirements)

| Test | Proves |
|------|--------|
| `TestDetach_ProactiveSIGTERMUnblocksWithoutSIGKILL` | contention-detach drops from ~1s to sub-grace (<1ms in CI, `wgWaitSigkillDeadline` held at 2s), and the SIGKILL backstop is **never** called |
| `TestDetach_FallsBackToSIGKILLWhenSIGTERMIgnored` | a client ignoring SIGTERM still escalates to SIGKILL and emits its WARN — backstop fires |
| `TestDetach_TermAttachSurvivesNextDetach` | #602 pairing guard extended to `termAttach`: non-nil after Detach, never nil'd in the defer |

The pre-existing `TestDetach_SIGKILLsAttachOnSlowWgWait` (termAttach unset) also now exercises the SIGTERM-absent fallback unchanged.

## Container play-test of the REAL path

Private tmux, `bash` instances: full-screen attach → **Ctrl-W detach → back to sidebar in <100 ms** (no 1s stall) → tmux session **survives** → marker history **persists** across attach→detach→re-attach → attach-client count **stable** (no orphan leak). Log shows **zero** `detach-trace`, **zero** `SIGKILLing tmux attach-session`, **zero** slow `wg.Wait` — the proactive SIGTERM handled every detach without the backstop.

## Gates

`golangci-lint --fast` clean · `gofmt -l .` empty · `go build ./...` clean · `make test-container` full suite green · `-race` clean on the detach suite.

## Follow-up (not folded in)

Fix A — pause the daemon's `capture-pane` poll for the detaching instance via RPC (extends #600 into the daemon) — will be filed as a separate responsiveness issue once this lands.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
