### PR TITLE
tui: suppress hidden pane verbs in automations

### DIFF
--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -87,9 +87,10 @@ func (m *home) showSearchOverlay() (tea.Model, tea.Cmd) {
 // section — which is only the compact summary since the #1096 play-test; the
 // full manager lives in the tasks overlay. Cursor keys move the section's
 // selection, Enter opens the manager overlay on it, Esc returns focus to the
-// tree. Everything else falls through to the caller so the global bindings
-// (Tab/Shift-Tab focus ring, task manager, hooks, ? help, q quit) keep
-// working.
+// tree. Advertised global bindings (Tab/Shift-Tab focus ring, task manager,
+// hooks, ? help, q quit) keep working, while pane-management verbs are
+// consumed here so hidden `s`/`S`/`x`/pane-switch keys cannot mutate workspace
+// panes from Automations focus (#1417).
 func (m *home) handleAutomationsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	if m.ring.Active() != layout.RegionAutomations {
 		return m, nil, false
@@ -105,7 +106,25 @@ func (m *home) handleAutomationsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 		m.focusRegion(layout.RegionTree)
 		return m, nil, true
 	}
+	if automationsConsumesPaneVerb(msg) {
+		return m, nil, true
+	}
 	return m, nil, false
+}
+
+func automationsConsumesPaneVerb(msg tea.KeyMsg) bool {
+	for _, name := range []keys.KeyName{
+		keys.KeyOpenPane,
+		keys.KeySplitPane,
+		keys.KeyHidePane,
+		keys.KeyPanePrev,
+		keys.KeyPaneNext,
+	} {
+		if key.Matches(msg, keys.GlobalKeyBindings[name]) {
+			return true
+		}
+	}
+	return false
 }
 
 // showTasksOverlay opens the task manager (list + create/edit form) as a

--- a/app/layout_cutover_test.go
+++ b/app/layout_cutover_test.go
@@ -124,6 +124,30 @@ func TestLayoutCutover_AutomationsEscReturnsFocusToTree(t *testing.T) {
 	assert.False(t, h.automations.Focused())
 }
 
+func TestLayoutCutover_AutomationsFocusConsumesHiddenPaneVerbs(t *testing.T) {
+	h := newTestHome(t)
+	alpha := addTreeInstance(t, h, "alpha")
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+	resizeHome(h, 100, 30)
+
+	h.focusRegion(layout.RegionAutomations)
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+	require.Equal(t, 0, h.store.NumOpenPanes(),
+		"hidden s must not open a workspace pane while Automations has focus")
+	assert.Equal(t, layout.RegionAutomations, h.ring.Active(),
+		"hidden s must not move focus away from Automations")
+
+	p := openTestPane(t, h, alpha, 0)
+	h.focusRegion(layout.RegionAutomations)
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+	require.Equal(t, 1, h.store.NumOpenPanes(),
+		"hidden s must not create another pane while Automations has focus")
+	assert.Same(t, p, h.store.OpenPanes()[0])
+	assert.Equal(t, layout.RegionAutomations, h.ring.Active(),
+		"hidden s must not focus the existing workspace pane")
+}
+
 // TestLayoutCutover_EnterOpensTasksOverlay: Enter on the focused in-rail
 // section opens the task manager as a centered modal (#1096 play-test fix 1),
 // preselecting the section cursor's task; Esc closes it and saving runs.


### PR DESCRIPTION
## Summary
- consume pane-management bindings while the Automations rail has focus so hidden `s` cannot open or focus workspace panes
- keep advertised Automations/global actions flowing through: manage, focus cycling, hooks, help, quit, and task manager
- add regression coverage for `s` with no panes and with an existing pane

Closes #1417

## Verification
- `make test-container GOTESTARGS="./app -run TestLayoutCutover_AutomationsFocusConsumesHiddenPaneVerbs"`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- verified branch is based on `origin/master`; scoped diff: `app/handle_overlay.go`, `app/layout_cutover_test.go`

Signed-off-by: Captain Claude <captain-claude@users.noreply.github.com>