### PR TITLE
refactor(session,daemon): delete IsRemote()/SupportsRemoteTerminal() aliases + typed remote-hook predicate (#1592 Phase 1 PR3)

### DIFF
--- a/app/attach_reentry_test.go
+++ b/app/attach_reentry_test.go
@@ -55,7 +55,7 @@ func TestHandleEnter_SecondEnterDuringAttachDoesNotScheduleSecondAttach(t *testi
 	inst := instanceWithFakeBackend(t, "inst")
 	inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
 	inst.SetStatusForTest(session.Running)
-	require.True(t, inst.IsRemote(), "precondition: instance must be remote for the full-screen attach path")
+	require.True(t, inst.Capabilities().Workspace == session.WorkspaceRemote, "precondition: instance must be remote for the full-screen attach path")
 	require.True(t, inst.TmuxAlive(), "precondition: instance must be attachable")
 
 	h.store.AddInstance(inst)
@@ -106,7 +106,7 @@ func TestHandleEnter_CanceledAttachHelpDoesNotWedgeGuard(t *testing.T) {
 	inst := instanceWithFakeBackend(t, "inst")
 	inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
 	inst.SetStatusForTest(session.Running)
-	require.True(t, inst.IsRemote(), "precondition: instance must be remote for the full-screen attach path")
+	require.True(t, inst.Capabilities().Workspace == session.WorkspaceRemote, "precondition: instance must be remote for the full-screen attach path")
 	require.True(t, inst.TmuxAlive(), "precondition: instance must be attachable")
 	h.store.AddInstance(inst)
 	h.sidebar.SetSelectedInstance(0)

--- a/app/handle_enter_remote_terminal_test.go
+++ b/app/handle_enter_remote_terminal_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 // remoteFakeBackend is a FakeBackend that reports itself as the remote hook
-// backend, so Instance.IsRemote() returns true without standing up a real
-// HookBackend (and its terminal_cmd PTY). Everything else — IsAlive() true so
-// the instance is attachable — is inherited.
+// backend, so its Capabilities().Workspace is WorkspaceRemote without standing
+// up a real HookBackend (and its terminal_cmd PTY). Everything else — IsAlive()
+// true so the instance is attachable — is inherited.
 type remoteFakeBackend struct {
 	*session.FakeBackend
 }
@@ -65,7 +65,7 @@ func driveHandleEnterAttach(t *testing.T, terminalTab, remote bool) (tea.Cmd, st
 		inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
 		inst.SetStatusForTest(session.Running)
 	}
-	require.Equal(t, remote, inst.IsRemote(),
+	require.Equal(t, remote, inst.Capabilities().Workspace == session.WorkspaceRemote,
 		"precondition: instance remote-ness must match the case under test")
 	require.True(t, inst.TmuxAlive(),
 		"precondition: instance must be attachable so handleEnter reaches the attach path")

--- a/app/help_test.go
+++ b/app/help_test.go
@@ -52,13 +52,14 @@ func TestGeneralHelpNavigationMatchesBindings(t *testing.T) {
 
 // TestInstanceStartHelpRemoteOmitsUnsupportedTabKeys guards against regressing
 // #988: remote instances block `t` (new tab) and `w` (close tab) — those
-// handlers reject IsRemote() with an error — so the instance-start help must
+// handlers reject backends without the TabManagement capability with an error —
+// so the instance-start help must
 // only advertise the tab keys that actually work (cycle / 1-9 jump). Local
 // instances keep the full hint.
 func TestInstanceStartHelpRemoteOmitsUnsupportedTabKeys(t *testing.T) {
 	remote := newStartedInstance(t, "remote")
 	remote.SetBackend(&session.HookBackend{})
-	require.True(t, remote.IsRemote(), "sanity: instance should report as remote")
+	require.True(t, remote.Capabilities().Workspace == session.WorkspaceRemote, "sanity: instance should report as remote")
 
 	remoteContent := helpStart(remote).toContent()
 	if strings.Contains(remoteContent, "t new tab") || strings.Contains(remoteContent, "w close") {
@@ -69,7 +70,7 @@ func TestInstanceStartHelpRemoteOmitsUnsupportedTabKeys(t *testing.T) {
 	}
 
 	local := newStartedInstance(t, "local")
-	require.False(t, local.IsRemote(), "sanity: instance should report as local")
+	require.False(t, local.Capabilities().Workspace == session.WorkspaceRemote, "sanity: instance should report as local")
 
 	localContent := helpStart(local).toContent()
 	if !strings.Contains(localContent, "t new tab") || !strings.Contains(localContent, "w close") {

--- a/app/interactive_test.go
+++ b/app/interactive_test.go
@@ -415,7 +415,7 @@ func TestEnterOnRemotePaneFallsBackToFullScreenAttach(t *testing.T) {
 	inst := instanceWithFakeBackend(t, "remote-inst")
 	inst.SetBackend(remoteFakeBackend{session.NewFakeBackend()})
 	inst.SetStatusForTest(session.Running)
-	require.True(t, inst.IsRemote())
+	require.True(t, inst.Capabilities().Workspace == session.WorkspaceRemote)
 	selectInstance(h, inst)
 	resizeHome(h, 120, 40)
 	openTestPane(t, h, inst, 0)

--- a/app/pr_info_test.go
+++ b/app/pr_info_test.go
@@ -72,7 +72,7 @@ func TestFetchPRInfoCmd_NilInstance_ReturnsNil(t *testing.T) {
 func TestFetchPRInfoCmd_RemoteInstance_ReturnsNil(t *testing.T) {
 	inst := newStartedInstance(t, "remote")
 	inst.SetBackend(&session.HookBackend{})
-	require.True(t, inst.IsRemote(), "sanity: instance should report as remote")
+	require.True(t, inst.Capabilities().Workspace == session.WorkspaceRemote, "sanity: instance should report as remote")
 
 	assert.Nil(t, fetchPRInfoCmd(inst, false))
 	assert.Nil(t, fetchPRInfoCmd(inst, true), "force must not override the remote guard")

--- a/app/sync_test.go
+++ b/app/sync_test.go
@@ -265,7 +265,7 @@ func TestImportRemoteHookSessionsAddsListCmdSessions(t *testing.T) {
 	require.Equal(t, 1, h.store.NumInstances())
 
 	inst := h.store.GetInstances()[0]
-	require.True(t, inst.IsRemote())
+	require.True(t, inst.Capabilities().Workspace == session.WorkspaceRemote)
 	require.Equal(t, "remote-one", inst.Title)
 
 	stored, err := config.LoadRepoInstances(repo.ID)

--- a/app/tab_hotkeys_test.go
+++ b/app/tab_hotkeys_test.go
@@ -272,7 +272,7 @@ func TestHandleNewTabRemoteShowsMessage(t *testing.T) {
 	inst, err := session.NewInstance(session.InstanceOptions{Title: "remote", Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
 	inst.SetBackend(&session.HookBackend{})
-	require.True(t, inst.IsRemote())
+	require.True(t, inst.Capabilities().Workspace == session.WorkspaceRemote)
 	selectInstance(h, inst)
 
 	_, _ = h.handleNewTab()

--- a/daemon/create_tab_test.go
+++ b/daemon/create_tab_test.go
@@ -84,9 +84,9 @@ type tabNoSessionErr struct{}
 
 func (*tabNoSessionErr) Error() string { return "session does not exist" }
 
-// remoteTypeBackend is a FakeBackend that reports the "remote" type so
-// Instance.IsRemote() returns true, letting CreateTab's remote-rejection branch
-// be exercised without a real hook backend.
+// remoteTypeBackend is a FakeBackend that reports a WorkspaceRemote capability
+// descriptor, letting CreateTab's remote-rejection branch (no TabManagement) be
+// exercised without a real hook backend.
 type remoteTypeBackend struct {
 	*session.FakeBackend
 }

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -199,7 +199,7 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 			return fmt.Errorf("remote hook name %q is already reserved", candidate)
 		}
 		for _, data := range diskData {
-			if data.BackendType != "remote" {
+			if !data.IsRemoteHook() {
 				continue
 			}
 			if session.RemoteHookName(data.Title, data.RemoteMeta) == candidate {

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -287,7 +287,7 @@ func (m *Manager) ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest) 
 		existingHookNames := make(map[string]bool)
 		for _, data := range existing {
 			existingTitles[data.Title] = true
-			if data.BackendType == "remote" {
+			if data.IsRemoteHook() {
 				existingHookNames[session.RemoteHookName(data.Title, data.RemoteMeta)] = true
 			}
 		}

--- a/session/backend.go
+++ b/session/backend.go
@@ -8,8 +8,8 @@ type WorkspaceKind int
 
 const (
 	// WorkspaceLocalWorktree: a git worktree on the daemon's own machine, driven
-	// by tmux (today's LocalBackend). Zero value — matches the historical
-	// nil-backend default of IsRemote()==false.
+	// by tmux (today's LocalBackend). Zero value — a backend-less instance reads
+	// as a local workspace.
 	WorkspaceLocalWorktree WorkspaceKind = iota
 	// WorkspaceRemote: the workspace lives off-box; there is no local worktree or
 	// tmux to drive (today's HookBackend; tomorrow's ssh/container runtimes).

--- a/session/backend_e2e_test.go
+++ b/session/backend_e2e_test.go
@@ -158,7 +158,7 @@ func TestE2ERemoteHooksFullLifecycle(t *testing.T) {
 		ForceRemote: true,
 	})
 	require.NoError(t, err)
-	assert.True(t, instance.IsRemote(), "NewInstance with ForceRemote should pick HookBackend")
+	assert.True(t, instance.Capabilities().Workspace == WorkspaceRemote, "NewInstance with ForceRemote should pick HookBackend")
 	assert.Equal(t, "remote", instance.GetBackend().Type())
 	assert.False(t, instance.Started())
 	assert.True(t, instance.AutoYes, "NewInstance should preserve AutoYes from options")
@@ -260,11 +260,11 @@ func TestE2ERemoteHooksMultipleSessions(t *testing.T) {
 	// Create and start two sessions.
 	inst1, err := NewInstance(InstanceOptions{Title: "session-alpha", Path: repoDir, Program: "claude", ForceRemote: true})
 	require.NoError(t, err)
-	require.True(t, inst1.IsRemote())
+	require.True(t, inst1.Capabilities().Workspace == WorkspaceRemote)
 
 	inst2, err := NewInstance(InstanceOptions{Title: "session-beta", Path: repoDir, Program: "claude", ForceRemote: true})
 	require.NoError(t, err)
-	require.True(t, inst2.IsRemote())
+	require.True(t, inst2.Capabilities().Workspace == WorkspaceRemote)
 
 	require.NoError(t, inst1.Start(true))
 	require.NoError(t, inst2.Start(true))
@@ -316,7 +316,7 @@ func TestE2ELocalBackendStillWorks(t *testing.T) {
 		Program: "bash",
 	})
 	require.NoError(t, err)
-	assert.False(t, instance.IsRemote(), "should default to LocalBackend")
+	assert.False(t, instance.Capabilities().Workspace == WorkspaceRemote, "should default to LocalBackend")
 	assert.Equal(t, "local", instance.GetBackend().Type())
 }
 
@@ -551,7 +551,7 @@ func TestE2ERemoteHooksRelativePaths(t *testing.T) {
 		ForceRemote: true,
 	})
 	require.NoError(t, err)
-	require.True(t, instance.IsRemote())
+	require.True(t, instance.Capabilities().Workspace == WorkspaceRemote)
 
 	require.NoError(t, instance.Start(true))
 	assert.Equal(t, []string{Slugify("rel-hooks")}, readLineStateFile(t, stateFile), "launch_cmd must have run")
@@ -598,7 +598,7 @@ func TestE2ERemoteHooksRelativePathsLinkedWorktree(t *testing.T) {
 		ForceRemote: true,
 	})
 	require.NoError(t, err)
-	require.True(t, instance.IsRemote())
+	require.True(t, instance.Capabilities().Workspace == WorkspaceRemote)
 
 	require.NoError(t, instance.Start(true))
 	assert.Equal(t, []string{Slugify("wt-session")}, readLineStateFile(t, stateFile))

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -294,8 +294,9 @@ func (b *HookBackend) PreviewFullHistory(i *Instance) (string, error) {
 }
 
 // HasTerminalCmd reports whether the optional terminal_cmd hook is configured.
-// When false, a remote instance carries only its agent tab and AttachTerminal /
-// SupportsRemoteTerminal report the "not available" guidance (#843).
+// It backs the Capabilities().TerminalTab bit — when false, a remote instance
+// carries only its agent tab and AttachTerminal reports the "not available"
+// guidance (#843).
 func (b *HookBackend) HasTerminalCmd() bool {
 	return strings.TrimSpace(b.Hooks.TerminalCmd) != ""
 }

--- a/session/backend_local_restore_test.go
+++ b/session/backend_local_restore_test.go
@@ -209,20 +209,21 @@ func TestHookBackendAttachTerminalUsesRemoteMetaName(t *testing.T) {
 	assert.Equal(t, "imported-name", strings.TrimSpace(string(raw)))
 }
 
-func TestInstanceSupportsRemoteTerminal(t *testing.T) {
-	t.Run("remote with terminal_cmd", func(t *testing.T) {
-		i := &Instance{backend: &HookBackend{Hooks: config.RemoteHooks{TerminalCmd: "/bin/true"}}}
-		assert.True(t, i.SupportsRemoteTerminal())
+func TestInstanceRemoteTerminalCapability(t *testing.T) {
+	t.Run("remote with terminal_cmd advertises the terminal tab", func(t *testing.T) {
+		caps := (&Instance{backend: &HookBackend{Hooks: config.RemoteHooks{TerminalCmd: "/bin/true"}}}).Capabilities()
+		assert.True(t, caps.Workspace == WorkspaceRemote && caps.TerminalTab)
 	})
 
-	t.Run("remote without terminal_cmd", func(t *testing.T) {
-		i := &Instance{backend: &HookBackend{}}
-		assert.False(t, i.SupportsRemoteTerminal())
+	t.Run("remote without terminal_cmd does not", func(t *testing.T) {
+		caps := (&Instance{backend: &HookBackend{}}).Capabilities()
+		assert.False(t, caps.Workspace == WorkspaceRemote && caps.TerminalTab)
 	})
 
-	t.Run("non-hook backend", func(t *testing.T) {
+	t.Run("non-hook backend rejects AttachRemoteTerminal", func(t *testing.T) {
 		i := &Instance{backend: &LocalBackend{}}
-		assert.False(t, i.SupportsRemoteTerminal())
+		caps := i.Capabilities()
+		assert.False(t, caps.Workspace == WorkspaceRemote && caps.TerminalTab)
 		_, err := i.AttachRemoteTerminal()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "remote sessions")

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -130,28 +130,6 @@ func TestBackendCapabilities(t *testing.T) {
 	}
 }
 
-// TestSupportsRemoteTerminal_TracksCapability confirms the Instance predicate is
-// driven by the descriptor (WorkspaceRemote + TerminalTab), not a concrete-type
-// assertion — the #1592 Phase 1 delocalization of SupportsRemoteTerminal.
-func TestSupportsRemoteTerminal_TracksCapability(t *testing.T) {
-	t.Run("local backend has no remote terminal", func(t *testing.T) {
-		i := &Instance{backend: &LocalBackend{}}
-		assert.False(t, i.SupportsRemoteTerminal())
-	})
-	t.Run("remote hook without terminal_cmd", func(t *testing.T) {
-		i := &Instance{backend: &HookBackend{Hooks: config.RemoteHooks{}}}
-		assert.False(t, i.SupportsRemoteTerminal())
-	})
-	t.Run("remote hook with terminal_cmd", func(t *testing.T) {
-		i := &Instance{backend: &HookBackend{Hooks: config.RemoteHooks{TerminalCmd: "/bin/ssh host"}}}
-		assert.True(t, i.SupportsRemoteTerminal())
-	})
-	t.Run("nil backend", func(t *testing.T) {
-		i := &Instance{}
-		assert.False(t, i.SupportsRemoteTerminal())
-	})
-}
-
 // TestLocalBackendKillBestEffort_TmuxFails is a regression test for issue
 // #478. When the tmux teardown fails, Kill must still clear in-memory state
 // and return nil so the caller can finish removing the session from the
@@ -342,20 +320,24 @@ func initTempGitRepo(t *testing.T) string {
 	return repoRoot
 }
 
-// --- IsRemote helper ---
+// --- Instance workspace capability ---
 
-func TestIsRemote(t *testing.T) {
+// TestInstanceCapabilitiesWorkspace pins Instance.Capabilities().Workspace,
+// including the nil-backend contract (a backend-less instance reads as local
+// full parity, not the zero value) that the deleted IsRemote() helper used to
+// nil-guard (#1592 Phase 1 PR3).
+func TestInstanceCapabilitiesWorkspace(t *testing.T) {
 	t.Run("local backend", func(t *testing.T) {
 		i := &Instance{backend: &LocalBackend{}}
-		assert.False(t, i.IsRemote())
+		assert.Equal(t, WorkspaceLocalWorktree, i.Capabilities().Workspace)
 	})
 	t.Run("hook backend", func(t *testing.T) {
 		i := &Instance{backend: &HookBackend{Hooks: config.RemoteHooks{}}}
-		assert.True(t, i.IsRemote())
+		assert.Equal(t, WorkspaceRemote, i.Capabilities().Workspace)
 	})
-	t.Run("nil backend", func(t *testing.T) {
+	t.Run("nil backend reports local parity", func(t *testing.T) {
 		i := &Instance{}
-		assert.False(t, i.IsRemote())
+		assert.Equal(t, (&LocalBackend{}).Capabilities(), i.Capabilities())
 	})
 }
 

--- a/session/instance.go
+++ b/session/instance.go
@@ -337,7 +337,8 @@ func (i *Instance) CloseTab(idx int) error {
 // previewable/attachable without a second spawn that would collide on the name.
 //
 // name is the resolved tab name returned by the daemon. Local instances only —
-// callers reject IsRemote() first. If a tab with that name is already present
+// callers reject backends without TabManagement first. If a tab with that name
+// is already present
 // (e.g. a refresh raced ahead) this is a no-op returning the existing tab.
 // Errors when the instance is not started or has no agent session/worktree.
 func (i *Instance) AttachShellTab(name string) (*Tab, error) {
@@ -447,8 +448,8 @@ func (i *Instance) DropClosedTab(idx int) error {
 // session). The agent tab (index 0) is never added or dropped: it is the
 // instance's own session and is always present. Returns whether the local list
 // changed. A no-op for a not-started instance, one without an agent session, or
-// a remote instance (callers skip IsRemote() — remote tabs come from hook
-// config, not the snapshot). Per-tab reconnect failures are collected into the
+// a remote instance (callers skip backends without TabManagement — remote tabs
+// come from hook config, not the snapshot). Per-tab reconnect failures are collected into the
 // returned error after every other change is applied, so one bad tab can't wedge
 // the reconcile.
 func (i *Instance) ReconcileTabsFromData(target []TabData) (bool, error) {

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -169,21 +169,12 @@ func (i *Instance) SendKeys(keys string) error {
 	return i.backend.SendKeys(i, keys)
 }
 
-// IsRemote returns true if this instance uses the remote hook backend.
-func (i *Instance) IsRemote() bool {
-	if i.backend == nil {
-		return false
-	}
-	return i.backend.Type() == "remote"
-}
-
 // Capabilities returns the backing runtime's capability descriptor (#1592
 // Phase 1). A nil backend (a not-yet-initialised instance) reports local
-// full parity, matching the historical nil-backend contract the delocalized
-// client gates replace: IsRemote() has always nil-guarded to false (local), so
-// the UI treated a backend-less instance as a capable local session. Returning
-// the zero value instead would be an incoherent descriptor (local workspace but
-// every capability off) and would regress e.g. the tab-management footer.
+// full parity: the UI treats a backend-less instance as a capable local
+// session, so returning the zero value instead would be an incoherent
+// descriptor (local workspace but every capability off) and would regress
+// e.g. the tab-management footer.
 func (i *Instance) Capabilities() Capabilities {
 	if i.backend == nil {
 		return (&LocalBackend{}).Capabilities()
@@ -191,30 +182,21 @@ func (i *Instance) Capabilities() Capabilities {
 	return i.backend.Capabilities()
 }
 
-// SupportsRemoteTerminal reports whether this instance can open an interactive
-// terminal on its remote machine — a remote-workspace runtime that advertises a
-// terminal tab (the optional terminal_cmd hook, #843). Reads the capability
-// descriptor rather than type-asserting the concrete backend (#1592 Phase 1).
-func (i *Instance) SupportsRemoteTerminal() bool {
-	caps := i.Capabilities()
-	return caps.Workspace == WorkspaceRemote && caps.TerminalTab
-}
-
 // AttachRemoteTerminal opens an interactive terminal on the remote machine via
 // the terminal_cmd hook. The returned channel is closed when the user detaches
 // or the terminal_cmd process exits. Errors when the instance is not backed by
 // remote hooks or terminal_cmd is not configured.
 //
-// RESIDUAL COUPLING (#1592 Phase 1): the gate SupportsRemoteTerminal() above now
-// reads the capability descriptor, but this attach path still type-asserts the
-// concrete *HookBackend because AttachTerminal (and its tmux-shaped chan struct{}
-// return) is not on the Backend interface. Gate and attach agree ONLY because
-// HookBackend is the sole WorkspaceRemote backend today — a future non-hook
-// remote backend would pass the capability gate and then fail this assertion.
-// This assertion is deliberately left for PR5 (attach → PTYStream, io.ReadWriteCloser
-// + Resize): when attach is unified through the interface, the terminal-tab attach
-// routes through the same stream and this *HookBackend special-case is deleted.
-// See the #1592 Phase 1 plan (5-PR sequence).
+// RESIDUAL COUPLING (#1592 Phase 1): callers gate on the capability descriptor
+// (Workspace==WorkspaceRemote && TerminalTab), but this attach path still
+// type-asserts the concrete *HookBackend because AttachTerminal (and its
+// tmux-shaped chan struct{} return) is not on the Backend interface. Gate and
+// attach agree ONLY because HookBackend is the sole WorkspaceRemote backend
+// today — a future non-hook remote backend would pass the capability gate and
+// then fail this assertion. This assertion is deliberately left for PR5 (attach
+// → PTYStream, io.ReadWriteCloser + Resize): when attach is unified through the
+// interface, the terminal-tab attach routes through the same stream and this
+// *HookBackend special-case is deleted. See the #1592 Phase 1 plan.
 func (i *Instance) AttachRemoteTerminal() (chan struct{}, error) {
 	hb, ok := i.backend.(*HookBackend)
 	if !ok {

--- a/session/storage.go
+++ b/session/storage.go
@@ -65,6 +65,17 @@ type InstanceData struct {
 	RemoteMeta        map[string]interface{} `json:"remote_meta,omitempty"`
 }
 
+// IsRemoteHook reports whether this serialized record is a remote hook session,
+// reading the persisted BackendType discriminator. It centralizes the raw-data
+// remote check (#1592 Phase 1 PR3) so daemon logic that iterates []InstanceData
+// — where no backend is reconstructed and Capabilities() is unavailable — never
+// hard-codes the "remote" magic string. The load-time factory
+// (NewInstanceFromData) remains the one place that maps the discriminator to a
+// concrete backend.
+func (d InstanceData) IsRemoteHook() bool {
+	return d.BackendType == "remote"
+}
+
 // ForStorage returns data suitable for instances.json. InstanceData is also the
 // daemon Snapshot payload, so it can carry transient in-flight operation state;
 // disk persistence must not.

--- a/session/tab_remote_test.go
+++ b/session/tab_remote_test.go
@@ -145,7 +145,7 @@ func TestRemoteTabsPersistRoundTrip(t *testing.T) {
 
 	inst, err := NewInstance(InstanceOptions{Title: "remote-persist", Path: repoDir, Program: "claude", ForceRemote: true})
 	require.NoError(t, err)
-	require.True(t, inst.IsRemote())
+	require.True(t, inst.Capabilities().Workspace == WorkspaceRemote)
 	require.NoError(t, inst.Start(true))
 	if hb, ok := inst.GetBackend().(*HookBackend); ok {
 		defer hb.closePTY(inst.Title)
@@ -161,7 +161,7 @@ func TestRemoteTabsPersistRoundTrip(t *testing.T) {
 	if hb, ok := rebuilt.GetBackend().(*HookBackend); ok {
 		defer hb.closePTY(rebuilt.Title)
 	}
-	require.True(t, rebuilt.IsRemote())
+	require.True(t, rebuilt.Capabilities().Workspace == WorkspaceRemote)
 	assertRemoteTabs(t, rebuilt, true)
 }
 

--- a/session/tab_spawn.go
+++ b/session/tab_spawn.go
@@ -9,8 +9,9 @@ import (
 
 // AddShellTab spawns a new Shell-kind tab running $SHELL in the instance's
 // worktree, appends it to Tabs, and returns it. Local instances only — remote
-// instances have no local worktree, so callers must reject IsRemote() before
-// calling. The new tab's display name is unique within the instance ("shell",
+// instances have no local worktree, so callers must reject backends without the
+// TabManagement capability before calling. The new tab's display name is unique
+// within the instance ("shell",
 // then "shell-2", "shell-3", …) and its tmux session name is derived from it so
 // it is collision-free and restorable by exact name across a restart (#930 PR
 // 4). Errors when the instance is not started, has no agent session/worktree, or
@@ -83,7 +84,8 @@ func (i *Instance) AddShellTab() (*Tab, error) {
 // CLI/agent-driven counterpart of AddShellTab: instead of $SHELL it runs an
 // arbitrary command, so an agent can prompt-spawn a tab hosting a data explorer,
 // test watcher, etc. Local instances only — remote instances have no local
-// worktree, so callers must reject IsRemote() before calling. The display name is
+// worktree, so callers must reject backends without the TabManagement capability
+// before calling. The display name is
 // requestedName when non-empty, otherwise derived from the command's basename;
 // it is sanitized and made unique within the instance ("btop", "btop-2", …) so
 // its derived tmux session name is collision-free and restorable by exact name

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -122,13 +122,14 @@ func TestMenuNewInstanceShowsSubmitProgramAndCancel(t *testing.T) {
 
 // TestMenuRemoteInstanceOmitsUnsupportedTabKeys guards against regressing #988:
 // remote instances block `t` (new tab) and `w` (close tab) — those handlers
-// reject IsRemote() with an error — so the footer menu must only surface the
-// tab keys that actually work (cycle / 1-9 jump), while local instances keep
+// reject backends without the TabManagement capability with an error — so the
+// footer menu must only surface the tab keys that actually work (cycle / 1-9
+// jump), while local instances keep
 // the full set.
 func TestMenuRemoteInstanceOmitsUnsupportedTabKeys(t *testing.T) {
 	remote := readyUIInstance()
 	remote.SetBackend(&session.HookBackend{})
-	if !remote.IsRemote() {
+	if remote.Capabilities().Workspace != session.WorkspaceRemote {
 		t.Fatal("sanity: instance should report as remote")
 	}
 
@@ -156,7 +157,7 @@ func TestMenuRemoteInstanceOmitsUnsupportedTabKeys(t *testing.T) {
 	}
 
 	local := readyUIInstance()
-	if local.IsRemote() {
+	if local.Capabilities().Workspace == session.WorkspaceRemote {
 		t.Fatal("sanity: instance should report as local")
 	}
 	m.SetInstance(local)

--- a/ui/tabbed_window_remote_test.go
+++ b/ui/tabbed_window_remote_test.go
@@ -40,7 +40,7 @@ func startedRemoteInstance(t *testing.T, withTerminal bool) *session.Instance {
 	inst, err := session.NewInstance(session.InstanceOptions{Title: "remote-tabbar", Path: t.TempDir(), Program: "claude"})
 	require.NoError(t, err)
 	inst.SetBackend(&session.HookBackend{Hooks: hooks})
-	require.True(t, inst.IsRemote())
+	require.True(t, inst.Capabilities().Workspace == session.WorkspaceRemote)
 	require.NoError(t, inst.Start(true))
 	t.Cleanup(func() { _ = inst.CloseAttachOnly() })
 	return inst

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -120,7 +120,7 @@ func makeRemoteInstance(t *testing.T, title string, hooks config.RemoteHooks) *s
 	require.NoError(t, err)
 	instance.SetBackend(&session.HookBackend{Hooks: hooks})
 	instance.SetStartedForTest(true)
-	require.True(t, instance.IsRemote(), "precondition: instance must report as remote")
+	require.True(t, instance.Capabilities().Workspace == session.WorkspaceRemote, "precondition: instance must report as remote")
 	return instance
 }
 


### PR DESCRIPTION
Third PR of **Phase 1** of the #1592 multi-backend refactor ([approved plan](https://github.com/sachiniyer/agent-factory/issues/1592#issuecomment-4940112492)) — the last delocalization before attach→PTYStream (PR5). Kills the final runtime remote-type special-casing. **Behavior-preserving, no user-visible change, zero state migration.**

## Part A — delete the dead alias methods
PR1 + PR2 converted every caller to the capability descriptor, leaving `Instance.IsRemote()` and `Instance.SupportsRemoteTerminal()` dead.

**Zero-call-site proof** (before deleting):
```
$ grep -rn 'IsRemote()\|SupportsRemoteTerminal()' --include='*.go' . | grep -v _test.go | grep -vE 'func '
# → only comments, no call sites
```
- Deleted `Instance.IsRemote()` — its body was `i.backend.Type() == "remote"`, the **last runtime `Type()=="remote"` branch** the plan calls out; it dies with the method.
- Deleted `Instance.SupportsRemoteTerminal()`.
- `Instance.Capabilities()` and `AttachRemoteTerminal()` **stay** (the latter's `*HookBackend` type-assertion is the documented RESIDUAL COUPLING owned by PR5).
- **Tests:** converted every test-only caller to `Capabilities().Workspace == WorkspaceRemote` (terminal availability → `Workspace==Remote && TerminalTab`). Deleted the two alias-only tests (`TestSupportsRemoteTerminal_TracksCapability`, `TestIsRemote`) whose descriptor coverage is already in `TestBackendCapabilities`; folded `IsRemote()`'s important nil-backend case into a new `TestInstanceCapabilitiesWorkspace` so the **nil→local-parity** contract stays pinned. Refreshed every stale comment that named the deleted methods.

## Part B — centralize the serialized-data remote check
Two daemon sites iterate **raw `[]session.InstanceData`** (no reconstructed backend → `Capabilities()` unavailable) and hard-coded the magic string.
- Added `func (d InstanceData) IsRemoteHook() bool` (`session/storage.go`) — the single typed predicate over the persisted `BackendType` discriminator.
- Replaced both checks:
  - `daemon/manager_create.go`: `data.BackendType != "remote"` → `!data.IsRemoteHook()`
  - `daemon/manager_sessions.go`: `data.BackendType == "remote"` → `data.IsRemoteHook()`
- No `== "remote"` string literals remain in daemon logic.

## KEPT (legitimate serialization discriminator — the plan retains these)
- `session/instance_data.go` `NewInstanceFromData` — the **one** load-time factory mapping the stored type → concrete backend.
- `session/backend_hook_remote.go` — the serializer that writes `BackendType: "remote"`.
- `session/backend_hook_backend.go` — `HookBackend.Type() { return "remote" }`.

The on-disk `"remote"` string is **unchanged → zero state migration**, no dual-read, no shims. Verified untouched in the diff.

## Gates (all green)
- `gofmt -l .` empty · `golangci-lint --fast` · `go build ./...` · **`deadcode -test ./...` empty** (this PR *removes* dead code — net −18 production lines) · `scripts/lint-file-length.sh`.
- `make test-container` — **every package passes**.
- `make tui-driver-selftest` — **25/25** (exercises the daemon create/list path Part B touches).

Part of #1592 (Phase 1, PR 3 of 5). Do not merge — awaiting root re-gate.

— Captain Claude