### PR TITLE
refactor(session): delete unused raw prompt path

### DIFF
--- a/session/backend.go
+++ b/session/backend.go
@@ -39,8 +39,8 @@ type Capabilities struct {
 	// per-session config (remote_hooks.terminal_cmd), so it is computed per
 	// instance rather than being a static per-type constant.
 	TerminalTab bool
-	// InteractiveInput: raw key / prompt injection works — SendKeys/TapEnter/
-	// SendPrompt drive a live PTY rather than returning "not supported".
+	// InteractiveInput: raw key injection and prompt acceptance work —
+	// SendKeys/TapEnter drive a live PTY rather than returning "not supported".
 	InteractiveInput bool
 }
 
@@ -110,9 +110,6 @@ type Backend interface {
 	// inspect it without a second capture. content is "" for backends with no
 	// live pane (remote/hook) or when the capture is unavailable.
 	HasUpdated(instance *Instance) (updated bool, hasPrompt bool, content string)
-
-	// SendPrompt sends a prompt string via PTY writes.
-	SendPrompt(instance *Instance, prompt string) error
 
 	// SendPromptCommand sends a prompt using a more reliable command-based
 	// approach (e.g. tmux send-keys).

--- a/session/backend_e2e_test.go
+++ b/session/backend_e2e_test.go
@@ -196,8 +196,8 @@ func TestE2ERemoteHooksFullLifecycle(t *testing.T) {
 	assert.False(t, obs.Updated)
 	assert.False(t, obs.HasPrompt)
 
-	// --- Step 7: SendPrompt/SendPromptCommand should return errors ---
-	assert.Error(t, instance.SendPrompt("hello"))
+	// --- Step 7: delivery should return errors ---
+	assert.Error(t, instance.AgentServer().SendPrompt("hello"))
 	assert.Error(t, instance.SendPromptCommand("hello"))
 
 	// --- Step 8: SetPreviewSize should be a no-op (no error) ---

--- a/session/backend_hook_backend.go
+++ b/session/backend_hook_backend.go
@@ -324,10 +324,6 @@ func (b *HookBackend) HasUpdated(_ *Instance) (updated bool, hasPrompt bool, con
 	return false, false, ""
 }
 
-func (b *HookBackend) SendPrompt(_ *Instance, _ string) error {
-	return fmt.Errorf("SendPrompt not supported for remote sessions")
-}
-
 func (b *HookBackend) SendPromptCommand(_ *Instance, _ string) error {
 	return fmt.Errorf("SendPromptCommand not supported for remote sessions")
 }

--- a/session/backend_hook_core_test.go
+++ b/session/backend_hook_core_test.go
@@ -553,14 +553,6 @@ func TestHookBackendHasUpdated(t *testing.T) {
 	assert.False(t, hasPrompt)
 }
 
-func TestHookBackendSendPromptReturnsError(t *testing.T) {
-	b := &HookBackend{Hooks: config.RemoteHooks{}}
-	i := &Instance{backend: b}
-	err := b.SendPrompt(i, "test")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not supported")
-}
-
 func TestHookBackendSendPromptCommandReturnsError(t *testing.T) {
 	b := &HookBackend{Hooks: config.RemoteHooks{}}
 	i := &Instance{backend: b}

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/sachiniyer/agent-factory/config"
 	"github.com/sachiniyer/agent-factory/log"
@@ -611,30 +610,6 @@ func (b *LocalBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool, co
 		return false, false, ""
 	}
 	return ts.HasUpdated()
-}
-
-func (b *LocalBackend) SendPrompt(i *Instance, prompt string) error {
-	i.mu.RLock()
-	s := i.started
-	ts := i.tmuxLocked()
-	i.mu.RUnlock()
-
-	if !s {
-		return fmt.Errorf("instance not started")
-	}
-	if ts == nil {
-		return fmt.Errorf("tmux session not initialized")
-	}
-	if err := ts.SendKeys(prompt); err != nil {
-		return fmt.Errorf("error sending keys to tmux session: %w", err)
-	}
-
-	time.Sleep(100 * time.Millisecond)
-	if err := ts.TapEnter(); err != nil {
-		return fmt.Errorf("error tapping enter: %w", err)
-	}
-
-	return nil
 }
 
 func (b *LocalBackend) SendPromptCommand(i *Instance, prompt string) error {

--- a/session/fake_backend.go
+++ b/session/fake_backend.go
@@ -118,7 +118,6 @@ func (b *FakeBackend) AttachTerminal(*Instance, int) (chan struct{}, error) {
 	return ch, nil
 }
 func (b *FakeBackend) HasUpdated(*Instance) (bool, bool, string) { return false, false, "" }
-func (b *FakeBackend) SendPrompt(*Instance, string) error        { return nil }
 func (b *FakeBackend) SendPromptCommand(*Instance, string) error { return nil }
 func (b *FakeBackend) SendKeys(*Instance, string) error          { return nil }
 func (b *FakeBackend) SetPreviewSize(*Instance, int, int) error  { return nil }

--- a/session/instance_backend.go
+++ b/session/instance_backend.go
@@ -147,11 +147,6 @@ func (i *Instance) SetPreviewSize(width, height int) error {
 	return i.backend.SetPreviewSize(i, width, height)
 }
 
-// SendPrompt sends a prompt to the session
-func (i *Instance) SendPrompt(prompt string) error {
-	return i.backend.SendPrompt(i, prompt)
-}
-
 // SendPromptCommand sends a prompt using a more reliable command-based approach.
 // This is more reliable for headless/scheduled runs where the PTY may not persist.
 func (i *Instance) SendPromptCommand(prompt string) error {

--- a/task/start_test.go
+++ b/task/start_test.go
@@ -53,7 +53,6 @@ func (b *startBackend) AttachTerminal(*session.Instance, int) (chan struct{}, er
 }
 
 func (b *startBackend) HasUpdated(*session.Instance) (bool, bool, string) { return false, false, "" }
-func (b *startBackend) SendPrompt(*session.Instance, string) error        { return nil }
 func (b *startBackend) SendPromptCommand(_ *session.Instance, prompt string) error {
 	b.sentPrompt = prompt
 	return nil


### PR DESCRIPTION
## Summary

- Delete the unused raw `Backend.SendPrompt` / `Instance.SendPrompt` path, including its local 100 ms send-then-Enter implementation and remote/fake stubs.
- Keep the single active delivery seam: `AgentServer.SendPrompt` delegates to the reliable `Backend.SendPromptCommand` path.
- Update the remote regression test to assert the active agent-server delivery route.

## Behavior preservation

This is a pure post-migration deletion. Repository-wide search found no production caller of the removed raw path; daemon delivery already uses `AgentServer.SendPrompt`, while startup delivery already uses `SendPromptCommand`. The remote runtime still rejects the active delivery path.

## Validation

- `golangci-lint run --fast`
- `gofmt -l` (empty)
- `go build ./...`
- `make test-container`
- `deadcode -test ./...`
- `make lint-file-length`

Refs #1241 and #1195.

— Captain Claude