### PR TITLE
feat(tui): archived sessions folder + A archive/restore action (#1028) [PR 6/6]

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,15 @@ Each session is one agent running in its own git worktree on its own branch — 
 | `o` | Attach to the selected session's active tab full-screen |
 | `Ctrl-w` | Detach from a full-screen attach (configurable via `detach_keys`) |
 | `D` | Kill the session and clean up its worktree |
+| `A` | Archive the session (tmux down, worktree moved out, restartable) — on an archived row, restore it |
 | `Tab` / `Shift-Tab` | Cycle focus forward / back: tree → open panes → automations |
 | `1`–`9` | Jump straight to a tab by number |
 | `t` | Open a new shell tab in the session's worktree |
 | `w` | Close the active tab (the agent tab can't be closed) |
 
 When a session's branch has an open pull request, `p` opens it in the browser and `P` copies its URL.
+
+Press `A` to **archive** a session you're done with for now: its tmux is torn down and its worktree is moved out to a global archive directory (branch and uncommitted changes preserved), and the row drops into a collapsed **Archived** folder at the bottom of the rail. Archived sessions survive restarts and are never auto-restored — press `A` again on an archived row (or run `af sessions restore <title>`) to move its worktree back and bring the agent up. Not available for remote or `--here` sessions, which don't own a relocatable worktree.
 
 #### Tabs
 

--- a/app/app.go
+++ b/app/app.go
@@ -710,6 +710,14 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.killInstanceCmd(msg.title)
 	case instanceKilledMsg:
 		return m.handleInstanceKilled(msg)
+	case startArchiveMsg:
+		// Archive confirmed; run the daemon teardown+move off the event loop
+		// (#1028), mirroring the kill dispatch.
+		return m, m.archiveInstanceCmd(msg.title)
+	case instanceArchivedMsg:
+		return m.handleInstanceArchived(msg)
+	case instanceRestoredMsg:
+		return m.handleInstanceRestored(msg)
 	case repaintAfterDetachMsg:
 		// Trigger an immediate repaint with whatever content is already
 		// cached on the panes (rendered when bubbletea's main loop calls
@@ -1674,6 +1682,27 @@ type startKillMsg struct {
 // daemon tore the session down and deleted its record; a non-nil err means
 // the session is still alive and the row must become retryable again.
 type instanceKilledMsg struct {
+	title string
+	err   error
+}
+
+// startArchiveMsg is emitted by the archive confirmation (#1028); its handler
+// dispatches archiveInstanceCmd to run the daemon teardown+move off the event
+// loop, mirroring startKillMsg → killInstanceCmd.
+type startArchiveMsg struct {
+	title string
+}
+
+// instanceArchivedMsg / instanceRestoredMsg report completion of an async
+// archive / restore (#1028). On success the row's new status arrives via the
+// next daemon Snapshot reconcile (which re-partitions it into / out of the
+// Archived folder); a non-nil err is surfaced in the error box.
+type instanceArchivedMsg struct {
+	title string
+	err   error
+}
+
+type instanceRestoredMsg struct {
 	title string
 	err   error
 }

--- a/app/archive_action_test.go
+++ b/app/archive_action_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// archiveActionInstance builds a started, mock-backed instance at the given
+// status for the archive/restore action tests.
+func archiveActionInstance(t *testing.T, title string, status session.Status) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "test"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStartedForTest(true)
+	inst.SetStatus(status)
+	return inst
+}
+
+// TestHandleArchive_LiveRowConfirms: archiving a live session opens the
+// confirmation overlay (archive is significant — tmux down + worktree moved) and
+// does not immediately dispatch the RPC.
+func TestHandleArchive_LiveRowConfirms(t *testing.T) {
+	h := newTestHome(t)
+	inst := archiveActionInstance(t, "worker", session.Ready)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	called := false
+	prev := archiveSessionThroughDaemon
+	archiveSessionThroughDaemon = func(string, string) (string, error) { called = true; return "", nil }
+	defer func() { archiveSessionThroughDaemon = prev }()
+
+	model, _ := h.handleArchive()
+	h = model.(*home)
+
+	require.Equal(t, stateConfirm, h.state, "archiving a live session must ask for confirmation")
+	require.False(t, called, "the archive RPC must not fire before confirmation")
+}
+
+// TestArchiveInstanceCmd_CallsDaemon: the archive command invokes the daemon
+// seam and reports completion.
+func TestArchiveInstanceCmd_CallsDaemon(t *testing.T) {
+	h := newTestHome(t)
+
+	var gotTitle string
+	prev := archiveSessionThroughDaemon
+	archiveSessionThroughDaemon = func(title, repoID string) (string, error) {
+		gotTitle = title
+		return "/archive/path", nil
+	}
+	defer func() { archiveSessionThroughDaemon = prev }()
+
+	msg := h.archiveInstanceCmd("worker")()
+	require.Equal(t, "worker", gotTitle, "the archive command must call the daemon for the given title")
+	done, ok := msg.(instanceArchivedMsg)
+	require.True(t, ok, "the command must emit instanceArchivedMsg")
+	require.NoError(t, done.err)
+	require.Equal(t, "worker", done.title)
+}
+
+// TestArchiveInstanceCmd_SurfacesError: a daemon rejection is carried back as an
+// error on the completion message (handled into the error box).
+func TestArchiveInstanceCmd_SurfacesError(t *testing.T) {
+	h := newTestHome(t)
+	prev := archiveSessionThroughDaemon
+	archiveSessionThroughDaemon = func(string, string) (string, error) {
+		return "", errors.New("cannot archive in-place session")
+	}
+	defer func() { archiveSessionThroughDaemon = prev }()
+
+	msg := h.archiveInstanceCmd("worker")()
+	done := msg.(instanceArchivedMsg)
+	require.Error(t, done.err)
+}
+
+// TestRestoreInstanceCmd_CallsDaemon: the restore command invokes the daemon
+// seam and reports completion.
+func TestRestoreInstanceCmd_CallsDaemon(t *testing.T) {
+	h := newTestHome(t)
+
+	var gotTitle string
+	prev := restoreArchivedThroughDaemon
+	restoreArchivedThroughDaemon = func(title, repoID string) (string, error) {
+		gotTitle = title
+		return "/worktree/path", nil
+	}
+	defer func() { restoreArchivedThroughDaemon = prev }()
+
+	msg := h.restoreInstanceCmd("worker")()
+	require.Equal(t, "worker", gotTitle)
+	done, ok := msg.(instanceRestoredMsg)
+	require.True(t, ok, "the command must emit instanceRestoredMsg")
+	require.NoError(t, done.err)
+}

--- a/app/archive_panes_test.go
+++ b/app/archive_panes_test.go
@@ -1,0 +1,92 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestArchive_ClosesOpenPanesViaFinalize (#1028 P1): archiving a session that has
+// an open pane must close that pane — an archived session's tmux/worktree is
+// torn down, so a live pane would dangle (the archived-row "no live panes"
+// contract). The finalize path (TUI `A` → handleInstanceArchived) closes it via
+// the synchronous pane prune in selectionChanged.
+func TestArchive_ClosesOpenPanesViaFinalize(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "worker")
+	inst.SetStatus(session.Running)
+	selectInstance(h, inst)
+	resizeHome(h, 200, 40)
+
+	_, _ = h.openOrFocusPane(inst, 0) // open the agent pane
+	require.Equal(t, 1, h.store.NumOpenPanes(), "precondition: a pane is open on the session")
+
+	h.handleInstanceArchived(instanceArchivedMsg{title: inst.Title})
+
+	require.Equal(t, session.Archived, inst.GetStatus())
+	require.True(t, h.store.ContainsInstance(inst),
+		"an archived instance stays in the projection (it moves to the Archived folder)")
+	require.Equal(t, 0, h.store.NumOpenPanes(),
+		"archiving must close panes bound to the session — an archived row has no live panes")
+}
+
+// TestArchive_ReconcileClosesOpenPanes (#1028 P1): an out-of-band archive (`af
+// sessions archive` while the TUI runs) mirrored by the snapshot reconcile must
+// ALSO close the session's panes, not just the TUI `A` path.
+func TestArchive_ReconcileClosesOpenPanes(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "worker")
+	inst.SetStatus(session.Running)
+	selectInstance(h, inst)
+	resizeHome(h, 200, 40)
+
+	_, _ = h.openOrFocusPane(inst, 0)
+	require.Equal(t, 1, h.store.NumOpenPanes())
+
+	// The daemon reports the session archived (same session — matching CreatedAt).
+	data := inst.ToInstanceData()
+	data.Status = session.Archived
+	h.reconcileSnapshot([]session.InstanceData{data})
+
+	require.Equal(t, session.Archived, inst.GetStatus())
+	require.Equal(t, 0, h.store.NumOpenPanes(),
+		"an out-of-band archive must close the session's panes via the reconcile prune")
+}
+
+// TestRestore_LeavesNoStalePaneBinding (#1028 P1 audit): archive closes the
+// session's panes, so restore never needs to touch panes — and it must never
+// leave a pane bound to a dead/archived session. Any pane present after the
+// round trip (e.g. a fresh preview auto-opened for the now-live selected row)
+// must bind to the LIVE restored instance, not a stale one.
+func TestRestore_LeavesNoStalePaneBinding(t *testing.T) {
+	h := newTestHome(t)
+	inst := startedLocalInstance(t, "worker")
+	inst.SetStatus(session.Running)
+	selectInstance(h, inst)
+	resizeHome(h, 200, 40)
+
+	_, _ = h.openOrFocusPane(inst, 0)
+	require.Equal(t, 1, h.store.NumOpenPanes())
+
+	// Archive closes the pane bound to the (about-to-be) archived session.
+	h.handleInstanceArchived(instanceArchivedMsg{title: inst.Title})
+	require.Equal(t, 0, h.store.NumOpenPanes(),
+		"archive closes the session's panes — no live pane on an archived row")
+
+	// Restore flips it back to Running via the reconcile.
+	data := inst.ToInstanceData()
+	data.Status = session.Running
+	h.reconcileSnapshot([]session.InstanceData{data})
+	require.Equal(t, session.Running, inst.GetStatus())
+
+	// Whatever panes exist now must bind ONLY to the live restored instance —
+	// never a stale/archived binding.
+	for _, p := range h.store.OpenPanes() {
+		require.True(t, h.store.ContainsInstance(p.Instance()),
+			"no pane may be bound to a session that left the projection")
+		require.NotEqual(t, session.Archived, p.Instance().GetStatus(),
+			"no pane may be bound to an archived session after restore")
+	}
+}

--- a/app/archive_reconcile_test.go
+++ b/app/archive_reconcile_test.go
@@ -1,0 +1,100 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// storeDeletingInstance adds a started, mock-backed instance to the store and
+// marks it Deleting — the exact local state a snapshot poll leaves behind when
+// it lands inside the archive teardown fence (#1028). Returns the instance.
+func storeDeletingInstance(t *testing.T, h *home, title string) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "test"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStatus(session.Deleting)
+	h.store.AddInstance(inst)
+	return inst
+}
+
+// TestReconcile_TerminalStatusOverridesLocalDeleting is the play-test regression
+// (#1028): a row locally mirrored to the transient Deleting (a snapshot caught
+// the archive teardown fence) must be updated when the daemon's NEXT snapshot
+// reports a TERMINAL status. Without the override, isTransientStatus skips the
+// row forever and it strands on "Tearing down session…", never reaching the
+// Archived folder. Covers all three terminal states.
+func TestReconcile_TerminalStatusOverridesLocalDeleting(t *testing.T) {
+	cases := []struct {
+		name   string
+		status session.Status
+	}{
+		{"archived", session.Archived},
+		{"lost", session.Lost},
+		{"dead", session.Dead},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			inst := storeDeletingInstance(t, h, "worker")
+
+			// The daemon (single writer) now reports the settled terminal status
+			// for the same session (matching CreatedAt — not a kill+recreate swap).
+			h.reconcileSnapshot([]session.InstanceData{
+				{Title: "worker", CreatedAt: inst.CreatedAt, Status: tc.status},
+			})
+
+			require.Equal(t, tc.status, inst.GetStatus(),
+				"a daemon terminal status must override a stale local Deleting row")
+		})
+	}
+}
+
+// TestReconcile_OptimisticDeletingPreservedForNonTerminal guards the kill UX:
+// a user-initiated optimistic Deleting row must STILL be left alone when the
+// daemon reports a non-terminal status (the kill hasn't completed yet), so the
+// "Tearing down…" feedback shows until the daemon confirms. Only a terminal
+// status may override it.
+func TestReconcile_OptimisticDeletingPreservedForNonTerminal(t *testing.T) {
+	cases := []struct {
+		name   string
+		status session.Status
+	}{
+		{"running", session.Running},
+		{"ready", session.Ready},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			inst := storeDeletingInstance(t, h, "worker")
+
+			h.reconcileSnapshot([]session.InstanceData{
+				{Title: "worker", CreatedAt: inst.CreatedAt, Status: tc.status},
+			})
+
+			require.Equal(t, session.Deleting, inst.GetStatus(),
+				"a non-terminal daemon status must NOT clobber an optimistic Deleting row (kill UX)")
+		})
+	}
+}
+
+// TestHandleInstanceArchived_FinalizesRowImmediately: on a successful archive the
+// local row is flipped to Archived immediately (belt-and-suspenders with the
+// reconcile override), so it partitions into the Archived folder without waiting
+// for the next snapshot poll.
+func TestHandleInstanceArchived_FinalizesRowImmediately(t *testing.T) {
+	h := newTestHome(t)
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "worker", Path: t.TempDir(), Program: "test"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStatus(session.Deleting) // as left by the archive fence
+	h.store.AddInstance(inst)
+
+	h.handleInstanceArchived(instanceArchivedMsg{title: "worker"})
+
+	require.Equal(t, session.Archived, inst.GetStatus(),
+		"a completed archive must finalize the local row to Archived at once")
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -294,13 +294,23 @@ func (m *home) restoreInstanceCmd(title string) tea.Cmd {
 	}
 }
 
