### PR TITLE
refactor(session): retire the MarkLive direct setter — Phase 2 lifecycle setters gone (#1195)

### DIFF
--- a/app/archive_action_test.go
+++ b/app/archive_action_test.go
@@ -17,7 +17,7 @@ func archiveActionInstance(t *testing.T, title string, status session.Status) *s
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
 	inst.SetStartedForTest(true)
-	inst.SetStatus(status)
+	inst.SetStatusForTest(status)
 	return inst
 }
 

--- a/app/archive_panes_test.go
+++ b/app/archive_panes_test.go
@@ -16,7 +16,7 @@ import (
 func TestArchive_ClosesOpenPanesViaFinalize(t *testing.T) {
 	h := newTestHome(t)
 	inst := startedLocalInstance(t, "worker")
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
@@ -38,7 +38,7 @@ func TestArchive_ClosesOpenPanesViaFinalize(t *testing.T) {
 func TestArchive_ReconcileClosesOpenPanes(t *testing.T) {
 	h := newTestHome(t)
 	inst := startedLocalInstance(t, "worker")
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
@@ -63,7 +63,7 @@ func TestArchive_ReconcileClosesOpenPanes(t *testing.T) {
 func TestRestore_LeavesNoStalePaneBinding(t *testing.T) {
 	h := newTestHome(t)
 	inst := startedLocalInstance(t, "worker")
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
@@ -83,7 +83,7 @@ func TestRestore_LeavesNoStalePaneBinding(t *testing.T) {
 		require.NoError(t, err)
 		ri.SetBackend(session.NewFakeBackend())
 		ri.SetStartedForTest(true)
-		ri.SetStatus(session.Running)
+		ri.SetStatusForTest(session.Running)
 		ri.ID = d.ID
 		return ri, nil
 	})

--- a/app/archive_reconcile_test.go
+++ b/app/archive_reconcile_test.go
@@ -17,7 +17,7 @@ func storeArchivingInstance(t *testing.T, h *home, title string) *session.Instan
 	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "test"})
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	inst.SetInFlightOpForTest(session.OpArchiving)
 	h.store.AddInstance(inst)
 	return inst
@@ -74,7 +74,7 @@ func TestReconcile_OptimisticKillPreservedForNonTerminal(t *testing.T) {
 			inst, err := session.NewInstance(session.InstanceOptions{Title: "worker", Path: t.TempDir(), Program: "test"})
 			require.NoError(t, err)
 			inst.SetBackend(session.NewFakeBackend())
-			inst.SetStatus(session.Running)
+			inst.SetStatusForTest(session.Running)
 			inst.SetInFlightOpForTest(session.OpKilling)
 			h.store.AddInstance(inst)
 
@@ -114,7 +114,7 @@ func TestReconcile_ArchivedToLiveRebuildsStarted(t *testing.T) {
 		require.NoError(t, err)
 		ri.SetBackend(session.NewFakeBackend())
 		ri.SetStartedForTest(true)
-		ri.SetStatus(session.Running)
+		ri.SetStatusForTest(session.Running)
 		ri.ID = d.ID
 		return ri, nil
 	})
@@ -141,7 +141,7 @@ func TestReconcile_ArchivedToLiveRebuildsStarted(t *testing.T) {
 func TestReconcile_LostToLiveStaysInPlace(t *testing.T) {
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "worker") // started=true
-	inst.SetStatus(session.Lost)
+	inst.SetStatusForTest(session.Lost)
 	h.store.AddInstance(inst)
 
 	restore := SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
@@ -191,7 +191,7 @@ func TestHandleInstanceArchived_FinalizesRowImmediately(t *testing.T) {
 	inst, err := session.NewInstance(session.InstanceOptions{Title: "worker", Path: t.TempDir(), Program: "test"})
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	inst.SetInFlightOpForTest(session.OpArchiving) // as left by the optimistic archive action
 	h.store.AddInstance(inst)
 
@@ -234,7 +234,7 @@ func TestRestore_EagerRehomeDoesNotBypassRebuild(t *testing.T) {
 		require.NoError(t, err)
 		ri.SetBackend(session.NewFakeBackend())
 		ri.SetStartedForTest(true)
-		ri.SetStatus(session.Running)
+		ri.SetStatusForTest(session.Running)
 		ri.ID = d.ID
 		return ri, nil
 	})

--- a/app/cli_daemon_integration_test.go
+++ b/app/cli_daemon_integration_test.go
@@ -257,7 +257,7 @@ func TestTUIRefreshDoesNotSwapLoadingPlaceholder(t *testing.T) {
 		Program: tmux.ProgramClaude,
 	})
 	require.NoError(t, err)
-	placeholder.SetStatus(session.Loading)
+	placeholder.SetStatusForTest(session.Loading)
 	h.store.AddInstance(placeholder)
 
 	// The daemon persists the session record mid-create — emulated by a CLI

--- a/app/cold_start_test.go
+++ b/app/cold_start_test.go
@@ -168,7 +168,7 @@ func TestColdStartFromSnapshot_AutoOpenWaitsOutTransientStatus(t *testing.T) {
 	h.initialPaneOpened = false
 	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
 		inst := newSnapshotTestInstance(t, d.Title)
-		inst.SetStatus(session.Loading)
+		inst.SetStatusForTest(session.Loading)
 		return inst, nil
 	}))
 	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
@@ -181,7 +181,7 @@ func TestColdStartFromSnapshot_AutoOpenWaitsOutTransientStatus(t *testing.T) {
 	require.False(t, h.initialPaneOpened, "the latch must stay unset so the auto-open can re-fire")
 
 	// The instance finishes restoring; the next tick's selectionChanged opens it.
-	h.store.GetInstances()[0].SetStatus(session.Running)
+	h.store.GetInstances()[0].SetStatusForTest(session.Running)
 	_ = h.selectionChanged()
 	require.Equal(t, 1, h.store.NumOpenPanes(), "the pane must auto-open once the instance leaves Loading")
 	require.Equal(t, "restoring", h.store.OpenPanes()[0].Instance().Title)

--- a/app/creation_test.go
+++ b/app/creation_test.go
@@ -179,7 +179,7 @@ func newLoadingInstance(t *testing.T, title string) *session.Instance {
 		Program: "claude",
 	})
 	require.NoError(t, err)
-	inst.SetStatus(session.Loading)
+	inst.SetStatusForTest(session.Loading)
 	return inst
 }
 
