### PR TITLE
fix(tui): don't focus-steal on background snapshot polling (#1603)

### DIFF
--- a/app/home_model.go
+++ b/app/home_model.go
@@ -204,13 +204,15 @@ type home struct {
 	// panePreviewSuppression remembers a user-dismissed preview target so the
 	// 100ms preview tick does not recreate it until the sidebar target changes.
 	panePreviewSuppression *panePreviewSuppression
-	// inPreviewTick is set only while the idle 100ms preview tick drives
-	// selectionChanged. It gates the one side effect that must never fire from a
-	// background refresh: pulling focus onto the selected instance's already-open
-	// pane. Without the gate the tick yanked focus back to that pane the moment
-	// the user Tabbed off it, so the focus ring could never traverse the other
-	// panes or rest on the tree (#1558). User-driven selectionChanged calls (nav,
-	// the open-or-focus verb, reconcile) leave it false and keep that behavior.
+	// inPreviewTick is set while a BACKGROUND REFRESH drives selectionChanged —
+	// the idle 100ms preview tick (#1558) or a daemon snapshot poll (#1603). It
+	// gates the one side effect that must never fire from a background refresh:
+	// pulling focus onto the selected instance's already-open pane. Without the
+	// gate the tick yanked focus back to that pane the moment the user Tabbed off
+	// it, so the focus ring could never traverse the other panes or rest on the
+	// tree (#1558); a snapshot poll did the same on any out-of-band change
+	// (#1603). User-driven selectionChanged calls (nav, the open-or-focus verb)
+	// leave it false and keep the focus-steal behavior.
 	inPreviewTick bool
 	// -- Live embedded terminal (#1089 PR 1, read-only proof path) --
 	//

--- a/app/home_update.go
+++ b/app/home_update.go
@@ -171,7 +171,15 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		detachTrace(tickStart, "snapshotFetchedMsg-reconcile-returned")
 		cmds := []tea.Cmd{tickRefreshExternalCmd}
 		if changed {
+			// A snapshot poll is a background refresh, not a user action, so its
+			// selectionChanged must NOT steal focus onto the selected instance's
+			// already-open pane — the same guard previewTickMsg uses (#1558). The
+			// pane close/rebind for out-of-band tab/session removals already ran in
+			// handleSnapshot above; this selectionChanged only re-derives the
+			// preview, which is exactly the focus-steal we gate here (#1603).
+			m.inPreviewTick = true
 			cmds = append(cmds, m.selectionChanged())
+			m.inPreviewTick = false
 		}
 		return m, tea.Batch(cmds...)
 	case taskTriggeredMsg:

--- a/app/pane_focus_ring_test.go
+++ b/app/pane_focus_ring_test.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"testing"
+	"time"
 
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/ui/layout"
 	"github.com/stretchr/testify/require"
 )
@@ -86,4 +88,63 @@ func TestPane_IdleTickDoesNotStealFocusFromTree(t *testing.T) {
 		require.Equal(t, layout.RegionTree, h.ring.Active(),
 			"the idle preview tick must leave focus on the tree, not steal it to the selected pane")
 	}
+}
+
+// TestPane_SnapshotFetchDoesNotStealFocusFromOtherPane is the snapshot-poll twin
+// of #1558 (#1603): a background daemon snapshot poll is a background refresh too,
+// so the selectionChanged it fires on any out-of-band change (new/removed session,
+// tab set changed) must NOT steal focus onto the selected instance's already-open
+// pane. Before the fix, snapshotFetchedMsg ran selectionChanged ungated, so a
+// snapshot arriving while the user was focused in another pane yanked focus back
+// onto the selected instance's open pane.
+//
+// The message is driven through Update (not handleSnapshot directly) so the real
+// snapshotFetchedMsg wiring runs exactly once — a second handleSnapshot on the
+// same data would report changed==false and never reach the gated branch.
+func TestPane_SnapshotFetchDoesNotStealFocusFromOtherPane(t *testing.T) {
+	h := paneTestHome(t)
+	alpha := h.store.GetInstanceByTitle("alpha")
+	beta := h.store.GetInstanceByTitle("beta")
+	gamma := h.store.GetInstanceByTitle("gamma")
+
+	t.Cleanup(SetInstanceBuilderForTest(func(d session.InstanceData) (*session.Instance, error) {
+		return newSnapshotTestInstance(t, d.Title), nil
+	}))
+
+	// Open alpha's agent tab in pane1.
+	_ = openTestPane(t, h, alpha, 0)
+	// Open beta's agent tab in pane2.
+	h.sidebar.SetSelectedInstance(1)
+	_ = h.selectionChanged()
+	pane2 := openTestPane(t, h, beta, 0)
+
+	// Select alpha (already open in pane1) — a user-driven selectionChanged, so
+	// the open-or-focus verb (#1493) focuses pane1.
+	h.sidebar.SetSelectedInstance(0)
+	_ = h.selectionChanged()
+
+	// The user then manually focuses pane2 (beta), away from the selection.
+	h.focusRegion(layout.PaneRegion(pane2.ID()))
+	require.Equal(t, layout.PaneRegion(pane2.ID()), h.ring.Active(),
+		"user manually focused pane2 (beta)")
+	require.Equal(t, "alpha", h.sidebar.GetSelectedInstance().Title,
+		"selection rests on alpha (open in pane1)")
+
+	// A background snapshot poll reports a new session "delta" — an out-of-band
+	// change that reconciles to changed==true and fires selectionChanged.
+	snap := snapshotFetchedMsg{
+		data: []session.InstanceData{
+			alpha.ToInstanceData(),
+			beta.ToInstanceData(),
+			gamma.ToInstanceData(),
+			{Title: "delta", CreatedAt: time.Now()},
+		},
+		repoID: h.repoID,
+	}
+	_, _ = h.Update(snap)
+
+	require.NotNil(t, h.store.GetInstanceByTitle("delta"),
+		"the snapshot reconciled the new session (changed==true, gated branch taken)")
+	require.Equal(t, layout.PaneRegion(pane2.ID()), h.ring.Active(),
+		"background snapshot reconciliation must not steal focus from pane2 (beta) to pane1 (alpha)")
 }

