### PR TITLE
tui: hide split hint without preview

### DIFF
--- a/app/home_model.go
+++ b/app/home_model.go
@@ -497,6 +497,7 @@ func (m *home) syncFocus() {
 		m.lastFocusedPaneID = p.ID()
 	}
 	m.menu.SetFocusRegion(active)
+	m.syncSplitPaneHint()
 }
 
 // focusRegion moves focus directly to the given region and re-solves the

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -230,6 +230,25 @@ func TestPanePreviewInvalidatesStaleContentSynchronously(t *testing.T) {
 	assert.Same(t, beta, h.panePreviewTxn.target.instance)
 }
 
+func TestPanePreviewSplitHintRequiresActivePreview(t *testing.T) {
+	h := paneTestHome(t)
+
+	pressKey(t, h, "s")
+	require.Nil(t, h.panePreviewTxn)
+	assert.NotContains(t, h.menu.String(), "split pane",
+		"the footer must not advertise S when there is no preview to commit")
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	require.NotNil(t, h.panePreviewTxn)
+	assert.Contains(t, h.menu.String(), "split pane",
+		"the footer should advertise S while a preview can be committed")
+
+	h.cancelPanePreview(false)
+	assert.NotContains(t, h.menu.String(), "split pane",
+		"canceling the preview must remove the split hint immediately")
+}
+
 func TestPanePreviewFastScrollLatestWins(t *testing.T) {
 	h := paneTestHome(t)
 	alpha := h.store.GetInstanceByTitle("alpha")

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -33,6 +33,8 @@ func samePaneBinding(a, b paneBinding) bool {
 }
 
 func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabSpecific bool, attachedNow bool) {
+	defer m.syncSplitPaneHint()
+
 	if attachedNow || m.interactive || selected == nil {
 		m.cancelPanePreview(false)
 		return
@@ -95,6 +97,8 @@ func (m *home) cancelPanePreview(focusOwner bool) {
 	if txn == nil {
 		return
 	}
+	defer m.syncSplitPaneHint()
+
 	m.panePreviewTxn = nil
 	if w := m.paneWindows[txn.ownerPaneID]; w != nil {
 		w.ClearPreview()
@@ -219,6 +223,18 @@ func previewCommitError(inst *session.Instance) error {
 		return fmt.Errorf("cannot commit preview for %q: session was lost", inst.Title)
 	}
 	return nil
+}
+
+func (m *home) syncSplitPaneHint() {
+	if m.menu == nil {
+		return
+	}
+	m.menu.SetSplitPaneAvailable(m.splitPaneAvailable())
+}
+
+func (m *home) splitPaneAvailable() bool {
+	txn := m.panePreviewTxn
+	return txn != nil && previewCommitError(txn.target.instance) == nil
 }
 
 func (m *home) renderBindingForPane(p *store.OpenPane) (paneBinding, uint64) {

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -70,6 +70,11 @@ type Menu struct {
 	// terminal (#1089, RFC §2.3), so the bar shows only the escape hatch.
 	interactive bool
 
+	// splitPaneAvailable is true only while there is an active preview that
+	// `S` can commit as another pane. Without that preview the key no-ops, so
+	// the footer must not advertise it (#1419).
+	splitPaneAvailable bool
+
 	// keyDown is the key which is pressed. The default is -1.
 	keyDown keys.KeyName
 
@@ -90,18 +95,6 @@ var newInstanceMenuOptions = []keys.KeyName{keys.KeySubmitName, keys.KeyChangePr
 // the cross-region ones.
 var automationsMenuOptions = []keys.KeyName{
 	keys.KeyManageAutomations, keys.KeyTab, keys.KeyHooks, keys.KeyHelp, keys.KeyQuit,
-}
-
-// paneMenuOptions are the status-bar hints while a workspace pane has focus
-// (#1088): enter interacts in-pane / o attaches full-screen (#1089), scroll
-// acts on the pane's own binding, s opens the selected tab as another pane,
-// S commits a preview as another pane, left/right switch panes, and x hides
-// this pane back to the background.
-var paneMenuOptions = []keys.KeyName{
-	keys.KeyEnter, keys.KeyAttach, keys.KeyShiftUp, keys.KeyShiftDown,
-	keys.KeyPanePrev, keys.KeyPaneNext,
-	keys.KeyOpenPane, keys.KeySplitPane, keys.KeyHidePane,
-	keys.KeyTab, keys.KeyHelp, keys.KeyQuit,
 }
 
 // interactiveMenuOptions is the whole bar while interactive (#1089, RFC
@@ -172,6 +165,14 @@ func (m *Menu) SetInteractive(on bool) {
 	m.updateOptions()
 }
 
+// SetSplitPaneAvailable controls whether the split-pane commit key is
+// advertised. The key is still globally bound; this only keeps the footer
+// honest when no preview exists to commit (#1419).
+func (m *Menu) SetSplitPaneAvailable(available bool) {
+	m.splitPaneAvailable = available
+	m.updateOptions()
+}
+
 // updateOptions updates the menu options based on current state, focus
 // region, and instance
 func (m *Menu) updateOptions() {
@@ -199,13 +200,7 @@ func (m *Menu) updateOptions() {
 	// attach/scroll on its binding, open another pane, hide this one. Same
 	// naming-flow exception as the strip.
 	if layout.IsPaneRegion(m.focusRegion) && m.state != StateNewInstance {
-		m.options = paneMenuOptions
-		m.groups = []menuGroup{
-			{start: 0, end: 4, isAction: true},
-			{start: 4, end: 6, isAction: false},
-			{start: 6, end: 9, isAction: false},
-			{start: 9, end: len(paneMenuOptions), isAction: false},
-		}
+		m.setPaneFocusOptions()
 		return
 	}
 	switch m.state {
@@ -280,8 +275,12 @@ func (m *Menu) addInstanceOptions() {
 	}
 
 	// Pane group (#1088/#1321): s opens the selected tab as a workspace pane
-	// (or focuses its pane when already open); S commits a preview alongside.
-	paneGroup := []keys.KeyName{keys.KeyOpenPane, keys.KeySplitPane}
+	// (or focuses its pane when already open); S commits a preview alongside
+	// only while one exists (#1419).
+	paneGroup := []keys.KeyName{keys.KeyOpenPane}
+	if m.splitPaneAvailable {
+		paneGroup = append(paneGroup, keys.KeySplitPane)
+	}
 
 	// System group: the focus-ring cycle plus help/quit.
 	systemGroup := []keys.KeyName{keys.KeyTab, keys.KeyHelp, keys.KeyQuit}
@@ -306,6 +305,38 @@ func (m *Menu) addInstanceOptions() {
 		{start: mgmtEnd, end: actionEnd, isAction: true},
 		{start: actionEnd, end: tabEnd, isAction: false},
 		{start: tabEnd, end: paneEnd, isAction: false},
+		{start: paneEnd, end: systemEnd, isAction: false},
+	}
+}
+
+func (m *Menu) setPaneFocusOptions() {
+	// Action group: enter interacts in-pane / o attaches full-screen (#1089),
+	// and scroll acts on this pane's binding.
+	actionGroup := []keys.KeyName{keys.KeyEnter, keys.KeyAttach, keys.KeyShiftUp, keys.KeyShiftDown}
+	focusGroup := []keys.KeyName{keys.KeyPanePrev, keys.KeyPaneNext}
+	paneGroup := []keys.KeyName{keys.KeyOpenPane}
+	if m.splitPaneAvailable {
+		paneGroup = append(paneGroup, keys.KeySplitPane)
+	}
+	paneGroup = append(paneGroup, keys.KeyHidePane)
+	systemGroup := []keys.KeyName{keys.KeyTab, keys.KeyHelp, keys.KeyQuit}
+
+	actionEnd := len(actionGroup)
+	focusEnd := actionEnd + len(focusGroup)
+	paneEnd := focusEnd + len(paneGroup)
+	systemEnd := paneEnd + len(systemGroup)
+
+	options := make([]keys.KeyName, 0, systemEnd)
+	options = append(options, actionGroup...)
+	options = append(options, focusGroup...)
+	options = append(options, paneGroup...)
+	options = append(options, systemGroup...)
+
+	m.options = options
+	m.groups = []menuGroup{
+		{start: 0, end: actionEnd, isAction: true},
+		{start: actionEnd, end: focusEnd, isAction: false},
+		{start: focusEnd, end: paneEnd, isAction: false},
 		{start: paneEnd, end: systemEnd, isAction: false},
 	}
 }

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -160,8 +160,9 @@ func TestMenuRemoteInstanceOmitsUnsupportedTabKeys(t *testing.T) {
 	}
 }
 
-// TestMenuPaneHintsFollowFocus pins the #1088 hint model: tree focus
-// advertises the open-pane verb with the instance actions; a focused
+// TestMenuPaneHintsFollowFocus pins the #1088/#1419 hint model: tree focus
+// advertises the open-pane verb with the instance actions; split-pane is
+// advertised only while a preview exists to commit; a focused
 // workspace pane gets its own option set — attach/scroll on its binding,
 // pane switching, open-pane, hide-pane.
 func TestMenuPaneHintsFollowFocus(t *testing.T) {
@@ -179,19 +180,28 @@ func TestMenuPaneHintsFollowFocus(t *testing.T) {
 	}
 
 	m.SetFocusRegion(layout.RegionTree)
-	if !has(keys.KeyOpenPane) || !has(keys.KeySplitPane) || has(keys.KeyHidePane) {
-		t.Errorf("tree focus must advertise open/split pane, not hide; options=%v", m.options)
+	if !has(keys.KeyOpenPane) || has(keys.KeySplitPane) || has(keys.KeyHidePane) {
+		t.Errorf("tree focus must advertise open pane, not split/hide without a preview; options=%v", m.options)
 	}
 	if !has(keys.KeyNewTab) || !has(keys.KeyKill) {
 		t.Errorf("tree focus keeps the instance actions; options=%v", m.options)
 	}
+	m.SetSplitPaneAvailable(true)
+	if !has(keys.KeySplitPane) {
+		t.Errorf("tree focus must advertise split pane while a preview can be committed; options=%v", m.options)
+	}
+	m.SetSplitPaneAvailable(false)
 
 	m.SetFocusRegion(layout.PaneRegion(7))
-	if !has(keys.KeyOpenPane) || !has(keys.KeySplitPane) || !has(keys.KeyHidePane) ||
+	if !has(keys.KeyOpenPane) || has(keys.KeySplitPane) || !has(keys.KeyHidePane) ||
 		!has(keys.KeyPanePrev) || !has(keys.KeyPaneNext) || !has(keys.KeyEnter) {
-		t.Errorf("a focused pane must advertise pane focus/open/split/hide + attach; options=%v", m.options)
+		t.Errorf("a focused pane must advertise pane focus/open/hide + attach, not split without a preview; options=%v", m.options)
 	}
 	if has(keys.KeyNewTab) {
 		t.Errorf("pane focus swaps to the pane option set; options=%v", m.options)
+	}
+	m.SetSplitPaneAvailable(true)
+	if !has(keys.KeySplitPane) {
+		t.Errorf("a focused pane must advertise split pane while a preview can be committed; options=%v", m.options)
 	}
 }


### PR DESCRIPTION
## Summary
- make the footer advertise `S split pane` only while a preview exists and can be committed
- keep tree and focused-pane footer options derived from the keymap while dynamically adding/removing the split action
- cover the app preview lifecycle so the hint appears on preview creation and disappears on cancel

Closes #1419

## Verification
- `make test-container GOTESTARGS="./ui ./app -run 'Test(MenuPaneHintsFollowFocus|PanePreviewSplitHintRequiresActivePreview)'"`\n- `golangci-lint run --timeout=3m --fast`\n- `gofmt -l .`\n- `go build ./...`\n- `make test-container`\n- `deadcode -test ./...`\n- `scripts/lint-file-length.sh`\n- verified branch is based on `origin/master`; scoped diff: `app/home_model.go`, `app/pane_preview.go`, `app/pane_model_test.go`, `ui/menu.go`, `ui/menu_test.go`\n\nSigned-off-by: Captain Claude <captain-claude@users.noreply.github.com>