### PR TITLE
feat(session): add persisted Archived status + inert load + guards (#1028) [PR 1/6]

### DIFF
--- a/app/dead_session_test.go
+++ b/app/dead_session_test.go
@@ -89,3 +89,32 @@ func TestHandleEnter_LostSessionShowsError(t *testing.T) {
 	require.Contains(t, h.errBox.String(), "lost-session",
 		"the error must name the offending session")
 }
+
+// TestHandleEnter_ArchivedSessionShowsError (#1028): Enter on an archived
+// session must take the explicit archived-error path — not interactive mode,
+// not the generic dead-tmux message — and must point the user at `restore` as
+// the off-ramp. Archived is checked before TmuxAlive in interactiveGuard so the
+// specific wording wins.
+func TestHandleEnter_ArchivedSessionShowsError(t *testing.T) {
+	h := newTestHome(t)
+
+	inst := newDeadInstance(t, "archived-session", session.Archived)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, cmd := h.handleEnter()
+	h = model.(*home)
+
+	require.Equal(t, stateDefault, h.state, "an archived session must not open any overlay")
+	require.Nil(t, h.textOverlay, "no help overlay should be installed for an archived session")
+	require.False(t, h.interactive, "Enter on an archived session must not enter interactive mode")
+
+	require.NotNil(t, cmd, "handleEnter must return the error-hide command, not a silent nil")
+	h.errBox.SetSize(200, 1)
+	require.Contains(t, h.errBox.String(), "is archived",
+		"the error must say the session is archived, not the generic dead message")
+	require.Contains(t, h.errBox.String(), "restore",
+		"the error must point at restore as the off-ramp")
+	require.Contains(t, h.errBox.String(), "archived-session",
+		"the error must name the offending session")
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -323,6 +323,14 @@ func interactiveGuard(inst *session.Instance) error {
 		// (#935). Checked before TmuxAlive so the specific message wins.
 		return fmt.Errorf("session '%s' was lost — its tmux session is gone", inst.Title)
 	}
+	if inst.GetStatus() == session.Archived {
+		// Archived (#1028): the user tore the session down and its worktree was
+		// moved to the global archive dir; there is no tmux to enter or attach.
+		// Point at the off-ramp (restore) rather than a bare "not running" —
+		// same explicit-feedback contract as Lost/Deleting. Checked before
+		// TmuxAlive so the specific message wins.
+		return fmt.Errorf("session '%s' is archived — restore it first (af sessions restore %s)", inst.Title, inst.Title)
+	}
 	if !inst.TmuxAlive() {
 		return fmt.Errorf("session '%s' is no longer running", inst.Title)
 	}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1248,6 +1248,15 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	if status := instance.GetStatus(); status == session.Loading || status == session.Deleting {
 		return
 	}
+	if instance.GetStatus() == session.Archived {
+		// An archived session (#1028) has no tmux to probe — its worktree was
+		// moved to the global archive dir and every tab torn down. It loads
+		// inert (started=false), so the !Started guard above already skips it;
+		// this explicit check is belt-and-suspenders so a future change that
+		// leaves an Archived instance started can never have the poll probe it,
+		// mark it Lost, or repaint it Ready. It stays put until RestoreArchived.
+		return
+	}
 	if m.isPollPaused(repoID, instance.Title) {
 		// A TUI is attached full-screen to this instance (#1160). It owns the
 		// shared tmux server for the attach duration; the daemon's capture-pane

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -92,6 +92,11 @@ func (m *Manager) RestoreLostSessions() {
 // side only TryLocks: the poll goroutine must never stall behind a slow
 // teardown, and the next tick retries.
 func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance) {
+	// Only a Lost session is recovery-eligible. This gate is also what fences
+	// out an Archived session (#1028): Archived != Lost, and an archived
+	// instance additionally loads with started=false, so the !Started() check
+	// short-circuits first — the restore loop never moves its worktree back or
+	// re-spawns its tmux. Restoring an archive is an explicit user action only.
 	if inst == nil || !inst.Started() || inst.GetStatus() != session.Lost {
 		return
 	}

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -172,7 +172,12 @@ func TestRestoreLostSessions_SkipsIneligible(t *testing.T) {
 	})
 
 	t.Run("non-lost statuses", func(t *testing.T) {
-		for _, status := range []session.Status{session.Running, session.Ready, session.Loading, session.Deleting} {
+		// Archived (#1028) is included: an archived session is deliberately
+		// quiescent and must NEVER be auto-restored — only an explicit
+		// RestoreArchived brings it back. (In production it also loads
+		// started=false, but registering it started here proves the ==Lost gate
+		// alone already fences it out.)
+		for _, status := range []session.Status{session.Running, session.Ready, session.Loading, session.Deleting, session.Archived} {
 			manager, repoID, repoPath := newStatusTestManager(t)
 			backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
 			registerStarted(t, manager, repoID, repoPath, "healthy", backend, true, status)

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -119,12 +119,18 @@ func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
 	}
 
 	if inst != nil {
-		if status := inst.GetStatus(); status != session.Dead && status != session.Lost {
+		if status := inst.GetStatus(); status != session.Dead && status != session.Lost && status != session.Archived {
 			// Adopt, never clobber: a live root — whatever program it runs
 			// and whoever created it — is the root agent. Nothing to do.
 			m.rootEnsureSucceeded(st)
 			return
 		}
+		// An Archived root (#1028) is inert — no tmux — so it must NOT be
+		// adopted as live; fall through to reap-and-recreate like Dead/Lost so
+		// the always-ensured root comes back. In practice ArchiveSession
+		// rejects archiving the reserved root title, so this is defensive; the
+		// in-place root worktree is external, so reapDeadRoot's Cleanup is a
+		// no-op that only removes daemon-owned state.
 		// The root's tmux vanished (crash, tmux server death — the #1104
 		// outage class; recorded as Lost since #1108, Dead by older builds).
 		// Reap the dead record and fall through to re-create in place — the

--- a/daemon/rootagent_test.go
+++ b/daemon/rootagent_test.go
@@ -265,6 +265,44 @@ func TestEnsureRootAgentsHealsLostRoot(t *testing.T) {
 	}
 }
 
+// TestEnsureRootAgentsDoesNotAdoptArchivedRoot (#1028): an Archived root is
+// inert (no tmux), so the ensure loop must NOT adopt it as live — it must reap
+// and re-create in place, exactly like Dead/Lost. Archiving the reserved root
+// is rejected upstream by ArchiveSession, so this is the defensive backstop for
+// the adopt-never-clobber condition.
+func TestEnsureRootAgentsDoesNotAdoptArchivedRoot(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	seen := installOptionsRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+
+	manager, err := NewManager(rootTestConfig(repoPath, config.RootAgentConfig{}))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	manager.EnsureRootAgents()
+	first := findRootInstance(t, manager, repoPath)
+	if first == nil {
+		t.Fatalf("root instance missing after first ensure")
+	}
+
+	first.SetStatus(session.Archived)
+	manager.EnsureRootAgents()
+
+	if len(*seen) != 2 {
+		t.Fatalf("expected a re-create after the root went Archived (never adopted), got %d creates", len(*seen))
+	}
+	healed := findRootInstance(t, manager, repoPath)
+	if healed == nil {
+		t.Fatalf("root instance missing after heal")
+	}
+	if healed == first {
+		t.Fatalf("an archived root must be reaped and replaced, not adopted in place")
+	}
+	if got := healed.GetStatus(); got == session.Archived {
+		t.Fatalf("healed root must be live, got %v", got)
+	}
+}
+
 // TestEnsureRootAgentsRespectsUserKill: an explicit KillSession of the root
 // suppresses re-creation for the rest of the daemon's life; a fresh manager
 // (daemon restart) re-asserts the configured root. This is the conservative

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -212,6 +212,11 @@ func TestRefreshStatuses_SkipsTransientAndUnstarted(t *testing.T) {
 		{"loading", true, session.Loading},
 		{"deleting", true, session.Deleting},
 		{"unstarted", false, session.Running},
+		// Archived (#1028) with started=true proves the explicit Archived guard
+		// fires BEFORE the liveness probe: without it, a started instance over a
+		// dead backend would be flipped to Lost. It must stay Archived — never
+		// probed, never marked Lost, never repainted Ready.
+		{"archived", true, session.Archived},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/session/archived_test.go
+++ b/session/archived_test.go
@@ -1,0 +1,72 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFromInstanceData_ArchivedLoadsInert: an Archived record (#1028) loads
+// WITHOUT calling Start — no tmux is spawned or reconnected, the instance stays
+// started=false, and its gitWorktree is bound to the persisted (archived) path.
+// This is the invariant that makes the status poll, the Lost-restore loop, and
+// EnsureRootAgents all pass an archived session by; it is also #970-consistent
+// (a load never un-archives). Unlike the Lost path, the worktree directory need
+// not even exist on disk — inertness means nothing touches it at load.
+func TestFromInstanceData_ArchivedLoadsInert(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_archived_agent"
+	shellName := agentName + shellTmuxSuffix
+
+	// Inject a spawn-counting exec so we can prove no tmux session is created on
+	// load. Because the Archived branch skips Start entirely, no Restore/spawn
+	// ever runs — the counter must stay at zero.
+	var newSessions int
+	exec := countingExec(map[string]bool{}, &newSessions)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	t.Cleanup(func() { restoreTmuxSession = prev })
+
+	data := deadInstanceData(t, Archived, agentName, shellName)
+	// Deliberately DO NOT create data.Worktree.WorktreePath: an inert load must
+	// not depend on the worktree existing (the Lost path would MkdirAll it).
+
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, Archived, restored.GetStatus(), "status round-trips as Archived")
+	assert.False(t, restored.Started(), "an archived session loads inert: Start is skipped, started=false")
+	assert.False(t, restored.TabAlive(0), "no tmux session is spawned or reconnected on load")
+	assert.Equal(t, 0, newSessions, "loading an archived session must never spawn tmux")
+	assert.Equal(t, data.Worktree.WorktreePath, restored.GetWorktreePath(),
+		"gitWorktree is bound to the persisted archived path so restore knows where the worktree lives")
+
+	// Round-trip: re-serializing preserves Archived + the archived worktree path.
+	out := restored.ToInstanceData()
+	assert.Equal(t, Archived, out.Status)
+	assert.Equal(t, data.Worktree.WorktreePath, out.Worktree.WorktreePath)
+}
+
+// TestArchivedInstance_NotRecoverable: Recover refuses an Archived session even
+// if something forced it started — Recover is the Lost off-ramp only. This locks
+// the boundary between the two states at the backend level (belt-and-suspenders
+// alongside the daemon restore loop's ==Lost gate).
+func TestArchivedInstance_NotRecoverable(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	inst := &Instance{Title: "arch", Status: Archived, backend: &LocalBackend{}}
+	err := inst.Recover()
+	require.Error(t, err, "an archived session is not Lost, so Recover must reject it")
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -55,6 +55,21 @@ const (
 	// daemon restores it best-effort (#1108). Persisted, like Dead; excluded
 	// from isTransientStatus for the same reason.
 	Lost
+	// Archived is the deliberate counterpart of Lost (#1028): the user ran
+	// `af sessions archive`, so the daemon tore down every tmux session (agent
+	// + shell/process tabs) and MOVED the worktree out to the global archive
+	// dir (<AGENT_FACTORY_HOME>/archived/<repoID>/<title>/). Where Lost is a
+	// wanted, actively-self-healing state (tmux vanished under a live record;
+	// the restore loop re-spawns it every poll), Archived is a wanted,
+	// QUIESCENT state: it is never probed, never marked Lost, and never
+	// auto-restored — only an explicit `af sessions restore` moves the worktree
+	// back and re-spawns the agent. It therefore loads INERT (FromInstanceData
+	// skips Start: no tmux binding, started=false), which is what keeps the
+	// status poll (skips !Started), the Lost-restore loop (gates on ==Lost),
+	// and the root ensure loop from touching it. Persisted, like Dead/Lost;
+	// appended, never renumbered (Status serializes as an int), so old records
+	// stay readable — the same rollforward discipline #658/#1108 rely on.
+	Archived
 )
 
 // Instance is a running instance of claude code.
@@ -863,6 +878,22 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 			URL:    data.PRInfo.URL,
 			State:  data.PRInfo.State,
 		}
+	}
+
+	// An archived session (#1028) loads INERT: its tmux was torn down and its
+	// worktree moved to the global archive dir at archive time, so there is
+	// nothing to re-spawn or reconnect. Skipping Start leaves started=false and
+	// no tmux binding, which is exactly what makes the status poll (skips
+	// !Started), the Lost-restore loop (gates on ==Lost), and EnsureRootAgents
+	// pass it by — the session sits quiescent until an explicit RestoreArchived.
+	// This is also #970-consistent: a load must never itself un-archive a
+	// session (no worktree move, no spawn) as a side effect. gitWorktree is
+	// already bound above to the persisted (archived) path so restore knows
+	// where the worktree currently lives; the Tabs list restored above is
+	// tmux-less for the same reason (its TmuxName entries reference sessions
+	// that no longer exist, and restoreLocalTabs only binds names, never spawns).
+	if status == Archived {
+		return instance, nil
 	}
 
 	if err := instance.Start(false); err != nil {

--- a/session/storage.go
+++ b/session/storage.go
@@ -145,10 +145,19 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 	// Worktree.RepoPath is empty. This mirrors CollectRepoRoots (#667).
 	grouped := make(map[string][]InstanceData)
 	for _, inst := range instances {
-		if status := inst.GetStatus(); status == Loading || status == Deleting {
+		status := inst.GetStatus()
+		if status == Loading || status == Deleting {
 			continue
 		}
-		if !inst.Started() {
+		// The !Started() skip drops transient never-started junk (a create that
+		// hasn't run Start, a discarded duplicate). It must NOT drop an Archived
+		// instance (#1028): archived sessions load deliberately inert
+		// (started=false — tmux torn down, worktree relocated), yet the record is
+		// the ONLY pointer to the relocated worktree. Dropping it on a wholesale
+		// per-repo checkpoint save — triggered whenever ANY started instance in
+		// the same repo is saved — would silently orphan the archived worktree.
+		// (Lost is unaffected: it loads started=true, so it already survives.)
+		if !inst.Started() && status != Archived {
 			continue
 		}
 		root := inst.GetRepoPath()

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -143,6 +143,43 @@ func TestDaemonSaveRemovesKilledInstances(t *testing.T) {
 	assert.False(t, titles["instance-B"], "killed instance should not be preserved")
 }
 
+// TestSavePreservesArchivedRecordAcrossCoRepoSave is the #1028 Greptile-P1
+// regression: an Archived instance loads inert (started=false), but its record
+// is the ONLY pointer to its relocated worktree. The wholesale per-repo
+// checkpoint save — triggered whenever a DIFFERENT started instance in the same
+// repo is saved — must preserve the archived record, not drop it and orphan the
+// worktree. Before the fix the `!Started()` skip silently removed it.
+func TestSavePreservesArchivedRecordAcrossCoRepoSave(t *testing.T) {
+	const repoPath = "/tmp/test-archive-repo"
+	ms := newMockStorage()
+
+	// Disk starts with both a live session and an archived one in the same repo.
+	seedDisk(t, ms, repoPath, []InstanceData{
+		{Title: "live-sess", Path: repoPath},
+		{Title: "archived-sess", Path: repoPath, Status: Archived},
+	})
+
+	live := makeInstance("live-sess", repoPath, true)          // started
+	archived := makeInstance("archived-sess", repoPath, false) // inert, started=false
+	archived.Status = Archived
+
+	storage, err := NewStorage(ms, "") // daemon mode
+	require.NoError(t, err)
+
+	// Saving the started instance re-marshals and overwrites the whole per-repo
+	// file — the exact operation that used to drop the inert archived record.
+	require.NoError(t, storage.SaveInstances([]*Instance{live, archived}))
+
+	byTitle := make(map[string]InstanceData)
+	for _, d := range readDisk(t, ms, repoPath) {
+		byTitle[d.Title] = d
+	}
+	require.Contains(t, byTitle, "archived-sess",
+		"an archived record must survive a co-repo checkpoint save, or its relocated worktree is orphaned")
+	assert.Equal(t, Archived, byTitle["archived-sess"].Status, "the record must reload as Archived")
+	assert.Contains(t, byTitle, "live-sess", "the started instance is still saved as before")
+}
+
 func TestDaemonSaveDoesNotTouchUnknownRepos(t *testing.T) {
 	const repoPath1 = "/tmp/repo1"
 	const repoPath2 = "/tmp/repo2"


### PR DESCRIPTION
**Part 1 of 6** for #1028 (Archive instances: bring down tmux + move worktree, restartable). Approved design: https://github.com/sachiniyer/agent-factory/issues/1028#issuecomment-4881997066

This is the **foundation** PR — the state model + invariants. **No user-facing surface yet**: nothing produces the `Archived` status until the `ArchiveSession` RPC (PR 3), so this PR is safe to land on its own and cannot change any existing behavior.

### What it does
- **Enum:** append `Archived` to `session.Status` (rollforward per #658/#1108 — `Status` serializes as an `int`, so we append and never renumber; old records stay readable). `Archived` is the deliberate counterpart of `Lost`: tmux torn down, worktree moved to the global archive dir, and — unlike `Lost` — **never auto-restored**.
- **Inert load:** `FromInstanceData` loads an `Archived` record without calling `Start` — it binds `gitWorktree` to the persisted (archived) path but spawns/reconnects no tmux, so the instance comes up `started=false`. This is what makes every background loop pass it by, and it is #970-consistent (a load never un-archives a session as a side effect).
- **Guards** (belt-and-suspenders, each with a regression test):
  - `refreshInstanceStatus` — explicit `Archived` short-circuit: never probed, never marked `Lost`, never repainted `Ready`.
  - `RestoreLostSessions`/`restoreLostSession` — the `==Lost` gate already fences `Archived` out; now documented + tested.
  - `EnsureRootAgents` — an `Archived` root is not adopted as live; reap+recreate like `Dead`/`Lost` (defensive — `ArchiveSession` will reject archiving the reserved root).
  - `interactiveGuard` (Enter/attach) — Enter on an archived row surfaces `"… is archived — restore it first (af sessions restore <title>)"` instead of silently swallowing the keypress or showing the generic dead-tmux message.

### Tests
- `session`: inert-load (no spawn, `started=false`, worktree bound to archived path) + `ToInstanceData` round-trip + `Recover` rejects `Archived`.
- `daemon`: status-poll skip (with `started=true` to prove the explicit guard fires before the liveness probe), lost-restore skip, root-not-adopted (mirrors the Dead/Lost heal tests).
- `app`: `handleEnter` on an archived session takes the archived-error path and names `restore` as the off-ramp.

### Verification
- `go build ./...`, `gofmt -l`, `go vet`, `golangci-lint run --fast`, `deadcode -test ./...` — all clean.
- Full `daemon` + `session` + `app` suites green under `make test-container`.

**Do not merge on my authority** — for root to gate (CI + Greptile + `make test-container`). PRs 2–6 stack on this in order; PR 6 closes #1028.

— Captain Claude