### PR TITLE
TUI: color pane borders by state

### DIFF
--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -69,7 +69,7 @@ func (m *home) paneSelectionHint(p *store.OpenPane) string {
 	if selected == nil {
 		return ""
 	}
-	if p.Instance() == selected && p.Tab() == m.store.ActiveTab() {
+	if m.paneMatchesSelection(p) {
 		return ""
 	}
 	tabLabel := ""
@@ -82,6 +82,14 @@ func (m *home) paneSelectionHint(p *store.OpenPane) string {
 		return selected.Title
 	}
 	return fmt.Sprintf("%s · %s", selected.Title, tabLabel)
+}
+
+func (m *home) paneMatchesSelection(p *store.OpenPane) bool {
+	if p == nil {
+		return false
+	}
+	selected := m.store.GetSelectedInstance()
+	return selected != nil && p.Instance() == selected && p.Tab() == m.store.ActiveTab()
 }
 
 // handleOpenPane dispatches the `s` key: open the tree selection's (instance,

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -119,6 +119,7 @@ func (m *home) View() string {
 			cols = append(cols, m.renderDivider(i-1))
 		}
 		if w := m.paneWindows[p.ID()]; w != nil {
+			w.SetSidebarSelected(m.paneMatchesSelection(p))
 			w.SetSelectionHint(m.paneSelectionHint(p))
 			cols = append(cols, w.View())
 		}

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -16,21 +16,29 @@ import (
 )
 
 var windowStyle = lipgloss.NewStyle().
-	BorderForeground(AccentColor).
+	BorderForeground(activeTheme.PaneBorderDefault).
 	Border(lipgloss.RoundedBorder())
 
-// blurredWindowStyle recedes the pane frame when focus is elsewhere in the
-// workspace, so the focus ring is legible at a glance.
+// blurredWindowStyle is the neutral pane frame for ordinary panes.
 var blurredWindowStyle = windowStyle.
 	BorderForeground(activeTheme.PaneBorderDefault)
 
+// selectedWindowStyle marks the pane that matches the current sidebar
+// highlight, while the focus ring is elsewhere.
+var selectedWindowStyle = windowStyle.
+	BorderForeground(activeTheme.PaneBorderSelected)
+
 // interactiveWindowStyle marks the pane that owns the keyboard in
-// interactive mode (#1089, RFC §2.3): a green DOUBLE border — unmistakably
-// distinct from the teal rounded nav-focus ring, and still distinct with
-// colors unavailable — signals "keystrokes go INTO this terminal".
+// interactive mode (#1089, RFC §2.3): a green DOUBLE border still signals
+// "keystrokes go INTO this terminal" even when colors are unavailable.
 var interactiveWindowStyle = windowStyle.
 	Border(lipgloss.DoubleBorder()).
 	BorderForeground(activeTheme.PaneBorderInteractive)
+
+// previewWindowStyle marks a transient #1321 preview binding without
+// mutating the pane's committed store binding.
+var previewWindowStyle = windowStyle.
+	BorderForeground(activeTheme.PaneBorderPreview)
 
 var paneHeaderStyle = lipgloss.NewStyle().
 	Bold(true).
@@ -107,6 +115,10 @@ type TabbedWindow struct {
 	// leaving the selected row and displayed content to appear contradictory
 	// (#1289).
 	selectionHint string
+	// sidebarSelected marks whether the pane's committed binding matches the
+	// current sidebar selection. It colors selected-but-not-focused panes blue
+	// without moving focus or mutating the pane binding.
+	sidebarSelected bool
 
 	// preview is a transient render binding for #1321. While set, the window
 	// still owns its committed store.OpenPane binding, but capture/render uses
@@ -394,6 +406,12 @@ func (w *TabbedWindow) SetSelectionHint(title string) {
 	w.selectionHint = title
 }
 
+// SetSidebarSelected marks whether this pane corresponds to the current
+// sidebar highlight. The root model updates it immediately before rendering.
+func (w *TabbedWindow) SetSidebarSelected(on bool) {
+	w.sidebarSelected = on
+}
+
 // registerZones records this frame's hit-test rects: the whole pane as the
 // body (click focuses; click focused interacts; wheel scrolls), the one-line
 // `title · tab` header inside the frame on top of it, and — exactly while the
@@ -537,6 +555,19 @@ func (w *TabbedWindow) renderHeader(width int) string {
 // live capture view.
 func (w *TabbedWindow) View() string { return w.String() }
 
+func (w *TabbedWindow) frameStyle() lipgloss.Style {
+	switch {
+	case w.preview != nil:
+		return previewWindowStyle
+	case w.interactive:
+		return interactiveWindowStyle
+	case w.sidebarSelected && !w.focused:
+		return selectedWindowStyle
+	default:
+		return blurredWindowStyle
+	}
+}
+
 func (w *TabbedWindow) String() string {
 	if w.rect.Empty() {
 		return ""
@@ -560,12 +591,5 @@ func (w *TabbedWindow) String() string {
 		w.renderHeader(iw),
 		layout.ClampToRect(content, layout.Rect{W: iw, H: ih}),
 	)
-	frame := windowStyle
-	switch {
-	case w.interactive:
-		frame = interactiveWindowStyle
-	case !w.focused:
-		frame = blurredWindowStyle
-	}
-	return layout.ClampToRect(frame.Render(inner), w.rect)
+	return layout.ClampToRect(w.frameStyle().Render(inner), w.rect)
 }

--- a/ui/tabbed_window_style_test.go
+++ b/ui/tabbed_window_style_test.go
@@ -1,0 +1,45 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+func TestTabbedWindowFrameStyleUsesPaneBorderThemeSlots(t *testing.T) {
+	defaultTheme := config.DefaultThemeConfig()
+	t.Cleanup(func() { ApplyTheme(defaultTheme) })
+
+	custom := defaultTheme
+	custom.PaneBorderDefault = "#111111"
+	custom.PaneBorderSelected = "#222222"
+	custom.PaneBorderInteractive = "#333333"
+	custom.PaneBorderPreview = "#444444"
+	ApplyTheme(custom)
+
+	assertFrameColor := func(name string, w *TabbedWindow, want string) {
+		t.Helper()
+		got := w.frameStyle().GetBorderBottomForeground()
+		if got != lipgloss.TerminalColor(lipgloss.Color(want)) {
+			t.Fatalf("%s border = %v, want %s", name, got, want)
+		}
+	}
+
+	w := NewTabbedWindow(NewTabPane(), nil)
+	assertFrameColor("default", w, "#111111")
+
+	w.SetSidebarSelected(true)
+	assertFrameColor("selected but not focused", w, "#222222")
+
+	w.Focus()
+	assertFrameColor("focused nav", w, "#111111")
+
+	w.SetInteractive(true)
+	assertFrameColor("interactive", w, "#333333")
+
+	w.SetInteractive(false)
+	w.SetPreview(nil, 0, "original")
+	assertFrameColor("preview", w, "#444444")
+}

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -92,13 +92,17 @@ func CurrentTheme() Theme {
 
 func applyThemeStyles() {
 	windowStyle = lipgloss.NewStyle().
-		BorderForeground(activeTheme.Accent).
+		BorderForeground(activeTheme.PaneBorderDefault).
 		Border(lipgloss.RoundedBorder())
 	blurredWindowStyle = windowStyle.
 		BorderForeground(activeTheme.PaneBorderDefault)
+	selectedWindowStyle = windowStyle.
+		BorderForeground(activeTheme.PaneBorderSelected)
 	interactiveWindowStyle = windowStyle.
 		Border(lipgloss.DoubleBorder()).
 		BorderForeground(activeTheme.PaneBorderInteractive)
+	previewWindowStyle = windowStyle.
+		BorderForeground(activeTheme.PaneBorderPreview)
 
 	paneHeaderStyle = lipgloss.NewStyle().
 		Bold(true).

--- a/ui/theme_test.go
+++ b/ui/theme_test.go
@@ -20,13 +20,14 @@ func TestAccentColorValue(t *testing.T) {
 // TestAccentSitesUseConstant guards against the half-finished migration that
 // left accent surfaces on unrelated literals while the rest of the TUI used
 // the configured accent. These are the most prominent accent surfaces.
+// Pane borders are semantic state colors and are covered in tabbed-window
+// tests.
 func TestAccentSitesUseConstant(t *testing.T) {
 	cases := []struct {
 		name string
 		got  lipgloss.TerminalColor
 	}{
 		{"sidebar title banner background", mainTitle.GetBackground()},
-		{"focused window border", windowStyle.GetBorderBottomForeground()},
 		{"automations strip title", automationsTitleStyle.GetForeground()},
 		{"menu action group", actionGroupStyle.GetForeground()},
 	}
@@ -47,6 +48,7 @@ func TestApplyThemeRebuildsProminentStyles(t *testing.T) {
 	custom.ForegroundMuted = "#556677"
 	custom.SelectionBackground = "#223344"
 	custom.SelectionForeground = "#DDEEFF"
+	custom.PaneBorderDefault = "#778899"
 	ApplyTheme(custom)
 
 	assertColor := func(name string, got lipgloss.TerminalColor, want string) {
@@ -57,7 +59,7 @@ func TestApplyThemeRebuildsProminentStyles(t *testing.T) {
 	}
 	assertColor("AccentColor", lipgloss.TerminalColor(AccentColor), "#112233")
 	assertColor("mainTitle background", mainTitle.GetBackground(), "#112233")
-	assertColor("window border", windowStyle.GetBorderBottomForeground(), "#112233")
+	assertColor("window border", windowStyle.GetBorderBottomForeground(), "#778899")
 	assertColor("menu action group", actionGroupStyle.GetForeground(), "#112233")
 	assertColor("tree title", lipgloss.TerminalColor(tree.InstanceTitleColor), "#445566")
 	assertColor("pane focused header background", paneHeaderFocusedStyle.GetBackground(), "#223344")


### PR DESCRIPTION
Closes #1424

Summary:
- route pane frame border colors through the configured pane_border_* theme slots
- mark selected-but-not-focused panes from the current sidebar selection
- give preview panes the preview border and keep interactive panes on the interactive border

Precedence:
- preview -> pane_border_preview
- interactive -> pane_border_interactive
- selected but not focused -> pane_border_selected
- ordinary pane -> pane_border_default

Gates:
- gofmt
- git diff --check
- go build ./...
- golangci-lint --fast
- make test-container
- deadcode
- scripts/lint-file-length.sh
- make tui-driver-selftest (24/24)