### PR TITLE
fix(tmux): avoid wrapped prompt prefix redraw

### DIFF
--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -16,53 +16,29 @@ import (
 // assume serialization.
 var pasteBufferSeq atomic.Uint64
 
-// SendKeysCommand sends text to the tmux pane using the `tmux send-keys` command
-// instead of writing to the PTY. This is more reliable for headless/scheduled runs
-// where the PTY connection may not persist. Text is sent literally (with -l flag)
-// followed by a pause to let terminal control sequences drain, then Enter to submit.
+// SendKeysCommand sends text to the tmux pane using tmux commands instead of
+// writing to the PTY. This is more reliable for headless/scheduled runs where
+// the PTY connection may not persist. Text is loaded into a tmux paste buffer,
+// pasted into the pane, followed by a pause to let terminal control sequences
+// drain, then Enter to submit.
 //
-// Codex is the exception: its composer runs paste-burst detection, so a large
-// run of characters delivered via `send-keys -l` is treated as an in-progress
-// paste and a following Enter is absorbed into it as a newline rather than
-// submitting. The prompt lands in the input box but never sends until a human
-// presses Enter (#1254). Codex therefore takes the bracketed-paste path, which
-// gives it an explicit end-of-paste marker so the trailing Enter is
-// unambiguously a submit. Submit handling is keyed off the agent actually
-// running in the pane (DetectAgentFromCommand), mirroring HasUpdated's
-// per-agent prompt heuristics, so a program_overrides redirect can't
-// misclassify the pane.
+// Most panes receive a plain paste. Codex is the exception: its composer runs
+// paste-burst detection, so it needs explicit bracketed-paste boundaries before
+// the following Enter is unambiguously a submit (#1254/#1256). Submit handling
+// is keyed off the agent actually running in the pane (DetectAgentFromCommand),
+// mirroring HasUpdated's per-agent prompt heuristics, so a program_overrides
+// redirect can't misclassify the pane.
 func (t *TmuxSession) SendKeysCommand(text string) error {
-	if DetectAgentFromCommand(t.programCmd()) == ProgramCodex {
-		return t.sendKeysBracketedPaste(text)
-	}
-
-	// Send text literally to avoid key name interpretation. `=` forces an
-	// exact session match so input is never sent to a prefix-matched sibling
-	// session if the agent session has died (#1006).
-	textCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "-l", text)
-	if err := t.cmdExec.Run(textCmd); err != nil {
-		return fmt.Errorf("error sending text via send-keys: %w", err)
-	}
-
-	// Wait for terminal control sequences (e.g. OSC color responses) to drain
-	// before sending Enter, otherwise they can corrupt the input
-	time.Sleep(500 * time.Millisecond)
-
-	// Send Enter separately to submit
-	enterCmd := exec.Command("tmux", "send-keys", "-t", exactTarget(t.sanitizedName), "Enter")
-	return t.cmdExec.Run(enterCmd)
+	return t.sendKeysPasteBuffer(text, DetectAgentFromCommand(t.programCmd()) == ProgramCodex)
 }
 
-// sendKeysBracketedPaste delivers text to the pane as a bracketed paste (`tmux
-// load-buffer` + `paste-buffer -p`) and then sends Enter to submit. tmux's `-p`
-// only wraps the buffer in bracketed-paste control codes when the running
-// application has actually requested bracketed-paste mode, so this is safe even
-// mid-dialog (it degrades to a plain paste). The end-of-paste marker lets codex
-// finalize its input buffer immediately, so the following Enter submits instead
-// of being swallowed by paste-burst detection (#1254). Text is streamed via
+// sendKeysPasteBuffer delivers text to the pane through a tmux paste buffer
+// (`load-buffer` + `paste-buffer`) and then sends Enter to submit. This avoids
+// the literal `send-keys -l` text path whose per-character delivery can leave a
+// duplicated wrapped prefix in bash/readline panes (#1292). Text is streamed via
 // stdin rather than an argv argument so arbitrarily large prompts are not
 // bounded by ARG_MAX.
