### PR TITLE
fix(tui): keep relaunch selection coherent with the shown workspace (#1559)

### DIFF
--- a/app/tui_state.go
+++ b/app/tui_state.go
@@ -40,6 +40,13 @@ func (m *home) applyTUIViewState(state config.TUIRepoViewState) int {
 		focusCopy := *state.Focus
 		m.pendingTUIViewFocus = &focusCopy
 	}
+	// A persisted selection that resolved to an archived row (or to nothing)
+	// leaves the store with no display selection, yet a live pane may have been
+	// restored above — an incoherent mix where the sidebar highlights nothing (or
+	// a stale archived row) while the workspace renders a live session, with
+	// keyboard nav stuck (#1559). Reconcile now, before the relayout, so launch
+	// selects the live session whose pane is actually shown.
+	m.reconcileRestoredSelectionWithWorkspace()
 	// The relayout below runs at term (0,0) → fallback → visiblePanes=nil, so
 	// capture the restored panes as the baseline the first real relayout uses to
 	// surface an auto-hide status for a pane the terminal can't fit (#1535).
@@ -110,6 +117,65 @@ func (m *home) restoreTUISelection(state config.TUIRepoViewState) {
 	m.menu.SetInstance(inst)
 	m.menu.SetActiveTab(tab)
 	m.sidebar.SelectTabRow(inst.Title, tab)
+}
+
+// reconcileRestoredSelectionWithWorkspace keeps the restored sidebar selection
+// coherent with the panes brought back on launch (#1559). restoreTUISelection
+// deliberately refuses to bind an archived (or vanished) persisted selection, so
+// the store can be left with no live display selection while restoreTUIViewPanes
+// still put a live pane on screen. That mismatch is the #1559 bug: the workspace
+// shows a live session but the sidebar highlights nothing (or an archived row),
+// and Down from the archived tail row has nowhere to go so keyboard nav stalls.
+// When the store has no live selection but a live pane is displayed, select that
+// live session — preferring the pane the restored focus points at, else the
+// most-recently-focused open pane — so the selected row and the shown pane always
+// refer to the same instance and the tree is immediately navigable.
+func (m *home) reconcileRestoredSelectionWithWorkspace() {
+	if sel := m.store.GetSelectedInstance(); sel != nil && !sel.ShownArchived() {
+		return // a live selection was restored — already coherent
+	}
+	pane := m.restoredFocusPane()
+	if pane == nil {
+		pane = m.mostRecentlyFocusedOpenPane()
+	}
+	if pane == nil {
+		return // no pane on screen — leave the ordinary cold-start selection
+	}
+	inst := pane.Instance()
+	if inst == nil || inst.ShownArchived() {
+		return
+	}
+	tab := pane.Tab()
+	m.sidebar.SelectInstance(inst)
+	m.store.SetActiveTab(tab)
+	m.menu.SetInstance(inst)
+	m.menu.SetActiveTab(tab)
+	m.sidebar.SelectTabRow(inst.Title, tab)
+}
+
+// restoredFocusPane resolves the open pane the persisted focus (loaded into
+// pendingTUIViewFocus by applyTUIViewState) points at, or nil when the focus is
+// not on a pane / the pane was not restored. Used to pick which live session the
+// launch selection should follow when the persisted selection can't be honored.
+func (m *home) restoredFocusPane() *store.OpenPane {
+	if m.pendingTUIViewFocus == nil || m.pendingTUIViewFocus.Region != tuiFocusRegionPane {
+		return nil
+	}
+	return m.openPaneByKey(m.pendingTUIViewFocus.PaneKey)
+}
+
+// mostRecentlyFocusedOpenPane returns the open pane with the highest focus-
+// recency stamp — the pane most likely to be the one the user was last looking
+// at, and the best proxy for "the shown workspace" when no explicit focus pane
+// survives the restore.
+func (m *home) mostRecentlyFocusedOpenPane() *store.OpenPane {
+	var best *store.OpenPane
+	for _, p := range m.store.OpenPanes() {
+		if best == nil || p.LastFocus() > best.LastFocus() {
+			best = p
+		}
+	}
+	return best
 }
 
 func (m *home) applyPendingTUIViewFocus() {

--- a/app/tui_state_test.go
+++ b/app/tui_state_test.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -180,6 +181,83 @@ func TestTUIViewStatePreviewTickDoesNotWriteUnchangedState(t *testing.T) {
 	require.NoError(t, err, "a structural pane-open action must save TUI state")
 	assert.Contains(t, string(raw), `"schema_version"`)
 	assert.Contains(t, string(raw), `"open_panes"`)
+}
+
+// TestTUIViewStateRestoreArchivedSelectionFollowsLivePane is the #1559 repro:
+// on relaunch the persisted selection pointed at a session that was archived
+// before quit, while a LIVE session's pane was left open. restoreTUISelection
+// refuses to bind the archived row, so pre-fix the store was left with no live
+// selection while the workspace still rendered the live pane — an incoherent
+// mix (sidebar highlights nothing/an archived row over a live workspace) whose
+// archived-tail cursor stalled keyboard nav. The launch selection must instead
+// follow the live pane that is actually shown, and stay keyboard-navigable.
+func TestTUIViewStateRestoreArchivedSelectionFollowsLivePane(t *testing.T) {
+	h := newTestHome(t)
+	h.initialPaneOpened = false
+	feature := tuiStateTestInstance(t, "feature")
+	qa := tuiStateTestInstance(t, "qa")
+	docs := tuiStateTestInstance(t, "docs")
+	docs.SetArchived() // archived before quit; persisted as the selection
+	h.store.AddInstance(feature)
+	h.store.AddInstance(qa)
+	h.store.AddInstance(docs)
+
+	state := config.TUIRepoViewState{
+		Selected: &config.TUIStateTarget{
+			InstanceID: docs.ID,
+			Title:      docs.Title,
+			TabName:    "agent",
+		},
+		ActiveTab: &config.TUIStateTarget{
+			InstanceID: docs.ID,
+			Title:      docs.Title,
+			TabName:    "agent",
+		},
+		OpenPanes: []config.TUIStateOpenPane{{
+			Key:        tuiPaneKeyForInstance(qa, "shell"),
+			InstanceID: qa.ID,
+			Title:      qa.Title,
+			TabName:    "shell",
+			FocusRank:  1,
+		}},
+	}
+	require.NoError(t, config.SaveTUIRepoViewState(h.repoID, state))
+
+	require.Equal(t, 1, h.restoreTUIViewStateOnLaunch())
+	resizeHome(h, 200, 40)
+
+	// The live pane is shown, so the live session it belongs to is selected —
+	// never the stale archived docs row.
+	require.Same(t, qa, h.store.GetSelectedInstance(),
+		"launch selects the live session whose pane is shown, not the archived one")
+	require.Same(t, qa, h.sidebar.GetSelectedInstance(),
+		"the sidebar cursor and the workspace pane refer to the same live session")
+	assert.Equal(t, 1, h.store.ActiveTab(), "the active tab follows the restored pane's tab")
+
+	// The restored selection rests on a live tab row (not an archived row), so
+	// keyboard nav moves through the live tree instead of stalling on the
+	// archived tail. qa sits below feature, so walking Up eventually reaches
+	// feature and never gets stuck on the same row.
+	sel := h.sidebar.GetSelection()
+	assert.Equal(t, ui.SectionInstances, sel.Kind)
+	assert.False(t, sel.IsHeader)
+	require.True(t, sel.IsTab, "the restored live selection rests on a tab row")
+
+	reachedFeature := false
+	for i := 0; i < 4 && !reachedFeature; i++ {
+		before := h.sidebar.GetSelection()
+		h.sidebar.Up()
+		after := h.sidebar.GetSelection()
+		require.NotEqual(t, before, after, "Up must move the cursor — keyboard nav is not stuck")
+		if h.sidebar.GetSelectedInstance() == feature {
+			reachedFeature = true
+		}
+	}
+	assert.True(t, reachedFeature, "Up walks up through the live tree to feature")
+
+	h.sidebar.Down()
+	assert.NotSame(t, feature, h.sidebar.GetSelectedInstance(),
+		"Down moves back down through the live tree")
 }
 
 func tuiStateTestInstance(t *testing.T, title string) *session.Instance {

--- a/app/tui_state_test.go
+++ b/app/tui_state_test.go
@@ -260,6 +260,79 @@ func TestTUIViewStateRestoreArchivedSelectionFollowsLivePane(t *testing.T) {
 		"Down moves back down through the live tree")
 }
 
+// TestTUIViewStateRestoreSelectionFollowsRestoredFocusPane pins the preferred
+// half of the #1559 reconcile: when the archived/absent persisted selection
+// forces the fallback AND multiple live panes are restored, the launch selection
+// must follow the pane the persisted FOCUS points at — not merely the
+// most-recently-focused pane. Here focus is pinned on feature's pane while qa's
+// pane carries the higher focus-recency stamp (restored last), so the
+// most-recently-focused fallback would pick qa; asserting feature proves the
+// restoredFocusPane path wins.
+func TestTUIViewStateRestoreSelectionFollowsRestoredFocusPane(t *testing.T) {
+	h := newTestHome(t)
+	h.initialPaneOpened = false
+	feature := tuiStateTestInstance(t, "feature")
+	qa := tuiStateTestInstance(t, "qa")
+	docs := tuiStateTestInstance(t, "docs")
+	docs.SetArchived() // archived before quit; persisted as the selection
+	h.store.AddInstance(feature)
+	h.store.AddInstance(qa)
+	h.store.AddInstance(docs)
+
+	state := config.TUIRepoViewState{
+		Selected: &config.TUIStateTarget{
+			InstanceID: docs.ID,
+			Title:      docs.Title,
+			TabName:    "agent",
+		},
+		// Focus rests on feature's pane, even though qa's pane restores last and
+		// therefore carries the higher focus-recency stamp (the fallback's pick).
+		Focus: &config.TUIStateFocus{
+			Region:  tuiFocusRegionPane,
+			PaneKey: tuiPaneKeyForInstance(feature, "agent"),
+		},
+		OpenPanes: []config.TUIStateOpenPane{
+			{
+				Key:        tuiPaneKeyForInstance(feature, "agent"),
+				InstanceID: feature.ID,
+				Title:      feature.Title,
+				TabName:    "agent",
+				FocusRank:  1,
+			},
+			{
+				Key:        tuiPaneKeyForInstance(qa, "shell"),
+				InstanceID: qa.ID,
+				Title:      qa.Title,
+				TabName:    "shell",
+				FocusRank:  2, // restored last → highest LastFocus → the fallback pick
+			},
+		},
+	}
+	require.NoError(t, config.SaveTUIRepoViewState(h.repoID, state))
+
+	require.Equal(t, 2, h.restoreTUIViewStateOnLaunch())
+
+	// Assert the fallback premise BEFORE the first sized relayout: the launch
+	// focus is only applied to feature's pane once the terminal has real dims, so
+	// until then qa's pane (restored last) still carries the higher focus-recency
+	// stamp — i.e. the most-recently-focused fallback would pick qa. The reconcile
+	// runs inside restoreTUIViewStateOnLaunch above and must have picked feature.
+	require.Same(t, qa, h.mostRecentlyFocusedOpenPane().Instance(),
+		"premise: qa's pane carries the higher focus-recency stamp (the fallback pick)")
+	require.Same(t, feature, h.store.GetSelectedInstance(),
+		"launch selects the FOCUSED pane's session, not the most-recently-focused fallback")
+	require.Same(t, feature, h.sidebar.GetSelectedInstance(),
+		"the sidebar cursor follows the focused pane's session")
+	assert.Equal(t, 0, h.store.ActiveTab(),
+		"the active tab follows the focused pane's tab (feature/agent)")
+
+	// The coherence survives the first real relayout (which applies the restored
+	// pane focus): the selection stays on the focused session.
+	resizeHome(h, 200, 40)
+	require.Same(t, feature, h.store.GetSelectedInstance(),
+		"the focused-pane selection remains coherent after layout")
+}
+
 func tuiStateTestInstance(t *testing.T, title string) *session.Instance {
 	t.Helper()
 	inst := instanceWithFakeBackend(t, title)


### PR DESCRIPTION
## Summary

Fixes #1559 — on relaunch the TUI could highlight an **archived** session in the
sidebar while the workspace rendered a **live** session's pane, an incoherent
mixed state (e.g. the reported `qa · Agent · selected: docs · Agent`). Worse,
keyboard-driven selection stalled from there — only a mouse click on a live row
recovered.

## Root cause

`restoreTUISelection` correctly refuses to bind a persisted selection that
resolved to an archived (or vanished) row. But `restoreTUIViewPanes` still
restores the live session's open pane. So the store was left with **no live
display selection** while a live pane was on screen:

- the sidebar highlighted nothing (or, after nav, a stale archived row);
- `Down` from the archived tail row has nowhere to go, so keyboard nav stuck.

The selected row and the displayed workspace disagreed.

## Fix

Add `reconcileRestoredSelectionWithWorkspace`, run right after
`restoreTUISelection` (before the launch relayout). When the store has no live
selection but a live pane was restored, select the live session **whose pane is
actually shown** — preferring the pane the restored focus points at, else the
most-recently-focused open pane — and bind its tab. Now the selected sidebar
row and the workspace pane always refer to the same instance, and the live tree
is immediately keyboard-navigable. Archived-selection over a live workspace can
no longer coexist.

A restored *live* selection is left untouched (already coherent), and a restore
with no panes still falls through to the ordinary cold-start auto-open.

Integrates with the recent pane work — #1557 (pane-dedup), #1547
(project-switch, which also routes through `restoreTUIViewStateOnLaunch`), and
#1551 (restored-pane auto-hide baseline): the reconcile runs before that
baseline capture and the relayout, touching only the selection binding.

## Tests

- New `TestTUIViewStateRestoreArchivedSelectionFollowsLivePane`: relaunch with a
  live pane restored + an archived session present + the persisted selection
  pointing at the archived row → the **live** session is selected (store +
  sidebar), the restored pane's tab is bound, and Up/Down walk the live tree
  instead of stalling.
- `make test-container` (full suite, incl. daemon + integration) green.
- `gofmt -l .` empty, `go build ./...`, `golangci-lint run --fast`,
  `deadcode -test ./...`, `scripts/lint-file-length.sh` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)