### PR TITLE
fix(tui-driver): confirm pane sends with marker

### DIFF
--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -148,7 +148,7 @@ compose across `docker exec` invocations.
 | `af_hide_pane` | `x` | focus back on tree (`n new`) |
 | `af_enter_interactive` | `Enter` | interactive menu (`ctrl+] nav mode`) |
 | `af_exit_interactive` | `Ctrl-]` | interactive menu gone |
-| `af_send_to_pane <text>` | text,`Enter` | input echoes in the pane (then wait for output yourself) |
+| `af_send_to_pane <text>` | marker+text,`Enter` | short delivery marker echoes in the pane (then wait for output yourself) |
 | `af_attach` | `o` | TUI chrome gone (full-screen) |
 | `af_detach` | `Ctrl-W` | TUI chrome back **and** the attach client is reaped (guards #1157) |
 | `af_new_tab` | `t` | tab-child count rises |

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -66,6 +66,33 @@ _expect_resize_rejected() {
     return 0
 }
 
+# _expect_wrapped_send_no_timeout — regression proof for #1287. At a narrow
+# width the echoed command wraps inside the framed pane; af_send_to_pane must
+# still confirm it without burning the old 8s false timeout.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_expect_wrapped_send_no_timeout() {
+    local saved_cols="$AF_DRIVER_COLS" saved_rows="$AF_DRIVER_ROWS"
+    local started elapsed rc=0
+    # shellcheck disable=SC2016
+    local long_cmd='printf "%s\n" "wrap-check-abcdefghijklmnopqrstuvwxyz-0123456789-abcdefghijklmnopqrstuvwxyz-0123456789"; echo WRAP_SEND_DONE_$((1200+87))'
+
+    af_resize 60 18 || return 1
+    af_wait_for 'nav mode' 10 'interactive mode after narrow resize' || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        started="$(_af_now)"
+        af_send_to_pane "$long_cmd" || rc=$?
+        elapsed=$(( $(_af_now) - started ))
+        if [ "$elapsed" -ge 7 ]; then
+            _af_log "wrapped command echo confirmation took ${elapsed}s; likely hit the old false timeout"
+            rc=1
+        fi
+        af_wait_for 'WRAP_SEND_DONE_1287([^0-9]|$)' 10 'wrapped command output' || rc=$?
+    fi
+
+    af_resize "$saved_cols" "$saved_rows" || return 1
+    return "$rc"
+}
+
 printf '=== tui-driver self-test (#1161) ===\n'
 printf 'session=%s size=%sx%s home=%s\n' \
     "$AF_DRIVER_SESSION" "$AF_DRIVER_COLS" "$AF_DRIVER_ROWS" "$AGENT_FACTORY_HOME"
@@ -104,6 +131,7 @@ step "assert beta is selected"                              af_expect_selected b
 
 step "open beta's tab as a pane"                            af_open_pane
 step "enter interactive mode"                               af_enter_interactive
+step "send a wrapped command without echo false-timeout"     _expect_wrapped_send_no_timeout
 # The command COMPUTES its marker (arithmetic expansion), so the sentinel we
 # assert on — SELFTEST_42 — appears ONLY in the command's output, never in the
 # echoed input line (which shows the literal $((6*7))). A shell that echoed

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -120,6 +120,69 @@ af_wait_gone() {
     done
 }
 
