### PR TITLE
feat(daemon): withAuth bearer-token enforcement + CORS allow-list, per-listener gate (#1592 Phase 3 PR2)

### DIFF
--- a/daemon/httpauth.go
+++ b/daemon/httpauth.go
@@ -1,49 +1,105 @@
 package daemon
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/sachiniyer/agent-factory/agentproto"
 )
 
-// The auth + CORS seam for the daemon HTTP/WS surface (#1592 Phase 2 PR5, §4.4).
-// It EXISTS now and enforces NOTHING: over the unix socket the peer is trusted
-// (filesystem perms are the auth, #1029). Its whole purpose is shape — Phase 3
-// adds a TCP+TLS transport with a bearer token, and this is where the
-// constant-time token compare and the real CORS policy drop in WITHOUT reshaping
-// a single route or handler. Every route (the REST mirror and the new WS routes)
-// is served through withAuth, and the WS handshake rides the same path, so the
-// token seam already covers both the Authorization header and the browser
-// ?access_token= fallback.
+// The auth + CORS gate for the daemon HTTP/WS surface (#1592 Phase 2 PR5 seam,
+// filled by Phase 3 PR2, §1.4/§1.5). Every route (the REST mirror and the WS
+// routes) is served through withAuth, and the WS handshake rides the same path,
+// so one gate covers both — the Authorization header and the browser
+// ?access_token= fallback — with no route-specific auth logic.
+//
+// Enforcement is PER-LISTENER. The local unix socket is trusted transport
+// (filesystem 0600 perms are the auth, #1029): it passes a nil gate and every
+// request is authorized, token ignored. The TCP+TLS listener (PR3) passes a
+// real gate and requires a valid bearer token. Because only the unix listener
+// exists today, this whole enforcement path is DARK — the gate is always nil at
+// runtime and nothing is ever rejected — until PR3 binds TCP with gate != nil.
 
