### PR TITLE
ci: lint Go files over 1000 lines with grandfathered allowlist (#1145)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,3 +52,6 @@ jobs:
             echo "$out"
             exit 1
           fi
+
+      - name: Check file lengths
+        run: scripts/lint-file-length.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,9 @@ jobs:
             exit 1
           fi
 
+      - name: Check file lengths
+        run: scripts/lint-file-length.sh
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,17 @@ gofmt -w .
 golangci-lint run --timeout=3m --fast
 gofmt -l .   # should produce no output
 deadcode -test ./...   # should produce no output
+scripts/lint-file-length.sh   # or: make lint-file-length
 ```
 
 Install the `deadcode` binary once with `go install golang.org/x/tools/cmd/deadcode@v0.36.0`; CI pins the same version (`@latest` requires Go 1.25+, above this project's Go floor — see #637).
+
+**File-length lint (#1145):** `scripts/lint-file-length.sh` fails if any Go
+file exceeds its line limit — 1000 lines for production code, 1500 for
+`*_test.go` — unless it's grandfathered in `scripts/file-length-allowlist.txt`.
+Grandfathered files carry a ceiling that ratchets (they can only shrink, and
+their entry must be removed once decomposed under the limit). Don't grandfather
+new files to dodge the limit — split them. See `docs/file-length-lint.md`.
 
 ## Project Structure
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,14 @@
 # See docs/container-testing.md.
 
 .PHONY: test-container playtest-container playtest-container-detached \
-	tui-driver tui-driver-selftest testbox-image
+	tui-driver tui-driver-selftest testbox-image lint-file-length
+
+# Structural-health lint (#1145): fail if any Go file exceeds its line limit
+# (1000 for production code, 1500 for *_test.go) unless grandfathered in
+# scripts/file-length-allowlist.txt. Runs on the host — no container needed.
+# See docs/file-length-lint.md.
+lint-file-length:
+	scripts/lint-file-length.sh
 
 # Full `go test ./...` inside the container — the one sanctioned way to run
 # the bare full suite on a shared box. Narrow or extend the run with

--- a/docs/file-length-lint.md
+++ b/docs/file-length-lint.md
@@ -1,0 +1,68 @@
+# File-length lint (#1145)
+
+A structural-health guard that keeps Go source files from silently growing
+into 2000-line monsters. Large files are decomposition candidates and a
+recurring source of merge pain and gotchas, so CI now bounds them.
+
+## What it checks
+
+`scripts/lint-file-length.sh` counts the **total physical lines** (`wc -l`) of
+every tracked Go file and fails if a file is over its limit:
+
+| File kind      | Limit       |
+| -------------- | ----------- |
+| production `.go` | 1000 lines |
+| `*_test.go`      | 1500 lines |
+
+Total lines — not non-blank/non-comment lines — is what a reader scrolls
+through and what your editor's gutter shows; it needs no Go parsing and is
+unambiguous. Test files get a higher ceiling because table-driven tests run
+legitimately longer, but they're still bounded.
+
+## The allowlist (grandfathering + ratchet)
+
+Several files already exceeded these limits when the lint landed. They're
+grandfathered in `scripts/file-length-allowlist.txt`, one `path ceiling` per
+line, where `ceiling` is the file's line count at grandfathering time.
+
+The ceiling is a **ratchet**: a grandfathered file may not grow past it, so
+the big files can only shrink. When a file is decomposed back under the base
+limit, remove its entry — the lint fails if a grandfathered file has already
+dropped to/under the limit (a dead entry), so the allowlist can't rot.
+
+Do **not** add new entries to dodge the limit. A brand-new file over the limit
+should be split, not grandfathered.
+
+The currently grandfathered files (the structural-health audit tracks
+splitting them):
+
+| File                       | Ceiling |
+| -------------------------- | ------- |
+| `daemon/control.go`        | 2765    |
+| `session/backend_test.go`  | 2241    |
+| `app/app.go`               | 1889    |
+| `session/instance.go`      | 1531    |
+| `session/tmux/tmux.go`     | 1424    |
+| `ui/sidebar.go`            | 1258    |
+| `config/config.go`         | 1128    |
+| `ui/task_pane.go`          | 1050    |
+| `daemon/watcher.go`        | 1046    |
+| `session/backend_hook.go`  | 1026    |
+
+## Running it
+
+```bash
+scripts/lint-file-length.sh      # or: make lint-file-length
+```
+
+It runs in CI as the **Check file lengths** step of the lint job in both
+`.github/workflows/pr.yml` (PR gate) and `.github/workflows/lint.yml` (master
+push).
+
+## When CI fails on this
+
+- **New file over the limit** → split it into focused files.
+- **Grandfathered file grew past its ceiling** → you added to a file that's
+  already too big; move the new code elsewhere or decompose the file.
+- **Dead allowlist entry** → you shrank a file under its limit; delete its
+  line from the allowlist.

--- a/scripts/file-length-allowlist.txt
+++ b/scripts/file-length-allowlist.txt
@@ -1,0 +1,31 @@
+# file-length-allowlist.txt — grandfathered oversized Go files (#1145)
+#
+# Each line: <path> <ceiling>
+#   <path>    repo-relative path (as `git ls-files` prints it)
+#   <ceiling> the file's line count when the length lint was introduced
+#
+# These files already exceeded the length limit (1000 lines for production
+# code, 1500 for *_test.go) when scripts/lint-file-length.sh landed. They are
+# grandfathered pending decomposition — the structural-health audit tracks
+# splitting them. The ceiling acts as a RATCHET: a grandfathered file may not
+# grow past its ceiling, so the big files can only shrink. Once a file is
+# decomposed back under the base limit, delete its entry here (the lint fails
+# if a grandfathered file has already dropped under the limit, so the list
+# can't rot).
+#
+# Do NOT add new entries to dodge the limit. A new file over the limit should
+# be split, not grandfathered.
+
+# --- production code (limit 1000) ---
+daemon/control.go 2765
+app/app.go 1889
+session/instance.go 1531
+session/tmux/tmux.go 1424
+ui/sidebar.go 1258
+config/config.go 1128
+ui/task_pane.go 1050
+daemon/watcher.go 1046
+session/backend_hook.go 1026
+
+# --- test code (limit 1500) ---
+session/backend_test.go 2241

--- a/scripts/lint-file-length.sh
+++ b/scripts/lint-file-length.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# lint-file-length.sh — structural-health lint (#1145).
+#
+# Fails if any tracked Go source file is longer than its line limit, unless
+# the file is grandfathered in scripts/file-length-allowlist.txt.
+#
+# WHAT WE COUNT: total physical lines (`wc -l`), not non-blank/non-comment
+# lines. Total lines is exactly what a reader scrolls through and what an
+# editor's gutter reports; it needs no Go parsing, and it's stable and
+# unambiguous. A file padded with blanks/comments to 1000+ lines is still a
+# file worth a second look, so counting them is a feature, not a bug.
+#
+# LIMITS:
+#   production .go : 1000 lines
+#   *_test.go      : 1500 lines  — table-driven tests run legitimately longer,
+#                                  so they get a higher ceiling but are still
+#                                  bounded (a 3000-line test file is still a
+#                                  decomposition candidate).
+#
+# ALLOWLIST (scripts/file-length-allowlist.txt): files already over their
+# limit when this lint landed. Each entry pins a CEILING = the file's size at
+# grandfathering time. A grandfathered file may not grow past its ceiling
+# (ratchet — the big files can only shrink), and once decomposed back under
+# the base limit its entry must be removed (this script fails if a
+# grandfathered file has dropped to/under the limit, so the list can't rot).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+MAX_PROD=1000
+MAX_TEST=1500
+ALLOWLIST="scripts/file-length-allowlist.txt"
+
+# Report a failure line and flip the exit flag. Uses ::error:: so GitHub
+# Actions surfaces it as an annotation; harmless as plain text locally.
+fail=0
+err() {
+	echo "::error::$*"
+	fail=1
+}
+
+base_limit() {
+	case "$1" in
+	*_test.go) echo "$MAX_TEST" ;;
+	*) echo "$MAX_PROD" ;;
+	esac
+}
+
+# Load the allowlist into path -> ceiling.
+declare -A CEIL
+if [[ -f "$ALLOWLIST" ]]; then
+	while read -r path ceil _; do
+		[[ -z "${path:-}" || "$path" == \#* ]] && continue
+		if ! [[ "$ceil" =~ ^[0-9]+$ ]]; then
+			err "$ALLOWLIST: malformed entry for '$path' (expected '<path> <ceiling>')"
+			continue
+		fi
+		CEIL["$path"]="$ceil"
+	done <"$ALLOWLIST"
+fi
+
+# 1. Enforce limits across every tracked Go file.
+while IFS= read -r path; do
+	lines=$(wc -l <"$path")
+	limit=$(base_limit "$path")
+	if [[ -n "${CEIL[$path]+x}" ]]; then
+		ceil="${CEIL[$path]}"
+		if ((lines > ceil)); then
+			err "$path has $lines lines, over its grandfathered ceiling of $ceil. Do not grow a file already past the $limit-line limit — decompose it instead (#1145)."
+		fi
+	elif ((lines > limit)); then
+		err "$path has $lines lines, over the $limit-line limit. Split it into smaller files; only grandfather it in $ALLOWLIST if a split is genuinely infeasible (#1145)."
+	fi
+done < <(git ls-files -- '*.go')
+
+# 2. Keep the allowlist honest: entries must exist and must still be over the
+#    base limit (otherwise the file has been decomposed and the entry is dead).
+for path in "${!CEIL[@]}"; do
+	if [[ ! -f "$path" ]]; then
+		err "$ALLOWLIST lists '$path', which no longer exists — remove that entry."
+		continue
+	fi
+	lines=$(wc -l <"$path")
+	limit=$(base_limit "$path")
+	if ((lines <= limit)); then
+		err "$path is now $lines lines (<= $limit) — it's under the limit, so remove its entry from $ALLOWLIST."
+	fi
+done
+
+if ((fail)); then
+	echo "file-length lint failed. See docs/file-length-lint.md" >&2
+	exit 1
+fi
+
+echo "file-length lint passed ($(git ls-files -- '*.go' | wc -l | tr -d ' ') Go files checked; ${#CEIL[@]} grandfathered)."


### PR DESCRIPTION
## What

Structural-health guard (#1145): CI now fails when a Go source file grows past its line limit, so large files can't silently balloon into decomposition/merge hazards.

## Design — grandfather + enforce-new (+ ratchet)

- **`scripts/lint-file-length.sh`** counts **total physical lines** (`wc -l`) per tracked Go file. Total lines is what a reader scrolls through and what an editor's gutter shows — no Go parsing, unambiguous, and a file padded to 1000+ lines is still worth a second look.
  - production `.go`: **1000** lines
  - `*_test.go`: **1500** lines — table-driven tests run legitimately longer, so a higher ceiling, but still bounded (a 3000-line test file is still a decomposition candidate).
- **`scripts/file-length-allowlist.txt`** grandfathers the current offenders, each pinned to a **ceiling** = its size today. The ceiling **ratchets**: a grandfathered file may not grow past it (big files can only shrink), and once decomposed under the base limit its entry must be removed — the lint fails on a *dead* entry (file now under limit, or missing), so the allowlist can't rot. New files over the limit are **not** grandfathered; they must be split.
- Wired into the **lint job of both `pr.yml` (PR gate) and `lint.yml` (master push)** as a `Check file lengths` step. Added `make lint-file-length` and documented in `CLAUDE.md` + `docs/file-length-lint.md`.

## Grandfathered files (structural-health audit tracks splitting these)

| File | Ceiling |
| --- | --- |
| `daemon/control.go` | 2765 |
| `session/backend_test.go` | 2241 |
| `app/app.go` | 1889 |
| `session/instance.go` | 1531 |
| `session/tmux/tmux.go` | 1424 |
| `ui/sidebar.go` | 1258 |
| `config/config.go` | 1128 |
| `ui/task_pane.go` | 1050 |
| `daemon/watcher.go` | 1046 |
| `session/backend_hook.go` | 1026 |

## Verification

- `scripts/lint-file-length.sh` → passes on this branch (335 Go files checked, 10 grandfathered).
- Failure paths exercised locally: new >1000-line file fails; growth past a ceiling fails; dead allowlist entry (under limit or nonexistent) fails.
- `gofmt -l .` empty, `go build ./...` OK, `shellcheck scripts/lint-file-length.sh` clean.
- No Go source touched, so the test suite is unaffected — leaving `make test-container` as the final gate for root verification.

Closes #1145

🤖 Generated with [Claude Code](https://claude.com/claude-code)