### PR TITLE
fix(config): preserve comments after escaped quotes

### DIFF
--- a/config/configset.go
+++ b/config/configset.go
@@ -398,6 +398,7 @@ func setTOMLScalar(content, section, leaf, encoded string) string {
 // preceded the '#'), so the comment can be reattached byte-for-byte.
 func splitTrailingComment(rest string) (value, comment string) {
 	inSingle, inDouble := false, false
+	escape := false
 	for i := 0; i < len(rest); i++ {
 		c := rest[i]
 		switch {
@@ -406,13 +407,20 @@ func splitTrailingComment(rest string) (value, comment string) {
 				inSingle = false
 			}
 		case inDouble:
-			if c == '"' {
+			if escape {
+				escape = false
+			} else if c == '\\' {
+				escape = true
+			} else if c == '"' {
 				inDouble = false
+				escape = false
 			}
 		case c == '\'':
 			inSingle = true
+			escape = false
 		case c == '"':
 			inDouble = true
+			escape = false
 		case c == '#':
 			j := i
 			for j > 0 && (rest[j-1] == ' ' || rest[j-1] == '\t') {

--- a/config/configset_test.go
+++ b/config/configset_test.go
@@ -104,6 +104,15 @@ func TestSetTOMLScalarHashInStringValue(t *testing.T) {
 	}
 }
 
+func TestSetTOMLScalarEscapedQuoteInDoubleQuotedString(t *testing.T) {
+	in := `branch_prefix = "a\"b"  # trailing`
+	got := setTOMLScalar(in, "", "branch_prefix", "'c#d'")
+	want := `branch_prefix = 'c#d'  # trailing`
+	if got != want {
+		t.Fatalf("escaped quote handling wrong.\n got: %q\nwant: %q", got, want)
+	}
+}
+
 func TestResolveSettable(t *testing.T) {
 	if s, leaf, _, ok := resolveSettable("default_program"); !ok || s != "" || leaf != "default_program" {
 		t.Fatalf("default_program resolve wrong: s=%q leaf=%q ok=%v", s, leaf, ok)


### PR DESCRIPTION
## Summary
- track backslash escapes while scanning double-quoted TOML basic strings in setTOMLScalar
- avoid treating an escaped quote as the end of the value when preserving trailing comments
- add regression coverage for key = "a\"b" # keep style lines

## Verify-first
- Verified stale check on current master: branch started from origin/master 23402e7.
- Added the regression test first, then ran the targeted container repro. It failed on master: TestSetTOMLScalarEscapedQuoteInDoubleQuotedString dropped the trailing inline comment after an escaped quote.

## Tests
- gofmt -l . empty
- go build ./...
- golangci-lint run --timeout=3m --fast
- make test-container
- make lint-file-length

Closes #1265

Signed: Captain Claude