### PR TITLE
fix(tui): auto-open archived section at nav tail

### DIFF
--- a/app/tree_nav_test.go
+++ b/app/tree_nav_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sachiniyer/agent-factory/keys"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui"
 )
 
 // pressNav drives handleDefaultKeyPress with a mapped nav key, the way
@@ -93,6 +94,40 @@ func TestTreeNav_JKWalksTabChildren(t *testing.T) {
 	pressNav(t, h, "l")
 	pressNav(t, h, "j")
 	assert.True(t, h.sidebar.GetSelection().IsTab)
+}
+
+func TestTreeNav_DownAutoOpensArchivedAtLiveBoundary(t *testing.T) {
+	h := newTestHome(t)
+	live := startedLocalInstance(t, "live-one")
+	archived := archiveActionInstance(t, "put-away", session.Ready)
+	archived.SetArchived()
+
+	h.store.AddInstance(live)
+	h.store.AddInstance(archived)
+	resizeHome(h, 120, 40)
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+	require.Same(t, live, h.sidebar.GetSelectedInstance())
+	require.NotContains(t, h.sidebar.View(), "put-away", "Archived starts collapsed")
+
+	pressNav(t, h, "j") // live Agent tab
+	pressNav(t, h, "j") // live Terminal tab
+	require.True(t, h.sidebar.GetSelection().IsTab)
+
+	pressNav(t, h, "j")
+	sel := h.sidebar.GetSelection()
+	require.Equal(t, ui.SectionArchived, sel.Kind,
+		"Down after the last live tab must auto-open Archived and select the first archived row")
+	require.False(t, sel.IsHeader)
+	require.Same(t, archived, h.sidebar.GetSelectedInstance())
+	assert.Contains(t, h.sidebar.View(), "put-away", "auto-opened Archived must render archived rows")
+
+	pressNav(t, h, "k")
+	sel = h.sidebar.GetSelection()
+	require.Equal(t, ui.SectionInstances, sel.Kind)
+	require.True(t, sel.IsTab)
+	require.Equal(t, 1, sel.TabIndex)
+	require.Same(t, live, h.sidebar.GetSelectedInstance())
 }
 
 func TestTreeNav_TabStopAcrossInstancePreservesParentForActions(t *testing.T) {

--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -181,8 +181,7 @@ func TestSidebar_NavCrossesBetweenLiveTabsAndArchivedRows(t *testing.T) {
 	addTestInstance(s, archivedInst)
 	s.SetSize(40, 40)
 
-	s.expandSectionKind(SectionArchived)
-	require.True(t, archivedRowVisible(s), "archived row must be visible for the boundary walk")
+	require.False(t, archivedRowVisible(s), "Archived starts collapsed before the boundary walk")
 	s.SetSelectedInstance(0)
 
 	s.Down() // live Agent tab
@@ -194,8 +193,10 @@ func TestSidebar_NavCrossesBetweenLiveTabsAndArchivedRows(t *testing.T) {
 
 	s.Down()
 	sel = s.GetSelection()
-	require.Equal(t, SectionArchived, sel.Kind, "Down after the last live tab reaches archived rows")
+	require.Equal(t, SectionArchived, sel.Kind,
+		"Down after the last live tab auto-opens Archived and reaches archived rows")
 	require.False(t, sel.IsHeader)
+	require.True(t, archivedRowVisible(s), "Down at the live boundary must expand Archived")
 	require.Same(t, archivedInst, s.GetSelectedInstance())
 
 	s.Up()
@@ -218,7 +219,7 @@ func TestSidebar_NavSkipsNonExpandableLiveRowsBeforeArchived(t *testing.T) {
 	addTestInstance(s, deletingInst)
 	addTestInstance(s, archivedInst)
 	s.SetSize(40, 40)
-	s.expandSectionKind(SectionArchived)
+	require.False(t, archivedRowVisible(s), "Archived starts collapsed before the boundary walk")
 
 	s.SetSelectedInstance(0)
 	s.Down() // live Agent tab
@@ -228,8 +229,9 @@ func TestSidebar_NavSkipsNonExpandableLiveRowsBeforeArchived(t *testing.T) {
 	s.Down()
 	sel := s.GetSelection()
 	require.Equal(t, SectionArchived, sel.Kind,
-		"Down after the last live tab skips non-expandable live rows and reaches archived rows")
+		"Down after the last live tab skips non-expandable live rows, auto-opens Archived, and reaches archived rows")
 	require.False(t, sel.IsHeader)
+	require.True(t, archivedRowVisible(s), "Down at the live boundary must expand Archived")
 	require.Same(t, archivedInst, s.GetSelectedInstance())
 
 	s.Up()
@@ -246,11 +248,21 @@ func TestSidebar_NavSkipsNonExpandableLiveRowsBeforeArchived(t *testing.T) {
 	require.False(t, sel.IsTab, "precondition: explicit selection can rest on the deleting live title")
 	require.Same(t, deletingInst, s.GetSelectedInstance())
 
+	for i, sec := range s.sections {
+		if sec.Kind == SectionArchived {
+			s.sections[i].Expanded = false
+			break
+		}
+	}
+	s.rebuildVisibleItems()
+	require.False(t, archivedRowVisible(s), "Archived can be collapsed again before walking from the live tail")
+
 	s.Down()
 	sel = s.GetSelection()
 	require.Equal(t, SectionArchived, sel.Kind,
-		"Down from a non-expandable live title reaches the next selectable row")
+		"Down from a non-expandable live title auto-opens Archived and reaches the next selectable row")
 	require.False(t, sel.IsHeader)
+	require.True(t, archivedRowVisible(s), "Down from the non-expandable live tail must expand Archived")
 	require.Same(t, archivedInst, s.GetSelectedInstance())
 
 	s.Up()

--- a/ui/sidebar_nav.go
+++ b/ui/sidebar_nav.go
@@ -376,10 +376,10 @@ func (s *Sidebar) selectNavStop(stop sidebarNavStop) bool {
 	return true
 }
 
-func (s *Sidebar) moveVerticalNavStop(dir int) {
+func (s *Sidebar) tryMoveVerticalNavStop(dir int) bool {
 	stops := s.verticalNavStops()
 	if len(stops) == 0 {
-		return
+		return false
 	}
 
 	sel := s.rawSelection()
@@ -387,27 +387,25 @@ func (s *Sidebar) moveVerticalNavStop(dir int) {
 		switch sel.Kind {
 		case SectionInstances:
 			if dir > 0 {
-				s.selectNavStop(stops[0])
+				return s.selectNavStop(stops[0])
 			}
-			return
+			return false
 		case SectionArchived:
 			if dir < 0 {
 				for i := len(stops) - 1; i >= 0; i-- {
 					if stops[i].isTab {
-						s.selectNavStop(stops[i])
-						return
+						return s.selectNavStop(stops[i])
 					}
 				}
 			} else {
 				for _, stop := range stops {
 					if !stop.isTab && stop.visibleIdx > s.selectedIdx {
-						s.selectNavStop(stop)
-						return
+						return s.selectNavStop(stop)
 					}
 				}
 			}
 		}
-		return
+		return false
 	}
 
 	target := -1
@@ -422,9 +420,44 @@ func (s *Sidebar) moveVerticalNavStop(dir int) {
 	}
 
 	if target < 0 || target >= len(stops) {
+		return false
+	}
+	return s.selectNavStop(stops[target])
+}
+
+func (s *Sidebar) moveVerticalNavStop(dir int) {
+	if s.tryMoveVerticalNavStop(dir) {
 		return
 	}
-	s.selectNavStop(stops[target])
+	// Archived rows are selectable stops only after the Archived section renders
+	// them. At the live-list tail, Down should reveal that folder and retry.
+	if dir <= 0 || !s.downNavCanRevealArchived() || !s.expandArchivedSectionForNav() {
+		return
+	}
+	_ = s.tryMoveVerticalNavStop(dir)
+}
+
+func (s *Sidebar) downNavCanRevealArchived() bool {
+	return s.rawSelection().Kind == SectionInstances
+}
+
+func (s *Sidebar) expandArchivedSectionForNav() bool {
+	_, archived := partitionByArchived(s.proj.GetInstances())
+	if len(archived) == 0 {
+		return false
+	}
+	for i, sec := range s.sections {
+		if sec.Kind != SectionArchived {
+			continue
+		}
+		if sec.Expanded {
+			return false
+		}
+		s.sections[i].Expanded = true
+		s.rebuildVisibleItems()
+		return true
+	}
+	return false
 }
 
 // Down moves the cursor down through live tab stops, skipping instance titles.


### PR DESCRIPTION
## Summary
- reveal the collapsed Archived section when Down crosses past the live tab-stop tail
- retry the existing #1516 vertical stop selection after Archived renders, preserving tab-only live navigation and the Up path from archived rows back to the last live tab
- add UI and app-level regression coverage for last-live-tab and non-expandable-live-tail navigation into Archived

Closes #1518

## Tests
- `golangci-lint run --fast`
- `gofmt -l ui/sidebar_nav.go ui/sidebar_archived_test.go app/tree_nav_test.go`
- `go build ./...`
- `make test-container`
- `make tui-driver-selftest` (24/24)
- `deadcode ./...` (exit 0; existing unreachable-helper report)
- `make lint-file-length`