### PR TITLE
fix(tui): auto-open a non-root pane on cold start (#1238)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1519,23 +1519,23 @@ func (m *home) clampSelectionTab() {
 // latch is set the workspace is entirely verb-driven: hiding every pane
 // leaves it empty until `s` opens one.
 //
-// A nil selected falls back to the first sidebar instance: launch never
-// auto-selects a row (the cursor rests on the Instances header — launch
-// selection parity, #1024 PR 2), so a cold start with restored sessions has
-// no selection to auto-open from. The fallback opens the first instance's
-// pane without touching the selection, and because selectionChanged re-enters
-// on every preview tick, it also re-fires once a restored instance leaves a
-// transient status (#1099 play-test).
+// A nil selected falls back to the first NON-reserved sidebar instance
+// (firstAutoOpenCandidate): launch never auto-selects a row (the cursor rests
+// on the Instances header — #1024 PR 2), so a cold start with restored sessions
+// has no selection to auto-open from. Preferring a non-reserved row keeps root
+// from being front-and-center after every relaunch (#1238). The fallback opens
+// the pane without touching the selection, and because selectionChanged
+// re-enters on every preview tick, it also re-fires once a restored instance
+// leaves a transient status (#1099 play-test).
 func (m *home) maybeAutoOpenInitialPane(selected *session.Instance) {
 	if m.initialPaneOpened || m.store.NumOpenPanes() > 0 {
 		return
 	}
 	if selected == nil {
-		instances := m.store.GetInstances()
-		if len(instances) == 0 {
+		selected = firstAutoOpenCandidate(m.store.GetInstances())
+		if selected == nil {
 			return
 		}
-		selected = instances[0]
 	}
 	if selected.HasInFlightOp() {
 		return

--- a/app/auto_open.go
+++ b/app/auto_open.go
@@ -1,0 +1,23 @@
+package app
+
+import "github.com/sachiniyer/agent-factory/session"
+
+// firstAutoOpenCandidate picks the pane to auto-open on a cold start when no row
+// is selected. It prefers the first NON-reserved instance so a relaunch (e.g.
+// right after an auto-update) doesn't greet the user with the daemon-managed
+// root agent front-and-center — the "kill right after a reload lands on root"
+// trap (#1238). Root pins first in the store order (ui/store/order.go), so
+// without this the auto-opened pane is always root. Falls back to the first
+// instance (root) only when root is the sole session. Returns nil for an empty
+// list.
+func firstAutoOpenCandidate(instances []*session.Instance) *session.Instance {
+	if len(instances) == 0 {
+		return nil
+	}
+	for _, inst := range instances {
+		if !session.IsReservedTitle(inst.Title) {
+			return inst
+		}
+	}
+	return instances[0]
+}

--- a/app/auto_open_candidate_test.go
+++ b/app/auto_open_candidate_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestFirstAutoOpenCandidate covers the #1238 relaunch trap: the cold-start
+// auto-open must prefer a non-reserved instance so a relaunch (e.g. right after
+// an auto-update) doesn't greet the user with root front-and-center — root pins
+// first in the store order, so instances[0] is always root when present.
+func TestFirstAutoOpenCandidate(t *testing.T) {
+	mk := func(title string) *session.Instance {
+		restore := session.SetBackendFactoryForTest(func(_ session.InstanceOptions, _ string) (session.Backend, error) {
+			return session.NewFakeBackend(), nil
+		})
+		defer restore()
+		inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "claude"})
+		require.NoError(t, err)
+		return inst
+	}
+
+	t.Run("empty list returns nil", func(t *testing.T) {
+		assert.Nil(t, firstAutoOpenCandidate(nil))
+		assert.Nil(t, firstAutoOpenCandidate([]*session.Instance{}))
+	})
+
+	t.Run("root is the sole session falls back to root", func(t *testing.T) {
+		root := mk(session.RootSessionTitle)
+		assert.Same(t, root, firstAutoOpenCandidate([]*session.Instance{root}))
+	})
+
+	t.Run("prefers the first non-reserved instance over a top-pinned root", func(t *testing.T) {
+		// Store order pins root first (ui/store/order.go); the candidate must
+		// skip it for the first real session.
+		root := mk(session.RootSessionTitle)
+		work := mk("feature-x")
+		other := mk("feature-y")
+		got := firstAutoOpenCandidate([]*session.Instance{root, work, other})
+		assert.Same(t, work, got)
+	})
+
+	t.Run("no root present returns the first instance", func(t *testing.T) {
+		a := mk("feature-x")
+		b := mk("feature-y")
+		assert.Same(t, a, firstAutoOpenCandidate([]*session.Instance{a, b}))
+	})
+}


### PR DESCRIPTION
## What

Optional follow-up to #1242 (rec (d) from the [#1238 investigation](https://github.com/sachiniyer/agent-factory/issues/1238#issuecomment-4887151304)).

Root pins to the **top** of the sidebar (`ui/store/order.go`), and the cold-start auto-open (`maybeAutoOpenInitialPane`) picked `instances[0]` — so every relaunch, notably right after an auto-update, greeted the user with the **daemon-managed root agent's pane front-and-center**. That is precisely the "kill right after a TUI reload lands on root" trap #1238 describes: the screen shows root while the cursor rests (unselected) on the Instances header, priming an inattentive navigate-down + `Shift-D`.

## The change

`firstAutoOpenCandidate` now prefers the first **non-reserved** instance for the initial auto-open, falling back to root only when root is the sole session. Selection is untouched — launch still rests the cursor on the Instances header (#1024) — this only changes which pane's *content* is shown on cold start.

- Helper lives in its own file (`app/auto_open.go`) so `app.go` stays under its grandfathered file-length ceiling (#1145).

## Relationship to #1242

Defense-in-depth, not a replacement: #1242 makes an accidental root kill *hard to dispatch* (distinct copy + distinct confirm key); this removes the *condition that primes it* (root being the pane you're staring at after a relaunch). Independent files, no overlap — either can merge first.

## Tests (`app` pkg)

`TestFirstAutoOpenCandidate`: empty → nil; root-only → root; root pinned first → first non-reserved; no root → first instance.

## Gates

`go build ./...`, `gofmt -l` (clean), `golangci-lint --fast ./app/...` (clean), full `app` package tests green, `deadcode` clean, `scripts/lint-file-length.sh` pass (app.go back under ceiling).

Refs #1238

🤖 Generated with [Claude Code](https://claude.com/claude-code)