### PR TITLE
feat(cli): af daemon status, sessions tabs aliases, af config get/list (#1192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ default_program = "claude"
 claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 ```
 
-Upgrading from a `config.json`? The move to TOML is automatic — `af` converts it on first run and keeps a `config.json.bak`. See [docs/configuration.md](docs/configuration.md) for every key, the migration, the precedence rules, and where state is stored.
+Read the effective global config from the CLI with `af config list` (or `af config get <key>`) — handy for scripts and agents; editing values is still done in the file. Upgrading from a `config.json`? The move to TOML is automatic — `af` converts it on first run and keeps a `config.json.bak`. See [docs/configuration.md](docs/configuration.md) for every key, the migration, the precedence rules, and where state is stored.
 
 ## Documentation
 

--- a/api/api.go
+++ b/api/api.go
@@ -460,12 +460,15 @@ func init() {
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptAllReposFlag, "all-repos", false, "With --all, broadcast across every repo instead of only the current/--repo one")
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptIncludeRootFlag, "include-root", false, "With --all, also deliver to the reserved root session (excluded by default)")
 
-	sessionsTabCreateCmd.Flags().StringVar(&tabCreateCommandFlag, "command", "", "Command to run in the new tab (required)")
-	sessionsTabCreateCmd.Flags().StringVar(&tabCreateNameFlag, "name", "", "Tab name (defaults to the command basename; auto-suffixed on collision)")
-	sessionsTabCreateCmd.MarkFlagRequired("command")
-
-	sessionsTabDeleteCmd.Flags().StringVar(&tabDeleteNameFlag, "name", "", "Name of the tab to delete (required)")
-	sessionsTabDeleteCmd.MarkFlagRequired("name")
+	// tab-create/tab-delete and their tabs {create,delete} aliases (#1192)
+	// share the same flag globals via these binders, so the two spellings stay
+	// in lockstep.
+	bindTabCreateFlags(sessionsTabCreateCmd)
+	bindTabCreateFlags(sessionsTabsCreateCmd)
+	bindTabDeleteFlags(sessionsTabDeleteCmd)
+	bindTabDeleteFlags(sessionsTabsDeleteCmd)
+	sessionsTabsCmd.AddCommand(sessionsTabsCreateCmd)
+	sessionsTabsCmd.AddCommand(sessionsTabsDeleteCmd)
 
 	SessionsCmd.AddCommand(sessionsListCmd)
 	SessionsCmd.AddCommand(sessionsGetCmd)
@@ -473,6 +476,7 @@ func init() {
 	SessionsCmd.AddCommand(sessionsSendPromptCmd)
 	SessionsCmd.AddCommand(sessionsTabCreateCmd)
 	SessionsCmd.AddCommand(sessionsTabDeleteCmd)
+	SessionsCmd.AddCommand(sessionsTabsCmd)
 	SessionsCmd.AddCommand(sessionsPreviewCmd)
 	SessionsCmd.AddCommand(sessionsKillCmd)
 	SessionsCmd.AddCommand(sessionsArchiveCmd)

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -506,6 +506,21 @@ var (
 	tabCreateNameFlag    string
 )
 
+// bindTabCreateFlags registers the tab-create flags on c, bound to the shared
+// globals. Called for both the hyphen verb and the tabs-create alias (#1192).
+func bindTabCreateFlags(c *cobra.Command) {
+	c.Flags().StringVar(&tabCreateCommandFlag, "command", "", "Command to run in the new tab (required)")
+	c.Flags().StringVar(&tabCreateNameFlag, "name", "", "Tab name (defaults to the command basename; auto-suffixed on collision)")
+	c.MarkFlagRequired("command")
+}
+
+// bindTabDeleteFlags registers the tab-delete flag on c, bound to the shared
+// global. Called for both the hyphen verb and the tabs-delete alias (#1192).
+func bindTabDeleteFlags(c *cobra.Command) {
+	c.Flags().StringVar(&tabDeleteNameFlag, "name", "", "Name of the tab to delete (required)")
+	c.MarkFlagRequired("name")
+}
+
 var sessionsTabCreateCmd = &cobra.Command{
 	Use:   "tab-create <title>",
 	Short: "Spawn a process tab running a command in a session's worktree",
@@ -520,34 +535,40 @@ sessions: they have no local worktree and the hook protocol can't run arbitrary
 commands — a remote session's only terminal tab comes from
 remote_hooks.terminal_cmd.`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Initialize(false)
-		defer log.Close()
+	RunE: runTabCreate,
+}
 
