### PR TITLE
Persist TUI view state across restarts

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
@@ -866,131 +865,6 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	return m, nil
 }
-
-func (m *home) handleQuit() (tea.Model, tea.Cmd) {
-	// Save any dirty task/hooks state. On failure the panes were reloaded to
-	// match disk; abort the quit and surface the error so the user sees the
-	// dropped edit instead of losing it silently on the way out.
-	if err := m.saveContentPaneState(); err != nil {
-		return m, m.handleError(err)
-	}
-	m.flushTUIViewStateBestEffort()
-
-	// No instances.json write on quit: the daemon is the sole writer (#960 PR 4)
-	// and every session/tab mutation already persisted through it as it
-	// happened. The TUI holds no authoritative instance state to flush.
-	//
-	// Do NOT tear down tab sessions on quit: as of #930 PR 2 each instance owns
-	// its agent and shell tab tmux sessions, and they must survive an af restart
-	// so the user reconnects to them on next launch (Sachin's persistence
-	// requirement). Killing an instance still tears its tabs down via
-	// LocalBackend.Kill.
-	//
-	// The live termpane attachment is the one exception: release its attach
-	// CLIENT (the session survives, exactly like a detach) so no orphaned
-	// `tmux attach-session` child outlives the TUI (#1089).
-	m.closeLiveTermPane()
-	m.quitting = true
-	return m, cleanQuitCmd()
-}
-
-// saveContentPaneState persists any changes from the hooks/task panes and
-// returns a non-nil error if any persist operation failed. Both panes'
-// failures are accumulated so neither is dropped when both are dirty at once.
-//
-// Recovery semantics on a hooks-save failure (#1001): we leave the HooksPane
-// dirty and deliberately do NOT reload it from disk. The edit the user is
-// trying to save lives only in memory, so reloading would discard the very
-// edit they care about — the silent data loss this fix exists to prevent.
-// Returning the error lets callers (handleQuit / focus release) abort the
-// destructive action and surface it via handleError; the dirty pane preserves
-// the edit so the user can retry from where they left off.
-//
-// Recovery semantics on a task-save failure (#934): we reload BOTH the sidebar
-// and the TaskPane from disk so the two panes always agree and always reflect
-// the committed on-disk state — never a mix of stale in-memory edits in one
-// pane and disk state in the other. Reloading clears the TaskPane's dirty flag,
-// which means a failed edit is discarded rather than left dangling; we
-// therefore return the error so callers surface it (via handleError) and the
-// dropped edit is never silent. We deliberately do NOT keep dirty=true for an
-// in-place retry: after the reload the in-memory edits are gone, so a lingering
-// dirty flag would point at nothing. The user re-applies the edit from a
-// known-consistent state instead.
-func (m *home) saveContentPaneState() error {
-	// Accumulate failures across both panes so a hooks error and a task error
-	// can never clobber one another (#1001).
-	var saveErr error
-
-	hp := m.hooksPane
-	if hp.IsDirty() {
-		// Hook edits are written to the in-repo .agent-factory/config.json —
-		// the canonical location for post_worktree_commands since #800. The
-		// legacy ~/.agent-factory/repos/<id>/config.json stays untouched as a
-		// read-only fallback; the saved in-repo key (even when emptied)
-		// shadows it.
-		if err := saveInRepoPostWorktreeCommandsFn(m.repoRoot, hp.GetCommands()); err != nil {
-			log.ErrorLog.Printf("failed to save hooks: %v", err)
-			// Surface the failure instead of swallowing it (#1001): callers
-			// abort the quit / focus release and show the error overlay rather
-			// than silently dropping the edit. The HooksPane stays dirty (see
-			// the recovery note above) so the in-memory edit survives for retry.
-			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save hooks: %w", err))
-		} else {
-			m.store.SetHookCount(len(hp.GetCommands()))
-		}
-	}
-
-	sp := m.automations.TaskPane()
-	if !sp.IsDirty() {
-		return saveErr
-	}
-
-	// Collect every persist failure instead of swallowing them: a partial
-	// failure must still surface so the user knows their edit didn't fully
-	// land (matches api/tasks.go, which propagates these errors).
-	//
-	// The writes route through the daemon (#1029 PR 6): the daemon is the sole
-	// writer of tasks.json among clients (#960), so a TUI edit/delete goes
-	// through the same RPC wrappers the CLI uses instead of touching the file
-	// directly. Each CRUD RPC re-arms the daemon's scheduler + watchers
-	// in-process, so there is no separate ReloadTasks poke here — the write and
-	// its schedule refresh are one atomic daemon call (removing the old
-	// double-reload).
-	//
-	// Persist ONLY the tasks the user actually edited (ConsumeDirty), not the
-	// whole pane: an unmodified task changed out-of-band (CLI, daemon) while the
-	// pane was open must not be clobbered by the pane's stale copy — #1213.
-	for _, tsk := range sp.ConsumeDirty() {
-		if err := updateTaskThroughDaemon(tsk); err != nil {
-			log.ErrorLog.Printf("failed to update task: %v", err)
-			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save task %q: %w", tsk.Name, err))
-		}
-	}
-	for _, tsk := range sp.ConsumeDeleted() {
-		if err := removeTaskThroughDaemon(tsk.ID); err != nil {
-			log.ErrorLog.Printf("failed to remove task: %v", err)
-			saveErr = errors.Join(saveErr, fmt.Errorf("failed to remove task %q: %w", tsk.Name, err))
-		}
-	}
-	// Reload BOTH panes from disk so the TaskPane and sidebar can never diverge
-	// (#934): whatever actually committed, both panes now show it.
-	tasks, err := task.LoadTasksForCurrentRepo()
-	if err == nil {
-		m.store.SetTasks(tasks)
-		sp.SetTasks(tasks)
-		// The task count feeds the rail's automations-section height (#1126);
-		// reflow so an add/delete grows or shrinks the section immediately.
-		m.relayout()
-	} else {
-		saveErr = errors.Join(saveErr, fmt.Errorf("failed to reload tasks after save: %w", err))
-	}
-	return saveErr
-}
-
-// saveInRepoPostWorktreeCommandsFn is indirected so TUI tests can force a
-// hooks-save failure deterministically — without relying on filesystem
-// permission tricks that a root test runner would bypass (#1001).
-var saveInRepoPostWorktreeCommandsFn = config.SaveInRepoPostWorktreeCommands
 
 // handleTaskCreate processes a pending task creation from the inline form.
 func (m *home) handleTaskCreate() tea.Cmd {

--- a/app/app.go
+++ b/app/app.go
@@ -546,7 +546,7 @@ func (m *home) Init() tea.Cmd {
 }
 
 func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	defer m.persistTUIViewStateIfChanged()
+	defer m.persistTUIViewStateAfter(msg)
 	switch msg := msg.(type) {
 	case hideErrMsg:
 		m.errBox.Clear()

--- a/app/app.go
+++ b/app/app.go
@@ -106,6 +106,9 @@ type home struct {
 	appConfig *config.Config
 	// appState stores persistent application state like seen help screens
 	appState config.AppState
+	// lastTUIViewState prevents preview ticks from rewriting unchanged state.
+	lastTUIViewState    config.TUIRepoViewState
+	hasLastTUIViewState bool
 
 	// -- State --
 
@@ -208,6 +211,10 @@ type home struct {
 	// respawn-die loop persists, instead of a line per 5s retry.
 	liveDeathLogKey string
 	liveDeathLogAt  time.Time
+	// pendingTUIViewFocus is loaded before Bubble Tea reports the terminal size.
+	// The pane bindings can restore immediately, but a pane focus target is only
+	// focusable after the first non-fallback relayout has rebuilt the ring.
+	pendingTUIViewFocus *config.TUIStateFocus
 
 	// interactive is the two-mode keyboard switch (#1089 PR 2, RFC §2.3).
 	// Nav mode (false): the host owns the keyboard — focus ring, verbs,
@@ -346,6 +353,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 	}
 
 	h.importRemoteHookSessions()
+	h.restoreTUIViewStateOnLaunch()
 
 	// Load tasks for sidebar display
 	tasks, err := task.LoadTasksForCurrentRepo()
@@ -425,6 +433,7 @@ func (m *home) relayout() {
 	ids = append(ids, layout.RegionAutomations)
 	m.ring.SetIDs(ids...)
 	m.ring.SetHidden(layout.RegionAutomations, !lay.AutomationsVisible)
+	m.applyPendingTUIViewFocus()
 	m.syncFocus()
 
 	m.sidebar.SetRect(lay.Tree)
@@ -537,6 +546,7 @@ func (m *home) Init() tea.Cmd {
 }
 
 func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	defer m.persistTUIViewStateIfChanged()
 	switch msg := msg.(type) {
 	case hideErrMsg:
 		m.errBox.Clear()
@@ -864,6 +874,7 @@ func (m *home) handleQuit() (tea.Model, tea.Cmd) {
 	if err := m.saveContentPaneState(); err != nil {
 		return m, m.handleError(err)
 	}
+	m.flushTUIViewStateBestEffort()
 
 	// No instances.json write on quit: the daemon is the sole writer (#960 PR 4)
 	// and every session/tab mutation already persisted through it as it

--- a/app/content_persistence.go
+++ b/app/content_persistence.go
@@ -1,0 +1,136 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+func (m *home) handleQuit() (tea.Model, tea.Cmd) {
+	// Save any dirty task/hooks state. On failure the panes were reloaded to
+	// match disk; abort the quit and surface the error so the user sees the
+	// dropped edit instead of losing it silently on the way out.
+	if err := m.saveContentPaneState(); err != nil {
+		return m, m.handleError(err)
+	}
+	m.flushTUIViewStateBestEffort()
+
+	// No instances.json write on quit: the daemon is the sole writer (#960 PR 4)
+	// and every session/tab mutation already persisted through it as it
+	// happened. The TUI holds no authoritative instance state to flush.
+	//
+	// Do NOT tear down tab sessions on quit: as of #930 PR 2 each instance owns
+	// its agent and shell tab tmux sessions, and they must survive an af restart
+	// so the user reconnects to them on next launch (Sachin's persistence
+	// requirement). Killing an instance still tears its tabs down via
+	// LocalBackend.Kill.
+	//
+	// The live termpane attachment is the one exception: release its attach
+	// CLIENT (the session survives, exactly like a detach) so no orphaned
+	// `tmux attach-session` child outlives the TUI (#1089).
+	m.closeLiveTermPane()
+	m.quitting = true
+	return m, cleanQuitCmd()
+}
+
+// saveContentPaneState persists any changes from the hooks/task panes and
+// returns a non-nil error if any persist operation failed. Both panes'
+// failures are accumulated so neither is dropped when both are dirty at once.
+//
+// Recovery semantics on a hooks-save failure (#1001): we leave the HooksPane
+// dirty and deliberately do NOT reload it from disk. The edit the user is
+// trying to save lives only in memory, so reloading would discard the very
+// edit they care about — the silent data loss this fix exists to prevent.
+// Returning the error lets callers (handleQuit / focus release) abort the
+// destructive action and surface it via handleError; the dirty pane preserves
+// the edit so the user can retry from where they left off.
+//
+// Recovery semantics on a task-save failure (#934): we reload BOTH the sidebar
+// and the TaskPane from disk so the two panes always agree and always reflect
+// the committed on-disk state — never a mix of stale in-memory edits in one
+// pane and disk state in the other. Reloading clears the TaskPane's dirty flag,
+// which means a failed edit is discarded rather than left dangling; we
+// therefore return the error so callers surface it (via handleError) and the
+// dropped edit is never silent. We deliberately do NOT keep dirty=true for an
+// in-place retry: after the reload the in-memory edits are gone, so a lingering
+// dirty flag would point at nothing. The user re-applies the edit from a
+// known-consistent state instead.
+func (m *home) saveContentPaneState() error {
+	// Accumulate failures across both panes so a hooks error and a task error
+	// can never clobber one another (#1001).
+	var saveErr error
+
+	hp := m.hooksPane
+	if hp.IsDirty() {
+		// Hook edits are written to the in-repo .agent-factory/config.json —
+		// the canonical location for post_worktree_commands since #800. The
+		// legacy ~/.agent-factory/repos/<id>/config.json stays untouched as a
+		// read-only fallback; the saved in-repo key (even when emptied)
+		// shadows it.
+		if err := saveInRepoPostWorktreeCommandsFn(m.repoRoot, hp.GetCommands()); err != nil {
+			log.ErrorLog.Printf("failed to save hooks: %v", err)
+			// Surface the failure instead of swallowing it (#1001): callers
+			// abort the quit / focus release and show the error overlay rather
+			// than silently dropping the edit. The HooksPane stays dirty (see
+			// the recovery note above) so the in-memory edit survives for retry.
+			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save hooks: %w", err))
+		} else {
+			m.store.SetHookCount(len(hp.GetCommands()))
+		}
+	}
+
+	sp := m.automations.TaskPane()
+	if !sp.IsDirty() {
+		return saveErr
+	}
+
+	// Collect every persist failure instead of swallowing them: a partial
+	// failure must still surface so the user knows their edit didn't fully
+	// land (matches api/tasks.go, which propagates these errors).
+	//
+	// The writes route through the daemon (#1029 PR 6): the daemon is the sole
+	// writer of tasks.json among clients (#960), so a TUI edit/delete goes
+	// through the same RPC wrappers the CLI uses instead of touching the file
+	// directly. Each CRUD RPC re-arms the daemon's scheduler + watchers
+	// in-process, so there is no separate ReloadTasks poke here — the write and
+	// its schedule refresh are one atomic daemon call (removing the old
+	// double-reload).
+	//
+	// Persist ONLY the tasks the user actually edited (ConsumeDirty), not the
+	// whole pane: an unmodified task changed out-of-band (CLI, daemon) while the
+	// pane was open must not be clobbered by the pane's stale copy — #1213.
+	for _, tsk := range sp.ConsumeDirty() {
+		if err := updateTaskThroughDaemon(tsk); err != nil {
+			log.ErrorLog.Printf("failed to update task: %v", err)
+			saveErr = errors.Join(saveErr, fmt.Errorf("failed to save task %q: %w", tsk.Name, err))
+		}
+	}
+	for _, tsk := range sp.ConsumeDeleted() {
+		if err := removeTaskThroughDaemon(tsk.ID); err != nil {
+			log.ErrorLog.Printf("failed to remove task: %v", err)
+			saveErr = errors.Join(saveErr, fmt.Errorf("failed to remove task %q: %w", tsk.Name, err))
+		}
+	}
+	// Reload BOTH panes from disk so the TaskPane and sidebar can never diverge
+	// (#934): whatever actually committed, both panes now show it.
+	tasks, err := task.LoadTasksForCurrentRepo()
+	if err == nil {
+		m.store.SetTasks(tasks)
+		sp.SetTasks(tasks)
+		// The task count feeds the rail's automations-section height (#1126);
+		// reflow so an add/delete grows or shrinks the section immediately.
+		m.relayout()
+	} else {
+		saveErr = errors.Join(saveErr, fmt.Errorf("failed to reload tasks after save: %w", err))
+	}
+	return saveErr
+}
+
+// saveInRepoPostWorktreeCommandsFn is indirected so TUI tests can force a
+// hooks-save failure deterministically — without relying on filesystem
+// permission tricks that a root test runner would bypass (#1001).
+var saveInRepoPostWorktreeCommandsFn = config.SaveInRepoPostWorktreeCommands

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -135,6 +135,7 @@ func wireTestPanes(h *home, proj *store.Projection) {
 	h.mouseClock = time.Now
 	h.wireZoneRegistry()
 	h.syncFocus()
+	h.rememberTUIViewState()
 }
 
 // openTestPane opens (instance, tab) as a pane the way the `s` verb does —

--- a/app/detach_paint_test.go
+++ b/app/detach_paint_test.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"os"
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,6 +54,8 @@ func TestRepaintAfterDetachMsg_KicksOffRefresh(t *testing.T) {
 	h.sidebar.SetSelectedInstance(0)
 	resizeHome(h, 120, 40)
 	openTestPane(t, h, inst, 0)
+	statePath, err := config.TUIStatePath()
+	require.NoError(t, err)
 
 	start := time.Now()
 	_, cmd := h.Update(repaintAfterDetachMsg{})
@@ -62,6 +66,9 @@ func TestRepaintAfterDetachMsg_KicksOffRefresh(t *testing.T) {
 			"with fresh content immediately after detach")
 	assert.Less(t, elapsed, 5*time.Millisecond,
 		"Update for repaintAfterDetachMsg must not block; saw %s", elapsed)
+	_, statErr := os.Stat(statePath)
+	assert.True(t, os.IsNotExist(statErr),
+		"repaintAfterDetachMsg must not synchronously flush TUI view-state")
 }
 
 // TestRefreshPanesCmd_ProducesPanesRefreshedMsg verifies the goroutine body

--- a/app/tui_state.go
+++ b/app/tui_state.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -203,6 +205,22 @@ func (m *home) persistTUIViewStateIfChanged() {
 	}
 	m.lastTUIViewState = next
 	m.hasLastTUIViewState = true
+}
+
+func (m *home) persistTUIViewStateAfter(msg tea.Msg) {
+	if !shouldPersistTUIViewStateAfter(msg) {
+		return
+	}
+	m.persistTUIViewStateIfChanged()
+}
+
+func shouldPersistTUIViewStateAfter(msg tea.Msg) bool {
+	switch msg.(type) {
+	case previewTickMsg, panesRefreshedMsg, repaintAfterDetachMsg, spinner.TickMsg, keyupMsg, hideErrMsg:
+		return false
+	default:
+		return true
+	}
 }
 
 func (m *home) flushTUIViewStateBestEffort() {

--- a/app/tui_state.go
+++ b/app/tui_state.go
@@ -1,0 +1,316 @@
+package app
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/store"
+)
+
+const tuiFocusRegionPane = "pane"
+
+// restoreTUIViewStateOnLaunch restores client-side pane/selection/focus state
+// after the daemon snapshot has populated the projection. It never fails the
+// launch; unreadable state files fall back to the ordinary cold-start path.
+func (m *home) restoreTUIViewStateOnLaunch() int {
+	state, ok := config.LoadTUIRepoViewState(m.repoID)
+	restored := 0
+	if ok {
+		restored = m.applyTUIViewState(state)
+		if restored > 0 {
+			m.initialPaneOpened = true
+		}
+	}
+	m.rememberTUIViewState()
+	return restored
+}
+
+func (m *home) applyTUIViewState(state config.TUIRepoViewState) int {
+	restored := m.restoreTUIViewPanes(state.OpenPanes)
+	m.restoreTUISelection(state)
+	if state.Focus != nil {
+		focusCopy := *state.Focus
+		m.pendingTUIViewFocus = &focusCopy
+	}
+	m.relayout()
+	return restored
+}
+
+func (m *home) restoreTUIViewPanes(saved []config.TUIStateOpenPane) int {
+	type restoredPane struct {
+		saved config.TUIStateOpenPane
+		pane  *store.OpenPane
+	}
+	var restored []restoredPane
+	seen := make(map[string]bool, len(saved))
+	for _, paneState := range saved {
+		inst := m.resolveTUIStateInstance(paneState.InstanceID, paneState.Title)
+		if inst == nil || inst.GetLiveness() == session.LiveArchived {
+			continue
+		}
+		tab, ok := tabIndexByName(inst, paneState.TabName)
+		if !ok {
+			continue
+		}
+		key := paneState.Key
+		if key == "" {
+			key = tuiPaneKey(paneState.InstanceID, paneState.Title, paneState.TabName)
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		pane := m.store.FindOpenPane(inst, tab)
+		if pane == nil {
+			pane = m.openPaneWindow(inst, tab)
+		}
+		if pane == nil {
+			continue
+		}
+		restored = append(restored, restoredPane{saved: paneState, pane: pane})
+	}
+	sort.SliceStable(restored, func(i, j int) bool {
+		return restored[i].saved.FocusRank < restored[j].saved.FocusRank
+	})
+	for _, item := range restored {
+		m.store.TouchOpenPane(item.pane)
+	}
+	return len(restored)
+}
+
+func (m *home) restoreTUISelection(state config.TUIRepoViewState) {
+	if state.Selected == nil {
+		return
+	}
+	inst := m.resolveTUIStateInstance(state.Selected.InstanceID, state.Selected.Title)
+	if inst == nil || inst.GetLiveness() == session.LiveArchived {
+		return
+	}
+	tabName := state.Selected.TabName
+	if state.ActiveTab != nil && sameTUIStateInstance(*state.Selected, *state.ActiveTab) {
+		tabName = state.ActiveTab.TabName
+	}
+	tab := tabIndexOrDefault(inst, tabName)
+	m.sidebar.SelectInstance(inst)
+	m.store.SetActiveTab(tab)
+	m.menu.SetInstance(inst)
+	m.menu.SetActiveTab(tab)
+	m.sidebar.SelectTabRow(inst.Title, tab)
+}
+
+func (m *home) applyPendingTUIViewFocus() {
+	if m.pendingTUIViewFocus == nil {
+		return
+	}
+	focus := m.pendingTUIViewFocus
+	m.pendingTUIViewFocus = nil
+	switch focus.Region {
+	case layout.RegionTree:
+		m.ring.Focus(layout.RegionTree)
+	case layout.RegionAutomations:
+		if !m.ring.Focus(layout.RegionAutomations) {
+			m.ring.Focus(layout.RegionTree)
+		}
+	case tuiFocusRegionPane:
+		if p := m.openPaneByKey(focus.PaneKey); p != nil {
+			if m.ring.Focus(layout.PaneRegion(p.ID())) {
+				return
+			}
+		}
+		m.ring.Focus(layout.RegionTree)
+	default:
+		m.ring.Focus(layout.RegionTree)
+	}
+}
+
+func (m *home) captureTUIViewState() config.TUIRepoViewState {
+	var openPanes []config.TUIStateOpenPane
+	for _, p := range m.store.OpenPanes() {
+		inst := p.Instance()
+		if inst == nil || !m.store.ContainsInstance(inst) {
+			continue
+		}
+		tabName, ok := tabNameAt(inst, p.Tab())
+		if !ok {
+			continue
+		}
+		openPanes = append(openPanes, config.TUIStateOpenPane{
+			Key:        tuiPaneKeyForInstance(inst, tabName),
+			InstanceID: inst.ID,
+			Title:      inst.Title,
+			TabName:    tabName,
+			FocusRank:  p.LastFocus(),
+		})
+	}
+	state := config.TUIRepoViewState{
+		Selected:  m.captureTUISelectedTarget(),
+		ActiveTab: m.captureTUISelectedTarget(),
+		Focus:     m.captureTUIFocus(),
+		OpenPanes: openPanes,
+	}
+	return state
+}
+
+func (m *home) captureTUISelectedTarget() *config.TUIStateTarget {
+	inst := m.store.GetSelectedInstance()
+	if inst == nil || !m.store.ContainsInstance(inst) {
+		return nil
+	}
+	tabName, _ := tabNameAt(inst, m.store.ActiveTab())
+	return &config.TUIStateTarget{
+		InstanceID: inst.ID,
+		Title:      inst.Title,
+		TabName:    tabName,
+	}
+}
+
+func (m *home) captureTUIFocus() *config.TUIStateFocus {
+	active := m.ring.Active()
+	if layout.IsPaneRegion(active) {
+		if p := m.focusedOpenPane(); p != nil {
+			return &config.TUIStateFocus{
+				Region:  tuiFocusRegionPane,
+				PaneKey: tuiPaneKeyForOpenPane(p),
+			}
+		}
+		return &config.TUIStateFocus{Region: layout.RegionTree}
+	}
+	if active == "" {
+		return nil
+	}
+	return &config.TUIStateFocus{Region: active}
+}
+
+func (m *home) persistTUIViewStateIfChanged() {
+	next := normalizeTUIViewState(m.captureTUIViewState())
+	if m.hasLastTUIViewState && reflect.DeepEqual(m.lastTUIViewState, next) {
+		return
+	}
+	if err := m.writeTUIViewState(next); err != nil {
+		log.WarningLog.Printf("failed to save TUI state: %v", err)
+		// Remember the attempted state so a preview tick does not retry the
+		// same failing write forever. A later structural change, or quit flush,
+		// will try again.
+		m.lastTUIViewState = next
+		m.hasLastTUIViewState = true
+		return
+	}
+	m.lastTUIViewState = next
+	m.hasLastTUIViewState = true
+}
+
+func (m *home) flushTUIViewStateBestEffort() {
+	next := normalizeTUIViewState(m.captureTUIViewState())
+	if err := m.writeTUIViewState(next); err != nil {
+		log.WarningLog.Printf("failed to flush TUI state on quit: %v", err)
+		return
+	}
+	m.lastTUIViewState = next
+	m.hasLastTUIViewState = true
+}
+
+func (m *home) rememberTUIViewState() {
+	m.lastTUIViewState = normalizeTUIViewState(m.captureTUIViewState())
+	m.hasLastTUIViewState = true
+}
+
+func (m *home) writeTUIViewState(state config.TUIRepoViewState) error {
+	if m.repoID == "" {
+		return nil
+	}
+	state.UpdatedAt = time.Now().UTC()
+	return config.SaveTUIRepoViewState(m.repoID, state)
+}
+
+func normalizeTUIViewState(state config.TUIRepoViewState) config.TUIRepoViewState {
+	state.UpdatedAt = time.Time{}
+	return state
+}
+
+func (m *home) resolveTUIStateInstance(instanceID, title string) *session.Instance {
+	if instanceID != "" {
+		for _, inst := range m.store.GetInstances() {
+			if inst.ID == instanceID {
+				return inst
+			}
+		}
+	}
+	if title != "" {
+		return m.store.GetInstanceByTitle(title)
+	}
+	return nil
+}
+
+func (m *home) openPaneByKey(key string) *store.OpenPane {
+	if key == "" {
+		return nil
+	}
+	for _, p := range m.store.OpenPanes() {
+		if tuiPaneKeyForOpenPane(p) == key {
+			return p
+		}
+	}
+	return nil
+}
+
+func tabNameAt(inst *session.Instance, idx int) (string, bool) {
+	tabs := inst.GetTabs()
+	if idx < 0 || idx >= len(tabs) {
+		return "", false
+	}
+	return tabs[idx].Name, true
+}
+
+func tabIndexByName(inst *session.Instance, name string) (int, bool) {
+	for i, tab := range inst.GetTabs() {
+		if tab.Name == name {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func tabIndexOrDefault(inst *session.Instance, name string) int {
+	if idx, ok := tabIndexByName(inst, name); ok {
+		return idx
+	}
+	return 0
+}
+
+func tuiPaneKeyForOpenPane(p *store.OpenPane) string {
+	if p == nil || p.Instance() == nil {
+		return ""
+	}
+	tabName, ok := tabNameAt(p.Instance(), p.Tab())
+	if !ok {
+		return ""
+	}
+	return tuiPaneKeyForInstance(p.Instance(), tabName)
+}
+
+func tuiPaneKeyForInstance(inst *session.Instance, tabName string) string {
+	if inst == nil {
+		return ""
+	}
+	return tuiPaneKey(inst.ID, inst.Title, tabName)
+}
+
+func tuiPaneKey(instanceID, title, tabName string) string {
+	if title != "" {
+		return fmt.Sprintf("title:%s:tab:%s", title, tabName)
+	}
+	return fmt.Sprintf("id:%s:tab:%s", instanceID, tabName)
+}
+
+func sameTUIStateInstance(a, b config.TUIStateTarget) bool {
+	if a.InstanceID != "" && b.InstanceID != "" {
+		return a.InstanceID == b.InstanceID
+	}
+	return a.Title != "" && a.Title == b.Title
+}

--- a/app/tui_state_test.go
+++ b/app/tui_state_test.go
@@ -1,0 +1,130 @@
+package app
+
+import (
+	"os"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTUIViewStateRestorePanesSelectionAndFocus(t *testing.T) {
+	h := newTestHome(t)
+	h.initialPaneOpened = false
+	alpha := tuiStateTestInstance(t, "alpha")
+	beta := tuiStateTestInstance(t, "beta")
+	h.store.AddInstance(alpha)
+	h.store.AddInstance(beta)
+
+	state := config.TUIRepoViewState{
+		Selected: &config.TUIStateTarget{
+			InstanceID: beta.ID,
+			Title:      beta.Title,
+			TabName:    "shell",
+		},
+		ActiveTab: &config.TUIStateTarget{
+			InstanceID: beta.ID,
+			Title:      beta.Title,
+			TabName:    "shell",
+		},
+		Focus: &config.TUIStateFocus{
+			Region:  tuiFocusRegionPane,
+			PaneKey: tuiPaneKeyForInstance(beta, "shell"),
+		},
+		OpenPanes: []config.TUIStateOpenPane{
+			{
+				Key:        tuiPaneKeyForInstance(alpha, "agent"),
+				InstanceID: alpha.ID,
+				Title:      alpha.Title,
+				TabName:    "agent",
+				FocusRank:  1,
+			},
+			{
+				Key:        tuiPaneKeyForInstance(beta, "shell"),
+				InstanceID: beta.ID,
+				Title:      beta.Title,
+				TabName:    "shell",
+				FocusRank:  2,
+			},
+		},
+	}
+	require.NoError(t, config.SaveTUIRepoViewState(h.repoID, state))
+
+	require.Equal(t, 2, h.restoreTUIViewStateOnLaunch())
+	resizeHome(h, 200, 40)
+
+	require.Equal(t, 2, h.store.NumOpenPanes())
+	assert.Equal(t, []string{"alpha", "beta"}, visibleTitles(h))
+	assert.Equal(t, 2, h.lastLayout.PaneCount(), "restored panes are laid out side by side")
+	assert.True(t, h.initialPaneOpened, "restored panes suppress startup auto-open")
+
+	require.Same(t, beta, h.store.GetSelectedInstance())
+	assert.Equal(t, 1, h.store.ActiveTab(), "active tab restores by tab name")
+
+	focused := h.focusedOpenPane()
+	require.NotNil(t, focused)
+	assert.Same(t, beta, focused.Instance())
+	assert.Equal(t, 1, focused.Tab())
+}
+
+func TestTUIViewStateNoValidPanesKeepsAutoOpenFallback(t *testing.T) {
+	h := newTestHome(t)
+	h.initialPaneOpened = false
+	alpha := tuiStateTestInstance(t, "alpha")
+	h.store.AddInstance(alpha)
+
+	state := config.TUIRepoViewState{
+		OpenPanes: []config.TUIStateOpenPane{{
+			Key:        "title:missing:tab:agent",
+			InstanceID: "missing-id",
+			Title:      "missing",
+			TabName:    "agent",
+			FocusRank:  1,
+		}},
+	}
+	require.NoError(t, config.SaveTUIRepoViewState(h.repoID, state))
+
+	require.Zero(t, h.restoreTUIViewStateOnLaunch())
+	require.False(t, h.initialPaneOpened)
+
+	_ = h.selectionChanged()
+	require.Equal(t, 1, h.store.NumOpenPanes(), "ordinary cold-start auto-open still runs")
+	assert.Same(t, alpha, h.store.OpenPanes()[0].Instance())
+}
+
+func TestTUIViewStatePreviewTickDoesNotWriteUnchangedState(t *testing.T) {
+	h := newTestHome(t)
+	alpha := tuiStateTestInstance(t, "alpha")
+	h.store.AddInstance(alpha)
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+	resizeHome(h, 200, 40)
+	h.rememberTUIViewState()
+
+	path, err := config.TUIStatePath()
+	require.NoError(t, err)
+	_, statErr := os.Stat(path)
+	require.True(t, os.IsNotExist(statErr), "baseline snapshot must not write by itself")
+
+	_, _ = h.Update(previewTickMsg{})
+	_, statErr = os.Stat(path)
+	require.True(t, os.IsNotExist(statErr), "unchanged preview tick must not write TUI state")
+
+	h.keySent = true
+	_, _ = h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err, "a structural pane-open action must save TUI state")
+	assert.Contains(t, string(raw), `"schema_version"`)
+	assert.Contains(t, string(raw), `"open_panes"`)
+}
+
+func tuiStateTestInstance(t *testing.T, title string) *session.Instance {
+	t.Helper()
+	inst := instanceWithFakeBackend(t, title)
+	inst.AddTabForTest("agent", session.TabKindAgent)
+	inst.AddTabForTest("shell", session.TabKindShell)
+	return inst
+}

--- a/config/tui_state.go
+++ b/config/tui_state.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// TUIStateFile is the global, TUI-owned view-state envelope. It is keyed by
+// repo ID because one user-level TUI state file covers every local repo.
+type TUIStateFile struct {
+	SchemaVersion int                         `json:"schema_version"`
+	Repos         map[string]TUIRepoViewState `json:"repos"`
+}
+
+// TUIRepoViewState is the client-side projection state restored by the TUI.
+type TUIRepoViewState struct {
+	UpdatedAt time.Time          `json:"updated_at,omitempty"`
+	Selected  *TUIStateTarget    `json:"selected,omitempty"`
+	ActiveTab *TUIStateTarget    `json:"active_tab,omitempty"`
+	Focus     *TUIStateFocus     `json:"focus,omitempty"`
+	OpenPanes []TUIStateOpenPane `json:"open_panes,omitempty"`
+}
+
+// TUIStateTarget identifies a session/tab by stable identity, falling back to
+// title for older records that did not carry a session ID.
+type TUIStateTarget struct {
+	InstanceID string `json:"instance_id,omitempty"`
+	Title      string `json:"title,omitempty"`
+	TabName    string `json:"tab_name,omitempty"`
+}
+
+// TUIStateFocus records the focused TUI region. Pane focus uses PaneKey instead
+// of an in-process pane ID, since pane IDs are reallocated on restore.
+type TUIStateFocus struct {
+	Region  string `json:"region"`
+	PaneKey string `json:"pane_key,omitempty"`
+}
+
+// TUIStateOpenPane records one explicit workspace pane binding.
+type TUIStateOpenPane struct {
+	Key        string `json:"key"`
+	InstanceID string `json:"instance_id,omitempty"`
+	Title      string `json:"title,omitempty"`
+	TabName    string `json:"tab_name"`
+	FocusRank  uint64 `json:"focus_rank,omitempty"`
+}
+
+// LoadTUIRepoViewState loads the saved TUI state for repoID. Missing, corrupt,
+// legacy, or newer files return defaults and log a warning instead of crashing
+// the TUI; the bool reports whether a repo entry was present and valid.
+func LoadTUIRepoViewState(repoID string) (TUIRepoViewState, bool) {
+	if err := ValidateRepoID(repoID); err != nil {
+		log.WarningLog.Printf("failed to load TUI state: %v", err)
+		return TUIRepoViewState{}, false
+	}
+	path, err := TUIStatePath()
+	if err != nil {
+		log.WarningLog.Printf("failed to resolve TUI state path: %v", err)
+		return TUIRepoViewState{}, false
+	}
+	file, ok, err := readTUIStateFile(path)
+	if err != nil {
+		log.WarningLog.Printf("failed to load TUI state from %s: %v", path, err)
+		return TUIRepoViewState{}, false
+	}
+	if !ok || file.Repos == nil {
+		return TUIRepoViewState{}, false
+	}
+	state, ok := file.Repos[repoID]
+	return state, ok
+}
+
+// SaveTUIRepoViewState updates only repoID's entry under the global TUI state
+// file lock, preserving other repos' client view-state.
+func SaveTUIRepoViewState(repoID string, state TUIRepoViewState) error {
+	if err := ValidateRepoID(repoID); err != nil {
+		return err
+	}
+	path, err := TUIStatePath()
+	if err != nil {
+		return err
+	}
+	return WithFileLock(path, func() error {
+		file, err := loadTUIStateFileForUpdate(path)
+		if err != nil {
+			return err
+		}
+		if file.Repos == nil {
+			file.Repos = make(map[string]TUIRepoViewState)
+		}
+		file.SchemaVersion = TUIStateSchemaVersion
+		file.Repos[repoID] = state
+		return writeTUIStateFile(path, file)
+	})
+}
+
+func readTUIStateFile(path string) (TUIStateFile, bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return defaultTUIStateFile(), false, nil
+		}
+		return TUIStateFile{}, false, err
+	}
+	file, err := decodeTUIStateFile(raw, path)
+	if err != nil {
+		return TUIStateFile{}, false, err
+	}
+	return file, true, nil
+}
+
+func loadTUIStateFileForUpdate(path string) (TUIStateFile, error) {
+	file, _, err := readTUIStateFile(path)
+	if err == nil {
+		return file, nil
+	}
+	var newer *UnsupportedSchemaVersionError
+	if errors.As(err, &newer) {
+		return TUIStateFile{}, err
+	}
+	log.WarningLog.Printf("replacing unreadable TUI state file %s: %v", path, err)
+	return defaultTUIStateFile(), nil
+}
+
+func decodeTUIStateFile(raw []byte, path string) (TUIStateFile, error) {
+	plan := NewTUIStateSchemaMigrationPlan(path, validateTUIStateEnvelope)
+	migrated, _, err := MigrateSchemaBytes(raw, plan)
+	if err != nil {
+		return TUIStateFile{}, err
+	}
+	var file TUIStateFile
+	if err := json.Unmarshal(migrated, &file); err != nil {
+		return TUIStateFile{}, err
+	}
+	if file.Repos == nil {
+		file.Repos = make(map[string]TUIRepoViewState)
+	}
+	return file, nil
+}
+
+func writeTUIStateFile(path string, file TUIStateFile) error {
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal TUI state: %w", err)
+	}
+	return AtomicWriteFile(path, data, 0644)
+}
+
+func defaultTUIStateFile() TUIStateFile {
+	return TUIStateFile{
+		SchemaVersion: TUIStateSchemaVersion,
+		Repos:         make(map[string]TUIRepoViewState),
+	}
+}
+
+func validateTUIStateEnvelope(raw []byte) error {
+	var file TUIStateFile
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return err
+	}
+	if file.SchemaVersion != TUIStateSchemaVersion {
+		return fmt.Errorf("schema_version = %d, want %d", file.SchemaVersion, TUIStateSchemaVersion)
+	}
+	if file.Repos == nil {
+		return nil
+	}
+	for repoID := range file.Repos {
+		if err := ValidateRepoID(repoID); err != nil {
+			return fmt.Errorf("repo %q: %w", repoID, err)
+		}
+	}
+	return nil
+}

--- a/config/tui_state_test.go
+++ b/config/tui_state_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTUIRepoViewStateMissingFileDefaults(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	state, ok := LoadTUIRepoViewState("repo-a")
+
+	assert.False(t, ok)
+	assert.Empty(t, state.OpenPanes)
+}
+
+func TestSaveTUIRepoViewStateWritesSchemaAndPreservesRepos(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	stateA := TUIRepoViewState{
+		Selected: &TUIStateTarget{InstanceID: "id-a", Title: "alpha", TabName: "agent"},
+		OpenPanes: []TUIStateOpenPane{{
+			Key:        "title:alpha:tab:agent",
+			InstanceID: "id-a",
+			Title:      "alpha",
+			TabName:    "agent",
+			FocusRank:  1,
+		}},
+	}
+	stateB := TUIRepoViewState{
+		Selected: &TUIStateTarget{InstanceID: "id-b", Title: "beta", TabName: "shell"},
+	}
+
+	require.NoError(t, SaveTUIRepoViewState("repo-a", stateA))
+	require.NoError(t, SaveTUIRepoViewState("repo-b", stateB))
+
+	path, err := TUIStatePath()
+	require.NoError(t, err)
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var file TUIStateFile
+	require.NoError(t, json.Unmarshal(raw, &file))
+	assert.Equal(t, TUIStateSchemaVersion, file.SchemaVersion)
+	require.Contains(t, file.Repos, "repo-a")
+	require.Contains(t, file.Repos, "repo-b")
+	assert.Equal(t, "alpha", file.Repos["repo-a"].Selected.Title)
+	assert.Equal(t, "beta", file.Repos["repo-b"].Selected.Title)
+	assert.NotContains(t, string(raw), `"version"`)
+}
+
+func TestTUIRepoViewStateCorruptFileDefaultsAndRepairsOnSave(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	path, err := TUIStatePath()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, []byte(`{not-json`), 0644))
+
+	state, ok := LoadTUIRepoViewState("repo-a")
+	assert.False(t, ok)
+	assert.Empty(t, state.OpenPanes)
+
+	want := TUIRepoViewState{
+		Selected: &TUIStateTarget{InstanceID: "id-a", Title: "alpha", TabName: "agent"},
+	}
+	require.NoError(t, SaveTUIRepoViewState("repo-a", want))
+
+	got, ok := LoadTUIRepoViewState("repo-a")
+	require.True(t, ok)
+	require.NotNil(t, got.Selected)
+	assert.Equal(t, "alpha", got.Selected.Title)
+}

--- a/ui/store/projection.go
+++ b/ui/store/projection.go
@@ -523,6 +523,10 @@ type OpenPane struct {
 // ID returns the pane's stable id, used as its focus-ring region id.
 func (o *OpenPane) ID() int { return o.id }
 
+// LastFocus returns the pane's focus-recency stamp. It is serialized by the
+// TUI view-state store so auto-hide ordering survives a restart.
+func (o *OpenPane) LastFocus() uint64 { return o.lastFocus }
+
 // Instance returns the instance the pane is bound to. Like the display
 // selection, the pointer may briefly dangle after its instance is removed
 // from the projection; the root model closes such panes on its next tick


### PR DESCRIPTION
## Summary
- Add a schema_versioned, TUI-owned `tui-state.json` store keyed by repo ID.
- Capture and restore open panes, pane focus recency, selected session/tab, active tab, and focus after the daemon snapshot is loaded.
- Save structural view-state changes and quit flushes without writing daemon-owned session state.
- Treat missing, corrupt, legacy, or newer state files as defaults on startup with warnings instead of crashes.

## Gates
- `gofmt -l config/tui_state.go config/tui_state_test.go app/tui_state.go app/tui_state_test.go app/app.go app/creation_test.go ui/store/projection.go` (empty)
- `go build ./...`
- `golangci-lint run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0` via v1.64.8 rebuilt with `GOTOOLCHAIN=go1.24.2`
- `make lint-file-length`
- `make test-container`

Root should verify and play-test the restart persistence flow before merge. Do not merge from this branch.

References #1240.

Signed-off-by: Captain Claude <captain-claude@users.noreply.github.com>