### PR TITLE
feat(daemon): HTTP/JSON server mirroring client-facing RPCs over a unix socket (#1029) [PR 4/6]

### DIFF
--- a/api/output.go
+++ b/api/output.go
@@ -1,59 +1,29 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
 )
 
-// Envelope is the additive JSON wrapper shared by the CLI and the (later,
-// #1029 PR 4+) daemon-hosted HTTP server. A success carries the payload in Data
-// with Error nil; a failure carries a nil Data and a populated Error. Both
-// members always serialize (no omitempty) so consumers can branch on
-// `error === null` without a presence check:
-//
-//	success: {"data": <payload>, "error": null}
-//	failure: {"data": null, "error": {"message": "<msg>"}}
-//
-// It is NEW infrastructure: today's commands still emit the bare payload by
-// default, and the envelope is only produced on the explicit opt-in path
-// (the --json flag), so no existing command's stdout/stderr bytes change.
-type Envelope struct {
-	Data  any            `json:"data"`
-	Error *EnvelopeError `json:"error"`
+// The {data,error} JSON envelope shared by the CLI's opt-in --json output and
+// the daemon-hosted HTTP server (#1029 PR 4) lives in the neutral apiproto
+// package so both emit a byte-identical shape. These thin package-local wrappers
+// preserve the original call sites in this package while delegating to the
+// single canonical definition.
+
+func successEnvelope(data any) apiproto.Envelope {
+	return apiproto.Success(data)
 }
 
-// EnvelopeError is the error member of an Envelope. Message is a human-readable
-// description; the struct leaves room to grow additional fields (e.g. a machine
-// code) later without breaking the additive contract.
-type EnvelopeError struct {
-	Message string `json:"message"`
+func errorEnvelope(msg string) apiproto.Envelope {
+	return apiproto.Failure(msg)
 }
 
-// successEnvelope wraps a payload as a successful Envelope (Error nil).
-func successEnvelope(data any) Envelope {
-	return Envelope{Data: data, Error: nil}
-}
-
-// errorEnvelope wraps a message as a failed Envelope (Data nil).
-func errorEnvelope(msg string) Envelope {
-	return Envelope{Data: nil, Error: &EnvelopeError{Message: msg}}
-}
-
-// marshalIndented is the single JSON-encoding primitive the output helpers
-// share so bare and enveloped output format identically (two-space indent).
 func marshalIndented(v any) ([]byte, error) {
-	return json.MarshalIndent(v, "", "  ")
+	return apiproto.MarshalIndented(v)
 }
 
-// writeEnvelope encodes env and writes it, newline-terminated, to w. It is the
-// shared write path the opt-in --json output uses today and the HTTP server
-// will reuse, keeping the CLI and HTTP responses byte-for-byte consistent.
-func writeEnvelope(w io.Writer, env Envelope) error {
-	data, err := marshalIndented(env)
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Fprintln(w, string(data))
-	return err
+func writeEnvelope(w io.Writer, env apiproto.Envelope) error {
+	return apiproto.WriteEnvelope(w, env)
 }

--- a/apiproto/envelope.go
+++ b/apiproto/envelope.go
@@ -1,0 +1,68 @@
+// Package apiproto holds the neutral JSON wire types shared by the `af` CLI
+// (api/) and the daemon-hosted HTTP server (daemon/). It deliberately depends on
+// neither: api/ imports daemon/ for its RPC client wrappers, so the daemon
+// cannot import api/, and both instead import this leaf package. Keeping the
+// Envelope definition here — rather than duplicated in each — is what guarantees
+// the CLI's `--json` output and the HTTP server's responses stay byte-for-byte
+// identical (#1029 PR 4).
+package apiproto
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// Envelope is the additive JSON wrapper shared by the CLI and the daemon-hosted
+// HTTP server. A success carries the payload in Data with Error nil; a failure
+// carries a nil Data and a populated Error. Both members always serialize (no
+// omitempty) so consumers can branch on `error === null` without a presence
+// check:
+//
+//	success: {"data": <payload>, "error": null}
+//	failure: {"data": null, "error": {"message": "<msg>"}}
+//
+// On the CLI it is NEW infrastructure: today's commands still emit the bare
+// payload by default, and the envelope is only produced on the explicit opt-in
+// path (the --json flag), so no existing command's stdout/stderr bytes change.
+// The HTTP server always emits it.
+type Envelope struct {
+	Data  any            `json:"data"`
+	Error *EnvelopeError `json:"error"`
+}
+
+// EnvelopeError is the error member of an Envelope. Message is a human-readable
+// description; the struct leaves room to grow additional fields (e.g. a machine
+// code) later without breaking the additive contract.
+type EnvelopeError struct {
+	Message string `json:"message"`
+}
+
+// Success wraps a payload as a successful Envelope (Error nil).
+func Success(data any) Envelope {
+	return Envelope{Data: data, Error: nil}
+}
+
+// Failure wraps a message as a failed Envelope (Data nil).
+func Failure(msg string) Envelope {
+	return Envelope{Data: nil, Error: &EnvelopeError{Message: msg}}
+}
+
+// MarshalIndented is the single JSON-encoding primitive the CLI and HTTP output
+// paths share so bare and enveloped output format identically (two-space
+// indent).
+func MarshalIndented(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}
+
+// WriteEnvelope encodes env and writes it, newline-terminated, to w. It is the
+// shared write path the CLI's opt-in --json output and the daemon HTTP server
+// both reuse, keeping their responses byte-for-byte consistent.
+func WriteEnvelope(w io.Writer, env Envelope) error {
+	data, err := MarshalIndented(env)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}

--- a/apiproto/envelope_test.go
+++ b/apiproto/envelope_test.go
@@ -1,0 +1,29 @@
+package apiproto
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests lock the EXACT wire bytes of the shared envelope. Both the `af`
+// CLI (--json) and the daemon HTTP server encode through WriteEnvelope, so
+// pinning the shape here guarantees the two surfaces stay identical: a change
+// that would drift the HTTP body from the CLI output breaks this test.
+
+func TestWriteEnvelope_SuccessExactBytes(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteEnvelope(&buf, Success(map[string]bool{"ok": true})))
+	require.Equal(t,
+		"{\n  \"data\": {\n    \"ok\": true\n  },\n  \"error\": null\n}\n",
+		buf.String())
+}
+
+func TestWriteEnvelope_FailureExactBytes(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteEnvelope(&buf, Failure("boom")))
+	require.Equal(t,
+		"{\n  \"data\": null,\n  \"error\": {\n    \"message\": \"boom\"\n  }\n}\n",
+		buf.String())
+}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -26,8 +26,12 @@ import (
 const (
 	controlServiceName   = "Control"
 	daemonSocketFileName = "daemon.sock"
-	daemonReadyTimeout   = 5 * time.Second
-	daemonDialTimeout    = 250 * time.Millisecond
+	// daemonHTTPSocketFileName is the Unix socket the daemon-hosted HTTP/JSON
+	// server (#1029 PR 4) listens on, alongside — never multiplexed onto — the
+	// gob net/rpc control socket above. One listener, one protocol.
+	daemonHTTPSocketFileName = "daemon-http.sock"
+	daemonReadyTimeout       = 5 * time.Second
+	daemonDialTimeout        = 250 * time.Millisecond
 	// shutdownAckGrace delays the daemon main-loop teardown after a Shutdown
 	// RPC handler returns so the response can flush back to the caller before
 	// the listener closes.
@@ -53,19 +57,24 @@ var nowFunc = time.Now
 
 // CreateSessionRequest is the daemon-owned session creation contract used by
 // the TUI, CLI, and scheduled task runner.
+//
+// The json tags on this and the other RPC request/response structs are for the
+// daemon-hosted HTTP server (#1029 PR 4): they define the HTTP JSON body shape.
+// The existing net/rpc control socket is unaffected — gob encoding ignores json
+// tags entirely and keys off the Go field names.
 type CreateSessionRequest struct {
-	Title     string
-	TitleBase string
-	RepoPath  string
-	Program   string
-	Prompt    string
-	AutoYes   bool
+	Title     string `json:"title"`
+	TitleBase string `json:"title_base"`
+	RepoPath  string `json:"repo_path"`
+	Program   string `json:"program"`
+	Prompt    string `json:"prompt"`
+	AutoYes   bool   `json:"auto_yes"`
 	// InPlace attaches the session to the repo's existing working tree at its
 	// current branch (`af sessions create --here`) instead of creating a new
 	// git worktree+branch; kill/cleanup leaves the user's tree and branch
 	// intact. Incompatible with ForceRemote.
-	InPlace     bool
-	ForceRemote bool
+	InPlace     bool `json:"in_place"`
+	ForceRemote bool `json:"force_remote"`
 
 	// allowReserved lets the daemon's own root-agent ensure loop (#1106)
 	// create the reserved "root" title that reserveCreate rejects for
@@ -76,54 +85,54 @@ type CreateSessionRequest struct {
 }
 
 type CreateSessionResponse struct {
-	Instance session.InstanceData
+	Instance session.InstanceData `json:"instance"`
 }
 
 type KillSessionRequest struct {
-	Title  string
-	RepoID string
+	Title  string `json:"title"`
+	RepoID string `json:"repo_id"`
 }
 
 type KillSessionResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 // ArchiveSessionRequest asks the daemon to archive a session (#1028): tear down
 // its tmux, relocate its worktree to the global archive dir, and mark it
 // Archived while preserving the record.
 type ArchiveSessionRequest struct {
-	Title  string
-	RepoID string
+	Title  string `json:"title"`
+	RepoID string `json:"repo_id"`
 }
 
 type ArchiveSessionResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 	// ArchivedPath is the new on-disk location of the relocated worktree.
-	ArchivedPath string
+	ArchivedPath string `json:"archived_path"`
 }
 
 // RestoreArchivedRequest asks the daemon to restore an archived session (#1028):
 // move its worktree back next to the repo, re-spawn the agent, and mark it
 // Running.
 type RestoreArchivedRequest struct {
-	Title  string
-	RepoID string
+	Title  string `json:"title"`
+	RepoID string `json:"repo_id"`
 }
 
 type RestoreArchivedResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 	// WorktreePath is the on-disk location the worktree was restored to.
-	WorktreePath string
+	WorktreePath string `json:"worktree_path"`
 }
 
 type SendPromptRequest struct {
-	Title  string
-	RepoID string
-	Prompt string
+	Title  string `json:"title"`
+	RepoID string `json:"repo_id"`
+	Prompt string `json:"prompt"`
 }
 
 type SendPromptResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 // DeliverPromptRequest asks the daemon to deliver a prompt to a target session,
@@ -133,11 +142,11 @@ type SendPromptResponse struct {
 // target ran concurrently (#865). RepoPath (not RepoID) is required because a
 // create needs the worktree root; the repo ID is resolved from it.
 type DeliverPromptRequest struct {
-	Title    string
-	RepoPath string
-	Program  string
-	Prompt   string
-	AutoYes  bool
+	Title    string `json:"title"`
+	RepoPath string `json:"repo_path"`
+	Program  string `json:"program"`
+	Prompt   string `json:"prompt"`
+	AutoYes  bool   `json:"auto_yes"`
 }
 
 // DeliverPromptResponse reports how the prompt was delivered. Status is
@@ -145,7 +154,7 @@ type DeliverPromptRequest struct {
 // initial prompt) and "sent" when it was sent into a session that already
 // existed — the same status vocabulary deliverTaskPrompt records on a task.
 type DeliverPromptResponse struct {
-	Status string
+	Status string `json:"status"`
 }
 
 // CreateTabRequest asks the daemon to spawn a tab in the target session's
@@ -163,15 +172,15 @@ type DeliverPromptResponse struct {
 //
 // Either way the resolved, collision-suffixed name is returned.
 type CreateTabRequest struct {
-	Title   string
-	RepoID  string
-	Command string
-	Name    string
-	Shell   bool
+	Title   string `json:"title"`
+	RepoID  string `json:"repo_id"`
+	Command string `json:"command"`
+	Name    string `json:"name"`
+	Shell   bool   `json:"shell"`
 }
 
 type CreateTabResponse struct {
-	Name string
+	Name string `json:"name"`
 }
 
 // CloseTabRequest asks the daemon to close a non-agent tab of a session and
@@ -183,14 +192,14 @@ type CreateTabResponse struct {
 // are fixed by their hook config, so closing them is refused. This mirrors the
 // TUI's `w` rule (handleCloseTab) and #930 PR 4/PR 6 semantics.
 type CloseTabRequest struct {
-	Title    string
-	RepoID   string
-	TabName  string
-	TabIndex int
+	Title    string `json:"title"`
+	RepoID   string `json:"repo_id"`
+	TabName  string `json:"tab_name"`
+	TabIndex int    `json:"tab_index"`
 }
 
 type CloseTabResponse struct {
-	Name string
+	Name string `json:"name"`
 }
 
 // SetPRInfoRequest records (or clears) the GitHub PR info for a session and
@@ -201,13 +210,13 @@ type CloseTabResponse struct {
 // today via prInfoUpdatedMsg + a full-list save (#921); PR 1 only adds the
 // mutation — the TUI is not switched to it until PR 2.
 type SetPRInfoRequest struct {
-	Title  string
-	RepoID string
-	PRInfo session.PRInfoData
+	Title  string             `json:"title"`
+	RepoID string             `json:"repo_id"`
+	PRInfo session.PRInfoData `json:"pr_info"`
 }
 
 type SetPRInfoResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 // PauseStatusPollRequest asks the daemon to pause its per-instance capture-pane
@@ -219,24 +228,24 @@ type SetPRInfoResponse struct {
 // instance for an unbounded time. The TUI renews the lease with a heartbeat
 // while attached and clears it with ResumeStatusPoll on detach.
 type PauseStatusPollRequest struct {
-	Title  string
-	RepoID string
+	Title  string `json:"title"`
+	RepoID string `json:"repo_id"`
 }
 
 type PauseStatusPollResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 // ResumeStatusPollRequest clears a pause set by PauseStatusPoll so the daemon's
 // poll resumes immediately on a clean detach rather than waiting out the lease
 // (#1160).
 type ResumeStatusPollRequest struct {
-	Title  string
-	RepoID string
+	Title  string `json:"title"`
+	RepoID string `json:"repo_id"`
 }
 
 type ResumeStatusPollResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 // SnapshotRequest asks the daemon for the authoritative session list of a repo
@@ -245,29 +254,29 @@ type ResumeStatusPollResponse struct {
 // in-memory instance map is the source of truth, so the TUI mirrors this
 // projection instead of re-reading instances.json off disk.
 type SnapshotRequest struct {
-	RepoID string
+	RepoID string `json:"repo_id"`
 }
 
 type SnapshotResponse struct {
-	Instances []session.InstanceData
+	Instances []session.InstanceData `json:"instances"`
 }
 
 type ImportRemoteHookSessionsRequest struct {
-	RepoPath string
+	RepoPath string `json:"repo_path"`
 }
 
 type ImportRemoteHookSessionsResponse struct {
-	Instances []session.InstanceData
+	Instances []session.InstanceData `json:"instances"`
 }
 
 type PingRequest struct{}
 type PingResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 type ReloadTasksRequest struct{}
 type ReloadTasksResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 // Task CRUD RPCs (#1029 PR 3). They promote task writes to the daemon so it is
@@ -284,17 +293,17 @@ type ReloadTasksResponse struct {
 // of Snapshot for sessions.
 type ListTasksRequest struct{}
 type ListTasksResponse struct {
-	Tasks []task.Task
+	Tasks []task.Task `json:"tasks"`
 }
 
 // AddTaskRequest carries a fully-populated task.Task to append. The CLI/TUI
 // still build and validate the struct (flag parsing, ID generation, program
 // resolution); the daemon re-validates via task.AddTask and owns the write.
 type AddTaskRequest struct {
-	Task task.Task
+	Task task.Task `json:"task"`
 }
 type AddTaskResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 // UpdateTaskRequest carries the edited task.Task to persist. task.UpdateTask
@@ -302,17 +311,17 @@ type AddTaskResponse struct {
 // the freshly-loaded record under the file lock, so a stale client copy never
 // clobbers them.
 type UpdateTaskRequest struct {
-	Task task.Task
+	Task task.Task `json:"task"`
 }
 type UpdateTaskResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 type RemoveTaskRequest struct {
-	ID string
+	ID string `json:"id"`
 }
 type RemoveTaskResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 // TriggerTaskRequest asks the daemon to fire a task NOW through the same
@@ -320,15 +329,15 @@ type RemoveTaskResponse struct {
 // fix). The handler preserves RunTask's guards: watch tasks and disabled tasks
 // are refused.
 type TriggerTaskRequest struct {
-	ID string
+	ID string `json:"id"`
 }
 type TriggerTaskResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 type ShutdownRequest struct{}
 type ShutdownResponse struct {
-	OK bool
+	OK bool `json:"ok"`
 }
 
 // daemonStartingErrText is the wire-visible text of the warm-up error. net/rpc

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -79,6 +79,22 @@ func RunDaemon(cfg *config.Config) error {
 		}
 	}()
 
+	// Start the HTTP/JSON mirror alongside the control socket (#1029 PR 4). It
+	// shares this daemon's live manager, so HTTP is just another thin client of
+	// the same core. Only the winner of bindControlServerExclusive reaches this
+	// point, so no extra spawn race applies. A bind failure is logged but never
+	// fatal: HTTP is auxiliary — the gob control plane every existing client
+	// depends on must not regress if the HTTP socket cannot bind.
+	if closeHTTP, err := startHTTPServer(manager, scheduler, watchers); err != nil {
+		log.WarningLog.Printf("failed to start daemon HTTP server: %v", err)
+	} else {
+		defer func() {
+			if err := closeHTTP(); err != nil {
+				log.WarningLog.Printf("failed to close daemon HTTP server: %v", err)
+			}
+		}()
+	}
+
 	// Write our PID as soon as the socket is bound so `af upgrade`'s SIGTERM
 	// fallback (#504) and StopDaemon can find a still-warming daemon. Both
 	// the SIGTERM and Shutdown-RPC exit paths fall through to the deferred

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -1,0 +1,230 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// The daemon-hosted HTTP/JSON server (#1029 PR 4) makes HTTP just another thin
+// client of the same daemon core the net/rpc control socket already exposes
+// (#960). It runs INSIDE the daemon, holds the *Manager directly through a
+// controlServer, and every route is a uniform 1:1 mirror of an RPC:
+//
+//	POST /v1/<Method>   JSON body = the RPC request struct
+//	                    response  = the shared {data,error} envelope wrapping
+//	                                the RPC response struct
+//	GET  /v1/health     liveness alias for Ping
+//
+// Each route decodes the request body into the EXACT SAME request struct the
+// net/rpc handler uses and calls the SAME (*controlServer) method — there is no
+// forked logic, so HTTP and RPC can never drift by construction. The response is
+// encoded through apiproto.WriteEnvelope, the identical primitive the CLI's
+// --json path uses, so the two surfaces are byte-for-byte consistent.
+//
+// Transport is a dedicated Unix socket (daemon-http.sock) with 0600 perms —
+// filesystem permissions are the authentication; there is no TCP port and no
+// token (#1029 locked decisions).
+
+// maxHTTPBodyBytes caps a request body so a client cannot exhaust daemon memory.
+// 16 MiB comfortably fits any realistic prompt or task payload.
+const maxHTTPBodyBytes = 16 << 20
+
+// httpReadHeaderTimeout bounds how long the server waits for request headers,
+// closing the Slowloris hold-open window (gosec G112). The socket is local and
+// 0600, but a defensive default costs nothing.
+const httpReadHeaderTimeout = 10 * time.Second
+
+// DaemonHTTPSocketPath returns the path of the daemon's HTTP/JSON Unix socket.
+func DaemonHTTPSocketPath() (string, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, daemonHTTPSocketFileName), nil
+}
+
+// startHTTPServer binds the HTTP/JSON server on its own Unix socket and serves
+// it in the background, returning a cleanup function that shuts the server down
+// and unlinks the socket. It shares the daemon's live *Manager (via a
+// controlServer built the same way startControlServer builds its own), so both
+// transports dispatch through one core. The Shutdown RPC is deliberately NOT
+// wired here (shutdownCh nil): HTTP mirrors only the client-facing surface, not
+// daemon lifecycle control.
+func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watcherSupervisor) (func() error, error) {
+	socketPath, err := DaemonHTTPSocketPath()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0755); err != nil {
+		return nil, err
+	}
+	_ = os.Remove(socketPath)
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(socketPath, 0600); err != nil {
+		_ = listener.Close()
+		return nil, err
+	}
+
+	cs := &controlServer{manager: manager, scheduler: scheduler, watchers: watchers}
+	srv := &http.Server{
+		Handler:           newHTTPMux(cs),
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+	}
+
+	go func() {
+		// Serve returns ErrServerClosed on a clean Close/Shutdown; anything else
+		// is worth logging (the listener died unexpectedly).
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			log.WarningLog.Printf("daemon HTTP server stopped: %v", err)
+		}
+	}()
+
+	return func() error {
+		// Close stops the listener (which unlinks the Unix socket file, net's
+		// default for a listener it created) and terminates active connections.
+		// Deliberately no explicit os.Remove: mirrors startControlServer's
+		// #718/#767 reasoning — a Remove could race a freshly bound socket.
+		return srv.Close()
+	}, nil
+}
+
+// newHTTPMux builds the route table. Every client-facing RPC gets a
+// POST /v1/<Method> route that dispatches to the matching controlServer method;
+// GET /v1/health is a liveness alias for Ping. Pure-infra RPCs (Shutdown,
+// Pause/ResumeStatusPoll, ReloadTasks, and bare Ping) are intentionally absent —
+// the HTTP surface mirrors only client-facing session and task ops.
+func newHTTPMux(cs *controlServer) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// Sessions.
+	mux.HandleFunc("/v1/CreateSession", rpcHandler(cs.CreateSession))
+	mux.HandleFunc("/v1/Snapshot", rpcHandler(cs.Snapshot))
+	mux.HandleFunc("/v1/KillSession", rpcHandler(cs.KillSession))
+	mux.HandleFunc("/v1/ArchiveSession", rpcHandler(cs.ArchiveSession))
+	mux.HandleFunc("/v1/RestoreArchived", rpcHandler(cs.RestoreArchived))
+	mux.HandleFunc("/v1/SendPrompt", rpcHandler(cs.SendPrompt))
+	mux.HandleFunc("/v1/DeliverPrompt", rpcHandler(cs.DeliverPrompt))
+	mux.HandleFunc("/v1/CreateTab", rpcHandler(cs.CreateTab))
+	mux.HandleFunc("/v1/CloseTab", rpcHandler(cs.CloseTab))
+	mux.HandleFunc("/v1/SetPRInfo", rpcHandler(cs.SetPRInfo))
+	mux.HandleFunc("/v1/ImportRemoteHookSessions", rpcHandler(cs.ImportRemoteHookSessions))
+
+	// Tasks.
+	mux.HandleFunc("/v1/ListTasks", rpcHandler(cs.ListTasks))
+	mux.HandleFunc("/v1/AddTask", rpcHandler(cs.AddTask))
+	mux.HandleFunc("/v1/UpdateTask", rpcHandler(cs.UpdateTask))
+	mux.HandleFunc("/v1/RemoveTask", rpcHandler(cs.RemoveTask))
+	mux.HandleFunc("/v1/TriggerTask", rpcHandler(cs.TriggerTask))
+
+	// Liveness. GET-only alias for the Ping RPC.
+	mux.HandleFunc("/v1/health", healthHandler(cs))
+
+	// Catch-all: any other path is an unknown route → 404 with the envelope.
+	// ServeMux routes the longest prefix match, so a real route above always
+	// wins and only genuinely-unknown paths (e.g. /v1/Nope, /) land here.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		writeHTTPError(w, http.StatusNotFound, fmt.Errorf("unknown route %q", r.URL.Path))
+	})
+
+	return mux
+}
+
+// rpcHandler adapts a controlServer method — the same one net/rpc dispatches —
+// into an HTTP handler. It enforces POST, decodes the JSON body into the RPC
+// request struct, calls the method, and encodes the response struct in the
+// shared envelope. Status mapping (kept pragmatic, documented here):
+//
+//	200 — success: {"data": <resp>, "error": null}
+//	400 — malformed / unreadable JSON request body
+//	405 — wrong HTTP verb (not POST)
+//	500 — the handler (validation or execution) returned an error
+//
+// 404 for unknown routes is handled by the mux's catch-all, not here.
+func rpcHandler[Req any, Resp any](call func(Req, *Resp) error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeHTTPError(w, http.StatusMethodNotAllowed,
+				fmt.Errorf("method %s not allowed; use POST", r.Method))
+			return
+		}
+		var req Req
+		if err := decodeHTTPRequest(r, &req); err != nil {
+			writeHTTPError(w, http.StatusBadRequest, err)
+			return
+		}
+		var resp Resp
+		if err := call(req, &resp); err != nil {
+			writeHTTPError(w, http.StatusInternalServerError, err)
+			return
+		}
+		writeHTTPSuccess(w, resp)
+	}
+}
+
+// healthHandler answers GET /v1/health by calling Ping, giving a trivial
+// liveness probe (curl the socket, look for {"data":{"ok":true},"error":null}).
+func healthHandler(cs *controlServer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeHTTPError(w, http.StatusMethodNotAllowed,
+				fmt.Errorf("method %s not allowed; use GET", r.Method))
+			return
+		}
+		var resp PingResponse
+		_ = cs.Ping(PingRequest{}, &resp)
+		writeHTTPSuccess(w, resp)
+	}
+}
+
+// decodeHTTPRequest reads the (size-capped) body and unmarshals it into dst. An
+// empty body is treated as a zero-value request so no-argument RPCs (ListTasks,
+// an all-repo Snapshot, health) work with `curl -d ”` or no body at all.
+func decodeHTTPRequest(r *http.Request, dst any) error {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxHTTPBodyBytes))
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, dst); err != nil {
+		return fmt.Errorf("malformed JSON request body: %w", err)
+	}
+	return nil
+}
+
+// writeHTTPSuccess encodes data in a success envelope with a 200.
+func writeHTTPSuccess(w http.ResponseWriter, data any) {
+	writeHTTPEnvelope(w, http.StatusOK, apiproto.Success(data))
+}
+
+// writeHTTPError encodes err in a failure envelope with the given status. The
+// envelope body is always returned on error, never a bare status.
+func writeHTTPError(w http.ResponseWriter, status int, err error) {
+	writeHTTPEnvelope(w, status, apiproto.Failure(err.Error()))
+}
+
+// writeHTTPEnvelope is the single write path for both success and failure so the
+// Content-Type, status, and byte-identical envelope shape stay uniform.
+func writeHTTPEnvelope(w http.ResponseWriter, status int, env apiproto.Envelope) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := apiproto.WriteEnvelope(w, env); err != nil {
+		log.WarningLog.Printf("failed to write HTTP response envelope: %v", err)
+	}
+}

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -37,8 +38,10 @@ import (
 // token (#1029 locked decisions).
 
 // maxHTTPBodyBytes caps a request body so a client cannot exhaust daemon memory.
-// 16 MiB comfortably fits any realistic prompt or task payload.
-const maxHTTPBodyBytes = 16 << 20
+// 16 MiB comfortably fits any realistic prompt or task payload. It is enforced
+// via http.MaxBytesReader, which REJECTS an oversize body (→ 413) rather than
+// silently truncating it. var, not const, so tests can shrink it.
+var maxHTTPBodyBytes int64 = 16 << 20
 
 // httpReadHeaderTimeout bounds how long the server waits for request headers,
 // closing the Slowloris hold-open window (gosec G112). The socket is local and
@@ -152,9 +155,12 @@ func newHTTPMux(cs *controlServer) *http.ServeMux {
 //	200 — success: {"data": <resp>, "error": null}
 //	400 — malformed / unreadable JSON request body
 //	405 — wrong HTTP verb (not POST)
+//	413 — request body exceeds maxHTTPBodyBytes
 //	500 — the handler (validation or execution) returned an error
 //
-// 404 for unknown routes is handled by the mux's catch-all, not here.
+// 404 for unknown routes is handled by the mux's catch-all, not here. A rejected
+// body (400 or 413) short-circuits before the manager call, so an oversize or
+// malformed request is never dispatched.
 func rpcHandler[Req any, Resp any](call func(Req, *Resp) error) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -163,8 +169,15 @@ func rpcHandler[Req any, Resp any](call func(Req, *Resp) error) http.HandlerFunc
 			return
 		}
 		var req Req
-		if err := decodeHTTPRequest(r, &req); err != nil {
-			writeHTTPError(w, http.StatusBadRequest, err)
+		if err := decodeHTTPRequest(w, r, &req); err != nil {
+			// An oversize body (MaxBytesReader tripped) is a distinct 413;
+			// everything else is ordinary malformed input → 400.
+			status := http.StatusBadRequest
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				status = http.StatusRequestEntityTooLarge
+			}
+			writeHTTPError(w, status, err)
 			return
 		}
 		var resp Resp
@@ -191,12 +204,21 @@ func healthHandler(cs *controlServer) http.HandlerFunc {
 	}
 }
 
