### PR TITLE
feat(config): TLS cert + bearer-token material + af token command (#1592 Phase 3 PR1)

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -297,6 +297,7 @@ func init() {
 	rootCmd.AddCommand(upgradeCmd)
 	rootCmd.AddCommand(daemonCmd)
 	rootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(tokenCmd)
 	rootCmd.AddCommand(api.SessionsCmd)
 	rootCmd.AddCommand(api.TasksCmd)
 	rootCmd.AddCommand(api.APICmd)

--- a/commands/tokencmd.go
+++ b/commands/tokencmd.go
@@ -1,0 +1,149 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/log"
+
+	"github.com/spf13/cobra"
+)
+
+// `af token` manages the daemon's bearer token — the credential for the
+// direct-TCP/TLS API surface (#1592 Phase 3). Under Sachin's locked auth model
+// one token = full access, single-owner. The token is DARK in PR1: no listener
+// enforces it yet (Phase 3 PR3 lights up the TLS TCP listener). `af token`
+// exists now so the material can be generated, inspected, and rotated ahead of
+// (and independently of) enabling the listener. The local unix socket is never
+// affected — its filesystem 0600 perms are the local auth (#1029).
+
+// tokenJSONFlag switches `af token show/rotate` from human output to the shared
+// {data,error} envelope, matching `af config`'s --json.
+var tokenJSONFlag bool
+
+// tokenShowResult is the `af token show` payload: the bearer token plus the TLS
+// fingerprint a client TOFU-pins for a self-signed daemon cert (§1.2).
+type tokenShowResult struct {
+	Token          string `json:"token"`
+	TLSFingerprint string `json:"tls_fingerprint"`
+}
+
+// tokenRotateResult is the `af token rotate` payload: the freshly generated
+// token. The fingerprint is unchanged by rotation (it depends on the cert, not
+// the token), so rotate does not reprint it.
+type tokenRotateResult struct {
+	Token string `json:"token"`
+}
+
+// resolveTLSFingerprint resolves the daemon's TLS material (user-provided cert
+// via tls_cert/tls_key, else the self-generated self-signed cert) and returns
+// its SHA-256 fingerprint. Resolving self-generates the cert on first use, so
+// `af token show` materializes both the token and the cert — still DARK, since
+// nothing binds a listener.
+func resolveTLSFingerprint() (string, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return "", err
+	}
+	material, err := daemon.ResolveTLSMaterial(dir, cfg.TLSCert, cfg.TLSKey)
+	if err != nil {
+		return "", err
+	}
+	return daemon.CertFingerprint(material.CertPath)
+}
+
+var tokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Manage the daemon's bearer token for the direct-TCP API",
+	Long: `Manage the bearer token that authenticates the daemon's direct-TCP/TLS API.
+
+The token grants full access under the single-owner auth model. It is only used
+by the TCP listener (enabled with the listen_addr config key); the local unix
+socket stays unauthenticated (its 0600 filesystem perms are the local auth).
+The token and the self-signed TLS cert are stored in the af home
+(~/.agent-factory) with 0600 permissions on the secret files.`,
+}
+
+var tokenShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Print the bearer token and TLS fingerprint (generating them if absent)",
+	Long: `Print the daemon's bearer token and its TLS certificate fingerprint.
+
+Both are generated on first access if they do not yet exist, so this is safe to
+run before the TCP listener is ever enabled. The fingerprint is the SHA-256 a
+remote client pins (TOFU) when the daemon uses its self-signed certificate; when
+a CA-issued certificate is configured via tls_cert/tls_key it is that
+certificate's fingerprint (clients verify it against system roots instead).`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		tokenPath, err := daemon.TokenPath()
+		if err != nil {
+			return jsonWrapError(cmd, tokenJSONFlag, err)
+		}
+		token, err := daemon.EnsureToken(tokenPath)
+		if err != nil {
+			return jsonWrapError(cmd, tokenJSONFlag, err)
+		}
+		fingerprint, err := resolveTLSFingerprint()
+		if err != nil {
+			return jsonWrapError(cmd, tokenJSONFlag, err)
+		}
+
+		result := tokenShowResult{Token: token, TLSFingerprint: fingerprint}
+		if tokenJSONFlag {
+			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(result))
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "token:           %s\n", result.Token)
+		fmt.Fprintf(cmd.OutOrStdout(), "tls_fingerprint: %s\n", result.TLSFingerprint)
+		return nil
+	},
+}
+
+var tokenRotateCmd = &cobra.Command{
+	Use:   "rotate",
+	Short: "Replace the bearer token with a fresh one and print it",
+	Long: `Generate a new bearer token, persist it (overwriting the old one), and print it.
+
+Rotation takes effect for new connections immediately — the auth gate re-reads
+the token file per request — while any in-flight streams keep running until they
+reconnect. The TLS fingerprint is unaffected (it depends on the certificate, not
+the token).`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		tokenPath, err := daemon.TokenPath()
+		if err != nil {
+			return jsonWrapError(cmd, tokenJSONFlag, err)
+		}
+		token, err := daemon.RotateToken(tokenPath)
+		if err != nil {
+			return jsonWrapError(cmd, tokenJSONFlag, err)
+		}
+
+		result := tokenRotateResult{Token: token}
+		if tokenJSONFlag {
+			return apiproto.WriteEnvelope(cmd.OutOrStdout(), apiproto.Success(result))
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "token: %s\n", result.Token)
+		return nil
+	},
+}
+
+func init() {
+	const jsonUsage = "Emit the result as JSON wrapped in the {data,error} envelope"
+	tokenShowCmd.Flags().BoolVar(&tokenJSONFlag, "json", false, jsonUsage)
+	tokenRotateCmd.Flags().BoolVar(&tokenJSONFlag, "json", false, jsonUsage)
+	tokenCmd.AddCommand(tokenShowCmd)
+	tokenCmd.AddCommand(tokenRotateCmd)
+}

