### PR TITLE
fix(app): select new naming instance by pointer

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -193,7 +193,7 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	}
 	_ = instance.Transition(session.BeginCreate())
 	m.store.AddInstance(instance)
-	m.sidebar.SetSelectedInstance(m.store.NumInstances() - 1)
+	m.sidebar.SelectInstance(instance)
 	m.namingInstance = instance
 	m.state = stateNew
 	m.menu.SetState(ui.StateNewInstance)

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -134,6 +135,35 @@ func TestHandleMenuHighlightingNewInstanceEnterTab(t *testing.T) {
 				"menu highlight render path should run for %s during stateNew", tc.name)
 		})
 	}
+}
+
+func TestStartNewInstanceSelectsNamingInstanceAfterSortedInsert(t *testing.T) {
+	h := newTestHome(t)
+
+	existing, err := session.NewInstance(session.InstanceOptions{
+		Title:   "existing",
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	require.NoError(t, err)
+	existing.CreatedAt = time.Now().Add(time.Hour)
+	h.store.AddInstance(existing)
+	h.sidebar.SetSelectedInstance(0)
+
+	model, cmd := h.startNewInstance(false)
+	require.Same(t, h, model)
+	require.Nil(t, cmd)
+	require.NotNil(t, h.namingInstance)
+
+	require.Equal(t, []string{"", "existing"}, collectTitles(h.store.GetInstances()),
+		"precondition: sorted insert placed the naming placeholder before the existing row")
+	assert.Same(t, h.namingInstance, h.sidebar.GetSelectedInstance(),
+		"sidebar highlight must track the naming placeholder after AddInstance sorts")
+	assert.Same(t, h.namingInstance, h.store.GetSelectedInstance(),
+		"store selection must agree with the highlighted naming placeholder")
+	assert.Equal(t, stateNew, h.state)
+	assert.Equal(t, session.OpCreating, h.namingInstance.GetInFlightOp(),
+		"the #1350 BeginCreate chokepoint still fires exactly once when naming starts")
 }
 
 // TestCancelNamingRemovesZombieAfterSelectionDrift is the regression guard for


### PR DESCRIPTION
## Summary
- Verified on current `origin/master` (`3f07dd6`) after the #1321 preview slices, #1302 pane-selection reconcile, and #1350/#1353 create-flow work: `startNewInstance` still selected `NumInstances()-1` after `AddInstance` sorted the projection.
- Select the newly added naming placeholder by pointer so the sidebar highlight and store selection track the real instance being named, regardless of sorted position.
- Add a regression that drives the real start-naming path with a sorted insert where the new placeholder is not the final row, while preserving the #1350 single `BeginCreate` behavior.

## Gates
- `gofmt -l .`
- `go build ./...`
- `golangci-lint run --fast`
- `scripts/lint-file-length.sh`
- `make test-container`

Closes #1332

Signed-off-by: Captain Claude <captain-claude@sachiniyer.com>