### PR TITLE
fix(tui): no-op missing remote hooks

### DIFF
--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -183,6 +183,15 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	if m.pendingProgram == "" && m.appConfig != nil {
 		m.pendingProgram = m.appConfig.DefaultProgram
 	}
+	if remote {
+		configured, err := session.RemoteHooksConfiguredForPath(".")
+		if err != nil {
+			return m, m.handleError(err)
+		}
+		if !configured {
+			return m, nil
+		}
+	}
 	instance, err := session.NewInstance(session.InstanceOptions{
 		Title:       "",
 		Path:        ".",

--- a/app/handle_input_test.go
+++ b/app/handle_input_test.go
@@ -167,6 +167,48 @@ func TestStartNewInstanceSelectsNamingInstanceAfterSortedInsert(t *testing.T) {
 		"the #1350 BeginCreate chokepoint still fires exactly once when naming starts")
 }
 
+func TestStartNewRemoteWithoutHooksNoops(t *testing.T) {
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+
+	model, cmd := h.startNewInstance(true)
+
+	require.Same(t, h, model)
+	require.Nil(t, cmd)
+	assert.Equal(t, stateDefault, h.state)
+	assert.Nil(t, h.namingInstance)
+	assert.Equal(t, 0, h.store.NumInstances())
+	assert.Empty(t, h.errBox.FullError())
+}
+
+func TestStartNewRemoteInvalidHooksStillErrors(t *testing.T) {
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	require.NoError(t, config.SaveRepoConfig(repo.ID, &config.RepoConfig{
+		RemoteHooks: &config.RemoteHooks{
+			AttachCmd: "/bin/echo",
+			DeleteCmd: "/bin/echo",
+		},
+	}))
+
+	model, cmd := h.startNewInstance(true)
+
+	require.Same(t, h, model)
+	require.NotNil(t, cmd)
+	assert.Equal(t, stateDefault, h.state)
+	assert.Nil(t, h.namingInstance)
+	assert.Equal(t, 0, h.store.NumInstances())
+	assert.Contains(t, h.errBox.FullError(), "remote_hooks.launch_cmd")
+}
+
 // TestCancelNamingRemovesZombieAfterSelectionDrift is the regression guard for
 // issue #717. While the user is naming a new instance, a background sidebar
 // mutation can remove a *preceding* instance, which rebuilds the sidebar's

--- a/session/backend_resolve.go
+++ b/session/backend_resolve.go
@@ -28,22 +28,45 @@ func backendForPath(absPath string) (Backend, error) {
 	return &LocalBackend{}, nil
 }
 
+// RemoteHooksConfiguredForPath reports whether absPath's repo has a validated
+// remote hook backend configured. A repo with no remote hooks is a normal empty
+// state, so it returns false, nil rather than an error.
+func RemoteHooksConfiguredForPath(absPath string) (bool, error) {
+	_, configured, err := loadHookBackendForPathIfConfigured(absPath)
+	return configured, err
+}
+
 // loadHookBackendForPath loads a HookBackend for the given workspace path.
 // Returns an error if no remote hooks are configured.
 func loadHookBackendForPath(absPath string) (*HookBackend, error) {
+	hook, configured, err := loadHookBackendForPathIfConfigured(absPath)
+	if err != nil {
+		return nil, err
+	}
+	if configured {
+		return hook, nil
+	}
 	repo, err := config.RepoFromPath(absPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve repo: %w", err)
 	}
+	return nil, fmt.Errorf("no remote hooks configured for repo %s", repo.ID)
+}
+
+func loadHookBackendForPathIfConfigured(absPath string) (*HookBackend, bool, error) {
+	repo, err := config.RepoFromPath(absPath)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to resolve repo: %w", err)
+	}
 	cfg, err := config.ResolveConfig(repo.Root)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve repo config: %w", err)
+		return nil, false, fmt.Errorf("failed to resolve repo config: %w", err)
 	}
 	if cfg.RemoteHooks == nil {
-		return nil, fmt.Errorf("no remote hooks configured for repo %s", repo.ID)
+		return nil, false, nil
 	}
 	if err := cfg.RemoteHooks.Validate(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return &HookBackend{Hooks: *cfg.RemoteHooks}, nil
+	return &HookBackend{Hooks: *cfg.RemoteHooks}, true, nil
 }


### PR DESCRIPTION
## Summary
- add a non-error remote-hook availability lookup for repos with no remote_hooks config
- make the TUI new-remote action no-op when hooks are absent, so the benign empty state never reaches handleError
- keep configured-but-invalid remote hooks surfacing as real errors

## Tests
- golangci-lint run --timeout=3m --fast
- gofmt -l .
- go build ./...
- make test-container
- deadcode -test ./...
- scripts/lint-file-length.sh

Closes #1510