### PR TITLE
fix(tui): move scroll-mode capture off the bubbletea event loop (#1637)

### DIFF
--- a/app/handle_mouse.go
+++ b/app/handle_mouse.go
@@ -304,7 +304,11 @@ func (m *home) handleWheel(msg tea.MouseMsg) tea.Cmd {
 		} else {
 			w.ScrollDown()
 		}
-		return nil
+		// Scroll entry no longer captures on the event loop (#1637); dispatch an
+		// off-loop refresh so the scrollback fill lands within a frame instead of
+		// waiting up to a preview tick. panesRefresh bypasses its throttle while
+		// the pane NeedsScrollFill.
+		return m.panesRefresh(m.attached.Load())
 	}
 	switch {
 	case strings.HasPrefix(id, "tree:"):

--- a/app/home_panes.go
+++ b/app/home_panes.go
@@ -180,7 +180,12 @@ func (m *home) panesRefresh(attachedNow bool) tea.Cmd {
 		if w.HasLive() {
 			continue
 		}
-		if time.Since(m.lastPaneCapture[p.ID()]) < paneCaptureMinInterval {
+		// A pane that just entered scroll mode has an empty scroll viewport
+		// waiting for its off-loop scrollback capture (#1637): bypass the throttle
+		// so the fill lands on this refresh instead of up to a tick later, which
+		// would flash a blank viewport. Scroll-mode entry no longer captures on the
+		// event loop, so this off-loop fill is the only place that populates it.
+		if !w.NeedsScrollFill() && time.Since(m.lastPaneCapture[p.ID()]) < paneCaptureMinInterval {
 			continue
 		}
 		m.lastPaneCapture[p.ID()] = time.Now()

--- a/ui/preview_scroll_fallback_test.go
+++ b/ui/preview_scroll_fallback_test.go
@@ -239,11 +239,14 @@ func TestPreviewScrollModeThenSessionGoneFallback(t *testing.T) {
 	// guard does not reset scroll on the instance-switch path.
 	require.NoError(t, p.UpdateContent(setup.instance, 0))
 
-	// Session vanishes; entering scroll mode now fails the PreviewFullHistory
-	// capture with ErrSessionGone and routes through setFallbackState.
+	// Session vanishes. Entering scroll mode is now I/O-free (#1637): ScrollUp
+	// just marks a pending fill, and the off-loop refresh (UpdateContent) is where
+	// the full-history capture fails with ErrSessionGone and routes through
+	// setFallbackState — so drive that refresh to reach the fallback.
 	sessionGone.Store(true)
 
 	require.NoError(t, p.ScrollUp(setup.instance, 0))
+	require.NoError(t, p.UpdateContent(setup.instance, 0))
 
 	require.False(t, p.isScrolling,
 		"session-gone while entering scroll mode must not leave the pane scrolling")

--- a/ui/preview_scroll_offloop_test.go
+++ b/ui/preview_scroll_offloop_test.go
@@ -1,0 +1,83 @@
+package ui
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScrollEntryExitNeverCapturesOnEventLoop is the #1637 regression: entering
+// and exiting scroll mode must NOT perform the full-scrollback capture inline.
+// Before the fix, ScrollUp/ScrollDown/ResetToNormalMode called the preview
+// source (a tmux capture-pane, later an unbounded daemon Preview RPC) directly
+// on the bubbletea event loop while holding p.mu, so a slow or hung capture froze
+// the entire TUI. Now scroll entry/exit only flips state and marks a pending
+// fill; the capture rides the off-loop refresh goroutine (UpdateContent).
+//
+// The preview source here blocks forever until released, standing in for a hung
+// capture. Each scroll method must return promptly regardless — a method that
+// blocks on it is doing I/O on the event loop, the exact freeze this fixes.
+func TestScrollEntryExitNeverCapturesOnEventLoop(t *testing.T) {
+	inst := makeShellInstance(t, "offloop", "scrollback-line")
+	defer func() { _ = inst.Kill() }()
+
+	release := make(chan struct{})
+	var calls int32
+	blockingSrc := func(_ *session.Instance, _ int, _ bool) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		<-release // stand in for a slow/hung tmux capture or daemon Preview RPC
+		return "scrollback-line", nil
+	}
+
+	p := NewTabPane(blockingSrc)
+	p.SetSize(80, 30)
+
+	// mustReturnPromptly runs fn on another goroutine and fails if it does not
+	// return quickly — i.e. if it blocked on the (never-released) capture.
+	mustReturnPromptly := func(what string, fn func() error) {
+		t.Helper()
+		done := make(chan error, 1)
+		go func() { done <- fn() }()
+		select {
+		case err := <-done:
+			require.NoError(t, err, what)
+		case <-time.After(3 * time.Second):
+			t.Fatalf("%s blocked on the capture — scroll entry/exit must not do I/O on the event loop (#1637)", what)
+		}
+	}
+
+	// Enter scroll mode on the shell tab. Must return at once and NOT capture.
+	mustReturnPromptly("ScrollUp", func() error { return p.ScrollUp(inst, 1) })
+	require.True(t, p.IsScrolling(), "ScrollUp enters scroll mode")
+	require.True(t, p.NeedsScrollFill(), "scroll entry marks a pending off-loop fill")
+	require.Equal(t, int32(0), atomic.LoadInt32(&calls),
+		"scroll entry must not call the preview source on the event loop")
+
+	// Exit scroll mode. Must also return at once and NOT capture.
+	mustReturnPromptly("ResetToNormalMode", func() error { return p.ResetToNormalMode(inst, 1) })
+	require.False(t, p.IsScrolling(), "ResetToNormalMode exits scroll mode")
+	require.Equal(t, int32(0), atomic.LoadInt32(&calls),
+		"scroll exit must not call the preview source on the event loop")
+
+	// The capture is the off-loop refresh's job. Re-enter scroll mode, then run
+	// UpdateContent (the refresh goroutine's work) — it IS allowed to block on the
+	// capture because it never runs on the event loop. Release the capture and it
+	// completes, filling the viewport and clearing the pending flag.
+	require.NoError(t, p.ScrollUp(inst, 1))
+	require.True(t, p.NeedsScrollFill())
+
+	fillDone := make(chan error, 1)
+	go func() { fillDone <- p.UpdateContent(inst, 1) }()
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) >= 1 }, 3*time.Second, 5*time.Millisecond,
+		"the off-loop refresh must be the path that performs the scroll capture")
+	close(release)
+	require.NoError(t, <-fillDone)
+
+	require.False(t, p.NeedsScrollFill(), "a completed fill clears the pending flag")
+	require.Contains(t, p.viewport.View(), "scrollback-line",
+		"the off-loop fill populates the scroll viewport")
+	require.True(t, p.IsScrolling(), "the pane stays in scroll mode after the fill")
+}

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -856,14 +856,15 @@ func TestPreviewUpdateContentSessionGoneRendersFallback(t *testing.T) {
 		"no ERROR log line on session-gone fallback path")
 }
 
