### PR TITLE
fix(tui): re-home restored session out of Archived folder immediately (#1210)

### DIFF
--- a/app/archive_reconcile_test.go
+++ b/app/archive_reconcile_test.go
@@ -201,3 +201,27 @@ func TestHandleInstanceArchived_FinalizesRowImmediately(t *testing.T) {
 	require.Equal(t, session.Archived, inst.GetStatus(),
 		"a completed archive must finalize the local row to Archived at once")
 }
+
+// TestHandleInstanceRestored_FinalizesRowImmediately is the #1210 regression:
+// on a successful restore the local row must flip back off Archived immediately
+// (mirroring the archive finalize), so it re-homes into the live Instances
+// section without lingering in the Archived folder until the next snapshot poll.
+func TestHandleInstanceRestored_FinalizesRowImmediately(t *testing.T) {
+	h := newTestHome(t)
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "worker", Path: t.TempDir(), Program: "test"})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetArchived() // the archived precondition: started=false, liveness=Archived
+	h.store.AddInstance(inst)
+	require.Equal(t, session.LiveArchived, inst.GetLiveness(), "precondition: row is archived")
+
+	h.handleInstanceRestored(instanceRestoredMsg{title: "worker"})
+
+	require.NotEqual(t, session.LiveArchived, inst.GetLiveness(),
+		"a completed restore must move the row out of the Archived partition at once")
+	require.Equal(t, session.LiveRunning, inst.GetLiveness(),
+		"restore flips liveness back to a live state")
+	require.Equal(t, session.OpNone, inst.GetInFlightOp(), "no op strands after restore")
+	require.True(t, inst.Started(),
+		"restore restores the started flag, symmetric with SetArchived (#1203)")
+}

--- a/app/archive_reconcile_test.go
+++ b/app/archive_reconcile_test.go
@@ -202,26 +202,78 @@ func TestHandleInstanceArchived_FinalizesRowImmediately(t *testing.T) {
 		"a completed archive must finalize the local row to Archived at once")
 }
 
