### PR TITLE
fix(config): anchor "aliased to" alias-probe alternatives (#1641)

### DIFF
--- a/config/claude_probe.go
+++ b/config/claude_probe.go
@@ -16,14 +16,19 @@ import (
 )
 
 // aliasOutputRegex extracts the command value from a shell alias-probe line.
-// Each alternative is anchored to a real alias shape so that interactive rc
-// files printing unrelated text cannot poison first-run config (#1003):
-//   - "aliased to ..."    — zsh `which` / bash `type` alias output
+// Every alternative is anchored to a real alias shape at the line start so that
+// interactive rc files printing unrelated text cannot poison first-run config
+// (#1003, #1641):
+//   - "^\S+:\s*aliased to ..."     — zsh `which` builtin ("claude: aliased to …")
+//   - "^\S+\s+is\s+aliased to ..." — bash `type` builtin ("claude is aliased to …")
+//     Both are anchored, so noise like "Tip: git is aliased to /usr/bin/git"
+//     printed before the real alias line no longer captures the wrong path
+//     (#1641).
 //   - "^\S+\s*-> ..."     — a "name -> value" alias line (command name at the
 //     line start before the arrow); the `->` is NOT matched mid-line, so noise
-//     like "Type help -> for assistance" no longer captures garbage
+//     like "Type help -> for assistance" no longer captures garbage (#1003)
 //   - "^[^/=\s]+\s*= ..." — a "name=value" alias assignment at the line start
-var aliasOutputRegex = regexp.MustCompile(`(?:aliased to|^\S+\s*->|^[^/=\s]+\s*=)\s*(.+)`)
+var aliasOutputRegex = regexp.MustCompile(`(?:^\S+:\s*aliased to|^\S+\s+is\s+aliased to|^\S+\s*->|^[^/=\s]+\s*=)\s*(.+)`)
 
 // probeWaitDelay bounds how long the claude shell probe's Output() call keeps
 // waiting for stdout/stderr EOF after the probe shell has exited (or the

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -252,6 +252,14 @@ func TestGetClaudeCommand(t *testing.T) {
 			// the arrow alternative and capture garbage; the real alias line
 			// that follows must win instead.
 			{"mid-line arrow noise before alias", "Type help -> for assistance\nclaude: aliased to /usr/local/bin/claude", "/usr/local/bin/claude"},
+			// #1641: an rc-file noise line containing a mid-line "aliased to"
+			// (e.g. a shell tip about another command) must NOT capture that
+			// command's path; the real "claude: aliased to …" line must win.
+			{"mid-line aliased-to noise before alias", "Tip: git is aliased to /usr/bin/git\nclaude: aliased to /usr/local/bin/claude", "/usr/local/bin/claude"},
+			// A noise line with a mid-line "aliased to" and no real alias
+			// anywhere must fall through to "" so GetClaudeCommand uses the PATH
+			// fallback rather than the noise line's path (#1641).
+			{"mid-line aliased-to noise only", "Tip: git is aliased to /usr/bin/git", ""},
 			// A noise line with a mid-line "->" and no real alias anywhere must
 			// fall through to "" so GetClaudeCommand uses the PATH fallback.
 			{"mid-line arrow noise only", "Type help -> for assistance", ""},


### PR DESCRIPTION
Fixes #1641.

## Problem
`aliasOutputRegex` in `config/claude_probe.go` parses shell alias-probe output to resolve the `claude` command path. Three of its four alternatives (`->`, `=`, and the two anchored via `^`) require the alias shape at the **line start**, but the `aliased to` branch was left **unanchored**. Any earlier rc-file noise line merely *containing* the phrase "aliased to" mid-line matched first and captured the wrong path.

Repro from the report:
```
Tip: git is aliased to /usr/bin/git
claude: aliased to /usr/local/bin/claude
```
- Before: captures `/usr/bin/git` (from the tip line)
- Expected: `/usr/local/bin/claude`

This is the same mid-line false-positive class that #1003 fixed for the `->` alternative, which the introducing commit (#1009) explicitly deferred as a "lower-risk gap".

## Fix
Anchor both real alias-output shapes to the line start:
- `^\S+:\s*aliased to` — zsh `which` builtin (`claude: aliased to …`)
- `^\S+\s+is\s+aliased to` — bash `type` builtin (`claude is aliased to …`)

Now every alternative is line-start-anchored, matching the already-fixed `->` and `=` branches, so only genuine alias lines match and mid-line noise falls through to the PATH lookup.

## Tests
Added the report's repro to the `parseCommandProbeOutput` table:
- noise line containing mid-line "aliased to" before the real alias → must capture the claude path
- noise-only variant (no real alias) → must fall through to `""` so `GetClaudeCommand` uses the PATH fallback

## Gates
- `gofmt -l` clean, `golangci-lint --fast` clean, `deadcode -test ./...` clean
- `go build ./...` ok
- `make test-container` — all packages green
- `make tui-driver-selftest` — 25/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)