### PR TITLE
Slugify session titles in worktree paths

### DIFF
--- a/session/git/util.go
+++ b/session/git/util.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	reUnsafe    = regexp.MustCompile(`[^a-z0-9\-_/.]+`)
-	reMultiDash = regexp.MustCompile(`-+`)
+	reUnsafe                    = regexp.MustCompile(`[^a-z0-9\-_/.]+`)
+	reUnsafeWorktreePathSegment = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+	reMultiDash                 = regexp.MustCompile(`-+`)
 )
 
 // SanitizeBranchName transforms an arbitrary string into a Git branch name friendly string.
@@ -93,6 +94,21 @@ func trimBranchNameEdges(s string) string {
 // validation and the TUI's pre-submit naming check derive branches identically.
 func BranchForTitle(branchPrefix, title string) string {
 	return SanitizeBranchName(branchPrefix + title)
+}
+
+// sanitizeWorktreePathSegment turns a display title into one filesystem path
+// segment for AF-owned worktree directories. It preserves ordinary title case
+// for readability while removing separators/traversal and replacing whitespace
+// or shell-hostile punctuation with dashes.
+func sanitizeWorktreePathSegment(title string) string {
+	s := reUnsafeWorktreePathSegment.ReplaceAllString(title, "-")
+	s = strings.ReplaceAll(s, "..", "")
+	s = reMultiDash.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-.")
+	if s == "" {
+		return "session"
+	}
+	return s
 }
 
 // TitlesCollide reports whether two session titles cannot coexist in the same

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -158,13 +158,7 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		return nil, "", err
 	}
 
-	// Sanitize sessionName for filesystem path to prevent directory traversal
-	safeSessionName := strings.ReplaceAll(sessionName, "..", "")
-	safeSessionName = strings.ReplaceAll(safeSessionName, "/", "-")
-	safeSessionName = strings.TrimLeft(safeSessionName, "-.")
-	if safeSessionName == "" {
-		safeSessionName = "session"
-	}
+	safeSessionName := sanitizeWorktreePathSegment(sessionName)
 
 	var basePath string
 	if cfg.WorktreeRoot == config.WorktreeRootSubdirectory {

--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -27,14 +26,7 @@ func SiblingWorktreePath(repoPath, title string) (string, error) {
 	worktreeDir := filepath.Dir(repoRoot)
 	repoName := filepath.Base(repoRoot)
 
-	// Sanitize the title into a single safe path segment, matching the
-	// safeSessionName handling in NewGitWorktree.
-	safe := strings.ReplaceAll(title, "..", "")
-	safe = strings.ReplaceAll(safe, "/", "-")
-	safe = strings.TrimLeft(safe, "-.")
-	if safe == "" {
-		safe = "session"
-	}
+	safe := sanitizeWorktreePathSegment(title)
 
 	base := filepath.Join(worktreeDir, repoName+"-"+safe)
 	absBase, _ := filepath.Abs(base)

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -277,6 +277,11 @@ func TestSiblingWorktreePath_DefaultCollisionAndSanitize(t *testing.T) {
 	ps, err := SiblingWorktreePath(repoRoot, "a/b..c")
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(parent, "repo-a-bc"), ps)
+
+	spaced, err := SiblingWorktreePath(repoRoot, "Review Threads")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(parent, "repo-Review-Threads"), spaced)
+	assert.NotContains(t, filepath.Base(spaced), " ")
 }
 
 // TestMoveWorktree_RepairFailureStillCommitsLocation (#1028 Greptile P1): in the

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -102,6 +102,26 @@ func TestNewGitWorktree_CleanName(t *testing.T) {
 	assert.Equal(t, filepath.Dir(repoRoot), filepath.Dir(gw.GetWorktreePath()))
 }
 
+func TestNewGitWorktree_SpaceTitleUsesSluggedSiblingPath(t *testing.T) {
+	sandboxHome(t)
+
+	repoRoot := createGitRepo(t)
+	repoName := filepath.Base(repoRoot)
+
+	cfg := config.DefaultConfig()
+	cfg.BranchPrefix = "test/"
+	require.NoError(t, config.SaveConfig(cfg))
+
+	gw, branchName, err := NewGitWorktree(repoRoot, "Review Threads")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test/review-threads", branchName)
+	assert.Equal(t, "Review Threads", gw.sessionName)
+	assert.NotContains(t, filepath.Base(gw.GetWorktreePath()), " ")
+	assert.True(t, strings.HasSuffix(gw.GetWorktreePath(), repoName+"-Review-Threads"),
+		"expected slugged worktree path, got: %s", gw.GetWorktreePath())
+}
+
 func TestNewGitWorktree_SubdirectoryCleanName(t *testing.T) {
 	sandboxHome(t)
 


### PR DESCRIPTION
Closes #1500

## Summary
- slugify AF-owned sibling worktree path segments derived from session titles
- preserve display titles and persisted storage paths while sharing create/restore path derivation
- add regression coverage for spaced titles in fresh and restore-side worktree paths

## Verification
- make test-container GOTESTARGS="./session/git"
- gofmt -l $(git ls-files '*.go')\n- go build ./...\n- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run --timeout=3m --fast-only --max-issues-per-linter=0 --max-same-issues=0\n- make test-container\n- go run golang.org/x/tools/cmd/deadcode@latest -test ./...\n- make lint-file-length\n\nNote: the workflow-pinned golangci-lint v1.64.8 and deadcode v0.36.0 analyzer invocations fail locally before analysis because their analyzer binaries report Go 1.23 against this Go 1.24.2 module; I reran both gates with current Go-toolchain-compatible versions.