### PR TITLE
refactor(session): route restore through the transition() chokepoint (#1195 Phase 2d)

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -1082,18 +1082,17 @@ func (i *Instance) RestoreArchivedWorktree(dest string) error {
 // out from under the restore. This replaces the old "park it in Lost purely to
 // trigger the re-spawn loop" overload (#1195).
 func (i *Instance) RestoreFromArchive() error {
-	i.mu.Lock()
-	i.started = true
-	i.liveness = LiveLost
-	i.inFlightOp = OpRestoring
-	i.mu.Unlock()
+	// Enter the restore fence through the chokepoint (#1195 Phase 2d): BeginRestore
+	// is legal only from Archived and sets started=true + Lost + OpRestoring — the
+	// exact head this used to write by hand, now enforcing I3 (a restore may begin
+	// only from an archived session; no double-restore).
+	if err := i.Transition(BeginRestore()); err != nil {
+		return err
+	}
 	if err := i.backend.Recover(i); err != nil {
-		// Re-spawn failed: drop the fence to a plain Lost so the #1108
-		// restore loop owns the retry against the now-restored worktree.
-		i.mu.Lock()
-		i.liveness = LiveLost
-		i.inFlightOp = OpNone
-		i.mu.Unlock()
+		// Re-spawn failed: drop the fence to a plain Lost (started left true) so
+		// the #1108 restore loop owns the retry against the now-restored worktree.
+		_ = i.Transition(AbortRestoreToLost())
 		return err
 	}
 	return nil


### PR DESCRIPTION
**Phase 2d of the #1195 structural-health epic** — the first **writer migration** onto the `Transition()` chokepoint (audit #6). Builds on merged 2a/2b/2c. Root-approved design: https://github.com/sachiniyer/agent-factory/issues/1195#issuecomment-4888497895

## What

`RestoreFromArchive`'s hand-written state mutations now route through `Instance.Transition`, so invariant **I3** (a restore may begin only from an archived session; no double-restore) is enforced **live** by the allowed-edge table instead of by convention.

- Restore head (`started=true, Lost, OpRestoring`) → **`Transition(BeginRestore())`** — legal only from `(Archived, None)`, sets `started=true` exactly as before (the Greptile #1314 fix).
- Re-spawn-failure tail (`Lost, OpNone`, started left true) → **`Transition(AbortRestoreToLost())`**.

## Behavior-preserving

The only prod caller is the daemon's `RestoreArchived`, which gates on `liveness==Archived` (re-verified under the op-lock) before calling in — so the instance is always `(Archived, None)` at the transition and `BeginRestore` never rejects in production. A rejection would only fire if a future caller bypassed the guard (surfaced as the soft error / panic-in-test the chokepoint provides). The resulting `(started, liveness, op)` on both success and failure paths is **identical** to the old direct field writes.

Scoped deliberately small (**restore flow only**) per the serialized, behavior-preserving 2d plan. **Archive (I2/I4)**, **kill/create (I1)**, and the **TUI optimistic ops** migrate in follow-up PRs.

## Gates (all green)

`go build`, `gofmt -l .` empty, `go vet`, `deadcode -test ./...` clean, `golangci-lint --fast`, file-length lint, and **`make test-container`** — full suite incl. the daemon `archive_test` restore round-trip + `lostrestore_test`.

Behavior-preserving refactor; the archive/restore area is behavior-sensitive, so a **restore + failed-respawn play-test** is worth a pass on your side. Refs #1195 (2d continues + Phase 3 remain — do not close).

— Captain Claude