### PR TITLE
fix(tui): skip sidebar title rows during nav

### DIFF
--- a/app/cold_start_test.go
+++ b/app/cold_start_test.go
@@ -85,8 +85,8 @@ func TestColdStartFromSnapshot_WaitsOutWarmingDaemon(t *testing.T) {
 // startup), so no instance is bound to the workspace panes — the pre-store
 // TabbedWindow.instance also started nil — and the active tab starts at 0.
 // The panes bind on the first cursor move: Down lands on the first restored
-// instance and selectionChanged binds it, exactly the old
-// selectionChanged→TabbedWindow.SetInstance first-keypress behavior.
+// instance's Agent tab and selectionChanged binds its parent instance, exactly
+// the old selectionChanged→TabbedWindow.SetInstance first-keypress behavior.
 func TestColdStartFromSnapshot_LaunchSelectionParity(t *testing.T) {
 	h := newTestHome(t)
 	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
@@ -108,11 +108,13 @@ func TestColdStartFromSnapshot_LaunchSelectionParity(t *testing.T) {
 		"no instance bound to the workspace panes at launch (TabbedWindow.instance started nil pre-store)")
 	require.Equal(t, 0, h.store.ActiveTab(), "active tab starts on the agent tab")
 
-	// First keypress: Down moves onto the first restored instance and binds it.
+	// First keypress: Down moves onto the first restored instance's Agent tab
+	// and binds its parent instance.
 	h.sidebar.Down()
 	_ = h.selectionChanged()
 	first := h.store.GetInstances()[0]
 	require.Equal(t, "first", first.Title)
+	require.True(t, h.sidebar.GetSelection().IsTab, "the first Down must land on a tab row")
 	require.Same(t, first, h.sidebar.GetSelectedInstance(),
 		"the first Down must land on the first restored instance")
 	require.Same(t, first, h.store.GetSelectedInstance(),

--- a/app/pane_model_test.go
+++ b/app/pane_model_test.go
@@ -512,7 +512,8 @@ func TestPanePreviewSplitHideDoesNotStickInPanePreview(t *testing.T) {
 	paneA := h.store.OpenPanes()[0]
 	require.Same(t, alpha, paneA.Instance())
 
-	for i := 0; i < 3; i++ {
+	// alpha tab 0 -> alpha tab 1 -> beta tab 0 -> beta tab 1.
+	for i := 0; i < 4; i++ {
 		pressNav(t, h, "j")
 	}
 	require.Same(t, beta, h.store.GetSelectedInstance())

--- a/app/tree_nav_test.go
+++ b/app/tree_nav_test.go
@@ -36,10 +36,11 @@ func addTreeInstance(t *testing.T, h *home, title string) *session.Instance {
 	return inst
 }
 
-// TestTreeNav_JKWalksTabChildren pins the #1024 PR 3 nav model at the app
-// layer: j/k walk from an instance row into its expanded tab children and out
-// to the next instance, with each tab row driving the store's active tab (the
-// content pane binding), and h folding back to the parent.
+// TestTreeNav_JKWalksTabChildren pins the #1024 PR 3 / #1515 nav model at the
+// app layer: j/k walk tab-to-tab, crossing instance boundaries directly from
+// the last tab of one instance to the first tab of the next. Each tab row
+// drives the store's active tab (the content pane binding), and h folds back
+// to the parent title row.
 func TestTreeNav_JKWalksTabChildren(t *testing.T) {
 	h := newTestHome(t)
 	a := addTreeInstance(t, h, "alpha")
@@ -64,17 +65,24 @@ func TestTreeNav_JKWalksTabChildren(t *testing.T) {
 	assert.Equal(t, 1, h.store.ActiveTab(),
 		"Enter on this row would attach the terminal tab — the tab dimension routes attach")
 
-	// j past the last child lands on beta; alpha folds (collapse-by-default).
+	// j past the last child lands on beta's first tab; alpha folds
+	// (collapse-by-default), and the cursor never stops on beta's title row.
 	pressNav(t, h, "j")
 	require.Same(t, b, h.sidebar.GetSelectedInstance())
 	assert.Same(t, b, h.store.GetSelectedInstance(), "tree selection retargets the store selection")
+	sel = h.sidebar.GetSelection()
+	assert.True(t, sel.IsTab)
+	assert.Equal(t, 0, sel.TabIndex)
+	assert.Equal(t, 0, h.store.ActiveTab())
 
-	// k back up: beta's row was preceded by alpha's (now folded) row.
+	// k back up lands on alpha's last tab, not alpha's title row.
 	pressNav(t, h, "k")
 	require.Same(t, a, h.sidebar.GetSelectedInstance())
+	sel = h.sidebar.GetSelection()
+	assert.True(t, sel.IsTab)
+	assert.Equal(t, 1, sel.TabIndex)
 
 	// h on a tab row folds to the parent instance row.
-	pressNav(t, h, "j")
 	require.True(t, h.sidebar.GetSelection().IsTab)
 	pressNav(t, h, "h")
 	sel = h.sidebar.GetSelection()
@@ -85,6 +93,37 @@ func TestTreeNav_JKWalksTabChildren(t *testing.T) {
 	pressNav(t, h, "l")
 	pressNav(t, h, "j")
 	assert.True(t, h.sidebar.GetSelection().IsTab)
+}
+
+func TestTreeNav_TabStopAcrossInstancePreservesParentForActions(t *testing.T) {
+	h := newTestHome(t)
+	alpha := startedLocalInstance(t, "alpha")
+	beta := startedLocalInstance(t, "beta")
+	h.store.AddInstance(alpha)
+	h.store.AddInstance(beta)
+	h.sidebar.SetSelectedInstance(0)
+	h.store.SetSelectedInstance(alpha)
+	_ = h.selectionChanged()
+
+	pressNav(t, h, "j") // alpha tab 0
+	pressNav(t, h, "j") // alpha tab 1
+	pressNav(t, h, "j") // beta tab 0, with no beta title stop
+
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsTab)
+	require.Equal(t, 1, sel.ItemIndex, "tab row keeps the parent instance index")
+	require.Same(t, beta, h.sidebar.GetSelectedInstance(),
+		"instance actions resolve the selected tab's parent instance")
+
+	var createdFor string
+	t.Cleanup(SetTabCreatorForTest(func(title, repoID string) (string, error) {
+		createdFor = title
+		return spawnDaemonTab(beta), nil
+	}))
+
+	_, _ = h.handleNewTab()
+	assert.Equal(t, beta.Title, createdFor,
+		"new-tab action must target the parent session of the selected tab")
 }
 
 // TestTreeNav_NumberJumpMovesCursorOnTabRows pins the 1-9 muscle-memory rule:

--- a/scripts/tui-driver-selftest.sh
+++ b/scripts/tui-driver-selftest.sh
@@ -126,9 +126,10 @@ step "create instance 'alpha'"                              af_new_instance alph
 # tree cursor still sits on the section header — so GetSelectedInstance() is
 # nil and cursor-driven verbs (o/D) silently NO-OP even though the row LOOKS
 # selected. The old af_select returned on iteration 0 (▾ present) and a
-# play-test could wrongly "pass". af_select now lands the cursor ON the row, so
-# `o attach` MUST actually fire here. If the bug returns, either af_select
-# fails (no 'D kill') or af_attach times out waiting for the chrome to vanish.
+# play-test could wrongly "pass". af_select now lands the cursor on an
+# actionable tab row, so `o attach` MUST actually fire here. If the bug returns,
+# either af_select fails (no 'D kill') or af_attach times out waiting for the
+# chrome to vanish.
 step "select the SOLE instance alpha"                       af_select alpha
 step "assert alpha display-selected (sole instance)"        af_expect_selected alpha
 step "attach the SOLE instance (proves 'o' is NOT a no-op)" af_attach

--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -384,11 +384,12 @@ af_new_instance() {
     af_wait_for "${name}.*●" "$AF_DRIVER_TIMEOUT" "instance '${name}' ready" || return 1
 }
 
-# af_select <name> — put the tree cursor ON <name>'s row (so it is the *real*
-# GetSelectedInstance(), not merely display-selected). Robust to any starting
-# cursor position: anchor at the top (k is idempotent there), then step down
-# until BOTH conditions hold — <name>'s row carries the ▾ selected/expanded
-# arrow AND the menu advertises a row-scoped verb (`D kill`).
+# af_select <name> — put the tree cursor on one of <name>'s TAB rows (so it is
+# the *real* GetSelectedInstance(), not merely display-selected). Robust to any
+# starting cursor position: anchor at the first live tab stop (k is idempotent
+# there), then step down until BOTH conditions hold — <name>'s parent row
+# carries the ▾ selected/expanded arrow AND the menu advertises an
+# instance-scoped verb (`D kill`).
 #
 # The two-part success condition is the #1174-item-1 / #1199 fix. The sticky
 # ▾ is a DISPLAY-selection: a SINGLE auto-selected instance renders ▾ while the
@@ -398,8 +399,8 @@ af_new_instance() {
 # check returns on iteration 0 in that case — a false positive that can make a
 # play-test wrongly "pass" a nav action that never fired. `D kill` appears in
 # the menu ONLY when an instance is actually under the cursor (non-nil
-# GetSelectedInstance()), so requiring it forces `j` past the header until the
-# cursor truly lands on the row.
+# GetSelectedInstance()), so requiring it forces `j` past the header/title rows
+# until the cursor truly lands on an actionable tab row.
 af_select() {
     local name="$1" _ screen name_re
     [ -n "$name" ] || { _af_fail "af_select: name required"; return 1; }
@@ -417,7 +418,7 @@ af_select() {
         af_send j
         sleep "$AF_DRIVER_POLL"
     done
-    _af_log "could not select '${name}' (need ▾ on its row AND cursor-on-row, i.e. 'D kill' in the menu)"
+    _af_log "could not select '${name}' (need ▾ on its parent row AND cursor-on-tab, i.e. 'D kill' in the menu)"
     printf '%s\n' "$screen" >&2
     return 1
 }

--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -170,6 +170,97 @@ func TestSidebar_MoveCursorToArchivedInstance(t *testing.T) {
 		"sync must not reassert the previous live cursor row over the archived selection")
 }
 
+func TestSidebar_NavCrossesBetweenLiveTabsAndArchivedRows(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+
+	liveInst := archTestInstance(t, "live-one", session.Ready)
+	addAgentShellTabs(liveInst)
+	archivedInst := archTestInstance(t, "put-away", session.Archived)
+	addTestInstance(s, liveInst)
+	addTestInstance(s, archivedInst)
+	s.SetSize(40, 40)
+
+	s.expandSectionKind(SectionArchived)
+	require.True(t, archivedRowVisible(s), "archived row must be visible for the boundary walk")
+	s.SetSelectedInstance(0)
+
+	s.Down() // live Agent tab
+	s.Down() // live Terminal tab, the last live tab stop
+	sel := s.GetSelection()
+	require.True(t, sel.IsTab)
+	require.Equal(t, SectionInstances, sel.Kind)
+	require.Equal(t, 1, sel.TabIndex)
+
+	s.Down()
+	sel = s.GetSelection()
+	require.Equal(t, SectionArchived, sel.Kind, "Down after the last live tab reaches archived rows")
+	require.False(t, sel.IsHeader)
+	require.Same(t, archivedInst, s.GetSelectedInstance())
+
+	s.Up()
+	sel = s.GetSelection()
+	require.Equal(t, SectionInstances, sel.Kind, "Up from the first archived row returns to live tabs")
+	require.True(t, sel.IsTab)
+	require.Equal(t, 1, sel.TabIndex)
+	require.Same(t, liveInst, s.GetSelectedInstance())
+}
+
+func TestSidebar_NavSkipsNonExpandableLiveRowsBeforeArchived(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+
+	liveInst := archTestInstance(t, "live-one", session.Ready)
+	addAgentShellTabs(liveInst)
+	deletingInst := archTestInstance(t, "going-away", session.Deleting)
+	archivedInst := archTestInstance(t, "put-away", session.Archived)
+	addTestInstance(s, liveInst)
+	addTestInstance(s, deletingInst)
+	addTestInstance(s, archivedInst)
+	s.SetSize(40, 40)
+	s.expandSectionKind(SectionArchived)
+
+	s.SetSelectedInstance(0)
+	s.Down() // live Agent tab
+	s.Down() // live Terminal tab, the last live tab stop
+	require.True(t, s.GetSelection().IsTab)
+
+	s.Down()
+	sel := s.GetSelection()
+	require.Equal(t, SectionArchived, sel.Kind,
+		"Down after the last live tab skips non-expandable live rows and reaches archived rows")
+	require.False(t, sel.IsHeader)
+	require.Same(t, archivedInst, s.GetSelectedInstance())
+
+	s.Up()
+	sel = s.GetSelection()
+	require.Equal(t, SectionInstances, sel.Kind,
+		"Up from archived skips non-expandable live rows and returns to the last live tab")
+	require.True(t, sel.IsTab)
+	require.Equal(t, 1, sel.TabIndex)
+	require.Same(t, liveInst, s.GetSelectedInstance())
+
+	s.SetSelectedInstance(1)
+	sel = s.GetSelection()
+	require.Equal(t, SectionInstances, sel.Kind)
+	require.False(t, sel.IsTab, "precondition: explicit selection can rest on the deleting live title")
+	require.Same(t, deletingInst, s.GetSelectedInstance())
+
+	s.Down()
+	sel = s.GetSelection()
+	require.Equal(t, SectionArchived, sel.Kind,
+		"Down from a non-expandable live title reaches the next selectable row")
+	require.False(t, sel.IsHeader)
+	require.Same(t, archivedInst, s.GetSelectedInstance())
+
+	s.Up()
+	sel = s.GetSelection()
+	require.Equal(t, SectionInstances, sel.Kind)
+	require.True(t, sel.IsTab)
+	require.Equal(t, 1, sel.TabIndex)
+	require.Same(t, liveInst, s.GetSelectedInstance())
+}
+
 func archivedRowVisible(s *Sidebar) bool {
 	for _, it := range s.visibleItems {
 		if it.Kind == SectionArchived && !it.IsHeader && it.ItemIndex >= 0 {

--- a/ui/sidebar_nav.go
+++ b/ui/sidebar_nav.go
@@ -241,21 +241,203 @@ func (s *Sidebar) GetSelection() SidebarItem {
 	return s.rawSelection()
 }
 
-// Down moves the cursor down, walking through expanded tab children.
+type sidebarTabStop struct {
+	itemIndex int
+	tabIndex  int
+}
+
+type sidebarNavStop struct {
+	isTab      bool
+	tab        sidebarTabStop
+	visibleIdx int
+}
+
+// liveTabStops returns the logical vertical-nav stops for the live Instances
+// tree. Instance title rows remain visible structural rows, but j/k/up/down
+// stop only on tab rows; archived rows are a separate flat section and keep
+// their existing selection behavior.
+func (s *Sidebar) liveTabStops() []sidebarTabStop {
+	instances := s.proj.GetInstances()
+	live, _ := partitionByArchived(instances)
+	stops := make([]sidebarTabStop, 0, len(live))
+	for _, idx := range live {
+		inst := instances[idx]
+		if !tree.Expandable(inst) {
+			continue
+		}
+		for tab := range tree.TabLabels(inst) {
+			stops = append(stops, sidebarTabStop{itemIndex: idx, tabIndex: tab})
+		}
+	}
+	return stops
+}
+
+func (s *Sidebar) verticalNavStops() []sidebarNavStop {
+	tabStops := s.liveTabStops()
+	stops := make([]sidebarNavStop, 0, len(tabStops))
+	for _, stop := range tabStops {
+		stops = append(stops, sidebarNavStop{isTab: true, tab: stop})
+	}
+	for i, item := range s.visibleItems {
+		if isSelectableNonTabNavStop(item) {
+			stops = append(stops, sidebarNavStop{visibleIdx: i})
+		}
+	}
+	return stops
+}
+
+func isSelectableNonTabNavStop(item SidebarItem) bool {
+	return !item.IsHeader && !item.IsTab && item.Kind == SectionArchived
+}
+
+func indexOfNavStop(stops []sidebarNavStop, selectedIdx int, sel SidebarItem) int {
+	for i, stop := range stops {
+		if stop.isTab {
+			if sel.Kind == SectionInstances && sel.IsTab &&
+				stop.tab.itemIndex == sel.ItemIndex && stop.tab.tabIndex == sel.TabIndex {
+				return i
+			}
+			continue
+		}
+		if stop.visibleIdx == selectedIdx && isSelectableNonTabNavStop(sel) {
+			return i
+		}
+	}
+	return -1
+}
+
+func firstNavStopAtOrAfterInstance(stops []sidebarNavStop, itemIndex int) int {
+	for i, stop := range stops {
+		if !stop.isTab || stop.tab.itemIndex >= itemIndex {
+			return i
+		}
+	}
+	return -1
+}
+
+func lastTabStopBeforeInstance(stops []sidebarNavStop, itemIndex int) int {
+	last := -1
+	for i, stop := range stops {
+		if !stop.isTab {
+			break
+		}
+		if stop.tab.itemIndex < itemIndex {
+			last = i
+		}
+	}
+	return last
+}
+
+func (s *Sidebar) selectTabStop(stop sidebarTabStop) bool {
+	instances := s.proj.GetInstances()
+	if stop.itemIndex < 0 || stop.itemIndex >= len(instances) {
+		return false
+	}
+	inst := instances[stop.itemIndex]
+	if !tree.Expandable(inst) {
+		return false
+	}
+	labels := tree.TabLabels(inst)
+	if stop.tabIndex < 0 || stop.tabIndex >= len(labels) {
+		return false
+	}
+
+	s.proj.SetSelectedInstance(inst)
+	s.proj.SetActiveTab(stop.tabIndex)
+	s.treeCollapsed = ""
+	for i, sec := range s.sections {
+		if sec.Kind == SectionInstances {
+			s.sections[i].Expanded = true
+			break
+		}
+	}
+	s.rebuildVisibleItems()
+	for j, item := range s.visibleItems {
+		if item.Kind == SectionInstances && !item.IsHeader && item.IsTab &&
+			item.ItemIndex == stop.itemIndex && item.TabIndex == stop.tabIndex {
+			s.selectedIdx = j
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Sidebar) selectNavStop(stop sidebarNavStop) bool {
+	if stop.isTab {
+		return s.selectTabStop(stop.tab)
+	}
+	if stop.visibleIdx < 0 || stop.visibleIdx >= len(s.visibleItems) {
+		return false
+	}
+	if !isSelectableNonTabNavStop(s.visibleItems[stop.visibleIdx]) {
+		return false
+	}
+	s.selectedIdx = stop.visibleIdx
+	return true
+}
+
+func (s *Sidebar) moveVerticalNavStop(dir int) {
+	stops := s.verticalNavStops()
+	if len(stops) == 0 {
+		return
+	}
+
+	sel := s.rawSelection()
+	if sel.IsHeader {
+		switch sel.Kind {
+		case SectionInstances:
+			if dir > 0 {
+				s.selectNavStop(stops[0])
+			}
+			return
+		case SectionArchived:
+			if dir < 0 {
+				for i := len(stops) - 1; i >= 0; i-- {
+					if stops[i].isTab {
+						s.selectNavStop(stops[i])
+						return
+					}
+				}
+			} else {
+				for _, stop := range stops {
+					if !stop.isTab && stop.visibleIdx > s.selectedIdx {
+						s.selectNavStop(stop)
+						return
+					}
+				}
+			}
+		}
+		return
+	}
+
+	target := -1
+	if cur := indexOfNavStop(stops, s.selectedIdx, sel); cur >= 0 {
+		target = cur + dir
+	} else if sel.Kind == SectionInstances && !sel.IsTab {
+		if dir > 0 {
+			target = firstNavStopAtOrAfterInstance(stops, sel.ItemIndex)
+		} else {
+			target = lastTabStopBeforeInstance(stops, sel.ItemIndex)
+		}
+	}
+
+	if target < 0 || target >= len(stops) {
+		return
+	}
+	s.selectNavStop(stops[target])
+}
+
+// Down moves the cursor down through live tab stops, skipping instance titles.
 func (s *Sidebar) Down() {
 	s.syncFromStore()
-	if s.selectedIdx < len(s.visibleItems)-1 {
-		s.selectedIdx++
-	}
+	s.moveVerticalNavStop(1)
 	s.afterCursorMove()
 }
 
-// Up moves the cursor up, walking through expanded tab children.
+// Up moves the cursor up through live tab stops, skipping instance titles.
 func (s *Sidebar) Up() {
 	s.syncFromStore()
-	if s.selectedIdx > 0 {
-		s.selectedIdx--
-	}
+	s.moveVerticalNavStop(-1)
 	s.afterCursorMove()
 }
 

--- a/ui/sidebar_render.go
+++ b/ui/sidebar_render.go
@@ -130,8 +130,10 @@ func (s *Sidebar) String() string {
 }
 
 // scrollToSelection clamps scrollOffset and moves it minimally so the selected
-// row is fully inside the rendered window. Only called when the list overflows
-// the allocation.
+// row is fully inside the rendered window. For tab rows, the parent instance
+// title is treated as the top anchor when it fits, preserving the rendered
+// group header even though vertical nav stops on tabs only. Only called when
+// the list overflows the allocation.
 func (s *Sidebar) scrollToSelection(heights []int, avail int) {
 	n := len(heights)
 	if s.scrollOffset > n-1 {
@@ -140,8 +142,9 @@ func (s *Sidebar) scrollToSelection(heights []int, avail int) {
 	if s.scrollOffset < 0 {
 		s.scrollOffset = 0
 	}
-	if s.selectedIdx < s.scrollOffset {
-		s.scrollOffset = s.selectedIdx
+	anchor := s.scrollAnchorIndex()
+	if anchor < s.scrollOffset {
+		s.scrollOffset = anchor
 	}
 	for s.scrollOffset < s.selectedIdx {
 		end, _, _ := fitWindow(heights, s.scrollOffset, avail)
@@ -159,6 +162,31 @@ func (s *Sidebar) scrollToSelection(heights []int, avail int) {
 		}
 		s.scrollOffset--
 	}
+}
+
+func (s *Sidebar) scrollAnchorIndex() int {
+	if s.selectedIdx < 0 || s.selectedIdx >= len(s.visibleItems) {
+		return s.selectedIdx
+	}
+	sel := s.visibleItems[s.selectedIdx]
+	if sel.Kind != SectionInstances || !sel.IsTab {
+		return s.selectedIdx
+	}
+	for i := s.selectedIdx - 1; i >= 0; i-- {
+		item := s.visibleItems[i]
+		if item.Kind == SectionInstances && !item.IsHeader && !item.IsTab &&
+			item.ItemIndex == sel.ItemIndex {
+			if i > 0 && s.visibleItems[i-1].IsHeader &&
+				s.visibleItems[i-1].Kind == SectionInstances {
+				return i - 1
+			}
+			return i
+		}
+		if isInstanceRow(item) && item.ItemIndex != sel.ItemIndex {
+			break
+		}
+	}
+	return s.selectedIdx
 }
 
 // fitWindow returns the exclusive end index of the rows that fit when

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -66,21 +66,14 @@ func TestSidebarNavigation(t *testing.T) {
 	assert.True(t, sel.IsHeader)
 	assert.Equal(t, SectionInstances, sel.Kind)
 
-	// Move down onto the first instance row: it becomes the selected instance
-	// and auto-expands its tab children (#1024 PR 3).
+	// Move down onto the first instance's first tab row: instance title rows
+	// remain rendered, but vertical nav stops on tabs only (#1515).
 	s.Down()
 	sel = s.GetSelection()
 	assert.False(t, sel.IsHeader)
 	assert.Equal(t, SectionInstances, sel.Kind)
 	assert.Equal(t, 0, sel.ItemIndex)
-	assert.False(t, sel.IsTab)
-
-	// j walks INTO the expanded tab children; landing on a tab row drives the
-	// store's active tab.
-	s.Down()
-	sel = s.GetSelection()
 	assert.True(t, sel.IsTab)
-	assert.Equal(t, 0, sel.ItemIndex)
 	assert.Equal(t, 0, sel.TabIndex)
 	assert.Equal(t, 0, s.proj.ActiveTab())
 
@@ -90,18 +83,18 @@ func TestSidebarNavigation(t *testing.T) {
 	assert.Equal(t, 1, sel.TabIndex)
 	assert.Equal(t, 1, s.proj.ActiveTab())
 
-	// Past the last child: the second instance. Selecting it collapses inst1
-	// (collapse-by-default for non-selected) and expands inst2.
+	// Past the last child: the second instance's first tab. Selecting it
+	// collapses inst1 (collapse-by-default for non-selected) and expands inst2.
 	s.Down()
 	sel = s.GetSelection()
-	assert.False(t, sel.IsTab)
+	assert.True(t, sel.IsTab)
 	assert.Equal(t, 1, sel.ItemIndex)
+	assert.Equal(t, 0, sel.TabIndex)
 	require.NotNil(t, s.GetSelectedInstance())
 	assert.Equal(t, "inst2", s.GetSelectedInstance().Title)
 
 	// Through inst2's children to the last row; the rail ends there (no more
 	// Tasks/Hooks headers since #1024 PR 4), so further Down is a no-op.
-	s.Down()
 	s.Down()
 	sel = s.GetSelection()
 	assert.True(t, sel.IsTab)
@@ -111,7 +104,7 @@ func TestSidebarNavigation(t *testing.T) {
 	s.Down()
 	assert.Equal(t, sel, s.GetSelection(), "Down past the last row is a no-op")
 
-	// Move back up onto inst2's first tab row
+	// Move back up onto inst2's first tab row.
 	s.Up()
 	sel = s.GetSelection()
 	assert.True(t, sel.IsTab)
@@ -170,11 +163,11 @@ func TestSidebarJumpSections(t *testing.T) {
 	assert.Equal(t, SectionInstances, sel.Kind)
 
 	// With Instances the only section (#1024 PR 4), the section-jump keys
-	// no-op forward and return the cursor to the header from a child row.
+	// no-op forward and return the cursor to the header from a tab row.
 	s.JumpNextSection()
 	assert.Equal(t, sel, s.GetSelection(), "no next section to jump to")
 
-	s.Down() // onto the instance row
+	s.Down() // onto the instance's Agent tab
 	s.JumpPrevSection()
 	sel = s.GetSelection()
 	assert.True(t, sel.IsHeader)
@@ -190,14 +183,14 @@ func TestSidebarCollapseFromChild(t *testing.T) {
 	})
 	addTestInstance(s, inst)
 
-	// Navigate to instance child (auto-expanded: it is now selected)
+	// Navigate to the instance's Agent tab (auto-expanded: it is now selected).
 	s.Down()
 	sel := s.GetSelection()
 	assert.False(t, sel.IsHeader)
 	assert.Equal(t, SectionInstances, sel.Kind)
 
 	// First collapse folds the instance's own tab children in place (#1024
-	// PR 3); the cursor stays on the instance row.
+	// PR 3); the cursor lands on the instance row.
 	s.CollapseSection()
 	sel = s.GetSelection()
 	assert.False(t, sel.IsHeader)
@@ -458,10 +451,10 @@ func TestSidebarWindowScrollsWithSelection(t *testing.T) {
 	check("initial")
 	for i := 0; ; i++ {
 		require.Less(t, i, 500, "down-walk must terminate")
-		before := s.selectedIdx
+		before := s.rowIdentityAt(s.rawSelection())
 		s.Down()
 		check(fmt.Sprintf("down %d", i))
-		if s.selectedIdx == before {
+		if s.rowIdentityAt(s.rawSelection()) == before {
 			break
 		}
 	}
@@ -470,12 +463,13 @@ func TestSidebarWindowScrollsWithSelection(t *testing.T) {
 	assert.True(t, up, "rows above must be indicated at the bottom")
 	assert.False(t, down, "nothing is hidden below at the bottom")
 
-	// Walk back up to the top.
+	// Walk back up to the first live tab stop.
 	for i := 0; ; i++ {
 		require.Less(t, i, 500, "up-walk must terminate")
+		before := s.rowIdentityAt(s.rawSelection())
 		s.Up()
 		check(fmt.Sprintf("up %d", i))
-		if sel := s.GetSelection(); sel.IsHeader && sel.Kind == SectionInstances {
+		if s.rowIdentityAt(s.rawSelection()) == before {
 			break
 		}
 	}


### PR DESCRIPTION
## Summary
- make sidebar up/down/j/k navigation walk live tab stops only, crossing instance boundaries directly from the last tab to the next parent's first tab
- preserve tab `ItemIndex` parent resolution for instance-scoped actions and keep archived row selection behavior intact
- keep rendered instance headers visible as group context while updating sidebar/app/driver expectations for the tab-only walk

Closes #1515

## Tests
- `golangci-lint run --fast`
- `gofmt -l ui/sidebar_nav.go ui/sidebar_render.go ui/sidebar_test.go app/tree_nav_test.go app/cold_start_test.go app/pane_model_test.go`
- `go build ./...`
- `make test-container`
- `make tui-driver-selftest` (24/24)
- `make lint-file-length`
- `deadcode ./...` (exit 0; reports existing unreachable helper list, no changed files reported)