### PR TITLE
refactor: route create/recover-complete writers through the chokepoint (#1195 Phase 2d)

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -85,9 +85,11 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.handleError(err)
 		}
 
-		// Apply the program selected during naming
+		// Apply the program selected during naming. The optimistic create op
+		// (OpCreating) was already raised in startNewInstance when the naming flow
+		// began — re-raising it here would be a second BeginCreate from OpCreating,
+		// an illegal edge the chokepoint rejects (#1350). Set it exactly once.
 		instance.Program = m.pendingProgram
-		_ = instance.Transition(session.BeginCreate())
 		m.namingInstance = nil
 		m.state = stateDefault
 		m.menu.SetState(ui.StateDefault)

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -87,7 +87,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		// Apply the program selected during naming
 		instance.Program = m.pendingProgram
-		instance.SetInFlightOp(session.OpCreating)
+		_ = instance.Transition(session.BeginCreate())
 		m.namingInstance = nil
 		m.state = stateDefault
 		m.menu.SetState(ui.StateDefault)
@@ -189,7 +189,7 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	if err != nil {
 		return m, m.handleError(err)
 	}
-	instance.SetInFlightOp(session.OpCreating)
+	_ = instance.Transition(session.BeginCreate())
 	m.store.AddInstance(instance)
 	m.sidebar.SetSelectedInstance(m.store.NumInstances() - 1)
 	m.namingInstance = instance

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -378,3 +378,37 @@ func TestHandleStateNewRejectsRemoteSlugCollision(t *testing.T) {
 	assert.Equal(t, "my_app", h.namingInstance.Title)
 	assert.Contains(t, h.errBox.String(), "myapp")
 }
+
+// TestNamingCreateFlow_NoDoubleTransition guards the #1350 regression: the
+// naming→create flow must raise the optimistic OpCreating exactly once. When the
+// naming flow began, startNewInstance already raised BeginCreate; the Enter
+// confirm handler must NOT re-raise it (a second BeginCreate from OpCreating is
+// an illegal edge). With the app-test panic hook installed (transition_hook_test),
+// a double-transition panics — so this drives the flow from the real precondition
+// (op already OpCreating) and asserts it does not.
+func TestNamingCreateFlow_NoDoubleTransition(t *testing.T) {
+	h := newTestHome(t)
+	h.state = stateNew
+	h.pendingProgram = "claude"
+	t.Cleanup(SetLocalSessionPreflightForTest(func(*config.Config, string) error { return nil }))
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "valid-title",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	// Precondition: startNewInstance already raised the optimistic create op.
+	require.NoError(t, inst.Transition(session.BeginCreate()))
+	require.Equal(t, session.OpCreating, inst.GetInFlightOp())
+	h.namingInstance = inst
+
+	// A second BeginCreate here would panic via the app illegal-transition hook.
+	assert.NotPanics(t, func() {
+		_, _ = h.handleStateNew(tea.KeyMsg{Type: tea.KeyEnter})
+	})
+
+	// Op raised exactly once — still Creating (the daemon start is deferred to the
+	// returned async cmd, which this test does not run).
+	assert.Equal(t, session.OpCreating, inst.GetInFlightOp())
+}

--- a/app/transition_hook_test.go
+++ b/app/transition_hook_test.go
@@ -1,0 +1,12 @@
+package app
+
+import "github.com/sachiniyer/agent-factory/session"
+
+// The app test binary panics on illegal lifecycle transitions (#1195 Phase 2d):
+// the TUI routes optimistic create/kill/archive overlays through the chokepoint,
+// and a mis-ordered edge (e.g. a double BeginCreate, #1350) must be a loud red
+// failure in tests rather than a silently-ignored soft error. Production leaves
+// the hook nil (soft error only).
+func init() {
+	session.SetIllegalTransitionHook(func(msg string) { panic("app: illegal transition: " + msg) })
+}

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -30,7 +30,8 @@ import (
 //     half-started session down.
 func finishCreateStart(instance *session.Instance, prompt string, startErr error) error {
 	if startErr == nil {
-		instance.MarkLive()
+		// Create succeeded: mark live through the chokepoint (#1195 Phase 2d).
+		_ = instance.Transition(session.ConfirmLive())
 		return nil
 	}
 	var limitErr *task.LimitReachedError

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -352,11 +352,11 @@ func (b *LocalBackend) respawn(i *Instance) error {
 	b.setupTabs(i)
 
 	// The program was just re-spawned and is booting: Running, exactly like a
-	// fresh create. markLive clears the OpRestoring/OpCreating fence this
-	// completion resolves while preserving a kill/archive teardown fence. The
-	// daemon poll re-derives Ready/Running from the live session from here on and
-	// persists the transition.
-	i.MarkLive()
+	// fresh create. ConfirmLive clears the OpRestoring/OpCreating fence this
+	// completion resolves while yielding to a kill/archive teardown fence (#1195
+	// Phase 2d — the chokepoint form of MarkLive). The daemon poll re-derives
+	// Ready/Running from the live session from here on and persists the transition.
+	_ = i.Transition(ConfirmLive())
 	return nil
 }
 

--- a/session/transition.go
+++ b/session/transition.go
@@ -228,6 +228,18 @@ var transitionTable = map[transitionKind]edgeSpec{
 // of the production binary.
 var onIllegalTransition func(msg string)
 
+// SetIllegalTransitionHook installs fn as the illegal-transition hook and returns
+// a restore func. It exists so test binaries in OTHER packages (app, daemon) can
+// install the same panic-on-illegal guard the session tests install directly — a
+// mis-ordered transition must be a loud failure everywhere a writer routes
+// through the chokepoint, not only in session-package tests. Production never
+// calls this: the hook stays nil and an illegal edge degrades to the soft error.
+func SetIllegalTransitionHook(fn func(msg string)) (restore func()) {
+	prev := onIllegalTransition
+	onIllegalTransition = fn
+	return func() { onIllegalTransition = prev }
+}
+
 // Transition applies a lifecycle event to the two-axis (liveness, inFlightOp)
 // state under i.mu, validating it against the allowed-edge table. It is the
 // single writer-side chokepoint for lifecycle-state changes (#1195 Phase 2c) and


### PR DESCRIPTION
**Phase 2d of #1195** — third writer migration onto the `Transition()` chokepoint. Builds on merged 2d restore (#1320) + archive (#1346). Design: https://github.com/sachiniyer/agent-factory/issues/1195#issuecomment-4888497895

## What

The create-side lifecycle writers now route through `Instance.Transition`:
- `session/backend_local.go` (recover/create success): `MarkLive()` → **`Transition(ConfirmLive())`**
- daemon `finishCreateStart` (create success): `MarkLive()` → **`Transition(ConfirmLive())`**
- app TUI optimistic create (×2): `SetInFlightOp(OpCreating)` → **`Transition(BeginCreate())`**

## Behavior-preserving

`ConfirmLive` is `MarkLive`'s exact chokepoint form — yields (no-op) to an in-flight kill/archive teardown, otherwise sets Running + clears the completing create/restore op, leaving `started` untouched. `BeginCreate` sets `OpCreating` on the freshly-built (`op==None`) naming instance, exactly as the direct setter did. `MarkLive` stays (test callers keep it reachable) until **2e** retires the direct setters.

## ⚠️ I1 / kill is deliberately NOT in this slice — flagging for your call

While migrating, I confirmed the kill path can't cleanly enforce I1 (tombstone-before-teardown) *via the chokepoint*:
- The daemon `KillSession` enforces I1 by **ordering** (`MarkUserKilled` before `Instance.Kill`) and **never sets an op** — keeping the snapshot pure liveness for out-of-band kills (your confirmed decision #3 on the anchor design).
- Daemon-internal kills (create-cleanup, reap-dead-root) call `Kill()` with **no tombstone** — so a "tombstone-before-every-teardown" rule is wrong.
- The TUI's optimistic `OpKilling` is a client overlay with **no tombstone** (the tombstone is daemon-side) — so `BeginKill`'s `requiresTombstone` (in the merged 2c table) can't gate it.

**Recommendation:** drop `requiresTombstone` from `BeginKill` (it's the client optimistic-kill overlay); keep I1 enforced by the daemon `KillSession` ordering (correct today). I2/I3/I4 are genuine `(liveness,op)` edges and stay chokepoint-enforced; I1 is a cross-object ordering that isn't. **I'll hold the kill/TUI-ops slice until you confirm this.**

## Gates (all green)

`go build`, `gofmt`, `go vet`, `deadcode -test ./...` clean, `golangci-lint --fast`, file-length, **`make test-container`** (full suite incl. app + daemon + integration).

Refs #1195.

— Captain Claude