### PR TITLE
fix(daemon): root agent self-heals after an explicit kill — no restart needed (#1223)

### DIFF
--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1309,11 +1309,11 @@ type Manager struct {
 	// root-agent ensure loop (#1106), keyed by the root_agents config key
 	// (the repo path as written in config.json).
 	rootEnsureStates map[string]*rootEnsureState
-	// rootKilledByUser records repos (by repo ID) whose root agent was
-	// removed through an explicit KillSession. The ensure loop respects the
-	// kill and stops re-creating that root until the daemon restarts —
-	// in-memory on purpose, so a restart re-asserts the configured state.
-	rootKilledByUser map[string]struct{}
+	// rootKilledAt records repos (by repo ID) whose root agent was explicitly
+	// killed, and WHEN. The ensure loop honors the kill only for
+	// rootKillHealDelay, then self-heals a still-configured root (#1223): config
+	// (root_agents), not a runtime kill, decides whether an always-on root runs.
+	rootKilledAt map[string]time.Time
 	// killsInFlight marks sessions (by daemon instance key) whose KillSession
 	// teardown is currently running, so the status poll's finish-kill pass for
 	// tombstoned records (#1108) never runs a second concurrent teardown of
@@ -1388,7 +1388,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		repoStartLocks:      make(map[string]*sync.Mutex),
 		targetLocks:         make(map[string]*sync.Mutex),
 		rootEnsureStates:    make(map[string]*rootEnsureState),
-		rootKilledByUser:    make(map[string]struct{}),
+		rootKilledAt:        make(map[string]time.Time),
 		killsInFlight:       make(map[string]struct{}),
 		lostRestoreStates:   make(map[string]*lostRestoreState),
 		limitResumeStates:   make(map[string]*limitResumeState),
@@ -2019,14 +2019,14 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 	m.mu.Lock()
 	delete(m.instances, key)
 	if session.IsReservedTitle(req.Title) {
-		// An explicit kill of the root agent is a user decision the ensure
-		// loop must respect (#1106): suppress re-creation for this repo until
-		// the daemon restarts, rather than fighting the user by resurrecting
-		// a session they just tore down. Recorded even for repos not (or no
-		// longer) in root_agents — harmless there, and it keeps the ordering
-		// between a kill and a concurrent config change race-free.
-		m.rootKilledByUser[repoID] = struct{}{}
-		log.InfoLog.Printf("root agent for repo %s killed by user; the ensure loop will not re-create it until the daemon restarts", repoID)
+		// An explicit kill is honored only briefly: the ensure loop suppresses
+		// re-creation for rootKillHealDelay, then self-heals a still-configured
+		// root (#1223). Config (root_agents) is the source of truth — removing
+		// the repo from it is the only permanent stop. Recorded even for
+		// unconfigured repos (harmless — the loop never visits them — and it
+		// keeps kill-vs-config-change ordering race-free).
+		m.rootKilledAt[repoID] = nowFunc()
+		log.InfoLog.Printf("root agent for repo %s killed by user; the ensure loop will re-create it in ~%s unless the repo is removed from root_agents", repoID, rootKillHealDelay)
 	}
 	m.mu.Unlock()
 	return nil

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -49,6 +49,16 @@ var (
 	rootEnsureBackoffMax  = 5 * time.Minute
 )
 
+// rootKillHealDelay is the grace window the ensure loop honors after an
+// explicit KillSession of the root before it self-heals a still-configured
+// root (#1223). Long enough to cover a deliberate manual restart or a brief
+// stop, short enough that an always-on root is never left dead for long — the
+// #1223 outage kept it dead 23 minutes (until a daemon restart). Package var so
+// tests can shorten it; the only permanent stop is removing the repo from
+// root_agents. The ensure loop reads the injectable package clock nowFunc for
+// the grace comparison, so tests advance time instead of sleeping.
+var rootKillHealDelay = 2 * time.Minute
+
 // rootEnsureState is the per-configured-repo retry state for the ensure
 // loop. Guarded by Manager.mu (the loop runs on the daemon poll goroutine,
 // but tests drive EnsureRootAgents directly).
@@ -103,19 +113,33 @@ func (m *Manager) ensureRootAgent(path string, rc config.RootAgentConfig) {
 
 	key := daemonInstanceKey(repo.ID, session.RootSessionTitle)
 	m.mu.Lock()
-	_, killed := m.rootKilledByUser[repo.ID]
+	killedAt, killed := m.rootKilledAt[repo.ID]
 	inst := m.instances[key]
 	m.mu.Unlock()
 
 	if killed {
-		m.mu.Lock()
-		logSuppression := !st.suppressLogged
-		st.suppressLogged = true
-		m.mu.Unlock()
-		if logSuppression {
-			log.InfoLog.Printf("root agent for %s was explicitly killed; not re-creating until the daemon restarts", repo.Root)
+		if nowFunc().Before(killedAt.Add(rootKillHealDelay)) {
+			// Still inside the grace window: honor the user's stop, but only
+			// briefly. Logged once per suppression so a killed root does not
+			// spam the log every poll tick.
+			m.mu.Lock()
+			logSuppression := !st.suppressLogged
+			st.suppressLogged = true
+			m.mu.Unlock()
+			if logSuppression {
+				log.InfoLog.Printf("root agent for %s was explicitly killed; honoring the stop, will re-create it in ~%s (config is the source of truth for an always-on root — remove it from root_agents to keep it down)", repo.Root, rootKillHealDelay)
+			}
+			return
 		}
-		return
+		// Grace window elapsed and the repo is still configured: config wins,
+		// so clear the kill and fall through to re-create. This is the #1223
+		// self-heal — a killed (or outage-downed) root comes back without a
+		// daemon restart.
+		m.mu.Lock()
+		delete(m.rootKilledAt, repo.ID)
+		st.suppressLogged = false
+		m.mu.Unlock()
+		log.InfoLog.Printf("root agent for %s: kill grace window elapsed; re-creating (always-on self-heal, #1223)", repo.Root)
 	}
 
 	if inst != nil {
@@ -186,18 +210,14 @@ func (m *Manager) deliverToReemergingRoot(repo *config.RepoContext, req DeliverP
 
 // repoRootAgentWillMaterialize reports whether the daemon's ensure loop is
 // responsible for (re-)creating the reserved "root" session for this repo: the
-// repo is opted into root_agents AND the root was not explicitly killed by the
-// user (an explicit kill suppresses re-creation until the daemon restarts).
-// When true, a delivery to a momentarily-absent root should wait for the ensure
-// loop rather than auto-create it. Config is immutable after daemon start, so
-// only the killed-set read needs the lock.
+// repo is opted into root_agents. Config is the single source of truth for
+// "root should be running" — a root that is Dead, Lost, or even explicitly
+// killed self-heals (the kill only delays re-creation by rootKillHealDelay,
+// #1223), so a configured root always materializes eventually and a delivery to
+// a momentarily-absent one should wait for the ensure loop rather than
+// auto-create it (which the reserved-name guard would reject). Config is
+// immutable after daemon start, so this needs no lock.
 func (m *Manager) repoRootAgentWillMaterialize(repoID string) bool {
-	m.mu.Lock()
-	_, killed := m.rootKilledByUser[repoID]
-	m.mu.Unlock()
-	if killed {
-		return false
-	}
 	for path := range m.cfg.RootAgents {
 		repo, err := config.RepoFromPath(config.ExpandTilde(path))
 		if err != nil {
@@ -211,8 +231,8 @@ func (m *Manager) repoRootAgentWillMaterialize(repoID string) bool {
 }
 
 // reapDeadRoot removes a Dead root instance so ensureRootAgent can re-create
-// the title. Mirrors KillSession's teardown but deliberately does NOT mark
-// rootKilledByUser: this is the daemon healing itself, not a user decision.
+// the title. Mirrors KillSession's teardown but deliberately does NOT record
+// rootKilledAt: this is the daemon healing itself, not a user decision.
 func (m *Manager) reapDeadRoot(repoID string, inst *session.Instance) error {
 	// Best-effort by design (#478): tmux is already gone and an in-place
 	// worktree's Cleanup is a no-op, so failures here only log inside Kill.

--- a/daemon/rootagent_test.go
+++ b/daemon/rootagent_test.go
@@ -303,15 +303,27 @@ func TestEnsureRootAgentsDoesNotAdoptArchivedRoot(t *testing.T) {
 	}
 }
 
-// TestEnsureRootAgentsRespectsUserKill: an explicit KillSession of the root
-// suppresses re-creation for the rest of the daemon's life; a fresh manager
-// (daemon restart) re-asserts the configured root. This is the conservative
-// #1108-adjacent shape: respect the explicit kill until daemon restart.
-func TestEnsureRootAgentsRespectsUserKill(t *testing.T) {
+// TestEnsureRootAgentsUserKillHealsAfterGraceWindow is the #1223 case-(b)
+// regression: an explicit KillSession of the root is honored only briefly —
+// within rootKillHealDelay the ensure loop leaves it down, room for a manual
+// restart or a deliberate stop — but a still-configured root then SELF-HEALS
+// once the grace window elapses, with NO daemon restart. Config (root_agents),
+// not a runtime kill-tombstone, is the source of truth for an always-on root.
+// The outage this fixes: root killed 10:39, dead until an 11:02 daemon restart
+// (~23 min), because the old kill tombstone was permanent.
+func TestEnsureRootAgentsUserKillHealsAfterGraceWindow(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	seen := installOptionsRecordingBackend(t)
 	repoPath := setupControlRepo(t)
 	cfg := rootTestConfig(repoPath, config.RootAgentConfig{})
+
+	// Deterministic injected clock — advance it instead of sleeping through the
+	// real grace window.
+	base := time.Unix(1_700_000_000, 0)
+	clock := base
+	origNow := nowFunc
+	nowFunc = func() time.Time { return clock }
+	t.Cleanup(func() { nowFunc = origNow })
 
 	manager, err := NewManager(cfg)
 	if err != nil {
@@ -330,24 +342,83 @@ func TestEnsureRootAgentsRespectsUserKill(t *testing.T) {
 		t.Fatalf("KillSession: %v", err)
 	}
 
+	// Inside the grace window: the kill is honored, no re-create.
+	clock = base.Add(rootKillHealDelay - time.Second)
 	manager.EnsureRootAgents()
 	manager.EnsureRootAgents()
 	if len(*seen) != 1 {
-		t.Fatalf("ensure must respect an explicit root kill until daemon restart, got %d creates", len(*seen))
+		t.Fatalf("ensure must honor the kill inside the grace window, got %d creates", len(*seen))
 	}
 	if findRootInstance(t, manager, repoPath) != nil {
-		t.Fatalf("killed root must stay gone")
+		t.Fatalf("root must stay down inside the grace window")
 	}
 
-	// A daemon restart (fresh manager over the same home) re-asserts the
-	// configured root: the suppression is deliberately in-memory only.
-	restarted, err := NewManager(cfg)
-	if err != nil {
-		t.Fatalf("NewManager (restart): %v", err)
-	}
-	restarted.EnsureRootAgents()
+	// Grace window elapsed: a still-configured root self-heals — NO daemon
+	// restart, unlike the pre-fix behavior.
+	clock = base.Add(rootKillHealDelay + time.Second)
+	manager.EnsureRootAgents()
 	if len(*seen) != 2 {
-		t.Fatalf("a restarted daemon must re-create the configured root, got %d creates", len(*seen))
+		t.Fatalf("configured root must self-heal after the grace window without a daemon restart, got %d creates", len(*seen))
+	}
+	if findRootInstance(t, manager, repoPath) == nil {
+		t.Fatalf("root instance must be back after self-heal")
+	}
+
+	// The kill tombstone is cleared, so a later pass just adopts the live root
+	// rather than churning creates.
+	manager.mu.Lock()
+	_, stillKilled := manager.rootKilledAt[repo.ID]
+	manager.mu.Unlock()
+	if stillKilled {
+		t.Fatalf("kill tombstone must be cleared after self-heal")
+	}
+	manager.EnsureRootAgents()
+	if len(*seen) != 2 {
+		t.Fatalf("healed root must be adopted, not re-created, got %d creates", len(*seen))
+	}
+}
+
+// TestEnsureRootAgentsDoesNotHealUnconfiguredRoot pins that the self-heal is
+// gated on config: a repo NOT in root_agents is never visited by the ensure
+// loop, so a killed (or absent) root there is never auto-created — even long
+// past the grace window. Removing a repo from root_agents is the ONLY permanent
+// stop, and this proves the loop does not spin-spawn roots for unconfigured
+// repos (#1223).
+func TestEnsureRootAgentsDoesNotHealUnconfiguredRoot(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	seen := installOptionsRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+
+	base := time.Unix(1_700_000_000, 0)
+	clock := base
+	origNow := nowFunc
+	nowFunc = func() time.Time { return clock }
+	t.Cleanup(func() { nowFunc = origNow })
+
+	// No root_agents entry for this repo.
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	// A kill records a tombstone even for an unconfigured repo (harmless
+	// bookkeeping — see KillSession).
+	manager.mu.Lock()
+	manager.rootKilledAt[repo.ID] = base
+	manager.mu.Unlock()
+
+	// Well past the grace window, the unconfigured repo is still never visited.
+	clock = base.Add(rootKillHealDelay + time.Hour)
+	manager.EnsureRootAgents()
+	manager.EnsureRootAgents()
+	if len(*seen) != 0 {
+		t.Fatalf("ensure must never create a root for a repo absent from root_agents, got %d creates", len(*seen))
+	}
+	if findRootInstance(t, manager, repoPath) != nil {
+		t.Fatalf("unconfigured repo must have no root instance")
 	}
 }
 


### PR DESCRIPTION
## #1223 case (b) — the real 23-minute outage today

Part A (delivery path) merged as #1224; this is the availability half — the one that actually bit Sachin today.

### The outage (from today's daemon log)
```
10:39:33 control.go  root agent … killed by user; the ensure loop will not re-create it until the daemon restarts
10:39:33 rootagent   root agent … was explicitly killed; not re-creating until the daemon restarts
11:02:33 rootagent   ensured root agent …          ← only AFTER an 11:02:30 daemon restart
```
An explicit `KillSession` of the daemon-managed root recorded a **permanent** in-memory tombstone (`rootKilledByUser`), so the ensure loop refused to re-create root until the daemon restarted. Root was dead **~23 minutes**. This was the second of two "stays dead until restart" conditions in #1223 — the first (give up after 6 failed ensure attempts) already landed in **#1122**.

### Fix — config is the single source of truth for "root should be running"
A kill is now honored **only briefly**: the ensure loop suppresses re-creation for a bounded grace window (`rootKillHealDelay`, default **2m** — room for a deliberate manual restart or a quick stop) and then **self-heals** a still-configured root, **with no daemon restart**. After the window a killed root unifies with the normal dead-root heal path, so an outage of any length recovers on its own once tmux returns. **The only permanent stop is removing the repo from `root_agents`.**

- `rootKilledByUser` (permanent set) → **`rootKilledAt`** (kill timestamp); the loop clears it and re-creates once the window elapses.
- `repoRootAgentWillMaterialize` (the delivery gate from #1224) now keys **purely on config membership** — since a killed root re-heals, a configured root always materializes eventually, so watch/monitor deliveries during the kill window also wait (bounded) for it instead of hitting the reserved-name guard.
- Grace timing reads the existing injectable package clock (`nowFunc`) → deterministic tests, no real waits.
- Clear state-transition logs: `killed → honoring the stop, will re-create in ~Ns` → `grace elapsed, re-creating (self-heal)`.

### Semantics — confirming the intended model
Per the always-on mandate: **a runtime kill is temporary; config is authoritative.** I recommend this as-is. One tradeoff worth naming: killing root to stop a *misbehaving/looping* root only buys ~2 min before it returns — the escape hatch is removing it from `root_agents`. If a longer/permanent manual stop is wanted, `rootKillHealDelay` is a single tunable knob (could be config-exposed later). Not blocking; flagging for visibility.

### Case (a) unchanged
The capped-long-backoff self-heal (never permanently give up) already landed in #1122; both conditions now self-heal.

### Tests (`make test-container`, injected clock — no real waits)
- `TestEnsureRootAgentsUserKillHealsAfterGraceWindow` — killed root honored inside the window; self-heals after it **without a daemon restart**; tombstone cleared; healed root adopted (no create churn).
- `TestEnsureRootAgentsDoesNotHealUnconfiguredRoot` — a repo absent from `root_agents` is never visited; no spin-spawn even past the grace window.
- Existing `TestEnsureRootAgentsKeepsRetryingAndHeals` (case a) still green.

### Gates
`golangci-lint --fast`, `gofmt -l .` (empty), `go build ./...`, `make test-container` (full `daemon` package green), `scripts/lint-file-length.sh` (control.go held at its 2604 ceiling), full-tree `deadcode` clean — all pass.

Closes #1223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)