### PR TITLE
refactor: route liveness observations through the chokepoint (#1195 Phase 2d)

### DIFF
--- a/app/sync.go
+++ b/app/sync.go
@@ -564,7 +564,7 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 	// never carries, so this can never clobber an optimistic kill/archive marker.
 	lv := snapshotLiveness(inst.GetLiveness(), d)
 	if inst.GetLiveness() != lv {
-		inst.SetLiveness(lv)
+		_ = inst.Transition(session.ObserveLiveness(lv))
 		changed = true
 	}
 	// Mirror the usage-limit reset time (#1146) alongside the liveness. It's

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -1595,7 +1595,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 	}
 	switch {
 	case updated:
-		instance.SetLiveness(session.LiveRunning)
+		_ = instance.Transition(session.ObserveLiveness(session.LiveRunning))
 	case hasPrompt:
 		// A waiting prompt with otherwise-unchanged output: leave the status for
 		// the next tick to resolve, exactly as runMetadataTick did. The
@@ -1609,7 +1609,7 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// intent on record, so the session vanished out from under a live
 		// record — an outage/reboot casualty that is recovery-eligible, not a
 		// corpse the user wanted gone.
-		instance.SetLiveness(session.LiveLost)
+		_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
 	default:
 		// Idle output: settle to Ready, or LimitReached when the pane shows a
 		// usage-limit banner for a claude/codex session (#1146). content is

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -70,7 +70,7 @@ func (m *Manager) resolveIdleLiveness(instance *session.Instance, content string
 		// writes only the liveness axis and never clobbers an in-flight op, so it
 		// needs no "if not deleting" guard — this is exactly what the poll's Ready
 		// fallback does inline in refreshInstanceStatus.
-		instance.SetLiveness(session.LiveReady)
+		_ = instance.Transition(session.ObserveLiveness(session.LiveReady))
 	}
 }
 

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -69,7 +69,7 @@ func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID str
 	switch instance.GetLiveness() {
 	case session.LiveLost:
 	case session.LiveDead:
-		instance.SetLiveness(session.LiveLost)
+		_ = instance.Transition(session.ObserveLiveness(session.LiveLost))
 	default:
 		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
 	}

--- a/daemon/transition_hook_test.go
+++ b/daemon/transition_hook_test.go
@@ -1,0 +1,12 @@
+package daemon
+
+import "github.com/sachiniyer/agent-factory/session"
+
+// The daemon test binary panics on illegal lifecycle transitions (#1195 Phase
+// 2d): the daemon is the authoritative writer routing archive/restore/create/
+// liveness through the chokepoint, and a mis-ordered edge must be a loud red
+// failure in tests rather than a silently-ignored soft error. Production leaves
+// the hook nil (soft error only).
+func init() {
+	session.SetIllegalTransitionHook(func(msg string) { panic("daemon: illegal transition: " + msg) })
+}


### PR DESCRIPTION
**Phase 2d of #1195** — final writer migration onto `Transition()`. Follows merged 2d slices (#1320, #1346, #1350, #1353). Design: https://github.com/sachiniyer/agent-factory/issues/1195#issuecomment-4888497895

## What

The daemon poll + TUI reconcile + limit/restore liveness writes now route through `Instance.Transition` via the **`ObserveLiveness`** edge — the unconditional daemon-truth edge that sets liveness, **preserves any in-flight op**, and never rejects (what keeps the #1187 strand impossible).

- daemon poll (`control.go`): `SetLiveness(Running/Lost)` → `ObserveLiveness`
- daemon restore-eligibility normalize (`restore.go`): `Dead`→`Lost` via `ObserveLiveness`
- daemon limit idle-settle (`limit.go`): `SetLiveness(Ready)` → `ObserveLiveness`
- TUI reconcile (`sync.go`): `SetLiveness(lv)` → `ObserveLiveness` (still applied **unconditionally** — daemon liveness always wins)

## Daemon panic hook

Installs the **daemon** test binary's illegal-transition panic hook (`transition_hook_test.go`, mirroring app's from #1350), so every daemon `Transition` caller — archive (`BeginArchive`/`CommitArchive`/`AbortArchiveToLost`), restore (`BeginRestore`/`AbortRestoreToLost`), create (`ConfirmLive`), and now `ObserveLiveness` — is validated as a **legal edge** under `make test-container` instead of soft-erroring silently. **Full suite green with the hook active.**

## Behavior-preserving

`ObserveLiveness` is `SetLiveness`'s exact chokepoint form. `SetLiveness` stays (test callers) until **Phase 2e** retires the direct setters.

## Gates
`go build`, `gofmt`, `go vet`, `deadcode -test ./...` clean, `golangci-lint --fast`, file-length, **`make test-container`** (app + daemon + integration, daemon panic hook active).

Refs #1195 (**Phase 2e — retire the direct setters — is next, the finish line**).

— Captain Claude