### PR TITLE
fix(limit): guard manual retry during teardown

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -420,6 +420,9 @@ func (m *home) handleLimitRetry() (tea.Model, tea.Cmd) {
 	if selected == nil {
 		return m, nil
 	}
+	if selected.IsTearingDown() {
+		return m, m.handleError(fmt.Errorf("session '%s' is being deleted", selected.Title))
+	}
 	if !selected.LimitReached() {
 		return m, m.handleError(fmt.Errorf("session '%s' is not blocked on a usage limit", selected.Title))
 	}

--- a/app/limit_action_test.go
+++ b/app/limit_action_test.go
@@ -63,6 +63,26 @@ func TestHandleLimitRetry_LimitRow_Dispatches(t *testing.T) {
 	require.Equal(t, "worker", gotTitle, "the resume command must call the daemon for the selected title")
 }
 
+// TestHandleLimitRetry_TearingDownRow_NoDispatch: pressing c on a limit-blocked
+// row that is already being deleted must not race a resume RPC against teardown.
+func TestHandleLimitRetry_TearingDownRow_NoDispatch(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+	inst := limitActionInstance(t, "worker", time.Now().Add(time.Hour))
+	inst.SetInFlightOp(session.OpKilling)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	called := false
+	restore := SetLimitResumerForTest(func(string, string) error { called = true; return nil })
+	defer restore()
+
+	_, cmd := h.handleLimitRetry()
+	require.False(t, called, "a deleting row must not dispatch the resume RPC")
+	require.NotNil(t, cmd, "the user should get a transient error message")
+	require.Contains(t, h.errBox.String(), "session 'worker' is being deleted")
+}
+
 // TestResumeFromLimitCmd_SurfacesError: a daemon rejection is carried back on the
 // completion message (handled into the error box, limit state left intact).
 func TestResumeFromLimitCmd_SurfacesError(t *testing.T) {

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -186,6 +186,36 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 		return fmt.Errorf("session %q is not blocked on a usage limit", req.Title)
 	}
 
+	key := daemonInstanceKey(repoID, instance.Title)
+	m.mu.Lock()
+	if _, killing := m.killsInFlight[key]; killing {
+		m.mu.Unlock()
+		return nil
+	}
+	m.mu.Unlock()
+
+	opLock := m.opLockFor(key)
+	if !opLock.TryLock() {
+		return nil
+	}
+	defer opLock.Unlock()
+
+	m.mu.Lock()
+	current := m.instances[key]
+	_, killing := m.killsInFlight[key]
+	m.mu.Unlock()
+	if killing || current != instance || instance.IsTearingDown() {
+		return nil
+	}
+
+	return m.resumeFromLimitLocked(repoID, key, instance, req.Title)
+}
+
+// resumeFromLimitLocked performs the shared limit-resume action. The caller
+// must hold the per-session op lock for key, so a manual retry cannot interleave
+// with kill teardown and auto-resume can reuse the body after its own op-lock
+// guard.
+func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.Instance, requestedTitle string) error {
 	unlock := m.lockTarget(repoID, instance.Title)
 	defer unlock()
 
@@ -194,8 +224,15 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 	if !instance.LimitReached() {
 		return nil
 	}
+	m.mu.Lock()
+	current := m.instances[key]
+	_, killing := m.killsInFlight[key]
+	m.mu.Unlock()
+	if killing || current != instance || instance.IsTearingDown() {
+		return nil
+	}
 	if instance.UserKilled() || session.IsReservedTitle(instance.Title) {
-		return fmt.Errorf("session %q cannot be resumed", req.Title)
+		return fmt.Errorf("session %q cannot be resumed", requestedTitle)
 	}
 
 	// Re-spawn only when the agent's tmux session actually exited while blocked
@@ -210,7 +247,7 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 	// lock.
 	if !instance.TmuxAlive() {
 		if rerr := instance.Respawn(); rerr != nil {
-			return fmt.Errorf("failed to re-spawn agent for %q: %w", req.Title, rerr)
+			return fmt.Errorf("failed to re-spawn agent for %q: %w", requestedTitle, rerr)
 		}
 	}
 
@@ -221,7 +258,7 @@ func (m *Manager) resumeFromLimit(req ResumeFromLimitRequest) error {
 		prompt = "continue"
 	}
 	if serr := instance.SendPromptCommand(prompt); serr != nil {
-		return fmt.Errorf("failed to resume %q: %w", req.Title, serr)
+		return fmt.Errorf("failed to resume %q: %w", requestedTitle, serr)
 	}
 	instance.ClearLimitReached()
 

--- a/daemon/limit_resume_test.go
+++ b/daemon/limit_resume_test.go
@@ -134,6 +134,63 @@ func TestResumeFromLimit_LiveStall_SendsContinueNoRespawn(t *testing.T) {
 	}
 }
 
+// TestResumeFromLimit_TeardownInFlightNoops pins #1263: a manual retry must not
+// send a prompt or respawn while a kill/delete already owns the session.
+func TestResumeFromLimit_TeardownInFlightNoops(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, *Manager, string, *session.Instance)
+	}{
+		{
+			name: "optimistic killing op",
+			setup: func(_ *testing.T, _ *Manager, _ string, inst *session.Instance) {
+				inst.SetInFlightOp(session.OpKilling)
+			},
+		},
+		{
+			name: "manager kill in flight",
+			setup: func(_ *testing.T, manager *Manager, repoID string, inst *session.Instance) {
+				key := daemonInstanceKey(repoID, inst.Title)
+				manager.mu.Lock()
+				manager.killsInFlight[key] = struct{}{}
+				manager.mu.Unlock()
+			},
+		},
+		{
+			name: "op lock busy",
+			setup: func(t *testing.T, manager *Manager, repoID string, inst *session.Instance) {
+				key := daemonInstanceKey(repoID, inst.Title)
+				opLock := manager.opLockFor(key)
+				opLock.Lock()
+				t.Cleanup(opLock.Unlock)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager, repoID, repoPath := newStatusTestManager(t)
+			backend := &limitResumeBackend{FakeBackend: session.NewFakeBackend(), alive: true}
+			inst := registerStarted(t, manager, repoID, repoPath, "deleting-limit", backend, true, session.Running)
+			inst.Prompt = "finish the migration"
+			inst.SetLimitReached(time.Now())
+			tt.setup(t, manager, repoID, inst)
+
+			if err := manager.resumeFromLimit(ResumeFromLimitRequest{Title: inst.Title, RepoID: repoID}); err != nil {
+				t.Fatalf("resumeFromLimit returned %v, want nil no-op", err)
+			}
+
+			recoverCalls, respawnCalls, prompts := backend.snapshot()
+			if recoverCalls != 0 || respawnCalls != 0 || len(prompts) != 0 {
+				t.Fatalf("teardown no-op must not act: recover=%d respawn=%d prompts=%v", recoverCalls, respawnCalls, prompts)
+			}
+			if !inst.LimitReached() {
+				t.Fatal("teardown no-op must leave the limit state intact")
+			}
+		})
+	}
+}
+
 // TestResumeFromLimit_NotLimited_Errors: resuming a session that is not blocked
 // on a usage limit is rejected before any re-spawn or prompt delivery, so PR3's
 // scheduler and the manual retry can both call it without a pre-check racing the

--- a/daemon/limitresume.go
+++ b/daemon/limitresume.go
@@ -194,7 +194,7 @@ func (m *Manager) resumeLimitedSession(key, repoID string, inst *session.Instanc
 	// never a hot re-limit loop.
 	attempts, wait := m.limitResumeAttempted(st, now, hadReset, retryInterval)
 
-	if err := m.resumeFromLimit(ResumeFromLimitRequest{Title: inst.Title, RepoID: repoID}); err != nil {
+	if err := m.resumeFromLimitLocked(repoID, key, inst, inst.Title); err != nil {
 		log.WarningLog.Printf("auto-resume of limit-blocked session %q failed (attempt %d), backing off %s: %v", inst.Title, attempts, wait, err)
 		return
 	}


### PR DESCRIPTION
## Summary
- verified #1263 on current master: the TUI manual usage-limit retry dispatches even when the selected row is tearing down, and daemon `resumeFromLimit` did not share the kill op-lock guard used by auto-resume
- add a TUI `IsTearingDown` guard so pressing retry on a deleting limit row surfaces an error and does not dispatch the RPC
- guard daemon manual resume with `killsInFlight`, the per-session op lock, current-instance rechecks, and teardown-op checks
- split `resumeFromLimitLocked` so auto-resume can keep using its existing op-lock path without self-deadlocking/no-oping

## Tests
- `gofmt -w .`
- `go build ./...`
- `scripts/lint-file-length.sh`
- `golangci-lint run --fast`
- `deadcode -test ./...`
- `make test-container`

Closes #1263

Signed-off-by: Captain Claude <captain-claude@users.noreply.github.com>