### PR TITLE
feat(limit): LimitReached liveness + TUI surface + manual retry (#1146) [PR 2/4]

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -717,6 +717,8 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleInstanceArchived(msg)
 	case instanceRestoredMsg:
 		return m.handleInstanceRestored(msg)
+	case limitRetriedMsg:
+		return m.handleLimitRetried(msg)
 	case repaintAfterDetachMsg:
 		// Trigger an immediate repaint with whatever content is already
 		// cached on the panes (rendered when bubbletea's main loop calls

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -108,6 +108,8 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 		return m.handleKill()
 	case keys.KeyArchive:
 		return m.handleArchive()
+	case keys.KeyLimitRetry:
+		return m.handleLimitRetry()
 	case keys.KeyEnter:
 		return m.handleEnter()
 	case keys.KeyAttach:
@@ -339,6 +341,64 @@ func (m *home) handleInstanceArchived(msg instanceArchivedMsg) (tea.Model, tea.C
 		}
 	}
 	return m, m.selectionChanged()
+}
+
+// limitRetriedMsg reports completion of an async usage-limit manual retry
+// (#1146, `c`). On success the daemon cleared the limit and re-delivered the
+// prompt; a non-nil err is surfaced in the error box.
+type limitRetriedMsg struct {
+	title string
+	err   error
+}
+
+// handleLimitRetry is the usage-limit manual-retry verb (#1146, `c`): on a
+// session blocked at a usage-limit wall it asks the daemon to re-spawn (if the
+// agent exited) and re-deliver the pending prompt, un-stalling the work. It is a
+// no-op with an explanatory message on any non-limit row. The daemon RPC re-
+// delivers a prompt (SendPromptCommand sleeps to let control sequences drain, and
+// a respawn can take a beat), so it runs OFF the event loop like the kill/archive
+// cmds rather than freezing the TUI.
+func (m *home) handleLimitRetry() (tea.Model, tea.Cmd) {
+	selected := m.sidebar.GetSelectedInstance()
+	if selected == nil {
+		return m, nil
+	}
+	if !selected.LimitReached() {
+		return m, m.handleError(fmt.Errorf("session '%s' is not blocked on a usage limit", selected.Title))
+	}
+	return m, m.resumeFromLimitCmd(selected.Title)
+}
+
+// resumeFromLimitCmd runs the daemon resume (re-spawn if needed + re-deliver the
+// prompt + clear the limit state) off the event loop (#1146), mirroring
+// restoreInstanceCmd.
+func (m *home) resumeFromLimitCmd(title string) tea.Cmd {
+	repoID := m.repoID
+	resume := resumeFromLimitThroughDaemon
+	return func() tea.Msg {
+		if err := resume(title, repoID); err != nil {
+			log.ErrorLog.Printf("could not resume limited session %q: %v", title, err)
+			return limitRetriedMsg{title: title, err: err}
+		}
+		return limitRetriedMsg{title: title}
+	}
+}
+
+// handleLimitRetried finalizes an async usage-limit retry. On success the daemon
+// has already cleared the limit + set Running and persisted; clear the local row
+// optimistically for instant feedback (the badge disappears without waiting for
+// the next snapshot reconcile). On failure the error lands in the error box.
+func (m *home) handleLimitRetried(msg limitRetriedMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		return m, m.handleError(fmt.Errorf("failed to resume session '%s': %w", msg.title, msg.err))
+	}
+	for _, inst := range m.store.GetInstances() {
+		if inst.Title == msg.title {
+			inst.ClearLimitReached()
+			break
+		}
+	}
+	return m, nil
 }
 
 // handleInstanceRestored finalizes an async restore. On success the row returns

