### PR TITLE
refactor(session): retire the SetLiveness direct setter (#1195 Phase 2e)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -844,7 +844,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.store.AddInstance(started)
 		}
 
-		started.SetStatus(session.Running)
+		_ = started.Transition(session.ConfirmLive())
 		if !swapped && !started.IsRemote() {
 			m.store.RegisterRepoForInstance(started)
 		}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -503,7 +503,7 @@ func (m *home) handleInstanceRestored(msg instanceRestoredMsg) (tea.Model, tea.C
 		case inst.Title != msg.title:
 			continue
 		case inst.GetLiveness() == session.LiveLost || inst.GetLiveness() == session.LiveDead:
-			inst.MarkLive()
+			_ = inst.Transition(session.ConfirmLive())
 		}
 		break
 	}

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -478,12 +478,12 @@ func TestPanePreviewEnterBlocksUncommittableTargets(t *testing.T) {
 	}{
 		{
 			name:      "dead",
-			configure: func(inst *session.Instance) { inst.SetLiveness(session.LiveDead) },
+			configure: func(inst *session.Instance) { _ = inst.Transition(session.ObserveLiveness(session.LiveDead)) },
 			wantErr:   "no longer running",
 		},
 		{
 			name:      "lost",
-			configure: func(inst *session.Instance) { inst.SetLiveness(session.LiveLost) },
+			configure: func(inst *session.Instance) { _ = inst.Transition(session.ObserveLiveness(session.LiveLost)) },
 			wantErr:   "was lost",
 		},
 		{
@@ -521,12 +521,12 @@ func TestPanePreviewSplitBlocksUncommittableTargets(t *testing.T) {
 	}{
 		{
 			name:      "dead",
-			configure: func(inst *session.Instance) { inst.SetLiveness(session.LiveDead) },
+			configure: func(inst *session.Instance) { _ = inst.Transition(session.ObserveLiveness(session.LiveDead)) },
 			wantErr:   "no longer running",
 		},
 		{
 			name:      "lost",
-			configure: func(inst *session.Instance) { inst.SetLiveness(session.LiveLost) },
+			configure: func(inst *session.Instance) { _ = inst.Transition(session.ObserveLiveness(session.LiveLost)) },
 			wantErr:   "was lost",
 		},
 		{

--- a/daemon/limitresume_test.go
+++ b/daemon/limitresume_test.go
@@ -154,7 +154,7 @@ func TestResumeLimitedSessions_ArchivedClearsTimer(t *testing.T) {
 	}
 
 	// The session is archived out from under the scheduler.
-	inst.SetLiveness(session.LiveArchived)
+	_ = inst.Transition(session.ObserveLiveness(session.LiveArchived))
 	advance(2 * time.Hour)
 	manager.ResumeLimitedSessions()
 

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -124,7 +124,7 @@ func TestRestoreSession_RecoversDeadInstanceOnDemand(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
 	inst := registerStarted(t, manager, repoID, repoPath, "dead", backend, true, session.Ready)
-	inst.SetLiveness(session.LiveDead)
+	_ = inst.Transition(session.ObserveLiveness(session.LiveDead))
 
 	_, err := manager.RestoreSession(RestoreSessionRequest{Title: "dead", RepoID: repoID})
 	if err != nil {

--- a/session/instance_test.go
+++ b/session/instance_test.go
@@ -117,28 +117,29 @@ func TestGetGitWorktree_RaceWithStart(t *testing.T) {
 	wg.Wait()
 }
 
-// TestSetLivenessNeverClobbersInFlightOp is the #1195 structural replacement for
-// the old #844 fence (SetStatusIfNotDeleting): the daemon poll writes only the
-// liveness axis, so a concurrent kill/archive op — living on the separate op axis
-// — can never be clobbered. The composed status keeps reflecting the op, which is
-// what the SetStatusIfNotDeleting guard used to reconstruct by hand.
-func TestSetLivenessNeverClobbersInFlightOp(t *testing.T) {
+// TestObserveLivenessNeverClobbersInFlightOp is the #1195 structural replacement
+// for the old #844 fence (SetStatusIfNotDeleting): the daemon poll writes only
+// the liveness axis (via the ObserveLiveness chokepoint edge), so a concurrent
+// kill/archive op — living on the separate op axis — can never be clobbered. The
+// composed status keeps reflecting the op, which is what SetStatusIfNotDeleting
+// used to reconstruct by hand.
+func TestObserveLivenessNeverClobbersInFlightOp(t *testing.T) {
 	i := &Instance{liveness: LiveReady}
 
 	// A kill is optimistically in flight (op axis), underlying liveness Running.
-	i.SetLiveness(LiveRunning)
-	i.SetInFlightOp(OpKilling)
+	require.NoError(t, i.Transition(ObserveLiveness(LiveRunning)))
+	require.NoError(t, i.Transition(BeginKill()))
 	require.Equal(t, Deleting, i.GetStatus())
 
 	// The poll writes liveness (Running/Ready/Lost) — the kill op survives every
 	// write, so the composed status stays Deleting.
-	i.SetLiveness(LiveReady)
-	require.Equal(t, OpKilling, i.GetInFlightOp(), "SetLiveness must not touch the op axis")
+	require.NoError(t, i.Transition(ObserveLiveness(LiveReady)))
+	require.Equal(t, OpKilling, i.GetInFlightOp(), "ObserveLiveness must not touch the op axis")
 	require.Equal(t, Deleting, i.GetStatus(), "a poll write must never clobber a kill marker")
-	i.SetLiveness(LiveLost)
+	require.NoError(t, i.Transition(ObserveLiveness(LiveLost)))
 	require.Equal(t, Deleting, i.GetStatus())
 
 	// The kill handler clears the op; the composed status then reflects liveness.
-	i.SetInFlightOp(OpNone)
+	require.NoError(t, i.Transition(RevertKill()))
 	require.Equal(t, Lost, i.GetStatus())
 }

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -194,17 +194,10 @@ func (i *Instance) GetLiveness() Liveness {
 	return i.liveness
 }
 
-// SetLiveness writes the health axis under the instance mutex, leaving the
-// in-flight op untouched. This is what the daemon poll uses instead of the old
-// SetStatusIfNotDeleting: writing liveness can never clobber an in-flight op
-// because the op is a separate field, so no "if not deleting" guard is needed —
-// a concurrent kill/archive op survives the write and still composes to the
-// transient status (#1195).
-func (i *Instance) SetLiveness(lv Liveness) {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	i.liveness = lv
-}
+// SetLiveness is retired (#1195 Phase 2e): the liveness axis is now written only
+// through the Transition chokepoint's ObserveLiveness edge (the daemon-truth
+// edge — sets liveness, preserves the in-flight op, never rejects), so there is
+// no direct liveness setter left to bypass it.
 
 // GetInFlightOp returns the client/executor op axis under the instance mutex.
 func (i *Instance) GetInFlightOp() InFlightOp {

--- a/ui/overlay/zones_test.go
+++ b/ui/overlay/zones_test.go
@@ -145,7 +145,7 @@ func TestSearchOverlayRegistersRowZonesAndSetSelectedIndex(t *testing.T) {
 
 func TestSearchOverlayRegistersLimitReachedRowZone(t *testing.T) {
 	inst := &session.Instance{Title: "blocked-session"}
-	inst.SetLiveness(session.LiveLimitReached)
+	_ = inst.Transition(session.ObserveLiveness(session.LiveLimitReached))
 	s := NewSearchOverlay([]*session.Instance{inst})
 	reg := zones.NewRegistry()
 

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -236,7 +236,7 @@ func TestInstanceRendererLimitReachedMarker(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	inst.SetLiveness(session.LiveLimitReached)
+	_ = inst.Transition(session.ObserveLiveness(session.LiveLimitReached))
 	out, _, _ := renderForTerminal(t, 120, inst, &spin)
 	assert.Contains(t, out, "[limit]", "a usage-limit-reached row must be explicitly marked (#1146)")
 	assert.Contains(t, out, "throttled", "the title must remain visible")


### PR DESCRIPTION
**Phase 2e of #1195 — the finish line begins.** Retire the direct state setters so `Instance.Transition` is the **sole path** for lifecycle state changes. Follows the merged 2d chain (#1320/#1346/#1350/#1353/#1355).

## What

- **Migrated the last two prod lifecycle callers** to the chokepoint:
  - app `instanceStarted` (`app.go`): `SetStatus(Running)` → `Transition(ConfirmLive())`
  - app restore-complete (`handle_actions.go`): `MarkLive()` → `Transition(ConfirmLive())`
  - `ConfirmLive` is the exact chokepoint form (Running + clear the completing create/restore op) and additionally **yields to an in-flight kill/archive teardown** — a strict improvement, identical in the normal (`OpCreating`) path.
- **DELETED `Instance.SetLiveness`.** After #1355 routed every prod liveness write through `ObserveLiveness`, it had **zero prod callers**. Migrated its 11 test callers to `Transition(ObserveLiveness(...))` and repurposed the `SetLiveness`-specific test as `TestObserveLivenessNeverClobbersInFlightOp` (same two-axis-independence assertion, now exercising the chokepoint edge + `BeginKill`/`RevertKill`).

**The liveness axis can no longer be written by any direct setter — only through the `ObserveLiveness` edge.** Subsequent 2e slices retire `SetInFlightOp` / `SetStatus` / `MarkLive` the same way, then Phase 2 is complete.

## Gates
`go build`, `gofmt`, `go vet`, **`deadcode -test ./...` clean** (`SetLiveness` gone), `golangci-lint --fast`, file-length, **`make test-container`** (full suite, daemon+app panic hooks active).

Refs #1195.

— Captain Claude