### PR TITLE
feat(daemon): ArchiveSession RPC — teardown + move + persist (#1028) [PR 3/6]

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -37,6 +37,16 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	if instance.IsRemote() {
 		return "", fmt.Errorf("cannot archive remote session %q: it has no local worktree to relocate", req.Title)
 	}
+	if instance.IsExternalWorktree() {
+		// An in-place/external worktree (`af sessions create --here`, #1107 — also
+		// how root is set up) IS the user's own working tree; archive relocates
+		// the worktree, which MoveWorktree refuses for external worktrees. Reject
+		// it HERE, in the upfront guard, so nothing is torn down for a session
+		// that can never be archived — otherwise the rejection would only surface
+		// in the move step, after tmux is already down, leaving a broken
+		// half-archive that rolls back to Lost.
+		return "", fmt.Errorf("cannot archive an in-place/external worktree session %q — archive relocates the worktree, which isn't supported for in-place sessions", req.Title)
+	}
 	switch instance.GetStatus() {
 	case session.Archived:
 		return "", fmt.Errorf("session %q is already archived", req.Title)

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -1,0 +1,143 @@
+package daemon
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// ArchiveSession archives a session (#1028): it tears down the session's tmux
+// (agent + shell/process tabs) while PRESERVING the record, relocates the
+// worktree to the global archive dir (<AF_HOME>/archived/<repoID>/<title>/), and
+// marks the instance Archived. The instance stays in the manager map as an inert
+// row (unlike Kill, which deletes it); a later RestoreArchived brings it back.
+//
+// Concurrency mirrors KillSession: it registers in killsInFlight (so a
+// concurrent kill or a second archive is rejected, and the Lost-restore /
+// finish-kill passes skip it) and holds the per-session op-lock (so archive,
+// kill, and Lost-recovery never interleave). Returns the relocated worktree's
+// new path.
+func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
+	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+	if err != nil {
+		return "", err
+	}
+	if session.IsReservedTitle(req.Title) {
+		return "", fmt.Errorf("cannot archive the reserved %q session", req.Title)
+	}
+	if instance == nil {
+		// A ghost disk record with no live instance has no in-memory worktree to
+		// relocate; there is nothing coherent to archive.
+		return "", fmt.Errorf("cannot archive session %q: it is not currently active", req.Title)
+	}
+	if instance.IsRemote() {
+		return "", fmt.Errorf("cannot archive remote session %q: it has no local worktree to relocate", req.Title)
+	}
+	switch instance.GetStatus() {
+	case session.Archived:
+		return "", fmt.Errorf("session %q is already archived", req.Title)
+	case session.Loading, session.Deleting:
+		return "", fmt.Errorf("session %q is busy (%v); try again in a moment", req.Title, instance.GetStatus())
+	}
+
+	key := daemonInstanceKey(repoID, req.Title)
+	m.mu.Lock()
+	if _, busy := m.killsInFlight[key]; busy {
+		m.mu.Unlock()
+		return "", fmt.Errorf("an operation is already in progress for session %q", req.Title)
+	}
+	m.killsInFlight[key] = struct{}{}
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		delete(m.killsInFlight, key)
+		m.mu.Unlock()
+	}()
+
+	opLock := m.opLockFor(key)
+	opLock.Lock()
+	defer opLock.Unlock()
+
+	// Re-verify under the op-lock: findSession released m.mu, so a racing kill
+	// may have torn the session down (map entry gone/replaced) or tombstoned it.
+	m.mu.Lock()
+	current := m.instances[key]
+	m.mu.Unlock()
+	if current != instance || instance.UserKilled() {
+		return "", fmt.Errorf("session %q changed state before archive could start", req.Title)
+	}
+
+	dest, err := archivedWorktreePath(repoID, req.Title)
+	if err != nil {
+		return "", err
+	}
+
+	// Fence the operation window with Deleting: the status poll skips a Deleting
+	// instance (and the checkpoint save skips persisting it) while tmux is down
+	// and the worktree is mid-move, so it is never misread as Lost. started is
+	// left true throughout so a move failure self-heals via the Lost loop.
+	instance.SetStatus(session.Deleting)
+
+	instance.ArchiveTeardown()
+
+	if err := instance.MoveArchivedWorktree(dest); err != nil {
+		// The worktree is still at a valid location (the git layer guarantees
+		// worktreePath points at the actual bytes even on a repair failure).
+		// Mark Lost — started is still true and the agent tmux binding was kept —
+		// so the Lost-restore loop re-spawns the agent in place. Persist the
+		// recovery-eligible state and surface the failure.
+		instance.SetStatus(session.Lost)
+		m.persistInstance(repoID, instance)
+		return "", fmt.Errorf("failed to archive session %q (its agent will be restored in place): %w", req.Title, err)
+	}
+
+	// Success: worktree relocated, tmux down. Flip to the inert Archived state
+	// (started=false) and persist the new path + status.
+	instance.SetArchived()
+	archivedPath := instance.GetWorktreePath()
+	m.persistInstance(repoID, instance)
+	log.InfoLog.Printf("archived session %q (repo %s): tmux torn down, worktree moved to %s", req.Title, repoID, archivedPath)
+	return archivedPath, nil
+}
+
+// persistInstance writes one instance's authoritative data through the targeted
+// per-repo writer under the repo start lock, mirroring refreshInstanceStatus's
+// persist. Best-effort: a failed write only logs.
+func (m *Manager) persistInstance(repoID string, instance *session.Instance) {
+	repoStartLock := m.startLockForRepo(repoID)
+	repoStartLock.Lock()
+	err := persistInstanceData(repoID, instance.ToInstanceData())
+	repoStartLock.Unlock()
+	if err != nil {
+		log.WarningLog.Printf("failed to persist instance %q: %v", instance.Title, err)
+	}
+}
+
+// archivedWorktreePath returns the global archive location for a session's
+// relocated worktree: <AGENT_FACTORY_HOME>/archived/<repoID>/<safeTitle>/. The
+// repoID namespace prevents cross-repo title collisions; the title is sanitized
+// for filesystem safety (the same scheme NewGitWorktree uses for session dirs).
+func archivedWorktreePath(repoID, title string) (string, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve archive directory: %w", err)
+	}
+	return filepath.Join(dir, "archived", repoID, sanitizeArchiveTitle(title)), nil
+}
+
+// sanitizeArchiveTitle makes a session title safe as a single path segment,
+// mirroring NewGitWorktree's safeSessionName handling (strip "..", "/"→"-",
+// trim leading separators), falling back to "session" when nothing remains.
+func sanitizeArchiveTitle(title string) string {
+	s := strings.ReplaceAll(title, "..", "")
+	s = strings.ReplaceAll(s, "/", "-")
+	s = strings.TrimLeft(s, "-.")
+	if s == "" {
+		s = "session"
+	}
+	return s
+}

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -150,6 +150,39 @@ func TestArchiveSession_RejectsWhenOperationInFlight(t *testing.T) {
 	assert.Contains(t, err.Error(), "in progress")
 }
 
+// TestArchiveSession_RejectsExternalWorktree (#1028 Greptile P1): an
+// in-place/external worktree (an `--here` session, or root) cannot be archived —
+// archive relocates the worktree, which MoveWorktree refuses for external
+// worktrees. The rejection must happen UP FRONT so nothing is torn down: the
+// session is left completely untouched (status unchanged, still started, its
+// worktree in place), never a broken half-archive that rolls back to Lost.
+func TestArchiveSession_RejectsExternalWorktree(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+
+	// An in-place/external worktree: the worktree IS the repo root, external=true.
+	gw, err := sessiongit.NewGitWorktreeFromStorage(repoPath, repoPath, "inplace", "master", "", true, false)
+	require.NoError(t, err)
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "inplace", Path: repoPath, Program: "claude"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetGitWorktreeForTest(gw)
+	inst.SetStartedForTest(true)
+	inst.SetStatus(session.Ready)
+	seedDiskInstance(t, repoID, "inplace", repoPath)
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(repoID, "inplace")] = inst
+	manager.mu.Unlock()
+
+	_, err = manager.ArchiveSession(ArchiveSessionRequest{Title: "inplace", RepoID: repoID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "in-place")
+
+	// Untouched: rejected before any teardown.
+	assert.Equal(t, session.Ready, inst.GetStatus(), "an unarchivable session must not be torn down or flipped Lost")
+	assert.True(t, inst.Started(), "an unarchivable session must stay started")
+	assert.True(t, exists(repoPath), "the user's in-place worktree must be untouched")
+}
+
 type fakeRemoteBackend struct {
 	*session.FakeBackend
 }

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -1,0 +1,176 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func exists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// registerArchivable creates a real linked worktree in the manager's repo and a
+// started instance bound to it (FakeBackend, no real tmux — ArchiveTeardown is a
+// no-op on an instance with no tmux-backed tabs), registered in the manager and
+// seeded on disk. Ready for ArchiveSession. Returns the instance and the
+// worktree's original path.
+func registerArchivable(t *testing.T, m *Manager, repoID, repoPath, title string) (*session.Instance, string) {
+	t.Helper()
+	wtPath := filepath.Join(filepath.Dir(repoPath), "wt-"+sanitizeArchiveTitle(title))
+	branch := "af/" + sanitizeArchiveTitle(title)
+	out, err := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branch, wtPath).CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.NoError(t, os.WriteFile(filepath.Join(wtPath, "dirty.txt"), []byte("uncommitted"), 0644))
+
+	gw, err := sessiongit.NewGitWorktreeFromStorage(repoPath, wtPath, title, branch, "", false, true)
+	require.NoError(t, err)
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: repoPath, Program: "claude"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetGitWorktreeForTest(gw)
+	inst.SetStartedForTest(true)
+	inst.SetStatus(session.Ready)
+
+	seedDiskInstance(t, repoID, title, repoPath)
+	m.mu.Lock()
+	m.instances[daemonInstanceKey(repoID, title)] = inst
+	m.mu.Unlock()
+	return inst, wtPath
+}
+
+// TestArchiveSession_MovesWorktreeAndMarksArchived: the happy path — tmux torn
+// down (no-op here), worktree relocated to <AF_HOME>/archived/<repoID>/<title>
+// with its dirty tree + registration intact, instance flipped to inert Archived
+// and preserved (not deleted) in the manager and on disk.
+func TestArchiveSession_MovesWorktreeAndMarksArchived(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, srcPath := registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	archivedPath, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	require.NoError(t, err)
+
+	expected, perr := archivedWorktreePath(repoID, "worker")
+	require.NoError(t, perr)
+	assert.Equal(t, expected, archivedPath, "worktree must land at the namespaced archive path")
+	assert.False(t, exists(srcPath), "the original worktree directory must be gone")
+	assert.True(t, exists(archivedPath), "the worktree must exist at the archive path")
+
+	dirty, rerr := os.ReadFile(filepath.Join(archivedPath, "dirty.txt"))
+	require.NoError(t, rerr, "the uncommitted tree must survive the archive move")
+	assert.Equal(t, "uncommitted", string(dirty))
+
+	assert.Equal(t, session.Archived, inst.GetStatus())
+	assert.False(t, inst.Started(), "an archived instance is inert (started=false)")
+
+	manager.mu.Lock()
+	_, tracked := manager.instances[daemonInstanceKey(repoID, "worker")]
+	manager.mu.Unlock()
+	assert.True(t, tracked, "an archived instance is preserved in the manager, not deleted like a kill")
+
+	assert.Equal(t, session.Archived, persistedStatus(t, repoID, "worker"))
+	rec := recordFor(t, repoID, "worker")
+	require.NotNil(t, rec)
+	assert.Equal(t, archivedPath, rec.Worktree.WorktreePath, "the persisted record must point at the relocated worktree")
+
+	// The worktree is still a valid, registered git worktree at its new path.
+	list, lerr := exec.Command("git", "-C", repoPath, "worktree", "list", "--porcelain").CombinedOutput()
+	require.NoError(t, lerr, string(list))
+	assert.Contains(t, string(list), archivedPath, "git must still register the worktree at its new path")
+}
+
+// TestArchiveSession_MoveFailureMarksLost: when the worktree move fails, the
+// instance is marked Lost (not Archived) with started still true, so the
+// Lost-restore loop re-spawns the agent in place — and the worktree is left
+// untouched at its original location.
+func TestArchiveSession_MoveFailureMarksLost(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, srcPath := registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	// Force the move to fail by pre-creating the destination (MoveWorktree
+	// refuses to clobber an existing dest), before any bytes are moved.
+	dest, err := archivedWorktreePath(repoID, "worker")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(dest, 0755))
+
+	_, err = manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	require.Error(t, err, "a failed move must surface an error")
+
+	assert.Equal(t, session.Lost, inst.GetStatus(), "a failed archive marks the session Lost for self-heal")
+	assert.True(t, inst.Started(), "started stays true so the Lost-restore loop re-spawns the agent")
+	assert.True(t, exists(srcPath), "the worktree must remain at its original path on a failed archive")
+	assert.Equal(t, session.Lost, persistedStatus(t, repoID, "worker"))
+}
+
+// TestArchiveSession_RejectsReservedRoot: the always-ensured root session cannot
+// be archived.
+func TestArchiveSession_RejectsReservedRoot(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerArchivable(t, manager, repoID, repoPath, session.RootSessionTitle)
+
+	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: session.RootSessionTitle, RepoID: repoID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved")
+}
+
+// TestArchiveSession_RejectsAlreadyArchived: archiving an already-archived
+// session is an error, not a second move.
+func TestArchiveSession_RejectsAlreadyArchived(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
+	inst.SetStatus(session.Archived)
+
+	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already archived")
+}
+
+// TestArchiveSession_RejectsWhenOperationInFlight: an archive is refused while
+// another destructive op (kill or archive) holds the session.
+func TestArchiveSession_RejectsWhenOperationInFlight(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	key := daemonInstanceKey(repoID, "worker")
+	manager.mu.Lock()
+	manager.killsInFlight[key] = struct{}{}
+	manager.mu.Unlock()
+
+	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "in progress")
+}
+
+type fakeRemoteBackend struct {
+	*session.FakeBackend
+}
+
+func (fakeRemoteBackend) Type() string { return "remote" }
+
+// TestArchiveSession_RejectsRemote: a remote session has no local worktree to
+// relocate, so archiving it is rejected up front.
+func TestArchiveSession_RejectsRemote(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "faraway", Path: repoPath, Program: "claude"})
+	require.NoError(t, err)
+	inst.SetBackend(fakeRemoteBackend{session.NewFakeBackend()})
+	inst.SetStartedForTest(true)
+	inst.SetStatus(session.Ready)
+	seedDiskInstance(t, repoID, "faraway", repoPath)
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(repoID, "faraway")] = inst
+	manager.mu.Unlock()
+
+	_, err = manager.ArchiveSession(ArchiveSessionRequest{Title: "faraway", RepoID: repoID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote")
+}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -88,6 +88,20 @@ type KillSessionResponse struct {
 	OK bool
 }
 
+// ArchiveSessionRequest asks the daemon to archive a session (#1028): tear down
+// its tmux, relocate its worktree to the global archive dir, and mark it
+// Archived while preserving the record.
+type ArchiveSessionRequest struct {
+	Title  string
+	RepoID string
+}
+
+type ArchiveSessionResponse struct {
+	OK bool
+	// ArchivedPath is the new on-disk location of the relocated worktree.
+	ArchivedPath string
+}
+
 type SendPromptRequest struct {
 	Title  string
 	RepoID string
@@ -829,6 +843,22 @@ func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionRes
 		return err
 	}
 	resp.OK = true
+	return nil
+}
+
+func (s *controlServer) ArchiveSession(req ArchiveSessionRequest, resp *ArchiveSessionResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
+	if err := validateRPCRepoID(req.RepoID); err != nil {
+		return err
+	}
+	archivedPath, err := s.manager.ArchiveSession(req)
+	if err != nil {
+		return err
+	}
+	resp.OK = true
+	resp.ArchivedPath = archivedPath
 	return nil
 }
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -1305,6 +1305,18 @@ func (i *Instance) Started() bool {
 	return i.started
 }
 
+// IsExternalWorktree reports whether the instance's worktree is external/in-place
+// (`af sessions create --here`, or a legacy external record) — the same flag
+// MoveWorktree checks. Such a worktree is the user's own working tree and must
+// never be relocated, so the daemon rejects archiving it (#1028). Returns false
+// when the instance has no worktree yet.
+func (i *Instance) IsExternalWorktree() bool {
+	i.mu.RLock()
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+	return gw != nil && gw.IsExternalWorktree()
+}
+
 // SetTitle sets the title of the instance. Returns an error if the instance has started.
 // We cant change the title once it's been used for a tmux session etc.
 func (i *Instance) SetTitle(title string) error {

--- a/session/instance.go
+++ b/session/instance.go
@@ -1152,6 +1152,81 @@ func (i *Instance) Recover() error {
 	return i.backend.Recover(i)
 }
 
+// ArchiveTeardown tears down every tab's tmux session for an archive (#1028) —
+// the tmux half of Kill, but it PRESERVES the worktree and the instance record.
+// It is deliberately best-effort (a stuck tmux only logs, mirroring Kill) and:
+//   - keeps the AGENT tab's tmux binding (its session name) so a failed archive
+//     can re-spawn it in place via the Lost-restore loop;
+//   - drops the shell/process tabs entirely — only the agent session is brought
+//     back on un-archive (Sachin's #1028 requirement);
+//   - leaves gitWorktree and started untouched, so the daemon caller controls
+//     the final state (started=false + Archived on success; Lost on a failed
+//     move, where started stays true so the loop re-spawns the agent).
+//
+// Local instances only — remote sessions have no local tmux/worktree and the
+// daemon rejects archiving them before reaching here.
+func (i *Instance) ArchiveTeardown() {
+	i.mu.Lock()
+	type tabSession struct {
+		name string
+		ts   *tmux.TmuxSession
+	}
+	sessions := make([]tabSession, 0, len(i.Tabs))
+	var agentTab *Tab
+	for idx, tab := range i.Tabs {
+		if idx == 0 {
+			agentTab = tab
+		}
+		if tab.tmux != nil {
+			sessions = append(sessions, tabSession{name: tab.Name, ts: tab.tmux})
+		}
+	}
+	title := i.Title
+	i.mu.Unlock()
+
+	// Tear each tab's tmux session down and wait for the pane to exit before the
+	// worktree is relocated, mirroring Kill's ordering (a process still flushing
+	// state races the move otherwise).
+	for _, s := range sessions {
+		if err := s.ts.CloseAndWaitForPaneExit(); err != nil {
+			log.WarningLog.Printf("archive %q: tmux teardown for tab %q failed: %v", title, s.name, err)
+		}
+	}
+
+	i.mu.Lock()
+	// Reduce to the agent tab only. Its tmux binding is kept (the server-side
+	// session is gone, but the name-holder lets a rollback Recover re-spawn it,
+	// and a successful archive persists it as an inert name-holder).
+	if agentTab != nil {
+		i.Tabs = []*Tab{agentTab}
+	}
+	i.mu.Unlock()
+}
+
+// MoveArchivedWorktree relocates this instance's worktree to dest (#1028),
+// delegating to the git relocation primitive. The caller holds the daemon
+// op-lock and has already run ArchiveTeardown, so no live tmux pane is cwd'd
+// into the worktree during the move.
+func (i *Instance) MoveArchivedWorktree(dest string) error {
+	i.mu.RLock()
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+	if gw == nil {
+		return fmt.Errorf("cannot archive %q: instance has no worktree to relocate", i.Title)
+	}
+	return gw.MoveWorktree(dest)
+}
+
+// SetArchived flips the instance into the inert Archived state atomically:
+// started=false (no tmux binding backs it) and Status=Archived. Called by the
+// daemon after a successful archive move.
+func (i *Instance) SetArchived() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.started = false
+	i.Status = Archived
+}
+
 // CloseAttachOnly releases the resources this instance opened to view or drive
 // its session (a tmux attach PTY, a remote preview process) without destroying
 // the session, worktree, or remote record. Use it — never Kill — to discard a


