### PR TITLE
Add preview split-pane key for #1321

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Common TUI keys:
 | `o` | Attach to the selected tab full-screen |
 | `Ctrl-w` | Detach from a full-screen attach |
 | `t` | Open a helper shell tab in the session worktree |
+| `s` | Open the selected tab as a workspace pane |
+| `S` | Commit a preview as a new workspace pane |
 | `a` | Archive or restore a session |
 | `D` | Kill a session and clean up its worktree |
 | `m` | Open the task manager |
@@ -94,6 +96,7 @@ keymap, pin those bindings in `~/.agent-factory/config.toml`:
 [keys]
 archive = "A"
 tasks = "S"
+split_pane = "alt+s"
 copy_pr = "P"
 hooks = "H"
 scroll_up = "shift+up"

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -64,10 +64,13 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 		// so its form is never clamped into the narrow rail.
 		return m.showTasksOverlay()
 
-	// N-pane verbs (#1088): s opens the selected tab as a pane (or focuses
-	// its pane); x hides the focused pane back to the background.
+	// N-pane verbs (#1088/#1321): s opens the selected tab as a pane (or
+	// focuses its pane); S commits an active preview alongside; x hides the
+	// focused pane back to the background.
 	case keys.KeyOpenPane:
 		return m.handleOpenPane()
