### PR TITLE
Surface restore for lost and dead sessions

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -25,15 +25,15 @@ var SessionsCmd = &cobra.Command{
 }
 
 var (
-	createSessionViaDaemon   = daemon.CreateSession
-	killSessionViaDaemon     = daemon.KillSession
-	archiveSessionViaDaemon  = daemon.ArchiveSession
-	restoreArchivedViaDaemon = daemon.RestoreArchived
-	sendPromptViaDaemon      = daemon.SendPrompt
-	deliverPromptViaDaemon   = daemon.DeliverPrompt
-	createTabViaDaemon       = daemon.CreateTab
-	closeTabViaDaemon        = daemon.CloseTab
-	preflightLocalSession    = preflight.LocalSessionPrereqs
+	createSessionViaDaemon  = daemon.CreateSession
+	killSessionViaDaemon    = daemon.KillSession
+	archiveSessionViaDaemon = daemon.ArchiveSession
+	restoreSessionViaDaemon = daemon.RestoreSession
+	sendPromptViaDaemon     = daemon.SendPrompt
+	deliverPromptViaDaemon  = daemon.DeliverPrompt
+	createTabViaDaemon      = daemon.CreateTab
+	closeTabViaDaemon       = daemon.CloseTab
+	preflightLocalSession   = preflight.LocalSessionPrereqs
 	// snapshotViaDaemon is the non-spawning read path for list/get/whoami
 	// (#1029 PR 2). It reflects the daemon's authoritative in-memory state when
 	// a daemon is already running, and returns daemon.ErrDaemonUnavailable
@@ -756,14 +756,16 @@ success.`,
 
 var sessionsRestoreCmd = &cobra.Command{
 	Use:   "restore <title>",
-	Short: "Restore an archived session (worktree back in place, agent re-spawned)",
-	Long: `Restore a previously archived session: move its git worktree back next to the
-repository, re-register it, re-spawn the agent, and mark it running. Only the
-agent session is brought back — shell/process tabs are not restored.
+	Short: "Restore an archived, lost, or dead session",
+	Long: `Restore a session that is currently archived, lost, or dead.
 
-Fails if the session is not archived, or if its origin repository is gone (the
-archived worktree is left intact for manual recovery). The restored worktree
-path is printed on success.`,
+Archived sessions are moved back next to the repository, re-registered,
+re-spawned, and marked running. Lost/dead sessions are recovered in place,
+rebuilding a missing worktree when possible and resuming the recorded agent
+conversation when required.
+
+Fails if the session is not restorable, or if its origin repository is gone.
+The restored worktree path is printed on success.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
@@ -774,7 +776,7 @@ path is printed on success.`,
 			return jsonError(err)
 		}
 
-		worktreePath, err := restoreArchivedViaDaemon(daemon.RestoreArchivedRequest{Title: args[0], RepoID: repoID})
+		worktreePath, err := restoreSessionViaDaemon(daemon.RestoreSessionRequest{Title: args[0], RepoID: repoID})
 		if err != nil {
 			return jsonError(err)
 		}

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -1352,16 +1352,16 @@ func TestSessionsArchive_HonorsRepoScopingAndReturnsPath(t *testing.T) {
 func TestSessionsRestore_HonorsRepoScopingAndReturnsPath(t *testing.T) {
 	repoID := setupRepoForCmd(t)
 
-	var gotReq daemon.RestoreArchivedRequest
-	prev := restoreArchivedViaDaemon
-	restoreArchivedViaDaemon = func(req daemon.RestoreArchivedRequest) (string, error) {
+	var gotReq daemon.RestoreSessionRequest
+	prev := restoreSessionViaDaemon
+	restoreSessionViaDaemon = func(req daemon.RestoreSessionRequest) (string, error) {
 		gotReq = req
 		if req.RepoID == "" {
 			return "", errors.New("RepoID empty: --repo scoping was dropped")
 		}
 		return "/home/u/src/repo-worker", nil
 	}
-	defer func() { restoreArchivedViaDaemon = prev }()
+	defer func() { restoreSessionViaDaemon = prev }()
 
 	out, err := runCmdCaptureStdout(t, sessionsRestoreCmd, []string{"worker"})
 	if err != nil {

--- a/app/archive_action_test.go
+++ b/app/archive_action_test.go
@@ -42,6 +42,34 @@ func TestHandleArchive_LiveRowConfirms(t *testing.T) {
 	require.False(t, called, "the archive RPC must not fire before confirmation")
 }
 
+func TestHandleArchive_LostRowRestoresWithoutConfirmation(t *testing.T) {
+	h := newTestHome(t)
+	inst := archiveActionInstance(t, "worker", session.Lost)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	var gotTitle string
+	prev := restoreSessionThroughDaemon
+	restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
+		gotTitle = title
+		return "/worktree/path", nil
+	}
+	defer func() { restoreSessionThroughDaemon = prev }()
+
+	model, cmd := h.handleArchive()
+	h = model.(*home)
+
+	require.Equal(t, stateDefault, h.state, "restoring a Lost session must not open the archive confirmation")
+	require.Equal(t, session.OpRestoring, inst.GetInFlightOp(), "Lost restore should show an in-flight restore state")
+	require.NotNil(t, cmd, "Lost restore must dispatch the restore command")
+
+	msg := cmd()
+	require.Equal(t, "worker", gotTitle)
+	done, ok := msg.(instanceRestoredMsg)
+	require.True(t, ok, "the command must emit instanceRestoredMsg")
+	require.NoError(t, done.err)
+}
+
 // TestArchiveInstanceCmd_CallsDaemon: the archive command invokes the daemon
 // seam and reports completion.
 func TestArchiveInstanceCmd_CallsDaemon(t *testing.T) {
@@ -84,16 +112,29 @@ func TestRestoreInstanceCmd_CallsDaemon(t *testing.T) {
 	h := newTestHome(t)
 
 	var gotTitle string
-	prev := restoreArchivedThroughDaemon
-	restoreArchivedThroughDaemon = func(title, repoID string) (string, error) {
+	prev := restoreSessionThroughDaemon
+	restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
 		gotTitle = title
 		return "/worktree/path", nil
 	}
-	defer func() { restoreArchivedThroughDaemon = prev }()
+	defer func() { restoreSessionThroughDaemon = prev }()
 
 	msg := h.restoreInstanceCmd("worker")()
 	require.Equal(t, "worker", gotTitle)
 	done, ok := msg.(instanceRestoredMsg)
 	require.True(t, ok, "the command must emit instanceRestoredMsg")
 	require.NoError(t, done.err)
+}
+
+func TestHandleInstanceRestored_LostRowMarksLive(t *testing.T) {
+	h := newTestHome(t)
+	inst := archiveActionInstance(t, "worker", session.Lost)
+	inst.SetInFlightOp(session.OpRestoring)
+	h.store.AddInstance(inst)
+
+	model, _ := h.handleInstanceRestored(instanceRestoredMsg{title: "worker"})
+	h = model.(*home)
+
+	require.Equal(t, session.Running, inst.GetStatus())
+	require.Equal(t, session.OpNone, inst.GetInFlightOp())
 }

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -286,12 +286,12 @@ func (m *home) handleInstanceKilled(msg instanceKilledMsg) (tea.Model, tea.Cmd) 
 	return m, m.selectionChanged()
 }
 
-// handleArchive is the archive/restore verb (#1028, `a`): on an archived row it
-// restores the session (non-destructive — no confirm); on a live row it archives
-// it behind a confirmation, since archive tears down tmux and relocates the
-// worktree. Remote and in-place sessions can't be archived (no relocatable
-// worktree) and are rejected up front with an immediate message; the daemon
-// enforces the same rules authoritatively.
+// handleArchive is the archive/restore verb (`a`): on an archived row it restores
+// the session (non-destructive — no confirm); on a Lost/Dead row it runs recovery
+// through the daemon; on a live row it archives behind a confirmation, since
+// archive tears down tmux and relocates the worktree. Remote and in-place
+// sessions can't be archived (no relocatable worktree) and are rejected up front
+// with an immediate message; the daemon enforces the same rules authoritatively.
 func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 	selected := m.sidebar.GetSelectedInstance()
 	if selected == nil || selected.IsCreating() {
@@ -310,7 +310,9 @@ func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 	// Archived→live transition and runs its rebuild/re-Start (#1203). The reconcile
 	// rebuild clears the op by replacing the row; a restore failure clears it in
 	// handleInstanceRestored.
-	if selected.GetLiveness() == session.LiveArchived {
+	if selected.GetLiveness() == session.LiveArchived ||
+		selected.GetLiveness() == session.LiveLost ||
+		selected.GetLiveness() == session.LiveDead {
 		if selected.GetInFlightOp() == session.OpRestoring {
 			return m, m.handleError(fmt.Errorf("session '%s' is already being restored", title))
 		}
@@ -358,11 +360,10 @@ func (m *home) archiveInstanceCmd(title string) tea.Cmd {
 	}
 }
 
-// restoreInstanceCmd runs the daemon restore (worktree move-back + agent
-// re-spawn) off the event loop (#1028).
+// restoreInstanceCmd runs the daemon restore/recovery off the event loop.
 func (m *home) restoreInstanceCmd(title string) tea.Cmd {
 	repoID := m.repoID
-	restore := restoreArchivedThroughDaemon
+	restore := restoreSessionThroughDaemon
 	return func() tea.Msg {
 		if _, err := restore(title, repoID); err != nil {
 			log.ErrorLog.Printf("could not restore instance %q: %v", title, err)
@@ -492,6 +493,15 @@ func (m *home) handleInstanceRestored(msg instanceRestoredMsg) (tea.Model, tea.C
 		}
 		return m, m.handleError(fmt.Errorf("failed to restore session '%s': %w", msg.title, msg.err))
 	}
+	for _, inst := range m.store.GetInstances() {
+		switch {
+		case inst.Title != msg.title:
+			continue
+		case inst.GetLiveness() == session.LiveLost || inst.GetLiveness() == session.LiveDead:
+			inst.MarkLive()
+		}
+		break
+	}
 	return m, m.selectionChanged()
 }
 
@@ -588,20 +598,21 @@ func interactiveGuard(inst *session.Instance) error {
 	if inst.IsTearingDown() {
 		return fmt.Errorf("session '%s' is being deleted", inst.Title)
 	}
+	if inst.GetInFlightOp() == session.OpRestoring {
+		// Restore in flight (#1210/#1300): archived rows are re-homed into
+		// Instances while the daemon moves/spawns, and Lost/Dead rows keep their
+		// unavailable liveness until recovery completes.
+		return fmt.Errorf("session '%s' is being restored", inst.Title)
+	}
 	if inst.GetLiveness() == session.LiveLost {
 		// Lost (#1108): the backing tmux session vanished with no kill on
 		// record. Entering or attaching is impossible right now; say what
 		// happened — same explicit-feedback contract as the Deleting path
 		// (#935). Checked before TmuxAlive so the specific message wins.
-		return fmt.Errorf("session '%s' was lost — its tmux session is gone", inst.Title)
+		return fmt.Errorf("session '%s' was lost — restore it first (af sessions restore %s)", inst.Title, inst.Title)
 	}
-	if inst.GetInFlightOp() == session.OpRestoring {
-		// Restore in flight (#1210): the row already re-homed into Instances
-		// (ShownArchived), but its worktree/agent aren't back yet — the reconcile
-		// rebuild hasn't run. Say it's restoring rather than the misleading
-		// "restore it first" the archived branch below would give. Checked before
-		// the LiveArchived branch because liveness is still Archived mid-restore.
-		return fmt.Errorf("session '%s' is being restored", inst.Title)
+	if inst.GetLiveness() == session.LiveDead {
+		return fmt.Errorf("session '%s' is no longer running — restore it first (af sessions restore %s)", inst.Title, inst.Title)
 	}
 	if inst.GetLiveness() == session.LiveArchived {
 		// Archived (#1028): the user tore the session down and its worktree was

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -322,8 +322,14 @@ func (m *home) handleEnterPane(p *store.OpenPane) (tea.Model, tea.Cmd) {
 	if instance.IsTearingDown() {
 		return m, m.handleError(fmt.Errorf("session '%s' is being deleted", instance.Title))
 	}
+	if instance.GetInFlightOp() == session.OpRestoring {
+		return m, m.handleError(fmt.Errorf("session '%s' is being restored", instance.Title))
+	}
 	if instance.GetLiveness() == session.LiveLost {
-		return m, m.handleError(fmt.Errorf("session '%s' was lost — its tmux session is gone", instance.Title))
+		return m, m.handleError(fmt.Errorf("session '%s' was lost — restore it first (af sessions restore %s)", instance.Title, instance.Title))
+	}
+	if instance.GetLiveness() == session.LiveDead {
+		return m, m.handleError(fmt.Errorf("session '%s' is no longer running — restore it first (af sessions restore %s)", instance.Title, instance.Title))
 	}
 	if !instance.TmuxAlive() {
 		return m, m.handleError(fmt.Errorf("session '%s' is no longer running", instance.Title))

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -36,15 +36,15 @@ var killSessionThroughDaemon = func(title, repoID string) error {
 	return daemon.KillSession(daemon.KillSessionRequest{Title: title, RepoID: repoID})
 }
 
-// archiveSessionThroughDaemon / restoreArchivedThroughDaemon route the #1028
-// archive/restore verbs through the daemon (the single writer). Package vars so
-// the app test suite can stub them without dialing a real daemon.
+// archiveSessionThroughDaemon / restoreSessionThroughDaemon route archive and
+// restore verbs through the daemon (the single writer). Package vars so the app
+// test suite can stub them without dialing a real daemon.
 var archiveSessionThroughDaemon = func(title, repoID string) (string, error) {
 	return daemon.ArchiveSession(daemon.ArchiveSessionRequest{Title: title, RepoID: repoID})
 }
 
-var restoreArchivedThroughDaemon = func(title, repoID string) (string, error) {
-	return daemon.RestoreArchived(daemon.RestoreArchivedRequest{Title: title, RepoID: repoID})
+var restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
+	return daemon.RestoreSession(daemon.RestoreSessionRequest{Title: title, RepoID: repoID})
 }
 
 // resumeFromLimitThroughDaemon routes the TUI's `c` (retry usage-limit session)

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -125,6 +125,20 @@ type RestoreArchivedResponse struct {
 	WorktreePath string `json:"worktree_path"`
 }
 
+// RestoreSessionRequest asks the daemon to restore a restorable session:
+// archived sessions are moved back from the archive, while Lost/Dead sessions
+// are recovered in place.
+type RestoreSessionRequest struct {
+	Title  string `json:"title"`
+	RepoID string `json:"repo_id"`
+}
+
+type RestoreSessionResponse struct {
+	OK bool `json:"ok"`
+	// WorktreePath is the on-disk location of the restored/recovered worktree.
+	WorktreePath string `json:"worktree_path"`
+}
+
 type SendPromptRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
@@ -533,11 +547,10 @@ func ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	return resp.ArchivedPath, nil
 }
 
-// RestoreArchived asks the daemon to restore an archived session (#1028) and
-// returns the worktree's restored path.
-func RestoreArchived(req RestoreArchivedRequest) (string, error) {
-	var resp RestoreArchivedResponse
-	if err := callDaemon("RestoreArchived", req, &resp); err != nil {
+// RestoreSession asks the daemon to restore an archived, Lost, or Dead session.
+func RestoreSession(req RestoreSessionRequest) (string, error) {
+	var resp RestoreSessionResponse
+	if err := callDaemon("RestoreSession", req, &resp); err != nil {
 		return "", err
 	}
 	return resp.WorktreePath, nil
@@ -1090,6 +1103,22 @@ func (s *controlServer) RestoreArchived(req RestoreArchivedRequest, resp *Restor
 		return err
 	}
 	worktreePath, err := s.manager.RestoreArchived(req)
+	if err != nil {
+		return err
+	}
+	resp.OK = true
+	resp.WorktreePath = worktreePath
+	return nil
+}
+
+func (s *controlServer) RestoreSession(req RestoreSessionRequest, resp *RestoreSessionResponse) error {
+	if err := s.requireManagerReady(); err != nil {
+		return err
+	}
+	if err := validateRPCRepoID(req.RepoID); err != nil {
+		return err
+	}
+	worktreePath, err := s.manager.RestoreSession(req)
 	if err != nil {
 		return err
 	}

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -88,6 +88,13 @@ var httpRoutes = []HTTPRoute{
 	},
 	{
 		Method:        http.MethodPost,
+		Path:          "/v1/RestoreSession",
+		Description:   "Restore an archived, Lost, or Dead session.",
+		RequestFields: jsonFields(reflect.TypeOf(RestoreSessionRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.RestoreSession) },
+	},
+	{
+		Method:        http.MethodPost,
 		Path:          "/v1/SendPrompt",
 		Description:   "Send a prompt to an existing session's agent.",
 		RequestFields: jsonFields(reflect.TypeOf(SendPromptRequest{})),

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -93,6 +93,51 @@ func TestRestoreLostSessions_RecoversLostInstance(t *testing.T) {
 	}
 }
 
+func TestRestoreSession_RecoversLostInstanceOnDemand(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "stranded", backend, true, session.Lost)
+	key := daemonInstanceKey(repoID, "stranded")
+	manager.mu.Lock()
+	manager.lostRestoreStates[key] = &lostRestoreState{consecutiveFailures: 3}
+	manager.mu.Unlock()
+
+	_, err := manager.RestoreSession(RestoreSessionRequest{Title: "stranded", RepoID: repoID})
+	if err != nil {
+		t.Fatalf("RestoreSession returned error: %v", err)
+	}
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("recover calls = %d, want 1", got)
+	}
+	if got := inst.GetStatus(); got != session.Running {
+		t.Fatalf("status = %v, want Running after manual restore", got)
+	}
+	manager.mu.Lock()
+	_, hasState := manager.lostRestoreStates[key]
+	manager.mu.Unlock()
+	if hasState {
+		t.Fatal("manual restore must drop Lost retry state")
+	}
+}
+
+func TestRestoreSession_RecoversDeadInstanceOnDemand(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
+	inst := registerStarted(t, manager, repoID, repoPath, "dead", backend, true, session.Ready)
+	inst.SetLiveness(session.LiveDead)
+
+	_, err := manager.RestoreSession(RestoreSessionRequest{Title: "dead", RepoID: repoID})
+	if err != nil {
+		t.Fatalf("RestoreSession returned error: %v", err)
+	}
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("recover calls = %d, want 1", got)
+	}
+	if got := inst.GetStatus(); got != session.Running {
+		t.Fatalf("status = %v, want Running after manual restore", got)
+	}
+}
+
 // TestRestoreLostSessions_KeepsRetryingAndHeals mirrors the #1128 root-ensure
 // guarantee for the general loop: failures past the escalation threshold never
 // park the retry permanently, and the first pass after the cause clears heals.

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// RestoreSession restores a user-restorable session regardless of how it became
+// unavailable: archived rows use the archive restore path, while Lost/Dead rows
+// run the same Recover path the daemon's automatic Lost loop uses.
+func (m *Manager) RestoreSession(req RestoreSessionRequest) (string, error) {
+	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+	if err != nil {
+		return "", err
+	}
+	if instance == nil {
+		return "", fmt.Errorf("cannot restore session %q: no such session", req.Title)
+	}
+
+	switch instance.GetLiveness() {
+	case session.LiveArchived:
+		return m.RestoreArchived(RestoreArchivedRequest{Title: req.Title, RepoID: repoID})
+	case session.LiveLost, session.LiveDead:
+		return m.restoreLostOrDeadSession(req, repoID, instance)
+	default:
+		return "", fmt.Errorf("session %q is not archived, lost, or dead", req.Title)
+	}
+}
+
+func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID string, instance *session.Instance) (string, error) {
+	if instance.UserKilled() {
+		return "", fmt.Errorf("cannot restore session %q: it is being deleted", req.Title)
+	}
+	if session.IsReservedTitle(instance.Title) {
+		return "", fmt.Errorf("cannot manually restore reserved session %q", req.Title)
+	}
+	if instance.IsRemote() {
+		return "", fmt.Errorf("cannot restore remote session %q: reconnect is not supported", req.Title)
+	}
+	if !instance.Started() {
+		return "", fmt.Errorf("cannot restore session %q: it is not started", req.Title)
+	}
+
+	key := daemonInstanceKey(repoID, req.Title)
+	m.mu.Lock()
+	if _, busy := m.killsInFlight[key]; busy {
+		m.mu.Unlock()
+		return "", fmt.Errorf("an operation is already in progress for session %q", req.Title)
+	}
+	m.killsInFlight[key] = struct{}{}
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		delete(m.killsInFlight, key)
+		m.mu.Unlock()
+	}()
+
+	opLock := m.opLockFor(key)
+	opLock.Lock()
+	defer opLock.Unlock()
+
+	m.mu.Lock()
+	current := m.instances[key]
+	m.mu.Unlock()
+	if current != instance {
+		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
+	}
+	switch instance.GetLiveness() {
+	case session.LiveLost:
+	case session.LiveDead:
+		instance.SetLiveness(session.LiveLost)
+	default:
+		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
+	}
+
+	if err := instance.Recover(); err != nil {
+		m.persistInstance(repoID, instance)
+		return "", err
+	}
+	m.persistInstance(repoID, instance)
+	m.mu.Lock()
+	delete(m.lostRestoreStates, key)
+	m.mu.Unlock()
+	return instance.GetWorktreePath(), nil
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,7 +35,7 @@ af sessions attach <title>                                # attach interactively
 af sessions whoami                                        # report the session this shell is inside
 af sessions kill <title>                                  # kill the session, clean up its worktree
 af sessions archive <title>                               # tmux down + worktree moved out; restartable
-af sessions restore <title>                               # bring an archived session back
+af sessions restore <title>                               # restore an archived/lost/dead session
 ```
 
 Flags:
@@ -46,7 +46,7 @@ Flags:
 - `tab-delete`: the counterpart of `tab-create` — `--name` (required) selects the tab to delete. The tab is removed from the daemon's session state and its tmux window is killed; the removal is persistent (the daemon won't respawn it, and it doesn't return on restart). The deleted tab's name is printed as `{"name": "..."}`. The agent tab can't be deleted — use `af sessions kill` to tear down the whole session. Targeting a missing tab or session is an error. Not available for remote sessions (their tabs are fixed by `remote_hooks` config).
 - `tabs {create,delete}`: additive noun-subcommand aliases — `af sessions tabs create` == `af sessions tab-create` and `af sessions tabs delete` == `af sessions tab-delete` (same flags and output). The hyphen verbs are kept for existing scripts; nothing is renamed. There is no `tabs list` — list a session's tabs via `af sessions get`.
 - `archive`: tears down the session's tmux and **moves its git worktree** out to the global archive directory (`<AGENT_FACTORY_HOME>/archived/<repoID>/<title>/`), preserving the branch and any uncommitted changes. The session is not deleted — it becomes a quiescent **archived** row that survives restarts and is never auto-restored. Prints `{"ok": true, "title": "...", "archived_path": "..."}`. Not available for remote or in-place (`--here`) sessions (they don't own a relocatable worktree). Bring it back with `restore`.