@@ -215,7 +215,7 @@ func TestInstanceStarted_Success_UserMovedToAnotherInstance(t *testing.T) {
 	h := newTestHome(t)
 	creating := newLoadingInstance(t, "still-creating")
 	other := newLoadingInstance(t, "other")
-	other.SetStatus(session.Running)
+	other.SetStatusForTest(session.Running)
 	h.store.AddInstance(creating)
 	h.store.AddInstance(other)
 	// User navigated to `other` while `creating` was still starting.
@@ -261,7 +261,7 @@ func TestInstanceStarted_Failure_RemovesByTitleNotBySelection(t *testing.T) {
 	h := newTestHome(t)
 	failing := newLoadingInstance(t, "failing")
 	innocent := newLoadingInstance(t, "innocent")
-	innocent.SetStatus(session.Running)
+	innocent.SetStatusForTest(session.Running)
 	h.store.AddInstance(failing)
 	h.store.AddInstance(innocent)
 	// User moved to `innocent` while `failing` was still starting.
@@ -341,7 +341,7 @@ func TestInstanceStartedRegistersRepoAfterStart(t *testing.T) {
 		Program: "claude",
 	})
 	require.NoError(t, err)
-	inst.SetStatus(session.Loading)
+	inst.SetStatusForTest(session.Loading)
 	inst.SetStartedForTest(true)
 	inst.SetGitWorktreeForTest(gw)
 
@@ -419,7 +419,7 @@ func TestInstanceStarted_ReplacesSwappedSameTitleRow(t *testing.T) {
 	placeholder := newLoadingInstance(t, "scripts")
 	diskCopy := newLoadingInstance(t, "scripts")
 	diskCopy.SetStartedForTest(true)
-	diskCopy.SetStatus(session.Running)
+	diskCopy.SetStatusForTest(session.Running)
 	h.store.AddInstance(diskCopy)
 
 	started := newLoadingInstance(t, "scripts")

--- a/app/dead_session_test.go
+++ b/app/dead_session_test.go
@@ -27,7 +27,7 @@ func newDeadInstance(t *testing.T, title string, status session.Status) *session
 	require.NoError(t, err)
 	inst.SetBackend(&deadBackend{FakeBackend: session.NewFakeBackend()})
 	inst.SetStartedForTest(true)
-	inst.SetStatus(status)
+	inst.SetStatusForTest(status)
 	return inst
 }
 

--- a/app/e2e_test.go
+++ b/app/e2e_test.go
@@ -135,7 +135,7 @@ func (eh *e2eHarness) addStartedInstance(title string) *session.Instance {
 		eh.t.Fatal(err)
 	}
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	eh.home.store.AddInstance(inst)
 	return inst
 }

