### PR TITLE
feat: add Amp agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![Agent Factory demo: multiple AI coding agents running in isolated git worktrees, with live Agent tabs, scheduled automations, helper tabs, and full-screen attach](docs/assets/demo.gif)
 
 Agent Factory (`af`) is a terminal UI for running many AI coding agents at once:
-Claude Code, Codex, Aider, and Gemini. Each normal session gets its own git
+Claude Code, Codex, Aider, Gemini, and Amp. Each normal session gets its own git
 worktree and branch, so parallel agents do not trample the same checkout. A
 daemon keeps sessions and automations alive, while the TUI, JSON CLI, and local
 HTTP API all read the same state.

--- a/api/api.go
+++ b/api/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // Shared flags
@@ -442,13 +443,13 @@ func init() {
 	// Sessions
 	sessionsCreateCmd.Flags().StringVar(&createNameFlag, "name", "", "Session name (required)")
 	sessionsCreateCmd.Flags().StringVar(&createPromptFlag, "prompt", "", "Initial prompt to send")
-	sessionsCreateCmd.Flags().StringVar(&createProgramFlag, "program", "", "Program to run (defaults to config default)")
+	sessionsCreateCmd.Flags().StringVar(&createProgramFlag, "program", "", "Program to run (one of: "+tmux.SupportedProgramsString()+"; defaults to config default)")
 	sessionsCreateCmd.Flags().BoolVar(&createHereFlag, "here", false, "Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both)")
 	sessionsCreateCmd.Flags().BoolVar(&createInPlaceFlag, "in-place", false, "Alias for --here")
 	sessionsCreateCmd.MarkFlagRequired("name")
 
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptCreateFlag, "create", false, "Auto-create the session if it doesn't exist")
-	sessionsSendPromptCmd.Flags().StringVar(&sendPromptProgramFlag, "program", "", "Program to run when creating a new session (defaults to config default)")
+	sessionsSendPromptCmd.Flags().StringVar(&sendPromptProgramFlag, "program", "", "Program to run when creating a new session (one of: "+tmux.SupportedProgramsString()+"; defaults to config default)")
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptAllFlag, "all", false, "Broadcast the prompt to every live session in scope (current repo by default; excludes the reserved root session)")
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptAllReposFlag, "all-repos", false, "With --all, broadcast across every repo instead of only the current/--repo one")
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptIncludeRootFlag, "include-root", false, "With --all, also deliver to the reserved root session (excluded by default)")
@@ -484,7 +485,7 @@ func init() {
 	tasksAddCmd.Flags().StringVar(&taskAddCronFlag, "cron", "", "Cron expression (exactly one of --cron / --watch-cmd)")
 	tasksAddCmd.Flags().StringVar(&taskAddWatchCmdFlag, "watch-cmd", "", "Long-running watch command; each stdout line triggers the task (exactly one of --cron / --watch-cmd)")
 	tasksAddCmd.Flags().StringVar(&taskAddTargetSessionFlag, "target-session", "", "Deliver the prompt into this session (auto-created if missing); empty creates a new session per run")
-	tasksAddCmd.Flags().StringVar(&taskAddProgramFlag, "program", "", "Program to run (defaults to config default)")
+	tasksAddCmd.Flags().StringVar(&taskAddProgramFlag, "program", "", "Program to run (one of: "+tmux.SupportedProgramsString()+"; defaults to config default)")
 	tasksAddCmd.MarkFlagRequired("name")
 
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateNameFlag, "name", "", "New task name")
@@ -493,7 +494,7 @@ func init() {
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateWatchCmdFlag, "watch-cmd", "", "New watch command (clears cron)")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateTargetSessionFlag, "target-session", "", "New target session; pass an empty value to revert to a new session per run")
 	tasksUpdateCmd.Flags().StringVar(&taskUpdateEnabledFlag, "enabled", "", "Enable or disable the task (true/false)")
-	tasksUpdateCmd.Flags().StringVar(&taskUpdateProgramFlag, "program", "", "New program to run (leave unset to keep the current one)")
+	tasksUpdateCmd.Flags().StringVar(&taskUpdateProgramFlag, "program", "", "New program to run (one of: "+tmux.SupportedProgramsString()+"; leave unset to keep the current one)")
 
 	TasksCmd.AddCommand(tasksListCmd)
 	TasksCmd.AddCommand(tasksGetCmd)

--- a/api/sessions_inplace_test.go
+++ b/api/sessions_inplace_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 // silenceStdio redirects stdout/stderr to /dev/null for the duration of the
@@ -97,6 +98,40 @@ func TestSessionsCreate_HereSetsInPlace(t *testing.T) {
 				t.Fatalf("--here must compose with --prompt; got prompt %q", got.Prompt)
 			}
 		})
