### PR TITLE
fix(daemon): log vanished live worktrees

### DIFF
--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -1,11 +1,16 @@
 package daemon
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
 )
 
 // The Lost-session restore loop (#1108 PR 2): the general form of the
@@ -41,6 +46,9 @@ type lostRestoreState struct {
 	// remoteLogged dedupes the "not restoring a remote session" note to once
 	// per Lost episode.
 	remoteLogged bool
+	// vanishedWorktreesLogged dedupes the high-visibility #1303 diagnostic to
+	// one ERROR per distinct missing worktree path during a Lost episode.
+	vanishedWorktreesLogged map[string]struct{}
 }
 
 // RestoreLostSessions runs one restore pass over every Lost session the
@@ -152,6 +160,7 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	}
 
 	if err := inst.Recover(); err != nil {
+		m.logVanishedWorktreeOnce(key, repoID, st, inst, err)
 		m.lostRestoreFailed(key, st, inst.Title, err)
 		return
 	}
@@ -181,8 +190,162 @@ func (m *Manager) lostRestoreFailed(key string, st *lostRestoreState, title stri
 	}
 	st.nextAttempt = time.Now().Add(backoff)
 	if st.consecutiveFailures == lostRestoreEscalationThreshold {
+		if path, ok := missingWorktreePath(err); ok && st.vanishedWorktreeWasLogged(path) {
+			log.WarningLog.Printf("restore of lost session %q failed %d consecutive times; missing worktree %q was already logged at ERROR — will keep retrying every %s (kill the session to stop): %v", title, st.consecutiveFailures, path, lostRestoreBackoffMax, err)
+			return
+		}
 		log.ErrorLog.Printf("restore of lost session %q failed %d consecutive times; the cause looks persistent — will keep retrying every %s (kill the session to stop): %v", title, st.consecutiveFailures, lostRestoreBackoffMax, err)
 		return
 	}
 	log.WarningLog.Printf("restore of lost session %q failed (attempt %d), retrying in %s: %v", title, st.consecutiveFailures, backoff, err)
