### PR TITLE
fix(tui): show auto-hidden status for panes hidden on restore (#1535)

### DIFF
--- a/app/home_model.go
+++ b/app/home_model.go
@@ -175,6 +175,14 @@ type home struct {
 	// pane is auto-hidden by width pressure. Callers that can return a tea.Cmd
 	// consume it to start the same transient clear timer normal errors use.
 	pendingPaneAutoHideStatus string
+	// restoredPaneBaseline holds the panes reopened from persisted TUI state so
+	// the first real (non-fallback) relayout after launch can detect panes the
+	// terminal is too narrow to fit. The restore-time relayout runs at term
+	// (0,0) → fallback → visiblePanes=nil, so without a baseline the first
+	// WindowSizeMsg sees an empty previousVisible and newlyAutoHiddenPane never
+	// surfaces the "N hidden: terminal too narrow" status (#1535). Consumed once
+	// on the first non-fallback relayout.
+	restoredPaneBaseline []*store.OpenPane
 	// lastPaneCapture is when each pane's capture was last dispatched, keyed
 	// by pane id; the paneCaptureMinInterval throttle reads it (RFC §5.2).
 	lastPaneCapture map[int]time.Time
@@ -446,6 +454,16 @@ func (m *home) relayout() {
 		m.syncFocus()
 		return
 	}
+
+	// First real relayout after a restore: the restore-time relayout ran at
+	// (0,0) and fell through to fallback with visiblePanes=nil, so the restored
+	// panes are the visibility baseline this pass uses to detect a pane the
+	// terminal can't fit (#1535). Consumed once; every later relayout carries a
+	// real previousVisible.
+	if len(previousVisible) == 0 && len(m.restoredPaneBaseline) > 0 {
+		previousVisible = m.restoredPaneBaseline
+	}
+	m.restoredPaneBaseline = nil
 
 	nextVisible := m.store.VisibleOpenPanes(lay.PaneCount())
 	if hidden := newlyAutoHiddenPane(previousVisible, nextVisible, m.store.OpenPanes()); hidden != nil {

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -458,12 +458,18 @@ func (m *home) relayout() {
 	// First real relayout after a restore: the restore-time relayout ran at
 	// (0,0) and fell through to fallback with visiblePanes=nil, so the restored
 	// panes are the visibility baseline this pass uses to detect a pane the
-	// terminal can't fit (#1535). Consumed once; every later relayout carries a
-	// real previousVisible.
+	// terminal can't fit (#1535). Clear it ONLY when it is actually consumed
+	// (previousVisible empty): an intermediate relayout that reaches here with a
+	// real previousVisible already established leaves nothing to consume, and one
+	// that falls through to fallback returned above — so the baseline survives
+	// every relayout until the first sized one uses it, instead of being cleared
+	// out from under that resize (#1551 review). Since visiblePanes is nil until
+	// the first non-fallback relayout, that first sized relayout is exactly the
+	// one that consumes it.
 	if len(previousVisible) == 0 && len(m.restoredPaneBaseline) > 0 {
 		previousVisible = m.restoredPaneBaseline
+		m.restoredPaneBaseline = nil
 	}
-	m.restoredPaneBaseline = nil
 
 	nextVisible := m.store.VisibleOpenPanes(lay.PaneCount())
 	if hidden := newlyAutoHiddenPane(previousVisible, nextVisible, m.store.OpenPanes()); hidden != nil {

--- a/app/tui_state.go
+++ b/app/tui_state.go
@@ -40,6 +40,12 @@ func (m *home) applyTUIViewState(state config.TUIRepoViewState) int {
 		focusCopy := *state.Focus
 		m.pendingTUIViewFocus = &focusCopy
 	}
+	// The relayout below runs at term (0,0) → fallback → visiblePanes=nil, so
+	// capture the restored panes as the baseline the first real relayout uses to
+	// surface an auto-hide status for a pane the terminal can't fit (#1535).
+	if restored > 0 {
+		m.restoredPaneBaseline = append([]*store.OpenPane(nil), m.store.OpenPanes()...)
+	}
 	m.relayout()
 	return restored
 }

--- a/app/tui_state_test.go
+++ b/app/tui_state_test.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +69,56 @@ func TestTUIViewStateRestorePanesSelectionAndFocus(t *testing.T) {
 	require.NotNil(t, focused)
 	assert.Same(t, beta, focused.Instance())
 	assert.Equal(t, 1, focused.Tab())
+}
+
+// TestTUIViewStateRestoredPanesAutoHideShowsStatus is the #1535 repro: panes
+// restored from persisted TUI state are laid out for the first time on the
+// first real WindowSizeMsg (the restore-time relayout runs at (0,0) and falls
+// through to fallback with no visible panes). When that first size is too
+// narrow to fit every restored pane, the "N hidden: terminal too narrow" status
+// must still surface — pre-fix newlyAutoHiddenPane saw an empty previousVisible
+// and returned nil, so the user got a silently missing pane with no explanation.
+func TestTUIViewStateRestoredPanesAutoHideShowsStatus(t *testing.T) {
+	h := newTestHome(t)
+	h.initialPaneOpened = false
+	alpha := tuiStateTestInstance(t, "alpha")
+	beta := tuiStateTestInstance(t, "beta")
+	h.store.AddInstance(alpha)
+	h.store.AddInstance(beta)
+
+	state := config.TUIRepoViewState{
+		OpenPanes: []config.TUIStateOpenPane{
+			{
+				Key:        tuiPaneKeyForInstance(alpha, "agent"),
+				InstanceID: alpha.ID,
+				Title:      alpha.Title,
+				TabName:    "agent",
+				FocusRank:  1,
+			},
+			{
+				Key:        tuiPaneKeyForInstance(beta, "agent"),
+				InstanceID: beta.ID,
+				Title:      beta.Title,
+				TabName:    "agent",
+				FocusRank:  2,
+			},
+		},
+	}
+	require.NoError(t, config.SaveTUIRepoViewState(h.repoID, state))
+
+	// Restore opens both panes; the restore-time relayout runs at (0,0) →
+	// fallback → visiblePanes stays nil.
+	require.Equal(t, 2, h.restoreTUIViewStateOnLaunch())
+	require.Empty(t, h.visiblePanes, "the restore-time relayout falls through at (0,0)")
+
+	// First real relayout at a width that fits only one pane: the other restored
+	// pane auto-hides and the status must surface.
+	resizeHome(h, layout.MultiPaneMinWidth-1, 40)
+
+	require.Equal(t, 1, h.lastLayout.PaneCount())
+	require.Equal(t, 2, h.store.NumOpenPanes(), "auto-hide retains both bindings")
+	assert.Contains(t, h.errBox.FullError(), "hidden: terminal too narrow for 2 panes",
+		"a pane hidden on the first post-restore relayout must still surface the status (#1535)")
 }
 
 func TestTUIViewStateNoValidPanesKeepsAutoOpenFallback(t *testing.T) {

--- a/app/tui_state_test.go
+++ b/app/tui_state_test.go
@@ -110,6 +110,15 @@ func TestTUIViewStateRestoredPanesAutoHideShowsStatus(t *testing.T) {
 	// fallback → visiblePanes stays nil.
 	require.Equal(t, 2, h.restoreTUIViewStateOnLaunch())
 	require.Empty(t, h.visiblePanes, "the restore-time relayout falls through at (0,0)")
+	require.Len(t, h.restoredPaneBaseline, 2, "restore seeds the auto-hide baseline")
+
+	// A snapshot-driven relayout can land between restore and the first
+	// WindowSizeMsg (sync.go relays out on reconcile). It must NOT consume the
+	// baseline out from under the pending resize (#1551): the baseline survives
+	// until the first sized relayout actually uses it.
+	h.relayout()
+	require.Len(t, h.restoredPaneBaseline, 2,
+		"an intermediate no-dims relayout must not clear the restore baseline")
 
 	// First real relayout at a width that fits only one pane: the other restored
 	// pane auto-hides and the status must surface.
@@ -117,6 +126,7 @@ func TestTUIViewStateRestoredPanesAutoHideShowsStatus(t *testing.T) {
 
 	require.Equal(t, 1, h.lastLayout.PaneCount())
 	require.Equal(t, 2, h.store.NumOpenPanes(), "auto-hide retains both bindings")
+	assert.Empty(t, h.restoredPaneBaseline, "the sized relayout consumes the baseline")
 	assert.Contains(t, h.errBox.FullError(), "hidden: terminal too narrow for 2 panes",
 		"a pane hidden on the first post-restore relayout must still surface the status (#1535)")
 }


### PR DESCRIPTION
## Summary

Fixes #1535 — when the terminal is too narrow to fit every pane restored from persisted TUI state, the pane was silently hidden with no status message.

### The bug

Panes reopened from persisted TUI state are laid out for the first time on the first real `WindowSizeMsg`. The restore-time `relayout` runs at term `(0,0)`, hits the fallback ladder, and leaves `visiblePanes = nil`. So the first real `WindowSizeMsg` re-runs `relayout` with panes open but `previousVisible` empty — `newlyAutoHiddenPane`'s `len(previousVisible)==0` guard returns `nil` and the `"N hidden: terminal too narrow"` status never surfaces. A pane just vanishes with no explanation.

### The fix

Capture the restored panes as a one-shot visibility baseline (`restoredPaneBaseline`) at restore time. The first non-fallback `relayout` substitutes it for the empty `previousVisible`, so a pane the terminal can't fit is detected and its status surfaces. The baseline is consumed once — every later `relayout` carries a real `previousVisible`, so steady-state behavior is unchanged.

### Test

`TestTUIViewStateRestoredPanesAutoHideShowsStatus` (in `tui_state_test.go`, alongside the other restore-flow tests): restore two panes, resize to a one-pane width, assert the status surfaces. Reproduced the silent miss pre-fix (verified by reverting the fix — empty errBox), green after.

> Note: the report suggested this test live in `pane_model_test.go`, but that file is already near the 1500-line test-file limit and adding the test tripped the file-length lint. `tui_state_test.go` is the more natural home anyway (it owns the restore-flow tests and already has the `config` import + `tuiStateTestInstance` helper).

### Verification

`gofmt`, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`, file-length lint all clean. `./app/...` green in the test container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)