### PR TITLE
feat(cli,docs): af api discoverability catalog + HTTP API reference (#1029) [PR 5/6]

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ af tasks add --name "Daily triage" --prompt "Triage open issues" --cron "0 9 * *
 
 See [docs/cli.md](docs/cli.md) for the complete command reference.
 
+### HTTP API
+
+The daemon also exposes the same session and task operations as a small JSON API over a **localhost-only Unix socket** (`$AGENT_FACTORY_HOME/daemon-http.sock`, `0600` owner-only — no TCP port, no token), so tools and agents can call Agent Factory without shelling out to `af`. Every response uses the same `{data, error}` envelope as `af --json`:
+
+```bash
+curl --unix-socket ~/.agent-factory/daemon-http.sock http://localhost/v1/health
+# {"data":{"ok":true},"error":null}
+```
+
+Run `af api` to list every endpoint (with a ready-to-run curl example) and the resolved socket path; see [docs/http-api.md](docs/http-api.md) for the full reference.
+
 ### Remote sessions
 
 With `remote_hooks` configured in a repo, `N` launches sessions on a remote backend (your own scripts: launch, list, attach, delete, terminal) and shows them alongside local ones with the same attach/kill/preview experience. See [docs/remote-hooks.md](docs/remote-hooks.md) for the script protocol.
@@ -133,6 +144,7 @@ Upgrading from a `config.json`? The move to TOML is automatic — `af` converts 
 ## Documentation
 
 - [docs/cli.md](docs/cli.md) — full CLI reference (`af sessions`, `af tasks`, `af daemon`, maintenance commands)
+- [docs/http-api.md](docs/http-api.md) — the daemon-hosted HTTP/JSON API: socket path, auth model, every endpoint (`af api` prints the same catalog)
 - [docs/configuration.md](docs/configuration.md) — config keys, global vs. in-repo precedence, state locations
 - [docs/tasks.md](docs/tasks.md) — task triggers, the watch-script contract, daemon lifecycle
 - [docs/remote-hooks.md](docs/remote-hooks.md) — remote backend script protocol

--- a/api/apicmd.go
+++ b/api/apicmd.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/daemon"
+
+	"github.com/spf13/cobra"
+)
+
+// apiJSONFlag switches `af api` from the human-readable catalog to the
+// machine-readable envelope form. Local to this command (not the shared
+// envelopeOutput flag) because `af api` has no bare-vs-envelope legacy to
+// preserve: the flag simply picks the output shape.
+var apiJSONFlag bool
+
+// APICmd prints the daemon-hosted HTTP/JSON API catalog so users can discover
+// and call it (#1029 PR 5). It is READ-ONLY and LOCAL: it resolves the socket
+// path and reads the in-process route catalog (daemon.HTTPRoutes) but never
+// dials the socket or spawns the daemon, so it works with no daemon running.
+var APICmd = &cobra.Command{
+	Use:   "api",
+	Short: "Show the daemon-hosted HTTP/JSON API catalog",
+	Long: `Print the HTTP/JSON API the daemon exposes over a local Unix socket.
+
+The daemon serves a small JSON API — a 1:1 mirror of the session and task
+operations the CLI performs — on a 0600 Unix socket (owner-only; there is no
+TCP port and no token). This command lists the resolved socket path and every
+endpoint with a ready-to-run curl example.
+
+It is read-only and never contacts or starts the daemon; it just prints the
+catalog. Use --json for a machine-readable form wrapped in the shared
+{data,error} envelope. Full reference: docs/http-api.md.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// DaemonHTTPSocketPath is pure path resolution ($AGENT_FACTORY_HOME or
+		// the default config dir) — it does not dial or spawn anything.
+		socketPath, err := daemon.DaemonHTTPSocketPath()
+		if err != nil {
+			return err
+		}
+		routes := daemon.HTTPRoutes()
+		if apiJSONFlag {
+			return printAPICatalogJSON(cmd.OutOrStdout(), socketPath, routes)
+		}
+		return printAPICatalogHuman(cmd.OutOrStdout(), socketPath, routes)
+	},
+}
+
+func init() {
+	APICmd.Flags().BoolVar(&apiJSONFlag, "json", false,
+		"Emit the catalog as JSON wrapped in the {data,error} envelope")
+}
+
+// apiCatalog is the machine-readable payload wrapped in the shared envelope by
+// `af api --json`. Endpoints entries have exactly the {method, path,
+// description, request_fields?} shape the HTTP server registers (daemon.HTTPRoute).
+type apiCatalog struct {
+	SocketPath string             `json:"socket_path"`
+	Auth       string             `json:"auth"`
+	Endpoints  []daemon.HTTPRoute `json:"endpoints"`
+}
+
+// apiAuthModel is the one-line auth description shared by the human and JSON
+// output so the two never disagree.
+const apiAuthModel = "owner-only 0600 Unix socket (localhost); no TCP port, no token"
+
+// printAPICatalogJSON writes the catalog as the shared {data,error} envelope so
+// it is byte-compatible with the CLI's --json output and the HTTP responses.
+func printAPICatalogJSON(w io.Writer, socketPath string, routes []daemon.HTTPRoute) error {
+	return apiproto.WriteEnvelope(w, apiproto.Success(apiCatalog{
+		SocketPath: socketPath,
+		Auth:       apiAuthModel,
+		Endpoints:  routes,
+	}))
+}
+
+// printAPICatalogHuman writes the discovery-oriented human view: the resolved
+// socket path, the auth model, and a table of every endpoint with a
+// copy-paste curl example.
+func printAPICatalogHuman(w io.Writer, socketPath string, routes []daemon.HTTPRoute) error {
+	fmt.Fprintln(w, "Agent Factory HTTP/JSON API")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  Socket: %s\n", socketPath)
+	fmt.Fprintf(w, "  Auth:   %s\n", apiAuthModel)
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Responses use the shared envelope: {\"data\": <payload>, \"error\": null}\n")
+	fmt.Fprintln(w)
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ENDPOINT\tDESCRIPTION")
+	for _, rt := range routes {
+		fmt.Fprintf(tw, "%s %s\t%s\n", rt.Method, rt.Path, rt.Description)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Examples:")
+	for _, rt := range routes {
+		fmt.Fprintf(w, "  # %s\n", rt.Description)
+		fmt.Fprintf(w, "  %s\n", curlExample(socketPath, rt))
+		if len(rt.RequestFields) > 0 {
+			fmt.Fprintf(w, "  # request fields: %s\n", strings.Join(rt.RequestFields, ", "))
+		}
+		fmt.Fprintln(w)
+	}
+	return nil
+}
+
+// curlExample builds a ready-to-run curl invocation for a route. GET routes
+// (health) omit the body; POST routes send an empty JSON object, which every
+// no-argument RPC accepts as-is and every other RPC accepts as a starting point
+// to fill in.
+func curlExample(socketPath string, rt daemon.HTTPRoute) string {
+	base := fmt.Sprintf("curl --unix-socket %s http://localhost%s", socketPath, rt.Path)
+	if rt.Method == "GET" {
+		return base
+	}
+	return base + " -d '{}'"
+}

--- a/api/apicmd_test.go
+++ b/api/apicmd_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/daemon"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runAPICmd executes `af api` (optionally with --json) capturing stdout, without
+// touching the process's real os.Stdout.
+func runAPICmd(t *testing.T, jsonMode bool) string {
+	t.Helper()
+	t.Cleanup(func() { apiJSONFlag = false })
+	apiJSONFlag = jsonMode
+
+	var buf bytes.Buffer
+	APICmd.SetOut(&buf)
+	require.NoError(t, APICmd.RunE(APICmd, nil))
+	return buf.String()
+}
+
+// TestAPICmd_ListsEveryRegisteredEndpoint is the command-side drift guard: the
+// human catalog must name EVERY route the HTTP server registers
+// (daemon.HTTPRoutes), so the discovery command can never fall behind the
+// server. The daemon-side TestHTTPRoutes_MatchRegisteredMux proves that same
+// catalog equals the served mux, so the chain is: `af api` == HTTPRoutes ==
+// served routes.
+func TestAPICmd_ListsEveryRegisteredEndpoint(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	out := runAPICmd(t, false)
+
+	routes := daemon.HTTPRoutes()
+	require.NotEmpty(t, routes)
+	for _, rt := range routes {
+		assert.Containsf(t, out, rt.Method+" "+rt.Path,
+			"human catalog must list %s %s", rt.Method, rt.Path)
+		// A ready-to-run curl example per endpoint.
+		assert.Containsf(t, out, "curl --unix-socket",
+			"human catalog must include a curl example for %s", rt.Path)
+	}
+	// The resolved socket path and the auth model are part of discovery.
+	assert.Contains(t, out, "daemon-http.sock")
+	assert.Contains(t, out, "0600")
+}
+
+// TestAPICmd_JSONEmitsEnvelopeCatalog covers `af api --json`: the output is the
+// shared {data,error} envelope wrapping the endpoint catalog, and the endpoints
+// match daemon.HTTPRoutes exactly.
+func TestAPICmd_JSONEmitsEnvelopeCatalog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	out := runAPICmd(t, true)
+
+	var env apiproto.Envelope
+	require.NoError(t, json.Unmarshal([]byte(out), &env), "output must be valid envelope JSON")
+	require.Nil(t, env.Error)
+	require.NotNil(t, env.Data)
+
+	// Re-marshal Data into the catalog shape.
+	raw, err := json.Marshal(env.Data)
+	require.NoError(t, err)
+	var cat apiCatalog
+	require.NoError(t, json.Unmarshal(raw, &cat))
+
+	assert.Equal(t, filepath.Join(home, "daemon-http.sock"), cat.SocketPath)
+	assert.Contains(t, cat.Auth, "0600")
+
+	// Endpoints equal the authoritative catalog (method/path/description/fields).
+	want := daemon.HTTPRoutes()
+	require.Len(t, cat.Endpoints, len(want))
+	for i := range want {
+		assert.Equal(t, want[i].Method, cat.Endpoints[i].Method)
+		assert.Equal(t, want[i].Path, cat.Endpoints[i].Path)
+		assert.Equal(t, want[i].Description, cat.Endpoints[i].Description)
+		assert.Equal(t, want[i].RequestFields, cat.Endpoints[i].RequestFields)
+	}
+}
+
+// TestAPICmd_DoesNotSpawnDaemon proves `af api` is read-only/local: after
+// running it against a pristine AGENT_FACTORY_HOME, neither the HTTP socket nor
+// the control socket exists — the command resolved the path and printed the
+// static catalog without binding, dialing, or spawning anything.
+func TestAPICmd_DoesNotSpawnDaemon(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	_ = runAPICmd(t, false)
+
+	for _, name := range []string{"daemon-http.sock", "daemon.sock"} {
+		_, err := os.Stat(filepath.Join(home, name))
+		assert.Truef(t, os.IsNotExist(err),
+			"`af api` must not create %s (it must never dial or spawn the daemon)", name)
+	}
+}
+
+// TestAPICmd_CurlExampleShape checks the curl example distinguishes GET (no
+// body) from POST (empty JSON body), so the printed examples are runnable as-is.
+func TestAPICmd_CurlExampleShape(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	out := runAPICmd(t, false)
+
+	// GET health: no -d body.
+	require.Contains(t, out, "http://localhost/v1/health")
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "/v1/health") && strings.Contains(line, "curl") {
+			assert.NotContains(t, line, "-d '{}'", "GET health curl must omit a body")
+		}
+		if strings.Contains(line, "/v1/CreateSession") && strings.Contains(line, "curl") {
+			assert.Contains(t, line, "-d '{}'", "POST curl must include an empty JSON body")
+		}
+	}
+}

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -1,0 +1,202 @@
+package daemon
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+)
+
+// The HTTP surface catalog (#1029 PR 5). httpRoutes is the SINGLE SOURCE OF
+// TRUTH describing every route the daemon-hosted HTTP/JSON server serves. Two
+// consumers read it and only it:
+//
+//   - newHTTPMux (daemon/httpserver.go) registers exactly these routes, so the
+//     server serves the catalog and nothing else.
+//   - HTTPRoutes() exports the same list to the `af api` discovery command, so
+//     the printed/JSON catalog can never drift from what the server registers.
+//
+// A drift guard test (httproutes_test.go) proves the mux serves precisely this
+// set, so adding a route means adding one entry here — the server and the
+// catalog move together by construction.
+
+// HTTPRoute describes one route of the daemon HTTP/JSON API: its verb, path, a
+// one-line description, and the JSON request-body field names (derived from the
+// RPC request struct, so they cannot drift from the wire shape). The exported
+// fields serialize into the `af api --json` catalog; the unexported handler
+// binds the route to a live controlServer at mux-build time and never
+// serializes.
+type HTTPRoute struct {
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+	Description string `json:"description"`
+	// RequestFields is the JSON body field names accepted by this route, in
+	// declaration order. Nil (omitted) for routes with no body (GET /v1/health)
+	// and no-argument POSTs (ListTasks).
+	RequestFields []string `json:"request_fields,omitempty"`
+	// handler builds the http.HandlerFunc for this route against a controlServer.
+	// Unexported: net/json skips it (so it never leaks into the catalog) and
+	// importers cannot set it.
+	handler func(*controlServer) http.HandlerFunc
+}
+
+// httpRoutes is the authoritative route table. Order here is the order the
+// `af api` catalog prints; it does not affect ServeMux dispatch.
+var httpRoutes = []HTTPRoute{
+	// Liveness.
+	{
+		Method:      http.MethodGet,
+		Path:        "/v1/health",
+		Description: "Liveness probe (alias for the Ping RPC); answers even while the daemon is restoring sessions.",
+		handler:     func(cs *controlServer) http.HandlerFunc { return healthHandler(cs) },
+	},
+
+	// Sessions.
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/CreateSession",
+		Description:   "Create a new session (git worktree + agent) in a repo.",
+		RequestFields: jsonFields(reflect.TypeOf(CreateSessionRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.CreateSession) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/Snapshot",
+		Description:   "List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos).",
+		RequestFields: jsonFields(reflect.TypeOf(SnapshotRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.Snapshot) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/KillSession",
+		Description:   "Tear down a session: kill its tmux/agent and remove its worktree and record.",
+		RequestFields: jsonFields(reflect.TypeOf(KillSessionRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.KillSession) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/ArchiveSession",
+		Description:   "Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record.",
+		RequestFields: jsonFields(reflect.TypeOf(ArchiveSessionRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ArchiveSession) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/RestoreArchived",
+		Description:   "Restore an archived session: move its worktree back next to the repo and re-spawn the agent.",
+		RequestFields: jsonFields(reflect.TypeOf(RestoreArchivedRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RestoreArchived) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/SendPrompt",
+		Description:   "Send a prompt to an existing session's agent.",
+		RequestFields: jsonFields(reflect.TypeOf(SendPromptRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SendPrompt) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/DeliverPrompt",
+		Description:   "Deliver a prompt to a session, auto-creating it if it does not exist yet.",
+		RequestFields: jsonFields(reflect.TypeOf(DeliverPromptRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.DeliverPrompt) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/CreateTab",
+		Description:   "Spawn a tab (process or shell) in a session's worktree.",
+		RequestFields: jsonFields(reflect.TypeOf(CreateTabRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.CreateTab) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/CloseTab",
+		Description:   "Close a non-agent tab of a session (the agent tab cannot be closed).",
+		RequestFields: jsonFields(reflect.TypeOf(CloseTabRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.CloseTab) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/SetPRInfo",
+		Description:   "Record or clear the GitHub PR info for a session.",
+		RequestFields: jsonFields(reflect.TypeOf(SetPRInfoRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.SetPRInfo) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/ImportRemoteHookSessions",
+		Description:   "Import sessions discovered via a repo's remote-hook backend.",
+		RequestFields: jsonFields(reflect.TypeOf(ImportRemoteHookSessionsRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ImportRemoteHookSessions) },
+	},
+
+	// Tasks.
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/ListTasks",
+		Description:   "List every task across all repos.",
+		RequestFields: jsonFields(reflect.TypeOf(ListTasksRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ListTasks) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/AddTask",
+		Description:   "Append a new task and re-arm the scheduler.",
+		RequestFields: jsonFields(reflect.TypeOf(AddTaskRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.AddTask) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/UpdateTask",
+		Description:   "Update an existing task, preserving scheduler-owned fields.",
+		RequestFields: jsonFields(reflect.TypeOf(UpdateTaskRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.UpdateTask) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/RemoveTask",
+		Description:   "Remove a task by ID.",
+		RequestFields: jsonFields(reflect.TypeOf(RemoveTaskRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RemoveTask) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/TriggerTask",
+		Description:   "Fire a cron task now through the daemon's scheduler path (refuses disabled and watch tasks).",
+		RequestFields: jsonFields(reflect.TypeOf(TriggerTaskRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.TriggerTask) },
+	},
+}
+
+// HTTPRoutes returns a copy of the HTTP/JSON API catalog for discovery
+// (`af api`). It is a pure, read-only description of the registered routes: it
+// does NOT dial the socket or spawn the daemon. The copy protects the internal
+// table from mutation by callers.
+func HTTPRoutes() []HTTPRoute {
+	out := make([]HTTPRoute, len(httpRoutes))
+	copy(out, httpRoutes)
+	return out
+}
+
+// jsonFields returns the JSON body field names of an RPC request struct in
+// declaration order, deriving the catalog's request_fields straight from the
+// wire structs so they can never drift from what the server decodes. Unexported
+// fields (net/rpc's gob and encoding/json both skip them) and json:"-" fields
+// are omitted.
+func jsonFields(t reflect.Type) []string {
+	var fields []string
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		name := strings.Split(f.Tag.Get("json"), ",")[0]
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = f.Name
+		}
+		fields = append(fields, name)
+	}
+	return fields
+}

--- a/daemon/httproutes_test.go
+++ b/daemon/httproutes_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHTTPRoutes_MatchRegisteredMux is the drift guard: it proves the mux the
+// daemon actually serves registers PRECISELY the routes HTTPRoutes() reports —
+// no more, no less. Since both newHTTPMux and HTTPRoutes read the same
+// httpRoutes table this holds by construction; the test locks it so a future
+// change that hand-registers a route (or drops one) fails loudly instead of
+// letting the `af api` catalog silently drift from the server.
+func TestHTTPRoutes_MatchRegisteredMux(t *testing.T) {
+	cs := &controlServer{}
+	mux := newHTTPMux(cs)
+
+	routes := HTTPRoutes()
+	require.NotEmpty(t, routes)
+
+	// Every cataloged route must be registered: the mux resolves it to a real
+	// handler, not the catch-all. An unknown path hits the catch-all (404 with
+	// an "unknown route" envelope), so a registered path is one whose handler
+	// pattern is NOT "/".
+	for _, rt := range routes {
+		_, pattern := mux.Handler(mustRequest(t, rt.Method, rt.Path))
+		assert.Equalf(t, rt.Path, pattern,
+			"route %s %s is in the catalog but not registered on the served mux", rt.Method, rt.Path)
+	}
+
+	// Conversely, a path NOT in the catalog must fall through to the catch-all,
+	// proving the mux serves nothing beyond the catalog.
+	_, pattern := mux.Handler(mustRequest(t, http.MethodPost, "/v1/NotACatalogRoute"))
+	assert.Equal(t, "/", pattern,
+		"an off-catalog path must hit the catch-all, i.e. the mux serves only the catalog")
+}
+
+// TestHTTPRoutes_HealthShape pins the two structural invariants the catalog
+// promises: exactly one GET route (health) and every other route a POST under
+// /v1/ carrying no leaked unexported handler in its serialized form.
+func TestHTTPRoutes_HealthShape(t *testing.T) {
+	routes := HTTPRoutes()
+
+	var gets int
+	for _, rt := range routes {
+		assert.True(t, len(rt.Path) > len("/v1/") && rt.Path[:4] == "/v1/",
+			"route path %q must be under /v1/", rt.Path)
+		switch rt.Method {
+		case http.MethodGet:
+			gets++
+			assert.Equal(t, "/v1/health", rt.Path, "the only GET route is /v1/health")
+			assert.Empty(t, rt.RequestFields, "health takes no request body")
+		case http.MethodPost:
+			// fine
+		default:
+			t.Fatalf("unexpected method %q for %q", rt.Method, rt.Path)
+		}
+	}
+	assert.Equal(t, 1, gets, "exactly one GET route (health)")
+}
+
+// TestHTTPRoutes_RequestFieldsMatchWireStruct spot-checks that request_fields is
+// derived from the actual RPC request struct's json tags (not a drifting
+// hand-list): CreateSession's fields must match its wire shape.
+func TestHTTPRoutes_RequestFieldsMatchWireStruct(t *testing.T) {
+	var create *HTTPRoute
+	for i := range httpRoutes {
+		if httpRoutes[i].Path == "/v1/CreateSession" {
+			create = &httpRoutes[i]
+			break
+		}
+	}
+	require.NotNil(t, create)
+	assert.Equal(t,
+		[]string{"title", "title_base", "repo_path", "program", "prompt", "auto_yes", "in_place", "force_remote"},
+		create.RequestFields,
+		"request_fields must mirror CreateSessionRequest's json tags in declaration order")
+}
+
+func mustRequest(t *testing.T, method, path string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, "http://localhost"+path, nil)
+	require.NoError(t, err)
+	return req
+}

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -106,36 +106,19 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 	}, nil
 }
 
-// newHTTPMux builds the route table. Every client-facing RPC gets a
-// POST /v1/<Method> route that dispatches to the matching controlServer method;
-// GET /v1/health is a liveness alias for Ping. Pure-infra RPCs (Shutdown,
-// Pause/ResumeStatusPoll, ReloadTasks, and bare Ping) are intentionally absent —
-// the HTTP surface mirrors only client-facing session and task ops.
+// newHTTPMux builds the route table by iterating the httpRoutes catalog — the
+// SAME list `af api` prints — so the served routes and the documented catalog
+// cannot diverge (#1029 PR 5). Every client-facing RPC has a POST /v1/<Method>
+// route dispatching to the matching controlServer method; GET /v1/health is a
+// liveness alias for Ping. Pure-infra RPCs (Shutdown, Pause/ResumeStatusPoll,
+// ReloadTasks, and bare Ping) are intentionally absent from the catalog — the
+// HTTP surface mirrors only client-facing session and task ops.
 func newHTTPMux(cs *controlServer) *http.ServeMux {
 	mux := http.NewServeMux()
 
-	// Sessions.
-	mux.HandleFunc("/v1/CreateSession", rpcHandler(cs.CreateSession))
-	mux.HandleFunc("/v1/Snapshot", rpcHandler(cs.Snapshot))
-	mux.HandleFunc("/v1/KillSession", rpcHandler(cs.KillSession))
-	mux.HandleFunc("/v1/ArchiveSession", rpcHandler(cs.ArchiveSession))
-	mux.HandleFunc("/v1/RestoreArchived", rpcHandler(cs.RestoreArchived))
-	mux.HandleFunc("/v1/SendPrompt", rpcHandler(cs.SendPrompt))
-	mux.HandleFunc("/v1/DeliverPrompt", rpcHandler(cs.DeliverPrompt))
-	mux.HandleFunc("/v1/CreateTab", rpcHandler(cs.CreateTab))
-	mux.HandleFunc("/v1/CloseTab", rpcHandler(cs.CloseTab))
-	mux.HandleFunc("/v1/SetPRInfo", rpcHandler(cs.SetPRInfo))
-	mux.HandleFunc("/v1/ImportRemoteHookSessions", rpcHandler(cs.ImportRemoteHookSessions))
-
-	// Tasks.
-	mux.HandleFunc("/v1/ListTasks", rpcHandler(cs.ListTasks))
-	mux.HandleFunc("/v1/AddTask", rpcHandler(cs.AddTask))
-	mux.HandleFunc("/v1/UpdateTask", rpcHandler(cs.UpdateTask))
-	mux.HandleFunc("/v1/RemoveTask", rpcHandler(cs.RemoveTask))
-	mux.HandleFunc("/v1/TriggerTask", rpcHandler(cs.TriggerTask))
-
-	// Liveness. GET-only alias for the Ping RPC.
-	mux.HandleFunc("/v1/health", healthHandler(cs))
+	for _, rt := range httpRoutes {
+		mux.HandleFunc(rt.Path, rt.handler(cs))
+	}
 
 	// Catch-all: any other path is an unknown route → 404 with the envelope.
 	// ServeMux routes the longest prefix match, so a real route above always

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -287,6 +287,34 @@ Remove a task. Emits `{"ok": true}`.
 
 ---
 
+## `af api`
+
+Print the catalog of the daemon-hosted HTTP/JSON API — the localhost-only Unix
+socket that mirrors the `af sessions` / `af tasks` operations for tools and
+agents that call the daemon directly. **Read-only and local:** it resolves the
+socket path and reads the in-process route catalog but never dials the socket or
+starts the daemon, so it works with no daemon running.
+
+```bash
+af api          # human-readable: resolved socket path, auth model, every endpoint + a curl example
+af api --json   # the same catalog as JSON, wrapped in the {data,error} envelope
+```
+
+The default output prints the resolved socket path
+(`$AGENT_FACTORY_HOME/daemon-http.sock`, falling back to
+`~/.agent-factory/daemon-http.sock`), the auth model (owner-only `0600` Unix
+socket; no TCP port, no token), and a table of every endpoint —
+`GET /v1/health` plus a `POST /v1/<Method>` for each mirrored RPC — with a
+ready-to-run `curl --unix-socket …` example per endpoint. `--json` emits a
+machine-readable catalog (`{socket_path, auth, endpoints: [{method, path,
+description, request_fields?}]}`) in the shared envelope.
+
+The catalog is derived from the daemon's actual route table, so it never drifts
+from what the server serves. Full request/response reference:
+[http-api.md](http-api.md).
+
+---
+
 ## `af daemon`
 
 Manage the background daemon that hosts task cron schedules, watch-task scripts,

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1,0 +1,229 @@
+# `af` HTTP/JSON API reference
+
+The Agent Factory daemon exposes a small JSON API — a 1:1 mirror of the session
+and task operations the `af` CLI performs — over a **local Unix socket**. It is
+the same daemon core (`#960` single-writer model) the TUI and `af sessions` /
+`af tasks` commands already drive, reached over HTTP instead of the internal
+`net/rpc` control socket, so the two surfaces can never diverge.
+
+This is a hand-written reference. There is deliberately **no OpenAPI/Swagger
+document and no generated schema** in v1. To discover the surface from the
+command line without reading this file, run:
+
+```bash
+af api          # human-readable catalog: socket path, auth model, every endpoint + a curl example
+af api --json   # the same catalog as JSON, wrapped in the shared {data,error} envelope
+```
+
+`af api` is read-only and local: it prints the catalog and the resolved socket
+path but never dials the socket or starts the daemon. Its catalog is derived
+from the daemon's actual route table, so it always matches what the server
+serves.
+
+## Transport & socket path
+
+The API is served over a dedicated Unix socket, **not** a TCP port:
+
+```
+$AGENT_FACTORY_HOME/daemon-http.sock
+```
+
+`$AGENT_FACTORY_HOME` is where Agent Factory keeps its state. It resolves as:
+
+1. the `AGENT_FACTORY_HOME` environment variable, if set (with a leading `~` /
+   `~/` expanded); otherwise
+2. the default config dir, `~/.agent-factory`.
+
+So on a default install the socket is `~/.agent-factory/daemon-http.sock`. `af
+api` prints the resolved path for your environment.
+
+The socket is created when the daemon starts (on demand whenever `af` runs and
+there is work to host, or via an autostart unit — see
+[tasks.md](tasks.md#daemon-lifecycle)). If the socket does not exist, the daemon
+is not running.
+
+## Authentication
+
+There is **no token and no TCP port**. Authentication is the filesystem:
+
+- The socket is a **Unix domain socket**, reachable only from the local host —
+  never the network.
+- It is created with **`0600` permissions** (owner read/write only), so only
+  the user who owns the daemon process can connect. Group and other have no
+  access.
+
+This matches the model of the daemon's internal control socket. It is a
+single-user, local-only API by design: anyone who can read the socket already
+runs as your user and could drive `af` directly, so no additional secret buys
+anything. Do not proxy this socket to a network interface.
+
+## Response envelope
+
+Every response — success or failure, on every endpoint — is the same
+`{data, error}` JSON envelope the CLI's `--json` flag emits, so the two surfaces
+are byte-for-byte identical.
+
+A **success** carries the payload under `data` with `error: null`:
+
+```json
+{
+  "data": { "ok": true },
+  "error": null
+}
+```
+
+A **failure** sets `data: null` and populates `error.message`:
+
+```json
+{
+  "data": null,
+  "error": { "message": "agent-factory daemon is starting (restoring sessions); retry shortly" }
+}
+```
+
+Both members always serialize (no `omitempty`), so a consumer can branch on
+`error === null` without a presence check. Every response sets
+`Content-Type: application/json`.
+
+## Status codes
+
+| Status | Meaning |
+|--------|---------|
+| `200 OK` | Success. `data` holds the response payload; `error` is `null`. |
+| `400 Bad Request` | The request body was not valid JSON. |
+| `404 Not Found` | Unknown route (e.g. `POST /v1/Nope`). |
+| `405 Method Not Allowed` | Wrong verb — RPC routes are POST-only; `/v1/health` is GET-only. |
+| `413 Request Entity Too Large` | The body exceeded the 16 MiB cap. The request is **rejected, never truncated-then-processed** — the daemon is never reached. |
+| `500 Internal Server Error` | The handler ran but returned an error (validation failure, not-found session, a disabled task refused by `TriggerTask`, etc.). `error.message` carries the detail. |
+
+The status maps the *transport* outcome; a business-logic failure (e.g. "session
+not found") is a `500` with a descriptive `error.message`, not a bare status.
+
+## Warm-up behavior
+
+The daemon binds its sockets **before** it finishes restoring sessions, which
+can take minutes on repos with remote-hook sessions. During that window:
+
+- `GET /v1/health` answers immediately (it is a pure liveness probe) — it does
+  not wait for the restore.
+- State-dependent routes (session and task RPCs) return an error envelope with
+  the message `agent-factory daemon is starting (restoring sessions); retry
+  shortly`. Treat it as **retryable**: the daemon is alive; the same request
+  succeeds once the restore completes.
+
+## Endpoints
+
+Request-body fields are the JSON keys of each RPC request struct; a `⟨none⟩`
+body means the route accepts an empty body (`-d '{}'` or no `-d` at all). All
+POST routes accept an empty JSON object as a starting point.
+
+### `GET /v1/health`
+
+Liveness probe (alias for the internal `Ping` RPC). Answers even while the
+daemon is restoring sessions.
+
+- **Request body:** none.
+- **Response `data`:** `{ "ok": true }`
+
+```bash
+curl --unix-socket ~/.agent-factory/daemon-http.sock http://localhost/v1/health
+# {"data":{"ok":true},"error":null}
+```
+
+### Sessions
+
+| Route | Description | Request fields |
+|-------|-------------|----------------|
+| `POST /v1/CreateSession` | Create a new session (git worktree + agent) in a repo. | `title`, `title_base`, `repo_path`, `program`, `prompt`, `auto_yes`, `in_place`, `force_remote` |
+| `POST /v1/Snapshot` | List sessions from the daemon's authoritative in-memory state (empty `repo_id` = all repos). | `repo_id` |
+| `POST /v1/KillSession` | Tear down a session: kill its tmux/agent and remove its worktree and record. | `title`, `repo_id` |
+| `POST /v1/ArchiveSession` | Archive a session: tear down tmux, relocate its worktree to the archive dir, keep the record. | `title`, `repo_id` |
+| `POST /v1/RestoreArchived` | Restore an archived session: move its worktree back and re-spawn the agent. | `title`, `repo_id` |
+| `POST /v1/SendPrompt` | Send a prompt to an existing session's agent. | `title`, `repo_id`, `prompt` |
+| `POST /v1/DeliverPrompt` | Deliver a prompt to a session, auto-creating it if missing. | `title`, `repo_path`, `program`, `prompt`, `auto_yes` |
+| `POST /v1/CreateTab` | Spawn a tab (process or shell) in a session's worktree. | `title`, `repo_id`, `command`, `name`, `shell` |
+| `POST /v1/CloseTab` | Close a non-agent tab of a session (the agent tab cannot be closed). | `title`, `repo_id`, `tab_name`, `tab_index` |
+| `POST /v1/SetPRInfo` | Record or clear the GitHub PR info for a session. | `title`, `repo_id`, `pr_info` |
+| `POST /v1/ImportRemoteHookSessions` | Import sessions discovered via a repo's remote-hook backend. | `repo_path` |
+
+**Response shapes.** `CreateSession` returns `{ "instance": <session> }`;
+`Snapshot` and `ImportRemoteHookSessions` return `{ "instances": [<session>…] }`;
+`ArchiveSession` returns `{ "ok": true, "archived_path": "…" }`;
+`RestoreArchived` returns `{ "ok": true, "worktree_path": "…" }`;
+`DeliverPrompt` returns `{ "status": "started" | "sent" }`; `CreateTab` /
+`CloseTab` return `{ "name": "<resolved-tab-name>" }`; the rest return
+`{ "ok": true }`.
+
+### Tasks
+
+| Route | Description | Request fields |
+|-------|-------------|----------------|
+| `POST /v1/ListTasks` | List every task across all repos. | ⟨none⟩ |
+| `POST /v1/AddTask` | Append a new task and re-arm the scheduler. | `task` |
+| `POST /v1/UpdateTask` | Update an existing task, preserving scheduler-owned fields. | `task` |
+| `POST /v1/RemoveTask` | Remove a task by ID. | `id` |
+| `POST /v1/TriggerTask` | Fire a cron task now through the daemon's scheduler path (refuses disabled and watch tasks). | `id` |
+
+**Response shapes.** `ListTasks` returns `{ "tasks": [<task>…] }`; the mutations
+return `{ "ok": true }`. The `task` field of `AddTask` / `UpdateTask` is a full
+task object — the CLI/TUI build and validate it, and the daemon re-validates and
+owns the write. See [tasks.md](tasks.md) for the task shape.
+
+## Examples
+
+Health check:
+
+```bash
+curl --unix-socket ~/.agent-factory/daemon-http.sock http://localhost/v1/health
+# {"data":{"ok":true},"error":null}
+```
+
+List every session (all repos):
+
+```bash
+curl --unix-socket ~/.agent-factory/daemon-http.sock \
+  http://localhost/v1/Snapshot -d '{}'
+```
+
+Send a prompt into an existing session:
+
+```bash
+curl --unix-socket ~/.agent-factory/daemon-http.sock \
+  http://localhost/v1/SendPrompt \
+  -d '{"title":"fix-auth","prompt":"run the tests and report failures"}'
+# {"data":{"ok":true},"error":null}
+```
+
+List tasks (no body needed):
+
+```bash
+curl --unix-socket ~/.agent-factory/daemon-http.sock http://localhost/v1/ListTasks -d '{}'
+```
+
+Wrong verb → `405`:
+
+```bash
+curl -i --unix-socket ~/.agent-factory/daemon-http.sock http://localhost/v1/ListTasks
+# HTTP/1.1 405 Method Not Allowed
+# {"data":null,"error":{"message":"method GET not allowed; use POST"}}
+```
+
+Oversize body → `413` (rejected, never processed):
+
+```bash
+head -c 20000000 /dev/zero | tr '\0' 'a' \
+  | curl -i --unix-socket ~/.agent-factory/daemon-http.sock \
+      http://localhost/v1/AddTask --data-binary @-
+# HTTP/1.1 413 Request Entity Too Large
+# {"data":null,"error":{"message":"request body exceeds 16777216-byte limit: …"}}
+```
+
+## Relationship to the CLI
+
+The HTTP API and `af sessions` / `af tasks` are two front-ends over one daemon
+core. Prefer the CLI for interactive and scripting use — it handles daemon
+startup, `--repo` resolution, and flag validation for you. Reach for the HTTP
+API when you want to call the daemon from a language or tool without shelling
+out to `af`, from inside an agent, or from a small local service. Both emit the
+identical `{data, error}` envelope, so a consumer written against one reads the
+other unchanged.

--- a/main.go
+++ b/main.go
@@ -286,6 +286,7 @@ func init() {
 	rootCmd.AddCommand(daemonCmd)
 	rootCmd.AddCommand(api.SessionsCmd)
 	rootCmd.AddCommand(api.TasksCmd)
+	rootCmd.AddCommand(api.APICmd)
 }
 
 func main() {


### PR DESCRIPTION
## Summary

The **closing PR of #1029** ("Easy HTTP + CLI interfaces"). PRs 1–4 shipped the
JSON envelope (#1179), read RPCs (#1180), task RPCs (#1181), and the
daemon-hosted HTTP/JSON server on `daemon-http.sock` (#1182). This PR makes that
HTTP surface **discoverable and documented**.

Per Sachin's locked decision: **hand-written docs + an `af api` catalog command —
no OpenAPI, no generated schema.** No OpenAPI/Swagger artifact is added.

## What's here

**1. `af api` command** (new top-level cobra command, registered like
`sessions`/`tasks`)
- Default: human catalog — resolved socket path, auth model (owner-only `0600`
  Unix socket; no TCP, no token), and a table of every endpoint with a
  ready-to-run `curl --unix-socket …` example per endpoint.
- `af api --json`: the same catalog wrapped in the shared `apiproto` `{data,error}`
  envelope (reused, not hand-rolled).
- **Read-only/local**: resolves the socket path + reads the in-process route
  catalog; it never dials the socket or spawns the daemon.

**2. Single source of truth (no-drift by construction)**
- `daemon/httproutes.go` defines `httpRoutes`, the authoritative route table, and
  exports `daemon.HTTPRoutes() []daemon.HTTPRoute`.
- `newHTTPMux` (the HTTP server registration from #1182) is **refactored to
  iterate this same list**, and `af api` consumes it too — so the served routes
  and the printed catalog can never diverge.
- `request_fields` is derived by reflection from each RPC request struct's json
  tags, so it tracks the actual wire shape.

**3. `docs/http-api.md`** — complete hand-written reference: socket-path
derivation from `AGENT_FACTORY_HOME`/config dir, the auth model and why, the
`{data,error}` envelope, every endpoint with request/response shapes, the
200/400/404/405/413/500 mapping, warm-up behavior (health during restore; state
RPCs return "daemon is starting" until Ready), and copy-paste curl examples
including oversize→413.

**4. README** "HTTP API" section (one paragraph + a health curl + pointers), and
`af api` added to `docs/cli-reference.md`.

## Drift guards / tests
- `daemon.TestHTTPRoutes_MatchRegisteredMux` — the served mux registers
  **precisely** the catalog set (nothing more, nothing less).
- `api.TestAPICmd_ListsEveryRegisteredEndpoint` — `af api` names every
  `daemon.HTTPRoutes()` route. Chain: `af api` == `HTTPRoutes` == served routes.
- `--json` emits the envelope catalog; `af api` does **not** spawn/create a
  daemon (no socket/home dir appears).

## Verification
- `gofmt -l .` clean · `golangci-lint run --timeout=3m --fast` clean ·
  `go build ./...` clean · `deadcode -test ./...` clean
- Full suite via `make test-container` — **all packages green** (api, daemon,
  integration incl.).

Built binary output:

```
$ af api
Agent Factory HTTP/JSON API

  Socket: ~/.agent-factory/daemon-http.sock
  Auth:   owner-only 0600 Unix socket (localhost); no TCP port, no token

Responses use the shared envelope: {"data": <payload>, "error": null}

ENDPOINT                           DESCRIPTION
GET /v1/health                     Liveness probe (alias for the Ping RPC); answers even while the daemon is restoring sessions.
POST /v1/CreateSession             Create a new session (git worktree + agent) in a repo.
POST /v1/Snapshot                  List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos).
...  (17 endpoints total)
POST /v1/TriggerTask               Fire a cron task now through the daemon's scheduler path (refuses disabled and watch tasks).

Examples:
  # Liveness probe (alias for the Ping RPC); answers even while the daemon is restoring sessions.
  curl --unix-socket ~/.agent-factory/daemon-http.sock http://localhost/v1/health
  ...
```

```
$ af api --json
{
  "data": {
    "socket_path": "~/.agent-factory/daemon-http.sock",
    "auth": "owner-only 0600 Unix socket (localhost); no TCP port, no token",
    "endpoints": [ { "method": "GET", "path": "/v1/health", "description": "…" }, … ]
  },
  "error": null
}
```

Closes #1029.

— Captain Claude