### PR TITLE
refactor(session): split Status into Liveness + InFlightOp axes behind a shim (#1195 Phase 1b)

### DIFF
--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -197,7 +197,7 @@ func TestInstanceStarted_Success_UserStillWatching(t *testing.T) {
 
 	_, _ = h.Update(instanceStartedMsg{instance: inst, err: nil})
 
-	assert.Equal(t, session.Running, inst.Status, "status must flip to Running")
+	assert.Equal(t, session.Running, inst.GetStatus(), "status must flip to Running")
 	assert.Equal(t, stateHelp, h.state, "user on the new instance should see the attach-help modal")
 	require.NotNil(t, h.textOverlay, "help modal overlay should be installed")
 }
@@ -217,7 +217,7 @@ func TestInstanceStarted_Success_UserMovedToAnotherInstance(t *testing.T) {
 
 	_, _ = h.Update(instanceStartedMsg{instance: creating, err: nil})
 
-	assert.Equal(t, session.Running, creating.Status, "status must flip to Running")
+	assert.Equal(t, session.Running, creating.GetStatus(), "status must flip to Running")
 	assert.Equal(t, stateDefault, h.state, "user state must not flip to stateHelp")
 	assert.Nil(t, h.textOverlay, "no help overlay should be shown")
 	assert.Same(t, other, h.sidebar.GetSelectedInstance(),
@@ -241,7 +241,7 @@ func TestInstanceStarted_Success_UserCreatingAnotherInstance(t *testing.T) {
 
 	_, _ = h.Update(instanceStartedMsg{instance: first, err: nil})
 
-	assert.Equal(t, session.Running, first.Status, "first instance should flip to Running")
+	assert.Equal(t, session.Running, first.GetStatus(), "first instance should flip to Running")
 	assert.Equal(t, stateNew, h.state, "naming state must be preserved")
 	assert.Same(t, second, h.namingInstance, "namingInstance pointer must not be clobbered")
 	assert.Nil(t, h.textOverlay, "no help overlay should be shown over the naming flow")
@@ -424,5 +424,5 @@ func TestInstanceStarted_ReplacesSwappedSameTitleRow(t *testing.T) {
 	instances := h.store.GetInstances()
 	require.Len(t, instances, 1, "one logical session must occupy exactly one sidebar row (#808)")
 	assert.Same(t, started, instances[0], "the started instance must replace the disk-built copy")
-	assert.Equal(t, session.Running, started.Status)
+	assert.Equal(t, session.Running, started.GetStatus())
 }

--- a/session/archived_test.go
+++ b/session/archived_test.go
@@ -66,7 +66,7 @@ func TestArchivedInstance_NotRecoverable(t *testing.T) {
 	defer log.Close()
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
-	inst := &Instance{Title: "arch", Status: Archived, backend: &LocalBackend{}}
+	inst := &Instance{Title: "arch", liveness: LiveArchived, backend: &LocalBackend{}}
 	err := inst.Recover()
 	require.Error(t, err, "an archived session is not Lost, so Recover must reject it")
 }

--- a/session/instance.go
+++ b/session/instance.go
@@ -77,8 +77,8 @@ const (
 type Instance struct {
 	// mu protects fields that are accessed concurrently by async Start()
 	// goroutines (writers) and the main bubbletea loop (readers):
-	// started, Status, Tabs (and the agent tab's tmux session), gitWorktree,
-	// prInfo, diffStats.
+	// started, liveness/inFlightOp, Tabs (and the agent tab's tmux session),
+	// gitWorktree, prInfo, diffStats.
 	mu sync.RWMutex
 
 	// ID is the instance's stable identity (#1195): a random UUID minted once at
@@ -97,8 +97,14 @@ type Instance struct {
 	Path string
 	// Branch is the branch of the instance.
 	Branch string
-	// Status is the status of the instance.
-	Status Status
+	// liveness and inFlightOp are the two orthogonal axes of session state
+	// (#1195): liveness is the daemon-owned health of the backing session
+	// (Running/Ready/Lost/Archived/…), inFlightOp is the transient, never-
+	// persisted client operation overlaid on it (Creating/Killing/Archiving/
+	// Restoring). The legacy Status enum is derived from them via the
+	// GetStatus/SetStatus shim in liveness.go. Both are mutex-protected.
+	liveness   Liveness
+	inFlightOp InFlightOp
 	// Program is the program to run in the instance.
 	Program string
 	// Height is the height of the instance.
@@ -604,11 +610,18 @@ func (i *Instance) ToInstanceData() InstanceData {
 	defer i.mu.RUnlock()
 
 	data := InstanceData{
-		ID:         i.ID,
-		Title:      i.Title,
-		Path:       i.Path,
-		Branch:     i.Branch,
-		Status:     i.Status,
+		ID:     i.ID,
+		Title:  i.Title,
+		Path:   i.Path,
+		Branch: i.Branch,
+		// Persist BOTH axes: Liveness is the new canonical value, Status the
+		// legacy int kept for one release so a binary rolled back to before
+		// #1195 still reads a sensible status (and as the read-fallback source
+		// for records this build wrote before the split). SaveInstances skips
+		// transient (Loading/Deleting) rows, so a persisted Status is always a
+		// settled liveness value.
+		Status:     i.statusLocked(),
+		Liveness:   i.liveness,
 		Height:     i.Height,
 		Width:      i.Width,
 		CreatedAt:  i.CreatedAt,
@@ -684,22 +697,34 @@ func (i *Instance) ToInstanceData() InstanceData {
 
 // FromInstanceData creates a new Instance from serialized data
 func FromInstanceData(data InstanceData) (*Instance, error) {
-	status := data.Status
-	if status == Dead {
-		// Rollforward (#1108): records persisted as Dead by pre-Lost builds
-		// were all written by observed-death paths (a user kill deletes the
-		// record instead), so they load as Lost — recovery-eligible. This is
-		// what makes sessions stranded by an outage under an old build
-		// restorable after an upgrade. A tombstoned record keeps its status;
-		// the daemon finishes its teardown rather than restoring it.
-		status = Lost
+	// Resolve the liveness axis: prefer the new `liveness` field; a record
+	// written before #1195 has LivenessUnset and falls back to the legacy
+	// `status` int (rollforward, no dual-read).
+	liveness := data.Liveness
+	if liveness == LivenessUnset {
+		liveness = livenessForStatus(data.Status)
 	}
+	if liveness == LiveDead {
+		// Rollforward (#1108): Dead was only ever written by observed-death
+		// paths (a user kill deletes the record instead), so it loads as Lost —
+		// recovery-eligible. This is what makes sessions stranded by an outage
+		// under an old build restorable after an upgrade. A tombstoned record
+		// keeps its (Lost) status; the daemon finishes its teardown rather than
+		// restoring it.
+		liveness = LiveLost
+	}
+	// Resolve the in-flight-op axis from the legacy status. A persisted record
+	// is always settled (SaveInstances skips transients), but a SNAPSHOT of a
+	// transient instance carries Loading/Deleting, which buildInstanceFromSnapshot
+	// must reconstruct so the rebuilt row composes to the identical Status.
+	inFlightOp := opForStatus(data.Status)
 	instance := &Instance{
 		ID:         data.ID,
 		Title:      data.Title,
 		Path:       data.Path,
 		Branch:     data.Branch,
-		Status:     status,
+		liveness:   liveness,
+		inFlightOp: inFlightOp,
 		Height:     data.Height,
 		Width:      data.Width,
 		CreatedAt:  data.CreatedAt,
@@ -772,7 +797,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 	// where the worktree currently lives; the Tabs list restored above is
 	// tmux-less for the same reason (its TmuxName entries reference sessions
 	// that no longer exist, and restoreLocalTabs only binds names, never spawns).
-	if status == Archived {
+	if liveness == LiveArchived {
 		return instance, nil
 	}
 
@@ -936,7 +961,7 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 	return &Instance{
 		ID:        newSessionID(),
 		Title:     opts.Title,
-		Status:    Ready,
+		liveness:  LiveReady,
 		Path:      absPath,
 		Program:   opts.Program,
 		Height:    0,
@@ -966,28 +991,6 @@ func (i *Instance) RepoName() (string, error) {
 	return gw.GetRepoName(), nil
 }
 
-func (i *Instance) SetStatus(status Status) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	i.Status = status
-}
-
-// SetStatusIfNotDeleting sets the status under the instance mutex unless the
-// instance is mid-deletion. The metadata tick runs off the event loop and
-// races the async kill flow (#844): between its own status check and its
-// store, the user can confirm a kill, and an unconditional Running/Ready
-// write would clobber the Deleting marker — re-enabling kill/attach on a
-// session whose teardown is already in flight. Only the kill completion
-// handler may move an instance out of Deleting, via SetStatus.
-func (i *Instance) SetStatusIfNotDeleting(status Status) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	if i.Status == Deleting {
-		return
-	}
-	i.Status = status
-}
-
 // SetAutoYes sets the AutoYes flag under the instance mutex. Writers must use
 // this rather than assigning i.AutoYes directly: TapEnter runs from the
 // metadata-tick background goroutine and reads AutoYes under i.mu.RLock, so
@@ -1008,14 +1011,6 @@ func (i *Instance) GetBranch() string {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	return i.Branch
-}
-
-// GetStatus returns the current status under the Instance's mutex, so
-// cross-goroutine readers don't race with SetStatus.
-func (i *Instance) GetStatus() Status {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-	return i.Status
 }
 
 // MarkUserKilled records kill intent on the instance (#1108). Callers persist
@@ -1115,13 +1110,14 @@ func (i *Instance) MoveArchivedWorktree(dest string) error {
 }
 
 // SetArchived flips the instance into the inert Archived state atomically:
-// started=false (no tmux binding backs it) and Status=Archived. Called by the
-// daemon after a successful archive move.
+// started=false (no tmux binding backs it) and liveness=Archived, clearing any
+// in-flight op. Called by the daemon after a successful archive move.
 func (i *Instance) SetArchived() {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.started = false
-	i.Status = Archived
+	i.liveness = LiveArchived
+	i.inFlightOp = OpNone
 }
 
 // RestoreArchivedWorktree moves this instance's archived worktree back to dest
@@ -1149,7 +1145,8 @@ func (i *Instance) RestoreArchivedWorktree(dest string) error {
 func (i *Instance) RestoreFromArchive() error {
 	i.mu.Lock()
 	i.started = true
-	i.Status = Lost
+	i.liveness = LiveLost
+	i.inFlightOp = OpNone
 	i.mu.Unlock()
 	return i.backend.Recover(i)
 }

--- a/session/instance_test.go
+++ b/session/instance_test.go
@@ -122,7 +122,7 @@ func TestGetGitWorktree_RaceWithStart(t *testing.T) {
 // flow stays unaffected and the kill completion handler (which uses SetStatus)
 // can still move the instance out of Deleting.
 func TestSetStatusIfNotDeleting(t *testing.T) {
-	i := &Instance{Status: Ready}
+	i := &Instance{liveness: LiveReady}
 
 	i.SetStatusIfNotDeleting(Running)
 	require.Equal(t, Running, i.GetStatus(), "non-deleting status updates must pass through")

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -1,0 +1,196 @@
+package session
+
+// Two-axis session state (#1195 Phase 1b).
+//
+// The legacy Status enum jammed two orthogonal axes into one int: what the
+// backing session actually IS (liveness — daemon-owned, persisted) and what
+// operation a client is mid-executing (an in-flight op — transient, never
+// persisted). Overloading a single field is what generated the whole
+// SetStatusIfNotDeleting / isTransientStatus / overrideDeleting apparatus that
+// reconstructs the split at read time, and the #1187 collision (Deleting meaning
+// both "TUI kill" and "daemon archive fence").
+//
+// This file introduces the two axes as separate fields and keeps the legacy
+// Status enum working as a thin DERIVATION SHIM: GetStatus composes the old value
+// from (liveness, inFlightOp) and SetStatus decomposes a legacy write back onto
+// them. Phase 1b is deliberately INERT — no behavior changes — so later PRs can
+// migrate writers (1c: daemon poll → SetLiveness) and readers (1d: reconcile →
+// inFlightOp) onto the axes incrementally, then delete the shim (1e).
+
+// Liveness is the daemon-owned health axis: what state the backing tmux/worktree
+// is actually in, independent of any client operation in flight. It is the
+// persisted half of the old Status enum — exactly the values SaveInstances ever
+// wrote to disk (transients are skipped) — now named on its own axis.
+type Liveness int
+
+const (
+	// LivenessUnset is the zero value. It is never a live in-memory state: it
+	// exists so an InstanceData decoded from a record written before #1195 (no
+	// `liveness` key) lands here and FromInstanceData falls back to the legacy
+	// `status` int. omitempty drops it on write.
+	LivenessUnset Liveness = iota
+	// LiveRunning: the agent is working.
+	LiveRunning
+	// LiveReady: idle, waiting for user input.
+	LiveReady
+	// LiveLost: the backing session vanished under a live record — recovery-
+	// eligible (#1108/#1104).
+	LiveLost
+	// LiveDead: legacy observed-death. Write-never since #1108 (deaths record
+	// Lost); FromInstanceData maps persisted Dead→Lost. Retained so the shim
+	// round-trips and a later PR can retire it (1e).
+	LiveDead
+	// LiveArchived: deliberately shelved, worktree moved out, inert (#1028).
+	LiveArchived
+	// LiveLimitReached: the agent hit a usage-limit wall (#1146). Folded in here
+	// from the start so the limit epic consumes a Liveness value rather than
+	// appending to the flat Status enum.
+	LiveLimitReached
+)
+
+// InFlightOp is the client/executor-owned axis: the operation a client (or the
+// daemon executor) is mid-way through, overlaid on the liveness. It is NEVER
+// serialized and NEVER carried in the daemon snapshot — a transient overlay that
+// clears when the liveness confirms the op's outcome. A separate field for it is
+// what will retire the reconstruct-at-read apparatus (1d).
+type InFlightOp int
+
+const (
+	// OpNone: no client operation in flight.
+	OpNone InFlightOp = iota
+	// OpCreating: a create is in flight (was Loading).
+	OpCreating
+	// OpKilling: an optimistic kill is in flight (was Deleting).
+	OpKilling
+	// OpArchiving: an archive teardown+move is in flight (was Deleting used as
+	// the archive fence) — a distinct value from OpKilling so the two owners no
+	// longer collide (#1187). Populated only through the shim in Phase 1b; the
+	// daemon archive executor sets it directly in 1c.
+	OpArchiving
+	// OpRestoring: an archive restore is in flight (replaces the RestoreFromArchive
+	// "park it in Lost to trigger the re-spawn loop" hack). Wired in 1c.
+	OpRestoring
+)
+
+// composeStatus derives the legacy Status enum from the two-axis model. An
+// in-flight op wins the composed value (it overlays the liveness), matching the
+// old single-field semantics where Loading/Deleting masked the underlying state.
+func composeStatus(lv Liveness, op InFlightOp) Status {
+	switch op {
+	case OpCreating:
+		return Loading
+	case OpKilling, OpArchiving:
+		return Deleting
+	case OpRestoring:
+		return Lost
+	}
+	switch lv {
+	case LiveRunning:
+		return Running
+	case LiveReady:
+		return Ready
+	case LiveLost:
+		return Lost
+	case LiveDead:
+		return Dead
+	case LiveArchived:
+		return Archived
+	case LiveLimitReached:
+		// No legacy Status equivalent; nothing composes it until the limit
+		// reader lands (1c/1d). Present the closest settled state meanwhile.
+		return Ready
+	}
+	// LivenessUnset and any unknown value: preserve the old zero-value Status
+	// (Running) so a bare Instance{} literal reads as it did pre-split.
+	return Running
+}
+
+// livenessForStatus maps a settled (non-transient) legacy Status to its Liveness
+// axis. Transient values (Loading/Deleting) are handled by setStatusLocked, which
+// sets the op and leaves liveness untouched, so they never reach here.
+func livenessForStatus(s Status) Liveness {
+	switch s {
+	case Running:
+		return LiveRunning
+	case Ready:
+		return LiveReady
+	case Lost:
+		return LiveLost
+	case Dead:
+		return LiveDead
+	case Archived:
+		return LiveArchived
+	}
+	return LiveReady
+}
+
+// opForStatus extracts the in-flight-op axis from a legacy Status: only the
+// transient values carry one, settled values map to OpNone. FromInstanceData
+// uses it so rebuilding an instance from a snapshot that caught a transient
+// (Loading/Deleting) reconstructs the same composed Status (the shim must be a
+// faithful round-trip in Phase 1b).
+func opForStatus(s Status) InFlightOp {
+	switch s {
+	case Loading:
+		return OpCreating
+	case Deleting:
+		return OpKilling
+	}
+	return OpNone
+}
+
+// statusLocked composes the legacy Status under the caller-held mutex. It is the
+// read half of the Phase 1b shim; every existing Status reader routes through it
+// (GetStatus, ToInstanceData, the tab-spawn guards) unchanged.
+func (i *Instance) statusLocked() Status {
+	return composeStatus(i.liveness, i.inFlightOp)
+}
+
+// setStatusLocked decomposes a legacy Status write onto the two axes under the
+// caller-held mutex. Transient values set the in-flight op and leave liveness
+// untouched (they overlay it); settled values set liveness and clear the op —
+// matching the old single-field clobber exactly.
+func (i *Instance) setStatusLocked(s Status) {
+	switch s {
+	case Loading:
+		i.inFlightOp = OpCreating
+	case Deleting:
+		i.inFlightOp = OpKilling
+	default:
+		i.inFlightOp = OpNone
+		i.liveness = livenessForStatus(s)
+	}
+}
+
+// SetStatus sets the status under the instance mutex (legacy shim — decomposes
+// onto the two axes).
+func (i *Instance) SetStatus(status Status) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.setStatusLocked(status)
+}
+
+// SetStatusIfNotDeleting sets the status under the instance mutex unless the
+// instance is mid-deletion. The metadata tick runs off the event loop and races
+// the async kill flow (#844): between its own status check and its store, the
+// user can confirm a kill, and an unconditional Running/Ready write would clobber
+// the Deleting marker — re-enabling kill/attach on a session whose teardown is
+// already in flight. Only the kill completion handler may move an instance out of
+// Deleting, via SetStatus. (Legacy shim; the guard now reads the composed value.)
+func (i *Instance) SetStatusIfNotDeleting(status Status) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.statusLocked() == Deleting {
+		return
+	}
+	i.setStatusLocked(status)
+}
+
+// GetStatus returns the current status under the Instance's mutex, so
+// cross-goroutine readers don't race with SetStatus (legacy shim — composes the
+// value from the two axes).
+func (i *Instance) GetStatus() Status {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.statusLocked()
+}

--- a/session/liveness_test.go
+++ b/session/liveness_test.go
@@ -1,0 +1,86 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatusShimRoundTrips is the #1195 Phase 1b inertness guard: SetStatus →
+// GetStatus must be a faithful round-trip for every legacy Status value, so the
+// two-axis decomposition/composition is invisible to existing callers.
+func TestStatusShimRoundTrips(t *testing.T) {
+	for _, s := range []Status{Running, Ready, Loading, Deleting, Dead, Lost, Archived} {
+		i := &Instance{}
+		i.SetStatus(s)
+		require.Equal(t, s, i.GetStatus(), "SetStatus(%v) must round-trip through GetStatus", s)
+	}
+}
+
+// TestStatusAxesDecomposition documents how each legacy value lands on the two
+// axes: transient values overlay the liveness (op set, liveness untouched);
+// settled values set the liveness and clear the op.
+func TestStatusAxesDecomposition(t *testing.T) {
+	cases := []struct {
+		status   Status
+		liveness Liveness
+		op       InFlightOp
+	}{
+		{Running, LiveRunning, OpNone},
+		{Ready, LiveReady, OpNone},
+		{Lost, LiveLost, OpNone},
+		{Dead, LiveDead, OpNone},
+		{Archived, LiveArchived, OpNone},
+	}
+	for _, c := range cases {
+		i := &Instance{}
+		i.SetStatus(c.status)
+		assert.Equal(t, c.liveness, i.liveness, "%v liveness", c.status)
+		assert.Equal(t, c.op, i.inFlightOp, "%v op", c.status)
+	}
+
+	// Transient values set the op and leave the underlying liveness intact.
+	i := &Instance{}
+	i.SetStatus(Running) // underlying liveness
+	i.SetStatus(Deleting)
+	assert.Equal(t, LiveRunning, i.liveness, "Deleting must overlay, not overwrite, liveness")
+	assert.Equal(t, OpKilling, i.inFlightOp)
+	assert.Equal(t, Deleting, i.GetStatus())
+
+	i2 := &Instance{}
+	i2.SetStatus(Ready)
+	i2.SetStatus(Loading)
+	assert.Equal(t, LiveReady, i2.liveness, "Loading must overlay, not overwrite, liveness")
+	assert.Equal(t, OpCreating, i2.inFlightOp)
+}
+
+// TestLivenessPersistenceRollforward guards the migration format: new records
+// carry the `liveness` key; records written before #1195 (no `liveness`) decode
+// to LivenessUnset so FromInstanceData falls back to the legacy `status` int.
+func TestLivenessPersistenceRollforward(t *testing.T) {
+	// New record: ToInstanceData writes both axes; the `liveness` key is present.
+	i := &Instance{}
+	i.SetStatus(Lost)
+	data := i.ToInstanceData()
+	require.Equal(t, LiveLost, data.Liveness)
+	require.Equal(t, Lost, data.Status, "legacy status still written for rollback")
+
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"liveness":`, "new records persist the liveness axis")
+
+	var back InstanceData
+	require.NoError(t, json.Unmarshal(raw, &back))
+	assert.Equal(t, LiveLost, back.Liveness, "liveness survives a JSON round-trip")
+
+	// Legacy record: only `status` on disk, no `liveness` key. It must decode to
+	// LivenessUnset — the signal FromInstanceData uses to fall back to `status`.
+	var legacy InstanceData
+	require.NoError(t, json.Unmarshal([]byte(`{"title":"old","status":5}`), &legacy))
+	assert.Equal(t, LivenessUnset, legacy.Liveness, "a pre-#1195 record has no liveness key")
+	assert.Equal(t, Lost, legacy.Status, "the legacy status int is still readable")
+	assert.Equal(t, LiveLost, livenessForStatus(legacy.Status),
+		"the fallback maps the legacy status onto the liveness axis")
+}

--- a/session/storage.go
+++ b/session/storage.go
@@ -15,11 +15,19 @@ type InstanceData struct {
 	// before #1195 simply have no id, and the reconcile falls back to
 	// title+CreatedAt for them (rollforward, mirroring the BranchCreatedByUs
 	// precedent).
-	ID        string    `json:"id,omitempty"`
-	Title     string    `json:"title"`
-	Path      string    `json:"path"`
-	Branch    string    `json:"branch"`
-	Status    Status    `json:"status"`
+	ID     string `json:"id,omitempty"`
+	Title  string `json:"title"`
+	Path   string `json:"path"`
+	Branch string `json:"branch"`
+	// Status is the legacy single-axis status int (#1195). Still written for one
+	// release for rollback safety and read as the fallback source for records
+	// that predate the `liveness` field. New code should read Liveness.
+	Status Status `json:"status"`
+	// Liveness is the daemon-owned health axis (#1195), the new canonical
+	// persisted state. omitempty + additive: records written before #1195 have
+	// no `liveness` key and decode to LivenessUnset, signaling FromInstanceData
+	// to fall back to the legacy `status` int (rollforward).
+	Liveness  Liveness  `json:"liveness,omitempty"`
 	Height    int       `json:"height"`
 	Width     int       `json:"width"`
 	CreatedAt time.Time `json:"created_at"`

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -95,7 +95,7 @@ func makeInstance(title, repoPath string, started bool) *Instance {
 	i := &Instance{
 		Title:     title,
 		Path:      repoPath,
-		Status:    Running,
+		liveness:  LiveRunning,
 		CreatedAt: time.Now(),
 		backend:   &LocalBackend{},
 		started:   started,
@@ -161,7 +161,7 @@ func TestSavePreservesArchivedRecordAcrossCoRepoSave(t *testing.T) {
 
 	live := makeInstance("live-sess", repoPath, true)          // started
 	archived := makeInstance("archived-sess", repoPath, false) // inert, started=false
-	archived.Status = Archived
+	archived.SetStatus(Archived)
 
 	storage, err := NewStorage(ms, "") // daemon mode
 	require.NoError(t, err)
@@ -302,7 +302,7 @@ func TestRepoSaveDropsLoadingFromMemory(t *testing.T) {
 	ms := newMockStorage()
 
 	loading := makeInstance("in-flight", repoPath, false)
-	loading.Status = Loading
+	loading.SetStatus(Loading)
 	storage, err := NewStorage(ms, repoID)
 	require.NoError(t, err)
 
@@ -327,7 +327,7 @@ func TestRepoSaveDropsDeletingFromMemory(t *testing.T) {
 	// Alive backend + started + empty disk: exactly the shape #819 preserves —
 	// unless the instance is Deleting.
 	deleting := makeAliveInstance("mid-teardown", repoPath)
-	deleting.Status = Deleting
+	deleting.SetStatus(Deleting)
 
 	storage, err := NewStorage(ms, repoID)
 	require.NoError(t, err)

--- a/session/tab_archive_race_test.go
+++ b/session/tab_archive_race_test.go
@@ -16,7 +16,7 @@ import (
 // (#1195).
 func flipStatus(i *Instance, s Status) {
 	i.mu.Lock()
-	i.Status = s
+	i.setStatusLocked(s)
 	i.mu.Unlock()
 }
 

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -37,7 +37,7 @@ func TabSpawnStatusErr(status Status) error {
 func (i *Instance) AddShellTab() (*Tab, error) {
 	i.mu.RLock()
 	started := i.started
-	status := i.Status
+	status := i.statusLocked()
 	agentTmux := i.tmuxLocked()
 	gw := i.gitWorktree
 	displayName := uniqueShellName(i.Tabs)
@@ -79,7 +79,7 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 	// would leak a tmux session that escapes teardown while its worktree is deleted
 	// or moved (#990, #1028). Make the recheck and append atomic under one
 	// acquisition so no further race opens.
-	stale := !i.started || TabSpawnStatusErr(i.Status) != nil
+	stale := !i.started || TabSpawnStatusErr(i.statusLocked()) != nil
 	title := i.Title
 	if !stale {
 		i.Tabs = append(i.Tabs, tab)
@@ -115,7 +115,7 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 
 	i.mu.RLock()
 	started := i.started
-	status := i.Status
+	status := i.statusLocked()
 	agentTmux := i.tmuxLocked()
 	gw := i.gitWorktree
 	displayName := uniqueTabName(i.Tabs, processTabBaseName(requestedName, command))
@@ -154,7 +154,7 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 	// started=true but flips status to Deleting→Archived (#1195); appending now
 	// would leak a tmux session whose worktree Kill deletes or archive moves (#990,
 	// #1028). Recheck + append are atomic under one acquisition.
-	stale := !i.started || TabSpawnStatusErr(i.Status) != nil
+	stale := !i.started || TabSpawnStatusErr(i.statusLocked()) != nil
 	title := i.Title
 	if !stale {
 		i.Tabs = append(i.Tabs, tab)

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -8,13 +8,22 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/layout"
 )
 
+// readyUIInstance builds a Ready-status instance for ui-package render tests.
+// liveness is unexported, so it goes through the SetStatus shim rather than a
+// struct literal (#1195 Phase 1b).
+func readyUIInstance() *session.Instance {
+	i := &session.Instance{}
+	i.SetStatus(session.Ready)
+	return i
+}
+
 // TestMenuTerminalTabShowsBothScrollKeys verifies that when the terminal tab
 // is active, the instance menu surfaces both shift+up and shift+down scroll
 // shortcuts. Regression test for issue #270.
 func TestMenuTerminalTabShowsBothScrollKeys(t *testing.T) {
 	m := NewMenu()
 	// Use a non-loading instance so addInstanceOptions renders the full menu.
-	m.SetInstance(&session.Instance{Status: session.Ready})
+	m.SetInstance(readyUIInstance())
 	m.SetActiveTab(1)
 
 	var gotShiftUp, gotShiftDown int
@@ -41,7 +50,7 @@ func TestMenuTerminalTabShowsBothScrollKeys(t *testing.T) {
 // test for issue #467.
 func TestMenuPreviewTabShowsBothScrollKeys(t *testing.T) {
 	m := NewMenu()
-	m.SetInstance(&session.Instance{Status: session.Ready})
+	m.SetInstance(readyUIInstance())
 	m.SetActiveTab(0)
 
 	var gotShiftUp, gotShiftDown int
@@ -68,7 +77,7 @@ func TestMenuPreviewTabShowsBothScrollKeys(t *testing.T) {
 // tab keys that actually work (cycle / 1-9 jump), while local instances keep
 // the full set.
 func TestMenuRemoteInstanceOmitsUnsupportedTabKeys(t *testing.T) {
-	remote := &session.Instance{Status: session.Ready}
+	remote := readyUIInstance()
 	remote.SetBackend(&session.HookBackend{})
 	if !remote.IsRemote() {
 		t.Fatal("sanity: instance should report as remote")
@@ -97,7 +106,7 @@ func TestMenuRemoteInstanceOmitsUnsupportedTabKeys(t *testing.T) {
 		t.Errorf("remote menu should still surface tab cycle and 1-9 jump; got tab=%d jump=%d", gotTab, gotJump)
 	}
 
-	local := &session.Instance{Status: session.Ready}
+	local := readyUIInstance()
 	if local.IsRemote() {
 		t.Fatal("sanity: instance should report as local")
 	}
@@ -121,7 +130,7 @@ func TestMenuRemoteInstanceOmitsUnsupportedTabKeys(t *testing.T) {
 // workspace pane gets its own option set — attach/scroll on its binding,
 // open-pane, hide-pane.
 func TestMenuPaneHintsFollowFocus(t *testing.T) {
-	local := &session.Instance{Status: session.Ready}
+	local := readyUIInstance()
 	m := NewMenu()
 	m.SetInstance(local)
 

--- a/ui/statusbar_test.go
+++ b/ui/statusbar_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,7 +60,7 @@ func TestMenuFocusRegionSwitchesHints(t *testing.T) {
 // hints to vanish on narrow terminals.
 func TestMenuNarrowWidthKeepsHelpAndQuit(t *testing.T) {
 	m := NewMenu()
-	m.SetInstance(&session.Instance{Status: session.Ready})
+	m.SetInstance(readyUIInstance())
 
 	for _, w := range []int{110, 80, 60, 45} {
 		m.SetSize(w, 1)

--- a/ui/store/order_test.go
+++ b/ui/store/order_test.go
@@ -116,8 +116,10 @@ func TestLessInstanceOrder_StableAcrossIdenticalSnapshots(t *testing.T) {
 // A Lost root still pins top; a Lost non-root sorts by CreatedAt like any other
 // instance (Lost is not special to ordering, #1108).
 func TestLessInstanceOrder_LostStatusDoesNotAffectOrder(t *testing.T) {
-	lostRoot := &session.Instance{Title: "root", CreatedAt: tNewest, Status: session.Lost}
-	lostBravo := &session.Instance{Title: "bravo", CreatedAt: tMid, Status: session.Lost}
+	lostRoot := &session.Instance{Title: "root", CreatedAt: tNewest}
+	lostRoot.SetStatus(session.Lost)
+	lostBravo := &session.Instance{Title: "bravo", CreatedAt: tMid}
+	lostBravo.SetStatus(session.Lost)
 	in := []*session.Instance{
 		lostBravo,
 		inst("charlie", tNewer),


### PR DESCRIPTION
## What

Phase 1b of the #1195 Status-split anchor: introduce the **two-axis model** (`Liveness` + `InFlightOp`) as separate fields on `Instance`, and keep the legacy `Status` enum working as a thin **derivation shim**. This PR is deliberately **INERT — zero behavior change** — so later PRs migrate writers (1c) and readers (1d) onto the axes incrementally, then delete the shim (1e). Builds on #1198 (Phase 1a, merged).

## The model (`session/liveness.go`)

- **`Liveness`** `{Running, Ready, Lost, Dead, Archived, LimitReached}` — the daemon-owned health axis (persisted). **`LimitReached` is included from the start** so the #1146 usage-limit epic consumes a Liveness value rather than appending to the flat enum (its PR2 status-surface is gated on this). `LivenessUnset` is the zero-value serialization sentinel.
- **`InFlightOp`** `{None, Creating, Killing, Archiving, Restoring}` — the client/executor-owned axis, **never serialized**. `Archiving` is a **distinct value from `Killing`**, so the two owners that collided as `Deleting` (the #1187 class) no longer share one enum.
- **Shim**: `composeStatus` / `livenessForStatus` / `opForStatus`, and `GetStatus`/`SetStatus`/`SetStatusIfNotDeleting` (moved out of `instance.go` — which nets **smaller**, staying under the #1145 ceiling).

`Instance` now holds `{liveness, inFlightOp}` instead of `Status`. `GetStatus` composes the legacy value; `SetStatus` decomposes a write back onto the axes — transient values (`Loading`/`Deleting`) overlay the liveness, settled values set liveness and clear the op, matching the old single-field clobber exactly.

## Persistence (rollforward, no dual-read)

- `InstanceData` gains `liveness,omitempty`. `ToInstanceData` writes **both** it and the legacy `status` int (kept one release for rollback).
- `FromInstanceData` prefers `liveness`, falls back to the legacy `status` for pre-#1195 records, and maps **Dead→Lost** (the #1108 rollforward) uniformly.
- A snapshot that caught a transient reconstructs the op via `opForStatus`, so a rebuilt row composes to the identical `Status`.
- The disk barely changes: the on-disk `status` was *already* pure liveness (transients skipped by `SaveInstances`), so this is a near-no-op migration.

## Interaction with #1196 (merged)
The archive-orphan tab-spawn guard reads through the shim (`statusLocked`); **1c folds it onto `InFlightOp` structurally**.

## Tests
- `session/liveness_test.go`: shim round-trip for **every** legacy value, axis decomposition, persistence rollforward + legacy-record fallback.
- Existing `Status`-setting test literals moved onto `SetStatus` / the unexported `liveness` field. A dropped-`Branch` regression in `ToInstanceData` was caught by the lifecycle e2e tests and fixed.

## Gates
`make test-container` full suite green; `gofmt -l` empty, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` all clean.

Part of #1195 (Phase 1 anchor). **Does not close it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)