### PR TITLE
fix(tui): target focused pane on Enter

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1478,8 +1478,8 @@ func (m *home) selectionChanged() tea.Cmd {
 	if sel.Kind == ui.SectionInstances && !sel.IsHeader {
 		selected := m.sidebar.GetSelectedInstance()
 		// Track the cursor's instance in the store's display selection — what
-		// the pane verbs (`s`, Enter-from-tree, 1-9) act on — then re-clamp
-		// the active tab index against the new instance's tab count.
+		// selection-scoped verbs (`s`, Enter-from-tree, tree-focus 1-9) act on —
+		// then re-clamp the active tab index against the new instance's tab count.
 		m.store.SetSelectedInstance(selected)
 		m.clampSelectionTab()
 		m.menu.SetInstance(selected)

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -512,19 +512,22 @@ func killConfirmationWarning(wt string) string {
 // mode on the pane — every keystroke forwards to the agent/shell in place,
 // no full-screen takeover, Ctrl-] returns to nav.
 //
-// Enter resolves its target from the SIDEBAR SELECTION — the exact
-// target-resolution the open-pane verb (`s`, handleOpenPane) uses — and never
-// from the focus ring (#1233). Reading focusedOpenPane first was the
-// wrong-target-input bug: after Ctrl-] leaves interactive mode the ring stays
-// on instance A's pane, so selecting instance B and pressing Enter re-entered
-// interactive on the stale A pane — typing into the WRONG agent. Enter now
-// opens (or focuses) the SELECTED instance's pane, exactly like `s`, then
-// enters it — one path, always the current selection.
+// Enter resolves its target from context: a focused workspace pane owns Enter,
+// otherwise the SIDEBAR SELECTION owns Enter. The tree/nav path keeps the
+// #1233/#1236 stale-target fix because tree navigation re-homes the focus ring
+// on the tree before Enter is pressed; in that context Enter opens (or focuses)
+// the selected instance's pane, exactly like `s`, then enters it. But when the
+// ring is already on a pane, re-reading GetSelectedInstance would silently jump
+// input to whichever row the sidebar currently highlights (#1253).
 //
 // Bindings that cannot embed — remote instances, whose only local terminal is
 // the full-screen hook PTY — fall back to the full-screen attach Enter used to
 // do; dead/transitional sessions keep their guard errors.
 func (m *home) handleEnter() (tea.Model, tea.Cmd) {
+	if p := m.focusedOpenPane(); p != nil {
+		return m.enterPane(p)
+	}
+
 	sel := m.sidebar.GetSelection()
 
 	// Toggle expandable section headers (Instances and the Archived folder).
@@ -775,14 +778,23 @@ func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
 	return m, m.selectionChanged()
 }
 
-// handleTabJump jumps the selection's active tab to a 1-based tab number (the
-// 1-9 number keys). Out-of-range numbers are a no-op (#930 PR 4). When the
-// sidebar cursor rests on one of the selected instance's tab rows, it follows
-// the jump so the tree can't disagree; the jumped-to tab is what `s` opens
-// and Enter attaches (#1088 — panes are explicit bindings, so the jump moves
-// the selection, not any open pane).
+// handleTabJump jumps to a 1-based tab number (the 1-9 number keys). With a
+// pane focused, the pane's own binding changes tab; with tree focus, the
+// sidebar selection's active tab changes. Out-of-range numbers are a no-op
+// (#930 PR 4). When the sidebar cursor rests on one of the selected instance's
+// tab rows, it follows the tree-focus jump so the tree and active tab agree.
 func (m *home) handleTabJump(oneBased int) (tea.Model, tea.Cmd) {
 	idx := oneBased - 1
+	if p := m.focusedOpenPane(); p != nil {
+		w := m.paneWindows[p.ID()]
+		if w == nil || !w.JumpToTab(idx) {
+			return m, nil
+		}
+		if p == m.livePane {
+			m.syncLiveTermPane()
+		}
+		return m, m.selectionChanged()
+	}
 	if idx < 0 || idx >= len(tree.TabLabels(m.store.GetSelectedInstance())) {
 		return m, nil
 	}

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -209,26 +209,26 @@ func (m *home) reconcilePanesForTabs(instance *session.Instance, oldNames []stri
 // points at, so leaving the ring on a stale pane desyncs the two: the
 // full-screen attach verb `o` (handleAttach) reads the focus ring first and
 // would keep attaching the previously-focused pane's instance instead of the
-// just-selected one — the same wrong-target class as the #1233 Enter bug (Enter
-// itself now resolves purely from the selection, see handleEnter). After Ctrl-]
-// leaves interactive mode the ring stays on instance A's pane, so without this
-// a user who navigates to instance B and presses `o` would attach A. Re-homing
-// the ring on the tree makes `o` resolve the current selection fresh. No-op
-// unless a pane is focused, so it never churns the tree/automations ring or the
-// live attachment (which persists on its still-visible pane).
+// just-selected one — the same wrong-target class as the #1233 Enter bug. Enter
+// is context-dependent now: a focused pane owns Enter, while tree focus resolves
+// the current selection. After Ctrl-] leaves interactive mode the ring stays on
+// instance A's pane, so without this a user who navigates to instance B and
+// presses `o` or Enter would target A. Re-homing the ring on the tree makes
+// those verbs resolve the current selection fresh. No-op unless a pane is
+// focused, so it never churns the tree/automations ring or the live attachment
+// (which persists on its still-visible pane).
 func (m *home) focusTreeForNav() {
 	if layout.IsPaneRegion(m.ring.Active()) {
 		m.focusRegion(layout.RegionTree)
 	}
 }
 
-// enterPane enters interactive mode on a SPECIFIC pane — the mouse
-// click-to-interact target (§2.5). Keyboard Enter (handleEnter) resolves the
-// SIDEBAR SELECTION so it can never type into a stale focused pane (#1233); a
-// body click, by contrast, has already named its exact pane, so it enters that
-// one directly. Remote/non-embeddable panes fall back to the full-screen attach
-// of the pane's tab, mirroring handleEnter's remote branch; guard errors
-// surface the same way.
+// enterPane enters interactive mode on a SPECIFIC pane — the keyboard
+// focused-pane target and the mouse click-to-interact target (§2.5). Tree-focus
+// Enter still resolves through the sidebar selection; callers that already have
+// a pane binding enter that pane directly. Remote/non-embeddable panes fall
+// back to the full-screen attach of the pane's tab, mirroring handleEnter's
+// remote branch; guard errors surface the same way.
 func (m *home) enterPane(p *store.OpenPane) (tea.Model, tea.Cmd) {
 	if p == nil {
 		return m, nil

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/layout"
 )
 
 // ----------------------------------------------------------------------------
@@ -189,12 +190,11 @@ func TestEnterFromTreeOpensPaneAndEntersInteractive(t *testing.T) {
 	require.Len(t, *fakes, 1)
 }
 
-// TestSecondEnterTargetsCurrentSelectionNotStalePane is the #1233 P1
+// TestSecondEnterTargetsCurrentSelectionNotStalePane is the #1233/#1236 P1
 // wrong-target-input regression: enter interactive on instance A, Ctrl-] to
-// nav, select a DIFFERENT instance B, Enter again. Input must route to B — the
-// current selection — never the pane the focus ring was left on (A). Enter
-// resolving from focusedOpenPane (the stale A pane) was the bug; it now
-// resolves purely from the sidebar selection, exactly like the open verb.
+// nav, select a DIFFERENT instance B through the real tree-nav keys, Enter
+// again. Tree navigation must re-home focus to the tree, so Enter routes to B
+// — the current selection — never the pane focus was previously left on (A).
 func TestSecondEnterTargetsCurrentSelectionNotStalePane(t *testing.T) {
 	h := newTestHome(t)
 	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
@@ -253,12 +253,11 @@ func TestSecondEnterTargetsCurrentSelectionNotStalePane(t *testing.T) {
 	assert.Empty(t, aFake.keys, "the previously-interacted instance A must receive nothing")
 }
 
-// TestEnterResolvesFromSelectionNotFocusRing pins the #1233 fix at the source:
-// with the focus ring left on instance A's pane but the sidebar selection on
-// instance B, Enter must act on the SELECTION (B), the same target-resolution
-// the open verb uses — never the focused pane. This isolates handleEnter's
-// resolution from the focus-rehoming nav helper.
-func TestEnterResolvesFromSelectionNotFocusRing(t *testing.T) {
+// TestEnterWithFocusedPaneTargetsFocusNotSidebarSelection pins #1253: with two
+// panes open, a focused pane owns Enter even if the sidebar selection points at
+// another instance. Switching the sidebar selection while a pane is focused
+// must not silently retarget input to the selected row.
+func TestEnterWithFocusedPaneTargetsFocusNotSidebarSelection(t *testing.T) {
 	h := newTestHome(t)
 	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
 	instA := startedLocalInstance(t, "alpha")
@@ -266,29 +265,31 @@ func TestEnterResolvesFromSelectionNotFocusRing(t *testing.T) {
 	h.store.AddInstance(instA)
 	h.store.AddInstance(instB)
 	resizeHome(h, 200, 40)
-	_, _ = stubLiveTermFactory(t)
+	fakes, _ := stubLiveTermFactory(t)
 
-	// Open A's pane and leave the focus ring on it.
+	// Open both panes, then focus A while the sidebar selection points at B.
 	paneA := openTestPane(t, h, instA, 0)
+	paneB := openTestPane(t, h, instB, 0)
+	require.Equal(t, paneB, h.focusedOpenPane(), "opening B focuses B")
+	h.focusRegion(layout.PaneRegion(paneA.ID()))
 	require.Equal(t, paneA, h.focusedOpenPane(), "A's pane must hold the focus ring")
 
-	// Point the selection at B while the ring stays on A's pane — the exact
-	// desync the wrong-target bug exploited.
 	h.sidebar.SetSelectedInstance(1)
 	h.store.SetSelectedInstance(instB)
 	h.clampSelectionTab()
 	require.Equal(t, instB, h.sidebar.GetSelectedInstance())
 
-	// Enter must open/enter B, not the focused A pane.
-	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
-	p := h.focusedOpenPane()
-	require.NotNil(t, p, "Enter must open the selection's pane")
-	assert.Equal(t, instB, p.Instance(), "Enter must resolve the SELECTED instance B, not the focused A pane")
-
-	_, cmd := h.Update(enterInteractiveMsg{pane: p})
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
 	runHermeticCmd(t, h, cmd, 0)
-	assert.True(t, h.interactive, "Enter must enter interactive mode on B")
-	assert.Equal(t, instB, h.livePane.Instance(), "input must bind to B")
+
+	require.True(t, h.interactive, "Enter must enter interactive mode")
+	require.Equal(t, paneA, h.focusedOpenPane(), "Enter must keep focus on pane A")
+	require.Equal(t, paneA, h.livePane, "input must bind to focused pane A")
+	assert.Equal(t, instA, h.livePane.Instance(), "input must target A, not sidebar-selected B")
+	assert.Equal(t, instB, h.sidebar.GetSelectedInstance(), "sidebar selection is unchanged")
+	require.Len(t, *fakes, 1)
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Z")})
+	assert.Equal(t, []string{"Z"}, (*fakes)[0].keys)
 }
 
 func TestEnterOnRemotePaneFallsBackToFullScreenAttach(t *testing.T) {

--- a/app/layout_cutover_test.go
+++ b/app/layout_cutover_test.go
@@ -338,10 +338,12 @@ func TestLayoutCutover_DigitJumpGatedByFocusRegion(t *testing.T) {
 	require.Equal(t, 1, h.store.ActiveTab(),
 		"a digit with the automations strip focused must not retarget the selection")
 
-	// A workspace pane focused: digit jumps again.
+	// A workspace pane focused: digit jumps the pane binding without
+	// retargeting the sidebar selection's active tab.
 	alpha := h.store.GetSelectedInstance()
-	openTestPane(t, h, alpha, 0)
+	p := openTestPane(t, h, alpha, 1)
 	require.True(t, layout.IsPaneRegion(h.ring.Active()))
 	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("1")})
-	require.Equal(t, 0, h.store.ActiveTab(), "digit with pane focus jumps tabs")
+	require.Equal(t, 1, h.store.ActiveTab(), "digit with pane focus must not retarget the selection")
+	require.Equal(t, 0, p.Tab(), "digit with pane focus jumps the focused pane's tab")
 }

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -163,6 +163,7 @@ func TestPane_TabDimension(t *testing.T) {
 
 	// Jumping the selection tab must not move the open pane's binding —
 	// and s on the OTHER tab of the same instance opens a second pane.
+	h.focusRegion(layout.RegionTree)
 	_, _ = h.handleTabJump(1)
 	require.Equal(t, 0, h.store.ActiveTab())
 	assert.Equal(t, 1, terminalPane.Tab(), "the pane's tab is bound independently of the selection")
@@ -170,6 +171,46 @@ func TestPane_TabDimension(t *testing.T) {
 	pressKey(t, h, "s")
 	require.Equal(t, 2, h.store.NumOpenPanes(), "each (instance, tab) pair is its own pane")
 	assert.Equal(t, 0, h.store.OpenPanes()[1].Tab())
+}
+
+// TestPane_NumberJumpTargetsFocusedPaneNotSidebarSelection covers the sibling
+// target-resolution path from #1253: digit jumps are routed while a pane is
+// focused, so they must retarget that pane's tab binding instead of the
+// sidebar-selected instance's active tab.
+func TestPane_NumberJumpTargetsFocusedPaneNotSidebarSelection(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Same(t, alpha, paneA.Instance())
+	require.Equal(t, 0, paneA.Tab())
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	pressKey(t, h, "s")
+	paneB := h.store.OpenPanes()[1]
+	require.Same(t, beta, h.store.GetSelectedInstance())
+	require.Same(t, beta, paneB.Instance())
+	require.Equal(t, 0, h.store.ActiveTab())
+
+	h.focusRegion(layout.PaneRegion(paneA.ID()))
+	_, _ = h.handleTabJump(2)
+
+	assert.Equal(t, 1, paneA.Tab(), "focused pane A must jump to tab 2")
+	assert.Equal(t, 0, paneB.Tab(), "sidebar-selected pane B must not be retargeted")
+	assert.Equal(t, 0, h.store.ActiveTab(), "sidebar active tab must stay on B's tab 1")
+	assert.Same(t, beta, h.store.GetSelectedInstance(), "sidebar selection must stay on B")
+
+	h.focusRegion(layout.RegionTree)
+	_, _ = h.handleTabJump(2)
+
+	assert.Equal(t, 1, h.store.ActiveTab(), "tree-focus jump must still target the sidebar selection")
+	assert.Equal(t, 1, paneA.Tab(), "tree-focus jump must not mutate pane A further")
+	assert.Equal(t, 0, paneB.Tab(), "tree-focus jump only changes the selection's active tab")
 }
 
 // TestPane_FocusRingCyclesNPanes: with three panes open, Tab cycles
@@ -536,13 +577,11 @@ func TestPane_FollowsSameTitleSwap(t *testing.T) {
 		"open-pane bindings must follow a same-title swap (#765 class)")
 }
 
-// TestPane_EnterAttachesSelectionNotFocusedPane: keyboard Enter resolves its
-// target from the SIDEBAR SELECTION — like the open verb — never the focus ring
-// (#1233). With a non-embeddable selection it falls back to the full-screen
-// attach of that selection, whether the ring sits on a pane or the tree; detach
-// hands back focus + panes intact. (The mouse click-to-interact path, which
-// enters the CLICKED pane, is covered by the mouse suite via enterPane.)
-func TestPane_EnterAttachesSelectionNotFocusedPane(t *testing.T) {
+// TestPane_EnterAttachTargetFollowsFocusContext: for non-embeddable panes,
+// keyboard Enter follows the same context rule as the embedded path. A focused
+// pane owns Enter even when the sidebar selection points elsewhere (#1253);
+// with tree focus, Enter falls back to the sidebar selection (#1233/#1236).
+func TestPane_EnterAttachTargetFollowsFocusContext(t *testing.T) {
 	resetDetachWatchdog(t)
 	h := paneTestHome(t)
 	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInstanceAttach{}.mask()))
@@ -565,15 +604,15 @@ func TestPane_EnterAttachesSelectionNotFocusedPane(t *testing.T) {
 		})
 	})
 
-	// Focus alpha's pane: Enter must STILL attach the selection (beta), never
-	// the focused alpha pane — the wrong-target class the #1233 fix closed.
+	// Focus alpha's pane: Enter must attach alpha, never silently retarget to
+	// the sidebar-selected beta.
 	h.focusRegion(layout.PaneRegion(p.ID()))
 	_, cmd := h.handleEnter()
-	require.NotNil(t, cmd, "the selection attach must run")
-	assert.Equal(t, "handleEnter-sidebar", attachedLabel,
-		"Enter resolves the selection, not the focused pane (#1233)")
-	assert.Equal(t, "beta", attachedTitle,
-		"Enter must target the selected beta, not the focused alpha pane")
+	require.NotNil(t, cmd, "the focused-pane attach must run")
+	assert.Equal(t, "handleEnter-pane", attachedLabel,
+		"focused-pane Enter must use the pane attach path")
+	assert.Equal(t, "alpha", attachedTitle,
+		"Enter must target focused alpha, not sidebar-selected beta")
 	endDetachWatchdog()
 
 	// Detach restored everything: focus still on the pane, binding intact.
@@ -581,7 +620,7 @@ func TestPane_EnterAttachesSelectionNotFocusedPane(t *testing.T) {
 	assert.Equal(t, 1, h.store.NumOpenPanes(), "detach keeps the pane open")
 	assert.Equal(t, "alpha", h.store.OpenPanes()[0].Instance().Title)
 
-	// Focus the tree: Enter attaches the same selection.
+	// Focus the tree: Enter attaches the sidebar selection.
 	h.focusRegion(layout.RegionTree)
 	_, cmd = h.handleEnter()
 	require.NotNil(t, cmd)


### PR DESCRIPTION
## Summary
- Make Enter context-dependent: focused pane wins when the focus ring is on an open pane; tree/nav focus keeps the sidebar-selected open/focus path from #1236.
- Keep full-screen attach (`o`) aligned with the focused-pane-first model and update Enter attach coverage for non-embeddable panes.
- Fix the adjacent digit tab-jump sibling so 1-9 mutates the focused pane binding when a pane has focus, while tree focus still changes the sidebar-selected active tab.

## Verification
- `./scripts/testbox.sh test ./app -run 'Test(EnterWithFocusedPaneTargetsFocusNotSidebarSelection|SecondEnterTargetsCurrentSelectionNotStalePane|Pane_EnterAttachTargetFollowsFocusContext|Pane_NumberJumpTargetsFocusedPaneNotSidebarSelection)$'`
- Driver play-test in `scripts/testbox.sh playtest -d`: two panes open, beta selected in sidebar, alpha focused; Enter wrote `$PWD` from alpha. Then tree-focus Enter with beta selected wrote `$PWD` from beta.
- `gofmt -l` empty
- `golangci-lint run --fast`
- `go build ./...`
- `scripts/lint-file-length.sh`
- `make test-container`

Closes #1253

Signed-off-by: Captain Claude <captain-claude@sachiniyer.com>