### PR TITLE
Fix tui driver literal tmux payloads

### DIFF
--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -93,6 +93,20 @@ _expect_wrapped_send_no_timeout() {
     return "$rc"
 }
 
+# _enter_interactive_and_probe_literal_send — regression proof for #1504. The
+# literal sender used to pass the text as tmux command arguments, so leading
+# hyphens were parsed as flags and repeated semicolons were parsed as command
+# separators. Type but do not run the probe, then clear the shell line.
+# shellcheck disable=SC2317  # dispatched indirectly via step(); not dead code.
+_enter_interactive_and_probe_literal_send() {
+    local text='- item ;; literal-send-1504'
+    af_enter_interactive || return 1
+    af_send_literal "$text" || return 1
+    _af_wait_for_pane_echo "$text" 8 "literal send preserves leading hyphen and ;;" || return 1
+    af_send C-u
+    sleep "$AF_DRIVER_POLL"
+}
+
 printf '=== tui-driver self-test (#1161) ===\n'
 printf 'session=%s size=%sx%s home=%s\n' \
     "$AF_DRIVER_SESSION" "$AF_DRIVER_COLS" "$AF_DRIVER_ROWS" "$AGENT_FACTORY_HOME"
@@ -130,7 +144,7 @@ step "select beta"                                          af_select beta
 step "assert beta is selected"                              af_expect_selected beta
 
 step "open beta's tab as a pane"                            af_open_pane
-step "enter interactive mode"                               af_enter_interactive
+step "enter interactive mode and probe literal send"         _enter_interactive_and_probe_literal_send
 step "send a wrapped command without echo false-timeout"     _expect_wrapped_send_no_timeout
 # The command COMPUTES its marker (arithmetic expansion), so the sentinel we
 # assert on — SELFTEST_42 — appears ONLY in the command's output, never in the

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -66,9 +66,16 @@ af_capture() { tmux capture-pane -p -t "$AF_DRIVER_SESSION" 2>/dev/null; }
 # Escape, 'C-]', or literal chars). Keys are interpreted by tmux.
 af_send() { tmux send-keys -t "$AF_DRIVER_SESSION" "$@"; }
 
-# af_send_literal <string> — deliver a string verbatim (no key-name parsing);
-# also the injection path for raw SGR mouse sequences.
-af_send_literal() { tmux send-keys -t "$AF_DRIVER_SESSION" -l "$1"; }
+# af_send_literal <string> — deliver a string verbatim; also the injection path
+# for raw SGR mouse sequences. Use a tmux paste buffer so the payload is stdin
+# data, not tmux command syntax (`-foo`, `;;`, and friends stay literal).
+af_send_literal() {
+    local text="$1" buffer
+    [ -n "$text" ] || return 0
+    buffer="af-driver-literal-${BASHPID:-$$}-${RANDOM}"
+    printf '%s' "$text" | tmux load-buffer -b "$buffer" - || return 1
+    tmux paste-buffer -r -d -t "$AF_DRIVER_SESSION" -b "$buffer"
+}
 
 # _af_resolve_bin — the af binary to launch/readiness-check. Prefer PATH, fall
 # back to the container's build output.


### PR DESCRIPTION
Closes #1504

## Summary
- send literal driver payloads through a tmux paste buffer so tmux does not parse leading hyphens or semicolons as command syntax
- add a selftest probe that types a leading-hyphen string containing `;;` and waits for the exact echo while preserving the 24/24 step count

## Tests
- shellcheck scripts/tui-driver.sh scripts/tui-driver-selftest.sh
- make tui-driver-selftest
- go build ./...
- make test-container