### PR TITLE
fix(tui): reconcile pane headers with tree selection

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -503,21 +503,6 @@ func (m *home) syncFocus() {
 	m.menu.SetFocusRegion(active)
 }
 
-// focusedOpenPane returns the open pane the focus ring points at, or nil when
-// focus is on the tree/automations (or the pane vanished).
-func (m *home) focusedOpenPane() *store.OpenPane {
-	active := m.ring.Active()
-	if !layout.IsPaneRegion(active) {
-		return nil
-	}
-	for _, p := range m.visiblePanes {
-		if layout.PaneRegion(p.ID()) == active {
-			return p
-		}
-	}
-	return nil
-}
-
 // focusRegion moves focus directly to the given region and re-solves the
 // layout so ring visibility and pane rects stay coherent.
 func (m *home) focusRegion(region string) {
@@ -1814,6 +1799,7 @@ func (m *home) View() string {
 			cols = append(cols, m.renderDivider(i-1))
 		}
 		if w := m.paneWindows[p.ID()]; w != nil {
+			w.SetSelectionHint(m.paneSelectionHint(p))
 			cols = append(cols, w.View())
 		}
 	}

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/store"
+	"github.com/sachiniyer/agent-factory/ui/tree"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -35,6 +36,49 @@ func (m *home) openPaneWindow(instance *session.Instance, tab int) *store.OpenPa
 	w.SetZoneRegistry(m.zones)
 	m.paneWindows[p.ID()] = w
 	return p
+}
+
+// focusedOpenPane returns the open pane the focus ring points at, or nil when
+// focus is on the tree/automations (or the pane vanished).
+func (m *home) focusedOpenPane() *store.OpenPane {
+	active := m.ring.Active()
+	if !layout.IsPaneRegion(active) {
+		return nil
+	}
+	for _, p := range m.visiblePanes {
+		if layout.PaneRegion(p.ID()) == active {
+			return p
+		}
+	}
+	return nil
+}
+
+// paneSelectionHint names the current tree/sidebar selection when a visible
+// pane is bound elsewhere. Panes are explicit workspace bindings, not
+// selection-driven previews; showing the selected title in the header makes
+// that divergence visible instead of letting the tree highlight and pane
+// content appear to disagree (#1289).
+func (m *home) paneSelectionHint(p *store.OpenPane) string {
+	if p == nil {
+		return ""
+	}
+	selected := m.store.GetSelectedInstance()
+	if selected == nil {
+		return ""
+	}
+	if p.Instance() == selected && p.Tab() == m.store.ActiveTab() {
+		return ""
+	}
+	tabLabel := ""
+	labels := tree.TabLabels(selected)
+	activeTab := m.store.ActiveTab()
+	if activeTab >= 0 && activeTab < len(labels) {
+		tabLabel = labels[activeTab]
+	}
+	if tabLabel == "" {
+		return selected.Title
+	}
+	return fmt.Sprintf("%s · %s", selected.Title, tabLabel)
 }
 
 // handleOpenPane dispatches the `s` key: open the tree selection's (instance,

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -144,6 +144,29 @@ func TestPane_OpenAlreadyOpenFocuses(t *testing.T) {
 	assert.Equal(t, layout.PaneRegion(p1.ID()), h.ring.Active(), "s focuses the existing pane")
 }
 
+// TestPane_HeaderAnnotatesSelectionDivergence is the #1289 session-level
+// reconciliation guard: open panes are explicit bindings, so selecting beta
+// must not silently make an alpha pane look like the selected workspace. The
+// header names both facts: what the pane is showing and which row is selected.
+func TestPane_HeaderAnnotatesSelectionDivergence(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Same(t, alpha, paneA.Instance())
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.Same(t, beta, h.store.GetSelectedInstance())
+	require.Same(t, alpha, paneA.Instance(), "selection must not retarget explicit panes")
+
+	view := h.View()
+	assert.Contains(t, view, "alpha · Preview · selected: beta · Preview",
+		"the visible pane header must reconcile selected row vs shown content")
+}
+
 // TestPane_TabDimension: opening from a tree TAB row binds that tab, distinct
 // (instance, tab) pairs get distinct panes, and later selection tab jumps
 // don't touch open panes.
