### PR TITLE
refactor(tui): route TUI task writes through daemon RPCs — daemon is sole task writer (#1029 follow-up) [PR 6/6]

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/config"
-	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -934,21 +933,26 @@ func (m *home) saveContentPaneState() error {
 	// Collect every persist failure instead of swallowing them: a partial
 	// failure must still surface so the user knows their edit didn't fully
 	// land (matches api/tasks.go, which propagates these errors).
+	//
+	// The writes route through the daemon (#1029 PR 6): the daemon is the sole
+	// writer of tasks.json among clients (#960), so a TUI edit/delete goes
+	// through the same RPC wrappers the CLI uses instead of touching the file
+	// directly. Each CRUD RPC re-arms the daemon's scheduler + watchers
+	// in-process, so there is no separate ReloadTasks poke here — the write and
+	// its schedule refresh are one atomic daemon call (removing the old
+	// double-reload).
 	for _, tsk := range sp.GetTasks() {
-		if err := task.UpdateTask(tsk); err != nil {
+		if err := updateTaskThroughDaemon(tsk); err != nil {
 			log.ErrorLog.Printf("failed to update task: %v", err)
 			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save task %q: %w", tsk.Name, err))
 		}
 	}
 	for _, tsk := range sp.ConsumeDeleted() {
-		if err := task.RemoveTask(tsk.ID); err != nil {
+		if err := removeTaskThroughDaemon(tsk.ID); err != nil {
 			log.ErrorLog.Printf("failed to remove task: %v", err)
 			saveErr = errors.Join(saveErr, fmt.Errorf("failed to remove task %q: %w", tsk.Name, err))
 		}
 	}
-	// Schedules live in the daemon (#782): a single reload poke after
-	// the batched writes brings its cron entries in sync.
-	reloadDaemonTaskSchedules()
 	// Reload BOTH panes from disk so the TaskPane and sidebar can never diverge
 	// (#934): whatever actually committed, both panes now show it.
 	tasks, err := task.LoadTasksForCurrentRepo()
@@ -964,23 +968,10 @@ func (m *home) saveContentPaneState() error {
 	return saveErr
 }
 
-// reloadDaemonTaskSchedulesFn is indirected so TUI tests can observe the poke
-// without dialing (or spawning) a real daemon.
-var reloadDaemonTaskSchedulesFn = daemon.ReloadTasks
-
 // saveInRepoPostWorktreeCommandsFn is indirected so TUI tests can force a
 // hooks-save failure deterministically — without relying on filesystem
 // permission tricks that a root test runner would bypass (#1001).
 var saveInRepoPostWorktreeCommandsFn = config.SaveInRepoPostWorktreeCommands
-
-// reloadDaemonTaskSchedules asks the daemon to re-read tasks.json after a
-// TUI-side task edit. Best-effort: the daemon reloads all tasks at every
-// start, so a failed poke only delays the change until then.
-func reloadDaemonTaskSchedules() {
-	if err := reloadDaemonTaskSchedulesFn(); err != nil {
-		log.WarningLog.Printf("task change saved, but the daemon schedule reload failed (the change applies at next daemon start): %v", err)
-	}
-}
 
 // handleTaskCreate processes a pending task creation from the inline form.
 func (m *home) handleTaskCreate() tea.Cmd {
@@ -1032,10 +1023,13 @@ func (m *home) handleTaskCreate() tea.Cmd {
 		Enabled:       true,
 		CreatedAt:     time.Now(),
 	}
-	if err := task.AddTask(t); err != nil {
+	// Route the create through the daemon (#1029 PR 6): it is the sole writer of
+	// tasks.json among clients (#960) and re-arms its own scheduler/watchers in
+	// the same RPC, so there is no separate ReloadTasks poke — the write and its
+	// schedule refresh are one atomic daemon call.
+	if err := addTaskThroughDaemon(t); err != nil {
 		return m.handleError(fmt.Errorf("failed to save task: %v", err))
 	}
-	reloadDaemonTaskSchedules()
 	// Refresh sidebar and task pane
 	tasks, err := task.LoadTasksForCurrentRepo()
 	if err == nil {

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/layout/zones"
@@ -30,11 +31,14 @@ func newTestHome(t *testing.T) *home {
 	tmp := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", tmp)
 
-	// Task save paths poke the daemon to reload schedules (#782); stub the
-	// poke so tests never dial — or spawn — a real daemon.
-	origReload := reloadDaemonTaskSchedulesFn
-	reloadDaemonTaskSchedulesFn = func() error { return nil }
-	t.Cleanup(func() { reloadDaemonTaskSchedulesFn = origReload })
+	// TUI task CRUD routes through the daemon (#1029 PR 6). Point the write
+	// seams at the direct task writers so tests never dial — or spawn — a real
+	// daemon, while the existing disk-assertion tests (which read tasks.json
+	// after driving the handlers) keep exercising the save orchestration
+	// unchanged. Tests asserting the daemon-dispatch itself swap in a recorder.
+	t.Cleanup(SetTaskAdderForTest(task.AddTask))
+	t.Cleanup(SetTaskUpdaterForTest(task.UpdateTask))
+	t.Cleanup(SetTaskRemoverForTest(task.RemoveTask))
 
 	// The tab + PR-info mutations now route through daemon RPCs (#960 PR 2).
 	// Stub the seams with safe defaults so tests that incidentally trigger them

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -243,6 +243,140 @@ func TestHandleStateTasks_ValidationFailureLeavesTaskPaneStale(t *testing.T) {
 		"reloading from disk clears dirty; the dropped edit is communicated via the error, not a dangling dirty flag")
 }
 
+// TestHandleTaskCreate_RoutesThroughDaemonRPC is the #1029 PR 6 guard for the
+// create path: the TUI inline create form must persist the new task through the
+// daemon RPC — the sole writer of tasks.json among clients (#960) — not by
+// writing the file directly. We swap the add seam for a recorder and assert (a)
+// it received the composed task and (b) nothing touched tasks.json on disk, so
+// the TUI no longer originates a task write.
+func TestHandleTaskCreate_RoutesThroughDaemonRPC(t *testing.T) {
+	h := newTestHome(t)
+
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+
+	var got *task.Task
+	calls := 0
+	// Overrides newTestHome's default (direct disk writer) with a recorder.
+	t.Cleanup(SetTaskAdderForTest(func(tk task.Task) error {
+		calls++
+		got = &tk
+		return nil
+	}))
+
+	tp := h.automations.TaskPane()
+	tp.SetTasks(nil)
+	_, _ = h.showTasksOverlay()
+	require.Equal(t, stateTasks, h.state)
+
+	// Fill and submit the inline create form (the same key path a user drives).
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	require.True(t, tp.IsCreating(), "'n' must open the inline create form")
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("new-task")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector (cron stays selected)
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> cron value
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("do a thing")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> target session
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> path
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> program
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> save button
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// (a) The create was dispatched through the daemon seam exactly once, with
+	// the task the user composed.
+	require.Equal(t, 1, calls, "create must route through the daemon RPC, not a direct disk write")
+	require.NotNil(t, got)
+	assert.Equal(t, "new-task", got.Name)
+	assert.Equal(t, "* * * * *", got.CronExpr)
+
+	// (b) The TUI wrote nothing to disk: with the daemon stubbed out, the only
+	// writer, tasks.json holds no task.
+	disk, err := task.LoadTasks()
+	require.NoError(t, err)
+	assert.Empty(t, disk, "TUI must not write tasks.json directly (#960 sole writer)")
+}
+
+// TestSaveContentPaneState_RoutesThroughDaemonRPC is the #1029 PR 6 guard for
+// the edit/delete path: closing the task manager with dirty edits must persist
+// them through the daemon RPCs (update + remove), not by writing tasks.json
+// directly. We seed two tasks, toggle one and delete the other, swap the update
+// and remove seams for recorders, and assert both were dispatched with the right
+// payloads and disk was left untouched.
+func TestSaveContentPaneState_RoutesThroughDaemonRPC(t *testing.T) {
+	h := newTestHome(t)
+
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+
+	keep := task.Task{
+		ID: "keep-1029", Name: "keep", Prompt: "p", CronExpr: "* * * * *",
+		ProjectPath: repo.Root, Program: "claude", Enabled: true, CreatedAt: time.Now(),
+	}
+	gone := task.Task{
+		ID: "gone-1029", Name: "gone", Prompt: "p", CronExpr: "* * * * *",
+		ProjectPath: repo.Root, Program: "claude", Enabled: true, CreatedAt: time.Now(),
+	}
+	require.NoError(t, task.AddTask(keep))
+	require.NoError(t, task.AddTask(gone))
+
+	loaded, err := task.LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	tp := h.automations.TaskPane()
+	tp.SetTasks(loaded)
+	h.store.SetTasks(loaded)
+	_, _ = h.showTasksOverlay()
+	require.Equal(t, stateTasks, h.state)
+
+	// Swap the write seams for recorders AFTER seeding (the seed used the direct
+	// writer); the save-on-close must now dispatch through these instead of disk.
+	var updated []task.Task
+	var removed []string
+	t.Cleanup(SetTaskUpdaterForTest(func(tk task.Task) error { updated = append(updated, tk); return nil }))
+	t.Cleanup(SetTaskRemoverForTest(func(id string) error { removed = append(removed, id); return nil }))
+
+	// Toggle the first task (keep) off — dirty, not yet persisted.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	// Move to the second task (gone) and delete it.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	require.True(t, tp.IsDirty(), "toggle + delete must mark the pane dirty")
+
+	// Esc releases focus → the overlay closes and saveContentPaneState runs.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
+	require.Equal(t, stateDefault, h.state)
+
+	// The remaining task's update and the deleted task's remove both routed
+	// through the daemon seams.
+	require.Len(t, removed, 1, "delete must route through the remove RPC")
+	assert.Equal(t, "gone-1029", removed[0])
+	var sawToggledKeep bool
+	for _, tk := range updated {
+		if tk.ID == "keep-1029" {
+			sawToggledKeep = true
+			assert.False(t, tk.Enabled, "the toggled state must be dispatched to the update RPC")
+		}
+	}
+	assert.True(t, sawToggledKeep, "the surviving task must route through the update RPC")
+
+	// The TUI wrote nothing to disk: with the daemon stubbed out, tasks.json
+	// still holds both seeded tasks, both enabled.
+	disk, err := task.LoadTasks()
+	require.NoError(t, err)
+	require.Len(t, disk, 2, "TUI must not write tasks.json directly (#960 sole writer)")
+	for _, tk := range disk {
+		assert.True(t, tk.Enabled, "the TUI is no longer a tasks.json writer, so disk stays untouched")
+	}
+}
+
 // dirtyHooksHome returns a home wired to a real repo with a single dirty,
 // unsaved hook edit ("echo test") in the HooksPane. The hooks-save seam is
 // left at the caller's discretion (default real save, or a stub).

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -3,6 +3,7 @@ package app
 import (
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
 )
 
 type sessionStartRequest struct {
@@ -57,6 +58,32 @@ var restoreArchivedThroughDaemon = func(title, repoID string) (string, error) {
 // package var so the app test suite can stub the trigger without dialing a real
 // daemon.
 var triggerTaskThroughDaemon = daemon.TriggerTask
+
+// addTaskThroughDaemon / updateTaskThroughDaemon / removeTaskThroughDaemon route
+// the TUI's own task CRUD (create in the inline form, edit/toggle/delete in the
+// task manager) through the daemon (#1029 PR 6), completing the #960 sole-writer
+// invariant for tasks: the daemon is the ONLY process that writes tasks.json
+// among clients. Previously these paths wrote the file directly via
+// task.AddTask/UpdateTask/RemoveTask and then poked ReloadTasks; now they go
+// through the SAME spawning RPC wrappers the CLI uses (api/tasks.go's
+// daemonAddTask/…), and because the daemon's CRUD handlers re-arm the scheduler
+// and watchers in-process (#1029 PR 3), the separate ReloadTasks poke is gone —
+// the write and its schedule refresh are one atomic daemon call. Like the tab
+// create/close RPCs (handleNewTab/handleCloseTab), these are quick daemon writes
+// dispatched synchronously on the event loop — not the tens-of-seconds ssh
+// teardowns that motivate the async kill/archive cmds — so saveContentPaneState
+// keeps its synchronous error-return contract and its callers still gate on it.
+//
+// Package vars so the app test suite can point them at the direct task writers
+// (the existing disk-assertion tests) or at a recorder (the dispatch tests)
+// without dialing — or spawning — a real daemon. Read only on the event loop, so
+// package globals are race-safe here (no off-loop goroutine reads them, unlike
+// the snapshot fetcher / poll-pause seams).
+var (
+	addTaskThroughDaemon    = daemon.AddTask
+	updateTaskThroughDaemon = daemon.UpdateTask
+	removeTaskThroughDaemon = daemon.RemoveTask
+)
 
 // pauseStatusPollThroughDaemon / resumeStatusPollThroughDaemon route the TUI's
 // attach-time poll-pause coordination to the daemon (#1160, Fix A follow-up to
@@ -138,6 +165,28 @@ func SetTaskTriggerForTest(f func(taskID string) error) func() {
 	prev := triggerTaskThroughDaemon
 	triggerTaskThroughDaemon = f
 	return func() { triggerTaskThroughDaemon = prev }
+}
+
+// SetTaskAdderForTest / SetTaskUpdaterForTest / SetTaskRemoverForTest swap the
+// task-write seams (#1029 PR 6) so tests can assert the TUI routes create/edit/
+// remove through the daemon — or point them at the direct task writers — without
+// dialing a real daemon.
+func SetTaskAdderForTest(f func(task.Task) error) func() {
+	prev := addTaskThroughDaemon
+	addTaskThroughDaemon = f
+	return func() { addTaskThroughDaemon = prev }
+}
+
+func SetTaskUpdaterForTest(f func(task.Task) error) func() {
+	prev := updateTaskThroughDaemon
+	updateTaskThroughDaemon = f
+	return func() { updateTaskThroughDaemon = prev }
+}
+
+func SetTaskRemoverForTest(f func(id string) error) func() {
+	prev := removeTaskThroughDaemon
+	removeTaskThroughDaemon = f
+	return func() { removeTaskThroughDaemon = prev }
 }
 
 func SetRemoteImporterForTest(f func(repoPath string) ([]session.InstanceData, error)) func() {

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -607,16 +607,6 @@ func DeliverPrompt(req DeliverPromptRequest) (string, error) {
 	return resp.Status, nil
 }
 
-// ReloadTasks asks the daemon to re-read tasks.json and rebuild its cron
-// schedule set. Task CRUD paths (CLI, API, TUI) call this after writing the
-// file so schedule changes take effect without a daemon restart. Like every
-// callDaemon path it ensures the daemon is running first, so adding a task
-// also brings the scheduler up.
-func ReloadTasks() error {
-	var resp ReloadTasksResponse
-	return callDaemon("ReloadTasks", ReloadTasksRequest{}, &resp)
-}
-
 // ListTasksNoSpawn returns the daemon's authoritative task list WITHOUT
 // starting a daemon (#1029 PR 3). Like SnapshotNoSpawn it dials the existing
 // control socket only if it is already serving and returns ErrDaemonUnavailable


### PR DESCRIPTION
## Summary

Completes the #960 "daemon is the sole writer" invariant for **tasks**. PR3 (#1181) added daemon task RPCs (`AddTask`/`UpdateTask`/`RemoveTask`) and routed the CLI + the TUI run-now trigger through them, but left the TUI's *own* task CRUD writing `tasks.json` **directly**. This PR migrates those last client-side task writes to the daemon RPC wrappers, so the daemon is the literal sole writer of `tasks.json` among clients.

Follow-up to #1029 (closed), completing the #960 sole-writer invariant for tasks. Since #960 the TUI is a read-only projection + RPC client; this makes the task path consistent with that model. The on-disk `tasks.json` format is unchanged, and behavior from the user's POV (create/edit/toggle/remove a task in the TUI) is preserved.

## What changed

- **`saveContentPaneState`** (edit/toggle/delete on task-manager close): `task.UpdateTask`/`task.RemoveTask` → `updateTaskThroughDaemon`/`removeTaskThroughDaemon`.
- **`handleTaskCreate`** (inline create form): `task.AddTask` → `addTaskThroughDaemon`.
- **New seams** in `app/session_control.go`: `addTaskThroughDaemon`/`updateTaskThroughDaemon`/`removeTaskThroughDaemon` = `daemon.AddTask`/`UpdateTask`/`RemoveTask`, with `SetTask{Adder,Updater,Remover}ForTest` helpers. These mirror the existing TUI→daemon RPC seam pattern (session create/kill/archive, tab create/close) and the CLI's `daemonAddTask`/… vars in `api/tasks.go` — the same **spawning** wrappers, so a TUI task write behaves exactly like the merged CLI task CRUD.
- **Removed the now-redundant `ReloadTasks` pokes.** The daemon's CRUD RPC handlers already re-arm the scheduler + watchers **in-process** (PR3), so the write and its schedule refresh are one atomic daemon call. This also let me delete the dead `reloadDaemonTaskSchedules`/`reloadDaemonTaskSchedulesFn` helper and the now-orphaned `daemon.ReloadTasks` client wrapper (its only caller was the removed poke; the `ReloadTasks` RPC endpoint/handler stays, still exercised by daemon tests).

## Dispatch model (sync vs async)

Task CRUD is a **quick** daemon write (small JSON file + in-process cron/watcher reload), so it is dispatched **synchronously on the event loop**, matching the existing tab create/close RPC precedent (`handleNewTab`/`handleCloseTab`). The async `tea.Cmd` pattern (`killInstanceCmd`/`archiveInstanceCmd`) exists specifically for the tens-of-seconds ssh teardowns — a different class. Keeping it synchronous preserves `saveContentPaneState`'s synchronous `error`-return contract, which its callers strictly gate on (abort quit on failure, flush dirty edits before create/trigger). Error surfacing is unchanged (`handleError`), matching the session-RPC pattern.

## Sole-writer confirmation (grep)

After this change, the only non-test code that writes `tasks.json` is inside the `daemon` and `task` packages:

```
$ grep -rn "task\.AddTask\|task\.UpdateTask\|task\.RemoveTask\|task\.SaveTasks\|saveTasks(" \
    --include="*.go" . | grep -v "_test.go" | grep -v "^\s*//"
task/task.go        # saveTasks impl + AddTask/UpdateTask/RemoveTask/UpdateTaskStatus internals
daemon/control.go   # AddTask/UpdateTask/RemoveTask RPC handlers (the daemon)
daemon/taskrun.go   # UpdateTaskStatus (daemon scheduler status write)
daemon/watcher.go   # UpdateTaskStatus (daemon watcher status write)
```

Zero direct `tasks.json` writers remain in `app/`, `ui/`, `api/`, or `cmd/`. The `daemon`-package writes stay because they **are** the daemon (the RPC handlers + the scheduler/watcher status writes).

## Tests

- Added `TestHandleTaskCreate_RoutesThroughDaemonRPC` and `TestSaveContentPaneState_RoutesThroughDaemonRPC`: drive the real key sequences, swap the write seams for recorders, and assert (a) create/update/remove dispatch through the daemon seams with the right payloads and (b) the TUI writes nothing to `tasks.json` on disk.
- Existing disk-assertion tests (#578 flush ordering, #934 failure recovery) are preserved: `newTestHome` now points the write seams at the direct task writers, so the save-orchestration logic stays under test unchanged.

## Verification

- `gofmt -l .` clean
- `golangci-lint run --timeout=3m --fast` clean
- `go build ./...` clean
- `deadcode -test ./...` clean
- Full suite via `make test-container` — all packages green (incl. `daemon`, `integration`, `app`, `ui`, `api`, `task`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude
