### PR TITLE
feat(bug-report): open a GitHub issue draft by default + redact log-tail titles (#1584)

### DIFF
--- a/bugreport/bugreport.go
+++ b/bugreport/bugreport.go
@@ -108,12 +108,24 @@ type Bundle struct {
 	daemonHuman string
 }
 
-// Result is what Build returns: a rendered text bundle (the default output the
-// user attaches) and the JSON manifest payload (the `--json` data member).
+// Result is what Build returns: a rendered text bundle (the file the user
+// attaches), the JSON manifest payload (the `--json` data member), and the
+// pre-filled GitHub issue-draft title/body the default flow opens in the
+// browser. Title/Body are short, already-redacted (built only from redacted
+// Bundle facts + a static template), and safe to inline in an issues/new URL —
+// the full bundle never rides in the URL; it reaches the issue as the attached
+// file. Body carries BundlePathPlaceholder for the command layer to replace with
+// the written bundle's path.
 type Result struct {
-	Text string
-	JSON []byte
+	Text  string
+	JSON  []byte
+	Title string
+	Body  string
 }
+
+// BundlePathPlaceholder marks where in the issue-draft body the command layer
+// substitutes the written bundle's path (known only once the file is written).
+const BundlePathPlaceholder = "{{BUNDLE_PATH}}"
 
 // Build collects, redacts, and renders the bundle. It never fails on a missing
 // or unreadable section — those are recorded in Bundle.Errors and rendering
@@ -149,8 +161,57 @@ func Build(in Inputs) (Result, error) {
 	jsonBytes = []byte(r.scrub(string(jsonBytes)))
 
 	text := r.scrub(renderText(b))
+	title, body := buildIssueDraft(b)
 
-	return Result{Text: text, JSON: jsonBytes}, nil
+	return Result{Text: text, JSON: jsonBytes, Title: title, Body: body}, nil
+}
+
+// buildIssueDraft renders the pre-filled GitHub issue-draft title and body from
+// the already-redacted Bundle. It is deliberately short (the full 2MiB bundle
+// cannot inline in an issues/new URL — it reaches the issue as the attached
+// file) and carries only redacted, structural facts plus a bug-report template
+// stub. BundlePathPlaceholder marks the attach-path the command layer fills in.
+func buildIssueDraft(b Bundle) (title, body string) {
+	title = fmt.Sprintf("af bug-report: %s on %s/%s", b.Versions.AF, b.Versions.OS, b.Versions.Arch)
+
+	daemon := "running"
+	if strings.Contains(strings.ToLower(b.daemonHuman), "not running") {
+		daemon = "not running"
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "<!-- Opened by `af bug-report`. This is a DRAFT — review it, attach the bundle below, then submit. -->\n\n")
+	fmt.Fprintf(&sb, "## Environment\n")
+	fmt.Fprintf(&sb, "- af: %s\n", b.Versions.AF)
+	fmt.Fprintf(&sb, "- go: %s\n", b.Versions.Go)
+	fmt.Fprintf(&sb, "- os/arch: %s/%s\n", b.Versions.OS, b.Versions.Arch)
+	fmt.Fprintf(&sb, "- daemon: %s\n", daemon)
+	fmt.Fprintf(&sb, "- sessions: %d across %d repo(s)\n", countInstances(b.Instances), len(b.Instances))
+	fmt.Fprintf(&sb, "- tasks: %d\n\n", len(b.Tasks))
+	fmt.Fprintf(&sb, "## What happened\n<!-- Describe the bug. -->\n\n")
+	fmt.Fprintf(&sb, "## What you expected\n\n")
+	fmt.Fprintf(&sb, "## Steps to reproduce\n\n")
+	fmt.Fprintf(&sb, "---\n")
+	fmt.Fprintf(&sb, "A best-effort **redacted** diagnostics bundle was written to:\n\n")
+	fmt.Fprintf(&sb, "    %s\n\n", BundlePathPlaceholder)
+	fmt.Fprintf(&sb, "**Attach that file to this issue** (drag-and-drop) before submitting. "+
+		"Open and review it first — redaction is best-effort and cannot catch everything.\n")
+	return title, sb.String()
+}
+
+// countInstances totals the session records across every repo's redacted
+// instances payload, for the issue-draft environment summary. A payload that
+// does not decode as an array contributes zero — the count is a best-effort
+// triage hint, never load-bearing.
+func countInstances(repos []repoInstances) int {
+	total := 0
+	for _, ri := range repos {
+		var arr []json.RawMessage
+		if err := json.Unmarshal(ri.Instances, &arr); err == nil {
+			total += len(arr)
+		}
+	}
+	return total
 }
 
 // collectTasks loads and redacts the configured tasks.
@@ -235,7 +296,7 @@ func collectLog(r *redactor, errs []string) (logSection, []string) {
 	}
 	text, lineTruncated := lastLines(string(data), logTailMaxLines)
 	sec.Truncated = truncated || lineTruncated
-	sec.Contents = r.scrub(text)
+	sec.Contents = r.scrubLog(text)
 	sec.Bytes = len(sec.Contents)
 	return sec, errs
 }

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -285,6 +285,57 @@ func TestRedactInstancesInvalidJSONOmitted(t *testing.T) {
 	}
 }
 
