### PR TITLE
Fix pane-next focus after preview cancel

### DIFF
--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -207,17 +207,18 @@ func paneFocusReservedKey(msg tea.KeyMsg) bool {
 // Edges clamp: pressing previous on the leftmost pane or next on the rightmost
 // pane is consumed but leaves focus where it is.
 func (m *home) focusAdjacentPane(delta int) tea.Cmd {
+	var refresh tea.Cmd
 	if m.panePreviewTxn != nil {
 		m.suppressActivePanePreview()
 		m.cancelPanePreview(true)
-		return m.panesRefresh(m.attached.Load())
+		refresh = m.panesRefresh(m.attached.Load())
 	}
 	if delta == 0 || len(m.visiblePanes) < 2 {
-		return nil
+		return refresh
 	}
 	current := m.focusedOpenPane()
 	if current == nil {
-		return nil
+		return refresh
 	}
 	pos := -1
 	for i, p := range m.visiblePanes {
@@ -227,7 +228,7 @@ func (m *home) focusAdjacentPane(delta int) tea.Cmd {
 		}
 	}
 	if pos < 0 {
-		return nil
+		return refresh
 	}
 	next := pos + delta
 	if next < 0 {
@@ -237,10 +238,10 @@ func (m *home) focusAdjacentPane(delta int) tea.Cmd {
 		next = len(m.visiblePanes) - 1
 	}
 	if next == pos {
-		return nil
+		return refresh
 	}
 	m.focusRegion(layout.PaneRegion(m.visiblePanes[next].ID()))
-	return nil
+	return refresh
 }
 
 // closePaneWindow removes a pane from the open list and drops its window and

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -817,6 +817,40 @@ func TestPaneArrowKeysSwitchFocusedPaneAndClamp(t *testing.T) {
 	assert.Equal(t, layout.RegionTree, h.ring.Active(), "right on the tree stays sidebar navigation, not pane switching")
 }
 
+func TestPaneArrowKeysMoveAfterCancelingPreview(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+	pressKey(t, h, "s")
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	pressKey(t, h, "s")
+	panes := h.store.OpenPanes()
+	require.Len(t, panes, 2)
+	paneA := panes[0]
+	paneB := panes[1]
+	require.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active(), "precondition: beta's right pane is focused")
+
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn, "selecting alpha while beta's pane is focused creates a transient preview")
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyLeft})
+	require.Nil(t, h.panePreviewTxn, "left cancels the preview")
+	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active(), "left still moves focus to the previous pane")
+	assert.Same(t, alpha, h.store.GetSelectedInstance(), "pane switching must not retarget the tree selection")
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn, "selecting beta while alpha's pane is focused creates a transient preview")
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRight})
+	require.Nil(t, h.panePreviewTxn, "right cancels the preview")
+	assert.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active(), "right still moves focus to the next pane")
+	assert.Same(t, beta, h.store.GetSelectedInstance(), "pane switching must not retarget the tree selection")
+}
+
 // TestPane_AutoHideOnShrinkRestoreOnGrow drives the §2.6 pane-count fitting:
 // shrinking below what fits auto-hides the least-recently-focused panes —
 // bindings retained, focused pane always visible — and growing restores them


### PR DESCRIPTION
Closes #1398

## Summary
- let pane-prev/pane-next cancel an active transient pane preview without swallowing the requested focus move
- add a regression test covering both left and right pane switches while a preview is active

## Verification
- make test-container GOTESTARGS="./app -run TestPaneArrowKeysMoveAfterCancelingPreview"
- make test-container
- #1398 driver repro in playtest container at 180x36

Signed-off-by: Captain Claude