### PR TITLE
fix(tui): keep wrapped pane transcript legible at boundaries (#1556)

### DIFF
--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -324,8 +324,26 @@ func (t *TermPane) Resize(width, height int) {
 	}
 	t.gridMu.Lock()
 	t.emu.Resize(width, ptyHeight)
+	// The pinned x/vt emulator resizes by re-windowing the cell buffer, not by
+	// reflowing it: a wrapped line is truncated to the new width and loses its
+	// overflow, while the stale continuation row it wrapped onto stays behind
+	// (#1556). Until tmux's SIGWINCH-driven full redraw lands, the grid can
+	// therefore show a command's tail running straight into the next prompt —
+	// prompts and commands visually merged. Blank the visible grid now so that
+	// unavoidable transient reads as an empty pane filling in rather than a
+	// corrupted transcript; tmux always full-redraws a resized client, so no
+	// legitimate content is lost. The write goes through the same parser as
+	// tmux's output and under the same lock, so it can never interleave with a
+	// redraw mid-parse.
+	_, _ = t.emu.Write(resizeBlank)
 	t.gridMu.Unlock()
 }
+
+// resizeBlank erases the whole display (ED 2) and homes the cursor — the
+// standard way a program clears a terminal. Written to the emulator after a
+// resize to drop the truncated, un-reflowed grid the pinned x/vt leaves behind
+// (#1556) before tmux repaints.
+var resizeBlank = []byte("\x1b[2J\x1b[H")
 
 // Render returns the emulator's current grid as exactly height ANSI-styled
 // lines of exactly width cells. It only reads the grid — safe to call at any

