### PR TITLE
fix(keys): normalize space override bindings

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -175,6 +175,8 @@ var keyDisplayNames = map[string]string{
 	"enter":      "↵",
 	"shift+up":   "⇧↑",
 	"shift+down": "⇧↓",
+	" ":          "space",
+	"ctrl+@":     "ctrl+space",
 }
 
 // namedKeys are the non-rune key names bubbletea produces (tea.KeyMsg.String()
@@ -403,9 +405,9 @@ func helpLabelFor(keyList []string) string {
 // an optional run of ctrl+/alt+/shift+ modifiers followed by a named key or
 // a single character. Modifier order is accepted flexibly, but runtime maps
 // store normalizeKeySpec's Bubble Tea spelling so override lookup compares
-// against tea.KeyMsg.String() forms. Whitespace never matches a configured
-// key string, so it is rejected outright (the classic mistake is "space",
-// which IS the named form bubbletea uses, vs " ").
+// against tea.KeyMsg.String() forms. Literal whitespace in config remains
+// invalid; users spell the spacebar as "space", and normalizeKeySpec maps it
+// to Bubble Tea's runtime spelling.
 func validKeySpec(s string) bool {
 	_, ok := normalizeKeySpec(s)
 	return ok
@@ -438,6 +440,13 @@ func normalizeKeySpec(s string) (string, bool) {
 			shift = true
 			rest = rest[len("shift+"):]
 		default:
+			if rest == "space" {
+				if ctrl {
+					rest = "@"
+				} else if !alt && !shift {
+					return " ", true
+				}
+			}
 			if !namedKeys[rest] && utf8.RuneCountInString(rest) != 1 {
 				return "", false
 			}

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -236,6 +236,45 @@ func TestApplyOverridesNormalizesMultiModifierOverrides(t *testing.T) {
 	t.Fatal("EffectiveBindings omitted the up action")
 }
 
+func TestApplyOverridesNormalizesSpaceOverridesToRuntimeKeys(t *testing.T) {
+	resetAfter(t)
+
+	spaceKey := tea.KeyMsg{Type: tea.KeySpace}.String()
+	ctrlSpaceKey := tea.KeyMsg{Type: tea.KeyCtrlAt}.String()
+	if spaceKey != " " {
+		t.Fatalf("Bubble Tea changed Space spelling to %q", spaceKey)
+	}
+	if ctrlSpaceKey != "ctrl+@" {
+		t.Fatalf("Bubble Tea changed Ctrl+Space spelling to %q", ctrlSpaceKey)
+	}
+
+	err := ApplyOverrides(map[string][]string{
+		"quit": {"space"},
+		"up":   {"ctrl+space"},
+	})
+	if err != nil {
+		t.Fatalf("ApplyOverrides: %v", err)
+	}
+
+	if got, ok := GlobalKeyStringsMap[spaceKey]; !ok || got != KeyQuit {
+		t.Fatalf("%q should dispatch KeyQuit, got %v (present=%v)", spaceKey, got, ok)
+	}
+	if got, ok := GlobalKeyStringsMap[ctrlSpaceKey]; !ok || got != KeyUp {
+		t.Fatalf("%q should dispatch KeyUp, got %v (present=%v)", ctrlSpaceKey, got, ok)
+	}
+	for _, dead := range []string{"space", "ctrl+space"} {
+		if _, ok := GlobalKeyStringsMap[dead]; ok {
+			t.Fatalf("non-runtime override spelling %q must not be stored in the dispatch map", dead)
+		}
+	}
+	if got := GlobalKeyBindings[KeyQuit].Help().Key; got != "space" {
+		t.Fatalf("space help label = %q, want space", got)
+	}
+	if got := GlobalKeyBindings[KeyUp].Help().Key; got != "ctrl+space" {
+		t.Fatalf("ctrl+space help label = %q, want ctrl+space", got)
+	}
+}
+
 func TestValidateOverridesErrors(t *testing.T) {
 	cases := []struct {
 		name      string


### PR DESCRIPTION
Closes #1327

## Summary
- normalize [keys] space overrides to Bubble Tea's runtime space key string
- normalize ctrl+space to ctrl+@ so global dispatch matches tea.KeyMsg.String()
- keep help labels readable for canonical space key strings

## Verify First
- Verified on origin/master at 8b8effd: normalizeKeySpec returned "space" and "ctrl+space" while Bubble Tea emits " " and "ctrl+@", so the dispatch map lookup was stale.

## Verification
- make test-container GOTESTARGS="./keys -run TestApplyOverridesNormalizesSpaceOverridesToRuntimeKeys"
- golangci-lint run --fast
- gofmt -l $(git ls-files '*.go') (empty)
- go build ./...
- make test-container
- make lint-file-length

Signed-off-by: Captain Claude <captain.claude@users.noreply.github.com>

Co-authored-by: Captain Claude <captain.claude@users.noreply.github.com>