### PR TITLE
Define tui-state schema_version convention

### DIFF
--- a/config/schema_versions.go
+++ b/config/schema_versions.go
@@ -9,6 +9,10 @@ const (
 	RepoConfigSchemaVersion = LegacySchemaVersion
 	// StateSchemaVersion is v0 for the current help-screen state.json object.
 	StateSchemaVersion = LegacySchemaVersion
+	// TUIStateSchemaVersion starts at v1 because tui-state.json is greenfield
+	// (#1240) and must carry schema_version from its first release. There is no
+	// v0/bare-version migration for this store.
+	TUIStateSchemaVersion = 1
 	// InstancesSchemaVersion is v0 for the current array-root instances.json.
 	InstancesSchemaVersion = LegacySchemaVersion
 )

--- a/config/tui_state_schema.go
+++ b/config/tui_state_schema.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+const TUIStateFileName = "tui-state.json"
+
+// TUIStatePath returns the global, TUI-owned view-state file path. The TUI
+// state is client-side convenience state, separate from daemon-owned
+// instances.json.
+func TUIStatePath() (string, error) {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get config directory: %w", err)
+	}
+	return filepath.Join(configDir, TUIStateFileName), nil
+}
+
+// NewTUIStateSchemaMigrationPlan returns the schema framework plan that #1240's
+// greenfield tui-state.json loader should use. The empty migrator registry is
+// deliberate: missing schema_version is legacy v0, but this file has no legacy
+// on-disk shape, so bare {"version": 1} documents are rejected instead of
+// silently accepted.
+func NewTUIStateSchemaMigrationPlan(path string, validate SchemaValidator) SchemaMigrationPlan {
+	return SchemaMigrationPlan{
+		StoreName:      TUIStateFileName,
+		Path:           path,
+		CurrentVersion: TUIStateSchemaVersion,
+		DetectVersion:  DetectJSONSchemaVersion,
+		Migrators:      NewSchemaMigrationRegistry(),
+		Validate:       validate,
+		Perm:           0644,
+	}
+}

--- a/config/tui_state_schema_test.go
+++ b/config/tui_state_schema_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTUIStatePathUsesConfigDir(t *testing.T) {
+	tempHome := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", tempHome)
+
+	got, err := TUIStatePath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tempHome, TUIStateFileName), got)
+}
+
+func TestTUIStateSchemaPlanAcceptsCurrentSchemaVersion(t *testing.T) {
+	raw := []byte(`{"schema_version":1,"repos":{}}`)
+	got, result, err := MigrateSchemaBytes(raw, NewTUIStateSchemaMigrationPlan(TUIStateFileName, validateTUIStateTestEnvelope))
+	require.NoError(t, err)
+
+	assert.False(t, result.Migrated)
+	assert.Equal(t, TUIStateSchemaVersion, result.OriginalVersion)
+	assert.Equal(t, TUIStateSchemaVersion, result.FinalVersion)
+	assert.JSONEq(t, string(raw), string(got))
+}
+
+func TestTUIStateSchemaPlanRejectsBareVersionField(t *testing.T) {
+	_, result, err := MigrateSchemaBytes(
+		[]byte(`{"version":1,"repos":{}}`),
+		NewTUIStateSchemaMigrationPlan(TUIStateFileName, nil),
+	)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "no schema migrator registered for version 0 -> 1")
+	assert.Equal(t, LegacySchemaVersion, result.OriginalVersion)
+	assert.Equal(t, LegacySchemaVersion, result.FinalVersion)
+}
+
+func TestTUIStateSchemaPlanRefusesNewerVersion(t *testing.T) {
+	_, _, err := MigrateSchemaBytes(
+		[]byte(`{"schema_version":2,"repos":{}}`),
+		NewTUIStateSchemaMigrationPlan(TUIStateFileName, nil),
+	)
+	require.Error(t, err)
+
+	var newer *UnsupportedSchemaVersionError
+	require.True(t, errors.As(err, &newer))
+	assert.Equal(t, TUIStateFileName, newer.StoreName)
+	assert.Equal(t, 2, newer.FileVersion)
+	assert.Equal(t, TUIStateSchemaVersion, newer.SupportedVersion)
+}
+
+func validateTUIStateTestEnvelope(raw []byte) error {
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return err
+	}
+	if _, ok := obj["repos"].(map[string]any); !ok {
+		return fmt.Errorf("repos must be an object")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Add the greenfield `tui-state.json` file/path contract for #1240 without implementing the view-state store yet.
- Set `TUIStateSchemaVersion = 1` and expose `NewTUIStateSchemaMigrationPlan` using the #1282 schema framework.
- Deliberately provide no v0 migrator, so a bare `{"version": 1}` document is rejected and #1240 starts with `schema_version` from day one; newer schema versions still hit the shared refuse-newer path.

Refs #1046.
Refs #1240.

## Verification

- `gofmt -w .`
- `go build ./...`
- `make test-container`
- `golangci-lint run --fast`
- `scripts/lint-file-length.sh`
- `deadcode -test ./...`

Do not merge until root verifies. -- Captain Claude