### PR TITLE
fix(bugreport): redact TmuxName fields to stop leaking session titles (#1533)

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -117,17 +117,19 @@ func TestScrubRedactsPEMPrivateKey(t *testing.T) {
 
 func TestRedactInstanceDataKeepsStructuralDropsFreeText(t *testing.T) {
 	d := session.InstanceData{
-		ID:      "abc123",
-		Title:   "proprietary session name",
-		Prompt:  "confidential task instructions with internal codename Bluebird",
-		Path:    "/home/alice/Desktop/proj",
-		Branch:  "alice/fix",
-		Status:  session.Status(1),
-		Program: "claude",
+		ID:       "abc123",
+		Title:    "proprietary session name",
+		Prompt:   "confidential task instructions with internal codename Bluebird",
+		Path:     "/home/alice/Desktop/proj",
+		Branch:   "alice/fix",
+		Status:   session.Status(1),
+		Program:  "claude",
+		TmuxName: "af_proprietarysessionname",
 		Tabs: []session.TabData{
 			{
-				Name:    "agent",
-				Command: "claude --token sk-SUPERSECRETTOKEN0123456",
+				Name:     "agent",
+				Command:  "claude --token sk-SUPERSECRETTOKEN0123456",
+				TmuxName: "af_proprietarysessionname",
 				Conversation: &session.AgentConversationData{
 					Agent: "claude",
 					ID:    "019f386f-7206-7fc2-803b-f7045e07a242",
@@ -158,6 +160,14 @@ func TestRedactInstanceDataKeepsStructuralDropsFreeText(t *testing.T) {
 	}
 	if d.Tabs[0].Command != redactedMarker {
 		t.Errorf("tab command not redacted: %q", d.Tabs[0].Command)
+	}
+	// TmuxName is derived from the session title, so it leaks the same
+	// confidential name and must be redacted at both the instance and tab level.
+	if d.TmuxName != redactedMarker {
+		t.Errorf("instance tmux name not redacted: %q", d.TmuxName)
+	}
+	if d.Tabs[0].TmuxName != redactedMarker {
+		t.Errorf("tab tmux name not redacted: %q", d.Tabs[0].TmuxName)
 	}
 	if d.Tabs[0].Conversation.ID != "" || d.AgentConversation.ID != "" {
 		t.Errorf("conversation ids not redacted: tab=%q instance=%q", d.Tabs[0].Conversation.ID, d.AgentConversation.ID)

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -233,9 +233,17 @@ func redactInstanceData(d *session.InstanceData) {
 	if d.Worktree.SessionName != "" {
 		d.Worktree.SessionName = redactedMarker
 	}
+	// TmuxName is derived from the session title (e.g. "af_ConfidentialDeal"),
+	// so it leaks the same free-text name Title carries and must be redacted too.
+	if d.TmuxName != "" {
+		d.TmuxName = redactedMarker
+	}
 	for i := range d.Tabs {
 		if d.Tabs[i].Command != "" {
 			d.Tabs[i].Command = redactedMarker
+		}
+		if d.Tabs[i].TmuxName != "" {
+			d.Tabs[i].TmuxName = redactedMarker
 		}
 		if d.Tabs[i].Conversation != nil {
 			d.Tabs[i].Conversation.ID = ""


### PR DESCRIPTION
## Summary

Bug-report bundles leaked confidential session/project names through the `TmuxName` fields.

`redactInstanceData` (`bugreport/redact.go`) blanks `Title`, `Prompt`, `Worktree.SessionName`, per-tab `Command`, and `PRInfo.Title/URL` — but it did **not** redact `InstanceData.TmuxName` or each `TabData.TmuxName`. `TmuxName` is derived directly from the session title (e.g. `af_ConfidentialAcmeMergerDeal`), so a public bug bundle still leaked the exact confidential name the other redactions were meant to strip.

## Fix

- Redact `InstanceData.TmuxName` to the redacted marker when non-empty.
- Redact each `TabData[].TmuxName` in the same loop that redacts tab commands.
- Extend `TestRedactInstanceDataKeepsStructuralDropsFreeText` to assert both the instance-level and per-tab `TmuxName` are blanked.

## Test plan

- [x] `go test ./bugreport/`
- [x] `gofmt -l bugreport/` clean
- [x] `go build ./...`

Fixes #1533

🤖 Generated with [Claude Code](https://claude.com/claude-code)