### PR TITLE
feat(agentproto): Phase 2 PR1 — wire protocol foundation (#1592)

### DIFF
--- a/agentproto/auth.go
+++ b/agentproto/auth.go
@@ -1,0 +1,58 @@
+package agentproto
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Auth material rides the transport, never the payload (§4.4). Sachin locked the
+// Phase-3 model to a single bearer token = full access (no mTLS/OIDC/per-user).
+// Phase 2 defines the seam and enforces nothing: over the unix socket the peer is
+// trusted (filesystem perms are the auth, #1029), so BearerToken/TokenFrom* only
+// EXTRACT a token — Phase 3 fills in the constant-time compare without reshaping a
+// single message.
+const (
+	// AuthHeader is the REST + WS request header carrying the token.
+	AuthHeader = "Authorization"
+	// BearerScheme is the Authorization scheme prefix (note the trailing space).
+	BearerScheme = "Bearer "
+	// AccessTokenQueryParam is the WS query-param fallback. Browsers cannot set
+	// request headers on a WebSocket handshake, so the token rides the URL for the
+	// web client (§4.4); it must be part of the design now, not retrofitted.
+	AccessTokenQueryParam = "access_token"
+)
+
+// BearerToken extracts the token from an Authorization header value, matching the
+// scheme case-insensitively. It returns "" when the value is absent or not a
+// bearer credential. No validation or enforcement — that is Phase 3.
+func BearerToken(headerValue string) string {
+	if len(headerValue) < len(BearerScheme) {
+		return ""
+	}
+	if !strings.EqualFold(headerValue[:len(BearerScheme)], BearerScheme) {
+		return ""
+	}
+	return strings.TrimSpace(headerValue[len(BearerScheme):])
+}
+
+// AccessTokenFromQuery reads the ?access_token= WS/browser fallback from parsed
+// query values, returning "" when absent.
+func AccessTokenFromQuery(q url.Values) string {
+	return q.Get(AccessTokenQueryParam)
+}
+
+// TokenFromRequest extracts the bearer token an incoming REST or WS request
+// presents, preferring the Authorization header and falling back to the
+// ?access_token= query param (the browser WS path). It returns "" when neither is
+// present. Pure extraction; the caller's auth middleware decides what to do with
+// it (a no-op in Phase 2).
+func TokenFromRequest(r *http.Request) string {
+	if tok := BearerToken(r.Header.Get(AuthHeader)); tok != "" {
+		return tok
+	}
+	if r.URL != nil {
+		return AccessTokenFromQuery(r.URL.Query())
+	}
+	return ""
+}

--- a/agentproto/auth_test.go
+++ b/agentproto/auth_test.go
@@ -1,0 +1,69 @@
+package agentproto
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestBearerToken(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"standard", "Bearer abc123", "abc123"},
+		{"case_insensitive_scheme", "bearer abc123", "abc123"},
+		{"trims_space", "Bearer   abc123  ", "abc123"},
+		{"empty", "", ""},
+		{"no_scheme", "abc123", ""},
+		{"wrong_scheme", "Basic abc123", ""},
+		{"scheme_only", "Bearer ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BearerToken(tc.in); got != tc.want {
+				t.Errorf("BearerToken(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAccessTokenFromQuery(t *testing.T) {
+	q := url.Values{}
+	q.Set(AccessTokenQueryParam, "tok-xyz")
+	if got := AccessTokenFromQuery(q); got != "tok-xyz" {
+		t.Errorf("AccessTokenFromQuery = %q, want %q", got, "tok-xyz")
+	}
+	if got := AccessTokenFromQuery(url.Values{}); got != "" {
+		t.Errorf("AccessTokenFromQuery(empty) = %q, want empty", got)
+	}
+}
+
+func TestTokenFromRequest(t *testing.T) {
+	// Header path.
+	r := &http.Request{Header: http.Header{}, URL: &url.URL{}}
+	r.Header.Set(AuthHeader, "Bearer header-tok")
+	if got := TokenFromRequest(r); got != "header-tok" {
+		t.Errorf("header path = %q, want header-tok", got)
+	}
+
+	// Query fallback (the browser WS path — no header).
+	r2 := &http.Request{Header: http.Header{}, URL: &url.URL{RawQuery: AccessTokenQueryParam + "=query-tok"}}
+	if got := TokenFromRequest(r2); got != "query-tok" {
+		t.Errorf("query fallback = %q, want query-tok", got)
+	}
+
+	// Header wins over query when both are present.
+	r3 := &http.Request{Header: http.Header{}, URL: &url.URL{RawQuery: AccessTokenQueryParam + "=query-tok"}}
+	r3.Header.Set(AuthHeader, "Bearer header-tok")
+	if got := TokenFromRequest(r3); got != "header-tok" {
+		t.Errorf("header precedence = %q, want header-tok", got)
+	}
+
+	// Neither present.
+	r4 := &http.Request{Header: http.Header{}, URL: &url.URL{}}
+	if got := TokenFromRequest(r4); got != "" {
+		t.Errorf("no auth = %q, want empty", got)
+	}
+}

--- a/agentproto/doc.go
+++ b/agentproto/doc.go
@@ -1,0 +1,47 @@
+// Package agentproto holds the neutral wire types for the Phase 2 agent-server
+// protocol (#1592): the binary PTY frame codec, the JSON control/event messages,
+// and the auth-handshake helpers a bearer token rides on.
+//
+// It is a leaf, exactly like apiproto. The daemon will import it for the WS PTY
+// broker and events plane (Phase 2 PR5), and the TUI/CLI/web clients import it to
+// speak the same wire format; so agentproto must depend on NEITHER daemon nor any
+// client package, or those importers would form a cycle. It imports only the
+// standard library and github.com/coder/websocket.
+//
+// # Reuse, not re-declaration, of the control plane
+//
+// The control plane stays the #1029 REST mirror: POST /v1/<Method> with the
+// apiproto.Envelope wrapper, whose bodies are the daemon RPC request/response
+// structs (daemon.CreateSessionRequest, daemon.KillSessionRequest, …) — those
+// already carry json tags for the HTTP server. agentproto deliberately does NOT
+// mirror, alias, or re-declare any of them: a second copy could drift from the
+// authoritative one, and importing the daemon package here would create the
+// import cycle described above. The control action contract therefore has exactly
+// one definition, in package daemon, and this package adds only what is genuinely
+// new to Phase 2 — the PTY data plane, the resize/exit/detach control frames, the
+// events plane, and the auth-readiness seam.
+//
+// # Multi-writer, no lease
+//
+// Sachin's decision supersedes the design doc's attach-lease sections (§3-Q3 /
+// §4.2): af is single-owner, so every WS subscriber is an equal read-write client
+// and the server accepts INPUT/RESIZE from any of them — there is no lease,
+// interactive/observer mode, or NACK. The one real multi-client conflict, terminal
+// size, is resolved by last-resize-wins plus the authoritative MsgResize echo. A
+// lease could be layered on later as purely additive advisory frames without
+// reshaping anything here; it is deliberately not built now.
+//
+// # What is defined here
+//
+//   - frame.go   — binary PTY frames: PTY_OUT / INPUT / RESIZE opcodes + codec.
+//   - message.go — JSON control frames (resize/exit/detach) carried as WS text
+//     frames on the PTY stream, and the events-plane Event envelope.
+//   - auth.go    — transport-carried bearer-token extraction (Authorization
+//     header + ?access_token= query fallback per §4.4). Types and pure helpers
+//     only; Phase 2 enforces nothing (the unix-socket peer is trusted, #1029).
+//   - wsconn.go  — thin read/write adapters that move the above over a
+//     github.com/coder/websocket connection.
+//
+// Nothing in production imports this package yet; Phase 2 PR1 is purely additive
+// scaffolding, unit-tested in isolation.
+package agentproto

--- a/agentproto/frame.go
+++ b/agentproto/frame.go
@@ -1,0 +1,109 @@
+package agentproto
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Opcode is the first byte of a binary WS frame on the PTY stream (§4.2). The
+// opcode discriminates the payload so the hot path carries raw PTY bytes without
+// the base64/JSON bloat a text frame would impose.
+type Opcode byte
+
+const (
+	// OpPTYOut (server → client) prefixes verbatim PTY output bytes. The client
+	// feeds them to its terminal emulator (ui/termpane, xterm.js); the server
+	// never renders a grid.
+	OpPTYOut Opcode = 0x00
+	// OpInput (client → server) prefixes raw key bytes. Multi-writer: the server
+	// accepts input from ANY connected client — there is no lease gating (§4.2,
+	// superseded by Sachin's multi-writer decision).
+	OpInput Opcode = 0x01
+	// OpResize (client → server) carries a rows,cols uint16 pair (see
+	// resizePayloadLen) from any connected client; the server applies
+	// last-resize-wins and echoes the authoritative size back as a ResizeMessage.
+	OpResize Opcode = 0x02
+)
+
+// resizePayloadLen is the fixed body size of an OpResize frame: two big-endian
+// uint16s, rows then cols.
+const resizePayloadLen = 4
+
+// String renders an opcode for diagnostics.
+func (o Opcode) String() string {
+	switch o {
+	case OpPTYOut:
+		return "PTY_OUT"
+	case OpInput:
+		return "INPUT"
+	case OpResize:
+		return "RESIZE"
+	default:
+		return fmt.Sprintf("Opcode(0x%02x)", byte(o))
+	}
+}
+
+// Frame is a decoded binary PTY frame. For OpPTYOut and OpInput the payload is in
+// Data; for OpResize the size is in Rows/Cols and Data is nil. Build frames with
+// PTYOutFrame/InputFrame/ResizeFrame and serialize with Encode; DecodeFrame is the
+// inverse, so DecodeFrame(f.Encode()) round-trips f.
+type Frame struct {
+	Op   Opcode
+	Data []byte // OpPTYOut, OpInput: raw payload. OpResize: nil.
+	Rows uint16 // OpResize only.
+	Cols uint16 // OpResize only.
+}
+
+// PTYOutFrame wraps verbatim PTY output bytes (server → client).
+func PTYOutFrame(b []byte) Frame { return Frame{Op: OpPTYOut, Data: b} }
+
+// InputFrame wraps raw key bytes (client → server, accepted from any client).
+func InputFrame(b []byte) Frame { return Frame{Op: OpInput, Data: b} }
+
+// ResizeFrame wraps a terminal size (client → server, accepted from any client;
+// last-resize-wins).
+func ResizeFrame(rows, cols uint16) Frame {
+	return Frame{Op: OpResize, Rows: rows, Cols: cols}
+}
+
+// Encode serializes the frame to its opcode-prefixed wire form.
+func (f Frame) Encode() []byte {
+	switch f.Op {
+	case OpResize:
+		out := make([]byte, 1+resizePayloadLen)
+		out[0] = byte(OpResize)
+		binary.BigEndian.PutUint16(out[1:3], f.Rows)
+		binary.BigEndian.PutUint16(out[3:5], f.Cols)
+		return out
+	default:
+		out := make([]byte, 1+len(f.Data))
+		out[0] = byte(f.Op)
+		copy(out[1:], f.Data)
+		return out
+	}
+}
+
+// DecodeFrame parses an opcode-prefixed binary frame. It errors on an empty frame,
+// an unknown opcode, or a malformed OpResize body.
+func DecodeFrame(raw []byte) (Frame, error) {
+	if len(raw) == 0 {
+		return Frame{}, fmt.Errorf("agentproto: empty binary frame")
+	}
+	op := Opcode(raw[0])
+	body := raw[1:]
+	switch op {
+	case OpPTYOut, OpInput:
+		return Frame{Op: op, Data: body}, nil
+	case OpResize:
+		if len(body) != resizePayloadLen {
+			return Frame{}, fmt.Errorf("agentproto: RESIZE frame body is %d bytes, want %d", len(body), resizePayloadLen)
+		}
+		return Frame{
+			Op:   OpResize,
+			Rows: binary.BigEndian.Uint16(body[0:2]),
+			Cols: binary.BigEndian.Uint16(body[2:4]),
+		}, nil
+	default:
+		return Frame{}, fmt.Errorf("agentproto: unknown opcode 0x%02x", byte(op))
+	}
+}

--- a/agentproto/frame_test.go
+++ b/agentproto/frame_test.go
@@ -1,0 +1,91 @@
+package agentproto
+
+import (
+	"bytes"
+	"testing"
+)
+
+// frameEqual compares two frames, treating nil and empty Data as equal (Encode of
+// an empty payload and DecodeFrame of a 1-byte frame differ only in nil-ness).
+func frameEqual(a, b Frame) bool {
+	return a.Op == b.Op && a.Rows == b.Rows && a.Cols == b.Cols && bytes.Equal(a.Data, b.Data)
+}
+
+func TestFrameRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Frame
+	}{
+		{"pty_out", PTYOutFrame([]byte("hello \x1b[31mworld\x1b[0m\r\n"))},
+		{"pty_out_empty", PTYOutFrame(nil)},
+		{"pty_out_binary", PTYOutFrame([]byte{0x00, 0x01, 0x02, 0xff, 0xfe})},
+		{"input", InputFrame([]byte("ls -la\n"))},
+		{"input_ctrl", InputFrame([]byte{0x03})}, // Ctrl-C
+		{"resize", ResizeFrame(24, 80)},
+		{"resize_zero", ResizeFrame(0, 0)},
+		{"resize_max", ResizeFrame(65535, 65535)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecodeFrame(tc.in.Encode())
+			if err != nil {
+				t.Fatalf("DecodeFrame(Encode()) error: %v", err)
+			}
+			if !frameEqual(got, tc.in) {
+				t.Fatalf("round-trip mismatch:\n in  = %+v\n got = %+v", tc.in, got)
+			}
+		})
+	}
+}
+
+func TestFrameEncodeWireBytes(t *testing.T) {
+	// Opcode is the first byte; the wire layout is load-bearing (public contract).
+	if b := PTYOutFrame([]byte("ab")).Encode(); !bytes.Equal(b, []byte{0x00, 'a', 'b'}) {
+		t.Errorf("PTY_OUT wire bytes = % x", b)
+	}
+	if b := InputFrame([]byte("ab")).Encode(); !bytes.Equal(b, []byte{0x01, 'a', 'b'}) {
+		t.Errorf("INPUT wire bytes = % x", b)
+	}
+	// RESIZE: opcode, then rows (big-endian uint16), then cols (big-endian uint16).
+	if b := ResizeFrame(24, 80).Encode(); !bytes.Equal(b, []byte{0x02, 0x00, 24, 0x00, 80}) {
+		t.Errorf("RESIZE wire bytes = % x", b)
+	}
+	if b := ResizeFrame(258, 259).Encode(); !bytes.Equal(b, []byte{0x02, 0x01, 0x02, 0x01, 0x03}) {
+		t.Errorf("RESIZE wire bytes = % x", b)
+	}
+}
+
+func TestDecodeFrameErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{"empty", nil},
+		{"unknown_opcode", []byte{0x7f, 'x'}},
+		{"resize_too_short", []byte{byte(OpResize), 0x00, 24}},
+		{"resize_too_long", []byte{byte(OpResize), 0, 24, 0, 80, 0}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := DecodeFrame(tc.raw); err == nil {
+				t.Fatalf("DecodeFrame(% x) = nil error, want error", tc.raw)
+			}
+		})
+	}
+}
+
+func TestOpcodeString(t *testing.T) {
+	for _, tc := range []struct {
+		op   Opcode
+		want string
+	}{
+		{OpPTYOut, "PTY_OUT"},
+		{OpInput, "INPUT"},
+		{OpResize, "RESIZE"},
+		{Opcode(0x42), "Opcode(0x42)"},
+	} {
+		if got := tc.op.String(); got != tc.want {
+			t.Errorf("Opcode(%#x).String() = %q, want %q", byte(tc.op), got, tc.want)
+		}
+	}
+}

