### PR TITLE
fix(tmux): log session name as %s arg, not into format string (#1211)

### DIFF
--- a/session/tmux/reap.go
+++ b/session/tmux/reap.go
@@ -107,6 +107,11 @@ func SessionProcessTrees(cmdExec cmd.Executor, sanitizedName string) []proctree.
 // per-process.
 func reapLeakedProcesses(sanitizedName string, procs []proctree.Process, grace, termWait time.Duration) {
 	proctree.KillEscalating(procs, grace, termWait, func(format string, args ...any) {
-		log.WarningLog.Printf("tmux "+sanitizedName+": "+format, args...)
+		// sanitizedName is a runtime value that deliberately preserves `%` (see
+		// tmux name sanitization), so it must be a `%s` ARGUMENT — never spliced
+		// into the format string, where its `%` sequences would be interpreted
+		// and corrupt the log (#1211). `format` itself is a constant literal
+		// supplied by KillEscalating, so concatenating it is safe.
+		log.WarningLog.Printf("tmux %s: "+format, append([]any{sanitizedName}, args...)...)
 	})
 }

--- a/session/tmux/reap_test.go
+++ b/session/tmux/reap_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +16,7 @@ import (
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,6 +63,47 @@ func spawnSessionWithEscapee(t *testing.T, name string) proctree.Process {
 		_ = proctree.Signal(escapee, syscall.SIGKILL)
 	})
 	return escapee
+}
+
+// TestReapLogsSessionNameLiterally is the #1211 regression: a session name is
+// a runtime value that deliberately preserves `%`, so it must be passed as a
+// `%s` argument to the reap logger — never spliced into the format string,
+// where its `%d`/`%s`/`%n` sequences would be interpreted and corrupt the log
+// with `%!s(MISSING)` / `%!d(...)` garbage.
+func TestReapLogsSessionNameLiterally(t *testing.T) {
+	// Redirect the WARNING logger to a buffer for the duration of this test.
+	var buf bytes.Buffer
+	oldOut, oldFlags := log.WarningLog.Writer(), log.WarningLog.Flags()
+	log.WarningLog.SetOutput(&buf)
+	log.WarningLog.SetFlags(0)
+	t.Cleanup(func() {
+		log.WarningLog.SetOutput(oldOut)
+		log.WarningLog.SetFlags(oldFlags)
+	})
+
+	// A real, live child that survives the (near-zero) grace period, so the
+	// reaper actually SIGTERMs it and emits a log line about it.
+	child := exec.Command("sleep", "300")
+	require.NoError(t, child.Start())
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		_, _ = child.Process.Wait()
+	})
+	snap, err := proctree.Snapshot()
+	require.NoError(t, err)
+	proc, ok := snap[child.Process.Pid]
+	require.True(t, ok, "child %d not in snapshot", child.Process.Pid)
+
+	// A session name packed with format specifiers — the exact hazard #1211
+	// describes (tmux sanitization preserves `%`).
+	const name = "af_fmt%d%s%n_evil"
+	reapLeakedProcesses(name, []proctree.Process{proc}, time.Millisecond, 300*time.Millisecond)
+
+	out := buf.String()
+	require.Contains(t, out, "tmux "+name+":",
+		"session name must be logged literally, not interpreted as a format string")
+	require.NotContains(t, out, "%!",
+		"format-string corruption markers (%%!s(MISSING), %%!d(...)) must not appear")
 }
 
 // TestCloseReapsEscapedPaneProcesses is the end-to-end #1104 regression


### PR DESCRIPTION
## What

`reapLeakedProcesses` in `session/tmux/reap.go` spliced the tmux session's `sanitizedName` **directly into the Printf format string**:

```go
log.WarningLog.Printf("tmux "+sanitizedName+": "+format, args...)
```

tmux name sanitization deliberately preserves `%`, so a session named `af_test%d_session` injects a `%d` directive that consumes one of the process-info args, corrupting teardown logs with `%!s(MISSING)` / `%!d(string=yes)` — losing diagnostic value exactly during a leak sweep.

## Fix

Pass `sanitizedName` as a `%s` **argument**, mirroring every other log site in this package (e.g. `tmux.go:1185`):

```go
log.WarningLog.Printf("tmux %s: "+format, append([]any{sanitizedName}, args...)...)
```

`format` is a constant literal supplied by `KillEscalating`, so concatenating it stays safe.

## Format-string audit (the important part)

Swept the whole codebase for Printf-family calls that splice a dynamic/user-influenced string into the **format** argument. **This was the only one.** Every other concat-into-format site either joins string *literals* (constant-folded, safe) or is a printf-wrapper whose `format` param receives literals at its call sites (`detachTracef`). `go vet`'s non-constant-format check is silent here because the call has trailing variadic args, so this required a manual sweep.

**Sites found + fixed: 1 / 1.**

## Test

`TestReapLogsSessionNameLiterally`: drives the reap logger with a `%`-laden session name and asserts it renders literally with no `%!` corruption markers. Fails on the old code, passes on the fix.

## Gates

- `go build ./...` ✅
- `go vet ./session/tmux/` ✅
- `gofmt -l` empty ✅
- `golangci-lint run --fast ./session/tmux/` clean ✅
- New test green ✅

Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude