### PR TITLE
First-run setup doctor and preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The installer places `af` in `~/.local/bin` by default. Override with
 Run `af upgrade` or rerun the script to update. Installed binaries auto-update
 on the stable channel unless you opt into preview builds in config.
 
+After install, run `af doctor --setup` to verify tmux, git, your configured
+agent command, git identity, config/state/log storage, and daemon health before
+creating your first session.
+
 Build from source with Go 1.24+:
 
 ```bash
@@ -61,6 +65,7 @@ Run `af` inside a git repository:
 
 ```bash
 cd your-project
+af doctor --setup
 af
 ```
 

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/preflight"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/git"
 
@@ -32,6 +33,7 @@ var (
 	deliverPromptViaDaemon   = daemon.DeliverPrompt
 	createTabViaDaemon       = daemon.CreateTab
 	closeTabViaDaemon        = daemon.CloseTab
+	preflightLocalSession    = preflight.LocalSessionPrereqs
 	// snapshotViaDaemon is the non-spawning read path for list/get/whoami
 	// (#1029 PR 2). It reflects the daemon's authoritative in-memory state when
 	// a daemon is already running, and returns daemon.ErrDaemonUnavailable
@@ -198,6 +200,9 @@ pointing at one).`,
 		} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program, ""); err != nil {
 			return jsonError(err)
 		}
+		if err := preflightLocalSession(&cfg.Config, program); err != nil {
+			return jsonError(err)
+		}
 
 		data, err := createSessionViaDaemon(daemon.CreateSessionRequest{
 			Title:    createNameFlag,
@@ -315,6 +320,9 @@ sessions fail, so scripts can inspect per-session results.`,
 			if program == "" {
 				program = cfg.DefaultProgram
 			} else if err := config.ValidateProgramEnum("--program flag", "--program flag", program, ""); err != nil {
+				return jsonError(err)
+			}
+			if err := preflightLocalSession(&cfg.Config, program); err != nil {
 				return jsonError(err)
 			}
 
@@ -766,7 +774,7 @@ path is printed on success.`,
 var sessionsAttachCmd = &cobra.Command{
 	Use:   "attach <title>",
 	Short: "Attach to a session's terminal",
-	Long:  "Attach to a running session's tmux terminal. Detach with the configured detach key (default: Ctrl-b d).",
+	Long:  "Attach to a running session's tmux terminal. Detach with the configured detach key (default: Ctrl-w).",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)

--- a/api/sessions_inplace_test.go
+++ b/api/sessions_inplace_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 )
@@ -36,11 +37,14 @@ func setSessionsCreateFlags(t *testing.T, name, repo string, here, inPlace bool)
 	t.Helper()
 	prevName, prevPrompt, prevProgram := createNameFlag, createPromptFlag, createProgramFlag
 	prevHere, prevInPlace, prevRepo := createHereFlag, createInPlaceFlag, repoFlag
+	prevPreflight := preflightLocalSession
 	createNameFlag, createPromptFlag, createProgramFlag = name, "do the thing", ""
 	createHereFlag, createInPlaceFlag, repoFlag = here, inPlace, repo
+	preflightLocalSession = func(*config.Config, string) error { return nil }
 	t.Cleanup(func() {
 		createNameFlag, createPromptFlag, createProgramFlag = prevName, prevPrompt, prevProgram
 		createHereFlag, createInPlaceFlag, repoFlag = prevHere, prevInPlace, prevRepo
+		preflightLocalSession = prevPreflight
 	})
 }
 
@@ -128,5 +132,45 @@ func TestSessionsCreate_HereOutsideRepoErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--here") || !strings.Contains(err.Error(), "git repository") {
 		t.Fatalf("error must name --here and the git-repo requirement, got: %v", err)
