### PR TITLE
fix(daemon): honor DeferWhileAttached in both wait-then-send delivery paths (#1638)

### DIFF
--- a/daemon/defer_attached_wait_paths_test.go
+++ b/daemon/defer_attached_wait_paths_test.go
@@ -1,0 +1,147 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestDeliverPrompt_ReemergingRootDefersWhileAttached pins the re-emerging-root
+// half of #1638. The re-emerging-root delivery path (deliverToReemergingRoot)
+// waits for a momentarily-absent root to be re-materialized, then sends. A TUI
+// can attach to root during that wait — PauseStatusPoll leases by (repoID,
+// title) even before the session exists — so the path must re-check the defer
+// lease before sending, exactly like the fast "exists" path. Before the fix it
+// sent unconditionally, pasting an automated prompt into the attached pane.
+func TestDeliverPrompt_ReemergingRootDefersWhileAttached(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	rec := installRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	// The repo is opted into a root agent, so the ensure loop owns "root" and a
+	// momentarily-absent root routes through deliverToReemergingRoot.
+	manager, err := NewManager(rootTestConfig(repoPath, config.RootAgentConfig{}))
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// A TUI attaches full-screen to root before it exists — the pause-poll lease
+	// is keyed by (repoID, title) and needs no live session.
+	manager.PauseStatusPoll(repo.ID, session.RootSessionTitle)
+
+	// A short while into the delivery's wait, the ensure loop re-materializes root
+	// in place. The delivery must then DEFER (attached), not send.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		if _, err := manager.CreateSession(CreateSessionRequest{
+			Title:         session.RootSessionTitle,
+			RepoPath:      repoPath,
+			Program:       "claude",
+			InPlace:       true,
+			allowReserved: true,
+		}); err != nil {
+			t.Errorf("background root (re-)create: %v", err)
+		}
+	}()
+
+	status, err := manager.DeliverPrompt(DeliverPromptRequest{
+		Title:              session.RootSessionTitle,
+		RepoPath:           repoPath,
+		Program:            "claude",
+		Prompt:             "monitor-event",
+		DeferWhileAttached: true,
+	})
+	if err != nil {
+		t.Fatalf("a deferred re-emerging-root delivery must not error: %v", err)
+	}
+	if status != StatusDeferredAttached {
+		t.Fatalf("status = %q, want %q — the re-emerging-root path must honor DeferWhileAttached", status, StatusDeferredAttached)
+	}
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Fatalf("a deferred delivery must NOT paste into the attached root pane, got %v", got)
+	}
+}
+
+// TestDeliverPrompt_ConcurrentCreateDefersWhileAttached pins the
+// concurrent-create half of #1638. When an outside creator reserves the title
+// between DeliverPrompt's existence check and its own reserveCreate, delivery
+// waits for the session to materialize (waitForTargetSession) then sends. A TUI
+// can attach during that wait, so the retry path must re-check the defer lease
+// before sending. Before the fix it sent unconditionally.
+func TestDeliverPrompt_ConcurrentCreateDefersWhileAttached(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	rec := installRecordingBackend(t)
+	repoPath := setupControlRepo(t)
+	repo, err := config.RepoFromPath(repoPath)
+	if err != nil {
+		t.Fatalf("RepoFromPath: %v", err)
+	}
+	manager, err := NewManager(config.DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	key := daemonInstanceKey(repo.ID, "captain")
+
+	// An outside creator has RESERVED the title but not yet finished creating the
+	// instance: DeliverPrompt's existence check sees no instance (so it is not the
+	// fast "exists" path), reserveCreate then rejects the duplicate as a retryable
+	// concurrent-create, and delivery drops into waitForTargetSession.
+	manager.mu.Lock()
+	manager.reservedTitles[key] = struct{}{}
+	manager.mu.Unlock()
+
+	// A TUI attaches BEFORE the session exists.
+	manager.PauseStatusPoll(repo.ID, "captain")
+
+	var wg sync.WaitGroup
+	var status string
+	var deliverErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		status, deliverErr = manager.DeliverPrompt(DeliverPromptRequest{
+			Title:              "captain",
+			RepoPath:           repoPath,
+			Program:            "claude",
+			Prompt:             "scheduled-event",
+			DeferWhileAttached: true,
+		})
+	}()
+
+	// Give the delivery goroutine time to enter waitForTargetSession, then let the
+	// outside creator "finish": register the instance (recording backend) and drop
+	// the reservation, so waitForTargetSession observes the session and returns.
+	time.Sleep(100 * time.Millisecond)
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "captain", Path: repoPath, Program: "claude"})
+	if err != nil {
+		t.Fatalf("NewInstance: %v", err)
+	}
+	inst.SetBackend(recordingBackend{readyFakeBackend{session.NewFakeBackend()}, rec})
+	inst.SetStartedForTest(true)
+	inst.SetStatusForTest(session.Running)
+	seedDiskInstance(t, repo.ID, "captain", repoPath)
+	manager.mu.Lock()
+	manager.instances[key] = inst
+	delete(manager.reservedTitles, key)
+	manager.mu.Unlock()
+
+	wg.Wait()
+
+	if deliverErr != nil {
+		t.Fatalf("a deferred delivery must not error: %v", deliverErr)
+	}
+	if status != StatusDeferredAttached {
+		t.Fatalf("status = %q, want %q — the concurrent-create retry must honor DeferWhileAttached", status, StatusDeferredAttached)
+	}
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Fatalf("a deferred delivery must NOT paste into the attached session, got %v", got)
+	}
+}

