### PR TITLE
feat(session): lifecycle transition() chokepoint + allowed-edge table, inert (#1195 Phase 2c)

### DIFF
--- a/session/transition.go
+++ b/session/transition.go
@@ -130,6 +130,20 @@ type stateAxes struct {
 	op       InFlightOp
 }
 
+// startedEffect is a transition's effect on the started flag: most transitions
+// leave it to the teardown/spawn machinery, but two own it — CommitArchive
+// clears it (the inert Archived state has no tmux behind it) and BeginRestore
+// sets it (mirroring RestoreFromArchive, whose head flips started=true before
+// Recover so the re-spawn is eligible — Recover's !Started() gate would
+// otherwise short-circuit and the restore would silently never start).
+type startedEffect int
+
+const (
+	startedUnchanged startedEffect = iota
+	startedSet                     // started = true (BeginRestore)
+	startedClear                   // started = false (CommitArchive)
+)
+
 // edgeSpec is one row of the allowed-edge table: which from-states an event is
 // legal from, the resulting state, and the event's side effects.
 type edgeSpec struct {
@@ -137,9 +151,9 @@ type edgeSpec struct {
 	allowedFrom func(s stateAxes) bool
 	// target computes the resulting state (ev carries ObserveLiveness's lv).
 	target func(s stateAxes, ev TransitionEvent) stateAxes
-	// clearsStarted marks whether the transition also sets started=false
-	// (CommitArchive: the inert Archived state has no tmux behind it).
-	clearsStarted bool
+	// started is the transition's effect on the started flag (default: leave it
+	// to the teardown/spawn machinery).
+	started startedEffect
 	// yieldWhenBlocked makes an out-of-set from-state a silent no-op instead of a
 	// rejection — for the daemon-truth edge (ObserveLiveness is always allowed)
 	// and ConfirmLive (yields to an in-flight teardown rather than fighting it).
@@ -182,9 +196,9 @@ var transitionTable = map[transitionKind]edgeSpec{
 		target: func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpArchiving} },
 	},
 	tkCommitArchive: {
-		allowedFrom:   func(s stateAxes) bool { return s.op == OpArchiving },
-		target:        func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveArchived, OpNone} },
-		clearsStarted: true,
+		allowedFrom: func(s stateAxes) bool { return s.op == OpArchiving },
+		target:      func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveArchived, OpNone} },
+		started:     startedClear,
 	},
 	tkAbortArchiveToLost: {
 		allowedFrom: func(s stateAxes) bool { return s.op == OpArchiving },
@@ -193,6 +207,9 @@ var transitionTable = map[transitionKind]edgeSpec{
 	tkBeginRestore: {
 		allowedFrom: func(s stateAxes) bool { return s.op == OpNone && s.liveness == LiveArchived },
 		target:      func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveLost, OpRestoring} },
+		// started=true mirrors RestoreFromArchive: Recover's !Started() gate would
+		// otherwise short-circuit and the restore would never start (Greptile #1314).
+		started: startedSet,
 	},
 	tkAbortRestoreToLost: {
 		allowedFrom: func(s stateAxes) bool { return s.op == OpRestoring && s.liveness == LiveLost },
@@ -237,7 +254,10 @@ func (i *Instance) Transition(ev TransitionEvent) error {
 	to := spec.target(from, ev)
 	i.liveness = to.liveness
 	i.inFlightOp = to.op
-	if spec.clearsStarted {
+	switch spec.started {
+	case startedSet:
+		i.started = true
+	case startedClear:
 		i.started = false
 	}
 	return nil

--- a/session/transition.go
+++ b/session/transition.go
@@ -1,0 +1,295 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+)
+
+// The lifecycle transition chokepoint (#1195 Phase 2c).
+//
+// Phase 1 split the session state into two axes — liveness (daemon-owned health)
+// and inFlightOp (client-owned operation) — but the ~15 writers still poke those
+// fields through a scatter of setters (SetLiveness, SetInFlightOp, MarkLive,
+// SetArchived, RestoreFromArchive, …) with NO transition table: the ordering
+// invariants that keep the lifecycle sound are enforced only by convention at
+// the call sites. Transition makes them structural — a single validated
+// chokepoint every writer routes through — so an illegal or mis-ordered
+// transition is caught by the edge table instead of silently corrupting state.
+//
+// The four ordering invariants it enforces (audit item #6):
+//   - I1 tombstone-before-kill: a kill may not begin unless the kill-intent
+//     tombstone is recorded — otherwise a crash mid-teardown reclassifies the
+//     session Lost and resurrects it.
+//   - I2 move-before-Archived: the inert Archived state is reachable ONLY out of
+//     the archive fence, which is only entered after the worktree move ran.
+//   - I3 move-before-respawn: a restore may begin only from Archived, and the
+//     daemon moves the worktree back before entering the restore fence.
+//   - I4 fence-brackets-archive: Archived/Lost is reachable from an archive only
+//     through the OpArchiving fence, so the poll/tab-spawn skip the whole window.
+//
+// Phase 2c lands this INERT: the API + table + tests, with no call-site
+// migration. Phase 2d migrates the daemon/app writers onto it and deletes the
+// ad-hoc guards; Phase 2e retires the direct setters.
+
+// transitionKind enumerates the lifecycle events Transition accepts. Each maps
+// to exactly one guarded edge (family) in transitionTable.
+type transitionKind int
+
+const (
+	tkBeginCreate transitionKind = iota
+	tkConfirmLive
+	tkObserveLiveness
+	tkBeginKill
+	tkRevertKill
+	tkBeginArchive
+	tkCommitArchive
+	tkAbortArchiveToLost
+	tkBeginRestore
+	tkAbortRestoreToLost
+	numTransitionKinds
+)
+
+func (k transitionKind) String() string {
+	switch k {
+	case tkBeginCreate:
+		return "BeginCreate"
+	case tkConfirmLive:
+		return "ConfirmLive"
+	case tkObserveLiveness:
+		return "ObserveLiveness"
+	case tkBeginKill:
+		return "BeginKill"
+	case tkRevertKill:
+		return "RevertKill"
+	case tkBeginArchive:
+		return "BeginArchive"
+	case tkCommitArchive:
+		return "CommitArchive"
+	case tkAbortArchiveToLost:
+		return "AbortArchiveToLost"
+	case tkBeginRestore:
+		return "BeginRestore"
+	case tkAbortRestoreToLost:
+		return "AbortRestoreToLost"
+	}
+	return fmt.Sprintf("transitionKind(%d)", int(k))
+}
+
+// TransitionEvent is a lifecycle event handed to Instance.Transition. Construct
+// one with the exported constructors below; lv is meaningful only for
+// ObserveLiveness.
+type TransitionEvent struct {
+	kind transitionKind
+	lv   Liveness
+}
+
+// BeginCreate overlays OpCreating for an optimistic create (was SetStatus(Loading)).
+func BeginCreate() TransitionEvent { return TransitionEvent{kind: tkBeginCreate} }
+
+// ConfirmLive marks a completed create/recover live — Running, op cleared (was
+// MarkLive). It YIELDS (no-op) when a kill/archive op is in flight, so a
+// completing spawn never resurrects a session a teardown owns.
+func ConfirmLive() TransitionEvent { return TransitionEvent{kind: tkConfirmLive} }
+
+// ObserveLiveness applies the daemon's authoritative liveness (was SetLiveness).
+// It is the unconditional daemon-truth edge: it sets liveness and preserves the
+// op axis, and never rejects — which is what keeps the #1187 strand impossible.
+func ObserveLiveness(lv Liveness) TransitionEvent {
+	return TransitionEvent{kind: tkObserveLiveness, lv: lv}
+}
+
+// BeginKill overlays OpKilling for an optimistic kill. Requires the kill-intent
+// tombstone already recorded (I1).
+func BeginKill() TransitionEvent { return TransitionEvent{kind: tkBeginKill} }
+
+// RevertKill clears an optimistic kill overlay (kill aborted / reverted).
+func RevertKill() TransitionEvent { return TransitionEvent{kind: tkRevertKill} }
+
+// BeginArchive raises the OpArchiving fence over an archive teardown+move (I4).
+func BeginArchive() TransitionEvent { return TransitionEvent{kind: tkBeginArchive} }
+
+// CommitArchive flips the session to the inert Archived state, started=false, on
+// a successful archive move (was SetArchived). Reachable only from the fence (I2).
+func CommitArchive() TransitionEvent { return TransitionEvent{kind: tkCommitArchive} }
+
+// AbortArchiveToLost rolls a failed archive move back to Lost so the restore
+// loop heals the agent in place.
+func AbortArchiveToLost() TransitionEvent { return TransitionEvent{kind: tkAbortArchiveToLost} }
+
+// BeginRestore enters the restore fence for an archived session (I3): Lost +
+// OpRestoring (replaces RestoreFromArchive's "park in Lost" head).
+func BeginRestore() TransitionEvent { return TransitionEvent{kind: tkBeginRestore} }
+
+// AbortRestoreToLost drops a failed restore's fence to a plain Lost so the
+// #1108 loop retries against the now-restored worktree.
+func AbortRestoreToLost() TransitionEvent { return TransitionEvent{kind: tkAbortRestoreToLost} }
+
+// stateAxes is the two-axis lifecycle state a transition reads and writes.
+type stateAxes struct {
+	liveness Liveness
+	op       InFlightOp
+}
+
+// edgeSpec is one row of the allowed-edge table: which from-states an event is
+// legal from, the resulting state, and the event's side effects.
+type edgeSpec struct {
+	// allowedFrom reports whether the event is legal from state s.
+	allowedFrom func(s stateAxes) bool
+	// target computes the resulting state (ev carries ObserveLiveness's lv).
+	target func(s stateAxes, ev TransitionEvent) stateAxes
+	// clearsStarted marks whether the transition also sets started=false
+	// (CommitArchive: the inert Archived state has no tmux behind it).
+	clearsStarted bool
+	// yieldWhenBlocked makes an out-of-set from-state a silent no-op instead of a
+	// rejection — for the daemon-truth edge (ObserveLiveness is always allowed)
+	// and ConfirmLive (yields to an in-flight teardown rather than fighting it).
+	yieldWhenBlocked bool
+	// requiresTombstone gates BeginKill on a recorded kill intent (I1).
+	requiresTombstone bool
+}
+
+// transitionTable is the allowed-edge table — the single declarative source of
+// truth for which (liveness, op) → (liveness, op) transitions are legal. Every
+// enforcement of I1–I4 lives here as a from-state predicate, not as a guard
+// scattered across the daemon/app call sites.
+var transitionTable = map[transitionKind]edgeSpec{
+	tkBeginCreate: {
+		allowedFrom: func(s stateAxes) bool { return s.op == OpNone },
+		target:      func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpCreating} },
+	},
+	tkConfirmLive: {
+		allowedFrom:      func(s stateAxes) bool { return s.op == OpNone || s.op == OpCreating || s.op == OpRestoring },
+		target:           func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveRunning, OpNone} },
+		yieldWhenBlocked: true,
+	},
+	tkObserveLiveness: {
+		allowedFrom: func(stateAxes) bool { return true },
+		target:      func(s stateAxes, ev TransitionEvent) stateAxes { return stateAxes{ev.lv, s.op} },
+	},
+	tkBeginKill: {
+		allowedFrom:       func(s stateAxes) bool { return s.op == OpNone },
+		target:            func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpKilling} },
+		requiresTombstone: true,
+	},
+	tkRevertKill: {
+		allowedFrom: func(s stateAxes) bool { return s.op == OpKilling },
+		target:      func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpNone} },
+	},
+	tkBeginArchive: {
+		allowedFrom: func(s stateAxes) bool {
+			return s.op == OpNone && (s.liveness == LiveRunning || s.liveness == LiveReady)
+		},
+		target: func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpArchiving} },
+	},
+	tkCommitArchive: {
+		allowedFrom:   func(s stateAxes) bool { return s.op == OpArchiving },
+		target:        func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveArchived, OpNone} },
+		clearsStarted: true,
+	},
+	tkAbortArchiveToLost: {
+		allowedFrom: func(s stateAxes) bool { return s.op == OpArchiving },
+		target:      func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveLost, OpNone} },
+	},
+	tkBeginRestore: {
+		allowedFrom: func(s stateAxes) bool { return s.op == OpNone && s.liveness == LiveArchived },
+		target:      func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveLost, OpRestoring} },
+	},
+	tkAbortRestoreToLost: {
+		allowedFrom: func(s stateAxes) bool { return s.op == OpRestoring && s.liveness == LiveLost },
+		target:      func(stateAxes, TransitionEvent) stateAxes { return stateAxes{LiveLost, OpNone} },
+	},
+}
+
+// onIllegalTransition, when non-nil, is invoked with the rejection message
+// before Transition returns the soft error. Test builds install a panicking hook
+// (an illegal, mis-ordered transition must be a loud red failure, never a silent
+// prod corruption); production leaves it nil and degrades to the soft error — a
+// user's daemon must not crash on a racing double-archive. Keeps `testing` out
+// of the production binary.
+var onIllegalTransition func(msg string)
+
+// Transition applies a lifecycle event to the two-axis (liveness, inFlightOp)
+// state under i.mu, validating it against the allowed-edge table. It is the
+// single writer-side chokepoint for lifecycle-state changes (#1195 Phase 2c) and
+// the enforcement point for the I1–I4 ordering invariants. An illegal edge
+// returns an error AND fires onIllegalTransition (panic in test builds); a
+// yielding edge (ObserveLiveness always, ConfirmLive under a teardown op) that
+// is out-of-set is a silent no-op. INERT until Phase 2d migrates the writers.
+func (i *Instance) Transition(ev TransitionEvent) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	from := stateAxes{i.liveness, i.inFlightOp}
+	spec, ok := transitionTable[ev.kind]
+	if !ok {
+		return i.rejectTransitionLocked(ev, from, "unknown event")
+	}
+	if !spec.allowedFrom(from) {
+		if spec.yieldWhenBlocked {
+			return nil
+		}
+		return i.rejectTransitionLocked(ev, from, "edge not allowed from this state")
+	}
+	if spec.requiresTombstone && !i.userKilled {
+		return i.rejectTransitionLocked(ev, from, "kill without a recorded tombstone (I1)")
+	}
+
+	to := spec.target(from, ev)
+	i.liveness = to.liveness
+	i.inFlightOp = to.op
+	if spec.clearsStarted {
+		i.started = false
+	}
+	return nil
+}
+
+// rejectTransitionLocked builds the rejection error, fires the illegal-transition
+// hook (panic in test), and returns the soft error. Caller holds i.mu; nothing
+// is mutated, so a rejected transition leaves the state untouched.
+func (i *Instance) rejectTransitionLocked(ev TransitionEvent, from stateAxes, why string) error {
+	msg := fmt.Sprintf("illegal session transition %s from (liveness=%s, op=%s): %s",
+		ev.kind, livenessLabel(from.liveness), opLabel(from.op), why)
+	if onIllegalTransition != nil {
+		onIllegalTransition(msg)
+	}
+	return errors.New(msg)
+}
+
+// livenessLabel / opLabel render the axes for transition error messages without
+// adding String() methods to the axis types (which would change %v formatting
+// elsewhere, e.g. in existing status logs).
+func livenessLabel(lv Liveness) string {
+	switch lv {
+	case LivenessUnset:
+		return "Unset"
+	case LiveRunning:
+		return "Running"
+	case LiveReady:
+		return "Ready"
+	case LiveLost:
+		return "Lost"
+	case LiveDead:
+		return "Dead"
+	case LiveArchived:
+		return "Archived"
+	case LiveLimitReached:
+		return "LimitReached"
+	}
+	return fmt.Sprintf("Liveness(%d)", int(lv))
+}
+
+func opLabel(op InFlightOp) string {
+	switch op {
+	case OpNone:
+		return "None"
+	case OpCreating:
+		return "Creating"
+	case OpKilling:
+		return "Killing"
+	case OpArchiving:
+		return "Archiving"
+	case OpRestoring:
+		return "Restoring"
+	}
+	return fmt.Sprintf("InFlightOp(%d)", int(op))
+}

