### PR TITLE
Fix pane preview selected tab target

### DIFF
--- a/app/home_panes.go
+++ b/app/home_panes.go
@@ -49,8 +49,8 @@ func (m *home) selectionChanged() tea.Cmd {
 		// just in the explicit tab-jump handlers.
 		m.menu.SetActiveTab(m.store.ActiveTab())
 		m.maybeAutoOpenInitialPane(selected)
-		previewTab := 0
-		previewTabSpecific := false
+		previewTab := m.store.ActiveTab()
+		previewTabSpecific := previewTab != 0
 		if sel.IsTab {
 			previewTab = sel.TabIndex
 			previewTabSpecific = true

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -340,6 +340,32 @@ func TestPanePreviewTabRowCommitsSameInstanceTerminal(t *testing.T) {
 	assert.Equal(t, layout.PaneRegion(paneA.ID()), h.ring.Active())
 }
 
+func TestPanePreviewInstanceRowUsesSelectedTerminalTab(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+
+	pressKey(t, h, "s")
+	paneA := h.store.OpenPanes()[0]
+	require.Same(t, alpha, paneA.Instance())
+	require.Equal(t, 0, paneA.Tab(), "precondition: alpha's agent pane is open")
+
+	h.sidebar.SetSelectedInstance(1)
+	h.store.SetActiveTab(1)
+	h.menu.SetActiveTab(1)
+	_ = h.selectionChanged()
+
+	sel := h.sidebar.GetSelection()
+	require.False(t, sel.IsTab, "precondition: cursor remains on beta's instance row")
+	require.Equal(t, 1, h.store.ActiveTab(), "precondition: selected/action tab is Terminal")
+	require.NotNil(t, h.panePreviewTxn)
+	assert.Same(t, beta, h.panePreviewTxn.target.instance)
+	assert.Equal(t, 1, h.panePreviewTxn.target.tab,
+		"preview target must match the selected/action (instance, tab), not default to Agent")
+	assert.Contains(t, h.View(), "PREVIEW beta · Terminal (original alpha · Agent)")
+	assert.NotContains(t, h.View(), "PREVIEW beta · Agent")
+}
+
 func TestPanePreviewEnterCommitsReplace(t *testing.T) {
 	h := paneTestHome(t)
 	alpha := h.store.GetInstanceByTitle("alpha")
@@ -442,7 +468,7 @@ func TestPanePreviewSplitHideDoesNotStickInPanePreview(t *testing.T) {
 	require.Same(t, beta, h.store.GetSelectedInstance())
 	require.Equal(t, layout.RegionTree, h.ring.Active(), "tree navigation owns focus during preview")
 	require.NotNil(t, h.panePreviewTxn)
-	require.Contains(t, h.View(), "PREVIEW beta · Agent (original alpha · Agent)")
+	require.Contains(t, h.View(), "PREVIEW beta · Terminal (original alpha · Agent)")
 
 	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("S")}, keys.KeySplitPane)
 	require.NotNil(t, cmd)
@@ -450,6 +476,7 @@ func TestPanePreviewSplitHideDoesNotStickInPanePreview(t *testing.T) {
 	require.Equal(t, 2, h.store.NumOpenPanes())
 	paneB := h.store.OpenPanes()[1]
 	require.Same(t, beta, paneB.Instance())
+	require.Equal(t, 1, paneB.Tab())
 	require.Equal(t, layout.PaneRegion(paneB.ID()), h.ring.Active())
 
 	pressTab(t, h, false)

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -55,9 +55,9 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 		original = m.panePreviewTxn.original
 	}
 	target := paneBinding{instance: selected, tab: targetTab}
-	// Plain instance-row previews stay on the selected instance's agent tab
-	// (#1321). Explicit tab rows, however, name a full (instance, tab) target:
-	// a same-instance terminal tab is distinct from the already-open agent pane.
+	// The preview target must match the selected/action tab. An instance row
+	// whose active tab is Terminal still names the full (instance, tab)
+	// target, so preview and commit cannot diverge (#1415, #1289 class).
 	if (!tabSpecific && original.instance == target.instance) ||
 		(tabSpecific && samePaneBinding(original, target)) {
 		m.cancelPanePreview(false)
@@ -124,7 +124,7 @@ func (m *home) suppressPanePreviewForSelection(owner *store.OpenPane) {
 	}
 	m.suppressPanePreview(
 		paneBinding{instance: owner.Instance(), tab: owner.Tab()},
-		paneBinding{instance: selected, tab: 0},
+		paneBinding{instance: selected, tab: m.store.ActiveTab()},
 	)
 }
 


### PR DESCRIPTION
Closes #1415

## Summary
- target pane previews at the selected/action tab instead of defaulting instance-row previews to Agent
- keep preview suppression keyed to the same selected (instance, tab) target
- add a regression test for Terminal-selected instance-row previews

## Verification
- Verified on master behavior: `make test-container GOTESTARGS="./app -run TestPanePreviewInstanceRowUsesSelectedTerminalTab -count=1"` failed before the fix because preview targeted tab 0 / Agent.
- `make test-container GOTESTARGS="./app -run TestPanePreviewInstanceRowUsesSelectedTerminalTab -count=1"`
- `make test-container GOTESTARGS="./app -count=1"`
- `make test-container`

Signed-off-by: Captain Claude