### PR TITLE
fix(session): close stale hook preview stdout

### DIFF
--- a/session/backend_hook.go
+++ b/session/backend_hook.go
@@ -855,15 +855,15 @@ func (b *HookBackend) ensurePTY(i *Instance) error {
 		b.ptys = make(map[string]*hookPTY)
 	}
 	if existing, ok := b.ptys[i.Title]; ok {
-		// If the existing entry is still alive, reuse it. Otherwise drop
-		// the stale entry and fall through to create a fresh process so
-		// preview can recover after attach_cmd has exited.
+		// If the existing entry is still alive, reuse it. Otherwise close and
+		// drop it before creating a fresh process after attach_cmd exits.
 		existing.mu.Lock()
 		alive := !existing.closed
 		existing.mu.Unlock()
 		if alive {
 			return nil
 		}
+		existing.closeStdout()
 		delete(b.ptys, i.Title)
 	}
 

--- a/session/backend_hook_fd.go
+++ b/session/backend_hook_fd.go
@@ -1,0 +1,8 @@
+package session
+
+func (hp *hookPTY) closeStdout() {
+	if hp == nil || hp.stdout == nil {
+		return
+	}
+	_ = hp.stdout.Close()
+}

--- a/session/backend_hook_fd_test.go
+++ b/session/backend_hook_fd_test.go
@@ -1,0 +1,38 @@
+package session
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookBackendEnsurePTYClosesStalePreviewStdout(t *testing.T) {
+	dir := t.TempDir()
+	attachCmd := writeScript(t, dir, "attach.sh", `echo "preview for $1"; exit 0`)
+	b := &HookBackend{Hooks: config.RemoteHooks{AttachCmd: attachCmd}}
+	i := &Instance{Title: "stale-fd-test", Path: t.TempDir(), backend: b}
+
+	require.NoError(t, b.ensurePTY(i))
+
+	var first *hookPTY
+	require.Eventually(t, func() bool {
+		first = b.getPTY(i.Title)
+		if first == nil {
+			return false
+		}
+		first.mu.Lock()
+		closed := first.closed
+		first.mu.Unlock()
+		return closed
+	}, 2*time.Second, 20*time.Millisecond, "preview process did not exit")
+	firstStdout := first.stdout
+
+	require.NoError(t, b.ensurePTY(i))
+	require.ErrorIs(t, firstStdout.Close(), os.ErrClosed,
+		"stale preview stdout fd must be closed before ensurePTY deletes the old entry")
+
+	b.closePTY(i.Title)
+}


### PR DESCRIPTION
Closes #1331

## Summary
- close stale HookBackend preview stdout handles before deleting closed PTY entries
- keep the close idempotent behind a small hookPTY helper
- add a regression that verifies stale preview stdout is closed after ensurePTY cleanup

## Verify First
- Verified on origin/master at 8b8effd: ensurePTY deleted closed b.ptys entries without closing existing.stdout, orphaning the preview pipe fd once the map entry was gone.

## Verification
- make test-container GOTESTARGS="./session -run TestHookBackendEnsurePTYClosesStalePreviewStdout"
- golangci-lint run --fast
- gofmt -l $(git ls-files '*.go') (empty)
- go build ./...
- make test-container
- make lint-file-length

Signed-off-by: Captain Claude <captain.claude@users.noreply.github.com>

Co-authored-by: Captain Claude <captain.claude@users.noreply.github.com>