### PR TITLE
Restore lost sessions when the branch is gone

### DIFF
--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -325,6 +325,7 @@ func (b *LocalBackend) respawn(i *Instance) error {
 	if workDir == "" {
 		return fmt.Errorf("recover: session %q has no worktree to re-spawn into", i.Title)
 	}
+	resolvedProgram := resolveProgramForInstance(i)
 	if _, err := os.Stat(workDir); err != nil {
 		if !os.IsNotExist(err) {
 			// Surface the real cause instead of a generic tmux new-session error:
@@ -333,16 +334,31 @@ func (b *LocalBackend) respawn(i *Instance) error {
 			return &WorktreeUnavailableError{Title: i.Title, WorktreePath: workDir, Err: err}
 		}
 		if rebuildErr := gw.RebuildFromExistingBranch(); rebuildErr != nil {
-			return &WorktreeUnavailableError{
-				Title:        i.Title,
-				WorktreePath: workDir,
-				Err:          fmt.Errorf("%w (rebuild from existing branch failed: %v)", err, rebuildErr),
+			exactProgram, ok := prepareExactResumeConversation(i, resolvedProgram)
+			if !ok {
+				return &WorktreeUnavailableError{
+					Title:        i.Title,
+					WorktreePath: workDir,
+					Err: fmt.Errorf("%w (rebuild from existing branch failed: %v; fresh rebuild requires a recorded conversation id for the resolved agent)",
+						err, rebuildErr),
+				}
 			}
+			if freshErr := gw.RebuildFreshFromRecordedBase(); freshErr != nil {
+				return &WorktreeUnavailableError{
+					Title:        i.Title,
+					WorktreePath: workDir,
+					Err: fmt.Errorf("%w (rebuild from existing branch failed: %v; fresh rebuild from recorded base failed: %v)",
+						err, rebuildErr, freshErr),
+				}
+			}
+			resolvedProgram = exactProgram
+			log.InfoLog.Printf("recover: rebuilt missing worktree for session %q at %s from recorded base and recreated branch %s", i.Title, workDir, gw.GetBranchName())
+		} else {
+			log.InfoLog.Printf("recover: rebuilt missing worktree for session %q at %s from branch %s", i.Title, workDir, gw.GetBranchName())
 		}
-		log.InfoLog.Printf("recover: rebuilt missing worktree for session %q at %s from branch %s", i.Title, workDir, gw.GetBranchName())
 	}
 
-	ts.SetProgram(injectSystemPrompt(prepareResumeConversation(i, resolveProgramForInstance(i))))
+	ts.SetProgram(injectSystemPrompt(prepareResumeConversation(i, resolvedProgram)))
 	if err := ts.Restore(workDir); err != nil {
 		if cleanupErr := ts.CloseAttachOnly(); cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)

--- a/session/conversation.go
+++ b/session/conversation.go
@@ -113,12 +113,19 @@ func prepareLaunchConversation(i *Instance, program string) string {
 }
 
 func prepareResumeConversation(i *Instance, program string) string {
-	conv := i.AgentConversation()
-	if !conv.HasID() {
-		return program
-	}
-	if rewritten, ok := tmux.ResumeProgramWithConversationID(program, conv.Agent, conv.ID); ok {
+	if rewritten, ok := prepareExactResumeConversation(i, program); ok {
 		return rewritten
 	}
 	return program
+}
+
+func prepareExactResumeConversation(i *Instance, program string) (string, bool) {
+	conv := i.AgentConversation()
+	if !conv.HasID() {
+		return program, false
+	}
+	if rewritten, ok := tmux.ResumeProgramWithConversationID(program, conv.Agent, conv.ID); ok {
+		return rewritten, true
+	}
+	return program, false
 }

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -81,6 +81,69 @@ func (g *GitWorktree) RebuildFromExistingBranch() error {
 	return nil
 }
 
+// RebuildFreshFromRecordedBase recreates a vanished session worktree when both
+// the directory and branch are gone. It creates a new branch with the persisted
+// name from the recorded base commit when possible, falling back to origin's
+// default branch and then HEAD. The caller must only use this when it can resume
+// the agent's exact recorded conversation; otherwise this would be a fresh
+// redispatch into an empty worktree.
+func (g *GitWorktree) RebuildFreshFromRecordedBase() error {
+	if g.externalWorktree {
+		return fmt.Errorf("cannot rebuild external worktree %s", g.worktreePath)
+	}
+	if g.worktreeDir == "" {
+		return fmt.Errorf("failed to get worktree directory: empty worktree directory")
+	}
+	if strings.TrimSpace(g.branchName) == "" {
+		return fmt.Errorf("cannot rebuild worktree %s: branch name is empty", g.worktreePath)
+	}
+	if err := os.MkdirAll(filepath.Dir(g.worktreePath), 0755); err != nil {
+		return err
+	}
+	if _, err := g.runGitCommand(g.repoPath, "show-ref", "--verify", fmt.Sprintf("refs/heads/%s", g.branchName)); err == nil {
+		return fmt.Errorf("cannot fresh rebuild worktree %s: branch %s already exists", g.worktreePath, g.branchName)
+	}
+
+	_, _ = g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath)
+	_, _ = g.runGitCommand(g.repoPath, "worktree", "prune")
+
+	baseCommit, err := g.rebuildBaseCommit()
+	if err != nil {
+		return err
+	}
+	if _, err := g.runGitCommand(g.repoPath, "worktree", "add", "-b", g.branchName, g.worktreePath, baseCommit); err != nil {
+		return fmt.Errorf("failed to create fresh worktree from commit %s: %w", baseCommit, err)
+	}
+
+	g.baseCommitSHA = baseCommit
+	g.branchCreatedByUs = true
+	RunPostWorktreeHooksAsync(g.hooksCtx, g.repoPath, g.worktreePath)
+	return nil
+}
+
+func (g *GitWorktree) rebuildBaseCommit() (string, error) {
+	if recorded := strings.TrimSpace(g.baseCommitSHA); recorded != "" {
+		if output, err := g.runGitCommand(g.repoPath, "rev-parse", "--verify", recorded+"^{commit}"); err == nil {
+			return strings.TrimSpace(output), nil
+		}
+		log.WarningLog.Printf("recorded base commit %s for worktree %s is unavailable; falling back to origin default/HEAD", recorded, g.worktreePath)
+	}
+	if baseCommit := g.resolveOriginHead(); baseCommit != "" {
+		return baseCommit, nil
+	}
+	output, err := g.runGitCommand(g.repoPath, "rev-parse", "HEAD")
+	if err != nil {
+		if strings.Contains(err.Error(), "fatal: ambiguous argument 'HEAD'") ||
+			strings.Contains(err.Error(), "fatal: not a valid object name") ||
+			strings.Contains(err.Error(), "fatal: HEAD: not a valid object name") {
+			return "", fmt.Errorf("this appears to be a brand new repository: please create an initial commit before restoring an instance")
+		}
+		return "", fmt.Errorf("failed to get HEAD commit hash: %w", err)
+	}
+	log.InfoLog.Printf("no recorded base/origin remote found, falling back to HEAD for recovered worktree")
+	return strings.TrimSpace(output), nil
+}
+
 // setupFromExistingBranch creates a worktree from an existing branch
 func (g *GitWorktree) setupFromExistingBranch() error {
 	// Directory already created in Setup(), skip duplicate creation

--- a/session/recover_test.go
+++ b/session/recover_test.go
@@ -242,6 +242,157 @@ func TestRecover_RebuildsMissingWorktreeFromExistingBranchAndResumesRecordedConv
 		"rebuilding from the surviving branch must preserve original branch ownership")
 }
 
+func TestRecover_RebuildsBranchGoneWorktreeFromRecordedBaseAndResumesRecordedConversation(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	repoRoot := initTempGitRepo(t)
+	gitOut(t, repoRoot, "config", "user.email", "test@test.com")
+	gitOut(t, repoRoot, "config", "user.name", "test")
+	gitOut(t, repoRoot, "commit", "--allow-empty", "-m", "base")
+	baseSHA := gitOut(t, repoRoot, "rev-parse", "HEAD")
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "later.txt"), []byte("later\n"), 0644))
+	gitOut(t, repoRoot, "add", "later.txt")
+	gitOut(t, repoRoot, "commit", "-m", "later")
+	require.NotEqual(t, baseSHA, gitOut(t, repoRoot, "rev-parse", "HEAD"))
+
+	const branch = "af/branch-gone"
+	const agentName = "af_recover_branch_gone"
+	shellName := agentName + shellTmuxSuffix
+	const conversationID = "019f386f-7206-7fc2-803b-f7045e07a242"
+	worktreePath := filepath.Join(t.TempDir(), "repo-branch-gone")
+	branchCreatedByUs := false
+	data := InstanceData{
+		Title:    "branch-gone",
+		Path:     repoRoot,
+		Branch:   branch,
+		Program:  tmux.ProgramClaude,
+		Status:   Lost,
+		TmuxName: agentName,
+		Tabs: []TabData{
+			{
+				Name:     agentTabName,
+				Kind:     TabKindAgent,
+				TmuxName: agentName,
+				Conversation: &AgentConversationData{
+					Agent:       tmux.ProgramClaude,
+					ID:          conversationID,
+					CaptureKind: ConversationCaptureInjected,
+				},
+			},
+			{Name: shellTabName, Kind: TabKindShell, TmuxName: shellName},
+		},
+		Worktree: GitWorktreeData{
+			RepoPath:          repoRoot,
+			WorktreePath:      worktreePath,
+			SessionName:       "branch-gone",
+			BranchName:        branch,
+			BaseCommitSHA:     baseSHA,
+			BranchCreatedByUs: &branchCreatedByUs,
+		},
+	}
+
+	var newSessions int
+	var spawns []string
+	exec := recordingExec(map[string]bool{}, &newSessions, &spawns)
+	pty := persistPtyFactory{t: t, cmdExec: exec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, exec)
+	}
+	t.Cleanup(func() { restoreTmuxSession = prev })
+
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+	require.Equal(t, Lost, restored.GetStatus())
+
+	require.NoError(t, restored.Recover())
+
+	assert.Equal(t, Running, restored.GetStatus())
+	require.DirExists(t, worktreePath)
+	assert.Equal(t, branch, gitOut(t, worktreePath, "rev-parse", "--abbrev-ref", "HEAD"))
+	assert.Equal(t, baseSHA, gitOut(t, worktreePath, "rev-parse", "HEAD"),
+		"branch-gone recovery should prefer the recorded base over current master")
+
+	var agentSpawn string
+	for _, spawn := range spawns {
+		if strings.Contains(spawn, agentName) && !strings.Contains(spawn, shellTmuxSuffix) {
+			agentSpawn = spawn
+			break
+		}
+	}
+	require.NotEmpty(t, agentSpawn, "expected to record the agent new-session command")
+	assert.Contains(t, agentSpawn, "--resume "+conversationID)
+	assert.NotContains(t, agentSpawn, "--continue")
+
+	saved := restored.ToInstanceData()
+	require.NotNil(t, saved.Worktree.BranchCreatedByUs)
+	assert.True(t, *saved.Worktree.BranchCreatedByUs,
+		"a branch recreated from recorded base is now owned by Agent Factory")
+	assert.Equal(t, baseSHA, saved.Worktree.BaseCommitSHA)
+}
+
+func TestRecover_BranchGoneWithoutRecordedConversationDoesNotFreshDispatch(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	repoRoot := initTempGitRepo(t)
+	gitOut(t, repoRoot, "config", "user.email", "test@test.com")
+	gitOut(t, repoRoot, "config", "user.name", "test")
+	gitOut(t, repoRoot, "commit", "--allow-empty", "-m", "base")
+	baseSHA := gitOut(t, repoRoot, "rev-parse", "HEAD")
+
+	const branch = "af/no-conversation"
+	const agentName = "af_recover_no_conversation"
+	shellName := agentName + shellTmuxSuffix
+	worktreePath := filepath.Join(t.TempDir(), "repo-no-conversation")
+	branchCreatedByUs := true
+	data := InstanceData{
+		Title:    "no-conversation",
+		Path:     repoRoot,
+		Branch:   branch,
+		Program:  tmux.ProgramCodex,
+		Status:   Lost,
+		TmuxName: agentName,
+		Tabs: []TabData{
+			{Name: agentTabName, Kind: TabKindAgent, TmuxName: agentName},
+			{Name: shellTabName, Kind: TabKindShell, TmuxName: shellName},
+		},
+		Worktree: GitWorktreeData{
+			RepoPath:          repoRoot,
+			WorktreePath:      worktreePath,
+			SessionName:       "no-conversation",
+			BranchName:        branch,
+			BaseCommitSHA:     baseSHA,
+			BranchCreatedByUs: &branchCreatedByUs,
+		},
+	}
+
+	var newSessions int
+	tmuxExec := countingExec(map[string]bool{}, &newSessions)
+	pty := persistPtyFactory{t: t, cmdExec: tmuxExec}
+	prev := restoreTmuxSession
+	restoreTmuxSession = func(name, program string) *tmux.TmuxSession {
+		return tmux.NewTmuxSessionFromSanitizedNameWithDeps(name, program, pty, tmuxExec)
+	}
+	t.Cleanup(func() { restoreTmuxSession = prev })
+
+	restored, err := FromInstanceData(data)
+	require.NoError(t, err)
+
+	err = restored.Recover()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recorded conversation id")
+	assert.Equal(t, 0, newSessions, "branch-gone recovery must not dispatch a fresh agent without exact resume")
+	_, statErr := os.Stat(worktreePath)
+	assert.True(t, os.IsNotExist(statErr), "worktree must remain absent when exact conversation resume is unavailable")
+	assert.Error(t, exec.Command("git", "-C", repoRoot, "show-ref", "--verify", "refs/heads/"+branch).Run(),
+		"branch must not be recreated without exact conversation resume")
+	assert.Equal(t, Lost, restored.GetStatus())
+}
+
 // TestRecover_RefusesNonLostAndTombstoned: Recover is for Lost sessions only —
 // a live session must never be re-spawned over (adopt, never clobber), and a
 // tombstoned record's only future is having its kill finished.


### PR DESCRIPTION
## Summary
- When a Lost session's worktree and branch are both gone, recreate the worktree from the recorded base commit, falling back to origin default/HEAD only when the recorded base is unavailable.
- Gate branch-gone restore on an exact recorded conversation resume command, so Claude/Codex use `--resume <id>` / `resume <id>` and unsupported/no-id cases do not fresh-dispatch into an empty worktree.
- Mark the recreated branch as Agent Factory-owned, since recovery creates it anew.
- Add focused recovery tests for recorded-base restore and the no-recorded-conversation refusal path.

## Verification
- `gofmt -w .`
- `go build ./...`
- `make test-container`
- `golangci-lint run --fast`
- `scripts/lint-file-length.sh`
- `deadcode -test ./...`
- `go test ./session ./session/git ./session/tmux ./daemon -run 'TestRecover|TestRestoreLostSessions_LogsVanishedWorktreeOnce|TestResumeProgramWithConversationID'`
- `git diff --check`

No TUI driver or playtest driver was run, per #1303 safety guidance.

Refs #1300
