### PR TITLE
fix(doctor): spare live macOS temp homes

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -76,3 +76,16 @@ func Health() HealthStatus {
 func LooksLikeDaemonArgv(args []string) bool {
 	return argsHaveDaemonFlag(args) && argsAreDaemonBinary(args)
 }
+
+// ProcessArgv returns pid's argv using the daemon package's cross-platform
+// lookup: /proc where available, then a best-effort `ps` fallback for macOS
+// and other Unix platforms without /proc.
+func ProcessArgv(pid int) []string {
+	return daemonArgs(pid)
+}
+
+// PIDLooksAlive reports whether pid still appears to name a live process,
+// using the same zombie-aware liveness probe as daemon shutdown paths.
+func PIDLooksAlive(pid int) bool {
+	return pidLooksAlive(pid)
+}

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -21,6 +21,11 @@ func selfPID() int { return os.Getpid() }
 
 func tempDirDefault() string { return os.TempDir() }
 
+var (
+	daemonProcessArgv   = daemon.ProcessArgv
+	daemonPIDLooksAlive = daemon.PIDLooksAlive
+)
+
 // runawayCPUFraction and runawayMinAge define "pegging a core for an
 // extended period": lifetime-average CPU ≥ 80% of a core for a process at
 // least 30 minutes old. A legitimate build rarely sustains that average; the
@@ -392,28 +397,22 @@ var afHomeMarkers = []string{
 // checkStaleTempHomes finds abandoned agent-factory homes under the temp
 // dir (leaked by tests/debug runs — the #1093 immortal-daemon fuel). A home
 // is stale only when nothing references it: no live process has it as
-// AGENT_FACTORY_HOME, its daemon.pid (if any) is dead, and it has not been
-// touched for MinTempHomeAge.
+// AGENT_FACTORY_HOME, no live tmux session marks it as AF_HOME, its
+// daemon.pid (if any) is verified absent/dead/stale rather than merely
+// unreadable, and it has not been touched for MinTempHomeAge.
 func checkStaleTempHomes(ctx *scanContext, report *Report) {
 	tempDir := filepath.Clean(ctx.opts.TempDir)
 	activeHome := filepath.Clean(ctx.opts.ConfigDir)
-
-	homesInUse := map[string]bool{}
-	if ctx.snap != nil {
-		for pid := range ctx.snap {
-			if home, ok := proctree.EnvValue(pid, "AGENT_FACTORY_HOME"); ok && home != "" {
-				homesInUse[filepath.Clean(home)] = true
-			}
-		}
-	}
+	homesInUse := processReferencedHomes(ctx.snap)
+	tmuxHomesInUse := liveTmuxHomes(ctx)
 
 	for _, dir := range candidateTempHomes(tempDir) {
 		dir = filepath.Clean(dir)
 		if dir == activeHome || !isAFHome(dir) {
 			continue
 		}
-		if homesInUse[dir] || tempHomeDaemonAlive(dir) {
-			report.OK = append(report.OK, fmt.Sprintf("temp home %s is in use (live process references it)", dir))
+		if reason := tempHomeInUseReason(dir, homesInUse, tmuxHomesInUse); reason != "" {
+			report.OK = append(report.OK, fmt.Sprintf("temp home %s is in use (%s)", dir, reason))
 			continue
 		}
 		age := timeSince(newestMtime(dir))
@@ -421,8 +420,7 @@ func checkStaleTempHomes(ctx *scanContext, report *Report) {
 			continue
 		}
 		// Containment re-check before offering an rm -rf.
-		rel, err := filepath.Rel(tempDir, dir)
-		if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		if !pathInside(tempDir, dir) {
 			continue
 		}
 		removeDir := dir
@@ -431,7 +429,7 @@ func checkStaleTempHomes(ctx *scanContext, report *Report) {
 			Detail: fmt.Sprintf("abandoned agent-factory home %s (untouched for %s)",
 				dir, formatAge(age.Seconds())),
 			FixAction: "remove " + dir,
-			fix:       func() error { return os.RemoveAll(removeDir) },
+			fix:       staleTempHomeRemoveFix(ctx, removeDir),
 		})
 	}
 }
@@ -477,18 +475,133 @@ func isAFHome(dir string) bool {
 	return found >= 2
 }
 
-// tempHomeDaemonAlive reports whether the home's daemon.pid names a live
-// agent-factory daemon.
-func tempHomeDaemonAlive(dir string) bool {
+func processReferencedHomes(snap map[int]proctree.Process) map[string]bool {
+	homes := map[string]bool{}
+	if snap == nil {
+		return homes
+	}
+	for pid := range snap {
+		if home, ok := proctree.EnvValue(pid, "AGENT_FACTORY_HOME"); ok && home != "" {
+			homes[filepath.Clean(home)] = true
+		}
+	}
+	return homes
+}
+
+func liveTmuxHomes(ctx *scanContext) map[string]bool {
+	homes := map[string]bool{}
+	for _, name := range listTmuxSessions(ctx) {
+		if !strings.HasPrefix(name, tmux.TmuxPrefix) {
+			continue
+		}
+		if home, ok := tmuxSessionHomeMarker(ctx, name); ok && home != "" {
+			homes[filepath.Clean(home)] = true
+		}
+	}
+	return homes
+}
+
+func tmuxSessionHomeMarker(ctx *scanContext, name string) (string, bool) {
+	out, err := ctx.opts.Exec.Output(exec.Command("tmux", "show-environment", "-t",
+		fmt.Sprintf("=%s:", name), tmux.EnvMarkerHome))
+	if err != nil {
+		return "", false
+	}
+	return strings.CutPrefix(strings.TrimSpace(string(out)), tmux.EnvMarkerHome+"=")
+}
+
+type tempHomeDaemonStatus int
+
+const (
+	tempHomeDaemonAbsentOrDead tempHomeDaemonStatus = iota
+	tempHomeDaemonAlive
+	tempHomeDaemonUnknown
+)
+
+// tempHomeDaemonLiveness reports whether the home's daemon.pid names a live
+// agent-factory daemon. A live PID with unreadable argv is unknown, not dead:
+// doctor must not delete a home when daemon liveness cannot be verified.
+func tempHomeDaemonLiveness(dir string) tempHomeDaemonStatus {
 	data, err := os.ReadFile(filepath.Join(dir, "daemon.pid"))
 	if err != nil {
-		return false
+		if os.IsNotExist(err) {
+			return tempHomeDaemonAbsentOrDead
+		}
+		return tempHomeDaemonUnknown
 	}
 	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil || pid <= 0 {
+		return tempHomeDaemonUnknown
+	}
+	if !daemonPIDLooksAlive(pid) {
+		return tempHomeDaemonAbsentOrDead
+	}
+	args := daemonProcessArgv(pid)
+	if len(args) == 0 {
+		return tempHomeDaemonUnknown
+	}
+	if daemon.LooksLikeDaemonArgv(args) {
+		return tempHomeDaemonAlive
+	}
+	return tempHomeDaemonAbsentOrDead
+}
+
+func tempHomeInUseReason(dir string, processHomes, tmuxHomes map[string]bool) string {
+	dir = filepath.Clean(dir)
+	switch {
+	case processHomes[dir]:
+		return "live process references it"
+	case tmuxHomes[dir]:
+		return "live tmux session references it"
+	}
+	switch tempHomeDaemonLiveness(dir) {
+	case tempHomeDaemonAlive:
+		return "daemon pid is live"
+	case tempHomeDaemonUnknown:
+		return "daemon.pid liveness is uncertain"
+	default:
+		return ""
+	}
+}
+
+func staleTempHomeRemoveFix(ctx *scanContext, dir string) func() error {
+	return func() error {
+		dir := filepath.Clean(dir)
+		if _, err := os.Stat(dir); err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("cannot stat %s before removal: %w", dir, err)
+		}
+		if !pathInside(filepath.Clean(ctx.opts.TempDir), dir) {
+			return fmt.Errorf("refusing to remove %s outside temp dir %s", dir, ctx.opts.TempDir)
+		}
+		if filepath.Clean(ctx.opts.ConfigDir) == dir {
+			return fmt.Errorf("refusing to remove active agent-factory home %s", dir)
+		}
+		if !isAFHome(dir) {
+			return fmt.Errorf("refusing to remove %s: it no longer looks like an agent-factory home", dir)
+		}
+
+		snap := ctx.snap
+		if ctx.opts.snapshot != nil {
+			if fresh, err := ctx.opts.snapshot(); err == nil {
+				snap = fresh
+			}
+		}
+		if reason := tempHomeInUseReason(dir, processReferencedHomes(snap), liveTmuxHomes(ctx)); reason != "" {
+			return fmt.Errorf("refusing to remove %s: %s", dir, reason)
+		}
+		return os.RemoveAll(dir)
+	}
+}
+
+func pathInside(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	if err != nil || rel == "." || rel == ".." {
 		return false
 	}
-	return daemon.LooksLikeDaemonArgv(proctree.Argv(pid))
+	return !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // newestMtime returns the most recent mtime among the dir itself and its
@@ -532,7 +645,7 @@ func checkForeignDaemons(ctx *scanContext, report *Report) {
 			continue
 		}
 		p := ctx.snap[pid]
-		args := proctree.Argv(pid)
+		args := daemonProcessArgv(pid)
 		if len(args) == 0 || !daemon.LooksLikeDaemonArgv(args) {
 			continue
 		}

--- a/doctor/temp_home_liveness_test.go
+++ b/doctor/temp_home_liveness_test.go
@@ -1,0 +1,158 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/internal/proctree"
+	"github.com/stretchr/testify/require"
+)
+
+func makeOldTempAFHome(t *testing.T, tempRoot, name string) string {
+	t.Helper()
+	dir := filepath.Join(tempRoot, name)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	markers := []string{
+		filepath.Join(dir, "config.json"),
+		filepath.Join(dir, "state.json"),
+	}
+	for _, marker := range markers {
+		require.NoError(t, os.WriteFile(marker, []byte("{}"), 0644))
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	for _, p := range append(markers, dir) {
+		require.NoError(t, os.Chtimes(p, old, old))
+	}
+	return dir
+}
+
+func writeOldDaemonPID(t *testing.T, dir string, pid int) {
+	t.Helper()
+	path := filepath.Join(dir, "daemon.pid")
+	require.NoError(t, os.WriteFile(path, []byte(strconv.Itoa(pid)), 0600))
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(path, old, old))
+}
+
+func stubDaemonProcessProbe(t *testing.T, alive func(int) bool, argv func(int) []string) {
+	t.Helper()
+	origAlive := daemonPIDLooksAlive
+	origArgv := daemonProcessArgv
+	daemonPIDLooksAlive = alive
+	daemonProcessArgv = argv
+	t.Cleanup(func() {
+		daemonPIDLooksAlive = origAlive
+		daemonProcessArgv = origArgv
+	})
+}
+
+func macLikeTempHomeOptions(t *testing.T, tempRoot string, fix bool) Options {
+	t.Helper()
+	opts := testOptions(t, fix)
+	opts.TempDir = tempRoot
+	opts.snapshot = func() (map[int]proctree.Process, error) {
+		return nil, fmt.Errorf("no /proc")
+	}
+	opts.Exec = cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return nil, fmt.Errorf("no tmux")
+		},
+	}
+	return opts
+}
+
+func TestTempHomeDaemonLivenessUsesDaemonProcessArgv(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.live-daemon")
+	writeOldDaemonPID(t, dir, 4242)
+	stubDaemonProcessProbe(t,
+		func(pid int) bool { return pid == 4242 },
+		func(pid int) []string {
+			require.Equal(t, 4242, pid)
+			return []string{"/usr/local/bin/af", "--daemon"}
+		},
+	)
+
+	report, err := Run(macLikeTempHomeOptions(t, tempRoot, true))
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "stale-temp-home"))
+	require.DirExists(t, dir, "a temp home with a verified live daemon must never be removed")
+	require.True(t, okContains(report, "daemon pid is live"))
+}
+
+func TestTempHomeDaemonUncertainLivenessSparesHome(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.unknown-daemon")
+	writeOldDaemonPID(t, dir, 4243)
+	stubDaemonProcessProbe(t,
+		func(pid int) bool { return pid == 4243 },
+		func(pid int) []string { return nil },
+	)
+
+	report, err := Run(macLikeTempHomeOptions(t, tempRoot, true))
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "stale-temp-home"))
+	require.DirExists(t, dir, "uncertain daemon liveness must fail closed")
+	require.True(t, okContains(report, "daemon.pid liveness is uncertain"))
+}
+
+func TestTempHomeWithLiveTmuxSessionMarkerSparesHomeWithoutProc(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.live-session")
+	opts := macLikeTempHomeOptions(t, tempRoot, true)
+	opts.Exec = cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			if len(cmd.Args) > 1 && cmd.Args[1] == "ls" {
+				return []byte("af_live-session\n"), nil
+			}
+			if len(cmd.Args) > 1 && cmd.Args[1] == "show-environment" &&
+				strings.Contains(strings.Join(cmd.Args, " "), "af_live-session") {
+				return []byte("AF_HOME=" + dir + "\n"), nil
+			}
+			return nil, fmt.Errorf("unexpected tmux command: %s", cmd.String())
+		},
+	}
+
+	report, err := Run(opts)
+	require.NoError(t, err)
+	require.Empty(t, findByCheck(report, "stale-temp-home"))
+	require.DirExists(t, dir, "a temp home with a live tmux session marker must never be removed")
+	require.True(t, okContains(report, "live tmux session references it"))
+}
+
+func TestStaleTempHomeFixRechecksDaemonBeforeRemove(t *testing.T) {
+	tempRoot := t.TempDir()
+	dir := makeOldTempAFHome(t, tempRoot, "tmp.race-daemon")
+	alive := false
+	stubDaemonProcessProbe(t,
+		func(pid int) bool { return alive && pid == 4244 },
+		func(pid int) []string {
+			if alive && pid == 4244 {
+				return []string{"af", "--daemon"}
+			}
+			return nil
+		},
+	)
+
+	report, err := Run(macLikeTempHomeOptions(t, tempRoot, false))
+	require.NoError(t, err)
+	findings := findByCheck(report, "stale-temp-home")
+	require.Len(t, findings, 1)
+	require.NotNil(t, findings[0].fix)
+
+	alive = true
+	writeOldDaemonPID(t, dir, 4244)
+	err = findings[0].fix()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "daemon pid is live")
+	require.DirExists(t, dir, "fix must re-check and refuse to remove a newly active temp home")
+}

