### PR TITLE
fix(daemon): make event-queue compaction crash-safe so a stale cursor can't wedge the queue (#1537)

### DIFF
--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -163,6 +163,18 @@ func (q *eventQueue) load() {
 		return
 	}
 	defer func() { _ = f.Close() }()
+
+	// Defense-in-depth (#1537): a cursor that clears the off<=size bound can
+	// still point into the MIDDLE of a record — e.g. a crash during compaction
+	// that shrank the file but left a pre-compaction offset behind. Records
+	// always end in '\n', so a real interior boundary has '\n' immediately
+	// before it; if q.offset isn't one, replay from the start rather than
+	// parking the drainer forever on an unreadable head (redelivering a few
+	// already-delivered events is at-least-once, a wedged queue is not).
+	if !q.offsetIsRecordBoundaryLocked(f) {
+		log.WarningLog.Printf("watch task %s: event-queue cursor %d is not on a record boundary; replaying the queue from the start", q.taskID, q.offset)
+		q.offset = 0
+	}
 	if _, err := f.Seek(q.offset, 0); err != nil {
 		return
 	}
@@ -365,14 +377,14 @@ func (q *eventQueue) removeDrainedFilesLocked() (bool, error) {
 }
 
 // compactLocked rewrites the queue file to just its pending suffix, dropping
-// the delivered prefix: copy suffix → temp file → rename over the original,
-// then reset the in-memory offset (the caller persists the cursor). Crash
-// safety is rename-based: a crash before the rename leaves the old
-// consistent (file, cursor) pair; a crash after the rename but before the
-// cursor write leaves a stale cursor pointing past the smaller new file,
-// which load()'s off<=size validation rejects — resetting to 0 and
-// redelivering the pending suffix (at-least-once, never loss). Callers hold
-// q.mu.
+// the delivered prefix: copy suffix → temp file → persist cursor 0 → rename
+// over the original → reset the in-memory offset. Crash safety comes from the
+// cursor-before-rename ordering (#1537): the post-compaction cursor is 0, and
+// it is made durable BEFORE the rename shrinks the file, so no crash can leave
+// the small compacted file beside a stale offset that points mid-record. Every
+// crash point leaves a record-aligned (file, cursor) pair; the worst case
+// redelivers an already-delivered prefix (at-least-once, never loss). Callers
+// hold q.mu.
 func (q *eventQueue) compactLocked() error {
 	src, err := os.Open(q.path)
 	if err != nil {
@@ -395,12 +407,45 @@ func (q *eventQueue) compactLocked() error {
 		_ = os.Remove(tmpName)
 		return err
 	}
+	// Persist the post-compaction cursor (0) durably BEFORE the rename shrinks
+	// the file, closing the crash window that used to wedge the queue (#1537).
+	// The old ordering renamed first and left the caller to persist the cursor
+	// after, so a crash in between paired the small compacted file with a stale
+	// pre-compaction offset pointing mid-record. Cursor-before-rename makes every
+	// crash point consistent and record-aligned: before this write, old file +
+	// old offset; after it but before the rename, old file + cursor 0 (redelivers
+	// the delivered prefix); after the rename, compacted file + cursor 0.
+	if err := q.persistCursorValueLocked(0); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
 	if err := os.Rename(tmpName, q.path); err != nil {
 		_ = os.Remove(tmpName)
+		// The file is still the old (large) one but the cursor is now 0; restore
+		// the real offset so the on-disk pair stays consistent (a crash before
+		// this restore just redelivers the delivered prefix — at-least-once).
+		if rerr := q.persistCursorLocked(); rerr != nil {
+			return fmt.Errorf("compaction rename failed (%v); cursor restore also failed: %w", err, rerr)
+		}
 		return err
 	}
 	q.offset, q.size = 0, n
 	return nil
+}
+
+// offsetIsRecordBoundaryLocked reports whether q.offset begins a record in the
+// open queue file f. Offset 0 and offset>=size are boundaries by definition;
+// any interior offset is a boundary iff the byte before it is the record
+// terminator '\n'. ReadAt leaves f's seek position untouched. Callers hold q.mu.
+func (q *eventQueue) offsetIsRecordBoundaryLocked(f *os.File) bool {
+	if q.offset <= 0 || q.offset >= q.size {
+		return true
+	}
+	var b [1]byte
+	if _, err := f.ReadAt(b[:], q.offset-1); err != nil {
+		return false
+	}
+	return b[0] == '\n'
 }
 
 // readEventAtLocked reads and parses one JSONL record at the given offset,
@@ -428,8 +473,16 @@ func (q *eventQueue) readEventAtLocked(off int64) (queuedEvent, int64, error) {
 	return ev, int64(len(raw)), nil
 }
 
-// persistCursorLocked writes the cursor file. Atomic (write+rename) so a torn
-// write can never yield a cursor pointing mid-record. Callers hold q.mu.
+// persistCursorLocked writes the current cursor (q.offset). Atomic
+// (write+rename) so a torn write can never yield a cursor pointing mid-record.
+// Callers hold q.mu.
 func (q *eventQueue) persistCursorLocked() error {
-	return config.AtomicWriteFile(q.curPath, []byte(strconv.FormatInt(q.offset, 10)), 0644)
+	return q.persistCursorValueLocked(q.offset)
+}
+
+// persistCursorValueLocked durably writes an explicit cursor value. Compaction
+// uses it to record the post-rewrite offset (0) BEFORE the rename that shrinks
+// the file (#1537). Callers hold q.mu.
+func (q *eventQueue) persistCursorValueLocked(off int64) error {
+	return config.AtomicWriteFile(q.curPath, []byte(strconv.FormatInt(off, 10)), 0644)
 }

--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -457,6 +457,64 @@ func TestEventQueue_CompactsDeliveredPrefix(t *testing.T) {
 	}
 }
 