+# _af_strip_screen_frame — remove the TUI frame columns from captured rows so
+# a terminal line wrapped inside a framed pane can be joined back together.
+_af_strip_screen_frame() {
+    sed -E 's/\r//g;
+            s/^[^│║┃┆┇┊┋]*[│║┃┆┇┊┋]//;
+            s/[│║┃┆┇┊┋][^│║┃┆┇┊┋]*$//;
+            s/^[[:space:]│║┃┆┇┊┋╭╮╰╯┌┐└┘╔╗╚╝╠╣╦╩╬─═]+//;
+            s/[[:space:]│║┃┆┇┊┋╭╮╰╯┌┐└┘╔╗╚╝╠╣╦╩╬─═]+$//'
+}
+
+_af_join_lines_tight() {
+    tr -d '\n'
+}
+
+_af_join_lines_spaced() {
+    awk 'NR > 1 { printf " " } { printf "%s", $0 }'
+}
+
+_af_squash_ws() {
+    tr '\n\r\t' '   ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//'
+}
+
+# _af_wait_for_pane_echo <literal> [timeout_s] [label] — wait for pane input
+# echo without assuming the marker remains on one captured row. The embedded
+# pane is framed by the TUI, so normalize both "wrap inside a word" and "wrap
+# at whitespace" cases before falling back to a whitespace-squashed comparison.
+_af_wait_for_pane_echo() {
+    local text="$1" timeout="${2:-8}" label="${3:-pane echo}" screen
+    local tight spaced spaced_ws text_ws
+    local deadline; deadline=$(( $(_af_now) + timeout ))
+    text_ws="$(printf '%s' "$text" | _af_squash_ws)"
+    while :; do
+        screen="$(af_capture)"
+        if printf '%s\n' "$screen" | grep -Fq -- "$text"; then
+            return 0
+        fi
+
+        tight="$(printf '%s\n' "$screen" | _af_strip_screen_frame | _af_join_lines_tight)"
+        if printf '%s' "$tight" | grep -Fq -- "$text"; then
+            return 0
+        fi
+
+        spaced="$(printf '%s\n' "$screen" | _af_strip_screen_frame | _af_join_lines_spaced)"
+        if printf '%s' "$spaced" | grep -Fq -- "$text"; then
+            return 0
+        fi
+
+        spaced_ws="$(printf '%s' "$spaced" | _af_squash_ws)"
+        if [ -n "$text_ws" ] && printf '%s' "$spaced_ws" | grep -Fq -- "$text_ws"; then
+            return 0
+        fi
+
+        if [ "$(_af_now)" -ge "$deadline" ]; then
+            _af_log "TIMEOUT ${timeout}s waiting for: $label"
+            _af_log "----- last screen -----"
+            printf '%s\n' "$screen" >&2
+            _af_log "-----------------------"
+            return 1
+        fi
+        sleep "$AF_DRIVER_POLL"
+    done
+}
+
 # af_ensure_nav — force a known focus state. Ctrl-] exits interactive mode (a
 # no-op in nav mode). This one primitive fixes the #1156 class: after it, keys
 # are guaranteed to reach the host, not a live pane as literal text.
@@ -354,14 +417,17 @@ af_exit_interactive() {
 }
 
 # af_send_to_pane <text> — type <text> + Enter into the pane. Precondition:
-# interactive mode is active (af_enter_interactive). Best-effort syncs on the
-# input echoing back; the CALLER should af_wait_for the command's output.
+# interactive mode is active (af_enter_interactive). Best-effort syncs on a
+# short no-op delivery marker, not the full command text, so confirmation stays
+# wrap-tolerant while the caller's command remains the final command executed.
+# The CALLER should af_wait_for the command's output.
 af_send_to_pane() {
-    local text="$1"
-    af_send_literal "$text"
+    local text="$1" marker
+    printf -v marker 'AF%04X%04X' "$RANDOM" "$RANDOM"
+    af_send_literal ": \"$marker\"; $text"
     af_send Enter
-    af_wait_for "$(_af_regex_escape "$text")" 8 "pane echoed '$text'" \
-        || _af_log "note: '$text' not seen echoed (may have scrolled off)"
+    _af_wait_for_pane_echo "$marker" 8 "pane echoed delivery marker for '$text'" \
+        || _af_log "note: delivery marker for '$text' not seen echoed (may have scrolled off)"
 }
 
 # af_attach — attach the selected instance full-screen (`o`). Precondition: an
@@ -373,6 +439,9 @@ af_attach() {
     _af_client_count > "$AF_DRIVER_STATE_DIR/attach_baseline"
     af_send o
     af_wait_gone 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'full-screen attach' || return 1
+    # Attach intentionally discards terminal probe bytes for ~50ms; let that
+    # window pass so an immediate scripted af_detach is not swallowed.
+    sleep "$AF_DRIVER_POLL"
 }
 
 # af_detach — detach from a full-screen attach (Ctrl-W by default) and, the
@@ -380,6 +449,10 @@ af_attach() {
 # count returns to the pre-attach baseline). A leaked client fails here.
 af_detach() {
     af_send "$AF_DRIVER_DETACH_KEY"
+    sleep "$AF_DRIVER_POLL"
+    if ! af_capture | grep -q 'Agent Factory'; then
+        af_send "$AF_DRIVER_DETACH_KEY"
+    fi
     af_wait_for 'Agent Factory' "$AF_DRIVER_TIMEOUT" 'detached back to TUI' || return 1
     local baseline; baseline="$(cat "$AF_DRIVER_STATE_DIR/attach_baseline" 2>/dev/null || echo 0)"
     local deadline; deadline=$(( $(_af_now) + AF_DRIVER_TIMEOUT ))


### PR DESCRIPTION
## Summary
- make `af_send_to_pane` confirm delivery with a short no-op marker instead of matching the full command text
- keep marker matching tolerant of pane frame/wrap boundaries
- add a narrow-width self-test case proving a wrapped command returns without the old false timeout
- make scripted full-screen detach tolerate the attach path's initial stdin discard window

## Tests
- `shellcheck scripts/tui-driver.sh scripts/tui-driver-selftest.sh`
- `make tui-driver-selftest`

Closes #1287

— Captain Claude