### PR TITLE
feat(doctor): add remote-hook setup checks to af doctor (#1039)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -462,7 +462,13 @@ af reset               # nuclear cleanup — see below
   sessions, CPU-pegging processes in live sessions, `af_` tmux sessions with no
   backing record, abandoned temp homes, and daemon problems. With `--fix` it
   kills verified orphans and removes stale temp homes; anything it cannot verify
-  is reported, never touched. Exits 1 when unresolved issues remain.
+  is reported, never touched. Exits 1 when unresolved issues remain. When the
+  current repo configures a [remote-hook backend](remote-hooks.md), it also
+  validates that setup — required `remote_hooks` commands present
+  (`remote-config`), each hook script present and executable (`remote-hook-script`),
+  and a bounded read-only `list_cmd --json` connectivity probe
+  (`remote-connectivity`). Repos with no remote backend (the common local-only
+  case) get a single `n/a` line and no findings.
 - `af reset` stops the daemon (reporting honestly if it couldn't), kills **all**
   Agent Factory tmux sessions, removes **every linked git worktree and its
   branch** from each repo with stored sessions, and deletes all stored session

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -109,4 +109,28 @@ from a dead Agent Factory session and removes stale temp homes, logging each
 action; anything it cannot verify is reported, never touched. Exits 1 when
 unresolved issues remain.
 
+When the repository you run it in configures a [remote-hook backend](remote-hooks.md),
+`af doctor` also validates that setup, so a misconfigured remote surfaces as a
+diagnosable problem instead of a cryptic failure at session-launch time:
+
+- **remote-config** — the required `remote_hooks` commands (`launch_cmd`,
+  `attach_cmd`, `delete_cmd`) are present, naming the missing field and the
+  in-repo config file when one is not.
+- **remote-hook-script** — every configured hook command resolves to something
+  runnable: a path that exists and carries the execute bit (with the exact
+  `chmod +x` fix otherwise), or a bare name found on `$PATH`.
+- **remote-connectivity** — a bounded, read-only round-trip probe that runs
+  `list_cmd --json` and checks it responds in time (default 10s) with a valid
+  JSON array. `list_cmd` is the only non-mutating verb, so it is the safe probe;
+  a non-zero exit quotes the script's stderr and a hang is reported as
+  unresponsive. When `list_cmd` is not configured the probe (and restore across
+  restarts) are unavailable — noted as informational, not a failure.
+
+These checks run only for a repo that configures `remote_hooks`. Run outside a
+git repo, or in a repo with no remote backend — the common local-only case —
+they collapse to a single `n/a — no remote backend configured` line and add no
+findings, so local users see no new noise. The remote checks are validated
+against the current working directory's repository; run `af doctor` from inside
+the repo whose remote setup you want to check.
+
 `af reset` attempts to stop the daemon (and reports honestly if it couldn't — e.g. a source-built `agent-factory --daemon` that left no PID file), kills **all** Agent Factory tmux sessions, removes **every linked git worktree (and its branch)** from each repo that has stored sessions — including worktrees you created by hand — and deletes all stored session records. Use it to recover from a corrupted state, not for day-to-day cleanup — `af sessions kill <title>` (or `D` in the TUI) removes a single session cleanly.

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -35,6 +35,15 @@ Configuring `remote_hooks` enables the remote backend for that repo, but using i
 
 > **Note:** `list_cmd` is **required for restore**. To carry remote sessions across restarts, Agent Factory re-runs `list_cmd` at startup to confirm each persisted session is still alive (#645). If `list_cmd` is empty, restore cannot verify liveness and the session is dropped with an actionable error naming the missing field — so configure `list_cmd` whenever you want remote sessions to survive restarts.
 
+### Validating your setup
+
+Run `af doctor` from inside the repository to check the remote-hook setup
+before you rely on it. It validates that the required commands are configured,
+that each hook script exists and is executable, and — via a bounded read-only
+`list_cmd --json` probe — that the remote round-trip actually works, with an
+actionable "how to fix" message for each problem. See
+[`af doctor`](cli.md) for the full list of remote checks.
+
 ## Script Protocol
 
 All scripts must:

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -5,6 +5,13 @@
 // agent-factory homes, and unhealthy daemons — and, with --fix, applies only
 // the remediations whose ancestry is verified.
 //
+// It also validates the remote-hook backend (#1039) for the repository
+// containing the current working directory: config completeness, hook-script
+// presence/executability, and a bounded read-only connectivity probe via
+// list_cmd. When no remote backend is configured — the common case — the
+// remote checks record a single informational "n/a" line and add no findings,
+// so local-only users see no new noise.
+//
 // The safety stance is asymmetric by design: detection is generous,
 // remediation is conservative. A process is only ever killed when its
 // AF_SESSION env marker proves it was spawned inside an af tmux session that
@@ -79,6 +86,17 @@ type Options struct {
 	// test or debug run is still coming back for it).
 	MinTempHomeAge time.Duration
 
+	// remoteProbeTimeout bounds the remote connectivity probe (list_cmd);
+	// defaults to remoteProbeTimeoutDefault. Tests shorten it to exercise the
+	// timeout path without waiting.
+	remoteProbeTimeout time.Duration
+
+	// remoteConfig resolves the remote-hook backend to validate and the repo
+	// root it was loaded from; nil hooks mean no remote is configured and the
+	// remote checks skip cleanly. Defaults to resolving the repo of the current
+	// working directory (defaultRemoteConfig); tests inject a hermetic resolver.
+	remoteConfig func() (*config.RemoteHooks, string, error)
+
 	// Escalation windows for --fix kills; default to 2s/2s.
 	killGrace    time.Duration
 	killTermWait time.Duration
@@ -144,6 +162,7 @@ func Run(opts Options) (*Report, error) {
 	checkLeakedTmuxSessions(ctx, report)
 	checkStaleTempHomes(ctx, report)
 	checkForeignDaemons(ctx, report)
+	checkRemoteSetup(ctx, report)
 
 	if opts.Fix {
 		for i := range report.Findings {

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -575,6 +575,30 @@ func TestRemoteConnectivityProbeFails(t *testing.T) {
 	require.Contains(t, findings[0].Detail, "Connection refused")
 }
 
+// TestRemoteConnectivityProbeSucceedsDespiteBenignError: a list_cmd that
+// exits 0 with valid JSON but leaves a background grandchild holding the
+// stdout pipe makes cmd.Run return exec.ErrWaitDelay (a benign non-nil error).
+// The probe must judge by the exit status, not the error, and report NO
+// connectivity failure — a false failure is the worst outcome for a doctor
+// check (#1234 review).
+func TestRemoteConnectivityProbeSucceedsDespiteBenignError(t *testing.T) {
+	testguard.IsolateTmux(t)
+	dir := t.TempDir()
+	good := writeHookScript(t, dir, "hook.sh", "#!/bin/sh\necho '[]'\n")
+	// The script writes its full JSON, then backgrounds a `sleep` that inherits
+	// the stdout pipe and outlives WaitDelay (500ms), then exits 0. Run() sees a
+	// clean exit-0 but returns ErrWaitDelay because the pipe stayed open.
+	list := writeHookScript(t, dir, "list.sh",
+		"#!/bin/sh\necho '[{\"name\":\"a\",\"status\":\"running\"}]'\nsleep 2 &\nexit 0\n")
+	hooks := &config.RemoteHooks{LaunchCmd: good, ListCmd: list, AttachCmd: good, DeleteCmd: good}
+
+	report, err := Run(withRemote(testOptions(t, false), hooks))
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "remote-connectivity"),
+		"a benign ErrWaitDelay on a successful exit-0 list_cmd must not be a failure")
+	require.True(t, okContains(report, "connectivity probe succeeded"))
+}
+
 // TestRemoteConnectivityProbeTimesOut: a hanging list_cmd is bounded by the
 // probe timeout and reported as unresponsive.
 func TestRemoteConnectivityProbeTimesOut(t *testing.T) {

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/cmd"
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/internal/proctree"
 	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/stretchr/testify/require"
@@ -70,6 +71,10 @@ func testOptionsWithHome(t *testing.T, home string, fix bool, pids ...int) Optio
 		killGrace:      100 * time.Millisecond,
 		killTermWait:   200 * time.Millisecond,
 		snapshot:       snapshotOf(t, pids...),
+		// Default to "no remote configured" so the non-remote suite stays
+		// hermetic (no git shell-out, no reading the real repo's in-repo
+		// config). The remote tests below inject their own resolver.
+		remoteConfig: func() (*config.RemoteHooks, string, error) { return nil, "", nil },
 	}
 }
 
@@ -443,4 +448,163 @@ func TestOrphanSignalIdentityGuard(t *testing.T) {
 	f := findByCheck(report, "orphaned-process")[0]
 	require.NotNil(t, f.fix)
 	require.NoError(t, f.fix(), "a vanished process is a successfully-reaped process")
+}
+
+// writeHookScript writes an executable hook script under dir and returns its
+// absolute path. body should be a complete shell script (with shebang).
+func writeHookScript(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o755))
+	return path
+}
+
+// okContains reports whether any OK line contains sub.
+func okContains(r *Report, sub string) bool {
+	for _, line := range r.OK {
+		if strings.Contains(line, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// withRemote returns opts wired to resolve the given hooks (repoRoot empty:
+// the check falls back to a generic "[remote_hooks]" hint).
+func withRemote(opts Options, hooks *config.RemoteHooks) Options {
+	opts.remoteConfig = func() (*config.RemoteHooks, string, error) { return hooks, "", nil }
+	return opts
+}
+
+// TestRemoteChecksSkippedWhenNoRemote: local-only users (no remote backend
+// configured) get a single informational OK line and zero remote findings —
+// running `af doctor` outside a remote setup adds no new noise.
+func TestRemoteChecksSkippedWhenNoRemote(t *testing.T) {
+	testguard.IsolateTmux(t)
+	report, err := Run(testOptions(t, false)) // default resolver => nil hooks
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "remote-config"))
+	require.Empty(t, findByCheck(report, "remote-hook-script"))
+	require.Empty(t, findByCheck(report, "remote-connectivity"))
+	require.True(t, okContains(report, "no remote backend configured"),
+		"a clean n/a line must be shown for local-only users")
+}
+
+// TestRemoteConfigMissingRequiredField: a remote config missing a required
+// command (launch_cmd) is reported with the exact field name and where to fix
+// it, mirroring the backend's own validation.
+func TestRemoteConfigMissingRequiredField(t *testing.T) {
+	testguard.IsolateTmux(t)
+	dir := t.TempDir()
+	good := writeHookScript(t, dir, "hook.sh", "#!/bin/sh\necho '[]'\n")
+	hooks := &config.RemoteHooks{LaunchCmd: "", AttachCmd: good, DeleteCmd: good}
+
+	report, err := Run(withRemote(testOptions(t, false), hooks))
+	require.NoError(t, err)
+	findings := findByCheck(report, "remote-config")
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Detail, "launch_cmd is required")
+	require.Contains(t, findings[0].Detail, "remote_hooks")
+	require.Empty(t, findings[0].FixAction, "config findings are report-only")
+}
+
+// TestRemoteHookScriptNotExecutable: a hook path that exists but lacks the
+// execute bit is flagged with the exact chmod fix.
+func TestRemoteHookScriptNotExecutable(t *testing.T) {
+	testguard.IsolateTmux(t)
+	dir := t.TempDir()
+	good := writeHookScript(t, dir, "hook.sh", "#!/bin/sh\necho '[]'\n")
+	noexec := filepath.Join(dir, "launch.sh")
+	require.NoError(t, os.WriteFile(noexec, []byte("#!/bin/sh\n"), 0o644))
+	hooks := &config.RemoteHooks{LaunchCmd: noexec, AttachCmd: good, DeleteCmd: good}
+
+	report, err := Run(withRemote(testOptions(t, false), hooks))
+	require.NoError(t, err)
+	findings := findByCheck(report, "remote-hook-script")
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Detail, "not executable")
+	require.Contains(t, findings[0].Detail, "chmod +x")
+}
+
+// TestRemoteHookScriptMissing: a hook path that does not exist is flagged.
+func TestRemoteHookScriptMissing(t *testing.T) {
+	testguard.IsolateTmux(t)
+	dir := t.TempDir()
+	good := writeHookScript(t, dir, "hook.sh", "#!/bin/sh\necho '[]'\n")
+	missing := filepath.Join(dir, "does-not-exist.sh")
+	hooks := &config.RemoteHooks{LaunchCmd: missing, AttachCmd: good, DeleteCmd: good}
+
+	report, err := Run(withRemote(testOptions(t, false), hooks))
+	require.NoError(t, err)
+	findings := findByCheck(report, "remote-hook-script")
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Detail, "does not exist")
+	require.Contains(t, findings[0].Detail, "launch_cmd")
+}
+
+// TestRemoteConnectivityProbeSucceeds: a healthy list_cmd (exit 0, JSON array)
+// yields no findings and a success OK line.
+func TestRemoteConnectivityProbeSucceeds(t *testing.T) {
+	testguard.IsolateTmux(t)
+	dir := t.TempDir()
+	good := writeHookScript(t, dir, "hook.sh", "#!/bin/sh\necho '[]'\n")
+	list := writeHookScript(t, dir, "list.sh", "#!/bin/sh\necho '[{\"name\":\"a\",\"status\":\"running\"}]'\n")
+	hooks := &config.RemoteHooks{LaunchCmd: good, ListCmd: list, AttachCmd: good, DeleteCmd: good}
+
+	report, err := Run(withRemote(testOptions(t, false), hooks))
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "remote-connectivity"))
+	require.Empty(t, findByCheck(report, "remote-config"))
+	require.Empty(t, findByCheck(report, "remote-hook-script"))
+	require.True(t, okContains(report, "connectivity probe succeeded"))
+}
+
+// TestRemoteConnectivityProbeFails: a list_cmd that exits non-zero surfaces an
+// actionable finding quoting the script's stderr.
+func TestRemoteConnectivityProbeFails(t *testing.T) {
+	testguard.IsolateTmux(t)
+	dir := t.TempDir()
+	good := writeHookScript(t, dir, "hook.sh", "#!/bin/sh\necho '[]'\n")
+	list := writeHookScript(t, dir, "list.sh", "#!/bin/sh\necho 'ssh: connect to host: Connection refused' >&2\nexit 1\n")
+	hooks := &config.RemoteHooks{LaunchCmd: good, ListCmd: list, AttachCmd: good, DeleteCmd: good}
+
+	report, err := Run(withRemote(testOptions(t, false), hooks))
+	require.NoError(t, err)
+	findings := findByCheck(report, "remote-connectivity")
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Detail, "Connection refused")
+}
+
+// TestRemoteConnectivityProbeTimesOut: a hanging list_cmd is bounded by the
+// probe timeout and reported as unresponsive.
+func TestRemoteConnectivityProbeTimesOut(t *testing.T) {
+	testguard.IsolateTmux(t)
+	dir := t.TempDir()
+	good := writeHookScript(t, dir, "hook.sh", "#!/bin/sh\necho '[]'\n")
+	list := writeHookScript(t, dir, "list.sh", "#!/bin/sh\nsleep 30\n")
+	hooks := &config.RemoteHooks{LaunchCmd: good, ListCmd: list, AttachCmd: good, DeleteCmd: good}
+
+	opts := withRemote(testOptions(t, false), hooks)
+	opts.remoteProbeTimeout = 200 * time.Millisecond
+	report, err := Run(opts)
+	require.NoError(t, err)
+	findings := findByCheck(report, "remote-connectivity")
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Detail, "did not respond")
+}
+
+// TestRemoteProbeSkippedWithoutListCmd: with no list_cmd, the probe and
+// restore are unavailable but this is informational, not a failure — a minimal
+// launch/attach/delete-only remote setup must not fail doctor.
+func TestRemoteProbeSkippedWithoutListCmd(t *testing.T) {
+	testguard.IsolateTmux(t)
+	dir := t.TempDir()
+	good := writeHookScript(t, dir, "hook.sh", "#!/bin/sh\necho '[]'\n")
+	hooks := &config.RemoteHooks{LaunchCmd: good, AttachCmd: good, DeleteCmd: good}
+
+	report, err := Run(withRemote(testOptions(t, false), hooks))
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "remote-connectivity"))
+	require.Empty(t, findByCheck(report, "remote-config"))
+	require.True(t, okContains(report, "connectivity probe skipped"))
 }

