### PR TITLE
fix(tui-driver): fail closed before destructive sandbox cleanup (#1303)

### DIFF
--- a/scripts/container/playtest-entry.sh
+++ b/scripts/container/playtest-entry.sh
@@ -43,6 +43,11 @@ if [ ! -d "$MOCK" ]; then
     mkdir -p "$MOCK"
     cd "$MOCK"
     git init -q -b master
+    # Sentinel proving this is a disposable driver sandbox. tui-driver.sh's
+    # af_reset_sandbox refuses its destructive worktree/branch cleanup unless
+    # this marker is present, so the cleanup can never run against a real repo
+    # (#1303). Must be created before any instance worktrees exist.
+    : >.af-throwaway-sandbox
     # printf writes literal shell into the mock repo — the $VARs are meant to
     # stay unexpanded, so single quotes are correct here.
     # shellcheck disable=SC2016

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -194,6 +194,28 @@ af_focus_tree() {
 # touches the driver's own session and NEVER runs kill-server. Fails closed if
 # AGENT_FACTORY_HOME does not look like a sandbox path, so it can never wipe a
 # real ~/.agent-factory.
+# _af_is_throwaway_sandbox <dir> — POSITIVE proof a path is a disposable driver
+# sandbox before any destructive cleanup runs against it. Fails CLOSED: a real
+# dev checkout (any repo with a remote), or any path missing the scaffolding's
+# sentinel, is rejected. A weak `*/sandbox/*` substring guard once let this
+# cleanup delete real dev worktrees + every non-master branch (#1303); this hard
+# gate replaces it. All three conditions must hold.
+_af_is_throwaway_sandbox() {
+    local dir="$1"
+    [ -n "$dir" ] || return 1
+    # 1) The sandbox scaffolding writes this sentinel; a real checkout never has it.
+    [ -f "$dir/.af-throwaway-sandbox" ] || return 1
+    # 2) A throwaway mock repo has NO remotes; a real checkout has 'origin'.
+    if [ -d "$dir/.git" ] && [ -n "$(git -C "$dir" remote 2>/dev/null)" ]; then
+        return 1
+    fi
+    # 3) Belt-and-suspenders: still require a sandbox-shaped path.
+    case "$dir" in
+        */sandbox/*|*/sandbox|/tmp/*|*/af-driver*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 af_reset_sandbox() {
     case "$AGENT_FACTORY_HOME" in
         */sandbox/*|*/sandbox|/tmp/*|*/af-driver*) ;;
@@ -212,21 +234,24 @@ af_reset_sandbox() {
           "$AGENT_FACTORY_HOME/state.json" 2>/dev/null || true
     # Remove leftover instance worktrees + branches in the mock repo, else a
     # re-created instance of the same name collides on the existing branch.
-    # Scoped to a sandbox mock-repo path only.
-    case "$AF_DRIVER_REPO" in
-        */sandbox/*|/tmp/*)
-            rm -rf "${AF_DRIVER_REPO}"-* 2>/dev/null || true
-            if [ -d "$AF_DRIVER_REPO/.git" ]; then
-                git -C "$AF_DRIVER_REPO" worktree prune 2>/dev/null || true
-                local b
-                for b in $(git -C "$AF_DRIVER_REPO" for-each-ref \
-                    --format='%(refname:short)' refs/heads/ 2>/dev/null \
-                    | grep -vE '^(master|main)$' || true); do
-                    git -C "$AF_DRIVER_REPO" branch -D "$b" 2>/dev/null || true
-                done
-            fi
-            ;;
-    esac
+    # DESTRUCTIVE (rm -rf glob + `branch -D` every non-master ref): fail CLOSED,
+    # only ever against a PROVEN throwaway sandbox. The old `*/sandbox/*` guard
+    # honored an AF_DRIVER_REPO pointed at the real dev repo and deleted every
+    # sibling worktree + session branch (#1303).
+    if _af_is_throwaway_sandbox "$AF_DRIVER_REPO"; then
+        rm -rf "${AF_DRIVER_REPO}"-* 2>/dev/null || true
+        if [ -d "$AF_DRIVER_REPO/.git" ]; then
+            git -C "$AF_DRIVER_REPO" worktree prune 2>/dev/null || true
+            local b
+            for b in $(git -C "$AF_DRIVER_REPO" for-each-ref \
+                --format='%(refname:short)' refs/heads/ 2>/dev/null \
+                | grep -vE '^(master|main)$' || true); do
+                git -C "$AF_DRIVER_REPO" branch -D "$b" 2>/dev/null || true
+            done
+        fi
+    else
+        _af_log "af_reset_sandbox: SKIP worktree/branch cleanup — '$AF_DRIVER_REPO' is not a proven throwaway sandbox (needs a .af-throwaway-sandbox marker + no remote); refusing destructive rm/branch -D (#1303)"
+    fi
     sleep 0.5
 }
 


### PR DESCRIPTION
## Critical data-loss fix (#1303)

`scripts/tui-driver.sh` `af_reset_sandbox` ran `rm -rf "${AF_DRIVER_REPO}"-*` + `git branch -D` on **every non-master branch**, guarded only by a `case "$AF_DRIVER_REPO" in */sandbox/*|/tmp/*` path substring. When a session ran the driver with `AF_DRIVER_REPO` pointed at the real dev repo (`/home/siyer/Desktop/claude-squad`), that became `rm -rf /home/siyer/Desktop/claude-squad-*` (every session worktree) + `branch -D` of every session branch. **This destroyed 5 sessions today** (one, then four at once) — uncommitted work lost.

## Fix — fail closed
New `_af_is_throwaway_sandbox` gate; the destructive cleanup runs only if ALL hold:
1. **Sentinel present** — `$AF_DRIVER_REPO/.af-throwaway-sandbox`, written only by the sandbox scaffolding (`playtest-entry.sh`).
2. **No git remote** — a real checkout has `origin`; a throwaway mock repo has none.
3. **Sandbox-shaped path** — retained as belt-and-suspenders.

Otherwise it **skips** the cleanup with a logged reason. Verified in isolation: refuses the real repo *even with a forged sentinel* (remote check), accepts a real sandbox, fails closed with no sentinel. The containerized selftest's reset step passes.

Pairs with #1300 (Recover should rebuild a missing worktree). Part of #1303's remediation; the worktree-vanish **instrumentation** (catch any live worktree going missing) is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)