### PR TITLE
fix(tui): declutter the automations rail — instance-color titles, expand-for-detail, grow-to-fit (#1126)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -368,6 +368,10 @@ func (m *home) relayout() {
 	// panes' bindings persist and restore on grow, which is exactly the
 	// retain-and-restore contract the A/B split had.
 	m.grid.Panes = m.store.NumOpenPanes()
+	// Size the automations section to its content: the grid grows it to show
+	// every automation when the rail has the room, collapsing only when the
+	// tree + automations can't both fit (#1126).
+	m.grid.Automations = m.store.NumTasks()
 	lay := m.grid.Solve(m.termWidth, m.termHeight)
 	m.lastLayout = lay
 	if lay.Fallback {
@@ -918,6 +922,9 @@ func (m *home) saveContentPaneState() error {
 	if err == nil {
 		m.store.SetTasks(tasks)
 		sp.SetTasks(tasks)
+		// The task count feeds the rail's automations-section height (#1126);
+		// reflow so an add/delete grows or shrinks the section immediately.
+		m.relayout()
 	} else {
 		saveErr = errors.Join(saveErr, fmt.Errorf("failed to reload tasks after save: %w", err))
 	}
@@ -1001,6 +1008,8 @@ func (m *home) handleTaskCreate() tea.Cmd {
 	if err == nil {
 		m.store.SetTasks(tasks)
 		sp.SetTasks(tasks)
+		// Reflow so the new automation grows the rail's section (#1126).
+		m.relayout()
 	}
 	return nil
 }

--- a/ui/automations.go
+++ b/ui/automations.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
+	"github.com/sachiniyer/agent-factory/ui/tree"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -29,9 +30,18 @@ var automationsEnabledStyle = lipgloss.NewStyle().
 var automationsDisabledStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.Color("#9C9494"))
 
-var automationsSelectedStyle = lipgloss.NewStyle().
-	Bold(true).
-	Foreground(lipgloss.Color("#FFCC00"))
+// automationItemTitleStyle paints an automation's title in the SAME adaptive
+// color the instances tree uses for instance titles (tree.InstanceTitleColor),
+// so the automations rail and the instance list above it read as one stacked
+// list rather than two differently-colored ones (#1126).
+var automationItemTitleStyle = lipgloss.NewStyle().
+	Foreground(tree.InstanceTitleColor)
+
+// automationDetailStyle renders an expanded row's cron/watch/status detail
+// line — the recede gray the tree uses for its branch/description lines, so the
+// detail reads as secondary to the title it hangs under (#1126).
+var automationDetailStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
 
 var automationsHintStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.Color("#7F7A7A"))
@@ -54,16 +64,19 @@ func fitLine(s string, w int) string {
 }
 
 // AutomationsPane is the bottom section of the left rail (#1087 revised RFC
-// §2.1's bottom strip): compact task rows — enabled glyph, name, trigger,
-// next/last run — pinned under the instances tree behind a horizontal rule.
-// The full TaskPane manager (list + edit/create form) is NOT hosted in the
-// rail: it opens as a centered modal overlay (like the hooks editor), so its
-// form is never clamped into the narrow rail. The pane OWNS the TaskPane the
-// overlay hosts; the compact rows render straight off the store projection so
-// the section and the manager can never show different task sets after a
-// reload.
+// §2.1's bottom strip): one row per task — the enabled glyph and the task
+// title in the instances-list title color — pinned under the instances tree
+// behind a horizontal rule. Rows are collapsed by default (title only, #1126
+// dropped the always-on trailing cron/next/last text); the focused cursor's
+// row expands to reveal its trigger and next/last-run detail on a dim indented
+// line beneath the title. The full TaskPane manager (list + edit/create form)
+// is NOT hosted in the rail: it opens as a centered modal overlay (like the
+// hooks editor), so its form is never clamped into the narrow rail. The pane
+// OWNS the TaskPane the overlay hosts; the rows render straight off the store
+// projection so the section and the manager can never show different task sets
+// after a reload.
 //
-// It implements layout.Pane. While focused the compact rows carry a cursor
+// It implements layout.Pane. While focused the rows carry a cursor
 // (up/down/j/k via HandleKey); the root opens the manager overlay on Enter/S
 // and moves the focus ring on Esc.
 type AutomationsPane struct {
@@ -212,23 +225,45 @@ func (a *AutomationsPane) nextRunSummary(tsk task.Task) string {
 	return strings.Join(parts, " · ")
 }
 
-// compactRow renders one section row: enabled glyph, name, trigger,
-// next/last — ellipsized to the rail width, with the focused cursor's row
-// marked "▸".
-func (a *AutomationsPane) compactRow(tsk task.Task, selected bool) string {
-	glyph, style := "[✓]", automationsEnabledStyle
+// itemPrefixWidth is the fixed lead of a collapsed row — marker (1) + the
+// enabled glyph "[✓]" (3) + a 2-cell gap — that the title starts after and the
+// expanded detail line indents to, so a row's detail aligns under its title.
+const itemPrefixWidth = 6
+
+// titleRow renders one collapsed automation row: the enabled/disabled glyph and
+// the task title in the instance-title color — and nothing else (#1126: no
+// always-on trailing cron/next/last text). The focused, expanded row is marked
+// "▾" and its title bolded; every other row leads with a blank marker.
+func (a *AutomationsPane) titleRow(tsk task.Task, expanded bool) string {
+	glyph, glyphStyle := "[✓]", automationsEnabledStyle
 	if !tsk.Enabled {
-		glyph, style = "[✗]", automationsDisabledStyle
+		glyph, glyphStyle = "[✗]", automationsDisabledStyle
 	}
 	marker := " "
-	if selected {
-		marker = "▸"
-		style = automationsSelectedStyle
+	nameStyle := automationItemTitleStyle
+	if expanded {
+		marker = "▾"
+		nameStyle = nameStyle.Bold(true)
 	}
-	parts := []string{glyph}
-	if tsk.Name != "" {
-		parts = append(parts, tsk.Name)
+	name := tsk.Name
+	if name == "" {
+		name = "(unnamed)"
 	}
+	w := a.rect.W
+	if w <= itemPrefixWidth {
+		// Too narrow to split the styled segments cleanly: fall back to one
+		// fitted plain line so the row never overflows the rail.
+		return automationItemTitleStyle.Render(fitLine(marker+glyph+"  "+name, w))
+	}
+	return marker + glyphStyle.Render(glyph) + "  " +
+		nameStyle.Render(fitLine(name, w-itemPrefixWidth))
+}
+
+// rowDetail is the text an expanded row reveals: the trigger (cron expression
+// or watch command) and the next/last-run or supervision summary — the details
+// that used to trail every collapsed row (#1126). Empty when a task has neither.
+func (a *AutomationsPane) rowDetail(tsk task.Task) string {
+	var parts []string
 	trigger := tsk.CronExpr
 	if tsk.IsWatch() {
 		trigger = "watch: " + tsk.WatchCmd
@@ -239,7 +274,18 @@ func (a *AutomationsPane) compactRow(tsk task.Task, selected bool) string {
 	if next := a.nextRunSummary(tsk); next != "" {
 		parts = append(parts, next)
 	}
-	return style.Render(fitLine(marker+strings.Join(parts, "  "), a.rect.W))
+	return strings.Join(parts, " · ")
+}
+
+// detailRow renders the expanded row's detail as a dim line indented under the
+// title, ellipsized to the rail width. Returns "" when the task has no detail.
+func (a *AutomationsPane) detailRow(tsk task.Task) string {
+	detail := a.rowDetail(tsk)
+	if detail == "" {
+		return ""
+	}
+	indent := strings.Repeat(" ", itemPrefixWidth)
+	return automationDetailStyle.Render(fitLine(indent+detail, a.rect.W))
 }
 
 // enabledCount returns how many of the projection's tasks are enabled.
@@ -323,16 +369,23 @@ func (a *AutomationsPane) String() string {
 	}
 
 	// Window the rows around the cursor so a focused selection below the fold
-	// scrolls into view instead of moving invisibly.
+	// scrolls into view instead of moving invisibly. The focused selection
+	// expands to a 2-line row (title + detail), so reserve a line for the
+	// detail when scrolling the selection to the bottom keeps it fully visible
+	// rather than clipping its detail off the fold.
 	visible := a.rect.H - 1
 	if visible < 0 {
 		visible = 0
 	}
+	effVisible := visible
+	if a.focused && effVisible > 1 {
+		effVisible--
+	}
 	if a.offset > a.selected {
 		a.offset = a.selected
 	}
-	if visible > 0 && a.selected >= a.offset+visible {
-		a.offset = a.selected - visible + 1
+	if effVisible > 0 && a.selected >= a.offset+effVisible {
+		a.offset = a.selected - effVisible + 1
 	}
 	if max := len(tasks) - visible; a.offset > max {
 		a.offset = max
@@ -344,12 +397,19 @@ func (a *AutomationsPane) String() string {
 		if len(lines) >= a.rect.H {
 			break
 		}
+		expanded := a.focused && i == a.selected
+		rowStart := len(lines)
+		lines = append(lines, a.titleRow(tasks[i], expanded))
+		if expanded && len(lines) < a.rect.H {
+			if detail := a.detailRow(tasks[i]); detail != "" {
+				lines = append(lines, detail)
+			}
+		}
 		if a.zones != nil {
 			a.zones.Register(zones.AutoTask(tasks[i].ID), layout.Rect{
-				X: a.rect.X, Y: a.rect.Y + len(lines), W: a.rect.W, H: 1,
+				X: a.rect.X, Y: a.rect.Y + rowStart, W: a.rect.W, H: len(lines) - rowStart,
 			})
 		}
-		lines = append(lines, a.compactRow(tasks[i], a.focused && i == a.selected))
 	}
 	return layout.ClampToRect(strings.Join(lines, "\n"), a.rect)
 }

--- a/ui/automations_test.go
+++ b/ui/automations_test.go
@@ -33,18 +33,43 @@ func stripTasks() []task.Task {
 	}
 }
 
-// TestAutomationsStripCompactRows pins the RFC §2.1 strip row shape: enabled
-// glyph, name, trigger, next/last run.
-func TestAutomationsStripCompactRows(t *testing.T) {
+// TestAutomationsCollapsedRowsAreTitleOnly pins the #1126 collapsed shape:
+// every row is just the enabled glyph and the task title — no always-on
+// trailing cron/next/last text.
+func TestAutomationsCollapsedRowsAreTitleOnly(t *testing.T) {
 	a := newTestAutomations(stripTasks())
 	a.SetRect(layout.Rect{W: 100, H: 3})
 
 	out := a.View()
 	require.Contains(t, out, "Automations")
-	assert.Contains(t, out, "[✓]  nightly-sweep  0 3 * * *  next Jul 02 03:00 · last Jul 01 03:00",
-		"an enabled cron task shows glyph, name, trigger, next fire, and last run")
-	assert.Contains(t, out, "[✗]  ci-watch  watch: tail -f ci.log  stopped",
-		"a disabled watch task shows glyph, name, command, and supervision state")
+	assert.Contains(t, out, "[✓]  nightly-sweep", "an enabled task shows its glyph and title")
+	assert.Contains(t, out, "[✗]  ci-watch", "a disabled task shows its glyph and title")
+	assert.NotContains(t, out, "0 3 * * *", "the collapsed row hides the cron trigger")
+	assert.NotContains(t, out, "next Jul 02 03:00", "the collapsed row hides the next-run detail")
+	assert.NotContains(t, out, "watch: tail -f ci.log", "the collapsed row hides the watch command")
+}
+
+// TestAutomationsExpandedRowRevealsDetail pins the #1126 expansion: the focused
+// cursor's row reveals its trigger and next/last-run detail on a line beneath
+// the title, and no other row does.
+func TestAutomationsExpandedRowRevealsDetail(t *testing.T) {
+	a := newTestAutomations(stripTasks())
+	a.SetRect(layout.Rect{W: 100, H: 4})
+	a.Focus()
+
+	out := a.View()
+	assert.Contains(t, out, "▾[✓]  nightly-sweep", "the focused row is marked expanded")
+	assert.Contains(t, out, "0 3 * * *", "the expanded row reveals its cron trigger")
+	assert.Contains(t, out, "next Jul 02 03:00 · last Jul 01 03:00",
+		"the expanded row reveals its next/last-run detail")
+	assert.NotContains(t, out, "watch: tail -f ci.log",
+		"a collapsed (unselected) row keeps its detail hidden")
+
+	a.ScrollDown()
+	out = a.View()
+	assert.Contains(t, out, "▾[✗]  ci-watch", "expansion follows the cursor")
+	assert.Contains(t, out, "watch: tail -f ci.log", "the newly expanded row reveals its command")
+	assert.NotContains(t, out, "0 3 * * *", "the previously expanded row re-collapses")
 }
 
 // TestAutomationsStripOneLineSummary covers the <80-col degradation (RFC
@@ -74,15 +99,15 @@ func TestAutomationsFocusShowsCursorNotManager(t *testing.T) {
 
 	out := a.View()
 	requireExactRect(t, out, layout.Rect{W: 100, H: 3}, "focused section")
-	assert.Contains(t, out, "▸[✓]", "the cursor marks the selected row")
+	assert.Contains(t, out, "▾[✓]", "the cursor marks (and expands) the selected row")
 	assert.NotContains(t, out, "Tasks", "the manager must not render in-rail")
 
 	a.ScrollDown()
-	assert.Contains(t, a.View(), "▸[✗]", "the cursor follows ScrollDown")
+	assert.Contains(t, a.View(), "▾[✗]", "the cursor follows ScrollDown")
 	assert.Equal(t, 1, a.SelectedTaskIndex())
 
 	a.Blur()
-	assert.NotContains(t, a.View(), "▸", "the cursor leaves with focus")
+	assert.NotContains(t, a.View(), "▾", "the cursor (and expansion) leaves with focus")
 }
 
 // TestAutomationsStripKeyRouting: the focused section consumes only its
@@ -172,7 +197,7 @@ func TestAutomationsCursorScrollsIntoView(t *testing.T) {
 	}
 	out := a.View()
 	requireExactRect(t, out, layout.Rect{W: 40, H: 3}, "scrolled section")
-	assert.Contains(t, out, "▸[✓]  task-f", "the cursor's row scrolled into view")
+	assert.Contains(t, out, "▾[✓]  task-f", "the cursor's row scrolled into view")
 }
 
 // TestAutomationsStripExactRectWithOverflow: more tasks than rows must

--- a/ui/layout/grid.go
+++ b/ui/layout/grid.go
@@ -90,6 +90,13 @@ type Grid struct {
 	// stay visible (least-recently-focused hide first) and keeps the rest
 	// bound for when the terminal grows back.
 	Panes int
+
+	// Automations is the number of automations (tasks) the rail's bottom
+	// section holds. The section grows to show one row per automation (plus
+	// its title) when the rail has the vertical room, and only collapses into
+	// a scrollable strip when the tree + automations together can't fit
+	// (#1126); zero keeps the section at its AutomationsRows floor.
+	Automations int
 }
 
 // Layout is a solved arrangement: the named region rects plus which regions
@@ -162,6 +169,21 @@ func (g Grid) Solve(width, height int) Layout {
 		rows := AutomationsRows
 		if l.AutomationsCompact {
 			rows = AutomationsCompactRows
+		} else {
+			// Grow the section to show every automation when the rail has the
+			// room: the title line, one row per automation, plus one line held
+			// for the focused row's expansion detail so expanding never has to
+			// scroll (#1126). The AutomationsRows floor keeps a recognizable
+			// strip when there are few automations; the half-rail cap keeps the
+			// instances tree the priority — automations only collapse into a
+			// scrollable strip once the tree + automations together can't fit,
+			// at which point the tree keeps at least half the rail.
+			if want := 2 + g.Automations; want > rows {
+				rows = want
+			}
+			if half := (rail.H - RailRuleRows) / 2; half >= AutomationsRows && rows > half {
+				rows = half
+			}
 		}
 		rail, l.Automations = rail.CutBottom(rows)
 		rail, l.RailRule = rail.CutBottom(RailRuleRows)

--- a/ui/layout/grid_test.go
+++ b/ui/layout/grid_test.go
@@ -155,6 +155,69 @@ func TestGridSolveAutomationsThresholds(t *testing.T) {
 	assert.Equal(t, layout.AutomationsCompactRows, shortCompact.Automations.H)
 }
 
+// TestGridSolveAutomationsGrowsToContent pins #1126: with vertical room the
+// automations section grows to show every automation (title + one row each +
+// one reserved expansion line) instead of the old fixed 3-row cap, and only
+// collapses once the tree + automations can't both fit — at which point the
+// half-rail cap keeps the tree the priority. The rail still tiles exactly.
+func TestGridSolveAutomationsGrowsToContent(t *testing.T) {
+	// Zero automations keeps the AutomationsRows floor (a recognizable strip).
+	none := layout.Grid{Automations: 0}.Solve(120, 60)
+	assert.Equal(t, layout.AutomationsRows, none.Automations.H, "no automations keeps the floor")
+
+	// A handful of automations on a tall rail: the section is exactly title +
+	// one row per automation + the reserved expansion line, and the tree gets
+	// the rest of the rail (not the reverse).
+	tall := layout.Grid{Automations: 4}.Solve(120, 60)
+	require.False(t, tall.AutomationsCompact, "a tall rail is not compact")
+	assert.Equal(t, 2+4, tall.Automations.H, "the section grows to fit all automations")
+	assert.Greater(t, tall.Tree.H, tall.Automations.H, "the tree keeps the larger share")
+
+	// More automations than half the rail: the section collapses to (at most)
+	// half so the tree keeps at least the other half, and the pane scrolls the
+	// overflow. The section never exceeds half the rail-minus-rule.
+	many := layout.Grid{Automations: 40}.Solve(100, 30)
+	require.False(t, many.AutomationsCompact)
+	railH := many.Tree.H + many.RailRule.H + many.Automations.H
+	assert.LessOrEqual(t, many.Automations.H, railH/2,
+		"crowded automations never take more than half the rail")
+	assert.GreaterOrEqual(t, many.Tree.H, many.Automations.H, "the tree keeps at least half")
+
+	// Growth must still tile the screen exactly at every size and count.
+	for _, count := range []int{0, 1, 3, 8, 50} {
+		grid := layout.Grid{Panes: 1, Automations: count}
+		for w := layout.HardMinWidth; w <= 200; w += 7 {
+			for h := layout.HardMinHeight; h <= 70; h += 3 {
+				l := grid.Solve(w, h)
+				require.False(t, l.Fallback)
+				screen := layout.Rect{X: 0, Y: 0, W: w, H: h}
+				visible := l.VisibleRegions()
+				parts := make([]layout.Rect, 0, len(visible))
+				for id, r := range visible {
+					require.False(t, r.Empty(),
+						"region %s empty at %dx%d automations=%d", id, w, h, count)
+					parts = append(parts, r)
+				}
+				requireTiles(t, screen, parts)
+			}
+		}
+	}
+}
+
+// TestGridSolveChromeMonotonicWithAutomations re-runs the chrome-shrink
+// monotonicity contract with a populated automations section, so the #1126
+// dynamic sizing can't regress the "chrome only gives way on shrink" invariant.
+func TestGridSolveChromeMonotonicWithAutomations(t *testing.T) {
+	grid := layout.Grid{Panes: 2, Automations: 10}
+	prev := grid.Solve(200, 72)
+	for h := 71; h >= 1; h-- {
+		cur := grid.Solve(200, h)
+		require.LessOrEqual(t, cur.Automations.H, prev.Automations.H,
+			"automations grew shrinking height to %d", h)
+		prev = cur
+	}
+}
+
 func TestGridSolveMinimalMode(t *testing.T) {
 	for _, tt := range []struct {
 		name string

--- a/ui/layout_height_test.go
+++ b/ui/layout_height_test.go
@@ -213,9 +213,9 @@ func TestWorkspacePanesRenderExactlyTheirRects(t *testing.T) {
 }
 
 // TestWorkspaceFocusedAutomationsTilesExactly covers the focused automations
-// section: focus adds a cursor to the compact rows — the manager itself is a
-// modal overlay, never an in-rail expansion — and the composed workspace must
-// still tile the window exactly (#1087).
+// section: focus adds a cursor that expands its row's detail inline (#1126) —
+// the manager itself stays a modal overlay, never rendered in-rail — and the
+// composed workspace must still tile the window exactly (#1087).
 func TestWorkspaceFocusedAutomationsTilesExactly(t *testing.T) {
 	lay := layout.Grid{Panes: 1}.Solve(100, 30)
 	require.True(t, lay.AutomationsVisible)
@@ -232,7 +232,7 @@ func TestWorkspaceFocusedAutomationsTilesExactly(t *testing.T) {
 	statusBar.SetRect(lay.StatusBar)
 
 	requireExactRect(t, automations.View(), lay.Automations, "focused automations")
-	require.Contains(t, automations.View(), "▸", "the focused section carries a cursor")
+	require.Contains(t, automations.View(), "▾", "the focused section carries an expanded cursor")
 	require.NotContains(t, automations.View(), "Tasks",
 		"the manager must NOT render in-rail — it lives in the tasks overlay")
 

--- a/ui/store/projection.go
+++ b/ui/store/projection.go
@@ -447,6 +447,12 @@ func (p *Projection) GetTasks() []task.Task {
 	return p.tasks
 }
 
+// NumTasks returns how many tasks (automations) the projection holds — the
+// grid reads it to size the automations rail to its content (#1126).
+func (p *Projection) NumTasks() int {
+	return len(p.tasks)
+}
+
 // SetHookCount updates the displayed hook count.
 func (p *Projection) SetHookCount(count int) {
 	p.hookCount = count

--- a/ui/theme_test.go
+++ b/ui/theme_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/sachiniyer/agent-factory/ui/tree"
 )
 
 // TestAccentColorValue pins the shared accent to the teal introduced in #932.
@@ -33,5 +35,16 @@ func TestAccentSitesUseConstant(t *testing.T) {
 		if c.got != lipgloss.TerminalColor(AccentColor) {
 			t.Errorf("%s = %v, want AccentColor (%s)", c.name, c.got, AccentColor)
 		}
+	}
+}
+
+// TestAutomationTitleMatchesInstanceTitle pins #1126: an automation's title
+// renders in the exact color the instances tree uses for instance titles, so
+// the two stacked lists read as one. Both must resolve to the shared
+// tree.InstanceTitleColor — a future literal can't silently drift them apart.
+func TestAutomationTitleMatchesInstanceTitle(t *testing.T) {
+	if got := automationItemTitleStyle.GetForeground(); got != lipgloss.TerminalColor(tree.InstanceTitleColor) {
+		t.Errorf("automation title foreground = %v, want tree.InstanceTitleColor (%v)",
+			got, tree.InstanceTitleColor)
 	}
 }

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -50,9 +50,17 @@ var deadStyle = lipgloss.NewStyle().
 var lostStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#C18401", Dark: "#E5C07B"})
 
+// InstanceTitleColor is the foreground of an unselected instance title — the
+// adaptive near-black (light) / near-white (dark) that reads as primary text
+// in the tree. It is exported as the single source of truth so surfaces
+// stacked below the tree — the automations rail (#1126) — can paint their own
+// titles in the exact same color and the two lists can never drift apart, the
+// same single-definition discipline AccentColor uses for the accent.
+var InstanceTitleColor = lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#dddddd"}
+
 var titleStyle = lipgloss.NewStyle().
 	Padding(1, 1, 0, 1).
-	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#dddddd"})
+	Foreground(InstanceTitleColor)
 
 var listDescStyle = lipgloss.NewStyle().
 	Padding(0, 1, 1, 1).


### PR DESCRIPTION
Closes #1126.

The bottom automations rail read as **busy**: every row carried always-on trailing cron/next/last text painted in status colors, and the section was hard-capped at 3 rows (only ~2 visible tasks) regardless of terminal height or task count. Sachin's three asks, all implemented:

1. **Titles in the instances color.** Automation titles now render in the *same* adaptive color the instances tree uses for instance titles. The instance-title foreground is promoted to one shared source of truth — `tree.InstanceTitleColor` — that both the tree renderer and the automations rail route through (the same single-definition discipline `AccentColor` uses), so the two stacked lists read as one and can't drift apart. Pinned by `TestAutomationTitleMatchesInstanceTitle`.
2. **Detail on expansion, not always-on.** Collapsed rows show only the enabled glyph + title. The focused cursor's row expands (marked `▾`) to reveal its trigger and next/last-run detail on a dim indented line; every other row stays title-only.
3. **Grow to fit; collapse only when crowded.** The section grows to show every automation when the rail has room (title + one row each + one reserved expansion line), capped at half the rail so the instances tree keeps priority. It only collapses into a scrollable strip once the tree + automations can't both fit — no more over-eager 3-row cap. The grid reads the live task count; the app reflows on task add/remove.

## Before / after

Rendered with 5 automations on a 144-col terminal (36-col rail).

**Before** — busy trailing text on every row, and the fixed 3-row cap hides 3 of the 5 tasks:

```
[grid gives the automations section H=3 for 5 tasks]

========== COLLAPSED (pane unfocused) ==========
 Automations (5) · S manage
 [✓]  nightly-sweep  0 3 * * *  nex…
 [✗]  ci-watch  watch: tail -f ci.l…

========== FOCUSED, cursor on row 3 (deploy-staging) ==========
 Automations (5) · S manage
 [✗]  ci-watch  watch: tail -f ci.l…
▸[✓]  deploy-staging  */15 * * * * …

Grid automations height by task count (100x40)
  tasks=0..10 -> Automations.H=3 (fixed)   Tree.H=34
```

**After** — clean title-only rows, all 5 visible, cursor expands one row's detail:

```
[grid gives the automations section H=7 for 5 tasks]

========== COLLAPSED (pane unfocused) ==========
 Automations (5) · S manage
 [✓]  nightly-sweep
 [✗]  ci-watch
 [✓]  deploy-staging
 [✓]  lint-nightly
 [✓]  backup-db

========== FOCUSED, cursor on row 3 (deploy-staging) ==========
 Automations (5) · S manage
 [✓]  nightly-sweep
 [✗]  ci-watch
▾[✓]  deploy-staging
      */15 * * * * · next Jul 02 02…
 [✓]  lint-nightly
 [✓]  backup-db

Grid automations height by task count (100x40)
  tasks=0  -> H=3    tasks=1  -> H=3    tasks=2  -> H=4
  tasks=3  -> H=5    tasks=4  -> H=6    tasks=6  -> H=8    tasks=10 -> H=12
```

## Live play-test (container sandbox, my dirty tree)

Built `af` from this branch in the container sandbox, added 5 automations, drove the real TUI:

```
 Automations (5) · S manage
 [✓]  nightly-sweep
 [✓]  deploy-staging
▾[✓]  lint-nightly
      0 4 * * * · next Jul 05 04:00
 [✓]  backup-db
 [✓]  ci-watch
```

Tab into the rail → cursor expands `lint-nightly` inline; others stay collapsed. Resized to 70×18 → degrades to the 1-line `Automations…· S manage` summary with no overflow; 200×50 → all rows render clean. No layout garbage at any size.

## Gates

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — empty
- `go build ./...` — clean
- `make test-container` — all packages green (added grid growth/monotonicity tests + rewrote the automations row-shape tests for the collapsed/expanded behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
