### PR TITLE
refactor(daemon): daemon poll writes liveness; archive/restore raise ops; fold archive-orphan guard (#1195 Phase 1c)

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -51,10 +51,10 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 		// half-archive that rolls back to Lost.
 		return "", fmt.Errorf("cannot archive an in-place/external worktree session %q — archive relocates the worktree, which isn't supported for in-place sessions", req.Title)
 	}
-	switch instance.GetStatus() {
-	case session.Archived:
+	if instance.GetLiveness() == session.LiveArchived {
 		return "", fmt.Errorf("session %q is already archived", req.Title)
-	case session.Loading, session.Deleting:
+	}
+	if instance.GetInFlightOp() != session.OpNone {
 		return "", fmt.Errorf("session %q is busy (%v); try again in a moment", req.Title, instance.GetStatus())
 	}
 
@@ -90,11 +90,13 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 		return "", err
 	}
 
-	// Fence the operation window with Deleting: the status poll skips a Deleting
-	// instance (and the checkpoint save skips persisting it) while tmux is down
-	// and the worktree is mid-move, so it is never misread as Lost. started is
-	// left true throughout so a move failure self-heals via the Lost loop.
-	instance.SetStatus(session.Deleting)
+	// Fence the operation window with OpArchiving: the status poll skips an
+	// instance with an in-flight op (and the checkpoint save skips persisting a
+	// mid-op row) while tmux is down and the worktree is mid-move, so it is never
+	// misread as Lost. started is left true throughout so a move failure
+	// self-heals via the Lost loop. OpArchiving is a DISTINCT op from a kill, so
+	// the fence can never be confused with a TUI optimistic kill (#1187).
+	instance.SetInFlightOp(session.OpArchiving)
 
 	instance.ArchiveTeardown()
 
@@ -102,9 +104,10 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 		// The worktree is still at a valid location (the git layer guarantees
 		// worktreePath points at the actual bytes even on a repair failure).
 		// Mark Lost — started is still true and the agent tmux binding was kept —
-		// so the Lost-restore loop re-spawns the agent in place. Persist the
-		// recovery-eligible state and surface the failure.
-		instance.SetStatus(session.Lost)
+		// so the Lost-restore loop re-spawns the agent in place. Clear the archive
+		// fence and persist the recovery-eligible state, then surface the failure.
+		instance.SetLiveness(session.LiveLost)
+		instance.SetInFlightOp(session.OpNone)
 		m.persistInstance(repoID, instance)
 		return "", fmt.Errorf("failed to archive session %q (its agent will be restored in place): %w", req.Title, err)
 	}
