### PR TITLE
tui: clarify first-run modal actions

### DIFF
--- a/app/handle_actions_test.go
+++ b/app/handle_actions_test.go
@@ -88,6 +88,30 @@ func TestHandleEnterAttachesCapturedInstanceAfterSelectionDrift(t *testing.T) {
 		"attach must target the instance captured at Enter-press time, not the drifted selection")
 }
 
+func TestFirstRunAttachHelpEscCancelsAttach(t *testing.T) {
+	h := newTestHome(t)
+	inst := instanceWithFakeBackend(t, "alpha")
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	attached := 0
+	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, attach func() (chan struct{}, error)) tea.Cmd {
+		attached++
+		return nil
+	})
+
+	model, _ := h.handleAttach()
+	h = model.(*home)
+	require.Equal(t, stateHelp, h.state, "first-time attach must show the help overlay")
+	require.NotNil(t, h.textOverlay)
+
+	_, cmd := h.handleHelpState(tea.KeyMsg{Type: tea.KeyEsc})
+	require.Equal(t, stateDefault, h.state, "Esc must close the attach help overlay")
+	require.False(t, h.attachTransitioning, "Esc cancel must not schedule the full-screen attach transition")
+	runHermeticCmd(t, h, cmd, 0)
+	require.Zero(t, attached, "Esc cancel must not invoke the attach callback")
+}
+
 // TestKillConfirmationWarning is the regression guard for issue #815. Kill
 // force-removes the worktree (`git worktree remove -f`), bypassing git's own
 // refusal to delete a dirty worktree, so the confirmation dialog's warning is

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -85,12 +85,12 @@ func TestHandleMenuHighlightingDoesNotInterceptNamingText(t *testing.T) {
 	assert.Nil(t, cmd)
 }
 
-// TestHandleMenuHighlightingNewInstanceEnterTab is the regression guard for
-// issue #691: pressing Enter or Tab while naming a new instance must drive the
+// TestHandleMenuHighlightingNewInstanceActions is the regression guard for
+// issue #691/#1413: pressing Enter, Tab, or Esc while naming a new instance must drive the
 // menu highlight animation. The bug (commit f294e5b) folded stateNew into the
 // early-return filter, which made the Enter→KeySubmitName / Tab→KeyChangeProgram
 // remapping — and thus the highlight render path — unreachable.