-// decodeHTTPRequest reads the (size-capped) body and unmarshals it into dst. An
+// decodeHTTPRequest reads the size-capped body and unmarshals it into dst. An
 // empty body is treated as a zero-value request so no-argument RPCs (ListTasks,
 // an all-repo Snapshot, health) work with `curl -d ”` or no body at all.
-func decodeHTTPRequest(r *http.Request, dst any) error {
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxHTTPBodyBytes))
+//
+// The cap is enforced with http.MaxBytesReader (NOT io.LimitReader): once the
+// body exceeds maxHTTPBodyBytes the read fails with an *http.MaxBytesError, so an
+// oversize request is REJECTED, never truncated-then-accepted. The error is
+// returned wrapped (chain preserved) so the caller can errors.As it to a 413.
+func decodeHTTPRequest(w http.ResponseWriter, r *http.Request, dst any) error {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxHTTPBodyBytes))
 	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			return fmt.Errorf("request body exceeds %d-byte limit: %w", maxHTTPBodyBytes, err)
+		}
 		return fmt.Errorf("failed to read request body: %w", err)
 	}
 	if len(bytes.TrimSpace(body)) == 0 {

--- a/daemon/httpserver_test.go
+++ b/daemon/httpserver_test.go
@@ -141,6 +141,59 @@ func TestHTTP_MalformedJSON_400(t *testing.T) {
 	assert.Contains(t, env.Error.Message, "malformed JSON")
 }
 
+// TestHTTP_OversizeBody_413_NotDispatched covers the body-over-limit → 413
+// mapping AND proves the oversize request is REJECTED, never
+// truncated-then-dispatched: with a well-formed AddTask body that exceeds the
+// (shrunk) cap, nothing is persisted and the scheduler is untouched — the
+// manager was never reached.
+func TestHTTP_OversizeBody_413_NotDispatched(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	orig := maxHTTPBodyBytes
+	maxHTTPBodyBytes = 64
+	t.Cleanup(func() { maxHTTPBodyBytes = orig })
+
+	cs := &controlServer{scheduler: newTaskScheduler()}
+	body, err := json.Marshal(AddTaskRequest{Task: enabledCronTask("ffff1001", "")})
+	require.NoError(t, err)
+	require.Greater(t, int64(len(body)), maxHTTPBodyBytes,
+		"body must exceed the cap for this test to exercise 413")
+
+	rec := doHTTP(cs, http.MethodPost, "/v1/AddTask", string(body))
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+
+	env := decodeEnvelope(t, rec)
+	require.Nil(t, env.Data)
+	require.NotNil(t, env.Error)
+
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.Empty(t, tasks, "oversize request must be rejected before the manager write")
+	require.Empty(t, cs.scheduler.scheduledTaskIDs(),
+		"oversize request must not re-arm the scheduler")
+}
+
+// TestHTTP_BodyUnderLimit_Succeeds covers the boundary from the other side: a
+// body that fits under the cap still decodes and dispatches normally.
+func TestHTTP_BodyUnderLimit_Succeeds(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	cs := &controlServer{scheduler: newTaskScheduler()}
+	body, err := json.Marshal(AddTaskRequest{Task: enabledCronTask("ffff2001", "")})
+	require.NoError(t, err)
+
+	orig := maxHTTPBodyBytes
+	maxHTTPBodyBytes = int64(len(body)) + 16 // comfortably above the body
+	t.Cleanup(func() { maxHTTPBodyBytes = orig })
+
+	rec := doHTTP(cs, http.MethodPost, "/v1/AddTask", string(body))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Nil(t, decodeEnvelope(t, rec).Error)
+
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "ffff2001", tasks[0].ID)
+}
+
 // TestHTTP_UnknownRoute_404 covers the unknown-route → 404 mapping via the mux
 // catch-all, still returning the envelope body.
 func TestHTTP_UnknownRoute_404(t *testing.T) {

--- a/daemon/httpserver_test.go
+++ b/daemon/httpserver_test.go
@@ -1,0 +1,281 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/task"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The daemon HTTP/JSON server (#1029 PR 4) is a 1:1 mirror of the client-facing
+// RPCs: each route decodes the SAME request struct and calls the SAME
+// controlServer method the net/rpc handler calls, then encodes the response in
+// the shared {data,error} envelope. These tests drive the mux directly (no
+// socket bound) since the mux is the whole surface under test.
+
+// doHTTP dispatches one request through the daemon HTTP mux.
+func doHTTP(cs *controlServer, method, path, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	newHTTPMux(cs).ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeEnvelope(t *testing.T, rec *httptest.ResponseRecorder) apiproto.Envelope {
+	t.Helper()
+	var env apiproto.Envelope
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
+	return env
+}
+
+// dataInto re-marshals the envelope's Data member into a typed response struct.
+func dataInto(t *testing.T, env apiproto.Envelope, dst any) {
+	t.Helper()
+	raw, err := json.Marshal(env.Data)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, dst))
+}
+
+// TestHTTP_ListTasks_ReadRoute covers a read route: POST /v1/ListTasks returns
+// 200 with the task list read from disk, wrapped in the success envelope.
+func TestHTTP_ListTasks_ReadRoute(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	require.NoError(t, task.AddTask(enabledCronTask("aaaa1001", "")))
+	require.NoError(t, task.AddTask(enabledCronTask("aaaa1002", "")))
+
+	rec := doHTTP(&controlServer{}, http.MethodPost, "/v1/ListTasks", `{}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	env := decodeEnvelope(t, rec)
+	require.Nil(t, env.Error)
+	var resp ListTasksResponse
+	dataInto(t, env, &resp)
+	require.Len(t, resp.Tasks, 2)
+	assert.ElementsMatch(t, []string{"aaaa1001", "aaaa1002"},
+		[]string{resp.Tasks[0].ID, resp.Tasks[1].ID})
+}
+
+// TestHTTP_Snapshot_ReadRoute covers the sessions read route against a ready
+// manager: an all-repo Snapshot with no sessions returns an empty list.
+func TestHTTP_Snapshot_ReadRoute(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	m, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+
+	rec := doHTTP(&controlServer{manager: m}, http.MethodPost, "/v1/Snapshot", `{"repo_id":""}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	env := decodeEnvelope(t, rec)
+	require.Nil(t, env.Error)
+	var resp SnapshotResponse
+	dataInto(t, env, &resp)
+	require.Empty(t, resp.Instances)
+}
+
+// TestHTTP_AddTask_MutationRoute covers a create/mutation route: POST /v1/AddTask
+// persists the task through the shared core and re-arms the scheduler.
+func TestHTTP_AddTask_MutationRoute(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	cs := &controlServer{scheduler: newTaskScheduler()}
+
+	body, err := json.Marshal(AddTaskRequest{Task: enabledCronTask("bbbb1001", "")})
+	require.NoError(t, err)
+	rec := doHTTP(cs, http.MethodPost, "/v1/AddTask", string(body))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	env := decodeEnvelope(t, rec)
+	require.Nil(t, env.Error)
+	var resp AddTaskResponse
+	dataInto(t, env, &resp)
+	assert.True(t, resp.OK)
+
+	tasks, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1, "AddTask route must persist through the shared daemon core")
+	assert.Equal(t, "bbbb1001", tasks[0].ID)
+	assert.Contains(t, cs.scheduler.scheduledTaskIDs(), "bbbb1001",
+		"AddTask route must re-arm the scheduler like the RPC handler")
+}
+
+// TestHTTP_TriggerTask_HandlerError covers the TriggerTask mutation route and the
+// handler-error → 500 mapping: RunTask refuses a disabled task, and the envelope
+// still carries the error message.
+func TestHTTP_TriggerTask_HandlerError(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	disabled := enabledCronTask("cccc1001", "")
+	disabled.Enabled = false
+	require.NoError(t, task.AddTask(disabled))
+
+	rec := doHTTP(&controlServer{}, http.MethodPost, "/v1/TriggerTask", `{"id":"cccc1001"}`)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	env := decodeEnvelope(t, rec)
+	require.Nil(t, env.Data)
+	require.NotNil(t, env.Error)
+	assert.Contains(t, env.Error.Message, "disabled")
+}
+
+// TestHTTP_MalformedJSON_400 covers the malformed-body → 400 mapping.
+func TestHTTP_MalformedJSON_400(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	rec := doHTTP(&controlServer{scheduler: newTaskScheduler()}, http.MethodPost, "/v1/AddTask", `{not json`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	env := decodeEnvelope(t, rec)
+	require.Nil(t, env.Data)
+	require.NotNil(t, env.Error)
+	assert.Contains(t, env.Error.Message, "malformed JSON")
+}
+
+// TestHTTP_UnknownRoute_404 covers the unknown-route → 404 mapping via the mux
+// catch-all, still returning the envelope body.
+func TestHTTP_UnknownRoute_404(t *testing.T) {
+	rec := doHTTP(&controlServer{}, http.MethodPost, "/v1/NoSuchMethod", `{}`)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	env := decodeEnvelope(t, rec)
+	require.Nil(t, env.Data)
+	require.NotNil(t, env.Error)
+}
+
+// TestHTTP_WrongVerb_405 covers the wrong-verb → 405 mapping: RPC routes are
+// POST-only, health is GET-only.
+func TestHTTP_WrongVerb_405(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	rec := doHTTP(&controlServer{}, http.MethodGet, "/v1/ListTasks", "")
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.NotNil(t, decodeEnvelope(t, rec).Error)
+
+	rec = doHTTP(&controlServer{}, http.MethodPost, "/v1/health", `{}`)
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.NotNil(t, decodeEnvelope(t, rec).Error)
+}
+
+// TestHTTP_Health covers GET /v1/health mapping to Ping.
+func TestHTTP_Health(t *testing.T) {
+	rec := doHTTP(&controlServer{}, http.MethodGet, "/v1/health", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	env := decodeEnvelope(t, rec)
+	require.Nil(t, env.Error)
+	var resp PingResponse
+	dataInto(t, env, &resp)
+	assert.True(t, resp.OK)
+}
+
+// TestHTTP_SharedCore_MatchesRPCTwin is the shared-core proof: the HTTP route and
+// the net/rpc handler (the controlServer method called directly) return
+// equivalent results because they ARE the same method.
+func TestHTTP_SharedCore_MatchesRPCTwin(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	require.NoError(t, task.AddTask(enabledCronTask("dddd1001", "")))
+	require.NoError(t, task.AddTask(enabledCronTask("dddd1002", "")))
+	cs := &controlServer{}
+
+	// net/rpc twin: invoke the method the way rpc.ServeConn would.
+	var rpcResp ListTasksResponse
+	require.NoError(t, cs.ListTasks(ListTasksRequest{}, &rpcResp))
+
+	// HTTP path: same method, wrapped in the envelope.
+	rec := doHTTP(cs, http.MethodPost, "/v1/ListTasks", `{}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var httpResp ListTasksResponse
+	dataInto(t, decodeEnvelope(t, rec), &httpResp)
+
+	require.Equal(t, rpcResp, httpResp,
+		"HTTP route and net/rpc twin must produce equivalent results (one shared core)")
+}
+
+// TestHTTP_UnixSocket_EndToEnd drives the real transport: startHTTPServer binds
+// the 0600 Unix socket, and a net/http client dialing that socket reaches the
+// health and ListTasks routes — the `curl --unix-socket` path from the PR. It
+// also asserts the socket is torn down on close.
+func TestHTTP_UnixSocket_EndToEnd(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	m, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, task.AddTask(enabledCronTask("eeee1001", "")))
+
+	closeHTTP, err := startHTTPServer(m, newTaskScheduler(), nil)
+	require.NoError(t, err)
+
+	sockPath, err := DaemonHTTPSocketPath()
+	require.NoError(t, err)
+
+	// 0600 is the authentication: no group/other access to the socket.
+	info, err := os.Stat(sockPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+		},
+	}}
+
+	getEnvelope := func(resp *http.Response) apiproto.Envelope {
+		t.Helper()
+		defer func() { _ = resp.Body.Close() }()
+		body, readErr := io.ReadAll(resp.Body)
+		require.NoError(t, readErr)
+		var env apiproto.Envelope
+		require.NoError(t, json.Unmarshal(body, &env))
+		return env
+	}
+
+	// GET /v1/health over the socket.
+	resp, err := client.Get("http://af/v1/health")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Nil(t, getEnvelope(resp).Error)
+
+	// POST /v1/ListTasks over the socket returns the persisted task.
+	resp, err = client.Post("http://af/v1/ListTasks", "application/json", strings.NewReader("{}"))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var listResp ListTasksResponse
+	dataInto(t, getEnvelope(resp), &listResp)
+	require.Len(t, listResp.Tasks, 1)
+	assert.Equal(t, "eeee1001", listResp.Tasks[0].ID)
+
+	// Close tears the listener down and unlinks the socket.
+	require.NoError(t, closeHTTP())
+	_, statErr := os.Stat(sockPath)
+	assert.True(t, os.IsNotExist(statErr), "socket file must be unlinked on close")
+}
+
+// TestHTTP_SuccessBodyUsesSharedEnvelopeWriter pins that the HTTP success body is
+// produced by the SAME apiproto.WriteEnvelope the CLI's --json path uses, so the
+// two surfaces are byte-for-byte identical and can never drift.
+func TestHTTP_SuccessBodyUsesSharedEnvelopeWriter(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	m, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+	cs := &controlServer{manager: m}
+
+	rec := doHTTP(cs, http.MethodPost, "/v1/Snapshot", `{}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp SnapshotResponse
+	require.NoError(t, cs.Snapshot(SnapshotRequest{}, &resp))
+	var want bytes.Buffer
+	require.NoError(t, apiproto.WriteEnvelope(&want, apiproto.Success(resp)))
+
+	require.Equal(t, want.String(), rec.Body.String(),
+		"HTTP body must be the shared envelope writer's bytes (identical to CLI --json)")
+}


### PR DESCRIPTION
## What & why

PR 4/6 of #1029 (*Easy HTTP + CLI interfaces*). Adds a **daemon-hosted HTTP/JSON server** that is a **1:1 mirror** of the client-facing daemon RPCs, so HTTP becomes just another thin client of the same daemon core (#960). PRs 1–3 (#1179/#1180/#1181) are merged; this builds on them.

**HTTP ≡ RPC by construction:** every HTTP route decodes the *same* request struct (from `daemon/control.go`) and calls the *same* `(*controlServer)` method the `net/rpc` handler calls, then encodes the response in the shared `{data,error}` envelope. There is no forked logic — the two surfaces cannot drift.

## Transport (Sachin's locked decisions)

- Dedicated **Unix socket** `~/.agent-factory/daemon-http.sock`, **chmod 0600** — filesystem perms are the auth. **No TCP, no token.**
- Bound **alongside** the gob control socket (one listener = one protocol; not multiplexed), torn down on shutdown.
- HTTP bind failure is logged, never fatal: the control plane every existing client depends on must not regress.

```
curl --unix-socket ~/.agent-factory/daemon-http.sock http://localhost/v1/Snapshot -d '{}'
curl --unix-socket ~/.agent-factory/daemon-http.sock http://localhost/v1/health
```

## Surface

Uniform `POST /v1/<Method>` mirroring the RPC name; `GET /v1/health` → `Ping`.

- **Sessions:** CreateSession, Snapshot, KillSession, ArchiveSession, RestoreArchived, SendPrompt, DeliverPrompt, CreateTab, CloseTab, SetPRInfo, ImportRemoteHookSessions
- **Tasks:** ListTasks, AddTask, UpdateTask, RemoveTask, TriggerTask
- **Excluded** (pure infra): Shutdown, Pause/ResumeStatusPoll, ReloadTasks, bare Ping.

> **Note:** ArchiveSession/RestoreArchived were added on top of the task's original include-list to keep the mirror *complete* after the #1028 archive epic merged — they are additive and the same client-facing class as KillSession.

Status mapping (documented in the handler): `200` success · `400` malformed JSON body · `404` unknown route · `405` wrong verb · `413` body over the size cap · `500` handler error. The envelope body is returned on **every** path. A rejected body (400/413) short-circuits before the manager call, so an oversize or malformed request is never dispatched.

> **Update (Greptile P2):** the body read uses `http.MaxBytesReader` (not `io.LimitReader`), so a body exceeding the 16 MiB cap is **rejected with 413**, not silently truncated-then-accepted. The overflow is detected precisely via `errors.As(err, &maxErr)` (`*http.MaxBytesError`); everything else stays 400. A test asserts an oversize body → 413 with the request **not** dispatched (nothing persisted, scheduler untouched), plus an under-limit body still succeeds.

## Import-cycle fix

`api/` already imports `daemon/`, so `daemon/` can't import `api/output.go`. Extracted the envelope type + helpers into a neutral **`apiproto`** package imported by both; the CLI `--json` path now delegates to it, so the CLI output and HTTP responses share one byte-identical writer. A test locks the exact envelope bytes so they can never diverge.

## Tests

`httptest` coverage per category (create/read/mutation), all error cases (malformed→400, unknown→404, wrong-verb→405), a **shared-core proof** (HTTP route == `net/rpc` twin), a real-socket **end-to-end** test (bind → 0600 → dial → health/ListTasks → close/unlink), and the envelope byte-identity lock. Existing `daemon/control.go` gob tests still pass with the json tags added.

Verified: `go build ./...`, `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...` all clean; full suite green via `make test-container`.

## Smoke-testing the HTTP socket in the container

Verified end-to-end against a **real** daemon (not httptest) in the `make playtest-container` sandbox. Copy-paste sequence:

```bash
# 1. Start a detached sandbox (af builds on boot; name is printed).
AF_PLAYTEST_NAME=af-http-smoke scripts/testbox.sh playtest -d
docker exec af-http-smoke sh -c 'until [ -x /home/dev/bin/af ]; do sleep 1; done'

# 2. Start the daemon. A task WRITE takes the spawning path (EnsureDaemon);
#    a read like `sessions list` deliberately does NOT spawn one, so use add:
docker exec af-http-smoke sh -c \
  'cd /home/dev/sandbox/mock-repo && af tasks add --name smoke --cron "0 3 * * *" --prompt hi'

# 3. Socket path = $AGENT_FACTORY_HOME/daemon-http.sock. In this sandbox
#    AGENT_FACTORY_HOME=/home/dev/sandbox/home (GetConfigDir returns it
#    verbatim — no .agent-factory suffix when the env var is set).
SOCK=/home/dev/sandbox/home/daemon-http.sock
docker exec af-http-smoke curl -s --unix-socket "$SOCK" http://localhost/v1/health
docker exec af-http-smoke curl -s --unix-socket "$SOCK" http://localhost/v1/Snapshot  -d '{}'
docker exec af-http-smoke curl -s --unix-socket "$SOCK" http://localhost/v1/ListTasks -d '{}'

# 4. Tear down.
docker rm -f af-http-smoke
```

Observed (all wrapped in the `{data,error}` envelope):

```
/v1/health    → {"data":{"ok":true},"error":null}
/v1/Snapshot  → {"data":{"instances":[]},"error":null}
/v1/ListTasks → {"data":{"tasks":[{"id":"…","name":"smoke",…}]},"error":null}
```

Error mappings confirmed over the same socket: `/v1/Nope` → 404, `GET /v1/Snapshot` → 405, `-d '{bad'` → 400. `af sessions list` (control socket) keeps working — the two sockets are independent.

**Warm-up caveat:** `GET /v1/health` (→ Ping) answers throughout, including during the post-bind instance restore. State RPCs (`/v1/Snapshot`, `/v1/CreateSession`, …) return the `daemon is starting (restoring sessions); retry shortly` error until the manager is `Ready` — the same gate the net/rpc handlers use. In this sandbox the restore is instant (empty home), so `/v1/Snapshot` returns immediately; on a real remote-hook home it may briefly 500 with that message right after the daemon spawns.

Refs #1029 (does **not** close it — PR 5/6 adds `af api` + OpenAPI + `docs/http-api.md` and closes it).

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
