### PR TITLE
TUI: add configurable Zenburn theme

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -244,10 +244,10 @@ func (m *home) layoutTextOverlay() {
 }
 
 var (
-	titleStyle  = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(ui.AccentColor)
-	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#36CFC9"))
-	keyStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
-	descStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFFFF"))
+	titleStyle  = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(ui.CurrentTheme().Accent)
+	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(ui.CurrentTheme().Info)
+	keyStyle    = lipgloss.NewStyle().Bold(true).Foreground(ui.CurrentTheme().Warning)
+	descStyle   = lipgloss.NewStyle().Foreground(ui.CurrentTheme().Foreground)
 )
 
 // showHelpScreen displays the help screen overlay if it hasn't been shown

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -303,6 +303,7 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 		fmt.Printf("Failed to load config: %v\n", err)
 		os.Exit(1)
 	}
+	applyTheme(appConfig.Theme)
 
 	// Apply configured detach key
 	if appConfig.DetachKeys != "" {

--- a/app/render.go
+++ b/app/render.go
@@ -167,7 +167,7 @@ func paneOverlayContentRect(styleRect layout.Rect) layout.Rect {
 // splitDividerStyle recedes the 1-col dividers between panes so the focused
 // pane's frame stays the strongest line on screen.
 var splitDividerStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#DDDADA", Dark: "#3C3C3C"})
+	Foreground(ui.CurrentTheme().BackgroundSubtle)
 
 // renderDivider renders the 1-col divider right of pane i (§2.6: "N panes
 // divide the workspace width evenly with 1-col dividers").

--- a/app/theme.go
+++ b/app/theme.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/ui"
+)
+
+func applyTheme(cfg config.ThemeConfig) {
+	ui.ApplyTheme(cfg)
+	t := ui.CurrentTheme()
+	hooksOverlayStyle = lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(t.Accent).
+		Padding(1, 2)
+	splitDividerStyle = lipgloss.NewStyle().
+		Foreground(t.BackgroundSubtle)
+	titleStyle = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(t.Accent)
+	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(t.Info)
+	keyStyle = lipgloss.NewStyle().Bold(true).Foreground(t.Warning)
+	descStyle = lipgloss.NewStyle().Foreground(t.Foreground)
+}

--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -74,6 +74,7 @@ func configEntries(cfg *config.Config) []configEntry {
 		{"worktree_root", cfg.WorktreeRoot},
 		{"detach_keys", cfg.DetachKeys},
 		{"update_channel", cfg.UpdateChannel},
+		{"theme", cfg.Theme},
 		{"root_agents", cfg.RootAgents},
 		{"limit_patterns", cfg.LimitPatterns},
 		{"keys", cfg.KeymapOverrides()},
@@ -201,7 +202,7 @@ Settable keys:
   update_channel             stable | preview
   limit_patterns.<agent>     usage-limit banner regex for an agent
 
-Structural keys (root_agents, the [keys] rebind table) are not settable here —
+Structural keys (root_agents, [theme], the [keys] rebind table) are not settable here —
 edit config.toml directly. Changes apply on the next af / daemon start.
 
 Examples:

--- a/commands/configcmd_test.go
+++ b/commands/configcmd_test.go
@@ -77,7 +77,7 @@ func TestFormatConfigValue(t *testing.T) {
 }
 
 // TestConfigEntriesCoverAllKeys guards that configEntries lists exactly the
-// documented settable top-level config keys — if a key is added to the Config
+// documented top-level global config keys — if a key is added to the Config
 // struct, this fails until the entry (and docs) are updated.
 func TestConfigEntriesCoverAllKeys(t *testing.T) {
 	got := map[string]bool{}
@@ -90,7 +90,7 @@ func TestConfigEntriesCoverAllKeys(t *testing.T) {
 	want := []string{
 		"default_program", "program_overrides", "auto_yes", "auto_update", "daemon_poll_interval",
 		"log_max_size_mb", "log_max_backups", "branch_prefix", "detach_keys",
-		"worktree_root", "update_channel", "root_agents", "limit_patterns", "keys",
+		"worktree_root", "update_channel", "theme", "root_agents", "limit_patterns", "keys",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("configEntries has %d keys, want %d", len(got), len(want))

--- a/config/config_parse.go
+++ b/config/config_parse.go
@@ -156,6 +156,7 @@ func validateConfig(config *Config, prettyConfigPath string) (*Config, error) {
 	}
 
 	sanitizeLimitPatterns(config)
+	sanitizeThemeColors(config, prettyConfigPath)
 	config.LimitRetryInterval = sanitizeLimitRetryInterval(config.LimitRetryInterval, prettyConfigPath)
 	config.WorktreeRoot = normalizeWorktreeRoot(config.WorktreeRoot, prettyConfigPath)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
+	stdlog "log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -340,6 +342,7 @@ func TestDefaultConfig(t *testing.T) {
 		assert.True(t, cfg.AutoUpdate)
 		assert.Equal(t, 1000, cfg.DaemonPollInterval)
 		assert.Equal(t, UpdateChannelStable, cfg.UpdateChannel)
+		assert.Equal(t, DefaultThemeConfig(), cfg.Theme)
 		assert.NotEmpty(t, cfg.BranchPrefix)
 		assert.True(t, strings.HasSuffix(cfg.BranchPrefix, "/"))
 		assert.Equal(t, WorktreeRootSibling, cfg.WorktreeRoot)
@@ -899,6 +902,9 @@ func TestLoadConfig(t *testing.T) {
 		assert.Contains(t, string(data), `update_channel = 'stable'`)
 		assert.Contains(t, string(data), `auto_update = true`)
 		assert.Contains(t, string(data), `worktree_root = 'sibling'`)
+		assert.Contains(t, string(data), `[theme]`)
+		assert.Contains(t, string(data), `accent = '#8CD0D3'`)
+		assert.Contains(t, string(data), `pane_border_preview = '#DC8CC3'`)
 
 		// The materialized file must reload cleanly through the TOML path.
 		cfg, err := LoadConfig()
@@ -1014,6 +1020,11 @@ daemon_poll_interval = 2000
 branch_prefix = "test/"
 worktree_root = "subdirectory"
 
+[theme]
+accent = "#abcdef"
+foreground = "#010203"
+pane_border_preview = "#aabbcc"
+
 [program_overrides]
 claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 codex = "/opt/codex/bin/codex --quiet"
@@ -1027,10 +1038,36 @@ codex = "/opt/codex/bin/codex --quiet"
 		assert.Equal(t, 2000, cfg.DaemonPollInterval)
 		assert.Equal(t, "test/", cfg.BranchPrefix)
 		assert.Equal(t, WorktreeRootSubdirectory, cfg.WorktreeRoot)
+		assert.Equal(t, "#ABCDEF", cfg.Theme.Accent)
+		assert.Equal(t, "#010203", cfg.Theme.Foreground)
+		assert.Equal(t, "#AABBCC", cfg.Theme.PaneBorderPreview)
+		assert.Equal(t, DefaultThemeConfig().Success, cfg.Theme.Success,
+			"omitted theme fields keep their Zenburn defaults")
 		assert.Equal(t, "/home/me/.local/bin/claude --dangerously-skip-permissions",
 			cfg.ProgramOverrides[tmux.ProgramClaude])
 		assert.Equal(t, "/opt/codex/bin/codex --quiet",
 			cfg.ProgramOverrides[tmux.ProgramCodex])
+	})
+
+	t.Run("invalid theme color warns and falls back", func(t *testing.T) {
+		var warnings bytes.Buffer
+		prevWarning := log.WarningLog
+		log.WarningLog = stdlog.New(&warnings, "", 0)
+		t.Cleanup(func() { log.WarningLog = prevWarning })
+
+		writeToml(t, `
+[theme]
+accent = "blue"
+error = "#cc9393"
+`)
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, DefaultThemeConfig().Accent, cfg.Theme.Accent)
+		assert.Equal(t, "#CC9393", cfg.Theme.Error)
+		assert.Contains(t, warnings.String(), "theme.accent")
+		assert.Contains(t, warnings.String(), "not a #RRGGBB color")
 	})
 
 	t.Run("loads legacy config.toml without schema_version as current schema", func(t *testing.T) {

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -127,6 +127,11 @@ type Config struct {
 	// additionally tracks the automatic 1.x.y-preview-z prereleases.
 	// Any other value falls back to stable with a warning.
 	UpdateChannel string `json:"update_channel" toml:"update_channel"`
+	// Theme is the global-only TOML [theme] table (#1389): editable TUI color
+	// slots defaulting to the Zenburn palette. It is intentionally TOML-only
+	// because legacy config.json is frozen and a cloned repo must never be able
+	// to recolor a user's TUI.
+	Theme ThemeConfig `json:"-" toml:"theme"`
 	// RootAgents opts specific repositories into an always-ensured "root"
 	// session (#1106): for each entry the daemon creates a reserved session
 	// titled "root" in-place at the repo root (the `af sessions create
@@ -278,6 +283,7 @@ func DefaultConfig() *Config {
 		LogMaxSizeMB:       log.DefaultMaxSizeMB,
 		LogMaxBackups:      log.DefaultMaxBackups,
 		UpdateChannel:      UpdateChannelStable,
+		Theme:              DefaultThemeConfig(),
 		WorktreeRoot:       WorktreeRootSibling,
 		BranchPrefix: func() string {
 			user, err := user.Current()

--- a/config/configset.go
+++ b/config/configset.go
@@ -175,7 +175,7 @@ func SetGlobalConfigValue(key, rawValue string) (*SetResult, error) {
 	section, leaf, spec, ok := resolveSettable(key)
 	if !ok {
 		return nil, fmt.Errorf("%q is not a settable config key. Settable keys: %s. "+
-			"Structural keys (root_agents, [keys] rebinds) are edited directly in config.toml",
+			"Structural keys (root_agents, [theme], [keys] rebinds) are edited directly in config.toml",
 			key, strings.Join(SettableKeys(), ", "))
 	}
 

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -104,15 +104,19 @@ var inRepoGlobalOnlyKeys = map[string]bool{
 	"log_max_backups":      true,
 	"log_max_size_mb":      true,
 	"root_agents":          true,
-	"update_channel":       true,
-	"worktree_root":        true,
+	// The [theme] table is a user/host visual preference; repositories must
+	// not be able to recolor a cloned user's TUI (#1389).
+	"theme":          true,
+	"update_channel": true,
+	"worktree_root":  true,
 }
 
 // tomlOnlyGlobalKeys is the subset of inRepoGlobalOnlyKeys that exists only in
 // config.toml (#1026/#1030), so their in-repo rejection message must direct
 // the user to config.toml rather than the resolved global config file.
 var tomlOnlyGlobalKeys = map[string]bool{
-	"keys": true,
+	"keys":  true,
+	"theme": true,
 }
 
 // InRepoConfigPath returns the path of the in-repo JSON config file for a

--- a/config/inrepo_toml_test.go
+++ b/config/inrepo_toml_test.go
@@ -119,6 +119,20 @@ func TestLoadInRepoConfigTOMLKeyPolicy(t *testing.T) {
 			"the keys rejection must not point at the ignored config.json path")
 	})
 
+	t.Run("rejecting the TOML-only theme table points at config.toml", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("AGENT_FACTORY_HOME", home)
+		repoRoot := t.TempDir()
+		writeInRepoTomlConfig(t, repoRoot, "[theme]\naccent = \"#8CD0D3\"\n")
+
+		_, _, err := LoadInRepoConfig(repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "global setting")
+		assert.Contains(t, err.Error(), TomlConfigFileName)
+		assert.NotContains(t, err.Error(), prettyHomePath(filepath.Join(home, ConfigFileName)),
+			"the theme rejection must not point at the ignored config.json path")
+	})
+
 	t.Run("rejects unknown key", func(t *testing.T) {
 		t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 		repoRoot := t.TempDir()

--- a/config/theme.go
+++ b/config/theme.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+var themeHexColorRE = regexp.MustCompile(`^#[0-9A-Fa-f]{6}$`)
+
+// ThemeConfig is the global-only [theme] table. It is TOML-only because TUI
+// colors are a user/host preference, like [keys], and legacy config.json is a
+// frozen reader.
+type ThemeConfig struct {
+	Foreground            string `json:"foreground" toml:"foreground"`
+	ForegroundStrong      string `json:"foreground_strong" toml:"foreground_strong"`
+	ForegroundMuted       string `json:"foreground_muted" toml:"foreground_muted"`
+	ForegroundDim         string `json:"foreground_dim" toml:"foreground_dim"`
+	Background            string `json:"background" toml:"background"`
+	BackgroundSubtle      string `json:"background_subtle" toml:"background_subtle"`
+	BackgroundPanel       string `json:"background_panel" toml:"background_panel"`
+	Accent                string `json:"accent" toml:"accent"`
+	Success               string `json:"success" toml:"success"`
+	Warning               string `json:"warning" toml:"warning"`
+	Error                 string `json:"error" toml:"error"`
+	Info                  string `json:"info" toml:"info"`
+	Purple                string `json:"purple" toml:"purple"`
+	SelectionBackground   string `json:"selection_background" toml:"selection_background"`
+	SelectionForeground   string `json:"selection_foreground" toml:"selection_foreground"`
+	PaneBorderDefault     string `json:"pane_border_default" toml:"pane_border_default"`
+	PaneBorderSelected    string `json:"pane_border_selected" toml:"pane_border_selected"`
+	PaneBorderInteractive string `json:"pane_border_interactive" toml:"pane_border_interactive"`
+	PaneBorderPreview     string `json:"pane_border_preview" toml:"pane_border_preview"`
+}
+
+// DefaultThemeConfig returns the approved Zenburn-derived default TUI palette
+// (#1389), materialized into first-run config.toml so users can edit it.
+func DefaultThemeConfig() ThemeConfig {
+	return ThemeConfig{
+		Foreground:            "#DCDCCC",
+		ForegroundStrong:      "#FFFFEF",
+		ForegroundMuted:       "#989890",
+		ForegroundDim:         "#656555",
+		Background:            "#3F3F3F",
+		BackgroundSubtle:      "#494949",
+		BackgroundPanel:       "#4F4F4F",
+		Accent:                "#8CD0D3",
+		Success:               "#7F9F7F",
+		Warning:               "#F0DFAF",
+		Error:                 "#CC9393",
+		Info:                  "#93E0E3",
+		Purple:                "#DC8CC3",
+		SelectionBackground:   "#4F4F4F",
+		SelectionForeground:   "#FFFFEF",
+		PaneBorderDefault:     "#989890",
+		PaneBorderSelected:    "#8CD0D3",
+		PaneBorderInteractive: "#7F9F7F",
+		PaneBorderPreview:     "#DC8CC3",
+	}
+}
+
+func sanitizeThemeColors(config *Config, prettyConfigPath string) {
+	if config == nil {
+		return
+	}
+	defaults := DefaultThemeConfig()
+	cfgValue := reflect.ValueOf(&config.Theme).Elem()
+	defaultValue := reflect.ValueOf(defaults)
+	cfgType := cfgValue.Type()
+	for i := 0; i < cfgValue.NumField(); i++ {
+		field := cfgValue.Field(i)
+		raw := strings.TrimSpace(field.String())
+		fallback := defaultValue.Field(i).String()
+		key := tomlTagName(cfgType.Field(i).Tag.Get("toml"))
+		if key == "" {
+			key = cfgType.Field(i).Name
+		}
+		if !themeHexColorRE.MatchString(raw) {
+			log.WarningLog.Printf("config %s: theme.%s=%q is not a #RRGGBB color; using default %s", prettyConfigPath, key, field.String(), fallback)
+			field.SetString(fallback)
+			continue
+		}
+		field.SetString("#" + strings.ToUpper(raw[1:]))
+	}
+}
+
+func tomlTagName(tag string) string {
+	for i := range tag {
+		if tag[i] == ',' {
+			return tag[:i]
+		}
+	}
+	return tag
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Precedence is **app defaults → global config → in-repo config**: an in-repo 
 
 Config is [TOML](https://toml.io) — chosen so it is easy to hand-edit. If you are upgrading from a version that used `config.json`, see [Migrating from JSON](#migrating-from-json) below; the change is automatic.
 
-You can also read and write the global config from the CLI: `af config get <key>` / `af config list` print the effective values, and `af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_yes`, `auto_update`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`; structural keys (`root_agents`, `[keys]`) are hand-edited only. See [`af config`](reference/cli.md#af-config) in the CLI reference. Changes apply on the next `af`/daemon start, the same as a hand-edit.
+You can also read and write the global config from the CLI: `af config get <key>` / `af config list` print the effective values, and `af config set <key> <value>` writes a single settable scalar key **in place**, preserving all comments and ordering (it never regenerates the file) and validating the value first. Settable keys are the scalar tunables — `default_program`, `program_overrides.<agent>`, `auto_yes`, `auto_update`, `daemon_poll_interval`, `log_max_size_mb`, `log_max_backups`, `branch_prefix`, `worktree_root`, `detach_keys`, `update_channel`, `limit_patterns.<agent>`; structural tables (`root_agents`, `[theme]`, `[keys]`) are hand-edited only. See [`af config`](reference/cli.md#af-config) in the CLI reference. Changes apply on the next `af`/daemon start, the same as a hand-edit.
 
 ## Global config
 
@@ -31,6 +31,27 @@ limit_retry_interval = "30m"
 
 [program_overrides]
 claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
+
+[theme]
+foreground = "#DCDCCC"
+foreground_strong = "#FFFFEF"
+foreground_muted = "#989890"
+foreground_dim = "#656555"
+background = "#3F3F3F"
+background_subtle = "#494949"
+background_panel = "#4F4F4F"
+accent = "#8CD0D3"
+success = "#7F9F7F"
+warning = "#F0DFAF"
+error = "#CC9393"
+info = "#93E0E3"
+purple = "#DC8CC3"
+selection_background = "#4F4F4F"
+selection_foreground = "#FFFFEF"
+pane_border_default = "#989890"
+pane_border_selected = "#8CD0D3"
+pane_border_interactive = "#7F9F7F"
+pane_border_preview = "#DC8CC3"
 ```
 
 | Field | Description |
@@ -50,7 +71,28 @@ claude = "/home/me/.local/bin/claude --dangerously-skip-permissions"
 | `limit_auto_resume` | Opt in to the daemon auto-resuming a session parked at a usage-limit wall once its limit window elapses (default: `false`). See [Usage-limit auto-resume](#usage-limit-auto-resume). |
 | `limit_retry_interval` | Fallback retry cadence (Go duration, e.g. `30m`) used only when `limit_auto_resume` is on **and** the limit banner carried no parseable reset time (default: `30m`). Empty or `0` disables the fallback. |
 | `limit_patterns` | Optional map from agent enum to a regex that overrides the built-in usage-limit **detection** banner for that agent (the built-in reset-time parser is kept). Default: none. See [Custom usage-limit detection](#custom-usage-limit-detection-limit_patterns). |
+| `theme` | Optional TUI color table. Defaults to a Zenburn-derived palette and validates each value as `#RRGGBB`; invalid values fall back to the corresponding default with a warning. See [Theme colors](#theme-colors-theme). |
 | `keys` | Optional keymap overrides for the TUI. See [Key bindings](#key-bindings-keys). |
+
+### Theme colors (`theme`)
+
+The TUI palette defaults to Zenburn: low-contrast foreground/background colors
+with muted green, red, yellow, blue, cyan, and purple accents. Override any
+slot in the global `[theme]` table; omitted slots keep their defaults.
+
+```toml
+[theme]
+accent = "#8CD0D3"
+success = "#7F9F7F"
+warning = "#F0DFAF"
+error = "#CC9393"
+pane_border_preview = "#DC8CC3"
+```
+
+All values must be `#RRGGBB`. Invalid values are ignored with a warning and the
+default for that slot is used, so a bad color cannot prevent the TUI from
+starting. `[theme]` is global-only and TOML-only, like `[keys]`: in-repo configs
+reject it so a cloned repository cannot recolor your terminal.
 
 ### Root agents (always-ensured)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -366,7 +366,7 @@ Settable keys:
   update_channel             stable | preview
   limit_patterns.<agent>     usage-limit banner regex for an agent
 
-Structural keys (root_agents, the [keys] rebind table) are not settable here —
+Structural keys (root_agents, [theme], the [keys] rebind table) are not settable here —
 edit config.toml directly. Changes apply on the next af / daemon start.
 
 Examples:

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,16 +1,16 @@
 /* ==========================================================================
    Agent Factory — docs theme
-   Built around the TUI accent (teal #7cb8bb, ui/theme.go). The deeper teals
+   Built around the TUI Zenburn accent (#8cd0d3, ui/theme.go). The deeper teals
    here are contrast-safe derivatives of that accent so the docs read as the
    same product: the raw accent shines in dark mode, a deeper teal carries the
    light-mode header/links where white-on-accent would fail WCAG.
    ========================================================================== */
 
 :root {
-  --af-teal:        #7cb8bb;  /* the TUI AccentColor, verbatim */
-  --af-teal-deep:   #2e7c80;  /* light-mode primary (header, contrast-safe) */
-  --af-teal-deeper: #245f62;
-  --af-teal-soft:   #e5f1f1;
+  --af-teal:        #8cd0d3;  /* the default TUI AccentColor, verbatim */
+  --af-teal-deep:   #34787b;  /* light-mode primary (header, contrast-safe) */
+  --af-teal-deeper: #285f62;
+  --af-teal-soft:   #e8f4f4;
   --md-code-font: "Roboto Mono", SFMono-Regular, Consolas, monospace;
 }
 

--- a/ui/alarm.go
+++ b/ui/alarm.go
@@ -33,12 +33,11 @@ type AlarmBanner struct {
 	alarms []AlarmInfo
 }
 
-// alarmStyle is a loud white-on-red bar. Red reads as an alert in both light
-// and dark terminals, so it is a fixed color rather than adaptive — the whole
-// point is that it stands apart from every normal surface.
+// alarmStyle is rebuilt from the active theme so alerts remain distinct under
+// user-configured palettes.
 var alarmStyle = lipgloss.NewStyle().
-	Background(lipgloss.Color("#B00020")).
-	Foreground(lipgloss.Color("#FFFFFF")).
+	Background(activeTheme.Error).
+	Foreground(activeTheme.SelectionForeground).
 	Bold(true)
 
 func NewAlarmBanner() *AlarmBanner { return &AlarmBanner{} }

--- a/ui/automations.go
+++ b/ui/automations.go
@@ -23,13 +23,13 @@ var automationsTitleStyle = lipgloss.NewStyle().
 
 var automationsTitleDimStyle = lipgloss.NewStyle().
 	Bold(true).
-	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+	Foreground(activeTheme.ForegroundMuted)
 
 var automationsEnabledStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("#36CFC9"))
+	Foreground(activeTheme.Info)
 
 var automationsDisabledStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("#9C9494"))
+	Foreground(activeTheme.ForegroundMuted)
 
 // automationItemTitleStyle paints an automation's title in the SAME adaptive
 // color the instances tree uses for instance titles (tree.InstanceTitleColor),
@@ -42,10 +42,10 @@ var automationItemTitleStyle = lipgloss.NewStyle().
 // line — the recede gray the tree uses for its branch/description lines, so the
 // detail reads as secondary to the title it hangs under (#1126).
 var automationDetailStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+	Foreground(activeTheme.ForegroundMuted)
 
 var automationsHintStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("#7F7A7A"))
+	Foreground(activeTheme.ForegroundDim)
 
 // fitLine truncates plain text to w cells, marking a cut with a trailing "…"
 // (dropped when even the ellipsis cannot fit) — the same treatment the tree

--- a/ui/err.go
+++ b/ui/err.go
@@ -14,10 +14,7 @@ type ErrBox struct {
 	err           error
 }
 
-var errStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
-	Light: "#FF0000",
-	Dark:  "#FF0000",
-})
+var errStyle = lipgloss.NewStyle().Foreground(activeTheme.Error)
 
 func NewErrBox() *ErrBox {
 	return &ErrBox{}

--- a/ui/hooks_pane.go
+++ b/ui/hooks_pane.go
@@ -149,12 +149,13 @@ func (h *HooksPane) handleEditMode(msg tea.KeyMsg) bool {
 }
 
 func (h *HooksPane) String() string {
-	tStyle := lipgloss.NewStyle().Bold(true).Foreground(AccentColor)
-	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
-	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
-	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
-	editStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FF79C6"))
-	descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A")).Italic(true)
+	t := CurrentTheme()
+	tStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Accent)
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Warning)
+	normalStyle := lipgloss.NewStyle().Foreground(t.ForegroundMuted)
+	hintStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	editStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Purple)
+	descStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim).Italic(true)
 
 	var b strings.Builder
 	b.WriteString(tStyle.Render("Post-Worktree Hooks"))

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -12,20 +12,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-var keyStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
-	Light: "#655F5F",
-	Dark:  "#7F7A7A",
-})
+var keyStyle = lipgloss.NewStyle().Foreground(activeTheme.ForegroundDim)
 
-var descStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
-	Light: "#7A7474",
-	Dark:  "#9C9494",
-})
+var descStyle = lipgloss.NewStyle().Foreground(activeTheme.ForegroundMuted)
 
-var sepStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
-	Light: "#DDDADA",
-	Dark:  "#3C3C3C",
-})
+var sepStyle = lipgloss.NewStyle().Foreground(activeTheme.BackgroundSubtle)
 
 var actionGroupStyle = lipgloss.NewStyle().Foreground(AccentColor)
 
@@ -33,7 +24,7 @@ var separator = " • "
 var verticalSeparator = " │ "
 
 var menuStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("205"))
