### PR TITLE
fix(tui-driver): restore selftest auto-update opt-out (#1498 regression) (#1596)

### DIFF
--- a/commands/autoupdate_test.go
+++ b/commands/autoupdate_test.go
@@ -172,6 +172,78 @@ func TestAutoUpdateWindowsSkipsNetworkRegardlessOfVersion(t *testing.T) {
 	}
 }
 
+// TestAutoUpdateEnvOffSwitchShortCircuits guards #1596: an explicit
+// AGENT_FACTORY_AUTO_UPDATE off-switch must short-circuit autoUpdate() before
+// any release fetch — no network, no download, no daemon restart. This is the
+// contract the selftest/playtest containers depend on (#1471/#1498): a
+// container binary built behind the latest release must NOT self-update and
+// restart the daemon mid-run, racing instance creation. The fetch seam is a
+// tripwire: if it is called, the off-switch is not being honored.
+//
+// A later refactor (the testbox containerization) dropped the propagation of
+// this env into the container, so the opt-out silently stopped taking effect;
+// this test locks the code-side contract so it can't rot again.
+func TestAutoUpdateEnvOffSwitchShortCircuits(t *testing.T) {
+	withTestHome(t) // unsets AGENT_FACTORY_AUTO_UPDATE; subtests set it explicitly
+	captureLogs(t)
+
+	prevGOOS := runtimeGOOS
+	prevFetch := fetchLatestReleaseTagFn
+	prevVersion := version
+	t.Cleanup(func() {
+		runtimeGOOS = prevGOOS
+		fetchLatestReleaseTagFn = prevFetch
+		version = prevVersion
+	})
+
+	// Non-Windows platform (Windows has its own early-return) and a version far
+	// behind any real release: without the off-switch this would fetch, see a
+	// much newer tag, download, and restart the daemon.
+	runtimeGOOS = "linux"
+	version = "0.0.1"
+	fetchCalls := 0
+	fetchLatestReleaseTagFn = func(string) (string, error) {
+		fetchCalls++
+		return "v99.0.0", nil
+	}
+
+	// Every accepted "off" spelling must short-circuit before the fetch.
+	for _, val := range []string{"false", "0", "no", "off", "n", "f"} {
+		t.Run("off_"+val, func(t *testing.T) {
+			t.Setenv(autoUpdateEnv, val)
+			fetchCalls = 0
+			if err := autoUpdate(); err != nil {
+				t.Fatalf("autoUpdate returned error with %s=%q: %v", autoUpdateEnv, val, err)
+			}
+			if fetchCalls != 0 {
+				t.Fatalf("fetchLatestReleaseTagFn called %d times with %s=%q; expected 0 — the env off-switch must short-circuit before any release fetch (#1596)", fetchCalls, autoUpdateEnv, val)
+			}
+		})
+	}
+
+	// Positive control: with the switch unset the fetch seam MUST fire, proving
+	// the tripwire above is meaningful and not passing because the code never
+	// reaches the network. A not-newer tag keeps this off the download/restart
+	// path, so the test needs no downloadBinaryFn/restart seams.
+	t.Run("unset_still_fetches", func(t *testing.T) {
+		if err := os.Unsetenv(autoUpdateEnv); err != nil {
+			t.Fatalf("unsetenv %s: %v", autoUpdateEnv, err)
+		}
+		version = "99.0.0"
+		fetchLatestReleaseTagFn = func(string) (string, error) {
+			fetchCalls++
+			return "v1.0.0", nil // not newer than 99.0.0 → records + returns, no download
+		}
+		fetchCalls = 0
+		if err := autoUpdate(); err != nil {
+			t.Fatalf("autoUpdate returned error with %s unset: %v", autoUpdateEnv, err)
+		}
+		if fetchCalls == 0 {
+			t.Fatalf("fetchLatestReleaseTagFn was not called with %s unset; the off-switch tripwire above would be vacuous", autoUpdateEnv)
+		}
+	})
+}
+
 // TestAutoUpdateDoesNotRecordCheckOnFetchFailure guards #1466: when
 // fetchLatestReleaseTag fails (blocked API, DNS, proxy, rate limit), the
 // 24-hour success throttle must not hide the failure for a full day.

