### PR TITLE
feat(daemon): RestoreArchived RPC — move worktree back + re-spawn agent (#1028) [PR 4/6]

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -1,13 +1,16 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 )
 
 // ArchiveSession archives a session (#1028): it tears down the session's tmux
@@ -112,6 +115,93 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	m.persistInstance(repoID, instance)
 	log.InfoLog.Printf("archived session %q (repo %s): tmux torn down, worktree moved to %s", req.Title, repoID, archivedPath)
 	return archivedPath, nil
+}
+
+// RestoreArchived restores an archived session (#1028): it moves the worktree
+// back next to the repo (a free sibling path), re-registers it, re-spawns the
+// agent, and marks the instance Running. Only the agent session is brought back
+// — shell/process tabs were dropped at archive time. Returns the restored
+// worktree path.
+//
+// Concurrency mirrors ArchiveSession/KillSession (killsInFlight + op-lock). On a
+// repo-gone failure the archive is left intact with an actionable error; on a
+// re-spawn failure the worktree is already back in place and the instance is
+// left Lost so the #1108 restore loop heals it.
+func (m *Manager) RestoreArchived(req RestoreArchivedRequest) (string, error) {
+	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+	if err != nil {
+		return "", err
+	}
+	if instance == nil {
+		return "", fmt.Errorf("cannot restore session %q: no such session", req.Title)
+	}
+	if instance.GetStatus() != session.Archived {
+		return "", fmt.Errorf("session %q is not archived", req.Title)
+	}
+
+	key := daemonInstanceKey(repoID, req.Title)
+	m.mu.Lock()
+	if _, busy := m.killsInFlight[key]; busy {
+		m.mu.Unlock()
+		return "", fmt.Errorf("an operation is already in progress for session %q", req.Title)
+	}
+	m.killsInFlight[key] = struct{}{}
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		delete(m.killsInFlight, key)
+		m.mu.Unlock()
+	}()
+
+	opLock := m.opLockFor(key)
+	opLock.Lock()
+	defer opLock.Unlock()
+
+	// Re-verify under the op-lock (findSession released m.mu).
+	m.mu.Lock()
+	current := m.instances[key]
+	m.mu.Unlock()
+	if current != instance || instance.GetStatus() != session.Archived {
+		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
+	}
+
+	repoPath := instance.GetRepoPath()
+	if repoPath == "" {
+		return "", fmt.Errorf("cannot restore session %q: no repo path on record", req.Title)
+	}
+	// Repo-gone check up front: SiblingWorktreePath and the worktree move both
+	// need the origin repo, so surface the actionable message (archive left
+	// intact) before either fails with a generic error.
+	if _, statErr := os.Stat(repoPath); statErr != nil {
+		return "", fmt.Errorf("cannot restore session %q: its origin repo %s is gone; the archived worktree is intact at %s — recover it manually with git", req.Title, repoPath, instance.GetWorktreePath())
+	}
+	dest, err := sessiongit.SiblingWorktreePath(repoPath, req.Title)
+	if err != nil {
+		return "", fmt.Errorf("cannot determine restore location for %q: %w", req.Title, err)
+	}
+
+	// Move the worktree back next to the repo. A repo-gone failure leaves the
+	// archive intact (the git layer guarantees this) and surfaces an actionable
+	// message; the instance stays Archived.
+	if err := instance.RestoreArchivedWorktree(dest); err != nil {
+		if errors.Is(err, sessiongit.ErrRepoGone) {
+			return "", fmt.Errorf("cannot restore session %q: its origin repo is gone; the archived worktree is intact at %s — recover it manually with git: %w", req.Title, instance.GetWorktreePath(), err)
+		}
+		return "", fmt.Errorf("failed to restore worktree for %q: %w", req.Title, err)
+	}
+
+	// Worktree is back in place. Re-spawn the agent and flip Running. On a
+	// re-spawn failure RestoreFromArchive leaves the instance started + Lost, so
+	// the Lost-restore loop keeps retrying against the now-restored worktree.
+	if err := instance.RestoreFromArchive(); err != nil {
+		m.persistInstance(repoID, instance)
+		return "", fmt.Errorf("restored worktree for %q but failed to re-spawn its agent (it will be retried): %w", req.Title, err)
+	}
+
+	worktreePath := instance.GetWorktreePath()
+	m.persistInstance(repoID, instance)
+	log.InfoLog.Printf("restored session %q (repo %s): worktree moved back to %s, agent re-spawned", req.Title, repoID, worktreePath)
+	return worktreePath, nil
 }
 
 // persistInstance writes one instance's authoritative data through the targeted

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -183,6 +183,104 @@ func TestArchiveSession_RejectsExternalWorktree(t *testing.T) {
 	assert.True(t, exists(repoPath), "the user's in-place worktree must be untouched")
 }
 
