### PR TITLE
Recover pane preview transaction for #1321

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -532,6 +532,10 @@ func (m *home) focusRegion(region string) {
 // only inside the tasks overlay, which saves on close (handleStateTasks) —
 // the in-rail automations section is read-only, so no save is needed here.
 func (m *home) cycleFocus(back bool) tea.Cmd {
+	if m.panePreviewTxn != nil {
+		m.cancelPanePreview(true)
+		return m.panesRefresh(m.attached.Load())
+	}
 	if back {
 		m.ring.Prev()
 	} else {
@@ -1104,6 +1108,10 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		if pane, bound := m.focusedContentPane(); pane != nil && pane.IsInScrollMode() {
 			if err := pane.ResetToNormalMode(bound); err != nil {
 				return m, m.handleError(err)
+			}
+			if m.panePreviewTxn != nil {
+				m.cancelPanePreview(true)
+				return m, m.panesRefresh(m.attached.Load())
 			}
 			return m, m.selectionChanged()
 		}

--- a/app/app.go
+++ b/app/app.go
@@ -182,6 +182,14 @@ type home struct {
 	// lastPaneCapture is when each pane's capture was last dispatched, keyed
 	// by pane id; the paneCaptureMinInterval throttle reads it (RFC §5.2).
 	lastPaneCapture map[int]time.Time
+	// panePreviewTxn is a transient #1321 preview binding owned by the most
+	// recently focused content pane. It never mutates the pane's committed
+	// store.OpenPane binding; commit/cancel semantics land in later PRs.
+	panePreviewTxn *panePreviewTxn
+	// lastFocusedPaneID remembers the focused pane before sidebar navigation
+	// re-homes focus to the tree (#1233/#1236). Preview-on-scroll uses it as
+	// the owner pane while the tree cursor moves.
+	lastFocusedPaneID int
 	// -- Live embedded terminal (#1089 PR 1, read-only proof path) --
 	//
 	// At most ONE pane holds a live termpane attachment: the focused pane
@@ -508,6 +516,7 @@ func (m *home) syncFocus() {
 	}
 	if p := m.focusedOpenPane(); p != nil {
 		m.store.TouchOpenPane(p)
+		m.lastFocusedPaneID = p.ID()
 	}
 	m.menu.SetFocusRegion(active)
 }
@@ -1360,6 +1369,7 @@ func (m *home) selectionChanged() tea.Cmd {
 		// just in the explicit tab-jump handlers.
 		m.menu.SetActiveTab(m.store.ActiveTab())
 		m.maybeAutoOpenInitialPane(selected)
+		m.updatePanePreview(selected, attachedNow)
 		detachTrace(selectionStart, "selectionChanged-instance-branch-built-cmds")
 		// Lazily refresh PR info when the user lands on an instance that
 		// hasn't been fetched recently. fetchPRInfoCmd is a no-op when the
@@ -1376,6 +1386,7 @@ func (m *home) selectionChanged() tea.Cmd {
 		// cold start with restored sessions landed on the empty workspace
 		// until the first cursor move (#1099 play-test).
 		m.maybeAutoOpenInitialPane(nil)
+		m.cancelPanePreview(false)
 		m.menu.SetInstance(nil)
 		if selected := m.store.GetSelectedInstance(); selected != nil && !m.store.ContainsInstance(selected) {
 			// The sticky binding dangles — its instance was removed (e.g. the
@@ -1477,7 +1488,8 @@ func (m *home) panesRefresh(attachedNow bool) tea.Cmd {
 			continue
 		}
 		m.lastPaneCapture[p.ID()] = time.Now()
-		cmds = append(cmds, refreshPanesCmd(w, p.Instance()))
+		binding, seq := m.renderBindingForPane(p)
+		cmds = append(cmds, refreshPaneBindingCmd(w, binding.instance, binding.tab, seq))
 	}
 	return tea.Batch(cmds...)
 }
@@ -1516,14 +1528,18 @@ type panesRefreshedMsg struct{}
 // refreshPanesCmd runs the active tab's capture off the bubbletea Update
 // goroutine. It shells out to `tmux capture-pane` (~3–5ms locally), which
 // previously blocked the event loop on every previewTickMsg (every 100ms) and
-// on every post-detach repaint. TabPane serialises its capture writes against
-// String() reads with an internal mutex, so the goroutine can mutate the
-// captured content concurrently with the renderer (#579).
+// on every post-detach repaint. TabPane serialises its state writes against
+// String() reads with an internal mutex, so the goroutine can publish captured
+// content concurrently with the renderer (#579).
 func refreshPanesCmd(tw *ui.TabbedWindow, selected *session.Instance) tea.Cmd {
+	return refreshPaneBindingCmd(tw, selected, tw.GetActiveTab(), tw.ContentSeq())
+}
+
+func refreshPaneBindingCmd(tw *ui.TabbedWindow, selected *session.Instance, activeTab int, seq uint64) tea.Cmd {
 	return func() tea.Msg {
 		cmdStart := time.Now()
 		detachTraceMark("refreshPanesCmd-goroutine-entry")
-		if err := tw.UpdateContent(selected); err != nil {
+		if err := tw.UpdateContentAt(selected, activeTab, seq); err != nil {
 			log.WarningLog.Printf("UpdateContent failed: %v", err)
 		}
 		detachTrace(cmdStart, "refreshPanesCmd-goroutine-exit")

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -790,6 +790,9 @@ func (m *home) handleTabJump(oneBased int) (tea.Model, tea.Cmd) {
 	idx := oneBased - 1
 	if p := m.focusedOpenPane(); p != nil {
 		w := m.paneWindows[p.ID()]
+		if m.panePreviewTxn != nil && m.panePreviewTxn.ownerPaneID == p.ID() {
+			m.cancelPanePreview(false)
+		}
 		if w == nil || !w.JumpToTab(idx) {
 			return m, nil
 		}

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -102,6 +102,7 @@ func (m *home) handleOpenPane() (tea.Model, tea.Cmd) {
 // pane already bound to it. The new/refocused pane is stamped most recently
 // focused, so the §2.6 fitting keeps it visible even at capacity.
 func (m *home) openOrFocusPane(instance *session.Instance, tab int) (tea.Model, tea.Cmd) {
+	m.cancelPanePreview(false)
 	p := m.store.FindOpenPane(instance, tab)
 	if p == nil {
 		p = m.openPaneWindow(instance, tab)
@@ -158,6 +159,9 @@ func (m *home) hidePane(p *store.OpenPane) {
 // tab-kill rebind, snapshot reconcile, dead-instance prune) goes through.
 // Callers relayout afterwards.
 func (m *home) closePaneWindow(p *store.OpenPane) {
+	if m.panePreviewTxn != nil && m.panePreviewTxn.ownerPaneID == p.ID() {
+		m.cancelPanePreview(false)
+	}
 	// Release the live termpane attachment before its window goes away —
 	// its (pane, window) binding is about to dangle (#1089).
 	if p == m.livePane {
@@ -240,6 +244,9 @@ func (m *home) reconcilePanesForTabs(instance *session.Instance, oldNames []stri
 			m.closePaneWindow(p)
 			changed = true
 		case idx != slot:
+			if m.panePreviewTxn != nil && m.panePreviewTxn.ownerPaneID == p.ID() {
+				m.cancelPanePreview(false)
+			}
 			p.SetTab(idx)
 			changed = true
 		}

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -72,6 +72,19 @@ func visibleTitles(h *home) []string {
 	return out
 }
 
+type previewTextBackend struct {
+	*session.FakeBackend
+	text string
+}
+
+func (b *previewTextBackend) Preview(*session.Instance) (string, error) {
+	return b.text, nil
+}
+
+func setPreviewText(inst *session.Instance, text string) {
+	inst.SetBackend(&previewTextBackend{FakeBackend: session.NewFakeBackend(), text: text})
+}
+
 func TestFirstRunWorkspaceEmptyState(t *testing.T) {
 	h := newTestHome(t)
 	resizeHome(h, 120, 30)
@@ -158,9 +171,9 @@ func TestPane_OpenAlreadyOpenFocuses(t *testing.T) {
 }
 
 // TestPane_HeaderAnnotatesSelectionDivergence is the #1289 session-level
-// reconciliation guard: open panes are explicit bindings, so selecting beta
-// must not silently make an alpha pane look like the selected workspace. The
-// header names both facts: what the pane is showing and which row is selected.
+// reconciliation guard with #1321 previews layered on: preview state must name
+// both the transient target and original pane, and canceling the preview must
+// restore the old selected-vs-shown header invariant.
 func TestPane_HeaderAnnotatesSelectionDivergence(t *testing.T) {
 	h := paneTestHome(t)
 	alpha := h.store.GetInstanceByTitle("alpha")
@@ -176,8 +189,80 @@ func TestPane_HeaderAnnotatesSelectionDivergence(t *testing.T) {
 	require.Same(t, alpha, paneA.Instance(), "selection must not retarget explicit panes")
 
 	view := h.View()
+	assert.Contains(t, view, "PREVIEW beta · Agent (original alpha · Agent)",
+		"preview header must reconcile transient target vs original pane")
+	assert.NotContains(t, view, "alpha · Agent · selected: beta · Agent",
+		"selected divergence is hidden while PREVIEW owns the render binding")
+
+	h.cancelPanePreview(false)
+	view = h.View()
 	assert.Contains(t, view, "alpha · Agent · selected: beta · Agent",
-		"the visible pane header must reconcile selected row vs shown content")
+		"canceling preview restores the #1289 selected row vs shown content invariant")
+}
+
+func TestPanePreviewInvalidatesStaleContentSynchronously(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+	setPreviewText(alpha, "ALPHA_PREVIEW_CONTENT")
+	setPreviewText(beta, "BETA_PREVIEW_CONTENT")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	w := h.paneWindows[paneA.ID()]
+	require.NotNil(t, w)
+	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, alpha, 0, w.ContentSeq())())
+	require.Contains(t, h.View(), "ALPHA_PREVIEW_CONTENT")
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+
+	view := h.View()
+	assert.Contains(t, view, "PREVIEW beta · Agent (original alpha · Agent)")
+	assert.Contains(t, view, "Loading preview...")
+	assert.NotContains(t, view, "ALPHA_PREVIEW_CONTENT",
+		"retargeting preview must clear the original content before async beta capture returns")
+	assert.Same(t, alpha, paneA.Instance(), "preview must not mutate the committed pane binding")
+	assert.Same(t, beta, h.panePreviewTxn.target.instance)
+}
+
+func TestPanePreviewFastScrollLatestWins(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+	gamma := h.store.GetInstanceByTitle("gamma")
+	setPreviewText(beta, "BETA_PREVIEW_CONTENT")
+	setPreviewText(gamma, "GAMMA_PREVIEW_CONTENT")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	w := h.paneWindows[paneA.ID()]
+	require.NotNil(t, w)
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn)
+	betaSeq := h.panePreviewTxn.seq
+
+	h.sidebar.SetSelectedInstance(2)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn)
+	gammaSeq := h.panePreviewTxn.seq
+	require.NotEqual(t, betaSeq, gammaSeq)
+
+	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, beta, 0, betaSeq)())
+	view := h.View()
+	assert.Contains(t, view, "PREVIEW gamma · Agent (original alpha · Agent)")
+	assert.Contains(t, view, "Loading preview...")
+	assert.NotContains(t, view, "BETA_PREVIEW_CONTENT",
+		"late beta capture must not overwrite the newer gamma preview target")
+
+	require.IsType(t, panesRefreshedMsg{}, refreshPaneBindingCmd(w, gamma, 0, gammaSeq)())
+	view = h.View()
+	assert.Contains(t, view, "PREVIEW gamma · Agent (original alpha · Agent)")
+	assert.Contains(t, view, "GAMMA_PREVIEW_CONTENT")
+	assert.NotContains(t, view, "BETA_PREVIEW_CONTENT")
+	assert.Same(t, alpha, paneA.Instance(), "latest-wins preview must still be transient")
 }
 
 // TestPane_TabDimension: opening from a tree TAB row binds that tab, distinct

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -81,6 +81,10 @@ func (b *previewTextBackend) Preview(*session.Instance) (string, error) {
 	return b.text, nil
 }
 
+func (b *previewTextBackend) PreviewFullHistory(*session.Instance) (string, error) {
+	return b.text, nil
+}
+
 func setPreviewText(inst *session.Instance, text string) {
 	inst.SetBackend(&previewTextBackend{FakeBackend: session.NewFakeBackend(), text: text})
 }
@@ -263,6 +267,44 @@ func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 	assert.Contains(t, view, "GAMMA_PREVIEW_CONTENT")
 	assert.NotContains(t, view, "BETA_PREVIEW_CONTENT")
 	assert.Same(t, alpha, paneA.Instance(), "latest-wins preview must still be transient")
+}
+
+func TestPanePreviewEscFromScrollRevertsOriginalCommittedTab(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+	setPreviewText(beta, "BETA_PREVIEW_HISTORY")
+
+	_, _ = h.openOrFocusPane(alpha, 1)
+	paneA := h.store.OpenPanes()[0]
+	w := h.paneWindows[paneA.ID()]
+	require.NotNil(t, w)
+	require.Equal(t, 1, paneA.Tab(), "precondition: original pane is alpha's terminal tab")
+
+	h.store.SetActiveTab(0)
+	h.menu.SetActiveTab(0)
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn)
+	require.True(t, w.Previewing())
+
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyCtrlU}, keys.KeyShiftUp)
+	require.True(t, w.IsInScrollMode(), "precondition: preview pane is in scroll mode")
+
+	_, cmd := h.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.NotNil(t, cmd, "Esc should schedule an original-pane refresh after canceling preview")
+
+	require.Nil(t, h.panePreviewTxn, "Esc from preview scroll must cancel the transient preview")
+	require.False(t, w.Previewing())
+	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active(), "Esc cancel focuses the owner pane")
+	assert.Same(t, alpha, paneA.Instance())
+	assert.Equal(t, 1, paneA.Tab(), "Esc must restore alpha's original tab, not alpha's agent tab")
+
+	view := h.View()
+	assert.Contains(t, view, "alpha · Terminal")
+	assert.NotContains(t, view, "PREVIEW beta")
+	assert.NotContains(t, view, "alpha · Agent",
+		"reset must not pair the committed alpha instance with the preview agent tab")
 }
 
 // TestPane_TabDimension: opening from a tree TAB row binds that tab, distinct

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/store"
+	"github.com/sachiniyer/agent-factory/ui/tree"
+)
+
+type paneBinding struct {
+	instance *session.Instance
+	tab      int
+}
+
+type panePreviewTxn struct {
+	ownerPaneID int
+	original    paneBinding
+	target      paneBinding
+	seq         uint64
+}
+
+func samePaneBinding(a, b paneBinding) bool {
+	return a.instance == b.instance && a.tab == b.tab
+}
+
+func (m *home) updatePanePreview(selected *session.Instance, attachedNow bool) {
+	if attachedNow || m.interactive || selected == nil {
+		m.cancelPanePreview(false)
+		return
+	}
+	owner := m.previewOwnerPane()
+	if owner == nil {
+		m.cancelPanePreview(false)
+		return
+	}
+	if m.panePreviewTxn != nil && m.panePreviewTxn.ownerPaneID != owner.ID() {
+		m.cancelPanePreview(false)
+	}
+	w := m.paneWindows[owner.ID()]
+	if w == nil {
+		m.cancelPanePreview(false)
+		return
+	}
+	original := paneBinding{instance: owner.Instance(), tab: owner.Tab()}
+	if m.panePreviewTxn != nil && m.panePreviewTxn.ownerPaneID == owner.ID() {
+		original = m.panePreviewTxn.original
+	}
+	target := paneBinding{instance: selected, tab: 0}
+	// #1321 is an instance preview, not a tab preview: selecting a different
+	// tab row on the pane's original instance keeps the #1289 divergence header.
+	if original.instance == target.instance {
+		m.cancelPanePreview(false)
+		return
+	}
+	changed := m.panePreviewTxn == nil ||
+		m.panePreviewTxn.ownerPaneID != owner.ID() ||
+		!samePaneBinding(m.panePreviewTxn.original, original) ||
+		!samePaneBinding(m.panePreviewTxn.target, target)
+
+	if owner == m.livePane {
+		m.closeLiveTermPane()
+		m.enforceInteractiveInvariant()
+	}
+
+	seq := w.SetPreview(target.instance, target.tab, paneBindingLabel(original))
+	m.panePreviewTxn = &panePreviewTxn{
+		ownerPaneID: owner.ID(),
+		original:    original,
+		target:      target,
+		seq:         seq,
+	}
+	if changed {
+		w.InvalidateContent(target.instance, target.tab, "Loading preview...")
+		m.lastPaneCapture[owner.ID()] = time.Time{}
+	}
+}
+
+func (m *home) cancelPanePreview(focusOwner bool) {
+	txn := m.panePreviewTxn
+	if txn == nil {
+		return
+	}
+	m.panePreviewTxn = nil
+	if w := m.paneWindows[txn.ownerPaneID]; w != nil {
+		w.ClearPreview()
+		w.InvalidateContent(txn.original.instance, txn.original.tab, "Loading pane...")
+		m.lastPaneCapture[txn.ownerPaneID] = time.Time{}
+	}
+	if focusOwner {
+		if p := m.openPaneByID(txn.ownerPaneID); p != nil {
+			m.focusRegion(layout.PaneRegion(p.ID()))
+		}
+	}
+}
+
+func (m *home) renderBindingForPane(p *store.OpenPane) (paneBinding, uint64) {
+	w := m.paneWindows[p.ID()]
+	if m.panePreviewTxn != nil && m.panePreviewTxn.ownerPaneID == p.ID() {
+		return m.panePreviewTxn.target, m.panePreviewTxn.seq
+	}
+	if w == nil {
+		return paneBinding{instance: p.Instance(), tab: p.Tab()}, 0
+	}
+	return paneBinding{instance: p.Instance(), tab: p.Tab()}, w.ContentSeq()
+}
+
+func (m *home) previewOwnerPane() *store.OpenPane {
+	if p := m.visiblePaneByID(m.lastFocusedPaneID); p != nil {
+		return p
+	}
+	if p := m.focusedOpenPane(); p != nil {
+		return p
+	}
+	if len(m.visiblePanes) > 0 {
+		return m.visiblePanes[0]
+	}
+	return nil
+}
+
+func (m *home) visiblePaneByID(id int) *store.OpenPane {
+	if id == 0 {
+		return nil
+	}
+	for _, p := range m.visiblePanes {
+		if p.ID() == id {
+			return p
+		}
+	}
+	return nil
+}
+
+func (m *home) openPaneByID(id int) *store.OpenPane {
+	if id == 0 {
+		return nil
+	}
+	for _, p := range m.store.OpenPanes() {
+		if p.ID() == id {
+			return p
+		}
+	}
+	return nil
+}
+
+func paneBindingLabel(binding paneBinding) string {
+	if binding.instance == nil {
+		return "no session"
+	}
+	label := ""
+	labels := tree.TabLabels(binding.instance)
+	if binding.tab >= 0 && binding.tab < len(labels) {
+		label = labels[binding.tab]
+	}
+	if label == "" {
+		return binding.instance.Title
+	}
+	return fmt.Sprintf("%s · %s", binding.instance.Title, label)
+}

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -515,6 +515,7 @@ func (p *TabPane) ResetToNormalMode(instance *session.Instance, activeTab int) e
 	if instance == nil || !wasScrolling {
 		return nil
 	}
+	p.dropStaleView(instance, activeTab)
 
 	// A shell/process slot simply returns to live capture on the next refresh —
 	// no re-capture here (the former TerminalPane.ResetToNormalMode behavior).

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -41,7 +41,7 @@ type tabContentState struct {
 //
 // All hard-won race/edge fixes from both panes live here, in one place:
 //   - #684 the active-tab index is an atomic on TabbedWindow (not here).
-//   - #579 UpdateContent serialises capture writes against String() reads via
+//   - #579 UpdateContent serialises state writes against String() reads via
 //     p.mu so the renderer never observes a half-written state.
 //   - #702/#746/#384 the mouse/keyboard scroll path can fire before the async
 //     UpdateContent for a newly selected tab/instance — dropStaleView resets
@@ -53,10 +53,10 @@ type tabContentState struct {
 //   - #496/#920/#935 session-gone / Deleting / Dead fallbacks.
 //   - #898/#649 trailing-newline strip + newest-lines truncation.
 type TabPane struct {
-	// mu serialises UpdateContent (called off the bubbletea Update goroutine via
-	// refreshPanesCmd) against String() (called from the renderer), plus the
-	// scroll-mode mutators. Without it the renderer can observe partially
-	// written state while a capture is in flight (#579).
+	// mu serialises UpdateContent writes (called off the bubbletea Update
+	// goroutine via refreshPanesCmd) against String() (called from the
+	// renderer), plus the scroll-mode mutators. Without it the renderer can
+	// observe partially written state while a capture is in flight (#579).
 	mu sync.Mutex
 
 	width  int
@@ -145,49 +145,85 @@ func (p *TabPane) setFallbackState(message string) {
 	p.viewport.SetContent("")
 }
 
-// UpdateContent captures the selected tab's content. Safe to call from a
-// goroutine — it serialises against String() via p.mu (#579). activeTab is the
-// 0-based selected tab index: index 0 is the agent tab (captured via the backend
-// preview), any other index is a shell/process tab captured straight from that
-// tab's tmux session. The slot selects the capture source and the fallback copy,
-// so the merged pane reproduces the old PreviewPane and TerminalPane behaviors.
-func (p *TabPane) UpdateContent(instance *session.Instance, activeTab int) error {
+type contentGuard func() bool
+
+func guardOK(guard contentGuard) bool {
+	return guard == nil || guard()
+}
+
+func (p *TabPane) isCurrentViewLocked(instance *session.Instance, activeTab int) bool {
+	return p.currentInstance == instance && p.currentTab == activeTab
+}
+
+// InvalidateContent synchronously adopts a new view key and fallback state.
+// This is used by #1321 preview retargeting so the next render frame cannot
+// pair a new PREVIEW header with stale content from the previous binding.
+func (p *TabPane) InvalidateContent(instance *session.Instance, activeTab int, message string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.dropStaleView(instance, activeTab)
-	if activeTab == 0 {
-		return p.updateAgentLocked(instance)
-	}
-	return p.updateShellLocked(instance, activeTab)
+	p.setFallbackState(message)
 }
 
-// updateAgentLocked reproduces the former PreviewPane.UpdateContent. Caller
-// must hold p.mu.
-func (p *TabPane) updateAgentLocked(instance *session.Instance) error {
+// UpdateContent captures the selected tab's content. Safe to call from a
+// goroutine — it serialises state writes against String() via p.mu (#579).
+// activeTab is the 0-based selected tab index: index 0 is the agent tab
+// (captured via the backend preview), any other index is a shell/process tab
+// captured straight from that tab's tmux session. The slot selects the capture
+// source and the fallback copy, so the merged pane reproduces the old
+// PreviewPane and TerminalPane behaviors.
+func (p *TabPane) UpdateContent(instance *session.Instance, activeTab int) error {
+	return p.UpdateContentGuarded(instance, activeTab, nil)
+}
+
+// UpdateContentGuarded captures the selected tab's content and publishes it
+// only while guard still reports that the caller's render binding is current.
+// Capture itself runs outside p.mu so event-loop invalidation can immediately
+// clear stale content even if an older capture is still in flight.
+func (p *TabPane) UpdateContentGuarded(instance *session.Instance, activeTab int, guard contentGuard) error {
+	if activeTab == 0 {
+		return p.updateAgent(instance, guard)
+	}
+	return p.updateShell(instance, activeTab, guard)
+}
+
+// updateAgent reproduces the former PreviewPane.UpdateContent.
+func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) error {
+	p.mu.Lock()
+	if !guardOK(guard) {
+		p.mu.Unlock()
+		return nil
+	}
+	p.dropStaleView(instance, 0)
 	switch {
 	case instance == nil:
 		p.setFallbackState("No agents running yet. Spin up a new instance with 'n' to get started!")
+		p.mu.Unlock()
 		return nil
 	case instance.IsCreating():
 		p.setFallbackState("Setting up workspace...")
+		p.mu.Unlock()
 		return nil
 	case instance.IsTearingDown():
 		// Mirror the creating case for a teardown op (#920/#1195): during
 		// teardown Preview() returns ("", nil) and Started()==false, so without
 		// this the generic name fallback below would claim throughout the delete.
 		p.setFallbackState("Tearing down session...")
+		p.mu.Unlock()
 		return nil
 	case instance.GetLiveness() == session.LiveDead:
 		// The daemon poll marks a session Dead once its backing session is
 		// gone (#935); keying off the liveness makes the fallback synchronous with
 		// the sidebar's dead-dot so the panes never disagree.
 		p.setFallbackState("Session no longer running.")
+		p.mu.Unlock()
 		return nil
 	case instance.GetLiveness() == session.LiveLost:
 		// Lost (#1108): the tmux session vanished with no kill on record —
 		// same synchronous-with-the-sidebar treatment as Dead, but the message
 		// says what happened rather than implying a plain corpse.
 		p.setFallbackState("Session lost — its tmux session is gone.")
+		p.mu.Unlock()
 		return nil
 	}
 	// A LimitReached agent (#1146) is deliberately NOT a fallback: its tmux is
@@ -197,7 +233,13 @@ func (p *TabPane) updateAgentLocked(instance *session.Instance) error {
 	// If in scroll mode but the viewport hasn't been filled yet, capture the
 	// full scrollback now (the agent slot fills lazily here; see ScrollUp).
 	if p.isScrolling && p.viewport.Height > 0 && len(p.viewport.View()) == 0 {
+		p.mu.Unlock()
 		content, err := instance.PreviewFullHistory()
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if !guardOK(guard) || !p.isCurrentViewLocked(instance, 0) {
+			return nil
+		}
 		if err != nil {
 			if errors.Is(err, tmux.ErrSessionGone) {
 				// setFallbackState clears scroll state and the stale viewport, so
@@ -207,15 +249,24 @@ func (p *TabPane) updateAgentLocked(instance *session.Instance) error {
 			}
 			return err
 		}
-		p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
+		if p.isScrolling && p.viewport.Height > 0 && len(p.viewport.View()) == 0 {
+			p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
+		}
 		return nil
 	}
 
 	if p.isScrolling {
+		p.mu.Unlock()
 		return nil
 	}
+	p.mu.Unlock()
 
 	content, err := instance.Preview()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !guardOK(guard) || !p.isCurrentViewLocked(instance, 0) {
+		return nil
+	}
 	if err != nil {
 		// Tmux session vanished out from under us (#496): render an inactive
 		// fallback instead of logging at ERROR every preview tick.
@@ -235,11 +286,18 @@ func (p *TabPane) updateAgentLocked(instance *session.Instance) error {
 	return nil
 }
 
-// updateShellLocked reproduces the former TerminalPane.UpdateContent for the
-// shell/process tab at activeTab. Caller must hold p.mu.
-func (p *TabPane) updateShellLocked(instance *session.Instance, activeTab int) error {
+// updateShell reproduces the former TerminalPane.UpdateContent for the
+// shell/process tab at activeTab.
+func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard contentGuard) error {
+	p.mu.Lock()
+	if !guardOK(guard) {
+		p.mu.Unlock()
+		return nil
+	}
+	p.dropStaleView(instance, activeTab)
 	if instance == nil {
 		p.setFallbackState("Select an instance to open a terminal")
+		p.mu.Unlock()
 		return nil
 	}
 	// A tearing-down instance reports Started()==false during teardown, so without
@@ -247,10 +305,12 @@ func (p *TabPane) updateShellLocked(instance *session.Instance, activeTab int) e
 	// while the session is going away (#920/#1195).
 	if instance.IsTearingDown() {
 		p.setFallbackState("Tearing down session...")
+		p.mu.Unlock()
 		return nil
 	}
 	if !instance.Started() {
 		p.setFallbackState("Instance is not started yet.")
+		p.mu.Unlock()
 		return nil
 	}
 
@@ -263,6 +323,7 @@ func (p *TabPane) updateShellLocked(instance *session.Instance, activeTab int) e
 		} else {
 			p.setFallbackState("Terminal tab not available for remote sessions.\nConfigure remote_hooks.terminal_cmd to enable it.\nUse the Agent tab to see session output.")
 		}
+		p.mu.Unlock()
 		return nil
 	}
 
@@ -275,19 +336,27 @@ func (p *TabPane) updateShellLocked(instance *session.Instance, activeTab int) e
 	// of leaving stale scrollback pinned on screen forever (#977). setFallbackState
 	// clears scroll state, so String() (which checks isScrolling first) renders the
 	// fallback message. This mirrors the agent slot, whose Dead check also precedes
-	// its scroll guard in updateAgentLocked.
+	// its scroll guard in updateAgent.
 	if !instance.TabAlive(activeTab) {
 		p.setFallbackState("Terminal session not available.")
+		p.mu.Unlock()
 		return nil
 	}
 
 	// Skip content updates while scrolling (the shell slot fills its viewport
 	// eagerly in enterScrollMode, not here).
 	if p.isScrolling {
+		p.mu.Unlock()
 		return nil
 	}
+	p.mu.Unlock()
 
 	content, err := instance.PreviewTab(activeTab)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
+		return nil
+	}
 	if err != nil {
 		// The alive pre-check above can race an external kill: fall through to a
 		// fallback instead of propagating an error logged at ERROR (#496).
@@ -402,7 +471,7 @@ func (p *TabPane) enterScrollModeLocked(instance *session.Instance, activeTab in
 		// return: a bare return leaves p.content (fallback==false) holding the
 		// last-rendered capture and isScrolling==false, so String() renders stale
 		// terminal output instead of the dead-session message. This mirrors
-		// updateShellLocked's !TabAlive branch and the ErrSessionGone path below,
+		// updateShell's !TabAlive branch and the ErrSessionGone path below,
 		// which both set the same fallback — the early-return was the inconsistency
 		// (#998, sibling of #977/#984).
 		if !instance.TabAlive(activeTab) {

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
@@ -106,6 +107,21 @@ type TabbedWindow struct {
 	// leaving the selected row and displayed content to appear contradictory
 	// (#1289).
 	selectionHint string
+
+	// preview is a transient render binding for #1321. While set, the window
+	// still owns its committed store.OpenPane binding, but capture/render uses
+	// preview.instance + preview.tab and the header makes that explicit.
+	preview *windowPreview
+	// contentSeq invalidates off-loop captures whose binding was superseded
+	// while they were in flight. The root model captures a sequence on the event
+	// loop and TabPane writes only if the sequence is still current.
+	contentSeq atomic.Uint64
+}
+
+type windowPreview struct {
+	instance *session.Instance
+	tab      int
+	original string
 }
 
 // LiveView is a live embedded-terminal render source (#1089): the termpane
@@ -131,12 +147,19 @@ func NewTabbedWindow(tab *TabPane, pane *store.OpenPane) *TabbedWindow {
 	}
 }
 
-// boundInstance returns the instance the window renders. Event-loop only.
+// boundInstance returns the committed pane instance. Event-loop only.
 func (w *TabbedWindow) boundInstance() *session.Instance {
 	if w.pane == nil {
 		return nil
 	}
 	return w.pane.Instance()
+}
+
+func (w *TabbedWindow) effectiveInstance() *session.Instance {
+	if w.preview != nil {
+		return w.preview.instance
+	}
+	return w.boundInstance()
 }
 
 // activeTab returns the window's 0-based tab index through the pane's atomic
@@ -148,12 +171,63 @@ func (w *TabbedWindow) activeTab() int {
 	return w.pane.Tab()
 }
 
+func (w *TabbedWindow) effectiveTab() int {
+	if w.preview != nil {
+		return w.preview.tab
+	}
+	return w.activeTab()
+}
+
 // setActiveTab writes the window's tab index to its pane binding.
 func (w *TabbedWindow) setActiveTab(idx int) {
 	if w.pane == nil {
 		return
 	}
+	if w.pane.Tab() == idx {
+		return
+	}
 	w.pane.SetTab(idx)
+	w.bumpContentSeq()
+}
+
+func (w *TabbedWindow) bumpContentSeq() uint64 {
+	return w.contentSeq.Add(1)
+}
+
+// ContentSeq returns the current render-binding generation.
+func (w *TabbedWindow) ContentSeq() uint64 {
+	return w.contentSeq.Load()
+}
+
+// SetPreview applies a transient render binding without mutating the committed
+// pane binding. original is rendered in the PREVIEW header so the reversible
+// state is visible to the user.
+func (w *TabbedWindow) SetPreview(instance *session.Instance, tab int, original string) uint64 {
+	if w.preview != nil &&
+		w.preview.instance == instance &&
+		w.preview.tab == tab &&
+		w.preview.original == original {
+		return w.ContentSeq()
+	}
+	w.preview = &windowPreview{instance: instance, tab: tab, original: original}
+	return w.bumpContentSeq()
+}
+
+// ClearPreview drops any transient render binding and returns the generation
+// after the clear. It is intentionally a no-op when there is no preview so
+// refresh throttling does not churn sequences.
+func (w *TabbedWindow) ClearPreview() uint64 {
+	if w.preview == nil {
+		return w.ContentSeq()
+	}
+	w.preview = nil
+	return w.bumpContentSeq()
+}
+
+// Previewing reports whether the window is currently rendering a transient
+// binding.
+func (w *TabbedWindow) Previewing() bool {
+	return w.preview != nil
 }
 
 // ClampActiveTab bounds the pane's tab index into [0, len(tabLabels())-1].
@@ -200,10 +274,18 @@ func (w *TabbedWindow) tabLabels() []string {
 	return tree.TabLabels(w.boundInstance())
 }
 
-// isAgentSlot reports whether the pane's tab index is the agent tab (index 0).
+func tabLabelFor(inst *session.Instance, idx int) string {
+	labels := tree.TabLabels(inst)
+	if idx >= 0 && idx < len(labels) {
+		return labels[idx]
+	}
+	return ""
+}
+
+// isAgentSlot reports whether the effective tab index is the agent tab (index 0).
 // Index 0 is always the agent tab; every other slot is a shell/terminal tab.
 func (w *TabbedWindow) isAgentSlot() bool {
-	return w.activeTab() == 0
+	return w.effectiveTab() == 0
 }
 
 // SetRect implements layout.Pane: the pane renders exactly r. The inner
@@ -341,25 +423,39 @@ func (w *TabbedWindow) registerZones(liveShowing bool) {
 // nil. It is called from the refreshPanesCmd goroutine with the instance
 // captured on the event loop at dispatch time — deliberately a parameter, not
 // a store read, so the capture is keyed to the binding the refresh was
-// dispatched for; only the tab index is read here, through the pane's
-// atomic (#684).
+// dispatched for.
 func (w *TabbedWindow) UpdateContent(instance *session.Instance) error {
-	return w.tab.UpdateContent(instance, w.activeTab())
+	return w.UpdateContentAt(instance, w.activeTab(), w.ContentSeq())
+}
+
+// UpdateContentAt captures a specific render binding if seq is still current.
+// It is used by #1321 previews so a fast sidebar scroll cannot let an older
+// off-loop capture overwrite the newest preview target.
+func (w *TabbedWindow) UpdateContentAt(instance *session.Instance, tab int, seq uint64) error {
+	return w.tab.UpdateContentGuarded(instance, tab, func() bool {
+		return w.ContentSeq() == seq
+	})
+}
+
+// InvalidateContent synchronously adopts a new view key and fallback message so
+// the next frame cannot show a preview header over the previous pane content.
+func (w *TabbedWindow) InvalidateContent(instance *session.Instance, tab int, message string) {
+	w.tab.InvalidateContent(instance, tab, message)
 }
 
 // ResetToNormalMode resets the pane's tab view to normal (non-scroll) mode.
 func (w *TabbedWindow) ResetToNormalMode(instance *session.Instance) error {
-	return w.tab.ResetToNormalMode(instance, w.activeTab())
+	return w.tab.ResetToNormalMode(instance, w.effectiveTab())
 }
 
 func (w *TabbedWindow) ScrollUp() {
-	if err := w.tab.ScrollUp(w.boundInstance(), w.activeTab()); err != nil {
+	if err := w.tab.ScrollUp(w.effectiveInstance(), w.effectiveTab()); err != nil {
 		log.InfoLog.Printf("tabbed window failed to scroll up: %v", err)
 	}
 }
 
 func (w *TabbedWindow) ScrollDown() {
-	if err := w.tab.ScrollDown(w.boundInstance(), w.activeTab()); err != nil {
+	if err := w.tab.ScrollDown(w.effectiveInstance(), w.effectiveTab()); err != nil {
 		log.InfoLog.Printf("tabbed window failed to scroll down: %v", err)
 	}
 }
@@ -409,13 +505,12 @@ func (w *TabbedWindow) IsInScrollMode() bool {
 // the highlight doubles as the pane's focus indicator.
 func (w *TabbedWindow) renderHeader(width int) string {
 	var text string
-	if inst := w.boundInstance(); inst != nil {
-		labels := w.tabLabels()
-		idx := w.activeTab()
-		label := ""
-		if idx >= 0 && idx < len(labels) {
-			label = labels[idx]
-		}
+	if w.preview != nil && w.preview.instance != nil {
+		inst := w.preview.instance
+		label := tabLabelFor(inst, w.preview.tab)
+		text = fmt.Sprintf(" PREVIEW %s · %s (original %s) ", inst.Title, label, w.preview.original)
+	} else if inst := w.boundInstance(); inst != nil {
+		label := tabLabelFor(inst, w.activeTab())
 		text = fmt.Sprintf(" %s · %s ", inst.Title, label)
 		if w.selectionHint != "" {
 			text = fmt.Sprintf(" %s · %s · selected: %s ", inst.Title, label, w.selectionHint)

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -445,7 +445,7 @@ func (w *TabbedWindow) InvalidateContent(instance *session.Instance, tab int, me
 
 // ResetToNormalMode resets the pane's tab view to normal (non-scroll) mode.
 func (w *TabbedWindow) ResetToNormalMode(instance *session.Instance) error {
-	return w.tab.ResetToNormalMode(instance, w.effectiveTab())
+	return w.tab.ResetToNormalMode(instance, w.activeTab())
 }
 
 func (w *TabbedWindow) ScrollUp() {

--- a/ui/tabbed_window_test.go
+++ b/ui/tabbed_window_test.go
@@ -6,14 +6,31 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // setWindowSize rects the pane at origin, the test shorthand for the layout
 // engine's SetRect call.
 func setWindowSize(w *TabbedWindow, width, height int) {
 	w.SetRect(layout.Rect{W: width, H: height})
+}
+
+func startedWindowInstance(t *testing.T, title string) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStartedForTest(true)
+	inst.SetStatus(session.Running)
+	addAgentShellTabs(inst)
+	return inst
 }
 
 // TestTabbedWindowSetRectClampsNegativeDimensions verifies that SetRect never
@@ -56,6 +73,26 @@ func TestTabbedWindowSetRectNormal(t *testing.T) {
 	previewW, previewH := w.GetPreviewSize()
 	assert.Greater(t, previewW, 0)
 	assert.Greater(t, previewH, 0)
+}
+
+func TestTabbedWindowResetPreviewScrollUsesCommittedBinding(t *testing.T) {
+	alpha := startedWindowInstance(t, "alpha")
+	beta := startedWindowInstance(t, "beta")
+	w := newTestTabbedWindow()
+	setWindowInstance(w, alpha)
+	setWindowSize(w, 100, 30)
+	require.True(t, w.JumpToTab(1), "precondition: original pane is alpha's terminal tab")
+
+	w.SetPreview(beta, 0, "alpha · Terminal")
+	w.InvalidateContent(beta, 0, "Loading preview...")
+	w.ScrollUp()
+	require.True(t, w.IsInScrollMode(), "precondition: preview target is scrolled")
+
+	require.NoError(t, w.ResetToNormalMode(alpha))
+	assert.False(t, w.IsInScrollMode())
+	assert.Same(t, alpha, w.tab.currentInstance)
+	assert.Equal(t, 1, w.tab.currentTab,
+		"reset must use the committed tab, not the preview target's agent tab")
 }
 
 // TestTabbedWindowViewIsExactlyRectSized enforces the layout.Pane contract


### PR DESCRIPTION
## Summary
- add a transient `panePreviewTxn` owned by the last focused content pane so sidebar selection can preview another instance without mutating `store.OpenPane`
- bind pane refresh/render through the effective preview target with an explicit `PREVIEW … (original …)` header
- synchronously invalidate stale pane content on preview retarget and guard off-loop captures with a latest-wins content sequence
- add focused regression coverage for #1289 header/content agreement, synchronous invalidation, and fast-scroll latest-wins behavior

## Scope
- PR1 only: recover-preview + cancel/revert scaffolding
- no Tab/Esc/Enter commit behavior yet
- no `S` split key yet

Refs #1321.

## Test
- `make test-container`