### PR TITLE
fix(sessions): honor worktree_root on archived-session restore (#1540)

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -175,10 +175,11 @@ func (m *Manager) undoCommittedArchive(repoID string, instance *session.Instance
 }
 
 // RestoreArchived restores an archived session (#1028): it moves the worktree
-// back next to the repo (a free sibling path), re-registers it, re-spawns the
-// agent, and marks the instance Running. Only the agent session is brought back
-// — shell/process tabs were dropped at archive time. Returns the restored
-// worktree path.
+// back to where session creation would place it under the configured
+// worktree_root (a free sibling path, or under $AF_HOME/worktrees for
+// subdirectory users — #1540), re-registers it, re-spawns the agent, and marks
+// the instance Running. Only the agent session is brought back — shell/process
+// tabs were dropped at archive time. Returns the restored worktree path.
 //
 // Concurrency mirrors ArchiveSession/KillSession (killsInFlight + op-lock). On a
 // repo-gone failure the archive is left intact with an actionable error; on a
@@ -232,7 +233,11 @@ func (m *Manager) RestoreArchived(req RestoreArchivedRequest) (string, error) {
 	if _, statErr := os.Stat(repoPath); statErr != nil {
 		return "", fmt.Errorf("cannot restore session %q: its origin repo %s is gone; the archived worktree is intact at %s — recover it manually with git", req.Title, repoPath, instance.GetWorktreePath())
 	}
-	dest, err := sessiongit.SiblingWorktreePath(repoPath, req.Title)
+	// Honor the configured worktree_root placement, exactly as session creation
+	// does (#1540): a subdirectory user's worktree is restored under
+	// $AF_HOME/worktrees/<branch>, not stranded beside the repo. The branch is
+	// needed only for subdirectory placement.
+	dest, err := sessiongit.RestoreWorktreePath(repoPath, req.Title, instance.GetBranch())
 	if err != nil {
 		return "", fmt.Errorf("cannot determine restore location for %q: %w", req.Title, err)
 	}

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -241,10 +241,10 @@ func TestRestoreArchived_MovesWorktreeBackAndRespawns(t *testing.T) {
 	require.Equal(t, session.Archived, inst.GetStatus())
 	archivedPath := inst.GetWorktreePath()
 
-	// Compute the expected sibling path BEFORE restore, while it is still free
-	// (afterwards the restored worktree occupies it, and SiblingWorktreePath
+	// Compute the expected restore path BEFORE restore, while it is still free
+	// (afterwards the restored worktree occupies it, and RestoreWorktreePath
 	// would return the "-2" suffix).
-	expected, perr := sessiongit.SiblingWorktreePath(repoPath, "worker")
+	expected, perr := sessiongit.RestoreWorktreePath(repoPath, "worker", inst.GetBranch())
 	require.NoError(t, perr)
 
 	worktreePath, err := manager.RestoreArchived(RestoreArchivedRequest{Title: "worker", RepoID: repoID})
@@ -314,7 +314,7 @@ func TestRestoreArchived_CollisionSuffixesPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Occupy the default sibling location so restore must suffix.
-	base, perr := sessiongit.SiblingWorktreePath(repoPath, "worker")
+	base, perr := sessiongit.RestoreWorktreePath(repoPath, "worker", inst.GetBranch())
 	require.NoError(t, perr)
 	require.NoError(t, os.MkdirAll(base, 0755))
 

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -172,7 +172,17 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 func resolveWorktreePlacement(cfg *config.Config, repoRoot, worktreeDir, sessionName, branchName string) (string, error) {
 	var basePath string
 	if cfg != nil && cfg.WorktreeRoot == config.WorktreeRootSubdirectory {
-		basePath = filepath.Join(worktreeDir, branchName)
+		// Subdirectory mode nests the branch name under the worktrees root. A
+		// record with no persisted branch (an old/edge archive) would otherwise
+		// resolve to worktreeDir itself, fail the strict-inside guard below, and
+		// block a restore the title-based path could still complete — so fall back
+		// to the sanitized session name as the leaf. A freshly created session
+		// always has a branch, so this fallback only ever engages on restore.
+		leaf := branchName
+		if strings.TrimSpace(leaf) == "" {
+			leaf = sanitizeWorktreePathSegment(sessionName)
+		}
+		basePath = filepath.Join(worktreeDir, leaf)
 	} else {
 		// Sibling mode: {repoParent}/{repoName}-{sessionName}
 		basePath = filepath.Join(worktreeDir, filepath.Base(repoRoot)+"-"+sanitizeWorktreePathSegment(sessionName))

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -145,37 +145,9 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		return nil, "", err
 	}
 
-	safeSessionName := sanitizeWorktreePathSegment(sessionName)
-
-	var basePath string
-	if cfg.WorktreeRoot == config.WorktreeRootSubdirectory {
-		basePath = filepath.Join(worktreeDir, branchName)
-	} else {
-		// Sibling mode: {repoParent}/{repoName}-{sessionName}
-		repoName := filepath.Base(repoPath)
-		basePath = filepath.Join(worktreeDir, repoName+"-"+safeSessionName)
-	}
-
-	// Ensure the worktree path is strictly nested inside worktreeDir. We use
-	// filepath.Rel instead of a HasPrefix check so the validation is correct
-	// when worktreeDir is the filesystem root ("/"): the naive prefix check
-	// produces "//" and rejects every valid child path. See #461.
-	absBase, _ := filepath.Abs(basePath)
-	absDir, _ := filepath.Abs(worktreeDir)
-	if !pathutil.IsStrictlyInside(absBase, absDir) {
-		return nil, "", fmt.Errorf("invalid session name: would create worktree outside expected directory")
-	}
-
-	worktreePath := basePath
-	for i := 2; ; i++ {
-		_, err := os.Stat(worktreePath)
-		if os.IsNotExist(err) {
-			break
-		}
-		if err != nil {
-			return nil, "", fmt.Errorf("cannot check worktree path %q: %w", worktreePath, err)
-		}
-		worktreePath = fmt.Sprintf("%s-%d", basePath, i)
+	worktreePath, err := resolveWorktreePlacement(cfg, repoPath, worktreeDir, sessionName, branchName)
+	if err != nil {
+		return nil, "", err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -188,6 +160,52 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		hooksCtx:     ctx,
 		hooksCancel:  cancel,
 	}, branchName, nil
+}
+
+// resolveWorktreePlacement computes a session's worktree path under the
+// configured placement mode — the single source of truth NewGitWorktree (create)
+// and RestoreWorktreePath (archive restore, #1540) share, so both honor
+// worktree_root identically. Subdirectory mode nests the branch name under
+// $AF_HOME/worktrees; sibling mode nests {repoName}-{safeSessionName} beside the
+// repo. The base path is validated to sit strictly inside worktreeDir (#461) and
+// a numeric suffix is appended when it is already occupied.
+func resolveWorktreePlacement(cfg *config.Config, repoRoot, worktreeDir, sessionName, branchName string) (string, error) {
+	var basePath string
+	if cfg != nil && cfg.WorktreeRoot == config.WorktreeRootSubdirectory {
+		basePath = filepath.Join(worktreeDir, branchName)
+	} else {
+		// Sibling mode: {repoParent}/{repoName}-{sessionName}
+		basePath = filepath.Join(worktreeDir, filepath.Base(repoRoot)+"-"+sanitizeWorktreePathSegment(sessionName))
+	}
+
+	// Ensure the worktree path is strictly nested inside worktreeDir. We use
+	// IsStrictlyInside instead of a HasPrefix check so the validation is correct
+	// when worktreeDir is the filesystem root ("/"): the naive prefix check
+	// produces "//" and rejects every valid child path. See #461.
+	absBase, _ := filepath.Abs(basePath)
+	absDir, _ := filepath.Abs(worktreeDir)
+	if !pathutil.IsStrictlyInside(absBase, absDir) {
+		return "", fmt.Errorf("invalid session name %q: would place worktree outside %s", sessionName, worktreeDir)
+	}
+	return firstFreeWorktreePath(basePath)
+}
+
+// firstFreeWorktreePath returns basePath, or basePath with the lowest "-N"
+// (N>=2) suffix that does not yet exist on disk — the collision discipline both
+// worktree creation and archive restore use so a session never clobbers an
+// occupied path.
+func firstFreeWorktreePath(basePath string) (string, error) {
+	p := basePath
+	for i := 2; ; i++ {
+		_, err := os.Stat(p)
+		if os.IsNotExist(err) {
+			return p, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("cannot check worktree path %q: %w", p, err)
+		}
+		p = fmt.Sprintf("%s-%d", basePath, i)
+	}
 }
 
 // NewGitWorktreeInPlace creates a GitWorktree attached to the repo's own

--- a/session/git/worktree_archive.go
+++ b/session/git/worktree_archive.go
@@ -8,44 +8,33 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/sachiniyer/agent-factory/internal/pathutil"
+	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 )
 
-// SiblingWorktreePath returns the standard sibling worktree location for a
-// session in the repo at repoPath — {repoParent}/{repoName}-{safeTitle} — with a
-// numeric suffix appended if that path is already occupied. It mirrors the
-// layout NewGitWorktree uses when creating a worktree, so RestoreWorktreeTo can
-// move an archived worktree back to where a fresh session's worktree would live
-// (#1028). The title is sanitized for filesystem safety and the result is
-// validated to sit strictly inside the worktree parent dir (the #461 guard).
-func SiblingWorktreePath(repoPath, title string) (string, error) {
+// RestoreWorktreePath returns where an archived session's worktree should be
+// restored, honoring the configured worktree_root placement (#1540) exactly as
+// NewGitWorktree does at creation — routing through the shared
+// resolveWorktreePlacement. Sibling mode returns {repoParent}/{repoName}-
+// {safeTitle}; subdirectory mode returns {AF_HOME}/worktrees/{branchName}, so a
+// subdirectory user gets the worktree back where it belongs instead of stranded
+// beside the repo. branchName is the session's persisted branch (used only for
+// subdirectory placement). A numeric suffix is appended if the path is occupied,
+// and the result is validated to sit strictly inside the worktree parent (#461).
+func RestoreWorktreePath(repoPath, title, branchName string) (string, error) {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to load config: %w", err)
+	}
 	repoRoot, err := findGitRepoRoot(repoPath)
 	if err != nil {
 		return "", err
 	}
-	worktreeDir := filepath.Dir(repoRoot)
-	repoName := filepath.Base(repoRoot)
-
-	safe := sanitizeWorktreePathSegment(title)
-
-	base := filepath.Join(worktreeDir, repoName+"-"+safe)
-	absBase, _ := filepath.Abs(base)
-	absDir, _ := filepath.Abs(worktreeDir)
-	if !pathutil.IsStrictlyInside(absBase, absDir) {
-		return "", fmt.Errorf("invalid session title %q: would place worktree outside %s", title, worktreeDir)
+	worktreeDir, err := getWorktreeDirectoryForRepoWithConfig(cfg, repoRoot)
+	if err != nil {
+		return "", err
 	}
-
-	p := base
-	for i := 2; ; i++ {
-		if _, statErr := os.Stat(p); os.IsNotExist(statErr) {
-			break
-		} else if statErr != nil {
-			return "", fmt.Errorf("cannot check worktree path %q: %w", p, statErr)
-		}
-		p = fmt.Sprintf("%s-%d", base, i)
-	}
-	return p, nil
+	return resolveWorktreePlacement(cfg, repoRoot, worktreeDir, title, branchName)
 }
 
 // ErrRepoGone is returned by RestoreWorktreeTo when the origin repository this

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/sachiniyer/agent-factory/config"
 	aflog "github.com/sachiniyer/agent-factory/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -253,35 +254,71 @@ func TestRestoreWorktreeTo_SubmoduleRepairFailureIsBestEffort(t *testing.T) {
 	assert.Contains(t, warnings.String(), "git -C \""+restoreDest+"\" submodule update --init --recursive")
 }
 
-// TestSiblingWorktreePath_DefaultCollisionAndSanitize: the restore-side path
-// computation returns {repoParent}/{repoName}-{safeTitle}, appends a numeric
-// suffix when that path is occupied, and sanitizes the title into a single safe
-// segment — mirroring NewGitWorktree's layout so restore lands the worktree
-// where a fresh session's would live (#1028).
-func TestSiblingWorktreePath_DefaultCollisionAndSanitize(t *testing.T) {
+// TestRestoreWorktreePath_SiblingCollisionAndSanitize: in the default sibling
+// mode the restore-side path computation returns {repoParent}/{repoName}-
+// {safeTitle}, appends a numeric suffix when that path is occupied, and
+// sanitizes the title into a single safe segment — mirroring NewGitWorktree's
+// layout so restore lands the worktree where a fresh session's would live (#1028).
+// The branch name is ignored in sibling mode.
+func TestRestoreWorktreePath_SiblingCollisionAndSanitize(t *testing.T) {
 	sandboxHome(t)
 	repoRoot := createGitRepo(t) // {tmp}/repo
 	parent := filepath.Dir(repoRoot)
 
-	p, err := SiblingWorktreePath(repoRoot, "feature-x")
+	p, err := RestoreWorktreePath(repoRoot, "feature-x", "af/feature-x")
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(parent, "repo-feature-x"), p)
 
 	// Collision: occupy the default path, expect the "-2" suffix.
 	require.NoError(t, os.MkdirAll(p, 0755))
-	p2, err := SiblingWorktreePath(repoRoot, "feature-x")
+	p2, err := RestoreWorktreePath(repoRoot, "feature-x", "af/feature-x")
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(parent, "repo-feature-x-2"), p2)
 
 	// Sanitize: "/" -> "-", ".." stripped.
-	ps, err := SiblingWorktreePath(repoRoot, "a/b..c")
+	ps, err := RestoreWorktreePath(repoRoot, "a/b..c", "af/ab..c")
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(parent, "repo-a-bc"), ps)
 
-	spaced, err := SiblingWorktreePath(repoRoot, "Review Threads")
+	spaced, err := RestoreWorktreePath(repoRoot, "Review Threads", "af/review")
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(parent, "repo-Review-Threads"), spaced)
 	assert.NotContains(t, filepath.Base(spaced), " ")
+}
+
+// TestRestoreWorktreePath_SubdirectoryHonorsWorktreeRoot is the #1540 regression:
+// for a user with worktree_root=subdirectory, the restore destination must live
+// under $AF_HOME/worktrees/<branch> — exactly where NewGitWorktree creates it —
+// not stranded beside the repo. A collision still suffixes.
+func TestRestoreWorktreePath_SubdirectoryHonorsWorktreeRoot(t *testing.T) {
+	sandboxHome(t)
+	cfg := config.DefaultConfig()
+	cfg.WorktreeRoot = config.WorktreeRootSubdirectory
+	require.NoError(t, config.SaveConfig(cfg))
+
+	repoRoot := createGitRepo(t)
+
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	worktreesDir := filepath.Join(configDir, "worktrees")
+
+	// Restore must match NewGitWorktree's subdirectory layout: {worktrees}/{branch}.
+	created, _, err := NewGitWorktree(repoRoot, "feature-x")
+	require.NoError(t, err)
+	branch := created.GetBranchName()
+	assert.Equal(t, filepath.Join(worktreesDir, branch), created.GetWorktreePath(),
+		"sanity: creation places the worktree under the subdirectory root")
+
+	p, err := RestoreWorktreePath(repoRoot, "feature-x", branch)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(worktreesDir, branch), p,
+		"restore must land the worktree under the subdirectory root, honoring worktree_root")
+
+	// Collision under the subdirectory root suffixes, not falls back to sibling.
+	require.NoError(t, os.MkdirAll(p, 0755))
+	p2, err := RestoreWorktreePath(repoRoot, "feature-x", branch)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(worktreesDir, branch+"-2"), p2)
 }
 
 // TestMoveWorktree_RepairFailureStillCommitsLocation (#1028 Greptile P1): in the

