### PR TITLE
feat: add `af bug-report` diagnostics bundle (#1048)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Read and write the global config from the CLI: `af config list` / `af config get
 
 This repo is autonomously maintained by Captain Claude, an AI maintainer running on Claude Code; the operating contract lives in [CLAUDE.md](CLAUDE.md). Every open issue gets a response — a fix, specific questions, or a reasoned close — and merged work reaches the preview channel (`1.x.y-preview-z`) from `master` every 3 hours; stable releases (`1.x.y`) are cut manually (see [docs/release-process.md](docs/release-process.md)).
 
-When filing an issue, include: steps to reproduce, expected vs. actual behavior, `af version` output and your platform, and (when relevant) logs from the application log (see `docs/configuration.md` for path resolution).
+When filing an issue, include: steps to reproduce, expected vs. actual behavior, `af version` output and your platform, and (when relevant) logs from the application log (see `docs/configuration.md` for path resolution). The fastest way to gather all of that is `af bug-report`, which bundles the log tail, versions, tasks, redacted session state, and daemon health into a single `~/af-bug-report-<ts>.txt` you can attach — redaction is best-effort, so review the file before sharing it.
 
 ## License
 

--- a/bugreport/bugreport.go
+++ b/bugreport/bugreport.go
@@ -1,0 +1,284 @@
+// Package bugreport builds `af bug-report`: a single, self-contained,
+// best-effort-redacted diagnostics bundle a user can attach to a GitHub issue.
+// It gathers the daemon log tail, versions, the configured tasks, the session
+// state (instances.json), the daemon health snapshot, and the global config,
+// then runs every free-text and secret-bearing field through the redactor in
+// redact.go. Redaction is best-effort by design — the bundle always carries a
+// "review before sharing" warning — but the policy is conservative: structural
+// triage fields are kept, free-text bodies are dropped, and $HOME/username and
+// known credential shapes are scrubbed everywhere.
+package bugreport
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+	aflog "github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+const (
+	// logTailMaxBytes bounds how much of the (possibly large) log we read —
+	// the tail is what matters for triage and the bundle must stay pasteable.
+	logTailMaxBytes = 2 << 20 // 2 MiB
+	// logTailMaxLines further caps the tail after the byte read so a log of
+	// very long lines still yields a bounded, readable slice.
+	logTailMaxLines = 5000
+
+	// reviewWarning is repeated at the top of the text bundle and carried in
+	// the JSON so no consumer can miss it: redaction is best-effort.
+	reviewWarning = "REVIEW THIS BUNDLE BEFORE SHARING. Redaction is best-effort — " +
+		"paths, prompts, and secrets are scrubbed on a conservative default, but " +
+		"perfect redaction is impossible. Open it, read it, and remove anything " +
+		"sensitive before attaching it to a public issue."
+)
+
+// Inputs are the already-collected, caller-supplied facts the bugreport
+// package cannot gather without importing package main. The command layer
+// resolves the af version and the daemon status (it owns collectDaemonStatus)
+// and passes them in; everything else this package reads itself.
+type Inputs struct {
+	// AFVersion is the `af` binary version (main.version).
+	AFVersion string
+	// GeneratedAt is a caller-formatted timestamp for the bundle header.
+	GeneratedAt string
+	// DaemonStatus is the structured `af daemon status` snapshot, embedded
+	// verbatim in the JSON manifest (its socket/pid paths are scrubbed by the
+	// final text pass).
+	DaemonStatus any
+	// DaemonHuman is the pre-rendered human `af daemon status` text for the
+	// text bundle's daemon section.
+	DaemonHuman string
+}
+
+// Versions is the version/platform block of the bundle.
+type Versions struct {
+	AF   string `json:"af"`
+	Go   string `json:"go"`
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+}
+
+// repoInstances is one repo's redacted session records.
+type repoInstances struct {
+	RepoID    string          `json:"repo_id"`
+	Instances json.RawMessage `json:"instances"`
+}
+
+// configSection is the redacted global config file, or nil when none exists.
+type configSection struct {
+	Path     string `json:"path"`
+	Format   string `json:"format"`
+	Contents string `json:"contents"`
+}
+
+// logSection is the redacted, bounded daemon log tail.
+type logSection struct {
+	Path      string `json:"path"`
+	Truncated bool   `json:"truncated"`
+	Bytes     int    `json:"bytes"`
+	Contents  string `json:"contents"`
+}
+
+// Bundle is the structured manifest emitted by `--json` and the source the
+// text bundle is rendered from.
+type Bundle struct {
+	GeneratedAt string          `json:"generated_at"`
+	Warning     string          `json:"warning"`
+	Versions    Versions        `json:"versions"`
+	Daemon      any             `json:"daemon"`
+	Tasks       []redactedTask  `json:"tasks"`
+	Instances   []repoInstances `json:"instances"`
+	Config      *configSection  `json:"config,omitempty"`
+	Log         logSection      `json:"log"`
+	// Errors records non-fatal collection failures (an unreadable section)
+	// so a partial bundle is still useful and the gaps are explicit.
+	Errors []string `json:"errors,omitempty"`
+
+	// daemonHuman is the pre-rendered human daemon-status text used by the
+	// text renderer. Unexported so it never appears in the JSON manifest (the
+	// structured Daemon snapshot is the machine-readable form there).
+	daemonHuman string
+}
+
+// Result is what Build returns: a rendered text bundle (the default output the
+// user attaches) and the JSON manifest payload (the `--json` data member).
+type Result struct {
+	Text string
+	JSON []byte
+}
+
+// Build collects, redacts, and renders the bundle. It never fails on a missing
+// or unreadable section — those are recorded in Bundle.Errors and rendering
+// continues — so a user on a broken install can still produce a report.
+func Build(in Inputs) (Result, error) {
+	r := newRedactor()
+	b := Bundle{
+		GeneratedAt: in.GeneratedAt,
+		Warning:     reviewWarning,
+		Versions: Versions{
+			AF:   in.AFVersion,
+			Go:   runtime.Version(),
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+		},
+		Daemon:      in.DaemonStatus,
+		daemonHuman: in.DaemonHuman,
+	}
+
+	b.Tasks, b.Errors = collectTasks(b.Errors)
+	b.Instances, b.Errors = collectInstances(r, b.Errors)
+	b.Config, b.Errors = collectConfig(r, b.Errors)
+	b.Log, b.Errors = collectLog(r, b.Errors)
+
+	jsonBytes, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return Result{}, fmt.Errorf("marshal bug-report bundle: %w", err)
+	}
+	// Final catch-all pass: scrubs $HOME/username in the passed-in daemon
+	// socket/pid paths and any residue. Idempotent over the per-section
+	// scrubbing already applied, and safe for JSON (replacements never
+	// introduce characters that need escaping).
+	jsonBytes = []byte(r.scrub(string(jsonBytes)))
+
+	text := r.scrub(renderText(b))
+
+	return Result{Text: text, JSON: jsonBytes}, nil
+}
+
+// collectTasks loads and redacts the configured tasks.
+func collectTasks(errs []string) ([]redactedTask, []string) {
+	tasks, err := task.LoadTasks()
+	if err != nil {
+		return nil, append(errs, fmt.Sprintf("tasks: %v", err))
+	}
+	out := make([]redactedTask, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, redactTask(t))
+	}
+	return out, errs
+}
+
+// collectInstances loads every repo's instances.json and redacts each, sorted
+// by repo id for stable output.
+func collectInstances(r *redactor, errs []string) ([]repoInstances, []string) {
+	all, err := config.LoadAllRepoInstances()
+	if err != nil {
+		return nil, append(errs, fmt.Sprintf("instances: %v", err))
+	}
+	repoIDs := make([]string, 0, len(all))
+	for id := range all {
+		repoIDs = append(repoIDs, id)
+	}
+	sort.Strings(repoIDs)
+	out := make([]repoInstances, 0, len(repoIDs))
+	for _, id := range repoIDs {
+		out = append(out, repoInstances{
+			RepoID:    id,
+			Instances: r.redactInstancesJSON(all[id]),
+		})
+	}
+	return out, errs
+}
+
+// collectConfig reads the global config file (config.toml preferred, else
+// config.json) and scrubs it. A missing file is not an error — many installs
+// run on defaults — it just yields a nil section.
+func collectConfig(r *redactor, errs []string) (*configSection, []string) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return nil, append(errs, fmt.Sprintf("config dir: %v", err))
+	}
+	for _, c := range []struct{ name, format string }{
+		{config.TomlConfigFileName, "toml"},
+		{config.ConfigFileName, "json"},
+	} {
+		path := filepath.Join(dir, c.name)
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			if os.IsNotExist(readErr) {
+				continue
+			}
+			errs = append(errs, fmt.Sprintf("config %s: %v", c.name, readErr))
+			continue
+		}
+		return &configSection{
+			Path:     path,
+			Format:   c.format,
+			Contents: r.scrub(string(data)),
+		}, errs
+	}
+	return nil, errs
+}
+
+// collectLog reads and scrubs the bounded tail of the production log.
+func collectLog(r *redactor, errs []string) (logSection, []string) {
+	path := aflog.LogFilePath()
+	sec := logSection{Path: path}
+	if path == "" {
+		return sec, append(errs, "log: could not resolve log path")
+	}
+	data, truncated, err := tailFile(path, logTailMaxBytes)
+	if err != nil {
+		if os.IsNotExist(err) {
+			sec.Contents = "(no log file at " + path + ")"
+			return sec, errs
+		}
+		return sec, append(errs, fmt.Sprintf("log %s: %v", path, err))
+	}
+	text, lineTruncated := lastLines(string(data), logTailMaxLines)
+	sec.Truncated = truncated || lineTruncated
+	sec.Contents = r.scrub(text)
+	sec.Bytes = len(sec.Contents)
+	return sec, errs
+}
+
+// tailFile reads at most maxBytes from the end of path. When the file is
+// larger, the read starts at a byte offset (so the first, likely-partial line
+// is dropped by lastLines) and truncated is true.
+func tailFile(path string, maxBytes int64) (data []byte, truncated bool, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, false, err
+	}
+	size := info.Size()
+	if size <= maxBytes {
+		buf, readErr := os.ReadFile(path)
+		return buf, false, readErr
+	}
+	if _, err := f.Seek(size-maxBytes, 0); err != nil {
+		return nil, false, err
+	}
+	buf := make([]byte, maxBytes)
+	n, err := f.Read(buf)
+	if err != nil {
+		return nil, false, err
+	}
+	// Drop the partial first line left by the mid-file seek.
+	if idx := bytes.IndexByte(buf[:n], '\n'); idx >= 0 && idx+1 <= n {
+		return buf[idx+1 : n], true, nil
+	}
+	return buf[:n], true, nil
+}
+
+// lastLines keeps the final maxLines lines of s, reporting whether earlier
+// lines were dropped.
+func lastLines(s string, maxLines int) (string, bool) {
+	lines := strings.Split(s, "\n")
+	if len(lines) <= maxLines {
+		return s, false
+	}
+	return strings.Join(lines[len(lines)-maxLines:], "\n"), true
+}

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -1,0 +1,243 @@
+package bugreport
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// A realistic 40-hex git SHA that must survive redaction — the "keep
+// structural triage fields" half of the policy.
+const testSHA = "9f2c1ab34de5f6a7b8c9d0e1f2a3b4c5d6e7f809"
+
+func TestScrubRedactsSecretsPathsAndUser(t *testing.T) {
+	r := &redactor{home: "/home/alice", users: []string{"alice"}}
+	in := strings.Join([]string{
+		"worktree /home/alice/Desktop/proj",
+		"branch alice/fix-1",
+		"openai sk-abcdefghijklmnopqrstuvwxyz012345",
+		"github ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+		"aws AKIA1234567890ABCDEF",
+		`github_token = "ghp_ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210"`,
+		"password: hunter2secretvalue",
+		"commit " + testSHA,
+	}, "\n")
+
+	out := r.scrub(in)
+
+	// Home collapsed and username blanked (including the bare branch token).
+	if strings.Contains(out, "/home/alice") {
+		t.Errorf("home directory not collapsed:\n%s", out)
+	}
+	if !strings.Contains(out, "~/Desktop/proj") {
+		t.Errorf("expected ~/Desktop/proj after home collapse:\n%s", out)
+	}
+	if strings.Contains(out, "alice/fix-1") {
+		t.Errorf("bare username not scrubbed:\n%s", out)
+	}
+	if !strings.Contains(out, userMarker+"/fix-1") {
+		t.Errorf("expected [user]/fix-1:\n%s", out)
+	}
+
+	// Every planted secret gone.
+	for _, leaked := range []string{
+		"sk-abcdefghijklmnopqrstuvwxyz012345",
+		"ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+		"ghp_ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210",
+		"AKIA1234567890ABCDEF",
+		"hunter2secretvalue",
+	} {
+		if strings.Contains(out, leaked) {
+			t.Errorf("secret leaked through scrub: %q\n%s", leaked, out)
+		}
+	}
+	if !strings.Contains(out, secretMarker) {
+		t.Errorf("expected a secret marker in output:\n%s", out)
+	}
+
+	// The git SHA is structural and must survive.
+	if !strings.Contains(out, testSHA) {
+		t.Errorf("git SHA was scrubbed but must survive:\n%s", out)
+	}
+}
+
+func TestScrubRedactsPEMPrivateKey(t *testing.T) {
+	r := &redactor{}
+	in := "before\n-----BEGIN OPENSSH PRIVATE KEY-----\nAAAAsecretkeymaterial\n-----END OPENSSH PRIVATE KEY-----\nafter"
+	out := r.scrub(in)
+	if strings.Contains(out, "secretkeymaterial") {
+		t.Errorf("PEM private key not scrubbed:\n%s", out)
+	}
+	if !strings.Contains(out, "before") || !strings.Contains(out, "after") {
+		t.Errorf("surrounding text should survive:\n%s", out)
+	}
+}
+
+func TestRedactInstanceDataKeepsStructuralDropsFreeText(t *testing.T) {
+	d := session.InstanceData{
+		ID:      "abc123",
+		Title:   "proprietary session name",
+		Path:    "/home/alice/Desktop/proj",
+		Branch:  "alice/fix",
+		Status:  session.Status(1),
+		Program: "claude",
+		Tabs: []session.TabData{
+			{Name: "agent", Command: "claude --token sk-SUPERSECRETTOKEN0123456"},
+		},
+		PRInfo: session.PRInfoData{Number: 42, State: "open", Title: "secret pr title", URL: "https://example.com/pr/42"},
+		Worktree: session.GitWorktreeData{
+			RepoPath:      "/home/alice/Desktop/proj",
+			WorktreePath:  "/home/alice/Desktop/proj-fix",
+			BaseCommitSHA: testSHA,
+		},
+		RemoteMeta: map[string]interface{}{"api_secret": "topsecretvalue"},
+	}
+
+	redactInstanceData(&d)
+
+	if d.Title != redactedMarker {
+		t.Errorf("title not redacted: %q", d.Title)
+	}
+	if d.Tabs[0].Command != redactedMarker {
+		t.Errorf("tab command not redacted: %q", d.Tabs[0].Command)
+	}
+	if d.PRInfo.Title != redactedMarker || d.PRInfo.URL != redactedMarker {
+		t.Errorf("PR free-text not redacted: %+v", d.PRInfo)
+	}
+	if v, ok := d.RemoteMeta["api_secret"]; ok {
+		t.Errorf("remote_meta secret survived: %v", v)
+	}
+
+	// Structural fields intact.
+	if d.ID != "abc123" || d.Program != "claude" || d.Status != session.Status(1) {
+		t.Errorf("structural fields mutated: %+v", d)
+	}
+	if d.PRInfo.Number != 42 || d.PRInfo.State != "open" {
+		t.Errorf("structural PR fields mutated: %+v", d.PRInfo)
+	}
+	if d.Worktree.BaseCommitSHA != testSHA {
+		t.Errorf("base commit SHA must survive: %q", d.Worktree.BaseCommitSHA)
+	}
+}
+
+// TestBuildEndToEnd plants a full temp home with a secret and a home path in
+// every collected surface (instances, tasks, config, log, daemon status) and
+// asserts the produced bundle scrubs them while keeping the structural fields.
+func TestBuildEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	afHome := filepath.Join(home, ".agent-factory")
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+	if err := os.MkdirAll(afHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// instances.json for one repo.
+	instDir := filepath.Join(afHome, "instances", "testrepo")
+	if err := os.MkdirAll(instDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	instances := `[{
+      "id": "abc123",
+      "title": "my proprietary session",
+      "path": "` + home + `/Desktop/proj",
+      "branch": "feature",
+      "status": 1,
+      "program": "claude",
+      "created_at": "2026-01-01T00:00:00Z",
+      "worktree": {"repo_path": "` + home + `/Desktop/proj", "worktree_path": "` + home + `/Desktop/proj-fix", "base_commit_sha": "` + testSHA + `"},
+      "tabs": [{"name": "agent", "command": "claude --token sk-INSTANCESECRET0123456789"}],
+      "pr_info": {"number": 42, "state": "open", "title": "secret pr", "url": "https://x/pr/42"},
+      "remote_meta": {"key": "topsecretremote"}
+    }]`
+	writeFile(t, filepath.Join(instDir, "instances.json"), instances)
+
+	// tasks.json
+	tasks := `[{"id": "t1", "name": "nightly", "prompt": "run with sk-TASKSECRET0123456789ABCD", "cron_expr": "0 9 * * *", "enabled": true, "project_path": "` + home + `/Desktop/proj", "program": "claude"}]`
+	writeFile(t, filepath.Join(afHome, "tasks.json"), tasks)
+
+	// config.toml with a planted credential and a home path.
+	cfg := "default_program = \"codex\"\ngithub_token = \"ghp_PLANTEDCONFIGSECRET0123456789ABCD\"\n# note path " + home + "/Desktop\n"
+	writeFile(t, filepath.Join(afHome, "config.toml"), cfg)
+
+	// log tail with a home path and a secret.
+	logLine := "2026-01-01 boot at " + home + "/Desktop key sk-LOGSECRET0123456789ABCDEF sha " + testSHA + "\n"
+	writeFile(t, filepath.Join(afHome, "agent-factory.log"), logLine)
+
+	res, err := Build(Inputs{
+		AFVersion:    "9.9.9",
+		GeneratedAt:  "2026-07-05 00:00:00 +0000",
+		DaemonStatus: map[string]any{"running": false, "control_socket": home + "/.agent-factory/daemon.sock"},
+		DaemonHuman:  "daemon: not running\n  control socket: " + home + "/.agent-factory/daemon.sock (absent)\n",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	// --- text bundle assertions ---
+	text := res.Text
+	mustContain(t, "text", text,
+		"AGENT FACTORY BUG REPORT",
+		"REVIEW THIS BUNDLE BEFORE SHARING",
+		"9.9.9",      // af version
+		"abc123",     // instance id (structural)
+		"t1",         // task id (structural)
+		"0 9 * * *",  // cron (structural)
+		"has_prompt", // task prompt presence signal
+		"~/Desktop",  // home collapsed, structural path kept
+		testSHA,      // git SHA survives
+		"_redacted",  // remote_meta signal preserved
+	)
+	planted := []string{
+		"sk-INSTANCESECRET0123456789",
+		"sk-TASKSECRET0123456789ABCD",
+		"sk-LOGSECRET0123456789ABCDEF",
+		"ghp_PLANTEDCONFIGSECRET0123456789ABCD",
+		"topsecretremote",
+		"my proprietary session",
+		"secret pr",
+		home, // raw home path (username-revealing) must never appear verbatim
+	}
+	mustNotContain(t, "text", text, planted...)
+
+	// --- json manifest assertions ---
+	var manifest map[string]any
+	if err := json.Unmarshal(res.JSON, &manifest); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	if manifest["warning"] == nil {
+		t.Error("manifest missing warning")
+	}
+	mustNotContain(t, "json", string(res.JSON), planted...)
+	// Structural fields survive into the manifest too.
+	mustContain(t, "json", string(res.JSON), "abc123", "9.9.9", testSHA)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func mustContain(t *testing.T, label, hay string, needles ...string) {
+	t.Helper()
+	for _, n := range needles {
+		if !strings.Contains(hay, n) {
+			t.Errorf("[%s] expected to contain %q", label, n)
+		}
+	}
+}
+
+func mustNotContain(t *testing.T, label, hay string, needles ...string) {
+	t.Helper()
+	for _, n := range needles {
+		if strings.Contains(hay, n) {
+			t.Errorf("[%s] must NOT contain %q (leak)", label, n)
+		}
+	}
+}

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -124,6 +124,58 @@ func TestRedactInstanceDataKeepsStructuralDropsFreeText(t *testing.T) {
 	}
 }
 
+// TestRedactInstancesFallbackRedactsOnDecodeFailure exercises the fail-safe
+// fallback: a legacy/corrupt record that fails the typed []InstanceData decode
+// (here `status` is a string, but the field is an int) must still be redacted —
+// MORE aggressively, not less. The prompt holds a proprietary phrase no secret
+// regex would catch, so only the structural key-redaction can remove it; the
+// path and arbitrary remote_meta are dropped wholesale too.
+func TestRedactInstancesFallbackRedactsOnDecodeFailure(t *testing.T) {
+	r := &redactor{home: "/home/alice", users: []string{"alice"}}
+	raw := json.RawMessage(`[{
+		"id": "leg-1",
+		"status": "legacy-string-status",
+		"prompt": "internal codename Bluebird migration runbook",
+		"command": "deploy --token ghp_LEGACYSECRET0123456789ABCDEF",
+		"path": "/home/alice/proprietary-project",
+		"remote_meta": {"weird_key": "arbitrarysecretvalue"}
+	}]`)
+
+	out := string(r.redactInstancesJSON(raw))
+
+	for _, leak := range []string{
+		"Bluebird",                         // proprietary free text — regex would miss it
+		"ghp_LEGACYSECRET0123456789ABCDEF", // secret under a sensitive key
+		"arbitrarysecretvalue",             // arbitrary metadata value
+		"proprietary-project",              // path dropped on the fallback
+	} {
+		if strings.Contains(out, leak) {
+			t.Errorf("fallback path leaked %q:\n%s", leak, out)
+		}
+	}
+	// Safe structural fields still survive.
+	if !strings.Contains(out, "leg-1") || !strings.Contains(out, "legacy-string-status") {
+		t.Errorf("fallback dropped safe structural fields:\n%s", out)
+	}
+	if !strings.Contains(out, redactedMarker) {
+		t.Errorf("expected redaction markers on the fallback path:\n%s", out)
+	}
+}
+
+// TestRedactInstancesInvalidJSONOmitted confirms that a payload which is not
+// even valid JSON surfaces nothing — the contents are omitted with a note.
+func TestRedactInstancesInvalidJSONOmitted(t *testing.T) {
+	r := &redactor{}
+	raw := json.RawMessage(`{not valid json at all sk-RAWSECRET0123456789ABCDEF`)
+	out := string(r.redactInstancesJSON(raw))
+	if strings.Contains(out, "sk-RAWSECRET0123456789ABCDEF") {
+		t.Errorf("invalid-JSON path leaked a secret:\n%s", out)
+	}
+	if !strings.Contains(out, "omitted for safety") {
+		t.Errorf("expected the omission note:\n%s", out)
+	}
+}
+
 // TestBuildEndToEnd plants a full temp home with a secret and a home path in
 // every collected surface (instances, tasks, config, log, daemon status) and
 // asserts the produced bundle scrubs them while keeping the structural fields.

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -1,0 +1,203 @@
+package bugreport
+
+import (
+	"encoding/json"
+	"os"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// Redaction markers. `redactedMarker` replaces a whole free-text field the
+// policy always drops (session titles, task prompts, tab commands);
+// `secretMarker` replaces a substring a best-effort pattern flagged as a
+// credential inside otherwise-kept text (log lines, config values).
+const (
+	redactedMarker = "[redacted]"
+	secretMarker   = "[redacted-secret]"
+	userMarker     = "[user]"
+)
+
+// secretPatterns are targeted, high-confidence credential shapes scrubbed
+// wherever they appear (log tail, config, instance/task text). They are
+// deliberately specific — a broad "any long hex string" rule would also nuke
+// the git SHAs and IDs a triager needs, so those are left intact. Best-effort
+// by construction; the bundle always warns the user to review before sharing.
+var secretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`sk-[A-Za-z0-9_-]{16,}`),                                     // OpenAI / Anthropic-style keys (incl. sk-ant-…)
+	regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,}`),                                // GitHub PAT / OAuth / server / refresh tokens
+	regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,}`),                              // GitHub fine-grained PAT
+	regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),                              // Slack tokens
+	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),                                          // AWS access key id
+	regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}`),                                     // Google API key
+	regexp.MustCompile(`eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+`), // JWT (header.payload.signature)
+}
+
+// keyValueSecret matches a `<credential-key> = <value>` / `<key>: <value>`
+// assignment and redacts only the value, preserving the key so triage can see
+// *that* a credential is configured without leaking it. The key half tolerates
+// a prefix (github_token, x-api-key, client_secret) and an optional opening
+// quote; the value half is any run of 6+ non-space, non-quote characters.
+var keyValueSecret = regexp.MustCompile(
+	`(?i)("?[a-z0-9_-]*(?:api[_-]?key|secret|token|password|passwd|pwd|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret|bearer|credential|private[_-]?key)s?"?\s*[:=]\s*"?)([^\s"',}\]]{6,})`)
+
+// privateKeyBlock matches a PEM private-key block in its entirety.
+var privateKeyBlock = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
+
+// redactor holds the per-run redaction context — the home directory to
+// collapse to "~" and the username token(s) to blank to "[user]" — resolved
+// once so every section scrubs against the same values. Constructed with
+// newRedactor() in production; tests build one directly with fixed values for
+// deterministic assertions.
+type redactor struct {
+	home  string
+	users []string
+}
+
+// newRedactor resolves the redaction context from the environment: the OS
+// home directory and the current username (plus the home directory's base
+// name, which is the username on a conventional layout).
+func newRedactor() *redactor {
+	home, _ := os.UserHomeDir()
+	var users []string
+	if u, err := user.Current(); err == nil {
+		users = appendUserToken(users, u.Username)
+	}
+	if home != "" {
+		users = appendUserToken(users, filepath.Base(home))
+	}
+	return &redactor{home: home, users: users}
+}
+
+// appendUserToken adds a username token to the scrub list, skipping empties,
+// path-ish junk, and tokens under 3 chars (too short to replace safely without
+// mangling unrelated substrings).
+func appendUserToken(users []string, name string) []string {
+	name = strings.TrimSpace(name)
+	if len(name) < 3 || name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
+		return users
+	}
+	for _, existing := range users {
+		if existing == name {
+			return users
+		}
+	}
+	return append(users, name)
+}
+
+// scrub is the catch-all text pass applied to every section: it removes PEM
+// blocks and pattern-matched credentials, collapses the home directory to "~",
+// and blanks bare username tokens to "[user]". It runs last over already
+// field-redacted content, so it is defense-in-depth, not the only line of
+// defense.
+func (r *redactor) scrub(s string) string {
+	s = privateKeyBlock.ReplaceAllString(s, secretMarker)
+	s = keyValueSecret.ReplaceAllString(s, "${1}"+secretMarker)
+	for _, re := range secretPatterns {
+		s = re.ReplaceAllString(s, secretMarker)
+	}
+	if r.home != "" && r.home != "/" {
+		s = strings.ReplaceAll(s, r.home, "~")
+	}
+	for _, name := range r.users {
+		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
+		s = re.ReplaceAllString(s, userMarker)
+	}
+	return s
+}
+
+// redactInstancesJSON parses one repo's instances.json, applies the
+// structural field-redaction policy to every record, re-marshals, and scrubs
+// the result. The typed decode is intentional and fail-closed: any field the
+// current InstanceData does not know about is dropped rather than passed
+// through, so a future secret-bearing field cannot leak before the redactor is
+// taught about it. If the payload does not decode as []InstanceData (corrupt
+// or legacy shape), the raw text is scrubbed and returned so triage still gets
+// something without risking a structural leak.
+func (r *redactor) redactInstancesJSON(raw json.RawMessage) json.RawMessage {
+	var datas []session.InstanceData
+	if err := json.Unmarshal(raw, &datas); err != nil {
+		return json.RawMessage(r.scrub(string(raw)))
+	}
+	for i := range datas {
+		redactInstanceData(&datas[i])
+	}
+	out, err := json.MarshalIndent(datas, "", "  ")
+	if err != nil {
+		return json.RawMessage(r.scrub(string(raw)))
+	}
+	return json.RawMessage(r.scrub(string(out)))
+}
+
+// redactInstanceData blanks the free-text and arbitrary-payload fields of a
+// single session record while leaving the structural triage fields (ids,
+// liveness/status, program, timestamps, git SHAs, counts, flags) intact.
+// Paths are left for the text scrub to collapse ($HOME→~, username→[user]).
+func redactInstanceData(d *session.InstanceData) {
+	if d.Title != "" {
+		d.Title = redactedMarker
+	}
+	for i := range d.Tabs {
+		if d.Tabs[i].Command != "" {
+			d.Tabs[i].Command = redactedMarker
+		}
+	}
+	if d.PRInfo.Title != "" {
+		d.PRInfo.Title = redactedMarker
+	}
+	if d.PRInfo.URL != "" {
+		d.PRInfo.URL = redactedMarker
+	}
+	if len(d.RemoteMeta) > 0 {
+		// Preserve the *signal* that remote metadata existed without emitting
+		// any of its (arbitrary, possibly secret) contents.
+		d.RemoteMeta = map[string]interface{}{"_redacted": true}
+	}
+}
+
+// redactedTask is the structural, secret-free projection of a task.Task. The
+// prompt and watch command — both free-text that can carry secrets — collapse
+// to a marker (and a boolean recording that one was present); everything else
+// is scheduling metadata safe to keep. ProjectPath survives here and is
+// scrubbed for $HOME/username by the text pass.
+type redactedTask struct {
+	ID            string `json:"id"`
+	Name          string `json:"name,omitempty"`
+	HasPrompt     bool   `json:"has_prompt"`
+	Prompt        string `json:"prompt,omitempty"`
+	CronExpr      string `json:"cron_expr,omitempty"`
+	HasWatchCmd   bool   `json:"has_watch_cmd"`
+	WatchCmd      string `json:"watch_cmd,omitempty"`
+	TargetSession string `json:"target_session,omitempty"`
+	ProjectPath   string `json:"project_path,omitempty"`
+	Program       string `json:"program,omitempty"`
+	Enabled       bool   `json:"enabled"`
+	LastRunStatus string `json:"last_run_status,omitempty"`
+}
+
+// redactTask maps a task.Task to its redacted projection.
+func redactTask(t task.Task) redactedTask {
+	rt := redactedTask{
+		ID:            t.ID,
+		Name:          t.Name,
+		CronExpr:      t.CronExpr,
+		TargetSession: t.TargetSession,
+		ProjectPath:   t.ProjectPath,
+		Program:       t.Program,
+		Enabled:       t.Enabled,
+		LastRunStatus: t.LastRunStatus,
+	}
+	if strings.TrimSpace(t.Prompt) != "" {
+		rt.HasPrompt = true
+		rt.Prompt = redactedMarker
+	}
+	if strings.TrimSpace(t.WatchCmd) != "" {
+		rt.HasWatchCmd = true
+		rt.WatchCmd = redactedMarker
+	}
+	return rt
+}

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -110,27 +110,96 @@ func (r *redactor) scrub(s string) string {
 	return s
 }
 