-// TestResetToNormalModeDoesNotClearFallbackFlag is the #577 regression: when
-// ResetToNormalMode exits scroll mode it fetches fresh preview content and
-// writes it into previewState.text, but previously it left previewState.fallback
-// untouched. If the prior state was a fallback (e.g. Loading or Session no
-// longer running), the pane would then hold real terminal output while still
-// flagged as fallback, and a subsequent UpdateContent that errored before
-// reaching its own `fallback: false` assignment would render the captured
-// terminal output with centered fallback styling.
+// TestResetToNormalModeDoesNotClearFallbackFlag is the #577 regression, updated
+// for the off-loop-scroll refactor (#1637). ResetToNormalMode no longer captures
+// preview content on the event loop; it clears scroll state and leaves p.content
+// untouched (a live restore rides the immediate off-loop refresh the app
+// dispatches after ESC). The #577 mismatch — fallback==true holding real terminal
+// text — is therefore structurally impossible on the exit path: ResetToNormalMode
+// never writes text, so it can never desync the flag from the text. This test
+// pins both halves: exit leaves the content flag/text consistent, and the
+// following refresh restores real content with fallback cleared.
 func TestResetToNormalModeDoesNotClearFallbackFlag(t *testing.T) {
 	const expectedContent = "$ terminal output"
 
@@ -909,17 +910,22 @@ func TestResetToNormalModeDoesNotClearFallbackFlag(t *testing.T) {
 	p.isScrolling = true
 	p.viewport.SetContent("ESC to exit scroll mode")
 
-	// Exit scroll mode. ResetToNormalMode pulls fresh content via Preview()
-	// (our mock returns expectedContent) and must clear the stale fallback
-	// flag at the same time, otherwise String() would render the captured
-	// terminal output with centered fallback styling.
+	// Exit scroll mode. ResetToNormalMode clears scroll state without capturing
+	// (#1637), so it must NOT leave a fallback==true / real-text mismatch — the
+	// #577 bug. A live instance matches none of its synchronous fallback cases, so
+	// p.content is left exactly as it was (the fallback), consistently.
 	require.NoError(t, p.ResetToNormalMode(setup.instance, 0))
-
 	require.False(t, p.isScrolling, "should exit scroll mode")
+	require.False(t, p.content.fallback && p.content.text == expectedContent,
+		"#577: ResetToNormalMode must never leave fallback==true holding real terminal text")
+
+	// The immediate off-loop refresh the app dispatches after ESC restores real
+	// content and clears the fallback flag together.
+	require.NoError(t, p.UpdateContent(setup.instance, 0))
 	require.Equal(t, expectedContent, p.content.text,
-		"text should be set to the captured preview content")
+		"the post-exit refresh sets text to the captured preview content")
 	require.False(t, p.content.fallback,
-		"fallback must be cleared when ResetToNormalMode sets real content (#577)")
+		"the post-exit refresh clears the fallback flag alongside real content (#577)")
 
 	// And the rendered output must use the normal (left-aligned) branch,
 	// not the centered fallback layout — i.e. it must not be padded with
