### PR TITLE
feat(cli): af sessions watch — block until a session goes idle/ready (#1617)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/config"
@@ -456,6 +457,9 @@ func init() {
 	sessionsKillCmd.Flags().BoolVar(&sessionsKillForce, "force", false, "Deprecated no-op, accepted for compatibility: kill always destroys the session (use 'af sessions archive' to keep it restorable)")
 	sessionsArchiveCmd.Flags().BoolVar(&sessionsArchiveSelf, "self", false, "Archive the current session (resolved via whoami); use from inside a session when your work is done")
 
+	sessionsWatchCmd.Flags().DurationVar(&watchTimeoutFlag, "timeout", 30*time.Minute, "Give up and exit non-zero if the session is not idle within this window (0 = wait forever)")
+	sessionsWatchCmd.Flags().DurationVar(&watchIntervalFlag, "interval", 2*time.Second, "How often to poll the session's status")
+
 	// tab-create/tab-delete and their tabs {create,delete} aliases (#1192)
 	// share the same flag globals via these binders, so the two spellings stay
 	// in lockstep.
@@ -474,6 +478,7 @@ func init() {
 	SessionsCmd.AddCommand(sessionsTabDeleteCmd)
 	SessionsCmd.AddCommand(sessionsTabsCmd)
 	SessionsCmd.AddCommand(sessionsPreviewCmd)
+	SessionsCmd.AddCommand(sessionsWatchCmd)
 	SessionsCmd.AddCommand(sessionsKillCmd)
 	SessionsCmd.AddCommand(sessionsArchiveCmd)
 	SessionsCmd.AddCommand(sessionsRestoreCmd)

--- a/api/sessions_watch.go
+++ b/api/sessions_watch.go
@@ -165,6 +165,21 @@ func describeWatchState(d *session.InstanceData) string {
 	return "not idle"
 }
 
+// validateWatchFlags rejects nonsensical --interval/--timeout values with an
+// actionable message (public CLI standard). The duration parser accepts negative
+// durations, so guard them here: a negative interval is meaningless, and a
+// negative timeout would otherwise slip past the `timeout > 0` check in
+// watchForReady and silently wait forever (only 0 means "wait forever").
+func validateWatchFlags(interval, timeout time.Duration) error {
+	if interval <= 0 {
+		return fmt.Errorf("--interval must be positive, got %s", interval)
+	}
+	if timeout < 0 {
+		return fmt.Errorf("--timeout cannot be negative, got %s (use 0 to wait forever)", timeout)
+	}
+	return nil
+}
+
 // getSessionByTitleInScope resolves a single session by title, honoring --repo
 // scoping (unlike the all-repo `sessions get`). An empty repoID preserves the
 // all-repo lookup; a non-empty one confines the lookup to that repo so a
@@ -219,8 +234,8 @@ session record. Honors --repo to scope the title lookup to one repository.`,
 
 		title := args[0]
 
-		if watchIntervalFlag <= 0 {
-			return jsonError(fmt.Errorf("--interval must be positive, got %s", watchIntervalFlag))
+		if err := validateWatchFlags(watchIntervalFlag, watchTimeoutFlag); err != nil {
+			return jsonError(err)
 		}
 
 		repoID, err := resolveRepoID()

--- a/api/sessions_watch.go
+++ b/api/sessions_watch.go
@@ -1,0 +1,248 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+
+	"github.com/spf13/cobra"
+)
+
+// watchOutcome classifies a single session snapshot for `sessions watch`.
+type watchOutcome int
+
+const (
+	// watchPending: the agent is still working, or a create/kill/archive/restore
+	// op is mid-flight, or it is blocked on a usage limit that auto-resumes
+	// (#1146) — keep polling.
+	watchPending watchOutcome = iota
+	// watchReady: the agent went idle and is awaiting input — done working, ready
+	// for review. Exits 0.
+	watchReady
+	// watchTerminal: the session reached a state it cannot leave on its own
+	// (lost/dead/archived) — stop watching and exit non-zero with the reason.
+	watchTerminal
+)
+
+var (
+	watchTimeoutFlag  time.Duration
+	watchIntervalFlag time.Duration
+)
+
+// classifyWatch maps a session snapshot onto the watch state machine. It reads
+// the canonical two-axis state (#1195): an in-flight client/executor operation
+// means the session is still settling (keep polling), otherwise the liveness
+// axis decides. It falls back to the composed legacy Status only for records
+// that predate the liveness field (LivenessUnset), so pre-#1195 rows still
+// classify. The returned reason is a human clause for the terminal case (and the
+// ready line).
+func classifyWatch(d *session.InstanceData) (watchOutcome, string) {
+	// Any operation in flight (create, kill, archive, restore) means the session
+	// is mid-transition; wait for it to settle rather than reporting the
+	// transient composed status. The timeout is the backstop if it never does.
+	switch d.InFlightOp {
+	case session.OpCreating, session.OpKilling, session.OpArchiving, session.OpRestoring:
+		return watchPending, ""
+	}
+
+	switch d.Liveness {
+	case session.LiveReady:
+		return watchReady, "idle (ready for review)"
+	case session.LiveRunning:
+		return watchPending, ""
+	case session.LiveLimitReached:
+		// Blocked on a provider usage limit; the daemon auto-resumes it (#1146),
+		// so treat it as still-working rather than done.
+		return watchPending, ""
+	case session.LiveLost:
+		return watchTerminal, "session is lost (its backing tmux/worktree vanished); recover it with 'af sessions restore' before watching again"
+	case session.LiveDead:
+		return watchTerminal, "session is dead (its backing tmux/worktree vanished)"
+	case session.LiveArchived:
+		return watchTerminal, "session is archived; restore it with 'af sessions restore' before watching"
+	case session.LivenessUnset:
+		// Pre-#1195 record with no liveness axis: derive from the legacy Status.
+		return classifyWatchByStatus(d.Status)
+	}
+	return watchPending, ""
+}
+
+// classifyWatchByStatus is the legacy-Status fallback for classifyWatch, used
+// only for records written before the liveness axis existed (#1195).
+func classifyWatchByStatus(s session.Status) (watchOutcome, string) {
+	switch s {
+	case session.Ready:
+		return watchReady, "idle (ready for review)"
+	case session.Running, session.Loading, session.Deleting:
+		return watchPending, ""
+	case session.Lost:
+		return watchTerminal, "session is lost (its backing tmux/worktree vanished); recover it with 'af sessions restore' before watching again"
+	case session.Dead:
+		return watchTerminal, "session is dead (its backing tmux/worktree vanished)"
+	case session.Archived:
+		return watchTerminal, "session is archived; restore it with 'af sessions restore' before watching"
+	}
+	return watchPending, ""
+}
+
+// watchDeps holds the injectable dependencies of the watch loop so tests can
+// drive the state machine deterministically without a real daemon or wall clock.
+type watchDeps struct {
+	get      func(title string) (*session.InstanceData, error)
+	interval time.Duration
+	timeout  time.Duration
+	now      func() time.Time
+	sleep    func(time.Duration)
+}
+
+// watchForReady polls until the session reaches a ready-for-review state,
+// reaches a terminal state, disappears, or the timeout elapses. On success it
+// returns the final snapshot and a nil error; every other outcome returns a
+// non-nil error so the CLI exits non-zero. It never spawns a daemon — the getter
+// is the same non-spawning snapshot read path `sessions get` uses.
+func watchForReady(d watchDeps, title string) (*session.InstanceData, error) {
+	start := d.now()
+	seen := false
+	for {
+		data, err := d.get(title)
+		if err != nil {
+			// A title that never resolved is a plain not-found error. If the
+			// session existed on an earlier poll and then vanished, it was killed
+			// or removed out from under us — report that distinctly instead of a
+			// bare "not found" so the operator knows their session is gone.
+			if errors.Is(err, errTitleNotFound) && seen {
+				return nil, fmt.Errorf("session %q disappeared while watching (it was killed or removed)", title)
+			}
+			return nil, err
+		}
+		seen = true
+
+		outcome, reason := classifyWatch(data)
+		switch outcome {
+		case watchReady:
+			return data, nil
+		case watchTerminal:
+			return data, fmt.Errorf("session %q will not become ready: %s", title, reason)
+		}
+
+		// Still pending. Give up once the window has elapsed rather than blocking
+		// forever, reporting the state it was stuck in.
+		if d.timeout > 0 && !d.now().Before(start.Add(d.timeout)) {
+			return data, fmt.Errorf("timed out after %s waiting for session %q to become idle (still %s)",
+				d.timeout, title, describeWatchState(data))
+		}
+		d.sleep(d.interval)
+	}
+}
+
+// describeWatchState renders a short human label for the session's current
+// (non-ready) state, used in the timeout message.
+func describeWatchState(d *session.InstanceData) string {
+	switch d.InFlightOp {
+	case session.OpCreating:
+		return "being created"
+	case session.OpKilling:
+		return "being killed"
+	case session.OpArchiving:
+		return "being archived"
+	case session.OpRestoring:
+		return "being restored"
+	}
+	switch d.Liveness {
+	case session.LiveRunning:
+		return "working"
+	case session.LiveLimitReached:
+		return "blocked on a usage limit"
+	}
+	// Fall back to the composed legacy status for pre-#1195 records.
+	if d.Status == session.Running {
+		return "working"
+	}
+	return "not idle"
+}
+
+// getSessionByTitleInScope resolves a single session by title, honoring --repo
+// scoping (unlike the all-repo `sessions get`). An empty repoID preserves the
+// all-repo lookup; a non-empty one confines the lookup to that repo so a
+// same-titled session in a different repo is never watched by mistake. It
+// prefers the daemon's live snapshot and falls back to a scoped disk scan when
+// no daemon is reachable, mirroring getSessionByTitle (#1029 PR 2).
+func getSessionByTitleInScope(repoID, title string) (*session.InstanceData, error) {
+	if repoID == "" {
+		return getSessionByTitle(title)
+	}
+	if data, err := snapshotViaDaemon(daemon.SnapshotRequest{RepoID: repoID}); err == nil {
+		for i := range data {
+			if data[i].Title == title {
+				return &data[i], nil
+			}
+		}
+		return nil, fmt.Errorf("instance %q %w", title, errTitleNotFound)
+	}
+	data, err := diskListSessions(repoID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range data {
+		if data[i].Title == title {
+			return &data[i], nil
+		}
+	}
+	return nil, fmt.Errorf("instance %q %w", title, errTitleNotFound)
+}
+
+var sessionsWatchCmd = &cobra.Command{
+	Use:   "watch <title>",
+	Short: "Block until a session goes idle (ready for review)",
+	Long: `Watch a session and return when its agent finishes working: exit 0 the moment
+the session goes IDLE (the agent stopped working and is awaiting input), so an
+operator or root agent can dispatch a session and be notified on completion
+instead of polling 'af sessions preview'.
+
+Polls the daemon's snapshot (the same read path as 'af sessions get') every
+--interval (default 2s). Exits non-zero if the session reaches a terminal state
+it can't leave on its own (lost, dead, or archived), if it disappears (killed),
+or if --timeout elapses first (default 30m). A session that is still working, a
+usage-limit block that auto-resumes, or a create/archive/restore in progress all
+keep the watch waiting.
+
+By default prints a concise line on transition; with --json emits the final
+session record. Honors --repo to scope the title lookup to one repository.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		title := args[0]
+
+		if watchIntervalFlag <= 0 {
+			return jsonError(fmt.Errorf("--interval must be positive, got %s", watchIntervalFlag))
+		}
+
+		repoID, err := resolveRepoID()
+		if err != nil {
+			return jsonError(err)
+		}
+
+		data, err := watchForReady(watchDeps{
+			get:      func(t string) (*session.InstanceData, error) { return getSessionByTitleInScope(repoID, t) },
+			interval: watchIntervalFlag,
+			timeout:  watchTimeoutFlag,
+			now:      time.Now,
+			sleep:    time.Sleep,
+		}, title)
+		if err != nil {
+			return jsonError(err)
+		}
+
+		if envelopeOutput {
+			return jsonOut(data)
+		}
+		fmt.Printf("session %q is idle (ready for review)\n", title)
+		return nil
+	},
+}

--- a/api/sessions_watch_test.go
+++ b/api/sessions_watch_test.go
@@ -81,6 +81,32 @@ func TestClassifyWatch(t *testing.T) {
 	}
 }
 