+	Foreground(activeTheme.Purple)
 
 // MenuState represents different states the menu can be in
 type MenuState int

--- a/ui/overlay/confirmationOverlay.go
+++ b/ui/overlay/confirmationOverlay.go
@@ -5,6 +5,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/sachiniyer/agent-factory/ui"
 )
 
 const (
@@ -32,7 +34,7 @@ type ConfirmationOverlay struct {
 	// Custom cancel key (defaults to 'n')
 	CancelKey string
 	// Custom styling options
-	borderColor lipgloss.Color
+	borderColor lipgloss.TerminalColor
 }
 
 // NewConfirmationOverlay creates a new confirmation dialog overlay with the given message
@@ -43,7 +45,7 @@ func NewConfirmationOverlay(message string) *ConfirmationOverlay {
 		width:       50, // Default width
 		ConfirmKey:  "y",
 		CancelKey:   "n",
-		borderColor: lipgloss.Color("#de613e"), // Red color for confirmations
+		borderColor: ui.CurrentTheme().Error,
 	}
 }
 

--- a/ui/overlay/searchOverlay.go
+++ b/ui/overlay/searchOverlay.go
@@ -207,7 +207,7 @@ type searchRenderPlan struct {
 func searchOverlayStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ui.AccentColor).
+		BorderForeground(ui.CurrentTheme().Accent).
 		Padding(1, 2)
 }
 
