### PR TITLE
refactor(session): capability-driven Backend, drop Type()==remote special-casing (#1592 Phase 1 PR1)

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -38,7 +38,7 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 		// relocate; there is nothing coherent to archive.
 		return "", fmt.Errorf("cannot archive session %q: it is not currently active", req.Title)
 	}
-	if instance.IsRemote() {
+	if !instance.Capabilities().Archive {
 		return "", fmt.Errorf("cannot archive remote session %q: it has no local worktree to relocate", req.Title)
 	}
 	if instance.IsExternalWorktree() {

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -330,6 +330,10 @@ type fakeRemoteBackend struct {
 
 func (fakeRemoteBackend) Type() string { return "remote" }
 
+func (fakeRemoteBackend) Capabilities() session.Capabilities {
+	return session.Capabilities{Workspace: session.WorkspaceRemote}
+}
+
 // TestArchiveSession_RejectsRemote: a remote session has no local worktree to
 // relocate, so archiving it is rejected up front.
 func TestArchiveSession_RejectsRemote(t *testing.T) {

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -93,6 +93,10 @@ type remoteTypeBackend struct {
 
 func (remoteTypeBackend) Type() string { return "remote" }
 
+func (remoteTypeBackend) Capabilities() session.Capabilities {
+	return session.Capabilities{Workspace: session.WorkspaceRemote}
+}
+
 // startedLocalTabInstance builds a started local instance whose agent tab is a
 // mock-backed tmux session, registers it in the manager, and seeds a matching
 // on-disk record so the manager's refresh keeps the live in-memory instance.

--- a/daemon/lostrestore.go
+++ b/daemon/lostrestore.go
@@ -128,7 +128,7 @@ func (m *Manager) restoreLostSession(key, repoID string, inst *session.Instance)
 		return
 	}
 
-	if inst.IsRemote() {
+	if !inst.Capabilities().Recover {
 		m.mu.Lock()
 		logIt := !st.remoteLogged
 		st.remoteLogged = true

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -55,6 +55,16 @@ func (b *recoverFakeBackend) Type() string {
 	return "local"
 }
 
+// Capabilities mirrors the Type override: a "remote" double reports a
+// WorkspaceRemote descriptor (Recover=false) so the lost-restore remote-skip
+// rule fires; otherwise it inherits FakeBackend's local parity (#1592 Phase 1).
+func (b *recoverFakeBackend) Capabilities() session.Capabilities {
+	if b.typeName == "remote" {
+		return session.Capabilities{Workspace: session.WorkspaceRemote}
+	}
+	return b.FakeBackend.Capabilities()
+}
+
 // zeroRestoreBackoff makes every RestoreLostSessions pass an attempt.
 func zeroRestoreBackoff(t *testing.T) {
 	t.Helper()

--- a/daemon/manager_tabs.go
+++ b/daemon/manager_tabs.go
@@ -33,7 +33,7 @@ func (m *Manager) CreateTab(req CreateTabRequest) (string, error) {
 	if instance == nil {
 		return "", fmt.Errorf("failed to restore instance %q", req.Title)
 	}
-	if instance.IsRemote() {
+	if !instance.Capabilities().TabManagement {
 		return "", fmt.Errorf("cannot create a tab on remote session %q: remote sessions have no local worktree and the hook protocol can't run arbitrary commands; their terminal tab comes from remote_hooks.terminal_cmd", req.Title)
 	}
 
@@ -107,7 +107,7 @@ func (m *Manager) CloseTab(req CloseTabRequest) (string, error) {
 	if instance == nil {
 		return "", fmt.Errorf("failed to restore instance %q", req.Title)
 	}
-	if instance.IsRemote() {
+	if !instance.Capabilities().TabManagement {
 		return "", fmt.Errorf("cannot close a tab on remote session %q: its tabs are fixed by remote_hooks config, not user-managed", req.Title)
 	}
 

--- a/daemon/restore.go
+++ b/daemon/restore.go
@@ -35,7 +35,7 @@ func (m *Manager) restoreLostOrDeadSession(req RestoreSessionRequest, repoID str
 	if session.IsReservedTitle(instance.Title) {
 		return "", fmt.Errorf("cannot manually restore reserved session %q", req.Title)
 	}
-	if instance.IsRemote() {
+	if !instance.Capabilities().Recover {
 		return "", fmt.Errorf("cannot restore remote session %q: reconnect is not supported", req.Title)
 	}
 	if !instance.Started() {

--- a/session/backend.go
+++ b/session/backend.go
@@ -1,5 +1,49 @@
 package session
 
+// WorkspaceKind describes where a backend's workspace physically lives, so
+// callers reason about locality without asking "is this the remote type"
+// (#1592 Phase 1). New runtimes (ssh/container) pick the kind that matches
+// where the git worktree lands.
+type WorkspaceKind int
+
+const (
+	// WorkspaceLocalWorktree: a git worktree on the daemon's own machine, driven
+	// by tmux (today's LocalBackend). Zero value — matches the historical
+	// nil-backend default of IsRemote()==false.
+	WorkspaceLocalWorktree WorkspaceKind = iota
+	// WorkspaceRemote: the workspace lives off-box; there is no local worktree or
+	// tmux to drive (today's HookBackend; tomorrow's ssh/container runtimes).
+	WorkspaceRemote
+)
+
+// Capabilities is a backend's self-description: which optional session
+// operations it can service. The daemon and UI branch on these instead of on
+// Type()=="remote" (#1592 Phase 1), so a NEW backend declares what it supports
+// rather than every call-site learning its name. The end state is full parity —
+// every backend implements every capability — but the descriptor stays so a
+// surface can gray out an op a given runtime hasn't wired up yet.
+type Capabilities struct {
+	// Workspace records where the workspace lives (local worktree vs off-box).
+	Workspace WorkspaceKind
+
+	// Attach: an interactive controller can attach to the agent session.
+	Attach bool
+	// Archive: the session can be archived/restored (local-worktree relocation
+	// today; push/pull the branch once every backend clones from GitHub).
+	Archive bool
+	// Recover: a Lost session can be reconnected / re-spawned in place.
+	Recover bool
+	// TabManagement: the user can add/close arbitrary tabs (new process tab).
+	TabManagement bool
+	// TerminalTab: an interactive terminal tab is available. May depend on
+	// per-session config (remote_hooks.terminal_cmd), so it is computed per
+	// instance rather than being a static per-type constant.
+	TerminalTab bool
+	// InteractiveInput: raw key / prompt injection works — SendKeys/TapEnter/
+	// SendPrompt drive a live PTY rather than returning "not supported".
+	InteractiveInput bool
+}
+
 // Backend abstracts the session lifecycle so that instances can be backed
 // by local tmux+git worktrees (the default) or by user-provided remote
 // hook scripts.
@@ -80,6 +124,15 @@ type Backend interface {
 	// precondition. Remote backends return ErrRecoverUnsupported.
 	Respawn(instance *Instance) error
 
-	// Type returns the backend type identifier ("local" or "remote").
+	// Type returns the backend type identifier ("local" or "remote"). Since
+	// #1592 Phase 1 this is the persisted serialization discriminator only (the
+	// load-time factory in instance_data.go) — runtime branching goes through
+	// Capabilities, never Type().
 	Type() string
+
+	// Capabilities reports which optional operations this backend can service,
+	// replacing Type()-based special-casing (#1592 Phase 1). Computed per
+	// instance because some capabilities (TerminalTab) depend on per-session
+	// config.
+	Capabilities() Capabilities
 }

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -23,6 +23,22 @@ type HookBackend struct {
 
 func (b *HookBackend) Type() string { return "remote" }
 
+// Capabilities reports the remote hook runtime's descriptor (#1592 Phase 1): an
+// off-box workspace reachable via attach_cmd, with no local worktree/tmux, so
+// archive/recover/tab-management/raw-input are unsupported in v1. TerminalTab is
+// dynamic — it tracks whether the optional terminal_cmd hook is configured.
+func (b *HookBackend) Capabilities() Capabilities {
+	return Capabilities{
+		Workspace:        WorkspaceRemote,
+		Attach:           true,
+		Archive:          false,
+		Recover:          false,
+		TabManagement:    false,
+		TerminalTab:      b.HasTerminalCmd(),
+		InteractiveInput: false,
+	}
+}
+
 func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 	if strings.TrimSpace(i.Title) == "" {
 		return fmt.Errorf("instance title cannot be empty")

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -63,6 +63,20 @@ type LocalBackend struct{}
 
 func (b *LocalBackend) Type() string { return "local" }
 
+// Capabilities reports the local runtime's full-parity descriptor: a local git
+// worktree driven by tmux, supporting every optional operation (#1592 Phase 1).
+func (b *LocalBackend) Capabilities() Capabilities {
+	return Capabilities{
+		Workspace:        WorkspaceLocalWorktree,
+		Attach:           true,
+		Archive:          true,
+		Recover:          true,
+		TabManagement:    true,
+		TerminalTab:      true,
+		InteractiveInput: true,
+	}
+}
+
 // WorktreeUnavailableError marks a recover/respawn failure caused by the
 // persisted worktree path being unavailable before tmux is touched. The daemon
 // uses the typed shape to add one-shot diagnostics for vanished live worktrees

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -63,6 +63,95 @@ func TestHookBackendType(t *testing.T) {
 	assert.Equal(t, "remote", b.Type())
 }
 
+// TestBackendCapabilities pins each backend's capability descriptor (#1592
+// Phase 1). This is the interface-compliance / parity contract: the daemon and
+// UI branch on these bits instead of Type()=="remote", so a regression that
+// silently flips a capability (e.g. a new backend forgetting Archive) is caught
+// here rather than in a lifecycle gate. HookBackend.TerminalTab is asserted to
+// track the terminal_cmd hook, the one config-dependent capability.
+func TestBackendCapabilities(t *testing.T) {
+	localCaps := Capabilities{
+		Workspace:        WorkspaceLocalWorktree,
+		Attach:           true,
+		Archive:          true,
+		Recover:          true,
+		TabManagement:    true,
+		TerminalTab:      true,
+		InteractiveInput: true,
+	}
+
+	tests := []struct {
+		name string
+		b    Backend
+		want Capabilities
+	}{
+		{
+			name: "local worktree runtime — full parity",
+			b:    &LocalBackend{},
+			want: localCaps,
+		},
+		{
+			name: "fake backend mirrors local parity",
+			b:    NewFakeBackend(),
+			want: localCaps,
+		},
+		{
+			name: "remote hook without terminal_cmd",
+			b:    &HookBackend{Hooks: config.RemoteHooks{}},
+			want: Capabilities{
+				Workspace:        WorkspaceRemote,
+				Attach:           true,
+				Archive:          false,
+				Recover:          false,
+				TabManagement:    false,
+				TerminalTab:      false,
+				InteractiveInput: false,
+			},
+		},
+		{
+			name: "remote hook with terminal_cmd flips TerminalTab on",
+			b:    &HookBackend{Hooks: config.RemoteHooks{TerminalCmd: "/bin/ssh host"}},
+			want: Capabilities{
+				Workspace:        WorkspaceRemote,
+				Attach:           true,
+				Archive:          false,
+				Recover:          false,
+				TabManagement:    false,
+				TerminalTab:      true,
+				InteractiveInput: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.b.Capabilities())
+		})
+	}
+}
+
+// TestSupportsRemoteTerminal_TracksCapability confirms the Instance predicate is
+// driven by the descriptor (WorkspaceRemote + TerminalTab), not a concrete-type
+// assertion — the #1592 Phase 1 delocalization of SupportsRemoteTerminal.
+func TestSupportsRemoteTerminal_TracksCapability(t *testing.T) {
+	t.Run("local backend has no remote terminal", func(t *testing.T) {
+		i := &Instance{backend: &LocalBackend{}}
+		assert.False(t, i.SupportsRemoteTerminal())
+	})
+	t.Run("remote hook without terminal_cmd", func(t *testing.T) {
+		i := &Instance{backend: &HookBackend{Hooks: config.RemoteHooks{}}}
+		assert.False(t, i.SupportsRemoteTerminal())
+	})
+	t.Run("remote hook with terminal_cmd", func(t *testing.T) {
+		i := &Instance{backend: &HookBackend{Hooks: config.RemoteHooks{TerminalCmd: "/bin/ssh host"}}}
+		assert.True(t, i.SupportsRemoteTerminal())
+	})
+	t.Run("nil backend", func(t *testing.T) {
+		i := &Instance{}
+		assert.False(t, i.SupportsRemoteTerminal())
+	})
+}
+
 // TestLocalBackendKillBestEffort_TmuxFails is a regression test for issue
 // #478. When the tmux teardown fails, Kill must still clear in-memory state
 // and return nil so the caller can finish removing the session from the

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -110,3 +110,19 @@ func (b *FakeBackend) TapEnter(*Instance)                        {}
 func (b *FakeBackend) Recover(*Instance) error                   { return nil }
 func (b *FakeBackend) Respawn(*Instance) error                   { return nil }
 func (b *FakeBackend) Type() string                              { return "local" }
+
+// Capabilities reports local full parity by default, mirroring LocalBackend so
+// the fake stands in for a local session (#1592 Phase 1). Test doubles that
+// impersonate a remote backend override this to return a WorkspaceRemote
+// descriptor.
+func (b *FakeBackend) Capabilities() Capabilities {
+	return Capabilities{
+		Workspace:        WorkspaceLocalWorktree,
+		Attach:           true,
+		Archive:          true,
+		Recover:          true,
+		TabManagement:    true,
+		TerminalTab:      true,
+		InteractiveInput: true,
+	}
+}

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -177,12 +177,23 @@ func (i *Instance) IsRemote() bool {
 	return i.backend.Type() == "remote"
 }
 
+// Capabilities returns the backing runtime's capability descriptor (#1592
+// Phase 1). A nil backend reports the zero value (local workspace, nothing
+// supported), matching the historical nil-backend defaults.
+func (i *Instance) Capabilities() Capabilities {
+	if i.backend == nil {
+		return Capabilities{}
+	}
+	return i.backend.Capabilities()
+}
+
 // SupportsRemoteTerminal reports whether this instance can open an interactive
-// terminal on its remote machine — i.e. it uses the remote hook backend and
-// the optional terminal_cmd hook is configured (#843).
+// terminal on its remote machine — a remote-workspace runtime that advertises a
+// terminal tab (the optional terminal_cmd hook, #843). Reads the capability
+// descriptor rather than type-asserting the concrete backend (#1592 Phase 1).
 func (i *Instance) SupportsRemoteTerminal() bool {
-	hb, ok := i.backend.(*HookBackend)
-	return ok && hb.HasTerminalCmd()
+	caps := i.Capabilities()
+	return caps.Workspace == WorkspaceRemote && caps.TerminalTab
 }
 
 // AttachRemoteTerminal opens an interactive terminal on the remote machine via

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -200,6 +200,17 @@ func (i *Instance) SupportsRemoteTerminal() bool {
 // the terminal_cmd hook. The returned channel is closed when the user detaches
 // or the terminal_cmd process exits. Errors when the instance is not backed by
 // remote hooks or terminal_cmd is not configured.
+//
+// RESIDUAL COUPLING (#1592 Phase 1): the gate SupportsRemoteTerminal() above now
+// reads the capability descriptor, but this attach path still type-asserts the
+// concrete *HookBackend because AttachTerminal (and its tmux-shaped chan struct{}
+// return) is not on the Backend interface. Gate and attach agree ONLY because
+// HookBackend is the sole WorkspaceRemote backend today — a future non-hook
+// remote backend would pass the capability gate and then fail this assertion.
+// This assertion is deliberately left for PR5 (attach → PTYStream, io.ReadWriteCloser
+// + Resize): when attach is unified through the interface, the terminal-tab attach
+// routes through the same stream and this *HookBackend special-case is deleted.
+// See the #1592 Phase 1 plan (5-PR sequence).
 func (i *Instance) AttachRemoteTerminal() (chan struct{}, error) {
 	hb, ok := i.backend.(*HookBackend)
 	if !ok {

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -61,6 +61,17 @@ func (b *startBackend) TapEnter(*session.Instance)      {}
 func (b *startBackend) Recover(*session.Instance) error { return nil }
 func (b *startBackend) Respawn(*session.Instance) error { return nil }
 func (b *startBackend) Type() string                    { return "local" }
+func (b *startBackend) Capabilities() session.Capabilities {
+	return session.Capabilities{
+		Workspace:        session.WorkspaceLocalWorktree,
+		Attach:           true,
+		Archive:          true,
+		Recover:          true,
+		TabManagement:    true,
+		TerminalTab:      true,
+		InteractiveInput: true,
+	}
+}
 
 func newStartTestInstance(t *testing.T, backend *startBackend) *session.Instance {
 	t.Helper()


### PR DESCRIPTION
First PR of **Phase 1** of the #1592 multi-backend refactor — the lowest-risk delocalizing slice from the [approved plan](https://github.com/sachiniyer/agent-factory/issues/1592#issuecomment-4940112492). Pure, behavior-preserving refactor: **no user-visible change**; local + remote-hook sessions work identically.

## What this does
Branches on a backend's **capability descriptor** instead of `Type()=="remote"`.

- **New `Capabilities` descriptor** (`session/backend.go`): `Workspace WorkspaceKind` + bools `Attach / Archive / Recover / TabManagement / TerminalTab / InteractiveInput`, exposed as `Backend.Capabilities()`. Computed per instance so `HookBackend.TerminalTab` tracks whether `terminal_cmd` is configured.
- **Implemented on all three backends:** `LocalBackend` (full parity), `HookBackend` (remote workspace; archive/recover/tab-mgmt/raw-input unsupported in v1; `TerminalTab = HasTerminalCmd()`), `FakeBackend` (local parity).
- **Daemon lifecycle gates delocalized** — `archive.go`, `restore.go`, `lostrestore.go`, `manager_tabs.go` (create + close) go from `IsRemote()` → the specific capability (`!Archive` / `!Recover` / `!TabManagement`). **Error strings are byte-identical** (only the `if` condition changed).
- **`SupportsRemoteTerminal()` reimplemented** via the descriptor (`WorkspaceRemote && TerminalTab`) rather than a `*HookBackend` type assertion; added `Instance.Capabilities()`.

## Scope / ordering (per the approved plan)
- `Type()` is now the **persisted serialization discriminator only** (the load-time factory in `instance_data.go`).
- `IsRemote()` still reads `Type()` **this PR only** — it's the alias the TUI/app branches use; PR2 delocalizes those, PR3 deletes `IsRemote()`/`SupportsRemoteTerminal()`. This is migration ordering, **not** a compat shim (no dual paths left behind).
- No on-disk format change; no behavior change.

## Tests
- New **table-driven capability-compliance test** in `backend_test.go` asserting each backend's descriptor, incl. `HookBackend.TerminalTab` flipping with `terminal_cmd`; plus a `SupportsRemoteTerminal` capability test.
- Daemon test doubles that impersonate a remote backend now declare a `WorkspaceRemote` descriptor.

## Regression proof / gates (all green locally)
- `go build ./...`, `gofmt -l .` (empty), `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...` (empty), `scripts/lint-file-length.sh`.
- `make test-container` — **all packages pass** (incl. `daemon`, `session`, `app`, `integration`).
- The converted daemon gates keep their existing archive/restore/tab rejection tests green with unchanged error strings.

Part of #1592 (Phase 1, PR 1 of 5). Do not squash into later slices — each PR is independently mergeable.

— Captain Claude