### PR TITLE
fix(daemon): don't let a slow post-worktree hook time out agent readiness (#1577)

### DIFF
--- a/session/git/hooks.go
+++ b/session/git/hooks.go
@@ -31,18 +31,29 @@ const hookWaitDelay = 2 * time.Second
 // completion or cancellation. Backgrounded grandchildren therefore never
 // outlive their parent hook.
 // Errors are logged but do not propagate.
-func RunPostWorktreeHooksAsync(ctx context.Context, repoPath, worktreePath string) {
+//
+// The returned channel is closed once every hook has finished — whether by
+// normal completion, failure, or ctx cancellation. It is closed immediately
+// when there are no hooks to run (or the repo config can't be resolved). It
+// lets callers tell whether provisioning is still in flight; in particular the
+// readiness wait uses it so a slow build hook running concurrently with the
+// agent is not charged against the agent's startup budget (see task.WaitForReady).
+func RunPostWorktreeHooksAsync(ctx context.Context, repoPath, worktreePath string) <-chan struct{} {
+	done := make(chan struct{})
 	repoCfg, err := config.ResolveConfig(repoPath)
 	if err != nil {
 		log.WarningLog.Printf("failed to resolve repo config for hooks: %v", err)
-		return
+		close(done)
+		return done
 	}
 	if len(repoCfg.PostWorktreeCommands) == 0 {
-		return
+		close(done)
+		return done
 	}
 
 	cmds := repoCfg.PostWorktreeCommands
 	go func() {
+		defer close(done)
 		for _, cmdStr := range cmds {
 			select {
 			case <-ctx.Done():
@@ -117,4 +128,5 @@ func RunPostWorktreeHooksAsync(ctx context.Context, repoPath, worktreePath strin
 			}
 		}
 	}()
+	return done
 }

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -76,6 +76,20 @@ type GitWorktree struct {
 	// outlive the worktree itself.
 	hooksCtx    context.Context
 	hooksCancel context.CancelFunc
+	// hooksDone is closed when the most recent post-worktree hook run finishes
+	// (completion or cancellation). Set by Setup/Rebuild* right before they
+	// return, read by the readiness wait after Start returns — a strict
+	// happens-before, so it is accessed lock-free like branchCreatedByUs. Nil
+	// until the first hook run is launched (e.g. external worktrees that skip
+	// hooks entirely), which HooksDone reports as "no hooks in flight".
+	hooksDone <-chan struct{}
+}
+
+// HooksDone returns a channel that is closed once the worktree's post-worktree
+// hooks have finished (completion or cancellation), or nil if no hook run has
+// been launched for this worktree. Callers treat nil as "nothing in flight".
+func (g *GitWorktree) HooksDone() <-chan struct{} {
+	return g.hooksDone
 }
 
 // IsExternalWorktree returns true if this worktree was not created by agent-factory

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -45,7 +45,7 @@ func (g *GitWorktree) Setup() error {
 	}
 
 	// Fire-and-forget post-worktree hooks (cancellable via hooksCtx)
-	RunPostWorktreeHooksAsync(g.hooksCtx, g.repoPath, g.worktreePath)
+	g.hooksDone = RunPostWorktreeHooksAsync(g.hooksCtx, g.repoPath, g.worktreePath)
 	return nil
 }
 
@@ -77,7 +77,7 @@ func (g *GitWorktree) RebuildFromExistingBranch() error {
 	}
 	g.branchCreatedByUs = branchCreatedByUs
 
-	RunPostWorktreeHooksAsync(g.hooksCtx, g.repoPath, g.worktreePath)
+	g.hooksDone = RunPostWorktreeHooksAsync(g.hooksCtx, g.repoPath, g.worktreePath)
 	return nil
 }
 
@@ -117,7 +117,7 @@ func (g *GitWorktree) RebuildFreshFromRecordedBase() error {
 
 	g.baseCommitSHA = baseCommit
 	g.branchCreatedByUs = true
-	RunPostWorktreeHooksAsync(g.hooksCtx, g.repoPath, g.worktreePath)
+	g.hooksDone = RunPostWorktreeHooksAsync(g.hooksCtx, g.repoPath, g.worktreePath)
 	return nil
 }
 

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -99,6 +99,22 @@ func (i *Instance) GetRepoPath() string {
 	return gw.GetRepoPath()
 }
 
