### PR TITLE
fix(bugreport): redact single-quoted config secrets

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -65,6 +65,43 @@ func TestScrubRedactsSecretsPathsAndUser(t *testing.T) {
 	}
 }
 
+func TestScrubRedactsSingleQuotedConfigSecrets(t *testing.T) {
+	r := &redactor{}
+	cases := []struct {
+		name string
+		in   string
+		leak string
+	}{
+		{
+			name: "password",
+			in:   "password = 'superSecretValue123'",
+			leak: "superSecretValue123",
+		},
+		{
+			name: "api key",
+			in:   "internal_api_key = 'company-internal-api-key'",
+			leak: "company-internal-api-key",
+		},
+		{
+			name: "token",
+			in:   "internal_token = 'internal-service-token-xyz'",
+			leak: "internal-service-token-xyz",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := r.scrub(tc.in)
+			if strings.Contains(out, tc.leak) {
+				t.Errorf("single-quoted secret leaked: input=%q output=%q", tc.in, out)
+			}
+			if !strings.Contains(out, secretMarker) {
+				t.Errorf("expected redaction marker in output: %q", out)
+			}
+		})
+	}
+}
+
 func TestScrubRedactsPEMPrivateKey(t *testing.T) {
 	r := &redactor{}
 	in := "before\n-----BEGIN OPENSSH PRIVATE KEY-----\nAAAAsecretkeymaterial\n-----END OPENSSH PRIVATE KEY-----\nafter"
@@ -212,8 +249,11 @@ func TestBuildEndToEnd(t *testing.T) {
 	tasks := `[{"id": "t1", "name": "nightly", "prompt": "run with sk-TASKSECRET0123456789ABCD", "cron_expr": "0 9 * * *", "enabled": true, "project_path": "` + home + `/Desktop/proj", "program": "claude"}]`
 	writeFile(t, filepath.Join(afHome, "tasks.json"), tasks)
 
-	// config.toml with a planted credential and a home path.
-	cfg := "default_program = \"codex\"\ngithub_token = \"ghp_PLANTEDCONFIGSECRET0123456789ABCD\"\n# note path " + home + "/Desktop\n"
+	// config.toml with planted credentials and a home path.
+	cfg := "default_program = \"codex\"\n" +
+		"github_token = \"ghp_PLANTEDCONFIGSECRET0123456789ABCD\"\n" +
+		"internal_api_key = 'company-internal-credential-value'\n" +
+		"# note path " + home + "/Desktop\n"
 	writeFile(t, filepath.Join(afHome, "config.toml"), cfg)
 
 	// log tail with a home path and a secret.
@@ -249,6 +289,7 @@ func TestBuildEndToEnd(t *testing.T) {
 		"sk-TASKSECRET0123456789ABCD",
 		"sk-LOGSECRET0123456789ABCDEF",
 		"ghp_PLANTEDCONFIGSECRET0123456789ABCD",
+		"company-internal-credential-value",
 		"topsecretremote",
 		"my proprietary session",
 		"secret pr",

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -40,10 +40,11 @@ var secretPatterns = []*regexp.Regexp{
 // keyValueSecret matches a `<credential-key> = <value>` / `<key>: <value>`
 // assignment and redacts only the value, preserving the key so triage can see
 // *that* a credential is configured without leaking it. The key half tolerates
-// a prefix (github_token, x-api-key, client_secret) and an optional opening
-// quote; the value half is any run of 6+ non-space, non-quote characters.
+// a prefix (github_token, x-api-key, client_secret) and optional quotes. The
+// value half recognizes TOML/JSON-style double-quoted strings, TOML literal
+// single-quoted strings, and bare token-like values.
 var keyValueSecret = regexp.MustCompile(
-	`(?i)("?[a-z0-9_-]*(?:api[_-]?key|secret|token|password|passwd|pwd|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret|bearer|credential|private[_-]?key)s?"?\s*[:=]\s*"?)([^\s"',}\]]{6,})`)
+	`(?i)(["']?[a-z0-9_-]*(?:api[_-]?key|secret|token|password|passwd|pwd|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret|bearer|credential|private[_-]?key)s?["']?\s*[:=]\s*)(?:"(?:\\.|[^"\\\r\n])*"|'[^'\r\n]*'|[^\s"',}\]]{6,})`)
 
 // privateKeyBlock matches a PEM private-key block in its entirety.
 var privateKeyBlock = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
@@ -96,7 +97,7 @@ func appendUserToken(users []string, name string) []string {
 // defense.
 func (r *redactor) scrub(s string) string {
 	s = privateKeyBlock.ReplaceAllString(s, secretMarker)
-	s = keyValueSecret.ReplaceAllString(s, "${1}"+secretMarker)
+	s = keyValueSecret.ReplaceAllStringFunc(s, redactKeyValueSecret)
 	for _, re := range secretPatterns {
 		s = re.ReplaceAllString(s, secretMarker)
 	}
@@ -108,6 +109,22 @@ func (r *redactor) scrub(s string) string {
 		s = re.ReplaceAllString(s, userMarker)
 	}
 	return s
+}
+
+func redactKeyValueSecret(match string) string {
+	idx := keyValueSecret.FindStringSubmatchIndex(match)
+	if len(idx) < 4 || idx[2] < 0 {
+		return secretMarker
+	}
+	prefix := match[idx[2]:idx[3]]
+	value := match[idx[3]:]
+	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+		return prefix + `"` + secretMarker + `"`
+	}
+	if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
+		return prefix + `'` + secretMarker + `'`
+	}
+	return prefix + secretMarker
 }
 
 // unparsedInstancesNote is emitted (as a JSON string) when instances.json is


### PR DESCRIPTION
## Summary
- redact sensitive key/value assignments when the value is a TOML single-quoted literal string
- preserve the original quote style around the redaction marker for quoted values
- add scrub-level and bundle-level coverage for planted single-quoted config secrets

## Verify-first
- Verified stale check on current master: branch started from origin/master 23402e7.
- Added the regression tests first, then ran the targeted container repro. It failed on master: TestScrubRedactsSingleQuotedConfigSecrets leaked all planted single-quoted values, and TestBuildEndToEnd leaked company-internal-credential-value in both text and JSON bundle output.

## Tests
- gofmt -l . empty
- go build ./...
- golangci-lint run --timeout=3m --fast
- make test-container
- make lint-file-length

Closes #1260

Signed: Captain Claude