### PR TITLE
feat(limit): usage-limit detector + reset-time parser (#1146) [PR 1/4]

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -167,6 +167,11 @@ type Config struct {
 	// in-repo config must never be able to opt a machine into an always-on
 	// agent just by being cloned.
 	RootAgents map[string]RootAgentConfig `json:"root_agents,omitempty" toml:"root_agents,omitempty"`
+	// LimitPatterns optionally overrides, per agent, the built-in usage-limit
+	// banner-detection regex (#1146) so drifting vendor banners can be patched
+	// without a release. Empty keeps every built-in default. See
+	// sanitizeLimitPatterns in limit_patterns.go for validation and semantics.
+	LimitPatterns map[string]string `json:"limit_patterns,omitempty" toml:"limit_patterns,omitempty"`
 	// Keys is the raw [keys] rebinding table (#1026): action name → a key
 	// string or list of key strings, replacing that action's default binding
 	// entirely (unlisted actions keep their defaults). TOML-ONLY by design —
@@ -254,24 +259,6 @@ func ValidateProgramEnum(lead, referent, name, exampleValue string) error {
 	)
 }
 
-// prettyHomePath returns absPath with the user's home directory prefix
-// collapsed to "~". Used to render config-file paths in user-facing errors
-// without leaking the absolute filesystem layout. Returns absPath unchanged
-// when the home directory cannot be determined or is not a prefix.
-func prettyHomePath(absPath string) string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil || homeDir == "" {
-		return absPath
-	}
-	if absPath == homeDir {
-		return "~"
-	}
-	if strings.HasPrefix(absPath, homeDir+string(filepath.Separator)) {
-		return "~" + absPath[len(homeDir):]
-	}
-	return absPath
-}
-
 // ResolveProgram returns the actual tmux invocation for an agent. When
 // cfg.ProgramOverrides has a non-empty entry for the agent, that value is
 // returned verbatim; otherwise the bare agent name is returned (relying on
@@ -328,20 +315,6 @@ func DefaultConfig() *Config {
 	}
 
 	return cfg
-}
-
-// shellQuotePath wraps a path that contains shell-special characters
-// (spaces, apostrophes) in single quotes, escaping any embedded apostrophes
-// with the standard POSIX '\” idiom. Paths free of those characters are
-// returned unchanged. Used by DefaultConfig when persisting auto-detected
-// claude paths into ProgramOverrides — the value is passed to `sh -c` by
-// tmux, so paths with spaces (e.g. macOS App Bundles, #569) would otherwise
-// be split into separate tokens.
-func shellQuotePath(path string) string {
-	if path == "" || !strings.ContainsAny(path, " '") {
-		return path
-	}
-	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
 }
 
 // claudeProbeResult caches a single (path, err) outcome of the claude shell
@@ -1023,6 +996,8 @@ func validateConfig(config *Config, prettyConfigPath string) (*Config, error) {
 			return nil, err
 		}
 	}
+
+	sanitizeLimitPatterns(config)
 
 	if config.DaemonPollInterval <= 0 {
 		log.WarningLog.Printf("daemon_poll_interval=%d is non-positive; using default %dms", config.DaemonPollInterval, defaultDaemonPollInterval)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1092,6 +1092,31 @@ codex = "/opt/codex/bin/codex --quiet"
 		}
 	})
 
+	t.Run("limit_patterns keeps valid overrides and drops invalid ones", func(t *testing.T) {
+		// A valid override is retained; an uncompilable regex and an
+		// unknown-agent key are warn-and-dropped so the built-in default
+		// stands and the load never fails over an optional detection tweak
+		// (#1146).
+		writeToml(t, `
+default_program = "claude"
+
+[limit_patterns]
+claude = "Custom limit banner"
+codex = "(unclosed"
+notanagent = "whatever"
+`)
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "Custom limit banner", cfg.LimitPatterns[tmux.ProgramClaude],
+			"a valid override must be retained")
+		_, hasCodex := cfg.LimitPatterns[tmux.ProgramCodex]
+		assert.False(t, hasCodex, "an uncompilable regex must be dropped")
+		_, hasUnknown := cfg.LimitPatterns["notanagent"]
+		assert.False(t, hasUnknown, "an unknown-agent key must be dropped")
+	})
+
 	t.Run("unknown keys warn but do not fail the load", func(t *testing.T) {
 		// Rollback tolerance within the TOML era: a newer af's config.toml
 		// (e.g. carrying a future [keys] table) must keep loading here.

--- a/config/limit_patterns.go
+++ b/config/limit_patterns.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// sanitizeLimitPatterns validates the limit_patterns override map in place,
+// dropping any entry that names an unknown agent or whose value is not a
+// compilable Go regexp and logging one warning per drop (#1146).
+//
+// Warn-and-drop, not hard-error: an optional usage-limit detection tweak must
+// never block config load — and thus the whole TUI/CLI — the way a bad key
+// would. The built-in default for that agent simply stands. This mirrors the
+// warn-on-unknown-key posture elsewhere in the loader; the [keys] table is the
+// deliberate hard-error exception. Dropping the bad entry (rather than leaving
+// it in place) guarantees the detector's resolver only ever sees valid
+// overrides, so it never has to re-validate.
+func sanitizeLimitPatterns(config *Config) {
+	for agent, pattern := range config.LimitPatterns {
+		if !isSupportedProgram(agent) {
+			log.WarningLog.Printf("limit_patterns key %q is not one of [%s]; ignoring this override",
+				agent, strings.Join(tmux.SupportedPrograms, ", "))
+			delete(config.LimitPatterns, agent)
+			continue
+		}
+		if _, err := regexp.Compile(pattern); err != nil {
+			log.WarningLog.Printf("limit_patterns[%q]=%q is not a valid regexp (%v); using the built-in default",
+				agent, pattern, err)
+			delete(config.LimitPatterns, agent)
+		}
+	}
+}
+
+// isSupportedProgram reports whether name is one of the canonical agent
+// programs (tmux.SupportedPrograms).
+func isSupportedProgram(name string) bool {
+	for _, supported := range tmux.SupportedPrograms {
+		if name == supported {
+			return true
+		}
+	}
+	return false
+}

--- a/config/paths.go
+++ b/config/paths.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// This file holds the config package's pure path/shell string helpers,
+// extracted from config.go (#1146) to keep that file under its length ceiling
+// (docs/file-length-lint.md). They are behavior-identical to their previous
+// in-config.go definitions — same package, no call-site changes.
+
+// prettyHomePath returns absPath with the user's home directory prefix
+// collapsed to "~". Used to render config-file paths in user-facing errors
+// without leaking the absolute filesystem layout. Returns absPath unchanged
+// when the home directory cannot be determined or is not a prefix.
+func prettyHomePath(absPath string) string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || homeDir == "" {
+		return absPath
+	}
+	if absPath == homeDir {
+		return "~"
+	}
+	if strings.HasPrefix(absPath, homeDir+string(filepath.Separator)) {
+		return "~" + absPath[len(homeDir):]
+	}
+	return absPath
+}
+
+// shellQuotePath wraps a path that contains shell-special characters
+// (spaces, apostrophes) in single quotes, escaping any embedded apostrophes
+// with the standard POSIX '\” idiom. Paths free of those characters are
+// returned unchanged. Used by DefaultConfig when persisting auto-detected
+// claude paths into ProgramOverrides — the value is passed to `sh -c` by
+// tmux, so paths with spaces (e.g. macOS App Bundles, #569) would otherwise
+// be split into separate tokens.
+func shellQuotePath(path string) string {
+	if path == "" || !strings.ContainsAny(path, " '") {
+		return path
+	}
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+}

--- a/task/limit.go
+++ b/task/limit.go
@@ -1,0 +1,375 @@
+package task
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// This file is the usage-limit detection + reset-time parsing layer (#1146,
+// PR1/4). It is the sibling of isReadyContent in runner.go: a pure per-agent
+// matcher over captured tmux pane content, with no I/O and no daemon/TUI
+// wiring. Later PRs consume it — PR2 wires isLimitContent into the daemon's
+// single-writer status refresh and adds a LimitReached status; PR3 schedules
+// an auto-resume off the parsed reset time; PR4 parks (not fails) a task run
+// that hits a limit mid-flight. Keeping this layer pure and table-tested is
+// what lets those PRs build on a trusted detector.
+//
+// Scope of what we schedule against: only the subscription-plan agents
+// (claude, codex) stall at a dead prompt with a parseable reset window, so
+// only they get a matcher here. gemini/aider are API-key-metered — a "limit"
+// there is a transient 429 the CLI already retries, with no plan-reset
+// timestamp to schedule against — so isLimitContent returns hit=false for
+// them in v1. The matcher map is structured so a surface-only entry for them
+// (detect set, parseReset nil) drops in later without touching the core.
+
+// agentLimitMatcher is the per-agent recipe for recognizing a usage-limit
+// banner and, when present, extracting its reset time.
+type agentLimitMatcher struct {
+	// detect matches the usage-limit banner anywhere in captured pane content.
+	// A match means hit=true regardless of whether a reset time can be parsed
+	// — detection must never depend on successful time parsing, so a reworded
+	// or truncated reset phrase still surfaces as a limit hit.
+	detect *regexp.Regexp
+	// parseReset extracts and parses the reset timestamp from content that
+	// detect has already matched, returning an absolute UTC reset time. It
+	// returns ok=false when no reset time is present or it cannot be parsed;
+	// detection still stands. now is the injected clock used to resolve
+	// relative and time-of-day-only forms into an absolute instant — the
+	// tested path never calls time.Now() itself, so tests are deterministic.
+	// nil for a detect-only (surface-only) agent; there are none in v1.
+	parseReset func(content string, now time.Time) (time.Time, bool)
+}
+
+var (
+	// claudeLimitDetect matches Claude Code's stall banner on its invariant
+	// lead sentence, e.g.
+	//   Claude usage limit reached. Your limit will reset at 2pm (America/New_York)
+	// Detection keys only on "Claude usage limit reached." so a reworded reset
+	// clause still surfaces as a hit; parseClaudeReset separately scans for the
+	// "reset at <tail>" phrase, symmetric with the codex detect/parse split.
+	claudeLimitDetect = regexp.MustCompile(`Claude usage limit reached\.`)
+
+	// codexLimitDetect matches Codex's stall banner. The reset phrase ("try
+	// again at <ts>" / "try again in <duration>") is often on a later line, so
+	// detection keys only on the invariant lead clause and reset extraction is
+	// a separate scan (parseCodexReset) over the whole capture. The trailing
+	// punctuation varies — "…usage limit." (weekly) vs "…usage limit, try
+	// again in…" (relative, openai/codex#3031) — so it is intentionally not
+	// anchored here.
+	codexLimitDetect = regexp.MustCompile(`You've hit your usage limit`)
+)
+
+// builtinLimitMatchers returns a fresh map of the shipped per-agent matchers.
+// A fresh map each call keeps resolveLimitMatchers free to swap detect regexes
+// per config without mutating shared state.
+func builtinLimitMatchers() map[string]agentLimitMatcher {
+	return map[string]agentLimitMatcher{
+		tmux.ProgramClaude: {detect: claudeLimitDetect, parseReset: parseClaudeReset},
+		tmux.ProgramCodex:  {detect: codexLimitDetect, parseReset: parseCodexReset},
+	}
+}
+
+// resolveLimitMatchers layers per-agent config overrides on top of the
+// built-in matchers: for each entry in overrides (agent name -> regexp
+// string), it replaces that agent's detect pattern while keeping the built-in
+// reset-time parser. An override for an agent with no built-in matcher
+// (gemini/aider in v1) is ignored — there is no reset parser to pair it with
+// yet, and detection-only surfacing lands in a later PR. An uncompilable
+// pattern is logged and skipped so the built-in default stands; validateConfig
+// already drops such entries, so this is defense in depth for hand-built
+// configs and non-config callers.
+//
+// PR1 has no live call site; the daemon (PR2) will call this once with
+// cfg.LimitPatterns and reuse the result across poll ticks. Taking a plain
+// map keeps the task package decoupled from the config package.
+func resolveLimitMatchers(overrides map[string]string) map[string]agentLimitMatcher {
+	matchers := builtinLimitMatchers()
+	for agent, pattern := range overrides {
+		if pattern == "" {
+			continue
+		}
+		base, ok := matchers[agent]
+		if !ok {
+			// No built-in matcher (and thus no reset parser) for this agent
+			// yet; a detection override alone would surface as an unparseable
+			// hit with no scheduling value. Ignore until surface-only support
+			// exists.
+			log.WarningLog.Printf("limit_patterns override for %q ignored: no built-in usage-limit matcher for that agent yet", agent)
+			continue
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			log.WarningLog.Printf("limit_patterns override for %q is not a valid regexp (%v); using built-in default", agent, err)
+			continue
+		}
+		base.detect = re
+		matchers[agent] = base
+	}
+	return matchers
+}
+
+// isLimitContent reports whether the captured pane content shows a usage-limit
+// banner for the given agent and, when present, the absolute UTC time the
+// limit resets. It is the usage-limit sibling of isReadyContent: callers
+// resolve the canonical agent the pane actually runs
+// (session.Instance.ResolvedAgent) and pass it here.
+//
+// Return contract:
+//   - hit=false: no banner for this agent (or an agent with no matcher, e.g.
+//     gemini/aider in v1). resetAt/hasResetTime are zero.
+//   - hit=true, hasResetTime=true: banner detected and a reset time parsed;
+//     resetAt is that time in UTC.
+//   - hit=true, hasResetTime=false: banner detected but the reset time was
+//     absent or unparseable. Detection never depends on parsing succeeding.
+//
+// matchers is the resolved set (built-ins with config overrides applied);
+// now is the injected clock used to turn time-of-day-only and relative reset
+// phrases into an absolute instant.
+func isLimitContent(content, agent string, matchers map[string]agentLimitMatcher, now time.Time) (hit bool, resetAt time.Time, hasResetTime bool) {
+	matcher, ok := matchers[agent]
+	if !ok || matcher.detect == nil {
+		return false, time.Time{}, false
+	}
+	if !matcher.detect.MatchString(content) {
+		return false, time.Time{}, false
+	}
+	if matcher.parseReset == nil {
+		return true, time.Time{}, false
+	}
+	if reset, parsed := matcher.parseReset(content, now); parsed {
+		return true, reset.UTC(), true
+	}
+	return true, time.Time{}, false
+}
+
+// --- reset-time parsers ---------------------------------------------------
+
+var (
+	// clockTime matches a 12-hour clock token like "2pm", "2:30 PM", "11am".
+	clockTime = regexp.MustCompile(`(?i)\b(\d{1,2})(?::(\d{2}))?\s*([ap])m\b`)
+	// parenTZ captures an IANA timezone inside parentheses, e.g.
+	// "(America/New_York)".
+	parenTZ = regexp.MustCompile(`\(([A-Za-z]+(?:/[A-Za-z_+\-]+)+)\)`)
+	// monthDay matches an optional-year calendar date like "Jul 25th, 2026",
+	// "Nov 6", "November 6 2026". The ordinal suffix and year are optional.
+	monthDay = regexp.MustCompile(`(?i)\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s+(\d{4}))?`)
+	// weekday matches a leading weekday name for the claude weekly variant
+	// when it names a day rather than a date.
+	weekday = regexp.MustCompile(`(?i)\b(sun|mon|tue|wed|thu|fri|sat)[a-z]*\b`)
+
+	monthIndex = map[string]time.Month{
+		"jan": time.January, "feb": time.February, "mar": time.March,
+		"apr": time.April, "may": time.May, "jun": time.June,
+		"jul": time.July, "aug": time.August, "sep": time.September,
+		"oct": time.October, "nov": time.November, "dec": time.December,
+	}
+	weekdayIndex = map[string]time.Weekday{
+		"sun": time.Sunday, "mon": time.Monday, "tue": time.Tuesday,
+		"wed": time.Wednesday, "thu": time.Thursday, "fri": time.Friday,
+		"sat": time.Saturday,
+	}
+)
+
+// claudeResetAnchor locates Claude's reset clause and captures the tail after
+// "reset " up to end of line, e.g. "2pm (America/New_York)" (5h) or "Monday at
+// 9am (…)" / "Nov 6, 2026 9am (…)" (weekly). The "at" is optional because the
+// weekday variant reads "reset Monday at 9am" — "reset <day>" — while the 5h
+// variant reads "reset at 2pm". Kept separate from detection so a reworded
+// reset clause still detects (hit=true) even when this yields no parse.
+var claudeResetAnchor = regexp.MustCompile(`(?i)reset\s+(?:at\s+)?([^\r\n]+)`)
+
+// parseClaudeReset scans content for Claude's "reset at <tail>" clause and
+// resolves the tail, in order: an optional timezone in parens (falling back to
+// now's location when absent — Claude renders in the account tz, which we
+// cannot know without the paren, so the injected clock's zone is the
+// deterministic stand-in), a required 12-hour clock time, and an optional
+// calendar date or weekday (the weekly variant). Without any date it mints the
+// next occurrence of that clock time strictly after now. Returns ok=false when
+// there is no reset clause or no clock time in it, so an unrecognized/reworded
+// tail degrades to hit=true, hasResetTime=false.
+func parseClaudeReset(content string, now time.Time) (time.Time, bool) {
+	anchor := claudeResetAnchor.FindStringSubmatch(content)
+	if anchor == nil {
+		return time.Time{}, false
+	}
+	reset := anchor[1]
+
+	loc := now.Location()
+	if m := parenTZ.FindStringSubmatch(reset); m != nil {
+		if l, err := time.LoadLocation(m[1]); err == nil {
+			loc = l
+		}
+	}
+
+	hour, minute, ok := parseClockTime(reset)
+	if !ok {
+		return time.Time{}, false
+	}
+
+	// Explicit calendar date wins (weekly variant that carries a date).
+	if m := monthDay.FindStringSubmatch(reset); m != nil {
+		month := monthIndex[strings.ToLower(m[1][:3])]
+		day, _ := strconv.Atoi(m[2])
+		year := now.In(loc).Year()
+		if m[3] != "" {
+			year, _ = strconv.Atoi(m[3])
+			return time.Date(year, month, day, hour, minute, 0, 0, loc).UTC(), true
+		}
+		// No year in the banner: pick the year that puts the date in the
+		// future relative to now (this year, else next).
+		candidate := time.Date(year, month, day, hour, minute, 0, 0, loc)
+		if !candidate.After(now) {
+			candidate = time.Date(year+1, month, day, hour, minute, 0, 0, loc)
+		}
+		return candidate.UTC(), true
+	}
+
+	// Weekday name (weekly variant that names a day): next such weekday at the
+	// clock time, strictly after now.
+	if m := weekday.FindStringSubmatch(reset); m != nil {
+		target := weekdayIndex[strings.ToLower(m[1][:3])]
+		return nextWeekday(now, loc, target, hour, minute).UTC(), true
+	}
+
+	// Time-only (5h window): next occurrence of the clock time after now.
+	return nextTimeOfDay(now, loc, hour, minute).UTC(), true
+}
+
+var (
+	// codexResetAt captures the absolute reset timestamp after "try again at",
+	// ending at the AM/PM marker so trailing prose or punctuation is excluded.
+	// Handles both "Jul 25th, 2026 5:55 PM" (weekly) and "6:34 AM" (5h).
+	codexResetAt = regexp.MustCompile(`(?is)try again at\s+(.+?[ap]m)\b`)
+	// codexResetIn captures a relative countdown, e.g.
+	// "try again in 4 days 2 hours 46 minutes" — a real Codex variant
+	// (openai/codex#3031). Parsed against the injected clock.
+	codexResetIn = regexp.MustCompile(`(?is)try again in\s+([0-9a-z\s]+?)\.`)
+	// dayHourMin pulls day/hour/minute counts out of a relative countdown.
+	relDays  = regexp.MustCompile(`(?i)(\d+)\s*day`)
+	relHours = regexp.MustCompile(`(?i)(\d+)\s*hour`)
+	relMins  = regexp.MustCompile(`(?i)(\d+)\s*min`)
+	// ordinalSuffix strips "st"/"nd"/"rd"/"th" off a day number so Go's
+	// reference-layout parser can read the date.
+	ordinalSuffix = regexp.MustCompile(`(?i)(\d{1,2})(st|nd|rd|th)`)
+)
+
+// parseCodexReset scans the whole captured pane content for Codex's reset
+// phrase. It prefers an absolute "try again at <ts>" timestamp (weekly
+// date+time or 5h time-only), then falls back to a relative "try again in
+// <duration>" countdown. Codex renders in local time with no timezone in the
+// banner, so absolute forms are interpreted in now's location. Returns
+// ok=false when neither form is found or parses, so a reworded banner degrades
+// to hit=true, hasResetTime=false.
+func parseCodexReset(content string, now time.Time) (time.Time, bool) {
+	if m := codexResetAt.FindStringSubmatch(content); m != nil {
+		if t, ok := parseCodexAbsolute(strings.TrimSpace(m[1]), now); ok {
+			return t, true
+		}
+	}
+	if m := codexResetIn.FindStringSubmatch(content); m != nil {
+		if d, ok := parseRelativeDuration(m[1]); ok {
+			return now.Add(d), true
+		}
+	}
+	return time.Time{}, false
+}
+
+// parseCodexAbsolute parses a Codex "try again at" timestamp in now's
+// location, trying the weekly date+time layout first, then the 5h time-only
+// form (whose next occurrence after now is minted).
+func parseCodexAbsolute(ts string, now time.Time) (time.Time, bool) {
+	loc := now.Location()
+	cleaned := ordinalSuffix.ReplaceAllString(ts, "$1")
+
+	// Weekly: "Jul 25, 2026 5:55 PM" (post-ordinal-strip).
+	if t, err := time.ParseInLocation("Jan 2, 2006 3:04 PM", cleaned, loc); err == nil {
+		return t, true
+	}
+
+	// 5h window: "6:34 AM" — a clock time with no date. Mint the next
+	// occurrence after now.
+	if hour, minute, ok := parseClockTime(cleaned); ok {
+		return nextTimeOfDay(now, loc, hour, minute), true
+	}
+	return time.Time{}, false
+}
+
+// parseRelativeDuration sums the day/hour/minute components of a Codex
+// countdown like "4 days 2 hours 46 minutes". Returns ok=false when no
+// component is found.
+func parseRelativeDuration(s string) (time.Duration, bool) {
+	var d time.Duration
+	found := false
+	if m := relDays.FindStringSubmatch(s); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		d += time.Duration(n) * 24 * time.Hour
+		found = true
+	}
+	if m := relHours.FindStringSubmatch(s); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		d += time.Duration(n) * time.Hour
+		found = true
+	}
+	if m := relMins.FindStringSubmatch(s); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		d += time.Duration(n) * time.Minute
+		found = true
+	}
+	return d, found
+}
+
+// parseClockTime extracts the first 12-hour clock token from s and returns its
+// 24-hour (hour, minute). "12am" maps to 0, "12pm" to 12.
+func parseClockTime(s string) (hour, minute int, ok bool) {
+	m := clockTime.FindStringSubmatch(s)
+	if m == nil {
+		return 0, 0, false
+	}
+	hour, _ = strconv.Atoi(m[1])
+	if hour < 1 || hour > 12 {
+		return 0, 0, false
+	}
+	if m[2] != "" {
+		minute, _ = strconv.Atoi(m[2])
+		if minute > 59 {
+			return 0, 0, false
+		}
+	}
+	if strings.EqualFold(m[3], "p") {
+		if hour != 12 {
+			hour += 12
+		}
+	} else if hour == 12 {
+		hour = 0
+	}
+	return hour, minute, true
+}
+
+// nextTimeOfDay returns the next instant in loc whose clock reads hour:minute
+// and that is strictly after now — today if it has not passed, else tomorrow.
+func nextTimeOfDay(now time.Time, loc *time.Location, hour, minute int) time.Time {
+	base := now.In(loc)
+	candidate := time.Date(base.Year(), base.Month(), base.Day(), hour, minute, 0, 0, loc)
+	if !candidate.After(now) {
+		candidate = candidate.AddDate(0, 0, 1)
+	}
+	return candidate
+}
+
+// nextWeekday returns the next instant in loc that falls on target at
+// hour:minute and is strictly after now. When today is the target weekday but
+// the clock time has already passed, it rolls a full week forward.
+func nextWeekday(now time.Time, loc *time.Location, target time.Weekday, hour, minute int) time.Time {
+	base := now.In(loc)
+	daysAhead := (int(target) - int(base.Weekday()) + 7) % 7
+	candidate := time.Date(base.Year(), base.Month(), base.Day(), hour, minute, 0, 0, loc).AddDate(0, 0, daysAhead)
+	if !candidate.After(now) {
+		candidate = candidate.AddDate(0, 0, 7)
+	}
+	return candidate
+}

--- a/task/limit_test.go
+++ b/task/limit_test.go
@@ -1,0 +1,231 @@
+package task
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// nyLoc and fixedNow give every case a deterministic clock: Saturday
+// 2026-07-04 10:00 America/New_York (14:00 UTC). All relative and
+// time-of-day-only reset phrases resolve against this injected now, so no test
+// touches the wall clock.
+func nyLoc(t *testing.T) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load America/New_York: %v", err)
+	}
+	return loc
+}
+
+func TestIsLimitContent(t *testing.T) {
+	loc := nyLoc(t)
+	now := time.Date(2026, 7, 4, 10, 0, 0, 0, loc) // Sat 10:00 EDT / 14:00 UTC
+
+	cases := []struct {
+		name         string
+		agent        string
+		content      string
+		wantHit      bool
+		wantReset    bool
+		wantResetUTC time.Time // only checked when wantReset
+	}{
+		{
+			name:         "claude 5h window: time + tz, resets later today",
+			agent:        tmux.ProgramClaude,
+			content:      "Claude usage limit reached. Your limit will reset at 2pm (America/New_York)",
+			wantHit:      true,
+			wantReset:    true,
+			wantResetUTC: time.Date(2026, 7, 4, 14, 0, 0, 0, loc).UTC(), // 18:00 UTC
+		},
+		{
+			name:         "claude weekly: explicit date + year + tz",
+			agent:        tmux.ProgramClaude,
+			content:      "Claude usage limit reached. Your limit will reset at Nov 6, 2026 9am (America/New_York)",
+			wantHit:      true,
+			wantReset:    true,
+			wantResetUTC: time.Date(2026, 11, 6, 9, 0, 0, 0, loc).UTC(), // EST -> 14:00 UTC
+		},
+		{
+			name:         "claude weekly: named weekday rolls forward to next Monday",
+			agent:        tmux.ProgramClaude,
+			content:      "Claude usage limit reached. Your limit will reset Monday at 9am (America/New_York)",
+			wantHit:      true,
+			wantReset:    true,
+			wantResetUTC: time.Date(2026, 7, 6, 9, 0, 0, 0, loc).UTC(), // Mon -> 13:00 UTC
+		},
+		{
+			name:         "claude 5h window: no timezone falls back to now's location",
+			agent:        tmux.ProgramClaude,
+			content:      "Claude usage limit reached. Your limit will reset at 2:30pm",
+			wantHit:      true,
+			wantReset:    true,
+			wantResetUTC: time.Date(2026, 7, 4, 14, 30, 0, 0, loc).UTC(), // 18:30 UTC
+		},
+		{
+			name:         "codex 5h window: time-only rolls to tomorrow (already past today)",
+			agent:        tmux.ProgramCodex,
+			content:      "You've hit your usage limit. Please try again at 6:34 AM.",
+			wantHit:      true,
+			wantReset:    true,
+			wantResetUTC: time.Date(2026, 7, 5, 6, 34, 0, 0, loc).UTC(), // 10:34 UTC
+		},
+		{
+			name:         "codex weekly: full date + time with ordinal suffix",
+			agent:        tmux.ProgramCodex,
+			content:      "You've hit your usage limit. You can try again at Jul 25th, 2026 5:55 PM.",
+			wantHit:      true,
+			wantReset:    true,
+			wantResetUTC: time.Date(2026, 7, 25, 17, 55, 0, 0, loc).UTC(), // 21:55 UTC
+		},
+		{
+			name:         "codex relative countdown: try again in N days/hours/minutes",
+			agent:        tmux.ProgramCodex,
+			content:      "You've hit your usage limit, try again in 4 days 2 hours 46 minutes.",
+			wantHit:      true,
+			wantReset:    true,
+			wantResetUTC: now.Add(4*24*time.Hour + 2*time.Hour + 46*time.Minute).UTC(),
+		},
+		{
+			name:      "claude banner present but reset time unparseable -> hit, no reset",
+			agent:     tmux.ProgramClaude,
+			content:   "Claude usage limit reached. Your limit will reset at some point soon.",
+			wantHit:   true,
+			wantReset: false,
+		},
+		{
+			name:      "codex banner present but no reset phrase -> hit, no reset",
+			agent:     tmux.ProgramCodex,
+			content:   "You've hit your usage limit. Upgrade your plan for more.",
+			wantHit:   true,
+			wantReset: false,
+		},
+		{
+			name:    "claude ready prompt, no banner -> no hit",
+			agent:   tmux.ProgramClaude,
+			content: "❯ waiting for your next instruction",
+			wantHit: false,
+		},
+		{
+			name:    "codex working pane, no banner -> no hit",
+			agent:   tmux.ProgramCodex,
+			content: "› thinking...\nRunning tests",
+			wantHit: false,
+		},
+		{
+			name:    "gemini limit banner is surface-only in v1 -> no hit",
+			agent:   tmux.ProgramGemini,
+			content: "Error 429: RESOURCE_EXHAUSTED. Claude usage limit reached. Your limit will reset at 2pm (America/New_York)",
+			wantHit: false,
+		},
+		{
+			name:    "aider rate-limit is API-key metered in v1 -> no hit",
+			agent:   tmux.ProgramAider,
+			content: "litellm.RateLimitError: You've hit your usage limit. try again at 6:34 AM",
+			wantHit: false,
+		},
+		{
+			name:    "unknown/non-agent resolved command -> no hit",
+			agent:   "",
+			content: "Claude usage limit reached. Your limit will reset at 2pm (America/New_York)",
+			wantHit: false,
+		},
+	}
+
+	matchers := resolveLimitMatchers(nil)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hit, resetAt, hasReset := isLimitContent(tc.content, tc.agent, matchers, now)
+			if hit != tc.wantHit {
+				t.Fatalf("hit = %v, want %v", hit, tc.wantHit)
+			}
+			if hasReset != tc.wantReset {
+				t.Fatalf("hasResetTime = %v, want %v (resetAt=%v)", hasReset, tc.wantReset, resetAt)
+			}
+			if !tc.wantReset {
+				if !resetAt.IsZero() {
+					t.Fatalf("resetAt = %v, want zero when no reset time", resetAt)
+				}
+				return
+			}
+			if !resetAt.Equal(tc.wantResetUTC) {
+				t.Fatalf("resetAt = %v, want %v", resetAt.UTC(), tc.wantResetUTC)
+			}
+			if resetAt.Location() != time.UTC {
+				t.Fatalf("resetAt location = %v, want UTC", resetAt.Location())
+			}
+			if !resetAt.After(now) {
+				t.Fatalf("resetAt = %v is not after now = %v", resetAt, now)
+			}
+		})
+	}
+}
+
+// TestIsLimitContentPatternOverride proves a config-provided regex replaces the
+// built-in detection pattern for an agent: content the built-in would miss is
+// detected once the override is applied, and the built-in reset-time parser
+// still runs against the same content.
+func TestIsLimitContentPatternOverride(t *testing.T) {
+	loc := nyLoc(t)
+	now := time.Date(2026, 7, 4, 10, 0, 0, 0, loc)
+
+	// A reworded banner the shipped claude pattern does not match.
+	content := "PLAN LIMIT TRIPPED — reset at 3pm (America/New_York)"
+
+	// Without an override the built-in claude matcher does not detect it.
+	if hit, _, _ := isLimitContent(content, tmux.ProgramClaude, resolveLimitMatchers(nil), now); hit {
+		t.Fatalf("built-in matcher unexpectedly detected reworded banner")
+	}
+
+	// With the override the reworded banner is detected, and the built-in
+	// reset parser still resolves "reset at 3pm (America/New_York)".
+	overrides := map[string]string{tmux.ProgramClaude: `PLAN LIMIT TRIPPED`}
+	hit, resetAt, hasReset := isLimitContent(content, tmux.ProgramClaude, resolveLimitMatchers(overrides), now)
+	if !hit {
+		t.Fatalf("override matcher did not detect reworded banner")
+	}
+	if !hasReset {
+		t.Fatalf("expected reset time to be parsed from overridden banner")
+	}
+	want := time.Date(2026, 7, 4, 15, 0, 0, 0, loc).UTC() // 19:00 UTC
+	if !resetAt.Equal(want) {
+		t.Fatalf("resetAt = %v, want %v", resetAt.UTC(), want)
+	}
+}
+
+// TestResolveLimitMatchers covers the resolver's guard rails: unknown-agent
+// and uncompilable overrides are dropped (built-in stands), and the built-ins
+// are present for the two v1 scheduled agents only.
+func TestResolveLimitMatchers(t *testing.T) {
+	base := resolveLimitMatchers(nil)
+	if _, ok := base[tmux.ProgramClaude]; !ok {
+		t.Fatalf("built-in claude matcher missing")
+	}
+	if _, ok := base[tmux.ProgramCodex]; !ok {
+		t.Fatalf("built-in codex matcher missing")
+	}
+	if _, ok := base[tmux.ProgramGemini]; ok {
+		t.Fatalf("gemini should have no matcher in v1")
+	}
+	if _, ok := base[tmux.ProgramAider]; ok {
+		t.Fatalf("aider should have no matcher in v1")
+	}
+
+	// An override for an agent with no built-in matcher is ignored (there is
+	// no reset parser to pair a detection-only override with yet).
+	withGemini := resolveLimitMatchers(map[string]string{tmux.ProgramGemini: `whatever`})
+	if _, ok := withGemini[tmux.ProgramGemini]; ok {
+		t.Fatalf("override for unmatched agent should be ignored")
+	}
+
+	// An uncompilable regex is dropped and the built-in default stands: the
+	// stock claude banner must still detect.
+	now := time.Date(2026, 7, 4, 10, 0, 0, 0, nyLoc(t))
+	bad := resolveLimitMatchers(map[string]string{tmux.ProgramClaude: `(unclosed`})
+	hit, _, _ := isLimitContent("Claude usage limit reached. Your limit will reset at 2pm (America/New_York)", tmux.ProgramClaude, bad, now)
+	if !hit {
+		t.Fatalf("invalid override should fall back to built-in claude matcher")
+	}
+}


### PR DESCRIPTION
## Scope — PR 1 of 4 for #1146

This is the **pure detection + parsing layer** of the approved [usage-limit reprompt design](https://github.com/sachiniyer/agent-factory/issues/1146). No daemon, no status enum, no TUI, no scheduler — those land in PR2/PR3/PR4. Everything here is a pure function with an injected clock and no I/O, so it runs under plain `go test`.

### What it adds

**`task/limit.go`** — a usage-limit matcher sibling to `isReadyContent`:

- `isLimitContent(content, agent, matchers, now) -> (hit, resetAt, hasResetTime)` — scans captured pane content for the given resolved agent. `resetAt` is always UTC. Detection **never depends on parsing succeeding**: a reworded/unparseable reset clause still returns `hit=true, hasResetTime=false`.
- Built-in matchers for the two **subscription-plan** agents that stall on a parseable reset window: **claude** and **codex**. **gemini/aider** are API-key metered (transient 429s, no plan-reset timestamp) so they return `hit=false` in v1 — the matcher map is structured so a surface-only entry drops in later without touching the core.
- Per-agent reset-time parsers with next-occurrence minting for time-only forms (against the injected `now`).

### Banners handled

| Agent | Form | Example |
|---|---|---|
| claude | 5h (time + tz) | `Claude usage limit reached. Your limit will reset at 2pm (America/New_York)` |
| claude | weekly (dated) | `…reset at Nov 6, 2026 9am (America/New_York)` |
| claude | weekly (named weekday) | `…reset Monday at 9am (America/New_York)` |
| claude | 5h (no tz → falls back to now's zone) | `…reset at 2:30pm` |
| codex | 5h (time-only) | `You've hit your usage limit. …try again at 6:34 AM` |
| codex | weekly (date + time) | `…try again at Jul 25th, 2026 5:55 PM` |
| codex | relative countdown | `…try again in 4 days 2 hours 46 minutes` ([openai/codex#3031](https://github.com/openai/codex/issues/3031)) |

### Config-overridable patterns

Vendor banners drift (Codex reworded theirs at the Apr-2026 limit-system change), so built-in detection regexes are overridable without a release. New `limit_patterns` map (`agent -> regexp`) **replaces** the built-in detection pattern for that agent; empty keeps every built-in default. Unknown-agent and uncompilable entries are **warn-and-dropped** (built-in stands) both at config load and in the detector's resolver. Only the pattern-override plumbing lands here — the `auto_resume` / retry keys are PR3/PR4.

### File decomposition (why config.go shrank)

`config/config.go` sits exactly at its file-length ceiling (`docs/file-length-lint.md`), so to make room:
- the `limit_patterns` validation moved to a new **`config/limit_patterns.go`**, and
- two pure path/shell helpers (`prettyHomePath`, `shellQuotePath`) moved **verbatim** to a new **`config/paths.go`**.

Same package, no call-site or behavior changes.

### Tests

Table-driven unit tests over captured banner fixtures cover every variant above plus: banner-present-but-unparseable, normal ready/working panes, gemini/aider surface-only (no hit), and a config pattern override taking effect (and being ignored when invalid). All use a **fixed injected clock** — no wall-clock in the tested path.

### Verification

- `go build ./...` ✅
- `go test ./task/ ./config/` ✅ (daemon pkg untouched; ran scoped per box-safety)
- `golangci-lint run --timeout=3m --fast` ✅
- `gofmt -l .` — empty ✅
- `deadcode -test ./...` — no new dead code ✅
- `scripts/lint-file-length.sh` ✅

Refs #1146 (does **not** close it — PR4 does). PR2 wires `isLimitContent` into the daemon's single-writer status refresh and adds the `LimitReached` status.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)