### PR TITLE
fix(tui): live-project tasks, route run-now through shared daemon path, and message p/P with no PR (#1168, #1169, #1170)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -654,12 +654,24 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		detachTraceMark("snapshotFetchedMsg-handler-entry")
 		tickStart := time.Now()
 		changed := m.handleSnapshot(msg)
+		// Live-project out-of-band task changes on the same poll (#1168),
+		// independent of the session snapshot's own error path.
+		if m.refreshTasks(msg.tasks, msg.tasksErr) {
+			changed = true
+		}
 		detachTrace(tickStart, "snapshotFetchedMsg-reconcile-returned")
 		cmds := []tea.Cmd{tickRefreshExternalCmd}
 		if changed {
 			cmds = append(cmds, m.selectionChanged())
 		}
 		return m, tea.Batch(cmds...)
+	case taskTriggeredMsg:
+		// The daemon-side run (#1169) failed — surface it. Success needs no
+		// action: the resulting session and updated task status live-project in.
+		if msg.err != nil {
+			return m, m.handleError(fmt.Errorf("failed to trigger task %q: %w", msg.title, msg.err))
+		}
+		return m, nil
 	case tea.MouseMsg:
 		// First-class mouse (#1024 R4, closes #1025): every event is
 		// resolved through the zone registry the last View() rebuilt and
@@ -1018,7 +1030,24 @@ func (m *home) handleTaskCreate() tea.Cmd {
 	return nil
 }
 
-// handleTaskTrigger immediately spawns an instance for the selected task.
+// taskTriggeredMsg reports the outcome of a TUI "run now" (#1169). The run
+// itself happens daemon-side (create-or-deliver + status write); the resulting
+// session and updated task status live-project back into the TUI, so success
+// needs no on-loop mutation — only a failure is surfaced to the user.
+type taskTriggeredMsg struct {
+	title string
+	err   error
+}
+
+// handleTaskTrigger runs the selected task through the daemon's single shared
+// trigger path (daemon.RunTask), the SAME entrypoint `af tasks trigger` and the
+// cron scheduler use. Previously the TUI "run now" unconditionally spawned a new
+// per-run session, ignoring the task's target_session and orphaning it (#1169);
+// routing through RunTask makes it honor target_session (deliver into it,
+// auto-creating when missing) and spawn a fresh session only when there is no
+// target — matching CLI/cron exactly. The daemon owns the create/deliver, so the
+// new/updated session appears via the Snapshot projection and the task's run
+// status via the task refresh, with no divergent TUI spawn path to drift.
 func (m *home) handleTaskTrigger() tea.Cmd {
 	sp := m.automations.TaskPane()
 	tsk := sp.ConsumePendingTrigger()
@@ -1032,66 +1061,28 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 		return m.handleError(fmt.Errorf("task %q is a watch task; it fires when its watch command emits output", task.TaskRunBaseTitle(*tsk)))
 	}
 
-	repo, err := config.RepoFromPath(tsk.ProjectPath)
-	if err != nil {
-		return m.handleError(fmt.Errorf("failed to resolve repo for task path: %w", err))
-	}
-	title, err := task.NextTaskRunTitle(repo.ID, tsk.ProjectPath, task.TaskRunBaseTitle(*tsk), tsk.Program)
-	if err != nil {
-		return m.handleError(fmt.Errorf("failed to allocate task run title: %w", err))
-	}
-
-	instance, err := session.NewInstance(session.InstanceOptions{
-		Title:   title,
-		Path:    tsk.ProjectPath,
-		Program: tsk.Program,
-	})
-	if err != nil {
-		return m.handleError(fmt.Errorf("failed to create instance: %w", err))
-	}
-
-	m.store.AddInstance(instance)
-	m.sidebar.SetSelectedInstance(m.store.NumInstances() - 1)
-	instance.SetStatus(session.Loading)
-	m.menu.SetState(ui.StateDefault)
-	// The run lands as a new session: close the tasks overlay (a trigger is
-	// fired from inside it) and move focus to the tree so the user is looking
-	// at the spawned instance, not the manager.
+	// The trigger fires from inside the tasks overlay: close it and move focus to
+	// the tree so the user is looking at the sessions, where the run lands (a
+	// fresh per-run session, or the delivered-into target_session).
 	if m.state == stateTasks {
 		m.state = stateDefault
-		m.automations.TaskPane().SetFocus(false)
+		sp.SetFocus(false)
 	}
 	m.focusRegion(layout.RegionTree)
 
-	prompt := tsk.Prompt
 	taskID := tsk.ID
-	// Capture the start seam on the event loop before the goroutine reads it, so a
-	// concurrent test-seam swap can't race the read (#960 PR 4 race-fix class).
-	start := startSessionThroughDaemon
-	startCmd := func() tea.Msg {
-		started, err := start(instance, sessionStartRequest{
-			Title:    instance.Title,
-			RepoPath: instance.Path,
-			Program:  instance.Program,
-			Prompt:   prompt,
-			AutoYes:  m.autoYes,
-		})
-		if err != nil {
-			return instanceStartedMsg{instance: instance, err: err}
+	taskTitle := task.TaskRunBaseTitle(*tsk)
+	// Capture the trigger seam on the event loop before the goroutine reads it, so
+	// a concurrent test-seam swap can't race the read (#960 PR 4 race-fix class).
+	trigger := triggerTaskThroughDaemon
+	triggerCmd := func() tea.Msg {
+		if err := trigger(taskID); err != nil {
+			return taskTriggeredMsg{title: taskTitle, err: err}
 		}
-
-		// Update task last run status. UpdateTaskStatus skips Program enum
-		// validation so legacy task records (pre-#658) still receive status
-		// bumps; see #664.
-		now := time.Now()
-		if err := task.UpdateTaskStatus(taskID, &now, "triggered"); err != nil {
-			log.ErrorLog.Printf("failed to update task status: %v", err)
-		}
-
-		return instanceStartedMsg{instance: instance, started: started, err: nil}
+		return taskTriggeredMsg{title: taskTitle}
 	}
 
-	return tea.Batch(tea.WindowSize(), m.selectionChanged(), startCmd)
+	return tea.Batch(tea.WindowSize(), m.selectionChanged(), triggerCmd)
 }
 
 func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly bool) {

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -513,11 +513,18 @@ func (m *home) handleTabJump(oneBased int) (tea.Model, tea.Cmd) {
 	return m, m.selectionChanged()
 }
 
+// noPRForSessionErr is the actionable message surfaced when p/P is pressed on a
+// session that has no PR yet, so the key press is never a silent no-op (#1170).
+var noPRForSessionErr = fmt.Errorf("no PR for this session yet — push a branch / open a PR first")
+
 // handleOpenPR opens the PR URL in the browser.
 func (m *home) handleOpenPR() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
-	if selected == nil || selected.GetPRInfo() == nil {
+	if selected == nil {
 		return m, nil
+	}
+	if selected.GetPRInfo() == nil {
+		return m, m.handleError(noPRForSessionErr)
 	}
 	url := selected.GetPRInfo().URL
 	var openCmd *exec.Cmd
@@ -540,8 +547,11 @@ func (m *home) handleOpenPR() (tea.Model, tea.Cmd) {
 // handleCopyPR copies the PR URL to the clipboard.
 func (m *home) handleCopyPR() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
-	if selected == nil || selected.GetPRInfo() == nil {
+	if selected == nil {
 		return m, nil
+	}
+	if selected.GetPRInfo() == nil {
+		return m, m.handleError(noPRForSessionErr)
 	}
 	url := selected.GetPRInfo().URL
 	var copyCmd *exec.Cmd

--- a/app/handle_actions_test.go
+++ b/app/handle_actions_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -124,4 +125,41 @@ func TestKillConfirmationWarning(t *testing.T) {
 		warning := killConfirmationWarning(filepath.Join(t.TempDir(), "gone"))
 		require.Contains(t, warning, "Could not verify worktree status")
 	})
+}
+
+// TestOpenCopyPRNoPRSurfacesMessage is the regression guard for #1170: p (open
+// PR) and P (copy PR URL) on a session that has no PR yet must surface a brief,
+// actionable message via the ErrBox rather than being a silent no-op. A nil
+// selection (no session at all) stays silent — there is no session context to
+// message about.
+func TestOpenCopyPRNoPRSurfacesMessage(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "no-pr", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	inst.SetStatus(session.Running)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+	require.Nil(t, inst.GetPRInfo(), "precondition: session has no PR")
+
+	// p (open PR)
+	_, cmd := h.handleOpenPR()
+	require.NotNil(t, cmd, "handleOpenPR must return a cmd that clears the message")
+	require.Contains(t, h.errBox.String(), "no PR for this session yet")
+
+	h.errBox.Clear()
+
+	// P (copy PR URL)
+	_, cmd = h.handleCopyPR()
+	require.NotNil(t, cmd, "handleCopyPR must return a cmd that clears the message")
+	require.Contains(t, h.errBox.String(), "no PR for this session yet")
+
+	// Nil selection stays silent — no session context to report.
+	h.errBox.Clear()
+	h.store.RemoveInstanceByTitle("no-pr")
+	require.Nil(t, h.sidebar.GetSelectedInstance(), "precondition: no session selected")
+	_, cmd = h.handleOpenPR()
+	require.Nil(t, cmd, "handleOpenPR on an empty selection must stay a silent no-op")
+	require.Empty(t, strings.TrimSpace(h.errBox.String()))
 }

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -35,6 +35,16 @@ var killSessionThroughDaemon = func(title, repoID string) error {
 	return daemon.KillSession(daemon.KillSessionRequest{Title: title, RepoID: repoID})
 }
 
+// triggerTaskThroughDaemon runs a task by ID through the daemon's single shared
+// trigger path (daemon.RunTask) — the SAME entrypoint `af tasks trigger` and the
+// cron scheduler use. Routing the TUI's `r` (run now) here makes it honor a
+// task's target_session (deliver into it, auto-create when missing) and only
+// spawn a fresh per-run session when target_session is empty, instead of the old
+// divergent path that unconditionally spawned a new session and orphaned the
+// target (#1169). It is a package var so the app test suite can stub the trigger
+// without dialing a real daemon.
+var triggerTaskThroughDaemon = daemon.RunTask
+
 // pauseStatusPollThroughDaemon / resumeStatusPollThroughDaemon route the TUI's
 // attach-time poll-pause coordination to the daemon (#1160, Fix A follow-up to
 // #1157). While a TUI is attached full-screen to an instance it owns the shared
@@ -107,6 +117,14 @@ func SetSessionStarterForTest(f func(*session.Instance, sessionStartRequest) (*s
 	prev := startSessionThroughDaemon
 	startSessionThroughDaemon = f
 	return func() { startSessionThroughDaemon = prev }
+}
+
+// SetTaskTriggerForTest swaps the task-trigger seam (#1169) so a test can assert
+// which task ID the TUI "run now" routes to the daemon, without a real daemon.
+func SetTaskTriggerForTest(f func(taskID string) error) func() {
+	prev := triggerTaskThroughDaemon
+	triggerTaskThroughDaemon = f
+	return func() { triggerTaskThroughDaemon = prev }
 }
 
 func SetRemoteImporterForTest(f func(repoPath string) ([]session.InstanceData, error)) func() {

--- a/app/sync.go
+++ b/app/sync.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -10,6 +11,7 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/task"
 )
 
 // prInfoStaleAfter is how long a fetched PR info entry is considered fresh.
@@ -29,6 +31,16 @@ type tickRefreshExternalMessage struct{}
 type snapshotFetchedMsg struct {
 	data []session.InstanceData
 	err  error
+	// tasks is the repo's task list re-read from disk on the same poll (#1168).
+	// Tasks are a disk-backed store shared between the TUI and the daemon — not
+	// solely daemon-owned like sessions (#960) — so an out-of-band `af tasks
+	// add|update|remove` is picked up here and live-projected into the rail/
+	// overlay instead of only appearing after a relaunch. Carried alongside the
+	// session snapshot so both external changes ride one 750ms poll. tasksErr is
+	// independent of err: a warming daemon can fail the session RPC while the
+	// disk task read still succeeds.
+	tasks    []task.Task
+	tasksErr error
 }
 
 // prInfoUpdatedMsg is returned by an async PR info fetch.
@@ -84,7 +96,12 @@ func (m *home) fetchSnapshotCmd() tea.Cmd {
 	fetch := m.snapshotFetcher
 	return func() tea.Msg {
 		data, err := fetch(repoID)
-		return snapshotFetchedMsg{data: data, err: err}
+		// Re-read the repo's tasks on the same poll so an out-of-band task
+		// change live-projects into the TUI (#1168). Independent of the session
+		// snapshot: its own error is carried separately so a warming-daemon RPC
+		// failure never suppresses a successful disk task read.
+		tasks, tasksErr := task.LoadTasksForCurrentRepo()
+		return snapshotFetchedMsg{data: data, err: err, tasks: tasks, tasksErr: tasksErr}
 	}
 }
 
@@ -235,6 +252,40 @@ func (m *home) handleSnapshot(msg snapshotFetchedMsg) bool {
 		return false
 	}
 	return m.reconcileSnapshot(msg.data)
+}
+
+// refreshTasks mirrors an out-of-band tasks.json change (a CLI/daemon `af tasks
+// add|update|remove`, or a run that bumped a task's last-run status) into the
+// running TUI, closing the live-projection gap that left a CLI-created task
+// invisible until relaunch (#1168 — the tasks sibling of the #959 tab fix).
+// Tasks are a disk-backed store shared between the TUI and the daemon, so the
+// TUI re-reads them on the snapshot poll rather than through the daemon's
+// session Snapshot. The automations rail (store) always mirrors the fresh list;
+// the tasks overlay pane is re-synced only when the user is not mid-edit, so a
+// background refresh can never clobber an in-progress create/edit or unsaved
+// deletions. Returns whether anything visible changed (the caller repaints on a
+// diff). A read error leaves the last-known list intact, matching handleSnapshot.
+func (m *home) refreshTasks(tasks []task.Task, tasksErr error) bool {
+	if tasksErr != nil {
+		log.WarningLog.Printf("failed to refresh tasks: %v", tasksErr)
+		return false
+	}
+	changed := false
+	if !reflect.DeepEqual(m.store.GetTasks(), tasks) {
+		m.store.SetTasks(tasks)
+		changed = true
+	}
+	// The overlay pane owns transient edit state (create/edit buffers, pending
+	// deletions): only re-sync it while idle so a background refresh never wipes
+	// the user's in-flight form or unsaved deletes.
+	sp := m.automations.TaskPane()
+	if !sp.IsEditing() && !sp.IsCreating() && !sp.IsDirty() {
+		if !reflect.DeepEqual(sp.GetTasks(), tasks) {
+			sp.SetTasks(tasks)
+			changed = true
+		}
+	}
+	return changed
 }
 
 // reconcileSnapshot mirrors the projection store to the daemon's authoritative

--- a/app/task_projection_test.go
+++ b/app/task_projection_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// TestTaskTriggerRoutesThroughDaemonSharedPath is the regression guard for
+// #1169: pressing `r` (run now) in the tasks overlay must route through the
+// daemon's single shared trigger path (daemon.RunTask, via
+// triggerTaskThroughDaemon) — the SAME entrypoint `af tasks trigger` and cron
+// use — passing the task's own ID. The old handler unconditionally spawned a
+// brand-new per-run session, ignoring target_session and orphaning it. Routing
+// through RunTask makes the daemon honor target_session (deliver into it) and
+// spawn a fresh session only when there is none. This test asserts the TUI no
+// longer spawns a session itself and hands the right task ID to the shared path.
+func TestTaskTriggerRoutesThroughDaemonSharedPath(t *testing.T) {
+	h := newTestHome(t)
+
+	var gotID string
+	restore := SetTaskTriggerForTest(func(taskID string) error {
+		gotID = taskID
+		return nil
+	})
+	defer restore()
+
+	sp := h.automations.TaskPane()
+	sp.SetTasks([]task.Task{{
+		ID:            "task-abc",
+		Name:          "hello-task",
+		CronExpr:      "0 0 * * *",
+		Prompt:        "echo hi",
+		TargetSession: "todo-add",
+		Enabled:       true,
+	}})
+	sp.SelectTask(0)
+
+	before := h.store.NumInstances()
+	cmd := h.handleTaskTrigger()
+	require.NotNil(t, cmd)
+
+	// The trigger fires off-loop inside a batch; drain it to run the goroutine.
+	drainCmd(t, cmd, 500*time.Millisecond)
+
+	require.Equal(t, "task-abc", gotID,
+		"run-now must route the task's own ID through the shared daemon trigger path")
+	require.Equal(t, before, h.store.NumInstances(),
+		"run-now must NOT spawn a divergent per-run session (#1169); the daemon owns create-or-deliver")
+}
+
+// TestTaskTriggerWatchRefused pins that a watch task still cannot be manually
+// triggered (it fires from its watch command's stdout), matching daemon.RunTask.
+func TestTaskTriggerWatchRefused(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+
+	called := false
+	restore := SetTaskTriggerForTest(func(string) error { called = true; return nil })
+	defer restore()
+
+	sp := h.automations.TaskPane()
+	sp.SetTasks([]task.Task{{ID: "w1", Name: "watcher", WatchCmd: "tail -f log", Enabled: true}})
+	sp.SelectTask(0)
+
+	h.handleTaskTrigger()
+	require.False(t, called, "a watch task must never reach the daemon trigger path")
+	require.Contains(t, h.errBox.String(), "watch task")
+}
+
+// TestRefreshTasksLiveProjectsOutOfBandChange is the regression guard for #1168:
+// a task added out-of-band (CLI/daemon `af tasks add`) must live-project into
+// the running TUI — both the automations rail (store) and the tasks overlay
+// (pane) — without a relaunch. refreshTasks is the poll-driven apply the
+// snapshot loop calls with the freshly re-read task list.
+func TestRefreshTasksLiveProjectsOutOfBandChange(t *testing.T) {
+	h := newTestHome(t)
+	require.Empty(t, h.store.GetTasks())
+	require.Empty(t, h.automations.TaskPane().GetTasks())
+
+	fresh := []task.Task{{
+		ID:            "t1",
+		Name:          "hello-task",
+		CronExpr:      "0 0 * * *",
+		Prompt:        "echo hi",
+		TargetSession: "todo-add",
+		Enabled:       true,
+	}}
+
+	require.True(t, h.refreshTasks(fresh, nil),
+		"an out-of-band task add must register as a visible change")
+	require.Len(t, h.store.GetTasks(), 1, "automations rail must live-project the new task")
+	require.Len(t, h.automations.TaskPane().GetTasks(), 1, "tasks overlay must live-project the new task")
+
+	// Idempotent: the same list on the next poll is not a change (no needless repaint).
+	require.False(t, h.refreshTasks(fresh, nil), "an unchanged task list must not report a change")
+
+	// A read error leaves the last-known list intact.
+	require.False(t, h.refreshTasks(nil, errRefreshFailed))
+	require.Len(t, h.store.GetTasks(), 1, "a failed refresh must not wipe the projected tasks")
+}
+
+// TestRefreshTasksSkipsPaneWhileCreating pins that a background refresh updates
+// the rail but never clobbers the overlay pane while the user is mid-create, so
+// an in-flight task form (or unsaved deletions) survive a concurrent poll.
+func TestRefreshTasksSkipsPaneWhileCreating(t *testing.T) {
+	h := newTestHome(t)
+	sp := h.automations.TaskPane()
+	sp.EnterCreateMode(t.TempDir())
+	require.True(t, sp.IsCreating(), "precondition: pane is mid-create")
+
+	fresh := []task.Task{{ID: "t1", Name: "hello", CronExpr: "0 0 * * *", Prompt: "echo hi", Enabled: true}}
+	h.refreshTasks(fresh, nil)
+
+	require.Len(t, h.store.GetTasks(), 1, "the rail must still live-project while the pane edits")
+	require.Empty(t, sp.GetTasks(), "the tasks overlay must not be clobbered mid-create")
+}
+
+var errRefreshFailed = errTest("refresh failed")
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }

--- a/task/runner.go
+++ b/task/runner.go
@@ -1,16 +1,13 @@
 package task
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
-	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -180,79 +177,4 @@ func TaskRunBaseTitle(t Task) string {
 		return t.Name
 	}
 	return fmt.Sprintf("task-%s", t.ID)
-}
-
-// NextTaskRunTitle chooses a repo-scoped title for a task run that will not
-// collide with persisted sessions or an already-live tmux session. Recurring
-// tasks can fire while a previous run is still around, so task sessions cannot
-// use the static task name blindly.
-func NextTaskRunTitle(repoID, repoPath, baseTitle, program string) (string, error) {
-	path, err := config.RepoInstancesPath(repoID)
-	if err != nil {
-		return "", err
-	}
-
-	var title string
-	if err := config.WithFileLock(path, func() error {
-		raw, err := config.LoadRepoInstances(repoID)
-		if err != nil {
-			return err
-		}
-
-		var existing []session.InstanceData
-		if err := json.Unmarshal(raw, &existing); err != nil {
-			return fmt.Errorf("failed to parse existing instances: %w", err)
-		}
-
-		usedTitles := make([]string, 0, len(existing))
-		for _, data := range existing {
-			usedTitles = append(usedTitles, data.Title)
-		}
-
-		// Mirror the daemon's title-conflict validation so we never hand back a
-		// candidate the daemon would reject, which would turn every
-		// TUI-triggered run into a round-trip error. The daemon rejects titles
-		// that collide either case-insensitively or after branch sanitization
-		// (see daemon.titlesCollide / git.SanitizeBranchName). A candidate like
-		// "nightly" collides with an existing "Nightly" (#721); "my-task"
-		// collides with "My Task" once both sanitize to the same branch (#741).
-		// LoadConfig supplies the same BranchPrefix the worktree layer uses;
-		// fall back to case-insensitive-only if it is unavailable.
-		branchPrefix := ""
-		if cfg, cfgErr := config.LoadConfig(); cfgErr == nil {
-			branchPrefix = cfg.BranchPrefix
-		}
-		titleTaken := func(candidate string) bool {
-			candidateBranch := git.SanitizeBranchName(branchPrefix + candidate)
-			for _, used := range usedTitles {
-				if strings.EqualFold(used, candidate) {
-					return true
-				}
-				if git.SanitizeBranchName(branchPrefix+used) == candidateBranch {
-					return true
-				}
-			}
-			return false
-		}
-
-		for i := 1; i <= 10000; i++ {
-			candidate := baseTitle
-			if i > 1 {
-				candidate = fmt.Sprintf("%s-%d", baseTitle, i)
-			}
-			if titleTaken(candidate) {
-				continue
-			}
-			if tmux.NewTmuxSessionForRepo(candidate, repoPath, program).DoesSessionExist() {
-				continue
-			}
-			title = candidate
-			return nil
-		}
-		return fmt.Errorf("could not find an available title for %q", baseTitle)
-	}); err != nil {
-		return "", err
-	}
-
-	return title, nil
 }

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -1,17 +1,14 @@
 package task
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -126,115 +123,6 @@ func TestIsReadyContent(t *testing.T) {
 				t.Errorf("isReadyContent(%q, %q) = %v, want %v", tc.content, tc.agent, got, tc.want)
 			}
 		})
