### PR TITLE
Fix limit-reached search overlay mouse clicks

### DIFF
--- a/ui/overlay/zones.go
+++ b/ui/overlay/zones.go
@@ -126,7 +126,7 @@ func (s *SearchOverlay) RegisterZones(reg *zones.Registry, origin layout.Point) 
 func searchRowTitle(line string) (string, bool) {
 	t := strings.Trim(xansi.Strip(line), "│ ")
 	r, size := utf8.DecodeRuneInString(t)
-	if r != '●' && r != '○' && r != '◌' {
+	if r != '●' && r != '○' && r != '◌' && r != '◆' {
 		return "", false
 	}
 	t = strings.TrimLeft(t[size:], " ")

--- a/ui/overlay/zones_test.go
+++ b/ui/overlay/zones_test.go
@@ -143,6 +143,21 @@ func TestSearchOverlayRegistersRowZonesAndSetSelectedIndex(t *testing.T) {
 	assert.Same(t, instances[0], s2.GetSelectedInstance())
 }
 
+func TestSearchOverlayRegistersLimitReachedRowZone(t *testing.T) {
+	inst := &session.Instance{Title: "blocked-session"}
+	inst.SetLiveness(session.LiveLimitReached)
+	s := NewSearchOverlay([]*session.Instance{inst})
+	reg := zones.NewRegistry()
+
+	s.RegisterZones(reg, layout.Point{})
+
+	r, ok := reg.Find(zones.OverlaySearchRow(0))
+	require.True(t, ok, "limit-reached search rows must stay mouse-clickable")
+	line := strings.Split(s.Render(), "\n")[r.Y]
+	assert.Contains(t, xansi.Strip(line), "◆", "test must exercise the limit glyph")
+	assert.Contains(t, xansi.Strip(line), inst.Title)
+}
+
 // TestSearchOverlayScrolledWindowRegistersVisibleRows pins the Greptile P1 on
 // the original mouse PR (#1086): once the selection scrolls past the first
 // page, Render windows the results — and the registered zones must be the


### PR DESCRIPTION
## Summary
- recognize the limit-reached diamond glyph when registering search overlay mouse zones
- add a regression test proving limit-reached search rows remain clickable

## Verification
- `gofmt -l $(rg --files -g'*.go')`
- `scripts/lint-file-length.sh`
- `go build ./...`
- `golangci-lint run --fast`
- `make test-container`

Closes #1258

Signed as Captain Claude.