+	case keys.KeySplitPane:
+		return m.handleSplitPane()
 	case keys.KeyHidePane:
 		return m.handleHidePane()
 

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -15,10 +15,11 @@ import (
 // This file hosts the N-pane verbs (#1088, RFC §2.3, replacing the PR-5 A/B
 // split): `s` opens the selected tab as a new vertical-split pane to the
 // right of the existing panes (or focuses its pane when the tab is already
-// open), `x` hides the focused pane back to the background. Hiding never
-// kills anything — the tab keeps running in its tmux session and reopens from
-// the tree any time. There is no pinned/primary pane distinction: every pane
-// is an explicit (instance, tab) binding in the store's open-pane list.
+// open), `S` commits an active #1321 preview alongside the owner pane, and
+// `x` hides the focused pane back to the background. Hiding never kills
+// anything — the tab keeps running in its tmux session and reopens from the
+// tree any time. There is no pinned/primary pane distinction: every pane is
+// an explicit (instance, tab) binding in the store's open-pane list.
 
 // openPaneWindow appends a pane bound to (instance, tab) to the store's
 // open-pane list and creates its content window. Callers dedupe via
@@ -114,6 +115,16 @@ func (m *home) openOrFocusPane(instance *session.Instance, tab int) (tea.Model, 
 	m.relayout()
 	m.focusRegion(layout.PaneRegion(p.ID()))
 	return m, m.selectionChanged()
+}
+
+// handleSplitPane dispatches the `S` key: commit the active preview alongside
+// its owner pane. The owner returns to its original committed binding, then
+// the preview target is opened as a new pane or, if already open, focused.
+func (m *home) handleSplitPane() (tea.Model, tea.Cmd) {
+	if m.panePreviewTxn == nil {
+		return m, nil
+	}
+	return m, m.commitPanePreviewAlongside()
 }
 
 // handleHidePane dispatches the `x` key: hide the FOCUSED pane back to the

--- a/app/help.go
+++ b/app/help.go
@@ -126,6 +126,7 @@ func (h helpTypeGeneral) toContent() string {
 			{helpKey(keys.KeyTab), "Cycle focus: tree → open panes → automations"},
 			{helpKey(keys.KeyShiftTab), "Cycle focus backwards"},
 			{helpKey(keys.KeyOpenPane), "Open the selected tab as a pane (or focus its pane)"},
+			{helpKey(keys.KeySplitPane), "Commit the current preview as another pane"},
 			{helpKey(keys.KeyHidePane), "Hide the focused pane (the tab keeps running)"},
 			{navKeys, "Navigate the tree (instances and their tabs)"},
 			{helpKey(keys.KeyLeft), "Collapse the selected instance's tabs"},

--- a/app/keymap_dispatch_test.go
+++ b/app/keymap_dispatch_test.go
@@ -70,7 +70,7 @@ func TestErgonomicDefaultKeysDispatchThroughKeymap(t *testing.T) {
 
 		h = newTestHome(t)
 		_ = dispatchKey(h, runeKey('S'))
-		assert.Equal(t, stateDefault, h.state, "old task key must be unbound by default")
+		assert.Equal(t, stateDefault, h.state, "S is split-pane by default, not task manager")
 	})
 
 	t.Run("hooks uses e and not H", func(t *testing.T) {
@@ -121,7 +121,7 @@ func TestErgonomicDefaultKeysDispatchThroughKeymap(t *testing.T) {
 }
 
 func TestPinnedOldDefaultDispatchesThroughKeymap(t *testing.T) {
-	require.NoError(t, keys.ApplyOverrides(map[string][]string{"tasks": {"S"}}))
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{"tasks": {"S"}, "split_pane": {"alt+s"}}))
 	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
 
 	h := newTestHome(t)

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -364,6 +364,68 @@ func TestPanePreviewEnterCommitFocusesAlreadyOpenTarget(t *testing.T) {
 	assert.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active(), "existing target pane takes focus")
 }
 
+func TestPanePreviewSplitCommitsAlongside(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Same(t, alpha, paneA.Instance())
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn)
+
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("S")}, keys.KeySplitPane)
+
+	require.NotNil(t, cmd, "commit-alongside should schedule a refresh")
+	require.Nil(t, h.panePreviewTxn)
+	require.Equal(t, 2, h.store.NumOpenPanes())
+	paneB := h.store.OpenPanes()[1]
+	assert.Same(t, alpha, paneA.Instance(), "split must restore the owner pane's original binding")
+	assert.Equal(t, 0, paneA.Tab())
+	assert.Same(t, beta, paneB.Instance(), "split appends the highlighted preview target")
+	assert.Equal(t, 0, paneB.Tab())
+	assert.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active(), "new target pane takes focus")
+	view := h.View()
+	assert.Contains(t, view, "alpha · Agent")
+	assert.Contains(t, view, "beta · Agent")
+	assert.NotContains(t, view, "PREVIEW")
+}
+
+func TestPanePreviewSplitFocusesAlreadyOpenTarget(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Same(t, alpha, paneA.Instance())
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	pressKey(t, h, "s")
+	require.Equal(t, 2, h.store.NumOpenPanes())
+	paneB := h.store.OpenPanes()[1]
+	require.Same(t, beta, paneB.Instance())
+
+	h.focusRegion(layout.PaneRegion(paneA.ID()))
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn)
+
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("S")}, keys.KeySplitPane)
+
+	require.NotNil(t, cmd, "focusing the existing target should schedule a refresh")
+	require.Nil(t, h.panePreviewTxn)
+	assert.Same(t, alpha, paneA.Instance(), "owner pane must keep its original binding")
+	assert.Same(t, beta, paneB.Instance())
+	assert.Equal(t, 2, h.store.NumOpenPanes(), "split onto an already-open target must not duplicate panes")
+	assert.Same(t, paneB, h.store.FindOpenPane(beta, 0))
+	assert.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active(), "existing target pane takes focus")
+}
+
 func TestPanePreviewTabAndEscCancelToOwnerPane(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -445,6 +507,50 @@ func TestPanePreviewEnterBlocksUncommittableTargets(t *testing.T) {
 			_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
 
 			require.NotNil(t, h.panePreviewTxn, "blocked commit should keep the preview active")
+			assert.Same(t, alpha, paneA.Instance())
+			assert.Contains(t, h.errBox.String(), tc.wantErr)
+		})
+	}
+}
+
+func TestPanePreviewSplitBlocksUncommittableTargets(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*session.Instance)
+		wantErr   string
+	}{
+		{
+			name:      "dead",
+			configure: func(inst *session.Instance) { inst.SetLiveness(session.LiveDead) },
+			wantErr:   "no longer running",
+		},
+		{
+			name:      "lost",
+			configure: func(inst *session.Instance) { inst.SetLiveness(session.LiveLost) },
+			wantErr:   "was lost",
+		},
+		{
+			name:      "in-flight",
+			configure: func(inst *session.Instance) { inst.SetInFlightOp(session.OpKilling) },
+			wantErr:   "operation in flight",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := paneTestHome(t)
+			alpha := h.store.GetInstanceByTitle("alpha")
+			beta := h.store.GetInstanceByTitle("beta")
+			tc.configure(beta)
+
+			pressKey(t, h, "s")
+			paneA := h.store.OpenPanes()[0]
+			h.sidebar.SetSelectedInstance(1)
+			_ = h.selectionChanged()
+			require.NotNil(t, h.panePreviewTxn, "preview remains allowed for blocked commit targets")
+
+			_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("S")}, keys.KeySplitPane)
+
+			require.NotNil(t, h.panePreviewTxn, "blocked split should keep the preview active")
+			assert.Equal(t, 1, h.store.NumOpenPanes(), "blocked split must not append a pane")
 			assert.Same(t, alpha, paneA.Instance())
 			assert.Contains(t, h.errBox.String(), tc.wantErr)
 		})

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -133,6 +133,24 @@ func (m *home) commitPanePreviewReplace() tea.Cmd {
 	return m.panesRefresh(m.attached.Load())
 }
 
