### PR TITLE
refactor(session): archive teardown mode — fold MoveWorktree into the core (#1195 Phase 2b)

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -98,9 +98,11 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	// the fence can never be confused with a TUI optimistic kill (#1187).
 	instance.SetInFlightOp(session.OpArchiving)
 
-	instance.ArchiveTeardown()
-
-	if err := instance.MoveArchivedWorktree(dest); err != nil {
+	// Tear down tmux and relocate the worktree in one call: the move is folded
+	// into the teardown core immediately after the pane-exit wait (#1195 Ph2b),
+	// so no live pane is cwd'd in the worktree during the move (previously a
+	// separate MoveArchivedWorktree step relying on duplicated ordering prose).
+	if err := instance.ArchiveTeardown(dest); err != nil {
 		// The worktree is still at a valid location (the git layer guarantees
 		// worktreePath points at the actual bytes even on a repair failure).
 		// Mark Lost — started is still true and the agent tmux binding was kept —

--- a/daemon/create_tab_archive_test.go
+++ b/daemon/create_tab_archive_test.go
@@ -160,6 +160,39 @@ func TestCreateTab_SerializedWithInFlightArchiveDoesNotOrphan(t *testing.T) {
 	assert.False(t, isAlive(agentName+"__btop"), "no process tmux session may be spawned during/after the archive move")
 }
 
+// TestArchiveSession_ModeBTearsDownExtraTabsNoOrphan pins the Phase 2b archive
+// mode (teardownArchive) structurally: archiving a session that has a live
+// shell/process tab must tear that tab's tmux DOWN and reduce the instance to
+// the agent tab alone (#1028) — leaving no orphaned session behind — with the
+// worktree relocated in the same folded teardown step (#1195 Ph2b). Together
+// with the OpArchiving fence over the teardown+move window (exercised by
+// TestCreateTab_SerializedWithInFlightArchiveDoesNotOrphan), this closes the
+// archive-orphan gap (audit #2/#5) by construction rather than by convention.
+func TestArchiveSession_ModeBTearsDownExtraTabsNoOrphan(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	const title, agentName = "worker", "af_worker_agent"
+	inst, srcPath, isAlive := registerArchivableWithTmux(t, manager, repoID, repoPath, title, agentName)
+
+	// Give the session a second (process) tab BEFORE archiving, so the archive
+	// teardown has an extra live tmux session it must not orphan into the worktree
+	// it is about to move.
+	_, err := manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Command: "btop"})
+	require.NoError(t, err, "a process tab must spawn on a live session")
+	require.Equal(t, 2, inst.TabCount(), "the session now has agent + process tabs")
+	require.True(t, isAlive(agentName+"__btop"), "the process tab's tmux session is live before archive")
+
+	_, err = manager.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
+	require.NoError(t, err)
+
+	// Mode B: the extra tab is torn down and dropped, only the agent name-holder
+	// remains, and the worktree has been relocated — no orphan left behind.
+	assert.Equal(t, 1, inst.TabCount(), "archive reduces the instance to the agent tab alone (#1028)")
+	assert.False(t, isAlive(agentName+"__btop"), "the process tab's tmux must be killed, not orphaned into the moved-away worktree")
+	assert.Equal(t, session.LiveArchived, inst.GetLiveness(), "a successful archive marks the session Archived")
+	assert.Equal(t, session.OpNone, inst.GetInFlightOp(), "the OpArchiving fence is cleared on success")
+	assert.False(t, exists(srcPath), "the worktree was moved out of its original path")
+}
+
 // TestCreateTab_ShellRejectedAfterArchive is the Shell=true (TUI `t`) counterpart
 // of TestCreateTab_RejectedAfterArchive: the shell-tab path is guarded too.
 func TestCreateTab_ShellRejectedAfterArchive(t *testing.T) {

--- a/session/instance.go
+++ b/session/instance.go
@@ -1003,69 +1003,28 @@ func (i *Instance) Respawn() error {
 	return i.backend.Respawn(i)
 }
 
-// ArchiveTeardown tears down every tab's tmux session for an archive (#1028) —
-// the tmux half of Kill, but it PRESERVES the worktree and the instance record.
-// It is deliberately best-effort (a stuck tmux only logs, mirroring Kill) and:
+// ArchiveTeardown tears down every tab's tmux session for an archive AND
+// relocates the worktree to dest in one operation (#1028) — the tmux half of
+// Kill, but it PRESERVES the record and MOVES the worktree instead of deleting
+// it. It routes through the shared teardownTabs core in the archive mode, so the
+// #802 "wait for every pane to exit before touching the worktree" ordering is
+// shared code with Kill rather than the duplicated prose it was when the move
+// lived in a separate daemon step (#1195 Phase 2b). It is deliberately
+// best-effort for tmux (a stuck session only logs, mirroring Kill) and:
 //   - keeps the AGENT tab's tmux binding (its session name) so a failed archive
 //     can re-spawn it in place via the Lost-restore loop;
 //   - drops the shell/process tabs entirely — only the agent session is brought
 //     back on un-archive (Sachin's #1028 requirement);
 //   - leaves gitWorktree and started untouched, so the daemon caller controls
 //     the final state (started=false + Archived on success; Lost on a failed
-//     move, where started stays true so the loop re-spawns the agent).
+//     move — returned here — where started stays true so the loop re-spawns the
+//     agent).
 //
-// Local instances only — remote sessions have no local tmux/worktree and the
-// daemon rejects archiving them before reaching here.
-func (i *Instance) ArchiveTeardown() {
-	i.mu.Lock()
-	type tabSession struct {
-		name string
-		ts   *tmux.TmuxSession
-	}
-	sessions := make([]tabSession, 0, len(i.Tabs))
-	var agentTab *Tab
-	for idx, tab := range i.Tabs {
-		if idx == 0 {
-			agentTab = tab
-		}
-		if tab.tmux != nil {
-			sessions = append(sessions, tabSession{name: tab.Name, ts: tab.tmux})
-		}
-	}
-	title := i.Title
-	i.mu.Unlock()
-
-	// Tear each tab's tmux session down and wait for the pane to exit before the
-	// worktree is relocated, mirroring Kill's ordering (a process still flushing
-	// state races the move otherwise).
-	for _, s := range sessions {
-		if err := s.ts.CloseAndWaitForPaneExit(); err != nil {
-			log.WarningLog.Printf("archive %q: tmux teardown for tab %q failed: %v", title, s.name, err)
-		}
-	}
-
-	i.mu.Lock()
-	// Reduce to the agent tab only. Its tmux binding is kept (the server-side
-	// session is gone, but the name-holder lets a rollback Recover re-spawn it,
-	// and a successful archive persists it as an inert name-holder).
-	if agentTab != nil {
-		i.Tabs = []*Tab{agentTab}
-	}
-	i.mu.Unlock()
-}
-
-// MoveArchivedWorktree relocates this instance's worktree to dest (#1028),
-// delegating to the git relocation primitive. The caller holds the daemon
-// op-lock and has already run ArchiveTeardown, so no live tmux pane is cwd'd
-// into the worktree during the move.
-func (i *Instance) MoveArchivedWorktree(dest string) error {
-	i.mu.RLock()
-	gw := i.gitWorktree
-	i.mu.RUnlock()
-	if gw == nil {
-		return fmt.Errorf("cannot archive %q: instance has no worktree to relocate", i.Title)
-	}
-	return gw.MoveWorktree(dest)
+// Returns the worktree-move error (nil on success). Local instances only —
+// remote sessions have no local tmux/worktree and the daemon rejects archiving
+// them before reaching here.
+func (i *Instance) ArchiveTeardown(dest string) error {
+	return i.teardownTabs(teardownArchive{dest: dest})
 }
 
 // SetArchived flips the instance into the inert Archived state atomically:

--- a/session/teardown.go
+++ b/session/teardown.go
@@ -166,3 +166,47 @@ func (teardownReleasePTY) clearsStarted() bool { return true }
 func (teardownReleasePTY) finalize(_ *Instance, closed []closedTab, _ *git.GitWorktree) {
 	clearClosedTmuxRefs(closed)
 }
+
+// teardownArchive tears down every tab's tmux session and RELOCATES the worktree
+// to dest (#1028) — the tmux half of Kill, but it preserves the record and MOVES
+// the worktree instead of deleting it. Folding the move into the core (via
+// handleWorktree, right after closeTab's pane-exit wait) is the whole point of
+// Phase 2b: the #802 "wait for every pane to exit before touching the worktree"
+// ordering becomes shared code instead of the duplicated prose it was when the
+// move lived in a separate daemon step. It keeps the agent tab's tmux binding as
+// a name-holder (a failed move / un-archive re-spawns it) and drops the
+// shell/process tabs; started is left true (the OpArchiving fence, not the #990
+// started guard, owns the teardown window) so a failed move self-heals via the
+// Lost-restore loop.
+type teardownArchive struct{ dest string }
+
+func (teardownArchive) closeTab(ts *tmux.TmuxSession, title, tabName string) error {
+	// Wait for the pane to exit before handleWorktree relocates the worktree: a
+	// process still flushing state races the move otherwise (#802). Best-effort.
+	if err := ts.CloseAndWaitForPaneExit(); err != nil {
+		log.WarningLog.Printf("archive %q: tmux teardown for tab %q failed: %v", title, tabName, err)
+	}
+	return nil
+}
+
+func (m teardownArchive) handleWorktree(gw *git.GitWorktree, title string) error {
+	if gw == nil {
+		return fmt.Errorf("cannot archive %q: instance has no worktree to relocate", title)
+	}
+	return gw.MoveWorktree(m.dest)
+}
+
+func (teardownArchive) clearsStarted() bool { return false }
+
+func (teardownArchive) finalize(i *Instance, _ []closedTab, _ *git.GitWorktree) {
+	// Reduce to the agent tab (i.Tabs[0]) only. Its tmux binding is KEPT (the
+	// server-side session is gone, but the name-holder lets a rollback Recover
+	// re-spawn it, and a successful archive persists it as an inert name-holder);
+	// the shell/process tabs are dropped — only the agent returns on un-archive
+	// (#1028). gitWorktree is left in place (the move relocated it; it still
+	// points at valid bytes) and started is left as the fence set it, so the
+	// refs are deliberately NOT cleared here.
+	if len(i.Tabs) > 0 {
+		i.Tabs = []*Tab{i.Tabs[0]}
+	}
+}


### PR DESCRIPTION
**Phase 2b of the #1195 structural-health epic** (audit item #5, the behavior-visible step). Builds on merged Phase 2a (#1248). Root-approved design: https://github.com/sachiniyer/agent-factory/issues/1195#issuecomment-4888497895

## What

Migrates the **third and last** open-coded teardown loop (`Instance.ArchiveTeardown`) onto the shared `teardownTabs` core, adding the **archive mode** (`teardownArchive`).

The load-bearing change: the worktree **move is folded INTO the teardown core** (`teardownArchive.handleWorktree`), invoked immediately after `closeTab`'s pane-exit wait — so the **#802 "wait for every pane to exit before touching the worktree" ordering is now shared code with `Kill`** instead of the duplicated prose it was when the move lived in a separate daemon step (`ArchiveTeardown` in `session/` + `MoveArchivedWorktree` called from `daemon/archive.go`). A fix to Kill's #802 race now reaches archive by construction. **This closes divergence (B) from the audit** and is the one behavior-visible step of Phase 2.

## Changes

- `ArchiveTeardown()` → **`ArchiveTeardown(dest string) error`**: tears down tmux **and** relocates the worktree in one call, returning the move error for the daemon to roll back on. Rollback unchanged: mark `Lost`, keep `started=true` so the Lost-restore loop re-spawns the agent in place.
- **`MoveArchivedWorktree` deleted** — its body (nil-guard + `gw.MoveWorktree`) folds into `teardownArchive.handleWorktree` (same error string).
- Archive mode keeps `started=true` (the `OpArchiving` fence, not the #990 `started` guard, owns the teardown window), keeps the agent tab's tmux name-holder, drops the shell/process tabs (#1028) — **all preserved exactly**.
- `daemon/archive.go`: the two-step `ArchiveTeardown()` + `MoveArchivedWorktree()` collapses to one `ArchiveTeardown(dest)` call; rollback semantics identical.
- **New structural test** `TestArchiveSession_ModeBTearsDownExtraTabsNoOrphan`: archiving a session with a live process tab tears that tab's tmux down and reduces to the agent tab alone (no orphan), fence cleared — the guard for the archive-orphan class (audit #2/#5).

With this, **all 3 copied `tabSession` loops are collapsed onto one core.**

## Gates

**Run (host, non-container):** `go build ./...`, `gofmt -l .` empty, `go vet ./session/ ./daemon/` (compiles the new test), `deadcode -test ./...` clean (`MoveArchivedWorktree` removed, `teardownArchive` reachable), `golangci-lint --fast`, file-length lint.

⚠️ **Container gates deferred to root's verification.** Per the worktree-data-loss freeze, I did **not** run `make test-container` or the archive/restore/failed-move play-test. **This is the behavior-visible step** — needs the daemon/integration suite + a play-test of archive + restore + failed-move rollback before merge.

Refs #1195 (Phase 2c–2e + Phase 3 remain — do not close).

— Captain Claude