@@ -294,17 +294,18 @@ func (s *SearchOverlay) windowForAvailableRows(available int) (startIdx, endIdx 
 
 // Render renders the search overlay.
 func (s *SearchOverlay) Render() string {
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.AccentColor)
-	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
-	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
-	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
-	queryStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FF79C6"))
-	statusRunning := lipgloss.NewStyle().Foreground(lipgloss.Color("#51bd73"))
-	statusReady := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFCC00"))
-	statusLoading := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+	t := ui.CurrentTheme()
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Accent)
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Warning)
+	normalStyle := lipgloss.NewStyle().Foreground(t.ForegroundMuted)
+	hintStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	queryStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Purple)
+	statusRunning := lipgloss.NewStyle().Foreground(t.Success)
+	statusReady := lipgloss.NewStyle().Foreground(t.Warning)
+	statusLoading := lipgloss.NewStyle().Foreground(t.ForegroundDim)
 	// statusLimit marks a usage-limit-blocked result (#1146) with a distinct
 	// warning red + diamond glyph so it never reads as a live Running/Ready dot.
-	statusLimit := lipgloss.NewStyle().Foreground(lipgloss.Color("#E06C75"))
+	statusLimit := lipgloss.NewStyle().Foreground(t.Error)
 
 	style := searchOverlayStyle()
 	plan := s.renderPlan(style)

