### PR TITLE
Auto-update on startup by configured channel

### DIFF
--- a/commands/autoupdate.go
+++ b/commands/autoupdate.go
@@ -19,6 +19,7 @@ import (
 const (
 	autoUpdateCheckInterval = 24 * time.Hour
 	lastCheckFile           = "last_update_check"
+	autoUpdateEnv           = "AGENT_FACTORY_AUTO_UPDATE"
 )
 
 // GitHub API endpoints for release discovery, one per channel (#1041).
@@ -52,91 +53,113 @@ var fetchLatestReleaseTagFn = fetchLatestReleaseTag
 
 // autoUpdateInBackground checks for a newer release and applies it silently.
 // It runs in a goroutine and never blocks the main program.
-func autoUpdateInBackground() {
+func autoUpdateInBackground(cfg *config.Config) {
+	if !autoUpdateEnabled(cfg) {
+		log.InfoLog.Printf("auto-update: disabled")
+		return
+	}
+	channel := config.UpdateChannelStable
+	if cfg != nil {
+		channel = cfg.UpdateChannel
+	}
 	go func() {
-		if err := autoUpdate(); err != nil {
+		if err := autoUpdateForChannel(channel); err != nil {
 			log.ErrorLog.Printf("auto-update: %v", err)
 		}
 	}()
 }
 
 func autoUpdate() error {
-	// Throttle: only check once per 24 hours
-	if !shouldCheck() {
+	cfg, err := config.LoadConfig()
+	if err != nil || cfg == nil {
+		if !autoUpdateEnabled(nil) {
+			return nil
+		}
+		return autoUpdateForChannel(config.UpdateChannelStable)
+	}
+	if !autoUpdateEnabled(cfg) {
 		return nil
 	}
+	return autoUpdateForChannel(cfg.UpdateChannel)
+}
 
+func autoUpdateForChannel(channel string) error {
+	channel = normalizeUpdateChannel(channel)
 	// Auto-update is not supported on Windows, so skip before any network
 	// operations — there is nothing to fetch, download, or install (#1002).
-	// Still record the check so the 24-hour throttle fires and we don't probe
-	// shouldCheck() on every launch (#262). Use the runtimeGOOS seam so tests
-	// can exercise this branch without building for Windows.
+	// Treat the platform skip as a successful startup decision so Windows
+	// launch loops do not re-enter this branch every time (#262).
 	if runtimeGOOS == "windows" {
-		recordCheck()
-		return nil
+		return withUpdateCheckLock(func(cache *updateCheckCache, now time.Time) error {
+			currentVersion := strings.TrimPrefix(version, "v")
+			if !updateCheckDue(cache, channel, currentVersion, now) {
+				return nil
+			}
+			return recordCheckLocked(cache, channel, "", currentVersion, now)
+		})
 	}
-
-	// Record the check up front so failure-prone steps below (network fetch,
-	// download, install) still honor the 24-hour throttle. Without this,
-	// persistent failures (blocked api.github.com, corp proxy, DNS) would
-	// retry on every launch and flood GitHub's rate limit. See issue #459.
-	recordCheck()
 
 	// Windows already returned above, before any network call (#1002).
 	goos := runtimeGOOS
 	goarch := runtime.GOARCH
 
-	latestTag, downloadURL, err := latestDownloadURL(updateChannel(), goos, goarch)
-	if err != nil {
-		return err
-	}
+	return withUpdateCheckLock(func(cache *updateCheckCache, now time.Time) error {
+		currentVersion := strings.TrimPrefix(version, "v")
+		if !updateCheckDue(cache, channel, currentVersion, now) {
+			return nil
+		}
 
-	// Strip leading "v" from tags for comparison
-	latestVersion := strings.TrimPrefix(latestTag, "v")
-	currentVersion := strings.TrimPrefix(version, "v")
-	if !isNewer(latestVersion, currentVersion) {
-		return nil
-	}
+		latestTag, downloadURL, err := latestDownloadURL(channel, goos, goarch)
+		if err != nil {
+			return err
+		}
 
-	log.InfoLog.Printf("auto-update: updating from %s to %s", version, latestVersion)
+		// Strip leading "v" from tags for comparison.
+		latestVersion := strings.TrimPrefix(latestTag, "v")
+		if !isNewer(latestVersion, currentVersion) {
+			return recordCheckLocked(cache, channel, latestTag, currentVersion, now)
+		}
 
-	binary, err := downloadBinaryFn(downloadURL)
-	if err != nil {
-		return err
-	}
+		log.InfoLog.Printf("auto-update: updating from %s to %s", version, latestVersion)
 
-	execPath, err := osExecutableFn()
-	if err != nil {
-		return fmt.Errorf("failed to find executable: %w", err)
-	}
-	// Resolve symlinks so we replace the real binary, not the symlink
-	// pointing to it (e.g. on macOS Homebrew installs).
-	resolvedPath, err := filepath.EvalSymlinks(execPath)
-	if err != nil {
-		return fmt.Errorf("failed to resolve executable path: %w", err)
-	}
+		binary, err := downloadBinaryFn(downloadURL)
+		if err != nil {
+			return err
+		}
 
-	if err := config.AtomicWriteFile(resolvedPath, binary, 0755); err != nil {
-		return fmt.Errorf("failed to write new binary: %w", err)
-	}
+		execPath, err := osExecutableFn()
+		if err != nil {
+			return fmt.Errorf("failed to find executable: %w", err)
+		}
+		// Resolve symlinks so we replace the real binary, not the symlink
+		// pointing to it (e.g. on macOS Homebrew installs).
+		resolvedPath, err := filepath.EvalSymlinks(execPath)
+		if err != nil {
+			return fmt.Errorf("failed to resolve executable path: %w", err)
+		}
 
-	// Same rationale as `af upgrade` (#498/#1386): restart the running daemon
-	// immediately from the freshly written binary. Quiet on the no-daemon path
-	// since autoUpdate runs in the background on every launch. Pre-#501
-	// daemons don't speak the Shutdown RPC; RequestShutdown falls back to
-	// PID-file-based SIGTERM (#504).
-	result, restartErr := restartDaemonFromPath(resolvedPath)
-	switch {
-	case restartErr != nil:
-		log.WarningLog.Printf("auto-update: updated to %s but failed to restart daemon: %v", latestVersion, restartErr)
-	case result == daemon.ShutdownViaRPC:
-		log.InfoLog.Printf("auto-update: updated to %s and restarted running daemon", latestVersion)
-	case result == daemon.ShutdownViaSIGTERM:
-		log.InfoLog.Printf("auto-update: updated to %s and restarted pre-#501 running daemon via SIGTERM fallback", latestVersion)
-	default:
-		log.InfoLog.Printf("auto-update: updated to %s (effective on next launch)", latestVersion)
-	}
-	return nil
+		if err := config.AtomicWriteFile(resolvedPath, binary, 0755); err != nil {
+			return fmt.Errorf("failed to write new binary: %w", err)
+		}
+
+		// Same rationale as `af upgrade` (#498/#1386): restart the running daemon
+		// immediately from the freshly written binary. Quiet on the no-daemon path
+		// since autoUpdate runs in the background on every launch. Pre-#501
+		// daemons don't speak the Shutdown RPC; RequestShutdown falls back to
+		// PID-file-based SIGTERM (#504).
+		result, restartErr := restartDaemonFromPath(resolvedPath)
+		switch {
+		case restartErr != nil:
+			log.WarningLog.Printf("auto-update: updated to %s but failed to restart daemon: %v", latestVersion, restartErr)
+		case result == daemon.ShutdownViaRPC:
+			log.InfoLog.Printf("auto-update: updated to %s and restarted running daemon", latestVersion)
+		case result == daemon.ShutdownViaSIGTERM:
+			log.InfoLog.Printf("auto-update: updated to %s and restarted pre-#501 running daemon via SIGTERM fallback", latestVersion)
+		default:
+			log.InfoLog.Printf("auto-update: updated to %s (effective on next launch)", latestVersion)
+		}
+		return recordCheckLocked(cache, channel, latestTag, latestVersion, now)
+	})
 }
 
 // updateChannel returns the release channel auto-update and `af upgrade`
@@ -149,7 +172,7 @@ func updateChannel() string {
 	if err != nil || cfg == nil {
 		return config.UpdateChannelStable
 	}
-	return cfg.UpdateChannel
+	return normalizeUpdateChannel(cfg.UpdateChannel)
 }
 
 // latestDownloadURL resolves the newest release on the given channel (#1041)
@@ -338,29 +361,140 @@ func lastCheckPath() string {
 	return filepath.Join(dir, lastCheckFile)
 }
 
-func shouldCheck() bool {
+func autoUpdateEnabled(cfg *config.Config) bool {
+	enabled := true
+	if cfg != nil {
+		enabled = cfg.AutoUpdate
+	}
+	raw, ok := os.LookupEnv(autoUpdateEnv)
+	if !ok {
+		return enabled
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "t", "yes", "y", "on":
+		return true
+	case "0", "false", "f", "no", "n", "off":
+		return false
+	case "":
+		return enabled
+	default:
+		log.WarningLog.Printf("auto-update: ignoring invalid %s=%q (expected true/false, 1/0, yes/no, on/off)", autoUpdateEnv, raw)
+		return enabled
+	}
+}
+
+func normalizeUpdateChannel(channel string) string {
+	if channel == config.UpdateChannelPreview {
+		return config.UpdateChannelPreview
+	}
+	return config.UpdateChannelStable
+}
+
+type updateCheckCache struct {
+	path          string
+	SchemaVersion int                          `json:"schema_version,omitempty"`
+	LastChannel   string                       `json:"last_channel,omitempty"`
+	Channels      map[string]updateCheckRecord `json:"channels,omitempty"`
+}
+
+type updateCheckRecord struct {
+	CheckedAt      time.Time `json:"checked_at"`
+	LastSeenTag    string    `json:"last_seen_tag,omitempty"`
+	CurrentVersion string    `json:"current_version,omitempty"`
+}
+
+func withUpdateCheckLock(fn func(cache *updateCheckCache, now time.Time) error) error {
+	path := lastCheckPath()
+	if path == "" {
+		return fn(&updateCheckCache{}, time.Now().UTC())
+	}
+	return config.WithFileLock(path, func() error {
+		cache := readUpdateCheckCache(path)
+		return fn(cache, time.Now().UTC())
+	})
+}
+
+func readUpdateCheckCache(path string) *updateCheckCache {
+	cache := &updateCheckCache{path: path}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cache
+	}
+	if err := json.Unmarshal(data, cache); err == nil {
+		cache.path = path
+		if cache.Channels == nil {
+			cache.Channels = map[string]updateCheckRecord{}
+		}
+		return cache
+	}
+	// Legacy cache files were a bare RFC3339 timestamp with no channel. Treat
+	// them as stale so the first new build re-checks and writes channel-aware
+	// metadata instead of letting a prior stable check suppress preview (#1466).
+	return cache
+}
+
+func shouldCheck(channel string) bool {
 	path := lastCheckPath()
 	if path == "" {
 		return true
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return true
-	}
-	t, err := time.Parse(time.RFC3339, strings.TrimSpace(string(data)))
-	if err != nil {
-		return true
-	}
-	if t.After(time.Now()) {
-		return true
-	}
-	return time.Since(t) >= autoUpdateCheckInterval
+	cache := readUpdateCheckCache(path)
+	return updateCheckDue(cache, normalizeUpdateChannel(channel), strings.TrimPrefix(version, "v"), time.Now().UTC())
 }
 
-func recordCheck() {
+func updateCheckDue(cache *updateCheckCache, channel, currentVersion string, now time.Time) bool {
+	channel = normalizeUpdateChannel(channel)
+	if cache == nil {
+		return true
+	}
+	if cache.LastChannel != "" && cache.LastChannel != channel {
+		return true
+	}
+	rec, ok := cache.Channels[channel]
+	if !ok {
+		return true
+	}
+	if rec.CurrentVersion != "" && rec.CurrentVersion != currentVersion {
+		return true
+	}
+	if rec.CheckedAt.IsZero() || rec.CheckedAt.After(now) {
+		return true
+	}
+	return now.Sub(rec.CheckedAt) >= autoUpdateCheckInterval
+}
+
+func recordCheck(channel, lastSeenTag, currentVersion string) {
 	path := lastCheckPath()
 	if path == "" {
 		return
 	}
-	_ = config.AtomicWriteFile(path, []byte(time.Now().UTC().Format(time.RFC3339)), 0644)
+	_ = config.WithFileLock(path, func() error {
+		return recordCheckLocked(readUpdateCheckCache(path), channel, lastSeenTag, currentVersion, time.Now().UTC())
+	})
+}
+
+func recordCheckLocked(cache *updateCheckCache, channel, lastSeenTag, currentVersion string, now time.Time) error {
+	if cache == nil {
+		cache = &updateCheckCache{}
+	}
+	if cache.path == "" {
+		return nil
+	}
+	channel = normalizeUpdateChannel(channel)
+	if cache.Channels == nil {
+		cache.Channels = map[string]updateCheckRecord{}
+	}
+	cache.SchemaVersion = 1
+	cache.LastChannel = channel
+	cache.Channels[channel] = updateCheckRecord{
+		CheckedAt:      now.UTC(),
+		LastSeenTag:    lastSeenTag,
+		CurrentVersion: strings.TrimPrefix(currentVersion, "v"),
+	}
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return config.AtomicWriteFile(cache.path, data, 0644)
 }

--- a/commands/autoupdate_test.go
+++ b/commands/autoupdate_test.go
@@ -64,8 +64,12 @@ func withTestHome(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	prev, had := os.LookupEnv("AGENT_FACTORY_HOME")
+	prevAutoUpdate, hadAutoUpdate := os.LookupEnv(autoUpdateEnv)
 	if err := os.Setenv("AGENT_FACTORY_HOME", dir); err != nil {
 		t.Fatalf("setenv: %v", err)
+	}
+	if err := os.Unsetenv(autoUpdateEnv); err != nil {
+		t.Fatalf("unsetenv %s: %v", autoUpdateEnv, err)
 	}
 	t.Cleanup(func() {
 		if had {
@@ -73,14 +77,20 @@ func withTestHome(t *testing.T) string {
 		} else {
 			os.Unsetenv("AGENT_FACTORY_HOME")
 		}
+		if hadAutoUpdate {
+			os.Setenv(autoUpdateEnv, prevAutoUpdate)
+		} else {
+			os.Unsetenv(autoUpdateEnv)
+		}
 	})
 	return dir
 }
 
 // TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable guards against the
 // regression tracked in issue #262: on Windows, when a newer release exists,
-// the early-return path must still call recordCheck() so the 24-hour throttle
-// fires and the GitHub API is not hit on every launch. It also guards #1002:
+// the early-return path must still record a successful platform decision so
+// the 24-hour throttle fires and the GitHub API is not hit on every launch.
+// It also guards #1002:
 // the Windows skip must precede any network call, so the fetch seam here is a
 // tripwire that fails the test if invoked.
 func TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable(t *testing.T) {
@@ -117,7 +127,7 @@ func TestAutoUpdateWindowsRecordsCheckWhenUpdateAvailable(t *testing.T) {
 		t.Fatalf("expected %s to be written after Windows early-return, got: %v",
 			lastCheckFile, err)
 	}
-	if shouldCheck() {
+	if shouldCheck(config.UpdateChannelStable) {
 		t.Fatalf("shouldCheck() returned true after recordCheck(); throttle is broken")
 	}
 	// Windows skips the actual update, so the misleading "updating from X to Y"
@@ -162,11 +172,10 @@ func TestAutoUpdateWindowsSkipsNetworkRegardlessOfVersion(t *testing.T) {
 	}
 }
 
-// TestAutoUpdateRecordsCheckOnFetchFailure guards against the regression
-// tracked in issue #459: when fetchLatestReleaseTag fails (blocked API, DNS,
-// proxy, rate limit), the 24-hour throttle must still fire so the next launch
-// does not retry the network immediately.
-func TestAutoUpdateRecordsCheckOnFetchFailure(t *testing.T) {
+// TestAutoUpdateDoesNotRecordCheckOnFetchFailure guards #1466: when
+// fetchLatestReleaseTag fails (blocked API, DNS, proxy, rate limit), the
+// 24-hour success throttle must not hide the failure for a full day.
+func TestAutoUpdateDoesNotRecordCheckOnFetchFailure(t *testing.T) {
 	dir := withTestHome(t)
 
 	prevFetch := fetchLatestReleaseTagFn
@@ -182,19 +191,19 @@ func TestAutoUpdateRecordsCheckOnFetchFailure(t *testing.T) {
 		t.Fatalf("autoUpdate returned nil error; expected fetch failure")
 	}
 
-	if _, err := os.Stat(filepath.Join(dir, lastCheckFile)); err != nil {
-		t.Fatalf("expected %s to be written after fetch failure, got: %v",
+	if _, err := os.Stat(filepath.Join(dir, lastCheckFile)); !os.IsNotExist(err) {
+		t.Fatalf("expected %s not to be written after fetch failure, got: %v",
 			lastCheckFile, err)
 	}
-	if shouldCheck() {
-		t.Fatalf("shouldCheck() returned true after fetch failure; throttle is broken")
+	if !shouldCheck(config.UpdateChannelStable) {
+		t.Fatalf("shouldCheck() returned false after fetch failure; failed checks must not be throttled")
 	}
 }
 
-// TestAutoUpdateRecordsCheckOnDownloadFailure guards against the regression
-// tracked in issue #459: when downloadBinary fails (network error mid-update),
-// the 24-hour throttle must still fire.
-func TestAutoUpdateRecordsCheckOnDownloadFailure(t *testing.T) {
+// TestAutoUpdateDoesNotRecordCheckOnDownloadFailure keeps failed apply
+// attempts retryable: if a newer release exists but the download fails, the
+// next startup should try again instead of being throttled for 24 hours.
+func TestAutoUpdateDoesNotRecordCheckOnDownloadFailure(t *testing.T) {
 	dir := withTestHome(t)
 
 	prevGOOS := runtimeGOOS
@@ -219,12 +228,12 @@ func TestAutoUpdateRecordsCheckOnDownloadFailure(t *testing.T) {
 		t.Fatalf("autoUpdate returned nil error; expected download failure")
 	}
 
-	if _, err := os.Stat(filepath.Join(dir, lastCheckFile)); err != nil {
-		t.Fatalf("expected %s to be written after download failure, got: %v",
+	if _, err := os.Stat(filepath.Join(dir, lastCheckFile)); !os.IsNotExist(err) {
+		t.Fatalf("expected %s not to be written after download failure, got: %v",
 			lastCheckFile, err)
 	}
-	if shouldCheck() {
-		t.Fatalf("shouldCheck() returned true after download failure; throttle is broken")
+	if !shouldCheck(config.UpdateChannelStable) {
+		t.Fatalf("shouldCheck() returned false after download failure; failed applies must not be throttled")
 	}
 }
 
@@ -670,6 +679,186 @@ func TestAutoUpdateChannelFromConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAutoUpdateThrottleIsChannelAware(t *testing.T) {
+	withTestHome(t)
+
+	prevVersion := version
+	t.Cleanup(func() { version = prevVersion })
+	version = "1.0.0"
+
+	recordCheck(config.UpdateChannelStable, "v1.0.0", "1.0.0")
+	if shouldCheck(config.UpdateChannelStable) {
+		t.Fatalf("stable channel should be throttled by its own fresh record")
+	}
+	if !shouldCheck(config.UpdateChannelPreview) {
+		t.Fatalf("preview channel must not be throttled by a stable-channel record")
+	}
+}
+
+func TestAutoUpdatePreviewCheckRunsAfterStableThrottleRecord(t *testing.T) {
+	withTestHome(t)
+
+	prevGOOS := runtimeGOOS
+	prevFetch := fetchLatestReleaseTagFn
+	prevVersion := version
+	t.Cleanup(func() {
+		runtimeGOOS = prevGOOS
+		fetchLatestReleaseTagFn = prevFetch
+		version = prevVersion
+	})
+
+	runtimeGOOS = "linux"
+	version = "1.0.0"
+	recordCheck(config.UpdateChannelStable, "v1.0.0", "1.0.0")
+
+	var gotChannel string
+	fetchLatestReleaseTagFn = func(channel string) (string, error) {
+		gotChannel = channel
+		return "v1.0.0", nil
+	}
+
+	if err := autoUpdateForChannel(config.UpdateChannelPreview); err != nil {
+		t.Fatalf("autoUpdateForChannel: %v", err)
+	}
+	if gotChannel != config.UpdateChannelPreview {
+		t.Fatalf("fetch channel = %q, want preview", gotChannel)
+	}
+}
+
+func TestAutoUpdateChannelSwitchRechecksImmediately(t *testing.T) {
+	withTestHome(t)
+
+	prevVersion := version
+	t.Cleanup(func() { version = prevVersion })
+	version = "1.0.0"
+
+	recordCheck(config.UpdateChannelPreview, "v1.0.1-preview-1", "1.0.0")
+	if shouldCheck(config.UpdateChannelPreview) {
+		t.Fatalf("preview channel should be throttled by its own fresh record")
+	}
+
+	recordCheck(config.UpdateChannelStable, "v1.0.0", "1.0.0")
+	if shouldCheck(config.UpdateChannelStable) {
+		t.Fatalf("stable channel should be throttled after recording a stable check")
+	}
+	if !shouldCheck(config.UpdateChannelPreview) {
+		t.Fatalf("switching back to preview must re-check immediately, not reuse the older preview record")
+	}
+}
+
+func TestAutoUpdateRecordsChannelTagAndInstalledVersionAfterSuccessfulCheck(t *testing.T) {
+	dir := withTestHome(t)
+	captureLogs(t)
+
+	prevGOOS := runtimeGOOS
+	prevFetch := fetchLatestReleaseTagFn
+	prevVersion := version
+	t.Cleanup(func() {
+		runtimeGOOS = prevGOOS
+		fetchLatestReleaseTagFn = prevFetch
+		version = prevVersion
+	})
+
+	runtimeGOOS = "linux"
+	version = "1.0.0"
+	fetchLatestReleaseTagFn = func(string) (string, error) { return "v1.0.0", nil }
+
+	if err := autoUpdateForChannel(config.UpdateChannelPreview); err != nil {
+		t.Fatalf("autoUpdateForChannel: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, lastCheckFile))
+	if err != nil {
+		t.Fatalf("read %s: %v", lastCheckFile, err)
+	}
+	var cache updateCheckCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		t.Fatalf("decode cache: %v\n%s", err, string(data))
+	}
+	if cache.LastChannel != config.UpdateChannelPreview {
+		t.Fatalf("last channel = %q, want preview", cache.LastChannel)
+	}
+	rec, ok := cache.Channels[config.UpdateChannelPreview]
+	if !ok {
+		t.Fatalf("cache missing preview record: %#v", cache.Channels)
+	}
+	if rec.LastSeenTag != "v1.0.0" {
+		t.Fatalf("last seen tag = %q, want v1.0.0", rec.LastSeenTag)
+	}
+	if rec.CurrentVersion != "1.0.0" {
+		t.Fatalf("current version = %q, want 1.0.0", rec.CurrentVersion)
+	}
+}
+
+func TestAutoUpdateConfigAndEnvOptOut(t *testing.T) {
+	cases := []struct {
+		name       string
+		configTOML string
+		env        *string
+		wantFetch  bool
+	}{
+		{
+			name:       "config disables",
+			configTOML: "default_program = 'claude'\nauto_update = false\n",
+			wantFetch:  false,
+		},
+		{
+			name:       "env disables",
+			configTOML: "default_program = 'claude'\nauto_update = true\n",
+			env:        strPtr("0"),
+			wantFetch:  false,
+		},
+		{
+			name:       "env can re-enable",
+			configTOML: "default_program = 'claude'\nauto_update = false\n",
+			env:        strPtr("true"),
+			wantFetch:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := withTestHome(t)
+			captureLogs(t)
+			if err := os.WriteFile(filepath.Join(dir, config.TomlConfigFileName), []byte(tc.configTOML), 0644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			if tc.env != nil {
+				if err := os.Setenv(autoUpdateEnv, *tc.env); err != nil {
+					t.Fatalf("setenv: %v", err)
+				}
+			}
+
+			prevGOOS := runtimeGOOS
+			prevFetch := fetchLatestReleaseTagFn
+			prevVersion := version
+			t.Cleanup(func() {
+				runtimeGOOS = prevGOOS
+				fetchLatestReleaseTagFn = prevFetch
+				version = prevVersion
+			})
+
+			runtimeGOOS = "linux"
+			version = "1.0.0"
+			fetchCalls := 0
+			fetchLatestReleaseTagFn = func(string) (string, error) {
+				fetchCalls++
+				return "v1.0.0", nil
+			}
+
+			if err := autoUpdate(); err != nil {
+				t.Fatalf("autoUpdate: %v", err)
+			}
+			if gotFetch := fetchCalls > 0; gotFetch != tc.wantFetch {
+				t.Fatalf("fetch called = %v, want %v", gotFetch, tc.wantFetch)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
 }
 
 // TestAutoUpdateDownloadsByTag verifies that the update tarball is fetched by

--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -66,6 +66,7 @@ func configEntries(cfg *config.Config) []configEntry {
 		{"default_program", cfg.DefaultProgram},
 		{"program_overrides", cfg.ProgramOverrides},
 		{"auto_yes", cfg.AutoYes},
+		{"auto_update", cfg.AutoUpdate},
 		{"daemon_poll_interval", cfg.DaemonPollInterval},
 		{"log_max_size_mb", cfg.LogMaxSizeMB},
 		{"log_max_backups", cfg.LogMaxBackups},
@@ -128,7 +129,7 @@ var configGetCmd = &cobra.Command{
 	Use:   "get <key>",
 	Short: "Print the value of a single global config key",
 	Long: `Print the effective global value of one config key (e.g. default_program,
-auto_yes, update_channel). Run "af config list" to see every key. Scalar values
+auto_yes, auto_update, update_channel). Run "af config list" to see every key. Scalar values
 print bare; composite values (program_overrides, root_agents, limit_patterns,
 keys) print as JSON.`,
 	Args: cobra.ExactArgs(1),
@@ -190,6 +191,7 @@ Settable keys:
   default_program            agent enum (claude, codex, aider, gemini)
   program_overrides.<agent>  full command string for an agent
   auto_yes                   true | false
+  auto_update                true | false
   daemon_poll_interval       positive integer (ms)
   log_max_size_mb            positive integer
   log_max_backups            non-negative integer
@@ -205,6 +207,7 @@ edit config.toml directly. Changes apply on the next af / daemon start.
 Examples:
   af config set default_program codex
   af config set auto_yes true
+  af config set auto_update false
   af config set program_overrides.claude "/usr/local/bin/claude --verbose"`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/commands/configcmd_test.go
+++ b/commands/configcmd_test.go
@@ -88,7 +88,7 @@ func TestConfigEntriesCoverAllKeys(t *testing.T) {
 		got[e.Key] = true
 	}
 	want := []string{
-		"default_program", "program_overrides", "auto_yes", "daemon_poll_interval",
+		"default_program", "program_overrides", "auto_yes", "auto_update", "daemon_poll_interval",
 		"log_max_size_mb", "log_max_backups", "branch_prefix", "detach_keys",
 		"worktree_root", "update_channel", "root_agents", "limit_patterns", "keys",
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -72,6 +72,10 @@ var (
 			if err != nil {
 				return err
 			}
+			// Start the self-update check as soon as the configured startup
+			// channel and opt-out are known. The work stays in the background;
+			// the TUI continues initializing while the check/download runs.
+			autoUpdateInBackground(&cfg.Config)
 
 			// Apply [keys] rebinds before the TUI starts (#1026): the maps
 			// are read concurrently once bubbletea runs, and the config was
@@ -107,8 +111,6 @@ var (
 			// it is up whenever an enabled task exists. In the background:
 			// daemon launch can take a few seconds and must not delay the TUI.
 			go ensureDaemonForTasks()
-			// Check for updates in the background (non-blocking).
-			autoUpdateInBackground()
 
 			app.Version = version
 			return app.Run(ctx, program, autoYes, repo)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -337,6 +337,7 @@ func TestDefaultConfig(t *testing.T) {
 		require.NotNil(t, cfg)
 		assert.Equal(t, tmux.ProgramClaude, cfg.DefaultProgram)
 		assert.False(t, cfg.AutoYes)
+		assert.True(t, cfg.AutoUpdate)
 		assert.Equal(t, 1000, cfg.DaemonPollInterval)
 		assert.Equal(t, UpdateChannelStable, cfg.UpdateChannel)
 		assert.NotEmpty(t, cfg.BranchPrefix)
@@ -896,6 +897,7 @@ func TestLoadConfig(t *testing.T) {
 		data, err := os.ReadFile(filepath.Join(configDir, TomlConfigFileName))
 		require.NoError(t, err)
 		assert.Contains(t, string(data), `update_channel = 'stable'`)
+		assert.Contains(t, string(data), `auto_update = true`)
 		assert.Contains(t, string(data), `worktree_root = 'sibling'`)
 
 		// The materialized file must reload cleanly through the TOML path.

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -98,6 +98,10 @@ type Config struct {
 	ProgramOverrides map[string]string `json:"program_overrides,omitempty" toml:"program_overrides,omitempty"`
 	// AutoYes is a flag to automatically accept all prompts.
 	AutoYes bool `json:"auto_yes" toml:"auto_yes"`
+	// AutoUpdate controls the startup self-update check. It defaults to true:
+	// af checks the configured release channel on launch and applies newer
+	// releases automatically. Set false to opt out on this machine.
+	AutoUpdate bool `json:"auto_update" toml:"auto_update"`
 	// DaemonPollInterval is the interval (ms) at which the daemon polls sessions for autoyes mode.
 	DaemonPollInterval int `json:"daemon_poll_interval" toml:"daemon_poll_interval"`
 	// LogMaxSizeMB is the size cap (MB) for agent-factory.log. When the log
@@ -267,6 +271,7 @@ func DefaultConfig() *Config {
 		SchemaVersion:      GlobalConfigSchemaVersion,
 		DefaultProgram:     defaultProgram,
 		AutoYes:            false,
+		AutoUpdate:         true,
 		DaemonPollInterval: defaultDaemonPollInterval,
 		LimitAutoResume:    false,
 		LimitRetryInterval: defaultLimitRetryInterval,

--- a/config/configset.go
+++ b/config/configset.go
@@ -66,6 +66,7 @@ var settableKeySpecs = map[string]settableKeySpec{
 		return ValidateProgramEnum("default_program", "default_program", v, "")
 	}},
 	"auto_yes":             {kind: cfgBool},
+	"auto_update":          {kind: cfgBool},
 	"daemon_poll_interval": {kind: cfgInt, validate: func(_, v string) error { return requirePositiveInt("daemon_poll_interval", v) }},
 	"log_max_size_mb":      {kind: cfgInt, validate: func(_, v string) error { return requirePositiveInt("log_max_size_mb", v) }},
 	"log_max_backups":      {kind: cfgInt, validate: func(_, v string) error { return requireNonNegativeInt("log_max_backups", v) }},

--- a/config/conversion_test.go
+++ b/config/conversion_test.go
@@ -32,6 +32,7 @@ func TestConversion_MigratesLegacyJSON(t *testing.T) {
 	configDir := seedJSONHome(t, `{
 		"default_program": "codex",
 		"auto_yes": true,
+		"auto_update": false,
 		"daemon_poll_interval": 2500,
 		"program_overrides": {"claude": "/opt/claude --dsp", "codex": "/opt/codex --quiet"},
 		"log_max_size_mb": 12,
@@ -55,6 +56,7 @@ func TestConversion_MigratesLegacyJSON(t *testing.T) {
 	// Settings are preserved through the conversion.
 	assert.Equal(t, "codex", cfg.DefaultProgram)
 	assert.True(t, cfg.AutoYes)
+	assert.False(t, cfg.AutoUpdate)
 	assert.Equal(t, 2500, cfg.DaemonPollInterval)
 	assert.Equal(t, "/opt/claude --dsp", cfg.ProgramOverrides["claude"])
 	assert.Equal(t, "/opt/codex --quiet", cfg.ProgramOverrides["codex"])

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -90,6 +90,7 @@ var inRepoAllowedKeys = []string{
 // so an in-repo value would either silently do nothing or, worse, let a repo
 // flip host-level behavior like autoyes.
 var inRepoGlobalOnlyKeys = map[string]bool{
+	"auto_update":          true,
 	"auto_yes":             true,
 	"branch_prefix":        true,
 	"daemon_poll_interval": true,

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -66,7 +66,7 @@ func TestLoadInRepoConfigEmptyValueIsSet(t *testing.T) {
 }
 
 func TestLoadInRepoConfigRejectsGlobalOnlyKeys(t *testing.T) {
-	for _, key := range []string{"auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "keys", "log_max_backups", "log_max_size_mb", "root_agents", "update_channel", "worktree_root"} {
+	for _, key := range []string{"auto_update", "auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "keys", "log_max_backups", "log_max_size_mb", "root_agents", "update_channel", "worktree_root"} {
 		t.Run(key, func(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("AGENT_FACTORY_HOME", home)

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -27,7 +27,7 @@ var legacyDeprecationLogged sync.Map
 type ResolvedConfig struct {
 	// Config carries the effective app-level fields. DefaultProgram and
 	// ProgramOverrides may have been overridden/merged from the in-repo
-	// file; the global-only fields (AutoYes, DaemonPollInterval,
+	// file; the global-only fields (AutoYes, AutoUpdate, DaemonPollInterval,
 	// BranchPrefix, DetachKeys) always come from the global config because
 	// LoadInRepoConfig rejects them per-repo.
 	Config

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,7 +93,7 @@ af config get <key>                # one key (scalars print bare; maps as JSON)
 af config set <key> <value>        # write one settable key, preserving comments/ordering
 ```
 
-`get`/`list` report effective global values (defaults applied). `set` edits only the target value's bytes — every comment, blank line, and key ordering is preserved (the file is not regenerated) — and validates the value with the loader's own rules before writing, so it can never produce a config that fails to load. Settable keys: `default_program`, `program_overrides.<agent>`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`. Structural keys (`root_agents`, `[keys]`) stay hand-edited. A change applies on the next `af`/daemon start, exactly like a hand-edit (`set` prints this reminder). Full key reference: [configuration.md](configuration.md).
+`get`/`list` report effective global values (defaults applied). `set` edits only the target value's bytes — every comment, blank line, and key ordering is preserved (the file is not regenerated) — and validates the value with the loader's own rules before writing, so it can never produce a config that fails to load. Settable keys: `default_program`, `program_overrides.<agent>`, `auto_yes`, `auto_update`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`. Structural keys (`root_agents`, `[keys]`) stay hand-edited. A change applies on the next `af`/daemon start, exactly like a hand-edit (`set` prints this reminder). Full key reference: [configuration.md](configuration.md).
 
 ## Maintenance commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
 
 Config is [TOML](https://toml.io) — chosen so it is easy to hand-edit. If you are upgrading from a version that used `config.json`, see [Migrating from JSON](#migrating-from-json) below; the change is automatic.
 
-You can also read and write the global config from the CLI: `af config get <key>` / `af config list` print the effective values, and `af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_yes`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`; structural keys (`root_agents`, `[keys]`) are hand-edited only. See [`af config`](reference/cli.md#af-config) in the CLI reference. Changes apply on the next `af`/daemon start, the same as a hand-edit.
+You can also read and write the global config from the CLI: `af config get <key>` / `af config list` print the effective values, and `af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_yes`, `auto_update`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`; structural keys (`root_agents`, `[keys]`) are hand-edited only. See [`af config`](reference/cli.md#af-config) in the CLI reference. Changes apply on the next `af`/daemon start, the same as a hand-edit.
 
 ## Global config
 
@@ -18,6 +18,7 @@ You can also read and write the global config from the CLI: `af config get <key>
 ```toml
 default_program = "claude"
 auto_yes = false
+auto_update = true
 daemon_poll_interval = 1000
 branch_prefix = "username/"
 worktree_root = "sibling"
@@ -37,6 +38,7 @@ claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 | `default_program` | Default agent enum. Must be one of `claude`, `codex`, `aider`, `gemini`. |
 | `program_overrides` | Optional map from agent enum to the full command string used when launching that agent. Use this to pin a path or pass flags (e.g. `--dangerously-skip-permissions`). Keys must be one of `claude`, `codex`, `aider`, `gemini`. Agent-specific launch flags (claude's `--plugin-dir`, codex's `developer_instructions`) and readiness detection follow the program the override actually runs, not the key: pointing an agent name at a different command (even a non-agent one like `bash`) launches it with no injected agent flags, and a command running no known agent counts as ready once its pane shows output. The agent is identified by command-token basename (`/opt/tools/claude --model opus` and `ionice -c 3 claude` are claude; `/opt/claude-wrapper/run` is not), so if you wrap an agent in a script, name the script after the agent to keep its flags and readiness behavior. |
 | `auto_yes` | Auto-accept agent prompts (experimental). |
+| `auto_update` | Startup self-update check. Defaults to `true`: `af` checks the configured `update_channel` on launch and automatically applies newer releases. Set to `false`, or set `AGENT_FACTORY_AUTO_UPDATE=0`, to opt out. |
 | `daemon_poll_interval` | Daemon polling interval in ms. |
 | `branch_prefix` | Prefix for worktree branches (defaults to `username/`). |
 | `worktree_root` | Where new worktrees are created: `sibling` (default, next to the repo as `<repo>-<session>`) or `subdirectory` (under `~/.agent-factory/worktrees/<branch>`). |
@@ -193,7 +195,7 @@ terminal_cmd = "./infra/terminal.sh"
 |-------|-------|
 | `default_program`, `program_overrides` | Valid globally **and** in-repo (in-repo wins). |
 | `post_worktree_commands`, `remote_hooks` | **In-repo only.** The legacy `~/.agent-factory/repos/<repoID>/config.json` location keeps working for one more release (a deprecation warning in the log points at the new file) and is shadowed whenever the in-repo file sets the same key — including by an explicit empty value like `post_worktree_commands = []`. |
-| `auto_yes`, `daemon_poll_interval`, `branch_prefix`, `worktree_root`, `detach_keys`, `log_max_size_mb`, `log_max_backups`, `update_channel`, `keys`, `root_agents`, `limit_auto_resume`, `limit_retry_interval` | Global only. Setting them in-repo is rejected with an error naming the key. |
+| `auto_yes`, `auto_update`, `daemon_poll_interval`, `branch_prefix`, `worktree_root`, `detach_keys`, `log_max_size_mb`, `log_max_backups`, `update_channel`, `keys`, `root_agents`, `limit_auto_resume`, `limit_retry_interval` | Global only. Setting them in-repo is rejected with an error naming the key. |
 
 `post_worktree_commands` are shell commands run after each new worktree is created (e.g. `npm install`, `make build`) — they can also be edited from the TUI via the `e` (worktree hooks) key. `remote_hooks` configures a remote-machine backend; see [remote-hooks.md](remote-hooks.md) for the script protocol.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,8 +24,9 @@ Run `af doctor --setup` after install to verify tmux, git, your configured
 agent command, git identity, config/state/log storage, and daemon health.
 
 To update later, re-run the script or run `af upgrade`. Installed binaries also
-auto-update along the **stable** channel; set `"update_channel": "preview"` in
-your global config to track preview builds instead (see the
+auto-update on launch along the **stable** channel by default; set
+`update_channel = "preview"` in your global config to track preview builds
+instead, or set `auto_update = false` to opt out (see the
 [release process](release-process.md)).
 
 Building from source instead? Clone the repo and run `./dev-install.sh` (this

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -314,7 +314,7 @@ af config
 Print the value of a single global config key
 
 Print the effective global value of one config key (e.g. default_program,
-auto_yes, update_channel). Run "af config list" to see every key. Scalar values
+auto_yes, auto_update, update_channel). Run "af config list" to see every key. Scalar values
 print bare; composite values (program_overrides, root_agents, limit_patterns,
 keys) print as JSON.
 
@@ -356,6 +356,7 @@ Settable keys:
   default_program            agent enum (claude, codex, aider, gemini)
   program_overrides.<agent>  full command string for an agent
   auto_yes                   true | false
+  auto_update                true | false
   daemon_poll_interval       positive integer (ms)
   log_max_size_mb            positive integer
   log_max_backups            non-negative integer
@@ -371,6 +372,7 @@ edit config.toml directly. Changes apply on the next af / daemon start.
 Examples:
   af config set default_program codex
   af config set auto_yes true
+  af config set auto_update false
   af config set program_overrides.claude "/usr/local/bin/claude --verbose"
 
 ```


### PR DESCRIPTION
## Summary
- Keep the startup auto-update hook non-blocking, but start it as soon as resolved config is available and pass the configured channel directly.
- Add default-on `auto_update` config plus `AGENT_FACTORY_AUTO_UPDATE` env override for opt-out/override.
- Replace the single timestamp throttle with a channel-aware JSON cache recording `last_seen_tag`, `current_version`, and `last_channel`; channel switches re-check immediately and stable checks never suppress preview checks.
- Record the 24-hour throttle only after a successful no-update check or successful auto-apply, and serialize check/apply under the existing config file lock for rapid relaunch safety.
- Preserve the existing auto-apply path and #1386 daemon respawn via `restartDaemonFromPath` / `respawnDaemonAfterUpgrade`.

## Current Behavior / Gap
Existing startup did call `autoUpdateInBackground()` and it already auto-applied, but it ran later in TUI startup and used a single global `last_update_check` timestamp. That meant a stable/default check, failed check, or pre-preview check could suppress preview release discovery for 24 hours. There was also no user opt-out.

## Verification
- `go test ./commands ./config`
- `git diff --check`
- `gofmt -l ...`
- `go build ./...`
- `scripts/lint-file-length.sh`
- `golangci-lint run --fast ./...`
- `deadcode -test ./...`
- `make docs`
- `make test-container`

No real self-update, dev install, sub-session, or TUI driver was run.

Closes #1466
Closes #1396