### PR TITLE
test(proctree): stop TestTreeOfFindsGrandchild failing before its deadline

### DIFF
--- a/internal/proctree/proctree_test.go
+++ b/internal/proctree/proctree_test.go
@@ -73,19 +73,21 @@ func TestTreeOfFindsGrandchild(t *testing.T) {
 		}
 		tree := TreeOf(snap, cmd.Process.Pid)
 		if len(tree) >= 2 {
-			if tree[0].PID != cmd.Process.Pid {
-				t.Errorf("tree root = %d, want %d", tree[0].PID, cmd.Process.Pid)
-			}
 			foundSleep := false
 			for _, p := range tree[1:] {
 				if p.Comm == "sleep" {
 					foundSleep = true
 				}
 			}
-			if !foundSleep {
-				t.Errorf("tree %v missing the sleep grandchild", tree)
+			// The grandchild sleep may not have exec'd yet even though the
+			// shell's children are already visible; keep polling until the
+			// deadline instead of failing on the first incomplete scan.
+			if foundSleep {
+				if tree[0].PID != cmd.Process.Pid {
+					t.Errorf("tree root = %d, want %d", tree[0].PID, cmd.Process.Pid)
+				}
+				return
 			}
-			return
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("sleep grandchild never appeared under pid %d", cmd.Process.Pid)


### PR DESCRIPTION
## What

Fixes the `TestTreeOfFindsGrandchild` flake seen on a **master Build**
(2026-07-04, run 28705335565-adjacent). The failing PR that triggered the
push (broadcast/api) was causally unrelated — this is a real-process
**timing** flake in the test itself.

## Root cause

`internal/proctree/proctree_test.go` spawns `sh -c 'sleep 300 & wait'`,
which forks a grandchild `sleep`, then polls the process tree with a 5s
deadline / 20ms loop. The bug: the failure branch

```go
if !foundSleep {
    t.Errorf("tree %v missing the sleep grandchild", tree)
}
return
```

fired **inside** the loop on the first scan where the two `sh` processes
were already visible but the grandchild `sleep` had not exec'd yet — then
`return`ed. On a loaded CI runner a slightly-slow grandchild fork fails
the test even though the `sleep` would appear a few ms later. The
post-deadline `t.Fatalf("...never appeared...")` is the *correct* failure
path; the in-loop `Errorf` was the bug.

## Fix

Only treat a missing grandchild as failure once the 5s deadline expires.
Within the deadline an incomplete scan just keeps polling. The root-PID
assertion moves onto the success path so it no longer re-fires every
iteration. Nothing the test asserts is weakened — a grandchild that
genuinely never appears still fails via the post-deadline `Fatalf`, and
the 5s deadline / success path are unchanged.

**Adjacent audit:** the other two poll loops in this file (`TestEnvValue`,
`TestCmdline`) already use the correct pattern (succeed → return; fail only
after the deadline). No sibling instance of the anti-pattern.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — OK
- `make test-container GOTESTARGS='-count=50 -run TestTreeOf ./internal/proctree/...'` — **green across all 50 runs**

No issue filed — direct CI-hygiene fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude