### PR TITLE
refactor(session): stable per-session UUID id for reconcile identity (#1195 Phase 1a)

### DIFF
--- a/app/snapshot_test.go
+++ b/app/snapshot_test.go
@@ -117,8 +117,10 @@ func TestReconcileSnapshot_SelectionDriftAfterSwapAndRemoval(t *testing.T) {
 	h.sidebar.SelectInstance(b)
 	require.Same(t, b, h.sidebar.GetSelectedInstance(), "initial selection must be on b")
 
-	// Snapshot: b was recreated (same title, different CreatedAt), a is gone, c unchanged
+	// Snapshot: b was recreated (same title, NEW session id — a kill+recreate
+	// mints a fresh stable id, #1195), a is gone, c unchanged.
 	bData := b.ToInstanceData()
+	bData.ID = "recreated-b"
 	bData.CreatedAt = time.Now().Add(time.Hour)
 	cData := c.ToInstanceData()
 

--- a/app/sync.go
+++ b/app/sync.go
@@ -381,7 +381,7 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 				continue
 			}
 		}
-		if !inst.CreatedAt.Equal(d.CreatedAt) {
+		if !sameSession(inst, d) {
 			// Same title, different session — a kill+recreate reused the title
 			// (#765). Swap the stale row for the live one rather than mutating the
 			// corpse in place.
@@ -436,6 +436,21 @@ func (m *home) reconcileSnapshot(data []session.InstanceData) bool {
 	}
 
 	return changed
+}
+
+// sameSession reports whether an existing same-title row and a snapshot record
+// are the SAME logical session rather than a kill+recreate that reused the title
+// (#765). It prefers the stable per-session ID (#1195): when both the row and the
+// record carry one, identity is a pure ID compare, immune to the CreatedAt-as-
+// identity gotcha the audit flagged (a manufactured or zero-CreatedAt record
+// silently degrading a swap into an in-place corpse mutation). Legacy records
+// written before #1195 have no ID; for them it falls back to CreatedAt equality —
+// exactly the prior behavior — so mixed old/new records reconcile correctly.
+func sameSession(inst *session.Instance, d session.InstanceData) bool {
+	if inst.ID != "" && d.ID != "" {
+		return inst.ID == d.ID
+	}
+	return inst.CreatedAt.Equal(d.CreatedAt)
 }
 
 // addInstanceFromSnapshot builds a live instance from a snapshot record and adds

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -131,6 +131,84 @@ func TestReconcileSnapshot_LeavesTransientRowStatusAlone(t *testing.T) {
 		"a mid-teardown row must keep its Deleting marker through a reconcile")
 }
 