@@ -211,6 +234,32 @@ func TestPane_NumberJumpTargetsFocusedPaneNotSidebarSelection(t *testing.T) {
 	assert.Equal(t, 1, h.store.ActiveTab(), "tree-focus jump must still target the sidebar selection")
 	assert.Equal(t, 1, paneA.Tab(), "tree-focus jump must not mutate pane A further")
 	assert.Equal(t, 0, paneB.Tab(), "tree-focus jump only changes the selection's active tab")
+}
+
+// TestPane_NumberJumpAnnotatesSelectedTabDivergence covers the #1289 tab-level
+// mismatch while preserving #1255: when a pane-focused digit jump changes the
+// visible pane tab, the sidebar-selected active tab is not retargeted, so the
+// pane header must make that divergence explicit.
+func TestPane_NumberJumpAnnotatesSelectedTabDivergence(t *testing.T) {
+	h := paneTestHome(t)
+	beta := h.store.GetInstanceByTitle("beta")
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	pressKey(t, h, "s")
+	paneB := h.store.OpenPanes()[0]
+	require.Same(t, beta, paneB.Instance())
+	require.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active())
+	require.Equal(t, 0, h.store.ActiveTab())
+
+	_, _ = h.handleTabJump(2)
+
+	assert.Equal(t, 1, paneB.Tab(), "focused beta pane jumps to tab 2")
+	assert.Equal(t, 0, h.store.ActiveTab(), "pane-focused jump must not retarget the sidebar selection")
+	view := h.View()
+	assert.Contains(t, view, "beta · Terminal · selected: beta · Preview",
+		"pane header shows the jumped tab and the still-selected tree tab")
+	assert.Contains(t, view, "1 Preview *", "sidebar active-tab marker stays on the selected tab")
 }
 
 // TestPane_FocusRingCyclesNPanes: with three panes open, Tab cycles

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -99,6 +99,13 @@ type TabbedWindow struct {
 	// capture — the capture polling for this pane is skipped by the root
 	// model for the same duration. Event-loop only.
 	live LiveView
+
+	// selectionHint names the current tree/sidebar selection when it differs
+	// from this pane's explicit binding. Open panes are intentionally not
+	// selection-driven, so the header makes that divergence visible instead of
+	// leaving the selected row and displayed content to appear contradictory
+	// (#1289).
+	selectionHint string
 }
 
 // LiveView is a live embedded-terminal render source (#1089): the termpane
@@ -299,6 +306,12 @@ func (w *TabbedWindow) SetRegion(region string) {
 	w.region = region
 }
 
+// SetSelectionHint annotates the pane header when the tree selection differs
+// from the pane's explicit binding. Empty clears the annotation.
+func (w *TabbedWindow) SetSelectionHint(title string) {
+	w.selectionHint = title
+}
+
 // registerZones records this frame's hit-test rects: the whole pane as the
 // body (click focuses; click focused interacts; wheel scrolls), the one-line
 // `title · tab` header inside the frame on top of it, and — exactly while the
@@ -404,6 +417,9 @@ func (w *TabbedWindow) renderHeader(width int) string {
 			label = labels[idx]
 		}
 		text = fmt.Sprintf(" %s · %s ", inst.Title, label)
+		if w.selectionHint != "" {
+			text = fmt.Sprintf(" %s · %s · selected: %s ", inst.Title, label, w.selectionHint)
+		}
 	} else {
 		text = " no session selected "
 	}


### PR DESCRIPTION
## Summary
- Keep the explicit open-pane binding model from #1255: pane-focused digit jumps do not retarget the sidebar selection.
- Annotate pane headers when the visible pane binding differs from the tree/sidebar selection, including tab-level divergence.
- Move `focusedOpenPane` into the pane helper file while adding the selection-hint helper, keeping `app.go` under its #1145 grandfathered ceiling.

## Verify First
- Verified on `origin/master` at `fff4b68`: an alpha pane could remain visible while beta was selected in the sidebar, reproducing the session/content mismatch from #1289.
- Also captured the tab-level mismatch path during pane-focused number jumps before the fix.

## Root Cause
Open workspace panes are explicit `(instance, tab)` bindings, while the sidebar tree has its own sticky selected instance and active tab. That separation is intentional after #1236/#1255, but the pane header rendered only the pane binding, so a selected row or selected tab elsewhere looked like a silent mismatch instead of a visible focus/selection divergence.

## Verification
- `gofmt`
- `go build ./...`

Root requested that all container-based gates stop after an infrastructure/data-loss incident, so I did not run `make test-container`, playtest containers, or any further containerized tests after that instruction. Root will handle testing/verification.

Closes #1289

Signed-off-by: Captain Claude <captain-claude@sachiniyer.com>