### PR TITLE
tui: keep task form quit reliable

### DIFF
--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -154,7 +154,7 @@ func (m *home) showTasksOverlay() (tea.Model, tea.Cmd) {
 // edit isn't silent. The configured quit key is root-routed before the task
 // form can type it into an input, and ctrl+c still quits from normal mode.
 func (m *home) handleStateTasks(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit]) {
+	if msg.String() == "ctrl+c" || key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit]) {
 		return m.handleQuit()
 	}
 

--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -77,6 +77,33 @@ func TestPaneOverlaysQuitWithReboundKeyBeforeEditFieldsConsumeIt(t *testing.T) {
 	})
 }
 
+func TestTaskOverlayQuitKeysBypassFocusedCreateForm(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(nil))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	for _, tc := range []struct {
+		name string
+		msg  tea.KeyMsg
+	}{
+		{name: "configured quit", msg: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")}},
+		{name: "ctrl+c hard quit", msg: tea.KeyMsg{Type: tea.KeyCtrlC}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHome(t)
+			tp := h.automations.TaskPane()
+			tp.SetFocus(true)
+			tp.EnterCreateMode("/tmp/repo")
+			h.state = stateTasks
+
+			_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("draft")})
+			_, cmd := h.handleStateTasks(tc.msg)
+
+			assert.True(t, reachesQuit(cmd), "%s must quit before the form consumes it", tc.name)
+			assert.True(t, tp.IsCreating(), "quit routing must not first cancel the form")
+		})
+	}
+}
+
 // TestHandleStateTasks_PendingCreateFlushesDirtyTaskState is the regression
 // guard for #578, re-homed to the tasks overlay (#1096 play-test moved the
 // manager out of the rail).

--- a/ui/quit_key.go
+++ b/ui/quit_key.go
@@ -10,3 +10,7 @@ import (
 func configuredQuitKey(msg tea.KeyMsg) bool {
 	return key.Matches(msg, keys.GlobalKeyBindings[keys.KeyQuit])
 }
+
+func configuredQuitHelp() string {
+	return keys.GlobalKeyBindings[keys.KeyQuit].Help().Key
+}

--- a/ui/task_pane_edit.go
+++ b/ui/task_pane_edit.go
@@ -373,10 +373,11 @@ func (s *TaskPane) renderEditMode() string {
 	b.WriteString("\n")
 	markEnd(taskFocusSave)
 	b.WriteString("\n")
+	quitHint := configuredQuitHelp() + " quit"
 	if s.creating {
-		hint := "tab/shift+tab fields • enter create • esc cancel"
+		hint := "tab/shift+tab fields • enter create • esc cancel • " + quitHint
 		if s.width > 0 && lipgloss.Width(hint) > s.width {
-			hint = "tab fields • enter • esc cancel"
+			hint = "tab fields • enter • esc cancel • " + quitHint
 		}
 		b.WriteString(hintStyle.Render(fitLine(hint, s.width)))
 	} else {
@@ -386,9 +387,9 @@ func (s *TaskPane) renderEditMode() string {
 		}
 		b.WriteString(hintStyle.Render(fitLine(hint, s.width)))
 		b.WriteString("\n")
-		actions := "r run now • x toggle • D delete • esc list"
+		actions := "r run now • x toggle • D delete • esc list • " + quitHint
 		if s.width > 0 && lipgloss.Width(actions) > s.width {
-			actions = "r run • x toggle • D del • esc list"
+			actions = "r run • x toggle • D del • esc • " + quitHint
 		}
 		b.WriteString(hintStyle.Render(fitLine(actions, s.width)))
 	}

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -1127,6 +1127,55 @@ func TestTaskPaneCreateModeEnterInPromptInsertsNewline(t *testing.T) {
 		"enter in the prompt must insert a newline")
 }
 
+func TestTaskPaneCreateModeCompactFooterShowsQuitKey(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(nil))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	tp := NewTaskPane()
+	tp.SetSize(40, 10)
+	tp.EnterCreateMode(newGitRepo(t))
+
+	lines := strings.Split(tp.String(), "\n")
+	assert.Contains(t, lines[len(lines)-1], "esc cancel", "cancel remains visible")
+	assert.Contains(t, lines[len(lines)-1], "q quit", "configured quit key stays visible in the compact form footer")
+}
+
+func TestTaskPaneCreateModeFooterUsesReboundQuitKey(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(map[string][]string{"quit": {"Q"}}))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	tp := NewTaskPane()
+	tp.SetSize(40, 10)
+	tp.EnterCreateMode(newGitRepo(t))
+
+	lines := strings.Split(tp.String(), "\n")
+	assert.Contains(t, lines[len(lines)-1], "Q quit", "form footer must derive the quit hint from the keymap")
+	assert.NotContains(t, lines[len(lines)-1], "q quit", "the old default quit key must not be advertised after rebinding")
+}
+
+func TestTaskPaneEditModeCompactActionFooterShowsQuitKey(t *testing.T) {
+	require.NoError(t, keys.ApplyOverrides(nil))
+	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
+
+	tp := NewTaskPane()
+	tp.SetSize(40, 10)
+	tp.SetTasks([]task.Task{{
+		ID:          "abc",
+		Name:        "nightly",
+		Prompt:      "do it",
+		CronExpr:    "0 0 * * *",
+		ProjectPath: newGitRepo(t),
+		Program:     "claude",
+		Enabled:     true,
+	}})
+	tp.SetFocus(true)
+	tp.EnterEditSelected()
+
+	lines := strings.Split(tp.String(), "\n")
+	assert.Contains(t, lines[len(lines)-1], "esc", "list escape remains visible")
+	assert.Contains(t, lines[len(lines)-1], "q quit", "quit key stays visible on the pinned edit action footer")
+}
+
 // TestTaskPaneEditFormClampsToHeightWithFocusInView pins #1098 finding 1: at
 // a 60x15 terminal the edit form is taller than the tasks overlay and used to
 // clip off the TOP — Name/Trigger invisible while Name silently held focus.


### PR DESCRIPTION
## Summary
- route Ctrl+C through the task overlay quit path before focused task form fields can consume it
- keep the configured quit key visible in compact create/edit task form footers
- add regression coverage for default/rebound quit keys and Ctrl+C from focused task fields

Closes #1426

## Verification
- `make test-container GOTESTARGS="./app ./ui -run 'Test(TaskOverlayQuitKeysBypassFocusedCreateForm|PaneOverlaysQuitWithReboundKeyBeforeEditFieldsConsumeIt|TaskPaneCreateModeCompactFooterShowsQuitKey|TaskPaneCreateModeFooterUsesReboundQuitKey|TaskPaneEditModeCompactActionFooterShowsQuitKey|TaskPaneCreateModeEnterInPromptInsertsNewline|TaskPaneEditModeCtrlCCancels|TaskPaneCreateModeCtrlCCancels)'"`\n- `golangci-lint run --timeout=3m --fast`\n- `gofmt -l .`\n- `go build ./...`\n- `make test-container`\n- `deadcode -test ./...`\n- `scripts/lint-file-length.sh`\n\nSigned-off-by: Captain Claude <captain-claude@users.noreply.github.com>