### PR TITLE
fix(config): preserve worktree_root in TOML migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ agent paths or flags.
 
 ```toml
 default_program = "claude"
+worktree_root = "sibling"
 
 [program_overrides]
 claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"

--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,8 @@ type Config struct {
 	LogMaxBackups int `json:"log_max_backups" toml:"log_max_backups"`
 	// BranchPrefix is the prefix used for git branches created by the application.
 	BranchPrefix string `json:"branch_prefix" toml:"branch_prefix"`
+	// WorktreeRoot controls where new worktrees are created.
+	WorktreeRoot string `json:"worktree_root" toml:"worktree_root"`
 	// DetachKeys is the key combination used to detach from an attached session (e.g. "ctrl-w", "ctrl-q").
 	DetachKeys string `json:"detach_keys" toml:"detach_keys"`
 	// UpdateChannel selects which release channel auto-update and
@@ -306,6 +308,7 @@ func DefaultConfig() *Config {
 		LogMaxSizeMB:       log.DefaultMaxSizeMB,
 		LogMaxBackups:      log.DefaultMaxBackups,
 		UpdateChannel:      UpdateChannelStable,
+		WorktreeRoot:       WorktreeRootSibling,
 		BranchPrefix: func() string {
 			user, err := user.Current()
 			if err != nil || user == nil || user.Username == "" {
@@ -1018,6 +1021,7 @@ func validateConfig(config *Config, prettyConfigPath string) (*Config, error) {
 
 	sanitizeLimitPatterns(config)
 	config.LimitRetryInterval = sanitizeLimitRetryInterval(config.LimitRetryInterval, prettyConfigPath)
+	config.WorktreeRoot = normalizeWorktreeRoot(config.WorktreeRoot, prettyConfigPath)
 
 	if config.DaemonPollInterval <= 0 {
 		log.WarningLog.Printf("daemon_poll_interval=%d is non-positive; using default %dms", config.DaemonPollInterval, defaultDaemonPollInterval)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -341,6 +341,7 @@ func TestDefaultConfig(t *testing.T) {
 		assert.Equal(t, UpdateChannelStable, cfg.UpdateChannel)
 		assert.NotEmpty(t, cfg.BranchPrefix)
 		assert.True(t, strings.HasSuffix(cfg.BranchPrefix, "/"))
+		assert.Equal(t, WorktreeRootSibling, cfg.WorktreeRoot)
 
 		// The detected path with --dangerously-skip-permissions lands in the
 		// nested overrides map; default_program stays a bare enum.
@@ -650,6 +651,7 @@ func TestLoadConfig(t *testing.T) {
 		assert.False(t, cfg.AutoYes)
 		assert.Equal(t, 1000, cfg.DaemonPollInterval)
 		assert.NotEmpty(t, cfg.BranchPrefix)
+		assert.Equal(t, WorktreeRootSibling, cfg.WorktreeRoot)
 	})
 
 	t.Run("loads valid config with enum default_program", func(t *testing.T) {
@@ -663,7 +665,8 @@ func TestLoadConfig(t *testing.T) {
 			"default_program": "codex",
 			"auto_yes": true,
 			"daemon_poll_interval": 2000,
-			"branch_prefix": "test/"
+			"branch_prefix": "test/",
+			"worktree_root": "subdirectory"
 		}`
 		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
 
