### PR TITLE
fix(http): reject unknown JSON request fields

### DIFF
--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -136,7 +136,7 @@ func newHTTPMux(cs *controlServer) *http.ServeMux {
 // shared envelope. Status mapping (kept pragmatic, documented here):
 //
 //	200 — success: {"data": <resp>, "error": null}
-//	400 — malformed / unreadable JSON request body
+//	400 — malformed / unreadable JSON request body, or unknown request field
 //	405 — wrong HTTP verb (not POST)
 //	413 — request body exceeds maxHTTPBodyBytes
 //	500 — the handler (validation or execution) returned an error
@@ -190,6 +190,8 @@ func healthHandler(cs *controlServer) http.HandlerFunc {
 // decodeHTTPRequest reads the size-capped body and unmarshals it into dst. An
 // empty body is treated as a zero-value request so no-argument RPCs (ListTasks,
 // an all-repo Snapshot, health) work with `curl -d ”` or no body at all.
+// Unknown fields are rejected so typo'd request keys cannot silently fall back
+// to zero-value RPC semantics such as an empty RepoID meaning all repos.
 //
 // The cap is enforced with http.MaxBytesReader (NOT io.LimitReader): once the
 // body exceeds maxHTTPBodyBytes the read fails with an *http.MaxBytesError, so an
@@ -207,7 +209,15 @@ func decodeHTTPRequest(w http.ResponseWriter, r *http.Request, dst any) error {
 	if len(bytes.TrimSpace(body)) == 0 {
 		return nil
 	}
-	if err := json.Unmarshal(body, dst); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return fmt.Errorf("malformed JSON request body: %w", err)
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("malformed JSON request body: multiple JSON values")
+		}
 		return fmt.Errorf("malformed JSON request body: %w", err)
 	}
 	return nil

--- a/daemon/httpserver_test.go
+++ b/daemon/httpserver_test.go
@@ -141,6 +141,23 @@ func TestHTTP_MalformedJSON_400(t *testing.T) {
 	assert.Contains(t, env.Error.Message, "malformed JSON")
 }
 
+// TestHTTP_UnknownJSONField_400 covers strict request decoding: a typo like
+// repo_idd must fail as a bad request instead of silently becoming the
+// zero-value RepoID and dispatching an all-repo Snapshot.
+func TestHTTP_UnknownJSONField_400(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	m, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+
+	rec := doHTTP(&controlServer{manager: m}, http.MethodPost, "/v1/Snapshot", `{"repo_idd":"typo"}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	env := decodeEnvelope(t, rec)
+	require.Nil(t, env.Data)
+	require.NotNil(t, env.Error)
+	assert.Contains(t, env.Error.Message, `unknown field "repo_idd"`)
+}
+
 // TestHTTP_OversizeBody_413_NotDispatched covers the body-over-limit → 413
 // mapping AND proves the oversize request is REJECTED, never
 // truncated-then-dispatched: with a well-formed AddTask body that exceeds the


### PR DESCRIPTION
## Summary
- switch daemon HTTP request decoding to a strict json.Decoder with DisallowUnknownFields
- preserve malformed/trailing JSON rejection behavior and keep HTTP/RPC dispatch shared
- add a regression test that typo'd repo_idd on Snapshot returns 400 instead of dispatching as all-repo

## Verify-first
- On origin/master, the new regression test failed in the container with expected 400 / actual 200, confirming #1264 was not stale.

## Tests
- make test-container GOTESTARGS="./daemon -run TestHTTP_UnknownJSONField_400"
- make test-container

Do not merge; root verifies.

Closes #1264

Signed-off-by: Captain Claude <captain-claude@sachiniyer.com>