-// handleInstanceArchived finalizes an async archive. On success the row's new
-// Archived status arrives via the next daemon Snapshot reconcile, which
-// re-partitions it into the collapsed Archived folder — nothing to do here but
-// refresh selection; on failure the error lands in the error box.
+// handleInstanceArchived finalizes an async archive. On success the RPC has
+// already returned, so the daemon has committed the session to Archived; mark
+// the local row Archived IMMEDIATELY (mirroring how handleInstanceKilled
+// finalizes the row) so it partitions into the Archived folder without waiting
+// for — or depending on — the next snapshot poll. This is belt-and-suspenders
+// alongside the reconcile override (#1028): together they guarantee the row can
+// never strand on "Tearing down session…" even if a poll caught it mid-fence.
+// On failure the error lands in the error box.
 func (m *home) handleInstanceArchived(msg instanceArchivedMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		return m, m.handleError(fmt.Errorf("failed to archive session '%s': %w", msg.title, msg.err))
+	}
+	for _, inst := range m.store.GetInstances() {
+		if inst.Title == msg.title {
+			inst.SetStatus(session.Archived)
+			break
+		}
 	}
 	return m, m.selectionChanged()
 }

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -106,6 +106,8 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 	// Instance actions
 	case keys.KeyKill:
 		return m.handleKill()