@@ -987,25 +993,35 @@ func TestScrollMouseDifferentInstanceResetsScrollMode(t *testing.T) {
 	p := NewTabPane(previewFromInstance)
 	p.SetSize(80, 30)
 
-	// Enter scroll mode on A via the mouse path (no prior UpdateContent).
+	// Enter scroll mode on A via the mouse path (no prior UpdateContent). Scroll
+	// entry is I/O-free (#1637); the off-loop refresh (UpdateContent) fills the
+	// viewport from A — the two-step flow production drives after a wheel scroll.
 	require.NoError(t, p.ScrollUp(instA, 0))
 	require.True(t, p.isScrolling, "should be scrolling A after ScrollUp(A)")
+	require.NoError(t, p.UpdateContent(instA, 0))
 	require.Contains(t, p.viewport.View(), previewA,
 		"precondition: viewport should hold A's captured content")
 
-	// Selection switches to B, but UpdateContent(B) has not run yet. A
-	// wheel-up arrives for B. Before the fix this scrolled A's stale viewport;
-	// now it must drop scroll state and re-capture B's content.
+	// Selection switches to B, but the refresh for B has not run yet. A wheel-up
+	// arrives for B. Before the fix this scrolled A's stale viewport; now ScrollUp
+	// drops scroll state and re-keys to B (dropStaleView clears the viewport at
+	// once), and the off-loop fill captures B's content — never stale A.
 	require.NoError(t, p.ScrollUp(instB, 0))
 	require.True(t, p.isScrolling,
 		"should re-enter scroll mode for B after the switch")
+	require.NotContains(t, p.viewport.View(), previewA,
+		"stale viewport content from A must be cleared on the scroll path at once")
+	require.NoError(t, p.UpdateContent(instB, 0))
 	require.Contains(t, p.viewport.View(), previewB,
 		"viewport must reflect B after the mouse scroll, not stale A")
 	require.NotContains(t, p.viewport.View(), previewA,
-		"stale viewport content from A must be cleared on the scroll path")
+		"the fill must capture B, never the previously rendered A (#746)")
 
 	// The same must hold for the ScrollDown entry point.
 	require.NoError(t, p.ScrollDown(instA, 0))
