### PR TITLE
fix(daemon): return actionable error when prompting an archived session (#1529)

### DIFF
--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -385,6 +385,39 @@ func TestDeliverPrompt_RefusesArchivedTargetBeforeTmuxSend(t *testing.T) {
 	}
 }
 
+// TestPromptTargetLivenessError_ArchivedQuotesRestoreCommand pins that the
+// suggested `af sessions restore <title>` command is shell-safe (#1529): a
+// title with a space or shell metacharacter must be single-quoted so a
+// copy-pasted command restores the intended session and cannot smuggle a second
+// shell command. A plain title stays unquoted so the common case reads cleanly.
+func TestPromptTargetLivenessError_ArchivedQuotesRestoreCommand(t *testing.T) {
+	cases := []struct {
+		name     string
+		title    string
+		wantCmd  string
+		unwanted string // a raw, unquoted form that must NOT appear
+	}{
+		{"plain title unquoted", "captain", "af sessions restore captain", ""},
+		{"space quoted", "my session", "af sessions restore 'my session'", "restore my session)"},
+		{"semicolon quoted", "a;rm -rf ~", "af sessions restore 'a;rm -rf ~'", "restore a;rm -rf ~"},
+		{"embedded quote escaped", "it's", `af sessions restore 'it'"'"'s'`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := promptTargetLivenessError(tc.title, session.LiveArchived)
+			if err == nil {
+				t.Fatalf("expected an Archived liveness error for %q", tc.title)
+			}
+			if !strings.Contains(err.Error(), tc.wantCmd) {
+				t.Fatalf("expected restore command %q in error, got: %v", tc.wantCmd, err)
+			}
+			if tc.unwanted != "" && strings.Contains(err.Error(), tc.unwanted) {
+				t.Fatalf("error must not contain the unquoted command %q (shell-injection risk), got: %v", tc.unwanted, err)
+			}
+		})
+	}
+}
+
 func TestSendPrompt_RefusesLostAndDeadTargetsBeforeBackendSend(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -354,6 +354,37 @@ func TestDeliverPrompt_RefusesLostTargetBeforeTmuxSend(t *testing.T) {
 	}
 }
 
+// TestDeliverPrompt_RefusesArchivedTargetBeforeTmuxSend is the #1529
+// regression: an archived target has no live tmux to deliver into, so the
+// prompt must be rejected with an actionable "restore it first" error instead
+// of falling through to a confusing raw backend error, and it must never reach
+// SendPromptCommand.
+func TestDeliverPrompt_RefusesArchivedTargetBeforeTmuxSend(t *testing.T) {
+	manager, repoID, repoPath := newStatusTestManager(t)
+	backend := &failingPromptBackend{readyFakeBackend: readyFakeBackend{session.NewFakeBackend()}}
+	registerStarted(t, manager, repoID, repoPath, "captain", backend, true, session.Archived)
+
+	_, err := manager.DeliverPrompt(DeliverPromptRequest{
+		Title:    "captain",
+		RepoPath: repoPath,
+		Program:  "claude",
+		Prompt:   "while-archived",
+	})
+	if err == nil {
+		t.Fatal("expected Archived target delivery to fail")
+	}
+	want := `target session "captain" is Archived; prompt not delivered; restore it first (af sessions restore captain)`
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected actionable Archived error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "tmux") || strings.Contains(err.Error(), "session not found") {
+		t.Fatalf("Archived delivery must not leak raw tmux errors, got: %v", err)
+	}
+	if backend.sent != 0 {
+		t.Fatalf("Archived delivery reached SendPromptCommand %d time(s); want 0", backend.sent)
+	}
+}
+
 func TestSendPrompt_RefusesLostAndDeadTargetsBeforeBackendSend(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
@@ -160,10 +161,30 @@ func promptTargetLivenessError(title string, liveness session.Liveness) error {
 	case session.LiveArchived:
 		// Archived sessions have no live tmux to deliver into (#1529): without
 		// this case the prompt falls through to a confusing backend error. Point
-		// at the off-ramp, mirroring the TUI's interactiveGuard message.
-		return fmt.Errorf("target session %q is Archived; prompt not delivered; restore it first (af sessions restore %s)", title, title)
+		// at the off-ramp, mirroring the TUI's interactiveGuard message. The
+		// restore command embeds the title, so shell-quote it — a title with
+		// spaces or shell metacharacters must not turn a copy-pasted
+		// `af sessions restore ...` into the wrong target or a second command.
+		return fmt.Errorf("target session %q is Archived; prompt not delivered; restore it first (af sessions restore %s)", title, shellQuoteArg(title))
 	}
 	return nil
+}
+
+// shellQuoteArg makes s safe to paste as a single shell argument: already-safe
+// strings pass through unquoted (so the common `restore captain` stays clean),
+// and anything with whitespace/metacharacters is single-quoted with embedded
+// quotes escaped. Mirrors the sibling copies in session/tmux/resume.go and
+// api/apicmd.go (a shared util is a separate consolidation, #1529).
+func shellQuoteArg(s string) string {
+	if s != "" && strings.IndexFunc(s, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			strings.ContainsRune("_@%+=:,./-", r))
+	}) == -1 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
 func (m *Manager) findSession(title, repoID string) (*session.Instance, string, *session.InstanceData, error) {

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -157,6 +157,11 @@ func promptTargetLivenessError(title string, liveness session.Liveness) error {
 		return fmt.Errorf("target session %q is Lost; prompt not delivered; recover it first", title)
 	case session.LiveDead:
 		return fmt.Errorf("target session %q is Dead; prompt not delivered; recover it first", title)
+	case session.LiveArchived:
+		// Archived sessions have no live tmux to deliver into (#1529): without
+		// this case the prompt falls through to a confusing backend error. Point
+		// at the off-ramp, mirroring the TUI's interactiveGuard message.
+		return fmt.Errorf("target session %q is Archived; prompt not delivered; restore it first (af sessions restore %s)", title, title)
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

`promptTargetLivenessError` switched on `LiveLost` and `LiveDead` but **not** `LiveArchived`. Delivering a prompt to an archived session therefore fell through the switch and hit a confusing raw backend error (`tmux error: session not found`) instead of telling the user what to do (#1529).

## Fix

Add a `case session.LiveArchived:` that points at the off-ramp, mirroring the TUI's `interactiveGuard` message and the phrasing of the existing Lost/Dead cases:

```
target session "captain" is Archived; prompt not delivered; restore it first (af sessions restore captain)
```

Both the `DeliverPrompt` and `SendPrompt` RPC/API paths funnel through `promptTargetLivenessError`, so both are covered.

## Test

`TestDeliverPrompt_RefusesArchivedTargetBeforeTmuxSend` asserts an archived target:
- returns the actionable `restore it first` error,
- does not leak a raw tmux / `session not found` error, and
- never reaches `SendPromptCommand` (`backend.sent == 0`).

`golangci-lint --fast`, `gofmt`, `deadcode`, and file-length lint all green.

Fixes #1529

🤖 Generated with [Claude Code](https://claude.com/claude-code)