### PR TITLE
fix(session): persist parked task prompt

### DIFF
--- a/daemon/limit_park_test.go
+++ b/daemon/limit_park_test.go
@@ -99,6 +99,16 @@ func TestCreateSession_ParksOnUsageLimitBanner(t *testing.T) {
 	if len(stored) != 1 || stored[0].Liveness != session.LiveLimitReached {
 		t.Fatalf("persisted store = %+v, want exactly one LiveLimitReached row", stored)
 	}
+	if stored[0].Prompt != "run the nightly report" {
+		t.Fatalf("persisted InstanceData prompt = %q, want the parked task prompt", stored[0].Prompt)
+	}
+	var persisted []map[string]any
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatalf("unmarshal persisted map: %v", err)
+	}
+	if len(persisted) != 1 || persisted[0]["prompt"] != "run the nightly report" {
+		t.Fatalf("persisted prompt = %v, want the parked task prompt to survive daemon restart", persisted)
+	}
 }
 
 // stubParkedCreate swaps createSessionForTask for one that reports a session

--- a/session/archived_test.go
+++ b/session/archived_test.go
@@ -38,6 +38,7 @@ func TestFromInstanceData_ArchivedLoadsInert(t *testing.T) {
 	t.Cleanup(func() { restoreTmuxSession = prev })
 
 	data := deadInstanceData(t, Archived, agentName, shellName)
+	data.Prompt = "run the nightly report"
 	// Deliberately DO NOT create data.Worktree.WorktreePath: an inert load must
 	// not depend on the worktree existing (the Lost path would MkdirAll it).
 
@@ -48,6 +49,7 @@ func TestFromInstanceData_ArchivedLoadsInert(t *testing.T) {
 	assert.False(t, restored.Started(), "an archived session loads inert: Start is skipped, started=false")
 	assert.False(t, restored.TabAlive(0), "no tmux session is spawned or reconnected on load")
 	assert.Equal(t, 0, newSessions, "loading an archived session must never spawn tmux")
+	assert.Equal(t, data.Prompt, restored.Prompt, "persisted prompts must restore onto the instance")
 	assert.Equal(t, data.Worktree.WorktreePath, restored.GetWorktreePath(),
 		"gitWorktree is bound to the persisted archived path so restore knows where the worktree lives")
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -577,6 +577,7 @@ func (i *Instance) ToInstanceData() InstanceData {
 		UpdatedAt:  time.Now(),
 		Program:    i.Program,
 		AutoYes:    i.AutoYes,
+		Prompt:     i.Prompt,
 		UserKilled: i.userKilled,
 	}
 
@@ -684,6 +685,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 		UpdatedAt:    data.UpdatedAt,
 		Program:      data.Program,
 		AutoYes:      data.AutoYes,
+		Prompt:       data.Prompt,
 		userKilled:   data.UserKilled,
 		remoteMeta:   data.RemoteMeta,
 	}

--- a/session/limit_test.go
+++ b/session/limit_test.go
@@ -85,10 +85,12 @@ func TestLimitReached_PersistRoundTrip(t *testing.T) {
 	i, err := NewInstance(InstanceOptions{Title: "limited", Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
 	i.SetLimitReached(reset)
+	i.Prompt = "run the nightly report"
 
 	data := i.ToInstanceData()
 	require.Equal(t, LiveLimitReached, data.Liveness)
 	require.True(t, data.LimitResetAt.Equal(reset))
+	require.Equal(t, "run the nightly report", data.Prompt)
 
 	// JSON round-trip (the on-disk + snapshot format).
 	raw, err := json.Marshal(data)
@@ -97,6 +99,7 @@ func TestLimitReached_PersistRoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(raw, &back))
 	require.Equal(t, LiveLimitReached, back.Liveness)
 	require.True(t, back.LimitResetAt.Equal(reset))
+	require.Equal(t, "run the nightly report", back.Prompt)
 
 	// FromInstanceData maps the reset time onto the rebuilt instance's field.
 	require.Equal(t, reset, back.LimitResetAt)

--- a/session/storage.go
+++ b/session/storage.go
@@ -40,6 +40,7 @@ type InstanceData struct {
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 	AutoYes      bool      `json:"auto_yes"`
+	Prompt       string    `json:"prompt,omitempty"`
 
 	Program string `json:"program"`
 	// UserKilled is the kill-intent tombstone (#1108): persisted by


### PR DESCRIPTION
Closes #1334

## Summary
- add `prompt` to persisted `InstanceData`
- wire prompt through `ToInstanceData` / `FromInstanceData` without touching conversation ID fields
- assert parked task sessions write their original prompt to disk so restart/resume can replay it

## Verification
- master verification: `make test-container GOTESTARGS="./daemon -run TestCreateSession_ParksOnUsageLimitBanner -count=1"` failed because the persisted parked row had no `prompt` key
- `make test-container GOTESTARGS="./daemon -run TestCreateSession_ParksOnUsageLimitBanner -count=1"`
- `make test-container GOTESTARGS="./session -run 'TestLimitReached_PersistRoundTrip|TestFromInstanceData_ArchivedLoadsInert' -count=1"`\n- `make test-container`\n\nSigned-off-by: Captain Claude <captain.claude@users.noreply.github.com>