### PR TITLE
Fix daemon event queue drain cleanup

### DIFF
--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -86,6 +86,7 @@ type eventQueue struct {
 	taskID  string
 	path    string // <dir>/<taskID>.jsonl
 	curPath string // <dir>/<taskID>.cursor
+	remove  func(string) error
 
 	mu      sync.Mutex
 	offset  int64 // byte offset of the first undelivered event
@@ -123,6 +124,7 @@ func newEventQueue(dir, taskID string) *eventQueue {
 		taskID:  taskID,
 		path:    filepath.Join(dir, taskID+".jsonl"),
 		curPath: filepath.Join(dir, taskID+".cursor"),
+		remove:  os.Remove,
 		now:     time.Now,
 	}
 	q.load()
@@ -205,6 +207,9 @@ func (q *eventQueue) enqueue(line string) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
+	if err := q.resetCursorBeforeFreshAppendLocked(); err != nil {
+		return err
+	}
 	q.seq++
 	rec, err := json.Marshal(queuedEvent{Seq: q.seq, TS: q.now(), Line: line})
 	if err != nil {
@@ -236,6 +241,22 @@ func (q *eventQueue) enqueue(line string) error {
 	q.pending++
 
 	return q.dropOldestOverCapsLocked()
+}
+
+// resetCursorBeforeFreshAppendLocked removes or zeroes any leftover cursor
+// before a brand-new queue file is created. A stale nonzero cursor beside a
+// fresh jsonl file could make a later daemon skip bytes on reload.
+func (q *eventQueue) resetCursorBeforeFreshAppendLocked() error {
+	if q.pending != 0 || q.offset != 0 || q.size != 0 {
+		return nil
+	}
+	if err := q.remove(q.curPath); err != nil && !os.IsNotExist(err) {
+		if resetErr := config.AtomicWriteFile(q.curPath, []byte("0"), 0644); resetErr != nil {
+			return fmt.Errorf("failed to reset stale event-queue cursor before enqueue: remove failed: %v; reset failed: %w", err, resetErr)
+		}
+		log.WarningLog.Printf("watch task %s: failed to remove stale event-queue cursor before enqueue; reset it to 0: %v", q.taskID, err)
+	}
+	return nil
 }
 
 // dropOldestOverCapsLocked advances the cursor past the oldest pending events
@@ -312,16 +333,7 @@ func (q *eventQueue) advance(cursor eventQueueCursor) (bool, error) {
 	q.offset += cursor.length
 	q.pending--
 	if q.pending == 0 {
-		// Fully drained: reclaim the delivered prefix by removing both files —
-		// the steady healthy state is no queue files at all.
-		q.offset, q.size = 0, 0
-		if err := os.Remove(q.path); err != nil && !os.IsNotExist(err) {
-			return false, err
-		}
-		if err := os.Remove(q.curPath); err != nil && !os.IsNotExist(err) {
-			return false, err
-		}
-		return true, nil
+		return q.removeDrainedFilesLocked()
 	}
 	if q.offset > watcherQueueCompactBytes {
 		if err := q.compactLocked(); err != nil {
@@ -331,6 +343,25 @@ func (q *eventQueue) advance(cursor eventQueueCursor) (bool, error) {
 		}
 	}
 	return true, q.persistCursorLocked()
+}
+
+// removeDrainedFilesLocked reclaims queue storage after the final event is
+// delivered. The in-memory delivered-prefix state must stay intact until the
+// jsonl file is gone; otherwise a later append can make already-delivered bytes
+// look pending and silently lose the appended event (#1433).
+func (q *eventQueue) removeDrainedFilesLocked() (bool, error) {
+	if err := q.remove(q.path); err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := q.remove(q.curPath); err != nil && !os.IsNotExist(err) {
+		if resetErr := config.AtomicWriteFile(q.curPath, []byte("0"), 0644); resetErr != nil {
+			q.offset, q.size = 0, 0
+			return false, fmt.Errorf("failed to reset drained event-queue cursor: remove failed: %v; reset failed: %w", err, resetErr)
+		}
+		log.WarningLog.Printf("watch task %s: failed to remove drained event-queue cursor; reset it to 0: %v", q.taskID, err)
+	}
+	q.offset, q.size = 0, 0
+	return true, nil
 }
 
 // compactLocked rewrites the queue file to just its pending suffix, dropping

--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -62,6 +62,107 @@ func TestEventQueue_EnqueuePeekAdvanceRoundTrip(t *testing.T) {
 	}
 }
 
+// TestEventQueue_RemoveFailureDoesNotLoseLaterEnqueue covers #1433: if the
+// final queue-file remove fails, advance must leave the delivered-prefix state
+// intact. A later enqueue appends behind that prefix; the next peek must see
+// the later event, not re-read the already delivered record and then unlink
+// the file containing both records.
+func TestEventQueue_RemoveFailureDoesNotLoseLaterEnqueue(t *testing.T) {
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab120009")
+	if err := q.enqueue("delivered-before-remove-failure"); err != nil {
+		t.Fatalf("enqueue first: %v", err)
+	}
+	_, cursor, ok, err := q.peek()
+	if err != nil || !ok {
+		t.Fatalf("peek first: ok=%v err=%v", ok, err)
+	}
+
+	removeErr := errors.New("simulated remove failure")
+	failNextRemove := true
+	q.remove = func(path string) error {
+		if path == q.path && failNextRemove {
+			failNextRemove = false
+			return removeErr
+		}
+		return os.Remove(path)
+	}
+	advanced, err := q.advance(cursor)
+	if !errors.Is(err, removeErr) {
+		t.Fatalf("advance error = %v, want %v", err, removeErr)
+	}
+	if advanced {
+		t.Fatal("advance reported success after queue-file removal failed")
+	}
+
+	if err := q.enqueue("new-after-remove-failure"); err != nil {
+		t.Fatalf("enqueue second: %v", err)
+	}
+	ev, cursor, ok, err := q.peek()
+	if err != nil || !ok {
+		t.Fatalf("peek second: ok=%v err=%v", ok, err)
+	}
+	if ev.Line != "new-after-remove-failure" {
+		t.Fatalf("head after failed remove = %q, want the later event", ev.Line)
+	}
+	advanceEventQueue(t, q, cursor)
+	if got := q.pendingCount(); got != 0 {
+		t.Fatalf("pending after second advance = %d, want 0", got)
+	}
+	if _, err := os.Stat(q.path); !os.IsNotExist(err) {
+		t.Fatalf("queue file after drain = %v, want removed", err)
+	}
+}
+
+func TestEventQueue_CursorRemoveFailureResetsBeforeFreshEnqueue(t *testing.T) {
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab120010")
+	for _, line := range []string{"first", "second"} {
+		if err := q.enqueue(line); err != nil {
+			t.Fatalf("enqueue %q: %v", line, err)
+		}
+	}
+	_, cursor, ok, err := q.peek()
+	if err != nil || !ok {
+		t.Fatalf("peek first: ok=%v err=%v", ok, err)
+	}
+	advanceEventQueue(t, q, cursor)
+
+	failCursorRemove := true
+	q.remove = func(path string) error {
+		if path == q.curPath && failCursorRemove {
+			failCursorRemove = false
+			return errors.New("simulated cursor remove failure")
+		}
+		return os.Remove(path)
+	}
+	_, cursor, ok, err = q.peek()
+	if err != nil || !ok {
+		t.Fatalf("peek second: ok=%v err=%v", ok, err)
+	}
+	advanceEventQueue(t, q, cursor)
+
+	raw, err := os.ReadFile(q.curPath)
+	if err != nil {
+		t.Fatalf("read reset cursor: %v", err)
+	}
+	if got := strings.TrimSpace(string(raw)); got != "0" {
+		t.Fatalf("cursor after failed remove = %q, want 0", got)
+	}
+	if err := q.enqueue("after-drain"); err != nil {
+		t.Fatalf("enqueue after drain: %v", err)
+	}
+
+	reopened := newEventQueue(dir, "ab120010")
+	if got := reopened.pendingCount(); got != 1 {
+		t.Fatalf("reopened pending = %d, want 1", got)
+	}
+	ev, _, ok, err := reopened.peek()
+	if err != nil || !ok || ev.Line != "after-drain" {
+		t.Fatalf("reopened head = %q ok=%v err=%v, want after-drain", ev.Line, ok, err)
+	}
+}
+
 // TestEventQueue_RecoversAcrossReopen: a partially drained backlog written by
 // one eventQueue is recovered by a fresh one over the same files — the daemon
 // restart / reload shape. The cursor keeps delivered events delivered.


### PR DESCRIPTION
Closes #1433.

## Summary
- Keep event-queue delivered-prefix state intact until the drained queue file is actually removed, so a later enqueue cannot reread old bytes and unlink newer events.
- Reset stale cursor files to 0 when cursor cleanup fails, and guard fresh appends from inheriting a stale cursor.
- Add event-queue regression coverage for remove-failure followed by enqueue and cursor cleanup failure.

## Verification
- gofmt -l daemon/eventqueue.go daemon/eventqueue_test.go
- golangci-lint run --fast
- go build ./...
- make test-container
- deadcode -test ./...
- make lint-file-length

Note: this installed golangci-lint requires the v2 subcommand form; literal `golangci-lint --fast` exits with unknown flag, so I ran `golangci-lint run --fast`.