### PR TITLE
fix(tui): stop the idle preview tick stealing focus off the ring (#1558)

### DIFF
--- a/app/home_model.go
+++ b/app/home_model.go
@@ -204,6 +204,14 @@ type home struct {
 	// panePreviewSuppression remembers a user-dismissed preview target so the
 	// 100ms preview tick does not recreate it until the sidebar target changes.
 	panePreviewSuppression *panePreviewSuppression
+	// inPreviewTick is set only while the idle 100ms preview tick drives
+	// selectionChanged. It gates the one side effect that must never fire from a
+	// background refresh: pulling focus onto the selected instance's already-open
+	// pane. Without the gate the tick yanked focus back to that pane the moment
+	// the user Tabbed off it, so the focus ring could never traverse the other
+	// panes or rest on the tree (#1558). User-driven selectionChanged calls (nav,
+	// the open-or-focus verb, reconcile) leave it false and keep that behavior.
+	inPreviewTick bool
 	// -- Live embedded terminal (#1089 PR 1, read-only proof path) --
 	//
 	// At most ONE pane holds a live termpane attachment: the focused pane

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -36,7 +36,12 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.syncLiveTermPane()
 		var cmd tea.Cmd
 		if !m.attached.Load() {
+			// Mark this selectionChanged as the idle refresh tick so the preview
+			// path does not steal focus onto the selected instance's open pane
+			// while the user drives the focus ring (#1558).
+			m.inPreviewTick = true
 			cmd = m.selectionChanged()
+			m.inPreviewTick = false
 		}
 		return m, tea.Batch(
 			cmd,

--- a/app/pane_focus_ring_test.go
+++ b/app/pane_focus_ring_test.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/stretchr/testify/require"
+)
+
+// fireIdlePreviewTick drives the real 100ms preview tick through Update, so the
+// tests exercise the same inPreviewTick wiring the running TUI uses.
+func fireIdlePreviewTick(h *home) {
+	_, _ = h.Update(previewTickMsg{})
+}
+
+// TestPane_ForwardTabVisitsAllPanesDespiteIdleTick is the #1558 regression. In
+// a three-pane workspace the forward focus ring must cycle
+// tree → pane → pane → pane → automations → tree, visiting every pane and
+// resting on the tree — even though the 100ms preview tick keeps firing between
+// keystrokes. Before the fix, that idle tick yanked focus back onto the
+// selected instance's already-open pane the moment the user Tabbed off it, so
+// the ring never reached the other panes or settled on the tree.
+func TestPane_ForwardTabVisitsAllPanesDespiteIdleTick(t *testing.T) {
+	h := paneTestHome(t)
+	for i := 0; i < 3; i++ {
+		h.sidebar.SetSelectedInstance(i)
+		_ = h.selectionChanged()
+		pressKey(t, h, "s")
+	}
+	require.Equal(t, 3, h.store.NumOpenPanes())
+	require.Equal(t, 3, h.lastLayout.PaneCount(), "200 cols fits three panes")
+	panes := h.store.OpenPanes()
+	// The selection rests on gamma (the last opened), whose pane is rightmost.
+	h.focusRegion(layout.RegionTree)
+
+	forward := []string{
+		layout.PaneRegion(panes[0].ID()),
+		layout.PaneRegion(panes[1].ID()),
+		layout.PaneRegion(panes[2].ID()),
+		layout.RegionAutomations,
+		layout.RegionTree,
+	}
+	for _, want := range forward {
+		_ = h.cycleFocus(false)
+		fireIdlePreviewTick(h) // the idle tick fires between keystrokes in the running TUI
+		require.Equal(t, want, h.ring.Active(),
+			"forward Tab + idle preview tick must advance the ring, not steal focus to the selected pane")
+	}
+
+	// Reverse mirrors it and is likewise immune to the idle tick.
+	backward := []string{
+		layout.RegionAutomations,
+		layout.PaneRegion(panes[2].ID()),
+		layout.PaneRegion(panes[1].ID()),
+		layout.PaneRegion(panes[0].ID()),
+		layout.RegionTree,
+	}
+	for _, want := range backward {
+		_ = h.cycleFocus(true)
+		fireIdlePreviewTick(h)
+		require.Equal(t, want, h.ring.Active(),
+			"Shift-Tab + idle preview tick must cycle the ring backwards")
+	}
+}
+
+// TestPane_IdleTickDoesNotStealFocusFromTree is the tree half of #1558: while
+// the ring rests on the tree with the selected instance's pane open, the idle
+// preview tick must NOT pull focus onto that pane. Focus stealing on every tick
+// is what broke the af_focus_tree driver helper (it could never rest on the
+// tree). A real navigation still focuses an already-open tab (#1493), covered by
+// TestPanePreviewSelectionFocusesAlreadyOpenTabPane.
+func TestPane_IdleTickDoesNotStealFocusFromTree(t *testing.T) {
+	h := paneTestHome(t)
+	for i := 0; i < 3; i++ {
+		h.sidebar.SetSelectedInstance(i)
+		_ = h.selectionChanged()
+		pressKey(t, h, "s")
+	}
+	h.focusRegion(layout.RegionTree)
+	require.Equal(t, layout.RegionTree, h.ring.Active())
+
+	for i := 0; i < 5; i++ {
+		fireIdlePreviewTick(h)
+		require.Equal(t, layout.RegionTree, h.ring.Active(),
+			"the idle preview tick must leave focus on the tree, not steal it to the selected pane")
+	}
+}

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -67,7 +67,15 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 	}
 	if existing := m.store.FindOpenPane(target.instance, target.tab); existing != nil && existing != owner {
 		m.cancelPanePreview(false)
-		m.focusOpenPane(existing)
+		// Landing on an already-open tab focuses its pane — the open-or-focus
+		// contract (#1493). But NEVER from the idle 100ms preview tick: doing so
+		// would keep yanking focus back onto the selected instance's pane after
+		// the user Tabbed to another pane, so the focus ring could never traverse
+		// the other panes or rest on the tree (#1558). On the tick the tab being
+		// open elsewhere just means "no preview to show" — leave focus put.
+		if !m.inPreviewTick {
+			m.focusOpenPane(existing)
+		}
 		return
 	}
 	if m.isPanePreviewSuppressed(original, target) {


### PR DESCRIPTION
## Summary

In a multi-pane workspace the forward Tab focus ring got stuck: Tab moved tree → a pane, but repeated Tab never traversed the other panes or returned to the tree, and the `af_focus_tree` driver helper (which relies on forward Tab reaching the tree) broke. Shift-Tab appeared to work.

**Root cause.** The 100ms preview tick runs `selectionChanged → updatePanePreview`, whose open-or-focus branch (#1493) pulls focus onto the selected instance's already-open pane. Firing that on *every idle tick* yanked focus back onto the selected pane the instant the user Tabbed off it, so the ring could never advance past it or rest on the tree. (It wasn't the ring logic — I confirmed with a live 3-pane driver trace that `ring.Next()` was correct and the focus was being stolen between keystrokes.)

**Fix.** The focus-steal now fires only for user-driven `selectionChanged` calls — tree navigation, the open-or-focus verb, reconcile — never from the idle tick, which is marked with a new `inPreviewTick` flag. On the tick, the selected tab being open elsewhere simply means "no preview to show", and focus is left where the user put it. The preview *content* still refreshes on the tick.

## Testing

- `make test-container` — full suite green.
- New `TestPane_ForwardTabVisitsAllPanesDespiteIdleTick` (forward **and** reverse cycle the full ring under a firing idle tick) and `TestPane_IdleTickDoesNotStealFocusFromTree`; both fail without the gate.
- `TestPanePreviewSelectionFocusesAlreadyOpenTabPane` (the #1493 open-or-focus contract) still passes, as does `TestPane_SnapshotTabRemovalRebindsPanes` (the reconcile relies on the same steal to re-focus a surviving pane — the gate deliberately leaves that path firing).
- Live driver verification in the container: 3-pane workspace now cycles tree → pane → pane → pane → automations → tree (all three panes reachable, `af_focus_tree` rests on the tree); `tui-driver-selftest` **25/25**.

Fixes #1558

🤖 Generated with [Claude Code](https://claude.com/claude-code)