### PR TITLE
fix(store): suppress unstarted removal error log

### DIFF
--- a/ui/store/projection.go
+++ b/ui/store/projection.go
@@ -237,14 +237,19 @@ func (p *Projection) KillInstance(target *session.Instance) error {
 		return nil
 	}
 	// Capture repo name before Kill(), because Kill() sets started=false
-	// which causes RepoName() to fail.
-	repoName, repoErr := target.RepoName()
+	// which causes RepoName() to fail. Unstarted placeholders were never
+	// registered in the repo counts, so there is nothing to decrement.
+	var repoName string
+	var repoErr error
+	if target.Started() {
+		repoName, repoErr = target.RepoName()
+	}
 	if err := target.Kill(); err != nil {
 		return fmt.Errorf("could not kill instance: %w", err)
 	}
 	if repoErr != nil {
 		log.ErrorLog.Printf("could not get repo name: %v", repoErr)
-	} else {
+	} else if repoName != "" {
 		p.rmRepo(repoName)
 	}
 	p.instances = append(p.instances[:idx], p.instances[idx+1:]...)
@@ -342,19 +347,16 @@ func (p *Projection) ReplaceInstanceByTitle(title string, replacement *session.I
 
 // RemoveInstanceByTitle removes an instance by title without killing it (the
 // external process already cleaned up tmux/worktree).
-// Note: the instance may already have been killed (started=false), so we fall
-// back to looking up the repo name from the gitWorktree directly.
 func (p *Projection) RemoveInstanceByTitle(title string) bool {
 	for i, inst := range p.instances {
 		if inst.Title == title {
-			repoName, err := inst.RepoName()
-			if err != nil {
-				// If RepoName() fails (e.g. instance already killed/not started),
-				// we cannot decrement the repo count without the name, so log and
-				// continue — the repo map will be corrected on next full rebuild.
-				log.ErrorLog.Printf("could not get repo name: %v", err)
-			} else {
-				p.rmRepo(repoName)
+			if inst.Started() {
+				repoName, err := inst.RepoName()
+				if err != nil {
+					log.ErrorLog.Printf("could not get repo name: %v", err)
+				} else {
+					p.rmRepo(repoName)
+				}
 			}
 			p.instances = append(p.instances[:i], p.instances[i+1:]...)
 			p.bump()

--- a/ui/store/projection_test.go
+++ b/ui/store/projection_test.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"bytes"
+	"testing"
+
+	aflog "github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+func captureProjectionErrorLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := aflog.ErrorLog.Writer()
+	aflog.ErrorLog.SetOutput(&buf)
+	t.Cleanup(func() { aflog.ErrorLog.SetOutput(prev) })
+	return &buf
+}
+
+func newUnstartedProjectionInstance(t *testing.T, title string) *session.Instance {
+	t.Helper()
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    t.TempDir(),
+		Program: "claude",
+	})
+	if err != nil {
+		t.Fatalf("NewInstance() error = %v", err)
+	}
+	if inst.Started() {
+		t.Fatalf("test fixture must be unstarted")
+	}
+	return inst
+}
+
+func TestProjectionRemoveUnstartedInstanceDoesNotLogError(t *testing.T) {
+	t.Run("KillInstance", func(t *testing.T) {
+		errLog := captureProjectionErrorLog(t)
+		p := NewProjection()
+		inst := newUnstartedProjectionInstance(t, "unstarted-kill")
+		p.AddInstance(inst)
+
+		if err := p.KillInstance(inst); err != nil {
+			t.Fatalf("KillInstance() error = %v", err)
+		}
+		if p.ContainsInstance(inst) {
+			t.Fatalf("KillInstance() left the instance in the projection")
+		}
+		if got := errLog.String(); got != "" {
+			t.Fatalf("ErrorLog = %q, want empty", got)
+		}
+	})
+
+	t.Run("RemoveInstanceByTitle", func(t *testing.T) {
+		errLog := captureProjectionErrorLog(t)
+		p := NewProjection()
+		inst := newUnstartedProjectionInstance(t, "unstarted-remove")
+		p.AddInstance(inst)
+
+		if !p.RemoveInstanceByTitle(inst.Title) {
+			t.Fatalf("RemoveInstanceByTitle() did not remove the instance")
+		}
+		if p.ContainsInstance(inst) {
+			t.Fatalf("RemoveInstanceByTitle() left the instance in the projection")
+		}
+		if got := errLog.String(); got != "" {
+			t.Fatalf("ErrorLog = %q, want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #1360

## Summary
- skip repo-name lookup and repo-count teardown when projection removes an instance that was never started
- preserve ERROR logging for repo-name failures on rows that were started before removal
- add store regression coverage for unstarted removal through both KillInstance and RemoveInstanceByTitle

## Verification
- gofmt -l $(git ls-files '*.go')\n- go build\n- golangci-lint run --fast (installed golangci-lint v1.60.1 rejects top-level `golangci-lint --fast`)\n- scripts/lint-file-length.sh\n- make test-container