+// TestRestoreArchived_MovesWorktreeBackAndRespawns: the happy path — an archived
+// session's worktree is moved back to the standard sibling location, re-
+// registered, the agent re-spawned (Recover flips Running), started=true, and
+// the record persisted as Running at the restored path.
+func TestRestoreArchived_MovesWorktreeBackAndRespawns(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst.SetBackend(backend)
+
+	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	require.NoError(t, err)
+	require.Equal(t, session.Archived, inst.GetStatus())
+	archivedPath := inst.GetWorktreePath()
+
+	// Compute the expected sibling path BEFORE restore, while it is still free
+	// (afterwards the restored worktree occupies it, and SiblingWorktreePath
+	// would return the "-2" suffix).
+	expected, perr := sessiongit.SiblingWorktreePath(repoPath, "worker")
+	require.NoError(t, perr)
+
+	worktreePath, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, worktreePath, "restore must land the worktree at the standard sibling location")
+	assert.False(t, exists(archivedPath), "the archive directory must be gone after restore")
+	assert.True(t, exists(worktreePath), "the worktree must exist at the restored path")
+
+	dirty, rerr := os.ReadFile(filepath.Join(worktreePath, "dirty.txt"))
+	require.NoError(t, rerr, "the uncommitted tree must survive the round trip")
+	assert.Equal(t, "uncommitted", string(dirty))
+
+	assert.Equal(t, 1, backend.recoverCalls(), "restore re-spawns the agent exactly once")
+	assert.Equal(t, session.Running, inst.GetStatus(), "a restored session is Running")
+	assert.True(t, inst.Started(), "a restored session is started")
+	assert.Equal(t, session.Running, persistedStatus(t, repoID, "worker"))
+	rec := recordFor(t, repoID, "worker")
+	require.NotNil(t, rec)
+	assert.Equal(t, worktreePath, rec.Worktree.WorktreePath)
+
+	list, lerr := exec.Command("git", "-C", repoPath, "worktree", "list", "--porcelain").CombinedOutput()
+	require.NoError(t, lerr, string(list))
+	assert.Contains(t, string(list), worktreePath, "git must register the worktree at the restored path")
+}
+
+// TestRestoreArchived_RejectsNonArchived: restoring a live (non-archived) session
+// is an error.
+func TestRestoreArchived_RejectsNonArchived(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	registerArchivable(t, manager, repoID, repoPath, "worker") // status Ready
+
+	_, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not archived")
+}
+
+// TestRestoreArchived_RepoGoneLeavesArchiveIntact: when the origin repo has been
+// deleted, restore fails with an actionable message and leaves the archived
+// worktree and the Archived status untouched.
+func TestRestoreArchived_RepoGoneLeavesArchiveIntact(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
+	inst.SetBackend(&recoverFakeBackend{FakeBackend: session.NewFakeBackend()})
+
+	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	require.NoError(t, err)
+	archivedPath := inst.GetWorktreePath()
+
+	require.NoError(t, os.RemoveAll(repoPath), "simulate the origin repo being deleted")
+
+	_, err = manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gone")
+	assert.True(t, exists(archivedPath), "the archived worktree must be left intact when the repo is gone")
+	assert.Equal(t, session.Archived, inst.GetStatus(), "a failed restore must leave the session Archived")
+}
+
+// TestRestoreArchived_CollisionSuffixesPath: when the standard sibling location
+// is occupied at restore time, the worktree is restored to a suffixed path.
+func TestRestoreArchived_CollisionSuffixesPath(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
+	inst.SetBackend(&recoverFakeBackend{FakeBackend: session.NewFakeBackend()})
+
+	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	require.NoError(t, err)
+
+	// Occupy the default sibling location so restore must suffix.
+	base, perr := sessiongit.SiblingWorktreePath(repoPath, "worker")
+	require.NoError(t, perr)
+	require.NoError(t, os.MkdirAll(base, 0755))
+
+	worktreePath, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
+	require.NoError(t, err)
+	assert.Equal(t, base+"-2", worktreePath, "restore must avoid clobbering an occupied sibling path")
+	assert.True(t, exists(filepath.Join(worktreePath, "dirty.txt")))
+}
+
 type fakeRemoteBackend struct {
 	*session.FakeBackend
 }

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -102,6 +102,20 @@ type ArchiveSessionResponse struct {
 	ArchivedPath string
 }
 
