### PR TITLE
fix(bugreport): redact session titles ending in non-word chars (#1639)

### DIFF
--- a/bugreport/bugreport_test.go
+++ b/bugreport/bugreport_test.go
@@ -336,6 +336,52 @@ func TestScrubLogRedactsSessionTitles(t *testing.T) {
 	}
 }
 
+// TestScrubLogRedactsTitlesEndingInNonWordChars is the #1639 regression guard:
+// bareTitleRegexp used `\b` on both edges, but `\b` matches only at a
+// word↔non-word transition, so a title ending (or starting) with a non-word
+// character (brackets, punctuation) has no boundary there and leaked through the
+// log scrub unredacted (e.g. the bare `%s`-formatted title in
+// "task ... started successfully as instance client[prod]").
+func TestScrubLogRedactsTitlesEndingInNonWordChars(t *testing.T) {
+	r := &redactor{}
+	// Titles the daemon may print bare, each ending/starting with a non-word char
+	// that defeats a naive `\b` anchor.
+	titles := []string{
+		"client[prod]", // trailing ']'
+		"deploy!",      // trailing '!'
+		"[staging]env", // leading '['
+	}
+	r.noteSession(&session.InstanceData{
+		Title: titles[0],
+		Tabs: []session.TabData{
+			{Name: "b", TmuxName: ""},
+		},
+	})
+	for _, ttl := range titles[1:] {
+		r.noteSession(&session.InstanceData{Title: ttl})
+	}
+
+	in := strings.Join([]string{
+		`task cron-123 started successfully as instance client[prod]`,
+		`task cron-456 started successfully as instance deploy!`,
+		`watcher fired for [staging]env at boot`,
+	}, "\n")
+
+	out := r.scrubLog(in)
+
+	for _, leaked := range titles {
+		if strings.Contains(out, leaked) {
+			t.Errorf("title ending/starting in a non-word char leaked through log scrub: %q\n%s", leaked, out)
+		}
+	}
+	// Structural context around the redacted titles survives so the log stays
+	// triageable.
+	if !strings.Contains(out, "started successfully as instance") ||
+		!strings.Contains(out, "cron-123") {
+		t.Errorf("structural log context should survive:\n%s", out)
+	}
+}
+
 // TestRedactPathCollapsesHome guards the fix for the raw-home-path leak: the
 // bundle path inlined into the (public) GitHub issue-draft body must have $HOME
 // collapsed to ~ so it never leaks the user's home/username.

--- a/bugreport/redact.go
+++ b/bugreport/redact.go
@@ -182,20 +182,46 @@ func redactAFTmuxTitle(match string) string {
 	return match[:12] + redactedMarker
 }
 
-// bareTitleRegexp compiles a word-boundary matcher for a bare session title, or
-// nil when the title is too short (< 4 chars) to redact without risking mangling
-// unrelated log text. Best-effort by design — the tmux-name redaction above is
-// the primary defense; this catches raw titles the log prints outside a name.
+// bareTitleRegexp compiles a boundary-anchored matcher for a bare session title,
+// or nil when the title is too short (< 4 chars) to redact without risking
+// mangling unrelated log text. Best-effort by design — the tmux-name redaction
+// above is the primary defense; this catches raw titles the log prints outside a
+// name.
+//
+// A `\b` anchor is only emitted on the edge where the title's own boundary
+// character is a word char ([A-Za-z0-9_]); `\b` matches only at a word↔non-word
+// transition, so anchoring an edge whose title char is itself non-word (e.g. the
+// trailing `]` of "client[prod]") never matches and the title leaks (#1639). The
+// per-edge anchor still guards word-char edges against partial-word mangling
+// (title "test" won't match inside "testing") while a non-word edge is already
+// self-delimiting and needs no anchor.
 func bareTitleRegexp(title string) *regexp.Regexp {
 	title = strings.TrimSpace(title)
 	if len(title) < 4 {
 		return nil
 	}
-	re, err := regexp.Compile(`\b` + regexp.QuoteMeta(title) + `\b`)
+	var left, right string
+	if isWordByte(title[0]) {
+		left = `\b`
+	}
+	if isWordByte(title[len(title)-1]) {
+		right = `\b`
+	}
+	re, err := regexp.Compile(left + regexp.QuoteMeta(title) + right)
 	if err != nil {
 		return nil
 	}
 	return re
+}
+
+// isWordByte reports whether b is a regex word character ([A-Za-z0-9_]), i.e. a
+// byte across which `\b` forms a boundary. ASCII-only, matching RE2's default
+// `\b` semantics.
+func isWordByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
 }
 
 // noteSession records a session's tmux name(s) and raw title(s) before they are


### PR DESCRIPTION
## Summary

Fixes #1639. `bareTitleRegexp` (the best-effort secondary redaction of bare session titles in the bundled daemon-log tail) anchored both edges of the title with `\b`. Go/RE2 `\b` matches **only** at a word↔non-word transition, so a title ending — or starting — with a non-word character (brackets, punctuation, e.g. `client[prod]`) has no boundary at that edge and the anchor never matches. Such titles leaked verbatim through the log scrub, e.g. the `%s`-formatted title in:

```
task cron-123 started successfully as instance client[prod]
```

The primary `af_<hash>_<title>` tmux-name regex doesn't match these bare occurrences, so `bareTitleRegexp` was the only defense.

## Fix

Emit the `\b` anchor **per-edge**, only where the title's own boundary character is itself a word char (`[A-Za-z0-9_]`):
- A word-char edge keeps its partial-word guard — title `test` still won't match inside `testing`.
- A non-word edge (`]`, `!`, `[`, …) is already self-delimiting and needs no anchor.

Stays within RE2 — no lookaround. Scoped to `bugreport/redact.go` + a test.

## Test

`TestScrubLogRedactsTitlesEndingInNonWordChars` covers titles ending in `]`/`!` and starting with `[`. Verified it **fails** on the pre-fix code and **passes** with the fix.

## Gates

- `gofmt -l .` clean, `go build ./...` OK
- `golangci-lint run --fast` clean, `deadcode -test ./...` clean
- `make test-container` green
- `make tui-driver-selftest` 25/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)