+	}
+}
+
+func TestSessionsCreatePreflightErrorSkipsDaemon(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	silenceStdio(t)
+
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	if out, err := exec.Command("git", "init", repoRoot).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+
+	prevName, prevPrompt, prevProgram := createNameFlag, createPromptFlag, createProgramFlag
+	prevHere, prevInPlace, prevRepo := createHereFlag, createInPlaceFlag, repoFlag
+	createNameFlag, createPromptFlag, createProgramFlag = "blocked", "", ""
+	createHereFlag, createInPlaceFlag, repoFlag = false, false, repoRoot
+	t.Cleanup(func() {
+		createNameFlag, createPromptFlag, createProgramFlag = prevName, prevPrompt, prevProgram
+		createHereFlag, createInPlaceFlag, repoFlag = prevHere, prevInPlace, prevRepo
+	})
+
+	prevPreflight := preflightLocalSession
+	preflightLocalSession = func(*config.Config, string) error {
+		return errors.New("tmux is not installed")
+	}
+	t.Cleanup(func() { preflightLocalSession = prevPreflight })
+
+	prevCreate := createSessionViaDaemon
+	createSessionViaDaemon = func(req daemon.CreateSessionRequest) (*session.InstanceData, error) {
+		t.Fatalf("daemon must not be reached after preflight failure: %+v", req)
+		return nil, nil
+	}
+	t.Cleanup(func() { createSessionViaDaemon = prevCreate })
+
+	err := sessionsCreateCmd.RunE(sessionsCreateCmd, nil)
+	if err == nil {
+		t.Fatal("expected preflight failure")
+	}
+	if !strings.Contains(err.Error(), "tmux is not installed") {
+		t.Fatalf("error should surface preflight detail, got: %v", err)
 	}
 }

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -436,9 +436,12 @@ func TestSessionsSendPrompt_CreateRoutesThroughDeliverPrompt(t *testing.T) {
 	repoFlag = repoRoot
 	prevCreate := sendPromptCreateFlag
 	sendPromptCreateFlag = true
+	prevPreflight := preflightLocalSession
+	preflightLocalSession = func(*config.Config, string) error { return nil }
 	defer func() {
 		repoFlag = prevRepoFlag
 		sendPromptCreateFlag = prevCreate
+		preflightLocalSession = prevPreflight
 	}()
 
 	var gotReq daemon.DeliverPromptRequest

--- a/app/app.go
+++ b/app/app.go
@@ -1790,7 +1790,11 @@ func (m *home) View() string {
 	rail := lipgloss.JoinVertical(lipgloss.Left, railParts...)
 	cols := []string{rail}
 	if len(m.visiblePanes) == 0 {
-		cols = append(cols, ui.EmptyWorkspace(m.lastLayout.Workspace))
+		if m.store.NumInstances() == 0 {
+			cols = append(cols, ui.FirstRunWorkspace(m.lastLayout.Workspace))
+		} else {
+			cols = append(cols, ui.EmptyWorkspace(m.lastLayout.Workspace))
+		}
 	}
 	for i, p := range m.visiblePanes {
 		if i > 0 {

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -40,6 +40,7 @@ func newTestHome(t *testing.T) *home {
 	t.Cleanup(SetTaskAdderForTest(task.AddTask))
 	t.Cleanup(SetTaskUpdaterForTest(task.UpdateTask))
 	t.Cleanup(SetTaskRemoverForTest(task.RemoveTask))
+	t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error { return nil }))
 
 	// The tab + PR-info mutations now route through daemon RPCs (#960 PR 2).
 	// Stub the seams with safe defaults so tests that incidentally trigger them

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -81,6 +81,9 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				))
 			}
 		}
+		if err := m.preflightSessionCreate(instance); err != nil {
+			return m, m.handleError(err)
+		}
 
 		// Apply the program selected during naming
 		instance.Program = m.pendingProgram
@@ -174,6 +177,9 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // If remote is true, the instance is forced to use the remote hook backend.
 func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	m.pendingProgram = m.program
+	if m.pendingProgram == "" && m.appConfig != nil {
+		m.pendingProgram = m.appConfig.DefaultProgram
+	}
 	instance, err := session.NewInstance(session.InstanceOptions{
 		Title:       "",
 		Path:        ".",

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -231,6 +232,32 @@ func TestHandleStateNewRejectsDuplicateTitle(t *testing.T) {
 	assert.Equal(t, stateNew, h.state)
 	require.NotNil(t, h.namingInstance)
 	assert.Contains(t, h.errBox.String(), "fix-bug")
+}
+
+func TestHandleStateNewPreflightErrorKeepsNamingFlow(t *testing.T) {
+	h := newTestHome(t)
+	h.state = stateNew
+	h.errBox.SetSize(160, 1)
+	h.pendingProgram = "claude"
+
+	preflightErr := errors.New("Claude Code is not installed or not on PATH")
+	t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error {
+		return preflightErr
+	}))
+
+	naming, err := session.NewInstance(session.InstanceOptions{
+		Title:   "first-agent",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	h.namingInstance = naming
+
+	_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, stateNew, h.state)
+	assert.Same(t, naming, h.namingInstance)
+	assert.Contains(t, h.errBox.String(), "Claude Code is not installed")
 }
 
 // TestHandleStateNewWhitespaceViaRealInput is the regression guard for #973: a

--- a/app/help.go
+++ b/app/help.go
@@ -173,6 +173,7 @@ func (h helpTypeInstanceStart) toContent() string {
 		headerStyle.Render("Managing:"),
 		keyStyle.Render(helpKey(keys.KeyEnter))+descStyle.Render(fmt.Sprintf("     - Interact with the session in its pane (%s returns to nav)", helpKey(keys.KeyExitInteractive))),
 		keyStyle.Render(helpKey(keys.KeyAttach))+descStyle.Render("     - Attach to the session full-screen"),
+		keyStyle.Render(tmux.DetachKeyDisplay)+descStyle.Render("     - Detach from a full-screen session"),
 		tabHelp,
 		keyStyle.Render(helpKey(keys.KeyKill))+descStyle.Render("     - Kill (delete) the selected session"),
 	)

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -75,3 +75,12 @@ func TestInstanceStartHelpRemoteOmitsUnsupportedTabKeys(t *testing.T) {
 		t.Errorf("local instance-start help should advertise the full t/w/1-9 tab hint; got:\n%s", localContent)
 	}
 }
+
+func TestInstanceStartHelpMentionsFullScreenDetach(t *testing.T) {
+	local := newStartedInstance(t, "local")
+	content := helpStart(local).toContent()
+
+	if !strings.Contains(content, "ctrl-w") || !strings.Contains(content, "Detach from a full-screen session") {
+		t.Errorf("instance-start help must name the full-screen detach key; got:\n%s", content)
+	}
+}

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -72,6 +72,19 @@ func visibleTitles(h *home) []string {
 	return out
 }
 
