### PR TITLE
tui: hide nested tmux status in embedded panes

### DIFF
--- a/ui/termpane/render.go
+++ b/ui/termpane/render.go
@@ -32,6 +32,10 @@ var cursorNone = cursorAt{}
 // with a reset so the styles can never bleed into the host TUI's surrounding
 // chrome.
 func renderGrid(emu *vt.Emulator, width, height int, cursor cursorAt) string {
+	return renderGridWindow(emu, width, height, 0, cursor)
+}
+
+func renderGridWindow(emu *vt.Emulator, width, height, sourceY int, cursor cursorAt) string {
 	if width <= 0 || height <= 0 {
 		return ""
 	}
@@ -41,10 +45,11 @@ func renderGrid(emu *vt.Emulator, width, height int, cursor cursorAt) string {
 		if y > 0 {
 			sb.WriteByte('\n')
 		}
+		row := y + sourceY
 		prev := uv.Style{}
 		for x := 0; x < width; {
 			content, cellWidth, style := " ", 1, uv.Style{}
-			if c := emu.CellAt(x, y); c != nil && c.Width > 0 && c.Content != "" {
+			if c := emu.CellAt(x, row); c != nil && c.Width > 0 && c.Content != "" {
 				content, cellWidth, style = c.Content, c.Width, c.Style
 			}
 			if x+cellWidth > width {
@@ -53,7 +58,7 @@ func renderGrid(emu *vt.Emulator, width, height int, cursor cursorAt) string {
 				// would overflow the row: blank it instead.
 				content, cellWidth = " ", 1
 			}
-			if cursor.show && y == cursor.y && x <= cursor.x && cursor.x < x+cellWidth {
+			if cursor.show && row == cursor.y && x <= cursor.x && cursor.x < x+cellWidth {
 				style.Attrs ^= uv.AttrReverse
 			}
 			sb.WriteString(style.Diff(&prev))
@@ -64,6 +69,25 @@ func renderGrid(emu *vt.Emulator, width, height int, cursor cursorAt) string {
 		if !prev.IsZero() {
 			sb.WriteString("\x1b[m")
 		}
+	}
+	return sb.String()
+}
+
+func padRenderedRows(grid string, width, rows int) string {
+	if width <= 0 || rows <= 0 {
+		return grid
+	}
+	blank := strings.Repeat(" ", width)
+	var sb strings.Builder
+	sb.Grow(len(grid) + rows*(width+1))
+	sb.WriteString(grid)
+	wrote := grid != ""
+	for range rows {
+		if wrote {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(blank)
+		wrote = true
 	}
 	return sb.String()
 }

--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -4,12 +4,14 @@
 //
 // A TermPane owns one attach client: a PTY running `tmux attach-session -t
 // =<name>`, whose output is fed through a charmbracelet/x/vt terminal
-// emulator into a cell grid. Render turns the grid into an ANSI-styled block
-// the TUI places inside a pane rect — no full-screen takeover, the rail stays
-// visible. Resize propagates the pane geometry to the PTY (tmux reflows on
-// the SIGWINCH) and to the emulator grid in step. Close kills the attach
-// CLIENT only; the tmux session keeps running server-side, exactly like a
-// detach.
+// emulator into a cell grid. Production tmux attachments are taller than the
+// pane rect by the nested session's configured status height (0-5 rows) so
+// tmux can draw its status line outside the rendered content window; Render
+// turns only the visible grid area into an ANSI-styled block the TUI places
+// inside a pane rect — no full-screen takeover, the rail stays visible. Resize
+// propagates the pane geometry to the PTY (tmux reflows on the SIGWINCH) and
+// to the emulator grid in step. Close kills the attach CLIENT only; the tmux
+// session keeps running server-side, exactly like a detach.
 //
 // This package is deliberately a pure projection: it never creates, kills, or
 // mutates tmux sessions — the daemon stays the sole session owner (#960).
@@ -31,6 +33,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -50,7 +53,21 @@ import (
 // returns anyway and leaks the goroutine: a leaked goroutine is strictly
 // better than freezing the event loop, the same trade waitForAttachDrain
 // makes.
-const closeDrainDeadline = 2 * time.Second
+const (
+	closeDrainDeadline = 2 * time.Second
+
+	// tmux clamps the status option to off/on or 2-5 rows. Embedded panes are
+	// already framed by af, so production attachments allocate those rows but
+	// crop them out of the rendered pane.
+	maxTmuxStatusRows = 5
+)
+
+type statusPosition int
+
+const (
+	statusBottom statusPosition = iota
+	statusTop
+)
 
 // TermPane is one live embedded terminal: PTY + attach client + vt emulator.
 //
@@ -75,7 +92,9 @@ type TermPane struct {
 	// Starts true (terminals boot with the cursor shown).
 	cursorVisible bool
 
-	width, height int
+	width, height  int
+	statusRows     int
+	statusPosition statusPosition
 
 	// done is closed when the PTY reader pump exits — on Close, or when the
 	// attach client dies on its own (session killed, tmux server gone, or an
@@ -89,7 +108,9 @@ type TermPane struct {
 // `=` forces an exact session-name match, mirroring session/tmux's Restore
 // (#1006) so a sibling session can never be prefix-matched instead.
 func New(sessionName string, width, height int) (*TermPane, error) {
-	return NewWithCommand(newAttachCommand(sessionName, os.Getenv("TMUX"), os.Environ()), width, height)
+	tmuxEnv, environ := os.Getenv("TMUX"), os.Environ()
+	rows, pos := tmuxStatusLayout(sessionName, tmuxEnv, environ)
+	return newWithCommand(newAttachCommand(sessionName, tmuxEnv, environ), width, height, rows, pos)
 }
 
 // newAttachCommand builds the attach client's argv and env. The TUI itself
@@ -104,6 +125,10 @@ func New(sessionName string, width, height int) (*TermPane, error) {
 // tmux emits escape sequences the grid understands.
 func newAttachCommand(sessionName, tmuxEnv string, environ []string) *exec.Cmd {
 	args := []string{"attach-session", "-t", "=" + sessionName}
+	return newTmuxCommand(tmuxEnv, environ, args...)
+}
+
+func newTmuxCommand(tmuxEnv string, environ []string, args ...string) *exec.Cmd {
 	// $TMUX is `socket_path,server_pid,session_id`; the path is what -S wants.
 	if sock, _, _ := strings.Cut(tmuxEnv, ","); sock != "" {
 		args = append([]string{"-S", sock}, args...)
@@ -120,24 +145,76 @@ func newAttachCommand(sessionName, tmuxEnv string, environ []string) *exec.Cmd {
 	return cmd
 }
 
+func tmuxStatusLayout(sessionName, tmuxEnv string, environ []string) (int, statusPosition) {
+	status, err := tmuxShowSessionOption(sessionName, tmuxEnv, environ, "status")
+	if err != nil {
+		log.WarningLog.Printf("termpane: tmux status query for %s failed: %v (assuming one bottom status row)", sessionName, err)
+		return 1, statusBottom
+	}
+	position, err := tmuxShowSessionOption(sessionName, tmuxEnv, environ, "status-position")
+	if err != nil {
+		log.WarningLog.Printf("termpane: tmux status-position query for %s failed: %v (assuming bottom)", sessionName, err)
+		position = "bottom"
+	}
+	return parseTmuxStatusRows(status), parseTmuxStatusPosition(position)
+}
+
+func tmuxShowSessionOption(sessionName, tmuxEnv string, environ []string, option string) (string, error) {
+	cmd := newTmuxCommand(tmuxEnv, environ, "show-options", "-Aqv", "-t", "="+sessionName+":", option)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", option, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func parseTmuxStatusRows(value string) int {
+	switch strings.TrimSpace(value) {
+	case "", "on":
+		return 1
+	case "off":
+		return 0
+	}
+	rows, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 1
+	}
+	return clampStatusRows(rows)
+}
+
+func parseTmuxStatusPosition(value string) statusPosition {
+	if strings.TrimSpace(value) == "top" {
+		return statusTop
+	}
+	return statusBottom
+}
+
 // NewWithCommand is New with a caller-built command on the PTY instead of the
 // default tmux attach argv. Tests use it to run scripted shells (no tmux
 // server) and to point a real attach at a private `-L` socket.
 func NewWithCommand(cmd *exec.Cmd, width, height int) (*TermPane, error) {
+	return newWithCommand(cmd, width, height, 0, statusBottom)
+}
+
+func newWithCommand(cmd *exec.Cmd, width, height, statusRows int, pos statusPosition) (*TermPane, error) {
 	width, height = clampSize(width, height)
-	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: uint16(height), Cols: uint16(width)}) //nolint:gosec // clampSize bounds to [1, 4096]
+	statusRows = clampStatusRows(statusRows)
+	ptyHeight := ptyHeightForVisibleRows(height, statusRows)
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: uint16(ptyHeight), Cols: uint16(width)}) //nolint:gosec // clampSize bounds to [1, 4096]
 	if err != nil {
 		return nil, fmt.Errorf("termpane: starting %q on a PTY: %w", cmd.Path, err)
 	}
 
 	t := &TermPane{
-		cmd:           cmd,
-		ptmx:          ptmx,
-		emu:           vt.NewEmulator(width, height),
-		cursorVisible: true,
-		width:         width,
-		height:        height,
-		done:          make(chan struct{}),
+		cmd:            cmd,
+		ptmx:           ptmx,
+		emu:            vt.NewEmulator(width, ptyHeight),
+		cursorVisible:  true,
+		width:          width,
+		height:         height,
+		statusRows:     statusRows,
+		statusPosition: pos,
+		done:           make(chan struct{}),
 	}
 	// The callback fires from emu.Write — always under gridMu's write lock —
 	// so the field write is ordered against Render's locked reads.
@@ -241,11 +318,12 @@ func (t *TermPane) Resize(width, height int) {
 		return
 	}
 	t.width, t.height = width, height
-	if err := pty.Setsize(t.ptmx, &pty.Winsize{Rows: uint16(height), Cols: uint16(width)}); err != nil { //nolint:gosec // clampSize bounds to [1, 4096]
+	ptyHeight := ptyHeightForVisibleRows(height, t.statusRows)
+	if err := pty.Setsize(t.ptmx, &pty.Winsize{Rows: uint16(ptyHeight), Cols: uint16(width)}); err != nil { //nolint:gosec // clampSize bounds to [1, 4096]
 		log.WarningLog.Printf("termpane: pty resize to %dx%d failed: %v", width, height, err)
 	}
 	t.gridMu.Lock()
-	t.emu.Resize(width, height)
+	t.emu.Resize(width, ptyHeight)
 	t.gridMu.Unlock()
 }
 
@@ -266,7 +344,13 @@ func (t *TermPane) Render(width, height int, showCursor bool) string {
 		pos := t.emu.CursorPosition()
 		cursor = cursorAt{x: pos.X, y: pos.Y, show: true}
 	}
-	return renderGrid(t.emu, width, height, cursor)
+	visibleHeight := min(height, t.height)
+	sourceY := 0
+	if t.statusPosition == statusTop {
+		sourceY = t.statusRows
+	}
+	grid := renderGridWindow(t.emu, width, visibleHeight, sourceY, cursor)
+	return padRenderedRows(grid, width, height-visibleHeight)
 }
 
 // Done reports attach-client death: the channel is closed once the PTY
@@ -332,4 +416,22 @@ func clampSize(width, height int) (int, int) {
 		height = 4096
 	}
 	return width, height
+}
+
+func clampStatusRows(rows int) int {
+	if rows < 0 {
+		return 0
+	}
+	if rows > maxTmuxStatusRows {
+		return maxTmuxStatusRows
+	}
+	return rows
+}
+
+func ptyHeightForVisibleRows(height, statusRows int) int {
+	ptyHeight := height + statusRows
+	if ptyHeight > 4096 {
+		return 4096
+	}
+	return ptyHeight
 }

--- a/ui/termpane/termpane_test.go
+++ b/ui/termpane/termpane_test.go
@@ -28,6 +28,14 @@ func startScript(t *testing.T, script string, width, height int) *TermPane {
 	return tp
 }
 
+func startScriptWithStatusLayout(t *testing.T, script string, width, height, statusRows int, pos statusPosition) *TermPane {
+	t.Helper()
+	tp, err := newWithCommand(exec.Command("/bin/sh", "-c", script), width, height, statusRows, pos)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tp.Close() })
+	return tp
+}
+
 // plainRender is Render with the styling stripped, for content assertions.
 func plainRender(tp *TermPane, width, height int) string {
 	return ansi.Strip(tp.Render(width, height, false))
@@ -61,6 +69,24 @@ func TestNewAttachCommandSocketParity(t *testing.T) {
 	assert.Equal(t, []string{"tmux", "attach-session", "-t", "=mysess"}, cmd.Args)
 }
 
+func TestParseTmuxStatusRows(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  int
+	}{
+		{value: "", want: 1},
+		{value: "on", want: 1},
+		{value: "off", want: 0},
+		{value: "0", want: 0},
+		{value: "2", want: 2},
+		{value: "5", want: 5},
+		{value: "6", want: 5},
+		{value: "bad", want: 1},
+	} {
+		assert.Equalf(t, tc.want, parseTmuxStatusRows(tc.value), "status %q", tc.value)
+	}
+}
+
 // TestNewAttachesAcrossNonDefaultSocket is the end-to-end pin for the #1121
 // play-test blocker: with af running inside a server on a non-default socket
 // ($TMUX carries its path), New must reach THAT server — not auto-start a
@@ -76,6 +102,8 @@ func TestNewAttachesAcrossNonDefaultSocket(t *testing.T) {
 	out, err := run("new-session", "-d", "-s", "sockparity", "-x", "80", "-y", "24",
 		"sh", "-c", "printf 'SOCK-PARITY-1121\\n'; sleep 120")
 	require.NoError(t, err, "tmux new-session: %s", out)
+	out, err = run("set-option", "-t", "sockparity", "status", "2")
+	require.NoError(t, err, "tmux set status: %s", out)
 
 	// What the TUI sees when it runs inside that server.
 	t.Setenv("TMUX", sock+",12345,$0")
@@ -83,6 +111,7 @@ func TestNewAttachesAcrossNonDefaultSocket(t *testing.T) {
 	tp, err := New("sockparity", 80, 24)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = tp.Close() })
+	assert.Equal(t, 2, tp.statusRows, "status query must use the non-default socket too")
 	waitForRender(t, tp, 80, 24, "SOCK-PARITY-1121")
 }
 
@@ -106,6 +135,34 @@ func TestResizePropagatesPTYWinsize(t *testing.T) {
 
 	tp.Resize(100, 30)
 	waitForRender(t, tp, 100, 30, "30 100")
+}
+
+func TestHiddenStatusRowsAreNotRendered(t *testing.T) {
+	tp := startScriptWithStatusLayout(t, "printf 'VISIBLE-1425\\033[7;1HSTATUS-1425-A\\033[8;1HSTATUS-1425-B'; sleep 30", 30, 6, 2, statusBottom)
+	waitForRender(t, tp, 30, 6, "VISIBLE-1425")
+
+	out := plainRender(tp, 30, 6)
+	assert.NotContains(t, out, "STATUS-1425-A", "first hidden bottom row must be cropped out of the pane")
+	assert.NotContains(t, out, "STATUS-1425-B", "second hidden bottom row must be cropped out of the pane")
+	gridLines(t, tp.Render(30, 6, false), 30, 6)
+}
+
+func TestTopStatusRowsAreNotRendered(t *testing.T) {
+	tp := startScriptWithStatusLayout(t, "printf 'TOP-STATUS-1425-A\\033[2;1HTOP-STATUS-1425-B\\033[3;1HVISIBLE-1425'; sleep 30", 30, 6, 2, statusTop)
+	waitForRender(t, tp, 30, 6, "VISIBLE-1425")
+
+	out := plainRender(tp, 30, 6)
+	assert.NotContains(t, out, "TOP-STATUS-1425-A", "first hidden top row must be cropped out of the pane")
+	assert.NotContains(t, out, "TOP-STATUS-1425-B", "second hidden top row must be cropped out of the pane")
+	gridLines(t, tp.Render(30, 6, false), 30, 6)
+}
+
+func TestHiddenStatusRowsAreIncludedInPTYWinsize(t *testing.T) {
+	tp := startScriptWithStatusLayout(t, "while :; do stty size; sleep 0.05; done", 80, 24, 2, statusBottom)
+	waitForRender(t, tp, 80, 24, "26 80")
+
+	tp.Resize(100, 30)
+	waitForRender(t, tp, 100, 30, "32 100")
 }
 
 func TestCloseKillsClientAndSignalsDone(t *testing.T) {
@@ -208,4 +265,41 @@ func TestCloseLeavesTmuxSessionAlive(t *testing.T) {
 		out, err := run("list-clients", "-t", "=termpane1089")
 		return err == nil && strings.TrimSpace(out) == ""
 	}, 3*time.Second, 50*time.Millisecond, "no attach client may survive Close")
+}
+
+func TestNewHidesNestedTmuxStatusLine(t *testing.T) {
+	testguard.IsolateTmux(t)
+
+	const (
+		sessionName  = "termpane1425"
+		statusMarker = "NESTED-STATUS-1425"
+	)
+	run := func(args ...string) (string, error) {
+		out, err := exec.Command("tmux", args...).CombinedOutput()
+		return string(out), err
+	}
+	t.Cleanup(func() { _, _ = run("kill-server") })
+	out, err := run("new-session", "-d", "-s", sessionName, "-x", "40", "-y", "6",
+		"sh", "-c", "printf 'LIVE-1425\\n'; sleep 120")
+	require.NoError(t, err, "tmux new-session: %s", out)
+	for _, args := range [][]string{
+		{"set-option", "-t", sessionName, "status", "2"},
+		{"set-option", "-t", sessionName, "status-format[0]", statusMarker + "-A"},
+		{"set-option", "-t", sessionName, "status-format[1]", statusMarker + "-B"},
+		{"set-option", "-t", sessionName, "status-interval", "0"},
+	} {
+		out, err = run(args...)
+		require.NoError(t, err, "tmux %v: %s", args, out)
+	}
+
+	tp, err := New(sessionName, 40, 6)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tp.Close() })
+	assert.Equal(t, 2, tp.statusRows, "New must query tmux's configured status row count")
+
+	waitForRender(t, tp, 40, 6, "LIVE-1425")
+	assert.Never(t, func() bool {
+		return strings.Contains(plainRender(tp, 40, 6), statusMarker)
+	}, 500*time.Millisecond, 20*time.Millisecond, "embedded pane must crop tmux's nested status line")
+	gridLines(t, tp.Render(40, 6, false), 40, 6)
 }


### PR DESCRIPTION
## Summary
- allocate one hidden bottom row for production embedded tmux attachments so tmux draws its status line outside the pane render
- keep custom TermPane commands at their exact requested PTY size
- add hermetic crop/winsize coverage plus an isolated real-tmux regression for the nested status marker

Closes #1425

## Verification
- `make test-container GOTESTARGS="./ui/termpane"`
- `golangci-lint run --timeout=3m --fast`
- `gofmt -l .`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`

Signed-off-by: Captain Claude <captain-claude@users.noreply.github.com>