-func (t *TmuxSession) sendKeysBracketedPaste(text string) error {
+func (t *TmuxSession) sendKeysPasteBuffer(text string, bracketed bool) error {
 	// A per-call unique buffer name: two concurrent deliveries to the same
 	// session must not share a buffer, or one call's load-buffer could overwrite
 	// the other's content between its load and paste and corrupt the submit.
@@ -75,10 +51,21 @@ func (t *TmuxSession) sendKeysBracketedPaste(text string) error {
 		return fmt.Errorf("error loading paste buffer: %w", err)
 	}
 
-	// `-p` inserts bracketed-paste markers (when the app requested the mode),
 	// `-d` deletes the buffer after pasting, `=` forces an exact session match
 	// so input never reaches a prefix-matched sibling session (#1006).
-	pasteCmd := exec.Command("tmux", "paste-buffer", "-d", "-p", "-b", buf, "-t", exactTarget(t.sanitizedName))
+	//
+	// Codex additionally needs `-p`: tmux inserts bracketed-paste markers (when
+	// the app requested the mode), giving codex an end-of-paste marker so the
+	// following Enter submits instead of being swallowed by paste-burst
+	// detection (#1254/#1256). Other panes intentionally use a plain paste to
+	// preserve their pre-existing raw-input newline behavior while still
+	// avoiding the wrapped-prefix redraw issue (#1292).
+	args := []string{"paste-buffer", "-d"}
+	if bracketed {
+		args = append(args, "-p")
+	}
+	args = append(args, "-b", buf, "-t", exactTarget(t.sanitizedName))
+	pasteCmd := exec.Command("tmux", args...)
 	if err := t.cmdExec.Run(pasteCmd); err != nil {
 		return fmt.Errorf("error pasting buffer: %w", err)
 	}

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -7,8 +7,11 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	cmdpkg "github.com/sachiniyer/agent-factory/cmd"
 	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,6 +61,15 @@ func bufferOf(args []string) string {
 	return ""
 }
 
+func hasArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
 // TestCodexSubmitUsesBracketedPaste is the #1254 regression: codex's composer
 // swallows the trailing Enter after a plain `send-keys -l` paste (paste-burst
 // detection), so the prompt lands but never submits. Codex must instead deliver
@@ -102,27 +114,43 @@ func TestCodexSubmitUsesBracketedPaste(t *testing.T) {
 	}
 }
 
-// TestNonCodexSubmitUsesLiteralSendKeys guards against regressing the agents
-// that already submit fine (claude/aider/gemini and unknown/override panes):
-// they keep the plain `send-keys -l` + Enter path and must not switch to
-// bracketed paste.
-func TestNonCodexSubmitUsesLiteralSendKeys(t *testing.T) {
+// TestNonCodexSubmitUsesPlainPasteBuffer guards against regressing the agents
+// that do not need bracketed-paste submit semantics (claude/aider/gemini and
+// unknown/override panes): they use tmux's plain paste-buffer path plus Enter.
+// This keeps codex's #1256 bracketed-paste behavior scoped to codex while
+// avoiding the literal `send-keys -l` wrapped-redraw issue seen in bash-backed
+// sessions (#1292).
+func TestNonCodexSubmitUsesPlainPasteBuffer(t *testing.T) {
 	for _, program := range []string{"claude", "aider", "gemini", "some-custom-shell"} {
 		t.Run(program, func(t *testing.T) {
-			cmds := recordTmuxCommands(t, program, "hello")
+			const prompt = "hello"
+			cmds := recordTmuxCommands(t, program, prompt)
 			joined := joinedArgs(cmds)
 
-			require.Len(t, cmds, 2, "literal path is send-keys -l then send-keys Enter; got %v", joined)
-			require.Contains(t, joined[0], "send-keys", "first command must be send-keys; got %v", joined)
-			require.Contains(t, joined[0], "-l", "non-codex must send text literally; got %v", joined)
-			require.Contains(t, joined[0], "hello", "literal text must be passed as an argv arg; got %v", joined)
-			require.Contains(t, joined[1], "Enter", "second command must submit with Enter; got %v", joined)
+			require.Len(t, cmds, 3, "plain paste path is load-buffer, paste-buffer, send-keys Enter; got %v", joined)
+			require.Contains(t, joined[0], "load-buffer", "first command must load the paste buffer; got %v", joined)
+			require.Equal(t, prompt, cmds[0].stdin, "paste text must be streamed on stdin")
+			require.Contains(t, joined[1], "paste-buffer", "second command must paste the buffer; got %v", joined)
+			require.Contains(t, joined[1], "-d", "paste must delete the buffer afterward (-d)")
+			require.False(t, hasArg(cmds[1].args, "-p"),
+				"non-codex panes must use plain paste, not bracketed paste; got %v", joined)
+			require.Contains(t, joined[2], "send-keys", "last command must send Enter; got %v", joined)
+			require.Contains(t, joined[2], "Enter", "last command must submit with Enter; got %v", joined)
 
 			for _, j := range joined {
-				require.NotContains(t, j, "paste-buffer",
-					"non-codex agents must not use the bracketed-paste path; got %v", joined)
-				require.NotContains(t, j, "load-buffer",
-					"non-codex agents must not use the bracketed-paste path; got %v", joined)
+				require.NotContains(t, j, "send-keys -t =af_proj: -l",
+					"non-codex must not use the literal send-keys path that redraws wrapped bash input (#1292); got %v", joined)
+			}
+
+			loadBuf, pasteBuf := bufferOf(cmds[0].args), bufferOf(cmds[1].args)
+			require.NotEmpty(t, loadBuf, "load-buffer must name a buffer; got %v", joined)
+			require.Equal(t, loadBuf, pasteBuf, "paste must read back the buffer the load wrote; got %v", joined)
+
+			for _, c := range cmds {
+				if tgt := targetOf(c.args); tgt != "" {
+					require.Equal(t, "=af_proj:", tgt,
+						"plain paste submit commands must target by exact match (#1006); got %q in %v", tgt, joined)
+				}
 			}
 		})
 	}
@@ -181,4 +209,50 @@ func TestCodexSubmitConcurrentDeliveriesUseDistinctBuffers(t *testing.T) {
 	// Every paste targeted a buffer that some load wrote, and no fixed name was
 	// shared across all calls.
 	require.Equal(t, unique, pasteBufs, "each paste must read back a per-call load buffer")
+}
+
+func TestBashWrappedSubmitDoesNotDuplicateCommandPrefix(t *testing.T) {
+	testguard.IsolateTmux(t)
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not available: %v", err)
+	}
+
+	session := newTmuxSession(
+		toTmuxName("wrap-submit", ""),
+		"bash --noprofile --norc -i",
+		MakePtyFactory(),
+		cmdpkg.MakeExecutor(),
+	)
+	require.NoError(t, session.Start(t.TempDir()))
+	t.Cleanup(func() {
+		require.NoError(t, session.Close())
+	})
+
+	require.NoError(t, session.SetDetachedSize(24, 10))
+	resizeCmd := exec.Command("tmux", "resize-window", "-t", exactTarget(session.sanitizedName), "-x", "24", "-y", "10")
+	require.NoError(t, session.cmdExec.Run(resizeCmd))
+
+	time.Sleep(100 * time.Millisecond)
+
+	const command = "printf '%s\\n' AF1292_DONE"
+	require.NoError(t, session.SendKeysCommand(command))
+
+	require.Eventually(t, func() bool {
+		content, err := captureRawPane(session)
+		return err == nil && strings.Contains(content, "\nAF1292_DONE\n")
+	}, 2*time.Second, 50*time.Millisecond, "wrapped bash command did not run")
+
+	content, err := captureRawPane(session)
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(content, "printf '%s"),
+		"wrapped command prefix must be captured once, not duplicated:\n%s", content)
+}
+
+func captureRawPane(session *TmuxSession) (string, error) {
+	cmd := exec.Command("tmux", "capture-pane", "-p", "-t", exactTarget(session.sanitizedName))
+	out, err := session.cmdExec.Output(cmd)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }


### PR DESCRIPTION
## Summary
- route non-codex prompt submits through tmux `load-buffer` + plain `paste-buffer` instead of literal `send-keys -l`
- keep codex on bracketed `paste-buffer -p` so the #1256 submit fix still gets an explicit paste boundary
- add coverage for non-codex plain paste delivery and a narrow bash-backed wrapped-command regression

## Root Cause
The non-codex `SendKeysCommand` path delivered prompt text with `tmux send-keys -l`, paused, then sent Enter as a second tmux command. In bash/readline panes at narrow widths, that leaves a wrapped in-progress command on screen long enough for readline/tmux redraw to preserve a stale prompt+command-prefix row before the final submitted line. The command executes once, but capture-pane can show the wrapped prefix twice. Moving text delivery to tmux paste-buffer avoids the per-character literal key redraw path; codex still uses bracketed paste for #1256.

## Verification
- focused container: `scripts/testbox.sh test ./session/tmux -run 'Test(CodexSubmitUsesBracketedPaste|NonCodexSubmitUsesPlainPasteBuffer|CodexSubmitConcurrentDeliveriesUseDistinctBuffers|BashWrappedSubmitDoesNotDuplicateCommandPrefix)'`
- manual patched play-test: bash-backed `af sessions send-prompt` at width 24 captured one wrapped `printf` command and one `AF1292_DONE` output
- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `scripts/lint-file-length.sh`
- `make test-container`

Closes #1292.

Do not merge; root verifies.

Signed-off-by: Captain Claude <noreply@anthropic.com>