### PR TITLE
fix(cli): silence cobra for json error envelopes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -400,12 +400,29 @@ func jsonOut(v any) error {
 // original error is always returned so exit codes are unchanged.
 func jsonError(err error) error {
 	if envelopeOutput {
+		silenceEnvelopeCobra()
+		log.CloseQuiet()
 		_ = writeEnvelope(os.Stderr, errorEnvelope(err.Error()))
 		return err
 	}
 	msg, _ := json.Marshal(map[string]string{"error": err.Error()})
 	fmt.Fprintln(os.Stderr, string(msg))
 	return err
+}
+
+func silenceEnvelopeCobra() {
+	SessionsCmd.SilenceUsage = true
+	SessionsCmd.SilenceErrors = true
+	TasksCmd.SilenceUsage = true
+	TasksCmd.SilenceErrors = true
+	if root := SessionsCmd.Root(); root != nil {
+		root.SilenceUsage = true
+		root.SilenceErrors = true
+	}
+	if root := TasksCmd.Root(); root != nil {
+		root.SilenceUsage = true
+		root.SilenceErrors = true
+	}
 }
 
 func init() {

--- a/api/output_test.go
+++ b/api/output_test.go
@@ -101,6 +101,16 @@ func TestJSONError_EnvelopeWrapsError(t *testing.T) {
 	sentinel := errors.New("nope")
 	var ret error
 	var out string
+	SessionsCmd.SilenceUsage = false
+	SessionsCmd.SilenceErrors = false
+	TasksCmd.SilenceUsage = false
+	TasksCmd.SilenceErrors = false
+	t.Cleanup(func() {
+		SessionsCmd.SilenceUsage = false
+		SessionsCmd.SilenceErrors = false
+		TasksCmd.SilenceUsage = false
+		TasksCmd.SilenceErrors = false
+	})
 	withEnvelope(t, func() {
 		out = captureStderr(t, func() {
 			ret = jsonError(sentinel)
@@ -108,4 +118,8 @@ func TestJSONError_EnvelopeWrapsError(t *testing.T) {
 	})
 	require.Equal(t, sentinel, ret)
 	require.JSONEq(t, `{"data":null,"error":{"message":"nope"}}`, out)
+	require.True(t, SessionsCmd.SilenceUsage)
+	require.True(t, SessionsCmd.SilenceErrors)
+	require.True(t, TasksCmd.SilenceUsage)
+	require.True(t, TasksCmd.SilenceErrors)
 }

--- a/configcmd.go
+++ b/configcmd.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -24,9 +23,16 @@ import (
 // instead of a bare Go error. The error is returned unchanged so the exit code
 // is unaffected. Off the --json path it is a no-op passthrough for cobra's
 // normal error handling.
-func jsonWrapError(errOut io.Writer, jsonMode bool, err error) error {
+func jsonWrapError(cmd *cobra.Command, jsonMode bool, err error) error {
 	if jsonMode && err != nil {
-		_ = apiproto.WriteEnvelope(errOut, apiproto.Failure(err.Error()))
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		if root := cmd.Root(); root != nil {
+			root.SilenceUsage = true
+			root.SilenceErrors = true
+		}
+		log.CloseQuiet()
+		_ = apiproto.WriteEnvelope(cmd.ErrOrStderr(), apiproto.Failure(err.Error()))
 	}
 	return err
 }
@@ -131,7 +137,7 @@ keys) print as JSON.`,
 
 		entries, err := loadGlobalConfigEntries()
 		if err != nil {
-			return jsonWrapError(cmd.ErrOrStderr(), configJSONFlag, err)
+			return jsonWrapError(cmd, configJSONFlag, err)
 		}
 		for _, e := range entries {
 			if e.Key == args[0] {
@@ -142,7 +148,7 @@ keys) print as JSON.`,
 				return nil
 			}
 		}
-		return jsonWrapError(cmd.ErrOrStderr(), configJSONFlag,
+		return jsonWrapError(cmd, configJSONFlag,
 			fmt.Errorf("unknown config key %q; run `af config list` to see all keys", args[0]))
 	},
 }
@@ -157,7 +163,7 @@ var configListCmd = &cobra.Command{
 
 		entries, err := loadGlobalConfigEntries()
 		if err != nil {
-			return jsonWrapError(cmd.ErrOrStderr(), configJSONFlag, err)
+			return jsonWrapError(cmd, configJSONFlag, err)
 		}
 		if configJSONFlag {
 			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(entries))
@@ -205,7 +211,7 @@ Examples:
 
 		res, err := config.SetGlobalConfigValue(args[0], args[1])
 		if err != nil {
-			return jsonWrapError(cmd.ErrOrStderr(), configJSONFlag, err)
+			return jsonWrapError(cmd, configJSONFlag, err)
 		}
 		if configJSONFlag {
 			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(res))

--- a/configcmd_test.go
+++ b/configcmd_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +20,39 @@ import (
 func tempAFHome(t *testing.T) {
 	t.Helper()
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+}
+
+func captureProcessStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func resetCobraSilence(cmd *cobra.Command) {
+	cmd.SilenceUsage = false
+	cmd.SilenceErrors = false
+	for _, child := range cmd.Commands() {
+		resetCobraSilence(child)
+	}
 }
 
 func TestFormatConfigValue(t *testing.T) {
@@ -131,6 +165,58 @@ func TestConfigGetUnknownKeyJSONEnvelope(t *testing.T) {
 	}
 	if env.Error == nil || !strings.Contains(env.Error.Message, "unknown config key") {
 		t.Fatalf("envelope missing the unknown-key message: %s", stderr.String())
+	}
+}
+
+func TestConfigGetUnknownKeyJSONRootSuppressesCobraAndLog(t *testing.T) {
+	tempAFHome(t)
+	prevJSON := configJSONFlag
+	t.Cleanup(func() {
+		configJSONFlag = prevJSON
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(os.Stdout)
+		rootCmd.SetErr(os.Stderr)
+		resetCobraSilence(rootCmd)
+		if flag := configGetCmd.Flags().Lookup("json"); flag != nil {
+			_ = flag.Value.Set("false")
+			flag.Changed = false
+		}
+	})
+
+	var stdout bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetArgs([]string{"config", "get", "not_a_key", "--json"})
+
+	var execErr error
+	stderr := captureProcessStderr(t, func() {
+		rootCmd.SetErr(os.Stderr)
+		execErr = rootCmd.Execute()
+	})
+	if execErr == nil {
+		t.Fatal("expected root execute error for unknown key")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("error path must not write stdout, got: %s", stdout.String())
+	}
+	if strings.Contains(stderr, "Usage:") || strings.Contains(stderr, "Error:") ||
+		strings.Contains(stderr, "wrote logs to") {
+		t.Fatalf("--json stderr contains non-envelope text: %q", stderr)
+	}
+
+	var env struct {
+		Data  any `json:"data"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(stderr), &env); err != nil {
+		t.Fatalf("stderr is not a clean JSON envelope: %v\n%s", err, stderr)
+	}
+	if env.Data != nil {
+		t.Errorf("failure envelope data should be null, got %v", env.Data)
+	}
+	if env.Error == nil || !strings.Contains(env.Error.Message, "unknown config key") {
+		t.Fatalf("envelope missing the unknown-key message: %s", stderr)
 	}
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -403,6 +403,17 @@ func Initialize(daemon bool) {
 }
 
 func Close() {
+	closeWithReport(true)
+}
+
+// CloseQuiet closes the current log file without printing the usual
+// "wrote logs to ..." stderr note. Structured CLI output uses this before
+// returning a JSON envelope error so stderr remains machine-parseable.
+func CloseQuiet() {
+	closeWithReport(false)
+}
+
+func closeWithReport(report bool) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -429,7 +440,7 @@ func Close() {
 		_ = globalLogFile.Close()
 		globalLogFile = nil
 	}
-	if fileWasOpened {
+	if fileWasOpened && report {
 		fmt.Fprintln(os.Stderr, "wrote logs to "+logFileName)
 	}
 }


### PR DESCRIPTION
## Summary
- suppress Cobra usage/error printing when a --json error envelope is emitted
- close logs quietly on structured JSON error paths so the machine stream is not polluted by the log-location note
- cover config root execution plus sessions/tasks JSON error helper behavior

## Verify-first
- On origin/master, `AGENT_FACTORY_HOME=$(mktemp -d) go run . config get not_a_key --json 2>&1 >/dev/null` emitted the JSON envelope followed by `wrote logs to`, `Error:`, and `Usage:` text, confirming #1267 was not stale.

## Tests
- make test-container GOTESTARGS=". -run TestConfigGetUnknownKeyJSONRootSuppressesCobraAndLog"
- make test-container GOTESTARGS="./api -run TestJSONError_EnvelopeWrapsError"
- make test-container
- local smoke, no install: built /tmp binary and verified `config get not_a_key --json` emits only the envelope on the machine stream while exiting nonzero

Do not merge; root verifies.

Closes #1267

Signed-off-by: Captain Claude <captain-claude@sachiniyer.com>