### PR TITLE
fix(daemon): reject duplicate remote hook slugs against in-memory sessions (#1636)

### DIFF
--- a/daemon/create_remote_slug_test.go
+++ b/daemon/create_remote_slug_test.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestCreateSessionRejectsRemoteSlugCollisionWithInMemoryInstance pins the
+// #1636 fix: the daemon's remote-slug collision check must consider in-memory
+// remote sessions, not just persisted diskData.
+//
+// refreshDaemonInstances preserves a running remote instance in m.instances
+// even after its repo directory vanishes from disk (a recoverable
+// inconsistency), yet loadRepoInstanceData then returns nothing for that repo.
+// Two titles like "My_App" and "MyApp" derive DISTINCT git branches (Slugify
+// drops the underscore while branch sanitization keeps it) so the branch
+// collision check lets both coexist, but both slugify to the same remote hook
+// name "myapp". The HTTP /v1/CreateSession path relies solely on this
+// daemon-side validation — the TUI's FindSlugCollision pre-check never runs for
+// it — so the daemon must reject the second create itself.
+func TestCreateSessionRejectsRemoteSlugCollisionWithInMemoryInstance(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// Register a running remote session in memory only — no on-disk record.
+	// Because the repo has no persisted instances directory, refreshLocked's
+	// "preserve in-memory instances for a missing repo directory" path keeps it
+	// alive across the refresh reserveCreate runs, while loadRepoInstanceData
+	// returns an empty slice for it — exactly the buggy state.
+	const existingTitle = "My_App"
+	inst, err := session.NewInstance(session.InstanceOptions{Title: existingTitle, Path: repoPath, Program: "claude"})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	inst.SetBackend(remoteTypeBackend{session.NewFakeBackend()})
+	inst.SetStartedForTest(true)
+	manager.mu.Lock()
+	manager.instances[daemonInstanceKey(repo.ID, existingTitle)] = inst
+	manager.mu.Unlock()
+
+	// Sanity-check the premise: the two titles do NOT collide on their git
+	// branch (so the branch check would pass), but they DO slugify to the same
+	// remote hook name. If this ever stops holding, the test is no longer
+	// exercising the slug-only collision path.
+	const newTitle = "MyApp"
+	if manager.titlesCollide(existingTitle, newTitle) {
+		t.Fatalf("test premise broken: %q and %q collide on branch, so the slug path is unreachable", existingTitle, newTitle)
+	}
+	if session.Slugify(existingTitle) != session.Slugify(newTitle) {
+		t.Fatalf("test premise broken: %q and %q must slugify to the same hook name", existingTitle, newTitle)
+	}
+
+	_, err = manager.CreateSession(CreateSessionRequest{
+		Title:       newTitle,
+		RepoPath:    repoPath,
+		Program:     "claude",
+		ForceRemote: true,
+	})
+	if err == nil {
+		t.Fatalf("expected duplicate remote hook slug to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "hook name") {
+		t.Fatalf("rejection must name the remote hook-name collision, got: %v", err)
+	}
+}

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -198,6 +198,31 @@ func (m *Manager) validateTitleAvailableLocked(repoID, repoPath, title, program 
 		if _, ok := m.reservedRemoteNames[candidate]; ok {
 			return fmt.Errorf("remote hook name %q is already reserved", candidate)
 		}
+		// Guard against in-memory remote sessions that are not (yet) on disk.
+		// refreshDaemonInstances preserves a running remote instance in
+		// m.instances even after its repo directory is deleted externally (a
+		// recoverable inconsistency), yet loadRepoInstanceData returns nothing
+		// for it — so a disk-only slug check would let a second title that
+		// slugifies to the same hook name through. The branch-collision check
+		// above misses this pair because Slugify drops underscores while branch
+		// sanitization keeps them as dashes ("My_App"->branch "my-app"/slug
+		// "myapp" vs "MyApp"->branch "myapp"/slug "myapp"). The TUI pre-check
+		// (FindSlugCollision over Snapshot()) catches it, but the HTTP
+		// CreateSession path bypasses that, so the daemon-side check must be
+		// complete (#1636).
+		for key, inst := range m.instances {
+			rid, _ := splitDaemonInstanceKey(key)
+			if rid != repoID || inst == nil {
+				continue
+			}
+			data := inst.ToInstanceData()
+			if !data.IsRemoteHook() {
+				continue
+			}
+			if session.RemoteHookName(data.Title, data.RemoteMeta) == candidate {
+				return fmt.Errorf("remote session titled %q already maps to hook name %q", data.Title, candidate)
+			}
+		}
 		for _, data := range diskData {
 			if !data.IsRemoteHook() {
 				continue


### PR DESCRIPTION
Fixes #1636.

## Problem

`daemon/manager_create.go`'s `validateTitleAvailableLocked` remote-slug collision check only scanned persisted `diskData`, not the in-memory `m.instances`. `refreshDaemonInstances` preserves a running remote instance in memory even after its repo directory is deleted externally (a recoverable inconsistency), but `loadRepoInstanceData` then returns nothing for that repo — so the disk-only check saw no existing remote session.

Two titles with different git branches but the same slug — e.g. `"My_App"` and `"MyApp"` both `Slugify` to `"myapp"`, while their branches differ because `Slugify` drops the underscore and branch sanitization keeps it — could therefore both be created as remote sessions, giving their hook scripts (`launch_cmd`, `attach_cmd`, `delete_cmd`) ambiguous/conflicting names.

The TUI catches this via a `FindSlugCollision` pre-check over `Snapshot()`, but the HTTP `/v1/CreateSession` path (`ForceRemote: true`) bypasses that pre-check and relies solely on the daemon-side validation, which was incomplete.

## Fix

Add an in-memory `m.instances` scan for the target repo's remote sessions alongside the existing `diskData` scan, mirroring how the title-collision logic (`findTitleConflictLocked`) already considers both sources.

## Test

`TestCreateSessionRejectsRemoteSlugCollisionWithInMemoryInstance` registers an in-memory-only remote session (`My_App`) whose repo has no on-disk record — the exact preserved-in-memory state — then drives `CreateSession` with a colliding title (`MyApp`). It asserts the create is rejected with the hook-name collision error, and includes premise checks that the two titles do NOT collide on their git branch but DO slugify to the same hook name. Verified it fails without the fix (the create slips past validation) and passes with it.

## Gates

- `gofmt -l .` clean, `golangci-lint --fast` clean, `go build ./...` clean
- `deadcode -test ./...` clean, `scripts/lint-file-length.sh` clean
- `make test-container` — full suite green
- `make tui-driver-selftest` — 25/25

🤖 Generated with [Claude Code](https://claude.com/claude-code)