### PR TITLE
fix(tui): route interactive Enter to the selected instance, not a stale pane (#1233)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -21,24 +21,33 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 	case keys.KeyHelp:
 		return m.showHelpScreen(helpTypeGeneral{}, nil)
 
-	// Tree navigation
+	// Tree navigation. Each moves the sidebar cursor and re-homes the focus
+	// ring on the tree (focusTreeForNav) so the ring-reading attach verb `o`
+	// resolves the freshly selected instance, not a pane left focused by a
+	// prior interactive session (#1233 wrong-target-input class).
 	case keys.KeyUp:
 		m.sidebar.Up()
+		m.focusTreeForNav()
 		return m, m.selectionChanged()
 	case keys.KeyDown:
 		m.sidebar.Down()
+		m.focusTreeForNav()
 		return m, m.selectionChanged()
 	case keys.KeyLeft:
 		m.sidebar.CollapseSection()
+		m.focusTreeForNav()
 		return m, m.selectionChanged()
 	case keys.KeyRight:
 		m.sidebar.ExpandSection()
+		m.focusTreeForNav()
 		return m, m.selectionChanged()
 	case keys.KeyNextSection:
 		m.sidebar.JumpNextSection()
+		m.focusTreeForNav()
 		return m, m.selectionChanged()
 	case keys.KeyPrevSection:
 		m.sidebar.JumpPrevSection()
+		m.focusTreeForNav()
 		return m, m.selectionChanged()
 
 	// Instance creation
@@ -463,26 +472,21 @@ func killConfirmationWarning(wt string) string {
 
 // handleEnter is the Enter verb (#1089 PR 2, RFC §2.3): enter INTERACTIVE
 // mode on the pane — every keystroke forwards to the agent/shell in place,
-// no full-screen takeover, Ctrl-] returns to nav. With a workspace pane
-// focused it enters that pane; on a tree instance/tab row it opens (or
-// focuses) the selection's pane first, exactly like `s`, then enters it.
-// Bindings that cannot embed — remote instances, whose only local terminal
-// is the full-screen hook PTY — fall back to the full-screen attach Enter
-// used to do; dead/transitional sessions keep their guard errors.
+// no full-screen takeover, Ctrl-] returns to nav.
+//
+// Enter resolves its target from the SIDEBAR SELECTION — the exact
+// target-resolution the open-pane verb (`s`, handleOpenPane) uses — and never
+// from the focus ring (#1233). Reading focusedOpenPane first was the
+// wrong-target-input bug: after Ctrl-] leaves interactive mode the ring stays
+// on instance A's pane, so selecting instance B and pressing Enter re-entered
+// interactive on the stale A pane — typing into the WRONG agent. Enter now
+// opens (or focuses) the SELECTED instance's pane, exactly like `s`, then
+// enters it — one path, always the current selection.
+//
+// Bindings that cannot embed — remote instances, whose only local terminal is
+// the full-screen hook PTY — fall back to the full-screen attach Enter used to
+// do; dead/transitional sessions keep their guard errors.
 func (m *home) handleEnter() (tea.Model, tea.Cmd) {
-	if p := m.focusedOpenPane(); p != nil {
-		if instErr := interactiveGuard(p.Instance()); instErr != nil {
-			return m, m.handleError(instErr)
-		}
-		if p.Instance() == nil || p.Instance().IsCreating() {
-			return m, nil
-		}
-		if liveSessionName(p.Instance(), p.Tab()) == "" {
-			// Not embeddable (remote): the old full-screen behavior.
-			return m.handleEnterPane(p)
-		}
-		return m.requestInteractive(p)
-	}
 	sel := m.sidebar.GetSelection()
 
 	// Toggle expandable section headers (Instances and the Archived folder).
@@ -490,33 +494,35 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		m.sidebar.ToggleSection()
 		return m, m.selectionChanged()
 	}
+	// Only instance/tab rows enter a pane; anything else (e.g. an automations
+	// row) is a no-op, as before.
+	if sel.Kind != ui.SectionInstances && sel.Kind != ui.SectionArchived {
+		return m, nil
+	}
 	// Instance selected — in either the Instances tree or the Archived folder
 	// (#1028). An archived row is not embeddable: interactiveGuard surfaces the
 	// "restore it first" error before any pane/attach path is reached.
-	if sel.Kind == ui.SectionInstances || sel.Kind == ui.SectionArchived {
-		selected := m.sidebar.GetSelectedInstance()
-		if selected == nil || selected.IsCreating() {
-			return m, nil
-		}
-		if err := interactiveGuard(selected); err != nil {
-			return m, m.handleError(err)
-		}
-		if liveSessionName(selected, m.store.ActiveTab()) == "" {
-			// Not embeddable (remote): the old full-screen attach flow.
-			return m.attachSelected(selected)
-		}
-		// Open (or focus) the selection's pane — the `s` semantics — then
-		// enter it. The pane pointer is captured here, at Enter-press time
-		// (#716), for the deferred activation.
-		_, cmd := m.openOrFocusPane(selected, m.store.ActiveTab())
-		p := m.store.FindOpenPane(selected, m.store.ActiveTab())
-		if p == nil {
-			return m, cmd
-		}
-		mod, interactCmd := m.requestInteractive(p)
-		return mod, tea.Batch(cmd, interactCmd)
+	selected := m.sidebar.GetSelectedInstance()
+	if selected == nil || selected.IsCreating() {
+		return m, nil
 	}
-	return m, nil
+	if err := interactiveGuard(selected); err != nil {
+		return m, m.handleError(err)
+	}
+	if liveSessionName(selected, m.store.ActiveTab()) == "" {
+		// Not embeddable (remote): the old full-screen attach flow.
+		return m.attachSelected(selected)
+	}
+	// Open (or focus) the selection's pane — the `s`/open semantics — then
+	// enter it. The pane pointer is captured here, at Enter-press time (#716),
+	// for the deferred activation.
+	_, cmd := m.openOrFocusPane(selected, m.store.ActiveTab())
+	p := m.store.FindOpenPane(selected, m.store.ActiveTab())
+	if p == nil {
+		return m, cmd
+	}
+	mod, interactCmd := m.requestInteractive(p)
+	return mod, tea.Batch(cmd, interactCmd)
 }
 
 // interactiveGuard returns the user-facing error that fences Enter off a

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -209,14 +209,18 @@ func (m *home) handleClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		// Click a pane header (or an unfocused pane's body): focus that pane
 		// — how the mouse picks one of the N panes. Click the FOCUSED pane's
 		// body: enter it, exactly like Enter (§2.5).
-		if p, _ := m.paneByRegion(region); p == nil {
+		p, _ := m.paneByRegion(region)
+		if p == nil {
 			return m, nil
 		}
 		if kind == zones.PaneKindHeader || m.ring.Active() != region {
 			m.focusRegionClick(region)
 			return m, nil
 		}
-		return m.handleEnter()
+		// A click on the already-focused pane's body enters THAT pane — the
+		// click named it, so enter it directly rather than the sidebar selection
+		// keyboard Enter resolves (#1233, §2.5).
+		return m.enterPane(p)
 	}
 	if taskID, ok := zones.AutoTaskID(id); ok {
 		// Click a task row: focus the automations section and select the

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -203,6 +203,49 @@ func (m *home) reconcilePanesForTabs(instance *session.Instance, oldNames []stri
 	return changed
 }
 
+// focusTreeForNav returns the focus ring to the tree when a tree-navigation
+// key (Up/Down, section jumps, collapse/expand) is pressed while a pane holds
+// focus. Those keys move the SIDEBAR cursor regardless of which region the ring
+// points at, so leaving the ring on a stale pane desyncs the two: the
+// full-screen attach verb `o` (handleAttach) reads the focus ring first and
+// would keep attaching the previously-focused pane's instance instead of the
+// just-selected one — the same wrong-target class as the #1233 Enter bug (Enter
+// itself now resolves purely from the selection, see handleEnter). After Ctrl-]
+// leaves interactive mode the ring stays on instance A's pane, so without this
+// a user who navigates to instance B and presses `o` would attach A. Re-homing
+// the ring on the tree makes `o` resolve the current selection fresh. No-op
+// unless a pane is focused, so it never churns the tree/automations ring or the
+// live attachment (which persists on its still-visible pane).
+func (m *home) focusTreeForNav() {
+	if layout.IsPaneRegion(m.ring.Active()) {
+		m.focusRegion(layout.RegionTree)
+	}
+}
+
+// enterPane enters interactive mode on a SPECIFIC pane — the mouse
+// click-to-interact target (§2.5). Keyboard Enter (handleEnter) resolves the
+// SIDEBAR SELECTION so it can never type into a stale focused pane (#1233); a
+// body click, by contrast, has already named its exact pane, so it enters that
+// one directly. Remote/non-embeddable panes fall back to the full-screen attach
+// of the pane's tab, mirroring handleEnter's remote branch; guard errors
+// surface the same way.
+func (m *home) enterPane(p *store.OpenPane) (tea.Model, tea.Cmd) {
+	if p == nil {
+		return m, nil
+	}
+	if instErr := interactiveGuard(p.Instance()); instErr != nil {
+		return m, m.handleError(instErr)
+	}
+	if p.Instance() == nil || p.Instance().IsCreating() {
+		return m, nil
+	}
+	if liveSessionName(p.Instance(), p.Tab()) == "" {
+		// Not embeddable (remote): the full-screen attach of this pane's tab.
+		return m.handleEnterPane(p)
+	}
+	return m.requestInteractive(p)
+}
+
 // handleEnterPane attaches the focused pane's (instance, tab) full-screen:
 // the Enter half of "attach the FOCUSED pane". It mirrors the tree path in
 // handleEnter guard for guard — Loading/Deleting fences, the #935 dead-tmux

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -189,6 +189,108 @@ func TestEnterFromTreeOpensPaneAndEntersInteractive(t *testing.T) {
 	require.Len(t, *fakes, 1)
 }
 
+// TestSecondEnterTargetsCurrentSelectionNotStalePane is the #1233 P1
+// wrong-target-input regression: enter interactive on instance A, Ctrl-] to
+// nav, select a DIFFERENT instance B, Enter again. Input must route to B — the
+// current selection — never the pane the focus ring was left on (A). Enter
+// resolving from focusedOpenPane (the stale A pane) was the bug; it now
+// resolves purely from the sidebar selection, exactly like the open verb.
+func TestSecondEnterTargetsCurrentSelectionNotStalePane(t *testing.T) {
+	h := newTestHome(t)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	instA := startedLocalInstance(t, "alpha")
+	instB := startedLocalInstance(t, "bravo")
+	h.store.AddInstance(instA)
+	h.store.AddInstance(instB)
+	h.sidebar.SetSelectedInstance(0) // land on A
+	h.store.SetSelectedInstance(instA)
+	h.clampSelectionTab()
+	resizeHome(h, 200, 40) // wide enough for both panes side by side
+	_, _ = stubLiveTermFactory(t)
+
+	// 1. Enter interactive on A (from the tree): opens A's pane, then enters it.
+	// openOrFocusPane focuses the pane it opened, so read it back off the focus
+	// ring (its tab index tracks the tree cursor, not necessarily 0).
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	paneA := h.focusedOpenPane()
+	require.NotNil(t, paneA, "Enter must open A's pane")
+	require.Equal(t, instA, paneA.Instance())
+	_, cmd := h.Update(enterInteractiveMsg{pane: paneA})
+	runHermeticCmd(t, h, cmd, 0)
+	require.True(t, h.interactive, "first Enter must enter interactive mode")
+	require.Equal(t, instA, h.livePane.Instance(), "first Enter binds A")
+	aFake := h.liveTerm.(*fakeLiveTerm)
+
+	// 2. Ctrl-] back to nav. Focus stays on A's pane — the bug precondition.
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
+	require.False(t, h.interactive, "Ctrl-] must return to nav mode")
+
+	// 3. Navigate to a DIFFERENT instance B through the real tree-nav keys.
+	for i := 0; i < 20 && h.sidebar.GetSelectedInstance() != instB; i++ {
+		_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyDown}, keys.KeyDown)
+	}
+	require.Equal(t, instB, h.sidebar.GetSelectedInstance(), "navigation must land on B")
+
+	// 4. Enter again — must open/enter B, NOT re-enter the stale A pane.
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	paneB := h.focusedOpenPane()
+	require.NotNil(t, paneB, "second Enter must open B's pane")
+	require.Equal(t, instB, paneB.Instance(), "the opened pane must belong to B")
+	require.NotEqual(t, paneA, paneB, "B's pane must be distinct from A's")
+	_, cmd = h.Update(enterInteractiveMsg{pane: paneB})
+	runHermeticCmd(t, h, cmd, 0)
+
+	require.True(t, h.interactive, "second Enter must (re)enter interactive mode")
+	assert.Equal(t, instB, h.livePane.Instance(),
+		"second Enter must bind input to the SELECTED instance B, not the previously-interacted A")
+	assert.Equal(t, paneB, h.livePane, "the live pane must be B's pane")
+
+	// A forwarded keystroke must land in B's attachment, never A's stale one.
+	bFake := h.liveTerm.(*fakeLiveTerm)
+	require.NotSame(t, aFake, bFake, "B must have its own attachment")
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Z")})
+	assert.Equal(t, []string{"Z"}, bFake.keys, "keystrokes must forward to the selected instance B")
+	assert.Empty(t, aFake.keys, "the previously-interacted instance A must receive nothing")
+}
+
+// TestEnterResolvesFromSelectionNotFocusRing pins the #1233 fix at the source:
+// with the focus ring left on instance A's pane but the sidebar selection on
+// instance B, Enter must act on the SELECTION (B), the same target-resolution
+// the open verb uses — never the focused pane. This isolates handleEnter's
+// resolution from the focus-rehoming nav helper.
+func TestEnterResolvesFromSelectionNotFocusRing(t *testing.T) {
+	h := newTestHome(t)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	instA := startedLocalInstance(t, "alpha")
+	instB := startedLocalInstance(t, "bravo")
+	h.store.AddInstance(instA)
+	h.store.AddInstance(instB)
+	resizeHome(h, 200, 40)
+	_, _ = stubLiveTermFactory(t)
+
+	// Open A's pane and leave the focus ring on it.
+	paneA := openTestPane(t, h, instA, 0)
+	require.Equal(t, paneA, h.focusedOpenPane(), "A's pane must hold the focus ring")
+
+	// Point the selection at B while the ring stays on A's pane — the exact
+	// desync the wrong-target bug exploited.
+	h.sidebar.SetSelectedInstance(1)
+	h.store.SetSelectedInstance(instB)
+	h.clampSelectionTab()
+	require.Equal(t, instB, h.sidebar.GetSelectedInstance())
+
+	// Enter must open/enter B, not the focused A pane.
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	p := h.focusedOpenPane()
+	require.NotNil(t, p, "Enter must open the selection's pane")
+	assert.Equal(t, instB, p.Instance(), "Enter must resolve the SELECTED instance B, not the focused A pane")
+
+	_, cmd := h.Update(enterInteractiveMsg{pane: p})
+	runHermeticCmd(t, h, cmd, 0)
+	assert.True(t, h.interactive, "Enter must enter interactive mode on B")
+	assert.Equal(t, instB, h.livePane.Instance(), "input must bind to B")
+}
+
 func TestEnterOnRemotePaneFallsBackToFullScreenAttach(t *testing.T) {
 	h := newTestHome(t)
 	require.NoError(t, h.appState.SetHelpScreensSeen(

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -536,10 +536,13 @@ func TestPane_FollowsSameTitleSwap(t *testing.T) {
 		"open-pane bindings must follow a same-title swap (#765 class)")
 }
 
-// TestPane_EnterAttachesFocusedPane: Enter attaches the FOCUSED pane's
-// binding — a pane's (instance, tab) when a pane has focus, the tree
-// selection everywhere else — and detach hands back focus + panes intact.
-func TestPane_EnterAttachesFocusedPane(t *testing.T) {
+// TestPane_EnterAttachesSelectionNotFocusedPane: keyboard Enter resolves its
+// target from the SIDEBAR SELECTION — like the open verb — never the focus ring
+// (#1233). With a non-embeddable selection it falls back to the full-screen
+// attach of that selection, whether the ring sits on a pane or the tree; detach
+// hands back focus + panes intact. (The mouse click-to-interact path, which
+// enters the CLICKED pane, is covered by the mouse suite via enterPane.)
+func TestPane_EnterAttachesSelectionNotFocusedPane(t *testing.T) {
 	resetDetachWatchdog(t)
 	h := paneTestHome(t)
 	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInstanceAttach{}.mask()))
@@ -547,13 +550,14 @@ func TestPane_EnterAttachesFocusedPane(t *testing.T) {
 	// Open alpha's pane, then drive the tree selection to beta.
 	pressKey(t, h, "s")
 	p := h.store.OpenPanes()[0]
+	require.Equal(t, "alpha", p.Instance().Title)
 	h.sidebar.SetSelectedInstance(1)
 	_ = h.selectionChanged()
 	require.Equal(t, "beta", h.store.GetSelectedInstance().Title)
 
-	var attachedLabel string
+	var attachedLabel, attachedTitle string
 	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
-		attachedLabel = label
+		attachedLabel, attachedTitle = label, title
 		return m.attachOverlayCallback(title, label, traceSuffix, rem, func() (chan struct{}, error) {
 			ch := make(chan struct{})
 			close(ch) // detach immediately — no real PTY
@@ -561,13 +565,15 @@ func TestPane_EnterAttachesFocusedPane(t *testing.T) {
 		})
 	})
 
-	// Focus the pane: Enter must take the pane attach path (alpha, not the
-	// beta selection).
+	// Focus alpha's pane: Enter must STILL attach the selection (beta), never
+	// the focused alpha pane — the wrong-target class the #1233 fix closed.
 	h.focusRegion(layout.PaneRegion(p.ID()))
 	_, cmd := h.handleEnter()
-	require.NotNil(t, cmd, "the pane attach must run")
-	assert.Equal(t, "handleEnter-pane", attachedLabel,
-		"Enter with a pane focused attaches that pane's binding")
+	require.NotNil(t, cmd, "the selection attach must run")
+	assert.Equal(t, "handleEnter-sidebar", attachedLabel,
+		"Enter resolves the selection, not the focused pane (#1233)")
+	assert.Equal(t, "beta", attachedTitle,
+		"Enter must target the selected beta, not the focused alpha pane")
 	endDetachWatchdog()
 
 	// Detach restored everything: focus still on the pane, binding intact.
@@ -575,13 +581,28 @@ func TestPane_EnterAttachesFocusedPane(t *testing.T) {
 	assert.Equal(t, 1, h.store.NumOpenPanes(), "detach keeps the pane open")
 	assert.Equal(t, "alpha", h.store.OpenPanes()[0].Instance().Title)
 
-	// Focus the tree: Enter attaches the selection, as before.
+	// Focus the tree: Enter attaches the same selection.
 	h.focusRegion(layout.RegionTree)
 	_, cmd = h.handleEnter()
 	require.NotNil(t, cmd)
-	assert.Equal(t, "handleEnter-sidebar", attachedLabel,
-		"Enter with tree focus attaches the selection, as before the pane model")
+	assert.Equal(t, "handleEnter-sidebar", attachedLabel)
+	assert.Equal(t, "beta", attachedTitle)
 	endDetachWatchdog()
+}
+
+// TestPane_TreeNavFromPaneRefocusesTree: a tree-navigation key pressed while a
+// pane holds the focus ring re-homes the ring on the tree, so the ring-reading
+// attach verb `o` resolves the freshly selected instance rather than the stale
+// focused pane (#1233 adjacent-audit fix; focusTreeForNav).
+func TestPane_TreeNavFromPaneRefocusesTree(t *testing.T) {
+	h := paneTestHome(t)
+	pressKey(t, h, "s") // open alpha's pane and focus it
+	p := h.store.OpenPanes()[0]
+	require.Equal(t, layout.PaneRegion(p.ID()), h.ring.Active(), "the opened pane holds focus")
+
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyDown}, keys.KeyDown)
+	assert.Equal(t, layout.RegionTree, h.ring.Active(),
+		"tree navigation must return focus to the tree so o/attach resolves the selection")
 }
 
 // TestPane_HideMiddleFocusesSuccessor: hiding a middle pane lands focus on


### PR DESCRIPTION
## P1: interactive-mode input routes to the wrong instance (#1233)

Fixes #1233.

### Repro
1. Press Enter to type to instance **A** (enter interactive mode on A).
2. Ctrl-] back to nav.
3. Select a different instance **B**, press Enter.
4. **Bug:** keystrokes still went to **A** — you were typing into the wrong agent.

### Root cause
`handleEnter` resolved its target from `focusedOpenPane()` **first**. Ctrl-] leaves the focus ring on A's pane, and sidebar navigation moves the tree cursor **without** moving the focus ring — so the second Enter re-entered the stale A pane instead of the selected B. Two divergent target-resolution paths (focus-first vs selection) were the defect — exactly the kind of divergence the reporter flagged.

### Fix
Per the reporter's preferred direction, **unify keyboard Enter onto the open-pane verb's resolution**: always the **sidebar selection**, never the focus ring. Enter now opens/focuses the selected instance's pane (exactly like `s`), then enters it. One path, always the current selection.

### Adjacent audit
- **`o` (full-screen attach, `handleAttach`)** shares the same focus-ring-first pattern and the same stale-target bug. Rather than strip its per-tab attach capability, tree-navigation keys now re-home the focus ring on the tree (`focusTreeForNav`), so `o` resolves the current selection after navigation too.
- **Mouse click-to-interact** legitimately enters the **clicked** pane (the click names its exact target, and it does not move the sidebar selection). Extracted `enterPane()` for that explicit-pane case so the mouse path no longer piggybacks on Enter's now-selection-based verb.

### Behavior note
Keyboard Enter no longer enters a pane you Tab-focused whose instance differs from the sidebar selection — it targets the selection (the reporter's intent: "Enter == open"). Deliberate per-pane entry is available via mouse click and `o`.

### Tests (`make test-container` green; all 25 packages pass)
- `TestSecondEnterTargetsCurrentSelectionNotStalePane` — the exact 4-step repro across two instances; asserts a forwarded keystroke lands in **B**'s attachment and **not** A's. Verified to **fail** without the fix (bound to alpha).
- `TestEnterResolvesFromSelectionNotFocusRing` — isolates `handleEnter`'s resolution (focus on A's pane, selection B → Enter targets B).
- `TestPane_TreeNavFromPaneRefocusesTree` — the `o`/nav focus re-homing.
- `TestPane_EnterAttachesSelectionNotFocusedPane` — updated to the new selection-based contract.

### Gates
`go build`, `gofmt -l`, `golangci-lint --fast`, `deadcode -test`, file-length lint, `make test-container` — all green.

> ⚠️ Do not merge yet — root to verify + run the live driver play-test of the 4-step repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude