### PR TITLE
refactor(tui): route TUI control+read through apiclient, drop net/rpc from the TUI (#1592 Phase 2 PR3)

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -28,6 +29,30 @@ import (
 	"github.com/sachiniyer/agent-factory/apiproto"
 	"github.com/sachiniyer/agent-factory/daemon"
 )
+
+// TransportError wraps a failure to REACH the daemon HTTP socket — a refused
+// dial, a missing socket file, a read error mid-response — as opposed to an
+// application error the daemon returned inside the envelope. The two are
+// categorically different: an envelope error is a real, deterministic failure
+// (session not found, repo invalid) that will recur, while a transport error on
+// a just-spawned daemon is a transient bind race — the daemon binds its HTTP
+// socket microseconds AFTER the control socket EnsureDaemon waits for (see the
+// daemon boot order), so a call fired in that window sees connection-refused.
+// Callers distinguish the two with IsTransportError so they can retry a bind
+// race without ever masking a real daemon error by retrying it.
+type TransportError struct{ Err error }
+
+func (e *TransportError) Error() string { return e.Err.Error() }
+func (e *TransportError) Unwrap() error { return e.Err }
+
+// IsTransportError reports whether err (or anything it wraps) is a TransportError
+// — a failure to reach the daemon socket rather than an error the daemon
+// returned. Envelope/application errors are never TransportErrors, so a caller
+// retrying on this signal can never spin on a deterministic failure.
+func IsTransportError(err error) bool {
+	var te *TransportError
+	return errors.As(err, &te)
+}
 
 // dialTimeout bounds how long the client waits to connect to the daemon HTTP
 // socket. It mirrors the net/rpc control client's dial timeout so the two read
@@ -98,13 +123,15 @@ func (c *Client) call(method string, req any, resp any) error {
 
 	httpResp, err := c.httpClient.Post(httpBaseURL+"/v1/"+method, "application/json", bytes.NewReader(reqBody))
 	if err != nil {
-		return err
+		// The round-trip never reached a daemon handler — refused dial, missing
+		// socket, etc. Tag it so a caller can tell a bind race from a real error.
+		return &TransportError{Err: err}
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
 	raw, err := io.ReadAll(httpResp.Body)
 	if err != nil {
-		return fmt.Errorf("apiclient: read response body: %w", err)
+		return &TransportError{Err: fmt.Errorf("apiclient: read response body: %w", err)}
 	}
 
 	// Decode into a RawMessage-backed envelope so the typed response is decoded

--- a/apiclient/control.go
+++ b/apiclient/control.go
@@ -1,0 +1,140 @@
+package apiclient
+
+import (
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/task"
+)
+
+// This file grows the HTTP client past the read-only Snapshot path (PR2) onto
+// the full control + task surface the TUI drives (#1592 Phase 2 PR3). Each
+// method is the HTTP twin of the identically-named net/rpc client wrapper the
+// daemon package used to expose: same request/response structs, same return
+// shape, so a caller swaps `daemon.X(req)` for `client.X(req)` with no other
+// change and gets byte-identical results (the envelope guarantees parity). The
+// TUI is the first full consumer — it now routes create/kill/archive/restore/
+// tab/PR-info/task/poll-pause/limit-resume through here instead of net/rpc, so
+// the gob control client stays only for CLI/internal callers.
+
+// CreateSession asks the daemon to create, start, and persist a session.
+func (c *Client) CreateSession(req daemon.CreateSessionRequest) (*session.InstanceData, error) {
+	var resp daemon.CreateSessionResponse
+	if err := c.call("CreateSession", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Instance, nil
+}
+
+// KillSession asks the daemon to kill a session and remove it from storage.
+func (c *Client) KillSession(req daemon.KillSessionRequest) error {
+	return c.call("KillSession", req, &daemon.KillSessionResponse{})
+}
+
+// ArchiveSession asks the daemon to archive a session (#1028) and returns the
+// relocated worktree's new path.
+func (c *Client) ArchiveSession(req daemon.ArchiveSessionRequest) (string, error) {
+	var resp daemon.ArchiveSessionResponse
+	if err := c.call("ArchiveSession", req, &resp); err != nil {
+		return "", err
+	}
+	return resp.ArchivedPath, nil
+}
+
+// RestoreSession asks the daemon to restore an archived, Lost, or Dead session.
+func (c *Client) RestoreSession(req daemon.RestoreSessionRequest) (string, error) {
+	var resp daemon.RestoreSessionResponse
+	if err := c.call("RestoreSession", req, &resp); err != nil {
+		return "", err
+	}
+	return resp.WorktreePath, nil
+}
+
+// ResumeFromLimit asks the daemon to resume a usage-limit-blocked session
+// (#1146) — the TUI's `c` key. It rides an internal (non-cataloged) route: a
+// client-facing session verb the `af api` catalog does not advertise.
+func (c *Client) ResumeFromLimit(req daemon.ResumeFromLimitRequest) error {
+	return c.call("ResumeFromLimit", req, &daemon.ResumeFromLimitResponse{})
+}
+
+// CreateTab asks the daemon to spawn, persist, and report a new process/shell
+// tab on an existing session, returning the resolved (collision-suffixed) name.
+func (c *Client) CreateTab(req daemon.CreateTabRequest) (string, error) {
+	var resp daemon.CreateTabResponse
+	if err := c.call("CreateTab", req, &resp); err != nil {
+		return "", err
+	}
+	return resp.Name, nil
+}
+
+// CloseTab asks the daemon to close a non-agent tab and returns the resolved
+// name of the tab that was closed.
+func (c *Client) CloseTab(req daemon.CloseTabRequest) (string, error) {
+	var resp daemon.CloseTabResponse
+	if err := c.call("CloseTab", req, &resp); err != nil {
+		return "", err
+	}
+	return resp.Name, nil
+}
+
+// SetPRInfo asks the daemon to record (or clear) a session's GitHub PR info.
+func (c *Client) SetPRInfo(req daemon.SetPRInfoRequest) error {
+	return c.call("SetPRInfo", req, &daemon.SetPRInfoResponse{})
+}
+
+// ImportRemoteHookSessions asks the daemon to reconcile remote sessions
+// reported by list_cmd into persisted storage.
+func (c *Client) ImportRemoteHookSessions(req daemon.ImportRemoteHookSessionsRequest) ([]session.InstanceData, error) {
+	var resp daemon.ImportRemoteHookSessionsResponse
+	if err := c.call("ImportRemoteHookSessions", req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Instances, nil
+}
+
+// PauseStatusPoll asks the daemon to pause its capture-pane liveness poll for
+// one attached session (#1160). Best-effort attach coordination; it rides an
+// internal (non-cataloged) route because it is daemon infra, not a public verb.
+func (c *Client) PauseStatusPoll(req daemon.PauseStatusPollRequest) error {
+	return c.call("PauseStatusPoll", req, &daemon.PauseStatusPollResponse{})
+}
+
+// ResumeStatusPoll asks the daemon to resume polling a session on a clean
+// detach (#1160). Internal (non-cataloged) route, like PauseStatusPoll.
+func (c *Client) ResumeStatusPoll(req daemon.ResumeStatusPollRequest) error {
+	return c.call("ResumeStatusPoll", req, &daemon.ResumeStatusPollResponse{})
+}
+
+// AddTask asks the daemon to append a task and re-arm its schedule set.
+func (c *Client) AddTask(t task.Task) error {
+	return c.call("AddTask", daemon.AddTaskRequest{Task: t}, &daemon.AddTaskResponse{})
+}
+
+// UpdateTask asks the daemon to persist an edited task and re-arm its schedule.
+func (c *Client) UpdateTask(t task.Task) error {
+	return c.call("UpdateTask", daemon.UpdateTaskRequest{Task: t}, &daemon.UpdateTaskResponse{})
+}
+
+// RemoveTask asks the daemon to delete a task and re-arm its schedule.
+func (c *Client) RemoveTask(id string) error {
+	return c.call("RemoveTask", daemon.RemoveTaskRequest{ID: id}, &daemon.RemoveTaskResponse{})
+}
+
+// TriggerTask asks the daemon to fire a task now through the shared RunTask
+// firing path (the same entrypoint the scheduler uses).
+func (c *Client) TriggerTask(id string) error {
+	return c.call("TriggerTask", daemon.TriggerTaskRequest{ID: id}, &daemon.TriggerTaskResponse{})
+}
+
+// SnapshotWithAlarms is Snapshot plus the persistent delivery-failure alarms
+// carried on the same authoritative response (#1238). It is the TUI's read
+// path: the session list and the alarm projection arrive from one call, so the
+// alarm is a field on the snapshot, not a side channel. Plain Snapshot (which
+// drops the alarms) stays the read path for CLI/API callers that only need the
+// session list.
+func (c *Client) SnapshotWithAlarms(req daemon.SnapshotRequest) (daemon.SnapshotResponse, error) {
+	var resp daemon.SnapshotResponse
+	if err := c.call("Snapshot", req, &resp); err != nil {
+		return daemon.SnapshotResponse{}, err
+	}
+	return resp, nil
+}

--- a/apiclient/control_test.go
+++ b/apiclient/control_test.go
@@ -1,0 +1,166 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// routeServer stands up a real Unix-socket HTTP server that answers a single
+// POST /v1/<method> route through the shared apiproto.WriteEnvelope — the exact
+// primitive daemon/httpserver.go uses — and returns a Client dialing it. Using
+// the real envelope writer makes each round-trip a genuine parity proof rather
+// than a mock agreeing with itself, exactly like snapshotServer does for reads.
+func routeServer(t *testing.T, method string, handle func(body []byte) apiproto.Envelope) *Client {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "daemon-http.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/"+method, func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = apiproto.WriteEnvelope(w, handle(body))
+	})
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return NewWithSocket(sockPath)
+}
+
+// TestControlRoundTrips drives each control method the TUI now routes over HTTP
+// through the real transport + envelope, asserting the request field the daemon
+// saw and the value the client decoded back. It is the write-side twin of the
+// PR2 read-side parity proof: the same structs go in and come out.
+func TestControlRoundTrips(t *testing.T) {
+	t.Run("CreateSession", func(t *testing.T) {
+		var got daemon.CreateSessionRequest
+		c := routeServer(t, "CreateSession", func(b []byte) apiproto.Envelope {
+			_ = json.Unmarshal(b, &got)
+			return apiproto.Success(daemon.CreateSessionResponse{
+				Instance: session.InstanceData{Title: got.Title, Program: got.Program},
+			})
+		})
+		inst, err := c.CreateSession(daemon.CreateSessionRequest{Title: "alpha", Program: "claude"})
+		if err != nil {
+			t.Fatalf("CreateSession: %v", err)
+		}
+		if got.Title != "alpha" || got.Program != "claude" {
+			t.Fatalf("daemon saw %+v, want title=alpha program=claude", got)
+		}
+		if inst == nil || inst.Title != "alpha" {
+			t.Fatalf("decoded instance = %+v, want Title=alpha", inst)
+		}
+	})
+
+	t.Run("ArchiveSession returns path", func(t *testing.T) {
+		c := routeServer(t, "ArchiveSession", func([]byte) apiproto.Envelope {
+			return apiproto.Success(daemon.ArchiveSessionResponse{ArchivedPath: "/arch/alpha"})
+		})
+		path, err := c.ArchiveSession(daemon.ArchiveSessionRequest{Title: "alpha"})
+		if err != nil || path != "/arch/alpha" {
+			t.Fatalf("ArchiveSession = %q, %v; want /arch/alpha", path, err)
+		}
+	})
+
+	t.Run("CreateTab returns resolved name", func(t *testing.T) {
+		c := routeServer(t, "CreateTab", func([]byte) apiproto.Envelope {
+			return apiproto.Success(daemon.CreateTabResponse{Name: "shell-2"})
+		})
+		name, err := c.CreateTab(daemon.CreateTabRequest{Title: "alpha", Shell: true})
+		if err != nil || name != "shell-2" {
+			t.Fatalf("CreateTab = %q, %v; want shell-2", name, err)
+		}
+	})
+
+	t.Run("KillSession success", func(t *testing.T) {
+		c := routeServer(t, "KillSession", func([]byte) apiproto.Envelope {
+			return apiproto.Success(daemon.KillSessionResponse{OK: true})
+		})
+		if err := c.KillSession(daemon.KillSessionRequest{Title: "alpha"}); err != nil {
+			t.Fatalf("KillSession: %v", err)
+		}
+	})
+
+	t.Run("ResumeFromLimit rides internal route", func(t *testing.T) {
+		c := routeServer(t, "ResumeFromLimit", func([]byte) apiproto.Envelope {
+			return apiproto.Success(daemon.ResumeFromLimitResponse{OK: true})
+		})
+		if err := c.ResumeFromLimit(daemon.ResumeFromLimitRequest{Title: "alpha"}); err != nil {
+			t.Fatalf("ResumeFromLimit: %v", err)
+		}
+	})
+
+	t.Run("PauseStatusPoll rides internal route", func(t *testing.T) {
+		c := routeServer(t, "PauseStatusPoll", func([]byte) apiproto.Envelope {
+			return apiproto.Success(daemon.PauseStatusPollResponse{OK: true})
+		})
+		if err := c.PauseStatusPoll(daemon.PauseStatusPollRequest{Title: "alpha"}); err != nil {
+			t.Fatalf("PauseStatusPoll: %v", err)
+		}
+	})
+}
+
+// TestSnapshotWithAlarms_CarriesAlarms verifies the TUI read path decodes both
+// the session list AND the delivery-failure alarms from one response — the alarm
+// is a field on the snapshot (#1238), not a side channel dropped by plain
+// Snapshot.
+func TestSnapshotWithAlarms_CarriesAlarms(t *testing.T) {
+	since := time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC)
+	c := routeServer(t, "Snapshot", func([]byte) apiproto.Envelope {
+		return apiproto.Success(daemon.SnapshotResponse{
+			Instances:      []session.InstanceData{{Title: "alpha"}},
+			DeliveryAlarms: []daemon.DeliveryAlarm{{TaskName: "watch", Pending: 3, Since: since}},
+		})
+	})
+	resp, err := c.SnapshotWithAlarms(daemon.SnapshotRequest{RepoID: "r"})
+	if err != nil {
+		t.Fatalf("SnapshotWithAlarms: %v", err)
+	}
+	if len(resp.Instances) != 1 || resp.Instances[0].Title != "alpha" {
+		t.Fatalf("instances = %+v, want one alpha", resp.Instances)
+	}
+	if len(resp.DeliveryAlarms) != 1 || resp.DeliveryAlarms[0].Pending != 3 {
+		t.Fatalf("alarms = %+v, want one pending=3", resp.DeliveryAlarms)
+	}
+}
+
+// TestControlError_SurfacesEnvelopeMessage verifies a daemon failure envelope
+// surfaces as a plain error carrying the daemon's message verbatim — and is NOT
+// a TransportError, so the TUI's warm-up retry never spins on a real failure.
+func TestControlError_SurfacesEnvelopeMessage(t *testing.T) {
+	c := routeServer(t, "KillSession", func([]byte) apiproto.Envelope {
+		return apiproto.Failure("session \"ghost\" not found")
+	})
+	err := c.KillSession(daemon.KillSessionRequest{Title: "ghost"})
+	if err == nil || err.Error() != "session \"ghost\" not found" {
+		t.Fatalf("want verbatim daemon message, got %v", err)
+	}
+	if IsTransportError(err) {
+		t.Fatal("an envelope/application error must not be classified as a TransportError")
+	}
+}
+
+// TestTransportError_OnUnreachableSocket verifies that a call to a socket with
+// nothing listening yields a TransportError — the signal the TUI retries while a
+// just-spawned daemon's HTTP socket finishes binding.
+func TestTransportError_OnUnreachableSocket(t *testing.T) {
+	c := NewWithSocket(filepath.Join(t.TempDir(), "does-not-exist.sock"))
+	err := c.KillSession(daemon.KillSessionRequest{Title: "x"})
+	if err == nil {
+		t.Fatal("want an error dialing a dead socket")
+	}
+	if !IsTransportError(err) {
+		t.Fatalf("want TransportError for an unreachable socket, got %T: %v", err, err)
+	}
+}

--- a/app/handle_actions.go
+++ b/app/handle_actions.go
@@ -231,12 +231,13 @@ func killConfirmMessage(title, warning string, reserved bool) string {
 }
 
 // killInstanceCmd returns a tea.Cmd that performs the actual session teardown
-// off the event loop. The daemon RPC blocks for the whole teardown — for
+// off the event loop. The daemon call blocks for the whole teardown — for
 // remote instances delete_cmd often runs over ssh and takes tens of seconds —
 // which is exactly why this must not run on the Update goroutine (#844). The
 // teardown itself (delete_cmd → tmux kill → worktree removal, #802 ordering)
-// is unchanged: it still goes through daemon.KillSession, which also keeps
-// the title blocked against reuse until the teardown completes.
+// is unchanged: it goes through the killSessionThroughDaemon seam — now the HTTP
+// apiclient's KillSession (#1592 Phase 2 PR3) — which keeps the title blocked
+// against reuse until the teardown completes.
 func (m *home) killInstanceCmd(title string) tea.Cmd {
 	repoID := m.repoID
 	// Capture the kill seam on the event loop, before the goroutine: it is a

--- a/app/session_control.go
+++ b/app/session_control.go
@@ -1,10 +1,70 @@
 package app
 
 import (
+	"time"
+
+	"github.com/sachiniyer/agent-factory/apiclient"
 	"github.com/sachiniyer/agent-factory/daemon"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
 )
+
+// The TUI drives every daemon control + read call over the HTTP API client
+// (#1592 Phase 2 PR3): it no longer touches the net/rpc control client at all.
+// The gob control socket stays for CLI/internal callers; the TUI is now a thin
+// HTTP client. Each seam below builds a fresh apiclient.Client per call — the
+// same per-call dial the net/rpc callDaemon did — and only daemon.EnsureDaemon
+// (a lifecycle concern, transport-agnostic) survives from the old path, to spawn
+// the daemon at cold start exactly as callDaemon's implicit ensure used to.
+
+// daemonHTTPWarmup{Wait,Poll} bound the retry the TUI's HTTP calls tolerate
+// while a freshly-ensured daemon finishes coming up. Two transient conditions
+// need it and both clear inside this window: (1) the daemon reports the #829
+// "still restoring sessions" starting error, and (2) its HTTP socket has not
+// finished binding — the daemon binds daemon-http.sock microseconds AFTER the
+// control socket EnsureDaemon waits for (daemon boot order), so a call fired in
+// that sliver sees a transport refusal. The values mirror the net/rpc callDaemon
+// warm-up (daemonReadyTimeout / a 100ms cadence) so the switch is behavior-
+// preserving.
+const (
+	daemonHTTPWarmupWait = 5 * time.Second
+	daemonHTTPWarmupPoll = 100 * time.Millisecond
+)
+
+// withDaemonHTTP ensures a daemon is running, then invokes fn against a fresh
+// HTTP client, retrying while the daemon is warming (starting error) or its
+// HTTP socket has not yet bound (transport error). It is the HTTP twin of the
+// net/rpc callDaemon: EnsureDaemon spawns the daemon if absent (the TUI relied
+// on callDaemon's implicit ensure to boot the daemon at cold start — spawning is
+// a lifecycle concern, independent of which transport the control calls take),
+// then the call rides daemon-http.sock. A package var so a future integration
+// test can point it at a fake without a real daemon; the unit suite stubs the
+// higher-level *ThroughDaemon seams instead, so this runs only in production.
+var withDaemonHTTP = func(fn func(*apiclient.Client) error) error {
+	if err := daemon.EnsureDaemon(); err != nil {
+		return err
+	}
+	c, err := apiclient.New()
+	if err != nil {
+		return err
+	}
+	err = fn(c)
+	deadline := time.Now().Add(daemonHTTPWarmupWait)
+	for httpCallWarming(err) && time.Now().Before(deadline) {
+		time.Sleep(daemonHTTPWarmupPoll)
+		err = fn(c)
+	}
+	return err
+}
+
+// httpCallWarming reports whether an HTTP control error is a transient warm-up
+// condition worth retrying: the daemon's #829 starting error, or a transport
+// failure while its HTTP socket finishes binding. A daemon application error
+// (session not found, invalid repo) comes back as an envelope message — never a
+// TransportError — so it is never retried and surfaces to the caller at once.
+func httpCallWarming(err error) bool {
+	return daemon.IsDaemonStartingErr(err) || apiclient.IsTransportError(err)
+}
 
 type sessionStartRequest struct {
 	Title       string
@@ -17,14 +77,19 @@ type sessionStartRequest struct {
 }
 
 var startSessionThroughDaemon = func(_ *session.Instance, req sessionStartRequest) (*session.Instance, error) {
-	data, err := daemon.CreateSession(daemon.CreateSessionRequest{
-		Title:       req.Title,
-		TitleBase:   req.TitleBase,
-		RepoPath:    req.RepoPath,
-		Program:     req.Program,
-		Prompt:      req.Prompt,
-		AutoYes:     req.AutoYes,
-		ForceRemote: req.ForceRemote,
+	var data *session.InstanceData
+	err := withDaemonHTTP(func(c *apiclient.Client) error {
+		var e error
+		data, e = c.CreateSession(daemon.CreateSessionRequest{
+			Title:       req.Title,
+			TitleBase:   req.TitleBase,
+			RepoPath:    req.RepoPath,
+			Program:     req.Program,
+			Prompt:      req.Prompt,
+			AutoYes:     req.AutoYes,
+			ForceRemote: req.ForceRemote,
+		})
+		return e
 	})
 	if err != nil {
 		return nil, err
@@ -33,18 +98,32 @@ var startSessionThroughDaemon = func(_ *session.Instance, req sessionStartReques
 }
 
 var killSessionThroughDaemon = func(title, repoID string) error {
-	return daemon.KillSession(daemon.KillSessionRequest{Title: title, RepoID: repoID})
+	return withDaemonHTTP(func(c *apiclient.Client) error {
+		return c.KillSession(daemon.KillSessionRequest{Title: title, RepoID: repoID})
+	})
 }
 
 // archiveSessionThroughDaemon / restoreSessionThroughDaemon route archive and
 // restore verbs through the daemon (the single writer). Package vars so the app
 // test suite can stub them without dialing a real daemon.
 var archiveSessionThroughDaemon = func(title, repoID string) (string, error) {
-	return daemon.ArchiveSession(daemon.ArchiveSessionRequest{Title: title, RepoID: repoID})
+	var path string
+	err := withDaemonHTTP(func(c *apiclient.Client) error {
+		var e error
+		path, e = c.ArchiveSession(daemon.ArchiveSessionRequest{Title: title, RepoID: repoID})
+		return e
+	})
+	return path, err
 }
 
 var restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
-	return daemon.RestoreSession(daemon.RestoreSessionRequest{Title: title, RepoID: repoID})
+	var path string
+	err := withDaemonHTTP(func(c *apiclient.Client) error {
+		var e error
+		path, e = c.RestoreSession(daemon.RestoreSessionRequest{Title: title, RepoID: repoID})
+		return e
+	})
+	return path, err
 }
 
 // resumeFromLimitThroughDaemon routes the TUI's `c` (retry usage-limit session)
@@ -53,7 +132,9 @@ var restoreSessionThroughDaemon = func(title, repoID string) (string, error) {
 // state. A package var so the app test suite can stub it without dialing a real
 // daemon.
 var resumeFromLimitThroughDaemon = func(title, repoID string) error {
-	return daemon.ResumeFromLimit(daemon.ResumeFromLimitRequest{Title: title, RepoID: repoID})
+	return withDaemonHTTP(func(c *apiclient.Client) error {
+		return c.ResumeFromLimit(daemon.ResumeFromLimitRequest{Title: title, RepoID: repoID})
+	})
 }
 
 // triggerTaskThroughDaemon runs a task by ID through the daemon's single shared
@@ -66,7 +147,11 @@ var resumeFromLimitThroughDaemon = func(title, repoID string) error {
 // unconditionally spawned a new session and orphaned the target (#1169). It is a
 // package var so the app test suite can stub the trigger without dialing a real
 // daemon.
-var triggerTaskThroughDaemon = daemon.TriggerTask
+var triggerTaskThroughDaemon = func(taskID string) error {
+	return withDaemonHTTP(func(c *apiclient.Client) error {
+		return c.TriggerTask(taskID)
+	})
+}
 
 // addTaskThroughDaemon / updateTaskThroughDaemon / removeTaskThroughDaemon route
 // the TUI's own task CRUD (create in the inline form, edit/toggle/delete in the
@@ -89,9 +174,15 @@ var triggerTaskThroughDaemon = daemon.TriggerTask
 // package globals are race-safe here (no off-loop goroutine reads them, unlike
 // the snapshot fetcher / poll-pause seams).
 var (
-	addTaskThroughDaemon    = daemon.AddTask
-	updateTaskThroughDaemon = daemon.UpdateTask
-	removeTaskThroughDaemon = daemon.RemoveTask
+	addTaskThroughDaemon = func(t task.Task) error {
+		return withDaemonHTTP(func(c *apiclient.Client) error { return c.AddTask(t) })
+	}
+	updateTaskThroughDaemon = func(t task.Task) error {
+		return withDaemonHTTP(func(c *apiclient.Client) error { return c.UpdateTask(t) })
+	}
+	removeTaskThroughDaemon = func(id string) error {
+		return withDaemonHTTP(func(c *apiclient.Client) error { return c.RemoveTask(id) })
+	}
 )
 
 // pauseStatusPollThroughDaemon / resumeStatusPollThroughDaemon route the TUI's
@@ -107,15 +198,25 @@ var (
 // race). The seams live per-home instead; tests assign a fake to
 // h.pauseStatusPoll / h.resumeStatusPoll directly.
 func pauseStatusPollThroughDaemon(title, repoID string) error {
-	return daemon.PauseStatusPoll(daemon.PauseStatusPollRequest{Title: title, RepoID: repoID})
+	return withDaemonHTTP(func(c *apiclient.Client) error {
+		return c.PauseStatusPoll(daemon.PauseStatusPollRequest{Title: title, RepoID: repoID})
+	})
 }
 
 func resumeStatusPollThroughDaemon(title, repoID string) error {
-	return daemon.ResumeStatusPoll(daemon.ResumeStatusPollRequest{Title: title, RepoID: repoID})
+	return withDaemonHTTP(func(c *apiclient.Client) error {
+		return c.ResumeStatusPoll(daemon.ResumeStatusPollRequest{Title: title, RepoID: repoID})
+	})
 }
 
 var importRemoteSessionsThroughDaemon = func(repoPath string) ([]session.InstanceData, error) {
-	return daemon.ImportRemoteHookSessions(daemon.ImportRemoteHookSessionsRequest{RepoPath: repoPath})
+	var listed []session.InstanceData
+	err := withDaemonHTTP(func(c *apiclient.Client) error {
+		var e error
+		listed, e = c.ImportRemoteHookSessions(daemon.ImportRemoteHookSessionsRequest{RepoPath: repoPath})
+		return e
+	})
+	return listed, err
 }
 
 // createShellTabThroughDaemon routes the TUI's `t` (new shell tab) mutation to
@@ -123,15 +224,23 @@ var importRemoteSessionsThroughDaemon = func(repoPath string) ([]session.Instanc
 // persist, returning the resolved tab name. The TUI reflects the new tab locally
 // for instant display via Instance.AttachShellTab.
 var createShellTabThroughDaemon = func(title, repoID string) (string, error) {
-	return daemon.CreateTab(daemon.CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
+	var name string
+	err := withDaemonHTTP(func(c *apiclient.Client) error {
+		var e error
+		name, e = c.CreateTab(daemon.CreateTabRequest{Title: title, RepoID: repoID, Shell: true})
+		return e
+	})
+	return name, err
 }
 
 // closeTabThroughDaemon routes the TUI's `w` (close tab) mutation to the daemon,
 // which kills the tab's tmux session and persists the shrunk list. The TUI drops
 // the now-dead tab locally via Instance.DropClosedTab.
 var closeTabThroughDaemon = func(title, repoID, tabName string) error {
-	_, err := daemon.CloseTab(daemon.CloseTabRequest{Title: title, RepoID: repoID, TabName: tabName})
-	return err
+	return withDaemonHTTP(func(c *apiclient.Client) error {
+		_, e := c.CloseTab(daemon.CloseTabRequest{Title: title, RepoID: repoID, TabName: tabName})
+		return e
+	})
 }
 
 // setPRInfoThroughDaemon routes the TUI's PR-info write (prInfoUpdatedMsg) to the
@@ -139,7 +248,9 @@ var closeTabThroughDaemon = func(title, repoID, tabName string) error {
 // stays TUI-side; only the persisted write moves. The TUI keeps its in-memory
 // SetPRInfo for instant UI feedback.
 var setPRInfoThroughDaemon = func(title, repoID string, info session.PRInfoData) error {
-	return daemon.SetPRInfo(daemon.SetPRInfoRequest{Title: title, RepoID: repoID, PRInfo: info})
+	return withDaemonHTTP(func(c *apiclient.Client) error {
+		return c.SetPRInfo(daemon.SetPRInfoRequest{Title: title, RepoID: repoID, PRInfo: info})
+	})
 }
 
 // snapshotThroughDaemon fetches the daemon's authoritative session list for a
@@ -152,7 +263,13 @@ var setPRInfoThroughDaemon = func(title, repoID string, info session.PRInfoData)
 // `go test -parallel`; the fetcher lives per-home instead, and tests assign a
 // fake to home.snapshotFetcher directly (#960 PR 4 race fix).
 func snapshotThroughDaemon(repoID string) (daemon.SnapshotResponse, error) {
-	return daemon.SnapshotWithAlarms(daemon.SnapshotRequest{RepoID: repoID})
+	var resp daemon.SnapshotResponse
+	err := withDaemonHTTP(func(c *apiclient.Client) error {
+		var e error
+		resp, e = c.SnapshotWithAlarms(daemon.SnapshotRequest{RepoID: repoID})
+		return e
+	})
+	return resp, err
 }
 
 // allReposSnapshotFetcher returns the daemon's session list across EVERY repo
@@ -161,7 +278,12 @@ func snapshotThroughDaemon(repoID string) (daemon.SnapshotResponse, error) {
 // can inject a fake multi-repo snapshot. It is a plain read — the switch itself
 // still re-scopes through home.snapshotFetcher(m.repoID).
 var allReposSnapshotFetcher = func() ([]session.InstanceData, error) {
-	resp, err := daemon.SnapshotWithAlarms(daemon.SnapshotRequest{RepoID: ""})
+	var resp daemon.SnapshotResponse
+	err := withDaemonHTTP(func(c *apiclient.Client) error {
+		var e error
+		resp, e = c.SnapshotWithAlarms(daemon.SnapshotRequest{RepoID: ""})
+		return e
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/close_tab_test.go
+++ b/daemon/close_tab_test.go
@@ -412,7 +412,7 @@ func TestControlServer_CloseTab_GatedAndValidated(t *testing.T) {
 // Manager → persist wire path. It is hermetic: the launch seam is stubbed so a
 // ping race can never fork the real daemon, and the socket lives under the test
 // temp HOME.
-func TestRPCClients_CloseTabAndSetPRInfo_RoundTrip(t *testing.T) {
+func TestRPCClients_CloseTab_RoundTrip(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 
 	prevLaunch := launchDaemonProcessFn
@@ -453,16 +453,8 @@ func TestRPCClients_CloseTabAndSetPRInfo_RoundTrip(t *testing.T) {
 	if inst.TabCount() != 1 {
 		t.Fatalf("expected 1 tab after client CloseTab, got %d", inst.TabCount())
 	}
-
-	if err := SetPRInfo(SetPRInfoRequest{
-		Title:  title,
-		RepoID: repo.ID,
-		PRInfo: session.PRInfoData{Number: 7, Title: "feat", URL: "https://example/pr/7", State: "OPEN"},
-	}); err != nil {
-		t.Fatalf("SetPRInfo client: %v", err)
-	}
-	got := inst.GetPRInfo()
-	if got == nil || got.Number != 7 || got.State != "OPEN" {
-		t.Fatalf("PR info after client SetPRInfo = %+v, want Number 7 / OPEN", got)
-	}
+	// The SetPRInfo net/rpc client wrapper moved onto the HTTP apiclient in #1592
+	// Phase 2 PR3 (the TUI was its only caller), so this round-trip now covers
+	// CloseTab alone. The controlServer.SetPRInfo handler stays covered by
+	// set_prinfo_test.go.
 }

--- a/daemon/control_client.go
+++ b/daemon/control_client.go
@@ -176,18 +176,14 @@ func CloseTab(req CloseTabRequest) (string, error) {
 	return resp.Name, nil
 }
 
-// SetPRInfo asks the daemon to record (or clear) a session's GitHub PR info.
-func SetPRInfo(req SetPRInfoRequest) error {
-	var resp SetPRInfoResponse
-	if err := callDaemon("SetPRInfo", req, &resp); err != nil {
-		return err
-	}
-	return nil
-}
-
-// The TUI read path is SnapshotWithAlarms (snapshot.go): it carries the session
-// list plus the delivery-failure alarms in one authoritative response (#1238).
-// SnapshotNoSpawn below is the CLI's non-spawning, instances-only read.
+// The TUI's control + read path moved onto the HTTP apiclient in #1592 Phase 2
+// PR3, so the net/rpc client wrappers only the TUI called — SetPRInfo,
+// ImportRemoteHookSessions, PauseStatusPoll, ResumeStatusPoll (here) and
+// ResumeFromLimit / SnapshotWithAlarms (in limit.go / snapshot.go) — are gone.
+// The controlServer handlers stay: the gob control socket still SERVES every
+// verb for CLI/internal callers; only the TUI-only Go client wrappers were
+// removed. SnapshotNoSpawn below remains the CLI's non-spawning, instances-only
+// read.
 
 // ErrDaemonUnavailable signals that a non-spawning daemon read (SnapshotNoSpawn)
 // found no reachable, ready daemon: the control socket is absent/refused or the
@@ -242,30 +238,6 @@ func RestoreSession(req RestoreSessionRequest) (string, error) {
 		return "", err
 	}
 	return resp.WorktreePath, nil
-}
-
-// PauseStatusPoll asks the daemon to pause its capture-pane liveness poll for
-// one attached session (#1160). Best-effort from the caller's side: the pause
-// is lease-bounded server-side, so the worst case of a failed call is the
-// daemon keeps polling — exactly the pre-#1160 behavior — never a broken
-// attach or a permanently-blinded daemon.
-func PauseStatusPoll(req PauseStatusPollRequest) error {
-	var resp PauseStatusPollResponse
-	if err := callDaemon("PauseStatusPoll", req, &resp); err != nil {
-		return err
-	}
-	return nil
-}
-
-// ResumeStatusPoll asks the daemon to resume polling a session on a clean
-// detach so its status refreshes on the next tick instead of after the lease
-// expires (#1160).
-func ResumeStatusPoll(req ResumeStatusPollRequest) error {
-	var resp ResumeStatusPollResponse
-	if err := callDaemon("ResumeStatusPoll", req, &resp); err != nil {
-		return err
-	}
-	return nil
 }
 
 // SendPrompt asks the daemon to send a prompt to an existing session.
@@ -333,14 +305,4 @@ func RemoveTask(id string) error {
 func TriggerTask(id string) error {
 	var resp TriggerTaskResponse
 	return callDaemon("TriggerTask", TriggerTaskRequest{ID: id}, &resp)
-}
-
-// ImportRemoteHookSessions asks the daemon to reconcile remote sessions
-// reported by list_cmd into persisted storage.
-func ImportRemoteHookSessions(req ImportRemoteHookSessionsRequest) ([]session.InstanceData, error) {
-	var resp ImportRemoteHookSessionsResponse
-	if err := callDaemon("ImportRemoteHookSessions", req, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Instances, nil
 }

--- a/daemon/httproutes.go
+++ b/daemon/httproutes.go
@@ -174,10 +174,59 @@ var httpRoutes = []HTTPRoute{
 	},
 }
 
-// HTTPRoutes returns a copy of the HTTP/JSON API catalog for discovery
-// (`af api`). It is a pure, read-only description of the registered routes: it
-// does NOT dial the socket or spawn the daemon. The copy protects the internal
-// table from mutation by callers.
+// internalHTTPRoutes are routes the daemon SERVES over HTTP but deliberately
+// keeps OUT of the public `af api` catalog (#1592 Phase 2 PR3). They exist so
+// the TUI can drop net/rpc entirely and reach every verb it drives over HTTP,
+// without advertising daemon-internal coordination as public API. newHTTPMux
+// registers these alongside httpRoutes, but HTTPRoutes() (the `af api` catalog)
+// returns only httpRoutes, so the discovery surface stays exactly the
+// client-facing session/task ops it promised.
+//
+// ResumeFromLimit is a genuine client-facing session verb (the TUI `c` key); it
+// lands here rather than the public catalog only to hold the catalog steady in
+// this PR — promoting it to httpRoutes is a one-line follow-up. Pause/Resume
+// StatusPoll are attach-coordination infra (best-effort poll leases, #1160)
+// that no CLI user should call, so they belong here permanently.
+var internalHTTPRoutes = []HTTPRoute{
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/ResumeFromLimit",
+		Description:   "Resume a usage-limit-blocked session: re-spawn if needed, re-deliver the pending prompt, clear the limit.",
+		RequestFields: jsonFields(reflect.TypeOf(ResumeFromLimitRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ResumeFromLimit) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/PauseStatusPoll",
+		Description:   "Pause the daemon's liveness poll for one attached session (best-effort attach coordination).",
+		RequestFields: jsonFields(reflect.TypeOf(PauseStatusPollRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.PauseStatusPoll) },
+	},
+	{
+		Method:        http.MethodPost,
+		Path:          "/v1/ResumeStatusPoll",
+		Description:   "Resume the daemon's liveness poll for a session on a clean detach.",
+		RequestFields: jsonFields(reflect.TypeOf(ResumeStatusPollRequest{})),
+		handler:       func(cs *controlServer) http.HandlerFunc { return rpcHandler(cs.ResumeStatusPoll) },
+	},
+}
+
+// servedHTTPRoutes is every route newHTTPMux registers: the public catalog plus
+// the internal routes. The mux serves this union; HTTPRoutes() exposes only the
+// public half. Keeping them as one concatenation here means "what is served" has
+// a single definition the drift-guard test locks against.
+func servedHTTPRoutes() []HTTPRoute {
+	out := make([]HTTPRoute, 0, len(httpRoutes)+len(internalHTTPRoutes))
+	out = append(out, httpRoutes...)
+	out = append(out, internalHTTPRoutes...)
+	return out
+}
+
+// HTTPRoutes returns a copy of the PUBLIC HTTP/JSON API catalog for discovery
+// (`af api`). It is a pure, read-only description of the client-facing routes:
+// it does NOT dial the socket or spawn the daemon, and it deliberately excludes
+// internalHTTPRoutes so the advertised surface stays client-facing-only. The
+// copy protects the internal table from mutation by callers.
 func HTTPRoutes() []HTTPRoute {
 	out := make([]HTTPRoute, len(httpRoutes))
 	copy(out, httpRoutes)

--- a/daemon/httproutes_test.go
+++ b/daemon/httproutes_test.go
@@ -9,33 +9,59 @@ import (
 )
 
 // TestHTTPRoutes_MatchRegisteredMux is the drift guard: it proves the mux the
-// daemon actually serves registers PRECISELY the routes HTTPRoutes() reports —
-// no more, no less. Since both newHTTPMux and HTTPRoutes read the same
-// httpRoutes table this holds by construction; the test locks it so a future
-// change that hand-registers a route (or drops one) fails loudly instead of
-// letting the `af api` catalog silently drift from the server.
+// daemon actually serves registers PRECISELY servedHTTPRoutes() — the public
+// `af api` catalog (HTTPRoutes) PLUS the internal, non-cataloged routes — and
+// nothing beyond it. Since both newHTTPMux and servedHTTPRoutes read the same
+// tables this holds by construction; the test locks it so a future change that
+// hand-registers a route (or drops one) fails loudly. The catalog invariant is
+// checked separately below: the internal routes must NOT leak into HTTPRoutes().
 func TestHTTPRoutes_MatchRegisteredMux(t *testing.T) {
 	cs := &controlServer{}
 	mux := newHTTPMux(cs)
 
-	routes := HTTPRoutes()
-	require.NotEmpty(t, routes)
+	served := servedHTTPRoutes()
+	require.NotEmpty(t, served)
 
-	// Every cataloged route must be registered: the mux resolves it to a real
+	// Every served route must be registered: the mux resolves it to a real
 	// handler, not the catch-all. An unknown path hits the catch-all (404 with
 	// an "unknown route" envelope), so a registered path is one whose handler
 	// pattern is NOT "/".
-	for _, rt := range routes {
+	for _, rt := range served {
 		_, pattern := mux.Handler(mustRequest(t, rt.Method, rt.Path))
 		assert.Equalf(t, rt.Path, pattern,
-			"route %s %s is in the catalog but not registered on the served mux", rt.Method, rt.Path)
+			"route %s %s is served but not registered on the mux", rt.Method, rt.Path)
 	}
 
-	// Conversely, a path NOT in the catalog must fall through to the catch-all,
-	// proving the mux serves nothing beyond the catalog.
-	_, pattern := mux.Handler(mustRequest(t, http.MethodPost, "/v1/NotACatalogRoute"))
+	// Conversely, a path in NEITHER table must fall through to the catch-all,
+	// proving the mux serves nothing beyond servedHTTPRoutes().
+	_, pattern := mux.Handler(mustRequest(t, http.MethodPost, "/v1/NotAServedRoute"))
 	assert.Equal(t, "/", pattern,
-		"an off-catalog path must hit the catch-all, i.e. the mux serves only the catalog")
+		"an off-table path must hit the catch-all, i.e. the mux serves only servedHTTPRoutes()")
+}
+
+// TestHTTPRoutes_InternalRoutesAbsentFromCatalog locks the #1592 PR3 invariant:
+// the internal routes are SERVED (registered on the mux, checked above) but must
+// stay OUT of the public `af api` catalog. A regression that appends an internal
+// route to httpRoutes — leaking Pause/ResumeStatusPoll into discovery — fails
+// here.
+func TestHTTPRoutes_InternalRoutesAbsentFromCatalog(t *testing.T) {
+	require.NotEmpty(t, internalHTTPRoutes)
+
+	catalogPaths := make(map[string]bool)
+	for _, rt := range HTTPRoutes() {
+		catalogPaths[rt.Path] = true
+	}
+
+	cs := &controlServer{}
+	mux := newHTTPMux(cs)
+	for _, rt := range internalHTTPRoutes {
+		assert.Falsef(t, catalogPaths[rt.Path],
+			"internal route %s must NOT appear in the public HTTPRoutes() catalog", rt.Path)
+		// But it MUST be served, or the TUI cannot reach it over HTTP.
+		_, pattern := mux.Handler(mustRequest(t, rt.Method, rt.Path))
+		assert.Equalf(t, rt.Path, pattern,
+			"internal route %s must be registered on the served mux", rt.Path)
+	}
 }
 
 // TestHTTPRoutes_HealthShape pins the two structural invariants the catalog

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -106,17 +106,19 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 	}, nil
 }
 
-// newHTTPMux builds the route table by iterating the httpRoutes catalog — the
-// SAME list `af api` prints — so the served routes and the documented catalog
-// cannot diverge (#1029 PR 5). Every client-facing RPC has a POST /v1/<Method>
-// route dispatching to the matching controlServer method; GET /v1/health is a
-// liveness alias for Ping. Pure-infra RPCs (Shutdown, Pause/ResumeStatusPoll,
-// ReloadTasks, and bare Ping) are intentionally absent from the catalog — the
-// HTTP surface mirrors only client-facing session and task ops.
+// newHTTPMux builds the route table by iterating servedHTTPRoutes() — the public
+// `af api` catalog (httpRoutes) plus the internal, non-cataloged routes
+// (internalHTTPRoutes). Every route has a POST /v1/<Method> handler dispatching
+// to the matching controlServer method; GET /v1/health is a liveness alias for
+// Ping. The public catalog (#1029 PR 5) still mirrors only client-facing session
+// and task ops; the internal routes (#1592 Phase 2 PR3) let the TUI drop net/rpc
+// and reach ResumeFromLimit and the Pause/ResumeStatusPoll attach-coordination
+// over HTTP without advertising them in `af api`. Shutdown, ReloadTasks, and
+// bare Ping remain absent from both — daemon lifecycle, not a client verb.
 func newHTTPMux(cs *controlServer) *http.ServeMux {
 	mux := http.NewServeMux()
 
-	for _, rt := range httpRoutes {
+	for _, rt := range servedHTTPRoutes() {
 		mux.HandleFunc(rt.Path, rt.handler(cs))
 	}
 

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -133,17 +133,10 @@ type ResumeFromLimitResponse struct {
 	OK bool `json:"ok"`
 }
 
-// ResumeFromLimit asks the daemon to resume a usage-limit-blocked session
-// (#1146): re-spawn if the agent exited, re-deliver the pending prompt, and
-// clear the limit state. Surfaces the daemon's error (e.g. the session is not
-// limit-blocked) verbatim so the TUI can show it.
-func ResumeFromLimit(req ResumeFromLimitRequest) error {
-	var resp ResumeFromLimitResponse
-	if err := callDaemon("ResumeFromLimit", req, &resp); err != nil {
-		return err
-	}
-	return nil
-}
+// The net/rpc ResumeFromLimit client wrapper moved onto the HTTP apiclient in
+// #1592 Phase 2 PR3 (apiclient.Client.ResumeFromLimit, an internal non-cataloged
+// route) — the TUI's `c` key was its only caller. The controlServer handler
+// below still serves the verb over both transports.
 
 func (s *controlServer) ResumeFromLimit(req ResumeFromLimitRequest, resp *ResumeFromLimitResponse) error {
 	if err := s.requireManagerReady(); err != nil {

--- a/daemon/snapshot.go
+++ b/daemon/snapshot.go
@@ -8,9 +8,14 @@ import (
 
 // Snapshot RPC types and the delivery-failure alarm projection (#960 PR 3,
 // #1238). Extracted from control.go so that file stays under its length ceiling
-// (#1145). The client entry points (Snapshot / SnapshotNoSpawn / SnapshotWithAlarms)
+// (#1145). The remaining net/rpc client entry points (Snapshot / SnapshotNoSpawn)
 // and the controlServer.Snapshot handler live in control.go alongside the other
 // RPCs; this file owns the wire shapes and the alarm assembly.
+//
+// The TUI's SnapshotWithAlarms read moved onto the HTTP apiclient in #1592 Phase
+// 2 PR3 (apiclient.Client.SnapshotWithAlarms), so the net/rpc SnapshotWithAlarms
+// client wrapper that used to live here is gone — the TUI was its only caller.
+// CLI/API callers use the instances-only Snapshot/SnapshotNoSpawn read.
 
 // SnapshotRequest asks the daemon for the authoritative session list of a repo
 // (#960 PR 3). RepoID scopes the read like the other sessions verbs (empty =
@@ -53,20 +58,6 @@ type DeliveryAlarm struct {
 	Since time.Time `json:"since"`
 	// LastError is the most recent delivery error, for the banner detail.
 	LastError string `json:"last_error,omitempty"`
-}
-
-// SnapshotWithAlarms is Snapshot plus the persistent delivery-failure alarms
-// carried on the same authoritative response (#1238). The TUI reconcile path
-// uses it so the session list and the alarm projection arrive from one RPC —
-// the alarm is a field on the snapshot, not a side channel. Plain Snapshot
-// (which drops the alarms) stays the read path for CLI/API callers that only
-// need the session list.
-func SnapshotWithAlarms(req SnapshotRequest) (SnapshotResponse, error) {
-	var resp SnapshotResponse
-	if err := callDaemon("Snapshot", req, &resp); err != nil {
-		return SnapshotResponse{}, err
-	}
-	return resp, nil
 }
 
 // deliveryAlarms assembles the persistent delivery-failure alarms for a repo


### PR DESCRIPTION
## What & why

Phase 2 PR3 of #1592. Moves the TUI's **control + read path off the `net/rpc`
control client onto the HTTP `apiclient`** (`daemon-http.sock`). After this PR
the TUI makes **zero** net/rpc control calls — it is a thin HTTP client. The gob
control socket stays exactly as-is for CLI/internal callers; this is a clean
break for the TUI only, not a removal of the control socket.

Rebased onto master after PR4 (#1622) landed — the only shared file,
`daemon/snapshot.go`, had no server/client overlap, and PR4's `limit.go` change
(`resumeFromLimitLocked`) is a different function from the client wrapper this PR
removes, so the rebase was clean.

## What moved to apiclient

New `apiclient.Client` methods (HTTP twins of the net/rpc wrappers, same
request/response structs → byte-identical results): `CreateSession`,
`KillSession`, `ArchiveSession`, `RestoreSession`, `ResumeFromLimit`,
`CreateTab`, `CloseTab`, `SetPRInfo`, `ImportRemoteHookSessions`,
`PauseStatusPoll`, `ResumeStatusPoll`, `AddTask`, `UpdateTask`, `RemoveTask`,
`TriggerTask`, and `SnapshotWithAlarms` (the TUI read path — session list + the
#1238 delivery alarms in one response).

`app/session_control.go` now routes every seam through a small
`withDaemonHTTP(fn)` helper — the HTTP twin of the old `callDaemon`:
`daemon.EnsureDaemon()` (spawn-if-absent, a transport-agnostic *lifecycle*
concern the TUI relied on at cold start) → fresh `apiclient.Client` → the call,
with a bounded warm-up retry. `app/sync.go` reads the snapshot through the same
seam. `app/handle_actions.go` only needed a stale comment corrected.

**Behavior preservation.** The wire shape is identical, so this is a pure
transport swap. Two transient conditions are retried inside `withDaemonHTTP`, so
the switch is behavior-identical to `callDaemon`: (1) the daemon's #829
"restoring sessions" starting error (same text matcher, `IsDaemonStartingErr`),
and (2) a transport refusal while the daemon's HTTP socket finishes binding — it
binds microseconds *after* the control socket `EnsureDaemon` waits for (daemon
boot order), so a call fired in that sliver is retried. A daemon *application*
error comes back as an envelope message (never a `TransportError`), so it is
never retried — surfaced verbatim, exactly as before. New `apiclient.TransportError`
+ `IsTransportError` draw that line.

## Missing HTTP routes → internal (non-cataloged) routes

Three verbs the TUI drives had no HTTP route: `ResumeFromLimit` (never added; PR2
did the read path only) and `PauseStatusPoll`/`ResumeStatusPoll` (deliberately
kept off the public catalog as attach-coordination infra). To let the TUI drop
net/rpc entirely without advertising infra in `af api`, I added an
`internalHTTPRoutes` table in `daemon/httproutes.go`: `newHTTPMux` serves
`httpRoutes ∪ internalHTTPRoutes`, but `HTTPRoutes()` (the `af api` catalog)
still returns only the public `httpRoutes`. The drift-guard test is updated to
lock the new invariant: the mux serves precisely `servedHTTPRoutes()`, and a new
test proves the internal routes are served but **absent** from the public catalog.

## What net/rpc code was DELETED

TUI-only net/rpc **client wrappers** (their only caller was the TUI; the
controlServer handlers and net/rpc registration stay — the socket still serves
every verb):

- `daemon/snapshot.go` — `SnapshotWithAlarms` (client-side only; PR4's server-side `deliveryAlarms` untouched)
- `daemon/control_client.go` — `SetPRInfo`, `ImportRemoteHookSessions`, `PauseStatusPoll`, `ResumeStatusPoll`
- `daemon/limit.go` — `ResumeFromLimit`

Their one wrapper-specific test (`daemon/close_tab_test.go`'s
`SetPRInfo`-round-trip) is trimmed to the `CloseTab` half it shares (CLI still
uses `CloseTab`); `deadcode -test ./...` is clean.

## Gates

- `gofmt`, `go build ./...`, `golangci-lint --fast`, `deadcode -test ./...`, file-length lint — all clean.
- `make test-container` (full suite) — green, including the real-daemon `app` integration tests (`cli_daemon_integration_test.go`) that now exercise the HTTP read path end-to-end.
- `make tui-driver-selftest` — **25/25**.
- **Heavy exploratory play-test** in the container sandbox (below).

## Play-test (containerized sandbox, real daemon, driven TUI)

Drove the real multi-pane TUI so the HTTP control/read path is exercised
end-to-end. **20/22 driver assertions green**; the 2 "failures" were a driver
navigation limitation (see below), not a product issue:

```
CREATE 3 (CreateSession/HTTP):        alpha, bravo, charlie → ready ●  ✓✓✓
SELECT each (Snapshot read):          ▾ + row-scoped verb                ✓✓✓
NEW TAB / CLOSE TAB (Create/CloseTab/HTTP): tab child count ↑ then ↓     ✓✓
OPEN PANE + interactive send:         pane ran the command               ✓✓✓✓
ATTACH / DETACH (Pause/ResumeStatusPoll/HTTP): client reaped, sel survived ✓✓✓
ARCHIVE alpha (ArchiveSession/HTTP):  alpha → "Archived (1)" ▧, worktree relocated to /archived ✓
KILL bravo (KillSession/HTTP):        row removed via Snapshot reconcile ✓✓
ORPHAN CHECK:                         no tmux attach clients reparented to init ✓
```

Verified `daemon-http.sock` is bound and, since the TUI source has **zero**
net/rpc client-wrapper calls, every one of the above ops is HTTP by
construction. Sidebar liveness (● ready dots) and the archive→Archived section
transition rendered from the Snapshot read path exactly as before. No orphans;
sandbox torn down clean.

**Restore (`r`)** routes through the same `withDaemonHTTP → apiclient.RestoreSession`
plumbing as archive/kill (both proven live above) and is covered by automated
tests at every layer — `apiclient/control_test.go` (HTTP round-trip),
`app/archive_action_test.go` + `archive_reconcile_test.go` (the TUI restore
seam), `daemon/lostrestore_test.go` (handler over the wire) — all green in the
container. The archive→Archived transition (its reverse, same daemon/transport)
was demonstrated live. I could not *keyboard-drive* the restore trigger because
the tui-driver can't land the cursor on an archived row (the `sidebar_nav.go`
reveal-on-collapsed-`j` behavior + an 80-col menu that truncates the `r restore`
verb + synthetic SGR clicks selecting display-binding rather than the actionable
cursor) — a harness limitation entirely orthogonal to this PR, which never
touches `ui/sidebar_nav.go` or selection.

Closes part of #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