@@ -136,7 +139,7 @@ func (m *Manager) RestoreArchived(req RestoreArchivedRequest) (string, error) {
 	if instance == nil {
 		return "", fmt.Errorf("cannot restore session %q: no such session", req.Title)
 	}
-	if instance.GetStatus() != session.Archived {
+	if instance.GetLiveness() != session.LiveArchived {
 		return "", fmt.Errorf("session %q is not archived", req.Title)
 	}
 
@@ -162,7 +165,7 @@ func (m *Manager) RestoreArchived(req RestoreArchivedRequest) (string, error) {
 	m.mu.Lock()
 	current := m.instances[key]
 	m.mu.Unlock()
-	if current != instance || instance.GetStatus() != session.Archived {
+	if current != instance || instance.GetLiveness() != session.LiveArchived {
 		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
 	}
 
@@ -226,7 +229,7 @@ func (m *Manager) RestoreArchived(req RestoreArchivedRequest) (string, error) {
 func (m *Manager) archiveExclusiveTabLock(key string, instance *session.Instance) (*sync.Mutex, error) {
 	opLock := m.opLockFor(key)
 	opLock.Lock()
-	if err := session.TabSpawnStatusErr(instance.GetStatus()); err != nil {
+	if err := instance.TabSpawnBlocked(); err != nil {
 		opLock.Unlock()
 		return nil, err
 	}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1496,9 +1496,9 @@ func (m *Manager) RefreshStatuses() {
 }
 
 // refreshInstanceStatus mirrors the old runMetadataTick body for one instance:
-//   - skip unstarted instances and the transient TUI-owned states (a Loading
-//     session's tmux may not exist yet; a Deleting one is mid-teardown — probing
-//     or writing either would poke a dying session, #844);
+//   - skip unstarted instances and any with an in-flight op (an archive/restore
+//     mid-teardown, a create/kill overlay — probing or writing either would poke
+//     a session whose tmux is being spun up or torn down, #844/#1195);
 //   - dismiss a pending trust prompt (CheckAndHandleTrustPrompt), moved here from
 //     the TUI so it works whether or not a TUI is attached;
 //   - HasUpdated → Running; a waiting prompt → TapEnter (the AutoYes path, which
@@ -1510,8 +1510,9 @@ func (m *Manager) RefreshStatuses() {
 //   - a session carrying the kill-intent tombstone (#1108) short-circuits all
 //     of the above: its interrupted teardown is finished instead.
 //
-// Status writes go through SetStatusIfNotDeleting so a concurrent kill's Deleting
-// marker is never clobbered. Only a real transition is persisted, and it persists
+// The poll writes only the liveness axis (SetLiveness), gated on there being no
+// in-flight op — so it can never clobber a concurrent kill/archive marker, which
+// lives on the separate op axis (#1195). Only a real transition is persisted, and it persists
 // under the per-repo start lock (mirroring CreateTab/CloseTab/SetPRInfo) through
 // the targeted writer persistInstanceData — never a whole-list re-marshal, the
 // dual-writer clobber surface #960 PR 4 retired — so an idle session never churns
@@ -1528,16 +1529,16 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		m.finishUserKill(repoID, instance)
 		return
 	}
-	if status := instance.GetStatus(); status == session.Loading || status == session.Deleting {
+	if instance.GetInFlightOp() != session.OpNone {
+		// An op is mid-flight (archive/restore teardown, create/kill overlay): the
+		// poll must not probe a session whose tmux is being spun up/torn down and
+		// mark it Lost — the op's executor writes the settled liveness. Replaces
+		// the old Loading/Deleting skip (#1195).
 		return
 	}
-	if instance.GetStatus() == session.Archived {
-		// An archived session (#1028) has no tmux to probe — its worktree was
-		// moved to the global archive dir and every tab torn down. It loads
-		// inert (started=false), so the !Started guard above already skips it;
-		// this explicit check is belt-and-suspenders so a future change that
-		// leaves an Archived instance started can never have the poll probe it,
-		// mark it Lost, or repaint it Ready. It stays put until RestoreArchived.
+	if instance.GetLiveness() == session.LiveArchived {
+		// Archived (#1028): no tmux to probe, inert (started=false) so already
+		// skipped by !Started above — belt-and-suspenders against a future change.
 		return
 	}
 	if m.isPollPaused(repoID, instance.Title) {
@@ -1554,7 +1555,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	}
 
 	instance.CheckAndHandleTrustPrompt()
-	before := instance.GetStatus()
+	before := instance.GetLiveness()
 	updated, hasPrompt := instance.HasUpdated()
 	if hasPrompt {
 		// Tap enter whenever a prompt is waiting (TapEnter is a no-op unless
@@ -1568,7 +1569,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	}
 	switch {
 	case updated:
-		instance.SetStatusIfNotDeleting(session.Running)
+		instance.SetLiveness(session.LiveRunning)
 	case hasPrompt:
 		// A waiting prompt with otherwise-unchanged output: leave the status for
 		// the next tick to resolve, exactly as runMetadataTick did. The
@@ -1582,15 +1583,15 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// intent on record, so the session vanished out from under a live
 		// record — an outage/reboot casualty that is recovery-eligible, not a
 		// corpse the user wanted gone.
-		instance.SetStatusIfNotDeleting(session.Lost)
+		instance.SetLiveness(session.LiveLost)
 	default:
-		instance.SetStatusIfNotDeleting(session.Ready)
+		instance.SetLiveness(session.LiveReady)
 	}
 
-	after := instance.GetStatus()
-	if after == before || after == session.Deleting || after == session.Loading {
-		// No real transition, or a concurrent kill moved it to a transient state
-		// we must not persist. Only transitions touch disk.
+	after := instance.GetLiveness()
+	if after == before || instance.GetInFlightOp() != session.OpNone {
+		// No real transition, or an op raced in after our top-of-function check —
+		// its executor owns the durable state. Only real transitions touch disk.
 		return
 	}
 
@@ -1705,7 +1706,7 @@ func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData,
 		return session.InstanceData{}, fmt.Errorf("failed to start instance: %w", err)
 	}
 
-	instance.SetStatus(session.Running)
+	instance.MarkLive()
 	data := instance.ToInstanceData()
 
 	// Register the in-memory instance and persist it to disk inside the

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -28,7 +28,7 @@ func (b *recoverFakeBackend) Recover(inst *session.Instance) error {
 	if b.failWith != nil {
 		return b.failWith
 	}
-	inst.SetStatusIfNotDeleting(session.Running)
+	inst.SetStatus(session.Running)
 	return nil
 }
 
@@ -224,7 +224,7 @@ func (b *raceBackend) Recover(inst *session.Instance) error {
 	if b.recoverBlock != nil {
 		<-b.recoverBlock
 	}
-	inst.SetStatusIfNotDeleting(session.Running)
+	inst.SetStatus(session.Running)
 	return nil
 }
 

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -294,9 +294,11 @@ func (b *LocalBackend) Recover(i *Instance) error {
 	b.setupTabs(i)
 
 	// The program was just re-spawned and is booting: Running, exactly like a
-	// fresh create. The daemon poll re-derives Ready/Running from the live
-	// session from here on and persists the transition.
-	i.SetStatusIfNotDeleting(Running)
+	// fresh create. markLive clears the OpRestoring/OpCreating fence this
+	// completion resolves while preserving a kill/archive teardown fence. The
+	// daemon poll re-derives Ready/Running from the live session from here on and
+	// persists the transition.
+	i.MarkLive()
 	return nil
 }
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -1137,18 +1137,34 @@ func (i *Instance) RestoreArchivedWorktree(dest string) error {
 // has been moved back into place (#1028), flipping it live. It marks the
 // instance started + Lost so the Recover re-spawn path is eligible (the same
 // re-spawn the #1108 Lost-restore loop drives), then Recover brings the agent
-// session up and sets Running. On a Recover failure the instance is left
-// started + Lost, so the daemon's Lost-restore loop keeps retrying — the
-// worktree is already back in place, so the session self-heals rather than
-// stranding as Archived with no tmux. Only the agent tab is restored (shell/
-// process tabs were dropped at archive time, per #1028).
+// session up and sets Running (markLive clears the OpRestoring fence). On a
+// Recover failure the instance is dropped to a plain Lost (op cleared), so the
+// daemon's Lost-restore loop keeps retrying — the worktree is already back in
+// place, so the session self-heals rather than stranding as Archived with no
+// tmux. Only the agent tab is restored (shell/process tabs were dropped at
+// archive time, per #1028).
+//
+// liveness is set to Lost (so Recover's ==Lost gate accepts it) and OpRestoring
+// fences the re-spawn window: the daemon poll skips an instance with an
+// in-flight op, so it never probes the half-spawned session and marks it Lost
+// out from under the restore. This replaces the old "park it in Lost purely to
+// trigger the re-spawn loop" overload (#1195).
 func (i *Instance) RestoreFromArchive() error {
 	i.mu.Lock()
 	i.started = true
 	i.liveness = LiveLost
-	i.inFlightOp = OpNone
+	i.inFlightOp = OpRestoring
 	i.mu.Unlock()
-	return i.backend.Recover(i)
+	if err := i.backend.Recover(i); err != nil {
+		// Re-spawn failed: drop the fence to a plain Lost so the #1108
+		// restore loop owns the retry against the now-restored worktree.
+		i.mu.Lock()
+		i.liveness = LiveLost
+		i.inFlightOp = OpNone
+		i.mu.Unlock()
+		return err
+	}
+	return nil
 }
 
 // CloseAttachOnly releases the resources this instance opened to view or drive

--- a/session/instance_test.go
+++ b/session/instance_test.go
@@ -117,22 +117,28 @@ func TestGetGitWorktree_RaceWithStart(t *testing.T) {
 	wg.Wait()
 }
 
-// TestSetStatusIfNotDeleting guards the #844 status fence: the metadata tick's
-// Running/Ready writes must not clobber a Deleting marker, while normal status
-// flow stays unaffected and the kill completion handler (which uses SetStatus)
-// can still move the instance out of Deleting.
-func TestSetStatusIfNotDeleting(t *testing.T) {
+// TestSetLivenessNeverClobbersInFlightOp is the #1195 structural replacement for
+// the old #844 fence (SetStatusIfNotDeleting): the daemon poll writes only the
+// liveness axis, so a concurrent kill/archive op — living on the separate op axis
+// — can never be clobbered. The composed status keeps reflecting the op, which is
+// what the SetStatusIfNotDeleting guard used to reconstruct by hand.
+func TestSetLivenessNeverClobbersInFlightOp(t *testing.T) {
 	i := &Instance{liveness: LiveReady}
 
-	i.SetStatusIfNotDeleting(Running)
-	require.Equal(t, Running, i.GetStatus(), "non-deleting status updates must pass through")
-
-	i.SetStatus(Deleting)
-	i.SetStatusIfNotDeleting(Running)
-	require.Equal(t, Deleting, i.GetStatus(), "tick writes must not clobber Deleting")
-	i.SetStatusIfNotDeleting(Ready)
+	// A kill is optimistically in flight (op axis), underlying liveness Running.
+	i.SetLiveness(LiveRunning)
+	i.SetInFlightOp(OpKilling)
 	require.Equal(t, Deleting, i.GetStatus())
 
-	i.SetStatus(Ready)
-	require.Equal(t, Ready, i.GetStatus(), "the kill handler's unconditional SetStatus must still work")
+	// The poll writes liveness (Running/Ready/Lost) — the kill op survives every
+	// write, so the composed status stays Deleting.
+	i.SetLiveness(LiveReady)
+	require.Equal(t, OpKilling, i.GetInFlightOp(), "SetLiveness must not touch the op axis")
+	require.Equal(t, Deleting, i.GetStatus(), "a poll write must never clobber a kill marker")
+	i.SetLiveness(LiveLost)
+	require.Equal(t, Deleting, i.GetStatus())
+
+	// The kill handler clears the op; the composed status then reflects liveness.
+	i.SetInFlightOp(OpNone)
+	require.Equal(t, Lost, i.GetStatus())
 }

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -1,5 +1,7 @@
 package session
 
+import "fmt"
+
 // Two-axis session state (#1195 Phase 1b).
 //
 // The legacy Status enum jammed two orthogonal axes into one int: what the
@@ -170,22 +172,6 @@ func (i *Instance) SetStatus(status Status) {
 	i.setStatusLocked(status)
 }
 
-// SetStatusIfNotDeleting sets the status under the instance mutex unless the
-// instance is mid-deletion. The metadata tick runs off the event loop and races
-// the async kill flow (#844): between its own status check and its store, the
-// user can confirm a kill, and an unconditional Running/Ready write would clobber
-// the Deleting marker — re-enabling kill/attach on a session whose teardown is
-// already in flight. Only the kill completion handler may move an instance out of
-// Deleting, via SetStatus. (Legacy shim; the guard now reads the composed value.)
-func (i *Instance) SetStatusIfNotDeleting(status Status) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	if i.statusLocked() == Deleting {
-		return
-	}
-	i.setStatusLocked(status)
-}
-
 // GetStatus returns the current status under the Instance's mutex, so
 // cross-goroutine readers don't race with SetStatus (legacy shim — composes the
 // value from the two axes).
@@ -193,4 +179,81 @@ func (i *Instance) GetStatus() Status {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	return i.statusLocked()
+}
+
+// GetLiveness returns the daemon-owned health axis under the instance mutex.
+func (i *Instance) GetLiveness() Liveness {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.liveness
+}
+
+// SetLiveness writes the health axis under the instance mutex, leaving the
+// in-flight op untouched. This is what the daemon poll uses instead of the old
+// SetStatusIfNotDeleting: writing liveness can never clobber an in-flight op
+// because the op is a separate field, so no "if not deleting" guard is needed —
+// a concurrent kill/archive op survives the write and still composes to the
+// transient status (#1195).
+func (i *Instance) SetLiveness(lv Liveness) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.liveness = lv
+}
+
+// GetInFlightOp returns the client/executor op axis under the instance mutex.
+func (i *Instance) GetInFlightOp() InFlightOp {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.inFlightOp
+}
+
+// SetInFlightOp writes the op axis under the instance mutex, leaving the liveness
+// untouched. The daemon archive executor uses it to raise OpArchiving as a fence
+// over its teardown+move window (and to clear it back to OpNone on a rollback).
+func (i *Instance) SetInFlightOp(op InFlightOp) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.inFlightOp = op
+}
+
+// MarkLive flips the instance to Running and clears a completing create/restore
+// op — the two-axis translation of the old SetStatusIfNotDeleting(Running) that
+// backend Start/Recover used. It preserves a teardown fence (OpKilling/
+// OpArchiving): a Start/Recover completing must never resurrect a session that a
+// kill or archive is tearing down; that owner writes the terminal liveness. It
+// does clear OpCreating/OpRestoring, which is exactly the op this completion
+// resolves.
+func (i *Instance) MarkLive() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.inFlightOp == OpKilling || i.inFlightOp == OpArchiving {
+		return
+	}
+	i.liveness = LiveRunning
+	i.inFlightOp = OpNone
+}
+
+// tabSpawnBlockedLocked reports the error, if any, forbidding a new tab spawn.
+// Caller holds i.mu. It reads the two axes directly (the #1195 structural fold of
+// the #1196 archive-orphan guard): a tab may not spawn into an archived session
+// (its worktree was moved away) or one with a teardown op in flight — an archive
+// (OpArchiving) or kill (OpKilling). The archive case is the load-bearing one:
+// ArchiveTeardown keeps started=true, so the #990 started-flag guard never fires
+// during archive; OpArchiving is the fence that started=true cannot provide.
+func (i *Instance) tabSpawnBlockedLocked() error {
+	if i.liveness == LiveArchived {
+		return fmt.Errorf("cannot add a tab to an archived session; restore it first (af sessions restore)")
+	}
+	if i.inFlightOp == OpArchiving || i.inFlightOp == OpKilling {
+		return fmt.Errorf("cannot add a tab to a session that is being archived or removed; try again in a moment")
+	}
+	return nil
+}
+
+// TabSpawnBlocked is the locking form of tabSpawnBlockedLocked, for callers that
+// don't already hold i.mu (the daemon's archive-exclusive tab lock).
+func (i *Instance) TabSpawnBlocked() error {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.tabSpawnBlockedLocked()
 }

--- a/session/tab_archive_race_test.go
+++ b/session/tab_archive_race_test.go
@@ -11,12 +11,19 @@ import (
 
 // flipStatus sets Status under the same lock the daemon archive op uses, so the
 // pre-spawn guard and the post-spawn recheck in AddShellTab/AddProcessTab observe
-// an archiving instance — the deterministic stand-in for a concurrent
-// ArchiveSession flipping status Deleting→Archived while started stays true
-// (#1195).
+// the target state (used here for the completed-archive LiveArchived case) (#1195).
 func flipStatus(i *Instance, s Status) {
 	i.mu.Lock()
 	i.setStatusLocked(s)
+	i.mu.Unlock()
+}
+
+// beginArchiving raises the OpArchiving fence under the same lock the daemon
+// archive op uses — the deterministic stand-in for a concurrent ArchiveSession
+// mid teardown+move (started stays true throughout) (#1195).
+func beginArchiving(i *Instance) {
+	i.mu.Lock()
+	i.inFlightOp = OpArchiving
 	i.mu.Unlock()
 }
 
@@ -68,8 +75,8 @@ func TestAddProcessTab_ArchivedInstanceRejected(t *testing.T) {
 }
 
 // TestAddShellTab_ArchiveRaceDoesNotLeakSession is the post-spawn backstop for
-// the #1195 archive-orphan class: if the session begins archiving (status flipped
-// to Deleting, started left true, mirroring ArchiveTeardown) in the window after
+// the #1195 archive-orphan class: if the session begins archiving (OpArchiving raised,
+// started left true, mirroring ArchiveTeardown) in the window after
 // the shell tab's tmux session is spawned but before it is appended, AddShellTab
 // must NOT append the tab, MUST tear down the spawned session (no orphan
 // referencing the worktree being moved), and MUST return an error.
@@ -80,7 +87,7 @@ func TestAddShellTab_ArchiveRaceDoesNotLeakSession(t *testing.T) {
 	const agentName = "af_shell_archrace"
 	var inst *Instance
 	var isAlive func(string) bool
-	inst, isAlive = raceMockInstance(t, agentName, func() { flipStatus(inst, Deleting) })
+	inst, isAlive = raceMockInstance(t, agentName, func() { beginArchiving(inst) })
 
 	tab, err := inst.AddShellTab()
 	require.Error(t, err, "a tab created during archive teardown must be refused")
@@ -98,7 +105,7 @@ func TestAddProcessTab_ArchiveRaceDoesNotLeakSession(t *testing.T) {
 	const agentName = "af_proc_archrace"
 	var inst *Instance
 	var isAlive func(string) bool
-	inst, isAlive = raceMockInstance(t, agentName, func() { flipStatus(inst, Deleting) })
+	inst, isAlive = raceMockInstance(t, agentName, func() { beginArchiving(inst) })
 
 	tab, err := inst.AddProcessTab("btop", "")
 	require.Error(t, err, "a process tab created during archive teardown must be refused")

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -7,25 +7,6 @@ import (
 	"github.com/sachiniyer/agent-factory/log"
 )
 
-// TabSpawnStatusErr reports the error, if any, that forbids spawning a new tab
-// for an instance in the given status. Adding a tab to an Archived instance
-// would spawn a tmux session in the moved-away worktree, and adding one to a
-// Deleting instance races the mid-flight teardown+move — the #1195 archive
-// orphan-tmux class: ArchiveTeardown keeps started=true (so the #990
-// started-flag guard never fires during archive), and the daemon's archive op
-// flips status Deleting→Archived across the teardown+move window. Callers guard
-// both before spawning (fail fast) and after (post-spawn recheck), mirroring the
-// #990 kill-race handling. Returns nil for any status in which a tab may spawn.
-func TabSpawnStatusErr(status Status) error {
-	switch status {
-	case Archived:
-		return fmt.Errorf("cannot add a tab to an archived session; restore it first (af sessions restore)")
-	case Deleting:
-		return fmt.Errorf("cannot add a tab to a session that is being archived or removed; try again in a moment")
-	}
-	return nil
-}
-
 // AddShellTab spawns a new Shell-kind tab running $SHELL in the instance's
 // worktree, appends it to Tabs, and returns it. Local instances only — remote
 // instances have no local worktree, so callers must reject IsRemote() before
@@ -37,15 +18,15 @@ func TabSpawnStatusErr(status Status) error {
 func (i *Instance) AddShellTab() (*Tab, error) {
 	i.mu.RLock()
 	started := i.started
-	status := i.statusLocked()
+	spawnErr := i.tabSpawnBlockedLocked()
 	agentTmux := i.tmuxLocked()
 	gw := i.gitWorktree
 	displayName := uniqueShellName(i.Tabs)
 	nTabs := len(i.Tabs)
 	i.mu.RUnlock()
 
-	if err := TabSpawnStatusErr(status); err != nil {
-		return nil, err
+	if spawnErr != nil {
+		return nil, spawnErr
 	}
 	if !started || agentTmux == nil || gw == nil {
 		return nil, fmt.Errorf("cannot add a tab to an instance that is not started")
@@ -75,11 +56,11 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 	// released the lock to spawn, and Kill (which does NOT take repoStartLock, so
 	// it is not serialized against CreateTab) can have flipped started=false and
 	// snapshotted Tabs for teardown in that window; an archive teardown+move keeps
-	// started=true but flips status to Deleting→Archived (#1195). Appending now
+	// started=true but raises OpArchiving over the window (#1195). Appending now
 	// would leak a tmux session that escapes teardown while its worktree is deleted
 	// or moved (#990, #1028). Make the recheck and append atomic under one
 	// acquisition so no further race opens.
-	stale := !i.started || TabSpawnStatusErr(i.statusLocked()) != nil
+	stale := !i.started || i.tabSpawnBlockedLocked() != nil
 	title := i.Title
 	if !stale {
 		i.Tabs = append(i.Tabs, tab)
@@ -115,15 +96,15 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 
 	i.mu.RLock()
 	started := i.started
-	status := i.statusLocked()
+	spawnErr := i.tabSpawnBlockedLocked()
 	agentTmux := i.tmuxLocked()
 	gw := i.gitWorktree
 	displayName := uniqueTabName(i.Tabs, processTabBaseName(requestedName, command))
 	nTabs := len(i.Tabs)
 	i.mu.RUnlock()
 
-	if err := TabSpawnStatusErr(status); err != nil {
-		return nil, err
+	if spawnErr != nil {
+		return nil, spawnErr
 	}
 	if !started || agentTmux == nil || gw == nil {
 		return nil, fmt.Errorf("cannot add a tab to an instance that is not started")
@@ -151,10 +132,10 @@ func (i *Instance) AddProcessTab(command, requestedName string) (*Tab, error) {
 	// Re-check started AND status under the write lock before appending (see
 	// AddShellTab): Kill can have flipped started=false and snapshotted Tabs for
 	// teardown while we spawned outside the lock, and an archive teardown+move keeps
-	// started=true but flips status to Deleting→Archived (#1195); appending now
+	// started=true but raises OpArchiving over the window (#1195); appending now
 	// would leak a tmux session whose worktree Kill deletes or archive moves (#990,
 	// #1028). Recheck + append are atomic under one acquisition.
-	stale := !i.started || TabSpawnStatusErr(i.statusLocked()) != nil
+	stale := !i.started || i.tabSpawnBlockedLocked() != nil
 	title := i.Title
 	if !stale {
 		i.Tabs = append(i.Tabs, tab)


### PR DESCRIPTION
## What

Phase 1c migrates the **daemon-side writers** onto the two axes (from #1200) and **folds the #1196 archive-orphan tab-spawn guard onto the op axis**. The TUI still uses the legacy shim (readers migrate in 1d), so this is transparent to it. Builds on #1198/#1200 (merged).

## Daemon poll (`refreshInstanceStatus`)

- Writes **only the liveness axis** (`SetLiveness`), gated on there being **no in-flight op**. Because the op is a separate field, a liveness write can **never** clobber a concurrent kill/archive marker — which is exactly why **`SetStatusIfNotDeleting` is deleted**. The old `Loading`/`Deleting`/`Archived` skip stanzas collapse to one `GetInFlightOp() != OpNone` gate plus the inert-archived belt-and-suspenders.

## Archive / restore executors

- **`ArchiveSession`** fences its teardown+move with **`OpArchiving`** — a **distinct op from a kill**, so the #1187 `Deleting`-collision cannot recur. A move failure clears the fence and drops to `LiveLost` so the #1108 loop self-heals.
- **`RestoreFromArchive`** raises **`OpRestoring`** over the re-spawn (the poll skips it, so it can't probe a half-spawned session and mark it Lost) and drops to a plain `Lost` on failure — replacing the old "park it in `Lost` purely to trigger the loop" overload. `backend.Recover` / create-success now call **`MarkLive`**, which clears a completing create/restore op while **preserving** a teardown fence (the two-axis form of `SetStatusIfNotDeleting(Running)`).

## Archive-orphan guard (folds #1196 structurally)

- The tab-spawn guard reads the axes directly (`tabSpawnBlockedLocked` / `TabSpawnBlocked`): reject a spawn into an `Archived` session or one with a teardown op (`OpArchiving`/`OpKilling`) in flight. Replaces the shim-composed `TabSpawnStatusErr`. Archive keeps `started=true`, so `OpArchiving` is the fence the #990 started-flag guard can't provide.

## New accessors (`session/liveness.go`)
`GetLiveness`/`SetLiveness`, `GetInFlightOp`/`SetInFlightOp`, `MarkLive`. `SetStatusIfNotDeleting` deleted.

## Tests
- `TestSetLivenessNeverClobbersInFlightOp` — the structural replacement for the old #844 fence: a poll liveness write can't clobber a kill op on the separate axis.
- The archive-race tests (`tab_archive_race_test.go`) now raise `OpArchiving` directly, exercising the real fence.

## Visible — needs a driver play-test
This touches archive / kill / restore / lost-recover flows. Suggested manual pass: create → archive → restore; kill mid-flight; force a Lost (kill tmux) → recover; confirm no orphan tmux and correct status labels.

## Gates
`control.go` kept at its #1145 ceiling (net-neutral). Full `make test-container` green; `gofmt -l` empty, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` all clean.

Part of #1195 (Phase 1 anchor). **Does not close it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)