+	case keys.KeyArchive:
+		return m.handleArchive()
 	case keys.KeyEnter:
 		return m.handleEnter()
 	case keys.KeyAttach:
@@ -228,6 +230,91 @@ func (m *home) handleInstanceKilled(msg instanceKilledMsg) (tea.Model, tea.Cmd) 
 	return m, m.selectionChanged()
 }
 
+// handleArchive is the archive/restore verb (#1028, `A`): on an archived row it
+// restores the session (non-destructive — no confirm); on a live row it archives
+// it behind a confirmation, since archive tears down tmux and relocates the
+// worktree. Remote and in-place sessions can't be archived (no relocatable
+// worktree) and are rejected up front with an immediate message; the daemon
+// enforces the same rules authoritatively.
+func (m *home) handleArchive() (tea.Model, tea.Cmd) {
+	selected := m.sidebar.GetSelectedInstance()
+	if selected == nil || selected.GetStatus() == session.Loading {
+		return m, nil
+	}
+	if selected.GetStatus() == session.Deleting {
+		return m, m.handleError(fmt.Errorf("session '%s' is being deleted", selected.Title))
+	}
+	title := selected.Title
+
+	// Archived row → restore. No confirmation: restore only moves the worktree
+	// back and re-spawns the agent.
+	if selected.GetStatus() == session.Archived {
+		return m, m.restoreInstanceCmd(title)
+	}
+
+	// Live row → archive. Fail fast on the unarchivable session kinds for a
+	// snappy message (the daemon rejects them too).
+	if selected.IsRemote() {
+		return m, m.handleError(fmt.Errorf("cannot archive remote session '%s': it has no local worktree to relocate", title))
+	}
+	if selected.IsExternalWorktree() {
+		return m, m.handleError(fmt.Errorf("cannot archive in-place session '%s': archive relocates the worktree, which it doesn't own", title))
+	}
+
+	message := fmt.Sprintf("[!] Archive session '%s'?\n\nIts tmux is torn down and its worktree is moved out to the archive directory (branch + uncommitted changes preserved). Restore later with A.", title)
+	return m, m.confirmAction(message, func() tea.Msg { return startArchiveMsg{title: title} })
+}
+
+// archiveInstanceCmd runs the daemon archive (tmux teardown + worktree move) off
+// the event loop (#1028), mirroring killInstanceCmd — the RPC blocks for the
+// whole operation, so it must not run on the Update goroutine.
+func (m *home) archiveInstanceCmd(title string) tea.Cmd {
+	repoID := m.repoID
+	archive := archiveSessionThroughDaemon
+	return func() tea.Msg {
+		if _, err := archive(title, repoID); err != nil {
+			log.ErrorLog.Printf("could not archive instance %q: %v", title, err)
+			return instanceArchivedMsg{title: title, err: err}
+		}
+		return instanceArchivedMsg{title: title}
+	}
+}
+
+// restoreInstanceCmd runs the daemon restore (worktree move-back + agent
+// re-spawn) off the event loop (#1028).
+func (m *home) restoreInstanceCmd(title string) tea.Cmd {
+	repoID := m.repoID
+	restore := restoreArchivedThroughDaemon
+	return func() tea.Msg {
+		if _, err := restore(title, repoID); err != nil {
+			log.ErrorLog.Printf("could not restore instance %q: %v", title, err)
+			return instanceRestoredMsg{title: title, err: err}
+		}
+		return instanceRestoredMsg{title: title}
+	}
+}
+
+// handleInstanceArchived finalizes an async archive. On success the row's new
+// Archived status arrives via the next daemon Snapshot reconcile, which
+// re-partitions it into the collapsed Archived folder — nothing to do here but
+// refresh selection; on failure the error lands in the error box.
+func (m *home) handleInstanceArchived(msg instanceArchivedMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		return m, m.handleError(fmt.Errorf("failed to archive session '%s': %w", msg.title, msg.err))
+	}
+	return m, m.selectionChanged()
+}
+
+// handleInstanceRestored finalizes an async restore. On success the row returns
+// to the live Instances section via the next Snapshot reconcile; on failure the
+// error (e.g. the origin repo is gone) lands in the error box.
+func (m *home) handleInstanceRestored(msg instanceRestoredMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		return m, m.handleError(fmt.Errorf("failed to restore session '%s': %w", msg.title, msg.err))
+	}
+	return m, m.selectionChanged()
+}
+
 // killConfirmationWarning returns the data-loss warning line for the kill
 // confirmation dialog, or "" if the worktree at wt is verifiably clean. Kill
 // tears the worktree down with `git worktree remove -f`, which bypasses git's
@@ -271,13 +358,15 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 	}
 	sel := m.sidebar.GetSelection()
 
