### PR TITLE
feat(limit): daemon auto-resume scheduler, opt-in (#1146) [PR 3/4]

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -172,6 +172,23 @@ type Config struct {
 	// without a release. Empty keeps every built-in default. See
 	// sanitizeLimitPatterns in limit_patterns.go for validation and semantics.
 	LimitPatterns map[string]string `json:"limit_patterns,omitempty" toml:"limit_patterns,omitempty"`
+	// LimitAutoResume opts a machine into the daemon's usage-limit auto-resume
+	// scheduler (#1146 PR3): when true, the daemon re-prompts a session parked at
+	// a usage-limit wall on its own once the limit window has elapsed (its parsed
+	// reset time + a grace buffer, or limit_retry_interval when the banner carried
+	// no parseable reset time). DEFAULT FALSE — opt-in for the first release. When
+	// false a limit is surface-only (the sidebar [limit] badge and the manual `c`
+	// retry from PR2) and the scheduler does zero work. Deliberately GLOBAL-ONLY
+	// (it configures daemon behavior), like auto_yes / daemon_poll_interval.
+	LimitAutoResume bool `json:"limit_auto_resume" toml:"limit_auto_resume"`
+	// LimitRetryInterval is the fixed fallback cadence the auto-resume scheduler
+	// uses ONLY when a usage-limit banner carried no parseable reset time (#1146
+	// PR3): a Go duration string ("30m", "1h"). Empty or a non-positive duration
+	// disables the fallback, leaving a no-reset-time limit surface-only even with
+	// limit_auto_resume on. Ignored when limit_auto_resume is false, or when a
+	// reset time WAS parsed (that schedules against the reset time + grace).
+	// Global-only, like limit_auto_resume. See LimitRetryIntervalDuration.
+	LimitRetryInterval string `json:"limit_retry_interval" toml:"limit_retry_interval"`
 	// Keys is the raw [keys] rebinding table (#1026): action name → a key
 	// string or list of key strings, replacing that action's default binding
 	// entirely (unlisted actions keep their defaults). TOML-ONLY by design —
@@ -284,6 +301,8 @@ func DefaultConfig() *Config {
 		DefaultProgram:     defaultProgram,
 		AutoYes:            false,
 		DaemonPollInterval: defaultDaemonPollInterval,
+		LimitAutoResume:    false,
+		LimitRetryInterval: defaultLimitRetryInterval,
 		LogMaxSizeMB:       log.DefaultMaxSizeMB,
 		LogMaxBackups:      log.DefaultMaxBackups,
 		UpdateChannel:      UpdateChannelStable,
@@ -998,6 +1017,7 @@ func validateConfig(config *Config, prettyConfigPath string) (*Config, error) {
 	}
 
 	sanitizeLimitPatterns(config)
+	config.LimitRetryInterval = sanitizeLimitRetryInterval(config.LimitRetryInterval, prettyConfigPath)
 
 	if config.DaemonPollInterval <= 0 {
 		log.WarningLog.Printf("daemon_poll_interval=%d is non-positive; using default %dms", config.DaemonPollInterval, defaultDaemonPollInterval)

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -92,12 +92,14 @@ var inRepoGlobalOnlyKeys = map[string]bool{
 	"detach_keys":          true,
 	// The [keys] keymap is a user/host preference: a cloned repo must never
 	// be able to rebind someone's terminal (#1026).
-	"keys":            true,
-	"log_max_backups": true,
-	"log_max_size_mb": true,
-	"root_agents":     true,
-	"update_channel":  true,
-	"worktree_root":   true,
+	"keys":                 true,
+	"limit_auto_resume":    true,
+	"limit_retry_interval": true,
+	"log_max_backups":      true,
+	"log_max_size_mb":      true,
+	"root_agents":          true,
+	"update_channel":       true,
+	"worktree_root":        true,
 }
 
 // tomlOnlyGlobalKeys is the subset of inRepoGlobalOnlyKeys that exists only in

--- a/config/limit_patterns.go
+++ b/config/limit_patterns.go
@@ -3,10 +3,55 @@ package config
 import (
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
+
+// defaultLimitRetryInterval is the fallback cadence for auto-resuming a
+// usage-limit-blocked session whose banner carried no parseable reset time
+// (#1146 PR3). Only consulted when limit_auto_resume is enabled, so it is
+// harmless while the feature is off by default.
+const defaultLimitRetryInterval = "30m"
+
+// LimitRetryIntervalDuration returns the parsed limit_retry_interval (#1146
+// PR3), or 0 when it is unset or disables the fallback. The value is validated
+// at load (sanitizeLimitRetryInterval), so a parse error here degrades safely to
+// 0 — surface-only for a no-parseable-reset-time limit.
+func (c *Config) LimitRetryIntervalDuration() time.Duration {
+	if c.LimitRetryInterval == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(c.LimitRetryInterval)
+	if err != nil || d < 0 {
+		return 0
+	}
+	return d
+}
+
+// sanitizeLimitRetryInterval validates the limit_retry_interval duration string
+// (#1146 PR3). An empty string is the explicit "no fallback" value and is kept.
+// A non-empty value must parse as a non-negative Go duration; anything else
+// warns and falls back to the default so a typo can neither silently disable
+// auto-resume nor mis-time it.
+func sanitizeLimitRetryInterval(raw, prettyConfigPath string) string {
+	if raw == "" {
+		return ""
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.WarningLog.Printf("Config issue in %s: limit_retry_interval=%q is not a valid duration (%v); using default %q",
+			prettyConfigPath, raw, err, defaultLimitRetryInterval)
+		return defaultLimitRetryInterval
+	}
+	if d < 0 {
+		log.WarningLog.Printf("Config issue in %s: limit_retry_interval=%q is negative; using default %q",
+			prettyConfigPath, raw, defaultLimitRetryInterval)
+		return defaultLimitRetryInterval
+	}
+	return raw
+}
 
 // sanitizeLimitPatterns validates the limit_patterns override map in place,
 // dropping any entry that names an unknown agent or whose value is not a

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1324,6 +1324,10 @@ type Manager struct {
 	// restore loop (#1108 PR 2), keyed by daemon instance key — the general
 	// sibling of rootEnsureStates.
 	lostRestoreStates map[string]*lostRestoreState
+	// limitResumeStates tracks per-session retry state for the usage-limit
+	// auto-resume scheduler (#1146 PR3), keyed by daemon instance key — the
+	// opt-in sibling of lostRestoreStates. Guarded by m.mu.
+	limitResumeStates map[string]*limitResumeState
 	// instanceOpLocks serializes the mutually-exclusive per-session
 	// operations — kill teardown and Lost-recovery — by daemon instance key.
 	// killsInFlight alone is a point-in-time signal; this lock is what makes
@@ -1387,6 +1391,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		rootKilledByUser:    make(map[string]struct{}),
 		killsInFlight:       make(map[string]struct{}),
 		lostRestoreStates:   make(map[string]*lostRestoreState),
+		limitResumeStates:   make(map[string]*limitResumeState),
 		instanceOpLocks:     make(map[string]*sync.Mutex),
 		pausedPolls:         make(map[string]time.Time),
 	}, nil
@@ -2753,13 +2758,4 @@ func ghostCleanup(data *session.InstanceData, title string) {
 		}
 	}
 	ghostCleanupWorktree(data, title)
-}
-
-func splitDaemonInstanceKey(key string) (string, string) {
-	for i := 0; i < len(key); i++ {
-		if key[i] == 0 {
-			return key[:i], key[i+1:]
-		}
-	}
-	return "", key
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -201,6 +201,14 @@ func RunDaemon(cfg *config.Config) error {
 			// root title). Backoff-throttled per session, like root-ensure.
 			manager.RestoreLostSessions()
 
+			// Opt-in auto-resume of usage-limit-blocked sessions (#1146 PR3):
+			// re-prompt a LiveLimitReached row once its limit window elapsed. A
+			// no-op unless limit_auto_resume is set, so a default install keeps
+			// a limit surface-only. Runs after RestoreLostSessions because a
+			// session must be settled onto its liveness first; it borrows the
+			// same per-session op-lock discipline.
+			manager.ResumeLimitedSessions()
+
 			// Handle stop before ticker.
 			select {
 			case <-stopCh:
@@ -400,6 +408,18 @@ func refreshDaemonInstances(existing map[string]*session.Instance) (map[string]*
 
 func daemonInstanceKey(repoID, title string) string {
 	return repoID + "\x00" + title
+}
+
+// splitDaemonInstanceKey is the inverse of daemonInstanceKey: it splits a
+// "<repoID>\x00<title>" key back into (repoID, title). A key with no NUL
+// separator (unexpected) is returned as ("", key).
+func splitDaemonInstanceKey(key string) (string, string) {
+	for i := 0; i < len(key); i++ {
+		if key[i] == 0 {
+			return key[:i], key[i+1:]
+		}
+	}
+	return "", key
 }
 
 func daemonInstances(instanceMap map[string]*session.Instance) []*session.Instance {

--- a/daemon/limitresume.go
+++ b/daemon/limitresume.go
@@ -1,0 +1,235 @@
+package daemon
+
+import (
+	"sort"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The usage-limit auto-resume scheduler (#1146 PR3): the opt-in daemon loop that
+// re-prompts a session parked at a usage-limit wall once its limit window has
+// elapsed. It is the automated sibling of the PR2 manual `c` retry and the
+// Lost-session restore loop (lostrestore.go) — same poll-goroutine discipline
+// (TryLock the per-session op lock, re-verify under it, back off on repeat) —
+// and it reuses the exact resumeFromLimit action the manual retry uses, so the
+// resume mechanics (re-spawn if the agent exited, re-deliver the stored prompt,
+// clear the limit) live in one place.
+//
+// Gated by config.LimitAutoResume (default OFF): when off, ResumeLimitedSessions
+// returns immediately and a limit stays surface-only (badge + manual retry).
+// When on, a LiveLimitReached row is resumed at limitResumeAt = its parsed reset
+// time + limitResumeGrace; a row whose banner carried NO parseable reset time is
+// retried on the fixed config.LimitRetryInterval fallback, or left surface-only
+// when that fallback is unset. A resume that itself re-hits the wall (the row
+// re-enters LiveLimitReached) is re-scheduled under exponential backoff so the
+// daemon never hammers a genuinely-exhausted plan. All comparisons are in UTC —
+// limitResetAt is stored UTC by the detector.
+
+// limitResumeGrace is added to a parsed reset time before a session is
+// auto-resumed (#1146). Usage-limit windows are rolling and approximate and the
+// banner's stated reset time is a lower bound, so a small buffer avoids resuming
+// straight back into a still-limited wall and immediately re-parking.
+const limitResumeGrace = 2 * time.Minute
+
+// Backoff between repeat auto-resume attempts for one session — a resume that
+// re-hits the wall, or a resumeFromLimit that errors. Package vars so tests can
+// shorten them (same pattern as lostRestoreBackoff*). Mirrors the lostrestore
+// discipline: exponential from base, settling at max, never a permanent
+// give-up. The no-parseable-reset-time fallback uses the fixed configured
+// interval instead of this backoff (see limitResumeAttempted).
+var (
+	limitResumeBackoffBase = 10 * time.Second
+	limitResumeBackoffMax  = 5 * time.Minute
+)
+
+// limitResumeState is the per-session auto-resume retry state, keyed by daemon
+// instance key and guarded by Manager.mu (the loop runs on the poll goroutine;
+// tests drive ResumeLimitedSessions directly). parkedAt anchors the
+// no-parseable-reset-time fallback interval (the first tick the session was seen
+// parked); nextAttempt is the backoff gate that ALSO survives the brief non-limit
+// window between resumeFromLimit clearing the limit and the next poll re-detecting
+// the banner, so an immediate re-limit continues the backoff instead of hammering.
+type limitResumeState struct {
+	attempts    int
+	nextAttempt time.Time
+	parkedAt    time.Time
+}
+
+// ResumeLimitedSessions runs one auto-resume pass over every LiveLimitReached
+// session the manager owns (#1146 PR3). A no-op when limit_auto_resume is off or
+// the manager is still warming up — the whole feature is opt-in and does zero
+// scheduling otherwise. Called from the daemon poll loop after
+// RestoreLostSessions. Mirrors RestoreLostSessions: snapshot under m.mu, prune
+// dead/resolved retry state, then attempt each session in a stable order so the
+// logs read coherently.
+func (m *Manager) ResumeLimitedSessions() {
+	if !m.cfg.LimitAutoResume || !m.Ready() {
+		return
+	}
+	retryInterval := m.cfg.LimitRetryIntervalDuration()
+
+	type entry struct {
+		key      string
+		repoID   string
+		instance *session.Instance
+	}
+	now := nowFunc()
+	m.mu.Lock()
+	entries := make([]entry, 0, len(m.instances))
+	for key, inst := range m.instances {
+		repoID, _ := splitDaemonInstanceKey(key)
+		entries = append(entries, entry{key: key, repoID: repoID, instance: inst})
+	}
+	// Drop retry state for sessions that are gone, or that have stayed OUT of
+	// LimitReached past their backoff window (a resume that stuck — the episode
+	// is over). State is deliberately KEPT for a row that is momentarily
+	// non-limit within its backoff window: that window is the gap between
+	// resumeFromLimit clearing the limit and the next poll re-detecting the
+	// banner, and keeping the state there is what throttles an immediate
+	// re-limit instead of restarting it at attempt zero.
+	for key, inst := range m.instances {
+		st := m.limitResumeStates[key]
+		if st == nil {
+			continue
+		}
+		if inst.GetLiveness() != session.LiveLimitReached && !now.Before(st.nextAttempt) {
+			delete(m.limitResumeStates, key)
+		}
+	}
+	for key := range m.limitResumeStates {
+		if _, live := m.instances[key]; !live {
+			delete(m.limitResumeStates, key)
+		}
+	}
+	m.mu.Unlock()
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
+	for _, e := range entries {
+		m.resumeLimitedSession(e.key, e.repoID, e.instance, retryInterval)
+	}
+}
+
+// resumeLimitedSession auto-resumes one session when it is eligible and its
+// limit window has elapsed. Eligibility mirrors restoreLostSession: started,
+// LiveLimitReached, not tombstoned, not the reserved root (the manual retry and
+// the poll own those), and no kill in flight. The op lock is only TryLock'd so
+// the poll goroutine never stalls behind a kill teardown; everything is
+// re-verified under it because the checks above are point-in-time. The resume
+// itself is the shared resumeFromLimit action (PR2), which takes its own target
+// lock and re-verifies the limit state once more before acting.
+func (m *Manager) resumeLimitedSession(key, repoID string, inst *session.Instance, retryInterval time.Duration) {
+	if inst == nil || !inst.Started() || inst.GetLiveness() != session.LiveLimitReached {
+		return
+	}
+	if inst.UserKilled() || session.IsReservedTitle(inst.Title) {
+		return
+	}
+
+	now := nowFunc()
+	m.mu.Lock()
+	if _, killing := m.killsInFlight[key]; killing {
+		m.mu.Unlock()
+		return
+	}
+	resetAt, hasReset := inst.LimitResetAt()
+	if !hasReset && retryInterval <= 0 {
+		// No parseable reset time and no fallback interval: the session is
+		// surface-only. Return WITHOUT creating retry state so unschedulable
+		// parks never accumulate a map entry.
+		m.mu.Unlock()
+		return
+	}
+	st := m.limitResumeStates[key]
+	if st == nil {
+		st = &limitResumeState{parkedAt: now}
+		m.limitResumeStates[key] = st
+	}
+	// due = when this session first becomes eligible. With a parsed reset time it
+	// is reset + grace (a reset already in the past yields a due in the past →
+	// resume promptly); with no reset time it is the fixed fallback interval
+	// measured from when the session was first seen parked. All in UTC.
+	due := st.parkedAt.Add(retryInterval)
+	if hasReset {
+		due = resetAt.Add(limitResumeGrace)
+	}
+	// The per-attempt backoff/interval gate sits on top of the due time, so the
+	// first fire lands at due and repeats are throttled.
+	if st.nextAttempt.After(due) {
+		due = st.nextAttempt
+	}
+	skip := now.Before(due)
+	m.mu.Unlock()
+	if skip {
+		return
+	}
+
+	opLock := m.opLockFor(key)
+	if !opLock.TryLock() {
+		// A kill (or its finish pass) holds the session; retry next tick.
+		return
+	}
+	defer opLock.Unlock()
+
+	// Re-verify under the lock: a kill may have torn the session down, a
+	// self-recovery or the manual retry may have cleared the limit, or the map
+	// entry may have been replaced since the point-in-time checks above. Resume
+	// only what is still provably a wanted, limit-blocked session.
+	m.mu.Lock()
+	current := m.instances[key]
+	_, killing := m.killsInFlight[key]
+	m.mu.Unlock()
+	if killing || current != inst || inst.UserKilled() || session.IsReservedTitle(inst.Title) || inst.GetLiveness() != session.LiveLimitReached {
+		return
+	}
+
+	// Whether this episode carried a parseable reset time, captured BEFORE the
+	// resume: resumeFromLimit clears the limit (and the reset time) on success,
+	// so it cannot be read back afterwards. It selects the re-schedule cadence.
+	_, hadReset := inst.LimitResetAt()
+
+	// Record the attempt and set the backoff/interval gate BEFORE firing, so a
+	// resume that re-hits the wall on the very next tick is already throttled —
+	// never a hot re-limit loop.
+	attempts, wait := m.limitResumeAttempted(st, now, hadReset, retryInterval)
+
+	if err := m.resumeFromLimit(ResumeFromLimitRequest{Title: inst.Title, RepoID: repoID}); err != nil {
+		log.WarningLog.Printf("auto-resume of limit-blocked session %q failed (attempt %d), backing off %s: %v", inst.Title, attempts, wait, err)
+		return
+	}
+	log.InfoLog.Printf("auto-resumed limit-blocked session %q (repo %s) after its usage-limit window elapsed (attempt %d)", inst.Title, repoID, attempts)
+}
+
+// limitResumeAttempted records one auto-resume attempt and sets the gate for the
+// next one, returning the new attempt count and the wait applied (#1146). With a
+// parsed reset time (or when no fixed fallback interval applies) repeats back off
+// exponentially — doubling from base, settling at max, never a permanent
+// give-up, mirroring lostRestoreFailed. With no reset time and a configured
+// interval, repeats use that fixed interval (§4: "retry on that fixed
+// interval"). Must be called with attempts reflecting THIS fire, so it increments
+// first. Guarded by m.mu.
+func (m *Manager) limitResumeAttempted(st *limitResumeState, now time.Time, hadReset bool, retryInterval time.Duration) (int, time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st.attempts++
+	wait := retryInterval
+	if hadReset || retryInterval <= 0 {
+		wait = limitResumeBackoffFor(st.attempts)
+	}
+	st.nextAttempt = now.Add(wait)
+	return st.attempts, wait
+}
+
+// limitResumeBackoffFor is the exponential backoff for the nth attempt (n>=1):
+// base<<(n-1), capped at max. The shift is guarded like lostRestoreFailed's —
+// past ~16 doublings the exponential form is meaningless and would overflow.
+func limitResumeBackoffFor(attempts int) time.Duration {
+	backoff := limitResumeBackoffMax
+	if shift := attempts - 1; shift >= 0 && shift < 16 {
+		if b := limitResumeBackoffBase << shift; b < backoff {
+			backoff = b
+		}
+	}
+	return backoff
+}

--- a/daemon/limitresume_test.go
+++ b/daemon/limitresume_test.go
@@ -1,0 +1,255 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The usage-limit auto-resume scheduler tests (#1146 PR3). Every test drives the
+// injected clock (withFrozenClock swaps nowFunc) rather than the wall clock, so
+// due-time and backoff assertions are deterministic. They reuse limitResumeBackend
+// (limit_resume_test.go) — its Respawn/SendPromptCommand instrumentation records
+// which resume path ran and what prompt was re-delivered.
+
+// newAutoResumeManager builds a status test manager with limit_auto_resume
+// enabled and the given fallback interval, plus a limitResumeBackend session
+// parked at a usage-limit wall (LiveLimitReached with resetAt). alive selects the
+// live-stall vs exited-agent arm of resumeFromLimit. Returns the manager, repoID,
+// the parked instance, and its backend.
+func newAutoResumeManager(t *testing.T, retryInterval string, alive bool, prompt string, resetAt time.Time) (*Manager, string, *session.Instance, *limitResumeBackend) {
+	t.Helper()
+	manager, repoID, repoPath := newStatusTestManager(t)
+	manager.cfg.LimitAutoResume = true
+	manager.cfg.LimitRetryInterval = retryInterval
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: alive}
+	inst := registerStarted(t, manager, repoID, repoPath, "limited", backend, true, session.Running)
+	inst.Prompt = prompt
+	inst.SetLimitReached(resetAt)
+	return manager, repoID, inst, backend
+}
+
+// TestResumeLimitedSessions_ResumesAfterWindow is the core PR3 flow: a session
+// parked at a usage-limit wall with a parsed reset time stays untouched until the
+// clock passes reset + limitResumeGrace, then is auto-resumed exactly once — the
+// stored task prompt re-delivered and the limit liveness cleared.
+func TestResumeLimitedSessions_ResumesAfterWindow(t *testing.T) {
+	advance := withFrozenClock(t)
+	base := nowFunc()
+	resetAt := base.Add(time.Hour)
+	manager, _, inst, backend := newAutoResumeManager(t, "", true, "finish the migration", resetAt)
+
+	// Before the window elapses: no resume, still parked.
+	manager.ResumeLimitedSessions()
+	if _, _, prompts := backend.snapshot(); len(prompts) != 0 {
+		t.Fatalf("resume fired before the window elapsed: prompts=%v", prompts)
+	}
+	if !inst.LimitReached() {
+		t.Fatal("session must stay LimitReached before the resume window")
+	}
+
+	// Advance to just before due (reset + grace): still no resume.
+	advance(time.Hour + limitResumeGrace - time.Second)
+	manager.ResumeLimitedSessions()
+	if _, _, prompts := backend.snapshot(); len(prompts) != 0 {
+		t.Fatalf("resume fired a second before due: prompts=%v", prompts)
+	}
+
+	// Advance past due: resume fires exactly once, re-delivering the stored prompt.
+	advance(2 * time.Second)
+	manager.ResumeLimitedSessions()
+	recoverCalls, respawnCalls, prompts := backend.snapshot()
+	if recoverCalls != 0 {
+		t.Fatalf("auto-resume must never route through Recover, got %d calls", recoverCalls)
+	}
+	if respawnCalls != 0 {
+		t.Fatalf("a live stall needs no re-spawn, got %d Respawn calls", respawnCalls)
+	}
+	if len(prompts) != 1 || prompts[0] != "finish the migration" {
+		t.Fatalf("re-delivered prompts = %v, want [\"finish the migration\"]", prompts)
+	}
+	if inst.LimitReached() {
+		t.Fatal("limit liveness must be cleared after auto-resume")
+	}
+}
+
+// TestResumeLimitedSessions_ExitedAgentRespawns: the same flow when the agent's
+// tmux exited while blocked — auto-resume must re-spawn through the guard-free
+// Respawn path (never Recover) before re-delivering the prompt.
+func TestResumeLimitedSessions_ExitedAgentRespawns(t *testing.T) {
+	advance := withFrozenClock(t)
+	base := nowFunc()
+	manager, _, _, backend := newAutoResumeManager(t, "", false, "resume work", base) // alive=false, reset in the past
+
+	advance(limitResumeGrace + time.Second)
+	manager.ResumeLimitedSessions()
+
+	recoverCalls, respawnCalls, prompts := backend.snapshot()
+	if recoverCalls != 0 {
+		t.Fatalf("auto-resume must not touch Recover, got %d calls", recoverCalls)
+	}
+	if respawnCalls != 1 {
+		t.Fatalf("an exited agent must be re-spawned once, got %d Respawn calls", respawnCalls)
+	}
+	if len(prompts) != 1 || prompts[0] != "resume work" {
+		t.Fatalf("re-delivered prompts = %v, want [\"resume work\"]", prompts)
+	}
+}
+
+// TestResumeLimitedSessions_DisabledIsSurfaceOnly: with limit_auto_resume off
+// (the default), the scheduler does ZERO work even long after the reset time —
+// the limit is surface-only (PR2 badge + manual retry).
+func TestResumeLimitedSessions_DisabledIsSurfaceOnly(t *testing.T) {
+	advance := withFrozenClock(t)
+	base := nowFunc()
+	manager, _, inst, backend := newAutoResumeManager(t, "", true, "should not send", base.Add(time.Hour))
+	manager.cfg.LimitAutoResume = false // override the helper's enable
+
+	advance(48 * time.Hour) // well past the reset time
+	manager.ResumeLimitedSessions()
+
+	if _, _, prompts := backend.snapshot(); len(prompts) != 0 {
+		t.Fatalf("auto-resume must not fire when limit_auto_resume is off: prompts=%v", prompts)
+	}
+	if !inst.LimitReached() {
+		t.Fatal("a disabled scheduler must leave the session parked (surface-only)")
+	}
+}
+
+// TestResumeLimitedSessions_KilledBeforeReset: a session tombstoned before its
+// reset time is never resumed — the eligibility guard rejects it — so the clock
+// passing due is a no-op.
+func TestResumeLimitedSessions_KilledBeforeReset(t *testing.T) {
+	advance := withFrozenClock(t)
+	base := nowFunc()
+	manager, _, inst, backend := newAutoResumeManager(t, "", true, "dead work", base.Add(time.Hour))
+	inst.MarkUserKilled()
+
+	advance(2 * time.Hour)
+	manager.ResumeLimitedSessions()
+
+	if _, _, prompts := backend.snapshot(); len(prompts) != 0 {
+		t.Fatalf("a tombstoned session must never be auto-resumed: prompts=%v", prompts)
+	}
+}
+
+// TestResumeLimitedSessions_ArchivedClearsTimer: a session archived after it was
+// seen parked is not resumed, and its retry state is dropped once it leaves the
+// limit liveness past its (never-set) backoff window — the timer is abandoned,
+// no crash, no resurrection.
+func TestResumeLimitedSessions_ArchivedClearsTimer(t *testing.T) {
+	advance := withFrozenClock(t)
+	base := nowFunc()
+	manager, repoID, inst, backend := newAutoResumeManager(t, "", true, "archived work", base.Add(time.Hour))
+	key := daemonInstanceKey(repoID, "limited")
+
+	// First pass (before due) creates the retry state.
+	manager.ResumeLimitedSessions()
+	manager.mu.Lock()
+	_, hasState := manager.limitResumeStates[key]
+	manager.mu.Unlock()
+	if !hasState {
+		t.Fatal("a parked session must record retry state on first sighting")
+	}
+
+	// The session is archived out from under the scheduler.
+	inst.SetLiveness(session.LiveArchived)
+	advance(2 * time.Hour)
+	manager.ResumeLimitedSessions()
+
+	if _, _, prompts := backend.snapshot(); len(prompts) != 0 {
+		t.Fatalf("an archived session must never be auto-resumed: prompts=%v", prompts)
+	}
+	manager.mu.Lock()
+	_, hasState = manager.limitResumeStates[key]
+	manager.mu.Unlock()
+	if hasState {
+		t.Fatal("retry state for a session that left the limit liveness must be dropped")
+	}
+}
+
+// TestResumeLimitedSessions_NoResetTimeFallback: a limit banner with no parseable
+// reset time is retried on the fixed limit_retry_interval fallback — nothing
+// before the interval elapses, then a resume.
+func TestResumeLimitedSessions_NoResetTimeFallback(t *testing.T) {
+	advance := withFrozenClock(t)
+	manager, _, _, backend := newAutoResumeManager(t, "30m", true, "no reset work", time.Time{}) // zero reset
+
+	// First pass anchors parkedAt = now; nothing is due for a full interval.
+	manager.ResumeLimitedSessions()
+	advance(29 * time.Minute)
+	manager.ResumeLimitedSessions()
+	if _, _, prompts := backend.snapshot(); len(prompts) != 0 {
+		t.Fatalf("resume fired before the fallback interval elapsed: prompts=%v", prompts)
+	}
+
+	advance(2 * time.Minute) // past 30m from the first sighting
+	manager.ResumeLimitedSessions()
+	if _, _, prompts := backend.snapshot(); len(prompts) != 1 || prompts[0] != "no reset work" {
+		t.Fatalf("re-delivered prompts = %v, want [\"no reset work\"] after the fallback interval", prompts)
+	}
+}
+
+// TestResumeLimitedSessions_NoResetNoIntervalNeverResumes: a limit banner with no
+// parseable reset time AND no fallback interval (limit_retry_interval empty) is
+// surface-only — never auto-resumed no matter how much time passes.
+func TestResumeLimitedSessions_NoResetNoIntervalNeverResumes(t *testing.T) {
+	advance := withFrozenClock(t)
+	manager, repoID, _, backend := newAutoResumeManager(t, "", true, "orphan work", time.Time{}) // zero reset, no interval
+	key := daemonInstanceKey(repoID, "limited")
+
+	for i := 0; i < 5; i++ {
+		advance(24 * time.Hour)
+		manager.ResumeLimitedSessions()
+	}
+
+	if _, _, prompts := backend.snapshot(); len(prompts) != 0 {
+		t.Fatalf("no reset time and no fallback interval must never auto-resume: prompts=%v", prompts)
+	}
+	// No schedulable state is retained either.
+	manager.mu.Lock()
+	_, hasState := manager.limitResumeStates[key]
+	manager.mu.Unlock()
+	if hasState {
+		t.Fatal("an unschedulable limit must not accumulate retry state")
+	}
+}
+
+// TestResumeLimitedSessions_ReLimitBacksOff is the re-limit guard: after a resume
+// the session re-hits the wall (re-enters LimitReached). The scheduler must NOT
+// hammer — the exponential backoff throttles the next attempt — so repeated
+// passes inside the backoff window fire nothing, and only one further resume
+// lands once the window elapses.
+func TestResumeLimitedSessions_ReLimitBacksOff(t *testing.T) {
+	advance := withFrozenClock(t)
+	base := nowFunc()
+	resetAt := base // reset already in the past
+	manager, _, inst, backend := newAutoResumeManager(t, "", true, "flaky work", resetAt)
+
+	// First resume fires once the grace window passes.
+	advance(limitResumeGrace + time.Second)
+	manager.ResumeLimitedSessions()
+	if _, _, prompts := backend.snapshot(); len(prompts) != 1 {
+		t.Fatalf("first resume: want 1 prompt, got %d", len(prompts))
+	}
+
+	// The session re-hits the wall with the same (past) reset time. Hammer the
+	// scheduler for 9s of 1s ticks — all inside the 10s base backoff — and prove
+	// it never re-fires.
+	inst.SetLimitReached(resetAt)
+	for i := 0; i < 9; i++ {
+		advance(time.Second)
+		manager.ResumeLimitedSessions()
+	}
+	if _, _, prompts := backend.snapshot(); len(prompts) != 1 {
+		t.Fatalf("re-limit inside the backoff window must not re-fire: want 1 prompt, got %d", len(prompts))
+	}
+
+	// Once the backoff window elapses, exactly one further resume lands.
+	advance(2 * time.Second) // now >10s since the first attempt
+	manager.ResumeLimitedSessions()
+	if _, _, prompts := backend.snapshot(); len(prompts) != 2 {
+		t.Fatalf("after the backoff window a re-limited session resumes once more: want 2 prompts, got %d", len(prompts))
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,8 @@ detach_keys = "ctrl-w"
 log_max_size_mb = 50
 log_max_backups = 2
 update_channel = "stable"
+limit_auto_resume = false
+limit_retry_interval = "30m"
 
 [program_overrides]
 claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
@@ -39,6 +41,8 @@ claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 | `log_max_backups` | How many rotated logs (`agent-factory.log.1`, `.2`, ...) to keep per log file; older ones are deleted (defaults to 2). `0` keeps none. |
 | `update_channel` | Release channel that auto-update and `af upgrade` follow: `stable` (default) tracks manual `1.x.y` releases only; `preview` opts into the automatic `1.x.y-preview-z` prereleases cut every 3 hours. Any other value falls back to `stable` with a warning. See [release-process.md](release-process.md). |
 | `root_agents` | Opt-in table of repositories that get an always-ensured `root` agent (default: none). See [Root agents](#root-agents-always-ensured). |
+| `limit_auto_resume` | Opt in to the daemon auto-resuming a session parked at a usage-limit wall once its limit window elapses (default: `false`). See [Usage-limit auto-resume](#usage-limit-auto-resume). |
+| `limit_retry_interval` | Fallback retry cadence (Go duration, e.g. `30m`) used only when `limit_auto_resume` is on **and** the limit banner carried no parseable reset time (default: `30m`). Empty or `0` disables the fallback. |
 | `keys` | Optional keymap overrides for the TUI. See [Key bindings](#key-bindings-keys). |
 
 ### Root agents (always-ensured)
@@ -68,6 +72,25 @@ Behavior and guarantees:
 - Changes to `root_agents` are picked up on the next **daemon restart**.
 
 Because the default profile skips permission prompts and auto-accepts, only opt in repositories where you are comfortable with a fully autonomous agent running at the repo root.
+
+### Usage-limit auto-resume
+
+When a `claude` or `codex` session hits a plan usage-limit wall, af marks it with a `[limit]` badge in the sidebar and — when the banner states a reset time — shows when the limit resets. By default the row stays there until you resume it yourself (the `c` key on the session).
+
+`limit_auto_resume = true` opts the **daemon** into resuming such a session on its own once the limit window has elapsed:
+
+```toml
+limit_auto_resume = true
+limit_retry_interval = "30m"
+```
+
+- **Off by default.** With `limit_auto_resume = false` (the default), a limit is surface-only — the badge and the manual `c` retry — and the daemon does no scheduling.
+- **When it resumes.** If the banner carried a parseable reset time, the daemon resumes shortly after that time (a small grace buffer is added because limit windows are rolling and approximate). A reset time already in the past resumes promptly.
+- **No parseable reset time.** Some banners don't state a reset time. In that case the daemon falls back to retrying on the fixed `limit_retry_interval` cadence (a Go duration such as `30m` or `1h`). Setting `limit_retry_interval` to empty or `0` leaves such a session surface-only.
+- **Re-limit backoff.** If a resumed session immediately hits the wall again, the daemon backs off exponentially (settling at one attempt every 5 minutes) rather than hammering a genuinely exhausted plan. Killing the session is always the off-ramp.
+- **Global-only, daemon behavior.** Both keys are rejected in in-repo configs and take effect on the next daemon restart.
+
+Resuming re-delivers the session's stored task prompt (task-driven sessions resume their work); an interactive session with no stored prompt is sent a bare `continue`, which loses the agent's prior in-context state.
 
 ### Key bindings (`[keys]`)
 
@@ -126,7 +149,7 @@ terminal_cmd = "./infra/terminal.sh"
 |-------|-------|
 | `default_program`, `program_overrides` | Valid globally **and** in-repo (in-repo wins). |
 | `post_worktree_commands`, `remote_hooks` | **In-repo only.** The legacy `~/.agent-factory/repos/<repoID>/config.json` location keeps working for one more release (a deprecation warning in the log points at the new file) and is shadowed whenever the in-repo file sets the same key — including by an explicit empty value like `post_worktree_commands = []`. |
-| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `detach_keys`, `log_max_size_mb`, `log_max_backups`, `update_channel`, `keys`, `root_agents` | Global only. Setting them in-repo is rejected with an error naming the key. |
+| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `detach_keys`, `log_max_size_mb`, `log_max_backups`, `update_channel`, `keys`, `root_agents`, `limit_auto_resume`, `limit_retry_interval` | Global only. Setting them in-repo is rejected with an error naming the key. |
 
 `post_worktree_commands` are shell commands run after each new worktree is created (e.g. `npm install`, `make build`) — they can also be edited from the TUI via the `H` (worktree hooks) key. `remote_hooks` configures a remote-machine backend; see [remote-hooks.md](remote-hooks.md) for the script protocol.
 

--- a/scripts/file-length-allowlist.txt
+++ b/scripts/file-length-allowlist.txt
@@ -17,7 +17,7 @@
 # be split, not grandfathered.
 
 # --- production code (limit 1000) ---
-daemon/control.go 2765
+daemon/control.go 2761
 app/app.go 1889
 session/instance.go 1531
 session/tmux/tmux.go 1424


### PR DESCRIPTION
## Scope — PR 3/4 of #1146

The **daemon-side usage-limit auto-resume scheduler**. Builds directly on merged **PR1** (detector, `task/limit.go`) and **PR2** (LimitReached liveness + `[limit]` surface + manual `c` retry + the reusable guard-free `resumeFromLimit` path). No task-runner park here — that's PR4.

### Config gate (default OFF)
- `limit_auto_resume` — bool, **default `false`**. When off, a limit stays surface-only (PR2 badge + manual retry) and the scheduler does **zero** work.
- `limit_retry_interval` — Go duration string, default `"30m"`, used **only** as the fallback cadence when a banner carried no parseable reset time. Empty/`0` disables the fallback.
- Both are **global-only** (rejected in in-repo configs), mirroring `daemon_poll_interval`.

### The scheduler
`ResumeLimitedSessions()` runs each poll tick after `RestoreLostSessions()` and **mirrors the lostrestore discipline exactly**: snapshot under `m.mu`, prune dead/resolved retry state, `TryLock` the per-session op-lock (never stall the poll goroutine), **re-verify under the lock**, then call the shared **`resumeFromLimit`** — the same action the manual `c` retry uses. Resume mechanics are **not** reimplemented.

- Resumes a `LiveLimitReached` row at `limitResetAt + limitResumeGrace` (a 2-minute buffer, since limit windows are rolling/approximate).
- A re-limit after a resume **backs off exponentially** (base 10s → settling at 5m), so a genuinely exhausted plan is never hammered.

### Edge cases (design §4)
- **No parseable reset time** → fixed `limit_retry_interval` fallback, or surface-only when that interval is empty/0 (no retry state is even created).
- **Reset time already in the past** → resumes promptly (grace respected).
- **Killed / archived / tombstoned before reset** → re-verify-under-lock rejects it, timer abandoned; no crash, no resurrection.
- All comparisons in **UTC** (`limitResetAt` is stored UTC).

### Tests — `make test-container` green, injected clock
`daemon/limitresume_test.go` drives an injected clock (`nowFunc`), never the wall clock:
- banner → parked → advance past window → resume fires, stored prompt re-sent, liveness cleared
- exited-agent → re-spawns via guard-free `Respawn` (never `Recover`)
- `limit_auto_resume=off` → advance past reset → **no** resume
- killed-before-reset → no-op
- archived → no resume, retry timer cleared
- no-reset-time + interval set → retries on the interval; interval `0` → never resumes
- re-limit → backs off, bounded attempts within a window (does not hammer)

### File-length (#1145)
New code lives in `daemon/limitresume.go`. To stay under ceilings, config helpers moved to `config/limit_patterns.go` and `splitDaemonInstanceKey` was co-located with its inverse `daemonInstanceKey` in `daemon.go` (`control.go` ratcheted 2765 → 2761).

### Verification
`gofmt -l .` clean · `go build ./...` · `golangci-lint run --fast` clean · `deadcode -test ./...` clean · file-length lint pass · `make test-container` **green**.

References #1146 — **PR4** (the task-runner park) closes it.

— Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)