--- a/app/help.go
+++ b/app/help.go
@@ -114,6 +114,7 @@ func (h helpTypeGeneral) toContent() string {
 			{helpKey(keys.KeyTaskList), "Manage tasks (n inside the manager creates one)"},
 			{"r", "Run selected task now"},
 			{helpKey(keys.KeyKill), "Kill (delete) the selected session"},
+			{helpKey(keys.KeyLimitRetry), "Retry a session blocked at a usage limit (re-spawn + resume)"},
 			{navKeys, "Navigate between sessions"},
 			{helpKey(keys.KeyEnter), "Interact with the session in its pane (all keys go to it)"},
 			{helpKey(keys.KeyExitInteractive), "Leave interactive mode (back to navigation)"},

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -16,7 +16,7 @@ import (
 func TestHelpReflectsKeymapRebinds(t *testing.T) {
 	require.NoError(t, keys.ApplyOverrides(map[string][]string{
 		"quit": {"Q"},
-		"new":  {"c"},
+		"new":  {"g"},
 		"up":   {"u", "ctrl+p"},
 	}))
 	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
@@ -24,7 +24,7 @@ func TestHelpReflectsKeymapRebinds(t *testing.T) {
 	content := helpTypeGeneral{}.toContent()
 
 	// Rebound keys must appear...
-	for _, want := range []string{"Q", "c", "u/ctrl+p"} {
+	for _, want := range []string{"Q", "g", "u/ctrl+p"} {
 		if !strings.Contains(content, want) {
 			t.Errorf("help must show rebound key %q; got:\n%s", want, content)
 		}

--- a/app/limit_action_test.go
+++ b/app/limit_action_test.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// limitActionInstance builds a started, mock-backed instance blocked at a usage
+// limit (#1146) for the manual-retry action tests.
+func limitActionInstance(t *testing.T, title string, resetAt time.Time) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "test"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStartedForTest(true)
+	inst.SetLimitReached(resetAt)
+	return inst
+}
+
+// TestHandleLimitRetry_NonLimitRow_NoDispatch: pressing c on a session that is
+// not usage-limit-blocked surfaces a message and never fires the resume RPC.
+func TestHandleLimitRetry_NonLimitRow_NoDispatch(t *testing.T) {
+	h := newTestHome(t)
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "worker", Path: t.TempDir(), Program: "test"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStartedForTest(true)
+	inst.SetStatus(session.Ready)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	called := false
+	restore := SetLimitResumerForTest(func(string, string) error { called = true; return nil })
+	defer restore()
+
+	_, _ = h.handleLimitRetry()
+	require.False(t, called, "a non-limit row must not dispatch the resume RPC")
+}
+
+// TestHandleLimitRetry_LimitRow_Dispatches: pressing c on a limit-blocked row
+// dispatches the resume command, which routes through the daemon seam.
+func TestHandleLimitRetry_LimitRow_Dispatches(t *testing.T) {
+	h := newTestHome(t)
+	inst := limitActionInstance(t, "worker", time.Now().Add(time.Hour))
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	var gotTitle string
+	restore := SetLimitResumerForTest(func(title, _ string) error { gotTitle = title; return nil })
+	defer restore()
+
+	_, cmd := h.handleLimitRetry()
+	require.NotNil(t, cmd, "a limit row must dispatch a resume command")
+	msg := cmd()
+	done, ok := msg.(limitRetriedMsg)
+	require.True(t, ok, "the command must emit limitRetriedMsg")
+	require.NoError(t, done.err)
+	require.Equal(t, "worker", gotTitle, "the resume command must call the daemon for the selected title")
+}
+
+// TestResumeFromLimitCmd_SurfacesError: a daemon rejection is carried back on the
+// completion message (handled into the error box, limit state left intact).
+func TestResumeFromLimitCmd_SurfacesError(t *testing.T) {
+	h := newTestHome(t)
+	restore := SetLimitResumerForTest(func(string, string) error {
+		return errors.New("session is not blocked on a usage limit")
+	})
+	defer restore()
+
+	msg := h.resumeFromLimitCmd("worker")()
+	done, ok := msg.(limitRetriedMsg)
+	require.True(t, ok)
+	require.Error(t, done.err)
+}
+
+// TestHandleLimitRetried_ClearsLocally: on a successful retry the local row's
+// limit state is cleared immediately, without waiting for the next snapshot.
+func TestHandleLimitRetried_ClearsLocally(t *testing.T) {
+	h := newTestHome(t)
+	inst := limitActionInstance(t, "worker", time.Now().Add(time.Hour))
+	h.store.AddInstance(inst)
+	require.True(t, inst.LimitReached())
+
+	_, _ = h.handleLimitRetried(limitRetriedMsg{title: "worker"})
+	require.False(t, inst.LimitReached(), "a successful retry must clear the local limit state")
+}

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -47,6 +47,15 @@ var restoreArchivedThroughDaemon = func(title, repoID string) (string, error) {
 	return daemon.RestoreArchived(daemon.RestoreArchivedRequest{Title: title, RepoID: repoID})
 }
 
+// resumeFromLimitThroughDaemon routes the TUI's `c` (retry usage-limit session)
+// verb (#1146) through the daemon — the single writer (#960) — which re-spawns
+// the agent if it exited, re-delivers the pending prompt, and clears the limit
+// state. A package var so the app test suite can stub it without dialing a real
+// daemon.
+var resumeFromLimitThroughDaemon = func(title, repoID string) error {
+	return daemon.ResumeFromLimit(daemon.ResumeFromLimitRequest{Title: title, RepoID: repoID})
+}
+
 // triggerTaskThroughDaemon runs a task by ID through the daemon's single shared
 // trigger path — the SAME entrypoint `af tasks trigger` and the cron scheduler
 // use. It routes through the TriggerTask RPC (#1029 PR 3) so the firing runs
@@ -187,6 +196,14 @@ func SetTaskRemoverForTest(f func(id string) error) func() {
 	prev := removeTaskThroughDaemon
 	removeTaskThroughDaemon = f
 	return func() { removeTaskThroughDaemon = prev }
+}
+
+// SetLimitResumerForTest swaps the usage-limit resume seam (#1146) so a test can
+// assert the TUI routes `c` through the daemon — without dialing a real one.
+func SetLimitResumerForTest(f func(title, repoID string) error) func() {
+	prev := resumeFromLimitThroughDaemon
+	resumeFromLimitThroughDaemon = f
+	return func() { resumeFromLimitThroughDaemon = prev }
 }
 
 func SetRemoteImporterForTest(f func(repoPath string) ([]session.InstanceData, error)) func() {

--- a/app/sync.go
+++ b/app/sync.go
@@ -517,16 +517,30 @@ func (m *home) swapInstanceFromSnapshot(d session.InstanceData) bool {
 func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.InstanceData) bool {
 	changed := false
 	// Mirror the daemon's authoritative LIVENESS onto the row (#960 PR 5, #1195):
-	// the daemon poll computes Running/Ready/Lost/Archived (the #935 liveness) and
-	// the TUI renders it. Applied UNCONDITIONALLY — daemon liveness always wins —
-	// which is what makes #1187 structurally impossible: a locally-archiving row
-	// still receives the terminal Archived instead of being stranded. The local
-	// in-flight op is a separate axis the daemon snapshot never carries, so this
-	// can never clobber an optimistic kill/archive marker.
+	// the daemon poll computes Running/Ready/Lost/Archived/LimitReached (the #935
+	// liveness) and the TUI renders it. Applied UNCONDITIONALLY — daemon liveness
+	// always wins — which is what makes #1187 structurally impossible: a
+	// locally-archiving row still receives the terminal Archived instead of being
+	// stranded. The local in-flight op is a separate axis the daemon snapshot
+	// never carries, so this can never clobber an optimistic kill/archive marker.
 	lv := snapshotLiveness(inst.GetLiveness(), d)
 	if inst.GetLiveness() != lv {
 		inst.SetLiveness(lv)
 		changed = true
+	}
+	// Mirror the usage-limit reset time (#1146) alongside the liveness. It's
+	// display-only metadata that rides LiveLimitReached — which composes to Ready,
+	// so the liveness compare above is what surfaces the [limit] badge; this only
+	// keeps its "resets <t>" suffix fresh. Set it on its own axis (not via
+	// SetLimitReached) so the liveness stays applied unconditionally above. When
+	// the daemon has moved the session off LimitReached, the reset field is left
+	// inert: LimitResetAt/ToInstanceData both gate on the liveness, so a stale
+	// value can never leak to the badge or to disk.
+	if lv == session.LiveLimitReached {
+		if curReset, _ := inst.LimitResetAt(); !curReset.Equal(d.LimitResetAt) {
+			inst.SetLimitResetAt(d.LimitResetAt)
+			changed = true
+		}
 	}
 	// Clear a local optimistic op once the daemon liveness confirms its outcome.
 	// An archive settles at Archived; a kill's op is cleared by row removal, not

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1562,6 +1562,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 
 	instance.CheckAndHandleTrustPrompt()
 	before := instance.GetLiveness()
+	beforeReset, _ := instance.LimitResetAt()
 	// HasUpdated hands back the captured pane content so the idle branch can run
 	// the usage-limit detector (#1146) without a second capture-pane.
 	updated, hasPrompt, content := instance.HasUpdated()
@@ -1599,9 +1600,8 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		m.resolveIdleLiveness(instance, content)
 	}
 
-	// Persist only a real liveness transition; see persistLivenessChange in
-	// limit.go (split out to keep control.go under its length ceiling, #1145).
-	m.persistLivenessChange(repoID, instance, before)
+	// Persist a liveness OR usage-limit reset-time change (#1146); see limit.go.
+	m.persistPollChange(repoID, instance, before, beforeReset)
 }
 
 // SaveInstances writes the manager's authoritative in-memory instances to disk

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1599,23 +1599,9 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		m.resolveIdleLiveness(instance, content)
 	}
 
-	after := instance.GetLiveness()
-	if after == before || instance.GetInFlightOp() != session.OpNone {
-		// No real transition, or an op raced in after our top-of-function check —
-		// its executor owns the durable state. Only real transitions touch disk.
-		// The liveness IS the compared axis (#1195), so a Ready→LimitReached idle
-		// transition (#1146) — invisible to the old composed-Status compare, since
-		// LimitReached composes to Ready — is caught here as a genuine change.
-		return
-	}
-
-	repoStartLock := m.startLockForRepo(repoID)
-	repoStartLock.Lock()
-	err := persistInstanceData(repoID, instance.ToInstanceData())
-	repoStartLock.Unlock()
-	if err != nil {
-		log.WarningLog.Printf("daemon failed to persist status for %q: %v", instance.Title, err)
-	}
+	// Persist only a real liveness transition; see persistLivenessChange in
+	// limit.go (split out to keep control.go under its length ceiling, #1145).
+	m.persistLivenessChange(repoID, instance, before)
 }
 
 // SaveInstances writes the manager's authoritative in-memory instances to disk

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1283,6 +1283,11 @@ func startControlServer(manager *Manager, scheduler *taskScheduler, watchers *wa
 type Manager struct {
 	cfg *config.Config
 
+	// limitDetector is the resolved usage-limit matcher set (#1146), built once
+	// from cfg.LimitPatterns at construction (it compiles the override regexes)
+	// and reused across poll ticks. Immutable; read lock-free by the poll loop.
+	limitDetector task.LimitDetector
+
 	// ready is closed once the initial instance restore has completed. Until
 	// then the daemon is "warming up": the control socket is already bound
 	// (#829) but state-dependent RPCs return errDaemonStarting.
@@ -1370,6 +1375,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 	}
 	return &Manager{
 		cfg:                 cfg,
+		limitDetector:       task.NewLimitDetector(cfg.LimitPatterns),
 		ready:               make(chan struct{}),
 		storage:             storage,
 		instances:           make(map[string]*session.Instance),
@@ -1556,7 +1562,9 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 
 	instance.CheckAndHandleTrustPrompt()
 	before := instance.GetLiveness()
-	updated, hasPrompt := instance.HasUpdated()
+	// HasUpdated hands back the captured pane content so the idle branch can run
+	// the usage-limit detector (#1146) without a second capture-pane.
+	updated, hasPrompt, content := instance.HasUpdated()
 	if hasPrompt {
 		// Tap enter whenever a prompt is waiting (TapEnter is a no-op unless
 		// AutoYes is on), independent of `updated` — exactly as the pre-#965
@@ -1585,13 +1593,19 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// corpse the user wanted gone.
 		instance.SetLiveness(session.LiveLost)
 	default:
-		instance.SetLiveness(session.LiveReady)
+		// Idle output: settle to Ready, or LimitReached when the pane shows a
+		// usage-limit banner for a claude/codex session (#1146). content is
+		// HasUpdated's capture (no re-capture); see resolveIdleLiveness.
+		m.resolveIdleLiveness(instance, content)
 	}
 
 	after := instance.GetLiveness()
 	if after == before || instance.GetInFlightOp() != session.OpNone {
 		// No real transition, or an op raced in after our top-of-function check —
 		// its executor owns the durable state. Only real transitions touch disk.
+		// The liveness IS the compared axis (#1195), so a Ready→LimitReached idle
+		// transition (#1146) — invisible to the old composed-Status compare, since
+		// LimitReached composes to Ready — is caught here as a genuine change.
 		return
 	}
 

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -29,6 +29,27 @@ func (m *Manager) resolveIdleLiveness(instance *session.Instance, content string
 	}
 }
 
+// persistLivenessChange writes an instance's state to disk only when the poll
+// actually transitioned its LIVENESS this tick (the #960 targeted writer). The
+// liveness is the compared axis (#1195), so a Ready→LimitReached idle transition
+// (#1146) — invisible to the old composed-Status compare, since LimitReached
+// composes to Ready — is caught here as a genuine change. A concurrent client op
+// (create/kill/archive) means that op's executor owns the durable state, so the
+// poll never persists over it. Split from refreshInstanceStatus so control.go
+// stays under its length ceiling (#1145).
+func (m *Manager) persistLivenessChange(repoID string, instance *session.Instance, before session.Liveness) {
+	if instance.GetLiveness() == before || instance.GetInFlightOp() != session.OpNone {
+		return
+	}
+	repoStartLock := m.startLockForRepo(repoID)
+	repoStartLock.Lock()
+	err := persistInstanceData(repoID, instance.ToInstanceData())
+	repoStartLock.Unlock()
+	if err != nil {
+		log.WarningLog.Printf("daemon failed to persist status for %q: %v", instance.Title, err)
+	}
+}
+
 // This file is the daemon side of the usage-limit manual-retry action (#1146
 // PR2): the ResumeFromLimit RPC and the reusable resumeFromLimit Manager method
 // behind it. Detection itself lives in refreshInstanceStatus (control.go), which
@@ -119,8 +140,15 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 	// Re-spawn only when the agent's tmux session actually exited while blocked
 	// (the edge case where the agent dropped to a shell / the pane vanished). A
 	// live stall — the common claude/codex case — just needs the un-stall prompt.
+	//
+	// Respawn, NOT Recover: the session is LiveLimitReached, and Recover's !Lost
+	// guard rejects any non-Lost liveness, so routing a limit retry through Recover
+	// always failed the guard (#1204 P1). Respawn is the guard-free re-spawn core
+	// (same resumeProgram path: claude --continue, codex resume --last); the
+	// LimitReached/no-tombstone precondition is enforced above under the target
+	// lock.
 	if !instance.TmuxAlive() {
-		if rerr := instance.Recover(); rerr != nil {
+		if rerr := instance.Respawn(); rerr != nil {
 			return fmt.Errorf("failed to re-spawn agent for %q: %w", req.Title, rerr)
 		}
 	}

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -29,16 +29,33 @@ func (m *Manager) resolveIdleLiveness(instance *session.Instance, content string
 	}
 }
 
-// persistLivenessChange writes an instance's state to disk only when the poll
-// actually transitioned its LIVENESS this tick (the #960 targeted writer). The
-// liveness is the compared axis (#1195), so a Ready→LimitReached idle transition
-// (#1146) — invisible to the old composed-Status compare, since LimitReached
-// composes to Ready — is caught here as a genuine change. A concurrent client op
-// (create/kill/archive) means that op's executor owns the durable state, so the
-// poll never persists over it. Split from refreshInstanceStatus so control.go
-// stays under its length ceiling (#1145).
-func (m *Manager) persistLivenessChange(repoID string, instance *session.Instance, before session.Liveness) {
-	if instance.GetLiveness() == before || instance.GetInFlightOp() != session.OpNone {
+// persistPollChange writes an instance's state to disk when the poll changed
+// something durable this tick (the #960 targeted writer): its LIVENESS
+// transitioned, OR — evaluated INDEPENDENTLY — its usage-limit reset time changed
+// (#1146). The liveness is the compared axis (#1195), so a Ready→LimitReached idle
+// transition (invisible to the old composed-Status compare, since LimitReached
+// composes to Ready) is caught as a genuine change.
+//
+// The reset-time check MUST be independent of the liveness compare: a row can
+// enter LiveLimitReached on one tick with no parsed reset time (the banner
+// matched but the time was not yet captured/parseable) and only parse it on a
+// LATER tick. That later tick leaves the liveness unchanged, so gating
+// persistence on the liveness alone would silently drop the reset time — the
+// [limit] resets <t> badge would never show it, and PR3's auto-resume scheduler
+// would have no time to schedule against once the daemon restarts and reloads
+// from disk. beforeReset is the reset time captured before this tick's poll.
+//
+// A concurrent client op (create/kill/archive) means that op's executor owns the
+// durable state, so the poll never persists over it. Split from
+// refreshInstanceStatus so control.go stays under its length ceiling (#1145).
+func (m *Manager) persistPollChange(repoID string, instance *session.Instance, before session.Liveness, beforeReset time.Time) {
+	if instance.GetInFlightOp() != session.OpNone {
+		return
+	}
+	afterReset, _ := instance.LimitResetAt()
+	livenessChanged := instance.GetLiveness() != before
+	resetChanged := !afterReset.Equal(beforeReset)
+	if !livenessChanged && !resetChanged {
 		return
 	}
 	repoStartLock := m.startLockForRepo(repoID)

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -1,0 +1,147 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// resolveIdleLiveness settles a session whose pane went idle this tick (#1146):
+// it sets LimitReached when the captured content shows a usage-limit banner for
+// the resolved agent (only claude/codex ever match), else the plain Ready
+// liveness. A limit session must never render Ready, which is why the detector
+// runs before the Ready fallback. Self-recovery (the banner scrolls away) or
+// resumed work (the `updated` branch → Running) clears the limit liveness on its
+// own later tick, so no explicit clear is needed here. Split from
+// refreshInstanceStatus so control.go stays under its length ceiling (#1145).
+func (m *Manager) resolveIdleLiveness(instance *session.Instance, content string) {
+	if hit, resetAt, _ := m.limitDetector.Check(content, instance.ResolvedAgent(), time.Now()); hit {
+		instance.SetLimitReached(resetAt)
+	} else {
+		// Plain idle: settle to Ready. On the two-axis model (#1195) SetLiveness
+		// writes only the liveness axis and never clobbers an in-flight op, so it
+		// needs no "if not deleting" guard — this is exactly what the poll's Ready
+		// fallback does inline in refreshInstanceStatus.
+		instance.SetLiveness(session.LiveReady)
+	}
+}
+
+// This file is the daemon side of the usage-limit manual-retry action (#1146
+// PR2): the ResumeFromLimit RPC and the reusable resumeFromLimit Manager method
+// behind it. Detection itself lives in refreshInstanceStatus (control.go), which
+// runs the PR1 detector over captured pane content and sets the LiveLimitReached
+// liveness. Split out of control.go to keep that (grandfathered, #1145) file
+// from growing.
+
+// ResumeFromLimitRequest asks the daemon to resume a session blocked at a usage-
+// limit wall (#1146): re-spawn its agent if the tmux session exited, re-deliver
+// the pending prompt, and clear the LimitReached liveness. It is the manual-
+// retry action behind the TUI's `c` key; PR3's auto-resume scheduler reuses the
+// same Manager method.
+type ResumeFromLimitRequest struct {
+	Title  string `json:"title"`
+	RepoID string `json:"repo_id"`
+}
+
+type ResumeFromLimitResponse struct {
+	OK bool `json:"ok"`
+}
+
+// ResumeFromLimit asks the daemon to resume a usage-limit-blocked session
+// (#1146): re-spawn if the agent exited, re-deliver the pending prompt, and
+// clear the limit state. Surfaces the daemon's error (e.g. the session is not
+// limit-blocked) verbatim so the TUI can show it.
+func ResumeFromLimit(req ResumeFromLimitRequest) error {
+	var resp ResumeFromLimitResponse
+	if err := callDaemon("ResumeFromLimit", req, &resp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *controlServer) ResumeFromLimit(req ResumeFromLimitRequest, resp *ResumeFromLimitResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
+	if err := validateRPCRepoID(req.RepoID); err != nil {
+		return err
+	}
+	if err := s.manager.resumeFromLimit(req); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+// resumeFromLimit clears a session's usage-limit block and nudges its agent back
+// to work (#1146). It is the reusable resume action shared by the TUI manual-
+// retry key (`c`) and PR3's auto-resume scheduler — factored as a Manager method
+// rather than inlined so the scheduler can call it directly. If the agent's tmux
+// session exited while blocked it is re-spawned (Recover → resumeProgram) before
+// the prompt is sent; a live stall needs no respawn. The pending prompt is then
+// re-delivered — the session's stored initial/task prompt when it carries one (a
+// task-driven session resumes its work), else a bare "continue" that un-stalls an
+// interactive session (which loses context per anthropics/claude-code#5977;
+// documented). The LimitReached liveness is cleared so the poll re-resolves the
+// real state on the next tick, and the transition is persisted.
+//
+// Runs under the per-(repo, title) target lock (like DeliverPrompt) and re-
+// verifies the limit state under it, so it never races a self-recovery, a kill,
+// or a concurrent resume. Rejects a tombstoned / reserved-root session, mirroring
+// the lostrestore guards.
+func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
+	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+	if err != nil {
+		return err
+	}
+	if instance == nil {
+		return fmt.Errorf("session %q not found", req.Title)
+	}
+	if !instance.LimitReached() {
+		return fmt.Errorf("session %q is not blocked on a usage limit", req.Title)
+	}
+
+	unlock := m.lockTarget(repoID, instance.Title)
+	defer unlock()
+
+	// Re-verify under the lock: a self-recovery or the poll may have cleared the
+	// limit between the check above and the lock.
+	if !instance.LimitReached() {
+		return nil
+	}
+	if instance.UserKilled() || session.IsReservedTitle(instance.Title) {
+		return fmt.Errorf("session %q cannot be resumed", req.Title)
+	}
+
+	// Re-spawn only when the agent's tmux session actually exited while blocked
+	// (the edge case where the agent dropped to a shell / the pane vanished). A
+	// live stall — the common claude/codex case — just needs the un-stall prompt.
+	if !instance.TmuxAlive() {
+		if rerr := instance.Recover(); rerr != nil {
+			return fmt.Errorf("failed to re-spawn agent for %q: %w", req.Title, rerr)
+		}
+	}
+
+	prompt := strings.TrimSpace(instance.Prompt)
+	if prompt == "" {
+		// Interactive session with no stored prompt: the best we can do is
+		// un-stall it. Loses the agent's prior context (documented caveat).
+		prompt = "continue"
+	}
+	if serr := instance.SendPromptCommand(prompt); serr != nil {
+		return fmt.Errorf("failed to resume %q: %w", req.Title, serr)
+	}
+	instance.ClearLimitReached()
+
+	repoStartLock := m.startLockForRepo(repoID)
+	repoStartLock.Lock()
+	perr := persistInstanceData(repoID, instance.ToInstanceData())
+	repoStartLock.Unlock()
+	if perr != nil {
+		log.WarningLog.Printf("daemon failed to persist resume for %q: %v", instance.Title, perr)
+	}
+	return nil
+}

--- a/daemon/limit_resume_test.go
+++ b/daemon/limit_resume_test.go
@@ -1,0 +1,156 @@
+package daemon
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// limitResumeBackend is a FakeBackend instrumented for the usage-limit manual-
+// retry tests (#1146). It reproduces LocalBackend.Recover's !Lost guard, so a
+// regression that routes a LimitReached retry back through Recover (the #1204 P1
+// — "respawn path always fails") trips that guard here exactly as it did against
+// the real backend. Respawn — the guard-free re-spawn core the fix uses instead —
+// and SendPromptCommand record their calls so the test can assert which path ran
+// and what prompt was re-delivered.
+type limitResumeBackend struct {
+	*session.FakeBackend
+	mu           sync.Mutex
+	alive        bool
+	recoverCalls int
+	respawnCalls int
+	sentPrompts  []string
+}
+
+func (b *limitResumeBackend) IsAlive(*session.Instance) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.alive
+}
+
+func (b *limitResumeBackend) Recover(i *session.Instance) error {
+	b.mu.Lock()
+	b.recoverCalls++
+	b.mu.Unlock()
+	// Mirror LocalBackend.Recover's guard: only a Lost session is recoverable.
+	// A LimitReached session composes to Ready, so this rejects it — which is the
+	// whole point of the P1 regression the fix removes.
+	if s := i.GetStatus(); s != session.Lost {
+		return fmt.Errorf("recover: session %q is %v, not Lost", i.Title, s)
+	}
+	i.MarkLive()
+	return nil
+}
+
+func (b *limitResumeBackend) Respawn(i *session.Instance) error {
+	b.mu.Lock()
+	b.respawnCalls++
+	b.mu.Unlock()
+	// The guard-free core: re-spawn regardless of liveness (matches the real
+	// LocalBackend.respawn, which ends by marking the session live).
+	i.MarkLive()
+	return nil
+}
+
+func (b *limitResumeBackend) SendPromptCommand(_ *session.Instance, prompt string) error {
+	b.mu.Lock()
+	b.sentPrompts = append(b.sentPrompts, prompt)
+	b.mu.Unlock()
+	return nil
+}
+
+func (b *limitResumeBackend) snapshot() (recover, respawn int, prompts []string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.recoverCalls, b.respawnCalls, append([]string(nil), b.sentPrompts...)
+}
+
+// TestResumeFromLimit_ExitedAgent_RespawnsNotRecover is the #1204 P1 regression:
+// retrying a session that hit a usage-limit wall AND whose agent tmux exited
+// while blocked must re-spawn through the guard-free Respawn path, never through
+// Recover — Recover's !Lost guard rejects a LimitReached session, so the old
+// instance.Recover() call made every such retry fail. A task-driven session (one
+// carrying a stored prompt) re-delivers that prompt so its work resumes.
+func TestResumeFromLimit_ExitedAgent_RespawnsNotRecover(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// alive=false → the agent tmux exited while blocked, forcing the re-spawn arm.
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: false}
+	inst := registerStarted(t, manager, repoID, repoPath, "limited", backend, true, session.Running)
+	inst.Prompt = "finish the migration"
+	inst.SetLimitReached(time.Time{})
+
+	if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "limited", RepoID: repoID}); err != nil {
+		// Before the fix this returned `recover: session "limited" is Ready, not
+		// Lost` — the P1. It must now succeed.
+		t.Fatalf("resumeFromLimit returned %v; a LimitReached retry must not fail the Recover !Lost guard (#1204 P1)", err)
+	}
+
+	recoverCalls, respawnCalls, prompts := backend.snapshot()
+	if recoverCalls != 0 {
+		t.Fatalf("Recover called %d times; the limit retry must NOT route through Recover's !Lost guard (#1204 P1)", recoverCalls)
+	}
+	if respawnCalls != 1 {
+		t.Fatalf("Respawn called %d times, want 1 (an exited agent must be re-spawned)", respawnCalls)
+	}
+	if inst.LimitReached() {
+		t.Fatal("limit state must be cleared after a successful resume")
+	}
+	if len(prompts) != 1 || prompts[0] != "finish the migration" {
+		t.Fatalf("re-delivered prompts = %v, want [\"finish the migration\"] (a task session resumes its stored prompt)", prompts)
+	}
+}
+
+// TestResumeFromLimit_LiveStall_SendsContinueNoRespawn: the common case — the
+// agent is still alive but stalled at the limit wall. No re-spawn is needed (and
+// Recover is never touched); an interactive session with no stored prompt just
+// gets a bare "continue" to un-stall it, and the limit state clears.
+func TestResumeFromLimit_LiveStall_SendsContinueNoRespawn(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	// alive=true → a live stall, so no re-spawn should happen.
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: true}
+	inst := registerStarted(t, manager, repoID, repoPath, "stalled", backend, true, session.Running)
+	inst.Prompt = "" // interactive session: no stored prompt
+	inst.SetLimitReached(time.Now())
+
+	if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "stalled", RepoID: repoID}); err != nil {
+		t.Fatalf("resumeFromLimit returned %v, want nil", err)
+	}
+
+	recoverCalls, respawnCalls, prompts := backend.snapshot()
+	if recoverCalls != 0 {
+		t.Fatalf("Recover called %d times; a live stall must never touch Recover", recoverCalls)
+	}
+	if respawnCalls != 0 {
+		t.Fatalf("Respawn called %d times, want 0 (a live agent needs no re-spawn)", respawnCalls)
+	}
+	if inst.LimitReached() {
+		t.Fatal("limit state must be cleared after a successful resume")
+	}
+	if len(prompts) != 1 || prompts[0] != "continue" {
+		t.Fatalf("re-delivered prompts = %v, want [\"continue\"] (an interactive session gets a bare un-stall)", prompts)
+	}
+}
+
+// TestResumeFromLimit_NotLimited_Errors: resuming a session that is not blocked
+// on a usage limit is rejected before any re-spawn or prompt delivery, so PR3's
+// scheduler and the manual retry can both call it without a pre-check racing the
+// poll's self-recovery.
+func TestResumeFromLimit_NotLimited_Errors(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: true}
+	inst := registerStarted(t, manager, repoID, repoPath, "ready", backend, true, session.Ready)
+
+	if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "ready", RepoID: repoID}); err == nil {
+		t.Fatal("resumeFromLimit on a non-limit session must return an error")
+	}
+	recoverCalls, respawnCalls, prompts := backend.snapshot()
+	if recoverCalls != 0 || respawnCalls != 0 || len(prompts) != 0 {
+		t.Fatalf("a rejected resume must not act: recover=%d respawn=%d prompts=%v", recoverCalls, respawnCalls, prompts)
+	}
+	if inst.LimitReached() {
+		t.Fatal("a Ready session must not become limit-blocked")
+	}
+}

