### PR TITLE
refactor(ui): exhaustive two-axis render/gate cutover incl LimitReached (#1195 Phase 1e)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1531,7 +1531,7 @@ func (m *home) maybeAutoOpenInitialPane(selected *session.Instance) {
 		}
 		selected = instances[0]
 	}
-	if status := selected.GetStatus(); status == session.Loading || status == session.Deleting {
+	if selected.HasInFlightOp() {
 		return
 	}
 	m.initialPaneOpened = true

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -126,10 +126,10 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 // so the event loop never blocks on it (#844).
 func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
-	if selected == nil || selected.GetStatus() == session.Loading {
+	if selected == nil || selected.IsCreating() {
 		return m, nil
 	}
-	if selected.GetStatus() == session.Deleting {
+	if selected.IsTearingDown() {
 		return m, m.handleError(fmt.Errorf("session '%s' is already being deleted", selected.Title))
 	}
 
@@ -242,17 +242,17 @@ func (m *home) handleInstanceKilled(msg instanceKilledMsg) (tea.Model, tea.Cmd) 
 // enforces the same rules authoritatively.
 func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
-	if selected == nil || selected.GetStatus() == session.Loading {
+	if selected == nil || selected.IsCreating() {
 		return m, nil
 	}
-	if selected.GetStatus() == session.Deleting {
+	if selected.IsTearingDown() {
 		return m, m.handleError(fmt.Errorf("session '%s' is being deleted", selected.Title))
 	}
 	title := selected.Title
 
 	// Archived row → restore. No confirmation: restore only moves the worktree
 	// back and re-spawns the agent.
-	if selected.GetStatus() == session.Archived {
+	if selected.GetLiveness() == session.LiveArchived {
 		return m, m.restoreInstanceCmd(title)
 	}
 
@@ -383,7 +383,7 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		if instErr := interactiveGuard(p.Instance()); instErr != nil {
 			return m, m.handleError(instErr)
 		}
-		if p.Instance() == nil || p.Instance().GetStatus() == session.Loading {
+		if p.Instance() == nil || p.Instance().IsCreating() {
 			return m, nil
 		}
 		if liveSessionName(p.Instance(), p.Tab()) == "" {
@@ -404,7 +404,7 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 	// "restore it first" error before any pane/attach path is reached.
 	if sel.Kind == ui.SectionInstances || sel.Kind == ui.SectionArchived {
 		selected := m.sidebar.GetSelectedInstance()
-		if selected == nil || selected.GetStatus() == session.Loading {
+		if selected == nil || selected.IsCreating() {
 			return m, nil
 		}
 		if err := interactiveGuard(selected); err != nil {
@@ -435,20 +435,20 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 // liveSessionName); nil instance and Loading are the caller's silent no-op
 // cases.
 func interactiveGuard(inst *session.Instance) error {
-	if inst == nil || inst.GetStatus() == session.Loading {
+	if inst == nil || inst.IsCreating() {
 		return nil
 	}
-	if inst.GetStatus() == session.Deleting {
+	if inst.IsTearingDown() {
 		return fmt.Errorf("session '%s' is being deleted", inst.Title)
 	}
-	if inst.GetStatus() == session.Lost {
+	if inst.GetLiveness() == session.LiveLost {
 		// Lost (#1108): the backing tmux session vanished with no kill on
 		// record. Entering or attaching is impossible right now; say what
 		// happened — same explicit-feedback contract as the Deleting path
 		// (#935). Checked before TmuxAlive so the specific message wins.
 		return fmt.Errorf("session '%s' was lost — its tmux session is gone", inst.Title)
 	}
-	if inst.GetStatus() == session.Archived {
+	if inst.GetLiveness() == session.LiveArchived {
 		// Archived (#1028): the user tore the session down and its worktree was
 		// moved to the global archive dir; there is no tmux to enter or attach.
 		// Point at the off-ramp (restore) rather than a bare "not running" —
@@ -478,7 +478,7 @@ func (m *home) handleAttach() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	selected := m.sidebar.GetSelectedInstance()
-	if selected == nil || selected.GetStatus() == session.Loading {
+	if selected == nil || selected.IsCreating() {
 		return m, nil
 	}
 	if err := interactiveGuard(selected); err != nil {
@@ -542,7 +542,7 @@ func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 	if selected == nil {
 		return m, nil
 	}
-	if status := selected.GetStatus(); status == session.Loading || status == session.Deleting {
+	if selected.HasInFlightOp() {
 		return m, nil
 	}
 	if selected.IsRemote() {

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -48,7 +48,7 @@ func (m *home) handleOpenPane() (tea.Model, tea.Cmd) {
 	if selected == nil {
 		return m, nil
 	}
-	if status := selected.GetStatus(); status == session.Loading || status == session.Deleting {
+	if selected.HasInFlightOp() {
 		return m, nil
 	}
 	return m.openOrFocusPane(selected, m.store.ActiveTab())
@@ -142,7 +142,7 @@ func (m *home) pruneDeadPanes() bool {
 	pruned := false
 	for _, p := range append([]*store.OpenPane(nil), m.store.OpenPanes()...) {
 		inst := p.Instance()
-		if !m.store.ContainsInstance(inst) || (inst != nil && inst.GetStatus() == session.Archived) {
+		if !m.store.ContainsInstance(inst) || (inst != nil && inst.GetLiveness() == session.LiveArchived) {
 			m.closePaneWindow(p)
 			pruned = true
 		}
@@ -211,13 +211,13 @@ func (m *home) reconcilePanesForTabs(instance *session.Instance, oldNames []stri
 // routing — but reads the pane's binding instead of the tree selection.
 func (m *home) handleEnterPane(p *store.OpenPane) (tea.Model, tea.Cmd) {
 	instance := p.Instance()
-	if instance == nil || instance.GetStatus() == session.Loading {
+	if instance == nil || instance.IsCreating() {
 		return m, nil
 	}
-	if instance.GetStatus() == session.Deleting {
+	if instance.IsTearingDown() {
 		return m, m.handleError(fmt.Errorf("session '%s' is being deleted", instance.Title))
 	}
-	if instance.GetStatus() == session.Lost {
+	if instance.GetLiveness() == session.LiveLost {
 		return m, m.handleError(fmt.Errorf("session '%s' was lost — its tmux session is gone", instance.Title))
 	}
 	if !instance.TmuxAlive() {

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -230,8 +230,15 @@ func liveSessionName(inst *session.Instance, tab int) string {
 	if inst == nil || inst.IsRemote() || !inst.Started() {
 		return ""
 	}
-	switch inst.GetStatus() {
-	case session.Loading, session.Deleting, session.Dead, session.Lost:
+	// No live session name for a row with an in-flight op (create/kill/archive)
+	// or a vanished session (Dead/Lost) (#1195, was the Loading/Deleting/Dead/Lost
+	// status check). A LimitReached agent is still alive (throttled), so it keeps
+	// its name and stays attachable.
+	if inst.HasInFlightOp() {
+		return ""
+	}
+	switch inst.GetLiveness() {
+	case session.LiveDead, session.LiveLost:
 		return ""
 	}
 	return inst.TabTmuxName(tab)

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -2411,7 +2411,7 @@ func (m *Manager) targetSessionState(repoID, title string) (exists, deleting boo
 	inst := m.instances[daemonInstanceKey(repoID, title)]
 	m.mu.Unlock()
 	if inst != nil {
-		return true, inst.GetStatus() == session.Deleting, nil
+		return true, inst.IsTearingDown(), nil
 	}
 
 	exists, err = repoHasSessionTitle(repoID, title)

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -207,6 +207,31 @@ func (i *Instance) GetInFlightOp() InFlightOp {
 	return i.inFlightOp
 }
 
+// IsCreating reports whether a create is in flight (the render/gate replacement
+// for the old GetStatus()==Loading check).
+func (i *Instance) IsCreating() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.inFlightOp == OpCreating
+}
+
+// IsTearingDown reports whether a kill or archive teardown is in flight (the
+// render/gate replacement for the old GetStatus()==Deleting check — both owners
+// now live on distinct ops, but both read as "going away").
+func (i *Instance) IsTearingDown() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.inFlightOp == OpKilling || i.inFlightOp == OpArchiving
+}
+
+// HasInFlightOp reports whether any client op is in flight (the render/gate
+// replacement for the old Loading||Deleting "is this row transient" check).
+func (i *Instance) HasInFlightOp() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.inFlightOp != OpNone
+}
+
 // SetInFlightOp writes the op axis under the instance mutex, leaving the liveness
 // untouched. The daemon archive executor uses it to raise OpArchiving as a fence
 // over its teardown+move window (and to clear it back to OpNone on a rollback).

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -236,8 +236,8 @@ func (m *Menu) updateOptions() {
 }
 
 func (m *Menu) addInstanceOptions() {
-	// Loading instances only get minimal options
-	if m.instance != nil && m.instance.GetStatus() == session.Loading {
+	// Creating (Loading) instances only get minimal options
+	if m.instance != nil && m.instance.IsCreating() {
 		m.options = []keys.KeyName{keys.KeyNew, keys.KeyHelp, keys.KeyQuit}
 		m.groups = []menuGroup{
 			{start: 0, end: 3, isAction: false},

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -223,17 +223,27 @@ func (s *SearchOverlay) Render(opts ...WhitespaceOption) string {
 	for i := startIdx; i < endIdx; i++ {
 		r := s.results[i]
 
-		// Status indicator
+		// Status indicator. Two axes (#1195): a create in flight reads as loading;
+		// otherwise a total switch over the liveness — every value explicit (incl.
+		// LimitReached, #1146), no silent default. Running/Ready get the filled dot;
+		// every other liveness gets the hollow ○.
 		var statusStr string
-		switch r.Instance.GetStatus() {
-		case session.Running:
-			statusStr = statusRunning.Render("●")
-		case session.Ready:
-			statusStr = statusReady.Render("●")
-		case session.Loading:
+		switch {
+		case r.Instance.GetInFlightOp() == session.OpCreating:
 			statusStr = statusLoading.Render("○")
-		default:
+		case r.Instance.GetInFlightOp() != session.OpNone:
+			// A kill/archive teardown in flight — going away.
 			statusStr = normalStyle.Render("○")
+		default:
+			switch r.Instance.GetLiveness() {
+			case session.LiveRunning:
+				statusStr = statusRunning.Render("●")
+			case session.LiveReady:
+				statusStr = statusReady.Render("●")
+			case session.LiveLost, session.LiveDead, session.LiveArchived,
+				session.LiveLimitReached, session.LivenessUnset:
+				statusStr = normalStyle.Render("○")
+			}
 		}
 
 		label := r.Instance.Title

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -67,7 +67,7 @@ func isInstanceRow(item SidebarItem) bool {
 // projection's stable order (#1028).
 func partitionByArchived(instances []*session.Instance) (live, archived []int) {
 	for i, inst := range instances {
-		if inst != nil && inst.GetStatus() == session.Archived {
+		if inst != nil && inst.GetLiveness() == session.LiveArchived {
 			archived = append(archived, i)
 		} else {
 			live = append(live, i)
@@ -707,7 +707,7 @@ func (s *Sidebar) SetSelectedInstance(idx int) {
 	}
 	// Expand whichever section holds the target so its row is part of
 	// visibleItems; otherwise the search below would silently no-op.
-	if instances[idx].GetStatus() == session.Archived {
+	if instances[idx].GetLiveness() == session.LiveArchived {
 		s.expandSectionKind(SectionArchived)
 	} else {
 		s.ExpandInstancesSection()

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -168,28 +168,31 @@ func (p *TabPane) updateAgentLocked(instance *session.Instance) error {
 	case instance == nil:
 		p.setFallbackState("No agents running yet. Spin up a new instance with 'n' to get started!")
 		return nil
-	case instance.GetStatus() == session.Loading:
+	case instance.IsCreating():
 		p.setFallbackState("Setting up workspace...")
 		return nil
-	case instance.GetStatus() == session.Deleting:
-		// Mirror the Loading case for the other transient status (#920): during
+	case instance.IsTearingDown():
+		// Mirror the creating case for a teardown op (#920/#1195): during
 		// teardown Preview() returns ("", nil) and Started()==false, so without
 		// this the generic name fallback below would claim throughout the delete.
 		p.setFallbackState("Tearing down session...")
 		return nil
-	case instance.GetStatus() == session.Dead:
-		// The metadata tick marks a session Dead once its backing session is
-		// gone (#935); keying off the status makes the fallback synchronous with
+	case instance.GetLiveness() == session.LiveDead:
+		// The daemon poll marks a session Dead once its backing session is
+		// gone (#935); keying off the liveness makes the fallback synchronous with
 		// the sidebar's dead-dot so the panes never disagree.
 		p.setFallbackState("Session no longer running.")
 		return nil
-	case instance.GetStatus() == session.Lost:
+	case instance.GetLiveness() == session.LiveLost:
 		// Lost (#1108): the tmux session vanished with no kill on record —
 		// same synchronous-with-the-sidebar treatment as Dead, but the message
 		// says what happened rather than implying a plain corpse.
 		p.setFallbackState("Session lost — its tmux session is gone.")
 		return nil
 	}
+	// A LimitReached agent (#1146) is deliberately NOT a fallback: its tmux is
+	// alive and its screen shows the limit message, so it falls through to the
+	// live Preview() below.
 
 	// If in scroll mode but the viewport hasn't been filled yet, capture the
 	// full scrollback now (the agent slot fills lazily here; see ScrollUp).
@@ -239,10 +242,10 @@ func (p *TabPane) updateShellLocked(instance *session.Instance, activeTab int) e
 		p.setFallbackState("Select an instance to open a terminal")
 		return nil
 	}
-	// A Deleting instance reports Started()==false during teardown, so without
+	// A tearing-down instance reports Started()==false during teardown, so without
 	// this it would fall through to the "not started yet" fallback — misleading
-	// while the session is going away (#920).
-	if instance.GetStatus() == session.Deleting {
+	// while the session is going away (#920/#1195).
+	if instance.IsTearingDown() {
 		p.setFallbackState("Tearing down session...")
 		return nil
 	}
@@ -453,20 +456,22 @@ func (p *TabPane) ResetToNormalMode(instance *session.Instance, activeTab int) e
 	// Agent slot: immediately restore content instead of waiting for the next
 	// UpdateContent, but keep transient/dead fallbacks rather than blanking the
 	// pane on an empty/erroring Preview() (#823/#920/#935).
-	switch instance.GetStatus() {
-	case session.Loading:
+	switch {
+	case instance.IsCreating():
 		p.setFallbackState("Setting up workspace...")
 		return nil
-	case session.Deleting:
+	case instance.IsTearingDown():
 		p.setFallbackState("Tearing down session...")
 		return nil
-	case session.Dead:
+	case instance.GetLiveness() == session.LiveDead:
 		p.setFallbackState("Session no longer running.")
 		return nil
-	case session.Lost:
+	case instance.GetLiveness() == session.LiveLost:
 		p.setFallbackState("Session lost — its tmux session is gone.")
 		return nil
 	}
+	// LimitReached (#1146) falls through to the live Preview() — its screen shows
+	// the limit message, more useful than a fallback.
 	content, err := instance.Preview()
 	if err != nil {
 		if errors.Is(err, tmux.ErrSessionGone) {

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -31,6 +31,13 @@ const lostIcon = "◌ "
 // row reads as "put away, restartable" rather than any live/vanished state.
 const archivedIcon = "▧ "
 
+// limitIcon marks a session that hit a usage-limit wall (#1146): the agent is
+// alive but blocked until its limit resets. A half-filled dot — "throttled, not
+// gone" — distinct in shape from the running/ready/lost/dead dots. Provisional:
+// #1204 refines the limit surface (label + reset time + retry key) on top of this
+// exhaustive-render slot.
+const limitIcon = "◒ "
+
 // expandedArrow/collapsedArrow mark an instance row whose tab children are
 // shown/hidden; nonExpandableArrow keeps transient rows (never expandable, see
 // Expandable) aligned with their siblings.
@@ -60,6 +67,12 @@ var lostStyle = lipgloss.NewStyle().
 // as live. Reused for the title/desc foreground below.
 var archivedStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+
+// limitStyle paints a usage-limit-reached dot amber (#1146): a warning state —
+// the agent is throttled, not healthy-green and not corpse-gray. Provisional
+// color; #1204 may tune it alongside the rest of the limit surface.
+var limitStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.AdaptiveColor{Light: "#C18401", Dark: "#E5C07B"})
 
 // InstanceTitleColor is the foreground of an unselected instance title — the
 // adaptive near-black (light) / near-white (dark) that reads as primary text
@@ -206,21 +219,36 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		descS = listDescStyle
 	}
 
-	// add spinner next to title if it's running
-	status := i.GetStatus()
+	// Status dot / spinner. Read the two axes directly (#1195): a row with any
+	// in-flight op (create/kill/archive) keeps the spinner ("busy"); otherwise
+	// the daemon-owned liveness picks the dot. The liveness switch is TOTAL — every
+	// value is rendered explicitly, no silent default — so adding a Liveness value
+	// (LimitReached landed this way, #1146) forces a deliberate choice here.
+	liveness := i.GetLiveness()
+	op := i.GetInFlightOp()
 	var join string
-	switch status {
-	case session.Running, session.Loading, session.Deleting:
+	switch {
+	case op != session.OpNone:
 		join = fmt.Sprintf("%s ", r.spinner.View())
-	case session.Ready:
-		join = readyStyle.Render(readyIcon)
-	case session.Dead:
-		join = deadStyle.Render(deadIcon)
-	case session.Lost:
-		join = lostStyle.Render(lostIcon)
-	case session.Archived:
-		join = archivedStyle.Render(archivedIcon)
 	default:
+		switch liveness {
+		case session.LiveRunning:
+			join = fmt.Sprintf("%s ", r.spinner.View())
+		case session.LiveReady:
+			join = readyStyle.Render(readyIcon)
+		case session.LiveDead:
+			join = deadStyle.Render(deadIcon)
+		case session.LiveLost:
+			join = lostStyle.Render(lostIcon)
+		case session.LiveArchived:
+			join = archivedStyle.Render(archivedIcon)
+		case session.LiveLimitReached:
+			join = limitStyle.Render(limitIcon)
+		case session.LivenessUnset:
+			// Serialization sentinel, never a live in-memory value; render like
+			// Running so a stray zero never blanks the dot.
+			join = fmt.Sprintf("%s ", r.spinner.View())
+		}
 	}
 
 	// Cut the title if it's too long
@@ -234,10 +262,10 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	// record" (#1108) is readable without decoding the amber dot; the title
 	// keeps full contrast — unlike deleting/dead treatments, the session is
 	// expected back.
-	if status == session.Lost {
+	if liveness == session.LiveLost {
 		titleText = "[lost] " + titleText
 	}
-	if status == session.Deleting {
+	if op == session.OpKilling || op == session.OpArchiving {
 		titleText = "[deleting] " + titleText
 		titleS = titleS.Foreground(deletingTitleColor)
 		// Dim the branch/PR lines too: on a selected row descS is the
@@ -247,10 +275,15 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	}
 	// An archived row (#1028) is explicitly marked and dimmed so it reads as
 	// "filed away, restartable" — restore with A — rather than a live session.
-	if status == session.Archived {
+	if liveness == session.LiveArchived {
 		titleText = "[archived] " + titleText
 		titleS = titleS.Foreground(deletingTitleColor)
 		descS = descS.Foreground(deletingTitleColor)
+	}
+	// A usage-limit-reached row (#1146) is marked so "throttled until reset" reads
+	// without decoding the amber dot; #1204 adds the reset time + retry key.
+	if liveness == session.LiveLimitReached {
+		titleText = "[limit] " + titleText
 	}
 	widthAvail := r.width - 3 - prefixWidth - 1
 	if widthAvail <= 0 {

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -224,6 +224,24 @@ func TestInstanceRendererDeletingMarker(t *testing.T) {
 	assert.Contains(t, after, "going-away", "the title must remain visible while deleting")
 }
 
+// TestInstanceRendererLimitReachedMarker guards the #1195 exhaustive-render
+// requirement for #1146: a LimitReached liveness renders its own explicit marker
+// (no silent default / blank dot). #1204 refines the label + reset time on top.
+func TestInstanceRendererLimitReachedMarker(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "throttled",
+		Path:    t.TempDir(),
+		Program: "test",
+	})
+	require.NoError(t, err)
+
+	inst.SetLiveness(session.LiveLimitReached)
+	out, _, _ := renderForTerminal(t, 120, inst, &spin)
+	assert.Contains(t, out, "[limit]", "a usage-limit-reached row must be explicitly marked (#1146)")
+	assert.Contains(t, out, "throttled", "the title must remain visible")
+}
+
 // TestInstanceRendererDeletingDimsSelectedRow pins the #853 fix: a SELECTED
 // deleting row must dim its branch and PR lines along with the title. Before
 // the fix only titleS picked up deletingTitleColor, so the high-contrast

--- a/ui/tree/tree.go
+++ b/ui/tree/tree.go
@@ -49,6 +49,8 @@ func Expandable(inst *session.Instance) bool {
 	if inst == nil {
 		return false
 	}
-	status := inst.GetStatus()
-	return status != session.Loading && status != session.Deleting
+	// A row with an in-flight op (create/kill/archive) is never expandable — the
+	// op owns it and its tabs aren't meaningfully attachable (#1195, was the
+	// Loading/Deleting check).
+	return !inst.HasInFlightOp()
 }


### PR DESCRIPTION
## What

Phase 1e (final) migrates the render + in-flight **gate readers** off the composed `Status` shim onto the two axes (`GetLiveness`/`GetInFlightOp`), and makes every status render a **total switch over the full `Liveness` set — no silent default**. This lands the **`LimitReached` (#1146) render slot** so the usage-limit epic (#1204) rebases onto a model that already renders it.

> **Stacked on #1203 (Phase 1d).** Base branch is `captain/1195-1d-reconcile`; the diff here is 1e-only. Retarget to `master` once 1d merges.

## Render sites — exhaustive `Liveness` + op, no gap

- **`ui/tree/render.go`**: the dot/spinner + title prefix switch on `(liveness, op)` with an **explicit case for every `Liveness` value**. `LimitReached` gets a `◒` dot + `[limit]` marker (provisional; #1204 refines label/reset-time/retry-key).
- **`ui/overlay/searchOverlay.go`**: the status-dot switch is now total (the old `default` gap is gone).
- **`ui/tab_pane.go`**: the transient/dead fallbacks read the axes; `LimitReached` deliberately **falls through to the live `Preview()`** (its tmux is alive and its screen shows the limit message — more useful than a fallback).
- **`ui/menu.go`, `ui/tree/tree.go`, `ui/sidebar.go`, `app/live_termpane.go`**: `Loading`/`Deleting`/`Archived` reads → `IsCreating`/`IsTearingDown`/`HasInFlightOp`/`GetLiveness`.

## Gate sites
`app/handle_actions`, `handle_panes`, `app.go`, `daemon/control`: `GetStatus()==Loading/Deleting/Archived/Lost` → the new axis predicates.

New predicates (`session/liveness.go`): `IsCreating`, `IsTearingDown`, `HasInFlightOp` — readable one-liners for the readers.

## Scope note (my recommended option-2)
The legacy `Loading`/`Deleting` **constants are retained** as the on-disk/wire enum — daemon ghost-record detection compares `InstanceData.Status` (the persisted int) against them, and removing them tangles with that wire format. **The in-memory model is now fully on the axes**; the `Status` shim survives only as the legacy persistence/compat layer. A later mechanical PR can retire the constants if you want the wire format changed too.

## Visible — needs a driver play-test
Confirm every status renders its dot/marker (Running/Ready/Lost/Dead/Archived + a `[limit]` row via a `LiveLimitReached` liveness), and the archive/kill/create labels are unchanged.

## Tests
`TestInstanceRendererLimitReachedMarker` (the new slot renders `[limit]`); every existing render/gate test passes unchanged (output preserved for all prior states). Full `make test-container` green; gofmt/golangci-lint/deadcode/file-length all clean.

Part of #1195 (Phase 1 anchor). **Does not close it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)