### PR TITLE
fix(daemon): make archive durable so persist failure can't orphan sessions (#1538)

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -89,6 +89,9 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// The pre-archive worktree location, captured before the move, so a persist
+	// failure after the commit can roll the worktree back home (#1538).
+	origPath := instance.GetWorktreePath()
 
 	// Raise the archive fence through the chokepoint (#1195 Phase 2d): BeginArchive
 	// sets OpArchiving (I4) so the status poll skips this instance (and the
@@ -119,13 +122,56 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	}
 
 	// Success: worktree relocated, tmux down. Commit the inert Archived state
-	// (started=false, op cleared) — reachable only from the fence (I2) — and
-	// persist the new path + status.
+	// (started=false, op cleared) — reachable only from the fence (I2) — then
+	// persist the new path + status DURABLY.
+	//
+	// Unlike the best-effort status poll, a swallowed persist failure here is
+	// unsafe (#1538): the on-disk record would still point at the pre-archive
+	// worktree with started=true, so after a daemon restart the Lost-restore loop
+	// would try to rebuild the worktree at the old path and hit "branch already
+	// checked out at <archivedPath>", orphaning the archive — the user can no
+	// longer reach it via af. So on a persist failure, undo the physical archive:
+	// move the worktree back home and drop the session to Lost, leaving the
+	// on-disk record and reality consistent again and letting the #1108 loop heal
+	// it in place. (The tiny window between the move and this persist completing —
+	// a crash there — is inherent without a write-ahead journal; the reproducible
+	// persist-error cause this issue reports is fully closed.)
 	_ = instance.Transition(session.CommitArchive())
 	archivedPath := instance.GetWorktreePath()
-	m.persistInstance(repoID, instance)
+	if perr := archivePersist(m, repoID, instance); perr != nil {
+		log.ErrorLog.Printf("archive of session %q: failed to durably record the Archived state (%v); rolling back to keep the on-disk record consistent", req.Title, perr)
+		if rbErr := m.undoCommittedArchive(repoID, instance, origPath); rbErr != nil {
+			// Could not move the worktree home: the committed archive is the
+			// safest remaining state. Persist it best-effort and surface both
+			// failures so the operator can recover it manually.
+			m.persistInstance(repoID, instance)
+			return "", fmt.Errorf("archived session %q to %s but failed to record it durably (%v) and could not roll it back (%v); it may need manual recovery", req.Title, archivedPath, perr, rbErr)
+		}
+		return "", fmt.Errorf("failed to durably archive session %q; rolled it back and left it Lost to be restored in place: %w", req.Title, perr)
+	}
 	log.InfoLog.Printf("archived session %q (repo %s): tmux torn down, worktree moved to %s", req.Title, repoID, archivedPath)
 	return archivedPath, nil
+}
+
+// undoCommittedArchive rolls a committed-but-unpersisted archive back to a
+// self-healing live state (#1538). It moves the worktree back to its pre-archive
+// location (origPath) and returns the instance to a plain Lost with started=true,
+// via the only legal edge path out of the committed Archived state: BeginRestore
+// (Archived -> Lost + OpRestoring, started=true) then AbortRestoreToLost (op
+// cleared). With the worktree home and the record dropped to Lost, the on-disk
+// record — still the pre-archive one, since the archive persist failed — matches
+// reality, so a daemon restart re-spawns at the right path and the #1108 restore
+// loop heals the agent in place. The rolled-back state is persisted best-effort;
+// even if that write also fails, the worktree being home already keeps disk and
+// reality consistent. Returns an error only when the move home itself fails.
+func (m *Manager) undoCommittedArchive(repoID string, instance *session.Instance, origPath string) error {
+	if err := instance.RestoreArchivedWorktree(origPath); err != nil {
+		return err
+	}
+	_ = instance.Transition(session.BeginRestore())
+	_ = instance.Transition(session.AbortRestoreToLost())
+	m.persistInstance(repoID, instance)
+	return nil
 }
 
 // RestoreArchived restores an archived session (#1028): it moves the worktree
@@ -243,18 +289,32 @@ func (m *Manager) archiveExclusiveTabLock(key string, instance *session.Instance
 	return opLock, nil
 }
 
-// persistInstance writes one instance's authoritative data through the targeted
-// per-repo writer under the repo start lock, mirroring refreshInstanceStatus's
-// persist. Best-effort: a failed write only logs.
-func (m *Manager) persistInstance(repoID string, instance *session.Instance) {
+// persistInstanceErr writes one instance's authoritative data through the
+// targeted per-repo writer under the repo start lock, mirroring
+// refreshInstanceStatus's persist, and returns any write error. persistInstance
+// wraps it for the best-effort callers; the archive commit uses this variant to
+// make the persist durable (#1538).
+func (m *Manager) persistInstanceErr(repoID string, instance *session.Instance) error {
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
-	err := persistInstanceData(repoID, instance.ToInstanceData())
-	repoStartLock.Unlock()
-	if err != nil {
+	defer repoStartLock.Unlock()
+	return persistInstanceData(repoID, instance.ToInstanceData())
+}
+
+// persistInstance is the best-effort form of persistInstanceErr: a failed write
+// only logs. Used everywhere the persist is a checkpoint that the next poll/tick
+// will re-attempt, never where the write's durability gates correctness.
+func (m *Manager) persistInstance(repoID string, instance *session.Instance) {
+	if err := m.persistInstanceErr(repoID, instance); err != nil {
 		log.WarningLog.Printf("failed to persist instance %q: %v", instance.Title, err)
 	}
 }
+
+// archivePersist is the durable persist ArchiveSession runs at its commit. A
+// package var so tests can force a persist failure in isolation (exercising the
+// rollback in #1538) without disturbing any other persist. Production points it
+// at persistInstanceErr.
+var archivePersist = (*Manager).persistInstanceErr
 
 // archivedWorktreePath returns the global archive location for a session's
 // relocated worktree: <AGENT_FACTORY_HOME>/archived/<repoID>/<safeTitle>/. The

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -109,6 +110,48 @@ func TestArchiveSession_MoveFailureMarksLost(t *testing.T) {
 	assert.True(t, inst.Started(), "started stays true so the Lost-restore loop re-spawns the agent")
 	assert.True(t, exists(srcPath), "the worktree must remain at its original path on a failed archive")
 	assert.Equal(t, session.Lost, persistedStatus(t, repoID, "worker"))
+}
+
+// TestArchiveSession_PersistFailureRollsBack is the #1538 regression: when the
+// durable persist of the committed Archived state fails, the archive must NOT be
+// left half-recorded (a stale on-disk record pointing at the vacated pre-archive
+// worktree, which would orphan the worktree after a daemon restart). Instead the
+// worktree is moved back to its original location and the session dropped to
+// Lost, so the #1108 restore loop heals it and the on-disk record matches
+// reality.
+func TestArchiveSession_PersistFailureRollsBack(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	inst, srcPath := registerArchivable(t, manager, repoID, repoPath, "worker")
+
+	prev := archivePersist
+	archivePersist = func(*Manager, string, *session.Instance) error {
+		return errors.New("forced persist failure")
+	}
+	t.Cleanup(func() { archivePersist = prev })
+
+	dest, derr := archivedWorktreePath(repoID, "worker")
+	require.NoError(t, derr)
+
+	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	require.Error(t, err, "a persist failure must surface an error, not a silent half-archive")
+
+	assert.Equal(t, session.Lost, inst.GetStatus(), "a persist failure rolls the archive back to Lost for self-heal")
+	assert.True(t, inst.Started(), "started stays true so the Lost-restore loop re-spawns the agent")
+	assert.Equal(t, srcPath, inst.GetWorktreePath(), "the worktree must be moved back to its original location")
+	assert.True(t, exists(srcPath), "the worktree must exist at its original location again")
+	assert.False(t, exists(dest), "the archive directory must be vacated by the rollback")
+
+	// The rolled-back Lost state is persisted (via the real writer in
+	// undoCommittedArchive), so a restart sees a record consistent with reality.
+	assert.Equal(t, session.Lost, persistedStatus(t, repoID, "worker"))
+	rec := recordFor(t, repoID, "worker")
+	require.NotNil(t, rec)
+	assert.Equal(t, srcPath, rec.Worktree.WorktreePath, "the persisted record must point back at the original worktree")
+
+	// The worktree is a valid, registered git worktree back at the original path.
+	list, lerr := exec.Command("git", "-C", repoPath, "worktree", "list", "--porcelain").CombinedOutput()
+	require.NoError(t, lerr, string(list))
+	assert.Contains(t, string(list), srcPath, "git must register the worktree back at the original path")
 }
 
 // TestArchiveSession_RejectsReservedRoot: the always-ensured root session cannot


### PR DESCRIPTION
## Problem

`ArchiveSession`'s success path committed the inert `Archived` state and then persisted it **best-effort** (`m.persistInstance`, which only logs on write failure):

```go
_ = instance.Transition(session.CommitArchive())
m.persistInstance(repoID, instance)   // error swallowed
```

If that persist failed, the on-disk record stayed **stale** — still pointing at the pre-archive worktree path with `started=true`, even though the worktree had physically moved to the archive dir. After a daemon restart:

1. The instance reloads pointing at the old (now vacated) worktree path.
2. The status poll marks it `Lost` (its tmux is gone).
3. The Lost-restore loop tries to **rebuild** the worktree at the old path.
4. git refuses: `branch '<b>' is already checked out at '<archived location>'`.
5. The archived worktree is **orphaned** — unreachable via `af`, and the loop retries forever.

## Fix

Make the archive commit **durable and atomic**:

- Persist through a new `persistInstanceErr` (returns the error) instead of swallowing it.
- On a persist failure, **undo the physical archive**: move the worktree back to its original location and drop the session to `Lost` — via the only legal edge path out of committed `Archived` (`BeginRestore` → `AbortRestoreToLost`, which restores `started=true`).
- The on-disk record (still the pre-archive one, since the archive persist failed) now **matches reality**, so a restart re-spawns at the right path and the #1108 restore loop heals the agent in place. A restart can never see a half-archived record.
- The persist error is now **surfaced to the caller** instead of silently swallowed.

Symmetric with the existing `ArchiveTeardown`-failure path, which already rolls back to `Lost` for self-heal.

### Crash window

The narrow window between the worktree move and this persist *completing* (a hard crash there) is inherent without a write-ahead journal, and is a strictly narrower/rarer case than the reproducible persist-error this issue reports — which is now fully closed. Noted here for the reviewer; a journal-based follow-up could close it entirely.

## Test

`TestArchiveSession_PersistFailureRollsBack`: forces the durable persist to fail (new `archivePersist` package-var seam) and asserts the worktree is moved back to its original registered location, the session is `Lost` + `started=true`, the archive dir is vacated, and the persisted record points back at the original worktree — i.e. disk and reality stay consistent. All existing archive/restore tests still pass.

## Gates
- `gofmt -l .` clean · `go build ./...` · `golangci-lint --fast` · `deadcode -test ./...` · file-length lint — all green
- `make test-container GOTESTARGS="-run 'TestArchiveSession|TestRestoreArchived' ./daemon/"` — green

Fixes #1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)