### PR TITLE
fix(tui): make help overlay scrollable

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -443,14 +443,7 @@ func (m *home) relayout() {
 	m.statusBar.SetRect(lay.StatusBar)
 	m.alarmBanner.SetRect(lay.Banner)
 
-	if m.textOverlay != nil {
-		m.textOverlay.SetWidth(int(float32(m.termWidth) * 0.6))
-		overlayHeight := m.termHeight - 2
-		if overlayHeight < 6 {
-			overlayHeight = m.termHeight
-		}
-		m.textOverlay.SetHeight(overlayHeight)
-	}
+	m.layoutTextOverlay()
 	if m.selectionOverlay != nil {
 		m.selectionOverlay.SetWidth(int(float32(m.termWidth) * 0.6))
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -445,6 +445,11 @@ func (m *home) relayout() {
 
 	if m.textOverlay != nil {
 		m.textOverlay.SetWidth(int(float32(m.termWidth) * 0.6))
+		overlayHeight := m.termHeight - 2
+		if overlayHeight < 6 {
+			overlayHeight = m.termHeight
+		}
+		m.textOverlay.SetHeight(overlayHeight)
 	}
 	if m.selectionOverlay != nil {
 		m.selectionOverlay.SetWidth(int(float32(m.termWidth) * 0.6))

--- a/app/help.go
+++ b/app/help.go
@@ -217,6 +217,22 @@ func (h helpTypeInteractive) mask() uint32 {
 	return 1 << 3
 }
 
+// layoutTextOverlay sizes help/intro text overlays to fit the terminal. The
+// overlay itself decides whether the content needs height-windowing, so short
+// one-shot help screens stay compact while the general help becomes scrollable
+// at 80x24 (#1290).
+func (m *home) layoutTextOverlay() {
+	if m.textOverlay == nil {
+		return
+	}
+	m.textOverlay.SetWidth(int(float32(m.termWidth) * 0.6))
+	overlayHeight := m.termHeight - 2
+	if overlayHeight < 6 {
+		overlayHeight = m.termHeight
+	}
+	m.textOverlay.SetHeight(overlayHeight)
+}
+
 var (
 	titleStyle  = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(ui.AccentColor)
 	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#36CFC9"))

--- a/app/help.go
+++ b/app/help.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -274,7 +275,16 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 
 // handleHelpState handles key events when in help state
 func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	// Any key press will close the help overlay
+	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftUp]) {
+		m.textOverlay.ScrollUp()
+		return m, nil
+	}
+	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftDown]) {
+		m.textOverlay.ScrollDown()
+		return m, nil
+	}
+
+	// Any non-scroll key press will close the help overlay.
 	dismissCmd, shouldClose := m.textOverlay.HandleKeyPress(msg)
 	if shouldClose {
 		m.state = stateDefault

--- a/ui/overlay/textOverlay.go
+++ b/ui/overlay/textOverlay.go
@@ -1,6 +1,8 @@
 package overlay
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -20,7 +22,9 @@ type TextOverlay struct {
 	// Content to display in the overlay
 	content string
 
-	width int
+	width  int
+	height int
+	scroll int
 }
 
 // NewTextOverlay creates a new text screen overlay with the given title and content
@@ -30,7 +34,8 @@ func NewTextOverlay(content string) *TextOverlay {
 		content:   content,
 		// Default width so PlaceOverlay can center/fade on narrow terminals.
 		// Callers should invoke SetWidth once the actual terminal size is known.
-		width: 60,
+		width:  60,
+		height: 20,
 	}
 }
 
@@ -55,11 +60,95 @@ func (t *TextOverlay) Render(opts ...WhitespaceOption) string {
 		BorderForeground(ui.AccentColor).
 		Padding(1, 2).
 		Width(t.width)
+	if inner := t.innerHeight(); inner > 0 && t.contentOverflows(inner) {
+		style = style.Height(inner)
+	}
 
 	// Apply the border style and return
-	return style.Render(t.content)
+	return style.Render(t.visibleContent())
 }
 
 func (t *TextOverlay) SetWidth(width int) {
 	t.width = width
+}
+
+func (t *TextOverlay) SetHeight(height int) {
+	t.height = height
+	t.clampScroll(t.innerHeight())
+}
+
+func (t *TextOverlay) ScrollUp() {
+	if t.scroll > 0 {
+		t.scroll--
+	}
+}
+
+func (t *TextOverlay) ScrollDown() {
+	t.scroll++
+	t.clampScroll(t.innerHeight())
+}
+
+func (t *TextOverlay) innerHeight() int {
+	if t.height <= 0 {
+		return 0
+	}
+	inner := t.height - 2 - 2 // border + vertical padding
+	if inner < 1 {
+		return 1
+	}
+	return inner
+}
+
+func (t *TextOverlay) clampScroll(inner int) {
+	if t.scroll < 0 {
+		t.scroll = 0
+	}
+	if inner <= 0 {
+		return
+	}
+	lines := strings.Split(t.content, "\n")
+	maxScroll := len(lines) - inner
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if t.scroll > maxScroll {
+		t.scroll = maxScroll
+	}
+}
+
+func (t *TextOverlay) contentOverflows(inner int) bool {
+	return inner > 0 && len(strings.Split(t.content, "\n")) > inner
+}
+
+func (t *TextOverlay) visibleContent() string {
+	inner := t.innerHeight()
+	if inner <= 0 {
+		return t.content
+	}
+	lines := strings.Split(t.content, "\n")
+	t.clampScroll(inner)
+	if len(lines) <= inner {
+		return t.content
+	}
+	end := t.scroll + inner
+	if end > len(lines) {
+		end = len(lines)
+	}
+	visible := append([]string(nil), lines[t.scroll:end]...)
+	if t.scroll > 0 && len(visible) > 0 {
+		visible[0] = textOverlayScrollMarker(t.width, "↑ more")
+	}
+	if end < len(lines) && len(visible) > 0 {
+		visible[len(visible)-1] = textOverlayScrollMarker(t.width, "↓ more")
+	}
+	return strings.Join(visible, "\n")
+}
+
+func textOverlayScrollMarker(width int, marker string) string {
+	if width < 1 {
+		width = 1
+	}
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#7F7A7A")).
+		Render(lipgloss.PlaceHorizontal(width, lipgloss.Center, marker))
 }

--- a/ui/overlay/textOverlay_test.go
+++ b/ui/overlay/textOverlay_test.go
@@ -76,3 +76,51 @@ func TestTextOverlayAllowsPlaceOverlayCentering(t *testing.T) {
 	assert.Equal(t, len(bgLines), strings.Count(out, "\n")+1,
 		"output should retain background height, confirming overlay was composited")
 }
+
+// TestTextOverlayHeightWindowsContent verifies that a tall text overlay renders
+// within its configured outer height instead of relying on PlaceOverlay to
+// handle an oversized foreground.
+func TestTextOverlayHeightWindowsContent(t *testing.T) {
+	overlay := NewTextOverlay(strings.Join([]string{
+		"title",
+		"line 1",
+		"line 2",
+		"line 3",
+		"line 4",
+		"line 5",
+		"line 6",
+		"line 7",
+	}, "\n"))
+	overlay.SetWidth(30)
+	overlay.SetHeight(6)
+
+	rendered := overlay.Render()
+	assert.Equal(t, 6, strings.Count(rendered, "\n")+1,
+		"rendered overlay should fit the requested outer height")
+	assert.Contains(t, rendered, "title", "initial viewport starts at the top")
+	assert.Contains(t, rendered, "↓ more", "overflow below is visible")
+}
+
+func TestTextOverlayScrollsContent(t *testing.T) {
+	overlay := NewTextOverlay(strings.Join([]string{
+		"title",
+		"line 1",
+		"line 2",
+		"line 3",
+		"line 4",
+		"line 5",
+		"line 6",
+		"line 7",
+	}, "\n"))
+	overlay.SetWidth(30)
+	overlay.SetHeight(6)
+
+	overlay.ScrollDown()
+	rendered := overlay.Render()
+	assert.NotContains(t, rendered, "title", "scrolling down moves the viewport")
+	assert.Contains(t, rendered, "↑ more", "overflow above is visible")
+
+	overlay.ScrollUp()
+	rendered = overlay.Render()
+	assert.Contains(t, rendered, "title", "scrolling up returns toward the top")
+}


### PR DESCRIPTION
## Summary
- Constrain text overlays to the terminal viewport height when content overflows, so the 80x24 help overlay starts at the title instead of rendering oversized/clipped.
- Add scroll state to `TextOverlay`, with visible `↑ more` / `↓ more` markers when content is outside the viewport.
- Route configured scroll-up/scroll-down keys in help state to overlay scrolling instead of dismissal; other keys still close the overlay.

## Verify First
- Verified on `origin/master` at `fff4b68`: at 80x24 the `?` help overlay opened clipped around lower sections and Shift+Down dismissed it instead of scrolling, reproducing #1290.

## Root Cause
The help screen used `TextOverlay`, which rendered its full content with only a width constraint and closed on every key. When the rendered foreground exceeded the 80x24 background, `PlaceOverlay` could not place it as a fitted modal, and scroll key events were treated as generic dismissal keys.

## Verification
- `gofmt`
- `go build ./...`

Root requested that all container-based gates stop after an infrastructure/data-loss incident, so I did not run `make test-container`, playtest containers, or any further containerized tests after that instruction. Root will handle testing/verification.

Closes #1290

Signed-off-by: Captain Claude <captain-claude@sachiniyer.com>