-// withAuth wraps the daemon mux with the auth + CORS seam. Phase 2: it extracts
-// the request's bearer token (header or query fallback) but does not enforce it,
-// applies a permissive CORS policy, and answers CORS preflight.
-func withAuth(next http.Handler) http.Handler {
+// errUnauthorized is the failure surfaced (as a 401 envelope) when a gated
+// request presents a missing or invalid bearer token. For a REST call it is a
+// plain 401; for a WS handshake the 401 pre-empts the upgrade so the client's
+// Dial fails — REST and WS auth are the same code path.
+var errUnauthorized = errors.New("unauthorized: missing or invalid bearer token")
+
+// authGate decides whether requests on a listener must present the bearer
+// token. A nil *authGate means trusted transport (the unix socket): every
+// request is authorized and the token is ignored. A non-nil gate enforces the
+// token, reading it fresh per auth event so `af token rotate` takes effect for
+// new connections without a daemon RPC (§1.3).
+type authGate struct {
+	// expectedToken returns the daemon's current bearer token. It is called
+	// once per auth event (per REST call / per WS handshake, not per byte), so
+	// re-reading the small token file keeps rotation live. An error — or an
+	// empty token — fails closed: the gate denies (see ConstantTimeEqual).
+	expectedToken func() (string, error)
+}
+
+// authorize reports whether the request presents the gate's expected bearer
+// token. It fails closed on any error resolving the expected token and on an
+// empty expected token (a daemon with no token must never accept the empty
+// credential), and compares in constant time to close the timing oracle.
+func (g *authGate) authorize(r *http.Request) bool {
+	want, err := g.expectedToken()
+	if err != nil {
+		return false
+	}
+	return ConstantTimeEqual(agentproto.TokenFromRequest(r), want)
+}
+
+// withAuth wraps the daemon mux with the auth + CORS gate. gate is nil for the
+// trusted unix socket (no token enforcement) and non-nil for the TCP listener.
+// corsOrigins is the exact-match browser-origin allow-list (§1.5); empty ⇒ no
+// Access-Control-Allow-Origin is emitted.
+func withAuth(next http.Handler, gate *authGate, corsOrigins []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Extract the token the request presents (Authorization: Bearer … or the
-		// ?access_token= WS/browser fallback). Deliberately discarded in Phase 2 —
-		// Phase 3 replaces this line with a constant-time compare against the
-		// daemon's token and a 401 on mismatch, and nothing else here changes.
-		_ = agentproto.TokenFromRequest(r)
-
-		applyCORSPolicy(w, r)
+		applyCORSPolicy(w, r, corsOrigins)
 		if r.Method == http.MethodOptions {
-			// CORS preflight: answered by the seam before any route runs.
+			// CORS preflight carries no credentials — answer it before the gate
+			// so cross-origin discovery works for the web client without a token.
 			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if gate != nil && !gate.authorize(r) {
+			writeHTTPError(w, http.StatusUnauthorized, errUnauthorized)
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
 }
 
-// applyCORSPolicy sets the CORS response headers. Permissive on the unix socket
-// now (any origin); Phase 3's policy tightens this for the TCP/TLS transport. It
-// is a hook, not a hard-coded rule, precisely so that later change is a policy
-// edit here rather than a re-plumb of every route.
-func applyCORSPolicy(w http.ResponseWriter, _ *http.Request) {
+// applyCORSPolicy sets the CORS response headers from the config allow-list
+// (§1.5). It echoes the request Origin ONLY when it exactly matches an
+// allow-list entry, and then advertises the allowed methods/headers. An empty
+// allow-list (the default) emits no Access-Control-Allow-Origin, so no
+// cross-origin browser can call the API; same-origin and non-browser clients
+// (TUI/CLI, curl) don't do CORS and are unaffected.
+func applyCORSPolicy(w http.ResponseWriter, r *http.Request, allowedOrigins []string) {
+	origin := r.Header.Get("Origin")
+	if origin == "" || !originAllowed(origin, allowedOrigins) {
+		return
+	}
 	h := w.Header()
-	h.Set("Access-Control-Allow-Origin", "*")
+	h.Set("Access-Control-Allow-Origin", origin)
+	// The response varies by Origin (we echo it conditionally), so caches must
+	// not serve one origin's response to another.
+	h.Add("Vary", "Origin")
 	h.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 	h.Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+}
+
+// originAllowed reports whether origin exactly matches an allow-list entry. No
+// wildcards or suffix matching — a browser origin is a full scheme://host[:port]
+// and must be listed verbatim.
+func originAllowed(origin string, allowedOrigins []string) bool {
+	for _, allowed := range allowedOrigins {
+		if allowed == origin {
+			return true
+		}
+	}
+	return false
 }

--- a/daemon/httpauth_test.go
+++ b/daemon/httpauth_test.go
@@ -4,46 +4,166 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
 )
 
-// TestWithAuthCORSPreflight pins the auth/CORS seam: a CORS preflight is answered
-// by the middleware (204 + permissive CORS headers) before any route runs, and a
-// real request still passes through to its handler with the CORS headers set.
-func TestWithAuthCORSPreflight(t *testing.T) {
-	h := withAuth(newHTTPMux(&controlServer{}))
+// staticGate is an authGate whose expected token is a fixed string, for the
+// enforcement matrix below. An empty tok models the fail-closed case (a daemon
+// with no token must reject every credential).
+func staticGate(tok string) *authGate {
+	return &authGate{expectedToken: func() (string, error) { return tok, nil }}
+}
 
-	// Preflight: answered by the seam, never reaching a route handler.
-	pre := httptest.NewRequest(http.MethodOptions, "/v1/sessions/x/stream", nil)
-	preRec := httptest.NewRecorder()
-	h.ServeHTTP(preRec, pre)
-	if preRec.Code != http.StatusNoContent {
-		t.Fatalf("preflight status = %d, want 204", preRec.Code)
+// bearerReq builds a GET /v1/health request carrying tok as an Authorization
+// Bearer header (empty tok ⇒ no header, an unauthenticated request).
+func bearerReq(tok string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	if tok != "" {
+		r.Header.Set(agentproto.AuthHeader, agentproto.BearerScheme+tok)
 	}
-	if got := preRec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
-		t.Fatalf("preflight CORS origin = %q, want *", got)
+	return r
+}
+
+// TestWithAuthGateEnforcement pins the per-listener token gate: with a non-nil
+// gate (the TCP listener, PR3), a request must present the exact bearer token.
+func TestWithAuthGateEnforcement(t *testing.T) {
+	const good = "s3cr3t-token"
+	h := withAuth(newHTTPMux(&controlServer{}), staticGate(good), nil)
+
+	// Valid token in the Authorization header → served (200).
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, bearerReq(good))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid token status = %d, want 200", rec.Code)
 	}
 
-	// A real request passes through the seam to its handler and still carries the
-	// CORS headers.
-	get := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
-	getRec := httptest.NewRecorder()
-	h.ServeHTTP(getRec, get)
-	if getRec.Code != http.StatusOK {
-		t.Fatalf("health status through seam = %d, want 200", getRec.Code)
+	// Valid token via the ?access_token= WS/browser fallback → served (200).
+	rec = httptest.NewRecorder()
+	q := httptest.NewRequest(http.MethodGet, "/v1/health?"+agentproto.AccessTokenQueryParam+"="+good, nil)
+	h.ServeHTTP(rec, q)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid ?access_token= status = %d, want 200", rec.Code)
 	}
-	if got := getRec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
-		t.Fatalf("health CORS origin = %q, want *", got)
+
+	// Wrong token → 401.
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, bearerReq("wrong"))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong token status = %d, want 401", rec.Code)
+	}
+
+	// Missing token → 401.
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, bearerReq(""))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token status = %d, want 401", rec.Code)
 	}
 }
 