+}
+
+func (m *Manager) logVanishedWorktreeOnce(key, repoID string, st *lostRestoreState, inst *session.Instance, restoreErr error) {
+	worktreePath, ok := missingWorktreePath(restoreErr)
+	if !ok {
+		return
+	}
+
+	m.mu.Lock()
+	alreadyLogged := st.vanishedWorktreeWasLogged(worktreePath)
+	if !alreadyLogged {
+		if st.vanishedWorktreesLogged == nil {
+			st.vanishedWorktreesLogged = make(map[string]struct{})
+		}
+		st.vanishedWorktreesLogged[worktreePath] = struct{}{}
+	}
+	_, killInFlight := m.killsInFlight[key]
+	m.mu.Unlock()
+	if alreadyLogged {
+		return
+	}
+
+	gw, _ := inst.GetGitWorktree()
+	diag := sessiongit.MissingWorktreeDiagnosis{
+		WorktreePath: worktreePath,
+		ParentPath:   filepath.Dir(worktreePath),
+	}
+	if gw != nil {
+		diag = gw.DiagnoseMissingWorktree()
+	}
+	branch := inst.GetBranch()
+	if branch == "" {
+		branch = diag.BranchName
+	}
+	liveness := inst.GetLiveness()
+	op := inst.GetInFlightOp()
+	userKilled := inst.UserKilled()
+	teardownIntent := userKilled || killInFlight || op == session.OpKilling || op == session.OpArchiving
+	classification := classifyMissingWorktree(diag.WorktreeRegistrationKnown, diag.WorktreeRegistered, teardownIntent)
+
+	log.ErrorLog.Printf(
+		"WORKTREE_MISSING_DETECTED classification=%q title=%q instance_id=%q repo_id=%q repo_path=%q worktree_path=%q branch=%q liveness=%q status=%q started=%t user_killed=%t kill_in_flight=%t in_flight_op=%d external_worktree=%t branch_created_by_us=%t observed_at=%q parent_path=%q parent_exists=%t parent_stat_error=%q repo_exists=%t repo_stat_error=%q git_worktree_registered=%q git_worktree_list_error=%q branch_exists=%q branch_probe_error=%q recover_error=%q",
+		classification,
+		inst.Title,
+		inst.ID,
+		repoID,
+		diag.RepoPath,
+		worktreePath,
+		branch,
+		livenessLabel(liveness),
+		statusLabel(inst.GetStatus()),
+		inst.Started(),
+		userKilled,
+		killInFlight,
+		op,
+		diag.ExternalWorktree,
+		diag.BranchCreatedByUs,
+		time.Now().UTC().Format(time.RFC3339Nano),
+		diag.ParentPath,
+		diag.ParentExists,
+		diag.ParentStatError,
+		diag.RepoExists,
+		diag.RepoStatError,
+		triBool(diag.WorktreeRegistrationKnown, diag.WorktreeRegistered),
+		diag.WorktreeListError,
+		triBool(diag.BranchKnown, diag.BranchExists),
+		diag.BranchError,
+		restoreErr.Error(),
+	)
+}
+
+func missingWorktreePath(err error) (string, bool) {
+	var wtErr *session.WorktreeUnavailableError
+	if !errors.As(err, &wtErr) || !errors.Is(err, os.ErrNotExist) {
+		return "", false
+	}
+	if wtErr.WorktreePath == "" {
+		return "<empty>", true
+	}
+	return wtErr.WorktreePath, true
+}
+
+func (st *lostRestoreState) vanishedWorktreeWasLogged(path string) bool {
+	if st == nil || st.vanishedWorktreesLogged == nil {
+		return false
+	}
+	_, ok := st.vanishedWorktreesLogged[path]
+	return ok
+}
+
+func classifyMissingWorktree(registrationKnown, registered, teardownIntent bool) string {
+	if teardownIntent {
+		return "expected_teardown"
+	}
+	if registrationKnown && registered {
+		return "unexpected_external_removal"
+	}
+	if registrationKnown {
+		return "missing_unregistered_live_worktree"
+	}
+	return "missing_worktree_registration_unknown"
+}
+
+func triBool(known, value bool) string {
+	if !known {
+		return "unknown"
+	}
+	return strconv.FormatBool(value)
+}
+
+func livenessLabel(lv session.Liveness) string {
+	switch lv {
+	case session.LivenessUnset:
+		return "LivenessUnset"
+	case session.LiveRunning:
+		return "LiveRunning"
+	case session.LiveReady:
+		return "LiveReady"
+	case session.LiveLost:
+		return "LiveLost"
+	case session.LiveDead:
+		return "LiveDead"
+	case session.LiveArchived:
+		return "LiveArchived"
+	case session.LiveLimitReached:
+		return "LiveLimitReached"
+	default:
+		return "Liveness(" + strconv.Itoa(int(lv)) + ")"
+	}
+}
+
+func statusLabel(s session.Status) string {
+	switch s {
+	case session.Running:
+		return "Running"
+	case session.Ready:
+		return "Ready"
+	case session.Loading:
+		return "Loading"
+	case session.Deleting:
+		return "Deleting"
+	case session.Dead:
+		return "Dead"
+	case session.Lost:
+		return "Lost"
+	case session.Archived:
+		return "Archived"
+	default:
+		return "Status(" + strconv.Itoa(int(s)) + ")"
+	}
 }

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -1,13 +1,23 @@
 package daemon
 
 import (
+	"bytes"
 	"errors"
+	stdlog "log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/cmd/cmd_test"
 	"github.com/sachiniyer/agent-factory/config"
+	aflog "github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	sessiongit "github.com/sachiniyer/agent-factory/session/git"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // recoverFakeBackend counts Recover calls and emulates LocalBackend.Recover's
@@ -127,6 +137,96 @@ func TestRestoreLostSessions_BacksOffBetweenFailures(t *testing.T) {
 
 	if got := backend.recoverCalls(); got != 1 {
 		t.Fatalf("passes inside the backoff window must not re-attempt: want 1, got %d", got)
+	}
+}
+
+type failPtyFactory struct{}
+
+func (failPtyFactory) Start(*exec.Cmd) (*os.File, error) {
+	return nil, errors.New("tmux spawn should not be reached when worktree is missing")
+}
+
+func (failPtyFactory) Close() {}
+
+// TestRestoreLostSessions_LogsVanishedWorktreeOnce covers the #1303
+// instrumentation: when a live registered Lost session points at a worktree
+// directory that disappeared but Git still has the worktree admin entry, the
+// daemon emits one high-visibility ERROR with the diagnostic context and does
+// not repeat it on the next retry.
+func TestRestoreLostSessions_LogsVanishedWorktreeOnce(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	zeroRestoreBackoff(t)
+
+	worktreePath := filepath.Join(t.TempDir(), "repo-vanished")
+	branch := "af/vanished-worktree"
+	if out, err := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branch, worktreePath).CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	gw, err := sessiongit.NewGitWorktreeFromStorage(repoPath, worktreePath, "vanished", branch, "", false, true)
+	if err != nil {
+		t.Fatalf("NewGitWorktreeFromStorage: %v", err)
+	}
+	if err := os.RemoveAll(worktreePath); err != nil {
+		t.Fatalf("remove worktree directory: %v", err)
+	}
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "vanished", Path: repoPath, Program: "claude"})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	inst.Branch = branch
+	inst.SetBackend(&session.LocalBackend{})
+	inst.SetStartedForTest(true)
+	inst.SetStatus(session.Lost)
+	inst.SetGitWorktreeForTest(gw)
+	inst.SetTmuxSession(tmux.NewTmuxSessionFromSanitizedNameWithDeps(
+		"af_1303_vanished",
+		"claude",
+		failPtyFactory{},
+		cmd_test.MockCmdExec{
+			RunFunc: func(*exec.Cmd) error {
+				return errors.New("tmux command should not be reached when worktree is missing")
+			},
+			OutputFunc: func(*exec.Cmd) ([]byte, error) {
+				return nil, errors.New("tmux command should not be reached when worktree is missing")
+			},
+		},
+	))
+
+	seedDiskInstance(t, repoID, "vanished", repoPath)
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(repoID, "vanished")] = inst
+	manager.mu.Unlock()
+
+	var buf bytes.Buffer
+	prevError := aflog.ErrorLog
+	aflog.ErrorLog = stdlog.New(&buf, "ERROR: ", 0)
+	t.Cleanup(func() { aflog.ErrorLog = prevError })
+
+	manager.RestoreLostSessions()
+	manager.RestoreLostSessions()
+
+	logged := buf.String()
+	if count := strings.Count(logged, "WORKTREE_MISSING_DETECTED"); count != 1 {
+		t.Fatalf("missing-worktree diagnostic count = %d, want 1; logs:\n%s", count, logged)
+	}
+	for _, want := range []string{
+		`classification="unexpected_external_removal"`,
+		`title="vanished"`,
+		`repo_id="` + repoID + `"`,
+		`worktree_path="` + worktreePath + `"`,
+		`branch="` + branch + `"`,
+		`liveness="LiveLost"`,
+		`status="Lost"`,
+		`parent_exists=true`,
+		`repo_exists=true`,
+		`git_worktree_registered="true"`,
+		`branch_exists="true"`,
+		`recover_error="recover: session \"vanished\" worktree unavailable: stat `,
+	} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("missing diagnostic field %s in logs:\n%s", want, logged)
+		}
 	}
 }
 

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -63,6 +63,24 @@ type LocalBackend struct{}
 
 func (b *LocalBackend) Type() string { return "local" }
 