--- a/internal/proctree/proctree.go
+++ b/internal/proctree/proctree.go
@@ -311,37 +311,12 @@ func EnvValue(pid int, key string) (string, bool) {
 // Cmdline returns the process's argv joined with spaces, or "" when
 // unreadable. For kernel threads (empty cmdline) it returns "". This is a
 // lossy, display-oriented view: it collapses argv boundaries, so a binary path
-// containing spaces cannot be recovered from it — use Argv for classification
-// that must survive spaced paths (#1214).
+// containing spaces cannot be recovered from it. Do not use it for
+// classification that depends on argv boundaries (#1214).
 func Cmdline(pid int) string {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(bytes.ReplaceAll(data, []byte{0}, []byte{' '})))
-}
-
-// Argv returns the process's argv with argument boundaries preserved (each
-// element a distinct argv entry, spaces within an argument kept intact), or nil
-// when unreadable or for kernel threads (empty cmdline). Unlike Cmdline it does
-// not collapse the NUL separators, so a binary path containing spaces stays in
-// a single element (#1214).
-func Argv(pid int) []string {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
-	if err != nil {
-		return nil
-	}
-	parts := bytes.Split(data, []byte{0})
-	// Drop the trailing empty element left by the final NUL terminator.
-	for len(parts) > 0 && len(parts[len(parts)-1]) == 0 {
-		parts = parts[:len(parts)-1]
-	}
-	if len(parts) == 0 {
-		return nil
-	}
-	argv := make([]string, len(parts))
-	for i, p := range parts {
-		argv[i] = string(p)
-	}
-	return argv
 }


