### PR TITLE
TUI test-driver: deterministic, scriptable manual-testing harness (#1161)

### DIFF
--- a/.claude/skills/tui-playtest.md
+++ b/.claude/skills/tui-playtest.md
@@ -25,18 +25,22 @@ mock repo, pids/memory caps, and teardown is one `docker rm -f`). See
 
 ```bash
 WORK="/tmp/af-playtest-$(date +%Y%m%d-%H%M%S)" && mkdir -p "$WORK"
+# PIN a per-run container name. The default is now UNIQUE per run (#1171) so
+# concurrent play-tests can't `docker rm -f` each other; pin it here so every
+# docker exec/rm below targets THIS run's container, never a hardcoded name.
+export AF_PLAYTEST_NAME="af-playtest-$$"
 git clone --depth 1 https://github.com/sachiniyer/agent-factory "$WORK/src"   # play-test master, not a dirty checkout
-make -C "$WORK/src" playtest-container-detached                               # container name: af-playtest
-docker exec af-playtest sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'   # af builds on boot
+make -C "$WORK/src" playtest-container-detached                               # container name: $AF_PLAYTEST_NAME
+docker exec "$AF_PLAYTEST_NAME" sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'   # af builds on boot
 
 # Drive the TUI exactly as in section 2, but through docker exec — no -L
 # socket needed; the container's default tmux server IS the private server:
-docker exec af-playtest tmux new-session -d -s drive -x 80 -y 24
-docker exec af-playtest tmux send-keys -t drive 'cd ~/sandbox/mock-repo && af' Enter
-docker exec af-playtest tmux capture-pane -p -t drive
+docker exec "$AF_PLAYTEST_NAME" tmux new-session -d -s drive -x 80 -y 24
+docker exec "$AF_PLAYTEST_NAME" tmux send-keys -t drive 'cd ~/sandbox/mock-repo && af' Enter
+docker exec "$AF_PLAYTEST_NAME" tmux capture-pane -p -t drive
 
 # Teardown (replaces section 4's script — one command reaps everything):
-docker rm -f af-playtest && rm -rf "$WORK"
+docker rm -f "$AF_PLAYTEST_NAME" && rm -rf "$WORK"
 ```
 
 `gh` issue filing (section 3) still happens on the host. Stress
@@ -61,8 +65,9 @@ interaction model and a gate-recipe library.
 # smoke-check the driver itself (and the TUI) first:
 make -C "$WORK/src" tui-driver-selftest
 
-# then drive the play-test through the driver instead of raw send-keys:
-docker exec af-playtest bash -lc '
+# then drive the play-test through the driver instead of raw send-keys
+# ("$AF_PLAYTEST_NAME" was pinned above):
+docker exec "$AF_PLAYTEST_NAME" bash -lc '
   source /src/scripts/tui-driver.sh
   af_boot
   af_new_instance alpha

--- a/.claude/skills/tui-playtest.md
+++ b/.claude/skills/tui-playtest.md
@@ -45,6 +45,38 @@ contained failure, not a non-event. Sections 1 and 4 below are the
 **fallback for boxes without docker/podman**; the rules underneath apply
 to every run, containerized or not.
 
+### Drive with the TUI driver, not raw send-keys (#1161)
+
+Don't hand-roll `send-keys`/`capture-pane`/`sleep N` — that is exactly what
+mis-drove the TUI in #1156 (keys landing in a live pane as text) and died on
+a `$TMUX` collision in #1155. Source
+[`scripts/tui-driver.sh`](../../scripts/tui-driver.sh): every action is
+self-synchronizing (waits on a screen marker, never a blind sleep),
+`af_ensure_nav` forces a known focus state, and `af_expect_selected` /
+`af_assert_no_orphan_clients` give real assertions. See
+[docs/tui-manual-testing.md](../../docs/tui-manual-testing.md) for the
+interaction model and a gate-recipe library.
+
+```bash
+# smoke-check the driver itself (and the TUI) first:
+make -C "$WORK/src" tui-driver-selftest
+
+# then drive the play-test through the driver instead of raw send-keys:
+docker exec af-playtest bash -lc '
+  source /src/scripts/tui-driver.sh
+  af_boot
+  af_new_instance alpha
+  af_select alpha && af_expect_selected alpha
+  af_open_pane && af_enter_interactive
+  af_send_to_pane "echo hello"
+  af_exit_interactive
+  af_assert_no_orphan_clients
+'
+```
+
+The raw `send-keys` recipe below still works and is fine for one-off pokes,
+but prefer the driver for anything you want to be repeatable or gate on.
+
 ## Hard isolation rules (non-negotiable)
 
 These rules exist because a previous play-test took down the whole dev box

--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,19 @@ playtest-container:
 	scripts/testbox.sh playtest
 
 # Same sandbox parked in the background for `docker exec` driving (used by
-# the tui-playtest skill). Tear down with: docker rm -f af-playtest
+# the tui-playtest skill). The container name is unique per run (#1171) and
+# printed on start; pin it with AF_PLAYTEST_NAME to target/tear down a
+# specific one (docker rm -f "$AF_PLAYTEST_NAME").
 playtest-container-detached:
 	scripts/testbox.sh playtest -d
 
 # Deterministic, scriptable TUI driver (#1161). tui-driver boots af through
-# the driver in the container sandbox and attaches you to the live session to
-# drive it by hand; tui-driver-selftest runs the acceptance scenario (boot →
-# 2 instances → select → pane → interactive → type → attach/detach → assert
-# selection + no orphan clients). Both auto-start the sandbox if needed.
-# See docs/tui-manual-testing.md. Tear down with: docker rm -f af-playtest
+# the driver in a uniquely-named container sandbox (#1171) and attaches you to
+# the live session to drive it by hand (it prints its teardown command);
+# tui-driver-selftest runs the acceptance scenario (boot → 2 instances →
+# select → pane → interactive → type → attach/detach → assert selection + no
+# orphan clients) in an EPHEMERAL sandbox that is torn down automatically.
+# See docs/tui-manual-testing.md.
 tui-driver:
 	scripts/testbox.sh drive
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 # real ~/.agent-factory, or this repo's worktrees.
 # See docs/container-testing.md.
 
-.PHONY: test-container playtest-container playtest-container-detached testbox-image
+.PHONY: test-container playtest-container playtest-container-detached \
+	tui-driver tui-driver-selftest testbox-image
 
 # Full `go test ./...` inside the container — the one sanctioned way to run
 # the bare full suite on a shared box. Narrow or extend the run with
@@ -22,6 +23,18 @@ playtest-container:
 # the tui-playtest skill). Tear down with: docker rm -f af-playtest
 playtest-container-detached:
 	scripts/testbox.sh playtest -d
+
+# Deterministic, scriptable TUI driver (#1161). tui-driver boots af through
+# the driver in the container sandbox and attaches you to the live session to
+# drive it by hand; tui-driver-selftest runs the acceptance scenario (boot →
+# 2 instances → select → pane → interactive → type → attach/detach → assert
+# selection + no orphan clients). Both auto-start the sandbox if needed.
+# See docs/tui-manual-testing.md. Tear down with: docker rm -f af-playtest
+tui-driver:
+	scripts/testbox.sh drive
+
+tui-driver-selftest:
+	scripts/testbox.sh selftest
 
 # (Re)build the toolchain image only.
 testbox-image:

--- a/docs/container-testing.md
+++ b/docs/container-testing.md
@@ -66,6 +66,13 @@ docker exec af-playtest tmux capture-pane -p -t drive
 docker rm -f af-playtest        # teardown: one command reaps everything
 ```
 
+Rather than hand-rolling `send-keys`/`capture-pane`/`sleep`, drive the TUI
+through the **deterministic driver** (`scripts/tui-driver.sh`): every action
+waits on a screen marker instead of a blind sleep, and it ships real
+assertions. `make tui-driver-selftest` is the acceptance gate; `make
+tui-driver` drops you into a live driven session. See
+[tui-manual-testing.md](tui-manual-testing.md).
+
 ## Known limitations
 
 - **No systemd inside** — autostart-unit flows (`af daemon install`) still

--- a/docs/container-testing.md
+++ b/docs/container-testing.md
@@ -55,15 +55,19 @@ down everything: the daemon, the tmux server, and every process the
 play-test spawned. Teardown is container exit, not a checklist.
 
 For scripted/agent-driven play-tests (the `tui-playtest` skill), park the
-sandbox in the background and drive it with `docker exec`:
+sandbox in the background and drive it with `docker exec`. The container name
+defaults to a **unique per-run value** (#1171) so concurrent runs can't
+`docker rm -f` each other — pin it with `AF_PLAYTEST_NAME` so every
+`docker exec`/`rm` targets this run's container:
 
 ```bash
+export AF_PLAYTEST_NAME="af-playtest-$$"
 make playtest-container-detached