--- a/session/git/worktree_archive_test.go
+++ b/session/git/worktree_archive_test.go
@@ -321,6 +321,29 @@ func TestRestoreWorktreePath_SubdirectoryHonorsWorktreeRoot(t *testing.T) {
 	assert.Equal(t, filepath.Join(worktreesDir, branch+"-2"), p2)
 }
 
+// TestRestoreWorktreePath_SubdirectoryEmptyBranchFallsBackToTitle is the
+// Greptile P1 on #1540: a legacy/edge archived record with an EMPTY persisted
+// branch must still restore under subdirectory mode. With no branch, branch-based
+// placement would resolve to the worktrees root itself and fail the strict-inside
+// guard — a regression, since the old title-based sibling path restored such
+// records fine. The destination must fall back to the sanitized title leaf.
+func TestRestoreWorktreePath_SubdirectoryEmptyBranchFallsBackToTitle(t *testing.T) {
+	sandboxHome(t)
+	cfg := config.DefaultConfig()
+	cfg.WorktreeRoot = config.WorktreeRootSubdirectory
+	require.NoError(t, config.SaveConfig(cfg))
+
+	repoRoot := createGitRepo(t)
+	configDir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	worktreesDir := filepath.Join(configDir, "worktrees")
+
+	p, err := RestoreWorktreePath(repoRoot, "feature-x", "")
+	require.NoError(t, err, "an empty-branch archive must still resolve a valid restore path")
+	assert.Equal(t, filepath.Join(worktreesDir, "feature-x"), p,
+		"an empty branch must fall back to the sanitized title leaf under the subdirectory root")
+}
+
 // TestMoveWorktree_RepairFailureStillCommitsLocation (#1028 Greptile P1): in the
 // cross-filesystem fallback, when the byte-move succeeds but `git worktree
 // repair` fails, the worktree object must already point at dest — where the