--- a/daemon/limit_status_test.go
+++ b/daemon/limit_status_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
@@ -44,7 +45,72 @@ func persistedLiveness(t *testing.T, repoID, title string) session.Liveness {
 	return session.LivenessUnset
 }
 
+// persistedLimitReset reads a session's persisted usage-limit reset time from the
+// on-disk store, so the reset-time-persist path (#1146/#1204) can be asserted on
+// disk rather than only in memory.
+func persistedLimitReset(t *testing.T, repoID, title string) time.Time {
+	t.Helper()
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var data []session.InstanceData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("unmarshal instances: %v", err)
+	}
+	for _, d := range data {
+		if d.Title == title {
+			return d.LimitResetAt
+		}
+	}
+	t.Fatalf("instance %q not found in persisted store", title)
+	return time.Time{}
+}
+
 const claudeLimitBanner = "Claude usage limit reached. Your limit will reset at 2pm (America/New_York)"
+
+// TestPersistPollChange_LaterResetTime_PersistsIndependentOfLiveness is the
+// #1204 reset-time-persist regression: a row can enter LiveLimitReached on one
+// tick with no parsed reset time and only parse it on a LATER tick. That later
+// tick leaves the liveness unchanged, so a liveness-only persist gate would
+// silently drop the reset time — the [limit] resets <t> badge would never show
+// it and PR3's auto-resume scheduler would have nothing to schedule against after
+// a daemon restart. persistPollChange must flush on a reset-time change even when
+// the liveness is unchanged. Uses fixed clock values, no wall-clock.
+func TestPersistPollChange_LaterResetTime_PersistsIndependentOfLiveness(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := limitBannerBackend{FakeBackend: session.NewFakeBackend(), content: claudeLimitBanner}
+	inst := registerStarted(t, manager, repoID, repoPath, "limited", backend, true, session.Running)
+
+	// Tick 1: the banner matched but carried no parseable reset time yet, so the
+	// row enters LimitReached with a zero reset time. This is a real liveness
+	// transition and persists.
+	before1 := inst.GetLiveness()
+	beforeReset1, _ := inst.LimitResetAt()
+	inst.SetLimitReached(time.Time{})
+	manager.persistPollChange(repoID, inst, before1, beforeReset1)
+
+	if got := persistedLiveness(t, repoID, "limited"); got != session.LiveLimitReached {
+		t.Fatalf("after tick 1 persisted liveness = %v, want LiveLimitReached", got)
+	}
+	if got := persistedLimitReset(t, repoID, "limited"); !got.IsZero() {
+		t.Fatalf("after tick 1 persisted reset = %v, want zero (none parsed yet)", got)
+	}
+
+	// Tick 2: a later poll finally parses the reset time. The liveness is UNCHANGED
+	// (already LimitReached), so a liveness-only gate would drop this write — the
+	// regression. persistPollChange must still flush the reset time to disk.
+	resetAt := time.Date(2026, 7, 6, 15, 0, 0, 0, time.UTC)
+	before2 := inst.GetLiveness()
+	beforeReset2, _ := inst.LimitResetAt()
+	inst.SetLimitReached(resetAt)
+	manager.persistPollChange(repoID, inst, before2, beforeReset2)
+
+	got := persistedLimitReset(t, repoID, "limited")
+	if !got.Equal(resetAt) {
+		t.Fatalf("persisted reset time = %v, want %v (a later-parsed reset time must persist even when liveness is unchanged, #1204)", got, resetAt)
+	}
+}
 
 // TestRefreshStatuses_LimitBannerBecomesLimitReached: an idle claude session
 // whose pane shows a usage-limit banner is marked LimitReached (not Ready), the

