### PR TITLE
Fix task update trigger switch with disabled flag

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -307,14 +307,27 @@ var tasksUpdateCmd = &cobra.Command{
 		if taskUpdateWatchCmdFlag != "" && strings.TrimSpace(taskUpdateWatchCmdFlag) == "" {
 			return jsonError(errors.New("watch-cmd must be non-empty"))
 		}
+
+		updatedEnabled := s.Enabled
+		switch taskUpdateEnabledFlag {
+		case "true":
+			updatedEnabled = true
+		case "false":
+			updatedEnabled = false
+		case "":
+			// not changed
+		default:
+			return jsonError(fmt.Errorf("--enabled must be 'true' or 'false'"))
+		}
+
 		if taskUpdateCronFlag != "" {
 			if err := task.ValidateCronExpr(taskUpdateCronFlag); err != nil {
 				return jsonError(fmt.Errorf("invalid cron expression: %w", err))
 			}
 			// Watch tasks may have an empty prompt (events default to the raw
 			// line), but a cron fire has no line to fall back to — switching
-			// triggers must supply one.
-			if s.WatchCmd != "" && strings.TrimSpace(s.Prompt) == "" {
+			// triggers must supply one when the resulting cron task is enabled.
+			if updatedEnabled && s.WatchCmd != "" && strings.TrimSpace(s.Prompt) == "" {
 				return jsonError(errors.New("switching to a cron trigger needs a prompt; set one with --prompt"))
 			}
 			// Setting one trigger clears the other so the exactly-one rule
@@ -333,16 +346,7 @@ var tasksUpdateCmd = &cobra.Command{
 			s.TargetSession = taskUpdateTargetSessionFlag
 		}
 
-		switch taskUpdateEnabledFlag {
-		case "true":
-			s.Enabled = true
-		case "false":
-			s.Enabled = false
-		case "":
-			// not changed
-		default:
-			return jsonError(fmt.Errorf("--enabled must be 'true' or 'false'"))
-		}
+		s.Enabled = updatedEnabled
 
 		// Partial-update semantics: "" means "leave unchanged" (mirroring
 		// --name and the add path's taskAddProgramFlag != "" guard). There is

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -340,6 +340,32 @@ func TestTasksUpdate_DisablePersistsViaDaemon(t *testing.T) {
 	assert.Equal(t, 1, calls.writes, "update must dispatch the write to the daemon")
 }
 
+func TestTasksUpdate_SwitchWatchToCronAndDisableWithoutPrompt(t *testing.T) {
+	useTempConfig(t)
+	resetUpdateFlags(t)
+	calls := stubDaemon(t)
+
+	seedTask(t, task.Task{
+		ID:       "watch1437",
+		Name:     "watch",
+		WatchCmd: "tail -f events.log",
+		Enabled:  true,
+	})
+
+	taskUpdateCronFlag = "30 6 * * 1"
+	taskUpdateEnabledFlag = "false"
+	err := tasksUpdateCmd.RunE(tasksUpdateCmd, []string{"watch1437"})
+	require.NoError(t, err)
+
+	got, err := task.GetTask("watch1437")
+	require.NoError(t, err)
+	assert.Equal(t, "30 6 * * 1", got.CronExpr)
+	assert.Empty(t, got.WatchCmd)
+	assert.Empty(t, got.Prompt)
+	assert.False(t, got.Enabled)
+	assert.Equal(t, 1, calls.writes)
+}
+
 func TestTasksUpdate_CronChangePersistsViaDaemon(t *testing.T) {
 	useTempConfig(t)
 	resetUpdateFlags(t)


### PR DESCRIPTION
Closes #1437

## Summary
- validate task trigger updates against the final enabled state from the same command
- allow watch-to-cron updates that also disable the task to persist as disabled cron drafts
- add a CLI regression test for `af tasks update <id> --cron ... --enabled false`

## Verification
- `make test-container GOTESTARGS="./api -run TestTasksUpdate_SwitchWatchToCronAndDisableWithoutPrompt"`
- `gofmt -l .`
- `scripts/lint-file-length.sh`
- `go build ./...`
- `GOTOOLCHAIN=go1.24.2 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0`
- `$(go env GOPATH)/bin/deadcode -test ./...`
- `make test-container`