### PR TITLE
feat(sessions): inject the af skill into amp agents (#1582)

### DIFF
--- a/session/ampskill.go
+++ b/session/ampskill.go
@@ -1,26 +1,40 @@
 package session
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
 )
 
-// ampSkillName is the directory- and skill-name amp discovers under its home
-// skills path.
-const ampSkillName = "af"
+// ampSkillDirName is the directory- and skill-name amp discovers under its home
+// skills path. It is deliberately "agent-factory", NOT "af": amp's skills dir is
+// the user's GLOBAL amp config, shared with skills they install by hand, and "af"
+// is exactly the short name a user or another tool would pick for their own af
+// helper skill. Namespacing to "agent-factory" makes the directory unambiguously
+// af-owned so we never collide with a user's "af" skill (#1585 review).
+const ampSkillDirName = "agent-factory"
+
+// ampSkillMarker stamps every SKILL.md we write so a later launch can tell a
+// file it owns (safe to regenerate) from a user's/tool's own skill that happens
+// to sit at our path (never clobber). See ensureAmpSkillDir.
+const ampSkillMarker = "managed by agent-factory (af): regenerated on each af session launch; do not edit"
 
 // ampSkillDoc is the SKILL.md served to amp. Its body is afUsageReference
 // (systemprompt.go) — the SAME text Claude receives via the plugin skill and
 // Codex via developer_instructions — so the three agents' af knowledge cannot
 // drift (#1043). Amp requires only name + description frontmatter for a skill
 // (verified against `amp skill list`); the description is what amp surfaces for
-// lazy activation, so it must mirror the Claude plugin skill's description.
+// lazy activation, so it mirrors the Claude plugin skill's description. The
+// ampSkillMarker rides in an HTML comment just below the frontmatter — invisible
+// in rendered markdown, and the token ensureAmpSkillDir checks for ownership.
 var ampSkillDoc = "---\n" +
-	"name: " + ampSkillName + "\n" +
+	"name: " + ampSkillDirName + "\n" +
 	"description: Manage Agent Factory (af) sessions, tabs, scheduled tasks, and the daemon via the af CLI\n" +
 	"---\n" +
+	"<!-- " + ampSkillMarker + " -->\n" +
 	"\n" +
 	afUsageReference + "\n"
 
@@ -42,28 +56,42 @@ func ampSkillsBaseDir() (string, error) {
 	return filepath.Join(home, ".config", "amp", "skills"), nil
 }
 
-// ensureAmpSkillDir writes the "af" skill into amp's home skills directory and
-// returns the skill directory path. Amp auto-discovers skills there with NO
-// command-line flag (amp has no --plugin-dir / developer_instructions
-// equivalent), so this is how afUsageReference reaches amp sessions WITHOUT
-// touching the launch command — the amp spawn stays byte-identical to the
-// no-injection launch that already reaches ready, which is the whole point of
-// choosing a file seam over a flag for amp (#1582; the unknown-flag-kills-spawn
-// class is #1043/#1116/#1131).
+// ensureAmpSkillDir writes the af-managed "agent-factory" skill into amp's home
+// skills directory and returns the skill directory path. Amp auto-discovers
+// skills there with NO command-line flag (amp has no --plugin-dir /
+// developer_instructions equivalent), so this is how afUsageReference reaches
+// amp sessions WITHOUT touching the launch command — the amp spawn stays
+// byte-identical to the no-injection launch that already reaches ready, which is
+// the whole point of choosing a file seam over a flag for amp (#1582; the
+// unknown-flag-kills-spawn class is #1043/#1116/#1131).
 //
-// Called on every amp-based session launch (see injectSystemPrompt). Like
-// ensurePluginDir it overwrites unconditionally, so an edit to afUsageReference
-// or the skill description propagates on the next amp session start.
+// Called on every amp-based session launch (see injectSystemPrompt). It writes
+// into the user's GLOBAL amp config, so the write is NON-DESTRUCTIVE: it only
+// (over)writes a SKILL.md that carries ampSkillMarker (a file we own). If a
+// SKILL.md already sits at our path WITHOUT the marker, it is a user's/tool's own
+// skill and is left untouched (logged) — we never silently destroy it. An
+// af-owned file is rewritten unconditionally, so edits to afUsageReference or the
+// description still propagate on the next amp session start.
 func ensureAmpSkillDir() (string, error) {
 	base, err := ampSkillsBaseDir()
 	if err != nil {
 		return "", err
 	}
-	skillDir := filepath.Join(base, ampSkillName)
+	skillDir := filepath.Join(base, ampSkillDirName)
+	path := filepath.Join(skillDir, "SKILL.md")
+
+	if existing, readErr := os.ReadFile(path); readErr == nil {
+		if !bytes.Contains(existing, []byte(ampSkillMarker)) {
+			log.WarningLog.Printf("amp af skill: %s exists but is not af-managed; leaving it untouched (af guidance not injected for amp)", path)
+			return skillDir, nil
+		}
+	} else if !os.IsNotExist(readErr) {
+		return "", readErr
+	}
+
 	if err := os.MkdirAll(skillDir, 0755); err != nil {
 		return "", err
 	}
-	path := filepath.Join(skillDir, "SKILL.md")
 	if err := config.AtomicWriteFile(path, []byte(ampSkillDoc), 0644); err != nil {
 		return "", err
 	}

--- a/session/ampskill.go
+++ b/session/ampskill.go
@@ -1,0 +1,71 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// ampSkillName is the directory- and skill-name amp discovers under its home
+// skills path.
+const ampSkillName = "af"
+
+// ampSkillDoc is the SKILL.md served to amp. Its body is afUsageReference
+// (systemprompt.go) — the SAME text Claude receives via the plugin skill and
+// Codex via developer_instructions — so the three agents' af knowledge cannot
+// drift (#1043). Amp requires only name + description frontmatter for a skill
+// (verified against `amp skill list`); the description is what amp surfaces for
+// lazy activation, so it must mirror the Claude plugin skill's description.
+var ampSkillDoc = "---\n" +
+	"name: " + ampSkillName + "\n" +
+	"description: Manage Agent Factory (af) sessions, tabs, scheduled tasks, and the daemon via the af CLI\n" +
+	"---\n" +
+	"\n" +
+	afUsageReference + "\n"
+
+// ampSkillsBaseDir returns amp's home-level skills directory: $HOME/.config/amp/skills.
+//
+// This matches amp's ACTUAL skills-discovery base, which was verified empirically
+// against the amp CLI (v0.0.1783687353): amp reads skills from $HOME/.config/amp/skills
+// and IGNORES $XDG_CONFIG_HOME for skills, even though it honors XDG_CONFIG_HOME
+// for its settings.json. So we deliberately do NOT consult XDG_CONFIG_HOME here —
+// a user with XDG_CONFIG_HOME set to a non-default path would otherwise get the
+// skill written where amp never looks, a silent miss. We also do NOT use
+// os.UserConfigDir(): on macOS it returns ~/Library/Application Support, whereas
+// amp uses ~/.config/amp on every platform.
+func ampSkillsBaseDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "amp", "skills"), nil
+}
+
+// ensureAmpSkillDir writes the "af" skill into amp's home skills directory and
+// returns the skill directory path. Amp auto-discovers skills there with NO
+// command-line flag (amp has no --plugin-dir / developer_instructions
+// equivalent), so this is how afUsageReference reaches amp sessions WITHOUT
+// touching the launch command — the amp spawn stays byte-identical to the
+// no-injection launch that already reaches ready, which is the whole point of
+// choosing a file seam over a flag for amp (#1582; the unknown-flag-kills-spawn
+// class is #1043/#1116/#1131).
+//
+// Called on every amp-based session launch (see injectSystemPrompt). Like
+// ensurePluginDir it overwrites unconditionally, so an edit to afUsageReference
+// or the skill description propagates on the next amp session start.
+func ensureAmpSkillDir() (string, error) {
+	base, err := ampSkillsBaseDir()
+	if err != nil {
+		return "", err
+	}
+	skillDir := filepath.Join(base, ampSkillName)
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		return "", err
+	}
+	path := filepath.Join(skillDir, "SKILL.md")
+	if err := config.AtomicWriteFile(path, []byte(ampSkillDoc), 0644); err != nil {
+		return "", err
+	}
+	return skillDir, nil
+}

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -103,13 +103,23 @@ func injectSystemPrompt(resolved string) string {
 		return resolved + " -c " + shellQuote("developer_instructions="+afUsageReference)
 	}
 	if agent == tmux.ProgramAmp {
-		// Amp gets a file seam, not a flag: writing the "af" skill into amp's
-		// home skills dir injects afUsageReference with ZERO change to the
+		// Amp gets a file seam, not a flag: writing the af-managed skill into
+		// amp's home skills dir injects afUsageReference with ZERO change to the
 		// launch command, so the spawn stays byte-identical to the working
 		// no-injection amp launch. A write failure just means amp loses the af
 		// guidance for this launch — it must never affect the spawn, so we log
 		// and return the command unchanged regardless (unlike claude, there is
 		// no flag whose absence to guard).
+		//
+		// Accepted tradeoff (#1585 review, finding 2): DetectAgentFromCommand is
+		// a shared basename heuristic, so a program_overrides entry pointing a
+		// NON-amp binary named "amp" reaches here and writes the skill file.
+		// We deliberately do NOT re-derive amp-ness with a second heuristic — the
+		// #1132 rule is that agent detection has exactly one choke-point, and a
+		// mis-detected "amp" is already mishandled everywhere else (resume
+		// rewrite, ready detection, trust prompts). The write itself is benign:
+		// ensureAmpSkillDir is af-owned, idempotent, and non-destructive, so the
+		// worst case is a dormant af-owned docs skill in ~/.config/amp/skills.
 		if _, err := ensureAmpSkillDir(); err != nil {
 			log.WarningLog.Printf("failed to set up amp af skill, af guidance unavailable to amp: %v", err)
 		}

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -69,7 +69,14 @@ func shellQuote(s string) string {
 //   - Claude Code: --plugin-dir flag only (a single "af" skill carrying afUsageReference)
 //   - Codex: -c developer_instructions="..." flag carrying the same afUsageReference
 //     (no custom-skills-folder mechanism exists in the Codex CLI; see #1043)
-//   - aider, gemini, amp, and commands running no known agent: no injection.
+//   - Amp: an "af" skill written to amp's home skills dir carrying the same
+//     afUsageReference (#1582). Amp has NO flag-based system-prompt seam (no
+//     --plugin-dir / developer_instructions equivalent), so injection is done
+//     purely by writing a file amp auto-discovers; the launch command is
+//     returned UNCHANGED, keeping the spawn byte-identical to the working
+//     no-injection amp launch (an unknown flag would kill it as an opaque
+//     readiness timeout — the #1116/#1131 class).
+//   - aider, gemini, and commands running no known agent: no injection.
 func injectSystemPrompt(resolved string) string {
 	agent := tmux.DetectAgentFromCommand(resolved)
 	if agent == tmux.ProgramClaude {
@@ -94,6 +101,19 @@ func injectSystemPrompt(resolved string) string {
 			return resolved
 		}
 		return resolved + " -c " + shellQuote("developer_instructions="+afUsageReference)
+	}
+	if agent == tmux.ProgramAmp {
+		// Amp gets a file seam, not a flag: writing the "af" skill into amp's
+		// home skills dir injects afUsageReference with ZERO change to the
+		// launch command, so the spawn stays byte-identical to the working
+		// no-injection amp launch. A write failure just means amp loses the af
+		// guidance for this launch — it must never affect the spawn, so we log
+		// and return the command unchanged regardless (unlike claude, there is
+		// no flag whose absence to guard).
+		if _, err := ensureAmpSkillDir(); err != nil {
+			log.WarningLog.Printf("failed to set up amp af skill, af guidance unavailable to amp: %v", err)
+		}
+		return resolved
 	}
 	return resolved
 }

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -139,9 +139,10 @@ func TestInjectSystemPrompt_Amp(t *testing.T) {
 		t.Errorf("expected amp command unchanged (file seam, no flag), got %q", result)
 	}
 
-	// The af skill must have been written where amp discovers it, carrying the
-	// same afUsageReference the other agents receive.
-	skillPath := filepath.Join(home, ".config", "amp", "skills", "af", "SKILL.md")
+	// The af skill must have been written where amp discovers it, in the
+	// af-owned "agent-factory" namespace, carrying the same afUsageReference the
+	// other agents receive plus the af-managed marker.
+	skillPath := filepath.Join(home, ".config", "amp", "skills", "agent-factory", "SKILL.md")
 	content, err := os.ReadFile(skillPath)
 	if err != nil {
 		t.Fatalf("expected af skill written to %s: %v", skillPath, err)
@@ -149,8 +150,11 @@ func TestInjectSystemPrompt_Amp(t *testing.T) {
 	if !strings.Contains(string(content), "af sessions whoami") {
 		t.Errorf("expected afUsageReference in amp SKILL.md, got %q", content)
 	}
-	if !strings.HasPrefix(string(content), "---\nname: af\n") {
+	if !strings.HasPrefix(string(content), "---\nname: agent-factory\n") {
 		t.Errorf("expected amp SKILL.md to start with name frontmatter, got %q", content)
+	}
+	if !strings.Contains(string(content), ampSkillMarker) {
+		t.Errorf("expected amp SKILL.md to carry the af-managed marker, got %q", content)
 	}
 }
 
@@ -250,8 +254,9 @@ func TestEnsureAmpSkillDir(t *testing.T) {
 		t.Fatalf("ensureAmpSkillDir() failed: %v", err)
 	}
 
-	// Must land exactly where amp searches: $HOME/.config/amp/skills/af.
-	expected := filepath.Join(home, ".config", "amp", "skills", "af")
+	// Must land exactly where amp searches, in the af-owned namespace:
+	// $HOME/.config/amp/skills/agent-factory.
+	expected := filepath.Join(home, ".config", "amp", "skills", "agent-factory")
 	if skillDir != expected {
 		t.Errorf("expected amp skill dir %q, got %q", expected, skillDir)
 	}
@@ -260,16 +265,64 @@ func TestEnsureAmpSkillDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected SKILL.md written: %v", err)
 	}
-	// name + description frontmatter (amp requires both) then the shared body.
+	// name + description frontmatter (amp requires both), the af-managed marker,
+	// then the shared body.
 	for _, want := range []string{
-		"name: af",
+		"name: agent-factory",
 		"description: Manage Agent Factory (af) sessions",
+		ampSkillMarker,
 		"af sessions whoami",
 		"af sessions archive --self",
 	} {
 		if !strings.Contains(string(content), want) {
 			t.Errorf("expected amp SKILL.md to contain %q, got %q", want, content)
 		}
+	}
+}
+
+// ensureAmpSkillDir must never clobber a SKILL.md it does not own. amp's skills
+// dir is the user's global amp config; a file there without the af-managed
+// marker belongs to the user (or another tool) and must survive untouched
+// (#1585 review, finding 1). A file WITH the marker is af-owned and regenerates.
+func TestEnsureAmpSkillDir_NonDestructive(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	skillDir := filepath.Join(home, ".config", "amp", "skills", "agent-factory")
+	path := filepath.Join(skillDir, "SKILL.md")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("seed mkdir: %v", err)
+	}
+	userSkill := "---\nname: agent-factory\ndescription: my own skill\n---\nhand-written, keep me\n"
+	if err := os.WriteFile(path, []byte(userSkill), 0644); err != nil {
+		t.Fatalf("seed user skill: %v", err)
+	}
+
+	if _, err := ensureAmpSkillDir(); err != nil {
+		t.Fatalf("ensureAmpSkillDir() must not error on a foreign skill: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != userSkill {
+		t.Errorf("expected the user's un-marked skill left untouched, got %q", got)
+	}
+
+	// A file that DOES carry the marker is af-owned and gets regenerated in place.
+	if err := os.WriteFile(path, []byte("stale\n<!-- "+ampSkillMarker+" -->\n"), 0644); err != nil {
+		t.Fatalf("seed af-owned skill: %v", err)
+	}
+	if _, err := ensureAmpSkillDir(); err != nil {
+		t.Fatalf("ensureAmpSkillDir() on af-owned file: %v", err)
+	}
+	got, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != ampSkillDoc {
+		t.Errorf("expected af-owned skill regenerated to ampSkillDoc, got %q", got)
 	}
 }
 
@@ -286,7 +339,7 @@ func TestEnsureAmpSkillDir_IgnoresXDG(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensureAmpSkillDir() failed: %v", err)
 	}
-	expected := filepath.Join(home, ".config", "amp", "skills", "af")
+	expected := filepath.Join(home, ".config", "amp", "skills", "agent-factory")
 	if skillDir != expected {
 		t.Errorf("expected skill dir under HOME %q, got %q", expected, skillDir)
 	}

--- a/session/systemprompt_test.go
+++ b/session/systemprompt_test.go
@@ -125,10 +125,32 @@ func TestInjectSystemPrompt_Gemini(t *testing.T) {
 }
 
 func TestInjectSystemPrompt_Amp(t *testing.T) {
+	// Amp's seam is a file, not a flag: point HOME at a temp dir so the write
+	// lands there instead of the real ~/.config/amp (amp discovers skills under
+	// $HOME/.config, ignoring XDG_CONFIG_HOME).
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
 	result := injectSystemPrompt("amp")
 
+	// The launch command must come back byte-identical — that is what keeps the
+	// amp spawn safe (#1582), since amp dies on unknown flags (#1116/#1131).
 	if result != "amp" {
-		t.Errorf("expected amp unchanged (no system-prompt flag), got %q", result)
+		t.Errorf("expected amp command unchanged (file seam, no flag), got %q", result)
+	}
+
+	// The af skill must have been written where amp discovers it, carrying the
+	// same afUsageReference the other agents receive.
+	skillPath := filepath.Join(home, ".config", "amp", "skills", "af", "SKILL.md")
+	content, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("expected af skill written to %s: %v", skillPath, err)
+	}
+	if !strings.Contains(string(content), "af sessions whoami") {
+		t.Errorf("expected afUsageReference in amp SKILL.md, got %q", content)
+	}
+	if !strings.HasPrefix(string(content), "---\nname: af\n") {
+		t.Errorf("expected amp SKILL.md to start with name frontmatter, got %q", content)
 	}
 }
 
@@ -141,6 +163,9 @@ func TestInjectSystemPrompt_Amp(t *testing.T) {
 // instantly and the spawn dies as an opaque timeout.
 func TestInjectSystemPrompt_ResolvedCommandMatrix(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	// The amp rows write their file seam under $HOME/.config/amp; keep it off
+	// the real home.
+	t.Setenv("HOME", t.TempDir())
 
 	tests := []struct {
 		name     string
@@ -213,6 +238,73 @@ func TestAfUsageReference_CoversFullSurface(t *testing.T) {
 		if !strings.Contains(afUsageReference, want) {
 			t.Errorf("afUsageReference must document %q", want)
 		}
+	}
+}
+
+func TestEnsureAmpSkillDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	skillDir, err := ensureAmpSkillDir()
+	if err != nil {
+		t.Fatalf("ensureAmpSkillDir() failed: %v", err)
+	}
+
+	// Must land exactly where amp searches: $HOME/.config/amp/skills/af.
+	expected := filepath.Join(home, ".config", "amp", "skills", "af")
+	if skillDir != expected {
+		t.Errorf("expected amp skill dir %q, got %q", expected, skillDir)
+	}
+
+	content, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("expected SKILL.md written: %v", err)
+	}
+	// name + description frontmatter (amp requires both) then the shared body.
+	for _, want := range []string{
+		"name: af",
+		"description: Manage Agent Factory (af) sessions",
+		"af sessions whoami",
+		"af sessions archive --self",
+	} {
+		if !strings.Contains(string(content), want) {
+			t.Errorf("expected amp SKILL.md to contain %q, got %q", want, content)
+		}
+	}
+}
+
+// ensureAmpSkillDir must resolve under $HOME/.config REGARDLESS of
+// XDG_CONFIG_HOME. amp honors XDG for settings.json but NOT for skills discovery
+// (verified against the amp CLI), so honoring XDG here would write the skill
+// where amp never looks for a user who has XDG_CONFIG_HOME set.
+func TestEnsureAmpSkillDir_IgnoresXDG(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // a DIFFERENT dir; must be ignored
+
+	skillDir, err := ensureAmpSkillDir()
+	if err != nil {
+		t.Fatalf("ensureAmpSkillDir() failed: %v", err)
+	}
+	expected := filepath.Join(home, ".config", "amp", "skills", "af")
+	if skillDir != expected {
+		t.Errorf("expected skill dir under HOME %q, got %q", expected, skillDir)
+	}
+}
+
+func TestEnsureAmpSkillDir_Idempotent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	dir1, err := ensureAmpSkillDir()
+	if err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+	dir2, err := ensureAmpSkillDir()
+	if err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+	if dir1 != dir2 {
+		t.Errorf("expected same dir on repeated calls, got %q and %q", dir1, dir2)
 	}
 }
 


### PR DESCRIPTION
Closes #1582.

## What

Amp sessions now receive the same af CLI usage reference (`afUsageReference`) that Claude gets via `--plugin-dir` and Codex via `-c developer_instructions=`. Previously amp/aider/gemini got **nothing**; this wires **amp only** (aider/gemini deferred per the issue).

## The seam: a file, not a flag

I investigated the real amp CLI (`~/.amp/bin/amp`, v0.0.1783687353) and amp docs. Findings:

- **Amp has no flag-based system-prompt seam.** No `--plugin-dir` (claude) or `-c developer_instructions=` (codex) equivalent. `-m/--mode` is a preset (low/med/high), and `--settings-file` carries no instructions field. Forcing an unknown flag would kill the spawn as the opaque readiness timeout of the #1043/#1116/#1131 class — exactly what we must avoid.
- **Amp discovers instructions via files.** It auto-loads skills from `$HOME/.config/amp/skills/` (among other paths) — a `SKILL.md` with `name`/`description` frontmatter.

So the amp case writes an **`af` skill** (`$HOME/.config/amp/skills/af/SKILL.md`, body = the shared `afUsageReference`) and returns the launch command **byte-identical**. Amp picks the skill up with zero command changes, mirroring claude's `ensurePluginDir` singleton (shared, idempotent, overwritten each launch so edits to `afUsageReference` propagate).

## Why spawn-safe (the critical requirement)

Because `injectSystemPrompt` returns the amp command **unchanged** (a unit test pins `injectSystemPrompt("amp") == "amp"`), the spawn is identical to today's working amp launch — no flag can kill it. A skill-write failure only logs and proceeds (amp loses af guidance for that launch; the spawn is never affected).

## `$HOME/.config`, not XDG — a subtle correctness fix

Amp honors `XDG_CONFIG_HOME` for `settings.json` but **ignores it for skills discovery** (verified empirically: a stub under a custom `XDG_CONFIG_HOME` was not found; the same stub under real `~/.config` was). So `ampSkillsBaseDir()` uses `$HOME/.config/amp/skills` and deliberately does **not** consult `XDG_CONFIG_HOME` — otherwise a user with XDG set would get the skill written where amp never looks (silent miss). It also avoids `os.UserConfigDir()`, which is `~/Library/Application Support` on macOS where amp doesn't look.

## Verification

- **End-to-end, live amp:** ran the real code path to emit `SKILL.md` to the real `~/.config/amp/skills/af`, then `amp skill list` on the **authenticated** amp CLI listed the `af` skill (`file:///…/.config/amp/skills/af`), parsing the full 4541-byte body (quotes/backticks/em-dashes intact). Artifact cleaned up after.
- Unit tests: amp command is byte-identical; SKILL.md written to the right path with the shared body; XDG ignored; idempotent.
- CI gates all green: `gofmt -l .` empty, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, and full `make test-container` (every package `ok`).

## Tradeoff (noted for review)

The skill lives in the user's amp config globally, so it's visible to their non-af amp sessions too. It's an af-namespaced, description-gated, dormant-until-relevant skill — strictly cleaner than the alternative (dirtying each git worktree with `.agents/skills/`, which would show up in `git status` and risk accidental commits). Amp reads `.claude/skills/` from the project too, but af's claude launch uses `--plugin-dir` into af's own config dir (not the worktree), so there's no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)