--- a/session/transition_test.go
+++ b/session/transition_test.go
@@ -1,0 +1,130 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The session test binary panics on illegal transitions (#1195 Phase 2c): a
+// mis-ordered lifecycle transition must be a loud red failure in tests.
+// Production leaves the hook nil (soft error only). Tests that assert the
+// soft-error prod path swap it out via swapIllegalHook.
+func init() {
+	onIllegalTransition = func(msg string) { panic(msg) }
+}
+
+// swapIllegalHook temporarily replaces the illegal-transition hook for one test
+// and restores it on cleanup.
+func swapIllegalHook(t *testing.T, h func(string)) {
+	t.Helper()
+	prev := onIllegalTransition
+	onIllegalTransition = h
+	t.Cleanup(func() { onIllegalTransition = prev })
+}
+
+// TestTransitionTable_EveryKindHasSpec is the table-exhaustiveness guard: every
+// transitionKind must have a fully-populated edge spec. A new event added
+// without a table row fails here instead of silently no-op'ing at runtime.
+func TestTransitionTable_EveryKindHasSpec(t *testing.T) {
+	for k := transitionKind(0); k < numTransitionKinds; k++ {
+		spec, ok := transitionTable[k]
+		require.Truef(t, ok, "transition kind %s has no table entry", k)
+		require.NotNilf(t, spec.allowedFrom, "transition kind %s: nil allowedFrom", k)
+		require.NotNilf(t, spec.target, "transition kind %s: nil target", k)
+	}
+}
+
+// TestTransition_LegalEdgesApply drives one canonical legal transition per event
+// (so every event constructor + table row is exercised) and asserts the
+// resulting (liveness, op, started).
+func TestTransition_LegalEdgesApply(t *testing.T) {
+	cases := []struct {
+		name        string
+		from        stateAxes
+		started     bool
+		userKilled  bool
+		ev          TransitionEvent
+		wantL       Liveness
+		wantOp      InFlightOp
+		wantStarted bool
+	}{
+		{"BeginCreate", stateAxes{LiveReady, OpNone}, true, false, BeginCreate(), LiveReady, OpCreating, true},
+		{"ConfirmLive from creating", stateAxes{LiveReady, OpCreating}, true, false, ConfirmLive(), LiveRunning, OpNone, true},
+		{"ConfirmLive from restoring", stateAxes{LiveLost, OpRestoring}, true, false, ConfirmLive(), LiveRunning, OpNone, true},
+		// ConfirmLive YIELDS to a teardown op: a completing spawn must not
+		// resurrect a session a kill/archive owns — no-op, no error.
+		{"ConfirmLive yields to killing", stateAxes{LiveRunning, OpKilling}, true, false, ConfirmLive(), LiveRunning, OpKilling, true},
+		{"ConfirmLive yields to archiving", stateAxes{LiveRunning, OpArchiving}, true, false, ConfirmLive(), LiveRunning, OpArchiving, true},
+		// ObserveLiveness is unconditional truth: sets liveness, PRESERVES the op
+		// fence (a mid-archive row still receives the terminal liveness — #1187).
+		{"ObserveLiveness sets liveness, keeps op", stateAxes{LiveRunning, OpArchiving}, true, false, ObserveLiveness(LiveLost), LiveLost, OpArchiving, true},
+		{"ObserveLiveness on idle row", stateAxes{LiveRunning, OpNone}, true, false, ObserveLiveness(LiveReady), LiveReady, OpNone, true},
+		{"BeginKill with tombstone", stateAxes{LiveRunning, OpNone}, true, true, BeginKill(), LiveRunning, OpKilling, true},
+		{"RevertKill", stateAxes{LiveRunning, OpKilling}, true, false, RevertKill(), LiveRunning, OpNone, true},
+		{"BeginArchive from Ready", stateAxes{LiveReady, OpNone}, true, false, BeginArchive(), LiveReady, OpArchiving, true},
+		{"BeginArchive from Running", stateAxes{LiveRunning, OpNone}, true, false, BeginArchive(), LiveRunning, OpArchiving, true},
+		{"CommitArchive clears started", stateAxes{LiveRunning, OpArchiving}, true, false, CommitArchive(), LiveArchived, OpNone, false},
+		{"AbortArchiveToLost", stateAxes{LiveRunning, OpArchiving}, true, false, AbortArchiveToLost(), LiveLost, OpNone, true},
+		{"BeginRestore from Archived", stateAxes{LiveArchived, OpNone}, false, false, BeginRestore(), LiveLost, OpRestoring, false},
+		{"AbortRestoreToLost", stateAxes{LiveLost, OpRestoring}, true, false, AbortRestoreToLost(), LiveLost, OpNone, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			i := &Instance{liveness: tc.from.liveness, inFlightOp: tc.from.op, started: tc.started, userKilled: tc.userKilled}
+			require.NoError(t, i.Transition(tc.ev))
+			assert.Equal(t, tc.wantL, i.liveness, "liveness")
+			assert.Equal(t, tc.wantOp, i.inFlightOp, "op")
+			assert.Equal(t, tc.wantStarted, i.started, "started")
+		})
+	}
+}
+
+// TestTransition_I1_KillWithoutTombstonePanics: BeginKill without a recorded
+// kill-intent tombstone is rejected — a teardown of a wanted session that a
+// crash could reclassify Lost and resurrect (#1108).
+func TestTransition_I1_KillWithoutTombstonePanics(t *testing.T) {
+	i := &Instance{liveness: LiveRunning, inFlightOp: OpNone, userKilled: false}
+	assert.Panics(t, func() { _ = i.Transition(BeginKill()) })
+	assert.Equal(t, OpNone, i.inFlightOp, "a rejected transition must not mutate state")
+}
+
+// TestTransition_I2_CommitArchiveWithoutArchivingPanics: CommitArchive is
+// reachable only from the OpArchiving fence — flipping Archived without it would
+// mark a session inert whose worktree never moved.
+func TestTransition_I2_CommitArchiveWithoutArchivingPanics(t *testing.T) {
+	i := &Instance{liveness: LiveRunning, inFlightOp: OpNone}
+	assert.Panics(t, func() { _ = i.Transition(CommitArchive()) })
+	assert.Equal(t, LiveRunning, i.liveness, "a rejected transition must not mutate state")
+	assert.Equal(t, OpNone, i.inFlightOp)
+}
+
+// TestTransition_I3_BeginRestoreFromRunningPanics: a restore may begin only from
+// Archived — restoring a live session is rejected.
+func TestTransition_I3_BeginRestoreFromRunningPanics(t *testing.T) {
+	i := &Instance{liveness: LiveRunning, inFlightOp: OpNone}
+	assert.Panics(t, func() { _ = i.Transition(BeginRestore()) })
+	assert.Equal(t, OpNone, i.inFlightOp, "a rejected transition must not mutate state")
+}
+
+// TestTransition_DoubleRestorePanics: BeginRestore while a restore is already in
+// flight (OpRestoring) is rejected — no double-restore.
+func TestTransition_DoubleRestorePanics(t *testing.T) {
+	i := &Instance{liveness: LiveLost, inFlightOp: OpRestoring}
+	assert.Panics(t, func() { _ = i.Transition(BeginRestore()) })
+	assert.Equal(t, OpRestoring, i.inFlightOp, "a rejected transition must not mutate state")
+}
+
+// TestTransition_IllegalReturnsSoftErrorInProd pins the production semantics:
+// with no hook installed (prod), an illegal edge returns an error and leaves the
+// state untouched rather than panicking — a user's daemon must not crash on a
+// racing illegal transition.
+func TestTransition_IllegalReturnsSoftErrorInProd(t *testing.T) {
+	swapIllegalHook(t, nil)
+	i := &Instance{liveness: LiveRunning, inFlightOp: OpNone}
+	err := i.Transition(BeginRestore())
+	require.Error(t, err, "an illegal edge must return a soft error in production")
+	assert.Equal(t, LiveRunning, i.liveness, "state must be untouched on rejection")
+	assert.Equal(t, OpNone, i.inFlightOp)
+}

