### PR TITLE
fix(tui): retry transient embedded-terminal open before surfacing error (#1526)

### DIFF
--- a/app/interactive.go
+++ b/app/interactive.go
@@ -65,12 +65,15 @@ func (m *home) activateInteractive(p *store.OpenPane) tea.Cmd {
 	}
 
 	// Focus (and, via the recency touch, un-auto-hide) the pane, then force
-	// the live bind for it now.
+	// the live bind for it now. The first bind after a preview opens can lose a
+	// race with tmux finishing the pane, so retry the transient miss a bounded
+	// number of times before surfacing the error (#1526) — the common
+	// first-render race stays invisible; a genuine failure still surfaces the
+	// "press o" guidance promptly.
 	m.store.TouchOpenPane(p)
 	m.focusRegion(layout.PaneRegion(p.ID()))
-	m.syncLiveTermPane()
 
-	if m.liveTerm == nil || m.livePane != p {
+	if !m.bindLiveTermPaneWithRetry(p) {
 		inst := p.Instance()
 		title := ""
 		if inst != nil {

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -494,3 +494,38 @@ func TestInteractivePersistentBindFailureSurfacesError(t *testing.T) {
 	assert.Contains(t, h.errBox.FullError(), inst.Title, "the error names the session")
 	assert.Contains(t, h.errBox.FullError(), "press o", "the error keeps the full-screen fallback guidance")
 }
+
+// TestInteractiveRetryZeroSizeExitStillSetsBackoff pins the #1526 review
+// finding: a bind retry that exits at the pre-bind zero-size guard must still
+// record the passive 5s backoff. Otherwise, after surfacing the interactive
+// error, the preview tick would re-attempt the same unavailable pane every
+// 100ms with no backoff (a busy loop that defeats the backoff).
+func TestInteractiveRetryZeroSizeExitStillSetsBackoff(t *testing.T) {
+	h, _ := liveTestHome(t)
+	zeroInteractiveBindRetryDelay(t)
+
+	var calls int
+	orig := newLiveTermPaneFn
+	newLiveTermPaneFn = func(string, int, int) (liveTermAttachment, error) {
+		calls++
+		return newFakeLiveTerm(), nil
+	}
+	t.Cleanup(func() { newLiveTermPaneFn = orig })
+
+	p := h.focusedOpenPane()
+	require.NotNil(t, p)
+	// Force every bind attempt to exit at the pre-bind zero-size guard.
+	h.paneWindows[p.ID()].SetRect(layout.Rect{})
+
+	require.False(t, h.bindLiveTermPaneWithRetry(p), "a zero-size pane cannot bind")
+	require.Zero(t, calls, "the zero-size guard exits before spawning an attachment")
+	require.False(t, h.liveBindFailedAt.IsZero(),
+		"a retry that exits at the zero-size guard must record a failure time for the passive backoff")
+
+	// The pane becomes laid out again, but the passive tick must honor the 5s
+	// backoff the failed retry set — no immediate re-attempt every tick.
+	resizeHome(h, 120, 40)
+	h.reconcileLiveTermPane()
+	assert.Nil(t, h.liveTerm, "the passive backoff must hold: no immediate re-attempt after a zero-size retry")
+	assert.Zero(t, calls, "no attachment spawned while the backoff is active")
+}

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -424,4 +425,72 @@ func TestWheelIsInertWhileInteractive(t *testing.T) {
 
 	assert.False(t, h.paneWindows[p.ID()].IsInScrollMode(),
 		"host wheel-scroll must not flip the live pane into capture scroll mode mid-typing")
+}
+
+// zeroInteractiveBindRetryDelay removes the inter-attempt sleep so the retry
+// tests don't burn wall-clock. Event-loop-only var, restored on cleanup.
+func zeroInteractiveBindRetryDelay(t *testing.T) {
+	t.Helper()
+	orig := interactiveBindRetryDelay
+	interactiveBindRetryDelay = 0
+	t.Cleanup(func() { interactiveBindRetryDelay = orig })
+}
+
+// TestInteractiveRetriesTransientBindThenSucceeds pins #1526: the embedded
+// terminal can miss the FIRST bind when the tmux pane isn't ready yet (a
+// first-render race). Entering interactive must retry that transient miss and
+// succeed without ever surfacing the "couldn't open an embedded terminal" line.
+func TestInteractiveRetriesTransientBindThenSucceeds(t *testing.T) {
+	h, _ := liveTestHome(t)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	zeroInteractiveBindRetryDelay(t)
+
+	var calls int
+	orig := newLiveTermPaneFn
+	newLiveTermPaneFn = func(sessionName string, width, height int) (liveTermAttachment, error) {
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("tmux pane not ready")
+		}
+		return newFakeLiveTerm(), nil
+	}
+	t.Cleanup(func() { newLiveTermPaneFn = orig })
+
+	enterInteractive(t, h)
+
+	assert.True(t, h.interactive, "a transient first-attempt miss must be retried into interactive mode")
+	assert.GreaterOrEqual(t, calls, 2, "the failed first bind must be retried")
+	assert.Empty(t, h.errBox.FullError(), "a recovered transient miss must not surface the open error")
+	assert.NotNil(t, h.liveTerm, "the retried bind must leave a live attachment")
+}
+
+// TestInteractivePersistentBindFailureSurfacesError is the other half of #1526:
+// once the bounded retries are exhausted, a genuine failure must still surface
+// the "press o to attach full-screen" guidance and stay in nav mode.
+func TestInteractivePersistentBindFailureSurfacesError(t *testing.T) {
+	h, inst := liveTestHome(t)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	zeroInteractiveBindRetryDelay(t)
+
+	var calls int
+	orig := newLiveTermPaneFn
+	newLiveTermPaneFn = func(sessionName string, width, height int) (liveTermAttachment, error) {
+		calls++
+		return nil, fmt.Errorf("attach failed")
+	}
+	t.Cleanup(func() { newLiveTermPaneFn = orig })
+
+	// Drive the activation by hand (help is marked seen, so Enter yields the
+	// deferred enterInteractiveMsg directly) and stop before running the
+	// returned transient-clear timer, so the surfaced error is still in the box
+	// when we assert.
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	require.NotNil(t, cmd)
+	_, _ = h.Update(cmd())
+
+	assert.False(t, h.interactive, "a persistent bind failure must not enter interactive mode")
+	assert.Equal(t, interactiveBindAttempts, calls, "all bounded attempts run before surfacing the error")
+	assert.Contains(t, h.errBox.FullError(), "couldn't open an embedded terminal")
+	assert.Contains(t, h.errBox.FullError(), inst.Title, "the error names the session")
+	assert.Contains(t, h.errBox.FullError(), "press o", "the error keeps the full-screen fallback guidance")
 }

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -186,14 +186,22 @@ func (m *home) reconcileLiveTermPane() {
 
 	w := m.paneWindows[target.ID()]
 	if w == nil {
-		m.liveBindKey = ""
+		// No window for this pane: record the failure so the passive 5s backoff
+		// applies. liveBindKey stays set (not reset to "") so the backoff
+		// key-match engages next tick instead of re-attempting every tick
+		// (#1526 review).
+		m.liveBindFailedAt = time.Now()
 		return
 	}
 	width, height := w.GetPreviewSize()
 	if width < 2 || height < 2 {
-		// Not laid out yet (or degenerate): retry next tick rather than
-		// attach a client at a size that would shrink the tmux session.
-		m.liveBindKey = ""
+		// Not laid out yet (or degenerate): don't attach at a size that would
+		// shrink the tmux session. Record the failure so the passive 5s backoff
+		// applies too — without it, an interactive retry that clears the backoff
+		// between attempts (bindLiveTermPaneWithRetry) would leave the tick
+		// re-attempting this unavailable pane every 100ms. liveBindKey stays set
+		// so the backoff key-match engages (#1526 review).
+		m.liveBindFailedAt = time.Now()
 		return
 	}
 	if !target.Instance().TabAlive(target.Tab()) {

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -75,6 +75,44 @@ func (m *home) syncLiveTermPane() {
 	m.enforceInteractiveInvariant()
 }
 
+// interactiveBindAttempts bounds how hard activateInteractive tries to bind the
+// live attachment before surfacing the open error. The embedded terminal can
+// miss on the FIRST attempt when the tmux pane isn't ready yet — a first-render
+// race that self-heals on the next tick (#1526). A few short retries make that
+// common transient miss invisible; the hard, non-retryable cases (remote, dead,
+// lost, transitional instances) are already fenced off by interactiveGuard
+// before we get here, so what remains at the bind is the transient class.
+const interactiveBindAttempts = 4
+
+// interactiveBindRetryDelay is the pause between bind attempts. attempts × delay
+// (≈120ms) bounds the worst-case event-loop block below what reads as a stall,
+// so a genuine failure still surfaces promptly and the loop never spins. A var
+// so tests can zero it; event-loop only, never read/written concurrently.
+var interactiveBindRetryDelay = 40 * time.Millisecond
+
+// bindLiveTermPaneWithRetry forces the live attachment for pane p, retrying the
+// transient "tmux pane not ready" miss (#1526) a bounded number of times before
+// giving up. reconcileLiveTermPane records a failed bind with a 5s backoff meant
+// for the passive preview tick; between attempts we clear that backoff so the
+// next attempt actually re-tries the bind instead of short-circuiting on it. The
+// final failure leaves the backoff intact so the passive tick keeps its
+// anti-respawn behavior. Returns true once the pane is bound. Event-loop only.
+func (m *home) bindLiveTermPaneWithRetry(p *store.OpenPane) bool {
+	for attempt := 0; attempt < interactiveBindAttempts; attempt++ {
+		m.syncLiveTermPane()
+		if m.liveTerm != nil && m.livePane == p {
+			return true
+		}
+		if attempt == interactiveBindAttempts-1 {
+			break
+		}
+		m.liveBindKey = ""
+		m.liveBindFailedAt = time.Time{}
+		time.Sleep(interactiveBindRetryDelay)
+	}
+	return false
+}
+
 func (m *home) reconcileLiveTermPane() {
 	// While the user is inside a full-screen attach our render client must
 	// not hold the same session (size fight) or generate tmux traffic


### PR DESCRIPTION
## Summary

Fixes #1526 — the transient "couldn't open an embedded terminal" line that flashes on preview open / startup.

### The bug

Entering interactive mode binds the live embedded terminal on the spot. The **first** bind can lose a race with tmux finishing the pane (a first-render race), so `activateInteractive` surfaced:

> couldn't open an embedded terminal for '<session>' — try again, or press o to attach full-screen

on the first attempt even though the next preview tick self-heals. Low-severity but recurring and user-visible (fires on startup and on opening a session).

### The fix

Make the common transient case invisible. `bindLiveTermPaneWithRetry` runs the bind a **bounded** number of times (`interactiveBindAttempts = 4`, ~40ms apart, ~120ms worst case) before giving up:

- The **hard, non-retryable** cases (remote, dead, lost, transitional instances) are already fenced off by `interactiveGuard` *before* the bind, so what remains at the bind is the transient "pane not ready" class — safe to retry.
- `reconcileLiveTermPane` records a failed bind with a 5s backoff meant for the *passive* preview tick, so between attempts we clear that backoff to let the next attempt actually re-try. The **final** failure leaves the backoff intact so the passive tick keeps its anti-respawn behavior.
- Only after the retries are exhausted does the "press o" guidance surface. The full-screen `o` fallback stays for real failures.

Bounded time, no spin: worst case ~120ms of event-loop block, well under a perceptible stall.

### Tests

- `TestInteractiveRetriesTransientBindThenSucceeds` — first bind fails, retry succeeds, interactive mode entered with **no** error surfaced (verified it fails with attempts=1).
- `TestInteractivePersistentBindFailureSurfacesError` — a persistent failure exhausts the bounded attempts and still surfaces the "press o" error in nav mode.

### Verification

`gofmt`, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`, file-length lint all clean. `./app/...` green in the test container; `make tui-driver-selftest` 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)