+// PostWorktreeHooksDone returns a channel that is closed once the instance's
+// post-worktree hooks (post_worktree_commands) have finished running, or nil
+// when no hook run is in flight — no worktree yet, an external worktree that
+// skips hooks, or a repo with no hooks configured. The readiness wait uses it
+// so a slow build hook running concurrently with the agent is not charged
+// against the agent's startup budget (see task.WaitForReady).
+func (i *Instance) PostWorktreeHooksDone() <-chan struct{} {
+	i.mu.RLock()
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+	if gw == nil {
+		return nil
+	}
+	return gw.HooksDone()
+}
+
 func (i *Instance) Started() bool {
 	i.mu.RLock()
 	defer i.mu.RUnlock()

--- a/task/runner.go
+++ b/task/runner.go
@@ -16,8 +16,20 @@ import (
 var (
 	waitForReadyTimeout      = 60 * time.Second
 	waitForReadyPollInterval = 500 * time.Millisecond
-	ampPromptFrameTop        = regexp.MustCompile(`(?m)^\s*╭[─ ]+(low|medium|high|deep)[─ ]+╮\s*\n\s*│`)
+	// waitForReadyHookGrace bounds how long in-flight post-worktree hooks may
+	// hold the readiness deadline open (see WaitForReady). It only matters for a
+	// misconfigured non-terminating hook; real provisioning builds finish far
+	// inside it, so it is generous rather than tight.
+	waitForReadyHookGrace = 10 * time.Minute
+	ampPromptFrameTop     = regexp.MustCompile(`(?m)^\s*╭[─ ]+(low|medium|high|deep)[─ ]+╮\s*\n\s*│`)
 )
+
+// postWorktreeHooksDoneForWait resolves the instance's post-worktree hook
+// completion channel. Indirected so tests can drive the hook-aware readiness
+// timing without standing up a real worktree and hook run.
+var postWorktreeHooksDoneForWait = func(instance *session.Instance) <-chan struct{} {
+	return instance.PostWorktreeHooksDone()
+}
 
 // LimitReachedError is what WaitForReady returns when the agent shows a
 // usage-limit banner during startup instead of its input prompt (#1146 PR4):
@@ -148,12 +160,45 @@ func WaitForReady(instance *session.Instance) error {
 	// limit banner mid-startup is recognized and PARKED, not spun into a failure
 	// (#1146 PR4). Only claude/codex ever match; other agents never park here.
 	detector := newLimitDetectorForWait()
-	timeout := time.After(waitForReadyTimeout)
+
+	// The readiness budget measures the AGENT's startup. Post-worktree hooks
+	// (e.g. a `make dev_install` build in post_worktree_commands) run
+	// concurrently with the agent and can saturate the machine, starving the
+	// agent's process so it renders its ready prompt late. That hook runtime must
+	// not be charged against readiness, or a perfectly healthy agent looks like
+	// it failed to start — the amp "does-amp-work" timeout. So the timeout stays
+	// disarmed while provisioning is in flight and starts fresh only once the
+	// hooks drain. A fast agent that becomes ready mid-hook still returns
+	// immediately from the ticker branch below, and when no hooks are in flight
+	// (hooksDone == nil — no worktree, external worktree, or no hooks configured)
+	// the timeout is armed right away, exactly as before.
+	hooksDone := postWorktreeHooksDoneForWait(instance)
+	var timeout <-chan time.Time
+	var hookGrace <-chan time.Time
+	if hooksDone == nil {
+		timeout = time.After(waitForReadyTimeout)
+	} else {
+		// Safety valve: a misconfigured non-terminating post_worktree_command
+		// (e.g. a foreground server) would otherwise hold the deadline open
+		// forever and wedge session startup. Cap how long hooks may defer the
+		// readiness clock; normal provisioning builds finish well within it.
+		hookGrace = time.After(waitForReadyHookGrace)
+	}
 	ticker := time.NewTicker(waitForReadyPollInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
+		case <-hooksDone:
+			// Provisioning finished: arm the full readiness budget from here and
+			// stop watching the hooks channels.
+			hooksDone, hookGrace = nil, nil
+			timeout = time.After(waitForReadyTimeout)
+		case <-hookGrace:
+			// Hooks ran too long to be normal provisioning; stop deferring to
+			// them and enforce the readiness budget so startup can't hang forever.
+			hooksDone, hookGrace = nil, nil
+			timeout = time.After(waitForReadyTimeout)
 		case <-timeout:
 			content, err := instance.Preview()
 			if err != nil {

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -273,6 +273,95 @@ func setWaitForReadyTimingForTest(timeout, poll time.Duration) func() {
 	}
 }
 
+// setWaitForReadyHookGraceForTest shrinks the hook-grace valve so a
+// non-terminating hook is bounded in milliseconds, and returns a restore func.
+func setWaitForReadyHookGraceForTest(grace time.Duration) func() {
+	prev := waitForReadyHookGrace
+	waitForReadyHookGrace = grace
+	return func() { waitForReadyHookGrace = prev }
+}
+
+// setPostWorktreeHooksDoneForWait injects the hook-completion channel
+// WaitForReady observes, so a test can drive hook-aware readiness timing
+// without standing up a real worktree and hook run. Returns a restore func.
+func setPostWorktreeHooksDoneForWait(fn func(*session.Instance) <-chan struct{}) func() {
+	prev := postWorktreeHooksDoneForWait
+	postWorktreeHooksDoneForWait = fn
+	return func() { postWorktreeHooksDoneForWait = prev }
+}
+
+// TestWaitForReadySlowHookDoesNotTimeOutHealthyAgent is the core fix for the
+// amp "does-amp-work" timeout: a slow post-worktree hook (e.g. a `make`
+// build) runs concurrently with the agent and its runtime must NOT be charged
+// against the agent's readiness budget. Here the agent stays not-ready for far
+// longer than the (tiny) base timeout while the hook runs; readiness must be
+// deferred until the hook drains, so the healthy agent is not spuriously failed.
+func TestWaitForReadySlowHookDoesNotTimeOutHealthyAgent(t *testing.T) {
+	defer setWaitForReadyTimingForTest(30*time.Millisecond, time.Millisecond)()
+
+	hookDone := make(chan struct{})
+	defer setPostWorktreeHooksDoneForWait(func(*session.Instance) <-chan struct{} { return hookDone })()
+
+	var ready atomic.Bool
+	inst := newPreviewInstance(t, func() (string, error) {
+		if ready.Load() {
+			return "ready now\n❯ ", nil
+		}
+		return "still building the worktree...\n", nil
+	})
+
+	// The agent only renders its prompt well after the 30ms base timeout would
+	// have fired — but while the hook is in flight, so readiness must be held.
+	go func() {
+		time.Sleep(120 * time.Millisecond)
+		ready.Store(true)
+		close(hookDone)
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- WaitForReady(inst) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("a slow post-worktree hook must not time out a healthy agent, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForReady never returned while a slow hook was in flight")
+	}
+}
+
+// TestWaitForReadyHookGraceBoundsNonTerminatingHook guards the safety valve: a
+// misconfigured post_worktree_command that never terminates (so its completion
+// channel never closes) must not hang startup forever. Once the hook grace
+// elapses the readiness budget is armed, so a never-ready agent still times out.
+func TestWaitForReadyHookGraceBoundsNonTerminatingHook(t *testing.T) {
+	defer setWaitForReadyTimingForTest(20*time.Millisecond, time.Millisecond)()
+	defer setWaitForReadyHookGraceForTest(30 * time.Millisecond)()
+
+	neverDone := make(chan struct{}) // never closed: models a stuck hook
+	defer setPostWorktreeHooksDoneForWait(func(*session.Instance) <-chan struct{} { return neverDone })()
+
+	inst := newPreviewInstance(t, func() (string, error) {
+		return "still building forever...\n", nil
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- WaitForReady(inst) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a timeout error once the hook grace elapses, got nil")
+		}
+		if !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("expected a timeout error after the grace valve fires, got %q", err.Error())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForReady hung on a non-terminating hook; grace valve did not fire")
+	}
+}
+
 // TestWaitForReadyFailsFastWhenSessionGone is the core #976 fix: when
 // Preview() reports tmux.ErrSessionGone (a definitive, non-retryable death),
 // WaitForReady must return immediately with a clear "session died" error —


### PR DESCRIPTION
Fixes #1577.

## Problem

Creating a session in a repo with a slow `post_worktree_commands` hook (e.g.
`["make dev_install"]`) can fail startup with a readiness timeout even though
the agent started fine. Hit live with an amp session ("does-amp-work").

## Root cause (general, not amp-specific)

`gw.Setup()` fires `RunPostWorktreeHooksAsync` (`session/git/worktree_ops.go`)
as a fire-and-forget goroutine, then the agent pane launches immediately after
(`session/backend_local.go`). The hook runs **concurrently** with the agent —
it never blocks the pane. `task.WaitForReady` then starts its 60s poll and
charges that budget against wall-clock time that includes the concurrent
`make dev_install` build. A heavy build saturates the box, starving the
agent's cold start so it renders its ready prompt **after** the window. The
`hooks.go` "post-worktree hooks cancelled" log is a downstream effect of the
resulting `instance.Kill()`, not the cause.

The amp label is incidental — any agent behind any slow post-worktree hook
hits this.

## Fix

Stop charging hook runtime against the agent's readiness budget:

- `RunPostWorktreeHooksAsync` returns a channel closed once the hooks finish
  (completion **or** cancellation, via `defer close`), surfaced through
  `GitWorktree.HooksDone()` and `Instance.PostWorktreeHooksDone()`.
- `WaitForReady` keeps its timeout **disarmed while hooks are in flight** and
  arms a fresh full readiness budget only once they drain. A fast agent that
  becomes ready mid-hook still returns immediately (readiness detection is
  independent of the timeout). A generous `waitForReadyHookGrace` (10m) safety
  valve bounds a misconfigured non-terminating hook so it can't wedge startup
  forever.
- No worktree / external worktree / no hooks configured → `hooksDone == nil`
  → the timeout arms immediately, exactly as before (all existing WaitForReady
  tests unchanged).

## Tests

- `TestWaitForReadySlowHookDoesNotTimeOutHealthyAgent` — agent stays not-ready
  past the base timeout while a hook runs; readiness is deferred and the agent
  succeeds.
- `TestWaitForReadyHookGraceBoundsNonTerminatingHook` — a never-closing hook
  channel still times out once the grace valve fires (no infinite hang).

Full container suite green; `gofmt`, `golangci-lint --fast`, `deadcode`, and
file-length lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)