--- a/doctor/remote.go
+++ b/doctor/remote.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -194,22 +193,47 @@ func probeListCmd(listCmd string, timeout time.Duration) string {
 	cmd.WaitDelay = 500 * time.Millisecond
 
 	err := cmd.Run()
-	if ctx.Err() == context.DeadlineExceeded {
+
+	// Judge the outcome by the process's ACTUAL exit status, not merely by
+	// whether cmd.Run returned an error. Run can return a benign non-nil error
+	// even when the command SUCCEEDED — notably exec.ErrWaitDelay, which fires
+	// when a spawned grandchild keeps a stdout/stderr pipe open past WaitDelay
+	// although the list script itself already exited 0. Treating any err != nil
+	// as a connectivity failure would make doctor cry wolf about a working
+	// remote — the worst outcome for a diagnostic (#1234 review). ExitCode is
+	// -1 when the process was signalled (e.g. killed on our timeout) or never
+	// started.
+	exitCode := -1
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+
+	switch {
+	case ctx.Err() == context.DeadlineExceeded && exitCode != 0:
+		// Deadline fired and the command did not already finish cleanly.
 		return fmt.Sprintf("remote_hooks.list_cmd did not respond within %s — the remote may be "+
 			"unreachable; check connectivity (e.g. the SSH host in %s)", timeout, listCmd)
-	}
-	if err != nil {
+	case exitCode > 0:
+		// Genuine command failure: a non-zero exit.
+		msg := fmt.Sprintf("remote_hooks.list_cmd exited %d", exitCode)
+		if s := strings.TrimSpace(stderr.String()); s != "" {
+			msg += ": " + firstLine(s)
+		}
+		return msg + " — the remote round-trip is not working; run `" + listCmd +
+			" --json` by hand to see the full output"
+	case exitCode < 0:
+		// The process never produced an exit status (failed to start, or was
+		// signalled for a reason other than our deadline) — a real failure.
 		msg := fmt.Sprintf("remote_hooks.list_cmd failed to run (%v)", err)
 		if s := strings.TrimSpace(stderr.String()); s != "" {
 			msg += ": " + firstLine(s)
 		}
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			msg += " — the remote round-trip is not working; run `" + listCmd + " --json` by hand to see the full output"
-		}
 		return msg
 	}
-	// Contract: list_cmd writes a JSON array of session objects to stdout.
+
+	// exitCode == 0: the command succeeded. Any err here (e.g. ErrWaitDelay) is
+	// benign and must NOT be reported as a failure. Validate the stdout payload
+	// against the documented contract: a JSON array of session objects.
 	var sessions []map[string]interface{}
 	if jsonErr := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &sessions); jsonErr != nil {
 		return fmt.Sprintf("remote_hooks.list_cmd exited 0 but did not return a JSON array on stdout "+

--- a/doctor/remote.go
+++ b/doctor/remote.go
@@ -1,0 +1,238 @@
+package doctor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// remoteProbeTimeoutDefault bounds the connectivity probe. The probe runs the
+// user's list_cmd (which may SSH to a remote host), so it is generous relative
+// to the runtime IsAlive timeouts (2s/5s): a user running `af doctor` is
+// actively diagnosing and can tolerate a slow round-trip, and the goal is an
+// actionable "did not respond" rather than a fast failure on a slow link.
+const remoteProbeTimeoutDefault = 10 * time.Second
+
+// defaultRemoteConfig resolves the remote-hook backend for the repository
+// containing the current working directory. It returns nil hooks — and no
+// error — whenever remote checks should skip cleanly: cwd is not inside a git
+// repo, or the repo configures no remote backend. This is the production
+// resolver; tests inject their own via Options.remoteConfig to stay hermetic.
+func defaultRemoteConfig() (*config.RemoteHooks, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, "", err
+	}
+	repo, err := config.RepoFromPath(cwd)
+	if err != nil {
+		// Not a git repo (or git unavailable): there is no repo whose
+		// remote_hooks we could validate. Skip cleanly rather than fail.
+		return nil, "", nil
+	}
+	cfg, err := config.ResolveConfig(repo.Root)
+	if err != nil {
+		return nil, repo.Root, err
+	}
+	// ResolveConfig has already rewritten relative hook paths to absolute
+	// against repo.Root, so executability checks below can stat them directly.
+	return cfg.RemoteHooks, repo.Root, nil
+}
+
+// checkRemoteSetup validates the remote-hook backend for the current repo:
+// config completeness, hook-script presence/executability, and a bounded
+// read-only connectivity probe via list_cmd. When no remote backend is
+// configured (the common case for local-only users), it records a single
+// informational "n/a" line and adds no findings — running `af doctor` outside
+// a remote setup must produce zero new noise.
+func checkRemoteSetup(ctx *scanContext, report *Report) {
+	resolve := ctx.opts.remoteConfig
+	if resolve == nil {
+		resolve = defaultRemoteConfig
+	}
+	hooks, repoRoot, err := resolve()
+	if err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "remote-config",
+			Detail: fmt.Sprintf("could not resolve remote-hook config for this repo: %v", err),
+		})
+		return
+	}
+	if hooks == nil {
+		report.OK = append(report.OK,
+			"remote hooks: n/a — no remote backend configured for this repo")
+		return
+	}
+
+	configHint := "in [remote_hooks]"
+	if repoRoot != "" {
+		configHint = "in " + config.InRepoConfigPath(repoRoot) + " under [remote_hooks]"
+	}
+
+	// 1. Required-field validity: the same guard the backend enforces before
+	// running any hook, surfaced here as a diagnosable finding instead of an
+	// operation-time failure.
+	if err := hooks.Validate(); err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "remote-config",
+			Detail: fmt.Sprintf("%v — set it %s", err, configHint),
+		})
+	} else {
+		report.OK = append(report.OK,
+			"remote hooks: configured with the required launch/attach/delete commands")
+	}
+
+	// 2. Hook-script presence + executability, for every configured command.
+	// A path that exists but lacks the execute bit, or a bare name missing
+	// from $PATH, is the most common remote-setup mistake — surface it with
+	// the exact fix.
+	type hook struct{ field, cmd string }
+	for _, h := range []hook{
+		{"launch_cmd", hooks.LaunchCmd},
+		{"list_cmd", hooks.ListCmd},
+		{"attach_cmd", hooks.AttachCmd},
+		{"delete_cmd", hooks.DeleteCmd},
+		{"terminal_cmd", hooks.TerminalCmd},
+	} {
+		if strings.TrimSpace(h.cmd) == "" {
+			continue // required-field emptiness is handled by Validate above.
+		}
+		if detail := hookExecIssue(h.field, h.cmd, configHint); detail != "" {
+			report.Findings = append(report.Findings, Finding{
+				Check:  "remote-hook-script",
+				Detail: detail,
+			})
+		}
+	}
+
+	// 3. Connectivity / round-trip probe. list_cmd is the only read-only verb
+	// (launch/attach/delete all mutate remote state), so it is the safe probe.
+	// When list_cmd is absent, restore and this probe are both unavailable —
+	// noted as informational, not a failure, since list_cmd is optional.
+	if strings.TrimSpace(hooks.ListCmd) == "" {
+		report.OK = append(report.OK,
+			"remote hooks: connectivity probe skipped — no list_cmd configured "+
+				"(set list_cmd to enable restore across restarts and the round-trip probe)")
+		return
+	}
+	// Skip the probe if list_cmd itself is not runnable — the executability
+	// check above already reported the actionable fix; running it would only
+	// add a redundant exec error.
+	if hookExecIssue("list_cmd", hooks.ListCmd, configHint) != "" {
+		return
+	}
+	timeout := ctx.opts.remoteProbeTimeout
+	if timeout == 0 {
+		timeout = remoteProbeTimeoutDefault
+	}
+	if detail := probeListCmd(hooks.ListCmd, timeout); detail != "" {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "remote-connectivity",
+			Detail: detail,
+		})
+	} else {
+		report.OK = append(report.OK,
+			"remote hooks: connectivity probe succeeded (list_cmd responded with valid JSON)")
+	}
+}
+
+// hookExecIssue returns an actionable message when the hook command cannot be
+// executed, or "" when it looks runnable. It mirrors exec.Command's own path
+// semantics: a value with a path separator (or absolute) is a filesystem path
+// that must exist and be executable; a bare name is resolved on $PATH. Values
+// reaching here have already had relative paths rewritten to absolute by
+// ResolveConfig, so a separator implies an absolute path.
+func hookExecIssue(field, cmd, configHint string) string {
+	cmd = strings.TrimSpace(cmd)
+	if strings.ContainsRune(cmd, filepath.Separator) {
+		info, err := os.Stat(cmd)
+		if err != nil {
+			return fmt.Sprintf("remote_hooks.%s points at %s, which does not exist — "+
+				"check the path %s", field, cmd, configHint)
+		}
+		if info.IsDir() {
+			return fmt.Sprintf("remote_hooks.%s points at %s, which is a directory, not an "+
+				"executable — check the path %s", field, cmd, configHint)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			return fmt.Sprintf("remote_hooks.%s script %s is not executable — run: chmod +x %s",
+				field, cmd, cmd)
+		}
+		return ""
+	}
+	// Bare name: resolved on $PATH exactly like exec.
+	if _, err := exec.LookPath(cmd); err != nil {
+		return fmt.Sprintf("remote_hooks.%s is %q, which was not found on $PATH — install it or "+
+			"use a path to the script %s", field, cmd, configHint)
+	}
+	return ""
+}
+
+// probeListCmd runs `list_cmd --json` under a bounded timeout and returns an
+// actionable message on failure, or "" when the round-trip succeeded (exit 0
+// and a parseable JSON array). stdout and stderr are captured separately so
+// the JSON parse sees only the documented stdout payload while error messages
+// can quote the script's stderr diagnostics.
+func probeListCmd(listCmd string, timeout time.Duration) string {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, listCmd, "--json")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	// Bound how long the reader waits after a timeout kill, mirroring the
+	// runtime list_cmd path (#645): a script that spawned a long-lived child
+	// must not hold the probe open past the deadline.
+	cmd.WaitDelay = 500 * time.Millisecond
+
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Sprintf("remote_hooks.list_cmd did not respond within %s — the remote may be "+
+			"unreachable; check connectivity (e.g. the SSH host in %s)", timeout, listCmd)
+	}
+	if err != nil {
+		msg := fmt.Sprintf("remote_hooks.list_cmd failed to run (%v)", err)
+		if s := strings.TrimSpace(stderr.String()); s != "" {
+			msg += ": " + firstLine(s)
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			msg += " — the remote round-trip is not working; run `" + listCmd + " --json` by hand to see the full output"
+		}
+		return msg
+	}
+	// Contract: list_cmd writes a JSON array of session objects to stdout.
+	var sessions []map[string]interface{}
+	if jsonErr := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &sessions); jsonErr != nil {
+		return fmt.Sprintf("remote_hooks.list_cmd exited 0 but did not return a JSON array on stdout "+
+			"(got %q) — see docs/remote-hooks.md for the list_cmd protocol", snippet(stdout.String()))
+	}
+	return ""
+}
+
+// firstLine returns the first non-empty line of s, for compact error context.
+func firstLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// snippet trims and truncates s for inclusion in a finding message.
+func snippet(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 80 {
+		s = s[:80] + "…"
+	}
+	return s
+}

