### PR TITLE
fix(tui): keep help overlay open on shift-scroll

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -282,6 +282,10 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 
 		m.textOverlay = overlay.NewTextOverlay(content)
 		m.textOverlay.OnDismiss = onDismiss
+		m.textOverlayDismissAnyKey = true
+		if _, ok := helpType.(helpTypeGeneral); ok {
+			m.textOverlayDismissAnyKey = false
+		}
 		if _, ok := helpType.(helpTypeInteractive); ok {
 			m.replayHelpDismissKey = true
 		}
@@ -299,20 +303,24 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 
 // handleHelpState handles key events when in help state
 func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftUp]) {
+	if isHelpScrollUpKey(msg) {
 		m.textOverlay.ScrollUp()
 		return m, nil
 	}
-	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftDown]) {
+	if isHelpScrollDownKey(msg) {
 		m.textOverlay.ScrollDown()
 		return m, nil
 	}
 
-	// Any non-scroll key press will close the help overlay.
+	if !m.textOverlayDismissAnyKey && !isHelpDismissKey(msg) {
+		return m, nil
+	}
+
 	dismissCmd, shouldClose := m.textOverlay.HandleKeyPress(msg)
 	if shouldClose {
 		replayDismissKey := m.replayHelpDismissKey
 		m.replayHelpDismissKey = false
+		m.textOverlayDismissAnyKey = false
 		m.state = stateDefault
 		// Menu.SetState rebuilds the options slice; call it synchronously
 		// on the event-loop goroutine rather than from a tea.Cmd closure
@@ -328,6 +336,20 @@ func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func isHelpScrollUpKey(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyShiftUp || key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftUp])
+}
+
+func isHelpScrollDownKey(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyShiftDown || key.Matches(msg, keys.GlobalKeyBindings[keys.KeyShiftDown])
+}
+
+func isHelpDismissKey(msg tea.KeyMsg) bool {
+	return msg.Type == tea.KeyEsc ||
+		msg.Type == tea.KeyCtrlC ||
+		key.Matches(msg, keys.GlobalKeyBindings[keys.KeyHelp])
 }
 
 func replayKeyAfterInteractiveHelpDismiss(dismissCmd tea.Cmd, keyMsg tea.KeyMsg) tea.Cmd {

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -98,8 +98,31 @@ func TestGeneralHelpOverlayFitsAndMarksScrollAt80x24(t *testing.T) {
 	require.Contains(t, out, "↓ more", "initial viewport must show overflow below")
 
 	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyCtrlD})
+	require.Equal(t, stateHelp, h.state, "configured scroll key must keep the help overlay open")
 	fg = h.textOverlay.Render()
 	require.LessOrEqual(t, strings.Count(fg, "\n")+1, 24, "scrolled help overlay foreground must fit inside the terminal")
 	out = h.View()
 	require.Contains(t, out, "↑ more", "scrolled viewport must show overflow above")
+}
+
+func TestGeneralHelpOverlayShiftArrowsScrollAt80x24(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 80, 24)
+
+	_, _ = h.showHelpScreen(helpTypeGeneral{}, nil)
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyShiftDown})
+	require.Equal(t, stateHelp, h.state, "Shift+Down must scroll, not dismiss the help overlay")
+	require.False(t, h.textOverlay.Dismissed, "scrolling must not mark the overlay dismissed")
+	require.Contains(t, h.View(), "↑ more", "Shift+Down should move the viewport down")
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyShiftUp})
+	require.Equal(t, stateHelp, h.state, "Shift+Up must scroll, not dismiss the help overlay")
+	require.False(t, h.textOverlay.Dismissed, "scrolling up must not mark the overlay dismissed")
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	require.Equal(t, stateHelp, h.state, "non-dismiss keys must not close the scrollable general help overlay")
+
+	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyEsc})
+	require.Equal(t, stateDefault, h.state, "Esc remains the explicit help dismiss key")
 }

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -246,6 +246,10 @@ type home struct {
 	spinner spinner.Model
 	// textOverlay displays text information
 	textOverlay *overlay.TextOverlay
+	// textOverlayDismissAnyKey keeps the one-shot intro/attach overlays as
+	// press-any-key gates while the general ? help behaves like a scrollable
+	// modal with explicit dismiss keys.
+	textOverlayDismissAnyKey bool
 	// replayHelpDismissKey marks the first-run interactive pane help: the
 	// key that closes that overlay is the user's first pane keystroke, so it
 	// must be forwarded after the deferred live bind completes (#1410).


### PR DESCRIPTION
## Summary
- route raw Shift+Up/Shift+Down through the help overlay scroll path
- keep the general ? help overlay open for non-dismiss keys while preserving press-any-key one-shot help screens
- add 80x24 regression coverage for configured scroll keys and Shift+arrows

## Verification
- gofmt check
- GOTOOLCHAIN=go1.24.2 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0
- go build ./...
- make test-container
- GOTOOLCHAIN=go1.24.2 go run golang.org/x/tools/cmd/deadcode@v0.36.0 -test ./...
- make lint-file-length
- 80x24 playtest sandbox: ?, S-Down, S-Up, Esc

Closes #1447

-- Captain Claude