### PR TITLE
feat(cli): af config set — comment-preserving, allowlisted, validated (#1192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ default_program = "claude"
 claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 ```
 
-Read the effective global config from the CLI with `af config list` (or `af config get <key>`) — handy for scripts and agents; editing values is still done in the file. Upgrading from a `config.json`? The move to TOML is automatic — `af` converts it on first run and keeps a `config.json.bak`. See [docs/configuration.md](docs/configuration.md) for every key, the migration, the precedence rules, and where state is stored.
+Read and write the global config from the CLI: `af config list` / `af config get <key>` show the effective values, and `af config set <key> <value>` writes a single settable key in place — preserving every comment and your ordering (it never regenerates the file), validated with the loader's own rules first. Structural keys (`root_agents`, `[keys]`) stay hand-edited. Upgrading from a `config.json`? The move to TOML is automatic — `af` converts it on first run and keeps a `config.json.bak`. See [docs/configuration.md](docs/configuration.md) for every key, the migration, the precedence rules, and where state is stored.
 
 ## Documentation
 

--- a/config/configset.go
+++ b/config/configset.go
@@ -274,10 +274,14 @@ var (
 
 // setTOMLScalar returns content with [section] leaf set to encoded, changing only
 // the target value's bytes. If the key exists its value (and only its value) is
-// replaced, preserving any trailing inline comment. If the key is absent it is
-// inserted with minimal disturbance — appended to the end of its section's block
-// (or, for a root key, the pre-section block); if the section itself is absent a
-// new [section] block is appended. section == "" targets the root block.
+// replaced, preserving any trailing inline comment. It recognizes both TOML
+// spellings of a table entry — a leaf under a [section] header AND a top-level
+// dotted key (section.leaf = …) — and edits whichever is present, so a
+// hand-edited dotted-key file is never left with a duplicate. If the key is
+// absent it is inserted with minimal disturbance — appended to the end of its
+// section's block (or, for a root key, the pre-section block); if the section
+// itself is absent a new [section] block is appended. section == "" targets the
+// root block.
 func setTOMLScalar(content, section, leaf, encoded string) string {
 	newLine := leaf + " = " + encoded
 
@@ -295,6 +299,17 @@ func setTOMLScalar(content, section, leaf, encoded string) string {
 	}
 
 	keyRe := regexp.MustCompile(`^(\s*` + regexp.QuoteMeta(leaf) + `\s*=\s*)(.*)$`)
+
+	// TOML also lets a hand-editor write a table entry as a top-level dotted key
+	// (program_overrides.claude = "…") instead of under a [program_overrides]
+	// header. For a dynamic key we must recognize that form too, or we would
+	// miss the existing key and append a duplicate — corrupting the file (a
+	// valid config never has both forms, so at most one matches). dotted whitespace
+	// around the '.' is allowed by TOML, so tolerate it.
+	var dottedKeyRe *regexp.Regexp
+	if section != "" {
+		dottedKeyRe = regexp.MustCompile(`^(\s*` + regexp.QuoteMeta(section) + `\s*\.\s*` + regexp.QuoteMeta(leaf) + `\s*=\s*)(.*)$`)
+	}
 
 	curSection := ""
 	firstHeaderIdx := -1
@@ -320,6 +335,15 @@ func setTOMLScalar(content, section, leaf, encoded string) string {
 			}
 			curSection = name
 			continue
+		}
+		// Top-level dotted form (section.leaf = …). Only valid at the root: the
+		// same text under another header would name a different key.
+		if dottedKeyRe != nil && curSection == "" {
+			if m := dottedKeyRe.FindStringSubmatch(line); m != nil {
+				_, comment := splitTrailingComment(m[2])
+				ls[i] = m[1] + encoded + comment
+				return rebuild()
+			}
 		}
 		if curSection != section {
 			continue

--- a/config/configset.go
+++ b/config/configset.go
@@ -1,0 +1,401 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// This file implements `af config set` (#1192). It writes a single scalar key
+// into the global config.toml with three deliberate properties:
+//
+//  1. Comment/ordering-preserving: it does a SURGICAL in-place edit of the file
+//     text (see setTOMLScalar) rather than re-marshaling the Config struct.
+//     toml.Marshal regenerates the file and would strip the comments, blank
+//     lines, and key ordering of a file the README tells users to hand-edit —
+//     an external-user footgun. Only the target value's bytes change.
+//  2. Allowlisted: only a curated set of safe, documented scalar keys is
+//     settable (settableKeySpecs). Unknown or structural keys (root_agents, the
+//     [keys] rebinds) are rejected with the settable list — they stay
+//     hand-edited.
+//  3. Validated with the loader's own rules BEFORE writing: the same
+//     ValidateProgramEnum / enum / range checks the loader applies, plus a final
+//     parseConfigTOML gate on the edited bytes, so `config set` can never write
+//     a config that then fails to load.
+//
+// config.toml is user-hand-editable state read by the daemon and TUI at
+// startup (not daemon-exclusively-owned like instances.json), so the write is a
+// file write guarded by WithFileLock (mirroring the pre-daemon tasks path) — not
+// a daemon RPC. Changes apply exactly as a hand-edit does: on the next af /
+// daemon start (SetResult.RequiresRestart is always true).
+
+// cfgValueKind is the scalar type a settable key accepts.
+type cfgValueKind int
+
+const (
+	cfgString cfgValueKind = iota
+	cfgInt
+	cfgBool
+)
+
+// settableKeySpec describes one settable key (or one dynamic family such as
+// program_overrides.<name>).
+type settableKeySpec struct {
+	kind cfgValueKind
+	// section is the TOML table the key lives under ("" = the root, pre-section
+	// block).
+	section string
+	// dynamic marks a family whose leaf is user-supplied (program_overrides.<x>,
+	// limit_patterns.<x>); the registry key is then the section/prefix name.
+	dynamic bool
+	// validate runs the loader's own validation on the parsed value before the
+	// write, returning the loader's error verbatim where possible. leaf is the
+	// sub-key for a dynamic family (the program name), else the key itself.
+	validate func(leaf, value string) error
+}
+
+// settableKeySpecs is the allowlist. Scalars + the two simple string maps only;
+// root_agents (nested table) and [keys] (array-capable rebinds) are
+// intentionally excluded from v1 and stay hand-edited.
+var settableKeySpecs = map[string]settableKeySpec{
+	"default_program": {kind: cfgString, validate: func(_, v string) error {
+		return ValidateProgramEnum("default_program", "default_program", v, "")
+	}},
+	"auto_yes":             {kind: cfgBool},
+	"daemon_poll_interval": {kind: cfgInt, validate: func(_, v string) error { return requirePositiveInt("daemon_poll_interval", v) }},
+	"log_max_size_mb":      {kind: cfgInt, validate: func(_, v string) error { return requirePositiveInt("log_max_size_mb", v) }},
+	"log_max_backups":      {kind: cfgInt, validate: func(_, v string) error { return requireNonNegativeInt("log_max_backups", v) }},
+	"branch_prefix":        {kind: cfgString},
+	"detach_keys":          {kind: cfgString},
+	"update_channel": {kind: cfgString, validate: func(_, v string) error {
+		if v != UpdateChannelStable && v != UpdateChannelPreview {
+			return fmt.Errorf("update_channel must be one of [%s, %s], got %q", UpdateChannelStable, UpdateChannelPreview, v)
+		}
+		return nil
+	}},
+	"program_overrides": {kind: cfgString, section: "program_overrides", dynamic: true, validate: func(leaf, v string) error {
+		return ValidateProgramEnum("program_overrides key", "program_overrides key", leaf, v)
+	}},
+	"limit_patterns": {kind: cfgString, section: "limit_patterns", dynamic: true, validate: func(leaf, v string) error {
+		if err := ValidateProgramEnum("limit_patterns key", "limit_patterns key", leaf, v); err != nil {
+			return err
+		}
+		if _, err := regexp.Compile(v); err != nil {
+			return fmt.Errorf("limit_patterns.%s is not a valid regular expression: %w", leaf, err)
+		}
+		return nil
+	}},
+}
+
+func requirePositiveInt(name, v string) error {
+	n, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil {
+		return fmt.Errorf("%s must be an integer, got %q", name, v)
+	}
+	if n <= 0 {
+		return fmt.Errorf("%s must be a positive integer, got %d", name, n)
+	}
+	return nil
+}
+
+func requireNonNegativeInt(name, v string) error {
+	n, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil {
+		return fmt.Errorf("%s must be an integer, got %q", name, v)
+	}
+	if n < 0 {
+		return fmt.Errorf("%s must be a non-negative integer, got %d", name, n)
+	}
+	return nil
+}
+
+// SettableKeys returns the sorted, human-facing list of keys `config set`
+// accepts; dynamic families are rendered as prefix.<name>.
+func SettableKeys() []string {
+	out := make([]string, 0, len(settableKeySpecs))
+	for k, s := range settableKeySpecs {
+		if s.dynamic {
+			out = append(out, k+".<name>")
+		} else {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// SetResult reports a successful `config set`.
+type SetResult struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Path  string `json:"path"`
+	// RequiresRestart is always true: config.toml is read at startup, so a
+	// change applies to af and the daemon on their next start, exactly like a
+	// hand-edit.
+	RequiresRestart bool `json:"requires_restart"`
+}
+
+// resolveSettable maps a user key ("default_program" or "program_overrides.claude")
+// to its spec, section, and leaf. ok is false for anything not on the allowlist.
+func resolveSettable(key string) (section, leaf string, spec settableKeySpec, ok bool) {
+	if s, found := settableKeySpecs[key]; found && !s.dynamic {
+		return "", key, s, true
+	}
+	if i := strings.IndexByte(key, '.'); i > 0 {
+		prefix, rest := key[:i], key[i+1:]
+		if s, found := settableKeySpecs[prefix]; found && s.dynamic && rest != "" && !strings.Contains(rest, ".") {
+			return prefix, rest, s, true
+		}
+	}
+	return "", "", settableKeySpec{}, false
+}
+
+// SetGlobalConfigValue validates key+rawValue against the settable-key allowlist
+// and the loader's validators, then surgically writes the value into the global
+// config.toml under a file lock, preserving all comments and ordering. It
+// guarantees the written file still loads. Returns an actionable error for an
+// unknown key, a wrong-typed or invalid value, or an I/O failure.
+func SetGlobalConfigValue(key, rawValue string) (*SetResult, error) {
+	section, leaf, spec, ok := resolveSettable(key)
+	if !ok {
+		return nil, fmt.Errorf("%q is not a settable config key. Settable keys: %s. "+
+			"Structural keys (root_agents, [keys] rebinds) are edited directly in config.toml",
+			key, strings.Join(SettableKeys(), ", "))
+	}
+
+	canonical, encoded, err := canonicalizeScalar(spec.kind, rawValue)
+	if err != nil {
+		return nil, fmt.Errorf("invalid value for %s: %w", key, err)
+	}
+	if spec.validate != nil {
+		if err := spec.validate(leaf, canonical); err != nil {
+			return nil, err
+		}
+	}
+
+	// Ensure config.toml exists (migrating a legacy config.json if needed) and
+	// that the current config actually loads, so a later parse failure is
+	// unambiguously our edit's fault, not a pre-existing broken file.
+	if _, err := LoadConfig(); err != nil {
+		return nil, fmt.Errorf("refusing to write: the current config does not load: %w", err)
+	}
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	tomlPath := filepath.Join(configDir, TomlConfigFileName)
+	prettyPath := prettyHomePath(tomlPath)
+
+	var result *SetResult
+	writeErr := WithFileLock(tomlPath, func() error {
+		current, err := os.ReadFile(tomlPath)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read %s: %w", prettyPath, err)
+		}
+		updated := setTOMLScalar(string(current), section, leaf, encoded)
+
+		// Final gate: the edited bytes must parse and validate exactly as the
+		// loader would, so `config set` can never leave an unloadable config.
+		if _, err := parseConfigTOML([]byte(updated), prettyPath); err != nil {
+			return fmt.Errorf("internal error: edited config would not load (no changes written): %w", err)
+		}
+		if err := AtomicWriteFile(tomlPath, []byte(updated), 0644); err != nil {
+			return err
+		}
+		result = &SetResult{Key: key, Value: canonical, Path: tomlPath, RequiresRestart: true}
+		return nil
+	})
+	if writeErr != nil {
+		return nil, writeErr
+	}
+	return result, nil
+}
+
+// canonicalizeScalar parses rawValue per kind and returns both the canonical
+// string form (for echo/validation) and its TOML encoding (for the file).
+func canonicalizeScalar(kind cfgValueKind, raw string) (canonical, encoded string, err error) {
+	switch kind {
+	case cfgBool:
+		b, perr := strconv.ParseBool(strings.TrimSpace(raw))
+		if perr != nil {
+			return "", "", fmt.Errorf("expected a boolean (true/false), got %q", raw)
+		}
+		s := strconv.FormatBool(b)
+		return s, s, nil
+	case cfgInt:
+		n, perr := strconv.Atoi(strings.TrimSpace(raw))
+		if perr != nil {
+			return "", "", fmt.Errorf("expected an integer, got %q", raw)
+		}
+		s := strconv.Itoa(n)
+		return s, s, nil
+	default:
+		return raw, encodeTOMLString(raw), nil
+	}
+}
+
+// encodeTOMLString renders s as a TOML string, preferring a literal single-quoted
+// string (matching go-toml's output style and leaving backslashes in paths
+// untouched). It falls back to a basic double-quoted string only when s contains
+// a single quote or a newline, which a literal string cannot represent.
+func encodeTOMLString(s string) string {
+	if !strings.ContainsAny(s, "'\n\r") {
+		return "'" + s + "'"
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+var (
+	tomlHeaderRe = regexp.MustCompile(`^\s*\[([^\[\]]+)\]\s*(#.*)?$`)
+)
+
+// setTOMLScalar returns content with [section] leaf set to encoded, changing only
+// the target value's bytes. If the key exists its value (and only its value) is
+// replaced, preserving any trailing inline comment. If the key is absent it is
+// inserted with minimal disturbance — appended to the end of its section's block
+// (or, for a root key, the pre-section block); if the section itself is absent a
+// new [section] block is appended. section == "" targets the root block.
+func setTOMLScalar(content, section, leaf, encoded string) string {
+	newLine := leaf + " = " + encoded
+
+	if strings.TrimSpace(content) == "" {
+		if section == "" {
+			return newLine + "\n"
+		}
+		return "[" + section + "]\n" + newLine + "\n"
+	}
+
+	hadTrailingNewline := strings.HasSuffix(content, "\n")
+	ls := strings.Split(content, "\n")
+	if hadTrailingNewline && len(ls) > 0 && ls[len(ls)-1] == "" {
+		ls = ls[:len(ls)-1]
+	}
+
+	keyRe := regexp.MustCompile(`^(\s*` + regexp.QuoteMeta(leaf) + `\s*=\s*)(.*)$`)
+
+	curSection := ""
+	firstHeaderIdx := -1
+	targetHeaderIdx := -1
+	lastLineIdxInTarget := -1
+
+	rebuild := func() string {
+		out := strings.Join(ls, "\n")
+		if hadTrailingNewline {
+			out += "\n"
+		}
+		return out
+	}
+
+	for i, line := range ls {
+		if m := tomlHeaderRe.FindStringSubmatch(line); m != nil {
+			if firstHeaderIdx == -1 {
+				firstHeaderIdx = i
+			}
+			name := strings.TrimSpace(m[1])
+			if name == section && targetHeaderIdx == -1 {
+				targetHeaderIdx = i
+			}
+			curSection = name
+			continue
+		}
+		if curSection != section {
+			continue
+		}
+		if m := keyRe.FindStringSubmatch(line); m != nil {
+			_, comment := splitTrailingComment(m[2])
+			ls[i] = m[1] + encoded + comment
+			return rebuild()
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			lastLineIdxInTarget = i
+		}
+	}
+
+	// Key not found — insert.
+	insertAt := func(idx int, s string) {
+		ls = append(ls, "")
+		copy(ls[idx+1:], ls[idx:])
+		ls[idx] = s
+	}
+
+	switch {
+	case section == "":
+		switch {
+		case lastLineIdxInTarget != -1:
+			insertAt(lastLineIdxInTarget+1, newLine)
+		case firstHeaderIdx != -1:
+			insertAt(firstHeaderIdx, newLine)
+		default:
+			ls = append(ls, newLine)
+		}
+	case targetHeaderIdx == -1:
+		// Section absent: append a fresh block, separated by one blank line.
+		if len(ls) > 0 && ls[len(ls)-1] != "" {
+			ls = append(ls, "")
+		}
+		ls = append(ls, "["+section+"]", newLine)
+	default:
+		if lastLineIdxInTarget != -1 {
+			insertAt(lastLineIdxInTarget+1, newLine)
+		} else {
+			insertAt(targetHeaderIdx+1, newLine)
+		}
+	}
+	return rebuild()
+}
+
+// splitTrailingComment separates a TOML value from a trailing inline comment,
+// tracking quote state so a '#' inside a string is not mistaken for a comment.
+// It returns the value part and the comment part (including the whitespace that
+// preceded the '#'), so the comment can be reattached byte-for-byte.
+func splitTrailingComment(rest string) (value, comment string) {
+	inSingle, inDouble := false, false
+	for i := 0; i < len(rest); i++ {
+		c := rest[i]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			}
+		case c == '\'':
+			inSingle = true
+		case c == '"':
+			inDouble = true
+		case c == '#':
+			j := i
+			for j > 0 && (rest[j-1] == ' ' || rest[j-1] == '\t') {
+				j--
+			}
+			return rest[:j], rest[j:]
+		}
+	}
+	return rest, ""
+}

