### PR TITLE
Share strict path containment helper

### DIFF
--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/pelletier/go-toml/v2"
+	"github.com/sachiniyer/agent-factory/internal/pathutil"
 	"github.com/sachiniyer/agent-factory/log"
 	"golang.org/x/sys/unix"
 )
@@ -114,24 +115,6 @@ var tomlOnlyGlobalKeys = map[string]bool{
 	"keys": true,
 }
 
-// isPathStrictlyInside reports whether absBase is a strict descendant of
-// absDir (absBase != absDir and absBase is not outside absDir). Both
-// arguments must be absolute, cleaned paths. Built on filepath.Rel rather
-// than strings.HasPrefix(path, dir+Separator) because the latter constructs
-// "//" when dir is the filesystem root, rejecting valid children of a repo
-// rooted at "/" (#852). Duplicates session/git.isPathStrictlyInside, which
-// this package cannot import without a cycle.
-func isPathStrictlyInside(absBase, absDir string) bool {
-	rel, err := filepath.Rel(absDir, absBase)
-	if err != nil {
-		return false
-	}
-	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return false
-	}
-	return true
-}
-
 // InRepoConfigPath returns the path of the in-repo JSON config file for a
 // repo root. The file is optional; callers should use LoadInRepoConfig rather
 // than reading this path directly so symlink and file-type guards apply.
@@ -227,7 +210,7 @@ func readInRepoConfigFile(repoRoot string) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to resolve repo root %s: %w", repoRoot, err)
 	}
