### PR TITLE
feat(cli): route sessions list/get/whoami through the daemon Snapshot RPC (#1029) [PR 2/6]

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -158,6 +158,95 @@ func loadAllInstancesAggregate() ([]session.InstanceData, []string, error) {
 	return allData, corrupted, nil
 }
 
+// diskListSessions is the disk-read fallback for `sessions list` when no daemon
+// is reachable (#1029 PR 2). It reproduces the pre-daemon read behavior exactly
+// — repo-scoped or all-repos, keeping the loud corrupt-file error on the
+// all-repos path (#730) — and additionally sorts the result by the daemon's
+// (repoID, title) key so the on-disk order matches the daemon Snapshot path,
+// giving scripts a stable order from either source.
+func diskListSessions(repoID string) ([]session.InstanceData, error) {
+	if repoID != "" {
+		raw, err := config.LoadRepoInstances(repoID)
+		if err != nil {
+			return nil, err
+		}
+		var data []session.InstanceData
+		if err := json.Unmarshal(raw, &data); err != nil {
+			return nil, fmt.Errorf("failed to parse instances: %w", err)
+		}
+		// Single repo: the (repoID, title) key reduces to title order.
+		sort.Slice(data, func(i, j int) bool { return data[i].Title < data[j].Title })
+		return data, nil
+	}
+
+	// Don't silently substitute an empty/partial list when a repo file is
+	// corrupted (#730): warn naming each bad repo and fail loudly so users can
+	// tell "no sessions" apart from "sessions hidden behind a corrupt file."
+	allInstances, err := config.LoadAllRepoInstances()
+	if err != nil {
+		return nil, err
+	}
+	type keyedInstance struct {
+		key  string
+		data session.InstanceData
+	}
+	var rows []keyedInstance
+	var corrupted []string
+	for rid, raw := range allInstances {
+		var instances []session.InstanceData
+		if err := json.Unmarshal(raw, &instances); err != nil {
+			log.WarningLog.Printf("skipping repo %s: corrupted instances.json: %v", rid, err)
+			corrupted = append(corrupted, rid)
+			continue
+		}
+		for _, inst := range instances {
+			// Build the same composite key the daemon sorts by:
+			// repoID + NUL + title (daemonInstanceKey). NUL sorts before any
+			// printable byte, so this is exactly the daemon's (repoID, title)
+			// order.
+			rows = append(rows, keyedInstance{key: rid + "\x00" + inst.Title, data: inst})
+		}
+	}
+	if len(corrupted) > 0 {
+		return nil, corruptedReposError(corrupted)
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].key < rows[j].key })
+	data := make([]session.InstanceData, 0, len(rows))
+	for _, r := range rows {
+		data = append(data, r.data)
+	}
+	return data, nil
+}
+
+// diskWhoami is the disk-read fallback for `sessions whoami` when no daemon is
+// reachable (#1029 PR 2). It scans every repo for an instance whose TmuxName
+// matches the current tmux session, keeping the loud corrupt-file behavior
+// (#730) so a hidden match is reported instead of a misleading "not found".
+func diskWhoami(tmuxName string) (*session.InstanceData, error) {
+	allInstances, err := config.LoadAllRepoInstances()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load instances: %w", err)
+	}
+	var corrupted []string
+	for repoID, raw := range allInstances {
+		var instances []session.InstanceData
+		if err := json.Unmarshal(raw, &instances); err != nil {
+			log.WarningLog.Printf("skipping repo %s: corrupted instances.json: %v", repoID, err)
+			corrupted = append(corrupted, repoID)
+			continue
+		}
+		for i := range instances {
+			if instances[i].TmuxName == tmuxName {
+				return &instances[i], nil
+			}
+		}
+	}
+	if len(corrupted) > 0 {
+		return nil, fmt.Errorf("no Agent Factory session found for tmux session %q; %s", tmuxName, corruptedReposSuffix(corrupted))
+	}
+	return nil, fmt.Errorf("no Agent Factory session found for tmux session %q", tmuxName)
+}
+
 func repoHasInstanceTitle(repoID, title string) (bool, error) {
 	raw, err := config.LoadRepoInstances(repoID)
 	if err != nil {

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -33,7 +32,57 @@ var (
 	deliverPromptViaDaemon   = daemon.DeliverPrompt
 	createTabViaDaemon       = daemon.CreateTab
 	closeTabViaDaemon        = daemon.CloseTab
+	// snapshotViaDaemon is the non-spawning read path for list/get/whoami
+	// (#1029 PR 2). It reflects the daemon's authoritative in-memory state when
+	// a daemon is already running, and returns daemon.ErrDaemonUnavailable
+	// (never spawning one) when it is not, so callers fall back to disk. Held in
+	// a var so tests can inject a snapshot without a live daemon.
+	snapshotViaDaemon = daemon.SnapshotNoSpawn
 )
+
+// listSessions returns the session list for repoID (empty = all repos),
+// preferring the daemon's live snapshot and falling back to disk when no daemon
+// is reachable (#1029 PR 2). Both paths return the same shape sorted by
+// (repoID, title), so scripts see a consistent order regardless of source.
+func listSessions(repoID string) ([]session.InstanceData, error) {
+	if data, err := snapshotViaDaemon(daemon.SnapshotRequest{RepoID: repoID}); err == nil {
+		return data, nil
+	}
+	return diskListSessions(repoID)
+}
+
+// getSessionByTitle returns the single session matching title, preferring the
+// daemon's live snapshot and falling back to the disk scan when no daemon is
+// reachable (#1029 PR 2). When a live snapshot is available the daemon is
+// authoritative: a miss returns not-found without re-reading disk.
+func getSessionByTitle(title string) (*session.InstanceData, error) {
+	if data, err := snapshotViaDaemon(daemon.SnapshotRequest{}); err == nil {
+		for i := range data {
+			if data[i].Title == title {
+				return &data[i], nil
+			}
+		}
+		// Mirror findInstanceByTitle's clean-miss error so output is unchanged.
+		return nil, fmt.Errorf("instance %q %w", title, errTitleNotFound)
+	}
+	data, _, err := findInstanceByTitle(title)
+	return data, err
+}
+
+// whoamiSession returns the session whose TmuxName matches tmuxName, preferring
+// the daemon's live snapshot and falling back to the disk scan when no daemon
+// is reachable (#1029 PR 2).
+func whoamiSession(tmuxName string) (*session.InstanceData, error) {
+	if data, err := snapshotViaDaemon(daemon.SnapshotRequest{}); err == nil {
+		for i := range data {
+			if data[i].TmuxName == tmuxName {
+				return &data[i], nil
+			}
+		}
+		return nil, fmt.Errorf("no Agent Factory session found for tmux session %q", tmuxName)
+	}
+	return diskWhoami(tmuxName)
+}
 
 var sessionsListCmd = &cobra.Command{
 	Use:   "list",
@@ -47,28 +96,13 @@ var sessionsListCmd = &cobra.Command{
 			return jsonError(err)
 		}
 
-		var allData []session.InstanceData
-		if repoID != "" {
-			raw, err := config.LoadRepoInstances(repoID)
-			if err != nil {
-				return jsonError(err)
-			}
-			if err := json.Unmarshal(raw, &allData); err != nil {
-				return jsonError(fmt.Errorf("failed to parse instances: %w", err))
-			}
-		} else {
-			// Don't silently substitute an empty/partial list when a repo
-			// file is corrupted (#730): loadAllInstancesAggregate warns naming
-			// each bad repo, and we fail loudly so users can tell "no sessions"
-			// apart from "sessions hidden behind a corrupt file."
-			data, corrupted, err := loadAllInstancesAggregate()
-			if err != nil {
-				return jsonError(err)
-			}
-			if len(corrupted) > 0 {
-				return jsonError(corruptedReposError(corrupted))
-			}
-			allData = data
+		// Read from the daemon's authoritative in-memory state when a daemon is
+		// running, falling back to disk otherwise (#1029 PR 2). listSessions
+		// never spawns a daemon, so `sessions list` in a script or CI keeps
+		// working with none running.
+		allData, err := listSessions(repoID)
+		if err != nil {
+			return jsonError(err)
 		}
 
 		if allData == nil {
@@ -86,7 +120,7 @@ var sessionsGetCmd = &cobra.Command{
 		log.Initialize(false)
 		defer log.Close()
 
-		data, _, err := findInstanceByTitle(args[0])
+		data, err := getSessionByTitle(args[0])
 		if err != nil {
 			return jsonError(err)
 		}
@@ -724,33 +758,13 @@ var sessionsWhoamiCmd = &cobra.Command{
 			return jsonError(fmt.Errorf("could not determine tmux session name"))
 		}
 
-		// Scan all instances for a matching tmux_name
-		allInstances, err := config.LoadAllRepoInstances()
+		// Match the tmux session against the daemon's authoritative in-memory
+		// state when a daemon is running, falling back to a disk scan otherwise
+		// (#1029 PR 2). Never spawns a daemon.
+		data, err := whoamiSession(tmuxName)
 		if err != nil {
-			return jsonError(fmt.Errorf("failed to load instances: %w", err))
+			return jsonError(err)
 		}
-
-		var corrupted []string
-		for repoID, raw := range allInstances {
-			var instances []session.InstanceData
-			if err := json.Unmarshal(raw, &instances); err != nil {
-				// Warn and record rather than silently skip (#730): the
-				// current session's record may live in the corrupted repo,
-				// so a bare "not found" would mask the real cause.
-				log.WarningLog.Printf("skipping repo %s: corrupted instances.json: %v", repoID, err)
-				corrupted = append(corrupted, repoID)
-				continue
-			}
-			for i := range instances {
-				if instances[i].TmuxName == tmuxName {
-					return jsonOut(instances[i])
-				}
-			}
-		}
-
-		if len(corrupted) > 0 {
-			return jsonError(fmt.Errorf("no Agent Factory session found for tmux session %q; %s", tmuxName, corruptedReposSuffix(corrupted)))
-		}
-		return jsonError(fmt.Errorf("no Agent Factory session found for tmux session %q", tmuxName))
+		return jsonOut(*data)
 	},
 }

--- a/api/sessions_snapshot_test.go
+++ b/api/sessions_snapshot_test.go
@@ -1,0 +1,277 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// stubSnapshot swaps snapshotViaDaemon for the duration of a test so the
+// list/get/whoami read paths can be exercised against a canned daemon snapshot
+// (or a forced ErrDaemonUnavailable) without a live daemon (#1029 PR 2). The
+// returned pointer captures every request the code under test issued so a test
+// can assert --repo scoping is threaded through.
+func stubSnapshot(t *testing.T, fn func(daemon.SnapshotRequest) ([]session.InstanceData, error)) *[]daemon.SnapshotRequest {
+	t.Helper()
+	var reqs []daemon.SnapshotRequest
+	prev := snapshotViaDaemon
+	snapshotViaDaemon = func(req daemon.SnapshotRequest) ([]session.InstanceData, error) {
+		reqs = append(reqs, req)
+		return fn(req)
+	}
+	t.Cleanup(func() { snapshotViaDaemon = prev })
+	return &reqs
+}
+
+// daemonUnavailable is the stub for "no daemon reachable" — every call falls
+// back to disk.
+func daemonUnavailable(daemon.SnapshotRequest) ([]session.InstanceData, error) {
+	return nil, daemon.ErrDaemonUnavailable
+}
+
+func titlesOf(data []session.InstanceData) []string {
+	out := make([]string, 0, len(data))
+	for _, d := range data {
+		out = append(out, d.Title)
+	}
+	return out
+}
+
+// TestListSessions_DaemonUp verifies the list read path returns the daemon's
+// live snapshot verbatim (scoping the request by repoID) and never consults
+// disk when a daemon is reachable.
+func TestListSessions_DaemonUp(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	// Disk holds DIFFERENT data so a result matching the snapshot proves the
+	// live path won and disk was not read.
+	diskJSON, err := json.Marshal([]session.InstanceData{{Title: "stale-disk"}})
+	if err != nil {
+		t.Fatalf("marshal disk: %v", err)
+	}
+	if err := config.SaveRepoInstances("repo-x", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	live := []session.InstanceData{{Title: "live-a"}, {Title: "live-b"}}
+	reqs := stubSnapshot(t, func(daemon.SnapshotRequest) ([]session.InstanceData, error) {
+		return live, nil
+	})
+
+	got, err := listSessions("repo-x")
+	if err != nil {
+		t.Fatalf("listSessions: %v", err)
+	}
+	if want := []string{"live-a", "live-b"}; !equalStrs(titlesOf(got), want) {
+		t.Fatalf("listSessions returned %v, want live snapshot %v", titlesOf(got), want)
+	}
+	if len(*reqs) != 1 || (*reqs)[0].RepoID != "repo-x" {
+		t.Fatalf("expected one snapshot request scoped to repo-x, got %+v", *reqs)
+	}
+}
+
+// TestListSessions_DiskFallbackNoDaemon verifies that with no daemon reachable
+// the list path falls back to disk, aggregates across repos, and sorts the
+// result by the daemon's (repoID, title) key so both sources agree.
+func TestListSessions_DiskFallbackNoDaemon(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	stubSnapshot(t, daemonUnavailable)
+
+	// Two repos, titles deliberately out of order within and across repos.
+	aJSON, err := json.Marshal([]session.InstanceData{{Title: "a2"}, {Title: "a1"}})
+	if err != nil {
+		t.Fatalf("marshal a: %v", err)
+	}
+	bJSON, err := json.Marshal([]session.InstanceData{{Title: "b1"}})
+	if err != nil {
+		t.Fatalf("marshal b: %v", err)
+	}
+	// Repo IDs chosen so "repo-a" sorts before "repo-b".
+	if err := config.SaveRepoInstances("repo-b", bJSON); err != nil {
+		t.Fatalf("save b: %v", err)
+	}
+	if err := config.SaveRepoInstances("repo-a", aJSON); err != nil {
+		t.Fatalf("save a: %v", err)
+	}
+
+	got, err := listSessions("")
+	if err != nil {
+		t.Fatalf("listSessions: %v", err)
+	}
+	// (repoID, title) order: repo-a/a1, repo-a/a2, repo-b/b1.
+	if want := []string{"a1", "a2", "b1"}; !equalStrs(titlesOf(got), want) {
+		t.Fatalf("disk fallback returned %v, want (repoID,title)-sorted %v", titlesOf(got), want)
+	}
+}
+
+// TestListSessions_DiskFallbackRepoScoped verifies the repo-scoped disk fallback
+// reads only the requested repo and sorts by title.
+func TestListSessions_DiskFallbackRepoScoped(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	stubSnapshot(t, daemonUnavailable)
+
+	aJSON, err := json.Marshal([]session.InstanceData{{Title: "z"}, {Title: "m"}, {Title: "a"}})
+	if err != nil {
+		t.Fatalf("marshal a: %v", err)
+	}
+	if err := config.SaveRepoInstances("repo-a", aJSON); err != nil {
+		t.Fatalf("save a: %v", err)
+	}
+	if err := config.SaveRepoInstances("repo-b", json.RawMessage(`[{"title":"other"}]`)); err != nil {
+		t.Fatalf("save b: %v", err)
+	}
+
+	got, err := listSessions("repo-a")
+	if err != nil {
+		t.Fatalf("listSessions: %v", err)
+	}
+	if want := []string{"a", "m", "z"}; !equalStrs(titlesOf(got), want) {
+		t.Fatalf("scoped disk fallback returned %v, want title-sorted %v", titlesOf(got), want)
+	}
+}
+
+// TestListSessions_DiskFallbackCorruptLoud verifies the loud corrupt-file
+// behavior (#730) is preserved on the disk fallback path.
+func TestListSessions_DiskFallbackCorruptLoud(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	_ = captureWarnings(t)
+	stubSnapshot(t, daemonUnavailable)
+
+	if err := config.SaveRepoInstances("bad-repo", json.RawMessage("{not json")); err != nil {
+		t.Fatalf("save corrupt: %v", err)
+	}
+
+	_, err := listSessions("")
+	if err == nil {
+		t.Fatalf("expected loud corrupt-file error on disk fallback, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad-repo") {
+		t.Fatalf("expected error to name the corrupted repo, got: %v", err)
+	}
+}
+
+// TestGetSessionByTitle_DaemonUp verifies get resolves from the live snapshot,
+// and that a miss against a reachable daemon returns not-found without reading
+// disk (the daemon is authoritative).
+func TestGetSessionByTitle_DaemonUp(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	// Disk holds the title so a "not found" proves disk was not consulted.
+	diskJSON, err := json.Marshal([]session.InstanceData{{Title: "ghost"}})
+	if err != nil {
+		t.Fatalf("marshal disk: %v", err)
+	}
+	if err := config.SaveRepoInstances("repo-x", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	live := []session.InstanceData{{Title: "one"}, {Title: "two"}}
+	stubSnapshot(t, func(daemon.SnapshotRequest) ([]session.InstanceData, error) { return live, nil })
+
+	got, err := getSessionByTitle("two")
+	if err != nil {
+		t.Fatalf("getSessionByTitle(two): %v", err)
+	}
+	if got.Title != "two" {
+		t.Fatalf("got %q, want two", got.Title)
+	}
+
+	_, err = getSessionByTitle("ghost")
+	if err == nil {
+		t.Fatalf("expected not-found for a title absent from the live snapshot")
+	}
+	if !errors.Is(err, errTitleNotFound) {
+		t.Fatalf("expected errTitleNotFound sentinel, got: %v", err)
+	}
+}
+
+// TestGetSessionByTitle_DiskFallback verifies get falls back to the disk scan
+// when no daemon is reachable.
+func TestGetSessionByTitle_DiskFallback(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	stubSnapshot(t, daemonUnavailable)
+
+	diskJSON, err := json.Marshal([]session.InstanceData{{Title: "findme"}})
+	if err != nil {
+		t.Fatalf("marshal disk: %v", err)
+	}
+	if err := config.SaveRepoInstances("repo-x", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	got, err := getSessionByTitle("findme")
+	if err != nil {
+		t.Fatalf("getSessionByTitle disk fallback: %v", err)
+	}
+	if got.Title != "findme" {
+		t.Fatalf("got %q, want findme", got.Title)
+	}
+}
+
+// TestWhoamiSession_DaemonUp verifies whoami matches TmuxName against the live
+// snapshot.
+func TestWhoamiSession_DaemonUp(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	// Disk holds a different TmuxName so a match must have come from the snapshot.
+	diskJSON, err := json.Marshal([]session.InstanceData{{Title: "d", TmuxName: "af_disk"}})
+	if err != nil {
+		t.Fatalf("marshal disk: %v", err)
+	}
+	if err := config.SaveRepoInstances("repo-x", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	live := []session.InstanceData{{Title: "live", TmuxName: "af_live_agent"}}
+	stubSnapshot(t, func(daemon.SnapshotRequest) ([]session.InstanceData, error) { return live, nil })
+
+	got, err := whoamiSession("af_live_agent")
+	if err != nil {
+		t.Fatalf("whoamiSession: %v", err)
+	}
+	if got.Title != "live" {
+		t.Fatalf("got %q, want live", got.Title)
+	}
+
+	if _, err := whoamiSession("af_disk"); err == nil {
+		t.Fatalf("expected no match for a tmux name absent from the live snapshot")
+	}
+}
+
+// TestWhoamiSession_DiskFallback verifies whoami falls back to the disk scan
+// when no daemon is reachable.
+func TestWhoamiSession_DiskFallback(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	stubSnapshot(t, daemonUnavailable)
+
+	diskJSON, err := json.Marshal([]session.InstanceData{{Title: "mine", TmuxName: "af_mine_agent"}})
+	if err != nil {
+		t.Fatalf("marshal disk: %v", err)
+	}
+	if err := config.SaveRepoInstances("repo-x", diskJSON); err != nil {
+		t.Fatalf("save disk: %v", err)
+	}
+
+	got, err := whoamiSession("af_mine_agent")
+	if err != nil {
+		t.Fatalf("whoamiSession disk fallback: %v", err)
+	}
+	if got.Title != "mine" {
+		t.Fatalf("got %q, want mine", got.Title)
+	}
+}
+
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -440,6 +440,33 @@ func Snapshot(req SnapshotRequest) ([]session.InstanceData, error) {
 	return resp.Instances, nil
 }
 
+// ErrDaemonUnavailable signals that a non-spawning daemon read (SnapshotNoSpawn)
+// found no reachable, ready daemon: the control socket is absent/refused or the
+// daemon is still restoring instances (#829). It is the CLI read path's cue to
+// fall back to reading instances.json off disk — never to spawn a daemon or to
+// surface a transient RPC error from a read-only command (#1029 PR 2).
+var ErrDaemonUnavailable = errors.New("daemon not available")
+
+// SnapshotNoSpawn returns the daemon's authoritative session snapshot WITHOUT
+// starting a daemon. Unlike Snapshot — which calls EnsureDaemon and spawns a
+// daemon when none is running — this dials the existing control socket only if
+// it is already serving. It is the read path for CLI commands (sessions
+// list/get/whoami) that must keep working with no daemon present (scripts, CI)
+// and must never launch one. When no live state is available it returns
+// ErrDaemonUnavailable so the caller falls back to disk; it returns the live
+// instances only on a clean Snapshot success.
+func SnapshotNoSpawn(req SnapshotRequest) ([]session.InstanceData, error) {
+	var resp SnapshotResponse
+	if err := callDaemonNoEnsure("Snapshot", req, &resp); err != nil {
+		// A dial failure means no daemon is running; a starting error (#829)
+		// means one is warming up. Either way there is no authoritative live
+		// state to read, so signal the caller to fall back to disk rather than
+		// spawning a daemon or failing a read-only command.
+		return nil, ErrDaemonUnavailable
+	}
+	return resp.Instances, nil
+}
+
 // KillSession asks the daemon to kill a session and remove it from storage.
 func KillSession(req KillSessionRequest) error {
 	var resp KillSessionResponse

--- a/daemon/snapshot_nospawn_test.go
+++ b/daemon/snapshot_nospawn_test.go
@@ -1,0 +1,47 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// TestSnapshotNoSpawn_NoDaemonReturnsUnavailable verifies the CLI read path's
+// core contract (#1029 PR 2): with no daemon serving the control socket,
+// SnapshotNoSpawn returns ErrDaemonUnavailable and MUST NOT spawn a daemon. It
+// only dials the (absent) socket, so it is safe to run outside the container —
+// unlike the EnsureDaemon-backed paths, it never launches a process.
+func TestSnapshotNoSpawn_NoDaemonReturnsUnavailable(t *testing.T) {
+	// Fresh home => no daemon.sock exists, so the dial fails fast.
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	// Guard against an accidental spawn: if SnapshotNoSpawn ever reached the
+	// EnsureDaemon path, launchDaemonProcessFn would fire. Make that a test
+	// failure rather than a silently-launched daemon.
+	prev := launchDaemonProcessFn
+	launchDaemonProcessFn = func() error {
+		t.Fatalf("SnapshotNoSpawn must never spawn a daemon")
+		return nil
+	}
+	t.Cleanup(func() { launchDaemonProcessFn = prev })
+
+	data, err := SnapshotNoSpawn(SnapshotRequest{})
+	if !errors.Is(err, ErrDaemonUnavailable) {
+		t.Fatalf("SnapshotNoSpawn with no daemon = (%v, %v), want ErrDaemonUnavailable", data, err)
+	}
+	if data != nil {
+		t.Fatalf("expected nil instances on the unavailable path, got %+v", data)
+	}
+}
+
+// TestSnapshotNoSpawn_RepoScopedRequest is a light compile/behavior check that a
+// repo-scoped request also degrades to ErrDaemonUnavailable with no daemon (the
+// scoping is enforced server-side; the client just forwards RepoID).
+func TestSnapshotNoSpawn_RepoScopedRequest(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	rid := config.RepoIDFromRoot("/tmp/nospawn-repo")
+	if _, err := SnapshotNoSpawn(SnapshotRequest{RepoID: rid}); !errors.Is(err, ErrDaemonUnavailable) {
+		t.Fatalf("repo-scoped SnapshotNoSpawn with no daemon: want ErrDaemonUnavailable, got %v", err)
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -52,6 +52,14 @@ Manage sessions. All subcommands accept **`--repo <path>`** to target a
 repository other than the current directory, and **`--json`** for envelope
 output.
 
+The read commands **`list`**, **`get`**, and **`whoami`** reflect the daemon's
+authoritative in-memory state — the same live view the TUI shows — when a daemon
+is running, so their output no longer lags behind the on-disk `instances.json`.
+They never start a daemon: with none running (a script, CI, or a fresh shell)
+they fall back to reading `instances.json` off disk, so they keep working with
+no daemon present. Both sources return the same shape, sorted identically by
+`(repo, title)`.
+
 ### `af sessions list`
 
 List sessions in scope (the current/`--repo` repo, or every repo when run


### PR DESCRIPTION
## PR 2/6 of #1029 — Easy HTTP + CLI interfaces

Builds on PR 1/6 (#1179, shared JSON envelope + `api/output.go` + `docs/cli-reference.md`).

### Goal
Make the CLI read paths reflect the daemon's **authoritative in-memory state** instead of a stale on-disk `instances.json`, fixing the CLI-vs-TUI staleness divergence. `af sessions list`, `af sessions get <title>`, and `af sessions whoami` now read the same live `Snapshot` the TUI uses.

### How
- **New non-spawning read path** `daemon.SnapshotNoSpawn`: dials the existing unix control socket only if it is already serving (via `callDaemonNoEnsure`, **not** `EnsureDaemon`) and returns the new sentinel `daemon.ErrDaemonUnavailable` when no daemon is reachable **or** one is still warming up (#829). It never launches a daemon — so `af sessions list` in a script or CI keeps working with none running and must not start one.
- **Disk fallback preserved**: on `ErrDaemonUnavailable` the three commands fall back to the pre-daemon disk read, keeping the loud corrupt-file behavior (#730). Live data is used **only** on a clean `Snapshot` success.
- **Output unchanged**: shapes are byte-for-byte identical (`list` = JSON array of `InstanceData`; `get`/`whoami` = single `InstanceData`). `--repo` scoping is preserved (list filters to that repo; get/whoami scan all repos). The disk-fallback path now sorts by the daemon's `(repoID, title)` key so scripts see the same order from either source.

### Scope
Exactly `list` / `get` / `whoami`. `sessions preview` and `sessions attach` (need a live `*Instance` for tmux) and tasks (PR 3) are untouched. Strictly additive; no CLI renames. References #1029 — does **not** close it (only the final PR does).

### Tests
- `api/sessions_snapshot_test.go` injects the snapshot func to cover **both** paths without a live daemon: daemon-up → results come from `Snapshot` (disk holds different data to prove disk isn't read); daemon-absent → disk fallback produces the same shape, `(repoID, title)` order, and the loud corrupt-file error.
- `daemon/snapshot_nospawn_test.go` asserts `SnapshotNoSpawn` returns `ErrDaemonUnavailable` with no daemon **and never spawns** (guards `launchDaemonProcessFn`).
- Docs: `docs/cli-reference.md` notes list/get/whoami reflect live daemon state and fall back to disk when no daemon is running.

### Verification
`gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean · `go build ./...` · `deadcode -test ./...` clean · full suite green via `make test-container`.

— Captain Claude