### PR TITLE
refactor(tui): gate TUI/app on backend Capabilities, delocalize IsRemote() call sites (#1592 Phase 1 PR2)

### DIFF
--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -174,10 +174,10 @@ func (m *home) handleKill() (tea.Model, tea.Cmd) {
 		return nil
 	}
 
-	// Check for uncommitted changes in the worktree (skip for remote sessions
-	// which have no local worktree).
+	// Check for uncommitted changes in the worktree (skip for backends without a
+	// local worktree, e.g. remote hook sessions).
 	warning := ""
-	if !selected.IsRemote() {
+	if selected.Capabilities().Workspace == session.WorkspaceLocalWorktree {
 		if wt := selected.GetWorktreePath(); wt != "" {
 			warning = killConfirmationWarning(wt)
 		}
@@ -327,7 +327,7 @@ func (m *home) handleArchive() (tea.Model, tea.Cmd) {
 
 	// Live row → archive. Fail fast on the unarchivable session kinds for a
 	// snappy message (the daemon rejects them too).
-	if selected.IsRemote() {
+	if !selected.Capabilities().Archive {
 		return m, m.handleError(fmt.Errorf("cannot archive remote session '%s': it has no local worktree to relocate", title))
 	}
 	if selected.IsExternalWorktree() {
@@ -709,10 +709,14 @@ func (m *home) attachSelected(selected *session.Instance) (tea.Model, tea.Cmd) {
 // remote-ness (#889). Callers pass the tab index captured at keypress time
 // (#716), before help-overlay deferral can let selection or active tab drift.
 func (m *home) attachInstanceTab(instance *session.Instance, tabIdx int, agentLabel, terminalLabel string) (tea.Model, tea.Cmd) {
+	// The post-detach terminal reset+reassert (#845/#848) keys off whether the
+	// workspace is remote: a remote instance's terminal tab is its terminal_cmd
+	// PTY, a local one's is a tmux session (#843/#889).
+	remote := instance.Capabilities().Workspace == session.WorkspaceRemote
 	if tabIdx != 0 {
 		return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
 			return m.beginAttachTransition(func() tea.Cmd {
-				return attachOverlayCallbackFn(m, instance.Title, terminalLabel, "", instance.IsRemote(), func() (chan struct{}, error) {
+				return attachOverlayCallbackFn(m, instance.Title, terminalLabel, "", remote, func() (chan struct{}, error) {
 					return ui.AttachTerminalTab(instance, tabIdx)
 				})
 			})
@@ -720,7 +724,7 @@ func (m *home) attachInstanceTab(instance *session.Instance, tabIdx int, agentLa
 	}
 	return m.showHelpScreen(helpTypeInstanceAttach{}, func() tea.Cmd {
 		return m.beginAttachTransition(func() tea.Cmd {
-			return attachOverlayCallbackFn(m, instance.Title, agentLabel, "", instance.IsRemote(), func() (chan struct{}, error) {
+			return attachOverlayCallbackFn(m, instance.Title, agentLabel, "", remote, func() (chan struct{}, error) {
 				return m.store.AttachInstance(instance)
 			})
 		})
@@ -748,7 +752,7 @@ func (m *home) handleNewTab() (tea.Model, tea.Cmd) {
 	if selected.HasInFlightOp() {
 		return m, nil
 	}
-	if selected.IsRemote() {
+	if !selected.Capabilities().TabManagement {
 		return m, m.handleError(fmt.Errorf("remote sessions don't support new process tabs; their terminal tab comes from remote_hooks.terminal_cmd and arbitrary remote processes aren't supported"))
 	}
 
@@ -796,7 +800,7 @@ func (m *home) handleCloseTab() (tea.Model, tea.Cmd) {
 	if idx <= 0 {
 		return m, m.handleError(fmt.Errorf("the agent tab can't be closed; use D to kill the session"))
 	}
-	if selected.IsRemote() {
+	if !selected.Capabilities().TabManagement {
 		return m, m.handleError(fmt.Errorf("remote session tabs can't be closed"))
 	}
 	tabs := selected.GetTabs()

--- a/app/handle_enter_remote_terminal_test.go
+++ b/app/handle_enter_remote_terminal_test.go
@@ -21,6 +21,13 @@ type remoteFakeBackend struct {
 
 func (remoteFakeBackend) Type() string { return "remote" }
 
+// Capabilities mirrors a bare remote hook backend (WorkspaceRemote, attachable,
+// no terminal_cmd) so the delocalized client gates that read Capabilities()
+// see this double as remote (#1592 Phase 1 PR2).
+func (remoteFakeBackend) Capabilities() session.Capabilities {
+	return (&session.HookBackend{}).Capabilities()
+}
+
 // swapAttachOverlayCallbackFn redirects the handleEnter -> attachOverlayCallback
 // indirection for the duration of a test. The substitute forwards the real
 // `remote` flag the call site computed but replaces the attach closure with one

--- a/app/handle_input.go
+++ b/app/handle_input.go
@@ -66,10 +66,10 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, m.handleError(fmt.Errorf("a session titled %q conflicts with existing session %q", instance.Title, other.Title))
 			}
 		}
-		if instance.IsRemote() {
+		if instance.Capabilities().Workspace == session.WorkspaceRemote {
 			existing := make([]*session.Instance, 0, m.store.NumInstances())
 			for _, other := range m.store.GetInstances() {
-				if other == instance || !other.IsRemote() {
+				if other == instance || other.Capabilities().Workspace != session.WorkspaceRemote {
 					continue
 				}
 				existing = append(existing, other)
@@ -105,7 +105,7 @@ func (m *home) handleStateNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				RepoPath:    instance.Path,
 				Program:     instance.Program,
 				AutoYes:     m.autoYes,
-				ForceRemote: instance.IsRemote(),
+				ForceRemote: instance.Capabilities().Workspace == session.WorkspaceRemote,
 			}
 			started, err := start(instance, req)
 			return instanceStartedMsg{

--- a/app/help.go
+++ b/app/help.go
@@ -165,7 +165,7 @@ func (h helpTypeInstanceStart) toContent() string {
 	// tabs also live in the left-rail tree since the layout cutover (#1024 PR 4).
 	openPane, newTab, closeTab := helpKey(keys.KeyOpenPane), helpKey(keys.KeyNewTab), helpKey(keys.KeyCloseTab)
 	tabHelp := keyStyle.Render("1-9 jump") + descStyle.Render(fmt.Sprintf(" - Select a tab (%s opens it; %s new tab, %s close; tabs live in the tree)", openPane, newTab, closeTab))
-	if h.instance.IsRemote() {
+	if !h.instance.Capabilities().TabManagement {
 		tabHelp = keyStyle.Render("1-9 jump") + descStyle.Render(fmt.Sprintf(" - Select a tab (%s opens it; tabs live in the tree)", openPane))
 	}
 	content := lipgloss.JoinVertical(lipgloss.Left,

--- a/app/home_attach.go
+++ b/app/home_attach.go
@@ -75,7 +75,8 @@ func (m *home) beginAttachTransition(run func() tea.Cmd) tea.Cmd {
 // terminal_cmd PTY) while preserving the real `remote` argument the call site
 // computed. That keeps the call-site decision exercised end to end — the #889
 // regression is that the terminal-tab site passed a hardcoded false instead of
-// selected.IsRemote(), which can only be caught by a test that drives the real
+// the instance's real remote-ness (now Capabilities().Workspace ==
+// WorkspaceRemote), which can only be caught by a test that drives the real
 // handleEnter and observes the post-detach reset keyed off that argument.
 var attachOverlayCallbackFn = (*home).attachOverlayCallback
 

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -339,7 +339,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		_ = started.Transition(session.ConfirmLive())
-		if !swapped && !started.IsRemote() {
+		if !swapped && started.Capabilities().Workspace == session.WorkspaceLocalWorktree {
 			m.store.RegisterRepoForInstance(started)
 		}
 		started.SetAutoYes(m.autoYes)

--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -349,7 +349,9 @@ func (m *home) liveBindCandidate(target *store.OpenPane) (key, sessionName strin
 // dead/lost/transitional instances are fenced off earlier by
 // interactiveGuard's explicit errors.
 func liveSessionName(inst *session.Instance, tab int) string {
-	if inst == nil || inst.IsRemote() || !inst.Started() {
+	// Only a local-worktree backend has a local tmux session to embed; other
+	// workspaces (remote hook) fall back to the full-screen attach path.
+	if inst == nil || inst.Capabilities().Workspace != session.WorkspaceLocalWorktree || !inst.Started() {
 		return ""
 	}
 	// No live session name for a row with an in-flight op (create/kill/archive)

--- a/app/preflight.go
+++ b/app/preflight.go
@@ -11,7 +11,9 @@ import (
 var localSessionPreflight = preflight.LocalSessionPrereqs
 
 func (m *home) preflightSessionCreate(instance *session.Instance) error {
-	if instance == nil || instance.IsRemote() {
+	// Local-session prerequisites (the agent binary, etc.) only apply to a
+	// backend that runs the agent on a local worktree.
+	if instance == nil || instance.Capabilities().Workspace != session.WorkspaceLocalWorktree {
 		return nil
 	}
 	cfg, err := m.preflightConfig()

--- a/app/sync.go
+++ b/app/sync.go
@@ -228,7 +228,9 @@ func SetPRInfoFetcherForTest(f func(repoPath, branch string) (*git.PRInfo, error
 // fresh / fetch already in flight). Using force=true ignores the freshness
 // check — for tick-driven refreshes of the selected instance.
 func fetchPRInfoCmd(inst *session.Instance, force bool) tea.Cmd {
-	if inst == nil || inst.IsRemote() {
+	// PR info comes from a local git branch (`gh pr view`), so it only applies to
+	// a backend with a local worktree.
+	if inst == nil || inst.Capabilities().Workspace != session.WorkspaceLocalWorktree {
 		return nil
 	}
 	if !force && inst.PRInfoAge() < prInfoStaleAfter {
@@ -611,9 +613,10 @@ func (m *home) updateInstanceFromSnapshot(inst *session.Instance, d session.Inst
 			changed = true
 		}
 	}
-	// Remote instances' tabs come from hook config (terminal_cmd), not the
-	// snapshot, so the backend owns them — skip the tab reconcile.
-	if !inst.IsRemote() {
+	// Backends without user-managed tabs (remote hook sessions) derive their tabs
+	// from config (terminal_cmd), not the snapshot, so the backend owns them —
+	// skip the tab reconcile.
+	if inst.Capabilities().TabManagement {
 		// Capture the slot→name list before the tab reconcile mutates it: an
 		// out-of-band tab removal (another client, `af sessions tab-delete`,
 		// daemon-side) must apply the SAME pane close/rebind semantics as the
@@ -773,7 +776,7 @@ func (m *home) importRemoteHookSessions() int {
 	existingTitles := m.store.GetInstanceTitles()
 	existingHookNames := make(map[string]bool)
 	for _, inst := range m.store.GetInstances() {
-		if !inst.IsRemote() {
+		if inst.Capabilities().Workspace != session.WorkspaceRemote {
 			continue
 		}
 		data := inst.ToInstanceData()

--- a/session/instance_accessors.go
+++ b/session/instance_accessors.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (i *Instance) RepoName() (string, error) {
-	if i.IsRemote() {
+	if i.Capabilities().Workspace != WorkspaceLocalWorktree {
 		return "", fmt.Errorf("remote instances do not have a local repo")
 	}
 	i.mu.RLock()

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -178,11 +178,15 @@ func (i *Instance) IsRemote() bool {
 }
 
 // Capabilities returns the backing runtime's capability descriptor (#1592
-// Phase 1). A nil backend reports the zero value (local workspace, nothing
-// supported), matching the historical nil-backend defaults.
+// Phase 1). A nil backend (a not-yet-initialised instance) reports local
+// full parity, matching the historical nil-backend contract the delocalized
+// client gates replace: IsRemote() has always nil-guarded to false (local), so
+// the UI treated a backend-less instance as a capable local session. Returning
+// the zero value instead would be an incoherent descriptor (local workspace but
+// every capability off) and would regress e.g. the tab-management footer.
 func (i *Instance) Capabilities() Capabilities {
 	if i.backend == nil {
-		return Capabilities{}
+		return (&LocalBackend{}).Capabilities()
 	}
 	return i.backend.Capabilities()
 }

--- a/task/start.go
+++ b/task/start.go
@@ -26,8 +26,10 @@ func StartAndSendPrompt(instance *session.Instance, prompt string) error {
 		return err
 	}
 
-	// Remote sessions handle readiness and prompts on the remote host.
-	if instance.IsRemote() {
+	// Readiness polling, trust-prompt dismissal and prompt delivery below all
+	// drive the agent's PTY locally; a backend without interactive input (remote
+	// hook) handles readiness and prompts on its own host, so skip them.
+	if !instance.Capabilities().InteractiveInput {
 		return nil
 	}
 

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -267,11 +267,12 @@ func (m *Menu) addInstanceOptions() {
 
 	// Tab group: create, close, and number-jump (#930 PR 4). The tab CYCLE key
 	// is gone — Tab now cycles the focus ring (#1024 PR 4); tabs are reached
-	// via the tree and the 1-9 jump keys. Remote instances block `t` (new tab)
-	// and `w` (close tab) — those handlers reject IsRemote() with an error — so
-	// only advertise the tab keys that actually work: number-jump (#988).
+	// via the tree and the 1-9 jump keys. Backends without tab management block
+	// `t` (new tab) and `w` (close tab) — those handlers reject them with an
+	// error — so only advertise the tab keys that actually work: number-jump
+	// (#988).
 	tabGroup := []keys.KeyName{keys.KeyNewTab, keys.KeyCloseTab, keys.KeyJumpTab}
-	if m.instance != nil && m.instance.IsRemote() {
+	if m.instance != nil && !m.instance.Capabilities().TabManagement {
 		tabGroup = []keys.KeyName{keys.KeyJumpTab}
 	}
 

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -317,8 +317,8 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 	// Remote instances have no local shell tab. When terminal_cmd is configured
 	// the tab is an interactive-only surface (#843): prompt the user to attach.
 	// Otherwise keep the "not available" fallback and name the config knob.
-	if instance.IsRemote() {
-		if instance.SupportsRemoteTerminal() {
+	if caps := instance.Capabilities(); caps.Workspace == session.WorkspaceRemote {
+		if caps.TerminalTab {
 			p.setFallbackState("Press Enter to open a terminal on the remote machine.")
 		} else {
 			p.setFallbackState("Terminal tab not available for remote sessions.\nConfigure remote_hooks.terminal_cmd to enable it.\nUse the Agent tab to see session output.")

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -516,8 +516,8 @@ func AttachTerminalTab(instance *session.Instance, tabIdx int) (chan struct{}, e
 	if instance == nil {
 		return nil, fmt.Errorf("no terminal session to attach to")
 	}
-	if instance.IsRemote() {
-		if !instance.SupportsRemoteTerminal() {
+	if caps := instance.Capabilities(); caps.Workspace == session.WorkspaceRemote {
+		if !caps.TerminalTab {
 			return nil, fmt.Errorf("remote terminal is not configured: add a terminal_cmd to remote_hooks to enable the Terminal tab for remote sessions")
 		}
 		return instance.AttachRemoteTerminal()

--- a/ui/tree/render.go
+++ b/ui/tree/render.go
@@ -303,7 +303,7 @@ func (r *InstanceRenderer) Render(i *session.Instance, _ int, selected bool, has
 
 	// Cut the title if it's too long
 	titleText := i.Title
-	if i.IsRemote() {
+	if i.Capabilities().Workspace == session.WorkspaceRemote {
 		titleText = "[remote] " + titleText
 	}
 	// A deleting row keeps spinning but is explicitly marked and dimmed so it

--- a/ui/tree/render_test.go
+++ b/ui/tree/render_test.go
@@ -16,6 +16,36 @@ import (
 
 var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
+// TestInstanceRendererRemoteBadge pins the sidebar "[remote]" title badge to the
+// backend's WorkspaceRemote capability rather than a Type()=="remote" check
+// (#1592 Phase 1 PR2): a hook-backed (remote-workspace) instance is prefixed,
+// a local one is not.
+func TestInstanceRendererRemoteBadge(t *testing.T) {
+	spin := spinner.New()
+	r := NewInstanceRenderer(&spin)
+	r.SetWidth(60)
+
+	render := func(t *testing.T, remote bool) string {
+		t.Helper()
+		inst, err := session.NewInstance(session.InstanceOptions{
+			Title:   "feature",
+			Path:    t.TempDir(),
+			Program: "test",
+		})
+		require.NoError(t, err)
+		if remote {
+			inst.SetBackend(&session.HookBackend{})
+			require.Equal(t, session.WorkspaceRemote, inst.Capabilities().Workspace)
+		}
+		return ansiEscape.ReplaceAllString(r.Render(inst, 1, false, false, false), "")
+	}
+
+	assert.Contains(t, render(t, true), "[remote] feature",
+		"a remote-workspace instance must carry the [remote] title badge")
+	assert.NotContains(t, render(t, false), "[remote]",
+		"a local instance must not carry the [remote] badge")
+}
+
 // effectiveWidth models a sidebar-style content buffer (narrower than the
 // allocation) so the renderer tests exercise an effective content width the
 // way the sidebar passes one to SetWidth in production. Inlined rather than


### PR DESCRIPTION
Second PR of **Phase 1** of the #1592 multi-backend refactor ([approved plan](https://github.com/sachiniyer/agent-factory/issues/1592#issuecomment-4940112492)). Builds on the merged PR1 capability descriptor. **Behavior-preserving, no user-visible change** — moves the *client-side* locality leaks off `IsRemote()` onto the specific capability each branch actually means. HookBackend is the only `WorkspaceRemote` backend today, so every converted gate is exactly equivalent to today's `IsRemote()` result.

## The rule applied
Gate on the **specific capability**, not a mechanical `IsRemote()` → `Workspace==Remote` swap. Each of the 26 call sites was mapped to what it's really asking.

## Converted call sites (capability + IsRemote()-equivalence)

| Site | Was | Now | Why equivalent today |
|---|---|---|---|
| `ui/menu.go` (tab keys) | `IsRemote()` | `!TabManagement` | hook has no tab mgmt |
| `app/help.go` (tab help) | `IsRemote()` | `!TabManagement` | " |
| `app/handle_actions.go` (new process tab) | `IsRemote()` | `!TabManagement` | " |
| `app/handle_actions.go` (close tab) | `IsRemote()` | `!TabManagement` | " |
| `app/sync.go` (tab reconcile) | `!IsRemote()` | `TabManagement` | " |
| `app/handle_actions.go` (archive action) | `IsRemote()` | `!Archive` | hook can't archive |
| `ui/tab_pane.go` (terminal-tab msg) | `IsRemote()`+`SupportsRemoteTerminal()` | `Workspace==Remote`+`TerminalTab` | msg is literally about remote |
| `ui/tabbed_window.go` (terminal attach) | `IsRemote()`+`SupportsRemoteTerminal()` | `Workspace==Remote`+`TerminalTab` | routes to remote-terminal attach |
| `app/handle_actions.go` (uncommitted warning) | `!IsRemote()` | `Workspace==LocalWorktree` | needs a local worktree |
| `app/preflight.go` (local prereqs) | `IsRemote()` | `Workspace!=LocalWorktree` | local-only prereqs |
| `app/sync.go` (PR info fetch) | `IsRemote()` | `Workspace!=LocalWorktree` | needs local git branch |
| `app/live_termpane.go` (live tmux name) | `IsRemote()` | `Workspace!=LocalWorktree` | no local tmux off-box |
| `app/home_update.go` (repo register) | `!IsRemote()` | `Workspace==LocalWorktree` | no local repo off-box |
| `session/instance_accessors.go` (`RepoName`) | `IsRemote()` | `Workspace!=LocalWorktree` | no local repo off-box |
| `ui/tree/render.go` (`[remote]` badge) | `IsRemote()` | `Workspace==Remote` | genuine remote-ness |
| `app/handle_actions.go` (attach reset flag ×2) | `IsRemote()` | `Workspace==Remote` | #845/#848 remote-detach reset keys off remote-ness |
| `app/handle_input.go` (hook-name uniqueness ×2 + `ForceRemote`) | `IsRemote()` | `Workspace==Remote` | genuine remote hook-name concern |
| `app/sync.go` (hook import) | `!IsRemote()` | `Workspace==Remote` | genuine remote |
| `task/start.go` (skip local readiness/trust/prompt) | `IsRemote()` | `!InteractiveInput` | can't drive a hook agent's PTY locally |

## One deliberate descriptor fix
`Instance.Capabilities()` on a **nil backend** now returns **local full parity** (was the incoherent zero value: `Workspace=LocalWorktree` but every bool `false`). `IsRemote()` has always nil-guarded to `false` (local), so a backend-less instance (e.g. a not-yet-started test fixture) must read as a capable local session — otherwise the tab-management footer regresses. This surfaced a real fixture: `readyUIInstance()` (`&session.Instance{}`, nil backend) → the menu footer test caught it. Fixed at the source.

## Scope / what's NOT here
- `IsRemote()` / `SupportsRemoteTerminal()` are **not deleted** — that + moving the daemon hook-name registry off the `BackendType=="remote"` string is **PR3**. PR2 only moves call sites. No compat shims.

## Tests
- Added `ui/tree` `[remote]`-badge test (the one visible surface that lacked direct coverage) and a `Capabilities()` override on the `remoteFakeBackend` app test double so client gates see it as remote.
- Remote-gated affordances are covered by existing `ui/`+`app/` tests that use the **real `HookBackend`** (correct `WorkspaceRemote` caps): menu remote-omits-tab-keys, terminal-tab (tabbed_window/preview/terminal), help, PR info, handle-enter-remote-terminal.

## Gates + play-test (all green)
- `gofmt -l .` empty · `golangci-lint --fast` · `go build ./...` · `deadcode -test ./...` empty · `scripts/lint-file-length.sh`.
- `make test-container` — **every package passes**.
- `make tui-driver-selftest` — **25/25**.
- **Exploratory play-test (real binary, playtest sandbox), LOCAL session:** create `alpha` → select → menu footer shows `t new tab • w close tab` (the exact TabManagement surface this PR touches) → new tab created → attach/detach round-trip → no orphan tmux clients → selection intact. All PASS.
- **Remote surface:** standing up a live remote machine isn't feasible in the harness; verified instead via the real-`HookBackend` unit tests above + the capability mapping (each remote branch ≡ today's `IsRemote()` because HookBackend is the sole `WorkspaceRemote` backend).

Part of #1592 (Phase 1, PR 2 of 5). Do not merge — awaiting root re-gate.

— Captain Claude