--- a/app/handle_actions_test.go
+++ b/app/handle_actions_test.go
@@ -58,10 +58,10 @@ func TestHandleEnterAttachesCapturedInstanceAfterSelectionDrift(t *testing.T) {
 
 	a, err := session.NewInstance(session.InstanceOptions{Title: "instance-a", Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
-	a.SetStatus(session.Running)
+	a.SetStatusForTest(session.Running)
 	b, err := session.NewInstance(session.InstanceOptions{Title: "instance-b", Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
-	b.SetStatus(session.Running)
+	b.SetStatusForTest(session.Running)
 
 	h.store.AddInstance(a)
 	h.store.AddInstance(b)
@@ -140,7 +140,7 @@ func TestOpenCopyPRNoPRSurfacesMessage(t *testing.T) {
 
 	inst, err := session.NewInstance(session.InstanceOptions{Title: "no-pr", Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 	require.Nil(t, inst.GetPRInfo(), "precondition: session has no PR")
@@ -217,7 +217,7 @@ func TestHandleCopyPRFailureShowsReasonAndURL(t *testing.T) {
 
 	inst, err := session.NewInstance(session.InstanceOptions{Title: "has-pr", Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	inst.SetPRInfo(&sessiongit.PRInfo{Number: 1284, Title: "clipboard", URL: url, State: "OPEN"})
 	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)

--- a/app/handle_enter_remote_terminal_test.go
+++ b/app/handle_enter_remote_terminal_test.go
@@ -56,7 +56,7 @@ func driveHandleEnterAttach(t *testing.T, terminalTab, remote bool) (tea.Cmd, st
 	inst := instanceWithFakeBackend(t, "inst")
 	if remote {
 		inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
-		inst.SetStatus(session.Running)
+		inst.SetStatusForTest(session.Running)
 	}
 	require.Equal(t, remote, inst.IsRemote(),
 		"precondition: instance remote-ness must match the case under test")

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -192,7 +192,7 @@ func TestCancelNamingRemovesZombieAfterSelectionDrift(t *testing.T) {
 			// sync removes it. It is not Loading, so sync is allowed to remove
 			// it (Loading rows are protected as in-flight creations).
 			preceding := newLoadingInstance(t, "preceding")
-			preceding.SetStatus(session.Running)
+			preceding.SetStatusForTest(session.Running)
 			h.store.AddInstance(preceding)
 
 			// The naming instance: Loading, empty title — exactly what
@@ -203,7 +203,7 @@ func TestCancelNamingRemovesZombieAfterSelectionDrift(t *testing.T) {
 				Program: "claude",
 			})
 			require.NoError(t, err)
-			naming.SetStatus(session.Loading)
+			naming.SetStatusForTest(session.Loading)
 			h.store.AddInstance(naming)
 			h.sidebar.SetSelectedInstance(h.store.NumInstances() - 1)
 			h.namingInstance = naming
@@ -211,7 +211,7 @@ func TestCancelNamingRemovesZombieAfterSelectionDrift(t *testing.T) {
 			// A trailing instance gives the drift somewhere to land now that
 			// the rail has no trailing Tasks/Hooks headers (#1024 PR 4).
 			trailing := newLoadingInstance(t, "trailing")
-			trailing.SetStatus(session.Running)
+			trailing.SetStatusForTest(session.Running)
 			h.store.AddInstance(trailing)
 
 			// A background mutation removes `preceding` (a daemon-owned row the

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -304,7 +304,7 @@ func TestEnterOnRemotePaneFallsBackToFullScreenAttach(t *testing.T) {
 		helpTypeInteractive{}.mask()|helpTypeInstanceAttach{}.mask()))
 	inst := instanceWithFakeBackend(t, "remote-inst")
 	inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	require.True(t, inst.IsRemote())
 	selectInstance(h, inst)
 	resizeHome(h, 120, 40)

--- a/app/keymap_dispatch_test.go
+++ b/app/keymap_dispatch_test.go
@@ -103,7 +103,7 @@ func TestErgonomicDefaultKeysDispatchThroughKeymap(t *testing.T) {
 		h.errBox.SetSize(200, 1)
 		inst, err := session.NewInstance(session.InstanceOptions{Title: "no-pr", Path: t.TempDir(), Program: "claude"})
 		require.NoError(t, err)
-		inst.SetStatus(session.Running)
+		inst.SetStatusForTest(session.Running)
 		selectInstance(h, inst)
 
 		_ = dispatchKey(h, runeKey('y'))
@@ -113,7 +113,7 @@ func TestErgonomicDefaultKeysDispatchThroughKeymap(t *testing.T) {
 		h.errBox.SetSize(200, 1)
 		inst, err = session.NewInstance(session.InstanceOptions{Title: "no-pr", Path: t.TempDir(), Program: "claude"})
 		require.NoError(t, err)
-		inst.SetStatus(session.Running)
+		inst.SetStatusForTest(session.Running)
 		selectInstance(h, inst)
 		_ = dispatchKey(h, runeKey('P'))
 		assert.NotContains(t, h.errBox.String(), "no PR for this session yet", "old copy key must be unbound by default")

--- a/app/kill_async_test.go
+++ b/app/kill_async_test.go
@@ -40,7 +40,7 @@ func newKillableInstance(t *testing.T, title string) *session.Instance {
 	defer restore()
 	inst, err := session.NewInstance(session.InstanceOptions{Title: title, Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
-	inst.SetStatus(session.Ready)
+	inst.SetStatusForTest(session.Ready)
 	return inst
 }
 
@@ -180,7 +180,7 @@ func TestHandleKill_DeletingInstanceIsNoOp(t *testing.T) {
 	h := newTestHome(t)
 	h.errBox.SetSize(500, 1)
 	inst := newKillableInstance(t, "going-away")
-	inst.SetStatus(session.Deleting)
+	inst.SetStatusForTest(session.Deleting)
 	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 
@@ -197,7 +197,7 @@ func TestHandleEnter_DeletingInstanceIsNoOp(t *testing.T) {
 	h := newTestHome(t)
 	h.errBox.SetSize(500, 1)
 	inst := newKillableInstance(t, "going-away")
-	inst.SetStatus(session.Deleting)
+	inst.SetStatusForTest(session.Deleting)
 	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 

--- a/app/limit_action_test.go
+++ b/app/limit_action_test.go
@@ -30,7 +30,7 @@ func TestHandleLimitRetry_NonLimitRow_NoDispatch(t *testing.T) {
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Ready)
+	inst.SetStatusForTest(session.Ready)
 	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)
 

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -852,7 +852,7 @@ func TestPane_CloseTabRebindsPanes(t *testing.T) {
 func TestPane_SnapshotTabRemovalRebindsPanes(t *testing.T) {
 	h := newTestHome(t)
 	inst := startedLocalInstance(t, "snaprebind")
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 
@@ -889,7 +889,7 @@ func TestPane_SnapshotTabRemovalRebindsPanes(t *testing.T) {
 func TestPane_SnapshotTabRemovalKeepsUnaffectedPaneBinding(t *testing.T) {
 	h := newTestHome(t)
 	inst := startedLocalInstance(t, "snapkeep")
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	selectInstance(h, inst)
 	resizeHome(h, 200, 40)
 

--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -50,7 +50,7 @@ func newStartedInstance(t *testing.T, title string) *session.Instance {
 	})
 	require.NoError(t, err)
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	return inst
 }
 

--- a/app/snapshot_test.go
+++ b/app/snapshot_test.go
@@ -24,7 +24,7 @@ func newSnapshotTestInstance(t *testing.T, title string) *session.Instance {
 		Program: "claude",
 	})
 	require.NoError(t, err)
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	return inst
 }
 

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -87,7 +87,7 @@ func instanceWithFakeBackend(t *testing.T, title string) *session.Instance {
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	return inst
 }
 
@@ -164,7 +164,7 @@ func TestReconcileSnapshot_IdentityUsesStableID(t *testing.T) {
 		require.NoError(t, err)
 		inst.SetBackend(session.NewFakeBackend())
 		inst.SetStartedForTest(true)
-		inst.SetStatus(session.Running)
+		inst.SetStatusForTest(session.Running)
 		inst.ID = id
 		inst.CreatedAt = created
 		h.store.AddInstance(inst)

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -39,7 +39,7 @@ func registerArchivable(t *testing.T, m *Manager, repoID, repoPath, title string
 	inst.SetBackend(session.NewFakeBackend())
 	inst.SetGitWorktreeForTest(gw)
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Ready)
+	inst.SetStatusForTest(session.Ready)
 
 	seedDiskInstance(t, repoID, title, repoPath)
 	m.mu.Lock()
@@ -127,7 +127,7 @@ func TestArchiveSession_RejectsReservedRoot(t *testing.T) {
 func TestArchiveSession_RejectsAlreadyArchived(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
-	inst.SetStatus(session.Archived)
+	inst.SetStatusForTest(session.Archived)
 
 	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.Error(t, err)
@@ -167,7 +167,7 @@ func TestArchiveSession_RejectsExternalWorktree(t *testing.T) {
 	inst.SetBackend(session.NewFakeBackend())
 	inst.SetGitWorktreeForTest(gw)
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Ready)
+	inst.SetStatusForTest(session.Ready)
 	seedDiskInstance(t, repoID, "inplace", repoPath)
 	manager.mu.Lock()
 	manager.instances[daemonInstanceKey(repoID, "inplace")] = inst
@@ -295,7 +295,7 @@ func TestArchiveSession_RejectsRemote(t *testing.T) {
 	require.NoError(t, err)
 	inst.SetBackend(fakeRemoteBackend{session.NewFakeBackend()})
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Ready)
+	inst.SetStatusForTest(session.Ready)
 	seedDiskInstance(t, repoID, "faraway", repoPath)
 	manager.mu.Lock()
 	manager.instances[daemonInstanceKey(repoID, "faraway")] = inst

--- a/daemon/conversation_capture_test.go
+++ b/daemon/conversation_capture_test.go
@@ -37,7 +37,7 @@ func TestCaptureAgentConversationPersistsCodexRolloutID(t *testing.T) {
 	})
 	require.NoError(t, err)
 	inst.SetTmuxSession(tmux.NewTmuxSession("codex-worker", tmux.ProgramCodex))
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	key := daemonInstanceKey(repo.ID, inst.Title)
 	manager.mu.Lock()
 	manager.instances[key] = inst

--- a/daemon/create_tab_archive_test.go
+++ b/daemon/create_tab_archive_test.go
@@ -82,7 +82,7 @@ func registerArchivableWithTmux(t *testing.T, m *Manager, repoID, repoPath, titl
 	inst.SetGitWorktreeForTest(gw)
 	inst.SetTmuxSession(tmux.NewTmuxSessionFromSanitizedNameWithDeps(agentName, "claude", pty, e))
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Ready)
+	inst.SetStatusForTest(session.Ready)
 
 	seedDiskInstance(t, repoID, title, repoPath)
 	m.mu.Lock()
@@ -147,7 +147,7 @@ func TestCreateTab_SerializedWithInFlightArchiveDoesNotOrphan(t *testing.T) {
 	// exactly as ArchiveSession.SetArchived does — then release so CreateTab can
 	// proceed and observe it. Because CreateTab is serialized behind the op-lock,
 	// it cannot have spawned anything before this point.
-	inst.SetStatus(session.Archived)
+	inst.SetStatusForTest(session.Archived)
 	manager.mu.Lock()
 	delete(manager.killsInFlight, key)
 	manager.mu.Unlock()

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -115,7 +115,7 @@ func startedLocalTabInstance(t *testing.T, m *Manager, repoID, repoPath, title, 
 	inst.SetGitWorktreeForTest(gw)
 	inst.SetTmuxSession(tmux.NewTmuxSessionFromSanitizedNameWithDeps(agentName, "claude", pty, exec))
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 
 	seedDiskInstance(t, repoID, title, repoPath)
 	m.mu.Lock()

--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -269,7 +269,7 @@ func TestDeliverPrompt_RefusesDeletingTarget(t *testing.T) {
 	if inst == nil {
 		t.Fatal("expected the created session to be in the manager's instance map")
 	}
-	inst.SetStatus(session.Deleting)
+	inst.SetStatusForTest(session.Deleting)
 
 	before := len(rec.snapshot())
 	_, err = manager.DeliverPrompt(DeliverPromptRequest{

--- a/daemon/find_session_test.go
+++ b/daemon/find_session_test.go
@@ -46,7 +46,7 @@ func newCountingInstance(t *testing.T, title, repoPath string) (*session.Instanc
 	backend := &attachCountingBackend{FakeBackend: session.NewFakeBackend()}
 	inst.SetBackend(backend)
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	return inst, backend
 }
 

--- a/daemon/limit_resume_test.go
+++ b/daemon/limit_resume_test.go
@@ -41,7 +41,7 @@ func (b *limitResumeBackend) Recover(i *session.Instance) error {
 	if s := i.GetStatus(); s != session.Lost {
 		return fmt.Errorf("recover: session %q is %v, not Lost", i.Title, s)
 	}
-	i.MarkLive()
+	_ = i.Transition(session.ConfirmLive())
 	return nil
 }
 
@@ -51,7 +51,7 @@ func (b *limitResumeBackend) Respawn(i *session.Instance) error {
 	b.mu.Unlock()
 	// The guard-free core: re-spawn regardless of liveness (matches the real
 	// LocalBackend.respawn, which ends by marking the session live).
-	i.MarkLive()
+	_ = i.Transition(session.ConfirmLive())
 	return nil
 }
 

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -38,7 +38,7 @@ func (b *recoverFakeBackend) Recover(inst *session.Instance) error {
 	if b.failWith != nil {
 		return b.failWith
 	}
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	return nil
 }
 
@@ -225,7 +225,7 @@ func TestRestoreLostSessions_LogsVanishedWorktreeOnce(t *testing.T) {
 	inst.Branch = branch
 	inst.SetBackend(&session.LocalBackend{})
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Lost)
+	inst.SetStatusForTest(session.Lost)
 	inst.SetGitWorktreeForTest(gw)
 	inst.SetTmuxSession(tmux.NewTmuxSessionFromSanitizedNameWithDeps(
 		"af_1303_vanished",
@@ -372,7 +372,7 @@ func (b *raceBackend) Recover(inst *session.Instance) error {
 	if b.recoverBlock != nil {
 		<-b.recoverBlock
 	}
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	return nil
 }
 
@@ -445,7 +445,7 @@ func TestKillSession_WaitsForInFlightRecover(t *testing.T) {
 	}
 	manager, repoID, inst := installRaceBackend(t, backend, "contested")
 	zeroRestoreBackoff(t)
-	inst.SetStatus(session.Lost)
+	inst.SetStatusForTest(session.Lost)
 
 	recoverStarted := backend.recoverStarted
 	restoreDone := make(chan struct{})
@@ -504,7 +504,7 @@ func TestRestoreLostSessions_SkipsDuringInFlightKill(t *testing.T) {
 	}
 	manager, repoID, inst := installRaceBackend(t, backend, "doomed")
 	zeroRestoreBackoff(t)
-	inst.SetStatus(session.Lost)
+	inst.SetStatusForTest(session.Lost)
 
 	killStarted := backend.killStarted
 	killDone := make(chan error, 1)

--- a/daemon/rootagent_test.go
+++ b/daemon/rootagent_test.go
@@ -163,7 +163,7 @@ func TestEnsureRootAgentsAdoptsLiveRoot(t *testing.T) {
 	}
 
 	for _, status := range []session.Status{session.Running, session.Ready, session.Loading} {
-		first.SetStatus(status)
+		first.SetStatusForTest(status)
 		manager.EnsureRootAgents()
 		if len(*seen) != 1 {
 			t.Fatalf("ensure over a live root (status %v) must be a no-op, got %d creates", status, len(*seen))
@@ -191,7 +191,7 @@ func TestEnsureRootAgentsHealsDeadRoot(t *testing.T) {
 		t.Fatalf("root instance missing after first ensure")
 	}
 
-	first.SetStatus(session.Dead)
+	first.SetStatusForTest(session.Dead)
 	manager.EnsureRootAgents()
 
 	if len(*seen) != 2 {
@@ -247,7 +247,7 @@ func TestEnsureRootAgentsHealsLostRoot(t *testing.T) {
 		t.Fatalf("root instance missing after first ensure")
 	}
 
-	first.SetStatus(session.Lost)
+	first.SetStatusForTest(session.Lost)
 	manager.EnsureRootAgents()
 
 	if len(*seen) != 2 {
@@ -285,7 +285,7 @@ func TestEnsureRootAgentsDoesNotAdoptArchivedRoot(t *testing.T) {
 		t.Fatalf("root instance missing after first ensure")
 	}
 
-	first.SetStatus(session.Archived)
+	first.SetStatusForTest(session.Archived)
 	manager.EnsureRootAgents()
 
 	if len(*seen) != 2 {
@@ -399,7 +399,7 @@ func TestKillDeadRootDoesNotDeleteSelfHealedRoot(t *testing.T) {
 	if rootA == nil {
 		t.Fatal("root-A missing after initial ensure")
 	}
-	rootA.SetStatus(session.Dead)
+	rootA.SetStatusForTest(session.Dead)
 
 	repo, err := config.RepoFromPath(repoPath)
 	if err != nil {
@@ -500,7 +500,7 @@ func TestEnsureRootAgentsBusyReapSkipDoesNotCreateOrBackoff(t *testing.T) {
 	if rootA == nil {
 		t.Fatal("root-A missing after initial ensure")
 	}
-	rootA.SetStatus(session.Dead)
+	rootA.SetStatusForTest(session.Dead)
 
 	repo, err := config.RepoFromPath(repoPath)
 	if err != nil {

--- a/daemon/status_test.go
+++ b/daemon/status_test.go
@@ -77,7 +77,7 @@ func registerStarted(t *testing.T, m *Manager, repoID, repoPath, title string, b
 	}
 	inst.SetBackend(backend)
 	inst.SetStartedForTest(started)
-	inst.SetStatus(status)
+	inst.SetStatusForTest(status)
 	seedDiskInstance(t, repoID, title, repoPath)
 	m.mu.Lock()
 	m.instances[daemonInstanceKey(repoID, title)] = inst

--- a/session/limit_test.go
+++ b/session/limit_test.go
@@ -40,7 +40,7 @@ func TestSetLimitReached_NoResetTime(t *testing.T) {
 func TestSetLimitReached_SkipsTransient(t *testing.T) {
 	for _, s := range []Status{Loading, Deleting} {
 		i := &Instance{}
-		i.SetStatus(s)
+		i.SetStatusForTest(s)
 		i.SetLimitReached(time.Now())
 		require.False(t, i.LimitReached(), "%v must not be overwritten by SetLimitReached", s)
 		require.Equal(t, s, i.GetStatus())
@@ -60,7 +60,7 @@ func TestClearLimitReached(t *testing.T) {
 
 	// No-op on a Ready instance.
 	r := &Instance{}
-	r.SetStatus(Ready)
+	r.SetStatusForTest(Ready)
 	r.ClearLimitReached()
 	require.Equal(t, Ready, r.GetStatus())
 }
@@ -70,7 +70,7 @@ func TestClearLimitReached(t *testing.T) {
 func TestLimitResetAt_ClearedWhenNotLimit(t *testing.T) {
 	i := &Instance{}
 	i.SetLimitReached(time.Now().Add(time.Hour))
-	i.SetStatus(Ready) // shim moves liveness to LiveReady, limitResetAt lingers
+	i.SetStatusForTest(Ready) // shim moves liveness to LiveReady, limitResetAt lingers
 	require.False(t, i.LimitReached())
 	_, ok := i.LimitResetAt()
 	require.False(t, ok, "a lingering reset time must not surface once off LimitReached")
@@ -110,7 +110,7 @@ func TestLimitReached_PersistRoundTrip(t *testing.T) {
 func TestToInstanceData_NoLimitResetForNormalSession(t *testing.T) {
 	i, err := NewInstance(InstanceOptions{Title: "normal", Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
-	i.SetStatus(Ready)
+	i.SetStatusForTest(Ready)
 	data := i.ToInstanceData()
 	require.True(t, data.LimitResetAt.IsZero(), "a non-limit session must not carry a reset time")
 }

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -262,22 +262,10 @@ func (i *Instance) SetInFlightOpForTest(op InFlightOp) {
 	i.inFlightOp = op
 }
 
-// MarkLive flips the instance to Running and clears a completing create/restore
-// op — the two-axis translation of the old SetStatusIfNotDeleting(Running) that
-// backend Start/Recover used. It preserves a teardown fence (OpKilling/
-// OpArchiving): a Start/Recover completing must never resurrect a session that a
-// kill or archive is tearing down; that owner writes the terminal liveness. It
-// does clear OpCreating/OpRestoring, which is exactly the op this completion
-// resolves.
-func (i *Instance) MarkLive() {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	if i.inFlightOp == OpKilling || i.inFlightOp == OpArchiving {
-		return
-	}
-	i.liveness = LiveRunning
-	i.inFlightOp = OpNone
-}
+// MarkLive is retired (#1195 Phase 2e): marking a completed create/recover live
+// is now the Transition chokepoint's ConfirmLive edge (Running + clear the
+// completing create/restore op, while yielding to an in-flight kill/archive
+// teardown). No direct "mark live" setter remains to bypass it.
 
 // tabSpawnBlockedLocked reports the error, if any, forbidding a new tab spawn.
 // Caller holds i.mu. It reads the two axes directly (the #1195 structural fold of

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -167,9 +167,15 @@ func (i *Instance) setStatusLocked(s Status) {
 	}
 }
 
-// SetStatus sets the status under the instance mutex (legacy shim — decomposes
-// onto the two axes).
-func (i *Instance) SetStatus(status Status) {
+// SetStatusForTest sets the status under the instance mutex by decomposing the
+// legacy composed Status onto the two axes — TEST scaffolding only (#1195 Phase
+// 2e), for establishing a precondition state via the familiar single-value API.
+// Production code never writes lifecycle state through the legacy Status: every
+// (liveness, inFlightOp) mutation goes through the Transition chokepoint. Mirrors
+// the SetInFlightOpForTest / SetStartedForTest scaffolding pattern. (GetStatus
+// stays — the composed value is still a legitimate read for rendering and test
+// assertions, pending a separate retirement of the legacy Status enum.)
+func (i *Instance) SetStatusForTest(status Status) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.setStatusLocked(status)

--- a/session/liveness_test.go
+++ b/session/liveness_test.go
@@ -14,7 +14,7 @@ import (
 func TestStatusShimRoundTrips(t *testing.T) {
 	for _, s := range []Status{Running, Ready, Loading, Deleting, Dead, Lost, Archived} {
 		i := &Instance{}
-		i.SetStatus(s)
+		i.SetStatusForTest(s)
 		require.Equal(t, s, i.GetStatus(), "SetStatus(%v) must round-trip through GetStatus", s)
 	}
 }
@@ -36,22 +36,22 @@ func TestStatusAxesDecomposition(t *testing.T) {
 	}
 	for _, c := range cases {
 		i := &Instance{}
-		i.SetStatus(c.status)
+		i.SetStatusForTest(c.status)
 		assert.Equal(t, c.liveness, i.liveness, "%v liveness", c.status)
 		assert.Equal(t, c.op, i.inFlightOp, "%v op", c.status)
 	}
 
 	// Transient values set the op and leave the underlying liveness intact.
 	i := &Instance{}
-	i.SetStatus(Running) // underlying liveness
-	i.SetStatus(Deleting)
+	i.SetStatusForTest(Running) // underlying liveness
+	i.SetStatusForTest(Deleting)
 	assert.Equal(t, LiveRunning, i.liveness, "Deleting must overlay, not overwrite, liveness")
 	assert.Equal(t, OpKilling, i.inFlightOp)
 	assert.Equal(t, Deleting, i.GetStatus())
 
 	i2 := &Instance{}
-	i2.SetStatus(Ready)
-	i2.SetStatus(Loading)
+	i2.SetStatusForTest(Ready)
+	i2.SetStatusForTest(Loading)
 	assert.Equal(t, LiveReady, i2.liveness, "Loading must overlay, not overwrite, liveness")
 	assert.Equal(t, OpCreating, i2.inFlightOp)
 }
@@ -62,7 +62,7 @@ func TestStatusAxesDecomposition(t *testing.T) {
 func TestLivenessPersistenceRollforward(t *testing.T) {
 	// New record: ToInstanceData writes both axes; the `liveness` key is present.
 	i := &Instance{}
-	i.SetStatus(Lost)
+	i.SetStatusForTest(Lost)
 	data := i.ToInstanceData()
 	require.Equal(t, LiveLost, data.Liveness)
 	require.Equal(t, Lost, data.Status, "legacy status still written for rollback")

--- a/session/storage_test.go
+++ b/session/storage_test.go
@@ -161,7 +161,7 @@ func TestSavePreservesArchivedRecordAcrossCoRepoSave(t *testing.T) {
 
 	live := makeInstance("live-sess", repoPath, true)          // started
 	archived := makeInstance("archived-sess", repoPath, false) // inert, started=false
-	archived.SetStatus(Archived)
+	archived.SetStatusForTest(Archived)
 
 	storage, err := NewStorage(ms, "") // daemon mode
 	require.NoError(t, err)
@@ -302,7 +302,7 @@ func TestRepoSaveDropsLoadingFromMemory(t *testing.T) {
 	ms := newMockStorage()
 
 	loading := makeInstance("in-flight", repoPath, false)
-	loading.SetStatus(Loading)
+	loading.SetStatusForTest(Loading)
 	storage, err := NewStorage(ms, repoID)
 	require.NoError(t, err)
 
@@ -327,7 +327,7 @@ func TestRepoSaveDropsDeletingFromMemory(t *testing.T) {
 	// Alive backend + started + empty disk: exactly the shape #819 preserves —
 	// unless the instance is Deleting.
 	deleting := makeAliveInstance("mid-teardown", repoPath)
-	deleting.SetStatus(Deleting)
+	deleting.SetStatusForTest(Deleting)
 
 	storage, err := NewStorage(ms, repoID)
 	require.NoError(t, err)

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -13,7 +13,7 @@ import (
 // struct literal (#1195 Phase 1b).
 func readyUIInstance() *session.Instance {
 	i := &session.Instance{}
-	i.SetStatus(session.Ready)
+	i.SetStatusForTest(session.Ready)
 	return i
 }
 
@@ -86,7 +86,7 @@ func TestMenuArchiveRestoreActionByRowState(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			inst := &session.Instance{}
-			inst.SetStatus(tc.status)
+			inst.SetStatusForTest(tc.status)
 			m := NewMenu()
 			m.SetInstance(inst)
 

--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -55,7 +55,7 @@ func TestPreviewScrollModeThenDeletingFallback(t *testing.T) {
 	})
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
-	inst.SetStatus(session.Deleting)
+	inst.SetStatusForTest(session.Deleting)
 
 	p := NewTabPane()
 	p.SetSize(80, 30)
@@ -117,7 +117,7 @@ func TestPreviewScrollModeThenLoadingFallback(t *testing.T) {
 	})
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
-	inst.SetStatus(session.Loading)
+	inst.SetStatusForTest(session.Loading)
 
 	p := NewTabPane()
 	p.SetSize(80, 30)
@@ -149,7 +149,7 @@ func TestPreviewScrollModeViewportContentCleared(t *testing.T) {
 	})
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
-	inst.SetStatus(session.Deleting)
+	inst.SetStatusForTest(session.Deleting)
 
 	p := NewTabPane()
 	p.SetSize(80, 30)

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -543,7 +543,7 @@ func TestPreviewResetToNormalModeLoadingShowsFallback(t *testing.T) {
 	})
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
-	inst.SetStatus(session.Loading)
+	inst.SetStatusForTest(session.Loading)
 
 	p := NewTabPane()
 	p.SetSize(80, 30)
@@ -583,7 +583,7 @@ func TestPreviewUpdateContentDeletingShowsTeardownFallback(t *testing.T) {
 	})
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
-	inst.SetStatus(session.Deleting)
+	inst.SetStatusForTest(session.Deleting)
 
 	// Precondition: this instance has empty preview content and is not started,
 	// exactly the state that previously produced the wrong "Please enter a

--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -20,7 +20,7 @@ func archTestInstance(t *testing.T, title string, status session.Status) *sessio
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
 	inst.SetStartedForTest(status != session.Archived)
-	inst.SetStatus(status)
+	inst.SetStatusForTest(status)
 	return inst
 }
 

--- a/ui/sidebar_tree_test.go
+++ b/ui/sidebar_tree_test.go
@@ -325,7 +325,7 @@ func TestSidebarTreeTransientRowsCollapse(t *testing.T) {
 	require.Equal(t, 2, tabRowCount(s))
 
 	inst := s.proj.GetInstances()[0]
-	inst.SetStatus(session.Deleting)
+	inst.SetStatusForTest(session.Deleting)
 	// Status flips in place (no store version bump) — the structure signature
 	// must still pick it up on the next read.
 	assert.Equal(t, 0, tabRowCount(s), "deleting instance folds its tab children")
@@ -334,7 +334,7 @@ func TestSidebarTreeTransientRowsCollapse(t *testing.T) {
 	assert.NotContains(t, out, "├", "no tab children while deleting")
 	assert.NotContains(t, out, "▾", "no expanded arrow while deleting")
 
-	inst.SetStatus(session.Ready)
+	inst.SetStatusForTest(session.Ready)
 	assert.Equal(t, 2, tabRowCount(s), "back to Ready re-expands the selection")
 }
 

--- a/ui/store/order_test.go
+++ b/ui/store/order_test.go
@@ -117,9 +117,9 @@ func TestLessInstanceOrder_StableAcrossIdenticalSnapshots(t *testing.T) {
 // instance (Lost is not special to ordering, #1108).
 func TestLessInstanceOrder_LostStatusDoesNotAffectOrder(t *testing.T) {
 	lostRoot := &session.Instance{Title: "root", CreatedAt: tNewest}
-	lostRoot.SetStatus(session.Lost)
+	lostRoot.SetStatusForTest(session.Lost)
 	lostBravo := &session.Instance{Title: "bravo", CreatedAt: tMid}
-	lostBravo.SetStatus(session.Lost)
+	lostBravo.SetStatusForTest(session.Lost)
 	in := []*session.Instance{
 		lostBravo,
 		inst("charlie", tNewer),

--- a/ui/tabbed_window_test.go
+++ b/ui/tabbed_window_test.go
@@ -28,7 +28,7 @@ func startedWindowInstance(t *testing.T, title string) *session.Instance {
 	require.NoError(t, err)
 	inst.SetBackend(session.NewFakeBackend())
 	inst.SetStartedForTest(true)
-	inst.SetStatus(session.Running)
+	inst.SetStatusForTest(session.Running)
 	addAgentShellTabs(inst)
 	return inst
 }

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -181,7 +181,7 @@ func TestTabPaneShellFallbackStates(t *testing.T) {
 		})
 		require.NoError(t, err)
 		inst.SetBackend(session.NewFakeBackend())
-		inst.SetStatus(session.Deleting)
+		inst.SetStatusForTest(session.Deleting)
 
 		require.NoError(t, p.UpdateContent(inst, 1))
 		p.mu.Lock()

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -214,11 +214,11 @@ func TestInstanceRendererDeletingMarker(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	inst.SetStatus(session.Ready)
+	inst.SetStatusForTest(session.Ready)
 	before, _, _ := renderForTerminal(t, 120, inst, &spin)
 	assert.NotContains(t, before, "[deleting]")
 
-	inst.SetStatus(session.Deleting)
+	inst.SetStatusForTest(session.Deleting)
 	after, _, _ := renderForTerminal(t, 120, inst, &spin)
 	assert.Contains(t, after, "[deleting]", "deleting rows must be explicitly marked")
 	assert.Contains(t, after, "going-away", "the title must remain visible while deleting")
@@ -311,13 +311,13 @@ func TestInstanceRendererDeletingDimsSelectedRow(t *testing.T) {
 		return lines
 	}
 
-	inst.SetStatus(session.Ready)
+	inst.SetStatusForTest(session.Ready)
 	before := renderLines()
 	require.NotContains(t, before[1], dimFG, "selected title must not be dimmed before deletion")
 	require.NotContains(t, before[2], dimFG, "selected branch line must not be dimmed before deletion")
 	require.NotContains(t, before[4], dimFG, "selected PR line must not be dimmed before deletion")
 
-	inst.SetStatus(session.Deleting)
+	inst.SetStatusForTest(session.Deleting)
 	after := renderLines()
 	assert.Contains(t, after[1], dimFG, "selected deleting title must be dimmed")
 	assert.Contains(t, after[2], dimFG, "selected deleting branch line must be dimmed")
@@ -345,7 +345,7 @@ func TestInstanceRendererTreeArrow(t *testing.T) {
 	expanded := strings.Split(r.Render(inst, 1, false, false, true), "\n")[1]
 	assert.Contains(t, expanded, expandedArrow, "expanded row must show ▾")
 
-	inst.SetStatus(session.Loading)
+	inst.SetStatusForTest(session.Loading)
 	transient := strings.Split(r.Render(inst, 1, false, false, false), "\n")[1]
 	assert.NotContains(t, transient, collapsedArrow, "transient rows are not expandable")
 	assert.NotContains(t, transient, expandedArrow, "transient rows are not expandable")


### PR DESCRIPTION
**Phase 2e of #1195 — the finish line.** Stacked on #1358; retarget to master as the chain merges.

## What (two commits)
1. **`MarkLive` → `Transition(ConfirmLive())`** and deleted. Its two callers were a test fake backend mirroring the real `LocalBackend` (already on `ConfirmLive` via #1350).
2. **`SetStatus` → `SetStatusForTest`** (root's call — prod-free, test-heavy). Zero prod callers after 2d/2e; renamed to the test-scaffolding pattern and migrated its **97 test callers**. `GetStatus` stays (composed read for rendering/asserts, pending a separate legacy-Status-enum retirement).

## Result: `Instance.Transition` is the SOLE production path for two-axis lifecycle state
Every `(liveness, inFlightOp)` mutation — create / kill / archive / restore / liveness-observe / op-overlay — routes through the chokepoint. All three two-axis direct setters are gone: `SetLiveness` (#1357, deleted), `SetInFlightOp` (#1358, →ForTest), `MarkLive` (deleted). `SetStatus` → `SetStatusForTest`.

## Documented remaining exceptions (out of Phase 2 scope)
- **`SetLimitReached` / `SetLimitResetAt`**: #1146's usage-limit writers — they also set the reset-time **metadata** (not a pure axis write), so folding them in needs a limit-aware edge coordinated with #1146.
- **`SetArchived`**: the TUI's unconditional **projection-mirror** of the daemon's committed Archived state (not a fenced transition — #1353).

## Gates
`go build`, `gofmt`, `go vet`, `deadcode -test ./...` clean, `golangci-lint --fast`, file-length, **`make test-container`** (full suite, **daemon+app panic hooks active** — every prod Transition caller validated as a legal edge).

Refs #1195. **This completes the Phase 2 chokepoint + lifecycle direct-setter retirement.**

— Captain Claude