### PR TITLE
chore: enable Mergify merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,39 @@
+merge_queue:
+  mode: serial
+  max_parallel_checks: 1
+  queue_controls_comment: true
+  status_comments: outcomes
+  queued_label: queued
+  dequeued_label: dequeued
+
+queue_rules:
+  - name: default
+    merge_method: squash
+    batch_size: 1
+    queue_conditions:
+      - base = master
+      - -draft
+      - -conflict
+      - check-success = Lint
+      - check-success = Build
+    merge_conditions:
+      - check-success = Lint
+      - check-success = Build
+      - -draft
+      - -conflict
+
+merge_protections_settings:
+  reporting_method: check-runs
+  post_comment: true
+  auto_merge_conditions:
+    - label = ready-to-merge
+
+merge_protections:
+  - name: require-current-ci
+    if:
+      - base = master
+    success_conditions:
+      - check-success = Lint
+      - check-success = Build
+      - -draft
+      - -conflict


### PR DESCRIPTION
## Summary
- add a Mergify merge queue configuration for `master`
- gate auto-queueing behind the `ready-to-merge` label
- use the existing required `Lint` and `Build` checks and squash merging

## Validation
- `mergify config validate`

## Follow-up
- install the Mergify GitHub App on this repository if it is not already installed
- after Mergify starts reporting `Mergify Merge Protections`, consider adding that check to the existing `main` ruleset as required