### PR TITLE
fix(tui): rename Preview tab to Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Docs](https://img.shields.io/badge/docs-live-2e7c80)](https://sachiniyer.github.io/agent-factory/)
 [![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-2e7c80)](LICENSE.md)
 
-![Agent Factory demo: multiple AI coding agents running in isolated git worktrees, with live previews, scheduled automations, helper tabs, and full-screen attach](docs/assets/demo.gif)
+![Agent Factory demo: multiple AI coding agents running in isolated git worktrees, with live Agent tabs, scheduled automations, helper tabs, and full-screen attach](docs/assets/demo.gif)
 
 Agent Factory (`af`) is a terminal UI for running many AI coding agents at once:
 Claude Code, Codex, Aider, and Gemini. Each normal session gets its own git
@@ -21,7 +21,7 @@ branded docs site.
 ## Why Agent Factory
 
 - **Worktree isolation:** one agent, one branch, one reviewable working tree.
-- **One-screen supervision:** watch live previews, attach full-screen, and add
+- **One-screen supervision:** watch agents live, attach full-screen, and add
   helper tabs beside an agent in the same worktree.
 - **Daemon-owned state:** sessions, tasks, usage-limit recovery, and APIs share
   one source of truth.

--- a/app/handle_enter_remote_terminal_test.go
+++ b/app/handle_enter_remote_terminal_test.go
@@ -35,7 +35,7 @@ func swapAttachOverlayCallbackFn(t *testing.T, fn func(*home, string, string, st
 }
 
 // driveHandleEnterAttach presses Enter on a single instance (remote or local)
-// with either the Terminal or the sidebar (Preview) tab active, and returns the
+// with either the Terminal or the sidebar Agent tab active, and returns the
 // post-detach cmd plus whatever was written to the remote-detach reset writer.
 //
 // The first-time attach help overlay is marked seen so showHelpScreen runs the
@@ -70,7 +70,7 @@ func driveHandleEnterAttach(t *testing.T, terminalTab, remote bool) (tea.Cmd, st
 		h.store.SetActiveTab(1)
 		require.Equal(t, 1, h.store.ActiveTab(), "precondition: Terminal tab must be active")
 	} else {
-		require.Equal(t, 0, h.store.ActiveTab(), "precondition: sidebar (Preview) tab must be active")
+		require.Equal(t, 0, h.store.ActiveTab(), "precondition: sidebar Agent tab must be active")
 	}
 
 	var out bytes.Buffer

--- a/app/layout_cutover_test.go
+++ b/app/layout_cutover_test.go
@@ -51,7 +51,7 @@ func TestLayoutCutover_ViewComposesFullWindow(t *testing.T) {
 		view := h.View()
 		requireViewSized(t, view, tc.w, tc.h)
 		assert.Contains(t, view, "Agent Factory", "%dx%d: tree title", tc.w, tc.h)
-		assert.Contains(t, view, "alpha · Preview", "%dx%d: pane header carries title · tab", tc.w, tc.h)
+		assert.Contains(t, view, "alpha · Agent", "%dx%d: pane header carries title · tab", tc.w, tc.h)
 		// The header ellipsizes at the narrowest rails, so assert the stable
 		// prefix plus the manage affordance FIX 2 guarantees is never cut.
 		assert.Contains(t, view, "Automation", "%dx%d: automations section", tc.w, tc.h)
@@ -313,7 +313,7 @@ func TestE2E_LayoutCutover_FocusRingAndHooksOverlay(t *testing.T) {
 	// The workspace still renders the instance afterwards.
 	var view string
 	eh.query(func(h *home) { view = h.View() })
-	assert.Contains(t, view, "alpha · Preview")
+	assert.Contains(t, view, "alpha · Agent")
 }
 
 // TestLayoutCutover_DigitJumpGatedByFocusRegion pins the 1-9 gate (Greptile on

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -176,7 +176,7 @@ func TestPane_HeaderAnnotatesSelectionDivergence(t *testing.T) {
 	require.Same(t, alpha, paneA.Instance(), "selection must not retarget explicit panes")
 
 	view := h.View()
-	assert.Contains(t, view, "alpha · Preview · selected: beta · Preview",
+	assert.Contains(t, view, "alpha · Agent · selected: beta · Agent",
 		"the visible pane header must reconcile selected row vs shown content")
 }
 
@@ -270,9 +270,9 @@ func TestPane_NumberJumpAnnotatesSelectedTabDivergence(t *testing.T) {
 	assert.Equal(t, 1, paneB.Tab(), "focused beta pane jumps to tab 2")
 	assert.Equal(t, 0, h.store.ActiveTab(), "pane-focused jump must not retarget the sidebar selection")
 	view := h.View()
-	assert.Contains(t, view, "beta · Terminal · selected: beta · Preview",
+	assert.Contains(t, view, "beta · Terminal · selected: beta · Agent",
 		"pane header shows the jumped tab and the still-selected tree tab")
-	assert.Contains(t, view, "1 Preview *", "sidebar active-tab marker stays on the selected tab")
+	assert.Contains(t, view, "1 Agent *", "sidebar active-tab marker stays on the selected tab")
 }
 
 // TestPane_FocusRingCyclesNPanes: with three panes open, Tab cycles
@@ -777,7 +777,7 @@ func TestE2E_PaneFlow(t *testing.T) {
 	// Pane 2's tab label is whatever the shared active-tab index resolved to
 	// after the tree walk (the index survives instance switches by design),
 	// so assert the instance halves only.
-	assert.Contains(t, view, "alpha · Preview", "pane 1 header shows its binding")
+	assert.Contains(t, view, "alpha · Agent", "pane 1 header shows its binding")
 	assert.Contains(t, view, "beta · ", "pane 2 header shows its binding")
 
 	// Tab from the beta pane wraps via automations/tree back around to the

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -327,7 +327,7 @@ func TestFreshInstanceSingleTabSlotUI(t *testing.T) {
 	inst := freshLocalInstance(t, "fresh-ui")
 	selectInstance(h, inst)
 
-	require.Equal(t, []string{"Preview"}, tree.TabLabels(inst),
+	require.Equal(t, []string{"Agent"}, tree.TabLabels(inst),
 		"a fresh instance renders exactly one tab slot — the agent tab")
 
 	_, _ = h.handleTabJump(2)
@@ -345,7 +345,7 @@ func TestFreshInstanceSingleTabSlotUI(t *testing.T) {
 	stubTabDaemonSeams(t, inst)
 	_, _ = h.handleNewTab()
 	require.Equal(t, 2, inst.TabCount())
-	require.Equal(t, []string{"Preview", "Terminal"}, tree.TabLabels(inst),
+	require.Equal(t, []string{"Agent", "Terminal"}, tree.TabLabels(inst),
 		"after t the terminal is a real second slot")
 	require.Equal(t, 1, h.store.ActiveTab(), "t selects the fresh terminal")
 

--- a/app/tree_nav_test.go
+++ b/app/tree_nav_test.go
@@ -54,7 +54,7 @@ func TestTreeNav_JKWalksTabChildren(t *testing.T) {
 	sel := h.sidebar.GetSelection()
 	assert.True(t, sel.IsTab)
 	assert.Equal(t, 0, h.store.ActiveTab())
-	assert.Equal(t, 0, h.store.ActiveTab(), "the agent (Preview) slot is active")
+	assert.Equal(t, 0, h.store.ActiveTab(), "the Agent slot is active")
 
 	pressNav(t, h, "j")
 	sel = h.sidebar.GetSelection()

--- a/docs/assets/demo-agent.sh
+++ b/docs/assets/demo-agent.sh
@@ -7,7 +7,7 @@
 #
 # The transcript is chosen from the worktree/branch name, so each demo session
 # ("fix-auth-timeout", "add-dark-mode", …) tells its own little story in the
-# preview pane. Nothing here talks to the network or a real model.
+# Agent tab. Nothing here talks to the network or a real model.
 set -u
 
 c_cyan=$'\033[36m'; c_yellow=$'\033[33m'; c_blue=$'\033[34m'

--- a/docs/assets/demo-tab.sh
+++ b/docs/assets/demo-tab.sh
@@ -12,7 +12,7 @@
 #     workspace pane the way the agent transcript (pre-streamed at native
 #     width) would not.
 #   * ASCII-only markers. The tab is a raw passthrough terminal (unlike the
-#     agent Preview, which af renders itself), so multibyte glyphs like the
+#     Agent tab, which af renders itself), so multibyte glyphs like the
 #     Vite "arrow" can degrade to a box/underscore depending on the pane's
 #     locale. A plain ">" bullet reads just as well and never mangles.
 # Nothing here talks to the network.

--- a/docs/concepts/tui.md
+++ b/docs/concepts/tui.md
@@ -16,7 +16,7 @@ af
 - **Sidebar.** Every session, with a live status indicator (running, waiting on
   you, hit a usage limit, dead-and-being-recovered). Sessions are grouped and
   navigable with the arrow keys or `j`/`k`.
-- **Preview pane.** A snapshot of the selected agent's terminal, updated as it
+- **Agent tab.** A snapshot of the selected agent's terminal, updated as it
   works — so you can follow progress across several agents without attaching to
   any of them. Toggle it with `s` (open) and `x` (hide).
 

--- a/docs/concepts/worktree-agents.md
+++ b/docs/concepts/worktree-agents.md
@@ -33,7 +33,7 @@ Because each session gets its own worktree:
    [configuration](../configuration.md) for the subdirectory option), and starts
    your chosen agent in that directory. Any configured post-worktree setup commands
    run first, so the agent starts in a ready environment.
-2. **Work.** The agent runs in its worktree. You watch it in the preview pane,
+2. **Work.** The agent runs in its worktree. You watch it in the Agent tab,
    interact in-pane, or attach full-screen. Extra [tabs](tui.md#tabs) can run a
    shell or a long-lived process (a dev server, a test watcher) in the *same*
    worktree, sharing the agent's files.
@@ -60,7 +60,7 @@ Everything above describes **local** sessions — worktrees on the machine runni
 `af`. Sessions can also run on a **remote** backend you define, through
 [remote hooks](../remote-hooks.md): your own scripts launch, list, attach to,
 and delete sessions elsewhere, and they show up in the same sidebar with the
-same preview/attach/kill experience. The worktree-isolation model is the same;
+same Agent tab, attach, and kill experience. The worktree-isolation model is the same;
 only the machine changes.
 
 ## Who owns the state

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,7 +46,7 @@ The TUI opens with an empty sidebar. From here:
 1. Press **`n`** to create a new session. Give it a name and, optionally, an
    choose the agent with **Tab**. `af` creates a fresh git worktree on a new
    branch and starts your agent in it.
-2. The session appears in the sidebar with a live status. The **preview pane**
+2. The session appears in the sidebar with a live status. The **Agent tab**
    on the right shows a snapshot of the agent's terminal — you can watch its
    progress without attaching.
 3. Press **`↵`** (Enter) to **interact** with the selected agent right in the
@@ -99,6 +99,6 @@ See [The daemon](concepts/daemon.md) for what it owns and why.
 
 - [Concepts: worktree-isolated agents](concepts/worktree-agents.md) — the core
   model.
-- [The TUI](concepts/tui.md) — the sidebar, preview, tabs, and key bindings.
+- [The TUI](concepts/tui.md) — the sidebar, Agent tab, tabs, and key bindings.
 - [Configuration](configuration.md) — choosing agents, global vs. in-repo
   config, and every key.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ hide:
 
     ---
 
-    A sidebar lists every session with live status; the preview pane snapshots
+    A sidebar lists every session with live status; the Agent tab snapshots
     any agent without attaching; `↵` takes you full-screen. Extra tabs run a
     shell or dev server alongside the agent in the same worktree.
 
@@ -56,7 +56,7 @@ hide:
 
     With remote hooks, sessions run on a backend you define — your own
     launch/list/attach/delete scripts — and appear in the same sidebar with the
-    same attach, kill, and preview experience.
+    same Agent tab, attach, and kill experience.
 
     [:octicons-arrow-right-24: Remote hooks](remote-hooks.md)
 
@@ -80,7 +80,7 @@ HTTP API can never show you three different worlds.
 
 ```
         ┌──────────────────────────────────────────────┐
-        │  af TUI  (sidebar · preview · attach · tabs)  │
+        │  af TUI  (sidebar · agent · attach · tabs)    │
         └──────────────────────┬───────────────────────┘
                                │ read-only projection + RPC
         ┌──────────────────────┴───────────────────────┐

--- a/docs/remote-hooks.md
+++ b/docs/remote-hooks.md
@@ -1,6 +1,6 @@
 # Remote Hooks
 
-Agent Factory supports remote machine backends via user-provided hook scripts. When configured, remote sessions appear alongside local sessions in the TUI with the same attach/kill/preview experience.
+Agent Factory supports remote machine backends via user-provided hook scripts. When configured, remote sessions appear alongside local sessions in the TUI with the same Agent tab, attach, and kill experience.
 
 ## Configuration
 
@@ -123,16 +123,16 @@ Agent Factory runs this command behind a local PTY and intercepts the configured
 
 When the attach stream ends — whether by the detach key or natural exit — Agent Factory emits terminal reset sequences that restore the local terminal to a neutral state: main screen buffer, cursor visible, no scroll region, all mouse/focus/paste reporting modes off. Your script does not need to emit these sequences; Agent Factory handles cleanup automatically (#845).
 
-Agent Factory also uses this script for the preview pane by running it in a background process and capturing its output.
+Agent Factory also uses this script for the Agent tab by running it in a background process and capturing its output.
 
-#### Preview output contract
+#### Agent tab output contract
 
-Preview output is rendered **inside a TUI pane**, not on a raw terminal. Two rules apply to the captured stream:
+Captured output is rendered **inside a TUI pane**, not on a raw terminal. Two rules apply to the captured stream:
 
 - **Control sequences are stripped.** Cursor movement, erase, scroll-region, alt-screen, and mode sequences (e.g. `\033[H`, `\033[?1049h`, `\033[?25l`), OSC strings, and bare carriage returns are removed before rendering — only SGR color sequences (`\033[...m`) and plain text (with `\n`/`\t`) reach the pane. Scripts don't need to avoid emitting these, but they have no effect.
 - **`\033[2J` (clear screen) starts a fresh snapshot.** Everything captured before the last `\033[2J` is discarded, so a clear-then-capture loop replaces the previous frame instead of concatenating stale ones.
 
-A preview-friendly capture loop looks like:
+A capture loop for the Agent tab looks like:
 
 ```bash
 while true; do
@@ -142,7 +142,7 @@ while true; do
 done
 ```
 
-Each iteration becomes the new preview frame. `capture-pane -e` keeps colors; they are preserved in the pane.
+Each iteration becomes the new Agent tab frame. `capture-pane -e` keeps colors; they are preserved in the pane.
 
 ### `terminal_cmd` (optional)
 
@@ -158,8 +158,8 @@ Agent Factory runs this command behind a local PTY with the same detach-key hand
 
 Remote sessions follow the same ephemeral-tab model as local ones (see the README "Tabs" section), with one structural difference driven by the protocol:
 
-- A remote session **always** has an agent tab (driven by `attach_cmd` and the preview loop above).
-- It has a **terminal tab if and only if `terminal_cmd` is configured.** Attaching to that tab runs `terminal_cmd`; previewing it shows a "Press Enter to open a terminal" prompt (the surface is interactive-only — `terminal_cmd` is never used for preview capture).
+- A remote session **always** has an Agent tab (driven by `attach_cmd` and the capture loop above).
+- It has a **terminal tab if and only if `terminal_cmd` is configured.** Attaching to that tab runs `terminal_cmd`; viewing it in the TUI shows a "Press Enter to open a terminal" prompt (the surface is interactive-only — `terminal_cmd` is never used for preview capture).
 - When `terminal_cmd` is **not** configured, a remote session has only its agent tab, and the would-be Terminal tab shows a "not available — configure `remote_hooks.terminal_cmd`" fallback.
 
 Because the protocol has no run-arbitrary-command verb, remote sessions **cannot** host extra process tabs: the `t` new-tab key, `af sessions tab-create`, and `af sessions tab-delete` are rejected for remote sessions with a message pointing at `terminal_cmd`. A remote session's terminal tab is the one defined by `terminal_cmd` and nothing else. These tabs persist across an `af`/daemon restart like local tabs, but are reconstructed from your live `terminal_cmd` config on restore rather than from any saved local session — so adding or removing `terminal_cmd` while `af` is down is honored on the next start.

--- a/docs/tui-manual-testing.md
+++ b/docs/tui-manual-testing.md
@@ -61,7 +61,7 @@ text-greppable selection signal the driver asserts on:
 
 ```
   ▾ 1.  alpha         ●      ← selected (expanded); ● = ready
-       └ 1 Preview *
+       └ 1 Agent *
   ▸ 2.  beta          ●      ← not selected (collapsed)
 ```
 

--- a/scripts/container/record-demo.sh
+++ b/scripts/container/record-demo.sh
@@ -155,7 +155,7 @@ EOF
     beat 0.9
     # Act 5 (finale) — a tab is a real process in the worktree, not another
     # agent. Open a second tab on the first agent (t auto-tiles a
-    # Preview | Terminal split), step in (Enter → interact in-pane, no full-
+    # Agent | Terminal split), step in (Enter → interact in-pane, no full-
     # screen), and run the dev server — it streams live beside the agent's own
     # transcript. This is the closing shot: an agent and a running dev-server
     # side by side in one worktree. Ending here (rather than tearing the split

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -252,7 +252,7 @@ func (m *Menu) addInstanceOptions() {
 	actionGroup := []keys.KeyName{keys.KeyEnter, keys.KeyAttach}
 
 	// Navigation group: every tab is a captured tmux session and supports
-	// scroll mode (#930 PR 2 — the agent "Preview" tab and the terminal tab
+	// scroll mode (#930 PR 2 — the Agent tab and the terminal tab
 	// both scroll), so the scroll keys always show for an instance.
 	actionGroup = append(actionGroup, keys.KeyShiftUp)
 	actionGroup = append(actionGroup, keys.KeyShiftDown)

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -44,11 +44,11 @@ func TestMenuTerminalTabShowsBothScrollKeys(t *testing.T) {
 	}
 }
 
-// TestMenuPreviewTabShowsBothScrollKeys verifies that the preview tab also
-// surfaces both scroll shortcuts — preview supports scrolling identically to
+// TestMenuAgentTabShowsBothScrollKeys verifies that the Agent tab also
+// surfaces both scroll shortcuts — the agent output supports scrolling identically to
 // terminal, and the help screen documents the shortcuts for both. Regression
 // test for issue #467.
-func TestMenuPreviewTabShowsBothScrollKeys(t *testing.T) {
+func TestMenuAgentTabShowsBothScrollKeys(t *testing.T) {
 	m := NewMenu()
 	m.SetInstance(readyUIInstance())
 	m.SetActiveTab(0)
@@ -64,10 +64,10 @@ func TestMenuPreviewTabShowsBothScrollKeys(t *testing.T) {
 	}
 
 	if gotShiftUp != 1 {
-		t.Errorf("expected exactly 1 KeyShiftUp in preview tab menu, got %d", gotShiftUp)
+		t.Errorf("expected exactly 1 KeyShiftUp in agent tab menu, got %d", gotShiftUp)
 	}
 	if gotShiftDown != 1 {
-		t.Errorf("expected exactly 1 KeyShiftDown in preview tab menu, got %d", gotShiftDown)
+		t.Errorf("expected exactly 1 KeyShiftDown in agent tab menu, got %d", gotShiftDown)
 	}
 }
 

--- a/ui/sidebar_tree_test.go
+++ b/ui/sidebar_tree_test.go
@@ -61,7 +61,7 @@ func TestSidebarTreeRendersTabChildren(t *testing.T) {
 
 	s.SetSelectedInstance(0)
 	out = s.String()
-	assert.Contains(t, out, "├ 1 Preview *", "agent tab child with slot number and active marker")
+	assert.Contains(t, out, "├ 1 Agent *", "agent tab child with slot number and active marker")
 	assert.Contains(t, out, "└ 2 Terminal", "terminal tab child with └ terminator")
 	assert.Contains(t, out, "▾", "selected instance shows the expanded arrow")
 	assert.Contains(t, out, "▸", "non-selected instance stays collapsed")
@@ -71,7 +71,7 @@ func TestSidebarTreeRendersTabChildren(t *testing.T) {
 	s.proj.SetActiveTab(1)
 	out = s.String()
 	assert.Contains(t, out, "└ 2 Terminal *")
-	assert.NotContains(t, out, "├ 1 Preview *")
+	assert.NotContains(t, out, "├ 1 Agent *")
 }
 
 // TestSidebarTreeFreshInstanceSingleTabRow pins the #1100 tree rendering: a
@@ -92,7 +92,7 @@ func TestSidebarTreeFreshInstanceSingleTabRow(t *testing.T) {
 
 	require.Equal(t, 1, tabRowCount(s), "fresh instance: exactly one tab row")
 	out := s.String()
-	assert.Contains(t, out, "└ 1 Preview *", "the agent tab is the only — and last — child row")
+	assert.Contains(t, out, "└ 1 Agent *", "the agent tab is the only — and last — child row")
 	assert.NotContains(t, out, "Terminal", "no phantom Terminal row before t is pressed")
 
 	// `t` materializes the shell tab; the tree grows a real second row.

--- a/ui/sidebar_zones_test.go
+++ b/ui/sidebar_zones_test.go
@@ -81,7 +81,7 @@ func TestSidebarRegistersRowZones(t *testing.T) {
 
 	// The selected (expanded) instance registers its tab child rows, and each
 	// zone's row renders that tab's label.
-	for idx, label := range []string{"1 Preview", "2 Terminal"} {
+	for idx, label := range []string{"1 Agent", "2 Terminal"} {
 		r, ok := reg.Find(zones.TreeTab("t-00", idx))
 		require.True(t, ok, "tab zone for slot %d; got %v", idx, reg.IDs())
 		assert.Equal(t, 1, r.H, "tab rows are single-line")

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -261,7 +261,7 @@ func (p *TabPane) updateShellLocked(instance *session.Instance, activeTab int) e
 		if instance.SupportsRemoteTerminal() {
 			p.setFallbackState("Press Enter to open a terminal on the remote machine.")
 		} else {
-			p.setFallbackState("Terminal tab not available for remote sessions.\nConfigure remote_hooks.terminal_cmd to enable it.\nUse the Preview tab to see session output.")
+			p.setFallbackState("Terminal tab not available for remote sessions.\nConfigure remote_hooks.terminal_cmd to enable it.\nUse the Agent tab to see session output.")
 		}
 		return nil
 	}

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -364,7 +364,7 @@ func (w *TabbedWindow) ScrollDown() {
 	}
 }
 
-// IsInPreviewTab returns true if the agent (Preview) tab is the pane's tab.
+// IsInPreviewTab returns true if the Agent tab is the pane's tab.
 func (w *TabbedWindow) IsInPreviewTab() bool {
 	return w.isAgentSlot()
 }

--- a/ui/tabbed_window_remote_test.go
+++ b/ui/tabbed_window_remote_test.go
@@ -47,7 +47,7 @@ func startedRemoteInstance(t *testing.T, withTerminal bool) *session.Instance {
 }
 
 // TestTabbedWindowRemoteTabBar verifies a remote instance is tab-driven: its
-// tab set is the agent (Preview) tab plus a Terminal tab only when
+// tab set is the Agent tab plus a Terminal tab only when
 // terminal_cmd is configured — never the local two-tab default when
 // terminal_cmd is absent.
 func TestTabbedWindowRemoteTabBar(t *testing.T) {
@@ -59,8 +59,8 @@ func TestTabbedWindowRemoteTabBar(t *testing.T) {
 		withTerm   bool
 		wantLabels []string
 	}{
-		{"with terminal_cmd shows agent + terminal", true, []string{"Preview", "Terminal"}},
-		{"without terminal_cmd shows only the agent tab", false, []string{"Preview"}},
+		{"with terminal_cmd shows agent + terminal", true, []string{"Agent", "Terminal"}},
+		{"without terminal_cmd shows only the agent tab", false, []string{"Agent"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			inst := startedRemoteInstance(t, tc.withTerm)

--- a/ui/tabbed_window_single_tab_test.go
+++ b/ui/tabbed_window_single_tab_test.go
@@ -20,7 +20,7 @@ func TestTabbedWindowSingleTabHeaderRendering(t *testing.T) {
 	inst := startedRemoteInstance(t, false)
 	w := newTestTabbedWindow()
 	setWindowInstance(w, inst)
-	require.Equal(t, []string{"Preview"}, w.tabLabels(), "remote without terminal_cmd has a single tab")
+	require.Equal(t, []string{"Agent"}, w.tabLabels(), "remote without terminal_cmd has a single tab")
 	require.Equal(t, 0, w.GetActiveTab(), "the lone tab is active")
 
 	setWindowSize(w, 120, 40)
@@ -28,7 +28,7 @@ func TestTabbedWindowSingleTabHeaderRendering(t *testing.T) {
 	lines := strings.Split(w.String(), "\n")
 	require.Greater(t, len(lines), 1, "expected the framed pane output")
 	headerRow := lines[1] // row 0 is the top border; the header is inside the frame
-	require.Contains(t, headerRow, "remote-tabbar · Preview",
+	require.Contains(t, headerRow, "remote-tabbar · Agent",
 		"the pane header must carry `title · tab`; got %q", headerRow)
 
 	require.False(t, w.JumpToTab(1), "the phantom second slot must not be jumpable")

--- a/ui/tabbed_window_test.go
+++ b/ui/tabbed_window_test.go
@@ -86,9 +86,9 @@ func TestTabbedWindowHeaderEllipsizesAtNarrowWidth(t *testing.T) {
 	w := newTestTabbedWindow()
 	setWindowInstance(w, inst)
 
-	// " remote-tabbar · Preview " needs 25 cells; give it 16.
+	// " remote-tabbar · Agent " needs 23 cells; give it 16.
 	header := w.renderHeader(16)
 	assert.LessOrEqual(t, lipgloss.Width(header), 16, "header must fit the pane width")
 	assert.Contains(t, header, "…", "the cut must be marked with an ellipsis")
-	assert.NotContains(t, header, "Preview", "the tail is truncated")
+	assert.NotContains(t, header, "Agent", "the tail is truncated")
 }

--- a/ui/tree/labels.go
+++ b/ui/tree/labels.go
@@ -10,12 +10,12 @@ import (
 // terminal tabs exist on demand only (#1100) — so promising a second slot
 // before the real tab list exists would manufacture a phantom jump/attach
 // target in every consumer of TabLabels.
-var placeholderTabLabels = []string{"Preview"}
+var placeholderTabLabels = []string{"Agent"}
 
 // TabLabels returns the display labels for an instance's tab slots — the
 // single source of truth shared by the TabbedWindow's header, the sidebar
 // tree (#1024 PR 3), and the 1-9 jump keys, so slot numbering can never
-// disagree between them. Agent tabs render as "Preview", shell tabs as
+// disagree between them. Agent tabs render as "Agent", shell tabs as
 // "Terminal"; any Process tab renders under its own name.
 //
 // Once an instance's tabs have materialized the labels mirror the real tab
@@ -41,7 +41,7 @@ func TabLabels(instance *session.Instance) []string {
 func labelForTab(tab *session.Tab) string {
 	switch tab.Kind {
 	case session.TabKindAgent:
-		return "Preview"
+		return "Agent"
 	case session.TabKindShell:
 		return "Terminal"
 	default:

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -362,8 +362,8 @@ func TestRenderTabRows(t *testing.T) {
 	r.SetWidth(30)
 	r.SetIndexWidth(1)
 
-	mid := ansiEscape.ReplaceAllString(r.RenderTab("Preview", 1, false, false, true), "")
-	assert.Contains(t, mid, "├ 1 Preview *", "active non-last tab: ├ connector + slot number + * marker")
+	mid := ansiEscape.ReplaceAllString(r.RenderTab("Agent", 1, false, false, true), "")
+	assert.Contains(t, mid, "├ 1 Agent *", "active non-last tab: ├ connector + slot number + * marker")
 
 	last := ansiEscape.ReplaceAllString(r.RenderTab("Terminal", 2, true, false, false), "")
 	assert.Contains(t, last, "└ 2 Terminal", "last tab uses the └ connector")
@@ -400,25 +400,25 @@ func TestFlatten(t *testing.T) {
 // mid-start) the placeholder is the single guaranteed slot, never a padded
 // two-slot bar that would advertise a phantom Terminal target.
 func TestTabLabelsMirrorRealTabs(t *testing.T) {
-	assert.Equal(t, []string{"Preview"}, TabLabels(nil),
+	assert.Equal(t, []string{"Agent"}, TabLabels(nil),
 		"nil instance: single-slot placeholder, no phantom Terminal")
 
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title: "labeled", Path: t.TempDir(), Program: "test",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"Preview"}, TabLabels(inst),
+	assert.Equal(t, []string{"Agent"}, TabLabels(inst),
 		"mid-start (no tabs yet): single-slot placeholder")
 
 	inst.AddTabForTest("agent", session.TabKindAgent)
-	assert.Equal(t, []string{"Preview"}, TabLabels(inst),
+	assert.Equal(t, []string{"Agent"}, TabLabels(inst),
 		"fresh instance (#1100): exactly one real slot, no padding to two")
 
 	inst.AddTabForTest("shell", session.TabKindShell)
-	assert.Equal(t, []string{"Preview", "Terminal"}, TabLabels(inst),
+	assert.Equal(t, []string{"Agent", "Terminal"}, TabLabels(inst),
 		"after t: the on-demand terminal is the second slot")
 
 	inst.AddTabForTest("btop", session.TabKindProcess)
-	assert.Equal(t, []string{"Preview", "Terminal", "btop"}, TabLabels(inst),
+	assert.Equal(t, []string{"Agent", "Terminal", "btop"}, TabLabels(inst),
 		"process tabs extend the list under their own names")
 }


### PR DESCRIPTION
## Summary
- Rename the shared TUI agent-output tab label from `Preview` to `Agent`.
- Update pane fallback copy, docs/demo text, and render/test assertions that exposed the old tab label.
- Keep the CLI `af sessions preview` command unchanged as a separate surface; it should only follow later if product decides to rename that CLI affordance too.

## Verification
- `gofmt`
- `go build ./...`
- `make test-container`
- `golangci-lint --fast` is not accepted by this installed golangci-lint; equivalent `golangci-lint run --fast` passed.
- `scripts/lint-file-length.sh`
- Did not run `scripts/tui-driver.sh` / driver play-test per #1303.

Closes #1322

Co-Authored-By: Captain Claude <noreply@anthropic.com>