### PR TITLE
refactor(app): route TUI optimistic kill/archive overlays through the chokepoint (#1195 Phase 2d)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -160,7 +160,7 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	killAction := func() tea.Msg {
 		for _, inst := range m.store.GetInstances() {
 			if inst.Title == selectedTitle {
-				inst.SetInFlightOp(session.OpKilling)
+				_ = inst.Transition(session.BeginKill())
 				return startKillMsg{title: selectedTitle}
 			}
 		}
@@ -259,7 +259,7 @@ func (m *home) handleInstanceKilled(msg instanceKilledMsg) (tea.Model, tea.Cmd) 
 			if inst.Title == msg.title && inst.GetInFlightOp() == session.OpKilling {
 				// Clear the optimistic kill op: the row reverts to its underlying
 				// daemon liveness so the user can retry the kill.
-				inst.SetInFlightOp(session.OpNone)
+				_ = inst.Transition(session.RevertKill())
 				break
 			}
 		}
@@ -335,7 +335,7 @@ func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 		// completion handler finalizes it — so the row can never strand (#1187).
 		for _, inst := range m.store.GetInstances() {
 			if inst.Title == title {
-				inst.SetInFlightOp(session.OpArchiving)
+				_ = inst.Transition(session.BeginArchive())
 				break
 			}
 		}
