### PR TITLE
refactor: move test Dockerfile into scripts container

### DIFF
--- a/docs/container-testing.md
+++ b/docs/container-testing.md
@@ -12,7 +12,7 @@ podman) with **no access to the host tmux server, the real
 `~/.agent-factory`, or the repo checkout** (mounted read-only).
 
 Requirements: docker or podman on `PATH`. Everything else lives in the
-image (`Dockerfile.test`: golang 1.24 + tmux + git).
+image (`scripts/container/Dockerfile.test`: golang 1.24 + tmux + git).
 
 ## `make test-container` — the full suite
 

--- a/scripts/container/Dockerfile.demo
+++ b/scripts/container/Dockerfile.demo
@@ -1,7 +1,8 @@
 # Demo-recording container for agent-factory (#1032).
 #
-# Extends the same golang+tmux+git toolchain as Dockerfile.test with the
-# recording stack, so the README demo GIF can be regenerated from committed
+# Extends the same golang+tmux+git toolchain as
+# scripts/container/Dockerfile.test with the recording stack, so the README
+# demo GIF can be regenerated from committed
 # scripts inside a throwaway container — never on the host. Build with no
 # context: `docker build -t agent-factory-demo - < scripts/container/Dockerfile.demo`
 #
@@ -34,8 +35,9 @@ RUN git config --system user.name "AF Testbox" \
     && git config --system user.email "testbox@localhost" \
     && git config --system init.defaultBranch master
 
-# Non-root dev user, mirroring Dockerfile.test so playtest-entry.sh builds
-# af into /home/dev/bin exactly as the play-test harness expects.
+# Non-root dev user, mirroring scripts/container/Dockerfile.test so
+# playtest-entry.sh builds af into /home/dev/bin exactly as the play-test
+# harness expects.
 RUN useradd -m -u 1000 dev \
     && mkdir -p /cache/gomod /cache/gobuild /work \
     && chown -R dev:dev /cache /work

--- a/scripts/container/Dockerfile.test
+++ b/scripts/container/Dockerfile.test
@@ -3,7 +3,8 @@
 # Toolchain-only image: the source tree is bind-mounted read-only at run
 # time by scripts/testbox.sh, so this image rebuilds only when the
 # toolchain or system packages change — never on code changes. Build it
-# with no context (`docker build - < Dockerfile.test`); there is no COPY.
+# with no context (`docker build - < scripts/container/Dockerfile.test`);
+# there is no COPY.
 FROM golang:1.24-bookworm
 
 # tmux + git are what the suite drives; procps provides pgrep for the

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -49,7 +49,7 @@ fi
 build_image() {
     # Dockerfile via stdin: no build context is sent (the Dockerfile has no
     # COPY), so this is instant when layers are cached.
-    "$ENGINE" build -q -t "$IMAGE" - <"$REPO_ROOT/Dockerfile.test" >/dev/null
+    "$ENGINE" build -q -t "$IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.test" >/dev/null
 }
 
 # Flags shared by every run:
@@ -122,7 +122,7 @@ cmd="${1:-test}"
 
 case "$cmd" in
 build)
-    "$ENGINE" build -t "$IMAGE" - <"$REPO_ROOT/Dockerfile.test"
+    "$ENGINE" build -t "$IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.test"
     ;;
 test)
     build_image


### PR DESCRIPTION
Refs #1392

## Summary
- Move `Dockerfile.test` to `scripts/container/Dockerfile.test`.
- Update `scripts/testbox.sh` to build the testbox image from the moved Dockerfile.
- Update `docs/container-testing.md` and `scripts/container/Dockerfile.demo` comments to reference the new path.

## Verification
- `go build ./...`
- `scripts/gen-docs.sh` and `make docs` (no generated docs drift)
- `test -f install.sh && test -f dev-install.sh && test -f scripts/gen-docs.sh && test -f Makefile && test -f scripts/container/Dockerfile.test`
- `sh -n install.sh`
- `bash -n dev-install.sh`
- `bash -n scripts/testbox.sh`
- `make -n docs test-container testbox-image lint-file-length`
- `make lint-file-length`
- `deadcode -test ./...`
- `go build -ldflags '-X main.version=9.8.7-test' -o /tmp/af-reorg-pr3 . && /tmp/af-reorg-pr3 version`
- `make testbox-image`
- `make test-container`

## Notes
- PR3 of the approved root reorg. This branch is fresh from `origin/master` and independent of PR2.
- I did not run any TUI driver/playtest target against a real repo.
