### PR TITLE
Honor rebound quit key in pane overlays

### DIFF
--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -132,8 +132,13 @@ func (m *home) showTasksOverlay() (tea.Model, tea.Cmd) {
 // processes its pending actions. Esc in list mode drops the manager's own
 // focus: the overlay closes and any dirty edits are saved — a failed save
 // reloads both views to match disk and is surfaced inline so the dropped
-// edit isn't silent. q and ctrl+c are not consumed by the manager and quit.
+// edit isn't silent. The configured quit key is root-routed before the task
+// form can type it into an input, and ctrl+c still quits from normal mode.
 func (m *home) handleStateTasks(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit]) {
+		return m.handleQuit()
+	}
+
 	sp := m.automations.TaskPane()
 	consumed := sp.HandleKeyPress(msg)
 
@@ -189,10 +194,14 @@ func (m *home) showHooksOverlay() (tea.Model, tea.Cmd) {
 }
 
 // handleStateHooks routes key events to the hooks editor overlay. Esc closes
-// the overlay (the pane drops its own focus) and persists any edits; q and
-// ctrl+c are not consumed by the pane and quit, exactly as they did when the
-// editor was hosted in the content pane.
+// the overlay (the pane drops its own focus) and persists any edits; the
+// configured quit key is root-routed before the pane can type it into an edit
+// field, and ctrl+c still quits from normal mode.
 func (m *home) handleStateHooks(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit]) {
+		return m.handleQuit()
+	}
+
 	consumed := m.hooksPane.HandleKeyPress(msg)
 	if !m.hooksPane.HasFocus() {
 		// The pane released focus (Esc): close the overlay and save. A failed

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
@@ -46,6 +47,34 @@ func TestHandleStateSelectProgramSwitchesAgent(t *testing.T) {
 	_, _ = h.handleStateSelectProgram(tea.KeyMsg{Type: tea.KeyEnter})
 
 	assert.Equal(t, tmux.ProgramCodex, h.pendingProgram)
+}
+
+func TestPaneOverlaysQuitWithReboundKeyBeforeEditFieldsConsumeIt(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{"quit": {"Q"}}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	t.Run("tasks create form", func(t *testing.T) {
+		h := newTestHome(t)
+		tp := h.automations.TaskPane()
+		tp.SetFocus(true)
+		tp.EnterCreateMode("/tmp/repo")
+		h.state = stateTasks
+
+		_, cmd := h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Q")})
+
+		assert.True(t, reachesQuit(cmd), "rebound quit must quit before the task form types it")
+	})
+
+	t.Run("hooks add form", func(t *testing.T) {
+		h := newTestHome(t)
+		h.hooksPane.SetFocus(true)
+		h.state = stateHooks
+		_, _ = h.handleStateHooks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+
+		_, cmd := h.handleStateHooks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Q")})
+
+		assert.True(t, reachesQuit(cmd), "rebound quit must quit before the hooks form types it")
+	})
 }
 
 // TestHandleStateTasks_PendingCreateFlushesDirtyTaskState is the regression

--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -73,7 +73,7 @@ func (h *HooksPane) HandleKeyPress(msg tea.KeyMsg) bool {
 }
 
 func (h *HooksPane) handleNormalMode(msg tea.KeyMsg) bool {
-	if msg.String() == "ctrl+c" || msg.String() == "q" {
+	if msg.String() == "ctrl+c" || configuredQuitKey(msg) {
 		return false
 	}
 	switch msg.String() {

--- a/ui/hooks_pane_test.go
+++ b/ui/hooks_pane_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHooksPaneEditModeCtrlCCancels(t *testing.T) {
@@ -19,6 +21,19 @@ func TestHooksPaneEditModeCtrlCCancels(t *testing.T) {
 	assert.False(t, h.editing)
 	assert.False(t, h.adding)
 	assert.Empty(t, h.editBuffer)
+}
+
+func TestHooksPaneNormalModeAllowsReboundQuitKeyToPropagate(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{"quit": {"Q"}}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	h := NewHooksPane()
+	h.SetCommands([]string{"make test"})
+	h.SetFocus(true)
+
+	assert.False(t, h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Q")}))
+	assert.True(t, h.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}),
+		"the old default key must not keep propagating after quit is rebound")
 }
 
 func TestHooksPaneSetCommandsEmptySliceBug(t *testing.T) {

--- a/ui/quit_key.go
+++ b/ui/quit_key.go
@@ -1,0 +1,12 @@
+package ui
+
+import (
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/sachiniyer/agent-factory/keys"
+)
+
+func configuredQuitKey(msg tea.KeyMsg) bool {
+	return key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit])
+}

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -314,7 +314,7 @@ func (s *TaskPane) HandleKeyPress(msg tea.KeyMsg) bool {
 }
 
 func (s *TaskPane) handleNormalMode(msg tea.KeyMsg) bool {
-	if msg.String() == "ctrl+c" || msg.String() == "q" {
+	if msg.String() == "ctrl+c" || configuredQuitKey(msg) {
 		return false
 	}
 	switch msg.String() {

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/task"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -151,6 +152,18 @@ func TestTaskPaneNormalModeAllowsQuitKeysToPropagate(t *testing.T) {
 
 	assert.False(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}))
 	assert.False(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyCtrlC}))
+}
+
+func TestTaskPaneNormalModeAllowsReboundQuitKeyToPropagate(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{"quit": {"Q"}}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	tp := NewTaskPane()
+	tp.SetFocus(true)
+
+	assert.False(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Q")}))
+	assert.True(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}),
+		"the old default key must not keep propagating after quit is rebound")
 }
 
 // tabTo advances the edit-form focus from its current position by pressing


### PR DESCRIPTION
Closes #1439

## Summary
- route the configured quit binding before task and hooks overlay edit fields can consume it
- make task and hooks pane normal mode propagate the effective quit binding instead of hardcoded `q`
- add app and pane regression tests for rebound quit keys

## Verification
- `make test-container GOTESTARGS="./app ./ui -run 'TestPaneOverlaysQuitWithReboundKeyBeforeEditFieldsConsumeIt|TestTaskPaneNormalModeAllowsReboundQuitKeyToPropagate|TestHooksPaneNormalModeAllowsReboundQuitKeyToPropagate'"`\n- `gofmt -l .`\n- `scripts/lint-file-length.sh`\n- `go build ./...`\n- `GOTOOLCHAIN=go1.24.2 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0`\n- `$(go env GOPATH)/bin/deadcode -test ./...`\n- `make test-container`\n\nNote: root should do the requested manual play-test; I did not run `tui-driver` against a real repo.