### PR TITLE
feat(daemon): optional TLS TCP listener (token-gated, off by default) (#1592 Phase 3 PR3)

### DIFF
--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -84,12 +84,15 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 	}
 
 	cs := &controlServer{manager: manager, scheduler: scheduler, watchers: watchers}
+	// One mux, shared by both listeners, so the REST/RPC/WS handler graph is
+	// single-sourced and the two transports can never drift (§1.1).
+	mux := newHTTPMux(cs)
 	srv := &http.Server{
 		// The unix socket is trusted transport (0600 perms are the auth, #1029),
 		// so it passes a NIL gate: no token enforcement (#1592 Phase 3 PR2,
-		// §1.4). The TCP listener (PR3) will pass a real gate over the same mux.
+		// §1.4). The TCP listener below passes a real gate over the same mux.
 		// CORS is config-driven (§1.5): empty allow-list ⇒ no ACAO emitted.
-		Handler:           withAuth(newHTTPMux(cs), nil, manager.cfg.CORSAllowedOrigins),
+		Handler:           withAuth(mux, nil, manager.cfg.CORSAllowedOrigins),
 		ReadHeaderTimeout: httpReadHeaderTimeout,
 	}
 
@@ -101,12 +104,33 @@ func startHTTPServer(manager *Manager, scheduler *taskScheduler, watchers *watch
 		}
 	}()
 
+	// Optional TLS TCP listener (#1592 Phase 3 PR3, §1.1). OFF BY DEFAULT: only
+	// bound when listen_addr is set. It serves the same mux behind a
+	// token-enforcing gate. A bind failure is logged but never fatal — the unix
+	// socket and control plane every local client depends on must not regress
+	// because a network port could not open.
+	closeTCP := func() error { return nil }
+	if manager.cfg.ListenAddr != "" {
+		if closer, info, err := startTCPListener(mux, manager.cfg); err != nil {
+			log.WarningLog.Printf("failed to start daemon TLS TCP listener on %q: %v", manager.cfg.ListenAddr, err)
+		} else {
+			closeTCP = closer
+			log.InfoLog.Printf("daemon TLS TCP listener enabled on %s (self-signed=%v)", info.Addr, info.SelfSigned)
+			log.InfoLog.Printf("  cert fingerprint: %s", info.Fingerprint)
+			log.InfoLog.Printf("  bearer token: %s", info.Token)
+		}
+	}
+
 	return func() error {
 		// Close stops the listener (which unlinks the Unix socket file, net's
 		// default for a listener it created) and terminates active connections.
 		// Deliberately no explicit os.Remove: mirrors startControlServer's
 		// #718/#767 reasoning — a Remove could race a freshly bound socket.
-		return srv.Close()
+		tcpErr := closeTCP()
+		if err := srv.Close(); err != nil {
+			return err
+		}
+		return tcpErr
 	}, nil
 }
 

