### PR TITLE
feat(apiclient): Phase 2 PR2 — HTTP API Go client, read path (#1592)

### DIFF
--- a/api/sessions.go
+++ b/api/sessions.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/log"
@@ -41,7 +42,14 @@ var (
 	// a daemon is already running, and returns daemon.ErrDaemonUnavailable
 	// (never spawning one) when it is not, so callers fall back to disk. Held in
 	// a var so tests can inject a snapshot without a live daemon.
-	snapshotViaDaemon = daemon.SnapshotNoSpawn
+	//
+	// #1592 Phase 2 PR2: this read now flows over the daemon's HTTP/JSON API
+	// (apiclient) instead of net/rpc. The response is byte-identical — apiclient
+	// decodes the same {data,error} envelope back into the same
+	// session.InstanceData structs the RPC returned — so list/get/whoami output,
+	// scoping, and disk-fallback behavior are unchanged; only the transport
+	// moved. Every write/control path stays on net/rpc for now.
+	snapshotViaDaemon = apiclient.SnapshotNoSpawn
 )
 
 // listSessions returns the session list for repoID (empty = all repos),

--- a/api/sessions_apiclient_parity_test.go
+++ b/api/sessions_apiclient_parity_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/apiclient"
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+
+	"github.com/stretchr/testify/require"
+)
+
+// parityInstances is a fixture with a spread of populated fields so byte-parity
+// is proven over real content, not two empty lists.
+func parityInstances() []session.InstanceData {
+	created := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	return []session.InstanceData{
+		{
+			ID:        "id-aaaa",
+			Title:     "alpha",
+			Path:      "/wt/alpha",
+			Branch:    "feat/alpha",
+			Status:    session.Status(1),
+			Liveness:  session.Liveness(2),
+			Height:    40,
+			Width:     120,
+			CreatedAt: created,
+			UpdatedAt: created,
+			Program:   "claude",
+			TmuxName:  "af_alpha",
+			Tabs:      []session.TabData{{Name: "agent"}},
+		},
+		{
+			ID:        "id-bbbb",
+			Title:     "beta",
+			Path:      "/wt/beta",
+			Branch:    "feat/beta",
+			Program:   "codex",
+			CreatedAt: created,
+			UpdatedAt: created,
+		},
+	}
+}
+
+// renderListJSON runs `sessions list --json` (the enveloped read path) against
+// whatever snapshotViaDaemon is currently wired to and returns its exact stdout
+// bytes.
+func renderListJSON(t *testing.T) string {
+	t.Helper()
+	prevEnvelope := envelopeOutput
+	prevRepo := repoFlag
+	envelopeOutput = true
+	repoFlag = ""
+	t.Cleanup(func() { envelopeOutput = prevEnvelope; repoFlag = prevRepo })
+
+	return captureStdout(t, func() {
+		if err := sessionsListCmd.RunE(sessionsListCmd, nil); err != nil {
+			t.Fatalf("sessions list --json: %v", err)
+		}
+	})
+}
+
+// TestSessionsListJSON_ByteParity_APIClientVsNetRPC is the #1592 PR2 gate: the
+// `af sessions list --json` output is BYTE-IDENTICAL whether the read is sourced
+// through the new apiclient (HTTP over daemon-http.sock) or the net/rpc path.
+//
+// The net/rpc side is represented by the exact value daemon.SnapshotNoSpawn
+// returns on success — its whole body is `return resp.Instances` — while the
+// apiclient side is a REAL HTTP round-trip: a live Unix-socket server encodes
+// that same slice through the daemon's shared apiproto envelope, apiclient
+// dials it, decodes, and hands the result to the identical rendering path. Equal
+// stdout bytes prove the transport swap is invisible to the CLI surface.
+func TestSessionsListJSON_ByteParity_APIClientVsNetRPC(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	canned := parityInstances()
+
+	// --- net/rpc side: SnapshotNoSpawn's success output is exactly its input. ---
+	prev := snapshotViaDaemon
+	snapshotViaDaemon = func(daemon.SnapshotRequest) ([]session.InstanceData, error) {
+		return canned, nil
+	}
+	netrpcJSON := renderListJSON(t)
+	snapshotViaDaemon = prev
+
+	// --- apiclient side: a real daemon-http.sock round-trip through the envelope. ---
+	sockPath, err := daemon.DaemonHTTPSocketPath()
+	require.NoError(t, err)
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/Snapshot", func(w http.ResponseWriter, r *http.Request) {
+		var req daemon.SnapshotRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_ = apiproto.WriteEnvelope(w, apiproto.Success(daemon.SnapshotResponse{Instances: canned}))
+	})
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	prev = snapshotViaDaemon
+	snapshotViaDaemon = apiclient.SnapshotNoSpawn
+	apiclientJSON := renderListJSON(t)
+	snapshotViaDaemon = prev
+
+	require.NotEmpty(t, apiclientJSON)
+	require.Contains(t, apiclientJSON, `"alpha"`, "sanity: fixture must actually render")
+	require.Equal(t, netrpcJSON, apiclientJSON,
+		"sessions list --json must be byte-identical between the apiclient and net/rpc read paths")
+}