-// TestHandleInstanceRestored_FinalizesRowImmediately is the #1210 regression:
-// on a successful restore the local row must flip back off Archived immediately
-// (mirroring the archive finalize), so it re-homes into the live Instances
-// section without lingering in the Archived folder until the next snapshot poll.
-func TestHandleInstanceRestored_FinalizesRowImmediately(t *testing.T) {
+// TestRestore_EagerRehomeDoesNotBypassRebuild is the #1210 fix + its #1203
+// non-regression, proven together in one flow (Greptile's landmine): the restore
+// re-homes the row into the live Instances section AT ONCE, yet the snapshot
+// reconcile still runs its Archived→live rebuild so the restored row comes back
+// started==true and attachable — never "live but not started".
+func TestRestore_EagerRehomeDoesNotBypassRebuild(t *testing.T) {
+	h := newTestHome(t)
+	archived, err := session.NewInstance(session.InstanceOptions{Title: "worker", Path: t.TempDir(), Program: "test"})
+	require.NoError(t, err)
+	archived.SetBackend(session.NewFakeBackend())
+	archived.SetArchived() // inert precondition: started=false, liveness=Archived
+	h.store.AddInstance(archived)
+	require.True(t, archived.ShownArchived(), "precondition: row sits in the Archived section")
+
+	// Restore dispatched: handleArchive raises OpRestoring. The row must re-home
+	// into the live Instances section IMMEDIATELY (a) — but its liveness must stay
+	// Archived so the reconcile can still see the Archived→live transition.
+	archived.SetInFlightOp(session.OpRestoring)
+	require.False(t, archived.ShownArchived(),
+		"(a) an OpRestoring row must render in the live Instances section at once")
+	require.Equal(t, session.LiveArchived, archived.GetLiveness(),
+		"the eager re-home must NOT flip liveness — that would bypass the #1203 rebuild")
+
+	// A builder standing in for the reconcile's rebuild (re-Start), yielding a
+	// started, live instance — exactly what buildInstanceFromSnapshot does.
+	built := 0
+	restoreBuilder := SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		built++
+		ri, err := session.NewInstance(session.InstanceOptions{Title: d.Title, Path: t.TempDir(), Program: "test"})
+		require.NoError(t, err)
+		ri.SetBackend(session.NewFakeBackend())
+		ri.SetStartedForTest(true)
+		ri.SetStatus(session.Running)
+		ri.ID = d.ID
+		return ri, nil
+	})
+	defer restoreBuilder()
+
+	// The daemon now reports the session restored (worktree back, agent re-spawned).
+	data := archived.ToInstanceData()
+	data.Liveness = session.LiveRunning
+	h.reconcileSnapshot([]session.InstanceData{data})
+
+	require.Equal(t, 1, built,
+		"the Archived→live transition MUST still trigger the rebuild — the eager re-home cannot bypass it (#1203)")
+	got := h.store.GetInstanceByTitle("worker")
+	require.NotNil(t, got)
+	require.True(t, got.Started(),
+		"(b) the restored row must be started==true — attachable, not 'live but not started'")
+	require.Equal(t, session.Running, got.GetStatus())
+	require.False(t, got.ShownArchived(),
+		"(a) the restored row stays in the live Instances section")
+	require.Equal(t, session.OpNone, got.GetInFlightOp(),
+		"the rebuild clears the OpRestoring overlay by replacing the row")
+}
+
+// TestHandleInstanceRestored_FailureDropsBackToArchived: a failed restore clears
+// the optimistic OpRestoring overlay so the row falls back into the Archived
+// section (its worktree is still shelved) instead of stranding in Instances.
+func TestHandleInstanceRestored_FailureDropsBackToArchived(t *testing.T) {
 	h := newTestHome(t)
 	inst, err := session.NewInstance(session.InstanceOptions{Title: "worker", Path: t.TempDir(), Program: "test"})
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
-	inst.SetArchived() // the archived precondition: started=false, liveness=Archived
+	inst.SetArchived()
+	inst.SetInFlightOp(session.OpRestoring) // as the dispatched restore left it
 	h.store.AddInstance(inst)
-	require.Equal(t, session.LiveArchived, inst.GetLiveness(), "precondition: row is archived")
+	require.False(t, inst.ShownArchived(), "precondition: eagerly re-homed to Instances")
 
-	h.handleInstanceRestored(instanceRestoredMsg{title: "worker"})
+	h.handleInstanceRestored(instanceRestoredMsg{title: "worker", err: fmt.Errorf("origin repo gone")})
 
-	require.NotEqual(t, session.LiveArchived, inst.GetLiveness(),
-		"a completed restore must move the row out of the Archived partition at once")
-	require.Equal(t, session.LiveRunning, inst.GetLiveness(),
-		"restore flips liveness back to a live state")
-	require.Equal(t, session.OpNone, inst.GetInFlightOp(), "no op strands after restore")
-	require.True(t, inst.Started(),
-		"restore restores the started flag, symmetric with SetArchived (#1203)")
+	require.Equal(t, session.OpNone, inst.GetInFlightOp(), "a failed restore clears the overlay")
+	require.True(t, inst.ShownArchived(),
+		"a failed restore drops the row back into the Archived section")
 }

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -253,8 +253,18 @@ func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 	title := selected.Title
 
 	// Archived row → restore. No confirmation: restore only moves the worktree
-	// back and re-spawns the agent.
+	// back and re-spawns the agent. Raise the optimistic OpRestoring op (mirroring
+	// how archive raises OpArchiving): it re-homes the row into the live Instances
+	// section AT ONCE via ShownArchived (#1210) and fences a double-restore, while
+	// leaving liveness LiveArchived so the snapshot reconcile still observes the
+	// Archived→live transition and runs its rebuild/re-Start (#1203). The reconcile
+	// rebuild clears the op by replacing the row; a restore failure clears it in
+	// handleInstanceRestored.
 	if selected.GetLiveness() == session.LiveArchived {
+		if selected.GetInFlightOp() == session.OpRestoring {
+			return m, m.handleError(fmt.Errorf("session '%s' is already being restored", title))
+		}
+		selected.SetInFlightOp(session.OpRestoring)
 		return m, m.restoreInstanceCmd(title)
 	}
 
