### PR TITLE
Fix archive fallback for submodule worktrees

### DIFF
--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -86,9 +86,14 @@ var worktreeRepair = func(g *GitWorktree, dest string) error {
 // directory move. `git worktree repair` fixes the superproject's .git pointer,
 // but submodule .git files can still contain relative gitdir paths computed
 // from the old worktree location. `git submodule absorbgitdirs` rewrites those
-// pointers without fetching or checking out new content.
+// pointers without fetching or checking out new content; the foreach pass makes
+// the repair explicit for initialized nested submodules on Git versions whose
+// top-level absorb does not recurse.
 var worktreeRepairSubmodules = func(g *GitWorktree, dest string) error {
-	_, err := g.runGitCommand(dest, "submodule", "absorbgitdirs")
+	if _, err := g.runGitCommand(dest, "submodule", "absorbgitdirs"); err != nil {
+		return err
+	}
+	_, err := g.runGitCommand(dest, "submodule", "foreach", "--recursive", "git submodule absorbgitdirs")
 	return err
 }
 
@@ -171,7 +176,7 @@ func (g *GitWorktree) relocateWorktreeTo(dest string) error {
 			return fmt.Errorf("moved worktree to %s but failed to repair its git registration: %w", dest, rErr)
 		}
 		if sErr := worktreeRepairSubmodules(g, dest); sErr != nil {
-			return fmt.Errorf("moved worktree to %s but failed to repair submodule gitdirs: %w", dest, sErr)
+			log.WarningLog.Printf("moved worktree to %s but failed to repair submodule gitdirs; continuing because the worktree move and registration repair already succeeded: %v", dest, sErr)
 		}
 		return nil
 	}

--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -82,6 +82,16 @@ var worktreeRepair = func(g *GitWorktree, dest string) error {
 	return err
 }
 
+// worktreeRepairSubmodules re-points initialized submodules after a raw
+// directory move. `git worktree repair` fixes the superproject's .git pointer,
+// but submodule .git files can still contain relative gitdir paths computed
+// from the old worktree location. `git submodule absorbgitdirs` rewrites those
+// pointers without fetching or checking out new content.
+var worktreeRepairSubmodules = func(g *GitWorktree, dest string) error {
+	_, err := g.runGitCommand(dest, "submodule", "absorbgitdirs")
+	return err
+}
+
 // MoveWorktree relocates this worktree's directory to dest and keeps git's
 // two-way worktree link consistent (the worktree's `.git` file and the repo's
 // `.git/worktrees/<name>/gitdir`). It is the archive-side primitive (#1028):
@@ -159,6 +169,9 @@ func (g *GitWorktree) relocateWorktreeTo(dest string) error {
 		g.setWorktreeLocation(dest)
 		if rErr := worktreeRepair(g, dest); rErr != nil {
 			return fmt.Errorf("moved worktree to %s but failed to repair its git registration: %w", dest, rErr)
+		}
+		if sErr := worktreeRepairSubmodules(g, dest); sErr != nil {
+			return fmt.Errorf("moved worktree to %s but failed to repair submodule gitdirs: %w", dest, sErr)
 		}
 		return nil
 	}

--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -176,7 +176,14 @@ func (g *GitWorktree) relocateWorktreeTo(dest string) error {
 			return fmt.Errorf("moved worktree to %s but failed to repair its git registration: %w", dest, rErr)
 		}
 		if sErr := worktreeRepairSubmodules(g, dest); sErr != nil {
-			log.WarningLog.Printf("moved worktree to %s but failed to repair submodule gitdirs; continuing because the worktree move and registration repair already succeeded: %v", dest, sErr)
+			log.WarningLog.Printf(
+				"submodule gitdir repair failed after moving worktree to %s; "+
+					"run `git -C %q submodule absorbgitdirs` "+
+					"(or `git -C %q submodule update --init --recursive`) "+
+					"to fix submodule status; continuing because the worktree move "+
+					"and registration repair already succeeded: %v",
+				dest, dest, dest, sErr,
+			)
 		}
 		return nil
 	}

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -1,11 +1,14 @@
 package git
 
 import (
+	"bytes"
 	"errors"
+	stdlog "log"
 	"os"
 	"path/filepath"
 	"testing"
 
+	aflog "github.com/sachiniyer/agent-factory/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,15 +33,21 @@ func archiveTestWorktree(t *testing.T) (gw *GitWorktree, repoRoot, wtPath string
 	return gw, repoRoot, wtPath
 }
 
-// archiveTestWorktreeWithSubmodule creates a linked worktree whose submodule is
-// initialized. Git refuses to move this shape via `git worktree move`, so it
-// exercises the archive fallback path that raw-moves bytes and repairs gitdirs.
+// archiveTestWorktreeWithSubmodule creates a linked worktree whose nested
+// submodules are initialized. Git refuses to move this shape via `git worktree
+// move`, so it exercises the archive fallback path that raw-moves bytes and
+// repairs gitdirs at every submodule depth.
 func archiveTestWorktreeWithSubmodule(t *testing.T) (gw *GitWorktree, repoRoot, wtPath string) {
 	t.Helper()
 	sandboxHome(t)
 
+	nestedRoot := createGitRepo(t)
+	runGitInPlaceTest(t, nestedRoot, "commit", "--allow-empty", "-m", "nested submodule init")
+
 	subRoot := createGitRepo(t)
 	runGitInPlaceTest(t, subRoot, "commit", "--allow-empty", "-m", "submodule init")
+	runGitInPlaceTest(t, subRoot, "-c", "protocol.file.allow=always", "submodule", "add", nestedRoot, "nested/child")
+	runGitInPlaceTest(t, subRoot, "commit", "-m", "add nested submodule")
 
 	repoRoot = createGitRepo(t)
 	runGitInPlaceTest(t, repoRoot, "commit", "--allow-empty", "-m", "init")
@@ -51,6 +60,7 @@ func archiveTestWorktreeWithSubmodule(t *testing.T) (gw *GitWorktree, repoRoot, 
 
 	require.NoError(t, os.WriteFile(filepath.Join(wtPath, "dirty.txt"), []byte("uncommitted work"), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(wtPath, "deps", "sub", "dirty-sub.txt"), []byte("submodule work"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(wtPath, "deps", "sub", "nested", "child", "dirty-nested.txt"), []byte("nested work"), 0644))
 
 	var err error
 	gw, err = NewGitWorktreeFromStorage(repoRoot, wtPath, "arch", "arch/branch", "", false, true)
@@ -95,6 +105,19 @@ func assertSubmoduleIntactAt(t *testing.T, path string) {
 	dirty, err := os.ReadFile(filepath.Join(subPath, "dirty-sub.txt"))
 	require.NoError(t, err, "submodule dirty file must survive the move")
 	assert.Equal(t, "submodule work", string(dirty))
+
+	nestedPath := filepath.Join(subPath, "nested", "child")
+	assert.Equal(t, nestedPath,
+		runGitInPlaceTest(t, nestedPath, "rev-parse", "--show-toplevel"),
+		"the nested submodule gitdir must point at this moved nested submodule")
+	assert.Contains(t,
+		runGitInPlaceTest(t, nestedPath, "status", "--short"),
+		"dirty-nested.txt",
+		"uncommitted nested submodule work must survive the move")
+
+	nestedDirty, err := os.ReadFile(filepath.Join(nestedPath, "dirty-nested.txt"))
+	require.NoError(t, err, "nested submodule dirty file must survive the move")
+	assert.Equal(t, "nested work", string(nestedDirty))
 }
 
 // TestMoveWorktree_FastPathPreservesTreeAndReregisters: the `git worktree move`
@@ -154,6 +177,39 @@ func TestRestoreWorktreeTo_FallbackRepairsSubmoduleGitdirs(t *testing.T) {
 	assert.False(t, pathExists(archiveDest), "the archive directory must be gone after restore")
 	assertLiveWorktreeAt(t, gw, restoreDest)
 	assertSubmoduleIntactAt(t, restoreDest)
+}
+
+// TestRestoreWorktreeTo_SubmoduleRepairFailureIsBestEffort proves the
+// submodule-gitdir repair cannot strand an archive/restore after the byte move
+// and superproject registration repair already succeeded. The worktree bytes and
+// git registration are at dest, so the only safe outcome is a warning plus nil.
+func TestRestoreWorktreeTo_SubmoduleRepairFailureIsBestEffort(t *testing.T) {
+	prevMove := worktreeMoveFast
+	worktreeMoveFast = func(*GitWorktree, string, string) error {
+		return errors.New("forced fast-path failure")
+	}
+	t.Cleanup(func() { worktreeMoveFast = prevMove })
+	prevSubmoduleRepair := worktreeRepairSubmodules
+	worktreeRepairSubmodules = func(*GitWorktree, string) error {
+		return errors.New("forced submodule repair failure")
+	}
+	t.Cleanup(func() { worktreeRepairSubmodules = prevSubmoduleRepair })
+	var warnings bytes.Buffer
+	origWarning := aflog.WarningLog
+	aflog.WarningLog = stdlog.New(&warnings, "WARNING: ", 0)
+	t.Cleanup(func() { aflog.WarningLog = origWarning })
+
+	gw, _, _ := archiveTestWorktree(t)
+	archiveDest := filepath.Join(t.TempDir(), "archived", "repoid", "arch")
+	require.NoError(t, gw.MoveWorktree(archiveDest))
+	assertLiveWorktreeAt(t, gw, archiveDest)
+
+	restoreDest := filepath.Join(t.TempDir(), "restored", "repo-arch-restored")
+	require.NoError(t, gw.RestoreWorktreeTo(restoreDest))
+
+	assert.False(t, pathExists(archiveDest), "the archive directory must be gone after restore")
+	assertLiveWorktreeAt(t, gw, restoreDest)
+	assert.Contains(t, warnings.String(), "failed to repair submodule gitdirs")
 }
 
 // TestSiblingWorktreePath_DefaultCollisionAndSanitize: the restore-side path

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -209,7 +209,9 @@ func TestRestoreWorktreeTo_SubmoduleRepairFailureIsBestEffort(t *testing.T) {
 
 	assert.False(t, pathExists(archiveDest), "the archive directory must be gone after restore")
 	assertLiveWorktreeAt(t, gw, restoreDest)
-	assert.Contains(t, warnings.String(), "failed to repair submodule gitdirs")
+	assert.Contains(t, warnings.String(), "submodule gitdir repair failed after moving worktree")
+	assert.Contains(t, warnings.String(), "git -C \""+restoreDest+"\" submodule absorbgitdirs")
+	assert.Contains(t, warnings.String(), "git -C \""+restoreDest+"\" submodule update --init --recursive")
 }
 
 // TestSiblingWorktreePath_DefaultCollisionAndSanitize: the restore-side path

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -30,6 +30,34 @@ func archiveTestWorktree(t *testing.T) (gw *GitWorktree, repoRoot, wtPath string
 	return gw, repoRoot, wtPath
 }
 
+// archiveTestWorktreeWithSubmodule creates a linked worktree whose submodule is
+// initialized. Git refuses to move this shape via `git worktree move`, so it
+// exercises the archive fallback path that raw-moves bytes and repairs gitdirs.
+func archiveTestWorktreeWithSubmodule(t *testing.T) (gw *GitWorktree, repoRoot, wtPath string) {
+	t.Helper()
+	sandboxHome(t)
+
+	subRoot := createGitRepo(t)
+	runGitInPlaceTest(t, subRoot, "commit", "--allow-empty", "-m", "submodule init")
+
+	repoRoot = createGitRepo(t)
+	runGitInPlaceTest(t, repoRoot, "commit", "--allow-empty", "-m", "init")
+	runGitInPlaceTest(t, repoRoot, "-c", "protocol.file.allow=always", "submodule", "add", subRoot, "deps/sub")
+	runGitInPlaceTest(t, repoRoot, "commit", "-m", "add submodule")
+
+	wtPath = filepath.Join(filepath.Dir(repoRoot), "repo-arch-sub-src")
+	runGitInPlaceTest(t, repoRoot, "worktree", "add", "-b", "arch/branch", wtPath)
+	runGitInPlaceTest(t, wtPath, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive")
+
+	require.NoError(t, os.WriteFile(filepath.Join(wtPath, "dirty.txt"), []byte("uncommitted work"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(wtPath, "deps", "sub", "dirty-sub.txt"), []byte("submodule work"), 0644))
+
+	var err error
+	gw, err = NewGitWorktreeFromStorage(repoRoot, wtPath, "arch", "arch/branch", "", false, true)
+	require.NoError(t, err)
+	return gw, repoRoot, wtPath
+}
+
 // assertLiveWorktreeAt asserts that gw's worktree is a valid, registered git
 // worktree at path, on branch arch/branch, with its uncommitted file intact.
 func assertLiveWorktreeAt(t *testing.T, gw *GitWorktree, path string) {
@@ -48,6 +76,25 @@ func assertLiveWorktreeAt(t *testing.T, gw *GitWorktree, path string) {
 	dirty, err := os.ReadFile(filepath.Join(path, "dirty.txt"))
 	require.NoError(t, err, "uncommitted file must survive the move")
 	assert.Equal(t, "uncommitted work", string(dirty))
+}
+
+// assertSubmoduleIntactAt asserts the initialized submodule still has a live
+// gitdir pointer after an archive/restore move and preserved its dirty file.
+func assertSubmoduleIntactAt(t *testing.T, path string) {
+	t.Helper()
+	subPath := filepath.Join(path, "deps", "sub")
+
+	assert.Equal(t, subPath,
+		runGitInPlaceTest(t, subPath, "rev-parse", "--show-toplevel"),
+		"the submodule gitdir must point at this moved submodule")
+	assert.Contains(t,
+		runGitInPlaceTest(t, subPath, "status", "--short"),
+		"dirty-sub.txt",
+		"uncommitted submodule work must survive the move")
+
+	dirty, err := os.ReadFile(filepath.Join(subPath, "dirty-sub.txt"))
+	require.NoError(t, err, "submodule dirty file must survive the move")
+	assert.Equal(t, "submodule work", string(dirty))
 }
 
 // TestMoveWorktree_FastPathPreservesTreeAndReregisters: the `git worktree move`
@@ -80,6 +127,33 @@ func TestMoveWorktree_FallbackRepairsRegistration(t *testing.T) {
 
 	assert.False(t, pathExists(srcPath), "the source directory must be gone after the fallback move")
 	assertLiveWorktreeAt(t, gw, dest)
+}
+
+// TestRestoreWorktreeTo_FallbackRepairsSubmoduleGitdirs archives and restores an
+// initialized submodule worktree through the manual-move fallback. Before #1459,
+// `git worktree repair` fixed the superproject but left deps/sub/.git pointing
+// at the old relative path, so the archived worktree was not a valid git repo.
+func TestRestoreWorktreeTo_FallbackRepairsSubmoduleGitdirs(t *testing.T) {
+	prev := worktreeMoveFast
+	worktreeMoveFast = func(*GitWorktree, string, string) error {
+		return errors.New("forced fast-path failure")
+	}
+	t.Cleanup(func() { worktreeMoveFast = prev })
+
+	gw, _, srcPath := archiveTestWorktreeWithSubmodule(t)
+	archiveDest := filepath.Join(t.TempDir(), "archived", "repoid", "arch")
+	require.NoError(t, gw.MoveWorktree(archiveDest))
+
+	assert.False(t, pathExists(srcPath), "the source directory must be gone after archive")
+	assertLiveWorktreeAt(t, gw, archiveDest)
+	assertSubmoduleIntactAt(t, archiveDest)
+
+	restoreDest := filepath.Join(t.TempDir(), "restored", "repo-arch-sub-restored")
+	require.NoError(t, gw.RestoreWorktreeTo(restoreDest))
+
+	assert.False(t, pathExists(archiveDest), "the archive directory must be gone after restore")
+	assertLiveWorktreeAt(t, gw, restoreDest)
+	assertSubmoduleIntactAt(t, restoreDest)
 }
 
 // TestSiblingWorktreePath_DefaultCollisionAndSanitize: the restore-side path


### PR DESCRIPTION
## Summary
- Repair initialized submodule gitdir pointers after the manual archive/restore fallback by running `git submodule absorbgitdirs` from the moved worktree.
- Add a regression test that archives and restores a populated submodule worktree through the fallback, asserting both parked and restored submodules remain valid.

## Findings
Fallback was broken, not benign. On master, `git worktree move` fails for populated submodule worktrees and the manual move + `git worktree repair` fallback runs, but the archived submodule's `.git` file still points at the old relative gitdir, so `git status` fails while parked. Restoring to the original path can appear to work because the stale pointer becomes valid again; restoring to a suffixed/collision path remains at risk without submodule gitdir repair.

## Verification
- Reproduced on `origin/master` with a mock repo containing an initialized submodule: direct `git worktree move` failed with "working trees containing submodules cannot be moved or removed"; archive fallback ran; archived submodule was broken.
- Re-ran the CLI repro after the fix: archived submodule `git status` succeeded, and restore to a suffixed collision path kept the submodule valid.
- `gofmt -l .`
- `golangci-lint run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0`
- `go build ./...`
- `deadcode -test ./...`
- `make lint-file-length`
- `make test-container`

Closes #1459

Captain Claude