### PR TITLE
Fix terminal tab pane focus binding

### DIFF
--- a/app/home_panes.go
+++ b/app/home_panes.go
@@ -49,7 +49,13 @@ func (m *home) selectionChanged() tea.Cmd {
 		// just in the explicit tab-jump handlers.
 		m.menu.SetActiveTab(m.store.ActiveTab())
 		m.maybeAutoOpenInitialPane(selected)
-		m.updatePanePreview(selected, attachedNow)
+		previewTab := 0
+		previewTabSpecific := false
+		if sel.IsTab {
+			previewTab = sel.TabIndex
+			previewTabSpecific = true
+		}
+		m.updatePanePreview(selected, previewTab, previewTabSpecific, attachedNow)
 		detachTrace(selectionStart, "selectionChanged-instance-branch-built-cmds")
 		// Lazily refresh PR info when the user lands on an instance that
 		// hasn't been fetched recently. fetchPRInfoCmd is a no-op when the

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -307,6 +307,39 @@ func TestPanePreviewEscFromScrollRevertsOriginalCommittedTab(t *testing.T) {
 		"reset must not pair the committed alpha instance with the preview agent tab")
 }
 
+func TestPanePreviewTabRowCommitsSameInstanceTerminal(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Same(t, alpha, paneA.Instance())
+	require.Equal(t, 0, paneA.Tab(), "precondition: alpha's agent pane is open")
+
+	// Walk the tree cursor onto alpha's terminal tab row. The selected tab is
+	// a full (instance, tab) target, not "any open pane for this instance".
+	pressNav(t, h, "j")
+	pressNav(t, h, "j")
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsTab)
+	require.Equal(t, 1, sel.TabIndex)
+	require.NotNil(t, h.panePreviewTxn)
+	assert.Same(t, alpha, h.panePreviewTxn.target.instance)
+	assert.Equal(t, 1, h.panePreviewTxn.target.tab)
+	assert.Equal(t, 0, paneA.Tab(), "preview remains transient until commit")
+	assert.Contains(t, h.View(), "PREVIEW alpha · Terminal (original alpha · Agent)")
+
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+
+	require.Nil(t, h.panePreviewTxn)
+	assert.Equal(t, 1, h.store.NumOpenPanes(), "commit-replace must not duplicate panes")
+	assert.Same(t, paneA, h.store.FindOpenPane(alpha, 1))
+	assert.Nil(t, h.store.FindOpenPane(alpha, 0),
+		"the already-open agent pane must not be treated as the terminal target")
+	assert.Equal(t, 1, paneA.Tab(), "the focused pane binds the selected terminal tab")
+	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active())
+}
+
 func TestPanePreviewEnterCommitsReplace(t *testing.T) {
 	h := paneTestHome(t)
 	alpha := h.store.GetInstanceByTitle("alpha")

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -32,7 +32,7 @@ func samePaneBinding(a, b paneBinding) bool {
 	return a.instance == b.instance && a.tab == b.tab
 }
 
-func (m *home) updatePanePreview(selected *session.Instance, attachedNow bool) {
+func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabSpecific bool, attachedNow bool) {
 	if attachedNow || m.interactive || selected == nil {
 		m.cancelPanePreview(false)
 		return
@@ -54,10 +54,12 @@ func (m *home) updatePanePreview(selected *session.Instance, attachedNow bool) {
 	if m.panePreviewTxn != nil && m.panePreviewTxn.ownerPaneID == owner.ID() {
 		original = m.panePreviewTxn.original
 	}
-	target := paneBinding{instance: selected, tab: 0}
-	// #1321 is an instance preview, not a tab preview: selecting a different
-	// tab row on the pane's original instance keeps the #1289 divergence header.
-	if original.instance == target.instance {
+	target := paneBinding{instance: selected, tab: targetTab}
+	// Plain instance-row previews stay on the selected instance's agent tab
+	// (#1321). Explicit tab rows, however, name a full (instance, tab) target:
+	// a same-instance terminal tab is distinct from the already-open agent pane.
+	if (!tabSpecific && original.instance == target.instance) ||
+		(tabSpecific && samePaneBinding(original, target)) {
 		m.cancelPanePreview(false)
 		return
 	}


### PR DESCRIPTION
## Summary
- carry tab-row specificity into pane preview targeting
- compare explicit tab-row preview targets by full `(instance, tab)` binding so a same-session terminal tab is not treated as the already-open agent pane
- add regression coverage for agent pane open -> select same session terminal tab -> commit replaces the pane binding with terminal

Fixes #1381.

## Verification
- `make test-container GOTESTARGS="./app -run TestPanePreviewTabRowCommitsSameInstanceTerminal"`
- `make test-container GOTESTARGS="./app -run 'TestPanePreview|TestPane_TabDimension|TestPane_NumberJump'"`\n- `golangci-lint run --fast`\n- `gofmt -l .`\n- `go build ./...`\n- `make lint-file-length`\n- `make test-container`