-// TestWithAuthTokenSeamIsNoOp pins that the auth seam does NOT enforce a token in
-// Phase 2 — a request with no credential is served normally (the unix-socket peer
-// is trusted; Phase 3 fills in enforcement here without reshaping routes).
-func TestWithAuthTokenSeamIsNoOp(t *testing.T) {
-	h := withAuth(newHTTPMux(&controlServer{}))
+// TestWithAuthGateFailsClosed pins that an empty expected token denies every
+// request (a daemon with no token must never accept the empty credential), and
+// that an error resolving the expected token also denies.
+func TestWithAuthGateFailsClosed(t *testing.T) {
+	// Empty expected token: even a request presenting "" is rejected.
+	h := withAuth(newHTTPMux(&controlServer{}), staticGate(""), nil)
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/health", nil))
+	h.ServeHTTP(rec, bearerReq(""))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("empty expected token, no cred status = %d, want 401", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, bearerReq("anything"))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("empty expected token, some cred status = %d, want 401", rec.Code)
+	}
+
+	// Expected-token resolution error (e.g. token file unreadable): deny.
+	errGate := &authGate{expectedToken: func() (string, error) {
+		return "", http.ErrNoLocation
+	}}
+	h = withAuth(newHTTPMux(&controlServer{}), errGate, nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, bearerReq("whatever"))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("token-resolution error status = %d, want 401", rec.Code)
+	}
+}
+
+// TestWithAuthNilGateBypasses is the regression guard for local trust: the unix
+// socket passes a nil gate, so every request is authorized regardless of the
+// (missing or bogus) credential. This is why enforcement stays DARK until PR3.
+func TestWithAuthNilGateBypasses(t *testing.T) {
+	h := withAuth(newHTTPMux(&controlServer{}), nil, nil)
+
+	for _, tok := range []string{"", "bogus"} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, bearerReq(tok))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("nil-gate request (token=%q) status = %d, want 200 (unix peer trusted)", tok, rec.Code)
+		}
+	}
+}
+
+// TestWithAuthPreflightBeforeGate pins that a CORS preflight is answered (204)
+// before the token gate runs — browsers never attach credentials to preflight,
+// so cross-origin discovery must work without a token even on a gated listener.
+func TestWithAuthPreflightBeforeGate(t *testing.T) {
+	h := withAuth(newHTTPMux(&controlServer{}), staticGate("tok"), []string{"https://af.example.com"})
+	req := httptest.NewRequest(http.MethodOptions, "/v1/sessions/x/stream", nil)
+	req.Header.Set("Origin", "https://af.example.com")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("preflight status = %d, want 204", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://af.example.com" {
+		t.Fatalf("preflight ACAO = %q, want the allowed origin echoed", got)
+	}
+}
+
+// TestCORSAllowList pins the config allow-list (§1.5): an allowed origin is
+// echoed with the method/header advertisements, a disallowed origin gets no
+// ACAO, and an empty allow-list (the default) emits no ACAO for any origin.
+func TestCORSAllowList(t *testing.T) {
+	allow := []string{"https://af.example.com", "https://ops.internal:8443"}
+
+	// Allowed origin → echoed verbatim, with methods/headers advertised.
+	h := withAuth(newHTTPMux(&controlServer{}), nil, allow)
+	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	req.Header.Set("Origin", "https://af.example.com")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://af.example.com" {
+		t.Fatalf("allowed origin ACAO = %q, want it echoed", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got == "" {
+		t.Fatalf("allowed origin missing Access-Control-Allow-Methods")
+	}
+	if got := rec.Header().Get("Vary"); got != "Origin" {
+		t.Fatalf("allowed origin Vary = %q, want Origin", got)
+	}
+
+	// Disallowed origin → no ACAO.
+	req = httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("disallowed origin ACAO = %q, want empty", got)
+	}
+
+	// Empty allow-list (default) → no ACAO even for an origin that would match
+	// an entry in a populated list, and the request still passes (nil gate).
+	h = withAuth(newHTTPMux(&controlServer{}), nil, nil)
+	req = httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	req.Header.Set("Origin", "https://af.example.com")
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("empty allow-list ACAO = %q, want empty", got)
+	}
 	if rec.Code != http.StatusOK {
-		t.Fatalf("unauthenticated request status = %d, want 200 (seam is a no-op in Phase 2)", rec.Code)
+		t.Fatalf("empty allow-list request status = %d, want 200", rec.Code)
 	}
 }

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -85,10 +85,11 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 
 	cs := &controlServer{manager: manager, scheduler: scheduler, watchers: watchers}
 	srv := &http.Server{
-		// The mux is wrapped in the auth/CORS seam (#1592 Phase 2 PR5): a no-op
-		// token extraction + permissive CORS today, the drop-in point for Phase 3's
-		// TCP+TLS+token enforcement without reshaping any route.
-		Handler:           withAuth(newHTTPMux(cs)),
+		// The unix socket is trusted transport (0600 perms are the auth, #1029),
+		// so it passes a NIL gate: no token enforcement (#1592 Phase 3 PR2,
+		// §1.4). The TCP listener (PR3) will pass a real gate over the same mux.
+		// CORS is config-driven (§1.5): empty allow-list ⇒ no ACAO emitted.
+		Handler:           withAuth(newHTTPMux(cs), nil, manager.cfg.CORSAllowedOrigins),
 		ReadHeaderTimeout: httpReadHeaderTimeout,
 	}
 


