### PR TITLE
Stop numbering instance rows

### DIFF
--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -388,15 +388,16 @@ af_new_instance() {
 # GetSelectedInstance()), so requiring it forces `j` past the header until the
 # cursor truly lands on the row.
 af_select() {
-    local name="$1" _ screen
+    local name="$1" _ screen name_re
     [ -n "$name" ] || { _af_fail "af_select: name required"; return 1; }
+    name_re="$(_af_regex_escape "$name")"
     af_ensure_nav
     af_focus_tree || return 1
     for _ in $(seq 1 30); do af_send k; done
     sleep "$AF_DRIVER_POLL"
     for _ in $(seq 1 40); do
         screen="$(af_capture)"
-        if printf '%s\n' "$screen" | grep -qE -- "▾[[:space:]]+[0-9]+\.[[:space:]]+${name}([[:space:]]|\$)" \
+        if printf '%s\n' "$screen" | grep -qE -- "▾[[:space:]]+${name_re}([[:space:]]|\$)" \
            && printf '%s\n' "$screen" | grep -qE -- 'D kill'; then
             return 0
         fi
@@ -557,8 +558,9 @@ af_click() {
 
 # af_click_instance <name> — find <name>'s row on screen and click it.
 af_click_instance() {
-    local name="$1" line
-    line="$(af_capture | grep -nE "[0-9]+\.[[:space:]]+${name}([[:space:]]|\$)" | head -1 | cut -d: -f1)"
+    local name="$1" line name_re
+    name_re="$(_af_regex_escape "$name")"
+    line="$(af_capture | grep -nE "[▾▸][[:space:]]+${name_re}([[:space:]]|\$)" | head -1 | cut -d: -f1)"
     [ -n "$line" ] || { _af_fail "instance '$name' not visible to click"; return 1; }
     af_click 14 "$line"
 }
@@ -641,8 +643,9 @@ af_refute_screen() {
 # (its row carries the ▾ arrow). This is the two-line answer to the #1156
 # failure: af_select + af_expect_selected.
 af_expect_selected() {
-    local name="$1"
-    af_assert_screen "▾[[:space:]]+[0-9]+\.[[:space:]]+${name}([[:space:]]|\$)" \
+    local name="$1" name_re
+    name_re="$(_af_regex_escape "$name")"
+    af_assert_screen "▾[[:space:]]+${name_re}([[:space:]]|\$)" \
         "instance '${name}' selected"
 }
 

--- a/ui/sidebar_render.go
+++ b/ui/sidebar_render.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/ui/layout"
@@ -291,10 +290,6 @@ func (s *Sidebar) renderInstance(idx int, selected bool) string {
 		return ""
 	}
 	inst := instances[idx]
-	// Pad the index to the digit width of the largest 1-based index in the list
-	// so every row's prefix is the same width and the branch/PR lines align,
-	// without widening the common small-list case (#871, #923, #939).
-	s.renderer.SetIndexWidth(len(strconv.Itoa(len(instances))))
 	return s.renderer.Render(inst, idx+1, selected, s.proj.NumRepos() > 1, s.instanceExpanded(inst))
 }
 
@@ -310,7 +305,6 @@ func (s *Sidebar) renderTabRow(item SidebarItem, selected bool) string {
 	if item.TabIndex < 0 || item.TabIndex >= len(labels) {
 		return ""
 	}
-	s.renderer.SetIndexWidth(len(strconv.Itoa(len(instances))))
 	return s.renderer.RenderTab(labels[item.TabIndex], item.TabIndex+1,
 		item.TabIndex == len(labels)-1, selected, s.proj.ActiveTab() == item.TabIndex)
 }

--- a/ui/sidebar_tree_test.go
+++ b/ui/sidebar_tree_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -65,6 +66,8 @@ func TestSidebarTreeRendersTabChildren(t *testing.T) {
 	assert.Contains(t, out, "└ 2 Terminal", "terminal tab child with └ terminator")
 	assert.Contains(t, out, "▾", "selected instance shows the expanded arrow")
 	assert.Contains(t, out, "▸", "non-selected instance stays collapsed")
+	assert.NotRegexp(t, regexp.MustCompile(`\b\d+\.\s+t-\d\d`), out,
+		"instance rows must not render their position number")
 	assert.Equal(t, 2, tabRowCount(s), "only the selected instance contributes tab rows")
 
 	// The active-tab marker follows the store's active tab.

--- a/ui/tree/arrow_test.go
+++ b/ui/tree/arrow_test.go
@@ -36,7 +36,6 @@ func TestArrowCellMatchesRenderedArrow(t *testing.T) {
 
 	r := NewInstanceRenderer(&spin)
 	r.SetWidth(30)
-	r.SetIndexWidth(1)
 
 	x, y, ok := ArrowCell(30)
 	require.True(t, ok)

--- a/ui/tree/limit_render_test.go
+++ b/ui/tree/limit_render_test.go
@@ -17,7 +17,6 @@ func renderClean(t *testing.T, inst *session.Instance) string {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	r := NewInstanceRenderer(&spin)
 	r.SetWidth(80)
-	r.SetIndexWidth(2)
 	out := r.Render(inst, 1, false, false, false)
 	return ansiEscape.ReplaceAllString(out, "")
 }

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -2,7 +2,6 @@ package tree
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -160,14 +159,6 @@ type InstanceRenderer struct {
 	// usable column (its rect minus row padding), keeping the layout math in
 	// one place outside this package.
 	width int
-	// indexWidth is the number of digits to left-pad the 1-based row index to,
-	// so every row in a list shares one prefix width and the branch/PR lines
-	// stay aligned across power-of-10 boundaries (9→10, 99→100, …). The caller
-	// sets it to the digit count of the largest index in the list; a small list
-	// keeps the original single-digit prefix and pays no extra width. When it is
-	// 0 (or smaller than idx's own digit count) Render falls back to idx's width
-	// so the index is never truncated (#871, #923, #939).
-	indexWidth int
 }
 
 // NewInstanceRenderer creates a renderer sharing the app-wide spinner.
@@ -180,12 +171,6 @@ func (r *InstanceRenderer) SetWidth(width int) {
 	r.width = width
 }
 
-// SetIndexWidth sets the digit width of the largest 1-based instance index in
-// the rendered list. See the indexWidth field.
-func (r *InstanceRenderer) SetIndexWidth(digits int) {
-	r.indexWidth = digits
-}
-
 // ɹ and ɻ are other options.
 const branchIcon = "Ꮧ"
 
@@ -196,8 +181,8 @@ const branchIcon = "Ꮧ"
 // leading space. ok is false at ultra-narrow widths, where Render drops the
 // arrow from the prefix entirely (the #646 fallback) — the sidebar registers
 // no arrow zone then. Kept next to Render so the prefix layout and the hit
-// target can't drift apart; the render test pins them together against
-// actual output.
+// target can't drift apart; the render test pins them together against actual
+// output.
 func ArrowCell(w int) (x, y int, ok bool) {
 	if w <= 9 {
 		return 0, 0, false
@@ -205,25 +190,19 @@ func ArrowCell(w int) (x, y int, ok bool) {
 	return 2, 1, true
 }
 
+// instancePrefix renders the display-only tree prefix on instance rows. It
+// intentionally does not include the instance's 1-based index (#1494).
+func instancePrefix(arrow string, width int) string {
+	if width <= 9 {
+		return ""
+	}
+	return fmt.Sprintf(" %s ", arrow)
+}
+
 // Render renders an instance row. expanded selects the ▾/▸ tree arrow; a
 // non-expandable instance (see Expandable) renders a blank arrow cell so its
 // title stays aligned with its siblings.
-func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, hasMultipleRepos bool, expanded bool) string {
-	// Each extra digit grows the prefix by one cell, which shifts the
-	// prefix-width-derived branch/PR indentation and misaligns adjacent visible
-	// rows at every power-of-10 boundary (9→10, 99→100, 999→1000, …). Left-pad
-	// the NUMBER (right-justified) to a width derived from the largest index in
-	// the list so every row's prefix is the same width while the dot and full
-	// index are always preserved. An earlier trim-loop (#923) held width by
-	// deleting the rightmost char per tier, which corrupted content — dropping
-	// the dot at idx≥100 and a digit at idx≥1000 (e.g. 1000 rendered as "100").
-	// Padding keeps the same alignment without eating content, and because the
-	// width tracks the list size a small list still renders the original
-	// single-digit prefix (#871, #923, #939).
-	digits := r.indexWidth
-	if d := len(strconv.Itoa(idx)); d > digits {
-		digits = d
-	}
+func (r *InstanceRenderer) Render(i *session.Instance, _ int, selected bool, hasMultipleRepos bool, expanded bool) string {
 	arrow := nonExpandableArrow
 	if Expandable(i) {
 		if expanded {
@@ -232,14 +211,7 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 			arrow = collapsedArrow
 		}
 	}
-	prefix := fmt.Sprintf(" %s %*d. ", arrow, digits, idx)
-	if r.width <= 9 {
-		// At ultra-narrow widths the 2-cell arrow prefix overflows the sidebar
-		// container (the #646 overflow class the padding drop below also
-		// handles) and there is no room to render children anyway; fall back
-		// to the pre-tree prefix.
-		prefix = fmt.Sprintf(" %*d. ", digits, idx)
-	}
+	prefix := instancePrefix(arrow, r.width)
 	// The arrow is multibyte, so alignment math below must use the prefix's
 	// CELL width, never len(prefix).
 	prefixWidth := runewidth.StringWidth(prefix)
@@ -327,7 +299,11 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	if liveness == session.LiveLimitReached {
 		titleText = limitBadgePrefix(i) + titleText
 	}
-	widthAvail := r.width - 3 - prefixWidth - 1
+	prefixSepWidth := 0
+	if prefix != "" {
+		prefixSepWidth = 1
+	}
+	widthAvail := r.width - 3 - prefixWidth - prefixSepWidth
 	if widthAvail <= 0 {
 		// No room for any title text at this width; render just the prefix.
 		// lipgloss.Place doesn't clip oversize content, so leaving titleText
@@ -356,9 +332,13 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		titleS = titleS.PaddingLeft(0).PaddingRight(0)
 		descS = descS.PaddingLeft(0).PaddingRight(0)
 	}
+	titleContent := titleText
+	if prefix != "" {
+		titleContent = fmt.Sprintf("%s %s", prefix, titleText)
+	}
 	title := titleS.Render(lipgloss.JoinHorizontal(
 		lipgloss.Left,
-		lipgloss.Place(r.width-3, 1, lipgloss.Left, lipgloss.Center, fmt.Sprintf("%s %s", prefix, titleText)),
+		lipgloss.Place(r.width-3, 1, lipgloss.Left, lipgloss.Center, titleContent),
 		" ",
 		join,
 	))
@@ -440,14 +420,9 @@ func (r *InstanceRenderer) RenderTab(label string, oneBased int, isLast, selecte
 	if active {
 		marker = " *"
 	}
-	// Indent the connector to the instance title's start column: the instance
-	// prefix " ▸ <idx>. " is digits+5 cells wide (see Render), so children read
-	// as nested under their parent regardless of list size.
-	digits := r.indexWidth
-	if digits < 1 {
-		digits = 1
-	}
-	text := fmt.Sprintf("%s%s %d %s%s", strings.Repeat(" ", digits+5), connector, oneBased, label, marker)
+	text := fmt.Sprintf("%s%s %d %s%s",
+		strings.Repeat(" ", runewidth.StringWidth(instancePrefix(expandedArrow, r.width))),
+		connector, oneBased, label, marker)
 	if r.width > 0 && runewidth.StringWidth(text) > r.width {
 		// Same narrow-width handling as the instance rows: drop the "..." tail
 		// when it would itself overflow, since lipgloss.Place won't clip

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -28,11 +28,8 @@ func effectiveWidth(width int) int {
 
 // prLineIndent renders an instance at the given 1-based display index and
 // returns the number of leading whitespace cells in front of the "PR #" text.
-// The PR line is indented by the prefix's cell width plus a constant style
-// padding, so any idx-dependent change in the indent reflects a change in the
-// numbered prefix width (#871). indexWidth is pinned to 5 to model a list
-// large enough to contain idx=10000: every row in that list pads to 5 digits,
-// so all indices must share one indent (#923).
+// Instance indices are no longer rendered (#1494), so secondary-row indentation
+// must not change as idx crosses power-of-10 boundaries.
 func prLineIndent(t *testing.T, idx int, spin *spinner.Model) int {
 	t.Helper()
 	inst, err := session.NewInstance(session.InstanceOptions{
@@ -44,8 +41,7 @@ func prLineIndent(t *testing.T, idx int, spin *spinner.Model) int {
 	inst.SetPRInfo(&git.PRInfo{Number: 42, Title: "do a thing", State: "OPEN"})
 
 	r := NewInstanceRenderer(spin)
-	r.SetWidth(60)     // wide enough to render the full PR line
-	r.SetIndexWidth(5) // model a list whose largest index is 10000 (5 digits)
+	r.SetWidth(60) // wide enough to render the full PR line
 
 	out := r.Render(inst, idx, false, false, false)
 	for _, line := range strings.Split(out, "\n") {
@@ -58,18 +54,42 @@ func prLineIndent(t *testing.T, idx int, spin *spinner.Model) int {
 	return -1
 }
 
-// TestInstanceRendererPrefixAlignment guards against the regression in #871:
-// the numbered prefix width must stay constant as the index grows so adjacent
-// visible rows keep the same branch/PR indentation. Before the fix the prefix
-// grew by a cell at the 99→100 boundary (and the 9→10 boundary already worked).
-func TestInstanceRendererPrefixAlignment(t *testing.T) {
+// TestInstanceRendererOmitsInstanceIndex guards #1494: the sidebar row may
+// still carry tree arrows and state glyphs, but it must not render a leading
+// "1. title" / "42. title" instance index.
+func TestInstanceRendererOmitsInstanceIndex(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   "feature",
+		Path:    t.TempDir(),
+		Program: "test",
+	})
+	require.NoError(t, err)
+
+	r := NewInstanceRenderer(&spin)
+	r.SetWidth(60)
+	indexPrefix := regexp.MustCompile(`\b\d+\.\s+feature`)
+	for _, idx := range []int{1, 9, 10, 99, 100, 10000} {
+		out := r.Render(inst, idx, false, false, false)
+		lines := strings.Split(ansiEscape.ReplaceAllString(out, ""), "\n")
+		require.GreaterOrEqual(t, len(lines), 2)
+		assert.Contains(t, lines[1], "feature")
+		assert.NotRegexp(t, indexPrefix, lines[1],
+			"instance row rendered the display index at idx=%d", idx)
+	}
+}
+
+// TestInstanceRendererSecondaryIndentIgnoresIndex keeps the branch/PR
+// indentation stable now that idx is display-only input rather than a rendered
+// prefix component.
+func TestInstanceRendererSecondaryIndentIgnoresIndex(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 
 	base := prLineIndent(t, 1, &spin)
 	for _, idx := range []int{9, 10, 11, 99, 100, 101, 999, 1000, 1001, 9999, 10000} {
 		got := prLineIndent(t, idx, &spin)
 		require.Equalf(t, base, got,
-			"PR line indent at idx=%d (%d) must match idx=1 (%d); prefix width drifted",
+			"PR line indent at idx=%d (%d) must match idx=1 (%d); idx leaked into display",
 			idx, got, base)
 	}
 }
@@ -190,10 +210,10 @@ func TestInstanceRendererNarrowTerminalPRNoTail(t *testing.T) {
 		State:  "OPEN",
 	})
 
-	// terminalW=28..32 produces prMaxWidth in {1, 2}, which is the bug
+	// terminalW=14..18 produces prMaxWidth in {1, 2}, which is the bug
 	// range where the pre-fix code passed a negative width to
 	// runewidth.Truncate and got back "..." (wider than prMaxWidth).
-	for _, terminalW := range []int{28, 30, 32} {
+	for _, terminalW := range []int{14, 16, 18} {
 		_, prLine, _ := renderForTerminal(t, terminalW, inst, &spin)
 		trimmed := strings.TrimRight(prLine, " ")
 		assert.Falsef(t, strings.HasSuffix(trimmed, "..."),
@@ -366,8 +386,9 @@ func TestInstanceRendererTreeArrow(t *testing.T) {
 	transient := strings.Split(r.Render(inst, 1, false, false, false), "\n")[1]
 	assert.NotContains(t, transient, collapsedArrow, "transient rows are not expandable")
 	assert.NotContains(t, transient, expandedArrow, "transient rows are not expandable")
-	// The blank arrow cell keeps the numbered prefix aligned with siblings.
-	assert.Contains(t, ansiEscape.ReplaceAllString(transient, ""), "   1. ")
+	clean := ansiEscape.ReplaceAllString(transient, "")
+	assert.Contains(t, clean, "arrowed")
+	assert.NotRegexp(t, regexp.MustCompile(`\b\d+\.\s+arrowed`), clean)
 }
 
 // TestRenderTabRows pins the tab child row shape: ├/└ connectors, the 1-based
@@ -377,7 +398,6 @@ func TestRenderTabRows(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	r := NewInstanceRenderer(&spin)
 	r.SetWidth(30)
-	r.SetIndexWidth(1)
 
 	mid := ansiEscape.ReplaceAllString(r.RenderTab("Agent", 1, false, false, true), "")
 	assert.Contains(t, mid, "├ 1 Agent *", "active non-last tab: ├ connector + slot number + * marker")


### PR DESCRIPTION
## Summary
- stop rendering the sidebar instance position prefix while preserving tree arrows, state markers, and secondary-row alignment
- keep tab child row slot numbers for the 1-9 jump keys
- update the TUI driver row matcher and add renderer/sidebar coverage for unnumbered instance rows

Closes #1494

## Tests
- gofmt
- golangci-lint run --fast
- go build ./...
- make test-container
- deadcode -test ./...
- make lint-file-length
- bash -n scripts/tui-driver.sh scripts/tui-driver-selftest.sh
- make tui-driver-selftest (24/24)
