### PR TITLE
fix(tui): open a task straight into its config editor in one step (#1249)

### DIFF
--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -107,16 +107,19 @@ func (m *home) handleAutomationsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 }
 
 // showTasksOverlay opens the task manager (list + create/edit form) as a
-// centered modal overlay, preselecting the in-rail cursor's task. The manager
-// opens with input focus so its key loop (j/k, n new, enter edit, x toggle,
-// D delete, r run, esc close) is live immediately — the same shape as the
-// hooks overlay.
+// centered modal overlay, preselecting the in-rail cursor's task and dropping
+// straight into that task's editable config in a single action (#1249) — no
+// second keypress to enter edit mode. Esc backs the form out to the list,
+// where the rest of the key loop (j/k, n new, x toggle, D delete, r run, esc
+// close) is live. When there are no tasks the overlay stays in list mode so
+// `n` can create the first one.
 func (m *home) showTasksOverlay() (tea.Model, tea.Cmd) {
 	sp := m.automations.TaskPane()
 	if idx := m.automations.SelectedTaskIndex(); idx >= 0 {
 		sp.SelectTask(idx)
 	}
 	sp.SetFocus(true)
+	sp.EnterEditSelected()
 	m.state = stateTasks
 	return m, nil
 }

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -99,6 +99,9 @@ func TestHandleStateTasks_PendingCreateFlushesDirtyTaskState(t *testing.T) {
 	tp.SetTasks(loaded)
 	_, _ = h.showTasksOverlay()
 	require.Equal(t, stateTasks, h.state)
+	// The overlay now opens the task straight into its edit form (#1249); Esc
+	// steps back to the list to drive the list-mode keys below.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
 
 	// User presses 'x' to toggle the task off — dirty in memory, not yet on disk.
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
@@ -197,6 +200,9 @@ func TestHandleStateTasks_ValidationFailureLeavesTaskPaneStale(t *testing.T) {
 	_, _ = h.showTasksOverlay()
 	require.Equal(t, stateTasks, h.state)
 	h.errBox.SetSize(500, 1)
+	// The overlay now opens the task straight into its edit form (#1249); Esc
+	// steps back to the list to drive the list-mode keys below.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
 
 	// User presses 'x' to toggle the task off — dirty in memory, not yet saved.
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
@@ -335,6 +341,9 @@ func TestSaveContentPaneState_RoutesThroughDaemonRPC(t *testing.T) {
 	h.store.SetTasks(loaded)
 	_, _ = h.showTasksOverlay()
 	require.Equal(t, stateTasks, h.state)
+	// The overlay now opens the task straight into its edit form (#1249); Esc
+	// steps back to the list to drive the list-mode keys below.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
 
 	// Swap the write seams for recorders AFTER seeding (the seed used the direct
 	// writer); the save-on-close must now dispatch through these instead of disk.
@@ -417,6 +426,9 @@ func TestSaveContentPaneState_DoesNotClobberUneditedTask(t *testing.T) {
 	h.store.SetTasks(loaded)
 	_, _ = h.showTasksOverlay()
 	require.Equal(t, stateTasks, h.state)
+	// The overlay now opens the task straight into its edit form (#1249); Esc
+	// steps back to the list to drive the list-mode keys below.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
 
 	// User toggles Task A (index 0) off — only A is dirty; B is never touched.
 	tp.SelectTask(0)
@@ -604,6 +616,9 @@ func TestSaveContentPaneState_HooksAndTaskFailuresBothSurfaced(t *testing.T) {
 	tp := h.automations.TaskPane()
 	tp.SetTasks(loaded)
 	_, _ = h.showTasksOverlay()
+	// The overlay now opens the task straight into its edit form (#1249); Esc
+	// steps back to the list where `x` toggles enabled and marks it dirty.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
 	require.True(t, tp.IsDirty(), "toggle must mark the task pane dirty")
 

--- a/app/layout_cutover_test.go
+++ b/app/layout_cutover_test.go
@@ -126,7 +126,12 @@ func TestLayoutCutover_AutomationsEscReturnsFocusToTree(t *testing.T) {
 // TestLayoutCutover_EnterOpensTasksOverlay: Enter on the focused in-rail
 // section opens the task manager as a centered modal (#1096 play-test fix 1),
 // preselecting the section cursor's task; Esc closes it and saving runs.
-func TestLayoutCutover_EnterOpensTasksOverlay(t *testing.T) {
+// TestLayoutCutover_EnterOpensTaskInEditMode is the #1249 guard: acting on a
+// task once (Enter on the section cursor's task) drops straight into that
+// task's editable config form — no second keypress to leave the list. Esc
+// steps back out of the form to the list (overlay still open), and a second
+// Esc closes the overlay.
+func TestLayoutCutover_EnterOpensTaskInEditMode(t *testing.T) {
 	h := newTestHome(t)
 	resizeHome(h, 100, 30)
 	tasks := []task.Task{
@@ -143,14 +148,24 @@ func TestLayoutCutover_EnterOpensTasksOverlay(t *testing.T) {
 	require.True(t, consumed)
 	require.Equal(t, stateTasks, h.state, "Enter opens the tasks overlay")
 	require.True(t, h.automations.TaskPane().HasFocus(), "the manager opens with input focus")
+	require.True(t, h.automations.TaskPane().IsEditing(),
+		"acting on a task once lands directly in its config editor (#1249)")
 
 	view := h.View()
 	requireViewSized(t, view, 100, 30)
-	assert.Contains(t, view, "Tasks", "the overlay hosts the manager list")
-	assert.Contains(t, view, "▸ [✓]  beta-task", "the manager preselects the section cursor's task")
+	assert.Contains(t, view, "Edit Task 2",
+		"the overlay opens the cursor's task straight into its edit form")
+	assert.Contains(t, view, "beta-task", "the form is prefilled with the selected task")
 
+	// First Esc backs the form out to the list — the overlay stays open.
 	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
-	assert.Equal(t, stateDefault, h.state, "Esc closes the overlay")
+	assert.Equal(t, stateTasks, h.state, "Esc from the form returns to the list, not out")
+	assert.False(t, h.automations.TaskPane().IsEditing(), "Esc leaves edit mode")
+	assert.Contains(t, h.View(), "n new", "the list view (and its key line) is back")
+
+	// Second Esc closes the overlay.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
+	assert.Equal(t, stateDefault, h.state, "Esc from the list closes the overlay")
 	assert.NotContains(t, h.View(), "n new", "the manager's key line leaves with the overlay")
 }
 

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -378,6 +378,18 @@ func (s *TaskPane) enterEditMode() {
 	s.editing = true
 }
 
+// EnterEditSelected drops straight into the edit form for the currently
+// selected task, no-op'ing when the list is empty (so an empty overlay stays
+// in list mode where `n` creates the first task). It bounds-guards the
+// selected index that the unexported enterEditMode assumes, letting the
+// overlay open a task directly into its config in a single action (#1249).
+func (s *TaskPane) EnterEditSelected() {
+	if len(s.tasks) == 0 {
+		return
+	}
+	s.enterEditMode()
+}
+
 // validateForm enforces the shared create/edit form contract, mirroring
 // `af tasks add` (api/tasks.go). The trigger-type selector already guarantees
 // at most one trigger, so validation reduces to: a name, a non-empty value

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -340,6 +340,63 @@ func TestTaskPaneEditModeCollapsesLegacyProgramToDefault(t *testing.T) {
 	}
 }
 
+// TestTaskPaneEnterEditSelectedEntersEditWhenTaskExists is the #1249 unit
+// guard: EnterEditSelected drops straight into the edit form for the selected
+// task, so the overlay can open a task into its editable config in a single
+// action rather than list-then-enter.
+func TestTaskPaneEnterEditSelectedEntersEditWhenTaskExists(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "* * * * *",
+		ProjectPath: newGitRepo(t),
+		Program:     "claude",
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.EnterEditSelected()
+	assert.True(t, tp.IsEditing(), "a single action must land directly in edit mode")
+}
+
+// TestTaskPaneEnterEditSelectedNoopsOnEmptyList verifies the empty-list guard:
+// with no tasks there is nothing to edit, so EnterEditSelected stays in list
+// mode where `n` can create the first task (and never indexes an empty slice).
+func TestTaskPaneEnterEditSelectedNoopsOnEmptyList(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{})
+	tp.SetFocus(true)
+	tp.EnterEditSelected()
+	assert.False(t, tp.IsEditing(), "empty list must stay in list mode so `n` works")
+}
+
+// TestTaskPaneEnterEditSelectedThenEscLeavesNoDirty is the #1213 guarantee for
+// the #1249 auto-open: merely opening a task into its edit form (then backing
+// out with Esc) must not mark the task dirty, so save-on-exit won't rewrite an
+// otherwise-untouched task over a concurrent CLI/daemon change.
+func TestTaskPaneEnterEditSelectedThenEscLeavesNoDirty(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "* * * * *",
+		ProjectPath: newGitRepo(t),
+		Program:     "claude",
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.EnterEditSelected()
+	assert.True(t, tp.IsEditing())
+
+	tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEsc}) // back out to list mode
+	assert.False(t, tp.IsEditing(), "Esc must return to the list")
+	assert.True(t, tp.HasFocus(), "Esc in edit mode keeps the overlay open")
+	assert.False(t, tp.IsDirty(), "auto-opening then cancelling must not mark the task dirty")
+	assert.Empty(t, tp.ConsumeDirty(), "no task should be persisted after a no-op open")
+}
+
 // TestTaskPaneEditModeCtrlCCancels is the regression guard for #526: Ctrl+C
 // inside the edit form must cancel the edit (matching Esc) instead of being
 // silently swallowed. Dirty buffer changes must not be written back.


### PR DESCRIPTION
## What & why

Editing an existing automation took **two** interactions, when it should take one:

| | Before (2 steps) | After (1 step) |
|---|---|---|
| **Open** | `S` (or Tab → Automations → Enter, or a task-row double-click) opens the tasks overlay in a **read-only list** | same key opens the overlay **directly in the selected task's editable config form** |
| **Edit** | a **second** `Enter` drops into the editable form | — already there |

Issue #1249: "Shouldn't need two clicks to start editing a task. Instead, it should enter into the task configuration automatically."

## The change

`showTasksOverlay()` is the single choke point shared by all three openers (`handle_actions.go` `S`, `handle_overlay.go` rail-Enter, `handle_mouse.go` double-click). After it preselects the in-rail cursor's task it now calls a new exported, **bounds-guarded** `TaskPane.EnterEditSelected()`:

- a task is selected → drop straight into its edit form;
- **empty list → no-op**, so the overlay still opens in list mode where `n` creates the first task (and we never index an empty slice).

Two production lines changed (`ui/task_pane.go`, `app/handle_overlay.go`); the rest is tests + doc comments.

## What's preserved (nothing else in the flow moves)

- **Esc backs the form out to the list** (overlay stays open), where the list-mode verbs live: `n` new, `x` toggle, `D` delete, `r` run, ↑/↓ navigate, `Enter` re-edit. A second `Esc` closes the overlay.
- **New-task creation** (`n` → form → `Enter`) unchanged.
- **#1213 dirty-tracking intact:** merely auto-opening a task into its form and Esc-ing out does **not** mark it dirty, so save-on-exit never rewrites an untouched task over a concurrent CLI/daemon change. Guarded by a new unit test.

## Tests

- `ui`: `EnterEditSelected` enters edit when a task exists; no-ops on empty list; auto-open-then-Esc leaves the pane clean (no dirty, nothing persisted).
- `app`: the overlay-open test now asserts the one-step edit + the Esc→list→Esc→close sequence; the overlay tests that drive list-mode `x`/`D` verbs step back to the list with `Esc` first (matching the new open-in-edit behavior).

## Gates (all green)

- `golangci-lint run --timeout=3m --fast` — clean
- `gofmt -l .` — empty
- `go build ./...` — OK
- `make test-container` — all packages `ok`
- `scripts/lint-file-length.sh` — passed
- `deadcode -test ./...` — clean

> Not merging — leaving this for verification + a driver play-test of the live TUI (open Automations, act on a task once → land in its editable config; edit+save; new-task+cancel).

Closes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Captain Claude <noreply@anthropic.com>