### PR DESCRIPTION
## Summary

Fills the Phase-2 auth/CORS **seam** (`daemon/httpauth.go`) with real enforcement, **gated per-listener** — plan §1.4 (withAuth wiring) + §1.5 (CORS).

**This PR is DARK: no runtime behavior change.** The unix socket passes a **nil gate** (peer trusted, token ignored — filesystem 0600 perms are the local auth, #1029), the CORS allow-list is **empty by default** (no `Access-Control-Allow-Origin` emitted), and **no TCP listener exists yet** (PR3), so the enforcement path is never taken at runtime. It is exercised only by the gated in-memory test server.

## The enforcement wiring (§1.4)

`withAuth(next)` → `withAuth(next, gate *authGate, corsOrigins []string)`:

- **nil gate** (unix socket) ⇒ trusted transport: every request authorized, token ignored.
- **non-nil gate** (TCP listener, PR3) ⇒ the request's bearer token — `Authorization: Bearer …` for REST, or `?access_token=` for the WS/browser path, both via Phase 2's `agentproto.TokenFromRequest` extractor — is **constant-time-compared** against PR1's token library (`ConstantTimeEqual`). Missing / wrong / empty-expected-token / token-read-error all **fail closed** with a `401` envelope.
- The `401` **pre-empts the WS upgrade**, so REST and WS auth are the same code path (no WS-specific rejection logic).
- **OPTIONS preflight** is answered *before* the gate — browsers never attach credentials to preflight, so cross-origin discovery works without a token.

## The per-listener gate — unix bypass

`startHTTPServer` passes **`nil`** as the gate for the unix socket, so local behavior is unchanged. PR3 will pass a real `&authGate{…}` (a closure reading `daemon-token`, rotation-live) over the **same mux** for the TCP listener. Because only the unix listener exists today, the gate is always nil at runtime → **nothing is ever rejected** until PR3.

## CORS allow-list (§1.5)

`applyCORSPolicy` replaces the permissive `*` with the config **`cors_allowed_origins`** exact-match allow-list:

- Echoes the request `Origin` **only on an exact match** (+ `Vary: Origin`, `Access-Control-Allow-Methods/Headers`).
- **Empty list (the default)** ⇒ no `Access-Control-Allow-Origin`, so no cross-origin browser can call the API. `*` was never usable by a credentialed client anyway.
- Non-browser clients (TUI/CLI, curl) don't do CORS and are unaffected.

## Scope boundaries

- Config keys (`listen_addr`, `tls_cert`, `tls_key`, `cors_allowed_origins`) already landed in **PR1** — **no docs drift** (`scripts/gen-docs.sh` regenerates clean).
- **No** TCP listener (PR3), **no** client changes (PR3/PR4). Clean, no shims. No version bump.

## Tests

`daemon/httpauth_test.go` — enforcement matrix on a gated server: valid token via header → 200, valid via `?access_token=` → 200, wrong → 401, missing → 401, empty-expected-token → 401 (fail-closed), token-resolution-error → 401; **nil-gate (unix) → 200 regardless of token** (local-trust regression guard); preflight-before-gate → 204 with echoed origin; CORS matrix (allowed echoed, disallowed no ACAO, empty-default no ACAO).

## Gates

- `gofmt -l .` clean, `golangci-lint run --fast` clean, `go build ./...` clean, `deadcode -test ./...` clean, `scripts/lint-file-length.sh` clean
- `make test-container` — full suite green
- `make tui-driver-selftest` — 25/25 (unaffected — local path unchanged)
- `scripts/gen-docs.sh` — no drift (no new config keys this PR)

Refs #1592

🤖 Generated with [Claude Code](https://claude.com/claude-code)