### PR TITLE
fix(tmux): delete named paste buffer when paste-buffer fails (#1536)

### DIFF
--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync/atomic"
@@ -17,6 +18,25 @@ import (
 // path releases the instance lock before these tmux calls, so it must not
 // assume serialization.
 var pasteBufferSeq atomic.Uint64
+
+// pasteBufferProcessToken uniquely identifies THIS process within a tmux server.
+// tmux buffers are server-scoped, and the seq counter above is process-local, so
+// two af processes sharing a server and a session name would otherwise mint the
+// SAME buffer name — letting one process's load-buffer clobber the other's
+// pending buffer, or (with the #1536 failure cleanup) one process's delete-buffer
+// remove the other's buffer and lose its prompt. The PID is unique among
+// concurrently-live processes, which is exactly the collision window, so keying
+// the name on it makes cross-process collision impossible. Resolved once at
+// startup.
+var pasteBufferProcessToken = fmt.Sprintf("%d", os.Getpid())
+
+// pasteBufferName builds the per-call unique tmux paste-buffer name. It is keyed
+// on the process token (cross-process uniqueness on a shared, server-scoped tmux
+// buffer namespace), the sanitized session name, and a process-local sequence
+// (intra-process uniqueness across concurrent deliveries to the same session).
+func pasteBufferName(processToken, sanitizedName string, seq uint64) string {
+	return fmt.Sprintf("af_paste_%s_%s_%d", processToken, sanitizedName, seq)
+}
 
 // SendKeysCommand sends text to the tmux pane using tmux commands instead of
 // writing to the PTY. This is more reliable for headless/scheduled runs where
@@ -43,9 +63,11 @@ func (t *TmuxSession) SendKeysCommand(text string) error {
 func (t *TmuxSession) sendKeysPasteBuffer(text string, bracketed bool) error {
 	// A per-call unique buffer name: two concurrent deliveries to the same
 	// session must not share a buffer, or one call's load-buffer could overwrite
-	// the other's content between its load and paste and corrupt the submit.
-	// `-d` clears the buffer after pasting so buffers never accumulate.
-	buf := fmt.Sprintf("af_paste_%s_%d", t.sanitizedName, pasteBufferSeq.Add(1))
+	// the other's content between its load and paste and corrupt the submit. The
+	// process token additionally keeps two af processes on a shared tmux server
+	// from colliding on the same server-scoped buffer name. `-d` clears the buffer
+	// after pasting so buffers never accumulate.
+	buf := pasteBufferName(pasteBufferProcessToken, t.sanitizedName, pasteBufferSeq.Add(1))
 
 	loadCmd := exec.Command("tmux", "load-buffer", "-b", buf, "-")
 	loadCmd.Stdin = strings.NewReader(text)

--- a/session/tmux/submit.go
+++ b/session/tmux/submit.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
 )
 
 // pasteBufferSeq makes each bracketed-paste buffer name unique per call so two
@@ -67,6 +69,14 @@ func (t *TmuxSession) sendKeysPasteBuffer(text string, bracketed bool) error {
 	args = append(args, "-b", buf, "-t", exactTarget(t.sanitizedName))
 	pasteCmd := exec.Command("tmux", args...)
 	if err := t.cmdExec.Run(pasteCmd); err != nil {
+		// `-d` only deletes the buffer once the paste succeeds; a failed paste
+		// would otherwise strand the named buffer, and tmux buffers are
+		// server-scoped (they outlive the session), so each failed submit would
+		// leak one buffer unbounded. Best-effort delete it before returning.
+		delCmd := exec.Command("tmux", "delete-buffer", "-b", buf)
+		if derr := t.cmdExec.Run(delCmd); derr != nil {
+			log.ErrorLog.Printf("failed to delete paste buffer %q after paste error: %v", buf, derr)
+		}
 		return fmt.Errorf("error pasting buffer: %w", err)
 	}
 

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -249,6 +249,42 @@ func TestBashWrappedSubmitDoesNotDuplicateCommandPrefix(t *testing.T) {
 		"wrapped command prefix must be captured once, not duplicated:\n%s", content)
 }
 
+// TestSubmitDeletesBufferWhenPasteFails guards the #1536 leak: `paste-buffer -d`
+// only deletes the named buffer once the paste SUCCEEDS, so a failed paste
+// strands it. tmux buffers are server-scoped (they outlive the session), so each
+// failed submit would leak one buffer unbounded. When paste-buffer errors the
+// submit path must best-effort `delete-buffer` the same buffer before returning.
+func TestSubmitDeletesBufferWhenPasteFails(t *testing.T) {
+	var loadBuf, deletedBuf string
+	var pasteErr = fmt.Errorf("boom: no client")
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(c *exec.Cmd) error {
+			joined := strings.Join(c.Args, " ")
+			switch {
+			case strings.Contains(joined, "load-buffer"):
+				loadBuf = bufferOf(c.Args)
+				return nil
+			case strings.Contains(joined, "paste-buffer"):
+				return pasteErr
+			case strings.Contains(joined, "delete-buffer"):
+				deletedBuf = bufferOf(c.Args)
+				return nil
+			}
+			return nil
+		},
+		OutputFunc: func(c *exec.Cmd) ([]byte, error) { return []byte("content"), nil },
+	}
+
+	session := newTmuxSession("af_proj", "claude", NewMockPtyFactory(t), cmdExec)
+	err := session.SendKeysCommand("a prompt that fails to paste")
+	require.Error(t, err, "a failed paste-buffer must surface as an error")
+	require.ErrorIs(t, err, pasteErr, "the paste error must be wrapped and returned")
+
+	require.NotEmpty(t, loadBuf, "load-buffer must have named a buffer")
+	require.Equal(t, loadBuf, deletedBuf,
+		"a failed paste must delete-buffer the same buffer it loaded, not leak it (#1536)")
+}
+
 func captureRawPane(session *TmuxSession) (string, error) {
 	cmd := exec.Command("tmux", "capture-pane", "-p", "-t", exactTarget(session.sanitizedName))
 	out, err := session.cmdExec.Output(cmd)

--- a/session/tmux/submit_test.go
+++ b/session/tmux/submit_test.go
@@ -285,6 +285,33 @@ func TestSubmitDeletesBufferWhenPasteFails(t *testing.T) {
 		"a failed paste must delete-buffer the same buffer it loaded, not leak it (#1536)")
 }
 
+// TestPasteBufferNameProcessTokenPreventsCrossProcessCollision is the #1536
+// Greptile guard: tmux buffers are server-scoped and the seq counter is
+// process-local, so two af processes sharing a tmux server and a session name
+// must NOT mint the same buffer name. If they did, one process's load-buffer
+// would clobber — or its failure-cleanup delete-buffer would remove — the other's
+// pending buffer and lose its prompt. The per-process token makes that
+// impossible while the seq still keeps one process's concurrent deliveries apart.
+func TestPasteBufferNameProcessTokenPreventsCrossProcessCollision(t *testing.T) {
+	const session = "af_proj"
+
+	// Same session + same seq, two different process tokens → distinct names.
+	a := pasteBufferName("1234", session, 1)
+	b := pasteBufferName("5678", session, 1)
+	require.NotEqual(t, a, b,
+		"different process tokens must not collide on the same session/seq (#1536)")
+	require.Contains(t, a, "1234", "the buffer name must carry the process token")
+	require.Contains(t, b, "5678", "the buffer name must carry the process token")
+
+	// Within one process, the seq still keeps concurrent same-session deliveries
+	// distinct.
+	require.NotEqual(t, pasteBufferName("1234", session, 1), pasteBufferName("1234", session, 2),
+		"the process-local seq must still disambiguate concurrent deliveries")
+
+	// The live process token is non-empty, so real submits are always namespaced.
+	require.NotEmpty(t, pasteBufferProcessToken, "the process token must be resolved at startup")
+}
+
 func captureRawPane(session *TmuxSession) (string, error) {
 	cmd := exec.Command("tmux", "capture-pane", "-p", "-t", exactTarget(session.sanitizedName))
 	out, err := session.cmdExec.Output(cmd)


### PR DESCRIPTION
## Summary

A failed prompt submission leaked a named tmux paste buffer server-wide.

`sendKeysPasteBuffer` (`session/tmux/submit.go`) loads text into a per-call named buffer, then pastes it with `paste-buffer -d`. The `-d` deletes the buffer only **after** a successful paste — if `paste-buffer` fails (e.g. the target pane/client has gone away), the named buffer is never deleted. tmux buffers are **server-scoped** and survive session destruction, so every failed submit stranded one buffer, leaking them unbounded.

## Fix

On a `paste-buffer` error, best-effort `delete-buffer -b <buf>` (its own error is logged, not surfaced) before returning the paste error. A failed submit can no longer strand a buffer.

## Test plan

- [x] New `TestSubmitDeletesBufferWhenPasteFails`: mock `cmdExec` fails the paste → asserts `delete-buffer` is invoked on the same buffer that was loaded, and the paste error is still returned/wrapped.
- [x] `go test ./session/tmux/`
- [x] `gofmt -l` clean, `go build ./...`

Fixes #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)