### PR TITLE
refactor(daemon): route archive through the transition() chokepoint (#1195 Phase 2d)

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -90,13 +90,18 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 		return "", err
 	}
 
-	// Fence the operation window with OpArchiving: the status poll skips an
-	// instance with an in-flight op (and the checkpoint save skips persisting a
-	// mid-op row) while tmux is down and the worktree is mid-move, so it is never
-	// misread as Lost. started is left true throughout so a move failure
-	// self-heals via the Lost loop. OpArchiving is a DISTINCT op from a kill, so
-	// the fence can never be confused with a TUI optimistic kill (#1187).
-	instance.SetInFlightOp(session.OpArchiving)
+	// Raise the archive fence through the chokepoint (#1195 Phase 2d): BeginArchive
+	// sets OpArchiving (I4) so the status poll skips this instance (and the
+	// checkpoint save skips persisting a mid-op row) while tmux is down and the
+	// worktree is mid-move — never misread as Lost. started is left true
+	// throughout so a move failure self-heals via the Lost loop. OpArchiving is a
+	// DISTINCT op from a kill, so the fence can never be confused with a TUI
+	// optimistic kill (#1187). The up-front guards (not archived, op==None) plus
+	// the op-lock guarantee this edge is legal; a rejection would surface here
+	// before any teardown.
+	if err := instance.Transition(session.BeginArchive()); err != nil {
+		return "", fmt.Errorf("cannot archive session %q: %w", req.Title, err)
+	}
 
 	// Tear down tmux and relocate the worktree in one call: the move is folded
 	// into the teardown core immediately after the pane-exit wait (#1195 Ph2b),
@@ -105,18 +110,18 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	if err := instance.ArchiveTeardown(dest); err != nil {
 		// The worktree is still at a valid location (the git layer guarantees
 		// worktreePath points at the actual bytes even on a repair failure).
-		// Mark Lost — started is still true and the agent tmux binding was kept —
-		// so the Lost-restore loop re-spawns the agent in place. Clear the archive
-		// fence and persist the recovery-eligible state, then surface the failure.
-		instance.SetLiveness(session.LiveLost)
-		instance.SetInFlightOp(session.OpNone)
+		// Roll the fence back to Lost — started is still true and the agent tmux
+		// binding was kept — so the Lost-restore loop re-spawns the agent in place.
+		// Persist the recovery-eligible state, then surface the failure.
+		_ = instance.Transition(session.AbortArchiveToLost())
 		m.persistInstance(repoID, instance)
 		return "", fmt.Errorf("failed to archive session %q (its agent will be restored in place): %w", req.Title, err)
 	}
 
-	// Success: worktree relocated, tmux down. Flip to the inert Archived state
-	// (started=false) and persist the new path + status.
-	instance.SetArchived()
+	// Success: worktree relocated, tmux down. Commit the inert Archived state
+	// (started=false, op cleared) — reachable only from the fence (I2) — and
+	// persist the new path + status.
+	_ = instance.Transition(session.CommitArchive())
 	archivedPath := instance.GetWorktreePath()
 	m.persistInstance(repoID, instance)
 	log.InfoLog.Printf("archived session %q (repo %s): tmux torn down, worktree moved to %s", req.Title, repoID, archivedPath)

