### PR TITLE
tui: surface width auto-hidden panes

### DIFF
--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -116,7 +116,9 @@ func (m *home) openOrFocusPane(instance *session.Instance, tab int) (tea.Model, 
 	m.store.TouchOpenPane(p)
 	m.relayout()
 	m.focusRegion(layout.PaneRegion(p.ID()))
-	return m, m.selectionChanged()
+	selectionCmd := m.selectionChanged()
+	statusCmd := m.consumePaneAutoHideStatus()
+	return m, tea.Batch(selectionCmd, statusCmd)
 }
 
 // handleSplitPane dispatches the `S` key: commit the active preview alongside

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync/atomic"
@@ -11,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/session/tmux"
@@ -162,6 +164,10 @@ type home struct {
 	// left-to-right order — rebuilt by relayout (§2.6 pane-count fitting:
 	// the least-recently-focused panes beyond Layout.MaxPanes are hidden).
 	visiblePanes []*store.OpenPane
+	// pendingPaneAutoHideStatus is set by relayout when a previously visible
+	// pane is auto-hidden by width pressure. Callers that can return a tea.Cmd
+	// consume it to start the same transient clear timer normal errors use.
+	pendingPaneAutoHideStatus string
 	// lastPaneCapture is when each pane's capture was last dispatched, keyed
 	// by pane id; the paneCaptureMinInterval throttle reads it (RFC §5.2).
 	lastPaneCapture map[int]time.Time
@@ -387,10 +393,11 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 
 // updateHandleWindowSizeEvent records the terminal size and re-solves the
 // layout.
-func (m *home) updateHandleWindowSizeEvent(msg tea.WindowSizeMsg) {
+func (m *home) updateHandleWindowSizeEvent(msg tea.WindowSizeMsg) tea.Cmd {
 	m.termWidth = msg.Width
 	m.termHeight = msg.Height
 	m.relayout()
+	return m.consumePaneAutoHideStatus()
 }
 
 // relayout is the single sizing path (#1024 PR 4): layout.Grid turns the
@@ -399,6 +406,7 @@ func (m *home) updateHandleWindowSizeEvent(msg tea.WindowSizeMsg) {
 // every WindowSizeMsg and whenever a grid input changes without a resize (a
 // pane opening or closing).
 func (m *home) relayout() {
+	previousVisible := append([]*store.OpenPane(nil), m.visiblePanes...)
 	// The grid is asked for every open pane; it honors at most MaxPanes of
 	// them (§2.6). The store then picks WHICH panes stay visible — the
 	// most-recently-focused ones, in workspace order — while the hidden
@@ -423,7 +431,11 @@ func (m *home) relayout() {
 		return
 	}
 
-	m.visiblePanes = m.store.VisibleOpenPanes(lay.PaneCount())
+	nextVisible := m.store.VisibleOpenPanes(lay.PaneCount())
+	if hidden := newlyAutoHiddenPane(previousVisible, nextVisible, m.store.OpenPanes()); hidden != nil {
+		m.setPaneAutoHideStatus(hidden, m.store.NumOpenPanes())
+	}
+	m.visiblePanes = nextVisible
 
 	// Rebuild the ring's pane entries to the visible set (auto-hidden panes
 	// leave the ring; the focused pane is most-recently-focused, so it is
@@ -472,6 +484,75 @@ func (m *home) relayout() {
 			}
 		}
 	}
+}
+
+func newlyAutoHiddenPane(previousVisible, nextVisible, openPanes []*store.OpenPane) *store.OpenPane {
+	if len(previousVisible) == 0 || len(openPanes) <= len(nextVisible) {
+		return nil
+	}
+	open := make(map[*store.OpenPane]bool, len(openPanes))
+	for _, p := range openPanes {
+		open[p] = true
+	}
+	visible := make(map[*store.OpenPane]bool, len(nextVisible))
+	for _, p := range nextVisible {
+		visible[p] = true
+	}
+	for _, p := range previousVisible {
+		if p != nil && open[p] && !visible[p] {
+			return p
+		}
+	}
+	return nil
+}
+
+func (m *home) setPaneAutoHideStatus(p *store.OpenPane, paneCount int) {
+	if p == nil || paneCount <= 1 {
+		return
+	}
+	msg := fmt.Sprintf("%s hidden: terminal too narrow for %d panes; resize wider%s",
+		paneStatusTitle(p), paneCount, paneRecoveryStatusHint())
+	m.pendingPaneAutoHideStatus = msg
+	m.errBox.SetError(errors.New(msg))
+}
+
+func paneStatusTitle(p *store.OpenPane) string {
+	if p == nil || p.Instance() == nil || p.Instance().Title == "" {
+		return "pane"
+	}
+	return p.Instance().Title
+}
+
+func paneRecoveryStatusHint() string {
+	if key := bindingKeyWithDesc("pane list"); key != "" {
+		return fmt.Sprintf(" or use `%s` pane list", key)
+	}
+	if binding, ok := keys.GlobalKeyBindings[keys.KeyOpenPane]; ok {
+		help := binding.Help()
+		if help.Key != "" && help.Desc != "" {
+			return fmt.Sprintf(" or use `%s` %s", help.Key, help.Desc)
+		}
+	}
+	return ""
+}
+
+func bindingKeyWithDesc(desc string) string {
+	for _, binding := range keys.GlobalKeyBindings {
+		help := binding.Help()
+		if help.Desc == desc && help.Key != "" {
+			return help.Key
+		}
+	}
+	return ""
+}
+
+func (m *home) consumePaneAutoHideStatus() tea.Cmd {
+	if m.pendingPaneAutoHideStatus == "" {
+		return nil
+	}
+	status := m.pendingPaneAutoHideStatus
+	m.pendingPaneAutoHideStatus = ""
+	return m.showTransientError(errors.New(status))
 }
 
 // syncFocus applies the focus ring's active region to the panes and the

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -166,8 +166,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		return m.handleKeyPress(msg)
 	case tea.WindowSizeMsg:
-		m.updateHandleWindowSizeEvent(msg)
-		return m, nil
+		return m, m.updateHandleWindowSizeEvent(msg)
 	case error:
 		return m, m.handleError(msg)
 	case runOnEventLoopMsg:

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -13,6 +13,13 @@ import (
 
 func (m *home) handleError(err error) tea.Cmd {
 	log.ErrorLog.Printf("%v", err)
+	return m.showTransientError(err)
+}
+
+func (m *home) showTransientError(err error) tea.Cmd {
+	if err == nil {
+		return nil
+	}
 	m.errBox.SetError(err)
 	return func() tea.Msg {
 		select {

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -960,6 +960,25 @@ func TestPane_OpenBeyondCapacityAutoHidesLRU(t *testing.T) {
 	assert.Equal(t, layout.PaneRegion(gamma.ID()), h.ring.Active(), "the new pane is focused")
 }
 
+func TestPane_AutoHideShowsTransientStatus(t *testing.T) {
+	h := paneTestHome(t)
+	resizeHome(h, layout.MultiPaneMinWidth-1, 40) // one pane fits
+
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+	pressKey(t, h, "s")
+	require.Equal(t, []string{"alpha"}, visibleTitles(h))
+
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	pressKey(t, h, "s")
+
+	require.Equal(t, 2, h.store.NumOpenPanes(), "the second pane still opens")
+	assert.Equal(t, []string{"beta"}, visibleTitles(h), "width pressure hides alpha and shows beta")
+	assert.Equal(t, "alpha hidden: terminal too narrow for 2 panes; resize wider or use `s` open pane",
+		h.errBox.FullError())
+}
+
 // TestPane_DegradationLadderWithNPanes drives the resize ladder with panes
 // open: minimal mode keeps exactly one pane, fallback renders the banner, and
 // growing back restores all bindings.


### PR DESCRIPTION
## Summary
- detect when relayout's width-pressure fitting moves a previously visible pane into the auto-hidden set
- show a transient status/error line naming the hidden session and total open pane count
- derive the recovery key text from the active keymap; this branch has no dedicated pane-list binding, so it falls back to the existing open-pane recovery binding instead of hardcoding `p`
- add a narrow-terminal pane model regression for opening a second pane

Closes #1420

## Tests
- gofmt -l $(git ls-files '*.go')
- go build ./...
- golangci-lint run --fast (installed CLI rejects top-level `golangci-lint --fast`)
- make lint-file-length
- $(go env GOPATH)/bin/deadcode -test ./...
- make tui-driver-selftest (24/24)
- make test-container