@@ -394,8 +394,13 @@ func (m *home) handleInstanceArchived(msg instanceArchivedMsg) (tea.Model, tea.C
 	}
 	for _, inst := range m.store.GetInstances() {
 		if inst.Title == msg.title {
-			// SetArchived flips the row inert (started=false, liveness=Archived,
-			// op cleared) — matching the daemon's committed state.
+			// SetArchived is an unconditional projection-mirror: it copies the
+			// daemon's already-committed Archived state (started=false,
+			// liveness=Archived, op cleared) onto the read-only row. It is NOT the
+			// fenced CommitArchive transition (that's the daemon's I2 enforcement
+			// point) — the TUI row may be in any state here (optimistic OpArchiving,
+			// or already Archived if the reconcile settled first), so it stays a
+			// direct unconditional mirror rather than a fenced edge (#1195 Phase 2d).
 			inst.SetArchived()
 			break
 		}

--- a/session/transition.go
+++ b/session/transition.go
@@ -17,9 +17,14 @@ import (
 // transition is caught by the edge table instead of silently corrupting state.
 //
 // The four ordering invariants it enforces (audit item #6):
-//   - I1 tombstone-before-kill: a kill may not begin unless the kill-intent
-//     tombstone is recorded — otherwise a crash mid-teardown reclassifies the
-//     session Lost and resurrects it.
+//   - I1 tombstone-before-teardown is NOT a (liveness,op) edge, so it is NOT
+//     enforced here: the tombstone (userKilled) is a daemon-side field the
+//     client optimistic kill overlay never has, and daemon-internal kills (reap,
+//     create-cleanup) legitimately carry no tombstone. The daemon KillSession
+//     enforces I1 by ordering (MarkUserKilled before Instance.Kill) while setting
+//     NO op — keeping the snapshot pure liveness for out-of-band kills. BeginKill
+//     is therefore an unconstrained optimistic overlay. I2–I4 below are genuine
+//     edges the table enforces.
 //   - I2 move-before-Archived: the inert Archived state is reachable ONLY out of
 //     the archive fence, which is only entered after the worktree move ran.
 //   - I3 move-before-respawn: a restore may begin only from Archived, and the
@@ -98,8 +103,12 @@ func ObserveLiveness(lv Liveness) TransitionEvent {
 	return TransitionEvent{kind: tkObserveLiveness, lv: lv}
 }
 
-// BeginKill overlays OpKilling for an optimistic kill. Requires the kill-intent
-// tombstone already recorded (I1).
+// BeginKill overlays OpKilling for an optimistic kill. It is always legal — a
+// kill is the terminal user intent and supersedes any in-flight op. I1
+// (tombstone-before-teardown) is NOT enforced here: the tombstone is a daemon-
+// side field the client optimistic overlay never has, and the daemon's
+// KillSession enforces I1 by ordering (MarkUserKilled before Instance.Kill)
+// while setting NO op (the snapshot stays pure liveness for out-of-band kills).
 func BeginKill() TransitionEvent { return TransitionEvent{kind: tkBeginKill} }
 
 // RevertKill clears an optimistic kill overlay (kill aborted / reverted).
@@ -109,7 +118,10 @@ func RevertKill() TransitionEvent { return TransitionEvent{kind: tkRevertKill} }
 func BeginArchive() TransitionEvent { return TransitionEvent{kind: tkBeginArchive} }
 
 // CommitArchive flips the session to the inert Archived state, started=false, on
-// a successful archive move (was SetArchived). Reachable only from the fence (I2).
+// a successful archive move (the daemon path). Reachable ONLY from the OpArchiving
+// fence (I2). The TUI's finalize is a separate unconditional projection-mirror
+// (SetArchived), not this fenced commit — it copies the daemon's already-committed
+// Archived state onto the read-only row, so it is not subject to I2.
 func CommitArchive() TransitionEvent { return TransitionEvent{kind: tkCommitArchive} }
 
 // AbortArchiveToLost rolls a failed archive move back to Lost so the restore
@@ -158,8 +170,6 @@ type edgeSpec struct {
 	// rejection — for the daemon-truth edge (ObserveLiveness is always allowed)
 	// and ConfirmLive (yields to an in-flight teardown rather than fighting it).
 	yieldWhenBlocked bool
-	// requiresTombstone gates BeginKill on a recorded kill intent (I1).
-	requiresTombstone bool
 }
 
 // transitionTable is the allowed-edge table — the single declarative source of
@@ -181,9 +191,10 @@ var transitionTable = map[transitionKind]edgeSpec{
 		target:      func(s stateAxes, ev TransitionEvent) stateAxes { return stateAxes{ev.lv, s.op} },
 	},
 	tkBeginKill: {
-		allowedFrom:       func(s stateAxes) bool { return s.op == OpNone },
-		target:            func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpKilling} },
-		requiresTombstone: true,
+		// Always legal: a kill supersedes any in-flight op (see BeginKill doc). I1
+		// is enforced by the daemon KillSession ordering, not this overlay.
+		allowedFrom: func(stateAxes) bool { return true },
+		target:      func(s stateAxes, _ TransitionEvent) stateAxes { return stateAxes{s.liveness, OpKilling} },
 	},
 	tkRevertKill: {
 		allowedFrom: func(s stateAxes) bool { return s.op == OpKilling },
@@ -261,9 +272,6 @@ func (i *Instance) Transition(ev TransitionEvent) error {
 			return nil
 		}
 		return i.rejectTransitionLocked(ev, from, "edge not allowed from this state")
-	}
-	if spec.requiresTombstone && !i.userKilled {
-		return i.rejectTransitionLocked(ev, from, "kill without a recorded tombstone (I1)")
 	}
 
 	to := spec.target(from, ev)

--- a/session/transition_test.go
+++ b/session/transition_test.go
@@ -61,7 +61,9 @@ func TestTransition_LegalEdgesApply(t *testing.T) {
 		// fence (a mid-archive row still receives the terminal liveness — #1187).
 		{"ObserveLiveness sets liveness, keeps op", stateAxes{LiveRunning, OpArchiving}, true, false, ObserveLiveness(LiveLost), LiveLost, OpArchiving, true},
 		{"ObserveLiveness on idle row", stateAxes{LiveRunning, OpNone}, true, false, ObserveLiveness(LiveReady), LiveReady, OpNone, true},
-		{"BeginKill with tombstone", stateAxes{LiveRunning, OpNone}, true, true, BeginKill(), LiveRunning, OpKilling, true},
+		{"BeginKill from idle", stateAxes{LiveRunning, OpNone}, true, false, BeginKill(), LiveRunning, OpKilling, true},
+		// BeginKill is always legal — a kill supersedes any in-flight op.
+		{"BeginKill supersedes archiving", stateAxes{LiveRunning, OpArchiving}, true, false, BeginKill(), LiveRunning, OpKilling, true},
 		{"RevertKill", stateAxes{LiveRunning, OpKilling}, true, false, RevertKill(), LiveRunning, OpNone, true},
 		{"BeginArchive from Ready", stateAxes{LiveReady, OpNone}, true, false, BeginArchive(), LiveReady, OpArchiving, true},
 		{"BeginArchive from Running", stateAxes{LiveRunning, OpNone}, true, false, BeginArchive(), LiveRunning, OpArchiving, true},
@@ -88,14 +90,10 @@ func TestTransition_LegalEdgesApply(t *testing.T) {
 	}
 }
 
