### PR TITLE
docs(skill): sync tui-playtest key wording with current keymap (#1562)

### DIFF
--- a/.claude/skills/tui-playtest.md
+++ b/.claude/skills/tui-playtest.md
@@ -244,14 +244,15 @@ to cross-check the help view against reality):
    go where you expect? Is it obvious how to get back out?
 3. **Tabs** — `t` new tab, `1`–`9` jump, `w` close. Also
    `"$AF" sessions tab-create` from the CLI and confirm the TUI reflects it.
-4. **Panes** — `s` split, `s` swap, `x` close split.
+4. **Panes** — `s` open the selected tab as a pane (or focus its pane), `S`
+   commit the current preview as another pane, `x` hide the focused pane.
 5. **Search** — `/`, find an instance by name, clear the search. Try a
    query with no matches.
 6. **Task flows** — create a task via `"$AF" tasks` (a bounded script,
    e.g. `echo hello`), open the task list with `m`, trigger with `r`,
    check the output landed. Manage automations from the rail.
 7. **Navigation & help** — `[`/`]` sections, `h`/`l` collapse/expand,
-   `?` help overlay, scroll with `shift+up/down`.
+   `?` help overlay, scroll with `ctrl+u`/`ctrl+d`.
 8. **Resize** — `tmux -L "$SOCK" resize-window -t drive -x 80 -y 24`,
    then smaller (`-x 60 -y 20`), then large (`-x 200 -y 50`). Look for
    overlap, truncation, panics, layout garbage at every size.


### PR DESCRIPTION
## What

Two lines in `.claude/skills/tui-playtest.md` described keys that no longer match `keys/keys.go`:

| Was | Now (per `keys/keys.go`) |
| --- | --- |
| `Panes — `s` split, `s` swap, `x` close split.` | `s` (`KeyOpenPane`) opens the selected tab as a pane / focuses its pane, `S` (`KeySplitPane`) commits the preview as another pane, `x` (`KeyHidePane`) hides the focused pane. There is no swap key. |
| `scroll with `shift+up/down`` | scroll is `ctrl+u`/`ctrl+d` (`KeyShiftUp`/`KeyShiftDown`, config `scroll_up`/`scroll_down`). |

## Cross-check

I audited every key reference in the skill against `keys/keys.go`. The rest already matched and is left unchanged: `n` (new), `enter`/`o` (interact/attach), `tab`/`shift+tab` (focus ring), `t`/`1`-`9`/`w` (new/jump/close tab), `/` (search), `m`/`r` (tasks/run now), `[`/`]` (sections), `h`/`l` (collapse/expand), `?` (help), `D` (kill), `q` (quit).

Doc-only change; no Go touched.

Fixes #1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)