### PR TITLE
Fix prompt delivery errors for lost sessions

### DIFF
--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -48,6 +48,18 @@ func (b recordingBackend) SendPromptCommand(_ *session.Instance, prompt string) 
 	return nil
 }
 
+// failingPromptBackend returns the low-level send error that should never leak
+// once daemon delivery has rejected an undeliverable liveness state.
+type failingPromptBackend struct {
+	readyFakeBackend
+	sent int
+}
+
+func (b *failingPromptBackend) SendPromptCommand(*session.Instance, string) error {
+	b.sent++
+	return fmt.Errorf("tmux error: session not found")
+}
+
 // slowRecordingKillBackend records prompts like recordingBackend and holds Kill
 // inside the teardown window so a test can exercise delivery while the daemon's
 // killsInFlight marker is set.
@@ -283,6 +295,73 @@ func TestDeliverPrompt_RefusesDeletingTarget(t *testing.T) {
 	}
 	if got := len(rec.snapshot()); got != before {
 		t.Fatalf("prompt was delivered into a Deleting session: recorded count went %d -> %d", before, got)
+	}
+}
+
+// TestDeliverPrompt_RefusesLostTargetBeforeTmuxSend is the #1432 regression:
+// a target session whose daemon record is Lost must produce an actionable
+// liveness error instead of attempting tmux delivery and leaking "session not
+// found" to the RPC/API caller.
+func TestDeliverPrompt_RefusesLostTargetBeforeTmuxSend(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &failingPromptBackend{readyFakeBackend: readyFakeBackend{session.NewFakeBackend()}}
+	registerStarted(t, manager, repoID, repoPath, "captain", backend, true, session.Lost)
+
+	_, err := manager.DeliverPrompt(DeliverPromptRequest{
+		Title:    "captain",
+		RepoPath: repoPath,
+		Program:  "claude",
+		Prompt:   "during-outage",
+	})
+	if err == nil {
+		t.Fatal("expected Lost target delivery to fail")
+	}
+	if !strings.Contains(err.Error(), `target session "captain" is Lost; prompt not delivered; recover it first`) {
+		t.Fatalf("expected actionable Lost error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "tmux") || strings.Contains(err.Error(), "session not found") {
+		t.Fatalf("Lost delivery must not leak raw tmux errors, got: %v", err)
+	}
+	if backend.sent != 0 {
+		t.Fatalf("Lost delivery reached SendPromptCommand %d time(s); want 0", backend.sent)
+	}
+}
+
+func TestSendPrompt_RefusesLostAndDeadTargetsBeforeBackendSend(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     session.Status
+		wantStatus string
+	}{
+		{name: "lost", status: session.Lost, wantStatus: "Lost"},
+		{name: "dead", status: session.Dead, wantStatus: "Dead"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, repoID, repoPath := newStatusTestManager(t)
+			backend := &failingPromptBackend{readyFakeBackend: readyFakeBackend{session.NewFakeBackend()}}
+			registerStarted(t, manager, repoID, repoPath, "captain", backend, true, tc.status)
+
+			err := manager.SendPrompt(SendPromptRequest{
+				Title:  "captain",
+				RepoID: repoID,
+				Prompt: "during-outage",
+			})
+			if err == nil {
+				t.Fatalf("expected %s target send to fail", tc.wantStatus)
+			}
+			want := fmt.Sprintf(`target session "captain" is %s; prompt not delivered; recover it first`, tc.wantStatus)
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("expected actionable %s error, got: %v", tc.wantStatus, err)
+			}
+			if strings.Contains(err.Error(), "tmux") || strings.Contains(err.Error(), "session not found") {
+				t.Fatalf("%s send must not leak raw tmux errors, got: %v", tc.wantStatus, err)
+			}
+			if backend.sent != 0 {
+				t.Fatalf("%s send reached SendPromptCommand %d time(s); want 0", tc.wantStatus, backend.sent)
+			}
+		})
 	}
 }
 
