### PR TITLE
TUI: drag sidebar tabs into panes

### DIFF
--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/layout/zones"
 	"github.com/sachiniyer/agent-factory/ui/store"
+	"github.com/sachiniyer/agent-factory/ui/tree"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -32,6 +34,26 @@ import (
 // rows).
 const doubleClickInterval = 400 * time.Millisecond
 
+// tabDragThresholdCells is the approved drag-start threshold: a tab-row press
+// becomes a drag once motion moves at least this many terminal cells by
+// Manhattan distance. Smaller movement replays a normal click on release.
+const tabDragThresholdCells = 2
+
+type tabDragState struct {
+	title string
+	tab   int
+	label string
+	zone  string
+
+	startX int
+	startY int
+	x      int
+	y      int
+
+	active       bool
+	targetRegion string
+}
+
 // wireZoneRegistry hands the shared registry to every long-lived
 // zone-producing pane. Called once at construction (newHome / test wiring);
 // pane windows are wired at creation (openPaneWindow) instead, since they
@@ -43,11 +65,17 @@ func (m *home) wireZoneRegistry() {
 }
 
 // handleMouse routes a mouse event: wheel scrolls the region under the
-// cursor, a left press clicks the zone under it, and interactive mode
-// forwards in-pane events to the embedded terminal. Release/motion events
-// matter only to the forwarding path (drags, button-up); host gestures all
-// act on the press.
+// cursor, left press/candidate/release handles sidebar tab drag-drop before
+// interactive forwarding, and the remaining left presses click the zone under
+// them. Release/motion events matter to tab drags and to interactive terminal
+// forwarding; other host gestures act on press.
 func (m *home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if handled, cmd := m.handleTabDragMouse(msg); handled {
+		if m.interactive && m.state == stateDefault {
+			m.enforceInteractiveInvariant()
+		}
+		return m, cmd
+	}
 	if m.interactive && m.state == stateDefault {
 		if done := m.forwardInteractiveMouse(msg); done {
 			return m, nil
@@ -67,6 +95,161 @@ func (m *home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m.handleClick(msg)
 	}
 	return m, nil
+}
+
+func (m *home) handleTabDragMouse(msg tea.MouseMsg) (bool, tea.Cmd) {
+	switch msg.Button {
+	case tea.MouseButtonWheelUp, tea.MouseButtonWheelDown:
+		if m.tabDrag != nil {
+			m.clearDragState()
+		}
+		return false, nil
+	}
+	if msg.Button != tea.MouseButtonLeft {
+		if msg.Action == tea.MouseActionPress && m.tabDrag != nil {
+			m.clearDragState()
+		}
+		return false, nil
+	}
+
+	switch msg.Action {
+	case tea.MouseActionPress:
+		return m.handleTabDragPress(msg), nil
+	case tea.MouseActionMotion:
+		return m.handleTabDragMotion(msg), nil
+	case tea.MouseActionRelease:
+		return m.handleTabDragRelease(msg)
+	default:
+		return false, nil
+	}
+}
+
+func (m *home) handleTabDragPress(msg tea.MouseMsg) bool {
+	if m.tabDrag != nil {
+		m.clearDragState()
+	}
+	if m.state != stateDefault {
+		return false
+	}
+	id, _, ok := m.zones.Resolve(msg.X, msg.Y)
+	if !ok {
+		return false
+	}
+	title, idx, ok := zones.TreeTabParts(id)
+	if !ok {
+		return false
+	}
+	inst := m.store.GetInstanceByTitle(title)
+	if inst == nil || idx < 0 || idx >= len(tree.TabLabels(inst)) {
+		return false
+	}
+	m.tabDrag = &tabDragState{
+		title:  title,
+		tab:    idx,
+		label:  paneBindingLabel(paneBinding{instance: inst, tab: idx}),
+		zone:   id,
+		startX: msg.X,
+		startY: msg.Y,
+		x:      msg.X,
+		y:      msg.Y,
+	}
+	return true
+}
+
+func (m *home) handleTabDragMotion(msg tea.MouseMsg) bool {
+	drag := m.tabDrag
+	if drag == nil {
+		return false
+	}
+	drag.x = msg.X
+	drag.y = msg.Y
+	if !drag.active && manhattanDistance(drag.startX, drag.startY, msg.X, msg.Y) >= tabDragThresholdCells {
+		drag.active = true
+	}
+	if drag.active {
+		drag.targetRegion = m.tabDragDropRegion(msg.X, msg.Y)
+	}
+	return true
+}
+
+func (m *home) handleTabDragRelease(msg tea.MouseMsg) (bool, tea.Cmd) {
+	drag := m.tabDrag
+	if drag == nil {
+		return false, nil
+	}
+	if !drag.active {
+		now := m.mouseClock()
+		double := drag.zone == m.lastClickZone && now.Sub(m.lastClickAt) <= doubleClickInterval
+		m.clearDragState()
+		if !double {
+			m.lastClickZone = drag.zone
+			m.lastClickAt = now
+		}
+		return true, m.handleTreeTabClick(drag.title, drag.tab, double)
+	}
+	drag = m.clearDragState()
+	region := m.tabDragDropRegion(msg.X, msg.Y)
+	if region == "" {
+		return true, nil
+	}
+	return true, m.dropTabOnPane(drag)
+}
+
+func (m *home) tabDragDropRegion(x, y int) string {
+	id, _, ok := m.zones.Resolve(x, y)
+	if !ok {
+		return ""
+	}
+	region, _, isPane := zones.PaneZone(id)
+	if !isPane {
+		return ""
+	}
+	p, _ := m.paneByRegion(region)
+	if p == nil {
+		return ""
+	}
+	return region
+}
+
+func (m *home) tabDragDropTargetRegion() string {
+	if m.tabDrag == nil || !m.tabDrag.active {
+		return ""
+	}
+	return m.tabDrag.targetRegion
+}
+
+func (m *home) dropTabOnPane(drag *tabDragState) tea.Cmd {
+	if drag == nil {
+		return nil
+	}
+	inst := m.store.GetInstanceByTitle(drag.title)
+	if inst == nil || drag.tab < 0 || drag.tab >= len(tree.TabLabels(inst)) {
+		return nil
+	}
+	m.focusRegionClick(layout.RegionTree)
+	m.sidebar.SelectTabRow(drag.title, drag.tab)
+	_, openCmd := m.openOrFocusPane(inst, drag.tab)
+	return openCmd
+}
+
+func (m *home) clearDragState() *tabDragState {
+	drag := m.tabDrag
+	m.tabDrag = nil
+	m.lastClickZone = ""
+	m.lastClickAt = time.Time{}
+	return drag
+}
+
+func manhattanDistance(x1, y1, x2, y2 int) int {
+	dx := x1 - x2
+	if dx < 0 {
+		dx = -dx
+	}
+	dy := y1 - y2
+	if dy < 0 {
+		dy = -dy
+	}
+	return dx + dy
 }
 
 // forwardInteractiveMouse implements the RFC §2.5 in-pane ownership rule
@@ -195,16 +378,7 @@ func (m *home) handleClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m, m.selectionChanged()
 	}
 	if title, idx, ok := zones.TreeTabParts(id); ok {
-		// Click a tab row: select it (drives the active tab); double-click
-		// interacts with that tab.
-		m.focusRegionClick(layout.RegionTree)
-		m.sidebar.SelectTabRow(title, idx)
-		if double {
-			selCmd := m.selectionChanged()
-			_, enterCmd := m.handleEnter()
-			return m, tea.Batch(selCmd, enterCmd)
-		}
-		return m, m.selectionChanged()
+		return m, m.handleTreeTabClick(title, idx, double)
 	}
 	if region, kind, ok := zones.PaneZone(id); ok {
 		// Click a pane header (or an unfocused pane's body): focus that pane
@@ -238,6 +412,33 @@ func (m *home) handleClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m.handleHintClick(key)
 	}
 	return m, nil
+}
+
+func (m *home) handleTreeTabClick(title string, idx int, double bool) tea.Cmd {
+	// Click a tab row: select it (drives the active tab); double-click
+	// interacts with that tab.
+	m.focusRegionClick(layout.RegionTree)
+	m.sidebar.SelectTabRow(title, idx)
+	if double {
+		selCmd := m.selectionChanged()
+		_, enterCmd := m.handleEnter()
+		return tea.Batch(selCmd, enterCmd)
+	}
+	return m.selectionChanged()
+}
+
+func (m *home) dragStatusText() string {
+	if m.tabDrag == nil || !m.tabDrag.active {
+		return ""
+	}
+	label := m.tabDrag.label
+	if label == "" {
+		label = fmt.Sprintf("%s tab %d", m.tabDrag.title, m.tabDrag.tab+1)
+	}
+	if m.tabDrag.targetRegion == "" {
+		return "Dragging… " + label
+	}
+	return "Dragging… " + label + " - drop to open pane"
 }
 
 // handleModalClick handles clicks while an overlay owns the screen: overlay

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -150,6 +150,10 @@ type home struct {
 	lastClickZone string
 	lastClickAt   time.Time
 	mouseClock    func() time.Time
+	// tabDrag tracks a possible/active sidebar-tab drag. The candidate starts
+	// on tree tab press; motion promotes it to an active drag; release either
+	// replays the ordinary tab click or drops onto a visible pane.
+	tabDrag *tabDragState
 
 	// sidebar is the left-rail instances+tabs tree
 	sidebar *ui.Sidebar

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 )
 
@@ -138,6 +139,7 @@ func (m *home) View() string {
 		if w := m.paneWindows[p.ID()]; w != nil {
 			w.SetSidebarSelected(m.paneMatchesSelection(p))
 			w.SetSelectionHint(m.paneSelectionHint(p))
+			w.SetDropTarget(m.tabDragDropTargetRegion() == layout.PaneRegion(p.ID()))
 			cols = append(cols, w.View())
 		}
 	}
@@ -149,6 +151,7 @@ func (m *home) View() string {
 	if banner := m.alarmBanner.View(); banner != "" {
 		viewParts = append(viewParts, banner)
 	}
+	m.menu.SetStatusText(m.dragStatusText())
 	viewParts = append(viewParts, top, m.statusBar.View())
 	mainView := lipgloss.JoinVertical(lipgloss.Left, viewParts...)
 

--- a/app/mouse_test.go
+++ b/app/mouse_test.go
@@ -71,11 +71,38 @@ func press(h *home, x, y int) tea.Cmd {
 	return cmd
 }
 
+// release injects a left release at (x, y) through the root mouse router.
+func release(h *home, x, y int) tea.Cmd {
+	_, cmd := h.handleMouse(tea.MouseMsg{
+		X: x, Y: y, Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft,
+	})
+	return cmd
+}
+
+// motion injects left-button motion at (x, y).
+func motion(h *home, x, y int) tea.Cmd {
+	_, cmd := h.handleMouse(tea.MouseMsg{
+		X: x, Y: y, Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft,
+	})
+	return cmd
+}
+
+func combineCmds(a, b tea.Cmd) tea.Cmd {
+	switch {
+	case a == nil:
+		return b
+	case b == nil:
+		return a
+	default:
+		return tea.Batch(a, b)
+	}
+}
+
 // clickZone renders, resolves id's rect, and clicks its top-left cell.
 func clickZone(t *testing.T, h *home, id string) tea.Cmd {
 	t.Helper()
 	r := zoneRect(t, h, id)
-	return press(h, r.X, r.Y)
+	return combineCmds(press(h, r.X, r.Y), release(h, r.X, r.Y))
 }
 
 // wheel injects a wheel event at (x, y).
@@ -115,6 +142,268 @@ func TestMouse_ClickTreeTabRowSelectsTab(t *testing.T) {
 	require.True(t, sel.IsTab, "the cursor lands on the tab row")
 	assert.Equal(t, 1, sel.TabIndex)
 	assert.Equal(t, 1, h.store.ActiveTab(), "the click drives the active tab")
+}
+
+func TestMouse_DoubleClickTreeTabRowEntersInteractive(t *testing.T) {
+	h, alpha, _ := mouseTestHome(t)
+	clock := newFakeClock(h)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	fakes, _ := stubLiveTermFactory(t)
+
+	clickZone(t, h, zones.TreeTab(alpha.Title, 1))
+	clock.advance(50 * time.Millisecond)
+	clickZone(t, h, zones.TreeTab(alpha.Title, 1))
+
+	p := h.store.FindOpenPane(alpha, 1)
+	require.NotNil(t, p, "double-clicking a tab row must enter that tab's pane target")
+	assert.Equal(t, p, h.focusedOpenPane())
+	_, cmd := h.Update(enterInteractiveMsg{pane: p})
+	runHermeticCmd(t, h, cmd, 0)
+	assert.True(t, h.interactive, "tab-row double-click still replays the Enter path")
+	require.Len(t, *fakes, 1)
+}
+
+func TestMouse_SubThresholdTabJitterSelectsPressedTab(t *testing.T) {
+	h, alpha, _ := mouseTestHome(t)
+	newFakeClock(h)
+	require.Equal(t, 0, h.store.ActiveTab())
+
+	pressTab := zoneRect(t, h, zones.TreeTab(alpha.Title, 1))
+	neighbor := zoneRect(t, h, zones.TreeTab(alpha.Title, 0))
+	require.Less(t,
+		manhattanDistance(pressTab.X, pressTab.Y, neighbor.X, neighbor.Y),
+		tabDragThresholdCells,
+		"test must release below the drag promotion threshold")
+
+	press(h, pressTab.X, pressTab.Y)
+	motion(h, neighbor.X, neighbor.Y)
+	require.NotNil(t, h.tabDrag)
+	require.False(t, h.tabDrag.active, "one-cell neighboring-row jitter is still a click")
+	release(h, neighbor.X, neighbor.Y)
+
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsTab)
+	assert.Equal(t, 1, sel.TabIndex, "sub-threshold jitter selects the press-origin tab")
+	assert.Equal(t, 1, h.store.ActiveTab())
+}
+
+func TestMouse_DragTreeTabToPaneOpensSplitAppend(t *testing.T) {
+	h, alpha, _ := mouseTestHome(t)
+	newFakeClock(h)
+	paneAgent := openTestPane(t, h, alpha, 0)
+	regionAgent := layout.PaneRegion(paneAgent.ID())
+	require.Equal(t, 1, h.store.NumOpenPanes())
+
+	tab := zoneRect(t, h, zones.TreeTab(alpha.Title, 1))
+	body := zoneRect(t, h, zones.PaneBody(regionAgent))
+
+	press(h, tab.X, tab.Y)
+	motion(h, body.X+3, body.Y+4)
+	require.NotNil(t, h.tabDrag)
+	assert.True(t, h.tabDrag.active, ">=2-cell motion promotes the candidate to a drag")
+	assert.Equal(t, regionAgent, h.tabDragDropTargetRegion(), "pane under cursor is the drop target")
+	assert.Contains(t, h.View(), "Dragging", "active drag renders a status affordance")
+
+	release(h, body.X+3, body.Y+4)
+
+	require.Nil(t, h.tabDrag)
+	require.Equal(t, 2, h.store.NumOpenPanes(), "drop opens a split pane")
+	panes := h.store.OpenPanes()
+	require.Len(t, panes, 2)
+	assert.Same(t, paneAgent, panes[0], "drop uses s/S append order, not adjacent replacement")
+	paneTerminal := panes[1]
+	assert.Same(t, alpha, paneTerminal.Instance())
+	assert.Equal(t, 1, paneTerminal.Tab())
+	assert.Equal(t, layout.PaneRegion(paneTerminal.ID()), h.ring.Active(), "the dropped tab's pane takes focus")
+	assert.Equal(t, 1, h.store.ActiveTab(), "drop selects the dragged tab in the sidebar")
+	sel := h.sidebar.GetSelection()
+	require.True(t, sel.IsTab)
+	assert.Equal(t, 1, sel.TabIndex)
+}
+
+func TestMouse_DragDropReresolvesInstanceAfterProjectionSwap(t *testing.T) {
+	h, alpha, _ := mouseTestHome(t)
+	newFakeClock(h)
+	paneAgent := openTestPane(t, h, alpha, 0)
+	regionAgent := layout.PaneRegion(paneAgent.ID())
+
+	tab := zoneRect(t, h, zones.TreeTab(alpha.Title, 1))
+	body := zoneRect(t, h, zones.PaneBody(regionAgent))
+	press(h, tab.X, tab.Y)
+	motion(h, body.X+3, body.Y+4)
+	require.NotNil(t, h.tabDrag)
+	require.True(t, h.tabDrag.active)
+
+	rebuilt := instanceWithFakeBackend(t, alpha.Title)
+	rebuilt.AddTabForTest("agent", session.TabKindAgent)
+	rebuilt.AddTabForTest("shell", session.TabKindShell)
+	require.True(t, h.store.ReplaceInstanceByTitle(alpha.Title, rebuilt))
+	require.False(t, h.store.ContainsInstance(alpha), "the press-time pointer is now orphaned")
+	require.Same(t, rebuilt, h.store.GetInstanceByTitle(alpha.Title))
+	require.Same(t, rebuilt, paneAgent.Instance(), "existing open panes follow the projection swap")
+
+	release(h, body.X+3, body.Y+4)
+
+	require.Equal(t, 2, h.store.NumOpenPanes())
+	dropped := h.store.FindOpenPane(rebuilt, 1)
+	require.NotNil(t, dropped, "drop must bind to the current same-title instance")
+	assert.Nil(t, h.store.FindOpenPane(alpha, 1), "drop must not bind an orphaned press-time pointer")
+	assert.Same(t, rebuilt, dropped.Instance())
+	assert.Equal(t, layout.PaneRegion(dropped.ID()), h.ring.Active())
+}
+
+func TestMouse_DragTreeTabOutsidePaneCancels(t *testing.T) {
+	h, alpha, _ := mouseTestHome(t)
+	newFakeClock(h)
+	openTestPane(t, h, alpha, 0)
+	require.False(t, h.sidebar.GetSelection().IsTab)
+	require.Equal(t, 0, h.store.ActiveTab())
+
+	tab := zoneRect(t, h, zones.TreeTab(alpha.Title, 1))
+	auto := zoneRect(t, h, zones.AutoBG)
+
+	press(h, tab.X, tab.Y)
+	motion(h, auto.X+1, auto.Y)
+	require.NotNil(t, h.tabDrag)
+	require.True(t, h.tabDrag.active)
+	assert.Empty(t, h.tabDragDropTargetRegion(), "non-pane regions are not valid drop targets")
+
+	release(h, auto.X+1, auto.Y)
+
+	assert.Nil(t, h.tabDrag)
+	assert.Equal(t, 1, h.store.NumOpenPanes(), "invalid drop must not open a pane")
+	assert.Equal(t, 0, h.store.ActiveTab(), "invalid drop must not select the dragged tab")
+	assert.False(t, h.sidebar.GetSelection().IsTab, "invalid drop is a no-op for selection")
+	assert.Nil(t, h.panePreviewTxn, "invalid drop must not create a preview")
+}
+
+func TestMouse_DragTerminationsResetDoubleClickTracker(t *testing.T) {
+	cases := []struct {
+		name      string
+		terminate func(t *testing.T, h *home, alpha *session.Instance, tab layout.Rect)
+		wantPanes int
+	}{
+		{
+			name: "active invalid drop cancel",
+			terminate: func(t *testing.T, h *home, _ *session.Instance, tab layout.Rect) {
+				t.Helper()
+				auto := zoneRect(t, h, zones.AutoBG)
+				press(h, tab.X, tab.Y)
+				motion(h, auto.X+1, auto.Y)
+				require.NotNil(t, h.tabDrag)
+				require.True(t, h.tabDrag.active)
+				release(h, auto.X+1, auto.Y)
+			},
+			wantPanes: 0,
+		},
+		{
+			name: "valid drop complete",
+			terminate: func(t *testing.T, h *home, alpha *session.Instance, tab layout.Rect) {
+				t.Helper()
+				paneAgent := openTestPane(t, h, alpha, 0)
+				body := zoneRect(t, h, zones.PaneBody(layout.PaneRegion(paneAgent.ID())))
+				press(h, tab.X, tab.Y)
+				motion(h, body.X+3, body.Y+4)
+				require.NotNil(t, h.tabDrag)
+				require.True(t, h.tabDrag.active)
+				release(h, body.X+3, body.Y+4)
+			},
+			wantPanes: 2,
+		},
+		{
+			name: "inactive wheel cancel",
+			terminate: func(t *testing.T, h *home, _ *session.Instance, tab layout.Rect) {
+				t.Helper()
+				auto := zoneRect(t, h, zones.AutoBG)
+				press(h, tab.X, tab.Y)
+				require.NotNil(t, h.tabDrag)
+				require.False(t, h.tabDrag.active)
+				wheel(h, auto.X+1, auto.Y, false)
+			},
+			wantPanes: 0,
+		},
+		{
+			name: "inactive other-button cancel",
+			terminate: func(t *testing.T, h *home, _ *session.Instance, tab layout.Rect) {
+				t.Helper()
+				press(h, tab.X, tab.Y)
+				require.NotNil(t, h.tabDrag)
+				require.False(t, h.tabDrag.active)
+				_, _ = h.handleMouse(tea.MouseMsg{
+					X: tab.X, Y: tab.Y, Action: tea.MouseActionPress, Button: tea.MouseButtonRight,
+				})
+			},
+			wantPanes: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, alpha, _ := mouseTestHome(t)
+			newFakeClock(h)
+			require.Zero(t, h.store.NumOpenPanes())
+
+			clickZone(t, h, zones.TreeTab(alpha.Title, 1))
+			require.Equal(t, zones.TreeTab(alpha.Title, 1), h.lastClickZone,
+				"precondition: first click seeds tracker")
+
+			tab := zoneRect(t, h, zones.TreeTab(alpha.Title, 1))
+			tc.terminate(t, h, alpha, tab)
+			require.Nil(t, h.tabDrag)
+			require.Empty(t, h.lastClickZone, "drag termination clears stale click state")
+			require.Equal(t, tc.wantPanes, h.store.NumOpenPanes())
+			require.Equal(t, stateDefault, h.state)
+
+			clickZone(t, h, zones.TreeTab(alpha.Title, 1))
+
+			assert.Equal(t, stateDefault, h.state,
+				"single click after drag termination must not reuse stale double-click state and enter")
+			assert.Equal(t, tc.wantPanes, h.store.NumOpenPanes())
+			assert.False(t, h.interactive)
+			sel := h.sidebar.GetSelection()
+			require.True(t, sel.IsTab)
+			assert.Equal(t, 1, sel.TabIndex)
+		})
+	}
+}
+
+func TestMouse_DragAlreadyOpenTabFocusesExistingPane(t *testing.T) {
+	h, alpha, _ := mouseTestHome(t)
+	newFakeClock(h)
+	paneAgent := openTestPane(t, h, alpha, 0)
+	paneTerminal := openTestPane(t, h, alpha, 1)
+	h.focusRegion(layout.PaneRegion(paneAgent.ID()))
+	require.Equal(t, 2, h.store.NumOpenPanes())
+
+	tab := zoneRect(t, h, zones.TreeTab(alpha.Title, 1))
+	body := zoneRect(t, h, zones.PaneBody(layout.PaneRegion(paneAgent.ID())))
+
+	press(h, tab.X, tab.Y)
+	motion(h, body.X+3, body.Y+4)
+	release(h, body.X+3, body.Y+4)
+
+	assert.Equal(t, 2, h.store.NumOpenPanes(), "already-open dragged tab must not duplicate panes")
+	assert.Same(t, paneTerminal, h.store.FindOpenPane(alpha, 1))
+	assert.Equal(t, layout.PaneRegion(paneTerminal.ID()), h.ring.Active(),
+		"drop reuses the existing #1493 focus path")
+}
+
+func TestMouse_TabDragThresholdAndWheelCancel(t *testing.T) {
+	h, alpha, _ := mouseTestHome(t)
+	newFakeClock(h)
+	openTestPane(t, h, alpha, 0)
+
+	tab := zoneRect(t, h, zones.TreeTab(alpha.Title, 1))
+
+	press(h, tab.X, tab.Y)
+	motion(h, tab.X+1, tab.Y)
+	require.NotNil(t, h.tabDrag)
+	assert.False(t, h.tabDrag.active, "one-cell jitter stays a click candidate")
+
+	wheel(h, tab.X, tab.Y, false)
+
+	assert.Nil(t, h.tabDrag, "wheel cancels a pending drag candidate")
+	assert.Equal(t, 0, h.store.ActiveTab(), "wheel-cancelled drag must not replay the dragged tab click")
 }
 
 // TestMouse_ClickArrowTogglesExpansion: the ▸/▾ arrow collapses/expands the
