### PR TITLE
fix(app): reject archived sessions in previewCommitError (#1633)

### DIFF
--- a/app/pane_preview.go
+++ b/app/pane_preview.go
@@ -235,6 +235,12 @@ func previewCommitError(inst *session.Instance) error {
 		return fmt.Errorf("cannot commit preview for %q: session no longer running", inst.Title)
 	case session.LiveLost:
 		return fmt.Errorf("cannot commit preview for %q: session was lost", inst.Title)
+	case session.LiveArchived:
+		// An archived session has no live tmux binding, and pruneDeadPanes closes
+		// any pane bound to one on the next tick — so committing a split-pane
+		// preview here would flash a pane that immediately vanishes. Reject it like
+		// Dead/Lost, matching interactiveGuard's archived case (#1633).
+		return fmt.Errorf("cannot commit preview for %q: session is archived", inst.Title)
 	}
 	return nil
 }

--- a/app/pane_preview_archive_test.go
+++ b/app/pane_preview_archive_test.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPreviewCommitErrorRejectsArchived pins #1633: previewCommitError gates
+// whether a split-pane preview can be committed (the `S` key) and whether the
+// footer advertises split-pane as available. An archived session has no live
+// tmux binding and pruneDeadPanes closes any pane bound to one, so committing a
+// preview for it would flash a pane that immediately vanishes. It must be
+// rejected exactly like Dead and Lost — the case that was originally omitted.
+func TestPreviewCommitErrorRejectsArchived(t *testing.T) {
+	inst := instanceWithFakeBackend(t, "archived-target")
+	inst.SetArchived()
+	require.Equal(t, session.LiveArchived, inst.GetLiveness())
+
+	require.Error(t, previewCommitError(inst),
+		"previewCommitError must reject an archived session so split-pane cannot commit a pane that pruneDeadPanes will immediately close")
+}
+
+// TestPreviewCommitErrorAcceptsRunning is the negative control: a live Running
+// session (fake backend, no in-flight op) is a valid commit target, so the
+// archived guard must not over-reject.
+func TestPreviewCommitErrorAcceptsRunning(t *testing.T) {
+	inst := instanceWithFakeBackend(t, "live-target")
+	require.Equal(t, session.LiveRunning, inst.GetLiveness())
+
+	require.NoError(t, previewCommitError(inst),
+		"a live Running session is a valid split-pane commit target")
+}


### PR DESCRIPTION
## Summary
Fixes #1633. `previewCommitError` gates whether a split-pane preview can be committed (the `S` key) and whether the footer advertises split-pane as available. It rejected `LiveDead`, `LiveLost`, and in-flight targets but **omitted `LiveArchived`** — the liveness value added in the Status→Liveness refactor.

Because it returned `nil` for an archived instance, a preview committed for a session archived mid-preview created a pane that `pruneDeadPanes` immediately closes on the next tick, so the `S` key appeared to work but the pane vanished.

## Change
- `app/pane_preview.go`: add the `session.LiveArchived` case, matching `interactiveGuard`'s archived guard and `pruneDeadPanes`'s treatment of archived panes.

## Test
- `app/pane_preview_archive_test.go`: `previewCommitError` must error for an archived session and still accept a live Running one. Verified it **fails without the fix** and passes with it.

## Gates
gofmt clean · `go build ./...` OK · `golangci-lint --fast` clean · `deadcode -test ./...` clean · `make test-container GOTESTARGS=./app/...` green · `make tui-driver-selftest` 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)