### PR TITLE
fix(tui): dedupe pane stack and clear stale narrow-width status (#1557)

### DIFF
--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -24,9 +24,19 @@ import (
 // an explicit (instance, tab) binding in the store's open-pane list.
 
 // openPaneWindow appends a pane bound to (instance, tab) to the store's
-// open-pane list and creates its content window. Callers dedupe via
-// FindOpenPane first and relayout afterwards.
+// open-pane list and creates its content window. Callers relayout afterwards.
+//
+// The (instance, tab) → at-most-one-pane invariant is enforced HERE, at the
+// single pane-creation chokepoint: opening a tab that already has a pane
+// (visible or auto-hidden) returns the existing pane instead of appending a
+// duplicate — the open-or-focus contract (#1493), now unconditional so the
+// callers that skip the FindOpenPane pre-check (the startup auto-open, the
+// started-session auto-open, the restore path) can never split one tab across
+// two panes and render it twice (#1557).
 func (m *home) openPaneWindow(instance *session.Instance, tab int) *store.OpenPane {
+	if existing := m.store.FindOpenPane(instance, tab); existing != nil {
+		return existing
+	}
 	p := m.store.AddOpenPane(instance, tab)
 	if p == nil {
 		return nil

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -175,6 +175,13 @@ type home struct {
 	// pane is auto-hidden by width pressure. Callers that can return a tea.Cmd
 	// consume it to start the same transient clear timer normal errors use.
 	pendingPaneAutoHideStatus string
+	// paneAutoHideNoticeID is the transient-notice generation of the currently
+	// displayed "N hidden: terminal too narrow" status, or 0 when none is shown.
+	// relayout clears the notice the moment a resize fits every open pane again,
+	// so the guidance never lingers on screen contradicting the visible panes
+	// (#1557). Tracked by id (not content) so a newer, unrelated notice that
+	// superseded it is never wiped.
+	paneAutoHideNoticeID uint64
 	// restoredPaneBaseline holds the panes reopened from persisted TUI state so
 	// the first real (non-fallback) relayout after launch can detect panes the
 	// terminal is too narrow to fit. The restore-time relayout runs at term
@@ -476,6 +483,7 @@ func (m *home) relayout() {
 		m.setPaneAutoHideStatus(hidden, m.store.NumOpenPanes())
 	}
 	m.visiblePanes = nextVisible
+	m.clearStaleAutoHideStatus()
 
 	// Rebuild the ring's pane entries to the visible set (auto-hidden panes
 	// leave the ring; the focused pane is most-recently-focused, so it is
@@ -553,7 +561,25 @@ func (m *home) setPaneAutoHideStatus(p *store.OpenPane, paneCount int) {
 	msg := fmt.Sprintf("%s hidden: terminal too narrow for %d panes; resize wider%s",
 		paneStatusTitle(p), paneCount, paneRecoveryStatusHint())
 	m.pendingPaneAutoHideStatus = msg
-	m.setTransientNotice(errors.New(msg))
+	m.paneAutoHideNoticeID = m.setTransientNotice(errors.New(msg))
+}
+
+// clearStaleAutoHideStatus drops the "N hidden: terminal too narrow" guidance
+// the moment a relayout fits every open pane again — otherwise a resize wide
+// enough to reveal the auto-hidden panes still leaves the narrow-width status
+// on the bar, contradicting the now-visible panes (#1557). Keyed on the notice
+// id so a newer, unrelated status that superseded ours is never wiped; the
+// guidance's own transient timer still handles the case where it is the current
+// notice but the panes never came back.
+func (m *home) clearStaleAutoHideStatus() {
+	if m.paneAutoHideNoticeID == 0 || m.store.NumOpenPanes() > len(m.visiblePanes) {
+		return
+	}
+	if m.transientNoticeID == m.paneAutoHideNoticeID {
+		m.errBox.Clear()
+	}
+	m.paneAutoHideNoticeID = 0
+	m.pendingPaneAutoHideStatus = ""
 }
 
 func paneStatusTitle(p *store.OpenPane) string {
@@ -592,7 +618,8 @@ func (m *home) consumePaneAutoHideStatus() tea.Cmd {
 	}
 	status := m.pendingPaneAutoHideStatus
 	m.pendingPaneAutoHideStatus = ""
-	return m.showTransientError(errors.New(status))
+	m.paneAutoHideNoticeID = m.setTransientNotice(errors.New(status))
+	return m.clearTransientMessageAfterDelay(m.paneAutoHideNoticeID)
 }
 
 // syncFocus applies the focus ring's active region to the panes and the

--- a/app/pane_autohide_status_test.go
+++ b/app/pane_autohide_status_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPane_OpenHiddenThenResizeWideNoDupNoStaleStatus is the #1557 regression:
+// open every instance's pane while too narrow to fit them all (earlier panes
+// auto-hide), then resize wide enough for all of them. The workspace must show
+// exactly one pane per instance — no duplicate for a revealed pane — and the
+// "N hidden: terminal too narrow" guidance must clear once the panes fit again,
+// never linger contradicting the now-visible panes.
+func TestPane_OpenHiddenThenResizeWideNoDupNoStaleStatus(t *testing.T) {
+	h := paneTestHome(t)
+	resizeHome(h, layout.MultiPaneMinWidth-1, 24) // one pane fits
+
+	for i := 0; i < 3; i++ {
+		h.sidebar.SetSelectedInstance(i)
+		_ = h.selectionChanged()
+		pressKey(t, h, "s")
+	}
+	require.Equal(t, 3, h.store.NumOpenPanes(), "each instance opens exactly one pane")
+	require.Equal(t, 1, len(h.visiblePanes), "only one pane fits at the narrow width")
+	require.NotEmpty(t, h.errBox.FullError(), "an auto-hide status is shown while panes are hidden")
+
+	// Grow wide enough to fit all three panes.
+	resizeHome(h, 200, 50)
+
+	assert.Equal(t, 3, h.store.NumOpenPanes(), "no duplicate pane is created on reveal")
+	assert.Equal(t, []string{"alpha", "beta", "gamma"}, visibleTitles(h),
+		"every instance is shown by exactly one pane, in order")
+	assert.Equal(t, "", h.errBox.FullError(),
+		"the narrow-width guidance clears once the panes fit again")
+}
+
+// TestPane_OpenPaneWindowIsIdempotent proves the (instance, tab) →
+// at-most-one-pane invariant is enforced at the openPaneWindow chokepoint, so
+// the callers that skip the FindOpenPane pre-check (auto-open, restore) cannot
+// split one tab across two panes (#1557).
+func TestPane_OpenPaneWindowIsIdempotent(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+
+	first := h.openPaneWindow(alpha, 0)
+	require.NotNil(t, first)
+	second := h.openPaneWindow(alpha, 0)
+	require.Same(t, first, second, "re-opening the same (instance, tab) returns the existing pane")
+	assert.Equal(t, 1, h.store.NumOpenPanes(), "no duplicate pane is appended")
+}


### PR DESCRIPTION
## Summary

Two coupled defects from the 2026-07-10 TUI play-test, both in the narrow→wide pane path:

1. **Duplicate panes on reveal.** Opening an already-open (possibly auto-hidden) tab could append a *second* pane bound to the same `(instance, tab)`, so after a resize wide the workspace rendered one instance's tab twice. The `(instance, tab) → at-most-one-pane` invariant is now enforced at the single `openPaneWindow` creation chokepoint (open-or-focus, #1493), so the callers that skip the `FindOpenPane` pre-check — the startup auto-open, the started-session auto-open, and the restore path — can no longer split one tab across two rendered panes.

2. **Stale narrow-width guidance.** The `"N hidden: terminal too narrow"` status lingered on the bar after a resize revealed the hidden panes, contradicting the now-visible panes. `relayout` now clears that notice the moment every open pane fits again. It is tracked by notice id, so a newer unrelated status is never wiped, and its own transient timer still covers the still-hidden case.

## Testing

- `make test-container` — full suite green.
- New `TestPane_OpenHiddenThenResizeWideNoDupNoStaleStatus` (open 3 while too narrow → resize wide → N panes for N instances, no dup, no stale status) and `TestPane_OpenPaneWindowIsIdempotent`.
- Verified the #1535 restored-pane auto-hide status test still passes.

Fixes #1557

🤖 Generated with [Claude Code](https://claude.com/claude-code)