### PR TITLE
Fix tiny terminal overlay clipping

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -129,6 +129,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.selectionOverlay = overlay.NewSelectionOverlay("Select Program", items)
 		m.selectionOverlay.SetWidth(40)
 		m.selectionOverlay.SetSelectedIndex(selectedIdx)
+		m.layoutSelectionOverlay()
 		m.state = stateSelectProgram
 		return m, nil
 	case tea.KeyRunes:

--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -78,6 +78,7 @@ func (m *home) showSearchOverlay() (tea.Model, tea.Cmd) {
 	}
 	m.searchOverlay = overlay.NewSearchOverlay(instances)
 	m.searchOverlay.SetWidth(60)
+	m.layoutSearchOverlay()
 	m.state = stateSearch
 	return m, nil
 }
@@ -122,6 +123,7 @@ func (m *home) showTasksOverlay() (tea.Model, tea.Cmd) {
 	}
 	sp.SetFocus(true)
 	sp.EnterEditSelected()
+	m.layoutPaneOverlays()
 	m.state = stateTasks
 	return m, nil
 }
@@ -181,6 +183,7 @@ func (m *home) handleStateTasks(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // is live immediately.
 func (m *home) showHooksOverlay() (tea.Model, tea.Cmd) {
 	m.hooksPane.SetFocus(true)
+	m.layoutPaneOverlays()
 	m.state = stateHooks
 	return m, nil
 }

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -445,23 +445,7 @@ func (m *home) relayout() {
 	m.statusBar.SetRect(lay.StatusBar)
 	m.alarmBanner.SetRect(lay.Banner)
 
-	m.layoutTextOverlay()
-	if m.selectionOverlay != nil {
-		m.selectionOverlay.SetWidth(int(float32(m.termWidth) * 0.6))
-	}
-	m.hooksPane.SetSize(int(float32(m.termWidth)*0.6), int(float32(m.termHeight)*0.6))
-	// The task manager renders in the centered tasks overlay (stateTasks), so
-	// it sizes off the terminal like the hooks editor — never off the rail.
-	// Floor the width so the edit form's fields and key line stay readable at
-	// an 80-col terminal, capped under the window for the overlay frame.
-	taskPaneW := int(float32(m.termWidth) * 0.6)
-	if taskPaneW < 52 {
-		taskPaneW = 52
-	}
-	if lim := m.termWidth - 8; taskPaneW > lim {
-		taskPaneW = lim
-	}
-	m.automations.TaskPane().SetSize(taskPaneW, int(float32(m.termHeight)*0.6))
+	m.layoutModalOverlays()
 
 	// tmux sessions render at the pane content size. Panes divide the
 	// workspace evenly, so the first visible pane's inner size stands for all

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -26,6 +26,7 @@ func (m *home) confirmAction(message string, action tea.Cmd) tea.Cmd {
 	m.state = stateConfirm
 	m.confirmationOverlay = overlay.NewConfirmationOverlay(message)
 	m.confirmationOverlay.SetWidth(50)
+	m.layoutConfirmationOverlay()
 
 	m.confirmationOverlay.OnConfirm = func() {
 		m.state = stateDefault

--- a/app/render.go
+++ b/app/render.go
@@ -6,11 +6,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/layout"
 )
 
-// View render helpers extracted from app.go (#1145): the overlay framing style
-// and the rail/divider rules the composed View draws. Behavior is unchanged —
-// this is a pure relocation to keep app.go under its length ceiling.
+// View render helpers extracted from app.go (#1145): overlay frame sizing and
+// the rail/divider rules the composed View draws.
 
 // hooksOverlayStyle frames the hooks editor when it is hosted as an overlay
 // (#1024 PR 4: hooks lost their persistent sidebar slot).
@@ -20,14 +20,148 @@ var hooksOverlayStyle = lipgloss.NewStyle().
 	Padding(1, 2)
 
 func (m *home) renderHooksOverlay() string {
-	return hooksOverlayStyle.Render(m.hooksPane.String())
+	return m.renderFittedPaneOverlay(
+		m.hooksOverlayContentRect(),
+		func(w, h int) { m.hooksPane.SetSize(w, h) },
+		m.hooksPane.String,
+	)
 }
 
 // renderTasksOverlay frames the task manager (list + create/edit form) as the
 // centered modal it lives in (#1087 play-test): the manager needs real
 // width/height for its form, which the narrow left rail cannot provide.
 func (m *home) renderTasksOverlay() string {
-	return hooksOverlayStyle.Render(m.automations.TaskPane().String())
+	return m.renderFittedPaneOverlay(
+		m.tasksOverlayContentRect(),
+		func(w, h int) { m.automations.TaskPane().SetSize(w, h) },
+		m.automations.TaskPane().String,
+	)
+}
+
+func (m *home) renderFittedPaneOverlay(r layout.Rect, setSize func(int, int), renderContent func() string) string {
+	if r.W < 1 {
+		r.W = 1
+	}
+	if r.H < 1 {
+		r.H = 1
+	}
+	for {
+		contentRect := paneOverlayContentRect(r)
+		setSize(contentRect.W, contentRect.H)
+		fg := sizedOverlayStyle(hooksOverlayStyle, r).Render(renderContent())
+		fgW, fgH := lipgloss.Width(fg), lipgloss.Height(fg)
+		tooWide := m.termWidth > 0 && fgW > m.termWidth
+		tooTall := m.termHeight > 0 && fgH > m.termHeight
+		if (!tooWide && !tooTall) || (r.W == 1 && r.H == 1) {
+			if tooWide || tooTall {
+				return layout.ClampToRect(fg, layout.Rect{W: m.termWidth, H: m.termHeight})
+			}
+			return fg
+		}
+		if tooWide && r.W > 1 {
+			r.W -= fgW - m.termWidth
+			if r.W < 1 {
+				r.W = 1
+			}
+		}
+		if tooTall && r.H > 1 {
+			r.H -= fgH - m.termHeight
+			if r.H < 1 {
+				r.H = 1
+			}
+		}
+	}
+}
+
+func (m *home) layoutModalOverlays() {
+	m.layoutTextOverlay()
+	m.layoutSelectionOverlay()
+	m.layoutConfirmationOverlay()
+	m.layoutSearchOverlay()
+	m.layoutPaneOverlays()
+}
+
+func (m *home) layoutSelectionOverlay() {
+	if m.selectionOverlay == nil {
+		return
+	}
+	m.selectionOverlay.SetWidth(int(float32(m.termWidth) * 0.6))
+	m.selectionOverlay.SetMaxSize(m.termWidth, m.termHeight)
+}
+
+func (m *home) layoutConfirmationOverlay() {
+	if m.confirmationOverlay != nil {
+		m.confirmationOverlay.SetMaxSize(m.termWidth, m.termHeight)
+	}
+}
+
+func (m *home) layoutSearchOverlay() {
+	if m.searchOverlay != nil {
+		m.searchOverlay.SetMaxSize(m.termWidth, m.termHeight)
+	}
+}
+
+func (m *home) layoutPaneOverlays() {
+	hooksRect := m.hooksOverlayContentRect()
+	hooksContent := paneOverlayContentRect(hooksRect)
+	m.hooksPane.SetSize(hooksContent.W, hooksContent.H)
+
+	taskRect := m.tasksOverlayContentRect()
+	taskContent := paneOverlayContentRect(taskRect)
+	m.automations.TaskPane().SetSize(taskContent.W, taskContent.H)
+}
+
+func (m *home) hooksOverlayContentRect() layout.Rect {
+	return m.modalContentRect(hooksOverlayStyle, m.preferredOverlayWidth(50), m.preferredOverlayHeight())
+}
+
+func (m *home) tasksOverlayContentRect() layout.Rect {
+	return m.modalContentRect(hooksOverlayStyle, m.preferredOverlayWidth(52), m.preferredOverlayHeight())
+}
+
+func (m *home) modalContentRect(style lipgloss.Style, preferredW, preferredH int) layout.Rect {
+	return layout.FitContentRect(
+		layout.Rect{W: preferredW, H: preferredH},
+		layout.Rect{W: m.termWidth, H: m.termHeight},
+		style.GetHorizontalBorderSize(),
+		style.GetVerticalBorderSize(),
+	)
+}
+
+func (m *home) preferredOverlayWidth(minWidth int) int {
+	width := int(float32(m.termWidth) * 0.6)
+	if width < minWidth {
+		width = minWidth
+	}
+	return width
+}
+
+func (m *home) preferredOverlayHeight() int {
+	return int(float32(m.termHeight) * 0.6)
+}
+
+func sizedOverlayStyle(style lipgloss.Style, r layout.Rect) lipgloss.Style {
+	if r.W > 0 {
+		style = style.Width(r.W)
+	}
+	if r.H > 0 {
+		style = style.Height(r.H)
+	}
+	return style
+}
+
+func paneOverlayContentRect(styleRect layout.Rect) layout.Rect {
+	r := layout.Rect{
+		W: styleRect.W - hooksOverlayStyle.GetHorizontalPadding(),
+		H: styleRect.H - hooksOverlayStyle.GetVerticalPadding(),
+	}
+	if styleRect.W > 0 && r.W < 1 {
+		r.W = 1
+	}
+	if styleRect.H > 0 && r.H < 1 {
+		r.H = 1
+	}
+	return r
 }
 
 // splitDividerStyle recedes the 1-col dividers between panes so the focused

--- a/app/tinyclip_overlay_test.go
+++ b/app/tinyclip_overlay_test.go
@@ -1,0 +1,100 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	xansi "github.com/charmbracelet/x/ansi"
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTinyClipConfirmationOverlaysFit(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		message string
+	}{
+		{name: "kill", message: "[!] Kill session 'beta'?"},
+		{
+			name: "archive",
+			message: "[!] Archive session 'beta'?\n\n" +
+				"Its tmux is torn down and its worktree is moved out to the archive directory " +
+				"(branch + uncommitted changes preserved). Restore later with a.",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			resizeHome(h, 40, 10)
+
+			_ = h.confirmAction(tc.message, nil)
+
+			view := h.View()
+			requireViewSized(t, view, 40, 10)
+			plain := xansi.Strip(view)
+			assert.Contains(t, plain, "confirm")
+			assert.Contains(t, plain, "cancel")
+		})
+	}
+}
+
+func TestTinyClipSearchOverlayFitsAtSmallSizes(t *testing.T) {
+	for _, size := range [][2]int{{40, 10}, {60, 15}} {
+		t.Run(fmt.Sprintf("%dx%d", size[0], size[1]), func(t *testing.T) {
+			h := newTestHome(t)
+			h.store.AddInstance(newSnapshotTestInstance(t, "alpha"))
+			h.store.AddInstance(newSnapshotTestInstance(t, "beta"))
+			h.store.AddInstance(newSnapshotTestInstance(t, "gamma"))
+			resizeHome(h, size[0], size[1])
+
+			_, _ = h.showSearchOverlay()
+			for _, r := range "gamma" {
+				_ = h.searchOverlay.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+			}
+
+			view := h.View()
+			requireViewSized(t, view, size[0], size[1])
+			plain := xansi.Strip(view)
+			assert.Contains(t, plain, "Search Sessions")
+			assert.Contains(t, plain, "gamma")
+			assert.Contains(t, plain, "esc close")
+		})
+	}
+}
+
+func TestTinyClipHooksOverlayFits(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 40, 10)
+
+	_, _ = h.showHooksOverlay()
+	_, _ = h.handleStateHooks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	for _, r := range "echo hook && false" {
+		_, _ = h.handleStateHooks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	view := h.View()
+	requireViewSized(t, view, 40, 10)
+	plain := xansi.Strip(view)
+	assert.Contains(t, plain, "Post-Worktree Hooks")
+	assert.Contains(t, plain, "enter save")
+	assert.Contains(t, plain, "esc cancel")
+}
+
+func TestTinyClipTasksOverlayFits(t *testing.T) {
+	h := newTestHome(t)
+	h.store.SetTasks([]task.Task{})
+	resizeHome(h, 40, 10)
+
+	_, _ = h.showTasksOverlay()
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	for _, r := range "tiny-task" {
+		_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	view := h.View()
+	requireViewSized(t, view, 40, 10)
+	plain := xansi.Strip(view)
+	assert.Contains(t, plain, "tiny-task")
+	assert.Contains(t, plain, "esc cancel")
+	assert.Contains(t, plain, "↑ more")
+}

--- a/ui/fit.go
+++ b/ui/fit.go
@@ -1,0 +1,50 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
+)
+
+func fitStyledLine(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= width {
+		return s
+	}
+	out := xansi.Truncate(s, width, "…")
+	if strings.Contains(out, "\x1b") {
+		out += "\x1b[0m"
+	}
+	return out
+}
+
+func fitBlockToSize(content string, width, height, pinnedFooter int) string {
+	lines := strings.Split(content, "\n")
+	for i := range lines {
+		lines[i] = fitStyledLine(lines[i], width)
+	}
+	if height <= 0 || len(lines) <= height {
+		return strings.Join(lines, "\n")
+	}
+	if pinnedFooter < 0 {
+		pinnedFooter = 0
+	}
+	if pinnedFooter > height {
+		pinnedFooter = height
+	}
+	bodyRows := height - pinnedFooter
+	fitted := make([]string, 0, height)
+	if bodyRows > 0 {
+		fitted = append(fitted, lines[:bodyRows]...)
+		if len(lines) > height {
+			fitted[bodyRows-1] = taskFormMoreStyle.Render(fitLine("  ↓ more", width))
+		}
+	}
+	if pinnedFooter > 0 {
+		fitted = append(fitted, lines[len(lines)-pinnedFooter:]...)
+	}
+	return strings.Join(fitted, "\n")
+}

--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -163,7 +163,11 @@ func (h *HooksPane) String() string {
 	b.WriteString("\n\n")
 
 	if len(h.commands) == 0 && !h.adding {
-		b.WriteString(normalStyle.Render("  No hooks configured. Press Enter to focus, then n to add."))
+		msg := "  No hooks configured. Press Enter to focus, then n to add."
+		if h.width > 0 && lipgloss.Width(msg) > h.width {
+			msg = "  No hooks configured. Press n to add."
+		}
+		b.WriteString(normalStyle.Render(msg))
 		b.WriteString("\n")
 	}
 
@@ -189,11 +193,15 @@ func (h *HooksPane) String() string {
 		if h.editing || h.adding {
 			b.WriteString(hintStyle.Render("enter save • esc cancel"))
 		} else {
-			b.WriteString(hintStyle.Render("n add • enter edit • D delete • esc back"))
+			hint := "n add • enter edit • D delete • esc back"
+			if h.width > 0 && lipgloss.Width(hint) > h.width {
+				hint = "n add • enter • esc back"
+			}
+			b.WriteString(hintStyle.Render(hint))
 		}
 	} else {
 		b.WriteString(hintStyle.Render("enter to focus and edit hooks"))
 	}
 
-	return b.String()
+	return fitBlockToSize(b.String(), h.width, h.height, 1)
 }

--- a/ui/layout/fit.go
+++ b/ui/layout/fit.go
@@ -1,0 +1,30 @@
+package layout
+
+// FitContentRect returns dimensions that fit inside maxOuter after the caller
+// adds the supplied outer frame cells. For lipgloss styles, pass border sizes:
+// Style.Width/Height already include padding, but rendered output adds borders.
+// A non-positive preferred dimension means "use all available space"; a
+// non-positive maxOuter dimension means "unbounded" for that axis.
+func FitContentRect(preferred, maxOuter Rect, horizontalFrame, verticalFrame int) Rect {
+	return Rect{
+		W: fitContentDimension(preferred.W, maxOuter.W, horizontalFrame),
+		H: fitContentDimension(preferred.H, maxOuter.H, verticalFrame),
+	}
+}
+
+func fitContentDimension(preferred, maxOuter, frame int) int {
+	if maxOuter <= 0 {
+		if preferred > 0 {
+			return preferred
+		}
+		return 0
+	}
+	available := maxOuter - frame
+	if available < 1 {
+		available = 1
+	}
+	if preferred <= 0 || preferred > available {
+		return available
+	}
+	return preferred
+}

--- a/ui/layout/fit_test.go
+++ b/ui/layout/fit_test.go
@@ -1,0 +1,41 @@
+package layout_test
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFitContentRectClampsFrameInsideOuterBounds(t *testing.T) {
+	got := layout.FitContentRect(
+		layout.Rect{W: 60, H: 20},
+		layout.Rect{W: 40, H: 10},
+		2,
+		2,
+	)
+
+	assert.Equal(t, layout.Rect{W: 38, H: 8}, got)
+}
+
+func TestFitContentRectUsesAvailableForAutoDimensions(t *testing.T) {
+	got := layout.FitContentRect(
+		layout.Rect{W: 50},
+		layout.Rect{W: 60, H: 15},
+		2,
+		2,
+	)
+
+	assert.Equal(t, layout.Rect{W: 50, H: 13}, got)
+}
+
+func TestFitContentRectKeepsUnboundedPreferredDimensions(t *testing.T) {
+	got := layout.FitContentRect(
+		layout.Rect{W: 50, H: 8},
+		layout.Rect{},
+		2,
+		2,
+	)
+
+	assert.Equal(t, layout.Rect{W: 50, H: 8}, got)
+}

--- a/ui/overlay/confirmationOverlay.go
+++ b/ui/overlay/confirmationOverlay.go
@@ -7,6 +7,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+const (
+	confirmationOverlayHorizontalPadding = 2
+	confirmationOverlayVerticalPadding   = 1
+)
+
 // ConfirmationOverlay represents a confirmation dialog overlay
 type ConfirmationOverlay struct {
 	// Whether the overlay has been dismissed
@@ -15,6 +20,9 @@ type ConfirmationOverlay struct {
 	message string
 	// Width of the overlay
 	width int
+	// Maximum outer dimensions available for rendering.
+	maxWidth  int
+	maxHeight int
 	// Callback function to be called when the user confirms (presses 'y')
 	OnConfirm func()
 	// Callback function to be called when the user cancels (presses 'n' or 'esc')
@@ -71,14 +79,17 @@ func (c *ConfirmationOverlay) Render() string {
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(c.borderColor).
-		Padding(1, 2).
-		Width(c.width)
+		Padding(confirmationOverlayVerticalPadding, confirmationOverlayHorizontalPadding)
 
-	// Add the confirmation instructions
-	content := c.message + "\n\n" +
-		"Press " + lipgloss.NewStyle().Bold(true).Render(c.ConfirmKey) + " to confirm, " +
-		lipgloss.NewStyle().Bold(true).Render(c.CancelKey) + " or " +
-		lipgloss.NewStyle().Bold(true).Render("esc") + " to cancel"
+	fit := fitOverlayContent(c.width, 0, c.maxWidth, c.maxHeight, style)
+	if fit.W > 0 {
+		style = style.Width(fit.W)
+	}
+	textRect := overlayTextRect(fit, style)
+	content := c.visibleContent(textRect.W, textRect.H)
+	if fit.H > 0 && renderedLineCount(content) >= textRect.H {
+		style = style.Height(fit.H)
+	}
 
 	// Apply the border style and return
 	return style.Render(content)
@@ -89,7 +100,67 @@ func (c *ConfirmationOverlay) SetWidth(width int) {
 	c.width = width
 }
 
+// SetMaxSize sets the maximum outer size the rendered confirmation may occupy.
+func (c *ConfirmationOverlay) SetMaxSize(width, height int) {
+	c.maxWidth = width
+	c.maxHeight = height
+}
+
 // SetConfirmKey sets the key used to confirm the action
 func (c *ConfirmationOverlay) SetConfirmKey(key string) {
 	c.ConfirmKey = key
+}
+
+func (c *ConfirmationOverlay) visibleContent(width, height int) string {
+	body := wrapOverlayLines(c.message, width)
+	hint := wrapOverlayLines(c.instruction(false), width)
+	compactHint := wrapOverlayLines(c.instruction(true), width)
+	if height > 0 && (len(body)+1+len(hint) > height || len(hint) > 2) {
+		hint = compactHint
+	}
+	if height <= 0 {
+		return strings.Join(append(append([]string{}, body...), append([]string{""}, hint...)...), "\n")
+	}
+	if len(hint) >= height {
+		return strings.Join(hint[:height], "\n")
+	}
+
+	gap := 1
+	bodyLimit := height - len(hint) - gap
+	if bodyLimit < 1 {
+		gap = 0
+		bodyLimit = height - len(hint)
+	}
+	body = windowOverlayBody(body, bodyLimit, width)
+	lines := append([]string{}, body...)
+	if gap > 0 && len(lines) > 0 {
+		lines = append(lines, "")
+	}
+	lines = append(lines, hint...)
+	return strings.Join(lines, "\n")
+}
+
+func (c *ConfirmationOverlay) instruction(compact bool) string {
+	bold := lipgloss.NewStyle().Bold(true).Render
+	if compact {
+		return bold(c.ConfirmKey) + " confirm • " +
+			bold(c.CancelKey) + "/" + bold("esc") + " cancel"
+	}
+	return "Press " + bold(c.ConfirmKey) + " to confirm, " +
+		bold(c.CancelKey) + " or " + bold("esc") + " to cancel"
+}
+
+func windowOverlayBody(lines []string, limit, width int) []string {
+	if limit <= 0 {
+		return nil
+	}
+	if len(lines) <= limit {
+		return lines
+	}
+	if limit == 1 {
+		return []string{truncateOverlayLine("…", width)}
+	}
+	out := append([]string{}, lines[:limit-1]...)
+	out = append(out, truncateOverlayLine("…", width))
+	return out
 }

--- a/ui/overlay/fit.go
+++ b/ui/overlay/fit.go
@@ -1,0 +1,63 @@
+package overlay
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	xansi "github.com/charmbracelet/x/ansi"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+)
+
+func fitOverlayContent(preferredW, preferredH, maxW, maxH int, style lipgloss.Style) layout.Rect {
+	return layout.FitContentRect(
+		layout.Rect{W: preferredW, H: preferredH},
+		layout.Rect{W: maxW, H: maxH},
+		style.GetHorizontalBorderSize(),
+		style.GetVerticalBorderSize(),
+	)
+}
+
+func overlayTextRect(styleRect layout.Rect, style lipgloss.Style) layout.Rect {
+	text := layout.Rect{
+		W: styleRect.W - style.GetHorizontalPadding(),
+		H: styleRect.H - style.GetVerticalPadding(),
+	}
+	if styleRect.W > 0 && text.W < 1 {
+		text.W = 1
+	}
+	if styleRect.H > 0 && text.H < 1 {
+		text.H = 1
+	}
+	return text
+}
+
+func wrapOverlayLines(s string, width int) []string {
+	if width <= 0 {
+		return []string{""}
+	}
+	wrapped := xansi.Wrap(s, width, " ")
+	lines := strings.Split(wrapped, "\n")
+	for i := range lines {
+		lines[i] = truncateOverlayLine(lines[i], width)
+	}
+	return lines
+}
+
+func truncateOverlayLine(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= width {
+		return s
+	}
+	out := xansi.Truncate(s, width, "…")
+	if strings.Contains(out, "\x1b") {
+		out += "\x1b[0m"
+	}
+	return out
+}
+
+func renderedLineCount(s string) int {
+	return strings.Count(s, "\n") + 1
+}

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -2,6 +2,7 @@ package overlay
 
 import (
 	"fmt"
+	"strings"
 	"unicode"
 
 	"github.com/sachiniyer/agent-factory/session"
@@ -26,6 +27,8 @@ type SearchOverlay struct {
 	selectedIdx int
 	submitted   bool
 	width       int
+	maxWidth    int
+	maxHeight   int
 }
 
 // NewSearchOverlay creates a search overlay with the given instances.
@@ -41,6 +44,12 @@ func NewSearchOverlay(instances []*session.Instance) *SearchOverlay {
 // SetWidth sets the overlay width.
 func (s *SearchOverlay) SetWidth(width int) {
 	s.width = width
+}
+
+// SetMaxSize sets the maximum outer size the rendered search overlay may occupy.
+func (s *SearchOverlay) SetMaxSize(width, height int) {
+	s.maxWidth = width
+	s.maxHeight = height
 }
 
 // IsSubmitted returns true if the user selected a result.
@@ -170,7 +179,13 @@ func runeEqualFold(a, b rune) bool {
 // the mouse zone registration (zones.go) so the rows registered are exactly
 // the rows rendered.
 func (s *SearchOverlay) visibleWindow() (startIdx, endIdx int) {
-	const maxVisible = 10
+	return s.visibleWindowForRows(10)
+}
+
+func (s *SearchOverlay) visibleWindowForRows(maxVisible int) (startIdx, endIdx int) {
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
 	if s.selectedIdx >= maxVisible {
 		startIdx = s.selectedIdx - maxVisible + 1
 	}
@@ -179,6 +194,106 @@ func (s *SearchOverlay) visibleWindow() (startIdx, endIdx int) {
 		endIdx = len(s.results)
 	}
 	return startIdx, endIdx
+}
+
+type searchRenderPlan struct {
+	styleWidth    int
+	styleHeight   int
+	contentWidth  int
+	contentHeight int
+	compact       bool
+	startIdx      int
+	endIdx        int
+	showAbove     bool
+	showBelow     bool
+}
+
+func searchOverlayStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ui.AccentColor).
+		Padding(1, 2)
+}
+
+func (s *SearchOverlay) renderPlan(style lipgloss.Style) searchRenderPlan {
+	fit := fitOverlayContent(s.width, 0, s.maxWidth, s.maxHeight, style)
+	if fit.W <= 0 {
+		fit.W = s.width
+	}
+	if fit.W <= 0 {
+		fit.W = 1
+	}
+	textRect := overlayTextRect(fit, style)
+	compact := textRect.H > 0 && textRect.H <= 8
+	baseRows := 6
+	if compact {
+		baseRows = 3
+	}
+	availableRows := 10
+	if textRect.H > 0 {
+		availableRows = textRect.H - baseRows
+		if len(s.results) == 0 {
+			availableRows = 0
+		} else if availableRows < 1 {
+			availableRows = 1
+		}
+		startIdx, endIdx, showAbove, showBelow := s.windowForAvailableRows(availableRows)
+		return searchRenderPlan{
+			styleWidth:    fit.W,
+			styleHeight:   fit.H,
+			contentWidth:  textRect.W,
+			contentHeight: textRect.H,
+			compact:       compact,
+			startIdx:      startIdx,
+			endIdx:        endIdx,
+			showAbove:     showAbove,
+			showBelow:     showBelow,
+		}
+	}
+
+	startIdx, endIdx := s.visibleWindowForRows(availableRows)
+	return searchRenderPlan{
+		styleWidth:    fit.W,
+		styleHeight:   fit.H,
+		contentWidth:  textRect.W,
+		contentHeight: textRect.H,
+		compact:       compact,
+		startIdx:      startIdx,
+		endIdx:        endIdx,
+		showAbove:     startIdx > 0,
+		showBelow:     endIdx < len(s.results),
+	}
+}
+
+func (s *SearchOverlay) windowForAvailableRows(available int) (startIdx, endIdx int, showAbove, showBelow bool) {
+	if len(s.results) == 0 {
+		return 0, 0, false, false
+	}
+	if available <= 0 {
+		available = 10
+	}
+	rows := available
+	if rows > 10 {
+		rows = 10
+	}
+	for rows > 0 {
+		startIdx, endIdx = s.visibleWindowForRows(rows)
+		showAbove = startIdx > 0
+		showBelow = endIdx < len(s.results)
+		need := endIdx - startIdx
+		if showAbove {
+			need++
+		}
+		if showBelow {
+			need++
+		}
+		if need <= available {
+			return startIdx, endIdx, showAbove, showBelow
+		}
+		rows--
+	}
+	startIdx, endIdx = s.visibleWindowForRows(1)
+	return startIdx, endIdx, false, false
 }
 
 // Render renders the search overlay.
@@ -195,25 +310,33 @@ func (s *SearchOverlay) Render() string {
 	// warning red + diamond glyph so it never reads as a live Running/Ready dot.
 	statusLimit := lipgloss.NewStyle().Foreground(lipgloss.Color("#E06C75"))
 
-	content := titleStyle.Render("Search Sessions") + "\n\n"
-	content += "/ " + queryStyle.Render(s.query+"_") + "\n\n"
+	style := searchOverlayStyle()
+	plan := s.renderPlan(style)
+
+	var lines []string
+	lines = append(lines, truncateOverlayLine(titleStyle.Render("Search Sessions"), plan.contentWidth))
+	if !plan.compact {
+		lines = append(lines, "")
+	}
+	lines = append(lines, truncateOverlayLine("/ "+queryStyle.Render(s.query+"_"), plan.contentWidth))
+	if !plan.compact {
+		lines = append(lines, "")
+	}
 
 	if len(s.results) == 0 {
 		if s.query == "" {
-			content += normalStyle.Render("  Type to search...") + "\n"
+			lines = append(lines, truncateOverlayLine(normalStyle.Render("  Type to search..."), plan.contentWidth))
 		} else {
-			content += normalStyle.Render("  No matches found.") + "\n"
+			lines = append(lines, truncateOverlayLine(normalStyle.Render("  No matches found."), plan.contentWidth))
 		}
 	}
 
-	startIdx, endIdx := s.visibleWindow()
-
-	if startIdx > 0 {
-		content += normalStyle.Render(
-			fmt.Sprintf("    ... %d more above", startIdx)) + "\n"
+	if plan.showAbove {
+		lines = append(lines, truncateOverlayLine(normalStyle.Render(
+			fmt.Sprintf("    ... %d more above", plan.startIdx)), plan.contentWidth))
 	}
 
-	for i := startIdx; i < endIdx; i++ {
+	for i := plan.startIdx; i < plan.endIdx; i++ {
 		r := s.results[i]
 
 		// Status indicator. Two axes (#1195): a create in flight reads as loading;
@@ -251,30 +374,34 @@ func (s *SearchOverlay) Render() string {
 		}
 
 		if i == s.selectedIdx {
-			content += "  " + statusStr + " " + selectedStyle.Render("▸ "+r.Instance.Title)
+			line := "  " + statusStr + " " + selectedStyle.Render("▸ "+r.Instance.Title)
 			if branch != "" {
-				content += normalStyle.Render(" (" + branch + ")")
+				line += normalStyle.Render(" (" + branch + ")")
 			}
-			content += "\n"
+			lines = append(lines, truncateOverlayLine(line, plan.contentWidth))
 		} else {
-			content += "  " + statusStr + " " + normalStyle.Render("  "+label) + "\n"
+			lines = append(lines, truncateOverlayLine("  "+statusStr+" "+normalStyle.Render("  "+label), plan.contentWidth))
 		}
 	}
 
-	if endIdx < len(s.results) {
-		remaining := len(s.results) - endIdx
-		content += normalStyle.Render(
-			fmt.Sprintf("    ... and %d more below", remaining)) + "\n"
+	if plan.showBelow {
+		remaining := len(s.results) - plan.endIdx
+		lines = append(lines, truncateOverlayLine(normalStyle.Render(
+			fmt.Sprintf("    ... and %d more below", remaining)), plan.contentWidth))
 	}
 
-	content += "\n"
-	content += hintStyle.Render("↑/↓ navigate • enter select • esc close")
+	if !plan.compact {
+		lines = append(lines, "")
+	}
+	hint := "↑/↓ navigate • enter select • esc close"
+	if plan.compact || lipgloss.Width(hint) > plan.contentWidth {
+		hint = "↑/↓ nav • enter • esc close"
+	}
+	lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), plan.contentWidth))
 
-	style := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ui.AccentColor).
-		Padding(1, 2).
-		Width(s.width)
-
-	return style.Render(content)
+	style = style.Width(plan.styleWidth)
+	if plan.styleHeight > 0 && len(lines) >= plan.contentHeight {
+		style = style.Height(plan.styleHeight)
+	}
+	return style.Render(strings.Join(lines, "\n"))
 }

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -174,14 +174,10 @@ func runeEqualFold(a, b rune) bool {
 	return false
 }
 
-// visibleWindow returns the [start, end) result window Render shows: at most
-// maxVisible rows, slid so the selected item is always included. Shared with
-// the mouse zone registration (zones.go) so the rows registered are exactly
-// the rows rendered.
-func (s *SearchOverlay) visibleWindow() (startIdx, endIdx int) {
-	return s.visibleWindowForRows(10)
-}
-
+// visibleWindowForRows returns the [start, end) result window Render shows:
+// at most maxVisible rows, slid so the selected item is always included.
+// Shared with the mouse zone registration (zones.go) so the rows registered
+// are exactly the rows rendered.
 func (s *SearchOverlay) visibleWindowForRows(maxVisible int) (startIdx, endIdx int) {
 	if maxVisible < 1 {
 		maxVisible = 1

--- a/ui/overlay/selectionOverlay.go
+++ b/ui/overlay/selectionOverlay.go
@@ -1,6 +1,8 @@
 package overlay
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -15,6 +17,8 @@ type SelectionOverlay struct {
 	submitted   bool
 	canceled    bool
 	width       int
+	maxWidth    int
+	maxHeight   int
 }
 
 // NewSelectionOverlay creates a new selection overlay with the given title and items
@@ -71,6 +75,12 @@ func (s *SelectionOverlay) SetWidth(width int) {
 	s.width = width
 }
 
+// SetMaxSize sets the maximum outer size the rendered selection overlay may occupy.
+func (s *SelectionOverlay) SetMaxSize(width, height int) {
+	s.maxWidth = width
+	s.maxHeight = height
+}
+
 // Render renders the selection overlay
 func (s *SelectionOverlay) Render() string {
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.AccentColor)
@@ -78,23 +88,85 @@ func (s *SelectionOverlay) Render() string {
 	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
 
-	content := titleStyle.Render(s.title) + "\n\n"
-
-	for i, item := range s.items {
-		if i == s.selectedIdx {
-			content += selectedStyle.Render("▸ "+item) + "\n"
-		} else {
-			content += normalStyle.Render("  "+item) + "\n"
-		}
-	}
-
-	content += "\n" + hintStyle.Render("↑/↓ navigate • enter select • esc cancel")
-
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(ui.AccentColor).
-		Padding(1, 2).
-		Width(s.width)
+		Padding(1, 2)
+	fit := fitOverlayContent(s.width, 0, s.maxWidth, s.maxHeight, style)
+	if fit.W <= 0 {
+		fit.W = s.width
+	}
+	if fit.W <= 0 {
+		fit.W = 1
+	}
+	textRect := overlayTextRect(fit, style)
+	compact := textRect.H > 0 && textRect.H <= 8
 
-	return style.Render(content)
+	lines := []string{truncateOverlayLine(titleStyle.Render(s.title), textRect.W)}
+	if !compact {
+		lines = append(lines, "")
+	}
+
+	availableItems := len(s.items)
+	if textRect.H > 0 {
+		base := 4
+		if compact {
+			base = 2
+		}
+		availableItems = textRect.H - base
+		if availableItems < 1 {
+			availableItems = 1
+		}
+	}
+	start, end := selectionWindow(s.selectedIdx, len(s.items), availableItems)
+	if start > 0 {
+		lines = append(lines, truncateOverlayLine(normalStyle.Render("  ... more above"), textRect.W))
+	}
+	for i := start; i < end; i++ {
+		item := s.items[i]
+		if i == s.selectedIdx {
+			lines = append(lines, truncateOverlayLine(selectedStyle.Render("▸ "+item), textRect.W))
+		} else {
+			lines = append(lines, truncateOverlayLine(normalStyle.Render("  "+item), textRect.W))
+		}
+	}
+	if end < len(s.items) {
+		lines = append(lines, truncateOverlayLine(normalStyle.Render("  ... more below"), textRect.W))
+	}
+
+	if !compact {
+		lines = append(lines, "")
+	}
+	hint := "↑/↓ navigate • enter select • esc cancel"
+	if compact || lipgloss.Width(hint) > textRect.W {
+		hint = "↑/↓ nav • enter • esc cancel"
+	}
+	lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), textRect.W))
+
+	style = style.Width(fit.W)
+	if fit.H > 0 && len(lines) >= textRect.H {
+		style = style.Height(fit.H)
+	}
+	return style.Render(strings.Join(lines, "\n"))
+}
+
+func selectionWindow(selected, total, maxVisible int) (start, end int) {
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
+	if total <= maxVisible {
+		return 0, total
+	}
+	if selected >= maxVisible {
+		start = selected - maxVisible + 1
+	}
+	end = start + maxVisible
+	if end > total {
+		end = total
+		start = end - maxVisible
+		if start < 0 {
+			start = 0
+		}
+	}
+	return start, end
 }

--- a/ui/overlay/zones.go
+++ b/ui/overlay/zones.go
@@ -36,11 +36,25 @@ func (c *ConfirmationOverlay) RegisterZones(reg *zones.Registry, origin layout.P
 	}
 	yesNeedle := c.ConfirmKey + " to confirm"
 	noNeedle := c.CancelKey + " or esc to cancel"
+	compactYesNeedle := c.ConfirmKey + " confirm"
+	compactNoNeedle := c.CancelKey + "/esc cancel"
 	lines := strings.Split(c.Render(), "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
 		plain := xansi.Strip(lines[i])
 		yi := strings.Index(plain, yesNeedle)
 		ni := strings.Index(plain, noNeedle)
+		if yi < 0 {
+			yi = strings.Index(plain, compactYesNeedle)
+			if yi >= 0 {
+				yesNeedle = compactYesNeedle
+			}
+		}
+		if ni < 0 {
+			ni = strings.Index(plain, compactNoNeedle)
+			if ni >= 0 {
+				noNeedle = compactNoNeedle
+			}
+		}
 		if yi < 0 && ni < 0 {
 			continue
 		}
@@ -98,7 +112,8 @@ func (s *SearchOverlay) RegisterZones(reg *zones.Registry, origin layout.Point) 
 	rendered := s.Render()
 	width := lipglossWidth(rendered)
 	lines := strings.Split(rendered, "\n")
-	startIdx, endIdx := s.visibleWindow()
+	plan := s.renderPlan(searchOverlayStyle())
+	startIdx, endIdx := plan.startIdx, plan.endIdx
 	next := startIdx
 	for i, line := range lines {
 		if next >= endIdx {

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -474,8 +474,8 @@ func (s *TaskPane) renderListMode() string {
 
 	// Width available to the indented detail lines under the selected row.
 	detailWidth := s.width - 8
-	if detailWidth < 20 {
-		detailWidth = 20
+	if detailWidth < 1 {
+		detailWidth = 1
 	}
 
 	for i, tsk := range s.tasks {
@@ -507,7 +507,7 @@ func (s *TaskPane) renderListMode() string {
 		// A crash-looped watcher gets its full #797 failure summary on a
 		// detail line — the only always-on detail, and only when errored.
 		if tsk.IsWatch() && strings.HasPrefix(tsk.LastRunStatus, "errored:") {
-			b.WriteString(erroredStyle.Render("      " + tsk.LastRunStatus))
+			b.WriteString(erroredStyle.Render(fitLine("      "+tsk.LastRunStatus, s.width)))
 			b.WriteString("\n")
 		}
 
@@ -535,20 +535,23 @@ func (s *TaskPane) renderListMode() string {
 				}
 				detail += " (" + statusLabel + ")"
 			}
-			b.WriteString(detailStyle.Render(detail))
+			b.WriteString(detailStyle.Render(fitLine(detail, s.width)))
 			b.WriteString("\n")
 		}
 	}
 
 	b.WriteString("\n")
 	if s.hasFocus {
-		b.WriteString(hintStyle.Render(fitLine(
-			"↑/↓ select • n new • enter edit • r run now • x toggle • D delete • esc back", s.width)))
+		hint := "↑/↓ select • n new • enter edit • r run now • x toggle • D delete • esc back"
+		if s.width > 0 && lipgloss.Width(hint) > s.width {
+			hint = "↑/↓ • n new • enter • esc back"
+		}
+		b.WriteString(hintStyle.Render(fitLine(hint, s.width)))
 	} else {
 		b.WriteString(hintStyle.Render(fitLine("enter to focus and edit tasks", s.width)))
 	}
 
-	return b.String()
+	return fitBlockToSize(b.String(), s.width, s.height, 1)
 }
 
 // promptSnippet collapses a prompt to a single line truncated to maxWidth,

--- a/ui/task_pane_edit.go
+++ b/ui/task_pane_edit.go
@@ -237,12 +237,16 @@ func (s *TaskPane) renderEditMode() string {
 		Background(AccentColor).
 		Foreground(lipgloss.Color("0"))
 
-	inputWidth := s.width - 6
-	if inputWidth < 20 {
-		inputWidth = 20
+	inputWidth := s.width - 9
+	if inputWidth < 1 {
+		inputWidth = 1
 	}
 	s.editName.Width = inputWidth
-	s.editPrompt.SetWidth(inputWidth)
+	promptWidth := s.width
+	if promptWidth < 1 {
+		promptWidth = 1
+	}
+	s.editPrompt.SetWidth(promptWidth)
 	if s.height > 0 {
 		s.editPrompt.SetHeight(s.height / 4)
 	}
@@ -370,14 +374,26 @@ func (s *TaskPane) renderEditMode() string {
 	markEnd(taskFocusSave)
 	b.WriteString("\n")
 	if s.creating {
-		b.WriteString(hintStyle.Render(fitLine("tab/shift+tab fields • enter create • esc cancel", s.width)))
+		hint := "tab/shift+tab fields • enter create • esc cancel"
+		if s.width > 0 && lipgloss.Width(hint) > s.width {
+			hint = "tab fields • enter • esc cancel"
+		}
+		b.WriteString(hintStyle.Render(fitLine(hint, s.width)))
 	} else {
-		b.WriteString(hintStyle.Render(fitLine("tab/shift+tab fields • enter save", s.width)))
+		hint := "tab/shift+tab fields • enter save"
+		if s.width > 0 && lipgloss.Width(hint) > s.width {
+			hint = "tab fields • enter save"
+		}
+		b.WriteString(hintStyle.Render(fitLine(hint, s.width)))
 		b.WriteString("\n")
-		b.WriteString(hintStyle.Render(fitLine("r run now • x toggle • D delete • esc list", s.width)))
+		actions := "r run now • x toggle • D delete • esc list"
+		if s.width > 0 && lipgloss.Width(actions) > s.width {
+			actions = "r run • x toggle • D del • esc list"
+		}
+		b.WriteString(hintStyle.Render(fitLine(actions, s.width)))
 	}
 
-	return s.clampFormToHeight(b.String(), focusStart, focusEnd)
+	return fitBlockToSize(s.clampFormToHeight(b.String(), focusStart, focusEnd), s.width, 0, 0)
 }
 
 // clampFormToHeight windows the rendered edit form to the pane height, keeping

--- a/ui/workspace.go
+++ b/ui/workspace.go
@@ -11,26 +11,22 @@ import (
 // N-pane model has no selection-driven pane — content appears when the user
 // opens a tab as a pane (`s`), so the empty state must say exactly that.
 func EmptyWorkspace(r layout.Rect) string {
-	if r.Empty() {
-		return ""
-	}
-	iw := r.W - blurredWindowStyle.GetHorizontalFrameSize()
-	ih := r.H - blurredWindowStyle.GetVerticalFrameSize()
-	if iw < 0 {
-		iw = 0
-	}
-	if ih < 0 {
-		ih = 0
-	}
-	hint := paneHeaderDimStyle.Render("no panes open — s opens the selected tab")
-	inner := lipgloss.Place(iw, ih, lipgloss.Center, lipgloss.Center, hint)
-	return layout.ClampToRect(blurredWindowStyle.Render(inner), r)
+	return emptyWorkspaceContent(r, []string{"no panes open — s opens the selected tab"})
 }
 
 // FirstRunWorkspace renders the zero-session onboarding state. It is distinct
 // from EmptyWorkspace because there is no selected tab yet, so the useful next
 // action is session creation, not opening a pane.
 func FirstRunWorkspace(r layout.Rect) string {
+	return emptyWorkspaceContent(r, []string{
+		"No sessions yet",
+		"Press n to create a local session",
+		"Press ? for all keys",
+		"Setup check: run af doctor --setup",
+	})
+}
+
+func emptyWorkspaceContent(r layout.Rect, lines []string) string {
 	if r.Empty() {
 		return ""
 	}
@@ -42,12 +38,11 @@ func FirstRunWorkspace(r layout.Rect) string {
 	if ih < 0 {
 		ih = 0
 	}
-	content := lipgloss.JoinVertical(lipgloss.Center,
-		paneHeaderDimStyle.Render("No sessions yet"),
-		paneHeaderDimStyle.Render("Press n to create a local session"),
-		paneHeaderDimStyle.Render("Press ? for all keys"),
-		paneHeaderDimStyle.Render("Setup check: run af doctor --setup"),
-	)
+	rendered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		rendered = append(rendered, paneHeaderDimStyle.Render(fitLine(line, iw)))
+	}
+	content := lipgloss.JoinVertical(lipgloss.Center, rendered...)
 	inner := lipgloss.Place(iw, ih, lipgloss.Center, lipgloss.Center, content)
 	return layout.ClampToRect(blurredWindowStyle.Render(inner), r)
 }

--- a/ui/workspace_test.go
+++ b/ui/workspace_test.go
@@ -1,0 +1,29 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyWorkspacePreservesFrameAtTinySize(t *testing.T) {
+	lay := layout.Grid{}.Solve(40, 10)
+	out := EmptyWorkspace(lay.Workspace)
+
+	requireExactRect(t, out, lay.Workspace, "empty workspace")
+	lines := strings.Split(stripANSI(out), "\n")
+	assert.True(t, strings.HasSuffix(lines[0], "╮"), "top right corner must stay visible")
+	assert.True(t, strings.HasSuffix(lines[len(lines)-1], "╯"), "bottom right corner must stay visible")
+}
+
+func TestFirstRunWorkspacePreservesFrameAtTinySize(t *testing.T) {
+	lay := layout.Grid{}.Solve(40, 10)
+	out := FirstRunWorkspace(lay.Workspace)
+
+	requireExactRect(t, out, lay.Workspace, "first-run workspace")
+	lines := strings.Split(stripANSI(out), "\n")
+	assert.True(t, strings.HasSuffix(lines[0], "╮"), "top right corner must stay visible")
+	assert.True(t, strings.HasSuffix(lines[len(lines)-1], "╯"), "bottom right corner must stay visible")
+}


### PR DESCRIPTION
## Summary
- clamp overlay style boxes to terminal bounds before compositing
- add compact/windowed rendering for confirmation, search, selection, hooks, and task overlays at 40x10
- fit empty workspace hints inside the frame before rendering borders

Fixes #1411
Fixes #1412
Fixes #1416
Fixes #1421

## Verification
- gofmt
- go build ./...
- golangci-lint run --fast
- make test-container
- scripts/lint-file-length.sh

Note: this local golangci-lint binary rejects the top-level form `golangci-lint --fast`; `golangci-lint run --fast` is the supported equivalent here.