--- a/ui/overlay/selectionOverlay.go
+++ b/ui/overlay/selectionOverlay.go
@@ -83,14 +83,15 @@ func (s *SelectionOverlay) SetMaxSize(width, height int) {
 
 // Render renders the selection overlay
 func (s *SelectionOverlay) Render() string {
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.AccentColor)
-	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
-	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
-	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+	t := ui.CurrentTheme()
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Accent)
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Warning)
+	normalStyle := lipgloss.NewStyle().Foreground(t.ForegroundMuted)
+	hintStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
 
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ui.AccentColor).
+		BorderForeground(t.Accent).
 		Padding(1, 2)
 	fit := fitOverlayContent(s.width, 0, s.maxWidth, s.maxHeight, style)
 	if fit.W <= 0 {

--- a/ui/overlay/textOverlay.go
+++ b/ui/overlay/textOverlay.go
@@ -63,7 +63,7 @@ func (t *TextOverlay) Render() string {
 	// Create styles
 	style := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ui.AccentColor).
+		BorderForeground(ui.CurrentTheme().Accent).
 		Padding(textOverlayVerticalPadding, textOverlayHorizontalPadding).
 		Width(t.width)
 	if inner := t.innerHeight(); inner > 0 && t.contentOverflows(inner) {
@@ -167,6 +167,6 @@ func textOverlayScrollMarker(width int, marker string) string {
 		width = 1
 	}
 	return lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#7F7A7A")).
+		Foreground(ui.CurrentTheme().ForegroundDim).
 		Render(lipgloss.PlaceHorizontal(width, lipgloss.Center, marker))
 }

--- a/ui/sidebar_model.go
+++ b/ui/sidebar_model.go
@@ -75,29 +75,29 @@ func partitionByArchived(instances []*session.Instance) (live, archived []int) {
 
 var sectionHeaderStyle = lipgloss.NewStyle().
 	Bold(true).
-	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#dddddd"})
+	Foreground(activeTheme.Foreground)
 
 var sectionHeaderSelectedStyle = lipgloss.NewStyle().
 	Bold(true).
-	Background(lipgloss.Color("#dde4f0")).
-	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#1a1a1a"})
+	Background(activeTheme.SelectionBackground).
+	Foreground(activeTheme.SelectionForeground)
 
 var windowIndicatorStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+	Foreground(activeTheme.ForegroundMuted)
 
 var mainTitle = lipgloss.NewStyle().
 	Background(AccentColor).
-	Foreground(lipgloss.Color("230"))
+	Foreground(activeTheme.Background)
 
 // blurredTitle is the title chip with tree focus elsewhere (#1024 PR 4 focus
 // ring): same shape, receded color.
 var blurredTitle = lipgloss.NewStyle().
-	Background(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#555555"}).
-	Foreground(lipgloss.Color("230"))
+	Background(activeTheme.ForegroundDim).
+	Foreground(activeTheme.ForegroundStrong)
 
 var autoYesStyle = lipgloss.NewStyle().
-	Background(lipgloss.Color("#dde4f0")).
-	Foreground(lipgloss.Color("#1a1a1a"))
+	Background(activeTheme.SelectionBackground).
+	Foreground(activeTheme.SelectionForeground)
 
 // Sidebar is the unified left navigation pane with collapsible sections. It is
 // a VIEW over the store.Projection (#1024 PR 2): the instance/task/hook data —

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -15,10 +15,10 @@ import (
 )
 
 var tabPaneStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#dddddd"})
+	Foreground(activeTheme.Foreground)
 
 var tabPaneFooterStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#808080", Dark: "#808080"})
+	Foreground(activeTheme.ForegroundMuted)
 
 // tabContentState holds the rendered content of the tab pane.
 //

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -22,7 +22,7 @@ var windowStyle = lipgloss.NewStyle().
 // blurredWindowStyle recedes the pane frame when focus is elsewhere in the
 // workspace, so the focus ring is legible at a glance.
 var blurredWindowStyle = windowStyle.
-	BorderForeground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#555555"})
+	BorderForeground(activeTheme.PaneBorderDefault)
 
 // interactiveWindowStyle marks the pane that owns the keyboard in
 // interactive mode (#1089, RFC §2.3): a green DOUBLE border — unmistakably
@@ -30,26 +30,26 @@ var blurredWindowStyle = windowStyle.
 // colors unavailable — signals "keystrokes go INTO this terminal".
 var interactiveWindowStyle = windowStyle.
 	Border(lipgloss.DoubleBorder()).
-	BorderForeground(lipgloss.AdaptiveColor{Light: "#1A7F37", Dark: "#3FB950"})
+	BorderForeground(activeTheme.PaneBorderInteractive)
 
 var paneHeaderStyle = lipgloss.NewStyle().
 	Bold(true).
-	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#dddddd"})
+	Foreground(activeTheme.Foreground)
 
 var paneHeaderFocusedStyle = lipgloss.NewStyle().
 	Bold(true).
-	Background(lipgloss.Color("#dde4f0")).
-	Foreground(lipgloss.Color("#1a1a1a"))
+	Background(activeTheme.SelectionBackground).
+	Foreground(activeTheme.SelectionForeground)
 
 var paneHeaderDimStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+	Foreground(activeTheme.ForegroundMuted)
 
 // paneHeaderInteractiveStyle matches the interactive frame: green header bar
 // on the pane whose terminal owns the keyboard.
 var paneHeaderInteractiveStyle = lipgloss.NewStyle().
 	Bold(true).
-	Background(lipgloss.AdaptiveColor{Light: "#D2F3DC", Dark: "#1A7F37"}).
-	Foreground(lipgloss.AdaptiveColor{Light: "#0A3D1E", Dark: "#EAFBEF"})
+	Background(activeTheme.Success).
+	Foreground(activeTheme.Background)
 
 // paneHeaderRows is the height of the `title · tab` header line rendered
 // inside the pane frame. With the tab bar gone (#1024 PR 4) the header is

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -22,11 +22,11 @@ const programDefaultLabel = "(use config default)"
 // cron "e.g. 0 9 * * 1-5") can never be mistaken for a typed value.
 var taskPlaceholderStyle = lipgloss.NewStyle().
 	Faint(true).
-	Foreground(lipgloss.AdaptiveColor{Light: "#B5B0B0", Dark: "#5C5757"})
+	Foreground(activeTheme.ForegroundDim)
 
 // taskFormMoreStyle dims the ↑/↓ markers flagging fields scrolled out of a
 // height-clamped edit form (#1098).
-var taskFormMoreStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+var taskFormMoreStyle = lipgloss.NewStyle().Foreground(activeTheme.ForegroundDim)
 
 // Edit-form focus stops, in tab order. The form is grouped: Essentials
 // (name, trigger, prompt) then Delivery (target session, path, program).
@@ -472,13 +472,14 @@ func taskDeliverySummary(tsk task.Task) string {
 }
 
 func (s *TaskPane) renderListMode() string {
-	tStyle := lipgloss.NewStyle().Bold(true).Foreground(AccentColor)
-	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
-	enabledStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#36CFC9"))
-	disabledStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
-	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
-	detailStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
-	erroredStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	t := CurrentTheme()
+	tStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Accent)
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Warning)
+	enabledStyle := lipgloss.NewStyle().Foreground(t.Info)
+	disabledStyle := lipgloss.NewStyle().Foreground(t.ForegroundMuted)
+	hintStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	detailStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	erroredStyle := lipgloss.NewStyle().Foreground(t.Error)
 
 	var b strings.Builder
 	b.WriteString(tStyle.Render("Tasks"))

--- a/ui/task_pane_edit.go
+++ b/ui/task_pane_edit.go
@@ -222,20 +222,21 @@ func (s *TaskPane) updateEditFocus() {
 }
 
 func (s *TaskPane) renderEditMode() string {
+	t := CurrentTheme()
 	editTitleStyle := lipgloss.NewStyle().
-		Foreground(AccentColor).
+		Foreground(t.Accent).
 		Bold(true).
 		MarginBottom(1)
 
 	labelStyle := lipgloss.NewStyle().Bold(true)
-	groupStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7F7A7A"))
-	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
-	errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
+	groupStyle := lipgloss.NewStyle().Bold(true).Foreground(t.ForegroundDim)
+	hintStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	errorStyle := lipgloss.NewStyle().Foreground(t.Error).Bold(true)
 
-	buttonStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
+	buttonStyle := lipgloss.NewStyle().Foreground(t.Foreground)
 	focusedButtonStyle := buttonStyle.
-		Background(AccentColor).
-		Foreground(lipgloss.Color("0"))
+		Background(t.Accent).
+		Foreground(t.Background)
 
 	inputWidth := s.width - 9
 	if inputWidth < 1 {
@@ -459,10 +460,11 @@ func (s *TaskPane) clampFormToHeight(content string, focusStart, focusEnd int) s
 // otherwise), matching the Program selector's treatment.
 func (s *TaskPane) renderTriggerSelector() string {
 	focused := s.focusIndex == taskFocusTrigger
-	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
-	dimSelectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
-	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9C9494"))
-	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+	t := CurrentTheme()
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Warning)
+	dimSelectedStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	normalStyle := lipgloss.NewStyle().Foreground(t.ForegroundMuted)
+	hintStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
 
 	option := func(name string, sel bool) string {
 		switch {
@@ -485,9 +487,10 @@ func (s *TaskPane) renderTriggerSelector() string {
 // the current choice; ←/→ steps through the options when focused.
 func (s *TaskPane) renderProgramSelector() string {
 	focused := s.focusIndex == taskFocusProgram
-	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
-	dimSelectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
-	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7F7A7A"))
+	t := CurrentTheme()
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Warning)
+	dimSelectedStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	hintStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
 
 	value := programDefaultLabel
 	if s.editProgramIdx >= 0 && s.editProgramIdx < len(s.editProgramOptions) {

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -1,17 +1,172 @@
 package ui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
 
-// AccentColor is the single source of truth for the UI accent (teal #7cb8bb,
-// introduced in #932). Every accent surface — the sidebar title banner, active
-// tab/window borders, overlay borders, menu action groups, task edit-mode
-// chrome, and the help screen titles — routes through this constant so the
-// accent can never drift again the way the old purple Color("62") banner did
-// (#950). It is intentionally a plain lipgloss.Color: #932 used the same hex
-// for both light and dark, so no AdaptiveColor split is needed, and a single
-// Color drops in cleanly at every Foreground/Background/BorderForeground site.
-//
-// This is the accent and nothing else. Semantic colors — success green
-// (#51bd73), error red, menu pink (Color("205")), and the recede/muted greys —
-// are deliberately NOT part of the accent and must not be folded in here.
-const AccentColor = lipgloss.Color("#7cb8bb")
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/ui/tree"
+)
+
+// Theme is the active TUI palette after resolving config.ThemeConfig into
+// lipgloss colors. Defaults are Zenburn-derived (#1389).
+type Theme struct {
+	Foreground            lipgloss.Color
+	ForegroundStrong      lipgloss.Color
+	ForegroundMuted       lipgloss.Color
+	ForegroundDim         lipgloss.Color
+	Background            lipgloss.Color
+	BackgroundSubtle      lipgloss.Color
+	BackgroundPanel       lipgloss.Color
+	Accent                lipgloss.Color
+	Success               lipgloss.Color
+	Warning               lipgloss.Color
+	Error                 lipgloss.Color
+	Info                  lipgloss.Color
+	Purple                lipgloss.Color
+	SelectionBackground   lipgloss.Color
+	SelectionForeground   lipgloss.Color
+	PaneBorderDefault     lipgloss.Color
+	PaneBorderSelected    lipgloss.Color
+	PaneBorderInteractive lipgloss.Color
+	PaneBorderPreview     lipgloss.Color
+}
+
+var activeTheme = themeFromConfig(config.DefaultThemeConfig())
+
+// AccentColor is the compatibility name for the main TUI accent. It now comes
+// from the active [theme] palette (Zenburn blue #8CD0D3 by default) instead of
+// the old fixed teal.
+var AccentColor = activeTheme.Accent
+
+func init() {
+	ApplyTheme(config.DefaultThemeConfig())
+}
+
+func themeFromConfig(cfg config.ThemeConfig) Theme {
+	return Theme{
+		Foreground:            lipgloss.Color(cfg.Foreground),
+		ForegroundStrong:      lipgloss.Color(cfg.ForegroundStrong),
+		ForegroundMuted:       lipgloss.Color(cfg.ForegroundMuted),
+		ForegroundDim:         lipgloss.Color(cfg.ForegroundDim),
+		Background:            lipgloss.Color(cfg.Background),
+		BackgroundSubtle:      lipgloss.Color(cfg.BackgroundSubtle),
+		BackgroundPanel:       lipgloss.Color(cfg.BackgroundPanel),
+		Accent:                lipgloss.Color(cfg.Accent),
+		Success:               lipgloss.Color(cfg.Success),
+		Warning:               lipgloss.Color(cfg.Warning),
+		Error:                 lipgloss.Color(cfg.Error),
+		Info:                  lipgloss.Color(cfg.Info),
+		Purple:                lipgloss.Color(cfg.Purple),
+		SelectionBackground:   lipgloss.Color(cfg.SelectionBackground),
+		SelectionForeground:   lipgloss.Color(cfg.SelectionForeground),
+		PaneBorderDefault:     lipgloss.Color(cfg.PaneBorderDefault),
+		PaneBorderSelected:    lipgloss.Color(cfg.PaneBorderSelected),
+		PaneBorderInteractive: lipgloss.Color(cfg.PaneBorderInteractive),
+		PaneBorderPreview:     lipgloss.Color(cfg.PaneBorderPreview),
+	}
+}
+
+// ApplyTheme installs the configured TUI palette and rebuilds package-level
+// lipgloss styles that captured the previous colors at init time.
+func ApplyTheme(cfg config.ThemeConfig) {
+	activeTheme = themeFromConfig(cfg)
+	AccentColor = activeTheme.Accent
+	tree.ApplyTheme(tree.Theme{
+		Foreground:          activeTheme.Foreground,
+		ForegroundStrong:    activeTheme.ForegroundStrong,
+		ForegroundMuted:     activeTheme.ForegroundMuted,
+		ForegroundDim:       activeTheme.ForegroundDim,
+		SelectionBackground: activeTheme.SelectionBackground,
+		SelectionForeground: activeTheme.SelectionForeground,
+		Success:             activeTheme.Success,
+		Warning:             activeTheme.Warning,
+		Error:               activeTheme.Error,
+	})
+	applyThemeStyles()
+}
+
+// CurrentTheme returns the active TUI palette for render-time styles.
+func CurrentTheme() Theme {
+	return activeTheme
+}
+
+func applyThemeStyles() {
+	windowStyle = lipgloss.NewStyle().
+		BorderForeground(activeTheme.Accent).
+		Border(lipgloss.RoundedBorder())
+	blurredWindowStyle = windowStyle.
+		BorderForeground(activeTheme.PaneBorderDefault)
+	interactiveWindowStyle = windowStyle.
+		Border(lipgloss.DoubleBorder()).
+		BorderForeground(activeTheme.PaneBorderInteractive)
+
+	paneHeaderStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(activeTheme.Foreground)
+	paneHeaderFocusedStyle = lipgloss.NewStyle().
+		Bold(true).
+		Background(activeTheme.SelectionBackground).
+		Foreground(activeTheme.SelectionForeground)
+	paneHeaderDimStyle = lipgloss.NewStyle().
+		Foreground(activeTheme.ForegroundMuted)
+	paneHeaderInteractiveStyle = lipgloss.NewStyle().
+		Bold(true).
+		Background(activeTheme.Success).
+		Foreground(activeTheme.Background)
+
+	sectionHeaderStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(activeTheme.Foreground)
+	sectionHeaderSelectedStyle = lipgloss.NewStyle().
+		Bold(true).
+		Background(activeTheme.SelectionBackground).
+		Foreground(activeTheme.SelectionForeground)
+	windowIndicatorStyle = lipgloss.NewStyle().
+		Foreground(activeTheme.ForegroundMuted)
+	mainTitle = lipgloss.NewStyle().
+		Background(activeTheme.Accent).
+		Foreground(activeTheme.Background)
+	blurredTitle = lipgloss.NewStyle().
+		Background(activeTheme.ForegroundDim).
+		Foreground(activeTheme.ForegroundStrong)
+	autoYesStyle = lipgloss.NewStyle().
+		Background(activeTheme.SelectionBackground).
+		Foreground(activeTheme.SelectionForeground)
+
+	automationsTitleStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(activeTheme.Accent)
+	automationsTitleDimStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(activeTheme.ForegroundMuted)
+	automationsEnabledStyle = lipgloss.NewStyle().
+		Foreground(activeTheme.Info)
+	automationsDisabledStyle = lipgloss.NewStyle().
+		Foreground(activeTheme.ForegroundMuted)
+	automationItemTitleStyle = lipgloss.NewStyle().
+		Foreground(tree.InstanceTitleColor)
+	automationDetailStyle = lipgloss.NewStyle().
+		Foreground(activeTheme.ForegroundMuted)
+	automationsHintStyle = lipgloss.NewStyle().
+		Foreground(activeTheme.ForegroundDim)
+
+	keyStyle = lipgloss.NewStyle().Foreground(activeTheme.ForegroundDim)
+	descStyle = lipgloss.NewStyle().Foreground(activeTheme.ForegroundMuted)
+	sepStyle = lipgloss.NewStyle().Foreground(activeTheme.BackgroundSubtle)
+	actionGroupStyle = lipgloss.NewStyle().Foreground(activeTheme.Accent)
+	menuStyle = lipgloss.NewStyle().Foreground(activeTheme.Purple)
+
+	tabPaneStyle = lipgloss.NewStyle().Foreground(activeTheme.Foreground)
+	tabPaneFooterStyle = lipgloss.NewStyle().Foreground(activeTheme.ForegroundMuted)
+
+	taskPlaceholderStyle = lipgloss.NewStyle().
+		Faint(true).
+		Foreground(activeTheme.ForegroundDim)
+	taskFormMoreStyle = lipgloss.NewStyle().Foreground(activeTheme.ForegroundDim)
+
+	alarmStyle = lipgloss.NewStyle().
+		Background(activeTheme.Error).
+		Foreground(activeTheme.SelectionForeground).
+		Bold(true)
+	errStyle = lipgloss.NewStyle().Foreground(activeTheme.Error)
+}

--- a/ui/theme_test.go
+++ b/ui/theme_test.go
@@ -5,22 +5,21 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/ui/tree"
 )
 
-// TestAccentColorValue pins the shared accent to the teal introduced in #932.
-// If someone changes the accent, they change it here in one place and this test
-// records the intent — the whole point of the constant (#950).
+// TestAccentColorValue pins the default shared accent to the Zenburn blue
+// approved in #1389. Custom configs can override it through [theme].accent.
 func TestAccentColorValue(t *testing.T) {
-	if got := string(AccentColor); got != "#7cb8bb" {
-		t.Fatalf("AccentColor = %q, want %q", got, "#7cb8bb")
+	if got := string(AccentColor); got != "#8CD0D3" {
+		t.Fatalf("AccentColor = %q, want %q", got, "#8CD0D3")
 	}
 }
 
 // TestAccentSitesUseConstant guards against the half-finished migration that
-// left the sidebar title banner purple (Color("62")) while everything else went
-// teal. These are the most prominent accent surfaces; assert they resolve to
-// AccentColor so a future literal can't silently drift them apart again.
+// left accent surfaces on unrelated literals while the rest of the TUI used
+// the configured accent. These are the most prominent accent surfaces.
 func TestAccentSitesUseConstant(t *testing.T) {
 	cases := []struct {
 		name string
@@ -36,6 +35,33 @@ func TestAccentSitesUseConstant(t *testing.T) {
 			t.Errorf("%s = %v, want AccentColor (%s)", c.name, c.got, AccentColor)
 		}
 	}
+}
+
+func TestApplyThemeRebuildsProminentStyles(t *testing.T) {
+	defaultTheme := config.DefaultThemeConfig()
+	t.Cleanup(func() { ApplyTheme(defaultTheme) })
+
+	custom := defaultTheme
+	custom.Accent = "#112233"
+	custom.Foreground = "#445566"
+	custom.ForegroundMuted = "#556677"
+	custom.SelectionBackground = "#223344"
+	custom.SelectionForeground = "#DDEEFF"
+	ApplyTheme(custom)
+
+	assertColor := func(name string, got lipgloss.TerminalColor, want string) {
+		t.Helper()
+		if got != lipgloss.TerminalColor(lipgloss.Color(want)) {
+			t.Fatalf("%s = %v, want %s", name, got, want)
+		}
+	}
+	assertColor("AccentColor", lipgloss.TerminalColor(AccentColor), "#112233")
+	assertColor("mainTitle background", mainTitle.GetBackground(), "#112233")
+	assertColor("window border", windowStyle.GetBorderBottomForeground(), "#112233")
+	assertColor("menu action group", actionGroupStyle.GetForeground(), "#112233")
+	assertColor("tree title", lipgloss.TerminalColor(tree.InstanceTitleColor), "#445566")
+	assertColor("pane focused header background", paneHeaderFocusedStyle.GetBackground(), "#223344")
+	assertColor("pane focused header foreground", paneHeaderFocusedStyle.GetForeground(), "#DDEEFF")
 }
 
 // TestAutomationTitleMatchesInstanceTitle pins #1126: an automation's title

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -15,6 +15,20 @@ import (
 
 const readyIcon = "● "
 
+// Theme is the subset of the TUI palette the tree renderer needs. It is
+// supplied by ui.ApplyTheme so this subpackage does not import ui.
+type Theme struct {
+	Foreground          lipgloss.TerminalColor
+	ForegroundStrong    lipgloss.TerminalColor
+	ForegroundMuted     lipgloss.TerminalColor
+	ForegroundDim       lipgloss.TerminalColor
+	SelectionBackground lipgloss.TerminalColor
+	SelectionForeground lipgloss.TerminalColor
+	Success             lipgloss.TerminalColor
+	Warning             lipgloss.TerminalColor
+	Error               lipgloss.TerminalColor
+}
+
 // deadIcon is hollow (not the filled readyIcon) so a dead session differs from
 // a healthy Ready one by shape as well as color — the distinction survives low
 // contrast and color-blindness (#935).
@@ -49,31 +63,31 @@ const (
 )
 
 var readyStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#51bd73", Dark: "#51bd73"})
+	Foreground(lipgloss.Color("#7F9F7F"))
 
 // deadStyle paints the status dot of a session whose backing tmux/remote
 // session has vanished (#935). A muted gray — the same recede treatment used
 // for a deleting row — keeps a corpse from reading as a healthy green session.
 var deadStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+	Foreground(lipgloss.Color("#989890"))
 
 // lostStyle paints the status dot of a Lost session (#1108): amber, not the
 // corpse gray — the session is expected to come back, but must not read as a
 // healthy green either.
 var lostStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#C18401", Dark: "#E5C07B"})
+	Foreground(lipgloss.Color("#F0DFAF"))
 
 // archivedStyle paints an archived session's dot + dims its title (#1028): the
 // same muted gray as a deleting/dead recede, so a filed-away session never reads
 // as live. Reused for the title/desc foreground below.
 var archivedStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+	Foreground(lipgloss.Color("#989890"))
 
 // limitStyle paints the status glyph of a usage-limit-blocked session (#1146): a
 // warning red-orange, distinct from the ready-green, lost-amber, and dead/
 // archived gray so the blocked state is unmistakable at a glance.
 var limitStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#D1493F", Dark: "#E06C75"})
+	Foreground(lipgloss.Color("#CC9393"))
 
 // limitBadgePrefix returns the sidebar title prefix for a usage-limit-blocked
 // session (#1146): "[limit] resets <t> " when a reset time is known, else a bare
@@ -110,7 +124,7 @@ func formatLimitReset(reset, now time.Time) string {
 // stacked below the tree — the automations rail (#1126) — can paint their own
 // titles in the exact same color and the two lists can never drift apart, the
 // same single-definition discipline AccentColor uses for the accent.
-var InstanceTitleColor = lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#dddddd"}
+var InstanceTitleColor lipgloss.TerminalColor = lipgloss.Color("#DCDCCC")
 
 var titleStyle = lipgloss.NewStyle().
 	Padding(1, 1, 0, 1).
@@ -118,38 +132,71 @@ var titleStyle = lipgloss.NewStyle().
 
 var listDescStyle = lipgloss.NewStyle().
 	Padding(0, 1, 1, 1).
-	Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"})
+	Foreground(lipgloss.Color("#989890"))
 
 var selectedTitleStyle = lipgloss.NewStyle().
 	Padding(1, 1, 0, 1).
-	Background(lipgloss.Color("#dde4f0")).
-	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#1a1a1a"})
+	Background(lipgloss.Color("#4F4F4F")).
+	Foreground(lipgloss.Color("#FFFFEF"))
 
 var selectedDescStyle = lipgloss.NewStyle().
 	Padding(0, 1, 1, 1).
-	Background(lipgloss.Color("#dde4f0")).
-	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#1a1a1a"})
+	Background(lipgloss.Color("#4F4F4F")).
+	Foreground(lipgloss.Color("#FFFFEF"))
 
 // tabRowStyle renders tab child rows in the same primary foreground as the
 // Agent/active tab label (#1456). Selection still supplies the row highlight.
 var tabRowStyle = lipgloss.NewStyle().
 	Foreground(InstanceTitleColor)
 
-// tabRowActiveStyle brightens the tab the content pane is showing (plus its
-// tmux-style "*" marker) so the active tab is findable without the tab bar.
+// tabRowActiveStyle keeps tab rows in the same foreground; the tmux-style "*"
+// marker carries the active cue.
 var tabRowActiveStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#dddddd"})
+	Foreground(InstanceTitleColor)
 
 // tabRowSelectedStyle highlights the tab row under the tree cursor with the
 // same background the selected instance row uses.
 var tabRowSelectedStyle = lipgloss.NewStyle().
-	Background(lipgloss.Color("#dde4f0")).
-	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#1a1a1a"})
+	Background(lipgloss.Color("#4F4F4F")).
+	Foreground(lipgloss.Color("#FFFFEF"))
 
 // deletingTitleColor dims a mid-deletion row — title and branch/PR lines —
 // to the description gray so it visually recedes while its teardown runs in
 // the background (#844, #853).
-var deletingTitleColor = lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"}
+var deletingTitleColor lipgloss.TerminalColor = lipgloss.Color("#989890")
+
+// ApplyTheme rebuilds package-level tree styles after the TUI palette changes.
+func ApplyTheme(t Theme) {
+	readyStyle = lipgloss.NewStyle().Foreground(t.Success)
+	deadStyle = lipgloss.NewStyle().Foreground(t.ForegroundMuted)
+	lostStyle = lipgloss.NewStyle().Foreground(t.Warning)
+	archivedStyle = lipgloss.NewStyle().Foreground(t.ForegroundMuted)
+	limitStyle = lipgloss.NewStyle().Foreground(t.Error)
+
+	InstanceTitleColor = t.Foreground
+	titleStyle = lipgloss.NewStyle().
+		Padding(1, 1, 0, 1).
+		Foreground(InstanceTitleColor)
+	listDescStyle = lipgloss.NewStyle().
+		Padding(0, 1, 1, 1).
+		Foreground(t.ForegroundMuted)
+	selectedTitleStyle = lipgloss.NewStyle().
+		Padding(1, 1, 0, 1).
+		Background(t.SelectionBackground).
+		Foreground(t.SelectionForeground)
+	selectedDescStyle = lipgloss.NewStyle().
+		Padding(0, 1, 1, 1).
+		Background(t.SelectionBackground).
+		Foreground(t.SelectionForeground)
+	tabRowStyle = lipgloss.NewStyle().
+		Foreground(InstanceTitleColor)
+	tabRowActiveStyle = lipgloss.NewStyle().
+		Foreground(InstanceTitleColor)
+	tabRowSelectedStyle = lipgloss.NewStyle().
+		Background(t.SelectionBackground).
+		Foreground(t.SelectionForeground)
+	deletingTitleColor = t.ForegroundMuted
+}
 
 // InstanceRenderer renders the tree's rows: session.Instance rows (absorbed
 // from ui/list.go) and their tab child rows.

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -332,9 +332,8 @@ func TestInstanceRendererDeletingDimsSelectedRow(t *testing.T) {
 	require.NoError(t, err)
 	inst.SetPRInfo(&git.PRInfo{Number: 7, Title: "teardown", State: "OPEN"})
 
-	// SGR foreground params of the dark-background deleting gray, e.g.
-	// "38;2;119;119;119" under TrueColor.
-	dimFG := termenv.RGBColor(deletingTitleColor.Dark).Sequence(false)
+	// SGR foreground params of the default Zenburn deleting gray.
+	dimFG := termenv.RGBColor("#989890").Sequence(false)
 
 	r := NewInstanceRenderer(&spin)
 	r.SetWidth(effectiveWidth(36))


### PR DESCRIPTION
Closes #1389

Summary:
- add global-only TOML [theme] config with Zenburn defaults and #RRGGBB validation with warning fallback
- source ui.AccentColor and rebuilt lipgloss styles from the active theme
- replace practical ad-hoc TUI color literals with theme slots and document the config surface

Gates:
- gofmt
- golangci-lint --fast
- go build ./...
- make test-container
- deadcode
- scripts/lint-file-length.sh
- make tui-driver-selftest (24/24)