@@ -480,6 +769,29 @@ func TestMouse_InteractiveForwardsGridEvents(t *testing.T) {
 		X: term.X + 5, Y: term.Y + 3, Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft,
 	})
 	require.Len(t, fake.mice, 3, "releases forward so the inner app sees complete clicks")
+}
+
+func TestMouse_InteractiveTabDragConsumesTerminalMotionAndDrop(t *testing.T) {
+	h, fake, region := interactiveMouseHome(t)
+	inst := h.store.GetSelectedInstance()
+	require.NotNil(t, inst)
+
+	tab := zoneRect(t, h, zones.TreeTab(inst.Title, 1))
+	term := zoneRect(t, h, zones.PaneTerm(region))
+
+	press(h, tab.X, tab.Y)
+	motion(h, term.X+5, term.Y+3)
+	require.NotNil(t, h.tabDrag)
+	require.True(t, h.tabDrag.active)
+	assert.Equal(t, region, h.tabDragDropTargetRegion())
+
+	release(h, term.X+5, term.Y+3)
+
+	assert.Empty(t, fake.mice, "active tab drag must run before interactive terminal mouse forwarding")
+	assert.False(t, h.interactive, "dropping onto a new pane moves focus and leaves interactive mode")
+	p := h.store.FindOpenPane(inst, 1)
+	require.NotNil(t, p, "drop over the live pane still opens the dragged tab")
+	assert.Equal(t, layout.PaneRegion(p.ID()), h.ring.Active())
 }
 
 // TestMouse_InteractiveSuppressesPaneChrome: clicks on the live pane's header

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -65,6 +65,10 @@ type Menu struct {
 	// `S` can commit as another pane. Without that preview the key no-ops, so
 	// the footer must not advertise it (#1419).
 	splitPaneAvailable bool
+	// statusText temporarily replaces key hints with a plain status row. Used
+	// for pointer gestures that need feedback but should not advertise
+	// clickable key zones while the gesture is in flight.
+	statusText string
 
 	// keyDown is the key which is pressed. The default is -1.
 	keyDown keys.KeyName
@@ -162,6 +166,12 @@ func (m *Menu) SetInteractive(on bool) {
 func (m *Menu) SetSplitPaneAvailable(available bool) {
 	m.splitPaneAvailable = available
 	m.updateOptions()
+}
+
+// SetStatusText temporarily replaces the hint row with a centered status
+// message. Empty restores the normal context-sensitive key hints.
+func (m *Menu) SetStatusText(text string) {
+	m.statusText = text
 }
 
 // updateOptions updates the menu options based on current state, focus
@@ -390,6 +400,10 @@ var hintDropOrder = [][]keys.KeyName{
 func (m *Menu) String() string {
 	if m.width <= 0 || m.height <= 0 {
 		return ""
+	}
+	if m.statusText != "" {
+		line := menuStyle.Render(fitLine(m.statusText, m.width))
+		return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, line)
 	}
 
 	// Render the full hint row; while it exceeds the bar width, drop options

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -40,6 +40,10 @@ var interactiveWindowStyle = windowStyle.
 var previewWindowStyle = windowStyle.
 	BorderForeground(activeTheme.PaneBorderPreview)
 
+// dropTargetWindowStyle marks the pane currently under an active tab drag.
+var dropTargetWindowStyle = windowStyle.
+	BorderForeground(activeTheme.Warning)
+
 var paneHeaderStyle = lipgloss.NewStyle().
 	Bold(true).
 	Foreground(activeTheme.Foreground)
@@ -119,6 +123,9 @@ type TabbedWindow struct {
 	// current sidebar selection. It colors selected-but-not-focused panes blue
 	// without moving focus or mutating the pane binding.
 	sidebarSelected bool
+	// dropTarget marks this pane as the current drop target while a sidebar
+	// tab drag is active. It is render-only and never changes pane focus.
+	dropTarget bool
 
 	// preview is a transient render binding for #1321. While set, the window
 	// still owns its committed store.OpenPane binding, but capture/render uses
@@ -412,6 +419,11 @@ func (w *TabbedWindow) SetSidebarSelected(on bool) {
 	w.sidebarSelected = on
 }
 
+// SetDropTarget marks whether this pane is the current tab-drag drop target.
+func (w *TabbedWindow) SetDropTarget(on bool) {
+	w.dropTarget = on
+}
+
 // registerZones records this frame's hit-test rects: the whole pane as the
 // body (click focuses; click focused interacts; wheel scrolls), the one-line
 // `title · tab` header inside the frame on top of it, and — exactly while the
@@ -561,6 +573,8 @@ func (w *TabbedWindow) frameStyle() lipgloss.Style {
 		return previewWindowStyle
 	case w.interactive:
 		return interactiveWindowStyle
+	case w.dropTarget:
+		return dropTargetWindowStyle
 	case w.sidebarSelected && !w.focused:
 		return selectedWindowStyle
 	default:

--- a/ui/tabbed_window_style_test.go
+++ b/ui/tabbed_window_style_test.go
@@ -17,6 +17,7 @@ func TestTabbedWindowFrameStyleUsesPaneBorderThemeSlots(t *testing.T) {
 	custom.PaneBorderSelected = "#222222"
 	custom.PaneBorderInteractive = "#333333"
 	custom.PaneBorderPreview = "#444444"
+	custom.Warning = "#555555"
 	ApplyTheme(custom)
 
 	assertFrameColor := func(name string, w *TabbedWindow, want string) {
@@ -42,4 +43,8 @@ func TestTabbedWindowFrameStyleUsesPaneBorderThemeSlots(t *testing.T) {
 	w.SetInteractive(false)
 	w.SetPreview(nil, 0, "original")
 	assertFrameColor("preview", w, "#444444")
+
+	w.ClearPreview()
+	w.SetDropTarget(true)
+	assertFrameColor("drop target", w, "#555555")
 }

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -103,6 +103,8 @@ func applyThemeStyles() {
 		BorderForeground(activeTheme.PaneBorderInteractive)
 	previewWindowStyle = windowStyle.
 		BorderForeground(activeTheme.PaneBorderPreview)
+	dropTargetWindowStyle = windowStyle.
+		BorderForeground(activeTheme.Warning)
 
 	paneHeaderStyle = lipgloss.NewStyle().
 		Bold(true).


### PR DESCRIPTION
## Summary
- add sidebar tab drag detection with press -> >=2-cell motion promotion -> release drop/cancel
- drop visible sidebar tabs onto visible pane zones to open/focus via the existing pane open path
- show a drag status affordance and highlight the pane under the active drop cursor
- preserve click/double-click behavior by replaying tab-row clicks on release when no drag starts

Closes #1514

## Tests
- make test-container GOTESTARGS=\"./app ./ui\"
- make test-container