### PR TITLE
docs: add comparison page and polish README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,53 @@
 # Agent Factory
 
-A terminal UI that runs multiple AI coding agents — Claude Code, Codex, Aider, Gemini — side by side, each in its own isolated git worktree. Start several agents on different tasks, watch their terminals live in the preview pane, attach to any of them, and automate the whole thing with scheduled tasks and a JSON CLI.
+[![Latest release](https://img.shields.io/github/v/release/sachiniyer/agent-factory?sort=semver)](https://github.com/sachiniyer/agent-factory/releases/latest)
+[![Docs](https://img.shields.io/badge/docs-live-2e7c80)](https://sachiniyer.github.io/agent-factory/)
+[![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-2e7c80)](LICENSE.md)
 
-![Agent Factory demo: spinning up a fleet of AI coding agents, each in its own isolated git worktree; watching their work stream live in the preview pane; a scheduled automations rail (triage issues every morning, nightly tests); opening a dev-server in a second tab beside an agent in the same worktree; and attaching full-screen to one](docs/assets/demo.gif)
+![Agent Factory demo: multiple AI coding agents running in isolated git worktrees, with live previews, scheduled automations, helper tabs, and full-screen attach](docs/assets/demo.gif)
 
-Fork of [claude-squad](https://github.com/smtg-ai/claude-squad) with per-repo scoping, a programmatic CLI, and automated tasks.
+Agent Factory (`af`) is a terminal UI for running many AI coding agents at once:
+Claude Code, Codex, Aider, and Gemini. Each normal session gets its own git
+worktree and branch, so parallel agents do not trample the same checkout. A
+daemon keeps sessions and automations alive, while the TUI, JSON CLI, and local
+HTTP API all read the same state.
+
+Fork of [claude-squad](https://github.com/smtg-ai/claude-squad), extended with
+per-repo scoping, task automation, remote hooks, a programmatic CLI, and a
+branded docs site.
+
+**Full docs:** [sachiniyer.github.io/agent-factory](https://sachiniyer.github.io/agent-factory/)
+
+## Why Agent Factory
+
+- **Worktree isolation:** one agent, one branch, one reviewable working tree.
+- **One-screen supervision:** watch live previews, attach full-screen, and add
+  helper tabs beside an agent in the same worktree.
+- **Daemon-owned state:** sessions, tasks, usage-limit recovery, and APIs share
+  one source of truth.
+- **Automation:** cron tasks and watch scripts can create sessions or deliver
+  prompts into existing ones.
+- **Scriptable control:** `af sessions` and `af tasks` print JSON; the daemon
+  also exposes a local HTTP/JSON API over a Unix socket.
+- **Remote hooks:** plug in your own launch/list/attach/delete scripts for
+  remote session backends.
 
 ## Install
 
-Prerequisites: **tmux**, **git**, and at least one AI coding agent (e.g. [Claude Code](https://docs.anthropic.com/en/docs/claude-code)). No Go required. Runs on Linux and macOS; on Windows, run it inside WSL — see [Platform support](#platform-support).
+Prerequisites: **tmux**, **git**, and at least one supported agent CLI. No Go
+toolchain is required for the prebuilt install path.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sachiniyer/agent-factory/master/install.sh | sh
 ```
 
-Installs the `af` binary (Linux/macOS, amd64/arm64) to `~/.local/bin` — override with `AF_INSTALL_DIR`, pin a release with `--version`. Re-run the script or `af upgrade` to update. Installed binaries also auto-update themselves along the stable channel; set `"update_channel": "preview"` in the global config to track preview builds instead (see [docs/release-process.md](docs/release-process.md)).
+The installer places `af` in `~/.local/bin` by default. Override with
+`AF_INSTALL_DIR`, pin with `--version`, or install from the
+[latest release](https://github.com/sachiniyer/agent-factory/releases/latest).
+Run `af upgrade` or rerun the script to update. Installed binaries auto-update
+on the stable channel unless you opt into preview builds in config.
 
-**Other ways:** grab a tarball from the [Releases page](https://github.com/sachiniyer/agent-factory/releases/latest), or build from source.
-
-### Building from source
-
-Needs **Go 1.24+**; installs to `~/.local/bin/af`:
+Build from source with Go 1.24+:
 
 ```bash
 git clone https://github.com/sachiniyer/agent-factory.git
@@ -28,118 +55,73 @@ cd agent-factory
 ./dev-install.sh
 ```
 
-### Launch
+## Quick Start
+
+Run `af` inside a git repository:
 
 ```bash
-cd your-project    # must be a git repo
-af                 # launch the TUI
+cd your-project
+af
 ```
 
-## Platform support
-
-| Platform | TUI & sessions | Daemon autostart (`af daemon install`) | Install |
-|----------|----------------|----------------------------------------|---------|
-| Linux | ✅ Supported — where development and CI testing happen | ✅ systemd user service | `install.sh`, tarball, or source |
-| macOS | ✅ Supported — expected to work; CI tests run on Linux only | ✅ launchd agent | `install.sh`, tarball, or source |
-| Windows (WSL2) | ✅ Runs as Linux inside WSL | ⚠️ Requires systemd enabled in the distro | `install.sh` inside WSL |
-| Windows (native) | ❌ Unsupported — does not build or run | ❌ | ❌ No binaries published |
-
-Caveats:
-
-- **tmux is load-bearing.** Every session, tab, and preview is a tmux session under the hood; `af` does not work without `tmux` on `PATH`, on any platform.
-- **Native Windows is not a target.** The code depends on tmux and Unix-only syscalls (process-group kills, `SIGWINCH`, `flock`) and does not compile for `GOOS=windows`; no Windows binaries are published, and `af upgrade`/auto-update refuse to run there. Use WSL.
-- **WSL:** `af daemon install` writes a systemd user unit, so your distro must have systemd enabled (the default on current WSL2; otherwise set `systemd=true` under `[boot]` in `/etc/wsl.conf`). Without it the daemon still starts on demand whenever `af` runs, but scheduled tasks stop firing once the WSL VM shuts down. Keep repos on the Linux filesystem (not `/mnt/c`) for git and worktree performance.
-- **macOS is cross-compiled.** Release binaries are published for macOS (amd64/arm64) and the macOS-specific code paths (launchd, `open`, `pbcopy`) are unit-tested, but CI does not run on real macOS hardware.
-- **Clipboard and browser keys** shell out per platform: `open`/`pbcopy` on macOS, `xdg-open` plus `wl-copy` or `xclip` on Linux and WSL. Copying a PR URL (`P`) needs one of those clipboard tools installed.
-- **Prebuilt binaries are amd64/arm64 only.** On other architectures, build from source.
-
-## Core features
-
-Press `?` inside the TUI for the full keybindings list.
-
-### Sessions
-
-Each session is one agent running in its own git worktree on its own branch — agents never step on each other's changes or on your working tree. Sessions persist across restarts, and everything is scoped to the current repo: the TUI only shows sessions for the repository you launched it in.
+Common TUI keys:
 
 | Key | Action |
-|-----|--------|
-| `n` | Create a new session |
-| `Enter` | Interact with the session in its pane — every key (including `Tab`) goes to the agent; the sessions rail stays visible |
-| `Ctrl-]` | Leave interactive mode, back to navigation |
-| `o` | Attach to the selected session's active tab full-screen |
-| `Ctrl-w` | Detach from a full-screen attach (configurable via `detach_keys`) |
-| `D` | Kill the session and clean up its worktree |
-| `A` | Archive the session (tmux down, worktree moved out, restartable) — on an archived row, restore it |
-| `Tab` / `Shift-Tab` | Cycle focus forward / back: tree → open panes → automations |
-| `1`–`9` | Jump straight to a tab by number |
-| `t` | Open a new shell tab in the session's worktree |
-| `w` | Close the active tab (the agent tab can't be closed) |
+|---|---|
+| `n` | Create a local worktree-backed session |
+| `N` | Create a remote session when `remote_hooks` are configured |
+| `Enter` | Interact with the selected tab in place |
+| `Ctrl-]` | Leave in-pane interaction |
+| `o` | Attach to the selected tab full-screen |
+| `Ctrl-w` | Detach from a full-screen attach |
+| `t` | Open a helper shell tab in the session worktree |
+| `A` | Archive or restore a session |
+| `D` | Kill a session and clean up its worktree |
+| `S` | Open the task manager |
 
-When a session's branch has an open pull request, `p` opens it in the browser and `P` copies its URL.
-
-Press `A` to **archive** a session you're done with for now: its tmux is torn down and its worktree is moved out to a global archive directory (branch and uncommitted changes preserved), and the row drops into a collapsed **Archived** folder at the bottom of the rail. Archived sessions survive restarts and are never auto-restored — press `A` again on an archived row (or run `af sessions restore <title>`) to move its worktree back and bring the agent up. Not available for remote or `--here` sessions, which don't own a relocatable worktree.
-
-#### Tabs
-
-Every session opens with a single **agent** tab (the AI agent, shown as *Preview*). Press `t` to spawn **shell** tabs (*Terminal*) running `$SHELL` in the worktree (up to nine tabs per session), `w` to close the active one, and `1`–`9` to jump between them. `Enter` types into whichever tab is active, in place (`o` for a full-screen attach). Tabs are ephemeral but persisted: they survive an `af`/daemon restart, reconnecting to their live processes. You can also spawn a tab running an arbitrary command from the CLI with `af sessions tab-create`, and delete a single tab with `af sessions tab-delete` (see below).
-
-Remote sessions are tab-driven too, with one limitation: the hook protocol can't run arbitrary commands on the remote host, so a remote session has an agent tab always and a single terminal tab **only when** its repo configures `remote_hooks.terminal_cmd` (`t`, `tab-create`, and `tab-delete` are rejected for remote sessions). See [docs/remote-hooks.md](docs/remote-hooks.md).
-
-### Tasks
-
-Tasks deliver a prompt to an agent automatically — on a cron schedule, or every time a long-running watch script emits a stdout line (e.g. a script polling for new GitHub issues). Each fire either creates a fresh session or sends the prompt into an existing one. In the TUI: `S` opens the task manager, `n` creates a task, `r` runs a cron task now.
-
-Tasks are hosted by a background daemon that starts on demand; run `af daemon install` once to keep them firing across reboots. See [docs/tasks.md](docs/tasks.md) for the full trigger × delivery matrix and the watch-script contract.
-
-### Usage limits
-
-When a `claude` or `codex` session hits a plan usage-limit wall, af detects the banner, marks the row `[limit]` in the sidebar (with the reset time when the banner states one), and keeps the session parked rather than treating it as dead. Press **`c`** on the session to resume it immediately; a task-driven session re-sends its stored prompt so it picks up where it left off.
-
-Opt into hands-off recovery with `limit_auto_resume = true` (global config): the daemon then resumes a parked `claude`/`codex` session on its own once its limit window elapses. Task runs that hit a limit at startup are **parked, not failed** — recorded as waiting for the window and resumed to completion, never counted as an errored run. `gemini`/`aider` are API-key-metered (transient 429s), so they are out of scope. See [docs/usage-limits.md](docs/usage-limits.md).
-
-### JSON CLI
-
-Everything the TUI does is scriptable — `af sessions` and `af tasks` print JSON, so other tools (or other agents) can orchestrate Agent Factory:
+Everything the TUI does is also scriptable:
 
 ```bash
 af sessions create --name fix-auth-bug --prompt "Fix the login redirect loop"
 af sessions preview fix-auth-bug
-af sessions tab-create fix-auth-bug --command "btop"   # spawn a process tab in the worktree
-af sessions tab-delete fix-auth-bug --name btop        # delete that tab again (agent tab can't be deleted)
+af sessions tab-create fix-auth-bug --command "npm run dev"
 af tasks add --name "Daily triage" --prompt "Triage open issues" --cron "0 9 * * *"
 ```
 
-See the [CLI guide](docs/cli.md) for a task-oriented tour and the [complete command reference](docs/reference/cli.md) (generated from the command tree) for every command and flag.
+## Core Concepts
 
-### HTTP API
+### Sessions And Tabs
 
-The daemon also exposes the same session and task operations as a small JSON API over a **localhost-only Unix socket** (`$AGENT_FACTORY_HOME/daemon-http.sock`, `0600` owner-only — no TCP port, no token), so tools and agents can call Agent Factory without shelling out to `af`. Every response uses the same `{data, error}` envelope as `af --json`:
+Each normal session is a dedicated git worktree on its own branch. The agent
+runs in that directory, helper tabs run beside it, and the branch remains a
+normal git artifact you can diff, push, or turn into a pull request. `--here`
+is available when you intentionally want an in-place session in the current
+checkout instead.
+
+### Tasks And Daemon
+
+Tasks deliver prompts on a cron schedule or whenever a long-running watch script
+prints a stdout line. A task can create a fresh session per fire or send the
+prompt into a named target session. The background daemon hosts those schedules,
+re-spawns sessions, drives auto-yes, and can park/resume Claude or Codex
+sessions that hit plan usage limits.
+
+### CLI And HTTP API
+
+`af sessions` and `af tasks` emit JSON, so they compose cleanly with shell
+scripts and other agents. The daemon exposes the same control surface as a local
+owner-only HTTP/JSON API over `$AGENT_FACTORY_HOME/daemon-http.sock`.
 
 ```bash
 curl --unix-socket ~/.agent-factory/daemon-http.sock http://localhost/v1/health
-# {"data":{"ok":true},"error":null}
 ```
-
-Run `af api` to list every endpoint (with a ready-to-run curl example) and the resolved socket path; see the [HTTP API guide](docs/http-api.md) for the transport/auth model and the [endpoint reference](docs/reference/api.md) for the full route table.
-
-### Remote sessions
-
-With `remote_hooks` configured in a repo, `N` launches sessions on a remote backend (your own scripts: launch, list, attach, delete, terminal) and shows them alongside local ones with the same attach/kill/preview experience. See [docs/remote-hooks.md](docs/remote-hooks.md) for the script protocol.
-
-### Root agent (always-ensured)
-
-Opt a repository into an always-on **root agent** — a reserved session titled `root` that the daemon keeps alive, attached in-place at the repo root (no worktree; killing it never touches your working tree) and re-created automatically if its tmux dies:
-
-```toml
-[root_agents]
-"/home/me/myrepo" = {}
-```
-
-Strictly opt-in via your global `~/.agent-factory/config.toml` (never from an in-repo config, so a cloned repo can't spawn one), and the default profile runs `claude --dangerously-skip-permissions` with auto-yes — see [docs/configuration.md](docs/configuration.md#root-agents-always-ensured) before opting in. The name `root` is reserved: normal session creation rejects it.
 
 ### Configuration
 
-Config is [TOML](https://toml.io), for easy hand-editing. Global defaults live in `~/.agent-factory/config.toml`; a repo can check in its own `.agent-factory/config.toml` that overrides them (and is the only place repo-specific keys like `remote_hooks` and `post_worktree_commands` may live):
+Configuration is TOML. Global defaults live in
+`~/.agent-factory/config.toml`; repo-specific settings can live in
+`.agent-factory/config.toml` inside the repository. Use `program_overrides` for
+agent paths or flags.
 
 ```toml
 default_program = "claude"
@@ -148,28 +130,41 @@ default_program = "claude"
 claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 ```
 
-Read and write the global config from the CLI: `af config list` / `af config get <key>` show the effective values, and `af config set <key> <value>` writes a single settable key in place — preserving every comment and your ordering (it never regenerates the file), validated with the loader's own rules first. Structural keys (`root_agents`, `[keys]`) stay hand-edited. Upgrading from a `config.json`? The move to TOML is automatic — `af` converts it on first run and keeps a `config.json.bak`. See [docs/configuration.md](docs/configuration.md) for every key, the migration, the precedence rules, and where state is stored.
+## Platform Support
+
+| Platform | TUI and sessions | Daemon autostart | Install |
+|---|---|---|---|
+| Linux | Supported and CI-tested | systemd user service | install script, tarball, source |
+| macOS | Supported; release binaries are cross-compiled | launchd agent | install script, tarball, source |
+| Windows via WSL2 | Supported as Linux inside WSL | requires systemd in the distro | install script inside WSL |
+| Native Windows | Unsupported | unsupported | no binaries |
+
+tmux is required on every supported platform. Native Windows is not a target;
+use WSL2 and keep repositories on the Linux filesystem for best git/worktree
+performance.
 
 ## Documentation
 
-📖 **Full documentation site: [sachiniyer.github.io/agent-factory](https://sachiniyer.github.io/agent-factory/)** — capabilities overview, concepts, getting started, and generated CLI/HTTP API references. Source lives in [`docs/`](docs/) and builds with MkDocs.
-
-- [docs/cli.md](docs/cli.md) — narrative CLI guide; the complete generated command reference is [docs/reference/cli.md](docs/reference/cli.md)
-- [docs/http-api.md](docs/http-api.md) — the daemon-hosted HTTP/JSON API: socket path, auth model, response envelope (`af api` prints the same catalog); the generated endpoint reference is [docs/reference/api.md](docs/reference/api.md)
-- [docs/configuration.md](docs/configuration.md) — config keys, global vs. in-repo precedence, state locations
-- [docs/tasks.md](docs/tasks.md) — task triggers, the watch-script contract, daemon lifecycle
-- [docs/usage-limits.md](docs/usage-limits.md) — usage-limit detection, the `[limit]` badge, manual retry, opt-in auto-resume, and task park-don't-fail
-- [docs/remote-hooks.md](docs/remote-hooks.md) — remote backend script protocol
-- [docs/release-process.md](docs/release-process.md) — release channels: manual stable `1.x.y` (the auto-update default), opt-in auto preview `1.x.y-preview-z`
-- [docs/release-testing-plan.md](docs/release-testing-plan.md) — release gate and smoke checks
-- [docs/container-testing.md](docs/container-testing.md) — running the test suite and TUI play-tests safely in a container (`make test-container` / `make playtest-container`)
-- [examples/](examples/) — runnable task watch-scripts and remote-hook skeletons
+- [Documentation site](https://sachiniyer.github.io/agent-factory/) - overview,
+  getting started, concepts, guides, and generated reference pages.
+- [Comparison](docs/comparison.md) - Agent Factory vs. tmux/manual worktrees and
+  peers such as Herdr.
+- [CLI guide](docs/cli.md) and [generated CLI reference](docs/reference/cli.md).
+- [HTTP API guide](docs/http-api.md) and [generated API reference](docs/reference/api.md).
+- [Configuration](docs/configuration.md), [tasks](docs/tasks.md),
+  [remote hooks](docs/remote-hooks.md), and [usage limits](docs/usage-limits.md).
+- [Container testing](docs/container-testing.md), [release process](docs/release-process.md),
+  and [release testing plan](docs/release-testing-plan.md).
 
 ## Maintenance
 
-This repo is autonomously maintained by Captain Claude, an AI maintainer running on Claude Code; the operating contract lives in [CLAUDE.md](CLAUDE.md). Every open issue gets a response — a fix, specific questions, or a reasoned close — and merged work reaches the preview channel (`1.x.y-preview-z`) from `master` every 3 hours; stable releases (`1.x.y`) are cut manually (see [docs/release-process.md](docs/release-process.md)).
+This repo is autonomously maintained by Captain Claude, an AI maintainer running
+on Claude Code. The operating contract lives in [CLAUDE.md](CLAUDE.md).
 
-When filing an issue, include: steps to reproduce, expected vs. actual behavior, `af version` output and your platform, and (when relevant) logs from the application log (see `docs/configuration.md` for path resolution). The fastest way to gather all of that is `af bug-report`, which bundles the log tail, versions, tasks, redacted session state, and daemon health into a single `~/af-bug-report-<ts>.txt` you can attach — redaction is best-effort, so review the file before sharing it.
+When filing an issue, include steps to reproduce, expected vs. actual behavior,
+`af version`, platform details, and logs when relevant. `af bug-report` gathers
+versions, daemon health, task state, redacted session state, and the recent log
+tail into a single report file for review.
 
 ## License
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,57 @@
+# Comparison
+
+Agent Factory is built around a specific workflow: give each agent a real git
+worktree and branch, keep the sessions alive through a daemon, and make the same
+state available from the TUI, JSON CLI, and local HTTP API.
+
+That is not the only good center of gravity. A classic tmux setup gives you the
+smallest set of primitives, and Herdr is a strong terminal-native agent
+multiplexer with real panes, agent state, remote attach, and a socket API. Use
+the table as a map of tradeoffs, not a scorecard.
+
+## Feature Comparison
+
+| Capability | Agent Factory | tmux + manual worktrees | Herdr |
+|---|---|---|---|
+| Worktree isolation | Built in for normal sessions: one session creates one branch and one git worktree. `--here` is the explicit in-place exception. | Possible, but you create, name, clean up, and review the worktrees yourself. | Supported through worktree-aware workspace commands; Herdr positions branch/diff review as a separate layer from its terminal multiplexer core. |
+| Parallel agents | Built for multiple concurrent sessions in one repo, each scoped to its own worktree. | Works if you launch each agent in a separate pane and directory. Isolation depends on your discipline. | Built for many concurrent terminal agents, with pane/workspace organization and state rollups. |
+| Daemon and automation | Background daemon owns state, re-spawns sessions, hosts cron/watch tasks, drives auto-yes, and can auto-resume Claude/Codex usage-limit waits. | tmux keeps panes alive, but scheduling, prompting, restart policy, and cleanup are custom scripts or cron jobs. | Background server keeps panes alive and exposes automation through CLI/socket APIs and plugins. A built-in cron/watch task scheduler is not documented as Herdr's main workflow. |
+| CLI + HTTP API | `af` prints JSON for sessions/tasks, and the daemon exposes a local owner-only HTTP/JSON API over a Unix socket. | tmux itself is scriptable; an HTTP API is not part of the tmux/manual stack. | CLI plus a local socket API for workspaces, panes, agents, events, and worktrees; not an HTTP API. |
+| Remote execution | Remote hooks let a repo define launch/list/attach/delete/terminal scripts for sessions elsewhere, shown in the same TUI. | SSH + tmux is a proven remote pattern, but agent/session metadata is manual. | First-class remote attach over SSH/direct remote client is a core feature. |
+| Open source / license | Open source, GNU AGPL v3. | tmux is open source under the ISC-style tmux license; your glue scripts and chosen agents vary. | Open source AGPL-3.0-or-later, with commercial licensing offered. |
+| Supported agents | Named agent choices are `claude`, `codex`, `aider`, and `gemini`; configure paths/flags with `program_overrides`. | Anything you can run in a shell. | Broad terminal-agent support, with richer integrations for many listed agents and fallback terminal support for others. |
+
+## When To Choose What
+
+**Choose Agent Factory** when the unit of work is "one task, one branch, one
+reviewable worktree" and you want sessions, scheduled prompts, event-driven
+tasks, remote hooks, and API access to share one daemon-owned state model.
+
+**Choose tmux + manual worktrees** when you want the fewest moving parts, already
+have shell scripts that fit your team, and are comfortable owning all lifecycle,
+cleanup, and automation policy yourself.
+
+**Choose Herdr** when the live terminal workspace is the product: persistent
+real panes, mouse-native terminal layout, agent state at a glance, direct
+attach, remote SSH workflows, and an agent/socket control surface.
+
+These tools can also layer together. For example, an Agent Factory remote hook
+can target infrastructure that uses tmux or another multiplexer, and Herdr can
+sit beside a worktree workflow when the main need is richer terminal layout and
+agent-state awareness.
+
+## Source Notes
+
+- Agent Factory behavior is documented in [Worktree-isolated agents](concepts/worktree-agents.md),
+  [The daemon](concepts/daemon.md), [Tasks & automation](tasks.md),
+  [Remote hooks](remote-hooks.md), the [CLI reference](reference/cli.md), and
+  the [HTTP API reference](reference/api.md).
+- Herdr's public docs describe it as a terminal-native agent multiplexer with
+  persistent panes, agent state, remote attach, CLI/socket APIs, and worktree
+  methods: [Herdr](https://herdr.dev/), [Compare](https://herdr.dev/compare/),
+  [Socket API](https://herdr.dev/docs/socket-api/), and
+  [license](https://github.com/ogulcancelik/herdr/blob/master/LICENSE).
+- tmux describes itself as a terminal multiplexer with detachable sessions; see
+  the [tmux README](https://github.com/tmux/tmux/blob/master/README) and
+  [license](https://github.com/tmux/tmux/blob/master/COPYING). The worktree
+  primitive is git's [git-worktree](https://git-scm.com/docs/git-worktree).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ validation:
 nav:
   - Home: index.md
   - Getting started: getting-started.md
+  - Comparison: comparison.md
   - Concepts:
       - Worktree-isolated agents: concepts/worktree-agents.md
       - The daemon: concepts/daemon.md


### PR DESCRIPTION
Do not merge — root review requested for the comparison framing and README polish.

## Summary
- Adds a new MkDocs `Comparison` page and wires it into the main nav.
- Compares Agent Factory with tmux + manual worktrees and Herdr across worktree isolation, parallel agents, daemon/automation, CLI/API surface, remote execution, license, and supported agents.
- Polishes the README front door with release/docs/license badges, a tighter feature list, cleaner install/quick-start flow, docs-site links, and less dense section structure.

## Notes for review
- Herdr is framed as a strong peer with a different center of gravity: terminal-native panes, agent state, remote attach, and socket/CLI control. Agent Factory is framed around daemon-owned worktree/session/task orchestration.
- Taste call for Sachin: the comparison language is intentionally non-combative and may be worth product-positioning review.
- This PR also fills the only concrete missing docs-site info I found while verifying #1033: a comparison page.

## Gates
- `scripts/gen-docs.sh && git diff --exit-code -- docs/reference/cli.md docs/reference/api.md`
- `scripts/lint-file-length.sh`
- `.venv-docs/bin/mkdocs build --strict`

Closes #1036
Closes #1037

— Captain Claude
