### PR TITLE
feat(cli): broadcast a prompt to all sessions with send-prompt --all (#1031)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -256,6 +256,60 @@ func instanceTitleExistsInScope(repoID, title string) (bool, error) {
 	return false, err
 }
 
+// scopedInstance is a persisted session paired with the repo ID it belongs to,
+// which the broadcast delivery path needs to address the daemon SendPrompt RPC.
+type scopedInstance struct {
+	RepoID string
+	Title  string
+	Status session.Status
+}
+
+// scopedInstancesForRepo lists one repo's persisted sessions with their repo ID
+// attached. Used by the broadcast path (send-prompt --all) to enumerate the
+// current/--repo scope's targets. Mirrors repoHasInstanceTitle's load+parse but
+// returns every entry rather than a single existence bit.
+func scopedInstancesForRepo(repoID string) ([]scopedInstance, error) {
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load instances for repo %s: %w", repoID, err)
+	}
+	var instances []session.InstanceData
+	if err := json.Unmarshal(raw, &instances); err != nil {
+		return nil, fmt.Errorf("failed to parse instances for repo %s: %w", repoID, err)
+	}
+	out := make([]scopedInstance, 0, len(instances))
+	for i := range instances {
+		out = append(out, scopedInstance{RepoID: repoID, Title: instances[i].Title, Status: instances[i].Status})
+	}
+	return out, nil
+}
+
+// allScopedInstances lists every repo's persisted sessions, preserving the repo
+// ID association each broadcast delivery needs (loadAllInstancesAggregate drops
+// it). Corrupted repos are logged (naming the repo) and returned via the second
+// value so the caller fails loudly instead of broadcasting to a truncated set
+// (#730) — the same contract as loadAllInstancesAggregate.
+func allScopedInstances() ([]scopedInstance, []string, error) {
+	allInstances, err := config.LoadAllRepoInstances()
+	if err != nil {
+		return nil, nil, err
+	}
+	var out []scopedInstance
+	var corrupted []string
+	for repoID, raw := range allInstances {
+		var instances []session.InstanceData
+		if err := json.Unmarshal(raw, &instances); err != nil {
+			log.WarningLog.Printf("skipping repo %s: corrupted instances.json: %v", repoID, err)
+			corrupted = append(corrupted, repoID)
+			continue
+		}
+		for i := range instances {
+			out = append(out, scopedInstance{RepoID: repoID, Title: instances[i].Title, Status: instances[i].Status})
+		}
+	}
+	return out, corrupted, nil
+}
+
 // jsonOut marshals v to JSON and writes to stdout.
 func jsonOut(v any) error {
 	data, err := json.MarshalIndent(v, "", "  ")
@@ -288,6 +342,9 @@ func init() {
 
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptCreateFlag, "create", false, "Auto-create the session if it doesn't exist")
 	sessionsSendPromptCmd.Flags().StringVar(&sendPromptProgramFlag, "program", "", "Program to run when creating a new session (defaults to config default)")
+	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptAllFlag, "all", false, "Broadcast the prompt to every live session in scope (current repo by default; excludes the reserved root session)")
+	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptAllReposFlag, "all-repos", false, "With --all, broadcast across every repo instead of only the current/--repo one")
+	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptIncludeRootFlag, "include-root", false, "With --all, also deliver to the reserved root session (excluded by default)")
 
 	sessionsTabCreateCmd.Flags().StringVar(&tabCreateCommandFlag, "command", "", "Command to run in the new tab (required)")
 	sessionsTabCreateCmd.Flags().StringVar(&tabCreateNameFlag, "name", "", "Tab name (defaults to the command basename; auto-suffixed on collision)")

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -205,13 +205,19 @@ to broadcast across every repo. The reserved root session is excluded unless
 sessions are reported, and one failure never aborts the rest. The command prints
 a JSON summary (delivered / failed / skipped) and exits 0 even when some
 sessions fail, so scripts can inspect per-session results.`,
-	// With --all the single positional is the prompt; otherwise it's
-	// <title> <prompt>. Flags are parsed before Args runs, so the mode flag is
-	// already set here.
+	// Validate flag combinations before arity (cobra runs Args before RunE):
+	// a broadcast-implying flag without --all must surface its actionable
+	// message here, not cobra's generic "accepts 2 arg(s)" (#658/#734: public
+	// CLI = actionable errors). Arity is then mode-aware — with --all the single
+	// positional is the prompt; otherwise it's <title> <prompt>. Flags are
+	// parsed before Args runs, so the mode flags are already set here.
 	Args: func(cmd *cobra.Command, args []string) error {
+		if err := validateSendPromptFlags(); err != nil {
+			return jsonError(err)
+		}
 		if sendPromptAllFlag {
 			if len(args) != 1 {
-				return fmt.Errorf("--all takes exactly one argument (the prompt to broadcast); got %d", len(args))
+				return jsonError(fmt.Errorf("--all broadcast takes exactly one argument (the prompt to broadcast); got %d", len(args)))
 			}
 			return nil
 		}
@@ -221,21 +227,13 @@ sessions fail, so scripts can inspect per-session results.`,
 		log.Initialize(false)
 		defer log.Close()
 
