### PR TITLE
tui: auto-collapse archived section when nav returns to live instances

### DIFF
--- a/ui/sidebar_archived_test.go
+++ b/ui/sidebar_archived_test.go
@@ -205,6 +205,41 @@ func TestSidebar_NavCrossesBetweenLiveTabsAndArchivedRows(t *testing.T) {
 	require.True(t, sel.IsTab)
 	require.Equal(t, 1, sel.TabIndex)
 	require.Same(t, liveInst, s.GetSelectedInstance())
+	require.False(t, archivedRowVisible(s),
+		"Up back into the live instances must auto-collapse the Archived section (#1518 symmetry)")
+}
+
+// TestSidebar_NavUpFromArchivedAutoCollapses is the focused mirror of the #1518
+// auto-open: Down at the live tail auto-expands the Archived folder, and Up back
+// into the live instances auto-collapses it again.
+func TestSidebar_NavUpFromArchivedAutoCollapses(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+
+	liveInst := archTestInstance(t, "live-one", session.Ready)
+	addAgentShellTabs(liveInst)
+	archivedInst := archTestInstance(t, "put-away", session.Archived)
+	addTestInstance(s, liveInst)
+	addTestInstance(s, archivedInst)
+	s.SetSize(40, 40)
+
+	require.False(t, archivedRowVisible(s), "Archived starts collapsed")
+	s.SetSelectedInstance(0)
+
+	// Nav down to the tail auto-expands Archived and lands on the archived row.
+	s.Down() // live Agent tab
+	s.Down() // live Terminal tab, the last live tab stop
+	s.Down()
+	require.Equal(t, SectionArchived, s.GetSelection().Kind, "Down at the tail enters Archived")
+	require.True(t, archivedRowVisible(s), "Down at the live boundary auto-expands Archived")
+
+	// Nav back up into the live instances auto-collapses Archived again.
+	s.Up()
+	sel := s.GetSelection()
+	require.Equal(t, SectionInstances, sel.Kind, "Up returns to the live instances")
+	require.True(t, sel.IsTab)
+	require.Same(t, liveInst, s.GetSelectedInstance())
+	require.False(t, archivedRowVisible(s), "Up back into live must auto-collapse Archived")
 }
 
 func TestSidebar_NavSkipsNonExpandableLiveRowsBeforeArchived(t *testing.T) {

--- a/ui/sidebar_nav.go
+++ b/ui/sidebar_nav.go
@@ -426,7 +426,14 @@ func (s *Sidebar) tryMoveVerticalNavStop(dir int) bool {
 }
 
 func (s *Sidebar) moveVerticalNavStop(dir int) {
+	before := s.rawSelection()
 	if s.tryMoveVerticalNavStop(dir) {
+		// Symmetric to the auto-open at the live tail (#1518): when Up carries the
+		// cursor out of an archived row back into the live instances, fold the
+		// Archived section again so it collapses as the user leaves it.
+		if dir < 0 && before.Kind == SectionArchived && s.rawSelection().Kind == SectionInstances {
+			s.collapseArchivedSectionForNav()
+		}
 		return
 	}
 	// Archived rows are selectable stops only after the Archived section renders
@@ -439,6 +446,25 @@ func (s *Sidebar) moveVerticalNavStop(dir int) {
 
 func (s *Sidebar) downNavCanRevealArchived() bool {
 	return s.rawSelection().Kind == SectionInstances
+}
+
+// collapseArchivedSectionForNav folds the Archived section back up — the mirror
+// of expandArchivedSectionForNav — after Up navigation carries the cursor out of
+// an archived row and back into the live instances (#1518 symmetry). The cursor
+// already rests on the live tab stop; rebuildPreservingCursor keeps it pinned
+// there as the trailing archived rows disappear.
+func (s *Sidebar) collapseArchivedSectionForNav() {
+	for i, sec := range s.sections {
+		if sec.Kind != SectionArchived {
+			continue
+		}
+		if !sec.Expanded {
+			return
+		}
+		s.sections[i].Expanded = false
+		s.rebuildPreservingCursor()
+		return
+	}
 }
 
 func (s *Sidebar) expandArchivedSectionForNav() bool {


### PR DESCRIPTION
## Summary

Symmetric follow-up to **#1518** ("auto-open archived section at nav tail", merged as 4b725c0 / #1520). That change auto-**expands** the collapsed Archived section when `Down` crosses past the live tab-stop tail. This is the mirror: when `Up` carries the cursor **out of** an archived row back into the live instances, the Archived section auto-**collapses** again — so it folds away as the user leaves it, exactly as it opened when they entered.

Requested by Sachin: "Auto collapse the archived sessions once I move back to the list of regular instances."

## Change

- `moveVerticalNavStop` captures the pre-move selection; after a successful upward move that crosses `SectionArchived → SectionInstances`, it calls the new `collapseArchivedSectionForNav`.
- `collapseArchivedSectionForNav` mirrors `expandArchivedSectionForNav`: it folds the Archived section and `rebuildPreservingCursor` keeps the cursor pinned on the live tab stop as the trailing archived rows disappear.
- Trigger is the boundary crossing (leaving archived back up into live), symmetric with the auto-expand trigger — no new state, no effect while browsing within the archived rows.
- #1518 auto-expand behavior is preserved (its regression tests still pass unchanged).

Localized to `ui/sidebar_nav.go` + its test.

## Tests

- Extended `TestSidebar_NavCrossesBetweenLiveTabsAndArchivedRows` to assert the Archived section collapses after `Up` returns to live.
- Added `TestSidebar_NavUpFromArchivedAutoCollapses` — focused down-to-tail-expands → up-into-live-collapses mirror.
- `gofmt -l .` (clean), `go build ./...`, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` (clean), `scripts/lint-file-length.sh`, `make test-container` (all packages green).

Closes the symmetry gap left by #1518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)