### PR TITLE
fix(daemon): pause per-instance capture-pane poll while a TUI is attached (#1160)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1294,13 +1294,22 @@ var attachOverlayCallbackFn = (*home).attachOverlayCallback
 // terminal-tab) all funnel through one place — and so the pause-while-attached
 // gating + the flag-clears-on-error path are testable without spinning up
 // real tmux.
-func (m *home) attachOverlayCallback(label, traceSuffix string, remote bool, attach func() (chan struct{}, error)) tea.Cmd {
+func (m *home) attachOverlayCallback(title, label, traceSuffix string, remote bool, attach func() (chan struct{}, error)) tea.Cmd {
 	detachTraceMark(label + "-onDismiss-entry" + traceSuffix)
 	ch, err := attach()
 	if err != nil {
 		log.ErrorLog.Printf("failed to attach (%s): %v", label+traceSuffix, err)
 		return nil
 	}
+
+	// While we hold the shared tmux server full-screen, ask the daemon to pause
+	// its per-instance capture-pane liveness poll for THIS instance so it stops
+	// contending with the live attach (#1160, Fix A follow-up to #1157). A
+	// heartbeat renews the daemon's lease-bounded pause until detach; the pause
+	// is best-effort so a down/slow daemon never disturbs the attach.
+	pauseDone := make(chan struct{})
+	go m.runStatusPollPauseHeartbeat(title, pauseDone)
+
 	m.attached.Store(true)
 	defer m.attached.Store(false)
 	// <-ch blocks for as long as the user is attached. Mark the boundary so
@@ -1308,6 +1317,12 @@ func (m *home) attachOverlayCallback(label, traceSuffix string, remote bool, att
 	// actually returned to the UI, not from when the attach started.
 	detachTraceMark(label + "-blocking-on-<-ch" + traceSuffix)
 	<-ch
+	// Stop the heartbeat and resume the daemon's poll immediately on this clean
+	// detach — don't wait out the lease. Fire-and-forget: the detach hot path
+	// must never block on an RPC (attach/detach responsiveness is the whole
+	// point of #1160).
+	close(pauseDone)
+	m.resumeStatusPoll(title)
 	detachStart := time.Now()
 	detachTraceMark(label + "-<-ch-unblocked" + traceSuffix)
 	m.state = stateDefault
@@ -1331,6 +1346,50 @@ func (m *home) attachOverlayCallback(label, traceSuffix string, remote bool, att
 		return tea.Sequence(tea.ClearScreen, repaintCmd)
 	}
 	return repaintCmd
+}
+
+// statusPollRenewInterval is how often an attached TUI re-sends PauseStatusPoll
+// to renew the daemon's lease-bounded pause (#1160). It MUST stay below the
+// daemon's statusPollLease (3s) so a live attach never lets the lease lapse and
+// let the daemon's capture-pane poll resume mid-attach; 1s against a 3s lease
+// leaves two missed renews of slack for a hiccuping daemon.
+const statusPollRenewInterval = 1 * time.Second
+
+// runStatusPollPauseHeartbeat pauses the daemon's capture-pane poll for the
+// attached instance and renews that lease every statusPollRenewInterval until
+// done closes (detach). It runs on its own goroutine so a slow Pause RPC never
+// blocks the attach/detach hot path, and every RPC is best-effort — a down or
+// slow daemon logs and continues, never disturbing the attach (the worst case
+// is the daemon keeps polling, exactly the pre-#1160 behavior).
+func (m *home) runStatusPollPauseHeartbeat(title string, done <-chan struct{}) {
+	pause := func() {
+		if err := pauseStatusPollThroughDaemon(title, m.repoID); err != nil {
+			log.ErrorLog.Printf("failed to pause daemon status poll for %q: %v", title, err)
+		}
+	}
+	pause() // pause immediately on attach, before the first renew tick
+	ticker := time.NewTicker(statusPollRenewInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			pause()
+		}
+	}
+}
+
+// resumeStatusPoll clears the daemon's pause for the detached instance so its
+// capture-pane poll resumes immediately rather than after the lease expires
+// (#1160). Fire-and-forget on its own goroutine and best-effort: the detach hot
+// path must never block on this RPC.
+func (m *home) resumeStatusPoll(title string) {
+	go func() {
+		if err := resumeStatusPollThroughDaemon(title, m.repoID); err != nil {
+			log.ErrorLog.Printf("failed to resume daemon status poll for %q: %v", title, err)
+		}
+	}()
 }
 
 // selectionChanged updates the selection binding and menu based on the

--- a/app/app.go
+++ b/app/app.go
@@ -88,6 +88,17 @@ type home struct {
 	// so there is no cross-test shared state to race. Defaults to
 	// snapshotThroughDaemon in production; tests assign a fake directly.
 	snapshotFetcher func(repoID string) ([]session.InstanceData, error)
+	// pauseStatusPoll / resumeStatusPoll are the daemon poll-pause seams for the
+	// attach heartbeat (#1160). PER-home fields, not package globals, for the
+	// same reason as snapshotFetcher: the heartbeat reads the seam from an
+	// off-loop goroutine, so a shared mutable global swapped by a test would race
+	// that goroutine against a sibling test's swap under `go test -parallel
+	// -race` (the #964 / #960-PR4 snapshot-fetcher race). Each home owns its
+	// seams; the goroutine captures them into locals at spawn so it never touches
+	// shared home state mid-flight. Default to pauseStatusPollThroughDaemon /
+	// resumeStatusPollThroughDaemon in production; tests assign fakes directly.
+	pauseStatusPoll  func(title, repoID string) error
+	resumeStatusPoll func(title, repoID string) error
 	// appConfig stores persistent application configuration
 	appConfig *config.Config
 	// appState stores persistent application state like seen help screens
@@ -282,27 +293,29 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 	errBox := ui.NewErrBox()
 
 	h := &home{
-		ctx:             ctx,
-		spinner:         spinner.New(spinner.WithSpinner(spinner.MiniDot)),
-		store:           proj,
-		menu:            menu,
-		errBox:          errBox,
-		paneWindows:     make(map[int]*ui.TabbedWindow),
-		lastPaneCapture: make(map[int]time.Time),
-		automations:     ui.NewAutomationsPane(proj),
-		statusBar:       ui.NewStatusBar(menu, errBox),
-		hooksPane:       ui.NewHooksPane(),
-		ring:            layout.NewRing(layout.RegionTree, layout.RegionAutomations),
-		zones:           zones.NewRegistry(),
-		mouseClock:      time.Now,
-		snapshotFetcher: snapshotThroughDaemon,
-		appConfig:       appConfig,
-		program:         program,
-		autoYes:         autoYes,
-		repoID:          repoID,
-		repoRoot:        repo.Root,
-		state:           stateDefault,
-		appState:        appState,
+		ctx:              ctx,
+		spinner:          spinner.New(spinner.WithSpinner(spinner.MiniDot)),
+		store:            proj,
+		menu:             menu,
+		errBox:           errBox,
+		paneWindows:      make(map[int]*ui.TabbedWindow),
+		lastPaneCapture:  make(map[int]time.Time),
+		automations:      ui.NewAutomationsPane(proj),
+		statusBar:        ui.NewStatusBar(menu, errBox),
+		hooksPane:        ui.NewHooksPane(),
+		ring:             layout.NewRing(layout.RegionTree, layout.RegionAutomations),
+		zones:            zones.NewRegistry(),
+		mouseClock:       time.Now,
+		snapshotFetcher:  snapshotThroughDaemon,
+		pauseStatusPoll:  pauseStatusPollThroughDaemon,
+		resumeStatusPoll: resumeStatusPollThroughDaemon,
+		appConfig:        appConfig,
+		program:          program,
+		autoYes:          autoYes,
+		repoID:           repoID,
+		repoRoot:         repo.Root,
+		state:            stateDefault,
+		appState:         appState,
 	}
 	h.sidebar = ui.NewSidebar(&h.spinner, autoYes, proj)
 	h.wireZoneRegistry()
@@ -1307,8 +1320,17 @@ func (m *home) attachOverlayCallback(title, label, traceSuffix string, remote bo
 	// contending with the live attach (#1160, Fix A follow-up to #1157). A
 	// heartbeat renews the daemon's lease-bounded pause until detach; the pause
 	// is best-effort so a down/slow daemon never disturbs the attach.
+	//
+	// Capture the seams + repoID off the home HERE, on the event loop, before
+	// any goroutine spawns: the seams are per-home fields (not shared globals)
+	// precisely so the goroutines never read home state a sibling test could
+	// reassign under `go test -parallel -race` (the #964 / #960-PR4 race class).
+	pause := m.pauseStatusPoll
+	resume := m.resumeStatusPoll
+	repoID := m.repoID
 	pauseDone := make(chan struct{})
-	go m.runStatusPollPauseHeartbeat(title, pauseDone)
+	heartbeatExited := make(chan struct{})
+	go runStatusPollPauseHeartbeat(pause, title, repoID, pauseDone, heartbeatExited)
 
 	m.attached.Store(true)
 	defer m.attached.Store(false)
@@ -1318,11 +1340,17 @@ func (m *home) attachOverlayCallback(title, label, traceSuffix string, remote bo
 	detachTraceMark(label + "-blocking-on-<-ch" + traceSuffix)
 	<-ch
 	// Stop the heartbeat and resume the daemon's poll immediately on this clean
-	// detach — don't wait out the lease. Fire-and-forget: the detach hot path
-	// must never block on an RPC (attach/detach responsiveness is the whole
-	// point of #1160).
+	// detach — don't wait out the lease. The resume must WIN over any in-flight
+	// pause: both were fire-and-forget, so a naive resume could land on the wire
+	// before the heartbeat's last pause() and leave the instance paused until the
+	// lease expires (Greptile P). runStatusPollResume waits for heartbeatExited
+	// (the heartbeat closes it after its final synchronous pause() returns — and
+	// callDaemon blocks until the daemon has applied that pause) so the resume
+	// strictly follows it. This runs on its OWN goroutine so the detach hot path
+	// never blocks on the wait or the RPC — attach/detach responsiveness is the
+	// whole point of #1160.
 	close(pauseDone)
-	m.resumeStatusPoll(title)
+	go runStatusPollResume(resume, title, repoID, heartbeatExited)
 	detachStart := time.Now()
 	detachTraceMark(label + "-<-ch-unblocked" + traceSuffix)
 	m.state = stateDefault
@@ -1357,17 +1385,21 @@ const statusPollRenewInterval = 1 * time.Second
 
 // runStatusPollPauseHeartbeat pauses the daemon's capture-pane poll for the
 // attached instance and renews that lease every statusPollRenewInterval until
-// done closes (detach). It runs on its own goroutine so a slow Pause RPC never
-// blocks the attach/detach hot path, and every RPC is best-effort — a down or
-// slow daemon logs and continues, never disturbing the attach (the worst case
-// is the daemon keeps polling, exactly the pre-#1160 behavior).
-func (m *home) runStatusPollPauseHeartbeat(title string, done <-chan struct{}) {
-	pause := func() {
-		if err := pauseStatusPollThroughDaemon(title, m.repoID); err != nil {
+// done closes (detach), then closes exited. pause + repoID are captured off the
+// event loop by the caller so this goroutine never touches shared home state
+// (#964 race class). Every RPC is best-effort — a down/slow daemon logs and
+// continues, never disturbing the attach (worst case the daemon keeps polling,
+// the pre-#1160 behavior). Because pause() is called SYNCHRONOUSLY in the loop,
+// once this goroutine returns no pause RPC is in-flight or pending, so exited
+// firing is the signal a following resume can safely win the wire.
+func runStatusPollPauseHeartbeat(pause func(title, repoID string) error, title, repoID string, done <-chan struct{}, exited chan<- struct{}) {
+	defer close(exited)
+	send := func() {
+		if err := pause(title, repoID); err != nil {
 			log.ErrorLog.Printf("failed to pause daemon status poll for %q: %v", title, err)
 		}
 	}
-	pause() // pause immediately on attach, before the first renew tick
+	send() // pause immediately on attach, before the first renew tick
 	ticker := time.NewTicker(statusPollRenewInterval)
 	defer ticker.Stop()
 	for {
@@ -1375,21 +1407,23 @@ func (m *home) runStatusPollPauseHeartbeat(title string, done <-chan struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
-			pause()
+			send()
 		}
 	}
 }
 
-// resumeStatusPoll clears the daemon's pause for the detached instance so its
-// capture-pane poll resumes immediately rather than after the lease expires
-// (#1160). Fire-and-forget on its own goroutine and best-effort: the detach hot
-// path must never block on this RPC.
-func (m *home) resumeStatusPoll(title string) {
-	go func() {
-		if err := resumeStatusPollThroughDaemon(title, m.repoID); err != nil {
-			log.ErrorLog.Printf("failed to resume daemon status poll for %q: %v", title, err)
-		}
-	}()
+// runStatusPollResume resumes the daemon's poll on a clean detach so the poll
+// resumes immediately rather than after the lease expires (#1160). It waits for
+// heartbeatExited FIRST so the resume RPC strictly follows the heartbeat's final
+// pause() — guaranteeing resume wins over any in-flight pause instead of racing
+// it (Greptile P). resume + repoID are captured off the event loop by the
+// caller (#964 race class). Best-effort; the caller runs this on its own
+// goroutine so the detach hot path never blocks on the wait or the RPC.
+func runStatusPollResume(resume func(title, repoID string) error, title, repoID string, heartbeatExited <-chan struct{}) {
+	<-heartbeatExited
+	if err := resume(title, repoID); err != nil {
+		log.ErrorLog.Printf("failed to resume daemon status poll for %q: %v", title, err)
+	}
 }
 
 // selectionChanged updates the selection binding and menu based on the

--- a/app/attached_pause_test.go
+++ b/app/attached_pause_test.go
@@ -104,7 +104,6 @@ func TestTickUpdatePRInfo_PausedWhileAttached(t *testing.T) {
 // two.
 func TestAttachOverlayCallback_ClearsFlagOnDetach(t *testing.T) {
 	h := newTestHome(t)
-	stubStatusPollPause(t)
 	require.False(t, h.attached.Load(), "test pre-condition: not attached")
 
 	ch := make(chan struct{})
@@ -158,24 +157,12 @@ func TestAttachOverlayCallback_LeavesFlagAloneWhenAttachErrors(t *testing.T) {
 			"metadata tick (#598 regression-risk path)")
 }
 
-// stubStatusPollPause swaps the #1160 daemon pause/resume seams with no-ops so
-// a test that drives attachOverlayCallback's heartbeat never reaches the real
-// callDaemon → EnsureDaemon (which would spawn a daemon on this box). Registers
-// its own t.Cleanup.
-func stubStatusPollPause(t *testing.T) {
-	t.Helper()
-	restore := SetPauseResumeStatusPollForTest(
-		func(string, string) error { return nil },
-		func(string, string) error { return nil },
-	)
-	t.Cleanup(restore)
-}
-
 // TestAttachOverlayCallback_PausesAndResumesDaemonPoll is the #1160 TUI-side
 // guard: while attached full-screen the callback must RPC the daemon to pause
 // this instance's capture-pane poll (before the user is blocked on <-ch), and
-// on detach it must resume it. The pause/resume seams are swapped with
-// recorders so no real daemon is contacted.
+// on detach it must resume it. The pause/resume seams are per-home fields (not
+// shared globals — the #964 race-fix), so the recorders are assigned directly
+// on the model under test and no real daemon is contacted.
 func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
 	h := newTestHome(t)
 
@@ -183,27 +170,24 @@ func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
 	var pausedTitle, resumedTitle string
 	var pauseCount, resumeCount int
 	pausedNow := make(chan struct{}, 1)
-	restore := SetPauseResumeStatusPollForTest(
-		func(title, _ string) error {
-			mu.Lock()
-			pausedTitle = title
-			pauseCount++
-			mu.Unlock()
-			select {
-			case pausedNow <- struct{}{}:
-			default:
-			}
-			return nil
-		},
-		func(title, _ string) error {
-			mu.Lock()
-			resumedTitle = title
-			resumeCount++
-			mu.Unlock()
-			return nil
-		},
-	)
-	defer restore()
+	h.pauseStatusPoll = func(title, _ string) error {
+		mu.Lock()
+		pausedTitle = title
+		pauseCount++
+		mu.Unlock()
+		select {
+		case pausedNow <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+	h.resumeStatusPoll = func(title, _ string) error {
+		mu.Lock()
+		resumedTitle = title
+		resumeCount++
+		mu.Unlock()
+		return nil
+	}
 
 	ch := make(chan struct{})
 	attach := func() (chan struct{}, error) { return ch, nil }
@@ -244,16 +228,98 @@ func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
 	endDetachWatchdog()
 }
 
+// TestAttachOverlayCallback_ResumeOrderedAfterLastPause is the Greptile-P guard:
+// on a clean detach the resume RPC must land strictly AFTER the heartbeat's
+// final pause, never race ahead of it (which would leave the instance paused
+// until the lease expires). The pause seam blocks on a gate the test releases
+// only after detach, so if resume were NOT ordered after the heartbeat it would
+// be recorded before the (still-blocked) final pause. We assert the recorded
+// call order ends with "resume" and that no resume is ever observed before the
+// final pause returns. Deterministic — gated on channels, not sleeps.
+func TestAttachOverlayCallback_ResumeOrderedAfterLastPause(t *testing.T) {
+	h := newTestHome(t)
+
+	var mu sync.Mutex
+	var order []string
+	pauseEntered := make(chan struct{}, 1)
+	releasePause := make(chan struct{})
+	firstPause := true
+
+	h.pauseStatusPoll = func(_, _ string) error {
+		// Only gate the FIRST pause (the on-attach one) so the test can hold a
+		// pause RPC "in flight" across the detach and prove resume waits for it.
+		mu.Lock()
+		gate := firstPause
+		firstPause = false
+		mu.Unlock()
+		if gate {
+			select {
+			case pauseEntered <- struct{}{}:
+			default:
+			}
+			<-releasePause // stay in-flight until the test releases us
+		}
+		mu.Lock()
+		order = append(order, "pause")
+		mu.Unlock()
+		return nil
+	}
+	h.resumeStatusPoll = func(_, _ string) error {
+		mu.Lock()
+		order = append(order, "resume")
+		mu.Unlock()
+		return nil
+	}
+
+	ch := make(chan struct{})
+	attach := func() (chan struct{}, error) { return ch, nil }
+	done := make(chan tea.Cmd, 1)
+	go func() {
+		done <- h.attachOverlayCallback("alpha", "test-attach", "", false, attach)
+	}()
+
+	// Wait until the on-attach pause is in-flight (blocked on releasePause).
+	select {
+	case <-pauseEntered:
+	case <-time.After(time.Second):
+		t.Fatal("on-attach pause never fired")
+	}
+
+	// Detach while that pause is still in-flight. The callback returns without
+	// blocking; the resume goroutine must WAIT for the heartbeat (and thus the
+	// in-flight pause) to finish before resuming.
+	close(ch)
+	<-done
+
+	// Nothing should be recorded yet — the pause is still gated, so resume must
+	// not have jumped ahead.
+	mu.Lock()
+	require.Empty(t, order, "resume must not fire before the in-flight pause completes")
+	mu.Unlock()
+
+	// Release the pause; now the heartbeat exits and resume runs after it.
+	close(releasePause)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(order) >= 2
+	}, time.Second, time.Millisecond, "both pause and resume must eventually be recorded")
+
+	mu.Lock()
+	require.Equal(t, []string{"pause", "resume"}, order,
+		"resume must be ordered strictly AFTER the heartbeat's final pause on a clean detach")
+	mu.Unlock()
+	endDetachWatchdog()
+}
+
 // TestAttachOverlayCallback_AttachSucceedsWhenPauseErrors proves the best-effort
 // property: a failing Pause RPC (daemon down) must NOT break the attach — the
 // callback still returns the repaint cmd and clears m.attached via its defer.
 func TestAttachOverlayCallback_AttachSucceedsWhenPauseErrors(t *testing.T) {
 	h := newTestHome(t)
-	restore := SetPauseResumeStatusPollForTest(
-		func(string, string) error { return errors.New("daemon down") },
-		func(string, string) error { return errors.New("daemon down") },
-	)
-	defer restore()
+	h.pauseStatusPoll = func(string, string) error { return errors.New("daemon down") }
+	h.resumeStatusPoll = func(string, string) error { return errors.New("daemon down") }
 
 	ch := make(chan struct{})
 	attach := func() (chan struct{}, error) { return ch, nil }

--- a/app/attached_pause_test.go
+++ b/app/attached_pause_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -103,6 +104,7 @@ func TestTickUpdatePRInfo_PausedWhileAttached(t *testing.T) {
 // two.
 func TestAttachOverlayCallback_ClearsFlagOnDetach(t *testing.T) {
 	h := newTestHome(t)
+	stubStatusPollPause(t)
 	require.False(t, h.attached.Load(), "test pre-condition: not attached")
 
 	ch := make(chan struct{})
@@ -110,7 +112,7 @@ func TestAttachOverlayCallback_ClearsFlagOnDetach(t *testing.T) {
 
 	done := make(chan tea.Cmd, 1)
 	go func() {
-		done <- h.attachOverlayCallback("test-attach", " title=t1", false, attach)
+		done <- h.attachOverlayCallback("t1", "test-attach", " title=t1", false, attach)
 	}()
 
 	// While the callback is blocked on <-ch the flag must be set.
@@ -147,13 +149,133 @@ func TestAttachOverlayCallback_LeavesFlagAloneWhenAttachErrors(t *testing.T) {
 	attachErr := errors.New("simulated attach failure")
 	attach := func() (chan struct{}, error) { return nil, attachErr }
 
-	cmd := h.attachOverlayCallback("test-attach", "", false, attach)
+	cmd := h.attachOverlayCallback("t1", "test-attach", "", false, attach)
 
 	assert.Nil(t, cmd, "attachOverlayCallback must return nil when attach fails")
 	assert.False(t, h.attached.Load(),
 		"attached flag must NOT be set when attach itself errors — "+
 			"otherwise a single failed attach permanently disables the "+
 			"metadata tick (#598 regression-risk path)")
+}
+
+// stubStatusPollPause swaps the #1160 daemon pause/resume seams with no-ops so
+// a test that drives attachOverlayCallback's heartbeat never reaches the real
+// callDaemon → EnsureDaemon (which would spawn a daemon on this box). Registers
+// its own t.Cleanup.
+func stubStatusPollPause(t *testing.T) {
+	t.Helper()
+	restore := SetPauseResumeStatusPollForTest(
+		func(string, string) error { return nil },
+		func(string, string) error { return nil },
+	)
+	t.Cleanup(restore)
+}
+
+// TestAttachOverlayCallback_PausesAndResumesDaemonPoll is the #1160 TUI-side
+// guard: while attached full-screen the callback must RPC the daemon to pause
+// this instance's capture-pane poll (before the user is blocked on <-ch), and
+// on detach it must resume it. The pause/resume seams are swapped with
+// recorders so no real daemon is contacted.
+func TestAttachOverlayCallback_PausesAndResumesDaemonPoll(t *testing.T) {
+	h := newTestHome(t)
+
+	var mu sync.Mutex
+	var pausedTitle, resumedTitle string
+	var pauseCount, resumeCount int
+	pausedNow := make(chan struct{}, 1)
+	restore := SetPauseResumeStatusPollForTest(
+		func(title, _ string) error {
+			mu.Lock()
+			pausedTitle = title
+			pauseCount++
+			mu.Unlock()
+			select {
+			case pausedNow <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+		func(title, _ string) error {
+			mu.Lock()
+			resumedTitle = title
+			resumeCount++
+			mu.Unlock()
+			return nil
+		},
+	)
+	defer restore()
+
+	ch := make(chan struct{})
+	attach := func() (chan struct{}, error) { return ch, nil }
+
+	done := make(chan tea.Cmd, 1)
+	go func() {
+		done <- h.attachOverlayCallback("alpha", "test-attach", "", false, attach)
+	}()
+
+	// The pause must fire while the user is still attached — i.e. before we
+	// close ch to simulate detach.
+	select {
+	case <-pausedNow:
+	case <-time.After(time.Second):
+		t.Fatal("PauseStatusPoll was not called before detach — the daemon poll must pause on attach")
+	}
+	mu.Lock()
+	require.Equal(t, "alpha", pausedTitle, "pause must target the attached instance's title")
+	require.Positive(t, pauseCount, "pause must fire on attach")
+	require.Zero(t, resumeCount, "resume must not fire while still attached")
+	mu.Unlock()
+
+	// Simulate detach.
+	close(ch)
+	<-done
+
+	// Resume is fire-and-forget on a goroutine, so poll for it.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return resumeCount > 0
+	}, time.Second, time.Millisecond, "ResumeStatusPoll must fire on detach")
+	mu.Lock()
+	assert.Equal(t, "alpha", resumedTitle, "resume must target the detached instance's title")
+	mu.Unlock()
+
+	require.False(t, h.attached.Load(), "attached flag must clear on detach")
+	endDetachWatchdog()
+}
+
+// TestAttachOverlayCallback_AttachSucceedsWhenPauseErrors proves the best-effort
+// property: a failing Pause RPC (daemon down) must NOT break the attach — the
+// callback still returns the repaint cmd and clears m.attached via its defer.
+func TestAttachOverlayCallback_AttachSucceedsWhenPauseErrors(t *testing.T) {
+	h := newTestHome(t)
+	restore := SetPauseResumeStatusPollForTest(
+		func(string, string) error { return errors.New("daemon down") },
+		func(string, string) error { return errors.New("daemon down") },
+	)
+	defer restore()
+
+	ch := make(chan struct{})
+	attach := func() (chan struct{}, error) { return ch, nil }
+
+	done := make(chan tea.Cmd, 1)
+	go func() {
+		done <- h.attachOverlayCallback("alpha", "test-attach", "", false, attach)
+	}()
+
+	require.Eventually(t, func() bool { return h.attached.Load() },
+		time.Second, time.Millisecond, "attached flag must arm even when the pause RPC errors")
+
+	close(ch)
+	cmd := <-done
+
+	require.NotNil(t, cmd, "attach must still return the repaint cmd despite a pause RPC error")
+	msg := cmd()
+	_, ok := msg.(repaintAfterDetachMsg)
+	assert.True(t, ok, "post-detach cmd must emit repaintAfterDetachMsg, got %T", msg)
+	require.False(t, h.attached.Load(),
+		"attached flag must clear on detach even when the pause/resume RPCs error (best-effort)")
+	endDetachWatchdog()
 }
 
 // drainCmd runs cmd (and any nested tea.Cmd it produces via tea.Batch) up

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -86,9 +86,16 @@ func newTestHome(t *testing.T) *home {
 		snapshotFetcher: func(string) ([]session.InstanceData, error) {
 			return nil, fmt.Errorf("snapshot fetcher not stubbed in test")
 		},
-		store:   proj,
-		spinner: spin,
-		repoID:  repoID,
+		// Default the #1160 poll-pause seams to no-ops so a test that incidentally
+		// drives the attach heartbeat never dials — or spawns — a real daemon.
+		// Per-home fields (not shared globals), so parallel tests can't race each
+		// other's swaps; tests exercising the pause/resume path assign their own
+		// recorders to h.pauseStatusPoll / h.resumeStatusPoll.
+		pauseStatusPoll:  func(string, string) error { return nil },
+		resumeStatusPoll: func(string, string) error { return nil },
+		store:            proj,
+		spinner:          spin,
+		repoID:           repoID,
 	}
 	h.sidebar = ui.NewSidebar(&h.spinner, false, proj)
 	wireTestPanes(h, proj)

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -376,13 +376,13 @@ func (m *home) attachSelected(selected *session.Instance) (tea.Model, tea.Cmd) {
 		// selection — or the user could change tabs while the help overlay is
 		// open — before the deferred attach callback runs.
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-			return attachOverlayCallbackFn(m, "handleEnter-terminal", "", selected.IsRemote(), func() (chan struct{}, error) {
+			return attachOverlayCallbackFn(m, selected.Title, "handleEnter-terminal", "", selected.IsRemote(), func() (chan struct{}, error) {
 				return ui.AttachTerminalTab(selected, activeTab)
 			})
 		})
 	}
 	return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-		return attachOverlayCallbackFn(m, "handleEnter-sidebar", "", selected.IsRemote(), func() (chan struct{}, error) {
+		return attachOverlayCallbackFn(m, selected.Title, "handleEnter-sidebar", "", selected.IsRemote(), func() (chan struct{}, error) {
 			return m.store.AttachInstance(selected)
 		})
 	})

--- a/app/handle_enter_remote_terminal_test.go
+++ b/app/handle_enter_remote_terminal_test.go
@@ -27,7 +27,7 @@ func (remoteFakeBackend) Type() string { return "remote" }
 // that detaches immediately (a pre-closed channel), so the real post-detach
 // lifecycle runs synchronously without a tmux client or a remote terminal_cmd
 // PTY.
-func swapAttachOverlayCallbackFn(t *testing.T, fn func(*home, string, string, bool, func() (chan struct{}, error)) tea.Cmd) {
+func swapAttachOverlayCallbackFn(t *testing.T, fn func(*home, string, string, string, bool, func() (chan struct{}, error)) tea.Cmd) {
 	t.Helper()
 	prev := attachOverlayCallbackFn
 	attachOverlayCallbackFn = fn
@@ -75,8 +75,9 @@ func driveHandleEnterAttach(t *testing.T, terminalTab, remote bool) (tea.Cmd, st
 
 	var out bytes.Buffer
 	swapRemoteDetachResetWriter(t, &out)
-	swapAttachOverlayCallbackFn(t, func(m *home, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
-		return m.attachOverlayCallback(label, traceSuffix, rem, func() (chan struct{}, error) {
+	stubStatusPollPause(t)
+	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+		return m.attachOverlayCallback(title, label, traceSuffix, rem, func() (chan struct{}, error) {
 			ch := make(chan struct{})
 			close(ch) // detach immediately, synchronously, no real PTY
 			return ch, nil

--- a/app/handle_enter_remote_terminal_test.go
+++ b/app/handle_enter_remote_terminal_test.go
@@ -75,7 +75,6 @@ func driveHandleEnterAttach(t *testing.T, terminalTab, remote bool) (tea.Cmd, st
 
 	var out bytes.Buffer
 	swapRemoteDetachResetWriter(t, &out)
-	stubStatusPollPause(t)
 	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
 		return m.attachOverlayCallback(title, label, traceSuffix, rem, func() (chan struct{}, error) {
 			ch := make(chan struct{})

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -218,13 +218,13 @@ func (m *home) handleEnterPane(p *store.OpenPane) (tea.Model, tea.Cmd) {
 	tabIdx := p.Tab()
 	if tabIdx != 0 {
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-			return attachOverlayCallbackFn(m, "handleEnter-pane-terminal", "", instance.IsRemote(), func() (chan struct{}, error) {
+			return attachOverlayCallbackFn(m, instance.Title, "handleEnter-pane-terminal", "", instance.IsRemote(), func() (chan struct{}, error) {
 				return ui.AttachTerminalTab(instance, tabIdx)
 			})
 		})
 	}
 	return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-		return attachOverlayCallbackFn(m, "handleEnter-pane", "", instance.IsRemote(), func() (chan struct{}, error) {
+		return attachOverlayCallbackFn(m, instance.Title, "handleEnter-pane", "", instance.IsRemote(), func() (chan struct{}, error) {
 			return m.store.AttachInstance(instance)
 		})
 	})

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -202,7 +202,7 @@ func TestEnterOnRemotePaneFallsBackToFullScreenAttach(t *testing.T) {
 	openTestPane(t, h, inst, 0)
 
 	attached := 0
-	swapAttachOverlayCallbackFn(t, func(m *home, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
 		attached++
 		assert.True(t, rem, "the remote flag must reach the attach path")
 		return nil
@@ -220,7 +220,7 @@ func TestAttachKeyKeepsFullScreenAttach(t *testing.T) {
 		helpTypeInteractive{}.mask()|helpTypeInstanceAttach{}.mask()))
 
 	attached := 0
-	swapAttachOverlayCallbackFn(t, func(m *home, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
 		attached++
 		return nil
 	})

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -552,9 +552,10 @@ func TestPane_EnterAttachesFocusedPane(t *testing.T) {
 	require.Equal(t, "beta", h.store.GetSelectedInstance().Title)
 
 	var attachedLabel string
-	swapAttachOverlayCallbackFn(t, func(m *home, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+	stubStatusPollPause(t)
+	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
 		attachedLabel = label
-		return m.attachOverlayCallback(label, traceSuffix, rem, func() (chan struct{}, error) {
+		return m.attachOverlayCallback(title, label, traceSuffix, rem, func() (chan struct{}, error) {
 			ch := make(chan struct{})
 			close(ch) // detach immediately — no real PTY
 			return ch, nil

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -552,7 +552,6 @@ func TestPane_EnterAttachesFocusedPane(t *testing.T) {
 	require.Equal(t, "beta", h.store.GetSelectedInstance().Title)
 
 	var attachedLabel string
-	stubStatusPollPause(t)
 	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
 		attachedLabel = label
 		return m.attachOverlayCallback(title, label, traceSuffix, rem, func() (chan struct{}, error) {

--- a/app/remote_detach_reset_test.go
+++ b/app/remote_detach_reset_test.go
@@ -26,7 +26,6 @@ func swapRemoteDetachResetWriter(t *testing.T, w io.Writer) {
 // post-detach cmd.
 func runAttachOverlayCallback(t *testing.T, h *home, remote bool) tea.Cmd {
 	t.Helper()
-	stubStatusPollPause(t)
 	ch := make(chan struct{})
 	done := make(chan tea.Cmd, 1)
 	go func() {

--- a/app/remote_detach_reset_test.go
+++ b/app/remote_detach_reset_test.go
@@ -26,10 +26,11 @@ func swapRemoteDetachResetWriter(t *testing.T, w io.Writer) {
 // post-detach cmd.
 func runAttachOverlayCallback(t *testing.T, h *home, remote bool) tea.Cmd {
 	t.Helper()
+	stubStatusPollPause(t)
 	ch := make(chan struct{})
 	done := make(chan tea.Cmd, 1)
 	go func() {
-		done <- h.attachOverlayCallback("test-attach", "", remote, func() (chan struct{}, error) {
+		done <- h.attachOverlayCallback("t1", "test-attach", "", remote, func() (chan struct{}, error) {
 			return ch, nil
 		})
 	}()
@@ -139,7 +140,7 @@ func TestAttachOverlayCallback_NoResetWhenRemoteAttachErrors(t *testing.T) {
 	var out bytes.Buffer
 	swapRemoteDetachResetWriter(t, &out)
 
-	cmd := h.attachOverlayCallback("test-attach", "", true, func() (chan struct{}, error) {
+	cmd := h.attachOverlayCallback("t1", "test-attach", "", true, func() (chan struct{}, error) {
 		return nil, assert.AnError
 	})
 

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -35,6 +35,21 @@ var killSessionThroughDaemon = func(title, repoID string) error {
 	return daemon.KillSession(daemon.KillSessionRequest{Title: title, RepoID: repoID})
 }
 
+// pauseStatusPollThroughDaemon / resumeStatusPollThroughDaemon route the TUI's
+// attach-time poll-pause coordination to the daemon (#1160, Fix A follow-up to
+// #1157). While a TUI is attached full-screen to an instance it owns the shared
+// tmux server, so having the daemon pause its capture-pane liveness probe for
+// that ONE instance removes needless contention with the live attach. Package
+// vars so tests can swap them (the killSessionThroughDaemon seam pattern) — and
+// so app tests never reach the real callDaemon → EnsureDaemon spawn.
+var pauseStatusPollThroughDaemon = func(title, repoID string) error {
+	return daemon.PauseStatusPoll(daemon.PauseStatusPollRequest{Title: title, RepoID: repoID})
+}
+
+var resumeStatusPollThroughDaemon = func(title, repoID string) error {
+	return daemon.ResumeStatusPoll(daemon.ResumeStatusPollRequest{Title: title, RepoID: repoID})
+}
+
 var importRemoteSessionsThroughDaemon = func(repoPath string) ([]session.InstanceData, error) {
 	return daemon.ImportRemoteHookSessions(daemon.ImportRemoteHookSessionsRequest{RepoPath: repoPath})
 }
@@ -111,6 +126,20 @@ func SetPRInfoSetterForTest(f func(title, repoID string, info session.PRInfoData
 	prev := setPRInfoThroughDaemon
 	setPRInfoThroughDaemon = f
 	return func() { setPRInfoThroughDaemon = prev }
+}
+
+// SetPauseResumeStatusPollForTest swaps the #1160 daemon pause/resume seams so
+// a test can record the calls attachOverlayCallback's heartbeat makes — and,
+// critically, so exercising the attach path never reaches the real callDaemon →
+// EnsureDaemon (which would spawn a daemon).
+func SetPauseResumeStatusPollForTest(pause, resume func(title, repoID string) error) func() {
+	prevPause, prevResume := pauseStatusPollThroughDaemon, resumeStatusPollThroughDaemon
+	pauseStatusPollThroughDaemon = pause
+	resumeStatusPollThroughDaemon = resume
+	return func() {
+		pauseStatusPollThroughDaemon = prevPause
+		resumeStatusPollThroughDaemon = prevResume
+	}
 }
 
 func SetInstanceBuilderForTest(f func(session.InstanceData) (*session.Instance, error)) func() {

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -39,14 +39,19 @@ var killSessionThroughDaemon = func(title, repoID string) error {
 // attach-time poll-pause coordination to the daemon (#1160, Fix A follow-up to
 // #1157). While a TUI is attached full-screen to an instance it owns the shared
 // tmux server, so having the daemon pause its capture-pane liveness probe for
-// that ONE instance removes needless contention with the live attach. Package
-// vars so tests can swap them (the killSessionThroughDaemon seam pattern) — and
-// so app tests never reach the real callDaemon → EnsureDaemon spawn.
-var pauseStatusPollThroughDaemon = func(title, repoID string) error {
+// that ONE instance removes needless contention with the live attach.
+//
+// These are the PRODUCTION defaults for home.pauseStatusPoll / .resumeStatusPoll
+// — plain functions, NOT swappable package globals. The attach heartbeat reads
+// the seam off an off-loop goroutine, so a mutable global would race a test seam
+// swap under `go test -parallel -race` (the #964 / #960-PR4 snapshot-fetcher
+// race). The seams live per-home instead; tests assign a fake to
+// h.pauseStatusPoll / h.resumeStatusPoll directly.
+func pauseStatusPollThroughDaemon(title, repoID string) error {
 	return daemon.PauseStatusPoll(daemon.PauseStatusPollRequest{Title: title, RepoID: repoID})
 }
 
-var resumeStatusPollThroughDaemon = func(title, repoID string) error {
+func resumeStatusPollThroughDaemon(title, repoID string) error {
 	return daemon.ResumeStatusPoll(daemon.ResumeStatusPollRequest{Title: title, RepoID: repoID})
 }
 
@@ -126,20 +131,6 @@ func SetPRInfoSetterForTest(f func(title, repoID string, info session.PRInfoData
 	prev := setPRInfoThroughDaemon
 	setPRInfoThroughDaemon = f
 	return func() { setPRInfoThroughDaemon = prev }
-}
-
-// SetPauseResumeStatusPollForTest swaps the #1160 daemon pause/resume seams so
-// a test can record the calls attachOverlayCallback's heartbeat makes — and,
-// critically, so exercising the attach path never reaches the real callDaemon →
-// EnsureDaemon (which would spawn a daemon).
-func SetPauseResumeStatusPollForTest(pause, resume func(title, repoID string) error) func() {
-	prevPause, prevResume := pauseStatusPollThroughDaemon, resumeStatusPollThroughDaemon
-	pauseStatusPollThroughDaemon = pause
-	resumeStatusPollThroughDaemon = resume
-	return func() {
-		pauseStatusPollThroughDaemon = prevPause
-		resumeStatusPollThroughDaemon = prevResume
-	}
 }
 
 func SetInstanceBuilderForTest(f func(session.InstanceData) (*session.Instance, error)) func() {

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -36,6 +36,21 @@ const (
 
 var ensureDaemonMu sync.Mutex
 
+// statusPollLease bounds how long a single PauseStatusPoll silences an
+// instance's daemon capture-pane liveness poll (#1160). The attached TUI
+// renews it with a heartbeat every statusPollRenewInterval (< this lease) and
+// clears it on clean detach, but this fixed SERVER-SIDE lease — never a
+// client-supplied duration — is the leak-safety guarantee: a crashed TUI that
+// never renews or resumes auto-resumes within one lease, so real tmux death is
+// still detected on the next tick and the daemon can never be permanently
+// blinded. var, not const, so tests can shrink it.
+var statusPollLease = 3 * time.Second
+
+// nowFunc is the clock used by the pause-poll lease logic (#1160), injectable
+// so lease-expiry tests advance time deterministically instead of racing real
+// sleeps.
+var nowFunc = time.Now
+
 // CreateSessionRequest is the daemon-owned session creation contract used by
 // the TUI, CLI, and scheduled task runner.
 type CreateSessionRequest struct {
@@ -164,6 +179,35 @@ type SetPRInfoRequest struct {
 }
 
 type SetPRInfoResponse struct {
+	OK bool
+}
+
+// PauseStatusPollRequest asks the daemon to pause its per-instance capture-pane
+// liveness poll for ONE session while a TUI is attached full-screen to it
+// (#1160, Fix A follow-up to #1157). Title selects the session; RepoID scopes
+// the lookup like the other sessions verbs. There is deliberately NO
+// client-supplied duration: the daemon always applies its own fixed
+// statusPollLease, so a misbehaving or crashed client can never silence an
+// instance for an unbounded time. The TUI renews the lease with a heartbeat
+// while attached and clears it with ResumeStatusPoll on detach.
+type PauseStatusPollRequest struct {
+	Title  string
+	RepoID string
+}
+
+type PauseStatusPollResponse struct {
+	OK bool
+}
+
+// ResumeStatusPollRequest clears a pause set by PauseStatusPoll so the daemon's
+// poll resumes immediately on a clean detach rather than waiting out the lease
+// (#1160).
+type ResumeStatusPollRequest struct {
+	Title  string
+	RepoID string
+}
+
+type ResumeStatusPollResponse struct {
 	OK bool
 }
 
@@ -372,6 +416,30 @@ func Snapshot(req SnapshotRequest) ([]session.InstanceData, error) {
 func KillSession(req KillSessionRequest) error {
 	var resp KillSessionResponse
 	if err := callDaemon("KillSession", req, &resp); err != nil {
+		return err
+	}
+	return nil
+}
+
+// PauseStatusPoll asks the daemon to pause its capture-pane liveness poll for
+// one attached session (#1160). Best-effort from the caller's side: the pause
+// is lease-bounded server-side, so the worst case of a failed call is the
+// daemon keeps polling — exactly the pre-#1160 behavior — never a broken
+// attach or a permanently-blinded daemon.
+func PauseStatusPoll(req PauseStatusPollRequest) error {
+	var resp PauseStatusPollResponse
+	if err := callDaemon("PauseStatusPoll", req, &resp); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ResumeStatusPoll asks the daemon to resume polling a session on a clean
+// detach so its status refreshes on the next tick instead of after the lease
+// expires (#1160).
+func ResumeStatusPoll(req ResumeStatusPollRequest) error {
+	var resp ResumeStatusPollResponse
+	if err := callDaemon("ResumeStatusPoll", req, &resp); err != nil {
 		return err
 	}
 	return nil
@@ -596,6 +664,31 @@ type controlServer struct {
 }
 
 func (s *controlServer) Ping(_ PingRequest, resp *PingResponse) error {
+	resp.OK = true
+	return nil
+}
+
+// PauseStatusPoll pauses the daemon's capture-pane liveness poll for one
+// attached session (#1160). Deliberately NOT gated on requireManagerReady:
+// it is a lightweight, lease-bounded map write on the dedicated pausedMu (not
+// m.mu), independent of the instance restore — a pause that lands during
+// warm-up is honored once the instance is restored, and it can never corrupt
+// state the way a create/kill racing the restore could. A nil manager (some
+// test control servers) is a no-op ack.
+func (s *controlServer) PauseStatusPoll(req PauseStatusPollRequest, resp *PauseStatusPollResponse) error {
+	if s.manager != nil {
+		s.manager.PauseStatusPoll(req.RepoID, req.Title)
+	}
+	resp.OK = true
+	return nil
+}
+
+// ResumeStatusPoll clears a pause set by PauseStatusPoll (#1160). Same
+// lightweight, ungated conventions as PauseStatusPoll.
+func (s *controlServer) ResumeStatusPoll(req ResumeStatusPollRequest, resp *ResumeStatusPollResponse) error {
+	if s.manager != nil {
+		s.manager.ResumeStatusPoll(req.RepoID, req.Title)
+	}
 	resp.OK = true
 	return nil
 }
@@ -953,6 +1046,19 @@ type Manager struct {
 	// repoStartLocks; entries are never removed (a few bytes per session ever
 	// touched).
 	instanceOpLocks map[string]*sync.Mutex
+
+	// pausedPolls records sessions whose daemon capture-pane liveness poll is
+	// paused while a TUI is attached full-screen to them (#1160), keyed by
+	// daemon instance key → lease expiry. Guarded by pausedMu, a DEDICATED
+	// mutex (NOT m.mu): refreshInstanceStatus deliberately snapshots under m.mu
+	// and then runs each slow tmux probe with m.mu RELEASED so a hung probe
+	// can't block unrelated RPCs — the pause check runs inside that lock-free
+	// window, so reusing m.mu would reintroduce exactly the contention the
+	// release avoids. Each entry is lease-bounded (statusPollLease): a crashed
+	// TUI that never sends Resume auto-resumes within one lease, so the pause
+	// can never permanently blind the daemon.
+	pausedMu    sync.Mutex
+	pausedPolls map[string]time.Time
 }
 
 // NewManager constructs a manager and synchronously restores all persisted
@@ -993,6 +1099,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		killsInFlight:       make(map[string]struct{}),
 		lostRestoreStates:   make(map[string]*lostRestoreState),
 		instanceOpLocks:     make(map[string]*sync.Mutex),
+		pausedPolls:         make(map[string]time.Time),
 	}, nil
 }
 
@@ -1047,6 +1154,46 @@ func (m *Manager) InstancesSnapshot() []*session.Instance {
 // The instance list is snapshotted under m.mu, then each instance's (possibly
 // slow) tmux probes run with the lock released so a hung capture-pane can't
 // block unrelated manager RPCs.
+// PauseStatusPoll pauses the daemon's capture-pane liveness poll for one
+// attached session for statusPollLease from now (#1160). Renewing (the TUI's
+// heartbeat) just pushes the expiry out; the pause is per-instance, so every
+// other session keeps refreshing during the attach.
+func (m *Manager) PauseStatusPoll(repoID, title string) {
+	key := daemonInstanceKey(repoID, title)
+	m.pausedMu.Lock()
+	m.pausedPolls[key] = nowFunc().Add(statusPollLease)
+	m.pausedMu.Unlock()
+}
+
+// ResumeStatusPoll clears a pause immediately on a clean detach so the poll
+// resumes on the next tick rather than waiting out the lease (#1160).
+func (m *Manager) ResumeStatusPoll(repoID, title string) {
+	key := daemonInstanceKey(repoID, title)
+	m.pausedMu.Lock()
+	delete(m.pausedPolls, key)
+	m.pausedMu.Unlock()
+}
+
+// isPollPaused reports whether an instance's poll is currently paused (#1160).
+// A present-but-expired lease is lazily deleted and reported unpaused, so a
+// crashed TUI that never sent Resume auto-resumes within one lease — the
+// crash-safety property that keeps a pause from ever permanently blinding the
+// daemon.
+func (m *Manager) isPollPaused(repoID, title string) bool {
+	key := daemonInstanceKey(repoID, title)
+	m.pausedMu.Lock()
+	defer m.pausedMu.Unlock()
+	expiry, ok := m.pausedPolls[key]
+	if !ok {
+		return false
+	}
+	if nowFunc().Before(expiry) {
+		return true
+	}
+	delete(m.pausedPolls, key) // lease lapsed — lazy GC, then poll as normal
+	return false
+}
+
 func (m *Manager) RefreshStatuses() {
 	type entry struct {
 		repoID   string
@@ -1099,6 +1246,18 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		return
 	}
 	if status := instance.GetStatus(); status == session.Loading || status == session.Deleting {
+		return
+	}
+	if m.isPollPaused(repoID, instance.Title) {
+		// A TUI is attached full-screen to this instance (#1160). It owns the
+		// shared tmux server for the attach duration; the daemon's capture-pane
+		// liveness probe here would needlessly contend with the live attach and
+		// hurt input responsiveness (Fix A follow-up to #1157). Skip the probe.
+		// The status is left UNCHANGED — a paused instance is known-attached-and-
+		// alive, never marked Lost (#1108): it has not vanished. Leak-safe: the
+		// pause is lease-bounded (statusPollLease), so a crashed TUI that never
+		// sends Resume auto-resumes within one lease and real death is detected
+		// on the next tick — the pause can never permanently blind the daemon.
 		return
 	}
 

--- a/daemon/status_pause_test.go
+++ b/daemon/status_pause_test.go
@@ -1,0 +1,160 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// withFrozenClock swaps the pause-poll clock (#1160) for a deterministic one so
+// lease-expiry assertions never race real time. It returns a setter to advance
+// the fake now, and registers cleanup.
+func withFrozenClock(t *testing.T) func(d time.Duration) {
+	t.Helper()
+	// A fixed, non-zero base — time.Now()'s actual value is irrelevant to the
+	// lease math, only deltas are.
+	base := time.Unix(1_700_000_000, 0)
+	cur := base
+	prev := nowFunc
+	nowFunc = func() time.Time { return cur }
+	t.Cleanup(func() { nowFunc = prev })
+	return func(d time.Duration) { cur = cur.Add(d) }
+}
+
+// TestRefreshStatuses_PausedInstanceSkipsProbe is the #1160 scope guard: while
+// instance X's poll is paused (a TUI attached full-screen), a RefreshStatuses
+// pass must NOT probe or transition X, while an unpaused sibling Y in the same
+// manager IS refreshed as normal. Both carry a dead backend, so if the pause
+// were ignored X would flip to Lost; it must stay Running.
+func TestRefreshStatuses_PausedInstanceSkipsProbe(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// Dead backends: an unpaused refresh marks these Lost. seedDiskInstance
+	// overwrites the per-repo file, so only the last seed persists — we assert
+	// in-memory status, which holds both instances independently.
+	registerStarted(t, manager, repoID, repoPath, "attached-x", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
+	registerStarted(t, manager, repoID, repoPath, "sibling-y", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
+
+	manager.PauseStatusPoll(repoID, "attached-x")
+
+	manager.RefreshStatuses()
+
+	x := manager.instances[daemonInstanceKey(repoID, "attached-x")]
+	if got := x.GetStatus(); got != session.Running {
+		t.Fatalf("paused instance status = %v, want Running untouched (its probe must be skipped)", got)
+	}
+	y := manager.instances[daemonInstanceKey(repoID, "sibling-y")]
+	if got := y.GetStatus(); got != session.Lost {
+		t.Fatalf("unpaused sibling status = %v, want Lost — the pause must affect ONLY the attached instance", got)
+	}
+}
+
+// TestRefreshStatuses_PausedDeadInstanceNotMarkedLost guards the #1108
+// interaction: a paused instance whose tmux is actually DEAD must not be marked
+// Lost while paused — a paused instance is known-attached, not vanished. Real
+// death is only surfaced once the pause is cleared/expired (see the lease test).
+func TestRefreshStatuses_PausedDeadInstanceNotMarkedLost(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStarted(t, manager, repoID, repoPath, "dead-but-paused", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
+
+	manager.PauseStatusPoll(repoID, "dead-but-paused")
+
+	manager.RefreshStatuses()
+
+	inst := manager.instances[daemonInstanceKey(repoID, "dead-but-paused")]
+	if got := inst.GetStatus(); got == session.Lost {
+		t.Fatalf("paused instance was marked Lost (#1108 interaction) — a paused instance must never be marked Lost while paused")
+	}
+	if got := inst.GetStatus(); got != session.Running {
+		t.Fatalf("paused instance status = %v, want Running untouched", got)
+	}
+}
+
+// TestRefreshStatuses_LeaseExpiryDetectsRealDeath is the crash-safety property:
+// a pause is lease-bounded, so once statusPollLease elapses a crashed TUI that
+// never sent Resume auto-resumes and REAL tmux death is detected — the dead
+// instance is marked Lost on the next pass. The clock is advanced past the
+// lease deterministically instead of sleeping.
+func TestRefreshStatuses_LeaseExpiryDetectsRealDeath(t *testing.T) {
+	advance := withFrozenClock(t)
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStarted(t, manager, repoID, repoPath, "crashed-tui", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
+
+	manager.PauseStatusPoll(repoID, "crashed-tui")
+
+	// Still within the lease: the dead instance is protected.
+	if !manager.isPollPaused(repoID, "crashed-tui") {
+		t.Fatal("instance should be paused immediately after PauseStatusPoll")
+	}
+	manager.RefreshStatuses()
+	inst := manager.instances[daemonInstanceKey(repoID, "crashed-tui")]
+	if got := inst.GetStatus(); got != session.Running {
+		t.Fatalf("within-lease status = %v, want Running untouched (still paused)", got)
+	}
+
+	// Advance past the lease: the crashed TUI never renewed, so the pause must
+	// have lapsed and real death must now be detected.
+	advance(statusPollLease + time.Second)
+	if manager.isPollPaused(repoID, "crashed-tui") {
+		t.Fatal("pause must auto-expire after statusPollLease — a crashed TUI can never permanently blind the daemon")
+	}
+	manager.RefreshStatuses()
+	if got := inst.GetStatus(); got != session.Lost {
+		t.Fatalf("post-lease status = %v, want Lost — real tmux death must be detected once the pause expires", got)
+	}
+}
+
+// TestResumeStatusPoll_ClearsPauseImmediately proves a clean detach resumes
+// polling without waiting out the lease: right after Resume, isPollPaused is
+// false and a subsequent RefreshStatuses probes the (dead) instance and marks
+// it Lost.
+func TestResumeStatusPoll_ClearsPauseImmediately(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerStarted(t, manager, repoID, repoPath, "detached", deadTmuxBackend{session.NewFakeBackend()}, true, session.Running)
+
+	manager.PauseStatusPoll(repoID, "detached")
+	if !manager.isPollPaused(repoID, "detached") {
+		t.Fatal("instance should be paused after PauseStatusPoll")
+	}
+
+	manager.ResumeStatusPoll(repoID, "detached")
+	if manager.isPollPaused(repoID, "detached") {
+		t.Fatal("ResumeStatusPoll must clear the pause immediately, not wait out the lease")
+	}
+
+	manager.RefreshStatuses()
+	inst := manager.instances[daemonInstanceKey(repoID, "detached")]
+	if got := inst.GetStatus(); got != session.Lost {
+		t.Fatalf("status after resume = %v, want Lost — polling must resume immediately on a clean detach", got)
+	}
+}
+
+// TestControlServer_PauseResumeStatusPoll exercises the RPC handlers directly
+// (the reflection-registered surface the TUI calls), proving they delegate to
+// the manager: Pause makes isPollPaused true, Resume makes it false, both ack.
+func TestControlServer_PauseResumeStatusPoll(t *testing.T) {
+	manager, repoID, _ := newStatusTestManager(t)
+	server := &controlServer{manager: manager}
+
+	var pauseResp PauseStatusPollResponse
+	if err := server.PauseStatusPoll(PauseStatusPollRequest{Title: "s", RepoID: repoID}, &pauseResp); err != nil {
+		t.Fatalf("PauseStatusPoll RPC: %v", err)
+	}
+	if !pauseResp.OK {
+		t.Fatal("PauseStatusPoll must ack OK")
+	}
+	if !manager.isPollPaused(repoID, "s") {
+		t.Fatal("PauseStatusPoll RPC must pause the instance via the manager")
+	}
+
+	var resumeResp ResumeStatusPollResponse
+	if err := server.ResumeStatusPoll(ResumeStatusPollRequest{Title: "s", RepoID: repoID}, &resumeResp); err != nil {
+		t.Fatalf("ResumeStatusPoll RPC: %v", err)
+	}
+	if !resumeResp.OK {
+		t.Fatal("ResumeStatusPoll must ack OK")
+	}
+	if manager.isPollPaused(repoID, "s") {
+		t.Fatal("ResumeStatusPoll RPC must clear the pause via the manager")
+	}
+}


### PR DESCRIPTION
**Fix A** — the complementary contention reduction to #1159 (Fix B). While a TUI is attached full-screen to an instance it owns the shared tmux server; the daemon's per-instance `capture-pane` liveness probe (`refreshInstanceStatus`, `DaemonPollInterval` = 1000ms) needlessly contends with the live attach and hurts input responsiveness. This pauses the poll for that **one** instance for the attach duration, following the #960 single-writer RPC model: the TUI is a client that RPCs the daemon, and the daemon owns state.

#1159 already removed the user-visible 1s detach stall, so this is a pure responsiveness improvement, not a regression fix.

## What changed

**Daemon RPC surface (`daemon/control.go`)**
- New `PauseStatusPoll` / `ResumeStatusPoll` RPCs + client wrappers, mirroring the `KillSession`/`SetPRInfo` template. Deliberately **not** gated on `requireManagerReady`: they are lightweight, lease-bounded map writes on a **dedicated `pausedMu`** (never `m.mu` — `refreshInstanceStatus` runs its slow probe with `m.mu` released so a hung probe can't block RPCs; the pause check runs in that lock-free window, so reusing `m.mu` would reintroduce the contention the release avoids). A pause that lands during warm-up is simply honored once the instance restores.
- `refreshInstanceStatus` skips the probe for a paused instance **after** the `UserKilled()` tombstone short-circuit (an in-flight kill still finishes) and the `Loading || Deleting` return, **before** `CheckAndHandleTrustPrompt`. The status is left **UNCHANGED** — never marked Lost/Dead/Ready.

**TUI side (`app/app.go`, `app/session_control.go`)**
- `attachOverlayCallback` (the single funnel all attach paths reach) now threads the instance title, spawns a heartbeat goroutine that Pauses on attach and renews every `statusPollRenewInterval` (1s), and Resumes immediately on clean detach. Every RPC is **best-effort and off the hot path**: a down daemon or a failed pause logs-and-continues and never breaks attach/detach. The `defer m.attached.Store(false)`, detach-trace marks, watchdog, and remote/local handling are all preserved — the pause/resume is purely additive.

## Design questions from #1160, answered

1. **Granularity** — **per-instance**, keyed by `daemonInstanceKey(repoID, title)`. Every other instance keeps refreshing during an attach; only the attached one pauses.
2. **Leak safety** — a **fixed 3s server-side lease** (`statusPollLease`), **not** a client-supplied duration. The TUI renews it with a 1s heartbeat and clears it with an immediate Resume on clean detach; expired entries lazy-GC. A crashed TUI / lost socket / missed detach auto-resumes within one lease. Because the client can never set the lease, there is **no way to permanently silence an instance** — this is the mechanism that guarantees the daemon can't be permanently blinded. Renew (1s) < lease (3s) leaves two missed-renew of slack for a hiccuping daemon.
3. **autoyes / trust-prompt** — while a human is attached full-screen they drive prompts directly, so pausing that one instance's `CheckAndHandleTrustPrompt`/autoyes for the attach duration is intended and harmless. Only the attached instance is affected; every other instance keeps its autoyes.
4. **Lost / #1108** — a paused instance is **never** marked Lost while paused (it is known-attached, not vanished). Real tmux death is detected on the first tick after the lease expires or Resume arrives — proven by the lease-expiry test below.

## Tests

**Daemon (`daemon/status_pause_test.go`)** — advance an injectable `nowFunc` instead of sleeping:
- `TestRefreshStatuses_PausedInstanceSkipsProbe` — paused X is not probed/transitioned while unpaused sibling Y **is** refreshed (scope).
- `TestRefreshStatuses_PausedDeadInstanceNotMarkedLost` — a paused instance whose tmux is dead is **not** marked Lost while paused (#1108 guard).
- `TestRefreshStatuses_LeaseExpiryDetectsRealDeath` — past the lease, `isPollPaused` → false and the dead instance is marked Lost: **real death is still detected** (crash-safety).
- `TestResumeStatusPoll_ClearsPauseImmediately` — Resume clears the pause at once.
- `TestControlServer_PauseResumeStatusPoll` — the RPC handlers delegate to the manager.

**App (`app/attached_pause_test.go`)** — pause/resume seams swapped with recorders (no real daemon contacted):
- `TestAttachOverlayCallback_PausesAndResumesDaemonPoll` — Pause fires (targeting the attached title) **before** `<-ch` unblocks; Resume fires after detach.
- `TestAttachOverlayCallback_AttachSucceedsWhenPauseErrors` — a failing Pause RPC never breaks attach: the callback still returns the repaint cmd and clears `m.attached` via its defer (best-effort).

## Gates

`go build ./...` clean · `gofmt -l .` empty · `golangci-lint --fast` clean · `deadcode -test ./...` empty · `make test-container` green (the lone `internal/proctree/TestTreeOfFindsGrandchild` failure is a pre-existing process-scheduling flake in a package this PR doesn't touch — passes on rerun).

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)