+// RestoreArchivedRequest asks the daemon to restore an archived session (#1028):
+// move its worktree back next to the repo, re-spawn the agent, and mark it
+// Running.
+type RestoreArchivedRequest struct {
+	Title  string
+	RepoID string
+}
+
+type RestoreArchivedResponse struct {
+	OK bool
+	// WorktreePath is the on-disk location the worktree was restored to.
+	WorktreePath string
+}
+
 type SendPromptRequest struct {
 	Title  string
 	RepoID string
@@ -859,6 +873,22 @@ func (s *controlServer) ArchiveSession(req ArchiveSessionRequest, resp *ArchiveS
 	}
 	resp.OK = true
 	resp.ArchivedPath = archivedPath
+	return nil
+}
+
+func (s *controlServer) RestoreArchived(req RestoreArchivedRequest, resp *RestoreArchivedResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
+	if err := validateRPCRepoID(req.RepoID); err != nil {
+		return err
+	}
+	worktreePath, err := s.manager.RestoreArchived(req)
+	if err != nil {
+		return err
+	}
+	resp.OK = true
+	resp.WorktreePath = worktreePath
 	return nil
 }
 

--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -6,10 +6,54 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/sachiniyer/agent-factory/log"
 )
+
+// SiblingWorktreePath returns the standard sibling worktree location for a
+// session in the repo at repoPath — {repoParent}/{repoName}-{safeTitle} — with a
+// numeric suffix appended if that path is already occupied. It mirrors the
+// layout NewGitWorktree uses when creating a worktree, so RestoreWorktreeTo can
+// move an archived worktree back to where a fresh session's worktree would live
+// (#1028). The title is sanitized for filesystem safety and the result is
+// validated to sit strictly inside the worktree parent dir (the #461 guard).
+func SiblingWorktreePath(repoPath, title string) (string, error) {
+	repoRoot, err := findGitRepoRoot(repoPath)
+	if err != nil {
+		return "", err
+	}
+	worktreeDir := filepath.Dir(repoRoot)
+	repoName := filepath.Base(repoRoot)
+
+	// Sanitize the title into a single safe path segment, matching the
+	// safeSessionName handling in NewGitWorktree.
+	safe := strings.ReplaceAll(title, "..", "")
+	safe = strings.ReplaceAll(safe, "/", "-")
+	safe = strings.TrimLeft(safe, "-.")
+	if safe == "" {
+		safe = "session"
+	}
+
+	base := filepath.Join(worktreeDir, repoName+"-"+safe)
+	absBase, _ := filepath.Abs(base)
+	absDir, _ := filepath.Abs(worktreeDir)
+	if !isPathStrictlyInside(absBase, absDir) {
+		return "", fmt.Errorf("invalid session title %q: would place worktree outside %s", title, worktreeDir)
+	}
+
+	p := base
+	for i := 2; ; i++ {
+		if _, statErr := os.Stat(p); os.IsNotExist(statErr) {
+			break
+		} else if statErr != nil {
+			return "", fmt.Errorf("cannot check worktree path %q: %w", p, statErr)
+		}
+		p = fmt.Sprintf("%s-%d", base, i)
+	}
+	return p, nil
+}
 
 // ErrRepoGone is returned by RestoreWorktreeTo when the origin repository this
 // worktree is registered against no longer exists (deleted, unmounted, or no

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -82,6 +82,32 @@ func TestMoveWorktree_FallbackRepairsRegistration(t *testing.T) {
 	assertLiveWorktreeAt(t, gw, dest)
 }
 
+// TestSiblingWorktreePath_DefaultCollisionAndSanitize: the restore-side path
+// computation returns {repoParent}/{repoName}-{safeTitle}, appends a numeric
+// suffix when that path is occupied, and sanitizes the title into a single safe
+// segment — mirroring NewGitWorktree's layout so restore lands the worktree
+// where a fresh session's would live (#1028).
+func TestSiblingWorktreePath_DefaultCollisionAndSanitize(t *testing.T) {
+	sandboxHome(t)
+	repoRoot := createGitRepo(t) // {tmp}/repo
+	parent := filepath.Dir(repoRoot)
+
+	p, err := SiblingWorktreePath(repoRoot, "feature-x")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(parent, "repo-feature-x"), p)
+
+	// Collision: occupy the default path, expect the "-2" suffix.
+	require.NoError(t, os.MkdirAll(p, 0755))
+	p2, err := SiblingWorktreePath(repoRoot, "feature-x")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(parent, "repo-feature-x-2"), p2)
+
+	// Sanitize: "/" -> "-", ".." stripped.
+	ps, err := SiblingWorktreePath(repoRoot, "a/b..c")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(parent, "repo-a-bc"), ps)
+}
+
 // TestMoveWorktree_RepairFailureStillCommitsLocation (#1028 Greptile P1): in the
 // cross-filesystem fallback, when the byte-move succeeds but `git worktree
 // repair` fails, the worktree object must already point at dest — where the

