### PR TITLE
fix(tui): add task-manager run-now affordance

### DIFF
--- a/app/home_model.go
+++ b/app/home_model.go
@@ -246,6 +246,10 @@ type home struct {
 	menu *ui.Menu
 	// errBox displays error messages inside the status bar (shared handle)
 	errBox *ui.ErrBox
+	// transientNoticeID is a generation token for the status-bar notice timer.
+	// Each new error/success notice increments it; a stale hideErrMsg from an
+	// older timer must not clear a newer notice.
+	transientNoticeID uint64
 	// alarmBanner is the top-of-screen delivery-failure alarm (#1238): a
 	// persistent red bar raised while the daemon snapshot reports a watch task
 	// whose events are failing to reach their target session. Fed each poll by
@@ -516,7 +520,7 @@ func (m *home) setPaneAutoHideStatus(p *store.OpenPane, paneCount int) {
 	msg := fmt.Sprintf("%s hidden: terminal too narrow for %d panes; resize wider%s",
 		paneStatusTitle(p), paneCount, paneRecoveryStatusHint())
 	m.pendingPaneAutoHideStatus = msg
-	m.errBox.SetError(errors.New(msg))
+	m.setTransientNotice(errors.New(msg))
 }
 
 func paneStatusTitle(p *store.OpenPane) string {

--- a/app/home_tasks.go
+++ b/app/home_tasks.go
@@ -106,12 +106,6 @@ func (m *home) handleTaskTrigger() tea.Cmd {
 		return m.handleError(fmt.Errorf("no task selected"))
 	}
 
-	// Watch tasks fire from their watch command's stdout; a manual trigger
-	// has no event line to render the prompt with. Mirrors daemon.RunTask.
-	if tsk.IsWatch() {
-		return m.handleError(fmt.Errorf("task %q is a watch task; it fires when its watch command emits output", task.TaskRunBaseTitle(*tsk)))
-	}
-
 	// The trigger fires from inside the tasks overlay: close it and move focus to
 	// the tree so the user is looking at the sessions, where the run lands (a
 	// fresh per-run session, or the delivered-into target_session).

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -17,7 +17,9 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	defer m.persistTUIViewStateAfter(msg)
 	switch msg := msg.(type) {
 	case hideErrMsg:
-		m.errBox.Clear()
+		if msg.noticeID == m.transientNoticeID {
+			m.errBox.Clear()
+		}
 	case previewTickMsg:
 		// While the user is attached to an instance, the preview/terminal
 		// panes are hidden behind the tmux client they detached into. Running
@@ -148,12 +150,13 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(cmds...)
 	case taskTriggeredMsg:
-		// The daemon-side run (#1169) failed — surface it. Success needs no
-		// action: the resulting session and updated task status live-project in.
+		// The daemon-side run (#1169) failed — surface it. On success, give a
+		// short positive acknowledgement while the resulting session and updated
+		// task status live-project in from the daemon snapshot.
 		if msg.err != nil {
 			return m, m.handleError(fmt.Errorf("failed to trigger task %q: %w", msg.title, msg.err))
 		}
-		return m, nil
+		return m, m.showTransientMessage(fmt.Sprintf("triggered %s", msg.title))
 	case tea.MouseMsg:
 		// First-class mouse (#1024 R4, closes #1025): every event is
 		// resolved through the zone registry the last View() rebuilt and

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -20,13 +21,29 @@ func (m *home) showTransientError(err error) tea.Cmd {
 	if err == nil {
 		return nil
 	}
+	return m.clearTransientMessageAfterDelay(m.setTransientNotice(err))
+}
+
+func (m *home) showTransientMessage(message string) tea.Cmd {
+	if strings.TrimSpace(message) == "" {
+		return nil
+	}
+	return m.clearTransientMessageAfterDelay(m.setTransientNotice(errors.New(message)))
+}
+
+func (m *home) setTransientNotice(err error) uint64 {
+	m.transientNoticeID++
 	m.errBox.SetError(err)
+	return m.transientNoticeID
+}
+
+func (m *home) clearTransientMessageAfterDelay(noticeID uint64) tea.Cmd {
 	return func() tea.Msg {
 		select {
 		case <-m.ctx.Done():
 		case <-time.After(3 * time.Second):
 		}
-		return hideErrMsg{}
+		return hideErrMsg{noticeID: noticeID}
 	}
 }
 
@@ -56,7 +73,7 @@ func (m *home) confirmAction(message string, action tea.Cmd) tea.Cmd {
 			if msg := action(); msg != nil {
 				if err, ok := msg.(error); ok {
 					log.ErrorLog.Printf("confirmation action failed: %v", err)
-					m.errBox.SetError(err)
+					m.setTransientNotice(err)
 				} else {
 					// Stash non-error messages so handleStateConfirm can
 					// forward them into the Bubble Tea event loop.

--- a/app/messages.go
+++ b/app/messages.go
@@ -4,7 +4,9 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
-type hideErrMsg struct{}
+type hideErrMsg struct {
+	noticeID uint64
+}
 type previewTickMsg struct{}
 type instanceChangedMsg struct{}
 

--- a/app/task_projection_test.go
+++ b/app/task_projection_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sachiniyer/agent-factory/task"
@@ -52,23 +53,145 @@ func TestTaskTriggerRoutesThroughDaemonSharedPath(t *testing.T) {
 		"run-now must NOT spawn a divergent per-run session (#1169); the daemon owns create-or-deliver")
 }
 
-// TestTaskTriggerWatchRefused pins that a watch task still cannot be manually
-// triggered (it fires from its watch command's stdout), matching daemon.RunTask.
+func TestTaskTriggerSuccessShowsTransientNotice(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+
+	_, cmd := h.Update(taskTriggeredMsg{title: "hello-task"})
+
+	require.NotNil(t, cmd, "success notice should schedule its clear timer")
+	require.Contains(t, h.errBox.String(), "triggered hello-task")
+}
+
+func TestTransientNoticeIgnoresStaleHideTimer(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+
+	_, errCmd := h.Update(errTest("first failure"))
+	require.NotNil(t, errCmd, "error notice should schedule its clear timer")
+	oldNoticeID := h.transientNoticeID
+	require.Contains(t, h.errBox.String(), "first failure")
+
+	_, successCmd := h.Update(taskTriggeredMsg{title: "hello-task"})
+	require.NotNil(t, successCmd, "success notice should schedule its clear timer")
+	newNoticeID := h.transientNoticeID
+	require.NotEqual(t, oldNoticeID, newNoticeID, "success must advance the notice generation")
+	require.Contains(t, h.errBox.String(), "triggered hello-task")
+
+	_, _ = h.Update(hideErrMsg{noticeID: oldNoticeID})
+	require.Contains(t, h.errBox.String(), "triggered hello-task",
+		"a stale timer from an older error must not clear the newer success notice")
+
+	_, _ = h.Update(hideErrMsg{noticeID: newNoticeID})
+	require.Empty(t, h.errBox.FullError(), "the current timer still clears the notice after its own delay")
+}
+
+func TestDirectTransientWriteIgnoresPriorRunNowTimer(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+
+	_, runNowCmd := h.Update(taskTriggeredMsg{title: "hello-task"})
+	require.NotNil(t, runNowCmd, "run-now notice should schedule its clear timer")
+	runNowNoticeID := h.transientNoticeID
+	require.Contains(t, h.errBox.String(), "triggered hello-task")
+
+	_ = h.confirmAction("confirm direct error?", func() tea.Msg {
+		return errTest("confirmation failed")
+	})
+	require.NotNil(t, h.confirmationOverlay)
+	h.confirmationOverlay.OnConfirm()
+	directNoticeID := h.transientNoticeID
+	require.NotEqual(t, runNowNoticeID, directNoticeID,
+		"direct status-bar writes must advance the notice generation too")
+	require.Contains(t, h.errBox.String(), "confirmation failed")
+
+	_, _ = h.Update(hideErrMsg{noticeID: runNowNoticeID})
+	require.Contains(t, h.errBox.String(), "confirmation failed",
+		"a stale run-now timer must not clear a later direct status-bar write")
+
+	_, _ = h.Update(hideErrMsg{noticeID: directNoticeID})
+	require.Empty(t, h.errBox.FullError(), "the direct write's own timer id remains authoritative")
+}
+
+// TestTaskTriggerWatchRefused pins that a watch task reaches the same daemon
+// trigger seam as `af tasks trigger`; the daemon refusal is what the TUI
+// surfaces, instead of the TUI taking a divergent pre-check path.
 func TestTaskTriggerWatchRefused(t *testing.T) {
 	h := newTestHome(t)
 	h.errBox.SetSize(200, 1)
 
-	called := false
-	restore := SetTaskTriggerForTest(func(string) error { called = true; return nil })
+	var gotID string
+	restore := SetTaskTriggerForTest(func(taskID string) error {
+		gotID = taskID
+		return errTest("task w1 is a watch task; it fires when its watch command emits output")
+	})
 	defer restore()
 
 	sp := h.automations.TaskPane()
 	sp.SetTasks([]task.Task{{ID: "w1", Name: "watcher", WatchCmd: "tail -f log", Enabled: true}})
 	sp.SelectTask(0)
 
-	h.handleTaskTrigger()
-	require.False(t, called, "a watch task must never reach the daemon trigger path")
+	cmd := h.handleTaskTrigger()
+	require.NotNil(t, cmd)
+	for _, msg := range drainCmd(t, cmd, 500*time.Millisecond) {
+		if triggered, ok := msg.(taskTriggeredMsg); ok {
+			_, _ = h.Update(triggered)
+		}
+	}
+
+	require.Equal(t, "w1", gotID, "watch tasks must still route through the daemon trigger path")
 	require.Contains(t, h.errBox.String(), "watch task")
+}
+
+// TestTaskTriggerDisabledMatchesDaemonCLIBehavior pins the disabled-task edge:
+// the TUI still sends the selected ID to the daemon trigger seam, and surfaces
+// the same refusal `af tasks trigger <id>` would return.
+func TestTaskTriggerDisabledMatchesDaemonCLIBehavior(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(200, 1)
+
+	var gotID string
+	restore := SetTaskTriggerForTest(func(taskID string) error {
+		gotID = taskID
+		return errTest("task d1 is disabled")
+	})
+	defer restore()
+
+	sp := h.automations.TaskPane()
+	sp.SetTasks([]task.Task{{
+		ID:       "d1",
+		Name:     "disabled",
+		CronExpr: "0 0 * * *",
+		Prompt:   "do it",
+		Enabled:  false,
+	}})
+	sp.SelectTask(0)
+
+	cmd := h.handleTaskTrigger()
+	require.NotNil(t, cmd)
+	for _, msg := range drainCmd(t, cmd, 500*time.Millisecond) {
+		if triggered, ok := msg.(taskTriggeredMsg); ok {
+			_, _ = h.Update(triggered)
+		}
+	}
+
+	require.Equal(t, "d1", gotID)
+	require.Contains(t, h.errBox.String(), "disabled")
+}
+
+func TestTaskOverlayRunNowWithoutSelectionShowsFeedback(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(120, 1)
+	h.state = stateTasks
+
+	sp := h.automations.TaskPane()
+	sp.SetTasks(nil)
+	sp.SetFocus(true)
+
+	_, cmd := h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+
+	require.NotNil(t, cmd, "no-selection feedback should schedule its clear timer")
+	require.Contains(t, h.errBox.String(), "no task selected")
 }
 
 // TestRefreshTasksLiveProjectsOutOfBandChange is the regression guard for #1168:

--- a/ui/task_pane.go
+++ b/ui/task_pane.go
@@ -399,6 +399,8 @@ func (s *TaskPane) deleteSelectedTask() {
 
 func (s *TaskPane) runSelectedTask() {
 	if !s.selectedTaskInRange() {
+		s.pendingTrigger = true
+		s.pendingTriggerID = ""
 		return
 	}
 	s.pendingTrigger = true
@@ -562,7 +564,7 @@ func (s *TaskPane) renderListMode() string {
 	if s.hasFocus {
 		hint := "↑/↓ select • n new • enter edit • r run now • x toggle • D delete • esc back"
 		if s.width > 0 && lipgloss.Width(hint) > s.width {
-			hint = "↑/↓ • n new • enter • esc back"
+			hint = "r run now • ↑/↓ • n new • enter • esc"
 		}
 		b.WriteString(hintStyle.Render(fitLine(hint, s.width)))
 	} else {

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -170,6 +170,37 @@ func TestTaskPaneConsumePendingTriggerResolvesByIDAfterReload(t *testing.T) {
 	assert.Empty(t, tp.pendingTriggerID)
 }
 
+// TestTaskPaneListModeRunNowKeyQueuesSelectedTask pins the documented task
+// manager list affordance from #1503: `r` runs the selected task now without
+// requiring Enter to open the edit form first.
+func TestTaskPaneListModeRunNowKeyQueuesSelectedTask(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{
+		{ID: "a", Name: "A"},
+		{ID: "b", Name: "B"},
+	})
+	tp.SetFocus(true)
+	tp.SelectTask(1)
+
+	assert.True(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")}))
+	require.True(t, tp.HasPendingTrigger(), "r must queue a run-now request from list mode")
+	pending := tp.ConsumePendingTrigger()
+	require.NotNil(t, pending)
+	assert.Equal(t, "b", pending.ID)
+}
+
+// TestTaskPaneListModeRunNowWithoutSelectionQueuesNoTask lets the app layer
+// turn an empty-list `r` press into the visible "no task selected" feedback.
+func TestTaskPaneListModeRunNowWithoutSelectionQueuesNoTask(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks(nil)
+	tp.SetFocus(true)
+
+	assert.True(t, tp.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")}))
+	require.True(t, tp.HasPendingTrigger(), "empty-list r must still surface through the app layer")
+	assert.Nil(t, tp.ConsumePendingTrigger())
+}
+
 func TestTaskPaneNormalModeAllowsQuitKeysToPropagate(t *testing.T) {
 	tp := NewTaskPane()
 	tp.SetFocus(true)
@@ -1151,6 +1182,24 @@ func TestTaskPaneCreateModeFooterUsesReboundQuitKey(t *testing.T) {
 	lines := strings.Split(tp.String(), "\n")
 	assert.Contains(t, lines[len(lines)-1], "Q quit", "form footer must derive the quit hint from the keymap")
 	assert.NotContains(t, lines[len(lines)-1], "q quit", "the old default quit key must not be advertised after rebinding")
+}
+
+func TestTaskPaneListCompactFooterShowsRunNow(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetSize(40, 10)
+	tp.SetFocus(true)
+	tp.SetTasks([]task.Task{{
+		ID:       "abc",
+		Name:     "nightly",
+		Prompt:   "do it",
+		CronExpr: "0 0 * * *",
+		Program:  "claude",
+		Enabled:  true,
+	}})
+
+	lines := strings.Split(tp.String(), "\n")
+	assert.Contains(t, lines[len(lines)-1], "r run now",
+		"compact task-list footer must keep the documented run-now affordance discoverable")
 }
 
 func TestTaskPaneEditModeCompactActionFooterShowsQuitKey(t *testing.T) {


### PR DESCRIPTION
## Summary
- keep `r run now` visible in the task-manager list footer, including compact layouts used by the TUI driver
- queue list-mode `r` through the same daemon trigger seam as `af tasks trigger`, with no-selection feedback and daemon-sourced disabled/watch refusals
- show a transient `triggered <task>` notice on successful run-now completion

Closes #1503

## Verification
- `gofmt -l .`
- `golangci-lint run --timeout=3m --fast`
- `go build ./...`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `make test-container`
- `make tui-driver-selftest` -> 24/24
- Sandbox repro: created cheap `logic` session and bounded `hello-logic` task, opened task manager, confirmed `r run now`, pressed `r`, saw `triggered hello-logic`, and verified `task-hello-from-task-flow` reached the target session.

Do not merge until root verifies and play-tests.