+// TestScrubLogRedactsSessionTitles is the #1584 regression guard: the daemon
+// log tail is bundled verbatim and prints af_<hash>_<title> tmux session names
+// on nearly every line, leaking the exact session titles the structured
+// sections already drop. scrubLog must redact the <title> segment while keeping
+// the line readable and structural fields (the hash prefix, git SHAs) intact.
+func TestScrubLogRedactsSessionTitles(t *testing.T) {
+	r := &redactor{}
+	// Seed the known-session set the way collectInstances does, so the bare-title
+	// and non-hashed-name paths are exercised alongside the shape regex.
+	r.noteSession(&session.InstanceData{
+		Title:    "design-1029-httpcli",
+		TmuxName: "af_0f8fc14c_design-1029-httpcli",
+		Tabs:     []session.TabData{{TmuxName: "af_0f8fc14c_design-1029-httpcli__shell"}},
+	})
+
+	in := strings.Join([]string{
+		`tmux session af_0f8fc14c_design-1029-httpcli is gone; status monitor going silent`,
+		`tmux session "af_0f8fc14c_fix-1436" missing on Restore; re-spawning`,
+		`window ref af_0f8fc14c_design-1029-httpcli:0.1 captured`,
+		`recover: rebuilt session "design-1029-httpcli" at /path from ` + testSHA,
+		`shell tab af_0f8fc14c_design-1029-httpcli__shell exited`,
+	}, "\n")
+
+	out := r.scrubLog(in)
+
+	// No real title survives, in either the tmux-name or bare form.
+	for _, leaked := range []string{
+		"design-1029-httpcli", // seeded session's title + name
+		"fix-1436",            // a historical session only present in the log
+	} {
+		if strings.Contains(out, leaked) {
+			t.Errorf("session title leaked through log scrub: %q\n%s", leaked, out)
+		}
+	}
+	// Every af_<hash>_ name is redacted to the stable, user-text-free prefix —
+	// the only text following the hash is the marker, never a real title.
+	if !strings.Contains(out, "af_0f8fc14c_"+redactedMarker) {
+		t.Errorf("expected the redacted af_<hash>_ prefix to be kept:\n%s", out)
+	}
+	// Structural context around the names survives so the log stays triageable.
+	if !strings.Contains(out, "status monitor going silent") ||
+		!strings.Contains(out, "missing on Restore") ||
+		!strings.Contains(out, testSHA) {
+		t.Errorf("structural log context should survive:\n%s", out)
+	}
+	// The ':' tmux window/pane ref bounds the name and is not eaten.
+	if !strings.Contains(out, ":0.1 captured") {
+		t.Errorf("expected the ':0.1' window ref to be preserved:\n%s", out)
+	}
+}
+
 // TestBuildEndToEnd plants a full temp home with a secret and a home path in
 // every collected surface (instances, tasks, config, log, daemon status) and
 // asserts the produced bundle scrubs them while keeping the structural fields.
