### PR TITLE
fix(git): distinct Unicode-only titles no longer collide under a branch prefix (#1640)

### DIFF
--- a/session/git/util.go
+++ b/session/git/util.go
@@ -93,7 +93,19 @@ func trimBranchNameEdges(s string) string {
 // SanitizeBranchName). Exported so both the daemon's authoritative create-time
 // validation and the TUI's pre-submit naming check derive branches identically.
 func BranchForTitle(branchPrefix, title string) string {
-	return SanitizeBranchName(branchPrefix + title)
+	result := SanitizeBranchName(branchPrefix + title)
+	// When the title portion sanitizes away entirely (e.g. a Unicode- or
+	// punctuation-only title), a non-empty prefix keeps the combined result
+	// non-empty, so SanitizeBranchName's empty-result random fallback never
+	// fires and every such title collapses to the sanitized-prefix string.
+	// That falsely collides distinct titles like "日本語" and "مرحبا" under a
+	// prefix (#1640). Detect the prefix-only outcome and append a random
+	// suffix so those titles still get distinct branches, matching the
+	// empty-prefix behavior.
+	if prefixOnly := SanitizeBranchName(branchPrefix); result == prefixOnly && result != "" {
+		result = result + "-" + randomHex(4)
+	}
+	return result
 }
 
 // sanitizeWorktreePathSegment turns a display title into one filesystem path

--- a/session/git/util_test.go
+++ b/session/git/util_test.go
@@ -176,6 +176,16 @@ func TestBranchForTitle(t *testing.T) {
 	if got := BranchForTitle("", "feature"); got != "feature" {
 		t.Errorf("BranchForTitle(\"\", \"feature\") = %q, want %q", got, "feature")
 	}
+	// A Unicode-only title under a non-empty prefix must not collapse to the
+	// bare sanitized prefix; it gets a random suffix so distinct such titles
+	// stay distinct (#1640).
+	jp := BranchForTitle("af-", "日本語")
+	if !strings.HasPrefix(jp, "af-") || jp == "af" {
+		t.Errorf("BranchForTitle(\"af-\", \"日本語\") = %q, want an \"af-\"-prefixed name with a random suffix", jp)
+	}
+	if ar := BranchForTitle("af-", "مرحبا"); jp == ar {
+		t.Errorf("distinct unicode-only titles produced the same branch %q", jp)
+	}
 }
 
 // TestTitlesCollide pins the shared collision rule used by both the daemon's
@@ -202,6 +212,13 @@ func TestTitlesCollide(t *testing.T) {
 		// and keeps two different ones from colliding by accident.
 		{name: "identical unsafe-only titles collide via EqualFold guard", a: "!!!", b: "!!!", prefix: "", want: true},
 		{name: "distinct unsafe-only titles do not collide via random fallback", a: "!!!", b: "???", prefix: "", want: false},
+		// A non-empty prefix keeps "<prefix><unsafe-only title>" non-empty, so
+		// SanitizeBranchName's random fallback never fires and every unsafe-only
+		// title would otherwise collapse to the sanitized prefix. BranchForTitle
+		// appends a random suffix in that case so distinct Unicode-only titles
+		// still get distinct branches (#1640).
+		{name: "distinct unicode-only titles do not collide under a prefix (#1640)", a: "日本語", b: "مرحبا", prefix: "af-", want: false},
+		{name: "identical unicode-only titles still collide under a prefix", a: "日本語", b: "日本語", prefix: "af-", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #1640.

## Problem
`SanitizeBranchName` only fires its random `session-<hex>` fallback when the sanitized string is **empty**. With a non-empty `branch_prefix`, a title made entirely of unsafe characters (Unicode, punctuation) leaves the combined `"<prefix><title>"` non-empty, so the fallback never triggers and every such title collapses to the bare sanitized prefix (e.g. `"af"`).

As a result `TitlesCollide("日本語", "مرحبا", "af-")` returned `true`, wrongly blocking users with non-ASCII session titles from creating a session whenever any other Unicode-only title already exists — even though the titles are completely different. This violates the function's documented intent (`util_test.go`: *"distinct unsafe-only titles do not collide via random fallback"*), which held only for the empty-prefix case.

## Fix
`BranchForTitle` now detects the prefix-only outcome — when `SanitizeBranchName("<prefix><title>")` equals `SanitizeBranchName("<prefix>")` — and appends a random suffix, restoring the empty-prefix behavior so distinct titles get distinct branches. Change is scoped to `session/git/util.go` (the file the issue names) plus tests.

## Tests
- `TestTitlesCollide`: two distinct Unicode-only titles under a prefix do **not** collide; two identical ones still do.
- `TestBranchForTitle`: a Unicode-only title under a prefix keeps the prefix, is not the bare prefix, and differs from another distinct Unicode-only title.

## Gates
gofmt / `golangci-lint --fast` / `go build ./...` / `deadcode -test ./...` clean; `make test-container` green; `make tui-driver-selftest` 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)