@@ -603,7 +682,7 @@ func TestDeliverPrompt_TmuxOrphanReturnsImmediatelyWithError(t *testing.T) {
 	if !tmux.NewTmuxSessionForRepo(orphanTitle, repo.Root, program).DoesSessionExist() {
 		t.Fatal("orphan tmux session should exist after creation")
 	}
-	if exists, _, err := manager.targetSessionState(repo.ID, orphanTitle); err != nil {
+	if exists, _, _, err := manager.targetSessionState(repo.ID, orphanTitle); err != nil {
 		t.Fatalf("targetSessionState: %v", err)
 	} else if exists {
 		t.Fatal("orphan title should NOT exist in daemon state")

--- a/daemon/delivery.go
+++ b/daemon/delivery.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
 )
 
 // targetDeliverWait bounds how long DeliverPrompt waits for a target session to
@@ -48,12 +49,15 @@ func (m *Manager) DeliverPrompt(req DeliverPromptRequest) (string, error) {
 	unlock := m.lockTarget(repo.ID, req.Title)
 	defer unlock()
 
-	exists, deleting, err := m.targetSessionState(repo.ID, req.Title)
+	exists, deleting, liveness, err := m.targetSessionState(repo.ID, req.Title)
 	if err != nil {
 		return "", err
 	}
 	if deleting {
 		return "", fmt.Errorf("target session %q is being deleted; prompt not delivered", req.Title)
+	}
+	if err := promptTargetLivenessError(req.Title, liveness); err != nil {
+		return "", err
 	}
 	if exists {
 		if err := m.SendPrompt(SendPromptRequest{Title: req.Title, RepoID: repo.ID, Prompt: req.Prompt}); err != nil {
@@ -120,42 +124,47 @@ func (m *Manager) lockTarget(repoID, title string) func() {
 }
 
 // targetSessionState reports whether a session with the given title exists for
-// the repo (in memory or persisted) and whether it is mid-teardown. Deleting is
-// transient in-memory state that is never persisted (#844/#847); the daemon's
-// KillSession path records it in killsInFlight, while TUI-initiated teardown is
-// reflected on the live instance as OpKilling.
-func (m *Manager) targetSessionState(repoID, title string) (exists, deleting bool, err error) {
+// the repo (in memory or persisted), whether it is mid-teardown, and the live
+// daemon instance's liveness when one is tracked. Deleting is transient
+// in-memory state that is never persisted (#844/#847); the daemon's KillSession
+// path records it in killsInFlight, while TUI-initiated teardown is reflected on
+// the live instance as OpKilling.
+func (m *Manager) targetSessionState(repoID, title string) (exists, deleting bool, liveness session.Liveness, err error) {
 	m.mu.Lock()
 	if rerr := m.refreshLocked(); rerr != nil {
 		m.mu.Unlock()
-		return false, false, rerr
+		return false, false, session.LivenessUnset, rerr
 	}
 	key := daemonInstanceKey(repoID, title)
 	inst := m.instances[key]
 	_, killing := m.killsInFlight[key]
 	m.mu.Unlock()
 	if killing {
-		return true, true, nil
+		return true, true, session.LivenessUnset, nil
 	}
 	if inst != nil {
-		return true, inst.IsTearingDown(), nil
+		return true, inst.IsTearingDown(), inst.GetLiveness(), nil
 	}
 
 	exists, err = repoHasSessionTitle(repoID, title)
-	return exists, false, err
+	return exists, false, session.LivenessUnset, err
 }
 
-// waitForTargetSession blocks until the target session exists, surfacing a
-// Deleting session rather than delivering into it, bounded by targetDeliverWait.
+// waitForTargetSession blocks until the target session exists, surfacing
+// undeliverable liveness states rather than delivering into them, bounded by
+// targetDeliverWait.
 func (m *Manager) waitForTargetSession(repoID, title string) error {
 	deadline := time.Now().Add(targetDeliverWait)
 	for {
-		exists, deleting, err := m.targetSessionState(repoID, title)
+		exists, deleting, liveness, err := m.targetSessionState(repoID, title)
 		if err != nil {
 			return err
 		}
 		if deleting {
 			return fmt.Errorf("target session %q is being deleted; prompt not delivered", title)
+		}
+		if err := promptTargetLivenessError(title, liveness); err != nil {
+			return err
 		}
 		if exists {
 			return nil

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -105,8 +105,24 @@ func (m *Manager) SendPrompt(req SendPromptRequest) error {
 	if instance == nil {
 		return fmt.Errorf("failed to restore instance %q", req.Title)
 	}
+	if instance.IsTearingDown() {
+		return fmt.Errorf("target session %q is being deleted; prompt not delivered", req.Title)
+	}
+	if err := promptTargetLivenessError(req.Title, instance.GetLiveness()); err != nil {
+		return err
+	}
 	if err := instance.SendPromptCommand(req.Prompt); err != nil {
 		return fmt.Errorf("failed to send prompt: %w", err)
+	}
+	return nil
+}
+
+func promptTargetLivenessError(title string, liveness session.Liveness) error {
+	switch liveness {
+	case session.LiveLost:
+		return fmt.Errorf("target session %q is Lost; prompt not delivered; recover it first", title)
+	case session.LiveDead:
+		return fmt.Errorf("target session %q is Dead; prompt not delivered; recover it first", title)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Refuse `DeliverPrompt` targets whose tracked daemon instance is `LiveLost` or `LiveDead` before calling `SendPrompt`, returning an actionable recovery error instead of leaking tmux.
- Apply the same Lost/Dead guard to direct `Manager.SendPrompt`, covering the RPC and HTTP/JSON `SendPrompt` surfaces.
- Add regression coverage for `DeliverPrompt` to a Lost target and direct `SendPrompt` to Lost/Dead targets, with a backend that would leak `tmux error: session not found` if reached.

## Adjacent audit
- Direct `SendPrompt`: fixed through `Manager.SendPrompt`.
- HTTP/JSON API: `SendPrompt` and `DeliverPrompt` routes call the same `controlServer`/manager methods, so they inherit the guard.
- Broadcast `send-prompt --all`: already skips Lost/Dead before daemon delivery, so no change needed.
- Watch-task delivery: existing queue/drainer treats delivery errors as retryable backlog; the new clear Lost/Dead error remains a retryable delivery failure and avoids relying on raw tmux text.

## Verification
- Verified on master before the fix: this branch was clean at `origin/master` (`e232c9b`), and `DeliverPrompt`'s exists branch called `SendPrompt` with no liveness check.
- `gofmt`
- `go build ./...`
- `golangci-lint run --fast`
- `deadcode -test ./...`
- `make lint-file-length`
- `make test-container GOTESTARGS="./daemon -run 'TestDeliverPrompt_RefusesLostTargetBeforeTmuxSend|TestSendPrompt_RefusesLostAndDeadTargetsBeforeBackendSend' -count=1"`
- `make test-container`

Closes #1432

Signed-off-by: Captain Claude <captain.claude@example.com>