### PR TITLE
fix(tmux): submit prompts to codex via bracketed paste (#1254)

### DIFF
--- a/scripts/file-length-allowlist.txt
+++ b/scripts/file-length-allowlist.txt
@@ -20,7 +20,7 @@
 daemon/control.go 2587
 app/app.go 1867
 session/instance.go 1531
-session/tmux/tmux.go 1424
+session/tmux/tmux.go 1402
 ui/sidebar.go 1258
 config/config.go 1128
 daemon/watcher.go 1011

--- a/scripts/file-length-allowlist.txt
+++ b/scripts/file-length-allowlist.txt
@@ -20,7 +20,7 @@
 daemon/control.go 2587
 app/app.go 1867
 session/instance.go 1531
-session/tmux/tmux.go 1402
+session/tmux/tmux.go 1393
 ui/sidebar.go 1258
 config/config.go 1128
 daemon/watcher.go 1011

--- a/session/tmux/program.go
+++ b/session/tmux/program.go
@@ -1,0 +1,37 @@
+package tmux
+
+// Program-command accessors for TmuxSession.
+//
+// program is the command the pane runs (override-resolved, flag-injected). It
+// is not immutable: Restore() rewrites it (resume-flag injection, #595) on the
+// restore goroutine while the status-poll and prompt-delivery goroutines read
+// it (readiness heuristics, submit routing). Every access therefore goes
+// through these helpers under programMu — the codex submit path reading program
+// is what first exposed this data race under `go test -race` (#1254).
+
+// SetProgram updates the program command before the session is started.
+func (t *TmuxSession) SetProgram(program string) {
+	t.setProgramCmd(program)
+}
+
+// Program returns the command this session's pane runs — after SetProgram,
+// the override-resolved, flag-injected string. This is the ground truth for
+// agent detection (DetectAgentFromCommand): what actually runs in the pane,
+// as opposed to the config-name enum the instance was created with (#1116).
+func (t *TmuxSession) Program() string {
+	return t.programCmd()
+}
+
+// programCmd returns the pane's program command string under programMu.
+func (t *TmuxSession) programCmd() string {
+	t.programMu.RLock()
+	defer t.programMu.RUnlock()
+	return t.program
+}
+
+// setProgramCmd stores the pane's program command string under programMu.
+func (t *TmuxSession) setProgramCmd(program string) {
+	t.programMu.Lock()
+	defer t.programMu.Unlock()
+	t.program = program
+}

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -1,0 +1,83 @@
+package tmux
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// SendKeysCommand sends text to the tmux pane using the `tmux send-keys` command
+// instead of writing to the PTY. This is more reliable for headless/scheduled runs
+// where the PTY connection may not persist. Text is sent literally (with -l flag)
+// followed by a pause to let terminal control sequences drain, then Enter to submit.
+//
+// Codex is the exception: its composer runs paste-burst detection, so a large
+// run of characters delivered via `send-keys -l` is treated as an in-progress
+// paste and a following Enter is absorbed into it as a newline rather than
+// submitting. The prompt lands in the input box but never sends until a human
+// presses Enter (#1254). Codex therefore takes the bracketed-paste path, which
+// gives it an explicit end-of-paste marker so the trailing Enter is
+// unambiguously a submit. Submit handling is keyed off the agent actually
+// running in the pane (DetectAgentFromCommand), mirroring HasUpdated's
+// per-agent prompt heuristics, so a program_overrides redirect can't
+// misclassify the pane.
+func (t *TmuxSession) SendKeysCommand(text string) error {
+	if DetectAgentFromCommand(t.program) == ProgramCodex {
+		return t.sendKeysBracketedPaste(text)
+	}
+
+	// Send text literally to avoid key name interpretation. `=` forces an
+	// exact session match so input is never sent to a prefix-matched sibling
+	// session if the agent session has died (#1006).
+	textCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "-l", text)
+	if err := t.cmdExec.Run(textCmd); err != nil {
+		return fmt.Errorf("error sending text via send-keys: %w", err)
+	}
+
+	// Wait for terminal control sequences (e.g. OSC color responses) to drain
+	// before sending Enter, otherwise they can corrupt the input
+	time.Sleep(500 * time.Millisecond)
+
+	// Send Enter separately to submit
+	enterCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "Enter")
+	return t.cmdExec.Run(enterCmd)
+}
+
+// sendKeysBracketedPaste delivers text to the pane as a bracketed paste (`tmux
+// load-buffer` + `paste-buffer -p`) and then sends Enter to submit. tmux's `-p`
+// only wraps the buffer in bracketed-paste control codes when the running
+// application has actually requested bracketed-paste mode, so this is safe even
+// mid-dialog (it degrades to a plain paste). The end-of-paste marker lets codex
+// finalize its input buffer immediately, so the following Enter submits instead
+// of being swallowed by paste-burst detection (#1254). Text is streamed via
+// stdin rather than an argv argument so arbitrarily large prompts are not
+// bounded by ARG_MAX.
+func (t *TmuxSession) sendKeysBracketedPaste(text string) error {
+	// One buffer name per session; sends to a single session are serialized, so
+	// reuse (load-buffer overwrites) is fine and `-d` clears it after pasting so
+	// buffers never accumulate.
+	buf := "af_paste_" + t.sanitizedName
+
+	loadCmd := exec.Command("tmux", "load-buffer", "-b", buf, "-")
+	loadCmd.Stdin = strings.NewReader(text)
+	if err := t.cmdExec.Run(loadCmd); err != nil {
+		return fmt.Errorf("error loading paste buffer: %w", err)
+	}
+
+	// `-p` inserts bracketed-paste markers (when the app requested the mode),
+	// `-d` deletes the buffer after pasting, `=` forces an exact session match
+	// so input never reaches a prefix-matched sibling session (#1006).
+	pasteCmd := exec.Command("tmux", "paste-buffer", "-d", "-p", "-b", buf, "-t", exactTarget(t.sanitizedName))
+	if err := t.cmdExec.Run(pasteCmd); err != nil {
+		return fmt.Errorf("error pasting buffer: %w", err)
+	}
+
+	// Wait for terminal control sequences (e.g. OSC color responses) and the
+	// paste to drain before sending Enter, otherwise they can corrupt the input.
+	time.Sleep(500 * time.Millisecond)
+
+	// Send Enter separately to submit.
+	enterCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "Enter")
+	return t.cmdExec.Run(enterCmd)
+}

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -23,7 +23,7 @@ import (
 // per-agent prompt heuristics, so a program_overrides redirect can't
 // misclassify the pane.
 func (t *TmuxSession) SendKeysCommand(text string) error {
-	if DetectAgentFromCommand(t.program) == ProgramCodex {
+	if DetectAgentFromCommand(t.programCmd()) == ProgramCodex {
 		return t.sendKeysBracketedPaste(text)
 	}
 

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -4,8 +4,17 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"time"
 )
+
+// pasteBufferSeq makes each bracketed-paste buffer name unique per call so two
+// concurrent deliveries to the same session can never race on a shared tmux
+// buffer (load-buffer overwrite between another call's load and paste). The
+// daemon op-lock usually serializes same-session deliveries, but the submit
+// path releases the instance lock before these tmux calls, so it must not
+// assume serialization.
+var pasteBufferSeq atomic.Uint64
 
 // SendKeysCommand sends text to the tmux pane using the `tmux send-keys` command
 // instead of writing to the PTY. This is more reliable for headless/scheduled runs
@@ -54,10 +63,11 @@ func (t *TmuxSession) SendKeysCommand(text string) error {
 // stdin rather than an argv argument so arbitrarily large prompts are not
 // bounded by ARG_MAX.
 func (t *TmuxSession) sendKeysBracketedPaste(text string) error {
-	// One buffer name per session; sends to a single session are serialized, so
-	// reuse (load-buffer overwrites) is fine and `-d` clears it after pasting so
-	// buffers never accumulate.
-	buf := "af_paste_" + t.sanitizedName
+	// A per-call unique buffer name: two concurrent deliveries to the same
+	// session must not share a buffer, or one call's load-buffer could overwrite
+	// the other's content between its load and paste and corrupt the submit.
+	// `-d` clears the buffer after pasting so buffers never accumulate.
+	buf := fmt.Sprintf("af_paste_%s_%d", t.sanitizedName, pasteBufferSeq.Add(1))
 
 	loadCmd := exec.Command("tmux", "load-buffer", "-b", buf, "-")
 	loadCmd.Stdin = strings.NewReader(text)

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -1,0 +1,113 @@
+package tmux
+
+import (
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/stretchr/testify/require"
+)
+
+// recordedCmd is a captured tmux invocation: the argv plus, for `load-buffer -`,
+// whatever was streamed on stdin (so the test can assert the paste payload).
+type recordedCmd struct {
+	args  []string
+	stdin string
+}
+
+func recordTmuxCommands(t *testing.T, program string, text string) []recordedCmd {
+	t.Helper()
+	var cmds []recordedCmd
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			rec := recordedCmd{args: c.Args}
+			if c.Stdin != nil {
+				b, _ := io.ReadAll(c.Stdin)
+				rec.stdin = string(b)
+			}
+			cmds = append(cmds, rec)
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+
+	session := newTmuxSession("af_proj", program, NewMockPtyFactory(t), cmdExec)
+	require.NoError(t, session.SendKeysCommand(text))
+	return cmds
+}
+
+func joinedArgs(cmds []recordedCmd) []string {
+	out := make([]string, len(cmds))
+	for i, c := range cmds {
+		out[i] = strings.Join(c.args, " ")
+	}
+	return out
+}
+
+// TestCodexSubmitUsesBracketedPaste is the #1254 regression: codex's composer
+// swallows the trailing Enter after a plain `send-keys -l` paste (paste-burst
+// detection), so the prompt lands but never submits. Codex must instead deliver
+// the text as a bracketed paste (`load-buffer` + `paste-buffer -p`) which gives
+// codex an explicit end-of-paste marker, and only THEN send Enter to submit.
+func TestCodexSubmitUsesBracketedPaste(t *testing.T) {
+	const prompt = "a big multi-line dispatch prompt"
+	cmds := recordTmuxCommands(t, "codex", prompt)
+	joined := joinedArgs(cmds)
+
+	require.Len(t, cmds, 3, "codex submit is load-buffer, paste-buffer, send-keys Enter; got %v", joined)
+
+	// 1. Text is streamed into a buffer via stdin (not an argv arg → no ARG_MAX
+	//    ceiling for large prompts) and never as `send-keys -l`.
+	require.Contains(t, joined[0], "load-buffer", "first command must load the paste buffer; got %v", joined)
+	require.Equal(t, prompt, cmds[0].stdin, "paste text must be streamed on stdin")
+	for _, j := range joined {
+		require.NotContains(t, j, "send-keys -t =af_proj: -l",
+			"codex must not use the plain literal send-keys path that gets swallowed (#1254); got %v", joined)
+	}
+
+	// 2. The paste is bracketed (-p) so codex gets an end-of-paste marker, and
+	//    the buffer is deleted after (-d) so buffers don't accumulate.
+	require.Contains(t, joined[1], "paste-buffer", "second command must paste the buffer; got %v", joined)
+	require.Contains(t, joined[1], "-p", "paste must be bracketed (-p) so codex sees the paste boundary")
+	require.Contains(t, joined[1], "-d", "paste must delete the buffer afterward (-d)")
+
+	// 3. Enter is a SEPARATE command issued last — this is what actually submits.
+	require.Contains(t, joined[2], "send-keys", "last command must send Enter; got %v", joined)
+	require.Contains(t, joined[2], "Enter", "last command must send Enter to submit; got %v", joined)
+
+	// Every targeted command keeps the #1006 exact-match target.
+	for _, c := range cmds {
+		if tgt := targetOf(c.args); tgt != "" {
+			require.Equal(t, "=af_proj:", tgt,
+				"codex submit commands must target by exact match (#1006); got %q in %v", tgt, joined)
+		}
+	}
+}
+
+// TestNonCodexSubmitUsesLiteralSendKeys guards against regressing the agents
+// that already submit fine (claude/aider/gemini and unknown/override panes):
+// they keep the plain `send-keys -l` + Enter path and must not switch to
+// bracketed paste.
+func TestNonCodexSubmitUsesLiteralSendKeys(t *testing.T) {
+	for _, program := range []string{"claude", "aider", "gemini", "some-custom-shell"} {
+		t.Run(program, func(t *testing.T) {
+			cmds := recordTmuxCommands(t, program, "hello")
+			joined := joinedArgs(cmds)
+
+			require.Len(t, cmds, 2, "literal path is send-keys -l then send-keys Enter; got %v", joined)
+			require.Contains(t, joined[0], "send-keys", "first command must be send-keys; got %v", joined)
+			require.Contains(t, joined[0], "-l", "non-codex must send text literally; got %v", joined)
+			require.Contains(t, joined[0], "hello", "literal text must be passed as an argv arg; got %v", joined)
+			require.Contains(t, joined[1], "Enter", "second command must submit with Enter; got %v", joined)
+
+			for _, j := range joined {
+				require.NotContains(t, j, "paste-buffer",
+					"non-codex agents must not use the bracketed-paste path; got %v", joined)
+				require.NotContains(t, j, "load-buffer",
+					"non-codex agents must not use the bracketed-paste path; got %v", joined)
+			}
+		})
+	}
+}

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -1,9 +1,11 @@
 package tmux
 
 import (
+	"fmt"
 	"io"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
@@ -46,6 +48,16 @@ func joinedArgs(cmds []recordedCmd) []string {
 	return out
 }
 
+// bufferOf returns the `-b <name>` buffer argument from a tmux argv, or "".
+func bufferOf(args []string) string {
+	for i, a := range args {
+		if a == "-b" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
 // TestCodexSubmitUsesBracketedPaste is the #1254 regression: codex's composer
 // swallows the trailing Enter after a plain `send-keys -l` paste (paste-burst
 // detection), so the prompt lands but never submits. Codex must instead deliver
@@ -68,10 +80,14 @@ func TestCodexSubmitUsesBracketedPaste(t *testing.T) {
 	}
 
 	// 2. The paste is bracketed (-p) so codex gets an end-of-paste marker, and
-	//    the buffer is deleted after (-d) so buffers don't accumulate.
+	//    the buffer is deleted after (-d) so buffers don't accumulate. The paste
+	//    reads back the SAME buffer the load wrote (no cross-talk).
 	require.Contains(t, joined[1], "paste-buffer", "second command must paste the buffer; got %v", joined)
 	require.Contains(t, joined[1], "-p", "paste must be bracketed (-p) so codex sees the paste boundary")
 	require.Contains(t, joined[1], "-d", "paste must delete the buffer afterward (-d)")
+	loadBuf, pasteBuf := bufferOf(cmds[0].args), bufferOf(cmds[1].args)
+	require.NotEmpty(t, loadBuf, "load-buffer must name a buffer; got %v", joined)
+	require.Equal(t, loadBuf, pasteBuf, "paste must read back the buffer the load wrote; got %v", joined)
 
 	// 3. Enter is a SEPARATE command issued last — this is what actually submits.
 	require.Contains(t, joined[2], "send-keys", "last command must send Enter; got %v", joined)
@@ -110,4 +126,59 @@ func TestNonCodexSubmitUsesLiteralSendKeys(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCodexSubmitConcurrentDeliveriesUseDistinctBuffers is the Greptile
+// shared-buffer-race guard (#1256 review): the submit path releases the
+// instance lock before its tmux calls, so two concurrent codex deliveries to
+// the SAME session can interleave. If they shared one buffer name, one call's
+// load-buffer could overwrite the other's content between its load and paste
+// and corrupt the submit. Each delivery must therefore use a per-call unique
+// buffer, and every paste must read back the buffer its own load wrote.
+func TestCodexSubmitConcurrentDeliveriesUseDistinctBuffers(t *testing.T) {
+	const workers = 24
+
+	var mu sync.Mutex
+	var loadBufs []string
+	pasteBufs := map[string]bool{}
+
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			mu.Lock()
+			defer mu.Unlock()
+			if strings.Contains(joined, "load-buffer") {
+				loadBufs = append(loadBufs, bufferOf(c.Args))
+			}
+			if strings.Contains(joined, "paste-buffer") {
+				pasteBufs[bufferOf(c.Args)] = true
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+	// One shared session — the same sanitizedName for every delivery, which is
+	// exactly the case where a fixed `af_paste_<name>` buffer would collide.
+	session := newTmuxSession("af_proj", "codex", NewMockPtyFactory(t), cmdExec)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			require.NoError(t, session.SendKeysCommand(fmt.Sprintf("prompt %d", i)))
+		}(i)
+	}
+	wg.Wait()
+
+	require.Len(t, loadBufs, workers, "every delivery must load its own buffer")
+	unique := map[string]bool{}
+	for _, b := range loadBufs {
+		require.NotEmpty(t, b, "load-buffer must name a buffer")
+		require.False(t, unique[b], "buffer name %q reused across concurrent deliveries — shared-buffer race", b)
+		unique[b] = true
+	}
+	// Every paste targeted a buffer that some load wrote, and no fixed name was
+	// shared across all calls.
+	require.Equal(t, unique, pasteBufs, "each paste must read back a per-call load buffer")
 }

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -726,28 +726,6 @@ func (t *TmuxSession) SendKeys(keys string) error {
 	return err
 }
 
-// SendKeysCommand sends text to the tmux pane using the `tmux send-keys` command
-// instead of writing to the PTY. This is more reliable for headless/scheduled runs
-// where the PTY connection may not persist. Text is sent literally (with -l flag)
-// followed by a pause to let terminal control sequences drain, then Enter to submit.
-func (t *TmuxSession) SendKeysCommand(text string) error {
-	// Send text literally to avoid key name interpretation. `=` forces an
-	// exact session match so input is never sent to a prefix-matched sibling
-	// session if the agent session has died (#1006).
-	textCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "-l", text)
-	if err := t.cmdExec.Run(textCmd); err != nil {
-		return fmt.Errorf("error sending text via send-keys: %w", err)
-	}
-
-	// Wait for terminal control sequences (e.g. OSC color responses) to drain
-	// before sending Enter, otherwise they can corrupt the input
-	time.Sleep(500 * time.Millisecond)
-
-	// Send Enter separately to submit
-	enterCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "Enter")
-	return t.cmdExec.Run(enterCmd)
-}
-
 // HasUpdated checks if the tmux pane content has changed since the last tick. It also returns true if the tmux
 // pane has a prompt for aider or claude code, plus the raw captured content so the daemon's usage-limit detector (#1146) can inspect it without a second capture ("" on early return).
 func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool, content string) {

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -38,7 +38,11 @@ type TmuxSession struct {
 	//
 	// The name of the tmux session and the sanitized name used for tmux commands.
 	sanitizedName string
-	program       string
+	// program is the command the pane runs. It is mutated by Restore() while
+	// other goroutines read it, so all access goes through the programMu-guarded
+	// accessors in program.go (#1254) — never touch these two fields directly.
+	program   string
+	programMu sync.RWMutex
 	// ptyFactory is used to create a PTY for the tmux session.
 	ptyFactory PtyFactory
 	// cmdExec is used to execute commands in the tmux session.
@@ -225,19 +229,6 @@ func newTmuxSession(sanitizedName string, program string, ptyFactory PtyFactory,
 	}
 }
 
-// SetProgram updates the program command before the session is started.
-func (t *TmuxSession) SetProgram(program string) {
-	t.program = program
-}
-
-// Program returns the command this session's pane runs — after SetProgram,
-// the override-resolved, flag-injected string. This is the ground truth for
-// agent detection (DetectAgentFromCommand): what actually runs in the pane,
-// as opposed to the config-name enum the instance was created with (#1116).
-func (t *TmuxSession) Program() string {
-	return t.program
-}
-
 // NewSiblingSession builds a second TmuxSession in the same worktree that
 // shares this session's PTY factory and command executor. Used for the #930
 // per-tab sessions (e.g. an instance's shell tab alongside its agent tab):
@@ -263,7 +254,7 @@ func (t *TmuxSession) Start(workDir string) error {
 	// spawns back to this session even after it is orphaned (#1104).
 	args := []string{"new-session", "-d", "-s", t.sanitizedName, "-c", workDir}
 	args = append(args, sessionEnvFlags(t.sanitizedName)...)
-	args = append(args, t.program)
+	args = append(args, t.programCmd())
 	cmd := exec.Command("tmux", args...)
 
 	ptmx, err := t.ptyFactory.Start(cmd)
@@ -292,7 +283,7 @@ func (t *TmuxSession) Start(workDir string) error {
 			// takes the whole tmux session down before this existence poll
 			// ever sees it — name the likely cause and the exact command so
 			// the user isn't left with a bare timeout (#1116, #1131).
-			timeoutErr := fmt.Errorf("timed out waiting for tmux session %s; the pane program may have exited immediately after launch — check that it runs and accepts its flags (program: %q)", t.sanitizedName, t.program)
+			timeoutErr := fmt.Errorf("timed out waiting for tmux session %s; the pane program may have exited immediately after launch — check that it runs and accepts its flags (program: %q)", t.sanitizedName, t.programCmd())
 			if cleanupErr := t.Close(); cleanupErr != nil {
 				timeoutErr = fmt.Errorf("%v (cleanup error: %v)", timeoutErr, cleanupErr)
 			}
@@ -332,7 +323,7 @@ func (t *TmuxSession) Start(workDir string) error {
 			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
 		}
 		if vanished {
-			return fmt.Errorf("tmux session %s vanished before attach; the pane program likely exited immediately after launch — check that it runs and accepts its flags (program: %q): %w", t.sanitizedName, t.program, err)
+			return fmt.Errorf("tmux session %s vanished before attach; the pane program likely exited immediately after launch — check that it runs and accepts its flags (program: %q): %w", t.sanitizedName, t.programCmd(), err)
 		}
 		return fmt.Errorf("error restoring tmux session: %w", err)
 	}
@@ -351,7 +342,7 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 	// Key off the agent actually running in the pane, token-matched — a loose
 	// substring check would route e.g. /opt/claude-wrapper/run through the
 	// claude branch (#1116 defect class).
-	if DetectAgentFromCommand(t.program) == ProgramClaude {
+	if DetectAgentFromCommand(t.programCmd()) == ProgramClaude {
 		if strings.Contains(content, "Do you trust the files in this folder?") ||
 			strings.Contains(content, "new MCP server") {
 			if err := t.TapEnter(); err != nil {
@@ -391,7 +382,7 @@ func (t *TmuxSession) Restore(workDir string) error {
 			return fmt.Errorf("tmux session %q does not exist", t.sanitizedName)
 		}
 		log.InfoLog.Printf("tmux session %q missing on Restore; re-spawning in %s", t.sanitizedName, workDir)
-		t.program = resumeProgram(t.program)
+		t.setProgramCmd(resumeProgram(t.programCmd()))
 		return t.Start(workDir)
 	}
 
@@ -763,7 +754,7 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool, content string
 	// Only set hasPrompt for agents with a known confirmation dialog, keyed
 	// off the agent actually running in the pane (a non-agent override or a
 	// substring-matching path must not get an agent's prompt heuristic).
-	switch DetectAgentFromCommand(t.program) {
+	switch DetectAgentFromCommand(t.programCmd()) {
 	case ProgramClaude:
 		hasPrompt = strings.Contains(content, "No, and tell Claude what to do differently")
 	case ProgramAider:


### PR DESCRIPTION
## Problem

`af sessions send-prompt` — and every prompt-delivery path (`DeliverPrompt`, `SendPrompt`, task delivery) — landed the prompt **text** in a **codex** session's composer but **never submitted it**. The prompt sat un-sent until a human pressed Enter. Claude/aider/gemini submitted fine. This blocked the codex switch (default_program, tasks, and daily practices are all on codex now). Root's workaround was a manual `tmux send-keys -t <session> Enter` after every codex dispatch.

## Root cause

Codex's composer runs **paste-burst detection**. A large run of characters delivered via `tmux send-keys -l` is treated as an *in-progress paste*, so the trailing `Enter` is absorbed into that paste as a newline instead of submitting. The existing 500ms drain delay doesn't defeat it — the composer has no explicit end-of-paste signal, so it keeps waiting for more paste bytes.

Reproduced against a **real codex 0.142.5** in a fenced sandbox (isolated tmux socket + scratch `CODEX_HOME`):

| Delivery | Prompt | Result |
|---|---|---|
| `send-keys -l` + Enter | short 1-line | ✅ submits |
| `send-keys -l` + Enter | ~6KB multi-line (real-dispatch shape) | ❌ **sits un-submitted** |
| bracketed paste + Enter | same ~6KB | ✅ submits |

So small prompts happened to work; real dispatch prompts reliably stuck — matching the report exactly.

## Fix

Route **codex** through a bracketed paste (`tmux load-buffer` + `paste-buffer -p`) before the submit Enter:

- `-p` wraps the buffer in bracketed-paste control codes (**only** when the app requested the mode, so it degrades to a plain paste mid-dialog), giving codex an explicit **end-of-paste marker** — so the following Enter is unambiguously a submit.
- Text is streamed via **stdin**, not an argv arg, so large prompts aren't bounded by `ARG_MAX`.
- Submit handling keys off `DetectAgentFromCommand` (the agent *actually running* in the pane), mirroring `HasUpdated`'s per-agent prompt heuristics. **claude/aider/gemini/overrides keep the untouched literal `send-keys -l` path**, so they can't regress.
- `-d` deletes the paste buffer after use so buffers don't accumulate; targeted commands keep the `=name` exact-match target (#1006).

Submit logic extracted to `session/tmux/submit.go` to keep `tmux.go` under its file-length ceiling (ratcheted 1424 → 1402).

## Tests

- `session/tmux/submit_test.go`:
  - `TestCodexSubmitUsesBracketedPaste` — codex emits `load-buffer` (payload on stdin) → `paste-buffer -d -p` → `send-keys Enter`, never the swallowed literal path.
  - `TestNonCodexSubmitUsesLiteralSendKeys` — claude/aider/gemini/override keep `send-keys -l` + Enter and never touch the paste buffer.
- Live re-verification of the exact new sequence against real codex 0.142.5 → prompt auto-submits, agent starts, **no manual Enter**.

## Gates
`gofmt -l .` empty · `go build ./...` clean · `golangci-lint --fast` clean · `deadcode -test ./...` clean · file-length lint pass · `make test-container` all-green.

## Verification note for root
Behavioral/visible change → needs a play-test: `af sessions send-prompt` to a codex session (both existing-session send-prompt **and** new-session `DeliverPrompt --create`) → it submits and the agent starts with no manual Enter.

Closes #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)