### PR TITLE
fix(upgrade): guard af upgrade against silent downgrades (#1212)

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -70,8 +70,17 @@ channel has been testing, and subsequent previews move to `1.0.139-preview-1`.
   prereleases, which are normally the newest. Prereleases are invisible to
   the `releases/latest` API/redirect, so the updater addresses release
   assets by tag.
-- **`af upgrade`** resolves through the same configured channel, so a manual
-  upgrade never downgrades a preview build back to an older stable.
+- **`af upgrade`** resolves through the same configured channel and compares
+  the channel's newest release against the running binary before installing,
+  so a manual upgrade never downgrades. If the resolved release is *older*
+  than the current build — which happens when you flip `update_channel` from
+  `preview` back to `stable` while the newest stable is behind the preview
+  you're on — the command is a no-op and prints, e.g.,
+  `af upgrade would downgrade 1.0.140-preview-2 -> 1.0.139 (stable channel).
+  Re-run with --allow-downgrade to proceed.` Passing `--allow-downgrade`
+  installs the older release anyway (and prints a `Downgrading X -> Y` notice);
+  when you're already on the channel's newest release it reports
+  `Already on the latest <channel> release (<version>).`
 - **`install.sh` and fresh installs** use the `releases/latest/download/...`
   redirect, which GitHub pins to the newest **stable** — new users start
   (and by default stay) on stable. A specific version (stable or preview)

--- a/upgrade.go
+++ b/upgrade.go
@@ -82,9 +82,28 @@ func downloadBinary(url string) ([]byte, error) {
 	return binary, nil
 }
 
+// upgradeAllowDowngrade is the opt-in for intentional channel-switch
+// downgrades (#1212). By default `af upgrade` refuses to install a release
+// that is older than the running binary — e.g. switching update_channel from
+// preview to stable when the newest stable is behind the preview you're on.
+// --allow-downgrade skips that guard.
+var upgradeAllowDowngrade bool
+
+func init() {
+	upgradeCmd.Flags().BoolVar(&upgradeAllowDowngrade, "allow-downgrade", false,
+		"Install the channel's latest release even if it is older than the current binary (e.g. switching from preview back to stable)")
+}
+
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "Upgrade agent-factory to the latest version",
+	Short: "Upgrade agent-factory to the latest release on the configured channel",
+	Long: `Upgrade agent-factory to the newest release on the configured update
+channel (stable by default, or preview via the update_channel config key).
+
+A manual upgrade never downgrades: if the channel's latest release is older
+than the running binary — which happens when you switch from the preview
+channel back to stable — the upgrade is a no-op with an explanation. Pass
+--allow-downgrade to install the older release anyway.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// RequestShutdown's SIGTERM fallback (#504) writes through
 		// log.InfoLog / log.WarningLog. Initialize logging up-front so those
@@ -104,14 +123,70 @@ var upgradeCmd = &cobra.Command{
 		// (#1041). The releases/latest/download redirect only serves the
 		// stable channel; a preview-channel user upgraded through it would
 		// silently downgrade back to the older stable.
-		latestTag, downloadURL, err := latestDownloadURL(updateChannel(), goos, goarch)
+		channel := updateChannel()
+		latestTag, downloadURL, err := latestDownloadURL(channel, goos, goarch)
 		if err != nil {
 			return err
+		}
+
+		// Guard against silently downgrading (#1212): switching from a newer
+		// preview to an older stable resolves an older tag here, and without
+		// this check runUpgrade would happily install it. shouldUpgrade
+		// reuses the same isNewer/parseSemver precedence auto-update relies on.
+		proceed, msg := shouldUpgrade(latestTag, version, channel, upgradeAllowDowngrade)
+		if msg != "" {
+			fmt.Println(msg)
+		}
+		if !proceed {
+			return nil
 		}
 
 		fmt.Printf("Downloading %s for %s/%s...\n", latestTag, goos, goarch)
 		return runUpgrade(downloadURL)
 	},
+}
+
+// shouldUpgrade decides whether `af upgrade` should install latestTag over the
+// currently running version, and returns a user-facing message to print
+// (empty when there is nothing to say beyond the normal download line). It
+// reuses parseSemver/isNewer so preview precedence matches auto-update
+// exactly: 1.2.0 < 1.2.1-preview-1 < 1.2.1-preview-2 < 1.2.1 (#1212).
+//
+//   - latest newer than current  -> proceed (normal upgrade).
+//   - latest older than current  -> refuse unless allowDowngrade, naming both
+//     versions and the channel so a preview->stable switch doesn't silently
+//     roll the binary back.
+//   - already on the latest       -> no-op with a friendly note.
+//   - off-scheme/unparseable tag  -> refuse; we can't prove it isn't a
+//     downgrade, and installing blind is exactly the bug we're guarding.
+func shouldUpgrade(latestTag, current, channel string, allowDowngrade bool) (proceed bool, msg string) {
+	latest := strings.TrimPrefix(latestTag, "v")
+	cur := strings.TrimPrefix(current, "v")
+
+	if parseSemver(latest) == nil {
+		return false, fmt.Sprintf(
+			"Cannot compare latest release %q against the current %s; refusing to upgrade to avoid an accidental downgrade.",
+			latestTag, current)
+	}
+
+	switch {
+	case isNewer(latest, cur):
+		return true, ""
+	case isNewer(cur, latest):
+		// latest is strictly older than current: a real downgrade.
+		if allowDowngrade {
+			return true, fmt.Sprintf("Downgrading %s -> %s (--allow-downgrade).", current, latestTag)
+		}
+		return false, fmt.Sprintf(
+			"af upgrade would downgrade %s -> %s (%s channel). Re-run with --allow-downgrade to proceed.",
+			current, latestTag, channel)
+	default:
+		// Equal base+precedence: already on the channel's latest release.
+		if allowDowngrade {
+			return true, fmt.Sprintf("Reinstalling %s (--allow-downgrade).", latestTag)
+		}
+		return false, fmt.Sprintf("Already on the latest %s release (%s).", channel, current)
+	}
 }
 
 // runUpgrade downloads the release tarball at downloadURL, atomically swaps

--- a/upgrade_test.go
+++ b/upgrade_test.go
@@ -392,6 +392,111 @@ func TestUpgradeReportsSIGTERMFallback(t *testing.T) {
 	}
 }
 
+// TestShouldUpgrade covers the downgrade guard added for #1212: `af upgrade`
+// must proceed only when the channel's latest release is genuinely newer than
+// the running binary, unless --allow-downgrade is set. This is the unit-level
+// guard around runUpgrade's caller so we never hit the network to prove it.
+func TestShouldUpgrade(t *testing.T) {
+	cases := []struct {
+		name          string
+		latestTag     string
+		current       string
+		channel       string
+		allowDown     bool
+		wantProceed   bool
+		wantMsgSubstr string
+	}{
+		{
+			name:        "newer proceeds silently",
+			latestTag:   "v1.0.141",
+			current:     "1.0.140",
+			channel:     "stable",
+			wantProceed: true,
+		},
+		{
+			name:        "newer preview over stable proceeds",
+			latestTag:   "1.0.141-preview-1",
+			current:     "1.0.140",
+			channel:     "preview",
+			wantProceed: true,
+		},
+		{
+			name:          "equal is a no-op",
+			latestTag:     "1.0.140",
+			current:       "1.0.140",
+			channel:       "stable",
+			wantProceed:   false,
+			wantMsgSubstr: "Already on the latest stable release (1.0.140)",
+		},
+		{
+			name:          "older without flag refuses and does not install",
+			latestTag:     "1.0.139",
+			current:       "1.0.140-preview-2",
+			channel:       "stable",
+			wantProceed:   false,
+			wantMsgSubstr: "would downgrade 1.0.140-preview-2 -> 1.0.139 (stable channel)",
+		},
+		{
+			name:          "older with flag proceeds",
+			latestTag:     "1.0.139",
+			current:       "1.0.140-preview-2",
+			channel:       "stable",
+			allowDown:     true,
+			wantProceed:   true,
+			wantMsgSubstr: "Downgrading 1.0.140-preview-2 -> 1.0.139 (--allow-downgrade)",
+		},
+		{
+			name:          "unparseable tag refuses safely",
+			latestTag:     "not-a-version",
+			current:       "1.0.140",
+			channel:       "stable",
+			wantProceed:   false,
+			wantMsgSubstr: "refusing to upgrade",
+		},
+		{
+			name:          "unparseable tag refuses even with flag",
+			latestTag:     "garbage",
+			current:       "1.0.140",
+			channel:       "stable",
+			allowDown:     true,
+			wantProceed:   false,
+			wantMsgSubstr: "refusing to upgrade",
+		},
+		{
+			name:          "equal with flag reinstalls",
+			latestTag:     "1.0.140",
+			current:       "1.0.140",
+			channel:       "stable",
+			allowDown:     true,
+			wantProceed:   true,
+			wantMsgSubstr: "Reinstalling 1.0.140 (--allow-downgrade)",
+		},
+		{
+			name:          "preview precedence: stable outranks its own preview",
+			latestTag:     "1.0.140-preview-9",
+			current:       "1.0.140",
+			channel:       "preview",
+			wantProceed:   false,
+			wantMsgSubstr: "would downgrade 1.0.140 -> 1.0.140-preview-9 (preview channel)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			proceed, msg := shouldUpgrade(tc.latestTag, tc.current, tc.channel, tc.allowDown)
+			if proceed != tc.wantProceed {
+				t.Fatalf("shouldUpgrade proceed = %v, want %v (msg=%q)", proceed, tc.wantProceed, msg)
+			}
+			if tc.wantMsgSubstr != "" && !strings.Contains(msg, tc.wantMsgSubstr) {
+				t.Fatalf("shouldUpgrade msg = %q, want substring %q", msg, tc.wantMsgSubstr)
+			}
+			if tc.wantProceed && tc.wantMsgSubstr == "" && msg != "" {
+				t.Fatalf("shouldUpgrade returned unexpected message on a silent proceed: %q", msg)
+			}
+		})
+	}
+}
+
 func makeTarGz(t *testing.T, files map[string][]byte) []byte {
 	t.Helper()
 


### PR DESCRIPTION
## Problem (#1212)

`af upgrade` could **downgrade** the binary when switching channels.
`upgradeCmd.RunE` resolved the configured channel's latest release
(`latestDownloadURL`) and called `runUpgrade` with **no version
comparison**. So a user on a newer preview (e.g. `1.0.140-preview-2`) who
flips `update_channel` to `stable` — whose latest is older (e.g.
`1.0.139`) — silently got the **older** binary installed.

This contradicted `docs/release-process.md`, which promised "a manual
upgrade never downgrades a preview build back to an older stable."
`autoupdate.go` already guarded this via `isNewer`; `upgrade.go` did not.

## Fix

- Add `shouldUpgrade(latestTag, current, channel, allowDowngrade) (proceed, msg)`
  as a small, unit-testable guard that `RunE` calls before `runUpgrade`.
  It **reuses the existing `isNewer`/`parseSemver`** precedence
  (`1.2.0 < 1.2.1-preview-1 < 1.2.1-preview-2 < 1.2.1`) — no new
  comparator — so it matches auto-update exactly:
  - **newer** → proceed (normal upgrade)
  - **older** → refuse by default, non-fatal no-op, naming both versions
    and the channel:
    `af upgrade would downgrade 1.0.140-preview-2 -> 1.0.139 (stable channel). Re-run with --allow-downgrade to proceed.`
  - **equal** → `Already on the latest <channel> release (<version>).`
  - **off-scheme/unparseable tag** → refuse safely (can't prove it isn't
    a downgrade)
- Add an **`--allow-downgrade`** flag as the explicit opt-in for
  intentional channel-switch downgrades. When set, the guard is skipped
  and a one-line `Downgrading X -> Y (--allow-downgrade).` notice prints
  before installing.
- Channel resolution and daemon-restart behavior are unchanged.

## Docs

`docs/release-process.md`'s "never downgrades" wording is now actually
**true**, and documents the preview→stable no-op UX and the flag. The
guard is described in `af upgrade --help` (short/long text).

## Tests (`make test-container`)

Table-driven `TestShouldUpgrade` covering: newer→proceed;
equal→no-op; older-without-flag→refuse (no install);
older-with-flag→proceed; unparseable→refuse (with and without flag);
equal-with-flag→reinstall; and stable-outranks-its-own-preview
precedence. No network.

## Gates

`golangci-lint run --timeout=3m --fast` · `gofmt -l .` (empty) ·
`go build ./...` · `deadcode -test ./...` · `make test-container` ·
`scripts/lint-file-length.sh` — all green.

Closes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)