### PR TITLE
fix(daemon): recover watcher event queue from partial-write + truncate failure (#1634)

### DIFF
--- a/daemon/eventqueue.go
+++ b/daemon/eventqueue.go
@@ -88,6 +88,13 @@ type eventQueue struct {
 	curPath string // <dir>/<taskID>.cursor
 	remove  func(string) error
 
+	// appendRecord/truncate are the append and truncate seams. Production wires
+	// them to os.Truncate and a real O_APPEND write; tests inject them to
+	// simulate the partial-write + truncate-failure path that #1634 wedged on
+	// (a real short write is otherwise impossible to force on a local FS).
+	appendRecord func(path string, rec []byte) (int, error)
+	truncate     func(path string, size int64) error
+
 	mu      sync.Mutex
 	offset  int64 // byte offset of the first undelivered event
 	size    int64 // total bytes in the jsonl file
@@ -121,11 +128,13 @@ func eventQueueDir() (string, error) {
 // which is what lets a backlog survive a daemon restart or reload.
 func newEventQueue(dir, taskID string) *eventQueue {
 	q := &eventQueue{
-		taskID:  taskID,
-		path:    filepath.Join(dir, taskID+".jsonl"),
-		curPath: filepath.Join(dir, taskID+".cursor"),
-		remove:  os.Remove,
-		now:     time.Now,
+		taskID:       taskID,
+		path:         filepath.Join(dir, taskID+".jsonl"),
+		curPath:      filepath.Join(dir, taskID+".cursor"),
+		remove:       os.Remove,
+		appendRecord: appendRecordToFile,
+		truncate:     os.Truncate,
+		now:          time.Now,
 	}
 	q.load()
 	return q
@@ -227,24 +236,17 @@ func (q *eventQueue) enqueue(line string) error {
 	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(q.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		return err
-	}
 	rec = append(rec, '\n')
-	n, err := f.Write(rec)
-	if closeErr := f.Close(); err == nil {
-		err = closeErr
-	}
+	n, err := q.appendRecord(q.path, rec)
 	if err != nil {
-		// A short write would leave a torn record that corrupts the NEXT
-		// append; truncate back to the last record boundary so the file stays
-		// record-aligned (the caller drops this event — same degradation as
-		// enqueue failing outright).
+		// A short write leaves a torn record that would corrupt the NEXT append:
+		// O_APPEND writes at the real end of file, so the next record glues onto
+		// the torn bytes into one invalid line. Truncate back to the last record
+		// boundary so the file stays record-aligned (the caller drops this event
+		// — same degradation as enqueue failing outright).
 		if n > 0 {
-			if terr := os.Truncate(q.path, q.size); terr != nil {
-				log.WarningLog.Printf("watch task %s: failed to truncate short-written event record: %v", q.taskID, terr)
-				q.size += int64(n)
+			if terr := q.truncate(q.path, q.size); terr != nil {
+				q.recoverTornRecordLocked(n, terr)
 			}
 		}
 		return err
@@ -253,6 +255,52 @@ func (q *eventQueue) enqueue(line string) error {
 	q.pending++
 
 	return q.dropOldestOverCapsLocked()
+}
+
+// appendRecordToFile is the production append seam: one O_APPEND write of the
+// whole record, returning the byte count written so a short write can be
+// recovered by the caller.
+func appendRecordToFile(path string, rec []byte) (int, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return 0, err
+	}
+	n, err := f.Write(rec)
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	return n, err
+}
+
+// recoverTornRecordLocked salvages a short write whose truncate ALSO failed, so
+// the torn bytes (n of them, no trailing newline) are stuck on disk. Left as-is
+// they would permanently wedge the queue (#1634): the next O_APPEND merges its
+// record onto the torn bytes into one invalid line that no restart could clear.
+// Best-effort recovery: append a single newline to force a record boundary, so
+// the torn fragment becomes its own (unparseable) line that peek() drops and
+// skips past instead of merging into the next event. The fragment is counted as
+// pending to keep the in-memory count equal to the on-disk line count — else a
+// later good event would be miscounted and silently lost when the head is
+// skipped. If even the newline append fails, the reader's skip path is the final
+// backstop (a merged line is skippable too, only losing the following event).
+// Callers hold q.mu.
+func (q *eventQueue) recoverTornRecordLocked(n int, truncErr error) {
+	f, ferr := os.OpenFile(q.path, os.O_WRONLY|os.O_APPEND, 0644)
+	if ferr != nil {
+		log.WarningLog.Printf("watch task %s: failed to truncate short-written event record (%v); could not reopen to re-align it: %v", q.taskID, truncErr, ferr)
+		return
+	}
+	_, werr := f.Write([]byte{'\n'})
+	if closeErr := f.Close(); werr == nil {
+		werr = closeErr
+	}
+	if werr != nil {
+		log.WarningLog.Printf("watch task %s: failed to truncate short-written event record (%v); could not re-align it with a newline: %v", q.taskID, truncErr, werr)
+		return
+	}
+	q.size += int64(n) + 1
+	q.pending++
+	log.WarningLog.Printf("watch task %s: failed to truncate short-written event record (%v); re-aligned the torn %d bytes with a trailing newline so the queue stays readable", q.taskID, truncErr, n)
 }
 
 // resetCursorBeforeFreshAppendLocked removes or zeroes any leftover cursor
@@ -305,17 +353,42 @@ func (q *eventQueue) dropOldestOverCapsLocked() error {
 
 // peek returns the oldest undelivered event and an advance cursor without
 // consuming it. ok is false when the queue is empty.
+//
+// Self-heal (#1634): an unreadable head record that is nonetheless record-
+// aligned (a corrupt line with a terminating newline — e.g. a torn fragment
+// re-aligned by recoverTornRecordLocked, or a merged line from a truncate
+// failure) is DROPPED and skipped rather than parking the drainer forever. On-
+// disk corruption survives every daemon restart, so parking is a permanent
+// wedge; dropping the one bad record and advancing keeps the valid events after
+// it reachable. Only a record with no boundary to skip to (an unterminated torn
+// tail) is surfaced as an error for the drainer to park on.
 func (q *eventQueue) peek() (ev queuedEvent, cursor eventQueueCursor, ok bool, err error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if q.pending == 0 {
-		return queuedEvent{}, eventQueueCursor{}, false, nil
+	for q.pending > 0 {
+		ev, n, rerr := q.readEventAtLocked(q.offset)
+		if rerr == nil {
+			return ev, eventQueueCursor{offset: q.offset, length: n, seq: ev.Seq}, true, nil
+		}
+		if n <= 0 {
+			// No record boundary found (unterminated torn tail): nothing safe to
+			// skip to. Surface the error; the drainer parks until the next reload.
+			return queuedEvent{}, eventQueueCursor{}, false, rerr
+		}
+		log.WarningLog.Printf("watch task %s: dropping unreadable queued event at offset %d (%d bytes): %v", q.taskID, q.offset, n, rerr)
+		q.offset += n
+		q.pending--
+		if q.pending == 0 {
+			if _, derr := q.removeDrainedFilesLocked(); derr != nil {
+				return queuedEvent{}, eventQueueCursor{}, false, derr
+			}
+			return queuedEvent{}, eventQueueCursor{}, false, nil
+		}
+		if perr := q.persistCursorLocked(); perr != nil {
+			return queuedEvent{}, eventQueueCursor{}, false, perr
+		}
 	}
-	ev, n, err := q.readEventAtLocked(q.offset)
-	if err != nil {
-		return queuedEvent{}, eventQueueCursor{}, false, err
-	}
-	return ev, eventQueueCursor{offset: q.offset, length: n, seq: ev.Seq}, true, nil
+	return queuedEvent{}, eventQueueCursor{}, false, nil
 }
 
 // advance consumes the oldest event AFTER its successful delivery: cursor
@@ -449,9 +522,12 @@ func (q *eventQueue) offsetIsRecordBoundaryLocked(f *os.File) bool {
 }
 
 // readEventAtLocked reads and parses one JSONL record at the given offset,
-// returning the record and its length including the newline. Callers hold
-// q.mu. A corrupt or truncated record is an error — the drainer logs and
-// parks rather than guessing at boundaries.
+// returning the record and its length including the newline. Callers hold q.mu.
+//
+// The returned length distinguishes the two failure modes so peek can self-heal
+// (#1634): a CORRUPT but newline-terminated record returns its byte length with
+// the error (there is a boundary to skip past), while a TRUNCATED record with no
+// terminating newline returns length 0 (no boundary — the drainer parks).
 func (q *eventQueue) readEventAtLocked(off int64) (queuedEvent, int64, error) {
 	f, err := os.Open(q.path)
 	if err != nil {
@@ -468,7 +544,7 @@ func (q *eventQueue) readEventAtLocked(off int64) (queuedEvent, int64, error) {
 	}
 	var ev queuedEvent
 	if err := json.Unmarshal(raw, &ev); err != nil {
-		return queuedEvent{}, 0, fmt.Errorf("corrupt event record at offset %d: %w", off, err)
+		return queuedEvent{}, int64(len(raw)), fmt.Errorf("corrupt event record at offset %d: %w", off, err)
 	}
 	return ev, int64(len(raw)), nil
 }

--- a/daemon/eventqueue_test.go
+++ b/daemon/eventqueue_test.go
@@ -313,6 +313,120 @@ func TestEventQueue_TornTrailingRecordTruncated(t *testing.T) {
 	}
 }
 
+// drainAllEvents peeks+advances until the queue is empty, returning the lines
+// of every event delivered in order. peek self-heals corrupt head records
+// (#1634), so a wedged queue would surface here as a peek error, not a hang.
+func drainAllEvents(t *testing.T, q *eventQueue) []string {
+	t.Helper()
+	var got []string
+	for {
+		ev, cursor, ok, err := q.peek()
+		if err != nil {
+			t.Fatalf("peek during drain: %v", err)
+		}
+		if !ok {
+			return got
+		}
+		got = append(got, ev.Line)
+		advanceEventQueue(t, q, cursor)
+	}
+}
+
+// enqueueTornWithTruncateFailure reproduces the #1634 failure mode: a partial
+// (torn, no-newline) write to the real file whose truncate ALSO fails, driven
+// through the appendRecord/truncate seams. It returns the enqueue error so the
+// caller can assert it, and restores the production seams before returning.
+func enqueueTornWithTruncateFailure(q *eventQueue, line string) error {
+	shortWrite := errors.New("simulated short write")
+	q.appendRecord = func(path string, rec []byte) (int, error) {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			return 0, err
+		}
+		half := len(rec) / 2 // < len(rec), so the trailing newline is never written
+		n, _ := f.Write(rec[:half])
+		_ = f.Close()
+		return n, shortWrite
+	}
+	q.truncate = func(string, int64) error { return errors.New("simulated truncate failure") }
+	defer func() {
+		q.appendRecord = appendRecordToFile
+		q.truncate = os.Truncate
+	}()
+	return q.enqueue(line)
+}
+
+// TestEventQueue_PartialWriteTruncateFailureStaysReadable is the #1634
+// regression: a partial write whose truncate fails must NOT wedge the queue.
+// The torn fragment is re-aligned with a newline and later dropped, and every
+// well-formed event — including one enqueued AFTER the failure — still drains in
+// order rather than being glued onto the torn bytes into an unparseable line.
+func TestEventQueue_PartialWriteTruncateFailureStaysReadable(t *testing.T) {
+	dir := t.TempDir()
+	q := newEventQueue(dir, "ab160034")
+	for _, line := range []string{"good-1", "good-2"} {
+		if err := q.enqueue(line); err != nil {
+			t.Fatalf("enqueue %s: %v", line, err)
+		}
+	}
+
+	if err := enqueueTornWithTruncateFailure(q, "torn"); err == nil {
+		t.Fatal("enqueue with short write + truncate failure returned nil, want an error")
+	}
+	// The follow-on append (production seams) must land on a record boundary,
+	// not merge onto the torn bytes.
+	if err := q.enqueue("good-3"); err != nil {
+		t.Fatalf("enqueue good-3 after failure: %v", err)
+	}
+
+	got := drainAllEvents(t, q)
+	want := []string{"good-1", "good-2", "good-3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("drained %v, want %v (torn fragment dropped, all real events intact)", got, want)
+	}
+	if n := q.pendingCount(); n != 0 {
+		t.Fatalf("pending after drain = %d, want 0", n)
+	}
+	for _, p := range []string{q.path, q.curPath} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("drained queue must remove %s", filepath.Base(p))
+		}
+	}
+}
+
+// TestEventQueue_PartialWriteTruncateFailureRecoversAcrossRestart pins the other
+// half of #1634: the original bug survived a daemon restart. After the partial
+// write + truncate failure, reopening the queue (as a restarted daemon would)
+// and draining must recover — the torn record is dropped and the valid events
+// after it stay reachable — instead of the reload re-wedging on the corrupt head.
+func TestEventQueue_PartialWriteTruncateFailureRecoversAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	taskID := "ab160035"
+	q := newEventQueue(dir, taskID)
+	for _, line := range []string{"good-1", "good-2"} {
+		if err := q.enqueue(line); err != nil {
+			t.Fatalf("enqueue %s: %v", line, err)
+		}
+	}
+	if err := enqueueTornWithTruncateFailure(q, "torn"); err == nil {
+		t.Fatal("enqueue with short write + truncate failure returned nil, want an error")
+	}
+	if err := q.enqueue("good-3"); err != nil {
+		t.Fatalf("enqueue good-3 after failure: %v", err)
+	}
+
+	// Simulate a daemon restart: a fresh queue recovers state purely from disk.
+	reopened := newEventQueue(dir, taskID)
+	got := drainAllEvents(t, reopened)
+	want := []string{"good-1", "good-2", "good-3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("drained after restart %v, want %v (restart must heal the corruption)", got, want)
+	}
+	if n := reopened.pendingCount(); n != 0 {
+		t.Fatalf("pending after restart drain = %d, want 0", n)
+	}
+}
+
 // TestEventQueue_DropsOldestOverEventCap: the backlog is bounded; overflow
 // drops the OLDEST pending events (newest are the actionable ones after an
 // outage) and counts the drops.


### PR DESCRIPTION
Fixes #1634.

## The bug
`daemon/eventqueue.go` provides the durable, disk-backed FIFO backlog for
watcher task events. When `enqueue()` hit a **short write** whose follow-up
`os.Truncate` **also failed**, the old code bumped `q.size` to include the torn
bytes and returned:

```go
if terr := os.Truncate(q.path, q.size); terr != nil {
    log.WarningLog.Printf(...)
    q.size += int64(n) // torn bytes counted as durable
}
```

The next `enqueue()` opens the file with `O_APPEND`, so the kernel writes at the
*real* end of file — directly after the unterminated torn bytes — gluing the two
records into one invalid JSON line. From then on `peek()` fails to parse the head
record and the drainer parks. **A daemon restart does not fix it**: `load()` only
recovers a torn *trailing* record (no newline), never a corrupt interior/head
one, so the queue stays wedged until the files are manually deleted.

## The fix
Make the queue recover instead of wedging:

- **`enqueue()`** — on a truncate failure, best-effort append a single newline so
  the torn fragment becomes its own record-aligned (if unparseable) line rather
  than merging into the next event, and count it as pending so the in-memory
  count stays equal to the on-disk line count (otherwise a later good event would
  be miscounted and lost when the head is skipped).
- **`peek()`** — drop and skip an unreadable but record-aligned head record
  (a corrupt line *with* a terminating newline) instead of parking the drainer
  forever. This heals both the live drainer and a restart, keeping the valid
  events after the corrupt one reachable. Only an unterminated torn tail (no
  boundary to skip to) still surfaces an error for the drainer to park on.

## Tests
Added `appendRecord`/`truncate` seams (mirroring the existing `remove` seam) so a
partial write + truncate failure — otherwise impossible to force on a local FS —
can be injected, plus two regression tests:

- `TestEventQueue_PartialWriteTruncateFailureStaysReadable` — the live process
  drains every well-formed event (including one enqueued *after* the failure) and
  drops only the torn fragment; no merge, no wedge.
- `TestEventQueue_PartialWriteTruncateFailureRecoversAcrossRestart` — reopening
  the queue (as a restarted daemon would) recovers rather than re-wedging.

## Gates
`gofmt` / `golangci-lint --fast` / `go build ./...` / `deadcode -test ./...` /
`scripts/lint-file-length.sh` clean; `make test-container` all packages green;
`make tui-driver-selftest` 25/25. Scope is the named file + its test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)