--- a/agentproto/message.go
+++ b/agentproto/message.go
@@ -1,0 +1,121 @@
+package agentproto
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// MessageType is the discriminator of a JSON control frame carried as a WS text
+// frame on the PTY stream (§4.2). Binary frames (frame.go) carry the hot path;
+// these text frames carry size/lifecycle control.
+//
+// Multi-writer model (Sachin, supersedes the design doc's lease sections §3-Q3 /
+// §4.2): af is single-owner, so there is NO attach lease and no interactive/observer
+// distinction — every WS subscriber is an equal read-write client, and the server
+// accepts INPUT/RESIZE from any of them. The only genuine multi-client conflict is
+// terminal size (one PTY, one size), handled by last-resize-wins + an authoritative
+// echo (MsgResize), not a lease. A lease could be re-introduced later as purely
+// additive advisory frames without reshaping anything defined here; it is
+// deliberately not built now.
+type MessageType string
+
+const (
+	// MsgResize (server → client) is the authoritative size echo. The server sizes
+	// the PTY to the MOST RECENT RESIZE it received (last-resize-wins) and echoes
+	// that authoritative size so every other client reflows its emulator to match.
+	MsgResize MessageType = "resize"
+	// MsgExit (server → client) reports that the agent/PTY ended.
+	MsgExit MessageType = "exit"
+	// MsgDetach (client → server) is a clean-close signal; also implicit on socket
+	// close.
+	MsgDetach MessageType = "detach"
+)
+
+// ResizeMessage is the server's authoritative size echo (last-resize-wins, §6.2).
+type ResizeMessage struct {
+	Type MessageType `json:"type"`
+	Rows uint16      `json:"rows"`
+	Cols uint16      `json:"cols"`
+}
+
+// NewResizeMessage builds a size echo.
+func NewResizeMessage(rows, cols uint16) ResizeMessage {
+	return ResizeMessage{Type: MsgResize, Rows: rows, Cols: cols}
+}
+
+// ExitMessage reports the agent/PTY end code.
+type ExitMessage struct {
+	Type MessageType `json:"type"`
+	Code int         `json:"code"`
+}
+
+// NewExitMessage builds an exit notice.
+func NewExitMessage(code int) ExitMessage {
+	return ExitMessage{Type: MsgExit, Code: code}
+}
+
+// DetachMessage is a client's clean-close signal.
+type DetachMessage struct {
+	Type MessageType `json:"type"`
+}
+
+// NewDetachMessage builds a detach request.
+func NewDetachMessage() DetachMessage {
+	return DetachMessage{Type: MsgDetach}
+}
+
+// MessageTypeOf peeks the "type" discriminator of a JSON control frame so a reader
+// can pick the concrete struct to unmarshal into.
+func MessageTypeOf(raw []byte) (MessageType, error) {
+	var env struct {
+		Type MessageType `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return "", fmt.Errorf("agentproto: decode control frame: %w", err)
+	}
+	if env.Type == "" {
+		return "", fmt.Errorf("agentproto: control frame missing type")
+	}
+	return env.Type, nil
+}
+
+// EventType is the discriminator of an events-plane message (§4.3), the WS/JSON
+// fan-out of session/task state changes served at GET /v1/events. It lets a client
+// replace Snapshot polling with push.
+type EventType string
+
+const (
+	EventSessionCreated  EventType = "session.created"
+	EventSessionUpdated  EventType = "session.updated"
+	EventSessionKilled   EventType = "session.killed"
+	EventSessionArchived EventType = "session.archived"
+	EventSessionRestored EventType = "session.restored"
+	EventTaskCreated     EventType = "task.created"
+	EventTaskUpdated     EventType = "task.updated"
+	EventTaskRemoved     EventType = "task.removed"
+)
+
+// Event is one message on the events plane. Data carries the same projection the
+// existing RPCs return, encoded — deliberately as a raw payload rather than a
+// typed field, so agentproto stays a leaf (no session/task import). By contract a
+// session.* event's Data is a marshaled session.InstanceData (the Snapshot
+// projection) and a task.* event's Data is a marshaled task.Task; the daemon
+// encodes it and the client decodes it into those authoritative types.
+type Event struct {
+	Type EventType       `json:"type"`
+	Data json.RawMessage `json:"data,omitempty"`
+}
+
+// NewEvent builds an event, marshaling payload into Data. A nil payload yields an
+// event with no data member (e.g. a delete signalled by id in the type's
+// convention, or a bare heartbeat).
+func NewEvent(t EventType, payload any) (Event, error) {
+	if payload == nil {
+		return Event{Type: t}, nil
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return Event{}, fmt.Errorf("agentproto: marshal %s event: %w", t, err)
+	}
+	return Event{Type: t, Data: data}, nil
+}

--- a/agentproto/message_test.go
+++ b/agentproto/message_test.go
@@ -1,0 +1,114 @@
+package agentproto
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestControlMessageWireShapes pins the exact JSON each control frame serializes
+// to — these are a public client-API contract (§4.2), so the bytes are load-bearing.
+func TestControlMessageWireShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  any
+		want string
+	}{
+		{"resize", NewResizeMessage(24, 80), `{"type":"resize","rows":24,"cols":80}`},
+		{"exit", NewExitMessage(0), `{"type":"exit","code":0}`},
+		{"exit_nonzero", NewExitMessage(137), `{"type":"exit","code":137}`},
+		{"detach", NewDetachMessage(), `{"type":"detach"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.msg)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Fatalf("wire shape mismatch:\n got  = %s\n want = %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMessageTypeOf(t *testing.T) {
+	raw, _ := json.Marshal(NewDetachMessage())
+	got, err := MessageTypeOf(raw)
+	if err != nil {
+		t.Fatalf("MessageTypeOf: %v", err)
+	}
+	if got != MsgDetach {
+		t.Fatalf("MessageTypeOf = %q, want %q", got, MsgDetach)
+	}
+
+	// A reader discriminates then unmarshals into the concrete type.
+	rawResize, _ := json.Marshal(NewResizeMessage(40, 120))
+	if tp, _ := MessageTypeOf(rawResize); tp != MsgResize {
+		t.Fatalf("type = %q, want %q", tp, MsgResize)
+	}
+	var rm ResizeMessage
+	if err := json.Unmarshal(rawResize, &rm); err != nil {
+		t.Fatalf("unmarshal resize: %v", err)
+	}
+	if rm.Rows != 40 || rm.Cols != 120 {
+		t.Fatalf("resize decoded to %dx%d, want 40x120", rm.Rows, rm.Cols)
+	}
+}
+
+func TestMessageTypeOfErrors(t *testing.T) {
+	if _, err := MessageTypeOf([]byte(`not json`)); err == nil {
+		t.Error("MessageTypeOf(bad json) = nil error, want error")
+	}
+	if _, err := MessageTypeOf([]byte(`{"rows":24}`)); err == nil {
+		t.Error("MessageTypeOf(no type) = nil error, want error")
+	}
+}
+
+func TestEventRoundTrip(t *testing.T) {
+	// A session.* event carries an opaque projection payload (a marshaled
+	// session.InstanceData by contract); agentproto stays a leaf and treats it as
+	// raw JSON. Use a stand-in payload to prove the envelope round-trips.
+	type projection struct {
+		Title    string `json:"title"`
+		Liveness string `json:"liveness"`
+	}
+	in := projection{Title: "root", Liveness: "running"}
+	ev, err := NewEvent(EventSessionUpdated, in)
+	if err != nil {
+		t.Fatalf("NewEvent: %v", err)
+	}
+
+	wire, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	var decoded Event
+	if err := json.Unmarshal(wire, &decoded); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if decoded.Type != EventSessionUpdated {
+		t.Fatalf("event type = %q, want %q", decoded.Type, EventSessionUpdated)
+	}
+	var out projection
+	if err := json.Unmarshal(decoded.Data, &out); err != nil {
+		t.Fatalf("unmarshal event data: %v", err)
+	}
+	if out != in {
+		t.Fatalf("payload round-trip: got %+v, want %+v", out, in)
+	}
+}
+
+func TestNewEventNilPayload(t *testing.T) {
+	ev, err := NewEvent(EventTaskRemoved, nil)
+	if err != nil {
+		t.Fatalf("NewEvent(nil): %v", err)
+	}
+	if ev.Data != nil {
+		t.Fatalf("nil payload should omit data, got %s", ev.Data)
+	}
+	got, _ := json.Marshal(ev)
+	if string(got) != `{"type":"task.removed"}` {
+		t.Fatalf("nil-payload event = %s", got)
+	}
+}

--- a/agentproto/wsconn.go
+++ b/agentproto/wsconn.go
@@ -1,0 +1,68 @@
+package agentproto
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/coder/websocket"
+)
+
+// This file is the only binding between agentproto's wire types and the WebSocket
+// transport (github.com/coder/websocket — context-aware, zero-dependency, actively
+// maintained; the design's recommended choice, §9.5). The codec (frame.go) and the
+// message types (message.go) stay transport-agnostic; these helpers move them over
+// a *websocket.Conn so the daemon broker and every client share one read/write
+// seam. No connection is opened here — Phase 2 PR1 wires nothing.
+
+// WriteFrame sends a binary PTY frame (PTY_OUT/INPUT/RESIZE) as a WS binary
+// message.
+func WriteFrame(ctx context.Context, c *websocket.Conn, f Frame) error {
+	return c.Write(ctx, websocket.MessageBinary, f.Encode())
+}
+
+// WriteControl marshals a JSON control frame (ResizeMessage, ExitMessage,
+// DetachMessage) or an events-plane Event and sends it as a WS text message.
+func WriteControl(ctx context.Context, c *websocket.Conn, msg any) error {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("agentproto: marshal control frame: %w", err)
+	}
+	return c.Write(ctx, websocket.MessageText, b)
+}
+
+// Message is one decoded frame off the wire: a binary PTY Frame or a JSON control
+// frame. Exactly one of Frame/Text is meaningful, selected by Binary.
+type Message struct {
+	// Binary reports whether this was a binary (PTY) frame; when false it was a
+	// text (JSON control) frame.
+	Binary bool
+	// Frame is the decoded binary frame, valid only when Binary is true.
+	Frame Frame
+	// Text is the raw JSON payload of a control frame, valid only when Binary is
+	// false; pass it to MessageTypeOf to discriminate, then unmarshal.
+	Text []byte
+}
+
+// ReadMessage reads the next WS frame and decodes it. A binary frame is parsed
+// through DecodeFrame; a text frame's raw JSON is returned in Message.Text for the
+// caller to discriminate with MessageTypeOf. It errors on the read itself, on a
+// malformed binary frame, or on an unexpected WS message type.
+func ReadMessage(ctx context.Context, c *websocket.Conn) (Message, error) {
+	typ, data, err := c.Read(ctx)
+	if err != nil {
+		return Message{}, err
+	}
+	switch typ {
+	case websocket.MessageBinary:
+		f, derr := DecodeFrame(data)
+		if derr != nil {
+			return Message{}, derr
+		}
+		return Message{Binary: true, Frame: f}, nil
+	case websocket.MessageText:
+		return Message{Binary: false, Text: data}, nil
+	default:
+		return Message{}, fmt.Errorf("agentproto: unexpected WS message type %v", typ)
+	}
+}