-	}
-}
-
-func TestNextTaskRunTitleSkipsPersistedTitles(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("AGENT_FACTORY_HOME", tmp)
-
-	repoID := "test-repo-title"
-	instancesPath, err := config.RepoInstancesPath(repoID)
-	if err != nil {
-		t.Fatalf("RepoInstancesPath: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(instancesPath), 0755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-
-	preexisting := []session.InstanceData{
-		{Title: "nightly"},
-		{Title: "nightly-2"},
-	}
-	preRaw, err := json.MarshalIndent(preexisting, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal preexisting: %v", err)
-	}
-	if err := os.WriteFile(instancesPath, preRaw, 0644); err != nil {
-		t.Fatalf("write preexisting: %v", err)
-	}
-
-	title, err := NextTaskRunTitle(repoID, "/tmp/repo", "nightly", "claude")
-	if err != nil {
-		t.Fatalf("NextTaskRunTitle: %v", err)
-	}
-	if title != "nightly-3" {
-		t.Fatalf("expected nightly-3, got %q", title)
-	}
-}
-
-// TestNextTaskRunTitleCaseInsensitive guards against #721: the persisted title
-// "Foo" must block the case-variant base "foo", so the next title is "foo-2"
-// rather than "foo". A case-sensitive check would hand back "foo", which the
-// daemon's EqualFold validation then rejects.
-func TestNextTaskRunTitleCaseInsensitive(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("AGENT_FACTORY_HOME", tmp)
-
-	repoID := "test-repo-title-case"
-	instancesPath, err := config.RepoInstancesPath(repoID)
-	if err != nil {
-		t.Fatalf("RepoInstancesPath: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(instancesPath), 0755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-
-	preexisting := []session.InstanceData{
-		{Title: "Foo"},
-	}
-	preRaw, err := json.MarshalIndent(preexisting, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal preexisting: %v", err)
-	}
-	if err := os.WriteFile(instancesPath, preRaw, 0644); err != nil {
-		t.Fatalf("write preexisting: %v", err)
-	}
-
-	title, err := NextTaskRunTitle(repoID, "/tmp/repo", "foo", "claude")
-	if err != nil {
-		t.Fatalf("NextTaskRunTitle: %v", err)
-	}
-	if title != "foo-2" {
-		t.Fatalf("expected foo-2 (case-variant of persisted %q must collide), got %q", "Foo", title)
-	}
-}
-
-// TestNextTaskRunTitleSanitizeCollision guards against #741 (completing #721):
-// the persisted title "My Task" must block the base "my-task" because both
-// sanitize to the same git branch, so the next title is "my-task-2". A check
-// that only compared case-insensitively would hand back "my-task", which the
-// daemon's branch-collision validation then rejects.
-func TestNextTaskRunTitleSanitizeCollision(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("AGENT_FACTORY_HOME", tmp)
-
-	repoID := "test-repo-title-sanitize"
-	instancesPath, err := config.RepoInstancesPath(repoID)
-	if err != nil {
-		t.Fatalf("RepoInstancesPath: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(instancesPath), 0755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-
-	preexisting := []session.InstanceData{
-		{Title: "My Task"},
-	}
-	preRaw, err := json.MarshalIndent(preexisting, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal preexisting: %v", err)
-	}
-	if err := os.WriteFile(instancesPath, preRaw, 0644); err != nil {
-		t.Fatalf("write preexisting: %v", err)
-	}
-
-	title, err := NextTaskRunTitle(repoID, "/tmp/repo", "my-task", "claude")
-	if err != nil {
-		t.Fatalf("NextTaskRunTitle: %v", err)
-	}
-	if title != "my-task-2" {
-		t.Fatalf("expected my-task-2 (sanitize-variant of persisted %q must collide), got %q", "My Task", title)
 	}
 }
 


### PR DESCRIPTION
Fixes three TUI bugs found in the daily play-test (#1102). All independent; two separable commits (the PR-message fix is standalone; the two task-projection/delivery gaps share the same TUI plumbing and are grouped).

## #1170 — `p`/`P` silent no-op on a no-PR session
`p` (open PR) and `P` (copy PR URL) early-returned with no feedback when the selected session had no PR yet — a silent no-op the play-test brief counts as a finding. Split the guard so a session without a PR now surfaces an actionable ErrBox message (*"no PR for this session yet — push a branch / open a PR first"*). A nil selection (no session at all) stays silent.

## #1168 — tasks not live-projected into a running TUI
A task added out-of-band (`af tasks add` from another shell, or the daemon) never appeared in a running TUI until relaunch — the sibling of #959 (tabs), which the #960 daemon Snapshot fixed for sessions/tabs but not tasks. Tasks are a **disk-backed store shared** between the TUI and the daemon (not solely daemon-owned like sessions), so the TUI now re-reads them on the existing snapshot poll — carried alongside the session snapshot with an independent error path — and mirrors them into the automations rail store and, while the user is not mid-edit, the tasks overlay pane. Unchanged lists are a no-op (no needless repaint); an in-flight create/edit or unsaved deletions are never clobbered.

## #1169 — TUI run-now (`r`) ignored `target_session`
Pressing `r` on a task with a `target_session` spawned a brand-new per-run session and orphaned the target, diverging from `af tasks trigger` and cron (which both honor `target_session`). The TUI run-now now routes through the **same single shared path** (`daemon.RunTask` via a `triggerTaskThroughDaemon` seam) the CLI and cron scheduler use, so the daemon makes the create-or-deliver decision: deliver into `target_session` when set, spawn a fresh session only when empty. The divergent TUI spawn path is deleted, and with it the now-orphaned `task.NextTaskRunTitle` pre-allocator (post-migration kludge — the daemon's own allocator owns collision-free naming) and its tests.

**Audit (per brief):** the task-trigger entrypoints — CLI `af tasks trigger`, cron scheduler, TUI run-now — now all route through `daemon.RunTask`. Watch tasks fire only from their watch stdout and remain refused on manual trigger.

## Tests
- `TestOpenCopyPRNoPRSurfacesMessage` — p/P on a no-PR session surfaces the message; nil selection stays silent.
- `TestTaskTriggerRoutesThroughDaemonSharedPath` — run-now hands the task's own ID to the shared daemon path and spawns no divergent session.
- `TestTaskTriggerWatchRefused` — watch task never reaches the trigger path.
- `TestRefreshTasksLiveProjectsOutOfBandChange` / `TestRefreshTasksSkipsPaneWhileCreating` — out-of-band task add live-projects to rail + overlay; idempotent; failed read leaves the list intact; mid-create pane is not clobbered.

## Gates
`golangci-lint --fast` ✓ · `gofmt -l` empty ✓ · `deadcode -test ./...` clean ✓ · `go build ./...` ✓ · `make test-container` — full suite green ✓

⚠️ Visible TUI changes — leaving for root to docker play-test before merge. **Do not merge; root verifies.**

Closes #1168
Closes #1169
Closes #1170

— Captain Claude
