### PR TITLE
feat(daemon,cli): task RPCs — daemon owns task writes + unified trigger firing path (#1029) [PR 3/6]

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -20,23 +20,49 @@ var TasksCmd = &cobra.Command{
 	Short: "Manage tasks",
 }
 
-// Indirected so tests can stub the daemon RPCs (reload poke, task run)
-// without dialing — or spawning — a real daemon.
+// Task operations are daemon-owned (#1029 PR 3): the daemon is the sole task
+// writer among clients and reloads its own scheduler/watchers in-process, so
+// there is no separate ReloadTasks poke. Writes (add/update/remove/trigger)
+// take the SPAWNING path (callDaemon/EnsureDaemon) — a task is not schedulable
+// without a running daemon. Reads (list/get) take the NON-SPAWNING path with a
+// disk fallback so a read-only command never launches a daemon (scripts, CI).
+// Held in vars so tests can inject the RPC client without dialing — or
+// spawning — a real daemon.
 var (
-	reloadDaemonTasks = daemon.ReloadTasks
-	runTask           = daemon.RunTask
+	daemonListTasksNoSpawn = daemon.ListTasksNoSpawn
+	daemonAddTask          = daemon.AddTask
+	daemonUpdateTask       = daemon.UpdateTask
+	daemonRemoveTask       = daemon.RemoveTask
+	daemonTriggerTask      = daemon.TriggerTask
 )
 
-// pokeDaemonTasksReload asks the daemon to re-read tasks.json so a CRUD
-// change takes effect immediately. Best-effort by design: the daemon reloads
-// the full task list at every start, so even if this poke fails the saved
-// change is picked up the next time the daemon comes up. That eventual
-// consistency is what removed the install/rollback complexity of the old
-// per-task timer model (#324, #457, #458, #762).
-func pokeDaemonTasksReload() {
-	if err := reloadDaemonTasks(); err != nil {
-		log.WarningLog.Printf("task change saved, but the daemon schedule reload failed (the change applies at next daemon start): %v", err)
+// listTasks returns the full task list, preferring the daemon's authoritative
+// snapshot and falling back to a disk read when no daemon is reachable (#1029
+// PR 3). It never spawns a daemon, so `af tasks list` keeps working with none
+// running. Both paths return the same shape (a JSON array of task.Task) so the
+// output is byte-identical regardless of source.
+func listTasks() ([]task.Task, error) {
+	if tasks, err := daemonListTasksNoSpawn(); err == nil {
+		return tasks, nil
 	}
+	return task.LoadTasks()
+}
+
+// getTaskByID returns the single task matching id, preferring the daemon's
+// authoritative snapshot and falling back to a disk read when no daemon is
+// reachable (#1029 PR 3). When a live snapshot is available the daemon is
+// authoritative: a miss returns not-found without re-reading disk. The
+// not-found message mirrors task.GetTask so output is unchanged.
+func getTaskByID(id string) (*task.Task, error) {
+	if tasks, err := daemonListTasksNoSpawn(); err == nil {
+		for i := range tasks {
+			if tasks[i].ID == id {
+				return &tasks[i], nil
+			}
+		}
+		return nil, fmt.Errorf("task with id %q not found", id)
+	}
+	return task.GetTask(id)
 }
 
 var tasksListCmd = &cobra.Command{
@@ -46,7 +72,7 @@ var tasksListCmd = &cobra.Command{
 		log.Initialize(false)
 		defer log.Close()
 
-		tasks, err := task.LoadTasks()
+		tasks, err := listTasks()
 		if err != nil {
 			return jsonError(fmt.Errorf("failed to load tasks: %w", err))
 		}
@@ -149,11 +175,12 @@ var tasksAddCmd = &cobra.Command{
 			CreatedAt:     time.Now(),
 		}
 
-		if err := task.AddTask(s); err != nil {
+		// Route the write through the daemon: it owns scheduling and reloads its
+		// own scheduler/watchers in-process, so no separate reload poke is needed
+		// (#1029 PR 3). The on-disk tasks.json format is unchanged.
+		if err := daemonAddTask(s); err != nil {
 			return jsonError(fmt.Errorf("failed to add task: %w", err))
 		}
-
-		pokeDaemonTasksReload()
 
 		return jsonOut(map[string]any{"id": id})
 	},
@@ -171,11 +198,9 @@ var tasksRemoveCmd = &cobra.Command{
 			return jsonError(err)
 		}
 
-		if err := task.RemoveTask(args[0]); err != nil {
+		if err := daemonRemoveTask(args[0]); err != nil {
 			return jsonError(fmt.Errorf("failed to remove task: %w", err))
 		}
-
-		pokeDaemonTasksReload()
 
 		return jsonOut(map[string]bool{"ok": true})
 	},
@@ -193,7 +218,7 @@ var tasksGetCmd = &cobra.Command{
 			return jsonError(err)
 		}
 
-		s, err := task.GetTask(args[0])
+		s, err := getTaskByID(args[0])
 		if err != nil {
 			return jsonError(fmt.Errorf("failed to get task: %w", err))
 		}
@@ -214,7 +239,10 @@ var tasksRunCmd = &cobra.Command{
 			return jsonError(err)
 		}
 
-		if err := runTask(args[0]); err != nil {
+		// Fire through the daemon's shared RunTask firing path — the same
+		// entrypoint the cron scheduler uses — instead of the old in-process
+		// daemon.RunTask CLI call (#1029 PR 3 / #1169-class fix).
+		if err := daemonTriggerTask(args[0]); err != nil {
 			return jsonError(fmt.Errorf("failed to trigger task: %w", err))
 		}
 
@@ -329,11 +357,9 @@ var tasksUpdateCmd = &cobra.Command{
 			s.Program = taskUpdateProgramFlag
 		}
 
-		if err := task.UpdateTask(*s); err != nil {
+		if err := daemonUpdateTask(*s); err != nil {
 			return jsonError(fmt.Errorf("failed to update task: %w", err))
 		}
-
-		pokeDaemonTasksReload()
 
 		return jsonOut(s)
 	},

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -9,41 +9,89 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/task"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// daemonCalls tracks stubbed invocations of the daemon RPC helpers so tests
-// can assert that task CRUD pokes the daemon to reload its schedule set
-// (#782) without dialing — or spawning — a real daemon.
+// daemonCalls tracks stubbed invocations of the daemon task RPCs so tests can
+// assert that task CRUD dispatches to the daemon (#1029 PR 3) without dialing —
+// or spawning — a real daemon. Task writes are now daemon-owned: the CLI sends
+// the write to the daemon, which persists tasks.json and reloads its own
+// scheduler/watchers in-process, so `writes` counts successful add/update/remove
+// RPC dispatches (each of which subsumes the old separate reload poke).
 type daemonCalls struct {
-	reloads   int
-	reloadErr error
+	writes    int
+	addErr    error
+	updateErr error
+	removeErr error
 	triggered []string
 	runErr    error
 }
 
-// stubDaemon swaps the daemon RPC indirections for in-memory stubs and
-// restores them on test cleanup.
+// stubDaemon swaps the daemon task-RPC indirections for in-memory stubs and
+// restores them on test cleanup. The write stubs perform the REAL disk write
+// (task.AddTask/UpdateTask/RemoveTask) so the tests' on-disk assertions
+// (task.LoadTasks/GetTask) still hold exactly as they did when the CLI wrote
+// disk directly — the behavior under test is only that the write now dispatches
+// through the daemon RPC. Injecting an *Err short-circuits before the write to
+// model an RPC failure. The read stub defaults to ErrDaemonUnavailable so
+// list/get fall back to the disk the tests seed; read-path tests override it.
 func stubDaemon(t *testing.T) *daemonCalls {
 	t.Helper()
 	calls := &daemonCalls{}
 
-	origReload := reloadDaemonTasks
-	origRun := runTask
-	reloadDaemonTasks = func() error {
-		calls.reloads++
-		return calls.reloadErr
+	origAdd := daemonAddTask
+	origUpdate := daemonUpdateTask
+	origRemove := daemonRemoveTask
+	origTrigger := daemonTriggerTask
+	origList := daemonListTasksNoSpawn
+
+	daemonAddTask = func(tk task.Task) error {
+		if calls.addErr != nil {
+			return calls.addErr
+		}
+		if err := task.AddTask(tk); err != nil {
+			return err
+		}
+		calls.writes++
+		return nil
 	}
-	runTask = func(id string) error {
+	daemonUpdateTask = func(tk task.Task) error {
+		if calls.updateErr != nil {
+			return calls.updateErr
+		}
+		if err := task.UpdateTask(tk); err != nil {
+			return err
+		}
+		calls.writes++
+		return nil
+	}
+	daemonRemoveTask = func(id string) error {
+		if calls.removeErr != nil {
+			return calls.removeErr
+		}
+		if err := task.RemoveTask(id); err != nil {
+			return err
+		}
+		calls.writes++
+		return nil
+	}
+	daemonTriggerTask = func(id string) error {
 		calls.triggered = append(calls.triggered, id)
 		return calls.runErr
 	}
+	daemonListTasksNoSpawn = func() ([]task.Task, error) {
+		return nil, daemon.ErrDaemonUnavailable
+	}
 	t.Cleanup(func() {
-		reloadDaemonTasks = origReload
-		runTask = origRun
+		daemonAddTask = origAdd
+		daemonUpdateTask = origUpdate
+		daemonRemoveTask = origRemove
+		daemonTriggerTask = origTrigger
+		daemonListTasksNoSpawn = origList
 	})
 	return calls
 }
@@ -129,7 +177,7 @@ func setupAddRepo(t *testing.T) string {
 	return repo
 }
 
-func TestTasksAdd_PersistsTaskAndPokesDaemon(t *testing.T) {
+func TestTasksAdd_PersistsTaskViaDaemon(t *testing.T) {
 	useTempConfig(t)
 	resetAddFlags(t)
 	calls := stubDaemon(t)
@@ -154,31 +202,30 @@ func TestTasksAdd_PersistsTaskAndPokesDaemon(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, resolvedRepo, resolvedProject)
 
-	assert.Equal(t, 1, calls.reloads, "add must poke the daemon to reload schedules")
+	assert.Equal(t, 1, calls.writes, "add must dispatch the write to the daemon")
 }
 
-// TestTasksAdd_DaemonPokeFailureDoesNotFailAdd pins the eventual-consistency
-// contract that replaced the old install/rollback dance (#324/#457/#458):
-// the task record is the source of truth; a failed reload poke is logged and
-// the daemon picks the task up at its next start.
-func TestTasksAdd_DaemonPokeFailureDoesNotFailAdd(t *testing.T) {
+// TestTasksAdd_DaemonWriteFailureFailsAdd pins the daemon-owned-write contract
+// (#1029 PR 3): the daemon is now the sole task writer, so a failed AddTask RPC
+// fails the CLI command — there is no client-side disk write to fall back to.
+// This replaces the old eventual-consistency "failed reload poke is fine" test,
+// which no longer applies now that the write itself goes through the daemon.
+func TestTasksAdd_DaemonWriteFailureFailsAdd(t *testing.T) {
 	useTempConfig(t)
 	resetAddFlags(t)
 	calls := stubDaemon(t)
-	calls.reloadErr = errors.New("simulated daemon-start failure")
+	calls.addErr = errors.New("simulated daemon RPC failure")
 	setupAddRepo(t)
 
-	taskAddNameFlag = "poke-fail"
+	taskAddNameFlag = "rpc-fail"
 	taskAddPromptFlag = "p"
 	taskAddCronFlag = "0 9 * * *"
 	taskAddProgramFlag = "claude"
 
 	err := tasksAddCmd.RunE(tasksAddCmd, nil)
-	require.NoError(t, err, "a failed daemon poke must not fail the add")
-
-	tasks, err := task.LoadTasks()
-	require.NoError(t, err)
-	require.Len(t, tasks, 1, "task record must persist even when the poke fails")
+	require.Error(t, err, "a failed daemon write RPC must fail the add")
+	assert.Contains(t, err.Error(), "failed to add task")
+	assert.Zero(t, calls.writes, "no successful write is recorded when the RPC fails")
 }
 
 // TestTasksAdd_RejectsEmptyPrompt is the regression guard for #517: Cobra's
@@ -202,7 +249,7 @@ func TestTasksAdd_RejectsEmptyPrompt(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "prompt must be non-empty")
 
-			assert.Zero(t, calls.reloads, "no daemon poke when validation fails")
+			assert.Zero(t, calls.writes, "no daemon write is dispatched when validation fails")
 
 			tasks, err := task.LoadTasks()
 			require.NoError(t, err)
@@ -225,7 +272,7 @@ func TestTasksAdd_RejectsInvalidCron(t *testing.T) {
 	err := tasksAddCmd.RunE(tasksAddCmd, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid cron expression")
-	assert.Zero(t, calls.reloads)
+	assert.Zero(t, calls.writes)
 }
 
 // TestTasksAdd_InvalidRepoNamesPathNotRequired is half of the #892 regression:
@@ -252,7 +299,7 @@ func TestTasksAdd_InvalidRepoNamesPathNotRequired(t *testing.T) {
 	assert.Contains(t, err.Error(), notARepo, "error must name the invalid --repo path")
 	assert.Contains(t, err.Error(), "not a valid git repository")
 	assert.NotContains(t, err.Error(), "--repo is required", "must not claim --repo is missing when it was provided")
-	assert.Zero(t, calls.reloads, "no daemon poke when repo resolution fails")
+	assert.Zero(t, calls.writes, "no daemon write is dispatched when repo resolution fails")
 }
 
 // TestTasksAdd_AbsentRepoInNonRepoCwdSaysRequired is the other half of #892:
@@ -276,7 +323,7 @@ func TestTasksAdd_AbsentRepoInNonRepoCwdSaysRequired(t *testing.T) {
 	assert.Contains(t, err.Error(), "--repo is required")
 }
 
-func TestTasksUpdate_DisablePersistsAndPokesDaemon(t *testing.T) {
+func TestTasksUpdate_DisablePersistsViaDaemon(t *testing.T) {
 	useTempConfig(t)
 	resetUpdateFlags(t)
 	calls := stubDaemon(t)
@@ -290,10 +337,10 @@ func TestTasksUpdate_DisablePersistsAndPokesDaemon(t *testing.T) {
 	got, err := task.GetTask("t1")
 	require.NoError(t, err)
 	assert.False(t, got.Enabled)
-	assert.Equal(t, 1, calls.reloads, "update must poke the daemon to reload schedules")
+	assert.Equal(t, 1, calls.writes, "update must dispatch the write to the daemon")
 }
 
-func TestTasksUpdate_CronChangePersistsAndPokesDaemon(t *testing.T) {
+func TestTasksUpdate_CronChangePersistsViaDaemon(t *testing.T) {
 	useTempConfig(t)
 	resetUpdateFlags(t)
 	calls := stubDaemon(t)
@@ -307,7 +354,7 @@ func TestTasksUpdate_CronChangePersistsAndPokesDaemon(t *testing.T) {
 	got, err := task.GetTask("t2")
 	require.NoError(t, err)
 	assert.Equal(t, "30 6 * * 1", got.CronExpr)
-	assert.Equal(t, 1, calls.reloads)
+	assert.Equal(t, 1, calls.writes)
 }
 
 func TestTasksUpdate_RejectsInvalidCron(t *testing.T) {
@@ -325,7 +372,7 @@ func TestTasksUpdate_RejectsInvalidCron(t *testing.T) {
 	got, err := task.GetTask("t3")
 	require.NoError(t, err)
 	assert.Equal(t, "0 9 * * *", got.CronExpr, "cron must remain unchanged on validation failure")
-	assert.Zero(t, calls.reloads)
+	assert.Zero(t, calls.writes)
 }
 
 func TestTasksUpdate_RejectsEmptyPrompt(t *testing.T) {
@@ -352,7 +399,7 @@ func TestTasksUpdate_RejectsEmptyPrompt(t *testing.T) {
 			got, err := task.GetTask("t-whitespace")
 			require.NoError(t, err)
 			assert.Equal(t, "valid prompt", got.Prompt, "prompt should remain unchanged")
-			assert.Zero(t, calls.reloads)
+			assert.Zero(t, calls.writes)
 		})
 	}
 }
@@ -387,7 +434,7 @@ func TestTasksUpdate_RejectsBlankWatchCmd(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, "0 3 * * *", got.CronExpr, "existing trigger must survive a rejected update")
 				assert.Empty(t, got.WatchCmd)
-				assert.Zero(t, calls.reloads)
+				assert.Zero(t, calls.writes)
 			})
 		}
 	}
@@ -418,7 +465,7 @@ func TestTasksUpdate_RejectsBlankCron(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, "tail -f errors.log", got.WatchCmd, "existing trigger must survive a rejected update")
 				assert.Empty(t, got.CronExpr)
-				assert.Zero(t, calls.reloads)
+				assert.Zero(t, calls.writes)
 			})
 		}
 	}
@@ -457,10 +504,10 @@ func TestTasksUpdate_RejectsBadEnabledValue(t *testing.T) {
 	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"t4"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--enabled must be 'true' or 'false'")
-	assert.Zero(t, calls.reloads)
+	assert.Zero(t, calls.writes)
 }
 
-func TestTasksRemove_RemovesTaskAndPokesDaemon(t *testing.T) {
+func TestTasksRemove_RemovesTaskViaDaemon(t *testing.T) {
 	useTempConfig(t)
 	calls := stubDaemon(t)
 
@@ -472,7 +519,7 @@ func TestTasksRemove_RemovesTaskAndPokesDaemon(t *testing.T) {
 	tasks, err := task.LoadTasks()
 	require.NoError(t, err)
 	assert.Empty(t, tasks)
-	assert.Equal(t, 1, calls.reloads, "remove must poke the daemon to reload schedules")
+	assert.Equal(t, 1, calls.writes, "remove must dispatch the write to the daemon")
 }
 
 func TestTasksRemove_MissingTaskErrors(t *testing.T) {
@@ -482,7 +529,7 @@ func TestTasksRemove_MissingTaskErrors(t *testing.T) {
 	err := tasksRemoveCmd.RunE(tasksRemoveCmd, []string{"nope1234"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
-	assert.Zero(t, calls.reloads, "no daemon poke when nothing changed")
+	assert.Zero(t, calls.writes, "no daemon write is dispatched when nothing changed")
 }
 
 func TestTasksTrigger_RunsThroughDaemon(t *testing.T) {
@@ -529,7 +576,7 @@ func TestTasksAdd_ExactlyOneTrigger(t *testing.T) {
 			err := tasksAddCmd.RunE(tasksAddCmd, nil)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "exactly one of --cron or --watch-cmd")
-			assert.Zero(t, calls.reloads)
+			assert.Zero(t, calls.writes)
 
 			tasks, err := task.LoadTasks()
 			require.NoError(t, err)
@@ -563,7 +610,7 @@ func TestTasksAdd_WatchTaskAllowsEmptyPrompt(t *testing.T) {
 	assert.Empty(t, tasks[0].CronExpr)
 	assert.Empty(t, tasks[0].Prompt)
 	assert.True(t, tasks[0].Enabled)
-	assert.Equal(t, 1, calls.reloads, "add must poke the daemon so the watcher starts")
+	assert.Equal(t, 1, calls.writes, "add must dispatch the write to the daemon so the watcher starts")
 }
 
 // TestTasksUpdate_SwitchingTriggersClearsTheOther verifies that setting one
@@ -682,7 +729,7 @@ func TestTasksUpdate_ProgramChange(t *testing.T) {
 	got, err := task.GetTask("pr1")
 	require.NoError(t, err)
 	assert.Equal(t, "codex", got.Program, "program must persist through update")
-	assert.Equal(t, 1, calls.reloads, "update must poke the daemon to reload schedules")
+	assert.Equal(t, 1, calls.writes, "update must dispatch the write to the daemon")
 	assert.Contains(t, out, `"program": "codex"`, "JSON output must reflect the new program")
 }
 
@@ -704,7 +751,7 @@ func TestTasksUpdate_RejectsInvalidProgram(t *testing.T) {
 	got, err := task.GetTask("pr2")
 	require.NoError(t, err)
 	assert.Equal(t, "claude", got.Program, "program must remain unchanged on validation failure")
-	assert.Zero(t, calls.reloads, "no daemon poke when validation fails")
+	assert.Zero(t, calls.writes, "no daemon write is dispatched when validation fails")
 }
 
 // TestTasksUpdate_OmittingProgramLeavesUnchanged pins the partial-update
@@ -723,4 +770,79 @@ func TestTasksUpdate_OmittingProgramLeavesUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "renamed", got.Name)
 	assert.Equal(t, "aider", got.Program, "absent --program must not change the program")
+}
+
+// --- Read path: list/get non-spawn + disk fallback (#1029 PR 3) ---
+
+// TestTasksList_FallsBackToDiskWhenNoDaemon pins that `tasks list` reads the
+// disk when no daemon is reachable — the stub returns ErrDaemonUnavailable by
+// default — so the command keeps working in scripts/CI with no daemon running
+// and never spawns one.
+func TestTasksList_FallsBackToDiskWhenNoDaemon(t *testing.T) {
+	useTempConfig(t)
+	stubDaemon(t) // daemonListTasksNoSpawn defaults to ErrDaemonUnavailable
+	seedTask(t, task.Task{ID: "d1", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
+
+	tasks, err := listTasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1, "list must fall back to the on-disk task")
+	assert.Equal(t, "d1", tasks[0].ID)
+}
+
+// TestTasksList_PrefersDaemonSnapshot pins that when a daemon IS reachable the
+// live snapshot is authoritative — even when it diverges from disk — so the CLI
+// mirrors the daemon's view rather than a stale disk read.
+func TestTasksList_PrefersDaemonSnapshot(t *testing.T) {
+	useTempConfig(t)
+	stubDaemon(t)
+	// Disk holds one task; the daemon reports a DIFFERENT one.
+	seedTask(t, task.Task{ID: "ondisk", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
+	daemonListTasksNoSpawn = func() ([]task.Task, error) {
+		return []task.Task{{ID: "live", Prompt: "p", CronExpr: "0 1 * * *", Enabled: true}}, nil
+	}
+
+	tasks, err := listTasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "live", tasks[0].ID, "a reachable daemon's snapshot is authoritative")
+}
+
+// TestTasksGet_FallsBackToDiskWhenNoDaemon pins the get read path's disk
+// fallback and its not-found behavior against the seeded disk state.
+func TestTasksGet_FallsBackToDiskWhenNoDaemon(t *testing.T) {
+	useTempConfig(t)
+	stubDaemon(t)
+	seedTask(t, task.Task{ID: "g1", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
+
+	got, err := getTaskByID("g1")
+	require.NoError(t, err)
+	assert.Equal(t, "g1", got.ID)
+
+	_, err = getTaskByID("missing1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestTasksGet_PrefersDaemonSnapshot pins that a reachable daemon is
+// authoritative for get: a match comes from the live snapshot, and a miss
+// returns not-found WITHOUT re-reading disk (even though disk holds the id).
+func TestTasksGet_PrefersDaemonSnapshot(t *testing.T) {
+	useTempConfig(t)
+	stubDaemon(t)
+	// Disk holds "shadow"; the daemon does NOT report it.
+	seedTask(t, task.Task{ID: "shadow", Prompt: "p", CronExpr: "0 9 * * *", Enabled: true})
+	daemonListTasksNoSpawn = func() ([]task.Task, error) {
+		return []task.Task{{ID: "live", Prompt: "p", CronExpr: "0 1 * * *", Enabled: true}}, nil
+	}
+
+	got, err := getTaskByID("live")
+	require.NoError(t, err)
+	assert.Equal(t, "live", got.ID)
+
+	// A daemon miss is authoritative — no disk fallback even though "shadow"
+	// exists on disk.
+	_, err = getTaskByID("shadow")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found",
+		"a reachable daemon's miss is authoritative; get must not re-read disk")
 }

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -36,14 +36,16 @@ var killSessionThroughDaemon = func(title, repoID string) error {
 }
 
 // triggerTaskThroughDaemon runs a task by ID through the daemon's single shared
-// trigger path (daemon.RunTask) — the SAME entrypoint `af tasks trigger` and the
-// cron scheduler use. Routing the TUI's `r` (run now) here makes it honor a
-// task's target_session (deliver into it, auto-create when missing) and only
-// spawn a fresh per-run session when target_session is empty, instead of the old
-// divergent path that unconditionally spawned a new session and orphaned the
-// target (#1169). It is a package var so the app test suite can stub the trigger
-// without dialing a real daemon.
-var triggerTaskThroughDaemon = daemon.RunTask
+// trigger path — the SAME entrypoint `af tasks trigger` and the cron scheduler
+// use. It routes through the TriggerTask RPC (#1029 PR 3) so the firing runs
+// IN the daemon process, not in the TUI: the daemon is the sole task-execution
+// host, and RunTask there honors a task's target_session (deliver into it,
+// auto-create when missing) and only spawns a fresh per-run session when
+// target_session is empty, instead of the old divergent path that
+// unconditionally spawned a new session and orphaned the target (#1169). It is a
+// package var so the app test suite can stub the trigger without dialing a real
+// daemon.
+var triggerTaskThroughDaemon = daemon.TriggerTask
 
 // pauseStatusPollThroughDaemon / resumeStatusPollThroughDaemon route the TUI's
 // attach-time poll-pause coordination to the daemon (#1160, Fix A follow-up to

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -270,6 +270,62 @@ type ReloadTasksResponse struct {
 	OK bool
 }
 
+// Task CRUD RPCs (#1029 PR 3). They promote task writes to the daemon so it is
+// the sole task writer among clients — exactly the model sessions already
+// follow — and the write and the scheduler/watcher refresh happen atomically
+// in-process (no separate ReloadTasks poke). The on-disk tasks.json format is
+// unchanged; the daemon reuses the same task.AddTask/UpdateTask/RemoveTask
+// (config.WithFileLock + saveTasks) that clients used to call directly.
+
+// ListTasksRequest asks the daemon for the full task list. There is
+// deliberately no repo filter: the daemon returns every repo's tasks and the
+// CLI applies its --repo filter, matching the disk-read fallback
+// (task.LoadTasks). It is the read side of the task single-writer model, mirror
+// of Snapshot for sessions.
+type ListTasksRequest struct{}
+type ListTasksResponse struct {
+	Tasks []task.Task
+}
+
+// AddTaskRequest carries a fully-populated task.Task to append. The CLI/TUI
+// still build and validate the struct (flag parsing, ID generation, program
+// resolution); the daemon re-validates via task.AddTask and owns the write.
+type AddTaskRequest struct {
+	Task task.Task
+}
+type AddTaskResponse struct {
+	OK bool
+}
+
+// UpdateTaskRequest carries the edited task.Task to persist. task.UpdateTask
+// preserves the scheduler-owned fields (LastRunAt/LastRunStatus/CreatedAt) from
+// the freshly-loaded record under the file lock, so a stale client copy never
+// clobbers them.
+type UpdateTaskRequest struct {
+	Task task.Task
+}
+type UpdateTaskResponse struct {
+	OK bool
+}
+
+type RemoveTaskRequest struct {
+	ID string
+}
+type RemoveTaskResponse struct {
+	OK bool
+}
+
+// TriggerTaskRequest asks the daemon to fire a task NOW through the same
+// RunTask firing path the in-daemon scheduler uses (#1029 PR 3 / #1169-class
+// fix). The handler preserves RunTask's guards: watch tasks and disabled tasks
+// are refused.
+type TriggerTaskRequest struct {
+	ID string
+}
+type TriggerTaskResponse struct {
+	OK bool
+}
+
 type ShutdownRequest struct{}
 type ShutdownResponse struct {
 	OK bool
@@ -552,6 +608,51 @@ func ReloadTasks() error {
 	return callDaemon("ReloadTasks", ReloadTasksRequest{}, &resp)
 }
 
+// ListTasksNoSpawn returns the daemon's authoritative task list WITHOUT
+// starting a daemon (#1029 PR 3). Like SnapshotNoSpawn it dials the existing
+// control socket only if it is already serving and returns ErrDaemonUnavailable
+// otherwise, so a read-only CLI command (tasks list/get) falls back to reading
+// tasks.json off disk rather than ever launching a daemon. Task reads do not
+// depend on the instance restore, so there is no warm-up starting-error window
+// to wait out here.
+func ListTasksNoSpawn() ([]task.Task, error) {
+	var resp ListTasksResponse
+	if err := callDaemonNoEnsure("ListTasks", ListTasksRequest{}, &resp); err != nil {
+		return nil, ErrDaemonUnavailable
+	}
+	return resp.Tasks, nil
+}
+
+// AddTask asks the daemon to append a task and re-arm its schedule set. Like
+// every callDaemon path it ensures the daemon is running first, so adding a task
+// also brings the scheduler up — a task is not schedulable without a running
+// daemon.
+func AddTask(t task.Task) error {
+	var resp AddTaskResponse
+	return callDaemon("AddTask", AddTaskRequest{Task: t}, &resp)
+}
+
+// UpdateTask asks the daemon to persist an edited task and re-arm its schedule.
+func UpdateTask(t task.Task) error {
+	var resp UpdateTaskResponse
+	return callDaemon("UpdateTask", UpdateTaskRequest{Task: t}, &resp)
+}
+
+// RemoveTask asks the daemon to delete a task and re-arm its schedule.
+func RemoveTask(id string) error {
+	var resp RemoveTaskResponse
+	return callDaemon("RemoveTask", RemoveTaskRequest{ID: id}, &resp)
+}
+
+// TriggerTask asks the daemon to fire a task now through the shared RunTask
+// firing path (the same entrypoint the in-daemon scheduler uses). Replaces the
+// old in-process daemon.RunTask CLI call so CLI, TUI, and scheduler triggers all
+// converge on one daemon-owned firing path (#1169-class fix).
+func TriggerTask(id string) error {
+	var resp TriggerTaskResponse
+	return callDaemon("TriggerTask", TriggerTaskRequest{ID: id}, &resp)
+}
+
 // ImportRemoteHookSessions asks the daemon to reconcile remote sessions
 // reported by list_cmd into persisted storage.
 func ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest) ([]session.InstanceData, error) {
@@ -768,17 +869,21 @@ func (s *controlServer) ResumeStatusPoll(req ResumeStatusPollRequest, resp *Resu
 	return nil
 }
 
-func (s *controlServer) ReloadTasks(_ ReloadTasksRequest, resp *ReloadTasksResponse) error {
+// reloadTaskSchedules re-arms the daemon's cron scheduler and watcher
+// supervisor from tasks.json. It is the shared refresh the ReloadTasks poke and
+// the task CRUD RPCs (Add/Update/RemoveTask) both invoke after a write, so the
+// write and its schedule refresh happen atomically in-daemon and no separate
+// ReloadTasks poke is needed for CRUD.
+//
+// During warm-up (#829) the scheduler and watcher supervisor have not started
+// yet; RunDaemon reloads both from tasks.json right after the restore completes,
+// so a change just written is picked up then. It returns nil (nothing to
+// reload) instead of erroring — the write is already durable.
+func (s *controlServer) reloadTaskSchedules() error {
 	if s.scheduler == nil {
 		return fmt.Errorf("this daemon does not host a task scheduler")
 	}
-	// During warm-up (#829) the scheduler and watcher supervisor have not
-	// started yet; RunDaemon reloads both from tasks.json right after the
-	// restore completes, so a change the caller just wrote is picked up then.
-	// Ack instead of erroring — the write is already durable and there is
-	// nothing running to reload.
 	if s.manager != nil && !s.manager.Ready() {
-		resp.OK = true
 		return nil
 	}
 	if err := s.scheduler.Reload(); err != nil {
@@ -791,6 +896,78 @@ func (s *controlServer) ReloadTasks(_ ReloadTasksRequest, resp *ReloadTasksRespo
 		if err := s.watchers.Reload(); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func (s *controlServer) ReloadTasks(_ ReloadTasksRequest, resp *ReloadTasksResponse) error {
+	if err := s.reloadTaskSchedules(); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+// ListTasks returns the full task list read from tasks.json (#1029 PR 3).
+// Deliberately NOT gated on requireManagerReady: task state lives on disk,
+// independent of the instance restore, so a read is always safe and always
+// current even while the daemon is warming up.
+func (s *controlServer) ListTasks(_ ListTasksRequest, resp *ListTasksResponse) error {
+	tasks, err := task.LoadTasks()
+	if err != nil {
+		return err
+	}
+	resp.Tasks = tasks
+	return nil
+}
+
+// AddTask persists a new task and re-arms the schedule set (#1029 PR 3). The
+// write goes through task.AddTask (config.WithFileLock + saveTasks) — the same
+// path clients used to call directly — so the on-disk format is unchanged; the
+// difference is the daemon now owns it and refreshes its own scheduler/watchers
+// in the same call.
+func (s *controlServer) AddTask(req AddTaskRequest, resp *AddTaskResponse) error {
+	if err := task.AddTask(req.Task); err != nil {
+		return err
+	}
+	if err := s.reloadTaskSchedules(); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskResponse) error {
+	if err := task.UpdateTask(req.Task); err != nil {
+		return err
+	}
+	if err := s.reloadTaskSchedules(); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskResponse) error {
+	if err := task.RemoveTask(req.ID); err != nil {
+		return err
+	}
+	if err := s.reloadTaskSchedules(); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+// TriggerTask fires a task NOW through the shared RunTask firing path — the same
+// entrypoint the in-daemon scheduler uses (#1029 PR 3). This unifies the CLI
+// `af tasks trigger`, the TUI run-now, and the cron scheduler on one
+// daemon-owned firing path, replacing the old in-process daemon.RunTask CLI call
+// (#1169-class fix). RunTask preserves the guards: watch tasks and disabled
+// tasks are refused.
+func (s *controlServer) TriggerTask(req TriggerTaskRequest, resp *TriggerTaskResponse) error {
+	if err := RunTask(req.ID); err != nil {
+		return err
 	}
 	resp.OK = true
 	return nil

--- a/daemon/task_rpc_test.go
+++ b/daemon/task_rpc_test.go
@@ -1,0 +1,192 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/task"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The task CRUD/trigger RPCs (#1029 PR 3) promote task writes to the daemon so
+// it is the sole task writer among clients: the handler performs the tasks.json
+// write and reloads its own scheduler/watchers in-process, and TriggerTask fires
+// through the SAME RunTask path the in-daemon scheduler uses.
+
+func enabledCronTask(id, repoPath string) task.Task {
+	return task.Task{
+		ID:          id,
+		Name:        id,
+		Prompt:      "do the thing",
+		CronExpr:    "0 3 * * *",
+		ProjectPath: repoPath,
+		Program:     "claude",
+		Enabled:     true,
+		CreatedAt:   time.Now(),
+	}
+}
+
+// TestControlListTasks_ReadsDisk pins that the ListTasks handler returns the
+// full task list read from tasks.json — the read side of the task
+// single-writer model, and the disk fallback the CLI mirrors.
+func TestControlListTasks_ReadsDisk(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	require.NoError(t, task.AddTask(enabledCronTask("aaaa0001", "")))
+	require.NoError(t, task.AddTask(enabledCronTask("aaaa0002", "")))
+
+	srv := &controlServer{}
+	var resp ListTasksResponse
+	require.NoError(t, srv.ListTasks(ListTasksRequest{}, &resp))
+	require.Len(t, resp.Tasks, 2)
+	ids := []string{resp.Tasks[0].ID, resp.Tasks[1].ID}
+	assert.ElementsMatch(t, []string{"aaaa0001", "aaaa0002"}, ids)
+}
+
+// TestControlAddTask_WritesAndArmsSchedule pins that AddTask persists the task
+// AND re-arms the scheduler in the same call, so no separate ReloadTasks poke is
+// needed — the write and the schedule refresh happen atomically in the daemon.
+func TestControlAddTask_WritesAndArmsSchedule(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	srv := &controlServer{scheduler: newTaskScheduler()}
+
+	var resp AddTaskResponse
+	require.NoError(t, srv.AddTask(AddTaskRequest{Task: enabledCronTask("bbbb0001", "")}, &resp))
+	assert.True(t, resp.OK)
+
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1, "AddTask must persist the task to tasks.json")
+	assert.Equal(t, "bbbb0001", tasks[0].ID)
+
+	assert.Contains(t, srv.scheduler.scheduledTaskIDs(), "bbbb0001",
+		"AddTask must re-arm the scheduler in-process (no separate reload poke)")
+}
+
+// TestControlUpdateTask_WritesAndRearms pins that UpdateTask persists the edit
+// and re-arms the schedule set.
+func TestControlUpdateTask_WritesAndRearms(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	require.NoError(t, task.AddTask(enabledCronTask("cccc0001", "")))
+
+	srv := &controlServer{scheduler: newTaskScheduler()}
+	edited := enabledCronTask("cccc0001", "")
+	edited.CronExpr = "30 6 * * 1"
+
+	var resp UpdateTaskResponse
+	require.NoError(t, srv.UpdateTask(UpdateTaskRequest{Task: edited}, &resp))
+	assert.True(t, resp.OK)
+
+	got, err := task.GetTask("cccc0001")
+	require.NoError(t, err)
+	assert.Equal(t, "30 6 * * 1", got.CronExpr, "UpdateTask must persist the edit")
+	assert.Contains(t, srv.scheduler.scheduledTaskIDs(), "cccc0001")
+}
+
+// TestControlRemoveTask_WritesAndDisarms pins that RemoveTask deletes the task
+// and drops it from the scheduler in the same call.
+func TestControlRemoveTask_WritesAndDisarms(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	require.NoError(t, task.AddTask(enabledCronTask("dddd0001", "")))
+
+	srv := &controlServer{scheduler: newTaskScheduler()}
+	require.NoError(t, srv.scheduler.Reload()) // arm it first
+	require.Contains(t, srv.scheduler.scheduledTaskIDs(), "dddd0001")
+
+	var resp RemoveTaskResponse
+	require.NoError(t, srv.RemoveTask(RemoveTaskRequest{ID: "dddd0001"}, &resp))
+	assert.True(t, resp.OK)
+
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	assert.Empty(t, tasks, "RemoveTask must delete the task from tasks.json")
+	assert.NotContains(t, srv.scheduler.scheduledTaskIDs(), "dddd0001",
+		"RemoveTask must disarm the scheduler in-process")
+}
+
+// TestControlAddTask_WarmupSkipsReload pins that during warm-up (manager not
+// ready) the write still lands but the reload is skipped — RunDaemon reloads
+// from tasks.json right after the restore, so the change is picked up then.
+func TestControlAddTask_WarmupSkipsReload(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	manager, err := newManagerShell(config.DefaultConfig()) // not ready: RestoreInstances not called
+	require.NoError(t, err)
+	require.False(t, manager.Ready())
+
+	srv := &controlServer{manager: manager, scheduler: newTaskScheduler()}
+	var resp AddTaskResponse
+	require.NoError(t, srv.AddTask(AddTaskRequest{Task: enabledCronTask("eeee0001", "")}, &resp))
+	assert.True(t, resp.OK)
+
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1, "the write must land even during warm-up")
+	assert.Empty(t, srv.scheduler.scheduledTaskIDs(),
+		"warm-up must skip the reload; RunDaemon arms the scheduler after the restore")
+}
+
+// TestControlTriggerTask_UsesSharedFiringPath pins the core #1169-class fix:
+// TriggerTask fires through RunTask — the SAME entrypoint the scheduler uses —
+// so a manual trigger goes through the daemon's create-or-deliver path, proven
+// here by the shared createSessionForTask hook receiving the task's details.
+func TestControlTriggerTask_UsesSharedFiringPath(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupTaskRepo(t)
+	creates, _ := stubTaskDelivery(t)
+
+	require.NoError(t, task.AddTask(enabledCronTask("ffff0001", repo)))
+
+	srv := &controlServer{}
+	var resp TriggerTaskResponse
+	require.NoError(t, srv.TriggerTask(TriggerTaskRequest{ID: "ffff0001"}, &resp))
+	assert.True(t, resp.OK)
+
+	require.Len(t, *creates, 1, "trigger must fire through the shared RunTask path")
+	assert.Equal(t, repo, (*creates)[0].RepoPath)
+	assert.Equal(t, "do the thing", (*creates)[0].Prompt)
+
+	// The shared path also records the run status, proving RunTask ran to
+	// completion rather than a divergent copy.
+	got, err := task.GetTask("ffff0001")
+	require.NoError(t, err)
+	assert.Equal(t, "started", got.LastRunStatus)
+}
+
+// TestControlTriggerTask_RefusesWatchTask pins that a watch task cannot be
+// manually triggered (it fires from its watch command's stdout), and never
+// reaches session creation.
+func TestControlTriggerTask_RefusesWatchTask(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	creates, _ := stubTaskDelivery(t)
+	require.NoError(t, task.AddTask(task.Task{
+		ID:        "ffff0002",
+		Name:      "watcher",
+		WatchCmd:  "tail -f log",
+		Enabled:   true,
+		CreatedAt: time.Now(),
+	}))
+
+	srv := &controlServer{}
+	var resp TriggerTaskResponse
+	err := srv.TriggerTask(TriggerTaskRequest{ID: "ffff0002"}, &resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "watch task")
+	assert.Empty(t, *creates, "a refused watch trigger must never create a session")
+}
+
+// TestControlTriggerTask_RefusesDisabledTask pins that a disabled task is
+// refused, whichever caller asks.
+func TestControlTriggerTask_RefusesDisabledTask(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	creates, _ := stubTaskDelivery(t)
+	require.NoError(t, seedDisabledTask("ffff0003"))
+
+	srv := &controlServer{}
+	var resp TriggerTaskResponse
+	err := srv.TriggerTask(TriggerTaskRequest{ID: "ffff0003"}, &resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disabled")
+	assert.Empty(t, *creates, "a refused disabled trigger must never create a session")
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -202,6 +202,19 @@ Manage tasks that deliver a prompt to an agent automatically — on a cron
 schedule or whenever a watch script emits a stdout line. Full semantics live in
 [tasks.md](tasks.md). All subcommands accept `--repo <path>` and `--json`.
 
+Task operations are **daemon-owned**: the daemon is the single writer that hosts
+task scheduling, so the write commands (**`add`**, **`update`**, **`remove`**,
+**`trigger`**) go through it. `add` / `update` / `remove` persist the change and
+re-arm the daemon's schedules atomically — starting a daemon if none is running,
+since a task is not schedulable without one. `trigger` fires through the same
+in-daemon path the cron scheduler uses. The on-disk `tasks.json` format is
+unchanged.
+
+The read commands **`list`** and **`get`** reflect the daemon's authoritative
+task view when one is already running, and **never start a daemon**: with none
+running (a script, CI, or a fresh shell) they fall back to reading `tasks.json`
+off disk. Both sources return the same shape.
+
 ### `af tasks list`
 
 List tasks (filtered to `--repo` when given). Emits a JSON array of task objects
@@ -264,7 +277,9 @@ Setting one trigger clears the other so the exactly-one rule holds.
 
 ### `af tasks trigger <id>`
 
-Run a cron task immediately (cron tasks only). Emits `{"ok": true}`.
+Run a cron task immediately (cron tasks only) through the daemon's shared firing
+path — the same entrypoint the cron scheduler uses. Watch tasks and disabled
+tasks are refused. Emits `{"ok": true}`.
 
 ### `af tasks remove <id>`
 


### PR DESCRIPTION
## What & why

PR 3/6 of #1029 (Easy HTTP + CLI interfaces). Makes **task operations
daemon-owned**, exactly like sessions already are (#960). Today the CLI writes
`tasks.json` directly (`config.WithFileLock`) then pokes `ReloadTasks`, and
`af tasks trigger` runs `daemon.RunTask` **in the CLI process** — the same
TUI-vs-CLI divergence class #1169 just fixed for run-now. This promotes task
ops to daemon `net/rpc` methods so the CLI (and, in PR4, HTTP) are thin clients
of one core, the daemon is the sole task writer among clients, and there is a
single shared trigger firing path.

The on-disk `tasks.json` format is **unchanged**.

## New daemon control RPCs (`daemon/control.go`)

Mirror the existing session RPC style (request/response structs + client
wrappers + auto-registration):

- **`ListTasks`** — reads `tasks.json`. Ungated on `requireManagerReady`: task
  state lives on disk, independent of the instance restore, so a read is always
  safe and current even during warm-up.
- **`AddTask` / `UpdateTask` / `RemoveTask`** — perform the write via the
  existing `task.AddTask/UpdateTask/RemoveTask` (`config.WithFileLock` +
  `saveTasks`) and re-arm the daemon's own scheduler + watcher supervisor
  **in-process** through the new shared `reloadTaskSchedules` helper. The write
  and the schedule refresh happen atomically in the daemon, so **no separate
  `ReloadTasks` poke is needed** for CRUD. During warm-up (#829) the reload is
  skipped (RunDaemon arms after the restore); the write still lands.
- **`TriggerTask`** — fires through the **same `RunTask` entrypoint the in-daemon
  scheduler uses** (the shared firing path), preserving RunTask's guards: watch
  tasks and disabled tasks are refused.

## CLI routing (`api/tasks.go`)

- **`add` / `update` / `remove` / `trigger`** dispatch through the daemon via the
  **spawning** path (`callDaemon`/`EnsureDaemon`) — consistent with today (the
  old reload poke already `EnsureDaemon`ed; a task isn't schedulable without a
  running daemon). The old in-process `daemon.RunTask` CLI call is **replaced by
  the `TriggerTask` RPC**.
- **`list` / `get`** route through `ListTasks` via a **non-spawning** read path
  with disk fallback (`ListTasksNoSpawn` → `ErrDaemonUnavailable` →
  `task.LoadTasks`), exactly like PR2's `SnapshotNoSpawn` pattern: `af tasks
  list` never auto-spawns a daemon and keeps working in scripts/CI with none
  running. Output shapes (list = JSON array of `task.Task`, get = single
  `task.Task`) and `--repo` filtering are byte-identical.

## TUI trigger unified (`app/session_control.go`)

The run-now `r` key now routes through the `TriggerTask` RPC (was in-process
`daemon.RunTask`), so **CLI, TUI, and the cron scheduler all converge on one
daemon-owned firing path**.

## Sole-writer audit

Grepped the repo for `task.AddTask/UpdateTask/RemoveTask/saveTasks` call sites:

- Daemon scheduler/watcher writes stay — they **are** the daemon.
- CLI (`api/tasks.go`) — migrated to RPCs (this PR).
- **Remaining client-side TUI direct-writes:** the batched task CRUD in
  `app/app.go` (`saveContentPaneState`'s `UpdateTask`/`RemoveTask` and
  `handleTaskCreate`'s `AddTask`), which still write disk directly + poke reload.
  These are **safe** (cross-process `WithFileLock`, functionally correct) and are
  left as a **tracked follow-up** to avoid ballooning this PR's TUI
  save-flow/test surface, per the PR3 scope note. CLI + RPC + trigger-unification
  are done completely.

## Docs

`docs/cli-reference.md` now documents task ops as daemon-owned, with `list`/`get`
disk-fallback when no daemon is running.

## Tests

- **Daemon-side** (`daemon/task_rpc_test.go`): handler tests for
  List/Add/Update/Remove/Trigger — Add/Update/Remove persist AND re-arm the
  scheduler in one call; warm-up skips the reload but still writes; Trigger uses
  the shared `RunTask` firing path (proven via the shared `createSessionForTask`
  hook + recorded run status) and refuses watch/disabled tasks.
- **CLI** (`api/tasks_test.go`): injects the RPC client to cover list/get
  non-spawn + disk fallback, daemon-authoritative reads, and that
  add/update/remove/trigger dispatch to the RPC (replacing the now-obsolete
  eventual-consistency poke-failure test with a daemon-write-failure test).

## Verification

- `gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean ·
  `go build ./...` · `deadcode -test ./...` clean
- Full suite via `make test-container` — **all green**.

Refs #1029 (does not close — only the final PR closes the epic).

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
