### PR TITLE
fix(session): preserve recovered shell tab tmux names

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -380,12 +380,16 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 	// dead-shell replacement below applies.
 	hasShellTab := false
 	hasLiveShell := false
+	replacementShellName := ""
 	for idx, tab := range tabs {
 		if idx == 0 {
 			continue
 		}
 		if tab.Kind == TabKindShell {
 			hasShellTab = true
+			if replacementShellName == "" {
+				replacementShellName = tab.Name
+			}
 		}
 		if tab.tmux == nil {
 			continue
@@ -415,7 +419,10 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 	// executor — real in production, mock in tests — keeping the create path
 	// hermetic. The name extends the agent session's name deterministically so
 	// it is collision-free and restorable by exact name.
-	shellTmux := agentTmux.NewSiblingSession(agentTmux.SanitizedName()+shellTmuxSuffix, defaultShell())
+	if replacementShellName == "" {
+		replacementShellName = shellTabName
+	}
+	shellTmux := agentTmux.NewSiblingSession(agentTmux.SanitizedName()+"__"+replacementShellName, defaultShell())
 	if err := shellTmux.Start(worktreePath); err != nil {
 		log.WarningLog.Printf("start shell tab for %q failed: %v", i.Title, err)
 		return
@@ -425,7 +432,9 @@ func (b *LocalBackend) setupTabs(i *Instance) {
 	if existing := i.shellTabLocked(); existing != nil {
 		existing.tmux = shellTmux
 	} else {
-		i.Tabs = append(i.Tabs, newShellTab(shellTmux))
+		tab := newShellTab(shellTmux)
+		tab.Name = replacementShellName
+		i.Tabs = append(i.Tabs, tab)
 	}
 	i.mu.Unlock()
 }

--- a/session/dead_respawn_test.go
+++ b/session/dead_respawn_test.go
@@ -310,6 +310,45 @@ func TestRunningInstance_DeadShellTabReplacedWithFreshShellOnLoad(t *testing.T) 
 	assert.True(t, restored.Started())
 }
 
+func TestRunningInstance_DeadNonDefaultShellTabKeepsTmuxNameOnLoad(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	const agentName = "af_1335_agent"
+	defaultShellName := agentName + shellTmuxSuffix
+	nonDefaultShellName := agentName + "__shell-2"
+
+	var newSessions, ptyNewSessions int
+	exec := countingExec(map[string]bool{agentName: true}, &newSessions)
+	pty := failFirstNewSessionPty{t: t, cmdExec: exec, count: &ptyNewSessions}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	defer func() { restoreTmuxSession = prev }()
+
+	data := deadInstanceData(t, Running, agentName, nonDefaultShellName)
+	data.Tabs[1].Name = "shell-2"
+
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+
+	tabs := restored.GetTabs()
+	require.Len(t, tabs, 2)
+	assert.Equal(t, "shell-2", tabs[1].Name)
+	assert.Equal(t, nonDefaultShellName, tabs[1].tmux.SanitizedName(),
+		"the recovered non-default shell tab must keep its #930-derived tmux name")
+	assert.True(t, restored.TabAlive(1), "the recovered non-default shell tab must be live")
+
+	tab, err := restored.AddShellTab()
+	require.NoError(t, err, "creating the default shell tab after recovery must not collide")
+	assert.Equal(t, shellTabName, tab.Name)
+	assert.Equal(t, defaultShellName, tab.tmux.SanitizedName())
+	assert.Equal(t, 2, newSessions,
+		"setupTabs should spawn shell-2, then AddShellTab should spawn shell")
+}
+
 // TestLiveInstance_RespawnsMissingSessionOnLoad guards the seam from the other
 // side: the #970 fix must NOT regress the #386/#930 re-spawn-across-reboot path.
 // A non-Dead (Running) instance whose tmux server died across a reboot must


### PR DESCRIPTION
Closes #1335

## Summary
- derive dead-shell replacement tmux names from the persisted shell tab display name
- keep recovered non-default shell tabs bound to the #930 agent__tab-name scheme
- cover recovery of shell-2 followed by creating a new shell tab without collision

## Verify First
- Verified on origin/master at 8b8effd: setupTabs hardcoded agentTmux.SanitizedName()+shellTmuxSuffix, so a recovered shell-2 tab could be rebound to agent__shell and block later creation of the real shell tab.

## Verification
- make test-container GOTESTARGS="./session -run TestRunningInstance_DeadNonDefaultShellTabKeepsTmuxNameOnLoad"
- golangci-lint run --fast
- gofmt -l $(git ls-files '*.go') (empty)
- go build ./...
- make test-container
- make lint-file-length

Signed-off-by: Captain Claude <captain.claude@users.noreply.github.com>

Co-authored-by: Captain Claude <captain.claude@users.noreply.github.com>