-// redactInstancesJSON parses one repo's instances.json, applies the
-// structural field-redaction policy to every record, re-marshals, and scrubs
-// the result. The typed decode is intentional and fail-closed: any field the
-// current InstanceData does not know about is dropped rather than passed
-// through, so a future secret-bearing field cannot leak before the redactor is
-// taught about it. If the payload does not decode as []InstanceData (corrupt
-// or legacy shape), the raw text is scrubbed and returned so triage still gets
-// something without risking a structural leak.
+// unparsedInstancesNote is emitted (as a JSON string) when instances.json is
+// not even valid JSON, so nothing sensitive is surfaced from a payload we
+// cannot reason about at all.
+const unparsedInstancesNote = `"[instances.json could not be parsed; contents omitted for safety]"`
+
+// redactInstancesJSON parses one repo's instances.json, applies the structural
+// field-redaction policy to every record, re-marshals, and scrubs the result.
+// The typed decode is intentional and fail-closed: any field the current
+// InstanceData does not know about is dropped rather than passed through, so a
+// future secret-bearing field cannot leak before the redactor is taught about
+// it.
+//
+// When the payload does NOT decode as []InstanceData (a corrupt or legacy
+// shape — e.g. a field whose type has since changed), the typed field-level
+// policy can't apply, so we redact MORE, not less (fail-safe — this bundle is
+// shared publicly): a generic key-aware walk blanks every value under a
+// known-sensitive key (prompts, commands, tokens, paths, arbitrary metadata)
+// before the text scrub runs. If it is not even valid JSON, the contents are
+// omitted entirely with a note. The fallback is never raw-with-regex-only —
+// under-including beats leaking.
 func (r *redactor) redactInstancesJSON(raw json.RawMessage) json.RawMessage {
 	var datas []session.InstanceData
-	if err := json.Unmarshal(raw, &datas); err != nil {
-		return json.RawMessage(r.scrub(string(raw)))
+	if err := json.Unmarshal(raw, &datas); err == nil {
+		for i := range datas {
+			redactInstanceData(&datas[i])
+		}
+		if out, marshalErr := json.MarshalIndent(datas, "", "  "); marshalErr == nil {
+			return json.RawMessage(r.scrub(string(out)))
+		}
 	}
-	for i := range datas {
-		redactInstanceData(&datas[i])
+
+	// Fallback: unknown/corrupt shape. Blank sensitive keys generically, then
+	// scrub. Omit entirely if the payload is not valid JSON.
+	var generic any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return json.RawMessage(unparsedInstancesNote)
 	}
-	out, err := json.MarshalIndent(datas, "", "  ")
+	out, err := json.MarshalIndent(redactUnknownJSON(generic), "", "  ")
 	if err != nil {
-		return json.RawMessage(r.scrub(string(raw)))
+		return json.RawMessage(unparsedInstancesNote)
 	}
 	return json.RawMessage(r.scrub(string(out)))
+}
+
+// sensitiveJSONKeys are object keys whose values are dropped wholesale on the
+// generic fallback path, where the typed field-level policy cannot apply. It is
+// deliberately broad and fail-safe: on a shape we could not parse, a key that
+// *might* hold free text, a secret, a path, or arbitrary metadata is redacted
+// rather than trusted. Structural keys (id, status, program, timestamps, git
+// SHAs, counts, flags) are absent here and so survive the walk (then get the
+// text scrub for any residual $HOME/username/credential).
+var sensitiveJSONKeys = map[string]bool{
+	"title": true, "prompt": true, "prompts": true,
+	"command": true, "cmd": true, "commands": true,
+	"args": true, "argv": true, "arg": true,
+	"env": true, "environment": true,
+	"token": true, "tokens": true, "secret": true, "secrets": true,
+	"password": true, "passwd": true, "pwd": true,
+	"credential": true, "credentials": true,
+	"api_key": true, "apikey": true, "key": true, "keys": true,
+	"auth": true, "authorization": true, "bearer": true,
+	"private_key": true, "url": true,
+	"path": true, "home": true, "repo_path": true, "worktree_path": true,
+	"remote_meta": true,
+}
+
+// redactUnknownJSON recursively rebuilds a decoded JSON value, blanking any
+// value whose object key is in sensitiveJSONKeys and recursing everywhere else.
+// Non-container leaves are returned unchanged (the caller text-scrubs them).
+func redactUnknownJSON(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			if sensitiveJSONKeys[strings.ToLower(k)] {
+				out[k] = redactedMarker
+				continue
+			}
+			out[k] = redactUnknownJSON(val)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = redactUnknownJSON(e)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // redactInstanceData blanks the free-text and arbitrary-payload fields of a

--- a/bugreport/render.go
+++ b/bugreport/render.go
@@ -1,0 +1,118 @@
+package bugreport
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// renderText renders the human-readable, single-file bundle from an
+// already-redacted Bundle. The output is plain text with clearly delimited
+// sections so it is pasteable into a GitHub issue and reviewable in one scroll
+// before sharing. The caller runs a final scrub pass over the returned string.
+func renderText(b Bundle) string {
+	var sb strings.Builder
+
+	section := func(title string) {
+		fmt.Fprintf(&sb, "\n===== %s =====\n", title)
+	}
+
+	fmt.Fprintln(&sb, "AGENT FACTORY BUG REPORT")
+	fmt.Fprintf(&sb, "generated: %s\n", b.GeneratedAt)
+	fmt.Fprintf(&sb, "\n!! %s\n", b.Warning)
+
+	section("VERSIONS")
+	fmt.Fprintf(&sb, "af:      %s\n", b.Versions.AF)
+	fmt.Fprintf(&sb, "go:      %s\n", b.Versions.Go)
+	fmt.Fprintf(&sb, "os/arch: %s/%s\n", b.Versions.OS, b.Versions.Arch)
+
+	section("DAEMON STATUS")
+	if strings.TrimSpace(b.DaemonHumanText()) != "" {
+		sb.WriteString(b.DaemonHumanText())
+		if !strings.HasSuffix(b.DaemonHumanText(), "\n") {
+			sb.WriteByte('\n')
+		}
+	} else {
+		writeIndentedJSON(&sb, b.Daemon)
+	}
+
+	section("TASKS (redacted)")
+	if len(b.Tasks) == 0 {
+		fmt.Fprintln(&sb, "(none configured)")
+	} else {
+		writeIndentedJSON(&sb, b.Tasks)
+	}
+
+	section("INSTANCES (redacted)")
+	if len(b.Instances) == 0 {
+		fmt.Fprintln(&sb, "(no sessions)")
+	} else {
+		for _, ri := range b.Instances {
+			fmt.Fprintf(&sb, "--- repo %s ---\n", ri.RepoID)
+			sb.Write(indentRaw(ri.Instances))
+			sb.WriteByte('\n')
+		}
+	}
+
+	section("CONFIG (redacted)")
+	if b.Config == nil {
+		fmt.Fprintln(&sb, "(no config file; running on defaults)")
+	} else {
+		fmt.Fprintf(&sb, "# %s (%s)\n", b.Config.Path, b.Config.Format)
+		sb.WriteString(b.Config.Contents)
+		if !strings.HasSuffix(b.Config.Contents, "\n") {
+			sb.WriteByte('\n')
+		}
+	}
+
+	section("DAEMON LOG TAIL (redacted)")
+	fmt.Fprintf(&sb, "# %s", b.Log.Path)
+	if b.Log.Truncated {
+		fmt.Fprint(&sb, " (truncated to the last ~2MiB / 5000 lines)")
+	}
+	sb.WriteByte('\n')
+	sb.WriteString(b.Log.Contents)
+	if b.Log.Contents != "" && !strings.HasSuffix(b.Log.Contents, "\n") {
+		sb.WriteByte('\n')
+	}
+
+	if len(b.Errors) > 0 {
+		section("COLLECTION ERRORS")
+		for _, e := range b.Errors {
+			fmt.Fprintf(&sb, "- %s\n", e)
+		}
+	}
+
+	return sb.String()
+}
+
+// DaemonHumanText exposes the pre-rendered human daemon status carried
+// alongside the structured snapshot. It is threaded through Build via a
+// package-private field set on the Bundle by the command layer; when unset the
+// renderer falls back to the structured JSON.
+func (b Bundle) DaemonHumanText() string { return b.daemonHuman }
+
+// writeIndentedJSON marshals v with two-space indent into sb, falling back to a
+// Go-syntax dump if marshaling fails (it should not for our own types).
+func writeIndentedJSON(sb *strings.Builder, v any) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		fmt.Fprintf(sb, "%+v\n", v)
+		return
+	}
+	sb.Write(data)
+	sb.WriteByte('\n')
+}
+
+// indentRaw re-indents an already-valid JSON payload for readable embedding.
+func indentRaw(raw json.RawMessage) []byte {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return raw
+	}
+	return out
+}