--- a/daemon/limit_status_test.go
+++ b/daemon/limit_status_test.go
@@ -1,0 +1,116 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// limitBannerBackend is a FakeBackend whose pane capture returns a fixed content
+// string every idle tick (updated=false, hasPrompt=false) — the shape of a
+// claude/codex session stalled at a usage-limit wall (#1146). IsAlive inherits
+// FakeBackend's true, so the daemon's idle branch runs the limit detector over
+// the content rather than probing the session Lost.
+type limitBannerBackend struct {
+	*session.FakeBackend
+	content string
+}
+
+func (b limitBannerBackend) HasUpdated(*session.Instance) (bool, bool, string) {
+	return false, false, b.content
+}
+
+// persistedLiveness reads a session's persisted liveness from the on-disk store,
+// so a limit transition (which composes to a Ready Status) can be asserted on the
+// axis the daemon actually writes.
+func persistedLiveness(t *testing.T, repoID, title string) session.Liveness {
+	t.Helper()
+	raw, err := config.LoadRepoInstances(repoID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var data []session.InstanceData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("unmarshal instances: %v", err)
+	}
+	for _, d := range data {
+		if d.Title == title {
+			return d.Liveness
+		}
+	}
+	t.Fatalf("instance %q not found in persisted store", title)
+	return session.LivenessUnset
+}
+
+const claudeLimitBanner = "Claude usage limit reached. Your limit will reset at 2pm (America/New_York)"
+
+// TestRefreshStatuses_LimitBannerBecomesLimitReached: an idle claude session
+// whose pane shows a usage-limit banner is marked LimitReached (not Ready), the
+// parsed reset time is stored, and the daemon persists the liveness transition
+// (#1146). This is the core PR2 detection-wiring guarantee.
+func TestRefreshStatuses_LimitBannerBecomesLimitReached(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := limitBannerBackend{FakeBackend: session.NewFakeBackend(), content: claudeLimitBanner}
+	// Start from Running to prove the pass actively transitions it.
+	registerStarted(t, manager, repoID, repoPath, "limited", backend, true, session.Running)
+
+	manager.RefreshStatuses()
+
+	inst := manager.instances[daemonInstanceKey(repoID, "limited")]
+	if !inst.LimitReached() {
+		t.Fatalf("in-memory liveness = %v, want LimitReached (a limit banner must never resolve to Ready)", inst.GetLiveness())
+	}
+	if _, ok := inst.LimitResetAt(); !ok {
+		t.Fatal("a parseable reset time must be stored for the badge")
+	}
+	if got := persistedLiveness(t, repoID, "limited"); got != session.LiveLimitReached {
+		t.Fatalf("persisted liveness = %v, want LiveLimitReached (the transition must persist)", got)
+	}
+}
+
+// TestRefreshStatuses_LimitClearsWhenBannerGone: a session that recovers on its
+// own — the banner scrolls away and the pane goes idle-clean — leaves the limit
+// state and resolves back to Ready.
+func TestRefreshStatuses_LimitClearsWhenBannerGone(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &limitBannerBackend{FakeBackend: session.NewFakeBackend(), content: claudeLimitBanner}
+	inst := registerStarted(t, manager, repoID, repoPath, "recovering", backend, true, session.Running)
+
+	manager.RefreshStatuses()
+	if !inst.LimitReached() {
+		t.Fatalf("expected LimitReached after the banner tick, got %v", inst.GetLiveness())
+	}
+
+	// The banner is gone; the pane is idle-clean now.
+	backend.content = "$ "
+	manager.RefreshStatuses()
+	if inst.LimitReached() {
+		t.Fatal("a session whose banner cleared must leave the limit state")
+	}
+	if got := inst.GetStatus(); got != session.Ready {
+		t.Fatalf("recovered session status = %v, want Ready", got)
+	}
+}
+
+// TestRefreshStatuses_GeminiBannerNotLimited: gemini is API-key-metered, so even
+// a rate-limit-looking pane never resolves to LimitReached in v1 — it settles
+// Ready like any idle session.
+func TestRefreshStatuses_GeminiBannerNotLimited(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := limitBannerBackend{FakeBackend: session.NewFakeBackend(), content: "429 RESOURCE_EXHAUSTED"}
+	inst := registerStarted(t, manager, repoID, repoPath, "gemini-sess", backend, true, session.Running)
+	// Point the resolved agent at gemini (registerStarted defaults Program to
+	// claude); the instance has no tmux, so ResolvedAgent falls back to Program.
+	inst.Program = "gemini"
+
+	manager.RefreshStatuses()
+
+	if inst.LimitReached() {
+		t.Fatal("gemini must never resolve to LimitReached in v1")
+	}
+	if got := inst.GetStatus(); got != session.Ready {
+		t.Fatalf("gemini idle status = %v, want Ready", got)
+	}
+}

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -35,8 +35,8 @@ type promptTapBackend struct {
 	tapped int
 }
 
-func (b *promptTapBackend) HasUpdated(*session.Instance) (bool, bool) { return false, true }
-func (b *promptTapBackend) TapEnter(*session.Instance)                { b.tapped++ }
+func (b *promptTapBackend) HasUpdated(*session.Instance) (bool, bool, string) { return false, true, "" }
+func (b *promptTapBackend) TapEnter(*session.Instance)                        { b.tapped++ }
 
 // bothFlagsBackend reports (updated, hasPrompt) == (true, true) — the state a
 // freshly-appeared prompt commonly produces, because the prompt text is itself
@@ -49,8 +49,8 @@ type bothFlagsBackend struct {
 	tapped int
 }
 
-func (b *bothFlagsBackend) HasUpdated(*session.Instance) (bool, bool) { return true, true }
-func (b *bothFlagsBackend) TapEnter(*session.Instance)                { b.tapped++ }
+func (b *bothFlagsBackend) HasUpdated(*session.Instance) (bool, bool, string) { return true, true, "" }
+func (b *bothFlagsBackend) TapEnter(*session.Instance)                        { b.tapped++ }
 
 // updatedOnlyBackend reports (updated, hasPrompt) == (true, false): live output
 // churn with no waiting prompt. It counts TapEnter so the status-only path can
@@ -60,8 +60,10 @@ type updatedOnlyBackend struct {
 	tapped int
 }
 
-func (b *updatedOnlyBackend) HasUpdated(*session.Instance) (bool, bool) { return true, false }
-func (b *updatedOnlyBackend) TapEnter(*session.Instance)                { b.tapped++ }
+func (b *updatedOnlyBackend) HasUpdated(*session.Instance) (bool, bool, string) {
+	return true, false, ""
+}
+func (b *updatedOnlyBackend) TapEnter(*session.Instance) { b.tapped++ }
 
 // registerStarted seeds a single on-disk record and registers a live in-memory
 // instance with the supplied backend and starting status under the daemon's key.
@@ -169,8 +171,10 @@ type nilMonitorBackend struct {
 	ts *tmux.TmuxSession
 }
 
