### PR TITLE
fix(log): LogFilePath returns the resolved fallback path (#1604)

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -116,16 +116,32 @@ func resolveLogPath() string {
 	return filepath.Join(dir, "agent-factory.log")
 }
 
-// LogFilePath returns the production agent-factory.log path — the file the
-// daemon and TUI write to — resolved from $AGENT_FACTORY_HOME then the
-// os.UserConfigDir default, exactly like resolveLogPath's env/default branches
-// but WITHOUT the test-scratch branch, the test-only override, and any
-// directory-creating side effect. It is read-only tooling support (e.g. `af
-// bug-report` locating the log to tail); it deliberately never returns the
-// temp test log so a bug report always names the real log even when built by a
-// test binary. Returns "" only when neither a home override nor UserConfigDir
-// can be resolved.
+// LogFilePath returns the agent-factory.log path for read-only tooling (e.g.
+// `af bug-report` locating the log to tail, `af doctor` checking the log
+// directory).
+//
+// Once Initialize has run, it returns the exact path logging resolved and is
+// writing to — resolveLogPath's cached result in logFileName. This is the
+// single source of truth: LogFilePath cannot diverge from where logs actually
+// land, no matter which resolveLogPath branch won (#1604). Before #1604 this
+// function re-derived the path from $AGENT_FACTORY_HOME without repeating
+// resolveLogPath's MkdirAll success check, so when the home override resolved
+// but could not be created — resolveLogPath falling back to the UserConfigDir
+// default — a bug report tailed the dead override path and collected no logs.
+//
+// Before Initialize (logFileName still ""), it resolves statically from
+// $AGENT_FACTORY_HOME then the os.UserConfigDir default, with no test-scratch
+// branch, no test-only override, and no directory-creating side effect — so a
+// pre-init bug report still names the real log even when built by a test
+// binary. Returns "" only when neither a home override nor UserConfigDir can be
+// resolved.
 func LogFilePath() string {
+	mu.Lock()
+	actual := logFileName
+	mu.Unlock()
+	if actual != "" {
+		return actual
+	}
 	if home := os.Getenv("AGENT_FACTORY_HOME"); home != "" {
 		if dir, ok := expandTilde(home); ok {
 			return filepath.Join(dir, "agent-factory.log")

--- a/log/log.go
+++ b/log/log.go
@@ -95,25 +95,69 @@ func resolveLogPath() string {
 	if logPathOverride != "" {
 		return logPathOverride
 	}
-	if home := os.Getenv("AGENT_FACTORY_HOME"); home != "" {
-		if dir, ok := expandTilde(home); ok {
-			if err := os.MkdirAll(dir, 0700); err == nil {
-				return filepath.Join(dir, "agent-factory.log")
-			}
-		}
-		// Unresolvable or uncreatable override: fall through to the defaults
-		// below rather than not logging at all.
+	// A set-and-creatable AGENT_FACTORY_HOME wins; an unresolvable or
+	// uncreatable override yields "" and falls through to the defaults below
+	// rather than not logging at all.
+	if p := homeLogPath(true); p != "" {
+		return p
 	}
 	if testing.Testing() {
 		return filepath.Join(os.TempDir(), "agent-factory-test.log")
 	}
-	configDir, err := os.UserConfigDir()
-	if err != nil {
+	p := defaultLogPath()
+	if p == "" {
 		return filepath.Join(os.TempDir(), "agent-factory.log")
 	}
-	dir := filepath.Join(configDir, "agent-factory")
-	os.MkdirAll(dir, 0700)
+	os.MkdirAll(filepath.Dir(p), 0700)
+	return p
+}
+
+// homeLogPath returns "$AGENT_FACTORY_HOME/agent-factory.log" when the home
+// override is set, expands, and its directory is usable, else "". It is the
+// single home-override gate shared by resolveLogPath and LogFilePath so the two
+// can never disagree on whether the override wins (#1604): before this, the
+// resolver validated the directory with MkdirAll and fell through when that
+// failed, while LogFilePath returned the override path unconditionally — so a
+// set-but-uncreatable AGENT_FACTORY_HOME made `af bug-report` tail a dead path
+// that was never written to.
+//
+// create selects how "usable" is checked and is the ONLY behavioral difference
+// between the two callers: resolveLogPath passes true to create the directory
+// (and thereby validate it); LogFilePath passes false to probe it read-only, so
+// the diagnostics query keeps no filesystem side effect. The read-only probe is
+// conservative — a not-yet-created but creatable home reads as unusable before
+// Initialize — but it never yields a path the app cannot write to, which is the
+// property #1604 needs. Post-Initialize LogFilePath does not reach here at all;
+// it returns the cached, exact logFileName.
+func homeLogPath(create bool) string {
+	home := os.Getenv("AGENT_FACTORY_HOME")
+	if home == "" {
+		return ""
+	}
+	dir, ok := expandTilde(home)
+	if !ok {
+		return ""
+	}
+	if create {
+		if os.MkdirAll(dir, 0700) != nil {
+			return ""
+		}
+	} else if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		return ""
+	}
 	return filepath.Join(dir, "agent-factory.log")
+}
+
+// defaultLogPath returns the historical default, os.UserConfigDir()/
+// agent-factory/agent-factory.log, with no side effect, and "" when
+// UserConfigDir cannot be resolved. Shared by resolveLogPath (which
+// additionally creates the directory) and LogFilePath.
+func defaultLogPath() string {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(configDir, "agent-factory", "agent-factory.log")
 }
 
 // LogFilePath returns the agent-factory.log path for read-only tooling (e.g.
@@ -129,11 +173,14 @@ func resolveLogPath() string {
 // but could not be created — resolveLogPath falling back to the UserConfigDir
 // default — a bug report tailed the dead override path and collected no logs.
 //
-// Before Initialize (logFileName still ""), it resolves statically from
-// $AGENT_FACTORY_HOME then the os.UserConfigDir default, with no test-scratch
-// branch, no test-only override, and no directory-creating side effect — so a
-// pre-init bug report still names the real log even when built by a test
-// binary. Returns "" only when neither a home override nor UserConfigDir can be
+// Before Initialize (logFileName still ""), it resolves statically through the
+// SAME homeLogPath / defaultLogPath helpers resolveLogPath uses — read-only, so
+// no directory-creating side effect, no test-scratch branch, no test-only
+// override. Routing both functions through one computation is what keeps them
+// from diverging in the pre-Initialize state too: an unusable
+// $AGENT_FACTORY_HOME falls through to the UserConfigDir default here exactly as
+// it does in the resolver, instead of returning a dead override path (#1604).
+// Returns "" only when neither a home override nor UserConfigDir can be
 // resolved.
 func LogFilePath() string {
 	mu.Lock()
@@ -142,16 +189,10 @@ func LogFilePath() string {
 	if actual != "" {
 		return actual
 	}
-	if home := os.Getenv("AGENT_FACTORY_HOME"); home != "" {
-		if dir, ok := expandTilde(home); ok {
-			return filepath.Join(dir, "agent-factory.log")
-		}
+	if p := homeLogPath(false); p != "" {
+		return p
 	}
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(configDir, "agent-factory", "agent-factory.log")
+	return defaultLogPath()
 }
 
 // rotationPolicy resolves the log-rotation cap and backup count from the

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -74,6 +74,45 @@ func TestLogFilePathMatchesResolvedFallback(t *testing.T) {
 	}
 }
 
+// TestLogFilePathPreInitFallsBackFromUncreatableHome covers the OTHER divergence
+// state #1604 can hit: LogFilePath called before Initialize (logFileName still
+// "") with a set-but-uncreatable AGENT_FACTORY_HOME. Because both the resolver
+// and LogFilePath now share the homeLogPath gate, the query must fall through to
+// the UserConfigDir default here too — not return the dead override path — even
+// though no Initialize has run to cache the resolved path.
+func TestLogFilePathPreInitFallsBackFromUncreatableHome(t *testing.T) {
+	mu.Lock()
+	saved := logFileName
+	logFileName = ""
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		logFileName = saved
+		mu.Unlock()
+	})
+
+	// Deterministic UserConfigDir under a temp dir so the fallback path is
+	// predictable and the test never touches the developer's real config.
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	blocker := filepath.Join(t.TempDir(), "blockdir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker file: %v", err)
+	}
+	afHome := filepath.Join(blocker, "subdir") // uncreatable: blocker is a file
+	afHomeLog := filepath.Join(afHome, "agent-factory.log")
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+
+	got := LogFilePath()
+	if got == afHomeLog {
+		t.Fatalf("pre-Initialize LogFilePath returned the uncreatable home path %q instead of the fallback", afHomeLog)
+	}
+	if want := filepath.Join(xdg, "agent-factory", "agent-factory.log"); got != want {
+		t.Fatalf("pre-Initialize LogFilePath=%q, want resolved fallback %q", got, want)
+	}
+}
+
 // TestInitializeRace spins multiple goroutines concurrently calling
 // Initialize to make sure the package-level mutex prevents data races on
 // globalLogFile and the exported logger pointers. Run with `go test -race`.

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -31,6 +31,49 @@ func TestLoggersInitializedByDefault(t *testing.T) {
 	ErrorLog.Printf("default-logger-smoke-test")
 }
 
+// TestLogFilePathMatchesResolvedFallback is the regression for
+// sachiniyer/agent-factory#1604: when AGENT_FACTORY_HOME is set but its
+// directory cannot be created, resolveLogPath falls back away from the home
+// override, and LogFilePath must return that same resolved path — not the dead
+// override — so `af bug-report`/`af doctor` tail the file logging actually
+// writes to.
+//
+// The uncreatable-home shape mirrors the report's /tmp/blockdir repro: a
+// regular file blocks MkdirAll of a subdir beneath it, so
+// AGENT_FACTORY_HOME=<file>/subdir can never be created.
+func TestLogFilePathMatchesResolvedFallback(t *testing.T) {
+	t.Cleanup(func() {
+		logFileName = ""
+		globalLogFile = nil
+	})
+
+	blocker := filepath.Join(t.TempDir(), "blockdir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker file: %v", err)
+	}
+	afHome := filepath.Join(blocker, "subdir") // uncreatable: blocker is a file
+	afHomeLog := filepath.Join(afHome, "agent-factory.log")
+	t.Setenv("AGENT_FACTORY_HOME", afHome)
+
+	Initialize(false)
+	defer Close()
+
+	// Sanity: the setup actually triggered the fallback (resolveLogPath could
+	// not use the uncreatable home), otherwise the test proves nothing.
+	if logFileName == afHomeLog {
+		t.Fatalf("expected Initialize to fall back away from the uncreatable home %q, but logFileName is the home path", afHomeLog)
+	}
+
+	// The fix: LogFilePath returns exactly where logging landed, never the
+	// abandoned override path.
+	if got := LogFilePath(); got != logFileName {
+		t.Fatalf("LogFilePath()=%q diverges from the written path logFileName=%q", got, logFileName)
+	}
+	if got := LogFilePath(); got == afHomeLog {
+		t.Fatalf("LogFilePath() returned the uncreatable home path %q instead of the resolved fallback", afHomeLog)
+	}
+}
+
 // TestInitializeRace spins multiple goroutines concurrently calling
 // Initialize to make sure the package-level mutex prevents data races on
 // globalLogFile and the exported logger pointers. Run with `go test -race`.


### PR DESCRIPTION
## Summary

Fixes #1604. `log.LogFilePath()` diverged from where logs are actually written: it re-derived the path from `$AGENT_FACTORY_HOME` **without** `resolveLogPath()`'s creatability check. When the home override resolved but its directory could not be created, `resolveLogPath()` intentionally falls back to the `os.UserConfigDir` default so logging still works — but `LogFilePath()` kept returning the dead override path.

Consequence (from the report's repro):
- `af bug-report` read `/tmp/blockdir_real_test/subdir/agent-factory.log` and collected **no logs** ("not a directory"), even though logs went to `~/.config/agent-factory/agent-factory.log`.
- `af doctor` emitted misleading "log directory … is not writable" guidance for a path the app had already abandoned.

## Fix — one shared path computation, correct-by-construction

`LogFilePath()` becomes the single source of truth in **every** state:

1. **After `Initialize()`** it returns the exact cached path (`logFileName`) that `resolveLogPath()` chose and opened — cannot diverge from the real write target.
2. **Before `Initialize()`** it resolves through the **same helpers** `resolveLogPath()` uses, extracted so the two can't drift:
   - `homeLogPath(create bool)` — the shared `$AGENT_FACTORY_HOME` gate. `resolveLogPath` passes `create=true` (`MkdirAll` validates+creates, exactly as before); `LogFilePath` passes `create=false` (read-only `os.Stat` probe — no filesystem side effect on a diagnostics query). An unusable home falls through to the default in both.
   - `defaultLogPath()` — the side-effect-free `os.UserConfigDir` default.

`resolveLogPath()`'s observable behavior is byte-identical (its `testing.Testing()` scratch branch — the #1056 hermeticity seam — and temp fallbacks are untouched). The read-only probe is conservative for a not-yet-created-but-creatable home pre-`Initialize`, but never yields a path the app can't write to — the property #1604 needs.

`bugreportcmd`/`doctor` call `Initialize()` before `LogFilePath()` (via `commands/root.go`), so the real flow hits case 1; case 2 closes the divergence for any pre-init caller too.

## Tests

- `TestLogFilePathMatchesResolvedFallback` — post-`Initialize`, uncreatable home; `LogFilePath() == logFileName`, never the dead override path.
- `TestLogFilePathPreInitFallsBackFromUncreatableHome` — pre-`Initialize` (`logFileName==""`), uncreatable home; `LogFilePath()` returns the UserConfigDir fallback, not the dead override path.

Both use the report's uncreatable-home shape (a regular file blocking `MkdirAll` of a subdir beneath it) and were each verified to fail on the pre-fix code.

## Scope & gates

Confined to `log/log.go` + `log/log_test.go`. Clean: `gofmt -l .`, `golangci-lint run --fast`, `go build ./...`, `deadcode -test ./...`, file-length lint, and full `make test-container`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)