### PR TITLE
Add preview commit model for #1321

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1115,6 +1115,10 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			}
 			return m, m.selectionChanged()
 		}
+		if m.panePreviewTxn != nil {
+			m.cancelPanePreview(true)
+			return m, m.panesRefresh(m.attached.Load())
+		}
 	}
 
 	// Ctrl+C is an always-on hard exit — never rebindable, so it stays a

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -527,6 +527,9 @@ func killConfirmationWarning(wt string) string {
 // the full-screen hook PTY — fall back to the full-screen attach Enter used to
 // do; dead/transitional sessions keep their guard errors.
 func (m *home) handleEnter() (tea.Model, tea.Cmd) {
+	if m.panePreviewTxn != nil {
+		return m, m.commitPanePreviewReplace()
+	}
 	if p := m.focusedOpenPane(); p != nil {
 		return m.enterPane(p)
 	}

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -231,18 +231,24 @@ func TestSecondEnterTargetsCurrentSelectionNotStalePane(t *testing.T) {
 	}
 	require.Equal(t, instB, h.sidebar.GetSelectedInstance(), "navigation must land on B")
 
-	// 4. Enter again — must open/enter B, NOT re-enter the stale A pane.
+	// 4. Enter again commits the active sidebar preview: the current
+	// selection B replaces the focused pane binding, rather than re-entering
+	// stale A (#1321 commit-replace preserving the #1233/#1236 target rule).
 	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
 	paneB := h.focusedOpenPane()
-	require.NotNil(t, paneB, "second Enter must open B's pane")
-	require.Equal(t, instB, paneB.Instance(), "the opened pane must belong to B")
-	require.NotEqual(t, paneA, paneB, "B's pane must be distinct from A's")
+	require.NotNil(t, paneB, "second Enter must leave a focused pane")
+	require.Same(t, paneA, paneB, "commit-replace keeps the owner pane")
+	require.Equal(t, instB, paneB.Instance(), "the committed pane must belong to selected B")
+	require.False(t, h.interactive, "commit-replace does not also enter interactive mode")
+
+	// 5. With no preview active now, Enter on the focused pane enters B.
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
 	_, cmd = h.Update(enterInteractiveMsg{pane: paneB})
 	runHermeticCmd(t, h, cmd, 0)
 
-	require.True(t, h.interactive, "second Enter must (re)enter interactive mode")
+	require.True(t, h.interactive, "third Enter must enter interactive mode on committed B")
 	assert.Equal(t, instB, h.livePane.Instance(),
-		"second Enter must bind input to the SELECTED instance B, not the previously-interacted A")
+		"input must bind to the committed instance B, not the previously-interacted A")
 	assert.Equal(t, paneB, h.livePane, "the live pane must be B's pane")
 
 	// A forwarded keystroke must land in B's attachment, never A's stale one.

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -307,6 +307,118 @@ func TestPanePreviewEscFromScrollRevertsOriginalCommittedTab(t *testing.T) {
 		"reset must not pair the committed alpha instance with the preview agent tab")
 }
 