--- a/session/transition.go
+++ b/session/transition.go
@@ -190,10 +190,13 @@ var transitionTable = map[transitionKind]edgeSpec{
 		target:      func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpNone} },
 	},
 	tkBeginArchive: {
-		allowedFrom: func(s stateAxes) bool {
-			return s.op == OpNone && (s.liveness == LiveRunning || s.liveness == LiveReady)
-		},
-		target: func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpArchiving} },
+		// Any non-archived session with no op in flight may be archived — matching
+		// the daemon's guards, which reject only an already-archived or busy
+		// session (a Lost / LimitReached session is archivable: shelving it tears
+		// down whatever tmux remains and moves the worktree out). I4 is the fence
+		// itself, not a liveness restriction.
+		allowedFrom: func(s stateAxes) bool { return s.op == OpNone && s.liveness != LiveArchived },
+		target:      func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpArchiving} },
 	},
 	tkCommitArchive: {
 		allowedFrom: func(s stateAxes) bool { return s.op == OpArchiving },

--- a/session/transition_test.go
+++ b/session/transition_test.go
@@ -65,6 +65,10 @@ func TestTransition_LegalEdgesApply(t *testing.T) {
 		{"RevertKill", stateAxes{LiveRunning, OpKilling}, true, false, RevertKill(), LiveRunning, OpNone, true},
 		{"BeginArchive from Ready", stateAxes{LiveReady, OpNone}, true, false, BeginArchive(), LiveReady, OpArchiving, true},
 		{"BeginArchive from Running", stateAxes{LiveRunning, OpNone}, true, false, BeginArchive(), LiveRunning, OpArchiving, true},
+		// A Lost / LimitReached session is archivable too (shelving it), matching
+		// the daemon guards — BeginArchive gates on the op/Archived, not liveness.
+		{"BeginArchive from Lost", stateAxes{LiveLost, OpNone}, true, false, BeginArchive(), LiveLost, OpArchiving, true},
+		{"BeginArchive from LimitReached", stateAxes{LiveLimitReached, OpNone}, true, false, BeginArchive(), LiveLimitReached, OpArchiving, true},
 		{"CommitArchive clears started", stateAxes{LiveRunning, OpArchiving}, true, false, CommitArchive(), LiveArchived, OpNone, false},
 		{"AbortArchiveToLost", stateAxes{LiveRunning, OpArchiving}, true, false, AbortArchiveToLost(), LiveLost, OpNone, true},
 		// BeginRestore SETS started=true on the archived (started=false) row,
@@ -117,6 +121,16 @@ func TestTransition_DoubleRestorePanics(t *testing.T) {
 	i := &Instance{liveness: LiveLost, inFlightOp: OpRestoring}
 	assert.Panics(t, func() { _ = i.Transition(BeginRestore()) })
 	assert.Equal(t, OpRestoring, i.inFlightOp, "a rejected transition must not mutate state")
+}
+
+// TestTransition_I4_BeginArchiveAlreadyArchivedPanics: an archive may not begin
+// on an already-archived session (I4 — the fence is raised once). Also covers
+// the busy case (op in flight) implicitly via allowedFrom.
+func TestTransition_I4_BeginArchiveAlreadyArchivedPanics(t *testing.T) {
+	i := &Instance{liveness: LiveArchived, inFlightOp: OpNone}
+	assert.Panics(t, func() { _ = i.Transition(BeginArchive()) })
+	assert.Equal(t, LiveArchived, i.liveness, "a rejected transition must not mutate state")
+	assert.Equal(t, OpNone, i.inFlightOp)
 }
 
 // TestTransition_IllegalReturnsSoftErrorInProd pins the production semantics:


### PR DESCRIPTION
**Phase 2d of #1195** — second writer migration onto the `Transition()` chokepoint (audit #6). Builds on merged 2d restore (#1320). Design: https://github.com/sachiniyer/agent-factory/issues/1195#issuecomment-4888497895

## What

The daemon archive flow's hand-written state mutations now route through `Instance.Transition`, enforcing **I2** (Archived reachable only from the fence — move-before-Archived) and **I4** (the `OpArchiving` fence brackets the teardown+move window) **live**.

- fence raise: `SetInFlightOp(OpArchiving)` → **`Transition(BeginArchive())`** (I4)
- move-fail rollback: `SetLiveness(Lost)+SetInFlightOp(None)` → **`Transition(AbortArchiveToLost())`**
- success: `SetArchived()` → **`Transition(CommitArchive())`** — reachable only from the `OpArchiving` fence (I2); sets `started=false` + Archived + op cleared, exactly as `SetArchived` did.

## Table change: relaxed `BeginArchive`

Relaxed the `BeginArchive` edge from `{Running,Ready}` to **`op==None && liveness != Archived`** to match the daemon's actual guards — a **Lost / LimitReached session is archivable** (shelving it tears down whatever tmux remains and moves the worktree out). I4 is the fence itself, not a liveness restriction. Added tests: `BeginArchive` legal from Lost/LimitReached + a panic test locking `BeginArchive`-from-Archived (I4).

## Behavior-preserving

The up-front guards (not archived, `op==None`) + the per-session op-lock guarantee `BeginArchive` is legal in production; the resulting `(started, liveness, op)` on the success and move-failure paths is **identical** to the old direct setters. `CommitArchive`/`AbortArchiveToLost` are only reachable with `op==OpArchiving`, so they never reject.

## Gates (all green)

`go build`, `gofmt -l .` empty, `go vet`, `deadcode -test ./...` clean, `golangci-lint --fast`, file-length, and **`make test-container`** — full suite incl. daemon `archive_test` + `integration`.

Archive is behavior-sensitive — an **archive + failed-move rollback + restore play-test** is worth a pass on your side. Refs #1195 (2d continues: kill/create (I1), TUI ops → then 2e).

— Captain Claude