### PR TITLE
feat(tui): collapsible Projects section at the bottom of the sidebar (default collapsed)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -583,10 +583,22 @@ func (m *home) handleEnter() (tea.Model, tea.Cmd) {
 
 	sel := m.sidebar.GetSelection()
 
-	// Toggle expandable section headers (Instances and the Archived folder).
-	if sel.IsHeader && (sel.Kind == ui.SectionInstances || sel.Kind == ui.SectionArchived) {
+	// Toggle expandable section headers (Instances, the Archived folder, and the
+	// Projects section). Expanding Projects refreshes its counts.
+	if sel.IsHeader && (sel.Kind == ui.SectionInstances || sel.Kind == ui.SectionArchived || sel.Kind == ui.SectionProjects) {
 		m.sidebar.ToggleSection()
+		if sel.Kind == ui.SectionProjects {
+			m.refreshSidebarProjects()
+		}
 		return m, m.selectionChanged()
+	}
+	// A Projects-section row switches the rail to that project, reusing the
+	// #1547 switch path (a no-op when it is already the active project).
+	if sel.Kind == ui.SectionProjects {
+		if proj, ok := m.sidebar.GetSelectedProject(); ok {
+			return m.switchToProjectRoot(proj.Root)
+		}
+		return m, nil
 	}
 	// Only instance/tab rows enter a pane; anything else (e.g. an automations
 	// row) is a no-op, as before.

--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -349,6 +349,13 @@ func (m *home) handleClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		m.sidebar.ClickHeaderKind(ui.SectionArchived)
 		m.focusRegionClick(layout.RegionTree)
 		return m, m.selectionChanged()
+	case zones.TreeHeaderProjects:
+		// Click the Projects section header: toggle it specifically and refresh
+		// its counts.
+		m.sidebar.ClickHeaderKind(ui.SectionProjects)
+		m.refreshSidebarProjects()
+		m.focusRegionClick(layout.RegionTree)
+		return m, m.selectionChanged()
 	case zones.TreeBG:
 		m.focusRegionClick(layout.RegionTree)
 		return m, nil
@@ -379,6 +386,12 @@ func (m *home) handleClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 	if title, idx, ok := zones.TreeTabParts(id); ok {
 		return m, m.handleTreeTabClick(title, idx, double)
+	}
+	if root, ok := zones.TreeProjectRoot(id); ok {
+		// Click a Projects-section row: switch the rail to that project (the
+		// row's primary action, like Enter on it).
+		m.focusRegionClick(layout.RegionTree)
+		return m.switchToProjectRoot(root)
 	}
 	if region, kind, ok := zones.PaneZone(id); ok {
 		// Click a pane header (or an unfocused pane's body): focus that pane

--- a/app/home_model.go
+++ b/app/home_model.go
@@ -403,6 +403,9 @@ func newHome(ctx context.Context, program string, autoYes bool, repo *config.Rep
 
 	h.importRemoteHookSessions()
 	h.restoreTUIViewStateOnLaunch()
+	// Populate the sidebar's Projects section from the cross-repo discovery so it
+	// renders (collapsed) at launch with the active project marked.
+	h.refreshSidebarProjects()
 
 	// Load tasks for sidebar display
 	tasks, err := task.LoadTasksForCurrentRepo()

--- a/app/switch_project.go
+++ b/app/switch_project.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 	"github.com/sachiniyer/agent-factory/ui/store"
 )
@@ -81,6 +82,38 @@ func (m *home) buildProjectList() []overlay.Project {
 		return projects[i].Root < projects[j].Root
 	})
 	return projects
+}
+
+// refreshSidebarProjects rebuilds the sidebar's Projects-section list from the
+// same cross-repo discovery the ctrl+p picker uses (buildProjectList), marking
+// the active project so the section highlights where the rail is scoped. Pushed
+// at launch, on project switch, and when the section is toggled, so its counts
+// track the picker without a per-frame daemon round-trip.
+func (m *home) refreshSidebarProjects() {
+	projects := m.buildProjectList()
+	rows := make([]ui.SidebarProject, 0, len(projects))
+	for _, p := range projects {
+		rows = append(rows, ui.SidebarProject{
+			Name:         p.Name,
+			Root:         p.Root,
+			SessionCount: p.SessionCount,
+			Active:       p.Root == m.repoRoot,
+		})
+	}
+	m.sidebar.SetProjects(rows)
+}
+
+// switchToProjectRoot resolves a Projects-section row's repo root and switches
+// the rail to it, reusing the #1461 switchProject path. A root that no longer
+// resolves (repo moved/removed) surfaces an error rather than silently doing
+// nothing. Switching to the already-active project is a no-op inside
+// switchProject.
+func (m *home) switchToProjectRoot(root string) (tea.Model, tea.Cmd) {
+	repo, err := config.RepoFromPath(root)
+	if err != nil {
+		return m, m.handleError(fmt.Errorf("cannot open project %q: %w", filepath.Base(root), err))
+	}
+	return m.switchProject(repo)
 }
 
 // handleStateSwitchProject routes key events to the project picker overlay and
@@ -208,6 +241,9 @@ func (m *home) switchProject(repo *config.RepoContext) (tea.Model, tea.Cmd) {
 	}
 
 	m.restoreTUIViewStateOnLaunch()
+	// Re-derive the Projects section for the new scope so its active marker and
+	// counts follow the switch.
+	m.refreshSidebarProjects()
 	m.focusTreeForNav()
 	m.relayout()
 	return m, tea.Sequence(tea.WindowSize(), m.selectionChanged())

--- a/app/switch_project_test.go
+++ b/app/switch_project_test.go
@@ -12,10 +12,74 @@ import (
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
+	"github.com/sachiniyer/agent-factory/ui"
 	"github.com/sachiniyer/agent-factory/ui/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestSelectProjectRowSwitchesProject: with the cursor on a Projects-section row,
+// Enter reuses the #1461 switchProject path to re-scope the rail to that
+// project. This is the sidebar surface for #1547's switch, additive to the
+// ctrl+p picker.
+func TestSelectProjectRowSwitchesProject(t *testing.T) {
+	h := newTestHome(t)
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+	h.snapshotFetcher = func(string) (daemon.SnapshotResponse, error) {
+		return daemon.SnapshotResponse{}, nil
+	}
+
+	// A real git repo the row resolves to (switchToProjectRoot runs RepoFromPath).
+	repoBRoot := initTestGitRepo(t)
+	require.NotEqual(t, h.repoRoot, repoBRoot)
+
+	// Push a Projects list holding the active project and repo B, then expand the
+	// section and move the cursor onto repo B's row.
+	h.sidebar.SetSize(40, 40)
+	h.sidebar.SetProjects([]ui.SidebarProject{
+		{Name: filepath.Base(repoBRoot), Root: repoBRoot, SessionCount: 0},
+		{Name: filepath.Base(h.repoRoot), Root: h.repoRoot, SessionCount: 1, Active: true},
+	})
+	h.sidebar.ClickHeaderKind(ui.SectionProjects) // expand; cursor on the header
+	h.sidebar.Down()                              // step onto the first project row (repo B)
+
+	proj, ok := h.sidebar.GetSelectedProject()
+	require.True(t, ok, "cursor must rest on a project row")
+	require.Equal(t, repoBRoot, proj.Root)
+
+	mod, _ := h.handleEnter()
+	require.NotNil(t, mod)
+
+	assert.Equal(t, config.RepoIDFromRoot(repoBRoot), h.repoID, "Enter on a project row must switch to it")
+	assert.Equal(t, repoBRoot, h.repoRoot)
+}
+
+// TestToggleProjectsHeaderExpands: Enter on the Projects header toggles the
+// section (it does not switch), exactly like the Instances/Archived headers.
+func TestToggleProjectsHeaderExpands(t *testing.T) {
+	h := newTestHome(t)
+	t.Cleanup(SetAllReposSnapshotFetcherForTest(func() ([]session.InstanceData, error) {
+		return nil, nil
+	}))
+	h.sidebar.SetSize(40, 40)
+	h.sidebar.SetProjects([]ui.SidebarProject{
+		{Name: filepath.Base(h.repoRoot), Root: h.repoRoot, SessionCount: 0, Active: true},
+	})
+
+	// Move the cursor onto the Projects header.
+	h.sidebar.ClickHeaderKind(ui.SectionProjects) // expands and lands on header
+	require.True(t, h.sidebar.GetSelection().IsHeader)
+	require.Equal(t, ui.SectionProjects, h.sidebar.GetSelection().Kind)
+
+	// Enter on the header toggles (collapses) it; the active project is unchanged.
+	before := h.repoID
+	mod, _ := h.handleEnter()
+	require.NotNil(t, mod)
+	assert.Equal(t, before, h.repoID, "toggling the Projects header must not switch projects")
+	assert.True(t, h.sidebar.GetSelection().IsHeader, "cursor stays on the Projects header after toggle")
+}
 
 // TestSwitchProjectRescopesSidebar is the core #1461 guarantee: switching to
 // another project fully swaps the sidebar to that project's sessions — the

--- a/ui/layout/zones/ids.go
+++ b/ui/layout/zones/ids.go
@@ -22,6 +22,9 @@ const (
 	// zone from TreeHeader so clicking each toggles its own section instead of
 	// colliding on one id.
 	TreeHeaderArchived = "tree:header:archived"
+	// TreeHeaderProjects is the Projects section header row — a DISTINCT zone
+	// from the other headers so clicking it toggles the Projects section only.
+	TreeHeaderProjects = "tree:header:projects"
 	// TreeBG is the tree pane's background: any click inside the rail's tree
 	// region that lands on no finer zone (focuses the tree).
 	TreeBG = "tree:bg"
@@ -40,6 +43,15 @@ func TreeInstance(title string) string { return "tree:instance:" + title }
 // TreeInstanceTitle parses a TreeInstance id back to its title.
 func TreeInstanceTitle(id string) (title string, ok bool) {
 	return strings.CutPrefix(id, "tree:instance:")
+}
+
+// TreeProject is the zone id of a Projects-section row, keyed by the project's
+// absolute repo root (unique per project, so a click resolves the right one).
+func TreeProject(root string) string { return "tree:project:" + root }
+
+// TreeProjectRoot parses a TreeProject id back to its repo root.
+func TreeProjectRoot(id string) (root string, ok bool) {
+	return strings.CutPrefix(id, "tree:project:")
 }
 
 // TreeArrow is the zone id of an instance row's expand/collapse arrow glyph.

--- a/ui/sidebar_model.go
+++ b/ui/sidebar_model.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
@@ -30,7 +31,28 @@ const (
 	// hidden entirely when no session is archived, so the folder only appears
 	// once there is something in it.
 	SectionArchived
+	// SectionProjects lists the projects af has seen (#1547 sidebar surface) in
+	// a folder pinned at the very bottom of the rail, below Archived, collapsed
+	// by default. Its rows are NOT instance rows: ItemIndex indexes the sidebar's
+	// pushed project list (SetProjects), each row carrying a repo's display name,
+	// session count, and whether it is the active (scoped-to) project. Selecting
+	// a row re-scopes the rail to that project via the #1547 switch path. The
+	// header is hidden only when no project list has been pushed; in the running
+	// TUI the active project is always present, so it always shows.
+	SectionProjects
 )
+
+// SidebarProject is one row of the Projects section: a repo af has seen, with
+// its display name (repo basename), absolute main-worktree root, tracked
+// session count, and whether it is the project the rail is currently scoped to.
+// The app derives these from the same discovery the ctrl+p picker uses and
+// pushes them via SetProjects.
+type SidebarProject struct {
+	Name         string
+	Root         string
+	SessionCount int
+	Active       bool
+}
 
 // SidebarItem represents one visible row in the sidebar. Within the Instances
 // section a non-header row is either an instance row or — the tree dimension
@@ -96,6 +118,20 @@ var blurredTitle = lipgloss.NewStyle().
 	Foreground(activeTheme.ForegroundStrong)
 
 var autoYesStyle = lipgloss.NewStyle().
+	Background(activeTheme.SelectionBackground).
+	Foreground(activeTheme.SelectionForeground)
+
+// projectRowStyle / projectRowActiveStyle / projectRowSelectedStyle render the
+// Projects section rows: the plain row, the active (scoped-to) project's accent
+// marker, and the cursor-selected row (selection background wins over active).
+var projectRowStyle = lipgloss.NewStyle().
+	Foreground(activeTheme.Foreground)
+
+var projectRowActiveStyle = lipgloss.NewStyle().
+	Bold(true).
+	Foreground(activeTheme.Accent)
+
+var projectRowSelectedStyle = lipgloss.NewStyle().
 	Background(activeTheme.SelectionBackground).
 	Foreground(activeTheme.SelectionForeground)
 
@@ -167,6 +203,13 @@ type Sidebar struct {
 	// an in-place project switch (#1461). Empty falls back to "Agent Factory".
 	projectName string
 
+	// projects backs the Projects section's rows (SetProjects). projectsSig is a
+	// fingerprint of that list folded into structureSig so a pushed change (new
+	// project, changed count, active flip) re-derives the row list on the next
+	// read, matching the lazy sync every other structural input uses.
+	projects    []SidebarProject
+	projectsSig string
+
 	// rect is the pane's screen rect (SetRect); zone registration needs the
 	// absolute origin, not just the size.
 	rect layout.Rect
@@ -182,10 +225,14 @@ func NewSidebar(spin *spinner.Model, autoYes bool, proj *store.Projection) *Side
 		proj: proj,
 		sections: []SidebarSection{
 			{Kind: SectionInstances, Title: "Instances", Expanded: true},
-			// Archived (#1028): pinned last, collapsed by default. Rendered only
-			// when it holds archived sessions (rebuildVisibleItems skips the empty
-			// folder).
+			// Archived (#1028): pinned below the live instances, collapsed by
+			// default. Rendered only when it holds archived sessions
+			// (rebuildVisibleItems skips the empty folder).
 			{Kind: SectionArchived, Title: "Archived", Expanded: false},
+			// Projects: pinned at the very bottom of the rail, collapsed by
+			// default. Rendered only once a project list is pushed
+			// (rebuildVisibleItems skips it while empty).
+			{Kind: SectionProjects, Title: "Projects", Expanded: false},
 		},
 		renderer:      tree.NewInstanceRenderer(spin),
 		autoyes:       autoYes,
@@ -239,6 +286,20 @@ func (s *Sidebar) Blur() { s.focused = false }
 // (#1461). Empty restores the default "Agent Factory" label.
 func (s *Sidebar) SetProjectName(name string) { s.projectName = name }
 
+// SetProjects replaces the Projects section's row list. The app pushes it from
+// the same cross-repo discovery the ctrl+p picker uses, whenever the list can
+// change (launch, project switch, section expand). The row list is re-derived
+// lazily on the next read: the pushed list is fingerprinted into projectsSig so
+// structureSig moves and syncFromStore rebuilds — no eager rebuild here.
+func (s *Sidebar) SetProjects(projects []SidebarProject) {
+	s.projects = projects
+	var b strings.Builder
+	for _, p := range projects {
+		fmt.Fprintf(&b, "%s\x1f%d\x1f%t\x1e", p.Root, p.SessionCount, p.Active)
+	}
+	s.projectsSig = b.String()
+}
+
 // HandleKey implements layout.Pane. Tree navigation stays routed through the
 // root model's global bindings in PR 4 (the keys also work when the workspace
 // pane has focus); per-pane routing arrives with the split (#1024 PR 5).
@@ -275,8 +336,11 @@ func (s *Sidebar) structureSig() string {
 	// identifies the partition, so it catches both a single archive/restore and
 	// a same-count swap.
 	_, archived := partitionByArchived(s.proj.GetInstances())
-	return fmt.Sprintf("%d|%s|%d|%t|%s|%v",
-		s.proj.Version(), selTitle, slots, expandable, s.treeCollapsed, archived)
+	// Fold in the pushed Projects list (SetProjects): it is independent of the
+	// projection, so without projectsSig a project add/count/active change would
+	// not re-derive the row list until the next structural change.
+	return fmt.Sprintf("%d|%s|%d|%t|%s|%v|%s",
+		s.proj.Version(), selTitle, slots, expandable, s.treeCollapsed, archived, s.projectsSig)
 }
 
 // instanceExpanded reports whether inst's tab children are currently shown:

--- a/ui/sidebar_nav.go
+++ b/ui/sidebar_nav.go
@@ -191,6 +191,12 @@ func (s *Sidebar) rebuildVisibleItems() {
 		if sec.Kind == SectionArchived && len(archived) == 0 {
 			continue
 		}
+		// The Projects folder only appears once a project list is pushed. In the
+		// running TUI the active project is always present, so it always shows;
+		// unit tests that never call SetProjects keep the pre-Projects layout.
+		if sec.Kind == SectionProjects && len(s.projects) == 0 {
+			continue
+		}
 		items = append(items, SidebarItem{Kind: sec.Kind, IsHeader: true})
 		if !sec.Expanded {
 			continue
@@ -212,6 +218,11 @@ func (s *Sidebar) rebuildVisibleItems() {
 			// Flat rows — archived sessions have no live tabs.
 			for _, idx := range archived {
 				items = append(items, SidebarItem{Kind: SectionArchived, ItemIndex: idx})
+			}
+		case SectionProjects:
+			// Flat rows — one per pushed project; ItemIndex indexes s.projects.
+			for idx := range s.projects {
+				items = append(items, SidebarItem{Kind: SectionProjects, ItemIndex: idx})
 			}
 		}
 	}
@@ -287,7 +298,8 @@ func (s *Sidebar) verticalNavStops() []sidebarNavStop {
 }
 
 func isSelectableNonTabNavStop(item SidebarItem) bool {
-	return !item.IsHeader && !item.IsTab && item.Kind == SectionArchived
+	return !item.IsHeader && !item.IsTab &&
+		(item.Kind == SectionArchived || item.Kind == SectionProjects)
 }
 
 func indexOfNavStop(stops []sidebarNavStop, selectedIdx int, sel SidebarItem) int {
@@ -390,20 +402,14 @@ func (s *Sidebar) tryMoveVerticalNavStop(dir int) bool {
 				return s.selectNavStop(stops[0])
 			}
 			return false
-		case SectionArchived:
+		case SectionArchived, SectionProjects:
+			// A trailing-section header (#1028 Archived, Projects): Down enters
+			// the section's first row; Up leaves to the row above — the last row
+			// of the section above (Archived) or the last live tab.
 			if dir < 0 {
-				for i := len(stops) - 1; i >= 0; i-- {
-					if stops[i].isTab {
-						return s.selectNavStop(stops[i])
-					}
-				}
-			} else {
-				for _, stop := range stops {
-					if !stop.isTab && stop.visibleIdx > s.selectedIdx {
-						return s.selectNavStop(stop)
-					}
-				}
+				return s.selectPrevNavStopBeforeHeader(stops)
 			}
+			return s.selectFirstNavStopAfterHeader(stops)
 		}
 		return false
 	}
@@ -425,37 +431,100 @@ func (s *Sidebar) tryMoveVerticalNavStop(dir int) bool {
 	return s.selectNavStop(stops[target])
 }
 
+// selectPrevNavStopBeforeHeader selects the nav stop immediately above a
+// trailing-section header (Archived/Projects): the last row of the section
+// above — a non-tab stop with a smaller visible index (an Archived row above a
+// Projects header) — or, when none is above, the last live tab stop.
+func (s *Sidebar) selectPrevNavStopBeforeHeader(stops []sidebarNavStop) bool {
+	for i := len(stops) - 1; i >= 0; i-- {
+		if stops[i].isTab {
+			return s.selectNavStop(stops[i])
+		}
+		if stops[i].visibleIdx < s.selectedIdx {
+			return s.selectNavStop(stops[i])
+		}
+	}
+	return false
+}
+
+// selectFirstNavStopAfterHeader selects the first row of the trailing section
+// whose header the cursor rests on: the first non-tab stop below it.
+func (s *Sidebar) selectFirstNavStopAfterHeader(stops []sidebarNavStop) bool {
+	for _, stop := range stops {
+		if !stop.isTab && stop.visibleIdx > s.selectedIdx {
+			return s.selectNavStop(stop)
+		}
+	}
+	return false
+}
+
 func (s *Sidebar) moveVerticalNavStop(dir int) {
 	before := s.rawSelection()
 	if s.tryMoveVerticalNavStop(dir) {
-		// Symmetric to the auto-open at the live tail (#1518): when Up carries the
-		// cursor out of an archived row back into the live instances, fold the
-		// Archived section again so it collapses as the user leaves it.
-		if dir < 0 && before.Kind == SectionArchived && s.rawSelection().Kind == SectionInstances {
-			s.collapseArchivedSectionForNav()
+		// Symmetric to the auto-open at the tail (#1518): when Up carries the
+		// cursor out of a trailing section (Archived/Projects) into a higher one,
+		// fold the section it just left so it collapses behind the cursor.
+		if dir < 0 {
+			s.autoCollapseTrailingSectionAfterUp(before)
 		}
 		return
 	}
-	// Archived rows are selectable stops only after the Archived section renders
-	// them. At the live-list tail, Down should reveal that folder and retry.
-	if dir <= 0 || !s.downNavCanRevealArchived() || !s.expandArchivedSectionForNav() {
+	// A trailing section's rows are selectable stops only once it renders them.
+	// At the tail, Down should reveal the next collapsed trailing section (the
+	// Archived folder, then Projects) and retry.
+	if dir <= 0 || !s.revealNextTrailingSectionForNav(before) {
 		return
 	}
 	_ = s.tryMoveVerticalNavStop(dir)
 }
 
-func (s *Sidebar) downNavCanRevealArchived() bool {
-	return s.rawSelection().Kind == SectionInstances
+// revealNextTrailingSectionForNav expands the next collapsed trailing section
+// below the cursor so Down can continue into it (#1518 auto-open, extended to
+// Projects). From the live instances it tries the Archived folder first, then
+// Projects; from an archived row it tries Projects. A collapsed trailing header
+// itself is left alone (Down on it is a no-op, matching the pre-Projects
+// Archived behavior). Returns whether a section was expanded so the caller
+// retries the move.
+func (s *Sidebar) revealNextTrailingSectionForNav(from SidebarItem) bool {
+	switch from.Kind {
+	case SectionInstances:
+		if s.expandArchivedSectionForNav() {
+			return true
+		}
+		return s.expandProjectsSectionForNav()
+	case SectionArchived:
+		if from.IsHeader {
+			return false
+		}
+		return s.expandProjectsSectionForNav()
+	}
+	return false
 }
 
-// collapseArchivedSectionForNav folds the Archived section back up — the mirror
-// of expandArchivedSectionForNav — after Up navigation carries the cursor out of
-// an archived row and back into the live instances (#1518 symmetry). The cursor
-// already rests on the live tab stop; rebuildPreservingCursor keeps it pinned
-// there as the trailing archived rows disappear.
-func (s *Sidebar) collapseArchivedSectionForNav() {
+// autoCollapseTrailingSectionAfterUp folds a trailing section back up after Up
+// navigation carries the cursor out of it into a higher section (#1518
+// symmetry): the Archived folder or the Projects section. The cursor already
+// rests on the higher row; rebuildPreservingCursor keeps it pinned as the
+// trailing rows disappear.
+func (s *Sidebar) autoCollapseTrailingSectionAfterUp(before SidebarItem) {
+	if before.IsHeader {
+		return
+	}
+	if before.Kind != SectionArchived && before.Kind != SectionProjects {
+		return
+	}
+	if s.rawSelection().Kind == before.Kind {
+		return
+	}
+	s.collapseSectionForNav(before.Kind)
+}
+
+// collapseSectionForNav folds the given trailing section back up — the mirror of
+// the expand-for-nav helpers. rebuildPreservingCursor keeps the cursor pinned on
+// its current row as the section's trailing rows disappear.
+func (s *Sidebar) collapseSectionForNav(kind SidebarSectionKind) {
 	for i, sec := range s.sections {
-		if sec.Kind != SectionArchived {
+		if sec.Kind != kind {
 			continue
 		}
 		if !sec.Expanded {
@@ -465,6 +534,27 @@ func (s *Sidebar) collapseArchivedSectionForNav() {
 		s.rebuildPreservingCursor()
 		return
 	}
+}
+
+// expandProjectsSectionForNav expands the Projects section for Down navigation
+// when it is collapsed and a project list is present. No-op (false) when it is
+// already expanded or empty (nothing to reveal).
+func (s *Sidebar) expandProjectsSectionForNav() bool {
+	if len(s.projects) == 0 {
+		return false
+	}
+	for i, sec := range s.sections {
+		if sec.Kind != SectionProjects {
+			continue
+		}
+		if sec.Expanded {
+			return false
+		}
+		s.sections[i].Expanded = true
+		s.rebuildVisibleItems()
+		return true
+	}
+	return false
 }
 
 func (s *Sidebar) expandArchivedSectionForNav() bool {
@@ -653,6 +743,21 @@ func (s *Sidebar) GetSelectedInstance() *session.Instance {
 		return nil
 	}
 	return instances[sel.ItemIndex]
+}
+
+// GetSelectedProject returns the Projects-section row under the cursor, or
+// false when the cursor rests anywhere else. The app reads it to switch the
+// rail to that project (reusing the #1547 switch path).
+func (s *Sidebar) GetSelectedProject() (SidebarProject, bool) {
+	s.syncFromStore()
+	sel := s.rawSelection()
+	if sel.Kind != SectionProjects || sel.IsHeader {
+		return SidebarProject{}, false
+	}
+	if sel.ItemIndex < 0 || sel.ItemIndex >= len(s.projects) {
+		return SidebarProject{}, false
+	}
+	return s.projects[sel.ItemIndex], true
 }
 
 // SetSelectedInstance sets the cursor to point at the given instance index.

--- a/ui/sidebar_projects_test.go
+++ b/ui/sidebar_projects_test.go
@@ -1,0 +1,246 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/sachiniyer/agent-factory/ui/layout/zones"
+	"github.com/sachiniyer/agent-factory/ui/store"
+)
+
+func projectsTestSidebar(t *testing.T) *Sidebar {
+	t.Helper()
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+	s.SetSize(40, 40)
+	return s
+}
+
+// projectRowVisible reports whether any non-header Projects row is currently in
+// the visible list.
+func projectRowVisible(s *Sidebar) bool {
+	for _, it := range s.visibleItems {
+		if it.Kind == SectionProjects && !it.IsHeader && it.ItemIndex >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSidebar_ProjectsSectionAtBottomDefaultCollapsed: once a project list is
+// pushed, the Projects section renders as the very LAST header on the rail
+// (below Instances and Archived), collapsed by default — no project rows show
+// until it is expanded.
+func TestSidebar_ProjectsSectionAtBottomDefaultCollapsed(t *testing.T) {
+	s := projectsTestSidebar(t)
+	addTestInstance(s, archTestInstance(t, "live-one", session.Ready))
+	addTestInstance(s, archTestInstance(t, "put-away", session.Archived))
+	s.SetProjects([]SidebarProject{
+		{Name: "alpha", Root: "/repos/alpha", SessionCount: 2, Active: true},
+		{Name: "beta", Root: "/repos/beta", SessionCount: 1},
+	})
+	// Expand Archived too so all three headers coexist and ordering is exercised.
+	s.ClickHeaderKind(SectionArchived)
+
+	var headerKinds []SidebarSectionKind
+	for _, it := range s.visibleItems {
+		if it.IsHeader {
+			headerKinds = append(headerKinds, it.Kind)
+		}
+	}
+	require.Equal(t, []SidebarSectionKind{SectionInstances, SectionArchived, SectionProjects}, headerKinds,
+		"the Projects section header must be pinned at the very bottom of the rail")
+
+	// Default collapsed: no project rows visible until expanded.
+	require.False(t, projectRowVisible(s), "the Projects section must start collapsed")
+
+	view := s.View()
+	assert.Contains(t, view, "Projects (2)", "the Projects header carries the project count")
+	assert.NotContains(t, view, "alpha", "collapsed Projects section shows no project rows")
+}
+
+// TestSidebar_ProjectsSectionHiddenWithoutList: with no project list pushed the
+// section does not render at all (unit-test parity with the pre-Projects rail).
+func TestSidebar_ProjectsSectionHiddenWithoutList(t *testing.T) {
+	s := projectsTestSidebar(t)
+	addTestInstance(s, archTestInstance(t, "live-one", session.Ready))
+	for _, it := range s.visibleItems {
+		assert.NotEqual(t, SectionProjects, it.Kind, "no Projects section renders before a list is pushed")
+	}
+	assert.NotContains(t, s.View(), "Projects")
+}
+
+// TestSidebar_ProjectsExpandListsProjectsAndMarksActive: expanding the section
+// reveals one row per pushed project — each with its name, session count, and,
+// for the active project, a distinct marker.
+func TestSidebar_ProjectsExpandListsProjectsAndMarksActive(t *testing.T) {
+	s := projectsTestSidebar(t)
+	s.SetProjects([]SidebarProject{
+		{Name: "alpha", Root: "/repos/alpha", SessionCount: 3, Active: true},
+		{Name: "beta", Root: "/repos/beta", SessionCount: 0},
+	})
+
+	s.ClickHeaderKind(SectionProjects)
+	require.True(t, projectRowVisible(s), "expanding the Projects section reveals the project rows")
+
+	// Both project rows resolve, in the pushed order.
+	var roots []string
+	for _, it := range s.visibleItems {
+		if it.Kind == SectionProjects && !it.IsHeader {
+			roots = append(roots, s.projects[it.ItemIndex].Root)
+		}
+	}
+	require.Equal(t, []string{"/repos/alpha", "/repos/beta"}, roots)
+
+	view := s.View()
+	assert.Contains(t, view, "alpha", "project rows render their name")
+	assert.Contains(t, view, "beta")
+	assert.Contains(t, view, "(3)", "project rows render their session count")
+	assert.Contains(t, view, "●", "the active project carries a distinct marker")
+}
+
+// TestSidebar_GetSelectedProjectResolvesRow: with the cursor on a project row,
+// GetSelectedProject returns that project (the hook the app reads to switch),
+// and returns false everywhere else.
+func TestSidebar_GetSelectedProjectResolvesRow(t *testing.T) {
+	s := projectsTestSidebar(t)
+	s.SetProjects([]SidebarProject{
+		{Name: "alpha", Root: "/repos/alpha", SessionCount: 1, Active: true},
+		{Name: "beta", Root: "/repos/beta", SessionCount: 2},
+	})
+
+	// On the collapsed header: not a project row.
+	_, ok := s.GetSelectedProject()
+	require.False(t, ok, "a header selection is not a project row")
+
+	s.ClickHeaderKind(SectionProjects)
+	// Land the cursor on the second project row and resolve it.
+	for i, it := range s.visibleItems {
+		if it.Kind == SectionProjects && !it.IsHeader && s.projects[it.ItemIndex].Root == "/repos/beta" {
+			s.selectedIdx = i
+			break
+		}
+	}
+	proj, ok := s.GetSelectedProject()
+	require.True(t, ok, "the cursor on a project row must resolve it")
+	assert.Equal(t, "/repos/beta", proj.Root)
+	assert.Equal(t, "beta", proj.Name)
+}
+
+// TestSidebar_NavReachesProjectsAtTail: Down at the rail tail auto-expands the
+// Projects section and steps into it; Up back out auto-collapses it again
+// (#1518 symmetry, extended to Projects).
+func TestSidebar_NavReachesProjectsAtTail(t *testing.T) {
+	s := projectsTestSidebar(t)
+	liveInst := archTestInstance(t, "live-one", session.Ready)
+	addAgentShellTabs(liveInst)
+	addTestInstance(s, liveInst)
+	s.SetProjects([]SidebarProject{
+		{Name: "alpha", Root: "/repos/alpha", SessionCount: 1, Active: true},
+	})
+	require.False(t, projectRowVisible(s), "Projects starts collapsed before the boundary walk")
+
+	s.SetSelectedInstance(0)
+	s.Down() // live Agent tab
+	s.Down() // live Terminal tab — the last live tab stop
+	require.True(t, s.GetSelection().IsTab)
+
+	s.Down()
+	sel := s.GetSelection()
+	require.Equal(t, SectionProjects, sel.Kind, "Down at the live tail auto-opens Projects and reaches its rows")
+	require.False(t, sel.IsHeader)
+	require.True(t, projectRowVisible(s), "Down at the tail must expand the Projects section")
+
+	s.Up()
+	sel = s.GetSelection()
+	require.Equal(t, SectionInstances, sel.Kind, "Up from the first project row returns to the live tabs")
+	require.True(t, sel.IsTab)
+	require.False(t, projectRowVisible(s), "Up back into the live instances auto-collapses the Projects section")
+}
+
+// TestSidebar_NavCrossesArchivedThenProjects: with both trailing sections
+// present, Down chains live tabs → Archived rows → Projects rows, and Up unwinds
+// the same path, auto-collapsing each section as the cursor leaves it.
+func TestSidebar_NavCrossesArchivedThenProjects(t *testing.T) {
+	s := projectsTestSidebar(t)
+	liveInst := archTestInstance(t, "live-one", session.Ready)
+	addAgentShellTabs(liveInst)
+	archivedInst := archTestInstance(t, "put-away", session.Archived)
+	addTestInstance(s, liveInst)
+	addTestInstance(s, archivedInst)
+	s.SetProjects([]SidebarProject{
+		{Name: "alpha", Root: "/repos/alpha", SessionCount: 1, Active: true},
+	})
+	s.SetSelectedInstance(0)
+
+	s.Down() // live Agent tab
+	s.Down() // live Terminal tab
+	s.Down() // auto-open Archived → first archived row
+	require.Equal(t, SectionArchived, s.GetSelection().Kind)
+
+	s.Down() // auto-open Projects → first project row
+	require.Equal(t, SectionProjects, s.GetSelection().Kind, "Down from the archived tail reaches the Projects rows")
+	require.True(t, projectRowVisible(s))
+
+	s.Up() // back into the archived row; Projects collapses behind the cursor
+	require.Equal(t, SectionArchived, s.GetSelection().Kind, "Up from Projects returns to the archived row")
+	require.False(t, projectRowVisible(s), "leaving Projects upward auto-collapses it")
+}
+
+// TestSidebar_ProjectsZonesRegistered: the Projects header gets its own distinct
+// zone id, and — once expanded — each project row registers a root-keyed
+// clickable zone.
+func TestSidebar_ProjectsZonesRegistered(t *testing.T) {
+	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
+	s := NewSidebar(&spin, false, store.NewProjection())
+	reg := zones.NewRegistry()
+	s.SetZoneRegistry(reg)
+	s.SetRect(layout.Rect{X: 0, Y: 0, W: 40, H: 40})
+	s.SetProjects([]SidebarProject{
+		{Name: "alpha", Root: "/repos/alpha", SessionCount: 1, Active: true},
+	})
+
+	reg.Reset()
+	_ = s.String()
+	_, okHeader := reg.Find(zones.TreeHeaderProjects)
+	require.True(t, okHeader, "the Projects header must register its own distinct zone")
+	assert.NotEqual(t, zones.TreeHeader, zones.TreeHeaderProjects)
+	assert.NotEqual(t, zones.TreeHeaderArchived, zones.TreeHeaderProjects)
+
+	// Collapsed → no project-row zone yet.
+	_, okRow := reg.Find(zones.TreeProject("/repos/alpha"))
+	require.False(t, okRow, "a collapsed Projects section registers no project-row zone")
+
+	// Expand and re-render: the project row registers a root-keyed zone.
+	s.ClickHeaderKind(SectionProjects)
+	reg.Reset()
+	_ = s.String()
+	_, okRow = reg.Find(zones.TreeProject("/repos/alpha"))
+	require.True(t, okRow, "an expanded project row must register a clickable TreeProject zone")
+	root, ok := zones.TreeProjectRoot(zones.TreeProject("/repos/alpha"))
+	require.True(t, ok)
+	assert.Equal(t, "/repos/alpha", root)
+}
+
+// TestSidebar_ProjectRowRenderTruncatesNarrow guards the #646 overflow class:
+// a long project name at a narrow rail truncates rather than pushing the row
+// past the allocation.
+func TestSidebar_ProjectRowRenderTruncatesNarrow(t *testing.T) {
+	s := projectsTestSidebar(t)
+	s.SetSize(12, 20)
+	s.SetProjects([]SidebarProject{
+		{Name: "a-very-long-project-name-that-overflows", Root: "/repos/x", SessionCount: 1, Active: true},
+	})
+	s.ClickHeaderKind(SectionProjects)
+	view := s.View()
+	for i, line := range strings.Split(view, "\n") {
+		require.LessOrEqualf(t, lipgloss.Width(line), 12, "line %d must not exceed the rail width", i)
+	}
+}

--- a/ui/sidebar_render.go
+++ b/ui/sidebar_render.go
@@ -47,6 +47,8 @@ func (s *Sidebar) String() string {
 			case SectionArchived:
 				// Archived rows are flat instance rows (#1028) — no tab children.
 				rows[i] = s.renderInstance(item.ItemIndex, isSelected)
+			case SectionProjects:
+				rows[i] = s.renderProject(item.ItemIndex, isSelected)
 			}
 		}
 		heights[i] = lipgloss.Height(rows[i])
@@ -300,6 +302,8 @@ func (s *Sidebar) renderHeader(kind SidebarSectionKind, selected bool) string {
 		label = fmt.Sprintf("Instances (%d)", len(live))
 	case SectionArchived:
 		label = fmt.Sprintf("Archived (%d)", len(archived))
+	case SectionProjects:
+		label = fmt.Sprintf("Projects (%d)", len(s.projects))
 	}
 
 	style := sectionHeaderStyle
@@ -346,4 +350,41 @@ func (s *Sidebar) renderTabRow(item SidebarItem, selected bool) string {
 	}
 	return s.renderer.RenderTab(labels[item.TabIndex], item.TabIndex+1,
 		item.TabIndex == len(labels)-1, selected, s.proj.ActiveTab() == item.TabIndex)
+}
+
+// renderProject renders one Projects-section row: "● name (N)" for the active
+// (scoped-to) project, "  name (N)" otherwise, where N is the tracked session
+// count. The cursor-selected row takes the selection background; a non-selected
+// active row takes the accent marker style. Width handling mirrors the section
+// header and window indicator (truncate with a "…" tail that itself drops when
+// the rail is too narrow, since lipgloss.Place pads but never clips).
+func (s *Sidebar) renderProject(idx int, selected bool) string {
+	if idx < 0 || idx >= len(s.projects) {
+		return ""
+	}
+	p := s.projects[idx]
+	w := s.contentWidth()
+
+	marker := "  "
+	if p.Active {
+		marker = "● "
+	}
+	text := fmt.Sprintf("%s%s (%d)", marker, p.Name, p.SessionCount)
+	if w > 0 && runewidth.StringWidth(text) > w {
+		tail := "..."
+		if w < runewidth.StringWidth(tail) {
+			tail = ""
+		}
+		text = runewidth.Truncate(text, w, tail)
+	}
+
+	style := projectRowStyle
+	switch {
+	case selected:
+		style = projectRowSelectedStyle
+	case p.Active:
+		style = projectRowActiveStyle
+	}
+	return style.Padding(0, narrowAwarePad(w)).Render(
+		lipgloss.Place(w, 1, lipgloss.Left, lipgloss.Center, text))
 }

--- a/ui/sidebar_test.go
+++ b/ui/sidebar_test.go
@@ -21,21 +21,26 @@ func TestSidebarInitialState(t *testing.T) {
 	spin := spinner.New(spinner.WithSpinner(spinner.MiniDot))
 	s := NewSidebar(&spin, false, store.NewProjection())
 
-	// The rail holds the Instances tree plus the Archived folder (#1028). The
-	// Archived section always exists so its collapse state persists, but it is
-	// rendered only when it holds archived sessions (see the assertion below).
-	assert.Equal(t, 2, len(s.sections))
+	// The rail holds the Instances tree, the Archived folder (#1028), and the
+	// Projects section. Archived and Projects always exist so their collapse
+	// state persists, but each renders only when it has content (an archived
+	// session / a pushed project list — see the assertions below).
+	assert.Equal(t, 3, len(s.sections))
 	assert.Equal(t, SectionInstances, s.sections[0].Kind)
 	assert.Equal(t, SectionArchived, s.sections[1].Kind)
+	assert.Equal(t, SectionProjects, s.sections[2].Kind)
 
-	// Instances is expanded by default; the Archived folder is collapsed.
+	// Instances is expanded by default; the Archived folder and Projects section
+	// start collapsed.
 	assert.True(t, s.sections[0].Expanded)
 	assert.False(t, s.sections[1].Expanded, "the Archived folder starts collapsed")
+	assert.False(t, s.sections[2].Expanded, "the Projects section starts collapsed")
 
-	// With nothing archived, no Archived header is rendered — only the
-	// Instances header is visible.
+	// With nothing archived and no project list pushed, neither the Archived nor
+	// the Projects header is rendered — only the Instances header is visible.
 	for _, it := range s.visibleItems {
 		assert.NotEqual(t, SectionArchived, it.Kind, "the empty Archived folder must not render")
+		assert.NotEqual(t, SectionProjects, it.Kind, "the empty Projects section must not render")
 	}
 
 	// Initial selection should be on Instances header

--- a/ui/sidebar_zones.go
+++ b/ui/sidebar_zones.go
@@ -35,11 +35,17 @@ func (s *Sidebar) registerZones(heights []int, start, end int, topIndicator bool
 		switch {
 		case item.IsHeader:
 			// Distinct zone per folder so a click toggles the right one (#1028).
-			if item.Kind == SectionArchived {
+			switch item.Kind {
+			case SectionArchived:
 				s.zones.Register(zones.TreeHeaderArchived, row)
-			} else {
+			case SectionProjects:
+				s.zones.Register(zones.TreeHeaderProjects, row)
+			default:
 				s.zones.Register(zones.TreeHeader, row)
 			}
+		case item.Kind == SectionProjects && item.ItemIndex >= 0 && item.ItemIndex < len(s.projects):
+			// Project row: a root-keyed zone; a click switches to that project.
+			s.zones.Register(zones.TreeProject(s.projects[item.ItemIndex].Root), row)
 		case isInstanceRow(item) && item.ItemIndex >= 0 && item.ItemIndex < len(instances):
 			inst := instances[item.ItemIndex]
 			switch {

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -138,6 +138,14 @@ func applyThemeStyles() {
 	autoYesStyle = lipgloss.NewStyle().
 		Background(activeTheme.SelectionBackground).
 		Foreground(activeTheme.SelectionForeground)
+	projectRowStyle = lipgloss.NewStyle().
+		Foreground(activeTheme.Foreground)
+	projectRowActiveStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(activeTheme.Accent)
+	projectRowSelectedStyle = lipgloss.NewStyle().
+		Background(activeTheme.SelectionBackground).
+		Foreground(activeTheme.SelectionForeground)
 
 	automationsTitleStyle = lipgloss.NewStyle().
 		Bold(true).


### PR DESCRIPTION
## What

Adds a **Projects** section pinned at the very bottom of the left sidebar (below Instances and Archived), **collapsed by default** — modeled on the existing Archived folder. This is a **second, additive** way to see and switch projects alongside the #1547 `ctrl+p` project picker (which keeps working unchanged).

Sachin's request: *"list the projects at the bottom of the left side pane, default collapsed."*

## Behavior

- **Bottom of the rail, default collapsed.** The header always renders once a project list is pushed (in the running TUI the active project is always present, so it always shows). Expanding it (Enter/click on the header, or auto-expand on nav) reveals the rows.
- **Rows** = the projects `af` has seen — the **same discovery as the #1547 picker** (`buildProjectList`: cross-repo session snapshot grouped by repo root, plus `root_agents` opt-ins, plus the current project). Each row shows the display name (`filepath.Base` of the repo root) and its session count.
- **Active project marked** with a `●` accent marker so it's clear which project the rail is scoped to.
- **Selecting a row switches to it** (Enter or click) by reusing the existing `switchProject(...)` path (#1461/#1547) — no duplicated switch logic.
- **Keyboard nav** is threaded through the section machinery consistently with Archived: `SectionProjects` is a selectable nav stop; Down at the tail auto-expands it (chaining past Archived, #1518); Up auto-collapses it as the cursor leaves (#1518 symmetry / #1527); the header toggles like the other sections. Instances/Archived nav is unchanged.
- **Mouse**: distinct zones (`TreeHeaderProjects`, `TreeProject(root)`).

## Design defaults chosen (flag if any is wrong)

- Position: very bottom, after Archived.
- Default collapsed; same toggle as Archived.
- Empty/one project: still shows the collapsed header; expanding shows just the current project.
- Counts refresh on section expand / switch / launch (not per-frame) to avoid a per-tick cross-repo daemon RPC; the header count is the project count.
- Mouse: a single click on a project row switches (matches "selecting switches" + keyboard Enter).

## Tests

- `ui/sidebar_projects_test.go`: renders at the bottom default-collapsed; hidden without a pushed list; expands to list projects with the active marker + counts; `GetSelectedProject` resolves the row; Down at the tail reaches Projects and Up auto-collapses; chains Archived→Projects; zones register; narrow-width truncation.
- `app/switch_project_test.go`: **Enter on a project row calls `switchProject`** (re-scopes `repoID`/`repoRoot`); Enter on the Projects header toggles (does not switch).

## Gates

`gofmt -l .` clean · `go build ./...` ok · `golangci-lint run --timeout=3m --fast` clean · `deadcode -test ./...` clean · `scripts/lint-file-length.sh` ok · `go test ./ui/... ./app/` green · `make tui-driver-selftest` 25/25 (boot path intact — this touches startup).

**Do not merge** — visible-TUI change; leaving for play-test + Greptile gate.

Signed-off-by: Captain Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)