### PR TITLE
Fix secondary TUI archive restore projection

### DIFF
--- a/app/archive_panes_test.go
+++ b/app/archive_panes_test.go
@@ -91,7 +91,9 @@ func TestRestore_LeavesNoStalePaneBinding(t *testing.T) {
 
 	title := inst.Title
 	data := inst.ToInstanceData()
+	data.Status = session.Running
 	data.Liveness = session.LiveRunning
+	data.InFlightOp = session.OpNone
 	h.reconcileSnapshot([]session.InstanceData{data})
 
 	// The restore rebuilt the row: re-resolve by title (the pointer changed) and

--- a/app/archive_reconcile_test.go
+++ b/app/archive_reconcile_test.go
@@ -27,18 +27,18 @@ func storeArchivingInstance(t *testing.T, h *home, title string) *session.Instan
 // #1195 regression gate. The old bug: a locally-archiving row was skipped by
 // isTransientStatus on every reconcile, so a poll that caught the archive fence
 // stranded it on "Tearing down session…" forever. Under the two-axis model the
-// daemon liveness is applied UNCONDITIONALLY (it never carries the op), so the row
-// can never be stranded: a mid-archive snapshot leaves it archiving, and the
-// terminal Archived always lands and clears the op. This test makes the failure
-// structurally impossible to reproduce.
+// daemon liveness is applied UNCONDITIONALLY and the op is reconciled on its own
+// axis, so the row can never be stranded: a mid-archive snapshot leaves it
+// archiving, and the terminal Archived always lands and clears the op. This test
+// makes the failure structurally impossible to reproduce.
 func TestReconcile_ArchivingRowReachesArchived(t *testing.T) {
 	h := newTestHome(t)
 	inst := storeArchivingInstance(t, h, "worker")
 	require.Equal(t, session.Deleting, inst.GetStatus(), "an archiving row renders as Deleting")
 
 	// A poll lands INSIDE the archive fence: the daemon still reports the live
-	// liveness (its OpArchiving fence is not serialized). The row must keep
-	// showing archiving — applied liveness, op preserved — never stranded.
+	// liveness and the archive op. The row must keep showing archiving — applied
+	// liveness, op preserved — never stranded.
 	mid := inst.ToInstanceData()
 	mid.Liveness = session.LiveRunning
 	h.reconcileSnapshot([]session.InstanceData{mid})
@@ -48,11 +48,123 @@ func TestReconcile_ArchivingRowReachesArchived(t *testing.T) {
 	// The daemon completes the archive and reports the terminal liveness. The row
 	// MUST reach Archived and clear its op — the strand the old code allowed.
 	done := inst.ToInstanceData()
+	done.Status = session.Archived
 	done.Liveness = session.LiveArchived
+	done.InFlightOp = session.OpNone
 	h.reconcileSnapshot([]session.InstanceData{done})
 	require.Equal(t, session.OpNone, inst.GetInFlightOp(), "the settled Archived liveness clears the op")
 	require.Equal(t, session.Archived, inst.GetStatus(),
 		"a daemon-confirmed Archived must always land — never stranded on Tearing down")
+}
+
+// TestReconcile_SecondaryColdStartMidArchiveReachesArchived is the #1436
+// secondary-TUI regression. A non-primary TUI can cold-start while another
+// client/CLI has the daemon mid-archive. The snapshot must carry OpArchiving
+// explicitly; reconstructing it from Status=Deleting turns it into OpKilling,
+// and the later LiveArchived snapshot never clears the stale Deleting overlay.
+func TestReconcile_SecondaryColdStartMidArchiveReachesArchived(t *testing.T) {
+	h := newTestHome(t)
+
+	daemonInst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "worker",
+		Path:    t.TempDir(),
+		Program: "test",
+	})
+	require.NoError(t, err)
+	daemonInst.SetBackend(session.NewFakeBackend())
+	daemonInst.SetStartedForTest(true)
+	daemonInst.SetStatusForTest(session.Running)
+	daemonInst.SetInFlightOpForTest(session.OpArchiving)
+
+	mid := daemonInst.ToInstanceData()
+	require.Equal(t, session.Deleting, mid.Status, "archive fence still composes to the legacy Deleting value")
+	require.Equal(t, session.LiveRunning, mid.Liveness)
+	require.Equal(t, session.OpArchiving, mid.InFlightOp,
+		"the daemon snapshot must preserve archiving, not only legacy Deleting")
+
+	restore := SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		inst, err := session.NewInstance(session.InstanceOptions{
+			Title:   d.Title,
+			Path:    t.TempDir(),
+			Program: "test",
+		})
+		require.NoError(t, err)
+		inst.ID = d.ID
+		inst.CreatedAt = d.CreatedAt
+		inst.SetBackend(session.NewFakeBackend())
+		inst.SetStartedForTest(true)
+		_ = inst.Transition(session.ObserveLiveness(snapshotLiveness(inst.GetLiveness(), d)))
+		inst.SetInFlightOpForTest(d.InFlightOp)
+		return inst, nil
+	})
+	defer restore()
+
+	h.reconcileSnapshot([]session.InstanceData{mid})
+	projection := h.store.GetInstanceByTitle("worker")
+	require.NotNil(t, projection)
+	require.Equal(t, session.OpArchiving, projection.GetInFlightOp(),
+		"cold-started projection must adopt the daemon's exact archive op")
+	require.Equal(t, session.Deleting, projection.GetStatus())
+
+	done := mid
+	done.Status = session.Archived
+	done.Liveness = session.LiveArchived
+	done.InFlightOp = session.OpNone
+	h.reconcileSnapshot([]session.InstanceData{done})
+
+	require.Same(t, projection, h.store.GetInstanceByTitle("worker"),
+		"same-session archive completion updates in place")
+	require.Equal(t, session.OpNone, projection.GetInFlightOp(),
+		"the settled Archived liveness clears the archive op")
+	require.Equal(t, session.Archived, projection.GetStatus(),
+		"a secondary TUI must converge to Archived instead of staying Deleting")
+}
+
+// TestReconcile_StaleDeletingProjectionClearsOnArchivedSnapshot covers the
+// already-stranded half of #1436: a secondary TUI that reconstructed
+// Status=Deleting as OpKilling must still converge once the daemon reports the
+// terminal Archived liveness.
+func TestReconcile_StaleDeletingProjectionClearsOnArchivedSnapshot(t *testing.T) {
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "worker")
+	inst.SetInFlightOpForTest(session.OpKilling)
+	h.store.AddInstance(inst)
+	require.Equal(t, session.Deleting, inst.GetStatus(), "precondition: stale projection is stuck as Deleting")
+
+	data := inst.ToInstanceData()
+	data.Status = session.Archived
+	data.Liveness = session.LiveArchived
+	data.InFlightOp = session.OpNone
+
+	h.reconcileSnapshot([]session.InstanceData{data})
+
+	require.Equal(t, session.OpNone, inst.GetInFlightOp())
+	require.Equal(t, session.Archived, inst.GetStatus(),
+		"terminal daemon Archived must clear a stale Deleting overlay")
+}
+
+// TestReconcile_StaleRestoringProjectionClearsOnLiveSnapshot is the restore-side
+// #1436 convergence check. A secondary row that is visibly Lost only because of
+// OpRestoring must clear that overlay when the daemon reports the restored live
+// state.
+func TestReconcile_StaleRestoringProjectionClearsOnLiveSnapshot(t *testing.T) {
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "worker")
+	inst.SetStatusForTest(session.Lost)
+	inst.SetInFlightOpForTest(session.OpRestoring)
+	h.store.AddInstance(inst)
+	require.Equal(t, session.Lost, inst.GetStatus(), "precondition: restoring overlay composes to Lost")
+
+	data := inst.ToInstanceData()
+	data.Status = session.Running
+	data.Liveness = session.LiveRunning
+	data.InFlightOp = session.OpNone
+
+	h.reconcileSnapshot([]session.InstanceData{data})
+
+	require.Equal(t, session.OpNone, inst.GetInFlightOp())
+	require.Equal(t, session.Running, inst.GetStatus(),
+		"terminal daemon Running must clear a stale restore overlay")
 }
 
 // TestReconcile_OptimisticKillPreservedForNonTerminal guards the kill UX: a
