### PR TITLE
fix(tui): clear chrome before full-screen attach

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -681,14 +681,18 @@ func (m *home) attachSelected(selected *session.Instance) (tea.Model, tea.Cmd) {
 func (m *home) attachInstanceTab(instance *session.Instance, tabIdx int, agentLabel, terminalLabel string) (tea.Model, tea.Cmd) {
 	if tabIdx != 0 {
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-			return attachOverlayCallbackFn(m, instance.Title, terminalLabel, "", instance.IsRemote(), func() (chan struct{}, error) {
-				return ui.AttachTerminalTab(instance, tabIdx)
+			return m.beginAttachTransition(func() tea.Cmd {
+				return attachOverlayCallbackFn(m, instance.Title, terminalLabel, "", instance.IsRemote(), func() (chan struct{}, error) {
+					return ui.AttachTerminalTab(instance, tabIdx)
+				})
 			})
 		})
 	}
 	return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
-		return attachOverlayCallbackFn(m, instance.Title, agentLabel, "", instance.IsRemote(), func() (chan struct{}, error) {
-			return m.store.AttachInstance(instance)
+		return m.beginAttachTransition(func() tea.Cmd {
+			return attachOverlayCallbackFn(m, instance.Title, agentLabel, "", instance.IsRemote(), func() (chan struct{}, error) {
+				return m.store.AttachInstance(instance)
+			})
 		})
 	})
 }

--- a/app/handle_actions_test.go
+++ b/app/handle_actions_test.go
@@ -79,8 +79,10 @@ func TestHandleEnterAttachesCapturedInstanceAfterSelectionDrift(t *testing.T) {
 	require.Same(t, b, h.sidebar.GetSelectedInstance(),
 		"precondition: selection must have drifted onto instance-b")
 
-	// Dismissing the overlay runs the deferred attach callback.
-	_, _ = h.handleHelpState(tea.KeyMsg{Type: tea.KeyEnter})
+	// Dismissing the overlay schedules the attach transition; run it so the
+	// deferred attach callback fires.
+	_, cmd := h.handleHelpState(tea.KeyMsg{Type: tea.KeyEnter})
+	_ = runAttachTransitionCmd(t, h, cmd)
 
 	require.Equal(t, []string{"instance-a"}, attachLog,
 		"attach must target the instance captured at Enter-press time, not the drifted selection")

--- a/app/handle_enter_remote_terminal_test.go
+++ b/app/handle_enter_remote_terminal_test.go
@@ -85,7 +85,8 @@ func driveHandleEnterAttach(t *testing.T, terminalTab, remote bool) (tea.Cmd, st
 
 	model, cmd := h.handleEnter()
 	require.Nil(t, model.(*home).textOverlay,
-		"the attach help overlay must be skipped so the attach callback ran")
+		"the attach help overlay must be skipped so the attach transition is scheduled")
+	cmd = runAttachTransitionCmd(t, h, cmd)
 	endDetachWatchdog()
 	return cmd, out.String()
 }

--- a/app/home_attach.go
+++ b/app/home_attach.go
@@ -43,6 +43,21 @@ const remoteDetachTerminalReassert = "" +
 // the real terminal in production, swappable so tests can capture it.
 var remoteDetachResetWriter io.Writer = os.Stdout
 
+type beginAttachMsg struct {
+	run func() tea.Cmd
+}
+
+// beginAttachTransition gives Bubble Tea one explicit blank/clear frame before
+// the existing blocking attach callback hands stdout to tmux. Direct writes from
+// the callback are too late for the renderer-owned status/footer diff; the final
+// TUI frame itself must contain no AF chrome (#1448).
+func (m *home) beginAttachTransition(run func() tea.Cmd) tea.Cmd {
+	m.attachTransitioning = true
+	return tea.Tick(20*time.Millisecond, func(time.Time) tea.Msg {
+		return beginAttachMsg{run: run}
+	})
+}
+
 // attachOverlayCallbackFn is the indirection handleEnter reaches
 // attachOverlayCallback through. Production points it at the method; tests swap
 // it to substitute a hermetic attach func (no real tmux client or remote
@@ -82,6 +97,7 @@ func (m *home) attachOverlayCallback(title, label, traceSuffix string, remote bo
 	detachTraceMark(label + "-onDismiss-entry" + traceSuffix)
 	ch, err := attach()
 	if err != nil {
+		m.attachTransitioning = false
 		log.ErrorLog.Printf("failed to attach (%s): %v", label+traceSuffix, err)
 		return nil
 	}
@@ -124,6 +140,7 @@ func (m *home) attachOverlayCallback(title, label, traceSuffix string, remote bo
 	go runStatusPollResume(resume, title, repoID, heartbeatExited)
 	detachStart := time.Now()
 	detachTraceMark(label + "-<-ch-unblocked" + traceSuffix)
+	m.attachTransitioning = false
 	m.state = stateDefault
 	// Arm the slow-detach watchdog: if the post-detach paint
 	// (panesRefreshedMsg) does not arrive within slowDetachThreshold, a

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -96,6 +96,9 @@ type home struct {
 	// quitting suppresses Bubble Tea's final graceful render after handleQuit has
 	// started terminal teardown, so stale TUI chrome is not repainted on exit.
 	quitting bool
+	// attachTransitioning suppresses the final pre-attach View so Bubble Tea
+	// clears AF chrome before the blocking full-screen tmux attach takes over.
+	attachTransitioning bool
 	// namingInstance is the instance currently being named in stateNew.
 	// Stored as a direct pointer so background sync cannot change which
 	// instance the naming keystrokes target.

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -187,6 +187,12 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmd = tea.Batch(cmd, replayCmd)
 		}
 		return m, cmd
+	case beginAttachMsg:
+		if msg.run == nil {
+			m.attachTransitioning = false
+			return m, nil
+		}
+		return m, msg.run()
 	case startKillMsg:
 		// The row was already flipped to Deleting synchronously by the kill
 		// confirmation; dispatch the slow teardown off the event loop (#844).

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -63,6 +64,9 @@ func (m *home) View() string {
 	m.zones.Reset()
 	if m.quitting {
 		return ""
+	}
+	if m.attachTransitioning {
+		return blankFrame(m.termWidth, m.termHeight)
 	}
 
 	// Below the hard minimum no layout exists; render the banner alone (and
@@ -142,6 +146,18 @@ func (m *home) View() string {
 	}
 
 	return mainView
+}
+
+func blankFrame(width, height int) string {
+	if width < 1 || height < 1 {
+		return ""
+	}
+	line := strings.Repeat(" ", width)
+	lines := make([]string, height)
+	for i := range lines {
+		lines[i] = line
+	}
+	return strings.Join(lines, "\n")
 }
 
 // The View render helpers (overlay framing + rail/divider rules) live in

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -338,7 +338,8 @@ func TestEnterOnRemotePaneFallsBackToFullScreenAttach(t *testing.T) {
 		return nil
 	})
 
-	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	_ = runAttachTransitionCmd(t, h, cmd)
 
 	assert.Equal(t, 1, attached, "a remote pane cannot embed: Enter must fall back to full-screen attach")
 	assert.False(t, h.interactive)
@@ -355,7 +356,8 @@ func TestAttachKeyKeepsFullScreenAttach(t *testing.T) {
 		return nil
 	})
 
-	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")}, keys.KeyAttach)
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("o")}, keys.KeyAttach)
+	_ = runAttachTransitionCmd(t, h, cmd)
 
 	assert.Equal(t, 1, attached, "`o` must run the full-screen attach flow")
 	assert.False(t, h.interactive, "`o` must not enter interactive mode")

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -1229,6 +1229,7 @@ func TestPane_EnterAttachTargetFollowsFocusContext(t *testing.T) {
 	h.focusRegion(layout.PaneRegion(p.ID()))
 	_, cmd := h.handleEnter()
 	require.NotNil(t, cmd, "the focused-pane attach must run")
+	_ = runAttachTransitionCmd(t, h, cmd)
 	assert.Equal(t, "handleEnter-pane", attachedLabel,
 		"focused-pane Enter must use the pane attach path")
 	assert.Equal(t, "alpha", attachedTitle,
@@ -1244,6 +1245,7 @@ func TestPane_EnterAttachTargetFollowsFocusContext(t *testing.T) {
 	h.focusRegion(layout.RegionTree)
 	_, cmd = h.handleEnter()
 	require.NotNil(t, cmd)
+	_ = runAttachTransitionCmd(t, h, cmd)
 	assert.Equal(t, "handleEnter-sidebar", attachedLabel)
 	assert.Equal(t, "beta", attachedTitle)
 	endDetachWatchdog()

--- a/app/remote_detach_reset_test.go
+++ b/app/remote_detach_reset_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +44,43 @@ func runAttachOverlayCallback(t *testing.T, h *home, remote bool) tea.Cmd {
 		t.Fatalf("attachOverlayCallback did not return after detach")
 		return nil
 	}
+}
+
+func runAttachTransitionCmd(t *testing.T, h *home, cmd tea.Cmd) tea.Cmd {
+	t.Helper()
+	var postAttachCmd tea.Cmd
+	for _, msg := range drainCmd(t, cmd, time.Second) {
+		if begin, ok := msg.(beginAttachMsg); ok {
+			_, postAttachCmd = h.Update(begin)
+		}
+	}
+	return postAttachCmd
+}
+
+func TestBeginAttachTransitionClearsFrameBeforeAttachStarts(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 80, 24)
+
+	attachStarted := false
+	cmd := h.beginAttachTransition(func() tea.Cmd {
+		attachStarted = true
+		return func() tea.Msg { return repaintAfterDetachMsg{} }
+	})
+
+	require.True(t, h.attachTransitioning, "attach transition must blank the next pre-attach frame")
+	frame := h.View()
+	require.Equal(t, 24, strings.Count(frame, "\n")+1,
+		"pre-attach blank frame must cover the full terminal height")
+	require.NotContains(t, frame, "help", "pre-attach frame must not repaint AF footer chrome")
+
+	begin, ok := cmd().(beginAttachMsg)
+	require.True(t, ok, "transition command must dispatch beginAttachMsg")
+
+	_, postAttachCmd := h.Update(begin)
+	require.True(t, attachStarted, "attach callback must start after the blank pre-attach frame")
+	require.NotNil(t, postAttachCmd)
+	_, isRepaint := postAttachCmd().(repaintAfterDetachMsg)
+	require.True(t, isRepaint, "beginAttachMsg must return the attach callback's cmd")
 }
 
 // TestAttachOverlayCallback_RemoteReassertsTerminalModes is the app half of


### PR DESCRIPTION
## Summary
- add a one-frame blank attach transition before the blocking full-screen tmux attach starts
- route full-screen attach callbacks through the transition so the last Bubble Tea frame contains no AF footer chrome
- keep existing attach/detach callback behavior and update tests to drive the deferred begin-attach message

## Verification
- gofmt check
- GOTOOLCHAIN=go1.24.2 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0
- go build ./...
- make test-container
- GOTOOLCHAIN=go1.24.2 go run golang.org/x/tools/cmd/deadcode@v0.36.0 -test ./...
- make lint-file-length
- 80x24 playtest sandbox: create alpha, attach with o, wait for tmux status, assert no AF footer text remains above tmux status, detach

Closes #1448

-- Captain Claude