-		// Reject nonsensical flag combinations up front with an actionable
-		// message (public CLI) rather than silently ignoring a flag.
-		if sendPromptAllReposFlag && !sendPromptAllFlag {
-			return jsonError(errors.New("--all-repos only applies to a broadcast; add --all"))
-		}
-		if sendPromptIncludeRootFlag && !sendPromptAllFlag {
-			return jsonError(errors.New("--include-root only applies to a broadcast; add --all"))
+		// Re-check here too: unit tests drive RunE directly (bypassing Args),
+		// and it is cheap defense-in-depth against a future caller that skips
+		// arg validation. In the real CLI Args already caught these.
+		if err := validateSendPromptFlags(); err != nil {
+			return jsonError(err)
 		}
 		if sendPromptAllFlag {
-			if sendPromptCreateFlag {
-				return jsonError(errors.New("--all cannot be combined with --create: broadcast only delivers to existing sessions"))
-			}
-			if sendPromptAllReposFlag && repoFlag != "" {
-				return jsonError(errors.New("--all-repos and --repo are mutually exclusive: --all-repos already spans every repo"))
-			}
 			return runBroadcast(args[0])
 		}
 
@@ -332,6 +330,36 @@ type broadcastTarget struct {
 	Status string `json:"status"`
 	Error  string `json:"error,omitempty"`
 	Reason string `json:"reason,omitempty"`
+}
+
+// validateSendPromptFlags rejects nonsensical send-prompt flag combinations
+// with an actionable message (public CLI standard, #658/#734). It runs from both
+// Args — so it fires before cobra's arity check, which would otherwise mask a
+// broadcast flag used without --all behind a generic "accepts 2 arg(s)" error —
+// and RunE, so unit tests that drive RunE directly still get the same guard.
+func validateSendPromptFlags() error {
+	if !sendPromptAllFlag {
+		// The broadcast-only flags are meaningless without --all. Name whichever
+		// were passed and point the user at the flag that unlocks them.
+		var needsAll []string
+		if sendPromptAllReposFlag {
+			needsAll = append(needsAll, "--all-repos")
+		}
+		if sendPromptIncludeRootFlag {
+			needsAll = append(needsAll, "--include-root")
+		}
+		if len(needsAll) > 0 {
+			return fmt.Errorf("%s can only be used with --all (broadcast mode); add --all to broadcast the prompt to every session in scope", strings.Join(needsAll, " and "))
+		}
+		return nil
+	}
+	if sendPromptCreateFlag {
+		return errors.New("--all cannot be combined with --create: broadcast only delivers to existing sessions")
+	}
+	if sendPromptAllReposFlag && repoFlag != "" {
+		return errors.New("--all-repos and --repo are mutually exclusive: --all-repos already spans every repo")
+	}
+	return nil
 }
 
 // runBroadcast implements `af sessions send-prompt --all`: deliver one prompt to

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sort"
 
 	"os/exec"
 	"strings"
@@ -178,21 +180,64 @@ pointing at one).`,
 }
 
 var (
-	sendPromptCreateFlag  bool
-	sendPromptProgramFlag string
+	sendPromptCreateFlag      bool
+	sendPromptProgramFlag     string
+	sendPromptAllFlag         bool
+	sendPromptAllReposFlag    bool
+	sendPromptIncludeRootFlag bool
 )
 
 var sessionsSendPromptCmd = &cobra.Command{
 	Use:   "send-prompt <title> <prompt>",
-	Short: "Send a prompt to a session",
+	Short: "Send a prompt to a session (or broadcast to all with --all)",
 	Long: `Send a prompt to an existing session. The session must already exist unless --create is used.
 
 If the session does not exist, use --create to automatically create it first,
