### PR TITLE
Restart daemon eagerly after upgrade

### DIFF
--- a/autoupdate.go
+++ b/autoupdate.go
@@ -120,28 +120,21 @@ func autoUpdate() error {
 		return fmt.Errorf("failed to write new binary: %w", err)
 	}
 
-	// Same rationale as `af upgrade` (#498): take down the running daemon so
-	// the next RPC respawns it from the freshly written binary. Quiet on the
-	// no-daemon path since autoUpdate runs in the background on every launch.
-	// Pre-#501 daemons don't speak the Shutdown RPC; RequestShutdown falls
-	// back to PID-file-based SIGTERM (#504).
-	result, shutdownErr := requestDaemonShutdownFn()
+	// Same rationale as `af upgrade` (#498/#1386): restart the running daemon
+	// immediately from the freshly written binary. Quiet on the no-daemon path
+	// since autoUpdate runs in the background on every launch. Pre-#501
+	// daemons don't speak the Shutdown RPC; RequestShutdown falls back to
+	// PID-file-based SIGTERM (#504).
+	result, restartErr := restartDaemonFromPath(resolvedPath)
 	switch {
-	case shutdownErr != nil:
-		log.WarningLog.Printf("auto-update: updated to %s but failed to restart daemon: %v", latestVersion, shutdownErr)
+	case restartErr != nil:
+		log.WarningLog.Printf("auto-update: updated to %s but failed to restart daemon: %v", latestVersion, restartErr)
 	case result == daemon.ShutdownViaRPC:
-		log.InfoLog.Printf("auto-update: updated to %s and stopped running daemon", latestVersion)
+		log.InfoLog.Printf("auto-update: updated to %s and restarted running daemon", latestVersion)
 	case result == daemon.ShutdownViaSIGTERM:
-		log.InfoLog.Printf("auto-update: updated to %s and stopped pre-#501 running daemon via SIGTERM fallback", latestVersion)
+		log.InfoLog.Printf("auto-update: updated to %s and restarted pre-#501 running daemon via SIGTERM fallback", latestVersion)
 	default:
 		log.InfoLog.Printf("auto-update: updated to %s (effective on next launch)", latestVersion)
-	}
-	if shutdownErr == nil && result != daemon.ShutdownNoDaemon {
-		// The daemon hosts task schedules and autoyes mode (#782); we just
-		// stopped a running one, so respawn it unconditionally from the
-		// freshly written binary instead of leaving schedules and autoyes
-		// sessions dark until the next af invocation (#813).
-		respawnDaemonFn()
 	}
 	return nil
 }