-func (b nilMonitorBackend) HasUpdated(*session.Instance) (bool, bool) { return b.ts.HasUpdated() }
-func (b nilMonitorBackend) IsAlive(*session.Instance) bool            { return b.ts.DoesSessionExist() }
+func (b nilMonitorBackend) HasUpdated(*session.Instance) (bool, bool, string) {
+	return b.ts.HasUpdated()
+}
+func (b nilMonitorBackend) IsAlive(*session.Instance) bool { return b.ts.DoesSessionExist() }
 
 // TestRefreshStatuses_DeadNilMonitorDoesNotPanic is the #999 regression at the
 // daemon poll layer: a persisted Dead/Lost instance whose TmuxSession has a nil

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -17,7 +17,8 @@ const (
 	KeyEnter
 	KeyNew
 	KeyKill
-	KeyArchive // Archive a live session / restore an archived one (#1028)
+	KeyArchive    // Archive a live session / restore an archived one (#1028)
+	KeyLimitRetry // Retry a session blocked at a usage-limit wall (#1146)
 	KeyQuit
 
 	KeyTab        // Tab cycles the workspace focus ring (tree → pane → automations).
@@ -114,6 +115,7 @@ var specs = []spec{
 	{name: KeyNew, configKey: "new", keys: []string{"n"}, desc: "new", dispatch: true},
 	{name: KeyKill, configKey: "kill", keys: []string{"D"}, desc: "kill", dispatch: true},
 	{name: KeyArchive, configKey: "archive", keys: []string{"A"}, desc: "archive/restore", dispatch: true},
+	{name: KeyLimitRetry, configKey: "limit_retry", keys: []string{"c"}, desc: "retry limit", dispatch: true},
 	{name: KeyHelp, configKey: "help", keys: []string{"?"}, desc: "help", dispatch: true},
 	{name: KeyQuit, configKey: "quit", keys: []string{"q"}, desc: "quit", dispatch: true},
 	{name: KeyNewRemote, configKey: "new_remote", keys: []string{"N"}, desc: "new remote", dispatch: true},

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -33,6 +33,7 @@ func TestDefaultMapsMatchLegacyTable(t *testing.T) {
 		"n":          KeyNew,
 		"D":          KeyKill,
 		"A":          KeyArchive,
+		"c":          KeyLimitRetry,
 		"q":          KeyQuit,
 		"tab":        KeyTab,
 		"shift+tab":  KeyShiftTab,

--- a/session/backend.go
+++ b/session/backend.go
@@ -70,6 +70,15 @@ type Backend interface {
 	// session is flagged but reconnect semantics are their own design.
 	Recover(instance *Instance) error
 
+	// Respawn re-establishes an instance's backing session in place — re-spawning
+	// the agent program via the resume path (resumeProgram: claude --continue,
+	// codex resume --last) — WITHOUT any liveness precondition. It is the
+	// guard-free core Recover wraps with its Lost guard; the usage-limit
+	// manual-retry (#1146) uses it directly because a LimitReached session (which
+	// Recover's !Lost guard rejects) needs the identical re-spawn. Callers own the
+	// precondition. Remote backends return ErrRecoverUnsupported.
+	Respawn(instance *Instance) error
+
 	// Type returns the backend type identifier ("local" or "remote").
 	Type() string
 }

--- a/session/backend.go
+++ b/session/backend.go
@@ -32,8 +32,11 @@ type Backend interface {
 	Attach(instance *Instance) (chan struct{}, error)
 
 	// HasUpdated reports whether the session output changed since the last
-	// check and whether the program is showing a prompt.
-	HasUpdated(instance *Instance) (updated bool, hasPrompt bool)
+	// check and whether the program is showing a prompt, and returns the raw
+	// captured pane content so the daemon's usage-limit detector (#1146) can
+	// inspect it without a second capture. content is "" for backends with no
+	// live pane (remote/hook) or when the capture is unavailable.
+	HasUpdated(instance *Instance) (updated bool, hasPrompt bool, content string)
 
 	// SendPrompt sends a prompt string via PTY writes.
 	SendPrompt(instance *Instance, prompt string) error

--- a/session/backend_e2e_test.go
+++ b/session/backend_e2e_test.go
@@ -191,7 +191,7 @@ func TestE2ERemoteHooksFullLifecycle(t *testing.T) {
 	assert.True(t, instance.TmuxAlive(), "TmuxAlive (delegates to IsAlive) should return true")
 
 	// --- Step 6: HasUpdated should always return (false, false) for remote ---
-	updated, hasPrompt := instance.HasUpdated()
+	updated, hasPrompt, _ := instance.HasUpdated()
 	assert.False(t, updated)
 	assert.False(t, hasPrompt)
 

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -507,8 +507,8 @@ func (b *HookBackend) AttachTerminal(i *Instance) (chan struct{}, error) {
 	return done, nil
 }
 
-func (b *HookBackend) HasUpdated(_ *Instance) (updated bool, hasPrompt bool) {
-	return false, false
+func (b *HookBackend) HasUpdated(_ *Instance) (updated bool, hasPrompt bool, content string) {
+	return false, false, ""
 }
 
 func (b *HookBackend) SendPrompt(_ *Instance, _ string) error {

--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -631,10 +631,10 @@ func (b *HookBackend) CheckAndHandleTrustPrompt(_ *Instance) bool {
 
 func (b *HookBackend) TapEnter(_ *Instance) {}
 
-// Recover is unsupported for remote sessions in v1 (#1108): a vanished remote
-// session is flagged Lost so it is visible, but reconnect semantics are a
-// design of their own — the restore loop skips remote instances.
+// Recover/Respawn are unsupported for remote sessions in v1 (#1108/#1146): a Lost
+// remote session is flagged for visibility, but reconnect semantics are TBD.
 func (b *HookBackend) Recover(_ *Instance) error { return ErrRecoverUnsupported }
+func (b *HookBackend) Respawn(_ *Instance) error { return ErrRecoverUnsupported }
 
 // ListRemoteHookInstanceData converts running sessions reported by list_cmd
 // into persistable remote InstanceData records for the current repo.

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -521,14 +521,14 @@ func (b *LocalBackend) Attach(i *Instance) (chan struct{}, error) {
 	return ts.Attach()
 }
 
-func (b *LocalBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool) {
+func (b *LocalBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool, content string) {
 	i.mu.RLock()
 	s := i.started
 	ts := i.tmuxLocked()
 	i.mu.RUnlock()
 
 	if !s || ts == nil {
-		return false, false
+		return false, false, ""
 	}
 	return ts.HasUpdated()
 }

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -262,7 +262,34 @@ func (b *LocalBackend) Recover(i *Instance) error {
 	if i.UserKilled() {
 		return fmt.Errorf("recover: session %q carries a kill tombstone", i.Title)
 	}
+	return b.respawn(i)
+}
 
+// Respawn re-establishes an instance's backing tmux session in place WITHOUT any
+// liveness precondition — the guard-free core Recover wraps. It exists so the
+// usage-limit manual-retry (#1146) can re-spawn an agent that exited while blocked
+// at a limit wall: that session is LiveLimitReached, which Recover's !Lost guard
+// would reject, but the re-spawn mechanics are identical. Callers own the
+// precondition (Recover enforces Lost/no-tombstone; resumeFromLimit enforces
+// LimitReached/no-tombstone under the target lock).
+func (b *LocalBackend) Respawn(i *Instance) error {
+	return b.respawn(i)
+}
+
+// respawn holds the shared re-spawn mechanics for Recover and Respawn: re-spawn
+// the agent program in its worktree with the same resolved-program flag injection
+// as a first-time launch (#1132 choke-point — never hand-rolled flag logic) and
+// the resume-path rewrite Restore applies (resumeProgram: claude --continue,
+// codex resume --last), then bring the other tabs back through the same setupTabs
+// path a restore uses. No liveness guard — the exported wrappers own that.
+//
+// Idempotence across retries: the injected program is recomputed from the clean
+// persisted i.Program on every attempt (SetProgram replaces, never appends), so
+// repeated failures never accumulate duplicate flags. On failure only the agent
+// tab's attach resources are released (the #1065 rule: no other tab has opened a
+// PTY yet on this path) and the tmux refs are kept, so the next tick's retry
+// reconnects each tab by its exact persisted name.
+func (b *LocalBackend) respawn(i *Instance) error {
 	i.mu.RLock()
 	ts := i.tmuxLocked()
 	gw := i.gitWorktree

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -826,7 +826,7 @@ func TestHookBackendIsAliveFailedCmd(t *testing.T) {
 func TestHookBackendHasUpdated(t *testing.T) {
 	b := &HookBackend{Hooks: config.RemoteHooks{}}
 	i := &Instance{backend: b}
-	updated, hasPrompt := b.HasUpdated(i)
+	updated, hasPrompt, _ := b.HasUpdated(i)
 	assert.False(t, updated)
 	assert.False(t, hasPrompt)
 }
@@ -878,7 +878,7 @@ func TestLocalBackendHasUpdatedNilTmuxSession(t *testing.T) {
 		backend: b,
 		started: true, // tmuxSession intentionally left nil
 	}
-	updated, hasPrompt := b.HasUpdated(i)
+	updated, hasPrompt, _ := b.HasUpdated(i)
 	assert.False(t, updated)
 	assert.False(t, hasPrompt)
 }

--- a/session/dead_respawn_test.go
+++ b/session/dead_respawn_test.go
@@ -235,7 +235,7 @@ func TestDeadInstance_HasUpdatedNilMonitor(t *testing.T) {
 
 	// This is the exact call refreshInstanceStatus makes every daemon tick.
 	// Before the nil-monitor guard it panicked here.
-	updated, hasPrompt := restored.HasUpdated()
+	updated, hasPrompt, _ := restored.HasUpdated()
 	assert.False(t, updated, "a restored Dead instance has nothing to report")
 	assert.False(t, hasPrompt)
 }

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -99,7 +99,7 @@ func (b *FakeBackend) Attach(*Instance) (chan struct{}, error) {
 	close(ch)
 	return ch, nil
 }
-func (b *FakeBackend) HasUpdated(*Instance) (bool, bool)         { return false, false }
+func (b *FakeBackend) HasUpdated(*Instance) (bool, bool, string) { return false, false, "" }
 func (b *FakeBackend) SendPrompt(*Instance, string) error        { return nil }
 func (b *FakeBackend) SendPromptCommand(*Instance, string) error { return nil }
 func (b *FakeBackend) SendKeys(*Instance, string) error          { return nil }

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -108,4 +108,5 @@ func (b *FakeBackend) IsAlive(*Instance) bool                    { return true }
 func (b *FakeBackend) CheckAndHandleTrustPrompt(*Instance) bool  { return false }
 func (b *FakeBackend) TapEnter(*Instance)                        {}
 func (b *FakeBackend) Recover(*Instance) error                   { return nil }
+func (b *FakeBackend) Respawn(*Instance) error                   { return nil }
 func (b *FakeBackend) Type() string                              { return "local" }

--- a/session/instance.go
+++ b/session/instance.go
@@ -105,6 +105,14 @@ type Instance struct {
 	// GetStatus/SetStatus shim in liveness.go. Both are mutex-protected.
 	liveness   Liveness
 	inFlightOp InFlightOp
+	// limitResetAt is the parsed usage-limit reset time (#1146), display-only in
+	// PR2: set alongside liveness == LiveLimitReached when the pane shows a limit
+	// banner carrying a parseable reset time (zero when it carried none). Read
+	// only while limit-blocked (LimitResetAt/ToInstanceData gate on the liveness),
+	// so a lingering value on a recovered session never surfaces. Persisted and
+	// carried in the daemon snapshot so the badge survives a restart; PR3's
+	// auto-resume scheduler reads it. Mutex-protected.
+	limitResetAt time.Time
 	// Program is the program to run in the instance.
 	Program string
 	// Height is the height of the instance.
@@ -638,6 +646,14 @@ func (i *Instance) ToInstanceData() InstanceData {
 		data.RemoteMeta = i.remoteMeta
 	}
 
+	// Persist the usage-limit reset time only while the session is actually
+	// limit-blocked (#1146). Gating on the liveness keeps a recovered session
+	// from carrying a stale reset time to disk or into the snapshot — the
+	// in-memory field lingers after ClearLimitReached but is never serialized.
+	if i.liveness == LiveLimitReached {
+		data.LimitResetAt = i.limitResetAt
+	}
+
 	// Persist each tab so the full agent+shell tab list survives a restart
 	// (Sachin's hard requirement for #930): on reload FromInstanceData restores
 	// each local tab's tmux session by its exact persisted name, reconnecting
@@ -697,42 +713,34 @@ func (i *Instance) ToInstanceData() InstanceData {
 
 // FromInstanceData creates a new Instance from serialized data
 func FromInstanceData(data InstanceData) (*Instance, error) {
-	// Resolve the liveness axis: prefer the new `liveness` field; a record
-	// written before #1195 has LivenessUnset and falls back to the legacy
-	// `status` int (rollforward, no dual-read).
-	liveness := data.Liveness
-	if liveness == LivenessUnset {
-		liveness = LivenessForStatus(data.Status)
-	}
-	if liveness == LiveDead {
-		// Rollforward (#1108): Dead was only ever written by observed-death
-		// paths (a user kill deletes the record instead), so it loads as Lost —
-		// recovery-eligible. This is what makes sessions stranded by an outage
-		// under an old build restorable after an upgrade. A tombstoned record
-		// keeps its (Lost) status; the daemon finishes its teardown rather than
-		// restoring it.
-		liveness = LiveLost
-	}
+	// Resolve the liveness axis via the shared rollforward (#1108/#1195): prefer
+	// the new `liveness` field, fall back to the legacy `status` int for records
+	// written before #1195, and load a persisted Dead as Lost — recovery-
+	// eligible, which is what makes sessions stranded by an outage under an old
+	// build restorable after an upgrade. A tombstoned record keeps its (Lost)
+	// status; the daemon finishes its teardown rather than restoring it.
+	liveness := livenessFromData(data)
 	// Resolve the in-flight-op axis from the legacy status. A persisted record
 	// is always settled (SaveInstances skips transients), but a SNAPSHOT of a
 	// transient instance carries Loading/Deleting, which buildInstanceFromSnapshot
 	// must reconstruct so the rebuilt row composes to the identical Status.
 	inFlightOp := opForStatus(data.Status)
 	instance := &Instance{
-		ID:         data.ID,
-		Title:      data.Title,
-		Path:       data.Path,
-		Branch:     data.Branch,
-		liveness:   liveness,
-		inFlightOp: inFlightOp,
-		Height:     data.Height,
-		Width:      data.Width,
-		CreatedAt:  data.CreatedAt,
-		UpdatedAt:  data.UpdatedAt,
-		Program:    data.Program,
-		AutoYes:    data.AutoYes,
-		userKilled: data.UserKilled,
-		remoteMeta: data.RemoteMeta,
+		ID:           data.ID,
+		Title:        data.Title,
+		Path:         data.Path,
+		Branch:       data.Branch,
+		liveness:     liveness,
+		inFlightOp:   inFlightOp,
+		limitResetAt: data.LimitResetAt,
+		Height:       data.Height,
+		Width:        data.Width,
+		CreatedAt:    data.CreatedAt,
+		UpdatedAt:    data.UpdatedAt,
+		Program:      data.Program,
+		AutoYes:      data.AutoYes,
+		userKilled:   data.UserKilled,
+		remoteMeta:   data.RemoteMeta,
 	}
 
 	// Pick backend based on persisted BackendType.
@@ -1180,7 +1188,7 @@ func (i *Instance) Preview() (string, error) {
 	return i.backend.Preview(i)
 }
 
-func (i *Instance) HasUpdated() (updated bool, hasPrompt bool) {
+func (i *Instance) HasUpdated() (updated bool, hasPrompt bool, content string) {
 	return i.backend.HasUpdated(i)
 }
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -1052,6 +1052,16 @@ func (i *Instance) Recover() error {
 	return i.backend.Recover(i)
 }
 
+// Respawn re-establishes the instance's backing session in place without a
+// liveness precondition — the guard-free core of Recover. The usage-limit
+// manual-retry (#1146, resumeFromLimit) uses it to re-spawn an agent that exited
+// while blocked at a limit wall: that session is LiveLimitReached, which Recover's
+// !Lost guard rejects, but the re-spawn mechanics are identical. The caller owns
+// the precondition.
+func (i *Instance) Respawn() error {
+	return i.backend.Respawn(i)
+}
+
 // ArchiveTeardown tears down every tab's tmux session for an archive (#1028) —
 // the tmux half of Kill, but it PRESERVES the worktree and the instance record.
 // It is deliberately best-effort (a stuck tmux only logs, mirroring Kill) and:

--- a/session/limit_test.go
+++ b/session/limit_test.go
@@ -1,0 +1,113 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetLimitReached sets the LimitReached liveness + reset time and reports
+// them through the accessors (#1146). The composed Status stays Ready (there is
+// no legacy limit value), so render sites must key off LimitReached, not Status.
+func TestSetLimitReached(t *testing.T) {
+	reset := time.Date(2026, 7, 5, 14, 0, 0, 0, time.UTC)
+	i := &Instance{}
+	i.SetLimitReached(reset)
+
+	require.True(t, i.LimitReached())
+	require.Equal(t, LiveLimitReached, i.GetLiveness())
+	require.Equal(t, Ready, i.GetStatus(), "LimitReached composes to Ready for legacy readers")
+
+	got, ok := i.LimitResetAt()
+	require.True(t, ok)
+	require.True(t, got.Equal(reset))
+}
+
+// TestSetLimitReached_NoResetTime: a banner with no parseable reset time still
+// blocks the session, but LimitResetAt reports no known time.
+func TestSetLimitReached_NoResetTime(t *testing.T) {
+	i := &Instance{}
+	i.SetLimitReached(time.Time{})
+	require.True(t, i.LimitReached())
+	_, ok := i.LimitResetAt()
+	require.False(t, ok, "a zero reset time must report as unknown")
+}
+
+// TestSetLimitReached_SkipsTransient: a row mid create/kill teardown must not be
+// clobbered into LimitReached (mirrors SetStatusIfNotDeleting).
+func TestSetLimitReached_SkipsTransient(t *testing.T) {
+	for _, s := range []Status{Loading, Deleting} {
+		i := &Instance{}
+		i.SetStatus(s)
+		i.SetLimitReached(time.Now())
+		require.False(t, i.LimitReached(), "%v must not be overwritten by SetLimitReached", s)
+		require.Equal(t, s, i.GetStatus())
+	}
+}
+
+// TestClearLimitReached moves a limit-blocked instance back to Running and drops
+// the reset time; it is a no-op on a non-limit instance.
+func TestClearLimitReached(t *testing.T) {
+	i := &Instance{}
+	i.SetLimitReached(time.Now().Add(time.Hour))
+	i.ClearLimitReached()
+	require.False(t, i.LimitReached())
+	require.Equal(t, LiveRunning, i.GetLiveness())
+	_, ok := i.LimitResetAt()
+	require.False(t, ok)
+
+	// No-op on a Ready instance.
+	r := &Instance{}
+	r.SetStatus(Ready)
+	r.ClearLimitReached()
+	require.Equal(t, Ready, r.GetStatus())
+}
+
+// TestLimitResetAt_ClearedWhenNotLimit: once the liveness moves off LimitReached
+// the reset time never surfaces, even if the field lingers in memory.
+func TestLimitResetAt_ClearedWhenNotLimit(t *testing.T) {
+	i := &Instance{}
+	i.SetLimitReached(time.Now().Add(time.Hour))
+	i.SetStatus(Ready) // shim moves liveness to LiveReady, limitResetAt lingers
+	require.False(t, i.LimitReached())
+	_, ok := i.LimitResetAt()
+	require.False(t, ok, "a lingering reset time must not surface once off LimitReached")
+}
+
+// TestLimitReached_PersistRoundTrip: a limit-blocked instance serializes its
+// liveness + reset time, and the InstanceData survives the JSON round-trip the
+// daemon writes to disk / carries in the snapshot — so the badge survives a
+// restart (#1146).
+func TestLimitReached_PersistRoundTrip(t *testing.T) {
+	reset := time.Date(2026, 7, 5, 14, 30, 0, 0, time.UTC)
+	i, err := NewInstance(InstanceOptions{Title: "limited", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	i.SetLimitReached(reset)
+
+	data := i.ToInstanceData()
+	require.Equal(t, LiveLimitReached, data.Liveness)
+	require.True(t, data.LimitResetAt.Equal(reset))
+
+	// JSON round-trip (the on-disk + snapshot format).
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+	var back InstanceData
+	require.NoError(t, json.Unmarshal(raw, &back))
+	require.Equal(t, LiveLimitReached, back.Liveness)
+	require.True(t, back.LimitResetAt.Equal(reset))
+
+	// FromInstanceData maps the reset time onto the rebuilt instance's field.
+	require.Equal(t, reset, back.LimitResetAt)
+}
+
+// TestToInstanceData_NoLimitResetForNormalSession: a Ready session never persists
+// a reset time, so omitempty drops the field for every normal row.
+func TestToInstanceData_NoLimitResetForNormalSession(t *testing.T) {
+	i, err := NewInstance(InstanceOptions{Title: "normal", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	i.SetStatus(Ready)
+	data := i.ToInstanceData()
+	require.True(t, data.LimitResetAt.IsZero(), "a non-limit session must not carry a reset time")
+}

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -1,6 +1,9 @@
 package session
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // Two-axis session state (#1195 Phase 1b).
 //
@@ -181,7 +184,10 @@ func (i *Instance) GetStatus() Status {
 	return i.statusLocked()
 }
 
-// GetLiveness returns the daemon-owned health axis under the instance mutex.
+// GetLiveness returns the daemon-owned liveness axis under the Instance's mutex
+// (#1146/#1195). Readers use it where the composed Status is lossy: the snapshot
+// reconcile mirrors liveness (not Status) so LiveLimitReached — which composes to
+// Ready — propagates from the daemon to the read-only TUI.
 func (i *Instance) GetLiveness() Liveness {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
@@ -281,4 +287,88 @@ func (i *Instance) TabSpawnBlocked() error {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	return i.tabSpawnBlockedLocked()
+}
+
+// SetLimitReached marks the instance blocked on a usage-limit wall (#1146): it
+// sets the LiveLimitReached liveness and stores the parsed reset time (zero when
+// the banner carried none) for the sidebar badge and PR3's auto-resume
+// scheduler. There is no legacy Status value for SetStatus to decompose onto, so
+// the daemon single-writer (#960) sets the liveness axis directly here. Skips a
+// row mid create/kill teardown so it never clobbers an in-flight op, mirroring
+// SetStatusIfNotDeleting.
+func (i *Instance) SetLimitReached(resetAt time.Time) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if s := i.statusLocked(); s == Loading || s == Deleting {
+		return
+	}
+	i.inFlightOp = OpNone
+	i.liveness = LiveLimitReached
+	i.limitResetAt = resetAt
+}
+
+// SetLimitResetAt records only the display-only reset time (#1146), leaving both
+// axes untouched. The read-only TUI reconcile uses it to mirror the daemon's
+// parsed reset time after it has already applied LiveLimitReached on the liveness
+// axis (Phase 1d applies liveness UNCONDITIONALLY via SetLiveness): the reset
+// time rides the liveness as pure display metadata, so it is set on its own
+// rather than through SetLimitReached, which would re-drive the liveness axis and
+// carry SetLimitReached's transient-op guard into a path that must be
+// unconditional.
+func (i *Instance) SetLimitResetAt(resetAt time.Time) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.limitResetAt = resetAt
+}
+
+// ClearLimitReached moves a limit-blocked instance back to LiveRunning so the
+// daemon poll re-resolves its real state on the next tick and the [limit] badge
+// clears (#1146). A no-op when the instance is not limit-blocked, so the resume
+// action (and PR3's scheduler) can call it unconditionally.
+func (i *Instance) ClearLimitReached() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.liveness != LiveLimitReached {
+		return
+	}
+	i.liveness = LiveRunning
+	i.limitResetAt = time.Time{}
+}
+
+// LimitReached reports whether the instance is blocked on a usage limit (#1146).
+// Every render/serialize site keys its [limit] badge off this rather than the
+// composed Status, which has no limit value (LiveLimitReached composes to Ready).
+func (i *Instance) LimitReached() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.liveness == LiveLimitReached
+}
+
+// LimitResetAt returns the parsed usage-limit reset time and whether one is
+// known (#1146). It reports (zero, false) when the session is not limit-blocked
+// or the banner carried no parseable reset time, so a stale reset value can
+// never leak onto a recovered session.
+func (i *Instance) LimitResetAt() (time.Time, bool) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if i.liveness != LiveLimitReached || i.limitResetAt.IsZero() {
+		return time.Time{}, false
+	}
+	return i.limitResetAt, true
+}
+
+// livenessFromData resolves the liveness a persisted or snapshot record should
+// take, applying the same rollforward FromInstanceData uses: prefer the
+// `liveness` field, fall back to the legacy `status` int for pre-#1195 records,
+// and map a persisted Dead → Lost (recovery-eligible, #1108). Shared so the
+// snapshot reconcile mirrors liveness identically to a cold-start restore.
+func livenessFromData(data InstanceData) Liveness {
+	lv := data.Liveness
+	if lv == LivenessUnset {
+		lv = LivenessForStatus(data.Status)
+	}
+	if lv == LiveDead {
+		lv = LiveLost
+	}
+	return lv
 }

--- a/session/storage.go
+++ b/session/storage.go
@@ -27,12 +27,19 @@ type InstanceData struct {
 	// persisted state. omitempty + additive: records written before #1195 have
 	// no `liveness` key and decode to LivenessUnset, signaling FromInstanceData
 	// to fall back to the legacy `status` int (rollforward).
-	Liveness  Liveness  `json:"liveness,omitempty"`
-	Height    int       `json:"height"`
-	Width     int       `json:"width"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	AutoYes   bool      `json:"auto_yes"`
+	Liveness Liveness `json:"liveness,omitempty"`
+	// LimitResetAt is the parsed usage-limit reset time (#1146), display-only:
+	// written (and carried in the daemon snapshot to the read-only TUI) only for a
+	// LiveLimitReached row so the sidebar [limit] badge can show "resets <t>" and
+	// survive a restart, and so PR3's auto-resume scheduler can read it. omitempty
+	// drops it for every normal session; additive + rollforward, mirroring the
+	// Liveness precedent.
+	LimitResetAt time.Time `json:"limit_reset_at,omitempty"`
+	Height       int       `json:"height"`
+	Width        int       `json:"width"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	AutoYes      bool      `json:"auto_yes"`
 
 	Program string `json:"program"`
 	// UserKilled is the kill-intent tombstone (#1108): persisted by

--- a/session/tmux/exact_target_test.go
+++ b/session/tmux/exact_target_test.go
@@ -148,7 +148,7 @@ func TestDeadAgentWithLiveShellSiblingIsNotPrefixMatched(t *testing.T) {
 
 	// HasUpdated must not report the agent as updated/alive off the shell's
 	// content; it must latch the monitor dead.
-	updated, hasPrompt := session.HasUpdated()
+	updated, hasPrompt, _ := session.HasUpdated()
 	require.False(t, updated, "a dead agent must not be marked updated via its shell sibling (#1006)")
 	require.False(t, hasPrompt)
 	require.True(t, session.monitor.dead, "monitor must latch dead once the agent session is confirmed gone")

--- a/session/tmux/hasupdated_nil_monitor_test.go
+++ b/session/tmux/hasupdated_nil_monitor_test.go
@@ -23,7 +23,7 @@ func TestHasUpdated_NilMonitor(t *testing.T) {
 	}
 	ts := NewTmuxSessionFromSanitizedNameWithDeps("af_nil_monitor", "claude", MakePtyFactory(), exec)
 
-	updated, hasPrompt := ts.HasUpdated()
+	updated, hasPrompt, _ := ts.HasUpdated()
 	assert.False(t, updated, "a session with no live monitor has nothing to report")
 	assert.False(t, hasPrompt)
 }

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -748,9 +748,9 @@ func (t *TmuxSession) SendKeysCommand(text string) error {
 	return t.cmdExec.Run(enterCmd)
 }
 
-// HasUpdated checks if the tmux pane content has changed since the last tick. It also returns true if
-// the tmux pane has a prompt for aider or claude code.
-func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
+// HasUpdated checks if the tmux pane content has changed since the last tick. It also returns true if the tmux
+// pane has a prompt for aider or claude code, plus the raw captured content so the daemon's usage-limit detector (#1146) can inspect it without a second capture ("" on early return).
+func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool, content string) {
 	// A nil monitor means Restore never ran for this session: a persisted Dead
 	// instance is loaded with started=true but LocalBackend.Start returns before
 	// Restore (which is the only place monitor is initialized) so the corpse is
@@ -762,7 +762,7 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
 	// Once the underlying tmux session has been confirmed gone, stay silent
 	// instead of relogging capture-pane failures every daemon tick (#489).
 	if t.monitor == nil || t.monitor.dead {
-		return false, false
+		return false, false, ""
 	}
 
 	content, err := t.CapturePaneContent()
@@ -776,10 +776,10 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
 		if errors.Is(err, ErrSessionGone) {
 			log.ErrorLog.Printf("tmux session %s is gone; status monitor going silent (capture-pane error: %v)", t.sanitizedName, err)
 			t.monitor.dead = true
-			return false, false
+			return false, false, ""
 		}
 		log.ErrorLog.Printf("error capturing pane content in status monitor: %v", err)
-		return false, false
+		return false, false, ""
 	}
 
 	// Only set hasPrompt for agents with a known confirmation dialog, keyed
@@ -797,9 +797,9 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
 	newHash := t.monitor.hash(content)
 	if !bytes.Equal(newHash, t.monitor.prevOutputHash) {
 		t.monitor.prevOutputHash = newHash
-		return true, hasPrompt
+		return true, hasPrompt, content
 	}
-	return false, hasPrompt
+	return false, hasPrompt, content
 }
 
 func (t *TmuxSession) Attach() (chan struct{}, error) {

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -424,7 +424,7 @@ func TestHasUpdatedSilentWhenSessionGone(t *testing.T) {
 
 	logs := captureErrorLog(t)
 
-	updated, hasPrompt := session.HasUpdated()
+	updated, hasPrompt, _ := session.HasUpdated()
 	require.False(t, updated)
 	require.False(t, hasPrompt)
 	require.True(t, session.monitor.dead, "monitor must latch dead after confirming session is gone")
@@ -437,7 +437,7 @@ func TestHasUpdatedSilentWhenSessionGone(t *testing.T) {
 	// 50 more ticks while the session is still gone must produce zero new
 	// log lines and zero additional capture-pane / has-session calls.
 	for i := 0; i < 50; i++ {
-		updated, hasPrompt = session.HasUpdated()
+		updated, hasPrompt, _ = session.HasUpdated()
 		require.False(t, updated)
 		require.False(t, hasPrompt)
 	}
@@ -468,7 +468,7 @@ func TestHasUpdatedRespawnResetsDead(t *testing.T) {
 	require.False(t, session.monitor.dead, "fresh monitor after Restore must not be dead")
 
 	// Polling resumes and produces a normal updated=true on first content.
-	updated, _ := session.HasUpdated()
+	updated, _, _ := session.HasUpdated()
 	require.True(t, updated, "first capture after Restore should report updated")
 }
 
@@ -486,7 +486,7 @@ func TestHasUpdatedTransientErrorKeepsLogging(t *testing.T) {
 	logs := captureErrorLog(t)
 
 	for i := 0; i < 3; i++ {
-		updated, hasPrompt := session.HasUpdated()
+		updated, hasPrompt, _ := session.HasUpdated()
 		require.False(t, updated)
 		require.False(t, hasPrompt)
 	}

--- a/task/limit.go
+++ b/task/limit.go
@@ -113,6 +113,33 @@ func resolveLimitMatchers(overrides map[string]string) map[string]agentLimitMatc
 	return matchers
 }
 
+// LimitDetector is the exported entry point the daemon uses to check captured
+// pane content for a usage-limit banner (#1146 PR2). It wraps the resolved
+// per-agent matcher set (built-ins with config overrides applied) so the daemon
+// never touches the internal matcher map type. Build it ONCE from
+// cfg.LimitPatterns (NewLimitDetector compiles the override regexes) and reuse
+// the value across poll ticks — it is immutable and safe for concurrent reads.
+type LimitDetector struct {
+	matchers map[string]agentLimitMatcher
+}
+
+// NewLimitDetector builds a detector from per-agent detect-pattern overrides
+// (config.LimitPatterns; nil/empty yields the built-in matchers). An override
+// for an agent with no built-in matcher, or an uncompilable pattern, is logged
+// and dropped, so the built-in default always stands (see resolveLimitMatchers).
+func NewLimitDetector(overrides map[string]string) LimitDetector {
+	return LimitDetector{matchers: resolveLimitMatchers(overrides)}
+}
+
+// Check reports whether content shows a usage-limit banner for agent and, when
+// present, the absolute UTC reset time — the return contract of isLimitContent.
+// now is the injected clock used to resolve time-of-day-only and relative reset
+// phrases into an absolute instant; the daemon passes time.Now(), tests a fixed
+// clock. Only claude/codex have matchers, so any other agent returns hit=false.
+func (d LimitDetector) Check(content, agent string, now time.Time) (hit bool, resetAt time.Time, hasResetTime bool) {
+	return isLimitContent(content, agent, d.matchers, now)
+}
+
 // isLimitContent reports whether the captured pane content shows a usage-limit
 // banner for the given agent and, when present, the absolute UTC time the
 // limit resets. It is the usage-limit sibling of isReadyContent: callers

--- a/task/limit_test.go
+++ b/task/limit_test.go
@@ -229,3 +229,32 @@ func TestResolveLimitMatchers(t *testing.T) {
 		t.Fatalf("invalid override should fall back to built-in claude matcher")
 	}
 }
+
+// TestLimitDetector covers the exported facade the daemon uses (#1146 PR2):
+// NewLimitDetector + Check apply config overrides and return the same contract
+// as the internal isLimitContent, and a non-scheduled agent never matches.
+func TestLimitDetector(t *testing.T) {
+	loc := nyLoc(t)
+	now := time.Date(2026, 7, 4, 10, 0, 0, 0, loc)
+
+	det := NewLimitDetector(nil)
+	hit, resetAt, hasReset := det.Check("Claude usage limit reached. Your limit will reset at 2pm (America/New_York)", tmux.ProgramClaude, now)
+	if !hit || !hasReset {
+		t.Fatalf("Check should detect the stock claude banner with a reset time; got hit=%v hasReset=%v", hit, hasReset)
+	}
+	want := time.Date(2026, 7, 4, 14, 0, 0, 0, loc).UTC()
+	if !resetAt.Equal(want) {
+		t.Fatalf("resetAt = %v, want %v", resetAt.UTC(), want)
+	}
+
+	// gemini is API-key-metered — no matcher, so never a hit.
+	if hit, _, _ := det.Check("429 RESOURCE_EXHAUSTED", tmux.ProgramGemini, now); hit {
+		t.Fatalf("gemini must not produce a limit hit in v1")
+	}
+
+	// A config override on the detector is honored.
+	overridden := NewLimitDetector(map[string]string{tmux.ProgramClaude: `PLAN LIMIT TRIPPED`})
+	if hit, _, _ := overridden.Check("PLAN LIMIT TRIPPED at 3pm", tmux.ProgramClaude, now); !hit {
+		t.Fatalf("override detector should detect the reworded banner")
+	}
+}

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -40,8 +40,8 @@ func (b *startBackend) Attach(*session.Instance) (chan struct{}, error) {
 	return ch, nil
 }
 
-func (b *startBackend) HasUpdated(*session.Instance) (bool, bool)  { return false, false }
-func (b *startBackend) SendPrompt(*session.Instance, string) error { return nil }
+func (b *startBackend) HasUpdated(*session.Instance) (bool, bool, string) { return false, false, "" }
+func (b *startBackend) SendPrompt(*session.Instance, string) error        { return nil }
 func (b *startBackend) SendPromptCommand(_ *session.Instance, prompt string) error {
 	b.sentPrompt = prompt
 	return nil

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -59,6 +59,7 @@ func (b *startBackend) CheckAndHandleTrustPrompt(*session.Instance) bool {
 }
 func (b *startBackend) TapEnter(*session.Instance)      {}
 func (b *startBackend) Recover(*session.Instance) error { return nil }
+func (b *startBackend) Respawn(*session.Instance) error { return nil }
 func (b *startBackend) Type() string                    { return "local" }
 
 func newStartTestInstance(t *testing.T, backend *startBackend) *session.Instance {

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -257,6 +257,14 @@ func (m *Menu) addInstanceOptions() {
 	actionGroup = append(actionGroup, keys.KeyShiftUp)
 	actionGroup = append(actionGroup, keys.KeyShiftDown)
 
+	// Usage-limit retry (#1146): advertised only when the selected session is
+	// actually blocked at a limit wall — c re-spawns (if the agent exited) and
+	// resumes it. Kept off the bar for every normal session so it never clutters
+	// the hints.
+	if m.instance != nil && m.instance.LimitReached() {
+		actionGroup = append(actionGroup, keys.KeyLimitRetry)
+	}
+
 	// Tab group: create, close, and number-jump (#930 PR 4). The tab CYCLE key
 	// is gone — Tab now cycles the focus ring (#1024 PR 4); tabs are reached
 	// via the tree and the 1-9 jump keys. Remote instances block `t` (new tab)

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -201,6 +201,9 @@ func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
 	statusRunning := lipgloss.NewStyle().Foreground(lipgloss.Color("#51bd73"))
 	statusReady := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFCC00"))
 	statusLoading := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+	// statusLimit marks a usage-limit-blocked result (#1146) with a distinct
+	// warning red + diamond glyph so it never reads as a live Running/Ready dot.
+	statusLimit := lipgloss.NewStyle().Foreground(lipgloss.Color("#E06C75"))
 
 	content := titleStyle.Render("Search Sessions") + "\n\n"
 	content += "/ " + queryStyle.Render(s.query+"_") + "\n\n"
@@ -225,8 +228,9 @@ func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
 
 		// Status indicator. Two axes (#1195): a create in flight reads as loading;
 		// otherwise a total switch over the liveness — every value explicit (incl.
-		// LimitReached, #1146), no silent default. Running/Ready get the filled dot;
-		// every other liveness gets the hollow ○.
+		// LimitReached, #1146, which gets its own red diamond so it never reads as a
+		// live dot), no silent default. Running/Ready get the filled dot; every
+		// other liveness gets the hollow ○.
 		var statusStr string
 		switch {
 		case r.Instance.GetInFlightOp() == session.OpCreating:
@@ -240,8 +244,12 @@ func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
 				statusStr = statusRunning.Render("●")
 			case session.LiveReady:
 				statusStr = statusReady.Render("●")
+			case session.LiveLimitReached:
+				// A usage-limit-blocked session (#1146) gets a distinct red diamond
+				// so "blocked on limit" never reads as a live/gone dot.
+				statusStr = statusLimit.Render("◆")
 			case session.LiveLost, session.LiveDead, session.LiveArchived,
-				session.LiveLimitReached, session.LivenessUnset:
+				session.LivenessUnset:
 				statusStr = normalStyle.Render("○")
 			}
 		}

--- a/ui/tree/limit_render_test.go
+++ b/ui/tree/limit_render_test.go
@@ -1,0 +1,73 @@
+package tree
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// renderClean renders an instance and returns its output with ANSI stripped.
+func renderClean(t *testing.T, inst *session.Instance) string {
+	t.Helper()
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	r := NewInstanceRenderer(&spin)
+	r.SetWidth(80)
+	r.SetIndexWidth(2)
+	out := r.Render(inst, 1, false, false, false)
+	return ansiEscape.ReplaceAllString(out, "")
+}
+
+// TestRender_LimitBadgeWithResetTime: a limit-blocked session renders the
+// [limit] marker with its reset time and the limit glyph, never a plain Ready
+// dot — the core #1146 surface invariant.
+func TestRender_LimitBadgeWithResetTime(t *testing.T) {
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "worker", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	// 2:30pm local today, so the badge omits the date.
+	now := time.Now()
+	reset := time.Date(now.Year(), now.Month(), now.Day(), 14, 30, 0, 0, time.Local)
+	inst.SetLimitReached(reset)
+
+	clean := renderClean(t, inst)
+	require.Contains(t, clean, "[limit] resets 2:30pm")
+	require.Contains(t, clean, strings.TrimSpace(limitIcon), "the limit glyph must render")
+	require.NotContains(t, clean, strings.TrimSpace(readyIcon)+" worker", "a limit row must not show the ready dot")
+}
+
+// TestRender_LimitBadgeNoResetTime: a limit with no parseable reset shows the
+// bare [limit] marker.
+func TestRender_LimitBadgeNoResetTime(t *testing.T) {
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "worker", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	inst.SetLimitReached(time.Time{})
+
+	clean := renderClean(t, inst)
+	require.Contains(t, clean, "[limit] worker")
+	require.NotContains(t, clean, "resets")
+}
+
+// TestFormatLimitReset covers the badge time formatting: on-the-hour vs minutes,
+// today (time only) vs a future day (date + time).
+func TestFormatLimitReset(t *testing.T) {
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.Local)
+	cases := []struct {
+		name  string
+		reset time.Time
+		want  string
+	}{
+		{"on the hour today", time.Date(2026, 7, 5, 14, 0, 0, 0, time.Local), "2pm"},
+		{"with minutes today", time.Date(2026, 7, 5, 14, 30, 0, 0, time.Local), "2:30pm"},
+		{"future day", time.Date(2026, 7, 12, 9, 0, 0, 0, time.Local), "Jul 12 9am"},
+		{"midnight today", time.Date(2026, 7, 5, 0, 0, 0, 0, time.Local), "12am"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, formatLimitReset(c.reset, now))
+		})
+	}
+}

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/lipgloss"
@@ -31,12 +32,13 @@ const lostIcon = "◌ "
 // row reads as "put away, restartable" rather than any live/vanished state.
 const archivedIcon = "▧ "
 
-// limitIcon marks a session that hit a usage-limit wall (#1146): the agent is
-// alive but blocked until its limit resets. A half-filled dot — "throttled, not
-// gone" — distinct in shape from the running/ready/lost/dead dots. Provisional:
-// #1204 refines the limit surface (label + reset time + retry key) on top of this
-// exhaustive-render slot.
-const limitIcon = "◒ "
+// limitIcon marks a session blocked at a usage-limit wall (#1146): a filled
+// diamond, distinct in shape from every dot/box glyph so "blocked on limit"
+// never reads as a live Running/Ready session — the honest surface the whole
+// feature exists for. Paired with the [limit] title prefix so it survives low
+// contrast and color-blindness, the same discipline as the dead/lost dots.
+// (Refines the provisional ◒ slot Phase 1e stubbed for #1204.)
+const limitIcon = "◆ "
 
 // expandedArrow/collapsedArrow mark an instance row whose tab children are
 // shown/hidden; nonExpandableArrow keeps transient rows (never expandable, see
@@ -68,11 +70,40 @@ var lostStyle = lipgloss.NewStyle().
 var archivedStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
 
-// limitStyle paints a usage-limit-reached dot amber (#1146): a warning state —
-// the agent is throttled, not healthy-green and not corpse-gray. Provisional
-// color; #1204 may tune it alongside the rest of the limit surface.
+// limitStyle paints the status glyph of a usage-limit-blocked session (#1146): a
+// warning red-orange, distinct from the ready-green, lost-amber, and dead/
+// archived gray so the blocked state is unmistakable at a glance.
 var limitStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#C18401", Dark: "#E5C07B"})
+	Foreground(lipgloss.AdaptiveColor{Light: "#D1493F", Dark: "#E06C75"})
+
+// limitBadgePrefix returns the sidebar title prefix for a usage-limit-blocked
+// session (#1146): "[limit] resets <t> " when a reset time is known, else a bare
+// "[limit] ". Kept a helper (not inlined) so the tab pane / search overlay could
+// reuse the exact same wording if they later surface it.
+func limitBadgePrefix(i *session.Instance) string {
+	resetAt, ok := i.LimitResetAt()
+	if !ok {
+		return "[limit] "
+	}
+	return fmt.Sprintf("[limit] resets %s ", formatLimitReset(resetAt, time.Now()))
+}
+
+// formatLimitReset renders a usage-limit reset time for the sidebar badge in the
+// viewer's local zone: a bare hour like "3pm" on the hour, "3:04pm" otherwise,
+// prefixed with the month/day ("Jul 6 3pm") when the reset is not today so a
+// weekly-limit reset days out is unambiguous. now is passed in for testability.
+func formatLimitReset(reset, now time.Time) string {
+	reset = reset.Local()
+	now = now.Local()
+	clock := strings.ToLower(reset.Format("3:04pm"))
+	if reset.Minute() == 0 {
+		clock = strings.ToLower(reset.Format("3pm"))
+	}
+	if reset.Year() == now.Year() && reset.YearDay() == now.YearDay() {
+		return clock
+	}
+	return reset.Format("Jan 2") + " " + clock
+}
 
 // InstanceTitleColor is the foreground of an unselected instance title — the
 // adaptive near-black (light) / near-white (dark) that reads as primary text
@@ -280,10 +311,12 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		titleS = titleS.Foreground(deletingTitleColor)
 		descS = descS.Foreground(deletingTitleColor)
 	}
-	// A usage-limit-reached row (#1146) is marked so "throttled until reset" reads
-	// without decoding the amber dot; #1204 adds the reset time + retry key.
+	// A usage-limit-blocked row (#1146) is prefixed with a [limit] marker and its
+	// reset time when known ("[limit] resets 3pm"), so the sidebar says WHY the
+	// session is stalled and roughly when it frees up — retry now with c. The title
+	// keeps full contrast (like [lost]): the session is blocked, not gone.
 	if liveness == session.LiveLimitReached {
-		titleText = "[limit] " + titleText
+		titleText = limitBadgePrefix(i) + titleText
 	}
 	widthAvail := r.width - 3 - prefixWidth - 1
 	if widthAvail <= 0 {


### PR DESCRIPTION
## PR 2/4 for #1146 — usage-limit detection wiring + status surface + manual retry

Builds on merged **PR1** (`task/limit.go` `isLimitContent` detector + reset-time parsers, config-overridable patterns) and **#1200** (`Liveness.LimitReached` from the Status-split). This PR sets the limit state via the **Liveness axis**, never the flat `session.Status` enum — the split owns the enum now.

**Not** in this PR: auto-resume scheduler (PR3), task-runner park-don't-fail (PR4).

### 1. Surface pane content to the detector
`TmuxSession.HasUpdated` (and the backend interface / `Instance.HasUpdated`) now return the captured pane content alongside `(updated, hasPrompt)`, so the daemon's per-tick poll can run the detector **without a second capture-pane**.

### 2. Wire detection into the daemon single-writer
- New exported `task.LimitDetector` facade over PR1's internals; `Manager` builds it once from `cfg.LimitPatterns` (regex compile is not per-tick).
- In `refreshInstanceStatus`, an idle pane is run through the detector before it resolves `Ready`. On a hit → `SetLimitReached(resetAt)` sets `LiveLimitReached` and stores `limitResetAt` (display-only, persisted; PR3 reads it). Only **claude + codex** ever hit (the detector returns `hit=false` for gemini/aider).
- The limit liveness clears on its own when the pane resumes work (`updated → Running`) or the banner scrolls away (idle-clean → `Ready`).
- Persist gate now compares the **liveness** axis too, since `LiveLimitReached` composes to a `Ready` Status and a Status-only compare would skip the write.

### 3. Render the surface (a limit session never renders Ready/Running)
Keyed off `Instance.LimitReached()` because the composed Status is `Ready`:
- **sidebar tree** (`ui/tree/render.go`): `[limit] resets 2:30pm` title prefix + a distinct red **◆** glyph (reset time in local zone; `Jul 12 9am` when not today; bare `[limit]` when unparseable).
- **search overlay**: distinct red ◆ status glyph.
- **snapshot reconcile** (`app/sync.go`): mirrors the daemon's **liveness** onto the read-only TUI row (Status-mirror alone wouldn't carry it).
- **serialization** (`InstanceData.LimitResetAt`, omitempty): persisted only for a limit row, so the badge survives a restart and travels in the snapshot.
- **menu**: the `c` hint shows only when the selected session is limit-blocked. Tab pane / live-term pane need no change — a limit session is alive, so the pane naturally shows the banner and stays attachable.

### 4. Manual-retry action + keybinding
- New key **`c`** (config key `limit_retry`, mnemonic "continue") → `daemon.ResumeFromLimit` RPC → reusable `Manager.resumeFromLimit`:
  - re-spawn via `Recover()` (→ `resumeProgram`) only if the agent's tmux exited; a live stall needs none,
  - re-deliver the pending prompt — the session's stored task/initial prompt when present, else a bare `continue` un-stall for an interactive session (context-loss caveat per anthropics/claude-code#5977),
  - clear the limit liveness + persist.
- Factored as a **reusable Manager method** so PR3's scheduler calls it directly. Runs under the per-`(repo,title)` target lock with re-verify, and rejects tombstoned/reserved-root sessions (lostrestore-style guards).

### File-length (#1145)
Daemon resume RPC + the split-out `resolveIdleLiveness` / `persistStatusChange` helpers live in a new **`daemon/limit.go`** so `control.go` stays under its ceiling; `limitRetriedMsg` sits with its handler in `handle_actions.go`.

### Tests
- `task`: `LimitDetector` facade (overrides, gemini no-hit).
- `session`: `SetLimitReached`/`ClearLimitReached`/`LimitResetAt`, transient-skip, JSON persist round-trip.
- `daemon`: banner → `LiveLimitReached` (persisted), self-recovery clears it, gemini never limits.
- `app`: `c` dispatches resume through the daemon seam; non-limit row is a no-op; retry clears the local row.
- `ui/tree`: badge rendering + `formatLimitReset` formatting.

All gates green: `go build`, `gofmt -l`, `golangci-lint --fast`, `deadcode -test`, file-length lint, `make test-container`.

Refs #1146. **Do not merge** — root verifies + driver play-tests the badge and gates.

— Captain Claude