-or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
-	Args: cobra.ExactArgs(2),
+or use 'af sessions create --name <title> --prompt <prompt>' instead.
+
+With --all, broadcast a single prompt to every live session in scope:
+
+    af sessions send-prompt --all "<prompt>"
+
+Broadcast scope defaults to the current repo (honoring --repo). Pass --all-repos
+to broadcast across every repo. The reserved root session is excluded unless
+--include-root is given. Delivery is best-effort per session: unreachable (Lost)
+sessions are reported, and one failure never aborts the rest. The command prints
+a JSON summary (delivered / failed / skipped) and exits 0 even when some
+sessions fail, so scripts can inspect per-session results.`,
+	// With --all the single positional is the prompt; otherwise it's
+	// <title> <prompt>. Flags are parsed before Args runs, so the mode flag is
+	// already set here.
+	Args: func(cmd *cobra.Command, args []string) error {
+		if sendPromptAllFlag {
+			if len(args) != 1 {
+				return fmt.Errorf("--all takes exactly one argument (the prompt to broadcast); got %d", len(args))
+			}
+			return nil
+		}
+		return cobra.ExactArgs(2)(cmd, args)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
 		defer log.Close()
+
+		// Reject nonsensical flag combinations up front with an actionable
+		// message (public CLI) rather than silently ignoring a flag.
+		if sendPromptAllReposFlag && !sendPromptAllFlag {
+			return jsonError(errors.New("--all-repos only applies to a broadcast; add --all"))
+		}
+		if sendPromptIncludeRootFlag && !sendPromptAllFlag {
+			return jsonError(errors.New("--include-root only applies to a broadcast; add --all"))
+		}
+		if sendPromptAllFlag {
+			if sendPromptCreateFlag {
+				return jsonError(errors.New("--all cannot be combined with --create: broadcast only delivers to existing sessions"))
+			}
+			if sendPromptAllReposFlag && repoFlag != "" {
+				return jsonError(errors.New("--all-repos and --repo are mutually exclusive: --all-repos already spans every repo"))
+			}
+			return runBroadcast(args[0])
+		}
 
 		title := args[0]
 		prompt := args[1]
@@ -264,6 +309,132 @@ or use 'af sessions create --name <title> --prompt <prompt>' instead.`,
 		}
 		return jsonOut(map[string]bool{"ok": true})
 	},
