### PR TITLE
fix(tui): offset embedded-terminal mouse Y by hidden status rows on status-top (#1534)

### DIFF
--- a/ui/termpane/mouse.go
+++ b/ui/termpane/mouse.go
@@ -15,20 +15,30 @@ import (
 
 // SendMouse forwards one mouse event to the embedded terminal at grid cell
 // (x, y) — pane-content-local coordinates, which the zone registry's local
-// point already is. It reports whether the event had a translation; false
-// means the event type has no encoding and was ignored (never a guessed
-// sequence), mirroring SendKey's contract. Whether a translated event
-// actually reaches the inner app is the emulator's mode-aware call. The lock
-// is required even though this only writes input: the encoder reads terminal
-// modes (mouse tracking, SGR encoding) that the PTY reader pump mutates
-// through emu.Write.
+// point already is. It reports whether the event was forwarded; false means it
+// was ignored — either the event type has no encoding (never a guessed
+// sequence, mirroring SendKey's contract) or it fell outside the live grid
+// during a resize gap. Whether a forwarded event actually reaches the inner app
+// is the emulator's mode-aware call. The lock is required even though this only
+// writes input: the encoder reads terminal modes (mouse tracking, SGR encoding)
+// that the PTY reader pump mutates through emu.Write.
 func (t *TermPane) SendMouse(msg tea.MouseMsg, x, y int) bool {
-	ev, ok := translateMouse(msg, x, t.mouseGridY(y))
+	gridY := t.mouseGridY(y)
+	ev, ok := translateMouse(msg, x, gridY)
 	if !ok {
 		return false
 	}
 	t.gridMu.RLock()
 	defer t.gridMu.RUnlock()
+	// During a resize gap the pane zone can grow before the embedded terminal
+	// is resized to match, so a click in the not-yet-propagated region — pushed
+	// further down by the status-top offset above — can land past the current
+	// emulator grid. Forwarding it would encode a bogus row/col the inner app
+	// never drew, so drop any event outside the live grid instead (#1534). The
+	// bounds read the emulator under the same lock SendMouse already holds.
+	if gridY < 0 || gridY >= t.emu.Height() || x < 0 || x >= t.emu.Width() {
+		return false
+	}
 	t.emu.SendMouse(ev)
 	return true
 }

--- a/ui/termpane/mouse.go
+++ b/ui/termpane/mouse.go
@@ -23,7 +23,7 @@ import (
 // modes (mouse tracking, SGR encoding) that the PTY reader pump mutates
 // through emu.Write.
 func (t *TermPane) SendMouse(msg tea.MouseMsg, x, y int) bool {
-	ev, ok := translateMouse(msg, x, y)
+	ev, ok := translateMouse(msg, x, t.mouseGridY(y))
 	if !ok {
 		return false
 	}
@@ -31,6 +31,22 @@ func (t *TermPane) SendMouse(msg tea.MouseMsg, x, y int) bool {
 	defer t.gridMu.RUnlock()
 	t.emu.SendMouse(ev)
 	return true
+}
+
+// mouseGridY maps a zone-local content row to the emulator grid row. With the
+// status bar at the top, Render draws the visible window starting at
+// sourceY=statusRows so the status rows stay hidden; a forwarded click's y must
+// shift down by that same hidden-row count, or the first statusRows visible
+// rows would send events into the hidden status area instead of the row the
+// user actually clicked (#1534). With the status bar at the bottom the hidden
+// rows are past the visible window, so no shift applies. statusPosition and
+// statusRows are set once at construction, so this needs no grid lock. Mirrors
+// Render's sourceY.
+func (t *TermPane) mouseGridY(y int) int {
+	if t.statusPosition == statusTop {
+		return y + t.statusRows
+	}
+	return y
 }
 
 // translateMouse maps a bubbletea v1 mouse message to the emulator's event

--- a/ui/termpane/mouse_test.go
+++ b/ui/termpane/mouse_test.go
@@ -92,6 +92,30 @@ func TestMouseGridYOffsetsForTopStatusOnly(t *testing.T) {
 	assert.Equal(t, 4, none.mouseGridY(4), "zero hidden rows: top status is a no-op")
 }
 
+// TestMouseResizeGapDropsEventPastGrid pins the #1534 review finding: during a
+// resize gap the pane zone can grow before the embedded terminal is resized to
+// match, so a click below the emulator's current grid — pushed further by the
+// status-top offset — must be DROPPED, not forwarded as a bogus row the inner
+// app never drew.
+func TestMouseResizeGapDropsEventPastGrid(t *testing.T) {
+	// Visible height 6, 2 hidden top status rows → emulator grid height 8;
+	// visible content occupies rows [2, 8), i.e. zone-local y in [0, 6).
+	tp := startScriptWithStatusLayout(t, "sleep 30", 30, 6, 2, statusTop)
+	require.Equal(t, 8, tp.emu.Height(), "grid height is visible rows + hidden status rows")
+	require.Equal(t, 30, tp.emu.Width())
+
+	click := mouseMsg(tea.MouseActionPress, tea.MouseButtonLeft, 0, 0)
+
+	assert.True(t, tp.SendMouse(click, 3, 5),
+		"a click on the last visible row (grid row 7) maps in-bounds and forwards")
+	assert.False(t, tp.SendMouse(click, 3, 6),
+		"a click one row into the resize gap lands at grid row 8, past the grid, and is dropped")
+	assert.False(t, tp.SendMouse(click, 3, 20),
+		"a click well past the grid is dropped, not forwarded as a bogus row")
+	assert.False(t, tp.SendMouse(click, 30, 5),
+		"a click past the last column is dropped too")
+}
+
 // TestTranslateMouseUnknownButton: buttons with no encoding are refused, not
 // guessed — SendKey's ignore contract, extended to the mouse.
 func TestTranslateMouseUnknownButton(t *testing.T) {

--- a/ui/termpane/mouse_test.go
+++ b/ui/termpane/mouse_test.go
@@ -74,6 +74,24 @@ func TestMouseForwardingSuppressedWithoutInnerMouseMode(t *testing.T) {
 	assert.Empty(t, got, "no mouse mode set → no bytes reach the PTY")
 }
 
+// TestMouseGridYOffsetsForTopStatusOnly pins #1534: with the status bar at the
+// top, Render hides the first statusRows rows (sourceY=statusRows), so a
+// forwarded click's zone-local y must shift down by statusRows to land on the
+// visible row the user clicked. With the status bar at the bottom the hidden
+// rows are off the end of the visible window, so no shift applies.
+func TestMouseGridYOffsetsForTopStatusOnly(t *testing.T) {
+	top := &TermPane{statusPosition: statusTop, statusRows: 2}
+	assert.Equal(t, 2, top.mouseGridY(0), "top status: click on visible row 0 maps past the hidden status rows")
+	assert.Equal(t, 5, top.mouseGridY(3), "top status: every content row shifts down by statusRows")
+
+	bottom := &TermPane{statusPosition: statusBottom, statusRows: 2}
+	assert.Equal(t, 0, bottom.mouseGridY(0), "bottom status: no hidden rows above content, no shift")
+	assert.Equal(t, 3, bottom.mouseGridY(3), "bottom status: content row maps 1:1")
+
+	none := &TermPane{statusPosition: statusTop, statusRows: 0}
+	assert.Equal(t, 4, none.mouseGridY(4), "zero hidden rows: top status is a no-op")
+}
+
 // TestTranslateMouseUnknownButton: buttons with no encoding are refused, not
 // guessed — SendKey's ignore contract, extended to the mouse.
 func TestTranslateMouseUnknownButton(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #1534 — embedded-terminal mouse clicks were offset when the tmux status bar is positioned at the top.

### The bug

With `status-position top`, `Render` draws the visible pane window starting at `sourceY = statusRows`, so the `statusRows` status rows at the top of the emulator grid are never shown. Mouse events, however, arrive **zone-local to the visible content** — `local.Y = 0` is the top *visible* row.

`SendMouse` forwarded that `y` straight to the emulator without accounting for the hidden rows, so a click on the first `statusRows` visible rows was encoded as a click into the **hidden status area**, and every click was off by `statusRows`.

### The fix

Mirror `Render`'s `sourceY` in the mouse path. Extracted `mouseGridY(y)`:

- `statusPosition == statusTop` → `y + statusRows` (shift past the hidden top rows)
- `statusBottom` → `y` unchanged (the hidden rows are *past* the visible window)

`statusPosition`/`statusRows` are set once at construction, so the mapping takes no grid lock.

### Test

`TestMouseGridYOffsetsForTopStatusOnly` asserts the offset is applied for `statusTop`, is a no-op for `statusBottom`, and is a no-op when `statusRows == 0`.

### Verification

`gofmt`, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`, file-length lint all clean. `./ui/termpane/...` green in the test container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)