-		if strings.TrimSpace(tabCreateCommandFlag) == "" {
-			return jsonError(fmt.Errorf("--command is required"))
-		}
+// runTabCreate is the shared RunE body behind both the legacy hyphen verb
+// (sessions tab-create) and the noun-subcommand alias (sessions tabs create),
+// so the two stay byte-identical (#1192). External users script the hyphen
+// verb, so it stays first-class — the alias is purely additive.
+func runTabCreate(cmd *cobra.Command, args []string) error {
+	log.Initialize(false)
+	defer log.Close()
 
-		// Honor --repo scoping (#891, same class as kill/send-prompt/attach). An
-		// empty repoID preserves the all-repo search; a non-empty one confines the
-		// session lookup to that repo so a same-titled session in another repo
-		// never receives the tab.
-		repoID, err := resolveRepoID()
-		if err != nil {
-			return jsonError(err)
-		}
+	if strings.TrimSpace(tabCreateCommandFlag) == "" {
+		return jsonError(fmt.Errorf("--command is required"))
+	}
 
-		name, err := createTabViaDaemon(daemon.CreateTabRequest{
-			Title:   args[0],
-			RepoID:  repoID,
-			Command: tabCreateCommandFlag,
-			Name:    tabCreateNameFlag,
-		})
-		if err != nil {
-			return jsonError(err)
-		}
-		return jsonOut(map[string]string{"name": name})
-	},
+	// Honor --repo scoping (#891, same class as kill/send-prompt/attach). An
+	// empty repoID preserves the all-repo search; a non-empty one confines the
+	// session lookup to that repo so a same-titled session in another repo
+	// never receives the tab.
+	repoID, err := resolveRepoID()
+	if err != nil {
+		return jsonError(err)
+	}
+
+	name, err := createTabViaDaemon(daemon.CreateTabRequest{
+		Title:   args[0],
+		RepoID:  repoID,
+		Command: tabCreateCommandFlag,
+		Name:    tabCreateNameFlag,
+	})
+	if err != nil {
+		return jsonError(err)
+	}
+	return jsonOut(map[string]string{"name": name})
 }
 
 var tabDeleteNameFlag string
