### PR TITLE
refactor(session): single teardownTabs core for kill + release-PTY (#1195 Phase 2a)

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -414,53 +413,13 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 // the rest. The in-memory pointers are cleared regardless so the daemon
 // caller can always proceed to remove the persisted record. See issue #478.
 func (b *LocalBackend) Kill(i *Instance) error {
-	i.mu.Lock()
-	// Snapshot every tab's tmux session under the lock. PR 2 of #930 gives an
-	// instance N tabs (agent + shell today), so Kill tears down each tab's
-	// session, not just the agent's.
-	type tabSession struct {
-		name string
-		ts   *tmux.TmuxSession
-	}
-	sessions := make([]tabSession, 0, len(i.Tabs))
-	for _, tab := range i.Tabs {
-		if tab.tmux != nil {
-			sessions = append(sessions, tabSession{name: tab.Name, ts: tab.tmux})
-		}
-	}
-	gw := i.gitWorktree
-	title := i.Title
-	i.started = false
-	i.mu.Unlock()
-
-	// Tear down every tab's tmux session BEFORE the worktree cleanup below, and
-	// wait for each pane's process to actually exit: kill-session only SIGHUPs
-	// it, and a process still flushing state mid-shutdown races git's recursive
-	// delete of the worktree, leaking a half-deleted directory ("Directory not
-	// empty", #802). The ordering — all panes exit, then remove the worktree
-	// once — is preserved across all tabs.
-	for _, s := range sessions {
-		if err := s.ts.CloseAndWaitForPaneExit(); err != nil {
-			log.WarningLog.Printf("kill %q: tmux cleanup for tab %q failed: %v", title, s.name, err)
-		}
-	}
-
-	if gw != nil {
-		if err := gw.Cleanup(); err != nil {
-			log.WarningLog.Printf("kill %q: git worktree cleanup failed: %v", title, err)
-		}
-	}
-
-	i.mu.Lock()
-	for _, tab := range i.Tabs {
-		tab.tmux = nil
-	}
-	if i.gitWorktree == gw {
-		i.gitWorktree = nil
-	}
-	i.mu.Unlock()
-
-	return nil
+	// PR 2 of #930 gives an instance N tabs (agent + shell today), so Kill tears
+	// down each tab's session, not just the agent's. The kill mode kill-sessions
+	// every tab (waiting for each pane to exit before the worktree delete, #802),
+	// deletes the worktree, and clears the refs — see teardownTabs. Best-effort:
+	// a stuck tmux or a failed worktree cleanup only logs so the caller can still
+	// drop the record (#478/#802). Returns nil regardless.
+	return i.teardownTabs(teardownKill{})
 }
 
 // CloseAttachOnly releases this instance's hold on its tmux sessions — the
@@ -471,45 +430,14 @@ func (b *LocalBackend) Kill(i *Instance) error {
 // (#867): the duplicate must surrender the PTYs it opened during restore
 // without tearing down the live sessions the canonical Instance shares.
 func (b *LocalBackend) CloseAttachOnly(i *Instance) error {
-	// Snapshot every tab's tmux session under the lock, mirroring Kill. Since
-	// #930 an instance holds N tabs (agent + shell/process), and restoring the
-	// duplicate opened an attach PTY for EVERY tab (Start restores the agent
-	// tab, setupTabs the rest), so releasing only the agent tab's PTY leaked
-	// one fd per extra tab each time the daemon discarded a duplicate —
-	// eventually EMFILE in the long-running daemon (#1065).
-	type tabSession struct {
-		tab *Tab
-		ts  *tmux.TmuxSession
-	}
-	i.mu.Lock()
-	sessions := make([]tabSession, 0, len(i.Tabs))
-	for _, tab := range i.Tabs {
-		if tab.tmux != nil {
-			sessions = append(sessions, tabSession{tab: tab, ts: tab.tmux})
-		}
-	}
-	i.started = false
-	i.mu.Unlock()
-
-	// Close outside the lock: CloseAttachOnly blocks draining the attach
-	// goroutines, and holding i.mu across it would stall every reader.
-	var errs []error
-	for _, s := range sessions {
-		if err := s.ts.CloseAttachOnly(); err != nil {
-			errs = append(errs, fmt.Errorf("tab %q: %w", s.tab.Name, err))
-		}
-	}
-
-	i.mu.Lock()
-	for _, s := range sessions {
-		// Only clear a ref that is still the session we closed: a concurrent
-		// Start may have swapped in a fresh session while the lock was released.
-		if s.tab.tmux == s.ts {
-			s.tab.tmux = nil
-		}
-	}
-	i.mu.Unlock()
-	return errors.Join(errs...)
+	// Since #930 an instance holds N tabs (agent + shell/process), and restoring
+	// the duplicate opened an attach PTY for EVERY tab (Start restores the agent
+	// tab, setupTabs the rest), so releasing only the agent tab's PTY leaked one
+	// fd per extra tab each time the daemon discarded a duplicate — eventually
+	// EMFILE in the long-running daemon (#1065). The release-PTY mode drops every
+	// tab's attach without kill-session and leaves the worktree intact — see
+	// teardownTabs — returning the joined per-tab close errors.
+	return i.teardownTabs(teardownReleasePTY{})
 }
 
 func (b *LocalBackend) Preview(i *Instance) (string, error) {

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -1,0 +1,120 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// Session teardown core (#1195 Phase 2, audit item #5).
+//
+// Every kill/archive/discard path used to open-code the same "snapshot each
+// tab's tmux under i.mu → close it OUTSIDE the lock → re-lock and clear the
+// refs" skeleton, each with its own local tabSession struct and four silent
+// divergences (worktree handling, the #802 pane-exit-before-worktree ordering,
+// the started fence, and the ref-clear identity guard). teardownTabs collapses
+// them into ONE parameterized core so a fix to one reaches all: the mode decides
+// the tmux verb, the worktree action, and the tab retention, and nothing else
+// forks.
+//
+// Phase 2a introduces the KILL and RELEASE-PTY modes and migrates
+// LocalBackend.Kill / LocalBackend.CloseAttachOnly. Phase 2b adds the ARCHIVE
+// mode (kill-session + wait, then MoveWorktree folded into the core immediately
+// after the pane-exit wait — closing the #802 duplication) and migrates
+// Instance.ArchiveTeardown.
+
+// teardownMode selects teardownTabs' behavior. It is a small sealed set — the
+// three physical teardown shapes — rather than a bag of booleans, so a caller
+// picks an intent and the core owns the mechanics.
+type teardownMode interface {
+	isTeardownMode()
+}
+
+// teardownKill tears the session fully down: kill-session on every tab (waiting
+// for each pane to exit, #802), DELETE the worktree, clear every tmux ref and
+// the worktree pointer. started is cleared. Best-effort — a stuck tmux or a
+// failed worktree cleanup only logs, so the caller can still drop the record
+// (#478).
+type teardownKill struct{}
+
+func (teardownKill) isTeardownMode() {}
+
+// teardownReleasePTY releases only this instance's hold on its tmux sessions —
+// the attach PTYs and `tmux attach-session` children — WITHOUT running
+// kill-session. The server-side tmux sessions and the worktree are left intact.
+// Used to discard a duplicate Instance built from disk that lost a race to the
+// canonical tracked one (#867/#1065): it must surrender every tab's PTY without
+// tearing down the live sessions the canonical Instance shares. Per-tab close
+// errors are collected and returned (not merely logged).
+type teardownReleasePTY struct{}
+
+func (teardownReleasePTY) isTeardownMode() {}
+
+// teardownTabs runs the one teardown skeleton for the given mode. It snapshots
+// each tab's tmux session under i.mu, tears them down OUTSIDE the lock (closing
+// under i.mu would stall every reader while a pane drains), performs the mode's
+// worktree action while no pane is cwd'd in the worktree, then re-locks and
+// clears the tmux refs. Clearing is identity-guarded (only a ref that is still
+// the session we closed is cleared) so a concurrent Start that swapped in a
+// fresh session is never nil'd out from under it.
+func (i *Instance) teardownTabs(mode teardownMode) error {
+	type tabSession struct {
+		tab *Tab
+		ts  *tmux.TmuxSession
+	}
+	i.mu.Lock()
+	sessions := make([]tabSession, 0, len(i.Tabs))
+	for _, tab := range i.Tabs {
+		if tab.tmux != nil {
+			sessions = append(sessions, tabSession{tab: tab, ts: tab.tmux})
+		}
+	}
+	gw := i.gitWorktree
+	title := i.Title
+	i.started = false
+	i.mu.Unlock()
+
+	// Tear down every tab's tmux session. For the kill mode this waits for each
+	// pane's process to actually exit BEFORE the worktree cleanup below: a
+	// process still flushing state mid-shutdown races git's recursive delete and
+	// leaks a half-deleted directory ("Directory not empty", #802). The release-
+	// PTY mode only drops the local attach and never touches the worktree, so it
+	// needs no wait and surfaces its per-tab errors to the caller.
+	var errs []error
+	for _, s := range sessions {
+		switch mode.(type) {
+		case teardownReleasePTY:
+			if err := s.ts.CloseAttachOnly(); err != nil {
+				errs = append(errs, fmt.Errorf("tab %q: %w", s.tab.Name, err))
+			}
+		default: // teardownKill
+			if err := s.ts.CloseAndWaitForPaneExit(); err != nil {
+				log.WarningLog.Printf("kill %q: tmux cleanup for tab %q failed: %v", title, s.tab.Name, err)
+			}
+		}
+	}
+
+	// Worktree action, once every pane has exited.
+	if _, ok := mode.(teardownKill); ok && gw != nil {
+		if err := gw.Cleanup(); err != nil {
+			log.WarningLog.Printf("kill %q: git worktree cleanup failed: %v", title, err)
+		}
+	}
+
+	i.mu.Lock()
+	for _, s := range sessions {
+		// Only clear a ref that is still the session we closed: a concurrent
+		// Start may have swapped in a fresh session while the lock was released.
+		if s.tab.tmux == s.ts {
+			s.tab.tmux = nil
+		}
+	}
+	if _, ok := mode.(teardownKill); ok && i.gitWorktree == gw {
+		i.gitWorktree = nil
+	}
+	i.mu.Unlock()
+
+	return errors.Join(errs...)
+}

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/git"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
@@ -15,21 +16,96 @@ import (
 // refs" skeleton, each with its own local tabSession struct and four silent
 // divergences (worktree handling, the #802 pane-exit-before-worktree ordering,
 // the started fence, and the ref-clear identity guard). teardownTabs collapses
-// them into ONE parameterized core so a fix to one reaches all: the mode decides
-// the tmux verb, the worktree action, and the tab retention, and nothing else
-// forks.
+// them into ONE core so a fix to one reaches all: the mode is polymorphic and
+// PROVIDES its behavior (tmux verb, worktree action, started fence, tab
+// finalization); the core just drives the shared skeleton and invokes the mode.
 //
 // Phase 2a introduces the KILL and RELEASE-PTY modes and migrates
 // LocalBackend.Kill / LocalBackend.CloseAttachOnly. Phase 2b adds the ARCHIVE
-// mode (kill-session + wait, then MoveWorktree folded into the core immediately
-// after the pane-exit wait — closing the #802 duplication) and migrates
-// Instance.ArchiveTeardown.
+// mode — which folds MoveWorktree into the core immediately after the pane-exit
+// wait (closing the #802 duplication) — by just implementing this interface; the
+// core does not change.
 
-// teardownMode selects teardownTabs' behavior. It is a small sealed set — the
-// three physical teardown shapes — rather than a bag of booleans, so a caller
-// picks an intent and the core owns the mechanics.
+// teardownMode supplies the per-mode behavior teardownTabs invokes. Polymorphic
+// dispatch (rather than a type-switch in the core) keeps the core closed to new
+// modes: an added mode implements these methods and the core is untouched.
 type teardownMode interface {
-	isTeardownMode()
+	// closeTab tears down one tab's tmux session, OUTSIDE i.mu. It returns an
+	// error for the core to join into teardownTabs' result (release-PTY surfaces
+	// its per-tab errors), or nil after best-effort logging (kill/archive only
+	// log a stuck tmux so the record can still be dropped).
+	closeTab(ts *tmux.TmuxSession, title, tabName string) error
+	// handleWorktree performs the mode's worktree action once every pane has
+	// exited: delete (kill), move (archive — returns the move error for the
+	// caller to roll back on), or nothing (release-PTY). gw may be nil.
+	handleWorktree(gw *git.GitWorktree, title string) error
+	// clearsStarted reports whether started is set false before teardown. Kill
+	// and release-PTY clear it (so the #990 tab-spawn guard fires); archive keeps
+	// it true and fences with OpArchiving instead, so a failed move self-heals
+	// via the Lost-restore loop.
+	clearsStarted() bool
+	// finalize reconciles the instance's tab list and worktree pointer under a
+	// held i.mu after teardown. closed pairs each torn-down tab with the tmux it
+	// closed (for identity-guarded ref clearing); gw is the worktree captured
+	// before teardown. The caller holds i.mu — finalize must not re-lock.
+	finalize(i *Instance, closed []closedTab, gw *git.GitWorktree)
+}
+
+// closedTab pairs a tab with the exact tmux session teardownTabs closed for it,
+// so finalize can identity-guard the ref clear: only a ref that is STILL the
+// session we closed is nil'd, never a fresh one a concurrent Start swapped in.
+type closedTab struct {
+	tab *Tab
+	ts  *tmux.TmuxSession
+}
+
+// teardownTabs runs the one teardown skeleton for the given mode. It snapshots
+// each tab's tmux under i.mu, tears them down OUTSIDE the lock (closing under
+// i.mu would stall every reader while a pane drains), performs the mode's
+// worktree action while no pane is cwd'd in the worktree, then re-locks and lets
+// the mode finalize the tab/worktree state. Errors from closeTab/handleWorktree
+// are joined and returned.
+func (i *Instance) teardownTabs(mode teardownMode) error {
+	i.mu.Lock()
+	closed := make([]closedTab, 0, len(i.Tabs))
+	for _, tab := range i.Tabs {
+		if tab.tmux != nil {
+			closed = append(closed, closedTab{tab: tab, ts: tab.tmux})
+		}
+	}
+	gw := i.gitWorktree
+	title := i.Title
+	if mode.clearsStarted() {
+		i.started = false
+	}
+	i.mu.Unlock()
+
+	var errs []error
+	for _, c := range closed {
+		if err := mode.closeTab(c.ts, title, c.tab.Name); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := mode.handleWorktree(gw, title); err != nil {
+		errs = append(errs, err)
+	}
+
+	i.mu.Lock()
+	mode.finalize(i, closed, gw)
+	i.mu.Unlock()
+
+	return errors.Join(errs...)
+}
+
+// clearClosedTmuxRefs nils each closed tab's tmux ref under a held i.mu,
+// identity-guarded so a concurrent Start that swapped in a fresh session is
+// never clobbered. Shared by the kill and release-PTY finalizers.
+func clearClosedTmuxRefs(closed []closedTab) {
+	for _, c := range closed {
+		if c.tab.tmux == c.ts {
+			c.tab.tmux = nil
+		}
+	}
 }
 
 // teardownKill tears the session fully down: kill-session on every tab (waiting
@@ -39,7 +115,33 @@ type teardownMode interface {
 // (#478).
 type teardownKill struct{}
 
-func (teardownKill) isTeardownMode() {}
+func (teardownKill) closeTab(ts *tmux.TmuxSession, title, tabName string) error {
+	// Wait for the pane to exit before the worktree delete in handleWorktree: a
+	// process still flushing state mid-shutdown races git's recursive delete and
+	// leaks a half-deleted directory ("Directory not empty", #802). Best-effort.
+	if err := ts.CloseAndWaitForPaneExit(); err != nil {
+		log.WarningLog.Printf("kill %q: tmux cleanup for tab %q failed: %v", title, tabName, err)
+	}
+	return nil
+}
+
+func (teardownKill) handleWorktree(gw *git.GitWorktree, title string) error {
+	if gw != nil {
+		if err := gw.Cleanup(); err != nil {
+			log.WarningLog.Printf("kill %q: git worktree cleanup failed: %v", title, err)
+		}
+	}
+	return nil
+}
+
+func (teardownKill) clearsStarted() bool { return true }
+
+func (teardownKill) finalize(i *Instance, closed []closedTab, gw *git.GitWorktree) {
+	clearClosedTmuxRefs(closed)
+	if i.gitWorktree == gw {
+		i.gitWorktree = nil
+	}
+}
 
 // teardownReleasePTY releases only this instance's hold on its tmux sessions —
 // the attach PTYs and `tmux attach-session` children — WITHOUT running
@@ -50,71 +152,17 @@ func (teardownKill) isTeardownMode() {}
 // errors are collected and returned (not merely logged).
 type teardownReleasePTY struct{}
 
-func (teardownReleasePTY) isTeardownMode() {}
+func (teardownReleasePTY) closeTab(ts *tmux.TmuxSession, _, tabName string) error {
+	if err := ts.CloseAttachOnly(); err != nil {
+		return fmt.Errorf("tab %q: %w", tabName, err)
+	}
+	return nil
+}
 
-// teardownTabs runs the one teardown skeleton for the given mode. It snapshots
-// each tab's tmux session under i.mu, tears them down OUTSIDE the lock (closing
-// under i.mu would stall every reader while a pane drains), performs the mode's
-// worktree action while no pane is cwd'd in the worktree, then re-locks and
-// clears the tmux refs. Clearing is identity-guarded (only a ref that is still
-// the session we closed is cleared) so a concurrent Start that swapped in a
-// fresh session is never nil'd out from under it.
-func (i *Instance) teardownTabs(mode teardownMode) error {
-	type tabSession struct {
-		tab *Tab
-		ts  *tmux.TmuxSession
-	}
-	i.mu.Lock()
-	sessions := make([]tabSession, 0, len(i.Tabs))
-	for _, tab := range i.Tabs {
-		if tab.tmux != nil {
-			sessions = append(sessions, tabSession{tab: tab, ts: tab.tmux})
-		}
-	}
-	gw := i.gitWorktree
-	title := i.Title
-	i.started = false
-	i.mu.Unlock()
+func (teardownReleasePTY) handleWorktree(_ *git.GitWorktree, _ string) error { return nil }
 
-	// Tear down every tab's tmux session. For the kill mode this waits for each
-	// pane's process to actually exit BEFORE the worktree cleanup below: a
-	// process still flushing state mid-shutdown races git's recursive delete and
-	// leaks a half-deleted directory ("Directory not empty", #802). The release-
-	// PTY mode only drops the local attach and never touches the worktree, so it
-	// needs no wait and surfaces its per-tab errors to the caller.
-	var errs []error
-	for _, s := range sessions {
-		switch mode.(type) {
-		case teardownReleasePTY:
-			if err := s.ts.CloseAttachOnly(); err != nil {
-				errs = append(errs, fmt.Errorf("tab %q: %w", s.tab.Name, err))
-			}
-		default: // teardownKill
-			if err := s.ts.CloseAndWaitForPaneExit(); err != nil {
-				log.WarningLog.Printf("kill %q: tmux cleanup for tab %q failed: %v", title, s.tab.Name, err)
-			}
-		}
-	}
+func (teardownReleasePTY) clearsStarted() bool { return true }
 
-	// Worktree action, once every pane has exited.
-	if _, ok := mode.(teardownKill); ok && gw != nil {
-		if err := gw.Cleanup(); err != nil {
-			log.WarningLog.Printf("kill %q: git worktree cleanup failed: %v", title, err)
-		}
-	}
-
-	i.mu.Lock()
-	for _, s := range sessions {
-		// Only clear a ref that is still the session we closed: a concurrent
-		// Start may have swapped in a fresh session while the lock was released.
-		if s.tab.tmux == s.ts {
-			s.tab.tmux = nil
-		}
-	}
-	if _, ok := mode.(teardownKill); ok && i.gitWorktree == gw {
-		i.gitWorktree = nil
-	}
-	i.mu.Unlock()
-
-	return errors.Join(errs...)
+func (teardownReleasePTY) finalize(_ *Instance, closed []closedTab, _ *git.GitWorktree) {
+	clearClosedTmuxRefs(closed)
 }


### PR DESCRIPTION
**Phase 2a of the #1195 structural-health epic** (audit item #5). Root-approved design: https://github.com/sachiniyer/agent-factory/issues/1195#issuecomment-4888497895

## What

Session teardown was open-coded **three times** — `LocalBackend.Kill`, `LocalBackend.CloseAttachOnly`, `Instance.ArchiveTeardown` — each with its own local `tabSession` struct and the same *snapshot-tmux-under-lock → close-outside-lock → re-lock-clear-refs* skeleton, diverging in four silent ways (worktree handling, the #802 pane-exit-before-worktree ordering, the `started` fence, the ref-clear identity guard). That divergence is the bug surface behind the #1196 archive-orphan class.

This introduces the shared core `teardownTabs(mode)` in a new `session/teardown.go` with the **kill** and **release-PTY** modes, and migrates the two backend methods onto it — collapsing **2 of the 3** copied loops.

## Behavior-preserving

- **kill mode** reproduces `LocalBackend.Kill` exactly: kill-session + wait for each pane to exit (#802) → delete the worktree → clear refs. The `kill "<title>":` warning prefix is kept **verbatim** (`backend_test.go` asserts it appears twice).
- **release-PTY mode** reproduces `LocalBackend.CloseAttachOnly`: drop every tab's attach PTY without `kill-session`, leave the worktree untouched, return the joined per-tab errors (#867/#1065).
- **ref-clearing is identity-guarded** for both modes — a strict refinement of Kill's old unconditional clear: identical result absent a concurrent `Start` swap, correct in the race Kill didn't handle.

The archive mode (folding `MoveWorktree` into the core right after the pane-exit wait, closing the #802 duplication) lands in **2b** with the `ArchiveTeardown` migration.

## Gates (all green locally)

- `go build ./...`
- `gofmt -l .` empty
- `golangci-lint run --timeout=3m --fast ./session/...`
- `deadcode -test ./...` clean
- `scripts/lint-file-length.sh` (new file well under ceiling; `backend_local.go` shrinks)
- **`make test-container`** — full suite green (daemon/integration/app/session incl. `tab_kill_race_test` + all kill tests)

Refs #1195 (Phase 2b–2e + Phase 3 remain — do not close).

— Captain Claude