-	// Toggle expandable section headers (only Instances has children)
-	if sel.IsHeader && sel.Kind == ui.SectionInstances {
+	// Toggle expandable section headers (Instances and the Archived folder).
+	if sel.IsHeader && (sel.Kind == ui.SectionInstances || sel.Kind == ui.SectionArchived) {
 		m.sidebar.ToggleSection()
 		return m, m.selectionChanged()
 	}
-	// Instance selected
-	if sel.Kind == ui.SectionInstances {
+	// Instance selected — in either the Instances tree or the Archived folder
+	// (#1028). An archived row is not embeddable: interactiveGuard surfaces the
+	// "restore it first" error before any pane/attach path is reached.
+	if sel.Kind == ui.SectionInstances || sel.Kind == ui.SectionArchived {
 		selected := m.sidebar.GetSelectedInstance()
 		if selected == nil || selected.GetStatus() == session.Loading {
 			return m, nil
@@ -346,7 +435,10 @@ func (m *home) handleAttach() (tea.Model, tea.Cmd) {
 		return m.handleEnterPane(p)
 	}
 	sel := m.sidebar.GetSelection()
-	if sel.IsHeader || sel.Kind != ui.SectionInstances {
+	// Accept both the Instances tree and the Archived folder (#1028): an
+	// archived row is non-attachable, and interactiveGuard surfaces the
+	// "restore it first" error rather than a silent no-op.
+	if sel.IsHeader || (sel.Kind != ui.SectionInstances && sel.Kind != ui.SectionArchived) {
 		return m, nil
 	}
 	selected := m.sidebar.GetSelectedInstance()

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -155,8 +155,14 @@ func (m *home) handleClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 	switch id {
 	case zones.TreeHeader:
-		// Click the section header: toggle it, like Enter on the row.
+		// Click the Instances header: toggle it, like Enter on the row.
 		m.sidebar.ClickHeader()
+		m.focusRegionClick(layout.RegionTree)
+		return m, m.selectionChanged()
+	case zones.TreeHeaderArchived:
+		// Click the Archived folder header (#1028): toggle the Archived folder
+		// specifically, not the Instances section.
+		m.sidebar.ClickHeaderKind(ui.SectionArchived)
 		m.focusRegionClick(layout.RegionTree)
 		return m, m.selectionChanged()
 	case zones.TreeBG:

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -127,14 +127,22 @@ func (m *home) closePaneWindow(p *store.OpenPane) {
 	delete(m.lastPaneCapture, p.ID())
 }
 
-// pruneDeadPanes closes panes whose instance left the projection (killed
-// here, or removed by an external kill the snapshot reconcile mirrored)
-// rather than keep rendering a dead session's last capture. Reports whether
-// anything closed; callers relayout on true.
+// pruneDeadPanes closes panes whose backing session can no longer render: the
+// instance left the projection (killed here, or removed by an external kill the
+// snapshot reconcile mirrored), OR the instance was archived (#1028). An
+// archived session's tmux and worktree are torn down, so an open pane bound to
+// it dangles on a dead session — the archived-row "no live panes" contract. The
+// instance stays PRESENT in the projection when archived (it moves to the
+// Archived folder), so the containment check alone would skip it; the status
+// check closes it. Keying on status here (not just the finalize handler) covers
+// EVERY archive path — the TUI `A` verb and a CLI `af sessions archive` mirrored
+// by the reconcile — since panesRefresh runs this on selection changes and
+// reconciles. Reports whether anything closed; callers relayout on true.
 func (m *home) pruneDeadPanes() bool {
 	pruned := false
 	for _, p := range append([]*store.OpenPane(nil), m.store.OpenPanes()...) {
-		if !m.store.ContainsInstance(p.Instance()) {
+		inst := p.Instance()
+		if !m.store.ContainsInstance(inst) || (inst != nil && inst.GetStatus() == session.Archived) {
 			m.closePaneWindow(p)
 			pruned = true
 		}

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -35,6 +35,17 @@ var killSessionThroughDaemon = func(title, repoID string) error {
 	return daemon.KillSession(daemon.KillSessionRequest{Title: title, RepoID: repoID})
 }
 
+// archiveSessionThroughDaemon / restoreArchivedThroughDaemon route the #1028
+// archive/restore verbs through the daemon (the single writer). Package vars so
+// the app test suite can stub them without dialing a real daemon.
+var archiveSessionThroughDaemon = func(title, repoID string) (string, error) {
+	return daemon.ArchiveSession(daemon.ArchiveSessionRequest{Title: title, RepoID: repoID})
+}
+
+var restoreArchivedThroughDaemon = func(title, repoID string) (string, error) {
+	return daemon.RestoreArchived(daemon.RestoreArchivedRequest{Title: title, RepoID: repoID})
+}
+
 // triggerTaskThroughDaemon runs a task by ID through the daemon's single shared
 // trigger path — the SAME entrypoint `af tasks trigger` and the cron scheduler
 // use. It routes through the TriggerTask RPC (#1029 PR 3) so the firing runs

--- a/app/sync.go
+++ b/app/sync.go
@@ -411,10 +411,15 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 		m.store.RemoveInstanceByTitle(inst.Title)
 		changed = true
 	}
-	// A removed instance takes its open panes with it (#1088): prune them
-	// here — not just on the next selectionChanged tick — so the focus ring
-	// and pane layout are consistent the moment the reconcile returns.
-	if len(toRemove) > 0 && m.pruneDeadPanes() {
+	// Prune panes whose backing session can no longer render — a removed
+	// instance takes its open panes with it (#1088), and a session archived out
+	// of band (`af sessions archive` while the TUI runs, #1028) leaves its pane
+	// dangling on a torn-down session. Do it here, not just on the next
+	// selectionChanged tick, so the focus ring and pane layout are consistent
+	// the moment the reconcile returns. Unconditional: pruneDeadPanes is O(open
+	// panes) and only relayouts when it actually closed something, so a reconcile
+	// with nothing to prune is a cheap no-op.
+	if m.pruneDeadPanes() {
 		m.relayout()
 	}
 

--- a/app/sync.go
+++ b/app/sync.go
@@ -361,9 +361,25 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 			}
 			continue
 		}
-		// In-flight TUI operations own their row: leave Loading/Deleting alone.
+		// In-flight TUI operations own their row: leave Loading/Deleting alone —
+		// EXCEPT a locally-Deleting row when the daemon (the single writer, #960)
+		// now reports a TERMINAL status (Archived/Lost/Dead). A settled terminal
+		// truth must win over a stale local transient: the archive flow fences
+		// its teardown+move window with the daemon's Deleting and then flips to
+		// the terminal Archived (#1028), so a 750ms snapshot poll landing inside
+		// that window mirrors the row to Deleting — and without this override
+		// isTransientStatus would skip it on every later reconcile, stranding it
+		// on "Tearing down session…" forever, never partitioning into the
+		// Archived folder. The optimistic Deleting-during-kill UX is preserved:
+		// a user kill leaves the daemon reporting a non-terminal status (or
+		// deletes the record) until it completes, so it never trips this
+		// override — only a daemon-confirmed terminal state does. Loading rows
+		// (a create the daemon may not list yet) are never overridden.
 		if isTransientStatus(inst.GetStatus()) {
-			continue
+			overrideDeleting := inst.GetStatus() == session.Deleting && isTerminalStatus(d.Status)
+			if !overrideDeleting {
+				continue
+			}
 		}
 		if !inst.CreatedAt.Equal(d.CreatedAt) {
 			// Same title, different session — a kill+recreate reused the title
@@ -535,6 +551,17 @@ func prInfoDiffersFromData(inst *session.Instance, d session.PRInfoData) bool {
 // neither replace nor reap it.
 func isTransientStatus(status session.Status) bool {
 	return status == session.Loading || status == session.Deleting
+}
+
+// isTerminalStatus reports whether a daemon-reported status is a settled,
+// persisted outcome rather than a transient in-flight one (#1028). A terminal
+// status from the single-writer daemon overrides a stale local transient
+// (Deleting) row in reconcileSnapshot — it is a truth that has already been
+// committed to disk, so the TUI must reflect it even if a poll caught the row
+// mid-teardown. Archived (deliberate), Lost, and Dead are the persisted
+// terminal states (Running/Ready are live, Loading/Deleting are transient).
+func isTerminalStatus(status session.Status) bool {
+	return status == session.Archived || status == session.Lost || status == session.Dead
 }
 
 func (m *home) importRemoteHookSessions() int {

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -17,6 +17,7 @@ const (
 	KeyEnter
 	KeyNew
 	KeyKill
+	KeyArchive // Archive a live session / restore an archived one (#1028)
 	KeyQuit
 
 	KeyTab        // Tab cycles the workspace focus ring (tree → pane → automations).
@@ -112,6 +113,7 @@ var specs = []spec{
 	{name: KeyExitInteractive, keys: []string{"ctrl+]"}, desc: "nav mode"},
 	{name: KeyNew, configKey: "new", keys: []string{"n"}, desc: "new", dispatch: true},
 	{name: KeyKill, configKey: "kill", keys: []string{"D"}, desc: "kill", dispatch: true},
+	{name: KeyArchive, configKey: "archive", keys: []string{"A"}, desc: "archive/restore", dispatch: true},
 	{name: KeyHelp, configKey: "help", keys: []string{"?"}, desc: "help", dispatch: true},
 	{name: KeyQuit, configKey: "quit", keys: []string{"q"}, desc: "quit", dispatch: true},
 	{name: KeyNewRemote, configKey: "new_remote", keys: []string{"N"}, desc: "new remote", dispatch: true},

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -32,6 +32,7 @@ func TestDefaultMapsMatchLegacyTable(t *testing.T) {
 		"o":          KeyAttach,
 		"n":          KeyNew,
 		"D":          KeyKill,
+		"A":          KeyArchive,
 		"q":          KeyQuit,
 		"tab":        KeyTab,
 		"shift+tab":  KeyShiftTab,

--- a/ui/layout/zones/ids.go
+++ b/ui/layout/zones/ids.go
@@ -18,6 +18,10 @@ const (
 	// TreeHeader is the Instances section header row (click toggles the
 	// section, like Enter on it).
 	TreeHeader = "tree:header"
+	// TreeHeaderArchived is the Archived folder header row (#1028) — a DISTINCT
+	// zone from TreeHeader so clicking each toggles its own section instead of
+	// colliding on one id.
+	TreeHeaderArchived = "tree:header:archived"
 	// TreeBG is the tree pane's background: any click inside the rail's tree
 	// region that lands on no finer zone (focuses the tree).
 	TreeBG = "tree:bg"

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -26,6 +26,13 @@ type SidebarSectionKind int
 
 const (
 	SectionInstances SidebarSectionKind = iota
+	// SectionArchived holds archived sessions (#1028) in a folder pinned at the
+	// bottom of the rail, collapsed by default. Its rows are instance rows like
+	// the Instances section's (ItemIndex is a projection index), but flat — an
+	// archived session has no live tabs and is not attachable. The header is
+	// hidden entirely when no session is archived, so the folder only appears
+	// once there is something in it.
+	SectionArchived
 )
 
 // SidebarItem represents one visible row in the sidebar. Within the Instances
@@ -47,6 +54,26 @@ type SidebarSection struct {
 	Kind     SidebarSectionKind
 	Title    string
 	Expanded bool
+}
+
+// isInstanceRow reports whether item is a selectable instance row — a non-header
+// row in either the Instances or Archived section (#1028). Both carry a
+// projection ItemIndex; the difference is only which folder they render under.
+func isInstanceRow(item SidebarItem) bool {
+	return !item.IsHeader && (item.Kind == SectionInstances || item.Kind == SectionArchived)
+}
+
+// partitionByArchived splits projection indices into live and archived, in the
+// projection's stable order (#1028).
+func partitionByArchived(instances []*session.Instance) (live, archived []int) {
+	for i, inst := range instances {
+		if inst != nil && inst.GetStatus() == session.Archived {
+			archived = append(archived, i)
+		} else {
+			live = append(live, i)
+		}
+	}
+	return live, archived
 }
 
 var sectionHeaderStyle = lipgloss.NewStyle().
@@ -153,6 +180,10 @@ func NewSidebar(spin *spinner.Model, autoYes bool, proj *store.Projection) *Side
 		proj: proj,
 		sections: []SidebarSection{
 			{Kind: SectionInstances, Title: "Instances", Expanded: true},
+			// Archived (#1028): pinned last, collapsed by default. Rendered only
+			// when it holds archived sessions (rebuildVisibleItems skips the empty
+			// folder).
+			{Kind: SectionArchived, Title: "Archived", Expanded: false},
 		},
 		renderer:      tree.NewInstanceRenderer(spin),
 		autoyes:       autoYes,
@@ -230,8 +261,16 @@ func (s *Sidebar) structureSig() string {
 		slots = len(tree.TabLabels(inst))
 		expandable = tree.Expandable(inst)
 	}
-	return fmt.Sprintf("%d|%s|%d|%t|%s",
-		s.proj.Version(), selTitle, slots, expandable, s.treeCollapsed)
+	// Fold in the archived partition (#1028): a status flip to/from Archived
+	// changes which folder a row belongs to but does NOT bump the projection
+	// Version (it mutates an existing instance in place), so without this the
+	// sidebar would not re-partition until the next structural change. The
+	// archived index set — stable within a projection order — uniquely
+	// identifies the partition, so it catches both a single archive/restore and
+	// a same-count swap.
+	_, archived := partitionByArchived(s.proj.GetInstances())
+	return fmt.Sprintf("%d|%s|%d|%t|%s|%v",
+		s.proj.Version(), selTitle, slots, expandable, s.treeCollapsed, archived)
 }
 
 // instanceExpanded reports whether inst's tab children are currently shown:
@@ -419,23 +458,41 @@ func (s *Sidebar) rebuildPreservingCursor() {
 // section — the tree rows (instances with tab children for expanded ones).
 func (s *Sidebar) rebuildVisibleItems() {
 	instances := s.proj.GetInstances()
+
+	// Partition projection indices into live and archived (#1028), preserving
+	// order. ItemIndex stays a projection index in both sections so every
+	// downstream resolve (GetSelectedInstance, render) indexes GetInstances()
+	// uniformly.
+	live, archived := partitionByArchived(instances)
+
 	var items []SidebarItem
 	for _, sec := range s.sections {
+		// The Archived folder only appears once it holds something: no empty
+		// "Archived (0)" header cluttering the rail.
+		if sec.Kind == SectionArchived && len(archived) == 0 {
+			continue
+		}
 		items = append(items, SidebarItem{Kind: sec.Kind, IsHeader: true})
-		if sec.Expanded {
-			switch sec.Kind {
-			case SectionInstances:
-				rows := tree.Flatten(len(instances),
-					func(i int) bool { return s.instanceExpanded(instances[i]) },
-					func(i int) int { return len(tree.TabLabels(instances[i])) })
-				for _, r := range rows {
-					item := SidebarItem{Kind: SectionInstances, ItemIndex: r.InstanceIndex}
-					if r.IsTab() {
-						item.IsTab = true
-						item.TabIndex = r.TabIndex
-					}
-					items = append(items, item)
+		if !sec.Expanded {
+			continue
+		}
+		switch sec.Kind {
+		case SectionInstances:
+			rows := tree.Flatten(len(live),
+				func(i int) bool { return s.instanceExpanded(instances[live[i]]) },
+				func(i int) int { return len(tree.TabLabels(instances[live[i]])) })
+			for _, r := range rows {
+				item := SidebarItem{Kind: SectionInstances, ItemIndex: live[r.InstanceIndex]}
+				if r.IsTab() {
+					item.IsTab = true
+					item.TabIndex = r.TabIndex
 				}
+				items = append(items, item)
+			}
+		case SectionArchived:
+			// Flat rows — archived sessions have no live tabs.
+			for _, idx := range archived {
+				items = append(items, SidebarItem{Kind: SectionArchived, ItemIndex: idx})
 			}
 		}
 	}
@@ -625,7 +682,10 @@ func (s *Sidebar) JumpPrevSection() {
 func (s *Sidebar) GetSelectedInstance() *session.Instance {
 	s.syncFromStore()
 	sel := s.rawSelection()
-	if sel.Kind != SectionInstances || sel.IsHeader {
+	// An archived row (#1028) is a real instance row too, so it resolves here —
+	// this is what lets the restore action and the Enter "restore it first"
+	// fence read the selected archived session.
+	if !isInstanceRow(sel) {
 		return nil
 	}
 	instances := s.proj.GetInstances()
@@ -636,24 +696,42 @@ func (s *Sidebar) GetSelectedInstance() *session.Instance {
 }
 
 // SetSelectedInstance sets the cursor to point at the given instance index.
-// If the Instances section is collapsed, it is expanded first so the target
-// row is always reachable.
+// The section holding the target (Instances, or the Archived folder for an
+// archived session, #1028) is expanded first so the target row is always
+// reachable.
 func (s *Sidebar) SetSelectedInstance(idx int) {
 	s.syncFromStore()
-	if idx >= s.proj.NumInstances() {
+	instances := s.proj.GetInstances()
+	if idx < 0 || idx >= len(instances) {
 		return
 	}
-	// Ensure the Instances section is expanded so the target row is part of
+	// Expand whichever section holds the target so its row is part of
 	// visibleItems; otherwise the search below would silently no-op.
-	s.ExpandInstancesSection()
-	// Find the visible item that corresponds to this instance
+	if instances[idx].GetStatus() == session.Archived {
+		s.expandSectionKind(SectionArchived)
+	} else {
+		s.ExpandInstancesSection()
+	}
+	// Find the visible instance row (either section) for this projection index.
 	for i, item := range s.visibleItems {
-		if item.Kind == SectionInstances && !item.IsHeader && !item.IsTab && item.ItemIndex == idx {
+		if isInstanceRow(item) && !item.IsTab && item.ItemIndex == idx {
 			s.selectedIdx = i
 			break
 		}
 	}
 	s.afterCursorMove()
+}
+
+// expandSectionKind expands the given section and rebuilds. Shared by
+// SetSelectedInstance's Instances/Archived branches.
+func (s *Sidebar) expandSectionKind(kind SidebarSectionKind) {
+	for i, sec := range s.sections {
+		if sec.Kind == kind {
+			s.sections[i].Expanded = true
+			break
+		}
+	}
+	s.rebuildVisibleItems()
 }
 
 // SelectInstance finds and selects the given instance.
@@ -771,6 +849,9 @@ func (s *Sidebar) String() string {
 				} else {
 					rows[i] = s.renderInstance(item.ItemIndex, isSelected)
 				}
+			case SectionArchived:
+				// Archived rows are flat instance rows (#1028) — no tab children.
+				rows[i] = s.renderInstance(item.ItemIndex, isSelected)
 			}
 		}
 		heights[i] = lipgloss.Height(rows[i])
@@ -1092,9 +1173,13 @@ func (s *Sidebar) renderHeader(kind SidebarSectionKind, selected bool) string {
 	}
 
 	var label string
+	live, archived := partitionByArchived(s.proj.GetInstances())
 	switch kind {
 	case SectionInstances:
-		label = fmt.Sprintf("Instances (%d)", s.proj.NumInstances())
+		// Count live sessions only — archived ones live under their own folder.
+		label = fmt.Sprintf("Instances (%d)", len(live))
+	case SectionArchived:
+		label = fmt.Sprintf("Archived (%d)", len(archived))
 	}
 
 	style := sectionHeaderStyle

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -962,18 +962,27 @@ func (s *Sidebar) registerZones(heights []int, start, end int, topIndicator bool
 		row := layout.Rect{X: s.rect.X, Y: y, W: s.rect.W, H: h}
 		switch {
 		case item.IsHeader:
-			s.zones.Register(zones.TreeHeader, row)
-		case item.Kind == SectionInstances && item.ItemIndex >= 0 && item.ItemIndex < len(instances):
-			inst := instances[item.ItemIndex]
-			if item.IsTab {
-				s.zones.Register(zones.TreeTab(inst.Title, item.TabIndex), row)
+			// Distinct zone per folder so a click toggles the right one (#1028).
+			if item.Kind == SectionArchived {
+				s.zones.Register(zones.TreeHeaderArchived, row)
 			} else {
+				s.zones.Register(zones.TreeHeader, row)
+			}
+		case isInstanceRow(item) && item.ItemIndex >= 0 && item.ItemIndex < len(instances):
+			inst := instances[item.ItemIndex]
+			switch {
+			case item.IsTab:
+				s.zones.Register(zones.TreeTab(inst.Title, item.TabIndex), row)
+			default:
+				// Instance row (live or archived, #1028): a title-keyed select
+				// zone. Archived rows are flat (no tab children), so they get no
+				// expand/collapse arrow — only live, expandable rows do.
 				s.zones.Register(zones.TreeInstance(inst.Title), row)
-				// The arrow cell registers ON TOP of the row (later wins) so
-				// clicking it expands/collapses instead of selecting.
-				if ax, ay, ok := tree.ArrowCell(s.contentWidth()); ok && tree.Expandable(inst) && ay < h {
-					s.zones.Register(zones.TreeArrow(inst.Title),
-						layout.Rect{X: s.rect.X + ax, Y: y + ay, W: 1, H: 1})
+				if item.Kind == SectionInstances {
+					if ax, ay, ok := tree.ArrowCell(s.contentWidth()); ok && tree.Expandable(inst) && ay < h {
+						s.zones.Register(zones.TreeArrow(inst.Title),
+							layout.Rect{X: s.rect.X + ax, Y: y + ay, W: 1, H: 1})
+					}
 				}
 			}
 		}
@@ -987,6 +996,21 @@ func (s *Sidebar) ClickHeader() {
 	s.syncFromStore()
 	for i, item := range s.visibleItems {
 		if item.IsHeader {
+			s.selectedIdx = i
+			break
+		}
+	}
+	s.ToggleSection()
+}
+
+// ClickHeaderKind moves the cursor onto the header of the given section kind and
+// toggles that section (#1028) — the click equivalent of Enter on that header.
+// Unlike ClickHeader (which targets the first/Instances header), this lets a
+// click on the Archived folder header toggle the Archived folder specifically.
+func (s *Sidebar) ClickHeaderKind(kind SidebarSectionKind) {
+	s.syncFromStore()
+	for i, item := range s.visibleItems {
+		if item.IsHeader && item.Kind == kind {
 			s.selectedIdx = i
 			break
 		}

--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
 )
 
@@ -109,4 +111,71 @@ func TestSidebar_ArchivedRowSelectableWhenExpanded(t *testing.T) {
 
 	// The row renders with the archived marker.
 	assert.True(t, strings.Contains(s.View(), "[archived]"), "archived rows render a distinct marker")
+}
+
+// TestSidebar_ArchivedZonesRegistered (#1028 mouse P2): the Archived folder
+// header gets its OWN zone id (distinct from the Instances header, so a click
+// toggles the right folder), and — once expanded — an archived row registers a
+// clickable TreeInstance zone so the mouse can select/act on it.
+func TestSidebar_ArchivedZonesRegistered(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+	reg := zones.NewRegistry()
+	s.SetZoneRegistry(reg)
+	s.SetRect(layout.Rect{X: 0, Y: 0, W: 40, H: 40})
+
+	addTestInstance(s, archTestInstance(t, "live-one", session.Ready))
+	addTestInstance(s, archTestInstance(t, "put-away", session.Archived))
+
+	reg.Reset()
+	_ = s.String()
+
+	// Both headers register, on DISTINCT ids (no collision).
+	_, okInst := reg.Find(zones.TreeHeader)
+	require.True(t, okInst, "the Instances header zone must be registered")
+	_, okArch := reg.Find(zones.TreeHeaderArchived)
+	require.True(t, okArch, "the Archived folder header must get its own distinct zone")
+	assert.NotEqual(t, zones.TreeHeader, zones.TreeHeaderArchived, "header zone ids must differ")
+
+	// Collapsed by default → the archived row is not rendered, so no row zone yet.
+	_, okRow := reg.Find(zones.TreeInstance("put-away"))
+	require.False(t, okRow, "a collapsed Archived folder registers no archived-row zone")
+
+	// Expand the Archived folder and re-render: the archived row now has a
+	// clickable select zone, keyed by its title like a live instance row.
+	s.ClickHeaderKind(SectionArchived)
+	reg.Reset()
+	_ = s.String()
+
+	_, okRow = reg.Find(zones.TreeInstance("put-away"))
+	require.True(t, okRow, "an expanded archived row must register a clickable TreeInstance zone")
+	// The live instance's zone is still present (a click there selects it).
+	_, okLive := reg.Find(zones.TreeInstance("live-one"))
+	require.True(t, okLive)
+}
+
+// TestSidebar_ClickHeaderKindTogglesCorrectFolder (#1028 mouse P2): toggling the
+// Archived header must collapse/expand the Archived folder ONLY, leaving the
+// Instances section untouched — the behavior the distinct header zones enable.
+func TestSidebar_ClickHeaderKindTogglesCorrectFolder(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+	addTestInstance(s, archTestInstance(t, "live-one", session.Ready))
+	addTestInstance(s, archTestInstance(t, "put-away", session.Archived))
+	s.SetSize(40, 40)
+
+	instExpanded := func() bool { return s.sections[0].Expanded }
+	archExpanded := func() bool { return s.sections[1].Expanded }
+	require.True(t, instExpanded())
+	require.False(t, archExpanded(), "Archived starts collapsed")
+
+	// Toggle the Archived header: only the Archived folder flips.
+	s.ClickHeaderKind(SectionArchived)
+	assert.True(t, archExpanded(), "clicking the Archived header must expand the Archived folder")
+	assert.True(t, instExpanded(), "the Instances section must be untouched")
+
+	// Toggle the Instances header: only Instances flips.
+	s.ClickHeader()
+	assert.False(t, instExpanded(), "clicking the Instances header toggles Instances")
+	assert.True(t, archExpanded(), "the Archived folder must be untouched")
 }

--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -1,0 +1,112 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/store"
+)
+
+func archTestInstance(t *testing.T, title string, status session.Status) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "test"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStartedForTest(status != session.Archived)
+	inst.SetStatus(status)
+	return inst
+}
+
+// TestSidebar_ArchivedPartitionedIntoFolder (#1028): a live session renders under
+// Instances and an archived one under a separate "Archived" folder at the bottom
+// (collapsed by default, so its row is hidden until expanded). The counts in the
+// two headers reflect the partition.
+func TestSidebar_ArchivedPartitionedIntoFolder(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+
+	addTestInstance(s, archTestInstance(t, "live-one", session.Ready))
+	addTestInstance(s, archTestInstance(t, "put-away", session.Archived))
+	s.SetSize(40, 40)
+
+	// Two section headers now exist: Instances and Archived.
+	var headers []SidebarItem
+	for _, it := range s.visibleItems {
+		if it.IsHeader {
+			headers = append(headers, it)
+		}
+	}
+	require.Len(t, headers, 2, "an Archived folder header must appear once a session is archived")
+	assert.Equal(t, SectionInstances, headers[0].Kind)
+	assert.Equal(t, SectionArchived, headers[1].Kind, "the Archived folder is pinned last")
+
+	// The Archived folder starts collapsed, so its archived row is not visible.
+	for _, it := range s.visibleItems {
+		if it.Kind == SectionArchived && !it.IsHeader {
+			t.Fatal("the Archived folder must start collapsed (no archived rows visible)")
+		}
+	}
+
+	// Header labels carry the partitioned counts.
+	view := s.View()
+	assert.Contains(t, view, "Instances (1)", "Instances counts only live sessions")
+	assert.Contains(t, view, "Archived (1)")
+}
+
+// TestSidebar_NoArchivedFolderWhenEmpty (#1028): with nothing archived, the
+// Archived folder header is not shown at all.
+func TestSidebar_NoArchivedFolderWhenEmpty(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+	addTestInstance(s, archTestInstance(t, "live-one", session.Ready))
+	s.SetSize(40, 40)
+
+	for _, it := range s.visibleItems {
+		if it.Kind == SectionArchived {
+			t.Fatal("the Archived folder must be hidden when no session is archived")
+		}
+	}
+	assert.NotContains(t, s.View(), "Archived")
+}
+
+// TestSidebar_ArchivedRowSelectableWhenExpanded (#1028): expanding the Archived
+// folder reveals the archived row, and GetSelectedInstance resolves it (so the
+// restore action and the Enter fence can read the selected archived session).
+func TestSidebar_ArchivedRowSelectableWhenExpanded(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+	addTestInstance(s, archTestInstance(t, "put-away", session.Archived))
+	s.SetSize(40, 40)
+
+	// Move onto the Archived header and expand it.
+	for i, it := range s.visibleItems {
+		if it.Kind == SectionArchived && it.IsHeader {
+			s.selectedIdx = i
+			break
+		}
+	}
+	s.ExpandSection()
+
+	// The archived row is now visible; select it and resolve the instance.
+	found := false
+	for i, it := range s.visibleItems {
+		if it.Kind == SectionArchived && !it.IsHeader {
+			s.selectedIdx = i
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expanding the Archived folder must reveal the archived row")
+
+	inst := s.GetSelectedInstance()
+	require.NotNil(t, inst, "an archived row must resolve to its instance")
+	assert.Equal(t, "put-away", inst.Title)
+
+	// The row renders with the archived marker.
+	assert.True(t, strings.Contains(s.View(), "[archived]"), "archived rows render a distinct marker")
+}

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -21,13 +21,22 @@ func TestSidebarInitialState(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	s := NewSidebar(&spin, false, store.NewProjection())
 
-	// The left rail is the instances tree only since the layout cutover
-	// (#1024 PR 4): tasks live in the automations strip, hooks behind an
-	// overlay.
-	assert.Equal(t, 1, len(s.sections))
+	// The rail holds the Instances tree plus the Archived folder (#1028). The
+	// Archived section always exists so its collapse state persists, but it is
+	// rendered only when it holds archived sessions (see the assertion below).
+	assert.Equal(t, 2, len(s.sections))
+	assert.Equal(t, SectionInstances, s.sections[0].Kind)
+	assert.Equal(t, SectionArchived, s.sections[1].Kind)
 
-	// The Instances section is expanded by default
+	// Instances is expanded by default; the Archived folder is collapsed.
 	assert.True(t, s.sections[0].Expanded)
+	assert.False(t, s.sections[1].Expanded, "the Archived folder starts collapsed")
+
+	// With nothing archived, no Archived header is rendered — only the
+	// Instances header is visible.
+	for _, it := range s.visibleItems {
+		assert.NotEqual(t, SectionArchived, it.Kind, "the empty Archived folder must not render")
+	}
 
 	// Initial selection should be on Instances header
 	sel := s.GetSelection()

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -26,6 +26,11 @@ const deadIcon = "○ "
 // differently from "dead" by shape as well as color.
 const lostIcon = "◌ "
 
+// archivedIcon marks an archived session (#1028): a filed-away box glyph, muted.
+// Deliberately distinct in shape from the running/ready/lost dots so an archived
+// row reads as "put away, restartable" rather than any live/vanished state.
+const archivedIcon = "▧ "
+
 // expandedArrow/collapsedArrow mark an instance row whose tab children are
 // shown/hidden; nonExpandableArrow keeps transient rows (never expandable, see
 // Expandable) aligned with their siblings.
@@ -49,6 +54,12 @@ var deadStyle = lipgloss.NewStyle().
 // healthy green either.
 var lostStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#C18401", Dark: "#E5C07B"})
+
+// archivedStyle paints an archived session's dot + dims its title (#1028): the
+// same muted gray as a deleting/dead recede, so a filed-away session never reads
+// as live. Reused for the title/desc foreground below.
+var archivedStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
 
 // InstanceTitleColor is the foreground of an unselected instance title — the
 // adaptive near-black (light) / near-white (dark) that reads as primary text
@@ -207,6 +218,8 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		join = deadStyle.Render(deadIcon)
 	case session.Lost:
 		join = lostStyle.Render(lostIcon)
+	case session.Archived:
+		join = archivedStyle.Render(archivedIcon)
 	default:
 	}
 
@@ -230,6 +243,13 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		// Dim the branch/PR lines too: on a selected row descS is the
 		// high-contrast selectedDescStyle, and leaving it bright makes the
 		// secondary lines stand out more than the dimmed title (#853).
+		descS = descS.Foreground(deletingTitleColor)
+	}
+	// An archived row (#1028) is explicitly marked and dimmed so it reads as
+	// "filed away, restartable" — restore with A — rather than a live session.
+	if status == session.Archived {
+		titleText = "[archived] " + titleText
+		titleS = titleS.Foreground(deletingTitleColor)
 		descS = descS.Foreground(deletingTitleColor)
 	}
 	widthAvail := r.width - 3 - prefixWidth - 1


### PR DESCRIPTION
**Part 6 of 6** for #1028 — the TUI surface. **Closes #1028.** Approved design: https://github.com/sachiniyer/agent-factory/issues/1028#issuecomment-4881997066

Builds on PRs 1–5 (all merged); targets `master` directly. TUI-only — all the daemon/CLI plumbing already exists.

### What it does
- **Sidebar:** a collapsed **"Archived (N)"** folder pinned at the bottom of the rail. `rebuildVisibleItems` partitions the projection by status — live sessions in the Instances tree, archived ones as flat rows under the Archived folder (no live tabs). Collapsed by default; **hidden entirely when nothing is archived**. Header counts are partitioned (`Instances (live)` / `Archived (n)`). `ItemIndex` stays a projection index in both sections so selection/rendering resolve uniformly (`isInstanceRow` helper); `SetSelectedInstance` expands whichever folder holds the target.
- **Re-partition on status flip:** `structureSig` folds in the archived index set — a flip to/from `Archived` mutates an instance in place and doesn't bump the projection Version, so without this the rail wouldn't re-partition until the next structural change.
- **Rendering:** archived rows get a distinct muted dot (`▧`) + a dimmed `[archived]` title marker, so a filed-away session never reads as live.
- **Key `A`:** archives a live row (behind a confirmation — it tears down tmux and relocates the worktree) and restores an archived row (no confirm). Both route through the daemon RPCs off the event loop, mirroring the kill flow; the row moves folders on the next Snapshot reconcile. Remote/`--here` sessions are rejected up front.
- **Enter/attach are section-aware:** an archived row is non-attachable and surfaces *"session is archived — restore it first"* (the #935-style fence from PR 1) rather than a silent no-op.
- **Docs:** README key table + Sessions section.

### Tests
Sidebar partitioning (folder appears/hidden, counts, collapsed-by-default, archived row selectable + `[archived]` marker) · app archive-confirm / restore routing + the daemon-seam commands · `handleEnter` archived fence · keys table (`A` → `KeyArchive`). **Full suite green under `make test-container`**; lint + deadcode + gofmt clean.

### Visible change → play-test
This is the visible capstone; ready for your docker play-test via the #1166 driver:
create instance → `A` (confirm) → row drops into the collapsed **Archived** folder, tmux down, worktree moved to `<AF_HOME>/archived/<repoID>/<title>/` → `A` on the archived row → worktree moves back, agent re-spawns, row returns live.

**Do not merge on my authority** — for you to verify + play-test.

— Captain Claude