### PR DESCRIPTION
## Summary
- Route doctor daemon PID checks through the daemon package's cross-platform process argv and liveness helpers, so macOS gets the existing `ps` fallback instead of `/proc`-only argv.
- Make temp-home daemon liveness tri-state: verified live, verified absent/dead/stale, or unknown. Unknown blocks deletion.
- Re-check process, tmux-session, and daemon liveness immediately before `RemoveAll` so an old finding cannot delete a home that became active.
- Add mac-like unit coverage for daemon argv fallback, unknown liveness fail-closed behavior, live tmux session markers without `/proc`, and fix-time recheck.

## Root Cause
`af doctor` used `proctree.Argv(pid)` in the temp-home daemon check. `proctree.Argv` reads `/proc/<pid>/cmdline`, which is Linux-only; on macOS it returns nil, so `daemon.LooksLikeDaemonArgv(nil)` always reported false. That made doctor classify temp AF homes with live daemons as stale based on age alone. The daemon package already had a `ps` fallback, but doctor bypassed it.

## Tests
- `scripts/testbox.sh test ./doctor`
- `gofmt -l $(git ls-files '*.go')` (empty)
- `go build ./...`
- `golangci-lint --fast` (installed v1.60.1 rejects this shorthand before linting: unknown flag)
- `golangci-lint run --fast`
- `make test-container`
- `scripts/lint-file-length.sh`

Do not merge; root verifies.

Closes #1261

Signed-off-by: Captain Claude <captain-claude@sachiniyer.com>