--- a/daemon/tcpserver.go
+++ b/daemon/tcpserver.go
@@ -1,0 +1,110 @@
+package daemon
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// The optional TLS TCP listener for the daemon's HTTP/WS surface (#1592 Phase 3
+// PR3, §1.1). It serves the SAME mux the unix socket serves, but wrapped in a
+// token-enforcing gate: the unix socket is trusted transport (0600 perms are
+// the auth, #1029) and passes a nil gate, while this listener requires a valid
+// bearer token on every request and applies the CORS allow-list.
+//
+// It is OFF BY DEFAULT — bound only when config.ListenAddr is non-empty. When
+// empty (the default) startHTTPServer never calls in here, so behavior is
+// byte-identical to the pure-unix daemon that shipped before Phase 3.
+
+// tlsMinVersion is the floor for the TCP listener. TLS 1.2 is the modern
+// baseline (1.0/1.1 are deprecated); the bearer token must never ride a
+// downgraded or plaintext connection.
+const tlsMinVersion = tls.VersionTLS12
+
+// tcpListenerInfo is the enable-banner payload startHTTPServer logs once when
+// the TCP listener binds. The token is included deliberately (§1.3): the daemon
+// log is the operator's channel to the freshly generated credential — a
+// documented log-file-readability consideration, gated behind the explicit
+// listen_addr opt-in.
+type tcpListenerInfo struct {
+	Addr        string // the resolved bound address (host:port, port filled in for :0)
+	Token       string // the bearer token clients must present
+	Fingerprint string // "sha256:<hex>" of the leaf cert, the value clients TOFU-pin
+	SelfSigned  bool   // true for the generated self-signed default, false for a user cert
+}
+
+// startTCPListener binds the TLS TCP listener on cfg.ListenAddr and serves mux
+// wrapped in a token-enforcing gate + the CORS allow-list. It returns a cleanup
+// function that shuts the server down and the banner payload the caller logs.
+//
+// It resolves the TLS material (PR1: self-signed default, or the user's
+// tls_cert/tls_key), ensures the bearer token exists before opening the port
+// (so an operator enabling the listener always has a credential to present),
+// and reads that token FRESH per auth event through the gate so `af token
+// rotate` takes effect for new connections without a daemon restart.
+func startTCPListener(mux http.Handler, cfg *config.Config) (func() error, tcpListenerInfo, error) {
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return nil, tcpListenerInfo{}, err
+	}
+
+	mat, err := ResolveTLSMaterial(dir, cfg.TLSCert, cfg.TLSKey)
+	if err != nil {
+		return nil, tcpListenerInfo{}, fmt.Errorf("resolve TLS material: %w", err)
+	}
+	cert, err := tls.LoadX509KeyPair(mat.CertPath, mat.KeyPath)
+	if err != nil {
+		return nil, tcpListenerInfo{}, fmt.Errorf("load TLS keypair: %w", err)
+	}
+	fingerprint, err := CertFingerprint(mat.CertPath)
+	if err != nil {
+		return nil, tcpListenerInfo{}, fmt.Errorf("compute cert fingerprint: %w", err)
+	}
+
+	// Generate-if-absent so enabling the listener always yields a usable token;
+	// the gate below re-reads the file per auth event, so rotation stays live.
+	tokenPath, err := TokenPath()
+	if err != nil {
+		return nil, tcpListenerInfo{}, err
+	}
+	token, err := EnsureToken(tokenPath)
+	if err != nil {
+		return nil, tcpListenerInfo{}, fmt.Errorf("ensure daemon token: %w", err)
+	}
+	gate := &authGate{expectedToken: func() (string, error) {
+		return LoadToken(tokenPath)
+	}}
+
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tlsMinVersion,
+	}
+	// tls.Listen wraps each accepted conn in the TLS handshake, so srv.Serve
+	// (not ServeTLS) is correct here — and Addr() reports the concrete port
+	// even when cfg.ListenAddr requests :0 (used by the integration test).
+	listener, err := tls.Listen("tcp", cfg.ListenAddr, tlsCfg)
+	if err != nil {
+		return nil, tcpListenerInfo{}, fmt.Errorf("bind TCP listener on %q: %w", cfg.ListenAddr, err)
+	}
+
+	srv := &http.Server{
+		Handler:           withAuth(mux, gate, cfg.CORSAllowedOrigins),
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+	}
+	go func() {
+		if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+			log.WarningLog.Printf("daemon TCP listener stopped: %v", err)
+		}
+	}()
+
+	info := tcpListenerInfo{
+		Addr:        listener.Addr().String(),
+		Token:       token,
+		Fingerprint: fingerprint,
+		SelfSigned:  mat.SelfSigned,
+	}
+	return srv.Close, info, nil
+}

--- a/daemon/tcpserver_test.go
+++ b/daemon/tcpserver_test.go
@@ -1,0 +1,151 @@
+package daemon
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/require"
+)
+
+// pinnedTLSConfig builds a client TLS config that trusts ONLY the daemon's
+// self-signed cert (read from disk), mirroring the fingerprint-pin PR4 will do.
+// The cert carries a 127.0.0.1 SAN, so verifying against 127.0.0.1 succeeds.
+func pinnedTLSConfig(t *testing.T, certPath string) *tls.Config {
+	t.Helper()
+	pem, err := os.ReadFile(certPath)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(pem), "load self-signed cert into pool")
+	return &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+}
+
+// TestTCPListener_TLS_TokenRoundTrip is the PR3 payoff: a real TLS TCP listener
+// on loopback that REQUIRES the bearer token. It proves REST + WS both accept a
+// correct token over https/wss and reject a missing/wrong one, with the client
+// pinning the self-signed cert.
+func TestTCPListener_TLS_TokenRoundTrip(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.ListenAddr = "127.0.0.1:0" // :0 ⇒ the kernel picks a free port
+	m, err := NewManager(cfg)
+	require.NoError(t, err)
+
+	cs := &controlServer{manager: m, scheduler: newTaskScheduler()}
+	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg)
+	require.NoError(t, err)
+	defer func() { _ = closeTCP() }()
+
+	require.NotEmpty(t, info.Token)
+	require.True(t, info.SelfSigned)
+	require.True(t, strings.HasPrefix(info.Fingerprint, "sha256:"))
+
+	// The self-signed material lives in the af home; pin it.
+	dir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: pinnedTLSConfig(t, dir+"/"+daemonTLSCertFileName)},
+	}
+	baseURL := "https://" + info.Addr
+
+	// --- REST: correct token → 200 -----------------------------------------
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+info.Token)
+	resp, err := client.Do(req)
+	require.NoError(t, err, "TLS handshake + authorized request must succeed")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	// --- REST: no token → 401 ----------------------------------------------
+	req, err = http.NewRequest(http.MethodGet, baseURL+"/v1/health", nil)
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "missing token must be rejected")
+	_ = resp.Body.Close()
+
+	// --- REST: wrong token → 401 -------------------------------------------
+	req, err = http.NewRequest(http.MethodGet, baseURL+"/v1/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer not-the-real-token")
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "wrong token must be rejected")
+	_ = resp.Body.Close()
+
+	// --- WS: correct token via ?access_token= → upgrades + streams ---------
+	wsBase := "wss://" + info.Addr
+	dialOpts := &websocket.DialOptions{HTTPClient: client}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, wsBase+"/v1/events?"+agentproto.AccessTokenQueryParam+"="+info.Token, dialOpts)
+	require.NoError(t, err, "authorized WS handshake must upgrade")
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
+
+	// Prove the stream is live: publish repeatedly (absorb subscribe race) and
+	// read one event back over the encrypted, token-gated socket.
+	ev, err := agentproto.NewEvent(agentproto.EventTaskCreated, nil)
+	require.NoError(t, err)
+	got := make(chan agentproto.MessageType, 1)
+	go func() {
+		if msg, rerr := agentproto.ReadMessage(ctx, conn); rerr == nil {
+			if typ, terr := agentproto.MessageTypeOf(msg.Text); terr == nil {
+				got <- typ
+			}
+		}
+	}()
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for streaming := true; streaming; {
+		select {
+		case typ := <-got:
+			require.Equal(t, string(agentproto.EventTaskCreated), string(typ))
+			streaming = false
+		case <-ticker.C:
+			m.events.publish(ev)
+		case <-ctx.Done():
+			t.Fatal("authorized WS client never received a published event")
+		}
+	}
+
+	// --- WS: no token → handshake fails (401 pre-empts the upgrade) ---------
+	badCtx, badCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer badCancel()
+	badConn, _, err := websocket.Dial(badCtx, wsBase+"/v1/events", dialOpts)
+	if badConn != nil {
+		_ = badConn.Close(websocket.StatusNormalClosure, "")
+	}
+	require.Error(t, err, "unauthenticated WS handshake must be rejected")
+}
+
+// TestStartHTTPServer_NoTCPByDefault pins the off-by-default guarantee: with an
+// empty ListenAddr (the default) startHTTPServer binds ONLY the unix socket and
+// no TCP port is opened — byte-identical to the pre-Phase-3 daemon.
+func TestStartHTTPServer_NoTCPByDefault(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	m, err := NewManager(config.DefaultConfig())
+	require.NoError(t, err)
+	require.Empty(t, m.cfg.ListenAddr, "default config must leave the TCP listener off")
+
+	closeHTTP, err := startHTTPServer(m, newTaskScheduler(), nil)
+	require.NoError(t, err)
+	require.NoError(t, closeHTTP())
+
+	// No self-signed TLS material is generated when the listener never binds.
+	dir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	_, statErr := os.Stat(dir + "/" + daemonTLSCertFileName)
+	require.True(t, os.IsNotExist(statErr), "no cert should be generated when TCP is off")
+}


