### PR TITLE
Clean terminal screen on TUI quit

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -111,6 +111,9 @@ type home struct {
 
 	// state is the current discrete state of the application
 	state state
+	// quitting suppresses Bubble Tea's final graceful render after handleQuit has
+	// started terminal teardown, so stale TUI chrome is not repainted on exit.
+	quitting bool
 	// namingInstance is the instance currently being named in stateNew.
 	// Stored as a direct pointer so background sync cannot change which
 	// instance the naming keystrokes target.
@@ -876,7 +879,8 @@ func (m *home) handleQuit() (tea.Model, tea.Cmd) {
 	// CLIENT (the session survives, exactly like a detach) so no orphaned
 	// `tmux attach-session` child outlives the TUI (#1089).
 	m.closeLiveTermPane()
-	return m, tea.Quit
+	m.quitting = true
+	return m, cleanQuitCmd()
 }
 
 // saveContentPaneState persists any changes from the hooks/task panes and
@@ -1771,6 +1775,9 @@ func (m *home) confirmAction(message string, action tea.Cmd) tea.Cmd {
 // mirrors exactly what this frame put on screen.
 func (m *home) View() string {
 	m.zones.Reset()
+	if m.quitting {
+		return ""
+	}
 
 	// Below the hard minimum no layout exists; render the banner alone (and
 	// register nothing — there is nothing to click).

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -573,10 +573,7 @@ func TestHandleQuit_HooksSaveSuccessQuitsAndUpdatesHookCount(t *testing.T) {
 	assert.NotContains(t, h.errBox.String(), "failed to save hooks",
 		"no error must be surfaced on a successful save")
 
-	// The returned command must be tea.Quit.
-	msg := cmd()
-	_, isQuit := msg.(tea.QuitMsg)
-	assert.True(t, isQuit, "a successful save must proceed to tea.Quit")
+	assert.True(t, commandEmitsQuit(cmd), "a successful save must proceed to tea.Quit")
 
 	assert.Equal(t, 1, h.store.GetHookCount(),
 		"the sidebar hook count must reflect the saved hook")

--- a/app/keymap_dispatch_test.go
+++ b/app/keymap_dispatch_test.go
@@ -13,11 +13,7 @@ import (
 // reachesQuit reports whether the command returned by the key handler resolves
 // to tea.Quit.
 func reachesQuit(cmd tea.Cmd) bool {
-	if cmd == nil {
-		return false
-	}
-	_, isQuit := cmd().(tea.QuitMsg)
-	return isQuit
+	return commandEmitsQuit(cmd)
 }
 
 func runeKey(r rune) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}} }

--- a/app/quit.go
+++ b/app/quit.go
@@ -1,0 +1,12 @@
+package app
+
+import tea "github.com/charmbracelet/bubbletea"
+
+func cleanQuitCmd() tea.Cmd {
+	return tea.Sequence(
+		tea.ClearScreen,
+		tea.ExitAltScreen,
+		tea.ClearScreen,
+		tea.Quit,
+	)
+}

--- a/app/quit_corruption_test.go
+++ b/app/quit_corruption_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,8 +29,6 @@ func TestHandleQuit_ReachesQuitWithCorruptedInstances(t *testing.T) {
 	_, cmd := h.handleQuit()
 
 	require.NotNil(t, cmd, "handleQuit must return a command even with corrupted instances.json")
-	msg := cmd()
-	_, isQuit := msg.(tea.QuitMsg)
-	assert.True(t, isQuit, "handleQuit must reach tea.Quit (got %T) instead of trapping the user in an error loop (#938)", msg)
+	assert.True(t, commandEmitsQuit(cmd), "handleQuit must reach tea.Quit instead of trapping the user in an error loop (#938)")
 	assert.Empty(t, strings.TrimSpace(h.errBox.String()), "a recoverable corruption must not surface a blocking error overlay")
 }

--- a/app/quit_teardown_test.go
+++ b/app/quit_teardown_test.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func commandEmitsQuit(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	msg := cmd()
+	if _, ok := msg.(tea.QuitMsg); ok {
+		return true
+	}
+	seq := reflect.ValueOf(msg)
+	if seq.Kind() != reflect.Slice {
+		return false
+	}
+	for i := 0; i < seq.Len(); i++ {
+		next, ok := seq.Index(i).Interface().(tea.Cmd)
+		if ok && commandEmitsQuit(next) {
+			return true
+		}
+	}
+	return false
+}
+
+func requireTeaSequence(t *testing.T, cmd tea.Cmd) []tea.Cmd {
+	t.Helper()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	seq := reflect.ValueOf(msg)
+	require.Equal(t, reflect.Slice, seq.Kind(), "expected tea.Sequence, got %T", msg)
+	cmds := make([]tea.Cmd, 0, seq.Len())
+	for i := 0; i < seq.Len(); i++ {
+		next, ok := seq.Index(i).Interface().(tea.Cmd)
+		require.True(t, ok, "sequence entry %d must be tea.Cmd", i)
+		cmds = append(cmds, next)
+	}
+	return cmds
+}
+
+func TestHandleQuitCleansTerminalBeforeQuit(t *testing.T) {
+	h := newTestHome(t)
+
+	_, cmd := h.handleQuit()
+
+	require.True(t, h.quitting, "quit must suppress Bubble Tea's final render")
+	assert.Empty(t, h.View(), "final graceful render must not repaint stale TUI chrome")
+
+	cmds := requireTeaSequence(t, cmd)
+	require.Len(t, cmds, 4, "quit must clear alt, leave alt-screen, clear main, then quit")
+	assert.Equal(t, tea.ClearScreen(), cmds[0]())
+	assert.Equal(t, tea.ExitAltScreen(), cmds[1]())
+	assert.Equal(t, tea.ClearScreen(), cmds[2]())
+	_, isQuit := cmds[3]().(tea.QuitMsg)
+	assert.True(t, isQuit, "teardown sequence must still finish with tea.Quit")
+}


### PR DESCRIPTION
## Summary
- suppress Bubble Tea's final graceful render after quit begins
- clear the active screen, exit alt-screen, clear the main screen, then quit
- add regression coverage for the ordered teardown sequence and existing quit paths

## Verification
- `gofmt -l $(rg --files -g'*.go')`
- `scripts/lint-file-length.sh`
- `go build ./...`
- `golangci-lint run --fast`
- `make test-container`
- fenced tmux smoke check with temp git repo/temp AGENT_FACTORY_HOME; after `q`, capture contained only log output, `AF_DONE`, and shell prompt, with no TUI frame/status/sidebar text

Closes #1291

Signed as Captain Claude.