-docker exec af-playtest sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'
-docker exec af-playtest tmux new-session -d -s drive -x 80 -y 24
-docker exec af-playtest tmux send-keys -t drive 'cd ~/sandbox/mock-repo && af' Enter
-docker exec af-playtest tmux capture-pane -p -t drive
-docker rm -f af-playtest        # teardown: one command reaps everything
+docker exec "$AF_PLAYTEST_NAME" sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'
+docker exec "$AF_PLAYTEST_NAME" tmux new-session -d -s drive -x 80 -y 24
+docker exec "$AF_PLAYTEST_NAME" tmux send-keys -t drive 'cd ~/sandbox/mock-repo && af' Enter
+docker exec "$AF_PLAYTEST_NAME" tmux capture-pane -p -t drive
+docker rm -f "$AF_PLAYTEST_NAME"   # teardown: one command reaps everything
 ```
 
 Rather than hand-rolling `send-keys`/`capture-pane`/`sleep`, drive the TUI

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -1,0 +1,314 @@
+# Manual TUI testing — the driver (#1161)
+
+Driving the real multi-pane TUI by hand for a play-test gate used to be
+error-prone: keys landed in a live pane as literal text (#1156), hand-rolled
+tmux harnesses died on `$TMUX`/`TMUX_TMPDIR` collisions (#1155), and every run
+re-derived `send-keys`/`capture-pane`/`sleep N` plumbing from scratch — where
+the blind `sleep`s were the main flake source.
+
+`scripts/tui-driver.sh` is the fix: a **sourceable driver library** of
+self-synchronizing functions that drive the live TUI and assert on it. It
+builds ON the #1130 container sandbox (which already solves isolation —
+throwaway home, mock repo, private tmux, pids/memory caps; see
+[container-testing.md](container-testing.md)). The container is the *where*;
+this driver is the *how*.
+
+- **Library**: [`scripts/tui-driver.sh`](../scripts/tui-driver.sh)
+- **Self-test / acceptance proof**:
+  [`scripts/tui-driver-selftest.sh`](../scripts/tui-driver-selftest.sh)
+- **Run it**: `make tui-driver-selftest` (gate) · `make tui-driver` (drive by
+  hand)
+
+---
+
+## 1. The interaction model — read this first
+
+The #1156 mis-drive happened because the driver didn't know *which mode the
+TUI was in*. Get this right and the rest follows.
+
+### Nav mode vs interactive mode
+
+| Mode | What the keyboard does | Menu bar shows | How you got here |
+|------|------------------------|----------------|------------------|
+| **Nav** | Keys are TUI commands (`n` new, `s` open pane, `t` new tab, `j`/`k` move the tree cursor, …) | context hints (`n new • …`, `↵ interact • …`) | default; `Ctrl-]` from interactive |
+| **Interactive** | *Every* key — including Tab — forwards to the focused pane's shell/agent | only `ctrl+] nav mode` | `Enter` on a focused pane |
+| **Attached (full-screen)** | tmux owns the terminal; the TUI chrome is gone | the tmux status line (`[af_…`) | `o` on a selected instance |
+
+The single most important primitive is **`af_ensure_nav`** — it sends `Ctrl-]`
+(a no-op in nav, the escape hatch from interactive) so a scenario can never
+mistake a live pane for the host. Call it before any nav action. This is the
+one-line fix for the entire #1156 class.
+
+### The focus ring
+
+In nav mode, `Tab`/`Shift-Tab` cycle **ring focus** across regions: the
+**instances tree** → each open **pane** → the **automations** strip → back.
+The menu bar is context-sensitive and follows focus:
+
+- **tree** focused → `n new • …` (plus instance verbs when a row is selected)
+- **pane** focused → `↵ interact • o attach • … • s open pane • x hide pane`
+- **automations** focused → `enter manage • …`
+
+`af_focus_tree` walks the ring (checking *before* it presses, so it never
+Tabs off the tree) until the `n new` hint proves the tree has focus.
+
+### The instances tree
+
+The left rail is a tree: each instance row carries its tabs as children. The
+**display-selected instance auto-expands** (arrow `▾`, its tab children shown)
+while every other instance collapses (arrow `▸`). That arrow is the reliable,
+text-greppable selection signal the driver asserts on:
+
+```
+  ▾ 1.  alpha         ●      ← selected (expanded); ● = ready
+       └ 1 Preview *
+  ▸ 2.  beta          ●      ← not selected (collapsed)
+```
+
+On a cold boot the cursor sits on the **section header** (no instance selected
+— menu shows the plain `n new • N new remote` set); the first `j` moves the
+cursor down onto the first instance. `af_select` is robust to any starting
+position: it anchors at the top (`k` is idempotent there), then steps down
+with `j` until the target row shows `▾`.
+
+### Which key goes where (defaults, from `keys/keys.go`)
+
+| Key | Nav action | | Key | Nav action |
+|-----|-----------|-|-----|-----------|
+| `n` | new instance | | `s` | open selected tab as pane |
+| `Enter` | interact (enter pane) | | `x` | hide focused pane |
+| `o` | attach full-screen | | `t` | new tab |
+| `Ctrl-]` | exit interactive → nav | | `w` | close tab |
+| `Tab` | cycle focus ring | | `1`–`9` | jump to tab |
+| `j`/`k`,`↓`/`↑` | move tree cursor | | `S` | tasks overlay |
+| `D` | kill instance | | `/` | search |
+| `Ctrl-W` | detach (full-screen) | | `q` | quit |
+
+`Enter`, `Tab`, `Shift-Tab`, `Esc`, `Ctrl-]`, and `1`–`9` are **reserved** and
+cannot be rebound (`[keys]` config). `Ctrl-W` is the configurable detach key
+(`detach_keys`); the driver reads it from `AF_DRIVER_DETACH_KEY`.
+
+---
+
+## 2. The wait-not-sleep principle
+
+**Never synchronize on a fixed `sleep`.** A `sleep 2` is a bet that the TUI
+finished repainting in under two seconds — it flakes when it's slow and wastes
+time when it's fast. Instead, every action helper returns *only once the screen
+shows its completion marker*:
+
+```bash
+af_send n                      # request a new instance
+af_wait_for 'submit name'      # ← block until the name prompt actually appears
+```
+
+`af_wait_for <regex> [timeout] [label]` polls `capture-pane` (a short poll
+interval, **not** a synchronization sleep) until the screen matches, and dumps
+the last screen on timeout so a failure is debuggable. `af_wait_gone` is the
+inverse. Every scenario helper is built from these, so a scenario is a
+straight-line list of intent with no timing knobs.
+
+---
+
+## 3. Driver command reference
+
+Source the library inside the container, then call the functions. State lives
+in the running TUI (a private tmux session, default name `drive`), so calls
+compose across `docker exec` invocations.
+
+### Anti-flake core
+
+| Function | What it does |
+|----------|--------------|
+| `af_wait_for <re> [t] [label]` | poll until the screen matches `<re>` (no blind sleeps) |
+| `af_wait_gone <re> [t] [label]` | poll until `<re>` is absent |
+| `af_ensure_nav` | `Ctrl-]` → force nav mode (fixes the #1156 class) |
+| `af_focus_tree` | Tab the ring until the instances tree has focus |
+
+### Scenario helpers (each self-synchronizes on its marker)
+
+| Function | Keys | Completion marker |
+|----------|------|-------------------|
+| `af_reset_sandbox` | — | wipes instances/branches for a deterministic rerun (sandbox-scoped, fails closed) |
+| `af_boot` | launch `af` | `Agent Factory` + `Instances (` frame |
+| `af_new_instance <name>` | `n`,text,`Enter` | the row shows `<name> … ●` (ready) |
+| `af_select <name>` | `k`×,`j`× | `<name>`'s row shows `▾` |
+| `af_open_pane` | `s` | pane-focus menu (`x hide pane`) |
+| `af_hide_pane` | `x` | focus back on tree (`n new`) |
+| `af_enter_interactive` | `Enter` | interactive menu (`ctrl+] nav mode`) |
+| `af_exit_interactive` | `Ctrl-]` | interactive menu gone |
+| `af_send_to_pane <text>` | text,`Enter` | input echoes in the pane (then wait for output yourself) |
+| `af_attach` | `o` | TUI chrome gone (full-screen) |
+| `af_detach` | `Ctrl-W` | TUI chrome back **and** the attach client is reaped (guards #1157) |
+| `af_new_tab` | `t` | tab-child count rises |
+| `af_close_tab` | `w` | tab-child count falls |
+| `af_open_tasks` / `af_close_tasks` | `S` / `Esc` | tasks overlay (`r run now`) appears / gone |
+| `af_click <x> <y>` / `af_click_instance <name>` | SGR mouse | injects a left click at a cell / on an instance row |
+| `af_scroll <up\|down> [x] [y]` | SGR wheel | injects a wheel event |
+| `af_set_config <toml>` + `af_relaunch` | — | rewrites `config.toml` (canonical since #1030) and reboots the TUI |
+| `af_quit` | `q` | back to a shell prompt |
+
+### Assertions & introspection
+
+| Function | Pass condition |
+|----------|----------------|
+| `af_assert_screen <re>` / `af_refute_screen <re>` | screen matches / does not match |
+| `af_expect_selected <name>` | `<name>`'s row carries `▾` |
+| `af_tmux_ls` | prints the tmux sessions (introspection) |
+| `af_ps` | prints the daemon + tmux attach/new-session process tree |
+| `af_assert_no_orphan_clients` | no `tmux attach-session` reparented to init (the #1155/#1157 leak signature); the daemon's own monitor clients are parented to the daemon and excluded |
+
+### Configuration (env vars)
+
+`AF_DRIVER_SESSION` (`drive`), `AF_DRIVER_COLS`/`ROWS` (`100`/`30`),
+`AF_DRIVER_REPO` (`$HOME/sandbox/mock-repo`), `AGENT_FACTORY_HOME`,
+`AF_DRIVER_TIMEOUT` (`25`s), `AF_DRIVER_POLL` (`0.25`s),
+`AF_DRIVER_DETACH_KEY` (`C-w`), `AF_DRIVER_BIN` (auto-resolved).
+
+---
+
+## 4. Running it
+
+### The self-test (acceptance proof + bitrot guard)
+
+```bash
+make tui-driver-selftest
+```
+
+Boots a **dedicated** container sandbox (`af-driver-selftest`, so it never
+disturbs a `drive`/`playtest` container you have open), then runs the exact
+scenario that failed in #1156, now deterministic:
+
+> reset → boot → create **two** instances → select each (assert selection) →
+> open a pane → enter interactive → type into the pane → exit → attach
+> full-screen → detach → assert selection preserved → assert no orphan clients.
+
+Green means the driver drives the TUI reliably. Any failure prints the step
+and the offending screen.
+
+### Driving by hand
+
+```bash
+make tui-driver          # boots af via the driver, then attaches you to the
+                         # live session (detach with your tmux prefix + d)
+```
+
+Or drive over `docker exec` against a detached sandbox
+(`make playtest-container-detached`):
+
+```bash
+docker exec af-playtest bash -lc '
+  source /src/scripts/tui-driver.sh
+  af_boot
+  af_new_instance alpha
+  af_new_instance beta
+  af_select beta && af_expect_selected beta
+  af_open_pane && af_enter_interactive
+  af_send_to_pane "echo hi"
+  af_exit_interactive
+  af_assert_no_orphan_clients
+'
+```
+
+Everything runs inside the container — the host tmux server, the real
+`~/.agent-factory`, and this repo are all untouched.
+
+---
+
+## 5. Gate-recipe library
+
+To gate a visible-TUI PR, run the scenario for its class and assert the
+markers. All of these are driver calls; each already self-synchronizes.
+
+### Any TUI-visible change → the smoke gate
+
+```bash
+make tui-driver-selftest
+```
+
+The self-test is the baseline gate for *any* PR that touches startup, the
+sidebar/tree, panes, interactive mode, or attach/detach. If it isn't green,
+stop.
+
+### Tree / selection / focus changes (the #1156, #1084 class)
+
+```bash
+af_boot
+af_new_instance a; af_new_instance b; af_new_instance c   # (cap: 3)
+af_select a; af_expect_selected a
+af_select c; af_expect_selected c
+af_select b; af_expect_selected b
+# after closing/killing, selection must not silently drift:
+af_open_pane; af_close_tab; af_expect_selected b
+```
+
+### Pane / interactive changes (the #1088, #1089 class)
+
+```bash
+af_select a; af_open_pane
+af_enter_interactive
+af_send_to_pane 'echo PANE_OK'; af_wait_for 'PANE_OK'
+af_exit_interactive
+af_refute_screen 'nav mode'          # cleanly back in nav
+af_hide_pane                          # pane hides, nothing killed
+```
+
+### Attach / detach changes (the #1155, #1157, #1159 class)
+
+```bash
+af_select a
+af_attach                             # full-screen
+af_detach                             # syncs on the attach client being reaped
+af_assert_no_orphan_clients           # the hard leak check
+af_expect_selected a                  # selection survives the round trip
+```
+
+### Tabs (the #930 class)
+
+```bash
+af_select a
+af_new_tab; af_new_tab                # add two shell tabs
+af_close_tab
+```
+
+### Config / keymap changes (the #1030 class)
+
+```bash
+af_set_config "$(cat <<'TOML'
+default_program = 'claude'
+[program_overrides]
+claude = 'bash'
+[keys]
+new = ['c']
+TOML
+)"
+af_relaunch
+af_ensure_nav; af_focus_tree
+af_send c; af_wait_for 'submit name'  # the rebound 'new' key works
+```
+
+### Mouse (the #1143 class)
+
+```bash
+af_new_instance a; af_new_instance b
+af_click_instance a; af_expect_selected a
+af_click_instance b; af_expect_selected b
+af_scroll down; af_scroll up
+```
+
+---
+
+## 6. Isolation & box safety (inherited from the container)
+
+Every rule from the [tui-playtest skill](../.claude/skills/tui-playtest.md)
+is satisfied *structurally* by running inside the container: private tmux
+server, throwaway `AGENT_FACTORY_HOME`, pre-built mock repo, pids/memory caps,
+teardown is `docker rm -f`. The driver reinforces this:
+
+- It only ever kills its **own** named session and (in `af_reset_sandbox`) the
+  sandbox's `af_*` sessions — **never `kill-server`**.
+- `af_reset_sandbox` **fails closed**: it refuses to wipe anything unless
+  `AGENT_FACTORY_HOME` and the mock repo are sandbox paths, so it can never
+  touch a real `~/.agent-factory`.
+- Instances run the cheap `bash` program (the sandbox's `config.toml`
+  override), never a real agent or an unbounded generator.

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -193,11 +193,14 @@ make tui-driver          # boots af via the driver, then attaches you to the
                          # live session (detach with your tmux prefix + d)
 ```
 
-Or drive over `docker exec` against a detached sandbox
-(`make playtest-container-detached`):
+Or drive over `docker exec` against a detached sandbox. The container name is
+unique per run (#1171); pin it with `AF_PLAYTEST_NAME` so your `docker exec`
+targets it:
 
 ```bash
-docker exec af-playtest bash -lc '
+export AF_PLAYTEST_NAME="af-playtest-$$"
+make playtest-container-detached
+docker exec "$AF_PLAYTEST_NAME" bash -lc '
   source /src/scripts/tui-driver.sh
   af_boot
   af_new_instance alpha
@@ -208,6 +211,7 @@ docker exec af-playtest bash -lc '
   af_exit_interactive
   af_assert_no_orphan_clients
 '
+docker rm -f "$AF_PLAYTEST_NAME"   # teardown
 ```
 
 Everything runs inside the container — the host tmux server, the real

--- a/scripts/container/playtest-entry.sh
+++ b/scripts/container/playtest-entry.sh
@@ -15,7 +15,18 @@ export AGENT_FACTORY_HOME="${AGENT_FACTORY_HOME:-$SANDBOX/home}"
 mkdir -p "$AGENT_FACTORY_HOME" "$HOME/bin"
 
 echo ">>> building af from /src ..."
-(cd /src && go build -o "$HOME/bin/af" .)
+# /src is a read-only bind mount owned by the HOST user, so its uid rarely
+# matches the container's `dev` user. Two guards keep the build from aborting
+# on that ownership mismatch (#1167):
+#   * safe.directory tells git not to refuse the "dubious ownership" repo, and
+#   * -buildvcs=false stops the toolchain reading .git for a VCS stamp at all
+#     ("error obtaining VCS status: exit status 128"). run-tests.sh strips
+#     .git by copying; here we build in place, so we disable buildvcs instead.
+# Keep both entry scripts consistent on this.
+# Run the config from a NON-repo cwd (the image WORKDIR is /src, and git would
+# otherwise try to resolve /src's foreign/broken .git and refuse to write).
+(cd / && git config --global --add safe.directory /src) 2>/dev/null || true
+(cd /src && go build -buildvcs=false -o "$HOME/bin/af" .)
 
 # Cheap instances: run a plain shell instead of a real agent. Since
 # #1116/#1131 af keys flag injection and readiness off the program the
@@ -32,9 +43,13 @@ if [ ! -d "$MOCK" ]; then
     mkdir -p "$MOCK"
     cd "$MOCK"
     git init -q -b master
+    # printf writes literal shell into the mock repo — the $VARs are meant to
+    # stay unexpanded, so single quotes are correct here.
+    # shellcheck disable=SC2016
     printf '#!/bin/bash\n# todo: list, add <text>, done <n>\nTODO_FILE="${TODO_FILE:-todo.txt}"\ntouch "$TODO_FILE"\ncase "$1" in\n  add) shift; echo "$*" >> "$TODO_FILE";;\n  done) sed -i "${2}d" "$TODO_FILE";;\n  *) nl -ba "$TODO_FILE";;\nesac\n' >todo.sh
     chmod +x todo.sh
     printf '# todo\nA tiny shell todo app.\n\nUsage: ./todo.sh [add <text> | done <n>]\n' >README.md
+    # shellcheck disable=SC2016
     printf '#!/bin/bash\nset -e\nexport TODO_FILE=$(mktemp)\n./todo.sh add "first item"\n./todo.sh | grep -q "first item"\nrm -f "$TODO_FILE"\necho ok\n' >test.sh
     chmod +x test.sh
     git add -A && git commit -qm "initial project"

--- a/scripts/container/run-tests.sh
+++ b/scripts/container/run-tests.sh
@@ -5,6 +5,12 @@
 # server and a throwaway home, so nothing can leak onto the host.
 set -euo pipefail
 
+# /src is a read-only mount owned by the host user; mark it safe so any git
+# invocation the toolchain makes does not refuse it as "dubious ownership"
+# (#1167). Run from a non-repo cwd (WORKDIR is /src). Kept in step with
+# playtest-entry.sh.
+(cd / && git config --global --add safe.directory /src) 2>/dev/null || true
+
 # Copy without .git: dev checkouts are often linked worktrees whose .git is
 # a pointer to a host path that does not exist in the container.
 mkdir -p /work
@@ -14,4 +20,6 @@ cd /work
 if [ $# -eq 0 ]; then
     set -- ./...
 fi
-exec go test -count=1 "$@"
+# -buildvcs=false: /work has no .git, but disabling the VCS stamp keeps the
+# build off git entirely and consistent with the play-test build (#1167).
+exec go test -count=1 -buildvcs=false "$@"

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -19,7 +19,21 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE="${AF_TESTBOX_IMAGE:-agent-factory-testbox}"
-PLAYTEST_NAME="${AF_PLAYTEST_NAME:-af-playtest}"
+
+# _uniq — a per-invocation token (pid + a little randomness) for container
+# names, so two runs never share a name.
+_uniq() {
+    local r=""
+    [ -r /dev/urandom ] && r="$(od -An -N3 -tx1 /dev/urandom 2>/dev/null | tr -d ' ')"
+    printf '%s' "$$${r:+-$r}"
+}
+
+# The sandbox container name defaults to a UNIQUE per-run value so concurrent
+# play-tests can't `docker rm -f` each other mid-run (#1171). Pin it with
+# AF_PLAYTEST_NAME to reuse/target a specific container. Whatever the value,
+# every message, teardown hint, and `docker exec`/`rm` below uses THIS
+# resolved name — never a hardcoded 'af-playtest'.
+PLAYTEST_NAME="${AF_PLAYTEST_NAME:-af-playtest-$(_uniq)}"
 
 # docker-or-podman autodetect (docker on the current dev box; podman kept
 # as a fallback for other boxes).
@@ -137,24 +151,34 @@ playtest)
     fi
     ;;
 selftest)
