### PR TITLE
fix(tui): forward the first Enter keystroke in an interactive pane (#1576)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -561,15 +561,24 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if m.panePreviewTxn != nil {
+		// Committing a sidebar tab-row preview is a tree-navigation action (the
+		// preview only exists while the tree cursor sits on a tab row), so this
+		// Enter selects/commits — it must NOT type into the agent (nil replay),
+		// exactly like the tree select path below (#1576).
 		p, commitCmd := m.commitPanePreviewReplace()
 		if p == nil || liveSessionName(p.Instance(), p.Tab()) == "" {
 			return m, commitCmd
 		}
-		mod, interactCmd := m.enterPane(p)
+		mod, interactCmd := m.enterPane(p, nil)
 		return mod, tea.Batch(commitCmd, interactCmd)
 	}
 	if p := m.focusedOpenPane(); p != nil {
-		return m.enterPane(p)
+		// Enter on an already-focused pane: from the pane's point of view this
+		// is the first in-pane keystroke, so forward it into the agent on entry
+		// rather than swallowing it (#1576). Only this branch replays — the
+		// preview-commit above and the tree select below are navigation Enters.
+		enterKey := tea.KeyMsg{Type: tea.KeyEnter}
+		return m.enterPane(p, &enterKey)
 	}
 
 	sel := m.sidebar.GetSelection()
@@ -606,7 +615,7 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 	if p == nil {
 		return m, cmd
 	}
-	mod, interactCmd := m.requestInteractive(p)
+	mod, interactCmd := m.requestInteractive(p, nil)
 	return mod, tea.Batch(cmd, interactCmd)
 }
 

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -394,8 +394,9 @@ func (m *home) handleClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		}
 		// A click on the already-focused pane's body enters THAT pane — the
 		// click named it, so enter it directly rather than the sidebar selection