@@ -314,6 +365,7 @@ func TestBuildEndToEnd(t *testing.T) {
 		Liveness:  session.LiveLimitReached,
 		Program:   "claude",
 		CreatedAt: createdAt,
+		TmuxName:  "af_0f8fc14c_myproprietarysession",
 		Worktree: session.GitWorktreeData{
 			RepoPath:      filepath.Join(home, "Desktop/proj"),
 			WorktreePath:  filepath.Join(home, "Desktop/proj-fix"),
@@ -342,8 +394,10 @@ func TestBuildEndToEnd(t *testing.T) {
 		"# note path " + home + "/Desktop\n"
 	writeFile(t, filepath.Join(afHome, "config.toml"), cfg)
 
-	// log tail with a home path and a secret.
-	logLine := "2026-01-01 boot at " + home + "/Desktop key sk-LOGSECRET0123456789ABCDEF sha " + testSHA + "\n"
+	// log tail with a home path, a secret, and a verbatim tmux session name
+	// (the #1584 leak vector: the session title rides in on the log blob).
+	logLine := "2026-01-01 boot at " + home + "/Desktop key sk-LOGSECRET0123456789ABCDEF sha " + testSHA + "\n" +
+		"2026-01-01 tmux session af_0f8fc14c_myproprietarysession is gone\n"
 	writeFile(t, filepath.Join(afHome, "agent-factory.log"), logLine)
 
 	res, err := Build(Inputs{
@@ -381,9 +435,21 @@ func TestBuildEndToEnd(t *testing.T) {
 		"Project Nightingale",
 		"customer launch details",
 		"secret pr",
-		home, // raw home path (username-revealing) must never appear verbatim
+		"myproprietarysession",             // session title, leaked via the log tmux name (#1584)
+		"af_0f8fc14c_myproprietarysession", // the verbatim tmux name itself
+		home,                               // raw home path (username-revealing) must never appear verbatim
 	}
 	mustNotContain(t, "text", text, planted...)
+
+	// --- GitHub issue-draft assertions ---
+	// The title is a short, templated, redacted summary line.
+	mustContain(t, "draft title", res.Title, "af bug-report:", "9.9.9", "/")
+	// The body carries the environment summary + the attach-path placeholder the
+	// command layer fills in, and never inlines a secret or a session title.
+	mustContain(t, "draft body", res.Body,
+		"## Environment", "af: 9.9.9", "sessions:", "tasks:", BundlePathPlaceholder,
+		"Attach that file")
+	mustNotContain(t, "draft body", res.Body, planted...)
 
 	// --- json manifest assertions ---
 	var manifest map[string]any

--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -336,6 +336,22 @@ func TestScrubLogRedactsSessionTitles(t *testing.T) {
 	}
 }
 
+// TestRedactPathCollapsesHome guards the fix for the raw-home-path leak: the
+// bundle path inlined into the (public) GitHub issue-draft body must have $HOME
+// collapsed to ~ so it never leaks the user's home/username.
+func TestRedactPathCollapsesHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	p := filepath.Join(home, "af-bug-report-20260710-120000.txt")
+	out := RedactPath(p)
+	if strings.Contains(out, home) {
+		t.Errorf("home path not collapsed in draft-body path: %q -> %q", p, out)
+	}
+	if !strings.HasPrefix(out, "~/") {
+		t.Errorf("expected the redacted path to start with ~/: %q", out)
+	}
+}
+
 // TestBuildEndToEnd plants a full temp home with a secret and a home path in
 // every collected surface (instances, tasks, config, log, daemon status) and
 // asserts the produced bundle scrubs them while keeping the structural fields.

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -49,6 +49,20 @@ var keyValueSecret = regexp.MustCompile(
 // privateKeyBlock matches a PEM private-key block in its entirety.
 var privateKeyBlock = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`)
 
+// afTmuxSessionName matches a repo-scoped af tmux session name
+// (af_<8 hex>_<title>, incl. any __tab / _paste suffix). The <title> segment is
+// the sanitized, whitespace-stripped session title, so it leaks the same
+// free-text name the structured redactor already drops from InstanceData.TmuxName
+// — but the daemon log tail is bundled verbatim and prints these names on nearly
+// every line (e.g. "af_0f8fc14c_fix-1436"), reintroducing the #1533 leak class
+// through the log blob (#1584). The title segment is a run of non-whitespace,
+// non-':' characters: titles never contain whitespace (stripped at
+// sanitization) and never contain ':' (rewritten to '_'), so ':' — a tmux
+// window/pane ref or log delimiter — cleanly bounds the name without ever
+// truncating a real title mid-way and leaving a fragment behind. Keys on the
+// name *shape*, so it scrubs archived/killed sessions no live set still knows.
+var afTmuxSessionName = regexp.MustCompile(`af_[0-9a-f]{8}_[^\s:]+`)
+
 // redactor holds the per-run redaction context — the home directory to
 // collapse to "~" and the username token(s) to blank to "[user]" — resolved
 // once so every section scrubs against the same values. Constructed with
@@ -57,6 +71,13 @@ var privateKeyBlock = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY--
 type redactor struct {
 	home  string
 	users []string
+	// tmuxNames and titles are the known session tmux names and raw session
+	// titles gathered while redacting instances (see noteSession). scrubLog uses
+	// them to redact bare titles and non-repo-scoped names (af_<title>, no hash,
+	// which the afTmuxSessionName shape can't match) out of the verbatim log
+	// tail — closing the #1584 leak the structured sections don't reach.
+	tmuxNames map[string]struct{}
+	titles    map[string]struct{}
 }
 
 // newRedactor resolves the redaction context from the environment: the OS
@@ -111,6 +132,89 @@ func (r *redactor) scrub(s string) string {
 	return s
 }
 
+// scrubLog scrubs the daemon log tail. On top of the standard scrub() pass it
+// redacts the free-text <title> in every af_<hash>_<title> tmux session name and
+// any bare session title the log prints, so the verbatim log blob can't leak the
+// session titles the structured sections already drop (#1584 — the exact #1533
+// class, reintroduced through the bundled log). Call this instead of scrub() for
+// the log section; it ends by delegating to scrub() for the usual
+// $HOME/username/secret pass.
+func (r *redactor) scrubLog(s string) string {
+	// Redact the title in every af_<hash>_<title> name. Keys on the name shape,
+	// so it catches current AND historical (archived/killed) sessions the live
+	// instance set no longer references.
+	s = afTmuxSessionName.ReplaceAllStringFunc(s, redactAFTmuxTitle)
+	// Non-repo-scoped names (af_<title>, no hash) don't match the shape above;
+	// redact those known names exactly.
+	for name := range r.tmuxNames {
+		if !afTmuxSessionName.MatchString(name) {
+			s = strings.ReplaceAll(s, name, tmuxPrefixMarker)
+		}
+	}
+	// Bare raw titles the log prints verbatim (e.g. via a %q-formatted Title).
+	// Best-effort: only titles long enough to redact without mangling unrelated
+	// words, matched on word boundaries.
+	for title := range r.titles {
+		if re := bareTitleRegexp(title); re != nil {
+			s = re.ReplaceAllString(s, redactedMarker)
+		}
+	}
+	return r.scrub(s)
+}
+
+// tmuxPrefixMarker is the redaction of an af tmux session name whose title
+// segment is removed but whose "af_" prefix is kept so the line still reads as
+// referring to an af session.
+const tmuxPrefixMarker = "af_" + redactedMarker
+
+// redactAFTmuxTitle redacts the <title> of a matched af_<8 hex>_<title> name,
+// keeping the fixed, user-text-free "af_<hash>_" prefix (3 + 8 + 1 = 12 chars).
+func redactAFTmuxTitle(match string) string {
+	return match[:12] + redactedMarker
+}
+
+// bareTitleRegexp compiles a word-boundary matcher for a bare session title, or
+// nil when the title is too short (< 4 chars) to redact without risking mangling
+// unrelated log text. Best-effort by design — the tmux-name redaction above is
+// the primary defense; this catches raw titles the log prints outside a name.
+func bareTitleRegexp(title string) *regexp.Regexp {
+	title = strings.TrimSpace(title)
+	if len(title) < 4 {
+		return nil
+	}
+	re, err := regexp.Compile(`\b` + regexp.QuoteMeta(title) + `\b`)
+	if err != nil {
+		return nil
+	}
+	return re
+}
+
+// noteSession records a session's tmux name(s) and raw title(s) before they are
+// redacted, so scrubLog can strip them from the log tail. Called on each record
+// while collecting instances, i.e. before collectLog runs.
+func (r *redactor) noteSession(d *session.InstanceData) {
+	if r.tmuxNames == nil {
+		r.tmuxNames = make(map[string]struct{})
+	}
+	if r.titles == nil {
+		r.titles = make(map[string]struct{})
+	}
+	if d.TmuxName != "" {
+		r.tmuxNames[d.TmuxName] = struct{}{}
+	}
+	if strings.TrimSpace(d.Title) != "" {
+		r.titles[d.Title] = struct{}{}
+	}
+	if strings.TrimSpace(d.Worktree.SessionName) != "" {
+		r.titles[d.Worktree.SessionName] = struct{}{}
+	}
+	for _, tab := range d.Tabs {
+		if tab.TmuxName != "" {
+			r.tmuxNames[tab.TmuxName] = struct{}{}
+		}
+	}
+}
+
 func redactKeyValueSecret(match string) string {
 	idx := keyValueSecret.FindStringSubmatchIndex(match)
 	if len(idx) < 4 || idx[2] < 0 {
@@ -151,6 +255,7 @@ func (r *redactor) redactInstancesJSON(raw json.RawMessage) json.RawMessage {
 	var datas []session.InstanceData
 	if err := json.Unmarshal(raw, &datas); err == nil {
 		for i := range datas {
+			r.noteSession(&datas[i])
 			redactInstanceData(&datas[i])
 		}
 		if out, marshalErr := json.MarshalIndent(datas, "", "  "); marshalErr == nil {

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -95,6 +95,15 @@ func newRedactor() *redactor {
 	return &redactor{home: home, users: users}
 }
 
+// RedactPath collapses $HOME to ~ and the username to [user] in a single path,
+// using the same rules as the bundle redactor. The command layer runs the
+// written bundle's path through it before inlining the path into the GitHub
+// issue-draft body, so the (public) draft can't leak $HOME/username even though
+// the bundle itself is redacted.
+func RedactPath(p string) string {
+	return newRedactor().scrub(p)
+}
+
 // appendUserToken adds a username token to the scrub list, skipping empties,
 // path-ish junk, and tokens under 3 chars (too short to replace safely without
 // mangling unrelated substrings).

--- a/commands/bugreport_github.go
+++ b/commands/bugreport_github.go
@@ -1,0 +1,146 @@
+package commands
+
+import (
+	"fmt"
+	"net/url"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// The GitHub issue-draft flow for `af bug-report`: after the redacted bundle is
+// written, open a PRE-FILLED new-issue draft in the browser for the current
+// repo. It NEVER auto-creates the issue — it opens `issues/new` (or `gh issue
+// create --web`) with a templated title/body for the user to review and submit
+// by hand. The full redacted bundle never rides in the URL (it is far past
+// GitHub's ~8KB query cap); it reaches the issue as the file the user attaches.
+//
+// Every helper here is best-effort and side-effect-scoped: if no github.com
+// origin remote exists, or no browser/gh opener is available, openGitHubIssueDraft
+// reports (false, reason) and the caller falls back to file-only — the command
+// always succeeds and always leaves the bundle on disk.
+
+// scpLikeRemote matches the scp-style git remote form git@host:owner/repo(.git).
+var scpLikeRemote = regexp.MustCompile(`^[A-Za-z0-9._-]+@([A-Za-z0-9._-]+):(.+)$`)
+
+// parseGitHubRepo extracts owner/repo from a git remote URL, returning ok=false
+// for anything that is not a github.com remote (enterprise hosts and other
+// forges fall back to the file-only path). It handles the scp-like
+// (git@github.com:owner/repo.git), https, and ssh:// forms.
+func parseGitHubRepo(remote string) (owner, repo string, ok bool) {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return "", "", false
+	}
+
+	var host, path string
+	if m := scpLikeRemote.FindStringSubmatch(remote); m != nil {
+		host, path = m[1], m[2]
+	} else {
+		u, err := url.Parse(remote)
+		if err != nil || u.Hostname() == "" {
+			return "", "", false
+		}
+		host, path = u.Hostname(), u.Path
+	}
+
+	host = strings.TrimPrefix(strings.ToLower(host), "www.")
+	if host != "github.com" {
+		return "", "", false
+	}
+
+	path = strings.TrimSuffix(strings.Trim(path, "/"), ".git")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// githubIssueNewURL builds a pre-filled issues/new URL. The title/body are
+// query-encoded; the caller keeps the body short so the URL stays under
+// GitHub's length cap. Opening this URL only DRAFTS the issue — GitHub does not
+// submit it until the user clicks the button.
+func githubIssueNewURL(owner, repo, title, body string) string {
+	q := url.Values{}
+	q.Set("title", title)
+	q.Set("body", body)
+	return fmt.Sprintf("https://github.com/%s/%s/issues/new?%s", owner, repo, q.Encode())
+}
+
+// ghIssueCreateWebArgs builds the `gh` arguments that open a pre-filled browser
+// draft. `--web` is what keeps this draft-only: gh constructs the issues/new URL
+// and opens the browser instead of creating the issue over the API, so there is
+// no auto-submit and no confirmation flag.
+func ghIssueCreateWebArgs(title, body string) []string {
+	return []string{"issue", "create", "--web", "--title", title, "--body", body}
+}
+
+// openGitHubIssueDraft opens a pre-filled, DRAFT-ONLY GitHub issue for the repo
+// at repoPath. It prefers `gh issue create --web` (a clean browser draft) and
+// falls back to opening the issues/new URL directly. It returns opened=false
+// with a human-readable reason when there is no github.com origin remote or no
+// working opener, so the caller can degrade to the file-only path. It never
+// creates the issue.
+func openGitHubIssueDraft(repoPath, title, body string) (opened bool, reason string) {
+	remote, err := gitRemoteURL(repoPath, "origin")
+	if err != nil || strings.TrimSpace(remote) == "" {
+		return false, "no 'origin' git remote for this repo"
+	}
+	owner, repo, ok := parseGitHubRepo(remote)
+	if !ok {
+		return false, "origin remote is not a github.com repository"
+	}
+
+	// Prefer gh when present — it opens a clean pre-filled browser draft.
+	if _, err := exec.LookPath("gh"); err == nil {
+		c := exec.Command("gh", ghIssueCreateWebArgs(title, body)...)
+		c.Dir = repoPath
+		if err := c.Start(); err == nil {
+			reap(c)
+			return true, ""
+		}
+	}
+
+	// Fallback: open the pre-filled issues/new URL in the browser.
+	if err := openInBrowser(githubIssueNewURL(owner, repo, title, body)); err != nil {
+		return false, fmt.Sprintf("no browser opener available (%v)", err)
+	}
+	return true, ""
+}
+
+// gitRemoteURL returns the configured URL of the named remote in repoPath.
+func gitRemoteURL(repoPath, name string) (string, error) {
+	out, err := exec.Command("git", "-C", repoPath, "remote", "get-url", name).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// openInBrowser launches the platform browser opener for target and reaps it so
+// it never lingers as a zombie for the life of the process (mirrors the PR-open
+// path in app/handle_actions.go, #816).
+func openInBrowser(target string) error {
+	var c *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		c = exec.Command("open", target)
+	case "windows":
+		c = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		c = exec.Command("xdg-open", target)
+	}
+	if err := c.Start(); err != nil {
+		return err
+	}
+	reap(c)
+	return nil
+}
+
+// reap waits on a started opener process in the background so it does not become
+// a zombie.
+func reap(c *exec.Cmd) {
+	go func() { _ = c.Wait() }()
+}

--- a/commands/bugreport_github.go
+++ b/commands/bugreport_github.go
@@ -1,12 +1,15 @@
 package commands
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"net/url"
 	"os/exec"
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // The GitHub issue-draft flow for `af bug-report`: after the redacted bundle is
@@ -70,11 +73,13 @@ func githubIssueNewURL(owner, repo, title, body string) string {
 }
 
 // ghIssueCreateWebArgs builds the `gh` arguments that open a pre-filled browser
-// draft. `--web` is what keeps this draft-only: gh constructs the issues/new URL
-// and opens the browser instead of creating the issue over the API, so there is
-// no auto-submit and no confirmation flag.
-func ghIssueCreateWebArgs(title, body string) []string {
-	return []string{"issue", "create", "--web", "--title", title, "--body", body}
+// draft. `--repo <owner/repo>` pins the target so gh cannot resolve to the wrong
+// repo via GH_REPO / a stray gh remote config; `--web` is what keeps this
+// draft-only: gh constructs the issues/new URL and opens the browser instead of
+// creating the issue over the API, so there is no auto-submit and no
+// confirmation flag.
+func ghIssueCreateWebArgs(repoSlug, title, body string) []string {
+	return []string{"issue", "create", "--repo", repoSlug, "--web", "--title", title, "--body", body}
 }
 
 // openGitHubIssueDraft opens a pre-filled, DRAFT-ONLY GitHub issue for the repo
@@ -93,21 +98,54 @@ func openGitHubIssueDraft(repoPath, title, body string) (opened bool, reason str
 		return false, "origin remote is not a github.com repository"
 	}
 
-	// Prefer gh when present — it opens a clean pre-filled browser draft.
+	// Prefer gh when present — it opens a clean, repo-pinned browser draft.
 	if _, err := exec.LookPath("gh"); err == nil {
-		c := exec.Command("gh", ghIssueCreateWebArgs(title, body)...)
-		c.Dir = repoPath
-		if err := c.Start(); err == nil {
-			reap(c)
-			return true, ""
-		}
+		return openViaGh(repoPath, owner+"/"+repo, title, body)
 	}
 
-	// Fallback: open the pre-filled issues/new URL in the browser.
+	// gh absent: open the pre-filled issues/new URL in the browser directly.
 	if err := openInBrowser(githubIssueNewURL(owner, repo, title, body)); err != nil {
 		return false, fmt.Sprintf("no browser opener available (%v)", err)
 	}
 	return true, ""
+}
+
+// openViaGh runs `gh issue create --web` and reports success ONLY when gh
+// actually exits 0. `--web` builds the issues/new URL and launches the browser
+// without waiting, so gh returns promptly; we wait (not fire-and-forget) so an
+// auth/remote/browser failure surfaces as opened=false — letting the caller fall
+// back to the file path — instead of a false "draft opened". A timeout guards
+// the (unexpected) case where gh blocks, and nil stdin means any prompt EOFs out
+// rather than hanging.
+func openViaGh(repoPath, repoSlug, title, body string) (opened bool, reason string) {
+	ctx, cancel := context.WithTimeout(context.Background(), ghDraftTimeout)
+	defer cancel()
+
+	c := exec.CommandContext(ctx, "gh", ghIssueCreateWebArgs(repoSlug, title, body)...)
+	c.Dir = repoPath
+	var errBuf bytes.Buffer
+	c.Stderr = &errBuf
+	if err := c.Run(); err != nil {
+		detail := firstLine(strings.TrimSpace(errBuf.String()))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return false, "gh could not open a draft: " + detail
+	}
+	return true, ""
+}
+
+// ghDraftTimeout bounds openViaGh so a wedged gh can never hang `af bug-report`;
+// gh --web normally returns in well under a second.
+const ghDraftTimeout = 20 * time.Second
+
+// firstLine returns s up to (not including) the first newline, so a multi-line
+// gh error collapses to a single readable reason.
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
 }
 
 // gitRemoteURL returns the configured URL of the named remote in repoPath.

--- a/commands/bugreportcmd.go
+++ b/commands/bugreportcmd.go
@@ -110,8 +110,11 @@ envelope) to stdout instead of writing a file or opening a draft.`,
 		}
 
 		// Default: open a pre-filled GitHub issue DRAFT for this repo. The bundle
-		// is attached by the user; nothing is submitted automatically.
-		body := strings.Replace(result.Body, bugreport.BundlePathPlaceholder, outPath, 1)
+		// is attached by the user; nothing is submitted automatically. The path is
+		// redacted ($HOME→~ / username→[user]) before it goes into the draft body
+		// so the public draft can't leak it, while stdout still prints the real
+		// local path.
+		body := strings.Replace(result.Body, bugreport.BundlePathPlaceholder, bugreport.RedactPath(outPath), 1)
 		opened, reason := openGitHubIssueDraft(".", result.Title, body)
 		if !opened {
 			fmt.Fprintf(w, "Couldn't open a GitHub issue draft (%s).\n", reason)

--- a/commands/bugreportcmd.go
+++ b/commands/bugreportcmd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/sachiniyer/agent-factory/apiproto"
@@ -17,6 +18,7 @@ import (
 var (
 	bugReportJSON   bool
 	bugReportOutput string
+	bugReportFile   bool
 )
 
 // bugReportCmd is `af bug-report` (#1048): bundle the daemon log tail,
@@ -43,8 +45,15 @@ var bugReportCmd = &cobra.Command{
   - the daemon health snapshot (same no-spawn probe as af daemon status)
   - the global config file, if any (redacted)
 
-Everything is written to a single text file (default ~/af-bug-report-<ts>.txt)
-so you can read the whole thing in one scroll before attaching it.
+By default the redacted bundle is written to a single text file
+(~/af-bug-report-<ts>.txt) and a pre-filled GitHub issue DRAFT is opened in your
+browser for this repo — with a templated title and body. The draft is never
+submitted for you: review it, drag the bundle file onto the issue, and click
+Submit yourself. If this repo has no github.com remote, or no browser/gh is
+available, the command falls back to just writing the bundle file and printing
+where it is so you can attach it to an issue by hand.
+
+Use -o/--output <path> or --file to skip GitHub and only write the bundle file.
 
 REDACTION IS BEST-EFFORT. Free-text and secret-bearing fields (session titles,
 session prompts, task prompts, tab commands, remote metadata) are dropped; $HOME and your
@@ -53,7 +62,7 @@ wherever they appear. Perfect redaction is impossible — open the file and
 review it before sharing it publicly.
 
 Use --json to emit the structured manifest (wrapped in the shared {data,error}
-envelope) to stdout instead of writing a file.`,
+envelope) to stdout instead of writing a file or opening a draft.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Initialize(false)
@@ -79,6 +88,9 @@ envelope) to stdout instead of writing a file.`,
 			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(json.RawMessage(result.JSON)))
 		}
 
+		// The redacted bundle is always written to disk — in the default flow it
+		// is the file the user drags onto the GitHub draft; in file-only mode it
+		// is the whole output.
 		outPath, err := resolveBugReportPath(bugReportOutput)
 		if err != nil {
 			return err
@@ -88,9 +100,28 @@ envelope) to stdout instead of writing a file.`,
 		}
 
 		w := cmd.OutOrStdout()