-func TestHandleMenuHighlightingNewInstanceEnterTab(t *testing.T) {
+func TestHandleMenuHighlightingNewInstanceActions(t *testing.T) {
 	// Force a real color profile so lipgloss emits the underline escape that
 	// signals a highlighted menu option; the Ascii profile used by default in
 	// non-TTY test runs strips all styling and would hide the highlight.
@@ -109,6 +109,7 @@ func TestHandleMenuHighlightingNewInstanceEnterTab(t *testing.T) {
 	}{
 		{"enter", tea.KeyMsg{Type: tea.KeyEnter}},
 		{"tab", tea.KeyMsg{Type: tea.KeyTab}},
+		{"esc", tea.KeyMsg{Type: tea.KeyEsc}},
 	}
 
 	for _, tc := range cases {
@@ -125,7 +126,7 @@ func TestHandleMenuHighlightingNewInstanceEnterTab(t *testing.T) {
 			cmd, returnEarly := h.handleMenuHighlighting(tc.key)
 
 			// The keypress is intercepted so the highlight + re-emit fire.
-			assert.True(t, returnEarly, "Enter/Tab should be intercepted during stateNew")
+			assert.True(t, returnEarly, "naming action keys should be intercepted during stateNew")
 			assert.NotNil(t, cmd)
 			assert.True(t, h.keySent, "keySent guards the re-emitted key from re-highlighting")
 

--- a/app/help.go
+++ b/app/help.go
@@ -97,6 +97,10 @@ func helpStart(instance *session.Instance) helpText {
 	return helpTypeInstanceStart{instance: instance}
 }
 
+func firstRunActionLine(actions string) string {
+	return descStyle.Render(actions)
+}
+
 func (h helpTypeGeneral) toContent() string {
 	// Every key glyph below is pulled from the generated binding table via
 	// helpKey, so [keys] rebinds appear here identically to the bottom menu
@@ -169,8 +173,7 @@ func (h helpTypeInstanceStart) toContent() string {
 		descStyle.Render("New session created:"),
 		descStyle.Render(fmt.Sprintf("• Git branch: %s (isolated worktree)",
 			lipgloss.NewStyle().Bold(true).Render(h.instance.GetBranch()))),
-		descStyle.Render(fmt.Sprintf("• %s running in background tmux session",
-			lipgloss.NewStyle().Bold(true).Render(h.instance.Program))),
+		descStyle.Render("• Agent process running in background tmux session"),
 		"",
 		headerStyle.Render("Managing:"),
 		keyStyle.Render(helpKey(keys.KeyEnter))+descStyle.Render(fmt.Sprintf("     - Interact with the session in its pane (%s returns to nav)", helpKey(keys.KeyExitInteractive))),
@@ -178,6 +181,9 @@ func (h helpTypeInstanceStart) toContent() string {
 		keyStyle.Render(tmux.DetachKeyDisplay)+descStyle.Render("     - Detach from a full-screen session"),
 		tabHelp,
 		keyStyle.Render(helpKey(keys.KeyKill))+descStyle.Render("     - Kill (delete) the selected session"),
+		"",
+		headerStyle.Render("Actions:"),
+		firstRunActionLine("enter continue • esc close"),
 	)
 	return content
 }
@@ -186,7 +192,8 @@ func (h helpTypeInstanceAttach) toContent() string {
 	content := lipgloss.JoinVertical(lipgloss.Left,
 		titleStyle.Render("Attaching to Instance"),
 		"",
-		descStyle.Render("To detach from a session, press ")+keyStyle.Render(tmux.DetachKeyDisplay),
+		firstRunActionLine("enter attach full-screen • esc cancel"),
+		descStyle.Render("Detach later with ")+keyStyle.Render(tmux.DetachKeyDisplay),
 	)
 	return content
 }
@@ -272,6 +279,7 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 	// Only show if we're showing the general help screen or the corresponding flag is not set
 	// in the seen bitmask.
 	m.replayHelpDismissKey = false
+	m.textOverlayDismissPolicy = nil
 	if alwaysShow || (m.appState.GetHelpScreensSeen()&flag) == 0 {
 		// Mark this help screen as seen and save state
 		if err := m.appState.SetHelpScreensSeen(m.appState.GetHelpScreensSeen() | flag); err != nil {
@@ -285,6 +293,10 @@ func (m *home) showHelpScreen(helpType helpText, onDismiss func() tea.Cmd) (tea.
 		m.textOverlayDismissAnyKey = true
 		if _, ok := helpType.(helpTypeGeneral); ok {
 			m.textOverlayDismissAnyKey = false
+		}
+		if _, ok := helpType.(helpTypeInstanceAttach); ok {
+			m.textOverlayDismissAnyKey = false
+			m.textOverlayDismissPolicy = attachHelpDismissPolicy
 		}
 		if _, ok := helpType.(helpTypeInteractive); ok {
 			m.replayHelpDismissKey = true
@@ -312,15 +324,30 @@ func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if !m.textOverlayDismissAnyKey && !isHelpDismissKey(msg) {
+	runOnDismiss := true
+	if m.textOverlayDismissPolicy != nil {
+		dismiss, run := m.textOverlayDismissPolicy(msg)
+		if !dismiss {
+			return m, nil
+		}
+		runOnDismiss = run
+	} else if !m.textOverlayDismissAnyKey && !isHelpDismissKey(msg) {
 		return m, nil
 	}
 
-	dismissCmd, shouldClose := m.textOverlay.HandleKeyPress(msg)
+	var dismissCmd tea.Cmd
+	var shouldClose bool
+	if runOnDismiss {
+		dismissCmd, shouldClose = m.textOverlay.HandleKeyPress(msg)
+	} else {
+		m.textOverlay.Dismissed = true
+		shouldClose = true
+	}
 	if shouldClose {
 		replayDismissKey := m.replayHelpDismissKey
 		m.replayHelpDismissKey = false
 		m.textOverlayDismissAnyKey = false
+		m.textOverlayDismissPolicy = nil
 		m.state = stateDefault
 		// Menu.SetState rebuilds the options slice; call it synchronously
 		// on the event-loop goroutine rather than from a tea.Cmd closure
@@ -336,6 +363,17 @@ func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func attachHelpDismissPolicy(msg tea.KeyMsg) (bool, bool) {
+	switch msg.Type {
+	case tea.KeyEnter:
+		return true, true
+	case tea.KeyEsc, tea.KeyCtrlC:
+		return true, false
+	default:
+		return false, false
+	}
 }
 
 func isHelpScrollUpKey(msg tea.KeyMsg) bool {

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -86,6 +86,39 @@ func TestInstanceStartHelpMentionsFullScreenDetach(t *testing.T) {
 	}
 }
 
+func TestInstanceStartHelpShowsFirstRunActionsAndGenericAgentCopy(t *testing.T) {
+	local := newStartedInstance(t, "local")
+	content := helpStart(local).toContent()
+
+	for _, want := range []string{
+		"Agent process running in background tmux session",
+		"enter continue",
+		"esc close",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("instance-start help missing %q; got:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "claude running in background tmux session") {
+		t.Errorf("instance-start help must not hard-code the selected program as the running process; got:\n%s", content)
+	}
+}
+
+func TestInstanceAttachHelpShowsProceedCancelAndDetach(t *testing.T) {
+	content := helpTypeInstanceAttach{}.toContent()
+
+	for _, want := range []string{
+		"enter attach full-screen",
+		"esc cancel",
+		"Detach later with",
+		"ctrl-w",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("attach help missing %q; got:\n%s", want, content)
+		}
+	}
+}
+
 func TestGeneralHelpOverlayFitsAndMarksScrollAt80x24(t *testing.T) {
 	h := newTestHome(t)
 	resizeHome(h, 80, 24)

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -253,6 +253,9 @@ type home struct {
 	// press-any-key gates while the general ? help behaves like a scrollable
 	// modal with explicit dismiss keys.
 	textOverlayDismissAnyKey bool
+	// textOverlayDismissPolicy, when set, decides whether a help overlay key
+	// closes the overlay and whether its OnDismiss callback should run.
+	textOverlayDismissPolicy func(tea.KeyMsg) (dismiss bool, runOnDismiss bool)
 	// replayHelpDismissKey marks the first-run interactive pane help: the
 	// key that closes that overlay is the user's first pane keystroke, so it
 	// must be forwarded after the deferred live bind completes (#1410).

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -351,8 +351,8 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 		m.keySent = false
 		return nil, false
 	}
-	// While naming a new instance the menu only shows the submit-name (enter)
-	// and change-program (tab) options, so those two keys are the only ones
+	// While naming a new instance the menu only shows the submit-name (enter),
+	// change-program (tab), and cancel (esc) options, so those keys are the only ones
 	// that should drive the highlight animation. Every other key is naming
 	// text and must pass through untouched — matching on msg.String() rather
 	// than GlobalKeyStringsMap also keeps "o" (a KeyEnter alias) usable as a
@@ -365,6 +365,8 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 			name = keys.KeySubmitName
 		case "tab":
 			name = keys.KeyChangeProgram
+		case "esc":
+			name = keys.KeyCancelName
 		default:
 			return nil, false
 		}

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -30,6 +30,7 @@ func (m *home) showErrorDetails() (tea.Model, tea.Cmd) {
 	}
 	m.textOverlay = overlay.NewTextOverlay("Last error\n\n" + full)
 	m.textOverlayDismissAnyKey = false
+	m.textOverlayDismissPolicy = nil
 	m.replayHelpDismissKey = false
 	m.layoutTextOverlay()
 	m.state = stateHelp

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -46,6 +46,7 @@ const (
 	KeyHooks  // Key for editing post-worktree hooks
 
 	KeyChangeProgram // Key for changing the program during new instance naming
+	KeyCancelName    // Display-only cancel hint during new instance naming
 
 	// Sidebar navigation
 	KeyLeft        // Collapse section / move to parent
@@ -154,6 +155,7 @@ var specs = []spec{
 	// -- Special keybindings --
 	{name: KeySubmitName, keys: []string{"enter"}, helpLabel: "enter", desc: "submit name"},
 	{name: KeyChangeProgram, keys: []string{"tab"}, desc: "change program"},
+	{name: KeyCancelName, keys: []string{"esc"}, desc: "cancel"},
 }
 
 // reservedKeys are key strings the config may never bind an action to: they

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -81,6 +81,7 @@ func TestDefaultMapsMatchApprovedKeymap(t *testing.T) {
 		KeyJumpTab:           "1-9",
 		KeySubmitName:        "enter",
 		KeyChangeProgram:     "tab",
+		KeyCancelName:        "esc",
 		KeyExitInteractive:   "ctrl+]",
 		KeyLeft:              "h/←",
 		KeyRight:             "l/→",

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -87,7 +87,7 @@ type Menu struct {
 }
 
 var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyNewRemote, keys.KeySearch, keys.KeyHelp, keys.KeyQuit}
-var newInstanceMenuOptions = []keys.KeyName{keys.KeySubmitName, keys.KeyChangeProgram}
+var newInstanceMenuOptions = []keys.KeyName{keys.KeySubmitName, keys.KeyChangeProgram, keys.KeyCancelName}
 
 // automationsMenuOptions are the status-bar hints while the in-rail
 // automations section has focus: Enter opens the task manager overlay (which

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -107,6 +107,19 @@ func menuHasOption(m *Menu, want keys.KeyName) bool {
 	return false
 }
 
+func TestMenuNewInstanceShowsSubmitProgramAndCancel(t *testing.T) {
+	m := NewMenu()
+	m.SetState(StateNewInstance)
+	m.SetSize(80, 1)
+
+	out := m.String()
+	for _, want := range []string{"enter submit name", "tab change program", "esc cancel"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("new-instance footer missing %q:\n%s", want, out)
+		}
+	}
+}
+
 // TestMenuRemoteInstanceOmitsUnsupportedTabKeys guards against regressing #988:
 // remote instances block `t` (new tab) and `w` (close tab) — those handlers
 // reject IsRemote() with an error — so the footer menu must only surface the

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -284,6 +284,9 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 
 	// Cut the title if it's too long
 	titleText := i.Title
+	if op == session.OpCreating {
+		titleText = "Session name: " + titleText
+	}
 	if i.IsRemote() {
 		titleText = "[remote] " + titleText
 	}

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -267,6 +267,23 @@ func TestInstanceRendererArchivedShowsName(t *testing.T) {
 	}
 }
 
+func TestInstanceRendererCreatingRowLabelsNamePrompt(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "alpha",
+		Path:    t.TempDir(),
+		Program: "test",
+	})
+	require.NoError(t, err)
+	require.NoError(t, inst.Transition(session.BeginCreate()))
+
+	r := NewInstanceRenderer(&spin)
+	r.SetWidth(40)
+
+	title := strings.Split(ansiEscape.ReplaceAllString(r.Render(inst, 1, true, false, false), ""), "\n")[1]
+	assert.Contains(t, title, "Session name: alpha", "creating rows must label the active name target")
+}
+
 // TestInstanceRendererDeletingDimsSelectedRow pins the #853 fix: a SELECTED
 // deleting row must dim its branch and PR lines along with the title. Before
 // the fix only titleS picked up deletingTitleColor, so the high-contrast


### PR DESCRIPTION
## Summary
- label the first-run create row as a session-name prompt and show esc cancel in the naming footer
- add explicit proceed/cancel action lines to the created and attach first-run overlays
- make Esc/Ctrl+C cancel the first-run attach overlay instead of starting attach, and use generic agent-process copy for overridden programs

Closes #1413

Signed-off-by: Captain Claude <captain.claude@example.com>

## Verification
- gofmt -l .
- scripts/lint-file-length.sh
- go build ./...
- golangci-lint run --timeout=3m --fast
- make tui-driver-selftest (SELF-TEST PASSED — 24/24 steps green)
- make test-container
- deadcode -test ./...