### PR TITLE
fix(daemon): persist instance after failed Recover() in lost-restore loop (#1532)

### DIFF
--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -160,6 +160,15 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 	}
 
 	if err := inst.Recover(); err != nil {
+		// Persist the instance even on failure, matching the manual restore path
+		// (restore.go): Recover can mutate durable worktree state before it fails
+		// — a rebuild reconstructs the worktree+branch and flips branchCreatedByUs
+		// true, then a later tmux spawn fails (#1532). Without this write the flag
+		// is lost, so after a daemon restart the instance reloads with a stale
+		// branchCreatedByUs=false; the next recovery skips the rebuild (the worktree
+		// now exists) and the flag stays wrong, so kill never deletes the branch and
+		// it is orphaned. persistInstance is best-effort (logs on write failure).
+		m.persistInstance(repoID, inst)
 		m.logVanishedWorktreeOnce(key, repoID, st, inst, err)
 		m.lostRestoreFailed(key, st, inst.Title, err)
 		return

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -185,6 +185,54 @@ func TestRestoreLostSessions_BacksOffBetweenFailures(t *testing.T) {
 	}
 }
 
+// TestRestoreLostSessions_PersistsAfterFailedRecover is the regression for
+// #1532: when Recover fails after partial success (worktree+branch rebuilt,
+// branchCreatedByUs flipped true, then the tmux spawn fails), the loop must
+// persist the instance so that durable state survives a daemon restart —
+// mirroring the manual restore path. Before the fix the failure branch returned
+// without persisting, so a rebuilt-but-not-persisted branchCreatedByUs was lost
+// and the branch was later orphaned on kill.
+func TestRestoreLostSessions_PersistsAfterFailedRecover(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	zeroRestoreBackoff(t)
+
+	// A real registered worktree whose in-memory record already carries the
+	// rebuild's branchCreatedByUs=true (the state Recover leaves behind before its
+	// tmux spawn fails). The seeded disk record (seedDiskInstance) has no worktree
+	// data, so it loads branchCreatedByUs=false — the stale value the bug leaves.
+	wtPath := filepath.Join(filepath.Dir(repoPath), "repo-1532")
+	branch := "af/persist-1532"
+	if out, err := exec.Command("git", "-C", repoPath, "worktree", "add", "-b", branch, wtPath).CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	gw, err := sessiongit.NewGitWorktreeFromStorage(repoPath, wtPath, "persist-1532", branch, "", false, true)
+	if err != nil {
+		t.Fatalf("NewGitWorktreeFromStorage: %v", err)
+	}
+
+	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend(), failWith: errors.New("tmux spawn failed after rebuild")}
+	inst := registerStarted(t, manager, repoID, repoPath, "persist-1532", backend, true, session.Lost)
+	inst.SetGitWorktreeForTest(gw)
+
+	manager.RestoreLostSessions()
+
+	if got := backend.recoverCalls(); got != 1 {
+		t.Fatalf("recover calls = %d, want 1", got)
+	}
+	// The failed-recover branch must have persisted the in-memory instance: the
+	// on-disk record now reflects its Lost status and its rebuilt worktree state.
+	rec := recordFor(t, repoID, "persist-1532")
+	if rec == nil {
+		t.Fatal("record must still exist after a failed recover")
+	}
+	if rec.Status != session.Lost {
+		t.Fatalf("persisted status = %v, want Lost (a failed recover must persist the instance)", rec.Status)
+	}
+	if rec.Worktree.BranchCreatedByUs == nil || !*rec.Worktree.BranchCreatedByUs {
+		t.Fatalf("persisted branchCreatedByUs = %v, want true (the rebuild's flag must survive a failed recover)", rec.Worktree.BranchCreatedByUs)
+	}
+}
+
 type failPtyFactory struct{}
 
 func (failPtyFactory) Start(*exec.Cmd) (*os.File, error) {


### PR DESCRIPTION
## Problem

The daemon's automatic Lost-restore loop (`daemon/lostrestore.go`) returned **without persisting the instance** when `inst.Recover()` failed after partial success.

`Recover()` can rebuild the worktree + branch and flip `branchCreatedByUs=true`, then fail later on the tmux spawn. Because the failure branch never persisted, that flag was lost:

1. Rebuild reconstructs the worktree/branch, sets `branchCreatedByUs=true` in memory.
2. tmux spawn fails → `Recover()` returns an error → loop returns **without persisting**.
3. Daemon restarts → instance reloads from disk with stale `branchCreatedByUs=false`.
4. Next recovery skips the rebuild (the worktree now exists on disk), so the flag stays wrong.
5. On kill, the branch is not deleted → **orphaned branch**.

The **manual** restore path (`daemon/restore.go`) already persists on **both** success and failure — the automatic loop was the outlier.

## Fix

Call `m.persistInstance(repoID, inst)` in the failed-`Recover()` branch of `restoreLostSession`, before returning — matching `restore.go`. `persistInstance` is best-effort (logs on write failure), so this cannot regress the retry/backoff behaviour.

## Test

`TestRestoreLostSessions_PersistsAfterFailedRecover`: a Lost instance carrying a rebuilt `branchCreatedByUs=true` whose `Recover()` fails on tmux spawn. Asserts the on-disk record is rewritten (status `Lost`) and `branchCreatedByUs=true` survives — reproducing the orphan condition and proving the persist.

## Gates
- `gofmt -l .` clean · `go build ./...` · `golangci-lint --fast` · `deadcode -test ./...` · file-length lint — all green
- `make test-container GOTESTARGS="-run TestRestoreLostSessions ./daemon/"` — green

Fixes #1532

🤖 Generated with [Claude Code](https://claude.com/claude-code)