### PR TITLE
fix(task): anchor Claude limit reset parsing

### DIFF
--- a/task/limit.go
+++ b/task/limit.go
@@ -35,13 +35,13 @@ type agentLimitMatcher struct {
 	// — detection must never depend on successful time parsing, so a reworded
 	// or truncated reset phrase still surfaces as a limit hit.
 	detect *regexp.Regexp
-	// parseReset extracts and parses the reset timestamp from content that
-	// detect has already matched, returning an absolute UTC reset time. It
-	// returns ok=false when no reset time is present or it cannot be parsed;
-	// detection still stands. now is the injected clock used to resolve
-	// relative and time-of-day-only forms into an absolute instant — the
-	// tested path never calls time.Now() itself, so tests are deterministic.
-	// nil for a detect-only (surface-only) agent; there are none in v1.
+	// parseReset extracts and parses the reset timestamp from content starting
+	// at detect's match, returning an absolute UTC reset time. It returns
+	// ok=false when no reset time is present or it cannot be parsed; detection
+	// still stands. now is the injected clock used to resolve relative and
+	// time-of-day-only forms into an absolute instant — the tested path never
+	// calls time.Now() itself, so tests are deterministic. nil for a detect-only
+	// (surface-only) agent; there are none in v1.
 	parseReset func(content string, now time.Time) (time.Time, bool)
 }
 
@@ -162,13 +162,14 @@ func isLimitContent(content, agent string, matchers map[string]agentLimitMatcher
 	if !ok || matcher.detect == nil {
 		return false, time.Time{}, false
 	}
-	if !matcher.detect.MatchString(content) {
+	match := matcher.detect.FindStringIndex(content)
+	if match == nil {
 		return false, time.Time{}, false
 	}
 	if matcher.parseReset == nil {
 		return true, time.Time{}, false
 	}
-	if reset, parsed := matcher.parseReset(content, now); parsed {
+	if reset, parsed := matcher.parseReset(content[match[0]:], now); parsed {
 		return true, reset.UTC(), true
 	}
 	return true, time.Time{}, false
@@ -210,11 +211,11 @@ var (
 // reset clause still detects (hit=true) even when this yields no parse.
 var claudeResetAnchor = regexp.MustCompile(`(?i)reset\s+(?:at\s+)?([^\r\n]+)`)
 
-// parseClaudeReset scans content for Claude's "reset at <tail>" clause and
-// resolves the tail, in order: an optional timezone in parens (falling back to
-// now's location when absent — Claude renders in the account tz, which we
-// cannot know without the paren, so the injected clock's zone is the
-// deterministic stand-in), a required 12-hour clock time, and an optional
+// parseClaudeReset scans the detector-matched tail for Claude's "reset at
+// <tail>" clause and resolves the tail, in order: an optional timezone in parens
+// (falling back to now's location when absent — Claude renders in the account
+// tz, which we cannot know without the paren, so the injected clock's zone is
+// the deterministic stand-in), a required 12-hour clock time, and an optional
 // calendar date or weekday (the weekly variant). Without any date it mints the
 // next occurrence of that clock time strictly after now. Returns ok=false when
 // there is no reset clause or no clock time in it, so an unrecognized/reworded
@@ -285,8 +286,8 @@ var (
 	ordinalSuffix = regexp.MustCompile(`(?i)(\d{1,2})(st|nd|rd|th)`)
 )
 
-// parseCodexReset scans the whole captured pane content for Codex's reset
-// phrase. It prefers an absolute "try again at <ts>" timestamp (weekly
+// parseCodexReset scans the detector-matched tail for Codex's reset phrase. It
+// prefers an absolute "try again at <ts>" timestamp (weekly
 // date+time or 5h time-only), then falls back to a relative "try again in
 // <duration>" countdown. Codex renders in local time with no timezone in the
 // banner, so absolute forms are interpreted in now's location. Returns

--- a/task/limit_test.go
+++ b/task/limit_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +40,18 @@ func TestIsLimitContent(t *testing.T) {
 			wantHit:      true,
 			wantReset:    true,
 			wantResetUTC: time.Date(2026, 7, 4, 14, 0, 0, 0, loc).UTC(), // 18:00 UTC
+		},
+		{
+			name:  "claude ignores earlier visible reset text before limit banner",
+			agent: tmux.ProgramClaude,
+			content: strings.Join([]string{
+				"Running deployment notes: reset at 3pm (America/New_York)",
+				"Build still in progress...",
+				"Claude usage limit reached. Your limit will reset at 7pm (America/New_York)",
+			}, "\n"),
+			wantHit:      true,
+			wantReset:    true,
+			wantResetUTC: time.Date(2026, 7, 4, 19, 0, 0, 0, loc).UTC(), // 23:00 UTC
 		},
 		{
 			name:         "claude weekly: explicit date + year + tz",


### PR DESCRIPTION
## Summary
- Fixes #1326 by anchoring reset-time parsing to the actual usage-limit detector match instead of scanning the whole captured pane.
- Preserves #1146 `limit_patterns` behavior by using the resolved matcher match, including overrides, as the parse anchor.
- Adds a representative Claude pane fixture where earlier visible output says `reset at 3pm` but the actual limit banner resets at `7pm`.

## Coordination
- #1146 auto-resume scheduler still uses `LimitResetAt`; this fixes the parsed input before scheduling.
- #1204 manual retry path is untouched and continues sharing the same resume machinery.
- #1334 parked-prompt persistence is already present; this PR does not alter prompt storage/resume behavior.

## Gates
- `gofmt -l $(git ls-files '*.go')` empty
- `go build ./...`
- `golangci-lint run --fast`
- `make lint-file-length`
- `make test-container`

Do not merge — root verifies.