### PR DESCRIPTION
## Problem

Archive-then-restore always computed the **sibling** worktree layout — `{repoParent}/{repoName}-{title}` — via `SiblingWorktreePath`, ignoring `cfg.WorktreeRoot`.

For users with `worktree_root="subdirectory"` (worktrees live under `$AF_HOME/worktrees/<branch>/`), restoring an archived session put the worktree in the **wrong place** — beside the repo instead of under the subdirectory root where session creation (`NewGitWorktree`) places it. The two code paths had diverged.

## Fix

Route the restore destination through the **same placement logic** session creation uses:

- Extract `resolveWorktreePlacement` as the single source of truth that `NewGitWorktree` (create) and the new `RestoreWorktreePath` (restore) both call — so both honor `worktree_root` identically (sibling **and** subdirectory), share the #461 strict-inside guard, and share the collision-suffix discipline.
- Replace `SiblingWorktreePath` with the config-aware `RestoreWorktreePath(repoPath, title, branchName)`.
- `RestoreArchived` passes the session's persisted branch (`instance.GetBranch()`), which subdirectory placement needs (its path is `{worktrees}/{branch}`).

Net effect for subdirectory users: an archived session's worktree is restored back under `$AF_HOME/worktrees/<branch>` — where it belongs — instead of stranded beside the repo. Sibling users are unaffected (identical output).

## Tests (both layouts)

- `TestRestoreWorktreePath_SiblingCollisionAndSanitize` — default sibling mode: layout, `-2` collision suffix, title sanitization.
- `TestRestoreWorktreePath_SubdirectoryHonorsWorktreeRoot` — the #1540 case: restore lands under `$AF_HOME/worktrees/<branch>`, asserted equal to where `NewGitWorktree` creates it, with collision suffixing under the subdirectory root (never a sibling fallback).
- Existing `TestRestoreArchived_*` daemon tests updated to the new API and still green.

## Gates
- `gofmt -l .` clean · `go build ./...` · `golangci-lint --fast` · `deadcode -test ./...` · file-length lint — all green
- `make test-container GOTESTARGS="-run 'TestArchiveSession|TestRestoreArchived' ./daemon/ ./session/git/"` — green
- `go test -run 'TestRestoreWorktreePath|TestNewGitWorktree|TestMoveWorktree' ./session/git/` — green

Fixes #1540

🤖 Generated with [Claude Code](https://claude.com/claude-code)