### PR TITLE
feat(tui): switch projects from inside af via a project-picker overlay (#1461)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -79,6 +79,9 @@ func (m *home) handleDefaultKeyPress(msg tea.KeyMsg, name keys.KeyName) (tea.Mod
 	case keys.KeySearch:
 		return m.showSearchOverlay()
 
+	case keys.KeySwitchProject:
+		return m.showProjectPickerOverlay()
+
 	// Hooks configuration (#1024 PR 4: an overlay, not a sidebar slot)
 	case keys.KeyHooks:
 		return m.showHooksOverlay()

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -183,8 +183,16 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	if m.pendingProgram == "" && m.appConfig != nil {
 		m.pendingProgram = m.appConfig.DefaultProgram
 	}
+	// Target the ACTIVE project's repo root, not the process cwd: after an
+	// in-place project switch (#1461) the active repo is m.repoRoot, which may no
+	// longer be where af was launched. At launch m.repoRoot is the cwd's repo, so
+	// this is equivalent for the unswitched case.
+	repoPath := m.repoRoot
+	if repoPath == "" {
+		repoPath = "."
+	}
 	if remote {
-		configured, err := session.RemoteHooksConfiguredForPath(".")
+		configured, err := session.RemoteHooksConfiguredForPath(repoPath)
 		if err != nil {
 			return m, m.handleError(err)
 		}
@@ -194,7 +202,7 @@ func (m *home) startNewInstance(remote bool) (tea.Model, tea.Cmd) {
 	}
 	instance, err := session.NewInstance(session.InstanceOptions{
 		Title:       "",
-		Path:        ".",
+		Path:        repoPath,
 		Program:     m.pendingProgram,
 		ForceRemote: remote,
 	})

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -571,6 +571,8 @@ func keyMsgFromString(s string) (tea.KeyMsg, bool) {
 		return tea.KeyMsg{Type: tea.KeyCtrlU}, true
 	case "ctrl+d":
 		return tea.KeyMsg{Type: tea.KeyCtrlD}, true
+	case "ctrl+p":
+		return tea.KeyMsg{Type: tea.KeyCtrlP}, true
 	case "ctrl+]":
 		return tea.KeyMsg{Type: tea.KeyCtrlCloseBracket}, true
 	}

--- a/app/help.go
+++ b/app/help.go
@@ -116,6 +116,7 @@ func (h helpTypeGeneral) toContent() string {
 		{title: "Managing:", rows: []helpRow{
 			{helpKey(keys.KeyNew), "Create a new session"},
 			{helpKey(keys.KeyNewRemote), "Create a new remote session (requires remote_hooks config)"},
+			{helpKey(keys.KeySwitchProject), "Switch to another project (repo) in place"},
 			{helpKey(keys.KeyTaskList), "Manage tasks (n inside the manager creates one)"},
 			{"r", "Run selected task now"},
 			{helpKey(keys.KeyKill), "Kill (delete) the selected session"},

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -18,14 +18,14 @@ func TestHelpReflectsKeymapRebinds(t *testing.T) {
 	require.NoError(t, keys.ApplyOverrides(map[string][]string{
 		"quit": {"Q"},
 		"new":  {"g"},
-		"up":   {"u", "ctrl+p"},
+		"up":   {"u", "ctrl+g"},
 	}))
 	t.Cleanup(func() { require.NoError(t, keys.ApplyOverrides(nil)) })
 
 	content := helpTypeGeneral{}.toContent()
 
 	// Rebound keys must appear...
-	for _, want := range []string{"Q", "g", "u/ctrl+p"} {
+	for _, want := range []string{"Q", "g", "u/ctrl+g"} {
 		if !strings.Contains(content, want) {
 			t.Errorf("help must show rebound key %q; got:\n%s", want, content)
 		}

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -36,6 +36,9 @@ const (
 	stateConfirm
 	// stateSearch is the state when the user is searching sessions.
 	stateSearch
+	// stateSwitchProject is the state when the project-picker overlay is open
+	// (#1461): pick another repo af has seen and switch the TUI to it in place.
+	stateSwitchProject
 	// stateSelectProgram is the state when the user is selecting a program during naming.
 	stateSelectProgram
 	// stateHooks is the state when the post-worktree hooks editor overlay is
@@ -286,6 +289,8 @@ type home struct {
 	selectionOverlay *overlay.SelectionOverlay
 	// searchOverlay handles session search
 	searchOverlay *overlay.SearchOverlay
+	// projectPickerOverlay handles switching the active project (#1461)
+	projectPickerOverlay *overlay.ProjectPickerOverlay
 	// pendingProgram tracks the program selected during new instance naming
 	pendingProgram string
 

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -437,6 +437,8 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m.handleStateConfirm(msg)
 	case stateSearch:
 		return m.handleStateSearch(msg)
+	case stateSwitchProject:
+		return m.handleStateSwitchProject(msg)
 	case stateSelectProgram:
 		return m.handleStateSelectProgram(msg)
 	case stateHooks:

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -136,6 +136,13 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// write back — and writing its whole-list view back is exactly the clobber
 		// the single-writer model retires (#959/#960).
 		detachTraceMark("snapshotFetchedMsg-handler-entry")
+		// Drop a snapshot fetched for a repo we have since switched away from
+		// (#1461): applying its old-repo sessions/tasks would bleed the previous
+		// project into the new view. Still re-arm the pacing tick so polling of
+		// the now-active repo continues.
+		if msg.repoID != m.repoID {
+			return m, tickRefreshExternalCmd
+		}
 		tickStart := time.Now()
 		changed := m.handleSnapshot(msg)
 		// Live-project out-of-band task changes on the same poll (#1168),

--- a/app/home_view.go
+++ b/app/home_view.go
@@ -174,6 +174,11 @@ func (m *home) View() string {
 		fg := m.searchOverlay.Render()
 		m.searchOverlay.RegisterZones(m.zones, overlayOrigin(fg, mainView))
 		return overlay.PlaceOverlay(0, 0, fg, mainView, true)
+	} else if m.state == stateSwitchProject {
+		if m.projectPickerOverlay == nil {
+			log.ErrorLog.Printf("project picker overlay is nil")
+		}
+		return overlay.PlaceOverlay(0, 0, m.projectPickerOverlay.Render(), mainView, true)
 	} else if m.state == stateSelectProgram {
 		if m.selectionOverlay == nil {
 			log.ErrorLog.Printf("selection overlay is nil")

--- a/app/render.go
+++ b/app/render.go
@@ -78,6 +78,7 @@ func (m *home) layoutModalOverlays() {
 	m.layoutSelectionOverlay()
 	m.layoutConfirmationOverlay()
 	m.layoutSearchOverlay()
+	m.layoutProjectPickerOverlay()
 	m.layoutPaneOverlays()
 }
 
@@ -98,6 +99,12 @@ func (m *home) layoutConfirmationOverlay() {
 func (m *home) layoutSearchOverlay() {
 	if m.searchOverlay != nil {
 		m.searchOverlay.SetMaxSize(m.termWidth, m.termHeight)
+	}
+}
+
+func (m *home) layoutProjectPickerOverlay() {
+	if m.projectPickerOverlay != nil {
+		m.projectPickerOverlay.SetMaxSize(m.termWidth, m.termHeight)
 	}
 }
 

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -155,6 +155,27 @@ func snapshotThroughDaemon(repoID string) (daemon.SnapshotResponse, error) {
 	return daemon.SnapshotWithAlarms(daemon.SnapshotRequest{RepoID: repoID})
 }
 
+// allReposSnapshotFetcher returns the daemon's session list across EVERY repo
+// (RepoID:"" = all repos), used only to build the project-picker's list with a
+// per-project session count (#1461). A package var so the project-switch tests
+// can inject a fake multi-repo snapshot. It is a plain read — the switch itself
+// still re-scopes through home.snapshotFetcher(m.repoID).
+var allReposSnapshotFetcher = func() ([]session.InstanceData, error) {
+	resp, err := daemon.SnapshotWithAlarms(daemon.SnapshotRequest{RepoID: ""})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Instances, nil
+}
+
+// SetAllReposSnapshotFetcherForTest swaps the all-repos discovery fetcher and
+// returns a restore func. Test-only.
+func SetAllReposSnapshotFetcherForTest(f func() ([]session.InstanceData, error)) func() {
+	prev := allReposSnapshotFetcher
+	allReposSnapshotFetcher = f
+	return func() { allReposSnapshotFetcher = prev }
+}
+
 // buildInstanceFromSnapshot materializes a live, tab-reconnected *session.Instance
 // from a snapshot record — the same restore FromInstanceData performs, reconnecting
 // every tab to its persisted tmux session by name so a snapshot-discovered session

--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -1,0 +1,214 @@
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui/overlay"
+	"github.com/sachiniyer/agent-factory/ui/store"
+)
+
+// showProjectPickerOverlay opens the searchable project switcher (#1461): every
+// repo af has seen — the current project, repos with tracked sessions, and the
+// root_agents opt-ins — each with its session count, plus a "+ Add project…"
+// affordance for registering a new repo on the fly.
+func (m *home) showProjectPickerOverlay() (tea.Model, tea.Cmd) {
+	projects := m.buildProjectList()
+	m.projectPickerOverlay = overlay.NewProjectPickerOverlay(projects, m.repoRoot)
+	m.projectPickerOverlay.SetWidth(60)
+	m.layoutProjectPickerOverlay()
+	m.state = stateSwitchProject
+	return m, nil
+}
+
+// buildProjectList derives the picker's project list with zero config: it groups
+// the daemon's cross-repo session snapshot by repo root for the session counts,
+// then unions in the root_agents opt-ins and the active project so repos with no
+// live session still appear. Names are the repo basename; ties break by root.
+func (m *home) buildProjectList() []overlay.Project {
+	counts := map[string]int{}
+	var order []string
+	seen := func(root string) {
+		if root == "" {
+			return
+		}
+		if _, ok := counts[root]; !ok {
+			counts[root] = 0
+			order = append(order, root)
+		}
+	}
+
+	if data, err := allReposSnapshotFetcher(); err != nil {
+		log.WarningLog.Printf("project picker: failed to list cross-repo sessions: %v", err)
+	} else {
+		for _, d := range data {
+			root := d.Worktree.RepoPath
+			if root == "" {
+				continue
+			}
+			seen(root)
+			counts[root]++
+		}
+	}
+
+	if m.appConfig != nil {
+		for path := range m.appConfig.RootAgents {
+			if repo, err := config.RepoFromPath(config.ExpandTilde(path)); err == nil {
+				seen(repo.Root)
+			}
+		}
+	}
+	seen(m.repoRoot)
+
+	projects := make([]overlay.Project, 0, len(order))
+	for _, root := range order {
+		projects = append(projects, overlay.Project{
+			Name:         filepath.Base(root),
+			Root:         root,
+			SessionCount: counts[root],
+		})
+	}
+	sort.Slice(projects, func(i, j int) bool {
+		if projects[i].Name != projects[j].Name {
+			return projects[i].Name < projects[j].Name
+		}
+		return projects[i].Root < projects[j].Root
+	})
+	return projects
+}
+
+// handleStateSwitchProject routes key events to the project picker overlay and
+// consumes its outcomes: an add request (validate + register + switch), a chosen
+// existing project (switch), or a cancel (close).
+func (m *home) handleStateSwitchProject(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	shouldClose := m.projectPickerOverlay.HandleKeyPress(msg)
+
+	// Add-project submit: validate app-side (the overlay must not shell out to
+	// git). An invalid path stays open with an inline error; a valid one is
+	// registered and switched to.
+	if path, ok := m.projectPickerOverlay.TakeAddRequest(); ok {
+		return m.handleAddProject(path)
+	}
+
+	if !shouldClose {
+		return m, nil
+	}
+
+	var target *config.RepoContext
+	if proj, ok := m.projectPickerOverlay.SelectedProject(); ok {
+		repo, err := config.RepoFromPath(proj.Root)
+		if err != nil {
+			m.closeProjectPicker()
+			return m, m.handleError(fmt.Errorf("cannot open project %q: %w", proj.Name, err))
+		}
+		target = repo
+	}
+	m.closeProjectPicker()
+	if target != nil {
+		return m.switchProject(target)
+	}
+	return m, nil
+}
+
+// handleAddProject validates a user-entered repo path, registers it in the
+// global root_agents opt-in list (so it persists in the picker), and switches to
+// it. A path that is not a git repository keeps the overlay open with an inline
+// error rather than dismissing the user's typing.
+func (m *home) handleAddProject(path string) (tea.Model, tea.Cmd) {
+	repo, err := config.RepoFromPath(config.ExpandTilde(path))
+	if err != nil {
+		m.projectPickerOverlay.SetAddError(fmt.Sprintf("not a git repository: %s", path))
+		return m, nil
+	}
+	if _, err := config.RegisterRootAgent(repo.Root); err != nil {
+		// Non-fatal: the switch still works this session; it just won't be
+		// remembered for the next launch.
+		log.WarningLog.Printf("failed to register project %s in root_agents: %v", repo.Root, err)
+	} else if m.appConfig != nil {
+		if m.appConfig.RootAgents == nil {
+			m.appConfig.RootAgents = map[string]config.RootAgentConfig{}
+		}
+		if _, ok := m.appConfig.RootAgents[repo.Root]; !ok {
+			m.appConfig.RootAgents[repo.Root] = config.RootAgentConfig{}
+		}
+	}
+	m.closeProjectPicker()
+	return m.switchProject(repo)
+}
+
+func (m *home) closeProjectPicker() {
+	m.projectPickerOverlay = nil
+	m.state = stateDefault
+}
+
+// switchProject re-scopes the running TUI to repo in place (#1461): it flushes
+// the outgoing project's view state, tears down its panes (and their live
+// termpane PTYs), resets the projection, then re-primes everything — sidebar,
+// tasks, hooks, view state — from the new project's daemon snapshot, which the
+// daemon already filters by repoID (so the sidebar shows ONLY the new project).
+// New sessions/tabs then target the new repoRoot. A no-op when already viewing
+// repo.
+func (m *home) switchProject(repo *config.RepoContext) (tea.Model, tea.Cmd) {
+	if repo.ID == m.repoID {
+		return m, nil
+	}
+
+	// Persist the OUTGOING project's pane/selection state under its still-current
+	// repoID before anything changes.
+	m.flushTUIViewStateBestEffort()
+
+	// Close every open pane (releasing its live termpane attachment) so no stale
+	// pane from the previous project can render against the new repo.
+	for _, p := range append([]*store.OpenPane(nil), m.store.OpenPanes()...) {
+		m.closePaneWindow(p)
+	}
+	m.store.ResetInstances()
+	m.initialPaneOpened = false
+	m.hasLastTUIViewState = false
+
+	m.repoID = repo.ID
+	m.repoRoot = repo.Root
+	m.sidebar.SetProjectName(filepath.Base(repo.Root))
+
+	// Re-resolve the new project's default program for future sessions. AutoYes,
+	// BranchPrefix, etc. are global-only, so they do not change on switch.
+	if resolved, err := config.ResolveConfig(repo.Root); err == nil {
+		if resolved.DefaultProgram != "" {
+			m.program = resolved.DefaultProgram
+		}
+		m.store.SetHookCount(len(resolved.PostWorktreeCommands))
+		m.hooksPane.SetCommands(resolved.PostWorktreeCommands)
+	} else {
+		log.WarningLog.Printf("switch project: failed to resolve config for %s: %v", repo.Root, err)
+	}
+
+	// Re-prime the projection from the new project's snapshot (scoped to the new
+	// repoID by the daemon — no cross-repo bleed). Persisted remote-hook sessions
+	// arrive on this snapshot too; the launch-time importRemoteHookSessions
+	// discovery is deliberately NOT re-run here because it resolves the CWD repo,
+	// not the switched-to one — newly-discovered remote sessions surface on the
+	// next launch instead.
+	if err := m.coldStartFromSnapshot(); err != nil {
+		return m, m.handleError(fmt.Errorf("failed to load sessions for %s: %w", filepath.Base(repo.Root), err))
+	}
+
+	if tasks, err := task.LoadTasksForRepo(repo.Root); err != nil {
+		log.WarningLog.Printf("switch project: failed to load tasks for %s: %v", repo.Root, err)
+		m.store.SetTasks(nil)
+		m.automations.TaskPane().SetTasks(nil)
+	} else {
+		m.store.SetTasks(tasks)
+		m.automations.TaskPane().SetTasks(tasks)
+	}
+
+	m.restoreTUIViewStateOnLaunch()
+	m.focusTreeForNav()
+	m.relayout()
+	return m, tea.Sequence(tea.WindowSize(), m.selectionChanged())
+}

--- a/app/switch_project_test.go
+++ b/app/switch_project_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,6 +64,72 @@ func TestSwitchProjectRescopesSidebar(t *testing.T) {
 	h.startNewInstance(false)
 	require.NotNil(t, h.namingInstance)
 	assert.Equal(t, repoBRoot, h.namingInstance.Path, "new sessions must target the switched-to project root")
+}
+
+// TestSwitchProjectDropsStaleSnapshot: a background snapshot fetched for the
+// previous project (in flight across the switch) must be dropped, not
+// reconciled into the new project's view (#1461 cross-repo bleed).
+func TestSwitchProjectDropsStaleSnapshot(t *testing.T) {
+	h := newTestHome(t)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+	oldRepoID := h.repoID
+
+	repoBRoot := t.TempDir()
+	repoB := &config.RepoContext{Root: repoBRoot, ID: config.RepoIDFromRoot(repoBRoot)}
+	h.snapshotFetcher = func(repoID string) (daemon.SnapshotResponse, error) {
+		if repoID == repoB.ID {
+			return daemon.SnapshotResponse{Instances: []session.InstanceData{
+				{Title: "repoB-session", CreatedAt: time.Now()},
+			}}, nil
+		}
+		return daemon.SnapshotResponse{}, nil
+	}
+	h.switchProject(repoB)
+	require.NotNil(t, findSidebarInstance(h, "repoB-session"))
+
+	// A stale snapshot for the OLD repo lands after the switch. The repoID guard
+	// must drop it so the old project's session does not reappear.
+	h.Update(snapshotFetchedMsg{
+		repoID: oldRepoID,
+		data:   []session.InstanceData{{Title: "repoA-ghost", CreatedAt: time.Now()}},
+	})
+	assert.Nil(t, findSidebarInstance(h, "repoA-ghost"), "a snapshot for the previous project must be dropped")
+	require.NotNil(t, findSidebarInstance(h, "repoB-session"), "the active project's session must remain")
+}
+
+// TestBackgroundRefreshFollowsActiveProject: after a switch the background
+// snapshot poll reads the ACTIVE project's tasks (m.repoRoot), not the launch
+// repo's, and tags the response with the active repoID (#1461).
+func TestBackgroundRefreshFollowsActiveProject(t *testing.T) {
+	h := newTestHome(t)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{}, nil
+	}
+
+	repoBRoot := t.TempDir()
+	repoB := &config.RepoContext{Root: repoBRoot, ID: config.RepoIDFromRoot(repoBRoot)}
+	require.NoError(t, task.AddTask(task.Task{
+		ID: "b1", Name: "B", Prompt: "p", CronExpr: "0 * * * *",
+		ProjectPath: repoBRoot, Program: "claude", Enabled: true, CreatedAt: time.Now(),
+	}))
+	require.NoError(t, task.AddTask(task.Task{
+		ID: "other", Name: "Other", Prompt: "p", CronExpr: "0 * * * *",
+		ProjectPath: "/some/other/repo", Program: "claude", Enabled: true, CreatedAt: time.Now(),
+	}))
+
+	h.switchProject(repoB)
+
+	msg, ok := h.fetchSnapshotCmd()().(snapshotFetchedMsg)
+	require.True(t, ok)
+	assert.Equal(t, repoB.ID, msg.repoID, "the poll response must be tagged with the active repoID")
+	require.NoError(t, msg.tasksErr)
+	require.Len(t, msg.tasks, 1, "the poll must read only the active project's tasks")
+	assert.Equal(t, "b1", msg.tasks[0].ID)
 }
 
 // TestSwitchProjectSameRepoIsNoop: switching to the already-active project is a

--- a/app/switch_project_test.go
+++ b/app/switch_project_test.go
@@ -132,6 +132,50 @@ func TestBackgroundRefreshFollowsActiveProject(t *testing.T) {
 	assert.Equal(t, "b1", msg.tasks[0].ID)
 }
 
+// TestSwitchProjectWithArchivedSection: switching away from a project that has
+// an archived session (and an expanded/navigated archived folder, #1516/#1518/
+// #1527) must fully swap to the target project — the previous project's archived
+// row is gone and the sidebar renders coherently, without the archived-section
+// state interfering with the scope swap (#1461).
+func TestSwitchProjectWithArchivedSection(t *testing.T) {
+	h := newTestHome(t)
+	h.sidebar.SetSize(40, 20)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+
+	// Repo A: a live session plus an archived one, with the archived folder
+	// expanded and the cursor driven into it.
+	h.store.AddInstance(newSnapshotTestInstance(t, "repoA-live"))
+	h.store.AddInstance(archiveActionInstance(t, "repoA-archived", session.Archived))
+	h.sidebar.ExpandSection()
+	h.sidebar.JumpNextSection() // move toward the archived folder
+	_ = h.sidebar.String()      // exercises the archived render + auto-collapse path
+	require.NotNil(t, findSidebarInstance(h, "repoA-archived"))
+
+	repoBRoot := t.TempDir()
+	repoB := &config.RepoContext{Root: repoBRoot, ID: config.RepoIDFromRoot(repoBRoot)}
+	h.snapshotFetcher = func(repoID string) (daemon.SnapshotResponse, error) {
+		if repoID == repoB.ID {
+			return daemon.SnapshotResponse{Instances: []session.InstanceData{
+				{Title: "repoB-live", CreatedAt: time.Now()},
+			}}, nil
+		}
+		return daemon.SnapshotResponse{}, nil
+	}
+
+	h.switchProject(repoB)
+
+	assert.Nil(t, findSidebarInstance(h, "repoA-live"), "previous project's live row must be gone")
+	assert.Nil(t, findSidebarInstance(h, "repoA-archived"), "previous project's archived row must be gone")
+	require.NotNil(t, findSidebarInstance(h, "repoB-live"), "target project's session must appear")
+
+	// The sidebar renders the new scope without stale archived rows or a panic.
+	out := h.sidebar.String()
+	assert.Contains(t, out, filepath.Base(repoBRoot))
+	assert.NotContains(t, out, "repoA-archived")
+}
+
 // TestSwitchProjectSameRepoIsNoop: switching to the already-active project is a
 // no-op that leaves the sidebar untouched.
 func TestSwitchProjectSameRepoIsNoop(t *testing.T) {

--- a/app/switch_project_test.go
+++ b/app/switch_project_test.go
@@ -1,0 +1,185 @@
+package app
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/overlay"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSwitchProjectRescopesSidebar is the core #1461 guarantee: switching to
+// another project fully swaps the sidebar to that project's sessions — the
+// previous project's sessions are hidden (no cross-repo bleed) — and re-scopes
+// repoID/repoRoot so new sessions target the newly active project.
+func TestSwitchProjectRescopesSidebar(t *testing.T) {
+	h := newTestHome(t)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+
+	// Seed the current (repo A) sidebar with a session.
+	h.store.AddInstance(newSnapshotTestInstance(t, "repoA-session"))
+	require.NotNil(t, findSidebarInstance(h, "repoA-session"))
+
+	repoBRoot := t.TempDir()
+	repoB := &config.RepoContext{Root: repoBRoot, ID: config.RepoIDFromRoot(repoBRoot)}
+
+	// The per-repo fetcher returns repo B's sessions only for repo B's id. Any
+	// bleed of repo A into the post-switch sidebar would show up as a stale row.
+	h.snapshotFetcher = func(repoID string) (daemon.SnapshotResponse, error) {
+		if repoID == repoB.ID {
+			return daemon.SnapshotResponse{Instances: []session.InstanceData{
+				{Title: "repoB-session", CreatedAt: time.Now()},
+			}}, nil
+		}
+		return daemon.SnapshotResponse{}, nil
+	}
+
+	mod, _ := h.switchProject(repoB)
+	require.NotNil(t, mod)
+
+	// repoID/repoRoot re-scoped to the target project.
+	assert.Equal(t, repoB.ID, h.repoID)
+	assert.Equal(t, repoBRoot, h.repoRoot)
+
+	// The sidebar now shows ONLY repo B's session.
+	require.NotNil(t, findSidebarInstance(h, "repoB-session"), "the target project's session must appear")
+	assert.Nil(t, findSidebarInstance(h, "repoA-session"), "the previous project's sessions must be hidden after switch")
+
+	// The active-project header reflects the new project.
+	h.sidebar.SetSize(40, 20)
+	assert.Contains(t, h.sidebar.String(), filepath.Base(repoBRoot), "sidebar title should name the active project")
+
+	// A new session created after the switch targets the new project's root.
+	h.startNewInstance(false)
+	require.NotNil(t, h.namingInstance)
+	assert.Equal(t, repoBRoot, h.namingInstance.Path, "new sessions must target the switched-to project root")
+}
+
+// TestSwitchProjectSameRepoIsNoop: switching to the already-active project is a
+// no-op that leaves the sidebar untouched.
+func TestSwitchProjectSameRepoIsNoop(t *testing.T) {
+	h := newTestHome(t)
+	h.store.AddInstance(newSnapshotTestInstance(t, "existing"))
+
+	same := &config.RepoContext{Root: h.repoRoot, ID: h.repoID}
+	h.switchProject(same)
+
+	require.NotNil(t, findSidebarInstance(h, "existing"), "a same-repo switch must not wipe the sidebar")
+}
+
+// TestBuildProjectListUnionsSourcesWithCounts: the picker list unions the
+// cross-repo session snapshot (with counts), the root_agents opt-ins, and the
+// active project, deduped by repo root.
+func TestBuildProjectListUnionsSourcesWithCounts(t *testing.T) {
+	h := newTestHome(t)
+	h.repoRoot = "/repos/active"
+
+	repoWithSessions := "/repos/busy"
+	t.Cleanup(SetAllReposSnapshotFetcherForTest(func() ([]session.InstanceData, error) {
+		mk := func(root string) session.InstanceData {
+			d := session.InstanceData{Title: "s", CreatedAt: time.Now()}
+			d.Worktree.RepoPath = root
+			return d
+		}
+		return []session.InstanceData{mk(repoWithSessions), mk(repoWithSessions)}, nil
+	}))
+	h.appConfig.RootAgents = map[string]config.RootAgentConfig{}
+
+	got := h.buildProjectList()
+	byRoot := map[string]overlay.Project{}
+	for _, p := range got {
+		byRoot[p.Root] = p
+	}
+
+	require.Contains(t, byRoot, repoWithSessions)
+	assert.Equal(t, 2, byRoot[repoWithSessions].SessionCount, "session count should be grouped by repo root")
+	require.Contains(t, byRoot, "/repos/active", "the active project must always be listed")
+	assert.Equal(t, 0, byRoot["/repos/active"].SessionCount)
+
+	// Names are basenames and the list is sorted by name.
+	assert.Equal(t, "active", byRoot["/repos/active"].Name)
+	for i := 1; i < len(got); i++ {
+		if got[i-1].Name == got[i].Name {
+			continue
+		}
+		assert.True(t, got[i-1].Name < got[i].Name, "project list should be sorted by name")
+	}
+}
+
+// TestHandleAddProjectRejectsNonGitPath keeps the overlay open with an inline
+// error when the entered path is not a git repository.
+func TestHandleAddProjectRejectsNonGitPath(t *testing.T) {
+	h := newTestHome(t)
+	h.projectPickerOverlay = overlay.NewProjectPickerOverlay(nil, h.repoRoot)
+	h.state = stateSwitchProject
+	// Enter add mode (the add row is selected when there are no projects), which
+	// is the only state from which an add is submitted in the real flow.
+	h.projectPickerOverlay.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+
+	nonGit := t.TempDir() // a plain dir, not a git repo
+	mod, cmd := h.handleAddProject(nonGit)
+	require.NotNil(t, mod)
+	_ = cmd
+
+	assert.Equal(t, stateSwitchProject, h.state, "an invalid add must keep the picker open")
+	require.NotNil(t, h.projectPickerOverlay, "overlay must stay open on an invalid path")
+	assert.Contains(t, h.projectPickerOverlay.Render(), "not a git repository")
+}
+
+func TestHandleAddProjectRegistersAndSwitches(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	h := newTestHome(t)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{}, nil
+	}
+	h.projectPickerOverlay = overlay.NewProjectPickerOverlay(nil, h.repoRoot)
+	h.state = stateSwitchProject
+
+	// A real git repo so RepoFromPath resolves.
+	repoRoot := initTestGitRepo(t)
+	mod, _ := h.handleAddProject(repoRoot)
+	require.NotNil(t, mod)
+
+	assert.Equal(t, stateDefault, h.state, "a valid add closes the picker")
+	assert.Nil(t, h.projectPickerOverlay)
+	assert.Equal(t, config.RepoIDFromRoot(repoRoot), h.repoID, "add should switch to the new project")
+
+	// Persisted into root_agents so it appears in the picker next launch.
+	cfg, err := config.LoadConfig()
+	require.NoError(t, err)
+	assert.Contains(t, cfg.RootAgents, repoRoot)
+}
+
+// initTestGitRepo initializes a bare-minimum git repo in a temp dir and returns
+// its resolved main-worktree root (as RepoFromPath would report it).
+func initTestGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "test")
+	repo, err := config.RepoFromPath(dir)
+	require.NoError(t, err)
+	return repo.Root
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	out, err := c.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, string(out))
+}

--- a/app/sync.go
+++ b/app/sync.go
@@ -32,6 +32,12 @@ type tickRefreshExternalMessage struct{}
 type snapshotFetchedMsg struct {
 	data []session.InstanceData
 	err  error
+	// repoID is the repo the fetch was scoped to, captured at spawn. The handler
+	// drops the whole message when it no longer matches m.repoID: an in-place
+	// project switch (#1461) can change the active repo while a fetch launched
+	// for the previous repo is still in flight, and applying its old-repo
+	// sessions/tasks would bleed the previous project into the new view.
+	repoID string
 	// tasks is the repo's task list re-read from disk on the same poll (#1168).
 	// Tasks are a disk-backed store shared between the TUI and the daemon — not
 	// solely daemon-owned like sessions (#960) — so an out-of-band `af tasks
@@ -99,15 +105,18 @@ func (m *home) fetchSnapshotCmd() tea.Cmd {
 	// here rather than inside the closure keeps the off-loop goroutine free of any
 	// field access that could race a concurrent reassignment (#960 PR 4 race fix).
 	repoID := m.repoID
+	repoRoot := m.repoRoot
 	fetch := m.snapshotFetcher
 	return func() tea.Msg {
 		resp, err := fetch(repoID)
-		// Re-read the repo's tasks on the same poll so an out-of-band task
-		// change live-projects into the TUI (#1168). Independent of the session
-		// snapshot: its own error is carried separately so a warming-daemon RPC
-		// failure never suppresses a successful disk task read.
-		tasks, tasksErr := task.LoadTasksForCurrentRepo()
-		return snapshotFetchedMsg{data: resp.Instances, alarms: resp.DeliveryAlarms, err: err, tasks: tasks, tasksErr: tasksErr}
+		// Re-read the ACTIVE repo's tasks on the same poll so an out-of-band task
+		// change live-projects into the TUI (#1168). Scoped to the captured
+		// repoRoot, not cwd, so a poll after an in-place project switch (#1461)
+		// reads the switched-to project's tasks — not the launch repo's. Its own
+		// error is carried separately so a warming-daemon RPC failure never
+		// suppresses a successful disk task read.
+		tasks, tasksErr := task.LoadTasksForRepo(repoRoot)
+		return snapshotFetchedMsg{data: resp.Instances, alarms: resp.DeliveryAlarms, err: err, tasks: tasks, tasksErr: tasksErr, repoID: repoID}
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1291,7 +1291,7 @@ up = ["u", "ctrl+g"]
 		}{
 			{"unknown action", "[keys]\nwarp = \"z\"\n", "unknown action"},
 			{"reserved key", "[keys]\nquit = \"enter\"\n", "reserved"},
-			{"conflict", "[keys]\nkill = \"q\"\n", "bound to both"},
+			{"conflict", "[keys]\nkill = \"z\"\nquit = \"z\"\n", "bound to both"},
 			{"invalid key string", "[keys]\nquit = \"space bar\"\n", "not a valid key"},
 			{"non-string value", "[keys]\nquit = 5\n", "expected a key string"},
 			{"non-string list item", "[keys]\nquit = [5]\n", "expected a key string"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1264,7 +1264,7 @@ default_program = "claude"
 
 [keys]
 quit = "Q"
-up = ["u", "ctrl+p"]
+up = ["u", "ctrl+g"]
 `)
 
 		cfg, err := LoadConfig()
@@ -1272,7 +1272,7 @@ up = ["u", "ctrl+p"]
 		require.NotNil(t, cfg)
 		overrides := cfg.KeymapOverrides()
 		assert.Equal(t, []string{"Q"}, overrides["quit"])
-		assert.Equal(t, []string{"u", "ctrl+p"}, overrides["up"])
+		assert.Equal(t, []string{"u", "ctrl+g"}, overrides["up"])
 	})
 
 	t.Run("keys table: absent means nil overrides", func(t *testing.T) {

--- a/config/rootagent_register.go
+++ b/config/rootagent_register.go
@@ -1,0 +1,35 @@
+package config
+
+// RegisterRootAgent opts repoRoot into the global root_agents list with the
+// default agent profile, unless it is already present. It is the persistence
+// side of the TUI's in-place "+ Add project…" flow (#1461): root_agents is the
+// existing, durable "af has seen this repo" store, so a project added at runtime
+// still appears in the picker on the next launch.
+//
+// The write is load-modify-persist over the whole global config so no other key
+// is clobbered, and idempotent: a repo already registered is a no-op that
+// reports added=false, so the caller can avoid a needless config rewrite. The
+// key is the repo's absolute main-worktree root (callers resolve it via
+// RepoFromPath first), matching how EnsureRootAgents resolves the map keys.
+//
+// Registering here does not itself spawn an always-on root agent: the daemon
+// reads root_agents at startup, so the always-ensure behavior only takes effect
+// on the next daemon start. Switching to the repo works immediately regardless,
+// because Snapshot/CreateSession resolve any repo path live.
+func RegisterRootAgent(repoRoot string) (bool, error) {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return false, err
+	}
+	if _, exists := cfg.RootAgents[repoRoot]; exists {
+		return false, nil
+	}
+	if cfg.RootAgents == nil {
+		cfg.RootAgents = map[string]RootAgentConfig{}
+	}
+	cfg.RootAgents[repoRoot] = RootAgentConfig{}
+	if err := SaveConfig(cfg); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/config/rootagent_register_test.go
+++ b/config/rootagent_register_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterRootAgentAddsAndIsIdempotent(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	// Seed a config with an unrelated key so we can prove the write preserves it.
+	seed := DefaultConfig()
+	seed.DefaultProgram = "codex"
+	require.NoError(t, SaveConfig(seed))
+
+	added, err := RegisterRootAgent("/repos/new-project")
+	require.NoError(t, err)
+	assert.True(t, added, "first registration should add the entry")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Contains(t, cfg.RootAgents, "/repos/new-project")
+	// The unrelated key must survive the load-modify-persist write.
+	assert.Equal(t, "codex", cfg.DefaultProgram)
+
+	// Second call is a no-op.
+	added, err = RegisterRootAgent("/repos/new-project")
+	require.NoError(t, err)
+	assert.False(t, added, "re-registering the same repo should be a no-op")
+
+	cfg, err = LoadConfig()
+	require.NoError(t, err)
+	assert.Len(t, cfg.RootAgents, 1)
+}
+
+func TestRegisterRootAgentPreservesExistingEntries(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	seed := DefaultConfig()
+	seed.RootAgents = map[string]RootAgentConfig{"/repos/existing": {}}
+	require.NoError(t, SaveConfig(seed))
+
+	_, err := RegisterRootAgent("/repos/added")
+	require.NoError(t, err)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Contains(t, cfg.RootAgents, "/repos/existing")
+	require.Contains(t, cfg.RootAgents, "/repos/added")
+}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -321,8 +321,27 @@ func RebindableActions() []string {
 	return names
 }
 
+// keyClaim is one action's claim on a key string while buildMaps resolves the
+// effective binding table: the action, whether a [keys] override placed it
+// there, and whether it dispatches (contextual claims participate in conflict
+// resolution but never enter GlobalKeyStringsMap).
+type keyClaim struct {
+	name       KeyName
+	action     string
+	overridden bool
+	dispatch   bool
+}
+
 // buildMaps generates the strings and bindings maps from specs with
 // overrides applied, validating as it goes.
+//
+// Conflict resolution distinguishes provenance so an UPGRADE never breaks boot
+// (#1461): a USER binding ([keys] override) of a key SUPPRESSES any DEFAULT
+// claim of the same key — a newly-shipped default binding yields to a key the
+// user already bound, rather than hard-erroring the whole config. Two USER
+// bindings on one key, or two DEFAULTS (a specs-table bug), are still a real
+// conflict, except for the sanctioned pane/tree contextual overlap. A suppressed
+// default simply loses that key (the user can rebind the action via [keys]).
 func buildMaps(overrides map[string][]string) (map[string]KeyName, map[KeyName]key.Binding, error) {
 	byConfigKey := specsByConfigKey()
 	normalizedOverrides, err := normalizeOverrides(overrides, byConfigKey)
@@ -330,55 +349,110 @@ func buildMaps(overrides map[string][]string) (map[string]KeyName, map[KeyName]k
 		return nil, nil, err
 	}
 
-	stringsMap := make(map[string]KeyName, 64)
-	bindings := make(map[KeyName]key.Binding, len(specs))
-	// boundBy tracks which action owns each dispatch/contextual key, to name
-	// both sides of a conflict. Fixed dispatch specs (enter/tab/shift+tab)
-	// participate, so an override cannot silently shadow them either (they
-	// are also in reservedKeys, which reports the clearer error first).
-	boundBy := map[string]bindingOwner{}
-	for _, sp := range specs {
-		effective := sp.keys
-		overridden := false
+	// Effective keys per spec, and whether an override replaced the default,
+	// plus a claim list per key (dispatch/contextual specs only).
+	effectiveKeys := make([][]string, len(specs))
+	overridden := make([]bool, len(specs))
+	claims := map[string][]keyClaim{}
+	for i, sp := range specs {
+		eff := sp.keys
 		if sp.configKey != "" {
 			if o, ok := normalizedOverrides[sp.configKey]; ok {
-				effective = o
-				overridden = true
+				eff = o
+				overridden[i] = true
+			}
+		}
+		effectiveKeys[i] = eff
+		if sp.dispatch || sp.contextual {
+			for _, k := range eff {
+				claims[k] = append(claims[k], keyClaim{
+					name: sp.name, action: ownerAction(sp), overridden: overridden[i], dispatch: sp.dispatch,
+				})
+			}
+		}
+	}
+
+	// suppressed[name][key] marks a default claim dropped because a user binding
+	// took the key. Iterate keys in sorted order so a table with multiple genuine
+	// conflicts reports the same one deterministically.
+	suppressed := map[KeyName]map[string]bool{}
+	keyStrings := make([]string, 0, len(claims))
+	for k := range claims {
+		keyStrings = append(keyStrings, k)
+	}
+	sort.Strings(keyStrings)
+	for _, k := range keyStrings {
+		cs := claims[k]
+		for i := 0; i < len(cs); i++ {
+			for j := i + 1; j < len(cs); j++ {
+				a, b := cs[i], cs[j]
+				if contextualKeyOverlapAllowed(a.name, b.name) {
+					continue // sanctioned pane/tree overlap: both keep the key
+				}
+				if a.overridden != b.overridden {
+					continue // user-vs-default: the default yields (suppressed below)
+				}
+				return nil, nil, fmt.Errorf("keys: %q is bound to both %q and %q; each key can trigger only one action", k, a.action, b.action)
+			}
+		}
+		for _, c := range cs {
+			if c.overridden || !overrideSuppressesDefault(k, c, cs) {
+				continue
+			}
+			if suppressed[c.name] == nil {
+				suppressed[c.name] = map[string]bool{}
+			}
+			suppressed[c.name][k] = true
+		}
+	}
+
+	stringsMap := make(map[string]KeyName, 64)
+	bindings := make(map[KeyName]key.Binding, len(specs))
+	for i, sp := range specs {
+		effective := effectiveKeys[i]
+		active := effective
+		if sup := suppressed[sp.name]; len(sup) > 0 {
+			active = make([]string, 0, len(effective))
+			for _, k := range effective {
+				if !sup[k] {
+					active = append(active, k)
+				}
 			}
 		}
 
-		if sp.dispatch || sp.contextual {
-			for _, k := range effective {
-				owner := bindingOwner{name: sp.name, action: ownerAction(sp)}
-				if prev, taken := boundBy[k]; taken {
-					if !contextualKeyOverlapAllowed(prev.name, owner.name) {
-						return nil, nil, fmt.Errorf("keys: %q is bound to both %q and %q; each key can trigger only one action", k, prev.action, owner.action)
-					}
-				} else {
-					boundBy[k] = owner
-				}
-				if !sp.dispatch {
-					continue
-				}
+		if sp.dispatch {
+			for _, k := range active {
 				stringsMap[k] = sp.name
 			}
 		}
 
 		label := sp.helpLabel
-		if label == "" || overridden {
-			label = helpLabelFor(effective)
+		if label == "" || overridden[i] || len(active) != len(effective) {
+			label = helpLabelFor(active)
 		}
 		bindings[sp.name] = key.NewBinding(
-			key.WithKeys(effective...),
+			key.WithKeys(active...),
 			key.WithHelp(label, sp.desc),
 		)
 	}
 	return stringsMap, bindings, nil
 }
 
-type bindingOwner struct {
-	name   KeyName
-	action string
+// overrideSuppressesDefault reports whether the default claim c on key k must
+// yield: some OTHER action bound k via a [keys] override and is not a sanctioned
+// contextual overlap with c. When true, c loses k rather than the config being
+// rejected (#1461).
+func overrideSuppressesDefault(k string, c keyClaim, cs []keyClaim) bool {
+	for _, o := range cs {
+		if !o.overridden || o.name == c.name {
+			continue
+		}
+		if contextualKeyOverlapAllowed(c.name, o.name) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func ownerAction(sp spec) string {

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -45,6 +45,13 @@ const (
 	KeyCopyPR // Key for copying PR URL to clipboard
 	KeyHooks  // Key for editing post-worktree hooks
 
+	// KeySwitchProject opens the searchable project-picker overlay to switch the
+	// TUI's active project/repo in place (#1461). ctrl+p rather than P: the
+	// capital keys are deliberately left free so a user can pin the old
+	// ergonomic bindings (copy_pr/archive/hooks) to them via [keys], and a new
+	// default on P would collide with such a pin at startup.
+	KeySwitchProject
+
 	KeyChangeProgram // Key for changing the program during new instance naming
 	KeyCancelName    // Display-only cancel hint during new instance naming
 
@@ -147,6 +154,7 @@ var specs = []spec{
 	{name: KeyOpenPR, configKey: "open_pr", keys: []string{"p"}, desc: "open PR", dispatch: true},
 	{name: KeyCopyPR, configKey: "copy_pr", keys: []string{"y"}, desc: "copy PR URL", dispatch: true},
 	{name: KeyHooks, configKey: "hooks", keys: []string{"e"}, desc: "worktree hooks", dispatch: true},
+	{name: KeySwitchProject, configKey: "switch_project", keys: []string{"ctrl+p"}, desc: "switch project", dispatch: true},
 	{name: KeyLeft, configKey: "collapse", keys: []string{"h", "left"}, desc: "collapse", dispatch: true},
 	{name: KeyRight, configKey: "expand", keys: []string{"l", "right"}, desc: "expand", dispatch: true},
 	{name: KeyNextSection, configKey: "next_section", keys: []string{"]"}, desc: "next section", dispatch: true},

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -51,6 +51,7 @@ func TestDefaultMapsMatchApprovedKeymap(t *testing.T) {
 		"p":         KeyOpenPR,
 		"y":         KeyCopyPR,
 		"e":         KeyHooks,
+		"ctrl+p":    KeySwitchProject,
 		"h":         KeyLeft,
 		"left":      KeyLeft,
 		"l":         KeyRight,
@@ -89,6 +90,7 @@ func TestDefaultMapsMatchApprovedKeymap(t *testing.T) {
 		KeyPaneNext:          "→",
 		KeyQuit:              "q",
 		KeyErrorDetails:      "E",
+		KeySwitchProject:     "ctrl+p",
 	}
 	for name, want := range helpChecks {
 		if got := GlobalKeyBindings[name].Help().Key; got != want {
@@ -173,7 +175,7 @@ func TestApplyOverridesRebindsDispatchAndHelp(t *testing.T) {
 	resetAfter(t)
 	err := ApplyOverrides(map[string][]string{
 		"quit": {"Q"},
-		"up":   {"u", "ctrl+p"},
+		"up":   {"u", "ctrl+g"},
 	})
 	if err != nil {
 		t.Fatalf("ApplyOverrides: %v", err)
@@ -185,8 +187,8 @@ func TestApplyOverridesRebindsDispatchAndHelp(t *testing.T) {
 	if _, still := GlobalKeyStringsMap["q"]; still {
 		t.Fatalf("an override replaces the default binding entirely; q must be unbound")
 	}
-	if got := GlobalKeyStringsMap["ctrl+p"]; got != KeyUp {
-		t.Fatalf("ctrl+p should dispatch KeyUp, got %v", got)
+	if got := GlobalKeyStringsMap["ctrl+g"]; got != KeyUp {
+		t.Fatalf("ctrl+g should dispatch KeyUp, got %v", got)
 	}
 	if _, still := GlobalKeyStringsMap["k"]; still {
 		t.Fatalf("k must be unbound after the up override")
@@ -195,8 +197,8 @@ func TestApplyOverridesRebindsDispatchAndHelp(t *testing.T) {
 	if got := GlobalKeyBindings[KeyQuit].Help().Key; got != "Q" {
 		t.Fatalf("help label must reflect the rebind, got %q", got)
 	}
-	if got := GlobalKeyBindings[KeyUp].Help().Key; got != "u/ctrl+p" {
-		t.Fatalf("multi-key help label = %q, want u/ctrl+p", got)
+	if got := GlobalKeyBindings[KeyUp].Help().Key; got != "u/ctrl+g" {
+		t.Fatalf("multi-key help label = %q, want u/ctrl+g", got)
 	}
 	// Unlisted actions keep their defaults.
 	if got := GlobalKeyStringsMap["D"]; got != KeyKill {

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -299,10 +299,11 @@ func TestValidateOverridesErrors(t *testing.T) {
 		{"reserved enter", map[string][]string{"quit": {"enter"}}, "reserved"},
 		{"reserved tab-jump digit", map[string][]string{"quit": {"3"}}, "reserved"},
 		{"reserved interactive exit", map[string][]string{"quit": {"ctrl+]"}}, "reserved"},
-		{"conflict with another default", map[string][]string{"kill": {"q"}}, "bound to both"},
+		// A user binding vs a DEFAULT is no longer a conflict — the default yields
+		// (#1461); those cases are covered by TestUserOverrideSuppressesDefault.
+		// Two USER bindings on one key remain a hard conflict.
 		{"conflict between two overrides", map[string][]string{"kill": {"z"}, "quit": {"z"}}, "bound to both"},
 		{"canonicalized conflict between overrides", map[string][]string{"up": {"shift+ctrl+up"}, "down": {"ctrl+shift+up"}}, "bound to both"},
-		{"contextual pane key conflicts with unrelated action", map[string][]string{"pane_prev": {"q"}}, "bound to both"},
 		{"contextual pane keys conflict with each other", map[string][]string{"pane_prev": {"z"}, "pane_next": {"z"}}, "bound to both"},
 	}
 	for _, tc := range cases {
@@ -324,6 +325,43 @@ func TestValidateOverridesErrors(t *testing.T) {
 	}
 	if err := ValidateOverrides(map[string][]string{"pane_prev": {"h"}, "pane_next": {"l"}}); err != nil {
 		t.Fatalf("pane switch keys may share tree-horizontal keys by context, got: %v", err)
+	}
+}
+
+// TestUserOverrideSuppressesDefault covers the #1461 boot-safety rule: a [keys]
+// override that binds a key which is ALSO some action's default must not break
+// boot — the default yields (is suppressed) and the user binding wins.
+func TestUserOverrideSuppressesDefault(t *testing.T) {
+	resetAfter(t)
+
+	// The upgrade scenario: a config already binds ctrl+p (the new switch_project
+	// default) to another action. It must still boot; switch_project simply gets
+	// no default key here.
+	if err := ApplyOverrides(map[string][]string{"up": {"u", "ctrl+p"}}); err != nil {
+		t.Fatalf("a config binding ctrl+p to another action must still boot: %v", err)
+	}
+	if got := GlobalKeyStringsMap["ctrl+p"]; got != KeyUp {
+		t.Fatalf("ctrl+p should dispatch the user's KeyUp binding, got %v", got)
+	}
+	for k, name := range GlobalKeyStringsMap {
+		if name == KeySwitchProject {
+			t.Fatalf("switch_project must be unbound after the user took ctrl+p; still bound to %q", k)
+		}
+	}
+	if got := GlobalKeyBindings[KeySwitchProject].Help().Key; got != "" {
+		t.Fatalf("suppressed switch_project should render no key, got %q", got)
+	}
+
+	// The general rule: a user binding beats a plain default on the same key —
+	// kill=q wins, quit's default q is suppressed, and boot succeeds.
+	if err := ApplyOverrides(map[string][]string{"kill": {"q"}}); err != nil {
+		t.Fatalf("kill=q must boot with quit yielding q: %v", err)
+	}
+	if got := GlobalKeyStringsMap["q"]; got != KeyKill {
+		t.Fatalf("q should dispatch the user's KeyKill binding, got %v", got)
+	}
+	if got := GlobalKeyBindings[KeyQuit].Help().Key; got != "" {
+		t.Fatalf("quit should be unbound after the user took q, got %q", got)
 	}
 }
 
@@ -397,9 +435,11 @@ func TestEffectiveBindings(t *testing.T) {
 		t.Fatalf("pane_prev info = %+v, want default left not rebound", panePrev)
 	}
 
-	// A broken table reports the same error the TUI would refuse to start
-	// with, instead of printing a keymap that is not in effect.
-	if _, err := EffectiveBindings(map[string][]string{"kill": {"q"}}); err == nil {
+	// A broken table (two USER bindings on one key) reports the same error the
+	// TUI would refuse to start with, instead of printing a keymap that is not in
+	// effect. (A user binding vs a mere default is not a conflict — the default
+	// yields, #1461 — so the conflict must be override-vs-override.)
+	if _, err := EffectiveBindings(map[string][]string{"kill": {"z"}, "quit": {"z"}}); err == nil {
 		t.Fatal("EffectiveBindings must reject a conflicting table")
 	}
 

--- a/task/task.go
+++ b/task/task.go
@@ -307,13 +307,21 @@ func LoadTasksForCurrentRepo() ([]Task, error) {
 	if err != nil {
 		return nil, err
 	}
+	return LoadTasksForRepo(repo.Root)
+}
+
+// LoadTasksForRepo returns only tasks whose ProjectPath matches repoRoot (the
+// repo's main-worktree root). It is the repo-scoped loader the in-place project
+// switch (#1461) uses to repopulate the automations strip for the newly active
+// project, without re-deriving the repo from cwd.
+func LoadTasksForRepo(repoRoot string) ([]Task, error) {
 	all, err := LoadTasks()
 	if err != nil {
 		return nil, err
 	}
 	var filtered []Task
 	for _, t := range all {
-		if t.ProjectPath == repo.Root {
+		if t.ProjectPath == repoRoot {
 			filtered = append(filtered, t)
 		}
 	}

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -131,6 +131,25 @@ func TestAddTask(t *testing.T) {
 	assert.Equal(t, "s2", loaded[1].ID)
 }
 
+func TestLoadTasksForRepo(t *testing.T) {
+	setupTestTasks(t, []Task{
+		{ID: "a", Name: "A", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: "/repos/one", Program: "claude", Enabled: true, CreatedAt: time.Now()},
+		{ID: "b", Name: "B", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: "/repos/two", Program: "claude", Enabled: true, CreatedAt: time.Now()},
+		{ID: "c", Name: "C", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: "/repos/one", Program: "claude", Enabled: true, CreatedAt: time.Now()},
+	})
+
+	one, err := LoadTasksForRepo("/repos/one")
+	require.NoError(t, err)
+	require.Len(t, one, 2)
+	for _, tk := range one {
+		assert.Equal(t, "/repos/one", tk.ProjectPath)
+	}
+
+	none, err := LoadTasksForRepo("/repos/absent")
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
 func TestRemoveTask(t *testing.T) {
 	tasks := []Task{
 		{ID: "keep", Name: "Keep", Prompt: "p", CronExpr: "0 * * * *", ProjectPath: "/tmp", Program: "claude", Enabled: true},

--- a/ui/overlay/projectPickerOverlay.go
+++ b/ui/overlay/projectPickerOverlay.go
@@ -1,0 +1,329 @@
+package overlay
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Project is one selectable entry in the project picker: a repo af has seen,
+// with its display name (repo basename), absolute main-worktree root, and the
+// number of sessions currently tracked for it.
+type Project struct {
+	Name         string
+	Root         string
+	SessionCount int
+}
+
+// ProjectPickerOverlay is the searchable project switcher (#1461). It mirrors
+// SearchOverlay's idiom — a hand-rolled query buffer, fuzzy filter, windowed
+// list, Enter/Esc handling — and adds an "+ Add project…" affordance: selecting
+// the trailing add row switches the overlay into add mode, where the query line
+// becomes a repo-path input. Path validation and registration happen app-side
+// (this package must not shell out to git), so add mode reports the entered path
+// back to the caller, which validates and either switches or feeds an inline
+// error back via SetAddError.
+type ProjectPickerOverlay struct {
+	all     []Project
+	results []Project
+	query   string
+
+	selectedIdx int
+	width       int
+	maxWidth    int
+	maxHeight   int
+
+	// submitted is set when Enter chose an existing project row (a switch).
+	submitted bool
+	// canceled is set when Esc dismissed the picker from list mode.
+	canceled bool
+
+	// adding is true while the add-project path input is active.
+	adding    bool
+	pathInput string
+	addErr    string
+	// addRequested carries a submitted add-mode path for the caller to validate;
+	// TakeAddRequest consumes it. Kept separate from submitted so the caller can
+	// reject an invalid path (SetAddError) and keep the overlay open.
+	addRequested bool
+}
+
+// NewProjectPickerOverlay creates a picker over the given projects (already
+// sorted by the caller). currentRoot, when non-empty, pre-selects the row for
+// the active project so the highlight starts on "where you are".
+func NewProjectPickerOverlay(projects []Project, currentRoot string) *ProjectPickerOverlay {
+	p := &ProjectPickerOverlay{
+		all:   projects,
+		width: 60,
+	}
+	p.updateResults()
+	for i, proj := range p.results {
+		if proj.Root == currentRoot {
+			p.selectedIdx = i
+			break
+		}
+	}
+	return p
+}
+
+// SetWidth sets the overlay width.
+func (p *ProjectPickerOverlay) SetWidth(width int) { p.width = width }
+
+// SetMaxSize sets the maximum outer size the rendered overlay may occupy.
+func (p *ProjectPickerOverlay) SetMaxSize(width, height int) {
+	p.maxWidth = width
+	p.maxHeight = height
+}
+
+// IsSubmitted reports whether the user chose an existing project (a switch).
+func (p *ProjectPickerOverlay) IsSubmitted() bool { return p.submitted }
+
+// SelectedProject returns the project the user chose, or false when none was.
+func (p *ProjectPickerOverlay) SelectedProject() (Project, bool) {
+	if p.submitted && p.selectedIdx >= 0 && p.selectedIdx < len(p.results) {
+		return p.results[p.selectedIdx], true
+	}
+	return Project{}, false
+}
+
+// rowCount is the number of navigable rows: the filtered projects plus the
+// trailing "+ Add project…" row, which is always present.
+func (p *ProjectPickerOverlay) rowCount() int { return len(p.results) + 1 }
+
+// addRowSelected reports whether the cursor is on the "+ Add project…" row.
+func (p *ProjectPickerOverlay) addRowSelected() bool { return p.selectedIdx == len(p.results) }
+
+// TakeAddRequest returns a submitted add-mode path once, clearing the pending
+// flag so the caller validates it exactly once. The caller registers + switches
+// on success, or calls SetAddError to surface an inline error and keep the
+// overlay open.
+func (p *ProjectPickerOverlay) TakeAddRequest() (string, bool) {
+	if !p.addRequested {
+		return "", false
+	}
+	p.addRequested = false
+	return strings.TrimSpace(p.pathInput), true
+}
+
+// SetAddError shows an inline error under the add-mode input and keeps the
+// overlay open so the user can correct the path.
+func (p *ProjectPickerOverlay) SetAddError(msg string) { p.addErr = msg }
+
+// HandleKeyPress processes input. Returns true if the overlay should close.
+func (p *ProjectPickerOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
+	if p.adding {
+		return p.handleAddKey(msg)
+	}
+	return p.handleListKey(msg)
+}
+
+func (p *ProjectPickerOverlay) handleListKey(msg tea.KeyMsg) bool {
+	switch msg.Type {
+	case tea.KeyEsc, tea.KeyCtrlC:
+		p.canceled = true
+		return true
+	case tea.KeyEnter:
+		if p.addRowSelected() {
+			p.adding = true
+			p.addErr = ""
+			return false
+		}
+		if len(p.results) > 0 {
+			p.submitted = true
+			return true
+		}
+	case tea.KeyUp:
+		if p.selectedIdx > 0 {
+			p.selectedIdx--
+		}
+	case tea.KeyDown:
+		if p.selectedIdx < p.rowCount()-1 {
+			p.selectedIdx++
+		}
+	case tea.KeyBackspace:
+		if len(p.query) > 0 {
+			runes := []rune(p.query)
+			p.query = string(runes[:len(runes)-1])
+			p.updateResults()
+		}
+	case tea.KeySpace:
+		p.query += " "
+		p.updateResults()
+	case tea.KeyRunes:
+		p.query += string(msg.Runes)
+		p.updateResults()
+	}
+	return false
+}
+
+func (p *ProjectPickerOverlay) handleAddKey(msg tea.KeyMsg) bool {
+	switch msg.Type {
+	case tea.KeyEsc, tea.KeyCtrlC:
+		// Back out of add mode to the list rather than closing the picker.
+		p.adding = false
+		p.pathInput = ""
+		p.addErr = ""
+		return false
+	case tea.KeyEnter:
+		if strings.TrimSpace(p.pathInput) != "" {
+			p.addRequested = true
+		}
+		return false
+	case tea.KeyBackspace:
+		if len(p.pathInput) > 0 {
+			runes := []rune(p.pathInput)
+			p.pathInput = string(runes[:len(runes)-1])
+			p.addErr = ""
+		}
+	case tea.KeySpace:
+		p.pathInput += " "
+		p.addErr = ""
+	case tea.KeyRunes:
+		p.pathInput += string(msg.Runes)
+		p.addErr = ""
+	}
+	return false
+}
+
+func (p *ProjectPickerOverlay) updateResults() {
+	p.results = nil
+	for _, proj := range p.all {
+		if p.matches(proj, p.query) {
+			p.results = append(p.results, proj)
+		}
+	}
+	// Clamp selection into the row range (projects + add row).
+	if p.selectedIdx >= p.rowCount() {
+		p.selectedIdx = p.rowCount() - 1
+	}
+	if p.selectedIdx < 0 {
+		p.selectedIdx = 0
+	}
+}
+
+func (p *ProjectPickerOverlay) matches(proj Project, query string) bool {
+	if query == "" {
+		return true
+	}
+	return fuzzyMatch(query, proj.Name) || fuzzyMatch(query, proj.Root)
+}
+
+// visibleWindow returns the [start, end) window over the navigable rows Render
+// shows: at most maxVisible rows, slid so the selected row is always included.
+func (p *ProjectPickerOverlay) visibleWindow(maxVisible int) (startIdx, endIdx int) {
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
+	total := p.rowCount()
+	if p.selectedIdx >= maxVisible {
+		startIdx = p.selectedIdx - maxVisible + 1
+	}
+	endIdx = startIdx + maxVisible
+	if endIdx > total {
+		endIdx = total
+	}
+	return startIdx, endIdx
+}
+
+// Render renders the project picker overlay.
+func (p *ProjectPickerOverlay) Render() string {
+	t := ui.CurrentTheme()
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Accent)
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Warning)
+	normalStyle := lipgloss.NewStyle().Foreground(t.ForegroundMuted)
+	hintStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	queryStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Purple)
+	countStyle := lipgloss.NewStyle().Foreground(t.ForegroundDim)
+	addStyle := lipgloss.NewStyle().Foreground(t.Success)
+	errStyle := lipgloss.NewStyle().Foreground(t.Error)
+
+	style := searchOverlayStyle()
+	fit := fitOverlayContent(p.width, 0, p.maxWidth, p.maxHeight, style)
+	if fit.W <= 0 {
+		fit.W = p.width
+	}
+	if fit.W <= 0 {
+		fit.W = 1
+	}
+	textRect := overlayTextRect(fit, style)
+	cw := textRect.W
+
+	var lines []string
+	lines = append(lines, truncateOverlayLine(titleStyle.Render("Switch Project"), cw))
+	lines = append(lines, "")
+
+	if p.adding {
+		lines = append(lines, truncateOverlayLine(normalStyle.Render("Add project — enter a repo path:"), cw))
+		lines = append(lines, truncateOverlayLine("  "+queryStyle.Render(p.pathInput+"_"), cw))
+		if p.addErr != "" {
+			lines = append(lines, truncateOverlayLine(errStyle.Render("  "+p.addErr), cw))
+		}
+		lines = append(lines, "")
+		hint := "enter add • esc back"
+		lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), cw))
+		return finishRender(style, fit, textRect, lines)
+	}
+
+	lines = append(lines, truncateOverlayLine("/ "+queryStyle.Render(p.query+"_"), cw))
+	lines = append(lines, "")
+
+	// Reserve rows for the fixed chrome (title, blank, query, blank, blank,
+	// hint) and window the navigable rows into what remains.
+	avail := textRect.H - 6
+	if avail < 1 {
+		avail = 1
+	}
+	start, end := p.visibleWindow(avail)
+	if start > 0 {
+		lines = append(lines, truncateOverlayLine(normalStyle.Render(fmt.Sprintf("    ... %d more above", start)), cw))
+	}
+	for i := start; i < end; i++ {
+		lines = append(lines, truncateOverlayLine(p.renderRow(i, selectedStyle, normalStyle, countStyle, addStyle), cw))
+	}
+	if end < p.rowCount() {
+		lines = append(lines, truncateOverlayLine(normalStyle.Render(fmt.Sprintf("    ... and %d more below", p.rowCount()-end)), cw))
+	}
+
+	lines = append(lines, "")
+	hint := "↑/↓ navigate • enter switch • esc close"
+	if lipgloss.Width(hint) > cw {
+		hint = "↑/↓ • enter • esc"
+	}
+	lines = append(lines, truncateOverlayLine(hintStyle.Render(hint), cw))
+
+	return finishRender(style, fit, textRect, lines)
+}
+
+// renderRow renders one navigable row: a project ("name (N)") or the trailing
+// "+ Add project…" affordance, highlighting the selected one.
+func (p *ProjectPickerOverlay) renderRow(i int, selectedStyle, normalStyle, countStyle, addStyle lipgloss.Style) string {
+	selected := i == p.selectedIdx
+	if i == len(p.results) {
+		text := "+ Add project…"
+		if selected {
+			return "  " + selectedStyle.Render("▸ "+text)
+		}
+		return "    " + addStyle.Render(text)
+	}
+	proj := p.results[i]
+	count := countStyle.Render(fmt.Sprintf(" (%d)", proj.SessionCount))
+	if selected {
+		return "  " + selectedStyle.Render("▸ "+proj.Name) + count
+	}
+	return "    " + normalStyle.Render(proj.Name) + count
+}
+
+// finishRender sizes the style box and joins the content lines, matching the
+// search overlay's sizing so both modals size identically.
+func finishRender(style lipgloss.Style, fit, textRect layout.Rect, lines []string) string {
+	style = style.Width(fit.W)
+	if fit.H > 0 && len(lines) >= textRect.H {
+		style = style.Height(fit.H)
+	}
+	return style.Render(strings.Join(lines, "\n"))
+}

--- a/ui/overlay/projectPickerOverlay_test.go
+++ b/ui/overlay/projectPickerOverlay_test.go
@@ -1,0 +1,192 @@
+package overlay
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func pickerFixture() *ProjectPickerOverlay {
+	// Pre-sorted by name, as the app's buildProjectList hands them in:
+	// afterburner, agent-factory, widgets.
+	projects := []Project{
+		{Name: "afterburner", Root: "/repos/afterburner", SessionCount: 0},
+		{Name: "agent-factory", Root: "/repos/agent-factory", SessionCount: 12},
+		{Name: "widgets", Root: "/repos/widgets", SessionCount: 3},
+	}
+	return NewProjectPickerOverlay(projects, "/repos/widgets")
+}
+
+func typeRunes(p *ProjectPickerOverlay, s string) {
+	for _, r := range s {
+		if r == ' ' {
+			p.HandleKeyPress(tea.KeyMsg{Type: tea.KeySpace})
+			continue
+		}
+		p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+}
+
+func resultNames(p *ProjectPickerOverlay) []string {
+	names := make([]string, len(p.results))
+	for i, r := range p.results {
+		names[i] = r.Name
+	}
+	return names
+}
+
+func TestProjectPickerCurrentRootPreselected(t *testing.T) {
+	p := pickerFixture()
+	// widgets sorts after agent-factory/afterburner; results are sorted by name:
+	// afterburner(0), agent-factory(1), widgets(2). currentRoot=/repos/widgets.
+	proj, ok := p.selectedProjectForTest()
+	if !ok || proj.Root != "/repos/widgets" {
+		t.Fatalf("expected the current project preselected, got %+v (ok=%v)", proj, ok)
+	}
+}
+
+func TestProjectPickerFuzzyAndSubstringFilter(t *testing.T) {
+	p := pickerFixture()
+	// "af" is a subsequence of both "agent-factory" and "afterburner" but not
+	// "widgets".
+	typeRunes(p, "af")
+	got := resultNames(p)
+	if len(got) != 2 {
+		t.Fatalf("filter 'af' = %v, want 2 matches", got)
+	}
+	for _, n := range got {
+		if n == "widgets" {
+			t.Fatalf("filter 'af' should not match widgets: %v", got)
+		}
+	}
+}
+
+func TestProjectPickerFilterMatchesPath(t *testing.T) {
+	p := pickerFixture()
+	typeRunes(p, "repos/widg")
+	if got := resultNames(p); len(got) != 1 || got[0] != "widgets" {
+		t.Fatalf("path filter = %v, want [widgets]", got)
+	}
+}
+
+func TestProjectPickerAddRowAlwaysNavigableAndLast(t *testing.T) {
+	p := pickerFixture()
+	// Filter to a single project: rows are [widgets, +Add]. The add row is the
+	// last navigable index and is always reachable, even when the filter empties
+	// the project list.
+	typeRunes(p, "zzz-no-match")
+	if len(p.results) != 0 {
+		t.Fatalf("expected no project matches, got %v", resultNames(p))
+	}
+	if p.rowCount() != 1 {
+		t.Fatalf("add row must remain navigable with an empty filter; rowCount=%d", p.rowCount())
+	}
+	if !p.addRowSelected() {
+		t.Fatalf("with no project matches the cursor should land on the add row")
+	}
+}
+
+func TestProjectPickerEnterSelectsProject(t *testing.T) {
+	p := pickerFixture()
+	// Move to the top project row and submit.
+	for i := 0; i < 5; i++ {
+		p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyUp})
+	}
+	closed := p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	if !closed || !p.IsSubmitted() {
+		t.Fatalf("Enter on a project row should submit and close (closed=%v submitted=%v)", closed, p.IsSubmitted())
+	}
+	proj, ok := p.SelectedProject()
+	if !ok || proj.Name != "afterburner" {
+		t.Fatalf("expected afterburner selected, got %+v (ok=%v)", proj, ok)
+	}
+}
+
+func TestProjectPickerEnterOnAddRowEntersAddMode(t *testing.T) {
+	p := pickerFixture()
+	// Jump to the add row.
+	for i := 0; i < 5; i++ {
+		p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if !p.addRowSelected() {
+		t.Fatalf("cursor should be on the add row")
+	}
+	closed := p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	if closed {
+		t.Fatalf("entering add mode must not close the overlay")
+	}
+	if !p.adding {
+		t.Fatalf("Enter on the add row should switch to add mode")
+	}
+
+	// Type a path; Enter requests the add (does not close), Esc cancels back.
+	typeRunes(p, "/some/repo")
+	if closed := p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}); closed {
+		t.Fatalf("add-mode Enter must not close the overlay (caller validates)")
+	}
+	path, ok := p.TakeAddRequest()
+	if !ok || path != "/some/repo" {
+		t.Fatalf("TakeAddRequest = (%q,%v), want (/some/repo,true)", path, ok)
+	}
+	// Consumed once.
+	if _, ok := p.TakeAddRequest(); ok {
+		t.Fatalf("TakeAddRequest should only fire once")
+	}
+}
+
+func TestProjectPickerAddErrorKeepsOpen(t *testing.T) {
+	p := pickerFixture()
+	for i := 0; i < 5; i++ {
+		p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter}) // enter add mode
+	typeRunes(p, "/bad")
+	p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEnter})
+	p.TakeAddRequest()
+	p.SetAddError("not a git repository: /bad")
+	p.SetMaxSize(80, 24)
+	out := p.Render()
+	if !strings.Contains(out, "not a git repository") {
+		t.Fatalf("add error should render inline; got:\n%s", out)
+	}
+	// Esc from add mode returns to the list without closing.
+	if closed := p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEsc}); closed {
+		t.Fatalf("Esc in add mode should return to the list, not close")
+	}
+	if p.adding {
+		t.Fatalf("Esc should leave add mode")
+	}
+}
+
+func TestProjectPickerEscCancels(t *testing.T) {
+	p := pickerFixture()
+	closed := p.HandleKeyPress(tea.KeyMsg{Type: tea.KeyEsc})
+	if !closed || p.IsSubmitted() {
+		t.Fatalf("Esc should cancel-close without submitting (closed=%v submitted=%v)", closed, p.IsSubmitted())
+	}
+	if !p.canceled {
+		t.Fatalf("Esc should mark the picker canceled")
+	}
+}
+
+func TestProjectPickerRenderShowsCounts(t *testing.T) {
+	p := pickerFixture()
+	p.SetMaxSize(80, 24)
+	out := p.Render()
+	if !strings.Contains(out, "agent-factory") || !strings.Contains(out, "(12)") {
+		t.Fatalf("render should show project names and session counts; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Add project") {
+		t.Fatalf("render should show the add-project affordance; got:\n%s", out)
+	}
+}
+
+// selectedProjectForTest returns the row under the cursor as a Project without
+// requiring submission, for assertions on the initial highlight.
+func (p *ProjectPickerOverlay) selectedProjectForTest() (Project, bool) {
+	if p.selectedIdx >= 0 && p.selectedIdx < len(p.results) {
+		return p.results[p.selectedIdx], true
+	}
+	return Project{}, false
+}

--- a/ui/sidebar_model.go
+++ b/ui/sidebar_model.go
@@ -162,6 +162,11 @@ type Sidebar struct {
 	width    int
 	focused  bool
 
+	// projectName is the active project's display name (repo basename), shown
+	// in the title chip so the rail always names which project is in view after
+	// an in-place project switch (#1461). Empty falls back to "Agent Factory".
+	projectName string
+
 	// rect is the pane's screen rect (SetRect); zone registration needs the
 	// absolute origin, not just the size.
 	rect layout.Rect
@@ -229,6 +234,10 @@ func (s *Sidebar) Focus() { s.focused = true }
 
 // Blur implements layout.Pane.
 func (s *Sidebar) Blur() { s.focused = false }
+
+// SetProjectName sets the active project's display name shown in the title chip
+// (#1461). Empty restores the default "Agent Factory" label.
+func (s *Sidebar) SetProjectName(name string) { s.projectName = name }
 
 // HandleKey implements layout.Pane. Tree navigation stays routed through the
 // root model's global bindings in PR 4 (the keys also work when the workspace

--- a/ui/sidebar_render.go
+++ b/ui/sidebar_render.go
@@ -85,14 +85,15 @@ func (s *Sidebar) String() string {
 	if !s.focused {
 		titleChip = blurredTitle
 	}
+	titleText := s.titleText()
 	if !s.autoyes {
 		b.WriteString(lipgloss.Place(
 			titleWidth, 1, lipgloss.Left, lipgloss.Bottom,
-			titleChip.Render(fitTitleText(" Agent Factory ", titleWidth))))
+			titleChip.Render(fitTitleText(titleText, titleWidth))))
 	} else {
 		title := lipgloss.Place(
 			titleWidth/2, 1, lipgloss.Left, lipgloss.Bottom,
-			titleChip.Render(fitTitleText(" Agent Factory ", titleWidth/2)))
+			titleChip.Render(fitTitleText(titleText, titleWidth/2)))
 		autoYes := lipgloss.Place(
 			titleWidth-(titleWidth/2), 1, lipgloss.Right, lipgloss.Bottom,
 			autoYesStyle.Render(fitTitleText(" auto-yes ", titleWidth-(titleWidth/2))))
@@ -255,6 +256,16 @@ func narrowAwarePad(w int) int {
 		return 0
 	}
 	return 1
+}
+
+// titleText is the title-chip label: the active project's name (#1461) when one
+// is set, otherwise the default " Agent Factory " brand. Both are wrapped in the
+// same single-space padding the chip has always rendered.
+func (s *Sidebar) titleText() string {
+	if s.projectName != "" {
+		return " " + s.projectName + " "
+	}
+	return " Agent Factory "
 }
 
 // fitTitleText truncates a title-bar chip's text to w cells so lipgloss.Place

--- a/ui/store/projection.go
+++ b/ui/store/projection.go
@@ -179,6 +179,25 @@ func (p *Projection) AddInstance(instance *session.Instance) (finalize func()) {
 	return func() { p.RegisterRepoForInstance(instance) }
 }
 
+// ResetInstances clears every instance, the repo bookkeeping, and the sticky
+// selection so the projection can be re-primed from a different repo's snapshot.
+// It is the store half of the in-place project switch (#1461): the daemon is
+// filtered by repoID, so after the switch coldStartFromSnapshot re-adds only the
+// new project's instances into this now-empty list — no cross-repo bleed.
+//
+// Open panes are NOT touched here: the app owns pane windows (and their live
+// termpane attachments) via its paneWindows map, so it must close every pane
+// through closePaneWindow BEFORE calling this, or the pane windows and their
+// PTYs would leak. Callers relayout afterwards.
+func (p *Projection) ResetInstances() {
+	p.instances = nil
+	p.repos = make(map[string]int)
+	p.selected = nil
+	p.activeTab.Store(0)
+	p.selectionSeq++
+	p.bump()
+}
+
 // sortInstances re-establishes the deterministic sidebar/tree order on the
 // instance list: root-first by reserved identity, then oldest-first by
 // CreatedAt (see LessInstanceOrder, #1144). Keeping GetInstances() sorted at


### PR DESCRIPTION
Closes #1461.

## What

Switch the active project/repo from inside the running TUI — no more exiting and relaunching in another directory. A keybind opens a searchable project-picker overlay; picking a project swaps the sidebar to that project's sessions and re-targets new sessions/tabs at it.

## Design (locked by Sachin; [plan comment](https://github.com/sachiniyer/agent-factory/issues/1461#issuecomment-4932804365) approved by root)

- **Trigger — `ctrl+p`** (config key `switch_project`, rebindable). Not `P`: the capital keys are deliberately left free so users can *pin* `copy_pr`/`archive`/`hooks` to them via `[keys]`, and a new default on `P` would collide with such a pin and hard-error at boot (`TestOldDefaultsCanBePinnedViaOverrides`). `ctrl+p` is free, has the VS Code "quick-open" mnemonic, and sits alongside the existing `ctrl+u`/`ctrl+d`/`ctrl+]`.
- **Overlay** — mirrors the search-overlay idiom (RoundedBorder + Accent, hand-rolled query buffer, windowed list, reuses `fuzzyMatch`). Rows are `name (N)` with a per-project session count; type-to-filter (fuzzy over name + path), Enter switches, Esc cancels. A trailing `+ Add project…` row enters a path-input mode.
- **View scope** — switching re-scopes the running `home` to the target `repoID`/`repoRoot` and re-primes the projection from the daemon snapshot, which the daemon already filters by `repoID`. The sidebar shows **only** the active project (full swap, no interleaving, no cross-repo bleed). The sidebar title chip surfaces the active project name. New sessions/tabs target the active project's repo root (`startNewInstance` no longer hardcodes cwd `"."`).
- **Discovery (zero-config)** — the cross-repo daemon snapshot (`RepoID:""`, grouped for counts) unioned with `root_agents` opt-ins and the active project. `+ Add project…` validates a repo path (`config.RepoFromPath`), registers it in the global `root_agents` list, and switches.

## Architecture notes (#960)

The daemon stays the single writer. The TUI does **no** session-state disk writes: "switch project" is purely a change of the TUI's active-repo scope + a re-render from the daemon snapshot. On switch, open panes (and their live termpane PTYs) are torn down and the outgoing project's view state is flushed first, so no stale pane renders against the new repo. The only disk write is `RegisterRootAgent` — a load-modify-persist of the global `config.toml` (config, not session state), idempotent and non-clobbering.

## Files

- `keys/keys.go` — `KeySwitchProject` / `switch_project` (`ctrl+p`).
- `ui/overlay/projectPickerOverlay.go` — the overlay (list + add-path modes).
- `app/switch_project.go` — discovery, overlay wiring, and `switchProject()`.
- `ui/store/projection.go` — `ResetInstances()`; `ui/sidebar_*` — active-project title.
- `config/rootagent_register.go` — `RegisterRootAgent`; `task/task.go` — `LoadTasksForRepo`.
- `app/handle_input.go` — new sessions target `m.repoRoot`; help + mouse-hint wiring.

## Tests

- `ui/overlay/projectPickerOverlay_test.go` — fuzzy/substring filter, count formatting, `+ Add` row always navigable/last, nav clamping, Enter/Esc in both modes, add-mode validation error stays open.
- `app/switch_project_test.go` — switch swaps `repoID`/`repoRoot`, sidebar shows only the target project (**explicit assertion the previous project's sessions are absent**), header updates, new sessions target the new root, add-project rejects non-git paths and registers+switches valid ones, same-repo switch is a no-op, discovery unions sources with counts.
- `config/rootagent_register_test.go`, `task/task_test.go` — helper coverage.

## Gates

`gofmt -l .` clean · `go build ./...` · `golangci-lint run --fast` · `deadcode -test ./...` · `scripts/lint-file-length.sh` · full suite via `make test-container` — all green.

Not merging: this is a visible-TUI change, so root will play-test (`make tui-driver-selftest`) + Greptile-gate + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
