### PR TITLE
tmux: serialize detach and close attach cleanup

### DIFF
--- a/session/tmux/close.go
+++ b/session/tmux/close.go
@@ -15,6 +15,9 @@ import (
 
 // Close terminates the tmux session and cleans up resources
 func (t *TmuxSession) Close() error {
+	t.attachMu.Lock()
+	defer t.attachMu.Unlock()
+
 	var errs []error
 
 	// Coordinate with any in-flight Attach goroutines (mirrors Detach):
@@ -47,10 +50,7 @@ func (t *TmuxSession) Close() error {
 	t.killAttach = nil
 	t.termAttach = nil
 
-	if t.attachCh != nil {
-		close(t.attachCh)
-		t.attachCh = nil
-	}
+	t.closeAttachChLocked()
 
 	// Capture the panes' process trees before kill-session — afterwards any
 	// survivor is reparented to init and its ancestry is unrecoverable
@@ -105,6 +105,9 @@ func (t *TmuxSession) Close() error {
 // still-tracked instance shares the same live session — calling Close there
 // would kill that session out from under the canonical instance.
 func (t *TmuxSession) CloseAttachOnly() error {
+	t.attachMu.Lock()
+	defer t.attachMu.Unlock()
+
 	var errs []error
 
 	// Mirror Close/Detach ordering: cancel any Attach goroutines before
@@ -141,10 +144,7 @@ func (t *TmuxSession) CloseAttachOnly() error {
 	t.killAttach = nil
 	t.termAttach = nil
 
-	if t.attachCh != nil {
-		close(t.attachCh)
-		t.attachCh = nil
-	}
+	t.closeAttachChLocked()
 
 	if len(errs) == 0 {
 		return nil

--- a/session/tmux/detach.go
+++ b/session/tmux/detach.go
@@ -252,7 +252,17 @@ func defaultKillByPid(pid int) error {
 	return nil
 }
 
+func (t *TmuxSession) closeAttachChLocked() {
+	if t.attachCh != nil {
+		close(t.attachCh)
+		t.attachCh = nil
+	}
+}
+
 func (t *TmuxSession) Attach() (chan struct{}, error) {
+	t.attachMu.Lock()
+	defer t.attachMu.Unlock()
+
 	// Detach clears t.ptmx after closing it so a Restore failure in the
 	// detach path can't leave a stale closed handle behind (issue #464).
 	// Refuse to attach without a live PTY rather than binding goroutines
@@ -377,12 +387,26 @@ func detachTracef(format string, args ...any) {
 // Detach disconnects from the current tmux session. Logs errors instead of panicking
 // so the application can attempt graceful recovery.
 func (t *TmuxSession) Detach() {
+	t.attachMu.Lock()
+	defer t.attachMu.Unlock()
+
 	detachStart := time.Now()
 	detachTracef("tmux.Detach-entry name=%s", t.sanitizedName)
+	if t.attachCh == nil {
+		detachTracef("tmux.Detach-noop name=%s reason=not-attached", t.sanitizedName)
+		return
+	}
+	if t.cancel == nil || t.ptmx == nil {
+		detachTracef("tmux.Detach-noop name=%s reason=attach-already-closing", t.sanitizedName)
+		t.closeAttachChLocked()
+		t.cancel = nil
+		t.ctx = nil
+		t.wg = nil
+		return
+	}
 	defer func() {
 		detachTracef("tmux.Detach-exit name=%s total=%v", t.sanitizedName, time.Since(detachStart))
-		close(t.attachCh)
-		t.attachCh = nil
+		t.closeAttachChLocked()
 		t.cancel = nil
 		t.ctx = nil
 		t.wg = nil

--- a/session/tmux/race_test.go
+++ b/session/tmux/race_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -175,6 +176,121 @@ func TestDetachHappyPathReplacesPtmx(t *testing.T) {
 	}
 	if session.ptmx == original {
 		t.Fatalf("expected Detach to swap in a fresh ptmx, got the original handle")
+	}
+}
+
+type blockingRestorePtyFactory struct {
+	t *testing.T
+
+	mu             sync.Mutex
+	starts         int
+	restoreStarted chan struct{}
+	releaseRestore chan struct{}
+}
+
+func (pt *blockingRestorePtyFactory) Start(_ *exec.Cmd) (*os.File, error) {
+	pt.mu.Lock()
+	pt.starts++
+	start := pt.starts
+	if start == 2 {
+		close(pt.restoreStarted)
+	}
+	pt.mu.Unlock()
+
+	if start == 2 {
+		<-pt.releaseRestore
+	}
+	return os.CreateTemp(pt.t.TempDir(), "pty-*")
+}
+
+func (pt *blockingRestorePtyFactory) Close() {}
+
+// TestDetachCloseConcurrentAttachChClose is the #1477 regression test.
+//
+// The stdin-reader goroutine that calls Detach is intentionally outside
+// t.wg. Before the fix, Close could run while Detach was still executing
+// (here, blocked in the post-detach Restore) and close t.attachCh; Detach's
+// deferred cleanup then closed the same channel again and panicked. This
+// interleaving must be serialized so exactly one teardown path owns the
+// attach channel close.
+func TestDetachCloseConcurrentAttachChClose(t *testing.T) {
+	ptyFactory := &blockingRestorePtyFactory{
+		t:              t,
+		restoreStarted: make(chan struct{}),
+		releaseRestore: make(chan struct{}),
+	}
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte(""), nil },
+	}
+
+	session := newTmuxSession(toTmuxName("detach-close-double-close", ""), "claude", ptyFactory, cmdExec)
+	if err := session.Restore(""); err != nil {
+		t.Fatalf("initial Restore: %v", err)
+	}
+
+	attachCh := make(chan struct{})
+	session.attachCh = attachCh
+	session.wg = &sync.WaitGroup{}
+	session.ctx, session.cancel = context.WithCancel(context.Background())
+
+	releaseWG := make(chan struct{})
+	session.wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		<-releaseWG
+	}(session.wg)
+
+	detachDone := make(chan struct{})
+	panicCh := make(chan any, 1)
+	go func() {
+		defer close(detachDone)
+		defer func() {
+			if r := recover(); r != nil {
+				panicCh <- r
+			}
+		}()
+		session.Detach()
+	}()
+
+	close(releaseWG)
+	select {
+	case <-ptyFactory.restoreStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Detach did not reach blocked Restore")
+	}
+
+	closeErrCh := make(chan error, 1)
+	go func() {
+		closeErrCh <- session.Close()
+	}()
+
+	select {
+	case <-attachCh:
+		// Pre-fix Close wins here, then Detach panics when released.
+	case <-time.After(200 * time.Millisecond):
+		// Fixed path: Close is serialized behind Detach and cannot close
+		// attachCh while Detach is still in progress.
+	}
+	close(ptyFactory.releaseRestore)
+
+	select {
+	case <-detachDone:
+	case <-time.After(time.Second):
+		t.Fatal("Detach did not return")
+	}
+	select {
+	case err := <-closeErrCh:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return")
+	}
+	select {
+	case r := <-panicCh:
+		t.Fatalf("Detach panicked closing attachCh: %v", r)
+	default:
 	}
 }
 

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -76,6 +76,11 @@ type TmuxSession struct {
 	// and cleared in lockstep with killAttach (same pairing invariant that
 	// the #602 regression broke — see Detach's inline clear).
 	termAttach func() (int, error)
+
+	// attachMu serializes attach lifecycle teardown. Detach is invoked by an
+	// Attach-spawned stdin goroutine that is intentionally outside wg, so Close
+	// cannot rely on wg.Wait before touching attachCh/cancel/ptmx (#1477).
+	attachMu sync.Mutex
 }
 
 const TmuxPrefix = "af_"


### PR DESCRIPTION
Summary:
- add an attach lifecycle mutex so Attach, Detach, Close, and CloseAttachOnly cannot concurrently mutate attach teardown fields
- centralize attachCh closing behind a nil guard and make Detach no-op when Close already tore down attach state
- add a race regression test that forces Close to close attachCh while Detach is blocked in Restore

Tests:
- reproduced pre-fix failure: make test-container GOTESTARGS="-race ./session/tmux -run TestDetachCloseConcurrentAttachChClose -count=1 -v"
- make test-container GOTESTARGS="-race ./session/tmux -run TestDetachCloseConcurrentAttachChClose -count=1 -v"
- make test-container GOTESTARGS="-race ./session/tmux -count=1"
- test -z "$(gofmt -l $(git ls-files '*.go'))"\n- git diff --check\n- make lint-file-length\n- GOTOOLCHAIN=go1.24.2 go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0\n- go build ./...\n- make test-container\n- GOTOOLCHAIN=go1.24.2 go run golang.org/x/tools/cmd/deadcode@v0.36.0 -test ./...\n\nCloses #1477