### PR TITLE
fix(daemon): watcher status persist must not revert task LastRunAt (#1215)

### DIFF
--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -1008,16 +1008,15 @@ func deliverWatchEvent(taskID, line string) error {
 
 // persistWatcherStatus records a watcher lifecycle status on the task:
 // "stopped", or "errored: <exit>: <first output line>" from the crash-loop
-// breaker (#797). LastRunAt is preserved — it tracks event
-// deliveries, not supervision changes. UpdateTaskStatus skips Program enum
-// validation so legacy task records still receive status bumps (#664).
+// breaker (#797). LastRunAt is preserved — it tracks event deliveries, not
+// supervision changes. Passing nil for lastRunAt tells UpdateTaskStatus to
+// leave LastRunAt untouched: reading it here (outside the file lock) and
+// writing it back would revert a newer timestamp a concurrent deliverWatchEvent
+// committed in the gap — the TOCTOU race in #1215. UpdateTaskStatus skips
+// Program enum validation so legacy task records still receive status bumps
+// (#664).
 func persistWatcherStatus(taskID, status string) {
-	t, err := task.GetTask(taskID)
-	if err != nil {
-		log.WarningLog.Printf("failed to load task %s to record watcher status %q: %v", taskID, status, err)
-		return
-	}
-	if err := task.UpdateTaskStatus(taskID, t.LastRunAt, status); err != nil {
+	if err := task.UpdateTaskStatus(taskID, nil, status); err != nil {
 		log.WarningLog.Printf("failed to record watcher status %q on task %s: %v", status, taskID, err)
 	}
 }

--- a/daemon/watcher_test.go
+++ b/daemon/watcher_test.go
@@ -528,6 +528,60 @@ func TestDeliverWatchEvent_RendersTemplateAndRecordsStatus(t *testing.T) {
 	}
 }
 
+// TestPersistWatcherStatus_PreservesLastRunAt is the regression guard for
+// #1215: recording a supervision-status change must update LastRunStatus
+// without reverting the LastRunAt that a prior event delivery committed. The
+// old code read LastRunAt outside the file lock and wrote it back, so a
+// status persist that raced a concurrent deliverWatchEvent could revert the
+// timestamp; persistWatcherStatus now passes nil so LastRunAt is never touched.
+func TestPersistWatcherStatus_PreservesLastRunAt(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repo := setupTaskRepo(t)
+	_, sends := stubTaskDelivery(t)
+	seedTargetSession(t, repo, "captain")
+
+	if err := task.AddTask(task.Task{
+		ID:            "cafe0002",
+		Name:          "gh-issues",
+		Prompt:        "Triage: {{line}}",
+		WatchCmd:      "watch.sh",
+		TargetSession: "captain",
+		ProjectPath:   repo,
+		Enabled:       true,
+		CreatedAt:     time.Now(),
+	}); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+
+	// An event delivery stamps a fresh LastRunAt.
+	if err := deliverWatchEvent("cafe0002", "new issue #9"); err != nil {
+		t.Fatalf("deliverWatchEvent: %v", err)
+	}
+	_ = sends
+	delivered, err := task.GetTask("cafe0002")
+	if err != nil {
+		t.Fatalf("GetTask after delivery: %v", err)
+	}
+	if delivered.LastRunAt == nil {
+		t.Fatalf("expected LastRunAt set after delivery")
+	}
+	deliveredAt := *delivered.LastRunAt
+
+	// A supervision-status persist must not revert that timestamp.
+	persistWatcherStatus("cafe0002", "stopped")
+
+	got, err := task.GetTask("cafe0002")
+	if err != nil {
+		t.Fatalf("GetTask after persist: %v", err)
+	}
+	if got.LastRunStatus != "stopped" {
+		t.Fatalf("expected LastRunStatus=stopped, got %q", got.LastRunStatus)
+	}
+	if got.LastRunAt == nil || !got.LastRunAt.Equal(deliveredAt) {
+		t.Fatalf("persistWatcherStatus reverted LastRunAt: want %v, got %v", deliveredAt, got.LastRunAt)
+	}
+}
+
 // syncBuffer is a mutex-guarded bytes.Buffer so tests can read captured log
 // output while watcher goroutines may still be writing it.
 type syncBuffer struct {

--- a/task/task.go
+++ b/task/task.go
@@ -284,6 +284,11 @@ func LoadTasksForCurrentRepo() ([]Task, error) {
 // fail current enum validation can still have their run status bumped by the
 // scheduler and TUI dispatch paths. Returns an error if no task with the given
 // ID exists.
+//
+// A nil lastRunAt means "leave LastRunAt untouched" — only LastRunStatus is
+// written. Callers that record a supervision-status change (not an event
+// delivery) pass nil so a concurrent writer's newer LastRunAt is never reverted
+// by a value the caller read outside the file lock (#1215).
 func UpdateTaskStatus(taskID string, lastRunAt *time.Time, lastRunStatus string) error {
 	if err := ValidateTaskID(taskID); err != nil {
 		return err
@@ -301,7 +306,13 @@ func UpdateTaskStatus(taskID string, lastRunAt *time.Time, lastRunStatus string)
 		found := false
 		for i := range tasks {
 			if tasks[i].ID == taskID {
-				tasks[i].LastRunAt = lastRunAt
+				// nil means "preserve the on-disk LastRunAt": a status-only
+				// update must not clobber a newer event-delivery timestamp that
+				// a concurrent writer committed while this caller held a stale
+				// copy (#1215).
+				if lastRunAt != nil {
+					tasks[i].LastRunAt = lastRunAt
+				}
 				tasks[i].LastRunStatus = lastRunStatus
 				found = true
 				break

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -392,6 +392,33 @@ func TestUpdateTaskStatus_BypassesProgramValidation(t *testing.T) {
 	assert.Equal(t, "/home/foo/bin/claude", got.Program, "Program must not be touched by status updates")
 }
 
+// TestUpdateTaskStatus_NilLastRunAtPreservesTimestamp is the regression guard
+// for #1215: a status-only update (lastRunAt == nil) must write LastRunStatus
+// without touching the on-disk LastRunAt. persistWatcherStatus relies on this
+// so a supervision-status write can't revert a newer event-delivery timestamp
+// committed by a concurrent deliverWatchEvent.
+func TestUpdateTaskStatus_NilLastRunAtPreservesTimestamp(t *testing.T) {
+	existing := time.Now().Truncate(time.Second)
+	stored := []Task{
+		{ID: "w1", Name: "Watcher", Prompt: "p", WatchCmd: "tail -f x", ProjectPath: "/tmp", Enabled: true, LastRunAt: &existing, LastRunStatus: "completed"},
+	}
+	setupTestTasks(t, stored)
+
+	// A newer event delivery lands first (this is the value we must not lose).
+	newer := existing.Add(90 * time.Second)
+	require.NoError(t, UpdateTaskStatus("w1", &newer, "completed"))
+
+	// A supervision-status write races in with a nil timestamp.
+	require.NoError(t, UpdateTaskStatus("w1", nil, "stopped"))
+
+	got, err := GetTask("w1")
+	require.NoError(t, err)
+	require.NotNil(t, got.LastRunAt)
+	assert.True(t, got.LastRunAt.Equal(newer),
+		"nil lastRunAt must preserve the newer on-disk timestamp, not revert it")
+	assert.Equal(t, "stopped", got.LastRunStatus, "LastRunStatus must still update")
+}
+
 // TestUpdateTaskStatus_NotFound verifies the not-found error path that the
 // runner / TUI rely on to log a meaningful failure when a task is deleted
 // mid-run.


### PR DESCRIPTION
## Summary

Fixes the TOCTOU lost-update reported in #1215. `persistWatcherStatus` read the task via `GetTask()` **outside** the file lock, then passed that stale `t.LastRunAt` into `UpdateTaskStatus`, which wrote it back **inside** the lock. A concurrent `deliverWatchEvent` that committed a newer `LastRunAt` in the gap was silently reverted — the classic read-outside-lock / write-inside-lock race. The code comment already documented the intent ("LastRunAt is preserved — it tracks event deliveries, not supervision changes"); the implementation violated it.

**Verified still reproducing on current master** (343d0cb) before fixing — the #960/#1194 single-writer work did not touch this daemon-internal path.

## Fix

Per the report's recommendation:
- `UpdateTaskStatus` now treats a `nil` `lastRunAt` as "leave `LastRunAt` untouched" — only `LastRunStatus` is written.
- `persistWatcherStatus` passes `nil` and **drops the `GetTask` read entirely**, so there is no TOCTOU window at all.

## Adjacent call-site audit

The other three `UpdateTaskStatus` callers (`deliverWatchEvent`, both `taskrun.go` sites) all pass a fresh `&now` generated at call time — the intended `LastRunAt` write. None read a timestamp outside the lock, so none share the bug. No change needed.

## Tests

- `task.TestUpdateTaskStatus_NilLastRunAtPreservesTimestamp` — a `nil` status-only update preserves a newer on-disk `LastRunAt` (fails on the old unconditional assignment).
- `daemon.TestPersistWatcherStatus_PreservesLastRunAt` — end-to-end: a supervision-status persist keeps the delivered `LastRunAt` and updates `LastRunStatus`.

## Gates

`go build` ✓ · `gofmt -l` empty ✓ · `golangci-lint --fast` ✓ · file-length lint ✓ · `make test-container` (task + daemon) ✓

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)