--- a/doctorcmd.go
+++ b/doctorcmd.go
@@ -26,6 +26,9 @@ var doctorCmd = &cobra.Command{
   - af_ tmux sessions with no backing session record
   - abandoned agent-factory homes under the temp dir (leaked by tests/debug runs)
   - daemon health: control socket, autostart unit, pid file, binary freshness
+  - remote-hook setup for the current repo: config completeness, hook-script
+    presence/executability, and a bounded list_cmd connectivity probe
+    (skipped cleanly when no remote backend is configured)
 
 Read-only by default. With --fix, applies the safe remediations — killing
 orphans whose ancestry markers prove they came from a dead af session, and


### PR DESCRIPTION
## Summary

Folds remote-setup validation into the **existing** `af doctor` command — not a separate `af remote doctor` — per Sachin's direction on #1039 ("af remote doctor should just be af doctor… let's add remote checking to the doctor command"). This is the **doctor half** of #1039; the remote round-trip integration harness (spawn→attach→detach→reconcile→kill against a real remote) remains the separate, larger half and is **not** built here.

When the repository containing the current working directory configures a `remote_hooks` backend, `af doctor` now validates it so a misconfigured remote surfaces as a diagnosable finding instead of a cryptic failure at session-launch time.

## Remote checks added

| Check slug | What it validates | Actionable fix on failure |
|---|---|---|
| `remote-config` | Required `remote_hooks` commands (`launch_cmd`, `attach_cmd`, `delete_cmd`) present — same guard the backend enforces at resolution time | Names the missing field + the in-repo config file |
| `remote-hook-script` | Every configured hook (`launch`/`list`/`attach`/`delete`/`terminal`) resolves to something runnable: an existing, executable path, or a bare name on `$PATH` | `chmod +x <path>`, "does not exist", or "not found on \$PATH" |
| `remote-connectivity` | A bounded, **read-only** `list_cmd --json` round-trip probe (default 10s) responds with a valid JSON array | Non-zero exit quotes the script's stderr; a hang reports "did not respond within Ns" |

`list_cmd` is the only non-mutating verb, so it is the safe probe; `launch`/`attach`/`delete` all mutate remote state and are **not** exercised here (that's the integration-harness half). When `list_cmd` is absent, the probe and restore-across-restarts are noted as **informational**, not a failure.

## Zero new noise for local-only users

When **no** remote backend is configured — the common case, or when `af doctor` runs outside a git repo — the remote checks collapse to a single informational line (`ok: remote hooks: n/a — no remote backend configured for this repo`) and add **zero findings**. Remote findings flow through the same `Report`/`Finding` structure as every other check, so they render identically (`ok:` / `issue:`) and are carried in any structured output the same way.

## Conservative choices (for root/Sachin to confirm)

1. **Scope = current repo (cwd).** `remote_hooks` is per-repo, in-repo config, so the checks validate the repo of the working directory. A future enhancement could enumerate all repos that have remote sessions; kept out of scope to keep this focused.
2. **Probe depth = read-only `list_cmd` round-trip only.** The deeper spawn/attach/kill validation belongs to the integration harness (the other half of #1039).

## Testing

- New hermetic tests in `doctor/doctor_test.go` (temp scripts, no network): no-remote-skips-cleanly, missing required field, non-executable hook, missing hook, probe success, probe failure (stderr surfaced), probe timeout, and probe-skipped-without-list_cmd. All pass in `make test-container`.
- Drove the real `af doctor` binary against a temp repo with (a) a broken remote config → correct `remote-hook-script` findings with actionable paths, and (b) a healthy config → both OK lines, zero remote findings.

## Gates

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — empty
- `go build ./...` — clean
- `make test-container GOTESTARGS=./doctor/` — green
- `scripts/lint-file-length.sh` — passed (new `doctor/remote.go`, well under limit)

## Docs

Updated `docs/cli.md` and `docs/cli-reference.md` with the new remote checks, and added a "Validating your setup" pointer in `docs/remote-hooks.md`.

Refs #1039 — **does not close it**; the integration-harness half remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)