### PR TITLE
docs(remote): document TCP+TLS+token remote daemon flow + Phase-3 wrap-up (#1592 Phase 3 PR5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ owner-only HTTP/JSON API over `$AGENT_FACTORY_HOME/daemon-http.sock`.
 curl --unix-socket ~/.agent-factory/daemon-http.sock http://localhost/v1/health
 ```
 
+To drive the daemon from another machine, SSH in and run `af` there, or enable
+the opt-in TLS+token TCP listener (`af token`, `--daemon-url`) — see
+[Remote daemon access](docs/remote-tcp-auth.md).
+
 ### Configuration
 
 Configuration is TOML. Global defaults live in
@@ -181,7 +185,9 @@ performance.
 - [CLI guide](docs/cli.md) and [generated CLI reference](docs/reference/cli.md).
 - [HTTP API guide](docs/http-api.md) and [generated API reference](docs/reference/api.md).
 - [Configuration](docs/configuration.md), [tasks](docs/tasks.md),
-  [remote hooks](docs/remote-hooks.md), and [usage limits](docs/usage-limits.md).
+  [remote hooks](docs/remote-hooks.md),
+  [remote daemon access](docs/remote-tcp-auth.md), and
+  [usage limits](docs/usage-limits.md).
 - [Container testing](docs/container-testing.md), [release process](docs/release-process.md),
   [release notes](docs/release-notes.md), and
   [release testing plan](docs/release-testing-plan.md).

--- a/commands/root.go
+++ b/commands/root.go
@@ -34,6 +34,14 @@ var (
 	rootCmd     = &cobra.Command{
 		Use:   "af",
 		Short: "Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, Gemini, and Amp.",
+		Long: `Run 'af' with no arguments to open the TUI. The subcommands below drive the
+same daemon non-interactively (` + "`af sessions`, `af tasks`" + ` emit JSON).
+
+By default 'af' talks to a daemon on the local machine over a Unix socket. To
+drive a daemon on ANOTHER machine, SSH to the host and run 'af' there, or enable
+the opt-in TLS+token TCP listener and point a client at it with the persistent
+--daemon-url/--token/--tls-fingerprint flags (see 'af token' for the credentials).
+Full guide: https://sachiniyer.github.io/agent-factory/remote-tcp-auth/`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			log.Initialize(daemonFlag)

--- a/commands/tokencmd.go
+++ b/commands/tokencmd.go
@@ -12,12 +12,12 @@ import (
 )
 
 // `af token` manages the daemon's bearer token — the credential for the
-// direct-TCP/TLS API surface (#1592 Phase 3). Under Sachin's locked auth model
-// one token = full access, single-owner. The token is DARK in PR1: no listener
-// enforces it yet (Phase 3 PR3 lights up the TLS TCP listener). `af token`
-// exists now so the material can be generated, inspected, and rotated ahead of
-// (and independently of) enabling the listener. The local unix socket is never
-// affected — its filesystem 0600 perms are the local auth (#1029).
+// direct-TCP/TLS API surface (#1592 Phase 3). Under the locked auth model one
+// token = full access, single-owner. The token authenticates the TLS TCP
+// listener (enabled with the listen_addr config key); the material can be
+// generated, inspected, and rotated independently of enabling the listener. The
+// local unix socket is never affected — its filesystem 0600 perms are the local
+// auth (#1029). See docs/remote-tcp-auth.md for the end-to-end flow.
 
 // tokenJSONFlag switches `af token show/rotate` from human output to the shared
 // {data,error} envelope, matching `af config`'s --json.
@@ -40,8 +40,8 @@ type tokenRotateResult struct {
 // resolveTLSFingerprint resolves the daemon's TLS material (user-provided cert
 // via tls_cert/tls_key, else the self-generated self-signed cert) and returns
 // its SHA-256 fingerprint. Resolving self-generates the cert on first use, so
-// `af token show` materializes both the token and the cert — still DARK, since
-// nothing binds a listener.
+// `af token show` materializes both the token and the cert even before the
+// listener is enabled.
 func resolveTLSFingerprint() (string, error) {
 	dir, err := config.GetConfigDir()
 	if err != nil {

--- a/config/config_types.go
+++ b/config/config_types.go
@@ -166,10 +166,9 @@ type Config struct {
 	LimitRetryInterval string `json:"limit_retry_interval" toml:"limit_retry_interval"`
 	// ListenAddr optionally binds the daemon's HTTP/WS API to a TLS TCP
 	// listener in addition to the always-present local unix socket (#1592
-	// Phase 3). Empty ⇒ no TCP listener (today's pure-unix behavior). A value
-	// like "0.0.0.0:8443" or ":8443" enables direct-TCP access gated by the
-	// bearer token (`af token`). DARK until Phase 3 PR3 binds the listener;
-	// declared now so the whole key set lands in one reviewable place.
+	// Phase 3). Empty ⇒ no TCP listener (the default pure-unix behavior). A
+	// value like "0.0.0.0:8443" or "127.0.0.1:8443" enables direct-TCP access
+	// gated by the bearer token (`af token`) — see docs/remote-tcp-auth.md.
 	// Global-only (daemon behavior), like daemon_poll_interval — a cloned
 	// repo must never be able to open a network port.
 	ListenAddr string `json:"listen_addr" toml:"listen_addr"`

--- a/daemon/httpauth.go
+++ b/daemon/httpauth.go
@@ -8,17 +8,16 @@ import (
 )
 
 // The auth + CORS gate for the daemon HTTP/WS surface (#1592 Phase 2 PR5 seam,
-// filled by Phase 3 PR2, §1.4/§1.5). Every route (the REST mirror and the WS
+// filled by Phase 3, §1.4/§1.5). Every route (the REST mirror and the WS
 // routes) is served through withAuth, and the WS handshake rides the same path,
 // so one gate covers both — the Authorization header and the browser
 // ?access_token= fallback — with no route-specific auth logic.
 //
 // Enforcement is PER-LISTENER. The local unix socket is trusted transport
 // (filesystem 0600 perms are the auth, #1029): it passes a nil gate and every
-// request is authorized, token ignored. The TCP+TLS listener (PR3) passes a
-// real gate and requires a valid bearer token. Because only the unix listener
-// exists today, this whole enforcement path is DARK — the gate is always nil at
-// runtime and nothing is ever rejected — until PR3 binds TCP with gate != nil.
+// request is authorized, token ignored. The TCP+TLS listener passes a real gate
+// (startTCPListener) and requires a valid bearer token on every request, so the
+// nil-vs-real gate is the whole difference between the two transports.
 
 // errUnauthorized is the failure surfaced (as a 401 envelope) when a gated
 // request presents a missing or invalid bearer token. For a REST call it is a

--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -154,9 +154,9 @@ func newHTTPMux(cs *controlServer) *http.ServeMux {
 	// indirection, and the events-plane fan-out. These are NOT REST/RPC mirrors —
 	// they upgrade to WebSockets — so they live outside servedHTTPRoutes (the `af
 	// api` RPC catalog) and register here with method+path patterns (a non-GET to
-	// a stream path is a 405 from the mux). They are DARK in Phase 2: nothing in
-	// the TUI consumes them yet (PR6 wires the TUI), but the routes exist and ride
-	// the same auth/CORS seam startHTTPServer wraps the mux in.
+	// a stream path is a 405 from the mux). The TUI consumes them for live panes,
+	// attach, and events (#1592 Phase 2 PR6/PR7), and they ride the same auth/CORS
+	// seam startHTTPServer wraps the mux in.
 	mux.HandleFunc("GET /v1/sessions/{id}/stream", cs.streamHandler)
 	mux.HandleFunc("GET /v1/sessions/{id}/stream-info", cs.streamInfoHandler)
 	mux.HandleFunc("GET /v1/events", cs.eventsHandler)

--- a/daemon/tlsmaterial.go
+++ b/daemon/tlsmaterial.go
@@ -17,10 +17,10 @@ import (
 	"time"
 )
 
-// The TLS material for the daemon's TCP surface (#1592 Phase 3 PR1, §1.2).
-// TLS is mandatory on the TCP listener — the bearer token must never ride the
-// wire in the clear. This file only produces and resolves the cert/key; it is
-// DARK: no listener uses it yet (Phase 3 PR3 binds the TLS TCP listener).
+// The TLS material for the daemon's TCP surface (#1592 Phase 3, §1.2). TLS is
+// mandatory on the TCP listener — the bearer token must never ride the wire in
+// the clear. This file produces and resolves the cert/key that startTCPListener
+// serves when listen_addr is set.
 //
 // Default (zero-config): a self-generated ECDSA P-256 self-signed cert stored
 // in the af home. The client pins its SHA-256 fingerprint (TOFU), so a
@@ -39,8 +39,8 @@ const (
 	selfSignedValidity = 10 * 365 * 24 * time.Hour
 )
 
-// TLSMaterial is the resolved cert/key the daemon's TCP listener will serve
-// (Phase 3 PR3). SelfSigned distinguishes the pinned self-signed default from
+// TLSMaterial is the resolved cert/key the daemon's TCP listener serves.
+// SelfSigned distinguishes the pinned self-signed default from
 // a user-provided CA cert (which the client verifies against system roots).
 type TLSMaterial struct {
 	// CertPath / KeyPath are the PEM files on disk.

--- a/daemon/token.go
+++ b/daemon/token.go
@@ -12,13 +12,13 @@ import (
 	"github.com/sachiniyer/agent-factory/config"
 )
 
-// The bearer-token material for the daemon's TCP/TLS surface (#1592 Phase 3
-// PR1, §1.3). Sachin locked the auth model to a single bearer token = full
-// access, single-owner. This file only produces and compares the material —
-// it is DARK: nothing here binds a socket or enforces a token. Phase 3 PR2
-// fills in the withAuth compare against this token; PR3 lights up the TCP
-// listener. The unix control socket stays unauthenticated (filesystem 0600
-// perms are the local auth, #1029) and never reads this token.
+// The bearer-token material for the daemon's TCP/TLS surface (#1592 Phase 3,
+// §1.3). The auth model is a single bearer token = full access, single-owner.
+// This file produces and compares the material; the withAuth gate enforces it
+// on the TLS TCP listener (startTCPListener), reading it fresh per auth event so
+// `af token rotate` takes effect without a restart. The unix control socket
+// stays unauthenticated (filesystem 0600 perms are the local auth, #1029) and
+// never reads this token.
 
 const (
 	// daemonTokenFileName is the bearer token file in the af home. 0600 —
@@ -123,7 +123,7 @@ func RotateToken(path string) (string, error) {
 
 // ConstantTimeEqual reports whether got equals want without leaking, through
 // timing, how many leading bytes matched. It is the compare the withAuth gate
-// uses in PR2. An empty want denies (fail closed): a daemon with no token must
+// uses. An empty want denies (fail closed): a daemon with no token must
 // never accept the empty string as a valid credential.
 func ConstantTimeEqual(got, want string) bool {
 	if want == "" {

--- a/daemon/ws_events.go
+++ b/daemon/ws_events.go
@@ -22,9 +22,8 @@ import (
 // follow agentproto's contract: a session.* event carries a marshaled
 // session.InstanceData, a task.* event a marshaled task.Task.
 //
-// DARK in Phase 2: nothing consumes /v1/events yet (the TUI still polls Snapshot
-// until PR6). The route exists, is threaded through the auth/CORS seam, and is
-// covered by the WS harness.
+// The TUI consumes /v1/events for live updates (#1592 Phase 2 PR6). The route is
+// threaded through the auth/CORS seam and covered by the WS harness.
 
 // eventsBufferSize bounds one subscriber's pending-event queue. A subscriber that
 // falls this far behind has an event dropped (non-blocking publish) rather than

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -30,10 +30,9 @@ import (
 // drops a dead subscriber WITHOUT touching the PTY/session — the structural
 // reliability win over a shared tmux render client (§6).
 //
-// This plane is DARK in Phase 2: nothing in the TUI consumes it yet (live panes
-// still render through the tmux attach client until PR6). The routes exist, are
-// threaded through the auth/CORS seam (httpserver.go), and are exercised by the
-// WS integration harness.
+// The TUI consumes this plane for live panes and full-screen attach (#1592
+// Phase 2 PR6/PR7); the routes are threaded through the auth/CORS seam
+// (httpserver.go) and exercised by the WS integration harness.
 
 // wsKeepaliveInterval is how often the broker pings each subscriber and how long
 // it waits for the pong before dropping that (dead) subscriber. A subscriber

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -59,6 +59,13 @@ single-user, local-only API by design: anyone who can read the socket already
 runs as your user and could drive `af` directly, so no additional secret buys
 anything. Do not proxy this socket to a network interface.
 
+!!! note "Reaching the daemon from another machine"
+
+    To drive the daemon from a **different host** — a remote TUI, or the future
+    browser web client — don't proxy this socket. SSH to the host and run `af`
+    there, or enable the opt-in TLS+token TCP listener. Both are covered in
+    [Remote daemon access](remote-tcp-auth.md).
+
 ## Response envelope
 
 Every response — success or failure, on every endpoint — is the same

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -63,6 +63,15 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 
 Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, Gemini, and Amp.
 
+Run 'af' with no arguments to open the TUI. The subcommands below drive the
+same daemon non-interactively (`af sessions`, `af tasks` emit JSON).
+
+By default 'af' talks to a daemon on the local machine over a Unix socket. To
+drive a daemon on ANOTHER machine, SSH to the host and run 'af' there, or enable
+the opt-in TLS+token TCP listener and point a client at it with the persistent
+--daemon-url/--token/--tls-fingerprint flags (see 'af token' for the credentials).
+Full guide: https://sachiniyer.github.io/agent-factory/remote-tcp-auth/
+
 ```
 af [flags]
 ```

--- a/docs/remote-tcp-auth.md
+++ b/docs/remote-tcp-auth.md
@@ -1,0 +1,281 @@
+# Remote daemon access: TCP, TLS, and tokens
+
+By default the Agent Factory daemon is reachable **only** from the machine it
+runs on, over a local Unix socket whose `0600` permissions are the entire auth
+story (see the [HTTP API guide](http-api.md#authentication)). There is no open
+port and no shared secret — anyone who can read the socket already runs as your
+user.
+
+Sometimes you want a client on **another machine** to drive that daemon: your
+laptop's TUI pointed at a workstation, a script on a build box, or (in the
+future) a browser web client. There are two ways to do that, and **they are not
+equal on security** — pick the first one unless you have a specific reason not
+to.
+
+| | SSH (recommended) | Direct TCP + token |
+|---|---|---|
+| **New secrets to manage** | None — reuses your existing SSH keys | A bearer token you must generate, store, and rotate |
+| **Network exposure** | Nothing new is listening; the daemon stays on its Unix socket | A TLS port is open (bind it to loopback, not `0.0.0.0`, if you can) |
+| **Setup** | You already have it | Edit config, restart the daemon, distribute a token + TLS pin |
+| **Works for a browser web client** | No | Yes — this is what it's for |
+| **Use it when** | You can SSH to the host (almost always) | You genuinely can't tunnel, or you're serving the web client |
+
+> **Rule of thumb:** if you can `ssh` to the box, use SSH. Reach for the TCP
+> listener only when you can't — most commonly to serve the browser web client,
+> which cannot open an SSH tunnel.
+
+---
+
+## Option 1 — SSH (recommended)
+
+SSH already solves "authenticated access to a remote machine" with keys you
+already manage. Lean on it instead of minting a new credential.
+
+**Just run `af` on the host.** Open an SSH session and use `af` there — the TUI
+renders over your terminal, and one-off commands work too:
+
+```bash
+ssh you@workstation                # then run `af` interactively
+ssh you@workstation af sessions list
+ssh you@workstation af sessions send-prompt my-session "run the tests"
+```
+
+Nothing new listens on the network, no token exists to leak, and the daemon's
+local Unix socket (`0600`) is the only gate — which is exactly the single-user,
+local-only model it was designed for.
+
+**If you specifically want a *local* client driving the remote daemon** (for
+example your laptop's TUI, over a low-latency link), keep the TCP listener bound
+to **loopback** on the host and forward it through SSH rather than exposing it to
+the network:
+
+```toml
+# ~/.agent-factory/config.toml on the HOST — loopback only, never 0.0.0.0
+listen_addr = "127.0.0.1:8443"
+```
+
+```bash
+# On your LAPTOP: forward local :8443 to the host's loopback listener over SSH
+ssh -N -L 8443:127.0.0.1:8443 you@workstation
+```
+
+Now a client on your laptop can talk to `wss://127.0.0.1:8443` (see
+[Option 2](#option-2-direct-tcp-token) for the flags). The token and TLS still
+apply, but the port is never reachable from the network — SSH is the only way
+in, and the encrypted SSH channel carries the traffic.
+
+---
+
+## Option 2 — Direct TCP + token
+
+Enable this when SSH isn't an option — most importantly, to serve the browser
+web client. It opens a **TLS-only** TCP listener on the daemon, gated by a
+**bearer token**. TLS is mandatory (the token must never ride the wire in the
+clear) and certificate verification is never skipped.
+
+The local Unix socket is **unaffected** — it stays tokenless and keeps working
+for local clients exactly as before. The TCP listener is purely additive and
+**off by default**.
+
+### 1. Enable the listener
+
+`listen_addr` is a **global-only** key (a cloned repo must never be able to open
+a network port), and it is not one of the scalar keys `af config set` writes, so
+**hand-edit** your global config:
+
+```toml
+# ~/.agent-factory/config.toml
+listen_addr = "0.0.0.0:8443"   # or "127.0.0.1:8443" for loopback-only (SSH-tunnelled)
+```
+
+Then restart the daemon so it binds the port:
+
+```bash
+af daemon restart   # live sessions keep running; the new daemon re-adopts them
+```
+
+On enable, the daemon logs a one-time banner with the bound address, the TLS
+fingerprint, and the bearer token — the operator's channel to the freshly
+generated credential:
+
+```
+daemon TLS TCP listener enabled on 0.0.0.0:8443 (self-signed=true)
+  cert fingerprint: sha256:2f1c…
+  bearer token: kZ9…-…q0
+```
+
+### 2. Read the token and TLS fingerprint
+
+On the **host**, `af token show` prints the bearer token and the TLS
+fingerprint a client pins. Both are generated on first access, so this is safe
+to run even before the listener is enabled:
+
+```console
+$ af token show
+token:           kZ9abc...-...q0
+tls_fingerprint: sha256:2f1c9e...af
+```
+
+```bash
+af token show --json    # same values wrapped in the {data,error} envelope
+```
+
+- **`token`** — the bearer credential. Under the single-owner auth model, one
+  token grants **full access**; treat it like a password. It lives in
+  `~/.agent-factory/daemon-token` with `0600` permissions.
+- **`tls_fingerprint`** — the SHA-256 of the daemon's TLS certificate,
+  formatted `sha256:<hex>`. A client pins this to trust a self-signed cert
+  (see [TLS trust](#tls-trust)). It depends on the **certificate**, not the
+  token, so rotating the token never changes it.
+
+### 3. Connect a remote client
+
+Point any `af` client at the daemon with three flags (each has an environment
+fallback):
+
+| Flag | Env var | Meaning |
+|---|---|---|
+| `--daemon-url` | `AF_DAEMON_URL` | The daemon's TLS URL: `wss://host:port` or `https://host:port` (the two are equivalent). Plaintext `ws://`/`http://` is rejected — the listener is TLS-only. |
+| `--token` | `AF_DAEMON_TOKEN` | The bearer token from `af token show`. |
+| `--tls-fingerprint` | `AF_DAEMON_TLS_FINGERPRINT` | The pinned `sha256:…` fingerprint for a self-signed cert. **Omit** when the daemon uses a CA-signed cert. |
+
+Flags take precedence over the environment. When `--daemon-url` (or
+`AF_DAEMON_URL`) is unset, `af` uses the local Unix socket exactly as before —
+the remote path is entirely opt-in.
+
+```bash
+# One-off command against a remote daemon (self-signed cert, pinned)
+af sessions list \
+  --daemon-url wss://workstation:8443 \
+  --token "$(ssh you@workstation af token show --json | jq -r .data.token)" \
+  --tls-fingerprint sha256:2f1c9e...af
+
+# Or export the environment once and drop the flags
+export AF_DAEMON_URL=wss://workstation:8443
+export AF_DAEMON_TOKEN=kZ9abc...-...q0
+export AF_DAEMON_TLS_FINGERPRINT=sha256:2f1c9e...af
+af sessions list          # now talks to the remote daemon
+af                        # the TUI, too — the flags are global
+```
+
+Every downstream layer — the `{data,error}` envelope, the WebSocket PTY stream,
+live panes, full-screen attach — is byte-identical to the local path. Only the
+transport differs, so once connected the client behaves exactly like a local
+one.
+
+An invalid or missing token is rejected with a **401** on every request and on
+the WebSocket handshake; a remote read surfaces that error rather than silently
+falling back to a local disk scan (there is no local disk on the other end).
+
+---
+
+## TLS trust
+
+The listener is always TLS. You choose how the client trusts the certificate.
+
+### Self-signed (default, zero-config)
+
+With no `tls_cert`/`tls_key` configured, the daemon generates a long-lived
+self-signed ECDSA certificate once and stores it in the af home. The client
+trusts it by **pinning its SHA-256 fingerprint** (trust-on-first-use):
+
+- Get the fingerprint from `af token show` on the host and pass it as
+  `--tls-fingerprint sha256:…`.
+- The pin **replaces** the usual CA-chain and hostname checks — it is not
+  skipped. An exact fingerprint match is required on every handshake, so
+  connecting by IP or through an SSH tunnel Just Works despite the cert's
+  hostname, while a substituted or regenerated cert **fails** the handshake with
+  a clear mismatch error.
+- The fingerprint accepts the `sha256:<hex>` form `af token show` prints, plain
+  hex, or colon/space-separated hex.
+
+### CA-signed certificate
+
+If you have a real certificate (Let's Encrypt, a corporate CA), point the daemon
+at it and skip the pin — the client verifies it against the system trust store
+like any HTTPS server:
+
+```toml
+# ~/.agent-factory/config.toml (global-only, both keys required together)
+listen_addr = "0.0.0.0:8443"
+tls_cert = "/etc/af/tls/fullchain.pem"
+tls_key  = "/etc/af/tls/privkey.pem"
+```
+
+Then connect **without** `--tls-fingerprint`:
+
+```bash
+af sessions list --daemon-url wss://af.example.com:8443 --token "$TOKEN"
+```
+
+Setting only one of `tls_cert`/`tls_key` is a configuration error — a cert
+without its key (or vice versa) cannot serve TLS.
+
+---
+
+## Rotating the token
+
+`af token rotate` replaces the bearer token with a fresh one and prints it:
+
+```console
+$ af token rotate
+token: nW4new...-...t8
+```
+
+Rotation takes effect **immediately for new connections** — the auth gate
+re-reads the token file on every request, so no daemon restart is needed. Any
+in-flight streams keep running until they reconnect. The TLS fingerprint is
+**unchanged** (it depends on the certificate, not the token), so clients keep
+their existing `--tls-fingerprint` pin.
+
+After rotating, the **old token is dead**: a new connection presenting it gets a
+`401`. Re-distribute the new token to your clients.
+
+---
+
+## CORS (for the browser web client)
+
+Browsers enforce CORS, so a web client served from a different origin than the
+daemon needs that origin explicitly allow-listed. `cors_allowed_origins` is an
+**exact-match** allow-list (no wildcards, no suffix matching):
+
+```toml
+# ~/.agent-factory/config.toml (global-only)
+listen_addr = "0.0.0.0:8443"
+cors_allowed_origins = ["https://af.example.com"]
+```
+
+- Empty (the default) emits no `Access-Control-Allow-Origin`, so **no
+  cross-origin browser** can reach the API.
+- Non-browser clients (the TUI, the `af` CLI, `curl`) don't do CORS and are
+  **unaffected** by this key either way.
+- A CORS preflight (`OPTIONS`) carries no credentials and is answered before the
+  token gate, so cross-origin discovery works; the actual request still needs a
+  valid token.
+
+---
+
+## Security notes
+
+- **The token is full access.** One token = full control of the daemon under the
+  single-owner model. Store it with the same care as an SSH private key; never
+  commit it or paste it into shared logs.
+- **Prefer loopback + SSH over `0.0.0.0`.** Binding `listen_addr` to
+  `127.0.0.1` and forwarding over SSH (Option 1) keeps the port off the network
+  entirely. Only bind a routable interface when you must (e.g. serving the web
+  client), and put it behind a firewall.
+- **TLS is never optional and never unverified.** The client refuses a plaintext
+  URL and refuses a cert that neither matches the pin nor chains to a trusted CA.
+- **The local socket is still local.** Enabling the TCP listener does not weaken
+  the Unix socket, and it does not add a token requirement for local clients.
+- **Rotate on suspected exposure.** `af token rotate` invalidates the old token
+  for new connections at once — no restart, no downtime for live sessions.
+
+## See also
+
+- [HTTP API guide](http-api.md) — the local Unix-socket surface and the
+  `{data,error}` envelope the remote listener mirrors.
+- [The daemon](concepts/daemon.md) — the single-writer model behind every
+  transport.
+- [Configuration](configuration.md) — the global config file the keys above live
+  in.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
           - The daemon: concepts/daemon.md
           - Tasks & automation: tasks.md
           - Remote hooks: remote-hooks.md
+          - Remote daemon access: remote-tcp-auth.md
           - Usage limits: usage-limits.md
       - API & reference:
           - HTTP API guide: http-api.md


### PR DESCRIPTION
Final Phase-3 PR for the remote-daemon epic (#1592): documents the whole
TCP + TLS + token flow the earlier PRs built, keeps the user-facing surfaces
honest, wraps up the transitional code comments, and executes the documented
flow end-to-end in the container.

Merged before this: PR1 (token + TLS material + `af token`), PR2 (withAuth +
CORS per-listener gate), PR3 (optional TLS TCP listener via `listen_addr`,
off by default), PR4 (client `--daemon-url`/`--token`/`--tls-fingerprint` + TOFU pin).

## New doc — `docs/remote-tcp-auth.md`

- **SSH vs direct-TCP guidance up front.** A decision table + rule of thumb:
  if you can `ssh` to the box, use SSH (zero new secrets, reuses `~/.ssh`);
  reach for the TLS+token TCP listener only when you can't tunnel — most
  commonly to serve the future browser web client. Loopback-bind + `ssh -L`
  is shown as the safer middle ground.
- Enabling the listener (`listen_addr`, hand-edited in the **global** config
  since it isn't an `af config set` scalar key; `af daemon restart`), with the
  daemon enable banner.
- `af token show` / `af token rotate` — what the token and `sha256:` fingerprint
  are, the `0600` files, and that rotation is live (no restart) while the
  fingerprint is unchanged.
- TLS trust: self-signed pin (`--tls-fingerprint`, TOFU) **vs** a CA cert
  (`tls_cert`/`tls_key`, omit the pin).
- Client flags + `AF_DAEMON_URL`/`AF_DAEMON_TOKEN`/`AF_DAEMON_TLS_FINGERPRINT`
  env, precedence, `wss://`≡`https://`, plaintext rejected.
- `cors_allowed_origins` for the web client; security notes.

## Honest `af --help` / README / API docs

- `af --help` gains a `Long` describing local-vs-remote and pointing at the doc
  (regenerated `docs/reference/cli.md`; `af token` + the three remote flags
  already surface from PR1/PR4).
- README (CLI/HTTP-API section + docs list) and `docs/http-api.md` (auth section)
  cross-reference the new doc; mkdocs nav lists it under Core concepts.

## Phase-3 wrap-up — transitional comments removed

Deleted the now-false `DARK` / `until PR3` / `declared now` notes across
`config_types.go`, `tokencmd.go`, `tlsmaterial.go`, `token.go`, `httpauth.go`
(the listener + gate shipped), plus the stale `DARK in Phase 2 … until PR6`
notes in `ws_pty.go`, `ws_events.go`, `httpserver.go` (PR6/PR7 wired the TUI to
those planes). Comments now describe present behavior and name the real symbols.

## End-to-end walkthrough (executed in the playtest container)

Ran the exact flow the doc describes against a real daemon in an isolated
container (never the host daemon). Every claim matches exercised behavior:

```
STEP 1  enable listen_addr=127.0.0.1:8443 → daemon binds; enable banner:
  daemon TLS TCP listener enabled on 127.0.0.1:8443 (self-signed=true)
    cert fingerprint: sha256:8af96d…8c56
    bearer token: GwFWleW7…666Q

STEP 2  af token show
  token:           GwFWleW7…666Q
  tls_fingerprint: sha256:8af96d…8c56

STEP 3  af sessions list --daemon-url wss://127.0.0.1:8443 --token <TOK1> --tls-fingerprint <FP>
  []                         → OK (current token accepted)

  negative controls:
  empty token        → {"error":"unauthorized: missing or invalid bearer token"}   (401)
  wrong fingerprint  → {"error":"… TLS fingerprint mismatch: pinned sha256:0000… but daemon presented sha256:8af96d… …"}
  plaintext ws://    → {"error":"… uses a plaintext scheme; the remote daemon is TLS-only, use wss:// or https://"}
  https:// + pin     → []   (https:// ≡ wss://, accepted)

STEP 4  af token rotate  → new token JU1RUN1w…R08
  token CHANGED (TOK1 != TOK2)                OK
  fingerprint UNCHANGED by rotation           OK

STEP 5  OLD token TOK1 on a NEW connection
  → {"error":"unauthorized: missing or invalid bearer token"}   (401 — old token dead)
  NEW token TOK2
  → []                        → OK (rotated token accepted)
```

## Gates

- `gofmt -l .` clean · `golangci-lint run --fast` clean · `deadcode -test ./...`
  clean · `scripts/lint-file-length.sh` clean · `go build ./...` OK
- `make test-container` — all packages green
- `make tui-driver-selftest` — 25/25
- `scripts/gen-docs.sh` — committed (only drift is the new root `Long`)

Scope: docs + copy only, no version bump, no dev-install. Closes out #1592
Phase 3.

Refs #1592.

— Captain Claude