+func TestFirstRunWorkspaceEmptyState(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 120, 30)
+
+	view := h.View()
+
+	assert.Contains(t, view, "No sessions yet")
+	assert.Contains(t, view, "Press n to create a local session")
+	assert.Contains(t, view, "Press ? for all keys")
+	assert.Contains(t, view, "af doctor --setup")
+	assert.NotContains(t, view, "s opens the selected tab")
+}
+
 // TestPane_OpenHideFlow walks the core verb set: s with tree focus opens the
 // selection as a focused pane; a second s on another instance opens a second
 // pane to the RIGHT; x hides the focused pane, the survivor re-divides the

--- a/app/preflight.go
+++ b/app/preflight.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/preflight"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+var localSessionPreflight = preflight.LocalSessionPrereqs
+
+func (m *home) preflightSessionCreate(instance *session.Instance) error {
+	if instance == nil || instance.IsRemote() {
+		return nil
+	}
+	cfg, err := m.preflightConfig()
+	if err != nil {
+		return err
+	}
+	return localSessionPreflight(cfg, m.pendingProgram)
+}
+
+func (m *home) preflightConfig() (*config.Config, error) {
+	if m.repoRoot != "" {
+		resolved, err := config.ResolveConfig(m.repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve config before starting session: %w", err)
+		}
+		return &resolved.Config, nil
+	}
+	if m.appConfig != nil {
+		return m.appConfig, nil
+	}
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config before starting session: %w", err)
+	}
+	return cfg, nil
+}
+
+func SetLocalSessionPreflightForTest(f func(*config.Config, string) error) func() {
+	prev := localSessionPreflight
+	localSessionPreflight = f
+	return func() { localSessionPreflight = prev }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,7 +95,8 @@ af version             # print the version and the release URL
 af debug               # print the resolved config and its path
 af keys                # print the effective TUI key bindings (defaults + [keys] rebinds)
 af upgrade             # self-upgrade to the latest GitHub release (Linux/macOS)
-af doctor              # diagnose leaked processes/sessions/temp homes and daemon health
+af doctor --setup      # verify first-run prerequisites and writable storage
+af doctor              # diagnose setup, leaked resources, and daemon health
 af doctor --fix        # also apply the safe remediations
 af bug-report          # bundle logs + versions + tasks + redacted state into one file to attach
 af bug-report --json   # emit the structured manifest to stdout instead of writing a file
@@ -115,6 +116,10 @@ scrubbed everywhere — but perfect redaction is impossible, so **review the fil
 before sharing it publicly**. It is read-only and local (like `af doctor`): it
 never dials the daemon or the network, and is not part of the HTTP `af api`
 surface.
+
+`af doctor --setup` is the first-run profile: it checks AF home/config/state/log
+writability, git and git identity, tmux, configured agent commands, daemon
+health, and remote-hook setup for the current repo when configured.
 
 `af doctor` is read-only by default: it reports orphaned processes left behind
 by dead sessions, processes pegging a CPU core inside live sessions, `af_` tmux

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,6 +20,9 @@ This installs the `af` binary (Linux/macOS, amd64/arm64) to `~/.local/bin` —
 override with `AF_INSTALL_DIR`, or pin a release with `--version`. Make sure
 `~/.local/bin` is on your `PATH`.
 
+Run `af doctor --setup` after install to verify tmux, git, your configured
+agent command, git identity, config/state/log storage, and daemon health.
+
 To update later, re-run the script or run `af upgrade`. Installed binaries also
 auto-update along the **stable** channel; set `"update_channel": "preview"` in
 your global config to track preview builds instead (see the
@@ -34,14 +37,15 @@ needs Go).
 
 ```bash
 cd your-project    # must be a git repo
+af doctor --setup  # optional but recommended on first run
 af                 # launch the TUI
 ```
 
 The TUI opens with an empty sidebar. From here:
 
 1. Press **`n`** to create a new session. Give it a name and, optionally, an
-   initial prompt. `af` creates a fresh git worktree on a new branch and starts
-   your agent in it.
+   choose the agent with **Tab**. `af` creates a fresh git worktree on a new
+   branch and starts your agent in it.
 2. The session appears in the sidebar with a live status. The **preview pane**
    on the right shows a snapshot of the agent's terminal — you can watch its
    progress without attaching.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -25,7 +25,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af daemon status`](#af-daemon-status) — Report daemon liveness, sockets, pid, and autostart
 - [`af daemon uninstall`](#af-daemon-uninstall) — Remove the daemon autostart unit
 - [`af debug`](#af-debug) — Print debug information like config paths
-- [`af doctor`](#af-doctor) — Diagnose leaked processes, sessions, temp homes, and daemon health
+- [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
 - [`af reset`](#af-reset) — Reset all stored instances
 - [`af sessions`](#af-sessions) — Manage sessions
@@ -70,7 +70,7 @@ af [flags]
 - [`af config`](#af-config) — Read and write the global agent-factory config
 - [`af daemon`](#af-daemon) — Manage the background daemon that schedules tasks
 - [`af debug`](#af-debug) — Print debug information like config paths
-- [`af doctor`](#af-doctor) — Diagnose leaked processes, sessions, temp homes, and daemon health
+- [`af doctor`](#af-doctor) — Diagnose setup, daemon health, and leaked session resources
 - [`af keys`](#af-keys) — Show the effective TUI key bindings (defaults plus [keys] rebinds)
 - [`af reset`](#af-reset) — Reset all stored instances
 - [`af sessions`](#af-sessions) — Manage sessions
@@ -452,9 +452,21 @@ af debug
 
 ## af doctor
 
-Diagnose leaked processes, sessions, temp homes, and daemon health
+Diagnose setup, daemon health, and leaked session resources
 
-Diagnose problems that accumulate silently on a machine running agent-factory:
+Diagnose the local agent-factory environment.
+
+For first-run setup checks, use:
+
+  af doctor --setup
+
+The setup profile checks the prerequisites needed to create the first local
+session: AF home writability, config materialization and parsing, git and the
+current repo, git identity, tmux, configured agent commands, state/log storage,
+daemon health, and remote-hook setup when this repo configures it.
+
+Without --setup, doctor runs the full maintenance sweep for problems that
+accumulate silently on a machine running agent-factory:
 
   - orphaned processes spawned by sessions that no longer exist
   - processes that escaped a live session's pane, or peg a CPU core for hours
@@ -481,6 +493,7 @@ af doctor [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--fix` |  | apply safe remediations (kill verified orphans, remove stale temp homes) |
+| `--setup` |  | run the first-run setup profile (prerequisites, config, agent commands) |
 
 ## af keys
 
@@ -562,7 +575,7 @@ af sessions archive <title>
 
 Attach to a session's terminal
 
-Attach to a running session's tmux terminal. Detach with the configured detach key (default: Ctrl-b d).
+Attach to a running session's tmux terminal. Detach with the configured detach key (default: Ctrl-w).
 
 ```
 af sessions attach <title>

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -73,6 +73,10 @@ func (r *Report) UnresolvedCount() int {
 type Options struct {
 	// Fix applies the safe remediations instead of only reporting.
 	Fix bool
+	// Setup runs the onboarding profile only: local prerequisites, writable
+	// AF home/config/state/log storage, daemon health, and remote-hook setup.
+	// It intentionally skips the full process/tmux/temp-home leak sweep.
+	Setup bool
 	// ConfigDir is the active agent-factory home; defaults to
 	// config.GetConfigDir().
 	ConfigDir string
@@ -143,11 +147,17 @@ func Run(opts Options) (*Report, error) {
 		opts.killTermWait = 2 * time.Second
 	}
 
+	ctx := &scanContext{opts: opts, selfAncestors: map[int]bool{}}
+	report := &Report{}
+	if opts.Setup {
+		checkSetup(ctx, report)
+		return report, nil
+	}
+
 	if opts.snapshot == nil {
 		opts.snapshot = proctree.Snapshot
 	}
 
-	ctx := &scanContext{opts: opts, selfAncestors: map[int]bool{}}
 	if snap, err := opts.snapshot(); err == nil {
 		ctx.snap = snap
 		for pid := range selfAndAncestors(snap) {
@@ -155,7 +165,6 @@ func Run(opts Options) (*Report, error) {
 		}
 	}
 
-	report := &Report{}
 	checkDaemonHealth(ctx, report)
 	checkOrphanedProcesses(ctx, report)
 	checkRunawayChildren(ctx, report)

--- a/doctor/setup.go
+++ b/doctor/setup.go
@@ -1,0 +1,224 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+	aflog "github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/preflight"
+)
+
+func checkSetup(ctx *scanContext, report *Report) {
+	checkAFHome(ctx, report)
+	cfg := checkConfig(ctx, report)
+	checkStateDirs(ctx, report)
+	checkLogStorage(report)
+	checkGit(report)
+	checkTmux(report)
+	if cfg != nil {
+		checkAgentPrograms(cfg, report)
+	}
+	checkDaemonHealth(ctx, report)
+	checkRemoteSetup(ctx, report)
+}
+
+func checkAFHome(ctx *scanContext, report *Report) {
+	if ctx.opts.ConfigDir == "" {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "af-home",
+			Detail: "agent-factory home could not be resolved",
+		})
+		return
+	}
+	if err := writableDir(ctx.opts.ConfigDir); err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check: "af-home",
+			Detail: fmt.Sprintf("agent-factory home %s is not writable — "+
+				"fix directory permissions or set AGENT_FACTORY_HOME to a writable directory",
+				ctx.opts.ConfigDir) + ": " + err.Error(),
+		})
+		return
+	}
+	report.OK = append(report.OK, fmt.Sprintf("agent-factory home: writable at %s", ctx.opts.ConfigDir))
+}
+
+func checkStateDirs(ctx *scanContext, report *Report) {
+	for _, d := range []struct {
+		check string
+		label string
+		dir   string
+	}{
+		{"state-dir", "state storage", filepath.Join(ctx.opts.ConfigDir, "instances")},
+		{"repo-state-dir", "repo state storage", filepath.Join(ctx.opts.ConfigDir, "repos")},
+	} {
+		if err := writableDir(d.dir); err != nil {
+			report.Findings = append(report.Findings, Finding{
+				Check:  d.check,
+				Detail: fmt.Sprintf("%s directory %s is not writable — fix directory permissions: %v", d.label, d.dir, err),
+			})
+		} else {
+			report.OK = append(report.OK, fmt.Sprintf("%s: writable at %s", d.label, d.dir))
+		}
+	}
+}
+
+func checkLogStorage(report *Report) {
+	path := aflog.LogFilePath()
+	if path == "" {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "log-storage",
+			Detail: "could not resolve application log path — set AGENT_FACTORY_HOME to a writable directory and retry",
+		})
+		return
+	}
+	dir := filepath.Dir(path)
+	if err := writableDir(dir); err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "log-storage",
+			Detail: fmt.Sprintf("log directory %s is not writable — fix directory permissions or set AGENT_FACTORY_HOME to a writable directory: %v", dir, err),
+		})
+		return
+	}
+	report.OK = append(report.OK, fmt.Sprintf("log storage: writable at %s", dir))
+}
+
+func checkConfig(_ *scanContext, report *Report) *config.Config {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "config",
+			Detail: fmt.Sprintf("config is not valid — fix the reported file or delete it to regenerate defaults: %v", err),
+		})
+		return nil
+	}
+	path, err := config.GlobalConfigPath()
+	if err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "config",
+			Detail: fmt.Sprintf("could not resolve config path: %v", err),
+		})
+		return cfg
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "config",
+			Detail: fmt.Sprintf("config loaded in memory but %s is not materialized on disk — run `af config set default_program %s` or fix AF home permissions: %v", path, cfg.DefaultProgram, statErr),
+		})
+		return cfg
+	}
+	report.OK = append(report.OK,
+		fmt.Sprintf("config: loaded %s (default_program = %q)", path, cfg.DefaultProgram))
+	return cfg
+}
+
+func checkGit(report *Report) {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "git",
+			Detail: "git is not installed or not on PATH — install git and retry",
+		})
+		return
+	}
+	report.OK = append(report.OK, fmt.Sprintf("git: available at %s", gitPath))
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "git-repo",
+			Detail: fmt.Sprintf("could not determine current directory: %v", err),
+		})
+		return
+	}
+	out, err := exec.Command(gitPath, "-C", cwd, "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "git-repo",
+			Detail: fmt.Sprintf("%s is not inside a git repository — run `af` from a repo root or pass --repo where supported", cwd),
+		})
+		return
+	}
+	report.OK = append(report.OK, fmt.Sprintf("git repo: %s", strings.TrimSpace(string(out))))
+	checkGitIdentity(gitPath, cwd, report)
+}
+
+func checkGitIdentity(gitPath, cwd string, report *Report) {
+	missing := []string{}
+	for _, key := range []string{"user.name", "user.email"} {
+		out, err := exec.Command(gitPath, "-C", cwd, "config", "--get", key).Output()
+		if err != nil || strings.TrimSpace(string(out)) == "" {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		report.Findings = append(report.Findings, Finding{
+			Check: "git-identity",
+			Detail: fmt.Sprintf("git identity is incomplete (missing %s) — run: "+
+				"git config --global user.name \"Your Name\" && git config --global user.email you@example.com",
+				strings.Join(missing, " and ")),
+		})
+		return
+	}
+	report.OK = append(report.OK, "git identity: user.name and user.email are configured")
+}
+
+func checkTmux(report *Report) {
+	version, err := preflight.CheckTmux()
+	if err != nil {
+		report.Findings = append(report.Findings, Finding{Check: "tmux", Detail: err.Error()})
+		return
+	}
+	report.OK = append(report.OK, fmt.Sprintf("tmux: %s", version))
+}
+
+func checkAgentPrograms(cfg *config.Config, report *Report) {
+	if cfg.DefaultProgram == "" {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "agent-program",
+			Detail: "default_program is empty — set it to one of claude, codex, aider, or gemini in ~/.agent-factory/config.toml",
+		})
+		return
+	}
+	checkOneProgram("default_program", cfg.DefaultProgram, config.ResolveProgram(cfg, cfg.DefaultProgram), report)
+	for _, agent := range sortedKeys(cfg.ProgramOverrides) {
+		command := strings.TrimSpace(cfg.ProgramOverrides[agent])
+		if command == "" {
+			continue
+		}
+		checkOneProgram("program_overrides."+agent, agent, command, report)
+	}
+}
+
+func checkOneProgram(field, agent, command string, report *Report) {
+	check, err := preflight.CheckCommand(command)
+	if err != nil {
+		report.Findings = append(report.Findings, Finding{
+			Check:  "agent-program",
+			Detail: fmt.Sprintf("%s resolves to %q but is not runnable — %v", field, command, preflight.ProgramError(agent, command, err)),
+		})
+		return
+	}
+	report.OK = append(report.OK,
+		fmt.Sprintf("%s: %q uses %s", field, command, check.Path))
+}
+
+func writableDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(dir, ".af-doctor-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	closeErr := f.Close()
+	removeErr := os.Remove(name)
+	if closeErr != nil {
+		return closeErr
+	}
+	return removeErr
+}

--- a/doctor/setup_test.go
+++ b/doctor/setup_test.go
@@ -1,0 +1,101 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupDoctorHealthy(t *testing.T) {
+	home := t.TempDir()
+	binDir := t.TempDir()
+	repo := setupDoctorRepo(t)
+	fakeTmux := writeExecutable(t, binDir, "tmux", "#!/bin/sh\nif [ \"$1\" = \"-V\" ]; then echo 'tmux 3.4'; exit 0; fi\nexit 0\n")
+	fakeAgent := writeExecutable(t, binDir, "fake-agent", "#!/bin/sh\nexit 0\n")
+	require.NotEmpty(t, fakeTmux)
+
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	writeSetupConfig(t, home, fakeAgent)
+	chdir(t, repo)
+
+	report, err := Run(Options{
+		Setup:     true,
+		ConfigDir: home,
+		TempDir:   t.TempDir(),
+		remoteConfig: func() (*config.RemoteHooks, string, error) {
+			return nil, "", nil
+		},
+	})
+	require.NoError(t, err)
+	require.Zero(t, report.UnresolvedCount(), "findings: %+v", report.Findings)
+	require.True(t, okContains(report, "default_program"))
+	require.True(t, okContains(report, "git identity"))
+	require.True(t, okContains(report, "log storage"))
+}
+
+func TestSetupDoctorReportsMissingDefaultProgram(t *testing.T) {
+	home := t.TempDir()
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "tmux", "#!/bin/sh\nif [ \"$1\" = \"-V\" ]; then echo 'tmux 3.4'; exit 0; fi\nexit 0\n")
+
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	t.Setenv("PATH", binDir)
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(home, config.TomlConfigFileName),
+		[]byte("default_program = \"claude\"\n"), 0o644))
+
+	report, err := Run(Options{
+		Setup:     true,
+		ConfigDir: home,
+		TempDir:   t.TempDir(),
+		remoteConfig: func() (*config.RemoteHooks, string, error) {
+			return nil, "", nil
+		},
+	})
+	require.NoError(t, err)
+	findings := findByCheck(report, "agent-program")
+	require.NotEmpty(t, findings)
+	require.Contains(t, findings[0].Detail, "default_program")
+	require.Contains(t, findings[0].Detail, "program_overrides.claude")
+}
+
+func setupDoctorRepo(t *testing.T) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	require.NoError(t, exec.Command("git", "init", repo).Run())
+	require.NoError(t, exec.Command("git", "-C", repo, "config", "user.email", "test@example.com").Run())
+	require.NoError(t, exec.Command("git", "-C", repo, "config", "user.name", "Test User").Run())
+	require.NoError(t, exec.Command("git", "-C", repo, "commit", "--allow-empty", "-m", "init").Run())
+	return repo
+}
+
+func writeSetupConfig(t *testing.T, home, agentPath string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	content := fmt.Sprintf("default_program = %q\n\n[program_overrides]\n%s = %q\n",
+		tmux.ProgramClaude, tmux.ProgramClaude, agentPath)
+	require.NoError(t, os.WriteFile(filepath.Join(home, config.TomlConfigFileName), []byte(content), 0o644))
+}
+
+func writeExecutable(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	return path
+}
+
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	old, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(old) })
+}

--- a/doctorcmd.go
+++ b/doctorcmd.go
@@ -9,6 +9,7 @@ import (
 )
 
 var doctorFixFlag bool
+var doctorSetupFlag bool
 
 // doctorCmd is `af doctor` (#1044, #1104): detect orphaned session
 // processes, runaway CPU children, leaked af_ tmux sessions, stale temp
@@ -18,8 +19,20 @@ var doctorFixFlag bool
 // whose home was deleted). Anything ambiguous is reported, never touched.
 var doctorCmd = &cobra.Command{
 	Use:   "doctor",
-	Short: "Diagnose leaked processes, sessions, temp homes, and daemon health",
-	Long: `Diagnose problems that accumulate silently on a machine running agent-factory:
+	Short: "Diagnose setup, daemon health, and leaked session resources",
+	Long: `Diagnose the local agent-factory environment.
+
+For first-run setup checks, use:
+
+  af doctor --setup
+
+The setup profile checks the prerequisites needed to create the first local
+session: AF home writability, config materialization and parsing, git and the
+current repo, git identity, tmux, configured agent commands, state/log storage,
+daemon health, and remote-hook setup when this repo configures it.
+
+Without --setup, doctor runs the full maintenance sweep for problems that
+accumulate silently on a machine running agent-factory:
 
   - orphaned processes spawned by sessions that no longer exist
   - processes that escaped a live session's pane, or peg a CPU core for hours
@@ -40,7 +53,7 @@ Exits 1 when unresolved issues remain, 0 when healthy.`,
 		log.Initialize(false)
 		defer log.Close()
 
-		report, err := doctor.Run(doctor.Options{Fix: doctorFixFlag})
+		report, err := doctor.Run(doctor.Options{Fix: doctorFixFlag, Setup: doctorSetupFlag})
 		if err != nil {
 			return err
 		}
@@ -57,6 +70,8 @@ Exits 1 when unresolved issues remain, 0 when healthy.`,
 }
 
 func init() {
+	doctorCmd.Flags().BoolVar(&doctorSetupFlag, "setup", false,
+		"run the first-run setup profile (prerequisites, config, agent commands)")
 	doctorCmd.Flags().BoolVar(&doctorFixFlag, "fix", false,
 		"apply safe remediations (kill verified orphans, remove stale temp homes)")
 	rootCmd.AddCommand(doctorCmd)

--- a/install.sh
+++ b/install.sh
@@ -149,13 +149,17 @@ echo "Version: $installed_version"
 
 case ":$PATH:" in
 	*":$INSTALL_DIR:"*)
-		echo "Run 'af' in a git repository to launch the TUI."
+		echo "Next:"
+		echo "  1. Make sure tmux, git, and an agent CLI (Claude Code, Codex, Aider, or Gemini) are installed."
+		echo "  2. Run: af doctor --setup"
+		echo "  3. In a git repository, run: af"
 		;;
 	*)
 		echo ""
 		echo "NOTE: $INSTALL_DIR is not on your PATH."
 		echo "Add it to your shell profile, e.g.:"
 		echo "    export PATH=\"$INSTALL_DIR:\$PATH\""
-		echo "Then restart your shell, or run af directly: $INSTALL_DIR/af"
+		echo "Then restart your shell and run: af doctor --setup"
+		echo "You can also run the installed binary directly: $INSTALL_DIR/af doctor --setup"
 		;;
 esac

--- a/preflight/preflight.go
+++ b/preflight/preflight.go
@@ -1,0 +1,263 @@
+package preflight
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// ProgramCheck describes the executable a configured agent command resolves to.
+type ProgramCheck struct {
+	Agent      string
+	Command    string
+	Executable string
+	Path       string
+}
+
+// CheckTmux verifies that tmux is present and can report its version.
+func CheckTmux() (string, error) {
+	path, err := exec.LookPath("tmux")
+	if err != nil {
+		return "", fmt.Errorf("tmux is not installed or not on PATH; install tmux (macOS: brew install tmux; Debian/Ubuntu: sudo apt install tmux) and retry")
+	}
+	out, err := exec.Command(path, "-V").Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux is installed at %s but `tmux -V` failed: %w", path, err)
+	}
+	version := strings.TrimSpace(string(out))
+	if version == "" {
+		version = path
+	}
+	return version, nil
+}
+
+// CheckProgram resolves agent through cfg.program_overrides and verifies the
+// command's executable exists. It does not run the command.
+func CheckProgram(cfg *config.Config, agent string) (*ProgramCheck, error) {
+	command := config.ResolveProgram(cfg, agent)
+	check, err := CheckCommand(command)
+	if check != nil {
+		check.Agent = agent
+	}
+	if err != nil {
+		return check, err
+	}
+	return check, nil
+}
+
+// CheckCommand verifies the first executable in command. It handles common
+// shell shapes used in program_overrides: quotes, explicit paths, leading
+// VAR=value assignments, and env VAR=value wrappers.
+func CheckCommand(command string) (*ProgramCheck, error) {
+	command = strings.TrimSpace(command)
+	check := &ProgramCheck{Command: command}
+	if command == "" {
+		return check, fmt.Errorf("command is empty")
+	}
+	words, err := shellWords(command, 12)
+	if err != nil {
+		return check, err
+	}
+	exe := firstExecutable(words)
+	check.Executable = exe
+	if exe == "" {
+		return check, fmt.Errorf("could not find an executable in command %q", command)
+	}
+	if strings.ContainsRune(exe, filepath.Separator) || strings.HasPrefix(exe, "~") {
+		path := config.ExpandTilde(exe)
+		info, err := os.Stat(path)
+		if err != nil {
+			return check, fmt.Errorf("executable %q does not exist", exe)
+		}
+		if info.IsDir() {
+			return check, fmt.Errorf("executable %q is a directory", exe)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			return check, fmt.Errorf("executable %q is not executable; run: chmod +x %s", exe, path)
+		}
+		check.Path = path
+		return check, nil
+	}
+	path, err := exec.LookPath(exe)
+	if err != nil {
+		return check, fmt.Errorf("executable %q was not found on PATH", exe)
+	}
+	check.Path = path
+	return check, nil
+}
+
+// LocalSessionPrereqs verifies the prerequisites needed before creating a
+// local tmux-backed session. Remote hook sessions intentionally skip this.
+func LocalSessionPrereqs(cfg *config.Config, agent string) error {
+	if _, err := CheckTmux(); err != nil {
+		return err
+	}
+	if _, err := CheckProgram(cfg, agent); err != nil {
+		return ProgramError(agent, config.ResolveProgram(cfg, agent), err)
+	}
+	return nil
+}
+
+// ProgramError renders the actionable user-facing error for a missing agent.
+func ProgramError(agent, command string, cause error) error {
+	name := agentDisplayName(agent)
+	if isSupportedAgent(agent) {
+		return fmt.Errorf("%s is not installed or not on PATH (resolved command: %q). Install %s, choose another agent, or set program_overrides.%s in ~/.agent-factory/config.toml. Details: %v",
+			name, command, name, agent, cause)
+	}
+	return fmt.Errorf("program %q is not installed or not on PATH (resolved command: %q). Install it, choose another agent, or fix the command in config. Details: %v",
+		agent, command, cause)
+}
+
+func agentDisplayName(agent string) string {
+	switch agent {
+	case tmux.ProgramClaude:
+		return "Claude Code"
+	case tmux.ProgramCodex:
+		return "Codex"
+	case tmux.ProgramAider:
+		return "Aider"
+	case tmux.ProgramGemini:
+		return "Gemini"
+	default:
+		if agent == "" {
+			return "the configured agent"
+		}
+		return agent
+	}
+}
+
+func isSupportedAgent(agent string) bool {
+	for _, p := range tmux.SupportedPrograms {
+		if agent == p {
+			return true
+		}
+	}
+	return false
+}
+
+func firstExecutable(words []string) string {
+	for len(words) > 0 && isAssignment(words[0]) {
+		words = words[1:]
+	}
+	if len(words) == 0 {
+		return ""
+	}
+	if words[0] != "env" {
+		return words[0]
+	}
+	words = words[1:]
+	for len(words) > 0 {
+		switch {
+		case words[0] == "--":
+			words = words[1:]
+		case isAssignment(words[0]):
+			words = words[1:]
+		case words[0] == "-u" || words[0] == "--unset" || words[0] == "-C" || words[0] == "--chdir":
+			if len(words) < 2 {
+				return ""
+			}
+			words = words[2:]
+		case strings.HasPrefix(words[0], "-"):
+			words = words[1:]
+		default:
+			return words[0]
+		}
+	}
+	return ""
+}
+
+func isAssignment(word string) bool {
+	i := strings.IndexRune(word, '=')
+	if i <= 0 {
+		return false
+	}
+	for pos, r := range word[:i] {
+		if pos == 0 {
+			if r != '_' && !unicode.IsLetter(r) {
+				return false
+			}
+			continue
+		}
+		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func shellWords(input string, limit int) ([]string, error) {
+	var words []string
+	var b strings.Builder
+	var quote rune
+	escaped := false
+	inWord := false
+
+	flush := func() {
+		if inWord {
+			words = append(words, b.String())
+			b.Reset()
+			inWord = false
+		}
+	}
+
+	for _, r := range input {
+		if escaped {
+			b.WriteRune(r)
+			inWord = true
+			escaped = false
+			continue
+		}
+		switch quote {
+		case '\'':
+			if r == '\'' {
+				quote = 0
+			} else {
+				b.WriteRune(r)
+				inWord = true
+			}
+			continue
+		case '"':
+			switch r {
+			case '"':
+				quote = 0
+			case '\\':
+				escaped = true
+			default:
+				b.WriteRune(r)
+				inWord = true
+			}
+			continue
+		}
+
+		switch {
+		case unicode.IsSpace(r):
+			flush()
+			if limit > 0 && len(words) >= limit {
+				return words, nil
+			}
+		case r == '\'' || r == '"':
+			quote = r
+			inWord = true
+		case r == '\\':
+			escaped = true
+		default:
+			b.WriteRune(r)
+			inWord = true
+		}
+	}
+	if escaped {
+		b.WriteRune('\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote in command %q", input)
+	}
+	flush()
+	return words, nil
+}

--- a/preflight/preflight_test.go
+++ b/preflight/preflight_test.go
@@ -1,0 +1,71 @@
+package preflight
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestShellWords(t *testing.T) {
+	got, err := shellWords(`env FOO=1 '/opt/Claude Code/claude' --flag`, 0)
+	if err != nil {
+		t.Fatalf("shellWords: %v", err)
+	}
+	want := []string{"env", "FOO=1", "/opt/Claude Code/claude", "--flag"}
+	if len(got) != len(want) {
+		t.Fatalf("shellWords len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("word %d = %q, want %q (all %#v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestFirstExecutable(t *testing.T) {
+	cases := []struct {
+		name  string
+		words []string
+		want  string
+	}{
+		{"bare", []string{"claude", "--flag"}, "claude"},
+		{"assignment", []string{"FOO=1", "codex"}, "codex"},
+		{"env assignment", []string{"env", "FOO=1", "gemini"}, "gemini"},
+		{"env unset", []string{"env", "-u", "FOO", "aider"}, "aider"},
+		{"env chdir", []string{"env", "-C", "/tmp", "claude"}, "claude"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := firstExecutable(tc.words); got != tc.want {
+				t.Fatalf("firstExecutable(%#v) = %q, want %q", tc.words, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckCommand(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "fake-agent")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	check, err := CheckCommand("env FOO=1 fake-agent --ready")
+	if err != nil {
+		t.Fatalf("CheckCommand: %v", err)
+	}
+	if check.Executable != "fake-agent" || check.Path != exe {
+		t.Fatalf("unexpected check: %+v", check)
+	}
+}
+
+func TestCheckCommandRejectsNonExecutablePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "agent")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if _, err := CheckCommand(path); err == nil {
+		t.Fatal("expected non-executable path to fail")
+	}
+}

--- a/ui/workspace.go
+++ b/ui/workspace.go
@@ -26,3 +26,28 @@ func EmptyWorkspace(r layout.Rect) string {
 	inner := lipgloss.Place(iw, ih, lipgloss.Center, lipgloss.Center, hint)
 	return layout.ClampToRect(blurredWindowStyle.Render(inner), r)
 }
+
+// FirstRunWorkspace renders the zero-session onboarding state. It is distinct
+// from EmptyWorkspace because there is no selected tab yet, so the useful next
+// action is session creation, not opening a pane.
+func FirstRunWorkspace(r layout.Rect) string {
+	if r.Empty() {
+		return ""
+	}
+	iw := r.W - blurredWindowStyle.GetHorizontalFrameSize()
+	ih := r.H - blurredWindowStyle.GetVerticalFrameSize()
+	if iw < 0 {
+		iw = 0
+	}
+	if ih < 0 {
+		ih = 0
+	}
+	content := lipgloss.JoinVertical(lipgloss.Center,
+		paneHeaderDimStyle.Render("No sessions yet"),
+		paneHeaderDimStyle.Render("Press n to create a local session"),
+		paneHeaderDimStyle.Render("Press ? for all keys"),
+		paneHeaderDimStyle.Render("Setup check: run af doctor --setup"),
+	)
+	inner := lipgloss.Place(iw, ih, lipgloss.Center, lipgloss.Center, content)
+	return layout.ClampToRect(blurredWindowStyle.Render(inner), r)
+}


### PR DESCRIPTION
Closes #1044.

## Summary
- Add `af doctor --setup` for first-run environment checks: AF home/config/state/log storage, git repo + identity, tmux, configured agent binaries, daemon health, and remote-hook setup when configured.
- Add local session preflight in CLI and TUI create paths so missing tmux/agent binaries fail fast with actionable guidance before daemon/session startup.
- Add zero-session first-run TUI empty state, full-screen detach guidance, install/readme/getting-started/help reference updates.

## Gates
- `gofmt -w .`
- `go build ./...`
- `make test-container`
- `golangci-lint run --fast`
- `scripts/lint-file-length.sh`
- `deadcode -test ./...`

Do not merge instruction honored by this agent; PR was later observed as already merged by GitHub state.

Captain Claude