@@ -674,6 +677,7 @@ func TestLoadConfig(t *testing.T) {
 		assert.True(t, cfg.AutoYes)
 		assert.Equal(t, 2000, cfg.DaemonPollInterval)
 		assert.Equal(t, "test/", cfg.BranchPrefix)
+		assert.Equal(t, WorktreeRootSubdirectory, cfg.WorktreeRoot)
 	})
 
 	t.Run("loads program_overrides nested map", func(t *testing.T) {
@@ -892,6 +896,7 @@ func TestLoadConfig(t *testing.T) {
 		data, err := os.ReadFile(filepath.Join(configDir, TomlConfigFileName))
 		require.NoError(t, err)
 		assert.Contains(t, string(data), `update_channel = 'stable'`)
+		assert.Contains(t, string(data), `worktree_root = 'sibling'`)
 
 		// The materialized file must reload cleanly through the TOML path.
 		cfg, err := LoadConfig()
@@ -1005,6 +1010,7 @@ default_program = "codex"
 auto_yes = true
 daemon_poll_interval = 2000
 branch_prefix = "test/"
+worktree_root = "subdirectory"
 
 [program_overrides]
 claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
@@ -1018,6 +1024,7 @@ codex = "/opt/codex/bin/codex --quiet"
 		assert.True(t, cfg.AutoYes)
 		assert.Equal(t, 2000, cfg.DaemonPollInterval)
 		assert.Equal(t, "test/", cfg.BranchPrefix)
+		assert.Equal(t, WorktreeRootSubdirectory, cfg.WorktreeRoot)
 		assert.Equal(t, "/home/me/.local/bin/claude --dangerously-skip-permissions",
 			cfg.ProgramOverrides[tmux.ProgramClaude])
 		assert.Equal(t, "/opt/codex/bin/codex --quiet",

--- a/config/configset.go
+++ b/config/configset.go
@@ -70,6 +70,12 @@ var settableKeySpecs = map[string]settableKeySpec{
 	"log_max_size_mb":      {kind: cfgInt, validate: func(_, v string) error { return requirePositiveInt("log_max_size_mb", v) }},
 	"log_max_backups":      {kind: cfgInt, validate: func(_, v string) error { return requireNonNegativeInt("log_max_backups", v) }},
 	"branch_prefix":        {kind: cfgString},
+	"worktree_root": {kind: cfgString, validate: func(_, v string) error {
+		if !validateWorktreeRootValue(v) {
+			return fmt.Errorf("worktree_root must be one of [%s, %s], got %q", WorktreeRootSubdirectory, WorktreeRootSibling, v)
+		}
+		return nil
+	}},
 	"detach_keys": {kind: cfgString, validate: func(_, v string) error {
 		if _, err := ParseDetachKey(v); err != nil {
 			return fmt.Errorf("detach_keys: %w", err)

--- a/config/configset_test.go
+++ b/config/configset_test.go
@@ -224,6 +224,7 @@ func TestSetGlobalConfigValueRejectsBadValues(t *testing.T) {
 		{"daemon_poll_interval", "abc", "integer"},
 		{"daemon_poll_interval", "0", "positive"},
 		{"log_max_backups", "-1", "non-negative"},
+		{"worktree_root", "elsewhere", "must be one of"},
 		{"update_channel", "banana", "must be one of"},
 		{"limit_patterns.claude", "(", "regular expression"},
 		{"program_overrides.notaprogram", "cmd", "must be one of"},

--- a/config/conversion_test.go
+++ b/config/conversion_test.go
@@ -33,9 +33,20 @@ func TestConversion_MigratesLegacyJSON(t *testing.T) {
 		"default_program": "codex",
 		"auto_yes": true,
 		"daemon_poll_interval": 2500,
-		"program_overrides": {"claude": "/opt/claude --dsp"}
+		"program_overrides": {"claude": "/opt/claude --dsp", "codex": "/opt/codex --quiet"},
+		"log_max_size_mb": 12,
+		"log_max_backups": 3,
+		"branch_prefix": "team/",
+		"worktree_root": "subdirectory",
+		"detach_keys": "ctrl-q",
+		"update_channel": "preview",
+		"limit_patterns": {"claude": "custom limit banner"},
+		"limit_auto_resume": true,
+		"limit_retry_interval": "45m",
+		"root_agents": {"/tmp/repo": {"program": "codex", "auto_yes": false}}
 	}`)
 	infoBuf := captureLog(t, &aflog.InfoLog)
+	warnBuf := captureLog(t, &aflog.WarningLog)
 
 	cfg, err := LoadConfig()
 	require.NoError(t, err)
@@ -46,12 +57,32 @@ func TestConversion_MigratesLegacyJSON(t *testing.T) {
 	assert.True(t, cfg.AutoYes)
 	assert.Equal(t, 2500, cfg.DaemonPollInterval)
 	assert.Equal(t, "/opt/claude --dsp", cfg.ProgramOverrides["claude"])
+	assert.Equal(t, "/opt/codex --quiet", cfg.ProgramOverrides["codex"])
+	assert.Equal(t, 12, cfg.LogMaxSizeMB)
+	assert.Equal(t, 3, cfg.LogMaxBackups)
+	assert.Equal(t, "team/", cfg.BranchPrefix)
+	assert.Equal(t, WorktreeRootSubdirectory, cfg.WorktreeRoot)
+	assert.Equal(t, "ctrl-q", cfg.DetachKeys)
+	assert.Equal(t, UpdateChannelPreview, cfg.UpdateChannel)
+	assert.Equal(t, "custom limit banner", cfg.LimitPatterns["claude"])
+	assert.True(t, cfg.LimitAutoResume)
+	assert.Equal(t, "45m", cfg.LimitRetryInterval)
+	require.Contains(t, cfg.RootAgents, "/tmp/repo")
+	rootAgent := cfg.RootAgents["/tmp/repo"]
+	assert.Equal(t, "codex", rootAgent.Program)
+	require.NotNil(t, rootAgent.AutoYes)
+	assert.False(t, rootAgent.AutoYesEnabled())
+	assert.NotContains(t, warnBuf.String(), "worktree_root", "worktree_root must be recognized and preserved, not warned as dropped")
 
 	// config.toml is now canonical; config.json is moved aside to .bak.
-	assert.FileExists(t, filepath.Join(configDir, TomlConfigFileName))
+	tomlPath := filepath.Join(configDir, TomlConfigFileName)
+	assert.FileExists(t, tomlPath)
 	assert.NoFileExists(t, filepath.Join(configDir, ConfigFileName))
 	assert.FileExists(t, filepath.Join(configDir, ConfigFileName+".bak"))
 	assert.Contains(t, infoBuf.String(), "migrated config to TOML")
+	tomlData, err := os.ReadFile(tomlPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(tomlData), "worktree_root = 'subdirectory'")
 
 	// The .bak still holds the original bytes, verbatim.
 	bak, err := os.ReadFile(filepath.Join(configDir, ConfigFileName+".bak"))
@@ -60,11 +91,12 @@ func TestConversion_MigratesLegacyJSON(t *testing.T) {
 
 	// Re-loading now reads config.toml canonically, with no duplicate-config
 	// warning (config.json is gone).
-	warnBuf := captureLog(t, &aflog.WarningLog)
+	reloadWarnBuf := captureLog(t, &aflog.WarningLog)
 	cfg2, err := LoadConfig()
 	require.NoError(t, err)
 	assert.Equal(t, "codex", cfg2.DefaultProgram)
-	assert.NotContains(t, warnBuf.String(), "both", "a clean conversion leaves no duplicate-config warning")
+	assert.Equal(t, WorktreeRootSubdirectory, cfg2.WorktreeRoot)
+	assert.NotContains(t, reloadWarnBuf.String(), "both", "a clean conversion leaves no duplicate-config warning")
 }
 
 func TestConversion_PreservesExistingBackup(t *testing.T) {

--- a/config/worktree_root.go
+++ b/config/worktree_root.go
@@ -1,0 +1,23 @@
+package config
+
+import "github.com/sachiniyer/agent-factory/log"
+
+const (
+	// WorktreeRootSubdirectory stores worktrees under the global config directory.
+	WorktreeRootSubdirectory = "subdirectory"
+	// WorktreeRootSibling stores worktrees beside the repository.
+	WorktreeRootSibling = "sibling"
+)
+
+func validateWorktreeRootValue(value string) bool {
+	return value == WorktreeRootSubdirectory || value == WorktreeRootSibling
+}
+
+func normalizeWorktreeRoot(value, prettyConfigPath string) string {
+	if validateWorktreeRootValue(value) {
+		return value
+	}
+	log.WarningLog.Printf("config %s: worktree_root=%q is not one of [%s, %s]; using default %q",
+		prettyConfigPath, value, WorktreeRootSubdirectory, WorktreeRootSibling, WorktreeRootSibling)
+	return WorktreeRootSibling
+}

--- a/configcmd.go
+++ b/configcmd.go
@@ -70,6 +70,7 @@ func configEntries(cfg *config.Config) []configEntry {
 		{"log_max_size_mb", cfg.LogMaxSizeMB},
 		{"log_max_backups", cfg.LogMaxBackups},
 		{"branch_prefix", cfg.BranchPrefix},
+		{"worktree_root", cfg.WorktreeRoot},
 		{"detach_keys", cfg.DetachKeys},
 		{"update_channel", cfg.UpdateChannel},
 		{"root_agents", cfg.RootAgents},
@@ -193,6 +194,7 @@ Settable keys:
   log_max_size_mb            positive integer
   log_max_backups            non-negative integer
   branch_prefix              string
+  worktree_root              subdirectory | sibling
   detach_keys                string (e.g. ctrl-w)
   update_channel             stable | preview
   limit_patterns.<agent>     usage-limit banner regex for an agent

--- a/configcmd_test.go
+++ b/configcmd_test.go
@@ -90,7 +90,7 @@ func TestConfigEntriesCoverAllKeys(t *testing.T) {
 	want := []string{
 		"default_program", "program_overrides", "auto_yes", "daemon_poll_interval",
 		"log_max_size_mb", "log_max_backups", "branch_prefix", "detach_keys",
-		"update_channel", "root_agents", "limit_patterns", "keys",
+		"worktree_root", "update_channel", "root_agents", "limit_patterns", "keys",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("configEntries has %d keys, want %d", len(got), len(want))

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,7 +86,7 @@ af config get <key>                # one key (scalars print bare; maps as JSON)
 af config set <key> <value>        # write one settable key, preserving comments/ordering
 ```
 
-`get`/`list` report effective global values (defaults applied). `set` edits only the target value's bytes — every comment, blank line, and key ordering is preserved (the file is not regenerated) — and validates the value with the loader's own rules before writing, so it can never produce a config that fails to load. Settable keys: `default_program`, `program_overrides.<agent>`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`. Structural keys (`root_agents`, `[keys]`) stay hand-edited. A change applies on the next `af`/daemon start, exactly like a hand-edit (`set` prints this reminder). Full key reference: [configuration.md](configuration.md).
+`get`/`list` report effective global values (defaults applied). `set` edits only the target value's bytes — every comment, blank line, and key ordering is preserved (the file is not regenerated) — and validates the value with the loader's own rules before writing, so it can never produce a config that fails to load. Settable keys: `default_program`, `program_overrides.<agent>`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`. Structural keys (`root_agents`, `[keys]`) stay hand-edited. A change applies on the next `af`/daemon start, exactly like a hand-edit (`set` prints this reminder). Full key reference: [configuration.md](configuration.md).
 
 ## Maintenance commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
 
 Config is [TOML](https://toml.io) — chosen so it is easy to hand-edit. If you are upgrading from a version that used `config.json`, see [Migrating from JSON](#migrating-from-json) below; the change is automatic.
 
-You can also read and write the global config from the CLI: `af config get <key>` / `af config list` print the effective values, and `af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`; structural keys (`root_agents`, `[keys]`) are hand-edited only. See [`af config`](reference/cli.md#af-config) in the CLI reference. Changes apply on the next `af`/daemon start, the same as a hand-edit.
+You can also read and write the global config from the CLI: `af config get <key>` / `af config list` print the effective values, and `af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`; structural keys (`root_agents`, `[keys]`) are hand-edited only. See [`af config`](reference/cli.md#af-config) in the CLI reference. Changes apply on the next `af`/daemon start, the same as a hand-edit.
 
 ## Global config
 
@@ -20,6 +20,7 @@ default_program = "claude"
 auto_yes = false
 daemon_poll_interval = 1000
 branch_prefix = "username/"
+worktree_root = "sibling"
 detach_keys = "ctrl-w"
 log_max_size_mb = 50
 log_max_backups = 2
@@ -38,6 +39,7 @@ claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 | `auto_yes` | Auto-accept agent prompts (experimental). |
 | `daemon_poll_interval` | Daemon polling interval in ms. |
 | `branch_prefix` | Prefix for worktree branches (defaults to `username/`). |
+| `worktree_root` | Where new worktrees are created: `sibling` (default, next to the repo as `<repo>-<session>`) or `subdirectory` (under `~/.agent-factory/worktrees/<branch>`). |
 | `detach_keys` | Key combination that detaches from an attached session (defaults to `ctrl-w`). |
 | `log_max_size_mb` | Size cap in MB for `agent-factory.log` and the per-task watch-script logs before they are rotated (defaults to 50). Must be positive. |
 | `log_max_backups` | How many rotated logs (`agent-factory.log.1`, `.2`, ...) to keep per log file; older ones are deleted (defaults to 2). `0` keeps none. |
@@ -174,7 +176,7 @@ terminal_cmd = "./infra/terminal.sh"
 |-------|-------|
 | `default_program`, `program_overrides` | Valid globally **and** in-repo (in-repo wins). |
 | `post_worktree_commands`, `remote_hooks` | **In-repo only.** The legacy `~/.agent-factory/repos/<repoID>/config.json` location keeps working for one more release (a deprecation warning in the log points at the new file) and is shadowed whenever the in-repo file sets the same key — including by an explicit empty value like `post_worktree_commands = []`. |
-| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `detach_keys`, `log_max_size_mb`, `log_max_backups`, `update_channel`, `keys`, `root_agents`, `limit_auto_resume`, `limit_retry_interval` | Global only. Setting them in-repo is rejected with an error naming the key. |
+| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `worktree_root`, `detach_keys`, `log_max_size_mb`, `log_max_backups`, `update_channel`, `keys`, `root_agents`, `limit_auto_resume`, `limit_retry_interval` | Global only. Setting them in-repo is rejected with an error naming the key. |
 
 `post_worktree_commands` are shell commands run after each new worktree is created (e.g. `npm install`, `make build`) — they can also be edited from the TUI via the `H` (worktree hooks) key. `remote_hooks` configures a remote-machine backend; see [remote-hooks.md](remote-hooks.md) for the script protocol.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -359,6 +359,7 @@ Settable keys:
   log_max_size_mb            positive integer
   log_max_backups            non-negative integer
   branch_prefix              string
+  worktree_root              subdirectory | sibling
   detach_keys                string (e.g. ctrl-w)
   update_channel             stable | preview
   limit_patterns.<agent>     usage-limit banner regex for an agent

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -25,9 +25,25 @@ func isPathStrictlyInside(absBase, absDir string) bool {
 	return true
 }
 
-// getWorktreeDirectoryForRepo returns the parent directory of the repo,
-// so worktrees are created as siblings next to the repository.
 func getWorktreeDirectoryForRepo(repoPath string) (string, error) {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return "", err
+	}
+	return getWorktreeDirectoryForRepoWithConfig(cfg, repoPath)
+}
+
+// getWorktreeDirectoryForRepoWithConfig returns the parent directory for new
+// worktrees under the configured placement mode.
+func getWorktreeDirectoryForRepoWithConfig(cfg *config.Config, repoPath string) (string, error) {
+	if cfg != nil && cfg.WorktreeRoot == config.WorktreeRootSubdirectory {
+		configDir, err := config.GetConfigDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(configDir, "worktrees"), nil
+	}
+
 	if repoPath == "" {
 		return "", fmt.Errorf("repo path is required for worktree creation")
 	}
@@ -137,14 +153,10 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		return nil, "", err
 	}
 
-	worktreeDir, err := getWorktreeDirectoryForRepo(repoPath)
+	worktreeDir, err := getWorktreeDirectoryForRepoWithConfig(cfg, repoPath)
 	if err != nil {
 		return nil, "", err
 	}
-
-	// Worktree is placed as a sibling: {repoParent}/{repoName}-{sessionName}
-	// Only append a numeric suffix if the path already exists (collision).
-	repoName := filepath.Base(repoPath)
 
 	// Sanitize sessionName for filesystem path to prevent directory traversal
 	safeSessionName := strings.ReplaceAll(sessionName, "..", "")
@@ -154,7 +166,14 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		safeSessionName = "session"
 	}
 
-	basePath := filepath.Join(worktreeDir, repoName+"-"+safeSessionName)
+	var basePath string
+	if cfg.WorktreeRoot == config.WorktreeRootSubdirectory {
+		basePath = filepath.Join(worktreeDir, branchName)
+	} else {
+		// Sibling mode: {repoParent}/{repoName}-{sessionName}
+		repoName := filepath.Base(repoPath)
+		basePath = filepath.Join(worktreeDir, repoName+"-"+safeSessionName)
+	}
 
 	// Ensure the worktree path is strictly nested inside worktreeDir. We use
 	// filepath.Rel instead of a HasPrefix check so the validation is correct

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -26,7 +26,7 @@ func (g *GitWorktree) Setup() error {
 		return fmt.Errorf("failed to get worktree directory: empty worktree directory")
 	}
 
-	if err := os.MkdirAll(g.worktreeDir, 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(g.worktreePath), 0755); err != nil {
 		return err
 	}
 

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -59,6 +59,21 @@ func TestGetWorktreeDirectoryForRepo(t *testing.T) {
 	assert.Equal(t, filepath.Dir(repoRoot), worktreeDir)
 }
 
+func TestGetWorktreeDirectoryForRepoSubdirectory(t *testing.T) {
+	sandboxHome(t)
+
+	repoRoot := createGitRepo(t)
+	cfg := config.DefaultConfig()
+	cfg.WorktreeRoot = config.WorktreeRootSubdirectory
+	require.NoError(t, config.SaveConfig(cfg))
+
+	worktreeDir, err := getWorktreeDirectoryForRepo(repoRoot)
+	require.NoError(t, err)
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(configDir, "worktrees"), worktreeDir)
+}
+
 func TestGetWorktreeDirectoryForRepo_RequiresRepoPath(t *testing.T) {
 	_, err := getWorktreeDirectoryForRepo("")
 	require.Error(t, err)
@@ -85,6 +100,25 @@ func TestNewGitWorktree_CleanName(t *testing.T) {
 
 	// Should be in the parent directory of the repo
 	assert.Equal(t, filepath.Dir(repoRoot), filepath.Dir(gw.GetWorktreePath()))
+}
+
+func TestNewGitWorktree_SubdirectoryCleanName(t *testing.T) {
+	sandboxHome(t)
+
+	repoRoot := createGitRepo(t)
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	cfg.WorktreeRoot = config.WorktreeRootSubdirectory
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, branchName, err := NewGitWorktree(repoRoot, "my-feature")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test/my-feature", branchName)
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(configDir, "worktrees", "test", "my-feature"), gw.GetWorktreePath())
 }
 
 func TestNewGitWorktree_CollisionSuffix(t *testing.T) {


### PR DESCRIPTION
## Summary
- restore the global `worktree_root` config key with JSON/TOML tags, default `sibling`, and validation for `subdirectory | sibling`
- preserve `worktree_root` during legacy `config.json` -> `config.toml` conversion and wire new worktree creation back to the configured placement mode
- expose/document `worktree_root` through `af config get/list/set`, config docs, README, and generated CLI reference

## Migration Audit
Audited the global legacy `config.json` reader, the TOML `Config` schema, and the separate `RepoConfig` legacy per-repo struct.

Still-valid global fields now preserved by the JSON->TOML migration: `default_program`, `program_overrides`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `root_agents`, `limit_patterns`, `limit_auto_resume`, `limit_retry_interval`.

Explicit non-migration: `keys` remains TOML-only by existing design and already gets a specific warning when present in `config.json`; it is not silently dropped. `RepoConfig` fields (`post_worktree_commands`, `remote_hooks`) are separate legacy per-repo JSON state and are not part of the global `config.json` -> `config.toml` migration.

## Tests
- `golangci-lint v1.64.8 --fast`: blocked before linting because that tool build reports Go 1.23 while this module targets Go 1.24.2
- `golangci-lint v2.12.2 run --fast-only --max-issues-per-linter=0 --max-same-issues=0`: 0 issues
- `gofmt -l .`: pass
- `go build ./...`: pass
- `make test-container`: pass
- `make lint-file-length`: pass
- `make docs`: pass

Closes #1283

— Captain Claude
