### PR TITLE
Add review-only auto-gate workflow

### DIFF
--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -1,0 +1,503 @@
+const ALLOWED_AUTHORS = new Set(["sachiniyer", "app-detail-app", "app-detail-app[bot]"]);
+const TUI_PATH_PREFIXES = ["app/", "ui/", "session/tmux/"];
+const DOCS_DEPLOY_PATHS = ["docs/", "mkdocs.yml"];
+const GREPTILE_RE = /greptile/i;
+
+async function evaluate({ github, context, core, prNumber, setOutputs = true }) {
+  const number = prNumber || (await findPullRequestNumber({ github, context, core }));
+
+  if (!number) {
+    return finish(core, setOutputs, {
+      prNumber: "",
+      shouldMerge: false,
+      reasons: ["No open pull request found for this event."],
+    });
+  }
+
+  const pr = await getPullRequest({ github, context, number });
+  const reasons = [];
+  const notes = [];
+
+  core.info(`Evaluating auto-gate for PR #${pr.number}: ${pr.title}`);
+  core.info(`PR URL: ${pr.url}`);
+  core.info(`Author: ${pr.author || "(unknown)"}`);
+  core.info(`Base: ${pr.baseRefName}; head SHA: ${pr.headRefOid}`);
+  core.info(`Mergeable: ${pr.mergeable}; merge state: ${pr.mergeStateStatus}`);
+
+  if (pr.baseRefName !== "master") {
+    reasons.push(`base branch is ${pr.baseRefName}, not master`);
+  }
+
+  if (pr.isDraft) {
+    reasons.push("PR is a draft");
+  }
+
+  if (!ALLOWED_AUTHORS.has(pr.author)) {
+    reasons.push(`author ${pr.author || "(unknown)"} is not an allowed maintainer/app`);
+  }
+
+  if (pr.mergeable === "CONFLICTING" || pr.mergeStateStatus === "DIRTY") {
+    reasons.push(`mergeability is blocked (${pr.mergeable}/${pr.mergeStateStatus})`);
+  } else if (pr.mergeable === "UNKNOWN") {
+    reasons.push("mergeability is still UNKNOWN");
+  }
+
+  const files = await listPullRequestFiles({ github, context, number: pr.number });
+  const touchesTui = files.some((path) => TUI_PATH_PREFIXES.some((prefix) => path.startsWith(prefix)));
+  const docsChanged = files.some((path) =>
+    DOCS_DEPLOY_PATHS.some((docsPath) => path === docsPath || path.startsWith(docsPath)),
+  );
+  const labels = new Set(pr.labels.map((label) => label.toLowerCase()));
+
+  if (touchesTui && !labels.has("play-tested")) {
+    reasons.push("PR touches visible TUI/pane paths and is missing the play-tested label");
+  } else if (touchesTui) {
+    notes.push("TUI path gate passed with play-tested label");
+  } else {
+    notes.push("TUI path gate not required");
+  }
+
+  if (docsChanged) {
+    notes.push("Docs deploy dispatch required after merge");
+  }
+
+  const requiredChecks = await evaluateRequiredChecks({
+    github,
+    context,
+    branch: pr.baseRefName,
+    sha: pr.headRefOid,
+    core,
+  });
+  if (!requiredChecks.ok) {
+    reasons.push(...requiredChecks.reasons);
+  }
+  notes.push(...requiredChecks.notes);
+
+  const greptile = await evaluateGreptile({
+    github,
+    context,
+    number: pr.number,
+    sha: pr.headRefOid,
+    lastCommitDate: pr.lastCommitDate,
+    core,
+  });
+  if (!greptile.ok) {
+    reasons.push(...greptile.reasons);
+  }
+  notes.push(...greptile.notes);
+
+  return finish(core, setOutputs, {
+    prNumber: String(pr.number),
+    shouldMerge: reasons.length === 0,
+    docsChanged,
+    reasons,
+    notes,
+  });
+}
+
+async function merge({ github, context, core, prNumber }) {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new Error(`Invalid PR number for merge: ${prNumber}`);
+  }
+
+  const gate = await evaluate({ github, context, core, prNumber, setOutputs: false });
+  if (!gate.shouldMerge) {
+    throw new Error(`Refusing to merge PR #${prNumber}; gate no longer passes: ${gate.summary}`);
+  }
+
+  const { owner, repo } = context.repo;
+  const response = await github.rest.pulls.merge({
+    owner,
+    repo,
+    pull_number: prNumber,
+    merge_method: "squash",
+  });
+
+  core.notice(`Squash-merged PR #${prNumber}: ${response.data.sha}`);
+
+  if (gate.docsChanged) {
+    await github.rest.actions.createWorkflowDispatch({
+      owner,
+      repo,
+      workflow_id: "docs.yml",
+      ref: "master",
+      inputs: {
+        deploy_docs: "true",
+      },
+    });
+    core.notice(`Dispatched Docs workflow for PR #${prNumber} docs-path merge.`);
+  }
+}
+
+async function findPullRequestNumber({ github, context, core }) {
+  const payload = context.payload;
+
+  if (payload.pull_request?.number) {
+    return payload.pull_request.number;
+  }
+
+  const checkSuitePrs = payload.check_suite?.pull_requests || [];
+  const checkSuitePr = checkSuitePrs.find((pr) => pr.base?.ref === "master") || checkSuitePrs[0];
+  if (checkSuitePr?.number) {
+    return checkSuitePr.number;
+  }
+
+  const sha = payload.check_suite?.head_sha || payload.sha;
+  if (!sha) {
+    core.info(`Event ${context.eventName} did not include a PR or SHA to evaluate.`);
+    return null;
+  }
+
+  const { owner, repo } = context.repo;
+  const pulls = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+    owner,
+    repo,
+    commit_sha: sha,
+    per_page: 100,
+  });
+
+  const openMasterPulls = pulls.filter((pr) => pr.state === "open" && pr.base?.ref === "master");
+  if (openMasterPulls.length > 1) {
+    core.warning(`Found multiple open master PRs for ${sha}; evaluating PR #${openMasterPulls[0].number}.`);
+  }
+
+  return openMasterPulls[0]?.number || null;
+}
+
+async function getPullRequest({ github, context, number }) {
+  const { owner, repo } = context.repo;
+  const query = `
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          number
+          title
+          url
+          baseRefName
+          headRefName
+          headRefOid
+          isDraft
+          mergeable
+          mergeStateStatus
+          author {
+            login
+          }
+          labels(first: 100) {
+            nodes {
+              name
+            }
+          }
+          commits(last: 1) {
+            nodes {
+              commit {
+                committedDate
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const response = await github.graphql(query, { owner, repo, number });
+  const pr = response.repository.pullRequest;
+  if (!pr) {
+    throw new Error(`PR #${number} was not found`);
+  }
+
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    baseRefName: pr.baseRefName,
+    headRefOid: pr.headRefOid,
+    isDraft: pr.isDraft,
+    mergeable: pr.mergeable,
+    mergeStateStatus: pr.mergeStateStatus,
+    author: pr.author?.login || "",
+    labels: pr.labels.nodes.map((label) => label.name),
+    lastCommitDate: pr.commits.nodes[0]?.commit?.committedDate,
+  };
+}
+
+async function listPullRequestFiles({ github, context, number }) {
+  const { owner, repo } = context.repo;
+  const files = await github.paginate(github.rest.pulls.listFiles, {
+    owner,
+    repo,
+    pull_number: number,
+    per_page: 100,
+  });
+  return files.map((file) => file.filename);
+}
+
+async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
+  const required = await getRequiredCheckContexts({ github, context, branch, core });
+  const contexts = required.contexts;
+  const notes = [];
+  const reasons = [...required.errors];
+
+  if (contexts.length === 0) {
+    if (reasons.length > 0) {
+      return { ok: false, reasons, notes };
+    }
+    notes.push("No required status checks configured for branch");
+    return { ok: true, reasons, notes };
+  }
+
+  notes.push(`Required status checks: ${contexts.join(", ")}`);
+
+  const { owner, repo } = context.repo;
+  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+    owner,
+    repo,
+    ref: sha,
+    per_page: 100,
+  });
+  const statuses = await github.paginate(github.rest.repos.listCommitStatusesForRef, {
+    owner,
+    repo,
+    ref: sha,
+    per_page: 100,
+  });
+
+  for (const contextName of contexts) {
+    const state = latestRequiredState(contextName, checkRuns, statuses);
+    if (!state) {
+      reasons.push(`required check ${contextName} is missing on ${sha}`);
+      continue;
+    }
+
+    notes.push(`${contextName}: ${state.description}`);
+    if (!state.ok) {
+      reasons.push(`required check ${contextName} is not completed successfully (${state.description})`);
+    }
+  }
+
+  return { ok: reasons.length === 0, reasons, notes };
+}
+
+async function getRequiredCheckContexts({ github, context, branch, core }) {
+  const { owner, repo } = context.repo;
+  const contexts = new Set();
+  const errors = [];
+
+  try {
+    const response = await github.request("GET /repos/{owner}/{repo}/rules/branches/{branch}", {
+      owner,
+      repo,
+      branch,
+    });
+
+    for (const rule of response.data || []) {
+      if (rule.type !== "required_status_checks") {
+        continue;
+      }
+      for (const check of rule.parameters?.required_status_checks || []) {
+        if (check.context) {
+          contexts.add(check.context);
+        }
+      }
+    }
+  } catch (error) {
+    if (error.status !== 404) {
+      const message = `could not read branch rules for ${branch}: ${formatError(error)}`;
+      core.warning(message);
+      errors.push(message);
+    }
+  }
+
+  if (contexts.size > 0) {
+    return { contexts: [...contexts].sort(), errors: [] };
+  }
+
+  try {
+    const response = await github.request(
+      "GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+      { owner, repo, branch },
+    );
+
+    for (const contextName of response.data.contexts || []) {
+      contexts.add(contextName);
+    }
+    for (const check of response.data.checks || []) {
+      if (check.context) {
+        contexts.add(check.context);
+      }
+    }
+  } catch (error) {
+    if (error.status !== 404) {
+      const message = `could not read branch protection checks for ${branch}: ${formatError(error)}`;
+      core.warning(message);
+      errors.push(message);
+    }
+  }
+
+  return { contexts: [...contexts].sort(), errors };
+}
+
+function latestRequiredState(contextName, checkRuns, statuses) {
+  const candidates = [];
+
+  for (const run of checkRuns) {
+    if (run.name !== contextName) {
+      continue;
+    }
+    candidates.push({
+      date: Date.parse(run.completed_at || run.started_at || run.created_at || 0),
+      ok: run.status === "completed" && run.conclusion === "success",
+      description: `check run ${run.status}/${run.conclusion || "no conclusion"}`,
+    });
+  }
+
+  for (const status of statuses) {
+    if (status.context !== contextName) {
+      continue;
+    }
+    candidates.push({
+      date: Date.parse(status.created_at || 0),
+      ok: status.state === "success",
+      description: `commit status ${status.state}`,
+    });
+  }
+
+  candidates.sort((a, b) => b.date - a.date);
+  return candidates[0] || null;
+}
+
+async function evaluateGreptile({ github, context, number, sha, lastCommitDate, core }) {
+  const notes = [];
+  const reasons = [];
+  const { owner, repo } = context.repo;
+
+  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+    owner,
+    repo,
+    ref: sha,
+    per_page: 100,
+  });
+  const greptileRuns = checkRuns
+    .filter((run) => GREPTILE_RE.test(run.name) || GREPTILE_RE.test(run.app?.slug || run.app?.name || ""))
+    .sort((a, b) => latestRunTime(b) - latestRunTime(a));
+  const latestRun = greptileRuns[0];
+
+  if (!latestRun) {
+    reasons.push("Greptile Review check run was not found");
+  } else {
+    notes.push(`Greptile check: ${latestRun.name} ${latestRun.status}/${latestRun.conclusion || "no conclusion"}`);
+    if (latestRun.status !== "completed" || latestRun.conclusion !== "success") {
+      reasons.push(`Greptile Review is not completed successfully (${latestRun.status}/${latestRun.conclusion || "no conclusion"})`);
+    }
+  }
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: number,
+    per_page: 100,
+  });
+  const latestGreptileComment = comments
+    .filter((comment) => GREPTILE_RE.test(comment.user?.login || ""))
+    .sort((a, b) => Date.parse(b.updated_at || b.created_at || 0) - Date.parse(a.updated_at || a.created_at || 0))[0];
+
+  if (!latestGreptileComment) {
+    reasons.push("latest greptile-apps summary comment was not found");
+  } else {
+    const score = parseConfidenceScore(latestGreptileComment.body || "");
+    if (score == null) {
+      reasons.push("latest greptile-apps summary comment did not include a Confidence Score");
+    } else if (score < 4) {
+      reasons.push(`Greptile Confidence Score is ${score}/5, below 4/5`);
+    } else {
+      notes.push(`Greptile Confidence Score: ${score}/5`);
+    }
+  }
+
+  const reviewComments = await github.paginate(github.rest.pulls.listReviewComments, {
+    owner,
+    repo,
+    pull_number: number,
+    per_page: 100,
+  });
+  const lastPushTime = Date.parse(lastCommitDate || 0);
+  const repliedTo = new Set(
+    reviewComments.filter((comment) => comment.in_reply_to_id).map((comment) => comment.in_reply_to_id),
+  );
+  const unresolvedFindings = reviewComments.filter((comment) => {
+    if (!GREPTILE_RE.test(comment.user?.login || "")) {
+      return false;
+    }
+    if (comment.in_reply_to_id) {
+      return false;
+    }
+    if (Date.parse(comment.created_at || 0) <= lastPushTime) {
+      return false;
+    }
+    return /\bP[12]\b/i.test(comment.body || "") && !repliedTo.has(comment.id);
+  });
+
+  if (unresolvedFindings.length > 0) {
+    reasons.push(`${unresolvedFindings.length} unresolved Greptile P1/P2 inline finding(s) after the last push`);
+  } else {
+    notes.push("No unresolved Greptile P1/P2 inline findings after the last push");
+  }
+
+  return { ok: reasons.length === 0, reasons, notes };
+}
+
+function parseConfidenceScore(body) {
+  const normalized = body.replace(/\s+/g, " ");
+  const patterns = [
+    /confidence\s*score\D{0,40}([0-5](?:\.\d+)?)\s*\/\s*5/i,
+    /confidence\D{0,40}([0-5](?:\.\d+)?)\s*\/\s*5/i,
+    /([0-5](?:\.\d+)?)\s*\/\s*5\D{0,40}confidence/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = normalized.match(pattern);
+    if (match) {
+      return Number.parseFloat(match[1]);
+    }
+  }
+
+  return null;
+}
+
+function latestRunTime(run) {
+  return Date.parse(run.completed_at || run.started_at || run.created_at || 0);
+}
+
+function finish(core, setOutputs, result) {
+  const summary =
+    result.reasons.length === 0
+      ? `PASS: ${result.notes.join("; ")}`
+      : `BLOCKED: ${result.reasons.join("; ")}`;
+
+  if (result.reasons.length === 0) {
+    core.notice(summary);
+  } else {
+    core.notice(summary);
+  }
+
+  for (const note of result.notes || []) {
+    core.info(`gate note: ${note}`);
+  }
+  for (const reason of result.reasons || []) {
+    core.info(`gate block: ${reason}`);
+  }
+
+  if (setOutputs) {
+    core.setOutput("pr_number", result.prNumber);
+    core.setOutput("should_merge", result.shouldMerge ? "true" : "false");
+    core.setOutput("docs_changed", result.docsChanged ? "true" : "false");
+    core.setOutput("summary", summary);
+  }
+
+  return { ...result, summary };
+}
+
+function formatError(error) {
+  return `${error.status || "error"} ${error.message || error}`;
+}
+
+module.exports = { evaluate, merge };

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -2,6 +2,7 @@ const ALLOWED_AUTHORS = new Set(["sachiniyer", "app-detail-app", "app-detail-app
 const TUI_PATH_PREFIXES = ["app/", "ui/", "session/tmux/"];
 const DOCS_DEPLOY_PATHS = ["docs/", "mkdocs.yml"];
 const GREPTILE_RE = /greptile/i;
+const RESOLUTION_MARKER_RE = /\b(?:RESOLVED|ACCEPTED)\b/;
 
 async function evaluate({ github, context, core, prNumber, setOutputs = true }) {
   try {
@@ -107,6 +108,7 @@ async function evaluatePullRequest({ github, context, core, prNumber, setOutputs
   return finish(core, setOutputs, {
     prNumber: String(pr.number),
     shouldMerge: reasons.length === 0,
+    headSha: pr.headRefOid,
     docsChanged,
     reasons,
     notes,
@@ -122,6 +124,9 @@ async function merge({ github, context, core, prNumber }) {
   if (!gate.shouldMerge) {
     throw new Error(`Refusing to merge PR #${prNumber}; gate no longer passes: ${gate.summary}`);
   }
+  if (!gate.headSha) {
+    throw new Error(`Refusing to merge PR #${prNumber}; evaluated head SHA is missing`);
+  }
 
   const { owner, repo } = context.repo;
   const response = await github.rest.pulls.merge({
@@ -129,6 +134,7 @@ async function merge({ github, context, core, prNumber }) {
     repo,
     pull_number: prNumber,
     merge_method: "squash",
+    sha: gate.headSha,
   });
 
   core.notice(`Squash-merged PR #${prNumber}: ${response.data.sha}`);
@@ -481,7 +487,13 @@ async function evaluateGreptile({ github, context, number, sha, lastCommitDate, 
   });
   const resolvedByAllowedReply = new Set(
     reviewComments
-      .filter((comment) => comment.in_reply_to_id && ALLOWED_AUTHORS.has(comment.user?.login || ""))
+      .filter((comment) => {
+        return (
+          comment.in_reply_to_id &&
+          ALLOWED_AUTHORS.has(comment.user?.login || "") &&
+          hasResolutionMarker(comment.body || "")
+        );
+      })
       .map((comment) => comment.in_reply_to_id),
   );
   const unresolvedFindings = reviewComments.filter((comment) => {
@@ -530,6 +542,10 @@ function parseConfidenceScore(body) {
   return null;
 }
 
+function hasResolutionMarker(body) {
+  return RESOLUTION_MARKER_RE.test(body) || body.includes("[gate-ack]");
+}
+
 function latestRunTime(run) {
   return parseTimestamp(run.completed_at || run.started_at || run.created_at) || 0;
 }
@@ -561,6 +577,7 @@ function finish(core, setOutputs, result) {
   if (setOutputs) {
     core.setOutput("pr_number", result.prNumber);
     core.setOutput("should_merge", result.shouldMerge ? "true" : "false");
+    core.setOutput("head_sha", result.headSha || "");
     core.setOutput("docs_changed", result.docsChanged ? "true" : "false");
     core.setOutput("summary", summary);
   }
@@ -577,6 +594,7 @@ module.exports = {
   merge,
   __test: {
     evaluateGreptile,
+    hasResolutionMarker,
     latestRequiredState,
     parseConfidenceScore,
   },

--- a/.github/scripts/auto-gate.js
+++ b/.github/scripts/auto-gate.js
@@ -4,13 +4,31 @@ const DOCS_DEPLOY_PATHS = ["docs/", "mkdocs.yml"];
 const GREPTILE_RE = /greptile/i;
 
 async function evaluate({ github, context, core, prNumber, setOutputs = true }) {
+  try {
+    return await evaluatePullRequest({ github, context, core, prNumber, setOutputs });
+  } catch (error) {
+    const message = formatError(error);
+    core.warning(error && error.stack ? error.stack : message);
+    return finish(core, setOutputs, {
+      prNumber: prNumber ? String(prNumber) : "",
+      shouldMerge: false,
+      docsChanged: false,
+      reasons: [`auto-gate evaluation error: ${message}`],
+      notes: [],
+    });
+  }
+}
+
+async function evaluatePullRequest({ github, context, core, prNumber, setOutputs = true }) {
   const number = prNumber || (await findPullRequestNumber({ github, context, core }));
 
   if (!number) {
     return finish(core, setOutputs, {
       prNumber: "",
       shouldMerge: false,
+      docsChanged: false,
       reasons: ["No open pull request found for this event."],
+      notes: [],
     });
   }
 
@@ -232,12 +250,12 @@ async function listPullRequestFiles({ github, context, number }) {
 }
 
 async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
-  const required = await getRequiredCheckContexts({ github, context, branch, core });
-  const contexts = required.contexts;
+  const required = await getRequiredCheckSpecs({ github, context, branch, core });
+  const specs = required.specs;
   const notes = [];
   const reasons = [...required.errors];
 
-  if (contexts.length === 0) {
+  if (specs.length === 0) {
     if (reasons.length > 0) {
       return { ok: false, reasons, notes };
     }
@@ -245,7 +263,7 @@ async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
     return { ok: true, reasons, notes };
   }
 
-  notes.push(`Required status checks: ${contexts.join(", ")}`);
+  notes.push(`Required status checks: ${specs.map(formatCheckSpec).join(", ")}`);
 
   const { owner, repo } = context.repo;
   const checkRuns = await github.paginate(github.rest.checks.listForRef, {
@@ -261,25 +279,25 @@ async function evaluateRequiredChecks({ github, context, branch, sha, core }) {
     per_page: 100,
   });
 
-  for (const contextName of contexts) {
-    const state = latestRequiredState(contextName, checkRuns, statuses);
+  for (const spec of specs) {
+    const state = latestRequiredState(spec, checkRuns, statuses);
     if (!state) {
-      reasons.push(`required check ${contextName} is missing on ${sha}`);
+      reasons.push(`required check ${formatCheckSpec(spec)} is missing on ${sha}`);
       continue;
     }
 
-    notes.push(`${contextName}: ${state.description}`);
+    notes.push(`${formatCheckSpec(spec)}: ${state.description}`);
     if (!state.ok) {
-      reasons.push(`required check ${contextName} is not completed successfully (${state.description})`);
+      reasons.push(`required check ${formatCheckSpec(spec)} is not completed successfully (${state.description})`);
     }
   }
 
   return { ok: reasons.length === 0, reasons, notes };
 }
 
-async function getRequiredCheckContexts({ github, context, branch, core }) {
+async function getRequiredCheckSpecs({ github, context, branch, core }) {
   const { owner, repo } = context.repo;
-  const contexts = new Set();
+  const specs = new Map();
   const errors = [];
 
   try {
@@ -295,7 +313,7 @@ async function getRequiredCheckContexts({ github, context, branch, core }) {
       }
       for (const check of rule.parameters?.required_status_checks || []) {
         if (check.context) {
-          contexts.add(check.context);
+          addCheckSpec(specs, check.context, check.integration_id);
         }
       }
     }
@@ -307,8 +325,8 @@ async function getRequiredCheckContexts({ github, context, branch, core }) {
     }
   }
 
-  if (contexts.size > 0) {
-    return { contexts: [...contexts].sort(), errors: [] };
+  if (specs.size > 0) {
+    return { specs: sortedCheckSpecs(specs), errors: [] };
   }
 
   try {
@@ -318,11 +336,11 @@ async function getRequiredCheckContexts({ github, context, branch, core }) {
     );
 
     for (const contextName of response.data.contexts || []) {
-      contexts.add(contextName);
+      addCheckSpec(specs, contextName, null);
     }
     for (const check of response.data.checks || []) {
       if (check.context) {
-        contexts.add(check.context);
+        addCheckSpec(specs, check.context, check.app_id);
       }
     }
   } catch (error) {
@@ -333,42 +351,75 @@ async function getRequiredCheckContexts({ github, context, branch, core }) {
     }
   }
 
-  return { contexts: [...contexts].sort(), errors };
+  return { specs: sortedCheckSpecs(specs), errors };
 }
 
-function latestRequiredState(contextName, checkRuns, statuses) {
+function addCheckSpec(specs, contextName, sourceAppId) {
+  const parsedAppId = Number(sourceAppId);
+  const normalizedAppId = Number.isInteger(parsedAppId) && parsedAppId > 0 ? parsedAppId : null;
+  const key = `${contextName}\0${normalizedAppId || ""}`;
+  specs.set(key, { context: contextName, sourceAppId: normalizedAppId });
+}
+
+function sortedCheckSpecs(specs) {
+  return [...specs.values()].sort((a, b) => formatCheckSpec(a).localeCompare(formatCheckSpec(b)));
+}
+
+function formatCheckSpec(spec) {
+  return spec.sourceAppId ? `${spec.context} (app ${spec.sourceAppId})` : spec.context;
+}
+
+function latestRequiredState(spec, checkRuns, statuses) {
   const candidates = [];
 
   for (const run of checkRuns) {
-    if (run.name !== contextName) {
+    if (run.name !== spec.context) {
+      continue;
+    }
+    if (spec.sourceAppId && Number(run.app?.id) !== spec.sourceAppId) {
       continue;
     }
     candidates.push({
-      date: Date.parse(run.completed_at || run.started_at || run.created_at || 0),
+      date: parseTimestamp(run.completed_at || run.started_at || run.created_at) || 0,
       ok: run.status === "completed" && run.conclusion === "success",
-      description: `check run ${run.status}/${run.conclusion || "no conclusion"}`,
+      description: `check run ${run.status}/${run.conclusion || "no conclusion"} from ${formatRunSource(run)}`,
     });
   }
 
-  for (const status of statuses) {
-    if (status.context !== contextName) {
-      continue;
+  if (!spec.sourceAppId) {
+    for (const status of statuses) {
+      if (status.context !== spec.context) {
+        continue;
+      }
+      candidates.push({
+        date: parseTimestamp(status.created_at) || 0,
+        ok: status.state === "success",
+        description: `commit status ${status.state}`,
+      });
     }
-    candidates.push({
-      date: Date.parse(status.created_at || 0),
-      ok: status.state === "success",
-      description: `commit status ${status.state}`,
-    });
   }
 
   candidates.sort((a, b) => b.date - a.date);
   return candidates[0] || null;
 }
 
+function formatRunSource(run) {
+  if (!run.app) {
+    return "unknown source";
+  }
+  const name = run.app.slug || run.app.name || "app";
+  return `${name} (${run.app.id || "unknown app id"})`;
+}
+
 async function evaluateGreptile({ github, context, number, sha, lastCommitDate, core }) {
   const notes = [];
   const reasons = [];
   const { owner, repo } = context.repo;
+  const lastPushTime = parseTimestamp(lastCommitDate);
+
+  if (lastPushTime == null) {
+    reasons.push("last commit timestamp was unavailable, so Greptile freshness cannot be verified");
+  }
 
   const checkRuns = await github.paginate(github.rest.checks.listForRef, {
     owner,
@@ -398,11 +449,20 @@ async function evaluateGreptile({ github, context, number, sha, lastCommitDate, 
   });
   const latestGreptileComment = comments
     .filter((comment) => GREPTILE_RE.test(comment.user?.login || ""))
-    .sort((a, b) => Date.parse(b.updated_at || b.created_at || 0) - Date.parse(a.updated_at || a.created_at || 0))[0];
+    .sort((a, b) => {
+      const bTime = parseTimestamp(b.updated_at || b.created_at) || 0;
+      const aTime = parseTimestamp(a.updated_at || a.created_at) || 0;
+      return bTime - aTime;
+    })[0];
 
   if (!latestGreptileComment) {
     reasons.push("latest greptile-apps summary comment was not found");
   } else {
+    const summaryTime = parseTimestamp(latestGreptileComment.updated_at || latestGreptileComment.created_at);
+    if (lastPushTime == null || summaryTime == null || summaryTime <= lastPushTime) {
+      reasons.push("latest greptile-apps summary comment is older than the head commit");
+    }
+
     const score = parseConfidenceScore(latestGreptileComment.body || "");
     if (score == null) {
       reasons.push("latest greptile-apps summary comment did not include a Confidence Score");
@@ -419,9 +479,10 @@ async function evaluateGreptile({ github, context, number, sha, lastCommitDate, 
     pull_number: number,
     per_page: 100,
   });
-  const lastPushTime = Date.parse(lastCommitDate || 0);
-  const repliedTo = new Set(
-    reviewComments.filter((comment) => comment.in_reply_to_id).map((comment) => comment.in_reply_to_id),
+  const resolvedByAllowedReply = new Set(
+    reviewComments
+      .filter((comment) => comment.in_reply_to_id && ALLOWED_AUTHORS.has(comment.user?.login || ""))
+      .map((comment) => comment.in_reply_to_id),
   );
   const unresolvedFindings = reviewComments.filter((comment) => {
     if (!GREPTILE_RE.test(comment.user?.login || "")) {
@@ -430,10 +491,16 @@ async function evaluateGreptile({ github, context, number, sha, lastCommitDate, 
     if (comment.in_reply_to_id) {
       return false;
     }
-    if (Date.parse(comment.created_at || 0) <= lastPushTime) {
+    if (lastPushTime == null || parseTimestamp(comment.created_at) == null || parseTimestamp(comment.created_at) <= lastPushTime) {
       return false;
     }
-    return /\bP[12]\b/i.test(comment.body || "") && !repliedTo.has(comment.id);
+    if (!/\bP[12]\b/i.test(comment.body || "")) {
+      return false;
+    }
+    if (comment.position == null) {
+      return false;
+    }
+    return !resolvedByAllowedReply.has(comment.id);
   });
 
   if (unresolvedFindings.length > 0) {
@@ -464,7 +531,12 @@ function parseConfidenceScore(body) {
 }
 
 function latestRunTime(run) {
-  return Date.parse(run.completed_at || run.started_at || run.created_at || 0);
+  return parseTimestamp(run.completed_at || run.started_at || run.created_at) || 0;
+}
+
+function parseTimestamp(value) {
+  const parsed = Date.parse(value || "");
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function finish(core, setOutputs, result) {
@@ -500,4 +572,12 @@ function formatError(error) {
   return `${error.status || "error"} ${error.message || error}`;
 }
 
-module.exports = { evaluate, merge };
+module.exports = {
+  evaluate,
+  merge,
+  __test: {
+    evaluateGreptile,
+    latestRequiredState,
+    parseConfidenceScore,
+  },
+};

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -1,6 +1,7 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
-const { __test } = require("./auto-gate.js");
+const autoGate = require("./auto-gate.js");
+const { __test } = autoGate;
 
 test("required check matching respects the required source app", () => {
   const spec = { context: "Build", sourceAppId: 15368 };
@@ -79,7 +80,7 @@ test("external replies do not resolve Greptile P1/P2 findings", async () => {
   assert.match(result.reasons.join("\n"), /1 unresolved Greptile P1\/P2 inline finding/);
 });
 
-test("maintainer replies resolve Greptile P1/P2 findings", async () => {
+test("maintainer discussion replies do not resolve Greptile P1/P2 findings without a marker", async () => {
   const result = await __test.evaluateGreptile({
     github: fakeGithub({
       checkRuns: [greptileRun()],
@@ -90,7 +91,34 @@ test("maintainer replies resolve Greptile P1/P2 findings", async () => {
           id: 11,
           in_reply_to_id: 10,
           user: { login: "sachiniyer" },
-          body: "Documented tradeoff accepted.",
+          body: "I see the tradeoff and will think about it.",
+          created_at: "2026-07-09T01:03:00Z",
+        },
+      ],
+    }),
+    context: fakeContext(),
+    number: 1465,
+    sha: "abc123",
+    lastCommitDate: "2026-07-09T01:00:00Z",
+    core: fakeCore(),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.reasons.join("\n"), /1 unresolved Greptile P1\/P2 inline finding/);
+});
+
+test("maintainer replies resolve Greptile P1/P2 findings only with an explicit marker", async () => {
+  const result = await __test.evaluateGreptile({
+    github: fakeGithub({
+      checkRuns: [greptileRun()],
+      issueComments: [freshGreptileSummary()],
+      reviewComments: [
+        greptileFinding({ id: 10 }),
+        {
+          id: 11,
+          in_reply_to_id: 10,
+          user: { login: "sachiniyer" },
+          body: "Documented tradeoff ACCEPTED.",
           created_at: "2026-07-09T01:03:00Z",
         },
       ],
@@ -103,6 +131,11 @@ test("maintainer replies resolve Greptile P1/P2 findings", async () => {
   });
 
   assert.equal(result.ok, true);
+});
+
+test("gate-ack token is an explicit Greptile finding resolution marker", () => {
+  assert.equal(__test.hasResolutionMarker("Root accepts this [gate-ack]."), true);
+  assert.equal(__test.hasResolutionMarker("accepted in discussion, not marked"), false);
 });
 
 test("outdated Greptile findings are not counted as unresolved", async () => {
@@ -120,6 +153,19 @@ test("outdated Greptile findings are not counted as unresolved", async () => {
   });
 
   assert.equal(result.ok, true);
+});
+
+test("merge pins the squash merge to the evaluated head SHA", async () => {
+  const github = fakeMergeGithub({ headSha: "sha-that-passed" });
+
+  await autoGate.merge({
+    github,
+    context: fakeContext(),
+    core: fakeCore(),
+    prNumber: 1465,
+  });
+
+  assert.equal(github.mergedWith.sha, "sha-that-passed");
 });
 
 function fakeGithub({ checkRuns, issueComments, reviewComments }) {
@@ -140,6 +186,73 @@ function fakeGithub({ checkRuns, issueComments, reviewComments }) {
     },
     paginate: async (fn) => responses.get(fn) || [],
   };
+}
+
+function fakeMergeGithub({ headSha }) {
+  const listFiles = function listFiles() {};
+  const listForRef = function listForRef() {};
+  const listComments = function listComments() {};
+  const listReviewComments = function listReviewComments() {};
+  const merge = async function merge(options) {
+    github.mergedWith = options;
+    return { data: { sha: "merge-sha" } };
+  };
+  const responses = new Map([
+    [listFiles, []],
+    [listForRef, [greptileRun()]],
+    [listComments, [freshGreptileSummary()]],
+    [listReviewComments, []],
+  ]);
+
+  const github = {
+    mergedWith: null,
+    rest: {
+      actions: {
+        createWorkflowDispatch: async () => {},
+      },
+      checks: { listForRef },
+      issues: { listComments },
+      pulls: { listFiles, listReviewComments, merge },
+    },
+    graphql: async () => {
+      return {
+        repository: {
+          pullRequest: {
+            number: 1465,
+            title: "Gate test",
+            url: "https://example.invalid/pr/1465",
+            baseRefName: "master",
+            headRefOid: headSha,
+            isDraft: false,
+            mergeable: "MERGEABLE",
+            mergeStateStatus: "CLEAN",
+            author: { login: "sachiniyer" },
+            labels: { nodes: [] },
+            commits: {
+              nodes: [
+                {
+                  commit: {
+                    committedDate: "2026-07-09T01:00:00Z",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+    },
+    paginate: async (fn) => responses.get(fn) || [],
+    request: async (route) => {
+      if (route.includes("/rules/branches/")) {
+        return { data: [] };
+      }
+      const error = new Error("not protected");
+      error.status = 404;
+      throw error;
+    },
+  };
+
+  return github;
 }
 
 function fakeContext() {

--- a/.github/scripts/auto-gate.test.js
+++ b/.github/scripts/auto-gate.test.js
@@ -1,0 +1,185 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { __test } = require("./auto-gate.js");
+
+test("required check matching respects the required source app", () => {
+  const spec = { context: "Build", sourceAppId: 15368 };
+  const checkRuns = [
+    {
+      name: "Build",
+      app: { id: 999, slug: "spoof" },
+      status: "completed",
+      conclusion: "success",
+      completed_at: "2026-07-09T01:00:00Z",
+    },
+    {
+      name: "Build",
+      app: { id: 15368, slug: "github-actions" },
+      status: "in_progress",
+      conclusion: null,
+      started_at: "2026-07-09T00:59:00Z",
+    },
+  ];
+
+  const state = __test.latestRequiredState(spec, checkRuns, []);
+
+  assert.equal(state.ok, false);
+  assert.match(state.description, /github-actions \(15368\)/);
+});
+
+test("stale Greptile confidence summary blocks even with a passing score", async () => {
+  const result = await __test.evaluateGreptile({
+    github: fakeGithub({
+      checkRuns: [greptileRun()],
+      issueComments: [
+        {
+          user: { login: "greptile-apps" },
+          body: "Confidence Score: 5/5",
+          created_at: "2026-07-09T00:00:00Z",
+          updated_at: "2026-07-09T00:00:00Z",
+        },
+      ],
+      reviewComments: [],
+    }),
+    context: fakeContext(),
+    number: 1465,
+    sha: "abc123",
+    lastCommitDate: "2026-07-09T01:00:00Z",
+    core: fakeCore(),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.reasons.join("\n"), /summary comment is older than the head commit/);
+});
+
+test("external replies do not resolve Greptile P1/P2 findings", async () => {
+  const result = await __test.evaluateGreptile({
+    github: fakeGithub({
+      checkRuns: [greptileRun()],
+      issueComments: [freshGreptileSummary()],
+      reviewComments: [
+        greptileFinding({ id: 10 }),
+        {
+          id: 11,
+          in_reply_to_id: 10,
+          user: { login: "outside-user" },
+          body: "Looks fine to me.",
+          created_at: "2026-07-09T01:03:00Z",
+        },
+      ],
+    }),
+    context: fakeContext(),
+    number: 1465,
+    sha: "abc123",
+    lastCommitDate: "2026-07-09T01:00:00Z",
+    core: fakeCore(),
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.reasons.join("\n"), /1 unresolved Greptile P1\/P2 inline finding/);
+});
+
+test("maintainer replies resolve Greptile P1/P2 findings", async () => {
+  const result = await __test.evaluateGreptile({
+    github: fakeGithub({
+      checkRuns: [greptileRun()],
+      issueComments: [freshGreptileSummary()],
+      reviewComments: [
+        greptileFinding({ id: 10 }),
+        {
+          id: 11,
+          in_reply_to_id: 10,
+          user: { login: "sachiniyer" },
+          body: "Documented tradeoff accepted.",
+          created_at: "2026-07-09T01:03:00Z",
+        },
+      ],
+    }),
+    context: fakeContext(),
+    number: 1465,
+    sha: "abc123",
+    lastCommitDate: "2026-07-09T01:00:00Z",
+    core: fakeCore(),
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test("outdated Greptile findings are not counted as unresolved", async () => {
+  const result = await __test.evaluateGreptile({
+    github: fakeGithub({
+      checkRuns: [greptileRun()],
+      issueComments: [freshGreptileSummary()],
+      reviewComments: [greptileFinding({ id: 10, position: null })],
+    }),
+    context: fakeContext(),
+    number: 1465,
+    sha: "abc123",
+    lastCommitDate: "2026-07-09T01:00:00Z",
+    core: fakeCore(),
+  });
+
+  assert.equal(result.ok, true);
+});
+
+function fakeGithub({ checkRuns, issueComments, reviewComments }) {
+  const listForRef = function listForRef() {};
+  const listComments = function listComments() {};
+  const listReviewComments = function listReviewComments() {};
+  const responses = new Map([
+    [listForRef, checkRuns],
+    [listComments, issueComments],
+    [listReviewComments, reviewComments],
+  ]);
+
+  return {
+    rest: {
+      checks: { listForRef },
+      issues: { listComments },
+      pulls: { listReviewComments },
+    },
+    paginate: async (fn) => responses.get(fn) || [],
+  };
+}
+
+function fakeContext() {
+  return { repo: { owner: "sachiniyer", repo: "agent-factory" } };
+}
+
+function fakeCore() {
+  return {
+    info: () => {},
+    notice: () => {},
+    setOutput: () => {},
+    warning: () => {},
+  };
+}
+
+function greptileRun() {
+  return {
+    name: "Greptile Review",
+    app: { id: 123, slug: "greptile" },
+    status: "completed",
+    conclusion: "success",
+    completed_at: "2026-07-09T01:05:00Z",
+  };
+}
+
+function freshGreptileSummary() {
+  return {
+    user: { login: "greptile-apps" },
+    body: "Confidence Score: 4/5",
+    created_at: "2026-07-09T01:02:00Z",
+    updated_at: "2026-07-09T01:02:00Z",
+  };
+}
+
+function greptileFinding({ id, position = 7 }) {
+  return {
+    id,
+    user: { login: "greptile-apps" },
+    body: "P1: this needs attention",
+    created_at: "2026-07-09T01:01:00Z",
+    position,
+  };
+}

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -1,0 +1,61 @@
+name: Auto Gate
+
+on:
+  check_suite:
+    types: [completed]
+  pull_request_review:
+  pull_request:
+    types: [labeled]
+  status:
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+  checks: read
+  statuses: read
+  issues: read
+
+concurrency:
+  group: auto-gate-${{ github.event.pull_request.number || github.event.check_suite.head_sha || github.event.sha || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  auto-gate:
+    name: Evaluate auto-merge gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out gate logic
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Evaluate gate
+        id: evaluate
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.AUTO_GATE_TOKEN || github.token }}
+          script: |
+            const autoGate = require("./.github/scripts/auto-gate.js");
+            await autoGate.evaluate({ github, context, core });
+
+      - name: Report disabled merge
+        if: steps.evaluate.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED != 'true'
+        run: |
+          echo "::notice::AUTO_GATE_ENABLED is not true; would squash-merge PR #${{ steps.evaluate.outputs.pr_number }}."
+          echo "::notice::Docs workflow dispatch after merge: ${{ steps.evaluate.outputs.docs_changed }}."
+          echo "${{ steps.evaluate.outputs.summary }}"
+
+      - name: Squash merge PR
+        if: steps.evaluate.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED == 'true'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.AUTO_GATE_TOKEN || github.token }}
+          script: |
+            const autoGate = require("./.github/scripts/auto-gate.js");
+            await autoGate.merge({
+              github,
+              context,
+              core,
+              prNumber: Number("${{ steps.evaluate.outputs.pr_number }}"),
+            });

--- a/.github/workflows/auto-gate.yml
+++ b/.github/workflows/auto-gate.yml
@@ -36,26 +36,59 @@ jobs:
         with:
           github-token: ${{ secrets.AUTO_GATE_TOKEN || github.token }}
           script: |
-            const autoGate = require("./.github/scripts/auto-gate.js");
-            await autoGate.evaluate({ github, context, core });
+            const fs = require("fs");
+            const path = require("path");
+            const helperPath = path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/auto-gate.js");
+
+            if (!fs.existsSync(helperPath)) {
+              const summary = "BLOCKED: auto-gate helper is not present on the default branch yet.";
+              core.notice(summary);
+              core.setOutput("pr_number", "");
+              core.setOutput("should_merge", "false");
+              core.setOutput("docs_changed", "false");
+              core.setOutput("summary", summary);
+              return;
+            }
+
+            try {
+              const autoGate = require(helperPath);
+              await autoGate.evaluate({ github, context, core });
+            } catch (error) {
+              const message = error && error.message ? error.message : String(error);
+              const summary = `BLOCKED: auto-gate evaluation error: ${message}`;
+              core.warning(error && error.stack ? error.stack : message);
+              core.notice(summary);
+              core.setOutput("pr_number", "");
+              core.setOutput("should_merge", "false");
+              core.setOutput("docs_changed", "false");
+              core.setOutput("summary", summary);
+            }
 
       - name: Report disabled merge
         if: steps.evaluate.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED != 'true'
+        env:
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          DOCS_CHANGED: ${{ steps.evaluate.outputs.docs_changed }}
+          SUMMARY: ${{ steps.evaluate.outputs.summary }}
         run: |
-          echo "::notice::AUTO_GATE_ENABLED is not true; would squash-merge PR #${{ steps.evaluate.outputs.pr_number }}."
-          echo "::notice::Docs workflow dispatch after merge: ${{ steps.evaluate.outputs.docs_changed }}."
-          echo "${{ steps.evaluate.outputs.summary }}"
+          echo "::notice::AUTO_GATE_ENABLED is not true; would squash-merge PR #${PR_NUMBER}."
+          echo "::notice::Docs workflow dispatch after merge: ${DOCS_CHANGED}."
+          printf '%s\n' "$SUMMARY"
 
       - name: Squash merge PR
         if: steps.evaluate.outputs.should_merge == 'true' && vars.AUTO_GATE_ENABLED == 'true'
         uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
         with:
           github-token: ${{ secrets.AUTO_GATE_TOKEN || github.token }}
           script: |
-            const autoGate = require("./.github/scripts/auto-gate.js");
+            const path = require("path");
+            const helperPath = path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/auto-gate.js");
+            const autoGate = require(helperPath);
             await autoGate.merge({
               github,
               context,
               core,
-              prNumber: Number("${{ steps.evaluate.outputs.pr_number }}"),
+              prNumber: Number(process.env.PR_NUMBER),
             });

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [master]
   workflow_dispatch:
+    inputs:
+      deploy_docs:
+        description: 'Deploy docs from master without a push event'
+        required: false
+        default: false
+        type: boolean
 
 # GITHUB_TOKEN defaults to read-only; the deploy job needs to publish the Pages
 # artifact and mint the OIDC token actions/deploy-pages exchanges.
@@ -28,9 +34,14 @@ jobs:
 
       - name: Check docs deploy paths
         id: docs_changes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "docs_changed=${{ inputs.deploy_docs }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           before="${{ github.event.before }}"
           after="${{ github.sha }}"
 


### PR DESCRIPTION
## Summary
- adds `.github/workflows/auto-gate.yml` plus a checked-in gate helper that evaluates required checks, Greptile score/findings, mergeability, author allowlist, and the TUI `play-tested` label gate
- keeps actual squash merge inert unless `vars.AUTO_GATE_ENABLED == 'true'`
- uses `secrets.AUTO_GATE_TOKEN || github.token` so switching to a PAT is a one-line token source change
- handles the Docs caveat by dispatching `docs.yml` after a successful docs-path auto-merge (`docs/` or `mkdocs.yml`), and adds an explicit `deploy_docs` workflow_dispatch input for that deploy path

## Safety / preflight
- Branch protection/ruleset: ok. Active `main` ruleset requires `Lint` + `Build` and linear history; no PR-review or restricted-merge rule blocks GITHUB_TOKEN once required checks pass.
- Downstream trigger: preview auto-release does not matter; it is schedule/manual only. Docs push deploy mattered, and this PR handles it by workflow_dispatch after docs-path merges.
- Review-only: do not enable `AUTO_GATE_ENABLED` until root review + Sachin approval.

## Verification
- `node --check .github/scripts/auto-gate.js`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml`
- `scripts/lint-file-length.sh`
- `go build ./...`
- `make test-container`

Refs #1409