+// TestEventQueue_RecoversFromStaleCursorAfterCompactionCrash (#1537): a daemon
+// crash AFTER compaction's rename but BEFORE the cursor write used to pair the
+// small compacted file with a PRE-compaction offset pointing into the middle of
+// a record. load()'s old off<=size check passed it, every subsequent read then
+// failed with "corrupt event record", and the drainer parked forever. The queue
+// must instead recover by replaying the pending suffix from the start.
+func TestEventQueue_RecoversFromStaleCursorAfterCompactionCrash(t *testing.T) {
+	dir := t.TempDir()
+
+	// Hand-build the exact on-disk state a crash between compaction's rename and
+	// its cursor write leaves behind: the queue file holds ONLY the pending
+	// suffix (events 5..9, as if the delivered prefix was already compacted
+	// away), while the cursor file still holds a stale PRE-compaction offset that
+	// lands mid-record within the now-smaller file. Enqueueing the suffix into a
+	// fresh queue produces that compacted file without depending on real
+	// compaction's byte-threshold timing.
+	q0 := newEventQueue(dir, "ab153701")
+	for i := 5; i < 10; i++ {
+		if err := q0.enqueue(fmt.Sprintf("event-%d", i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+	q0.mu.Lock()
+	size := q0.size
+	q0.mu.Unlock()
+
+	// Offset 3 sits inside event-5's record: 0 < 3 < size, and the byte before
+	// it is not '\n', so it clears off<=size but is not a record boundary.
+	staleOffset := int64(3)
+	if staleOffset >= size {
+		t.Fatalf("test bug: stale offset %d must be < compacted size %d", staleOffset, size)
+	}
+	curPath := filepath.Join(dir, "ab153701.cursor")
+	if err := os.WriteFile(curPath, []byte(fmt.Sprintf("%d", staleOffset)), 0644); err != nil {
+		t.Fatalf("write stale cursor: %v", err)
+	}
+
+	// Reopen: the queue must recover and redeliver events 5..9 in order rather
+	// than parking the drainer on an unreadable head.
+	reopened := newEventQueue(dir, "ab153701")
+	if got := reopened.pendingCount(); got != 5 {
+		t.Fatalf("recovered pending = %d, want 5", got)
+	}
+	for i := 5; i < 10; i++ {
+		ev, cursor, ok, err := reopened.peek()
+		if err != nil || !ok {
+			t.Fatalf("recovered peek %d: ok=%v err=%v", i, ok, err)
+		}
+		if want := fmt.Sprintf("event-%d", i); ev.Line != want {
+			t.Fatalf("recovery reordered/corrupted: got %q, want %q", ev.Line, want)
+		}
+		advanceEventQueue(t, reopened, cursor)
+	}
+	if got := reopened.pendingCount(); got != 0 {
+		t.Fatalf("pending after recovery drain = %d, want 0", got)
+	}
+}
+
 // TestWatcherDrainExpiresAgedEvents (#1129 PR 4): queued events older than
 // the retention bound are expired at drain time — never delivered — and a
 // fresh event still replays. Expiry empties the queue files like a normal


### PR DESCRIPTION
## Problem

The durable watch-task event queue (`daemon/eventqueue.go`) compacts a queue file by rewriting its pending suffix to a temp file, `os.Rename`-ing it over the original, and having `advance()` persist the cursor **afterward**.

A daemon crash **after** the rename but **before** `persistCursorLocked()` leaves the small **compacted** file (pending suffix only) beside the **pre-compaction** cursor offset. On restart, `load()` validated the cursor with only `off <= q.size` — with a backlog the stale offset is often inside the smaller file yet lands in the **middle of a JSON record**. It passes validation, every subsequent read fails with `corrupt event record`, the drainer parks, and reload repeats. The queue is **permanently wedged** until an operator manually deletes the queue/cursor files.

(With production defaults the delivered prefix, 1 MiB, dwarfs the pending cap, 256 KiB, so the stale offset usually overshoots the compacted size and `off<=size` incidentally catches it — but that safety is a fragile magnitude coincidence, not a real boundary guarantee.)

## Fix

Structural (ordering/atomicity), not a validation band-aid — both layers requested in the report:

- **Primary — cursor-before-rename.** `compactLocked` now persists the post-compaction cursor (`0`) **durably before** the rename that shrinks the file (`config.AtomicWriteFile` is fsync+rename). Every crash point now leaves a record-aligned `(file, cursor)` pair; the worst case redelivers an already-delivered prefix (at-least-once, never loss). If the rename itself fails after the cursor write, the real offset is restored so the on-disk pair stays consistent with the un-compacted file.
- **Defense-in-depth — record-boundary validation on load.** `load()` now rejects a cursor that isn't on a record boundary (offset `0`/`size`, or the byte before it is the `'\n'` terminator) via `offsetIsRecordBoundaryLocked`, and replays from the start instead of parking the drainer on an unreadable head.

## Test

`TestEventQueue_RecoversFromStaleCursorAfterCompactionCrash` hand-builds the exact crash state — a compacted pending-suffix file plus a stale mid-record cursor — and asserts the queue **recovers** and redelivers pending events in order. Verified it **fails without the fix** (`corrupt event record at offset 3`, drainer parks) and **passes with it**.

## Verification

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — passed
- `make test-container GOTESTARGS='./daemon -count=1'` — **ok** (full daemon package, incl. the new test)

Fixes #1537

🤖 Generated with [Claude Code](https://claude.com/claude-code)