--- a/session/instance.go
+++ b/session/instance.go
@@ -1227,6 +1227,36 @@ func (i *Instance) SetArchived() {
 	i.Status = Archived
 }
 
+// RestoreArchivedWorktree moves this instance's archived worktree back to dest
+// and re-registers it against the origin repo (#1028). Surfaces git.ErrRepoGone
+// when the repo has been deleted so the caller can leave the archive intact.
+func (i *Instance) RestoreArchivedWorktree(dest string) error {
+	i.mu.RLock()
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+	if gw == nil {
+		return fmt.Errorf("cannot restore %q: instance has no worktree", i.Title)
+	}
+	return gw.RestoreWorktreeTo(dest)
+}
+
+// RestoreFromArchive re-spawns an archived instance's agent after its worktree
+// has been moved back into place (#1028), flipping it live. It marks the
+// instance started + Lost so the Recover re-spawn path is eligible (the same
+// re-spawn the #1108 Lost-restore loop drives), then Recover brings the agent
+// session up and sets Running. On a Recover failure the instance is left
+// started + Lost, so the daemon's Lost-restore loop keeps retrying — the
+// worktree is already back in place, so the session self-heals rather than
+// stranding as Archived with no tmux. Only the agent tab is restored (shell/
+// process tabs were dropped at archive time, per #1028).
+func (i *Instance) RestoreFromArchive() error {
+	i.mu.Lock()
+	i.started = true
+	i.Status = Lost
+	i.mu.Unlock()
+	return i.backend.Recover(i)
+}
+
 // CloseAttachOnly releases the resources this instance opened to view or drive
 // its session (a tmux attach PTY, a remote preview process) without destroying
 // the session, worktree, or remote record. Use it — never Kill — to discard a


### PR DESCRIPTION
**Part 4 of 6** for #1028. Approved design: https://github.com/sachiniyer/agent-factory/issues/1028#issuecomment-4881997066

> ⚠️ **Stacked on #1176 (PR 3).** Base is the PR 3 branch so the diff shows only PR 4's changes; it retargets to `master` when #1176 merges. Merge #1176 first.

The daemon-side restore operation, the inverse of `ArchiveSession`: move an archived session's worktree back next to the repo, re-register it, re-spawn **only the agent** (shell/process tabs were dropped at archive time, per Sachin's #1028 requirement), and flip it `Running`. **Client wrapper + CLI land in PR 5.**

### Manager.RestoreArchived
- Rejects non-archived sessions.
- **Concurrency** mirrors `ArchiveSession` (`killsInFlight` + per-session op-lock); re-verifies under the lock after `findSession` released `m.mu`.
- **Destination** via `git.SiblingWorktreePath` — the standard `{repoParent}/{repoName}-{title}` location a fresh session would use, with a numeric suffix if occupied (title collision at restore time).
- **Repo-gone:** checked up front and surfaced as an actionable error that leaves the archive intact (`git.ErrRepoGone` also caught as a backstop).
- **Re-spawn failure:** `RestoreFromArchive` leaves the instance `started` + `Lost` *after* the worktree is back, so the #1108 Lost-restore loop heals it against the now-restored worktree rather than stranding it `Archived` with no tmux.

### Primitives
`git.SiblingWorktreePath` (standard sibling path + collision suffix + title sanitize) · `Instance.RestoreArchivedWorktree` (→ `gw.RestoreWorktreeTo`) · `Instance.RestoreFromArchive` (`started=true` + `Lost`, then `Recover` re-spawns the agent → `Running`).

### Tests (real temp worktrees)
restore round-trip (worktree back at sibling location, still git-registered, dirty tree preserved, agent re-spawned once, `Running` + started + persisted) · reject-non-archived · repo-gone leaves archive intact + stays `Archived` · collision suffixes the path · `SiblingWorktreePath` default/collision/sanitize. Full daemon+session suites green under `make test-container`; lint + deadcode clean.

**Do not merge on my authority.**

— Captain Claude