--- a/ui/termpane/termpane.go
+++ b/ui/termpane/termpane.go
@@ -342,7 +342,9 @@ func (t *TermPane) Resize(width, height int) {
 // resizeBlank erases the whole display (ED 2) and homes the cursor — the
 // standard way a program clears a terminal. Written to the emulator after a
 // resize to drop the truncated, un-reflowed grid the pinned x/vt leaves behind
-// (#1556) before tmux repaints.
+// (#1556) before tmux repaints. x/vt's ED 2 is screen-aware — it clears the
+// active screen (e.scr) — so this also blanks the alternate screen when a
+// full-screen program (vim/less/...) is what the resize caught mid-frame.
 var resizeBlank = []byte("\x1b[2J\x1b[H")
 
 // Render returns the emulator's current grid as exactly height ANSI-styled

--- a/ui/termpane/termpane_test.go
+++ b/ui/termpane/termpane_test.go
@@ -159,6 +159,22 @@ func TestResizeBlanksStaleGrid(t *testing.T) {
 	assert.Emptyf(t, strings.TrimSpace(got), "resize must blank the truncated, un-reflowed grid (#1556); got:\n%s", got)
 }
 
+// TestResizeBlanksStaleAltScreenGrid extends the #1556 fix to a full-screen
+// program (vim/less/...) occupying the alternate screen when the resize lands.
+// The blank must follow the ACTIVE screen: x/vt's ED 2 clears whichever screen
+// is current (e.scr), so entering the alternate screen (?1049h) and resizing
+// must leave that screen blank, not the stale, truncated alt grid — otherwise
+// the pane would show a merged full-screen buffer until tmux repaints.
+func TestResizeBlanksStaleAltScreenGrid(t *testing.T) {
+	// Switch to the alternate screen, then draw a line there that wraps at 20.
+	tp := startScript(t, "printf '\\033[?1049h'; printf 'ALT chmod +x todo.sh test.sh\\r\\nalt-marker-1556\\r\\n'; sleep 30", 20, 6)
+	waitForRender(t, tp, 20, 6, "alt-marker-1556")
+
+	tp.Resize(14, 6)
+	got := plainRender(tp, 14, 6)
+	assert.Emptyf(t, strings.TrimSpace(got), "resize must blank the ACTIVE (alternate) screen (#1556); got:\n%s", got)
+}
+
 func TestHiddenStatusRowsAreNotRendered(t *testing.T) {
 	tp := startScriptWithStatusLayout(t, "printf 'VISIBLE-1425\\033[7;1HSTATUS-1425-A\\033[8;1HSTATUS-1425-B'; sleep 30", 30, 6, 2, statusBottom)
 	waitForRender(t, tp, 30, 6, "VISIBLE-1425")

--- a/ui/termpane/termpane_test.go
+++ b/ui/termpane/termpane_test.go
@@ -137,6 +137,28 @@ func TestResizePropagatesPTYWinsize(t *testing.T) {
 	waitForRender(t, tp, 100, 30, "30 100")
 }
 
+// TestResizeBlanksStaleGrid pins the #1556 fix: the pinned x/vt emulator
+// resizes by re-windowing the cell buffer, not by reflowing it, so a wrapped
+// line is truncated to the new width and its continuation row is left behind —
+// which renders as a command's tail merging straight into the next prompt.
+// Real attachments self-heal on tmux's redraw, but until it lands the grid must
+// not show that corrupted transcript. Resize therefore blanks the visible grid;
+// here a scripted PTY (no tmux, so nothing ever redraws) makes that guarantee
+// observable: after the resize the pane is empty, not merged.
+func TestResizeBlanksStaleGrid(t *testing.T) {
+	// "dev@host$ chmod +x todo.sh test.sh" is 34 cols, so it wraps at width 20:
+	// row 0 is the prompt+command head, row 1 the "odo.sh test.sh" tail.
+	tp := startScript(t, "printf 'dev@host$ chmod +x todo.sh test.sh\\r\\nnext-marker-1556\\r\\n'; sleep 30", 20, 6)
+	waitForRender(t, tp, 20, 6, "next-marker-1556")
+	require.Contains(t, plainRender(tp, 20, 6), "odo.sh test.sh", "setup: the command must wrap so a continuation row exists")
+
+	// Shrink the pane. With no tmux behind the PTY nothing repaints, so whatever
+	// the grid holds now is exactly what a pre-redraw frame would show.
+	tp.Resize(14, 6)
+	got := plainRender(tp, 14, 6)
+	assert.Emptyf(t, strings.TrimSpace(got), "resize must blank the truncated, un-reflowed grid (#1556); got:\n%s", got)
+}
+
 func TestHiddenStatusRowsAreNotRendered(t *testing.T) {
 	tp := startScriptWithStatusLayout(t, "printf 'VISIBLE-1425\\033[7;1HSTATUS-1425-A\\033[8;1HSTATUS-1425-B'; sleep 30", 30, 6, 2, statusBottom)
 	waitForRender(t, tp, 30, 6, "VISIBLE-1425")


### PR DESCRIPTION
## What

Fixes #1556 — the embedded terminal pane (`ui/termpane`) momentarily rendered prompts, commands, and output visually **merged** at pane boundaries after a resize, e.g.:

```
dev@host:~/sandbox/mock-repo-feature$ git 
& echo commit -m 'add smoke test ok'
```

where the real command was `git add smoke.sh && echo commit -m 'add smoke test ok'`. The underlying files/tests/commits were always correct — this was purely a rendering/legibility problem that undermined trust while doing real shell work.

## Root cause

The pane emulates tmux's screen through the pinned `charmbracelet/x/vt` emulator. That emulator **resizes by re-windowing its cell buffer, not by reflowing it**: on a narrowing resize a wrapped line is truncated to the new width and loses its overflow, while the continuation row it had wrapped onto is left behind. The result is a grid where a command's tail runs straight into the next prompt.

In production this is **transient**: tmux always issues a full redraw on the resize `SIGWINCH`, so the pane self-heals within a frame or two. But `Render` is driven by the TUI's 100 ms tick, and any tick that lands in the window between `emu.Resize` and tmux's redraw shows the corrupted grid. `TabbedWindow.SetRect` calls `live.Resize` on every layout change — entering interactive mode, window/sidebar resize — so the merge is easy to catch, which is exactly what the play-test did.

Steady-state rendering is **not** affected: I verified the termpane output is byte-identical to `tmux capture-pane -p` with no resize in play.

## Fix

Blank the visible grid (`ED 2` + cursor home) right after `emu.Resize`, so the unavoidable pre-redraw transient reads as an **empty pane filling in** rather than a garbled transcript. tmux full-redraws a resized client, so no legitimate content is lost; the erase goes through the same parser and under the same `gridMu` lock as tmux's output, so it can never interleave with a redraw mid-parse.

This is a clean render-layer fix — the underlying non-reflowing resize is an upstream `x/vt` limitation we don't control, but we fully control what the pane shows in the gap before tmux repaints.

## Why not "just reflow"

Reflow lives in the emulator (upstream), not our layer. Recreating the emulator on each resize would race the PTY read/response pumps that hold its pipes. Blanking is the minimal, safe, correct thing to show until tmux's authoritative redraw lands.

## Test

`TestResizeBlanksStaleGrid` pins the fix with a scripted PTY (no tmux, so nothing ever repaints — the post-resize frame is exactly a pre-redraw frame). Verified it **fails without the fix**, printing the `dev@host$ chmo` / `odo.sh test.sh` merge, and passes with it.

## Guardrails

- `gofmt -l .` — clean
- `go build ./...` — ok
- `golangci-lint run --timeout=3m --fast` — clean
- `deadcode -test ./...` — clean
- `scripts/lint-file-length.sh` — passed
- `make test-container` — all packages green

Not merging — this is VISIBLE-TUI, so leaving it for root to play-test + Greptile-gate + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
