### PR TITLE
tui: expose full status error details

### DIFF
--- a/app/error_details_test.go
+++ b/app/error_details_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorDetailsOverlayShowsFullTruncatedError(t *testing.T) {
+	h := newTestHome(t)
+	resizeHome(h, 80, 24)
+
+	msg := "no clipboard tool found (install xclip/wl-clipboard, or pbcopy on macOS); PR URL: https://example.invalid/pr/987"
+	cmd := h.handleError(errors.New(msg))
+	require.NotNil(t, cmd, "handleError still returns the normal clear-message command")
+	require.Contains(t, h.errBox.String(), "E details",
+		"truncated status error should advertise the details key")
+
+	_, detailsCmd := h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("E")})
+	require.Nil(t, detailsCmd)
+	require.Equal(t, stateHelp, h.state)
+	require.NotNil(t, h.textOverlay)
+
+	rendered := h.textOverlay.Render()
+	assert.Contains(t, rendered, "Last error")
+	assert.Contains(t, rendered, "https://example.invalid/pr/987",
+		"full fallback data must be recoverable from the details overlay")
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -20,6 +20,8 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 	switch name {
 	case keys.KeyHelp:
 		return m.showHelpScreen(helpTypeGeneral{}, nil)
+	case keys.KeyErrorDetails:
+		return m.showErrorDetails()
 
 	// Tree navigation. Each moves the sidebar cursor and re-homes the focus
 	// ring on the tree (focusTreeForNav) so the ring-reading attach verb `o`

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -394,6 +394,9 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 	if name == keys.KeyShiftDown || name == keys.KeyShiftUp {
 		return nil, false
 	}
+	if name == keys.KeyErrorDetails {
+		return nil, false
+	}
 	// Skip sidebar nav keys from menu highlighting
 	if name == keys.KeyLeft || name == keys.KeyRight || name == keys.KeyNextSection || name == keys.KeyPrevSection {
 		return nil, false

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -23,6 +23,19 @@ func (m *home) handleError(err error) tea.Cmd {
 	}
 }
 
+func (m *home) showErrorDetails() (tea.Model, tea.Cmd) {
+	full := m.errBox.FullError()
+	if full == "" {
+		return m, nil
+	}
+	m.textOverlay = overlay.NewTextOverlay("Last error\n\n" + full)
+	m.textOverlayDismissAnyKey = false
+	m.replayHelpDismissKey = false
+	m.layoutTextOverlay()
+	m.state = stateHelp
+	return m, nil
+}
+
 func (m *home) confirmAction(message string, action tea.Cmd) tea.Cmd {
 	m.state = stateConfirm
 	m.confirmationOverlay = overlay.NewConfirmationOverlay(message)

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -20,6 +20,7 @@ const (
 	KeyArchive    // Archive a live session / restore an archived, Lost, or Dead one (#1028, #1300)
 	KeyLimitRetry // Retry a session blocked at a usage-limit wall (#1146)
 	KeyQuit
+	KeyErrorDetails // Show the full last error when the status line is truncated (#1423).
 
 	KeyTab        // Tab cycles the workspace focus ring (tree → pane → automations).
 	KeyShiftTab   // ShiftTab cycles the focus ring in reverse.
@@ -127,6 +128,7 @@ var specs = []spec{
 	{name: KeyLimitRetry, configKey: "limit_retry", keys: []string{"c"}, desc: "retry limit", dispatch: true},
 	{name: KeyHelp, configKey: "help", keys: []string{"?"}, desc: "help", dispatch: true},
 	{name: KeyQuit, configKey: "quit", keys: []string{"q"}, desc: "quit", dispatch: true},
+	{name: KeyErrorDetails, configKey: "error_details", keys: []string{"E"}, desc: "details", dispatch: true},
 	{name: KeyNewRemote, configKey: "new_remote", keys: []string{"N"}, desc: "new remote", dispatch: true},
 	{name: KeyTab, keys: []string{"tab"}, desc: "focus", dispatch: true},
 	{name: KeyShiftTab, keys: []string{"shift+tab"}, desc: "focus prev", dispatch: true},

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -37,6 +37,7 @@ func TestDefaultMapsMatchApprovedKeymap(t *testing.T) {
 		"a":         KeyArchive,
 		"c":         KeyLimitRetry,
 		"q":         KeyQuit,
+		"E":         KeyErrorDetails,
 		"tab":       KeyTab,
 		"shift+tab": KeyShiftTab,
 		"t":         KeyNewTab,
@@ -86,6 +87,7 @@ func TestDefaultMapsMatchApprovedKeymap(t *testing.T) {
 		KeyPanePrev:          "←",
 		KeyPaneNext:          "→",
 		KeyQuit:              "q",
+		KeyErrorDetails:      "E",
 	}
 	for name, want := range helpChecks {
 		if got := GlobalKeyBindings[name].Help().Key; got != want {

--- a/ui/err.go
+++ b/ui/err.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
+	"github.com/sachiniyer/agent-factory/keys"
 )
 
 type ErrBox struct {
@@ -35,43 +36,78 @@ func (e *ErrBox) SetSize(width, height int) {
 	e.height = height
 }
 
+func (e *ErrBox) FullError() string {
+	if e.err == nil {
+		return ""
+	}
+	return sanitizeError(e.err.Error())
+}
+
 func (e *ErrBox) String() string {
 	if e.width <= 0 || e.height <= 0 {
 		return ""
 	}
 	var err string
 	if e.err != nil {
-		err = e.err.Error()
-		// Agent pane output can reach us via wrapped errors (see #502) and
-		// carry ANSI escape sequences — CSI (SGR colors, private-mode like
-		// \x1b[?25l) and OSC (e.g. the OSC 8 hyperlink protocol from #565).
-		// Use xansi.Strip so width math and the final Truncate operate on
-		// plain text only — a bespoke regex repeatedly missed variants
-		// (#525 → #552 → #565).
-		err = xansi.Strip(err)
-		// xansi.Strip handles ANSI escapes but leaves bare \r untouched. Hook
-		// scripts commonly emit \r from progress indicators on stderr (see
-		// #668); a \r reaching the terminal moves the cursor back to column 0,
-		// overwriting lipgloss.Place's padding and corrupting the box.
-		err = strings.ReplaceAll(err, "\r", "")
-		lines := strings.Split(err, "\n")
-		err = strings.Join(lines, "//")
-		if runewidth.StringWidth(err) > e.width {
-			// Only add ellipsis when the string is long enough that the
-			// truncated content plus "..." is shorter than the original.
-			// Otherwise just hard-truncate to avoid losing more content
-			// to the 3-char ellipsis than we save by truncating.
-			tail := "..."
-			tailWidth := runewidth.StringWidth(tail)
-			if e.width < tailWidth {
-				// Container is too narrow to fit "..."; drop the tail to
-				// avoid overflowing past e.width (lipgloss.Place won't clip).
-				tail = ""
-			} else if runewidth.StringWidth(err) <= e.width+tailWidth {
-				tail = ""
-			}
-			err = runewidth.Truncate(err, e.width, tail)
-		}
+		err = e.statusLine()
 	}
 	return lipgloss.Place(e.width, e.height, lipgloss.Center, lipgloss.Center, errStyle.Render(err))
+}
+
+func (e *ErrBox) statusLine() string {
+	line := strings.Join(strings.Split(e.FullError(), "\n"), "//")
+	if runewidth.StringWidth(line) <= e.width {
+		return line
+	}
+	if hint := errorDetailsHint(); hint != "" {
+		const sep = "  "
+		hintWidth := runewidth.StringWidth(sep + hint)
+		if prefixWidth := e.width - hintWidth; prefixWidth > 3 {
+			return truncateStatusText(line, prefixWidth) + sep + hint
+		}
+	}
+	return truncateStatusText(line, e.width)
+}
+
+func sanitizeError(raw string) string {
+	// Agent pane output can reach us via wrapped errors (see #502) and carry
+	// ANSI escape sequences — CSI (SGR colors, private-mode like \x1b[?25l)
+	// and OSC (e.g. the OSC 8 hyperlink protocol from #565). Use xansi.Strip
+	// so width math and the final truncate operate on plain text only — a
+	// bespoke regex repeatedly missed variants (#525 → #552 → #565).
+	clean := xansi.Strip(raw)
+	// xansi.Strip handles ANSI escapes but leaves bare \r untouched. Hook
+	// scripts commonly emit \r from progress indicators on stderr (see #668);
+	// a \r reaching the terminal moves the cursor back to column 0, overwriting
+	// lipgloss.Place's padding and corrupting the box.
+	return strings.ReplaceAll(clean, "\r", "")
+}
+
+func truncateStatusText(text string, width int) string {
+	// Only add ellipsis when the string is long enough that the truncated
+	// content plus "..." is shorter than the original. Otherwise just
+	// hard-truncate to avoid losing more content to the 3-char ellipsis than
+	// we save by truncating.
+	tail := "..."
+	tailWidth := runewidth.StringWidth(tail)
+	if width < tailWidth {
+		// Container is too narrow to fit "..."; drop the tail to avoid
+		// overflowing past width (lipgloss.Place won't clip).
+		tail = ""
+	} else if runewidth.StringWidth(text) <= width+tailWidth {
+		tail = ""
+	}
+	return runewidth.Truncate(text, width, tail)
+}
+
+func errorDetailsHint() string {
+	binding, ok := keys.GlobalKeyBindings[keys.KeyErrorDetails]
+	if !ok {
+		return ""
+	}
+	help := binding.Help()
+	if help.Key == "" || help.Desc == "" {
+		return ""
+	}
+	return help.Key + " " + help.Desc
 }

--- a/ui/err_test.go
+++ b/ui/err_test.go
@@ -96,6 +96,24 @@ func TestErrBoxWithoutANSIUnchanged(t *testing.T) {
 	}
 }
 
+func TestErrBoxTruncatedErrorShowsDetailsHint(t *testing.T) {
+	const full = "no clipboard tool found (install xclip/wl-clipboard, or pbcopy on macOS); PR URL: https://example.invalid/pr/987"
+	e := NewErrBox()
+	e.SetSize(64, 1)
+	e.SetError(errors.New(full))
+
+	out := stripANSI(e.String())
+	if !strings.Contains(out, "E details") {
+		t.Fatalf("truncated error should advertise the full-details key, got %q", out)
+	}
+	if strings.Contains(out, "https://example.invalid/pr/987") {
+		t.Fatalf("test precondition failed: rendered status line was not truncated: %q", out)
+	}
+	if got := e.FullError(); got != full {
+		t.Fatalf("FullError() = %q, want %q", got, full)
+	}
+}
+
 // TestErrBoxStripsANSIVariants is a regression matrix covering every ANSI
 // variant the strip pass has had to learn the hard way:
 //   - Plain CSI / SGR (#525, original bug — partial CSI bytes leaked).


### PR DESCRIPTION
## Summary
- add a keymap-derived `E details` path for truncated status errors
- keep the status line one row, but preserve sanitized full error text for a scrollable overlay
- cover the clipboard-style fallback URL case so the full PR URL is recoverable from the TUI

Closes #1423

## Verification
- `make test-container GOTESTARGS="./app ./ui ./keys -run 'Test(ErrorDetailsOverlayShowsFullTruncatedError|ErrBoxTruncatedErrorShowsDetailsHint|DefaultMapsMatchApprovedKeymap)'"`\n- `golangci-lint run --timeout=3m --fast`\n- `gofmt -l .`\n- `go build ./...`\n- `make test-container`\n- `deadcode -test ./...`\n- `scripts/lint-file-length.sh`\n- verified branch is based on current `origin/master`; scoped diff: `app/handle_actions.go`, `app/home_update.go`, `app/home_view.go`, `app/error_details_test.go`, `keys/keys.go`, `keys/keys_test.go`, `ui/err.go`, `ui/err_test.go`\n\nSigned-off-by: Captain Claude <captain-claude@users.noreply.github.com>