### PR TITLE
Add Captain Claude workflow skills

### DIFF
--- a/.claude/skills/cut-release.md
+++ b/.claude/skills/cut-release.md
@@ -1,0 +1,60 @@
+---
+name: cut-release
+description: Cut stable releases from verified merged work and confirm preview releases continue
+user_invocable: true
+---
+
+# Cut Stable Release
+
+Cut a stable release when meaningful verified work has accumulated since the
+last stable release. Patch releases are the maintainer's lever; minor
+`1.x.0` releases are Sachin's lever and require asking him first.
+
+## Steps
+
+1. **Find the latest releases** — compare the last stable release with preview
+   releases:
+   ```bash
+   gh release list --limit 20
+   ```
+
+   Identify the latest stable `1.0.<patch>` release and the newest preview
+   release. Use the stable release date as the starting point for the merge
+   count.
+
+2. **Count merged PRs since the last stable**:
+   ```bash
+   gh pr list --state merged --base master --limit 100 \
+     --search "merged:>YYYY-MM-DD" \
+     --json number,title,mergedAt,author
+   ```
+
+   Cut a stable release when the merged work is meaningful and already
+   verified. Security fixes and data-loss fixes warrant a prompt stable
+   release even if the batch is small.
+
+3. **Choose the next version** — increment only the patch component:
+   ```bash
+   gh workflow run "Stable Release" -f version=1.0.<next>
+   ```
+
+   Do not cut a `1.x.0` minor release without Sachin's explicit direction.
+
+4. **Watch the stable workflow to completion**:
+   ```bash
+   gh run list --workflow "Stable Release" --limit 5
+   gh run watch <run-id>
+   ```
+
+   If the run fails, inspect the logs and fix or escalate before announcing
+   the release.
+
+5. **Confirm preview releases still cut** — check the `Auto Preview Release`
+   workflow and the latest preview release:
+   ```bash
+   gh run list --workflow "Auto Preview Release" --limit 5
+   gh release list --limit 20
+   ```
+
+   A stable release is not done until the stable workflow has completed and
+   the preview auto-release path still looks healthy.

--- a/.claude/skills/decompose-file.md
+++ b/.claude/skills/decompose-file.md
@@ -1,0 +1,58 @@
+---
+name: decompose-file
+description: Decompose one oversized file from a fresh master branch without stacking or logic changes
+user_invocable: true
+---
+
+# Decompose File
+
+Use the #1195 Phase 3 process to split one oversized file into cohesive files.
+Each PR handles exactly one file, starts fresh from current `master`, and
+merges before the next file begins.
+
+## Steps
+
+1. **Start fresh from master** — never stack on another PR branch:
+   ```bash
+   git fetch origin master
+   git checkout -B phase-<file> origin/master
+   ```
+
+2. **Split by responsibility** — move cohesive types, helpers, tests, or
+   command groups into clearly named files. Keep package boundaries and public
+   behavior unchanged.
+
+3. **Keep it pure move** — do not make logic changes in the decomposition PR.
+   Verify moved function bodies exactly match the original source. If you find
+   a bug or cleanup while moving code, open a follow-up PR after the
+   decomposition merges.
+
+4. **Check for accidental stacking before pushing**:
+   ```bash
+   git diff --stat origin/master
+   ```
+
+   Confirm the stat lists only the original oversized file, its split files,
+   and any expected `scripts/file-length-allowlist.txt` or docs changes. If
+   any other file appears, the branch started from a stale base or another PR;
+   redo it from current `origin/master`.
+
+5. **Ratchet the allowlist** — reduce or remove the file's entry in
+   `scripts/file-length-allowlist.txt`. Prefer removing the entry entirely
+   when the split brings the file below the lint threshold.
+
+6. **Run the gates**:
+   ```bash
+   gofmt -w <changed-go-files>
+   go build ./...
+   make test-container
+   scripts/lint-file-length.sh
+   deadcode -test ./...
+   ```
+
+   If the change is TUI-visible, also play-test the affected flow before
+   opening the PR.
+
+7. **Open one PR against master** — base the PR on `master`, explain that it
+   is a pure decomposition, and merge it before starting the next file. The
+   allowlist is a shared conflict point, so serialize this work.

