### PR TITLE
tui: show teardown fallback when scrolling killing tabs

### DIFF
--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -136,6 +136,33 @@ func TestPreviewScrollModeThenLoadingFallback(t *testing.T) {
 	require.NotContains(t, rendered, staleScrollMarker)
 }
 
+func TestPreviewScrollEntryDeletingShowsTeardownFallback(t *testing.T) {
+	log.Initialize(false)
+	defer log.Close()
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title: "deleting", Path: t.TempDir(), Program: "test",
+	})
+	require.NoError(t, err)
+	inst.SetBackend(session.NewFakeBackend())
+	inst.SetStatusForTest(session.Deleting)
+
+	p := NewTabPane()
+	p.SetSize(80, 30)
+
+	require.NoError(t, p.ScrollUp(inst, 0))
+
+	require.False(t, p.isScrolling,
+		"deleting agent tab must not enter empty scroll mode")
+	require.True(t, p.content.fallback,
+		"deleting agent tab must enter fallback state when scrolling starts")
+	require.Contains(t, p.content.text, "Tearing down session...")
+	require.NotContains(t, p.viewport.View(), scrollFooter(),
+		"scroll footer must not be the only visible content")
+	require.Contains(t, p.String(), "Tearing down session...",
+		"rendered frame must show the teardown fallback")
+}
+
 // TestPreviewScrollModeViewportContentCleared focuses on the viewport-clearing
 // half of the invariant: after entering any fallback, viewport.View() must no
 // longer contain the captured scroll content. Without the fix the viewport is

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -462,6 +462,11 @@ func (p *TabPane) ScrollDown(instance *session.Instance, activeTab int) error {
 // + tab index, never a cached title, so the wrong view can never be captured
 // (#746/#384).
 func (p *TabPane) enterScrollModeLocked(instance *session.Instance, activeTab int) error {
+	if instance.IsTearingDown() {
+		p.setFallbackState("Tearing down session...")
+		return nil
+	}
+
 	var content string
 	var err error
 	if activeTab == 0 {


### PR DESCRIPTION
## Summary
- guard scroll-mode entry for tearing-down sessions before full-history capture
- keep the tab pane on the existing 'Tearing down session...' fallback instead of an empty scroll viewport
- add a regression test for scrolling a deleting agent tab

Closes #1478

Signed-off-by: Captain Claude <captain.claude@example.com>

## Verification
- gofmt -l .
- scripts/lint-file-length.sh
- go build ./...
- golangci-lint run --timeout=3m --fast
- make tui-driver-selftest (SELF-TEST PASSED — 24/24 steps green)
- make test-container
- deadcode -test ./...