### PR TITLE
fix(ui): sync cursor to archived selections

### DIFF
--- a/ui/sidebar.go
+++ b/ui/sidebar.go
@@ -348,7 +348,7 @@ func (s *Sidebar) moveCursorToInstance(target *session.Instance) {
 	}
 	instRow := -1
 	for j, item := range s.visibleItems {
-		if item.Kind != SectionInstances || item.IsHeader || item.ItemIndex != instIdx {
+		if !isInstanceRow(item) || item.ItemIndex != instIdx {
 			continue
 		}
 		if item.IsTab {

--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -143,6 +143,42 @@ func TestSidebar_ArchivedRowSelectableWhenExpanded(t *testing.T) {
 	assert.False(t, strings.Contains(view, "[archived]"), "archived rows must not carry the name-eating text prefix (#1225)")
 }
 
+func TestSidebar_MoveCursorToArchivedInstance(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+
+	liveInst := archTestInstance(t, "live-one", session.Ready)
+	archivedInst := archTestInstance(t, "put-away", session.Archived)
+	addTestInstance(s, liveInst)
+	addTestInstance(s, archivedInst)
+	s.SetSize(40, 40)
+
+	s.SetSelectedInstance(0)
+	require.Same(t, liveInst, s.GetSelectedInstance())
+
+	s.ClickHeaderKind(SectionArchived)
+	require.True(t, archivedRowVisible(s), "archived row must be visible after expanding Archived")
+
+	s.proj.SelectInstance(archivedInst)
+	s.syncFromStore()
+
+	sel := s.rawSelection()
+	assert.Equal(t, SectionArchived, sel.Kind, "cursor should move to the archived row")
+	assert.False(t, sel.IsHeader)
+	assert.Same(t, archivedInst, s.GetSelectedInstance())
+	assert.Same(t, archivedInst, s.proj.GetSelectedInstance(),
+		"sync must not reassert the previous live cursor row over the archived selection")
+}
+
+func archivedRowVisible(s *Sidebar) bool {
+	for _, it := range s.visibleItems {
+		if it.Kind == SectionArchived && !it.IsHeader && it.ItemIndex >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // TestSidebar_ArchivedZonesRegistered (#1028 mouse P2): the Archived folder
 // header gets its OWN zone id (distinct from the Instances header, so a click
 // toggles the right folder), and — once expanded — an archived row registers a


### PR DESCRIPTION
## Summary
- Verified on current `origin/master` (`3f07dd6`) after the #1321 preview slices, #1302 pane-selection reconcile, and #1350/#1353 lifecycle work: `moveCursorToInstance` still filtered only `SectionInstances`, so archived targets were skipped.
- Reuse the existing `isInstanceRow` helper in the cursor re-pin path so externally asserted archived selections land on the intended archived row.
- Add regression coverage that starts on a live row, expands Archived, asserts an archived selection through the projection, and verifies sync does not reassert the stale live cursor row.

## Gates
- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --fast`
- `scripts/lint-file-length.sh`
- `make test-container`

Closes #1336

Signed-off-by: Captain Claude <captain-claude@sachiniyer.com>