### PR TITLE
fix(tui): guard the root agent kill confirmation (#1238)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -175,11 +175,49 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		}
 	}
 
-	message := fmt.Sprintf("[!] Kill session '%s'?", selectedTitle)
+	reserved := session.IsReservedTitle(selectedTitle)
+	message := killConfirmMessage(selectedTitle, warning, reserved)
+	cmd := m.confirmAction(message, killAction)
+	if reserved && m.confirmationOverlay != nil {
+		// Break the muscle-memory D+y reflex on the daemon-managed singleton
+		// (#1238): a distinct confirm key means a reflexive 'y' — the ordinary
+		// kill confirmation — is ignored, so the user has to read the warning
+		// and press the named key before root is torn down.
+		m.confirmationOverlay.SetConfirmKey(rootKillConfirmKey)
+	}
+	return m, cmd
+}
+
+// rootKillConfirmKey is the confirm key the kill dialog demands for the reserved
+// root agent (#1238). Deliberately NOT the ordinary 'y' so an inattentive D+y —
+// the exact gesture that silently decapitated root's event pipeline on
+// 2026-07-05 — cannot dispatch the kill; the key is surfaced in the rendered
+// prompt ("Press k to confirm").
+const rootKillConfirmKey = "k"
+
+// killConfirmMessage builds the kill-confirmation copy for a session. The
+// reserved root agent (#1238) gets distinct, consequence-bearing copy instead of
+// the generic "[!] Kill session 'root'?" that killing any throwaway worktree
+// shows: killing root stops every scheduled/watch-task delivery to it (the
+// inbound event pipeline) until it self-heals or the daemon is restarted. This
+// mirrors the reserved-title guard the create path already applies
+// (app/handle_input.go). #1237 made root self-heal ~2 min after a kill, so the
+// copy names that recovery rather than the pre-#1237 "until the daemon restarts".
+func killConfirmMessage(title, warning string, reserved bool) string {
+	var message string
+	if reserved {
+		message = fmt.Sprintf(
+			"[!] '%s' is the daemon-managed root agent, not a scratch session.\n"+
+				"Killing it stops scheduled and watch-task delivery to '%s' until it\n"+
+				"self-heals (~2 min) or you restart the daemon.\n\n"+
+				"Kill the root agent anyway?", title, title)
+	} else {
+		message = fmt.Sprintf("[!] Kill session '%s'?", title)
+	}
 	if warning != "" {
 		message += "\n\n" + warning
 	}
-	return m, m.confirmAction(message, killAction)
+	return message
 }
 
 // killInstanceCmd returns a tea.Cmd that performs the actual session teardown