--- a/session/transition_test.go
+++ b/session/transition_test.go
@@ -67,7 +67,10 @@ func TestTransition_LegalEdgesApply(t *testing.T) {
 		{"BeginArchive from Running", stateAxes{LiveRunning, OpNone}, true, false, BeginArchive(), LiveRunning, OpArchiving, true},
 		{"CommitArchive clears started", stateAxes{LiveRunning, OpArchiving}, true, false, CommitArchive(), LiveArchived, OpNone, false},
 		{"AbortArchiveToLost", stateAxes{LiveRunning, OpArchiving}, true, false, AbortArchiveToLost(), LiveLost, OpNone, true},
-		{"BeginRestore from Archived", stateAxes{LiveArchived, OpNone}, false, false, BeginRestore(), LiveLost, OpRestoring, false},
+		// BeginRestore SETS started=true on the archived (started=false) row,
+		// mirroring RestoreFromArchive — else Recover's !Started() gate would
+		// short-circuit and restore would never start (Greptile #1314).
+		{"BeginRestore from Archived sets started", stateAxes{LiveArchived, OpNone}, false, false, BeginRestore(), LiveLost, OpRestoring, true},
 		{"AbortRestoreToLost", stateAxes{LiveLost, OpRestoring}, true, false, AbortRestoreToLost(), LiveLost, OpNone, true},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
**Phase 2c of the #1195 structural-health epic** (audit item #6). Builds on merged Phase 2a (#1248) + 2b (#1304). Root-approved design: https://github.com/sachiniyer/agent-factory/issues/1195#issuecomment-4888497895

## What

Phase 1 split session state into two axes (`liveness`, `inFlightOp`), but ~15 writers still poke those fields through scattered setters with **no transition table** — the lifecycle ordering invariants are enforced only by convention at each call site. This adds **`Instance.Transition`**, the single validated chokepoint every writer will route through, with the **allowed-edge table** (`transitionTable`) as the declarative source of truth for which `(liveness, op)` → `(liveness, op)` transitions are legal.

The table turns the **four ordering invariants** (audit #6) into from-state predicates instead of scattered guards:
- **I1** tombstone-before-kill: `BeginKill` requires the kill-intent tombstone (else a crash mid-teardown reclassifies the session `Lost` and resurrects it).
- **I2** move-before-Archived: `CommitArchive` is reachable **only** from the `OpArchiving` fence (only entered after the worktree move).
- **I3** move-before-respawn: `BeginRestore` is legal only from `Archived`.
- **I4** fence-brackets-archive: `Archived`/`Lost` is reachable from an archive only through the `OpArchiving` fence.

## Semantics

- **Illegal edge → soft error AND `onIllegalTransition`** (a testing-only hook the session test binary installs as a panic): a mis-ordered transition is a loud red test, never a silent prod corruption; a user's daemon degrades to the soft error and never crashes on a racing double-archive.
- **`ObserveLiveness`** is the unconditional daemon-truth edge — sets liveness, **preserves the op fence**, never rejects (what keeps #1187 structurally impossible).
- **`ConfirmLive`** yields (no-op) to an in-flight teardown rather than resurrecting it (mirrors `MarkLive`).

## Inert

This PR is **the API + table + tests only — no call-site migration**. Nothing in production calls `Transition` yet (`deadcode -test` confirms it's reachable via tests). **Phase 2d** migrates the daemon/app writers onto it + deletes the ad-hoc guards (mapping to the same user-facing error strings); **Phase 2e** retires the direct setters.

## Tests

- `TestTransitionTable_EveryKindHasSpec` — table-exhaustiveness (every kind has a populated spec).
- `TestTransition_LegalEdgesApply` — one canonical legal transition per event (exercises every constructor + row), incl. the `ConfirmLive`-yields and `ObserveLiveness`-preserves-op cases.
- One **illegal-edge panic test per I1–I4**: kill-without-tombstone, CommitArchive-without-Archiving, BeginRestore-from-Running, double-restore.
- `TestTransition_IllegalReturnsSoftErrorInProd` — hook disabled → soft error + state untouched.

## Gates (all green)

`go build`, `gofmt -l .` empty, `go vet`, `deadcode -test ./...` clean, `golangci-lint --fast`, file-length lint, and **`make test-container`** — full suite.

**Behavior-preserving / inert** — no runtime behavior change (nothing calls it yet), so no play-test needed for this PR. Refs #1195 (Phase 2d–2e + Phase 3 remain — do not close).

— Captain Claude