### PR TITLE
feat(cli): af agent-server headless mode over HTTP/WS+TLS+token (#1592 Phase 4 PR1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # See docs/container-testing.md.
 
 .PHONY: test-container remote-roundtrip-container ws-pty-roundtrip-container \
+	agent-server-roundtrip-container \
 	playtest-container playtest-container-detached tui-driver tui-driver-selftest \
 	testbox-image lint-file-length docs
 
@@ -39,6 +40,13 @@ remote-roundtrip-container:
 # container fence (a real tmux server) as the full suite.
 ws-pty-roundtrip-container:
 	scripts/testbox.sh test ./integration -run TestWSPTYBrokerRoundTrip
+
+# Focused headless agent-server harness (#1592 Phase 4 PR1): starts a REAL
+# out-of-process `af agent-server` on a loopback TLS+token listener and drives it
+# over HTTPS/WSS — provision/launch, PTY stream input echo, snapshot — inside the
+# same container fence (a real tmux server) as the full suite.
+agent-server-roundtrip-container:
+	scripts/testbox.sh test ./integration -run TestAgentServerRoundTrip
 
 # Interactive TUI play-test sandbox: builds af inside, scaffolds a
 # throwaway AF home + mock project repo, drops you in a shell with a

--- a/commands/agentservercmd.go
+++ b/commands/agentservercmd.go
@@ -1,0 +1,86 @@
+package commands
+
+import (
+	"os"
+
+	"github.com/sachiniyer/agent-factory/daemon"
+	"github.com/sachiniyer/agent-factory/log"
+
+	"github.com/spf13/cobra"
+)
+
+// `af agent-server` (#1592 Phase 4 PR1) runs a headless, single-workspace
+// agent-server over the HTTP/WS+TLS+token protocol — the process that will later
+// run INSIDE each docker/ssh sandbox and be driven by a remote daemon over an
+// authed URL. It is the standalone, out-of-process form of the daemon's
+// in-process local agent-server: one session's workspace (worktree + tmux),
+// exposed over the exact wire the daemon already speaks, behind a bearer token on
+// a TLS listener.
+//
+// It is DARK in this PR: nothing provisions a sandbox to run it and nothing in the
+// daemon drives it yet. Run it by hand and drive it directly to prove the process
+// boundary.
+
+var (
+	agentServerListen  string
+	agentServerRepo    string
+	agentServerTitle   string
+	agentServerProgram string
+	agentServerAutoYes bool
+)
+
+var agentServerCmd = &cobra.Command{
+	Use:   "agent-server",
+	Short: "Run a headless single-workspace agent-server over HTTP/WS+TLS+token",
+	Long: `Run a headless agent-server for exactly one session's workspace, served over
+the same REST + WebSocket protocol the daemon speaks, behind a TLS listener that
+requires a bearer token on every request.
+
+This is the process that will later run inside a docker container or on an ssh
+remote (#1592 Phase 4): a remote daemon dials the authed URL it exposes and
+drives the workspace exactly as it drives a local in-process session. Run it
+directly to reach one workspace over the network.
+
+The listener is always TLS + token (the token must never ride the wire in the
+clear). On startup it prints one JSON line to stdout carrying the bound address,
+the bearer token, and the self-signed cert path/fingerprint to pin. On
+SIGINT/SIGTERM it tears the workspace down (kills tmux, removes the worktree) —
+durability of in-progress work is the driving daemon's job (push the branch
+before shutdown), not this server's.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Initialize(false)
+		defer log.Close()
+
+		repo := agentServerRepo
+		if repo == "" {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			repo = cwd
+		}
+
+		return daemon.RunAgentServer(daemon.AgentServerOptions{
+			ListenAddr: agentServerListen,
+			RepoPath:   repo,
+			Title:      agentServerTitle,
+			Program:    agentServerProgram,
+			AutoYes:    agentServerAutoYes,
+		}, cmd.OutOrStdout())
+	},
+}
+
+func init() {
+	agentServerCmd.Flags().StringVar(&agentServerListen, "listen", "127.0.0.1:0",
+		"TLS TCP bind address (host:port); :0 lets the kernel pick a free port")
+	agentServerCmd.Flags().StringVar(&agentServerRepo, "repo", "",
+		"Repository path the workspace runs against (default: current directory)")
+	agentServerCmd.Flags().StringVar(&agentServerTitle, "title", "",
+		"Session title for the workspace (required)")
+	agentServerCmd.Flags().StringVar(&agentServerProgram, "program", "",
+		"Agent program to run (default: the configured default_program)")
+	agentServerCmd.Flags().BoolVar(&agentServerAutoYes, "auto-yes", false,
+		"Enable the agent-server's AutoYes accept for the workspace")
+	_ = agentServerCmd.MarkFlagRequired("title")
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -320,6 +320,7 @@ func init() {
 	rootCmd.AddCommand(resetCmd)
 	rootCmd.AddCommand(upgradeCmd)
 	rootCmd.AddCommand(daemonCmd)
+	rootCmd.AddCommand(agentServerCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(tokenCmd)
 	rootCmd.AddCommand(api.SessionsCmd)

--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -1,0 +1,417 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/coder/websocket"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/log"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// The headless single-workspace agent-server (#1592 Phase 4 PR1) — the process
+// that will later run INSIDE each docker/ssh sandbox (§1.1). It is the mirror
+// image of the daemon's in-process localAgentServer: where the daemon drives a
+// local session through session.AgentServer directly, this exposes ONE session's
+// AgentServer over the exact HTTP/WS+TLS+token wire the daemon already speaks, so
+// a remote daemon (PR2's remoteAgentServer) can drive it across the process
+// boundary exactly like the in-process one.
+//
+// It is deliberately NOT the orchestrator (§1.1): no task scheduler, no watch
+// supervisor, no multi-session Manager, no disk-state ownership. It owns exactly
+// one live session.AgentServer and exposes it. The workspace is DARK in this PR:
+// nothing provisions a sandbox to run it (PR4/PR5) and nothing in the daemon
+// drives it yet (PR2) — it is a standalone `af agent-server` you run and hit
+// directly.
+//
+// Reuse, not reimplementation: the TLS+token listener (startTCPListener), the
+// auth+CORS gate (withAuth), the WS PTY broker fan-out (servePTYStream), the
+// events plane (serveEvents), the REST envelope dispatch (rpcHandler), and the
+// agentproto wire frames are all the Phase-1–3 seams, unchanged. This file is
+// only the single-workspace glue that binds one AgentServer to those routes.
+
+// headlessServer hosts exactly one session.AgentServer over the daemon's HTTP/WS
+// surface. It is the single-workspace analogue of controlServer: where
+// controlServer resolves an AgentServer out of the multi-session Manager,
+// headlessServer holds the one it owns directly.
+type headlessServer struct {
+	// as is the single workspace's agent-server — the local in-process
+	// implementation over tmux (same runtime as the daemon's local sessions),
+	// exposed here over the wire.
+	as session.AgentServer
+	// title is the workspace's session title, echoed in the startup banner so a
+	// driver knows which id to name on the /v1/sessions/{id}/stream path.
+	title string
+	// events is a private events hub so the /v1/events route upgrades and stays
+	// alive for surface parity with the daemon. A single-workspace server has no
+	// orchestrator mutations to publish, so the plane is deliberately quiet — the
+	// session lifecycle events belong to the daemon that drives this server, not
+	// to the server itself (§1.1: not the orchestrator).
+	events *eventsHub
+}
+
+// AgentServerOptions configures a headless agent-server process.
+type AgentServerOptions struct {
+	// ListenAddr is the TLS TCP bind address (host:port). "127.0.0.1:0" — the
+	// loopback zero-config default — lets the kernel pick a free port, reported
+	// back in the startup banner.
+	ListenAddr string
+	// RepoPath is the git repository the single workspace runs against.
+	RepoPath string
+	// Title is the session title for the single workspace (required).
+	Title string
+	// Program is the agent program to run (empty ⇒ the config default).
+	Program string
+	// AutoYes enables the agent-server's AutoYes accept for the workspace.
+	AutoYes bool
+}
+
+// AgentServerInfo is the machine-readable startup banner the process prints to
+// stdout as one JSON line the instant the listener binds. A driver reads it to
+// learn the concrete bound address (port filled in for :0), the bearer token to
+// present, and the self-signed cert path/fingerprint to TOFU-pin — the same
+// three facts the daemon's tcpListenerInfo carries, surfaced on stdout because
+// the agent-server has no daemon log the operator watches.
+type AgentServerInfo struct {
+	Addr        string `json:"addr"`
+	Token       string `json:"token"`
+	Fingerprint string `json:"fingerprint"`
+	SelfSigned  bool   `json:"self_signed"`
+	CertPath    string `json:"cert_path"`
+	Title       string `json:"title"`
+}
+
+// RunAgentServer builds the single workspace's agent-server, binds the TLS+token
+// listener, prints the startup banner to stdout, and blocks until SIGINT/SIGTERM,
+// at which point it tears the workspace down. It is the process body behind
+// `af agent-server`.
+//
+// The listener is ALWAYS TLS + token here (unlike the daemon, where the TCP
+// listener is off-by-default): the agent-server exists to be reached over the
+// network by a remote daemon, so the bearer token must never ride the wire in the
+// clear. It reuses startTCPListener verbatim — the same cert/token/gate wiring the
+// daemon's `listen_addr` opt-in uses.
+func RunAgentServer(opts AgentServerOptions, stdout io.Writer) error {
+	if opts.Title == "" {
+		return fmt.Errorf("agent-server requires a session title (--title)")
+	}
+	if opts.RepoPath == "" {
+		return fmt.Errorf("agent-server requires a repository path (--repo)")
+	}
+
+	// LoadConfig honors tls_cert/tls_key/cors_allowed_origins/default_program for
+	// a configured host; a sandbox with no config file falls back to defaults.
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		cfg = config.DefaultConfig()
+	}
+	cfg.ListenAddr = opts.ListenAddr
+
+	program := opts.Program
+	if program == "" {
+		program = cfg.DefaultProgram
+	}
+
+	instance, err := session.NewInstance(session.InstanceOptions{
+		Title:   opts.Title,
+		Path:    opts.RepoPath,
+		Program: program,
+		AutoYes: opts.AutoYes,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build workspace instance: %w", err)
+	}
+
+	hs := &headlessServer{
+		as:     instance.AgentServer(),
+		title:  opts.Title,
+		events: newEventsHub(),
+	}
+
+	closeTCP, tcpInfo, err := startTCPListener(hs.newMux(), cfg)
+	if err != nil {
+		return fmt.Errorf("failed to start agent-server listener on %q: %w", opts.ListenAddr, err)
+	}
+
+	info := AgentServerInfo{
+		Addr:        tcpInfo.Addr,
+		Token:       tcpInfo.Token,
+		Fingerprint: tcpInfo.Fingerprint,
+		SelfSigned:  tcpInfo.SelfSigned,
+		CertPath:    resolveCertPath(cfg, tcpInfo.SelfSigned),
+		Title:       opts.Title,
+	}
+	// The startup banner is a single JSON line on stdout — the agent-server's only
+	// channel to hand a driver the address+token+pin, since it runs headless with
+	// no daemon log to read (mirrors tcpListenerInfo's role for the daemon).
+	if data, mErr := json.Marshal(info); mErr == nil {
+		fmt.Fprintln(stdout, string(data))
+	}
+	log.InfoLog.Printf("af agent-server listening on %s (self-signed=%v) for workspace %q", info.Addr, info.SelfSigned, info.Title)
+	log.InfoLog.Printf("  cert fingerprint: %s", info.Fingerprint)
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	// Clean teardown: stop accepting connections, then kill the workspace so no
+	// tmux session or worktree is orphaned. Durability of in-progress work is the
+	// driving daemon's job (archive = push branch, epic §5), not this dark PR's.
+	_ = closeTCP()
+	if err := hs.as.Kill(); err != nil {
+		log.WarningLog.Printf("agent-server: workspace teardown on shutdown: %v", err)
+	}
+	return nil
+}
+
+// resolveCertPath returns the certificate path a client TOFU-pins. For the
+// self-signed default it is the generated cert in the af home; for a user cert it
+// is the configured tls_cert (verified against system roots, so the pin is
+// advisory).
+func resolveCertPath(cfg *config.Config, selfSigned bool) string {
+	if !selfSigned {
+		return cfg.TLSCert
+	}
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, daemonTLSCertFileName)
+}
+
+// newMux builds the single-workspace route table. The control plane mirrors the
+// session.AgentServer interface 1:1 under /v1/agent/* (the contract PR2's
+// remoteAgentServer speaks), and the WS PTY + events planes are served at the
+// SAME paths the daemon serves so a driver reuses the identical client
+// (apiclient.DialStream dials /v1/sessions/{id}/stream). Every route is wrapped
+// in the token gate by startTCPListener, exactly like the daemon mux.
+func (hs *headlessServer) newMux() *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// Liveness alias, matching the daemon's GET /v1/health.
+	mux.HandleFunc("GET /v1/health", hs.healthHandler)
+
+	// Control REST — the session.AgentServer interface over the shared envelope
+	// dispatch (rpcHandler: POST-only, {data,error} envelope, 400/413/500 mapping).
+	mux.HandleFunc("/v1/agent/provision", rpcHandler(hs.Provision))
+	mux.HandleFunc("/v1/agent/launch", rpcHandler(hs.Launch))
+	mux.HandleFunc("/v1/agent/expose", rpcHandler(hs.Expose))
+	mux.HandleFunc("/v1/agent/snapshot", rpcHandler(hs.Snapshot))
+	mux.HandleFunc("/v1/agent/preview", rpcHandler(hs.Preview))
+	mux.HandleFunc("/v1/agent/alive", rpcHandler(hs.Alive))
+	mux.HandleFunc("/v1/agent/send-prompt", rpcHandler(hs.SendPrompt))
+	mux.HandleFunc("/v1/agent/tap-enter", rpcHandler(hs.TapEnter))
+	mux.HandleFunc("/v1/agent/kill", rpcHandler(hs.Kill))
+
+	// WS data plane — same paths, same broker, same wire as the daemon (§1.1: all
+	// over the same routes the daemon mux already serves).
+	mux.HandleFunc("GET /v1/sessions/{id}/stream", hs.streamHandler)
+	mux.HandleFunc("GET /v1/sessions/{id}/stream-info", hs.streamInfoHandler)
+	mux.HandleFunc("GET /v1/events", hs.eventsHandler)
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		writeHTTPError(w, http.StatusNotFound, fmt.Errorf("unknown route %q", r.URL.Path))
+	})
+	return mux
+}
+
+// healthHandler answers GET /v1/health with a trivial liveness envelope.
+func (hs *headlessServer) healthHandler(w http.ResponseWriter, r *http.Request) {
+	writeHTTPSuccess(w, map[string]bool{"ok": true})
+}
+
+// --- control REST: 1:1 mirror of session.AgentServer -----------------------
+
+// agentLifecycleRequest carries the firstTimeSetup flag Provision/Launch take: a
+// fresh create materializes the worktree and spawns; a restore reconnects.
+type agentLifecycleRequest struct {
+	FirstTimeSetup bool `json:"first_time_setup"`
+}
+
+// agentOKResponse is the acknowledgement for the no-return interface methods.
+type agentOKResponse struct {
+	OK bool `json:"ok"`
+}
+
+func (hs *headlessServer) Provision(req agentLifecycleRequest, resp *agentOKResponse) error {
+	if err := hs.as.Provision(req.FirstTimeSetup); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+func (hs *headlessServer) Launch(req agentLifecycleRequest, resp *agentOKResponse) error {
+	if err := hs.as.Launch(req.FirstTimeSetup); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+// agentExposeResponse is StreamEndpoint over the wire — where this session's data
+// plane is reachable. For the local runtime it is Local=true with an empty URL;
+// the driver then dials the WS stream on this same listener.
+type agentExposeResponse struct {
+	Local bool   `json:"local"`
+	URL   string `json:"url"`
+}
+
+func (hs *headlessServer) Expose(_ struct{}, resp *agentExposeResponse) error {
+	ep, err := hs.as.Expose()
+	if err != nil {
+		return err
+	}
+	resp.Local = ep.Local
+	resp.URL = ep.URL
+	return nil
+}
+
+// agentSnapshotResponse is Observation over the wire — the non-interactive poll
+// the daemon reads each tick.
+type agentSnapshotResponse struct {
+	Updated   bool   `json:"updated"`
+	HasPrompt bool   `json:"has_prompt"`
+	Content   string `json:"content"`
+}
+
+func (hs *headlessServer) Snapshot(_ struct{}, resp *agentSnapshotResponse) error {
+	obs, err := hs.as.Snapshot()
+	if err != nil {
+		return err
+	}
+	resp.Updated = obs.Updated
+	resp.HasPrompt = obs.HasPrompt
+	resp.Content = obs.Content
+	return nil
+}
+
+// agentPreviewRequest selects tab Tab's content; Full=true returns the entire
+// scrollback history, false the visible screen.
+type agentPreviewRequest struct {
+	Tab  int  `json:"tab"`
+	Full bool `json:"full"`
+}
+
+type agentPreviewResponse struct {
+	Content string `json:"content"`
+}
+
+func (hs *headlessServer) Preview(req agentPreviewRequest, resp *agentPreviewResponse) error {
+	content, err := hs.as.Preview(req.Tab, req.Full)
+	if err != nil {
+		return err
+	}
+	resp.Content = content
+	return nil
+}
+
+type agentAliveResponse struct {
+	Alive bool `json:"alive"`
+}
+
+func (hs *headlessServer) Alive(_ struct{}, resp *agentAliveResponse) error {
+	resp.Alive = hs.as.Alive()
+	return nil
+}
+
+type agentSendPromptRequest struct {
+	Prompt string `json:"prompt"`
+}
+
+func (hs *headlessServer) SendPrompt(req agentSendPromptRequest, resp *agentOKResponse) error {
+	if err := hs.as.SendPrompt(req.Prompt); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+func (hs *headlessServer) TapEnter(_ struct{}, resp *agentOKResponse) error {
+	hs.as.TapEnter()
+	resp.OK = true
+	return nil
+}
+
+func (hs *headlessServer) Kill(_ struct{}, resp *agentOKResponse) error {
+	if err := hs.as.Kill(); err != nil {
+		return err
+	}
+	resp.OK = true
+	return nil
+}
+
+// --- WS data plane: single-workspace variants of the daemon handlers -------
+
+// streamHandler upgrades GET /v1/sessions/{id}/stream to a WebSocket and fans the
+// single workspace's PTY stream. It is the controlServer.streamHandler shape with
+// the Manager lookup replaced by the one AgentServer this server owns — the id is
+// vestigial (there is exactly one workspace) but the path matches the daemon so a
+// driver reuses the identical client. Subscribe happens BEFORE the upgrade so a
+// bad cursor or an un-launched workspace returns an HTTP error envelope.
+func (hs *headlessServer) streamHandler(w http.ResponseWriter, r *http.Request) {
+	since, err := parseSince(r.URL.Query().Get("since"))
+	if err != nil {
+		writeHTTPError(w, http.StatusBadRequest, err)
+		return
+	}
+	tab, err := parseTab(r.URL.Query().Get("tab"))
+	if err != nil {
+		writeHTTPError(w, http.StatusBadRequest, err)
+		return
+	}
+	sub, err := hs.as.Subscribe(tab, since)
+	if err != nil {
+		writeHTTPError(w, http.StatusInternalServerError, err)
+		return
+	}
+	w.Header().Set(streamSeqHeader, strconv.FormatUint(uint64(sub.Seq()), 10))
+	// The token gate (withAuth) and CORS allow-list already authenticated the
+	// handshake; InsecureSkipVerify defers the Origin check to that gate, exactly
+	// as the daemon's streamHandler does.
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+	if err != nil {
+		_ = sub.Close()
+		return
+	}
+	servePTYStream(hs.as, tab, sub, conn)
+}
+
+// streamInfoHandler answers GET /v1/sessions/{id}/stream-info with where the
+// stream is reachable. For the local runtime that is the relative stream path on
+// this same listener.
+func (hs *headlessServer) streamInfoHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	ep, err := hs.as.Expose()
+	if err != nil {
+		writeHTTPError(w, http.StatusInternalServerError, err)
+		return
+	}
+	resp := streamInfoResponse{Local: ep.Local}
+	if ep.URL != "" {
+		resp.URL = ep.URL
+	} else {
+		resp.URL = localStreamPath(id, "")
+	}
+	writeHTTPSuccess(w, resp)
+}
+
+// eventsHandler upgrades GET /v1/events for surface parity with the daemon. The
+// hub is quiet on a single-workspace server (no orchestrator mutations), so this
+// proves the plane upgrades and stays alive under the token gate rather than
+// carrying session lifecycle events.
+func (hs *headlessServer) eventsHandler(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+	if err != nil {
+		return
+	}
+	serveEvents(hs.events, conn)
+}

--- a/daemon/agentserver_headless_test.go
+++ b/daemon/agentserver_headless_test.go
@@ -1,0 +1,240 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeHeadlessAgentServer is an in-memory session.AgentServer for the headless
+// wiring test: it records the control calls, returns canned observations, and
+// backs Subscribe/Input with a simple channel fan-out so the WS PTY path can be
+// exercised end to end without tmux. It lets the headless HTTP/WS surface be
+// proven fast and anywhere (no real session, no daemon spawn).
+type fakeHeadlessAgentServer struct {
+	mu           sync.Mutex
+	provisioned  bool
+	launched     bool
+	killed       bool
+	lastPrompt   string
+	tapped       int
+	subs         map[*fakeSub]struct{}
+	snapshotText string
+}
+
+func newFakeHeadlessAgentServer() *fakeHeadlessAgentServer {
+	return &fakeHeadlessAgentServer{subs: map[*fakeSub]struct{}{}, snapshotText: "❯ ready"}
+}
+
+var _ session.AgentServer = (*fakeHeadlessAgentServer)(nil)
+
+func (f *fakeHeadlessAgentServer) Provision(bool) error { f.set(&f.provisioned); return nil }
+func (f *fakeHeadlessAgentServer) Launch(bool) error    { f.set(&f.launched); return nil }
+func (f *fakeHeadlessAgentServer) Expose() (session.StreamEndpoint, error) {
+	return session.StreamEndpoint{Local: true}, nil
+}
+func (f *fakeHeadlessAgentServer) Snapshot() (session.Observation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return session.Observation{Updated: true, HasPrompt: false, Content: f.snapshotText}, nil
+}
+func (f *fakeHeadlessAgentServer) Preview(int, bool) (string, error) { return "preview-body", nil }
+func (f *fakeHeadlessAgentServer) Alive() bool                       { return true }
+func (f *fakeHeadlessAgentServer) SendPrompt(p string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastPrompt = p
+	return nil
+}
+func (f *fakeHeadlessAgentServer) TapEnter() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.tapped++
+}
+
+func (f *fakeHeadlessAgentServer) Subscribe(_ int, _ session.Seq) (session.PTYSubscription, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s := &fakeSub{ch: make(chan session.PTYEvent, 16)}
+	f.subs[s] = struct{}{}
+	return s, nil
+}
+
+func (f *fakeHeadlessAgentServer) Input(_ int, b []byte) error {
+	// Echo the input to every subscriber as PTY output, so a WS client that types
+	// sees its bytes come back over the stream (proving the round trip).
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for s := range f.subs {
+		select {
+		case s.ch <- session.PTYEvent{Kind: session.PTYData, Data: append([]byte("echo:"), b...)}:
+		default:
+		}
+	}
+	return nil
+}
+
+func (f *fakeHeadlessAgentServer) Resize(_ int, _, _ uint16) error { return nil }
+
+func (f *fakeHeadlessAgentServer) Kill() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.killed = true
+	for s := range f.subs {
+		close(s.ch)
+		delete(f.subs, s)
+	}
+	return nil
+}
+
+func (f *fakeHeadlessAgentServer) set(b *bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	*b = true
+}
+
+// fakeSub is a channel-backed PTYSubscription for the fake agent-server.
+type fakeSub struct {
+	ch chan session.PTYEvent
+}
+
+func (s *fakeSub) NextEvent(ctx context.Context) (session.PTYEvent, error) {
+	select {
+	case <-ctx.Done():
+		return session.PTYEvent{}, ctx.Err()
+	case ev, ok := <-s.ch:
+		if !ok {
+			return session.PTYEvent{}, io.EOF
+		}
+		return ev, nil
+	}
+}
+func (s *fakeSub) Seq() session.Seq { return 0 }
+func (s *fakeSub) Close() error     { return nil }
+
+// TestHeadlessAgentServer_TLSTokenRoundTrip drives the headless agent-server's
+// wiring in-process over a REAL loopback TLS+token listener: the control REST
+// mirror of session.AgentServer and the WS PTY stream, both behind the bearer
+// token, plus a missing-token rejection. It proves the routes are wired to the
+// single AgentServer and gated exactly like the daemon surface — without a real
+// session or a spawned daemon.
+func TestHeadlessAgentServer_TLSTokenRoundTrip(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	fake := newFakeHeadlessAgentServer()
+	hs := &headlessServer{as: fake, title: "probe", events: newEventsHub()}
+
+	cfg := config.DefaultConfig()
+	cfg.ListenAddr = "127.0.0.1:0"
+	closeTCP, info, err := startTCPListener(hs.newMux(), cfg)
+	require.NoError(t, err)
+	defer func() { _ = closeTCP() }()
+	require.NotEmpty(t, info.Token)
+
+	dir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: pinnedTLSConfig(t, dir+"/"+daemonTLSCertFileName)},
+	}
+	baseURL := "https://" + info.Addr
+
+	post := func(path, body string) (*http.Response, error) {
+		req, rerr := http.NewRequest(http.MethodPost, baseURL+path, strings.NewReader(body))
+		require.NoError(t, rerr)
+		req.Header.Set("Authorization", "Bearer "+info.Token)
+		req.Header.Set("Content-Type", "application/json")
+		return client.Do(req)
+	}
+	// decodeData decodes the {data,error} envelope's data member into dst.
+	decodeData := func(resp *http.Response, dst any) {
+		var env struct {
+			Data  json.RawMessage `json:"data"`
+			Error *struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&env))
+		_ = resp.Body.Close()
+		require.Nil(t, env.Error)
+		if dst != nil {
+			require.NoError(t, json.Unmarshal(env.Data, dst))
+		}
+	}
+
+	// --- control REST: provision + launch (create the session) --------------
+	resp, err := post("/v1/agent/provision", `{"first_time_setup":true}`)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	decodeData(resp, nil)
+	resp, err = post("/v1/agent/launch", `{"first_time_setup":true}`)
+	require.NoError(t, err)
+	decodeData(resp, nil)
+	require.True(t, fake.provisioned)
+	require.True(t, fake.launched)
+
+	// --- control REST: snapshot ---------------------------------------------
+	resp, err = post("/v1/agent/snapshot", ``)
+	require.NoError(t, err)
+	var snap agentSnapshotResponse
+	decodeData(resp, &snap)
+	require.Equal(t, "❯ ready", snap.Content)
+	require.True(t, snap.Updated)
+
+	// --- control REST: alive / send-prompt / tap-enter ----------------------
+	resp, err = post("/v1/agent/alive", ``)
+	require.NoError(t, err)
+	var alive agentAliveResponse
+	decodeData(resp, &alive)
+	require.True(t, alive.Alive)
+
+	resp, err = post("/v1/agent/send-prompt", `{"prompt":"hello world"}`)
+	require.NoError(t, err)
+	decodeData(resp, nil)
+	require.Equal(t, "hello world", fake.lastPrompt)
+
+	// --- REST: missing token → 401 ------------------------------------------
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/agent/snapshot", nil)
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	// --- WS PTY stream: subscribe, type input, see it echoed back -----------
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx,
+		"wss://"+info.Addr+"/v1/sessions/probe/stream?"+agentproto.AccessTokenQueryParam+"="+info.Token,
+		&websocket.DialOptions{HTTPClient: client})
+	require.NoError(t, err, "authorized WS handshake must upgrade")
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
+
+	require.NoError(t, agentproto.WriteFrame(ctx, conn, agentproto.InputFrame([]byte("typed\n"))))
+	msg, err := agentproto.ReadMessage(ctx, conn)
+	require.NoError(t, err)
+	require.True(t, msg.Binary)
+	require.Equal(t, agentproto.OpPTYOut, msg.Frame.Op)
+	require.Equal(t, "echo:typed\n", string(msg.Frame.Data))
+
+	// --- WS PTY stream: no token → handshake rejected -----------------------
+	badCtx, badCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer badCancel()
+	badConn, _, err := websocket.Dial(badCtx, "wss://"+info.Addr+"/v1/sessions/probe/stream",
+		&websocket.DialOptions{HTTPClient: client})
+	if badConn != nil {
+		_ = badConn.Close(websocket.StatusNormalClosure, "")
+	}
+	require.Error(t, err, "unauthenticated WS handshake must be rejected")
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,6 +9,7 @@ Run `af <command> --help` for the same information at the terminal. For a narrat
 ## Commands
 
 - [`af`](#af) — Agent Factory - Manage multiple AI agents like Claude Code, Aider, Codex, Gemini, and Amp.
+- [`af agent-server`](#af-agent-server) — Run a headless single-workspace agent-server over HTTP/WS+TLS+token
 - [`af api`](#af-api) — Show the daemon-hosted HTTP/JSON API catalog
 - [`af bug-report`](#af-bug-report) — Bundle logs, versions, tasks, and redacted state for a bug report
 - [`af completion`](#af-completion) — Generate the autocompletion script for the specified shell
@@ -78,6 +79,7 @@ af [flags]
 
 **Subcommands**
 
+- [`af agent-server`](#af-agent-server) — Run a headless single-workspace agent-server over HTTP/WS+TLS+token
 - [`af api`](#af-api) — Show the daemon-hosted HTTP/JSON API catalog
 - [`af bug-report`](#af-bug-report) — Bundle logs, versions, tasks, and redacted state for a bug report
 - [`af completion`](#af-completion) — Generate the autocompletion script for the specified shell
@@ -100,6 +102,48 @@ af [flags]
 | `-y`, `--autoyes` |  | [experimental] If enabled, all instances will automatically accept prompts |
 | `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `-p`, `--program` | `string` | Program to run in new instances (one of: claude, codex, aider, gemini, amp) |
+| `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
+| `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
+
+## af agent-server
+
+Run a headless single-workspace agent-server over HTTP/WS+TLS+token
+
+Run a headless agent-server for exactly one session's workspace, served over
+the same REST + WebSocket protocol the daemon speaks, behind a TLS listener that
+requires a bearer token on every request.
+
+This is the process that will later run inside a docker container or on an ssh
+remote (#1592 Phase 4): a remote daemon dials the authed URL it exposes and
+drives the workspace exactly as it drives a local in-process session. Run it
+directly to reach one workspace over the network.
+
+The listener is always TLS + token (the token must never ride the wire in the
+clear). On startup it prints one JSON line to stdout carrying the bound address,
+the bearer token, and the self-signed cert path/fingerprint to pin. On
+SIGINT/SIGTERM it tears the workspace down (kills tmux, removes the worktree) —
+durability of in-progress work is the driving daemon's job (push the branch
+before shutdown), not this server's.
+
+```
+af agent-server [flags]
+```
+
+**Flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--auto-yes` |  | Enable the agent-server's AutoYes accept for the workspace |
+| `--listen` | `string` | TLS TCP bind address (host:port); :0 lets the kernel pick a free port (default `127.0.0.1:0`) |
+| `--program` | `string` | Agent program to run (default: the configured default_program) |
+| `--repo` | `string` | Repository path the workspace runs against (default: current directory) |
+| `--title` | `string` | Session title for the workspace (required) |
+
+**Global flags**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--daemon-url` | `string` | Target a REMOTE daemon at this wss:// or https:// URL instead of the local unix socket (env: AF_DAEMON_URL). Requires --token. |
 | `--tls-fingerprint` | `string` | Pinned SHA-256 fingerprint of a remote daemon's self-signed TLS cert (env: AF_DAEMON_TLS_FINGERPRINT); omit for a CA-signed cert. From `af token show`. |
 | `--token` | `string` | Bearer token for a remote daemon set with --daemon-url (env: AF_DAEMON_TOKEN). Get it with `af token show` on the daemon host. |
 

--- a/integration/agent_server_test.go
+++ b/integration/agent_server_test.go
@@ -1,0 +1,258 @@
+package integration_test
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// agentServerBanner mirrors daemon.AgentServerInfo — the JSON startup line the
+// `af agent-server` process prints to stdout the instant its listener binds.
+type agentServerBanner struct {
+	Addr        string `json:"addr"`
+	Token       string `json:"token"`
+	Fingerprint string `json:"fingerprint"`
+	SelfSigned  bool   `json:"self_signed"`
+	CertPath    string `json:"cert_path"`
+	Title       string `json:"title"`
+}
+
+// TestAgentServerRoundTrip is the #1592 Phase 4 PR1 payoff: it starts a REAL,
+// out-of-process `af agent-server` on a loopback TLS+token listener against a real
+// git repo + tmux session, then drives it directly over HTTPS/WSS presenting the
+// token — provisioning + launching the workspace, subscribing to the PTY stream,
+// typing input and seeing the pane echo it, and reading a snapshot. This proves
+// the agent-server is a real out-of-process runtime a remote daemon can drive over
+// the wire exactly like the in-process local one (PR2), across the process
+// boundary the whole phase is built on.
+//
+// Run it in the container fence: make agent-server-roundtrip-container.
+func TestAgentServerRoundTrip(t *testing.T) {
+	requireTool(t, "git")
+	requireTool(t, "tmux")
+	testguard.IsolateTmux(t)
+
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	// The fake agent pane runs `cat` (echoes input) behind a wrapper that prints a
+	// ready prompt and swallows the agent-specific flags injectSystemPrompt adds —
+	// the same harness the WS PTY broker round-trip uses.
+	wrapper := home + "/fake-agent.sh"
+	writeFile(t, wrapper, "#!/bin/sh\nprintf '❯ '\nexec cat\n", 0755)
+	writeConfigWithProgramPath(t, home, wrapper)
+
+	bin := buildBinary(t)
+	repo := setupGitRepo(t)
+
+	// --- start the real out-of-process agent-server -------------------------
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, "agent-server",
+		"--listen", "127.0.0.1:0", "--repo", repo, "--title", "probe", "--program", tmux.ProgramClaude)
+	cmd.Env = append(os.Environ(), "AGENT_FACTORY_HOME="+home, "TERM=xterm")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start agent-server: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		done := make(chan struct{})
+		go func() { _, _ = cmd.Process.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			_ = cmd.Process.Kill()
+		}
+		// Backstop: sweep the workspace tmux session if teardown did not.
+		if name := tmuxNameForProbe(); name != "" && tmuxSessionExists(name) {
+			_ = exec.Command("tmux", "kill-session", "-t="+name).Run()
+		}
+	})
+
+	// --- read the machine-readable startup banner ---------------------------
+	banner := readAgentServerBanner(t, stdout)
+	if banner.Addr == "" || banner.Token == "" || banner.CertPath == "" {
+		t.Fatalf("incomplete startup banner: %+v", banner)
+	}
+	if !strings.HasPrefix(banner.Fingerprint, "sha256:") {
+		t.Fatalf("expected a sha256 cert fingerprint, got %q", banner.Fingerprint)
+	}
+
+	t.Logf("agent-server up: addr=%s self_signed=%v fingerprint=%s title=%s (token %d bytes)",
+		banner.Addr, banner.SelfSigned, banner.Fingerprint, banner.Title, len(banner.Token))
+
+	client := pinnedClient(t, banner.CertPath)
+	base := "https://" + banner.Addr
+
+	post := func(path, body string) map[string]any {
+		t.Helper()
+		req, rerr := http.NewRequest(http.MethodPost, base+path, strings.NewReader(body))
+		if rerr != nil {
+			t.Fatalf("new request %s: %v", path, rerr)
+		}
+		req.Header.Set("Authorization", "Bearer "+banner.Token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, rerr := client.Do(req)
+		if rerr != nil {
+			t.Fatalf("POST %s: %v", path, rerr)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("POST %s: status %d: %s", path, resp.StatusCode, body)
+		}
+		var env struct {
+			Data  map[string]any `json:"data"`
+			Error *struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+			t.Fatalf("decode %s: %v", path, err)
+		}
+		if env.Error != nil {
+			t.Fatalf("POST %s returned error: %s", path, env.Error.Message)
+		}
+		return env.Data
+	}
+
+	// --- create the session in the agent-server's runtime -------------------
+	post("/v1/agent/provision", `{"first_time_setup":true}`)
+	post("/v1/agent/launch", `{"first_time_setup":true}`)
+
+	// --- subscribe to the PTY stream over WSS -------------------------------
+	wsCtx, wsCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer wsCancel()
+	conn, _, err := websocket.Dial(wsCtx,
+		"wss://"+banner.Addr+"/v1/sessions/probe/stream?"+agentproto.AccessTokenQueryParam+"="+banner.Token,
+		&websocket.DialOptions{HTTPClient: client})
+	if err != nil {
+		t.Fatalf("dial PTY stream: %v", err)
+	}
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
+	conn.SetReadLimit(1 << 20)
+
+	// Accumulate PTY_OUT bytes in a read pump.
+	var (
+		pumpMu sync.Mutex
+		pump   strings.Builder
+	)
+	go func() {
+		for {
+			msg, rerr := agentproto.ReadMessage(wsCtx, conn)
+			if rerr != nil {
+				return
+			}
+			if msg.Binary && msg.Frame.Op == agentproto.OpPTYOut {
+				pumpMu.Lock()
+				pump.Write(msg.Frame.Data)
+				pumpMu.Unlock()
+			}
+		}
+	}()
+	output := func() string {
+		pumpMu.Lock()
+		defer pumpMu.Unlock()
+		return pump.String()
+	}
+
+	// --- send input; the `cat` pane echoes it back over the stream ----------
+	if err := agentproto.WriteFrame(wsCtx, conn, agentproto.InputFrame([]byte("hello-agent-server\n"))); err != nil {
+		t.Fatalf("send input: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "PTY stream echoes typed input", func() bool {
+		return strings.Contains(output(), "hello-agent-server")
+	})
+	t.Logf("PTY stream echoed typed input over WSS: %q", strings.TrimSpace(output()))
+
+	// --- read a snapshot over the control REST ------------------------------
+	snap := post("/v1/agent/snapshot", ``)
+	content, _ := snap["content"].(string)
+	if !strings.Contains(content, "hello-agent-server") {
+		t.Fatalf("snapshot content did not reflect the typed input: %q", content)
+	}
+	t.Logf("snapshot over control REST reflects the pane: %q", strings.TrimSpace(content))
+
+	// --- alive reports the workspace is running -----------------------------
+	alive := post("/v1/agent/alive", ``)
+	if a, _ := alive["alive"].(bool); !a {
+		t.Fatalf("expected the workspace to be alive, got %+v", alive)
+	}
+}
+
+// readAgentServerBanner reads the first stdout line and decodes it as the JSON
+// startup banner, then drains the rest of stdout so the pipe never blocks the
+// child.
+func readAgentServerBanner(t *testing.T, stdout io.Reader) agentServerBanner {
+	t.Helper()
+	reader := bufio.NewReader(stdout)
+	type result struct {
+		line string
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		line, err := reader.ReadString('\n')
+		ch <- result{line: line, err: err}
+	}()
+	var line string
+	select {
+	case r := <-ch:
+		if r.err != nil && r.line == "" {
+			t.Fatalf("read startup banner: %v", r.err)
+		}
+		line = r.line
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the agent-server startup banner")
+	}
+	go func() { _, _ = io.Copy(io.Discard, reader) }()
+
+	var banner agentServerBanner
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &banner); err != nil {
+		t.Fatalf("decode startup banner %q: %v", line, err)
+	}
+	return banner
+}
+
+// pinnedClient builds an HTTPS client that trusts ONLY the agent-server's
+// self-signed cert (TOFU pin), mirroring what a remote daemon does.
+func pinnedClient(t *testing.T, certPath string) *http.Client {
+	t.Helper()
+	pem, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert %s: %v", certPath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		t.Fatalf("load cert %s into pool", certPath)
+	}
+	return &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}},
+	}
+}
+
+// tmuxNameForProbe derives the sanitized tmux session name for the "probe"
+// workspace so cleanup can sweep it if the agent-server's own teardown did not.
+func tmuxNameForProbe() string {
+	return tmux.NewTmuxSessionForRepo("probe", "", tmux.ProgramClaude).SanitizedName()
+}