--- a/scripts/container/playtest-entry.sh
+++ b/scripts/container/playtest-entry.sh
@@ -12,6 +12,14 @@ set -euo pipefail
 
 SANDBOX="$HOME/sandbox"
 export AGENT_FACTORY_HOME="${AGENT_FACTORY_HOME:-$SANDBOX/home}"
+# Disable startup auto-update inside the sandbox (#1596). A container binary is
+# built at the branch's main.go version, which is typically behind the latest
+# release, so on boot it would download a new binary and RESTART THE DAEMON —
+# racing selftest/playtest instance creation. testbox.sh already passes this at
+# the container level (reaching the tmux server + daemon via `docker run -e`);
+# this export defends the direct-`af`-child interactive flow and honors an
+# explicit override. Real users are unaffected — the switch is unset for them.
+export AGENT_FACTORY_AUTO_UPDATE="${AGENT_FACTORY_AUTO_UPDATE:-false}"
 mkdir -p "$AGENT_FACTORY_HOME" "$HOME/bin"
 
 echo ">>> building af from /src ..."

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -96,11 +96,23 @@ fix_cache_perms() {
 # start_playtest_detached — run the play-test sandbox container detached, so a
 # driver can work it over `docker exec`. Shared by `playtest -d`, `selftest`,
 # and `drive`.
+#
+# AGENT_FACTORY_AUTO_UPDATE=false is passed at the CONTAINER level (not just
+# exported in a driver shell) so it reaches EVERY process in the container —
+# the tmux server, the `af` TUI it launches, and the daemon `af` spawns —
+# exactly like AGENT_FACTORY_HOME does. `docker exec` inherits `docker run -e`
+# vars but NOT a transient exec shell's exports, so a driver-shell-only export
+# reaches `af` only when the tmux server happens to fork from that shell —
+# flaky. Without this, a container binary built behind the latest release
+# self-updates and restarts the daemon mid-selftest, racing instance creation
+# (#1596, regression of the #1498 opt-out). Override to `true` to exercise the
+# real auto-update path in the sandbox.
 start_playtest_detached() {
     "$ENGINE" run -d \
         "${RUN_FLAGS[@]}" \
         --name "$PLAYTEST_NAME" \
         -e AGENT_FACTORY_HOME=/home/dev/sandbox/home \
+        -e "AGENT_FACTORY_AUTO_UPDATE=${AGENT_FACTORY_AUTO_UPDATE:-false}" \
         "$IMAGE" bash /src/scripts/container/playtest-entry.sh hold >/dev/null
 }
 
@@ -147,6 +159,7 @@ playtest)
             "${RUN_FLAGS[@]}" \
             --name "$PLAYTEST_NAME" \
             -e AGENT_FACTORY_HOME=/home/dev/sandbox/home \
+            -e "AGENT_FACTORY_AUTO_UPDATE=${AGENT_FACTORY_AUTO_UPDATE:-false}" \
             "$IMAGE" bash /src/scripts/container/playtest-entry.sh
     fi
     ;;


### PR DESCRIPTION
Fixes #1596.

## Root cause

`make tui-driver-selftest` intermittently timed out at step "create instance alpha"
(`[tui-driver] TIMEOUT 25s waiting for: instance 'alpha' ready`). In the selftest's
throwaway `AGENT_FACTORY_HOME` there is no `last_update_check`, so `shouldCheck()` is
always true. The container binary is built at the branch's `main.go` version — typically
behind the latest release — so `autoUpdateInBackground` finds a newer release, downloads a
new binary, and **restarts the daemon** (`restartDaemonFromPath`) *mid-selftest*, racing the
"instance alpha → ready" wait. Whichever run loses the race times out.

This is a regression of the #1498 opt-out — but only the **propagation half**:

- The **code-side** off-switch is intact: #1471's `autoUpdateEnabled` already makes
  `autoUpdate()`/`autoUpdateInBackground` early-return when `AGENT_FACTORY_AUTO_UPDATE`
  is falsey, before any release fetch. (No change needed in `commands/autoupdate.go`.)
- The **container** never received the env. `tui-driver.sh` exports it, but the testbox
  containerization runs the driver via `docker exec`, and **`docker exec` inherits
  `docker run -e` vars, not a transient exec shell's exports**. So the opt-out reached the
  in-container `af`/daemon only when the tmux server happened to fork from that exact shell
  — flaky. (This is exactly why `AGENT_FACTORY_HOME`, which *is* passed via `docker run -e`,
  always reaches `af` and the daemon.)

## Fix

1. **`scripts/testbox.sh`** — pass `-e "AGENT_FACTORY_AUTO_UPDATE=${AGENT_FACTORY_AUTO_UPDATE:-false}"`
   at the **container level** for the shared detached run (selftest/drive/playtest -d) and the
   interactive playtest run, mirroring `AGENT_FACTORY_HOME`. Now it reaches every process in the
   container — tmux server, the `af` TUI, and the daemon `af` spawns — deterministically.
   Overridable to `true` to exercise the real auto-update path in the sandbox.
2. **`scripts/container/playtest-entry.sh`** — export the same default as belt-and-suspenders
   for the direct-`af`-child interactive flow.
3. **`commands/autoupdate_test.go`** — regression guard `TestAutoUpdateEnvOffSwitchShortCircuits`:
   asserts the env off-switch short-circuits `autoUpdate()` before any release fetch (using the
   `fetchLatestReleaseTagFn` seam as a tripwire — no network, no download), across every accepted
   "off" spelling, with a **positive control** (`unset_still_fetches`) proving the tripwire is
   meaningful rather than vacuous. This locks the code-side contract so it can't silently rot again.

## Real-user auto-update is untouched

The switch is unset for real users, so `autoUpdateEnabled` keeps its default-`true` behavior — the
startup self-update check/download/daemon-restart is entirely unchanged. This only gives
tests/CI/sandboxes a hard, deterministic off-switch.

## Verification

All four CI gates green:
- `gofmt -l .` — clean
- `golangci-lint run --timeout=3m --fast` — clean
- `go build ./...` — ok
- `make test-container` — all packages green

**Determinism proof.** `main.go` is currently at `1.0.172` = the latest release, so auto-update
would never trigger on this exact branch (a 24/24 would prove nothing). To make the proof
meaningful I temporarily built the container binary at a **behind-release** version (`1.0.100`,
reverted — not committed; `main.go` is unchanged in this PR) and ran `make tui-driver-selftest`
**5 consecutive times**:

```
RUN 1: === SELF-TEST PASSED — 25/25 steps green ===
RUN 2: === SELF-TEST PASSED — 25/25 steps green ===
RUN 3: === SELF-TEST PASSED — 25/25 steps green ===
RUN 4: === SELF-TEST PASSED — 25/25 steps green ===
RUN 5: === SELF-TEST PASSED — 25/25 steps green ===
```

**Negative control** — same behind-release binary, but forcing the switch back on
(`AGENT_FACTORY_AUTO_UPDATE=true make tui-driver-selftest`) reproduces the exact #1596 failure,
confirming both the mechanism and that the fix is what prevents it:

```
NEGCTL RUN 1: [tui-driver] TIMEOUT 25s waiting for: instance 'alpha' ready | === SELF-TEST FAILED at: create instance 'alpha' ===
NEGCTL RUN 2: [tui-driver] TIMEOUT 25s waiting for: instance 'alpha' ready | === SELF-TEST FAILED at: create instance 'alpha' ===
NEGCTL RUN 3: [tui-driver] TIMEOUT 25s waiting for: instance 'alpha' ready | === SELF-TEST FAILED at: create instance 'alpha' ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)