-	if !isPathStrictlyInside(resolved, filepath.Clean(resolvedRoot)) {
+	if !pathutil.IsStrictlyInside(resolved, filepath.Clean(resolvedRoot)) {
 		return nil, "", fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to read it", prettyHomePath(path), prettyHomePath(resolved))
 	}
 
@@ -423,7 +406,7 @@ func inRepoConfigWriteTarget(repoRoot, path string) (string, string, error) {
 			return "", "", fmt.Errorf("failed to resolve in-repo config %s: %w", prettyHomePath(path), err)
 		}
 		resolvedPath = filepath.Clean(resolvedPath)
-		if !isPathStrictlyInside(resolvedPath, resolvedRoot) {
+		if !pathutil.IsStrictlyInside(resolvedPath, resolvedRoot) {
 			return "", "", fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to save it", prettyHomePath(path), prettyHomePath(resolvedPath))
 		}
 		return filepath.Dir(resolvedPath), filepath.Base(resolvedPath), nil
@@ -441,7 +424,7 @@ func inRepoConfigWriteTarget(repoRoot, path string) (string, string, error) {
 	}
 	resolvedDir = filepath.Clean(resolvedDir)
 	resolvedPath := filepath.Join(resolvedDir, filepath.Base(path))
-	if !isPathStrictlyInside(resolvedPath, resolvedRoot) {
+	if !pathutil.IsStrictlyInside(resolvedPath, resolvedRoot) {
 		return "", "", fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to save it", prettyHomePath(path), prettyHomePath(resolvedPath))
 	}
 	return resolvedDir, filepath.Base(path), nil
@@ -561,7 +544,7 @@ func SaveInRepoPostWorktreeCommands(repoRoot string, commands []string) error {
 	// dir symlinked outside the repo must not receive the save. The read
 	// guard alone can't cover this — it only fires when the config file
 	// already exists at the resolved location.
-	if !isPathStrictlyInside(resolvedPath, resolveSymlinksForCompare(repoRoot)) {
+	if !pathutil.IsStrictlyInside(resolvedPath, resolveSymlinksForCompare(repoRoot)) {
 		return fmt.Errorf("in-repo config %s resolves outside the repository (to %s); refusing to save it", prettyHomePath(path), prettyHomePath(resolvedPath))
 	}
 	data, _, err := readInRepoConfigFile(repoRoot)

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -216,35 +216,6 @@ func TestSaveInRepoPostWorktreeCommandsNull(t *testing.T) {
 	assert.Contains(t, err.Error(), prettyHomePath(path))
 }
 
-// TestIsPathStrictlyInside is the regression test for #852: the previous
-// strings.HasPrefix(path, root+Separator) check built the prefix "//" for a
-// repo rooted at the filesystem root (real in containers with WORKDIR /),
-// rejecting every valid child. The Rel-based helper must accept children of
-// "/" while still rejecting equality, siblings, and traversal escapes.
-func TestIsPathStrictlyInside(t *testing.T) {
-	sep := string(filepath.Separator)
-	cases := []struct {
-		name    string
-		absBase string
-		absDir  string
-		want    bool
-	}{
-		{"child of filesystem root", filepath.Join(sep, ".agent-factory", "config.json"), sep, true},
-		{"filesystem root is not inside itself", sep, sep, false},
-		{"child of normal repo", filepath.Join(sep, "repo", InRepoConfigDirName, "config.json"), filepath.Join(sep, "repo"), true},
-		{"repo root is not inside itself", filepath.Join(sep, "repo"), filepath.Join(sep, "repo"), false},
-		{"sibling sharing a string prefix", filepath.Join(sep, "repo2"), filepath.Join(sep, "repo"), false},
-		{"parent of the repo", sep, filepath.Join(sep, "repo"), false},
-		{"path outside the repo", filepath.Join(sep, "outside", "config.json"), filepath.Join(sep, "repo"), false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, isPathStrictlyInside(tc.absBase, tc.absDir),
-				"isPathStrictlyInside(%q, %q)", tc.absBase, tc.absDir)
-		})
-	}
-}
-
 func TestLoadInRepoConfigTraversalSafety(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 

--- a/internal/pathutil/inside.go
+++ b/internal/pathutil/inside.go
@@ -1,0 +1,20 @@
+package pathutil
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// IsStrictlyInside reports whether absBase is a strict descendant of absDir
+// (absBase != absDir and absBase is not outside absDir). Both arguments must
+// be absolute, cleaned paths.
+func IsStrictlyInside(absBase, absDir string) bool {
+	rel, err := filepath.Rel(absDir, absBase)
+	if err != nil {
+		return false
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}

--- a/internal/pathutil/inside_test.go
+++ b/internal/pathutil/inside_test.go
@@ -1,0 +1,32 @@
+package pathutil
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsStrictlyInside(t *testing.T) {
+	sep := string(filepath.Separator)
+	cases := []struct {
+		name    string
+		absBase string
+		absDir  string
+		want    bool
+	}{
+		{"child of filesystem root", filepath.Join(sep, ".agent-factory", "config.json"), sep, true},
+		{"filesystem root is not inside itself", sep, sep, false},
+		{"child of normal dir", filepath.Join(sep, "repo", ".agent-factory", "config.json"), filepath.Join(sep, "repo"), true},
+		{"dir is not inside itself", filepath.Join(sep, "repo"), filepath.Join(sep, "repo"), false},
+		{"sibling sharing a string prefix", filepath.Join(sep, "repo2"), filepath.Join(sep, "repo"), false},
+		{"parent of the dir", sep, filepath.Join(sep, "repo"), false},
+		{"path outside the dir", filepath.Join(sep, "outside", "config.json"), filepath.Join(sep, "repo"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsStrictlyInside(tc.absBase, tc.absDir),
+				"IsStrictlyInside(%q, %q)", tc.absBase, tc.absDir)
+		})
+	}
+}

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -8,22 +8,9 @@ import (
 	"strings"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/internal/pathutil"
 	"github.com/sachiniyer/agent-factory/log"
 )
-
-// isPathStrictlyInside reports whether absBase is a strict descendant of
-// absDir (absBase != absDir and absBase is not outside absDir). Both
-// arguments must be absolute, cleaned paths.
-func isPathStrictlyInside(absBase, absDir string) bool {
-	rel, err := filepath.Rel(absDir, absBase)
-	if err != nil {
-		return false
-	}
-	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return false
-	}
-	return true
-}
 
 func getWorktreeDirectoryForRepo(repoPath string) (string, error) {
 	cfg, err := config.LoadConfig()
@@ -175,7 +162,7 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 	// produces "//" and rejects every valid child path. See #461.
 	absBase, _ := filepath.Abs(basePath)
 	absDir, _ := filepath.Abs(worktreeDir)
-	if !isPathStrictlyInside(absBase, absDir) {
+	if !pathutil.IsStrictlyInside(absBase, absDir) {
 		return nil, "", fmt.Errorf("invalid session name: would create worktree outside expected directory")
 	}
 

--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/sachiniyer/agent-factory/internal/pathutil"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
@@ -31,7 +32,7 @@ func SiblingWorktreePath(repoPath, title string) (string, error) {
 	base := filepath.Join(worktreeDir, repoName+"-"+safe)
 	absBase, _ := filepath.Abs(base)
 	absDir, _ := filepath.Abs(worktreeDir)
-	if !isPathStrictlyInside(absBase, absDir) {
+	if !pathutil.IsStrictlyInside(absBase, absDir) {
 		return "", fmt.Errorf("invalid session title %q: would place worktree outside %s", title, worktreeDir)
 	}
 

--- a/session/git/worktree_test.go
+++ b/session/git/worktree_test.go
@@ -753,31 +753,6 @@ func TestGetWorktreeDirectoryForRepo_FromLinkedWorktree(t *testing.T) {
 		"new worktrees should be placed next to the main repo, not next to a linked worktree")
 }
 
-// TestIsPathStrictlyInside covers the containment check used to validate that
-// a derived worktree path lives under the configured worktree directory. The
-// `/`-root cases exercise the fix for #461.
-func TestIsPathStrictlyInside(t *testing.T) {
-	cases := []struct {
-		name    string
-		absBase string
-		absDir  string
-		want    bool
-	}{
-		{"nested under home", "/home/user/repo-session", "/home/user", true},
-		{"nested under root", "/repo-session", "/", true},
-		{"sibling directory", "/home/user2/foo", "/home/user", false},
-		{"equal to dir", "/home/user", "/home/user", false},
-		{"equal to root", "/", "/", false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := isPathStrictlyInside(tc.absBase, tc.absDir)
-			assert.Equal(t, tc.want, got,
-				"isPathStrictlyInside(%q, %q)", tc.absBase, tc.absDir)
-		})
-	}
-}
-
 func createGitRepo(t *testing.T) string {
 	t.Helper()
 	repoRoot := filepath.Join(t.TempDir(), "repo")


### PR DESCRIPTION
## Summary
- move the duplicated strict path containment check from `config` and `session/git` into `internal/pathutil`
- keep one shared regression matrix for the filesystem-root and sibling-prefix cases
- route in-repo config and worktree placement guards through the shared helper

## Why this is behavior-preserving
The helper body is the same `filepath.Rel`-based logic that both packages already used. Callers still pass the same absolute/cleaned paths in the same order; only the implementation location changed. This removes one duplicated abstraction that could drift after the #1195 structural-health work.

## Validation
- `gofmt -l .`
- `scripts/lint-file-length.sh`
- `go build ./...`
- `golangci-lint run --timeout=3m --fast`
- `deadcode -test ./...`
- `make test-container`

Part of #1241. Related to #1195.

Signed-off-by: Captain Claude