--- a/autoupdate_test.go
+++ b/autoupdate_test.go
@@ -257,7 +257,12 @@ func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
 	})
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonFn = func() { respawnCalls++ }
+	var respawnPath string
+	respawnDaemonFn = func(path string) error {
+		respawnCalls++
+		respawnPath = path
+		return nil
+	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 
 	runtimeGOOS = "linux"
@@ -280,6 +285,9 @@ func TestAutoUpdateCallsShutdownAfterBinarySwap(t *testing.T) {
 	}
 	if respawnCalls != 1 {
 		t.Fatalf("expected the daemon respawn check to run once after shutdown, got %d", respawnCalls)
+	}
+	if respawnPath != tempBin {
+		t.Fatalf("daemon respawn path = %q, want %q", respawnPath, tempBin)
 	}
 	got, err := os.ReadFile(tempBin)
 	if err != nil {
@@ -327,7 +335,10 @@ func TestAutoUpdateSucceedsWhenShutdownErrors(t *testing.T) {
 	})
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonFn = func() { respawnCalls++ }
+	respawnDaemonFn = func(string) error {
+		respawnCalls++
+		return nil
+	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 
 	runtimeGOOS = "linux"
@@ -703,7 +714,7 @@ func TestAutoUpdateDownloadsByTag(t *testing.T) {
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
 		return daemon.ShutdownNoDaemon, nil
 	}
-	respawnDaemonFn = func() {}
+	respawnDaemonFn = func(string) error { return nil }
 
 	if err := autoUpdate(); err != nil {
 		t.Fatalf("autoUpdate: %v", err)

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -51,6 +51,21 @@ func DaemonSocketPath() (string, error) {
 
 // EnsureDaemon starts the daemon if the control socket is not already serving.
 func EnsureDaemon() error {
+	return ensureDaemonWithLauncher(launchDaemonProcessFn)
+}
+
+// EnsureDaemonFromPath starts the daemon from execPath if the control socket is
+// not already serving. It is used by post-upgrade restart paths after the
+// current process's executable may have been replaced on disk: asking the
+// still-running old process for os.Executable can resolve to a deleted inode,
+// while execPath is the freshly written binary path the new daemon must run.
+func EnsureDaemonFromPath(execPath string) error {
+	return ensureDaemonWithLauncher(func() error {
+		return launchDaemonProcessAt(execPath)
+	})
+}
+
+func ensureDaemonWithLauncher(launch func() error) error {
 	ensureDaemonMu.Lock()
 	defer ensureDaemonMu.Unlock()
 
@@ -65,7 +80,7 @@ func EnsureDaemon() error {
 		log.WarningLog.Printf("failed to stop stale daemon before launch: %v", err)
 	}
 
-	if err := launchDaemonProcessFn(); err != nil {
+	if err := launch(); err != nil {
 		return err
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -457,6 +457,10 @@ func launchDaemonProcess() error {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
 
+	return launchDaemonProcessAt(execPath)
+}
+
+func launchDaemonProcessAt(execPath string) error {
 	pid, err := startDaemonChild(execPath)
 	if err != nil {
 		return err

--- a/daemoncmd.go
+++ b/daemoncmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/daemon"
@@ -177,10 +178,58 @@ machine-readable form wrapped in the shared {data,error} envelope.`,
 	},
 }
 
+// daemonRestartQuiet suppresses the "no daemon" no-op line. The install
+// scripts use this so fresh installs stay quiet while real restarts still
+// print a confirmation.
+var daemonRestartQuiet bool
+
+var daemonRestartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restart the running daemon without stopping live sessions",
+	Long: `Restart the background daemon if one is running. Live sessions keep running
+in tmux; the new daemon re-adopts persisted session state on startup. If no
+daemon is running, this command exits successfully without starting one.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		execPath, err := osExecutableFn()
+		if err != nil {
+			return fmt.Errorf("failed to find current executable: %w", err)
+		}
+		resolvedPath, err := filepath.EvalSymlinks(execPath)
+		if err != nil {
+			return fmt.Errorf("failed to resolve executable path: %w", err)
+		}
+
+		result, err := restartDaemonFromPath(resolvedPath)
+		if err != nil {
+			return err
+		}
+
+		w := cmd.OutOrStdout()
+		switch result {
+		case daemon.ShutdownNoDaemon:
+			if !daemonRestartQuiet {
+				fmt.Fprintln(w, "no running daemon to restart")
+			}
+		case daemon.ShutdownViaSIGTERM:
+			fmt.Fprintln(w, "daemon restarted (stopped old daemon via SIGTERM fallback)")
+		default:
+			fmt.Fprintln(w, "daemon restarted")
+		}
+		return nil
+	},
+}
+
 func init() {
 	daemonStatusCmd.Flags().BoolVar(&daemonStatusJSON, "json", false,
 		"Emit the status as JSON wrapped in the {data,error} envelope")
+	daemonRestartCmd.Flags().BoolVar(&daemonRestartQuiet, "quiet", false,
+		"Suppress output when no daemon is running")
 	daemonCmd.AddCommand(daemonInstallCmd)
+	daemonCmd.AddCommand(daemonRestartCmd)
 	daemonCmd.AddCommand(daemonUninstallCmd)
 	daemonCmd.AddCommand(daemonStatusCmd)
 }
@@ -195,9 +244,23 @@ var respawnDaemonFn = respawnDaemonAfterUpgrade
 var (
 	autostartInstalledFn        = daemon.AutostartInstalled
 	restartAutostartUnitFn      = daemon.RestartAutostartUnit
-	ensureDaemonFn              = daemon.EnsureDaemon
+	ensureDaemonFromPathFn      = daemon.EnsureDaemonFromPath
 	waitForShutdownCompletionFn = daemon.WaitForShutdownCompletion
 )
+
+func restartDaemonFromPath(execPath string) (daemon.ShutdownResult, error) {
+	result, shutdownErr := requestDaemonShutdownFn()
+	if shutdownErr != nil {
+		return result, fmt.Errorf("failed to stop running daemon: %w", shutdownErr)
+	}
+	if result == daemon.ShutdownNoDaemon {
+		return result, nil
+	}
+	if err := respawnDaemonFn(execPath); err != nil {
+		return result, fmt.Errorf("failed to restart daemon: %w", err)
+	}
+	return result, nil
+}
 
 // respawnDaemonAfterUpgrade restores the daemon that the upgrade/auto-update
 // path just stopped. The Shutdown RPC is a clean exit, and the autostart unit
@@ -215,7 +278,7 @@ var (
 // left autoyes-only users without a daemon until the next af run (#813). The
 // task gate belongs only on the cold-start path (ensureDaemonForTasks), where
 // nothing was running and "no enabled tasks" means there is nothing to start.
-func respawnDaemonAfterUpgrade() {
+func respawnDaemonAfterUpgrade(execPath string) error {
 	// The Shutdown RPC acks before the daemon tears down, so the old daemon's
 	// control socket can still answer pings here. Respawning into that window
 	// makes EnsureDaemon — or the unit-restarted daemon's own startup ping
@@ -228,17 +291,24 @@ func respawnDaemonAfterUpgrade() {
 	if err := waitForShutdownCompletionFn(); err != nil {
 		log.WarningLog.Printf("post-upgrade respawn: %v; respawning anyway, but the new daemon may see the old one as alive and exit — run af again if schedules stay dark", err)
 	}
+	var unitErr error
 	if autostartInstalledFn() {
 		err := restartAutostartUnitFn()
 		if err == nil {
 			log.InfoLog.Printf("restarted the daemon autostart unit from the new binary")
-			return
+			return nil
 		}
+		unitErr = err
 		log.WarningLog.Printf("failed to restart the daemon autostart unit; falling back to an ad-hoc daemon: %v", err)
 	}
-	if err := ensureDaemonFn(); err != nil {
+	if err := ensureDaemonFromPathFn(execPath); err != nil {
 		log.ErrorLog.Printf("failed to respawn daemon after upgrade: %v", err)
+		if unitErr != nil {
+			return fmt.Errorf("unit restart failed: %w; ad-hoc fallback failed: %v", unitErr, err)
+		}
+		return err
 	}
+	return nil
 }
 
 // ensureDaemonForTasks starts the daemon when any enabled task exists, so

--- a/daemoncmd_test.go
+++ b/daemoncmd_test.go
@@ -3,10 +3,14 @@ package main
 import (
 	"errors"
 	"testing"
+
+	"github.com/sachiniyer/agent-factory/daemon"
 )
 
+const testUpgradeDaemonPath = "/tmp/af-upgraded"
+
 // Tests for the unit-aware upgrade respawn (#796) and the unconditional
-// fallback (#813). All three collaborators are stubbed so nothing here
+// fallback (#813). All collaborators are stubbed so nothing here
 // touches the real systemctl/launchctl or spawns a daemon process — a real
 // supervised daemon may be running on the machine executing these tests.
 
@@ -20,12 +24,12 @@ func stubRespawnCollaborators(t *testing.T, installed bool, restartErr error) (r
 	t.Helper()
 	prevInstalled := autostartInstalledFn
 	prevRestart := restartAutostartUnitFn
-	prevEnsure := ensureDaemonFn
+	prevEnsure := ensureDaemonFromPathFn
 	prevWait := waitForShutdownCompletionFn
 	t.Cleanup(func() {
 		autostartInstalledFn = prevInstalled
 		restartAutostartUnitFn = prevRestart
-		ensureDaemonFn = prevEnsure
+		ensureDaemonFromPathFn = prevEnsure
 		waitForShutdownCompletionFn = prevWait
 	})
 	restartCalls = new(int)
@@ -35,7 +39,7 @@ func stubRespawnCollaborators(t *testing.T, installed bool, restartErr error) (r
 		*restartCalls++
 		return restartErr
 	}
-	ensureDaemonFn = func() error {
+	ensureDaemonFromPathFn = func(string) error {
 		*ensureCalls++
 		return nil
 	}
@@ -50,7 +54,9 @@ func stubRespawnCollaborators(t *testing.T, installed bool, restartErr error) (r
 func TestRespawnAfterUpgradeRestartsInstalledUnit(t *testing.T) {
 	restartCalls, ensureCalls := stubRespawnCollaborators(t, true, nil)
 
-	respawnDaemonAfterUpgrade()
+	if err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
+	}
 
 	if *restartCalls != 1 {
 		t.Fatalf("unit restarts = %d, want 1", *restartCalls)
@@ -65,7 +71,9 @@ func TestRespawnAfterUpgradeRestartsInstalledUnit(t *testing.T) {
 func TestRespawnAfterUpgradeWithoutUnitSpawnsAdHoc(t *testing.T) {
 	restartCalls, ensureCalls := stubRespawnCollaborators(t, false, nil)
 
-	respawnDaemonAfterUpgrade()
+	if err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
+	}
 
 	if *restartCalls != 0 {
 		t.Fatalf("unit restarts = %d, want 0 when no unit is installed", *restartCalls)
@@ -81,7 +89,9 @@ func TestRespawnAfterUpgradeWithoutUnitSpawnsAdHoc(t *testing.T) {
 func TestRespawnAfterUpgradeFallsBackWhenRestartFails(t *testing.T) {
 	restartCalls, ensureCalls := stubRespawnCollaborators(t, true, errors.New("systemctl exited 1"))
 
-	respawnDaemonAfterUpgrade()
+	if err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
+	}
 
 	if *restartCalls != 1 {
 		t.Fatalf("unit restarts = %d, want 1", *restartCalls)
@@ -102,10 +112,29 @@ func TestRespawnAfterUpgradeSpawnsWithZeroEnabledTasks(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	_, ensureCalls := stubRespawnCollaborators(t, false, nil)
 
-	respawnDaemonAfterUpgrade()
+	if err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
+	}
 
 	if *ensureCalls != 1 {
 		t.Fatalf("ad-hoc spawns = %d, want 1 even with zero enabled tasks (autoyes-only daemon must be restored, #813)", *ensureCalls)
+	}
+}
+
+func TestRespawnAfterUpgradeSpawnsAdHocFromProvidedPath(t *testing.T) {
+	stubRespawnCollaborators(t, false, nil)
+	var gotPath string
+	ensureDaemonFromPathFn = func(path string) error {
+		gotPath = path
+		return nil
+	}
+
+	if err := respawnDaemonAfterUpgrade("/opt/af/new"); err != nil {
+		t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
+	}
+
+	if gotPath != "/opt/af/new" {
+		t.Fatalf("ad-hoc respawn path = %q, want /opt/af/new", gotPath)
 	}
 }
 
@@ -134,21 +163,75 @@ func TestRespawnAfterUpgradeWaitsForShutdownFirst(t *testing.T) {
 				seq = append(seq, "wait")
 				return tc.waitErr
 			}
-			prevRestart, prevEnsure := restartAutostartUnitFn, ensureDaemonFn
+			prevRestart, prevEnsure := restartAutostartUnitFn, ensureDaemonFromPathFn
 			restartAutostartUnitFn = func() error {
 				seq = append(seq, "restart")
 				return prevRestart()
 			}
-			ensureDaemonFn = func() error {
+			ensureDaemonFromPathFn = func(path string) error {
 				seq = append(seq, "ensure")
-				return prevEnsure()
+				return prevEnsure(path)
 			}
 
-			respawnDaemonAfterUpgrade()
+			if err := respawnDaemonAfterUpgrade(testUpgradeDaemonPath); err != nil {
+				t.Fatalf("respawnDaemonAfterUpgrade: %v", err)
+			}
 
 			if len(seq) != 2 || seq[0] != "wait" || seq[1] != tc.wantStep {
 				t.Fatalf("call sequence = %v, want [wait %s]", seq, tc.wantStep)
 			}
 		})
+	}
+}
+
+func TestRestartDaemonFromPathNoDaemonIsNoOp(t *testing.T) {
+	prevShutdown := requestDaemonShutdownFn
+	prevRespawn := respawnDaemonFn
+	t.Cleanup(func() {
+		requestDaemonShutdownFn = prevShutdown
+		respawnDaemonFn = prevRespawn
+	})
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
+		return daemon.ShutdownNoDaemon, nil
+	}
+	respawnDaemonFn = func(string) error {
+		t.Fatalf("respawn must not run when no daemon is present")
+		return nil
+	}
+
+	result, err := restartDaemonFromPath(testUpgradeDaemonPath)
+	if err != nil {
+		t.Fatalf("restartDaemonFromPath: %v", err)
+	}
+	if result != daemon.ShutdownNoDaemon {
+		t.Fatalf("restart result = %v, want ShutdownNoDaemon", result)
+	}
+}
+
+func TestRestartDaemonFromPathRespawnsStoppedDaemon(t *testing.T) {
+	prevShutdown := requestDaemonShutdownFn
+	prevRespawn := respawnDaemonFn
+	t.Cleanup(func() {
+		requestDaemonShutdownFn = prevShutdown
+		respawnDaemonFn = prevRespawn
+	})
+	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
+		return daemon.ShutdownViaRPC, nil
+	}
+	var gotPath string
+	respawnDaemonFn = func(path string) error {
+		gotPath = path
+		return nil
+	}
+
+	result, err := restartDaemonFromPath("/opt/af/current")
+	if err != nil {
+		t.Fatalf("restartDaemonFromPath: %v", err)
+	}
+	if result != daemon.ShutdownViaRPC {
+		t.Fatalf("restart result = %v, want ShutdownViaRPC", result)
+	}
+	if gotPath != "/opt/af/current" {
+		t.Fatalf("respawn path = %q, want /opt/af/current", gotPath)
 	}
 }

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -17,5 +17,10 @@ chmod +x "${BIN_DIR}/${BINARY_NAME}"
 
 echo "Installed successfully: $(${BIN_DIR}/${BINARY_NAME} version 2>/dev/null || echo "${BIN_DIR}/${BINARY_NAME}")"
 
+if ! "${BIN_DIR}/${BINARY_NAME}" daemon restart --quiet; then
+	echo "warning: installed af, but failed to restart the running daemon" >&2
+	echo "         run '${BIN_DIR}/${BINARY_NAME} daemon restart' to retry" >&2
+fi
+
 echo ""
 echo "Setup complete!"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,11 +70,17 @@ The background daemon hosts task cron schedules, watch-task scripts, and autoyes
 
 ```bash
 af daemon install      # register autostart at login
+af daemon restart      # restart a running daemon and re-adopt live sessions
 af daemon uninstall    # remove the autostart unit (the daemon still starts on demand)
 af daemon status       # read-only health snapshot: running?, socket paths, pid, autostart (+ --json)
 ```
 
 `af daemon status` uses the same no-spawn probe as `af doctor` — it reports whether the daemon answers on the control socket, the control/HTTP socket paths and file presence, the recorded (and verified) pid, whether the autostart unit is installed, and whether a running daemon is on a since-replaced binary. It never dials in a way that starts a daemon.
+
+`af daemon restart` is safe to run after replacing the `af` binary. It asks a
+running daemon to shut down cleanly, restarts the autostart unit when one is
+installed, otherwise starts an ad-hoc daemon from the current binary. If no
+daemon is running, it exits successfully without starting one.
 
 ## `af config`
 

--- a/docs/concepts/daemon.md
+++ b/docs/concepts/daemon.md
@@ -58,12 +58,15 @@ daemon's autostart unit once:
 ```bash
 af daemon install     # systemd user service on Linux, launchd agent on macOS
 af daemon status      # liveness, sockets, pid, and autostart state
+af daemon restart     # restart the daemon process; sessions are re-adopted
 af daemon uninstall   # remove the autostart unit
 ```
 
 Because the daemon owns live state, you don't stop it by force while sessions
-are running; let `af` manage its lifecycle. `af daemon status` is the right tool
-when you want to know whether it's up and where its sockets are.
+are running; let `af` manage its lifecycle. `af daemon restart` restarts only
+the daemon process and re-adopts existing tmux sessions from persisted state.
+`af daemon status` is the right tool when you want to know whether it's up and
+where its sockets are.
 
 ## Sockets
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -22,6 +22,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af config set`](#af-config-set) — Set a single settable global config key
 - [`af daemon`](#af-daemon) — Manage the background daemon that schedules tasks
 - [`af daemon install`](#af-daemon-install) — Register the daemon to start automatically at login
+- [`af daemon restart`](#af-daemon-restart) — Restart the running daemon without stopping live sessions
 - [`af daemon status`](#af-daemon-status) — Report daemon liveness, sockets, pid, and autostart
 - [`af daemon uninstall`](#af-daemon-uninstall) — Remove the daemon autostart unit
 - [`af debug`](#af-debug) — Print debug information like config paths
@@ -399,6 +400,7 @@ af daemon
 **Subcommands**
 
 - [`af daemon install`](#af-daemon-install) — Register the daemon to start automatically at login
+- [`af daemon restart`](#af-daemon-restart) — Restart the running daemon without stopping live sessions
 - [`af daemon status`](#af-daemon-status) — Report daemon liveness, sockets, pid, and autostart
 - [`af daemon uninstall`](#af-daemon-uninstall) — Remove the daemon autostart unit
 
@@ -409,6 +411,24 @@ Register the daemon to start automatically at login
 ```
 af daemon install
 ```
+
+## af daemon restart
+
+Restart the running daemon without stopping live sessions
+
+Restart the background daemon if one is running. Live sessions keep running
+in tmux; the new daemon re-adopts persisted session state on startup. If no
+daemon is running, this command exits successfully without starting one.
+
+```
+af daemon restart [flags]
+```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--quiet` |  | Suppress output when no daemon is running |
 
 ## af daemon status
 

--- a/install.sh
+++ b/install.sh
@@ -147,6 +147,11 @@ echo "Installed af to $INSTALL_DIR/af"
 installed_version="$("$INSTALL_DIR/af" version 2>/dev/null || echo "unknown")"
 echo "Version: $installed_version"
 
+if ! "$INSTALL_DIR/af" daemon restart --quiet; then
+	echo "warning: installed af, but failed to restart the running daemon" >&2
+	echo "         run '$INSTALL_DIR/af daemon restart' to retry" >&2
+fi
+
 case ":$PATH:" in
 	*":$INSTALL_DIR:"*)
 		echo "Next:"

--- a/release_scripts_test.go
+++ b/release_scripts_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -146,5 +147,146 @@ func TestValidateStableVersionScript(t *testing.T) {
 		if ok := err == nil; ok != c.wantOK {
 			t.Errorf("%s: validate %q ok=%v, want ok=%v (err: %v)", c.name, c.version, ok, c.wantOK, err)
 		}
+	}
+}
+
+func TestInstallScriptRestartsDaemonWithInstalledBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh is POSIX sh; not run on Windows")
+	}
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "fakebin")
+	installDir := filepath.Join(dir, "install")
+	callsFile := filepath.Join(dir, "af-calls")
+
+	writeExecutable(t, filepath.Join(fakeBin, "curl"), `#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-o" ]; then
+		out="$2"
+		break
+	fi
+	shift
+done
+[ -n "$out" ] || exit 2
+printf fake-tarball > "$out"
+`)
+	writeExecutable(t, filepath.Join(fakeBin, "tar"), `#!/bin/sh
+case "$1" in
+	tzf)
+		exit 0
+		;;
+	xzf)
+		outdir=
+		shift 2
+		while [ "$#" -gt 0 ]; do
+			if [ "$1" = "-C" ]; then
+				outdir="$2"
+				break
+			fi
+			shift
+		done
+		[ -n "$outdir" ] || exit 2
+		cat > "$outdir/agent-factory" <<'AF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$AF_FAKE_AF_CALLS"
+if [ "$1" = "version" ]; then
+	echo "agent-factory version fake"
+fi
+exit 0
+AF
+		chmod +x "$outdir/agent-factory"
+		;;
+	*)
+		exit 2
+		;;
+esac
+`)
+
+	cmd := exec.Command("sh", "install.sh", "--version", "v9.9.9")
+	cmd.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AF_INSTALL_DIR="+installDir,
+		"AF_FAKE_AF_CALLS="+callsFile,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install.sh failed: %v\n%s", err, out)
+	}
+
+	assertScriptRestartCall(t, callsFile)
+}
+
+func TestDevInstallScriptRestartsDaemonWithInstalledBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("dev-install.sh is POSIX sh; not run on Windows")
+	}
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "fakebin")
+	installDir := filepath.Join(dir, "install")
+	callsFile := filepath.Join(dir, "af-calls")
+
+	writeExecutable(t, filepath.Join(fakeBin, "go"), `#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+	if [ "$1" = "-o" ]; then
+		out="$2"
+		break
+	fi
+	shift
+done
+[ -n "$out" ] || exit 2
+cat > "$out" <<'AF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$AF_FAKE_AF_CALLS"
+if [ "$1" = "version" ]; then
+	echo "agent-factory version fake"
+fi
+exit 0
+AF
+chmod +x "$out"
+`)
+
+	scriptPath, err := filepath.Abs("dev-install.sh")
+	if err != nil {
+		t.Fatalf("resolve dev-install.sh: %v", err)
+	}
+	cmd := exec.Command("sh", scriptPath)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"BIN_DIR="+installDir,
+		"AF_FAKE_AF_CALLS="+callsFile,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dev-install.sh failed: %v\n%s", err, out)
+	}
+
+	assertScriptRestartCall(t, callsFile)
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir fake tool dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("write fake tool %s: %v", path, err)
+	}
+}
+
+func assertScriptRestartCall(t *testing.T, callsFile string) {
+	t.Helper()
+	raw, err := os.ReadFile(callsFile)
+	if err != nil {
+		t.Fatalf("read fake af calls: %v", err)
+	}
+	calls := string(raw)
+	if !strings.Contains(calls, "version\n") {
+		t.Fatalf("installed af version command was not called; calls:\n%s", calls)
+	}
+	if !strings.Contains(calls, "daemon restart --quiet\n") {
+		t.Fatalf("installed af daemon restart --quiet was not called; calls:\n%s", calls)
 	}
 }

--- a/upgrade.go
+++ b/upgrade.go
@@ -21,8 +21,8 @@ import (
 // requestDaemonShutdownFn is indirected so tests can stub the daemon
 // shutdown call without standing up a real control socket. The production
 // implementation contacts the local control plane (#436) and asks any
-// running daemon to exit so the next RPC respawns from the freshly written
-// binary (#498).
+// running daemon to exit before the upgrade path respawns it from the freshly
+// written binary (#498/#1386).
 var requestDaemonShutdownFn = daemon.RequestShutdown
 
 // osExecutableFn is indirected so tests can point the upgrade flow at a
@@ -214,30 +214,22 @@ func runUpgrade(downloadURL string) error {
 		return fmt.Errorf("failed to write new binary: %w", err)
 	}
 
-	// The running daemon process still references the old binary's inode
-	// on Linux, so users would keep running the stale image until they
-	// killed it manually. Ask any running daemon to exit; the next `af`
-	// invocation will EnsureDaemon-respawn from the new binary (#498).
-	// Pre-#501 daemons don't speak the Shutdown RPC, so RequestShutdown
-	// falls back to PID-file-based SIGTERM (#504).
-	result, shutdownErr := requestDaemonShutdownFn()
+	// The running daemon process still references the old binary's inode on
+	// Linux, so users would keep running the stale image until they killed it
+	// manually. Restart any running daemon now from the freshly written binary
+	// (#498/#1386). Pre-#501 daemons don't speak the Shutdown RPC, so
+	// RequestShutdown falls back to PID-file-based SIGTERM (#504).
+	result, restartErr := restartDaemonFromPath(resolvedPath)
 	switch {
-	case shutdownErr != nil:
-		fmt.Printf("Upgraded successfully! Failed to restart the running daemon: %v\n", shutdownErr)
+	case restartErr != nil:
+		fmt.Printf("Upgraded successfully! Failed to restart the running daemon: %v\n", restartErr)
 		fmt.Println("Stop the daemon manually (e.g. `af reset`) or kill the `--daemon` process to pick up the new binary.")
 	case result == daemon.ShutdownViaRPC:
-		fmt.Println("Upgraded successfully! Stopped the running daemon; it will respawn from the new binary on next use.")
+		fmt.Println("Upgraded successfully! Restarted the running daemon from the new binary.")
 	case result == daemon.ShutdownViaSIGTERM:
-		fmt.Println("Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM); it will respawn from the new binary on next use.")
+		fmt.Println("Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM) and restarted it from the new binary.")
 	default:
 		fmt.Println("Upgraded successfully!")
-	}
-	if shutdownErr == nil && result != daemon.ShutdownNoDaemon {
-		// The daemon hosts task schedules and autoyes mode (#782); we just
-		// stopped a running one, so respawn it unconditionally from the
-		// freshly written binary instead of leaving schedules and autoyes
-		// sessions dark until the next af invocation (#813).
-		respawnDaemonFn()
 	}
 	return nil
 }

--- a/upgrade_test.go
+++ b/upgrade_test.go
@@ -219,7 +219,12 @@ func TestUpgradeCallsShutdownAfterBinarySwap(t *testing.T) {
 	})
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonFn = func() { respawnCalls++ }
+	var respawnPath string
+	respawnDaemonFn = func(path string) error {
+		respawnCalls++
+		respawnPath = path
+		return nil
+	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	shutdownCalls := 0
@@ -236,6 +241,9 @@ func TestUpgradeCallsShutdownAfterBinarySwap(t *testing.T) {
 	}
 	if respawnCalls != 1 {
 		t.Fatalf("expected the daemon respawn check to run once after shutdown, got %d", respawnCalls)
+	}
+	if respawnPath != tempBin {
+		t.Fatalf("daemon respawn path = %q, want %q", respawnPath, tempBin)
 	}
 	got, err := os.ReadFile(tempBin)
 	if err != nil {
@@ -270,7 +278,10 @@ func TestUpgradeSucceedsWhenNoDaemon(t *testing.T) {
 	})
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonFn = func() { respawnCalls++ }
+	respawnDaemonFn = func(string) error {
+		respawnCalls++
+		return nil
+	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
@@ -317,7 +328,10 @@ func TestUpgradeSucceedsWhenShutdownErrors(t *testing.T) {
 	})
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonFn = func() { respawnCalls++ }
+	respawnDaemonFn = func(string) error {
+		respawnCalls++
+		return nil
+	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
@@ -360,7 +374,12 @@ func TestUpgradeReportsSIGTERMFallback(t *testing.T) {
 	})
 	prevRespawn := respawnDaemonFn
 	respawnCalls := 0
-	respawnDaemonFn = func() { respawnCalls++ }
+	var respawnPath string
+	respawnDaemonFn = func(path string) error {
+		respawnCalls++
+		respawnPath = path
+		return nil
+	}
 	t.Cleanup(func() { respawnDaemonFn = prevRespawn })
 	osExecutableFn = func() (string, error) { return tempBin, nil }
 	requestDaemonShutdownFn = func() (daemon.ShutdownResult, error) {
@@ -389,6 +408,12 @@ func TestUpgradeReportsSIGTERMFallback(t *testing.T) {
 	want := "Upgraded successfully! Stopped the running daemon (pre-fix; used SIGTERM)"
 	if !strings.Contains(got, want) {
 		t.Fatalf("runUpgrade stdout missing SIGTERM-fallback message.\n got=%q\nwant substring=%q", got, want)
+	}
+	if respawnCalls != 1 {
+		t.Fatalf("expected the daemon respawn check to run once after SIGTERM fallback, got %d", respawnCalls)
+	}
+	if respawnPath != tempBin {
+		t.Fatalf("daemon respawn path = %q, want %q", respawnPath, tempBin)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add public `af daemon restart` that no-ops when no daemon is running and otherwise uses the existing graceful shutdown + unit-aware respawn path
- make `af upgrade` and background auto-update respawn ad-hoc daemons from the resolved post-install binary path instead of the replaced process executable
- have `install.sh` and `dev-install.sh` call the newly installed `af daemon restart --quiet` after moving the binary, warning without failing if daemon restart coordination fails
- update daemon docs/generated CLI reference and add fake-tool script tests

Closes #1386

## Test Plan

- [x] `gofmt -l .`
- [x] `go build ./...`
- [x] `golangci-lint run --timeout=3m --fast`
- [x] `scripts/lint-file-length.sh`
- [x] `make test-container`
- [ ] Manual daemon restart/re-adoption verification by root before merge

No TUI-driver run; this change touches daemon/startup lifecycle and root will verify re-adoption manually.