### PR TITLE
fix(daemon): detect daemon under binary paths with spaces (#1214)

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -672,55 +672,57 @@ func cleanupDaemonRuntimeFiles(pidFile string) {
 }
 
 // isAgentFactoryDaemon checks whether the process at pid looks like an agent-factory daemon:
-// its command line must carry the --daemon flag as a discrete argument AND its executable must
-// be an agent-factory binary ("af" or "agent-factory"). It tries /proc/<pid>/cmdline first
-// (Linux) and falls back to `ps -p <pid> -o args=` (macOS and other unixes). If neither source
-// yields a readable command line, returns false so callers treat the PID as unverified.
+// its argv must carry the --daemon flag as a discrete argument AND its executable must be an
+// agent-factory binary ("af" or "agent-factory"). It reads the process argv with argument
+// boundaries preserved (see daemonArgs); if no readable argv is available, returns false so
+// callers treat the PID as unverified.
 //
 // Both checks are required so that a stale PID file whose PID has been reused by an unrelated
 // process carrying a "--daemon" token (e.g. "sleep --daemon af-test") is not mistaken for our
 // daemon and signaled by StopDaemon/locateDaemonPID. This mirrors the host-wide pgrep scan in
-// sigterm_fallback.go, which already requires both cmdlineHasDaemonFlag and cmdlineIsDaemonBinary;
+// sigterm_fallback.go, which also requires both argsHaveDaemonFlag and argsAreDaemonBinary;
 // the two PID-validation paths must agree (#1004).
 //
-// We split the command line on whitespace and require an exact "--daemon" token (or a
-// "--daemon=..." form), so flags like --daemonize don't get matched as substrings.
+// Detection operates on real argv elements (not a space-joined string), so a binary installed
+// under a path containing spaces — e.g. "/home/John Smith/.local/bin/af" — is classified
+// correctly instead of having its path shredded across argv boundaries (#1214). We still require
+// an exact "--daemon" token (or the "--daemon=..." form), so flags like --daemonize never match.
 func isAgentFactoryDaemon(pid int) bool {
-	cmdline := readProcCmdline(pid)
-	if cmdline == "" {
-		cmdline = readPsArgs(pid)
-	}
-	if cmdline == "" {
+	args := daemonArgs(pid)
+	if len(args) == 0 {
 		return false
 	}
-	return cmdlineHasDaemonFlag(cmdline) && cmdlineIsDaemonBinary(cmdline)
+	return argsHaveDaemonFlag(args) && argsAreDaemonBinary(args)
 }
 
-// cmdlineHasDaemonFlag reports whether cmdline contains "--daemon" as a discrete argument
-// (either bare or in the "--daemon=value" form). It deliberately rejects substring matches like
-// "--daemonize" or "--daemon-mode".
-func cmdlineHasDaemonFlag(cmdline string) bool {
-	for _, field := range strings.Fields(cmdline) {
-		if field == "--daemon" || strings.HasPrefix(field, "--daemon=") {
+// argsHaveDaemonFlag reports whether argv contains "--daemon" as a discrete argument (either bare
+// or in the "--daemon=value" form). It deliberately rejects substring matches like "--daemonize"
+// or "--daemon-mode". Because it scans real argv elements, spaces inside another argument (such as
+// a spaced binary path in argv[0]) can never fabricate or hide a "--daemon" token (#1214).
+func argsHaveDaemonFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--daemon" || strings.HasPrefix(a, "--daemon=") {
 			return true
 		}
 	}
 	return false
 }
 
-// cmdlineIsDaemonBinary reports whether the executable in cmdline is an
-// agent-factory daemon binary: installed as "af" or built from source
-// (`go build .`) as "agent-factory". The host-wide pgrep scan in
-// sigterm_fallback.go matches any process carrying a "--daemon" token, so this
-// restores the binary-name specificity that the old "af --daemon" substring
-// pattern provided — while still catching source-built `agent-factory --daemon`
-// daemons that the old pattern missed (#937).
-func cmdlineIsDaemonBinary(cmdline string) bool {
-	fields := strings.Fields(cmdline)
-	if len(fields) == 0 {
+// argsAreDaemonBinary reports whether argv[0] is an agent-factory daemon binary: installed as "af"
+// or built from source (`go build .`) as "agent-factory". The host-wide pgrep scan in
+// sigterm_fallback.go matches any process carrying a "--daemon" token, so this restores the
+// binary-name specificity that the old "af --daemon" substring pattern provided — while still
+// catching source-built `agent-factory --daemon` daemons that the old pattern missed (#937).
+//
+// argv[0] is a single argv element, so filepath.Base sees the whole executable path even when it
+// contains spaces (e.g. "/home/John Smith/.local/bin/af" → base "af"). The previous
+// implementation space-joined the argv and re-split on whitespace, which turned that same path
+// into base "John" and made every spaced-install daemon undetectable (#1214).
+func argsAreDaemonBinary(args []string) bool {
+	if len(args) == 0 {
 		return false
 	}
-	switch filepath.Base(fields[0]) {
+	switch filepath.Base(args[0]) {
 	case "af", "agent-factory":
 		return true
 	default:
@@ -728,15 +730,45 @@ func cmdlineIsDaemonBinary(cmdline string) bool {
 	}
 }
 
-// readProcCmdline returns the full command line for pid via /proc/<pid>/cmdline (Linux).
-// Returns "" if /proc is unavailable or the file cannot be read.
-func readProcCmdline(pid int) string {
+// daemonArgs returns the argv of pid with argument boundaries preserved. It prefers
+// /proc/<pid>/cmdline (NUL-separated argv, Linux), the only source that keeps spaces inside an
+// individual argument intact. When /proc is unavailable (macOS and other unixes) it falls back to
+// `ps -p <pid> -o args=`, whose output is already space-joined and therefore CANNOT recover the
+// original argv boundaries for a spaced binary path — the fallback splits on whitespace and is
+// best-effort, so spaced-install detection (#1214) is only fully reliable where /proc exists.
+func daemonArgs(pid int) []string {
+	if args := readProcArgv(pid); args != nil {
+		return args
+	}
+	ps := readPsArgs(pid)
+	if ps == "" {
+		return nil
+	}
+	return strings.Fields(ps)
+}
+
+// readProcArgv reads /proc/<pid>/cmdline (Linux) and splits it into argv on the NUL separators,
+// preserving spaces within an individual argument. Returns nil when /proc is unavailable or the
+// process has no cmdline (zombies, kernel threads).
+func readProcArgv(pid int) []string {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 	if err != nil {
-		return ""
+		return nil
 	}
-	// /proc/<pid>/cmdline separates args with NUL bytes.
-	return strings.ReplaceAll(strings.TrimRight(string(data), "\x00"), "\x00", " ")
+	return splitNULArgv(data)
+}
+
+// splitNULArgv splits a /proc cmdline blob on its NUL separators into argv, dropping the trailing
+// empty element left by the final NUL terminator. Returns nil for an empty/whitespace-only blob.
+func splitNULArgv(data []byte) []string {
+	parts := strings.Split(string(data), "\x00")
+	for len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return parts
 }
 
 // readPsArgs returns the full command line for pid via `ps -p <pid> -o args=`. This flag set is

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -151,54 +151,90 @@ func TestStopDaemon_NonExistentPID(t *testing.T) {
 	}
 }
 
-// TestCmdlineHasDaemonFlag verifies that --daemon is matched only as a discrete argument,
-// not as a substring of unrelated flags like --daemonize. Regression test for issue #342.
-func TestCmdlineHasDaemonFlag(t *testing.T) {
+// TestArgsHaveDaemonFlag verifies that --daemon is matched only as a discrete argv element,
+// not as a substring of unrelated flags like --daemonize (#342), and that spaces inside another
+// argument (e.g. a spaced binary path in argv[0]) neither fabricate nor hide a match (#1214).
+func TestArgsHaveDaemonFlag(t *testing.T) {
 	tests := []struct {
-		name    string
-		cmdline string
-		want    bool
+		name string
+		args []string
+		want bool
 	}{
-		{name: "empty", cmdline: "", want: false},
-		{name: "bare --daemon flag", cmdline: "/usr/local/bin/agent-factory --daemon", want: true},
-		{name: "--daemon with leading args", cmdline: "agent-factory --verbose --daemon", want: true},
-		{name: "--daemon= form", cmdline: "agent-factory --daemon=foo", want: true},
-		{name: "--daemonize substring should not match", cmdline: "/usr/bin/some-tool --daemonize", want: false},
-		{name: "--daemon-mode substring should not match", cmdline: "agent-factory --daemon-mode", want: false},
-		{name: "no daemon flag at all", cmdline: "/usr/bin/sleep 60", want: false},
+		{name: "empty", args: nil, want: false},
+		{name: "bare --daemon flag", args: []string{"/usr/local/bin/agent-factory", "--daemon"}, want: true},
+		{name: "--daemon with leading args", args: []string{"agent-factory", "--verbose", "--daemon"}, want: true},
+		{name: "--daemon= form", args: []string{"agent-factory", "--daemon=foo"}, want: true},
+		{name: "--daemonize substring should not match", args: []string{"/usr/bin/some-tool", "--daemonize"}, want: false},
+		{name: "--daemon-mode substring should not match", args: []string{"agent-factory", "--daemon-mode"}, want: false},
+		{name: "no daemon flag at all", args: []string{"/usr/bin/sleep", "60"}, want: false},
+		// #1214: a spaced binary path in argv[0] must not shred into a false
+		// "--daemon" match, and a genuine --daemon still matches alongside it.
+		{name: "spaced path, real --daemon", args: []string{"/home/John Smith/.local/bin/af", "--daemon"}, want: true},
+		{name: "spaced path, no --daemon", args: []string{"/home/John Smith/.local/bin/af", "serve"}, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := cmdlineHasDaemonFlag(tt.cmdline); got != tt.want {
-				t.Errorf("cmdlineHasDaemonFlag(%q) = %v, want %v", tt.cmdline, got, tt.want)
+			if got := argsHaveDaemonFlag(tt.args); got != tt.want {
+				t.Errorf("argsHaveDaemonFlag(%q) = %v, want %v", tt.args, got, tt.want)
 			}
 		})
 	}
 }
 
-// TestCmdlineIsDaemonBinary verifies the host-wide pgrep scan keeps only
+// TestArgsAreDaemonBinary verifies the host-wide pgrep scan keeps only
 // agent-factory daemon binaries — installed `af` or source-built
 // `agent-factory` — so broadening the pgrep pattern to a bare `--daemon` can't
-// claim an unrelated `--daemon` process (#937). Pure string logic; nothing is
-// signaled.
-func TestCmdlineIsDaemonBinary(t *testing.T) {
+// claim an unrelated `--daemon` process (#937). Pure argv logic; nothing is
+// signaled. Spaced argv[0] paths (#1214) are the key regression: filepath.Base
+// must see the whole path, not a whitespace-split fragment.
+func TestArgsAreDaemonBinary(t *testing.T) {
 	tests := []struct {
-		name    string
-		cmdline string
-		want    bool
+		name string
+		args []string
+		want bool
 	}{
-		{name: "empty", cmdline: "", want: false},
-		{name: "installed af binary", cmdline: "/home/u/.local/bin/af --daemon", want: true},
-		{name: "source-built agent-factory binary", cmdline: "/home/u/src/agent-factory --daemon", want: true},
-		{name: "bare af in PATH", cmdline: "af --daemon", want: true},
-		{name: "bare agent-factory in PATH", cmdline: "agent-factory --daemon", want: true},
-		{name: "unrelated daemon", cmdline: "/usr/bin/dockerd --daemon", want: false},
-		{name: "lookalike suffix", cmdline: "/usr/bin/not-agent-factory --daemon", want: false},
+		{name: "empty", args: nil, want: false},
+		{name: "installed af binary", args: []string{"/home/u/.local/bin/af", "--daemon"}, want: true},
+		{name: "source-built agent-factory binary", args: []string{"/home/u/src/agent-factory", "--daemon"}, want: true},
+		{name: "bare af in PATH", args: []string{"af", "--daemon"}, want: true},
+		{name: "bare agent-factory in PATH", args: []string{"agent-factory", "--daemon"}, want: true},
+		{name: "unrelated daemon", args: []string{"/usr/bin/dockerd", "--daemon"}, want: false},
+		{name: "lookalike suffix", args: []string{"/usr/bin/not-agent-factory", "--daemon"}, want: false},
+		// #1214: the spaced-install path must resolve to base "af"/"agent-factory".
+		{name: "spaced path af", args: []string{"/home/John Smith/.local/bin/af", "--daemon"}, want: true},
+		{name: "spaced path agent-factory", args: []string{"/opt/my tools/agent-factory", "--daemon"}, want: true},
+		{name: "spaced path non-af", args: []string{"/opt/John Smith/tools/dockerd", "--daemon"}, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := cmdlineIsDaemonBinary(tt.cmdline); got != tt.want {
-				t.Errorf("cmdlineIsDaemonBinary(%q) = %v, want %v", tt.cmdline, got, tt.want)
+			if got := argsAreDaemonBinary(tt.args); got != tt.want {
+				t.Errorf("argsAreDaemonBinary(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLooksLikeDaemonArgv is the exported-surface counterpart used by `af
+// doctor`'s foreign-daemon scan. It must agree with the daemon's own
+// PID-validation rules (#1004) and classify spaced-install paths correctly
+// (#1214): both a discrete --daemon token AND an af/agent-factory basename.
+func TestLooksLikeDaemonArgv(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "empty", args: nil, want: false},
+		{name: "real af daemon", args: []string{"/home/u/.local/bin/af", "--daemon"}, want: true},
+		{name: "spaced af daemon", args: []string{"/home/John Smith/.local/bin/af", "--daemon"}, want: true},
+		{name: "af without --daemon", args: []string{"/home/u/.local/bin/af", "sessions"}, want: false},
+		{name: "non-af with --daemon", args: []string{"sleep", "--daemon", "af-test"}, want: false},
+		{name: "--daemonize lookalike", args: []string{"af", "--daemonize"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LooksLikeDaemonArgv(tt.args); got != tt.want {
+				t.Errorf("LooksLikeDaemonArgv(%q) = %v, want %v", tt.args, got, tt.want)
 			}
 		})
 	}
@@ -214,33 +250,19 @@ func TestCmdlineIsDaemonBinary(t *testing.T) {
 // scan path (pgrepDaemonCandidates). Hermetic: spawns long-lived sleeps and
 // reads /proc cmdline; never signals any real daemon.
 func TestIsAgentFactoryDaemon_RequiresBinaryName(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skipf("bash not available: %v", err)
-	}
-
-	// spawn launches `exec -a <argv0> sleep 60` and waits until the rewritten
-	// post-exec cmdline (carrying the af-test marker) is visible in /proc.
+	// spawn launches a process whose argv is [argv0, "--daemon", "af-test"]
+	// with REAL argv boundaries and waits until that argv is visible in /proc.
+	// argv0 may contain spaces (the #1214 spaced-install case).
 	spawn := func(argv0 string) int {
 		t.Helper()
-		cmd := exec.Command("bash", "-c", fmt.Sprintf("exec -a %q sleep 60", argv0))
-		if err := cmd.Start(); err != nil {
-			t.Fatalf("start fake process: %v", err)
-		}
+		cmd := spawnFakeDaemonProc(t, argv0, "sleep 60; :", "--daemon", "af-test")
 		pid := cmd.Process.Pid
-		t.Cleanup(func() {
-			_ = cmd.Process.Kill()
-			_, _ = cmd.Process.Wait()
-		})
-		// Wait for the post-exec cmdline: the rewritten argv carries the
-		// "af-test" marker, and the "bash -c"/"exec -a" wrapper is gone once
-		// exec replaces the shell. Matching on "af-test" alone would fire on
-		// the pre-exec bash process (whose argv embeds the same script text).
-		waitForReady(t, fmt.Sprintf("pid=%d post-exec cmdline visible", pid), func() bool {
-			cmdline := readProcCmdline(pid)
-			if cmdline == "" {
-				cmdline = readPsArgs(pid)
-			}
-			return strings.Contains(cmdline, "af-test") && !strings.Contains(cmdline, "exec")
+		// Wait until the crafted argv is visible: the last element is the
+		// "af-test" marker. Reading argv (not a joined string) means a spaced
+		// argv0 stays intact, which is the whole point of the fix.
+		waitForReady(t, fmt.Sprintf("pid=%d post-exec argv visible", pid), func() bool {
+			args := daemonArgs(pid)
+			return len(args) > 0 && args[len(args)-1] == "af-test"
 		})
 		return pid
 	}
@@ -248,20 +270,40 @@ func TestIsAgentFactoryDaemon_RequiresBinaryName(t *testing.T) {
 	// The exact #1004 repro: "--daemon" present but argv[0] base is "sleep",
 	// not af/agent-factory. Pre-fix this returned true (the bug); it must now
 	// be false so StopDaemon/locateDaemonPID refuse to signal it.
-	nonAFPID := spawn("sleep --daemon af-test")
+	nonAFPID := spawn("sleep")
 	if isAgentFactoryDaemon(nonAFPID) {
-		t.Errorf("isAgentFactoryDaemon(pid with cmdline %q) = true; "+
+		t.Errorf("isAgentFactoryDaemon(pid with argv %q) = true; "+
 			"want false — a non-af process carrying --daemon must not be treated as our daemon (#1004)",
-			readProcCmdline(nonAFPID))
+			daemonArgs(nonAFPID))
 	}
 
-	// A genuine agent-factory daemon cmdline (af argv[0] + --daemon) must still
+	// A genuine agent-factory daemon (af argv[0] + --daemon) must still
 	// validate true, so the fix doesn't break the real stop/reset path.
-	afPID := spawn("af --daemon af-test")
+	afPID := spawn("af")
 	if !isAgentFactoryDaemon(afPID) {
-		t.Errorf("isAgentFactoryDaemon(pid with cmdline %q) = false; "+
+		t.Errorf("isAgentFactoryDaemon(pid with argv %q) = false; "+
 			"want true — a real af --daemon process must still validate",
-			readProcCmdline(afPID))
+			daemonArgs(afPID))
+	}
+
+	// #1214: a daemon installed under a path with spaces. Pre-fix, the argv was
+	// space-joined and re-split, so filepath.Base saw "John" (not "af") and the
+	// daemon was undetectable — breaking `af reset`, health, and foreign-daemon
+	// scans for every spaced install path. It must now validate true.
+	spacedPID := spawn("/home/John Smith/.local/bin/af")
+	if !isAgentFactoryDaemon(spacedPID) {
+		t.Errorf("isAgentFactoryDaemon(pid with argv %q) = false; "+
+			"want true — an af daemon installed under a spaced path must validate (#1214)",
+			daemonArgs(spacedPID))
+	}
+
+	// A non-af binary under a spaced path carrying --daemon must still be
+	// rejected: the space fix must not weaken the binary-name gate (#1004).
+	spacedNonAFPID := spawn("/opt/John Smith/tools/notdaemon")
+	if isAgentFactoryDaemon(spacedNonAFPID) {
+		t.Errorf("isAgentFactoryDaemon(pid with argv %q) = true; "+
+			"want false — a non-af spaced-path process carrying --daemon must be rejected (#1004)",
+			daemonArgs(spacedNonAFPID))
 	}
 }
 
@@ -271,26 +313,16 @@ func TestIsAgentFactoryDaemon_RequiresBinaryName(t *testing.T) {
 // before the fix this called proc.Kill() unconditionally, bypassing the
 // daemon's state-save path.
 func TestStopDaemon_SIGTERMFirst(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skipf("bash not available: %v", err)
-	}
 	tmpHome := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
 
-	// Spawn a process that responds to SIGTERM by exiting (sleep's default
-	// behavior) and presents an agent-factory daemon cmdline: an "af" argv[0]
-	// plus a discrete "--daemon" token (via bash's `exec -a` argv[0] rewrite),
-	// so it satisfies both checks isAgentFactoryDaemon now requires (#1004).
-	// This is the same recipe used in TestSigtermFallback_KillsPIDFileDaemon.
-	cmd := exec.Command("bash", "-c", "exec -a 'af --daemon af-test' sleep 60")
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start fake daemon: %v", err)
-	}
+	// Spawn a process that responds to SIGTERM by exiting (bash re-raises the
+	// signal by default) and presents an agent-factory daemon argv: an "af"
+	// argv[0] plus a discrete "--daemon" token as a real argv element, so it
+	// satisfies both checks isAgentFactoryDaemon requires (#1004, #1214). This
+	// is the same recipe used in TestSigtermFallback_KillsPIDFileDaemon.
+	cmd := spawnFakeDaemonProc(t, "af", "sleep 60; :", "--daemon", "af-test")
 	pid := cmd.Process.Pid
-	defer func() {
-		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
-	}()
 
 	// Wait for the post-exec cmdline to be readable. Event-driven with a
 	// generous bound so a loaded runner cannot expire the old fixed 2s wait
@@ -355,9 +387,6 @@ func TestStopDaemon_SIGTERMFirst(t *testing.T) {
 // when the daemon ignores SIGTERM, StopDaemon must wait stopDaemonGrace and
 // then SIGKILL the process. Companion to TestStopDaemon_SIGTERMFirst.
 func TestStopDaemon_EscalatesToSIGKILL(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skipf("bash not available: %v", err)
-	}
 	tmpHome := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
 
@@ -371,28 +400,18 @@ func TestStopDaemon_EscalatesToSIGKILL(t *testing.T) {
 		stopDaemonPoll = origPoll
 	}()
 
-	// Inner bash sets SIGTERM to SIG_IGN via `trap '' TERM` (the empty-string
-	// form, which truly ignores the signal — `trap : TERM` would run a no-op
-	// but bash still terminates non-interactively after the handler). Outer
-	// bash uses `exec -a` to rewrite argv[0] to an "af" binary name with a
-	// discrete "--daemon" token, so it passes both checks isAgentFactoryDaemon
-	// requires (#1004). A ready-file sentinel proves the trap was installed
-	// before SIGTERM lands, closing a race where the cmdline becomes visible
-	// while bash is still parsing the script.
+	// The fake daemon sets SIGTERM to SIG_IGN via `trap "" TERM` (the
+	// empty-string form, which truly ignores the signal) and loops, so it can
+	// only be stopped by the SIGKILL escalation. Its argv[0] is an "af" binary
+	// name with a discrete "--daemon" token as a real argv element, so it
+	// passes both checks isAgentFactoryDaemon requires (#1004, #1214). A
+	// ready-file sentinel proves the trap was installed before SIGTERM lands,
+	// closing a race where the cmdline becomes visible while bash is still
+	// parsing the script.
 	readyFile := filepath.Join(tmpHome, "trap-ready")
-	script := fmt.Sprintf(
-		`exec -a 'af --daemon af-test' bash -c 'trap "" TERM; : > %q; while :; do sleep 1; done'`,
-		readyFile,
-	)
-	cmd := exec.Command("bash", "-c", script)
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start fake daemon: %v", err)
-	}
+	script := fmt.Sprintf(`trap "" TERM; : > %s; while :; do sleep 1; done`, readyFile)
+	cmd := spawnFakeDaemonProc(t, "af", script, "--daemon", "af-test")
 	pid := cmd.Process.Pid
-	defer func() {
-		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
-	}()
 
 	// Wait until the trap is installed (sentinel present) AND the rewritten
 	// cmdline is visible. Event-driven with a generous bound so a loaded runner

--- a/daemon/fake_daemon_test.go
+++ b/daemon/fake_daemon_test.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// shSingleQuote wraps s in single quotes for safe embedding in a `bash -c`
+// script, escaping any embedded single quotes. Used to build the fake-daemon
+// spawn recipe without shell-injection surprises when argv0 contains spaces.
+func shSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// spawnFakeDaemonProc launches a long-lived process whose /proc/<pid>/cmdline
+// exposes REAL argv boundaries: argv[0] == argv0 (which may itself contain
+// spaces, e.g. "/home/John Smith/.local/bin/af"), followed by extraArgs as
+// distinct argv elements. This is the shape the daemon detection path
+// (daemonArgs → argsAreDaemonBinary/argsHaveDaemonFlag) must classify, and the
+// only shape that exercises spaced-path parsing (#1214): the older
+// `exec -a 'af --daemon af-test' sleep 60` recipe jammed everything into a
+// single argv[0], so it could never test real boundary handling.
+//
+// The underlying program is bash running `script`. `script` MUST be a compound
+// command (contain a `;`, a loop, etc.) so bash's single-simple-command exec
+// optimization does not replace the crafted argv with the child's. The process
+// and any children share a new process group so cleanup can reap the whole tree
+// — bash dies by the test's SIGTERM/SIGKILL, orphaning any `sleep` child in the
+// group.
+func spawnFakeDaemonProc(t *testing.T, argv0, script string, extraArgs ...string) *exec.Cmd {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not available: %v", err)
+	}
+	// Build: exec -a <argv0> bash -c <script> <argv0> <extraArgs...>
+	// The resulting bash process argv is [<argv0>, "-c", <script>, <argv0>, extraArgs...].
+	parts := []string{"exec", "-a", shSingleQuote(argv0), "bash", "-c", shSingleQuote(script), shSingleQuote(argv0)}
+	for _, a := range extraArgs {
+		parts = append(parts, shSingleQuote(a))
+	}
+	cmd := exec.Command("bash", "-c", strings.Join(parts, " "))
+	// Put the process (and its children) in their own group so cleanup reaps
+	// any orphaned `sleep` child left behind when bash dies by signal.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake daemon proc: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+	})
+	return cmd
+}

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -67,11 +67,12 @@ func Health() HealthStatus {
 	return h
 }
 
-// LooksLikeDaemonCmdline reports whether a command line names an
-// agent-factory daemon process (an `af`/`agent-factory` binary carrying a
-// discrete --daemon flag). Exported for `af doctor`'s host-wide scan so its
-// matching stays in lockstep with the daemon's own PID-validation rules
-// (#1004).
-func LooksLikeDaemonCmdline(cmdline string) bool {
-	return cmdlineHasDaemonFlag(cmdline) && cmdlineIsDaemonBinary(cmdline)
+// LooksLikeDaemonArgv reports whether argv names an agent-factory daemon
+// process (an `af`/`agent-factory` binary carrying a discrete --daemon flag).
+// It takes real argv elements (boundaries preserved) so a daemon installed
+// under a path containing spaces is classified correctly (#1214). Exported for
+// `af doctor`'s host-wide scan so its matching stays in lockstep with the
+// daemon's own PID-validation rules (#1004).
+func LooksLikeDaemonArgv(args []string) bool {
+	return argsHaveDaemonFlag(args) && argsAreDaemonBinary(args)
 }

--- a/daemon/sigterm_fallback.go
+++ b/daemon/sigterm_fallback.go
@@ -130,7 +130,7 @@ func readPIDFromFile() (int, bool) {
 // for any zombie before escalating to SIGKILL — visible as a 5s pause in
 // `af upgrade` when the dying daemon's parent isn't waiting.
 //
-// On platforms without /proc (macOS), readProcCmdline returns "" and we
+// On platforms without /proc (macOS), the cmdline read below returns "" and we
 // can't distinguish zombie from "kernel doesn't expose the cmdline"; we
 // fall back to the signal-0 result. The cost there is the 5s grace, which
 // is correct but slow.
@@ -173,7 +173,7 @@ var errPgrepUnavailable = errors.New("pgrep not found in PATH")
 // `agent-factory`. The `--` before the pattern stops pgrep from treating the
 // leading-dash pattern as a flag. We match the bare `--daemon` token rather
 // than "af --daemon" so source-built daemons running as `agent-factory
-// --daemon` are found too (#937); cmdlineIsDaemonBinary restores the
+// --daemon` are found too (#937); argsAreDaemonBinary restores the
 // binary-name specificity the old substring gave. Go test binaries living
 // under /tmp/Test* and the current process are excluded. We rely on pgrep -f
 // rather than parsing /proc directly so the path works on both Linux and macOS.
@@ -207,26 +207,24 @@ func pgrepDaemonCandidates() ([]int, error) {
 		if pid == self {
 			continue
 		}
-		// Defensive: re-read the cmdline and require it to (a) contain
-		// "--daemon" as a discrete token (pgrep -f does substring matching,
-		// not token matching), (b) belong to an `af`/`agent-factory` binary so
-		// the broad `--daemon` pattern can't match an unrelated daemon (#937),
-		// and (c) not be a Go test binary (these live under /tmp/Test... when
-		// invoked from `go test`).
-		cmdline := readProcCmdline(pid)
-		if cmdline == "" {
-			cmdline = readPsArgs(pid)
-		}
-		if cmdline == "" {
+		// Defensive: re-read the argv (boundaries preserved, so a spaced binary
+		// path in argv[0] is classified correctly — #1214) and require it to (a)
+		// contain "--daemon" as a discrete token (pgrep -f does substring
+		// matching, not token matching), (b) belong to an `af`/`agent-factory`
+		// binary so the broad `--daemon` pattern can't match an unrelated daemon
+		// (#937), and (c) not be a Go test binary (these live under /tmp/Test...
+		// when invoked from `go test`).
+		args := daemonArgs(pid)
+		if len(args) == 0 {
 			continue
 		}
-		if !cmdlineHasDaemonFlag(cmdline) {
+		if !argsHaveDaemonFlag(args) {
 			continue
 		}
-		if !cmdlineIsDaemonBinary(cmdline) {
+		if !argsAreDaemonBinary(args) {
 			continue
 		}
-		if isTestBinaryCmdline(cmdline) {
+		if isTestBinaryArgs(args) {
 			continue
 		}
 		pids = append(pids, pid)
@@ -234,14 +232,14 @@ func pgrepDaemonCandidates() ([]int, error) {
 	return pids, nil
 }
 
-// isTestBinaryCmdline filters out Go test binaries spawned during `go test`.
+// isTestBinaryArgs filters out Go test binaries spawned during `go test`.
 // They typically live under /tmp/Test<name>... (t.TempDir paths) or
 // /tmp/go-build... (compiled-test cache). We don't want a test that spawns a
 // fake "af --daemon" subprocess to accidentally claim a real daemon match
 // when run in parallel with another test.
-func isTestBinaryCmdline(cmdline string) bool {
-	for _, field := range strings.Fields(cmdline) {
-		if strings.HasPrefix(field, "/tmp/Test") || strings.HasPrefix(field, "/tmp/go-build") {
+func isTestBinaryArgs(args []string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(a, "/tmp/Test") || strings.HasPrefix(a, "/tmp/go-build") {
 			return true
 		}
 	}

--- a/daemon/sigterm_fallback_test.go
+++ b/daemon/sigterm_fallback_test.go
@@ -183,31 +183,21 @@ func stubDaemonScan(t *testing.T, pids []int, err error) {
 
 // spawnFakeDaemonWithDaemonFlag launches a long-lived child process whose
 // /proc/<pid>/cmdline presents an agent-factory daemon: an "af" argv[0] plus a
-// discrete "--daemon" token, satisfying both checks isAgentFactoryDaemon
-// requires (#1004). We use bash's `exec -a` to rewrite argv[0] so the cmdline
-// carries both without the underlying `sleep` actually being asked to parse
-// "--daemon" as a flag (it would reject "--daemon" as an invalid time
-// interval). The single process is just sleep, which terminates cleanly on
-// SIGTERM — making this the minimum-moving-parts way to test the fallback's
-// SIGTERM path.
+// discrete "--daemon" token as a real argv element, satisfying both checks
+// isAgentFactoryDaemon requires (#1004, #1214). See spawnFakeDaemonProc for how
+// the crafted argv is built and reaped; it terminates cleanly on SIGTERM,
+// making this the minimum-moving-parts way to test the fallback's SIGTERM path.
 //
 // Returns the *exec.Cmd so the test can call cmd.Wait() to reap the zombie
 // after SIGTERM. Without that, kill(pid, 0) keeps returning success against
 // the zombie, defeating any "did it die?" check based on signal probes.
 func spawnFakeDaemonWithDaemonFlag(t *testing.T) *exec.Cmd {
 	t.Helper()
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skipf("bash not available, skipping SIGTERM-fallback test: %v", err)
-	}
-	cmd := exec.Command("bash", "-c", "exec -a 'af --daemon af-test' sleep 60")
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start fake daemon: %v", err)
-	}
-	// Wait for bash to exec into sleep so the cmdline we read is the post-exec
-	// one with the rewritten argv[0]. Event-driven with a generous bound so a
-	// loaded CI runner cannot miss the window — the old fixed ~500ms wait could
-	// expire just before the exec landed, failing the caller's cmdline sanity
-	// check spuriously (#878).
+	cmd := spawnFakeDaemonProc(t, "af", "sleep 60; :", "--daemon", "af-test")
+	// Wait until the crafted post-exec argv is visible. Event-driven with a
+	// generous bound so a loaded CI runner cannot miss the window — the old
+	// fixed ~500ms wait could expire just before the exec landed, failing the
+	// caller's cmdline sanity check spuriously (#878).
 	waitForReady(t, "fake daemon cmdline exposes --daemon", func() bool {
 		return isAgentFactoryDaemon(cmd.Process.Pid)
 	})
@@ -293,7 +283,7 @@ func TestSigtermFallback_IgnoresNonMatchingCmdline(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", home)
 	stubDaemonScan(t, nil, nil)
 
-	// sleep, no --daemon flag in its argv — cmdlineHasDaemonFlag must say no.
+	// sleep, no --daemon flag in its argv — argsHaveDaemonFlag must say no.
 	victim := exec.Command("sleep", "60")
 	if err := victim.Start(); err != nil {
 		t.Fatalf("start victim: %v", err)

--- a/daemon/spawn_stop_race_test.go
+++ b/daemon/spawn_stop_race_test.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -43,9 +42,6 @@ func startTestControlServer(t *testing.T) {
 // Post-fix, cleanup pings the socket first and leaves the runtime files alone
 // when a live daemon answers.
 func TestStopDaemon_PreservesNewDaemonSocket(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skipf("bash not available: %v", err)
-	}
 	tmpHome := t.TempDir()
 	t.Setenv("AGENT_FACTORY_HOME", tmpHome)
 
@@ -56,17 +52,11 @@ func TestStopDaemon_PreservesNewDaemonSocket(t *testing.T) {
 	}
 
 	// Daemon A: a fake old daemon that exits on SIGTERM and presents an "af"
-	// argv[0] with a discrete "--daemon" cmdline token, satisfying both checks
-	// isAgentFactoryDaemon requires (same recipe as TestStopDaemon_SIGTERMFirst).
-	cmd := exec.Command("bash", "-c", "exec -a 'af --daemon af-test' sleep 60")
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start fake daemon: %v", err)
-	}
+	// argv[0] with a discrete "--daemon" token as a real argv element,
+	// satisfying both checks isAgentFactoryDaemon requires (same recipe as
+	// TestStopDaemon_SIGTERMFirst).
+	cmd := spawnFakeDaemonProc(t, "af", "sleep 60; :", "--daemon", "af-test")
 	pid := cmd.Process.Pid
-	defer func() {
-		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
-	}()
 
 	// Event-driven readiness with a generous bound so a loaded runner cannot
 	// expire the old fixed 2s wait before the exec rewrites the cmdline (#878).

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -488,7 +488,7 @@ func tempHomeDaemonAlive(dir string) bool {
 	if err != nil || pid <= 0 {
 		return false
 	}
-	return daemon.LooksLikeDaemonCmdline(proctree.Cmdline(pid))
+	return daemon.LooksLikeDaemonArgv(proctree.Argv(pid))
 }
 
 // newestMtime returns the most recent mtime among the dir itself and its
@@ -532,8 +532,8 @@ func checkForeignDaemons(ctx *scanContext, report *Report) {
 			continue
 		}
 		p := ctx.snap[pid]
-		cmdline := proctree.Cmdline(pid)
-		if cmdline == "" || !daemon.LooksLikeDaemonCmdline(cmdline) {
+		args := proctree.Argv(pid)
+		if len(args) == 0 || !daemon.LooksLikeDaemonArgv(args) {
 			continue
 		}
 		home, ok := proctree.EnvValue(pid, "AGENT_FACTORY_HOME")

--- a/internal/proctree/proctree.go
+++ b/internal/proctree/proctree.go
@@ -309,11 +309,39 @@ func EnvValue(pid int, key string) (string, bool) {
 }
 
 // Cmdline returns the process's argv joined with spaces, or "" when
-// unreadable. For kernel threads (empty cmdline) it returns "".
+// unreadable. For kernel threads (empty cmdline) it returns "". This is a
+// lossy, display-oriented view: it collapses argv boundaries, so a binary path
+// containing spaces cannot be recovered from it — use Argv for classification
+// that must survive spaced paths (#1214).
 func Cmdline(pid int) string {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(bytes.ReplaceAll(data, []byte{0}, []byte{' '})))
+}
+
+// Argv returns the process's argv with argument boundaries preserved (each
+// element a distinct argv entry, spaces within an argument kept intact), or nil
+// when unreadable or for kernel threads (empty cmdline). Unlike Cmdline it does
+// not collapse the NUL separators, so a binary path containing spaces stays in
+// a single element (#1214).
+func Argv(pid int) []string {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return nil
+	}
+	parts := bytes.Split(data, []byte{0})
+	// Drop the trailing empty element left by the final NUL terminator.
+	for len(parts) > 0 && len(parts[len(parts)-1]) == 0 {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	argv := make([]string, len(parts))
+	for i, p := range parts {
+		argv[i] = string(p)
+	}
+	return argv
 }


### PR DESCRIPTION
## Problem

Daemon lifecycle commands broke whenever `af` was installed under a path
containing spaces — e.g. `/home/John Smith/.local/bin/af`. Affected:
`af reset` (StopDaemon), `af doctor` / health (`PIDVerified`), foreign-daemon
detection, and the `af daemon install` handover all treated a live, healthy
daemon as absent or unverified.

## Root cause

The **detection** path parsed process command lines as space-joined strings.
`readProcCmdline` read the NUL-separated `/proc/<pid>/cmdline` and collapsed the
NULs to spaces; `cmdlineIsDaemonBinary` / `cmdlineHasDaemonFlag` then re-split
with `strings.Fields`. A spaced argv[0] like
`/home/John Smith/.local/bin/af --daemon` split into
`{"/home/John", "Smith/.local/bin/af", "--daemon"}`, so
`filepath.Base(fields[0])` was `"John"` (not `"af"`) and `isAgentFactoryDaemon`
returned false — undetectable for every spaced install path.

## Fix

Parse the process argv with boundaries preserved and classify on real argv
elements:

- **daemon**: add `readProcArgv` / `daemonArgs` (split `/proc/<pid>/cmdline` on
  NUL, keeping spaces inside each arg) and argv-based `argsHaveDaemonFlag` /
  `argsAreDaemonBinary`. `isAgentFactoryDaemon` and the SIGTERM-fallback pgrep
  filter use them. The `ps -o args=` fallback (platforms without `/proc`) still
  cannot recover argv boundaries for a spaced path — documented honestly rather
  than pretending it's solved; `/proc` argv is preferred where available.
- **health / doctor**: `LooksLikeDaemonCmdline(string)` →
  `LooksLikeDaemonArgv([]string)`; add `proctree.Argv` and switch the
  foreign-daemon scan to it so it survives spaced paths too.

Behavior is unchanged for normal (no-space) paths, and the existing #1004/#937
semantics hold: a match still requires **both** a discrete `--daemon` /
`--daemon=` token **and** an `af`/`agent-factory` basename — still rejecting
`--daemonize` substrings and `sleep --daemon af-test` PID-reuse.

## Why the generation side is untouched

Generation is already space-safe and has existing tests in
`daemon/autostart_test.go` (covers `/opt/my tools/af`):
- `quoteExecStartPath` quotes the systemd `ExecStart`.
- `launchdAutostartPlist` uses a `ProgramArguments` `<array>` (each arg its own
  `<string>`).
- the daemon spawn passes argv directly: `exec.Command(execPath, "--daemon")`.

Only the detection/parse side was wrong, so only it changed.

## Tests

- argv-level table tests (`TestArgsHaveDaemonFlag`, `TestArgsAreDaemonBinary`,
  `TestLooksLikeDaemonArgv`) including spaced `af`/`agent-factory` paths and
  spaced non-af rejection.
- `isAgentFactoryDaemon`-level regression spawning a live process whose argv[0]
  is `/home/John Smith/.local/bin/af` — now detected — plus a spaced non-af
  path that is still rejected.
- The process-spawning daemon tests now construct **real** argv boundaries via a
  shared `spawnFakeDaemonProc` helper (the old `exec -a 'af --daemon af-test'`
  recipe jammed everything into argv[0] and couldn't exercise boundary parsing).

## Gates

`go build ./...`, `go vet`, `gofmt -l .` (empty), `deadcode -test ./...`,
`scripts/lint-file-length.sh`, `golangci-lint run --timeout=3m --fast`, and the
full `make test-container` suite all pass.

Closes #1214

🤖 Generated with [Claude Code](https://claude.com/claude-code)