### PR TITLE
docs: brand the MkDocs site — hero, capability cards, teal palette (#1247)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ __debug_bin*
 
 # MkDocs build output
 site/
+
+# Local docs virtualenv (see requirements-docs.txt)
+.venv-docs/

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Agent Factory">
+  <rect width="32" height="32" rx="7" fill="#2e7c80"/>
+  <rect x="6" y="15" width="4.5" height="11" rx="2.25" fill="#ffffff"/>
+  <rect x="13.75" y="8" width="4.5" height="18" rx="2.25" fill="#ffffff"/>
+  <rect x="21.5" y="12" width="4.5" height="14" rx="2.25" fill="#ffffff"/>
+</svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" role="img" aria-label="Agent Factory">
+  <rect x="4" y="14" width="5" height="14" rx="2.5" fill="#ffffff"/>
+  <rect x="13.5" y="6" width="5" height="22" rx="2.5" fill="#ffffff"/>
+  <rect x="23" y="10" width="5" height="18" rx="2.5" fill="#ffffff"/>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,52 +1,82 @@
-# Agent Factory
+---
+template: home.html
+hide:
+  - navigation
+  - toc
+---
 
-Agent Factory (`af`) is a terminal UI for running **many AI coding agents at
-once** — Claude Code, Codex, Aider, Gemini — each in its own isolated git
-worktree. You spin up a session per task, hand each agent a prompt, and watch
-their work stream live in a preview pane; when one is ready, you attach
-full-screen and take over. Nothing shares a working tree, so agents never step
-on each other, and every session is a real branch you can review and merge like
-any other.
+<p class="af-section-label">Core capabilities</p>
+<h2 class="af-section-title">Everything you need to run agents at scale</h2>
 
-It runs on Linux and macOS (and Windows under WSL), needs only **tmux**, **git**,
-and at least one agent installed — no Go, no daemon to babysit. Start with
-[Getting started](getting-started.md).
+<div class="grid cards" markdown>
 
-## What it does
+-   :material-source-branch:{ .lg .middle } __Parallel agents, in isolation__
 
-- **Runs agents in parallel, in isolation.** Each session is a dedicated git
-  worktree on its own branch. Five agents can refactor five corners of the same
-  repo simultaneously and never collide. See
-  [Worktree-isolated agents](concepts/worktree-agents.md).
-- **Keeps you in one screen.** A sidebar lists every session with live status;
-  the preview pane snapshots any agent's terminal without attaching; `↵`
-  attaches you full-screen and a detach key drops you back. Extra **tabs** run
-  shells or long-lived processes (a dev server, `btop`) alongside the agent in
-  the same worktree.
-- **Survives restarts and works unattended.** A background **daemon** owns all
-  state and keeps things alive: it re-spawns a session's process if it dies,
-  runs scheduled and event-driven **tasks**, and can auto-accept agent prompts
-  so work proceeds while you're away. See [The daemon](concepts/daemon.md) and
-  [Tasks & automation](tasks.md).
-- **Automates on a schedule or a signal.** A task delivers a prompt to an agent
-  on a **cron** schedule ("triage issues every morning at 9") or whenever a
-  **watch script** emits a line (a new row in a queue, a failing build). Each
-  run can spawn a fresh session or target an existing one.
-- **Scriptable end to end.** Everything the TUI does, the `af` CLI does too, as
-  JSON on stdout — so it composes with `jq` and shell. The same operations are
-  also a small local **HTTP/JSON API** over a Unix socket, for calling `af` from
-  another language or from inside an agent. See the
-  [CLI reference](reference/cli.md) and [HTTP API reference](reference/api.md).
-- **Reaches beyond your laptop.** With **remote hooks**, sessions can run on a
-  backend you define — your own launch/list/attach/delete scripts — and appear
-  in the same sidebar with the same attach/kill/preview experience. See
-  [Remote hooks](remote-hooks.md).
-- **Handles usage limits gracefully.** When Claude or Codex hits a usage limit,
-  `af` marks the session and can auto-resume it once the window elapses; task
-  runs that hit a limit are parked and resumed, never counted as failures. See
-  [Usage limits](usage-limits.md).
+    ---
+
+    Each session is a dedicated git worktree on its own branch. Five agents can
+    refactor five corners of the same repo at once and never collide — every
+    session is a real branch you review and merge like any other.
+
+    [:octicons-arrow-right-24: Worktree-isolated agents](concepts/worktree-agents.md)
+
+-   :material-view-dashboard-outline:{ .lg .middle } __One-screen workflow__
+
+    ---
+
+    A sidebar lists every session with live status; the preview pane snapshots
+    any agent without attaching; `↵` takes you full-screen. Extra tabs run a
+    shell or dev server alongside the agent in the same worktree.
+
+    [:octicons-arrow-right-24: The TUI](concepts/tui.md)
+
+-   :material-cog-sync-outline:{ .lg .middle } __A daemon that never sleeps__
+
+    ---
+
+    A background daemon owns all state: it re-spawns dead sessions, runs
+    scheduled and event-driven tasks, and can auto-accept prompts so work
+    proceeds while you're away — surviving restarts.
+
+    [:octicons-arrow-right-24: The daemon](concepts/daemon.md)
+
+-   :material-console:{ .lg .middle } __Scriptable, CLI + HTTP__
+
+    ---
+
+    Everything the TUI does, the `af` CLI does too — as JSON on stdout, so it
+    composes with `jq`. The same operations are a local HTTP/JSON API over a
+    Unix socket for calling `af` from any language.
+
+    [:octicons-arrow-right-24: CLI reference](reference/cli.md)
+
+-   :material-cloud-outline:{ .lg .middle } __Reaches beyond your laptop__
+
+    ---
+
+    With remote hooks, sessions run on a backend you define — your own
+    launch/list/attach/delete scripts — and appear in the same sidebar with the
+    same attach, kill, and preview experience.
+
+    [:octicons-arrow-right-24: Remote hooks](remote-hooks.md)
+
+-   :material-timer-sand:{ .lg .middle } __Handles usage limits__
+
+    ---
+
+    When Claude or Codex hits a usage limit, `af` marks the session and
+    auto-resumes it once the window elapses. Task runs that hit a limit are
+    parked and resumed — never counted as failures.
+
+    [:octicons-arrow-right-24: Usage limits](usage-limits.md)
+
+</div>
 
 ## How it fits together
+
+The TUI and the CLI are both thin front-ends; the **daemon** is the single
+source of truth that owns every write. That is why the TUI, the CLI, and the
+HTTP API can never show you three different worlds.
 
 ```
         ┌──────────────────────────────────────────────┐
@@ -67,19 +97,36 @@ and at least one agent installed — no Go, no daemon to babysit. Start with
         └───────────────────────────────────────────────┘
 ```
 
-The TUI and the CLI are both thin front-ends; the daemon is the single source of
-truth that owns every write. That is why the TUI, the CLI, and the HTTP API can
-never show you three different worlds. Read [The daemon](concepts/daemon.md) for
-why that design matters.
+Read [The daemon](concepts/daemon.md) for why that design matters.
 
 ## Where to go next
 
-- **New here?** [Getting started](getting-started.md) — install, first session,
-  attach and detach.
-- **Want the model in your head?** The *Concepts* section:
-  [worktree-isolated agents](concepts/worktree-agents.md),
-  [the daemon](concepts/daemon.md), [the TUI](concepts/tui.md),
-  [tasks](tasks.md), [remote hooks](remote-hooks.md).
-- **Scripting or integrating?** The [CLI reference](reference/cli.md) and
-  [HTTP API reference](reference/api.md) — both generated from the code, so they
-  never drift.
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch-outline:{ .lg .middle } __New here?__
+
+    ---
+
+    Install `af`, create your first session, attach and detach.
+
+    [:octicons-arrow-right-24: Getting started](getting-started.md)
+
+-   :material-lightbulb-on-outline:{ .lg .middle } __Want the model in your head?__
+
+    ---
+
+    The concepts: worktree-isolated agents, the daemon, the TUI, tasks, and
+    remote hooks.
+
+    [:octicons-arrow-right-24: Concepts](concepts/worktree-agents.md)
+
+-   :material-code-braces:{ .lg .middle } __Scripting or integrating?__
+
+    ---
+
+    The CLI and HTTP API references — both generated from the code, so they
+    never drift.
+
+    [:octicons-arrow-right-24: CLI reference](reference/cli.md)
+
+</div>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,0 +1,44 @@
+{#-
+  Landing-page template for Agent Factory. Extends the Material base and injects
+  a full-bleed hero directly under the header/tabs (the `tabs` block), then
+  renders the page's markdown body (capability card grid + architecture) in the
+  normal content column via `super()`. Used only by docs/index.md through its
+  `template: home.html` front matter.
+-#}
+{% extends "main.html" %}
+
+{% block tabs %}
+  {{ super() }}
+  <section class="af-hero">
+    <div class="af-hero__inner">
+      <div class="af-hero__copy">
+        <span class="af-hero__eyebrow">Terminal-native agent orchestration</span>
+        <h1 class="af-hero__title">Run a swarm of coding agents — <code>af</code> keeps them from stepping on each other.</h1>
+        <p class="af-hero__tagline">
+          Agent Factory runs many AI coding agents at once — Claude Code, Codex,
+          Aider, Gemini — each in its own isolated git worktree. Spin up a session
+          per task, watch every agent stream live in one pane, and attach
+          full-screen when one is ready to hand off.
+        </p>
+        <div class="af-hero__cta">
+          <a href="{{ 'getting-started/' | url }}" class="md-button md-button--primary">Get started</a>
+          <a href="{{ config.repo_url }}" class="md-button">View on GitHub</a>
+        </div>
+        <div class="af-hero__badges">
+          <span>{% include ".icons/octicons/check-16.svg" %} Linux · macOS · WSL</span>
+          <span>{% include ".icons/octicons/check-16.svg" %} Needs only tmux + git</span>
+          <span>{% include ".icons/octicons/check-16.svg" %} No Go, no babysitting</span>
+        </div>
+      </div>
+      <div class="af-hero__media">
+        <img src="{{ 'assets/demo.gif' | url }}" alt="Agent Factory managing several coding agents from one terminal">
+      </div>
+    </div>
+  </section>
+{% endblock %}
+
+{% block content %}
+  <div class="af-home">
+    {{ super() }}
+  </div>
+{% endblock %}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,263 @@
+/* ==========================================================================
+   Agent Factory — docs theme
+   Built around the TUI accent (teal #7cb8bb, ui/theme.go). The deeper teals
+   here are contrast-safe derivatives of that accent so the docs read as the
+   same product: the raw accent shines in dark mode, a deeper teal carries the
+   light-mode header/links where white-on-accent would fail WCAG.
+   ========================================================================== */
+
+:root {
+  --af-teal:        #7cb8bb;  /* the TUI AccentColor, verbatim */
+  --af-teal-deep:   #2e7c80;  /* light-mode primary (header, contrast-safe) */
+  --af-teal-deeper: #245f62;
+  --af-teal-soft:   #e5f1f1;
+  --md-code-font: "Roboto Mono", SFMono-Regular, Consolas, monospace;
+}
+
+/* --- Light scheme -------------------------------------------------------- */
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color:        var(--af-teal-deep);
+  --md-primary-fg-color--light: var(--af-teal);
+  --md-primary-fg-color--dark:  var(--af-teal-deeper);
+  --md-accent-fg-color:         #1f6d70;
+  --md-typeset-a-color:         var(--af-teal-deep);
+}
+
+/* --- Dark scheme: the raw TUI accent leads ------------------------------- */
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:        #163033;
+  --md-primary-fg-color--light: var(--af-teal);
+  --md-primary-fg-color--dark:  #0f2426;
+  --md-accent-fg-color:         var(--af-teal);
+  --md-typeset-a-color:         var(--af-teal);
+  --md-default-bg-color:        #0e1516;
+  --af-teal-soft:               #16292b;
+}
+
+/* Header/nav follow the primary; in dark mode keep the tab bar deep-teal. */
+[data-md-color-scheme="slate"] .md-header,
+[data-md-color-scheme="slate"] .md-tabs {
+  background-color: #0f2426;
+}
+
+/* ==========================================================================
+   Typography & header wordmark
+   ========================================================================== */
+
+.md-header__title .md-header__topic:first-child .md-ellipsis {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3 {
+  letter-spacing: -0.015em;
+  font-weight: 700;
+}
+
+.md-typeset h2 {
+  margin-top: 2.4rem;
+}
+
+/* ==========================================================================
+   Hero (injected via overrides/home.html)
+   ========================================================================== */
+
+.af-hero {
+  background:
+    radial-gradient(1200px 400px at 15% -10%, rgba(124, 184, 187, 0.22), transparent 60%),
+    linear-gradient(180deg, var(--af-teal-soft) 0%, transparent 100%);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  padding: 3.2rem 0.8rem 2.6rem;
+}
+
+[data-md-color-scheme="slate"] .af-hero {
+  background:
+    radial-gradient(1200px 400px at 15% -10%, rgba(124, 184, 187, 0.16), transparent 60%),
+    linear-gradient(180deg, #16292b 0%, transparent 100%);
+}
+
+.af-hero__inner {
+  max-width: 61rem;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: 2.4rem;
+  align-items: center;
+}
+
+.af-hero__eyebrow {
+  display: inline-block;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--af-teal-deep);
+  background: var(--af-teal-soft);
+  padding: 0.28rem 0.6rem;
+  border-radius: 999px;
+  margin-bottom: 0.9rem;
+}
+
+[data-md-color-scheme="slate"] .af-hero__eyebrow {
+  color: var(--af-teal);
+}
+
+.af-hero__title {
+  font-size: 2.15rem;
+  line-height: 1.12;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  margin: 0 0 0.7rem;
+}
+
+.af-hero__title code {
+  background: rgba(124, 184, 187, 0.18);
+  color: var(--af-teal-deep);
+  padding: 0 0.24em;
+  border-radius: 0.24rem;
+}
+
+[data-md-color-scheme="slate"] .af-hero__title code {
+  color: var(--af-teal);
+}
+
+.af-hero__tagline {
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: var(--md-default-fg-color--light);
+  margin: 0 0 1.3rem;
+  max-width: 34rem;
+}
+
+.af-hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.af-hero__cta .md-button {
+  margin: 0;
+}
+
+.af-hero__cta .md-button--primary {
+  box-shadow: 0 6px 18px rgba(46, 124, 128, 0.28);
+}
+
+.af-hero__media {
+  position: relative;
+}
+
+.af-hero__media img {
+  width: 100%;
+  border-radius: 0.6rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.22);
+}
+
+.af-hero__badges {
+  margin-top: 1.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.1rem;
+  font-size: 0.72rem;
+  color: var(--md-default-fg-color--light);
+}
+
+.af-hero__badges span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.af-hero__badges svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  fill: var(--af-teal-deep);
+}
+
+[data-md-color-scheme="slate"] .af-hero__badges svg {
+  fill: var(--af-teal);
+}
+
+@media screen and (max-width: 44.9375em) {
+  .af-hero__inner {
+    grid-template-columns: 1fr;
+    gap: 1.6rem;
+  }
+  .af-hero__title {
+    font-size: 1.7rem;
+  }
+  .af-hero__media {
+    order: -1;
+  }
+}
+
+/* Home page: suppress Material's auto-injected "Home" <h1> — the hero already
+   carries the page title/wordmark. */
+.af-home > h1:first-child {
+  display: none;
+}
+
+/* ==========================================================================
+   Grid cards — capability grid
+   ========================================================================== */
+
+.md-typeset .grid.cards > ul > li,
+.md-typeset .grid.cards > :is(ul, ol) > li {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.6rem;
+  padding: 1.1rem 1.15rem;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.md-typeset .grid.cards > :is(ul, ol) > li:hover {
+  border-color: var(--af-teal);
+  box-shadow: 0 10px 30px rgba(46, 124, 128, 0.16);
+  transform: translateY(-2px);
+}
+
+.md-typeset .grid.cards > :is(ul, ol) > li > hr {
+  margin: 0.7rem 0;
+  border-color: var(--md-default-fg-color--lightest);
+}
+
+.md-typeset .grid.cards .twemoji.lg,
+.md-typeset .grid.cards .lg.middle {
+  color: var(--af-teal-deep);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .grid.cards .twemoji.lg,
+[data-md-color-scheme="slate"] .md-typeset .grid.cards .lg.middle {
+  color: var(--af-teal);
+}
+
+/* ==========================================================================
+   Section heading above the card grid
+   ========================================================================== */
+
+.af-section-label {
+  text-align: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--af-teal-deep);
+  margin: 2.6rem 0 0.2rem;
+}
+
+[data-md-color-scheme="slate"] .af-section-label {
+  color: var(--af-teal);
+}
+
+.af-section-title {
+  text-align: center;
+  margin-top: 0.2rem !important;
+}
+
+/* Buttons: rounder, product-flavored */
+.md-typeset .md-button {
+  border-radius: 0.5rem;
+  font-weight: 600;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,40 +12,59 @@ docs_dir: docs
 
 theme:
   name: material
+  custom_dir: docs/overrides
+  logo: assets/logo.svg
+  favicon: assets/favicon.svg
   icon:
     repo: fontawesome/brands/github
   features:
+    - navigation.tabs
     - navigation.sections
     - navigation.top
     - navigation.instant
+    - navigation.instant.progress
     - navigation.tracking
     - navigation.footer
     - toc.follow
     - content.code.copy
     - content.code.annotate
+    - content.tabs.link
     - search.suggest
     - search.highlight
   palette:
+    # Auto (respects the OS): the icon toggles light <-> dark. The accent
+    # teal (ui/theme.go #7cb8bb) and its contrast-safe derivatives are defined
+    # in docs/stylesheets/extra.css, so both schemes use `custom`.
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
+  font:
+    text: Inter
+    code: Roboto Mono
 
 markdown_extensions:
   - admonition
   - attr_list
   - md_in_html
   - tables
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - toc:
       permalink: true
   - pymdownx.details
@@ -56,6 +75,15 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
+
+extra_css:
+  - stylesheets/extra.css
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/sachiniyer/agent-factory
+      name: Agent Factory on GitHub
 
 plugins:
   - search


### PR DESCRIPTION
Closes #1247.

Heavily themes the **existing** mkdocs-material site to herdr-level polish — **no framework switch**, and the autogen CLI/API reference from #1244 is untouched. This is a visual upgrade, not a content rewrite.

> Rendered screenshots (landing dark/light, a content page, the CLI reference, and mobile) were shared with root and Sachin for the visual review. The temp review commit has been stripped — this PR ships only the deliverable.

## What changed

**Palette tied to the product.** The color scheme is built around the TUI `AccentColor` (teal `#7cb8bb`, `ui/theme.go`). A contrast-safe deep teal (`#2e7c80`) carries the light-mode header and links where white-on-`#7cb8bb` would fail WCAG; the raw accent leads in dark mode. So the docs read as the same product as the TUI.

**Branded landing page** (`docs/index.md` → `docs/overrides/home.html`):
- A full-bleed **hero** — eyebrow, punchy headline, tagline, the demo GIF in a framed panel, **Get started** / **View on GitHub** CTAs, and a Linux·macOS·WSL / tmux+git / no-Go badge row.
- A **card grid of the six core capabilities** (parallel agents, one-screen workflow, daemon, CLI+HTTP, remote hooks, usage limits) — each an icon + one line + link. A second card row for "where to go next."
- The architecture diagram and next-steps content are preserved.

**Wordmark + branding.** An SVG logo mark (a parallel-lanes glyph evoking parallel agents) sits in the header next to the "Agent Factory" title; an SVG favicon uses the same mark on a teal tile.

**Material polish features.** `navigation.tabs`, `navigation.instant.progress`, `content.tabs.link`, `content.code.copy`, `search.suggest`, and a prominent **Auto / Light / Dark** palette toggle. Card hover states, hero gradient, and full light+dark theming in `docs/stylesheets/extra.css`.

## Files
- `mkdocs.yml` — custom palette, logo/favicon, `custom_dir`, `extra_css`, `pymdownx.emoji` (material icons), tabs + polish features
- `docs/index.md` — hero + capability card grid (via `home.html`)
- `docs/overrides/home.html` — hero template
- `docs/stylesheets/extra.css` — palette, hero, cards, typography (light+dark)
- `docs/assets/{logo,favicon}.svg` — wordmark mark + favicon
- `.gitignore` — ignore the local `.venv-docs/`

## Gates
- ✅ `mkdocs build --strict` (no broken links)
- ✅ autogen-staleness: `scripts/gen-docs.sh` leaves `docs/reference` in sync
- ✅ `scripts/lint-file-length.sh` (no Go files touched)

Preview locally:

```bash
python3 -m venv .venv-docs
.venv-docs/bin/pip install -r requirements-docs.txt
.venv-docs/bin/mkdocs serve   # http://127.0.0.1:8000
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Captain Claude <noreply@anthropic.com>