-    # Bring up (or reuse) a DEDICATED sandbox and run the TUI driver
-    # self-test inside it (#1161). Its own container name means running the
-    # gate never disturbs a `drive`/`playtest` sandbox you have open. The
-    # self-test resets sandbox state at its start, so a reused container is
-    # still deterministic.
-    PLAYTEST_NAME="${AF_SELFTEST_NAME:-af-driver-selftest}"
+    # Run the TUI driver self-test (#1161) in an EPHEMERAL, uniquely-named
+    # dedicated sandbox: unique so concurrent gates don't clobber each other
+    # (#1171), ephemeral so gates leave nothing behind. Pin AF_SELFTEST_NAME
+    # to reuse a specific container (then it is NOT torn down). The self-test
+    # also resets sandbox state at its start, so a pinned reused container
+    # stays deterministic.
+    if [ -n "${AF_SELFTEST_NAME:-}" ]; then
+        PLAYTEST_NAME="$AF_SELFTEST_NAME"; teardown=no
+    else
+        PLAYTEST_NAME="af-driver-selftest-$(_uniq)"; teardown=yes
+    fi
     ensure_playtest_up
-    exec "$ENGINE" exec "$PLAYTEST_NAME" bash /src/scripts/tui-driver-selftest.sh
+    rc=0
+    "$ENGINE" exec "$PLAYTEST_NAME" bash /src/scripts/tui-driver-selftest.sh || rc=$?
+    if [ "$teardown" = yes ]; then
+        "$ENGINE" rm -f "$PLAYTEST_NAME" >/dev/null 2>&1 || true
+    fi
+    exit "$rc"
     ;;
 drive)
-    # Bring up (or reuse) the detached sandbox, boot af through the driver,
+    # Bring up a uniquely-named sandbox (#1171), boot af through the driver,
     # then attach you interactively to the live driver session so you can
-    # watch/drive it by hand. Detach with your tmux prefix + d; tear the
-    # sandbox down with: $ENGINE rm -f $PLAYTEST_NAME
+    # watch/drive it by hand. Detach with your tmux prefix + d.
     ensure_playtest_up
     "$ENGINE" exec "$PLAYTEST_NAME" bash -lc \
         'source /src/scripts/tui-driver.sh && af_boot' >&2
-    echo "testbox: af is up in session 'drive'; attaching (detach with prefix+d)..." >&2
+    echo "testbox: af is up in session 'drive'; attaching (detach with prefix+d)." >&2
+    echo "testbox: tear down with: $ENGINE rm -f $PLAYTEST_NAME" >&2
     exec "$ENGINE" exec -it "$PLAYTEST_NAME" tmux attach -t drive
     ;;
 *)

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -7,6 +7,8 @@
 #   scripts/testbox.sh test [go-test-args...]  full suite (default ./...)
 #   scripts/testbox.sh playtest                interactive sandbox shell
 #   scripts/testbox.sh playtest -d             detached; drive via `docker exec`
+#   scripts/testbox.sh selftest                run the TUI driver self-test (#1161)
+#   scripts/testbox.sh drive                   boot af via the driver + attach
 #   scripts/testbox.sh build                   (re)build the image only
 #
 # The container gets: its own tmux server, a throwaway AF home, pids/memory
@@ -77,6 +79,30 @@ fix_cache_perms() {
         "$IMAGE" chown -R dev:dev /cache >/dev/null
 }
 
+# start_playtest_detached — run the play-test sandbox container detached, so a
+# driver can work it over `docker exec`. Shared by `playtest -d`, `selftest`,
+# and `drive`.
+start_playtest_detached() {
+    "$ENGINE" run -d \
+        "${RUN_FLAGS[@]}" \
+        --name "$PLAYTEST_NAME" \
+        -e AGENT_FACTORY_HOME=/home/dev/sandbox/home \
+        "$IMAGE" bash /src/scripts/container/playtest-entry.sh hold >/dev/null
+}
+
+# ensure_playtest_up — start the detached sandbox if it is not already
+# running, then block until af has finished building inside it.
+ensure_playtest_up() {
+    if ! "$ENGINE" inspect -f '{{.State.Running}}' "$PLAYTEST_NAME" 2>/dev/null | grep -q true; then
+        "$ENGINE" rm -f "$PLAYTEST_NAME" >/dev/null 2>&1 || true
+        build_image
+        fix_cache_perms
+        echo "testbox: starting sandbox '$PLAYTEST_NAME' (af builds on boot)..." >&2
+        start_playtest_detached
+    fi
+    "$ENGINE" exec "$PLAYTEST_NAME" sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'
+}
+
 cmd="${1:-test}"
 [ $# -gt 0 ] && shift
 
@@ -94,15 +120,8 @@ test)
 playtest)
     build_image
     fix_cache_perms
-    RUN_FLAGS+=(
-        --name "$PLAYTEST_NAME"
-        # docker exec inherits env set at create time, so the sandbox home
-        # is visible to every exec'd command, not just the entry script.
-        -e AGENT_FACTORY_HOME=/home/dev/sandbox/home
-    )
     if [ "${1:-}" = "-d" ]; then
-        "$ENGINE" run -d "${RUN_FLAGS[@]}" "$IMAGE" \
-            bash /src/scripts/container/playtest-entry.sh hold >/dev/null
+        start_playtest_detached
         echo "playtest sandbox '$PLAYTEST_NAME' is starting (af builds on boot)."
         echo "  wait for it:  $ENGINE exec $PLAYTEST_NAME sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'"
         echo "  drive it:     $ENGINE exec $PLAYTEST_NAME tmux new-session -d -s drive -x 80 -y 24"
@@ -110,12 +129,36 @@ playtest)
         echo "                $ENGINE exec $PLAYTEST_NAME tmux capture-pane -p -t drive"
         echo "  tear down:    $ENGINE rm -f $PLAYTEST_NAME"
     else
-        exec "$ENGINE" run -it "${RUN_FLAGS[@]}" "$IMAGE" \
-            bash /src/scripts/container/playtest-entry.sh
+        exec "$ENGINE" run -it \
+            "${RUN_FLAGS[@]}" \
+            --name "$PLAYTEST_NAME" \
+            -e AGENT_FACTORY_HOME=/home/dev/sandbox/home \
+            "$IMAGE" bash /src/scripts/container/playtest-entry.sh
     fi
     ;;
