### PR TITLE
doctor: report non-missing foreign home stat errors

### DIFF
--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -657,13 +657,19 @@ func checkForeignDaemons(ctx *scanContext, report *Report) {
 		if home == activeHome || home == "" {
 			continue // this install's daemon; covered by checkDaemonHealth
 		}
-		if _, err := os.Stat(home); err != nil {
+		if _, err := os.Stat(home); os.IsNotExist(err) {
 			report.Findings = append(report.Findings, Finding{
 				Check: "foreign-daemon",
 				Detail: fmt.Sprintf("%s serves agent-factory home %s which no longer exists "+
 					"(abandoned daemon will run its cron tasks forever)", describeProc(p), home),
 				FixAction: fmt.Sprintf("kill pid %d", pid),
 				fix:       killFix(ctx, p),
+			})
+		} else if err != nil {
+			report.Findings = append(report.Findings, Finding{
+				Check: "foreign-daemon",
+				Detail: fmt.Sprintf("%s serves agent-factory home %s whose status cannot be verified: %v",
+					describeProc(p), home, err),
 			})
 		} else {
 			report.Findings = append(report.Findings, Finding{

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -374,6 +374,25 @@ func TestForeignDaemonHandling(t *testing.T) {
 	require.True(t, alive(intentional))
 }
 
+func TestForeignDaemonStatErrorIsNotReportedAsMissing(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	loopHome := filepath.Join(t.TempDir(), "loop-home")
+	require.NoError(t, os.Symlink(loopHome, loopHome))
+	uncertain := spawnWithEnv(t, "af", []string{"--daemon"}, map[string]string{"AGENT_FACTORY_HOME": loopHome})
+
+	report, err := Run(testOptions(t, true, uncertain.PID))
+	require.NoError(t, err)
+	findings := findByCheck(report, "foreign-daemon")
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Detail, loopHome)
+	require.Contains(t, findings[0].Detail, "status cannot be verified")
+	require.NotContains(t, findings[0].Detail, "no longer exists")
+	require.Empty(t, findings[0].FixAction, "non-ENOENT stat errors must be report-only")
+	require.False(t, findings[0].Fixed)
+	require.True(t, alive(uncertain), "an uncertain foreign daemon must survive --fix")
+}
+
 // TestCleanRunHasNoFindings: an empty environment yields a clean bill of
 // health and exit-0 semantics.
 func TestCleanRunHasNoFindings(t *testing.T) {


### PR DESCRIPTION
## Summary
- only treat a foreign daemon home as missing when os.IsNotExist reports ENOENT
- surface other stat failures as report-only findings with the real stat error
- add a regression test covering an ELOOP stat failure under --fix

Closes #1435

## Verification
- make test-container GOTESTARGS="./doctor -run TestForeignDaemonStatErrorIsNotReportedAsMissing"
- make test-container GOTESTARGS="./doctor"
- gofmt -l doctor/checks.go doctor/doctor_test.go
- git diff --check
- make lint-file-length
- golangci-lint run --fast
- go build ./...
- deadcode -test ./...
- make test-container