+	require.NotContains(t, p.viewport.View(), previewB,
+		"stale viewport content from B must be cleared on ScrollDown path at once")
+	require.NoError(t, p.UpdateContent(instA, 0))
 	require.Contains(t, p.viewport.View(), previewA,
 		"ScrollDown on a switched-to instance must re-capture its content")
 	require.NotContains(t, p.viewport.View(), previewB,

--- a/ui/tab_pane.go
+++ b/ui/tab_pane.go
@@ -64,7 +64,14 @@ type TabPane struct {
 
 	content     tabContentState
 	isScrolling bool
-	viewport    viewport.Model
+	// scrollFillPending is set when ScrollUp/ScrollDown enter scroll mode and
+	// cleared once the off-loop capture has populated the viewport. Scroll entry
+	// no longer captures on the bubbletea event loop (#1637); this flag is the
+	// deterministic "capture still owed" signal the updateAgent/updateShell
+	// lazy-fill and NeedsScrollFill key off — a sized viewport's View() is never
+	// the empty string (it renders padding), so viewport emptiness cannot serve.
+	scrollFillPending bool
+	viewport          viewport.Model
 
 	// currentInstance + currentTab identify the (instance, tab-index) view
 	// currently rendered. UpdateContent/ScrollUp/ScrollDown reset scroll-mode
@@ -108,6 +115,18 @@ func (p *TabPane) IsScrolling() bool {
 	return p.isScrolling
 }
 
+// NeedsScrollFill reports whether the pane is in scroll mode with an unfilled
+// viewport — ScrollUp/ScrollDown just entered scroll mode and the off-loop
+// capture that populates the scrollback (updateAgent/updateShell lazy-fill) has
+// not landed yet. panesRefresh uses it to bypass its capture throttle so the
+// fill runs on the very next refresh instead of up to a tick later, keeping
+// scroll-mode entry visually instant with no capture on the event loop (#1637).
+func (p *TabPane) NeedsScrollFill() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.isScrolling && p.scrollFillPending && p.viewport.Height > 0
+}
+
 func (p *TabPane) SetSize(width, maxHeight int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -134,6 +153,7 @@ func (p *TabPane) dropStaleView(instance *session.Instance, activeTab int) {
 	if instance != p.currentInstance || activeTab != p.currentTab {
 		if p.isScrolling {
 			p.isScrolling = false
+			p.scrollFillPending = false
 			p.viewport.SetContent("")
 			p.viewport.GotoTop()
 		}
@@ -156,6 +176,7 @@ func (p *TabPane) setFallbackState(message string) {
 		text:     lipgloss.JoinVertical(lipgloss.Center, FallBackText, "", message),
 	}
 	p.isScrolling = false
+	p.scrollFillPending = false
 	p.viewport.SetContent("")
 }
 
@@ -244,9 +265,13 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 	// alive and its screen shows the limit message, so it falls through to the
 	// live Preview() below.
 
-	// If in scroll mode but the viewport hasn't been filled yet, capture the
-	// full scrollback now (the agent slot fills lazily here; see ScrollUp).
-	if p.isScrolling && p.viewport.Height > 0 && len(p.viewport.View()) == 0 {
+	// If scroll mode was entered but the scrollback hasn't been captured yet,
+	// capture the full history now. ScrollUp/ScrollDown enter scroll mode WITHOUT
+	// any capture (that used to block the bubbletea event loop on a slow tmux
+	// capture / daemon RPC — #1637); the fill happens here instead, on the
+	// off-loop refresh goroutine, the first time UpdateContent runs with a
+	// pending scroll fill.
+	if p.isScrolling && p.scrollFillPending {
 		p.mu.Unlock()
 		content, err := p.previewSrc(instance, 0, true)
 		p.mu.Lock()
@@ -263,8 +288,18 @@ func (p *TabPane) updateAgent(instance *session.Instance, guard contentGuard) er
 			}
 			return err
 		}
-		if p.isScrolling && p.viewport.Height > 0 && len(p.viewport.View()) == 0 {
+		// Re-check under the relocked mutex: a concurrent dropStaleView/fallback
+		// during the capture may have cleared the pending fill, in which case this
+		// stale capture must not clobber the new state.
+		if p.isScrolling && p.scrollFillPending {
 			p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
+			// First fill lands at the bottom (newest output), matching the live
+			// view the user was looking at when they entered scroll mode. This is
+			// the only place that pins the offset: subsequent LineUp/LineDown move
+			// it and the fill no longer runs (pending cleared), so the scroll
+			// position is preserved (#1637).
+			p.viewport.GotoBottom()
+			p.scrollFillPending = false
 		}
 		return nil
 	}
@@ -357,8 +392,40 @@ func (p *TabPane) updateShell(instance *session.Instance, activeTab int, guard c
 		return nil
 	}
 
-	// Skip content updates while scrolling (the shell slot fills its viewport
-	// eagerly in enterScrollMode, not here).
+	// Scroll mode with a pending fill: capture the tab's full scrollback here —
+	// off the event loop, exactly like the agent slot. ScrollUp/ScrollDown no
+	// longer capture inline (that blocked the bubbletea event loop on a slow tmux
+	// capture / daemon RPC — #1637); the shell slot fills lazily on this off-loop
+	// refresh goroutine, the first time UpdateContent runs with a pending fill.
+	if p.isScrolling && p.scrollFillPending {
+		p.mu.Unlock()
+		content, err := p.previewSrc(instance, activeTab, true)
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if !guardOK(guard) || !p.isCurrentViewLocked(instance, activeTab) {
+			return nil
+		}
+		if err != nil {
+			if errors.Is(err, tmux.ErrSessionGone) {
+				// setFallbackState clears scroll state and the stale viewport, so
+				// the fallback renders even mid scroll-capture (#940/#977).
+				p.setFallbackState("Terminal session no longer running.")
+				return nil
+			}
+			return err
+		}
+		// Re-check under the relocked mutex (see updateAgent): a concurrent
+		// dropStaleView/fallback may have cleared the pending fill.
+		if p.isScrolling && p.scrollFillPending {
+			p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
+			p.viewport.GotoBottom()
+			p.scrollFillPending = false
+		}
+		return nil
+	}
+
+	// Already-filled scroll viewport: leave it (and p.content) untouched so
+	// LineUp/LineDown keep their position.
 	if p.isScrolling {
 		p.mu.Unlock()
 		return nil
@@ -471,49 +538,35 @@ func (p *TabPane) ScrollDown(instance *session.Instance, activeTab int) error {
 	return nil
 }
 
-// enterScrollModeLocked captures the selected view's full scrollback and enters
-// scroll mode. Caller must hold p.mu. Capture is keyed off the passed instance
-// + tab index, never a cached title, so the wrong view can never be captured
-// (#746/#384).
+// enterScrollModeLocked switches the pane into scroll mode WITHOUT capturing.
+// The full-scrollback capture used to run inline here, on the bubbletea event
+// loop — an unbounded tmux capture / daemon Preview RPC that froze the whole TUI
+// while entering scroll mode if that capture was slow or hung (#1637). It now
+// only flips scroll state and empties the viewport; the capture happens off the
+// event loop on the next UpdateContent (the updateAgent/updateShell lazy-fill,
+// keyed on an empty scroll viewport), which the app dispatches immediately on
+// scroll entry (panesRefresh bypasses its throttle while NeedsScrollFill). Caller
+// must hold p.mu. Validation uses in-memory state only, never I/O.
 func (p *TabPane) enterScrollModeLocked(instance *session.Instance, activeTab int) error {
 	if instance.IsTearingDown() {
 		p.setFallbackState("Tearing down session...")
 		return nil
 	}
-
-	var content string
-	var err error
-	if activeTab == 0 {
-		content, err = p.previewSrc(instance, 0, true)
-	} else {
-		// An already-dead shell tab must transition to the fallback, not bare
-		// return: a bare return leaves p.content (fallback==false) holding the
-		// last-rendered capture and isScrolling==false, so String() renders stale
-		// terminal output instead of the dead-session message. This mirrors
-		// updateShell's !TabAlive branch and the ErrSessionGone path below,
-		// which both set the same fallback — the early-return was the inconsistency
-		// (#998, sibling of #977/#984).
-		if !instance.TabAlive(activeTab) {
-			p.setFallbackState("Terminal session not available.")
-			return nil
-		}
-		content, err = p.previewSrc(instance, activeTab, true)
+	// An already-dead shell tab transitions to the fallback rather than entering
+	// scroll mode over stale terminal output: leaving p.content intact with
+	// isScrolling==false would render the last capture instead of the dead-session
+	// message. Mirrors updateShell's !TabAlive branch (#998, sibling of #977/#984).
+	if activeTab != 0 && !instance.TabAlive(activeTab) {
+		p.setFallbackState("Terminal session not available.")
+		return nil
 	}
-	if err != nil {
-		if errors.Is(err, tmux.ErrSessionGone) {
-			if activeTab == 0 {
-				p.setFallbackState("Session no longer running.")
-			} else {
-				p.setFallbackState("Terminal session no longer running.")
-			}
-			return nil
-		}
-		return err
-	}
-
-	p.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, content, scrollFooter()))
-	p.viewport.GotoBottom()
+	// Empty the viewport and mark a fill pending so the off-loop lazy-fill
+	// captures the full scrollback and pins it to the bottom. Capture is keyed off
+	// the passed instance + tab index there, never a cached title, so the wrong
+	// view can never be captured (#746/#384).
+	p.viewport.SetContent("")
 	p.isScrolling = true
+	p.scrollFillPending = true
 	return nil
 }
 
@@ -527,6 +580,7 @@ func (p *TabPane) ResetToNormalMode(instance *session.Instance, activeTab int) e
 	wasScrolling := p.isScrolling
 	if wasScrolling {
 		p.isScrolling = false
+		p.scrollFillPending = false
 		p.viewport.SetContent("")
 		p.viewport.GotoTop()
 	}
@@ -542,34 +596,25 @@ func (p *TabPane) ResetToNormalMode(instance *session.Instance, activeTab int) e
 		return nil
 	}
 
-	// Agent slot: immediately restore content instead of waiting for the next
-	// UpdateContent, but keep transient/dead fallbacks rather than blanking the
-	// pane on an empty/erroring Preview() (#823/#920/#935).
+	// Agent slot: surface a transient/dead fallback synchronously (these are
+	// in-memory checks, no I/O) so ESC on a gone/creating session shows the right
+	// message at once rather than the pre-scroll capture (#823/#920/#935). Live
+	// content is restored off the event loop by the immediate refresh the app
+	// dispatches after ESC — there is no inline Preview() here, which used to
+	// block the bubbletea event loop on a slow tmux capture / daemon RPC (#1637).
+	// A live session keeps p.content (the last non-scroll capture, still valid)
+	// until that refresh lands; a LimitReached agent (#1146) likewise falls
+	// through to its live screen rather than a fallback.
 	switch {
 	case instance.IsCreating():
 		p.setFallbackState("Setting up workspace...")
-		return nil
 	case instance.IsTearingDown():
 		p.setFallbackState("Tearing down session...")
-		return nil
 	case instance.GetLiveness() == session.LiveDead:
 		p.setFallbackState("Session no longer running.")
-		return nil
 	case instance.GetLiveness() == session.LiveLost:
 		p.setFallbackState("Session lost — its tmux session is gone.")
-		return nil
 	}
-	// LimitReached (#1146) falls through to the live Preview() — its screen shows
-	// the limit message, more useful than a fallback.
-	content, err := p.previewSrc(instance, 0, false)
-	if err != nil {
-		if errors.Is(err, tmux.ErrSessionGone) {
-			p.setFallbackState("Session no longer running.")
-			return nil
-		}
-		return err
-	}
-	p.content = tabContentState{fallback: false, text: content}
 	return nil
 }
 

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -525,6 +525,13 @@ func (w *TabbedWindow) IsInScrollMode() bool {
 	return w.tab.IsScrolling()
 }
 
+// NeedsScrollFill reports whether the pane just entered scroll mode and is still
+// waiting for its off-loop scrollback capture — panesRefresh bypasses its
+// throttle for such a pane so the fill is immediate (#1637).
+func (w *TabbedWindow) NeedsScrollFill() bool {
+	return w.tab.NeedsScrollFill()
+}
+
 // renderHeader renders the one-line `title · tab` header. The header is the
 // only place the pane's tab is named inside the pane (the tab bar is gone);
 // the highlight doubles as the pane's focus indicator.

--- a/ui/terminal_test.go
+++ b/ui/terminal_test.go
@@ -238,6 +238,8 @@ func TestTabPaneShellFallbackResetsScrollMode(t *testing.T) {
 		p.SetSize(80, 30)
 		require.NoError(t, p.ScrollUp(prior, 1))
 		require.True(t, p.IsScrolling(), "precondition: in scroll mode")
+		// Scroll entry is I/O-free (#1637); the off-loop refresh fills the viewport.
+		require.NoError(t, p.UpdateContent(prior, 1))
 		require.Contains(t, p.viewport.View(), priorContent)
 
 		require.NoError(t, p.UpdateContent(nil, 1))
@@ -299,8 +301,12 @@ func TestTabPaneShellScrollUsesSelectedView(t *testing.T) {
 	require.NoError(t, p.UpdateContent(instA, 1))
 
 	// User scrolls while B is the selected instance, before UpdateContent(B) ran.
+	// ScrollUp enters scroll mode keyed to B (dropStaleView adopts B); the
+	// scrollback capture then runs off the event loop on the next UpdateContent
+	// (#1637), which fills the viewport from B — never the previously rendered A.
 	require.NoError(t, p.ScrollUp(instB, 1))
 	require.True(t, p.IsScrolling())
+	require.NoError(t, p.UpdateContent(instB, 1))
 	require.Contains(t, p.viewport.View(), contentB,
 		"scroll must capture the selected instance's (B) shell history")
 	require.NotContains(t, p.viewport.View(), contentA,
@@ -475,9 +481,11 @@ func TestTabPaneShellScrollModeSessionGoneExternally(t *testing.T) {
 	p := NewTabPane(previewFromInstance)
 	p.SetSize(80, 30)
 
-	// Enter scroll mode on the live shell tab: the viewport fills with scrollback.
+	// Enter scroll mode on the live shell tab, then let the off-loop refresh fill
+	// the viewport with scrollback (scroll entry itself is I/O-free — #1637).
 	require.NoError(t, p.ScrollUp(inst, 1))
 	require.True(t, p.IsScrolling(), "precondition: shell tab is in scroll mode")
+	require.NoError(t, p.UpdateContent(inst, 1))
 	require.Contains(t, p.viewport.View(), scrollback,
 		"precondition: viewport holds the live shell's scrollback")
 


### PR DESCRIPTION
## Summary
Fixes #1637. Entering or exiting scroll mode captured the full scrollback **inline on the bubbletea event loop** while holding the pane mutex — `ScrollUp`/`ScrollDown` → `enterScrollModeLocked` and `ResetToNormalMode` called the preview source directly. That source is a `tmux capture-pane` and, since #1592 Phase 2 PR6, an **unbounded daemon Preview RPC** (the apiclient sets *no* request timeout). A slow or hung capture therefore froze the entire TUI — no input, no redraws — on a scroll keystroke or ESC.

Periodic refresh was already moved off-loop (#579); the interactive scroll path was the remaining half of that same inconsistency, now closed.

## Change
- **Scroll entry/exit is I/O-free.** `enterScrollModeLocked`/`ResetToNormalMode` only flip scroll state and set an explicit `scrollFillPending` flag. The full-scrollback capture rides the existing off-loop refresh goroutine (the `updateAgent`/`updateShell` lazy-fill), which now keys off the flag — a sized viewport's `View()` is never the empty string, so viewport-emptiness could not serve as the signal — and pins the first fill to the bottom.
- **Immediate fill.** `panesRefresh` bypasses its 100 ms throttle while a pane `NeedsScrollFill`, and the mouse-wheel path now dispatches a refresh (the key/ESC paths already did via `selectionChanged`), so the fill lands within a frame with no capture on the event loop.
- `ResetToNormalMode` keeps only its in-memory transient/dead fallbacks; because it no longer writes content, the #577 fallback-flag/real-text mismatch is structurally impossible on the exit path.

The capture is now off-loop everywhere: `grep` confirms `previewSrc` is only reached from `updateAgent`/`updateShell` (the refresh goroutine), never from a scroll method.

## Tests
- **New regression** (`ui/preview_scroll_offloop_test.go`): a preview source that blocks forever stands in for a hung capture — `ScrollUp` and `ResetToNormalMode` must return promptly and never call it, while `UpdateContent` (the off-loop refresh) is the path that performs it. **Verified it hangs (fails) when the capture is restored inline**, passes off-loop.
- Existing scroll tests (#702/#746/#669/#940/#977/#998/#577) updated to drive the off-loop fill (`UpdateContent`) after entering scroll mode — the two-step flow production now uses. All hard-won edge cases preserved.

## Verification of the flake
`TestE2E_PaneFlow` (the flake this bug caused) runs clean; the pane suite is green.

## Gates
gofmt clean · `go build ./...` OK · `golangci-lint --fast` clean · `deadcode -test ./...` clean · `make test-container GOTESTARGS=./ui/... ./app/...` green · `make tui-driver-selftest` 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)