### PR TITLE
Fix first-run interactive key replay

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -271,6 +271,7 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 	// Check if this help screen has been seen before
 	// Only show if we're showing the general help screen or the corresponding flag is not set
 	// in the seen bitmask.
+	m.replayHelpDismissKey = false
 	if alwaysShow || (m.appState.GetHelpScreensSeen()&flag) == 0 {
 		// Mark this help screen as seen and save state
 		if err := m.appState.SetHelpScreensSeen(m.appState.GetHelpScreensSeen() | flag); err != nil {
@@ -281,6 +282,9 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 
 		m.textOverlay = overlay.NewTextOverlay(content)
 		m.textOverlay.OnDismiss = onDismiss
+		if _, ok := helpType.(helpTypeInteractive); ok {
+			m.replayHelpDismissKey = true
+		}
 		m.layoutTextOverlay()
 		m.state = stateHelp
 		return m, nil
@@ -307,11 +311,16 @@ func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Any non-scroll key press will close the help overlay.
 	dismissCmd, shouldClose := m.textOverlay.HandleKeyPress(msg)
 	if shouldClose {
+		replayDismissKey := m.replayHelpDismissKey
+		m.replayHelpDismissKey = false
 		m.state = stateDefault
 		// Menu.SetState rebuilds the options slice; call it synchronously
 		// on the event-loop goroutine rather than from a tea.Cmd closure
 		// that runs off-loop and races with home.View -> Menu.String.
 		m.menu.SetState(ui.StateDefault)
+		if replayDismissKey {
+			dismissCmd = replayKeyAfterInteractiveHelpDismiss(dismissCmd, msg)
+		}
 		// dismissCmd forwards repaintAfterDetachMsg{} from the attach
 		// callback (#579) so the post-detach repaint doesn't have to wait
 		// for the next previewTickMsg cycle.
@@ -319,4 +328,19 @@ func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func replayKeyAfterInteractiveHelpDismiss(dismissCmd tea.Cmd, keyMsg tea.KeyMsg) tea.Cmd {
+	if dismissCmd == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		msg := dismissCmd()
+		if enter, ok := msg.(enterInteractiveMsg); ok {
+			enter.replayKey = keyMsg
+			enter.replay = true
+			return enter
+		}
+		return msg
+	}
 }

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -246,6 +246,10 @@ type home struct {
 	spinner spinner.Model
 	// textOverlay displays text information
 	textOverlay *overlay.TextOverlay
+	// replayHelpDismissKey marks the first-run interactive pane help: the
+	// key that closes that overlay is the user's first pane keystroke, so it
+	// must be forwarded after the deferred live bind completes (#1410).
+	replayHelpDismissKey bool
 	// confirmationOverlay displays confirmation modals
 	confirmationOverlay *overlay.ConfirmationOverlay
 	// pendingConfirmMsg holds a non-error tea.Msg returned by a confirmation

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -181,7 +181,12 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case enterInteractiveMsg:
 		// Deferred by the first-time interactive help screen's dismiss cmd
 		// (#1089 PR 2); the pane pointer is re-validated inside.
-		return m, m.activateInteractive(msg.pane)
+		cmd := m.activateInteractive(msg.pane)
+		if msg.replay && m.interactive {
+			_, replayCmd := m.handleInteractiveKey(msg.replayKey)
+			cmd = tea.Batch(cmd, replayCmd)
+		}
+		return m, cmd
 	case startKillMsg:
 		// The row was already flipped to Deleting synchronously by the kill
 		// confirmation; dispatch the slow teardown off the event loop (#844).

--- a/app/interactive.go
+++ b/app/interactive.go
@@ -27,7 +27,9 @@ import (
 // where model state must not be touched (#716 capture discipline: the pane
 // is captured at Enter-press time, then re-validated on arrival).
 type enterInteractiveMsg struct {
-	pane *store.OpenPane
+	pane      *store.OpenPane
+	replayKey tea.KeyMsg
+	replay    bool
 }
 
 // requestInteractive routes Enter-on-a-live-eligible-pane through the

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -81,6 +81,25 @@ func TestEnterOnFocusedLivePaneEntersInteractive(t *testing.T) {
 	assert.Contains(t, h.menu.String(), "ctrl+]", "the status bar must show the escape hatch")
 }
 
+func TestFirstRunInteractiveHelpForwardsDismissKey(t *testing.T) {
+	h, _ := liveTestHome(t)
+	fakes, _ := stubLiveTermFactory(t)
+
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	require.Nil(t, cmd, "first-time interactive entry waits on the help overlay")
+	require.Equal(t, stateHelp, h.state)
+	require.NotNil(t, h.textOverlay)
+	require.Empty(t, *fakes, "the live terminal must not bind until help is dismissed")
+
+	_, cmd = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	runHermeticCmd(t, h, cmd, 0)
+
+	require.True(t, h.interactive, "dismissing first-run help should enter interactive mode")
+	require.Len(t, *fakes, 1)
+	assert.Equal(t, []string{"q"}, (*fakes)[0].keys,
+		"the key that dismisses the first-run interactive help must reach the pane")
+}
+
 func TestInteractiveForwardsAllKeysIncludingTab(t *testing.T) {
 	h, _, fakes := interactiveTestHome(t)
 	enterInteractive(t, h)


### PR DESCRIPTION
Closes #1410

## Summary
- replay the key that dismisses the first-run interactive pane help after the live pane activates
- keep the replay scoped to the interactive help overlay only
- add a first-run interactive regression test proving the dismissing key reaches the pane

## Verification
- Verified on master behavior: `make test-container GOTESTARGS="./app -run TestFirstRunInteractiveHelpForwardsDismissKey -count=1"` failed before the fix because `q` was not forwarded.
- `make test-container GOTESTARGS="./app -run TestFirstRunInteractiveHelpForwardsDismissKey -count=1"`
- `make test-container GOTESTARGS="./app -count=1"`

Signed-off-by: Captain Claude