### PR TITLE
refactor(session,daemon): AgentServer interface + local in-process impl (#1592 Phase 2 PR4)

### DIFF
--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -246,7 +246,8 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 	// (same resumeProgram path: claude --continue, codex resume --last); the
 	// LimitReached/no-tombstone precondition is enforced above under the target
 	// lock.
-	if !instance.TmuxAlive() {
+	as := instance.AgentServer()
+	if !as.Alive() {
 		if rerr := instance.Respawn(); rerr != nil {
 			return fmt.Errorf("failed to re-spawn agent for %q: %w", requestedTitle, rerr)
 		}
@@ -258,7 +259,7 @@ func (m *Manager) resumeFromLimitLocked(repoID, key string, instance *session.In
 		// un-stall it. Loses the agent's prior context (documented caveat).
 		prompt = "continue"
 	}
-	if serr := instance.SendPromptCommand(prompt); serr != nil {
+	if serr := as.SendPrompt(prompt); serr != nil {
 		return fmt.Errorf("failed to resume %q: %w", requestedTitle, serr)
 	}
 	instance.ClearLimitReached()

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -151,7 +151,10 @@ func (m *Manager) SendPrompt(req SendPromptRequest) error {
 	if err := promptTargetLivenessError(req.Title, instance.GetLiveness()); err != nil {
 		return err
 	}
-	if err := instance.SendPromptCommand(req.Prompt); err != nil {
+	// Deliver through the agent-server (#1592 Phase 2 PR4), not the tmux-shaped
+	// Backend method — the daemon's delivery path is runtime-agnostic. SendPrompt
+	// is the reliable command path automated deliveries need.
+	if err := instance.AgentServer().SendPrompt(req.Prompt); err != nil {
 		return fmt.Errorf("failed to send prompt: %w", err)
 	}
 	return nil

--- a/daemon/manager_status.go
+++ b/daemon/manager_status.go
@@ -148,21 +148,35 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		return
 	}
 
-	instance.CheckAndHandleTrustPrompt()
+	// The daemon observes and drives the session ONLY through its agent-server
+	// (#1592 Phase 2 PR4) — never the tmux-shaped Backend probes directly, so this
+	// poll makes no assumption that the session is local tmux. For the local
+	// runtime the agent-server drives tmux in-process.
+	as := instance.AgentServer()
 	before := instance.GetLiveness()
 	beforeReset, _ := instance.LimitResetAt()
-	// HasUpdated hands back the captured pane content so the idle branch can run
-	// the usage-limit detector (#1146) without a second capture-pane.
-	updated, hasPrompt, content := instance.HasUpdated()
+	// Snapshot dismisses a pending trust prompt then reads the pane in one probe
+	// (the exact order the poll used to run CheckAndHandleTrustPrompt then
+	// HasUpdated). Content is the capture handed back so the idle branch runs the
+	// usage-limit detector (#1146) without a second capture-pane.
+	obs, err := as.Snapshot()
+	if err != nil {
+		// A future remote runtime's observation channel failed: leave the status
+		// for the next tick rather than misreading it. The local agent-server
+		// never errors here, so this is inert today — it mirrors the paused /
+		// in-flight-op early returns above (never mark Lost on a failed probe).
+		return
+	}
+	updated, hasPrompt, content := obs.Updated, obs.HasPrompt, obs.Content
 	if hasPrompt {
 		// Tap enter whenever a prompt is waiting (TapEnter is a no-op unless
 		// AutoYes is on), independent of `updated` — exactly as the pre-#965
-		// AutoYes loop did with `if _, hasPrompt := instance.HasUpdated(); …`.
-		// A prompt's text is itself fresh output, so a just-appeared prompt
-		// commonly reports (updated, hasPrompt) == (true, true); folding the tap
-		// into the switch below `case updated` swallowed it on that first tick
-		// and only tapped on the next poll — a one-interval AutoYes delay (#992).
-		instance.TapEnter()
+		// AutoYes loop did with `if _, hasPrompt := ...Snapshot(); …`. A prompt's
+		// text is itself fresh output, so a just-appeared prompt commonly reports
+		// (updated, hasPrompt) == (true, true); folding the tap into the switch
+		// below `case updated` swallowed it on that first tick and only tapped on
+		// the next poll — a one-interval AutoYes delay (#992).
+		as.TapEnter()
 	}
 	switch {
 	case updated:
@@ -171,8 +185,8 @@ func (m *Manager) refreshInstanceStatus(repoID string, instance *session.Instanc
 		// A waiting prompt with otherwise-unchanged output: leave the status for
 		// the next tick to resolve, exactly as runMetadataTick did. The
 		// prompt-tap already fired above regardless of `updated`.
-	case !instance.TmuxAlive():
-		// HasUpdated returned (false,false), which a healthy idle session and a
+	case !as.Alive():
+		// Snapshot returned (false,false), which a healthy idle session and a
 		// dead one both produce — indistinguishable on their own. Probe liveness
 		// only on this idle branch so a vanished session is marked Lost and
 		// rendered distinctly rather than repainted as a green Ready dot it can

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -1,0 +1,137 @@
+package session
+
+import (
+	"errors"
+	"io"
+)
+
+// AgentServer is the uniform contract the daemon speaks to a session's runtime,
+// regardless of where that runtime physically lives (#1592 Phase 2 — the
+// OpenHands-style agent-server seam). The daemon's observation and delivery
+// paths depend ONLY on this interface; the tmux mechanism is an internal detail
+// of the LOCAL in-process implementation (agentserver_local.go), no longer
+// visible on the daemon's path. A Phase-4 runtime (container/ssh) implements the
+// same interface over a native PTY behind an authed URL, and the daemon code
+// above it does not change.
+//
+// This is the locality leak the epic set out to remove: before PR4 the daemon
+// called tmux-shaped Backend methods (HasUpdated/TapEnter/IsAlive/
+// SendPromptCommand/Preview) directly, baking "the session is local tmux" into
+// the orchestrator. Those methods now live behind the agent-server.
+//
+// MULTI-WRITER (locked #1592): the data plane has NO lease. Subscribe is
+// read-write for every subscriber, Input/Resize are accepted from any of them,
+// and the PTY size is last-resize-wins. There is deliberately no mode argument —
+// af is single-owner, so gating typing would be needless machinery. A lease is
+// additive/reversible later if the rare two-active-clients resize-flap ever
+// bites.
+type AgentServer interface {
+	// Provision establishes WHERE the agent runs — the local git worktree for the
+	// local runtime, an off-box workspace for a future remote/container runtime.
+	// It is the first half of Phase-1's Start split (backend provision phase).
+	Provision(firstTimeSetup bool) error
+	// Launch starts WHAT runs in the provisioned workspace — the agent process and
+	// its tabs. It is the second half of Phase-1's Start split (backend launch
+	// phase). firstTimeSetup mirrors Provision: a fresh create materializes the
+	// worktree and spawns; a restore reconnects.
+	Launch(firstTimeSetup bool) error
+	// Expose returns where the session's data plane is reachable. For the local
+	// in-process agent-server it is an in-process handle; a Phase-4 runtime returns
+	// an authed URL. The WS PTY broker (PR5) consumes it.
+	Expose() (StreamEndpoint, error)
+
+	// Snapshot returns the current non-interactive observation the daemon's
+	// liveness/AutoYes poll reads each tick, dismissing any pending trust/permission
+	// prompt as a side effect (the poll always did both, in that order). See
+	// Observation. The local implementation never errors; the error is for a future
+	// remote runtime whose observation channel can fail.
+	Snapshot() (Observation, error)
+	// Preview returns the session's visible output; full=true returns the entire
+	// scrollback history.
+	Preview(full bool) (string, error)
+	// Alive reports whether the underlying session process is still running. Kept
+	// separate from Snapshot (rather than folded into Observation) so the daemon
+	// probes liveness ONLY on the idle branch, exactly as before — folding it in
+	// would add a liveness probe to every non-idle tick.
+	Alive() bool
+
+	// SendPrompt delivers a prompt over the reliable command path (tmux send-keys
+	// for the local runtime) — the path automated/scheduled deliveries use, which
+	// survives a PTY that is not currently attached. This is the daemon's delivery
+	// primitive; interactive per-keystroke input is Input, on the data plane.
+	SendPrompt(prompt string) error
+	// TapEnter sends a bare Enter keystroke — the AutoYes accept. A no-op unless
+	// the session has AutoYes enabled. An input helper that routes through the same
+	// underlying channel as SendPrompt.
+	TapEnter()
+
+	// Subscribe returns a fan-out read of the raw PTY byte stream from cursor
+	// `since` (0 = from the buffer tail), so a reconnecting client replays the gap.
+	// Data plane — wired by the WS PTY broker in PR5; the local agent-server returns
+	// ErrDataPlaneUnwired until then.
+	Subscribe(since Seq) (PTYSubscription, error)
+	// Input writes raw bytes to the PTY (the multi-writer input path that subsumes
+	// the old tmux-shaped SendKeys). Data plane — wired in PR5.
+	Input(b []byte) error
+	// Resize sets the PTY size; last-resize-wins across subscribers. Data plane —
+	// wired in PR5.
+	Resize(rows, cols uint16) error
+
+	// Kill terminates the session and releases its backing resources.
+	Kill() error
+}
+
+// Seq is a monotonic cursor into a session's PTY output ring buffer, used by
+// Subscribe(since) to replay the gap after a reconnect (#1592 Phase 2). Defined
+// here so the data-plane signatures are stable; the ring buffer that mints these
+// lands with the WS PTY broker in PR5.
+type Seq uint64
+
+// StreamEndpoint identifies where a session's data plane is reachable. For the
+// local in-process agent-server it is an in-process handle (Local=true); a
+// Phase-4 remote runtime returns an authed URL. Auth-ready-by-shape for Phase 3.
+type StreamEndpoint struct {
+	// Local marks an in-process endpoint with no network hop — the only kind in
+	// Phase 2 (local runtime).
+	Local bool
+	// URL is the authed endpoint a remote/container runtime exposes (empty for a
+	// local in-process endpoint). Filled in Phase 4.
+	URL string
+}
+
+// Observation is the non-interactive snapshot the daemon's liveness/AutoYes poll
+// reads each tick (#1592 Phase 2): whether the pane changed since the last probe,
+// whether the program is showing a prompt awaiting input, and the raw captured
+// pane content so the usage-limit detector (#1146) can inspect it without a
+// second capture. It replaces the daemon reading the tmux-shaped HasUpdated probe
+// directly.
+type Observation struct {
+	// Updated is true if the session output changed since the last probe.
+	Updated bool
+	// HasPrompt is true if the program is showing a yes/no prompt awaiting input
+	// (the AutoYes trigger).
+	HasPrompt bool
+	// Content is the raw captured pane content, handed back so the idle branch can
+	// run the usage-limit detector without a second capture (#1146). Empty for a
+	// runtime with no live pane.
+	Content string
+}
+
+// PTYSubscription is the read side of a session's raw PTY byte stream plus a
+// sequence cursor for replay (#1592 Phase 2). The WS PTY broker (PR5) implements
+// it; the local agent-server returns ErrDataPlaneUnwired from Subscribe until
+// then, so there is no concrete implementer in this PR.
+type PTYSubscription interface {
+	io.ReadCloser
+	// Seq reports the cursor of the next byte to be read, so a client that
+	// reconnects can resume with Subscribe(since).
+	Seq() Seq
+}
+
+// ErrDataPlaneUnwired is returned by the local agent-server's data-plane methods
+// (Subscribe/Input/Resize) in Phase 2 PR4: the interface is defined and the
+// observation/delivery paths route through it, but the raw-PTY streaming plane is
+// built on top in PR5 (the WS broker + clientless tmux fan-out). It is a distinct
+// sentinel so PR5 can assert callers handle it and delete it once the plane is
+// wired.
+var ErrDataPlaneUnwired = errors.New("agent-server data plane not wired yet (Phase 2 PR5)")

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -1,0 +1,94 @@
+package session
+
+// localAgentServer is the in-process AgentServer for the local runtime (#1592
+// Phase 2 PR4): the agent runs as a tmux session on the daemon's own machine, so
+// this "server" is a thin in-process facade that drives that tmux session
+// directly. It is where the tmux-shaped operations the daemon used to call itself
+// (HasUpdated/TapEnter/IsAlive/SendPromptCommand/Preview) now live — internal to
+// the local runtime, reached only through the uniform AgentServer interface.
+//
+// It calls the Backend methods directly (i.backend.*) rather than the Instance
+// wrappers, so the wrappers that existed only for the daemon's path (Instance
+// HasUpdated/TapEnter) could be deleted with the daemon routed here — the seam is
+// the AgentServer interface, not a second set of pass-through methods.
+//
+// It is stateless (holds only the instance) and constructed on demand by
+// Instance.AgentServer(); the stateful pieces — the PTY ring buffer and the
+// fan-out subscriber set — arrive with the WS broker in PR5, at which point the
+// agent-server becomes a cached per-instance singleton.
+type localAgentServer struct {
+	inst *Instance
+}
+
+// AgentServer returns the agent-server for this instance's runtime (#1592 Phase
+// 2). The daemon speaks to a session ONLY through this interface, so its
+// observation/delivery paths never assume the session is local tmux. Local today;
+// a per-runtime factory selects container/ssh agent-servers in Phase 4.
+func (i *Instance) AgentServer() AgentServer {
+	return &localAgentServer{inst: i}
+}
+
+var _ AgentServer = (*localAgentServer)(nil)
+
+func (s *localAgentServer) Provision(firstTimeSetup bool) error {
+	return s.inst.backend.Provision(s.inst, firstTimeSetup)
+}
+
+func (s *localAgentServer) Launch(firstTimeSetup bool) error {
+	return s.inst.backend.Launch(s.inst, firstTimeSetup)
+}
+
+func (s *localAgentServer) Expose() (StreamEndpoint, error) {
+	// The local runtime's data plane is in-process — no network hop, no URL. The
+	// WS PTY broker (PR5) binds to this handle to fan tmux bytes to subscribers.
+	return StreamEndpoint{Local: true}, nil
+}
+
+func (s *localAgentServer) Snapshot() (Observation, error) {
+	// Dismiss a pending trust/permission prompt first, then read the pane — the
+	// exact order the daemon poll ran (CheckAndHandleTrustPrompt then HasUpdated).
+	// CheckAndHandleTrustPrompt's bool return is intentionally discarded: the poll
+	// never consumed it.
+	s.inst.backend.CheckAndHandleTrustPrompt(s.inst)
+	updated, hasPrompt, content := s.inst.backend.HasUpdated(s.inst)
+	return Observation{Updated: updated, HasPrompt: hasPrompt, Content: content}, nil
+}
+
+func (s *localAgentServer) Preview(full bool) (string, error) {
+	if full {
+		return s.inst.backend.PreviewFullHistory(s.inst)
+	}
+	return s.inst.backend.Preview(s.inst)
+}
+
+func (s *localAgentServer) Alive() bool {
+	return s.inst.backend.IsAlive(s.inst)
+}
+
+func (s *localAgentServer) SendPrompt(prompt string) error {
+	// The reliable command path (tmux send-keys), which is what automated/scheduled
+	// deliveries need — it lands whether or not a PTY is currently attached.
+	return s.inst.backend.SendPromptCommand(s.inst, prompt)
+}
+
+func (s *localAgentServer) TapEnter() {
+	s.inst.backend.TapEnter(s.inst)
+}
+
+// --- data plane: wired in PR5 (WS PTY broker + clientless tmux fan-out) ---
+
+func (s *localAgentServer) Subscribe(Seq) (PTYSubscription, error) {
+	return nil, ErrDataPlaneUnwired
+}
+
+func (s *localAgentServer) Input([]byte) error {
+	return ErrDataPlaneUnwired
+}
+
+func (s *localAgentServer) Resize(uint16, uint16) error {
+	return ErrDataPlaneUnwired
+}
+
+func (s *localAgentServer) Kill() error {
+	return s.inst.backend.Kill(s.inst)
+}

--- a/session/agentserver_local_test.go
+++ b/session/agentserver_local_test.go
@@ -1,0 +1,171 @@
+package session
+
+import (
+	"errors"
+	"testing"
+)
+
+// probeBackend records which Backend methods the local agent-server calls and
+// returns recognizable values, so the tests below pin that localAgentServer
+// routes each AgentServer method to the right underlying Backend call (#1592
+// Phase 2 PR4). It embeds FakeBackend for the methods it does not care about.
+type probeBackend struct {
+	*FakeBackend
+
+	trustChecked   bool
+	tapped         bool
+	provisionFirst *bool
+	launchFirst    *bool
+	sentPrompt     string
+	killed         bool
+}
+
+func (b *probeBackend) CheckAndHandleTrustPrompt(*Instance) bool {
+	b.trustChecked = true
+	return false
+}
+
+// HasUpdated returns a distinct triple so Snapshot's field mapping is verifiable.
+func (b *probeBackend) HasUpdated(*Instance) (bool, bool, string) {
+	return true, true, "captured-pane"
+}
+
+func (b *probeBackend) TapEnter(*Instance) { b.tapped = true }
+
+func (b *probeBackend) IsAlive(*Instance) bool { return false }
+
+func (b *probeBackend) Preview(*Instance) (string, error) { return "short", nil }
+
+func (b *probeBackend) PreviewFullHistory(*Instance) (string, error) { return "full", nil }
+
+func (b *probeBackend) SendPromptCommand(_ *Instance, prompt string) error {
+	b.sentPrompt = prompt
+	return nil
+}
+
+func (b *probeBackend) Provision(_ *Instance, firstTimeSetup bool) error {
+	b.provisionFirst = &firstTimeSetup
+	return nil
+}
+
+func (b *probeBackend) Launch(_ *Instance, firstTimeSetup bool) error {
+	b.launchFirst = &firstTimeSetup
+	return nil
+}
+
+func (b *probeBackend) Kill(*Instance) error {
+	b.killed = true
+	return nil
+}
+
+func newProbeInstance(t *testing.T) (*Instance, *probeBackend) {
+	t.Helper()
+	inst, err := NewInstance(InstanceOptions{Title: "probe", Path: t.TempDir(), Program: "claude"})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	b := &probeBackend{FakeBackend: NewFakeBackend()}
+	inst.SetBackend(b)
+	return inst, b
+}
+
+func TestLocalAgentServerSnapshot(t *testing.T) {
+	inst, b := newProbeInstance(t)
+	obs, err := inst.AgentServer().Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if !b.trustChecked {
+		t.Error("Snapshot must dismiss a pending trust prompt (CheckAndHandleTrustPrompt) first")
+	}
+	if !obs.Updated || !obs.HasPrompt || obs.Content != "captured-pane" {
+		t.Errorf("Observation mismapped: got %+v", obs)
+	}
+}
+
+func TestLocalAgentServerTapEnter(t *testing.T) {
+	inst, b := newProbeInstance(t)
+	inst.AgentServer().TapEnter()
+	if !b.tapped {
+		t.Error("TapEnter must route to Backend.TapEnter")
+	}
+}
+
+func TestLocalAgentServerAlive(t *testing.T) {
+	inst, _ := newProbeInstance(t)
+	if inst.AgentServer().Alive() {
+		t.Error("Alive must route to Backend.IsAlive (probe returns false)")
+	}
+}
+
+func TestLocalAgentServerPreview(t *testing.T) {
+	inst, _ := newProbeInstance(t)
+	as := inst.AgentServer()
+	if got, _ := as.Preview(false); got != "short" {
+		t.Errorf("Preview(false) = %q, want the visible-pane capture", got)
+	}
+	if got, _ := as.Preview(true); got != "full" {
+		t.Errorf("Preview(true) = %q, want the full scrollback", got)
+	}
+}
+
+func TestLocalAgentServerSendPrompt(t *testing.T) {
+	inst, b := newProbeInstance(t)
+	if err := inst.AgentServer().SendPrompt("hello"); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if b.sentPrompt != "hello" {
+		t.Errorf("SendPrompt must route to the reliable command path; got %q", b.sentPrompt)
+	}
+}
+
+func TestLocalAgentServerLifecycle(t *testing.T) {
+	inst, b := newProbeInstance(t)
+	as := inst.AgentServer()
+	if err := as.Provision(true); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if b.provisionFirst == nil || *b.provisionFirst != true {
+		t.Error("Provision must forward firstTimeSetup to Backend.Provision")
+	}
+	if err := as.Launch(false); err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	if b.launchFirst == nil || *b.launchFirst != false {
+		t.Error("Launch must forward firstTimeSetup to Backend.Launch")
+	}
+	if err := as.Kill(); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if !b.killed {
+		t.Error("Kill must route to Backend.Kill")
+	}
+}
+
+func TestLocalAgentServerExpose(t *testing.T) {
+	inst, _ := newProbeInstance(t)
+	ep, err := inst.AgentServer().Expose()
+	if err != nil {
+		t.Fatalf("Expose: %v", err)
+	}
+	if !ep.Local || ep.URL != "" {
+		t.Errorf("local endpoint = %+v, want {Local:true, URL:\"\"}", ep)
+	}
+}
+
+// TestLocalAgentServerDataPlaneUnwired pins that the raw-PTY data plane is a stub
+// in PR4 — Subscribe/Input/Resize all report ErrDataPlaneUnwired until the WS
+// broker wires them in PR5.
+func TestLocalAgentServerDataPlaneUnwired(t *testing.T) {
+	inst, _ := newProbeInstance(t)
+	as := inst.AgentServer()
+	if _, err := as.Subscribe(0); !errors.Is(err, ErrDataPlaneUnwired) {
+		t.Errorf("Subscribe err = %v, want ErrDataPlaneUnwired", err)
+	}
+	if err := as.Input([]byte("x")); !errors.Is(err, ErrDataPlaneUnwired) {
+		t.Errorf("Input err = %v, want ErrDataPlaneUnwired", err)
+	}
+	if err := as.Resize(24, 80); !errors.Is(err, ErrDataPlaneUnwired) {
+		t.Errorf("Resize err = %v, want ErrDataPlaneUnwired", err)
+	}
+}

--- a/session/autoyes_race_test.go
+++ b/session/autoyes_race_test.go
@@ -59,7 +59,7 @@ func TestAutoYesDataRace(t *testing.T) {
 				return
 			default:
 			}
-			inst.TapEnter()
+			inst.AgentServer().TapEnter()
 		}
 	}()
 

--- a/session/backend.go
+++ b/session/backend.go
@@ -51,14 +51,26 @@ type Backend interface {
 	// Start initialises the session. When firstTimeSetup is true a brand-new
 	// session is created; otherwise an existing one is restored from storage.
 	//
-	// Each backend implements Start as two internal phases (#1592 Phase 1 PR4):
-	// a PROVISION step that establishes WHERE the agent runs (the local git
-	// worktree, or the remote workspace via launch_cmd) and a LAUNCH step that
-	// starts WHAT runs in it (the tmux/PTY/agent process and its tabs). The
-	// boundary is kept internal for now — Start is still the only interface
-	// entry point — but it prepares the backend for the future agent-server
-	// "provision-and-expose" model, where the two halves are driven separately.
+	// Each backend implements Start as two phases (#1592 Phase 1 PR4): a PROVISION
+	// step that establishes WHERE the agent runs (the local git worktree, or the
+	// remote workspace via launch_cmd) and a LAUNCH step that starts WHAT runs in
+	// it (the tmux/PTY/agent process and its tabs). Start is Provision then Launch.
+	// The two halves are on the interface (#1592 Phase 2 PR4) so the local
+	// agent-server's provision-and-expose model can drive them separately; Start
+	// stays as the combined lifecycle entry point its existing callers use.
 	Start(instance *Instance, firstTimeSetup bool) error
+
+	// Provision establishes WHERE the session runs without starting the agent
+	// process — the local git worktree + tmux binding, or a remote/off-box
+	// workspace. The first half of Start. See each backend's implementation for the
+	// precise on-disk vs in-memory boundary.
+	Provision(instance *Instance, firstTimeSetup bool) error
+
+	// Launch starts (or restores) WHAT runs in the workspace Provision established
+	// — the agent process and its tabs. The second half of Start; it owns the
+	// failure-cleanup scope (a launch failure tears down Provision's worktree on a
+	// fresh create).
+	Launch(instance *Instance, firstTimeSetup bool) error
 
 	// Kill terminates the session and cleans up all associated resources.
 	Kill(instance *Instance) error

--- a/session/backend_e2e_test.go
+++ b/session/backend_e2e_test.go
@@ -190,10 +190,11 @@ func TestE2ERemoteHooksFullLifecycle(t *testing.T) {
 	// --- Step 5: IsAlive should return true (session is in state file with status=running) ---
 	assert.True(t, instance.TmuxAlive(), "TmuxAlive (delegates to IsAlive) should return true")
 
-	// --- Step 6: HasUpdated should always return (false, false) for remote ---
-	updated, hasPrompt, _ := instance.HasUpdated()
-	assert.False(t, updated)
-	assert.False(t, hasPrompt)
+	// --- Step 6: Snapshot should always report (false, false) for remote ---
+	obs, err := instance.AgentServer().Snapshot()
+	assert.NoError(t, err)
+	assert.False(t, obs.Updated)
+	assert.False(t, obs.HasPrompt)
 
 	// --- Step 7: SendPrompt/SendPromptCommand should return errors ---
 	assert.Error(t, instance.SendPrompt("hello"))

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -50,20 +50,20 @@ func (b *HookBackend) Capabilities() Capabilities {
 // backend's provision/launch seam so the future agent-server model can swap the
 // provision half (spin up an off-box workspace) without touching launch.
 func (b *HookBackend) Start(i *Instance, firstTimeSetup bool) error {
-	if err := b.provision(i, firstTimeSetup); err != nil {
+	if err := b.Provision(i, firstTimeSetup); err != nil {
 		return err
 	}
-	return b.launch(i, firstTimeSetup)
+	return b.Launch(i, firstTimeSetup)
 }
 
-// provision establishes the remote workspace WITHOUT starting the local
+// Provision establishes the remote workspace WITHOUT starting the local
 // preview/attach process (#1592 Phase 1 PR4). A fresh create runs launch_cmd to
 // allocate the remote session and records its metadata (remoteMeta + Branch); a
 // restore only verifies that the previously-allocated remote session is still
 // alive. It sets neither the started flag nor the tab model — those belong to
 // launch — so a provision failure returns before any of launch's work, exactly
 // as the pre-split Start's early error returns did.
-func (b *HookBackend) provision(i *Instance, firstTimeSetup bool) error {
+func (b *HookBackend) Provision(i *Instance, firstTimeSetup bool) error {
 	if strings.TrimSpace(i.Title) == "" {
 		return fmt.Errorf("instance title cannot be empty")
 	}
@@ -142,7 +142,7 @@ func (b *HookBackend) provision(i *Instance, firstTimeSetup bool) error {
 	return nil
 }
 
-// launch starts the local machinery that drives the remote workspace provision
+// Launch starts the local machinery that drives the remote workspace Provision
 // established (#1592 Phase 1 PR4): the attach/preview process (ensurePTY), the
 // remote tab model (syncRemoteTabs), and the started flag. It preserves each
 // path's exact pre-split ordering and error handling — a restore treats a failed
@@ -150,7 +150,7 @@ func (b *HookBackend) provision(i *Instance, firstTimeSetup bool) error {
 // up, while a fresh create marks it started first and logs a failed preview
 // best-effort (launch_cmd already succeeded, so the remote session is alive and
 // still attachable interactively).
-func (b *HookBackend) launch(i *Instance, firstTimeSetup bool) error {
+func (b *HookBackend) Launch(i *Instance, firstTimeSetup bool) error {
 	if !firstTimeSetup {
 		if err := b.ensurePTY(i); err != nil {
 			return fmt.Errorf("failed to start preview process: %w", err)

--- a/session/backend_hook_core_test.go
+++ b/session/backend_hook_core_test.go
@@ -48,14 +48,14 @@ func TestHookBackendProvisionLaunchSeam(t *testing.T) {
 	}
 
 	// PROVISION: remote workspace allocated, but nothing launched locally yet.
-	require.NoError(t, b.provision(i, true))
+	require.NoError(t, b.Provision(i, true))
 	assert.NotNil(t, i.remoteMeta, "provision records the remote workspace metadata")
 	assert.Equal(t, Slugify("test-session"), i.Branch)
 	assert.False(t, i.Started(), "provision must not mark the instance started")
 	assert.Empty(t, i.Tabs, "provision must not build the tab model")
 
 	// LAUNCH: local machinery comes up and the instance goes live.
-	require.NoError(t, b.launch(i, true))
+	require.NoError(t, b.Launch(i, true))
 	assert.True(t, i.Started(), "launch marks the instance started")
 	assert.NotEmpty(t, i.Tabs, "launch syncs the remote tab model")
 

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -105,13 +105,13 @@ func (e *WorktreeUnavailableError) Unwrap() error {
 // backend for the future agent-server "provision-and-expose" model, where
 // provision spins up an off-box workspace and launch exposes the agent stream.
 func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
-	if err := b.provision(i, firstTimeSetup); err != nil {
+	if err := b.Provision(i, firstTimeSetup); err != nil {
 		return err
 	}
-	return b.launch(i, firstTimeSetup)
+	return b.Launch(i, firstTimeSetup)
 }
 
-// provision establishes the local workspace a session will run in WITHOUT
+// Provision establishes the local workspace a session will run in WITHOUT
 // starting any agent process (#1592 Phase 1 PR4): it binds the instance's tmux
 // session handle and, on a first-time create, computes the git worktree record +
 // branch name. Nothing here spawns a tmux server session, materializes the
@@ -121,7 +121,7 @@ func (b *LocalBackend) Start(i *Instance, firstTimeSetup bool) error {
 // on disk to clean up and returns before launch's cleanup scope is ever entered
 // — exactly as the pre-split Start did (its NewGitWorktree failure returned
 // before the deferred cleanup handler was registered).
-func (b *LocalBackend) provision(i *Instance, firstTimeSetup bool) error {
+func (b *LocalBackend) Provision(i *Instance, firstTimeSetup bool) error {
 	if strings.TrimSpace(i.Title) == "" {
 		return fmt.Errorf("instance title cannot be empty")
 	}
@@ -172,7 +172,7 @@ func (b *LocalBackend) provision(i *Instance, firstTimeSetup bool) error {
 	return nil
 }
 
-// launch starts (or restores) the agent PROCESS in the workspace provision
+// Launch starts (or restores) the agent PROCESS in the workspace Provision
 // established (#1592 Phase 1 PR4): it materializes the worktree on disk
 // (worktree.Setup on a fresh create), spawns or reconnects the tmux session, and
 // brings up the non-agent tabs. It owns the failure-cleanup scope — a launch
@@ -182,7 +182,7 @@ func (b *LocalBackend) provision(i *Instance, firstTimeSetup bool) error {
 // failure needs the same teardown as any other launch failure, so it belongs
 // inside this cleanup scope. Behavior is identical to the pre-split Start — this
 // is exactly the code that followed provision's work in the monolithic form.
-func (b *LocalBackend) launch(i *Instance, firstTimeSetup bool) error {
+func (b *LocalBackend) Launch(i *Instance, firstTimeSetup bool) error {
 	i.mu.RLock()
 	tmuxSession := i.tmuxLocked()
 	i.mu.RUnlock()

--- a/session/dead_respawn_test.go
+++ b/session/dead_respawn_test.go
@@ -204,9 +204,9 @@ func TestTombstonedInstance_NotRespawnedOnLoad(t *testing.T) {
 // the #1108 rollforward) with started=true but LocalBackend.Start returns
 // before TmuxSession.Restore (the only place the tmux monitor is initialized)
 // so the session is not re-spawned (#970). The daemon's refreshInstanceStatus
-// still polls every started instance via instance.HasUpdated(); before the fix
-// that dereferenced a nil monitor and panicked, killing the refresh goroutine
-// and zombifying the daemon. HasUpdated must instead return (false,false) — a
+// still polls every started instance via its agent-server Snapshot; before the
+// fix that dereferenced a nil monitor and panicked, killing the refresh goroutine
+// and zombifying the daemon. Snapshot must instead report (false,false) — a
 // session with no live monitor has nothing to report.
 func TestDeadInstance_HasUpdatedNilMonitor(t *testing.T) {
 	log.Initialize(false)
@@ -235,9 +235,10 @@ func TestDeadInstance_HasUpdatedNilMonitor(t *testing.T) {
 
 	// This is the exact call refreshInstanceStatus makes every daemon tick.
 	// Before the nil-monitor guard it panicked here.
-	updated, hasPrompt, _ := restored.HasUpdated()
-	assert.False(t, updated, "a restored Dead instance has nothing to report")
-	assert.False(t, hasPrompt)
+	obs, err := restored.AgentServer().Snapshot()
+	require.NoError(t, err)
+	assert.False(t, obs.Updated, "a restored Dead instance has nothing to report")
+	assert.False(t, obs.HasPrompt)
 }
 
 // failFirstNewSessionPty is a PtyFactory that fails the first `tmux new-session`

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -63,6 +63,19 @@ func (b *FakeBackend) FailStart(err error) {
 // -- Backend interface implementation --
 
 func (b *FakeBackend) Start(instance *Instance, firstTimeSetup bool) error {
+	if err := b.Provision(instance, firstTimeSetup); err != nil {
+		return err
+	}
+	return b.Launch(instance, firstTimeSetup)
+}
+
+// Provision is a no-op for the fake backend: it holds no workspace. The blocking
+// start semantics (startCalled/startBlock, startErr, SetStartedForTest) live in
+// Launch so Start = Provision then Launch matches the real backends (#1592 Phase
+// 2 PR4).
+func (b *FakeBackend) Provision(*Instance, bool) error { return nil }
+
+func (b *FakeBackend) Launch(instance *Instance, _ bool) error {
 	b.mu.Lock()
 	b.startCount++
 	first := b.startCount == 1

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -125,18 +125,9 @@ func (i *Instance) Preview() (string, error) {
 	return i.backend.Preview(i)
 }
 
-func (i *Instance) HasUpdated() (updated bool, hasPrompt bool, content string) {
-	return i.backend.HasUpdated(i)
-}
-
 // CheckAndHandleTrustPrompt checks for and dismisses the trust prompt for supported programs.
 func (i *Instance) CheckAndHandleTrustPrompt() bool {
 	return i.backend.CheckAndHandleTrustPrompt(i)
-}
-
-// TapEnter sends an enter key press to the tmux session if AutoYes is enabled.
-func (i *Instance) TapEnter() {
-	i.backend.TapEnter(i)
 }
 
 func (i *Instance) Attach() (chan struct{}, error) {

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -19,6 +19,13 @@ func (b *startBackend) Start(instance *session.Instance, _ bool) error {
 	return nil
 }
 
+func (b *startBackend) Provision(*session.Instance, bool) error { return nil }
+
+func (b *startBackend) Launch(instance *session.Instance, _ bool) error {
+	instance.SetStartedForTest(true)
+	return nil
+}
+
 func (b *startBackend) Kill(instance *session.Instance) error {
 	instance.SetStartedForTest(false)
 	return nil


### PR DESCRIPTION
Phase 2 **PR4** of #1592. Introduces the **AgentServer** interface + a **local in-process** implementation, and routes the daemon's observation/delivery paths through it instead of the tmux-shaped `Backend` methods. **Same tmux underneath → behavior-preserving.** No client-visible change; does not touch `app/` or add any wire/WS (that's PR5+).

This removes the locality leak the epic set out to kill: before PR4 the daemon called tmux-shaped methods (`HasUpdated`/`TapEnter`/`IsAlive`/`SendPromptCommand`) directly, baking "the session is local tmux" into the orchestrator.

## The interface (`session/agentserver.go`)

```go
type AgentServer interface {
    Provision(firstTimeSetup bool) error       // WHERE the agent runs  (Phase-1 Start half 1)
    Launch(firstTimeSetup bool) error          // WHAT runs in it       (Phase-1 Start half 2)
    Expose() (StreamEndpoint, error)           // data-plane endpoint   (in-process for local)

    Snapshot() (Observation, error)            // trust-dismiss + pane read, one probe
    Preview(full bool) (string, error)
    Alive() bool                               // liveness probe

    SendPrompt(prompt string) error            // reliable command delivery path
    TapEnter()                                 // AutoYes accept

    Subscribe(since Seq) (PTYSubscription, error)  // ── data plane: stubbed in PR4,
    Input(b []byte) error                          //    ErrDataPlaneUnwired until the
    Resize(rows, cols uint16) error                //    WS PTY broker wires it in PR5

    Kill() error
}
```

**MULTI-WRITER (locked #1592):** the data plane has **no lease** — `Subscribe` is read-write for every subscriber, `Input`/`Resize` from any of them, PTY size = last-resize-wins. No `mode` argument; no lease machinery.

Two deliberate deviations from the illustrative design §5, both documented in-code:
- **`Alive()` is separate**, not folded into `Observation` — so the poll probes liveness **only on the idle branch**, exactly as before. Folding it in would add a liveness probe to every non-idle tick.
- **`Launch(firstTimeSetup bool)`** carries the flag the backend launch phase needs (design showed `Launch(inst)`).

## The local impl (`session/agentserver_local.go`)

`localAgentServer` is a thin in-process facade over the instance's tmux backend. It calls the `Backend` methods **directly** (`i.backend.*`), so the tmux-shaped operations the daemon used to invoke now live **internal to the local runtime**, reached only through the uniform interface. Stateless + constructed on demand by `Instance.AgentServer()`; it becomes a cached per-instance singleton in PR5 when the PTY ring buffer + subscriber set arrive.

- `Snapshot()` → `CheckAndHandleTrustPrompt` then `HasUpdated` (exact prior order).
- `Preview(full)` → `Preview` / `PreviewFullHistory`.
- `Alive()` → `IsAlive`; `SendPrompt` → `SendPromptCommand`; `TapEnter` → `TapEnter`; `Kill` → `Kill`.
- `Provision`/`Launch` → the promoted `Backend.Provision`/`Launch`.
- Data plane → `ErrDataPlaneUnwired`.

## What was routed / moved / deleted

**Routed (daemon server side, tmux-shaped → AgentServer):**
- `daemon/manager_status.go` — the liveness/AutoYes poll: `CheckAndHandleTrustPrompt`+`HasUpdated` → `Snapshot()`; `TapEnter` → `as.TapEnter()`; `TmuxAlive` → `as.Alive()`.
- `daemon/manager_sessions.go` — `SendPrompt` RPC: `SendPromptCommand` → `as.SendPrompt()`. (`daemon/delivery.go`'s cron/watch path rides this RPC, so it is covered without a direct edit.)
- `daemon/limit.go` — usage-limit resume (#1146): `TmuxAlive`/`SendPromptCommand` → `as.Alive()`/`as.SendPrompt()`.

**Moved behind the local agent-server** (no longer on the daemon's path): `HasUpdated`, `TapEnter`, `IsAlive`, `SendPromptCommand`, `Preview`/`PreviewFullHistory`, trust-prompt dismissal. They remain on `Backend` for `app/`/`task/`/`api/` (their client-side move is PR6).

**Deleted (clean-break, no new-alongside-old):** the daemon-only `Instance.HasUpdated()` and `Instance.TapEnter()` pass-through wrappers — now dead once the daemon routes through the agent-server (deadcode gate enforces). The seam is the interface, not a second set of pass-throughs.

**Promoted:** the Phase-1 internal `provision`/`launch` phase methods → exported `Backend.Provision`/`Launch` (a genuine structural step toward the epic's "provision-and-expose" runtime model), so the agent-server drives the halves without type-asserting the concrete backend. `Start` = `Provision` then `Launch`, unchanged behavior. `FakeBackend`/`startBackend` split accordingly; the embedding test doubles inherit.

## Shared-file note

`daemon/snapshot.go` (co-touched by PR3, client side) is **not** modified — the observation routing lives in `manager_status.go`, so there is no overlap to rebase.

## Behavior preservation + verification

Pure forwarding: the local agent-server calls the same backend methods in the same order, so preview text, liveness transitions, cron/watch prompt delivery, and AutoYes tap-enter are unchanged by construction.

- `go build ./...`, `gofmt -l`, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean.
- `make test-container` — **all packages pass**, including the daemon tests that exercise exactly the routed paths: liveness/AutoYes (`status_test`, `status_pause_test`, `autoyes_race_test`), cron/watch delivery (`deliver_prompt_test`, `taskrun_test`, `task_rpc_test`), limit-resume (`limit_resume_test`, `limitresume_test`).
- `make tui-driver-selftest` — **25/25** (real binary: interactive send, attach/detach, no orphan clients).
- New `session/agentserver_local_test.go` pins the routing (each AgentServer method → the right Backend call), the `Observation` field mapping, the `{Local:true}` endpoint, and the `ErrDataPlaneUnwired` data-plane stubs.

Closes a slice of #1592. Do not merge until CI + review are green.