### PR TITLE
Recover lost sessions when the branch survives

### DIFF
--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -150,9 +150,9 @@ func (failPtyFactory) Close() {}
 
 // TestRestoreLostSessions_LogsVanishedWorktreeOnce covers the #1303
 // instrumentation: when a live registered Lost session points at a worktree
-// directory that disappeared but Git still has the worktree admin entry, the
-// daemon emits one high-visibility ERROR with the diagnostic context and does
-// not repeat it on the next retry.
+// directory that disappeared and the branch is also gone, the daemon emits one
+// high-visibility ERROR with the diagnostic context and does not repeat it on
+// the next retry.
 func TestRestoreLostSessions_LogsVanishedWorktreeOnce(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	zeroRestoreBackoff(t)
@@ -168,6 +168,9 @@ func TestRestoreLostSessions_LogsVanishedWorktreeOnce(t *testing.T) {
 	}
 	if err := os.RemoveAll(worktreePath); err != nil {
 		t.Fatalf("remove worktree directory: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoPath, "update-ref", "-d", "refs/heads/"+branch).CombinedOutput(); err != nil {
+		t.Fatalf("delete branch ref: %v\n%s", err, out)
 	}
 
 	inst, err := session.NewInstance(session.InstanceOptions{Title: "vanished", Path: repoPath, Program: "claude"})
@@ -221,7 +224,7 @@ func TestRestoreLostSessions_LogsVanishedWorktreeOnce(t *testing.T) {
 		`parent_exists=true`,
 		`repo_exists=true`,
 		`git_worktree_registered="true"`,
-		`branch_exists="true"`,
+		`branch_exists="false"`,
 		`recover_error="recover: session \"vanished\" worktree unavailable: stat `,
 	} {
 		if !strings.Contains(logged, want) {

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -326,13 +326,23 @@ func (b *LocalBackend) respawn(i *Instance) error {
 		return fmt.Errorf("recover: session %q has no worktree to re-spawn into", i.Title)
 	}
 	if _, err := os.Stat(workDir); err != nil {
-		// Surface the real cause instead of a generic tmux new-session error:
-		// a deleted worktree is the expected permanent-failure shape, and the
-		// restore loop's escalation log should say so.
-		return &WorktreeUnavailableError{Title: i.Title, WorktreePath: workDir, Err: err}
+		if !os.IsNotExist(err) {
+			// Surface the real cause instead of a generic tmux new-session error:
+			// a deleted worktree is the expected permanent-failure shape, and the
+			// restore loop's escalation log should say so.
+			return &WorktreeUnavailableError{Title: i.Title, WorktreePath: workDir, Err: err}
+		}
+		if rebuildErr := gw.RebuildFromExistingBranch(); rebuildErr != nil {
+			return &WorktreeUnavailableError{
+				Title:        i.Title,
+				WorktreePath: workDir,
+				Err:          fmt.Errorf("%w (rebuild from existing branch failed: %v)", err, rebuildErr),
+			}
+		}
+		log.InfoLog.Printf("recover: rebuilt missing worktree for session %q at %s from branch %s", i.Title, workDir, gw.GetBranchName())
 	}
 
-	ts.SetProgram(injectSystemPrompt(resolveProgramForInstance(i)))
+	ts.SetProgram(injectSystemPrompt(prepareResumeConversation(i, resolveProgramForInstance(i))))
 	if err := ts.Restore(workDir); err != nil {
 		if cleanupErr := ts.CloseAttachOnly(); cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)

--- a/session/conversation.go
+++ b/session/conversation.go
@@ -111,3 +111,14 @@ func prepareLaunchConversation(i *Instance, program string) string {
 	})
 	return rewritten
 }
+
+func prepareResumeConversation(i *Instance, program string) string {
+	conv := i.AgentConversation()
+	if !conv.HasID() {
+		return program
+	}
+	if rewritten, ok := tmux.ResumeProgramWithConversationID(program, conv.Agent, conv.ID); ok {
+		return rewritten
+	}
+	return program
+}

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -49,6 +49,38 @@ func (g *GitWorktree) Setup() error {
 	return nil
 }
 
+// RebuildFromExistingBranch recreates this session worktree at its persisted
+// path using its persisted branch. It is the Lost-recovery path for a vanished
+// worktree whose branch survived: unlike Setup, it must never create a fresh
+// branch when the recorded branch is gone.
+func (g *GitWorktree) RebuildFromExistingBranch() error {
+	if g.externalWorktree {
+		return fmt.Errorf("cannot rebuild external worktree %s", g.worktreePath)
+	}
+	if g.worktreeDir == "" {
+		return fmt.Errorf("failed to get worktree directory: empty worktree directory")
+	}
+	if strings.TrimSpace(g.branchName) == "" {
+		return fmt.Errorf("cannot rebuild worktree %s: branch name is empty", g.worktreePath)
+	}
+	if err := os.MkdirAll(filepath.Dir(g.worktreePath), 0755); err != nil {
+		return err
+	}
+	if _, err := g.runGitCommand(g.repoPath, "show-ref", "--verify", fmt.Sprintf("refs/heads/%s", g.branchName)); err != nil {
+		return fmt.Errorf("cannot rebuild worktree %s: branch %s is unavailable: %w", g.worktreePath, g.branchName, err)
+	}
+
+	branchCreatedByUs := g.branchCreatedByUs
+	if err := g.setupFromExistingBranch(); err != nil {
+		g.branchCreatedByUs = branchCreatedByUs
+		return err
+	}
+	g.branchCreatedByUs = branchCreatedByUs
+
+	RunPostWorktreeHooksAsync(g.hooksCtx, g.repoPath, g.worktreePath)
+	return nil
+}
+
 // setupFromExistingBranch creates a worktree from an existing branch
 func (g *GitWorktree) setupFromExistingBranch() error {
 	// Directory already created in Setup(), skip duplicate creation

--- a/session/recover_test.go
+++ b/session/recover_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -152,6 +153,93 @@ func TestRecover_FailsWithoutWorktree(t *testing.T) {
 	assert.Contains(t, err.Error(), "worktree", "the failure must name the missing worktree")
 	assert.Equal(t, 0, newSessions, "no spawn may happen without a worktree")
 	assert.Equal(t, Lost, restored.GetStatus())
+}
+
+func TestRecover_RebuildsMissingWorktreeFromExistingBranchAndResumesRecordedConversation(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	repoRoot := initTempGitRepo(t)
+	gitOut(t, repoRoot, "config", "user.email", "test@test.com")
+	gitOut(t, repoRoot, "config", "user.name", "test")
+	gitOut(t, repoRoot, "commit", "--allow-empty", "-m", "initial")
+	const branch = "af/lost-recover"
+	gitOut(t, repoRoot, "branch", branch)
+
+	const agentName = "af_recover_branch"
+	shellName := agentName + shellTmuxSuffix
+	const conversationID = "019f386f-7206-7fc2-803b-f7045e07a242"
+	worktreePath := filepath.Join(t.TempDir(), "repo-lost-recover")
+	branchCreatedByUs := true
+	data := InstanceData{
+		Title:    "lost-recover",
+		Path:     repoRoot,
+		Branch:   branch,
+		Program:  tmux.ProgramCodex,
+		Status:   Lost,
+		TmuxName: agentName,
+		Tabs: []TabData{
+			{
+				Name:     agentTabName,
+				Kind:     TabKindAgent,
+				TmuxName: agentName,
+				Conversation: &AgentConversationData{
+					Agent:       tmux.ProgramCodex,
+					ID:          conversationID,
+					CaptureKind: ConversationCaptureCodexRollout,
+				},
+			},
+			{Name: shellTabName, Kind: TabKindShell, TmuxName: shellName},
+		},
+		Worktree: GitWorktreeData{
+			RepoPath:          repoRoot,
+			WorktreePath:      worktreePath,
+			SessionName:       "lost-recover",
+			BranchName:        branch,
+			BranchCreatedByUs: &branchCreatedByUs,
+		},
+	}
+
+	var newSessions int
+	var spawns []string
+	exec := recordingExec(map[string]bool{}, &newSessions, &spawns)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	t.Cleanup(func() { restoreTmuxSession = prev })
+
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+	require.Equal(t, Lost, restored.GetStatus())
+	_, statErr := os.Stat(worktreePath)
+	require.True(t, os.IsNotExist(statErr), "test setup should start with a missing worktree")
+
+	require.NoError(t, restored.Recover())
+
+	assert.Equal(t, Running, restored.GetStatus())
+	assert.True(t, restored.TabAlive(0), "Recover must re-spawn the agent after rebuilding the worktree")
+	require.DirExists(t, worktreePath)
+	assert.Equal(t, branch, gitOut(t, worktreePath, "rev-parse", "--abbrev-ref", "HEAD"))
+
+	var agentSpawn string
+	for _, spawn := range spawns {
+		if strings.Contains(spawn, agentName) && !strings.Contains(spawn, shellTmuxSuffix) {
+			agentSpawn = spawn
+			break
+		}
+	}
+	require.NotEmpty(t, agentSpawn, "expected to record the agent new-session command")
+	assert.Contains(t, agentSpawn, "codex resume "+conversationID,
+		"Recover must resume the recorded Codex conversation, not the latest one")
+	assert.NotContains(t, agentSpawn, "resume --last")
+
+	saved := restored.ToInstanceData()
+	require.NotNil(t, saved.Worktree.BranchCreatedByUs)
+	assert.True(t, *saved.Worktree.BranchCreatedByUs,
+		"rebuilding from the surviving branch must preserve original branch ownership")
 }
 
 // TestRecover_RefusesNonLostAndTombstoned: Recover is for Lost sessions only —

--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -101,6 +101,48 @@ func resumeProgram(program string) string {
 	return program
 }
 
+// ResumeProgramWithConversationID derives a "resume this exact conversation"
+// variant of program when the detected agent matches the recorded provider. It
+// returns ok=false when the provider has no id-specific resume path here, when
+// the command already carries an explicit resume/session flag, or when the
+// recorded provider no longer matches the resolved command. Callers should fall
+// back to Restore's latest-session resume behavior in those cases.
+func ResumeProgramWithConversationID(program, recordedAgent, id string) (rewritten string, ok bool) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return program, false
+	}
+	tokens, ends := splitShellTokens(program)
+	agentIdx, agent := findAgentToken(tokens)
+	if agentIdx < 0 || agent == "" || recordedAgent != agent {
+		return program, false
+	}
+
+	switch agent {
+	case ProgramClaude:
+		for _, tok := range tokens[agentIdx+1:] {
+			if tok == "-c" || tok == "--continue" || tok == "-r" || tok == "--resume" ||
+				strings.HasPrefix(tok, "--resume=") || strings.HasPrefix(tok, "-r=") ||
+				isShortResumeWithAttachedValue(tok) ||
+				tok == "--session-id" || strings.HasPrefix(tok, "--session-id=") {
+				return program, false
+			}
+		}
+		return program + " --resume " + id, true
+	case ProgramCodex:
+		insertAt := agentIdx + 1
+		if insertAt < len(tokens) && tokens[insertAt] == "exec" {
+			insertAt++
+		}
+		if insertAt < len(tokens) && tokens[insertAt] == "resume" {
+			return program, false
+		}
+		off := ends[insertAt-1]
+		return program[:off] + " resume " + id + program[off:], true
+	}
+	return program, false
+}
+
 // ClaudeProgramWithSessionID appends Claude Code's explicit conversation id flag
 // to a first-launch program string. It preserves the original program verbatim
 // except for the appended tokens and refuses to inject when the Claude command

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -373,6 +373,43 @@ func TestClaudeProgramWithSessionID(t *testing.T) {
 	}
 }
 