--- a/.claude/skills/dispatch-af-session.md
+++ b/.claude/skills/dispatch-af-session.md
@@ -1,0 +1,81 @@
+---
+name: dispatch-af-session
+description: Dispatch and manage af sessions for Captain Claude issue work with safe prompts and root notification
+user_invocable: true
+---
+
+# Dispatch AF Session
+
+Dispatch focused implementation work to an `af` session with the standard
+Captain Claude contract. Root verifies and merges; worker sessions do not.
+
+## Steps
+
+1. **Create a complete prompt** — every dispatch prompt carries the same
+   contract:
+   ```text
+   Verify first: if this is already fixed on master, close the issue as stale
+   and report that status.
+
+   Task: <specific implementation request>
+
+   Do NOT merge. Root verifies the PR.
+
+   Gates:
+   - go build ./...
+   - make test-container
+   - scripts/lint-file-length.sh
+   - <any task-specific gate>
+
+   Sign the PR as Captain Claude.
+   Include: Closes #<n>
+
+   NOTIFY ROOT:
+   af sessions send-prompt root "DONE <name>: <PR#/status>"
+   ```
+
+   If the notification message contains backticks, write it to a temp file and
+   pass the file contents to `af sessions send-prompt`; inline backticks can
+   shell-execute in root's repo:
+   ```bash
+   tmp="$(mktemp)"
+   printf '%s\n' 'DONE <name>: PR #<n> (`make test-container` passed)' > "$tmp"
+   af sessions send-prompt root "$(cat "$tmp")"
+   rm -f "$tmp"
+   ```
+
+2. **Include box-safety rules** — every prompt must say:
+   - No bare host `go test`; use `make test-container` only.
+   - Never run `scripts/tui-driver.sh` against a real repo (#1303).
+   - No sub-sessions.
+   - No dev-install.
+
+3. **Send or create the session**:
+   ```bash
+   af sessions send-prompt <name> "<prompt>" --create
+   ```
+
+   Use a unique session name that identifies the issue or slice. Keep the
+   prompt self-contained because the receiving agent inherits no root context.
+
+4. **Expect work to completion** — after notifying root, the worker should
+   continue to the next assigned slice when one exists. It should not idle
+   just because the first PR is open.
+
+5. **Run the idle sweep** — periodically inspect sessions for stale, blocked,
+   or completed work:
+   ```bash
+   af sessions list
+   af sessions preview <name>
+   ```
+
+   Re-prompt sessions that have stopped without a root notification. Archive or
+   kill only when the session is genuinely done or unrecoverable.
+
+6. **Reap completed sessions** — once all PRs for a session's ticket have
+   merged, clean up the session and its worktree:
+   ```bash
+   af sessions kill <name>
+   ```
+
+   Do not reap a session while any of its PRs are still under review.

--- a/.claude/skills/gate-pr.md
+++ b/.claude/skills/gate-pr.md
@@ -1,0 +1,71 @@
+---
+name: gate-pr
+description: Review and gate Captain Claude pull requests through CI, Greptile, play-test, and squash merge
+user_invocable: true
+---
+
+# Gate Pull Request
+
+Review a PR authored by `sachiniyer` or `app/detail-app`, verify it is truly
+ready, and merge it only after the required gates pass. Detail dead-code PRs
+from `app/detail-app` may auto-merge once the gates are clean.
+
+## Steps
+
+1. **Fetch the PR state** — inspect the base branch, author, merge state, and
+   check rollup:
+   ```bash
+   gh pr view <n> --json number,title,url,author,baseRefName,headRefName,mergeStateStatus,statusCheckRollup
+   gh pr checks <n> --watch
+   ```
+
+   - Gate only PRs authored by `sachiniyer` or `app/detail-app`.
+   - Require `baseRefName` to be `master`.
+   - Require `mergeStateStatus` to be mergeable or clean enough to merge.
+   - Inspect `statusCheckRollup` for failing and pending checks.
+   - CodeQL can report mid-run non-success states; only a completed
+     conclusion is real. Do not fail a PR on an in-progress CodeQL state.
+
+2. **Require green CI** — do not merge while any required signal is red or
+   pending:
+   - No `FAILURE` conclusions.
+   - Zero pending checks.
+   - No missing required check that is expected to report.
+
+3. **Gate Greptile** — require one of these outcomes:
+   - Greptile Confidence `5/5`.
+   - Greptile Confidence `4/5` with zero unresolved inline findings.
+
+   If a Greptile finding is valid, route it back to the authoring session and
+   stop. Do not merge a PR with a valid unresolved finding.
+
+4. **Verify branch shape** — catch stacked or tangled branches before merge:
+   ```bash
+   git fetch origin master
+   gh pr checkout <n>
+   git diff --stat origin/master
+   git log --oneline origin/master..HEAD
+   ```
+
+   For decomposition PRs, `git diff --stat origin/master` must show exactly
+   the one source file being decomposed, its split files, and any expected
+   `scripts/file-length-allowlist.txt` or docs changes. If unrelated files
+   appear, the PR is stacked or stale; send it back instead of merging.
+
+5. **Play-test TUI-visible changes** — for `VISIBLE-TUI`, pane-focus, attach,
+   or similar interaction changes, play-test before merge:
+   ```bash
+   git fetch origin pull/<n>/head:gate-pr-<n>
+   git worktree add ../gate-pr-<n> gate-pr-<n>
+   make -C ../gate-pr-<n> tui-driver-selftest
+   ```
+
+   Require the self-test to report `24/24`. If it fails, send the failure back
+   to the authoring session.
+
+6. **Merge only after all gates pass**:
+   ```bash
+   gh pr merge <n> --squash
+   ```
+
+   Do not use another merge strategy unless the maintainer explicitly asks.

--- a/.claude/skills/incident-response.md
+++ b/.claude/skills/incident-response.md
@@ -1,0 +1,47 @@
+---
+name: incident-response
+description: Recover lost sessions, vanished worktrees, and daemon restarts without destroying resumable state
+user_invocable: true
+---
+
+# Incident Response
+
+Use this playbook when an `af` session, worktree, or daemon looks lost. Treat
+lost sessions as recoverable until proven otherwise.
+
+## Steps
+
+1. **Classify before acting** — a `LOST` session is recoverable, not terminal.
+   `Instance.Recover` re-spawns the agent and resumes it with the backend's
+   continuation command, such as `codex resume --last` or `claude --continue`.
+
+2. **Recover vanished worktrees** — if the worktree is gone but the branch is
+   alive, re-add the worktree and then let lost-restore resume the session:
+   ```bash
+   git worktree add <path> <branch>
+   af sessions restore <name>
+   ```
+
+   #1300 now rebuilds missing worktrees automatically during restore, so prefer
+   `af sessions restore` when it can do the job.
+
+3. **Avoid destructive cleanup** — `af sessions kill <name>` prunes the branch
+   and discards resumable state. Use it only after confirming the worktree,
+   branch, and commits are all unrecoverable or no longer needed.
+
+4. **Know the known cause** — the worktree-vanish incident came from
+   destructive `tui-driver` sandbox cleanup (#1303). The driver is now guarded
+   fail-closed, but never run it against a real repo.
+
+5. **Treat daemon restart as recoverable** — a daemon restart re-adopts live
+   sessions and is safe when handled through `af`-managed daemon behavior. Do
+   not kill the real daemon by process name.
+
+6. **Never use broad host kills**:
+   - Never run bare `tmux kill-server`; sandbox tmux work needs a private
+     `TMUX` or `TMUX_TMPDIR`.
+   - Never run bare `go test ./...` on the host; use `make test-container`.
+   - Never `pgrep` and kill the real daemon by broad process name.
+
+   If cleanup is required, scope it to the recorded sandbox path, private tmux
+   socket, or exact PID that the sandbox created.


### PR DESCRIPTION
## Summary

- Add five Captain Claude workflow skills under `.claude/skills`: PR gating, release cutting, file decomposition, af-session dispatch, and incident response.
- Match the existing skill frontmatter and step-oriented markdown style from `create-pr.md` and `tui-playtest.md`.
- Document the requested safety rules, no-stacking checks, Greptile/CI gates, release cadence, and recoverability playbooks.

Root should review wording and workflow accuracy before merge.

Closes #1394

## Test Plan

- [x] Frontmatter/structure validator passed for all `.claude/skills/*.md`
- [x] `go build ./...`
- [x] `make test-container`
- [x] `scripts/lint-file-length.sh`
- [ ] Manually tested in TUI (not applicable; docs-only skill change)