--- a/app/root_kill_guard_test.go
+++ b/app/root_kill_guard_test.go
@@ -1,0 +1,113 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// ----------------------------------------------------------------------------
+// Regression tests for #1238: killing the daemon-managed root agent from the
+// TUI must not look — or be dispatched — like killing a throwaway worktree.
+//
+// The 2026-07-05 outage was a muscle-memory D+y on root's row: the generic
+// "[!] Kill session 'root'?" confirm gave no hint that root is the daemon-
+// managed singleton, and the ordinary 'y' confirm tore it down, silently
+// decapitating the inbound event pipeline. The guard gives root distinct,
+// consequence-bearing copy AND a distinct confirm key so a reflexive 'y' is a
+// no-op.
+// ----------------------------------------------------------------------------
+
+// TestKillConfirmMessage_RootIsDistinctAndNamesConsequence pins the copy on the
+// IsReservedTitle branch: it must name the daemon-managed root, the delivery
+// consequence, and the self-heal recovery (#1237) — and must NOT be the generic
+// scratch-session prompt.
+func TestKillConfirmMessage_RootIsDistinctAndNamesConsequence(t *testing.T) {
+	generic := killConfirmMessage("scratch-1", "", false)
+	assert.Equal(t, "[!] Kill session 'scratch-1'?", generic,
+		"non-reserved copy must be unchanged")
+
+	root := killConfirmMessage(session.RootSessionTitle, "", true)
+	assert.NotEqual(t, "[!] Kill session 'root'?", root,
+		"root must not show the generic scratch-session prompt")
+	assert.Contains(t, root, "daemon-managed root agent",
+		"root copy must identify the singleton")
+	assert.Contains(t, strings.ToLower(root), "delivery",
+		"root copy must name the delivery consequence")
+	assert.Contains(t, strings.ToLower(root), "self-heal",
+		"root copy must name the #1237 self-heal recovery, not a hard-coded restart")
+}
+
+// TestKillConfirmMessage_WarningAppendsForBothBranches verifies the uncommitted-
+// changes warning is still appended for reserved and non-reserved alike.
+func TestKillConfirmMessage_WarningAppendsForBothBranches(t *testing.T) {
+	warn := "you have uncommitted changes"
+	assert.Contains(t, killConfirmMessage("scratch-1", warn, false), warn)
+	assert.Contains(t, killConfirmMessage(session.RootSessionTitle, warn, true), warn)
+}
+
+// TestHandleKill_RootRequiresDistinctConfirmKey is the core guard: selecting
+// root and pressing kill must arm a dialog whose confirm key is NOT the ordinary
+// 'y', so a reflexive 'y' cannot dispatch the kill — only the named key does.
+func TestHandleKill_RootRequiresDistinctConfirmKey(t *testing.T) {
+	h := newTestHome(t)
+	root := newKillableInstance(t, session.RootSessionTitle)
+	h.store.AddInstance(root)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, _ := h.handleKill()
+	hm := model.(*home)
+	require.Equal(t, stateConfirm, hm.state, "kill must open the confirmation dialog")
+	require.NotNil(t, hm.confirmationOverlay)
+	require.Equal(t, rootKillConfirmKey, hm.confirmationOverlay.ConfirmKey,
+		"root kill must demand the distinct confirm key, not the ordinary 'y'")
+	require.NotEqual(t, "y", hm.confirmationOverlay.ConfirmKey)
+
+	// A reflexive 'y' — the muscle-memory gesture from #1238 — must be ignored:
+	// the dialog stays open, root is untouched.
+	model, cmd := hm.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	hm = model.(*home)
+	assert.Equal(t, stateConfirm, hm.state, "reflexive 'y' must not confirm a root kill")
+	assert.NotNil(t, hm.confirmationOverlay, "dialog must stay open after a rejected key")
+	assert.Nil(t, cmd, "no kill must be dispatched by 'y'")
+	assert.NotEqual(t, session.Deleting, root.GetStatus(), "root must not be marked Deleting")
+
+	// The named key confirms.
+	model, cmd = hm.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(rootKillConfirmKey)})
+	hm = model.(*home)
+	assert.Equal(t, stateDefault, hm.state, "the named key must confirm")
+	assert.Nil(t, hm.confirmationOverlay, "dialog must close on confirm")
+	require.NotNil(t, cmd, "confirm must forward the start-kill message")
+	assert.Equal(t, session.Deleting, root.GetStatus(),
+		"root row must be marked Deleting once confirmed")
+	startMsg, ok := cmd().(startKillMsg)
+	require.True(t, ok, "confirm must emit startKillMsg, got a different msg")
+	assert.Equal(t, session.RootSessionTitle, startMsg.title)
+}
+
+// TestHandleKill_NonReservedKeepsOrdinaryConfirm guards the acceptance criterion
+// "no change to killing non-reserved sessions": a scratch session still uses the
+// ordinary 'y' confirm.
+func TestHandleKill_NonReservedKeepsOrdinaryConfirm(t *testing.T) {
+	h := newTestHome(t)
+	inst := newKillableInstance(t, "scratch-1")
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, _ := h.handleKill()
+	hm := model.(*home)
+	require.Equal(t, stateConfirm, hm.state)
+	require.NotNil(t, hm.confirmationOverlay)
+	assert.Equal(t, "y", hm.confirmationOverlay.ConfirmKey,
+		"non-reserved kill must keep the ordinary 'y' confirm")
+
+	model, cmd := hm.handleStateConfirm(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	assert.Equal(t, stateDefault, model.(*home).state, "'y' must confirm a scratch kill")
+	require.NotNil(t, cmd)
+	assert.Equal(t, session.Deleting, inst.GetStatus())
+}


### PR DESCRIPTION
## What

Killing the daemon-managed `root` agent from the TUI was indistinguishable from killing a throwaway worktree — same generic `[!] Kill session 'root'?` confirm, same muscle-memory `y` to dispatch. On 2026-07-05 a reflexive `Shift-D`+`y` on root's row (root pins to the **top** of the sidebar) tore it down and silently decapitated the inbound GitHub-events pipeline for ~23 minutes.

This is the **trigger-prevention** half of #1238 (fix (a)). #1237 already fixed the 23-min *impact* (root self-heals ~2 min after a kill); this stops the accidental kill in the first place.

## Root cause (full investigation in the [#1238 comment](https://github.com/sachiniyer/agent-factory/issues/1238#issuecomment-4887151304))

The investigation ruled out any silent trigger:
- **Selection never silently jumps to root.** It re-pins by *stable title* across a daemon reconnect (`app/sync.go:349-352,445-448`, the #969 fix), and a fresh TUI launch selects **nothing** — the cursor rests on the Instances header (`app/app.go:1522-1523`, #1024). Selection-by-ID (#1198) is not the issue.
- **No replay/queued-input vector.** The *only* path to `daemon.KillSession` is `Shift-D` → `y` (`handle_actions.go` → `session_control.go:36`); auto-update never restarts the bubbletea program, so no buffered `KeyMsg` survives to re-fire a confirm; the 21-min gap rules out type-ahead.

So the kill was a deliberate-but-inattentive human gesture. The real gap: the kill confirmation gives root no special treatment — unlike the **create** path, which already guards `IsReservedTitle` (`app/handle_input.go:53-55`).

## The fix (symmetric kill-path guard)

When the kill target is the reserved root title:
1. **Distinct, consequence-bearing copy** — names the daemon-managed singleton and that killing it stops scheduled/watch delivery to `root` (the event pipeline). Wording coordinated with **#1237**: it says root *self-heals (~2 min) or you restart the daemon*, not the pre-#1237 "until the daemon restarts".
2. **A stronger confirm than muscle-memory `D`+`y`.** The confirm key becomes **`k`** (surfaced in the rendered prompt "Press k to confirm") instead of the ordinary `y`, so a reflexive `y` is a no-op — the user must read the warning and press the named key.

**Stronger-confirm choice — a distinct confirm key (`k`), not a typed token.** It's the least-annoying-but-effective option: one keypress, self-documented in the prompt, and it fully breaks the `D`→`y` reflex (a buffered/reflexive `y` is ignored). A typed `root` token would require a stateful refactor of the shared `ConfirmationOverlay`; the distinct key reuses the existing `SetConfirmKey` and keeps the diff to one file. Mouse-confirm (clicking the "k to confirm" zone) still works via the existing zone→`ConfirmKey` synthesis. Happy to switch to a typed token if you'd prefer during review.

Non-reserved kills are **completely unchanged** (still `[!] Kill session 'x'?` + `y`).

## Tests (`app` pkg, FakeBackend — no tmux/daemon)

- `TestKillConfirmMessage_*` — reserved copy is distinct, names the delivery consequence + the #1237 self-heal; warning still appends for both branches.
- `TestHandleKill_RootRequiresDistinctConfirmKey` — the dialog demands `k`; a reflexive `y` leaves the dialog open and root untouched; `k` confirms and marks the row Deleting.
- `TestHandleKill_NonReservedKeepsOrdinaryConfirm` — scratch sessions keep `y`.

## Gates

`go build ./...`, `gofmt -l` (clean), `golangci-lint --fast ./app/...` (clean), full `app` package tests green, `deadcode` clean on the changed symbols, `scripts/lint-file-length.sh` pass.

## Scope

One focused change (fix (a) only). Leaves #1238's (c) — a TUI alarm on a persistently failing watch/task delivery target — to track separately as the broader defense-in-depth. **Does not close #1238.**

Refs #1238

🤖 Generated with [Claude Code](https://claude.com/claude-code)