### PR TITLE
Derive archive confirmation key hint

### DIFF
--- a/app/archive_action_test.go
+++ b/app/archive_action_test.go
@@ -2,10 +2,12 @@ package app
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
 )
 
@@ -40,6 +42,38 @@ func TestHandleArchive_LiveRowConfirms(t *testing.T) {
 
 	require.Equal(t, stateConfirm, h.state, "archiving a live session must ask for confirmation")
 	require.False(t, called, "the archive RPC must not fire before confirmation")
+}
+
+func TestHandleArchive_ConfirmationUsesEffectiveArchiveKey(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		overrides map[string][]string
+		wantKey   string
+		notKey    string
+	}{
+		{name: "default", wantKey: "with a.", notKey: "with A."},
+		{name: "pinned old archive key", overrides: map[string][]string{"archive": {"A"}}, wantKey: "with A.", notKey: "with a."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, keys.ApplyOverrides(tc.overrides))
+			t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+			h := newTestHome(t)
+			inst := archiveActionInstance(t, "worker", session.Ready)
+			h.store.AddInstance(inst)
+			h.sidebar.SetSelectedInstance(0)
+
+			model, _ := h.handleArchive()
+			h = model.(*home)
+
+			require.Equal(t, stateConfirm, h.state)
+			require.NotNil(t, h.confirmationOverlay)
+			rendered := strings.Join(strings.Fields(h.confirmationOverlay.Render()), " ")
+			require.Contains(t, rendered, "Restore later")
+			require.Contains(t, rendered, tc.wantKey)
+			require.NotContains(t, rendered, tc.notKey)
+		})
+	}
 }
 
 func TestHandleArchive_LostRowRestoresWithoutConfirmation(t *testing.T) {

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -329,7 +329,8 @@ func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 		return m, m.handleError(fmt.Errorf("cannot archive in-place session '%s': archive relocates the worktree, which it doesn't own", title))
 	}
 
-	message := fmt.Sprintf("[!] Archive session '%s'?\n\nIts tmux is torn down and its worktree is moved out to the archive directory (branch + uncommitted changes preserved). Restore later with A.", title)
+	archiveKey := keys.GlobalKeyBindings[keys.KeyArchive].Help().Key
+	message := fmt.Sprintf("[!] Archive session '%s'?\n\nIts tmux is torn down and its worktree is moved out to the archive directory (branch + uncommitted changes preserved). Restore later with %s.", title, archiveKey)
 	return m, m.confirmAction(message, func() tea.Msg {
 		// Raise the optimistic OpArchiving op so the row visibly shows archiving
 		// while the RPC runs (#1195). It composes to Deleting for rendering; the

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -305,8 +305,8 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		descS = descS.Foreground(deletingTitleColor)
 	}
 	// An archived row (#1028) is dimmed and carries the ▧ archived glyph so it
-	// reads as "filed away, restartable" — restore with A — rather than a live
-	// session. It deliberately carries NO "[archived] " text prefix: unlike the
+	// reads as "filed away, restartable" rather than a live session. It
+	// deliberately carries NO "[archived] " text prefix: unlike the
 	// transient [deleting]/[lost] states, the Archived list is a persistent list
 	// the user browses BY NAME, and an 11-char word prefix eats the whole title
 	// cell at ordinary sidebar widths (~13 cols), clipping every name to


### PR DESCRIPTION
Closes #1400

## Summary
- derive the archive confirmation restore hint from the effective archive key binding instead of hardcoding A
- cover the default a key and a pinned A override in archive action tests
- audit old A/S/P/H key hints; remaining old-key mentions are docs/tests for intentional pinned overrides or old-default unbound assertions

## Verification
- make test-container GOTESTARGS="./app -run 'TestHandleArchive_ConfirmationUsesEffectiveArchiveKey|TestErgonomicDefaultKeysDispatchThroughKeymap'"
- make test-container
- #1400 driver repro in playtest container; confirmation shows "with a."

Signed-off-by: Captain Claude