-		// keyboard Enter resolves (#1233, §2.5).
-		return m.enterPane(p)
+		// keyboard Enter resolves (#1233, §2.5). No replay key: a click is not a
+		// keystroke, so nothing is forwarded into the pane on entry (#1576).
+		return m.enterPane(p, nil)
 	}
 	if taskID, ok := zones.AutoTaskID(id); ok {
 		// Click a task row: focus the automations section and select the

--- a/app/handle_panes.go
+++ b/app/handle_panes.go
@@ -398,8 +398,12 @@ func (m *home) focusTreeForNav() {
 // Enter still resolves through the sidebar selection; callers that already have
 // a pane binding enter that pane directly. Remote/non-embeddable panes fall
 // back to the full-screen attach of the pane's tab, mirroring handleEnter's
-// remote branch; guard errors surface the same way.
-func (m *home) enterPane(p *store.OpenPane) (tea.Model, tea.Cmd) {
+// remote branch; guard errors surface the same way. A non-nil replayKey is the
+// keystroke that triggered the entry and is forwarded into the pane once
+// interactive mode is live (#1576) — the keyboard focused-pane Enter passes it
+// so the first Enter reaches the agent; the mouse click passes nil (no
+// keystroke to forward).
+func (m *home) enterPane(p *store.OpenPane, replayKey *tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if p == nil {
 		return m, nil
 	}
@@ -413,7 +417,7 @@ func (m *home) enterPane(p *store.OpenPane) (tea.Model, tea.Cmd) {
 		// Not embeddable (remote): the full-screen attach of this pane's tab.
 		return m.handleEnterPane(p)
 	}
-	return m.requestInteractive(p)
+	return m.requestInteractive(p, replayKey)
 }
 
 // handleEnterPane attaches the focused pane's (instance, tab) full-screen:

--- a/app/interactive.go
+++ b/app/interactive.go
@@ -34,10 +34,25 @@ type enterInteractiveMsg struct {
 
 // requestInteractive routes Enter-on-a-live-eligible-pane through the
 // first-time interactive help screen (seen-bitmask, like the attach help)
-// into activation.
-func (m *home) requestInteractive(p *store.OpenPane) (tea.Model, tea.Cmd) {
+// into activation. A non-nil replayKey is the keystroke that triggered the
+// entry (an already-focused pane's Enter): it is forwarded into the pane on
+// activation so the transition key is not swallowed (#1576) — the same
+// contract the first-run help path already honors by replaying its dismiss
+// key. The tree/nav select path and the mouse click pass nil: a navigation
+// Enter opens the pane without also typing into the agent, and a click has no
+// keystroke to forward. When the first-run help IS shown, the dismiss key
+// replay (replayKeyAfterInteractiveHelpDismiss) overrides this key, so the
+// entry key that only surfaced the overlay is never double-forwarded.
+func (m *home) requestInteractive(p *store.OpenPane, replayKey *tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m.showHelpScreen(helpTypeInteractive{}, func() tea.Cmd {
-		return func() tea.Msg { return enterInteractiveMsg{pane: p} }
+		return func() tea.Msg {
+			msg := enterInteractiveMsg{pane: p}
+			if replayKey != nil {
+				msg.replay = true
+				msg.replayKey = *replayKey
+			}
+			return msg
+		}
 	})
 }
 

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -61,11 +61,17 @@ func runHermeticCmd(t *testing.T, h *home, cmd tea.Cmd, depth int) {
 }
 
 // enterInteractive presses Enter on the focused pane and drives the deferred
-// activation to completion.
+// activation to completion. That entry Enter is itself forwarded into the pane
+// (#1576) — TestFirstEnterOnFocusedPaneForwardsIntoPane pins that behavior. The
+// recorded keys are reset here so callers can assert on the keystrokes they
+// send NEXT without the entry Enter sitting in front of them.
 func enterInteractive(t *testing.T, h *home) {
 	t.Helper()
 	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
 	runHermeticCmd(t, h, cmd, 0)
+	if lt, ok := h.liveTerm.(*fakeLiveTerm); ok {
+		lt.keys = nil
+	}
 }
 
 func TestEnterOnFocusedLivePaneEntersInteractive(t *testing.T) {
@@ -80,6 +86,55 @@ func TestEnterOnFocusedLivePaneEntersInteractive(t *testing.T) {
 	assert.Equal(t, p, h.livePane)
 	assert.True(t, h.paneWindows[p.ID()].Interactive(), "the pane must carry the interactive visual cue")
 	assert.Contains(t, h.menu.String(), "ctrl+]", "the status bar must show the escape hatch")
+}
+
+// TestFirstEnterOnFocusedPaneForwardsIntoPane is the #1576 regression: with the
+// interactive help already seen (every established user), pressing Enter on an
+// already-focused pane must both enter interactive mode AND forward that first
+// Enter into the pane — the transition key is the pane's first in-pane
+// keystroke and must not be swallowed. Before the fix only the once-ever
+// first-run help path replayed the entry key, so every later entry dropped it.
+func TestFirstEnterOnFocusedPaneForwardsIntoPane(t *testing.T) {
+	h, _, fakes := interactiveTestHome(t)
+
+	// Drive the entry WITHOUT the key-resetting enterInteractive helper so the
+	// forwarded entry keystroke is observable.
+	_, cmd := h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	runHermeticCmd(t, h, cmd, 0)
+
+	require.True(t, h.interactive, "Enter on a focused pane must enter interactive mode")
+	require.Len(t, *fakes, 1)
+	assert.Equal(t, []string{"enter"}, (*fakes)[0].keys,
+		"the Enter that enters a focused pane must forward into the pane, not be swallowed (#1576)")
+
+	// And the pane keeps forwarding normally afterwards.
+	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("z")})
+	assert.Equal(t, []string{"enter", "z"}, (*fakes)[0].keys,
+		"subsequent keystrokes must forward on top of the entry Enter")
+}
+
+// TestEnterFromTreeDoesNotForwardIntoPane guards the other half of #1576: a
+// navigation Enter (tree/sidebar selection) opens+enters the pane but must NOT
+// type into the agent — only an already-focused-pane Enter forwards.
+func TestEnterFromTreeDoesNotForwardIntoPane(t *testing.T) {
+	h := newTestHome(t)
+	require.NoError(t, h.appState.SetHelpScreensSeen(helpTypeInteractive{}.mask()))
+	inst := startedLocalInstance(t, "tree-noforward")
+	selectInstance(h, inst)
+	resizeHome(h, 120, 40)
+	fakes, _ := stubLiveTermFactory(t)
+	require.Zero(t, h.store.NumOpenPanes())
+
+	_, _ = h.handleDefaultKeyPress(tea.KeyMsg{Type: tea.KeyEnter}, keys.KeyEnter)
+	p := h.store.FindOpenPane(inst, 0)
+	require.NotNil(t, p, "Enter from the tree must open the selection's pane")
+	_, cmd := h.Update(enterInteractiveMsg{pane: p})
+	runHermeticCmd(t, h, cmd, 0)
+
+	require.True(t, h.interactive)
+	require.Len(t, *fakes, 1)
+	assert.Empty(t, (*fakes)[0].keys,
+		"a tree/nav select Enter opens the pane but must not type into the agent (#1576)")
 }
 
 func TestFirstRunInteractiveHelpForwardsDismissKey(t *testing.T) {
@@ -348,7 +403,9 @@ func TestEnterWithFocusedPaneTargetsFocusNotSidebarSelection(t *testing.T) {
 	assert.Equal(t, instB, h.sidebar.GetSelectedInstance(), "sidebar selection is unchanged")
 	require.Len(t, *fakes, 1)
 	_, _ = h.handleKeyPress(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Z")})
-	assert.Equal(t, []string{"Z"}, (*fakes)[0].keys)
+	// The entry Enter forwards into focused pane A (#1576), then Z on top —
+	// both land on A's attachment, never sidebar-selected B's.
+	assert.Equal(t, []string{"enter", "Z"}, (*fakes)[0].keys)
 }
 
 func TestEnterOnRemotePaneFallsBackToFullScreenAttach(t *testing.T) {


### PR DESCRIPTION
## What

Pressing **Enter as the first keystroke on a focused embedded-terminal pane** swallowed that Enter instead of forwarding it to the agent/shell. The mode flipped into interactive, but the triggering Enter never reached the program — you had to press Enter a *second* time. Later keystrokes always worked.

Fixes #1576.

## Root cause

Entry into interactive mode consumed the transition keystroke. The **only** path that forwarded it was the once-ever first-run interactive help overlay, which replays its dismiss key (`replayKeyAfterInteractiveHelpDismiss`). Once the help "seen" bit is set — i.e. for every established user, on every entry — `requestInteractive` → `showHelpScreen` returns immediately with `enterInteractiveMsg{replay: false}`, so `activateInteractive` flips the mode on but `handleInteractiveKey` is never called for the entry key.

Swallowed path: `handleEnter` (focused-pane branch) → `enterPane` → `requestInteractive` → `enterInteractiveMsg{replay:false}` → `home_update` activates but skips the forward.

Reproduces exactly as Sachin reported: `s` (open/focus pane) → Enter (swallowed, enters interactive) → Enter (forwarded).

## Fix

Thread the triggering keystroke through the **keyboard focused-pane** entry so it is forwarded into the pane on activation, mirroring the first-run replay contract that already existed.

Scope is deliberately just the in-pane Enter (the guardrail: *nav-mode Enter still selects/opens*):
- **Focused-pane Enter** (`handleEnter` focused-pane branch) → replays the Enter into the agent. ✅ the bug.
- **Tree/sidebar select Enter** and **tab-row preview-commit Enter** → navigation actions; open/select without typing into the agent (nil replay).
- **Mouse click-to-interact** → no keystroke to forward (nil replay).
- **First-run help** → its dismiss-key replay overrides, so the entry key that only surfaced the overlay is never double-forwarded.

## Tests

- `TestFirstEnterOnFocusedPaneForwardsIntoPane` — the #1576 regression: entry Enter reaches the pane, then normal forwarding continues.
- `TestEnterFromTreeDoesNotForwardIntoPane` — guards the nav-Enter half (tree select opens the pane but types nothing).
- Existing interactive/mouse suites updated for the now-forwarded entry key.

## Guardrails

`gofmt -l .` clean · `go build ./...` OK · `golangci-lint run --fast` clean · `deadcode -test ./...` clean · file-length lint passed · `go test ./app/ ./ui/termpane/` green. (Visible-TUI change — root runs `make tui-driver-selftest` before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
