### PR TITLE
fix(api): shell-quote curl socket examples

### DIFF
--- a/api/apicmd.go
+++ b/api/apicmd.go
@@ -118,9 +118,23 @@ func printAPICatalogHuman(w io.Writer, socketPath string, routes []daemon.HTTPRo
 // no-argument RPC accepts as-is and every other RPC accepts as a starting point
 // to fill in.
 func curlExample(socketPath string, rt daemon.HTTPRoute) string {
-	base := fmt.Sprintf("curl --unix-socket %s http://localhost%s", socketPath, rt.Path)
+	base := fmt.Sprintf("curl --unix-socket %s http://localhost%s", shellQuoteArg(socketPath), rt.Path)
 	if rt.Method == "GET" {
 		return base
 	}
 	return base + " -d '{}'"
+}
+
+func shellQuoteArg(arg string) string {
+	if arg == "" {
+		return "''"
+	}
+	for _, r := range arg {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
+			strings.ContainsRune("@%_+=:,./-", r) {
+			continue
+		}
+		return "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
+	}
+	return arg
 }

--- a/api/apicmd_test.go
+++ b/api/apicmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -118,4 +119,31 @@ func TestAPICmd_CurlExampleShape(t *testing.T) {
 			assert.Contains(t, line, "-d '{}'", "POST curl must include an empty JSON body")
 		}
 	}
+}
+
+func TestAPICmd_CurlExampleQuotesSpacedSocketPath(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "home with spaces and 'quote'", "daemon-http.sock")
+	line := curlExample(socketPath, daemon.HTTPRoute{Method: "GET", Path: "/v1/health"})
+
+	binDir := t.TempDir()
+	argsPath := filepath.Join(t.TempDir(), "curl-args")
+	fakeCurl := filepath.Join(binDir, "curl")
+	require.NoError(t, os.WriteFile(fakeCurl, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$AF_CURL_ARGS\"\n"), 0755))
+
+	cmd := exec.Command("sh", "-c", line)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AF_CURL_ARGS="+argsPath,
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	raw, err := os.ReadFile(argsPath)
+	require.NoError(t, err)
+	args := strings.Split(strings.TrimSuffix(string(raw), "\n"), "\n")
+	require.Equal(t, []string{
+		"--unix-socket",
+		socketPath,
+		"http://localhost/v1/health",
+	}, args)
 }


### PR DESCRIPTION
## Summary
- shell-quote the `af api` curl example `--unix-socket` argument when the socket path contains shell-special characters
- add a regression test that executes the printed curl line through `sh` with a fake curl and proves a spaced/quoted socket path arrives as one argument

## Verify-first
- On origin/master, the new regression test failed in the container because the socket path was split into seven shell arguments, confirming #1269 was not stale.
- Manual baseline smoke also showed `curl --unix-socket /tmp/af api spaced home/...` unquoted.

## Tests
- make test-container GOTESTARGS="./api -run TestAPICmd_CurlExampleQuotesSpacedSocketPath"
- make test-container
- visible smoke: `AGENT_FACTORY_HOME="/tmp/af api spaced home" go run . api | rg -m1 "curl --unix-socket"` prints the socket path quoted

Do not merge; root verifies.

Closes #1269

Signed-off-by: Captain Claude <captain-claude@sachiniyer.com>