+selftest)
+    # Bring up (or reuse) a DEDICATED sandbox and run the TUI driver
+    # self-test inside it (#1161). Its own container name means running the
+    # gate never disturbs a `drive`/`playtest` sandbox you have open. The
+    # self-test resets sandbox state at its start, so a reused container is
+    # still deterministic.
+    PLAYTEST_NAME="${AF_SELFTEST_NAME:-af-driver-selftest}"
+    ensure_playtest_up
+    exec "$ENGINE" exec "$PLAYTEST_NAME" bash /src/scripts/tui-driver-selftest.sh
+    ;;
+drive)
+    # Bring up (or reuse) the detached sandbox, boot af through the driver,
+    # then attach you interactively to the live driver session so you can
+    # watch/drive it by hand. Detach with your tmux prefix + d; tear the
+    # sandbox down with: $ENGINE rm -f $PLAYTEST_NAME
+    ensure_playtest_up
+    "$ENGINE" exec "$PLAYTEST_NAME" bash -lc \
+        'source /src/scripts/tui-driver.sh && af_boot' >&2
+    echo "testbox: af is up in session 'drive'; attaching (detach with prefix+d)..." >&2
+    exec "$ENGINE" exec -it "$PLAYTEST_NAME" tmux attach -t drive
+    ;;
 *)
-    echo "testbox: unknown command '$cmd' (want: test | playtest | build)" >&2
+    echo "testbox: unknown command '$cmd' (want: test | playtest | selftest | drive | build)" >&2
     exit 1
     ;;
 esac

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# tui-driver-selftest.sh — the acceptance proof for the #1161 TUI driver.
+#
+# Runs the exact scenario that failed in #1156 — and it is now a handful of
+# self-synchronizing lines instead of a hand-rolled tmux harness:
+#
+#   boot → create TWO instances → select each (assert selection) →
+#   open a pane → enter interactive → type into the pane → exit →
+#   attach full-screen → detach → assert selection preserved →
+#   assert no orphan attach clients.
+#
+# It is BOTH the acceptance proof and the bitrot guard. Run it in the
+# container sandbox:
+#
+#   make tui-driver-selftest
+#   # or directly:
+#   docker exec af-playtest bash /src/scripts/tui-driver-selftest.sh
+#
+# Exit status: 0 = every step green; non-zero = the first failed step (with
+# the offending screen dumped to stderr by the driver).
+
+set -uo pipefail
+
+# Resolve the driver next to this script (works from /src in the container).
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/tui-driver.sh
+source "$SELF_DIR/tui-driver.sh"
+
+PASS=0
+FAIL=0
+
+# step <description> <command...> — run a driver step, tally, and abort the
+# whole run on the first failure (a broken premise makes later steps noise).
+step() {
+    local desc="$1"; shift
+    printf '\n>>> %s\n' "$desc"
+    if "$@"; then
+        printf '    ✓ %s\n' "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf '    ✗ FAILED: %s\n' "$desc"
+        FAIL=$((FAIL + 1))
+        printf '\n=== SELF-TEST FAILED at: %s ===\n' "$desc"
+        printf 'passed %d step(s) before the failure.\n' "$PASS"
+        exit 1
+    fi
+}
+
+printf '=== tui-driver self-test (#1161) ===\n'
+printf 'session=%s size=%sx%s home=%s\n' \
+    "$AF_DRIVER_SESSION" "$AF_DRIVER_COLS" "$AF_DRIVER_ROWS" "$AGENT_FACTORY_HOME"
+
+# Start from a clean slate so the run is deterministic even in a reused
+# container (scoped to the sandbox; fails closed on a non-sandbox home).
+step "reset sandbox to a clean state"                       af_reset_sandbox
+step "boot af at ${AF_DRIVER_COLS}x${AF_DRIVER_ROWS}"        af_boot
+step "create instance 'alpha'"                              af_new_instance alpha
+step "create instance 'beta'"                               af_new_instance beta
+
+# The #1156 failure, now two lines each.
+step "select alpha"                                         af_select alpha
+step "assert alpha is selected"                             af_expect_selected alpha
+step "select beta"                                          af_select beta
+step "assert beta is selected"                              af_expect_selected beta
+
+step "open beta's tab as a pane"                            af_open_pane
+step "enter interactive mode"                               af_enter_interactive
+step "type a command into the pane"                         af_send_to_pane 'echo DRIVER_SELFTEST_OK'
+step "assert the pane ran it"                               af_wait_for 'DRIVER_SELFTEST_OK' 10 'pane output'
+step "exit interactive mode"                                af_exit_interactive
+
+step "attach full-screen"                                   af_attach
+step "detach (and prove the attach client was reaped)"      af_detach
+
+step "assert selection survived attach/detach"              af_expect_selected beta
+step "assert no orphan tmux attach clients"                 af_assert_no_orphan_clients
+
+printf '\n=== SELF-TEST PASSED — %d/%d steps green ===\n' "$PASS" "$PASS"
+printf 'the #1156 mis-drive is now a deterministic scenario.\n'
+
+# Leave the sandbox as we found it (best-effort; container teardown is the
+# real cleanup).
+af_quit >/dev/null 2>&1 || true
+exit 0

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -13,8 +13,8 @@
 # container sandbox:
 #
 #   make tui-driver-selftest
-#   # or directly:
-#   docker exec af-playtest bash /src/scripts/tui-driver-selftest.sh
+#   # or directly against a running sandbox (name is unique per run, #1171):
+#   docker exec "$AF_PLAYTEST_NAME" bash /src/scripts/tui-driver-selftest.sh
 #
 # Exit status: 0 = every step green; non-zero = the first failed step (with
 # the offending screen dumped to stderr by the driver).
@@ -65,8 +65,16 @@ step "assert beta is selected"                              af_expect_selected b
 
 step "open beta's tab as a pane"                            af_open_pane
 step "enter interactive mode"                               af_enter_interactive
-step "type a command into the pane"                         af_send_to_pane 'echo DRIVER_SELFTEST_OK'
-step "assert the pane ran it"                               af_wait_for 'DRIVER_SELFTEST_OK' 10 'pane output'
+# The command COMPUTES its marker (arithmetic expansion), so the sentinel we
+# assert on — SELFTEST_42 — appears ONLY in the command's output, never in the
+# echoed input line (which shows the literal $((6*7))). A shell that echoed
+# input but failed to RUN it would therefore fail this step (Greptile P2).
+# Single quotes are REQUIRED: the arithmetic must reach the pane's shell
+# unexpanded, not be computed by this script.
+# shellcheck disable=SC2016
+step "type a command into the pane"                         af_send_to_pane 'echo SELFTEST_$((6*7))'
+step "assert the pane RAN it (computed marker, not input echo)" \
+    af_wait_for 'SELFTEST_42([^0-9]|$)' 10 'computed pane output'
 step "exit interactive mode"                                af_exit_interactive
 
 step "attach full-screen"                                   af_attach

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -4,8 +4,11 @@
 # the live TUI through a private tmux session, syncing every action on a
 # screen marker instead of a blind `sleep`.
 #
-#   docker exec af-playtest bash -lc \
+#   docker exec "$AF_PLAYTEST_NAME" bash -lc \
 #     'source /src/scripts/tui-driver.sh && af_boot && af_new_instance alpha'
