### PR TITLE
fix(config): validate detach_keys before writing

### DIFF
--- a/config/configset.go
+++ b/config/configset.go
@@ -70,7 +70,12 @@ var settableKeySpecs = map[string]settableKeySpec{
 	"log_max_size_mb":      {kind: cfgInt, validate: func(_, v string) error { return requirePositiveInt("log_max_size_mb", v) }},
 	"log_max_backups":      {kind: cfgInt, validate: func(_, v string) error { return requireNonNegativeInt("log_max_backups", v) }},
 	"branch_prefix":        {kind: cfgString},
-	"detach_keys":          {kind: cfgString},
+	"detach_keys": {kind: cfgString, validate: func(_, v string) error {
+		if _, err := ParseDetachKey(v); err != nil {
+			return fmt.Errorf("detach_keys: %w", err)
+		}
+		return nil
+	}},
 	"update_channel": {kind: cfgString, validate: func(_, v string) error {
 		if v != UpdateChannelStable && v != UpdateChannelPreview {
 			return fmt.Errorf("update_channel must be one of [%s, %s], got %q", UpdateChannelStable, UpdateChannelPreview, v)

--- a/config/configset_test.go
+++ b/config/configset_test.go
@@ -211,6 +211,7 @@ func TestSetGlobalConfigValueRejectsBadValues(t *testing.T) {
 	writeTempConfig(t, "default_program = 'claude'\n")
 	cases := []struct{ key, val, wantSub string }{
 		{"default_program", "bogus", "must be one of"},
+		{"detach_keys", "alt-w", "detach_keys"},
 		{"daemon_poll_interval", "abc", "integer"},
 		{"daemon_poll_interval", "0", "positive"},
 		{"log_max_backups", "-1", "non-negative"},
@@ -229,6 +230,23 @@ func TestSetGlobalConfigValueRejectsBadValues(t *testing.T) {
 		if !strings.Contains(err.Error(), c.wantSub) {
 			t.Errorf("set %s=%s: error %q missing %q", c.key, c.val, err.Error(), c.wantSub)
 		}
+	}
+}
+
+func TestSetGlobalConfigValueRejectsInvalidDetachKeysWithoutWriting(t *testing.T) {
+	path := writeTempConfig(t, "default_program = 'claude'\ndetach_keys = 'ctrl-w'  # keep\n")
+	before, _ := os.ReadFile(path)
+
+	_, err := SetGlobalConfigValue("detach_keys", "alt-w")
+	if err == nil {
+		t.Fatal("expected invalid detach_keys to be rejected")
+	}
+	if !strings.Contains(err.Error(), "detach_keys") || !strings.Contains(err.Error(), "ctrl-") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after, _ := os.ReadFile(path)
+	if string(after) != string(before) {
+		t.Fatalf("config file must be untouched when detach_keys is invalid.\n before: %q\n after:  %q", before, after)
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate af config set detach_keys with ParseDetachKey before writing config.toml
- return the parser's actionable ctrl-* error for invalid values
- add regression coverage that invalid detach_keys is rejected and the existing config file remains byte-for-byte unchanged

## Verify-first
- Verified stale check on current master: branch started from origin/master 23402e7.
- Added the regression tests first, then ran the targeted container repro. It failed on master: TestSetGlobalConfigValueRejectsBadValues accepted detach_keys=alt-w, and TestSetGlobalConfigValueRejectsInvalidDetachKeysWithoutWriting saw no rejection before write.

## Tests
- gofmt -l . empty
- go build ./...
- golangci-lint run --timeout=3m --fast
- make test-container
- make lint-file-length

Closes #1268

Signed: Captain Claude