### PR TITLE
Quote detected agent paths for tmux startup

### DIFF
--- a/config/paths.go
+++ b/config/paths.go
@@ -29,15 +29,13 @@ func prettyHomePath(absPath string) string {
 	return absPath
 }
 
-// shellQuotePath wraps a path that contains shell-special characters
-// (spaces, apostrophes) in single quotes, escaping any embedded apostrophes
-// with the standard POSIX '\” idiom. Paths free of those characters are
-// returned unchanged. Used by DefaultConfig when persisting auto-detected
-// claude paths into ProgramOverrides — the value is passed to `sh -c` by
-// tmux, so paths with spaces (e.g. macOS App Bundles, #569) would otherwise
-// be split into separate tokens.
+// shellQuotePath wraps a non-empty filesystem path in single quotes, escaping
+// any embedded apostrophes with the standard POSIX single-quote escape idiom.
+// Used by DefaultConfig when persisting auto-detected claude paths into
+// ProgramOverrides — the value is passed to `sh -c` by tmux, so shell
+// metacharacters in paths must never be left for the shell to interpret.
 func shellQuotePath(path string) string {
-	if path == "" || !strings.ContainsAny(path, " '") {
+	if path == "" {
 		return path
 	}
 	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"

--- a/config/paths_test.go
+++ b/config/paths_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShellQuotePathQuotesEveryNonEmptyPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain path", "/usr/local/bin/claude", "'/usr/local/bin/claude'"},
+		{"space", "/Applications/Claude Code.app/claude", "'/Applications/Claude Code.app/claude'"},
+		{"metachar", "/tmp/R&D/bin/claude", "'/tmp/R&D/bin/claude'"},
+		{"apostrophe", "/tmp/dev's tools/claude", "'/tmp/dev'\\''s tools/claude'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellQuotePath(tt.path))
+		})
+	}
+}
+
+func TestDefaultConfigQuotesDetectedClaudePathWithShellMetacharacters(t *testing.T) {
+	tests := []struct {
+		name    string
+		dirName string
+	}{
+		{"metacharacters without spaces", "R&D"},
+		{"spaces and metacharacters", "Claude Path (R&D) $HOME"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binDir := filepath.Join(t.TempDir(), tt.dirName)
+			require.NoError(t, os.MkdirAll(binDir, 0755))
+			target := filepath.Join(binDir, "claude")
+			require.NoError(t, os.WriteFile(target, []byte("#!/bin/sh\nprintf 'argv:%s\\n' \"$*\"\n"), 0755))
+
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("SHELL", requireBash(t))
+			t.Setenv("PATH", binDir)
+
+			cfg := DefaultConfig()
+			override := cfg.ProgramOverrides[tmux.ProgramClaude]
+			require.Equal(t, shellSingleQuote(target)+" --dangerously-skip-permissions", override)
+
+			out, err := exec.Command("/bin/sh", "-c", override).CombinedOutput()
+			require.NoError(t, err, string(out))
+			assert.Equal(t, "argv:--dangerously-skip-permissions", strings.TrimSpace(string(out)))
+		})
+	}
+}
+
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}


### PR DESCRIPTION
## Summary
- always single-quote non-empty detected filesystem paths before storing them in `program_overrides`
- leave aliases and configured command strings untouched unless they are proven on-disk paths
- add shell execution coverage for metacharacter-only paths and paths with spaces plus metacharacters

## Verification
- `gofmt -l $(rg --files -g'*.go')`
- `scripts/lint-file-length.sh`
- `go build ./...`
- `golangci-lint run --fast`
- `make test-container`

Closes #1259

Signed as Captain Claude.