### PR TITLE
fix(tui): task pane save must not clobber unedited tasks (#1213)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -943,7 +943,11 @@ func (m *home) saveContentPaneState() error {
 	// in-process, so there is no separate ReloadTasks poke here — the write and
 	// its schedule refresh are one atomic daemon call (removing the old
 	// double-reload).
-	for _, tsk := range sp.GetTasks() {
+	//
+	// Persist ONLY the tasks the user actually edited (ConsumeDirty), not the
+	// whole pane: an unmodified task changed out-of-band (CLI, daemon) while the
+	// pane was open must not be clobbered by the pane's stale copy — #1213.
+	for _, tsk := range sp.ConsumeDirty() {
 		if err := updateTaskThroughDaemon(tsk); err != nil {
 			log.ErrorLog.Printf("failed to update task: %v", err)
 			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save task %q: %w", tsk.Name, err))

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -377,6 +377,81 @@ func TestSaveContentPaneState_RoutesThroughDaemonRPC(t *testing.T) {
 	}
 }
 
+// TestSaveContentPaneState_DoesNotClobberUneditedTask is the regression guard
+// for #1213: saving a dirty task pane must persist ONLY the tasks the user
+// actually edited, never the whole pane. Before the fix, saveContentPaneState
+// iterated every task in the pane and wrote each back, so a stale pane copy of
+// an untouched task silently overwrote a change another writer (CLI, daemon)
+// committed while the pane was open — a lost update.
+//
+// Scenario: the user opens the manager and toggles Task A (only A is dirty).
+// While the pane is open, the CLI changes Task B's prompt on disk. Closing the
+// manager must land A's toggle without reverting B's out-of-band change.
+func TestSaveContentPaneState_DoesNotClobberUneditedTask(t *testing.T) {
+	h := newTestHome(t)
+
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+
+	// newTestHome points the write seams at the direct disk writers, so the
+	// save-on-close and the simulated CLI write both land in the same tasks.json.
+	taskA := task.Task{
+		ID: "task-a-1213", Name: "Task A", Prompt: "prompt A", CronExpr: "* * * * *",
+		ProjectPath: repo.Root, Program: "claude", Enabled: true, CreatedAt: time.Now(),
+	}
+	taskB := task.Task{
+		ID: "task-b-1213", Name: "Task B", Prompt: "prompt B original", CronExpr: "* * * * *",
+		ProjectPath: repo.Root, Program: "claude", Enabled: true, CreatedAt: time.Now(),
+	}
+	require.NoError(t, task.AddTask(taskA))
+	require.NoError(t, task.AddTask(taskB))
+
+	loaded, err := task.LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	tp := h.automations.TaskPane()
+	tp.SetTasks(loaded)
+	h.store.SetTasks(loaded)
+	_, _ = h.showTasksOverlay()
+	require.Equal(t, stateTasks, h.state)
+
+	// User toggles Task A (index 0) off — only A is dirty; B is never touched.
+	tp.SelectTask(0)
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	require.True(t, tp.IsDirty(), "toggling A must mark the pane dirty")
+
+	// The CLI changes Task B on disk while the pane is open, holding a stale B.
+	cliB := taskB
+	cliB.Prompt = "CLI MODIFIED"
+	require.NoError(t, task.UpdateTask(cliB))
+
+	// Esc releases focus → the overlay closes and saveContentPaneState runs.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
+	require.Equal(t, stateDefault, h.state)
+
+	disk, err := task.LoadTasks()
+	require.NoError(t, err)
+	byID := map[string]task.Task{}
+	for _, tk := range disk {
+		byID[tk.ID] = tk
+	}
+
+	// A's edit landed.
+	gotA, ok := byID["task-a-1213"]
+	require.True(t, ok)
+	assert.False(t, gotA.Enabled, "the toggled task A must be persisted")
+
+	// B's out-of-band CLI change survives — the untouched task was NOT written
+	// back from the stale pane copy (the #1213 lost update).
+	gotB, ok := byID["task-b-1213"]
+	require.True(t, ok)
+	assert.Equal(t, "CLI MODIFIED", gotB.Prompt,
+		"unedited Task B must keep the concurrent CLI change, not be clobbered by the stale pane copy")
+}
+
 // dirtyHooksHome returns a home wired to a real repo with a single dirty,
 // unsaved hook edit ("echo test") in the HooksPane. The hooks-save seam is
 // left at the caller's discretion (default real save, or a stub).

--- a/scripts/file-length-allowlist.txt
+++ b/scripts/file-length-allowlist.txt
@@ -23,7 +23,6 @@ session/instance.go 1531
 session/tmux/tmux.go 1424
 ui/sidebar.go 1258
 config/config.go 1128
-ui/task_pane.go 1050
 daemon/watcher.go 1046
 session/backend_hook.go 1026
 

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -89,8 +89,15 @@ type TaskPane struct {
 
 	width, height int
 	dirty         bool
-	deleted       []task.Task
-	hasFocus      bool
+	// dirtyIDs records which tasks the user actually edited (toggle/enabled or
+	// field edit) since the pane was loaded, keyed by task ID. saveContentPaneState
+	// persists ONLY these, so a save can't overwrite an unmodified task whose
+	// on-disk copy a concurrent writer (CLI/daemon) changed while the pane was
+	// open — the lost-update in #1213. Deletions stay tracked separately in
+	// `deleted` (mirrors ConsumeDeleted).
+	dirtyIDs map[string]bool
+	deleted  []task.Task
+	hasFocus bool
 }
 
 // NewTaskPane creates a new task pane.
@@ -104,78 +111,10 @@ func (s *TaskPane) SetSize(width, height int) {
 	s.height = height
 }
 
-// SetTasks sets the task data.
-func (s *TaskPane) SetTasks(tasks []task.Task) {
-	s.tasks = tasks
-	s.dirty = false
-	s.deleted = nil
-	s.editing = false
-	if len(s.tasks) == 0 {
-		s.selectedIdx = 0
-	} else if s.selectedIdx >= len(s.tasks) {
-		s.selectedIdx = len(s.tasks) - 1
-	}
-}
-
-// GetTasks returns the current tasks.
-func (s *TaskPane) GetTasks() []task.Task {
-	return s.tasks
-}
-
-// SelectTask moves the list selection to idx (clamped). The tasks overlay
-// uses it to open the manager on the task the in-rail cursor was resting on.
-func (s *TaskPane) SelectTask(idx int) {
-	if idx < 0 {
-		idx = 0
-	}
-	if idx >= len(s.tasks) {
-		idx = len(s.tasks) - 1
-	}
-	if idx >= 0 {
-		s.selectedIdx = idx
-	}
-}
-
-// ConsumeDeleted returns the tasks pending deletion and clears the pane's
-// dirty state so a subsequent save can't reprocess already-deleted tasks. The
-// deletion loop in saveContentPaneState removes task records as a side
-// effect, so re-running it would call RemoveTask on records that no longer
-// exist and log spurious errors (fixes #763).
-func (s *TaskPane) ConsumeDeleted() []task.Task {
-	deleted := s.deleted
-	s.deleted = nil
-	s.dirty = false
-	return deleted
-}
-
-// IsDirty returns true if tasks were modified.
-func (s *TaskPane) IsDirty() bool {
-	return s.dirty
-}
-
-// HasFocus returns whether the pane has input focus.
-func (s *TaskPane) HasFocus() bool {
-	return s.hasFocus
-}
-
-// SetFocus sets the focus state.
-func (s *TaskPane) SetFocus(focus bool) {
-	s.hasFocus = focus
-	if !focus {
-		s.editing = false
-		s.creating = false
-	}
-}
-
-// IsEditing returns true if in edit mode.
-func (s *TaskPane) IsEditing() bool {
-	return s.editing
-}
-
-// IsCreating returns true if in create mode.
-func (s *TaskPane) IsCreating() bool {
-	return s.creating
-}
+// The TaskPane's task-list, selection, dirty-tracking, and focus/mode state
+// accessors live in task_pane_state.go (SetTasks, GetTasks, SelectTask,
+// ConsumeDirty, ConsumeDeleted, IsDirty, focus/mode getters). This file keeps
+// the create/edit form, rendering, and key handling.
 
 // initForm builds the shared create/edit field set. A nil task initializes an
 // empty create form (path prefilled with defaultPath); otherwise the fields
@@ -405,7 +344,7 @@ func (s *TaskPane) handleNormalMode(msg tea.KeyMsg) bool {
 	case "x":
 		if len(s.tasks) > 0 {
 			s.tasks[s.selectedIdx].Enabled = !s.tasks[s.selectedIdx].Enabled
-			s.dirty = true
+			s.markTaskDirty(s.tasks[s.selectedIdx].ID)
 		}
 		return true
 	case "D":
@@ -413,6 +352,10 @@ func (s *TaskPane) handleNormalMode(msg tea.KeyMsg) bool {
 			deleted := s.tasks[s.selectedIdx]
 			s.deleted = append(s.deleted, deleted)
 			s.tasks = append(s.tasks[:s.selectedIdx], s.tasks[s.selectedIdx+1:]...)
+			// A task queued for deletion must not also be in the update set:
+			// removeTaskThroughDaemon handles it, and an update on a just-removed
+			// task would log a spurious not-found error.
+			delete(s.dirtyIDs, deleted.ID)
 			s.dirty = true
 			if s.selectedIdx >= len(s.tasks) && s.selectedIdx > 0 {
 				s.selectedIdx--
@@ -548,7 +491,7 @@ func (s *TaskPane) handleEditMode(msg tea.KeyMsg) bool {
 			s.tasks[s.selectedIdx].TargetSession = s.editTarget.Value()
 			s.tasks[s.selectedIdx].ProjectPath = absPath
 			s.tasks[s.selectedIdx].Program = s.programValue()
-			s.dirty = true
+			s.markTaskDirty(s.tasks[s.selectedIdx].ID)
 			s.editing = false
 		}
 		return true

--- a/ui/task_pane_state.go
+++ b/ui/task_pane_state.go
@@ -1,0 +1,116 @@
+package ui
+
+import "github.com/sachiniyer/agent-factory/task"
+
+// This file holds the TaskPane's task-list, selection, dirty-tracking, and
+// focus/mode state accessors — the non-rendering, non-key-handling surface the
+// app layer drives. Split out of task_pane.go to keep that file under the
+// file-length limit (#1145); the rendering and key-handling code stays there.
+
+// SetTasks sets the task data.
+func (s *TaskPane) SetTasks(tasks []task.Task) {
+	s.tasks = tasks
+	s.dirty = false
+	s.dirtyIDs = nil
+	s.deleted = nil
+	s.editing = false
+	if len(s.tasks) == 0 {
+		s.selectedIdx = 0
+	} else if s.selectedIdx >= len(s.tasks) {
+		s.selectedIdx = len(s.tasks) - 1
+	}
+}
+
+// GetTasks returns the current tasks.
+func (s *TaskPane) GetTasks() []task.Task {
+	return s.tasks
+}
+
+// SelectTask moves the list selection to idx (clamped). The tasks overlay
+// uses it to open the manager on the task the in-rail cursor was resting on.
+func (s *TaskPane) SelectTask(idx int) {
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(s.tasks) {
+		idx = len(s.tasks) - 1
+	}
+	if idx >= 0 {
+		s.selectedIdx = idx
+	}
+}
+
+// markTaskDirty records that the task with the given ID was edited so a later
+// save persists it. It also sets the pane-wide dirty flag that gates whether
+// saveContentPaneState runs at all (#1213).
+func (s *TaskPane) markTaskDirty(id string) {
+	if s.dirtyIDs == nil {
+		s.dirtyIDs = make(map[string]bool)
+	}
+	s.dirtyIDs[id] = true
+	s.dirty = true
+}
+
+// ConsumeDirty returns the tasks the user actually edited since the pane was
+// loaded and clears the per-task dirty set. saveContentPaneState persists only
+// these — never the full task list — so saving an edit to one task can't write
+// a stale pane copy of an UNMODIFIED task back over a change another writer
+// (CLI/daemon) committed while the pane was open (#1213). Mirrors the
+// per-task tracking that ConsumeDeleted already does for deletions. The
+// pane-wide dirty flag is left to ConsumeDeleted to clear so a save that has
+// both edits and deletions still processes both.
+func (s *TaskPane) ConsumeDirty() []task.Task {
+	if len(s.dirtyIDs) == 0 {
+		s.dirtyIDs = nil
+		return nil
+	}
+	var modified []task.Task
+	for _, t := range s.tasks {
+		if s.dirtyIDs[t.ID] {
+			modified = append(modified, t)
+		}
+	}
+	s.dirtyIDs = nil
+	return modified
+}
+
+// ConsumeDeleted returns the tasks pending deletion and clears the pane's
+// dirty state so a subsequent save can't reprocess already-deleted tasks. The
+// deletion loop in saveContentPaneState removes task records as a side
+// effect, so re-running it would call RemoveTask on records that no longer
+// exist and log spurious errors (fixes #763).
+func (s *TaskPane) ConsumeDeleted() []task.Task {
+	deleted := s.deleted
+	s.deleted = nil
+	s.dirty = false
+	return deleted
+}
+
+// IsDirty returns true if tasks were modified.
+func (s *TaskPane) IsDirty() bool {
+	return s.dirty
+}
+
+// HasFocus returns whether the pane has input focus.
+func (s *TaskPane) HasFocus() bool {
+	return s.hasFocus
+}
+
+// SetFocus sets the focus state.
+func (s *TaskPane) SetFocus(focus bool) {
+	s.hasFocus = focus
+	if !focus {
+		s.editing = false
+		s.creating = false
+	}
+}
+
+// IsEditing returns true if in edit mode.
+func (s *TaskPane) IsEditing() bool {
+	return s.editing
+}
+
+// IsCreating returns true if in create mode.
+func (s *TaskPane) IsCreating() bool {
+	return s.creating
+}

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newGitRepo creates a throwaway git repository and returns its absolute path.
@@ -56,6 +57,58 @@ func TestTaskPaneSetTasksClampsSelectedIdx(t *testing.T) {
 
 	tp.SetTasks([]task.Task{{ID: "a"}})
 	assert.Equal(t, 0, tp.selectedIdx)
+}
+
+// TestTaskPaneConsumeDirtyTracksOnlyEditedTasks is the pane-level regression
+// guard for #1213: only tasks the user actually edited (toggle or field edit)
+// are returned by ConsumeDirty, so the save path never rewrites unmodified
+// tasks. A no-edit pane returns nothing; toggling one task in a two-task pane
+// returns only that task.
+func TestTaskPaneConsumeDirtyTracksOnlyEditedTasks(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{
+		{ID: "a", Name: "A", Enabled: true},
+		{ID: "b", Name: "B", Enabled: true},
+	})
+	tp.SetFocus(true)
+
+	// Nothing edited yet.
+	assert.Empty(t, tp.ConsumeDirty(), "an unedited pane must have no dirty tasks")
+	assert.False(t, tp.IsDirty())
+
+	// Toggle only task A (selectedIdx defaults to 0).
+	assert.True(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")}))
+	assert.True(t, tp.IsDirty(), "toggling a task marks the pane dirty")
+
+	dirty := tp.ConsumeDirty()
+	require.Len(t, dirty, 1, "only the toggled task must be dirty")
+	assert.Equal(t, "a", dirty[0].ID)
+	assert.False(t, dirty[0].Enabled, "the dirty task carries the toggled value")
+
+	// ConsumeDirty clears the set: a second call returns nothing.
+	assert.Empty(t, tp.ConsumeDirty(), "ConsumeDirty must clear the dirty set")
+}
+
+// TestTaskPaneConsumeDirtyExcludesDeletedTask verifies that a task edited and
+// then deleted is not returned by ConsumeDirty — deletion is handled by
+// ConsumeDeleted, and updating a just-removed task would log a spurious
+// not-found error (#1213 / #763).
+func TestTaskPaneConsumeDirtyExcludesDeletedTask(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{
+		{ID: "a", Name: "A", Enabled: true},
+		{ID: "b", Name: "B", Enabled: true},
+	})
+	tp.SetFocus(true)
+
+	// Toggle A (dirty), then delete A.
+	assert.True(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")}))
+	assert.True(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")}))
+
+	assert.Empty(t, tp.ConsumeDirty(), "a deleted task must not appear in the dirty update set")
+	deleted := tp.ConsumeDeleted()
+	require.Len(t, deleted, 1)
+	assert.Equal(t, "a", deleted[0].ID)
 }
 
 // TestTaskPaneConsumePendingTriggerEmpty verifies that ConsumePendingTrigger


### PR DESCRIPTION
## Summary

Fixes the lost-update reported in #1213. When a dirty task pane was saved, `saveContentPaneState` iterated `sp.GetTasks()` and wrote **every** task through the daemon update RPC — not just the ones the user edited. So editing Task A and saving persisted a **stale pane copy of Task B** over any change the CLI/daemon had committed to B while the pane was open, silently clobbering it.

**Verified still reproducing on current master** (343d0cb) before fixing. Routing through the daemon (#1194/#960) did **not** close this: `daemon.UpdateTask` still overwrites user-editable fields (Name, Prompt, CronExpr, WatchCmd, TargetSession, Program, Enabled) from the caller's struct, so a full-pane write is still a lost update.

## Fix

Track per-task edits and persist only those, mirroring the existing `ConsumeDeleted` pattern for deletions:
- `TaskPane` gains a `dirtyIDs` set; the toggle (`x`) and edit-commit paths call `markTaskDirty(id)`; deletion drops the id from the set so a removed task isn't also "updated" (spurious not-found).
- New `ConsumeDirty()` returns only the edited tasks and clears the set.
- `saveContentPaneState` iterates `ConsumeDirty()` instead of `GetTasks()`.

Unmodified tasks are never written, so a concurrent out-of-band change survives a pane save.

## File-length lint (#1145)

`ui/task_pane.go` was exactly at its 1050 grandfathered ceiling, so the new methods would break the lint. Decomposed the pane's state/selection/dirty/focus accessors into `ui/task_pane_state.go`, bringing `task_pane.go` to 993 lines (under the 1000 limit) and **removed its allowlist entry**.

## Tests

- `app.TestSaveContentPaneState_DoesNotClobberUneditedTask` — edit A, CLI changes B out-of-band, save; B's change must survive. Reproduces the report's exact failure (`prompt B original`) on the old code and passes on the fix.
- `ui.TestTaskPaneConsumeDirtyTracksOnlyEditedTasks` / `TestTaskPaneConsumeDirtyExcludesDeletedTask` — per-task dirty tracking, and that a deleted task is excluded from the update set.

## Gates

`go build` ✓ · `gofmt -l` empty ✓ · `golangci-lint --fast` ✓ · `deadcode` ✓ · file-length lint ✓ · `make test-container` (ui + app + task) ✓

Closes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)