+// TestValidateWatchFlags guards the duration-flag edge cases the parser accepts
+// but the command must reject: a non-positive interval, and a negative timeout
+// that would otherwise be indistinguishable from 0 ("wait forever") in the loop.
+func TestValidateWatchFlags(t *testing.T) {
+	cases := []struct {
+		name     string
+		interval time.Duration
+		timeout  time.Duration
+		wantErr  bool
+	}{
+		{"ok", 2 * time.Second, 30 * time.Minute, false},
+		{"zero-timeout-waits-forever", 2 * time.Second, 0, false},
+		{"zero-interval", 0, 30 * time.Minute, true},
+		{"negative-interval", -1 * time.Second, 30 * time.Minute, true},
+		{"negative-timeout", 2 * time.Second, -1 * time.Minute, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateWatchFlags(tc.interval, tc.timeout)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("validateWatchFlags(%s, %s) err=%v, wantErr=%v", tc.interval, tc.timeout, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestWatchForReady_GreenTransition: a session that works for several polls then
 // goes idle exits 0 and returns the final ready snapshot.
 func TestWatchForReady_GreenTransition(t *testing.T) {

--- a/api/sessions_watch_test.go
+++ b/api/sessions_watch_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// virtualClock is a deterministic clock for the watch loop: sleep() advances a
+// monotonic virtual now, so timeout behavior is exact and tests never touch the
+// wall clock.
+type virtualClock struct{ now time.Time }
+
+func newVirtualClock() *virtualClock          { return &virtualClock{now: time.Unix(0, 0)} }
+func (c *virtualClock) Now() time.Time        { return c.now }
+func (c *virtualClock) Sleep(d time.Duration) { c.now = c.now.Add(d) }
+
+// seqGetter returns each supplied snapshot in turn, repeating the last one
+// forever once the sequence is exhausted (so a pending-forever session drives
+// the timeout path). A nil entry means "return errTitleNotFound".
+func seqGetter(seq []*session.InstanceData) func(string) (*session.InstanceData, error) {
+	i := 0
+	return func(string) (*session.InstanceData, error) {
+		var d *session.InstanceData
+		if i < len(seq) {
+			d = seq[i]
+			i++
+		} else if len(seq) > 0 {
+			d = seq[len(seq)-1]
+		}
+		if d == nil {
+			return nil, fmt.Errorf("instance %q %w", "x", errTitleNotFound)
+		}
+		return d, nil
+	}
+}
+
+func running() *session.InstanceData {
+	return &session.InstanceData{Title: "x", Liveness: session.LiveRunning, Status: session.Running}
+}
+func ready() *session.InstanceData {
+	return &session.InstanceData{Title: "x", Liveness: session.LiveReady, Status: session.Ready}
+}
+
+func TestClassifyWatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		data    *session.InstanceData
+		want    watchOutcome
+		wantSub string // substring the reason must contain (terminal cases)
+	}{
+		{"ready", ready(), watchReady, "ready for review"},
+		{"running", running(), watchPending, ""},
+		{"limit-reached", &session.InstanceData{Liveness: session.LiveLimitReached}, watchPending, ""},
+		{"lost", &session.InstanceData{Liveness: session.LiveLost}, watchTerminal, "lost"},
+		{"dead", &session.InstanceData{Liveness: session.LiveDead}, watchTerminal, "dead"},
+		{"archived", &session.InstanceData{Liveness: session.LiveArchived}, watchTerminal, "archived"},
+		// An in-flight op overlays the liveness: still settling, keep polling even
+		// though the underlying liveness (Ready) would otherwise read as done.
+		{"archiving-op", &session.InstanceData{Liveness: session.LiveReady, InFlightOp: session.OpArchiving}, watchPending, ""},
+		{"creating-op", &session.InstanceData{Liveness: session.LivenessUnset, InFlightOp: session.OpCreating}, watchPending, ""},
+		// Pre-#1195 record: no liveness axis, classify from the legacy Status.
+		{"legacy-ready", &session.InstanceData{Liveness: session.LivenessUnset, Status: session.Ready}, watchReady, "ready for review"},
+		{"legacy-running", &session.InstanceData{Liveness: session.LivenessUnset, Status: session.Running}, watchPending, ""},
+		{"legacy-lost", &session.InstanceData{Liveness: session.LivenessUnset, Status: session.Lost}, watchTerminal, "lost"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := classifyWatch(tc.data)
+			if got != tc.want {
+				t.Fatalf("classifyWatch = %v, want %v", got, tc.want)
+			}
+			if tc.wantSub != "" && !strings.Contains(reason, tc.wantSub) {
+				t.Fatalf("reason %q does not contain %q", reason, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestWatchForReady_GreenTransition: a session that works for several polls then
+// goes idle exits 0 and returns the final ready snapshot.
+func TestWatchForReady_GreenTransition(t *testing.T) {
+	clk := newVirtualClock()
+	seq := []*session.InstanceData{running(), running(), running(), ready()}
+	got, err := watchForReady(watchDeps{
+		get:      seqGetter(seq),
+		interval: 2 * time.Second,
+		timeout:  30 * time.Minute,
+		now:      clk.Now,
+		sleep:    clk.Sleep,
+	}, "x")
+	if err != nil {
+		t.Fatalf("expected nil error on green transition, got: %v", err)
+	}
+	if got == nil || got.Liveness != session.LiveReady {
+		t.Fatalf("expected final ready snapshot, got %+v", got)
+	}
+}
+
+// TestWatchForReady_Terminal: lost/dead/archived each stop the watch immediately
+// with a non-nil error naming the reason.
+func TestWatchForReady_Terminal(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		lv      session.Liveness
+		wantSub string
+	}{
+		{"lost", session.LiveLost, "lost"},
+		{"dead", session.LiveDead, "dead"},
+		{"archived", session.LiveArchived, "archived"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clk := newVirtualClock()
+			seq := []*session.InstanceData{running(), {Title: "x", Liveness: tc.lv}}
+			_, err := watchForReady(watchDeps{
+				get:      seqGetter(seq),
+				interval: 2 * time.Second,
+				timeout:  30 * time.Minute,
+				now:      clk.Now,
+				sleep:    clk.Sleep,
+			}, "x")
+			if err == nil {
+				t.Fatalf("expected non-nil error for terminal %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q does not mention %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestWatchForReady_Timeout: a session that never leaves Running exits non-zero
+// once the window elapses, and does so in exactly timeout/interval polls (the
+// virtual clock makes this exact).
+func TestWatchForReady_Timeout(t *testing.T) {
+	clk := newVirtualClock()
+	polls := 0
+	get := func(string) (*session.InstanceData, error) {
+		polls++
+		return running(), nil
+	}
+	_, err := watchForReady(watchDeps{
+		get:      get,
+		interval: 2 * time.Second,
+		timeout:  10 * time.Second,
+		now:      clk.Now,
+		sleep:    clk.Sleep,
+	}, "x")
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") || !strings.Contains(err.Error(), "working") {
+		t.Fatalf("expected a timeout-while-working error, got: %v", err)
+	}
+	// Polls at t=0,2,4,6,8,10s: the sixth poll sees elapsed==timeout and exits.
+	if polls != 6 {
+		t.Fatalf("expected 6 polls for a 10s/2s window, got %d", polls)
+	}
+}
+
+// TestWatchForReady_UnknownTitle: a title that never resolves surfaces the plain
+// not-found sentinel (never the "disappeared" variant).
+func TestWatchForReady_UnknownTitle(t *testing.T) {
+	clk := newVirtualClock()
+	_, err := watchForReady(watchDeps{
+		get:      seqGetter([]*session.InstanceData{nil}),
+		interval: 2 * time.Second,
+		timeout:  30 * time.Minute,
+		now:      clk.Now,
+		sleep:    clk.Sleep,
+	}, "x")
+	if err == nil {
+		t.Fatalf("expected not-found error for unknown title")
+	}
+	if !errors.Is(err, errTitleNotFound) {
+		t.Fatalf("expected errTitleNotFound sentinel, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "disappeared") {
+		t.Fatalf("unknown title should not report 'disappeared', got: %v", err)
+	}
+}
+
+// TestWatchForReady_DisappearsMidWatch: a session that existed and then vanishes
+// (killed) reports a distinct "disappeared" error, not a bare not-found.
+func TestWatchForReady_DisappearsMidWatch(t *testing.T) {
+	clk := newVirtualClock()
+	_, err := watchForReady(watchDeps{
+		get:      seqGetter([]*session.InstanceData{running(), running(), nil}),
+		interval: 2 * time.Second,
+		timeout:  30 * time.Minute,
+		now:      clk.Now,
+		sleep:    clk.Sleep,
+	}, "x")
+	if err == nil {
+		t.Fatalf("expected error when session disappears mid-watch")
+	}
+	if !strings.Contains(err.Error(), "disappeared") {
+		t.Fatalf("expected a 'disappeared' error, got: %v", err)
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -44,6 +44,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af sessions tabs`](#af-sessions-tabs) — Manage a session's process tabs (create/delete)
 - [`af sessions tabs create`](#af-sessions-tabs-create) — Spawn a process tab running a command in a session's worktree
 - [`af sessions tabs delete`](#af-sessions-tabs-delete) — Delete a single tab from a session
+- [`af sessions watch`](#af-sessions-watch) — Block until a session goes idle (ready for review)
 - [`af sessions whoami`](#af-sessions-whoami) — Identify the current Agent Factory session
 - [`af tasks`](#af-tasks) — Manage tasks
 - [`af tasks add`](#af-tasks-add) — Add a new task
@@ -574,6 +575,7 @@ af sessions
 - [`af sessions tab-create`](#af-sessions-tab-create) — Spawn a process tab running a command in a session's worktree
 - [`af sessions tab-delete`](#af-sessions-tab-delete) — Delete a single tab from a session
 - [`af sessions tabs`](#af-sessions-tabs) — Manage a session's process tabs (create/delete)
+- [`af sessions watch`](#af-sessions-watch) — Block until a session goes idle (ready for review)
 - [`af sessions whoami`](#af-sessions-whoami) — Identify the current Agent Factory session
 
 **Flags**
@@ -944,6 +946,43 @@ af sessions tabs delete <title> [flags]
 | Flag | Type | Description |
 |------|------|-------------|
 | `--name` | `string` | Name of the tab to delete (required) |
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
+| `--repo` | `string` | Path to git repository |
+
+## af sessions watch
+
+Block until a session goes idle (ready for review)
+
+Watch a session and return when its agent finishes working: exit 0 the moment
+the session goes IDLE (the agent stopped working and is awaiting input), so an
+operator or root agent can dispatch a session and be notified on completion
+instead of polling 'af sessions preview'.
+
+Polls the daemon's snapshot (the same read path as 'af sessions get') every
+--interval (default 2s). Exits non-zero if the session reaches a terminal state
+it can't leave on its own (lost, dead, or archived), if it disappears (killed),
+or if --timeout elapses first (default 30m). A session that is still working, a
+usage-limit block that auto-resumes, or a create/archive/restore in progress all
+keep the watch waiting.
+
+By default prints a concise line on transition; with --json emits the final
+session record. Honors --repo to scope the title lookup to one repository.
+
+```
+af sessions watch <title> [flags]
+```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--interval` | `duration` | How often to poll the session's status (default `2s`) |
+| `--timeout` | `duration` | Give up and exit non-zero if the session is not idle within this window (0 = wait forever) (default `30m0s`) |
 
 **Global flags**
 

--- a/session/systemprompt.go
+++ b/session/systemprompt.go
@@ -13,7 +13,7 @@ import (
 // (agentskill.go), and the aider --read context file — so no surface can drift
 // (#1043). Keep it complete but terse: every user-facing command group (sessions,
 // tabs, tasks, daemon, maintenance), no boilerplate.
-const afUsageReference = `You are running inside Agent Factory (af), a terminal multiplexer that runs each AI coding agent in an isolated git worktree. Manage sessions, tasks, and the daemon with the "af" CLI. Commands print JSON on stdout; run "af <command> --help" for full flag lists. To target another repository, pass --repo <path>: honored by sessions create/list/send-prompt/kill/attach/tab-create/tab-delete/archive/restore and tasks list/add. Two commands accept --repo but SILENTLY IGNORE it — "sessions get" and "sessions preview" always resolve the title across ALL repos, so with the same title in two repos you may get the wrong one regardless of --repo; disambiguate by using unique titles. tasks get/update/trigger/remove take a globally unique id (no --repo needed).
+const afUsageReference = `You are running inside Agent Factory (af), a terminal multiplexer that runs each AI coding agent in an isolated git worktree. Manage sessions, tasks, and the daemon with the "af" CLI. Commands print JSON on stdout; run "af <command> --help" for full flag lists. To target another repository, pass --repo <path>: honored by sessions create/list/send-prompt/kill/attach/tab-create/tab-delete/archive/restore/watch and tasks list/add. Two commands accept --repo but SILENTLY IGNORE it — "sessions get" and "sessions preview" always resolve the title across ALL repos, so with the same title in two repos you may get the wrong one regardless of --repo; disambiguate by using unique titles. tasks get/update/trigger/remove take a globally unique id (no --repo needed).
 
 Sessions (one agent per isolated worktree):
   af sessions whoami                                   Identify your own session
@@ -22,6 +22,7 @@ Sessions (one agent per isolated worktree):
   af sessions create --name <title> [--prompt <p>] [--program claude|codex|aider|gemini|amp]
   af sessions send-prompt <title> <prompt> [--create]  Send a prompt (--create makes the session first if missing)
   af sessions preview <title>                          Snapshot another session's terminal output
+  af sessions watch <title>                            Block until the session goes idle (agent done, ready for review); exits 0 when ready, non-zero on lost/dead/archived or --timeout (default 30m)
   af sessions attach <title>                           Attach interactively (foreground)
   af sessions kill <title>                             Kill a session and clean up its worktree
   af sessions archive <title>                          Archive (tmux down, worktree moved out; restartable)


### PR DESCRIPTION
Closes #1617.

## What

Adds `af sessions watch <title>` — a blocking command that polls the daemon snapshot (the same non-spawning read path as `af sessions get`) and **exits 0 the moment the session's agent goes IDLE** (`LiveReady` — done working, awaiting input). Operators and root agents can now dispatch-and-wait instead of hand-rolling a `sessions preview` poll loop.

## State machine (`classifyWatch`)

Reads the canonical two-axis state (#1195); falls back to the composed legacy `Status` for pre-#1195 records:

| Snapshot state | Outcome |
|---|---|
| `LiveReady` | **exit 0** — prints `session "X" is idle (ready for review)` |
| `LiveRunning`, usage-limit-blocked (auto-resumes, #1146), any in-flight create/kill/archive/restore op | keep polling |
| `LiveLost` / `LiveDead` / `LiveArchived` | exit non-zero with an actionable reason |
| unknown title | exit non-zero (not found) |
| existed then vanished mid-watch (killed) | exit non-zero (distinct "disappeared" message) |
| `--timeout` elapses while still pending | exit non-zero, naming the stuck state |

## Flags

- `--timeout <dur>` — default `30m`; `0` waits forever.
- `--interval <dur>` — poll cadence, default `2s`.
- `--json` — emit the final session record via the shared `{data,error}` envelope (consistent with other sessions commands); default prints the concise human line.
- `--repo` — honored, scoping the title lookup (unlike `get`/`preview`, which resolve across all repos).

## Tests

The poll loop takes injectable `now`/`sleep`, so the timeout path is unit-tested deterministically with a virtual clock (exact poll counts, no wall-clock flakiness):
- `classifyWatch` table across every liveness / in-flight-op / legacy-Status case
- green transition after several working polls → exit 0
- Lost / Dead / Archived → non-zero with reason
- timeout → non-zero (exact 6 polls for a 10s/2s window)
- unknown title → not-found sentinel; vanished-mid-watch → distinct error

## Docs

`session/systemprompt.go` afUsageReference (agents learn the command + that it honors `--repo`), cobra help, and the regenerated `docs/reference/cli.md`.

## Verification

- `gofmt -l .`, `go build ./...`, `golangci-lint run --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean.
- `make test-container` — full suite green; `make tui-driver-selftest` — 25/25.
- Exercised read-only against the live daemon: idle session → exit 0 + human line + `--json` envelope; archived session → non-zero with reason; unknown title → non-zero; a busy session → correct `--timeout` non-zero ("still working").

_Captain Claude_

🤖 Generated with [Claude Code](https://claude.com/claude-code)