### PR TITLE
Improve af doctor diagnostics

### DIFF
--- a/commands/doctorcmd.go
+++ b/commands/doctorcmd.go
@@ -10,6 +10,7 @@ import (
 
 var doctorFixFlag bool
 var doctorSetupFlag bool
+var doctorVerboseFlag bool
 
 // doctorCmd is `af doctor` (#1044, #1104): detect orphaned session
 // processes, runaway CPU children, leaked af_ tmux sessions, stale temp
@@ -43,6 +44,10 @@ accumulate silently on a machine running agent-factory:
     presence/executability, and a bounded list_cmd connectivity probe
     (skipped cleanly when no remote backend is configured)
 
+High-volume process findings are summarized by default so the actionable
+problem is visible first. Use --verbose to show each process behind those
+summaries.
+
 Read-only by default. With --fix, applies the safe remediations — killing
 orphans whose ancestry markers prove they came from a dead af session, and
 removing stale temp homes — logging each action. Ambiguous cases are always
@@ -53,11 +58,11 @@ Exits 1 when unresolved issues remain, 0 when healthy.`,
 		log.Initialize(false)
 		defer log.Close()
 
-		report, err := doctor.Run(doctor.Options{Fix: doctorFixFlag, Setup: doctorSetupFlag})
+		report, err := doctor.Run(doctor.Options{Fix: doctorFixFlag, Setup: doctorSetupFlag, Version: version})
 		if err != nil {
 			return err
 		}
-		doctor.Render(os.Stdout, report, doctorFixFlag)
+		doctor.Render(os.Stdout, report, doctorFixFlag, doctorVerboseFlag)
 		if report.UnresolvedCount() > 0 {
 			// Distinguish "problems found" from cobra usage errors without
 			// printing a redundant error line.
@@ -74,5 +79,7 @@ func init() {
 		"run the first-run setup profile (prerequisites, config, agent commands)")
 	doctorCmd.Flags().BoolVar(&doctorFixFlag, "fix", false,
 		"apply safe remediations (kill verified orphans, remove stale temp homes)")
+	doctorCmd.Flags().BoolVar(&doctorVerboseFlag, "verbose", false,
+		"show per-process doctor findings instead of collapsed summaries")
 	rootCmd.AddCommand(doctorCmd)
 }

--- a/config/config_load.go
+++ b/config/config_load.go
@@ -109,6 +109,58 @@ func LoadConfig() (*Config, error) {
 	return convertJSONToTOML(configDir, configPath, tomlPath, prettyConfigPath, prettyTomlPath)
 }
 
+// ReadOnlyConfigLoad is a no-write config snapshot for diagnostics.
+type ReadOnlyConfigLoad struct {
+	Config       *Config
+	Path         string
+	Missing      bool
+	LegacyJSON   bool
+	ShadowedJSON bool
+}
+
+// LoadConfigReadOnly reads and validates the active global config without
+// materializing defaults, converting config.json, removing empty stubs, or
+// writing any file. It is intended for diagnostics such as `af doctor`.
+func LoadConfigReadOnly() (ReadOnlyConfigLoad, error) {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return ReadOnlyConfigLoad{}, fmt.Errorf("failed to get config directory: %w", err)
+	}
+
+	configPath := filepath.Join(configDir, ConfigFileName)
+	prettyConfigPath := prettyHomePath(configPath)
+	tomlPath := filepath.Join(configDir, TomlConfigFileName)
+	prettyTomlPath := prettyHomePath(tomlPath)
+
+	tomlData, tomlErr := os.ReadFile(tomlPath)
+	if tomlErr == nil {
+		cfg, err := parseConfigTOML(tomlData, prettyTomlPath)
+		return ReadOnlyConfigLoad{
+			Config:       cfg,
+			Path:         tomlPath,
+			ShadowedJSON: fileExists(configPath),
+		}, err
+	}
+	if !os.IsNotExist(tomlErr) {
+		return ReadOnlyConfigLoad{Path: tomlPath}, fmt.Errorf("failed to read config file %s: %w", prettyTomlPath, tomlErr)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err == nil {
+		cfg, parseErr := parseConfig(data, prettyConfigPath)
+		return ReadOnlyConfigLoad{
+			Config:     cfg,
+			Path:       configPath,
+			LegacyJSON: true,
+		}, parseErr
+	}
+	if !os.IsNotExist(err) {
+		return ReadOnlyConfigLoad{Path: configPath}, fmt.Errorf("failed to read config file %s: %w", prettyConfigPath, err)
+	}
+
+	return ReadOnlyConfigLoad{Path: tomlPath, Missing: true}, nil
+}
+
 // fileExists reports whether path exists (any stat error other than
 // not-exist — e.g. permission denied — counts as "exists" so a shadowed
 // config.json is still flagged rather than silently assumed gone).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -497,6 +497,10 @@ accumulate silently on a machine running agent-factory:
     presence/executability, and a bounded list_cmd connectivity probe
     (skipped cleanly when no remote backend is configured)
 
+High-volume process findings are summarized by default so the actionable
+problem is visible first. Use --verbose to show each process behind those
+summaries.
+
 Read-only by default. With --fix, applies the safe remediations — killing
 orphans whose ancestry markers prove they came from a dead af session, and
 removing stale temp homes — logging each action. Ambiguous cases are always
@@ -514,6 +518,7 @@ af doctor [flags]
 |------|------|-------------|
 | `--fix` |  | apply safe remediations (kill verified orphans, remove stale temp homes) |
 | `--setup` |  | run the first-run setup profile (prerequisites, config, agent commands) |
+| `--verbose` |  | show per-process doctor findings instead of collapsed summaries |
 
 ## af keys
 

--- a/doctor/checks.go
+++ b/doctor/checks.go
@@ -100,41 +100,32 @@ func killFix(ctx *scanContext, p proctree.Process) func() error {
 func checkDaemonHealth(ctx *scanContext, report *Report) {
 	h := daemon.Health()
 	if h.SocketErr != nil {
-		report.Findings = append(report.Findings, Finding{
-			Check:  "daemon-health",
-			Detail: fmt.Sprintf("cannot resolve daemon socket path: %v", h.SocketErr),
-		})
+		report.Fail(sectionDaemon, "daemon", fmt.Sprintf("cannot resolve daemon socket path: %v", h.SocketErr),
+			"fix AGENT_FACTORY_HOME and rerun `af doctor`")
 		return
-	}
-	unit := "ad-hoc (no autostart unit; `af daemon install` sets one up)"
-	if h.AutostartUnit {
-		unit = "autostart unit installed"
 	}
 	switch {
 	case h.PingErr == nil:
-		report.OK = append(report.OK, fmt.Sprintf("daemon: responding on %s; %s", h.SocketPath, unit))
+		report.Pass(sectionDaemon, "daemon", "responding on "+h.SocketPath)
 	case !h.SocketExists:
-		report.OK = append(report.OK, "daemon: not running (starts on demand); "+unit)
+		report.Pass(sectionDaemon, "daemon", "not running; starts on demand")
 	default:
-		report.Findings = append(report.Findings, Finding{
-			Check: "daemon-health",
-			Detail: fmt.Sprintf("socket %s exists but the daemon is not responding (%v) — "+
-				"likely a stale socket from a crashed daemon", h.SocketPath, h.PingErr),
-		})
+		report.Fail(sectionDaemon, "daemon", fmt.Sprintf("socket %s exists but the daemon is not responding (%v)", h.SocketPath, h.PingErr),
+			"run `af daemon restart`; if it still fails, remove the stale socket after verifying no daemon is running")
+	}
+	if h.AutostartUnit {
+		report.Pass(sectionDaemon, "autostart", "installed")
+	} else {
+		report.Warn(sectionDaemon, "autostart", "not installed",
+			"run `af daemon install` to keep scheduled tasks running across reboots", false)
 	}
 	if h.PIDFilePID > 0 && !h.PIDVerified && h.PingErr != nil {
-		report.Findings = append(report.Findings, Finding{
-			Check: "daemon-health",
-			Detail: fmt.Sprintf("daemon.pid records pid %d but no agent-factory daemon is running under it "+
-				"(stale pid file)", h.PIDFilePID),
-		})
+		report.Warn(sectionDaemon, "daemon.pid", fmt.Sprintf("records pid %d but no agent-factory daemon is running under it", h.PIDFilePID),
+			"remove the stale daemon.pid after verifying the pid is not an af daemon", true)
 	}
 	if h.BinaryDeleted {
-		report.Findings = append(report.Findings, Finding{
-			Check: "daemon-health",
-			Detail: fmt.Sprintf("daemon pid %d is running a binary that was since replaced on disk — "+
-				"it will keep running the old version until restarted", h.PIDFilePID),
-		})
+		report.Warn(sectionDaemon, "daemon binary", fmt.Sprintf("pid %d is running a binary that was replaced on disk", h.PIDFilePID),
+			"run `af daemon restart` to pick up the current binary", true)
 	}
 }
 
@@ -412,7 +403,7 @@ func checkStaleTempHomes(ctx *scanContext, report *Report) {
 			continue
 		}
 		if reason := tempHomeInUseReason(dir, homesInUse, tmuxHomesInUse); reason != "" {
-			report.OK = append(report.OK, fmt.Sprintf("temp home %s is in use (%s)", dir, reason))
+			report.Pass(sectionProcesses, "temp home", fmt.Sprintf("%s is in use (%s)", dir, reason))
 			continue
 		}
 		age := timeSince(newestMtime(dir))

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -23,7 +23,6 @@ package doctor
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"time"
 
@@ -46,10 +45,46 @@ type Finding struct {
 	// Fixed / FixErr record the outcome when a fix was attempted.
 	Fixed  bool
 	FixErr error
+	// Section, Severity, and Remediation drive the grouped doctor renderer.
+	// Empty values are filled from the Check slug so existing detectors stay
+	// compact while new checks can be explicit.
+	Section     string
+	Severity    CheckStatus
+	Remediation string
+}
+
+// CheckStatus is the user-facing status for one doctor row.
+type CheckStatus string
+
+const (
+	StatusPass  CheckStatus = "PASS"
+	StatusWarn  CheckStatus = "WARN"
+	StatusFail  CheckStatus = "FAIL"
+	StatusFixed CheckStatus = "FIXED"
+)
+
+// HeaderItem is one key-value fact printed before grouped checks.
+type HeaderItem struct {
+	Label string
+	Value string
+}
+
+// CheckResult is one grouped doctor row that is not backed by a Finding.
+type CheckResult struct {
+	Section     string
+	Name        string
+	Status      CheckStatus
+	Detail      string
+	Remediation string
+	Problem     bool
 }
 
 // Report is the result of a doctor run.
 type Report struct {
+	// Header holds the key environment facts printed before the sections.
+	Header []HeaderItem
+	// Checks holds sectioned PASS/WARN/FAIL rows that are not Finding-backed.
+	Checks []CheckResult
 	// OK holds informational healthy lines, grouped by section.
 	OK []string
 	// Findings holds detected problems in detection order.
@@ -60,6 +95,11 @@ type Report struct {
 // report-only, fix not requested, or fix failed).
 func (r *Report) UnresolvedCount() int {
 	n := 0
+	for _, c := range r.Checks {
+		if c.Problem && c.Status != StatusPass && c.Status != StatusFixed {
+			n++
+		}
+	}
 	for _, f := range r.Findings {
 		if !f.Fixed {
 			n++
@@ -71,6 +111,8 @@ func (r *Report) UnresolvedCount() int {
 // Options configures a doctor run. Zero values resolve to production
 // defaults; tests override ConfigDir/TempDir/Exec to stay hermetic.
 type Options struct {
+	// Version is the af version stamped into the root command.
+	Version string
 	// Fix applies the safe remediations instead of only reporting.
 	Fix bool
 	// Setup runs the onboarding profile only: local prerequisites, writable
@@ -154,6 +196,9 @@ func Run(opts Options) (*Report, error) {
 		return report, nil
 	}
 
+	cfg := checkConfigAndStorage(ctx, report)
+	checkEnvironment(ctx, report, cfg)
+
 	if opts.snapshot == nil {
 		opts.snapshot = proctree.Snapshot
 	}
@@ -209,52 +254,6 @@ func selfAndAncestors(snap map[int]proctree.Process) map[int]bool {
 		pid = p.PPID
 	}
 	return out
-}
-
-// Render writes the human-readable report. fixMode changes the trailing
-// hints (no "--fix would..." when fixes were just applied).
-func Render(w io.Writer, r *Report, fixMode bool) {
-	if len(r.OK) > 0 {
-		for _, line := range r.OK {
-			fmt.Fprintf(w, "ok: %s\n", line)
-		}
-	}
-	if len(r.Findings) == 0 {
-		fmt.Fprintf(w, "\nNo problems found.\n")
-		return
-	}
-	fmt.Fprintln(w)
-	for _, f := range r.Findings {
-		switch {
-		case f.Fixed:
-			fmt.Fprintf(w, "fixed: [%s] %s (%s)\n", f.Check, f.Detail, f.FixAction)
-		case f.FixErr != nil:
-			fmt.Fprintf(w, "fix-failed: [%s] %s (%s: %v)\n", f.Check, f.Detail, f.FixAction, f.FixErr)
-		case f.FixAction != "" && !fixMode:
-			fmt.Fprintf(w, "issue: [%s] %s (--fix will %s)\n", f.Check, f.Detail, f.FixAction)
-		default:
-			fmt.Fprintf(w, "issue: [%s] %s\n", f.Check, f.Detail)
-		}
-	}
-	unresolved := r.UnresolvedCount()
-	fixed := len(r.Findings) - unresolved
-	switch {
-	case fixMode && fixed > 0:
-		fmt.Fprintf(w, "\n%d issue(s) found, %d fixed, %d remaining.\n", len(r.Findings), fixed, unresolved)
-	case !fixMode && hasFixable(r):
-		fmt.Fprintf(w, "\n%d issue(s) found. Re-run with --fix to apply the safe remediations.\n", len(r.Findings))
-	default:
-		fmt.Fprintf(w, "\n%d issue(s) found.\n", len(r.Findings))
-	}
-}
-
-func hasFixable(r *Report) bool {
-	for _, f := range r.Findings {
-		if f.FixAction != "" {
-			return true
-		}
-	}
-	return false
 }
 
 // sortedKeys returns m's keys in stable order so report output is

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -157,6 +157,16 @@ func findByCheck(r *Report, check string) []Finding {
 	return out
 }
 
+func findCheckRows(r *Report, name string) []CheckResult {
+	var out []CheckResult
+	for _, c := range r.Checks {
+		if c.Name == name {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 // TestOrphanedProcessDetectedAndFixed is the doctor half of the #1104
 // regression: a process whose AF_SESSION marker names a dead session is a
 // verified orphan — reported without --fix, killed with it.
@@ -403,8 +413,9 @@ func TestCleanRunHasNoFindings(t *testing.T) {
 	require.Zero(t, report.UnresolvedCount())
 
 	var buf bytes.Buffer
-	Render(&buf, report, false)
-	require.Contains(t, buf.String(), "No problems found")
+	Render(&buf, report, false, false)
+	require.Contains(t, buf.String(), "Summary:")
+	require.Contains(t, buf.String(), "no issues require action")
 }
 
 // TestRenderShapes covers the three finding render states.
@@ -418,13 +429,20 @@ func TestRenderShapes(t *testing.T) {
 		},
 	}
 	var buf bytes.Buffer
-	Render(&buf, r, false)
+	Render(&buf, r, false, false)
 	out := buf.String()
-	require.Contains(t, out, "ok: daemon: not running")
-	require.Contains(t, out, "--fix will kill pid 1234")
-	require.Contains(t, out, "issue: [leaked-tmux-session]")
-	require.Contains(t, out, "fixed: [stale-temp-home]")
-	require.Contains(t, out, "Re-run with --fix")
+	require.Contains(t, out, "Agent Factory Doctor")
+	require.Contains(t, out, "orphaned-processes")
+	require.Contains(t, out, "1 safe to clean")
+	require.Contains(t, out, "leaked-tmux-session")
+	require.Contains(t, out, "FIXED stale-temp-home")
+	require.Contains(t, out, "1 fixable with `af doctor --fix`")
+
+	buf.Reset()
+	Render(&buf, r, false, true)
+	out = buf.String()
+	require.Contains(t, out, "orphaned-process")
+	require.Contains(t, out, "run `af doctor --fix` to kill pid 1234")
 }
 
 // TestTmuxServerDeadParsing pins the conservative TMUX-env heuristics.
@@ -505,7 +523,7 @@ func TestRemoteChecksSkippedWhenNoRemote(t *testing.T) {
 	require.Empty(t, findByCheck(report, "remote-config"))
 	require.Empty(t, findByCheck(report, "remote-hook-script"))
 	require.Empty(t, findByCheck(report, "remote-connectivity"))
-	require.True(t, okContains(report, "no remote backend configured"),
+	require.True(t, okContains(report, "remote hooks: not configured"),
 		"a clean n/a line must be shown for local-only users")
 }
 
@@ -520,11 +538,12 @@ func TestRemoteConfigMissingRequiredField(t *testing.T) {
 
 	report, err := Run(withRemote(testOptions(t, false), hooks))
 	require.NoError(t, err)
-	findings := findByCheck(report, "remote-config")
-	require.Len(t, findings, 1)
-	require.Contains(t, findings[0].Detail, "launch_cmd is required")
-	require.Contains(t, findings[0].Detail, "remote_hooks")
-	require.Empty(t, findings[0].FixAction, "config findings are report-only")
+	checks := findCheckRows(report, "remote config")
+	require.Len(t, checks, 1)
+	require.Equal(t, StatusWarn, checks[0].Status)
+	require.Contains(t, checks[0].Detail, "launch_cmd is required")
+	require.Contains(t, checks[0].Detail, "remote_hooks")
+	require.Zero(t, report.UnresolvedCount(), "remote warnings must not fail doctor")
 }
 
 // TestRemoteHookScriptNotExecutable: a hook path that exists but lacks the
@@ -539,10 +558,12 @@ func TestRemoteHookScriptNotExecutable(t *testing.T) {
 
 	report, err := Run(withRemote(testOptions(t, false), hooks))
 	require.NoError(t, err)
-	findings := findByCheck(report, "remote-hook-script")
-	require.Len(t, findings, 1)
-	require.Contains(t, findings[0].Detail, "not executable")
-	require.Contains(t, findings[0].Detail, "chmod +x")
+	checks := findCheckRows(report, "remote hook")
+	require.Len(t, checks, 1)
+	require.Equal(t, StatusWarn, checks[0].Status)
+	require.Contains(t, checks[0].Detail, "not executable")
+	require.Contains(t, checks[0].Detail, "chmod +x")
+	require.Zero(t, report.UnresolvedCount(), "remote warnings must not fail doctor")
 }
 
 // TestRemoteHookScriptMissing: a hook path that does not exist is flagged.
@@ -555,10 +576,12 @@ func TestRemoteHookScriptMissing(t *testing.T) {
 
 	report, err := Run(withRemote(testOptions(t, false), hooks))
 	require.NoError(t, err)
-	findings := findByCheck(report, "remote-hook-script")
-	require.Len(t, findings, 1)
-	require.Contains(t, findings[0].Detail, "does not exist")
-	require.Contains(t, findings[0].Detail, "launch_cmd")
+	checks := findCheckRows(report, "remote hook")
+	require.Len(t, checks, 1)
+	require.Equal(t, StatusWarn, checks[0].Status)
+	require.Contains(t, checks[0].Detail, "does not exist")
+	require.Contains(t, checks[0].Detail, "launch_cmd")
+	require.Zero(t, report.UnresolvedCount(), "remote warnings must not fail doctor")
 }
 
 // TestRemoteConnectivityProbeSucceeds: a healthy list_cmd (exit 0, JSON array)
@@ -575,7 +598,7 @@ func TestRemoteConnectivityProbeSucceeds(t *testing.T) {
 	require.Empty(t, findByCheck(report, "remote-connectivity"))
 	require.Empty(t, findByCheck(report, "remote-config"))
 	require.Empty(t, findByCheck(report, "remote-hook-script"))
-	require.True(t, okContains(report, "connectivity probe succeeded"))
+	require.True(t, okContains(report, "remote connectivity: list_cmd responded"))
 }
 
 // TestRemoteConnectivityProbeFails: a list_cmd that exits non-zero surfaces an
@@ -589,9 +612,31 @@ func TestRemoteConnectivityProbeFails(t *testing.T) {
 
 	report, err := Run(withRemote(testOptions(t, false), hooks))
 	require.NoError(t, err)
-	findings := findByCheck(report, "remote-connectivity")
-	require.Len(t, findings, 1)
-	require.Contains(t, findings[0].Detail, "Connection refused")
+	checks := findCheckRows(report, "remote connectivity")
+	require.Len(t, checks, 1)
+	require.Equal(t, StatusWarn, checks[0].Status)
+	require.Contains(t, checks[0].Detail, "Connection refused")
+	require.Zero(t, report.UnresolvedCount(), "remote warnings must not fail doctor")
+}
+
+func TestRemoteCoderWhoamiWarnsWithoutFailingDoctor(t *testing.T) {
+	testguard.IsolateTmux(t)
+	dir := t.TempDir()
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "coder", "#!/bin/sh\nif [ \"$1\" = \"whoami\" ]; then echo 'not logged in' >&2; exit 1; fi\nexit 0\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	hook := writeHookScript(t, dir, "coder-hook.sh", "#!/bin/sh\necho '[]'\n")
+	hooks := &config.RemoteHooks{LaunchCmd: hook, ListCmd: hook, AttachCmd: hook, DeleteCmd: hook}
+
+	report, err := Run(withRemote(testOptions(t, false), hooks))
+	require.NoError(t, err)
+	checks := findCheckRows(report, "coder")
+	require.Len(t, checks, 1)
+	require.Equal(t, StatusWarn, checks[0].Status)
+	require.Contains(t, checks[0].Detail, "not logged in")
+	require.Equal(t, "run `coder login`", checks[0].Remediation)
+	require.Zero(t, report.UnresolvedCount(), "coder auth warnings must not fail doctor")
 }
 
 // TestRemoteConnectivityProbeSucceedsDespiteBenignError: a list_cmd that
@@ -615,7 +660,7 @@ func TestRemoteConnectivityProbeSucceedsDespiteBenignError(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, findByCheck(report, "remote-connectivity"),
 		"a benign ErrWaitDelay on a successful exit-0 list_cmd must not be a failure")
-	require.True(t, okContains(report, "connectivity probe succeeded"))
+	require.True(t, okContains(report, "remote connectivity: list_cmd responded"))
 }
 
 // TestRemoteConnectivityProbeTimesOut: a hanging list_cmd is bounded by the
@@ -631,9 +676,11 @@ func TestRemoteConnectivityProbeTimesOut(t *testing.T) {
 	opts.remoteProbeTimeout = 200 * time.Millisecond
 	report, err := Run(opts)
 	require.NoError(t, err)
-	findings := findByCheck(report, "remote-connectivity")
-	require.Len(t, findings, 1)
-	require.Contains(t, findings[0].Detail, "did not respond")
+	checks := findCheckRows(report, "remote connectivity")
+	require.Len(t, checks, 1)
+	require.Equal(t, StatusWarn, checks[0].Status)
+	require.Contains(t, checks[0].Detail, "did not respond")
+	require.Zero(t, report.UnresolvedCount(), "remote warnings must not fail doctor")
 }
 
 // TestRemoteProbeSkippedWithoutListCmd: with no list_cmd, the probe and
@@ -649,5 +696,9 @@ func TestRemoteProbeSkippedWithoutListCmd(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, findByCheck(report, "remote-connectivity"))
 	require.Empty(t, findByCheck(report, "remote-config"))
-	require.True(t, okContains(report, "connectivity probe skipped"))
+	checks := findCheckRows(report, "remote connectivity")
+	require.Len(t, checks, 1)
+	require.Equal(t, StatusWarn, checks[0].Status)
+	require.Contains(t, checks[0].Detail, "probe skipped")
+	require.Zero(t, report.UnresolvedCount(), "remote warnings must not fail doctor")
 }

--- a/doctor/environment.go
+++ b/doctor/environment.go
@@ -1,0 +1,211 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/preflight"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+func checkConfigAndStorage(ctx *scanContext, report *Report) *config.Config {
+	load, cfgErr := config.LoadConfigReadOnly()
+	cfg := load.Config
+	channel := "unknown"
+	if cfg != nil && cfg.UpdateChannel != "" {
+		channel = cfg.UpdateChannel
+	} else if load.Missing {
+		channel = config.UpdateChannelStable
+	}
+
+	version := ctx.opts.Version
+	if version == "" {
+		version = "dev"
+	}
+	report.AddHeader("af", fmt.Sprintf("%s (channel: %s)", version, channel))
+	report.AddHeader("os", runtime.GOOS+"/"+runtime.GOARCH)
+	report.AddHeader("home", ctx.opts.ConfigDir)
+	report.Pass(sectionEnvironment, "af", fmt.Sprintf("%s (channel: %s)", version, channel))
+	report.Pass(sectionEnvironment, "os", runtime.GOOS+"/"+runtime.GOARCH)
+
+	reportConfigValidity(report, load, cfgErr)
+	checkHomeHealth(ctx, report)
+	repoRoot, repoErr := currentRepoRoot()
+	mode := worktreeMode(cfg, load.Missing)
+	report.AddHeader("repo", repoHeader(repoRoot, repoErr, mode))
+	checkWorktreeMode(ctx, report, repoRoot, repoErr, mode)
+	return cfg
+}
+
+func checkEnvironment(_ *scanContext, report *Report, cfg *config.Config) {
+	checkTmuxEnvironment(report)
+	checkAgentBinaries(cfg, report)
+}
+
+func reportConfigValidity(report *Report, load config.ReadOnlyConfigLoad, err error) {
+	switch {
+	case err != nil:
+		path := load.Path
+		if path == "" {
+			path = "global config"
+		}
+		report.Fail(sectionConfig, "config", fmt.Sprintf("%s is not valid: %v", path, err),
+			"edit the config file, or delete it to regenerate defaults")
+	case load.Missing:
+		report.Warn(sectionConfig, "config", fmt.Sprintf("no config file at %s; defaults will be created on first write", load.Path),
+			"run `af` once to materialize defaults or create config.toml", false)
+	case load.LegacyJSON:
+		report.Warn(sectionConfig, "config", fmt.Sprintf("loaded legacy config.json at %s", load.Path),
+			"run `af` once to convert it to config.toml", false)
+	case load.ShadowedJSON:
+		report.Warn(sectionConfig, "config", fmt.Sprintf("loaded %s; config.json is also present and ignored", load.Path),
+			"delete or rename the shadowed config.json", false)
+	default:
+		report.Pass(sectionConfig, "config",
+			fmt.Sprintf("loaded %s (default_program: %s)", load.Path, load.Config.DefaultProgram))
+	}
+}
+
+func checkHomeHealth(ctx *scanContext, report *Report) {
+	home := ctx.opts.ConfigDir
+	info, err := os.Stat(home)
+	switch {
+	case err == nil && info.IsDir():
+		report.Pass(sectionConfig, "home", "readable directory at "+home)
+	case err == nil:
+		report.Fail(sectionConfig, "home", home+" exists but is not a directory",
+			"move the file aside and create an agent-factory home directory")
+	case os.IsNotExist(err):
+		report.Warn(sectionConfig, "home", home+" does not exist yet",
+			"run `af` once to create it, or create the directory manually", false)
+	default:
+		report.Fail(sectionConfig, "home", fmt.Sprintf("cannot stat %s: %v", home, err),
+			"fix permissions or set AGENT_FACTORY_HOME to a readable directory")
+	}
+
+	for _, subdir := range []string{"instances", "repos"} {
+		checkStorageDir(report, filepath.Join(home, subdir), subdir)
+	}
+}
+
+func checkStorageDir(report *Report, path, name string) {
+	info, err := os.Stat(path)
+	switch {
+	case err == nil && info.IsDir():
+		report.Pass(sectionConfig, name, "present at "+path)
+	case err == nil:
+		report.Fail(sectionConfig, name, path+" exists but is not a directory",
+			"move the file aside so af can use this storage directory")
+	case os.IsNotExist(err):
+		report.Pass(sectionConfig, name, "not present; created on demand at "+path)
+	default:
+		report.Fail(sectionConfig, name, fmt.Sprintf("cannot stat %s: %v", path, err),
+			"fix permissions on the agent-factory home")
+	}
+}
+
+func currentRepoRoot() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	repo, err := config.RepoFromPath(cwd)
+	if err != nil {
+		return "", err
+	}
+	return repo.Root, nil
+}
+
+func worktreeMode(cfg *config.Config, missingConfig bool) string {
+	if cfg != nil && cfg.WorktreeRoot != "" {
+		return cfg.WorktreeRoot
+	}
+	if missingConfig {
+		return config.WorktreeRootSibling
+	}
+	return "unknown"
+}
+
+func repoHeader(repoRoot string, repoErr error, mode string) string {
+	if repoErr != nil {
+		return "n/a (not inside a git repository)"
+	}
+	return fmt.Sprintf("%s (worktree_root: %s)", repoRoot, mode)
+}
+
+func checkWorktreeMode(ctx *scanContext, report *Report, repoRoot string, repoErr error, mode string) {
+	if repoErr != nil {
+		report.Warn(sectionConfig, "worktrees", "repo-scoped worktree checks skipped: "+repoErr.Error(),
+			"run `af doctor` from inside a git repository", false)
+		return
+	}
+
+	parent := ""
+	switch mode {
+	case config.WorktreeRootSubdirectory:
+		parent = filepath.Join(ctx.opts.ConfigDir, "worktrees")
+	case config.WorktreeRootSibling:
+		parent = filepath.Dir(repoRoot)
+	default:
+		report.Warn(sectionConfig, "worktrees", "worktree_root is unknown because config did not load",
+			"fix config first, then rerun `af doctor`", true)
+		return
+	}
+
+	info, err := os.Stat(parent)
+	switch {
+	case err == nil && info.IsDir():
+		report.Pass(sectionConfig, "worktrees", fmt.Sprintf("%s mode; parent %s is present", mode, parent))
+	case err == nil:
+		report.Fail(sectionConfig, "worktrees", fmt.Sprintf("%s mode parent %s exists but is not a directory", mode, parent),
+			"move the file aside or change worktree_root")
+	case os.IsNotExist(err):
+		report.Warn(sectionConfig, "worktrees", fmt.Sprintf("%s mode parent %s does not exist yet", mode, parent),
+			"create the directory or let af create it on the next session", false)
+	default:
+		report.Fail(sectionConfig, "worktrees", fmt.Sprintf("cannot stat %s mode parent %s: %v", mode, parent, err),
+			"fix permissions or change worktree_root")
+	}
+}
+
+func checkTmuxEnvironment(report *Report) {
+	version, err := preflight.CheckTmux()
+	if err != nil {
+		report.AddHeader("tmux", "unavailable")
+		report.Fail(sectionEnvironment, "tmux", "not available or not runnable", err.Error())
+		return
+	}
+	report.AddHeader("tmux", version)
+	report.Pass(sectionEnvironment, "tmux", version)
+}
+
+func checkAgentBinaries(cfg *config.Config, report *Report) {
+	header := make([]string, 0, len(tmux.SupportedPrograms))
+	for _, agent := range tmux.SupportedPrograms {
+		command := agent
+		configured := false
+		if cfg != nil {
+			command = config.ResolveProgram(cfg, agent)
+			configured = cfg.DefaultProgram == agent || strings.TrimSpace(cfg.ProgramOverrides[agent]) != ""
+		}
+		check, err := preflight.CheckCommand(command)
+		if err == nil {
+			header = append(header, agent+"=present")
+			report.Pass(sectionEnvironment, agent, fmt.Sprintf("%q resolves to %s", command, check.Path))
+			continue
+		}
+		header = append(header, agent+"=missing")
+		detail := fmt.Sprintf("%q is not runnable: %v", command, err)
+		remediation := fmt.Sprintf("install %s or set program_overrides.%s", agent, agent)
+		if configured {
+			report.Fail(sectionEnvironment, agent, detail, remediation)
+		} else {
+			report.Warn(sectionEnvironment, agent, detail, remediation, false)
+		}
+	}
+	report.AddHeader("agents", strings.Join(header, ", "))
+}

--- a/doctor/remote.go
+++ b/doctor/remote.go
@@ -59,17 +59,15 @@ func checkRemoteSetup(ctx *scanContext, report *Report) {
 	}
 	hooks, repoRoot, err := resolve()
 	if err != nil {
-		report.Findings = append(report.Findings, Finding{
-			Check:  "remote-config",
-			Detail: fmt.Sprintf("could not resolve remote-hook config for this repo: %v", err),
-		})
+		report.Warn(sectionRemote, "remote config", fmt.Sprintf("could not resolve remote-hook config for this repo: %v", err),
+			"fix the repo .agent-factory config and rerun `af doctor`", false)
 		return
 	}
 	if hooks == nil {
-		report.OK = append(report.OK,
-			"remote hooks: n/a — no remote backend configured for this repo")
+		report.Pass(sectionRemote, "remote hooks", "not configured for this repo")
 		return
 	}
+	checkCoderStatus(hooks, report)
 
 	configHint := "in [remote_hooks]"
 	if repoRoot != "" {
@@ -80,13 +78,10 @@ func checkRemoteSetup(ctx *scanContext, report *Report) {
 	// running any hook, surfaced here as a diagnosable finding instead of an
 	// operation-time failure.
 	if err := hooks.Validate(); err != nil {
-		report.Findings = append(report.Findings, Finding{
-			Check:  "remote-config",
-			Detail: fmt.Sprintf("%v — set it %s", err, configHint),
-		})
+		report.Warn(sectionRemote, "remote config", fmt.Sprintf("%v; set it %s", err, configHint),
+			"edit the repo .agent-factory config and rerun `af doctor`", false)
 	} else {
-		report.OK = append(report.OK,
-			"remote hooks: configured with the required launch/attach/delete commands")
+		report.Pass(sectionRemote, "remote config", "required launch/attach/delete commands configured")
 	}
 
 	// 2. Hook-script presence + executability, for every configured command.
@@ -105,10 +100,8 @@ func checkRemoteSetup(ctx *scanContext, report *Report) {
 			continue // required-field emptiness is handled by Validate above.
 		}
 		if detail := hookExecIssue(h.field, h.cmd, configHint); detail != "" {
-			report.Findings = append(report.Findings, Finding{
-				Check:  "remote-hook-script",
-				Detail: detail,
-			})
+			report.Warn(sectionRemote, "remote hook", detail,
+				"fix the hook path or executable bit and rerun `af doctor`", false)
 		}
 	}
 
@@ -117,9 +110,9 @@ func checkRemoteSetup(ctx *scanContext, report *Report) {
 	// When list_cmd is absent, restore and this probe are both unavailable —
 	// noted as informational, not a failure, since list_cmd is optional.
 	if strings.TrimSpace(hooks.ListCmd) == "" {
-		report.OK = append(report.OK,
-			"remote hooks: connectivity probe skipped — no list_cmd configured "+
-				"(set list_cmd to enable restore across restarts and the round-trip probe)")
+		report.Warn(sectionRemote, "remote connectivity",
+			"probe skipped because no list_cmd is configured",
+			"set remote_hooks.list_cmd to enable restore and the round-trip probe", false)
 		return
 	}
 	// Skip the probe if list_cmd itself is not runnable — the executability
@@ -133,14 +126,68 @@ func checkRemoteSetup(ctx *scanContext, report *Report) {
 		timeout = remoteProbeTimeoutDefault
 	}
 	if detail := probeListCmd(hooks.ListCmd, timeout); detail != "" {
-		report.Findings = append(report.Findings, Finding{
-			Check:  "remote-connectivity",
-			Detail: detail,
-		})
+		report.Warn(sectionRemote, "remote connectivity", detail,
+			"run the list_cmd by hand, fix connectivity, then rerun `af doctor`", false)
 	} else {
-		report.OK = append(report.OK,
-			"remote hooks: connectivity probe succeeded (list_cmd responded with valid JSON)")
+		report.Pass(sectionRemote, "remote connectivity", "list_cmd responded with valid JSON")
 	}
+}
+
+func checkCoderStatus(hooks *config.RemoteHooks, report *Report) {
+	mentionsCoder := remoteHooksMentionCoder(hooks)
+	coderPath, lookErr := exec.LookPath("coder")
+	if lookErr != nil {
+		if mentionsCoder {
+			report.Warn(sectionRemote, "coder", "coder CLI is not on PATH",
+				"install coder or update the remote hook scripts", false)
+		} else {
+			report.Pass(sectionRemote, "coder", "not detected; hook commands do not directly reference coder")
+		}
+		return
+	}
+	if !mentionsCoder {
+		report.Pass(sectionRemote, "coder", "available at "+coderPath)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, coderPath, "whoami")
+	cmd.WaitDelay = 500 * time.Millisecond
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := "coder whoami failed"
+		if ctx.Err() == context.DeadlineExceeded {
+			detail = "coder whoami timed out"
+		} else if line := firstLine(string(out)); line != "" {
+			detail += ": " + line
+		}
+		report.Warn(sectionRemote, "coder", detail, "run `coder login`", false)
+		return
+	}
+	who := firstLine(string(out))
+	if who == "" {
+		who = "authenticated"
+	}
+	report.Pass(sectionRemote, "coder", who)
+}
+
+func remoteHooksMentionCoder(hooks *config.RemoteHooks) bool {
+	if hooks == nil {
+		return false
+	}
+	for _, command := range []string{
+		hooks.LaunchCmd,
+		hooks.ListCmd,
+		hooks.AttachCmd,
+		hooks.DeleteCmd,
+		hooks.TerminalCmd,
+	} {
+		if strings.Contains(strings.ToLower(command), "coder") {
+			return true
+		}
+	}
+	return false
 }
 
 // hookExecIssue returns an actionable message when the hook command cannot be

--- a/doctor/report.go
+++ b/doctor/report.go
@@ -1,0 +1,452 @@
+package doctor
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	sectionEnvironment = "Environment"
+	sectionConfig      = "Config & Storage"
+	sectionDaemon      = "Daemon"
+	sectionRemote      = "Remote Hooks"
+	sectionProcesses   = "Session & Process Health"
+)
+
+var sectionOrder = []string{
+	sectionEnvironment,
+	sectionConfig,
+	sectionDaemon,
+	sectionRemote,
+	sectionProcesses,
+}
+
+// AddHeader adds one top-level fact to the doctor heading.
+func (r *Report) AddHeader(label, value string) {
+	if value == "" {
+		value = "unknown"
+	}
+	r.Header = append(r.Header, HeaderItem{Label: label, Value: value})
+}
+
+// AddCheck adds one grouped non-finding row. problem controls whether a
+// non-pass row contributes to the process exit code.
+func (r *Report) AddCheck(section, name string, status CheckStatus, detail, remediation string, problem bool) {
+	if section == "" {
+		section = sectionEnvironment
+	}
+	r.Checks = append(r.Checks, CheckResult{
+		Section:     section,
+		Name:        name,
+		Status:      status,
+		Detail:      detail,
+		Remediation: remediation,
+		Problem:     problem,
+	})
+	if status == StatusPass {
+		r.OK = append(r.OK, fmt.Sprintf("%s: %s", name, detail))
+	}
+}
+
+func (r *Report) Pass(section, name, detail string) {
+	r.AddCheck(section, name, StatusPass, detail, "", false)
+}
+
+func (r *Report) Warn(section, name, detail, remediation string, problem bool) {
+	r.AddCheck(section, name, StatusWarn, detail, remediation, problem)
+}
+
+func (r *Report) Fail(section, name, detail, remediation string) {
+	r.AddCheck(section, name, StatusFail, detail, remediation, true)
+}
+
+// Render writes the human-readable report. fixMode changes remediation hints
+// so a --fix run reports attempted outcomes rather than promising future work.
+// verbose includes each process finding; the default collapses high-volume
+// process classes into summary rows.
+func Render(w io.Writer, r *Report, fixMode, verbose bool) {
+	fmt.Fprintln(w, "Agent Factory Doctor")
+	for _, item := range r.Header {
+		fmt.Fprintf(w, "%s: %s\n", item.Label, item.Value)
+	}
+
+	rows := renderRows(r, fixMode, verbose)
+	for _, section := range orderedSections(rows) {
+		fmt.Fprintf(w, "\n%s\n", section)
+		for _, row := range rows {
+			if row.section != section {
+				continue
+			}
+			fmt.Fprintf(w, "  %-5s %-24s %s\n", row.status, row.name+":", row.detail)
+			if row.remediation != "" && row.status != StatusPass && row.status != StatusFixed {
+				fmt.Fprintf(w, "        fix: %s\n", row.remediation)
+			}
+		}
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, summaryLine(r, rows, fixMode))
+}
+
+type renderRow struct {
+	section     string
+	name        string
+	status      CheckStatus
+	detail      string
+	remediation string
+}
+
+func renderRows(r *Report, fixMode, verbose bool) []renderRow {
+	rows := make([]renderRow, 0, len(r.Checks)+len(r.Findings)+len(r.OK))
+	for _, c := range r.Checks {
+		rows = append(rows, renderRow{
+			section:     c.Section,
+			name:        c.Name,
+			status:      c.Status,
+			detail:      c.Detail,
+			remediation: c.Remediation,
+		})
+	}
+	if len(r.Checks) == 0 {
+		for _, ok := range r.OK {
+			rows = append(rows, renderRow{
+				section: sectionEnvironment,
+				name:    "ok",
+				status:  StatusPass,
+				detail:  ok,
+			})
+		}
+	}
+	if verbose {
+		for _, f := range r.Findings {
+			rows = append(rows, findingRow(f, fixMode))
+		}
+		return rows
+	}
+
+	collapsed := collapseProcessFindings(r.Findings, fixMode)
+	for _, f := range r.Findings {
+		if collapsibleFinding(f.Check) {
+			continue
+		}
+		rows = append(rows, findingRow(f, fixMode))
+	}
+	rows = append(rows, collapsed...)
+	return rows
+}
+
+func collapsibleFinding(check string) bool {
+	switch check {
+	case "orphaned-process", "escaped-process", "possible-orphan", "runaway-cpu":
+		return true
+	default:
+		return false
+	}
+}
+
+func collapseProcessFindings(findings []Finding, fixMode bool) []renderRow {
+	byCheck := map[string][]Finding{}
+	for _, f := range findings {
+		if collapsibleFinding(f.Check) {
+			byCheck[f.Check] = append(byCheck[f.Check], f)
+		}
+	}
+	var rows []renderRow
+	for _, check := range []string{"orphaned-process", "escaped-process", "possible-orphan", "runaway-cpu"} {
+		group := byCheck[check]
+		if len(group) == 0 {
+			continue
+		}
+		rows = append(rows, collapsedProcessRow(check, group, fixMode))
+	}
+	return rows
+}
+
+func collapsedProcessRow(check string, findings []Finding, fixMode bool) renderRow {
+	total := collapsedCount(findings)
+	fixable := 0
+	fixed := 0
+	failed := 0
+	for _, f := range findings {
+		if f.Fixed {
+			fixed++
+		}
+		if f.FixErr != nil {
+			failed++
+		}
+		if f.FixAction != "" && !f.Fixed {
+			fixable++
+		}
+	}
+
+	status := StatusWarn
+	if fixable > 0 || failed > 0 {
+		status = StatusFail
+	}
+	if fixed == len(findings) && failed == 0 {
+		status = StatusFixed
+	}
+
+	return renderRow{
+		section:     sectionProcesses,
+		name:        collapsedProcessName(check),
+		status:      status,
+		detail:      collapsedProcessDetail(check, total, fixable, fixed, failed, fixMode),
+		remediation: collapsedProcessRemediation(check, fixable, fixMode),
+	}
+}
+
+func collapsedProcessName(check string) string {
+	switch check {
+	case "orphaned-process":
+		return "orphaned-processes"
+	case "escaped-process":
+		return "escaped-processes"
+	case "possible-orphan":
+		return "possible-orphans"
+	case "runaway-cpu":
+		return "runaway-cpu"
+	default:
+		return check
+	}
+}
+
+func collapsedProcessDetail(check string, total, fixable, fixed, failed int, fixMode bool) string {
+	switch check {
+	case "orphaned-process":
+		parts := []string{fmt.Sprintf("%s from dead sessions", plural(total, "orphaned process", "orphaned processes"))}
+		if fixable > 0 {
+			parts = append(parts, fmt.Sprintf("%d safe to clean", fixable))
+		}
+		if fixMode && fixed > 0 {
+			parts = append(parts, fmt.Sprintf("%d fixed", fixed))
+		}
+		if failed > 0 {
+			parts = append(parts, fmt.Sprintf("%d fix failed", failed))
+		}
+		return strings.Join(parts, ", ")
+	case "escaped-process":
+		return fmt.Sprintf("%s escaped live session pane trees", plural(total, "process", "processes"))
+	case "possible-orphan":
+		return fmt.Sprintf("%s belong to dead tmux servers without agent-factory markers", plural(total, "process", "processes"))
+	case "runaway-cpu":
+		return fmt.Sprintf("%s averaged a pegged CPU core inside live sessions", plural(total, "process", "processes"))
+	default:
+		return fmt.Sprintf("%s reported", plural(total, "finding", "findings"))
+	}
+}
+
+func collapsedProcessRemediation(check string, fixable int, fixMode bool) string {
+	switch check {
+	case "orphaned-process":
+		if fixable > 0 && !fixMode {
+			return "run `af doctor --fix` to clean the safe processes; rerun with `--verbose` for details"
+		}
+		return "rerun with `--verbose` for per-process details; inspect report-only processes manually"
+	case "escaped-process":
+		return "rerun with `--verbose` for details; inspect the live session or stop the process manually"
+	case "possible-orphan":
+		return "rerun with `--verbose` for details; verify ownership before killing anything manually"
+	case "runaway-cpu":
+		return "rerun with `--verbose` for details; inspect the live session before stopping processes"
+	default:
+		return "rerun with `--verbose` for details"
+	}
+}
+
+func collapsedCount(findings []Finding) int {
+	total := 0
+	for _, f := range findings {
+		if n, ok := summarizedMoreCount(f.Detail); ok {
+			total += n
+			continue
+		}
+		total++
+	}
+	return total
+}
+
+func summarizedMoreCount(detail string) (int, bool) {
+	fields := strings.Fields(detail)
+	for i := 0; i+2 < len(fields); i++ {
+		if fields[i] != "and" || fields[i+2] != "more" {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(fields[i+1], "%d", &n); err == nil {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func plural(n int, singular, plural string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	}
+	return fmt.Sprintf("%d %s", n, plural)
+}
+
+func findingRow(f Finding, fixMode bool) renderRow {
+	status := findingStatus(f)
+	detail := f.Detail
+	if f.FixErr != nil {
+		detail = fmt.Sprintf("%s (fix failed: %v)", detail, f.FixErr)
+	}
+	return renderRow{
+		section:     findingSection(f),
+		name:        f.Check,
+		status:      status,
+		detail:      detail,
+		remediation: findingRemediation(f, fixMode),
+	}
+}
+
+func findingStatus(f Finding) CheckStatus {
+	switch {
+	case f.Fixed:
+		return StatusFixed
+	case f.FixErr != nil:
+		return StatusFail
+	case f.Severity != "":
+		return f.Severity
+	case f.FixAction != "":
+		return StatusFail
+	default:
+		return StatusWarn
+	}
+}
+
+func findingSection(f Finding) string {
+	if f.Section != "" {
+		return f.Section
+	}
+	switch f.Check {
+	case "daemon-health":
+		return sectionDaemon
+	case "remote-config", "remote-hook-script", "remote-connectivity":
+		return sectionRemote
+	case "config", "af-home", "state-dir", "repo-state-dir", "log-storage", "git-repo", "worktree-root":
+		return sectionConfig
+	case "git", "git-identity", "tmux", "agent-program":
+		return sectionEnvironment
+	default:
+		return sectionProcesses
+	}
+}
+
+func findingRemediation(f Finding, fixMode bool) string {
+	switch {
+	case f.Fixed:
+		return ""
+	case f.FixErr != nil:
+		if f.FixAction != "" {
+			return fmt.Sprintf("resolve the error, then rerun `af doctor --fix` to %s", f.FixAction)
+		}
+		return "resolve the reported error, then rerun `af doctor`"
+	case f.Remediation != "":
+		return f.Remediation
+	case f.FixAction != "" && !fixMode:
+		return fmt.Sprintf("run `af doctor --fix` to %s", f.FixAction)
+	}
+	switch f.Check {
+	case "escaped-process", "runaway-cpu":
+		return "inspect the live session or stop the process manually"
+	case "possible-orphan":
+		return "verify ownership, then kill the process manually if stale"
+	case "orphaned-process":
+		return "run `af doctor` with the owning AGENT_FACTORY_HOME active, or inspect manually"
+	case "leaked-tmux-session":
+		return "verify ownership, then run the tmux kill command shown in the message"
+	case "foreign-daemon":
+		return "verify the other AGENT_FACTORY_HOME is intentional, then stop that daemon if stale"
+	case "daemon-health":
+		return "run `af daemon restart`; if the socket is stale, remove it after verifying no daemon is running"
+	case "remote-config":
+		return "edit the repo .agent-factory config and rerun `af doctor`"
+	case "remote-hook-script":
+		return "fix the hook path or executable bit and rerun `af doctor`"
+	case "remote-connectivity":
+		return "run the listed hook command by hand and fix the remote connection"
+	case "agent-program":
+		return "install the agent binary or set the matching program_overrides entry"
+	default:
+		return "inspect the message above and rerun `af doctor`"
+	}
+}
+
+func orderedSections(rows []renderRow) []string {
+	present := map[string]bool{}
+	for _, row := range rows {
+		present[row.section] = true
+	}
+	var out []string
+	for _, section := range sectionOrder {
+		if present[section] {
+			out = append(out, section)
+			delete(present, section)
+		}
+	}
+	for _, section := range sortedKeys(present) {
+		out = append(out, section)
+	}
+	return out
+}
+
+func summaryLine(r *Report, rows []renderRow, fixMode bool) string {
+	counts := map[CheckStatus]int{}
+	for _, row := range rows {
+		counts[row.status]++
+	}
+	parts := []string{
+		fmt.Sprintf("%d PASS", counts[StatusPass]),
+		fmt.Sprintf("%d WARN", counts[StatusWarn]),
+		fmt.Sprintf("%d FAIL", counts[StatusFail]),
+	}
+	if counts[StatusFixed] > 0 {
+		parts = append(parts, fmt.Sprintf("%d FIXED", counts[StatusFixed]))
+	}
+
+	unresolved := r.UnresolvedCount()
+	summary := fmt.Sprintf("Summary: %s; %s.", strings.Join(parts, ", "), issuePhrase(unresolved))
+	switch {
+	case !fixMode && fixableCount(r) > 0:
+		summary = strings.TrimSuffix(summary, ".") +
+			fmt.Sprintf("; %d fixable with `af doctor --fix`.", fixableCount(r))
+	case fixMode && fixedCount(r) > 0:
+		summary = strings.TrimSuffix(summary, ".") +
+			fmt.Sprintf("; %d fixed.", fixedCount(r))
+	}
+	return summary
+}
+
+func issuePhrase(n int) string {
+	if n == 0 {
+		return "no issues require action"
+	}
+	if n == 1 {
+		return "1 underlying issue requires action"
+	}
+	return fmt.Sprintf("%d underlying issues require action", n)
+}
+
+func fixableCount(r *Report) int {
+	n := 0
+	for _, f := range r.Findings {
+		if f.FixAction != "" && !f.Fixed {
+			n++
+		}
+	}
+	return n
+}
+
+func fixedCount(r *Report) int {
+	n := 0
+	for _, f := range r.Findings {
+		if f.Fixed {
+			n++
+		}
+	}
+	return n
+}

--- a/doctor/setup.go
+++ b/doctor/setup.go
@@ -43,7 +43,7 @@ func checkAFHome(ctx *scanContext, report *Report) {
 		})
 		return
 	}
-	report.OK = append(report.OK, fmt.Sprintf("agent-factory home: writable at %s", ctx.opts.ConfigDir))
+	report.Pass(sectionConfig, "agent-factory home", fmt.Sprintf("writable at %s", ctx.opts.ConfigDir))
 }
 
 func checkStateDirs(ctx *scanContext, report *Report) {
@@ -61,7 +61,7 @@ func checkStateDirs(ctx *scanContext, report *Report) {
 				Detail: fmt.Sprintf("%s directory %s is not writable — fix directory permissions: %v", d.label, d.dir, err),
 			})
 		} else {
-			report.OK = append(report.OK, fmt.Sprintf("%s: writable at %s", d.label, d.dir))
+			report.Pass(sectionConfig, d.label, fmt.Sprintf("writable at %s", d.dir))
 		}
 	}
 }
@@ -83,7 +83,7 @@ func checkLogStorage(report *Report) {
 		})
 		return
 	}
-	report.OK = append(report.OK, fmt.Sprintf("log storage: writable at %s", dir))
+	report.Pass(sectionConfig, "log storage", fmt.Sprintf("writable at %s", dir))
 }
 
 func checkConfig(_ *scanContext, report *Report) *config.Config {
@@ -110,8 +110,8 @@ func checkConfig(_ *scanContext, report *Report) *config.Config {
 		})
 		return cfg
 	}
-	report.OK = append(report.OK,
-		fmt.Sprintf("config: loaded %s (default_program = %q)", path, cfg.DefaultProgram))
+	report.Pass(sectionConfig, "config",
+		fmt.Sprintf("loaded %s (default_program = %q)", path, cfg.DefaultProgram))
 	return cfg
 }
 
@@ -124,7 +124,7 @@ func checkGit(report *Report) {
 		})
 		return
 	}
-	report.OK = append(report.OK, fmt.Sprintf("git: available at %s", gitPath))
+	report.Pass(sectionEnvironment, "git", fmt.Sprintf("available at %s", gitPath))
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -142,7 +142,7 @@ func checkGit(report *Report) {
 		})
 		return
 	}
-	report.OK = append(report.OK, fmt.Sprintf("git repo: %s", strings.TrimSpace(string(out))))
+	report.Pass(sectionConfig, "git repo", strings.TrimSpace(string(out)))
 	checkGitIdentity(gitPath, cwd, report)
 }
 
@@ -163,7 +163,7 @@ func checkGitIdentity(gitPath, cwd string, report *Report) {
 		})
 		return
 	}
-	report.OK = append(report.OK, "git identity: user.name and user.email are configured")
+	report.Pass(sectionEnvironment, "git identity", "user.name and user.email are configured")
 }
 
 func checkTmux(report *Report) {
@@ -172,7 +172,7 @@ func checkTmux(report *Report) {
 		report.Findings = append(report.Findings, Finding{Check: "tmux", Detail: err.Error()})
 		return
 	}
-	report.OK = append(report.OK, fmt.Sprintf("tmux: %s", version))
+	report.Pass(sectionEnvironment, "tmux", version)
 }
 
 func checkAgentPrograms(cfg *config.Config, report *Report) {
@@ -202,8 +202,7 @@ func checkOneProgram(field, agent, command string, report *Report) {
 		})
 		return
 	}
-	report.OK = append(report.OK,
-		fmt.Sprintf("%s: %q uses %s", field, command, check.Path))
+	report.Pass(sectionEnvironment, field, fmt.Sprintf("%q uses %s", command, check.Path))
 }
 
 func writableDir(dir string) error {

--- a/doctor/setup_test.go
+++ b/doctor/setup_test.go
@@ -49,7 +49,7 @@ func TestSetupDoctorReportsMissingDefaultProgram(t *testing.T) {
 	t.Setenv("PATH", binDir)
 	require.NoError(t, os.MkdirAll(home, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(home, config.TomlConfigFileName),
-		[]byte("default_program = \"claude\"\n"), 0o644))
+		[]byte("default_program = \"claude\"\n\n[program_overrides]\nclaude = \"/missing/claude\"\n"), 0o644))
 
 	report, err := Run(Options{
 		Setup:     true,


### PR DESCRIPTION
## Summary

- Add a triage header to `af doctor`: af version/channel, OS, home, repo/worktree mode, tmux, and agent binary presence.
- Render grouped PASS/WARN/FAIL checks with a one-line `fix:` remediation on every non-pass.
- Collapse high-volume process findings by default and add `--verbose` for per-process detail.
- Add read-only config validity, home health, storage, and worktree mode checks.
- Downgrade remote/coder problems to non-blocking WARN rows; failed `coder whoami` says `run coder login`.

Closes #1467

Root reviews. Do not merge.

## Before

Full audit comment with captured BEFORE output: https://github.com/sachiniyer/agent-factory/issues/1467#issuecomment-4922274303

Shape before:

```text
ok: daemon: responding on /home/siyer/.agent-factory/daemon.sock; autostart unit installed
ok: temp home ... is in use (...)
ok: remote hooks: n/a — no remote backend configured for this repo

issue: [orphaned-process] pid ... (--fix will kill pid ...)
issue: [orphaned-process] pid ... belongs to another agent-factory home ...
issue: [escaped-process] pid ... escaped the pane tree ...
issue: [possible-orphan] pid ... belongs to a dead tmux server ...
issue: [possible-orphan] … and 47 more processes of dead tmux servers ...

24 issue(s) found. Re-run with --fix to apply the safe remediations.
```

## After

Captured from `/tmp/af-doctor-redesign doctor`:

```text
Agent Factory Doctor
af: 1.0.157 (channel: preview)
os: linux/amd64
home: /home/siyer/.agent-factory
repo: /home/siyer/Desktop/claude-squad (worktree_root: sibling)
tmux: tmux 3.4
agents: claude=present, codex=present, aider=present, gemini=present

Environment
  PASS  af:                      1.0.157 (channel: preview)
  PASS  os:                      linux/amd64
  PASS  tmux:                    tmux 3.4
  PASS  claude:                  "/home/siyer/.local/bin/claude --dangerously-skip-permissions" resolves to /home/siyer/.local/bin/claude
  PASS  codex:                   "codex" resolves to /home/siyer/.local/share/pnpm/nodejs/22.22.1/bin/codex
  PASS  aider:                   "aider" resolves to /home/siyer/.local/bin/aider
  PASS  gemini:                  "gemini" resolves to /home/siyer/.local/share/pnpm/nodejs/22.22.1/bin/gemini

Config & Storage
  PASS  config:                  loaded /home/siyer/.agent-factory/config.toml (default_program: codex)
  PASS  home:                    readable directory at /home/siyer/.agent-factory
  PASS  instances:               present at /home/siyer/.agent-factory/instances
  PASS  repos:                   present at /home/siyer/.agent-factory/repos
  PASS  worktrees:               sibling mode; parent /home/siyer/Desktop is present

Daemon
  PASS  daemon:                  responding on /home/siyer/.agent-factory/daemon.sock
  PASS  autostart:               installed

Remote Hooks
  PASS  remote hooks:            not configured for this repo

Session & Process Health
  PASS  temp home:               /tmp/af1459-fixed.dAMkoA/af-home is in use (live process references it)
  PASS  temp home:               /tmp/af1459-nested.Cq7nTI/af-home is in use (live process references it)
  PASS  temp home:               /tmp/af1459.EVsVN9/af-home is in use (live process references it)
  PASS  temp home:               /tmp/af1459.NbVYxP/af-home is in use (live process references it)
  FAIL  orphaned-processes:      6 orphaned processes from dead sessions, 2 safe to clean
        fix: run `af doctor --fix` to clean the safe processes; rerun with `--verbose` for details
  WARN  escaped-processes:       2 processes escaped live session pane trees
        fix: rerun with `--verbose` for details; inspect the live session or stop the process manually
  WARN  possible-orphans:        62 processes belong to dead tmux servers without agent-factory markers
        fix: rerun with `--verbose` for details; verify ownership before killing anything manually

Summary: 19 PASS, 2 WARN, 1 FAIL; 24 underlying issues require action; 2 fixable with `af doctor --fix`.
```

`af doctor --verbose` restores the detailed per-process rows.

## Gates

- `gofmt -l ...` clean
- `go build ./...` passed
- `make test-container` passed
- `scripts/lint-file-length.sh` passed
- `GOTOOLCHAIN=go1.25.12 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0` passed
- `GOTOOLCHAIN=go1.25.12 go run golang.org/x/tools/cmd/deadcode@v0.36.0 -test ./...` passed

Note: without forcing `GOTOOLCHAIN=go1.25.12`, the pinned golangci/deadcode tools failed before analysis because their build metadata reported Go 1.23 while this module targets Go 1.24.2.