+#
+# (The sandbox container name is unique per run — #1171; pin AF_PLAYTEST_NAME
+# to target it. `make tui-driver-selftest` handles all of this for you.)
 #
 # The container already solves ISOLATION (throwaway home, mock repo, private
 # tmux, pids/memory caps — scripts/testbox.sh + docs/container-testing.md).

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -1,0 +1,528 @@
+#!/usr/bin/env bash
+# tui-driver.sh — a deterministic, scriptable driver for the real Agent
+# Factory TUI (#1161). Source it INSIDE the #1130 container sandbox and drive
+# the live TUI through a private tmux session, syncing every action on a
+# screen marker instead of a blind `sleep`.
+#
+#   docker exec af-playtest bash -lc \
+#     'source /src/scripts/tui-driver.sh && af_boot && af_new_instance alpha'
+#
+# The container already solves ISOLATION (throwaway home, mock repo, private
+# tmux, pids/memory caps — scripts/testbox.sh + docs/container-testing.md).
+# This library is the DRIVING + ASSERTION layer on top of it: the piece whose
+# absence caused the #1156 mis-drive (keys landing in a live pane as text)
+# and the #1155 hand-rolled-harness death.
+#
+# Design rules:
+#   * Every action helper is SELF-SYNCHRONIZING: it returns only once the
+#     screen shows its completion marker (af_wait_for), never after a fixed
+#     sleep. The only sleeps here are short poll intervals between captures.
+#   * af_ensure_nav forces a known focus state (Ctrl-]) so a scenario can
+#     never mistake interactive mode for nav mode — the #1156 root cause.
+#   * Nothing touches the host: it talks only to the container's own tmux
+#     server. It never runs `tmux kill-server`; it only ever kills its OWN
+#     named driver session.
+#
+# See docs/tui-manual-testing.md for the interaction model and gate recipes.
+
+# ----------------------------------------------------------------------------
+# Configuration (override via environment before sourcing / calling af_boot).
+# ----------------------------------------------------------------------------
+: "${AF_DRIVER_SESSION:=drive}"                 # tmux session the TUI runs in
+: "${AF_DRIVER_COLS:=100}"                       # launch width
+: "${AF_DRIVER_ROWS:=30}"                        # launch height
+: "${AF_DRIVER_REPO:=$HOME/sandbox/mock-repo}"   # cwd the TUI launches in
+: "${AGENT_FACTORY_HOME:=$HOME/sandbox/home}"    # sandbox AF home
+: "${AF_DRIVER_BIN:=}"                            # af path ("" → auto-resolve)
+: "${AF_DRIVER_TIMEOUT:=25}"                      # default wait timeout (s)
+: "${AF_DRIVER_POLL:=0.25}"                       # capture-pane poll interval
+: "${AF_DRIVER_DETACH_KEY:=C-w}"                 # tmux key that detaches attach
+: "${AF_DRIVER_STATE_DIR:=${TMPDIR:-/tmp}/af-driver}"  # cross-call scratch
+
+export AGENT_FACTORY_HOME
+
+# ----------------------------------------------------------------------------
+# Low-level plumbing.
+# ----------------------------------------------------------------------------
+_af_log()  { printf '[tui-driver] %s\n' "$*" >&2; }
+_af_fail() { printf '[tui-driver] FAIL: %s\n' "$*" >&2; return 1; }
+
+# _af_now — seconds since epoch (its own function so a test can stub it).
+_af_now() { date +%s; }
+
+# af_capture — the current TUI screen as plain text.
+af_capture() { tmux capture-pane -p -t "$AF_DRIVER_SESSION" 2>/dev/null; }
+
+# af_send <key>... — deliver key(s) to the TUI (tmux key names: Enter, Tab,
+# Escape, 'C-]', or literal chars). Keys are interpreted by tmux.
+af_send() { tmux send-keys -t "$AF_DRIVER_SESSION" "$@"; }
+
+# af_send_literal <string> — deliver a string verbatim (no key-name parsing);
+# also the injection path for raw SGR mouse sequences.
+af_send_literal() { tmux send-keys -t "$AF_DRIVER_SESSION" -l "$1"; }
+
+# _af_resolve_bin — the af binary to launch/readiness-check. Prefer PATH, fall
+# back to the container's build output.
+_af_resolve_bin() {
+    if [ -n "$AF_DRIVER_BIN" ]; then printf '%s' "$AF_DRIVER_BIN"
+    elif command -v af >/dev/null 2>&1; then command -v af
+    else printf '%s' "$HOME/bin/af"; fi
+}
+
+# _af_regex_escape <s> — escape ERE metacharacters so a literal can be waited
+# on with af_wait_for.
+_af_regex_escape() { printf '%s' "$1" | sed -E 's/[.[\({*+?^$|)}\]\\]/\\&/g'; }
+
+# ----------------------------------------------------------------------------
+# Anti-flake core — wait on the screen, never on the clock.
+# ----------------------------------------------------------------------------
+
+# af_wait_for <regex> [timeout_s] [label] — poll capture-pane until the screen
+# matches <regex>. Returns 0 on match, 1 on timeout (dumping the last screen).
+af_wait_for() {
+    local re="$1" timeout="${2:-$AF_DRIVER_TIMEOUT}" label="${3:-$1}" screen
+    local deadline; deadline=$(( $(_af_now) + timeout ))
+    while :; do
+        screen="$(af_capture)"
+        if printf '%s\n' "$screen" | grep -qE -- "$re"; then
+            return 0
+        fi
+        if [ "$(_af_now)" -ge "$deadline" ]; then
+            _af_log "TIMEOUT ${timeout}s waiting for: $label"
+            _af_log "----- last screen -----"
+            printf '%s\n' "$screen" >&2
+            _af_log "-----------------------"
+            return 1
+        fi
+        sleep "$AF_DRIVER_POLL"
+    done
+}
+
+# af_wait_gone <regex> [timeout_s] [label] — the inverse: wait until <regex> is
+# absent from the screen.
+af_wait_gone() {
+    local re="$1" timeout="${2:-$AF_DRIVER_TIMEOUT}" label="${3:-!$1}" screen
+    local deadline; deadline=$(( $(_af_now) + timeout ))
+    while :; do
+        screen="$(af_capture)"
+        if ! printf '%s\n' "$screen" | grep -qE -- "$re"; then
+            return 0
+        fi
+        if [ "$(_af_now)" -ge "$deadline" ]; then
+            _af_log "TIMEOUT ${timeout}s waiting for absence of: $label"
+            printf '%s\n' "$screen" >&2
+            return 1
+        fi
+        sleep "$AF_DRIVER_POLL"
+    done
+}
+
+# af_ensure_nav — force a known focus state. Ctrl-] exits interactive mode (a
+# no-op in nav mode). This one primitive fixes the #1156 class: after it, keys
+# are guaranteed to reach the host, not a live pane as literal text.
+af_ensure_nav() {
+    af_send 'C-]'
+    sleep "$AF_DRIVER_POLL"
+}
+
+# af_focus_tree — put ring focus on the instances tree (the state whose menu
+# advertises `n new`). Checks BEFORE pressing, so it never Tabs off the tree
+# when already there. Assumes nav mode (call af_ensure_nav first).
+af_focus_tree() {
+    local _
+    for _ in $(seq 1 8); do
+        if af_capture | grep -qE -- 'n new'; then
+            return 0
+        fi
+        af_send Tab
+        sleep "$AF_DRIVER_POLL"
+    done
+    _af_fail "could not focus the tree ('n new' hint never appeared)"
+}
+
+# ----------------------------------------------------------------------------
+# Scenario helpers — each encodes the nav/interactive model and self-syncs.
+# ----------------------------------------------------------------------------
+
+# af_reset_sandbox — return the sandbox to a clean, instance-free state so a
+# scenario is deterministic across reruns in a REUSED container (the self-test
+# calls this first). Strictly scoped to the container's own sandbox: it stops
+# the sandbox daemon, kills the af_* instance sessions on THIS
+# container-private tmux server, and wipes the instance store. It never
+# touches the driver's own session and NEVER runs kill-server. Fails closed if
+# AGENT_FACTORY_HOME does not look like a sandbox path, so it can never wipe a
+# real ~/.agent-factory.
+af_reset_sandbox() {
+    case "$AGENT_FACTORY_HOME" in
+        */sandbox/*|*/sandbox|/tmp/*|*/af-driver*) ;;
+        *) _af_fail "af_reset_sandbox: refusing — '$AGENT_FACTORY_HOME' is not a sandbox path"; return 1 ;;
+    esac
+    tmux kill-session -t "$AF_DRIVER_SESSION" 2>/dev/null || true
+    if [ -f "$AGENT_FACTORY_HOME/daemon.pid" ]; then
+        kill "$(cat "$AGENT_FACTORY_HOME/daemon.pid")" 2>/dev/null || true
+    fi
+    local s
+    for s in $(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^af_' || true); do
+        tmux kill-session -t "$s" 2>/dev/null || true
+    done
+    rm -rf "$AGENT_FACTORY_HOME/instances" 2>/dev/null || true
+    rm -f "$AGENT_FACTORY_HOME/daemon.pid" "$AGENT_FACTORY_HOME/daemon.sock" \
+          "$AGENT_FACTORY_HOME/state.json" 2>/dev/null || true
+    # Remove leftover instance worktrees + branches in the mock repo, else a
+    # re-created instance of the same name collides on the existing branch.
+    # Scoped to a sandbox mock-repo path only.
+    case "$AF_DRIVER_REPO" in
+        */sandbox/*|/tmp/*)
+            rm -rf "${AF_DRIVER_REPO}"-* 2>/dev/null || true
+            if [ -d "$AF_DRIVER_REPO/.git" ]; then
+                git -C "$AF_DRIVER_REPO" worktree prune 2>/dev/null || true
+                local b
+                for b in $(git -C "$AF_DRIVER_REPO" for-each-ref \
+                    --format='%(refname:short)' refs/heads/ 2>/dev/null \
+                    | grep -vE '^(master|main)$' || true); do
+                    git -C "$AF_DRIVER_REPO" branch -D "$b" 2>/dev/null || true
+                done
+            fi
+            ;;
+    esac
+    sleep 0.5
+}
+
+# af_boot — launch af at a fixed size in a fresh driver session and wait for
+# the first frame. Pre-seeds help_screens_seen so the one-time overlays
+# (instance-created, attach, interactive) never appear — the single biggest
+# source of driver non-determinism.
+af_boot() {
+    mkdir -p "$AF_DRIVER_STATE_DIR" "$AGENT_FACTORY_HOME"
+    local bin; bin="$(_af_resolve_bin)"
+
+    # Wait for the container's on-boot `go build` to finish.
+    local deadline; deadline=$(( $(_af_now) + 180 ))
+    while [ ! -x "$bin" ]; do
+        if [ "$(_af_now)" -ge "$deadline" ]; then
+            _af_fail "af binary not found/executable at '$bin'"; return 1
+        fi
+        sleep 1
+    done
+
+    # Suppress every first-time help overlay (bits: 1 start | 2 attach |
+    # 4 interactive, plus the general help bit) BEFORE the TUI reads state.
+    printf '{\n  "help_screens_seen": 15\n}\n' > "$AGENT_FACTORY_HOME/state.json"
+
+    # Fresh driver session. Kill ONLY our own named session — never the
+    # server (the container hosts the daemon's sessions too).
+    tmux kill-session -t "$AF_DRIVER_SESSION" 2>/dev/null || true
+    tmux new-session -d -s "$AF_DRIVER_SESSION" -x "$AF_DRIVER_COLS" -y "$AF_DRIVER_ROWS"
+
+    af_send_literal "cd $AF_DRIVER_REPO && $bin"
+    af_send Enter
+    af_wait_for 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'af first frame' || return 1
+    af_wait_for 'Instances \(' "$AF_DRIVER_TIMEOUT" 'instances header' || return 1
+    af_focus_tree
+}
+
+# af_new_instance <name> — create an instance and wait until it is ready
+# (its row shows the ● ready dot). Cheap-instance config makes `bash` the
+# program, so ready arrives in seconds.
+af_new_instance() {
+    local name="$1"
+    [ -n "$name" ] || { _af_fail "af_new_instance: name required"; return 1; }
+    af_ensure_nav
+    af_focus_tree || return 1
+    af_send n
+    af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'name prompt' || return 1
+    af_send_literal "$name"
+    af_send Enter
+    af_wait_for "${name}.*●" "$AF_DRIVER_TIMEOUT" "instance '${name}' ready" || return 1
+}
+
+# af_select <name> — make <name> the display-selected instance. Robust to any
+# starting cursor position: anchor at the top (k is idempotent there), then
+# step down until <name>'s row carries the ▾ selected/expanded arrow.
+af_select() {
+    local name="$1" _ screen
+    [ -n "$name" ] || { _af_fail "af_select: name required"; return 1; }
+    af_ensure_nav
+    af_focus_tree || return 1
+    for _ in $(seq 1 30); do af_send k; done
+    sleep "$AF_DRIVER_POLL"
+    for _ in $(seq 1 40); do
+        screen="$(af_capture)"
+        if printf '%s\n' "$screen" | grep -qE -- "▾[[:space:]]+[0-9]+\.[[:space:]]+${name}([[:space:]]|\$)"; then
+            return 0
+        fi
+        af_send j
+        sleep "$AF_DRIVER_POLL"
+    done
+    _af_log "could not select '${name}'"
+    printf '%s\n' "$screen" >&2
+    return 1
+}
+
+# af_open_pane — open the selected instance's active tab as a workspace pane
+# (or focus its pane if already open). Precondition: an instance is selected
+# (call af_select first). Syncs on the pane-focus menu (`x hide pane`).
+af_open_pane() {
+    af_ensure_nav
+    af_focus_tree || return 1
+    af_send s
+    af_wait_for 'hide pane' "$AF_DRIVER_TIMEOUT" 'pane opened/focused' || return 1
+}
+
+# af_hide_pane — hide the focused pane back to the background (nothing is
+# killed). Precondition: a pane is focused. Syncs on focus returning to the
+# tree (`n new`).
+af_hide_pane() {
+    af_send x
+    af_wait_for 'n new' "$AF_DRIVER_TIMEOUT" 'pane hidden' || return 1
+}
+
+# af_enter_interactive — enter the focused pane: every subsequent key forwards
+# to the pane's shell/agent. Precondition: a pane is focused. Syncs on the
+# interactive menu (only `ctrl+] nav mode` shows).
+af_enter_interactive() {
+    af_send Enter
+    af_wait_for 'nav mode' "$AF_DRIVER_TIMEOUT" 'interactive mode' || return 1
+}
+
+# af_exit_interactive — Ctrl-] back to nav mode. Syncs on the interactive
+# menu disappearing.
+af_exit_interactive() {
+    af_send 'C-]'
+    af_wait_gone 'nav mode' "$AF_DRIVER_TIMEOUT" 'exit interactive' || return 1
+}
+
+# af_send_to_pane <text> — type <text> + Enter into the pane. Precondition:
+# interactive mode is active (af_enter_interactive). Best-effort syncs on the
+# input echoing back; the CALLER should af_wait_for the command's output.
+af_send_to_pane() {
+    local text="$1"
+    af_send_literal "$text"
+    af_send Enter
+    af_wait_for "$(_af_regex_escape "$text")" 8 "pane echoed '$text'" \
+        || _af_log "note: '$text' not seen echoed (may have scrolled off)"
+}
+
+# af_attach — attach the selected instance full-screen (`o`). Precondition: an
+# instance is selected. Records the attach-client baseline so af_detach can
+# prove the client was reaped. Syncs on the TUI chrome vanishing.
+af_attach() {
+    af_ensure_nav
+    af_focus_tree || return 1
+    _af_client_count > "$AF_DRIVER_STATE_DIR/attach_baseline"
+    af_send o
+    af_wait_gone 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'full-screen attach' || return 1
+}
+
+# af_detach — detach from a full-screen attach (Ctrl-W by default) and, the
+# anti-#1157-flake part, wait until the attach client is actually reaped (the
+# count returns to the pre-attach baseline). A leaked client fails here.
+af_detach() {
+    af_send "$AF_DRIVER_DETACH_KEY"
+    af_wait_for 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'detached back to TUI' || return 1
+    local baseline; baseline="$(cat "$AF_DRIVER_STATE_DIR/attach_baseline" 2>/dev/null || echo 0)"
+    local deadline; deadline=$(( $(_af_now) + AF_DRIVER_TIMEOUT ))
+    local n
+    while :; do
+        n="$(_af_client_count)"
+        [ "$n" -le "$baseline" ] && return 0
+        if [ "$(_af_now)" -ge "$deadline" ]; then
+            _af_log "detach: attach clients did not return to baseline ($n > $baseline) — possible #1157-class leak"
+            af_ps >&2
+            return 1
+        fi
+        sleep "$AF_DRIVER_POLL"
+    done
+}
+
+# af_new_tab — spawn a new shell tab in the selected instance (`t`).
+# Precondition: an instance is selected. Syncs on the tab-child count rising.
+af_new_tab() {
+    af_ensure_nav
+    af_focus_tree || return 1
+    local before; before="$(_af_tab_count)"
+    af_send t
+    local deadline; deadline=$(( $(_af_now) + AF_DRIVER_TIMEOUT ))
+    while [ "$(_af_tab_count)" -le "$before" ]; do
+        if [ "$(_af_now)" -ge "$deadline" ]; then
+            _af_fail "new tab did not appear (was $before)"; return 1
+        fi
+        sleep "$AF_DRIVER_POLL"
+    done
+}
+
+# af_close_tab — close the active (non-agent) tab (`w`). Precondition: a
+# closeable tab is active. Syncs on the tab-child count falling.
+af_close_tab() {
+    af_ensure_nav
+    af_focus_tree || return 1
+    local before; before="$(_af_tab_count)"
+    af_send w
+    local deadline; deadline=$(( $(_af_now) + AF_DRIVER_TIMEOUT ))
+    while [ "$(_af_tab_count)" -ge "$before" ]; do
+        if [ "$(_af_now)" -ge "$deadline" ]; then
+            _af_fail "tab not closed (still $before)"; return 1
+        fi
+        sleep "$AF_DRIVER_POLL"
+    done
+}
+
+# _af_tab_count — number of tab-child rows the selected instance shows. Only
+# the selected instance auto-expands, so this counts its tabs.
+_af_tab_count() {
+    af_capture | grep -cE '[├└][[:space:]]+[0-9]+[[:space:]]+(Preview|Terminal|Diff)' || true
+}
+
+# af_open_tasks — open the task-manager overlay (`S`). Syncs on the overlay's
+# unique `r run now` hint line.
+af_open_tasks() {
+    af_ensure_nav
+    af_send S
+    af_wait_for 'run now' "$AF_DRIVER_TIMEOUT" 'tasks overlay' || return 1
+}
+
+# af_close_tasks — dismiss the tasks overlay (Escape).
+af_close_tasks() {
+    af_send Escape
+    af_wait_gone 'run now' 8 'tasks overlay closed' || return 1
+}
+
+# af_click <x> <y> — inject an SGR left click at 1-based screen cell (x,y).
+# This is how the #1143 mouse work is codified: a real terminal would send
+# these bytes; we send them straight to the TUI's stdin.
+af_click() {
+    local x="$1" y="$2"
+    af_send_literal "$(printf '\033[<0;%d;%dM\033[<0;%d;%dm' "$x" "$y" "$x" "$y")"
+    sleep "$AF_DRIVER_POLL"
+}
+
+# af_click_instance <name> — find <name>'s row on screen and click it.
+af_click_instance() {
+    local name="$1" line
+    line="$(af_capture | grep -nE "[0-9]+\.[[:space:]]+${name}([[:space:]]|\$)" | head -1 | cut -d: -f1)"
+    [ -n "$line" ] || { _af_fail "instance '$name' not visible to click"; return 1; }
+    af_click 14 "$line"
+}
+
+# af_scroll <up|down> [x] [y] — inject an SGR mouse-wheel event over cell
+# (x,y) (defaults to the workspace pane).
+af_scroll() {
+    local dir="$1" x="${2:-60}" y="${3:-10}" b
+    case "$dir" in
+        up)   b=64 ;;
+        down) b=65 ;;
+        *) _af_fail "af_scroll: direction must be up|down"; return 1 ;;
+    esac
+    af_send_literal "$(printf '\033[<%d;%d;%dM' "$b" "$x" "$y")"
+    sleep "$AF_DRIVER_POLL"
+}
+
+# af_set_config <toml-body> — replace the sandbox config.toml. NOTE: once
+# config.toml exists it is canonical and config.json is ignored (#1030), so
+# the driver writes TOML. Include a [program_overrides] claude = 'bash' block
+# to keep instances cheap. Call af_relaunch to apply.
+af_set_config() {
+    printf '%s\n' "$1" > "$AGENT_FACTORY_HOME/config.toml"
+}
+
+# af_quit — quit the TUI back to a shell prompt. Dismisses any overlay and
+# interactive mode first, then syncs on the on-quit log line.
+af_quit() {
+    af_ensure_nav
+    af_send Escape
+    af_send q
+    af_wait_for 'wrote logs to|\$ *$' 10 'shell prompt after quit' || return 1
+}
+
+# af_relaunch — quit and relaunch af (for config/keymap play-tests). Reuses
+# the existing driver session.
+af_relaunch() {
+    local bin; bin="$(_af_resolve_bin)"
+    af_quit || return 1
+    af_send_literal "cd $AF_DRIVER_REPO && $bin"
+    af_send Enter
+    af_wait_for 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'af first frame (relaunch)' || return 1
+    af_wait_for 'Instances \(' "$AF_DRIVER_TIMEOUT" 'instances header (relaunch)' || return 1
+    af_focus_tree
+}
+
+# ----------------------------------------------------------------------------
+# Assertions.
+# ----------------------------------------------------------------------------
+
+# af_assert_screen <regex> [label] — pass iff the screen matches <regex>.
+af_assert_screen() {
+    local re="$1" label="${2:-$1}" screen
+    screen="$(af_capture)"
+    if printf '%s\n' "$screen" | grep -qE -- "$re"; then
+        _af_log "assert OK: $label"
+        return 0
+    fi
+    _af_log "ASSERT FAILED: expected screen to match: $label"
+    _af_log "----- screen -----"
+    printf '%s\n' "$screen" >&2
+    _af_log "------------------"
+    return 1
+}
+
+# af_refute_screen <regex> [label] — pass iff the screen does NOT match.
+af_refute_screen() {
+    local re="$1" label="${2:-$1}" screen
+    screen="$(af_capture)"
+    if printf '%s\n' "$screen" | grep -qE -- "$re"; then
+        _af_log "REFUTE FAILED: screen unexpectedly matched: $label"
+        printf '%s\n' "$screen" >&2
+        return 1
+    fi
+    _af_log "refute OK: $label"
+    return 0
+}
+
+# af_expect_selected <name> — assert <name> is the display-selected instance
+# (its row carries the ▾ arrow). This is the two-line answer to the #1156
+# failure: af_select + af_expect_selected.
+af_expect_selected() {
+    local name="$1"
+    af_assert_screen "▾[[:space:]]+[0-9]+\.[[:space:]]+${name}([[:space:]]|\$)" \
+        "instance '${name}' selected"
+}
+
+# ----------------------------------------------------------------------------
+# Introspection / leak checks.
+# ----------------------------------------------------------------------------
+
+# _af_client_count — number of tmux clients attached to af_* sessions.
+_af_client_count() {
+    tmux list-clients 2>/dev/null | grep -c 'af_' || true
+}
+
+# af_tmux_ls — list tmux sessions on the (container's private) server.
+af_tmux_ls() { tmux list-sessions 2>&1; }
+
+# af_ps — the af process tree relevant to leaks: the daemon, and every tmux
+# attach/new-session it or the TUI spawned.
+af_ps() {
+    # ps (not pgrep): we want the ppid+args table, and the same shape the
+    # orphan check reasons about.
+    # shellcheck disable=SC2009
+    ps -eo pid,ppid,args 2>/dev/null \
+        | grep -E 'af --daemon|/af( |$)|tmux (attach-session|new-session)' \
+        | grep -v grep || true
+}
+
+# af_assert_no_orphan_clients — fail if any `tmux attach-session` client has
+# been reparented to init (ppid 1): its spawning TUI/pane exited but the
+# client lived on. That is the #1155/#1157 leak signature. The daemon's own
+# monitor clients are parented to the daemon (ppid != 1), so they are
+# correctly excluded.
+af_assert_no_orphan_clients() {
+    local orphans
+    orphans="$(ps -eo ppid,args 2>/dev/null | awk '$1==1 && /tmux attach-session/ {print}')"
+    if [ -n "$orphans" ]; then
+        _af_log "ORPHAN attach clients (reparented to init):"
+        printf '%s\n' "$orphans" >&2
+        return 1
+    fi
+    _af_log "assert OK: no orphan tmux attach clients"
+    return 0
+}


### PR DESCRIPTION
## What & why

Driving the real multi-pane TUI by hand for a play-test gate has been
error-prone since the pane rewrite (#1099/#1135/#1143):

- **#1156** — mis-drove the TUI: `t`/`w` landed in a live pane as literal
  text and a second instance never got created, because the driver wasn't in
  nav mode with the tree focused and didn't know it.
- **#1155** — a hand-rolled tmux driver died on a `TMUX_TMPDIR`/`$TMUX`
  collision.
- Every play-test re-derived `send-keys`/`capture-pane`/`sleep N` plumbing
  from scratch, and blind `sleep` was the main flake source.

#1130's container harness already solves **isolation** (throwaway home, mock
repo, private tmux, pids/memory caps). This PR adds the missing **driving +
assertion** layer on top of it.

## What's here

**`scripts/tui-driver.sh`** — a sourceable driver library:

- **Anti-flake core**: `af_wait_for <regex> [t]` polls `capture-pane` until
  the screen matches (never a blind sleep); `af_ensure_nav` sends `Ctrl-]` to
  force a known focus state — the one-line fix for the entire #1156 class.
- **Self-synchronizing scenario helpers** (each waits on its own completion
  marker): `af_boot`, `af_new_instance`, `af_select`, `af_open_pane`/
  `af_hide_pane` (`s`/`x`), `af_enter_interactive`/`af_exit_interactive`
  (`Enter`/`Ctrl-]`), `af_send_to_pane`, `af_attach`/`af_detach`,
  `af_new_tab`/`af_close_tab` (`t`/`w`), `af_open_tasks` (`S`),
  `af_click`/`af_scroll` (SGR mouse injection, codifying the #1143 work),
  `af_set_config`+`af_relaunch`. Plus `af_reset_sandbox` for deterministic
  reruns (sandbox-scoped, **fails closed** on a non-sandbox home).
- **Assertions + introspection**: `af_assert_screen`/`af_refute_screen`/
  `af_expect_selected`, `af_tmux_ls`/`af_ps`/`af_assert_no_orphan_clients`.
  `af_detach` self-syncs on the attach client being reaped (guards the #1157
  class); the orphan check keys off the reparented-to-init leak signature and
  excludes the daemon's legitimate monitor clients.

**`scripts/tui-driver-selftest.sh`** — the acceptance proof: the exact #1156
failure, now a straight-line scenario. Boot → **two** instances → select each
(assert selection) → open a pane → enter interactive → type into the pane →
exit → attach full-screen → detach → assert selection preserved → assert no
orphan clients. Doubles as the bitrot guard.

**Invocation**: `make tui-driver-selftest` (gate, runs in its own dedicated
container so it never disturbs a `drive`/`playtest` sandbox) and
`make tui-driver` (boot + attach to drive by hand); plus `testbox.sh
selftest`/`drive` and a documented `docker exec` path.

**`docs/tui-manual-testing.md`** — interaction model (nav vs interactive,
focus ring, key map), driver reference, the wait-not-sleep principle, and a
gate-recipe library. The `tui-playtest` skill and `container-testing.md` now
point at the driver.

No Go touched. `shellcheck` clean (0.9.0).

## Acceptance — self-test green in-container

```
=== tui-driver self-test (#1161) ===
session=drive size=100x30 home=/home/dev/sandbox/home

>>> reset sandbox to a clean state                     ✓
>>> boot af at 100x30                                  ✓
>>> create instance 'alpha'                            ✓
>>> create instance 'beta'                             ✓
>>> select alpha                                       ✓
>>> assert alpha is selected                           ✓
>>> select beta                                        ✓
>>> assert beta is selected                            ✓
>>> open beta's tab as a pane                          ✓
>>> enter interactive mode                             ✓
>>> type a command into the pane                       ✓
>>> assert the pane ran it                             ✓
>>> exit interactive mode                              ✓
>>> attach full-screen                                 ✓
>>> detach (and prove the attach client was reaped)    ✓
>>> assert selection survived attach/detach            ✓
>>> assert no orphan tmux attach clients               ✓

=== SELF-TEST PASSED — 17/17 steps green ===
```

Verified green across a fresh container **and** two consecutive reruns of a
reused (dirty) container (`af_reset_sandbox` makes it deterministic).

## Box safety

Everything runs inside the container. The driver only ever kills its **own**
named session and (in `af_reset_sandbox`) the sandbox's `af_*` sessions —
**never `kill-server`**; `af_reset_sandbox` refuses to wipe unless
`AGENT_FACTORY_HOME`/repo are sandbox paths. Instances run cheap `bash`.

**Do not merge** — this is for root to dogfood (run the self-test + drive it
by hand) before merging.

Closes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude