### PR TITLE
fix(tui): guard against re-entrant attach on repeated Enter (#1530)

### DIFF
--- a/app/attach_reentry_test.go
+++ b/app/attach_reentry_test.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"bytes"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBeginAttachTransition_SecondCallIgnoredWhileInFlight pins the #1530
+// re-entry guard at the funnel every full-screen attach entry point passes
+// through: once a transition is armed (or an attach is live), a second
+// beginAttachTransition must be a no-op — no new tick scheduled, so no second
+// attach flow spins up duplicate heartbeat/resume goroutines or races
+// m.attached.Store.
+func TestBeginAttachTransition_SecondCallIgnoredWhileInFlight(t *testing.T) {
+	h := newTestHome(t)
+
+	// First call arms the transition and returns a real tick cmd.
+	cmd1 := h.beginAttachTransition(func() tea.Cmd { return nil })
+	require.NotNil(t, cmd1, "first attach transition must schedule the pre-attach tick")
+	require.True(t, h.attachTransitioning, "first attach transition must arm the flag")
+
+	// Second call while the transition is armed must be ignored.
+	cmd2 := h.beginAttachTransition(func() tea.Cmd { return nil })
+	require.Nil(t, cmd2, "a second attach transition while one is in flight must be a no-op")
+
+	// Same when an attach is already live (transitioning flag cleared, attached set).
+	h.attachTransitioning = false
+	h.attached.Store(true)
+	cmd3 := h.beginAttachTransition(func() tea.Cmd { return nil })
+	require.Nil(t, cmd3, "an attach transition while already attached must be a no-op")
+	h.attached.Store(false)
+}
+
+// TestHandleEnter_SecondEnterDuringAttachDoesNotScheduleSecondAttach is the
+// #1530 regression: pressing Enter again during the attach transition window
+// must be ignored, not kick off a second concurrent attach flow. The first
+// Enter arms the transition (attachTransitioning=true) but does not run the
+// attach callback yet — that happens when the returned tick resolves to a
+// beginAttachMsg — so a second Enter lands squarely in the window the bug
+// exploited. With the guard, exactly one attach flow runs despite two presses.
+func TestHandleEnter_SecondEnterDuringAttachDoesNotScheduleSecondAttach(t *testing.T) {
+	resetDetachWatchdog(t)
+
+	h := newTestHome(t)
+	// Skip the first-time attach help overlay so the deferred attach callback
+	// is scheduled synchronously inside handleEnter.
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInstanceAttach{}.mask()))
+
+	// Remote instance so handleEnter takes the full-screen attach path
+	// (liveSessionName == "") that funnels through beginAttachTransition.
+	inst := instanceWithFakeBackend(t, "inst")
+	inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
+	inst.SetStatusForTest(session.Running)
+	require.True(t, inst.IsRemote(), "precondition: instance must be remote for the full-screen attach path")
+	require.True(t, inst.TmuxAlive(), "precondition: instance must be attachable")
+
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	var out bytes.Buffer
+	swapRemoteDetachResetWriter(t, &out)
+
+	attaches := 0
+	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+		attaches++
+		return m.attachOverlayCallback(title, label, traceSuffix, rem, func() (chan struct{}, error) {
+			ch := make(chan struct{})
+			close(ch) // detach immediately, synchronously, no real PTY
+			return ch, nil
+		})
+	})
+
+	// First Enter arms the transition; the attach callback has NOT run yet.
+	model, cmd1 := h.handleEnter()
+	require.True(t, model.(*home).attachTransitioning, "first Enter must arm the attach transition")
+	require.NotNil(t, cmd1, "first Enter must schedule the attach transition tick")
+
+	// Second Enter arrives during the transition window — it must be ignored.
+	_, cmd2 := h.handleEnter()
+	require.Nil(t, cmd2, "a second Enter during the attach transition must be ignored")
+
+	// Let the single scheduled transition run to completion (attach + detach).
+	runAttachTransitionCmd(t, h, cmd1)
+	endDetachWatchdog()
+
+	require.Equal(t, 1, attaches, "exactly one attach flow must be scheduled despite two Enter presses")
+}

--- a/app/attach_reentry_test.go
+++ b/app/attach_reentry_test.go
@@ -89,3 +89,89 @@ func TestHandleEnter_SecondEnterDuringAttachDoesNotScheduleSecondAttach(t *testi
 
 	require.Equal(t, 1, attaches, "exactly one attach flow must be scheduled despite two Enter presses")
 }
+
+// TestHandleEnter_CanceledAttachHelpDoesNotWedgeGuard is the #1530 follow-up
+// regression: opening the first-time attach help overlay and dismissing it with
+// Esc (a cancel — the attach callback never runs) must NOT leave the re-entry
+// guard armed. A subsequent Enter must still attach. Before the defensive clear,
+// any attach-abort path that armed attachTransitioning without reaching the
+// callback's cleanup would make every later Enter a no-op until restart.
+func TestHandleEnter_CanceledAttachHelpDoesNotWedgeGuard(t *testing.T) {
+	resetDetachWatchdog(t)
+
+	h := newTestHome(t)
+	// Do NOT mark the help seen — the first-time attach overlay must appear so
+	// the Esc-cancel path is exercised.
+
+	inst := instanceWithFakeBackend(t, "inst")
+	inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
+	inst.SetStatusForTest(session.Running)
+	require.True(t, inst.IsRemote(), "precondition: instance must be remote for the full-screen attach path")
+	require.True(t, inst.TmuxAlive(), "precondition: instance must be attachable")
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	var out bytes.Buffer
+	swapRemoteDetachResetWriter(t, &out)
+	attaches := 0
+	swapAttachOverlayCallbackFn(t, func(m *home, title, label, traceSuffix string, rem bool, _ func() (chan struct{}, error)) tea.Cmd {
+		attaches++
+		return m.attachOverlayCallback(title, label, traceSuffix, rem, func() (chan struct{}, error) {
+			ch := make(chan struct{})
+			close(ch)
+			return ch, nil
+		})
+	})
+
+	// Enter → first-time attach help overlay shown; attach not started yet.
+	model, _ := h.handleEnter()
+	h = model.(*home)
+	require.NotNil(t, h.textOverlay, "first-time attach must show the help overlay")
+	require.Equal(t, stateHelp, h.state, "attach help overlay must put the model in stateHelp")
+	require.False(t, h.attachTransitioning, "the help overlay alone must not arm the attach guard")
+	require.Equal(t, 0, attaches, "the overlay must not start an attach")
+
+	// Esc dismisses the overlay WITHOUT running the attach callback (cancel).
+	model, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyEsc})
+	h = model.(*home)
+	require.Equal(t, stateDefault, h.state, "Esc must close the attach help overlay (back to stateDefault)")
+	require.False(t, h.attachTransitioning, "a canceled attach must not leave the re-entry guard armed")
+	require.Equal(t, 0, attaches, "Esc must not start an attach")
+
+	// A subsequent Enter must STILL attach — the guard was cleared. The help was
+	// marked seen on the first show, so this Enter runs the attach synchronously.
+	_, cmd := h.handleEnter()
+	runAttachTransitionCmd(t, h, cmd)
+	endDetachWatchdog()
+	require.Equal(t, 1, attaches, "a canceled attach must not block a subsequent attach")
+}
+
+// TestHandleHelpState_AttachCancelClearsTransitionGuard directly exercises the
+// #1530 defensive clear: if the re-entrant-attach guard is armed while the
+// attach help overlay is up (simulating any current or future path that arms
+// attachTransitioning before the overlay resolves), canceling the overlay with
+// Esc must clear it — otherwise every later Enter would be a permanent no-op.
+// This fails without the clear in handleHelpState's cancel branch.
+func TestHandleHelpState_AttachCancelClearsTransitionGuard(t *testing.T) {
+	h := newTestHome(t)
+
+	inst := instanceWithFakeBackend(t, "inst")
+	inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
+	inst.SetStatusForTest(session.Running)
+	h.store.AddInstance(inst)
+	h.sidebar.SetSelectedInstance(0)
+
+	// Enter → first-time attach help overlay shown.
+	model, _ := h.handleEnter()
+	h = model.(*home)
+	require.Equal(t, stateHelp, h.state, "precondition: attach help overlay must be up")
+
+	// Simulate the guard having been armed before the overlay resolves.
+	h.attachTransitioning = true
+
+	// Esc cancels the overlay (attachHelpDismissPolicy → runOnDismiss=false).
+	model, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyEsc})
+	h = model.(*home)
+	require.Equal(t, stateDefault, h.state, "Esc must close the attach help overlay")
+	require.False(t, h.attachTransitioning, "canceling the attach help must clear the re-entry guard")
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -551,6 +551,15 @@ func killConfirmationWarning(wt string) string {
 // the full-screen hook PTY — fall back to the full-screen attach Enter used to
 // do; dead/transitional sessions keep their guard errors.
 func (m *home) handleEnter() (tea.Model, tea.Cmd) {
+	// Ignore Enter entirely while a full-screen attach is starting or live
+	// (#1530): the transition hands stdout/stdin to tmux, so any Enter that
+	// arrives in that window must not kick off a second attach flow (or any
+	// other pane action). beginAttachTransition guards the attach funnel too;
+	// this stops the re-entry one step earlier, at the key handler. Both flags
+	// clear on detach.
+	if m.attachTransitioning || m.attached.Load() {
+		return m, nil
+	}
 	if m.panePreviewTxn != nil {
 		p, commitCmd := m.commitPanePreviewReplace()
 		if p == nil || liveSessionName(p.Instance(), p.Tab()) == "" {

--- a/app/help.go
+++ b/app/help.go
@@ -341,6 +341,16 @@ func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if runOnDismiss {
 		dismissCmd, shouldClose = m.textOverlay.HandleKeyPress(msg)
 	} else {
+		// The overlay was canceled (Esc/Ctrl+C on the attach help,
+		// attachHelpDismissPolicy → runOnDismiss=false): its OnDismiss — the
+		// attach flow — will NOT run. Clear the re-entrant-attach guard here so a
+		// canceled attach can never leave attachTransitioning armed and turn every
+		// later Enter into a no-op (#1530). Today the flag isn't set until
+		// beginAttachTransition runs inside OnDismiss (which this path skips), so
+		// this is defense-in-depth that keeps the now-load-bearing guard invariant
+		// robust if arming ever moves earlier. Harmless for non-attach overlays,
+		// whose guard is already clear.
+		m.attachTransitioning = false
 		m.textOverlay.Dismissed = true
 		shouldClose = true
 	}

--- a/app/home_attach.go
+++ b/app/home_attach.go
@@ -52,6 +52,17 @@ type beginAttachMsg struct {
 // the callback are too late for the renderer-owned status/footer diff; the final
 // TUI frame itself must contain no AF chrome (#1448).
 func (m *home) beginAttachTransition(run func() tea.Cmd) tea.Cmd {
+	// Re-entry guard (#1530): every full-screen attach entry point funnels
+	// through here, so this is the reliable place to block a second attach from
+	// starting while one is already in flight. Without it, repeated Enter/`o`
+	// presses during the transition window each schedule an independent attach
+	// flow — duplicate heartbeat/resume goroutines, racing m.attached.Store,
+	// doubled post-detach side effects, and possible terminal corruption. The
+	// flags clear on detach (attachTransitioning here, attached via its defer in
+	// attachOverlayCallback), so this only ignores presses until then.
+	if m.attachTransitioning || m.attached.Load() {
+		return nil
+	}
 	m.attachTransitioning = true
 	return tea.Tick(20*time.Millisecond, func(time.Time) tea.Msg {
 		return beginAttachMsg{run: run}


### PR DESCRIPTION
## Problem

`beginAttachTransition` set `attachTransitioning=true` but never checked it, and `handleEnter` checked neither `attachTransitioning` nor `attached`. During the attach transition window — the 20ms tick before the blocking attach callback hands stdout/stdin to tmux — repeated Enter presses each scheduled an **independent** attach flow:

- duplicate status-poll pause/resume heartbeat goroutines,
- racing `m.attached.Store`,
- doubled post-detach side effects,
- possible terminal corruption.

(#1530)

## Fix

Add a re-entry guard at both layers so it reliably blocks every attach entry point:

- **`beginAttachTransition`** — the funnel every full-screen attach entry point (`handleEnter` remote path, `handleAttach` `o`, terminal-tab) passes through — no-ops when `attachTransitioning || attached.Load()`.
- **`handleEnter`** — ignores Enter entirely in the same window, blocking the re-entry one step earlier at the key handler.

Both flags clear on detach (`attachTransitioning` + `attached`'s defer in `attachOverlayCallback`), so this only ignores presses until the attach ends.

## Tests

- `TestHandleEnter_SecondEnterDuringAttachDoesNotScheduleSecondAttach` drives two Enter presses through the real `handleEnter` during the transition window and asserts exactly one attach flow runs.
- `TestBeginAttachTransition_SecondCallIgnoredWhileInFlight` pins the funnel guard for both the `transitioning` and `attached` preconditions.

Both verified to **fail** without the guard. The full `./app/...` suite, `golangci-lint --fast`, `gofmt`, `deadcode`, and file-length lint are green, and the normal single attach/detach flow passes `make tui-driver-selftest` (24/24 steps, no orphan clients).

Fixes #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)