--- a/daemon/delivery.go
+++ b/daemon/delivery.go
@@ -42,6 +42,19 @@ const StatusDeferredAttached = "deferred: target attached"
 // durable re-queue/retry without tripping the delivery-failure alarm (#1238).
 var errTargetBusy = errors.New("target session is attached; delivery deferred until detach")
 
+// deferWhileAttached reports whether an automated delivery must be held because a
+// TUI is attached full-screen to the target (#1586). Every SendPrompt delivery
+// path routes through this: the fast "exists" path AND both wait-then-send paths
+// (the concurrent-create retry here and the re-emerging-root path in
+// rootagent.go). A TUI can attach during either wait — PauseStatusPoll leases by
+// (repoID, title) even before the session exists — so all three must re-check the
+// lease right before sending, or an automated prompt pastes into the pane the
+// user is typing in (#1638). Only automated deliveries set DeferWhileAttached; a
+// manual send-prompt is an explicit user action and still lands immediately.
+func (m *Manager) deferWhileAttached(repoID string, req DeliverPromptRequest) bool {
+	return req.DeferWhileAttached && m.isPollPaused(repoID, req.Title)
+}
+
 // DeliverPrompt delivers a prompt to a target session, auto-creating that
 // session when it does not exist. The whole create-or-send decision runs under
 // a per-(repo, title) lock, so concurrent deliveries to the same shared target
@@ -84,7 +97,7 @@ func (m *Manager) DeliverPrompt(req DeliverPromptRequest) (string, error) {
 		// status and re-fires next tick) rather than corrupting live input. Only
 		// automated deliveries set DeferWhileAttached — a manual send-prompt is an
 		// explicit user action and still lands immediately.
-		if req.DeferWhileAttached && m.isPollPaused(repo.ID, req.Title) {
+		if m.deferWhileAttached(repo.ID, req) {
 			return StatusDeferredAttached, nil
 		}
 		if err := m.SendPrompt(SendPromptRequest{Title: req.Title, RepoID: repo.ID, Prompt: req.Prompt}); err != nil {
@@ -121,6 +134,12 @@ func (m *Manager) DeliverPrompt(req DeliverPromptRequest) (string, error) {
 		if isConcurrentCreateErr(err) {
 			if werr := m.waitForTargetSession(repo.ID, req.Title); werr != nil {
 				return "", werr
+			}
+			// A TUI can attach during the wait above, so re-check the defer lease
+			// before sending — otherwise this path pastes into an attached pane the
+			// "exists" path would have deferred (#1638).
+			if m.deferWhileAttached(repo.ID, req) {
+				return StatusDeferredAttached, nil
 			}
 			if serr := m.SendPrompt(SendPromptRequest{Title: req.Title, RepoID: repo.ID, Prompt: req.Prompt}); serr != nil {
 				return "", serr

--- a/daemon/rootagent.go
+++ b/daemon/rootagent.go
@@ -206,6 +206,12 @@ func (m *Manager) deliverToReemergingRoot(repo *config.RepoContext, req DeliverP
 	if err := m.waitForTargetSession(repo.ID, req.Title); err != nil {
 		return "", true, fmt.Errorf("root agent for %q is being recreated (tmux momentarily absent); event not delivered this attempt: %w", repo.Root, err)
 	}
+	// A TUI can attach to root during the wait above, so re-check the defer lease
+	// before sending — otherwise this path pastes into an attached pane the
+	// "exists" path would have deferred (#1638).
+	if m.deferWhileAttached(repo.ID, req) {
+		return StatusDeferredAttached, true, nil
+	}
 	if err := m.SendPrompt(SendPromptRequest{Title: req.Title, RepoID: repo.ID, Prompt: req.Prompt}); err != nil {
 		return "", true, err
 	}


### PR DESCRIPTION
## Summary
Fixes #1638. `DeliverPrompt` has three paths that call `SendPrompt`: the fast "exists" path and two **wait-then-send** paths — the concurrent-create retry (`delivery.go`) and the re-emerging-root path (`rootagent.go`). Only the "exists" path re-checked the `DeferWhileAttached` lease before sending. The two wait-then-send paths waited for the target session to appear, then sent **unconditionally**.

A TUI can attach during that wait — `PauseStatusPoll` leases by `(repoID, title)` even before the session exists — so an automated cron/watch prompt could paste into and submit a user's half-typed input despite `DeferWhileAttached=true`.

## Change
- Extract the guard into `Manager.deferWhileAttached(repoID, req)` and route **all three** paths through it, so no delivery path can send into an attached session and a future fourth path can't silently reintroduce the gap.
- `delivery.go` (exists path + concurrent-create retry) and `rootagent.go` (re-emerging root) now re-check the lease immediately before `SendPrompt`.

## Tests
- `daemon/defer_attached_wait_paths_test.go`: two regression tests, one per wait-then-send path. Each attaches a TUI **during** the wait and asserts the delivery defers (status `deferred: target attached`, nothing pasted). Both verified to **fail without the guards** and pass with them.

## Gates
gofmt clean · `go build ./...` OK · `golangci-lint --fast` clean · `deadcode -test ./...` clean · `make test-container GOTESTARGS=./daemon/...` green (full daemon package). Daemon-only change with no TUI surface; the boot/attach flow is unchanged (`tui-driver-selftest` 25/25 verified on the sibling #1633 branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)