### PR TITLE
Match Terminal tab color to Agent

### DIFF
--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -131,10 +131,10 @@ var selectedDescStyle = lipgloss.NewStyle().
 	Background(lipgloss.Color("#dde4f0")).
 	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#1a1a1a"})
 
-// tabRowStyle renders an inactive tab child row in the same recede gray as the
-// branch line, so the tree's children read as secondary to the instance rows.
+// tabRowStyle renders tab child rows in the same primary foreground as the
+// Agent/active tab label (#1456). Selection still supplies the row highlight.
 var tabRowStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+	Foreground(InstanceTitleColor)
 
 // tabRowActiveStyle brightens the tab the content pane is showing (plus its
 // tmux-style "*" marker) so the active tab is findable without the tab bar.

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -376,6 +376,13 @@ func TestRenderTabRows(t *testing.T) {
 	assert.LessOrEqual(t, lipgloss.Width(narrow), 14, "tab rows must hard-truncate to the row width")
 }
 
+func TestTabRowForegroundMatchesAgentTab(t *testing.T) {
+	assert.Equal(t, tabRowActiveStyle.GetForeground(), tabRowStyle.GetForeground(),
+		"Terminal/default tab rows must use the same foreground as the Agent/active tab")
+	assert.NotEqual(t, lipgloss.NoColor{}, tabRowSelectedStyle.GetBackground(),
+		"selected tab rows keep their highlight background")
+}
+
 // TestFlatten pins the tree flattening order: each instance row immediately
 // followed by its tab children when expanded.
 func TestFlatten(t *testing.T) {


### PR DESCRIPTION
## Summary
- Render default sidebar tab rows with the same foreground as the Agent/active tab label, so Terminal no longer appears in a different color.
- Keep the selected tab-row highlight background unchanged.
- Add a renderer style test pinning the Terminal/default tab foreground to the Agent/active tab foreground.

## Verification
- gofmt -l ui/tree/render.go ui/tree/render_test.go
- go build ./...
- deadcode -test ./...
- make lint-file-length
- make test-container
- golangci-lint run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0

Closes #1456

Captain Claude