+func TestPanePreviewEnterCommitsReplace(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Same(t, alpha, paneA.Instance())
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn)
+
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+
+	require.NotNil(t, cmd, "commit-replace should schedule a refresh for the committed pane")
+	require.Nil(t, h.panePreviewTxn)
+	assert.Same(t, beta, paneA.Instance(), "Enter commits the highlighted preview into the owner pane")
+	assert.Equal(t, 0, paneA.Tab())
+	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active())
+	view := h.View()
+	assert.Contains(t, view, "beta · Agent")
+	assert.NotContains(t, view, "PREVIEW")
+}
+
+func TestPanePreviewTabAndEscCancelToOwnerPane(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(*home) tea.Cmd
+	}{
+		{
+			name: "Tab",
+			run: func(h *home) tea.Cmd {
+				_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyTab}, keys.KeyTab)
+				return cmd
+			},
+		},
+		{
+			name: "Esc",
+			run: func(h *home) tea.Cmd {
+				_, cmd := h.Update(tea.KeyMsg{Type: tea.KeyEsc})
+				return cmd
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := paneTestHome(t)
+			alpha := h.store.GetInstanceByTitle("alpha")
+
+			pressKey(t, h, "s")
+			paneA := h.store.OpenPanes()[0]
+			h.sidebar.SetSelectedInstance(1)
+			_ = h.selectionChanged()
+			require.NotNil(t, h.panePreviewTxn)
+
+			cmd := tc.run(h)
+
+			require.NotNil(t, cmd, "cancel should schedule an owner-pane refresh")
+			require.Nil(t, h.panePreviewTxn)
+			assert.Same(t, alpha, paneA.Instance())
+			assert.Equal(t, 0, paneA.Tab())
+			assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active())
+			view := h.View()
+			assert.Contains(t, view, "alpha · Agent · selected: beta · Agent")
+			assert.NotContains(t, view, "PREVIEW")
+		})
+	}
+}
+
+func TestPanePreviewEnterBlocksUncommittableTargets(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*session.Instance)
+		wantErr   string
+	}{
+		{
+			name:      "dead",
+			configure: func(inst *session.Instance) { inst.SetLiveness(session.LiveDead) },
+			wantErr:   "no longer running",
+		},
+		{
+			name:      "lost",
+			configure: func(inst *session.Instance) { inst.SetLiveness(session.LiveLost) },
+			wantErr:   "was lost",
+		},
+		{
+			name:      "in-flight",
+			configure: func(inst *session.Instance) { inst.SetInFlightOp(session.OpKilling) },
+			wantErr:   "operation in flight",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := paneTestHome(t)
+			alpha := h.store.GetInstanceByTitle("alpha")
+			beta := h.store.GetInstanceByTitle("beta")
+			tc.configure(beta)
+
+			pressKey(t, h, "s")
+			paneA := h.store.OpenPanes()[0]
+			h.sidebar.SetSelectedInstance(1)
+			_ = h.selectionChanged()
+			require.NotNil(t, h.panePreviewTxn, "preview remains allowed for blocked commit targets")
+
+			_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+
+			require.NotNil(t, h.panePreviewTxn, "blocked commit should keep the preview active")
+			assert.Same(t, alpha, paneA.Instance())
+			assert.Contains(t, h.errBox.String(), tc.wantErr)
+		})
+	}
+}
+
 // TestPane_TabDimension: opening from a tree TAB row binds that tab, distinct
 // (instance, tab) pairs get distinct panes, and later selection tab jumps
 // don't touch open panes.