@@ -80,6 +192,7 @@ func TestReconcile_OptimisticKillPreservedForNonTerminal(t *testing.T) {
 
 			data := inst.ToInstanceData()
 			data.Liveness = tc.liveness
+			data.InFlightOp = session.OpNone
 			h.reconcileSnapshot([]session.InstanceData{data})
 
 			require.Equal(t, session.OpKilling, inst.GetInFlightOp())
@@ -122,7 +235,9 @@ func TestReconcile_ArchivedToLiveRebuildsStarted(t *testing.T) {
 
 	// The daemon reports the session restored (worktree back, agent re-spawned).
 	data := archived.ToInstanceData()
+	data.Status = session.Running
 	data.Liveness = session.LiveRunning
+	data.InFlightOp = session.OpNone
 	h.reconcileSnapshot([]session.InstanceData{data})
 
 	require.Equal(t, 1, built, "an archived→live transition must rebuild (re-Start), not update in place")
@@ -150,7 +265,9 @@ func TestReconcile_LostToLiveStaysInPlace(t *testing.T) {
 	defer restore()
 
 	data := inst.ToInstanceData()
+	data.Status = session.Running
 	data.Liveness = session.LiveRunning
+	data.InFlightOp = session.OpNone
 	h.reconcileSnapshot([]session.InstanceData{data})
 
 	require.Same(t, inst, h.store.GetInstanceByTitle("worker"), "same pointer preserved (in-place update)")
@@ -242,7 +359,9 @@ func TestRestore_EagerRehomeDoesNotBypassRebuild(t *testing.T) {
 
 	// The daemon now reports the session restored (worktree back, agent re-spawned).
 	data := archived.ToInstanceData()
+	data.Status = session.Running
 	data.Liveness = session.LiveRunning
+	data.InFlightOp = session.OpNone
 	h.reconcileSnapshot([]session.InstanceData{data})
 
 	require.Equal(t, 1, built,

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -154,9 +154,9 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 	// Runs synchronously in the confirmation overlay's OnConfirm, on the
 	// event loop — keep it fast. Raising the optimistic OpKilling op here (not in
 	// the background cmd) guarantees the row is visibly deleting and kill/attach
-	// are fenced off before any other event can be processed. The op is a local
-	// overlay the daemon snapshot never carries (#1195), so it composes to
-	// Deleting for rendering and can never be clobbered by a reconcile.
+	// are fenced off before any other event can be processed. OpKilling is a local
+	// overlay (the daemon does not emit a kill op; it drops the record), so it
+	// composes to Deleting for rendering and survives non-terminal reconciles.
 	killAction := func() tea.Msg {
 		for _, inst := range m.store.GetInstances() {
 			if inst.Title == selectedTitle {

--- a/app/sync.go
+++ b/app/sync.go
@@ -560,11 +560,14 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 	// liveness) and the TUI renders it. Applied UNCONDITIONALLY — daemon liveness
 	// always wins — which is what makes #1187 structurally impossible: a
 	// locally-archiving row still receives the terminal Archived instead of being
-	// stranded. The local in-flight op is a separate axis the daemon snapshot
-	// never carries, so this can never clobber an optimistic kill/archive marker.
+	// stranded. The op axis is reconciled separately below so a liveness write
+	// never clobbers a local optimistic marker by accident.
 	lv := snapshotLiveness(inst.GetLiveness(), d)
 	if inst.GetLiveness() != lv {
 		_ = inst.Transition(session.ObserveLiveness(lv))
+		changed = true
+	}
+	if reconcileSnapshotOp(inst, d.InFlightOp, lv) {
 		changed = true
 	}
 	// Mirror the usage-limit reset time (#1146) alongside the liveness. It's
@@ -580,13 +583,6 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 			inst.SetLimitResetAt(d.LimitResetAt)
 			changed = true
 		}
-	}
-	// Clear a local optimistic op once the daemon liveness confirms its outcome.
-	// An archive settles at Archived; a kill's op is cleared by row removal, not
-	// here, so it survives liveness updates until the daemon drops the record.
-	if inst.GetInFlightOp() == session.OpArchiving && lv == session.LiveArchived {
-		_ = inst.Transition(session.ClearOp())
-		changed = true
 	}
 	// Remote instances' tabs come from hook config (terminal_cmd), not the
 	// snapshot, so the backend owns them — skip the tab reconcile.
@@ -616,6 +612,62 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 		changed = true
 	}
 	return changed
+}
+
+// reconcileSnapshotOp mirrors the daemon snapshot's operation axis while
+// preserving local optimistic operations until the daemon liveness confirms an
+// outcome. Snapshot ops are transient but authoritative for daemon-side
+// archive/restore windows (#1436); terminal snapshots carry OpNone and clear
+// stale overlays through the Transition chokepoint.
+func reconcileSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.Liveness) bool {
+	if op != session.OpNone {
+		return adoptSnapshotOp(inst, op, lv)
+	}
+
+	switch inst.GetInFlightOp() {
+	case session.OpArchiving, session.OpKilling:
+		if lv == session.LiveArchived || lv == session.LiveLost {
+			_ = inst.Transition(session.ClearOp())
+			return true
+		}
+	case session.OpRestoring:
+		if lv != session.LiveArchived {
+			_ = inst.Transition(session.ClearOp())
+			return true
+		}
+	}
+	return false
+}
+
+func adoptSnapshotOp(inst *session.Instance, op session.InFlightOp, lv session.Liveness) bool {
+	if inst.GetInFlightOp() == op {
+		return false
+	}
+	if inst.GetInFlightOp() != session.OpNone {
+		_ = inst.Transition(session.ClearOp())
+	}
+
+	var err error
+	switch op {
+	case session.OpCreating:
+		err = inst.Transition(session.BeginCreate())
+	case session.OpKilling:
+		err = inst.Transition(session.BeginKill())
+	case session.OpArchiving:
+		if lv == session.LiveArchived {
+			return true
+		}
+		err = inst.Transition(session.BeginArchive())
+	case session.OpRestoring:
+		err = inst.Transition(session.MarkRestoring())
+	default:
+		return false
+	}
+	if err != nil {
+		log.WarningLog.Printf("failed to adopt snapshot op %v for %q: %v", op, inst.Title, err)
+		return false
+	}
+	return true
 }
 
 // prInfoFromData rebuilds a *git.PRInfo from its serialized form, returning nil

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -115,9 +115,10 @@ func TestReconcileSnapshot_MirrorsStatusOntoExistingRow(t *testing.T) {
 
 // TestReconcileSnapshot_LeavesTransientOpAlone guards the #1195 structural
 // property: a row the TUI owns mid-kill (local OpKilling) keeps its op through a
-// reconcile even though the daemon liveness is applied. The daemon snapshot never
-// carries the op, and a liveness write can't touch the separate op axis, so the
-// composed status stays Deleting — replacing the old isTransientStatus skip.
+// reconcile even though the daemon liveness is applied. A terminal snapshot
+// clears kill by removing the row; a non-terminal liveness write can't touch the
+// separate local op axis, so the composed status stays Deleting — replacing the
+// old isTransientStatus skip.
 func TestReconcileSnapshot_LeavesTransientOpAlone(t *testing.T) {
 	h := newTestHome(t)
 	inst := instanceWithFakeBackend(t, "a")
@@ -126,6 +127,7 @@ func TestReconcileSnapshot_LeavesTransientOpAlone(t *testing.T) {
 
 	data := inst.ToInstanceData()
 	data.Liveness = session.LiveReady // daemon doesn't know about the in-flight kill
+	data.InFlightOp = session.OpNone
 
 	h.reconcileSnapshot([]session.InstanceData{data})
 

--- a/daemon/manager_persist.go
+++ b/daemon/manager_persist.go
@@ -14,6 +14,7 @@ import (
 )
 
 func appendInstanceData(repoID string, data session.InstanceData) error {
+	data = data.ForStorage()
 	return config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {
 		var existing []session.InstanceData
 		if err := json.Unmarshal(raw, &existing); err != nil {
@@ -50,6 +51,7 @@ func appendInstanceData(repoID string, data session.InstanceData) error {
 // no record with that title exists (the caller already resolved a live
 // instance, so a missing disk record means storage drifted out from under us).
 func persistInstanceData(repoID string, data session.InstanceData) error {
+	data = data.ForStorage()
 	found := false
 	if err := config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {
 		var existing []session.InstanceData

--- a/daemon/rootkill.go
+++ b/daemon/rootkill.go
@@ -124,6 +124,7 @@ func (m *Manager) finishUserKill(repoID string, instance *session.Instance) {
 }
 
 func persistInstanceDataByStableID(repoID string, data session.InstanceData) error {
+	data = data.ForStorage()
 	found := false
 	sameTitleDifferentID := false
 	if err := config.UpdateRepoInstances(repoID, func(raw json.RawMessage) (json.RawMessage, error) {

--- a/daemon/snapshot_test.go
+++ b/daemon/snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
 )
 
 // TestManagerSnapshot_RepoScopedAndOrdered verifies Manager.Snapshot returns the
@@ -53,6 +54,33 @@ func TestManagerSnapshot_RepoScopedAndOrdered(t *testing.T) {
 	sort.Strings(sortedAll)
 	if !equalStrings(sortedAll, []string{"a1", "a2", "b1"}) {
 		t.Fatalf("Snapshot(\"\") = %v, want all three sessions", gotAll)
+	}
+}
+
+func TestManagerSnapshot_CarriesInFlightOp(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	m, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	inst := startedLocalTabInstance(t, m, repo.ID, repoPath, "worker", "af_worker_agent")
+	inst.SetInFlightOpForTest(session.OpArchiving)
+
+	data := m.Snapshot(repo.ID)
+	if len(data) != 1 {
+		t.Fatalf("Snapshot returned %d instances, want 1", len(data))
+	}
+	if data[0].InFlightOp != session.OpArchiving {
+		t.Fatalf("snapshot in-flight op = %v, want OpArchiving", data[0].InFlightOp)
+	}
+	if data[0].Status != session.Deleting {
+		t.Fatalf("snapshot legacy status = %v, want Deleting", data[0].Status)
 	}
 }
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -95,10 +95,11 @@ type Instance struct {
 	Branch string
 	// liveness and inFlightOp are the two orthogonal axes of session state
 	// (#1195): liveness is the daemon-owned health of the backing session
-	// (Running/Ready/Lost/Archived/…), inFlightOp is the transient, never-
-	// persisted client operation overlaid on it (Creating/Killing/Archiving/
-	// Restoring). The legacy Status enum is derived from them via the
-	// GetStatus/SetStatus shim in liveness.go. Both are mutex-protected.
+	// (Running/Ready/Lost/Archived/…), inFlightOp is the transient client
+	// operation overlaid on it (Creating/Killing/Archiving/Restoring). Snapshots
+	// carry the op so secondary TUIs converge; disk persistence strips it. The
+	// legacy Status enum is derived from them via the GetStatus/SetStatus shim in
+	// liveness.go. Both are mutex-protected.
 	liveness   Liveness
 	inFlightOp InFlightOp
 	// limitResetAt is the parsed usage-limit reset time (#1146), display-only in

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -18,14 +18,13 @@ func (i *Instance) ToInstanceData() InstanceData {
 		Title:  i.Title,
 		Path:   i.Path,
 		Branch: i.Branch,
-		// Persist BOTH axes: Liveness is the new canonical value, Status the
-		// legacy int kept for one release so a binary rolled back to before
-		// #1195 still reads a sensible status (and as the read-fallback source
-		// for records this build wrote before the split). SaveInstances skips
-		// transient (Loading/Deleting) rows, so a persisted Status is always a
-		// settled liveness value.
+		// Serialize the two-axis state plus the legacy composed Status. Liveness is
+		// the daemon truth; InFlightOp rides daemon snapshots so secondary TUIs can
+		// cold-start into archive/restore operations without lossy Status
+		// reconstruction (#1436). Disk writers scrub InFlightOp before persistence.
 		Status:     i.statusLocked(),
 		Liveness:   i.liveness,
+		InFlightOp: i.inFlightOp,
 		Height:     i.Height,
 		Width:      i.Width,
 		CreatedAt:  i.CreatedAt,
@@ -121,11 +120,12 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 	// build restorable after an upgrade. A tombstoned record keeps its (Lost)
 	// status; the daemon finishes its teardown rather than restoring it.
 	liveness := livenessFromData(data)
-	// Resolve the in-flight-op axis from the legacy status. A persisted record
-	// is always settled (SaveInstances skips transients), but a SNAPSHOT of a
-	// transient instance carries Loading/Deleting, which buildInstanceFromSnapshot
-	// must reconstruct so the rebuilt row composes to the identical Status.
-	inFlightOp := opForStatus(data.Status)
+	// Resolve the in-flight-op axis from the snapshot payload, falling back to
+	// the legacy status for old daemons/records. A persisted record is always
+	// settled (disk writers scrub this field and SaveInstances skips
+	// Loading/Deleting), but a SNAPSHOT can catch archive/restore in progress and
+	// must round-trip the exact op (#1436).
+	inFlightOp := inFlightOpFromData(data)
 	instance := &Instance{
 		ID:           data.ID,
 		Title:        data.Title,

--- a/session/liveness.go
+++ b/session/liveness.go
@@ -54,10 +54,10 @@ const (
 )
 
 // InFlightOp is the client/executor-owned axis: the operation a client (or the
-// daemon executor) is mid-way through, overlaid on the liveness. It is NEVER
-// serialized and NEVER carried in the daemon snapshot — a transient overlay that
-// clears when the liveness confirms the op's outcome. A separate field for it is
-// what will retire the reconstruct-at-read apparatus (1d).
+// daemon executor) is mid-way through, overlaid on the liveness. It is carried
+// in daemon Snapshots so read-only TUIs can cold-start into the exact
+// archive/restore operation, but disk writers scrub it before persistence: a
+// transient overlay must not survive a daemon restart.
 type InFlightOp int
 
 const (
@@ -142,6 +142,16 @@ func opForStatus(s Status) InFlightOp {
 		return OpKilling
 	}
 	return OpNone
+}
+
+// inFlightOpFromData resolves the operation axis a persisted or snapshot record
+// should take. New daemon snapshots carry the exact op; older payloads and disk
+// records omit it and fall back to the legacy composed Status.
+func inFlightOpFromData(data InstanceData) InFlightOp {
+	if data.InFlightOp != OpNone {
+		return data.InFlightOp
+	}
+	return opForStatus(data.Status)
 }
 
 // statusLocked composes the legacy Status under the caller-held mutex. It is the

--- a/session/liveness_test.go
+++ b/session/liveness_test.go
@@ -84,3 +84,53 @@ func TestLivenessPersistenceRollforward(t *testing.T) {
 	assert.Equal(t, LiveLost, LivenessForStatus(legacy.Status),
 		"the fallback maps the legacy status onto the liveness axis")
 }
+
+// TestSnapshotInFlightOpRoundTrips guards #1436: a daemon Snapshot must carry
+// the transient operation axis explicitly. The legacy Status value is lossy
+// (OpArchiving and OpKilling both compose to Deleting; OpRestoring composes to
+// Lost), so secondary TUIs must not reconstruct the op from Status alone.
+func TestSnapshotInFlightOpRoundTrips(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		op     InFlightOp
+		status Status
+	}{
+		{name: "archiving", op: OpArchiving, status: Deleting},
+		{name: "restoring", op: OpRestoring, status: Lost},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			i := &Instance{}
+			i.SetStatusForTest(Running)
+			i.SetInFlightOpForTest(tc.op)
+
+			data := i.ToInstanceData()
+			require.Equal(t, tc.status, data.Status, "legacy status still carries the composed value")
+			require.Equal(t, tc.op, data.InFlightOp, "snapshot data must preserve the non-round-trippable op")
+
+			raw, err := json.Marshal(data)
+			require.NoError(t, err)
+			assert.Contains(t, string(raw), `"in_flight_op":`, "snapshots encode the op axis")
+
+			var back InstanceData
+			require.NoError(t, json.Unmarshal(raw, &back))
+			require.Equal(t, tc.op, inFlightOpFromData(back))
+		})
+	}
+
+	legacy := InstanceData{Status: Deleting}
+	require.Equal(t, OpKilling, inFlightOpFromData(legacy),
+		"legacy data without in_flight_op keeps the old Deleting fallback")
+}
+
+func TestInFlightOpStrippedFromStorageRecords(t *testing.T) {
+	data := InstanceData{Status: Deleting, Liveness: LiveRunning, InFlightOp: OpArchiving}
+	stored := data.ForStorage()
+	require.Equal(t, OpNone, stored.InFlightOp)
+	require.Equal(t, Running, stored.Status,
+		"storage must persist the settled liveness status, not a transient overlay")
+
+	raw, err := json.Marshal(stored)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "in_flight_op",
+		"instances.json must not persist transient operations")
+}

--- a/session/storage.go
+++ b/session/storage.go
@@ -28,6 +28,12 @@ type InstanceData struct {
 	// no `liveness` key and decode to LivenessUnset, signaling FromInstanceData
 	// to fall back to the legacy `status` int (rollforward).
 	Liveness Liveness `json:"liveness,omitempty"`
+	// InFlightOp is the transient operation axis (#1195/#1436) carried by the
+	// daemon Snapshot so secondary TUIs can reconstruct non-round-trippable ops
+	// exactly (OpArchiving vs OpKilling; OpRestoring vs plain Lost). It is scrubbed
+	// at disk write/load boundaries: in-flight operations are process-local and
+	// must not be resurrected after a daemon restart.
+	InFlightOp InFlightOp `json:"in_flight_op,omitempty"`
 	// LimitResetAt is the parsed usage-limit reset time (#1146), display-only:
 	// written (and carried in the daemon snapshot to the read-only TUI) only for a
 	// LiveLimitReached row so the sidebar [limit] badge can show "resets <t>" and
@@ -57,6 +63,17 @@ type InstanceData struct {
 	PRInfo            PRInfoData             `json:"pr_info,omitempty"`
 	BackendType       string                 `json:"backend_type,omitempty"`
 	RemoteMeta        map[string]interface{} `json:"remote_meta,omitempty"`
+}
+
+// ForStorage returns data suitable for instances.json. InstanceData is also the
+// daemon Snapshot payload, so it can carry transient in-flight operation state;
+// disk persistence must not.
+func (d InstanceData) ForStorage() InstanceData {
+	lv := livenessFromData(d)
+	d.Status = composeStatus(lv, OpNone)
+	d.Liveness = lv
+	d.InFlightOp = OpNone
+	return d
 }
 
 // TabData is the serializable form of a session.Tab. The full list is persisted
@@ -194,7 +211,7 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 			root = inst.Path
 		}
 		rid := config.RepoIDFromRoot(root)
-		grouped[rid] = append(grouped[rid], inst.ToInstanceData())
+		grouped[rid] = append(grouped[rid], inst.ToInstanceData().ForStorage())
 	}
 
 	for rid, group := range grouped {
@@ -254,6 +271,7 @@ func (s *Storage) LoadInstances() ([]*Instance, error) {
 		// immediately, not just after the next save rewrites the file.
 		instancesData = dedupeInstanceData(instancesData)
 		for _, data := range instancesData {
+			data = data.ForStorage()
 			instance, err := FromInstanceData(data)
 			if err != nil {
 				// Instance's tmux session or worktree may have been


### PR DESCRIPTION
## Summary
- Carry the daemon snapshot in-flight operation axis so secondary TUIs can cold-start mid archive/restore without lossy Status reconstruction.
- Reconcile snapshot ops through the Transition chokepoint and clear stale Deleting/Lost overlays when terminal daemon liveness arrives.
- Strip transient ops, and their composed transient legacy Status, from instances.json persistence.

## Tests
- gofmt -l .
- make lint-file-length
- go build ./...
- golangci-lint run --timeout=3m --fast
- deadcode -test ./...
- make test-container

Closes #1436