### PR DESCRIPTION
## What

Adds **`af agent-server`** — a headless, single-workspace agent-server that runs one session's runtime (worktree + tmux, the same local `AgentServer` the daemon drives in-process) STANDALONE over the daemon's HTTP/WS protocol, bound to a **mandatory TLS + bearer-token** listener.

This is the process that will later run **INSIDE** each docker/ssh sandbox (#1592 Phase 4) and be driven by a remote daemon over an authed URL — the OpenHands *provision-and-expose* model. PR1 proves it at the **process boundary**: a real out-of-process `af agent-server` you can start and drive directly over `wss://`.

**DARK / additive:** nothing provisions a sandbox to run it (PR4/PR5) and nothing in the daemon drives it yet (PR2). No existing flow changes.

## The subcommand

```
af agent-server --listen 127.0.0.1:0 --repo <path> --title <name> [--program <p>] [--auto-yes]
```

The listener is **always** TLS+token (the token must never ride the wire in the clear — unlike the daemon's off-by-default TCP listener). On startup it prints one JSON line to stdout — `{addr, token, fingerprint, self_signed, cert_path, title}` — the agent-server's only channel to hand a driver the address + token + pin, since it runs headless with no daemon log. On SIGINT/SIGTERM it tears the workspace down.

## What it exposes

Single workspace, **minus the orchestrator** (no scheduler / task store / multi-session `Manager` / disk-state ownership, per plan §1.1):

- **Control REST** mirroring `session.AgentServer` 1:1 under `/v1/agent/*` — `provision`, `launch`, `expose`, `snapshot`, `preview`, `alive`, `send-prompt`, `tap-enter`, `kill` — over the shared `{data,error}` envelope dispatch. This is the contract PR2's `remoteAgentServer` HTTP/WS client will speak.
- **WS PTY stream** at the **same paths the daemon serves** (`/v1/sessions/{id}/stream`, `stream-info`) so a driver reuses the identical client (`apiclient.DialStream`), plus `/v1/events` for surface parity (quiet on a single-workspace server — lifecycle events belong to the driving daemon).

## Reuse of the Phase 1-3 seams (not reimplementation)

`session.AgentServer` interface, `agentproto` wire frames, `withAuth` token+CORS gate, `ResolveTLSMaterial`, the token material, `startTCPListener`, the `servePTYStream` broker fan-out, `serveEvents`, and `rpcHandler` are **all unchanged**. `daemon/agentserver_headless.go` is only the single-workspace glue binding one `AgentServer` to those routes — the mirror image of the daemon's in-process `localAgentServer`.

## Out-of-process drive proof

`TestAgentServerRoundTrip` starts a **real `af agent-server` subprocess** on a loopback TLS+token listener against a real git repo + tmux session, then drives it over HTTPS/WSS presenting the token:

```
agent-server up: addr=127.0.0.1:39595 self_signed=true fingerprint=sha256:60b0d1ed…dd59 title=probe (token 43 bytes)
PTY stream echoed typed input over WSS: "hello-agent-server\r\nhello-agent-server"
snapshot over control REST reflects the pane: "❯ hello-agent-server\nhello-agent-server"
--- PASS: TestAgentServerRoundTrip (1.02s)
```

— provision + launch the workspace, subscribe to the PTY stream, type input and see the `cat` pane echo it back, read a snapshot that reflects the pane, confirm alive. Run it with `make agent-server-roundtrip-container`.

A fast in-process daemon test (`TestHeadlessAgentServer_TLSTokenRoundTrip`, fake `AgentServer` over real loopback TLS) covers the REST/WS wiring plus the **missing-token → 401 / handshake rejection**, and runs anywhere in `make test-container`.

## Gates

- `gofmt -l .` / `golangci-lint --fast` / `deadcode -test ./...` / `scripts/lint-file-length.sh` — clean
- `go build ./...` — clean
- `make test-container` — all packages green
- `scripts/gen-docs.sh` — regenerated, committed (`docs/reference/cli.md`)
- `make tui-driver-selftest` — 25/25 (unaffected)

Link #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)