### PR TITLE
fix(tui): suppress stale pane preview after hide

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -190,6 +190,9 @@ type home struct {
 	// re-homes focus to the tree (#1233/#1236). Preview-on-scroll uses it as
 	// the owner pane while the tree cursor moves.
 	lastFocusedPaneID int
+	// panePreviewSuppression remembers a user-dismissed preview target so the
+	// 100ms preview tick does not recreate it until the sidebar target changes.
+	panePreviewSuppression *panePreviewSuppression
 	// -- Live embedded terminal (#1089 PR 1, read-only proof path) --
 	//
 	// At most ONE pane holds a live termpane attachment: the focused pane
@@ -533,6 +536,7 @@ func (m *home) focusRegion(region string) {
 // the in-rail automations section is read-only, so no save is needed here.
 func (m *home) cycleFocus(back bool) tea.Cmd {
 	if m.panePreviewTxn != nil {
+		m.suppressActivePanePreview()
 		m.cancelPanePreview(true)
 		return m.panesRefresh(m.attached.Load())
 	}
@@ -1110,12 +1114,14 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 				return m, m.handleError(err)
 			}
 			if m.panePreviewTxn != nil {
+				m.suppressActivePanePreview()
 				m.cancelPanePreview(true)
 				return m, m.panesRefresh(m.attached.Load())
 			}
 			return m, m.selectionChanged()
 		}
 		if m.panePreviewTxn != nil {
+			m.suppressActivePanePreview()
 			m.cancelPanePreview(true)
 			return m, m.panesRefresh(m.attached.Load())
 		}
@@ -1399,6 +1405,7 @@ func (m *home) selectionChanged() tea.Cmd {
 		// until the first cursor move (#1099 play-test).
 		m.maybeAutoOpenInitialPane(nil)
 		m.cancelPanePreview(false)
+		m.panePreviewSuppression = nil
 		m.menu.SetInstance(nil)
 		if selected := m.store.GetSelectedInstance(); selected != nil && !m.store.ContainsInstance(selected) {
 			// The sticky binding dangles — its instance was removed (e.g. the

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -154,14 +154,17 @@ func (m *home) hidePane(p *store.OpenPane) {
 	}
 	m.closePaneWindow(p)
 	m.relayout()
+	var focusedAfter *store.OpenPane
 	if pos >= 0 && len(m.visiblePanes) > 0 {
 		if pos >= len(m.visiblePanes) {
 			pos = len(m.visiblePanes) - 1
 		}
-		m.ring.Focus(layout.PaneRegion(m.visiblePanes[pos].ID()))
+		focusedAfter = m.visiblePanes[pos]
+		m.ring.Focus(layout.PaneRegion(focusedAfter.ID()))
 	} else {
 		m.ring.Focus(layout.RegionTree)
 	}
+	m.suppressPanePreviewForSelection(focusedAfter)
 	m.syncFocus()
 }
 

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -394,6 +394,56 @@ func TestPanePreviewSplitCommitsAlongside(t *testing.T) {
 	assert.NotContains(t, view, "PREVIEW")
 }
 
+func TestPanePreviewSplitHideDoesNotStickInPanePreview(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Same(t, alpha, paneA.Instance())
+
+	for i := 0; i < 3; i++ {
+		pressNav(t, h, "j")
+	}
+	require.Same(t, beta, h.store.GetSelectedInstance())
+	require.Equal(t, layout.RegionTree, h.ring.Active(), "tree navigation owns focus during preview")
+	require.NotNil(t, h.panePreviewTxn)
+	require.Contains(t, h.View(), "PREVIEW beta · Agent (original alpha · Agent)")
+
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("S")}, keys.KeySplitPane)
+	require.NotNil(t, cmd)
+	require.Nil(t, h.panePreviewTxn)
+	require.Equal(t, 2, h.store.NumOpenPanes())
+	paneB := h.store.OpenPanes()[1]
+	require.Same(t, beta, paneB.Instance())
+	require.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active())
+
+	pressTab(t, h, false)
+	require.Equal(t, layout.RegionAutomations, h.ring.Active())
+	pressTab(t, h, true)
+	require.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active())
+
+	pressKey(t, h, "x")
+
+	require.Equal(t, 1, h.store.NumOpenPanes())
+	require.Same(t, paneA, h.store.OpenPanes()[0])
+	require.Nil(t, h.panePreviewTxn, "hiding the split target must not recreate its preview")
+	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active(), "focus lands on the surviving pane")
+	view := h.View()
+	assert.Contains(t, view, "alpha · Agent · selected: beta ·",
+		"the survivor keeps the #1289 selected-vs-shown header")
+	assert.NotContains(t, view, "PREVIEW", "the hidden split pane must not leave a transient preview")
+
+	_ = h.selectionChanged()
+	require.Nil(t, h.panePreviewTxn, "the preview tick must not recreate the dismissed split target")
+
+	pressTab(t, h, false)
+	assert.Equal(t, layout.RegionAutomations, h.ring.Active(), "Tab must cycle out of pane context")
+	pressTab(t, h, false)
+	assert.Equal(t, layout.RegionTree, h.ring.Active(), "the focus ring must remain able to reach the tree")
+}
+
 func TestPanePreviewSplitFocusesAlreadyOpenTarget(t *testing.T) {
 	h := paneTestHome(t)
 	alpha := h.store.GetInstanceByTitle("alpha")

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -23,6 +23,11 @@ type panePreviewTxn struct {
 	seq         uint64
 }
 
+type panePreviewSuppression struct {
+	original paneBinding
+	target   paneBinding
+}
+
 func samePaneBinding(a, b paneBinding) bool {
 	return a.instance == b.instance && a.tab == b.tab
 }
@@ -53,6 +58,10 @@ func (m *home) updatePanePreview(selected *session.Instance, attachedNow bool) {
 	// #1321 is an instance preview, not a tab preview: selecting a different
 	// tab row on the pane's original instance keeps the #1289 divergence header.
 	if original.instance == target.instance {
+		m.cancelPanePreview(false)
+		return
+	}
+	if m.isPanePreviewSuppressed(original, target) {
 		m.cancelPanePreview(false)
 		return
 	}
@@ -95,6 +104,48 @@ func (m *home) cancelPanePreview(focusOwner bool) {
 			m.focusRegion(layout.PaneRegion(p.ID()))
 		}
 	}
+}
+
+func (m *home) suppressActivePanePreview() {
+	if txn := m.panePreviewTxn; txn != nil {
+		m.suppressPanePreview(txn.original, txn.target)
+	}
+}
+
+func (m *home) suppressPanePreviewForSelection(owner *store.OpenPane) {
+	if owner == nil {
+		return
+	}
+	selected := m.store.GetSelectedInstance()
+	if selected == nil {
+		return
+	}
+	m.suppressPanePreview(
+		paneBinding{instance: owner.Instance(), tab: owner.Tab()},
+		paneBinding{instance: selected, tab: 0},
+	)
+}
+
+func (m *home) suppressPanePreview(original, target paneBinding) {
+	if original.instance == nil || target.instance == nil || samePaneBinding(original, target) {
+		return
+	}
+	m.panePreviewSuppression = &panePreviewSuppression{
+		original: original,
+		target:   target,
+	}
+}
+
+func (m *home) isPanePreviewSuppressed(original, target paneBinding) bool {
+	suppressed := m.panePreviewSuppression
+	if suppressed == nil {
+		return false
+	}
+	if !samePaneBinding(suppressed.target, target) {
+		m.panePreviewSuppression = nil
+		return false
+	}
+	return samePaneBinding(suppressed.original, original)
 }
 
 func (m *home) commitPanePreviewReplace() tea.Cmd {
@@ -146,6 +197,7 @@ func (m *home) commitPanePreviewAlongside() tea.Cmd {
 		return nil
 	}
 	target := txn.target
+	m.suppressActivePanePreview()
 	m.cancelPanePreview(false)
 	_, cmd := m.openOrFocusPane(target.instance, target.tab)
 	return cmd


### PR DESCRIPTION
## Summary
- suppress a dismissed pane preview target so preview ticks do not recreate it after Tab/Esc or split commit
- suppress preview recreation when hiding a focused pane leaves a surviving pane with a divergent sidebar selection
- add regression coverage for preview -> S split -> Tab/Shift-Tab -> x hide, including focus-ring recovery to the tree

Fixes #1363.

## Verification
- gofmt -l $(git ls-files '*.go')
- go build ./...
- golangci-lint run --fast (local golangci-lint exposes --fast under run; top-level golangci-lint --fast is rejected by this installed version)
- scripts/lint-file-length.sh
- make test-container