### PR TITLE
fix(task): use last usage-limit banner for reset time (#1602)

### DIFF
--- a/task/limit.go
+++ b/task/limit.go
@@ -163,14 +163,19 @@ func isLimitContent(content, agent string, matchers map[string]agentLimitMatcher
 	if !ok || matcher.detect == nil {
 		return false, time.Time{}, false
 	}
-	match := matcher.detect.FindStringIndex(content)
-	if match == nil {
+	// The captured pane can legitimately contain multiple genuine usage-limit
+	// banners (e.g. the user hits the retry key and trips the limit again before
+	// the first banner scrolls off). Anchor reset parsing to the LAST match so
+	// resetAt reflects the most recent banner, not a stale earlier one (#1602).
+	matches := matcher.detect.FindAllStringIndex(content, -1)
+	if len(matches) == 0 {
 		return false, time.Time{}, false
 	}
+	last := matches[len(matches)-1]
 	if matcher.parseReset == nil {
 		return true, time.Time{}, false
 	}
-	if reset, parsed := matcher.parseReset(content[match[0]:], now); parsed {
+	if reset, parsed := matcher.parseReset(content[last[0]:], now); parsed {
 		return true, reset.UTC(), true
 	}
 	return true, time.Time{}, false

--- a/task/limit_test.go
+++ b/task/limit_test.go
@@ -54,6 +54,21 @@ func TestIsLimitContent(t *testing.T) {
 			wantResetUTC: time.Date(2026, 7, 4, 19, 0, 0, 0, loc).UTC(), // 23:00 UTC
 		},
 		{
+			// Two GENUINE banners in the pane (user tripped the limit, hit the
+			// retry key, tripped it again). Reset must come from the LAST/most
+			// recent banner (7pm), not the stale first one (2pm) — see #1602.
+			name:  "claude two real banners: uses last banner's later reset time",
+			agent: tmux.ProgramClaude,
+			content: strings.Join([]string{
+				"Claude usage limit reached. Your limit will reset at 2pm (America/New_York)",
+				"c",
+				"Claude usage limit reached. Your limit will reset at 7pm (America/New_York)",
+			}, "\n"),
+			wantHit:      true,
+			wantReset:    true,
+			wantResetUTC: time.Date(2026, 7, 4, 19, 0, 0, 0, loc).UTC(), // 23:00 UTC, not 18:00
+		},
+		{
 			name:         "claude weekly: explicit date + year + tz",
 			agent:        tmux.ProgramClaude,
 			content:      "Claude usage limit reached. Your limit will reset at Nov 6, 2026 9am (America/New_York)",


### PR DESCRIPTION
Fixes #1602.

## Problem
`isLimitContent` (task/limit.go) anchored reset-time parsing to `matcher.detect.FindStringIndex(content)`, which returns the **first** regex match. The captured pane can legitimately contain multiple **genuine** usage-limit banners — e.g. the user presses the documented retry key `c` and trips the limit again before the first banner scrolls off. Anchoring to the first match parses the reset time from the *oldest* banner, so `resetAt` is stale (earlier than reality). Backoff/resume scheduling then computes a too-early reset, causing premature auto-resume attempts and repeated limit hits until the real (later) reset.

Regression from #1367 (commit 7cd8c69), which switched to `FindStringIndex` to anchor parsing to the banner position.

## Fix
Use `FindAllStringIndex(content, -1)` and anchor parsing to the **last** match, so `resetAt` reflects the most recent banner.

## Test
Added a two-genuine-banner case to `TestIsLimitContent` (2pm then 7pm, per the report's repro) asserting the later reset time (23:00 UTC) is returned. Verified it fails against the unfixed code (returns stale 18:00 UTC) and passes with the fix.

## Gates
- `gofmt -l` clean
- `golangci-lint run --fast` clean
- `deadcode -test ./...` clean
- `go build ./...` ok
- `make test-container` — full suite green

Change confined to `task/limit.go` + `task/limit_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)