@@ -782,6 +894,7 @@ func TestPane_EnterAttachTargetFollowsFocusContext(t *testing.T) {
 	h.sidebar.SetSelectedInstance(1)
 	_ = h.selectionChanged()
 	require.Equal(t, "beta", h.store.GetSelectedInstance().Title)
+	h.cancelPanePreview(false)
 
 	var attachedLabel, attachedTitle string
 	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
@@ -959,6 +1072,11 @@ func TestPane_StoreOpenPanePrimitives(t *testing.T) {
 	vis = proj.VisibleOpenPanes(1)
 	require.Equal(t, []*store.OpenPane{p1}, vis)
 	assert.Empty(t, proj.VisibleOpenPanes(0))
+
+	require.True(t, proj.RebindOpenPane(p1, b, 1))
+	assert.Same(t, b, p1.Instance())
+	assert.Equal(t, 1, p1.Tab())
+	assert.Same(t, p1, proj.FindOpenPane(b, 1))
 
 	require.True(t, proj.CloseOpenPane(p2))
 	require.False(t, proj.CloseOpenPane(p2), "closing twice reports absence")

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -332,6 +332,38 @@ func TestPanePreviewEnterCommitsReplace(t *testing.T) {
 	assert.NotContains(t, view, "PREVIEW")
 }
 
+func TestPanePreviewEnterCommitFocusesAlreadyOpenTarget(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Same(t, alpha, paneA.Instance())
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	pressKey(t, h, "s")
+	require.Equal(t, 2, h.store.NumOpenPanes())
+	paneB := h.store.OpenPanes()[1]
+	require.Same(t, beta, paneB.Instance())
+
+	h.focusRegion(layout.PaneRegion(paneA.ID()))
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn)
+
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+
+	require.NotNil(t, cmd, "focusing the existing target should schedule a refresh")
+	require.Nil(t, h.panePreviewTxn)
+	assert.Same(t, alpha, paneA.Instance(), "owner pane must keep its original binding")
+	assert.Same(t, beta, paneB.Instance())
+	assert.Equal(t, 2, h.store.NumOpenPanes(), "commit onto an already-open target must not duplicate panes")
+	assert.Same(t, paneB, h.store.FindOpenPane(beta, 0))
+	assert.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active(), "existing target pane takes focus")
+}
+
 func TestPanePreviewTabAndEscCancelToOwnerPane(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -110,6 +110,13 @@ func (m *home) commitPanePreviewReplace() tea.Cmd {
 		m.cancelPanePreview(false)
 		return nil
 	}
+	if existing := m.store.FindOpenPane(txn.target.instance, txn.target.tab); existing != nil && existing != owner {
+		m.cancelPanePreview(false)
+		m.store.TouchOpenPane(existing)
+		m.relayout()
+		m.focusRegion(layout.PaneRegion(existing.ID()))
+		return m.panesRefresh(m.attached.Load())
+	}
 	w := m.paneWindows[owner.ID()]
 	m.panePreviewTxn = nil
 	if w != nil {

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/store"
@@ -94,6 +95,51 @@ func (m *home) cancelPanePreview(focusOwner bool) {
 			m.focusRegion(layout.PaneRegion(p.ID()))
 		}
 	}
+}
+
+func (m *home) commitPanePreviewReplace() tea.Cmd {
+	txn := m.panePreviewTxn
+	if txn == nil {
+		return nil
+	}
+	if err := previewCommitError(txn.target.instance); err != nil {
+		return m.handleError(err)
+	}
+	owner := m.openPaneByID(txn.ownerPaneID)
+	if owner == nil {
+		m.cancelPanePreview(false)
+		return nil
+	}
+	w := m.paneWindows[owner.ID()]
+	m.panePreviewTxn = nil
+	if w != nil {
+		w.ClearPreview()
+		w.InvalidateContent(txn.target.instance, txn.target.tab, "Loading pane...")
+	}
+	if !m.store.RebindOpenPane(owner, txn.target.instance, txn.target.tab) {
+		return nil
+	}
+	m.store.TouchOpenPane(owner)
+	m.lastPaneCapture[owner.ID()] = time.Time{}
+	m.relayout()
+	m.focusRegion(layout.PaneRegion(owner.ID()))
+	return m.panesRefresh(m.attached.Load())
+}
+
+func previewCommitError(inst *session.Instance) error {
+	if inst == nil {
+		return fmt.Errorf("no preview to commit")
+	}
+	if inst.HasInFlightOp() {
+		return fmt.Errorf("cannot commit preview for %q: session operation in flight", inst.Title)
+	}
+	switch inst.GetLiveness() {
+	case session.LiveDead:
+		return fmt.Errorf("cannot commit preview for %q: session no longer running", inst.Title)
+	case session.LiveLost:
+		return fmt.Errorf("cannot commit preview for %q: session was lost", inst.Title)
+	}
+	return nil
 }
 
 func (m *home) renderBindingForPane(p *store.OpenPane) (paneBinding, uint64) {

--- a/ui/store/projection.go
+++ b/ui/store/projection.go
@@ -581,6 +581,28 @@ func (p *Projection) AddOpenPane(instance *session.Instance, tab int) *OpenPane 
 	return pane
 }
 
+// RebindOpenPane retargets an existing pane's local UI binding. This is used by
+// preview commit/replace flows: daemon-owned session/tab state is untouched, but
+// the workspace pane now renders a different explicit (instance, tab).
+func (p *Projection) RebindOpenPane(pane *OpenPane, instance *session.Instance, tab int) bool {
+	if pane == nil || instance == nil {
+		return false
+	}
+	for _, cur := range p.openPanes {
+		if cur != pane {
+			continue
+		}
+		if cur.instance == instance && cur.Tab() == tab {
+			return true
+		}
+		cur.instance = instance
+		cur.SetTab(tab)
+		p.bump()
+		return true
+	}
+	return false
+}
+
 // CloseOpenPane removes a pane from the open list — the hide verb (`x`) and
 // the dead-instance prune both land here. The pane's tab keeps running in
 // its tmux session; nothing is killed (§2.3). Reports whether the pane was


### PR DESCRIPTION
## Summary
- make Enter commit an active pane preview into the owner pane (commit-replace)
- make Esc cancel an active non-scrolled preview, matching Tab/Shift-Tab cancel behavior
- block preview commits for Dead, Lost, and in-flight targets with explicit errors while keeping the preview active
- add `Projection.RebindOpenPane` for local pane binding replacement without daemon/session persistence mutation
- update #1233/#1236 Enter target coverage for the active-preview commit model while preserving focused-pane behavior when no preview is active

## Scope
- PR2 only: Tab/Esc cancel + Enter replace + blocked commits
- no `S` split/commit-alongside key yet

Refs #1321. Follows merged PR #1325.

## Test
- `make test-container`