+func TestResumeProgramWithConversationID(t *testing.T) {
+	const id = "019f386f-7206-7fc2-803b-f7045e07a242"
+	cases := []struct {
+		name          string
+		agent         string
+		in            string
+		want          string
+		wantRewritten bool
+	}{
+		{"claude bare", ProgramClaude, "claude", "claude --resume " + id, true},
+		{"claude with flag", ProgramClaude, "claude --model sonnet", "claude --model sonnet --resume " + id, true},
+		{"claude wrapper", ProgramClaude, "ionice -c 3 claude", "ionice -c 3 claude --resume " + id, true},
+		{"claude already resume", ProgramClaude, "claude --resume old", "claude --resume old", false},
+		{"claude already continue", ProgramClaude, "claude --continue", "claude --continue", false},
+		{"codex bare", ProgramCodex, "codex", "codex resume " + id, true},
+		{"codex with flag", ProgramCodex, "codex --model gpt-5", "codex resume " + id + " --model gpt-5", true},
+		{"codex exec", ProgramCodex, "codex exec --foo bar", "codex exec resume " + id + " --foo bar", true},
+		{"codex quoted path", ProgramCodex, "'/path with spaces/codex' --model gpt-5", "'/path with spaces/codex' resume " + id + " --model gpt-5", true},
+		{"codex already resume", ProgramCodex, "codex resume --last", "codex resume --last", false},
+		{"provider mismatch", ProgramClaude, "codex --model gpt-5", "codex --model gpt-5", false},
+		{"unsupported provider", ProgramGemini, "gemini", "gemini", false},
+		{"empty id", ProgramCodex, "codex", "codex", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotID := id
+			if tc.name == "empty id" {
+				gotID = ""
+			}
+			got, rewritten := ResumeProgramWithConversationID(tc.in, tc.agent, gotID)
+			require.Equal(t, tc.want, got)
+			require.Equal(t, tc.wantRewritten, rewritten)
+		})
+	}
+}
+
 // TestResumeProgram_CodexProfileResumeFalsePositive guards #632: the codex
 // "already has resume" check must be position-aware. A profile named "resume"
 // (or any other flag value of "resume") must not be mistaken for the resume


### PR DESCRIPTION
## Summary
- Rebuild a missing local session worktree from its persisted branch during Lost recovery, without creating a new branch when the recorded one is gone.
- Respawn recovered agents with the recorded conversation ID for Claude/Codex when the resolved command still matches that provider; otherwise keep the existing latest-session fallback.
- Preserve the original branch ownership flag across rebuilds so later cleanup semantics do not change.
- Keep the #1303 missing-worktree diagnostic test on the unrecoverable branch-gone path.

## Verification
- `gofmt -w .`
- `go build ./...`
- `make test-container`
- `golangci-lint run --fast`
- `scripts/lint-file-length.sh`
- `deadcode -test ./...`
- `go test ./daemon -run TestRestoreLostSessions_LogsVanishedWorktreeOnce`
- `go test ./session ./session/tmux ./session/git`
- `git diff --check`

No TUI driver or playtest driver was run, per #1303 safety guidance.

Refs #1300
