### PR TITLE
test(daemon): de-flake TestWatcherDrainExpiresAgedEvents timing race

### DIFF
--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -85,6 +85,11 @@ type eventQueue struct {
 
 	dropped     int // events dropped to the overflow caps, for the drop log
 	lastDropLog time.Time
+
+	// now stamps each event's enqueue timestamp; a seam so tests can backdate
+	// events into the past and exercise age-based expiry deterministically,
+	// with no real-time sleep. Defaults to time.Now in production.
+	now func() time.Time
 }
 
 // eventQueueDir resolves the queue directory, creating it on first use.
@@ -108,6 +113,7 @@ func newEventQueue(dir, taskID string) *eventQueue {
 		taskID:  taskID,
 		path:    filepath.Join(dir, taskID+".jsonl"),
 		curPath: filepath.Join(dir, taskID+".cursor"),
+		now:     time.Now,
 	}
 	q.load()
 	return q
@@ -190,7 +196,7 @@ func (q *eventQueue) enqueue(line string) error {
 	defer q.mu.Unlock()
 
 	q.seq++
-	rec, err := json.Marshal(queuedEvent{Seq: q.seq, TS: time.Now(), Line: line})
+	rec, err := json.Marshal(queuedEvent{Seq: q.seq, TS: q.now(), Line: line})
 	if err != nil {
 		return err
 	}

--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -314,18 +314,25 @@ func TestWatcherDrainExpiresAgedEvents(t *testing.T) {
 	fd := &flakyDeliver{}
 	fd.healed.Store(true)
 	s.deliver = fd.deliver
-	s.queueMaxAge = 150 * time.Millisecond
+	// A generous bound: the "fresh" event has the whole window to be delivered,
+	// which no CI stall approaches — while the stale events are backdated an
+	// hour, an enormous margin past it. The seam replaces the old
+	// "200ms sleep > 150ms max-age" race, which crossed the boundary
+	// unpredictably under arm64/CI load.
+	s.queueMaxAge = 5 * time.Second
 	queueDir, _ := s.queueDir()
 
-	// Two events queued before the watcher exists; both age past the bound.
+	// Two events queued before the watcher exists, backdated an hour so they
+	// are unambiguously past the retention bound — no real-time sleep.
 	seed := newEventQueue(queueDir, "ab130005")
+	seed.now = func() time.Time { return time.Now().Add(-time.Hour) }
 	for _, line := range []string{"stale-1", "stale-2"} {
 		if err := seed.enqueue(line); err != nil {
 			t.Fatalf("seed enqueue: %v", err)
 		}
 	}
-	time.Sleep(200 * time.Millisecond)
-	// A fresh third event right at reload time must still be delivered.
+	// A fresh third event stamped at real now must still be delivered.
+	seed.now = time.Now
 	if err := seed.enqueue("fresh"); err != nil {
 		t.Fatalf("seed enqueue fresh: %v", err)
 	}


### PR DESCRIPTION
## What

Fixes the `TestWatcherDrainExpiresAgedEvents` flake that failed a **master arm64 Build** (run 28711521802, 2026-07-04) at 10.21s — causally unrelated to the docs push that triggered it. No issue filed; direct CI-hygiene fix.

## Root cause

The test asserted age-based expiry using **real elapsed time**: `queueMaxAge = 150ms`, then `time.Sleep(200ms)`, expecting the queued events to have aged past the bound. Two ways this crosses the boundary unpredictably under load (esp. arm64):

- The 50ms margin between the 150ms max-age and the 200ms wait is too tight for a loaded/slow runner.
- The **"fresh"** event only had a 150ms window to be delivered before it, too, aged out and got expired — failing the "fresh must replay" assertion whenever the drain was slow.

Same class as the #1165 proctree and #882 sigterm de-flakes: real-time margins + CI load.

## Fix

Add a small clock seam to `eventQueue` — `now func() time.Time`, defaulting to `time.Now` in production and used to stamp each event's enqueue timestamp. The test now:

- backdates the two stale events **an hour** into the past (`seed.now = func() time.Time { return time.Now().Add(-time.Hour) }`), so they are unambiguously past the retention bound, and
- sets a **generous 5s** `queueMaxAge`, giving the fresh event the whole window to be delivered — no CI stall approaches it — with **no real-time sleep at all**.

Behavior asserted is unchanged: aged events are expired-not-delivered at drain, the fresh event replays, and the queue files are removed.

## Audit adjacent

Checked the sibling sleeps in `watcher_test.go` (149/194 assert nothing respawned after a clean exit / tripped breaker; 189 is a backoff **lower** bound). All are negative or lower-bound assertions — a slow machine only makes them *safer*, never flaky. No sibling fix needed.

## Verification

- `gofmt -l` clean, `go build ./...` ok
- **50× green**: `make test-container GOTESTARGS='-count=50 -run TestWatcher ./daemon/...'` → `ok  daemon  135.026s`
- `make test-container GOTESTARGS='-run "TestEventQueue|TestWatcher|TestOutage" ./daemon/...'` → `ok`

Do not merge — root verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)