-// TestTransition_I1_KillWithoutTombstonePanics: BeginKill without a recorded
-// kill-intent tombstone is rejected — a teardown of a wanted session that a
-// crash could reclassify Lost and resurrect (#1108).
-func TestTransition_I1_KillWithoutTombstonePanics(t *testing.T) {
-	i := &Instance{liveness: LiveRunning, inFlightOp: OpNone, userKilled: false}
-	assert.Panics(t, func() { _ = i.Transition(BeginKill()) })
-	assert.Equal(t, OpNone, i.inFlightOp, "a rejected transition must not mutate state")
-}
+// I1 (tombstone-before-teardown) is intentionally NOT a chokepoint edge —
+// BeginKill is an unconstrained optimistic overlay (see its doc and
+// TestTransition_LegalEdgesApply's "BeginKill supersedes archiving"). I1 is
+// enforced by the daemon KillSession ordering instead.
 
 // TestTransition_I2_CommitArchiveWithoutArchivingPanics: CommitArchive is
 // reachable only from the OpArchiving fence — flipping Archived without it would


### PR DESCRIPTION
**Phase 2d of #1195** — TUI optimistic-op writers onto the `Transition()` chokepoint. Follows merged 2d slices (#1320 restore, #1346 archive, #1350 create). Design: https://github.com/sachiniyer/agent-factory/issues/1195#issuecomment-4888497895

## What
- optimistic kill: `SetInFlightOp(OpKilling)` → **`Transition(BeginKill())`**
- kill revert (on failure): `SetInFlightOp(OpNone)` → **`Transition(RevertKill())`**
- optimistic archive: `SetInFlightOp(OpArchiving)` → **`Transition(BeginArchive())`**

## Edge-table change (root-approved)
**Dropped `requiresTombstone` from `BeginKill`.** I1 (tombstone-before-teardown) is not a `(liveness,op)` edge — the tombstone is a daemon-side field the client overlay never has, and daemon-internal kills (reap, create-cleanup) carry none. `KillSession` enforces I1 by **ordering** (`MarkUserKilled` before `Instance.Kill`) while setting **no op** (snapshot stays pure liveness for out-of-band kills — your confirmed decision). `BeginKill` is an unconstrained optimistic overlay (a kill supersedes any in-flight op). I2–I4 stay chokepoint-enforced.

## Deliberately NOT migrated (documented in place)
- **TUI restore overlay** (`OpRestoring`) stays direct — must keep `liveness=Archived` so the reconcile rebuilds the row (#1203/#1210); `BeginRestore` would flip it to Lost.
- **TUI archive finalize** (`SetArchived`) stays an unconditional **projection-mirror** of the daemon's already-committed Archived state — not the fenced `CommitArchive` (that's the daemon's I2 point). `handleInstanceArchived` may run from any row state (optimistic `OpArchiving`, or already-Archived if the reconcile settled first).

## Behavior-preserving
Same `(liveness,op,started)` as the direct setters; reverts are guarded. Validated with the **app-test panic hook** (from #1350) active — an illegal edge would panic the app tests; full suite green.

## Gates
`go build`, `gofmt`, `go vet`, `deadcode -test ./...` clean, `golangci-lint --fast`, file-length, **`make test-container`** (app + daemon + integration).

Refs #1195 (Phase 2e — retire the direct setters — remains).

— Captain Claude