--- a/config/configset_test.go
+++ b/config/configset_test.go
@@ -50,6 +50,39 @@ func TestSetTOMLScalarAppendsNewSection(t *testing.T) {
 	}
 }
 
+// TestSetTOMLScalarEditsDottedForm guards the #1208 Greptile fix: a table entry
+// hand-written as a top-level dotted key must be edited in place, never
+// duplicated by appending a [section] block.
+func TestSetTOMLScalarEditsDottedForm(t *testing.T) {
+	in := "default_program = 'claude'\nprogram_overrides.claude = '/bin/claude'  # dotted\n"
+	got := setTOMLScalar(in, "program_overrides", "claude", "'/bin/codex'")
+	want := "default_program = 'claude'\nprogram_overrides.claude = '/bin/codex'  # dotted\n"
+	if got != want {
+		t.Fatalf("dotted edit wrong.\n got: %q\nwant: %q", got, want)
+	}
+	if strings.Contains(got, "[program_overrides]") {
+		t.Fatal("must not append a [program_overrides] block for the dotted form")
+	}
+}
+
+// TestSetTOMLScalarDottedFormWhitespaceAndScoping checks tolerance of spaces
+// around the dot, and that the dotted match is scoped to the root — the same
+// text under another header is a different key and must not be touched.
+func TestSetTOMLScalarDottedFormWhitespaceAndScoping(t *testing.T) {
+	got := setTOMLScalar("program_overrides . claude = 'x'\n", "program_overrides", "claude", "'y'")
+	if got != "program_overrides . claude = 'y'\n" {
+		t.Fatalf("spaced dotted edit wrong: %q", got)
+	}
+
+	// Under [other], the line other.program_overrides.claude is unrelated: no
+	// root match, so a canonical [program_overrides] block is appended instead.
+	in := "[other]\nprogram_overrides.claude = 'x'\n"
+	res := setTOMLScalar(in, "program_overrides", "claude", "'z'")
+	if !strings.Contains(res, "[program_overrides]\nclaude = 'z'") {
+		t.Fatalf("expected canonical block appended, got: %q", res)
+	}
+}
+
 func TestSetTOMLScalarEmptyFile(t *testing.T) {
 	if got := setTOMLScalar("", "", "auto_yes", "true"); got != "auto_yes = true\n" {
 		t.Fatalf("empty root wrong: %q", got)
@@ -141,6 +174,36 @@ func TestSetGlobalConfigValueRoundTrip(t *testing.T) {
 	}
 	if cfg.DefaultProgram != "codex" {
 		t.Fatalf("loaded default_program = %q, want codex", cfg.DefaultProgram)
+	}
+}
+
+// TestSetGlobalConfigValueDottedRoundTrip is the end-to-end #1208 guard: a
+// config whose program override is written in dotted-key form is updated in
+// place, with no duplicate and no [program_overrides] block appended, and the
+// result loads with the new value.
+func TestSetGlobalConfigValueDottedRoundTrip(t *testing.T) {
+	orig := "default_program = 'claude'\nprogram_overrides.claude = '/bin/claude'\n"
+	path := writeTempConfig(t, orig)
+
+	if _, err := SetGlobalConfigValue("program_overrides.claude", "/bin/codex"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	got, _ := os.ReadFile(path)
+	want := "default_program = 'claude'\nprogram_overrides.claude = '/bin/codex'\n"
+	if string(got) != want {
+		t.Fatalf("dotted round-trip wrong.\n got: %q\nwant: %q", got, want)
+	}
+	if strings.Contains(string(got), "[program_overrides]") {
+		t.Fatal("must not append a [program_overrides] block")
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("written config does not load: %v", err)
+	}
+	if cfg.ProgramOverrides["claude"] != "/bin/codex" {
+		t.Fatalf("loaded override = %q, want /bin/codex", cfg.ProgramOverrides["claude"])
 	}
 }
 

--- a/config/configset_test.go
+++ b/config/configset_test.go
@@ -1,0 +1,202 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSetTOMLScalarReplacePreservesComments is the crux guard: replacing a
+// value must change ONLY that value's bytes — every comment, blank line,
+// section header, ordering, and even the changed line's trailing inline comment
+// stays byte-identical.
+func TestSetTOMLScalarReplacePreservesComments(t *testing.T) {
+	in := "# header comment\n\ndefault_program = 'claude'   # inline note\nauto_yes = false\n\n" +
+		"# section comment\n[program_overrides]\nclaude = '/bin/claude --flag'  # path\n"
+	want := "# header comment\n\ndefault_program = 'codex'   # inline note\nauto_yes = false\n\n" +
+		"# section comment\n[program_overrides]\nclaude = '/bin/claude --flag'  # path\n"
+
+	got := setTOMLScalar(in, "", "default_program", "'codex'")
+	if got != want {
+		t.Fatalf("replace not byte-preserving.\n--- got ---\n%q\n--- want ---\n%q", got, want)
+	}
+}
+
+func TestSetTOMLScalarInsertRootKeyBeforeSections(t *testing.T) {
+	in := "default_program = 'claude'\nauto_yes = false\n\n[program_overrides]\nclaude = 'x'\n"
+	got := setTOMLScalar(in, "", "branch_prefix", "'feat/'")
+	want := "default_program = 'claude'\nauto_yes = false\nbranch_prefix = 'feat/'\n\n[program_overrides]\nclaude = 'x'\n"
+	if got != want {
+		t.Fatalf("root insert wrong.\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestSetTOMLScalarInsertIntoExistingSection(t *testing.T) {
+	in := "[program_overrides]\nclaude = 'x'\n"
+	got := setTOMLScalar(in, "program_overrides", "codex", "'/usr/bin/codex'")
+	want := "[program_overrides]\nclaude = 'x'\ncodex = '/usr/bin/codex'\n"
+	if got != want {
+		t.Fatalf("section insert wrong.\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestSetTOMLScalarAppendsNewSection(t *testing.T) {
+	in := "default_program = 'claude'\n"
+	got := setTOMLScalar(in, "limit_patterns", "claude", "'rate.*limit'")
+	want := "default_program = 'claude'\n\n[limit_patterns]\nclaude = 'rate.*limit'\n"
+	if got != want {
+		t.Fatalf("new section wrong.\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestSetTOMLScalarEmptyFile(t *testing.T) {
+	if got := setTOMLScalar("", "", "auto_yes", "true"); got != "auto_yes = true\n" {
+		t.Fatalf("empty root wrong: %q", got)
+	}
+	if got := setTOMLScalar("", "limit_patterns", "claude", "'x'"); got != "[limit_patterns]\nclaude = 'x'\n" {
+		t.Fatalf("empty section wrong: %q", got)
+	}
+}
+
+// TestSetTOMLScalarHashInStringValue guards that a '#' inside the existing
+// quoted value is not mistaken for a comment when computing the trailing
+// comment to preserve.
+func TestSetTOMLScalarHashInStringValue(t *testing.T) {
+	in := "branch_prefix = 'a#b'  # trailing\n"
+	got := setTOMLScalar(in, "", "branch_prefix", "'c#d'")
+	want := "branch_prefix = 'c#d'  # trailing\n"
+	if got != want {
+		t.Fatalf("hash-in-value wrong.\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestResolveSettable(t *testing.T) {
+	if s, leaf, _, ok := resolveSettable("default_program"); !ok || s != "" || leaf != "default_program" {
+		t.Fatalf("default_program resolve wrong: s=%q leaf=%q ok=%v", s, leaf, ok)
+	}
+	if s, leaf, _, ok := resolveSettable("program_overrides.claude"); !ok || s != "program_overrides" || leaf != "claude" {
+		t.Fatalf("dynamic resolve wrong: s=%q leaf=%q ok=%v", s, leaf, ok)
+	}
+	// A dotted leaf on a fixed key, an unknown key, and a nested dynamic leaf are rejected.
+	for _, bad := range []string{"default_program.x", "root_agents.foo", "nope", "program_overrides.a.b", "program_overrides."} {
+		if _, _, _, ok := resolveSettable(bad); ok {
+			t.Errorf("expected %q to be unsettable", bad)
+		}
+	}
+}
+
+func TestEncodeTOMLString(t *testing.T) {
+	cases := map[string]string{
+		"claude":        "'claude'",
+		"/bin/x --flag": "'/bin/x --flag'",
+		`C:\path`:       `'C:\path'`, // literal keeps backslashes
+		"has'quote":     `"has'quote"`,
+		"line1\nline2":  `"line1\nline2"`,
+	}
+	for in, want := range cases {
+		if got := encodeTOMLString(in); got != want {
+			t.Errorf("encodeTOMLString(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// writeTempConfig points AGENT_FACTORY_HOME at a temp dir seeded with content
+// and returns the config.toml path.
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	p := filepath.Join(home, "config.toml")
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestSetGlobalConfigValueRoundTrip proves the full path: a comment-rich,
+// custom-ordered config keeps every comment/line except the changed value, the
+// result still loads, and the loaded value is the new one.
+func TestSetGlobalConfigValueRoundTrip(t *testing.T) {
+	orig := "# keep me\ndefault_program = 'claude'  # fav\nauto_yes = false\n\n[program_overrides]\nclaude = '/bin/claude'\n"
+	path := writeTempConfig(t, orig)
+
+	res, err := SetGlobalConfigValue("default_program", "codex")
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if res.Value != "codex" || !res.RequiresRestart {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+
+	got, _ := os.ReadFile(path)
+	want := "# keep me\ndefault_program = 'codex'  # fav\nauto_yes = false\n\n[program_overrides]\nclaude = '/bin/claude'\n"
+	if string(got) != want {
+		t.Fatalf("file not preserved.\n got: %q\nwant: %q", got, want)
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("written config does not load: %v", err)
+	}
+	if cfg.DefaultProgram != "codex" {
+		t.Fatalf("loaded default_program = %q, want codex", cfg.DefaultProgram)
+	}
+}
+
+func TestSetGlobalConfigValueRejectsBadValues(t *testing.T) {
+	writeTempConfig(t, "default_program = 'claude'\n")
+	cases := []struct{ key, val, wantSub string }{
+		{"default_program", "bogus", "must be one of"},
+		{"daemon_poll_interval", "abc", "integer"},
+		{"daemon_poll_interval", "0", "positive"},
+		{"log_max_backups", "-1", "non-negative"},
+		{"update_channel", "banana", "must be one of"},
+		{"limit_patterns.claude", "(", "regular expression"},
+		{"program_overrides.notaprogram", "cmd", "must be one of"},
+		{"nope", "1", "not a settable config key"},
+		{"root_agents.x", "y", "not a settable config key"},
+	}
+	for _, c := range cases {
+		_, err := SetGlobalConfigValue(c.key, c.val)
+		if err == nil {
+			t.Errorf("set %s=%s: expected error", c.key, c.val)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.wantSub) {
+			t.Errorf("set %s=%s: error %q missing %q", c.key, c.val, err.Error(), c.wantSub)
+		}
+	}
+}
+
+// TestSetGlobalConfigValueRefusesOnUnloadableConfig proves set never writes on
+// top of a config that does not currently load.
+func TestSetGlobalConfigValueRefusesOnUnloadableConfig(t *testing.T) {
+	// An invalid keymap hard-errors on load.
+	path := writeTempConfig(t, "default_program = 'claude'\n\n[keys]\nquit = 'not-a-real-key'\n")
+	before, _ := os.ReadFile(path)
+
+	_, err := SetGlobalConfigValue("auto_yes", "true")
+	if err == nil {
+		t.Fatal("expected refusal on unloadable config")
+	}
+	if !strings.Contains(err.Error(), "does not load") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Fatal("config file must be untouched when the current config does not load")
+	}
+}
+
+func TestSettableKeysSorted(t *testing.T) {
+	keys := SettableKeys()
+	if len(keys) != len(settableKeySpecs) {
+		t.Fatalf("SettableKeys len %d != specs %d", len(keys), len(settableKeySpecs))
+	}
+	for i := 1; i < len(keys); i++ {
+		if keys[i-1] > keys[i] {
+			t.Fatalf("SettableKeys not sorted: %v", keys)
+		}
+	}
+}

--- a/configcmd.go
+++ b/configcmd.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/sachiniyer/agent-factory/apiproto"
@@ -103,15 +106,15 @@ func formatConfigValue(v any) string {
 
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Read the global agent-factory config",
-	Long: `Read keys from the global config (~/.agent-factory/config.toml).
+	Short: "Read and write the global agent-factory config",
+	Long: `Read and write keys in the global config (~/.agent-factory/config.toml).
 
-Values are the effective global config with defaults applied — what a session
-gets before any in-repo .agent-factory/config.toml override is layered on.
-
-This command is read-only. To change a value, edit config.toml directly (it is
-plain TOML, made for hand-editing); a CLI write path (config set) is tracked in
-#1192.`,
+"get"/"list" print the effective global config with defaults applied — what a
+session gets before any in-repo .agent-factory/config.toml override is layered
+on. "set" writes a single settable key, editing only that value in place so all
+comments and ordering in your config.toml are preserved. Changes apply the same
+way a hand-edit does: af and the daemon read config.toml at startup, so restart
+them to pick up a change.`,
 }
 
 var configGetCmd = &cobra.Command{
@@ -167,10 +170,72 @@ var configListCmd = &cobra.Command{
 	},
 }
 
+var configSetCmd = &cobra.Command{
+	Use:   "set <key> <value>",
+	Short: "Set a single settable global config key",
+	Long: `Write one key into the global config.toml, editing only that value in place —
+every comment, blank line, section header, and key ordering is preserved (the
+file is not regenerated). Only a curated set of scalar keys is settable; the
+value is validated with the same rules the config loader uses before anything is
+written, so set can never leave a config that fails to load.
+
+Settable keys:
+  default_program            agent enum (claude, codex, aider, gemini)
+  program_overrides.<agent>  full command string for an agent
+  auto_yes                   true | false
+  daemon_poll_interval       positive integer (ms)
+  log_max_size_mb            positive integer
+  log_max_backups            non-negative integer
+  branch_prefix              string
+  detach_keys                string (e.g. ctrl-w)
+  update_channel             stable | preview
+  limit_patterns.<agent>     usage-limit banner regex for an agent
+
+Structural keys (root_agents, the [keys] rebind table) are not settable here —
+edit config.toml directly. Changes apply on the next af / daemon start.
+
+Examples:
+  af config set default_program codex
+  af config set auto_yes true
+  af config set program_overrides.claude "/usr/local/bin/claude --verbose"`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		res, err := config.SetGlobalConfigValue(args[0], args[1])
+		if err != nil {
+			return jsonWrapError(cmd.ErrOrStderr(), configJSONFlag, err)
+		}
+		if configJSONFlag {
+			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(res))
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "set %s = %s in %s\n", res.Key, res.Value, prettyPath(res.Path))
+		if res.RequiresRestart {
+			fmt.Fprintln(cmd.OutOrStdout(),
+				"note: af and the daemon read config.toml at startup — restart them to apply (same as a hand-edit)")
+		}
+		return nil
+	},
+}
+
+// prettyPath abbreviates $HOME to ~ for display, matching how the config
+// package renders paths in diagnostics.
+func prettyPath(p string) string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if rel, err := filepath.Rel(home, p); err == nil && !strings.HasPrefix(rel, "..") {
+			return filepath.Join("~", rel)
+		}
+	}
+	return p
+}
+
 func init() {
 	const jsonUsage = "Emit the value(s) as JSON wrapped in the {data,error} envelope"
 	configGetCmd.Flags().BoolVar(&configJSONFlag, "json", false, jsonUsage)
 	configListCmd.Flags().BoolVar(&configJSONFlag, "json", false, jsonUsage)
+	configSetCmd.Flags().BoolVar(&configJSONFlag, "json", false, jsonUsage)
 	configCmd.AddCommand(configGetCmd)
 	configCmd.AddCommand(configListCmd)
+	configCmd.AddCommand(configSetCmd)
 }

--- a/configcmd_test.go
+++ b/configcmd_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -129,6 +131,64 @@ func TestConfigGetUnknownKeyJSONEnvelope(t *testing.T) {
 	}
 	if env.Error == nil || !strings.Contains(env.Error.Message, "unknown config key") {
 		t.Fatalf("envelope missing the unknown-key message: %s", stderr.String())
+	}
+}
+
+// TestConfigSetWritesAndReflects drives the set command through cobra and
+// confirms the value is written and read back, comments in the seeded config
+// preserved.
+func TestConfigSetWritesAndReflects(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	path := filepath.Join(home, "config.toml")
+	if err := os.WriteFile(path, []byte("# hi\ndefault_program = 'claude'  # note\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	if err := configSetCmd.RunE(cmd, []string{"default_program", "codex"}); err != nil {
+		t.Fatalf("config set: %v", err)
+	}
+
+	got, _ := os.ReadFile(path)
+	want := "# hi\ndefault_program = 'codex'  # note\n"
+	if string(got) != want {
+		t.Fatalf("file not preserved.\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestConfigSetBadValueJSONEnvelope pins that a failed `config set --json`
+// emits the shared failure envelope on stderr, consistent with config get.
+func TestConfigSetBadValueJSONEnvelope(t *testing.T) {
+	tempAFHome(t)
+	prev := configJSONFlag
+	configJSONFlag = true
+	defer func() { configJSONFlag = prev }()
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := configSetCmd.RunE(cmd, []string{"default_program", "notanagent"})
+	if err == nil {
+		t.Fatal("expected error for invalid value")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("error path must not write stdout: %s", stdout.String())
+	}
+	var env struct {
+		Data  any `json:"data"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &env); err != nil {
+		t.Fatalf("stderr not an envelope: %v\n%s", err, stderr.String())
+	}
+	if env.Error == nil || !strings.Contains(env.Error.Message, "must be one of") {
+		t.Fatalf("envelope missing validation message: %s", stderr.String())
 	}
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -372,12 +372,15 @@ pid, pid_verified, autostart_unit, binary_stale}` in the shared envelope.
 
 ## `af config`
 
-Read keys from the **global** config (`~/.agent-factory/config.toml`) so scripts
-and agents can discover the current settings without hand-parsing TOML.
-**Read-only** (config is file-owned, hand-edited; there is no daemon RPC for it),
-and it reports the effective global values with defaults applied — i.e. what a
-session sees before any in-repo `.agent-factory/config.toml` override is layered
-on. **Text output**, or `--json` for the shared envelope.
+Read and write keys in the **global** config (`~/.agent-factory/config.toml`) so
+scripts and agents can discover and change settings without hand-parsing TOML.
+Config is **file-owned** (hand-editable; read by the daemon and TUI at startup —
+there is no daemon RPC for it). **Text output**, or `--json` for the shared
+envelope on both success and error.
+
+`get`/`list` report the effective global values with defaults applied — i.e.
+what a session sees before any in-repo `.agent-factory/config.toml` override is
+layered on:
 
 ```bash
 af config list                     # every key and its effective value
@@ -386,12 +389,49 @@ af config get program_overrides    # composite values print as JSON
 af config list --json              # [{key, value}, …] wrapped in the envelope
 ```
 
-Known keys: `default_program`, `program_overrides`, `auto_yes`,
+Readable keys: `default_program`, `program_overrides`, `auto_yes`,
 `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`,
-`detach_keys`, `update_channel`, `root_agents`, `limit_patterns`, `keys`. To
-change a value, edit `config.toml` directly — see
-[configuration.md](configuration.md). A CLI write path (`config set`) is tracked
-in [#1192](https://github.com/sachiniyer/agent-factory/issues/1192).
+`detach_keys`, `update_channel`, `root_agents`, `limit_patterns`, `keys`.
+
+### `af config set <key> <value>`
+
+Write a single settable key. The value is edited **in place** — every comment,
+blank line, section header, and key ordering in your `config.toml` is preserved
+(the file is *not* regenerated from the parsed struct, which would strip
+comments). The value is validated with the **same rules the loader uses** before
+anything is written, and the edited file is re-parsed as a final gate, so `set`
+can never leave a config that fails to load.
+
+```bash
+af config set default_program codex
+af config set auto_yes true
+af config set program_overrides.claude "/usr/local/bin/claude --verbose"
+af config set update_channel preview
+af config set default_program bad --json   # failure envelope on stderr, exit 1
+```
+
+Settable keys (curated scalars + the two simple string maps):
+
+| Key | Value |
+|-----|-------|
+| `default_program` | agent enum: `claude`, `codex`, `aider`, `gemini` |
+| `program_overrides.<agent>` | full command string for an agent |
+| `auto_yes` | `true` / `false` |
+| `daemon_poll_interval` | positive integer (ms) |
+| `log_max_size_mb` | positive integer |
+| `log_max_backups` | non-negative integer |
+| `branch_prefix` | string |
+| `detach_keys` | string (e.g. `ctrl-w`) |
+| `update_channel` | `stable` / `preview` |
+| `limit_patterns.<agent>` | usage-limit banner regex for an agent |
+
+Structural keys (`root_agents`, the `[keys]` rebind table) are **not** settable
+here — they stay hand-edited; `set` rejects them with the settable list. A
+change is a plain file write guarded by a file lock (config is not
+daemon-exclusively-owned state), and it applies the same way a hand-edit does:
+`af` and the daemon read `config.toml` at startup, so restart them to pick it up
+(`set` prints this reminder). Full key reference:
+[configuration.md](configuration.md).
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,14 +78,15 @@ af daemon status       # read-only health snapshot: running?, socket paths, pid,
 
 ## `af config`
 
-Read the **global** config (`~/.agent-factory/config.toml`) from the CLI. Read-only — config is a hand-edited file, not daemon-owned — reporting the effective global values with defaults applied. `--json` wraps output in the shared envelope.
+Read and write the **global** config (`~/.agent-factory/config.toml`) from the CLI. Config is a hand-editable file read by the daemon and TUI at startup (not daemon-owned state). `--json` wraps output in the shared envelope (success and error).
 
 ```bash
-af config list                     # every key and its effective value
+af config list                     # every key and its effective value (defaults applied)
 af config get <key>                # one key (scalars print bare; maps as JSON)
+af config set <key> <value>        # write one settable key, preserving comments/ordering
 ```
 
-Known keys: `default_program`, `program_overrides`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `detach_keys`, `update_channel`, `root_agents`, `limit_patterns`, `keys`. To change a value, edit `config.toml` directly (see [configuration.md](configuration.md)); a CLI write path is tracked in [#1192](https://github.com/sachiniyer/agent-factory/issues/1192).
+`get`/`list` report effective global values (defaults applied). `set` edits only the target value's bytes — every comment, blank line, and key ordering is preserved (the file is not regenerated) — and validates the value with the loader's own rules before writing, so it can never produce a config that fails to load. Settable keys: `default_program`, `program_overrides.<agent>`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`. Structural keys (`root_agents`, `[keys]`) stay hand-edited. A change applies on the next `af`/daemon start, exactly like a hand-edit (`set` prints this reminder). Full key reference: [configuration.md](configuration.md).
 
 ## Maintenance commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,8 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
 
 Config is [TOML](https://toml.io) — chosen so it is easy to hand-edit. If you are upgrading from a version that used `config.json`, see [Migrating from JSON](#migrating-from-json) below; the change is automatic.
 
+You can also read and write the global config from the CLI: `af config get <key>` / `af config list` print the effective values, and `af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`; structural keys (`root_agents`, `[keys]`) are hand-edited only. See [docs/cli-reference.md](cli-reference.md#af-config). Changes apply on the next `af`/daemon start, the same as a hand-edit.
+
 ## Global config
 
 `~/.agent-factory/config.toml`:


### PR DESCRIPTION
Completes the final #1192 nit — a CLI write path for the global `config.toml` — after `af daemon status` + `sessions tabs` aliases + `config get/list` shipped in #1206. **Closes #1192.**

The whole risk of `config set` was doing it wrong; this addresses the three things I flagged when deferring it.

## 1. Comment/ordering-preserving write (the crux)
`config.SetGlobalConfigValue` does a **surgical in-place text edit** (`setTOMLScalar`), never a `toml.Marshal` of the struct. It locates the target key's line and replaces **only its value** (any trailing inline comment kept); a missing key is inserted at the end of its section's block; a missing section is appended. `toml.Marshal` would regenerate the file and strip the comments/blank-lines/ordering of a file the README explicitly tells users to hand-edit — the footgun this avoids.

Proven by a byte-identical round-trip test. Real example from a hand-run:

```diff
  # My agent factory config
  # hand-edited, keep these comments!

- default_program = 'claude'   # my favorite agent
+ default_program = 'codex'   # my favorite agent
- auto_yes = false
+ auto_yes = true
  daemon_poll_interval = 1000
+ branch_prefix = 'feat/'

  # program-specific commands below
  [program_overrides]
  claude = '/home/me/.local/bin/claude --dangerously-skip-permissions'  # custom path
+ codex = '/usr/bin/codex'

  [keys]
  quit = 'ctrl+c'
+
+ [limit_patterns]
+ claude = 'rate.*limit'
```

Every comment (header, inline, section) preserved; only intended values changed; correct insertion for root key / existing section / brand-new section.

## 2. Settable-key allowlist
Only curated scalar keys + the two simple string maps are settable: `default_program`, `program_overrides.<agent>`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`. Structural keys (`root_agents`, the `[keys]` rebind table) are **rejected** with the settable list — they stay hand-edited. No arbitrary nested structures in v1.

## 3. Validation reuse
The value runs through the **loader's own validators** before writing — `ValidateProgramEnum` for `default_program` / `program_overrides` keys (verbatim loader error), the `stable|preview` enum for `update_channel`, positive/non-negative int checks for the numeric keys, `regexp.Compile` for `limit_patterns`. As a final gate the edited bytes are re-parsed via `parseConfigTOML`, so `set` can **never** write a config that then fails to load. It also refuses to write if the *current* config doesn't load (so a later parse error is unambiguously the edit's fault).

## Ownership / apply semantics
`config.toml` is user-hand-editable state read by the daemon + TUI **at startup** (not daemon-exclusively-owned like `instances.json`), so `set` is a **file write** guarded by `config.WithFileLock` (mirroring the pre-daemon tasks path) — **not** a daemon RPC. It applies exactly as a hand-edit does — on the next `af`/daemon start — and `set` prints that reminder (`requires_restart` is always true in `--json`). Confirmed this matches how hand-edits already apply.

## `--json`
Shared `{data,error}` envelope on success (stdout) and failure (stderr), consistent with `config get`. No HTTP mirror change: config has no daemon RPC, so the `af api` catalog (derived from `daemon.HTTPRoutes`) is unaffected.

## Tests & docs
- `config/configset_test.go`: byte-identical preservation (replace + all insertion cases + hash-in-string-value + empty file), allowlist/validation rejections, full round-trip that re-loads, refusal on an unloadable config, `resolveSettable`/`encodeTOMLString`/`SettableKeys`.
- `configcmd_test.go`: CLI-level write-and-reflect + `--json` failure envelope on stderr.
- Docs: `cli-reference.md`, `cli.md`, `README.md`, `configuration.md`.

## Gates (all green)
`gofmt -l .` empty · `go build ./...` · `golangci-lint --fast` clean · `deadcode -test` clean · file-length lint pass · **`make test-container` full suite green**.

Closes #1192.

Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)