-- `restore`: the counterpart of `archive` — moves the worktree back next to the repo, re-registers it, re-spawns **only the agent** (shell/process tabs are not restored), and marks the session running. Prints `{"ok": true, "title": "...", "worktree_path": "..."}`. Fails if the session isn't archived, or if its origin repo is gone (the archived worktree is left intact for manual recovery). Honors `--repo` like `kill`.
+- `restore`: restores an **archived**, **Lost**, or **Dead** session. Archived sessions move their worktree back next to the repo, re-register it, re-spawn **only the agent** (shell/process tabs are not restored), and mark the session running. Lost/Dead sessions recover in place, rebuilding a missing worktree when possible and resuming the recorded agent conversation when required. Prints `{"ok": true, "title": "...", "worktree_path": "..."}`. Fails if the session is not restorable, or if its origin repo is gone (an archived worktree is left intact for manual recovery). Honors `--repo` like `kill`.
 
 ## `af tasks`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,6 +56,9 @@ The TUI opens with an empty sidebar. From here:
    running.
 4. When you're done with a session, **`D`** kills it and removes its worktree
    and branch, or **`a`** archives it to set it aside and restore it later.
+   If a session is marked Lost or Dead after a crash, reboot, or missing
+   worktree, select it and press **`a`** or run `af sessions restore <title>` to
+   recover it and resume its recorded agent conversation when possible.
 
 Because each session is a real git branch, reviewing and merging an agent's work
 is just your normal git/PR flow.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -18,6 +18,7 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `POST` | `/v1/KillSession` | `title`, `repo_id` | Tear down a session: kill its tmux/agent and remove its worktree and record. |
 | `POST` | `/v1/ArchiveSession` | `title`, `repo_id` | Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record. |
 | `POST` | `/v1/RestoreArchived` | `title`, `repo_id` | Restore an archived session: move its worktree back next to the repo and re-spawn the agent. |