--- a/bugreportcmd.go
+++ b/bugreportcmd.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/bugreport"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/spf13/cobra"
+)
+
+var (
+	bugReportJSON   bool
+	bugReportOutput string
+)
+
+// bugReportCmd is `af bug-report` (#1048): bundle the daemon log tail,
+// versions, configured tasks, the redacted session state, the daemon health
+// snapshot, and the redacted global config into ONE shareable, best-effort
+// redacted file a user can attach to a bug report. It is read-only — it reads
+// local state and writes a single output file, never touching sessions, the
+// daemon, or the network.
+//
+// A single concatenated text file (not a tarball) is deliberate: the bundle
+// carries only text, and the "review before sharing" contract is only real if
+// the user can open one file and read the whole thing in one scroll before
+// attaching it. A tarball would hide the contents behind an extract step and
+// invite blind, un-reviewed sharing of a redaction miss.
+var bugReportCmd = &cobra.Command{
+	Use:   "bug-report",
+	Short: "Bundle logs, versions, tasks, and redacted state for a bug report",
+	Long: `Collect a single, shareable diagnostics bundle for triage:
+
+  - the daemon log tail (bounded to the last ~2MiB / 5000 lines)
+  - versions: af, Go, OS/arch, and the daemon's version snapshot
+  - the configured tasks (redacted)
+  - the session state from instances.json (redacted)
+  - the daemon health snapshot (same no-spawn probe as af daemon status)
+  - the global config file, if any (redacted)
+
+Everything is written to a single text file (default ~/af-bug-report-<ts>.txt)
+so you can read the whole thing in one scroll before attaching it.
+
+REDACTION IS BEST-EFFORT. Free-text and secret-bearing fields (session titles,
+task prompts, tab commands, remote metadata) are dropped; $HOME and your
+username are collapsed to ~ / [user]; and known credential shapes are scrubbed
+wherever they appear. Perfect redaction is impossible — open the file and
+review it before sharing it publicly.
+
+Use --json to emit the structured manifest (wrapped in the shared {data,error}
+envelope) to stdout instead of writing a file.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		info := collectDaemonStatus()
+		var daemonHuman bytes.Buffer
+		humanCmd := &cobra.Command{}
+		humanCmd.SetOut(&daemonHuman)
+		printDaemonStatusHuman(humanCmd, info)
+
+		result, err := bugreport.Build(bugreport.Inputs{
+			AFVersion:    version,
+			GeneratedAt:  time.Now().Format("2006-01-02 15:04:05 -0700"),
+			DaemonStatus: info,
+			DaemonHuman:  daemonHuman.String(),
+		})
+		if err != nil {
+			return err
+		}
+
+		if bugReportJSON {
+			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(json.RawMessage(result.JSON)))
+		}
+
+		outPath, err := resolveBugReportPath(bugReportOutput)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(outPath, []byte(result.Text), 0600); err != nil {
+			return fmt.Errorf("write bug report: %w", err)
+		}
+
+		w := cmd.OutOrStdout()
+		fmt.Fprintf(w, "Wrote bug report to %s\n", outPath)
+		fmt.Fprintln(w, "Attach this file to your bug report.")
+		fmt.Fprintln(w, "Review it first — redaction is best-effort and cannot catch everything.")
+		return nil
+	},
+}
+
+// resolveBugReportPath returns the output path: the explicit --output when
+// given, else a timestamped file in the user's home directory, falling back to
+// the current directory when the home directory cannot be resolved. The file
+// is written 0600 because, even redacted, it may contain residual sensitive
+// context until the user reviews it.
+func resolveBugReportPath(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	name := fmt.Sprintf("af-bug-report-%s.txt", time.Now().Format("20060102-150405"))
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return name, nil
+	}
+	return filepath.Join(home, name), nil
+}
+
+func init() {
+	bugReportCmd.Flags().BoolVar(&bugReportJSON, "json", false,
+		"Emit the structured manifest to stdout (in the {data,error} envelope) instead of writing a file")
+	bugReportCmd.Flags().StringVarP(&bugReportOutput, "output", "o", "",
+		"Write the bundle to this path instead of the default ~/af-bug-report-<ts>.txt")
+	rootCmd.AddCommand(bugReportCmd)
+}

--- a/bugreportcmd_test.go
+++ b/bugreportcmd_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBugReportCmdWritesFile drives the command end-to-end against a fresh temp
+// home: it must resolve the daemon status without spawning anything, build the
+// bundle, write it to the requested path, and print the attach/review guidance.
+func TestBugReportCmdWritesFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(home, ".agent-factory"))
+
+	out := filepath.Join(home, "report.txt")
+	t.Cleanup(func() { bugReportJSON, bugReportOutput = false, "" })
+	bugReportJSON, bugReportOutput = false, out
+
+	var buf bytes.Buffer
+	bugReportCmd.SetOut(&buf)
+	if err := bugReportCmd.RunE(bugReportCmd, nil); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "Attach this file") {
+		t.Errorf("missing attach guidance:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "Review it first") {
+		t.Errorf("missing review guidance:\n%s", buf.String())
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("bundle not written: %v", err)
+	}
+	if !strings.Contains(string(data), "AGENT FACTORY BUG REPORT") {
+		t.Errorf("bundle missing header:\n%s", data)
+	}
+	if !strings.Contains(string(data), "REVIEW THIS BUNDLE BEFORE SHARING") {
+		t.Error("bundle missing review banner")
+	}
+}
+
+// TestBugReportCmdJSON checks the --json path emits a valid {data,error}
+// envelope to stdout and writes no file.
+func TestBugReportCmdJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_FACTORY_HOME", filepath.Join(home, ".agent-factory"))
+
+	t.Cleanup(func() { bugReportJSON, bugReportOutput = false, "" })
+	bugReportJSON, bugReportOutput = true, ""
+
+	var buf bytes.Buffer
+	bugReportCmd.SetOut(&buf)
+	if err := bugReportCmd.RunE(bugReportCmd, nil); err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+
+	var env struct {
+		Data  map[string]any `json:"data"`
+		Error any            `json:"error"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("output is not a valid envelope: %v\n%s", err, buf.String())
+	}
+	if env.Error != nil {
+		t.Errorf("expected nil error member, got %v", env.Error)
+	}
+	if env.Data["warning"] == nil {
+		t.Error("manifest missing warning")
+	}
+	if env.Data["versions"] == nil {
+		t.Error("manifest missing versions")
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -447,6 +447,8 @@ af upgrade             # self-upgrade to the latest release on the configured ch
 af upgrade --allow-downgrade  # downgrade to an older release (e.g. preview→stable switch)
 af doctor              # diagnose leaked processes/sessions/temp homes and daemon health
 af doctor --fix        # also apply the safe remediations
+af bug-report          # bundle logs + versions + tasks + redacted state into one file
+af bug-report --json   # emit the structured manifest to stdout instead of writing a file
 af reset               # nuclear cleanup — see below
 ```
 
@@ -469,6 +471,25 @@ af reset               # nuclear cleanup — see below
   and a bounded read-only `list_cmd --json` connectivity probe
   (`remote-connectivity`). Repos with no remote backend (the common local-only
   case) get a single `n/a` line and no findings.
+- `af bug-report` bundles diagnostics for triage into **one** file: the daemon
+  log tail (bounded to the last ~2MiB / 5000 lines), versions (af, Go, OS/arch,
+  the daemon version snapshot), the configured tasks, the session state from
+  `instances.json`, the `af daemon status` health snapshot, and the global
+  config file. The default writes a single text file to
+  `~/af-bug-report-<ts>.txt` (mode 0600) and prints its path; `-o`/`--output`
+  overrides the path, and `--json` emits the structured manifest (wrapped in the
+  `{data, error}` envelope) to stdout instead of writing a file. It is read-only
+  and local — the same no-spawn probe as `af doctor`, never dialing the daemon
+  or the network — and is a CLI-only maintenance command, not part of the HTTP
+  `af api` route surface. **Redaction is best-effort**: free-text and
+  secret-bearing fields (session titles, task prompts, tab commands, remote
+  metadata) are dropped; structural triage fields (ids, status/liveness,
+  program, timestamps, git SHAs, counts) are kept; `$HOME` and your username are
+  collapsed to `~` / `[user]`; and known credential shapes (`sk-…`, `ghp_…`,
+  AWS/Slack/Google keys, `key = "…"` assignments, PEM private keys) are scrubbed
+  wherever they appear. Perfect redaction is impossible, so the bundle carries a
+  "review before sharing" banner — open it and check it before attaching it to a
+  public issue.
 - `af reset` stops the daemon (reporting honestly if it couldn't), kills **all**
   Agent Factory tmux sessions, removes **every linked git worktree and its
   branch** from each repo with stored sessions, and deletes all stored session

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,8 +97,24 @@ af keys                # print the effective TUI key bindings (defaults + [keys]
 af upgrade             # self-upgrade to the latest GitHub release (Linux/macOS)
 af doctor              # diagnose leaked processes/sessions/temp homes and daemon health
 af doctor --fix        # also apply the safe remediations
+af bug-report          # bundle logs + versions + tasks + redacted state into one file to attach
+af bug-report --json   # emit the structured manifest to stdout instead of writing a file
 af reset               # nuclear option — see below
 ```
+
+`af bug-report` collects one shareable diagnostics file: the daemon log tail
+(bounded to the last ~2MiB / 5000 lines), versions (af, Go, OS/arch, the daemon
+snapshot), the configured tasks, the session state from `instances.json`, the
+`af daemon status` health snapshot, and the global config. It writes a single
+text file (default `~/af-bug-report-<ts>.txt`, mode 0600; override with
+`-o/--output`) so you can read the whole thing in one scroll before attaching
+it. Redaction is **best-effort**: free-text and secret-bearing fields (session
+titles, task prompts, tab commands, remote metadata) are dropped, `$HOME` and
+your username are collapsed to `~` / `[user]`, and known credential shapes are
+scrubbed everywhere — but perfect redaction is impossible, so **review the file
+before sharing it publicly**. It is read-only and local (like `af doctor`): it
+never dials the daemon or the network, and is not part of the HTTP `af api`
+surface.
 
 `af doctor` is read-only by default: it reports orphaned processes left behind
 by dead sessions, processes pegging a CPU core inside live sessions, `af_` tmux

--- a/log/log.go
+++ b/log/log.go
@@ -116,6 +116,28 @@ func resolveLogPath() string {
 	return filepath.Join(dir, "agent-factory.log")
 }
 
+// LogFilePath returns the production agent-factory.log path — the file the
+// daemon and TUI write to — resolved from $AGENT_FACTORY_HOME then the
+// os.UserConfigDir default, exactly like resolveLogPath's env/default branches
+// but WITHOUT the test-scratch branch, the test-only override, and any
+// directory-creating side effect. It is read-only tooling support (e.g. `af
+// bug-report` locating the log to tail); it deliberately never returns the
+// temp test log so a bug report always names the real log even when built by a
+// test binary. Returns "" only when neither a home override nor UserConfigDir
+// can be resolved.
+func LogFilePath() string {
+	if home := os.Getenv("AGENT_FACTORY_HOME"); home != "" {
+		if dir, ok := expandTilde(home); ok {
+			return filepath.Join(dir, "agent-factory.log")
+		}
+	}
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(configDir, "agent-factory", "agent-factory.log")
+}
+
 // rotationPolicy resolves the log-rotation cap and backup count from the
 // global config file ("log_max_size_mb" / "log_max_backups"), falling back to
 // the package defaults. This package cannot import config (config imports


### PR DESCRIPTION
Closes #1048.

Adds `af bug-report`: one command that bundles diagnostics for triage into a single shareable, best-effort-redacted file.

## What it collects
- **Daemon log tail** — bounded to the last ~2MiB / 5000 lines (never dumps a huge log)
- **Versions** — af, Go, OS/arch, and the daemon snapshot (via the no-spawn health probe, same as `af daemon status`)
- **Tasks** — the configured tasks, redacted
- **Instances** — session state from every repo's `instances.json`, redacted
- **Daemon status** — the `af daemon status` health snapshot (running, sockets, pid, autostart)
- **Config** — the global `config.toml`/`config.json`, redacted (if present)

## Bundle format: single text file (not a tarball)
Default output is `~/af-bug-report-<ts>.txt` (mode `0600`; override with `-o/--output`). **Why a text file over a tarball:** everything collected is text, and the "review before sharing" contract is only real if the user can open **one** file and read the whole thing in one scroll before attaching it. A tarball hides the contents behind an extract step and invites blind, un-reviewed sharing of a redaction miss. `--json` emits the structured manifest wrapped in the shared `{data,error}` envelope to stdout (writes no file).

## Redaction policy — conservative "drop free-text + secrets, keep structural"
This bundle may be shared publicly, so the redaction is the load-bearing part. Two layers:

**1. Field-level (structural, fail-closed):**
- **Dropped → `[redacted]`:** session titles, task prompts, watch commands, tab commands, PR title/URL, and the whole `remote_meta` map (replaced with `{"_redacted": true}` so the *signal* it existed survives).
- **Kept (structural triage):** ids, status/liveness, program, timestamps, git SHAs, tab names/kinds, PR number/state, counts, flags, branch/session names.
- `instances.json` is redacted via a **typed decode** — any field the current `InstanceData` doesn't know about is dropped rather than passed through, so a future secret-bearing field can't leak before the redactor is taught about it.

**2. Text scrub (defense-in-depth, applied to every section + a final whole-bundle pass):**
- `$HOME` → `~` and the username → `[user]` (kills the username-revealing path/branch leak)
- Known credential shapes scrubbed → `[redacted-secret]`: `sk-…` (OpenAI/Anthropic), `ghp_/gho_/…` + `github_pat_…`, Slack `xox…`, AWS `AKIA…`, Google `AIza…`, JWTs, PEM private-key blocks, and generic `key = "value"` assignments where the key names a credential.
- Deliberately **not** a broad "any long hex" rule — that would nuke the git SHAs and IDs a triager needs. Git SHAs are verified to survive.

The bundle always carries a **"review before sharing"** banner: perfect redaction is impossible.

### Load-bearing choices I made conservatively (flagging for review)
- **Project directory names in paths are kept** (only the `$HOME`/username prefix is collapsed). The issue's stated sensitivity is *paths that reveal the username*; the trailing dir name is triage-useful and not that. Easy to strip further if you'd prefer.
- **Branch/session names are kept** (username-scrubbed). They're structural and normally shared in a PR workflow.
- **Tasks are redacted too** (prompts/watch-cmds dropped) even though the issue framed redaction around instances/config/log — task prompts are exactly the free-text-that-can-hold-secrets the issue warns about.
- **Not added to the HTTP `af api` catalog.** `bug-report` writes a local file and is read-only/local like `af doctor`/`af daemon status`/`af reset` — none of which are HTTP routes. Documented as a CLI-only maintenance command.

## Tests (all via `make test-container`)
- `scrub` redacts every planted secret shape + PEM blocks, collapses `$HOME`→`~` and username→`[user]`, and **keeps** a git SHA.
- `redactInstanceData` drops free-text, keeps structural fields.
- **End-to-end `Build`** plants a secret and a home path in *every* surface (instances, tasks, config, log, daemon status) and asserts the bundle scrubs them while structural fields survive — in both the text bundle and the JSON manifest.
- Command-layer tests for the file-writing and `--json` paths.
- **Real-data check** (manual): `af bug-report --json` against the real dev-box home → 0 occurrences of the real `$HOME` path, 0 bare-username tokens, 8 titles redacted, 35 paths collapsed, structural fields intact.

## Docs
- `docs/cli.md` + `docs/cli-reference.md` — full `af bug-report` entry (redaction policy, output, flags, api-catalog rationale)
- `README.md` — the "when filing an issue" guidance now points at `af bug-report`

## Gates
`golangci-lint --fast` clean · `gofmt -l` empty · `go build ./...` clean · `make test-container` exit 0 · file-length lint passed · `deadcode` clean.

Do not merge — root verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)