+	}
+}
+
+func TestSessionsCreateAcceptsAmpProgram(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	silenceStdio(t)
+
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repoRoot, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoRoot, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+
+	var got *daemon.CreateSessionRequest
+	prevCreate := createSessionViaDaemon
+	createSessionViaDaemon = func(req daemon.CreateSessionRequest) (*session.InstanceData, error) {
+		got = &req
+		return &session.InstanceData{Title: req.Title}, nil
+	}
+	t.Cleanup(func() { createSessionViaDaemon = prevCreate })
+
+	setSessionsCreateFlags(t, "amp-test", repoRoot, false, false)
+	createProgramFlag = tmux.ProgramAmp
+
+	if err := sessionsCreateCmd.RunE(sessionsCreateCmd, nil); err != nil {
+		t.Fatalf("sessions create: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("daemon create was never called")
+	}
+	if got.Program != tmux.ProgramAmp {
+		t.Fatalf("CreateSessionRequest.Program = %q, want %q", got.Program, tmux.ProgramAmp)
 	}
 }
 

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 	"github.com/sachiniyer/agent-factory/task"
 
 	"github.com/stretchr/testify/assert"
@@ -186,7 +187,7 @@ func TestTasksAdd_PersistsTaskViaDaemon(t *testing.T) {
 	taskAddNameFlag = "nightly"
 	taskAddPromptFlag = "do the nightly sweep"
 	taskAddCronFlag = "0 3 * * *"
-	taskAddProgramFlag = "claude"
+	taskAddProgramFlag = tmux.ProgramAmp
 
 	err := tasksAddCmd.RunE(tasksAddCmd, nil)
 	require.NoError(t, err)
@@ -196,6 +197,7 @@ func TestTasksAdd_PersistsTaskViaDaemon(t *testing.T) {
 	require.Len(t, tasks, 1)
 	assert.Equal(t, "nightly", tasks[0].Name)
 	assert.True(t, tasks[0].Enabled)
+	assert.Equal(t, tmux.ProgramAmp, tasks[0].Program)
 	resolvedRepo, err := filepath.EvalSymlinks(repo)
 	require.NoError(t, err)
 	resolvedProject, err := filepath.EvalSymlinks(tasks[0].ProjectPath)

--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 
 	"github.com/spf13/cobra"
 )
@@ -182,14 +183,14 @@ var configListCmd = &cobra.Command{
 var configSetCmd = &cobra.Command{
 	Use:   "set <key> <value>",
 	Short: "Set a single settable global config key",
-	Long: `Write one key into the global config.toml, editing only that value in place —
+	Long: fmt.Sprintf(`Write one key into the global config.toml, editing only that value in place —
 every comment, blank line, section header, and key ordering is preserved (the
 file is not regenerated). Only a curated set of scalar keys is settable; the
 value is validated with the same rules the config loader uses before anything is
 written, so set can never leave a config that fails to load.
 
 Settable keys:
-  default_program            agent enum (claude, codex, aider, gemini)
+  default_program            agent enum (%s)
   program_overrides.<agent>  full command string for an agent
   auto_yes                   true | false
   auto_update                true | false
@@ -209,7 +210,7 @@ Examples:
   af config set default_program codex
   af config set auto_yes true
   af config set auto_update false
-  af config set program_overrides.claude "/usr/local/bin/claude --verbose"`,
+  af config set program_overrides.claude "/usr/local/bin/claude --verbose"`, tmux.SupportedProgramsString()),
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)

--- a/commands/root.go
+++ b/commands/root.go
@@ -32,7 +32,7 @@ var (
 	daemonFlag  bool
 	rootCmd     = &cobra.Command{
 		Use:   "af",
-		Short: "Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, and Gemini.",
+		Short: "Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, Gemini, and Amp.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			log.Initialize(daemonFlag)
@@ -278,7 +278,7 @@ func init() {
 	// tmux.SupportedPrograms, so advertise exactly those accepted values.
 	rootCmd.Flags().StringVarP(&programFlag, "program", "p", "",
 		fmt.Sprintf("Program to run in new instances (one of: %s)",
-			strings.Join(tmux.SupportedPrograms, ", ")))
+			tmux.SupportedProgramsString()))
 	rootCmd.Flags().BoolVarP(&autoYesFlag, "autoyes", "y", false,
 		"[experimental] If enabled, all instances will automatically accept prompts")
 	rootCmd.Flags().BoolVar(&daemonFlag, "daemon", false, "Run the background daemon that schedules"+

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -426,7 +426,7 @@ func TestValidateProgramEnum(t *testing.T) {
 		in   string
 	}{
 		{"path with flag", "/home/siyer/.local/bin/claude --dangerously-skip-permissions"},
-		{"unknown agent", "amp"},
+		{"unknown agent", "notanagent"},
 		{"agent with flags", "claude --model opus"},
 		{"empty", ""},
 		{"random word", "foo"},
@@ -446,7 +446,7 @@ func TestValidateProgramEnum(t *testing.T) {
 			assert.Contains(t, err.Error(), "program_overrides")
 			// Enum must render comma-separated so the message is readable
 			// when Cobra prefixes it with "Error: " (see #661).
-			assert.Contains(t, err.Error(), "[claude, codex, aider, gemini]")
+			assert.Contains(t, err.Error(), "[claude, codex, aider, gemini, amp]")
 			// Leading "\n\n" + trailing "\n" pair with Cobra's "Error: "
 			// prefix and Println-added newline to produce a blank line on
 			// both sides of the message body.
@@ -469,7 +469,7 @@ func TestValidateProgramEnum(t *testing.T) {
 	// the user's command, not echo the invalid key (#675).
 	t.Run("program_overrides preserves user command in example", func(t *testing.T) {
 		const (
-			key     = "amp"
+			key     = "notanagent"
 			command = "/opt/amp --some-flag"
 		)
 		err := ValidateProgramEnum(
@@ -666,7 +666,7 @@ func TestLoadConfig(t *testing.T) {
 
 		configPath := filepath.Join(configDir, ConfigFileName)
 		configContent := `{
-			"default_program": "codex",
+			"default_program": "amp",
 			"auto_yes": true,
 			"daemon_poll_interval": 2000,
 			"branch_prefix": "test/",
@@ -677,7 +677,7 @@ func TestLoadConfig(t *testing.T) {
 		cfg, err := LoadConfig()
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
-		assert.Equal(t, "codex", cfg.DefaultProgram)
+		assert.Equal(t, tmux.ProgramAmp, cfg.DefaultProgram)
 		assert.True(t, cfg.AutoYes)
 		assert.Equal(t, 2000, cfg.DaemonPollInterval)
 		assert.Equal(t, "test/", cfg.BranchPrefix)
@@ -695,7 +695,8 @@ func TestLoadConfig(t *testing.T) {
 			"default_program": "claude",
 			"program_overrides": {
 				"claude": "/home/me/.local/bin/claude --dangerously-skip-permissions",
-				"codex": "/opt/codex/bin/codex --quiet"
+				"codex": "/opt/codex/bin/codex --quiet",
+				"amp": "/opt/amp/bin/amp --no-ide"
 			}
 		}`
 		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
@@ -707,6 +708,8 @@ func TestLoadConfig(t *testing.T) {
 			cfg.ProgramOverrides[tmux.ProgramClaude])
 		assert.Equal(t, "/opt/codex/bin/codex --quiet",
 			cfg.ProgramOverrides[tmux.ProgramCodex])
+		assert.Equal(t, "/opt/amp/bin/amp --no-ide",
+			cfg.ProgramOverrides[tmux.ProgramAmp])
 	})
 
 	t.Run("rejects legacy default_program with path-and-flags", func(t *testing.T) {
@@ -743,7 +746,7 @@ func TestLoadConfig(t *testing.T) {
 		require.NoError(t, os.MkdirAll(configDir, 0755))
 
 		configPath := filepath.Join(configDir, ConfigFileName)
-		require.NoError(t, os.WriteFile(configPath, []byte(`{"default_program": "amp"}`), 0644))
+		require.NoError(t, os.WriteFile(configPath, []byte(`{"default_program": "/opt/amp --some-flag"}`), 0644))
 
 		cfg, err := LoadConfig()
 		require.Error(t, err)
@@ -761,12 +764,12 @@ func TestLoadConfig(t *testing.T) {
 		require.NoError(t, os.MkdirAll(configDir, 0755))
 
 		configPath := filepath.Join(configDir, ConfigFileName)
-		require.NoError(t, os.WriteFile(configPath, []byte(`{"default_program": "amp"}`), 0644))
+		require.NoError(t, os.WriteFile(configPath, []byte(`{"default_program": "notanagent"}`), 0644))
 
 		cfg, err := LoadConfig()
 		require.Error(t, err)
 		assert.Nil(t, cfg)
-		assert.Contains(t, err.Error(), `"amp"`)
+		assert.Contains(t, err.Error(), `"notanagent"`)
 	})
 
 	t.Run("rejects unknown agent key in program_overrides", func(t *testing.T) {
@@ -779,7 +782,7 @@ func TestLoadConfig(t *testing.T) {
 		content := `{
 			"default_program": "claude",
 			"program_overrides": {
-				"amp": "/opt/amp"
+				"notanagent": "/opt/notanagent"
 			}
 		}`
 		require.NoError(t, os.WriteFile(configPath, []byte(content), 0644))
@@ -1200,15 +1203,27 @@ quit = "q"
 		assert.Equal(t, "codex", cfg.DefaultProgram)
 	})
 
-	t.Run("shares enum validation with the JSON path", func(t *testing.T) {
+	t.Run("accepts amp default program", func(t *testing.T) {
 		writeToml(t, `default_program = "amp"`+"\n")
 
 		cfg, err := LoadConfig()
-		require.Error(t, err)
-		assert.Nil(t, cfg)
-		assert.Contains(t, err.Error(), `"amp"`)
-		assert.Contains(t, err.Error(), "program_overrides")
-		assert.Contains(t, err.Error(), TomlConfigFileName)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, tmux.ProgramAmp, cfg.DefaultProgram)
+	})
+
+	t.Run("accepts amp key in program_overrides", func(t *testing.T) {
+		writeToml(t, `
+default_program = "amp"
+
+[program_overrides]
+amp = "/opt/amp"
+`)
+
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, "/opt/amp", cfg.ProgramOverrides[tmux.ProgramAmp])
 	})
 
 	t.Run("rejects unknown agent key in program_overrides", func(t *testing.T) {
@@ -1216,7 +1231,7 @@ quit = "q"
 default_program = "claude"
 
 [program_overrides]
-amp = "/opt/amp"
+notanagent = "/opt/notanagent"
 `)
 
 		cfg, err := LoadConfig()

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -88,7 +88,7 @@ func GetConfigDir() (string, error) {
 type Config struct {
 	SchemaVersion int `json:"schema_version" toml:"schema_version"`
 	// DefaultProgram is the default agent program name. Must be one of
-	// tmux.SupportedPrograms (e.g. "claude", "codex", "aider", "gemini").
+	// tmux.SupportedPrograms (e.g. "claude", "codex", "aider", "gemini", "amp").
 	DefaultProgram string `json:"default_program" toml:"default_program"`
 	// ProgramOverrides maps an agent name (key) to the full command string
 	// (value) used when invoking that agent under tmux. Keys must be in
@@ -245,7 +245,7 @@ func ValidateProgramEnum(lead, referent, name, exampleValue string) error {
 	}
 	return fmt.Errorf(
 		"\n\n%s must be one of [%s], got %q. To preserve a custom path or flags, set %s to the agent name and move the full command into program_overrides. Example: \"default_program\": \"claude\", \"program_overrides\": { \"claude\": %q }\n",
-		lead, strings.Join(tmux.SupportedPrograms, ", "), name,
+		lead, tmux.SupportedProgramsString(), name,
 		referent,
 		exampleValue,
 	)

--- a/config/limit_patterns.go
+++ b/config/limit_patterns.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/log"
@@ -68,7 +67,7 @@ func sanitizeLimitPatterns(config *Config) {
 	for agent, pattern := range config.LimitPatterns {
 		if !isSupportedProgram(agent) {
 			log.WarningLog.Printf("limit_patterns key %q is not one of [%s]; ignoring this override",
-				agent, strings.Join(tmux.SupportedPrograms, ", "))
+				agent, tmux.SupportedProgramsString())
 			delete(config.LimitPatterns, agent)
 			continue
 		}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,7 +13,7 @@ af                 # launch the TUI
 
 | Flag | Description |
 |------|-------------|
-| `-p`, `--program` | Agent to run in new sessions, one of `claude`, `codex`, `aider`, `gemini`. To pass custom paths or flags, use `program_overrides` in the config instead — see [configuration.md](configuration.md#choosing-the-agent). |
+| `-p`, `--program` | Agent to run in new sessions, one of `claude`, `codex`, `aider`, `gemini`, `amp`. To pass custom paths or flags, use `program_overrides` in the config instead — see [configuration.md](configuration.md#choosing-the-agent). |
 | `-y`, `--autoyes` | Experimental: automatically accept agent prompts in all sessions. |
 
 ## `af sessions`

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -19,7 +19,7 @@ the table as a map of tradeoffs, not a scorecard.
 | CLI + HTTP API | `af` prints JSON for sessions/tasks, and the daemon exposes a local owner-only HTTP/JSON API over a Unix socket. | tmux itself is scriptable; an HTTP API is not part of the tmux/manual stack. | CLI plus a local socket API for workspaces, panes, agents, events, and worktrees; not an HTTP API. |
 | Remote execution | Remote hooks let a repo define launch/list/attach/delete/terminal scripts for sessions elsewhere, shown in the same TUI. | SSH + tmux is a proven remote pattern, but agent/session metadata is manual. | First-class remote attach over SSH/direct remote client is a core feature. |
 | Open source / license | Open source, GNU AGPL v3. | tmux is open source under the ISC-style tmux license; your glue scripts and chosen agents vary. | Open source AGPL-3.0-or-later, with commercial licensing offered. |
-| Supported agents | Named agent choices are `claude`, `codex`, `aider`, and `gemini`; configure paths/flags with `program_overrides`. | Anything you can run in a shell. | Broad terminal-agent support, with richer integrations for many listed agents and fallback terminal support for others. |
+| Supported agents | Named agent choices are `claude`, `codex`, `aider`, `gemini`, and `amp`; configure paths/flags with `program_overrides`. | Anything you can run in a shell. | Broad terminal-agent support, with richer integrations for many listed agents and fallback terminal support for others. |
 
 ## When To Choose What
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,8 +56,8 @@ pane_border_preview = "#DC8CC3"
 
 | Field | Description |
 |-------|-------------|
-| `default_program` | Default agent enum. Must be one of `claude`, `codex`, `aider`, `gemini`. |
-| `program_overrides` | Optional map from agent enum to the full command string used when launching that agent. Use this to pin a path or pass flags (e.g. `--dangerously-skip-permissions`). Keys must be one of `claude`, `codex`, `aider`, `gemini`. Agent-specific launch flags (claude's `--plugin-dir`, codex's `developer_instructions`) and readiness detection follow the program the override actually runs, not the key: pointing an agent name at a different command (even a non-agent one like `bash`) launches it with no injected agent flags, and a command running no known agent counts as ready once its pane shows output. The agent is identified by command-token basename (`/opt/tools/claude --model opus` and `ionice -c 3 claude` are claude; `/opt/claude-wrapper/run` is not), so if you wrap an agent in a script, name the script after the agent to keep its flags and readiness behavior. |
+| `default_program` | Default agent enum. Must be one of `claude`, `codex`, `aider`, `gemini`, `amp`. |
+| `program_overrides` | Optional map from agent enum to the full command string used when launching that agent. Use this to pin a path or pass flags (e.g. `--dangerously-skip-permissions`). Keys must be one of `claude`, `codex`, `aider`, `gemini`, `amp`. Agent-specific launch flags (claude's `--plugin-dir`, codex's `developer_instructions`) and readiness detection follow the program the override actually runs, not the key: pointing an agent name at a different command (even a non-agent one like `bash`) launches it with no injected agent flags, and a command running no known agent counts as ready once its pane shows output. The agent is identified by command-token basename (`/opt/tools/claude --model opus` and `ionice -c 3 claude` are claude; `/opt/claude-wrapper/run` is not), so if you wrap an agent in a script, name the script after the agent to keep its flags and readiness behavior. |
 | `auto_yes` | Auto-accept agent prompts (experimental). |
 | `auto_update` | Startup self-update check. Defaults to `true`: `af` checks the configured `update_channel` on launch and automatically applies newer releases. Set to `false`, or set `AGENT_FACTORY_AUTO_UPDATE=0`, to opt out. |
 | `daemon_poll_interval` | Daemon polling interval in ms. |
@@ -158,7 +158,7 @@ claude = "Claude usage limit reached\\."
 codex  = "You've hit your usage limit"
 ```
 
-- Keys must be a supported agent enum (`claude`, `codex`, `aider`, `gemini`).
+- Keys must be a supported agent enum (`claude`, `codex`, `aider`, `gemini`, `amp`).
 - An override for an agent with no built-in matcher (`aider`/`gemini` today — they are API-key-metered and have no plan reset window) is ignored with a warning.
 - An uncompilable regex warns and falls back to the built-in default, so a typo can never disable detection.
 - `limit_patterns` is a detection tweak, not a behavior switch: it is honored everywhere the built-in detector runs (the daemon status poll, and the task-run startup park path).
@@ -210,7 +210,7 @@ Override the agent for new sessions with `-p`:
 af -p aider
 ```
 
-`-p` and the per-task `program` field both accept a bare agent enum only (`claude`, `codex`, `aider`, `gemini`). To pass a custom path or flags for an agent, set `program_overrides.<agent>` in your config — every session that launches that agent will use the override.
+`-p` and the per-task `program` field both accept a bare agent enum only (`claude`, `codex`, `aider`, `gemini`, `amp`). To pass a custom path or flags for an agent, set `program_overrides.<agent>` in your config — every session that launches that agent will use the override.
 
 ## In-repo config
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,7 +8,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 
 ## Commands
 
-- [`af`](#af) — Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, and Gemini.
+- [`af`](#af) — Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, Gemini, and Amp.
 - [`af api`](#af-api) — Show the daemon-hosted HTTP/JSON API catalog
 - [`af bug-report`](#af-bug-report) — Bundle logs, versions, tasks, and redacted state for a bug report
 - [`af completion`](#af-completion) — Generate the autocompletion script for the specified shell
@@ -57,7 +57,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 
 ## af
 
-Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, and Gemini.
+Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, Gemini, and Amp.
 
 ```
 af [flags]
@@ -84,7 +84,7 @@ af [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `-y`, `--autoyes` |  | [experimental] If enabled, all instances will automatically accept prompts |
-| `-p`, `--program` | `string` | Program to run in new instances (one of: claude, codex, aider, gemini) |
+| `-p`, `--program` | `string` | Program to run in new instances (one of: claude, codex, aider, gemini, amp) |
 
 ## af api
 
@@ -353,7 +353,7 @@ value is validated with the same rules the config loader uses before anything is
 written, so set can never leave a config that fails to load.
 
 Settable keys:
-  default_program            agent enum (claude, codex, aider, gemini)
+  default_program            agent enum (claude, codex, aider, gemini, amp)
   program_overrides.<agent>  full command string for an agent
   auto_yes                   true | false
   auto_update                true | false
@@ -641,7 +641,7 @@ af sessions create [flags]
 | `--here` |  | Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both) |
 | `--in-place` |  | Alias for --here |
 | `--name` | `string` | Session name (required) |
-| `--program` | `string` | Program to run (defaults to config default) |
+| `--program` | `string` | Program to run (one of: claude, codex, aider, gemini, amp; defaults to config default) |
 | `--prompt` | `string` | Initial prompt to send |
 
 **Global flags**
@@ -785,7 +785,7 @@ af sessions send-prompt <title> <prompt> [flags]
 | `--all-repos` |  | With --all, broadcast across every repo instead of only the current/--repo one |
 | `--create` |  | Auto-create the session if it doesn't exist |
 | `--include-root` |  | With --all, also deliver to the reserved root session (excluded by default) |
-| `--program` | `string` | Program to run when creating a new session (defaults to config default) |
+| `--program` | `string` | Program to run when creating a new session (one of: claude, codex, aider, gemini, amp; defaults to config default) |
 
 **Global flags**
 
@@ -988,7 +988,7 @@ af tasks add [flags]
 |------|------|-------------|
 | `--cron` | `string` | Cron expression (exactly one of --cron / --watch-cmd) |
 | `--name` | `string` | Task name (required) |
-| `--program` | `string` | Program to run (defaults to config default) |
+| `--program` | `string` | Program to run (one of: claude, codex, aider, gemini, amp; defaults to config default) |
 | `--prompt` | `string` | Prompt to send (required for --cron tasks; --watch-cmd tasks default to the emitted line, with {{line}} substituted when present) |
 | `--target-session` | `string` | Deliver the prompt into this session (auto-created if missing); empty creates a new session per run |
 | `--watch-cmd` | `string` | Long-running watch command; each stdout line triggers the task (exactly one of --cron / --watch-cmd) |
@@ -1075,7 +1075,7 @@ af tasks update <id> [flags]
 | `--cron` | `string` | New cron expression (clears watch-cmd) |
 | `--enabled` | `string` | Enable or disable the task (true/false) |
 | `--name` | `string` | New task name |
-| `--program` | `string` | New program to run (leave unset to keep the current one) |
+| `--program` | `string` | New program to run (one of: claude, codex, aider, gemini, amp; leave unset to keep the current one) |
 | `--prompt` | `string` | New prompt |
 | `--target-session` | `string` | New target session; pass an empty value to revert to a new session per run |
 | `--watch-cmd` | `string` | New watch command (clears cron) |

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -26,7 +26,7 @@ Tasks live in `~/.agent-factory/tasks.json`. Manage them via `af tasks` (JSON CL
 | `watch_cmd` | Event trigger — long-running command; each stdout line fires the task (exactly one of `cron_expr` / `watch_cmd`) |
 | `target_session` | Deliver into this session by title (auto-created if missing). Empty = create a new session per fire |
 | `project_path` | Repo the task operates on; also the watch script's working directory |
-| `program` | Agent to run (`claude`, `aider`, …). Empty = configured `default_program` |
+| `program` | Agent to run (`claude`, `codex`, `aider`, `gemini`, `amp`). Empty = configured `default_program` |
 | `enabled` | Disabled tasks never fire; their watch script is stopped |
 | `last_run_at` / `last_run_status` | Set by the daemon: `started` (session created), `sent` (prompt delivered into a session), `parked: usage limit` (the session hit a plan usage-limit wall at startup and is parked, not failed — see [usage-limits.md](usage-limits.md#task-runs-park-dont-fail)), and for watch tasks `stopped` / `errored` (see below) |
 

--- a/docs/usage-limits.md
+++ b/docs/usage-limits.md
@@ -109,10 +109,12 @@ failure even though nothing was actually wrong — you'd just hit your plan limi
 | `codex` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `gemini` | — | — | — | — | — |
 | `aider` | — | — | — | — | — |
+| `amp` | — | — | — | — | — |
 
 Auto-resume covers `claude`/`codex` because their banners carry a parseable
-reset window; `gemini`/`aider` are API-key-metered (transient 429s the CLI
-retries) with no plan window to schedule against.
+reset window; other supported agents either do not expose a known plan-reset
+banner or are API-key-metered (transient 429s the CLI retries) with no plan
+window to schedule against.
 
 ## Custom detection patterns
 
@@ -125,7 +127,8 @@ claude = "Claude usage limit reached\\."
 codex  = "You've hit your usage limit"
 ```
 
-Keys must be a supported agent (`claude`, `codex`, `aider`, `gemini`); an
-override for an agent with no built-in matcher (`aider`/`gemini` today) is
-ignored, and an uncompilable regex warns and falls back to the built-in default.
+Keys must be a supported agent (`claude`, `codex`, `aider`, `gemini`, `amp`);
+an override for an agent with no built-in matcher (`aider`/`gemini`/`amp`
+today) is ignored, and an uncompilable regex warns and falls back to the
+built-in default.
 See [configuration.md](configuration.md#custom-usage-limit-detection-limit_patterns).

--- a/doctor/setup.go
+++ b/doctor/setup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	aflog "github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/preflight"
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 func checkSetup(ctx *scanContext, report *Report) {
@@ -179,7 +180,7 @@ func checkAgentPrograms(cfg *config.Config, report *Report) {
 	if cfg.DefaultProgram == "" {
 		report.Findings = append(report.Findings, Finding{
 			Check:  "agent-program",
-			Detail: "default_program is empty — set it to one of claude, codex, aider, or gemini in ~/.agent-factory/config.toml",
+			Detail: fmt.Sprintf("default_program is empty — set it to one of %s in ~/.agent-factory/config.toml", tmux.SupportedProgramsString()),
 		})
 		return
 	}

--- a/doctor/setup_test.go
+++ b/doctor/setup_test.go
@@ -66,6 +66,29 @@ func TestSetupDoctorReportsMissingDefaultProgram(t *testing.T) {
 	require.Contains(t, findings[0].Detail, "program_overrides.claude")
 }
 
+func TestDoctorAgentBinaryScanIncludesAmp(t *testing.T) {
+	binDir := t.TempDir()
+	fakeAmp := writeExecutable(t, binDir, "amp", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", binDir)
+
+	cfg := &config.Config{
+		DefaultProgram:   tmux.ProgramAmp,
+		ProgramOverrides: map[string]string{tmux.ProgramAmp: fakeAmp},
+	}
+	report := &Report{}
+	checkAgentBinaries(cfg, report)
+
+	var agentsHeader string
+	for _, h := range report.Header {
+		if h.Label == "agents" {
+			agentsHeader = h.Value
+			break
+		}
+	}
+	require.Contains(t, agentsHeader, "amp=present")
+	require.True(t, okContains(report, "amp"), "amp pass row should be recorded")
+}
+
 func setupDoctorRepo(t *testing.T) string {
 	t.Helper()
 	repo := filepath.Join(t.TempDir(), "repo")

--- a/preflight/preflight.go
+++ b/preflight/preflight.go
@@ -125,6 +125,8 @@ func agentDisplayName(agent string) string {
 		return "Aider"
 	case tmux.ProgramGemini:
 		return "Gemini"
+	case tmux.ProgramAmp:
+		return "Amp"
 	default:
 		if agent == "" {
 			return "the configured agent"

--- a/preflight/preflight_test.go
+++ b/preflight/preflight_test.go
@@ -1,9 +1,13 @@
 package preflight
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
 )
 
 func TestShellWords(t *testing.T) {
@@ -67,5 +71,12 @@ func TestCheckCommandRejectsNonExecutablePath(t *testing.T) {
 	}
 	if _, err := CheckCommand(path); err == nil {
 		t.Fatal("expected non-executable path to fail")
+	}
+}
+
+func TestProgramErrorDisplaysAmp(t *testing.T) {
+	err := ProgramError(tmux.ProgramAmp, "amp", errors.New("missing"))
+	if !strings.Contains(err.Error(), "Amp is not installed") {
+		t.Fatalf("ProgramError() = %q, want Amp display name", err.Error())
 	}
 }

--- a/session/backend_hook_core_test.go
+++ b/session/backend_hook_core_test.go
@@ -650,6 +650,7 @@ func TestLocalBackendCheckAndHandleTrustPromptDispatch(t *testing.T) {
 		{"codex dispatches (#729)", tmux.ProgramCodex, true},
 		{"aider dispatches", tmux.ProgramAider, true},
 		{"gemini dispatches", tmux.ProgramGemini, true},
+		{"amp dispatches", tmux.ProgramAmp, true},
 		{"legacy codex path dispatches (#729)", "/usr/local/bin/codex", true},
 		{"unknown program does not dispatch", "some-other-tool", false},
 	}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -641,7 +641,7 @@ func (b *LocalBackend) CheckAndHandleTrustPrompt(i *Instance) bool {
 	// here, so a codex trust/confirmation dialog was never dismissed even
 	// though isReadyContent could surface it.
 	switch i.ResolvedAgent() {
-	case tmux.ProgramClaude, tmux.ProgramCodex, tmux.ProgramAider, tmux.ProgramGemini:
+	case tmux.ProgramClaude, tmux.ProgramCodex, tmux.ProgramAider, tmux.ProgramGemini, tmux.ProgramAmp:
 		return ts.CheckAndHandleTrustPrompt()
 	}
 	return false

--- a/session/conversation_capture_test.go
+++ b/session/conversation_capture_test.go
@@ -49,7 +49,9 @@ func TestCaptureAgentConversation_CodexAmbiguousConcurrentRollouts(t *testing.T)
 
 func TestCaptureAgentConversation_UnsupportedAgentGracefullyNoID(t *testing.T) {
 	snap := BeginConversationCapture()
-	conv, err := CaptureAgentConversation(tmux.ProgramGemini, snap, 0)
-	require.NoError(t, err)
-	require.False(t, conv.HasID())
+	for _, agent := range []string{tmux.ProgramGemini, tmux.ProgramAmp} {
+		conv, err := CaptureAgentConversation(agent, snap, 0)
+		require.NoError(t, err)
+		require.False(t, conv.HasID())
+	}
 }

--- a/session/hook_preview_sanitize_test.go
+++ b/session/hook_preview_sanitize_test.go
@@ -197,8 +197,9 @@ func TestSanitizeHookPreview(t *testing.T) {
 
 // TestSanitizeHookPreviewKeepsReadySignals pins the contract that
 // task.WaitForReady depends on: the per-agent ready glyphs that
-// isReadyContent matches (codex "›", claude "❯", aider "\n> ", gemini "╰")
-// must survive sanitization of a realistic raw remote capture.
+// isReadyContent matches (codex "›", claude "❯", aider "\n> ", gemini "╰",
+// amp's mode-labeled input frame) must survive sanitization of a realistic raw
+// remote capture.
 func TestSanitizeHookPreviewKeepsReadySignals(t *testing.T) {
 	cases := []struct {
 		name string
@@ -224,6 +225,11 @@ func TestSanitizeHookPreviewKeepsReadySignals(t *testing.T) {
 			name: "gemini frame corner",
 			raw:  "\x1b[2J╭───╮\r\n╰───╯\r\n",
 			want: "╰",
+		},
+		{
+			name: "amp input frame",
+			raw:  "\x1b[2JWelcome to Amp\r\n╭──────── medium ────────╮\r\n│ > \x1b[?25h",
+			want: "╭",
 		},
 	}
 	for _, tc := range cases {

--- a/session/resolved_agent_test.go
+++ b/session/resolved_agent_test.go
@@ -25,11 +25,13 @@ func TestResolvedAgent(t *testing.T) {
 		{"override to bash (#1131)", withTmuxProgram("bash"), ""},
 		{"override to unknown tool (#1116)", withTmuxProgram("/usr/bin/some-other-tool --foo"), ""},
 		{"override to codex", withTmuxProgram("/usr/local/bin/codex --full-auto"), tmux.ProgramCodex},
+		{"override to amp", withTmuxProgram("/home/me/.amp/bin/amp --no-ide"), tmux.ProgramAmp},
 		{"claude with injected flags", withTmuxProgram("claude --plugin-dir '/x/plugin'"), tmux.ProgramClaude},
 
 		// No tmux session yet: fall back to the Program value, including
 		// legacy free-form persisted shapes (#677).
 		{"no tmux, bare enum", &Instance{Program: tmux.ProgramGemini}, tmux.ProgramGemini},
+		{"no tmux, amp enum", &Instance{Program: tmux.ProgramAmp}, tmux.ProgramAmp},
 		{"no tmux, legacy claude path", &Instance{Program: "/home/foo/bin/claude --plugin-dir x"}, tmux.ProgramClaude},
 		{"no tmux, unknown program", &Instance{Program: "some-other-tool"}, ""},
 	}

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -18,7 +18,7 @@ Sessions (one agent per isolated worktree):
   af sessions whoami                                   Identify your own session
   af sessions list                                     List sessions
   af sessions get <title>                              Fetch one session
-  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini]
+  af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp]
   af sessions send-prompt <title> <prompt> [--create]  Send a prompt (--create makes the session first if missing)
   af sessions preview <title>                          Snapshot another session's terminal output
   af sessions attach <title>                           Attach interactively (foreground)
@@ -66,7 +66,7 @@ func shellQuote(s string) string {
 //   - Claude Code: --plugin-dir flag only (a single "af" skill carrying afUsageReference)
 //   - Codex: -c developer_instructions="..." flag carrying the same afUsageReference
 //     (no custom-skills-folder mechanism exists in the Codex CLI; see #1043)
-//   - aider, gemini, and commands running no known agent: no injection.
+//   - aider, gemini, amp, and commands running no known agent: no injection.
 func injectSystemPrompt(resolved string) string {
 	agent := tmux.DetectAgentFromCommand(resolved)
 	if agent == tmux.ProgramClaude {

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -124,6 +124,14 @@ func TestInjectSystemPrompt_Gemini(t *testing.T) {
 	}
 }
 
+func TestInjectSystemPrompt_Amp(t *testing.T) {
+	result := injectSystemPrompt("amp")
+
+	if result != "amp" {
+		t.Errorf("expected amp unchanged (no system-prompt flag), got %q", result)
+	}
+}
+
 // TestInjectSystemPrompt_ResolvedCommandMatrix pins #1116/#1131: which flags
 // get injected is decided by the agent the RESOLVED command actually runs —
 // through every override shape (bare name, absolute path, path+flags,
@@ -139,11 +147,12 @@ func TestInjectSystemPrompt_ResolvedCommandMatrix(t *testing.T) {
 		resolved string
 		want     string // "" = resolved must come back unchanged
 	}{
-		// name→name (no override) for all four agents.
+		// name→name (no override) for all supported agents.
 		{"claude bare", "claude", "--plugin-dir"},
 		{"codex bare", "codex", "developer_instructions="},
 		{"aider bare", "aider", ""},
 		{"gemini bare", "gemini", ""},
+		{"amp bare", "amp", ""},
 
 		// name→path and name→path+flags overrides.
 		{"claude override path", "/opt/claude-next/bin/claude", "--plugin-dir"},
@@ -151,6 +160,7 @@ func TestInjectSystemPrompt_ResolvedCommandMatrix(t *testing.T) {
 		{"codex override path with flags", "/usr/local/bin/codex --full-auto", "developer_instructions="},
 		{"aider override path", "/usr/local/bin/aider --no-auto-commits", ""},
 		{"gemini override path", "/usr/local/bin/gemini", ""},
+		{"amp override path", "/home/me/.amp/bin/amp --no-ide", ""},
 
 		// name→other-agent: the RESOLVED agent's flags, not the key's.
 		{"claude key resolved to codex gets codex flags", "codex --full-auto", "developer_instructions="},

--- a/session/tmux/detect_agent_test.go
+++ b/session/tmux/detect_agent_test.go
@@ -18,17 +18,20 @@ func TestDetectAgentFromCommand(t *testing.T) {
 		{"bare codex", "codex", ProgramCodex},
 		{"bare aider", "aider", ProgramAider},
 		{"bare gemini", "gemini", ProgramGemini},
+		{"bare amp", "amp", ProgramAmp},
 
 		// Override / legacy shapes: absolute paths, flags, quoting.
 		{"claude abs path", "/home/foo/bin/claude", ProgramClaude},
 		{"claude path with flags", "/home/foo/bin/claude --plugin-dir x", ProgramClaude},
 		{"codex path with flags", "/usr/local/bin/codex --full-auto", ProgramCodex},
+		{"amp path with flags", "/home/user/.amp/bin/amp --no-ide", ProgramAmp},
 		{"quoted claude path", "'/opt/my tools/claude' --model opus", ProgramClaude},
 		{"uppercase base matches", "/opt/bin/Claude", ProgramClaude},
 
 		// Wrapper prefixes still match (#742 precedent from resumeProgram).
 		{"ionice wrapper", "ionice -c 3 claude", ProgramClaude},
 		{"env wrapper", "env FOO=1 gemini --resume latest", ProgramGemini},
+		{"amp env wrapper", "env AMP_URL=https://ampcode.com amp --no-notifications", ProgramAmp},
 
 		// Non-agent commands: no agent behavior may attach to these.
 		{"bare shell (#1131)", "bash", ""},

--- a/session/tmux/resume.go
+++ b/session/tmux/resume.go
@@ -10,7 +10,7 @@ import (
 // #595). For agents without a resume-most-recent flag, programs that already
 // include one, and unknown programs, returns program unchanged.
 //
-// Agent-specific rewrites — all four paths preserve the original program
+// Agent-specific rewrites preserve the original program
 // string verbatim (modulo the inserted resume tokens) so user shell quoting,
 // $VAR / ~ / glob metacharacters survive respawn unchanged (#640):
 //
@@ -31,9 +31,13 @@ import (
 //   - gemini: append --resume latest at the end. The "latest" keyword
 //     resumes the most recent session in cwd and silently falls back
 //     to a fresh session if none exists.
+//   - amp: insert "threads continue --last" after any leading Amp global
+//     options. Amp's resume path is a subcommand; explicit user subcommands
+//     like "amp review" are left unchanged.
 //
-// All four CLIs silently fall back to a fresh session when no prior session
-// exists in cwd, so the rewrite is safe to apply unconditionally.
+// The latest-session paths above either fall back to a fresh session when no
+// prior session exists or are left unchanged when af cannot identify a safe
+// provider resume command.
 func resumeProgram(program string) string {
 	tokens, ends := splitShellTokens(program)
 	agentIdx, agent := findAgentToken(tokens)
@@ -97,6 +101,13 @@ func resumeProgram(program string) string {
 			}
 		}
 		return program + " --resume latest"
+	case ProgramAmp:
+		insertAt, alreadyResume := ampResumeInsertIndex(tokens, agentIdx)
+		if alreadyResume || insertAt < 0 {
+			return program
+		}
+		off := ends[insertAt-1]
+		return program[:off] + " threads continue --last" + program[off:]
 	}
 	return program
 }
@@ -128,7 +139,7 @@ func ResumeProgramWithConversationID(program, recordedAgent, id string) (rewritt
 				return program, false
 			}
 		}
-		return program + " --resume " + id, true
+		return program + " --resume " + shellQuoteArg(id), true
 	case ProgramCodex:
 		insertAt := agentIdx + 1
 		if insertAt < len(tokens) && tokens[insertAt] == "exec" {
@@ -138,9 +149,28 @@ func ResumeProgramWithConversationID(program, recordedAgent, id string) (rewritt
 			return program, false
 		}
 		off := ends[insertAt-1]
-		return program[:off] + " resume " + id + program[off:], true
+		return program[:off] + " resume " + shellQuoteArg(id) + program[off:], true
+	case ProgramAmp:
+		insertAt, alreadyResume := ampResumeInsertIndex(tokens, agentIdx)
+		if alreadyResume || insertAt < 0 {
+			return program, false
+		}
+		off := ends[insertAt-1]
+		return program[:off] + " threads continue " + shellQuoteArg(id) + program[off:], true
 	}
 	return program, false
+}
+
+func shellQuoteArg(arg string) string {
+	if arg != "" && strings.IndexFunc(arg, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			strings.ContainsRune("_@%+=:,./-", r))
+	}) == -1 {
+		return arg
+	}
+	return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
 }
 
 // ClaudeProgramWithSessionID appends Claude Code's explicit conversation id flag
@@ -201,6 +231,130 @@ func findAgentToken(tokens []string) (int, string) {
 		}
 	}
 	return -1, ""
+}
+
+// ampResumeInsertIndex returns the token index before which Amp's resume
+// subcommand should be inserted. Amp global options may appear before the
+// subcommand ("amp --no-ide threads continue --last"), while an explicit user
+// subcommand ("amp review", "amp threads list") should not be rewritten.
+func ampResumeInsertIndex(tokens []string, agentIdx int) (insertAt int, alreadyResume bool) {
+	i := agentIdx + 1
+	for i < len(tokens) {
+		tok := tokens[i]
+		switch {
+		case tok == "--":
+			return -1, false
+		case tok == "-x" || strings.HasPrefix(tok, "-x") || tok == "--execute" || strings.HasPrefix(tok, "--execute="):
+			return -1, false
+		case tok == "-h" || tok == "--help" || tok == "-V" || tok == "--version" || tok == "-v":
+			return -1, false
+		case ampFlagHasAttachedValue(tok):
+			i++
+		case ampFlagTakesValue(tok):
+			i++
+			if i < len(tokens) {
+				i++
+			}
+		case tok == "--plugin-ready-timeout":
+			i++
+			if i < len(tokens) && !strings.HasPrefix(tokens[i], "-") {
+				i++
+			}
+		case ampKnownBooleanFlag(tok):
+			i++
+		case strings.HasPrefix(tok, "-"):
+			i = ampConsumeUnknownFlag(tokens, i)
+		default:
+			goto command
+		}
+	}
+	return i, false
+
+command:
+	switch tokens[i] {
+	case "last", "l":
+		return i, true
+	case "threads", "thread", "t":
+		if i+1 < len(tokens) && (tokens[i+1] == "continue" || tokens[i+1] == "c") {
+			return i, true
+		}
+		return -1, false
+	default:
+		return -1, false
+	}
+}
+
+func ampFlagTakesValue(tok string) bool {
+	switch tok {
+	case "--visibility", "--settings-file", "--log-level", "--log-file",
+		"--mcp-config", "-m", "--mode", "--effort", "-l", "--label":
+		return true
+	default:
+		return false
+	}
+}
+
+func ampFlagHasAttachedValue(tok string) bool {
+	for _, prefix := range []string{
+		"--visibility=", "--settings-file=", "--log-level=", "--log-file=",
+		"--mcp-config=", "--mode=", "--effort=", "--label=",
+		"--plugin-ready-timeout=",
+	} {
+		if strings.HasPrefix(tok, prefix) {
+			return true
+		}
+	}
+	return strings.HasPrefix(tok, "-m") && len(tok) > 2 ||
+		strings.HasPrefix(tok, "-l") && len(tok) > 2
+}
+
+func ampKnownBooleanFlag(tok string) bool {
+	switch tok {
+	case "--notifications", "--no-notifications",
+		"--color", "--no-color",
+		"--ide", "--no-ide",
+		"--stream-json", "--stream-json-thinking", "--stream-json-input",
+		"--no-archive-after-execute":
+		return true
+	default:
+		return false
+	}
+}
+
+func ampConsumeUnknownFlag(tokens []string, i int) int {
+	tok := tokens[i]
+	i++
+	if strings.Contains(tok, "=") {
+		return i
+	}
+	// Accepted forward-compat limitation: for an unknown Amp option, we cannot
+	// know whether `amp --foo threads` means boolean --foo plus the `threads`
+	// subcommand, or value-taking --foo whose value is "threads". All current
+	// value-taking global options from `amp --help` are enumerated above; if
+	// Amp ships another one, add it to ampFlagTakesValue so resume insertion
+	// can consume its value unambiguously.
+	if i < len(tokens) && !strings.HasPrefix(tokens[i], "-") && !ampKnownTopLevelCommand(tokens[i]) {
+		i++
+	}
+	return i
+}
+
+func ampKnownTopLevelCommand(tok string) bool {
+	switch tok {
+	case "version", "logout", "login", "orb", "clone", "top",
+		"last", "l",
+		"threads", "thread", "t",
+		"tools", "tool",
+		"review",
+		"skill", "skills",
+		"permissions", "permission",
+		"mcp", "config",
+		"projects", "usage",
+		"update", "up":
+		return true
+	default:
+		return false
+	}
 }
 
 // isShortResumeWithAttachedValue reports whether tok is the POSIX

--- a/session/tmux/resume_test.go
+++ b/session/tmux/resume_test.go
@@ -249,6 +249,35 @@ func TestResumeProgram(t *testing.T) {
 			"gemini --model x -r5",
 		},
 
+		// Amp: insert the resume subcommand after any leading Amp global
+		// options. Explicit user subcommands are left unchanged so af does not
+		// rewrite e.g. "amp review" into a different command.
+		{"amp bare", "amp", "amp threads continue --last"},
+		{"amp with global flag", "amp --no-ide", "amp --no-ide threads continue --last"},
+		{"amp with global flag value", "amp --settings-file ~/.config/amp/test.json", "amp --settings-file ~/.config/amp/test.json threads continue --last"},
+		{"amp with mode", "amp -m high --no-notifications", "amp -m high --no-notifications threads continue --last"},
+		{"amp with optional global flag value", "amp --plugin-ready-timeout 30 --no-color", "amp --plugin-ready-timeout 30 --no-color threads continue --last"},
+		{"amp with optional global flag attached value", "amp --plugin-ready-timeout=30", "amp --plugin-ready-timeout=30 threads continue --last"},
+		{"amp with unknown value-taking global flag", "amp --future-setting workspace --no-ide", "amp --future-setting workspace --no-ide threads continue --last"},
+		{"amp with unknown attached global flag value", "amp --future-setting=workspace --no-ide", "amp --future-setting=workspace --no-ide threads continue --last"},
+		{
+			"amp absolute path",
+			"/home/user/.amp/bin/amp --no-ide",
+			"/home/user/.amp/bin/amp --no-ide threads continue --last",
+		},
+		{
+			"amp quoted path with spaces",
+			"'/path with space/amp' --no-ide",
+			"'/path with space/amp' --no-ide threads continue --last",
+		},
+		{"amp already last", "amp last", "amp last"},
+		{"amp already l", "amp l", "amp l"},
+		{"amp already threads continue", "amp threads continue --last", "amp threads continue --last"},
+		{"amp already threads c", "amp threads c --last", "amp threads c --last"},
+		{"amp explicit subcommand", "amp review", "amp review"},
+		{"amp explicit subcommand after unknown boolean", "amp --future-bool review", "amp --future-bool review"},
+		{"amp explicit threads list", "amp threads list --json", "amp threads list --json"},
+
 		// Wrapper-command flags must not be mistaken for agent resume flags
 		// (#742). The already-has-resume scan is position-aware: only tokens
 		// AFTER the agent token are inspected, so a wrapper flag like
@@ -316,6 +345,11 @@ func TestResumeProgram(t *testing.T) {
 			"gemini wrapper with agent attached resume",
 			"ionice -c 3 gemini -r5",
 			"ionice -c 3 gemini -r5",
+		},
+		{
+			"amp ionice wrapper",
+			"ionice -c 3 amp --no-ide",
+			"ionice -c 3 amp --no-ide threads continue --last",
 		},
 
 		// Unknown programs are passed through unchanged so unrelated CLIs
@@ -392,6 +426,11 @@ func TestResumeProgramWithConversationID(t *testing.T) {
 		{"codex exec", ProgramCodex, "codex exec --foo bar", "codex exec resume " + id + " --foo bar", true},
 		{"codex quoted path", ProgramCodex, "'/path with spaces/codex' --model gpt-5", "'/path with spaces/codex' resume " + id + " --model gpt-5", true},
 		{"codex already resume", ProgramCodex, "codex resume --last", "codex resume --last", false},
+		{"amp bare", ProgramAmp, "amp", "amp threads continue " + id, true},
+		{"amp with global flag", ProgramAmp, "amp --no-ide", "amp --no-ide threads continue " + id, true},
+		{"amp quoted path", ProgramAmp, "'/path with spaces/amp' --no-ide", "'/path with spaces/amp' --no-ide threads continue " + id, true},
+		{"amp already resume latest", ProgramAmp, "amp threads continue --last", "amp threads continue --last", false},
+		{"amp explicit command", ProgramAmp, "amp review", "amp review", false},
 		{"provider mismatch", ProgramClaude, "codex --model gpt-5", "codex --model gpt-5", false},
 		{"unsupported provider", ProgramGemini, "gemini", "gemini", false},
 		{"empty id", ProgramCodex, "codex", "codex", false},
@@ -408,6 +447,34 @@ func TestResumeProgramWithConversationID(t *testing.T) {
 			require.Equal(t, tc.wantRewritten, rewritten)
 		})
 	}
+}
+
+func TestResumeProgramWithConversationIDQuotesUnsafeID(t *testing.T) {
+	const id = "thread id?x=1&y=2"
+	cases := []struct {
+		name  string
+		agent string
+		in    string
+		want  string
+	}{
+		{"claude", ProgramClaude, "claude", "claude --resume 'thread id?x=1&y=2'"},
+		{"codex", ProgramCodex, "codex", "codex resume 'thread id?x=1&y=2'"},
+		{"amp", ProgramAmp, "amp", "amp threads continue 'thread id?x=1&y=2'"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, rewritten := ResumeProgramWithConversationID(tc.in, tc.agent, id)
+			require.True(t, rewritten)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestShellQuoteArg(t *testing.T) {
+	require.Equal(t, "abc-123_./:@%+=", shellQuoteArg("abc-123_./:@%+="))
+	require.Equal(t, "'thread id?x=1&y=2'", shellQuoteArg("thread id?x=1&y=2"))
+	require.Equal(t, `'it'"'"'s'`, shellQuoteArg("it's"))
 }
 
 // TestResumeProgram_CodexProfileResumeFalsePositive guards #632: the codex
@@ -462,6 +529,12 @@ func TestResumeProgram_Idempotent(t *testing.T) {
 		"ionice -c 3 aider",
 		"ionice -c 3 gemini",
 		"taskset -c 0-3 gemini",
+		"amp",
+		"amp --no-ide",
+		"amp --settings-file ~/.config/amp/test.json",
+		"ionice -c 3 amp --no-ide",
+		"amp threads continue --last",
+		"amp review",
 	} {
 		once := resumeProgram(in)
 		twice := resumeProgram(once)

--- a/session/tmux/session.go
+++ b/session/tmux/session.go
@@ -19,9 +19,15 @@ const ProgramClaude = "claude"
 const ProgramCodex = "codex"
 const ProgramAider = "aider"
 const ProgramGemini = "gemini"
+const ProgramAmp = "amp"
 
 // SupportedPrograms is the canonical list of known agent programs.
-var SupportedPrograms = []string{ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini}
+var SupportedPrograms = []string{ProgramClaude, ProgramCodex, ProgramAider, ProgramGemini, ProgramAmp}
+
+// SupportedProgramsString returns the canonical user-facing agent enum list.
+func SupportedProgramsString() string {
+	return strings.Join(SupportedPrograms, ", ")
+}
 
 // TmuxSession represents a managed tmux session
 type TmuxSession struct {

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -115,13 +115,14 @@ func TestCodexSubmitUsesBracketedPaste(t *testing.T) {
 }
 
 // TestNonCodexSubmitUsesPlainPasteBuffer guards against regressing the agents
-// that do not need bracketed-paste submit semantics (claude/aider/gemini and
-// unknown/override panes): they use tmux's plain paste-buffer path plus Enter.
+// that do not need bracketed-paste submit semantics
+// (claude/aider/gemini/amp and unknown/override panes): they use tmux's plain
+// paste-buffer path plus Enter.
 // This keeps codex's #1256 bracketed-paste behavior scoped to codex while
 // avoiding the literal `send-keys -l` wrapped-redraw issue seen in bash-backed
 // sessions (#1292).
 func TestNonCodexSubmitUsesPlainPasteBuffer(t *testing.T) {
-	for _, program := range []string{"claude", "aider", "gemini", "some-custom-shell"} {
+	for _, program := range []string{"claude", "aider", "gemini", "amp", "some-custom-shell"} {
 		t.Run(program, func(t *testing.T) {
 			const prompt = "hello"
 			cmds := recordTmuxCommands(t, program, prompt)

--- a/task/limit.go
+++ b/task/limit.go
@@ -21,11 +21,12 @@ import (
 //
 // Scope of what we schedule against: only the subscription-plan agents
 // (claude, codex) stall at a dead prompt with a parseable reset window, so
-// only they get a matcher here. gemini/aider are API-key-metered — a "limit"
-// there is a transient 429 the CLI already retries, with no plan-reset
-// timestamp to schedule against — so isLimitContent returns hit=false for
-// them in v1. The matcher map is structured so a surface-only entry for them
-// (detect set, parseReset nil) drops in later without touching the core.
+// only they get a matcher here. Other agents are API-key-metered or have no
+// known plan-reset banner — a "limit" there is a transient CLI/API failure
+// with no reset timestamp to schedule against — so isLimitContent returns
+// hit=false for them in v1. The matcher map is structured so a surface-only
+// entry for them (detect set, parseReset nil) drops in later without touching
+// the core.
 
 // agentLimitMatcher is the per-agent recipe for recognizing a usage-limit
 // banner and, when present, extracting its reset time.
@@ -78,8 +79,8 @@ func builtinLimitMatchers() map[string]agentLimitMatcher {
 // built-in matchers: for each entry in overrides (agent name -> regexp
 // string), it replaces that agent's detect pattern while keeping the built-in
 // reset-time parser. An override for an agent with no built-in matcher
-// (gemini/aider in v1) is ignored — there is no reset parser to pair it with
-// yet, and detection-only surfacing lands in a later PR. An uncompilable
+// is ignored — there is no reset parser to pair it with yet, and
+// detection-only surfacing lands in a later PR. An uncompilable
 // pattern is logged and skipped so the built-in default stands; validateConfig
 // already drops such entries, so this is defense in depth for hand-built
 // configs and non-config callers.
@@ -148,7 +149,7 @@ func (d LimitDetector) Check(content, agent string, now time.Time) (hit bool, re
 //
 // Return contract:
 //   - hit=false: no banner for this agent (or an agent with no matcher, e.g.
-//     gemini/aider in v1). resetAt/hasResetTime are zero.
+//     any non-claude/codex agent in v1). resetAt/hasResetTime are zero.
 //   - hit=true, hasResetTime=true: banner detected and a reset time parsed;
 //     resetAt is that time in UTC.
 //   - hit=true, hasResetTime=false: banner detected but the reset time was

--- a/task/limit_test.go
+++ b/task/limit_test.go
@@ -225,12 +225,19 @@ func TestResolveLimitMatchers(t *testing.T) {
 	if _, ok := base[tmux.ProgramAider]; ok {
 		t.Fatalf("aider should have no matcher in v1")
 	}
+	if _, ok := base[tmux.ProgramAmp]; ok {
+		t.Fatalf("amp should have no matcher in v1")
+	}
 
 	// An override for an agent with no built-in matcher is ignored (there is
 	// no reset parser to pair a detection-only override with yet).
 	withGemini := resolveLimitMatchers(map[string]string{tmux.ProgramGemini: `whatever`})
 	if _, ok := withGemini[tmux.ProgramGemini]; ok {
 		t.Fatalf("override for unmatched agent should be ignored")
+	}
+	withAmp := resolveLimitMatchers(map[string]string{tmux.ProgramAmp: `whatever`})
+	if _, ok := withAmp[tmux.ProgramAmp]; ok {
+		t.Fatalf("override for amp should be ignored until amp has a built-in matcher")
 	}
 
 	// An uncompilable regex is dropped and the built-in default stands: the

--- a/task/runner.go
+++ b/task/runner.go
@@ -3,6 +3,7 @@ package task
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 var (
 	waitForReadyTimeout      = 60 * time.Second
 	waitForReadyPollInterval = 500 * time.Millisecond
+	ampPromptFrameTop        = regexp.MustCompile(`(?m)^\s*╭[─ ]+(low|medium|high|deep)[─ ]+╮\s*\n\s*│`)
 )
 
 // LimitReachedError is what WaitForReady returns when the agent shows a
@@ -99,6 +101,13 @@ func isReadyContent(content, agent string) bool {
 		// TODO(#714): replace with a confirmed gemini-specific ready string.
 		return strings.Contains(content, "╰") ||
 			isDocTrustPrompt(content)
+	case tmux.ProgramAmp:
+		// Amp is ready when its input-prompt frame is visible. A bare
+		// box-drawing character is too broad: loading frames, banners, and
+		// stale scrollback can all contain the same glyphs before the prompt is
+		// accepting input.
+		return isAmpPromptFrame(content) ||
+			isDocTrustPrompt(content)
 	case tmux.ProgramClaude:
 		if strings.Contains(content, "❯") ||
 			strings.Contains(content, "Do you trust") ||
@@ -111,6 +120,10 @@ func isReadyContent(content, agent string) bool {
 		// the pane rendered any non-blank output.
 		return strings.TrimSpace(content) != ""
 	}
+}
+
+func isAmpPromptFrame(content string) bool {
+	return ampPromptFrameTop.MatchString(content)
 }
 
 // isDocTrustPrompt reports whether content shows the documentation-link trust

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -112,6 +112,15 @@ func TestIsReadyContent(t *testing.T) {
 		},
 		{"gemini not ready", "gemini", "starting gemini-cli…", false},
 
+		// amp
+		{"amp welcome before prompt", "amp", "Welcome to Amp\nctrl+o for commands", false},
+		{"amp input box", "amp", "╭──────── medium ────────╮\n│  \n╰──────── /tmp/repo ─────╯", true},
+		{"amp high-mode input box", "amp", "╭──────── high ────────╮\n│ > \n╰──────── /tmp/repo ─────╯", true},
+		{"amp box without prompt anchor", "amp", "╭ downloading tools ╮\n╰ please wait ─────╯", false},
+		{"amp prompt top without input line", "amp", "╭──────── medium ────────╮\nloading plugins", false},
+		{"amp doc trust prompt", "amp", "Open documentation url for more info.\n(D)on't ask again", true},
+		{"amp not ready on arbitrary output", "amp", "loading settings", false},
+
 		// shared doc-trust guard: both substrings required.
 		{"only open documentation url without confirm", "claude", "See Open documentation url for details.", false},
 		{"only dont ask again without doc url", "aider", "Some prompt asking (D)on't ask again", false},
@@ -469,9 +478,9 @@ func TestWaitForReadyParksOnUsageLimit(t *testing.T) {
 }
 
 // TestWaitForReadyDoesNotParkNonLimitAgent guards the scope boundary (#1146): a
-// gemini/aider pane has no usage-limit matcher, so even a limit-looking banner
-// must NOT park — WaitForReady keeps polling and times out as before. gemini's
-// readiness glyph never appears here, so it hits the (shortened) timeout.
+// A non-limit-matched agent pane must not park on a limit-looking banner —
+// WaitForReady keeps polling and times out as before. gemini's readiness glyph
+// never appears here, so it hits the (shortened) timeout.
 func TestWaitForReadyDoesNotParkNonLimitAgent(t *testing.T) {
 	defer setWaitForReadyTimingForTest(200*time.Millisecond, time.Millisecond)()
 	defer setWaitLimitForTest(NewLimitDetector(nil), time.Now)()

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -305,12 +305,12 @@ func TestUpdateTaskPersistsProgram(t *testing.T) {
 	setupTestTasks(t, tasks)
 
 	updated := tasks[0]
-	updated.Program = "aider"
+	updated.Program = "amp"
 	require.NoError(t, UpdateTask(updated))
 
 	got, err := GetTask("p1")
 	require.NoError(t, err)
-	assert.Equal(t, "aider", got.Program)
+	assert.Equal(t, "amp", got.Program)
 }
 
 // TestValidateTaskID_PathTraversalRejected covers the CLI path-traversal

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -323,7 +323,7 @@ func TestTaskPaneEditModePresetFromExistingProgram(t *testing.T) {
 		Prompt:      "do it",
 		CronExpr:    "* * * * *",
 		ProjectPath: newGitRepo(t),
-		Program:     "aider",
+		Program:     "amp",
 		Enabled:     true,
 	}})
 	tp.SetFocus(true)
@@ -337,7 +337,7 @@ func TestTaskPaneEditModePresetFromExistingProgram(t *testing.T) {
 	assert.False(t, tp.IsEditing(), "save should exit edit mode")
 	tasks := tp.GetTasks()
 	if assert.Len(t, tasks, 1) {
-		assert.Equal(t, "aider", tasks[0].Program,
+		assert.Equal(t, "amp", tasks[0].Program,
 			"pre-selected canonical option must round-trip the original value")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds Sourcegraph Amp (`amp`) as a supported Agent Factory program across config validation, CLI/API help, task selectors, docs, preflight, and doctor agent-binary checks.
- Wires Amp runtime behavior: plain launches use `amp`, latest-session restore uses `amp threads continue --last`, conversation-ID restore uses `amp threads continue <id>`, and explicit Amp subcommands such as `amp review` are left unchanged.
- Adds coverage for Amp in config, API/tasks, readiness, trust dispatch, resume rewriting, system-prompt injection, command detection, doctor, and UI task selection tests.

## Revert Finding
- PR #493 only added `ProgramAmp` to `tmux.SupportedPrograms` so Amp appeared in task program selectors; its PR body explicitly left Amp runtime behavior out of scope.
- `gh pr view 494` does not resolve because #494 is an issue, not a PR. Issue #494 requested removing `ProgramAmp` because it should not exist anymore. The actual revert was PR #497, which dropped `ProgramAmp` from `SupportedPrograms` and added a fallback test for bare `amp`.
- I did not find a runtime bug cited for the revert; the problem was that Amp had been added as a surface-only supported program. This PR avoids that by auditing the same registration sites as claude/codex/aider/gemini and wiring support end to end, including resume behavior and doctor/config/docs/tests.

## Amp CLI Check
- Checked the installed Amp CLI with `amp --version` and `amp --help` (`/home/siyer/.amp/bin/amp`, version `0.0.1783660582-g392d1a`, released 2026-07-10T05:16:22.000Z). The installed CLI is an ELF binary, so the local help output is the available source of truth here.
- Current value-taking global options from help are covered: `--visibility`, `--settings-file`, `--log-level`, `--log-file`, `--mcp-config`, `-m`/`--mode`, `--effort`, and `-l`/`--label`; `--plugin-ready-timeout [seconds]` is handled as an optional-value global.
- `-x`/`--execute [message]` is also an optional-value global, but execute mode is intentionally treated as not resumable because it is not an interactive restore path.
- The remaining unknown-flag fallback has a documented accepted limitation: a future unknown value-taking flag whose value is itself an Amp subcommand name is ambiguous until Amp ships that flag and af adds it to the known value-taking list.

## Verification
- `golangci-lint run --timeout=3m --fast`
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `scripts/lint-file-length.sh`
- `git diff --check`

Closes #1521
