### PR TITLE
Skip repo registration for unstarted projections

### DIFF
--- a/ui/store/projection.go
+++ b/ui/store/projection.go
@@ -202,6 +202,9 @@ func (p *Projection) sortInstances() {
 // RegisterRepoForInstance records the instance's repo after the instance has
 // started and its worktree is available.
 func (p *Projection) RegisterRepoForInstance(instance *session.Instance) {
+	if !instance.Started() {
+		return
+	}
 	repoName, err := instance.RepoName()
 	if err != nil {
 		log.ErrorLog.Printf("could not get repo name: %v", err)

--- a/ui/store/projection_test.go
+++ b/ui/store/projection_test.go
@@ -34,6 +34,22 @@ func newUnstartedProjectionInstance(t *testing.T, title string) *session.Instanc
 }
 
 func TestProjectionRemoveUnstartedInstanceDoesNotLogError(t *testing.T) {
+	t.Run("RegisterRepoForInstance", func(t *testing.T) {
+		errLog := captureProjectionErrorLog(t)
+		p := NewProjection()
+		inst := newUnstartedProjectionInstance(t, "unstarted-register")
+
+		finalize := p.AddInstance(inst)
+		finalize()
+
+		if got := p.NumRepos(); got != 0 {
+			t.Fatalf("NumRepos() = %d, want 0", got)
+		}
+		if got := errLog.String(); got != "" {
+			t.Fatalf("ErrorLog = %q, want empty", got)
+		}
+	})
+
 	t.Run("KillInstance", func(t *testing.T) {
 		errLog := captureProjectionErrorLog(t)
 		p := NewProjection()


### PR DESCRIPTION
Closes #1499

## Summary
- skip projection repo registration while an instance is still unstarted
- keep unexpected started-instance repo lookup failures on ErrorLog
- extend the unstarted projection regression test to cover the AddInstance finalizer path

## Verification
- make test-container GOTESTARGS="./ui/store"
- gofmt -l $(git ls-files '*.go')\n- go build ./...\n- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run --timeout=3m --fast-only --max-issues-per-linter=0 --max-same-issues=0\n- make test-container\n- go run golang.org/x/tools/cmd/deadcode@latest -test ./...\n- make lint-file-length\n- make tui-driver-selftest (24/24)\n\nNote: the workflow-pinned golangci-lint v1.64.8 and deadcode v0.36.0 analyzer invocations fail locally before analysis because their analyzer binaries report Go 1.23 against this Go 1.24.2 module; I reran both gates with current Go-toolchain-compatible versions.