@@ -567,33 +588,67 @@ session. Deleting a tab or session that doesn't exist is an error, not a
 silent success. Not available for remote sessions: their tabs are fixed by
 remote_hooks config.`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Initialize(false)
-		defer log.Close()
+	RunE: runTabDelete,
+}
 
-		if strings.TrimSpace(tabDeleteNameFlag) == "" {
-			return jsonError(fmt.Errorf("--name is required"))
-		}
+// runTabDelete is the shared RunE body behind both sessions tab-delete and the
+// sessions tabs delete alias (#1192); see runTabCreate.
+func runTabDelete(cmd *cobra.Command, args []string) error {
+	log.Initialize(false)
+	defer log.Close()
 
-		// Honor --repo scoping (#891 class), mirroring tab-create: an empty
-		// repoID preserves the all-repo search; a non-empty one confines the
-		// session lookup to that repo so a same-titled session in another repo
-		// never loses a tab.
-		repoID, err := resolveRepoID()
-		if err != nil {
-			return jsonError(err)
-		}
+	if strings.TrimSpace(tabDeleteNameFlag) == "" {
+		return jsonError(fmt.Errorf("--name is required"))
+	}
 
-		name, err := closeTabViaDaemon(daemon.CloseTabRequest{
-			Title:   args[0],
-			RepoID:  repoID,
-			TabName: tabDeleteNameFlag,
-		})
-		if err != nil {
-			return jsonError(err)
-		}
-		return jsonOut(map[string]string{"name": name})
-	},
+	// Honor --repo scoping (#891 class), mirroring tab-create: an empty
+	// repoID preserves the all-repo search; a non-empty one confines the
+	// session lookup to that repo so a same-titled session in another repo
+	// never loses a tab.
+	repoID, err := resolveRepoID()
+	if err != nil {
+		return jsonError(err)
+	}
+
+	name, err := closeTabViaDaemon(daemon.CloseTabRequest{
+		Title:   args[0],
+		RepoID:  repoID,
+		TabName: tabDeleteNameFlag,
+	})
+	if err != nil {
+		return jsonError(err)
+	}
+	return jsonOut(map[string]string{"name": name})
+}
+
+// The sessions tabs {create,delete} group gives a noun-subcommand spelling of
+// the tab-create/tab-delete verbs (#1192). Both spellings share the same RunE
+// and flag globals; the hyphen verbs are kept for the scripts that already use
+// them. tab-list has no equivalent — tabs are listed via `sessions get`.
+var sessionsTabsCmd = &cobra.Command{
+	Use:   "tabs",
+	Short: "Manage a session's process tabs (create/delete)",
+	Long: `Noun-subcommand aliases for the tab-create/tab-delete verbs.
+
+"sessions tabs create" is identical to "sessions tab-create" and "sessions tabs
+delete" is identical to "sessions tab-delete"; the hyphen verbs remain supported
+for existing scripts. To list a session's tabs, use "sessions get <title>".`,
+}
+
+var sessionsTabsCreateCmd = &cobra.Command{
+	Use:   "create <title>",
+	Short: "Spawn a process tab running a command in a session's worktree",
+	Long:  `Alias for "sessions tab-create". See "af sessions tab-create --help" for details.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTabCreate,
+}
+
+var sessionsTabsDeleteCmd = &cobra.Command{
+	Use:   "delete <title>",
+	Short: "Delete a single tab from a session",
+	Long:  `Alias for "sessions tab-delete". See "af sessions tab-delete --help" for details.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTabDelete,
 }
 
 var sessionsPreviewCmd = &cobra.Command{

--- a/api/sessions_tabs_test.go
+++ b/api/sessions_tabs_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// findSub returns the direct subcommand of parent whose first Use word matches
+// name, or nil.
+func findSub(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestSessionsTabsAliasesRegistered pins the #1192 additive aliases: the
+// noun-subcommand `sessions tabs {create,delete}` group exists alongside the
+// original hyphen verbs (which must stay for scripts), and each alias carries
+// the same required flags as the verb it mirrors.
+func TestSessionsTabsAliasesRegistered(t *testing.T) {
+	// Hyphen verbs must still be present — removing them would break scripts.
+	if findSub(SessionsCmd, "tab-create") == nil {
+		t.Error("sessions tab-create must remain registered")
+	}
+	if findSub(SessionsCmd, "tab-delete") == nil {
+		t.Error("sessions tab-delete must remain registered")
+	}
+
+	tabs := findSub(SessionsCmd, "tabs")
+	if tabs == nil {
+		t.Fatal("sessions tabs group not registered")
+	}
+
+	create := findSub(tabs, "create")
+	if create == nil {
+		t.Fatal("sessions tabs create not registered")
+	}
+	if create.RunE == nil {
+		t.Error("sessions tabs create has no RunE")
+	}
+	if create.Flag("command") == nil {
+		t.Error("sessions tabs create missing --command flag")
+	}
+	if create.Flag("name") == nil {
+		t.Error("sessions tabs create missing --name flag")
+	}
+
+	del := findSub(tabs, "delete")
+	if del == nil {
+		t.Fatal("sessions tabs delete not registered")
+	}
+	if del.RunE == nil {
+		t.Error("sessions tabs delete has no RunE")
+	}
+	if del.Flag("name") == nil {
+		t.Error("sessions tabs delete missing --name flag")
+	}
+}

--- a/configcmd.go
+++ b/configcmd.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+
+	"github.com/spf13/cobra"
+)
+
+// The `af config` group is a read-only view over the global config
+// (~/.agent-factory/config.toml) so users and scripts can discover the current
+// settings without hand-parsing the TOML (#1192). Writing from the CLI (`config
+// set`) is deliberately not implemented yet: it needs a settable-key allowlist,
+// validation reuse (ValidateProgramEnum et al.), and a comment-preserving TOML
+// write that go-toml/v2's Marshal cannot do — a design pass tracked on #1192.
+
+// configJSONFlag switches `af config get/list` from human output to the shared
+// {data,error} envelope. Local to this group (like `af api`'s --json) since
+// there is no bare-vs-envelope legacy to preserve here.
+var configJSONFlag bool
+
+// configEntry is one global config key and its effective value (defaults
+// applied). Value is heterogeneous — scalars for simple keys, maps for
+// program_overrides/root_agents/limit_patterns/keys.
+type configEntry struct {
+	Key   string `json:"key"`
+	Value any    `json:"value"`
+}
+
+// configEntries lists every global config key in a stable order with the
+// effective value from the loaded config (i.e. what a session sees before any
+// in-repo override). Mirrors the settable keys documented in
+// docs/configuration.md; keep the two in sync when a key is added.
+func configEntries(cfg *config.Config) []configEntry {
+	return []configEntry{
+		{"default_program", cfg.DefaultProgram},
+		{"program_overrides", cfg.ProgramOverrides},
+		{"auto_yes", cfg.AutoYes},
+		{"daemon_poll_interval", cfg.DaemonPollInterval},
+		{"log_max_size_mb", cfg.LogMaxSizeMB},
+		{"log_max_backups", cfg.LogMaxBackups},
+		{"branch_prefix", cfg.BranchPrefix},
+		{"detach_keys", cfg.DetachKeys},
+		{"update_channel", cfg.UpdateChannel},
+		{"root_agents", cfg.RootAgents},
+		{"limit_patterns", cfg.LimitPatterns},
+		{"keys", cfg.KeymapOverrides()},
+	}
+}
+
+// loadGlobalConfigEntries loads the global config and returns its keys. It
+// reads the same file the daemon and TUI read (config.toml, defaults applied);
+// it never resolves in-repo overrides, matching the get/set contract of
+// operating on the global file.
+func loadGlobalConfigEntries() ([]configEntry, error) {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return nil, err
+	}
+	return configEntries(cfg), nil
+}
+
+// formatConfigValue renders a value for human output: scalars bare (so
+// `af config get default_program` prints exactly `claude`, script-friendly),
+// composites as compact JSON.
+func formatConfigValue(v any) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case bool:
+		return strconv.FormatBool(x)
+	case int:
+		return strconv.Itoa(x)
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(b)
+	}
+}
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Read the global agent-factory config",
+	Long: `Read keys from the global config (~/.agent-factory/config.toml).
+
+Values are the effective global config with defaults applied — what a session
+gets before any in-repo .agent-factory/config.toml override is layered on.
+
+This command is read-only. To change a value, edit config.toml directly (it is
+plain TOML, made for hand-editing); a CLI write path (config set) is tracked in
+#1192.`,
+}
+
+var configGetCmd = &cobra.Command{
+	Use:   "get <key>",
+	Short: "Print the value of a single global config key",
+	Long: `Print the effective global value of one config key (e.g. default_program,
+auto_yes, update_channel). Run "af config list" to see every key. Scalar values
+print bare; composite values (program_overrides, root_agents, limit_patterns,
+keys) print as JSON.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		entries, err := loadGlobalConfigEntries()
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if e.Key == args[0] {
+				if configJSONFlag {
+					return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(e))
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), formatConfigValue(e.Value))
+				return nil
+			}
+		}
+		return fmt.Errorf("unknown config key %q; run `af config list` to see all keys", args[0])
+	},
+}
+
+var configListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Print every global config key and its effective value",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		entries, err := loadGlobalConfigEntries()
+		if err != nil {
+			return err
+		}
+		if configJSONFlag {
+			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(entries))
+		}
+		tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		for _, e := range entries {
+			fmt.Fprintf(tw, "%s\t%s\n", e.Key, formatConfigValue(e.Value))
+		}
+		return tw.Flush()
+	},
+}
+
+func init() {
+	const jsonUsage = "Emit the value(s) as JSON wrapped in the {data,error} envelope"
+	configGetCmd.Flags().BoolVar(&configJSONFlag, "json", false, jsonUsage)
+	configListCmd.Flags().BoolVar(&configJSONFlag, "json", false, jsonUsage)
+	configCmd.AddCommand(configGetCmd)
+	configCmd.AddCommand(configListCmd)
+}

--- a/configcmd.go
+++ b/configcmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strconv"
 	"text/tabwriter"
 
@@ -12,6 +13,20 @@ import (
 
 	"github.com/spf13/cobra"
 )
+
+// jsonWrapError honors the --json contract for the CLI commands in package
+// main: when jsonMode is set, a failure is emitted as the shared {data,error}
+// envelope on errOut (the command's stderr, matching the api package's
+// jsonError), so a `--json` caller always gets the envelope it was promised
+// instead of a bare Go error. The error is returned unchanged so the exit code
+// is unaffected. Off the --json path it is a no-op passthrough for cobra's
+// normal error handling.
+func jsonWrapError(errOut io.Writer, jsonMode bool, err error) error {
+	if jsonMode && err != nil {
+		_ = apiproto.WriteEnvelope(errOut, apiproto.Failure(err.Error()))
+	}
+	return err
+}
 
 // The `af config` group is a read-only view over the global config
 // (~/.agent-factory/config.toml) so users and scripts can discover the current
@@ -113,7 +128,7 @@ keys) print as JSON.`,
 
 		entries, err := loadGlobalConfigEntries()
 		if err != nil {
-			return err
+			return jsonWrapError(cmd.ErrOrStderr(), configJSONFlag, err)
 		}
 		for _, e := range entries {
 			if e.Key == args[0] {
@@ -124,7 +139,8 @@ keys) print as JSON.`,
 				return nil
 			}
 		}
-		return fmt.Errorf("unknown config key %q; run `af config list` to see all keys", args[0])
+		return jsonWrapError(cmd.ErrOrStderr(), configJSONFlag,
+			fmt.Errorf("unknown config key %q; run `af config list` to see all keys", args[0]))
 	},
 }
 
@@ -138,7 +154,7 @@ var configListCmd = &cobra.Command{
 
 		entries, err := loadGlobalConfigEntries()
 		if err != nil {
-			return err
+			return jsonWrapError(cmd.ErrOrStderr(), configJSONFlag, err)
 		}
 		if configJSONFlag {
 			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(entries))

--- a/configcmd_test.go
+++ b/configcmd_test.go
@@ -93,6 +93,45 @@ func TestConfigGetUnknownKeyErrors(t *testing.T) {
 	}
 }
 
+// TestConfigGetUnknownKeyJSONEnvelope pins the #1206 Greptile fix: a failed
+// `config get --json` must emit the shared {data,error} envelope on stderr, not
+// a bare Go error, so scripts parsing --json still get a structured error.
+func TestConfigGetUnknownKeyJSONEnvelope(t *testing.T) {
+	tempAFHome(t)
+	prev := configJSONFlag
+	configJSONFlag = true
+	defer func() { configJSONFlag = prev }()
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := configGetCmd.RunE(cmd, []string{"not_a_key"})
+	if err == nil {
+		t.Fatal("expected error for unknown key")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("error path must not write stdout, got: %s", stdout.String())
+	}
+
+	var env struct {
+		Data  any `json:"data"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &env); err != nil {
+		t.Fatalf("stderr is not the shared envelope: %v\n%s", err, stderr.String())
+	}
+	if env.Data != nil {
+		t.Errorf("failure envelope data should be null, got %v", env.Data)
+	}
+	if env.Error == nil || !strings.Contains(env.Error.Message, "unknown config key") {
+		t.Fatalf("envelope missing the unknown-key message: %s", stderr.String())
+	}
+}
+
 func TestConfigListJSONEnvelope(t *testing.T) {
 	tempAFHome(t)
 	prev := configJSONFlag

--- a/configcmd_test.go
+++ b/configcmd_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+
+	"github.com/spf13/cobra"
+)
+
+// tempAFHome points AGENT_FACTORY_HOME at a fresh temp dir so config reads
+// materialize DefaultConfig there instead of touching the real home or a
+// running daemon's config.
+func tempAFHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+}
+
+func TestFormatConfigValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"string bare", "claude", "claude"},
+		{"bool", true, "true"},
+		{"int", 1000, "1000"},
+		{"map as json", map[string]string{"claude": "x"}, `{"claude":"x"}`},
+		{"nil map", map[string]string(nil), "null"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := formatConfigValue(c.in); got != c.want {
+				t.Fatalf("formatConfigValue(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestConfigEntriesCoverAllKeys guards that configEntries lists exactly the
+// documented settable top-level config keys — if a key is added to the Config
+// struct, this fails until the entry (and docs) are updated.
+func TestConfigEntriesCoverAllKeys(t *testing.T) {
+	got := map[string]bool{}
+	for _, e := range configEntries(config.DefaultConfig()) {
+		if got[e.Key] {
+			t.Fatalf("duplicate config key %q in configEntries", e.Key)
+		}
+		got[e.Key] = true
+	}
+	want := []string{
+		"default_program", "program_overrides", "auto_yes", "daemon_poll_interval",
+		"log_max_size_mb", "log_max_backups", "branch_prefix", "detach_keys",
+		"update_channel", "root_agents", "limit_patterns", "keys",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("configEntries has %d keys, want %d", len(got), len(want))
+	}
+	for _, k := range want {
+		if !got[k] {
+			t.Errorf("configEntries missing key %q", k)
+		}
+	}
+}
+
+func TestConfigGetScalarBare(t *testing.T) {
+	tempAFHome(t)
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := configGetCmd.RunE(cmd, []string{"default_program"}); err != nil {
+		t.Fatalf("config get default_program: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "claude" {
+		t.Fatalf("config get default_program = %q, want %q", got, "claude")
+	}
+}
+
+func TestConfigGetUnknownKeyErrors(t *testing.T) {
+	tempAFHome(t)
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	err := configGetCmd.RunE(cmd, []string{"not_a_key"})
+	if err == nil {
+		t.Fatal("config get not_a_key: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown config key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfigListJSONEnvelope(t *testing.T) {
+	tempAFHome(t)
+	prev := configJSONFlag
+	configJSONFlag = true
+	defer func() { configJSONFlag = prev }()
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := configListCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("config list --json: %v", err)
+	}
+
+	var env struct {
+		Data  []configEntry `json:"data"`
+		Error any           `json:"error"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &env); err != nil {
+		t.Fatalf("output is not the shared envelope: %v\n%s", err, out.String())
+	}
+	if env.Error != nil {
+		t.Fatalf("envelope error should be null, got %v", env.Error)
+	}
+	var haveDefaultProgram bool
+	for _, e := range env.Data {
+		if e.Key == "default_program" {
+			haveDefaultProgram = true
+		}
+	}
+	if !haveDefaultProgram {
+		t.Fatalf("config list --json missing default_program: %s", out.String())
+	}
+}

--- a/daemoncmd.go
+++ b/daemoncmd.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/task"
@@ -64,9 +66,123 @@ var daemonUninstallCmd = &cobra.Command{
 	},
 }
 
+// daemonStatusJSON switches `af daemon status` to the shared {data,error}
+// envelope. Local to this command (like `af api`'s --json) — there is no
+// bare-vs-envelope legacy to preserve.
+var daemonStatusJSON bool
+
+// daemonStatusInfo is the read-only liveness/topology snapshot printed by
+// `af daemon status`. It is derived entirely from daemon.Health() (the same
+// no-spawn probe `af doctor` uses) plus an os.Stat of the HTTP socket, so the
+// command never dials or starts a daemon and needs no new RPC.
+type daemonStatusInfo struct {
+	Running           bool   `json:"running"`
+	ControlSocket     string `json:"control_socket"`
+	ControlSocketFile bool   `json:"control_socket_file"`
+	HTTPSocket        string `json:"http_socket"`
+	HTTPSocketFile    bool   `json:"http_socket_file"`
+	PID               int    `json:"pid"`
+	PIDVerified       bool   `json:"pid_verified"`
+	AutostartUnit     bool   `json:"autostart_unit"`
+	BinaryStale       bool   `json:"binary_stale"`
+}
+
+// collectDaemonStatus builds a daemonStatusInfo from the read-only health
+// probe. httpSocketPath is resolved separately (its own path helper) and
+// stat'd; a missing config dir leaves the field empty rather than erroring, so
+// status still reports the control-plane facts.
+func collectDaemonStatus() daemonStatusInfo {
+	h := daemon.Health()
+	info := daemonStatusInfo{
+		Running:           h.PingErr == nil,
+		ControlSocket:     h.SocketPath,
+		ControlSocketFile: h.SocketExists,
+		PID:               h.PIDFilePID,
+		PIDVerified:       h.PIDVerified,
+		AutostartUnit:     h.AutostartUnit,
+		BinaryStale:       h.BinaryDeleted,
+	}
+	if httpPath, err := daemon.DaemonHTTPSocketPath(); err == nil {
+		info.HTTPSocket = httpPath
+		if _, err := os.Stat(httpPath); err == nil {
+			info.HTTPSocketFile = true
+		}
+	}
+	return info
+}
+
+// printDaemonStatusHuman renders the snapshot as a short human report mirroring
+// the wording `af doctor` uses for the daemon check.
+func printDaemonStatusHuman(cmd *cobra.Command, info daemonStatusInfo) {
+	w := cmd.OutOrStdout()
+	if info.Running {
+		fmt.Fprintln(w, "daemon: running")
+	} else {
+		fmt.Fprintln(w, "daemon: not running (starts on demand when you run af with an enabled task)")
+	}
+	fmt.Fprintf(w, "  control socket: %s (%s)\n", info.ControlSocket, presence(info.ControlSocketFile))
+	if info.HTTPSocket != "" {
+		fmt.Fprintf(w, "  http socket:    %s (%s)\n", info.HTTPSocket, presence(info.HTTPSocketFile))
+	}
+	if info.PID > 0 {
+		pidNote := "unverified"
+		if info.PIDVerified {
+			pidNote = "verified"
+		}
+		fmt.Fprintf(w, "  pid:            %d (%s)\n", info.PID, pidNote)
+	} else {
+		fmt.Fprintln(w, "  pid:            (no daemon.pid on disk)")
+	}
+	if info.AutostartUnit {
+		fmt.Fprintln(w, "  autostart:      installed")
+	} else {
+		fmt.Fprintln(w, "  autostart:      not installed (`af daemon install` to keep schedules running across reboots)")
+	}
+	if info.BinaryStale {
+		fmt.Fprintf(w, "  warning:        pid %d is running a binary since replaced on disk — restart the daemon to pick up the new version\n", info.PID)
+	}
+}
+
+// presence is the file-present/absent label shared by the two socket lines.
+func presence(exists bool) string {
+	if exists {
+		return "present"
+	}
+	return "absent"
+}
+
+var daemonStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Report daemon liveness, sockets, pid, and autostart",
+	Long: `Print a read-only snapshot of the background daemon: whether it is responding
+on the control socket, the control and HTTP socket paths (and whether their
+files are present), the recorded pid and whether it is a verified af daemon,
+whether the autostart unit is installed, and whether the running daemon is on a
+since-replaced binary.
+
+It never contacts a paused daemon in a way that spawns one and never starts the
+daemon — it uses the same no-spawn health probe as af doctor. Use --json for a
+machine-readable form wrapped in the shared {data,error} envelope.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		info := collectDaemonStatus()
+		if daemonStatusJSON {
+			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(info))
+		}
+		printDaemonStatusHuman(cmd, info)
+		return nil
+	},
+}
+
 func init() {
+	daemonStatusCmd.Flags().BoolVar(&daemonStatusJSON, "json", false,
+		"Emit the status as JSON wrapped in the {data,error} envelope")
 	daemonCmd.AddCommand(daemonInstallCmd)
 	daemonCmd.AddCommand(daemonUninstallCmd)
+	daemonCmd.AddCommand(daemonStatusCmd)
 }
 
 // respawnDaemonFn is indirected so upgrade/auto-update tests can observe the

--- a/daemonstatuscmd_test.go
+++ b/daemonstatuscmd_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestCollectDaemonStatusNoDaemon runs the read-only probe against a fresh
+// temp home where no daemon is running: it must report not-running and resolve
+// both socket paths under that home without dialing or spawning anything.
+func TestCollectDaemonStatusNoDaemon(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	info := collectDaemonStatus()
+	if info.Running {
+		t.Fatal("expected Running=false with no daemon in a fresh home")
+	}
+	if !strings.HasPrefix(info.ControlSocket, home) {
+		t.Fatalf("control socket %q not under temp home %q", info.ControlSocket, home)
+	}
+	if !strings.HasPrefix(info.HTTPSocket, home) {
+		t.Fatalf("http socket %q not under temp home %q", info.HTTPSocket, home)
+	}
+	if info.ControlSocketFile || info.HTTPSocketFile {
+		t.Fatal("no socket files should exist in a fresh home")
+	}
+}
+
+func TestPrintDaemonStatusHumanRunning(t *testing.T) {
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	printDaemonStatusHuman(cmd, daemonStatusInfo{
+		Running:           true,
+		ControlSocket:     "/h/daemon.sock",
+		ControlSocketFile: true,
+		HTTPSocket:        "/h/daemon-http.sock",
+		HTTPSocketFile:    true,
+		PID:               42,
+		PIDVerified:       true,
+		AutostartUnit:     true,
+		BinaryStale:       true,
+	})
+	got := out.String()
+	for _, want := range []string{
+		"daemon: running",
+		"control socket: /h/daemon.sock (present)",
+		"http socket:    /h/daemon-http.sock (present)",
+		"pid:            42 (verified)",
+		"autostart:      installed",
+		"warning:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("human output missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestPrintDaemonStatusHumanNotRunning(t *testing.T) {
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	printDaemonStatusHuman(cmd, daemonStatusInfo{
+		Running:           false,
+		ControlSocket:     "/h/daemon.sock",
+		ControlSocketFile: false,
+	})
+	got := out.String()
+	if !strings.Contains(got, "not running") {
+		t.Errorf("expected not-running line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "(absent)") {
+		t.Errorf("expected absent socket label, got:\n%s", got)
+	}
+	if !strings.Contains(got, "no daemon.pid on disk") {
+		t.Errorf("expected empty-pid line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "af daemon install") {
+		t.Errorf("expected autostart install hint, got:\n%s", got)
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -174,6 +174,13 @@ The removal is persistent (the daemon won't respawn it). The agent tab can't be
 deleted — use `kill` to tear down the whole session. Not available for remote
 sessions.
 
+### `af sessions tabs {create,delete}`
+
+Noun-subcommand aliases for the two verbs above: `af sessions tabs create` is
+identical to `af sessions tab-create`, and `af sessions tabs delete` is identical
+to `af sessions tab-delete` (same flags, same output). The hyphen verbs remain
+supported — nothing is renamed. To list a session's tabs, use `af sessions get`.
+
 ### `af sessions preview <title>`
 
 Snapshot the session's terminal pane. Emits `{"title": "<title>", "content":
@@ -347,7 +354,44 @@ exists; installing an autostart unit keeps schedules firing after reboots. See
 ```bash
 af daemon install      # register autostart at login (systemd user unit / launchd agent)
 af daemon uninstall    # remove the autostart unit (the daemon still starts on demand)
+af daemon status       # read-only health snapshot (see below); add --json for the envelope
 ```
+
+### `af daemon status`
+
+Print a read-only snapshot of the daemon: whether it is responding on the
+control socket, the control and HTTP socket paths (and whether their files are
+present), the recorded pid and whether it is a verified `af` daemon, whether the
+autostart unit is installed, and whether a running daemon is on a since-replaced
+binary. It uses the same no-spawn health probe as `af doctor`, so it never
+contacts a paused daemon in a way that starts one. `--json` emits
+`{running, control_socket, control_socket_file, http_socket, http_socket_file,
+pid, pid_verified, autostart_unit, binary_stale}` in the shared envelope.
+
+---
+
+## `af config`
+
+Read keys from the **global** config (`~/.agent-factory/config.toml`) so scripts
+and agents can discover the current settings without hand-parsing TOML.
+**Read-only** (config is file-owned, hand-edited; there is no daemon RPC for it),
+and it reports the effective global values with defaults applied — i.e. what a
+session sees before any in-repo `.agent-factory/config.toml` override is layered
+on. **Text output**, or `--json` for the shared envelope.
+
+```bash
+af config list                     # every key and its effective value
+af config get default_program      # one key; scalars print bare (script-friendly)
+af config get program_overrides    # composite values print as JSON
+af config list --json              # [{key, value}, …] wrapped in the envelope
+```
+
+Known keys: `default_program`, `program_overrides`, `auto_yes`,
+`daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`,
+`detach_keys`, `update_channel`, `root_agents`, `limit_patterns`, `keys`. To
+change a value, edit `config.toml` directly — see
+[configuration.md](configuration.md). A CLI write path (`config set`) is tracked
+in [#1192](https://github.com/sachiniyer/agent-factory/issues/1192).
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,8 @@ af sessions send-prompt <title> "..."                     # append a prompt to a
 af sessions send-prompt <title> "..." --create            # send-or-create
 af sessions tab-create <title> --command "<cmd>"          # spawn a process tab in the session's worktree
 af sessions tab-delete <title> --name <tab>               # delete a single tab (the daemon won't respawn it)
+af sessions tabs create <title> --command "<cmd>"         # alias for tab-create (hyphen verb still works)
+af sessions tabs delete <title> --name <tab>              # alias for tab-delete
 af sessions preview <title>                               # snapshot the session's pane
 af sessions attach <title>                                # attach interactively (foreground)
 af sessions whoami                                        # report the session this shell is inside
@@ -42,6 +44,7 @@ Flags:
 - `send-prompt`: `--create` auto-creates the session if it doesn't exist; `--program` picks the agent when creating.
 - `tab-create`: `--command` (required) is run in the session's git worktree as a new tab; `--name` sets the tab's display name (defaults to the command's basename, auto-suffixed `-2`, `-3`, … on collision). The resolved tab name is printed as `{"name": "..."}` so scripts/agents can address it. The tab persists and reconnects across a daemon/`af` restart like every other tab. Refused once a session already holds 9 tabs. **Not available for remote sessions:** they have no local worktree and the hook protocol can't run arbitrary commands — a remote session's only terminal tab comes from `remote_hooks.terminal_cmd` (see [remote-hooks.md](remote-hooks.md)).
 - `tab-delete`: the counterpart of `tab-create` — `--name` (required) selects the tab to delete. The tab is removed from the daemon's session state and its tmux window is killed; the removal is persistent (the daemon won't respawn it, and it doesn't return on restart). The deleted tab's name is printed as `{"name": "..."}`. The agent tab can't be deleted — use `af sessions kill` to tear down the whole session. Targeting a missing tab or session is an error. Not available for remote sessions (their tabs are fixed by `remote_hooks` config).
+- `tabs {create,delete}`: additive noun-subcommand aliases — `af sessions tabs create` == `af sessions tab-create` and `af sessions tabs delete` == `af sessions tab-delete` (same flags and output). The hyphen verbs are kept for existing scripts; nothing is renamed. There is no `tabs list` — list a session's tabs via `af sessions get`.
 - `archive`: tears down the session's tmux and **moves its git worktree** out to the global archive directory (`<AGENT_FACTORY_HOME>/archived/<repoID>/<title>/`), preserving the branch and any uncommitted changes. The session is not deleted — it becomes a quiescent **archived** row that survives restarts and is never auto-restored. Prints `{"ok": true, "title": "...", "archived_path": "..."}`. Not available for remote or in-place (`--here`) sessions (they don't own a relocatable worktree). Bring it back with `restore`.
 - `restore`: the counterpart of `archive` — moves the worktree back next to the repo, re-registers it, re-spawns **only the agent** (shell/process tabs are not restored), and marks the session running. Prints `{"ok": true, "title": "...", "worktree_path": "..."}`. Fails if the session isn't archived, or if its origin repo is gone (the archived worktree is left intact for manual recovery). Honors `--repo` like `kill`.
 
@@ -68,7 +71,21 @@ The background daemon hosts task cron schedules, watch-task scripts, and autoyes
 ```bash
 af daemon install      # register autostart at login
 af daemon uninstall    # remove the autostart unit (the daemon still starts on demand)
+af daemon status       # read-only health snapshot: running?, socket paths, pid, autostart (+ --json)
 ```
+
+`af daemon status` uses the same no-spawn probe as `af doctor` — it reports whether the daemon answers on the control socket, the control/HTTP socket paths and file presence, the recorded (and verified) pid, whether the autostart unit is installed, and whether a running daemon is on a since-replaced binary. It never dials in a way that starts a daemon.
+
+## `af config`
+
+Read the **global** config (`~/.agent-factory/config.toml`) from the CLI. Read-only — config is a hand-edited file, not daemon-owned — reporting the effective global values with defaults applied. `--json` wraps output in the shared envelope.
+
+```bash
+af config list                     # every key and its effective value
+af config get <key>                # one key (scalars print bare; maps as JSON)
+```
+
+Known keys: `default_program`, `program_overrides`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `detach_keys`, `update_channel`, `root_agents`, `limit_patterns`, `keys`. To change a value, edit `config.toml` directly (see [configuration.md](configuration.md)); a CLI write path is tracked in [#1192](https://github.com/sachiniyer/agent-factory/issues/1192).
 
 ## Maintenance commands
 

--- a/main.go
+++ b/main.go
@@ -284,6 +284,7 @@ func init() {
 	rootCmd.AddCommand(resetCmd)
 	rootCmd.AddCommand(upgradeCmd)
 	rootCmd.AddCommand(daemonCmd)
+	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(api.SessionsCmd)
 	rootCmd.AddCommand(api.TasksCmd)
 	rootCmd.AddCommand(api.APICmd)


### PR DESCRIPTION
Additive CLI/API polish deferred from the #1029 HTTP+CLI epic (the optional PR6 grab-bag). Everything here is **non-breaking** — every existing verb keeps working; this only *adds* surface, which matters because external users script `af`.

Implements 2½ of the 3 nits in #1192; `config set` is scoped out with rationale (below), so this is **Part of #1192**, not a full close.

## What's added

### `af daemon status`
Read-only liveness/topology snapshot, built entirely on the existing no-spawn health probe `af doctor` uses (`daemon.Health()`) plus an `os.Stat` of the HTTP socket. **No new daemon RPC, no daemon-startup change, never spawns/starts a daemon.** Reports: responding on the control socket?, control + HTTP socket paths and file presence, recorded + verified pid, autostart unit installed?, and stale-binary warning. `--json` emits the shared `{data,error}` envelope.

```
$ af daemon status
daemon: running
  control socket: ~/.agent-factory/daemon.sock (present)
  http socket:    ~/.agent-factory/daemon-http.sock (present)
  pid:            12345 (verified)
  autostart:      installed
```

### `af sessions tabs {create,delete}`
Noun-subcommand aliases for `sessions tab-create` / `sessions tab-delete`, sharing the exact same `RunE` bodies and flag globals. The hyphen verbs stay first-class — **nothing is renamed**. There is no `tabs list` (tabs are listed via `sessions get`), matching the existing surface. Inherits the `--repo` / `--json` persistent flags like every other `sessions` subcommand.

### `af config get <key>` / `af config list`
Read-only view over the **global** `~/.agent-factory/config.toml` so scripts/agents can discover settings without hand-parsing TOML. Config is **file-owned and hand-edited — not daemon-owned**, so there is no single-writer (#960) race; get/list read the effective global values with defaults applied. Scalars print bare (`af config get default_program` → `claude`, script-friendly); composite keys print as JSON. `--json` wraps in the envelope.

## Why `config set` is deferred (kept open on #1192)
`set` is not a nit — it needs a real design pass: (1) a settable-key allowlist, (2) validation reuse (`ValidateProgramEnum` et al.), and critically (3) a **comment-preserving TOML write** — the repo's `go-toml/v2` `Marshal` regenerates the file and would silently strip the comments/ordering of a config the README explicitly tells users to hand-edit. Rewriting a hand-edited file on first `config set` is exactly the kind of surprise that hurts external users, so `set` gets its own scoped follow-up rather than a guess here.

## HTTP mirror
No change needed. All three are CLI-only: `daemon status` is a client-side view over the already-existing `GET /v1/health`, and `config`/`tabs` add no daemon RPCs. The `af api` catalog (derived from `daemon.HTTPRoutes()`) stays accurate.

## Tests & docs
- New unit tests: config helpers + get/list output & envelope (`configcmd_test.go`), `daemon status` probe + human render (`daemonstatuscmd_test.go`), tabs alias registration + hyphen-verb retention (`api/sessions_tabs_test.go`).
- Docs: `docs/cli.md`, `docs/cli-reference.md`, `README.md`.

## Gates (all green)
- `gofmt -l .` empty · `go build ./...` · `golangci-lint run --fast` clean · `deadcode -test ./...` clean · file-length lint pass · **`make test-container` full suite green** (incl. daemon/integration/app).

Part of #1192.

Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)