-		fmt.Fprintf(w, "Wrote bug report to %s\n", outPath)
-		fmt.Fprintln(w, "Attach this file to your bug report.")
-		fmt.Fprintln(w, "Review it first — redaction is best-effort and cannot catch everything.")
+
+		// File-only: an explicit --output path or --file skips GitHub entirely.
+		if bugReportFile || bugReportOutput != "" {
+			fmt.Fprintf(w, "Wrote bug report to %s\n", outPath)
+			fmt.Fprintln(w, "Attach this file to your bug report.")
+			fmt.Fprintln(w, "Review it first — redaction is best-effort and cannot catch everything.")
+			return nil
+		}
+
+		// Default: open a pre-filled GitHub issue DRAFT for this repo. The bundle
+		// is attached by the user; nothing is submitted automatically.
+		body := strings.Replace(result.Body, bugreport.BundlePathPlaceholder, outPath, 1)
+		opened, reason := openGitHubIssueDraft(".", result.Title, body)
+		if !opened {
+			fmt.Fprintf(w, "Couldn't open a GitHub issue draft (%s).\n", reason)
+			fmt.Fprintf(w, "Wrote the redacted bug-report bundle to %s\n", outPath)
+			fmt.Fprintln(w, "Attach it to a new issue manually. Review it first — redaction is best-effort.")
+			return nil
+		}
+		fmt.Fprintf(w, "Wrote the redacted bug-report bundle to %s\n", outPath)
+		fmt.Fprintln(w, "Opened a pre-filled GitHub issue draft in your browser — it is NOT submitted.")
+		fmt.Fprintln(w, "Attach the bundle file above to the draft (drag-and-drop), review both, then click Submit.")
 		return nil
 	},
 }