+// WorktreeUnavailableError marks a recover/respawn failure caused by the
+// persisted worktree path being unavailable before tmux is touched. The daemon
+// uses the typed shape to add one-shot diagnostics for vanished live worktrees
+// without parsing error strings (#1303).
+type WorktreeUnavailableError struct {
+	Title        string
+	WorktreePath string
+	Err          error
+}
+
+func (e *WorktreeUnavailableError) Error() string {
+	return fmt.Sprintf("recover: session %q worktree unavailable: %v", e.Title, e.Err)
+}
+
+func (e *WorktreeUnavailableError) Unwrap() error {
+	return e.Err
+}
+
 func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 	if strings.TrimSpace(i.Title) == "" {
 		return fmt.Errorf("instance title cannot be empty")
@@ -311,7 +329,7 @@ func (b *LocalBackend) respawn(i *Instance) error {
 		// Surface the real cause instead of a generic tmux new-session error:
 		// a deleted worktree is the expected permanent-failure shape, and the
 		// restore loop's escalation log should say so.
-		return fmt.Errorf("recover: session %q worktree unavailable: %w", i.Title, err)
+		return &WorktreeUnavailableError{Title: i.Title, WorktreePath: workDir, Err: err}
 	}
 
 	ts.SetProgram(injectSystemPrompt(resolveProgramForInstance(i)))

--- a/session/git/worktree_diagnose.go
+++ b/session/git/worktree_diagnose.go
@@ -1,0 +1,83 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MissingWorktreeDiagnosis is a cheap filesystem/git snapshot captured when a
+// live session points at a worktree directory that no longer exists (#1303).
+type MissingWorktreeDiagnosis struct {
+	RepoPath     string
+	WorktreePath string
+	BranchName   string
+	ParentPath   string
+
+	RepoExists    bool
+	RepoStatError string
+
+	ParentExists    bool
+	ParentStatError string
+
+	WorktreeRegistrationKnown bool
+	WorktreeRegistered        bool
+	WorktreeListError         string
+
+	BranchKnown  bool
+	BranchExists bool
+	BranchError  string
+
+	ExternalWorktree  bool
+	BranchCreatedByUs bool
+}
+
+// DiagnoseMissingWorktree captures low-cost context that helps distinguish a
+// directory removed out from under a live session from a teardown that also
+// cleaned up git's worktree registration. It is intentionally local-only: stat,
+// git worktree list, and git show-ref.
+func (g *GitWorktree) DiagnoseMissingWorktree() MissingWorktreeDiagnosis {
+	d := MissingWorktreeDiagnosis{
+		RepoPath:          g.repoPath,
+		WorktreePath:      g.worktreePath,
+		BranchName:        g.branchName,
+		ParentPath:        filepath.Dir(g.worktreePath),
+		ExternalWorktree:  g.externalWorktree,
+		BranchCreatedByUs: g.branchCreatedByUs,
+	}
+
+	if g.repoPath != "" {
+		if _, err := os.Stat(g.repoPath); err == nil {
+			d.RepoExists = true
+		} else {
+			d.RepoStatError = err.Error()
+		}
+	}
+
+	if g.worktreePath != "" {
+		if _, err := os.Stat(d.ParentPath); err == nil {
+			d.ParentExists = true
+		} else {
+			d.ParentStatError = err.Error()
+		}
+	}
+
+	if registered, err := g.isWorktreeRegistered(); err == nil {
+		d.WorktreeRegistrationKnown = true
+		d.WorktreeRegistered = registered
+	} else {
+		d.WorktreeListError = err.Error()
+	}
+
+	if strings.TrimSpace(g.branchName) != "" {
+		if _, err := g.runGitCommand(g.repoPath, "show-ref", "--verify", "refs/heads/"+g.branchName); err == nil {
+			d.BranchKnown = true
+			d.BranchExists = true
+		} else {
+			d.BranchKnown = true
+			d.BranchError = err.Error()
+		}
+	}
+
+	return d
+}


### PR DESCRIPTION
## Summary
- add a typed local-recover worktree-unavailable error for the missing-directory stat path
- add cheap git/filesystem diagnostics for vanished worktrees: parent/repo presence, git worktree registration, branch presence, ownership flags
- emit one WORKTREE_MISSING_DETECTED ERROR per distinct missing worktree during Lost recovery, with session title, instance id, path, branch, liveness, timestamp, and classification

Fixes #1303.

## Tests
- GOTOOLCHAIN=go1.24.2 go run -a github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0
- gofmt -l .
- go build ./...
- make test-container
- scripts/lint-file-length.sh
- deadcode -test ./...