+}
+
+// broadcastResult is the JSON summary `send-prompt --all` prints: aggregate
+// counts plus a per-session breakdown so scripts can tell exactly which
+// sessions received the prompt and why any did not.
+type broadcastResult struct {
+	Prompt    string            `json:"prompt"`
+	Scope     string            `json:"scope"`
+	Delivered int               `json:"delivered"`
+	Failed    int               `json:"failed"`
+	Skipped   int               `json:"skipped"`
+	Results   []broadcastTarget `json:"results"`
+}
+
+// broadcastTarget is one session's outcome in a broadcast. Status is one of
+// "delivered", "failed", or "skipped"; Error carries the daemon's reason on a
+// failure and Reason explains an intentional skip (root excluded, session lost).
+type broadcastTarget struct {
+	Title  string `json:"title"`
+	RepoID string `json:"repo_id"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// runBroadcast implements `af sessions send-prompt --all`: deliver one prompt to
+// every live session in scope via the same daemon SendPrompt RPC the single-
+// target path uses. Scope defaults to the current repo (honoring --repo) so a
+// broadcast can never blast another repo's sessions (#761 data-loss class);
+// --all-repos opts into spanning every repo. The reserved root session is
+// excluded unless --include-root. Delivery is best-effort: a Lost/unreachable
+// target is reported and skipped, a per-session send error is recorded, and
+// neither aborts the rest. The command exits 0 with a JSON summary regardless of
+// individual failures so callers inspect the per-session results.
+func runBroadcast(prompt string) error {
+	var (
+		targets    []scopedInstance
+		scopeLabel string
+	)
+	if sendPromptAllReposFlag {
+		all, corrupted, err := allScopedInstances()
+		if err != nil {
+			return jsonError(err)
+		}
+		// Fail loudly on a corrupted repo rather than silently broadcasting to
+		// a truncated set — the same loud-fail contract as `sessions list`
+		// (#730). A hidden session that never receives the prompt is worse than
+		// an error the user can act on.
+		if len(corrupted) > 0 {
+			return jsonError(corruptedReposError(corrupted))
+		}
+		targets = all
+		scopeLabel = "all-repos"
+	} else {
+		repoID, err := resolveRepoID()
+		if err != nil {
+			return jsonError(err)
+		}
+		if repoID == "" {
+			// Refuse to guess the scope: silently broadcasting to every repo
+			// here is exactly the #761 wrong-repo hazard the --repo scoping
+			// exists to prevent.
+			return jsonError(errors.New("broadcast needs a target repo: run inside a git repository, pass --repo <path>, or use --all-repos to broadcast to every repo"))
+		}
+		scoped, err := scopedInstancesForRepo(repoID)
+		if err != nil {
+			return jsonError(err)
+		}
+		targets = scoped
+		scopeLabel = "repo:" + repoID
+	}
+
+	// Deterministic order (repo, then title) so output is stable across runs
+	// and the all-repos map iteration order does not leak into the summary.
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].RepoID != targets[j].RepoID {
+			return targets[i].RepoID < targets[j].RepoID
+		}
+		return targets[i].Title < targets[j].Title
+	})
+
+	result := broadcastResult{Prompt: prompt, Scope: scopeLabel, Results: []broadcastTarget{}}
+	for _, t := range targets {
+		// The reserved root session belongs to the maintainer agent (#1106):
+		// don't broadcast into it unless explicitly asked.
+		if session.IsReservedTitle(t.Title) && !sendPromptIncludeRootFlag {
+			result.Skipped++
+			result.Results = append(result.Results, broadcastTarget{
+				Title:  t.Title,
+				RepoID: t.RepoID,
+				Status: "skipped",
+				Reason: "reserved root session excluded; pass --include-root to broadcast to it",
+			})
+			continue
+		}
+		// Lost/Dead sessions have no live backing session to deliver into
+		// (#1108). Report them as skipped-unreachable instead of attempting a
+		// send that would only fail — the broadcast tolerates them cleanly.
+		if t.Status == session.Lost || t.Status == session.Dead {
+			result.Skipped++
+			result.Results = append(result.Results, broadcastTarget{
+				Title:  t.Title,
+				RepoID: t.RepoID,
+				Status: "skipped",
+				Reason: "session is lost/unreachable; recover it before broadcasting",
+			})
+			continue
+		}
+		if err := sendPromptViaDaemon(daemon.SendPromptRequest{Title: t.Title, RepoID: t.RepoID, Prompt: prompt}); err != nil {
+			result.Failed++
+			result.Results = append(result.Results, broadcastTarget{
+				Title:  t.Title,
+				RepoID: t.RepoID,
+				Status: "failed",
+				Error:  err.Error(),
+			})
+			continue
+		}
+		result.Delivered++
+		result.Results = append(result.Results, broadcastTarget{
+			Title:  t.Title,
+			RepoID: t.RepoID,
+			Status: "delivered",
+		})
+	}
+	return jsonOut(result)
 }
 
 var (

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -1136,3 +1136,56 @@ func TestSessionsSendPrompt_BroadcastAllReposSpansRepos(t *testing.T) {
 		t.Fatalf("expected --all-repos/--repo mutual-exclusion error, got: %v", err)
 	}
 }
+
+// TestSessionsSendPrompt_BroadcastFlagWithoutAll pins the Greptile P2 fix:
+// cobra runs the Args (arity) check before RunE, so a broadcast-implying flag
+// used without --all must surface its actionable "requires --all" message from
+// Args rather than being masked by cobra's generic "accepts 2 arg(s)" arity
+// error. The cases cover one and two positionals (arity would trip differently
+// for each) and a combination of both broadcast flags.
+func TestSessionsSendPrompt_BroadcastFlagWithoutAll(t *testing.T) {
+	cases := []struct {
+		name       string
+		allRepos   bool
+		includeRT  bool
+		args       []string
+		wantSubstr []string
+	}{
+		{"all-repos, one arg", true, false, []string{"prompt"}, []string{"--all-repos", "--all"}},
+		{"all-repos, two args", true, false, []string{"title", "prompt"}, []string{"--all-repos", "--all"}},
+		{"include-root, one arg", false, true, []string{"prompt"}, []string{"--include-root", "--all"}},
+		{"both flags", true, true, []string{"prompt"}, []string{"--all-repos and --include-root", "--all"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetBroadcastFlags(t)
+			sendPromptAllReposFlag = tc.allRepos
+			sendPromptIncludeRootFlag = tc.includeRT
+
+			// Exercise the command's Args validator directly — this is the hook
+			// cobra runs before RunE, and where the generic arity error would
+			// otherwise win. Silence the JSON error write to stderr.
+			origStderr := os.Stderr
+			devnull, _ := os.Open(os.DevNull)
+			os.Stderr = devnull
+			err := sessionsSendPromptCmd.Args(sessionsSendPromptCmd, tc.args)
+			os.Stderr = origStderr
+			if devnull != nil {
+				devnull.Close()
+			}
+
+			if err == nil {
+				t.Fatalf("expected an actionable error for a broadcast flag without --all, got nil")
+			}
+			for _, want := range tc.wantSubstr {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error %q should mention %q", err.Error(), want)
+				}
+			}
+			// The generic cobra arity error must not be what the user sees.
+			if strings.Contains(err.Error(), "accepts") && strings.Contains(err.Error(), "arg(s)") {
+				t.Fatalf("got cobra's generic arity error, want the actionable --all message: %v", err)
+			}
+		})
+	}
+}

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -735,5 +736,403 @@ func TestSessionsTabDelete_SurfacesDaemonError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "ghost") {
 		t.Fatalf("expected error naming the missing tab, got: %v", err)
+	}
+}
+
+// resetBroadcastFlags clears the send-prompt broadcast flags before a test and
+// restores their prior values on cleanup, so package-level flag state never
+// leaks between tests.
+func resetBroadcastFlags(t *testing.T) {
+	t.Helper()
+	prevAll := sendPromptAllFlag
+	prevAllRepos := sendPromptAllReposFlag
+	prevRoot := sendPromptIncludeRootFlag
+	prevCreate := sendPromptCreateFlag
+	prevRepo := repoFlag
+	t.Cleanup(func() {
+		sendPromptAllFlag = prevAll
+		sendPromptAllReposFlag = prevAllRepos
+		sendPromptIncludeRootFlag = prevRoot
+		sendPromptCreateFlag = prevCreate
+		repoFlag = prevRepo
+	})
+	sendPromptAllFlag = false
+	sendPromptAllReposFlag = false
+	sendPromptIncludeRootFlag = false
+	sendPromptCreateFlag = false
+}
+
+// runBroadcastCmd invokes the send-prompt command's RunE with the given args,
+// capturing the JSON summary it prints so tests can assert on per-session
+// outcomes. It returns the parsed summary and the RunE error.
+func runBroadcastCmd(t *testing.T, args []string) (broadcastResult, error) {
+	t.Helper()
+	sendPromptAllFlag = true
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = sessionsSendPromptCmd.RunE(sessionsSendPromptCmd, args)
+	})
+	var res broadcastResult
+	if runErr == nil && strings.TrimSpace(out) != "" {
+		if err := json.Unmarshal([]byte(out), &res); err != nil {
+			t.Fatalf("failed to parse broadcast summary %q: %v", out, err)
+		}
+	}
+	return res, runErr
+}
+
+// TestSessionsSendPrompt_BroadcastHonorsRepoScoping is the #761 data-loss-class
+// regression guard for the broadcast path: `send-prompt --all --repo <repoA>`
+// must deliver only to repo A's sessions and never touch a session in another
+// repo. A broadcast that ignored --repo would blast every repo's sessions — the
+// exact wrong-repo hazard the send-prompt scoping was built to prevent.
+func TestSessionsSendPrompt_BroadcastHonorsRepoScoping(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+	resetBroadcastFlags(t)
+
+	repoARoot := filepath.Join(tmp, "repo-a")
+	if err := os.MkdirAll(repoARoot, 0755); err != nil {
+		t.Fatalf("mkdir repo A: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoARoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init repo A: %v (%s)", err, out)
+	}
+	repoA, err := config.RepoFromPath(repoARoot)
+	if err != nil {
+		t.Fatalf("RepoFromPath repo A: %v", err)
+	}
+	repoBID := "repo-b-synthetic"
+	if repoBID == repoA.ID {
+		t.Fatalf("test setup: synthetic repo B ID collided with repo A")
+	}
+
+	rawA, err := json.Marshal([]session.InstanceData{
+		{Title: "a1", Status: session.Running},
+		{Title: "a2", Status: session.Ready},
+	})
+	if err != nil {
+		t.Fatalf("marshal repo A: %v", err)
+	}
+	rawB, err := json.Marshal([]session.InstanceData{{Title: "b1", Status: session.Running}})
+	if err != nil {
+		t.Fatalf("marshal repo B: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoA.ID, rawA); err != nil {
+		t.Fatalf("save repo A: %v", err)
+	}
+	if err := config.SaveRepoInstances(repoBID, rawB); err != nil {
+		t.Fatalf("save repo B: %v", err)
+	}
+
+	repoFlag = repoARoot
+
+	var gotRepoIDs, gotTitles []string
+	prevSend := sendPromptViaDaemon
+	sendPromptViaDaemon = func(req daemon.SendPromptRequest) error {
+		gotRepoIDs = append(gotRepoIDs, req.RepoID)
+		gotTitles = append(gotTitles, req.Title)
+		return nil
+	}
+	defer func() { sendPromptViaDaemon = prevSend }()
+
+	res, err := runBroadcastCmd(t, []string{"ship it"})
+	if err != nil {
+		t.Fatalf("broadcast returned error: %v", err)
+	}
+	if res.Delivered != 2 || res.Failed != 0 || res.Skipped != 0 {
+		t.Fatalf("counts = delivered %d / failed %d / skipped %d, want 2/0/0", res.Delivered, res.Failed, res.Skipped)
+	}
+	for _, id := range gotRepoIDs {
+		if id != repoA.ID {
+			t.Fatalf("broadcast delivered to repo %q, want only repo A %q (repo B leaked)", id, repoA.ID)
+		}
+	}
+	for _, title := range gotTitles {
+		if title == "b1" {
+			t.Fatalf("broadcast delivered to repo B's session b1 despite --repo repo A")
+		}
+	}
+	if res.Scope != "repo:"+repoA.ID {
+		t.Fatalf("scope = %q, want %q", res.Scope, "repo:"+repoA.ID)
+	}
+}
+
+// TestSessionsSendPrompt_BroadcastExcludesRoot verifies the broadcast excludes
+// the reserved root session by default (#1106) and includes it only when
+// --include-root is passed.
+func TestSessionsSendPrompt_BroadcastExcludesRoot(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+
+	repoRoot := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoRoot, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoRoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	repo, err := config.RepoFromPath(repoRoot)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	raw, err := json.Marshal([]session.InstanceData{
+		{Title: "alpha", Status: session.Ready},
+		{Title: session.RootSessionTitle, Status: session.Ready},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := config.SaveRepoInstances(repo.ID, raw); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Default: root excluded.
+	t.Run("excluded by default", func(t *testing.T) {
+		resetBroadcastFlags(t)
+		repoFlag = repoRoot
+		var got []string
+		prevSend := sendPromptViaDaemon
+		sendPromptViaDaemon = func(req daemon.SendPromptRequest) error {
+			got = append(got, req.Title)
+			return nil
+		}
+		defer func() { sendPromptViaDaemon = prevSend }()
+
+		res, err := runBroadcastCmd(t, []string{"hello"})
+		if err != nil {
+			t.Fatalf("broadcast returned error: %v", err)
+		}
+		if len(got) != 1 || got[0] != "alpha" {
+			t.Fatalf("delivered to %v, want only [alpha]", got)
+		}
+		if res.Delivered != 1 || res.Skipped != 1 {
+			t.Fatalf("counts = delivered %d / skipped %d, want 1/1", res.Delivered, res.Skipped)
+		}
+		var rootSkipped bool
+		for _, r := range res.Results {
+			if r.Title == session.RootSessionTitle {
+				if r.Status != "skipped" {
+					t.Fatalf("root status = %q, want skipped", r.Status)
+				}
+				rootSkipped = true
+			}
+		}
+		if !rootSkipped {
+			t.Fatalf("root session missing from results: %+v", res.Results)
+		}
+	})
+
+	// --include-root: root also gets the prompt.
+	t.Run("included with flag", func(t *testing.T) {
+		resetBroadcastFlags(t)
+		repoFlag = repoRoot
+		sendPromptIncludeRootFlag = true
+		var got []string
+		prevSend := sendPromptViaDaemon
+		sendPromptViaDaemon = func(req daemon.SendPromptRequest) error {
+			got = append(got, req.Title)
+			return nil
+		}
+		defer func() { sendPromptViaDaemon = prevSend }()
+
+		res, err := runBroadcastCmd(t, []string{"hello"})
+		if err != nil {
+			t.Fatalf("broadcast returned error: %v", err)
+		}
+		if res.Delivered != 2 {
+			t.Fatalf("delivered = %d, want 2 (alpha + root)", res.Delivered)
+		}
+		var sawRoot bool
+		for _, title := range got {
+			if title == session.RootSessionTitle {
+				sawRoot = true
+			}
+		}
+		if !sawRoot {
+			t.Fatalf("--include-root did not deliver to root; delivered to %v", got)
+		}
+	})
+}
+
+// TestSessionsSendPrompt_BroadcastToleratesLost verifies best-effort delivery:
+// a Lost/unreachable session is reported and skipped (not attempted), a per-
+// session send failure is recorded, and neither aborts the rest of the
+// broadcast — the command still exits 0 with a full per-session summary.
+func TestSessionsSendPrompt_BroadcastToleratesLost(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+	resetBroadcastFlags(t)
+
+	repoRoot := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoRoot, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoRoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+	repo, err := config.RepoFromPath(repoRoot)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	raw, err := json.Marshal([]session.InstanceData{
+		{Title: "alive", Status: session.Running},
+		{Title: "boom", Status: session.Running},
+		{Title: "gone", Status: session.Lost},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := config.SaveRepoInstances(repo.ID, raw); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	repoFlag = repoRoot
+
+	var attempted []string
+	prevSend := sendPromptViaDaemon
+	sendPromptViaDaemon = func(req daemon.SendPromptRequest) error {
+		attempted = append(attempted, req.Title)
+		if req.Title == "boom" {
+			return errors.New("daemon: session not reachable")
+		}
+		return nil
+	}
+	defer func() { sendPromptViaDaemon = prevSend }()
+
+	res, err := runBroadcastCmd(t, []string{"status?"})
+	if err != nil {
+		t.Fatalf("broadcast must not fail the whole command on a per-session error, got: %v", err)
+	}
+	if res.Delivered != 1 || res.Failed != 1 || res.Skipped != 1 {
+		t.Fatalf("counts = delivered %d / failed %d / skipped %d, want 1/1/1 (%+v)", res.Delivered, res.Failed, res.Skipped, res.Results)
+	}
+	// The Lost session must never be attempted — it is known-unreachable.
+	for _, title := range attempted {
+		if title == "gone" {
+			t.Fatalf("broadcast attempted delivery to Lost session %q; it should be skipped", title)
+		}
+	}
+	byTitle := map[string]broadcastTarget{}
+	for _, r := range res.Results {
+		byTitle[r.Title] = r
+	}
+	if byTitle["alive"].Status != "delivered" {
+		t.Fatalf("alive status = %q, want delivered", byTitle["alive"].Status)
+	}
+	if byTitle["boom"].Status != "failed" || byTitle["boom"].Error == "" {
+		t.Fatalf("boom result = %+v, want failed with an error reason", byTitle["boom"])
+	}
+	if byTitle["gone"].Status != "skipped" || byTitle["gone"].Reason == "" {
+		t.Fatalf("gone result = %+v, want skipped with a reason", byTitle["gone"])
+	}
+}
+
+// TestSessionsSendPrompt_BroadcastRequiresScope verifies the broadcast refuses
+// to guess its scope: with no current repo, no --repo, and no --all-repos it
+// errors instead of silently blasting every repo (the #761 hazard).
+func TestSessionsSendPrompt_BroadcastRequiresScope(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+	resetBroadcastFlags(t)
+
+	// A non-repo cwd so config.CurrentRepo() fails and resolveRepoID() returns
+	// "" (all-repo mode) — which the broadcast must reject rather than honor.
+	nonRepo := filepath.Join(tmp, "not-a-repo")
+	if err := os.MkdirAll(nonRepo, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	prevWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(nonRepo); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(prevWd) }()
+
+	prevSend := sendPromptViaDaemon
+	sendPromptViaDaemon = func(req daemon.SendPromptRequest) error {
+		t.Fatalf("broadcast must not deliver without a resolved scope; got %+v", req)
+		return nil
+	}
+	defer func() { sendPromptViaDaemon = prevSend }()
+
+	sendPromptAllFlag = true
+	origStderr := os.Stderr
+	devnull, _ := os.Open(os.DevNull)
+	os.Stderr = devnull
+	err = sessionsSendPromptCmd.RunE(sessionsSendPromptCmd, []string{"hello"})
+	os.Stderr = origStderr
+	if devnull != nil {
+		devnull.Close()
+	}
+	if err == nil {
+		t.Fatal("expected an error when broadcast scope cannot be resolved, got nil")
+	}
+	if !strings.Contains(err.Error(), "--all-repos") || !strings.Contains(err.Error(), "--repo") {
+		t.Fatalf("scope error should point to --repo/--all-repos, got: %v", err)
+	}
+}
+
+// TestSessionsSendPrompt_BroadcastAllReposSpansRepos verifies --all-repos
+// delivers to every repo's sessions, and that --all-repos with --repo is a
+// clean mutual-exclusion error.
+func TestSessionsSendPrompt_BroadcastAllReposSpansRepos(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tmp)
+	resetBroadcastFlags(t)
+
+	rawA, err := json.Marshal([]session.InstanceData{{Title: "a1", Status: session.Running}})
+	if err != nil {
+		t.Fatalf("marshal repo A: %v", err)
+	}
+	rawB, err := json.Marshal([]session.InstanceData{{Title: "b1", Status: session.Ready}})
+	if err != nil {
+		t.Fatalf("marshal repo B: %v", err)
+	}
+	if err := config.SaveRepoInstances("repo-a", rawA); err != nil {
+		t.Fatalf("save repo A: %v", err)
+	}
+	if err := config.SaveRepoInstances("repo-b", rawB); err != nil {
+		t.Fatalf("save repo B: %v", err)
+	}
+
+	var got []string
+	prevSend := sendPromptViaDaemon
+	sendPromptViaDaemon = func(req daemon.SendPromptRequest) error {
+		got = append(got, req.RepoID+"/"+req.Title)
+		return nil
+	}
+	defer func() { sendPromptViaDaemon = prevSend }()
+
+	sendPromptAllReposFlag = true
+	res, err := runBroadcastCmd(t, []string{"all hands"})
+	if err != nil {
+		t.Fatalf("--all-repos broadcast returned error: %v", err)
+	}
+	if res.Delivered != 2 {
+		t.Fatalf("delivered = %d, want 2 (one per repo)", res.Delivered)
+	}
+	if res.Scope != "all-repos" {
+		t.Fatalf("scope = %q, want all-repos", res.Scope)
+	}
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "repo-a/a1" || got[1] != "repo-b/b1" {
+		t.Fatalf("delivered to %v, want [repo-a/a1 repo-b/b1]", got)
+	}
+
+	// --all-repos + --repo must be a clean mutual-exclusion error.
+	repoFlag = "/some/path"
+	origStderr := os.Stderr
+	devnull, _ := os.Open(os.DevNull)
+	os.Stderr = devnull
+	err = sessionsSendPromptCmd.RunE(sessionsSendPromptCmd, []string{"x"})
+	os.Stderr = origStderr
+	if devnull != nil {
+		devnull.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected --all-repos/--repo mutual-exclusion error, got: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #1031 (from the #1023 roadmap).

## What

Adds an `--all` broadcast mode to the existing `af sessions send-prompt` path so a single action delivers one prompt to every live session in scope. Reuses the daemon `SendPrompt` RPC per target — no new RPC surface.

```
af sessions send-prompt --all "<prompt>"
```

## Contract shipped (for root's review)

This adds a CLI/API surface, so stating the contract explicitly:

- **Command**: `af sessions send-prompt --all "<prompt>"`. With `--all`, the single positional arg is the prompt (not `<title> <prompt>`); arg count is validated per mode.
- **Scope** defaults to the **current repo** and **honors `--repo`**. Broadcasting with no resolvable repo scope (not in a repo, no `--repo`, no `--all-repos`) **errors** rather than guessing — silently blasting every repo is exactly the #761 wrong-repo data-loss class the send-prompt scoping exists to prevent. `--all-repos` opts into spanning every repo explicitly (mutually exclusive with `--repo`).
- **Root excluded by default**: the reserved `root` session (#1106) is skipped unless `--include-root` is passed.
- **Best-effort delivery**: Lost/unreachable sessions (#1108) are reported and skipped (never attempted); a per-session send error is recorded; neither aborts the rest. The command prints a **JSON summary** and **exits 0 even when some sessions fail**, so scripts can parse per-session results:

```json
{
  "prompt": "ship it",
  "scope": "repo:<id>",
  "delivered": 2,
  "failed": 1,
  "skipped": 1,
  "results": [
    { "title": "alpha", "repo_id": "<id>", "status": "delivered" },
    { "title": "beta",  "repo_id": "<id>", "status": "failed", "error": "..." },
    { "title": "root",  "repo_id": "<id>", "status": "skipped", "reason": "reserved root session excluded; pass --include-root to broadcast to it" }
  ]
}
```

- **Actionable errors** for bad flag combos (public CLI): `--all-repos`/`--include-root` without `--all`, `--all` with `--create`, `--all-repos` with `--repo`.
- **Deterministic output**: targets sorted by (repo, title) so the all-repos map iteration order never leaks.

### Deviations / open questions for root
- **CLI-only for v1.** A TUI broadcast overlay is a clean follow-up but not trivial (input overlay + scope selection + result surface); deferring it keeps this PR focused. Flagging as a follow-up rather than blocking.
- **Exit 0 on partial failure** is deliberate (the issue asks: never fail the whole command because one session is unreachable). The JSON summary carries the failure detail. If root prefers a non-zero exit when *all* deliveries fail, that's a one-line change.

## Regression-prone area audit (`--repo` scoping)

⚠️ This touches the send-prompt/daemon RPC path. The broadcast **must not** ignore `--repo` (#761/#776/#891 data-loss class). Guards in place:
- Scope resolves through the same `resolveRepoID()` the other subcommands use; an unresolved scope is a hard error, never an implicit all-repos blast.
- `--all-repos` is the *only* way to broaden past the current/`--repo` repo, and it can't be combined with `--repo`.
- Corrupted repos fail loudly (the #730 contract) instead of broadcasting to a truncated set.

## Tests

`api/sessions_test.go`:
- `BroadcastHonorsRepoScoping` — #761 guard: `--all --repo repoA` delivers only to repo A's sessions; repo B never touched.
- `BroadcastExcludesRoot` — root skipped by default; delivered with `--include-root`.
- `BroadcastToleratesLost` — Lost session skipped (never attempted), a failing send recorded, command still exits 0 with delivered/failed/skipped = 1/1/1.
- `BroadcastRequiresScope` — unresolved scope errors, pointing at `--repo`/`--all-repos`.
- `BroadcastAllReposSpansRepos` — `--all-repos` hits every repo; `--all-repos --repo` is a clean mutual-exclusion error.

## Gates

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — empty
- `go build ./...` — clean
- `make test-container` — full suite green (api + daemon + all)
- `deadcode -test ./...` — no new dead code

Also exercised the real `af` binary end-to-end for `--help` and every error path (scope-required, all mutual-exclusion / combo errors). Happy-path delivery is covered by the mocked-daemon unit tests; deliberately did not spawn a real daemon on the shared dev box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
