### PR TITLE
fix(tui): surface clipboard copy failures

### DIFF
--- a/app/clipboard.go
+++ b/app/clipboard.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+type clipboardCommandSpec struct {
+	path string
+	args []string
+}
+
+var copyToClipboard = copyTextToClipboard
+
+func copyTextToClipboard(text string) error {
+	spec, err := clipboardCommandForPlatform(runtime.GOOS, exec.LookPath)
+	if err != nil {
+		return err
+	}
+	return runClipboardCommand(exec.Command(spec.path, spec.args...), text)
+}
+
+func clipboardCommandForPlatform(goos string, lookPath func(string) (string, error)) (clipboardCommandSpec, error) {
+	switch goos {
+	case "darwin":
+		path, err := lookPath("pbcopy")
+		if err != nil {
+			return clipboardCommandSpec{}, noClipboardToolErr()
+		}
+		return clipboardCommandSpec{path: path}, nil
+	default:
+		if path, err := lookPath("wl-copy"); err == nil {
+			return clipboardCommandSpec{path: path}, nil
+		}
+		if path, err := lookPath("xclip"); err == nil {
+			return clipboardCommandSpec{path: path, args: []string{"-selection", "clipboard"}}, nil
+		}
+		return clipboardCommandSpec{}, noClipboardToolErr()
+	}
+}
+
+func runClipboardCommand(copyCmd *exec.Cmd, text string) error {
+	var stderr bytes.Buffer
+	copyCmd.Stdin = strings.NewReader(text)
+	copyCmd.Stderr = &stderr
+
+	if err := copyCmd.Run(); err != nil {
+		stderrText := strings.TrimSpace(stderr.String())
+		if stderrText != "" {
+			return fmt.Errorf("copy failed: %s", stderrText)
+		}
+		return fmt.Errorf("copy failed: %w", err)
+	}
+	return nil
+}
+
+func noClipboardToolErr() error {
+	return errors.New("no clipboard tool found (install xclip/wl-clipboard, or pbcopy on macOS)")
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -845,20 +845,8 @@ func (m *home) handleCopyPR() (tea.Model, tea.Cmd) {
 		return m, m.handleError(noPRForSessionErr)
 	}
 	url := selected.GetPRInfo().URL
-	var copyCmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		copyCmd = exec.Command("pbcopy")
-	default:
-		if _, err := exec.LookPath("wl-copy"); err == nil {
-			copyCmd = exec.Command("wl-copy")
-		} else {
-			copyCmd = exec.Command("xclip", "-selection", "clipboard")
-		}
-	}
-	copyCmd.Stdin = strings.NewReader(url)
-	if err := copyCmd.Run(); err != nil {
-		return m, m.handleError(fmt.Errorf("failed to copy PR URL: %w", err))
+	if err := copyToClipboard(url); err != nil {
+		return m, m.handleError(fmt.Errorf("%w; PR URL: %s", err, url))
 	}
 	return m, nil
 }

--- a/app/handle_actions_test.go
+++ b/app/handle_actions_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 )
 
 // recordingAttachBackend wraps a FakeBackend and records the title of the
@@ -162,4 +164,75 @@ func TestOpenCopyPRNoPRSurfacesMessage(t *testing.T) {
 	_, cmd = h.handleOpenPR()
 	require.Nil(t, cmd, "handleOpenPR on an empty selection must stay a silent no-op")
 	require.Empty(t, strings.TrimSpace(h.errBox.String()))
+}
+
+func TestClipboardCommandForPlatform(t *testing.T) {
+	lookPath := func(paths map[string]string) func(string) (string, error) {
+		return func(name string) (string, error) {
+			if path, ok := paths[name]; ok {
+				return path, nil
+			}
+			return "", exec.ErrNotFound
+		}
+	}
+
+	t.Run("darwin uses pbcopy", func(t *testing.T) {
+		spec, err := clipboardCommandForPlatform("darwin", lookPath(map[string]string{"pbcopy": "/bin/pbcopy"}))
+		require.NoError(t, err)
+		require.Equal(t, clipboardCommandSpec{path: "/bin/pbcopy"}, spec)
+	})
+
+	t.Run("non-darwin prefers wl-copy", func(t *testing.T) {
+		spec, err := clipboardCommandForPlatform("linux", lookPath(map[string]string{
+			"wl-copy": "/bin/wl-copy",
+			"xclip":   "/bin/xclip",
+		}))
+		require.NoError(t, err)
+		require.Equal(t, clipboardCommandSpec{path: "/bin/wl-copy"}, spec)
+	})
+
+	t.Run("non-darwin falls back to xclip", func(t *testing.T) {
+		spec, err := clipboardCommandForPlatform("linux", lookPath(map[string]string{"xclip": "/bin/xclip"}))
+		require.NoError(t, err)
+		require.Equal(t, clipboardCommandSpec{path: "/bin/xclip", args: []string{"-selection", "clipboard"}}, spec)
+	})
+
+	t.Run("missing tools are actionable", func(t *testing.T) {
+		_, err := clipboardCommandForPlatform("linux", lookPath(nil))
+		require.EqualError(t, err, "no clipboard tool found (install xclip/wl-clipboard, or pbcopy on macOS)")
+	})
+}
+
+func TestRunClipboardCommandCapturesStderr(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "cat >/dev/null; printf 'cannot open display\\n' >&2; exit 1")
+	err := runClipboardCommand(cmd, "https://github.com/sachiniyer/agent-factory/pull/1")
+	require.EqualError(t, err, "copy failed: cannot open display")
+}
+
+func TestHandleCopyPRFailureShowsReasonAndURL(t *testing.T) {
+	const url = "https://github.com/sachiniyer/agent-factory/pull/1284"
+
+	h := newTestHome(t)
+	h.errBox.SetSize(500, 1)
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "has-pr", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	inst.SetStatus(session.Running)
+	inst.SetPRInfo(&sessiongit.PRInfo{Number: 1284, Title: "clipboard", URL: url, State: "OPEN"})
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	prevCopy := copyToClipboard
+	copyToClipboard = func(text string) error {
+		require.Equal(t, url, text)
+		return errors.New("copy failed: cannot open display")
+	}
+	t.Cleanup(func() { copyToClipboard = prevCopy })
+
+	_, cmd := h.handleCopyPR()
+	require.NotNil(t, cmd, "copy failure should return the normal clear-message command")
+
+	rendered := h.errBox.String()
+	require.Contains(t, rendered, "copy failed: cannot open display")
+	require.Contains(t, rendered, "PR URL: "+url)
 }


### PR DESCRIPTION
## Summary

- Route PR URL copying through a small clipboard helper that distinguishes missing tooling from command failures.
- Capture clipboard command stderr and surface it as `copy failed: <stderr>` instead of a bare exit status.
- On any clipboard failure, include `PR URL: ...` in the TUI status/error line so the user can copy it manually.

## Verification

- Verified `origin/master` at `f8e7104`: `handleCopyPR` used `copyCmd.Run()` without stderr capture and fell through to `xclip` without a missing-tool check.
- `golangci-lint --fast` is unsupported by installed `golangci-lint` v1.60.1 (`unknown flag: --fast`); equivalent `golangci-lint run --fast` passed.
- `gofmt -l $(git ls-files '*.go')` returned empty.
- `go build ./...`
- `make test-container`
- `make lint-file-length`

Closes #1284.

Do not merge; root verifies.

Signed-off-by: Captain Claude <noreply@anthropic.com>
