### PR TITLE
Fix general help overlay scrolling at 80x24

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -281,6 +281,7 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 
 		m.textOverlay = overlay.NewTextOverlay(content)
 		m.textOverlay.OnDismiss = onDismiss
+		m.layoutTextOverlay()
 		m.state = stateHelp
 		return m, nil
 	}

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/stretchr/testify/require"
@@ -83,4 +84,22 @@ func TestInstanceStartHelpMentionsFullScreenDetach(t *testing.T) {
 	if !strings.Contains(content, "ctrl-w") || !strings.Contains(content, "Detach from a full-screen session") {
 		t.Errorf("instance-start help must name the full-screen detach key; got:\n%s", content)
 	}
+}
+
+func TestGeneralHelpOverlayFitsAndMarksScrollAt80x24(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 80, 24)
+
+	_, _ = h.showHelpScreen(helpTypeGeneral{}, nil)
+	fg := h.textOverlay.Render()
+	require.LessOrEqual(t, strings.Count(fg, "\n")+1, 24, "help overlay foreground must fit inside the terminal")
+	out := h.View()
+	require.Contains(t, out, "Agent Factory v", "initial viewport must include the title")
+	require.Contains(t, out, "↓ more", "initial viewport must show overflow below")
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyCtrlD})
+	fg = h.textOverlay.Render()
+	require.LessOrEqual(t, strings.Count(fg, "\n")+1, 24, "scrolled help overlay foreground must fit inside the terminal")
+	out = h.View()
+	require.Contains(t, out, "↑ more", "scrolled viewport must show overflow above")
 }

--- a/ui/overlay/textOverlay.go
+++ b/ui/overlay/textOverlay.go
@@ -5,8 +5,14 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/reflow/wordwrap"
 
 	"github.com/sachiniyer/agent-factory/ui"
+)
+
+const (
+	textOverlayHorizontalPadding = 2
+	textOverlayVerticalPadding   = 1
 )
 
 // TextOverlay represents a text screen overlay
@@ -58,7 +64,7 @@ func (t *TextOverlay) Render() string {
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(ui.AccentColor).
-		Padding(1, 2).
+		Padding(textOverlayVerticalPadding, textOverlayHorizontalPadding).
 		Width(t.width)
 	if inner := t.innerHeight(); inner > 0 && t.contentOverflows(inner) {
 		style = style.Height(inner)
@@ -92,11 +98,19 @@ func (t *TextOverlay) innerHeight() int {
 	if t.height <= 0 {
 		return 0
 	}
-	inner := t.height - 2 - 2 // border + vertical padding
+	inner := t.height - 2 - textOverlayVerticalPadding*2 // border + vertical padding
 	if inner < 1 {
 		return 1
 	}
 	return inner
+}
+
+func (t *TextOverlay) textWidth() int {
+	width := t.width - textOverlayHorizontalPadding*2
+	if width < 1 {
+		return 1
+	}
+	return width
 }
 
 func (t *TextOverlay) clampScroll(inner int) {
@@ -106,7 +120,7 @@ func (t *TextOverlay) clampScroll(inner int) {
 	if inner <= 0 {
 		return
 	}
-	lines := strings.Split(t.content, "\n")
+	lines := t.wrappedContentLines()
 	maxScroll := len(lines) - inner
 	if maxScroll < 0 {
 		maxScroll = 0
@@ -117,7 +131,7 @@ func (t *TextOverlay) clampScroll(inner int) {
 }
 
 func (t *TextOverlay) contentOverflows(inner int) bool {
-	return inner > 0 && len(strings.Split(t.content, "\n")) > inner
+	return inner > 0 && len(t.wrappedContentLines()) > inner
 }
 
 func (t *TextOverlay) visibleContent() string {
@@ -125,10 +139,10 @@ func (t *TextOverlay) visibleContent() string {
 	if inner <= 0 {
 		return t.content
 	}
-	lines := strings.Split(t.content, "\n")
+	lines := t.wrappedContentLines()
 	t.clampScroll(inner)
 	if len(lines) <= inner {
-		return t.content
+		return strings.Join(lines, "\n")
 	}
 	end := t.scroll + inner
 	if end > len(lines) {
@@ -136,12 +150,16 @@ func (t *TextOverlay) visibleContent() string {
 	}
 	visible := append([]string(nil), lines[t.scroll:end]...)
 	if t.scroll > 0 && len(visible) > 0 {
-		visible[0] = textOverlayScrollMarker(t.width, "↑ more")
+		visible[0] = textOverlayScrollMarker(t.textWidth(), "↑ more")
 	}
 	if end < len(lines) && len(visible) > 0 {
-		visible[len(visible)-1] = textOverlayScrollMarker(t.width, "↓ more")
+		visible[len(visible)-1] = textOverlayScrollMarker(t.textWidth(), "↓ more")
 	}
 	return strings.Join(visible, "\n")
+}
+
+func (t *TextOverlay) wrappedContentLines() []string {
+	return strings.Split(wordwrap.String(t.content, t.textWidth()), "\n")
 }
 
 func textOverlayScrollMarker(width int, marker string) string {

--- a/ui/overlay/textOverlay_test.go
+++ b/ui/overlay/textOverlay_test.go
@@ -124,3 +124,25 @@ func TestTextOverlayScrollsContent(t *testing.T) {
 	rendered = overlay.Render()
 	assert.Contains(t, rendered, "title", "scrolling up returns toward the top")
 }
+
+func TestTextOverlayHeightWindowsWrappedContent(t *testing.T) {
+	overlay := NewTextOverlay(strings.Join([]string{
+		"title",
+		"this line is intentionally long enough to wrap into several visual rows inside the overlay",
+		"tail",
+	}, "\n"))
+	overlay.SetWidth(24)
+	overlay.SetHeight(8)
+
+	rendered := overlay.Render()
+	assert.Equal(t, 8, strings.Count(rendered, "\n")+1,
+		"wrapped content should still fit the requested outer height")
+	assert.Contains(t, rendered, "title")
+	assert.Contains(t, rendered, "↓ more")
+
+	overlay.ScrollDown()
+	rendered = overlay.Render()
+	assert.Equal(t, 8, strings.Count(rendered, "\n")+1,
+		"scrolled wrapped content should still fit the requested outer height")
+	assert.Contains(t, rendered, "↑ more")
+}


### PR DESCRIPTION
Closes #1399

## Summary
- wrap text-overlay content before calculating scroll windows so long help lines cannot make the rendered overlay taller than the terminal
- size help overlays immediately on open so the first paint uses the current terminal geometry
- add regression coverage for the general help overlay at 80x24 and wrapped overlay scroll markers

## Verification
- make test-container GOTESTARGS="./app ./ui/overlay -run 'TestGeneralHelpOverlayFitsAndMarksScrollAt80x24|TestTextOverlayHeightWindowsWrappedContent|TestTextOverlayHeightWindowsContent|TestTextOverlayScrollsContent'"
- make test-container
- #1399 driver repro in playtest container at 80x24

Signed-off-by: Captain Claude