### PR TITLE
refactor(session): split backend Start into provision + launch phases (#1592 Phase 1 PR4)

### DIFF
--- a/session/backend.go
+++ b/session/backend.go
@@ -50,6 +50,14 @@ type Capabilities struct {
 type Backend interface {
 	// Start initialises the session. When firstTimeSetup is true a brand-new
 	// session is created; otherwise an existing one is restored from storage.
+	//
+	// Each backend implements Start as two internal phases (#1592 Phase 1 PR4):
+	// a PROVISION step that establishes WHERE the agent runs (the local git
+	// worktree, or the remote workspace via launch_cmd) and a LAUNCH step that
+	// starts WHAT runs in it (the tmux/PTY/agent process and its tabs). The
+	// boundary is kept internal for now — Start is still the only interface
+	// entry point — but it prepares the backend for the future agent-server
+	// "provision-and-expose" model, where the two halves are driven separately.
 	Start(instance *Instance, firstTimeSetup bool) error
 
 	// Kill terminates the session and cleans up all associated resources.

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -39,7 +39,31 @@ func (b *HookBackend) Capabilities() Capabilities {
 	}
 }
 
+// Start brings a remote hook session up in two explicit phases (#1592 Phase 1
+// PR4): provision establishes the remote WORKSPACE (a fresh create runs
+// launch_cmd to allocate the remote session and records its metadata; a restore
+// verifies via list_cmd that the previously-allocated remote session still
+// exists), then launch starts WHAT drives it locally (the attach/preview process
+// via ensurePTY, the tab model, and the started flag). The split is
+// behavior-preserving: Start = provision then launch reproduces the pre-split
+// Start exactly (same order, side effects, and errors), and it mirrors the local
+// backend's provision/launch seam so the future agent-server model can swap the
+// provision half (spin up an off-box workspace) without touching launch.
 func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
+	if err := b.provision(i, firstTimeSetup); err != nil {
+		return err
+	}
+	return b.launch(i, firstTimeSetup)
+}
+
+// provision establishes the remote workspace WITHOUT starting the local
+// preview/attach process (#1592 Phase 1 PR4). A fresh create runs launch_cmd to
+// allocate the remote session and records its metadata (remoteMeta + Branch); a
+// restore only verifies that the previously-allocated remote session is still
+// alive. It sets neither the started flag nor the tab model — those belong to
+// launch — so a provision failure returns before any of launch's work, exactly
+// as the pre-split Start's early error returns did.
+func (b *HookBackend) provision(i *Instance, firstTimeSetup bool) error {
 	if strings.TrimSpace(i.Title) == "" {
 		return fmt.Errorf("instance title cannot be empty")
 	}
@@ -72,13 +96,6 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 		if !alive {
 			return fmt.Errorf("remote session %q no longer exists in list_cmd output%s", i.Title, formatListedNames(listed))
 		}
-		if err := b.ensurePTY(i); err != nil {
-			return fmt.Errorf("failed to start preview process: %w", err)
-		}
-		i.mu.Lock()
-		i.started = true
-		i.mu.Unlock()
-		b.syncRemoteTabs(i)
 		return nil
 	}
 
@@ -120,6 +137,32 @@ func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
 	if name, ok := meta["name"].(string); ok && i.Branch == "" {
 		i.Branch = name
 	}
+	i.mu.Unlock()
+
+	return nil
+}
+
+// launch starts the local machinery that drives the remote workspace provision
+// established (#1592 Phase 1 PR4): the attach/preview process (ensurePTY), the
+// remote tab model (syncRemoteTabs), and the started flag. It preserves each
+// path's exact pre-split ordering and error handling — a restore treats a failed
+// preview process as fatal and only marks the instance started once the PTY is
+// up, while a fresh create marks it started first and logs a failed preview
+// best-effort (launch_cmd already succeeded, so the remote session is alive and
+// still attachable interactively).
+func (b *HookBackend) launch(i *Instance, firstTimeSetup bool) error {
+	if !firstTimeSetup {
+		if err := b.ensurePTY(i); err != nil {
+			return fmt.Errorf("failed to start preview process: %w", err)
+		}
+		i.mu.Lock()
+		i.started = true
+		i.mu.Unlock()
+		b.syncRemoteTabs(i)
+		return nil
+	}
+
+	i.mu.Lock()
 	i.started = true
 	i.mu.Unlock()
 

--- a/session/backend_hook_core_test.go
+++ b/session/backend_hook_core_test.go
@@ -34,6 +34,34 @@ func TestHookBackendStartFirstTime(t *testing.T) {
 	b.closePTY(i.Title)
 }
 
+// TestHookBackendProvisionLaunchSeam locks in the #1592 Phase 1 PR4 split:
+// provision establishes the remote workspace (launch_cmd → remoteMeta/Branch)
+// WITHOUT starting the local launch machinery — the instance is not yet marked
+// started and carries no tabs — and launch is what flips it live and syncs the
+// tab model. Start(true) must be exactly provision(true) then launch(true).
+func TestHookBackendProvisionLaunchSeam(t *testing.T) {
+	b := makeHooks(t)
+	i := &Instance{
+		Title:   "test-session",
+		Path:    t.TempDir(),
+		backend: b,
+	}
+
+	// PROVISION: remote workspace allocated, but nothing launched locally yet.
+	require.NoError(t, b.provision(i, true))
+	assert.NotNil(t, i.remoteMeta, "provision records the remote workspace metadata")
+	assert.Equal(t, Slugify("test-session"), i.Branch)
+	assert.False(t, i.Started(), "provision must not mark the instance started")
+	assert.Empty(t, i.Tabs, "provision must not build the tab model")
+
+	// LAUNCH: local machinery comes up and the instance goes live.
+	require.NoError(t, b.launch(i, true))
+	assert.True(t, i.Started(), "launch marks the instance started")
+	assert.NotEmpty(t, i.Tabs, "launch syncs the remote tab model")
+
+	b.closePTY(i.Title)
+}
+
 func TestHookBackendStartRestore(t *testing.T) {
 	b := makeHooks(t)
 	i := &Instance{

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -95,7 +95,33 @@ func (e *WorktreeUnavailableError) Unwrap() error {
 	return e.Err
 }
 
+// Start brings a local session up in two explicit phases (#1592 Phase 1 PR4):
+// provision establishes WHERE the agent will run (the tmux session handle bound
+// to the instance, plus — for a fresh create — the git worktree record and its
+// branch), then launch starts WHAT runs in it (materializing the worktree on
+// disk and spawning/reconnecting the agent process and its tabs). The split is
+// behavior-preserving: Start = provision then launch is exactly the monolithic
+// Start it replaced (same order, side effects, and errors), and it prepares the
+// backend for the future agent-server "provision-and-expose" model, where
+// provision spins up an off-box workspace and launch exposes the agent stream.
 func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
+	if err := b.provision(i, firstTimeSetup); err != nil {
+		return err
+	}
+	return b.launch(i, firstTimeSetup)
+}
+
+// provision establishes the local workspace a session will run in WITHOUT
+// starting any agent process (#1592 Phase 1 PR4): it binds the instance's tmux
+// session handle and, on a first-time create, computes the git worktree record +
+// branch name. Nothing here spawns a tmux server session, materializes the
+// worktree on disk, or launches the agent program — those are launch's job.
+// NewGitWorktree is purely in-memory (the disk-mutating `git worktree add` runs
+// in worktree.Setup(), which launch owns), so a provision failure leaves nothing
+// on disk to clean up and returns before launch's cleanup scope is ever entered
+// — exactly as the pre-split Start did (its NewGitWorktree failure returned
+// before the deferred cleanup handler was registered).
+func (b *LocalBackend) provision(i *Instance, firstTimeSetup bool) error {
 	if strings.TrimSpace(i.Title) == "" {
 		return fmt.Errorf("instance title cannot be empty")
 	}
@@ -142,6 +168,24 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 		i.Branch = branchName
 		i.mu.Unlock()
 	}
+
+	return nil
+}
+
+// launch starts (or restores) the agent PROCESS in the workspace provision
+// established (#1592 Phase 1 PR4): it materializes the worktree on disk
+// (worktree.Setup on a fresh create), spawns or reconnects the tmux session, and
+// brings up the non-agent tabs. It owns the failure-cleanup scope — a launch
+// failure tears down provision's worktree via i.Kill on a fresh create, or
+// releases only the attach PTY on a restore. worktree.Setup deliberately stays
+// here rather than in provision: it is the first on-disk mutation, and its
+// failure needs the same teardown as any other launch failure, so it belongs
+// inside this cleanup scope. Behavior is identical to the pre-split Start — this
+// is exactly the code that followed provision's work in the monolithic form.
+func (b *LocalBackend) launch(i *Instance, firstTimeSetup bool) error {
+	i.mu.RLock()
+	tmuxSession := i.tmuxLocked()
+	i.mu.RUnlock()
 
 	// Setup error handler to cleanup resources on any error.
 	// Kill() acquires its own lock, so we must not hold i.mu here.


### PR DESCRIPTION
## What

Splits each `Backend.Start` into two explicit internal phases — **PROVISION**
(establish WHERE the agent runs) and **LAUNCH** (start WHAT runs in it) — as
prep for the future agent-server "provision-and-expose" model (#1592 Phase 1
PR4). The seam is kept **internal**: unexported `provision`/`launch` helpers on
each concrete backend, with `Start = provision then launch`. No interface
signature change, no CLI/API surface, no version bump.

Phase 1 PR1 (capability-driven Backend) is already on master; this continues
the Phase 1 sequence and is file-disjoint from PR2 (ui/app delocalization).

## The seam, per backend

**LocalBackend** (`session/backend_local.go`)
- `provision` — binds the instance's tmux session handle and, on a first-time
  create, computes the git worktree record + branch name. `NewGitWorktree` is
  purely in-memory (the disk-mutating `git worktree add` runs in
  `worktree.Setup()`), so a provision failure leaves nothing on disk and returns
  *before* launch's cleanup scope — exactly as the pre-split Start's
  `NewGitWorktree` failure returned before the deferred cleanup handler was
  registered.
- `launch` — materializes the worktree on disk (`Setup`), spawns/reconnects the
  tmux session, and brings up the non-agent tabs. It owns the failure-cleanup
  scope (i.Kill on a fresh create, CloseAttachOnly on a restore), so
  `worktree.Setup` deliberately stays here: it's the first on-disk mutation and
  its failure needs the same teardown as any other launch failure.

**HookBackend** (`session/backend_hook_backend.go`)
- `provision` — allocates the remote workspace: a fresh create runs `launch_cmd`
  and records `remoteMeta`/`Branch`; a restore verifies via `list_cmd` that the
  previously-allocated remote session still exists. Sets neither `started` nor
  the tab model.
- `launch` — starts the local machinery that drives the remote workspace: the
  attach/preview process (`ensurePTY`), the remote tab model (`syncRemoteTabs`),
  and the `started` flag. Each path's exact pre-split ordering and error handling
  is preserved (restore treats a failed preview as fatal and marks started only
  after the PTY is up; a fresh create marks started first and logs a failed
  preview best-effort).

`session/backend.go` gains a doc note on `Start` documenting the provision/launch
decomposition convention.

## Behavior preservation

`Start = provision then launch` reproduces the pre-split monolithic `Start`
exactly — same order, same side effects, same errors. The split points were
chosen to avoid moving any code across a failure-handling boundary:
- Local: the cut is at the exact point where the deferred cleanup handler was
  registered, so cleanup-on-failure semantics are identical.
- Hook: provision's early error returns map 1:1 to the old early returns; launch
  reproduces each path's ordering verbatim. The one movement — `started=true` for
  the fresh path shifting from provision's `remoteMeta` lock into launch — is
  behavior-equivalent (the two phases run back-to-back within `Start` with no
  intervening reader; final state is identical) and makes "launch = the session
  is now started" consistent across both paths.

The launch *implementation* is unchanged — this is a seam-introduction refactor
only; it deliberately does not touch the open #1592 agent-server questions
(reuse-tmux-vs-native-PTY, backend extensibility).

## Tests

Adds `TestHookBackendProvisionLaunchSeam`, which asserts provision records the
remote workspace metadata without marking the instance started or building the
tab model, and that launch is what flips it live — locking the boundary in place.
Existing Start tests (fresh + restore, both backends) continue to exercise the
`Start = provision then launch` wrapper end-to-end.

## Gates

- `gofmt -l .` clean
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean; `scripts/lint-file-length.sh` OK
- `go build ./...` OK
- `make test-container` green (full suite)
- `make tui-driver-selftest` → 25/25 (exercises the Start path via "create instance alpha")

Refs #1592 (Phase 1 PR4).