+| `POST` | `/v1/RestoreSession` | `title`, `repo_id` | Restore an archived, Lost, or Dead session. |
 | `POST` | `/v1/SendPrompt` | `title`, `repo_id`, `prompt` | Send a prompt to an existing session's agent. |
 | `POST` | `/v1/DeliverPrompt` | `title`, `repo_path`, `program`, `prompt`, `auto_yes` | Deliver a prompt to a session, auto-creating it if it does not exist yet. |
 | `POST` | `/v1/CreateTab` | `title`, `repo_id`, `command`, `name`, `shell` | Spawn a tab (process or shell) in a session's worktree. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,7 +36,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af sessions kill`](#af-sessions-kill) — Kill a session
 - [`af sessions list`](#af-sessions-list) — List sessions
 - [`af sessions preview`](#af-sessions-preview) — Preview a session's terminal content
-- [`af sessions restore`](#af-sessions-restore) — Restore an archived session (worktree back in place, agent re-spawned)
+- [`af sessions restore`](#af-sessions-restore) — Restore an archived, lost, or dead session
 - [`af sessions send-prompt`](#af-sessions-send-prompt) — Send a prompt to a session (or broadcast to all with --all)
 - [`af sessions tab-create`](#af-sessions-tab-create) — Spawn a process tab running a command in a session's worktree
 - [`af sessions tab-delete`](#af-sessions-tab-delete) — Delete a single tab from a session
@@ -532,7 +532,7 @@ af sessions
 - [`af sessions kill`](#af-sessions-kill) — Kill a session
 - [`af sessions list`](#af-sessions-list) — List sessions
 - [`af sessions preview`](#af-sessions-preview) — Preview a session's terminal content
-- [`af sessions restore`](#af-sessions-restore) — Restore an archived session (worktree back in place, agent re-spawned)
+- [`af sessions restore`](#af-sessions-restore) — Restore an archived, lost, or dead session
 - [`af sessions send-prompt`](#af-sessions-send-prompt) — Send a prompt to a session (or broadcast to all with --all)
 - [`af sessions tab-create`](#af-sessions-tab-create) — Spawn a process tab running a command in a session's worktree
 - [`af sessions tab-delete`](#af-sessions-tab-delete) — Delete a single tab from a session
@@ -683,15 +683,17 @@ af sessions preview <title>
 
 ## af sessions restore
 
-Restore an archived session (worktree back in place, agent re-spawned)
+Restore an archived, lost, or dead session
 
-Restore a previously archived session: move its git worktree back next to the
-repository, re-register it, re-spawn the agent, and mark it running. Only the
-agent session is brought back — shell/process tabs are not restored.
+Restore a session that is currently archived, lost, or dead.
 
-Fails if the session is not archived, or if its origin repository is gone (the
-archived worktree is left intact for manual recovery). The restored worktree
-path is printed on success.
+Archived sessions are moved back next to the repository, re-registered,
+re-spawned, and marked running. Lost/dead sessions are recovered in place,
+rebuilding a missing worktree when possible and resuming the recorded agent
+conversation when required.
+
+Fails if the session is not restorable, or if its origin repository is gone.
+The restored worktree path is printed on success.
 
 ```
 af sessions restore <title>

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -248,6 +248,11 @@ func (m *Menu) addInstanceOptions() {
 
 	// Instance management group
 	mgmtGroup := []keys.KeyName{keys.KeyNew, keys.KeyKill}
+	if m.instance != nil && (m.instance.GetLiveness() == session.LiveArchived ||
+		m.instance.GetLiveness() == session.LiveLost ||
+		m.instance.GetLiveness() == session.LiveDead) {
+		mgmtGroup = append(mgmtGroup, keys.KeyArchive)
+	}
 
 	// Action group: enter interacts in-pane, o attaches full-screen (#1089).
 	actionGroup := []keys.KeyName{keys.KeyEnter, keys.KeyAttach}

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -246,13 +246,9 @@ func (m *Menu) addInstanceOptions() {
 		return
 	}
 
-	// Instance management group
-	mgmtGroup := []keys.KeyName{keys.KeyNew, keys.KeyKill}
-	if m.instance != nil && (m.instance.GetLiveness() == session.LiveArchived ||
-		m.instance.GetLiveness() == session.LiveLost ||
-		m.instance.GetLiveness() == session.LiveDead) {
-		mgmtGroup = append(mgmtGroup, keys.KeyArchive)
-	}
+	// Instance management group. The `a` verb is archive for live rows and
+	// restore for Archived/Lost/Dead rows.
+	mgmtGroup := []keys.KeyName{keys.KeyNew, keys.KeyKill, keys.KeyArchive}
 
 	// Action group: enter interacts in-pane, o attaches full-screen (#1089).
 	actionGroup := []keys.KeyName{keys.KeyEnter, keys.KeyAttach}
@@ -360,8 +356,10 @@ var hintDropOrder = [][]keys.KeyName{
 	{keys.KeyHidePane},
 	{keys.KeyTab},
 	{keys.KeyEnter},
+	{keys.KeyAttach},
 	{keys.KeyKill},
 	{keys.KeyNew},
+	{keys.KeyArchive},
 }
 
 func (m *Menu) String() string {

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -71,24 +71,39 @@ func TestMenuAgentTabShowsBothScrollKeys(t *testing.T) {
 	}
 }
 
-func TestMenuRestorableRowsShowArchiveRestoreAction(t *testing.T) {
-	for _, status := range []session.Status{session.Lost, session.Dead, session.Archived} {
-		inst := &session.Instance{}
-		inst.SetStatus(status)
-		m := NewMenu()
-		m.SetInstance(inst)
+func TestMenuArchiveRestoreActionByRowState(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     session.Status
+		wantAction bool
+	}{
+		{name: "running archives", status: session.Running, wantAction: true},
+		{name: "ready archives", status: session.Ready, wantAction: true},
+		{name: "lost restores", status: session.Lost, wantAction: true},
+		{name: "dead restores", status: session.Dead, wantAction: true},
+		{name: "archived restores", status: session.Archived, wantAction: true},
+		{name: "creating omits archive restore", status: session.Loading, wantAction: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := &session.Instance{}
+			inst.SetStatus(tc.status)
+			m := NewMenu()
+			m.SetInstance(inst)
 
-		var found bool
-		for _, k := range m.options {
-			if k == keys.KeyArchive {
-				found = true
-				break
+			if got := menuHasOption(m, keys.KeyArchive); got != tc.wantAction {
+				t.Fatalf("KeyArchive present = %v, want %v", got, tc.wantAction)
 			}
-		}
-		if !found {
-			t.Fatalf("status %v: restore action not shown in menu options", status)
+		})
+	}
+}
+
+func menuHasOption(m *Menu, want keys.KeyName) bool {
+	for _, k := range m.options {
+		if k == want {
+			return true
 		}
 	}
+	return false
 }
 
 // TestMenuRemoteInstanceOmitsUnsupportedTabKeys guards against regressing #988:

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -71,6 +71,26 @@ func TestMenuAgentTabShowsBothScrollKeys(t *testing.T) {
 	}
 }
 
+func TestMenuRestorableRowsShowArchiveRestoreAction(t *testing.T) {
+	for _, status := range []session.Status{session.Lost, session.Dead, session.Archived} {
+		inst := &session.Instance{}
+		inst.SetStatus(status)
+		m := NewMenu()
+		m.SetInstance(inst)
+
+		var found bool
+		for _, k := range m.options {
+			if k == keys.KeyArchive {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("status %v: restore action not shown in menu options", status)
+		}
+	}
+}
+
 // TestMenuRemoteInstanceOmitsUnsupportedTabKeys guards against regressing #988:
 // remote instances block `t` (new tab) and `w` (close tab) — those handlers
 // reject IsRemote() with an error — so the footer menu must only surface the

--- a/ui/statusbar_test.go
+++ b/ui/statusbar_test.go
@@ -69,6 +69,9 @@ func TestMenuNarrowWidthKeepsHelpAndQuit(t *testing.T) {
 			"width %d: the prioritized row must fit the bar", w)
 		assert.Containsf(t, out, "q quit", "width %d: quit must survive", w)
 		assert.Containsf(t, out, "? help", "width %d: help must survive", w)
+		if w == 45 {
+			assert.Contains(t, out, "archive/restore", "the live-row archive hint should outrank attach at narrow widths")
+		}
 	}
 
 	// At a roomy width nothing is dropped: the scroll hints still render.


### PR DESCRIPTION
## Summary
- Add a generic daemon RestoreSession RPC that dispatches Archived rows to the existing archive restore path and Lost/Dead rows to Recover under the per-session op lock.
- Point `af sessions restore` at the generic restore path so the CLI can recover Lost/Dead sessions as well as archived sessions.
- Surface TUI restore for Lost/Dead rows through the existing `a` archive/restore action, with restore-in-flight guards and updated attach/enter messages.
- Built on #1349 after PR3 merged.

## Verification
- `gofmt -w .`
- `go build ./...`
- `make test-container`
- `golangci-lint run --fast`
- `scripts/lint-file-length.sh`
- `deadcode -test ./...`
- `git diff --check`

No TUI driver or playtest driver was run.

Closes #1300