### PR TITLE
Fix task trigger intent after reload

### DIFF
--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -278,6 +278,69 @@ func TestHandleStateTasks_ValidationFailureLeavesTaskPaneStale(t *testing.T) {
 		"reloading from disk clears dirty; the dropped edit is communicated via the error, not a dangling dirty flag")
 }
 
+// TestHandleStateTasks_PendingTriggerSurvivesDeleteFailureReloadByID covers
+// #1474: after a delete fails, saveContentPaneState reloads the task pane from
+// disk. A pending run-now intent must still target the task selected when `r`
+// was pressed, not whatever task lands at the old selected index after reload.
+func TestHandleStateTasks_PendingTriggerSurvivesDeleteFailureReloadByID(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(500, 1)
+
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+
+	taskA := task.Task{
+		ID: "task-a-1474", Name: "Task A", Prompt: "p", CronExpr: "* * * * *",
+		ProjectPath: repo.Root, Program: "claude", Enabled: true, CreatedAt: time.Now(),
+	}
+	taskB := task.Task{
+		ID: "task-b-1474", Name: "Task B", Prompt: "p", CronExpr: "* * * * *",
+		ProjectPath: repo.Root, Program: "claude", Enabled: true, CreatedAt: time.Now(),
+	}
+	require.NoError(t, task.AddTask(taskA))
+	require.NoError(t, task.AddTask(taskB))
+
+	loaded, err := task.LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	tp := h.automations.TaskPane()
+	tp.SetTasks(loaded)
+	h.store.SetTasks(loaded)
+	_, _ = h.showTasksOverlay()
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
+
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("D")})
+	require.Len(t, tp.GetTasks(), 1)
+	require.Equal(t, "task-b-1474", tp.GetTasks()[0].ID)
+
+	t.Cleanup(SetTaskRemoverForTest(func(string) error {
+		return fmt.Errorf("daemon RPC failure")
+	}))
+
+	_, cmd := h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	require.NotNil(t, cmd)
+	assert.Contains(t, h.errBox.String(), "failed to remove task")
+	require.True(t, tp.HasPendingTrigger())
+	require.Len(t, tp.GetTasks(), 2)
+	require.Equal(t, "task-a-1474", tp.GetTasks()[0].ID)
+	require.Equal(t, "task-b-1474", tp.GetTasks()[1].ID)
+
+	var triggeredID string
+	t.Cleanup(SetTaskTriggerForTest(func(id string) error {
+		triggeredID = id
+		return nil
+	}))
+
+	_, cmd = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	drainCmd(t, cmd, 500*time.Millisecond)
+
+	assert.Equal(t, "task-b-1474", triggeredID,
+		"pending trigger must resolve by task ID after the failed-delete reload")
+}
+
 // TestHandleTaskCreate_RoutesThroughDaemonRPC is the #1029 PR 6 guard for the
 // create path: the TUI inline create form must persist the new task through the
 // daemon RPC — the sole writer of tasks.json among clients (#960) — not by

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -79,10 +79,11 @@ type TaskPane struct {
 	formScroll int
 
 	// Create mode
-	creating       bool
-	createPath     string
-	pendingCreate  bool
-	pendingTrigger bool
+	creating         bool
+	createPath       string
+	pendingCreate    bool
+	pendingTrigger   bool
+	pendingTriggerID string
 
 	width, height int
 	dirty         bool
@@ -271,7 +272,22 @@ func (s *TaskPane) HasPendingTrigger() bool {
 
 // ConsumePendingTrigger returns the triggered task and clears the flag.
 func (s *TaskPane) ConsumePendingTrigger() *task.Task {
+	id := s.pendingTriggerID
+	hadPending := s.pendingTrigger
 	s.pendingTrigger = false
+	s.pendingTriggerID = ""
+	if id != "" {
+		for i := range s.tasks {
+			if s.tasks[i].ID == id {
+				tsk := s.tasks[i]
+				return &tsk
+			}
+		}
+		return nil
+	}
+	if hadPending {
+		return nil
+	}
 	if s.selectedIdx >= 0 && s.selectedIdx < len(s.tasks) {
 		tsk := s.tasks[s.selectedIdx]
 		return &tsk
@@ -386,6 +402,7 @@ func (s *TaskPane) runSelectedTask() {
 		return
 	}
 	s.pendingTrigger = true
+	s.pendingTriggerID = s.tasks[s.selectedIdx].ID
 }
 
 func (s *TaskPane) enterEditMode() {

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -137,13 +137,37 @@ func TestTaskPaneConsumePendingTriggerReturnsSelected(t *testing.T) {
 		{ID: "b"},
 	})
 	tp.selectedIdx = 1
-	tp.pendingTrigger = true
+	tp.runSelectedTask()
 
 	got := tp.ConsumePendingTrigger()
 	if assert.NotNil(t, got) {
 		assert.Equal(t, "b", got.ID)
 	}
 	assert.False(t, tp.pendingTrigger)
+}
+
+// TestTaskPaneConsumePendingTriggerResolvesByIDAfterReload verifies that a
+// pending run-now intent survives a task reload by task ID, not by stale index.
+func TestTaskPaneConsumePendingTriggerResolvesByIDAfterReload(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{
+		{ID: "a"},
+		{ID: "b"},
+	})
+	tp.SelectTask(1)
+	tp.runSelectedTask()
+
+	tp.SetTasks([]task.Task{
+		{ID: "b"},
+		{ID: "a"},
+	})
+
+	got := tp.ConsumePendingTrigger()
+	if assert.NotNil(t, got) {
+		assert.Equal(t, "b", got.ID)
+	}
+	assert.False(t, tp.pendingTrigger)
+	assert.Empty(t, tp.pendingTriggerID)
 }
 
 func TestTaskPaneNormalModeAllowsQuitKeysToPropagate(t *testing.T) {


### PR DESCRIPTION
## Summary
- capture pending task trigger intent by stable task ID instead of selected index
- resolve the pending trigger against the reloaded task list before dispatch
- add pane and overlay regressions for failed-delete reloads

Closes #1474

## Tests
- make test-container GOTESTARGS="./ui ./app -run 'TestTaskPaneConsumePendingTrigger|TestHandleStateTasks_PendingTrigger|TestTaskTriggerRoutesThroughDaemonSharedPath|TestTaskTriggerWatchRefused'"\n- make test-container GOTESTARGS="./ui ./app"