@@ -114,8 +145,10 @@ func resolveBugReportPath(override string) (string, error) {
 
 func init() {
 	bugReportCmd.Flags().BoolVar(&bugReportJSON, "json", false,
-		"Emit the structured manifest to stdout (in the {data,error} envelope) instead of writing a file")
+		"Emit the structured manifest to stdout (in the {data,error} envelope) instead of writing a file or opening a draft")
 	bugReportCmd.Flags().StringVarP(&bugReportOutput, "output", "o", "",
-		"Write the bundle to this path instead of the default ~/af-bug-report-<ts>.txt")
+		"Write the bundle to this path and skip opening a GitHub draft (implies --file)")
+	bugReportCmd.Flags().BoolVar(&bugReportFile, "file", false,
+		"Only write the bundle file (to ~/af-bug-report-<ts>.txt); do not open a GitHub issue draft")
 	rootCmd.AddCommand(bugReportCmd)
 }

--- a/commands/bugreportcmd_test.go
+++ b/commands/bugreportcmd_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,4 +78,124 @@ func TestBugReportCmdJSON(t *testing.T) {
 	if env.Data["versions"] == nil {
 		t.Error("manifest missing versions")
 	}
+}
+
+// TestParseGitHubRepo covers the remote-URL forms the draft flow must recognize
+// and the non-github.com remotes it must reject (so the caller falls back to
+// file-only).
+func TestParseGitHubRepo(t *testing.T) {
+	cases := []struct {
+		remote            string
+		wantOwner, wantRe string
+		wantOK            bool
+	}{
+		{"git@github.com:sachiniyer/agent-factory.git", "sachiniyer", "agent-factory", true},
+		{"git@github.com:sachiniyer/agent-factory", "sachiniyer", "agent-factory", true},
+		{"https://github.com/sachiniyer/agent-factory.git", "sachiniyer", "agent-factory", true},
+		{"https://github.com/sachiniyer/agent-factory", "sachiniyer", "agent-factory", true},
+		{"https://www.github.com/sachiniyer/agent-factory", "sachiniyer", "agent-factory", true},
+		{"ssh://git@github.com/sachiniyer/agent-factory.git", "sachiniyer", "agent-factory", true},
+		{"https://github.com/sachiniyer/agent-factory/", "sachiniyer", "agent-factory", true},
+		// Rejected: other forges / enterprise hosts / malformed.
+		{"git@gitlab.com:owner/repo.git", "", "", false},
+		{"https://example.com/owner/repo.git", "", "", false},
+		{"https://github.enterprise.com/owner/repo.git", "", "", false},
+		{"https://github.com/onlyowner", "", "", false},
+		{"", "", "", false},
+	}
+	for _, tc := range cases {
+		owner, repo, ok := parseGitHubRepo(tc.remote)
+		if ok != tc.wantOK || owner != tc.wantOwner || repo != tc.wantRe {
+			t.Errorf("parseGitHubRepo(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tc.remote, owner, repo, ok, tc.wantOwner, tc.wantRe, tc.wantOK)
+		}
+	}
+}
+
+// TestGithubIssueNewURL asserts the pre-filled draft URL points at the right
+// repo's issues/new endpoint and query-encodes the templated title/body — and
+// that it carries no auto-submit signal (opening it only drafts the issue).
+func TestGithubIssueNewURL(t *testing.T) {
+	title := "af bug-report: 9.9.9 on linux/amd64"
+	body := "## Environment\n- af: 9.9.9\nAttach the bundle."
+	got := githubIssueNewURL("sachiniyer", "agent-factory", title, body)
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("URL does not parse: %v", err)
+	}
+	if u.Host != "github.com" || u.Path != "/sachiniyer/agent-factory/issues/new" {
+		t.Errorf("draft URL points at the wrong place: %s", got)
+	}
+	q := u.Query()
+	if q.Get("title") != title {
+		t.Errorf("title not round-tripped: %q", q.Get("title"))
+	}
+	if q.Get("body") != body {
+		t.Errorf("body not round-tripped: %q", q.Get("body"))
+	}
+	// issues/new only DRAFTS — there is no submit/confirm parameter.
+	for _, k := range []string{"submit", "confirm", "yes"} {
+		if q.Has(k) {
+			t.Errorf("draft URL must not carry an auto-submit param %q: %s", k, got)
+		}
+	}
+}
+
+// TestGhIssueCreateWebArgs pins the gh invocation to the draft-only shape: it
+// must pass --web (which opens a browser draft instead of creating the issue)
+// with the templated title/body, and must NOT carry any non-interactive submit
+// flag.
+func TestGhIssueCreateWebArgs(t *testing.T) {
+	args := ghIssueCreateWebArgs("my title", "my body")
+	joined := strings.Join(args, " ")
+
+	if args[0] != "issue" || args[1] != "create" {
+		t.Errorf("expected `gh issue create ...`, got %v", args)
+	}
+	if !containsArg(args, "--web") {
+		t.Errorf("draft flow must use --web (browser draft, no auto-submit): %v", args)
+	}
+	if !containsArgValue(args, "--title", "my title") || !containsArgValue(args, "--body", "my body") {
+		t.Errorf("title/body not templated into gh args: %v", args)
+	}
+	// gh creates the issue over the API without --web, or non-interactively with
+	// these flags — none of which may appear.
+	for _, bad := range []string{"--yes", "--confirm", "-y"} {
+		if containsArg(args, bad) {
+			t.Errorf("draft flow must not carry auto-submit flag %q: %s", bad, joined)
+		}
+	}
+}
+
+// TestOpenGitHubIssueDraftFallsBackWithoutRemote confirms the graceful fallback:
+// a directory with no origin remote yields opened=false + a reason, never a
+// browser launch, so the caller can degrade to file-only.
+func TestOpenGitHubIssueDraftFallsBackWithoutRemote(t *testing.T) {
+	dir := t.TempDir() // not a git repo, so no origin remote
+	opened, reason := openGitHubIssueDraft(dir, "t", "b")
+	if opened {
+		t.Fatal("must not open a draft without a github.com origin remote")
+	}
+	if reason == "" {
+		t.Error("expected a human-readable fallback reason")
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArgValue(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
 }

--- a/commands/bugreportcmd_test.go
+++ b/commands/bugreportcmd_test.go
@@ -147,7 +147,7 @@ func TestGithubIssueNewURL(t *testing.T) {
 // with the templated title/body, and must NOT carry any non-interactive submit
 // flag.
 func TestGhIssueCreateWebArgs(t *testing.T) {
-	args := ghIssueCreateWebArgs("my title", "my body")
+	args := ghIssueCreateWebArgs("sachiniyer/agent-factory", "my title", "my body")
 	joined := strings.Join(args, " ")
 
 	if args[0] != "issue" || args[1] != "create" {
@@ -155,6 +155,10 @@ func TestGhIssueCreateWebArgs(t *testing.T) {
 	}
 	if !containsArg(args, "--web") {
 		t.Errorf("draft flow must use --web (browser draft, no auto-submit): %v", args)
+	}
+	// The target repo must be pinned so gh can't resolve to the wrong repo.
+	if !containsArgValue(args, "--repo", "sachiniyer/agent-factory") {
+		t.Errorf("gh target not pinned to the parsed repo: %v", args)
 	}
 	if !containsArgValue(args, "--title", "my title") || !containsArgValue(args, "--body", "my body") {
 		t.Errorf("title/body not templated into gh args: %v", args)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -124,8 +124,15 @@ Collect a single, shareable diagnostics bundle for triage:
   - the daemon health snapshot (same no-spawn probe as af daemon status)
   - the global config file, if any (redacted)
 
-Everything is written to a single text file (default ~/af-bug-report-<ts>.txt)
-so you can read the whole thing in one scroll before attaching it.
+By default the redacted bundle is written to a single text file
+(~/af-bug-report-<ts>.txt) and a pre-filled GitHub issue DRAFT is opened in your
+browser for this repo — with a templated title and body. The draft is never
+submitted for you: review it, drag the bundle file onto the issue, and click
+Submit yourself. If this repo has no github.com remote, or no browser/gh is
+available, the command falls back to just writing the bundle file and printing
+where it is so you can attach it to an issue by hand.
+
+Use -o/--output <path> or --file to skip GitHub and only write the bundle file.
 
 REDACTION IS BEST-EFFORT. Free-text and secret-bearing fields (session titles,
 session prompts, task prompts, tab commands, remote metadata) are dropped; $HOME and your
@@ -134,7 +141,7 @@ wherever they appear. Perfect redaction is impossible — open the file and
 review it before sharing it publicly.
 
 Use --json to emit the structured manifest (wrapped in the shared {data,error}
-envelope) to stdout instead of writing a file.
+envelope) to stdout instead of writing a file or opening a draft.
 
 ```
 af bug-report [flags]
@@ -144,8 +151,9 @@ af bug-report [flags]
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `--json` |  | Emit the structured manifest to stdout (in the {data,error} envelope) instead of writing a file |
-| `-o`, `--output` | `string` | Write the bundle to this path instead of the default ~/af-bug-report-<ts>.txt |
+| `--file` |  | Only write the bundle file (to ~/af-bug-report-<ts>.txt); do not open a GitHub issue draft |
+| `--json` |  | Emit the structured manifest to stdout (in the {data,error} envelope) instead of writing a file or opening a draft |
+| `-o`, `--output` | `string` | Write the bundle to this path and skip opening a GitHub draft (implies --file) |
 
 ## af completion
 


### PR DESCRIPTION
Fixes #1584. Two related improvements to `af bug-report`, both approved by root + Sachin.

## Part 1 — fix #1584: log-tail leaks session titles

The #1533/#1541 fix redacts the structured `InstanceData.TmuxName` / `TabData.TmuxName`, but the **daemon log tail** is bundled verbatim and prints `af_<hash>_<title>` tmux names on nearly every line (root's live `--json` run: 51 distinct session titles leaked in the log section, 0 elsewhere — e.g. `af_0f8fc14c_design-1029-httpcli`). Sharing the bundle publicly leaks every session title through the log blob — the exact #1533 class.

**Fix:** new `scrubLog()` for the log section:
- `af_[0-9a-f]{8}_[^\s:]+` regex redacts the free-text `<title>` to `af_<hash>_[redacted]`, keeping the stable hash prefix. Bounded by whitespace/`:` — neither ever appears inside a sanitized title — so it never truncates a title mid-way and leaves a fragment. Keys on the name **shape**, so it also scrubs archived/killed sessions no live instance set still references.
- Exact-match for non-hashed `af_<title>` names, plus a best-effort word-boundary scrub of bare session titles (≥4 chars), sourced from the same instances the structured redactor already parses.
- `collectLog` now calls `scrubLog` instead of `scrub`.

Test: `TestScrubLogRedactsSessionTitles` + the e2e test now plants a tmux name in the log and asserts 0 real titles survive (`af_<hash>_[redacted]` only).

## Part 2 — GitHub issue-DRAFT is the new default flow

Per Sachin's mid-flight change ("I want the default flow to be to push to github instead of under a flag"):

- **Default `af bug-report`**: writes the redacted bundle to `~/af-bug-report-<ts>.txt` **and** opens a pre-filled, **draft-only** new-issue in the browser for this repo (templated title + short env-summary body). It **never auto-submits** — the user reviews, attaches the bundle file, and clicks Submit.
- **URL-length constraint handled**: the 2MiB bundle never inlines in the URL (past GitHub's ~8KB cap). The draft body is a short, already-redacted summary that points at the written bundle file; the full bundle reaches the issue as the **attached file**.
- **Mechanism**: prefers `gh issue create --web` when present (clean browser draft); else opens the `issues/new?title=&body=` URL. Repo derived from the `origin` remote, github.com only (SSH + HTTPS + `ssh://` forms).
- **Graceful fallback** (command always succeeds, bundle always written): no origin / non-github / no `gh`+browser → print `Couldn't open a GitHub issue draft (<reason>)` + the bundle path + manual-attach guidance.
- **Flags**: `-o/--output <path>` and new `--file` force file-only; `--json` unchanged. `--help` + `docs/reference/cli.md` regenerated.

Tests: `parseGitHubRepo` (all remote forms + rejects non-github/enterprise), `githubIssueNewURL` (right repo/endpoint, encoded title+body, no auto-submit param), `ghIssueCreateWebArgs` (`--web`, templated, no `--yes/--confirm`), and the no-remote fallback. Construction is tested; the browser-open is never executed against the real repo.

## Verification
- `gofmt -l .` empty · `go build ./...` · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `scripts/lint-file-length.sh` pass · **`make test-container` fully green**.
- Manually exercised all four flows (default fallback, `--file`, `-o`, `--json`) + the gh-draft happy path via a stubbed `gh` — confirmed `--web`, correct title/body, placeholder substituted with the real bundle path, no auto-submit, tiny body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)