### PR TITLE
test(tui-driver): disable startup auto-update during selftest

### DIFF
--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -41,8 +41,14 @@
 : "${AF_DRIVER_POLL:=0.25}"                       # capture-pane poll interval
 : "${AF_DRIVER_DETACH_KEY:=C-w}"                 # tmux key that detaches attach
 : "${AF_DRIVER_STATE_DIR:=${TMPDIR:-/tmp}/af-driver}"  # cross-call scratch
+: "${AGENT_FACTORY_AUTO_UPDATE:=false}"          # disable startup auto-update: a
+                                                 # branch binary built behind the
+                                                 # latest release would try to
+                                                 # self-update mid-test and time
+                                                 # out instance creation.
 
 export AGENT_FACTORY_HOME
+export AGENT_FACTORY_AUTO_UPDATE
 
 # ----------------------------------------------------------------------------
 # Low-level plumbing.


### PR DESCRIPTION
**Root cause of the recent string of 'create instance alpha' selftest timeouts.** After #1471 (startup auto-update), a PR-branch af binary built BEHIND the latest release triggers the startup auto-update mid-selftest — it blocks/slows startup while trying to download+swap, so 'create instance alpha' times out (25s). Master (built at the latest version) sees no update and passes, which is why only behind-master branches false-failed (#1486/#1488/#1489/#1495/#1497 all hit this).

**Fix:** set `AGENT_FACTORY_AUTO_UPDATE=false` in the tui-driver env (the opt-out from #1471) so the TUI under test never self-updates during a play-test. Verified: selftest still 24/24 green.

This removes a whole class of play-test false-failures on behind-master branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>