### PR DESCRIPTION
## #1592 Phase 3 PR3 — lights up the network surface, off by default

This PR adds the daemon's **TLS TCP listener** — the first real network
surface for the HTTP/WS API — and keeps it **OFF BY DEFAULT**. It builds on
PR1 (token lib `daemon/token.go` + TLS material `daemon/tlsmaterial.go` +
`af token`) and PR2 (`withAuth(next, gate, corsOrigins)` per-listener
enforcement + CORS).

### Dual listener, one handler, per-listener gate (§1.1)
`startHTTPServer` now builds **one shared mux** (`newHTTPMux(cs)`) served by
two `http.Server`s:

```
unix socket  →  withAuth(mux, nil,       cors)   // trusted transport, token ignored (unchanged)
TCP + TLS    →  withAuth(mux, gateToken, cors)   // peer MUST present the bearer token
```

The unix socket is **byte-identical to today** — same 0600 socket, same nil
gate. The new TCP listener (in `daemon/tcpserver.go`) requires a valid bearer
token on every request and applies the CORS allow-list.

### Off by default
New behavior is gated entirely behind the existing `listen_addr` config key
(added dark in PR1, global-only like `daemon_poll_interval`):

| `listen_addr` | Behavior |
|---|---|
| `""` (default) | **No TCP listener binds.** Pure unix, no cert generated — zero change for existing users. |
| `:8443` / `127.0.0.1:8443` | Daemon also listens there with **TLS + bearer token**. |

### TLS from PR1
The TCP listener serves the cert/key resolved by `ResolveTLSMaterial`: a
self-signed ECDSA cert with a stable pinned fingerprint by default, or a
user-provided `tls_cert`/`tls_key`. `crypto/tls` with a **TLS 1.2 floor** — the
token never rides a downgraded connection. The bearer token is
generate-if-absent on enable and re-read **per auth event**, so `af token
rotate` takes effect for new connections without a restart.

A TCP bind failure is **logged but never fatal** — the local unix control
plane must not regress because a network port could not open. On enable the
daemon logs the bound address, cert fingerprint, and bearer token (the
operator's channel to the freshly generated credential — a documented
log-readability consideration, gated behind the explicit opt-in).

Not in scope: the client side (`--daemon-url`/`--token`/TLS pin → PR4) and
docs polish (PR5).

### Live token round-trip proof
`daemon/tcpserver_test.go` binds a **real TLS TCP listener on `127.0.0.1:0`**,
with the client **pinning the self-signed cert**:

```
=== RUN   TestTCPListener_TLS_TokenRoundTrip
--- PASS: TestTCPListener_TLS_TokenRoundTrip (0.04s)
=== RUN   TestStartHTTPServer_NoTCPByDefault
--- PASS: TestStartHTTPServer_NoTCPByDefault (0.00s)
PASS
ok  	github.com/sachiniyer/agent-factory/daemon
```

- **REST** `GET /v1/health` over `https://`: correct token → **200**; missing token → **401**; wrong token → **401**.
- **WS** `/v1/events?access_token=<token>` over `wss://`: authorized handshake **upgrades and streams** a published event; **no token → handshake rejected** (401 pre-empts the upgrade).
- **Off-by-default**: empty `listen_addr` binds only the unix socket and **generates no cert**.

### Gates
- `gofmt -l .` clean · `go build ./...` OK · `golangci-lint --fast` clean · `deadcode -test ./...` clean · `scripts/lint-file-length.sh` clean
- `scripts/gen-docs.sh` → **no drift** (the `listen_addr`/`tls_*`/`cors_*` keys were already documented in PR1)
- `make test-container GOTESTARGS='./daemon/...'` → green (45s)
- `make tui-driver-selftest` → **25/25** (TCP off by default ⇒ unaffected)

Part of #1592. Do not merge until reviewed — root merges autonomously when verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)