### PR TITLE
test(app): harden TestE2E_PaneFlow against darwin CI timing flake (#1610)

### DIFF
--- a/app/e2e_test.go
+++ b/app/e2e_test.go
@@ -41,7 +41,20 @@ type e2eHarness struct {
 	prFetchResp *git.PRInfo
 }
 
-const e2eAsyncTimeout = 5 * time.Second
+// e2eAsyncTimeout is the ceiling every E2E poll-until-condition waits before
+// failing. It is deliberately generous: these waits round-trip through the real
+// tea.Program goroutine, and on a slow/contended CI runner (the darwin matrix in
+// particular, see #1610) a single step transition can take several seconds of
+// wall time under load. The happy path returns the instant the condition holds
+// — the poll fires every 10ms — so a large ceiling costs nothing when the test
+// passes and only widens the margin against false-failing on a slow runner.
+const e2eAsyncTimeout = 30 * time.Second
+
+// e2eQueryTimeout bounds a single query() round-trip onto the tea goroutine. It
+// is the same generous budget as e2eAsyncTimeout — query() is called from inside
+// the waitUntil poll loops, so it must not false-fail before the outer wait does
+// when the event loop is merely slow rather than wedged.
+const e2eQueryTimeout = e2eAsyncTimeout
 
 type prFetchCall struct {
 	repoPath string
@@ -257,7 +270,7 @@ func (eh *e2eHarness) query(f func(h *home)) {
 	eh.tm.Send(runOnEventLoopMsg{fn: f, done: done})
 	select {
 	case <-done:
-	case <-time.After(2 * time.Second):
+	case <-time.After(e2eQueryTimeout):
 		eh.t.Fatal("timed out waiting for e2e query to run on tea goroutine")
 	}
 }


### PR DESCRIPTION
Fixes #1610.

## Root cause

`TestE2E_PaneFlow` (and the other `app/` E2E tests) share a single wait
ceiling, `e2eAsyncTimeout = 5 * time.Second`. Every wait in these tests is a
poll-until-condition that round-trips through the **real `tea.Program`
goroutine** via `query()`. On a slow/contended CI runner — specifically the
darwin auto-preview "Build Binary and Test" matrix — a single step transition
can take several seconds of wall time under load, blowing past the tight 5s
budget.

That false-failed at `pane_model_test.go:1431: timeout after 5s waiting for: x
hides the focused pane` on **two consecutive, unrelated master merges** (#1608
archive-UX, #1609 skill-injection), while the required linux `Test` check passed
both times and the darwin job passed on rerun. Classic slow-runner flake.

## Not a race — verified

The `x`-hide path is fully synchronous inside the Update handler:
`handleHidePane` → `focusedOpenPane()` → `hidePane()` closes the focused pane
(count 2→1) and lands focus on the survivor, all within one `Update`. The step
immediately before pressing `x` already asserts (`waitUntil`) that focus is on a
pane region, so the transition is deterministic once the key is processed.
There is no ordering/race dependency that could also bite users — **no
production pane logic was touched.**

## The change (test-only)

- Bump the shared `e2eAsyncTimeout` ceiling **5s → 30s**.
- Route the `query()` round-trip deadline (also exercised inside these poll
  loops, previously a hardcoded 2s) through the same generous budget
  (`e2eQueryTimeout`).

The poll still fires every **10ms**, so the happy path returns the instant the
condition holds — the larger ceiling costs nothing on success and only widens
the margin against a slow runner. Assertions are unchanged; the test stays a
real end-to-end drive of `tea.Program`.

## Stability proof

- `go test ./app/ -run TestE2E_PaneFlow -count=20` → **20/20 green**
- `go test ./app/ -run 'TestE2E|TestPane|TestLayoutCutover' -count=3` → green
  (other tests sharing the constant unaffected)
- `make test-container` (full suite) → all packages green
- `make tui-driver-selftest` → **25/25**
- `gofmt -l .`, `golangci-lint run --fast`, `deadcode -test ./...`, `go build
  ./...` → all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)