### PR TITLE
feat(api): shared JSON envelope + output helpers + CLI reference (#1029) [PR 1/6]

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -17,6 +17,11 @@ import (
 // Shared flags
 var (
 	repoFlag string
+	// envelopeOutput is set by the opt-in --json flag on the sessions/tasks
+	// command groups. It defaults OFF so every existing invocation is
+	// byte-identical to today (bare payload / {"error":"<msg>"}); when ON,
+	// jsonOut/jsonError wrap output in the shared {data,error} Envelope (#1029).
+	envelopeOutput bool
 )
 
 // repoFromFlag resolves the --repo flag to a RepoContext. Its errors name the
@@ -310,9 +315,14 @@ func allScopedInstances() ([]scopedInstance, []string, error) {
 	return out, corrupted, nil
 }
 
-// jsonOut marshals v to JSON and writes to stdout.
+// jsonOut marshals v to JSON and writes to stdout. By default it prints the
+// bare payload (byte-identical to before #1029). With the opt-in --json flag it
+// wraps the payload in the shared success Envelope via writeEnvelope.
 func jsonOut(v any) error {
-	data, err := json.MarshalIndent(v, "", "  ")
+	if envelopeOutput {
+		return writeEnvelope(os.Stdout, successEnvelope(v))
+	}
+	data, err := marshalIndented(v)
 	if err != nil {
 		return err
 	}
@@ -320,8 +330,15 @@ func jsonOut(v any) error {
 	return nil
 }
 
-// jsonError writes a JSON error to stderr and returns the error.
+// jsonError writes a JSON error to stderr and returns the error. By default it
+// prints the bare {"error":"<msg>"} form (byte-identical to before #1029). With
+// the opt-in --json flag it emits the shared failure Envelope instead. The
+// original error is always returned so exit codes are unchanged.
 func jsonError(err error) error {
+	if envelopeOutput {
+		_ = writeEnvelope(os.Stderr, errorEnvelope(err.Error()))
+		return err
+	}
 	msg, _ := json.Marshal(map[string]string{"error": err.Error()})
 	fmt.Fprintln(os.Stderr, string(msg))
 	return err
@@ -331,6 +348,14 @@ func init() {
 	// --repo flag on each top-level subcommand
 	SessionsCmd.PersistentFlags().StringVar(&repoFlag, "repo", "", "Path to git repository")
 	TasksCmd.PersistentFlags().StringVar(&repoFlag, "repo", "", "Path to git repository")
+
+	// Opt-in envelope output. Defaults OFF so existing scripts keep parsing the
+	// bare payload; --json wraps stdout/stderr in the {data,error} Envelope that
+	// the CLI and the later HTTP server share (#1029). Bound to both groups'
+	// PersistentFlags (like --repo) so it works on every subcommand.
+	const jsonFlagUsage = "Wrap output in the {data,error} JSON envelope (default: bare payload)"
+	SessionsCmd.PersistentFlags().BoolVar(&envelopeOutput, "json", false, jsonFlagUsage)
+	TasksCmd.PersistentFlags().BoolVar(&envelopeOutput, "json", false, jsonFlagUsage)
 
 	// Sessions
 	sessionsCreateCmd.Flags().StringVar(&createNameFlag, "name", "", "Session name (required)")

--- a/api/output.go
+++ b/api/output.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Envelope is the additive JSON wrapper shared by the CLI and the (later,
+// #1029 PR 4+) daemon-hosted HTTP server. A success carries the payload in Data
+// with Error nil; a failure carries a nil Data and a populated Error. Both
+// members always serialize (no omitempty) so consumers can branch on
+// `error === null` without a presence check:
+//
+//	success: {"data": <payload>, "error": null}
+//	failure: {"data": null, "error": {"message": "<msg>"}}
+//
+// It is NEW infrastructure: today's commands still emit the bare payload by
+// default, and the envelope is only produced on the explicit opt-in path
+// (the --json flag), so no existing command's stdout/stderr bytes change.
+type Envelope struct {
+	Data  any            `json:"data"`
+	Error *EnvelopeError `json:"error"`
+}
+
+// EnvelopeError is the error member of an Envelope. Message is a human-readable
+// description; the struct leaves room to grow additional fields (e.g. a machine
+// code) later without breaking the additive contract.
+type EnvelopeError struct {
+	Message string `json:"message"`
+}
+
+// successEnvelope wraps a payload as a successful Envelope (Error nil).
+func successEnvelope(data any) Envelope {
+	return Envelope{Data: data, Error: nil}
+}
+
+// errorEnvelope wraps a message as a failed Envelope (Data nil).
+func errorEnvelope(msg string) Envelope {
+	return Envelope{Data: nil, Error: &EnvelopeError{Message: msg}}
+}
+
+// marshalIndented is the single JSON-encoding primitive the output helpers
+// share so bare and enveloped output format identically (two-space indent).
+func marshalIndented(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}
+
+// writeEnvelope encodes env and writes it, newline-terminated, to w. It is the
+// shared write path the opt-in --json output uses today and the HTTP server
+// will reuse, keeping the CLI and HTTP responses byte-for-byte consistent.
+func writeEnvelope(w io.Writer, env Envelope) error {
+	data, err := marshalIndented(env)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}

--- a/api/output_test.go
+++ b/api/output_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// captureStderr mirrors captureStdout (tasks_test.go) for the error path.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(data)
+}
+
+// withEnvelope flips the opt-in --json flag on for the duration of fn and
+// restores it, so a test can exercise the enveloped output path in isolation.
+func withEnvelope(t *testing.T, fn func()) {
+	t.Helper()
+	orig := envelopeOutput
+	envelopeOutput = true
+	t.Cleanup(func() { envelopeOutput = orig })
+	fn()
+}
+
+func TestSuccessEnvelope_ShapeAndNullError(t *testing.T) {
+	env := successEnvelope(map[string]string{"hello": "world"})
+	require.Nil(t, env.Error)
+
+	data, err := json.Marshal(env)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"data":{"hello":"world"},"error":null}`, string(data))
+}
+
+func TestErrorEnvelope_ShapeAndNullData(t *testing.T) {
+	env := errorEnvelope("boom")
+	require.Nil(t, env.Data)
+	require.NotNil(t, env.Error)
+	require.Equal(t, "boom", env.Error.Message)
+
+	data, err := json.Marshal(env)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"data":null,"error":{"message":"boom"}}`, string(data))
+}
+
+// TestJSONOut_DefaultIsBarePayload locks in that the default (no --json) output
+// is the bare, byte-for-byte payload — the additive contract that keeps existing
+// scripts parsing `af sessions ...` output working after #1029.
+func TestJSONOut_DefaultIsBarePayload(t *testing.T) {
+	require.False(t, envelopeOutput, "envelope must default OFF")
+
+	out := captureStdout(t, func() {
+		require.NoError(t, jsonOut(map[string]bool{"ok": true}))
+	})
+	require.Equal(t, "{\n  \"ok\": true\n}\n", out)
+}
+
+// TestJSONOut_EnvelopeWrapsPayload verifies the opt-in path wraps the same
+// payload in the success envelope.
+func TestJSONOut_EnvelopeWrapsPayload(t *testing.T) {
+	var out string
+	withEnvelope(t, func() {
+		out = captureStdout(t, func() {
+			require.NoError(t, jsonOut(map[string]bool{"ok": true}))
+		})
+	})
+	require.JSONEq(t, `{"data":{"ok":true},"error":null}`, out)
+}
+
+// TestJSONError_DefaultIsBareError locks in the historical stderr shape
+// (compact {"error":"<msg>"}) and that the original error is returned unchanged.
+func TestJSONError_DefaultIsBareError(t *testing.T) {
+	require.False(t, envelopeOutput, "envelope must default OFF")
+
+	sentinel := errors.New("nope")
+	var ret error
+	out := captureStderr(t, func() {
+		ret = jsonError(sentinel)
+	})
+	require.Equal(t, sentinel, ret)
+	require.Equal(t, "{\"error\":\"nope\"}\n", out)
+}
+
+// TestJSONError_EnvelopeWrapsError verifies the opt-in path emits the failure
+// envelope to stderr while still returning the original error (exit code stays).
+func TestJSONError_EnvelopeWrapsError(t *testing.T) {
+	sentinel := errors.New("nope")
+	var ret error
+	var out string
+	withEnvelope(t, func() {
+		out = captureStderr(t, func() {
+			ret = jsonError(sentinel)
+		})
+	})
+	require.Equal(t, sentinel, ret)
+	require.JSONEq(t, `{"data":null,"error":{"message":"nope"}}`, out)
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,339 @@
+# `af` CLI reference
+
+A complete reference of the current `af` command-line surface: every command and
+subcommand, its flags, and the JSON (or text) shape it emits today.
+
+This documents **existing behavior**. For narrative usage see
+[cli.md](cli.md); for task semantics see [tasks.md](tasks.md); for configuration
+see [configuration.md](configuration.md). Run `af <command> --help` for the
+authoritative flag list of any command.
+
+## Output conventions
+
+The `af sessions` and `af tasks` command groups emit **JSON to stdout** and
+**errors to stderr**, so they compose with `jq` and shell scripts. All other
+commands (`daemon`, `doctor`, `version`, `debug`, `keys`, `upgrade`, `reset`)
+emit human-readable text.
+
+By default, the JSON commands print the **bare payload** documented below. Every
+`af sessions` / `af tasks` subcommand also accepts an opt-in **`--json`** flag
+that instead wraps output in a shared envelope — see
+[JSON envelope (`--json`)](#json-envelope---json). The flag defaults off, so
+existing scripts see byte-identical output.
+
+**Errors.** On failure a JSON command writes `{"error":"<message>"}` to stderr
+(compact, single line) and exits non-zero; cobra additionally prints an
+`Error: …` line and usage. With `--json`, the stderr body is the envelope form
+`{"data":null,"error":{"message":"<message>"}}` instead. The process exit code
+is identical in both modes.
+
+---
+
+## `af` — launch the TUI
+
+```bash
+cd your-project    # must be a git repo
+af                 # launch the terminal UI
+```
+
+| Flag | Description |
+|------|-------------|
+| `-p`, `--program` | Agent to run in new sessions: one of `claude`, `codex`, `aider`, `gemini`. For custom paths/flags use `program_overrides` in the config — see [configuration.md](configuration.md#choosing-the-agent). |
+| `-y`, `--autoyes` | Experimental: automatically accept agent prompts in all sessions. |
+
+(`--daemon` exists but is hidden — it is the internal entry point the daemon
+supervisor uses, not a user-facing command.)
+
+---
+
+## `af sessions`
+
+Manage sessions. All subcommands accept **`--repo <path>`** to target a
+repository other than the current directory, and **`--json`** for envelope
+output.
+
+### `af sessions list`
+
+List sessions in scope (the current/`--repo` repo, or every repo when run
+outside one). Emits a JSON array of session objects (empty `[]` when none).
+
+```json
+[
+  {
+    "title": "fix-login",
+    "path": "/home/you/.agent-factory/worktrees/…",
+    "branch": "af/fix-login",
+    "status": 1,
+    "height": 0,
+    "width": 0,
+    "created_at": "2026-07-04T12:00:00Z",
+    "updated_at": "2026-07-04T12:05:00Z",
+    "auto_yes": false,
+    "program": "claude",
+    "tmux_name": "af_fix-login",
+    "tabs": [ { "name": "agent", "kind": 0, "tmux_name": "af_fix-login" } ],
+    "worktree": {
+      "repo_path": "/home/you/project",
+      "worktree_path": "/home/you/.agent-factory/worktrees/…",
+      "session_name": "fix-login",
+      "branch_name": "af/fix-login",
+      "base_commit_sha": "…"
+    }
+  }
+]
+```
+
+`status` is a numeric enum (`Running`, `Ready`, `Loading`, `Paused`, `Lost`,
+`Dead`, …). Fields tagged `omitempty` in storage (`user_killed`, `tmux_name`,
+`tabs`, `pr_info`, `backend_type`, `remote_meta`, worktree
+`external_worktree` / `branch_created_by_us`) appear only when set. A corrupted
+`instances.json` in any repo is reported as an error rather than silently
+dropped (#730).
+
+### `af sessions get <title>`
+
+Fetch a single session by title. Emits one session object (same shape as a
+`list` element). Errors if the title matches no session.
+
+### `af sessions create`
+
+Create a new session running an agent in its own git worktree. Emits the created
+session object.
+
+| Flag | Description |
+|------|-------------|
+| `--name` | **Required.** Session title. `root` (any casing) is reserved for the daemon-managed root agent. |
+| `--prompt` | Initial prompt to send to the agent. |
+| `--program` | Agent enum (`claude`/`codex`/`aider`/`gemini`); defaults to the configured `default_program`. |
+| `--here` | Attach to the repo's **existing working tree at its current branch** — no new worktree/branch; killing the session preserves both. Requires a git repository. |
+| `--in-place` | Alias for `--here`. |
+
+### `af sessions send-prompt <title> <prompt>`
+
+Send a prompt to an existing session. Emits `{"ok": true}` on success.
+
+| Flag | Description |
+|------|-------------|
+| `--create` | Auto-create the session if it doesn't exist (routes through the daemon's serialized create-or-send path). |
+| `--program` | Agent to run when `--create` makes a new session. |
+| `--all` | Broadcast one prompt to every live session in scope. Takes a single positional (the prompt). |
+| `--all-repos` | With `--all`, broadcast across every repo instead of only the current/`--repo` one (mutually exclusive with `--repo`). |
+| `--include-root` | With `--all`, also deliver to the reserved root session (excluded by default). |
+
+Broadcast (`--all`) emits a summary object and exits 0 even when some sessions
+fail, so scripts can inspect per-session results:
+
+```json
+{
+  "prompt": "run the tests",
+  "scope": "repo:<id>",
+  "delivered": 2,
+  "failed": 0,
+  "skipped": 1,
+  "results": [
+    { "title": "fix-login", "repo_id": "<id>", "status": "delivered" },
+    { "title": "root", "repo_id": "<id>", "status": "skipped",
+      "reason": "reserved root session excluded; pass --include-root to broadcast to it" }
+  ]
+}
+```
+
+Each result's `status` is `delivered`, `failed`, or `skipped`; `error` carries a
+failure reason and `reason` explains an intentional skip.
+
+### `af sessions tab-create <title>`
+
+Spawn a process tab that runs a command in the session's git worktree. Emits the
+resolved tab name: `{"name": "<tab>"}`.
+
+| Flag | Description |
+|------|-------------|
+| `--command` | **Required.** Command to run in the session's worktree as a new tab. |
+| `--name` | Tab display name; defaults to the command basename, auto-suffixed `-2`, `-3`, … on collision. |
+
+Refused once a session already holds 9 tabs. Not available for remote sessions.
+
+### `af sessions tab-delete <title>`
+
+Delete a single named tab (the counterpart of `tab-create`). Emits the deleted
+tab's name: `{"name": "<tab>"}`.
+
+| Flag | Description |
+|------|-------------|
+| `--name` | **Required.** Name of the tab to delete. |
+
+The removal is persistent (the daemon won't respawn it). The agent tab can't be
+deleted — use `kill` to tear down the whole session. Not available for remote
+sessions.
+
+### `af sessions preview <title>`
+
+Snapshot the session's terminal pane. Emits `{"title": "<title>", "content":
+"<pane text>"}`.
+
+### `af sessions attach <title>`
+
+Attach interactively to the session's tmux terminal (foreground). Detach with
+the configured detach key (default `Ctrl-b d`). **Interactive — emits no JSON.**
+
+### `af sessions kill <title>`
+
+Kill the session and clean up its worktree. Emits `{"ok": true}`.
+
+### `af sessions whoami`
+
+Report the session the current shell is inside, by matching the tmux session
+name against stored instances. Emits the matching session object (same shape as
+`get`); errors if the shell is not inside a known Agent Factory tmux session.
+
+---
+
+## `af tasks`
+
+Manage tasks that deliver a prompt to an agent automatically — on a cron
+schedule or whenever a watch script emits a stdout line. Full semantics live in
+[tasks.md](tasks.md). All subcommands accept `--repo <path>` and `--json`.
+
+### `af tasks list`
+
+List tasks (filtered to `--repo` when given). Emits a JSON array of task objects
+(empty `[]` when none):
+
+```json
+[
+  {
+    "id": "a1b2c3",
+    "name": "morning-standup",
+    "prompt": "summarize overnight CI",
+    "cron_expr": "0 9 * * *",
+    "target_session": "",
+    "project_path": "/home/you/project",
+    "program": "claude",
+    "enabled": true,
+    "created_at": "2026-07-04T09:00:00Z"
+  }
+]
+```
+
+Exactly one of `cron_expr` / `watch_cmd` is set. Fields tagged `omitempty`
+(`name`, `cron_expr`, `watch_cmd`, `target_session`, `last_run_at`,
+`last_run_status`) appear only when set.
+
+### `af tasks get <id>`
+
+Fetch one task by ID. Emits a single task object (same shape as a `list`
+element).
+
+### `af tasks add`
+
+Create a task. Emits the new task's ID: `{"id": "<id>"}`.
+
+| Flag | Description |
+|------|-------------|
+| `--name` | **Required.** Task name. |
+| `--prompt` | Prompt to send. Required for `--cron` tasks; `--watch-cmd` tasks default to the emitted line (with `{{line}}` substituted when present). |
+| `--cron` | Cron expression. **Exactly one** of `--cron` / `--watch-cmd`. |
+| `--watch-cmd` | Long-running watch command; each stdout line triggers the task. |
+| `--target-session` | Deliver into this session (auto-created if missing); empty creates a new session per run. |
+| `--program` | Agent enum; defaults to the configured `default_program`. |
+
+### `af tasks update <id>`
+
+Update a task's properties (partial update — an omitted/empty flag means "leave
+unchanged"). Emits the updated task object.
+
+| Flag | Description |
+|------|-------------|
+| `--name` | New task name. |
+| `--prompt` | New prompt (must be non-empty when given). |
+| `--cron` | New cron expression (clears `watch-cmd`). |
+| `--watch-cmd` | New watch command (clears `cron`). |
+| `--target-session` | New target session; pass an empty value to revert to a new session per run. |
+| `--enabled` | `true` or `false`. |
+| `--program` | New agent enum. |
+
+Setting one trigger clears the other so the exactly-one rule holds.
+
+### `af tasks trigger <id>`
+
+Run a cron task immediately (cron tasks only). Emits `{"ok": true}`.
+
+### `af tasks remove <id>`
+
+Remove a task. Emits `{"ok": true}`.
+
+---
+
+## `af daemon`
+
+Manage the background daemon that hosts task cron schedules, watch-task scripts,
+and autoyes mode. It starts on demand whenever `af` runs and an enabled task
+exists; installing an autostart unit keeps schedules firing after reboots. See
+[tasks.md](tasks.md#daemon-lifecycle). **Text output.**
+
+```bash
+af daemon install      # register autostart at login (systemd user unit / launchd agent)
+af daemon uninstall    # remove the autostart unit (the daemon still starts on demand)
+```
+
+---
+
+## Maintenance commands
+
+**Text output** unless noted.
+
+```bash
+af version             # print the version and the release URL
+af debug               # print the config path followed by the resolved config as JSON
+af keys                # print the effective TUI key bindings as a table (ACTION/KEYS/DESCRIPTION/SOURCE)
+af upgrade             # self-upgrade to the latest GitHub release (Linux/macOS)
+af doctor              # diagnose leaked processes/sessions/temp homes and daemon health
+af doctor --fix        # also apply the safe remediations
+af reset               # nuclear cleanup — see below
+```
+
+- `af debug` prints `Config: <path>` then the resolved config marshaled as
+  indented JSON (a diagnostic dump, not part of the scriptable `--json`
+  surface).
+- `af doctor` is read-only by default: it reports orphaned processes from dead
+  sessions, CPU-pegging processes in live sessions, `af_` tmux sessions with no
+  backing record, abandoned temp homes, and daemon problems. With `--fix` it
+  kills verified orphans and removes stale temp homes; anything it cannot verify
+  is reported, never touched. Exits 1 when unresolved issues remain.
+- `af reset` stops the daemon (reporting honestly if it couldn't), kills **all**
+  Agent Factory tmux sessions, removes **every linked git worktree and its
+  branch** from each repo with stored sessions, and deletes all stored session
+  records. For recovering from a corrupted state — not day-to-day cleanup
+  (`af sessions kill <title>` removes a single session cleanly).
+
+---
+
+## JSON envelope (`--json`)
+
+`af sessions` and `af tasks` accept an opt-in **`--json`** flag that wraps output
+in a stable envelope shared by the CLI and (in a later change) a daemon-hosted
+HTTP server. It is **additive**: the flag defaults off, and without it every
+command prints the bare payloads documented above, byte-for-byte as before.
+
+With `--json`, a success wraps the payload under `data` with `error: null`:
+
+```jsonc
+// af sessions send-prompt fix-login "hi" --json
+{
+  "data": { "ok": true },
+  "error": null
+}
+```
+
+and a failure sets `data: null` and populates `error.message` (written to
+stderr, exit code unchanged):
+
+```jsonc
+{
+  "data": null,
+  "error": { "message": "instance \"nope\" not found …" }
+}
+```
+
+Both members always serialize, so a consumer can branch on `error === null`
+without a presence check.


### PR DESCRIPTION
## PR 1/6 of #1029 (Easy HTTP + CLI interfaces) — the pure foundation

Refs #1029. **This is PR 1 of 6 — it does not close the issue.** The daemon is
the core; TUI/CLI/HTTP are thin clients. Later PRs add a daemon-hosted HTTP
server that 1:1 mirrors the daemon RPCs and reuses the JSON envelope this PR
introduces. Per Sachin's locked decisions: **additive envelope only** — today's
bare payloads stay the default, the envelope is opt-in, no CLI renames, no
breaking existing `af …` JSON output.

### What landed

**1. Shared output layer (`api/output.go`)**
- `Envelope { data, error }` + `EnvelopeError { message }`. Both members always
  serialize (no `omitempty`) so consumers branch on `error === null`:
  - success: `{"data": <payload>, "error": null}`
  - failure: `{"data": null, "error": {"message": "<msg>"}}`
- Helpers `successEnvelope` / `errorEnvelope` / `writeEnvelope` /
  `marshalIndented` — the write path the CLI uses today and the HTTP server will
  reuse, keeping CLI and HTTP responses byte-consistent.

**2. `jsonOut`/`jsonError` refactored onto the helpers (`api/api.go`)**
- **Default output is byte-identical to today**: bare indented payload on
  stdout; compact `{"error":"<msg>"}` on stderr; same exit codes.
- New opt-in **`--json`** persistent flag on the `sessions`/`tasks` groups (bound
  like `--repo`) wraps output in the envelope. **Defaults OFF** — every existing
  invocation is unchanged, so no script that parses `af sessions …` breaks.

**3. `docs/cli-reference.md`** — complete, accurate reference of the *current*
`af` surface: every command/subcommand (`sessions {list,get,create,send-prompt,
tab-create,tab-delete,preview,attach,kill,whoami}`, `tasks {list,get,add,update,
remove,trigger}`, `daemon {install,uninstall}`, `doctor`, `version`, `keys`,
`debug`, `upgrade`, `reset`), their flags, and the JSON/text shape each emits.
Documentation of existing behavior only.

### Scope decisions
- **`--json` flag included** (not deferred): it wired in cleanly with **zero
  call-site churn** — all 96 output sites already route through
  `jsonOut`/`jsonError`, so gating those two functions was enough.
- **Adjacent-call-site audit:** `api/` has no other ad-hoc JSON-output sites —
  `broadcastResult`, tab-create/delete, preview, etc. all already go through
  `jsonOut`. `main.go`'s `af debug` config dump is a diagnostic text dump in a
  different package (`Config: <path>\n<json>`), intentionally left off the
  scriptable surface.

### Verification
- `go build ./...`, `gofmt -l .`, `golangci-lint run --timeout=3m --fast`,
  `deadcode -test ./...` — all clean (new helpers are referenced by the
  refactored `jsonOut`/`jsonError`, so nothing is dead).
- **`make test-container` — full suite green.**
- Added `api/output_test.go`: envelope shapes + default-vs-`--json` output for
  `jsonOut`/`jsonError`, locking in the byte-identical default contract.
- Ran the built binary end-to-end: `sessions list` → `[]`; `--json` →
  `{"data":[],"error":null}`; error path bare vs enveloped both verified;
  `--json` appears in `--help`.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)