### PR TITLE
fix(tui): projects pane vim-scroll + search only on '/' (#1620)

### DIFF
--- a/app/handle_overlay.go
+++ b/app/handle_overlay.go
@@ -114,17 +114,22 @@ func (m *home) handleAutomationsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool)
 
 // handleProjectsFocus routes key events for the focused bottom Projects section
 // (#1588 follow-up) — a peer of the automations section that the Tab focus ring
-// cycles into. Cursor keys move the section's selection, Enter switches the rail
-// to the cursor's project (reusing the #1547 switchProject path via
-// switchToProjectRoot), Esc returns focus to the tree. Advertised global
-// bindings (Tab/Shift-Tab focus ring, ctrl+p picker, ? help, q quit) keep
-// working, while pane-management verbs are consumed here so hidden `s`/`S`/`x`/
-// pane-switch keys cannot mutate workspace panes from Projects focus (mirrors
-// the #1417 automations guard).
+// cycles into. It is a captive vim-style list (#1620): cursor keys (j/k/up/down)
+// move the section's selection, Enter switches the rail to the cursor's project
+// (reusing the #1547 switchProject path via switchToProjectRoot), and Esc returns
+// focus to the tree. Search is entered ONLY on `/` (keys.KeySearch); every OTHER
+// key is a no-op here (consumed, never fired) so nothing can START a search or
+// filter from the section — notably the ctrl+p project-picker filter and the
+// session-create/tasks/collapse verbs that used to leak through when this handler
+// fell through to the global key map. Only the focus-ring and hard-exit chrome
+// (Tab/Shift-Tab, ? help, q quit, ctrl+c) is allowed to fall through, so the user
+// is never trapped in the section. Scoped to Projects focus; the Instances tree
+// and Automations section are untouched.
 func (m *home) handleProjectsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 	if m.ring.Active() != layout.RegionProjects {
 		return m, nil, false
 	}
+	// The section owns its vim/cursor nav (j/k/up/down).
 	if _, consumed := m.projects.HandleKey(msg); consumed {
 		return m, nil, true
 	}
@@ -139,10 +144,46 @@ func (m *home) handleProjectsFocus(msg tea.KeyMsg) (tea.Model, tea.Cmd, bool) {
 		m.focusRegion(layout.RegionTree)
 		return m, nil, true
 	}
-	if automationsConsumesPaneVerb(msg) {
-		return m, nil, true
+	// `/` is the ONLY key that enters search from the Projects section (#1620),
+	// vim-style. Route it explicitly rather than letting it fall through, so the
+	// blanket no-op below can suppress every other key without also swallowing
+	// the one search affordance.
+	if key.Matches(msg, keys.GlobalKeyBindings[keys.KeySearch]) {
+		mod, cmd := m.showSearchOverlay()
+		return mod, cmd, true
 	}
-	return m, nil, false
+	// The focus ring and hard-exit chrome must keep working so the user can
+	// always leave the section; let only those fall through to the root handler.
+	if projectsChromeFallthroughKey(msg) {
+		return m, nil, false
+	}
+	// Everything else is inert while Projects holds focus (#1620): no
+	// session-create, no tasks overlay, no collapse/expand, and no ctrl+p
+	// project-filter — so no key other than `/` can begin a search/filter from
+	// the section.
+	return m, nil, true
+}
+
+// projectsChromeFallthroughKey reports whether a key pressed with the Projects
+// section focused must still reach the global handler — the focus ring
+// (Tab/Shift-Tab), help (?), quit (q), and the always-on ctrl+c hard exit. Every
+// other key is consumed as a no-op by handleProjectsFocus (#1620), so these are
+// the only escape hatches out of the captive section.
+func projectsChromeFallthroughKey(msg tea.KeyMsg) bool {
+	if msg.String() == "ctrl+c" {
+		return true
+	}
+	for _, name := range []keys.KeyName{
+		keys.KeyTab,
+		keys.KeyShiftTab,
+		keys.KeyHelp,
+		keys.KeyQuit,
+	} {
+		if key.Matches(msg, keys.GlobalKeyBindings[name]) {
+			return true
+		}
+	}
+	return false
 }
 
 func automationsConsumesPaneVerb(msg tea.KeyMsg) bool {

--- a/app/projects_pane_vim_test.go
+++ b/app/projects_pane_vim_test.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/sachiniyer/agent-factory/ui"
+	"github.com/sachiniyer/agent-factory/ui/layout"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// projectsHomeWithRows returns a home focused on the Projects section with two
+// project rows and one session in the store, ready to exercise the #1620
+// captive-vim-list input model.
+func projectsHomeWithRows(t *testing.T) *home {
+	t.Helper()
+	h := newTestHome(t)
+	// One session so the `/` search overlay has something to open on (it errors
+	// out with zero sessions and never enters stateSearch).
+	h.store.AddInstance(newSnapshotTestInstance(t, "alpha"))
+	h.projects.SetProjects([]ui.SidebarProject{
+		{Name: filepath.Base(h.repoRoot), Root: h.repoRoot, SessionCount: 1, Active: true},
+		{Name: "zzz-other", Root: "/repos/zzz-other", SessionCount: 0},
+	})
+	h.focusRegion(layout.RegionProjects)
+	require.Equal(t, layout.RegionProjects, h.ring.Active())
+	require.Equal(t, stateDefault, h.state)
+	return h
+}
+
+// TestProjectsSection_VimKeysScrollList: with the section focused, j/k (and the
+// arrow aliases) move the cursor through the project list and are consumed by
+// the section — the #1620 vim-scroll requirement, matching how the Instances
+// tree navigates with the same up=k/down=j bindings.
+func TestProjectsSection_VimKeysScrollList(t *testing.T) {
+	h := projectsHomeWithRows(t)
+
+	start, ok := h.projects.SelectedProject()
+	require.True(t, ok)
+
+	// `j` steps the cursor DOWN onto the next project and is consumed.
+	_, _, consumed := h.handleProjectsFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	require.True(t, consumed, "j is consumed by the focused Projects section")
+	down, _ := h.projects.SelectedProject()
+	require.NotEqual(t, start.Root, down.Root, "j moved the cursor to the next project")
+
+	// `k` steps back UP to where it started and is consumed.
+	_, _, consumed = h.handleProjectsFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	require.True(t, consumed, "k is consumed by the focused Projects section")
+	up, _ := h.projects.SelectedProject()
+	require.Equal(t, start.Root, up.Root, "k moved the cursor back up")
+
+	// The arrow aliases behave identically.
+	_, _, consumed = h.handleProjectsFocus(tea.KeyMsg{Type: tea.KeyDown})
+	require.True(t, consumed, "Down is consumed too")
+	_, _, consumed = h.handleProjectsFocus(tea.KeyMsg{Type: tea.KeyUp})
+	require.True(t, consumed, "Up is consumed too")
+
+	assert.Equal(t, stateDefault, h.state, "nav never opens an overlay")
+}
+
+// TestProjectsSection_SearchOnlyOnSlash: `/` is the ONLY key that enters search
+// from the Projects section (#1620). It opens the session search overlay; every
+// other key is consumed as a no-op and can never start a search/filter.
+func TestProjectsSection_SearchOnlyOnSlash(t *testing.T) {
+	h := projectsHomeWithRows(t)
+
+	// `/` enters search.
+	_, _, consumed := h.handleProjectsFocus(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	require.True(t, consumed, "/ is consumed by the section")
+	require.NotNil(t, h.searchOverlay, "/ opens the search overlay")
+	assert.Equal(t, stateSearch, h.state, "/ is the search entry key")
+}
+
+// TestProjectsSection_OtherKeysAreInert: keys that used to leak through the old
+// fall-through — the ctrl+p project-picker filter, `n` new session, `m` tasks,
+// `h`/`l` collapse/expand — are now consumed as no-ops while Projects holds
+// focus (#1620). None of them opens an overlay, changes state, or creates a
+// session, so no key other than `/` can begin a search/filter from the section.
+func TestProjectsSection_OtherKeysAreInert(t *testing.T) {
+	inert := []struct {
+		name string
+		msg  tea.KeyMsg
+	}{
+		{"ctrl+p project picker (a filter)", tea.KeyMsg{Type: tea.KeyCtrlP}},
+		{"n new session", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}},
+		{"m tasks", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}}},
+		{"h collapse", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}}},
+		{"l expand", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}},
+		{"e hooks", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}}},
+		{"an unbound letter", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}}},
+	}
+	for _, tc := range inert {
+		t.Run(tc.name, func(t *testing.T) {
+			h := projectsHomeWithRows(t)
+			before := h.store.NumInstances()
+
+			_, _, consumed := h.handleProjectsFocus(tc.msg)
+
+			require.True(t, consumed, "%s is consumed as a no-op, not passed to the global map", tc.name)
+			assert.Equal(t, stateDefault, h.state, "%s must not open any overlay", tc.name)
+			assert.Nil(t, h.searchOverlay, "%s must not open a search overlay", tc.name)
+			assert.Nil(t, h.projectPickerOverlay, "%s must not open the project-picker filter", tc.name)
+			assert.Equal(t, before, h.store.NumInstances(), "%s must not create a session", tc.name)
+			assert.Equal(t, layout.RegionProjects, h.ring.Active(), "%s must not steal focus off the section", tc.name)
+		})
+	}
+}
+
+// TestProjectsSection_ChromeFallsThrough: the focus-ring and hard-exit chrome
+// (Tab, Shift-Tab, ? help, q quit, ctrl+c) must still fall through to the global
+// handler so the user is never trapped in the captive section (#1620).
+func TestProjectsSection_ChromeFallsThrough(t *testing.T) {
+	chrome := []struct {
+		name string
+		msg  tea.KeyMsg
+	}{
+		{"Tab", tea.KeyMsg{Type: tea.KeyTab}},
+		{"Shift-Tab", tea.KeyMsg{Type: tea.KeyShiftTab}},
+		{"? help", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}}},
+		{"q quit", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}},
+		{"ctrl+c", tea.KeyMsg{Type: tea.KeyCtrlC}},
+	}
+	for _, tc := range chrome {
+		t.Run(tc.name, func(t *testing.T) {
+			h := projectsHomeWithRows(t)
+			_, _, consumed := h.handleProjectsFocus(tc.msg)
+			require.False(t, consumed, "%s must fall through to the global handler", tc.name)
+		})
+	}
+}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -79,6 +79,12 @@ const (
 	// this name never appears in GlobalKeyStringsMap.
 	KeyManageAutomations
 
+	// KeySwitchProjectRow is the Projects-section display alias of Enter
+	// (menu/help only): with the bottom Projects section focused, Enter switches
+	// the rail to the cursor's project (#1620). Dispatch is root-routed
+	// (handleProjectsFocus), so this name never appears in GlobalKeyStringsMap.
+	KeySwitchProjectRow
+
 	// Interactive mode (#1089, RFC §2.3): Enter on a live pane enters it —
 	// every subsequent keystroke (including Tab) forwards to the agent/shell
 	// in-pane, no full-screen takeover. KeyAttach keeps the full-screen tmux
@@ -147,6 +153,7 @@ var specs = []spec{
 	{name: KeyJumpTab, keys: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}, helpLabel: "1-9", desc: "jump"},
 	{name: KeyTaskList, configKey: "tasks", keys: []string{"m"}, desc: "tasks", dispatch: true},
 	{name: KeyManageAutomations, keys: []string{"enter"}, desc: "manage"},
+	{name: KeySwitchProjectRow, keys: []string{"enter"}, desc: "switch"},
 	{name: KeyOpenPane, configKey: "open_pane", keys: []string{"s"}, desc: "open pane", dispatch: true},
 	{name: KeySplitPane, configKey: "split_pane", keys: []string{"S"}, desc: "split pane", dispatch: true},
 	{name: KeyHidePane, configKey: "hide_pane", keys: []string{"x"}, desc: "hide pane", dispatch: true},

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -92,6 +92,17 @@ var automationsMenuOptions = []keys.KeyName{
 	keys.KeyManageAutomations, keys.KeyTab, keys.KeyHooks, keys.KeyHelp, keys.KeyQuit,
 }
 
+// projectsMenuOptions are the status-bar hints while the bottom Projects section
+// has focus (#1620): the section is a captive vim-style list, so the bar
+// advertises exactly the keys that DO something there — Enter switches to the
+// cursor's project and `/` opens search — plus the cross-region focus/help/quit.
+// Every other key is a no-op in handleProjectsFocus, so listing the instance
+// verbs here (as the pre-#1620 fall-through footer did) would advertise keys that
+// do nothing.
+var projectsMenuOptions = []keys.KeyName{
+	keys.KeySwitchProjectRow, keys.KeySearch, keys.KeyTab, keys.KeyHelp, keys.KeyQuit,
+}
+
 // interactiveMenuOptions is the whole bar while interactive (#1089, RFC
 // §2.3): every other key — including these hints' own letters — forwards to
 // the pane's terminal, so advertising anything else would be a lie.
@@ -194,6 +205,17 @@ func (m *Menu) updateOptions() {
 		m.groups = []menuGroup{
 			{start: 0, end: 1, isAction: true},
 			{start: 1, end: len(automationsMenuOptions), isAction: false},
+		}
+		return
+	}
+	// The bottom Projects section owns the hints while focused (#1620), mirroring
+	// the automations branch: Enter switch / `/` search are its actions, the rest
+	// is cross-region chrome. Naming's submit/change-program hints still win.
+	if m.focusRegion == layout.RegionProjects && m.state != StateNewInstance {
+		m.options = projectsMenuOptions
+		m.groups = []menuGroup{
+			{start: 0, end: 2, isAction: true},
+			{start: 2, end: len(projectsMenuOptions), isAction: false},
 		}
 		return
 	}

--- a/ui/menu_test.go
+++ b/ui/menu_test.go
@@ -318,6 +318,48 @@ func TestMenuPaneHintsFollowFocus(t *testing.T) {
 	}
 }
 
