### PR TITLE
feat(tui): alarm banner for a persistently-failing watch-task delivery target (#1238 fix c)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -85,8 +86,11 @@ type home struct {
 	// mutable global swapped by a test seam would race that goroutine against a
 	// sibling test's swap under `go test -parallel`. Each home owns its fetcher,
 	// so there is no cross-test shared state to race. Defaults to
-	// snapshotThroughDaemon in production; tests assign a fake directly.
-	snapshotFetcher func(repoID string) ([]session.InstanceData, error)
+	// snapshotThroughDaemon in production; tests assign a fake directly. It
+	// returns the full daemon.SnapshotResponse so the session list and the
+	// delivery-failure alarms (#1238) arrive from one authoritative RPC — the
+	// alarm is a field on the snapshot, not a side channel.
+	snapshotFetcher func(repoID string) (daemon.SnapshotResponse, error)
 	// pauseStatusPoll / resumeStatusPoll are the daemon poll-pause seams for the
 	// attach heartbeat (#1160). PER-home fields, not package globals, for the
 	// same reason as snapshotFetcher: the heartbeat reads the seam from an
@@ -233,6 +237,11 @@ type home struct {
 	menu *ui.Menu
 	// errBox displays error messages inside the status bar (shared handle)
 	errBox *ui.ErrBox
+	// alarmBanner is the top-of-screen delivery-failure alarm (#1238): a
+	// persistent red bar raised while the daemon snapshot reports a watch task
+	// whose events are failing to reach their target session. Fed each poll by
+	// applyDeliveryAlarms from the snapshot's DeliveryAlarms projection.
+	alarmBanner *ui.AlarmBanner
 	// global spinner instance. we plumb this down to where it's needed
 	spinner spinner.Model
 	// textOverlay displays text information
@@ -292,6 +301,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 	errBox := ui.NewErrBox()
 
 	h := &home{
+		alarmBanner:      ui.NewAlarmBanner(),
 		ctx:              ctx,
 		spinner:          spinner.New(spinner.WithSpinner(spinner.MiniDot)),
 		store:            proj,
@@ -384,6 +394,10 @@ func (m *home) relayout() {
 	// every automation when the rail has the room, collapsing only when the
 	// tree + automations can't both fit (#1126).
 	m.grid.Automations = m.store.NumTasks()
+	// Reserve the alarm banner row exactly when a delivery-failure alarm is
+	// raised (#1238), so the row appears/disappears with the alarm and never
+	// steals space in the healthy steady state.
+	m.grid.Banner = m.alarmBanner.Active()
 	lay := m.grid.Solve(m.termWidth, m.termHeight)
 	m.lastLayout = lay
 	if lay.Fallback {
@@ -427,6 +441,7 @@ func (m *home) relayout() {
 	m.automations.SetRect(lay.Automations)
 	m.automations.SetCompact(lay.AutomationsCompact)
 	m.statusBar.SetRect(lay.StatusBar)
+	m.alarmBanner.SetRect(lay.Banner)
 
 	if m.textOverlay != nil {
 		m.textOverlay.SetWidth(int(float32(m.termWidth) * 0.6))
@@ -1803,7 +1818,15 @@ func (m *home) View() string {
 		}
 	}
 	top := lipgloss.JoinHorizontal(lipgloss.Top, cols...)
-	mainView := lipgloss.JoinVertical(lipgloss.Left, top, m.statusBar.View())
+	// Stack the delivery-failure alarm banner (#1238) above everything when
+	// raised, so it is visible without navigating and the layout reserved its
+	// row in relayout.
+	viewParts := make([]string, 0, 3)
+	if banner := m.alarmBanner.View(); banner != "" {
+		viewParts = append(viewParts, banner)
+	}
+	viewParts = append(viewParts, top, m.statusBar.View())
+	mainView := lipgloss.JoinVertical(lipgloss.Left, viewParts...)
 
 	if m.state == stateHelp {
 		if m.textOverlay == nil {
@@ -1840,50 +1863,5 @@ func (m *home) View() string {
 	return mainView
 }
 
-// hooksOverlayStyle frames the hooks editor when it is hosted as an overlay
-// (#1024 PR 4: hooks lost their persistent sidebar slot).
-var hooksOverlayStyle = lipgloss.NewStyle().
-	Border(lipgloss.RoundedBorder()).
-	BorderForeground(ui.AccentColor).
-	Padding(1, 2)
-
-func (m *home) renderHooksOverlay() string {
-	return hooksOverlayStyle.Render(m.hooksPane.String())
-}
-
-// renderTasksOverlay frames the task manager (list + create/edit form) as the
-// centered modal it lives in (#1087 play-test): the manager needs real
-// width/height for its form, which the narrow left rail cannot provide.
-func (m *home) renderTasksOverlay() string {
-	return hooksOverlayStyle.Render(m.automations.TaskPane().String())
-}
-
-// splitDividerStyle recedes the 1-col dividers between panes so the focused
-// pane's frame stays the strongest line on screen.
-var splitDividerStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#DDDADA", Dark: "#3C3C3C"})
-
-// renderDivider renders the 1-col divider right of pane i (§2.6: "N panes
-// divide the workspace width evenly with 1-col dividers").
-func (m *home) renderDivider(i int) string {
-	if i < 0 || i >= len(m.lastLayout.Dividers) {
-		return ""
-	}
-	r := m.lastLayout.Dividers[i]
-	if r.Empty() {
-		return ""
-	}
-	col := strings.TrimSuffix(strings.Repeat("│\n", r.H), "\n")
-	return splitDividerStyle.Render(col)
-}
-
-// renderRailRule renders the full-rail-width horizontal rule separating the
-// instances tree from the bottom-aligned automations section (#1087), in the
-// same receded style as the split divider.
-func (m *home) renderRailRule() string {
-	r := m.lastLayout.RailRule
-	if r.Empty() {
-		return ""
-	}
-	return splitDividerStyle.Render(strings.Repeat("─", r.W))
-}
+// The View render helpers (overlay framing + rail/divider rules) live in
+// render.go, extracted to keep app.go under its file-length ceiling (#1145).

--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -130,9 +130,13 @@ func findSidebarInstance(h *home, title string) *session.Instance {
 // CLI→daemon→TUI integration checks.
 func reconcileFromDaemon(t *testing.T, h *home) bool {
 	t.Helper()
-	data, err := snapshotThroughDaemon(h.repoID)
+	resp, err := snapshotThroughDaemon(h.repoID)
 	require.NoError(t, err)
-	return h.reconcileSnapshot(data)
+	changed := h.reconcileSnapshot(resp.Instances)
+	if h.applyDeliveryAlarms(resp.DeliveryAlarms) {
+		changed = true
+	}
+	return changed
 }
 
 func buildIntegrationBinary(t *testing.T) string {

--- a/app/cold_start_test.go
+++ b/app/cold_start_test.go
@@ -36,9 +36,9 @@ func TestColdStartFromSnapshot_PopulatesSidebar(t *testing.T) {
 		return newSnapshotTestInstance(t, d.Title), nil
 	}))
 
-	h.snapshotFetcher = func(repoID string) ([]session.InstanceData, error) {
+	h.snapshotFetcher = func(repoID string) (daemon.SnapshotResponse, error) {
 		require.Equal(t, h.repoID, repoID, "cold start must fetch the TUI's repo scope")
-		return []session.InstanceData{{Title: "alpha"}, {Title: "beta"}}, nil
+		return daemon.SnapshotResponse{Instances: []session.InstanceData{{Title: "alpha"}, {Title: "beta"}}}, nil
 	}
 
 	require.NoError(t, h.coldStartFromSnapshot())
@@ -62,12 +62,12 @@ func TestColdStartFromSnapshot_WaitsOutWarmingDaemon(t *testing.T) {
 	defer func() { coldStartWarmupPoll = prevPoll }()
 
 	calls := 0
-	h.snapshotFetcher = func(string) ([]session.InstanceData, error) {
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
 		calls++
 		if calls < 3 {
-			return nil, errDaemonStarting()
+			return daemon.SnapshotResponse{}, errDaemonStarting()
 		}
-		return []session.InstanceData{{Title: "restored"}}, nil
+		return daemon.SnapshotResponse{Instances: []session.InstanceData{{Title: "restored"}}}, nil
 	}
 
 	require.NoError(t, h.coldStartFromSnapshot())
@@ -92,8 +92,8 @@ func TestColdStartFromSnapshot_LaunchSelectionParity(t *testing.T) {
 	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
 		return newSnapshotTestInstance(t, d.Title), nil
 	}))
-	h.snapshotFetcher = func(string) ([]session.InstanceData, error) {
-		return []session.InstanceData{{Title: "first"}, {Title: "second"}, {Title: "third"}}, nil
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{Instances: []session.InstanceData{{Title: "first"}, {Title: "second"}, {Title: "third"}}}, nil
 	}
 
 	require.NoError(t, h.coldStartFromSnapshot())
@@ -133,8 +133,8 @@ func TestColdStartFromSnapshot_AutoOpensFirstInstancePane(t *testing.T) {
 	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
 		return newSnapshotTestInstance(t, d.Title), nil
 	}))
-	h.snapshotFetcher = func(string) ([]session.InstanceData, error) {
-		return []session.InstanceData{{Title: "first"}, {Title: "second"}}, nil
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{Instances: []session.InstanceData{{Title: "first"}, {Title: "second"}}}, nil
 	}
 
 	require.NoError(t, h.coldStartFromSnapshot())
@@ -171,8 +171,8 @@ func TestColdStartFromSnapshot_AutoOpenWaitsOutTransientStatus(t *testing.T) {
 		inst.SetStatus(session.Loading)
 		return inst, nil
 	}))
-	h.snapshotFetcher = func(string) ([]session.InstanceData, error) {
-		return []session.InstanceData{{Title: "restoring"}}, nil
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{Instances: []session.InstanceData{{Title: "restoring"}}}, nil
 	}
 
 	require.NoError(t, h.coldStartFromSnapshot())
@@ -192,8 +192,8 @@ func TestColdStartFromSnapshot_AutoOpenWaitsOutTransientStatus(t *testing.T) {
 // with the launch paint path running clean — matching the pre-store TUI.
 func TestColdStartFromSnapshot_EmptySnapshotNoSelection(t *testing.T) {
 	h := newTestHome(t)
-	h.snapshotFetcher = func(string) ([]session.InstanceData, error) {
-		return nil, nil
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{}, nil
 	}
 
 	require.NoError(t, h.coldStartFromSnapshot())
@@ -211,8 +211,8 @@ func TestColdStartFromSnapshot_EmptySnapshotNoSelection(t *testing.T) {
 func TestColdStartFromSnapshot_HardErrorAborts(t *testing.T) {
 	h := newTestHome(t)
 
-	h.snapshotFetcher = func(string) ([]session.InstanceData, error) {
-		return nil, errors.New("connection refused")
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{}, errors.New("connection refused")
 	}
 
 	err := h.coldStartFromSnapshot()

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/task"
@@ -87,8 +88,8 @@ func newTestHome(t *testing.T) *home {
 		// regress this.) Tests exercising the fetch path assign their own fake to
 		// h.snapshotFetcher. The fetcher is a per-home field, not a shared global, so
 		// parallel tests can't race each other's swaps.
-		snapshotFetcher: func(string) ([]session.InstanceData, error) {
-			return nil, fmt.Errorf("snapshot fetcher not stubbed in test")
+		snapshotFetcher: func(string) (daemon.SnapshotResponse, error) {
+			return daemon.SnapshotResponse{}, fmt.Errorf("snapshot fetcher not stubbed in test")
 		},
 		// Default the #1160 poll-pause seams to no-ops so a test that incidentally
 		// drives the attach heartbeat never dials — or spawns — a real daemon.
@@ -116,6 +117,9 @@ func wireTestPanes(h *home, proj *store.Projection) {
 	}
 	if h.errBox == nil {
 		h.errBox = ui.NewErrBox()
+	}
+	if h.alarmBanner == nil {
+		h.alarmBanner = ui.NewAlarmBanner()
 	}
 	h.paneWindows = make(map[int]*ui.TabbedWindow)
 	h.lastPaneCapture = make(map[int]time.Time)

--- a/app/delivery_alarm_test.go
+++ b/app/delivery_alarm_test.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyDeliveryAlarms_RaisesAndClearsBanner drives the TUI half of #1238
+// fix (c): a snapshot that reports a persistent delivery failure raises the
+// top-of-screen alarm banner (reserving its own layout row and rendering the
+// target/pending detail into the composed View), and a later clean snapshot
+// clears it — the row disappears and the View shrinks back. This is the
+// signal that turns the 23-minute silent event-pipeline window into an alarm
+// visible without navigating.
+func TestApplyDeliveryAlarms_RaisesAndClearsBanner(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 120, 40)
+
+	// Healthy steady state: no banner, no reserved row.
+	require.False(t, h.alarmBanner.Active())
+	require.True(t, h.lastLayout.Banner.Empty(), "no row reserved while healthy")
+	baseView := h.View()
+	requireViewSized(t, baseView, 120, 40)
+	require.NotContains(t, baseView, "events not delivering")
+
+	// A snapshot reports events failing to reach "root" since 10:39.
+	since := time.Date(2026, 7, 5, 10, 39, 0, 0, time.Local)
+	changed := h.applyDeliveryAlarms([]daemon.DeliveryAlarm{{
+		TaskID:        "12e09daa",
+		TaskName:      "captain-events",
+		TargetSession: "root",
+		Pending:       5,
+		Consecutive:   14,
+		Since:         since,
+		LastError:     "root agent is being recreated",
+	}})
+	require.True(t, changed, "a newly-raised alarm is a visible change")
+	require.True(t, h.alarmBanner.Active(), "the banner must be active")
+	require.False(t, h.lastLayout.Banner.Empty(), "the alarm must reserve a layout row")
+
+	alarmView := h.View()
+	requireViewSized(t, alarmView, 120, 40)
+	require.Contains(t, alarmView, "events not delivering to \"root\"",
+		"the banner names the failing target")
+	require.Contains(t, alarmView, "5 pending", "the banner shows the stuck-event count")
+	require.Contains(t, alarmView, "10:39", "the banner shows since-when")
+	require.Contains(t, alarmView, "captain-events", "the banner names the task")
+
+	// Re-applying the same alarm set is not a visible change (no needless repaint).
+	require.False(t, h.applyDeliveryAlarms([]daemon.DeliveryAlarm{{
+		TaskID:        "12e09daa",
+		TaskName:      "captain-events",
+		TargetSession: "root",
+		Pending:       5,
+		Consecutive:   14,
+		Since:         since,
+		LastError:     "root agent is being recreated",
+	}}), "an unchanged alarm set reports no change")
+
+	// Delivery recovers: an empty alarm set clears the banner and its row.
+	require.True(t, h.applyDeliveryAlarms(nil), "clearing the alarm is a visible change")
+	require.False(t, h.alarmBanner.Active(), "the banner clears on recovery")
+	require.True(t, h.lastLayout.Banner.Empty(), "the reserved row is released")
+
+	clearedView := h.View()
+	requireViewSized(t, clearedView, 120, 40)
+	require.NotContains(t, clearedView, "events not delivering",
+		"the banner is gone once delivery recovers")
+	require.Equal(t, len(strings.Split(baseView, "\n")), len(strings.Split(clearedView, "\n")),
+		"the view returns to its pre-alarm height")
+}

--- a/app/render.go
+++ b/app/render.go
@@ -1,0 +1,61 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/sachiniyer/agent-factory/ui"
+)
+
+// View render helpers extracted from app.go (#1145): the overlay framing style
+// and the rail/divider rules the composed View draws. Behavior is unchanged —
+// this is a pure relocation to keep app.go under its length ceiling.
+
+// hooksOverlayStyle frames the hooks editor when it is hosted as an overlay
+// (#1024 PR 4: hooks lost their persistent sidebar slot).
+var hooksOverlayStyle = lipgloss.NewStyle().
+	Border(lipgloss.RoundedBorder()).
+	BorderForeground(ui.AccentColor).
+	Padding(1, 2)
+
+func (m *home) renderHooksOverlay() string {
+	return hooksOverlayStyle.Render(m.hooksPane.String())
+}
+
+// renderTasksOverlay frames the task manager (list + create/edit form) as the
+// centered modal it lives in (#1087 play-test): the manager needs real
+// width/height for its form, which the narrow left rail cannot provide.
+func (m *home) renderTasksOverlay() string {
+	return hooksOverlayStyle.Render(m.automations.TaskPane().String())
+}
+
+// splitDividerStyle recedes the 1-col dividers between panes so the focused
+// pane's frame stays the strongest line on screen.
+var splitDividerStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.AdaptiveColor{Light: "#DDDADA", Dark: "#3C3C3C"})
+
+// renderDivider renders the 1-col divider right of pane i (§2.6: "N panes
+// divide the workspace width evenly with 1-col dividers").
+func (m *home) renderDivider(i int) string {
+	if i < 0 || i >= len(m.lastLayout.Dividers) {
+		return ""
+	}
+	r := m.lastLayout.Dividers[i]
+	if r.Empty() {
+		return ""
+	}
+	col := strings.TrimSuffix(strings.Repeat("│\n", r.H), "\n")
+	return splitDividerStyle.Render(col)
+}
+
+// renderRailRule renders the full-rail-width horizontal rule separating the
+// instances tree from the bottom-aligned automations section (#1087), in the
+// same receded style as the split divider.
+func (m *home) renderRailRule() string {
+	r := m.lastLayout.RailRule
+	if r.Empty() {
+		return ""
+	}
+	return splitDividerStyle.Render(strings.Repeat("─", r.W))
+}

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -151,8 +151,8 @@ var setPRInfoThroughDaemon = func(title, repoID string, info session.PRInfoData)
 // goroutine, so a mutable global would race a test seam swap under
 // `go test -parallel`; the fetcher lives per-home instead, and tests assign a
 // fake to home.snapshotFetcher directly (#960 PR 4 race fix).
-func snapshotThroughDaemon(repoID string) ([]session.InstanceData, error) {
-	return daemon.Snapshot(daemon.SnapshotRequest{RepoID: repoID})
+func snapshotThroughDaemon(repoID string) (daemon.SnapshotResponse, error) {
+	return daemon.SnapshotWithAlarms(daemon.SnapshotRequest{RepoID: repoID})
 }
 
 // buildInstanceFromSnapshot materializes a live, tab-reconnected *session.Instance

--- a/app/snapshot_test.go
+++ b/app/snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -186,10 +187,10 @@ func TestFetchSnapshotCmd_UsesFetcherSeam(t *testing.T) {
 	}))
 
 	called := false
-	h.snapshotFetcher = func(repoID string) ([]session.InstanceData, error) {
+	h.snapshotFetcher = func(repoID string) (daemon.SnapshotResponse, error) {
 		called = true
 		require.Equal(t, h.repoID, repoID, "the snapshot fetch must be scoped to this repo")
-		return []session.InstanceData{{Title: "viaseam", CreatedAt: time.Now()}}, nil
+		return daemon.SnapshotResponse{Instances: []session.InstanceData{{Title: "viaseam", CreatedAt: time.Now()}}}, nil
 	}
 
 	msg := h.fetchSnapshotCmd()()

--- a/app/sync.go
+++ b/app/sync.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui"
 )
 
 // prInfoStaleAfter is how long a fetched PR info entry is considered fresh.
@@ -41,6 +42,11 @@ type snapshotFetchedMsg struct {
 	// disk task read still succeeds.
 	tasks    []task.Task
 	tasksErr error
+	// alarms carries any persistent watch-task delivery-failure alarms projected
+	// on the same daemon snapshot (#1238). It rides the session snapshot because
+	// it is a field of the one authoritative Snapshot response, not a separate
+	// subsystem; handleSnapshot mirrors it into the alarm banner state.
+	alarms []daemon.DeliveryAlarm
 }
 
 // prInfoUpdatedMsg is returned by an async PR info fetch.
@@ -95,13 +101,13 @@ func (m *home) fetchSnapshotCmd() tea.Cmd {
 	repoID := m.repoID
 	fetch := m.snapshotFetcher
 	return func() tea.Msg {
-		data, err := fetch(repoID)
+		resp, err := fetch(repoID)
 		// Re-read the repo's tasks on the same poll so an out-of-band task
 		// change live-projects into the TUI (#1168). Independent of the session
 		// snapshot: its own error is carried separately so a warming-daemon RPC
 		// failure never suppresses a successful disk task read.
 		tasks, tasksErr := task.LoadTasksForCurrentRepo()
-		return snapshotFetchedMsg{data: data, err: err, tasks: tasks, tasksErr: tasksErr}
+		return snapshotFetchedMsg{data: resp.Instances, alarms: resp.DeliveryAlarms, err: err, tasks: tasks, tasksErr: tasksErr}
 	}
 }
 
@@ -155,9 +161,9 @@ func (m *home) fetchColdStartSnapshot() ([]session.InstanceData, error) {
 	deadline := time.Now().Add(coldStartWarmupWait)
 	announced := false
 	for {
-		data, err := m.snapshotFetcher(m.repoID)
+		resp, err := m.snapshotFetcher(m.repoID)
 		if err == nil {
-			return data, nil
+			return resp.Instances, nil
 		}
 		if !daemon.IsDaemonStartingErr(err) {
 			return nil, err
@@ -251,7 +257,40 @@ func (m *home) handleSnapshot(msg snapshotFetchedMsg) bool {
 		log.WarningLog.Printf("failed to fetch daemon snapshot: %v", msg.err)
 		return false
 	}
-	return m.reconcileSnapshot(msg.data)
+	changed := m.reconcileSnapshot(msg.data)
+	if m.applyDeliveryAlarms(msg.alarms) {
+		changed = true
+	}
+	return changed
+}
+
+// applyDeliveryAlarms mirrors the snapshot's persistent delivery-failure alarms
+// (#1238) into the banner. Because the banner reserves a layout row exactly
+// when it is active, an active-state flip re-solves the grid so the row appears
+// or disappears with the alarm. Returns whether the visible alarm set changed
+// (the caller repaints on a diff). Only ever called on a successful snapshot:
+// a transient RPC error leaves the last-known alarm up rather than clearing a
+// real outage on a hiccup.
+func (m *home) applyDeliveryAlarms(alarms []daemon.DeliveryAlarm) bool {
+	var infos []ui.AlarmInfo
+	for _, a := range alarms {
+		infos = append(infos, ui.AlarmInfo{
+			TaskName: a.TaskName,
+			Target:   a.TargetSession,
+			Pending:  a.Pending,
+			Since:    a.Since,
+		})
+	}
+	// Leave infos nil (not an empty slice) when there are no alarms so the
+	// steady-state DeepEqual against a nil last-known set reports "no change".
+	wasActive := m.alarmBanner.Active()
+	changed := !reflect.DeepEqual(m.alarmBanner.Alarms(), infos)
+	m.alarmBanner.SetAlarms(infos)
+	if m.alarmBanner.Active() != wasActive {
+		// The reserved banner row appeared or vanished — re-rect every region.
+		m.relayout()
+	}
+	return changed
 }
 
 // refreshTasks mirrors an out-of-band tasks.json change (a CLI/daemon `af tasks

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -248,18 +248,9 @@ type ResumeStatusPollResponse struct {
 	OK bool `json:"ok"`
 }
 
-// SnapshotRequest asks the daemon for the authoritative session list of a repo
-// (#960 PR 3). RepoID scopes the read like the other sessions verbs (empty =
-// all repos). It is the read side of the single-writer model: the daemon's
-// in-memory instance map is the source of truth, so the TUI mirrors this
-// projection instead of re-reading instances.json off disk.
-type SnapshotRequest struct {
-	RepoID string `json:"repo_id"`
-}
-
-type SnapshotResponse struct {
-	Instances []session.InstanceData `json:"instances"`
-}
+// SnapshotRequest, SnapshotResponse, and the DeliveryAlarm projection live in
+// snapshot.go (extracted to keep control.go under its file-length ceiling,
+// #1145).
 
 type ImportRemoteHookSessionsRequest struct {
 	RepoPath string `json:"repo_path"`
@@ -492,18 +483,9 @@ func SetPRInfo(req SetPRInfoRequest) error {
 	return nil
 }
 
-// Snapshot asks the daemon for the authoritative session list of repoID (empty
-// = all repos). It is the TUI's read path under the single-writer model (#960
-// PR 3): the daemon owns session/tab state, so the TUI mirrors this projection
-// rather than re-reading instances.json. A warming daemon (#829) returns the
-// retryable starting error, which callDaemon already waits out.
-func Snapshot(req SnapshotRequest) ([]session.InstanceData, error) {
-	var resp SnapshotResponse
-	if err := callDaemon("Snapshot", req, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Instances, nil
-}
+// The TUI read path is SnapshotWithAlarms (snapshot.go): it carries the session
+// list plus the delivery-failure alarms in one authoritative response (#1238).
+// SnapshotNoSpawn below is the CLI's non-spawning, instances-only read.
 
 // ErrDaemonUnavailable signals that a non-spawning daemon read (SnapshotNoSpawn)
 // found no reachable, ready daemon: the control socket is absent/refused or the
@@ -1066,6 +1048,7 @@ func (s *controlServer) Snapshot(req SnapshotRequest, resp *SnapshotResponse) er
 		return err
 	}
 	resp.Instances = s.manager.Snapshot(req.RepoID)
+	resp.DeliveryAlarms = s.deliveryAlarms(req.RepoID)
 	return nil
 }
 

--- a/daemon/delivery_alarm.go
+++ b/daemon/delivery_alarm.go
@@ -1,0 +1,96 @@
+package daemon
+
+import (
+	"sort"
+	"time"
+)
+
+// Watch-task delivery-failure alarm state (#1238 fix c). The daemon tracks how
+// long each watch task's event delivery to its target session has been failing
+// and projects the persistent ones into the Snapshot (see snapshot.go) so the
+// TUI can raise a banner — turning the 2026-07-05 silent, log-only outage into
+// an alarm visible within a bounded window. The per-watcher failure fields live
+// on taskWatcher (watcher.go); this file owns the threshold, the per-attempt
+// bookkeeping, and the snapshot assembly.
+
+// watcherDeliveryAlarmThreshold is how long a watch task's event delivery must
+// have been failing before the daemon raises a TUI-visible alarm for it. It
+// sits just past the #1237 root self-heal window (rootKillHealDelay, 2m): a
+// normal root kill self-heals and delivery recovers — clearing deliverFailSince
+// — before the threshold, so the routine ~2m recovery never false-alarms. A
+// failure that persists materially past that window (target permanently gone,
+// tmux server dead, or a misconfigured target) crosses the threshold and
+// alarms. On the rare boundary where a heal lands late in the drain backoff
+// cycle, the alarm may show briefly and then auto-clear on recovery — honest,
+// since delivery genuinely was down past the threshold. A var so tests can
+// shrink it and exercise the threshold without real waits.
+var watcherDeliveryAlarmThreshold = 3 * time.Minute
+
+// recordDeliveryResult folds one delivery attempt's outcome into the watcher's
+// alarm state. A failure starts (or extends) the consecutive-failure run —
+// stamping deliverFailSince on the first failure so the alarm can measure how
+// long the pipeline has been down — and records the error. A success clears the
+// run, which is what makes the TUI banner disappear the instant delivery
+// recovers. Called after every deliver attempt on both the live path
+// (handleEvent) and the replay path (drainLoop).
+func (w *taskWatcher) recordDeliveryResult(now time.Time, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err == nil {
+		w.deliverFailSince = time.Time{}
+		w.deliverFailCount = 0
+		w.deliverFailErr = ""
+		return
+	}
+	if w.deliverFailSince.IsZero() {
+		w.deliverFailSince = now
+	}
+	w.deliverFailCount++
+	w.deliverFailErr = err.Error()
+}
+
+// deliveryAlarms returns the persistent delivery-failure alarms across watch
+// tasks whose repo matches repoID (empty = all repos), evaluated against now.
+// A task alarms only once its consecutive delivery failures have persisted for
+// at least watcherDeliveryAlarmThreshold — long enough that a normal root
+// self-heal (#1237, ~2m) would have cleared, so the routine recovery window
+// never false-alarms. The pending count is the queue's undelivered backlog, so
+// the banner can say how many events are stuck.
+func (s *watcherSupervisor) deliveryAlarms(repoID string, now time.Time) []DeliveryAlarm {
+	s.mu.Lock()
+	ws := make([]*taskWatcher, 0, len(s.watchers))
+	for _, w := range s.watchers {
+		ws = append(ws, w)
+	}
+	s.mu.Unlock()
+
+	var alarms []DeliveryAlarm
+	for _, w := range ws {
+		if repoID != "" && w.repoID != repoID {
+			continue
+		}
+		w.mu.Lock()
+		since := w.deliverFailSince
+		count := w.deliverFailCount
+		lastErr := w.deliverFailErr
+		w.mu.Unlock()
+		if since.IsZero() || now.Sub(since) < watcherDeliveryAlarmThreshold {
+			continue
+		}
+		pending := 0
+		if w.queue != nil {
+			pending = w.queue.pendingCount()
+		}
+		alarms = append(alarms, DeliveryAlarm{
+			TaskID:        w.taskID,
+			TaskName:      w.name,
+			TargetSession: w.targetSession,
+			Pending:       pending,
+			Consecutive:   count,
+			Since:         since,
+			LastError:     lastErr,
+		})
+	}
+	sort.Slice(alarms, func(i, j int) bool { return alarms[i].TaskID < alarms[j].TaskID })
+	return alarms
+}

--- a/daemon/delivery_alarm_test.go
+++ b/daemon/delivery_alarm_test.go
@@ -1,0 +1,142 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/require"
+)
+
+// registerFailingWatcher inserts a taskWatcher directly into the supervisor's
+// map with a preset delivery-failure state, bypassing newTaskWatcher (which
+// would run config.RepoFromPath against a non-repo temp dir). It lets these
+// tests exercise deliveryAlarms deterministically without spawning scripts.
+func registerFailingWatcher(s *watcherSupervisor, id, repoID, target string, since time.Time, count int, lastErr string) *taskWatcher {
+	w := &taskWatcher{
+		taskID:        id,
+		name:          "watch-" + id,
+		repoID:        repoID,
+		targetSession: target,
+	}
+	w.deliverFailSince = since
+	w.deliverFailCount = count
+	w.deliverFailErr = lastErr
+	s.mu.Lock()
+	s.watchers[id] = w
+	s.mu.Unlock()
+	return w
+}
+
+// TestDeliveryAlarms_ThresholdScopingAndClear covers the daemon projection at
+// the heart of #1238 fix (c): a delivery-failure alarm is raised only once the
+// failure has persisted past watcherDeliveryAlarmThreshold (so a normal ~2m
+// self-heal never false-alarms), is scoped to the requesting repo, carries the
+// target/pending/consecutive/error detail the banner needs, and clears the
+// instant delivery succeeds.
+func TestDeliveryAlarms_ThresholdScopingAndClear(t *testing.T) {
+	s := newWatcherSupervisor()
+	now := time.Now()
+
+	// A failure younger than the threshold — the routine self-heal window —
+	// must NOT alarm. This is the false-alarm guard.
+	registerFailingWatcher(s, "recent", "repo1", "root",
+		now.Add(-watcherDeliveryAlarmThreshold/2), 3, "momentary")
+	require.Empty(t, s.deliveryAlarms("repo1", now),
+		"a sub-threshold failure must not alarm (self-heal window)")
+
+	// A failure aged past the threshold IS a genuine outage → alarm, with the
+	// full detail the TUI banner renders.
+	since := now.Add(-watcherDeliveryAlarmThreshold - time.Minute)
+	w := registerFailingWatcher(s, "stale", "repo1", "root", since, 7, "target session down")
+
+	// Back the stale watcher with a real queue so Pending reflects the backlog.
+	queueDir := t.TempDir()
+	w.queue = newEventQueue(queueDir, "stale")
+	for i := 0; i < 5; i++ {
+		require.NoError(t, w.queue.enqueue("event"))
+	}
+
+	alarms := s.deliveryAlarms("repo1", now)
+	require.Len(t, alarms, 1, "a past-threshold failure must alarm")
+	got := alarms[0]
+	require.Equal(t, "stale", got.TaskID)
+	require.Equal(t, "watch-stale", got.TaskName)
+	require.Equal(t, "root", got.TargetSession)
+	require.Equal(t, 7, got.Consecutive)
+	require.Equal(t, 5, got.Pending, "Pending must surface the queued backlog")
+	require.Equal(t, since, got.Since)
+	require.Equal(t, "target session down", got.LastError)
+
+	// Repo scoping: a failing watcher in another repo is invisible to repo1's
+	// snapshot, but the all-repos read (empty repoID) sees both.
+	registerFailingWatcher(s, "otherrepo", "repo2", "root",
+		now.Add(-watcherDeliveryAlarmThreshold-time.Minute), 4, "x")
+	require.Len(t, s.deliveryAlarms("repo1", now), 1, "another repo's alarm must not leak into repo1")
+	require.Len(t, s.deliveryAlarms("", now), 2, "the all-repos read sees every failing target")
+
+	// Recovery clears the alarm the moment a delivery succeeds.
+	w.recordDeliveryResult(now, nil)
+	require.Empty(t, s.deliveryAlarms("repo1", now),
+		"a successful delivery must clear the alarm")
+}
+
+// TestRecordDeliveryResult_FailureRunLifecycle pins the failure-run bookkeeping
+// recordDeliveryResult maintains: the first failure stamps deliverFailSince,
+// subsequent failures extend the same run (since unchanged, count climbs, error
+// refreshed), and one success zeroes the whole run so a later failure starts a
+// fresh window.
+func TestRecordDeliveryResult_FailureRunLifecycle(t *testing.T) {
+	w := &taskWatcher{taskID: "aaaa", name: "watch-aaaa"}
+	t0 := time.Now()
+
+	w.recordDeliveryResult(t0, errors.New("first"))
+	require.Equal(t, t0, w.deliverFailSince, "first failure stamps the run start")
+	require.Equal(t, 1, w.deliverFailCount)
+	require.Equal(t, "first", w.deliverFailErr)
+
+	w.recordDeliveryResult(t0.Add(time.Minute), errors.New("second"))
+	require.Equal(t, t0, w.deliverFailSince, "a continuing failure keeps the original run start")
+	require.Equal(t, 2, w.deliverFailCount)
+	require.Equal(t, "second", w.deliverFailErr, "the latest error is retained")
+
+	w.recordDeliveryResult(t0.Add(2*time.Minute), nil)
+	require.True(t, w.deliverFailSince.IsZero(), "a success clears the run start")
+	require.Equal(t, 0, w.deliverFailCount)
+	require.Empty(t, w.deliverFailErr)
+
+	// A later failure opens a brand-new window at its own timestamp.
+	t1 := t0.Add(10 * time.Minute)
+	w.recordDeliveryResult(t1, errors.New("again"))
+	require.Equal(t, t1, w.deliverFailSince)
+	require.Equal(t, 1, w.deliverFailCount)
+}
+
+// TestControlServerSnapshot_ProjectsDeliveryAlarms proves the alarm rides the
+// authoritative Snapshot RPC — a field on the response, not a side channel
+// (#1238): the controlServer folds the supervisor's persistent delivery
+// failures into resp.DeliveryAlarms, scoped to the request's repo.
+func TestControlServerSnapshot_ProjectsDeliveryAlarms(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	m, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+	s := newWatcherSupervisor()
+	cs := &controlServer{manager: m, watchers: s}
+
+	repoID := config.RepoIDFromRoot("/tmp/alarm-repo")
+
+	// Healthy steady state: the snapshot carries no alarms.
+	var resp SnapshotResponse
+	require.NoError(t, cs.Snapshot(SnapshotRequest{RepoID: repoID}, &resp))
+	require.Empty(t, resp.DeliveryAlarms, "no alarms when nothing is failing")
+
+	// A past-threshold failing watcher surfaces on the response for its repo.
+	registerFailingWatcher(s, "stale", repoID, "root",
+		time.Now().Add(-watcherDeliveryAlarmThreshold-time.Minute), 9, "target down")
+	resp = SnapshotResponse{}
+	require.NoError(t, cs.Snapshot(SnapshotRequest{RepoID: repoID}, &resp))
+	require.Len(t, resp.DeliveryAlarms, 1, "the persistent failure must project onto the snapshot")
+	require.Equal(t, "root", resp.DeliveryAlarms[0].TargetSession)
+	require.Equal(t, 9, resp.DeliveryAlarms[0].Consecutive)
+}

--- a/daemon/snapshot.go
+++ b/daemon/snapshot.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// Snapshot RPC types and the delivery-failure alarm projection (#960 PR 3,
+// #1238). Extracted from control.go so that file stays under its length ceiling
+// (#1145). The client entry points (Snapshot / SnapshotNoSpawn / SnapshotWithAlarms)
+// and the controlServer.Snapshot handler live in control.go alongside the other
+// RPCs; this file owns the wire shapes and the alarm assembly.
+
+// SnapshotRequest asks the daemon for the authoritative session list of a repo
+// (#960 PR 3). RepoID scopes the read like the other sessions verbs (empty =
+// all repos). It is the read side of the single-writer model: the daemon's
+// in-memory instance map is the source of truth, so the TUI mirrors this
+// projection instead of re-reading instances.json off disk.
+type SnapshotRequest struct {
+	RepoID string `json:"repo_id"`
+}
+
+type SnapshotResponse struct {
+	Instances []session.InstanceData `json:"instances"`
+	// DeliveryAlarms projects persistent watch-task delivery failures into the
+	// authoritative snapshot the TUI mirrors (#1238). When a watch task's events
+	// have been failing to reach their target session for longer than the alarm
+	// threshold — the 2026-07-05 silent event-pipeline outage — the daemon lists
+	// them here so the TUI can raise a banner instead of the failure being
+	// visible only in the daemon log. Empty (omitted) in the healthy steady
+	// state, and additive/gob- and JSON-compatible with older peers that ignore
+	// the field.
+	DeliveryAlarms []DeliveryAlarm `json:"delivery_alarms,omitempty"`
+}
+
+// DeliveryAlarm is one watch task whose event delivery to TargetSession has
+// been failing persistently (past watcherDeliveryAlarmThreshold). It carries
+// what the TUI banner needs — the target, how many events are stuck, when the
+// failures began, and the last error — so an operator sees a dead delivery
+// pipeline within the threshold window instead of discovering it by accident
+// (#1238 fix c).
+type DeliveryAlarm struct {
+	TaskID        string `json:"task_id"`
+	TaskName      string `json:"task_name"`
+	TargetSession string `json:"target_session"`
+	// Pending is the number of undelivered events queued behind the failure.
+	Pending int `json:"pending"`
+	// Consecutive is the count of back-to-back failed delivery attempts.
+	Consecutive int `json:"consecutive"`
+	// Since is when the current run of failures began (first consecutive
+	// failure); the TUI renders "since HH:MM".
+	Since time.Time `json:"since"`
+	// LastError is the most recent delivery error, for the banner detail.
+	LastError string `json:"last_error,omitempty"`
+}
+
+// SnapshotWithAlarms is Snapshot plus the persistent delivery-failure alarms
+// carried on the same authoritative response (#1238). The TUI reconcile path
+// uses it so the session list and the alarm projection arrive from one RPC —
+// the alarm is a field on the snapshot, not a side channel. Plain Snapshot
+// (which drops the alarms) stays the read path for CLI/API callers that only
+// need the session list.
+func SnapshotWithAlarms(req SnapshotRequest) (SnapshotResponse, error) {
+	var resp SnapshotResponse
+	if err := callDaemon("Snapshot", req, &resp); err != nil {
+		return SnapshotResponse{}, err
+	}
+	return resp, nil
+}
+
+// deliveryAlarms assembles the persistent delivery-failure alarms for a repo
+// (empty = all repos) from the watcher supervisor, evaluated against the
+// current time. Nil when there is no supervisor or nothing is failing.
+func (s *controlServer) deliveryAlarms(repoID string) []DeliveryAlarm {
+	if s.watchers == nil {
+		return nil
+	}
+	return s.watchers.deliveryAlarms(repoID, time.Now())
+}

--- a/daemon/tailbuffer.go
+++ b/daemon/tailbuffer.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"strings"
+	"sync"
+)
+
+// tailBuffer is a small bounded ring of one script run's most recent output
+// lines — stdout lines that did not become delivered events, plus stderr —
+// kept so a failing run's log line can show WHY the script died instead of a
+// bare exit status (#797). Bounded to watcherTailMaxLines lines and
+// watcherTailMaxBytes total bytes, always retaining at least the newest line.
+// Extracted from watcher.go to keep that file under its length ceiling (#1145).
+type tailBuffer struct {
+	mu    sync.Mutex
+	lines []string
+	size  int
+}
+
+// add records one output line, trimming the line terminator and capping the
+// line at watcherTailMaxBytes. Blank lines are skipped — they carry no
+// diagnostics and would evict lines that do.
+func (b *tailBuffer) add(line string) {
+	line = strings.TrimRight(line, "\r\n")
+	if strings.TrimSpace(line) == "" {
+		return
+	}
+	if len(line) > watcherTailMaxBytes {
+		line = truncateRunes(line, watcherTailMaxBytes)
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.lines = append(b.lines, line)
+	b.size += len(line)
+	for len(b.lines) > 1 && (len(b.lines) > watcherTailMaxLines || b.size > watcherTailMaxBytes) {
+		b.size -= len(b.lines[0])
+		b.lines = b.lines[1:]
+	}
+}
+
+// logSuffix renders the buffered output for appending to a failure log line:
+// "; last output:" plus one indented line each, or "" when the run produced
+// nothing to show (so failure logs never grow an empty trailer).
+func (b *tailBuffer) logSuffix() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.lines) == 0 {
+		return ""
+	}
+	return "; last output:\n  " + strings.Join(b.lines, "\n  ")
+}
+
+// firstLine returns the oldest buffered line — usually the script's initial
+// complaint — for the persisted status summary.
+func (b *tailBuffer) firstLine() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.lines) == 0 {
+		return ""
+	}
+	return b.lines[0]
+}
+
+// failureSummary builds the status the crash-loop breaker persists:
+// "errored: <exit error>: <first buffered line>", capped at
+// watcherStatusSummaryMax. The "errored" prefix is what the TUI keys the
+// supervision state off (ui.watchTaskStatus), so it must come first.
+func failureSummary(runErr error, tail *tailBuffer) string {
+	summary := "errored: " + runErr.Error()
+	if first := tail.firstLine(); first != "" {
+		summary += ": " + first
+	}
+	if len(summary) > watcherStatusSummaryMax {
+		summary = truncateRunes(summary, watcherStatusSummaryMax) + "…"
+	}
+	return summary
+}

--- a/daemon/watcher.go
+++ b/daemon/watcher.go
@@ -287,14 +287,24 @@ func (s *watcherSupervisor) droppedEvents(taskID string) int {
 
 func (s *watcherSupervisor) newTaskWatcher(t task.Task) *taskWatcher {
 	w := &taskWatcher{
-		taskID: t.ID,
-		name:   t.Name,
-		cmdStr: t.WatchCmd,
-		dir:    t.ProjectPath,
-		sig:    watcherSignature(t),
-		sup:    s,
-		stopCh: make(chan struct{}),
-		doneCh: make(chan struct{}),
+		taskID:        t.ID,
+		name:          t.Name,
+		cmdStr:        t.WatchCmd,
+		dir:           t.ProjectPath,
+		sig:           watcherSignature(t),
+		targetSession: t.TargetSession,
+		sup:           s,
+		stopCh:        make(chan struct{}),
+		doneCh:        make(chan struct{}),
+	}
+	// Resolve the repo the task belongs to so a delivery alarm can be scoped to
+	// the right repo's snapshot (#1238). A resolution failure only costs the
+	// alarm its repo scope — it never disables the watcher — so it is logged and
+	// left empty rather than propagated.
+	if repo, err := config.RepoFromPath(t.ProjectPath); err != nil {
+		log.WarningLog.Printf("watch task %s: cannot resolve repo for delivery-alarm scope: %v", t.ID, err)
+	} else {
+		w.repoID = repo.ID
 	}
 	// Recover any backlog a previous watcher/daemon left behind (#1129); the
 	// run loop starts the drainer if the queue is non-empty. A queue-dir
@@ -325,75 +335,8 @@ func stopWatchers(ws []*taskWatcher) {
 	wg.Wait()
 }
 
-// tailBuffer is a small bounded ring of one script run's most recent output
-// lines — stdout lines that did not become delivered events, plus stderr —
-// kept so a failing run's log line can show WHY the script died instead of a
-// bare exit status (#797). Bounded to watcherTailMaxLines lines and
-// watcherTailMaxBytes total bytes, always retaining at least the newest line.
-type tailBuffer struct {
-	mu    sync.Mutex
-	lines []string
-	size  int
-}
-
-// add records one output line, trimming the line terminator and capping the
-// line at watcherTailMaxBytes. Blank lines are skipped — they carry no
-// diagnostics and would evict lines that do.
-func (b *tailBuffer) add(line string) {
-	line = strings.TrimRight(line, "\r\n")
-	if strings.TrimSpace(line) == "" {
-		return
-	}
-	if len(line) > watcherTailMaxBytes {
-		line = truncateRunes(line, watcherTailMaxBytes)
-	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.lines = append(b.lines, line)
-	b.size += len(line)
-	for len(b.lines) > 1 && (len(b.lines) > watcherTailMaxLines || b.size > watcherTailMaxBytes) {
-		b.size -= len(b.lines[0])
-		b.lines = b.lines[1:]
-	}
-}
-
-// logSuffix renders the buffered output for appending to a failure log line:
-// "; last output:" plus one indented line each, or "" when the run produced
-// nothing to show (so failure logs never grow an empty trailer).
-func (b *tailBuffer) logSuffix() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if len(b.lines) == 0 {
-		return ""
-	}
-	return "; last output:\n  " + strings.Join(b.lines, "\n  ")
-}
-
-// firstLine returns the oldest buffered line — usually the script's initial
-// complaint — for the persisted status summary.
-func (b *tailBuffer) firstLine() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if len(b.lines) == 0 {
-		return ""
-	}
-	return b.lines[0]
-}
-
-// failureSummary builds the status the crash-loop breaker persists:
-// "errored: <exit error>: <first buffered line>", capped at
-// watcherStatusSummaryMax. The "errored" prefix is what the TUI keys the
-// supervision state off (ui.watchTaskStatus), so it must come first.
-func failureSummary(runErr error, tail *tailBuffer) string {
-	summary := "errored: " + runErr.Error()
-	if first := tail.firstLine(); first != "" {
-		summary += ": " + first
-	}
-	if len(summary) > watcherStatusSummaryMax {
-		summary = truncateRunes(summary, watcherStatusSummaryMax) + "…"
-	}
-	return summary
-}
+// tailBuffer and its failure-summary helpers live in tailbuffer.go (extracted
+// to keep watcher.go under its file-length ceiling, #1145).
 
 // taskWatcher supervises one watch task: it restarts the script with backoff
 // on failure and feeds its stdout lines to the supervisor's deliver hook.
@@ -406,6 +349,15 @@ type taskWatcher struct {
 	cmdStr string
 	dir    string
 	sig    string
+	// repoID/targetSession are captured at construction to label a delivery
+	// alarm (#1238) without disk I/O on the snapshot hot path. repoID scopes
+	// the alarm to a repo's snapshot; targetSession names where events are
+	// failing to land (e.g. "root"). Both come from the task's delivery fields,
+	// which are not part of the watcher signature — a target_session edit is
+	// picked up by deliverWatchEvent's per-event reload, so a stale label here
+	// is at worst momentary and never affects delivery itself.
+	repoID        string
+	targetSession string
 
 	sup *watcherSupervisor
 
@@ -428,6 +380,16 @@ type taskWatcher struct {
 	// draining marks a live drainLoop goroutine, so at most one drains the
 	// queue at a time and replay order is preserved.
 	draining bool
+
+	// Delivery-failure alarm state (#1238), guarded by mu. deliverFailSince is
+	// the start of the current run of consecutive failed deliveries (zero when
+	// the last delivery succeeded); deliverFailCount is how many back-to-back
+	// attempts have failed; deliverFailErr is the most recent delivery error.
+	// A single success clears all three, so a task in the map with a non-zero
+	// deliverFailSince is exactly one whose pipeline is currently down.
+	deliverFailSince time.Time
+	deliverFailCount int
+	deliverFailErr   string
 }
 
 // stop requests termination and blocks until the run goroutine returns. The
@@ -821,7 +783,9 @@ func (w *taskWatcher) handleEvent(line string, tail *tailBuffer) {
 		return
 	}
 
-	if err := w.sup.deliver(w.taskID, line); err != nil {
+	err := w.sup.deliver(w.taskID, line)
+	w.recordDeliveryResult(time.Now(), err)
+	if err != nil {
 		log.ErrorLog.Printf("watch task %s: failed to deliver event: %v", w.taskID, err)
 		w.enqueueEvent(line, tail)
 	}
@@ -958,6 +922,7 @@ func (w *taskWatcher) drainLoop() {
 			continue
 		}
 		if err := w.sup.deliver(w.taskID, ev.Line); err != nil {
+			w.recordDeliveryResult(time.Now(), err)
 			log.WarningLog.Printf("watch task %s: replay delivery failed (%d event(s) pending); retrying in %s: %v", w.taskID, w.queue.pendingCount(), backoff, err)
 			if !w.sleepStopAware(backoff) {
 				w.stopDraining()
@@ -969,6 +934,7 @@ func (w *taskWatcher) drainLoop() {
 			}
 			continue
 		}
+		w.recordDeliveryResult(time.Now(), nil)
 		if err := w.queue.advance(n); err != nil {
 			log.ErrorLog.Printf("watch task %s: failed to advance the event queue; replay parked until the next reload: %v", w.taskID, err)
 			w.stopDraining()

--- a/scripts/file-length-allowlist.txt
+++ b/scripts/file-length-allowlist.txt
@@ -17,13 +17,13 @@
 # be split, not grandfathered.
 
 # --- production code (limit 1000) ---
-daemon/control.go 2604
-app/app.go 1889
+daemon/control.go 2587
+app/app.go 1867
 session/instance.go 1531
 session/tmux/tmux.go 1424
 ui/sidebar.go 1258
 config/config.go 1128
-daemon/watcher.go 1046
+daemon/watcher.go 1011
 session/backend_hook.go 1026
 
 # --- test code (limit 1500) ---

--- a/ui/alarm.go
+++ b/ui/alarm.go
@@ -1,0 +1,83 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+)
+
+// AlarmInfo is one delivery-failure alarm's display data. The app maps it from
+// the daemon snapshot's DeliveryAlarm (#1238) so the ui package needs no daemon
+// dependency.
+type AlarmInfo struct {
+	TaskName string
+	Target   string
+	Pending  int
+	Since    time.Time
+}
+
+// AlarmBanner is the persistent top-of-screen alarm shown while one or more
+// watch tasks have been failing to deliver events to their target session
+// (#1238 fix c). It is deliberately impossible to miss — a full-width red bar
+// stacked above everything else — so a silently dead delivery pipeline (the
+// 2026-07-05 outage was visible only in the daemon log for ~23 minutes)
+// becomes visible without navigating. Empty alarm set = inactive = renders
+// nothing and reserves no row.
+type AlarmBanner struct {
+	rect   layout.Rect
+	alarms []AlarmInfo
+}
+
+// alarmStyle is a loud white-on-red bar. Red reads as an alert in both light
+// and dark terminals, so it is a fixed color rather than adaptive — the whole
+// point is that it stands apart from every normal surface.
+var alarmStyle = lipgloss.NewStyle().
+	Background(lipgloss.Color("#B00020")).
+	Foreground(lipgloss.Color("#FFFFFF")).
+	Bold(true)
+
+func NewAlarmBanner() *AlarmBanner { return &AlarmBanner{} }
+
+// SetAlarms replaces the banner's alarm set.
+func (b *AlarmBanner) SetAlarms(alarms []AlarmInfo) { b.alarms = alarms }
+
+// Alarms returns the current alarm set (for change detection).
+func (b *AlarmBanner) Alarms() []AlarmInfo { return b.alarms }
+
+// Active reports whether any alarm is raised. The app reserves the banner row
+// in the grid exactly when this is true.
+func (b *AlarmBanner) Active() bool { return len(b.alarms) > 0 }
+
+// SetRect places the banner. Height is honored from the reserved grid rect.
+func (b *AlarmBanner) SetRect(r layout.Rect) { b.rect = r }
+
+// View renders the banner to its rect, or "" when inactive or unsized. With
+// multiple failing tasks it names the first and counts the rest, keeping the
+// bar to a single line.
+func (b *AlarmBanner) View() string {
+	if !b.Active() || b.rect.Empty() {
+		return ""
+	}
+	a := b.alarms[0]
+	target := a.Target
+	if target == "" {
+		// A task with no target_session creates a fresh session per event, so
+		// there is no named target — describe it rather than print an empty "".
+		target = "a new session per event"
+	}
+	msg := fmt.Sprintf("⚠ events not delivering to %q — %d pending since %s (task: %s)",
+		target, a.Pending, a.Since.Format("15:04"), a.TaskName)
+	if extra := len(b.alarms) - 1; extra > 0 {
+		msg += fmt.Sprintf("  (+%d more)", extra)
+	}
+	if runewidth.StringWidth(msg) > b.rect.W {
+		msg = runewidth.Truncate(msg, b.rect.W, "…")
+	}
+	line := alarmStyle.Width(b.rect.W).Render(msg)
+	return layout.ClampToRect(strings.TrimRight(line, "\n"), b.rect)
+}

--- a/ui/layout/grid.go
+++ b/ui/layout/grid.go
@@ -41,6 +41,12 @@ const (
 	// StatusBarRows is the fixed status-bar height.
 	StatusBarRows = 2
 
+	// AlarmBarRows is the height of the delivery-failure alarm banner (#1238),
+	// reserved at the very top of the screen only when Grid.Banner is set. One
+	// loud full-width row above everything so a dead delivery pipeline can't be
+	// missed.
+	AlarmBarRows = 1
+
 	// RailRuleRows is the horizontal rule separating the instances tree from
 	// the automations section inside the left rail (#1087).
 	RailRuleRows = 1
@@ -97,6 +103,12 @@ type Grid struct {
 	// a scrollable strip when the tree + automations together can't fit
 	// (#1126); zero keeps the section at its AutomationsRows floor.
 	Automations int
+
+	// Banner reserves the top-of-screen delivery-failure alarm row (#1238) when
+	// set. It is cut before every other region so the alarm sits above the rail,
+	// workspace, and status bar, and it survives the degradation ladder — an
+	// active outage alarm shows even in minimal mode.
+	Banner bool
 }
 
 // Layout is a solved arrangement: the named region rects plus which regions
@@ -127,6 +139,9 @@ type Layout struct {
 	RailRule    Rect
 	Automations Rect
 	StatusBar   Rect
+	// Banner is the top-of-screen delivery-failure alarm row (#1238), non-empty
+	// exactly when Grid.Banner was set and the layout is not a fallback.
+	Banner Rect
 
 	// MaxPanes is how many panes fit at this size (§2.6 pane-count fitting):
 	// always at least 1 outside fallback. The caller auto-hides
@@ -153,7 +168,16 @@ func (g Grid) Solve(width, height int) Layout {
 
 	minimal := width < MinimalWidth || height < MinimalHeight
 
-	rem, statusBar := Rect{X: 0, Y: 0, W: width, H: height}.CutBottom(StatusBarRows)
+	// Reserve the alarm banner at the very top first, so every other region's
+	// absolute Y is shifted down by CutTop and click zones stay accurate. It
+	// is cut regardless of minimal mode — a delivery-failure alarm must survive
+	// a cramped terminal (#1238).
+	full := Rect{X: 0, Y: 0, W: width, H: height}
+	if g.Banner {
+		l.Banner, full = full.CutTop(AlarmBarRows)
+	}
+
+	rem, statusBar := full.CutBottom(StatusBarRows)
 	l.StatusBar = statusBar
 
 	// The left rail and the workspace both run the full height above the

--- a/ui/layout/grid_test.go
+++ b/ui/layout/grid_test.go
@@ -276,6 +276,51 @@ func TestGridSolveStatusBarFixedHeight(t *testing.T) {
 	}
 }
 
+// TestGridSolveBannerReservesTopRow pins the delivery-failure alarm banner
+// reservation (#1238): with Grid.Banner set, a full-width AlarmBarRows band is
+// cut from the very top, every other region shifts below it, and the banner
+// plus the visible regions still tile the screen exactly. Without Banner the
+// rect is empty and nothing is reserved.
+func TestGridSolveBannerReservesTopRow(t *testing.T) {
+	for _, size := range [][2]int{{40, 10}, {59, 14}, {80, 24}, {200, 60}} {
+		w, h := size[0], size[1]
+
+		// No banner requested → no row reserved.
+		off := layout.Grid{Panes: 2}.Solve(w, h)
+		require.True(t, off.Banner.Empty(), "no banner row without Grid.Banner at %v", size)
+
+		on := layout.Grid{Panes: 2, Banner: true}.Solve(w, h)
+		require.False(t, on.Fallback)
+		require.Equal(t, layout.Rect{X: 0, Y: 0, W: w, H: layout.AlarmBarRows}, on.Banner,
+			"banner is a full-width top band at %v", size)
+
+		// Every other region sits strictly below the banner.
+		visible := on.VisibleRegions()
+		parts := make([]layout.Rect, 0, len(visible)+1)
+		for id, r := range visible {
+			assert.GreaterOrEqual(t, r.Y, layout.AlarmBarRows,
+				"region %s must sit below the banner at %v", id, size)
+			parts = append(parts, r)
+		}
+		// The banner is passive (not in VisibleRegions); include it to prove the
+		// banner + regions still tile the whole screen with no gap or overlap.
+		parts = append(parts, on.Banner)
+		requireTiles(t, layout.Rect{X: 0, Y: 0, W: w, H: h}, parts)
+	}
+}
+
+// TestGridSolveBannerSurvivesMinimalMode proves an active outage alarm is
+// reserved even in minimal mode — a cramped terminal must not hide it (#1238).
+func TestGridSolveBannerSurvivesMinimalMode(t *testing.T) {
+	// Just inside minimal (below MinimalWidth) but above the hard minimum.
+	w, h := layout.MinimalWidth-1, layout.MinimalHeight
+	l := layout.Grid{Panes: 2, Banner: true}.Solve(w, h)
+	require.False(t, l.Fallback)
+	require.False(t, l.AutomationsVisible, "sanity: this size is minimal mode")
+	require.Equal(t, layout.AlarmBarRows, l.Banner.H, "the banner is reserved in minimal mode too")
+	require.Equal(t, 0, l.Banner.Y)
+}
+
 // TestGridSolveLadderMonotonic shrinks each axis one cell at a time and
 // asserts the degradation level never decreases: shrinking can never
 // re-enable a richer mode.


### PR DESCRIPTION
## #1238 fix (c) — a TUI-visible alarm for a persistently-failing delivery target

The last open part of #1238. Fixes (a) [#1242] and (d) [#1243] are merged; this
is the defense-in-depth for the **2026-07-05 silent event-pipeline outage**:
when `root` (or any target) is down, watch-task delivery to it fails and events
pile up — and today that was visible **only in the daemon log** (~23 minutes of
silent WARNING-level drops before anyone noticed). This turns that silent window
into a **prominent, persistent TUI banner** visible without navigating.

### Design

**1. Daemon — the source of truth.** Each `taskWatcher` now tracks its
consecutive delivery-failure run: `deliverFailSince` (start of the current run),
`deliverFailCount`, `deliverFailErr`. `recordDeliveryResult` folds every delivery
attempt's outcome in — on both the **live** path (`handleEvent`) and the **replay**
path (`drainLoop`, the loop that today logs `replay delivery failed (N pending);
retrying in <backoff>` and nothing else). One success clears the run.

**2. Projected onto the Snapshot — a field, not a side channel.** A new
`DeliveryAlarm` list on the `SnapshotResponse` the TUI already mirrors:

```go
type DeliveryAlarm struct {
    TaskID, TaskName, TargetSession string
    Pending      int       // undelivered events queued behind the failure
    Consecutive  int       // back-to-back failed attempts
    Since        time.Time // first failure of the current run
    LastError    string
}

type SnapshotResponse struct {
    Instances      []session.InstanceData `json:"instances"`
    DeliveryAlarms []DeliveryAlarm        `json:"delivery_alarms,omitempty"` // NEW
}
```

`watcherSupervisor.deliveryAlarms(repoID, now)` returns only the tasks whose
failures have persisted past the threshold, repo-scoped. `omitempty` +
gob/JSON-additive, so it's version-skew safe. The TUI fetch (`SnapshotWithAlarms`)
carries alarms and the session list in **one** authoritative RPC.

**3. TUI — the alarm.** `applyDeliveryAlarms` mirrors the projection into a
full-width red `AlarmBanner` reserved at the very top of the layout grid
(`Grid.Banner` → a 1-row `CutTop` above the rail/workspace/status bar, surviving
minimal mode). It renders, e.g.:

> ⚠ events not delivering to "root" — 5 pending since 10:39 (task: captain-events)

It is impossible to miss and **clears the instant** the snapshot reports delivery
recovered (the reserved row is released and the layout re-solves).

### False-alarm threshold decision

**`watcherDeliveryAlarmThreshold = 3m`** — a package var (test-injectable). It sits
just past the **#1237 root self-heal window** (`rootKillHealDelay`, 2m): a normal
root kill self-heals and delivery recovers — clearing `deliverFailSince` — before
3m, so the routine ~2m recovery **never false-alarms**. A failure that persists
materially past that window (target permanently gone, tmux server dead, a
misconfigured target) crosses it and alarms.

Chosen UX: **alarm on genuinely-persistent failure; may alarm-then-clear on the
rare boundary** where a heal lands late in the drain backoff cycle (the alarm
shows briefly, then auto-clears on recovery). That's honest — delivery genuinely
*was* down past the threshold — and still turns the 23-minute silent window into
a ≤3-minute-to-visible alarm.

**Verifies the watch item:** the `captain-events` pipeline (target `root`, the
`12e09daa` backlog) is exactly this case — during today's outage its failures
persisted 23 min, so it would have crossed 3m and raised the banner within
minutes instead of being discovered by accident.

**Scope note:** the alarm covers **watch tasks** — the durable-retry, silent case
that actually bit us. Cron-task delivery failures already surface as an
`errored:` task status in the TUI rail, so they are not silent.

### File-length decomposition (#1145)

`daemon/control.go`, `daemon/watcher.go`, and `app/app.go` were all at their
grandfathered ceilings (zero headroom), and the ratchet forbids growing them. To
add the wiring, cohesive blocks were relocated into new files (pure moves, no
behavior change) and the allowlist ceilings ratcheted **down**:
- `daemon/snapshot.go` — the Snapshot RPC types + `DeliveryAlarm` + client/handler helpers
- `daemon/delivery_alarm.go` — the threshold, `recordDeliveryResult`, `deliveryAlarms`
- `daemon/tailbuffer.go` — the pre-existing `tailBuffer` failure-diagnostics ring
- `app/render.go` — the pre-existing View render helpers
- (removed the now-dead `daemon.Snapshot()` client func, superseded by `SnapshotWithAlarms`)

### Tests
- `daemon`: threshold gate (sub-threshold ≠ alarm), repo scoping, full alarm
  detail incl. `Pending` from the real queue, success clears; `recordDeliveryResult`
  run lifecycle; `controlServer.Snapshot` projects the alarm onto the response.
- `app`: a failing snapshot raises the banner (reserves a row, renders
  target/pending/since/task into the composed View); an unchanged set is a no-op;
  recovery clears the banner and releases the row.
- `ui/layout`: `Grid.Banner` reserves the top row, shifts every region below it,
  still tiles exactly, and survives minimal mode.

### Gates
`golangci-lint --fast`, `gofmt -l .` (empty), `go build ./...`,
`make test-container` (full suite green incl. `daemon`), `scripts/lint-file-length.sh`,
`deadcode -test ./...` — all pass.

**Do not merge — for root review + driver play-test** (simulate a failing target →
banner shows → recovery → banner clears). Closes #1238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
