### PR TITLE
Capture agent conversation IDs

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -123,9 +123,17 @@ func TestRedactInstanceDataKeepsStructuralDropsFreeText(t *testing.T) {
 		Status:  session.Status(1),
 		Program: "claude",
 		Tabs: []session.TabData{
-			{Name: "agent", Command: "claude --token sk-SUPERSECRETTOKEN0123456"},
+			{
+				Name:    "agent",
+				Command: "claude --token sk-SUPERSECRETTOKEN0123456",
+				Conversation: &session.AgentConversationData{
+					Agent: "claude",
+					ID:    "019f386f-7206-7fc2-803b-f7045e07a242",
+				},
+			},
 		},
-		PRInfo: session.PRInfoData{Number: 42, State: "open", Title: "secret pr title", URL: "https://example.com/pr/42"},
+		AgentConversation: &session.AgentConversationData{Agent: "claude", ID: "019f386f-7206-7fc2-803b-f7045e07a242"},
+		PRInfo:            session.PRInfoData{Number: 42, State: "open", Title: "secret pr title", URL: "https://example.com/pr/42"},
 		Worktree: session.GitWorktreeData{
 			RepoPath:      "/home/alice/Desktop/proj",
 			WorktreePath:  "/home/alice/Desktop/proj-fix",
@@ -141,6 +149,9 @@ func TestRedactInstanceDataKeepsStructuralDropsFreeText(t *testing.T) {
 	}
 	if d.Tabs[0].Command != redactedMarker {
 		t.Errorf("tab command not redacted: %q", d.Tabs[0].Command)
+	}
+	if d.Tabs[0].Conversation.ID != "" || d.AgentConversation.ID != "" {
+		t.Errorf("conversation ids not redacted: tab=%q instance=%q", d.Tabs[0].Conversation.ID, d.AgentConversation.ID)
 	}
 	if d.PRInfo.Title != redactedMarker || d.PRInfo.URL != redactedMarker {
 		t.Errorf("PR free-text not redacted: %+v", d.PRInfo)

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -231,6 +231,12 @@ func redactInstanceData(d *session.InstanceData) {
 		if d.Tabs[i].Command != "" {
 			d.Tabs[i].Command = redactedMarker
 		}
+		if d.Tabs[i].Conversation != nil {
+			d.Tabs[i].Conversation.ID = ""
+		}
+	}
+	if d.AgentConversation != nil {
+		d.AgentConversation.ID = ""
 	}
 	if d.PRInfo.Title != "" {
 		d.PRInfo.Title = redactedMarker

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1686,6 +1686,8 @@ func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData,
 		return session.InstanceData{}, err
 	}
 
+	conversationCapture := session.BeginConversationCapture()
+
 	// Single creation flow (#930 PR 3): every instance owns its worktree 1:1.
 	// InPlace only changes WHICH worktree that is — the repo's own working tree,
 	// marked external — not the flow itself. finishCreateStart marks the instance
@@ -1718,6 +1720,7 @@ func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData,
 		_ = instance.Kill()
 		return session.InstanceData{}, persistErr
 	}
+	m.captureAgentConversationAsync(repo.ID, key, instance, conversationCapture)
 
 	return data, nil
 }

--- a/daemon/conversation_capture.go
+++ b/daemon/conversation_capture.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+var conversationCaptureTimeout = 2 * time.Second
+
+func (m *Manager) captureAgentConversationAsync(repoID, key string, inst *session.Instance, snap session.ConversationCaptureSnapshot) {
+	go m.captureAgentConversation(repoID, key, inst, snap, conversationCaptureTimeout)
+}
+
+func (m *Manager) captureAgentConversation(repoID, key string, inst *session.Instance, snap session.ConversationCaptureSnapshot, timeout time.Duration) {
+	if inst == nil || inst.UserKilled() || inst.AgentConversation().HasID() {
+		return
+	}
+	agent := inst.ResolvedAgent()
+	if agent == "" {
+		return
+	}
+	conv, err := session.CaptureAgentConversation(agent, snap, timeout)
+	if err != nil {
+		log.WarningLog.Printf("conversation capture for %q failed: %v", inst.Title, err)
+		return
+	}
+	if !conv.HasID() {
+		return
+	}
+
+	m.mu.Lock()
+	current := m.instances[key]
+	m.mu.Unlock()
+	if current != inst || inst.UserKilled() {
+		return
+	}
+	if !inst.SetAgentConversation(conv) {
+		return
+	}
+
+	repoStartLock := m.startLockForRepo(repoID)
+	repoStartLock.Lock()
+	err = persistInstanceData(repoID, inst.ToInstanceData())
+	repoStartLock.Unlock()
+	if err != nil {
+		log.WarningLog.Printf("failed to persist conversation id for %q: %v", inst.Title, err)
+	}
+}

--- a/daemon/conversation_capture_test.go
+++ b/daemon/conversation_capture_test.go
@@ -1,0 +1,62 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/stretchr/testify/require"
+)
+
+func writeDaemonCodexRolloutFile(t *testing.T, codexHome, name string) {
+	t.Helper()
+	path := filepath.Join(codexHome, "sessions", "2026", "07", "06", name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, []byte(`{"type":"session_meta"}`+"\n"), 0644))
+}
+
+func TestCaptureAgentConversationPersistsCodexRolloutID(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	require.NoError(t, err)
+
+	manager, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "codex-worker",
+		Path:    repoPath,
+		Program: tmux.ProgramCodex,
+	})
+	require.NoError(t, err)
+	inst.SetTmuxSession(tmux.NewTmuxSession("codex-worker", tmux.ProgramCodex))
+	inst.SetStatus(session.Running)
+	key := daemonInstanceKey(repo.ID, inst.Title)
+	manager.mu.Lock()
+	manager.instances[key] = inst
+	manager.mu.Unlock()
+	require.NoError(t, appendInstanceData(repo.ID, inst.ToInstanceData()))
+
+	snap := session.BeginConversationCapture()
+	writeDaemonCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+
+	manager.captureAgentConversation(repo.ID, key, inst, snap, time.Second)
+
+	raw, err := config.LoadRepoInstances(repo.ID)
+	require.NoError(t, err)
+	var stored []session.InstanceData
+	require.NoError(t, json.Unmarshal(raw, &stored))
+	require.Len(t, stored, 1)
+	require.NotNil(t, stored[0].AgentConversation)
+	require.Equal(t, "019f386f-7206-7fc2-803b-f7045e07a242", stored[0].AgentConversation.ID)
+	require.Len(t, stored[0].Tabs, 1)
+	require.NotNil(t, stored[0].Tabs[0].Conversation)
+	require.Equal(t, stored[0].AgentConversation.ID, stored[0].Tabs[0].Conversation.ID)
+}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -212,8 +212,12 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 			return setupErr
 		}
 
-		// Inject Agent Factory instructions into the session.
-		tmuxSession.SetProgram(injectSystemPrompt(resolveProgramForInstance(i)))
+		// Inject Agent Factory instructions into the session. On a first launch
+		// only, seed provider conversation identity when a supported agent offers
+		// an explicit id flag; restore/respawn paths keep their existing latest-
+		// session behavior until PR2 wires resume-by-recorded-id.
+		program := prepareLaunchConversation(i, resolveProgramForInstance(i))
+		tmuxSession.SetProgram(injectSystemPrompt(program))
 
 		// Create new session
 		if err := tmuxSession.Start(gw.GetWorktreePath()); err != nil {

--- a/session/conversation.go
+++ b/session/conversation.go
@@ -1,0 +1,113 @@
+package session
+
+import (
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+const (
+	ConversationCaptureInjected     = "injected"
+	ConversationCaptureCodexRollout = "codex_rollout"
+)
+
+// AgentConversationData is the provider-specific conversation identity for a
+// tab. It is additive/rollforward data: older records simply have no
+// conversation object, and recovery falls back to the provider's latest-session
+// behavior until a new id is captured.
+type AgentConversationData struct {
+	Agent       string    `json:"agent,omitempty"`
+	ID          string    `json:"id,omitempty"`
+	CapturedAt  time.Time `json:"captured_at,omitempty"`
+	CaptureKind string    `json:"capture_kind,omitempty"`
+}
+
+func (c AgentConversationData) Empty() bool {
+	return strings.TrimSpace(c.Agent) == "" &&
+		strings.TrimSpace(c.ID) == "" &&
+		c.CapturedAt.IsZero() &&
+		strings.TrimSpace(c.CaptureKind) == ""
+}
+
+func (c AgentConversationData) HasID() bool {
+	return strings.TrimSpace(c.Agent) != "" && strings.TrimSpace(c.ID) != ""
+}
+
+func conversationDataPtr(c AgentConversationData) *AgentConversationData {
+	if c.Empty() {
+		return nil
+	}
+	cp := c
+	return &cp
+}
+
+// AgentConversation returns the Agent tab's recorded provider conversation, if
+// one has been captured.
+func (i *Instance) AgentConversation() AgentConversationData {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if len(i.Tabs) == 0 {
+		return AgentConversationData{}
+	}
+	return i.Tabs[0].Conversation
+}
+
+// SetAgentConversation records a provider conversation on the Agent tab.
+// Returns true when the in-memory value changed and should be persisted.
+func (i *Instance) SetAgentConversation(conv AgentConversationData) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.setAgentConversationLocked(conv)
+}
+
+func (i *Instance) setAgentConversationLocked(conv AgentConversationData) bool {
+	if len(i.Tabs) == 0 {
+		return false
+	}
+	if i.Tabs[0].Conversation == conv {
+		return false
+	}
+	i.Tabs[0].Conversation = conv
+	return true
+}
+
+// SetTabConversation records a provider conversation on a named tab. It is used
+// by daemon-owned post-spawn capture; tabs without a matching name are ignored
+// so a late capture racing with tab close degrades to a no-op.
+func (i *Instance) SetTabConversation(name string, conv AgentConversationData) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	for _, tab := range i.Tabs {
+		if tab.Name != name {
+			continue
+		}
+		if tab.Conversation == conv {
+			return false
+		}
+		tab.Conversation = conv
+		return true
+	}
+	return false
+}
+
+func prepareLaunchConversation(i *Instance, program string) string {
+	if tmux.DetectAgentFromCommand(program) != tmux.ProgramClaude {
+		return program
+	}
+	id := i.ID
+	if strings.TrimSpace(id) == "" {
+		id = newSessionID()
+	}
+	rewritten, injected := tmux.ClaudeProgramWithSessionID(program, id)
+	if !injected {
+		return program
+	}
+	i.SetAgentConversation(AgentConversationData{
+		Agent:       tmux.ProgramClaude,
+		ID:          id,
+		CapturedAt:  time.Now(),
+		CaptureKind: ConversationCaptureInjected,
+	})
+	return rewritten
+}

--- a/session/conversation_capture.go
+++ b/session/conversation_capture.go
@@ -1,0 +1,135 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+var codexRolloutFileRE = regexp.MustCompile(`(?i)^rollout-.+-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$`)
+
+// ConversationCaptureSnapshot records provider-local state before a pane is
+// spawned. It lets post-spawn capture identify a newly-created conversation
+// without reading transcript contents.
+type ConversationCaptureSnapshot struct {
+	startedAt   time.Time
+	codexHome   string
+	codexBefore map[string]struct{}
+}
+
+// BeginConversationCapture snapshots local provider transcript stores before
+// spawning a tab. Today only Codex exposes a local file id we can safely observe;
+// other providers degrade to their existing latest-session resume path unless a
+// deterministic id was injected before spawn (Claude).
+func BeginConversationCapture() ConversationCaptureSnapshot {
+	home := codexHomeDir()
+	return ConversationCaptureSnapshot{
+		startedAt:   time.Now(),
+		codexHome:   home,
+		codexBefore: codexRolloutFiles(home),
+	}
+}
+
+// CaptureAgentConversation waits until a supported provider exposes the
+// conversation id for a just-spawned tab. Unsupported providers return empty
+// data and nil error so callers gracefully keep existing --last/latest behavior.
+func CaptureAgentConversation(agent string, snap ConversationCaptureSnapshot, timeout time.Duration) (AgentConversationData, error) {
+	switch agent {
+	case tmux.ProgramCodex:
+		return captureCodexConversation(snap, timeout)
+	default:
+		return AgentConversationData{}, nil
+	}
+}
+
+func codexHomeDir() string {
+	if home := strings.TrimSpace(os.Getenv("CODEX_HOME")); home != "" {
+		return home
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".codex")
+	}
+	return ""
+}
+
+func captureCodexConversation(snap ConversationCaptureSnapshot, timeout time.Duration) (AgentConversationData, error) {
+	if snap.codexHome == "" {
+		return AgentConversationData{}, nil
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		conv, retry, err := captureCodexConversationOnce(snap)
+		if err != nil || conv.HasID() || !retry || timeout <= 0 || time.Now().After(deadline) {
+			return conv, err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func captureCodexConversationOnce(snap ConversationCaptureSnapshot) (AgentConversationData, bool, error) {
+	after := codexRolloutFiles(snap.codexHome)
+	var candidates []string
+	for path := range after {
+		if _, existed := snap.codexBefore[path]; existed {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err == nil && info.ModTime().Before(snap.startedAt.Add(-time.Second)) {
+			continue
+		}
+		if id := codexConversationIDFromPath(path); id != "" {
+			candidates = append(candidates, id)
+		}
+	}
+	switch len(candidates) {
+	case 0:
+		return AgentConversationData{}, true, nil
+	case 1:
+		return AgentConversationData{
+			Agent:       tmux.ProgramCodex,
+			ID:          candidates[0],
+			CapturedAt:  time.Now(),
+			CaptureKind: ConversationCaptureCodexRollout,
+		}, false, nil
+	default:
+		return AgentConversationData{}, false, fmt.Errorf("codex conversation capture ambiguous: %d new rollout files appeared", len(candidates))
+	}
+}
+
+func codexRolloutFiles(codexHome string) map[string]struct{} {
+	out := make(map[string]struct{})
+	if codexHome == "" {
+		return out
+	}
+	root := filepath.Join(codexHome, "sessions")
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if path == root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d == nil || d.IsDir() {
+			return nil
+		}
+		if codexConversationIDFromPath(path) == "" {
+			return nil
+		}
+		out[path] = struct{}{}
+		return nil
+	})
+	return out
+}
+
+func codexConversationIDFromPath(path string) string {
+	matches := codexRolloutFileRE.FindStringSubmatch(filepath.Base(path))
+	if len(matches) != 2 {
+		return ""
+	}
+	return strings.ToLower(matches[1])
+}

--- a/session/conversation_capture_test.go
+++ b/session/conversation_capture_test.go
@@ -1,0 +1,55 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/stretchr/testify/require"
+)
+
+func writeCodexRolloutFile(t *testing.T, codexHome, name string) string {
+	t.Helper()
+	path := filepath.Join(codexHome, "sessions", "2026", "07", "06", name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, []byte(`{"type":"session_meta"}`+"\n"), 0644))
+	return path
+}
+
+func TestCaptureAgentConversation_CodexRolloutFile(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	writeCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-33-aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa.jsonl")
+
+	snap := BeginConversationCapture()
+	writeCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+
+	conv, err := CaptureAgentConversation(tmux.ProgramCodex, snap, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, tmux.ProgramCodex, conv.Agent)
+	require.Equal(t, "019f386f-7206-7fc2-803b-f7045e07a242", conv.ID)
+	require.Equal(t, ConversationCaptureCodexRollout, conv.CaptureKind)
+	require.False(t, conv.CapturedAt.IsZero())
+}
+
+func TestCaptureAgentConversation_CodexAmbiguousConcurrentRollouts(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	snap := BeginConversationCapture()
+
+	writeCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-35-019f386f-7206-7fc2-803b-f7045e07a242.jsonl")
+	writeCodexRolloutFile(t, codexHome, "rollout-2026-07-06T10-17-36-019f386f-75b6-7f68-88e3-6d5e1f15bb6a.jsonl")
+
+	conv, err := CaptureAgentConversation(tmux.ProgramCodex, snap, time.Second)
+	require.Error(t, err)
+	require.False(t, conv.HasID(), "ambiguous capture must not guess a conversation id")
+}
+
+func TestCaptureAgentConversation_UnsupportedAgentGracefullyNoID(t *testing.T) {
+	snap := BeginConversationCapture()
+	conv, err := CaptureAgentConversation(tmux.ProgramGemini, snap, 0)
+	require.NoError(t, err)
+	require.False(t, conv.HasID())
+}

--- a/session/conversation_test.go
+++ b/session/conversation_test.go
@@ -1,0 +1,91 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversationDataRoundTrip(t *testing.T) {
+	capturedAt := time.Date(2026, 7, 6, 10, 17, 35, 0, time.UTC)
+	data := InstanceData{
+		Title:   "worker",
+		Path:    "/tmp/repo",
+		Program: tmux.ProgramCodex,
+		Tabs: []TabData{
+			{
+				Name: "agent",
+				Kind: TabKindAgent,
+				Conversation: &AgentConversationData{
+					Agent:       tmux.ProgramCodex,
+					ID:          "019f386f-7206-7fc2-803b-f7045e07a242",
+					CapturedAt:  capturedAt,
+					CaptureKind: ConversationCaptureCodexRollout,
+				},
+			},
+		},
+		AgentConversation: &AgentConversationData{
+			Agent:       tmux.ProgramCodex,
+			ID:          "019f386f-7206-7fc2-803b-f7045e07a242",
+			CapturedAt:  capturedAt,
+			CaptureKind: ConversationCaptureCodexRollout,
+		},
+	}
+
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), `"agent_conversation"`)
+	require.Contains(t, string(raw), `"conversation"`)
+
+	var restored InstanceData
+	require.NoError(t, json.Unmarshal(raw, &restored))
+	require.NotNil(t, restored.AgentConversation)
+	require.Equal(t, "019f386f-7206-7fc2-803b-f7045e07a242", restored.AgentConversation.ID)
+	require.Len(t, restored.Tabs, 1)
+	require.NotNil(t, restored.Tabs[0].Conversation)
+	require.Equal(t, ConversationCaptureCodexRollout, restored.Tabs[0].Conversation.CaptureKind)
+}
+
+func TestConversationDataOmittedWhenEmpty(t *testing.T) {
+	raw, err := json.Marshal(InstanceData{
+		Title:   "worker",
+		Path:    "/tmp/repo",
+		Program: tmux.ProgramCodex,
+		Tabs:    []TabData{{Name: "agent", Kind: TabKindAgent}},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), "agent_conversation")
+	require.NotContains(t, string(raw), "conversation")
+}
+
+func TestRestoreLocalTabsFallsBackToInstanceConversation(t *testing.T) {
+	conv := &AgentConversationData{Agent: tmux.ProgramClaude, ID: "019f386f-7206-7fc2-803b-f7045e07a242"}
+	inst := &Instance{}
+
+	restoreLocalTabs(inst, InstanceData{
+		Title:             "legacy",
+		Program:           tmux.ProgramClaude,
+		AgentConversation: conv,
+		Tabs:              []TabData{{Name: "agent", Kind: TabKindAgent, TmuxName: "af_legacy_agent"}},
+	})
+
+	require.Equal(t, *conv, inst.AgentConversation())
+}
+
+func TestPrepareLaunchConversationSeedsClaudeSessionID(t *testing.T) {
+	const id = "019f386f-7206-7fc2-803b-f7045e07a242"
+	inst := &Instance{ID: id, Title: "worker"}
+	inst.SetTmuxSession(tmux.NewTmuxSession("worker", tmux.ProgramClaude))
+
+	got := prepareLaunchConversation(inst, "claude --model sonnet")
+
+	require.Equal(t, "claude --model sonnet --session-id "+id, got)
+	conv := inst.AgentConversation()
+	require.Equal(t, tmux.ProgramClaude, conv.Agent)
+	require.Equal(t, id, conv.ID)
+	require.Equal(t, ConversationCaptureInjected, conv.CaptureKind)
+	require.False(t, conv.CapturedAt.IsZero())
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -608,6 +608,7 @@ func (i *Instance) ToInstanceData() InstanceData {
 		if tab.tmux != nil {
 			td.TmuxName = tab.tmux.SanitizedName()
 		}
+		td.Conversation = conversationDataPtr(tab.Conversation)
 		data.Tabs = append(data.Tabs, td)
 	}
 
@@ -616,6 +617,9 @@ func (i *Instance) ToInstanceData() InstanceData {
 	// agent session by its exact name, and old readers ignore the new Tabs list.
 	if ts := i.tmuxLocked(); ts != nil {
 		data.TmuxName = ts.SanitizedName()
+	}
+	if len(i.Tabs) > 0 {
+		data.AgentConversation = conversationDataPtr(i.Tabs[0].Conversation)
 	}
 
 	// Only include worktree data if gitWorktree is initialized
@@ -773,17 +777,24 @@ var restoreTmuxSession = tmux.NewTmuxSessionFromSanitizedName
 //     No shell tab is synthesized: terminal tabs are on-demand only (#1100).
 func restoreLocalTabs(instance *Instance, data InstanceData) {
 	if len(data.Tabs) > 0 {
-		for _, td := range data.Tabs {
+		for idx, td := range data.Tabs {
 			kind := tabKindForData(td.Kind)
 			var ts *tmux.TmuxSession
 			if td.TmuxName != "" {
 				ts = restoreTmuxSession(td.TmuxName, tabProgram(kind, td.Command, data.Program))
 			}
+			var conversation AgentConversationData
+			if td.Conversation != nil {
+				conversation = *td.Conversation
+			} else if idx == 0 && data.AgentConversation != nil {
+				conversation = *data.AgentConversation
+			}
 			instance.Tabs = append(instance.Tabs, &Tab{
-				Name:    td.Name,
-				Kind:    kind,
-				Command: td.Command,
-				tmux:    ts,
+				Name:         td.Name,
+				Kind:         kind,
+				Command:      td.Command,
+				Conversation: conversation,
+				tmux:         ts,
 			})
 		}
 		return
@@ -794,6 +805,9 @@ func restoreLocalTabs(instance *Instance, data InstanceData) {
 		instance.setTmuxLocked(restoreTmuxSession(data.TmuxName, data.Program))
 	} else {
 		instance.setTmuxLocked(tmux.NewTmuxSession(data.Title, data.Program))
+	}
+	if data.AgentConversation != nil {
+		instance.SetAgentConversation(*data.AgentConversation)
 	}
 }
 

--- a/session/storage.go
+++ b/session/storage.go
@@ -46,13 +46,16 @@ type InstanceData struct {
 	// Manager.KillSession before teardown begins. Present only in the crash
 	// window between tombstone write and record deletion — a surviving
 	// tombstoned record means "finish this kill", never "restore this".
-	UserKilled  bool                   `json:"user_killed,omitempty"`
-	TmuxName    string                 `json:"tmux_name,omitempty"`
-	Tabs        []TabData              `json:"tabs,omitempty"`
-	Worktree    GitWorktreeData        `json:"worktree"`
-	PRInfo      PRInfoData             `json:"pr_info,omitempty"`
-	BackendType string                 `json:"backend_type,omitempty"`
-	RemoteMeta  map[string]interface{} `json:"remote_meta,omitempty"`
+	UserKilled bool      `json:"user_killed,omitempty"`
+	TmuxName   string    `json:"tmux_name,omitempty"`
+	Tabs       []TabData `json:"tabs,omitempty"`
+	// AgentConversation mirrors the Agent tab's provider conversation id for
+	// API/CLI consumers. The per-tab source of truth is TabData.Conversation.
+	AgentConversation *AgentConversationData `json:"agent_conversation,omitempty"`
+	Worktree          GitWorktreeData        `json:"worktree"`
+	PRInfo            PRInfoData             `json:"pr_info,omitempty"`
+	BackendType       string                 `json:"backend_type,omitempty"`
+	RemoteMeta        map[string]interface{} `json:"remote_meta,omitempty"`
 }
 
 // TabData is the serializable form of a session.Tab. The full list is persisted
@@ -66,6 +69,10 @@ type TabData struct {
 	Kind     TabKind `json:"kind"`
 	Command  string  `json:"command,omitempty"`
 	TmuxName string  `json:"tmux_name,omitempty"`
+	// Conversation is the provider-specific conversation id for this tab, when
+	// the underlying agent exposes a durable resume id. Omitted for legacy rows
+	// and providers where af can only resume "latest".
+	Conversation *AgentConversationData `json:"conversation,omitempty"`
 }
 
 // PRInfoData represents the serializable data of a PRInfo

--- a/session/tab.go
+++ b/session/tab.go
@@ -54,6 +54,10 @@ type Tab struct {
 	// Command is the process to run; empty means the kind's default. Unused in
 	// PR 1 — the agent program is still resolved by the local backend.
 	Command string
+	// Conversation is the provider-specific id that resumes this tab's agent
+	// conversation exactly. Empty means recovery falls back to the provider's
+	// existing latest-session behavior.
+	Conversation AgentConversationData
 	// tmux is the tab's tmux session. nil until the instance is started, and
 	// always nil for remote/hook-backed instances, which drive their agent
 	// session through hook commands rather than a local tmux session.

--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -101,6 +101,30 @@ func resumeProgram(program string) string {
 	return program
 }
 
+// ClaudeProgramWithSessionID appends Claude Code's explicit conversation id flag
+// to a first-launch program string. It preserves the original program verbatim
+// except for the appended tokens and refuses to inject when the Claude command
+// already carries a resume/continue/session-id flag.
+func ClaudeProgramWithSessionID(program, sessionID string) (string, bool) {
+	if strings.TrimSpace(sessionID) == "" {
+		return program, false
+	}
+	tokens, _ := splitShellTokens(program)
+	agentIdx, agent := findAgentToken(tokens)
+	if agent != ProgramClaude {
+		return program, false
+	}
+	for _, tok := range tokens[agentIdx+1:] {
+		if tok == "-c" || tok == "--continue" || tok == "-r" || tok == "--resume" ||
+			strings.HasPrefix(tok, "--resume=") || strings.HasPrefix(tok, "-r=") ||
+			isShortResumeWithAttachedValue(tok) ||
+			tok == "--session-id" || strings.HasPrefix(tok, "--session-id=") {
+			return program, false
+		}
+	}
+	return program + " --session-id " + sessionID, true
+}
+
 // DetectAgentFromCommand returns the canonical agent name (one of
 // SupportedPrograms) that a resolved command string will actually run, or ""
 // when no agent token is present — e.g. a program_overrides entry that points

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -341,6 +341,38 @@ func TestResumeProgram_QuotedCodexPath(t *testing.T) {
 	require.Equal(t, "'/path with space/codex' resume --last --model gpt-5", got)
 }
 
+func TestClaudeProgramWithSessionID(t *testing.T) {
+	const id = "019f386f-7206-7fc2-803b-f7045e07a242"
+	cases := []struct {
+		name     string
+		in       string
+		want     string
+		injected bool
+	}{
+		{"bare", "claude", "claude --session-id " + id, true},
+		{"with flag", "claude --model sonnet", "claude --model sonnet --session-id " + id, true},
+		{"wrapper", "ionice -c 3 claude", "ionice -c 3 claude --session-id " + id, true},
+		{"quoted path", "'/Applications/Claude Code.app/Contents/MacOS/claude' --foo", "'/Applications/Claude Code.app/Contents/MacOS/claude' --foo --session-id " + id, true},
+		{"already session id", "claude --session-id abc", "claude --session-id abc", false},
+		{"already session id equals", "claude --session-id=abc", "claude --session-id=abc", false},
+		{"already resume", "claude --resume abc", "claude --resume abc", false},
+		{"already continue", "claude --continue", "claude --continue", false},
+		{"unknown", "mytool --foo", "mytool --foo", false},
+		{"empty id", "claude", "claude", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID := id
+			if tc.name == "empty id" {
+				gotID = ""
+			}
+			got, injected := ClaudeProgramWithSessionID(tc.in, gotID)
+			require.Equal(t, tc.want, got)
+			require.Equal(t, tc.injected, injected)
+		})
+	}
+}
+
 // TestResumeProgram_CodexProfileResumeFalsePositive guards #632: the codex
 // "already has resume" check must be position-aware. A profile named "resume"
 // (or any other flag value of "resume") must not be mistaken for the resume


### PR DESCRIPTION
## Summary
- Add rollforward-additive, daemon-owned conversation metadata on instances and tabs, with legacy top-level fallback for the agent tab.
- Capture Claude conversations deterministically by injecting `--session-id` on first launch and persisting that ID.
- Capture Codex conversation IDs by snapshotting `CODEX_HOME`/`~/.codex` rollout files around spawn, accepting exactly one new rollout and refusing ambiguous concurrent captures.
- Keep unsupported providers on the graceful no-ID path so existing fallback behavior remains available for later recovery PRs.

## Verification
- `gofmt -w .`
- `go build ./...`
- `make test-container`
- `golangci-lint run --fast`
- `scripts/lint-file-length.sh`
- `deadcode -test ./...`
- `go test ./daemon ./session ./session/tmux ./bugreport`
- `git diff --check`

No TUI driver or playtest driver was run, per #1303 safety guidance.

Refs #1300