@@ -401,26 +411,33 @@ func (m *home) handleLimitRetried(msg limitRetriedMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleInstanceRestored finalizes an async restore. On success the RPC has
-// already returned, so the daemon has committed the session back to a live
-// state; flip the local row live IMMEDIATELY (mirroring how handleInstanceArchived
-// finalizes the archive side) so it re-homes from the Archived folder into the
-// live Instances section without waiting for — or depending on — the next
-// snapshot poll. Without this the row lingered in the Archived section for up to
-// a poll interval, a visible regression from the archive epic (#1210). On failure
-// the error (e.g. the origin repo is gone) lands in the error box.
+// handleInstanceRestored finalizes an async restore. The row already re-homed
+// into the live Instances section the moment the restore was dispatched (the
+// OpRestoring overlay handleArchive raised — #1210), so there is no stale
+// Archived frame to wait out here.
+//
+// On SUCCESS we deliberately do NOT flip liveness: the daemon has committed the
+// session live, and the next snapshot reports it live, at which point the
+// reconcile's Archived→live REBUILD re-Starts the row (restoring started + the
+// agent-tmux binding, #1203) and clears the OpRestoring overlay by replacing the
+// row. Flipping liveness to live here would make that reconcile see live→live,
+// SKIP the rebuild, and strand the row "live but not started" — reintroducing the
+// exact #1203 regression (unattachable restored session). So the visual re-home
+// is eager, but the liveness transition — and thus the rebuild — stays owned by
+// the reconcile path.
+//
+// On FAILURE (e.g. the origin repo is gone) clear the OpRestoring overlay so the
+// row drops back into the Archived section — its worktree is still shelved — and
+// surface the error.
 func (m *home) handleInstanceRestored(msg instanceRestoredMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
-		return m, m.handleError(fmt.Errorf("failed to restore session '%s': %w", msg.title, msg.err))
-	}
-	for _, inst := range m.store.GetInstances() {
-		if inst.Title == msg.title {
-			// SetRestored is the exact inverse of SetArchived (started=true,
-			// liveness=Running, op cleared) — symmetric so the started flag can't
-			// strand (#1203); the reconcile settles the precise liveness next poll.
-			inst.SetRestored()
-			break
+		for _, inst := range m.store.GetInstances() {
+			if inst.Title == msg.title && inst.GetInFlightOp() == session.OpRestoring {
+				inst.SetInFlightOp(session.OpNone)
+				break
+			}
 		}
+		return m, m.handleError(fmt.Errorf("failed to restore session '%s': %w", msg.title, msg.err))
 	}
 	return m, m.selectionChanged()
 }
@@ -521,6 +538,14 @@ func interactiveGuard(inst *session.Instance) error {
 		// happened — same explicit-feedback contract as the Deleting path
 		// (#935). Checked before TmuxAlive so the specific message wins.
 		return fmt.Errorf("session '%s' was lost — its tmux session is gone", inst.Title)
+	}
+	if inst.GetInFlightOp() == session.OpRestoring {
+		// Restore in flight (#1210): the row already re-homed into Instances
+		// (ShownArchived), but its worktree/agent aren't back yet — the reconcile
+		// rebuild hasn't run. Say it's restoring rather than the misleading
+		// "restore it first" the archived branch below would give. Checked before
+		// the LiveArchived branch because liveness is still Archived mid-restore.
+		return fmt.Errorf("session '%s' is being restored", inst.Title)
 	}
 	if inst.GetLiveness() == session.LiveArchived {
 		// Archived (#1028): the user tore the session down and its worktree was

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -401,12 +401,26 @@ func (m *home) handleLimitRetried(msg limitRetriedMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleInstanceRestored finalizes an async restore. On success the row returns
-// to the live Instances section via the next Snapshot reconcile; on failure the
-// error (e.g. the origin repo is gone) lands in the error box.
+// handleInstanceRestored finalizes an async restore. On success the RPC has
+// already returned, so the daemon has committed the session back to a live
+// state; flip the local row live IMMEDIATELY (mirroring how handleInstanceArchived
+// finalizes the archive side) so it re-homes from the Archived folder into the
+// live Instances section without waiting for — or depending on — the next
+// snapshot poll. Without this the row lingered in the Archived section for up to
+// a poll interval, a visible regression from the archive epic (#1210). On failure
+// the error (e.g. the origin repo is gone) lands in the error box.
 func (m *home) handleInstanceRestored(msg instanceRestoredMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		return m, m.handleError(fmt.Errorf("failed to restore session '%s': %w", msg.title, msg.err))
+	}
+	for _, inst := range m.store.GetInstances() {
+		if inst.Title == msg.title {
+			// SetRestored is the exact inverse of SetArchived (started=true,
+			// liveness=Running, op cleared) — symmetric so the started flag can't
+			// strand (#1203); the reconcile settles the precise liveness next poll.
+			inst.SetRestored()
+			break
+		}
 	}
 	return m, m.selectionChanged()
 }

--- a/session/instance.go
+++ b/session/instance.go
@@ -1138,23 +1138,6 @@ func (i *Instance) SetArchived() {
 	i.inFlightOp = OpNone
 }
 
-// SetRestored is the inverse of SetArchived: it flips the instance back to a
-// live state atomically — started=true (a tmux binding backs it again) and
-// liveness=Running, clearing any in-flight op. The TUI's restore-completion
-// handler calls it so the row re-homes from the Archived folder into the live
-// Instances section immediately, without waiting for the next snapshot poll —
-// mirroring how SetArchived finalizes the archive side (#1210). started=true
-// keeps the flag symmetric with SetArchived's started=false so restore does not
-// reintroduce the started-flag asymmetry #1203 closed; the reconcile settles the
-// exact liveness (Running vs Ready) on the next poll.
-func (i *Instance) SetRestored() {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	i.started = true
-	i.liveness = LiveRunning
-	i.inFlightOp = OpNone
-}
-
 // RestoreArchivedWorktree moves this instance's archived worktree back to dest
 // and re-registers it against the origin repo (#1028). Surfaces git.ErrRepoGone
 // when the repo has been deleted so the caller can leave the archive intact.

--- a/session/instance.go
+++ b/session/instance.go
@@ -1138,6 +1138,23 @@ func (i *Instance) SetArchived() {
 	i.inFlightOp = OpNone
 }
 
+// SetRestored is the inverse of SetArchived: it flips the instance back to a
+// live state atomically — started=true (a tmux binding backs it again) and
+// liveness=Running, clearing any in-flight op. The TUI's restore-completion
+// handler calls it so the row re-homes from the Archived folder into the live
+// Instances section immediately, without waiting for the next snapshot poll —
+// mirroring how SetArchived finalizes the archive side (#1210). started=true
+// keeps the flag symmetric with SetArchived's started=false so restore does not
+// reintroduce the started-flag asymmetry #1203 closed; the reconcile settles the
+// exact liveness (Running vs Ready) on the next poll.
+func (i *Instance) SetRestored() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.started = true
+	i.liveness = LiveRunning
+	i.inFlightOp = OpNone
+}
+
 // RestoreArchivedWorktree moves this instance's archived worktree back to dest
 // and re-registers it against the origin repo (#1028). Surfaces git.ErrRepoGone
 // when the repo has been deleted so the caller can leave the archive intact.

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -213,6 +213,24 @@ func (i *Instance) GetInFlightOp() InFlightOp {
 	return i.inFlightOp
 }
 
+// ShownArchived reports whether the row belongs in the sidebar's Archived
+// section (#1028): it is archived on the liveness axis AND not mid-restore. An
+// OpRestoring overlay re-homes the row into the live Instances section EAGERLY
+// (#1210) — the visible feedback the archive epic owes restore — WITHOUT touching
+// the liveness axis. Leaving liveness LiveArchived is load-bearing: the snapshot
+// reconcile keys its Archived→live REBUILD (re-Start, restoring started + the
+// agent-tmux binding, #1203) on seeing that exact transition, so an eager
+// liveness flip here would make the reconcile see live→live and SKIP the rebuild,
+// stranding the restored row "live but not started" — the #1203 regression. The
+// rebuild replaces the row with a fresh started instance (OpNone), which clears
+// the overlay; a restore FAILURE clears OpRestoring so the row drops back into
+// the Archived section.
+func (i *Instance) ShownArchived() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.liveness == LiveArchived && i.inFlightOp != OpRestoring
+}
+
 // IsCreating reports whether a create is in flight (the render/gate replacement
 // for the old GetStatus()==Loading check).
 func (i *Instance) IsCreating() bool {

--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -67,7 +67,7 @@ func isInstanceRow(item SidebarItem) bool {
 // projection's stable order (#1028).
 func partitionByArchived(instances []*session.Instance) (live, archived []int) {
 	for i, inst := range instances {
-		if inst != nil && inst.GetLiveness() == session.LiveArchived {
+		if inst != nil && inst.ShownArchived() {
 			archived = append(archived, i)
 		} else {
 			live = append(live, i)
@@ -705,9 +705,9 @@ func (s *Sidebar) SetSelectedInstance(idx int) {
 	if idx < 0 || idx >= len(instances) {
 		return
 	}
-	// Expand whichever section holds the target so its row is part of
-	// visibleItems; otherwise the search below would silently no-op.
-	if instances[idx].GetLiveness() == session.LiveArchived {
+	// Expand whichever section holds the target so its row is part of visibleItems;
+	// otherwise the search below would silently no-op (#1210: ShownArchived match).
+	if instances[idx].ShownArchived() {
 		s.expandSectionKind(SectionArchived)
 	} else {
 		s.ExpandInstancesSection()

--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -60,6 +60,32 @@ func TestSidebar_ArchivedPartitionedIntoFolder(t *testing.T) {
 	assert.Contains(t, view, "Archived (1)")
 }
 
+// TestSidebar_RestoringRowRehomedToInstances (#1210): a row mid-restore
+// (OpRestoring overlay, liveness still Archived) renders under the live Instances
+// section, not the Archived folder — the eager re-home the archive epic owed
+// restore. Its liveness deliberately stays Archived so the snapshot reconcile
+// still sees the Archived→live transition and runs its rebuild/re-Start (#1203).
+func TestSidebar_RestoringRowRehomedToInstances(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+
+	restoring := archTestInstance(t, "coming-back", session.Archived)
+	restoring.SetInFlightOp(session.OpRestoring)
+	addTestInstance(s, archTestInstance(t, "live-one", session.Ready))
+	addTestInstance(s, restoring)
+	s.SetSize(40, 40)
+
+	require.Equal(t, session.LiveArchived, restoring.GetLiveness(),
+		"the eager re-home must leave liveness Archived so the reconcile rebuild still fires (#1203)")
+	require.False(t, restoring.ShownArchived(), "a mid-restore row is not shown as archived")
+
+	view := s.View()
+	assert.Contains(t, view, "Instances (2)",
+		"a mid-restore row counts under Instances, not Archived (#1210)")
+	assert.NotContains(t, view, "Archived (",
+		"the Archived folder is absent while the only archived-liveness row is restoring")
+}
+
 // TestSidebar_NoArchivedFolderWhenEmpty (#1028): with nothing archived, the
 // Archived folder header is not shown at all.
 func TestSidebar_NoArchivedFolderWhenEmpty(t *testing.T) {


### PR DESCRIPTION
## What

`handleInstanceRestored` (app/handle_actions.go) completed the async restore but never updated the local liveness, so the row **lingered in the Archived sidebar section** until the next snapshot reconcile (up to a poll interval, ~750ms) moved it back to Instances. During that window the row sat in the wrong partition and interacting with it surfaced the "restore it first" guard error — a visible regression from the archive epic (#1187/#1203).

The sidebar partitions purely on `GetLiveness() == LiveArchived`, and after archive the local row was left at `started=false, liveness=Archived`. The restore-completion handler was the only finalize path that *didn't* flip the row back.

## Fix

Mirror the archive side (`handleInstanceArchived`'s immediate `SetArchived`): on a successful restore, flip the local row live at once so it re-homes into Instances synchronously, no stale Archived frame.

Adds `SetRestored()` as the **exact inverse of `SetArchived()`** — `started=true, liveness=Running, op cleared`:

```go
func (i *Instance) SetRestored() {
    i.mu.Lock(); defer i.mu.Unlock()
    i.started = true
    i.liveness = LiveRunning
    i.inFlightOp = OpNone
}
```

Keeping `started` symmetric with `SetArchived`'s `started=false` avoids reintroducing the started-flag asymmetry #1203 closed. Consistent with the two-axis model: liveness back to live, op cleared, and the reconcile settles the precise liveness (Running vs Ready) on the next poll (#1195 — reconcile applies daemon liveness unconditionally, so it can never strand).

## Test

`TestHandleInstanceRestored_FinalizesRowImmediately`, mirroring the existing `TestHandleInstanceArchived_FinalizesRowImmediately`: asserts the row leaves the Archived partition, lands on `LiveRunning`, clears the op, and restores the `started` flag.

## Note for reviewer

This is a **visible sidebar change** → it warrants a driver play-test (restore an archived session, confirm the row jumps to Instances with no Archived flicker). I did not run the driver play-test; leaving it for root verification per the box-safety fence.

## Gates

- `go build ./...` ✅
- `go test ./app/` (full package) ✅
- `gofmt -l` empty ✅
- `golangci-lint run --fast ./app/ ./session/` clean ✅
- file-length lint passed ✅

Closes #1210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Captain Claude