+func (m *home) commitPanePreviewAlongside() tea.Cmd {
+	txn := m.panePreviewTxn
+	if txn == nil {
+		return nil
+	}
+	if err := previewCommitError(txn.target.instance); err != nil {
+		return m.handleError(err)
+	}
+	if m.openPaneByID(txn.ownerPaneID) == nil {
+		m.cancelPanePreview(false)
+		return nil
+	}
+	target := txn.target
+	m.cancelPanePreview(false)
+	_, cmd := m.openOrFocusPane(target.instance, target.tab)
+	return cmd
+}
+
 func previewCommitError(inst *session.Instance) error {
 	if inst == nil {
 		return fmt.Errorf("no preview to commit")

--- a/docs/concepts/tui.md
+++ b/docs/concepts/tui.md
@@ -59,6 +59,8 @@ Tabs persist across restarts, and each is a real process the daemon tracks.
 - **`m`** opens the tasks view to manage [scheduled and event-driven
   automations](../tasks.md).
 - **`c`** retries a session that's parked on a [usage limit](../usage-limits.md).
+- **`s`** opens the selected tab as a workspace pane; **`S`** commits an
+  active preview as another pane.
 - **`Ctrl-u`** / **`Ctrl-d`** scroll the current tab up and down.
 
 ## Key bindings are yours

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,7 +132,7 @@ tasks = "ctrl+t"
 ```
 
 - Key strings are the forms the terminal reports: a single character (`Q`, `/`, `?`), a named key (`up`, `enter`, `f5`, `space`), or a `ctrl+`/`alt+`/`shift+` combination (`ctrl+t`, `shift+up`).
-- **Rebindable actions:** `up`, `down`, `scroll_up`, `scroll_down`, `attach`, `new`, `kill`, `quit`, `help`, `new_remote`, `new_tab`, `close_tab`, `tasks`, `search`, `open_pr`, `copy_pr`, `hooks`, `open_pane`, `hide_pane`, `collapse`, `expand`, `next_section`, `prev_section`. (Run `af keys` to print the full effective table.)
+- **Rebindable actions:** `up`, `down`, `scroll_up`, `scroll_down`, `attach`, `new`, `kill`, `quit`, `help`, `new_remote`, `new_tab`, `close_tab`, `tasks`, `search`, `open_pr`, `copy_pr`, `hooks`, `open_pane`, `split_pane`, `hide_pane`, `collapse`, `expand`, `next_section`, `prev_section`. (Run `af keys` to print the full effective table.)
 - **Reserved keys** are rejected: binding any action to `enter`, `tab`, `shift+tab`, `esc`, `ctrl+]`, or a digit `1`–`9` is a startup error naming the key and why it's reserved (they drive interaction, the focus ring, overlay cancel, the interactive-mode exit, and the 1–9 tab jump respectively).
 - **`ctrl+c` is a fixed hard exit, not a reserved key.** Validation does *not* reject it — you can write `quit = "ctrl+c"` (or point any action at it) with no error — but `ctrl+c` always quits and is handled before the keymap ever sees the keypress, so binding an action to it has no effect: the hard exit wins. It is therefore not *effectively* rebindable, which is different from the reserved keys above that are outright rejected at load.
 - Any problem — an unknown action, an unparseable or reserved key, or two actions bound to the same key — is a **hard error at startup** that names the file and the offending action, so a typo can't silently leave you with a dead key. The bottom menu and the `?` help overlay both reflect your rebinds.
@@ -150,6 +150,7 @@ aliases; restore any old binding you still want by pinning it here:
 [keys]
 archive = "A"
 tasks = "S"
+split_pane = "alt+s"
 copy_pr = "P"
 hooks = "H"
 scroll_up = "shift+up"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@ keymap, add:
 [keys]
 archive = "A"
 tasks = "S"
+split_pane = "alt+s"
 copy_pr = "P"
 hooks = "H"
 scroll_up = "shift+up"

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -54,10 +54,12 @@ const (
 
 	// N-pane workspace verbs (#1088, replaces the PR-5 A/B split): `s` opens
 	// the selected tab as a new vertical-split pane (or focuses its pane when
-	// already open); `x` hides the focused pane back to the background — the
-	// tab keeps running, nothing is killed.
-	KeyOpenPane // OpenPane: open the selected tab as a pane / focus its pane.
-	KeyHidePane // HidePane hides the focused pane back to the background.
+	// already open); `S` commits a #1321 preview beside the owner pane; `x`
+	// hides the focused pane back to the background — the tab keeps running,
+	// nothing is killed.
+	KeyOpenPane  // OpenPane: open the selected tab as a pane / focus its pane.
+	KeySplitPane // SplitPane commits the active preview as a pane beside the owner.
+	KeyHidePane  // HidePane hides the focused pane back to the background.
 
 	// KeyManageAutomations is the automations-section display alias of Enter
 	// (menu/help only): with the in-rail section focused, Enter opens the task
@@ -127,6 +129,7 @@ var specs = []spec{
 	{name: KeyTaskList, configKey: "tasks", keys: []string{"m"}, desc: "tasks", dispatch: true},
 	{name: KeyManageAutomations, keys: []string{"enter"}, desc: "manage"},
 	{name: KeyOpenPane, configKey: "open_pane", keys: []string{"s"}, desc: "open pane", dispatch: true},
+	{name: KeySplitPane, configKey: "split_pane", keys: []string{"S"}, desc: "split pane", dispatch: true},
 	{name: KeyHidePane, configKey: "hide_pane", keys: []string{"x"}, desc: "hide pane", dispatch: true},
 	{name: KeySearch, configKey: "search", keys: []string{"/"}, desc: "search", dispatch: true},
 	{name: KeyOpenPR, configKey: "open_pr", keys: []string{"p"}, desc: "open PR", dispatch: true},

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -43,6 +43,7 @@ func TestDefaultMapsMatchApprovedKeymap(t *testing.T) {
 		"w":         KeyCloseTab,
 		"?":         KeyHelp,
 		"s":         KeyOpenPane,
+		"S":         KeySplitPane,
 		"x":         KeyHidePane,
 		"m":         KeyTaskList,
 		"/":         KeySearch,
@@ -97,7 +98,6 @@ func TestDefaultMapsMatchApprovedKeymap(t *testing.T) {
 func TestOldErgonomicReplacementsAreNotBoundByDefault(t *testing.T) {
 	oldDefaults := map[string]KeyName{
 		"A":          KeyArchive,
-		"S":          KeyTaskList,
 		"P":          KeyCopyPR,
 		"H":          KeyHooks,
 		"shift+up":   KeyShiftUp,
@@ -117,6 +117,9 @@ func TestOldErgonomicReplacementsAreNotBoundByDefault(t *testing.T) {
 	if got := GlobalKeyStringsMap["N"]; got != KeyNewRemote {
 		t.Fatalf("new remote key N must remain bound; got %v", got)
 	}
+	if got := GlobalKeyStringsMap["S"]; got != KeySplitPane {
+		t.Fatalf("S is now the approved split-pane default; got %v", got)
+	}
 }
 
 func TestOldDefaultsCanBePinnedViaOverrides(t *testing.T) {
@@ -124,6 +127,7 @@ func TestOldDefaultsCanBePinnedViaOverrides(t *testing.T) {
 	err := ApplyOverrides(map[string][]string{
 		"archive":     {"A"},
 		"tasks":       {"S"},
+		"split_pane":  {"alt+s"},
 		"copy_pr":     {"P"},
 		"hooks":       {"H"},
 		"scroll_up":   {"shift+up"},
@@ -136,6 +140,7 @@ func TestOldDefaultsCanBePinnedViaOverrides(t *testing.T) {
 	pinned := map[string]KeyName{
 		"A":          KeyArchive,
 		"S":          KeyTaskList,
+		"alt+s":      KeySplitPane,
 		"P":          KeyCopyPR,
 		"H":          KeyHooks,
 		"shift+up":   KeyShiftUp,

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -95,10 +95,11 @@ var automationsMenuOptions = []keys.KeyName{
 // paneMenuOptions are the status-bar hints while a workspace pane has focus
 // (#1088): enter interacts in-pane / o attaches full-screen (#1089), scroll
 // acts on the pane's own binding, s opens the selected tab as another pane,
-// x hides this pane back to the background.
+// S commits a preview as another pane, and x hides this pane back to the
+// background.
 var paneMenuOptions = []keys.KeyName{
 	keys.KeyEnter, keys.KeyAttach, keys.KeyShiftUp, keys.KeyShiftDown,
-	keys.KeyOpenPane, keys.KeyHidePane,
+	keys.KeyOpenPane, keys.KeySplitPane, keys.KeyHidePane,
 	keys.KeyTab, keys.KeyHelp, keys.KeyQuit,
 }
 
@@ -200,8 +201,8 @@ func (m *Menu) updateOptions() {
 		m.options = paneMenuOptions
 		m.groups = []menuGroup{
 			{start: 0, end: 4, isAction: true},
-			{start: 4, end: 6, isAction: false},
-			{start: 6, end: len(paneMenuOptions), isAction: false},
+			{start: 4, end: 7, isAction: false},
+			{start: 7, end: len(paneMenuOptions), isAction: false},
 		}
 		return
 	}
@@ -275,9 +276,9 @@ func (m *Menu) addInstanceOptions() {
 		tabGroup = []keys.KeyName{keys.KeyJumpTab}
 	}
 
-	// Pane group (#1088): s opens the selected tab as a workspace pane (or
-	// focuses its pane when already open).
-	paneGroup := []keys.KeyName{keys.KeyOpenPane}
+	// Pane group (#1088/#1321): s opens the selected tab as a workspace pane
+	// (or focuses its pane when already open); S commits a preview alongside.
+	paneGroup := []keys.KeyName{keys.KeyOpenPane, keys.KeySplitPane}
 
 	// System group: the focus-ring cycle plus help/quit.
 	systemGroup := []keys.KeyName{keys.KeyTab, keys.KeyHelp, keys.KeyQuit}
@@ -347,7 +348,7 @@ var hintDropOrder = [][]keys.KeyName{
 	{keys.KeyJumpTab},
 	{keys.KeyCloseTab},
 	{keys.KeyNewTab},
-	{keys.KeyOpenPane},
+	{keys.KeyOpenPane, keys.KeySplitPane},
 	{keys.KeySearch},
 	{keys.KeyNewRemote},
 	{keys.KeyHooks},

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -144,16 +144,16 @@ func TestMenuPaneHintsFollowFocus(t *testing.T) {
 	}
 
 	m.SetFocusRegion(layout.RegionTree)
-	if !has(keys.KeyOpenPane) || has(keys.KeyHidePane) {
-		t.Errorf("tree focus must advertise open-pane, not hide; options=%v", m.options)
+	if !has(keys.KeyOpenPane) || !has(keys.KeySplitPane) || has(keys.KeyHidePane) {
+		t.Errorf("tree focus must advertise open/split pane, not hide; options=%v", m.options)
 	}
 	if !has(keys.KeyNewTab) || !has(keys.KeyKill) {
 		t.Errorf("tree focus keeps the instance actions; options=%v", m.options)
 	}
 
 	m.SetFocusRegion(layout.PaneRegion(7))
-	if !has(keys.KeyOpenPane) || !has(keys.KeyHidePane) || !has(keys.KeyEnter) {
-		t.Errorf("a focused pane must advertise open-pane + hide-pane + attach; options=%v", m.options)
+	if !has(keys.KeyOpenPane) || !has(keys.KeySplitPane) || !has(keys.KeyHidePane) || !has(keys.KeyEnter) {
+		t.Errorf("a focused pane must advertise open/split/hide pane + attach; options=%v", m.options)
 	}
 	if has(keys.KeyNewTab) {
 		t.Errorf("pane focus swaps to the pane option set; options=%v", m.options)


### PR DESCRIPTION
## Summary
- add `KeySplitPane` / `[keys].split_pane` with default `S`, surfaced through help, menu, `af keys`, and docs
- implement #1321 commit-alongside: cancel/revert the preview owner pane, then append/focus the highlighted target pane
- preserve the no-duplicate-pane invariant by reusing the existing open-or-focus pane path
- cover split append/focus, already-open focus/no-duplicate, blocked Dead/Lost/in-flight commits, and keymap migration behavior

## Tests
- `go test ./keys`
- `go test ./ui`
- `go test ./app -run 'TestPinnedOldDefaultDispatchesThroughKeymap|TestErgonomicDefaultKeysDispatchThroughKeymap|TestPanePreviewSplit'`\n- `go build ./...`\n- `scripts/lint-file-length.sh`\n- `go run . keys | rg 'split_pane|open_pane|hide_pane'`\n- `make test-container`\n\nRefs #1321\n\nSafety: did not run `scripts/tui-driver.sh`.