### PR TITLE
Fix Enter on previewed tab entering pane

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -547,7 +547,12 @@ func killConfirmationWarning(wt string) string {
 // do; dead/transitional sessions keep their guard errors.
 func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 	if m.panePreviewTxn != nil {
-		return m, m.commitPanePreviewReplace()
+		p, commitCmd := m.commitPanePreviewReplace()
+		if p == nil || liveSessionName(p.Instance(), p.Tab()) == "" {
+			return m, commitCmd
+		}
+		mod, interactCmd := m.enterPane(p)
+		return mod, tea.Batch(commitCmd, interactCmd)
 	}
 	if p := m.focusedOpenPane(); p != nil {
 		return m.enterPane(p)

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -211,6 +211,41 @@ func TestEnterFromTreeOpensPaneAndEntersInteractive(t *testing.T) {
 	require.Len(t, *fakes, 1)
 }
 
+func TestEnterOnPreviewedTabRowCommitsAndEntersInteractive(t *testing.T) {
+	h := newTestHome(t)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	inst := startedLocalInstance(t, "tab-row-live")
+	selectInstance(h, inst)
+	resizeHome(h, 120, 40)
+	fakes, sessions := stubLiveTermFactory(t)
+
+	pane := openTestPane(t, h, inst, 0)
+	require.Equal(t, 0, pane.Tab(), "precondition: the Agent tab is open")
+
+	h.focusRegion(layout.RegionTree)
+	pressNav(t, h, "j") // Agent tab row.
+	pressNav(t, h, "j") // Terminal tab row.
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsTab)
+	require.Equal(t, 1, sel.TabIndex)
+	require.NotNil(t, h.panePreviewTxn, "the terminal row must be a preview before Enter")
+	require.Equal(t, 0, pane.Tab(), "preview remains transient until Enter")
+
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	require.Nil(t, h.panePreviewTxn)
+	require.Equal(t, 1, pane.Tab(), "Enter commits the Terminal tab into the pane")
+	require.Equal(t, pane, h.focusedOpenPane(), "the committed pane keeps focus")
+	runHermeticCmd(t, h, cmd, 0)
+
+	require.True(t, h.interactive, "the same Enter must enter the committed tab")
+	require.Equal(t, pane, h.livePane)
+	require.Len(t, *fakes, 1)
+	require.Equal(t, inst.TabTmuxName(1), (*sessions)[0])
+
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Z")})
+	assert.Equal(t, []string{"Z"}, (*fakes)[0].keys, "typing after one Enter must route into the tab")
+}
+
 // TestSecondEnterTargetsCurrentSelectionNotStalePane is the #1233/#1236 P1
 // wrong-target-input regression: enter interactive on instance A, Ctrl-] to
 // nav, select a DIFFERENT instance B through the real tree-nav keys, Enter
@@ -255,19 +290,15 @@ func TestSecondEnterTargetsCurrentSelectionNotStalePane(t *testing.T) {
 	// 4. Enter again commits the active sidebar preview: the current
 	// selection B replaces the focused pane binding, rather than re-entering
 	// stale A (#1321 commit-replace preserving the #1233/#1236 target rule).
-	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	// The same Enter also enters the committed pane (#1455).
+	_, cmd = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
 	paneB := h.focusedOpenPane()
 	require.NotNil(t, paneB, "second Enter must leave a focused pane")
 	require.Same(t, paneA, paneB, "commit-replace keeps the owner pane")
 	require.Equal(t, instB, paneB.Instance(), "the committed pane must belong to selected B")
-	require.False(t, h.interactive, "commit-replace does not also enter interactive mode")
-
-	// 5. With no preview active now, Enter on the focused pane enters B.
-	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
-	_, cmd = h.Update(enterInteractiveMsg{pane: paneB})
 	runHermeticCmd(t, h, cmd, 0)
 
-	require.True(t, h.interactive, "third Enter must enter interactive mode on committed B")
+	require.True(t, h.interactive, "second Enter must enter interactive mode on committed B")
 	assert.Equal(t, instB, h.livePane.Instance(),
 		"input must bind to the committed instance B, not the previously-interacted A")
 	assert.Equal(t, paneB, h.livePane, "the live pane must be B's pane")

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -150,25 +150,25 @@ func (m *home) isPanePreviewSuppressed(original, target paneBinding) bool {
 	return samePaneBinding(suppressed.original, original)
 }
 
-func (m *home) commitPanePreviewReplace() tea.Cmd {
+func (m *home) commitPanePreviewReplace() (*store.OpenPane, tea.Cmd) {
 	txn := m.panePreviewTxn
 	if txn == nil {
-		return nil
+		return nil, nil
 	}
 	if err := previewCommitError(txn.target.instance); err != nil {
-		return m.handleError(err)
+		return nil, m.handleError(err)
 	}
 	owner := m.openPaneByID(txn.ownerPaneID)
 	if owner == nil {
 		m.cancelPanePreview(false)
-		return nil
+		return nil, nil
 	}
 	if existing := m.store.FindOpenPane(txn.target.instance, txn.target.tab); existing != nil && existing != owner {
 		m.cancelPanePreview(false)
 		m.store.TouchOpenPane(existing)
 		m.relayout()
 		m.focusRegion(layout.PaneRegion(existing.ID()))
-		return m.panesRefresh(m.attached.Load())
+		return existing, m.panesRefresh(m.attached.Load())
 	}
 	w := m.paneWindows[owner.ID()]
 	m.panePreviewTxn = nil
@@ -177,13 +177,13 @@ func (m *home) commitPanePreviewReplace() tea.Cmd {
 		w.InvalidateContent(txn.target.instance, txn.target.tab, "Loading pane...")
 	}
 	if !m.store.RebindOpenPane(owner, txn.target.instance, txn.target.tab) {
-		return nil
+		return nil, nil
 	}
 	m.store.TouchOpenPane(owner)
 	m.lastPaneCapture[owner.ID()] = time.Time{}
 	m.relayout()
 	m.focusRegion(layout.PaneRegion(owner.ID()))
-	return m.panesRefresh(m.attached.Load())
+	return owner, m.panesRefresh(m.attached.Load())
 }
 
 func (m *home) commitPanePreviewAlongside() tea.Cmd {


### PR DESCRIPTION
## Summary
- Make Enter on an active #1321 pane preview commit the preview and immediately request embedded interactive mode for the committed pane.
- Preserve preview navigation: scroll remains preview-only, Tab/Esc still revert, S still splits, and o remains the full-screen attach path.
- Add regression coverage for Enter on a previewed Terminal tab row becoming typeable after one Enter.

## Verification
- gofmt -l app/handle_actions.go app/pane_preview.go app/interactive_test.go
- go build ./...
- golangci-lint run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0
- deadcode -test ./...
- make lint-file-length
- make test-container

Closes #1455

Captain Claude