### PR TITLE
tui: drop create session name label

### DIFF
--- a/scripts/tui-driver.sh
+++ b/scripts/tui-driver.sh
@@ -379,6 +379,7 @@ af_new_instance() {
     af_focus_tree || return 1
     af_send n
     af_wait_for 'submit name' "$AF_DRIVER_TIMEOUT" 'name prompt' || return 1
+    af_wait_gone '[Ss]ession [Nn]ame:' 1 'old name prompt label' || return 1
     af_send_literal "$name"
     af_send Enter
     af_wait_for "${name}.*●" "$AF_DRIVER_TIMEOUT" "instance '${name}' ready" || return 1

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -303,9 +303,6 @@ func (r *InstanceRenderer) Render(i *session.Instance, _ int, selected bool, has
 
 	// Cut the title if it's too long
 	titleText := i.Title
-	if op == session.OpCreating {
-		titleText = "Session name: " + titleText
-	}
 	if i.IsRemote() {
 		titleText = "[remote] " + titleText
 	}

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -287,7 +287,7 @@ func TestInstanceRendererArchivedShowsName(t *testing.T) {
 	}
 }
 
-func TestInstanceRendererCreatingRowLabelsNamePrompt(t *testing.T) {
+func TestInstanceRendererCreatingRowShowsBareName(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	inst, err := session.NewInstance(session.InstanceOptions{
 		Title:   "alpha",
@@ -301,7 +301,8 @@ func TestInstanceRendererCreatingRowLabelsNamePrompt(t *testing.T) {
 	r.SetWidth(40)
 
 	title := strings.Split(ansiEscape.ReplaceAllString(r.Render(inst, 1, true, false, false), ""), "\n")[1]
-	assert.Contains(t, title, "Session name: alpha", "creating rows must label the active name target")
+	assert.Contains(t, title, "alpha", "creating rows must show the typed name")
+	assert.NotContains(t, title, "Session name:", "creating rows must not prefix the input label")
 }
 
 // TestInstanceRendererDeletingDimsSelectedRow pins the #853 fix: a SELECTED


### PR DESCRIPTION
Summary:
- Remove the "Session name:" prefix from the new-instance naming row so the typed title stands alone.
- Update the tree renderer assertion and the TUI driver create helper to guard against the old label returning.

Tests:
- gofmt -l .
- golangci-lint run --timeout=3m --out-format=line-number --fast --max-issues-per-linter=0 --max-same-issues=0
- go build ./...
- deadcode -test ./...
- scripts/lint-file-length.sh
- make tui-driver-selftest (24/24)
- make test-container

Closes #1517