+// TestReconcileSnapshot_IdentityUsesStableID guards the #1195 identity fix: the
+// reconcile decides "same session" vs "title reused" (#765) by the stable
+// per-session ID, not CreatedAt equality (the audit's identity-by-circumstance
+// gotcha). It also verifies the legacy fallback: records without an ID still use
+// CreatedAt, exactly as before, so mixed old/new records reconcile correctly.
+func TestReconcileSnapshot_IdentityUsesStableID(t *testing.T) {
+	t1 := time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 7, 4, 11, 0, 0, 0, time.UTC)
+
+	// stubBuilder records swap builds and returns a fresh fake-backed instance
+	// carrying the snapshot record's identity (no real tmux/worktree — the #961
+	// reattach-flake lesson).
+	stubBuilder := func(t *testing.T, built *[]session.InstanceData) func() {
+		return SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+			*built = append(*built, d)
+			inst, err := session.NewInstance(session.InstanceOptions{Title: d.Title, Path: t.TempDir(), Program: "test"})
+			require.NoError(t, err)
+			inst.SetBackend(session.NewFakeBackend())
+			inst.SetStartedForTest(true)
+			inst.ID = d.ID
+			inst.CreatedAt = d.CreatedAt
+			return inst, nil
+		})
+	}
+	makeStored := func(t *testing.T, h *home, id, title string, created time.Time) *session.Instance {
+		inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "test"})
+		require.NoError(t, err)
+		inst.SetBackend(session.NewFakeBackend())
+		inst.SetStartedForTest(true)
+		inst.SetStatus(session.Running)
+		inst.ID = id
+		inst.CreatedAt = created
+		h.store.AddInstance(inst)
+		return inst
+	}
+
+	cases := []struct {
+		name        string
+		storedID    string
+		storedAt    time.Time
+		snapID      string
+		snapAt      time.Time
+		wantSwapped bool
+	}{
+		// ID authoritative: different ID is a title reuse even when CreatedAt matches.
+		{"different id -> swap despite equal CreatedAt", "id-A", t1, "id-B", t1, true},
+		// ID authoritative: same ID is the same session even when CreatedAt drifted.
+		{"same id -> no swap despite differing CreatedAt", "id-A", t1, "id-A", t2, false},
+		// Legacy fallback: no IDs on either side -> CreatedAt decides (prior behavior).
+		{"legacy no ids, differing CreatedAt -> swap", "", t1, "", t2, true},
+		{"legacy no ids, equal CreatedAt -> no swap", "", t1, "", t1, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			var built []session.InstanceData
+			restore := stubBuilder(t, &built)
+			defer restore()
+
+			stored := makeStored(t, h, tc.storedID, "worker", tc.storedAt)
+			h.reconcileSnapshot([]session.InstanceData{
+				{ID: tc.snapID, Title: "worker", CreatedAt: tc.snapAt, Status: session.Ready},
+			})
+
+			got := h.store.GetInstanceByTitle("worker")
+			require.NotNil(t, got)
+			if tc.wantSwapped {
+				require.Len(t, built, 1, "a title reuse must rebuild (swap) the row")
+				require.NotSame(t, stored, got, "swap must replace the stale pointer")
+			} else {
+				require.Empty(t, built, "same session must update in place, not swap")
+				require.Same(t, stored, got, "same session must keep its pointer")
+			}
+		})
+	}
+}
+
 func TestImportRemoteHookSessionsAddsListCmdSessions(t *testing.T) {
 	repoDir := setupRealRepo(t)
 	t.Chdir(repoDir)

--- a/session/instance.go
+++ b/session/instance.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"crypto/rand"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -80,6 +81,16 @@ type Instance struct {
 	// prInfo, diffStats.
 	mu sync.RWMutex
 
+	// ID is the instance's stable identity (#1195): a random UUID minted once at
+	// NewInstance, persisted, and never mutated. The reconcile uses it to tell
+	// "same session" from "title reused" (#765) without leaning on CreatedAt
+	// equality — the audit's identity-by-circumstance gotcha (a manufactured or
+	// zero-CreatedAt record silently degraded a swap into an in-place corpse
+	// mutation). Legacy records persisted before #1195 carry no ID; the reconcile
+	// falls back to title+CreatedAt for them until they are recreated. Immutable
+	// after construction, so cross-goroutine readers may read it without the mutex
+	// (like Title).
+	ID string
 	// Title is the title of the instance.
 	Title string
 	// Path is the path to the workspace.
@@ -593,6 +604,7 @@ func (i *Instance) ToInstanceData() InstanceData {
 	defer i.mu.RUnlock()
 
 	data := InstanceData{
+		ID:         i.ID,
 		Title:      i.Title,
 		Path:       i.Path,
 		Branch:     i.Branch,
@@ -683,6 +695,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		status = Lost
 	}
 	instance := &Instance{
+		ID:         data.ID,
 		Title:      data.Title,
 		Path:       data.Path,
 		Branch:     data.Branch,
@@ -884,6 +897,22 @@ func SetBackendFactoryForTest(f func(opts InstanceOptions, absPath string) (Back
 	return func() { backendFactory = prev }
 }
 
+// newSessionID mints a random RFC-4122 v4 UUID for an instance's stable identity
+// (#1195). It is a package var so tests can inject deterministic IDs. crypto/rand
+// is the entropy source; on the (near-impossible) read failure it falls back to a
+// timestamp-derived value so session creation never blocks on entropy — still
+// unique per call in practice, and the reconcile's title+CreatedAt fallback covers
+// any theoretical collision.
+var newSessionID = func() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("ts-%d", time.Now().UnixNano())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
 func NewInstance(opts InstanceOptions) (*Instance, error) {
 	t := time.Now()
 
@@ -905,6 +934,7 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 	}
 
 	return &Instance{
+		ID:        newSessionID(),
 		Title:     opts.Title,
 		Status:    Ready,
 		Path:      absPath,

--- a/session/storage.go
+++ b/session/storage.go
@@ -10,6 +10,12 @@ import (
 
 // InstanceData represents the serializable data of an Instance
 type InstanceData struct {
+	// ID is the instance's stable identity (#1195), minted at NewInstance and
+	// used as the reconcile identity key. omitempty + additive: records written
+	// before #1195 simply have no id, and the reconcile falls back to
+	// title+CreatedAt for them (rollforward, mirroring the BranchCreatedByUs
+	// precedent).
+	ID        string    `json:"id,omitempty"`
 	Title     string    `json:"title"`
 	Path      string    `json:"path"`
 	Branch    string    `json:"branch"`


### PR DESCRIPTION
## What

Phase 1a of the #1195 Status-split anchor: mint a **stable per-session UUID** at `NewInstance`, persist it, and use it as the reconcile identity — retiring the CreatedAt-as-identity gotcha (#1195 item #7). Ships **first** and independently; the axis split (1b–1e) builds on this.

## Why

The reconcile decides "same session" vs "title reused" (#765) by `!inst.CreatedAt.Equal(d.CreatedAt)` (`app/sync.go`). That's robust by circumstance, not construction: a manufactured, duplicate, or **zero**-`CreatedAt` record silently degrades a #765 swap into an **in-place corpse mutation** with no assertion or fallback. The audit paired this with the Status split because both touch `NewInstance`/reconcile identity; doing IDs first means the reconcile rewrite in 1d is written against a stable key from day one.

## How

- **`Instance.ID`** — random RFC-4122 v4 UUID minted once at `NewInstance` (`newSessionID()`, `crypto/rand`, dependency-free; a package var so tests inject deterministic IDs). Immutable after construction, read without the mutex like `Title`.
- **Persistence** — `InstanceData.ID` as `json:"id,omitempty"`, additive/rollforward (records written before #1195 simply have no `id`). Wired through `ToInstanceData`/`FromInstanceData`, so the id flows **daemon → snapshot → TUI** (`buildInstanceFromSnapshot = FromInstanceData`) and all three processes agree on identity.
- **Reconcile** — new `sameSession(inst, d)`: prefers `id` when both sides carry one, else falls back to `CreatedAt` equality for legacy records. `CreatedAt` stays for ordering only.

### Scope note (flagged for review)
The reconcile **map key stays `title`** (display-unique within the repo-scoped snapshot the TUI always fetches). Re-keying the lookup/reap purely by `id` would break the title-based #765 swap detection that selection/pane preservation (#969/#1088) depends on — a legacy-corpse-vs-new-with-id recreate would become add+remove and bypass `swapInstanceFromSnapshot`. The `id` refines the identity **discriminator**, which is exactly where the gotcha lived.

## Tests
- `TestReconcileSnapshot_IdentityUsesStableID` — `id` authoritative over `CreatedAt` both directions (different id → swap despite equal CreatedAt; same id → no swap despite differing CreatedAt) + legacy no-id fallback both ways.
- Existing #765 coverage exercises the distinct-id recreate path end-to-end (`snapshot_test.go`, `cli_daemon_integration_test.go`). Updated the one drift test that simulated a recreate via a `CreatedAt` bump to mint a new `id` instead (a real kill+recreate now mints a fresh id).

## Gates
- `make test-container` full suite green; `gofmt -l`, `golangci-lint --fast`, `deadcode -test ./...` all clean.
- Driver play-test (same-title kill+recreate #765 swap) deferred to reviewer's gate per the epic plan.

Part of #1195 (Phase 1 anchor). **Does not close it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)