+// TestMenuProjectsFocusFooterIsHonest pins the #1620 fix: with the bottom
+// Projects section focused, the footer advertises exactly the section's live
+// affordances — Enter switch and `/` search — plus the cross-region
+// focus/help/quit. It must NOT fall through to the instance verbs (n new,
+// D kill, s open pane), which are all no-ops there now, so the footer never
+// advertises a key that does nothing.
+func TestMenuProjectsFocusFooterIsHonest(t *testing.T) {
+	m := NewMenu()
+	m.SetInstance(readyUIInstance())
+	m.SetFocusRegion(layout.RegionProjects)
+
+	has := func(want keys.KeyName) bool {
+		for _, k := range m.options {
+			if k == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !has(keys.KeySwitchProjectRow) || !has(keys.KeySearch) {
+		t.Errorf("Projects focus must advertise switch + search; options=%v", m.options)
+	}
+	if !has(keys.KeyTab) || !has(keys.KeyHelp) || !has(keys.KeyQuit) {
+		t.Errorf("Projects focus keeps the focus/help/quit chrome; options=%v", m.options)
+	}
+	for _, leak := range []keys.KeyName{keys.KeyNew, keys.KeyKill, keys.KeyOpenPane, keys.KeyNewTab} {
+		if has(leak) {
+			t.Errorf("Projects focus must not advertise instance verb %v (it is a no-op there); options=%v", leak, m.options)
+		}
+	}
+
+	m.SetSize(120, 1)
+	out := m.String()
+	if !strings.Contains(out, "search") || !strings.Contains(out, "switch") {
+		t.Fatalf("Projects footer must render switch + search:\n%s", out)
+	}
+	if strings.Contains(out, "new") {
+		t.Fatalf("Projects footer must not render the instance 'new' verb:\n%s", out)
+	}
+}
+
 func TestMenuNarrowPaneFocusDoesNotShowHideWithoutOpen(t *testing.T) {
 	m := NewMenu()
 	m.SetInstance(readyUIInstance())


### PR DESCRIPTION
Fixes #1620. Two input-behavior fixes to the bottom **Projects** sidebar section (the Tab-focusable section below Automations, from #1590).

## Current behavior found

With the Projects section focused (`RegionProjects`):

- **Vim scroll already worked** — `ProjectsPane.HandleKey` maps `j`/`k`/`↓`/`↑` to cursor moves and the pane windows its offset (shipped in #1590).
- **Search was not gated.** `handleProjectsFocus` consumed only cursor-nav/Enter/Esc and let *everything else fall through to the global key map*. So from Projects focus:
  - `/` opened the session search overlay,
  - **`ctrl+p` opened the project-picker filter-as-you-type overlay**,
  - `n` created a session, `m` opened tasks, `h`/`l` collapsed/expanded + stole focus to the tree.

  That fall-through is why non-`/` keys "start searching/filtering".
- **The footer lied.** `ui/menu.go` had cases for `RegionAutomations` and pane regions but **no `RegionProjects` case**, so the Projects footer rendered the *instance* menu (`n new · D kill · s open pane`) — advertising keys that don't belong to the section.

## The two changes

1. **Vim-scrollable** — kept; verified j/k/↓/↑ move the cursor and scroll the list when it overflows, matching Instances nav. (No code change needed; covered by new tests + play-test.)
2. **Search only on `/`** — `handleProjectsFocus` is now a **captive vim-list**: `j/k` navigate, `Enter` switches project, `Esc` returns to the tree, and `/` (`keys.KeySearch`) is the **only** key that opens a search. Every other key is a consumed no-op — no session-create, no tasks overlay, no collapse/expand, and **no ctrl+p project-picker filter**. Only the focus ring (`Tab`/`Shift-Tab`), `?` help, `q` quit, and `ctrl+c` fall through, so the user is never trapped.

Scoped to Projects focus — Instances and Automations are untouched.

### Honest footer (required by the above)

Because non-`/` keys are now no-ops, the old instance-menu footer would advertise dead keys — and it was also fooling the `tui-driver`'s `af_focus_tree` (which finds the tree by the `n new` hint). Added a `RegionProjects` menu case + a display-only `KeySwitchProjectRow` alias so the footer reads:

```
↵ switch · / search │ tab focus · ? help · q quit
```

## Gates

- `gofmt` / `go build ./...` / `deadcode -test ./...` / `scripts/lint-file-length.sh` / `golangci-lint run --fast` — clean
- `make test-container` — all packages green (incl. new `app`/`ui` tests)
- `make tui-driver-selftest` — **25/25** (this fix also un-breaks the self-test's `af_focus_tree`)
- Exploratory Projects play-test in the container sandbox (9 seeded `root_agents` projects + the active repo):

```
  PASS Tab reaches the Projects section
  PASS footer advertises '/ search'
  PASS footer no longer shows 'n new' / instance verbs
>>> visible project rows at top:    mock-repo (1),proj-1 (1),proj-2 (1),proj-3 (1),proj-4 (1),proj-5 (1),proj-6 (1),
>>> visible project rows after 7x j: proj-1 (1),proj-2 (1),proj-3 (1),proj-4 (1),proj-5 (1),proj-6 (1),proj-7 (1),
  PASS j scrolls the projects list (window shifted)
  PASS k scrolls back to the top of the list
  PASS '/' opens the session search overlay
  PASS 'n' is a no-op in Projects (no naming prompt)
  PASS ctrl+p is a no-op in Projects (no picker/filter)
  PASS 'z' (unbound) starts no search/filter
  PASS focus stayed on Projects after the no-op keys

=== play-test: 10 passed, 0 failed ===
```

## Notes

- `/` opens the existing **session** search overlay (that is what `keys.KeySearch` binds), per the issue's wording ("only enter search when `/` … `keys.KeySearch`"). It needs ≥1 session in the active repo (existing `showSearchOverlay` behavior); happy to redirect `/` to a project-scoped filter instead if that's preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