--- a/commands/tokencmd_test.go
+++ b/commands/tokencmd_test.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/apiproto"
+
+	"github.com/spf13/cobra"
+)
+
+// runToken invokes a token subcommand with a fresh output buffer, resetting the
+// shared --json flag first so tests do not leak state into one another.
+func runToken(t *testing.T, cmd *cobra.Command, jsonMode bool) string {
+	t.Helper()
+	tokenJSONFlag = jsonMode
+	t.Cleanup(func() { tokenJSONFlag = false })
+
+	var out bytes.Buffer
+	c := &cobra.Command{}
+	c.SetOut(&out)
+	if err := cmd.RunE(c, nil); err != nil {
+		t.Fatalf("%s: %v", cmd.Use, err)
+	}
+	return out.String()
+}
+
+func TestTokenShowGeneratesTokenAndFingerprint(t *testing.T) {
+	tempAFHome(t)
+
+	out := runToken(t, tokenShowCmd, false)
+	if !strings.Contains(out, "token:") {
+		t.Fatalf("token show output missing token line:\n%s", out)
+	}
+	if !strings.Contains(out, "tls_fingerprint: sha256:") {
+		t.Fatalf("token show output missing tls_fingerprint line:\n%s", out)
+	}
+}
+
+func TestTokenShowIdempotent(t *testing.T) {
+	tempAFHome(t)
+
+	first := parseTokenJSON(t, runToken(t, tokenShowCmd, true))
+	second := parseTokenJSON(t, runToken(t, tokenShowCmd, true))
+
+	if first.Token == "" {
+		t.Fatal("empty token from show")
+	}
+	if first.Token != second.Token {
+		t.Fatalf("token show not idempotent: %q != %q", first.Token, second.Token)
+	}
+	if first.TLSFingerprint != second.TLSFingerprint {
+		t.Fatalf("fingerprint changed across shows: %q != %q", first.TLSFingerprint, second.TLSFingerprint)
+	}
+	if !strings.HasPrefix(first.TLSFingerprint, "sha256:") {
+		t.Fatalf("unexpected fingerprint format: %q", first.TLSFingerprint)
+	}
+}
+
+func TestTokenRotateChangesToken(t *testing.T) {
+	tempAFHome(t)
+
+	before := parseTokenJSON(t, runToken(t, tokenShowCmd, true)).Token
+	rotated := parseTokenJSON(t, runToken(t, tokenRotateCmd, true)).Token
+	if rotated == "" {
+		t.Fatal("empty token from rotate")
+	}
+	if rotated == before {
+		t.Fatalf("rotate did not change the token: %q", rotated)
+	}
+
+	// A subsequent show reflects the rotated token.
+	after := parseTokenJSON(t, runToken(t, tokenShowCmd, true)).Token
+	if after != rotated {
+		t.Fatalf("show after rotate = %q, want rotated %q", after, rotated)
+	}
+}
+
+// tokenJSONPayload mirrors tokenShowResult/tokenRotateResult for decoding.
+type tokenJSONPayload struct {
+	Token          string `json:"token"`
+	TLSFingerprint string `json:"tls_fingerprint"`
+}
+
+func parseTokenJSON(t *testing.T, out string) tokenJSONPayload {
+	t.Helper()
+	var env struct {
+		Data  tokenJSONPayload        `json:"data"`
+		Error *apiproto.EnvelopeError `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("decode envelope: %v\noutput: %s", err, out)
+	}
+	if env.Error != nil {
+		t.Fatalf("envelope carried an error: %s", env.Error.Message)
+	}
+	return env.Data
+}

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -164,6 +164,28 @@ type Config struct {
 	// reset time WAS parsed (that schedules against the reset time + grace).
 	// Global-only, like limit_auto_resume. See LimitRetryIntervalDuration.
 	LimitRetryInterval string `json:"limit_retry_interval" toml:"limit_retry_interval"`
+	// ListenAddr optionally binds the daemon's HTTP/WS API to a TLS TCP
+	// listener in addition to the always-present local unix socket (#1592
+	// Phase 3). Empty ⇒ no TCP listener (today's pure-unix behavior). A value
+	// like "0.0.0.0:8443" or ":8443" enables direct-TCP access gated by the
+	// bearer token (`af token`). DARK until Phase 3 PR3 binds the listener;
+	// declared now so the whole key set lands in one reviewable place.
+	// Global-only (daemon behavior), like daemon_poll_interval — a cloned
+	// repo must never be able to open a network port.
+	ListenAddr string `json:"listen_addr" toml:"listen_addr"`
+	// TLSCert / TLSKey optionally point at a user-provided PEM cert and its
+	// matching key for the TCP listener (#1592 Phase 3, §1.2). Empty ⇒ the
+	// daemon self-generates a pinned self-signed cert. Both must be set
+	// together. Global-only, like listen_addr.
+	TLSCert string `json:"tls_cert" toml:"tls_cert"`
+	TLSKey  string `json:"tls_key" toml:"tls_key"`
+	// CORSAllowedOrigins is the exact-match allow-list of browser origins
+	// permitted to call the API cross-origin (#1592 Phase 3, §1.5), e.g.
+	// ["https://af.example.com"]. Empty ⇒ no Access-Control-Allow-Origin is
+	// emitted, so no cross-origin browser can reach the API (the future web
+	// client's only Phase-3 dependency). Non-browser clients (TUI/CLI, curl)
+	// are unaffected. Global-only, like listen_addr.
+	CORSAllowedOrigins []string `json:"cors_allowed_origins,omitempty" toml:"cors_allowed_origins,omitempty"`
 	// Keys is the raw [keys] rebinding table (#1026): action name → a key
 	// string or list of key strings, replacing that action's default binding
 	// entirely (unlisted actions keep their defaults). TOML-ONLY by design —

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -91,11 +91,16 @@ var inRepoAllowedKeys = []string{
 // so an in-repo value would either silently do nothing or, worse, let a repo
 // flip host-level behavior like autoyes.
 var inRepoGlobalOnlyKeys = map[string]bool{
-	"auto_update":          true,
-	"auto_yes":             true,
-	"branch_prefix":        true,
+	"auto_update":   true,
+	"auto_yes":      true,
+	"branch_prefix": true,
+	// TCP/TLS auth material configures the daemon's network surface, never a
+	// repository — a cloned repo must never be able to open a port, swap the
+	// server cert, or widen the CORS allow-list (#1592 Phase 3).
+	"cors_allowed_origins": true,
 	"daemon_poll_interval": true,
 	"detach_keys":          true,
+	"listen_addr":          true,
 	// The [keys] keymap is a user/host preference: a cloned repo must never
 	// be able to rebind someone's terminal (#1026).
 	"keys":                 true,
@@ -107,6 +112,8 @@ var inRepoGlobalOnlyKeys = map[string]bool{
 	// The [theme] table is a user/host visual preference; repositories must
 	// not be able to recolor a cloned user's TUI (#1389).
 	"theme":          true,
+	"tls_cert":       true,
+	"tls_key":        true,
 	"update_channel": true,
 	"worktree_root":  true,
 }

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -66,7 +66,7 @@ func TestLoadInRepoConfigEmptyValueIsSet(t *testing.T) {
 }
 
 func TestLoadInRepoConfigRejectsGlobalOnlyKeys(t *testing.T) {
-	for _, key := range []string{"auto_update", "auto_yes", "branch_prefix", "daemon_poll_interval", "detach_keys", "keys", "log_max_backups", "log_max_size_mb", "root_agents", "update_channel", "worktree_root"} {
+	for _, key := range []string{"auto_update", "auto_yes", "branch_prefix", "cors_allowed_origins", "daemon_poll_interval", "detach_keys", "keys", "listen_addr", "log_max_backups", "log_max_size_mb", "root_agents", "tls_cert", "tls_key", "update_channel", "worktree_root"} {
 		t.Run(key, func(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("AGENT_FACTORY_HOME", home)

--- a/daemon/tlsmaterial.go
+++ b/daemon/tlsmaterial.go
@@ -1,0 +1,179 @@
+package daemon
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// The TLS material for the daemon's TCP surface (#1592 Phase 3 PR1, §1.2).
+// TLS is mandatory on the TCP listener — the bearer token must never ride the
+// wire in the clear. This file only produces and resolves the cert/key; it is
+// DARK: no listener uses it yet (Phase 3 PR3 binds the TLS TCP listener).
+//
+// Default (zero-config): a self-generated ECDSA P-256 self-signed cert stored
+// in the af home. The client pins its SHA-256 fingerprint (TOFU), so a
+// hostname/SAN mismatch is irrelevant — connecting by IP or through an
+// ssh -L tunnel Just Works. Override: user-provided PEM cert/key (Let's
+// Encrypt, corporate CA), verified against system roots (no pin needed).
+
+const (
+	// daemonTLSCertFileName / daemonTLSKeyFileName are the self-signed PEM
+	// cert and key in the af home. The key is 0600; the cert is public.
+	daemonTLSCertFileName = "daemon-tls.crt"
+	daemonTLSKeyFileName  = "daemon-tls.key"
+	// selfSignedValidity is how long a self-generated cert is valid. It is
+	// long-lived because it is pinned by fingerprint, not chained to a CA:
+	// rotation would only change the pin the client already trusts.
+	selfSignedValidity = 10 * 365 * 24 * time.Hour
+)
+
+// TLSMaterial is the resolved cert/key the daemon's TCP listener will serve
+// (Phase 3 PR3). SelfSigned distinguishes the pinned self-signed default from
+// a user-provided CA cert (which the client verifies against system roots).
+type TLSMaterial struct {
+	// CertPath / KeyPath are the PEM files on disk.
+	CertPath string
+	KeyPath  string
+	// SelfSigned is true when the daemon generated the cert (client must pin
+	// the fingerprint); false when the user supplied tls_cert/tls_key.
+	SelfSigned bool
+}
+
+// ResolveTLSMaterial returns the TLS cert/key for the daemon's TCP surface.
+//
+// When both userCert and userKey are set it uses them verbatim (the override
+// path) and does not self-generate. When both are empty it loads — or, on
+// first use, generates — a self-signed ECDSA cert under dir. Setting exactly
+// one of the pair is a configuration error, since a cert without its key (or
+// vice versa) cannot serve TLS.
+func ResolveTLSMaterial(dir, userCert, userKey string) (TLSMaterial, error) {
+	switch {
+	case userCert != "" && userKey != "":
+		if _, err := os.Stat(userCert); err != nil {
+			return TLSMaterial{}, fmt.Errorf("tls_cert %s: %w", userCert, err)
+		}
+		if _, err := os.Stat(userKey); err != nil {
+			return TLSMaterial{}, fmt.Errorf("tls_key %s: %w", userKey, err)
+		}
+		return TLSMaterial{CertPath: userCert, KeyPath: userKey, SelfSigned: false}, nil
+	case userCert != "" || userKey != "":
+		return TLSMaterial{}, fmt.Errorf(
+			"tls_cert and tls_key must be set together (got tls_cert=%q, tls_key=%q)", userCert, userKey)
+	default:
+		certPath := filepath.Join(dir, daemonTLSCertFileName)
+		keyPath := filepath.Join(dir, daemonTLSKeyFileName)
+		if err := ensureSelfSignedCert(certPath, keyPath); err != nil {
+			return TLSMaterial{}, err
+		}
+		return TLSMaterial{CertPath: certPath, KeyPath: keyPath, SelfSigned: true}, nil
+	}
+}
+
+// ensureSelfSignedCert loads the self-signed cert/key at the given paths,
+// generating and persisting a fresh pair only when either file is missing. It
+// is idempotent — once generated the pair is reused, so the pinned
+// fingerprint stays stable across daemon restarts.
+func ensureSelfSignedCert(certPath, keyPath string) error {
+	_, certErr := os.Stat(certPath)
+	_, keyErr := os.Stat(keyPath)
+	if certErr == nil && keyErr == nil {
+		return nil
+	}
+	if certErr != nil && !os.IsNotExist(certErr) {
+		return fmt.Errorf("stat tls cert: %w", certErr)
+	}
+	if keyErr != nil && !os.IsNotExist(keyErr) {
+		return fmt.Errorf("stat tls key: %w", keyErr)
+	}
+	return generateSelfSignedCert(certPath, keyPath)
+}
+
+// generateSelfSignedCert writes a fresh self-signed ECDSA P-256 cert/key pair
+// to the given paths. SANs cover loopback (v4 + v6) and localhost plus the
+// machine hostname, so a same-host or tunneled connection matches even before
+// the pin makes SAN validation moot. The key is written 0600; the cert 0644.
+func generateSelfSignedCert(certPath, keyPath string) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate tls key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return fmt.Errorf("generate tls serial: %w", err)
+	}
+
+	dnsNames := []string{"localhost"}
+	if host, hErr := os.Hostname(); hErr == nil && host != "" && host != "localhost" {
+		dnsNames = append(dnsNames, host)
+	}
+
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "agent-factory daemon"},
+		NotBefore:             now.Add(-time.Hour), // tolerate small clock skew
+		NotAfter:              now.Add(selfSignedValidity),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              dnsNames,
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return fmt.Errorf("create tls cert: %w", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return fmt.Errorf("marshal tls key: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(certPath), 0o700); err != nil {
+		return fmt.Errorf("create tls directory: %w", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(certPath, certPEM, 0o644); err != nil {
+		return fmt.Errorf("write tls cert: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		return fmt.Errorf("write tls key: %w", err)
+	}
+	// Force 0600 on the key regardless of umask (WriteFile masks the mode).
+	if err := os.Chmod(keyPath, 0o600); err != nil {
+		return fmt.Errorf("chmod tls key: %w", err)
+	}
+	return nil
+}
+
+// CertFingerprint returns the SHA-256 fingerprint of the leaf certificate in
+// the PEM file at certPath, formatted "sha256:<lowercase-hex>". This is the
+// value the client TOFU-pins (§1.2) and that `af token show` prints. It is
+// computed over the certificate DER, so it is stable as long as the cert file
+// is (self-signed certs are generated once and reused).
+func CertFingerprint(certPath string) (string, error) {
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		return "", err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return "", fmt.Errorf("no PEM certificate found in %s", certPath)
+	}
+	sum := sha256.Sum256(block.Bytes)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/daemon/tlsmaterial_test.go
+++ b/daemon/tlsmaterial_test.go
@@ -1,0 +1,173 @@
+package daemon
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// parseCertFile decodes and parses the leaf certificate from a PEM file.
+func parseCertFile(t *testing.T, path string) *x509.Certificate {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		t.Fatal("no PEM block in cert file")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return cert
+}
+
+func TestResolveTLSMaterialSelfSignedValid(t *testing.T) {
+	dir := t.TempDir()
+
+	material, err := ResolveTLSMaterial(dir, "", "")
+	if err != nil {
+		t.Fatalf("ResolveTLSMaterial: %v", err)
+	}
+	if !material.SelfSigned {
+		t.Fatal("expected SelfSigned=true for the zero-config path")
+	}
+	if material.CertPath != filepath.Join(dir, daemonTLSCertFileName) {
+		t.Fatalf("unexpected cert path %q", material.CertPath)
+	}
+
+	// The generated pair loads as a usable TLS keypair.
+	if _, err := tls.LoadX509KeyPair(material.CertPath, material.KeyPath); err != nil {
+		t.Fatalf("generated cert/key is not a valid keypair: %v", err)
+	}
+
+	cert := parseCertFile(t, material.CertPath)
+
+	// SANs cover loopback + localhost.
+	hasLocalhost := false
+	for _, name := range cert.DNSNames {
+		if name == "localhost" {
+			hasLocalhost = true
+		}
+	}
+	if !hasLocalhost {
+		t.Fatalf("cert DNSNames %v missing localhost", cert.DNSNames)
+	}
+	hasLoopback := false
+	for _, ip := range cert.IPAddresses {
+		if ip.Equal(net.IPv4(127, 0, 0, 1)) {
+			hasLoopback = true
+		}
+	}
+	if !hasLoopback {
+		t.Fatalf("cert IPAddresses %v missing 127.0.0.1", cert.IPAddresses)
+	}
+
+	// Long-lived validity window (pinned, not CA-chained).
+	if remaining := time.Until(cert.NotAfter); remaining < 365*24*time.Hour {
+		t.Fatalf("cert expires too soon: NotAfter in %v", remaining)
+	}
+
+	// The key file is 0600; the public cert is not required to be.
+	info, err := os.Stat(material.KeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("key file perms = %o, want 0600", perm)
+	}
+}
+
+func TestResolveTLSMaterialFingerprintStable(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := ResolveTLSMaterial(dir, "", "")
+	if err != nil {
+		t.Fatalf("ResolveTLSMaterial (first): %v", err)
+	}
+	fp1, err := CertFingerprint(first.CertPath)
+	if err != nil {
+		t.Fatalf("CertFingerprint (first): %v", err)
+	}
+
+	// A second resolve must reuse the persisted cert (not regenerate), so the
+	// pinned fingerprint is stable across daemon restarts.
+	second, err := ResolveTLSMaterial(dir, "", "")
+	if err != nil {
+		t.Fatalf("ResolveTLSMaterial (second): %v", err)
+	}
+	fp2, err := CertFingerprint(second.CertPath)
+	if err != nil {
+		t.Fatalf("CertFingerprint (second): %v", err)
+	}
+	if fp1 != fp2 {
+		t.Fatalf("fingerprint changed across resolves: %q != %q", fp1, fp2)
+	}
+	if !strings.HasPrefix(fp1, "sha256:") || len(fp1) != len("sha256:")+64 {
+		t.Fatalf("unexpected fingerprint format: %q", fp1)
+	}
+}
+
+func TestResolveTLSMaterialUserOverride(t *testing.T) {
+	dir := t.TempDir()
+
+	// A self-signed pair we can reuse as a stand-in "user-provided" cert.
+	certPath := filepath.Join(dir, "user.crt")
+	keyPath := filepath.Join(dir, "user.key")
+	if err := generateSelfSignedCert(certPath, keyPath); err != nil {
+		t.Fatalf("generate user cert: %v", err)
+	}
+
+	material, err := ResolveTLSMaterial(dir, certPath, keyPath)
+	if err != nil {
+		t.Fatalf("ResolveTLSMaterial override: %v", err)
+	}
+	if material.SelfSigned {
+		t.Fatal("expected SelfSigned=false when a user cert is provided")
+	}
+	if material.CertPath != certPath || material.KeyPath != keyPath {
+		t.Fatalf("override not honored: %+v", material)
+	}
+
+	// The override must be used verbatim: the self-signed default file must
+	// not have been generated.
+	if _, err := os.Stat(filepath.Join(dir, daemonTLSCertFileName)); !os.IsNotExist(err) {
+		t.Fatalf("self-signed cert was generated despite an override (err=%v)", err)
+	}
+}
+
+func TestResolveTLSMaterialOverrideErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	// Only one of the pair set: a configuration error.
+	if _, err := ResolveTLSMaterial(dir, "/x/cert.pem", ""); err == nil {
+		t.Fatal("want error when only tls_cert is set")
+	}
+	if _, err := ResolveTLSMaterial(dir, "", "/x/key.pem"); err == nil {
+		t.Fatal("want error when only tls_key is set")
+	}
+
+	// Both set but the files do not exist.
+	if _, err := ResolveTLSMaterial(dir, "/x/cert.pem", "/x/key.pem"); err == nil {
+		t.Fatal("want error when the override files do not exist")
+	}
+}
+
+func TestCertFingerprintNonCert(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notacert.pem")
+	if err := os.WriteFile(path, []byte("not pem"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CertFingerprint(path); err == nil {
+		t.Fatal("want error fingerprinting a non-certificate file")
+	}
+}

--- a/daemon/token.go
+++ b/daemon/token.go
@@ -1,0 +1,133 @@
+package daemon
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// The bearer-token material for the daemon's TCP/TLS surface (#1592 Phase 3
+// PR1, §1.3). Sachin locked the auth model to a single bearer token = full
+// access, single-owner. This file only produces and compares the material —
+// it is DARK: nothing here binds a socket or enforces a token. Phase 3 PR2
+// fills in the withAuth compare against this token; PR3 lights up the TCP
+// listener. The unix control socket stays unauthenticated (filesystem 0600
+// perms are the local auth, #1029) and never reads this token.
+
+const (
+	// daemonTokenFileName is the bearer token file in the af home. 0600 —
+	// leaking it grants full daemon access under the locked auth model.
+	daemonTokenFileName = "daemon-token"
+	// tokenRandomBytes is the entropy drawn from crypto/rand per token: 256
+	// bits, base64url-encoded to a 43-char printable string.
+	tokenRandomBytes = 32
+)
+
+// TokenPath returns <af home>/daemon-token, the file the bearer token is
+// persisted in. It mirrors DaemonSocketPath: the af home is resolved through
+// config.GetConfigDir so AGENT_FACTORY_HOME is honored uniformly.
+func TokenPath() (string, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, daemonTokenFileName), nil
+}
+
+// generateToken returns a fresh bearer token: 256 bits from crypto/rand,
+// base64url-encoded without padding (URL/header-safe, no '=' to escape).
+func generateToken() (string, error) {
+	buf := make([]byte, tokenRandomBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// writeToken persists tok to path with 0600 permissions, creating the parent
+// af home directory if needed. It writes then chmods so the mode is exactly
+// 0600 regardless of the process umask.
+func writeToken(path, tok string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create token directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(tok+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write token: %w", err)
+	}
+	// WriteFile only applies the mode on create and masks it by the umask;
+	// force 0600 so a pre-existing file with looser perms is tightened too.
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("chmod token: %w", err)
+	}
+	return nil
+}
+
+// LoadToken reads and returns the persisted bearer token at path. It returns
+// an error when the file is absent or unreadable — callers that must fail
+// closed (the auth gate) treat any error as "deny". The stored value is
+// trimmed of the trailing newline writeToken adds.
+func LoadToken(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	tok := strings.TrimSpace(string(data))
+	if tok == "" {
+		return "", fmt.Errorf("token file %s is empty", path)
+	}
+	return tok, nil
+}
+
+// EnsureToken returns the bearer token at path, generating and persisting one
+// (0600) if the file does not yet exist. It is idempotent: a second call
+// returns the same token. This is the generate-if-absent entry point behind
+// `af token show`, so the token exists before the TCP listener is ever
+// enabled.
+func EnsureToken(path string) (string, error) {
+	if tok, err := LoadToken(path); err == nil {
+		return tok, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	tok, err := generateToken()
+	if err != nil {
+		return "", err
+	}
+	if err := writeToken(path, tok); err != nil {
+		return "", err
+	}
+	return tok, nil
+}
+
+// RotateToken generates a fresh bearer token, persists it (0600) over any
+// existing one, and returns it. Because the auth gate re-reads the token file
+// per auth event (§1.3), rotation takes effect for new connections
+// immediately without a daemon RPC; existing streams keep running until they
+// reconnect.
+func RotateToken(path string) (string, error) {
+	tok, err := generateToken()
+	if err != nil {
+		return "", err
+	}
+	if err := writeToken(path, tok); err != nil {
+		return "", err
+	}
+	return tok, nil
+}
+
+// ConstantTimeEqual reports whether got equals want without leaking, through
+// timing, how many leading bytes matched. It is the compare the withAuth gate
+// uses in PR2. An empty want denies (fail closed): a daemon with no token must
+// never accept the empty string as a valid credential.
+func ConstantTimeEqual(got, want string) bool {
+	if want == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}

--- a/daemon/token_test.go
+++ b/daemon/token_test.go
@@ -1,0 +1,145 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateTokenUniqueAndStrong(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		tok, err := generateToken()
+		if err != nil {
+			t.Fatalf("generateToken: %v", err)
+		}
+		// base64url of 32 bytes, no padding => 43 chars.
+		if len(tok) != 43 {
+			t.Fatalf("token length = %d, want 43 (%q)", len(tok), tok)
+		}
+		if seen[tok] {
+			t.Fatalf("duplicate token generated: %q", tok)
+		}
+		seen[tok] = true
+	}
+}
+
+func TestEnsureTokenGeneratesAndPersists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon-token")
+
+	tok, err := EnsureToken(path)
+	if err != nil {
+		t.Fatalf("EnsureToken: %v", err)
+	}
+	if tok == "" {
+		t.Fatal("EnsureToken returned an empty token")
+	}
+
+	// The file must exist and be 0600.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("token file perms = %o, want 0600", perm)
+	}
+
+	// Round-trip: LoadToken returns the same value.
+	loaded, err := LoadToken(path)
+	if err != nil {
+		t.Fatalf("LoadToken: %v", err)
+	}
+	if loaded != tok {
+		t.Fatalf("LoadToken = %q, want %q", loaded, tok)
+	}
+}
+
+func TestEnsureTokenIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon-token")
+
+	first, err := EnsureToken(path)
+	if err != nil {
+		t.Fatalf("EnsureToken (first): %v", err)
+	}
+	second, err := EnsureToken(path)
+	if err != nil {
+		t.Fatalf("EnsureToken (second): %v", err)
+	}
+	if first != second {
+		t.Fatalf("EnsureToken not idempotent: %q != %q", first, second)
+	}
+}
+
+func TestLoadTokenAbsentAndEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	// Absent file: an error the auth gate treats as fail-closed.
+	if _, err := LoadToken(filepath.Join(dir, "nope")); err == nil {
+		t.Fatal("LoadToken on an absent file: want error, got nil")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("LoadToken absent: want IsNotExist, got %v", err)
+	}
+
+	// Empty/whitespace file: rejected so an empty token never authenticates.
+	empty := filepath.Join(dir, "empty")
+	if err := os.WriteFile(empty, []byte("   \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadToken(empty); err == nil {
+		t.Fatal("LoadToken on an empty file: want error, got nil")
+	}
+}
+
+func TestRotateTokenChangesValueAndPersists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon-token")
+
+	original, err := EnsureToken(path)
+	if err != nil {
+		t.Fatalf("EnsureToken: %v", err)
+	}
+	rotated, err := RotateToken(path)
+	if err != nil {
+		t.Fatalf("RotateToken: %v", err)
+	}
+	if rotated == original {
+		t.Fatal("RotateToken produced the same token")
+	}
+
+	// The new token is the one now persisted, and perms stay 0600.
+	loaded, err := LoadToken(path)
+	if err != nil {
+		t.Fatalf("LoadToken after rotate: %v", err)
+	}
+	if loaded != rotated {
+		t.Fatalf("persisted token = %q, want rotated %q", loaded, rotated)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("rotated token file perms = %o, want 0600", perm)
+	}
+}
+
+func TestConstantTimeEqual(t *testing.T) {
+	cases := []struct {
+		name      string
+		got, want string
+		expect    bool
+	}{
+		{"equal", "s3cr3t", "s3cr3t", true},
+		{"different", "s3cr3t", "guess", false},
+		{"prefix-of", "s3c", "s3cr3t", false},
+		{"empty-want-denies", "s3cr3t", "", false},
+		{"empty-want-empty-got-denies", "", "", false},
+		{"empty-got", "", "s3cr3t", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ConstantTimeEqual(tc.got, tc.want); got != tc.expect {
+				t.Fatalf("ConstantTimeEqual(%q, %q) = %v, want %v", tc.got, tc.want, got, tc.expect)
+			}
+		})
+	}
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -53,6 +53,9 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 - [`af tasks remove`](#af-tasks-remove) — Remove a task
 - [`af tasks trigger`](#af-tasks-trigger) — Trigger a task to run immediately
 - [`af tasks update`](#af-tasks-update) — Update a task's properties
+- [`af token`](#af-token) — Manage the daemon's bearer token for the direct-TCP API
+- [`af token rotate`](#af-token-rotate) — Replace the bearer token with a fresh one and print it
+- [`af token show`](#af-token-show) — Print the bearer token and TLS fingerprint (generating them if absent)
 - [`af upgrade`](#af-upgrade) — Upgrade agent-factory to the latest release on the configured channel
 - [`af version`](#af-version) — Print the version number of agent-factory
 
@@ -77,6 +80,7 @@ af [flags]
 - [`af reset`](#af-reset) — Reset all stored instances
 - [`af sessions`](#af-sessions) — Manage sessions
 - [`af tasks`](#af-tasks) — Manage tasks
+- [`af token`](#af-token) — Manage the daemon's bearer token for the direct-TCP API
 - [`af upgrade`](#af-upgrade) — Upgrade agent-factory to the latest release on the configured channel
 - [`af version`](#af-version) — Print the version number of agent-factory
 
@@ -1144,6 +1148,70 @@ af tasks update <id> [flags]
 |------|------|-------------|
 | `--json` |  | Wrap output in the {data,error} JSON envelope (default: bare payload) |
 | `--repo` | `string` | Path to git repository |
+
+## af token
+
+Manage the daemon's bearer token for the direct-TCP API
+
+Manage the bearer token that authenticates the daemon's direct-TCP/TLS API.
+
+The token grants full access under the single-owner auth model. It is only used
+by the TCP listener (enabled with the listen_addr config key); the local unix
+socket stays unauthenticated (its 0600 filesystem perms are the local auth).
+The token and the self-signed TLS cert are stored in the af home
+(~/.agent-factory) with 0600 permissions on the secret files.
+
+```
+af token
+```
+
+**Subcommands**
+
+- [`af token rotate`](#af-token-rotate) — Replace the bearer token with a fresh one and print it
+- [`af token show`](#af-token-show) — Print the bearer token and TLS fingerprint (generating them if absent)
+
+## af token rotate
+
+Replace the bearer token with a fresh one and print it
+
+Generate a new bearer token, persist it (overwriting the old one), and print it.
+
+Rotation takes effect for new connections immediately — the auth gate re-reads
+the token file per request — while any in-flight streams keep running until they
+reconnect. The TLS fingerprint is unaffected (it depends on the certificate, not
+the token).
+
+```
+af token rotate [flags]
+```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--json` |  | Emit the result as JSON wrapped in the {data,error} envelope |
+
+## af token show
+
+Print the bearer token and TLS fingerprint (generating them if absent)
+
+Print the daemon's bearer token and its TLS certificate fingerprint.
+
+Both are generated on first access if they do not yet exist, so this is safe to
+run before the TCP listener is ever enabled. The fingerprint is the SHA-256 a
+remote client pins (TOFU) when the daemon uses its self-signed certificate; when
+a CA-issued certificate is configured via tls_cert/tls_key it is that
+certificate's fingerprint (clients verify it against system roots instead).
+
+```
+af token show [flags]
+```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--json` |  | Emit the result as JSON wrapped in the {data,error} envelope |
 
 ## af upgrade
 


### PR DESCRIPTION
## Phase 3 PR1 — auth material (DARK)

First PR of #1592 Phase 3 (TCP + bearer-token auth). This lays the **auth
material** the later PRs enforce. It is **DARK**: no listener binds, no
middleware enforces, and no existing served byte changes. `withAuth` stays a
no-op and the local unix socket is untouched (its 0600 filesystem perms remain
the local auth, #1029). Auth is only a TCP concept — none of this touches local
flows. Material files are created **only on demand**.

### What's generated/stored & where

All under the af home (`~/.agent-factory`, honoring `AGENT_FACTORY_HOME`):

| File | Perms | Contents |
|---|---|---|
| `daemon-token` | **0600** | Bearer token: 256 bits from `crypto/rand`, base64url (43 chars). Auto-generated on first access. |
| `daemon-tls.key` | **0600** | Self-signed ECDSA P-256 private key (PKCS#8 PEM). |
| `daemon-tls.crt` | 0644 | Self-signed cert (public). SANs: `localhost` + hostname + loopback v4/v6. 10-year validity (pinned, not CA-chained). |

- **Token library** (`daemon/token.go`): generate / load / persist / rotate,
  plus `ConstantTimeEqual` (`crypto/subtle`) for the Phase-3 PR2 gate.
  Fail-closed — an empty or absent token authenticates nothing.
- **TLS material** (`daemon/tlsmaterial.go`): self-signed default with
  load-or-generate persistence (so the pinned fingerprint is stable across
  restarts); user `tls_cert`/`tls_key` PEM override (used verbatim, both must
  be set together); SHA-256 cert fingerprint helper (`sha256:<hex>`) the client
  will TOFU-pin (§1.2).

### `af token` UX

```
af token show      # print token + TLS fingerprint (generates if absent, idempotent)
af token rotate    # replace the token, print the new one
```

Both honor `--json` (the shared `{data,error}` envelope, like `af config`):

```json
{ "data": { "token": "…", "tls_fingerprint": "sha256:…" }, "error": null }
```

`rotate` re-reads live for new connections once the listener exists (the gate
will re-read the file per auth event); the TLS fingerprint is unaffected by
rotation.

### Config keys (declared now, off by default)

`listen_addr`, `tls_cert`, `tls_key`, `cors_allowed_origins` are added to the
Config struct in one reviewable place. Defaults are empty/off, so nothing
changes. All four are **global-only**: a cloned repo is rejected if it tries to
set them (a repo must never open a port, swap the server cert, or widen CORS).
They are consumed in PR2/PR3.

### DARK — nothing enforces this yet

- `withAuth` is unchanged (still extracts-and-discards).
- No TCP listener; no wire/protocol change; no new endpoints.
- The only new user-visible surface is the `af token` command.

### Gates

- `gofmt -l .` clean, `golangci-lint run --fast` clean, `go build ./...` ok
- `deadcode -test ./...` clean, `scripts/lint-file-length.sh` passes
- `make test-container` — full suite green
- `make tui-driver-selftest` — **25/25** (unaffected surface)
- Unit tests: cert round-trip (valid keypair, SANs, expiry, **fingerprint
  stable across resolves**, override-picked-over-self-gen, mismatched-pair
  error); token gen uniqueness + 0600 + round-trip + rotate-changes-value +
  fail-closed `ConstantTimeEqual` truth table; `af token show/rotate` behavior +
  generate-if-absent idempotence + JSON envelope
- Exercised the real `af token show/--json/rotate` CLI end-to-end; verified file
  perms (0600 on token + key)

Part of #1592 (Phase 3 of 5). Do not squash-merge ahead of the plan sequence;
PR2 fills in the `withAuth` compare, PR3 lights up the TLS TCP listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)