### PR DESCRIPTION
**Part 3 of 6** for #1028. Approved design: https://github.com/sachiniyer/agent-factory/issues/1028#issuecomment-4881997066

Builds on PR 1 (#1173) and PR 2 (#1175), both now merged to `master`; this targets `master` directly and is a single focused commit.

The daemon-side archive operation: tear down a session's tmux (agent + shell/process tabs) while **preserving the record**, relocate the worktree to the global archive dir, and mark the instance `Archived`. The instance stays in the manager map as an inert row (unlike Kill, which deletes it). **Client wrapper + CLI land in PR 5.**

### Manager.ArchiveSession
- Rejects the reserved root, remote sessions (no local worktree), already-archived/busy sessions.
- **Concurrency** mirrors `KillSession`: registers in `killsInFlight` (a concurrent kill or second archive is rejected; Lost-restore / finish-kill skip it) and holds the per-session op-lock (archive/kill/recover never interleave). Re-verifies under the lock after `findSession` released `m.mu`.
- **Fences** the window with `Deleting` so the status poll and checkpoint save skip the instance while tmux is down and the worktree is mid-move; `started` stays true so a failure self-heals.
- **Ordering:** teardown → move → persist(`Archived`, `started=false`).
- **Move-failure rollback:** marks the instance `Lost` (started still true, agent tmux binding kept) so the #1108 Lost-restore loop re-spawns the agent in place; the git layer (PR 2) guarantees the worktree is left at a valid path.

### Instance primitives
`ArchiveTeardown` (tmux down, keep agent-tab binding, drop shell/process tabs, preserve worktree) · `MoveArchivedWorktree` · `SetArchived` (atomic `started=false` + `Archived`).

**Archive path:** `<AGENT_FACTORY_HOME>/archived/<repoID>/<safeTitle>/` — repoID-namespaced, title sanitized like `NewGitWorktree`'s session dirs.

### Tests (real temp worktrees)
happy path (worktree relocated + still git-registered, dirty tree preserved, record preserved + `Archived` on disk) · move-failure→`Lost` (worktree untouched, `started` stays true) · reject reserved-root / remote / already-archived / operation-in-flight. Full daemon+session suites green under `make test-container`; lint + deadcode clean.

### Known bounded window
A daemon crash *between* the worktree move and the status persist leaves the pre-archive record pointing at the old path (bytes are safely at the archive dir — never deleted, recoverable). Mirrors Kill's teardown crash window; a restore-time reconcile can be added later if root wants it.

**Do not merge on my authority.**

— Captain Claude