### PR TITLE
fix(tui-driver): af_select cursor-on-row + af_resize + pre-#1166 gate docs (#1174)

### DIFF
--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -69,7 +69,18 @@ On a cold boot the cursor sits on the **section header** (no instance selected
 — menu shows the plain `n new • N new remote` set); the first `j` moves the
 cursor down onto the first instance. `af_select` is robust to any starting
 position: it anchors at the top (`k` is idempotent there), then steps down
-with `j` until the target row shows `▾`.
+with `j` until the target row shows `▾` **and** the tree cursor is actually on
+it.
+
+> **Display-selected ≠ cursor-on-row (#1174 / #1199).** The sticky `▾` is only
+> a *display* signal. A **single** auto-selected instance renders `▾` while the
+> cursor still sits on the section header — there `GetSelectedInstance()` is
+> `nil`, so `o`/`D`/attach silently no-op even though the row *looks* selected
+> (a false pass waiting to happen). `af_select` therefore also requires the
+> menu to advertise a **row-scoped verb (`D kill`)** — present only when a real
+> instance is under the cursor — and keeps pressing `j` past the header until
+> it appears. `af_attach`/`af_open_pane` inherit the fix because scenarios call
+> `af_select` first.
 
 ### Which key goes where (defaults, from `keys/keys.go`)
 
@@ -146,6 +157,7 @@ compose across `docker exec` invocations.
 | `af_click <x> <y>` / `af_click_instance <name>` | SGR mouse | injects a left click at a cell / on an instance row |
 | `af_scroll <up\|down> [x] [y]` | SGR wheel | injects a wheel event |
 | `af_set_config <toml>` + `af_relaunch` | — | rewrites `config.toml` (canonical since #1030) and reboots the TUI |
+| `af_resize <cols> <rows>` | — | pins the session to an exact geometry that STICKS (`window-size manual` + `resize-window`), for tiny-size gates |
 | `af_quit` | `q` | back to a shell prompt |
 
 ### Assertions & introspection
@@ -164,6 +176,10 @@ compose across `docker exec` invocations.
 `AF_DRIVER_REPO` (`$HOME/sandbox/mock-repo`), `AGENT_FACTORY_HOME`,
 `AF_DRIVER_TIMEOUT` (`25`s), `AF_DRIVER_POLL` (`0.25`s),
 `AF_DRIVER_DETACH_KEY` (`C-w`), `AF_DRIVER_BIN` (auto-resolved).
+
+Set `AF_DRIVER_COLS`/`ROWS` **before** `af_boot` to launch at a non-default
+size — `af_boot` pins it so it sticks (see the tiny-size gate below). Change
+the size mid-run with `af_resize <cols> <rows>`.
 
 ---
 
@@ -300,9 +316,53 @@ af_click_instance b; af_expect_selected b
 af_scroll down; af_scroll up
 ```
 
+### Tiny geometry / responsive-layout changes (the #1174-item-2 class)
+
+A **detached** tmux session defaults to `window-size latest`, which snaps the
+window back to the last-attached client (80x23) and *ignores* `new-session
+-x/-y`. So a naive small-size boot silently ran at 80x23 and never exercised
+the tiny layout. Boot with the size preset (`af_boot` pins it), or resize
+mid-run with `af_resize`:
+
+```bash
+AF_DRIVER_COLS=60 AF_DRIVER_ROWS=15 af_boot   # boots pinned at 60x15
+af_new_instance a
+af_select a; af_expect_selected a             # selection still works when narrow
+
+af_resize 40 10                               # squeeze to 40x10 mid-run
+af_assert_screen 'Instances'                  # header must survive the squeeze
+```
+
 ---
 
-## 6. Isolation & box safety (inherited from the container)
+## 6. Gating a branch cut BEFORE #1166 (the driver isn't in the tree yet)
+
+`scripts/tui-driver.sh` landed in **#1166**. A branch cut before that commit has
+no driver to source, so `source /src/scripts/tui-driver.sh` fails with *No such
+file*. Two ways to gate such a branch — pick one **before** you boot:
+
+- **Rebase the branch onto `master`** (preferred when the branch is yours and
+  rebasing is clean) — this pulls the driver + self-test into the tree
+  naturally, and you gate exactly what will merge.
+- **Copy the driver in from `master`** when a rebase is noisy or the branch is
+  an external PR you don't want to rewrite. Inside the running sandbox
+  container:
+
+  ```bash
+  # From the host, into the sandbox container (name is unique per run, #1171):
+  docker cp scripts/tui-driver.sh          "$AF_PLAYTEST_NAME":/src/scripts/
+  docker cp scripts/tui-driver-selftest.sh "$AF_PLAYTEST_NAME":/src/scripts/
+  # then drive as usual — the driver is pure harness, so master's copy gates
+  # any older product tree without changing what you're testing.
+  ```
+
+Because the driver only sends keys and reads the screen — it carries no product
+code — master's copy is safe to run against an older `af` build; it asserts on
+the same on-screen markers regardless of the branch under test.
+
+---
+
+## 7. Isolation & box safety (inherited from the container)
 
 Every rule from the [tui-playtest skill](../.claude/skills/tui-playtest.md)
 is satisfied *structurally* by running inside the container: private tmux

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -55,6 +55,21 @@ printf 'session=%s size=%sx%s home=%s\n' \
 step "reset sandbox to a clean state"                       af_reset_sandbox
 step "boot af at ${AF_DRIVER_COLS}x${AF_DRIVER_ROWS}"        af_boot
 step "create instance 'alpha'"                              af_new_instance alpha
+
+# --- #1174 item 1 / #1199 regression: the SINGLE-instance false positive ---
+# With exactly one instance the row auto-display-selects (sticky ▾) while the
+# tree cursor still sits on the section header — so GetSelectedInstance() is
+# nil and cursor-driven verbs (o/D) silently NO-OP even though the row LOOKS
+# selected. The old af_select returned on iteration 0 (▾ present) and a
+# play-test could wrongly "pass". af_select now lands the cursor ON the row, so
+# `o attach` MUST actually fire here. If the bug returns, either af_select
+# fails (no 'D kill') or af_attach times out waiting for the chrome to vanish.
+step "select the SOLE instance alpha"                       af_select alpha
+step "assert alpha display-selected (sole instance)"        af_expect_selected alpha
+step "attach the SOLE instance (proves 'o' is NOT a no-op)" af_attach
+step "detach from the single-instance attach"              af_detach
+step "assert alpha survived the single-instance round trip"  af_expect_selected alpha
+
 step "create instance 'beta'"                               af_new_instance beta
 
 # The #1156 failure, now two lines each.

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -46,6 +46,26 @@ step() {
     fi
 }
 
+# _expect_resize_rejected — the NEGATIVE check for af_resize (Greptile, #1201):
+# a resize tmux cannot honor must FAIL LOUDLY, never masquerade as success (or a
+# tiny-size gate would keep running at the wrong size). We point af_resize at a
+# session that does not exist; it must return non-zero. AF_DRIVER_SESSION is
+# saved/restored so the rest of the run is unaffected; af_resize leaves
+# AF_DRIVER_COLS/ROWS untouched because it returns before recording them on a
+# failed resize.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_resize_rejected() {
+    local saved="$AF_DRIVER_SESSION" rc=0
+    AF_DRIVER_SESSION="no-such-driver-session-selftest"
+    af_resize 60 15 >/dev/null 2>&1 || rc=$?
+    AF_DRIVER_SESSION="$saved"
+    if [ "$rc" -eq 0 ]; then
+        _af_log "af_resize wrongly SUCCEEDED on a missing session (should fail loudly)"
+        return 1
+    fi
+    return 0
+}
+
 printf '=== tui-driver self-test (#1161) ===\n'
 printf 'session=%s size=%sx%s home=%s\n' \
     "$AF_DRIVER_SESSION" "$AF_DRIVER_COLS" "$AF_DRIVER_ROWS" "$AGENT_FACTORY_HOME"
@@ -53,7 +73,11 @@ printf 'session=%s size=%sx%s home=%s\n' \
 # Start from a clean slate so the run is deterministic even in a reused
 # container (scoped to the sandbox; fails closed on a non-sandbox home).
 step "reset sandbox to a clean state"                       af_reset_sandbox
+# af_boot routes launch geometry through af_resize, which verifies the window
+# actually took the requested size — so a green boot is also positive proof
+# af_resize works (#1174 item 2 / #1201).
 step "boot af at ${AF_DRIVER_COLS}x${AF_DRIVER_ROWS}"        af_boot
+step "af_resize fails loudly on an impossible resize"       _expect_resize_rejected
 step "create instance 'alpha'"                              af_new_instance alpha
 
 # --- #1174 item 1 / #1199 regression: the SINGLE-instance false positive ---

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -133,9 +133,14 @@ af_ensure_nav() {
 # which snaps the window back to the last-attached client (80x23) and IGNORES
 # the `new-session -x/-y` request — so tiny-size gates (60x15, 40x10) silently
 # ran at 80x23 (#1174 item 2). Pinning `window-size manual` + an explicit
-# `resize-window` makes the geometry deterministic. Also updates
-# AF_DRIVER_COLS/ROWS so later helpers and logs reflect the live size. Sleeps
-# one poll so the TUI observes SIGWINCH and repaints before we assert on it.
+# `resize-window` makes the geometry deterministic.
+#
+# FAILS LOUDLY (non-zero + message) if tmux rejects the resize (invalid dims,
+# missing session) OR the window's actual size doesn't match what was
+# requested — a testing helper that lied about a resize would let a tiny-size
+# gate keep running at the wrong size while believing it resized (Greptile,
+# #1201). AF_DRIVER_COLS/ROWS are updated ONLY after the size is confirmed, so
+# they never advertise a geometry that isn't live.
 af_resize() {
     local cols="$1" rows="$2"
     if [ -z "$cols" ] || [ -z "$rows" ]; then
@@ -145,10 +150,21 @@ af_resize() {
     tmux set-option -t "$AF_DRIVER_SESSION" window-size manual >/dev/null 2>&1 \
         || tmux set-option -w -t "$AF_DRIVER_SESSION" window-size manual >/dev/null 2>&1 \
         || true
-    tmux resize-window -t "$AF_DRIVER_SESSION" -x "$cols" -y "$rows" >/dev/null 2>&1 || true
+    if ! tmux resize-window -t "$AF_DRIVER_SESSION" -x "$cols" -y "$rows" 2>/dev/null; then
+        _af_fail "af_resize: tmux rejected resize to ${cols}x${rows} (invalid size, or missing session '$AF_DRIVER_SESSION')"
+        return 1
+    fi
+    # Let tmux apply the resize and the TUI observe SIGWINCH / repaint, then
+    # verify the window actually took the requested geometry.
+    sleep "$AF_DRIVER_POLL"
+    local actual
+    actual="$(tmux display-message -p -t "$AF_DRIVER_SESSION" '#{window_width}x#{window_height}' 2>/dev/null)"
+    if [ "$actual" != "${cols}x${rows}" ]; then
+        _af_fail "af_resize: requested ${cols}x${rows} but window is ${actual:-unknown} — resize did not stick"
+        return 1
+    fi
     AF_DRIVER_COLS="$cols"
     AF_DRIVER_ROWS="$rows"
-    sleep "$AF_DRIVER_POLL"
 }
 
 # af_focus_tree — put ring focus on the instances tree (the state whose menu
@@ -242,7 +258,8 @@ af_boot() {
     # A detached session ignores -x/-y under `window-size latest`; pin it so the
     # TUI reads the requested geometry on startup (#1174 item 2). Honors any
     # AF_DRIVER_COLS/ROWS override set before af_boot, including tiny sizes.
-    af_resize "$AF_DRIVER_COLS" "$AF_DRIVER_ROWS"
+    # af_resize verifies the geometry took, so a bad size fails the boot loudly.
+    af_resize "$AF_DRIVER_COLS" "$AF_DRIVER_ROWS" || return 1
 
     af_send_literal "cd $AF_DRIVER_REPO && $bin"
     af_send Enter

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -128,6 +128,29 @@ af_ensure_nav() {
     sleep "$AF_DRIVER_POLL"
 }
 
+# af_resize <cols> <rows> — force the driver session to an exact geometry and
+# MAKE IT STICK. A DETACHED tmux session defaults to `window-size latest`,
+# which snaps the window back to the last-attached client (80x23) and IGNORES
+# the `new-session -x/-y` request — so tiny-size gates (60x15, 40x10) silently
+# ran at 80x23 (#1174 item 2). Pinning `window-size manual` + an explicit
+# `resize-window` makes the geometry deterministic. Also updates
+# AF_DRIVER_COLS/ROWS so later helpers and logs reflect the live size. Sleeps
+# one poll so the TUI observes SIGWINCH and repaints before we assert on it.
+af_resize() {
+    local cols="$1" rows="$2"
+    if [ -z "$cols" ] || [ -z "$rows" ]; then
+        _af_fail "af_resize: <cols> <rows> required"; return 1
+    fi
+    # window-size is a session option in modern tmux; -w covers older builds.
+    tmux set-option -t "$AF_DRIVER_SESSION" window-size manual >/dev/null 2>&1 \
+        || tmux set-option -w -t "$AF_DRIVER_SESSION" window-size manual >/dev/null 2>&1 \
+        || true
+    tmux resize-window -t "$AF_DRIVER_SESSION" -x "$cols" -y "$rows" >/dev/null 2>&1 || true
+    AF_DRIVER_COLS="$cols"
+    AF_DRIVER_ROWS="$rows"
+    sleep "$AF_DRIVER_POLL"
+}
+
 # af_focus_tree — put ring focus on the instances tree (the state whose menu
 # advertises `n new`). Checks BEFORE pressing, so it never Tabs off the tree
 # when already there. Assumes nav mode (call af_ensure_nav first).
@@ -216,6 +239,10 @@ af_boot() {
     # server (the container hosts the daemon's sessions too).
     tmux kill-session -t "$AF_DRIVER_SESSION" 2>/dev/null || true
     tmux new-session -d -s "$AF_DRIVER_SESSION" -x "$AF_DRIVER_COLS" -y "$AF_DRIVER_ROWS"
+    # A detached session ignores -x/-y under `window-size latest`; pin it so the
+    # TUI reads the requested geometry on startup (#1174 item 2). Honors any
+    # AF_DRIVER_COLS/ROWS override set before af_boot, including tiny sizes.
+    af_resize "$AF_DRIVER_COLS" "$AF_DRIVER_ROWS"
 
     af_send_literal "cd $AF_DRIVER_REPO && $bin"
     af_send Enter
@@ -239,9 +266,22 @@ af_new_instance() {
     af_wait_for "${name}.*●" "$AF_DRIVER_TIMEOUT" "instance '${name}' ready" || return 1
 }
 
-# af_select <name> — make <name> the display-selected instance. Robust to any
-# starting cursor position: anchor at the top (k is idempotent there), then
-# step down until <name>'s row carries the ▾ selected/expanded arrow.
+# af_select <name> — put the tree cursor ON <name>'s row (so it is the *real*
+# GetSelectedInstance(), not merely display-selected). Robust to any starting
+# cursor position: anchor at the top (k is idempotent there), then step down
+# until BOTH conditions hold — <name>'s row carries the ▾ selected/expanded
+# arrow AND the menu advertises a row-scoped verb (`D kill`).
+#
+# The two-part success condition is the #1174-item-1 / #1199 fix. The sticky
+# ▾ is a DISPLAY-selection: a SINGLE auto-selected instance renders ▾ while the
+# tree cursor still sits on the `Instances` section header, so GetSelected-
+# Instance() is nil and every cursor-driven verb (o attach, D kill, and
+# af_attach/af_open_pane which run after af_select) silently no-ops. A ▾-only
+# check returns on iteration 0 in that case — a false positive that can make a
+# play-test wrongly "pass" a nav action that never fired. `D kill` appears in
+# the menu ONLY when an instance is actually under the cursor (non-nil
+# GetSelectedInstance()), so requiring it forces `j` past the header until the
+# cursor truly lands on the row.
 af_select() {
     local name="$1" _ screen
     [ -n "$name" ] || { _af_fail "af_select: name required"; return 1; }
@@ -251,13 +291,14 @@ af_select() {
     sleep "$AF_DRIVER_POLL"
     for _ in $(seq 1 40); do
         screen="$(af_capture)"
-        if printf '%s\n' "$screen" | grep -qE -- "▾[[:space:]]+[0-9]+\.[[:space:]]+${name}([[:space:]]|\$)"; then
+        if printf '%s\n' "$screen" | grep -qE -- "▾[[:space:]]+[0-9]+\.[[:space:]]+${name}([[:space:]]|\$)" \
+           && printf '%s\n' "$screen" | grep -qE -- 'D kill'; then
             return 0
         fi
         af_send j
         sleep "$AF_DRIVER_POLL"
     done
-    _af_log "could not select '${name}'"
+    _af_log "could not select '${name}' (need ▾ on its row AND cursor-on-row, i.e. 'D kill' in the menu)"
     printf '%s\n' "$screen" >&2
     return 1
 }


### PR DESCRIPTION
Closes #1174. Resolves #1199 (its sharper root-cause is carried into item 1).

Three gaps surfaced by the driver's first real play-test gates (#1172, #1198). One correctness fix, one new helper, one docs addition — all in `scripts/tui-driver.sh` + its self-test + docs.

## 1. Correctness — `af_select` false-positive on a SINGLE instance (#1174 item 1 / #1199)

The sticky `▾` is a *display*-selection, not a cursor position. With exactly one instance the row auto-display-selects (`▾`) while the tree cursor still sits on the `▼ Instances` section **header** — so `GetSelectedInstance()` is `nil` and every cursor-driven verb (`o attach`, `D kill`, and `af_attach`/`af_open_pane` which run after `af_select`) silently **no-ops** even though the row *looks* selected. A nav action that no-ops can make a play-test wrongly "pass".

`af_select` stepped `j` only until the row **displayed** selected, so it returned on iteration 0 in the single-instance case, cursor still on the header.

**Fix:** the success condition now requires **both** `▾` on the target row **and** a row-scoped verb (`D kill`) in the menu — the latter is present only when a real instance is under the cursor (`GetSelectedInstance()` non-nil). So it keeps pressing `j` past the header until the cursor truly lands on the row. `af_attach`/`af_open_pane` inherit the fix because scenarios call `af_select` first.

**Regression added** to `tui-driver-selftest.sh`: with a **single** instance, `af_select` then `o` (`af_attach`) must actually attach full-screen. I verified it *catches* the bug — reverting `af_select` to the old `▾`-only condition fails this exact step (`o` no-ops, the TUI chrome never leaves):

```
>>> attach the SOLE instance (proves 'o' is NOT a no-op)
    ✗ FAILED: attach the SOLE instance (proves 'o' is NOT a no-op)
```

With the fix, 22/22 steps green.

## 2. `af_resize <cols> <rows>` helper (#1174 item 2)

A **detached** tmux session defaults to `window-size latest`, which ignores `new-session -x/-y` and snaps the window back to a client's 80×23 — so tiny-size gates silently ran at 80×23 and never exercised the small layout. The helper pins `window-size manual` + `resize-window` so 60×15 / 40×10 gates are first-class. `af_boot` now routes launch geometry through it and honors `AF_DRIVER_COLS/ROWS` set before boot.

Verified in-container: `AF_DRIVER_COLS=60 AF_DRIVER_ROWS=15 af_boot` → window `60x15`; mid-run `af_resize 40 10` → `40x10`.

## 3. Docs (`docs/tui-manual-testing.md`)

- **Pre-#1166 branch gating:** the driver landed in #1166, so a branch cut before it has no `scripts/tui-driver.sh` to source. Documented the two ways to gate such a branch — rebase onto `master`, or `docker cp` the driver in from master (it's pure harness, safe against an older product tree).
- Tiny-geometry gate recipe and a "display-selected ≠ cursor-on-row" note.

## Gates
- `shellcheck` clean on both scripts.
- `make tui-driver-selftest` — **22/22 green** in-container (includes the new single-instance regression).
- `scripts/lint-file-length.sh` passes.
- Box-safety: all runs inside the throwaway container; host tmux untouched; no `kill-server`; no dev-install.

Not merging — root re-runs the self-test to verify.

— Captain Claude