--- a/agentproto/wsconn_test.go
+++ b/agentproto/wsconn_test.go
@@ -1,0 +1,107 @@
+package agentproto
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// TestWSRoundTrip drives the WriteFrame/WriteControl/ReadMessage helpers over a
+// real coder/websocket connection, both directions: server → client PTY bytes +
+// an authoritative resize echo, and client → server an input frame. This proves
+// the wire helpers move the codec's binary frames and the JSON control frames
+// intact.
+func TestWSRoundTrip(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	serverGot := make(chan Message, 1)
+	serverErr := make(chan error, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer c.Close(websocket.StatusInternalError, "")
+
+		// Server → client: a PTY_OUT frame then an authoritative resize echo.
+		if err := WriteFrame(ctx, c, PTYOutFrame([]byte("\x1b[32mready\x1b[0m"))); err != nil {
+			serverErr <- err
+			return
+		}
+		if err := WriteControl(ctx, c, NewResizeMessage(24, 80)); err != nil {
+			serverErr <- err
+			return
+		}
+
+		// Client → server: expect an input frame.
+		msg, err := ReadMessage(ctx, c)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		serverGot <- msg
+		c.Close(websocket.StatusNormalClosure, "")
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[len("http"):]
+	c, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close(websocket.StatusInternalError, "")
+
+	// Read the binary PTY frame.
+	m1, err := ReadMessage(ctx, c)
+	if err != nil {
+		t.Fatalf("read frame: %v", err)
+	}
+	if !m1.Binary || m1.Frame.Op != OpPTYOut || !bytes.Equal(m1.Frame.Data, []byte("\x1b[32mready\x1b[0m")) {
+		t.Fatalf("unexpected first message: %+v", m1)
+	}
+
+	// Read the JSON control frame and discriminate it.
+	m2, err := ReadMessage(ctx, c)
+	if err != nil {
+		t.Fatalf("read control: %v", err)
+	}
+	if m2.Binary {
+		t.Fatalf("expected text control frame, got binary")
+	}
+	if tp, err := MessageTypeOf(m2.Text); err != nil || tp != MsgResize {
+		t.Fatalf("control type = %q (err %v), want resize", tp, err)
+	}
+	var resize ResizeMessage
+	if err := json.Unmarshal(m2.Text, &resize); err != nil {
+		t.Fatalf("unmarshal resize: %v", err)
+	}
+	if resize.Rows != 24 || resize.Cols != 80 {
+		t.Fatalf("resize = %+v, want 24x80", resize)
+	}
+
+	// Client → server: send an input frame and confirm the server decoded it.
+	if err := WriteFrame(ctx, c, InputFrame([]byte("q\n"))); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	select {
+	case got := <-serverGot:
+		if !got.Binary || got.Frame.Op != OpInput || !bytes.Equal(got.Frame.Data, []byte("q\n")) {
+			t.Fatalf("server got %+v, want INPUT q\\n", got)
+		}
+	case err := <-serverErr:
+		t.Fatalf("server error: %v", err)
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for server")
+	}
+
+	c.Close(websocket.StatusNormalClosure, "")
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20260422141420-a6cbdff8a7e2
 	github.com/charmbracelet/x/vt v0.0.0-20260629091435-9c70f75e26a4
+	github.com/coder/websocket v1.8.15
 	github.com/creack/pty v1.1.24
 	github.com/mattn/go-runewidth v0.0.23
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=


### PR DESCRIPTION
## Phase 2 PR1 — protocol foundation (#1592)

The first PR of the #1592 Phase 2 sequence (design: `docs/design/phase2-agent-server.md` §8 PR1). **Purely additive**: a new `agentproto` leaf package holding the agent-server wire protocol. **Nothing wires it yet** — it compiles and is unit-tested in isolation. No `app/`, daemon serving, or TUI changes; no version bump.

### What's defined
- **`frame.go`** — binary PTY frames. Opcodes `PTY_OUT (0x00)` / `INPUT (0x01)` / `RESIZE (0x02)` and an opcode-prefixed codec (`Frame.Encode` / `DecodeFrame`). `RESIZE` body = big-endian `rows,cols` uint16 pair. Round-trips: `DecodeFrame(f.Encode()) == f`.
- **`message.go`** — JSON control frames carried as WS **text** frames (`resize` / `exit` / `detach`) + the events-plane `Event` envelope (`session.*` / `task.*` discriminators). Event payload is opaque `json.RawMessage` (by contract a marshaled `session.InstanceData` / `task.Task`) so the package stays a leaf.
- **`auth.go`** — auth-readiness (§4.4). Bearer-token extraction from the `Authorization` header **plus** the `?access_token=` WS/browser query fallback (browsers can't set WS headers). Types + pure helpers only — **no enforcement** in Phase 2 (unix-socket peer is trusted, #1029). Phase 3 fills `withAuth` with a constant-time compare and reshapes nothing.
- **`wsconn.go`** — thin `WriteFrame` / `WriteControl` / `ReadMessage` adapters over the WS transport, anchoring the dependency and giving the daemon/clients one shared read/write seam.

### Reused vs. new types
The **control plane stays the #1029 REST mirror**, whose bodies are the existing **daemon RPC request/response structs** (`daemon.CreateSessionRequest`, `daemon.KillSessionRequest`, …) — already json-tagged for the HTTP server. `agentproto` **deliberately does not mirror, alias, or re-declare any of them**:
- a second copy could **drift** from the authoritative one, and
- importing `daemon` here would form an **import cycle** — `daemon` imports `agentproto` for the WS PTY broker in PR5.

So the control-action contract has exactly one definition (in `daemon`), and this package adds **only** what's genuinely new to Phase 2: the PTY data plane, the resize/exit/detach control frames, the events plane, and the auth seam. This follows the existing `apiproto` leaf-package precedent (imports neither `daemon` nor clients).

### ⚠️ Supersedes the design doc's lease sections (multi-writer)
Per Sachin's decision, this **supersedes design doc §3-Q3 and the lease parts of §4.2**: **no attach lease — the protocol is multi-writer.** af is single-owner, so gating who-can-type is machinery for a case that ~never happens. Concretely baked into these types:
- Every WS subscriber is an equal **read-write** client; the server accepts `INPUT`/`RESIZE` from **any** connection. No `mode=interactive|observe`, no observer/NACK concept.
- **Dropped** the `{"type":"lease",…}` frame and the `mode` query param.
- **Kept** the authoritative `{"type":"resize",…}` echo — the one real multi-client conflict (one PTY = one size) is resolved by **last-resize-wins**: the server sizes the PTY to the most recent RESIZE and echoes the authoritative size so other clients reflow.
- **Kept** everything else: raw `PTY_OUT` bytes, binary + JSON framing, `exit`, `detach` (clean-close signal), and the auth-ready seam.
- Designed so a lease could be **added later additively** (advisory frames) without reshaping — but not built now.

### WebSocket library choice (§9.5)
Adds **`github.com/coder/websocket` v1.8.15** — context-aware, minimal, **zero transitive deps**, actively maintained; the design's recommended pick over `gorilla/websocket` or hand-rolled RFC6455. `go.sum` grows by only its two lines; dependency-file footprint is `go.mod`/`go.sum` only (single vendored dep).

### Tests & gates
- Unit tests: control-frame **marshal** wire-shape pins, frame **round-trip** (encode→decode→equal), decode-error cases, auth extraction (header/query/precedence), and a **real WS round-trip** over `coder/websocket` exercising all wire helpers.
- Green: `gofmt -l`, `golangci-lint run --fast`, `go build ./...`, `deadcode -test ./...`, `scripts/lint-file-length.sh`, **`make test-container`** (full suite, 0 failures), **`make tui-driver-selftest` 25/25** (unaffected, confirmed).

Part of #1592 (Phase 2). Do not merge without root sign-off on the load-bearing protocol contract (§9.1).