### PR TITLE
feat(daemon): WS PTY broker + clientless-tmux agent-server (#1592 Phase 2 PR5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@
 # real ~/.agent-factory, or this repo's worktrees.
 # See docs/container-testing.md.
 
-.PHONY: test-container remote-roundtrip-container playtest-container \
-	playtest-container-detached tui-driver tui-driver-selftest testbox-image \
-	lint-file-length docs
+.PHONY: test-container remote-roundtrip-container ws-pty-roundtrip-container \
+	playtest-container playtest-container-detached tui-driver tui-driver-selftest \
+	testbox-image lint-file-length docs
 
 # Structural-health lint (#1145): fail if any Go file exceeds its line limit
 # (1000 for production code, 1500 for *_test.go) unless grandfathered in
@@ -32,6 +32,13 @@ test-container:
 # round-trip gate inside the same container fence as the full suite.
 remote-roundtrip-container:
 	scripts/testbox.sh test ./integration -run TestRemoteHookRoundTripMockRemote
+
+# Focused WS PTY broker harness (#1592 Phase 2 PR5): connects two subscribers to
+# a real local session's stream, exercises multi-writer input, last-resize-wins +
+# echo, ?since replay, and keepalive dead-subscriber drop — inside the same
+# container fence (a real tmux server) as the full suite.
+ws-pty-roundtrip-container:
+	scripts/testbox.sh test ./integration -run TestWSPTYBrokerRoundTrip
 
 # Interactive TUI play-test sandbox: builds af inside, scaffolds a
 # throwaway AF home + mock project repo, drops you in a shell with a

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -9,7 +9,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
 )
 
@@ -116,6 +118,7 @@ func (s *controlServer) AddTask(req AddTaskRequest, resp *AddTaskResponse) error
 		return err
 	}
 	resp.OK = true
+	s.manager.publishEvent(agentproto.EventTaskCreated, req.Task)
 	return nil
 }
 
@@ -127,6 +130,7 @@ func (s *controlServer) UpdateTask(req UpdateTaskRequest, resp *UpdateTaskRespon
 		return err
 	}
 	resp.OK = true
+	s.manager.publishEvent(agentproto.EventTaskUpdated, req.Task)
 	return nil
 }
 
@@ -138,6 +142,7 @@ func (s *controlServer) RemoveTask(req RemoveTaskRequest, resp *RemoveTaskRespon
 		return err
 	}
 	resp.OK = true
+	s.manager.publishEvent(agentproto.EventTaskRemoved, task.Task{ID: req.ID})
 	return nil
 }
 
@@ -194,6 +199,7 @@ func (s *controlServer) CreateSession(req CreateSessionRequest, resp *CreateSess
 		return err
 	}
 	resp.Instance = data
+	s.manager.publishEvent(agentproto.EventSessionCreated, data)
 	return nil
 }
 
@@ -264,6 +270,7 @@ func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionRes
 		return err
 	}
 	resp.OK = true
+	s.manager.publishEvent(agentproto.EventSessionKilled, session.InstanceData{Title: req.Title})
 	return nil
 }
 
@@ -280,6 +287,7 @@ func (s *controlServer) ArchiveSession(req ArchiveSessionRequest, resp *ArchiveS
 	}
 	resp.OK = true
 	resp.ArchivedPath = archivedPath
+	s.manager.publishEvent(agentproto.EventSessionArchived, session.InstanceData{Title: req.Title})
 	return nil
 }
 
@@ -296,6 +304,7 @@ func (s *controlServer) RestoreArchived(req RestoreArchivedRequest, resp *Restor
 	}
 	resp.OK = true
 	resp.WorktreePath = worktreePath
+	s.manager.publishEvent(agentproto.EventSessionRestored, session.InstanceData{Title: req.Title})
 	return nil
 }
 
@@ -312,6 +321,7 @@ func (s *controlServer) RestoreSession(req RestoreSessionRequest, resp *RestoreS
 	}
 	resp.OK = true
 	resp.WorktreePath = worktreePath
+	s.manager.publishEvent(agentproto.EventSessionRestored, session.InstanceData{Title: req.Title})
 	return nil
 }
 

--- a/daemon/httpauth.go
+++ b/daemon/httpauth.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"net/http"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+)
+
+// The auth + CORS seam for the daemon HTTP/WS surface (#1592 Phase 2 PR5, §4.4).
+// It EXISTS now and enforces NOTHING: over the unix socket the peer is trusted
+// (filesystem perms are the auth, #1029). Its whole purpose is shape — Phase 3
+// adds a TCP+TLS transport with a bearer token, and this is where the
+// constant-time token compare and the real CORS policy drop in WITHOUT reshaping
+// a single route or handler. Every route (the REST mirror and the new WS routes)
+// is served through withAuth, and the WS handshake rides the same path, so the
+// token seam already covers both the Authorization header and the browser
+// ?access_token= fallback.
+
+// withAuth wraps the daemon mux with the auth + CORS seam. Phase 2: it extracts
+// the request's bearer token (header or query fallback) but does not enforce it,
+// applies a permissive CORS policy, and answers CORS preflight.
+func withAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Extract the token the request presents (Authorization: Bearer … or the
+		// ?access_token= WS/browser fallback). Deliberately discarded in Phase 2 —
+		// Phase 3 replaces this line with a constant-time compare against the
+		// daemon's token and a 401 on mismatch, and nothing else here changes.
+		_ = agentproto.TokenFromRequest(r)
+
+		applyCORSPolicy(w, r)
+		if r.Method == http.MethodOptions {
+			// CORS preflight: answered by the seam before any route runs.
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// applyCORSPolicy sets the CORS response headers. Permissive on the unix socket
+// now (any origin); Phase 3's policy tightens this for the TCP/TLS transport. It
+// is a hook, not a hard-coded rule, precisely so that later change is a policy
+// edit here rather than a re-plumb of every route.
+func applyCORSPolicy(w http.ResponseWriter, _ *http.Request) {
+	h := w.Header()
+	h.Set("Access-Control-Allow-Origin", "*")
+	h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	h.Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+}

--- a/daemon/httpauth_test.go
+++ b/daemon/httpauth_test.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestWithAuthCORSPreflight pins the auth/CORS seam: a CORS preflight is answered
+// by the middleware (204 + permissive CORS headers) before any route runs, and a
+// real request still passes through to its handler with the CORS headers set.
+func TestWithAuthCORSPreflight(t *testing.T) {
+	h := withAuth(newHTTPMux(&controlServer{}))
+
+	// Preflight: answered by the seam, never reaching a route handler.
+	pre := httptest.NewRequest(http.MethodOptions, "/v1/sessions/x/stream", nil)
+	preRec := httptest.NewRecorder()
+	h.ServeHTTP(preRec, pre)
+	if preRec.Code != http.StatusNoContent {
+		t.Fatalf("preflight status = %d, want 204", preRec.Code)
+	}
+	if got := preRec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("preflight CORS origin = %q, want *", got)
+	}
+
+	// A real request passes through the seam to its handler and still carries the
+	// CORS headers.
+	get := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	getRec := httptest.NewRecorder()
+	h.ServeHTTP(getRec, get)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("health status through seam = %d, want 200", getRec.Code)
+	}
+	if got := getRec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("health CORS origin = %q, want *", got)
+	}
+}
+
+// TestWithAuthTokenSeamIsNoOp pins that the auth seam does NOT enforce a token in
+// Phase 2 — a request with no credential is served normally (the unix-socket peer
+// is trusted; Phase 3 fills in enforcement here without reshaping routes).
+func TestWithAuthTokenSeamIsNoOp(t *testing.T) {
+	h := withAuth(newHTTPMux(&controlServer{}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/health", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unauthenticated request status = %d, want 200 (seam is a no-op in Phase 2)", rec.Code)
+	}
+}

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -85,7 +85,10 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 
 	cs := &controlServer{manager: manager, scheduler: scheduler, watchers: watchers}
 	srv := &http.Server{
-		Handler:           newHTTPMux(cs),
+		// The mux is wrapped in the auth/CORS seam (#1592 Phase 2 PR5): a no-op
+		// token extraction + permissive CORS today, the drop-in point for Phase 3's
+		// TCP+TLS+token enforcement without reshaping any route.
+		Handler:           withAuth(newHTTPMux(cs)),
 		ReadHeaderTimeout: httpReadHeaderTimeout,
 	}
 
@@ -121,6 +124,17 @@ func newHTTPMux(cs *controlServer) *http.ServeMux {
 	for _, rt := range servedHTTPRoutes() {
 		mux.HandleFunc(rt.Path, rt.handler(cs))
 	}
+
+	// WS data plane (#1592 Phase 2 PR5): the PTY stream broker + its stream-info
+	// indirection, and the events-plane fan-out. These are NOT REST/RPC mirrors —
+	// they upgrade to WebSockets — so they live outside servedHTTPRoutes (the `af
+	// api` RPC catalog) and register here with method+path patterns (a non-GET to
+	// a stream path is a 405 from the mux). They are DARK in Phase 2: nothing in
+	// the TUI consumes them yet (PR6 wires the TUI), but the routes exist and ride
+	// the same auth/CORS seam startHTTPServer wraps the mux in.
+	mux.HandleFunc("GET /v1/sessions/{id}/stream", cs.streamHandler)
+	mux.HandleFunc("GET /v1/sessions/{id}/stream-info", cs.streamInfoHandler)
+	mux.HandleFunc("GET /v1/events", cs.eventsHandler)
 
 	// Catch-all: any other path is an unknown route → 404 with the envelope.
 	// ServeMux routes the longest prefix match, so a real route above always

--- a/daemon/limit.go
+++ b/daemon/limit.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sachiniyer/agent-factory/agentproto"
 	"github.com/sachiniyer/agent-factory/log"
 	"github.com/sachiniyer/agent-factory/session"
 	"github.com/sachiniyer/agent-factory/task"
@@ -105,11 +106,16 @@ func (m *Manager) persistPollChange(repoID string, instance *session.Instance, b
 	}
 	repoStartLock := m.startLockForRepo(repoID)
 	repoStartLock.Lock()
-	err := persistInstanceData(repoID, instance.ToInstanceData())
+	data := instance.ToInstanceData()
+	err := persistInstanceData(repoID, data)
 	repoStartLock.Unlock()
 	if err != nil {
 		log.WarningLog.Printf("daemon failed to persist status for %q: %v", instance.Title, err)
 	}
+	// Push the change onto the events plane (#1592 PR5): this is the single choke
+	// point every liveness/limit transition already flows through, so one publish
+	// here covers session.updated without threading it through each caller.
+	m.publishEvent(agentproto.EventSessionUpdated, data)
 }
 
 // This file is the daemon side of the usage-limit manual-retry action (#1146

--- a/daemon/manager.go
+++ b/daemon/manager.go
@@ -83,6 +83,13 @@ type Manager struct {
 	// can never permanently blind the daemon.
 	pausedMu    sync.Mutex
 	pausedPolls map[string]time.Time
+
+	// events is the WS events-plane fan-out (#1592 Phase 2 PR5): every session/
+	// task mutation the daemon owns publishes here, and GET /v1/events streams it
+	// to clients. On the Manager (not a controlServer) because both transports
+	// mutate through this one Manager, so a single hub captures every change.
+	// Immutable after construction; the hub is internally synchronized.
+	events *eventsHub
 }
 
 // NewManager constructs a manager and synchronously restores all persisted
@@ -126,6 +133,7 @@ func newManagerShell(cfg *config.Config) (*Manager, error) {
 		limitResumeStates:   make(map[string]*limitResumeState),
 		instanceOpLocks:     make(map[string]*sync.Mutex),
 		pausedPolls:         make(map[string]time.Time),
+		events:              newEventsHub(),
 	}, nil
 }
 

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -195,6 +195,22 @@ func shellQuoteArg(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
+// agentServerForStream resolves a session (by title, with optional repoID) to
+// its cached agent-server for the WS PTY broker (#1592 Phase 2 PR5). It reuses
+// findSession — the same lookup SendPrompt uses — so a session absent from memory
+// is restored and tracked exactly once, and the returned server is the tracked
+// instance's cached singleton whose ring buffer/subscribers persist.
+func (m *Manager) agentServerForStream(title, repoID string) (session.AgentServer, error) {
+	instance, _, _, err := m.findSession(title, repoID)
+	if err != nil {
+		return nil, err
+	}
+	if instance == nil {
+		return nil, fmt.Errorf("session %q not found", title)
+	}
+	return instance.AgentServer(), nil
+}
+
 func (m *Manager) findSession(title, repoID string) (*session.Instance, string, *session.InstanceData, error) {
 	if title == "" {
 		return nil, "", nil, fmt.Errorf("session title is required")

--- a/daemon/ws_events.go
+++ b/daemon/ws_events.go
@@ -1,0 +1,155 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/coder/websocket"
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// The daemon's events plane (#1592 Phase 2 PR5, §4.3): a WebSocket/JSON fan-out
+// of session and task state changes served at GET /v1/events, so a client can
+// replace Snapshot polling with push. Every mutation the daemon owns publishes an
+// agentproto.Event to the hub; each connected client receives the stream.
+//
+// The hub lives on the Manager because BOTH transports (the net/rpc control
+// socket and the HTTP server) mutate through the same Manager, so a single hub
+// there captures every mutation regardless of which transport drove it. Payloads
+// follow agentproto's contract: a session.* event carries a marshaled
+// session.InstanceData, a task.* event a marshaled task.Task.
+//
+// DARK in Phase 2: nothing consumes /v1/events yet (the TUI still polls Snapshot
+// until PR6). The route exists, is threaded through the auth/CORS seam, and is
+// covered by the WS harness.
+
+// eventsBufferSize bounds one subscriber's pending-event queue. A subscriber that
+// falls this far behind has an event dropped (non-blocking publish) rather than
+// stalling the mutation that published it — a dropped state-change is recoverable
+// by a Snapshot, a blocked daemon mutation is not. Generous enough that a healthy
+// client never drops.
+const eventsBufferSize = 256
+
+// eventsHub is the Manager-owned fan-out of state-change events to every
+// connected /v1/events subscriber. Non-blocking on publish (drop-slow), so no
+// subscriber can back-pressure a daemon mutation.
+type eventsHub struct {
+	mu   sync.Mutex
+	subs map[uint64]chan agentproto.Event
+	next uint64
+}
+
+func newEventsHub() *eventsHub {
+	return &eventsHub{subs: make(map[uint64]chan agentproto.Event)}
+}
+
+// subscribe registers a subscriber and returns its id and receive channel.
+func (h *eventsHub) subscribe() (uint64, <-chan agentproto.Event) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.next++
+	id := h.next
+	ch := make(chan agentproto.Event, eventsBufferSize)
+	h.subs[id] = ch
+	return id, ch
+}
+
+// unsubscribe removes a subscriber.
+func (h *eventsHub) unsubscribe(id uint64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.subs, id)
+}
+
+// publish fans an event to every subscriber, dropping it for any whose buffer is
+// full (never blocking the mutation that published it).
+func (h *eventsHub) publish(ev agentproto.Event) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, ch := range h.subs {
+		select {
+		case ch <- ev:
+		default:
+			// Slow subscriber: drop this event rather than block the daemon. The
+			// client can re-Snapshot to resynchronise.
+		}
+	}
+}
+
+// publishEvent marshals payload into an agentproto.Event and fans it out. A nil
+// manager or hub (some test control servers) is a no-op; a marshal error is
+// logged and swallowed — an events-plane failure must never break a mutation.
+func (m *Manager) publishEvent(t agentproto.EventType, payload any) {
+	if m == nil || m.events == nil {
+		return
+	}
+	ev, err := agentproto.NewEvent(t, payload)
+	if err != nil {
+		log.WarningLog.Printf("events plane: marshal %s event: %v", t, err)
+		return
+	}
+	m.events.publish(ev)
+}
+
+// eventsHandler upgrades GET /v1/events to a WebSocket and streams state-change
+// events to the client until it disconnects.
+func (cs *controlServer) eventsHandler(w http.ResponseWriter, r *http.Request) {
+	if cs.manager == nil || cs.manager.events == nil {
+		writeHTTPError(w, http.StatusServiceUnavailable, fmt.Errorf("daemon has no events hub"))
+		return
+	}
+	// Permissive origin on the unix socket now (§4.4); Phase 3 tightens it.
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+	if err != nil {
+		return
+	}
+	serveEvents(cs.manager.events, conn)
+}
+
+// serveEvents streams the hub's events to one connection: a writer loop draining
+// the subscriber channel, a reader loop that detects the client's disconnect, and
+// a keepalive pinger that drops a dead subscriber without side effects.
+func serveEvents(hub *eventsHub, conn *websocket.Conn) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	id, ch := hub.subscribe()
+	defer hub.unsubscribe(id)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	// Reader: the events plane is server→client only, so any inbound frame or
+	// read error just signals disconnect.
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		for {
+			if _, _, err := conn.Read(ctx); err != nil {
+				return
+			}
+		}
+	}()
+	go func() { defer wg.Done(); defer cancel(); keepalivePTY(ctx, conn) }()
+
+	for {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close(websocket.StatusNormalClosure, "")
+			wg.Wait()
+			return
+		case ev := <-ch:
+			wctx, wcancel := context.WithTimeout(ctx, wsWriteTimeout)
+			err := agentproto.WriteControl(wctx, conn, ev)
+			wcancel()
+			if err != nil {
+				cancel()
+				_ = conn.Close(websocket.StatusNormalClosure, "")
+				wg.Wait()
+				return
+			}
+		}
+	}
+}

--- a/daemon/ws_events_test.go
+++ b/daemon/ws_events_test.go
@@ -1,0 +1,108 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestEventsHubFanoutAndDropSlow pins the hub contract: an event fans out to
+// every subscriber, and a subscriber whose bounded buffer is full drops events
+// rather than blocking publish (so a slow client can never back-pressure a daemon
+// mutation).
+func TestEventsHubFanoutAndDropSlow(t *testing.T) {
+	hub := newEventsHub()
+	_, a := hub.subscribe()
+	_, b := hub.subscribe()
+
+	ev, err := agentproto.NewEvent(agentproto.EventSessionUpdated, session.InstanceData{Title: "x"})
+	if err != nil {
+		t.Fatalf("NewEvent: %v", err)
+	}
+	hub.publish(ev)
+	for _, ch := range []<-chan agentproto.Event{a, b} {
+		select {
+		case got := <-ch:
+			if got.Type != agentproto.EventSessionUpdated {
+				t.Fatalf("event type = %q, want session.updated", got.Type)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("subscriber did not receive the published event")
+		}
+	}
+
+	// Overfill one subscriber's buffer: publish must not block (drop-slow).
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < eventsBufferSize*3; i++ {
+			hub.publish(ev)
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("publish blocked on a full subscriber buffer (drop-slow broken)")
+	}
+}
+
+// TestServeEventsDelivers proves the /v1/events serving path end to end over a
+// real WebSocket: a published event reaches a connected client.
+func TestServeEventsDelivers(t *testing.T) {
+	hub := newEventsHub()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		serveEvents(hub, conn)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial events ws: %v", err)
+	}
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
+
+	ev, err := agentproto.NewEvent(agentproto.EventTaskCreated, nil)
+	if err != nil {
+		t.Fatalf("NewEvent: %v", err)
+	}
+	// Publish repeatedly to absorb the subscribe/connect race, until the client
+	// reads one event or the deadline trips.
+	got := make(chan agentproto.MessageType, 1)
+	go func() {
+		msg, rerr := agentproto.ReadMessage(ctx, conn)
+		if rerr != nil {
+			return
+		}
+		if typ, terr := agentproto.MessageTypeOf(msg.Text); terr == nil {
+			got <- typ
+		}
+	}()
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case typ := <-got:
+			if string(typ) != string(agentproto.EventTaskCreated) {
+				t.Fatalf("event type = %q, want task.created", typ)
+			}
+			return
+		case <-ticker.C:
+			hub.publish(ev)
+		case <-ctx.Done():
+			t.Fatal("client never received a published event")
+		}
+	}
+}

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -1,0 +1,258 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The daemon's WebSocket PTY stream broker (#1592 Phase 2 PR5) — the data plane
+// the control plane (#1029 REST mirror) sits beside. It exposes two routes:
+//
+//	GET /v1/sessions/{id}/stream?since=<seq>  — the live PTY stream
+//	GET /v1/sessions/{id}/stream-info         — where that stream is reachable
+//
+// The stream upgrades to a WebSocket (agentproto's coder/websocket binding) and
+// fans the session's raw PTY output to every subscriber from the local
+// agent-server's bounded ring buffer; `?since=<seq>` replays the tail a
+// reconnecting client missed. It is MULTI-WRITER with no lease: INPUT and RESIZE
+// frames are accepted from ANY subscriber and applied via the agent-server
+// (RESIZE is last-resize-wins with an authoritative echo). A WS keepalive ping
+// drops a dead subscriber WITHOUT touching the PTY/session — the structural
+// reliability win over a shared tmux render client (§6).
+//
+// This plane is DARK in Phase 2: nothing in the TUI consumes it yet (live panes
+// still render through the tmux attach client until PR6). The routes exist, are
+// threaded through the auth/CORS seam (httpserver.go), and are exercised by the
+// WS integration harness.
+
+// wsKeepaliveInterval is how often the broker pings each subscriber and how long
+// it waits for the pong before dropping that (dead) subscriber. A subscriber
+// whose peer stops responding is closed WITHOUT affecting the session or other
+// subscribers. Overridable via AF_WS_KEEPALIVE_INTERVAL so the integration
+// harness can shorten it (the daemon runs as its own process, so a package var
+// alone is not reachable from the harness).
+var wsKeepaliveInterval = envDurationOr("AF_WS_KEEPALIVE_INTERVAL", 15*time.Second)
+
+// streamSeqHeader carries the subscription's starting seq on the WS handshake
+// response so a client can compute its absolute cursor (startSeq + bytesReceived)
+// and reconnect with ?since=<cursor> to replay the gap it missed.
+const streamSeqHeader = "X-Af-Stream-Seq"
+
+// wsWriteTimeout bounds a single frame write to a subscriber, so a wedged client
+// that has stopped reading cannot block its writer goroutine forever — the write
+// fails, the subscriber is dropped, and the session is untouched. var so tests
+// can shrink it.
+var wsWriteTimeout = 10 * time.Second
+
+// envDurationOr parses a time.Duration from env key, falling back to def when the
+// variable is unset or unparseable.
+func envDurationOr(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}
+
+// streamHandler upgrades GET /v1/sessions/{id}/stream to a WebSocket and serves
+// the session's PTY stream. Session resolution and Subscribe happen BEFORE the
+// upgrade so a missing session or bad cursor returns an HTTP error envelope;
+// after websocket.Accept the connection is hijacked and errors close the socket.
+func (cs *controlServer) streamHandler(w http.ResponseWriter, r *http.Request) {
+	if cs.manager == nil {
+		writeHTTPError(w, http.StatusServiceUnavailable, fmt.Errorf("daemon has no session manager"))
+		return
+	}
+	id := r.PathValue("id")
+	repoID := r.URL.Query().Get("repo_id")
+	since, err := parseSince(r.URL.Query().Get("since"))
+	if err != nil {
+		writeHTTPError(w, http.StatusBadRequest, err)
+		return
+	}
+	as, err := cs.manager.agentServerForStream(id, repoID)
+	if err != nil {
+		writeHTTPError(w, http.StatusNotFound, err)
+		return
+	}
+	sub, err := as.Subscribe(since)
+	if err != nil {
+		writeHTTPError(w, http.StatusInternalServerError, err)
+		return
+	}
+	// Announce the subscription's starting cursor on the handshake response so the
+	// client knows its absolute seq: PTY_OUT frames carry raw bytes with no seq, so
+	// a client tracks its position as startSeq + bytesReceived and reconnects with
+	// ?since=<that> to replay a gap. Set BEFORE Accept so it rides the 101 response.
+	w.Header().Set(streamSeqHeader, strconv.FormatUint(uint64(sub.Seq()), 10))
+	// Permissive origin check on the unix socket now (§4.4); Phase 3's CORS policy
+	// tightens it for the TCP/TLS transport without reshaping this handler.
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+	if err != nil {
+		_ = sub.Close()
+		return // Accept already wrote the error response.
+	}
+	servePTYStream(as, sub, conn)
+}
+
+// servePTYStream runs the three loops of one subscriber's connection until any of
+// them ends: the writer (ring → PTY_OUT / resize-echo), the reader (INPUT/RESIZE/
+// detach → agent-server), and the keepalive pinger. It owns closing the
+// subscription and the socket.
+func servePTYStream(as session.AgentServer, sub session.PTYSubscription, conn *websocket.Conn) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	defer func() { _ = sub.Close() }()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); defer cancel(); readPTYClient(ctx, as, conn) }()
+	go func() { defer wg.Done(); defer cancel(); keepalivePTY(ctx, conn) }()
+
+	writePTYStream(ctx, sub, conn)
+
+	cancel()
+	_ = conn.Close(websocket.StatusNormalClosure, "")
+	wg.Wait()
+}
+
+// writePTYStream is the single writer goroutine: it multiplexes the subscriber's
+// output bytes and resize echoes onto the one connection. Keeping it single means
+// no concurrent data writes race on the socket.
+func writePTYStream(ctx context.Context, sub session.PTYSubscription, conn *websocket.Conn) {
+	for {
+		ev, err := sub.NextEvent(ctx)
+		if err != nil {
+			return // ctx cancelled or io.EOF (session gone / broker closed)
+		}
+		wctx, wcancel := context.WithTimeout(ctx, wsWriteTimeout)
+		switch ev.Kind {
+		case session.PTYData:
+			err = agentproto.WriteFrame(wctx, conn, agentproto.PTYOutFrame(ev.Data))
+		case session.PTYResize:
+			err = agentproto.WriteControl(wctx, conn, agentproto.NewResizeMessage(ev.Rows, ev.Cols))
+		}
+		wcancel()
+		if err != nil {
+			return // wedged/dead client: drop it (the session is untouched)
+		}
+	}
+}
+
+// readPTYClient handles client → server frames: INPUT and RESIZE are applied to
+// the agent-server (multi-writer, from any subscriber); a detach control frame or
+// any read error ends the connection.
+func readPTYClient(ctx context.Context, as session.AgentServer, conn *websocket.Conn) {
+	for {
+		msg, err := agentproto.ReadMessage(ctx, conn)
+		if err != nil {
+			return
+		}
+		if msg.Binary {
+			switch msg.Frame.Op {
+			case agentproto.OpInput:
+				_ = as.Input(msg.Frame.Data)
+			case agentproto.OpResize:
+				_ = as.Resize(msg.Frame.Rows, msg.Frame.Cols)
+			}
+			continue
+		}
+		if t, _ := agentproto.MessageTypeOf(msg.Text); t == agentproto.MsgDetach {
+			return
+		}
+	}
+}
+
+// keepalivePTY pings the subscriber every wsKeepaliveInterval; a missed pong
+// within the same interval drops this (dead) subscriber. Dropping never touches
+// the PTY/session or other subscribers.
+func keepalivePTY(ctx context.Context, conn *websocket.Conn) {
+	ticker := time.NewTicker(wsKeepaliveInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pctx, pcancel := context.WithTimeout(ctx, wsKeepaliveInterval)
+			err := conn.Ping(pctx)
+			pcancel()
+			if err != nil {
+				return
+			}
+		}
+	}
+}
+
+// streamInfoResponse tells a client WHERE a session's PTY stream is reachable —
+// the "expose an authed URL" indirection (§4.2). For the local runtime it is the
+// relative stream path on this same socket; a Phase-4 remote/container runtime
+// returns its own authed wss:// URL, and the client dials whatever it is handed
+// without knowing which runtime backs the session.
+type streamInfoResponse struct {
+	URL   string `json:"url"`
+	Local bool   `json:"local"`
+}
+
+// streamInfoHandler answers GET /v1/sessions/{id}/stream-info with the stream
+// endpoint for the session. It resolves the session (404 if absent) and reads its
+// agent-server's Expose() handle.
+func (cs *controlServer) streamInfoHandler(w http.ResponseWriter, r *http.Request) {
+	if cs.manager == nil {
+		writeHTTPError(w, http.StatusServiceUnavailable, fmt.Errorf("daemon has no session manager"))
+		return
+	}
+	id := r.PathValue("id")
+	repoID := r.URL.Query().Get("repo_id")
+	as, err := cs.manager.agentServerForStream(id, repoID)
+	if err != nil {
+		writeHTTPError(w, http.StatusNotFound, err)
+		return
+	}
+	ep, err := as.Expose()
+	if err != nil {
+		writeHTTPError(w, http.StatusInternalServerError, err)
+		return
+	}
+	resp := streamInfoResponse{Local: ep.Local}
+	if ep.URL != "" {
+		resp.URL = ep.URL // a remote/container runtime's own authed URL (Phase 4)
+	} else {
+		resp.URL = localStreamPath(id, repoID)
+	}
+	writeHTTPSuccess(w, resp)
+}
+
+// localStreamPath builds the relative stream URL for a local session, escaping
+// the id and carrying repo_id through so the client dials the same session the
+// info request named.
+func localStreamPath(id, repoID string) string {
+	p := "/v1/sessions/" + url.PathEscape(id) + "/stream"
+	if repoID != "" {
+		p += "?repo_id=" + url.QueryEscape(repoID)
+	}
+	return p
+}
+
+// parseSince parses the ?since=<seq> replay cursor. Empty means 0 (live tail).
+func parseSince(raw string) (session.Seq, error) {
+	if raw == "" {
+		return 0, nil
+	}
+	v, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid since cursor %q: %w", raw, err)
+	}
+	return session.Seq(v), nil
+}

--- a/integration/ws_pty_test.go
+++ b/integration/ws_pty_test.go
@@ -1,0 +1,235 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sachiniyer/agent-factory/agentproto"
+)
+
+// TestWSPTYBrokerRoundTrip is the WS PTY broker integration harness (#1592 Phase
+// 2 PR5), modelled on the remote-hook round-trip. Against a REAL daemon serving a
+// REAL local tmux session (the fake-agent pane runs `cat`, so it echoes input) it
+// exercises the whole data plane end to end:
+//
+//   - two subscribers both receive PTY_OUT bytes;
+//   - INPUT is accepted from EITHER subscriber (multi-writer, no lease);
+//   - RESIZE is last-resize-wins with an authoritative echo broadcast to all;
+//   - dropping one subscriber mid-stream and reconnecting with ?since replays the
+//     gap it missed (the ring-buffer repaint);
+//   - a keepalive ping drops a dead subscriber WITHOUT killing the session — a
+//     live subscriber keeps receiving and the session stays listed.
+//
+// Run it in the container fence: make ws-pty-roundtrip-container.
+func TestWSPTYBrokerRoundTrip(t *testing.T) {
+	// Shorten the broker's keepalive so the dead-subscriber drop is observable in
+	// test time; the daemon (a child process) reads this from the environment.
+	t.Setenv("AF_WS_KEEPALIVE_INTERVAL", "300ms")
+
+	h := newHarness(t)
+	h.startDaemon()
+	h.createSession("wsstream")
+	streamPath := "/v1/sessions/wsstream/stream"
+
+	// --- two subscribers both receive PTY_OUT ---
+	a := h.dialWS(t, streamPath)
+	defer a.close()
+	b := h.dialWS(t, streamPath)
+	defer b.close()
+
+	// --- INPUT from A → the pane echoes it; both subscribers see it ---
+	a.sendInput(t, []byte("ping-from-a\n"))
+	a.waitOutput(t, "ping-from-a")
+	b.waitOutput(t, "ping-from-a")
+
+	// --- INPUT from B → multi-writer: input from any subscriber is applied ---
+	b.sendInput(t, []byte("ping-from-b\n"))
+	a.waitOutput(t, "ping-from-b")
+	b.waitOutput(t, "ping-from-b")
+
+	// --- RESIZE: authoritative echo broadcast to every subscriber, last-wins ---
+	// Resize from A, wait for BOTH to see the echo, THEN supersede from B — sending
+	// both at once would race at the wire (two connections, no ordering), so this
+	// deterministically pins both "echo reaches every subscriber" and "the last
+	// resize wins" without a flaky ordering assumption.
+	a.sendResize(t, 30, 100)
+	a.waitResize(t, 30, 100)
+	b.waitResize(t, 30, 100)
+	b.sendResize(t, 40, 120) // multi-writer: B resizes too; last-resize-wins
+	a.waitResize(t, 40, 120)
+	b.waitResize(t, 40, 120)
+
+	// --- drop A mid-stream + ?since replay repaints the gap ---
+	since := a.sinceCursor()
+	a.close()
+	// B keeps the capture alive, so the ring retains the bytes A misses.
+	b.sendInput(t, []byte("after-a-dropped\n"))
+	b.waitOutput(t, "after-a-dropped")
+	a2 := h.dialWS(t, fmt.Sprintf("%s?since=%d", streamPath, since))
+	defer a2.close()
+	a2.waitOutput(t, "after-a-dropped")
+
+	// --- keepalive drops a dead subscriber without killing the session ---
+	// A "dead" subscriber never reads, so it never pongs; the server's ping times
+	// out and drops it. It must NOT take the session or the live subscriber down.
+	dead := h.dialWSRaw(t, streamPath)
+	// Wait out several keepalive cycles (300ms ping + 300ms pong timeout).
+	time.Sleep(1500 * time.Millisecond)
+	// The server closed the dead subscriber: its first read now errors.
+	if err := dead.readErrWithin(2 * time.Second); err == nil {
+		t.Fatal("dead subscriber was not dropped by keepalive")
+	}
+	// The session survived: a live subscriber still receives fresh output...
+	b.sendInput(t, []byte("after-dead\n"))
+	b.waitOutput(t, "after-dead")
+	// ...and it is still a live, listed session.
+	if !hasTitle(h.listSessions(), "wsstream") {
+		t.Fatal("session vanished after a dead subscriber was dropped")
+	}
+}
+
+// wsClient is a test subscriber: a coder/websocket connection with a read pump
+// accumulating PTY_OUT bytes and resize echoes.
+type wsClient struct {
+	conn    *websocket.Conn
+	baseSeq uint64
+	ctx     context.Context
+	cancel  context.CancelFunc
+
+	mu      sync.Mutex
+	out     []byte
+	resizes []agentproto.ResizeMessage
+}
+
+// dialWS opens a subscriber and starts its read pump.
+func (h *harness) dialWS(t *testing.T, path string) *wsClient {
+	t.Helper()
+	conn, base := h.dialWSConn(t, path)
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &wsClient{conn: conn, baseSeq: base, ctx: ctx, cancel: cancel}
+	go c.readPump()
+	return c
+}
+
+// dialWSRaw opens a subscriber but starts NO read pump, so it never answers
+// pings — the "dead" subscriber the keepalive must drop.
+func (h *harness) dialWSRaw(t *testing.T, path string) *wsClient {
+	t.Helper()
+	conn, base := h.dialWSConn(t, path)
+	ctx, cancel := context.WithCancel(context.Background())
+	return &wsClient{conn: conn, baseSeq: base, ctx: ctx, cancel: cancel}
+}
+
+func (h *harness) dialWSConn(t *testing.T, path string) (*websocket.Conn, uint64) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	conn, resp, err := websocket.Dial(ctx, "ws://unix"+path, &websocket.DialOptions{HTTPClient: h.httpClient()})
+	if err != nil {
+		t.Fatalf("dial ws %s: %v", path, err)
+	}
+	conn.SetReadLimit(1 << 20)
+	var base uint64
+	if v := resp.Header.Get("X-Af-Stream-Seq"); v != "" {
+		base, _ = strconv.ParseUint(v, 10, 64)
+	}
+	return conn, base
+}
+
+func (c *wsClient) readPump() {
+	for {
+		msg, err := agentproto.ReadMessage(c.ctx, c.conn)
+		if err != nil {
+			return
+		}
+		c.mu.Lock()
+		if msg.Binary {
+			if msg.Frame.Op == agentproto.OpPTYOut {
+				c.out = append(c.out, msg.Frame.Data...)
+			}
+		} else if typ, _ := agentproto.MessageTypeOf(msg.Text); typ == agentproto.MsgResize {
+			var rm agentproto.ResizeMessage
+			if json.Unmarshal(msg.Text, &rm) == nil {
+				c.resizes = append(c.resizes, rm)
+			}
+		}
+		c.mu.Unlock()
+	}
+}
+
+func (c *wsClient) sendInput(t *testing.T, b []byte) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := agentproto.WriteFrame(ctx, c.conn, agentproto.InputFrame(b)); err != nil {
+		t.Fatalf("send input: %v", err)
+	}
+}
+
+func (c *wsClient) sendResize(t *testing.T, rows, cols uint16) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := agentproto.WriteFrame(ctx, c.conn, agentproto.ResizeFrame(rows, cols)); err != nil {
+		t.Fatalf("send resize: %v", err)
+	}
+}
+
+func (c *wsClient) output() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return string(c.out)
+}
+
+// sinceCursor is the absolute seq this client has consumed: its handshake base
+// seq plus every output byte it has received.
+func (c *wsClient) sinceCursor() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.baseSeq + uint64(len(c.out))
+}
+
+func (c *wsClient) lastResize() (agentproto.ResizeMessage, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.resizes) == 0 {
+		return agentproto.ResizeMessage{}, false
+	}
+	return c.resizes[len(c.resizes)-1], true
+}
+
+func (c *wsClient) waitOutput(t *testing.T, want string) {
+	t.Helper()
+	waitUntil(t, 5*time.Second, fmt.Sprintf("output contains %q", want), func() bool {
+		return strings.Contains(c.output(), want)
+	})
+}
+
+func (c *wsClient) waitResize(t *testing.T, rows, cols uint16) {
+	t.Helper()
+	waitUntil(t, 5*time.Second, fmt.Sprintf("authoritative resize echo %dx%d", rows, cols), func() bool {
+		r, ok := c.lastResize()
+		return ok && r.Rows == rows && r.Cols == cols
+	})
+}
+
+// readErrWithin performs one read with a deadline and returns its error; used to
+// prove the server closed a dropped subscriber.
+func (c *wsClient) readErrWithin(d time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
+	_, _, err := c.conn.Read(ctx)
+	return err
+}
+
+func (c *wsClient) close() {
+	c.cancel()
+	_ = c.conn.Close(websocket.StatusNormalClosure, "")
+}

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -1,7 +1,7 @@
 package session
 
 import (
-	"errors"
+	"context"
 	"io"
 )
 
@@ -65,16 +65,21 @@ type AgentServer interface {
 	// underlying channel as SendPrompt.
 	TapEnter()
 
-	// Subscribe returns a fan-out read of the raw PTY byte stream from cursor
-	// `since` (0 = from the buffer tail), so a reconnecting client replays the gap.
-	// Data plane — wired by the WS PTY broker in PR5; the local agent-server returns
-	// ErrDataPlaneUnwired until then.
+	// Subscribe returns a fan-out read of the session's PTY stream from cursor
+	// `since` (0 = from the ring-buffer tail / live), so a reconnecting client
+	// replays the gap it missed. The local agent-server (PR5) drives a clientless
+	// tmux channel — pipe-pane for output capture — and fans the bytes to every
+	// subscriber through a bounded ring buffer; a subscriber that falls behind or
+	// dies is dropped without touching the PTY (§6). Read-write: Input/Resize below
+	// are accepted from every subscriber (multi-writer, no lease).
 	Subscribe(since Seq) (PTYSubscription, error)
 	// Input writes raw bytes to the PTY (the multi-writer input path that subsumes
-	// the old tmux-shaped SendKeys). Data plane — wired in PR5.
+	// the old tmux-shaped SendKeys). For the local runtime it is a clientless tmux
+	// send-keys, accepted from any subscriber.
 	Input(b []byte) error
-	// Resize sets the PTY size; last-resize-wins across subscribers. Data plane —
-	// wired in PR5.
+	// Resize sets the PTY size; last-resize-wins across subscribers. The local
+	// runtime drives a clientless tmux resize-window and broadcasts an
+	// authoritative size echo to every subscriber so their emulators reflow (§6.2).
 	Resize(rows, cols uint16) error
 
 	// Kill terminates the session and releases its backing resources.
@@ -117,21 +122,43 @@ type Observation struct {
 	Content string
 }
 
-// PTYSubscription is the read side of a session's raw PTY byte stream plus a
-// sequence cursor for replay (#1592 Phase 2). The WS PTY broker (PR5) implements
-// it; the local agent-server returns ErrDataPlaneUnwired from Subscribe until
-// then, so there is no concrete implementer in this PR.
+// PTYSubscription is one subscriber's read side of a session's PTY stream
+// (#1592 Phase 2 PR5), fanned out from the local agent-server's per-session ring
+// buffer. It is event-oriented rather than a bare byte reader so a single
+// consumer goroutine (the daemon's WS writer) can multiplex the two things that
+// travel to a client on one connection — raw output bytes and the authoritative
+// resize echo — without a second concurrent writer on the socket.
 type PTYSubscription interface {
-	io.ReadCloser
-	// Seq reports the cursor of the next byte to be read, so a client that
-	// reconnects can resume with Subscribe(since).
+	// NextEvent blocks until the next stream event (output bytes or a resize
+	// echo), ctx cancellation, or Close. It returns io.EOF once the stream ends
+	// (the session's PTY vanished or the broker closed). A client that reconnects
+	// resumes from Seq() via Subscribe(since).
+	NextEvent(ctx context.Context) (PTYEvent, error)
+	// Seq reports the cursor of the next output byte this subscriber will read, so
+	// a client that reconnects can resume the gap with Subscribe(since).
 	Seq() Seq
+	io.Closer
 }
 
-// ErrDataPlaneUnwired is returned by the local agent-server's data-plane methods
-// (Subscribe/Input/Resize) in Phase 2 PR4: the interface is defined and the
-// observation/delivery paths route through it, but the raw-PTY streaming plane is
-// built on top in PR5 (the WS broker + clientless tmux fan-out). It is a distinct
-// sentinel so PR5 can assert callers handle it and delete it once the plane is
-// wired.
-var ErrDataPlaneUnwired = errors.New("agent-server data plane not wired yet (Phase 2 PR5)")
+// PTYEventKind discriminates a PTYEvent between output bytes and a resize echo.
+type PTYEventKind int
+
+const (
+	// PTYData carries verbatim PTY output bytes (Data), mapped to an OpPTYOut wire
+	// frame by the WS broker.
+	PTYData PTYEventKind = iota
+	// PTYResize carries the authoritative last-resize-wins size (Rows/Cols),
+	// mapped to a resize control frame so every subscriber's emulator reflows.
+	PTYResize
+)
+
+// PTYEvent is one event delivered to a subscriber: either output bytes or the
+// authoritative resize echo, selected by Kind.
+type PTYEvent struct {
+	Kind PTYEventKind
+	// Data is the verbatim PTY output, valid only when Kind == PTYData.
+	Data []byte
+	// Rows/Cols are the authoritative size, valid only when Kind == PTYResize.
+	Rows uint16
+	Cols uint16
+}

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -1,5 +1,10 @@
 package session
 
+import (
+	"fmt"
+	"sync"
+)
+
 // localAgentServer is the in-process AgentServer for the local runtime (#1592
 // Phase 2 PR4): the agent runs as a tmux session on the daemon's own machine, so
 // this "server" is a thin in-process facade that drives that tmux session
@@ -12,20 +17,30 @@ package session
 // HasUpdated/TapEnter) could be deleted with the daemon routed here — the seam is
 // the AgentServer interface, not a second set of pass-through methods.
 //
-// It is stateless (holds only the instance) and constructed on demand by
-// Instance.AgentServer(); the stateful pieces — the PTY ring buffer and the
-// fan-out subscriber set — arrive with the WS broker in PR5, at which point the
-// agent-server becomes a cached per-instance singleton.
+// As of PR5 it is a CACHED per-instance singleton (Instance.AgentServer memoizes
+// it): its data plane owns the stateful pieces — the PTY output ring buffer and
+// the fan-out subscriber set (ptyBroker) — which a per-call throwaway would drop.
+// The broker is itself lazy: it is built (and its clientless tmux capture
+// started) on the first Subscribe/Input/Resize and torn down on Kill.
 type localAgentServer struct {
 	inst *Instance
+
+	mu     sync.Mutex
+	broker *ptyBroker
 }
 
-// AgentServer returns the agent-server for this instance's runtime (#1592 Phase
-// 2). The daemon speaks to a session ONLY through this interface, so its
-// observation/delivery paths never assume the session is local tmux. Local today;
-// a per-runtime factory selects container/ssh agent-servers in Phase 4.
+// AgentServer returns the cached agent-server for this instance's runtime (#1592
+// Phase 2). The daemon speaks to a session ONLY through this interface, so its
+// observation/delivery paths never assume the session is local tmux. Cached so
+// the data-plane ring buffer and subscribers persist across calls. Local today; a
+// per-runtime factory selects container/ssh agent-servers in Phase 4.
 func (i *Instance) AgentServer() AgentServer {
-	return &localAgentServer{inst: i}
+	i.agentSrvMu.Lock()
+	defer i.agentSrvMu.Unlock()
+	if i.agentSrv == nil {
+		i.agentSrv = &localAgentServer{inst: i}
+	}
+	return i.agentSrv
 }
 
 var _ AgentServer = (*localAgentServer)(nil)
@@ -75,20 +90,58 @@ func (s *localAgentServer) TapEnter() {
 	s.inst.backend.TapEnter(s.inst)
 }
 
-// --- data plane: wired in PR5 (WS PTY broker + clientless tmux fan-out) ---
+// --- data plane: WS PTY broker + clientless tmux fan-out (#1592 PR5) ---
 
-func (s *localAgentServer) Subscribe(Seq) (PTYSubscription, error) {
-	return nil, ErrDataPlaneUnwired
+// ensureBroker lazily builds the per-session ptyBroker bound to the instance's
+// clientless tmux channel. It errors when the instance has no local PTY (not
+// started, or a remote runtime with no agent tmux session) rather than panicking.
+func (s *localAgentServer) ensureBroker() (*ptyBroker, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.broker != nil {
+		return s.broker, nil
+	}
+	ts := s.inst.agentTmuxSession()
+	if ts == nil {
+		return nil, fmt.Errorf("session %q has no local PTY to stream", s.inst.Title)
+	}
+	s.broker = newPTYBroker(newTmuxClientlessChannel(ts))
+	return s.broker, nil
 }
 
-func (s *localAgentServer) Input([]byte) error {
-	return ErrDataPlaneUnwired
+func (s *localAgentServer) Subscribe(since Seq) (PTYSubscription, error) {
+	br, err := s.ensureBroker()
+	if err != nil {
+		return nil, err
+	}
+	return br.subscribe(since)
 }
 
-func (s *localAgentServer) Resize(uint16, uint16) error {
-	return ErrDataPlaneUnwired
+func (s *localAgentServer) Input(b []byte) error {
+	br, err := s.ensureBroker()
+	if err != nil {
+		return err
+	}
+	return br.input(b)
+}
+
+func (s *localAgentServer) Resize(rows, cols uint16) error {
+	br, err := s.ensureBroker()
+	if err != nil {
+		return err
+	}
+	return br.resize(rows, cols)
 }
 
 func (s *localAgentServer) Kill() error {
+	// Tear the data plane down first so the clientless capture stops and every
+	// subscriber's NextEvent returns io.EOF, then kill the underlying session.
+	s.mu.Lock()
+	br := s.broker
+	s.broker = nil
+	s.mu.Unlock()
+	if br != nil {
+		br.close()
+	}
 	return s.inst.backend.Kill(s.inst)
 }

--- a/session/agentserver_local_test.go
+++ b/session/agentserver_local_test.go
@@ -1,7 +1,7 @@
 package session
 
 import (
-	"errors"
+	"strings"
 	"testing"
 )
 
@@ -153,19 +153,31 @@ func TestLocalAgentServerExpose(t *testing.T) {
 	}
 }
 
-// TestLocalAgentServerDataPlaneUnwired pins that the raw-PTY data plane is a stub
-// in PR4 — Subscribe/Input/Resize all report ErrDataPlaneUnwired until the WS
-// broker wires them in PR5.
-func TestLocalAgentServerDataPlaneUnwired(t *testing.T) {
+// TestLocalAgentServerDataPlaneNoLocalPTY pins that the wired data plane
+// (#1592 PR5) degrades gracefully when the instance has no live tmux pane to
+// stream — a probe instance is never started — rather than panicking: every
+// data-plane method returns a "no local PTY" error. The ring/fan-out behaviour
+// with a live channel is covered by TestPTYBroker* in ptybroker_test.go.
+func TestLocalAgentServerDataPlaneNoLocalPTY(t *testing.T) {
 	inst, _ := newProbeInstance(t)
 	as := inst.AgentServer()
-	if _, err := as.Subscribe(0); !errors.Is(err, ErrDataPlaneUnwired) {
-		t.Errorf("Subscribe err = %v, want ErrDataPlaneUnwired", err)
+	if _, err := as.Subscribe(0); err == nil || !strings.Contains(err.Error(), "no local PTY") {
+		t.Errorf("Subscribe err = %v, want a no-local-PTY error", err)
 	}
-	if err := as.Input([]byte("x")); !errors.Is(err, ErrDataPlaneUnwired) {
-		t.Errorf("Input err = %v, want ErrDataPlaneUnwired", err)
+	if err := as.Input([]byte("x")); err == nil || !strings.Contains(err.Error(), "no local PTY") {
+		t.Errorf("Input err = %v, want a no-local-PTY error", err)
 	}
-	if err := as.Resize(24, 80); !errors.Is(err, ErrDataPlaneUnwired) {
-		t.Errorf("Resize err = %v, want ErrDataPlaneUnwired", err)
+	if err := as.Resize(24, 80); err == nil || !strings.Contains(err.Error(), "no local PTY") {
+		t.Errorf("Resize err = %v, want a no-local-PTY error", err)
+	}
+}
+
+// TestLocalAgentServerCached pins the PR5 caching invariant: AgentServer returns
+// the SAME instance each call so the data-plane ring buffer and subscribers
+// persist (a fresh server per call would drop them).
+func TestLocalAgentServerCached(t *testing.T) {
+	inst, _ := newProbeInstance(t)
+	if inst.AgentServer() != inst.AgentServer() {
+		t.Error("AgentServer() must return the cached per-instance singleton")
 	}
 }

--- a/session/instance.go
+++ b/session/instance.go
@@ -166,6 +166,25 @@ type Instance struct {
 	Tabs []*Tab
 	// gitWorktree is the git worktree for the instance.
 	gitWorktree *git.GitWorktree
+
+	// agentSrv is the cached per-instance AgentServer (#1592 Phase 2 PR5). Cached
+	// rather than reconstructed per call because its data plane holds stateful
+	// pieces — the PTY output ring buffer and the fan-out subscriber set — that
+	// must persist across calls; a fresh server each call would drop subscribers
+	// and lose the replay buffer. Lazily built by AgentServer(), guarded by
+	// agentSrvMu (a dedicated mutex, not i.mu, so building the server never
+	// contends with the session-state fields i.mu guards).
+	agentSrv   *localAgentServer
+	agentSrvMu sync.Mutex
+}
+
+// agentTmuxSession returns the instance's agent-tab tmux session, or nil when the
+// instance is not started or is remote. It is the clientless data plane's binding
+// point (#1592 PR5); it takes i.mu, so callers must not already hold it.
+func (i *Instance) agentTmuxSession() *tmux.TmuxSession {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.tmuxLocked()
 }
 
 // tmuxLocked returns the agent tab's tmux session, or nil when the instance has

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -1,0 +1,330 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// The WS PTY broker's server-side data plane (#1592 Phase 2 PR5). A ptyBroker
+// owns one session's raw PTY output and fans it to N subscribers:
+//
+//   - A bounded ring buffer holds the recent output with a monotonic Seq cursor,
+//     so a (re)connecting subscriber can Subscribe(since) and replay the tail it
+//     missed rather than losing the gap.
+//   - Bytes arrive from a CLIENTLESS tmux channel (pipe-pane capture, see
+//     clientlessChannel) — producing the stream no longer requires a
+//     `tmux attach-session` render client, which is the structural move that lets
+//     PR6 delete that render client entirely.
+//   - INPUT and RESIZE are accepted from ANY subscriber (multi-writer, no lease):
+//     Input is a clientless send-keys, Resize is a clientless resize-window with
+//     last-resize-wins plus an authoritative echo broadcast to every subscriber.
+//   - A dead subscriber (its WS keepalive lapsed, or its consumer went away) is
+//     dropped WITHOUT touching the PTY/session — the reliability win over a shared
+//     tmux client, whose death used to take output down with it (§6).
+//
+// The broker is lazy: the clientless capture starts on the first Subscribe and
+// stops when the last subscriber leaves, so a session nobody is watching runs no
+// extra tmux pipe or reader goroutine.
+
+// ptyRingMaxBytes bounds one session's output ring buffer. A subscriber that
+// falls further behind than this loses the intervening bytes (its cursor is
+// fast-forwarded to the oldest retained byte) — acceptable for a terminal, whose
+// next full repaint re-synchronises the emulator, and the keepalive drops a
+// truly-dead subscriber rather than letting it grow the buffer unbounded. var,
+// not const, so tests can shrink it.
+var ptyRingMaxBytes = 256 * 1024
+
+// clientlessChannel is the local runtime's clientless tmux binding (#1592 PR5):
+// output capture and input/size WITHOUT a tmux client. The real implementation
+// (tmuxClientlessChannel) drives `tmux pipe-pane`/`send-keys`/`resize-window`;
+// tests substitute an in-memory fake so the ring/fan-out logic is exercised with
+// no real tmux server.
+type clientlessChannel interface {
+	// StartCapture enables output capture and returns a reader over the raw PTY
+	// byte stream. The broker reads it on a goroutine until StopCapture.
+	StartCapture() (io.ReadCloser, error)
+	// StopCapture disables capture and releases its resources (closing the reader
+	// StartCapture returned).
+	StopCapture() error
+	// SendRaw writes raw input bytes to the pane (clientless send-keys).
+	SendRaw(b []byte) error
+	// Resize sets the pane/window size (clientless resize-window). Last-resize-wins
+	// is enforced by the broker; this just applies the winning size.
+	Resize(rows, cols uint16) error
+}
+
+// ptyBroker is the per-session data plane. Guarded by mu; the ring buffer, the
+// subscriber set, and the authoritative size all live under it.
+type ptyBroker struct {
+	ch       clientlessChannel
+	maxBytes int
+
+	mu   sync.Mutex
+	buf  []byte // ring: recent output bytes, buf[0] is at seq `base`
+	base Seq    // seq of buf[0]; head == base + len(buf)
+
+	subs      map[uint64]*ptySub
+	nextSubID uint64
+
+	rows, cols uint16
+	hasSize    bool
+	resizeGen  uint64 // bumped on each resize; a subscriber echoes when it lags
+
+	capturing   bool
+	stopCapture func() // tears down the capture goroutine + clientless channel
+	closed      bool
+}
+
+func newPTYBroker(ch clientlessChannel) *ptyBroker {
+	return &ptyBroker{
+		ch:       ch,
+		maxBytes: ptyRingMaxBytes,
+		subs:     make(map[uint64]*ptySub),
+	}
+}
+
+// head returns the seq just past the last buffered byte. Caller holds mu.
+func (b *ptyBroker) headLocked() Seq { return b.base + Seq(len(b.buf)) }
+
+// subscribe registers a subscriber whose cursor starts at `since` (0 = the live
+// tail). It starts the clientless capture on the first subscriber. Read-write:
+// the returned subscription is also the identity Input/Resize fan out to.
+func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return nil, fmt.Errorf("pty broker closed")
+	}
+	if !b.capturing {
+		if err := b.startCaptureLocked(); err != nil {
+			b.mu.Unlock()
+			return nil, err
+		}
+	}
+	head := b.headLocked()
+	cursor := since
+	// since == 0 means "from the live tail" (the documented default); a real
+	// replay cursor is clamped into the retained window [base, head].
+	if cursor == 0 || cursor > head {
+		cursor = head
+	}
+	if cursor < b.base {
+		cursor = b.base
+	}
+	b.nextSubID++
+	sub := &ptySub{
+		br:         b,
+		id:         b.nextSubID,
+		cursor:     cursor,
+		resizeSeen: b.resizeGen,
+		notify:     make(chan struct{}, 1),
+	}
+	b.subs[sub.id] = sub
+	b.mu.Unlock()
+	return sub, nil
+}
+
+// startCaptureLocked spins up the clientless output capture and the goroutine
+// that feeds its bytes into the ring. Caller holds mu.
+func (b *ptyBroker) startCaptureLocked() error {
+	r, err := b.ch.StartCapture()
+	if err != nil {
+		return fmt.Errorf("start clientless pty capture: %w", err)
+	}
+	done := make(chan struct{})
+	b.capturing = true
+	b.stopCapture = func() {
+		if err := b.ch.StopCapture(); err != nil {
+			log.WarningLog.Printf("pty broker: stop clientless capture: %v", err)
+		}
+		_ = r.Close()
+		<-done
+	}
+	go b.readLoop(r, done)
+	return nil
+}
+
+// readLoop copies the clientless capture reader into the ring until it errors or
+// the capture is stopped.
+func (b *ptyBroker) readLoop(r io.Reader, done chan struct{}) {
+	defer close(done)
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			b.feed(buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// feed appends output bytes to the ring, evicting the oldest bytes past the cap,
+// and wakes every subscriber.
+func (b *ptyBroker) feed(p []byte) {
+	b.mu.Lock()
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > b.maxBytes {
+		drop := len(b.buf) - b.maxBytes
+		// Compact in place (dst index < src index, a safe forward copy) so the
+		// backing array does not grow without bound.
+		b.buf = append(b.buf[:0], b.buf[drop:]...)
+		b.base += Seq(drop)
+	}
+	b.wakeAllLocked()
+	b.mu.Unlock()
+}
+
+// input writes raw bytes to the pane. Accepted from any subscriber (multi-writer).
+func (b *ptyBroker) input(p []byte) error {
+	if len(p) == 0 {
+		return nil
+	}
+	return b.ch.SendRaw(p)
+}
+
+// resize records the winning size (last-resize-wins) and broadcasts an
+// authoritative echo to every subscriber so their emulators reflow, then applies
+// the size to the pane best-effort. The echo is the broker's authoritative
+// decision and is broadcast REGARDLESS of whether the tmux apply succeeds — a
+// failed resize-window (an old tmux, a vanished pane) must not swallow the echo
+// clients depend on to reflow; the apply error is logged, not propagated as a
+// missing echo.
+func (b *ptyBroker) resize(rows, cols uint16) error {
+	b.mu.Lock()
+	b.rows, b.cols = rows, cols
+	b.hasSize = true
+	b.resizeGen++
+	b.wakeAllLocked()
+	b.mu.Unlock()
+
+	if err := b.ch.Resize(rows, cols); err != nil {
+		log.WarningLog.Printf("pty broker: apply resize %dx%d to pane: %v", rows, cols, err)
+		return err
+	}
+	return nil
+}
+
+// wakeAllLocked signals every subscriber that state changed. The notify channel
+// is a coalescing (cap-1) doorbell — a subscriber re-reads all state under mu
+// after waking, so a single pending signal is enough. Caller holds mu.
+func (b *ptyBroker) wakeAllLocked() {
+	for _, s := range b.subs {
+		select {
+		case s.notify <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// remove drops a subscriber and stops the clientless capture once the last one
+// leaves — never touching the PTY/session itself.
+func (b *ptyBroker) remove(id uint64) {
+	b.mu.Lock()
+	if _, ok := b.subs[id]; !ok {
+		b.mu.Unlock()
+		return
+	}
+	delete(b.subs, id)
+	var stop func()
+	if len(b.subs) == 0 && b.capturing {
+		stop = b.stopCapture
+		b.capturing = false
+		b.stopCapture = nil
+	}
+	b.mu.Unlock()
+	if stop != nil {
+		stop()
+	}
+}
+
+// close tears down the broker: every subscriber's NextEvent returns io.EOF and
+// the clientless capture is stopped. Called when the session is killed.
+func (b *ptyBroker) close() {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return
+	}
+	b.closed = true
+	b.wakeAllLocked()
+	var stop func()
+	if b.capturing {
+		stop = b.stopCapture
+		b.capturing = false
+		b.stopCapture = nil
+	}
+	b.mu.Unlock()
+	if stop != nil {
+		stop()
+	}
+}
+
+// ptySub is one subscriber's cursor into the broker's ring plus a resize-echo
+// watermark. All state is read/written under br.mu; notify is the wake doorbell.
+type ptySub struct {
+	br         *ptyBroker
+	id         uint64
+	cursor     Seq    // next output byte to deliver
+	resizeSeen uint64 // last resizeGen echoed to this subscriber
+	notify     chan struct{}
+	closeOnce  sync.Once
+}
+
+var _ PTYSubscription = (*ptySub)(nil)
+
+// NextEvent blocks for the next event for this subscriber: a pending resize echo
+// (delivered before bytes so the emulator resizes before the reflow bytes land),
+// then any output bytes from the cursor, else it waits. Returns io.EOF when the
+// broker closes.
+func (s *ptySub) NextEvent(ctx context.Context) (PTYEvent, error) {
+	for {
+		s.br.mu.Lock()
+		if s.br.closed {
+			s.br.mu.Unlock()
+			return PTYEvent{}, io.EOF
+		}
+		if s.br.hasSize && s.resizeSeen != s.br.resizeGen {
+			s.resizeSeen = s.br.resizeGen
+			ev := PTYEvent{Kind: PTYResize, Rows: s.br.rows, Cols: s.br.cols}
+			s.br.mu.Unlock()
+			return ev, nil
+		}
+		head := s.br.headLocked()
+		if s.cursor < s.br.base {
+			s.cursor = s.br.base // fell behind eviction: skip the lost gap
+		}
+		if s.cursor < head {
+			off := int(s.cursor - s.br.base)
+			data := append([]byte(nil), s.br.buf[off:]...)
+			s.cursor = head
+			s.br.mu.Unlock()
+			return PTYEvent{Kind: PTYData, Data: data}, nil
+		}
+		s.br.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return PTYEvent{}, ctx.Err()
+		case <-s.notify:
+		}
+	}
+}
+
+// Seq reports the cursor of the next output byte this subscriber will read.
+func (s *ptySub) Seq() Seq {
+	s.br.mu.Lock()
+	defer s.br.mu.Unlock()
+	return s.cursor
+}
+
+// Close removes the subscriber from the broker's fan-out. Idempotent.
+func (s *ptySub) Close() error {
+	s.closeOnce.Do(func() { s.br.remove(s.id) })
+	return nil
+}

--- a/session/ptybroker_test.go
+++ b/session/ptybroker_test.go
@@ -1,0 +1,231 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClientlessChannel is an in-memory clientlessChannel: StartCapture hands
+// back an io.Pipe the test feeds with emit(), and SendRaw/Resize record calls so
+// the broker's input/size fan-out can be asserted without a real tmux server.
+type fakeClientlessChannel struct {
+	mu       sync.Mutex
+	r        *io.PipeReader
+	w        *io.PipeWriter
+	starts   int
+	stops    int
+	sent     [][]byte
+	resizes  [][2]uint16
+	startErr error
+}
+
+func (f *fakeClientlessChannel) StartCapture() (io.ReadCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.startErr != nil {
+		return nil, f.startErr
+	}
+	f.starts++
+	f.r, f.w = io.Pipe()
+	return f.r, nil
+}
+
+func (f *fakeClientlessChannel) StopCapture() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stops++
+	if f.w != nil {
+		_ = f.w.Close()
+	}
+	return nil
+}
+
+func (f *fakeClientlessChannel) SendRaw(b []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, append([]byte(nil), b...))
+	return nil
+}
+
+func (f *fakeClientlessChannel) Resize(rows, cols uint16) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resizes = append(f.resizes, [2]uint16{rows, cols})
+	return nil
+}
+
+// emit writes pane output into the capture pipe. Write blocks until the broker's
+// read loop consumes it, so on return the bytes are in flight to the ring.
+func (f *fakeClientlessChannel) emit(t *testing.T, b []byte) {
+	t.Helper()
+	f.mu.Lock()
+	w := f.w
+	f.mu.Unlock()
+	if w == nil {
+		t.Fatal("emit before StartCapture")
+	}
+	if _, err := w.Write(b); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+}
+
+func nextWithin(t *testing.T, sub PTYSubscription, d time.Duration) (PTYEvent, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
+	return sub.NextEvent(ctx)
+}
+
+// mustData blocks for the next event and asserts it is output bytes equal to want.
+func mustData(t *testing.T, sub PTYSubscription, want string) {
+	t.Helper()
+	ev, err := nextWithin(t, sub, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NextEvent: %v", err)
+	}
+	if ev.Kind != PTYData || string(ev.Data) != want {
+		t.Fatalf("event = %+v, want data %q", ev, want)
+	}
+}
+
+func TestPTYBrokerFanout(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe a: %v", err)
+	}
+	b, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe b: %v", err)
+	}
+	ch.emit(t, []byte("hello"))
+	mustData(t, a, "hello")
+	mustData(t, b, "hello")
+	if ch.starts != 1 {
+		t.Fatalf("StartCapture calls = %d, want 1 (lazy, once)", ch.starts)
+	}
+}
+
+func TestPTYBrokerReplayFromSeq(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+	a, _ := br.subscribe(0)
+	ch.emit(t, []byte("hello"))
+	mustData(t, a, "hello")
+	if got := a.Seq(); got != 5 {
+		t.Fatalf("seq after 5 bytes = %d, want 5", got)
+	}
+	// A reconnecting client resumes from a prior cursor and replays the gap.
+	b, err := br.subscribe(2)
+	if err != nil {
+		t.Fatalf("subscribe replay: %v", err)
+	}
+	mustData(t, b, "llo")
+}
+
+func TestPTYBrokerSinceZeroIsLiveTail(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+	a, _ := br.subscribe(0)
+	ch.emit(t, []byte("old"))
+	mustData(t, a, "old")
+	// since==0 means "from the live tail": no replay of already-buffered bytes.
+	b, _ := br.subscribe(0)
+	ch.emit(t, []byte("new"))
+	mustData(t, b, "new")
+}
+
+func TestPTYBrokerResizeEchoBroadcast(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+	a, _ := br.subscribe(0)
+	b, _ := br.subscribe(0)
+	if err := br.resize(24, 80); err != nil {
+		t.Fatalf("resize: %v", err)
+	}
+	// last-resize-wins: a second resize supersedes the first authoritative size.
+	if err := br.resize(30, 100); err != nil {
+		t.Fatalf("resize 2: %v", err)
+	}
+	for _, sub := range []PTYSubscription{a, b} {
+		ev, err := nextWithin(t, sub, 2*time.Second)
+		if err != nil {
+			t.Fatalf("resize NextEvent: %v", err)
+		}
+		if ev.Kind != PTYResize || ev.Rows != 30 || ev.Cols != 100 {
+			t.Fatalf("resize echo = %+v, want 30x100 (last-wins)", ev)
+		}
+	}
+	if len(ch.resizes) != 2 {
+		t.Fatalf("channel resizes = %v, want 2 applied", ch.resizes)
+	}
+}
+
+func TestPTYBrokerInput(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+	if err := br.input([]byte{0x1b, 0x5b, 0x41}); err != nil { // up arrow
+		t.Fatalf("input: %v", err)
+	}
+	if len(ch.sent) != 1 || string(ch.sent[0]) != "\x1b[A" {
+		t.Fatalf("sent = %v, want the up-arrow bytes", ch.sent)
+	}
+}
+
+func TestPTYBrokerCloseEOF(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+	a, _ := br.subscribe(0)
+	br.close()
+	if _, err := nextWithin(t, a, 2*time.Second); !errors.Is(err, io.EOF) {
+		t.Fatalf("NextEvent after close = %v, want io.EOF", err)
+	}
+}
+
+func TestPTYBrokerEvictionFastForwards(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+	br.maxBytes = 4 // tiny ring
+	// Subscribe but do not read, then overflow the ring so its tail is evicted.
+	b, err := br.subscribe(1) // a stale cursor into the soon-evicted region
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	ch.emit(t, []byte("abcdefgh"))
+	// The ring retains only the last 4 bytes; the cursor fast-forwards past the
+	// lost gap to the oldest retained byte rather than replaying evicted data.
+	ev, err := nextWithin(t, b, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NextEvent: %v", err)
+	}
+	if ev.Kind != PTYData || string(ev.Data) != "efgh" {
+		t.Fatalf("event = %+v, want the retained tail %q", ev, "efgh")
+	}
+}
+
+func TestPTYBrokerStopsCaptureWhenLastSubscriberLeaves(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+	a, _ := br.subscribe(0)
+	b, _ := br.subscribe(0)
+	_ = a.Close()
+	if ch.stops != 0 {
+		t.Fatalf("StopCapture after 1 of 2 leaves = %d, want 0 (capture stays up)", ch.stops)
+	}
+	_ = b.Close()
+	if ch.stops != 1 {
+		t.Fatalf("StopCapture after last leaves = %d, want 1", ch.stops)
+	}
+	// A later subscribe restarts the capture (lazy, again).
+	if _, err := br.subscribe(0); err != nil {
+		t.Fatalf("re-subscribe: %v", err)
+	}
+	if ch.starts != 2 {
+		t.Fatalf("StartCapture calls = %d, want 2 (restarted)", ch.starts)
+	}
+}

--- a/session/ptychannel_tmux.go
+++ b/session/ptychannel_tmux.go
@@ -1,0 +1,109 @@
+package session
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// tmuxClientlessChannel is the local runtime's clientlessChannel (#1592 Phase 2
+// PR5): it captures a tmux pane's output through `pipe-pane` into a private FIFO
+// and drives input/size through `send-keys`/`resize-window` — all WITHOUT a
+// `tmux attach-session` render client. The WS PTY broker fans the FIFO bytes to
+// its subscribers; PR6 deletes the render client the TUI still uses today.
+type tmuxClientlessChannel struct {
+	ts *tmux.TmuxSession
+
+	mu   sync.Mutex
+	dir  string   // temp dir holding the FIFO, removed on StopCapture
+	fifo string   // FIFO path pipe-pane writes to
+	rc   *os.File // read end of the FIFO
+}
+
+var _ clientlessChannel = (*tmuxClientlessChannel)(nil)
+
+func newTmuxClientlessChannel(ts *tmux.TmuxSession) *tmuxClientlessChannel {
+	return &tmuxClientlessChannel{ts: ts}
+}
+
+// StartCapture makes a private FIFO, opens its read end, and enables pipe-pane to
+// write the pane's raw output into it. The FIFO is opened O_RDWR so the reader
+// stays valid even across the brief window before tmux's `cat` opens the write
+// end (and never sees EOF from a transient writer close) — StopCapture is the
+// only thing that ends the stream.
+func (c *tmuxClientlessChannel) StartCapture() (io.ReadCloser, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.rc != nil {
+		return nil, fmt.Errorf("clientless capture already started")
+	}
+
+	dir, err := os.MkdirTemp("", "af-ptystream-")
+	if err != nil {
+		return nil, fmt.Errorf("create pty stream dir: %w", err)
+	}
+	fifo := filepath.Join(dir, "pane.out")
+	if err := syscall.Mkfifo(fifo, 0600); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("mkfifo pty stream: %w", err)
+	}
+	rc, err := os.OpenFile(fifo, os.O_RDWR, 0600)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("open pty stream fifo: %w", err)
+	}
+	if err := c.ts.EnablePipePane(pipePaneCommand(fifo)); err != nil {
+		_ = rc.Close()
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
+	c.dir, c.fifo, c.rc = dir, fifo, rc
+	return rc, nil
+}
+
+// StopCapture disables pipe-pane, closes the read end, and removes the FIFO dir.
+func (c *tmuxClientlessChannel) StopCapture() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.rc == nil {
+		return nil
+	}
+	err := c.ts.DisablePipePane()
+	_ = c.rc.Close()
+	if c.dir != "" {
+		_ = os.RemoveAll(c.dir)
+	}
+	c.dir, c.fifo, c.rc = "", "", nil
+	return err
+}
+
+// SendRaw writes verbatim input bytes to the pane (clientless send-keys).
+func (c *tmuxClientlessChannel) SendRaw(b []byte) error {
+	return c.ts.SendRawKeys(b)
+}
+
+// Resize applies the winning size to the window (clientless resize-window). tmux
+// takes cols (x) then rows (y); the broker's rows/cols argument order is flipped
+// to match here.
+func (c *tmuxClientlessChannel) Resize(rows, cols uint16) error {
+	return c.ts.ResizeWindow(int(cols), int(rows))
+}
+
+// pipePaneCommand builds the `cat >> <fifo>` shell snippet handed to pipe-pane
+// (tmux runs it through /bin/sh). The FIFO path is single-quoted so a home dir
+// with spaces or shell metacharacters cannot break the command.
+func pipePaneCommand(fifoPath string) string {
+	return "cat >> " + shellSingleQuote(fifoPath)
+}
+
+// shellSingleQuote single-quotes s for safe interpolation into a /bin/sh command,
+// escaping any embedded single quotes.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}

--- a/session/tmux/clientless.go
+++ b/session/tmux/clientless.go
@@ -1,0 +1,93 @@
+package tmux
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// Clientless control channel (#1592 Phase 2 PR5). These primitives capture pane
+// output and drive input/size WITHOUT a `tmux attach-session` render client:
+//
+//   - EnablePipePane/DisablePipePane stream the pane's raw output to a shell
+//     command via `tmux pipe-pane` — the WS PTY broker points it at a FIFO it
+//     drains, so producing the byte stream no longer needs a tmux client.
+//   - SendRawKeys writes verbatim input bytes with `send-keys -H` (hex), the
+//     multi-writer interactive-input path (distinct from the SendKeysCommand
+//     paste-buffer path automated deliveries use).
+//   - ResizeWindow sets the window size with `resize-window`, which pins the
+//     window to a manual size independent of any attached client.
+//
+// This is the structural move the epic set up: once the daemon produces the
+// stream clientlessly, PR6 can delete the attach-session render client the TUI
+// still uses today. Every command uses the exact `=name:` target so a
+// prefix-matched sibling session (e.g. a `__shell` tab) can never be driven by
+// mistake (#1006).
+
+// EnablePipePane starts piping the pane's raw output to shellCommand via
+// `tmux pipe-pane -O` (output only). tmux runs shellCommand through /bin/sh, so
+// the broker passes e.g. `cat >> <fifo>`. A pane may hold only one pipe at a
+// time; DisablePipePane closes it.
+func (t *TmuxSession) EnablePipePane(shellCommand string) error {
+	cmd := exec.Command("tmux", "pipe-pane", "-O", "-t", exactTarget(t.sanitizedName), shellCommand)
+	if err := t.cmdExec.Run(cmd); err != nil {
+		if !t.DoesSessionExist() {
+			return fmt.Errorf("%w: pipe-pane", ErrSessionGone)
+		}
+		return fmt.Errorf("error enabling pipe-pane: %w", err)
+	}
+	return nil
+}
+
+// DisablePipePane closes the pane's current output pipe. `tmux pipe-pane` with no
+// shell-command closes the active pipe (tmux man page); a missing session is a
+// no-op success since the pipe is already gone with it.
+func (t *TmuxSession) DisablePipePane() error {
+	cmd := exec.Command("tmux", "pipe-pane", "-t", exactTarget(t.sanitizedName))
+	if err := t.cmdExec.Run(cmd); err != nil {
+		if !t.DoesSessionExist() {
+			return nil
+		}
+		return fmt.Errorf("error disabling pipe-pane: %w", err)
+	}
+	return nil
+}
+
+// SendRawKeys writes verbatim input bytes to the pane using `send-keys -H`
+// (hex-encoded), so arbitrary control bytes (arrow keys, Ctrl sequences) land
+// exactly as typed — the interactive multi-writer input path. Empty input is a
+// no-op.
+func (t *TmuxSession) SendRawKeys(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	args := make([]string, 0, len(b)+4)
+	args = append(args, "send-keys", "-t", exactTarget(t.sanitizedName), "-H")
+	for _, c := range b {
+		args = append(args, fmt.Sprintf("%02x", c))
+	}
+	cmd := exec.Command("tmux", args...)
+	if err := t.cmdExec.Run(cmd); err != nil {
+		if !t.DoesSessionExist() {
+			return fmt.Errorf("%w: send-keys", ErrSessionGone)
+		}
+		return fmt.Errorf("error sending raw keys: %w", err)
+	}
+	return nil
+}
+
+// ResizeWindow sets the window to cols×rows with `resize-window -x -y`, which
+// switches the window to a manual size so it no longer tracks an attached
+// client's dimensions — the clientless last-resize-wins size the broker applies.
+func (t *TmuxSession) ResizeWindow(cols, rows int) error {
+	cmd := exec.Command("tmux", "resize-window", "-t", exactTarget(t.sanitizedName),
+		"-x", fmt.Sprintf("%d", cols), "-y", fmt.Sprintf("%d", rows))
+	if err := t.cmdExec.Run(cmd); err != nil {
+		if !t.DoesSessionExist() {
+			return fmt.Errorf("%w: resize-window", ErrSessionGone)
+		}
+		// resize-window fails on tmux servers older than 2.9; surface the error so
+		// the caller can log it rather than silently mis-sizing the pane.
+		return fmt.Errorf("error resizing window: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Adds the WebSocket **PTY stream broker** — the daemon's data plane for #1592
Phase 2. Server-side and **DARK**: nothing in the TUI consumes it yet (live panes
stay on the tmux render-client until PR6), so it is off the UX hot path. No
client-visible change, no backcompat shims, no version bump.

Part of the #1592 multi-backend epic. Builds on PR1 (agentproto wire types),
PR2 (apiclient), PR3 (TUI-as-HTTP-client), PR4 (AgentServer interface).

## The broker + ring / replay / keepalive (`session/ptybroker.go`)

A per-session, lazily-created broker owns the raw PTY output and fans it to N
subscribers:

- **Bounded ring buffer** with a monotonic `Seq` cursor holds the recent output.
- `?since=<seq>` **replays the tail** a reconnecting client missed; a subscriber
  that falls behind ring eviction fast-forwards past the lost gap (a terminal
  re-syncs on its next repaint).
- A **dead subscriber is dropped WITHOUT touching the PTY/session** — the
  structural reliability win over a shared tmux client, whose death used to take
  output down with it (§6).
- Lazy lifecycle: the clientless capture starts on the first `Subscribe` and
  stops when the last subscriber leaves — a session nobody watches runs no extra
  tmux pipe or reader goroutine.

The `PTYSubscription` interface (a PR4 placeholder `io.ReadCloser`) is reshaped to
an **event stream** (`NextEvent → PTYData | PTYResize`) so one WS-writer goroutine
multiplexes output bytes and resize echoes onto the single connection without a
second concurrent socket writer. `ErrDataPlaneUnwired` is deleted (its job done).

## The multi-writer data plane (LOCKED — no lease)

Every subscriber is read-write. `INPUT` (0x01) and `RESIZE` (0x02) are accepted
from **any** subscriber and applied via the agent-server. PTY size is
**last-resize-wins** with an **authoritative resize-echo** broadcast to every
subscriber so their emulators reflow (§6.2). The echo is the broker's
authoritative decision and is broadcast regardless of whether the tmux apply
succeeds — a flaky `resize-window` must never swallow the echo clients depend on.
There is no lease / observe-mode / NACK.

`AgentServer` gains wired `Subscribe(since)` / `Input` / `Resize`, and
`Instance.AgentServer()` is now a **cached per-instance singleton** so the ring
buffer and subscriber set persist across calls.

## The clientless-tmux switch — what it replaces, what it sets up

`session/tmux/clientless.go` + `session/ptychannel_tmux.go` bind the local
agent-server to tmux through a **clientless control channel**:

| concern | mechanism | replaces |
|---|---|---|
| output capture | `tmux pipe-pane` → private FIFO the broker drains | the attach client's PTY |
| input | `tmux send-keys -H` (hex, verbatim bytes) | the attach client's stdin |
| size | `tmux resize-window` (manual window size) | the attach client's dimensions |

Producing the byte stream **no longer requires a `tmux attach-session` CLIENT**.
This is the structural move that later lets **PR6 DELETE the render client** the
TUI still uses today. Verified end-to-end on the container's tmux 3.3a and locally
on 3.4 (pipe-pane capture + `send-keys -H` + `resize-window` all green).

## The routes + auth/CORS seam

New routes, registered outside the `af api` RPC catalog (they upgrade to
WebSockets), with method+path patterns:

- `GET /v1/sessions/{id}/stream?since=<seq>` — the live PTY stream.
- `GET /v1/sessions/{id}/stream-info` — the **"expose an authed URL" indirection**
  so Phase 3/4 can hand back a remote `wss://` URL; local returns the relative
  stream path.
- `GET /v1/events` — WS/JSON **state-change fan-out** (§4.3): session
  created/updated/killed/archived/restored + task created/updated/removed,
  published from the single mutation choke points on the shared `Manager` hub
  (drop-slow, never back-pressures a daemon mutation).

The handshake announces the subscription's starting seq on an `X-Af-Stream-Seq`
response header so a client (whose PTY_OUT frames carry no seq) can compute its
cursor as `startSeq + bytesReceived` and reconnect with `?since=`.

`daemon/httpauth.go` threads **every route + the WS handshake** through a
`withAuth` middleware + a CORS policy hook: the bearer header and `?access_token=`
query fallback are **extracted but NOT enforced** (the unix-socket peer is trusted,
#1029), CORS is permissive. It **exists now** so Phase 3 drops in TCP+TLS+token
enforcement at one line without reshaping any route.

## Gates

- `gofmt` / `go vet` / `golangci-lint --fast` / `deadcode -test ./...` — clean.
- `go build ./...` — clean.
- `make test-container` — full suite green (daemon, integration, session, tmux, …).
- `make tui-driver-selftest` — **25/25** (the TUI still uses the tmux render-client,
  so it is unaffected — confirmed).

### WS integration harness — `make ws-pty-roundtrip-container`

Modelled on `make remote-roundtrip-container`: a real daemon + real local tmux
session (`cat` fake-agent echoes input). Exercises the whole data plane and passes
stably (4× consecutive green):

```
scripts/testbox.sh test ./integration -run TestWSPTYBrokerRoundTrip
ok  	github.com/sachiniyer/agent-factory/integration	3.5s
```

Covered: two subscribers both receive PTY_OUT; INPUT from **either** subscriber
(multi-writer); RESIZE echo broadcast to every subscriber + **last-resize-wins**;
drop one subscriber mid-stream and **reconnect with `?since`** to replay the gap;
**keepalive drops a dead subscriber** (never pongs) while the live subscriber keeps
receiving and the session stays listed. Plus white-box tests for the ring/fan-out
(`session/ptybroker_test.go`), the events hub + `serveEvents` delivery, and the
auth/CORS preflight/no-op-token seam.

Closes a slice of #1592. Do not merge until CI is green.

— Captain Claude
