### PR TITLE
fix(tui): stop Automations rail overlapping the workspace frame at small widths (#1560)

### DIFF
--- a/app/layout_cutover_test.go
+++ b/app/layout_cutover_test.go
@@ -216,7 +216,8 @@ func TestLayoutCutover_DegradationLadder(t *testing.T) {
 	resizeHome(h, 79, 24)
 	require.True(t, h.lastLayout.AutomationsVisible)
 	assert.True(t, h.lastLayout.AutomationsCompact, "<80 cols: 1-line automations summary")
-	assert.Equal(t, 1, h.lastLayout.Automations.H)
+	assert.Equal(t, layout.AutomationsCompactRows, h.lastLayout.Automations.H,
+		"compact strip is the summary plus its reserved bottom-margin row (#1560)")
 
 	resizeHome(h, 59, 14)
 	assert.False(t, h.lastLayout.AutomationsVisible, "minimal mode drops the strip")

--- a/ui/automations.go
+++ b/ui/automations.go
@@ -381,13 +381,19 @@ func (a *AutomationsPane) String() string {
 	}
 
 	// Reserve the last rail row as a blank bottom margin so the workspace
-	// frame's bottom border never abuts the section's last row (#1560). The
-	// grid sizes the region one row taller to keep the visible capacity, so
-	// content is rendered into contentH = rect.H-1 and the final ClampToRect
-	// leaves the reserved row blank.
-	contentH := a.rect.H - 1
-	if contentH < 1 {
-		contentH = 1
+	// frame's bottom border never abuts the section's last row (#1560), the way
+	// the sidebar's leading blank row keeps the frame's TOP border off the
+	// rail. The grid sizes every full-mode section at least layout.AutomationsRows
+	// tall (floor / grow-to-content / half-cap all include this margin), so
+	// reserving one row costs no visible capacity in the app. Guard the
+	// reservation on the section being at least that floor tall: a direct caller
+	// that hands the pane a tighter, content-exact rect (below any size the grid
+	// ever produces) keeps every content row rather than silently losing one —
+	// the margin only matters where a workspace frame is actually drawn beside
+	// the section, which is always at the grid's real (>= floor) sizes.
+	contentH := a.rect.H
+	if a.rect.H >= layout.AutomationsRows {
+		contentH = a.rect.H - 1
 	}
 
 	// Window the rows around the cursor so a focused selection below the fold

--- a/ui/automations.go
+++ b/ui/automations.go
@@ -380,12 +380,22 @@ func (a *AutomationsPane) String() string {
 			fitLine(fmt.Sprintf("  no tasks — press %s, then n to create one", automationHelpKey(keys.KeyTaskList)), a.rect.W)))
 	}
 
+	// Reserve the last rail row as a blank bottom margin so the workspace
+	// frame's bottom border never abuts the section's last row (#1560). The
+	// grid sizes the region one row taller to keep the visible capacity, so
+	// content is rendered into contentH = rect.H-1 and the final ClampToRect
+	// leaves the reserved row blank.
+	contentH := a.rect.H - 1
+	if contentH < 1 {
+		contentH = 1
+	}
+
 	// Window the rows around the cursor so a focused selection below the fold
 	// scrolls into view instead of moving invisibly. The focused selection
 	// expands to a 2-line row (title + detail), so reserve a line for the
 	// detail when scrolling the selection to the bottom keeps it fully visible
 	// rather than clipping its detail off the fold.
-	visible := a.rect.H - 1
+	visible := contentH - 1
 	if visible < 0 {
 		visible = 0
 	}
@@ -406,13 +416,13 @@ func (a *AutomationsPane) String() string {
 		a.offset = 0
 	}
 	for i := a.offset; i < len(tasks); i++ {
-		if len(lines) >= a.rect.H {
+		if len(lines) >= contentH {
 			break
 		}
 		expanded := a.focused && i == a.selected
 		rowStart := len(lines)
 		lines = append(lines, a.titleRow(tasks[i], expanded))
-		if expanded && len(lines) < a.rect.H {
+		if expanded && len(lines) < contentH {
 			if detail := a.detailRow(tasks[i]); detail != "" {
 				lines = append(lines, detail)
 			}

--- a/ui/automations_test.go
+++ b/ui/automations_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -39,7 +40,8 @@ func stripTasks() []task.Task {
 // trailing cron/next/last text.
 func TestAutomationsCollapsedRowsAreTitleOnly(t *testing.T) {
 	a := newTestAutomations(stripTasks())
-	a.SetRect(layout.Rect{W: 100, H: 3})
+	// H is title + 2 task rows + the reserved bottom-margin row (#1560).
+	a.SetRect(layout.Rect{W: 100, H: 4})
 
 	out := a.View()
 	require.Contains(t, out, "Automations")
@@ -55,7 +57,9 @@ func TestAutomationsCollapsedRowsAreTitleOnly(t *testing.T) {
 // the title, and no other row does.
 func TestAutomationsExpandedRowRevealsDetail(t *testing.T) {
 	a := newTestAutomations(stripTasks())
-	a.SetRect(layout.Rect{W: 100, H: 4})
+	// H is title + the expanded row (title + detail) + a collapsed row + the
+	// reserved bottom-margin row (#1560).
+	a.SetRect(layout.Rect{W: 100, H: 5})
 	a.Focus()
 
 	out := a.View()
@@ -83,6 +87,44 @@ func TestAutomationsStripOneLineSummary(t *testing.T) {
 	out := a.View()
 	requireExactRect(t, out, layout.Rect{W: 70, H: 1}, "compact strip")
 	assert.Contains(t, out, "Automations: 2 (1 on)")
+}
+
+// TestAutomationsReservesBottomMargin pins #1560: the section always keeps its
+// last row blank so the workspace frame's bottom border can never land on the
+// same line as a task row (or the compact summary). It mirrors the sidebar's
+// leading blank row, which keeps the workspace's TOP border off the rail.
+func TestAutomationsReservesBottomMargin(t *testing.T) {
+	tasks := make([]task.Task, 8)
+	for i := range tasks {
+		tasks[i] = task.Task{
+			ID: fmt.Sprintf("%d", i), Name: fmt.Sprintf("task-%d", i),
+			CronExpr: "0 3 * * *", Enabled: true,
+		}
+	}
+	lastBlank := func(lines []string) bool {
+		return strings.TrimRight(lines[len(lines)-1], " ") == ""
+	}
+
+	// Compact summary: the region is 2 rows (summary + reserved margin).
+	compact := newTestAutomations(tasks)
+	compact.SetRect(layout.Rect{W: 40, H: layout.AutomationsCompactRows})
+	compact.SetCompact(true)
+	clines := plainLines(compact.View())
+	require.Len(t, clines, layout.AutomationsCompactRows)
+	assert.Contains(t, clines[0], "Automations")
+	assert.True(t, lastBlank(clines), "the compact summary reserves a blank bottom-margin row")
+
+	// Full mode, focused, with more tasks than fit: content wants every row, but
+	// the last row still stays blank.
+	full := newTestAutomations(tasks)
+	full.SetRect(layout.Rect{W: 40, H: 5})
+	full.Focus()
+	flines := plainLines(full.View())
+	require.Len(t, flines, 5)
+	assert.Contains(t, strings.Join(flines[:len(flines)-1], "\n"), "task-",
+		"tasks render in the rows above the reserved margin")
+	assert.True(t, lastBlank(flines),
+		"the last row stays blank so the workspace border can't abut a task row")
 }
 
 // TestAutomationsFocusShowsCursorNotManager: focusing the section adds a

--- a/ui/automations_test.go
+++ b/ui/automations_test.go
@@ -40,8 +40,7 @@ func stripTasks() []task.Task {
 // trailing cron/next/last text.
 func TestAutomationsCollapsedRowsAreTitleOnly(t *testing.T) {
 	a := newTestAutomations(stripTasks())
-	// H is title + 2 task rows + the reserved bottom-margin row (#1560).
-	a.SetRect(layout.Rect{W: 100, H: 4})
+	a.SetRect(layout.Rect{W: 100, H: 3})
 
 	out := a.View()
 	require.Contains(t, out, "Automations")
@@ -57,8 +56,9 @@ func TestAutomationsCollapsedRowsAreTitleOnly(t *testing.T) {
 // the title, and no other row does.
 func TestAutomationsExpandedRowRevealsDetail(t *testing.T) {
 	a := newTestAutomations(stripTasks())
-	// H is title + the expanded row (title + detail) + a collapsed row + the
-	// reserved bottom-margin row (#1560).
+	// title + the expanded row (title + detail) + a collapsed row + the reserved
+	// bottom-margin row (#1560) — the size the grid grows the section to for two
+	// tasks (2 + margin + 2).
 	a.SetRect(layout.Rect{W: 100, H: 5})
 	a.Focus()
 
@@ -125,6 +125,18 @@ func TestAutomationsReservesBottomMargin(t *testing.T) {
 		"tasks render in the rows above the reserved margin")
 	assert.True(t, lastBlank(flines),
 		"the last row stays blank so the workspace border can't abut a task row")
+
+	// No capacity regression below the grid's floor: a direct caller that hands
+	// the pane a tighter, content-exact full-mode rect than the grid ever
+	// produces keeps every task row rather than losing one to the margin. The
+	// grid always sizes the real section >= AutomationsRows tall, so this is a
+	// direct-caller-only path — the margin only matters at the grid's real sizes.
+	tight := newTestAutomations(stripTasks())
+	require.Less(t, 3, layout.AutomationsRows, "H:3 must be below the margin floor for this to test the tight path")
+	tight.SetRect(layout.Rect{W: 100, H: 3})
+	out := tight.View()
+	assert.Contains(t, out, "nightly-sweep", "H:3 full mode keeps the first task row")
+	assert.Contains(t, out, "ci-watch", "H:3 full mode keeps the second task row (no capacity regression)")
 }
 
 // TestAutomationsFocusShowsCursorNotManager: focusing the section adds a

--- a/ui/automations_zones_test.go
+++ b/ui/automations_zones_test.go
@@ -19,7 +19,8 @@ func TestAutomationsRegistersRowZones(t *testing.T) {
 	a := newTestAutomations(tasks)
 	reg := zones.NewRegistry()
 	a.SetZoneRegistry(reg)
-	rect := layout.Rect{X: 2, Y: 40, W: 90, H: 3}
+	// H is title + 2 task rows + the reserved bottom-margin row (#1560).
+	rect := layout.Rect{X: 2, Y: 40, W: 90, H: 4}
 	a.SetRect(rect)
 
 	reg.Reset()

--- a/ui/automations_zones_test.go
+++ b/ui/automations_zones_test.go
@@ -19,8 +19,7 @@ func TestAutomationsRegistersRowZones(t *testing.T) {
 	a := newTestAutomations(tasks)
 	reg := zones.NewRegistry()
 	a.SetZoneRegistry(reg)
-	// H is title + 2 task rows + the reserved bottom-margin row (#1560).
-	rect := layout.Rect{X: 2, Y: 40, W: 90, H: 4}
+	rect := layout.Rect{X: 2, Y: 40, W: 90, H: 3}
 	a.SetRect(rect)
 
 	reg.Reset()

--- a/ui/layout/grid.go
+++ b/ui/layout/grid.go
@@ -53,9 +53,21 @@ const (
 
 	// AutomationsRows is the full automations-section height (bottom of the
 	// left rail, #1087); AutomationsCompactRows is its 1-line-summary height
-	// when the terminal is tight.
-	AutomationsRows        = 3
-	AutomationsCompactRows = 1
+	// when the terminal is tight. Both include automationsBottomMargin: the
+	// section reserves its last row as a blank bottom margin so the workspace
+	// frame's bottom border never abuts the rail's text (#1560) — the floor is
+	// therefore 4 (title + one row + margin) and the compact summary is 2
+	// (summary + margin).
+	AutomationsRows        = 4
+	AutomationsCompactRows = 2
+
+	// automationsBottomMargin is the blank row the automations section keeps at
+	// the very bottom of the rail. It mirrors the sidebar's leading blank row
+	// (sidebar chromeLines): that keeps the workspace's TOP border off the
+	// rail's first row, and this keeps the BOTTOM border off the rail's last
+	// row, so the bottom-aligned section can never render text on the same line
+	// as the workspace frame's `╰──╯` (#1560).
+	automationsBottomMargin = 1
 
 	// PaneMinWidth is the minimum usable width of one workspace pane (#1088,
 	// §2.6). The pane-count fitting divides the workspace evenly with 1-col
@@ -195,14 +207,15 @@ func (g Grid) Solve(width, height int) Layout {
 			rows = AutomationsCompactRows
 		} else {
 			// Grow the section to show every automation when the rail has the
-			// room: the title line, one row per automation, plus one line held
-			// for the focused row's expansion detail so expanding never has to
-			// scroll (#1126). The AutomationsRows floor keeps a recognizable
-			// strip when there are few automations; the half-rail cap keeps the
-			// instances tree the priority — automations only collapse into a
-			// scrollable strip once the tree + automations together can't fit,
-			// at which point the tree keeps at least half the rail.
-			if want := 2 + g.Automations; want > rows {
+			// room: the title line, one row per automation, one line held for
+			// the focused row's expansion detail so expanding never has to
+			// scroll (#1126), plus the reserved bottom margin (#1560). The
+			// AutomationsRows floor keeps a recognizable strip when there are
+			// few automations; the half-rail cap keeps the instances tree the
+			// priority — automations only collapse into a scrollable strip once
+			// the tree + automations together can't fit, at which point the tree
+			// keeps at least half the rail.
+			if want := 2 + automationsBottomMargin + g.Automations; want > rows {
 				rows = want
 			}
 			if half := (rail.H - RailRuleRows) / 2; half >= AutomationsRows && rows > half {

--- a/ui/layout/grid_test.go
+++ b/ui/layout/grid_test.go
@@ -166,11 +166,12 @@ func TestGridSolveAutomationsGrowsToContent(t *testing.T) {
 	assert.Equal(t, layout.AutomationsRows, none.Automations.H, "no automations keeps the floor")
 
 	// A handful of automations on a tall rail: the section is exactly title +
-	// one row per automation + the reserved expansion line, and the tree gets
-	// the rest of the rail (not the reverse).
+	// one row per automation + the reserved expansion line + the reserved
+	// bottom-margin row (#1560), and the tree gets the rest of the rail (not the
+	// reverse).
 	tall := layout.Grid{Automations: 4}.Solve(120, 60)
 	require.False(t, tall.AutomationsCompact, "a tall rail is not compact")
-	assert.Equal(t, 2+4, tall.Automations.H, "the section grows to fit all automations")
+	assert.Equal(t, 2+1+4, tall.Automations.H, "the section grows to fit all automations plus the bottom margin")
 	assert.Greater(t, tall.Tree.H, tall.Automations.H, "the tree keeps the larger share")
 
 	// More automations than half the rail: the section collapses to (at most)


### PR DESCRIPTION
## Problem (#1560)

With at least one task row in the Automations rail, at small widths (e.g. 60×20 — and around the task row at wider sizes after pane-resize churn) the rail text/task row and the workspace frame border share the same line:

```
 Automation…· m manage╰────────────╯    (compact summary)
 [✓] hello-task       │──────────│      (a task row, when content fills to the bottom)
```

## Root cause

The left rail bottom-aligns the Automations section flush against the full-height bordered workspace. The workspace's **top** border row is kept off the rail's text by the sidebar's deliberate leading blank row (`chromeLines`), but there was **no symmetric bottom margin** — so the workspace's **bottom** border row (`╰──╯`) always landed on the same line as the Automations section's last row. It only *looks* clean when the section happens to have slack (few tasks, unfocused); compact mode and focused/expanded/overflowing full mode fill to the last row and collide.

## Fix

Reserve one blank row at the very bottom of the Automations section, mirroring the sidebar's leading blank row that already protects the top border:

- The grid sizes the section one row taller (`AutomationsRows` 3→4, `AutomationsCompactRows` 1→2, grow-to-content budget +1) so **visible task capacity is unchanged**.
- The pane renders content into `rect.H-1` rows, leaving the last row blank.

The workspace's bottom border now always abuts a blank rail row, exactly like the top. Exact tiling is preserved (the reserved row belongs to the section's rect).

## Verification

Before → after at 60×20 (compact):

```
 Automation…· m manage╰────────────╯     →      Automation…· m manage│           │
                                                                     ╰───────────╯
```

Task rows / the compact summary now abut a clean `│` separator (like the tree rows), and `╰──╯` sits beside a blank rail row.

- Driven live in the containerized TUI sandbox at 60×20 (compact) and 90×24 (full mode, automations focused + a row expanded) — collision gone in both.
- Adds `TestAutomationsReservesBottomMargin` (compact + focused-overflow); updates height fixtures that hard-coded the old flush sizing.
- `gofmt`, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` all clean.

Fixes #1560.

Signed-off-by: Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)