### PR TITLE
fix(tui): clear pending task-create/trigger on overlay close (#1531)

### DIFF
--- a/app/handle_overlay_test.go
+++ b/app/handle_overlay_test.go
@@ -368,6 +368,98 @@ func TestHandleStateTasks_PendingTriggerSurvivesDeleteFailureReloadByID(t *testi
 		"pending trigger must resolve by task ID after the failed-delete reload")
 }
 
+// TestHandleStateTasks_FailedCreateDoesNotDuplicateOnReopen covers #1531: when
+// a create is submitted but its pre-create flush (saveContentPaneState) fails,
+// handleTaskCreate never runs and pendingCreate is left set. Pre-fix, that flag
+// survived the overlay close, so reopening the manager (which drops straight
+// into the selected task's edit form, #1249) and pressing any key fired
+// HasPendingCreate() → handleTaskCreate() against the reloaded buffers,
+// duplicating the selected task. The fix clears the stuck pending create on the
+// failed-flush reload (SetTasks) and on overlay close (SetFocus(false)), so no
+// phantom task is created.
+func TestHandleStateTasks_FailedCreateDoesNotDuplicateOnReopen(t *testing.T) {
+	h := newTestHome(t)
+	h.errBox.SetSize(500, 1)
+
+	repoDir := setupRealRepo(t)
+	t.Chdir(repoDir)
+	repo, err := config.CurrentRepo()
+	require.NoError(t, err)
+	h.repoID = repo.ID
+
+	existing := task.Task{
+		ID: "existing-1531", Name: "nightly", Prompt: "do something",
+		CronExpr: "* * * * *", ProjectPath: repo.Root, Program: "claude",
+		Enabled: true, CreatedAt: time.Now(),
+	}
+	require.NoError(t, task.AddTask(existing))
+
+	loaded, err := task.LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	tp := h.automations.TaskPane()
+	tp.SetTasks(loaded)
+	h.store.SetTasks(loaded)
+
+	// Record every create routed through the daemon RPC seam.
+	var creates []task.Task
+	t.Cleanup(SetTaskAdderForTest(func(tk task.Task) error {
+		creates = append(creates, tk)
+		return task.AddTask(tk)
+	}))
+
+	_, _ = h.showTasksOverlay()
+	require.Equal(t, stateTasks, h.state)
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc}) // edit form -> list
+
+	// Toggle the task so the pre-create flush has dirty state to persist.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	require.True(t, tp.IsDirty(), "toggle must mark the pane dirty")
+
+	// Force the pre-create flush to fail, so the create is submitted but
+	// handleTaskCreate never runs and pendingCreate is stranded.
+	restoreUpdater := SetTaskUpdaterForTest(func(task.Task) error {
+		return fmt.Errorf("daemon RPC failure")
+	})
+
+	// Fill and submit the inline create form.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	require.True(t, tp.IsCreating(), "'n' must open the inline create form")
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("dup-task")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> trigger selector
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> cron value
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("* * * * *")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> prompt
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("dup prompt")})
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> target session
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> path
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> program
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab}) // -> save button
+	_, cmd := h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd, "the failed pre-create flush must surface an error")
+	require.Empty(t, creates, "the create must not have persisted — its flush failed")
+
+	// The transient failure clears; a later flush would succeed.
+	restoreUpdater()
+
+	// Esc closes the overlay.
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyEsc})
+	require.Equal(t, stateDefault, h.state, "Esc must close the tasks overlay")
+
+	// Reopen (drops into the selected task's edit form) and press a key that
+	// keeps focus so the HasPendingCreate branch is reached. Pre-fix this fired
+	// handleTaskCreate against the reloaded buffers and duplicated the task.
+	_, _ = h.showTasksOverlay()
+	require.Equal(t, stateTasks, h.state)
+	_, _ = h.handleStateTasks(tea.KeyMsg{Type: tea.KeyTab})
+
+	assert.Empty(t, creates,
+		"reopening after a failed create must NOT create a duplicate task (#1531)")
+	disk, err := task.LoadTasksForCurrentRepo()
+	require.NoError(t, err)
+	assert.Len(t, disk, 1, "only the original task remains — no phantom duplicate")
+}
+
 // TestHandleTaskCreate_RoutesThroughDaemonRPC is the #1029 PR 6 guard for the
 // create path: the TUI inline create form must persist the new task through the
 // daemon RPC — the sole writer of tasks.json among clients (#960) — not by

--- a/ui/task_pane_state.go
+++ b/ui/task_pane_state.go
@@ -14,6 +14,15 @@ func (s *TaskPane) SetTasks(tasks []task.Task) {
 	s.dirtyIDs = nil
 	s.deleted = nil
 	s.editing = false
+	// A reload replaces the create-form buffers a pending create was captured
+	// against, so a create left un-consumed by a failed save must be dropped —
+	// otherwise the next keypress after reopen fires it against the wrong
+	// (reloaded) buffers and duplicates the now-selected task (#1531). Only
+	// pendingCreate is cleared here: pendingTrigger is deliberately left intact
+	// because saveContentPaneState reloads via SetTasks mid-flush and a pending
+	// run-now must survive that reload to resolve by task ID (#1474). The
+	// overlay-close path clears pendingTrigger instead (SetFocus(false)).
+	s.pendingCreate = false
 	if len(s.tasks) == 0 {
 		s.selectedIdx = 0
 	} else if s.selectedIdx >= len(s.tasks) {
@@ -102,6 +111,13 @@ func (s *TaskPane) SetFocus(focus bool) {
 	if !focus {
 		s.editing = false
 		s.creating = false
+		// Closing the overlay (Esc drops focus) must also drop any pending
+		// create/trigger whose save failed and left it un-consumed: otherwise
+		// it survives the close and fires on the next keypress after reopen,
+		// against the reloaded buffers, duplicating a task (#1531).
+		s.pendingCreate = false
+		s.pendingTrigger = false
+		s.pendingTriggerID = ""
 	}
 }
 

--- a/ui/task_pane_test.go
+++ b/ui/task_pane_test.go
@@ -1120,6 +1120,46 @@ func TestTaskPaneCreateModeEnterSubmitsFromAnyField(t *testing.T) {
 	assert.False(t, tp.creating)
 }
 
+// TestTaskPaneCloseClearsPendingCreateAndTrigger pins #1531: when a create/run
+// is submitted but its save fails, the pending request is left un-consumed. Esc
+// then closes the overlay (SetFocus(false)); the pending flag must be dropped
+// there, or on reopen the next keypress fires it against the reloaded buffers
+// and duplicates the selected task.
+func TestTaskPaneCloseClearsPendingCreateAndTrigger(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{ID: "a", Name: "A", Enabled: true}})
+	tp.SetFocus(true)
+	tp.pendingCreate = true
+	tp.pendingTrigger = true
+	tp.pendingTriggerID = "a"
+
+	tp.SetFocus(false)
+
+	assert.False(t, tp.HasPendingCreate(), "closing the overlay must drop a pending create")
+	assert.False(t, tp.HasPendingTrigger(), "closing the overlay must drop a pending trigger")
+	assert.Empty(t, tp.pendingTriggerID)
+}
+
+// TestTaskPaneSetTasksClearsPendingCreateButKeepsPendingTrigger pins the
+// asymmetry the #1531 fix must preserve: a reload (SetTasks) replaces the
+// create-form buffers, so a stale pending create is dropped — but a pending
+// run-now must SURVIVE the reload so it can resolve by task ID after
+// saveContentPaneState's mid-flush failure reload (#1474).
+func TestTaskPaneSetTasksClearsPendingCreateButKeepsPendingTrigger(t *testing.T) {
+	tp := NewTaskPane()
+	tp.SetTasks([]task.Task{{ID: "a", Name: "A", Enabled: true}})
+	tp.pendingCreate = true
+	tp.pendingTrigger = true
+	tp.pendingTriggerID = "a"
+
+	tp.SetTasks([]task.Task{{ID: "a", Name: "A", Enabled: true}})
+
+	assert.False(t, tp.HasPendingCreate(), "a reload must drop a stale pending create (#1531)")
+	assert.True(t, tp.HasPendingTrigger(),
+		"a reload must NOT drop a pending run-now — it resolves by ID after a failed-save reload (#1474)")
+	assert.Equal(t, "a", tp.pendingTriggerID)
+}
+
 // TestTaskPaneCreateModeEnterMovesFocusToInvalidField: submitting an invalid
 // form from any field surfaces the inline error AND moves focus to the
 // offending field, so the error is in view even when the clamped form has it


### PR DESCRIPTION
## Summary

Fixes #1531 — a failed create submission in the tasks overlay could duplicate the selected task on the next overlay open.

### The bug

Submitting the inline create form sets `pendingCreate` **without** releasing focus. The overlay handler (`handleStateTasks`) then flushes dirty edits (`saveContentPaneState`) *before* running `handleTaskCreate`. When that flush fails, the handler surfaces the error and returns **without** running `handleTaskCreate` — leaving `pendingCreate` set.

`SetFocus(false)` (Esc close) cleared `editing`/`creating` but **not** `pendingCreate`, so the stale flag survived the close. On reopen the manager drops straight into the selected task's edit form (#1249); the next keypress hit `HasPendingCreate()` → `handleTaskCreate()` against the **reloaded** buffers, creating a duplicate of the selected task.

### The fix

Clear the stranded pending request in two places:

- **`SetFocus(false)`** — closing the overlay abandons both a pending create *and* a pending trigger.
- **`SetTasks()`** — the failed-flush reload replaces the create-form buffers, so a stale pending **create** is dropped there too.

**Important asymmetry:** `pendingTrigger` is deliberately **not** cleared in `SetTasks()`. `saveContentPaneState` reloads via `SetTasks` mid-flush, and a pending run-now must **survive** that reload to resolve by task ID (#1474 / `TestHandleStateTasks_PendingTriggerSurvivesDeleteFailureReloadByID`). Clearing it there would regress that feature. The overlay-close path (`SetFocus(false)`) is where a pending trigger is abandoned.

### Tests

- `TestTaskPaneCloseClearsPendingCreateAndTrigger` / `TestTaskPaneSetTasksClearsPendingCreateButKeepsPendingTrigger` — unit guards for the clearing + the #1474 survival exception.
- `TestHandleStateTasks_FailedCreateDoesNotDuplicateOnReopen` — end-to-end: failed create → close → reopen → keypress. Reproduced the duplicate pre-fix (verified by reverting the fix — 2 tasks on disk), green after.

### Verification

`gofmt`, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`, file-length lint all clean. `./ui/...` and `./app/...` green in the test container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)