--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -68,11 +68,12 @@ func (m *home) updatePanePreview(selected *session.Instance, targetTab int, tabS
 	if existing := m.store.FindOpenPane(target.instance, target.tab); existing != nil && existing != owner {
 		m.cancelPanePreview(false)
 		// Landing on an already-open tab focuses its pane — the open-or-focus
-		// contract (#1493). But NEVER from the idle 100ms preview tick: doing so
-		// would keep yanking focus back onto the selected instance's pane after
-		// the user Tabbed to another pane, so the focus ring could never traverse
-		// the other panes or rest on the tree (#1558). On the tick the tab being
-		// open elsewhere just means "no preview to show" — leave focus put.
+		// contract (#1493). But NEVER from a background refresh (the idle 100ms
+		// preview tick, #1558; or a snapshot poll, #1603): doing so would keep
+		// yanking focus back onto the selected instance's pane after the user
+		// Tabbed to another pane, so the focus ring could never traverse the other
+		// panes or rest on the tree. From a background refresh the tab being open
+		// elsewhere just means "no preview to show" — leave focus put.
 		if !m.inPreviewTick {
 			m.focusOpenPane(existing)
 		}


### PR DESCRIPTION
Closes #1603.

## Problem
`snapshotFetchedMsg` in `app/home_update.go` runs `selectionChanged()` on any out-of-band change the daemon snapshot poll detects (`changed == true`: a session appeared/was removed, a tab set changed). `selectionChanged()` flows into `updatePanePreview()`'s open-or-focus logic, which — when the selected instance's tab is already open in *another* pane — calls `focusOpenPane(existing)` and yanks focus there.

That focus-steal is only correct for **user-driven** actions (#1493). A background poll is not user-driven, so it must not move focus — the exact same class as #1558, which fixed it for `previewTickMsg` by gating that call with `inPreviewTick`. `snapshotFetchedMsg` was the only remaining ungated background caller of `selectionChanged()`.

## Fix
- Gate the `snapshotFetchedMsg` handler's `selectionChanged()` with the existing `inPreviewTick` guard (symmetric to `previewTickMsg`), so a background snapshot poll cannot reach `focusOpenPane(existing)`.
- The pane close/rebind for out-of-band tab/session removals already runs **inside** `handleSnapshot` → `reconcileSnapshot`, not in the post-reconcile `selectionChanged()`. So the surviving-pane behavior (`TestPane_SnapshotTabRemovalRebindsPanes` and siblings) is untouched — only the preview-focus-steal is suppressed.
- Generalized the `inPreviewTick` doc comment (`home_model.go`) and the guard comment (`pane_preview.go`) to name **both** background-refresh callers, closing the codebase inconsistency the report flagged.

## Test
`TestPane_SnapshotFetchDoesNotStealFocusFromOtherPane` (in `app/pane_focus_ring_test.go`, the #1558 focus-steal family) opens two panes, focuses the non-selected one, then delivers a background snapshot that adds a new session. It asserts the reconcile happened (new session present ⇒ gated branch taken) **and** that focus stayed put.

Driven through `Update(snap)` — not `handleSnapshot` directly — so the real `snapshotFetchedMsg` wiring runs exactly once (a second `handleSnapshot` on the same data reports `changed==false` and would never reach the gated branch, silently passing on buggy code). Verified to **fail before** the gate (`pane:2` → `pane:1`) and **pass after**.

Scope: confined to `app/home_update.go`, `app/pane_preview.go`, `app/home_model.go` (doc only), and the new test.

## Gates
- `gofmt -l .` clean
- `go build ./...` ok
- `golangci-lint run --timeout=3m --fast` clean
- `deadcode -test ./...` clean
- `scripts/lint-file-length.sh` pass
- `make test-container` — full suite green (app 70.9s, daemon, integration, all)
- `make tui-driver-selftest` — 25/25 steps green

🤖 Generated with [Claude Code](https://claude.com/claude-code)