### PR TITLE
fix(tui): derive automations rail hints from keymap

### DIFF
--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -87,7 +87,8 @@ func (m *home) showSearchOverlay() (tea.Model, tea.Cmd) {
 // full manager lives in the tasks overlay. Cursor keys move the section's
 // selection, Enter opens the manager overlay on it, Esc returns focus to the
 // tree. Everything else falls through to the caller so the global bindings
-// (Tab/Shift-Tab focus ring, S manage, H hooks, ? help, q quit) keep working.
+// (Tab/Shift-Tab focus ring, task manager, hooks, ? help, q quit) keep
+// working.
 func (m *home) handleAutomationsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	if m.ring.Active() != layout.RegionAutomations {
 		return m, nil, false

--- a/app/layout_cutover_test.go
+++ b/app/layout_cutover_test.go
@@ -55,7 +55,8 @@ func TestLayoutCutover_ViewComposesFullWindow(t *testing.T) {
 		// The header ellipsizes at the narrowest rails, so assert the stable
 		// prefix plus the manage affordance FIX 2 guarantees is never cut.
 		assert.Contains(t, view, "Automation", "%dx%d: automations section", tc.w, tc.h)
-		assert.Contains(t, view, "S manage", "%dx%d: the manage affordance survives", tc.w, tc.h)
+		manageHint := helpKey(keys.KeyTaskList) + " manage"
+		assert.Contains(t, view, manageHint, "%dx%d: the manage affordance survives", tc.w, tc.h)
 		// #1087: the automations section lives inside the left rail, under a
 		// full-rail-width horizontal rule.
 		assert.Contains(t, view, strings.Repeat("─", h.lastLayout.RailRule.W),
@@ -97,7 +98,7 @@ func TestLayoutCutover_FocusRingCycles(t *testing.T) {
 	assert.Equal(t, layout.RegionAutomations, h.ring.Active())
 	assert.True(t, h.automations.Focused())
 	assert.False(t, h.automations.TaskPane().HasFocus(),
-		"focusing the section must not focus the manager — Enter/S open it as an overlay")
+		"focusing the section must not focus the manager — Enter or the task key opens it as an overlay")
 	assert.Equal(t, layout.AutomationsRows, h.lastLayout.Automations.H,
 		"the focused section keeps its compact allocation — no in-rail expansion")
 

--- a/ui/automations.go
+++ b/ui/automations.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/layout/zones"
@@ -77,8 +78,8 @@ func fitLine(s string, w int) string {
 // after a reload.
 //
 // It implements layout.Pane. While focused the rows carry a cursor
-// (up/down/j/k via HandleKey); the root opens the manager overlay on Enter/S
-// and moves the focus ring on Esc.
+// (up/down/j/k via HandleKey); the root opens the manager overlay on Enter or
+// the global task-manager key and moves the focus ring on Esc.
 type AutomationsPane struct {
 	proj     *store.Projection
 	taskPane *TaskPane
@@ -299,16 +300,27 @@ func (a *AutomationsPane) enabledCount() int {
 	return n
 }
 
-// titleLine renders the section header width-aware: segments drop
-// right-to-left ("H hooks" first, then the task counts) and finally the name
-// shrinks with an ellipsis — the "S manage" affordance is the last thing cut,
-// so the key to the manager stays visible even at the 22-col rail minimum
-// (#1090 width).
+func automationHelpKey(name keys.KeyName) string {
+	return keys.GlobalKeyBindings[name].Help().Key
+}
+
+func automationsManageHint() string {
+	return "· " + automationHelpKey(keys.KeyTaskList) + " manage"
+}
+
+func automationsActionHint(name keys.KeyName, desc string) string {
+	return automationHelpKey(name) + " " + desc
+}
+
+// titleLine renders the section header width-aware: segments drop right-to-left
+// (hooks first, then the task counts) and finally the name shrinks with an
+// ellipsis. The manage affordance is the last thing cut, so the key to the
+// manager stays visible even at the 22-col rail minimum (#1090 width).
 func (a *AutomationsPane) titleLine(name string, nameStyle lipgloss.Style) string {
 	w := a.rect.W
 	const shortName = " Automations "
-	const manage = "· S manage"
-	const hooks = " · H hooks"
+	manage := automationsManageHint()
+	hooks := " · " + automationsActionHint(keys.KeyHooks, "hooks")
 	if runewidth.StringWidth(name+manage+hooks) <= w {
 		return nameStyle.Render(name) + automationsHintStyle.Render(manage+hooks)
 	}
@@ -365,7 +377,7 @@ func (a *AutomationsPane) String() string {
 	lines := []string{title}
 	if len(tasks) == 0 {
 		lines = append(lines, automationsDisabledStyle.Render(
-			fitLine("  no tasks — press m, then n to create one", a.rect.W)))
+			fitLine(fmt.Sprintf("  no tasks — press %s, then n to create one", automationHelpKey(keys.KeyTaskList)), a.rect.W)))
 	}
 
 	// Window the rows around the cursor so a focused selection below the fold

--- a/ui/automations_test.go
+++ b/ui/automations_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/store"
@@ -133,29 +134,33 @@ func TestAutomationsStripKeyRouting(t *testing.T) {
 }
 
 // TestAutomationsTitleWidthAware pins the #1096 play-test fix: the header's
-// hint segments drop right-to-left ("H hooks" first) and the name shrinks
-// with an ellipsis so the "S manage" affordance survives even the 22-col
-// rail minimum — never a bare hard clamp.
+// hint segments drop right-to-left (hooks first) and the name shrinks with an
+// ellipsis so the manage affordance survives even the 22-col rail minimum —
+// never a bare hard clamp.
 func TestAutomationsTitleWidthAware(t *testing.T) {
 	tasks := stripTasks()
+	manageHint := automationHelpKey(keys.KeyTaskList) + " manage"
+	hooksHint := automationHelpKey(keys.KeyHooks) + " hooks"
 
 	wide := newTestAutomations(tasks)
 	wide.SetRect(layout.Rect{W: 60, H: 3})
 	out := wide.View()
-	assert.Contains(t, out, "S manage", "wide rail shows the manage hint")
-	assert.Contains(t, out, "H hooks", "wide rail shows the hooks hint")
+	assert.Contains(t, out, manageHint, "wide rail shows the manage hint")
+	assert.Contains(t, out, hooksHint, "wide rail shows the hooks hint")
+	assert.NotContains(t, out, "S manage", "the old task-manager key must not be advertised by default")
+	assert.NotContains(t, out, "H hooks", "the old hooks key must not be advertised by default")
 
 	mid := newTestAutomations(tasks)
 	mid.SetRect(layout.Rect{W: 36, H: 3})
 	out = mid.View()
-	assert.Contains(t, out, "S manage", "36-col rail keeps the manage hint")
-	assert.NotContains(t, out, "H hooks", "the hooks hint drops first under width pressure")
+	assert.Contains(t, out, manageHint, "36-col rail keeps the manage hint")
+	assert.NotContains(t, out, hooksHint, "the hooks hint drops first under width pressure")
 
 	narrow := newTestAutomations(tasks)
 	narrow.SetRect(layout.Rect{W: 22, H: 3})
 	out = narrow.View()
 	requireExactRect(t, out, layout.Rect{W: 22, H: 3}, "22-col section")
-	assert.Contains(t, out, "S manage", "22-col rail still shows the manage affordance")
+	assert.Contains(t, out, manageHint, "22-col rail still shows the manage affordance")
 	assert.Contains(t, out, "…", "the shrunk name marks its cut with an ellipsis")
 
 	// The 1-line degraded summary applies the same policy.
@@ -164,7 +169,25 @@ func TestAutomationsTitleWidthAware(t *testing.T) {
 	compact.SetCompact(true)
 	out = compact.View()
 	requireExactRect(t, out, layout.Rect{W: 22, H: 1}, "22-col compact summary")
-	assert.Contains(t, out, "S manage", "the compact summary keeps the manage affordance")
+	assert.Contains(t, out, manageHint, "the compact summary keeps the manage affordance")
+}
+
+func TestAutomationsHintsReflectKeymapRebinds(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{
+		"tasks": {"f"},
+		"hooks": {"g"},
+	}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	a := newTestAutomations(nil)
+	a.SetRect(layout.Rect{W: 80, H: 3})
+
+	out := a.View()
+	assert.Contains(t, out, "f manage", "manage title hint follows the rebound task-manager key")
+	assert.Contains(t, out, "g hooks", "hooks title hint follows the rebound hooks key")
+	assert.Contains(t, out, "press f, then n", "empty-state hint follows the rebound task-manager key")
+	assert.NotContains(t, out, "m manage", "default task-manager key must not be hardcoded")
+	assert.NotContains(t, out, "e hooks", "default hooks key must not be hardcoded")
 }
 
 // TestAutomationsEmptyStateEllipsized: the no-tasks hint ellipsizes instead


### PR DESCRIPTION
Fixes #1362.

## Summary
- Derive the automations rail manage/hooks hints from `keys.GlobalKeyBindings` instead of hardcoded old defaults.
- Derive the empty-state task-manager prompt from the effective task key.
- Update rail/layout tests and add a rebind regression covering tasks/hooks hints.

## Verification
- `gofmt -l $(git ls-files '*.go')`\n- `GOTOOLCHAIN=go1.24.2 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0`\n- `go build ./...`\n- `make lint-file-length`\n- `make test-container`