--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -1,0 +1,133 @@
+// Package apiclient is a typed Go client for the daemon-hosted HTTP/JSON API
+// (#1029) that the daemon serves on its `daemon-http.sock` Unix socket. It is
+// the read-side twin of the gob `net/rpc` control client in daemon/: it dials
+// the SAME daemon core over a DIFFERENT transport and, by decoding the shared
+// `{data,error}` envelope back into the SAME request/response structs the RPC
+// client uses, it returns byte-identical results. This is the seam #1592 Phase 2
+// grows the client API on — HTTP today, WebSocket streaming later — without the
+// TUI or CLI ever touching the wire shape.
+//
+// Phase 2 PR2 scope: this client exposes only the READ-ONLY Snapshot path and
+// its first consumer is the non-spawning `af sessions list`/`get` read
+// (api/sessions.go). Every write/control call stays on net/rpc; the disk
+// fallback is unchanged. The envelope is NOT redefined here — the client decodes
+// the exact bytes daemon/httpserver.go writes via apiproto.WriteEnvelope, which
+// is what guarantees parity.
+package apiclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/daemon"
+)
+
+// dialTimeout bounds how long the client waits to connect to the daemon HTTP
+// socket. It mirrors the net/rpc control client's dial timeout so the two read
+// paths fail fast identically when no daemon is listening: an absent or stale
+// socket refuses immediately, and a live daemon is local, so a quarter second is
+// ample. Deliberately no overall request timeout — like the net/rpc client's
+// blocking Call, the read waits for the daemon's in-memory snapshot rather than
+// racing an arbitrary deadline.
+const dialTimeout = 250 * time.Millisecond
+
+// httpBaseURL is a syntactic placeholder host. The Unix-socket dialer ignores it
+// (the socket path is the real address), but net/http requires a valid URL, so
+// every request targets http://af/v1/<Method>.
+const httpBaseURL = "http://af"
+
+// Client dials the daemon's HTTP/JSON Unix socket and calls its /v1/* routes.
+// It holds a net/http.Client whose transport dials the fixed socket path, so a
+// Client is bound to one daemon home. Construct it with New (resolves the socket
+// from the config dir) or NewWithSocket (explicit path, for tests). A zero
+// Client is not usable.
+type Client struct {
+	httpClient *http.Client
+}
+
+// New returns a Client dialing the daemon HTTP socket resolved from the current
+// config dir (AGENT_FACTORY_HOME), the same path the daemon binds. It does not
+// dial or spawn anything — a daemon need not be running yet; the first call
+// surfaces an unreachable socket as a transport error the caller collapses to
+// the disk-fallback signal.
+func New() (*Client, error) {
+	socketPath, err := daemon.DaemonHTTPSocketPath()
+	if err != nil {
+		return nil, err
+	}
+	return NewWithSocket(socketPath), nil
+}
+
+// NewWithSocket returns a Client dialing an explicit HTTP socket path. It is the
+// injection seam for tests, which bind a real Unix socket at a temp path and
+// point the client at it without a full daemon.
+func NewWithSocket(socketPath string) *Client {
+	dialer := &net.Dialer{Timeout: dialTimeout}
+	return &Client{
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				// Ignore the URL host/port entirely and dial the Unix socket.
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return dialer.DialContext(ctx, "unix", socketPath)
+				},
+			},
+		},
+	}
+}
+
+// call POSTs req as JSON to /v1/<method>, decodes the shared {data,error}
+// envelope, and unmarshals the envelope's data member into resp. It is the
+// single client-side twin of daemon/httpserver.go's rpcHandler: request struct
+// in, response struct out, the envelope in between. A populated envelope error —
+// the same string the net/rpc handler would return, since both call the same
+// controlServer method — is surfaced as a Go error; a transport failure (no
+// daemon listening) surfaces as the raw net/http error. resp may be nil for a
+// caller that only needs success/failure.
+func (c *Client) call(method string, req any, resp any) error {
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("apiclient: marshal request: %w", err)
+	}
+
+	httpResp, err := c.httpClient.Post(httpBaseURL+"/v1/"+method, "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	raw, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return fmt.Errorf("apiclient: read response body: %w", err)
+	}
+
+	// Decode into a RawMessage-backed envelope so the typed response is decoded
+	// in a second pass — the daemon's data member is the RPC response struct,
+	// and keeping it raw until the error branch is checked avoids interpreting a
+	// failure body's null data.
+	var env struct {
+		Data  json.RawMessage         `json:"data"`
+		Error *apiproto.EnvelopeError `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return fmt.Errorf("apiclient: malformed response envelope: %w", err)
+	}
+	if env.Error != nil {
+		// Surface the daemon's message verbatim — byte-identical to what the
+		// net/rpc client would carry, since both transports wrap the same
+		// controlServer error.
+		return fmt.Errorf("%s", env.Error.Message)
+	}
+	if resp != nil {
+		if err := json.Unmarshal(env.Data, resp); err != nil {
+			return fmt.Errorf("apiclient: malformed response data: %w", err)
+		}
+	}
+	return nil
+}

--- a/apiclient/client_test.go
+++ b/apiclient/client_test.go
@@ -1,0 +1,153 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// richInstances is a fixture exercising a spread of InstanceData fields —
+// scalars, times, an enum, a slice, and a nested struct — so a successful
+// round-trip proves the client decodes the daemon envelope back into
+// byte-identical structs, not just the two obvious title/path columns.
+func richInstances() []session.InstanceData {
+	created := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	updated := time.Date(2026, 7, 10, 12, 5, 0, 0, time.UTC)
+	return []session.InstanceData{
+		{
+			ID:        "id-aaaa",
+			Title:     "alpha",
+			Path:      "/home/u/.af/worktrees/alpha",
+			Branch:    "feat/alpha",
+			Status:    session.Status(1),
+			Liveness:  session.Liveness(2),
+			Height:    40,
+			Width:     120,
+			CreatedAt: created,
+			UpdatedAt: updated,
+			Program:   "claude",
+			TmuxName:  "af_alpha",
+			Tabs:      []session.TabData{{Name: "agent"}},
+		},
+		{
+			ID:        "id-bbbb",
+			Title:     "beta",
+			Path:      "/home/u/.af/worktrees/beta",
+			Branch:    "feat/beta",
+			Program:   "codex",
+			CreatedAt: created,
+			UpdatedAt: updated,
+		},
+	}
+}
+
+// snapshotServer stands up a REAL Unix-socket HTTP server that answers
+// POST /v1/Snapshot exactly the way the daemon does — encoding the response
+// through the shared apiproto.WriteEnvelope, the identical primitive
+// daemon/httpserver.go uses — and returns a Client dialing it. Using the real
+// envelope writer (not a hand-rolled body) is what makes the round-trip a
+// genuine parity proof rather than a mock agreeing with itself.
+func snapshotServer(t *testing.T, handle func(daemon.SnapshotRequest) apiproto.Envelope) *Client {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "daemon-http.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/Snapshot", func(w http.ResponseWriter, r *http.Request) {
+		var req daemon.SnapshotRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		_ = apiproto.WriteEnvelope(w, handle(req))
+	})
+
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	return NewWithSocket(sockPath)
+}
+
+// TestClientSnapshot_RoundTripsStructsByteIdentically drives the real transport:
+// the client dials a Unix socket, POSTs a Snapshot request, decodes the daemon's
+// {data,error} envelope, and returns []session.InstanceData that is
+// byte-identical to what the server put in. This is the client-side half of the
+// #1592 PR2 byte-parity proof.
+func TestClientSnapshot_RoundTripsStructsByteIdentically(t *testing.T) {
+	want := richInstances()
+	var gotReq daemon.SnapshotRequest
+	c := snapshotServer(t, func(req daemon.SnapshotRequest) apiproto.Envelope {
+		gotReq = req
+		return apiproto.Success(daemon.SnapshotResponse{Instances: want})
+	})
+
+	got, err := c.Snapshot(daemon.SnapshotRequest{RepoID: "repo-x"})
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	if gotReq.RepoID != "repo-x" {
+		t.Fatalf("repo scoping lost: server saw RepoID=%q, want repo-x", gotReq.RepoID)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("decoded structs differ from server payload:\n got=%+v\nwant=%+v", got, want)
+	}
+
+	// The stronger claim: the client's result re-marshals to the exact bytes the
+	// server's payload does. This is the byte-parity the envelope guarantees.
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal want: %v", err)
+	}
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal got: %v", err)
+	}
+	if string(gotJSON) != string(wantJSON) {
+		t.Fatalf("JSON not byte-identical after round-trip:\n got=%s\nwant=%s", gotJSON, wantJSON)
+	}
+}
+
+// TestSnapshotNoSpawn_NoDaemon_FallsBackSignal verifies that with nothing
+// listening the drop-in read returns daemon.ErrDaemonUnavailable — the exact
+// sentinel the net/rpc twin returns — so the CLI read path falls back to disk
+// rather than failing or spawning a daemon.
+func TestSnapshotNoSpawn_NoDaemon_FallsBackSignal(t *testing.T) {
+	// Point the config-dir resolver at an empty home so New() resolves a socket
+	// path that no daemon is serving.
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	got, err := SnapshotNoSpawn(daemon.SnapshotRequest{})
+	if !errors.Is(err, daemon.ErrDaemonUnavailable) {
+		t.Fatalf("want ErrDaemonUnavailable, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("want nil instances on unavailable daemon, got %+v", got)
+	}
+}
+
+// TestSnapshot_FailureEnvelope_SurfacesMessage verifies a daemon failure
+// envelope (error != null) surfaces as a Go error carrying the daemon's message
+// verbatim, byte-identical to what the net/rpc client would carry since both
+// wrap the same controlServer error string.
+func TestSnapshot_FailureEnvelope_SurfacesMessage(t *testing.T) {
+	c := snapshotServer(t, func(daemon.SnapshotRequest) apiproto.Envelope {
+		return apiproto.Failure("boom: repo not found")
+	})
+
+	_, err := c.Snapshot(daemon.SnapshotRequest{})
+	if err == nil || err.Error() != "boom: repo not found" {
+		t.Fatalf("want verbatim daemon message, got %v", err)
+	}
+}

--- a/apiclient/sessions.go
+++ b/apiclient/sessions.go
@@ -1,0 +1,39 @@
+package apiclient
+
+import (
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// Snapshot returns the daemon's authoritative session list over the HTTP API,
+// the exact `[]session.InstanceData` the net/rpc Snapshot RPC returns. It POSTs
+// to /v1/Snapshot and unwraps resp.Instances from the shared envelope, so its
+// result is byte-identical to daemon.SnapshotNoSpawn's on a running daemon. Like
+// the RPC read it is scoped by req.RepoID (empty = all repos).
+func (c *Client) Snapshot(req daemon.SnapshotRequest) ([]session.InstanceData, error) {
+	var resp daemon.SnapshotResponse
+	if err := c.call("Snapshot", req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Instances, nil
+}
+
+// SnapshotNoSpawn is a drop-in for daemon.SnapshotNoSpawn over the HTTP API: it
+// returns the daemon's authoritative session snapshot WITHOUT ever starting a
+// daemon, and collapses every failure — no socket, a refused dial, a warming
+// daemon's starting-error envelope (#829) — into daemon.ErrDaemonUnavailable so
+// the read-only CLI read path (api/sessions.go) falls back to disk instead of
+// spawning a daemon or failing. This is the ONE behavioral contract the caller
+// depends on, and it matches the net/rpc twin exactly: live daemon → live
+// snapshot, otherwise → disk fallback.
+func SnapshotNoSpawn(req daemon.SnapshotRequest) ([]session.InstanceData, error) {
+	c, err := New()
+	if err != nil {
+		return nil, daemon.ErrDaemonUnavailable
+	}
+	instances, err := c.Snapshot(req)
+	if err != nil {
+		return nil, daemon.ErrDaemonUnavailable
+	}
+	return instances, nil
+}


### PR DESCRIPTION
## What

Phase 2 **PR2** of #1592: a typed Go client (`apiclient`) for the #1029 daemon HTTP/JSON API served on `daemon-http.sock`, plus the first (safest) cutover of a read path onto it. Runs in parallel with PR1 (`agentproto`); files are disjoint.

Per the approved design (`docs/design/phase2-agent-server.md` §8 PR2): additive, behavior-preserving, read-only. **No wire/envelope change** — this is a new client for the existing #1029 surface.

## Client shape

`apiclient` is the read-side twin of the gob `net/rpc` control client in `daemon/`: it dials the **same daemon core** over a **different transport** (HTTP over the `daemon-http.sock` Unix socket) and decodes the shared `{data,error}` envelope back into the **same request/response structs** the RPC client uses — so results are byte-identical.

- `apiclient.Client` — holds a `net/http.Client` whose transport dials the fixed Unix socket (dial timeout mirrors the net/rpc client's; no overall request timeout, matching the RPC client's blocking `Call`).
- `New()` resolves the socket via `daemon.DaemonHTTPSocketPath()`; `NewWithSocket(path)` is the test seam.
- `(*Client).call(method, req, resp)` — the single client-side twin of `httpserver.go`'s `rpcHandler`: POSTs the request struct as JSON to `/v1/<Method>`, decodes the envelope (raw-message data, second-pass typed decode), surfaces a failure envelope's message **verbatim** (byte-identical to what net/rpc would carry, since both wrap the same `controlServer` error).
- `(*Client).Snapshot` + package-level `apiclient.SnapshotNoSpawn` — a drop-in for `daemon.SnapshotNoSpawn`: returns the daemon's authoritative `[]session.InstanceData`, and collapses **every** failure (no socket, refused dial, warming-daemon starting-error #829) into `daemon.ErrDaemonUnavailable` so the caller falls back to disk. Never spawns a daemon.

`api → apiclient → daemon`; `daemon` imports neither, so no cycle. The envelope is **not** redefined — the client decodes the exact bytes `daemon/httpserver.go` writes through `apiproto.WriteEnvelope`, which is what guarantees parity.

## The list/get cutover

`api/sessions.go` `snapshotViaDaemon` (the non-spawning read backing `sessions list`/`get`/`whoami`) flips from `daemon.SnapshotNoSpawn` (net/rpc) to `apiclient.SnapshotNoSpawn` (HTTP). One line + the import. Output, `--repo` scoping, and disk-fallback behavior are unchanged; only the transport moved. **Every write/control path stays on net/rpc**; the disk fallback is untouched. Tasks reads stay on net/rpc.

## Byte-parity proof

- `api/TestSessionsListJSON_ByteParity_APIClientVsNetRPC` — renders `sessions list --json` twice: the net/rpc side is `SnapshotNoSpawn`'s exact success output (`return resp.Instances`), the apiclient side is a **real `daemon-http.sock` round-trip** (live Unix-socket server encoding the same slice through the shared `apiproto` envelope). Asserts **identical stdout bytes**.
- `apiclient/TestClientSnapshot_RoundTripsStructsByteIdentically` — real Unix-socket transport; asserts the decoded structs re-marshal to the server payload's **exact bytes** (rich fixture: scalars, times, enum, slice, nested struct), and that `--repo` scoping threads through.
- Plus: no-daemon → `ErrDaemonUnavailable` fallback signal; failure-envelope message surfaced verbatim.

## Gates

- `gofmt` / `golangci-lint --fast` / `go build ./...` / `deadcode -test ./...` / file-length — all clean
- `make test-container` — green across all packages (incl. new `apiclient`)
- `make tui-driver-selftest` — **25/25**

Part of #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)