### PR TITLE
feat(limit): task-runner park-don't-fail + docs (#1146) [PR 4/4]

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Tasks deliver a prompt to an agent automatically — on a cron schedule, or ever
 
 Tasks are hosted by a background daemon that starts on demand; run `af daemon install` once to keep them firing across reboots. See [docs/tasks.md](docs/tasks.md) for the full trigger × delivery matrix and the watch-script contract.
 
+### Usage limits
+
+When a `claude` or `codex` session hits a plan usage-limit wall, af detects the banner, marks the row `[limit]` in the sidebar (with the reset time when the banner states one), and keeps the session parked rather than treating it as dead. Press **`c`** on the session to resume it immediately; a task-driven session re-sends its stored prompt so it picks up where it left off.
+
+Opt into hands-off recovery with `limit_auto_resume = true` (global config): the daemon then resumes a parked `claude`/`codex` session on its own once its limit window elapses. Task runs that hit a limit at startup are **parked, not failed** — recorded as waiting for the window and resumed to completion, never counted as an errored run. `gemini`/`aider` are API-key-metered (transient 429s), so they are out of scope. See [docs/usage-limits.md](docs/usage-limits.md).
+
 ### JSON CLI
 
 Everything the TUI does is scriptable — `af sessions` and `af tasks` print JSON, so other tools (or other agents) can orchestrate Agent Factory:
@@ -150,6 +156,7 @@ Read the effective global config from the CLI with `af config list` (or `af conf
 - [docs/http-api.md](docs/http-api.md) — the daemon-hosted HTTP/JSON API: socket path, auth model, every endpoint (`af api` prints the same catalog)
 - [docs/configuration.md](docs/configuration.md) — config keys, global vs. in-repo precedence, state locations
 - [docs/tasks.md](docs/tasks.md) — task triggers, the watch-script contract, daemon lifecycle
+- [docs/usage-limits.md](docs/usage-limits.md) — usage-limit detection, the `[limit]` badge, manual retry, opt-in auto-resume, and task park-don't-fail
 - [docs/remote-hooks.md](docs/remote-hooks.md) — remote backend script protocol
 - [docs/release-process.md](docs/release-process.md) — release channels: manual stable `1.x.y` (the auto-update default), opt-in auto preview `1.x.y-preview-z`
 - [docs/release-testing-plan.md](docs/release-testing-plan.md) — release gate and smoke checks

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1704,14 +1704,13 @@ func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData,
 	}
 
 	// Single creation flow (#930 PR 3): every instance owns its worktree 1:1.
-	// InPlace only changes WHICH worktree that is — the repo's own working
-	// tree, marked external — not the flow itself.
-	if err = task.StartAndSendPrompt(instance, req.Prompt); err != nil {
+	// InPlace only changes WHICH worktree that is — the repo's own working tree,
+	// marked external — not the flow itself. finishCreateStart marks the instance
+	// live, PARKS it at a usage-limit wall (#1146 PR4), or returns a fatal error.
+	if serr := finishCreateStart(instance, req.Prompt, task.StartAndSendPrompt(instance, req.Prompt)); serr != nil {
 		_ = instance.Kill()
-		return session.InstanceData{}, fmt.Errorf("failed to start instance: %w", err)
+		return session.InstanceData{}, fmt.Errorf("failed to start instance: %w", serr)
 	}
-
-	instance.MarkLive()
 	data := instance.ToInstanceData()
 
 	// Register the in-memory instance and persist it to disk inside the
@@ -2358,13 +2357,14 @@ func (m *Manager) DeliverPrompt(req DeliverPromptRequest) (string, error) {
 	// The session is absent and, because deliveries to this target serialize on
 	// the per-target lock, no other in-daemon delivery is creating it. Create it
 	// now and deliver the prompt as its initial prompt.
-	if _, err := m.CreateSession(CreateSessionRequest{
+	created, err := m.CreateSession(CreateSessionRequest{
 		Title:    req.Title,
 		RepoPath: req.RepoPath,
 		Program:  req.Program,
 		Prompt:   req.Prompt,
 		AutoYes:  req.AutoYes,
-	}); err != nil {
+	})
+	if err != nil {
 		// A creator outside this daemon (a plain `af sessions create`, the API)
 		// can still claim the title between our check and reserveCreate. Rather
 		// than drop the prompt (#865), wait for the session to materialize and
@@ -2381,7 +2381,7 @@ func (m *Manager) DeliverPrompt(req DeliverPromptRequest) (string, error) {
 		}
 		return "", fmt.Errorf("failed to auto-create target session %q: %w", req.Title, err)
 	}
-	return "started", nil
+	return createdTaskStatus(created), nil
 }
 
 // lockTarget acquires the per-(repo, title) delivery lock, creating it on first

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -1,13 +1,57 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
 )
+
+// finishCreateStart settles a freshly created instance after StartAndSendPrompt
+// returns (#1146 PR4). It is the single place CreateSession translates that
+// outcome into liveness:
+//   - startErr nil: the agent came up — mark it live.
+//   - startErr is a usage-limit park (task.LimitReachedError): the agent hit a
+//     usage-limit wall during startup before the prompt could be delivered. KEEP
+//     the session — mark it limit-blocked with its parsed reset time and stash
+//     the prompt so the resume machinery (the daemon auto-resume scheduler when
+//     limit_auto_resume is on, or the manual `c` retry) re-delivers it once the
+//     window resets. Return nil so CreateSession registers+persists it as a
+//     parked row, not a failed one, firing no failure side-effects. instance.Prompt
+//     is the only input resumeFromLimit re-delivers and is never otherwise set on
+//     a daemon-created instance (the initial prompt goes straight to
+//     StartAndSendPrompt), so it is set here so a parked task run resumes its OWN
+//     work rather than a bare "continue".
+//   - any other error: return it for CreateSession to surface after tearing the
+//     half-started session down.
+func finishCreateStart(instance *session.Instance, prompt string, startErr error) error {
+	if startErr == nil {
+		instance.MarkLive()
+		return nil
+	}
+	var limitErr *task.LimitReachedError
+	if errors.As(startErr, &limitErr) {
+		instance.SetLimitReached(limitErr.ResetAt)
+		instance.Prompt = prompt
+		return nil
+	}
+	return startErr
+}
+
+// createdTaskStatus maps a freshly created session's data to the task-run status
+// DeliverPrompt records (#1146 PR4): the parked status when the create hit a
+// usage-limit wall at startup (a NON-failure outcome the resume machinery owns),
+// else the historical "started".
+func createdTaskStatus(data session.InstanceData) string {
+	if data.Liveness == session.LiveLimitReached {
+		return TaskStatusLimitParked
+	}
+	return "started"
+}
 
 // resolveIdleLiveness settles a session whose pane went idle this tick (#1146):
 // it sets LimitReached when the captured content shows a usage-limit banner for

--- a/daemon/limit_park_test.go
+++ b/daemon/limit_park_test.go
@@ -1,0 +1,207 @@
+package daemon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// The task-runner "park don't fail" tests (#1146 PR4). A task-driven session
+// that hits a usage-limit wall during startup must be PARKED (LiveLimitReached,
+// prompt stashed for the resume machinery), NOT killed and recorded as a failed
+// run. Resuming that parked session re-delivers its OWN prompt so the run
+// proceeds to completion — never a bare "continue" that would drop the work.
+
+// limitBannerCreateBackend is a FakeBackend whose pane capture always shows the
+// Claude usage-limit banner, so WaitForReady (via the built-in detector) parks
+// the create instead of spinning to a readiness timeout. CompleteStart lets
+// instance.Start return immediately.
+type limitBannerCreateBackend struct {
+	*session.FakeBackend
+}
+
+func (limitBannerCreateBackend) Preview(*session.Instance) (string, error) {
+	return "Claude usage limit reached. Your limit will reset at 2pm (America/New_York)", nil
+}
+
+func installLimitBannerBackend(t *testing.T) {
+	t.Helper()
+	restore := session.SetBackendFactoryForTest(func(_ session.InstanceOptions, _ string) (session.Backend, error) {
+		backend := session.NewFakeBackend()
+		backend.CompleteStart()
+		return limitBannerCreateBackend{backend}, nil
+	})
+	t.Cleanup(restore)
+}
+
+// TestCreateSession_ParksOnUsageLimitBanner is the load-bearing PR4 assertion: a
+// create whose agent shows a usage-limit banner during startup must return
+// SUCCESS with a LiveLimitReached row — the session KEPT (registered + persisted),
+// the prompt stashed for resume — not an error that kills the session and records
+// the task run as failed.
+func TestCreateSession_ParksOnUsageLimitBanner(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	installLimitBannerBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	data, err := manager.CreateSession(CreateSessionRequest{
+		Title:    "nightly-task",
+		RepoPath: repoPath,
+		Program:  "claude",
+		Prompt:   "run the nightly report",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession must PARK, not fail, on a usage-limit banner: %v", err)
+	}
+	if data.Liveness != session.LiveLimitReached {
+		t.Fatalf("parked create liveness = %v, want LiveLimitReached", data.Liveness)
+	}
+
+	// The session must remain registered (not killed) and limit-blocked.
+	key := daemonInstanceKey(repo.ID, "nightly-task")
+	manager.mu.Lock()
+	inst := manager.instances[key]
+	manager.mu.Unlock()
+	if inst == nil {
+		t.Fatal("parked session must stay registered in the manager, not be killed")
+	}
+	if !inst.LimitReached() {
+		t.Fatalf("registered instance liveness = %v, want LimitReached", inst.GetLiveness())
+	}
+	// The task prompt must be stashed so resume re-delivers the task's OWN work.
+	if inst.Prompt != "run the nightly report" {
+		t.Fatalf("stored prompt = %q, want the task prompt so resume re-delivers it", inst.Prompt)
+	}
+
+	// Persisted as limit-blocked so the badge + auto-resume scheduler survive a
+	// daemon restart.
+	raw, err := config.LoadRepoInstances(repo.ID)
+	if err != nil {
+		t.Fatalf("LoadRepoInstances: %v", err)
+	}
+	var stored []session.InstanceData
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("unmarshal stored: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Liveness != session.LiveLimitReached {
+		t.Fatalf("persisted store = %+v, want exactly one LiveLimitReached row", stored)
+	}
+}
+
+// stubParkedCreate swaps createSessionForTask for one that reports a session
+// parked at a usage-limit wall (LiveLimitReached), the shape CreateSession
+// returns after PR4's park branch. Restored on cleanup.
+func stubParkedCreate(t *testing.T) {
+	t.Helper()
+	orig := createSessionForTask
+	createSessionForTask = func(req CreateSessionRequest) (*session.InstanceData, error) {
+		title := req.Title
+		if title == "" {
+			title = req.TitleBase
+		}
+		return &session.InstanceData{Title: title, Liveness: session.LiveLimitReached}, nil
+	}
+	t.Cleanup(func() { createSessionForTask = orig })
+}
+
+// TestDeliverTaskPrompt_ParksOnUsageLimit: a no-target task run whose fresh
+// session parks must return the distinct parked status — not "started" and never
+// an "errored:" value.
+func TestDeliverTaskPrompt_ParksOnUsageLimit(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupTaskRepo(t)
+	stubParkedCreate(t)
+
+	tsk := &task.Task{ID: "ffff0010", Name: "nightly", Prompt: "do it", CronExpr: "0 3 * * *", ProjectPath: repo, Enabled: true}
+	status, err := deliverTaskPrompt(tsk, tsk.Prompt)
+	if err != nil {
+		t.Fatalf("deliverTaskPrompt must not error on a park: %v", err)
+	}
+	if status != TaskStatusLimitParked {
+		t.Fatalf("status = %q, want %q", status, TaskStatusLimitParked)
+	}
+	if strings.HasPrefix(status, "errored") {
+		t.Fatalf("a parked run must never carry an errored status, got %q", status)
+	}
+}
+
+// TestRunTask_ParksNotFailedOnUsageLimit is the end-to-end guard: a cron task
+// whose run parks records the parked status via the normal success path — the
+// deferred failure recorder (which writes "errored: …") never fires, so no
+// failure side-effect occurs. LastRunAt is set so the TUI shows the run
+// happened and is waiting, not stale and not failed.
+func TestRunTask_ParksNotFailedOnUsageLimit(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupTaskRepo(t)
+	stubParkedCreate(t)
+
+	if err := task.AddTask(task.Task{
+		ID:          "ffff0011",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "0 3 * * *",
+		ProjectPath: repo,
+		Enabled:     true,
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+
+	if err := RunTask("ffff0011"); err != nil {
+		t.Fatalf("RunTask must not error on a parked run: %v", err)
+	}
+
+	got, err := task.GetTask("ffff0011")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.LastRunStatus != TaskStatusLimitParked {
+		t.Fatalf("LastRunStatus = %q, want %q (parked, not failed)", got.LastRunStatus, TaskStatusLimitParked)
+	}
+	if strings.HasPrefix(got.LastRunStatus, "errored") {
+		t.Fatalf("parked run must not record an errored status (no failure side-effect)")
+	}
+	if got.LastRunAt == nil {
+		t.Fatalf("LastRunAt must be set for a parked run")
+	}
+}
+
+// TestResumeFromLimit_ParkedTaskSessionReDeliversTaskPrompt closes the loop: a
+// task session parked at startup (live stall, carrying its task prompt) resumes
+// its OWN prompt and clears the limit — parked -> proceeds to completion. A bare
+// "continue" here would silently drop the task's work.
+func TestResumeFromLimit_ParkedTaskSessionReDeliversTaskPrompt(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: true}
+	inst := registerStarted(t, manager, repoID, repoPath, "nightly-task", backend, true, session.Running)
+	inst.Prompt = "run the nightly report"
+	inst.SetLimitReached(time.Now())
+
+	if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: "nightly-task", RepoID: repoID}); err != nil {
+		t.Fatalf("resume of a parked task session failed: %v", err)
+	}
+
+	_, respawnCalls, prompts := backend.snapshot()
+	if respawnCalls != 0 {
+		t.Fatalf("a live-stall park needs no re-spawn, got %d", respawnCalls)
+	}
+	if len(prompts) != 1 || prompts[0] != "run the nightly report" {
+		t.Fatalf("parked task must resume its OWN prompt, got %v (a bare \"continue\" would drop the work)", prompts)
+	}
+	if inst.LimitReached() {
+		t.Fatal("resume must clear the limit so the run proceeds to completion")
+	}
+}

--- a/daemon/taskrun.go
+++ b/daemon/taskrun.go
@@ -10,9 +10,19 @@ import (
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/task"
 )
+
+// TaskStatusLimitParked is the run status recorded when a task-driven session
+// hits a usage-limit wall during startup and is PARKED instead of failed (#1146
+// PR4). It is deliberately NOT an "errored:"-prefixed value, so the TUI and task
+// history show the run waiting for the limit window to reset — not failed — and
+// no failure side-effects fire. The daemon auto-resume scheduler (opt-in) or the
+// manual `c` retry re-delivers the stored prompt once the window resets, after
+// which the run records its normal completion status.
+const TaskStatusLimitParked = "parked: usage limit"
 
 // Indirected so delivery tests can observe the daemon RPCs without dialing —
 // or spawning — a real daemon. Both helpers loop back through the daemon's
@@ -46,6 +56,14 @@ func deliverTaskPrompt(t *task.Task, prompt string) (string, error) {
 		})
 		if err != nil {
 			return "", fmt.Errorf("failed to start task session: %w", err)
+		}
+		// The freshly created session hit a usage-limit wall during startup and
+		// was parked, not failed (#1146 PR4). Record the parked status so the run
+		// is NOT counted as a failure; the resume machinery re-delivers the
+		// prompt once the limit window resets.
+		if data.Liveness == session.LiveLimitReached {
+			log.InfoLog.Printf("task %s parked at a usage limit as instance %s; waiting for the limit window to reset", t.ID, data.Title)
+			return TaskStatusLimitParked, nil
 		}
 		log.InfoLog.Printf("task %s started successfully as instance %s", t.ID, data.Title)
 		return "started", nil

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,7 @@ claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 | `root_agents` | Opt-in table of repositories that get an always-ensured `root` agent (default: none). See [Root agents](#root-agents-always-ensured). |
 | `limit_auto_resume` | Opt in to the daemon auto-resuming a session parked at a usage-limit wall once its limit window elapses (default: `false`). See [Usage-limit auto-resume](#usage-limit-auto-resume). |
 | `limit_retry_interval` | Fallback retry cadence (Go duration, e.g. `30m`) used only when `limit_auto_resume` is on **and** the limit banner carried no parseable reset time (default: `30m`). Empty or `0` disables the fallback. |
+| `limit_patterns` | Optional map from agent enum to a regex that overrides the built-in usage-limit **detection** banner for that agent (the built-in reset-time parser is kept). Default: none. See [Custom usage-limit detection](#custom-usage-limit-detection-limit_patterns). |
 | `keys` | Optional keymap overrides for the TUI. See [Key bindings](#key-bindings-keys). |
 
 ### Root agents (always-ensured)
@@ -75,6 +76,8 @@ Because the default profile skips permission prompts and auto-accepts, only opt 
 
 ### Usage-limit auto-resume
 
+> This section covers the two auto-resume config keys. For the whole usage-limit feature end to end — detection, the `[limit]` badge, manual retry, auto-resume, and task park-don't-fail — see [docs/usage-limits.md](usage-limits.md).
+
 When a `claude` or `codex` session hits a plan usage-limit wall, af marks it with a `[limit]` badge in the sidebar and — when the banner states a reset time — shows when the limit resets. By default the row stays there until you resume it yourself (the `c` key on the session).
 
 `limit_auto_resume = true` opts the **daemon** into resuming such a session on its own once the limit window has elapsed:
@@ -91,6 +94,26 @@ limit_retry_interval = "30m"
 - **Global-only, daemon behavior.** Both keys are rejected in in-repo configs and take effect on the next daemon restart.
 
 Resuming re-delivers the session's stored task prompt (task-driven sessions resume their work); an interactive session with no stored prompt is sent a bare `continue`, which loses the agent's prior in-context state.
+
+- **Task runs park, don't fail.** When a cron/watch task fires while your plan is already exhausted, the task-driven session that hits the wall at startup is **parked** — kept, marked `[limit]`, and recorded with the run status `parked: usage limit` — instead of being torn down and recorded as a failed run. Once the window resets, the same resume machinery (auto-resume or your manual `c` retry) re-delivers the stored task prompt and the run proceeds to completion. See [docs/usage-limits.md](usage-limits.md#task-runs-park-dont-fail).
+
+### Custom usage-limit detection (`limit_patterns`)
+
+The built-in usage-limit detection recognizes the shipped `claude`/`codex`
+banners. If an agent reworded its banner, override the **detection** regex per
+agent with `limit_patterns`; the built-in reset-time parser is kept, so a custom
+detect pattern still schedules auto-resume against the parsed reset time.
+
+```toml
+[limit_patterns]
+claude = "Claude usage limit reached\\."
+codex  = "You've hit your usage limit"
+```
+
+- Keys must be a supported agent enum (`claude`, `codex`, `aider`, `gemini`).
+- An override for an agent with no built-in matcher (`aider`/`gemini` today — they are API-key-metered and have no plan reset window) is ignored with a warning.
+- An uncompilable regex warns and falls back to the built-in default, so a typo can never disable detection.
+- `limit_patterns` is a detection tweak, not a behavior switch: it is honored everywhere the built-in detector runs (the daemon status poll, and the task-run startup park path).
 
 ### Key bindings (`[keys]`)
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -28,7 +28,7 @@ Tasks live in `~/.agent-factory/tasks.json`. Manage them via `af tasks` (JSON CL
 | `project_path` | Repo the task operates on; also the watch script's working directory |
 | `program` | Agent to run (`claude`, `aider`, …). Empty = configured `default_program` |
 | `enabled` | Disabled tasks never fire; their watch script is stopped |
-| `last_run_at` / `last_run_status` | Set by the daemon: `started` (session created), `sent` (prompt delivered into a session), and for watch tasks `stopped` / `errored` (see below) |
+| `last_run_at` / `last_run_status` | Set by the daemon: `started` (session created), `sent` (prompt delivered into a session), `parked: usage limit` (the session hit a plan usage-limit wall at startup and is parked, not failed — see [usage-limits.md](usage-limits.md#task-runs-park-dont-fail)), and for watch tasks `stopped` / `errored` (see below) |
 
 A task with both triggers set is always invalid. An enabled task must have exactly one; a disabled task with neither is tolerated as a draft. An enabled cron task must carry a non-empty prompt — there is no event line to fall back to. Watch tasks are exempt (empty prompt defaults to the emitted line). Disabled drafts are tolerated regardless of prompt.
 

--- a/docs/usage-limits.md
+++ b/docs/usage-limits.md
@@ -1,0 +1,131 @@
+# Usage limits
+
+Subscription-plan agents (`claude`, `codex`) can hit a **plan usage-limit
+wall**: the CLI stops working and prints a banner like *"Claude usage limit
+reached. Your limit will reset at 2pm (America/New_York)"* or *"You've hit your
+usage limit … try again at Jul 25th, 2026 5:55 PM"*. The agent is not dead — it
+is parked until its limit window resets.
+
+Agent Factory detects that state, surfaces it, and can bring the session back on
+its own once the window elapses. This page covers the whole flow end to end.
+
+## What is detected
+
+- **`claude` and `codex`** — their usage-limit banners are recognized, and when
+  the banner states a reset time it is parsed into an absolute instant. These
+  are the plan-metered agents that stall at a dead prompt with a reset window,
+  so they are the only ones that get auto-resume.
+- **`gemini` and `aider`** — **not** detected. They are API-key-metered: a
+  "limit" there is a transient HTTP 429 the CLI already retries, with no plan
+  reset time to schedule against. They are surface-only in the sense that
+  nothing special happens — no badge, no auto-resume.
+
+Detection runs on captured pane content, so it needs no agent cooperation. You
+can tune the detection regex per agent with
+[`limit_patterns`](#custom-detection-patterns).
+
+## The `[limit]` badge
+
+When the daemon's status poll sees a usage-limit banner for a `claude`/`codex`
+session, it marks the session **LimitReached**. In the sidebar the row shows a
+`[limit]` badge, and — when the banner carried a parseable reset time — when the
+limit resets:
+
+```
+▸ fix-auth-bug   [limit] resets 2:00 PM
+```
+
+`[limit]` means "parked at a usage-limit wall", distinct from working, idle
+(ready), or dead. The badge clears automatically once the session resumes work
+(whether you resume it, the daemon auto-resumes it, or the banner scrolls away
+on its own).
+
+## Manual retry (the `c` key)
+
+Select a limit-blocked session and press **`c`** to resume it immediately. This:
+
+1. Re-spawns the agent if its tmux session exited while blocked (the rare case);
+   a live stall just gets nudged.
+2. Re-delivers the pending prompt — a task-driven session re-sends its **stored
+   task prompt** so it resumes its actual work; an interactive session with no
+   stored prompt is sent a bare `continue` (which loses the agent's prior
+   in-context state, an unavoidable limitation — see
+   [anthropics/claude-code#5977](https://github.com/anthropics/claude-code/issues/5977)).
+3. Clears the `[limit]` badge so the poll re-resolves the real state.
+
+The `c` binding is rebindable like any other via the `[keys]` table (action
+`limit_retry`); see [configuration.md](configuration.md#key-bindings-keys).
+
+## Opt-in auto-resume
+
+By default a limit is **surface-only**: the badge plus the manual `c` retry. Set
+`limit_auto_resume = true` in your global config to let the **daemon** resume a
+parked `claude`/`codex` session on its own once its limit window elapses:
+
+```toml
+limit_auto_resume = true
+limit_retry_interval = "30m"   # fallback cadence when a banner states no reset time
+```
+
+- **Parsed reset time** → the daemon resumes shortly after that time (a small
+  grace buffer is added because limit windows are rolling and approximate). A
+  reset time already in the past resumes promptly.
+- **No parseable reset time** → the daemon retries on the fixed
+  `limit_retry_interval` cadence. Set it to empty or `0` to leave such a session
+  surface-only.
+- **Re-limit backoff** → if a resumed session immediately hits the wall again,
+  the daemon backs off exponentially (settling at one attempt every 5 minutes)
+  rather than hammering an exhausted plan. Killing the session is always the
+  off-ramp.
+- **Global-only.** `limit_auto_resume` and `limit_retry_interval` are rejected
+  in in-repo configs and take effect on the next daemon restart.
+
+Full config reference: [configuration.md](configuration.md#usage-limit-auto-resume).
+
+## Task runs: park, don't fail
+
+A **task** (cron or watch) can fire while your plan is already exhausted. When a
+task-driven session hits a usage-limit wall as it starts up — before its prompt
+is even delivered — Agent Factory **parks** the run instead of failing it:
+
+- The session is **kept**, not torn down, and marked `[limit]` (with its reset
+  time) so the badge, the manual `c` retry, and auto-resume all apply to it.
+- The task's run status is recorded as **`parked: usage limit`** — *not* an
+  errored/failed run. It shows in the task manager as waiting for the limit
+  window, and no failure side-effects fire.
+- Once the window resets, the **same resume machinery** takes over: auto-resume
+  (if `limit_auto_resume` is on) or your manual `c` retry re-delivers the
+  session's stored task prompt, and the run proceeds to completion. A parked run
+  becomes a completed one — never a failed one.
+
+Before this behavior, such a run spun a readiness timeout and was recorded as a
+failure even though nothing was actually wrong — you'd just hit your plan limit.
+
+## Scope summary
+
+| Agent | Detected | `[limit]` badge | Manual `c` retry | Auto-resume | Task park |
+|-------|:--------:|:---------------:|:----------------:|:-----------:|:---------:|
+| `claude` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `codex` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `gemini` | — | — | — | — | — |
+| `aider` | — | — | — | — | — |
+
+Auto-resume covers `claude`/`codex` because their banners carry a parseable
+reset window; `gemini`/`aider` are API-key-metered (transient 429s the CLI
+retries) with no plan window to schedule against.
+
+## Custom detection patterns
+
+If an agent reworded its banner, override the detection regex per agent with
+`limit_patterns` (the built-in reset-time parser is kept):
+
+```toml
+[limit_patterns]
+claude = "Claude usage limit reached\\."
+codex  = "You've hit your usage limit"
+```
+
+Keys must be a supported agent (`claude`, `codex`, `aider`, `gemini`); an
+override for an agent with no built-in matcher (`aider`/`gemini` today) is
+ignored, and an uncompilable regex warns and falls back to the built-in default.
+See [configuration.md](configuration.md#custom-usage-limit-detection-limit_patterns).

--- a/task/runner.go
+++ b/task/runner.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -15,6 +16,49 @@ var (
 	waitForReadyTimeout      = 60 * time.Second
 	waitForReadyPollInterval = 500 * time.Millisecond
 )
+
+// LimitReachedError is what WaitForReady returns when the agent shows a
+// usage-limit banner during startup instead of its input prompt (#1146 PR4):
+// the plan is exhausted, so the agent will never become ready and spinning the
+// full readiness timeout would record the task run as FAILED. It is a distinct,
+// NON-failure outcome — callers PARK the session (mark it LimitReached, record a
+// "waiting for the limit window" status, fire no failure side-effects) and let
+// the existing resume machinery (the daemon auto-resume scheduler, or the manual
+// `c` retry) re-deliver the stored prompt once the window resets. ResetAt is the
+// parsed reset time, zero when the banner carried none.
+type LimitReachedError struct {
+	ResetAt time.Time
+}
+
+// ErrLimitReached is the sentinel LimitReachedError wraps so callers can match
+// it with errors.As(&LimitReachedError) or errors.Is(ErrLimitReached) without
+// depending on the concrete type.
+var ErrLimitReached = errors.New("agent hit a usage limit during startup")
+
+func (e *LimitReachedError) Error() string { return ErrLimitReached.Error() }
+
+func (e *LimitReachedError) Unwrap() error { return ErrLimitReached }
+
+// Indirected so tests can pin a fixed detector + clock instead of loading config
+// and calling time.Now(). Production resolves the same limit_patterns overrides
+// the daemon poll uses, so a hand-tuned detect regex parks a task run identically
+// to how it surfaces one (#1146).
+var (
+	newLimitDetectorForWait = defaultLimitDetectorForWait
+	waitLimitNow            = time.Now
+)
+
+// defaultLimitDetectorForWait builds the usage-limit detector WaitForReady uses,
+// honoring config.LimitPatterns. A config-load failure degrades to the built-in
+// claude/codex matchers rather than blocking startup — detection is best-effort
+// and must never break the create path.
+func defaultLimitDetectorForWait() LimitDetector {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return NewLimitDetector(nil)
+	}
+	return NewLimitDetector(cfg.LimitPatterns)
+}
 
 // isReadyContent reports whether the captured pane content indicates that the
 // given agent is ready for input — or is showing a trust/confirmation prompt
@@ -87,6 +131,10 @@ func WaitForReady(instance *session.Instance) error {
 	// program's readiness heuristic, and a non-agent override gets the
 	// generic one instead of waiting 60s for a claude glyph (#1116, #1131).
 	agent := instance.ResolvedAgent()
+	// Resolve the usage-limit detector once so a claude/codex pane that shows a
+	// limit banner mid-startup is recognized and PARKED, not spun into a failure
+	// (#1146 PR4). Only claude/codex ever match; other agents never park here.
+	detector := newLimitDetectorForWait()
 	timeout := time.After(waitForReadyTimeout)
 	ticker := time.NewTicker(waitForReadyPollInterval)
 	defer ticker.Stop()
@@ -108,6 +156,11 @@ func WaitForReady(instance *session.Instance) error {
 				log.ErrorLog.Printf("waitForReady timed out (preview also failed: %v)", err)
 				return formatWaitForReadyTimeoutError(waitForReadyTimeout, "")
 			}
+			// A limit banner may be all that ever rendered: park instead of
+			// failing even at the timeout boundary, symmetric with the ticker case.
+			if perr := limitParkError(detector, content, agent); perr != nil {
+				return perr
+			}
 			log.ErrorLog.Printf("waitForReady timed out. Last pane content: %s", content)
 			return formatWaitForReadyTimeoutError(waitForReadyTimeout, content)
 		case <-ticker.C:
@@ -123,11 +176,28 @@ func WaitForReady(instance *session.Instance) error {
 				}
 				continue
 			}
+			// Check the usage-limit banner BEFORE readiness: a limit-blocked pane
+			// never shows the ready glyph, but checking limit first keeps the
+			// intent explicit and future-proofs against a banner that also carried
+			// one. On a hit, stop waiting and return the park sentinel (#1146).
+			if perr := limitParkError(detector, content, agent); perr != nil {
+				return perr
+			}
 			if isReadyContent(content, agent) {
 				return nil
 			}
 		}
 	}
+}
+
+// limitParkError returns a *LimitReachedError when content shows a usage-limit
+// banner for agent, else nil. Factored out so both the ticker and timeout
+// branches of WaitForReady detect the banner identically (#1146 PR4).
+func limitParkError(detector LimitDetector, content, agent string) error {
+	if hit, resetAt, _ := detector.Check(content, agent, waitLimitNow()); hit {
+		return &LimitReachedError{ResetAt: resetAt}
+	}
+	return nil
 }
 
 // formatWaitForReadyTimeoutError builds the user-facing timeout error. When

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -392,3 +392,105 @@ func TestWaitForReadyTimesOutOnPersistentTransientErrors(t *testing.T) {
 		t.Fatal("WaitForReady never timed out on persistent transient errors")
 	}
 }
+
+// setWaitLimitForTest pins WaitForReady's usage-limit detector and clock so a
+// park test resolves a deterministic reset time without loading config or
+// touching the wall clock (#1146 PR4). Returns a restore func.
+func setWaitLimitForTest(detector LimitDetector, now func() time.Time) func() {
+	prevDet, prevNow := newLimitDetectorForWait, waitLimitNow
+	newLimitDetectorForWait = func() LimitDetector { return detector }
+	waitLimitNow = now
+	return func() {
+		newLimitDetectorForWait, waitLimitNow = prevDet, prevNow
+	}
+}
+
+// TestWaitForReadyParksOnUsageLimit is the core PR4 change (#1146): when the
+// agent shows a usage-limit banner during startup instead of its ready prompt,
+// WaitForReady must STOP waiting and return a *LimitReachedError carrying the
+// parsed reset time — a distinct, NON-failure outcome the create path parks on —
+// rather than spinning the full timeout and returning a failure. The 2s watchdog
+// (well under the 10s test timeout) fails the test on the pre-fix spin-to-timeout
+// behavior.
+func TestWaitForReadyParksOnUsageLimit(t *testing.T) {
+	defer setWaitForReadyTimingForTest(10*time.Second, time.Millisecond)()
+	fixed := time.Date(2026, 7, 4, 9, 0, 0, 0, time.UTC)
+	defer setWaitLimitForTest(NewLimitDetector(nil), func() time.Time { return fixed })()
+
+	cases := []struct {
+		name    string
+		program string
+		banner  string
+		wantUTC time.Time
+	}{
+		{
+			name:    "claude",
+			program: "claude",
+			banner:  "Claude usage limit reached. Your limit will reset at 2pm (America/New_York)",
+			// 2pm America/New_York (EDT, UTC-4) on 2026-07-04 = 18:00 UTC.
+			wantUTC: time.Date(2026, 7, 4, 18, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "codex",
+			program: "codex",
+			banner:  "You've hit your usage limit. Try again at Jul 25th, 2026 5:55 PM.",
+			// codex renders local time; the fixed clock's zone is UTC, so 5:55 PM UTC.
+			wantUTC: time.Date(2026, 7, 25, 17, 55, 0, 0, time.UTC),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := newPreviewInstanceWithProgram(t, tc.program, func() (string, error) {
+				return tc.banner, nil
+			})
+			done := make(chan error, 1)
+			go func() { done <- WaitForReady(inst) }()
+
+			select {
+			case err := <-done:
+				var limitErr *LimitReachedError
+				if !errors.As(err, &limitErr) {
+					t.Fatalf("expected *LimitReachedError, got %v", err)
+				}
+				if !errors.Is(err, ErrLimitReached) {
+					t.Fatalf("park error must wrap ErrLimitReached, got %v", err)
+				}
+				if strings.Contains(err.Error(), "timed out") {
+					t.Fatalf("a park must not be a timeout/failure error, got %q", err.Error())
+				}
+				if got := limitErr.ResetAt.UTC(); !got.Equal(tc.wantUTC) {
+					t.Fatalf("ResetAt = %v, want %v", got, tc.wantUTC)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("WaitForReady did not park on a usage-limit banner; still polling")
+			}
+		})
+	}
+}
+
+// TestWaitForReadyDoesNotParkNonLimitAgent guards the scope boundary (#1146): a
+// gemini/aider pane has no usage-limit matcher, so even a limit-looking banner
+// must NOT park — WaitForReady keeps polling and times out as before. gemini's
+// readiness glyph never appears here, so it hits the (shortened) timeout.
+func TestWaitForReadyDoesNotParkNonLimitAgent(t *testing.T) {
+	defer setWaitForReadyTimingForTest(200*time.Millisecond, time.Millisecond)()
+	defer setWaitLimitForTest(NewLimitDetector(nil), time.Now)()
+
+	inst := newPreviewInstanceWithProgram(t, "gemini", func() (string, error) {
+		return "Claude usage limit reached. Your limit will reset at 2pm (America/New_York)", nil
+	})
+	done := make(chan error, 1)
+	go func() { done <- WaitForReady(inst) }()
+
+	select {
+	case err := <-done:
+		if errors.Is(err, ErrLimitReached) {
+			t.Fatalf("gemini has no limit matcher and must not park, got %v", err)
+		}
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("expected a plain timeout for a non-limit agent, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForReady never returned for a non-limit agent")
+	}
+}


### PR DESCRIPTION
**The FINAL PR of #1146**, on top of merged PR1 (detector), PR2 (`LimitReached` liveness + `[limit]` surface + manual retry), and PR3 (opt-in daemon auto-resume). **Closes #1146.**

## Scope

### 1. Park, don't fail, in the task-run path
Today a task-driven session that hits a usage limit at startup makes `WaitForReady` spin its ~60s readiness timeout and return a FAILURE — the task is recorded failed and failure side-effects fire. This PR parks it instead:

- **`WaitForReady`** now runs the PR1 usage-limit detector over captured pane content. On a claude/codex limit banner it stops waiting and returns a distinct **`*task.LimitReachedError`** (wrapping `ErrLimitReached`) carrying the parsed reset time — a NON-failure outcome the caller can tell apart from both success and a real timeout/death. Only claude/codex ever match; other agents never park.
- **`CreateSession`** translates that outcome via `finishCreateStart`: instead of killing the session and erroring, it KEEPS the session, marks it `LiveLimitReached` with its reset time, and stashes the prompt so resume re-delivers the task's own work. It registers + persists a parked row (the daemon poll + PR3 scheduler then own it).
- The task run records the status **`parked: usage limit`** — not an `errored:` value — so task history/TUI show it *waiting for the window*, not failed, and **no failure side-effects fire** (the `RunTask` errored-status defer never runs because the create returns success). Both task-run entry points are covered: no-target `deliverTaskPrompt` and target-session `DeliverPrompt` (auto-create sub-path).
- Once the window resets, the **existing machinery** finishes the job: PR3's auto-resume (when `limit_auto_resume` is on) or the manual **`c`** retry re-delivers the stored prompt via `resumeFromLimit`, and the parked run proceeds to completion — **parked → completed, never parked → failed**.

### 2. Docs (the feature's public documentation, end to end)
- **New `docs/usage-limits.md`** — the whole feature: detection scope (claude/codex auto-resume vs surface-only gemini/aider), the `[limit]` badge, the manual `c` retry, opt-in auto-resume, task park-don't-fail, and `limit_patterns` overrides.
- **`docs/configuration.md`** — document `limit_patterns` (previously undocumented as a config key), add a task-park note to the auto-resume section, cross-link the feature page. `limit_auto_resume` / `limit_retry_interval` were already documented by PR3.
- **`README.md`** — a *Usage limits* section + documentation-index entry.
- **`docs/tasks.md`** — document the new `parked: usage limit` run status.
- Manual-retry key verified against `keys/keys.go`: it's **`c`** (`KeyLimitRetry`, action `limit_retry`) — documented, not invented.

### 3. Tests (`make test-container` green)
- **task/**: `WaitForReady` parks on claude+codex banners with the parsed reset time and returns a non-failure outcome; a non-limit agent (gemini) never parks and still times out.
- **daemon/**: real `CreateSession` parks (session kept, `LiveLimitReached`, prompt stashed, persisted) rather than killed; `deliverTaskPrompt`/`RunTask` record the parked status and never an `errored:` one (no failure side-effect); a parked task session resumes its OWN prompt and clears the limit (parked→completed). Injected clock / fake backends, mirroring the PR3 test style.

## Verification
`gofmt -l`, `go build ./...`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, and `make test-container` all clean. New logic lives in `daemon/limit.go` / `task/runner.go` so grandfathered `control.go` stays at its length ceiling.

Closes #1146.

_Captain Claude_