### PR TITLE
fix(tui): show archived session name in sidebar, drop [archived] text prefix (#1225)

### DIFF
--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -135,8 +135,12 @@ func TestSidebar_ArchivedRowSelectableWhenExpanded(t *testing.T) {
 	require.NotNil(t, inst, "an archived row must resolve to its instance")
 	assert.Equal(t, "put-away", inst.Title)
 
-	// The row renders with the archived marker.
-	assert.True(t, strings.Contains(s.View(), "[archived]"), "archived rows render a distinct marker")
+	// The row renders with the distinct archived marker — the ▧ glyph, not a
+	// name-eating "[archived] " text prefix (#1225) — and keeps its NAME visible.
+	view := s.View()
+	assert.True(t, strings.Contains(view, "▧"), "archived rows render the distinct ▧ marker")
+	assert.True(t, strings.Contains(view, "put-away"), "archived rows keep their name visible")
+	assert.False(t, strings.Contains(view, "[archived]"), "archived rows must not carry the name-eating text prefix (#1225)")
 }
 
 // TestSidebar_ArchivedZonesRegistered (#1028 mouse P2): the Archived folder

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -304,10 +304,16 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		// secondary lines stand out more than the dimmed title (#853).
 		descS = descS.Foreground(deletingTitleColor)
 	}
-	// An archived row (#1028) is explicitly marked and dimmed so it reads as
-	// "filed away, restartable" — restore with A — rather than a live session.
+	// An archived row (#1028) is dimmed and carries the ▧ archived glyph so it
+	// reads as "filed away, restartable" — restore with A — rather than a live
+	// session. It deliberately carries NO "[archived] " text prefix: unlike the
+	// transient [deleting]/[lost] states, the Archived list is a persistent list
+	// the user browses BY NAME, and an 11-char word prefix eats the whole title
+	// cell at ordinary sidebar widths (~13 cols), clipping every name to
+	// "[archived]..." (#1225). The state is already conveyed three other ways on
+	// the same row — the ▧ glyph, the dimming below, and the "▼ Archived (n)"
+	// section header — so the name stays full-width like a live row's.
 	if liveness == session.LiveArchived {
-		titleText = "[archived] " + titleText
 		titleS = titleS.Foreground(deletingTitleColor)
 		descS = descS.Foreground(deletingTitleColor)
 	}

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -242,6 +242,31 @@ func TestInstanceRendererLimitReachedMarker(t *testing.T) {
 	assert.Contains(t, out, "throttled", "the title must remain visible")
 }
 
+// TestInstanceRendererArchivedShowsName pins #1225: an archived row must show
+// its NAME at the widths users actually run (100/80 cols), not a name-eating
+// "[archived] " word prefix that clips every archived session to "[archived]...".
+// The archived state is conveyed by the ▧ glyph + dimming + section header, so
+// the title cell is spent on the identifier, exactly like a live row.
+func TestInstanceRendererArchivedShowsName(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "one",
+		Path:    t.TempDir(),
+		Program: "test",
+	})
+	require.NoError(t, err)
+	inst.SetArchived()
+
+	for _, terminalW := range []int{100, 80} {
+		title, _, _ := renderForTerminal(t, terminalW, inst, &spin)
+		clean := ansiEscape.ReplaceAllString(title, "")
+		assert.Containsf(t, clean, "one",
+			"archived row must show its name at %d cols; got %q", terminalW, clean)
+		assert.NotContainsf(t, clean, "[archived]",
+			"archived row must not carry the name-eating text prefix at %d cols; got %q", terminalW, clean)
+	}
+}
+
 // TestInstanceRendererDeletingDimsSelectedRow pins the #853 fix: a SELECTED
 // deleting row must dim its branch and PR lines along with the title. Before
 // the fix only titleS picked up deletingTitleColor, so the high-contrast


### PR DESCRIPTION
## Problem

In the sidebar, archived rows rendered the title as a literal `"[archived] " + name` string, then width-truncated it. The 11-char `[archived] ` prefix ate the ~13-col title cell, clipping every name to `[archived]...`:

- **100 cols:** title reads `[archived]...` — name gone.
- **80 cols:** the archived title line is squeezed out entirely.
- **200 cols:** finally shows `[archived] one`.

Every archived session looked identical at the widths users actually run.

## Fix

Drop the `"[archived] "` text prefix. The archived state is already conveyed three other ways on the same row — the `▧` archived glyph, the row dimming, and the `▼ Archived (n)` section header — so the redundant word prefix only cost the name its cell. Archived rows now render their **name** full-width like a live row, distinguished by glyph + section + dimming.

```
Before (100 cols):  ▸ 1.  [archived]...     ▧
After  (100 cols):  ▸ 1.  one               ▧
```

## Adjacent-prefix audit (#1195 Phase-1e render class)

Empirically checked the sibling liveness/in-flight-op prefixes at 100/80 cols:

| Prefix | Chars | 100 cols | 80 cols | Verdict |
|---|---|---|---|---|
| `[archived]` | 11 | name gone | line vanishes | **fixed** |
| `[lost]` | 7 | `[lost] one` ✅ | `[lost] one` ✅ | keep — name stays; transient recovery state |
| `[deleting]` | 11 | `[deleting] one` ✅ | clipped | keep — transient in-flight op (row vanishes in seconds), keeps spinner glyph |
| `[limit]` (bare) | 8 | `[limit] one` ✅ | `[limit] one` ✅ | keep — name visible |
| `[limit] resets …` | ~22 | reset payload wins | clipped | keep — reset time is the meaningful payload (#1146/#1204), row stays distinct via ◆ glyph + color |

Only **Archived** is a persistent, browse-by-name list, so only it needs the fix. The transient/actionable siblings keep their word (the tradeoff the issue itself calls out).

## Tests
- `ui/tree`: new `TestInstanceRendererArchivedShowsName` asserts the archived row shows its name (and no `[archived]` tag) at 100 and 80 cols.
- `ui`: updated `TestSidebar_ArchivedRowSelectableWhenExpanded` to pin the `▧` glyph as the distinct marker + name visibility, instead of the removed text prefix.

## Gates
`golangci-lint --fast` clean · `gofmt -l` empty · `go build ./...` · `make test-container` all green · file-length lint passes.

Closes #1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)