### PR TITLE
feat(session): remoteAgentServer — daemon drives an out-of-process agent-server over HTTP/WS (#1592 Phase 4 PR2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # See docs/container-testing.md.
 
 .PHONY: test-container remote-roundtrip-container ws-pty-roundtrip-container \
-	agent-server-roundtrip-container \
+	agent-server-roundtrip-container remote-agent-server-roundtrip-container \
 	playtest-container playtest-container-detached tui-driver tui-driver-selftest \
 	testbox-image lint-file-length docs
 
@@ -47,6 +47,14 @@ ws-pty-roundtrip-container:
 # same container fence (a real tmux server) as the full suite.
 agent-server-roundtrip-container:
 	scripts/testbox.sh test ./integration -run TestAgentServerRoundTrip
+
+# Focused remote agent-server harness (#1592 Phase 4 PR2 — the de-risk): starts a
+# REAL out-of-process `af agent-server` on a loopback TLS+token listener and drives
+# it through the daemon-side session.remoteAgentServer HTTP/WS client — the full
+# AgentServer surface (provision/launch/subscribe/input/snapshot/preview/kill)
+# across the process boundary — inside the same container fence as the full suite.
+remote-agent-server-roundtrip-container:
+	scripts/testbox.sh test ./integration -run TestRemoteAgentServerRoundTrip
 
 # Interactive TUI play-test sandbox: builds af inside, scaffolds a
 # throwaway AF home + mock project repo, drops you in a shell with a

--- a/agentproto/tlspin.go
+++ b/agentproto/tlspin.go
@@ -1,0 +1,96 @@
+package agentproto
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// TLS pinning is part of the wire-auth material (§4.4, alongside the bearer
+// token above): a client reaching an `af` TLS listener — a remote daemon
+// (apiclient, #1592 Phase 3) or a remote agent-server (session, #1592 Phase 4) —
+// either pins the listener's self-signed cert by SHA-256 fingerprint (TOFU) or,
+// when no fingerprint is given, verifies a real CA cert against the system trust
+// store. Both clients dial the same kind of listener with the same auth, so the
+// pin logic lives here as ONE source of truth rather than duplicated per client.
+//
+// TLS is MANDATORY on those listeners (the bearer token would ride the wire in
+// the clear otherwise) and verification is NEVER skipped: the pin REPLACES the
+// default CA-chain + hostname check with a stronger exact-fingerprint match, so
+// connecting by IP or through a tunnel works despite the self-signed cert's SAN
+// while a substituted cert is refused.
+
+// PinnedTLSConfig builds the client TLS config for a remote `af` TLS listener.
+// With a fingerprint it pins the leaf cert's SHA-256 (TOFU): the default CA-chain
+// + hostname check is REPLACED — not skipped — by a VerifyPeerCertificate
+// callback that requires an exact fingerprint match, so an IP/tunnel connection
+// to the pinned identity works while a substituted cert fails the handshake.
+// Without a fingerprint the listener must present a cert that chains to a system
+// root (a real CA cert), verified normally.
+//
+// Pinning a bare SHA-256 (a hash, not the cert) is only expressible in Go by
+// taking over verification with a callback; the standard-library idiom for that
+// pairs the callback with InsecureSkipVerify (below) so the callback is the SOLE
+// arbiter. The connection is never actually unverified — an unmatched cert fails
+// the handshake.
+func PinnedTLSConfig(fingerprint string) (*tls.Config, error) {
+	if fingerprint == "" {
+		// CA-cert path: standard system-root verification, TLS 1.2 floor.
+		return &tls.Config{MinVersion: tls.VersionTLS12}, nil
+	}
+	want, err := NormalizeFingerprint(fingerprint)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		// The default CA-chain + hostname check is handed off to the pin below —
+		// NOT skipped. It cannot validate a self-signed cert, and its SAN check
+		// would wrongly reject a legitimate IP/tunnel connection to the pinned
+		// identity; VerifyPeerCertificate enforces the stronger fingerprint match
+		// on every handshake instead, so an unmatched cert still fails.
+		InsecureSkipVerify: true,
+		// VerifyPeerCertificate is the sole arbiter: it fails the handshake unless
+		// the leaf's SHA-256 exactly matches the pin. rawCerts[0] is the leaf DER
+		// — the same bytes CertFingerprint hashes — so the comparison is
+		// apples-to-apples. Hostname/SAN is deliberately not checked (§1.2).
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			if len(rawCerts) == 0 {
+				return fmt.Errorf("remote host presented no TLS certificate")
+			}
+			got := CertFingerprint(rawCerts[0])
+			if got != want {
+				return fmt.Errorf("TLS fingerprint mismatch: pinned sha256:%s but host presented sha256:%s "+
+					"(wrong host, or the cert was regenerated — re-check the fingerprint on the host)", want, got)
+			}
+			return nil
+		},
+	}, nil
+}
+
+// NormalizeFingerprint canonicalizes a user-supplied pin to bare lowercase hex.
+// It accepts the `sha256:<hex>` form the daemon/agent-server print, plain hex,
+// and colon- or space-separated hex, and requires exactly 32 bytes (a SHA-256).
+func NormalizeFingerprint(fingerprint string) (string, error) {
+	s := strings.TrimSpace(fingerprint)
+	s = strings.TrimPrefix(strings.ToLower(s), "sha256:")
+	s = strings.NewReplacer(":", "", " ", "").Replace(s)
+	if len(s) != sha256.Size*2 {
+		return "", fmt.Errorf("invalid TLS fingerprint %q: expected a SHA-256 hex string (optionally sha256:-prefixed)", fingerprint)
+	}
+	if _, err := hex.DecodeString(s); err != nil {
+		return "", fmt.Errorf("invalid TLS fingerprint %q: not hexadecimal: %w", fingerprint, err)
+	}
+	return s, nil
+}
+
+// CertFingerprint returns the lowercase-hex SHA-256 of a DER-encoded certificate,
+// matching the daemon's `sha256:<hex>` banner form minus the prefix (the daemon
+// hashes the same DER bytes: cs.PeerCertificates[0].Raw == the leaf DER).
+func CertFingerprint(der []byte) string {
+	sum := sha256.Sum256(der)
+	return hex.EncodeToString(sum[:])
+}

--- a/agentproto/tlspin_test.go
+++ b/agentproto/tlspin_test.go
@@ -1,0 +1,68 @@
+package agentproto
+
+import (
+	"crypto/tls"
+	"strings"
+	"testing"
+)
+
+// TestNormalizeFingerprint_AcceptsFormsRejectsGarbage proves the pin accepts the
+// sha256:-prefixed form the daemon/agent-server print, plain hex, and
+// colon-separated hex, and rejects wrong-length / non-hex input up front (before
+// any dial).
+func TestNormalizeFingerprint_AcceptsFormsRejectsGarbage(t *testing.T) {
+	const bare = "aa11bb22cc33dd44ee55ff66007788990011223344556677889900aabbccddee"
+	forms := []string{bare, "sha256:" + bare, strings.ToUpper(bare), "SHA256:" + bare}
+	for _, f := range forms {
+		got, err := NormalizeFingerprint(f)
+		if err != nil {
+			t.Fatalf("NormalizeFingerprint(%q): %v", f, err)
+		}
+		if got != bare {
+			t.Fatalf("NormalizeFingerprint(%q) = %q, want %q", f, got, bare)
+		}
+	}
+	// Colon-separated hex (openssl's default form) normalizes to the same bare hex.
+	colon := "aa:11:bb:22:cc:33:dd:44:ee:55:ff:66:00:77:88:99:00:11:22:33:44:55:66:77:88:99:00:aa:bb:cc:dd:ee"
+	if got, err := NormalizeFingerprint(colon); err != nil || got != bare {
+		t.Fatalf("NormalizeFingerprint(colon) = (%q,%v), want (%q,nil)", got, err, bare)
+	}
+	for _, f := range []string{"", "abcd", bare + "ff", "zz11" + bare[4:]} {
+		if _, err := NormalizeFingerprint(f); err == nil {
+			t.Fatalf("NormalizeFingerprint(%q): want error, got nil", f)
+		}
+	}
+}
+
+// TestPinnedTLSConfig_PinReplacesDefaultVerify proves a fingerprint pin takes over
+// verification (InsecureSkipVerify with a VerifyPeerCertificate callback) while an
+// empty fingerprint leaves standard system-root verification in place.
+func TestPinnedTLSConfig_PinReplacesDefaultVerify(t *testing.T) {
+	const bare = "aa11bb22cc33dd44ee55ff66007788990011223344556677889900aabbccddee"
+	pinned, err := PinnedTLSConfig("sha256:" + bare)
+	if err != nil {
+		t.Fatalf("PinnedTLSConfig(pin): %v", err)
+	}
+	if !pinned.InsecureSkipVerify || pinned.VerifyPeerCertificate == nil {
+		t.Fatalf("pinned config must hand verification to the callback, got %+v", pinned)
+	}
+	if pinned.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("pinned config must floor at TLS 1.2, got %x", pinned.MinVersion)
+	}
+	// The callback is the sole arbiter: no cert ⇒ handshake fails.
+	if err := pinned.VerifyPeerCertificate(nil, nil); err == nil {
+		t.Fatal("pin callback must reject an empty cert chain")
+	}
+
+	ca, err := PinnedTLSConfig("")
+	if err != nil {
+		t.Fatalf("PinnedTLSConfig(\"\"): %v", err)
+	}
+	if ca.InsecureSkipVerify || ca.VerifyPeerCertificate != nil {
+		t.Fatalf("no-pin config must keep standard system-root verification, got %+v", ca)
+	}
+
+	if _, err := PinnedTLSConfig("not-a-fingerprint"); err == nil {
+		t.Fatal("PinnedTLSConfig must reject a malformed fingerprint")
+	}
+}

--- a/apiclient/remote.go
+++ b/apiclient/remote.go
@@ -1,16 +1,14 @@
 package apiclient
 
 import (
-	"crypto/sha256"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/hex"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
 )
 
 // The REMOTE transport for the daemon HTTP/WS API (#1592 Phase 3 PR4, §1.6). A
@@ -43,7 +41,11 @@ func NewRemote(daemonURL, token, fingerprint string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	tlsCfg, err := pinnedTLSConfig(fingerprint)
+	// The TLS pin (self-signed TOFU fingerprint or system-root CA verification)
+	// is shared wire-auth material, single-sourced in agentproto so this remote
+	// daemon client and the remote agent-server client (#1592 Phase 4) pin
+	// identically.
+	tlsCfg, err := agentproto.PinnedTLSConfig(fingerprint)
 	if err != nil {
 		return nil, err
 	}
@@ -83,76 +85,4 @@ func parseDaemonURL(daemonURL string) (httpBase, wsBase string, err error) {
 		return "", "", fmt.Errorf("--daemon-url %q has no host:port", daemonURL)
 	}
 	return "https://" + u.Host, "wss://" + u.Host, nil
-}
-
-// pinnedTLSConfig builds the client TLS config for a remote daemon. With a
-// fingerprint it pins the leaf cert's SHA-256 (TOFU): the default CA-chain +
-// hostname check is REPLACED — not skipped — by a VerifyPeerCertificate callback
-// that requires an exact fingerprint match, so connecting by IP or through a
-// tunnel works despite the self-signed cert's SAN, while a substituted cert is
-// refused. Without a fingerprint the daemon must present a cert that chains to a
-// system root (a real CA cert), verified normally.
-//
-// Pinning a bare SHA-256 (a hash, not the cert) is only expressible in Go by
-// taking over verification with a callback; the standard-library idiom for that
-// pairs the callback with SkipDefaultVerify (below) so the callback is the SOLE
-// arbiter. The connection is never actually unverified — an unmatched cert fails
-// the handshake.
-func pinnedTLSConfig(fingerprint string) (*tls.Config, error) {
-	if fingerprint == "" {
-		// CA-cert path: standard system-root verification, TLS 1.2 floor.
-		return &tls.Config{MinVersion: tls.VersionTLS12}, nil
-	}
-	want, err := normalizeFingerprint(fingerprint)
-	if err != nil {
-		return nil, err
-	}
-	return &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		// The default CA-chain + hostname check is handed off to the pin below —
-		// NOT skipped. It cannot validate a self-signed cert, and its SAN check
-		// would wrongly reject a legitimate IP/tunnel connection to the pinned
-		// identity; VerifyPeerCertificate enforces the stronger fingerprint match
-		// on every handshake instead, so an unmatched cert still fails.
-		InsecureSkipVerify: true,
-		// VerifyPeerCertificate is the sole arbiter: it fails the handshake unless
-		// the leaf's SHA-256 exactly matches the pin. rawCerts[0] is the leaf DER
-		// — the same bytes daemon.CertFingerprint hashes — so the comparison is
-		// apples-to-apples. Hostname/SAN is deliberately not checked (§1.2).
-		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-			if len(rawCerts) == 0 {
-				return fmt.Errorf("remote daemon presented no TLS certificate")
-			}
-			got := certFingerprint(rawCerts[0])
-			if got != want {
-				return fmt.Errorf("TLS fingerprint mismatch: pinned sha256:%s but daemon presented sha256:%s "+
-					"(wrong daemon, or the cert was regenerated — re-check `af token show` on the daemon host)", want, got)
-			}
-			return nil
-		},
-	}, nil
-}
-
-// normalizeFingerprint canonicalizes a user-supplied pin to bare lowercase hex.
-// It accepts the `sha256:<hex>` form `af token show` prints, plain hex, and
-// colon- or space-separated hex, and requires exactly 32 bytes (a SHA-256).
-func normalizeFingerprint(fingerprint string) (string, error) {
-	s := strings.TrimSpace(fingerprint)
-	s = strings.TrimPrefix(strings.ToLower(s), "sha256:")
-	s = strings.NewReplacer(":", "", " ", "").Replace(s)
-	if len(s) != sha256.Size*2 {
-		return "", fmt.Errorf("invalid --tls-fingerprint %q: expected a SHA-256 hex string (optionally sha256:-prefixed)", fingerprint)
-	}
-	if _, err := hex.DecodeString(s); err != nil {
-		return "", fmt.Errorf("invalid --tls-fingerprint %q: not hexadecimal: %w", fingerprint, err)
-	}
-	return s, nil
-}
-
-// certFingerprint returns the lowercase-hex SHA-256 of a DER-encoded certificate,
-// matching daemon.CertFingerprint's `sha256:<hex>` form minus the prefix (the
-// daemon hashes the same DER bytes: cs.PeerCertificates[0].Raw == the leaf DER).
-func certFingerprint(der []byte) string {
-	sum := sha256.Sum256(der)
-	return hex.EncodeToString(sum[:])
 }

--- a/apiclient/remote_test.go
+++ b/apiclient/remote_test.go
@@ -44,33 +44,6 @@ func TestParseDaemonURL_AcceptsTLSSchemesRejectsPlaintext(t *testing.T) {
 	}
 }
 
-// TestNormalizeFingerprint_AcceptsFormsRejectsGarbage proves the pin accepts the
-// sha256:-prefixed form `af token show` prints, plain hex, and colon-separated
-// hex, and rejects wrong-length / non-hex input up front (before any dial).
-func TestNormalizeFingerprint_AcceptsFormsRejectsGarbage(t *testing.T) {
-	const bare = "aa11bb22cc33dd44ee55ff66007788990011223344556677889900aabbccddee"
-	forms := []string{bare, "sha256:" + bare, strings.ToUpper(bare), "SHA256:" + bare}
-	for _, f := range forms {
-		got, err := normalizeFingerprint(f)
-		if err != nil {
-			t.Fatalf("normalizeFingerprint(%q): %v", f, err)
-		}
-		if got != bare {
-			t.Fatalf("normalizeFingerprint(%q) = %q, want %q", f, got, bare)
-		}
-	}
-	// Colon-separated hex (openssl's default form) normalizes to the same bare hex.
-	colon := "aa:11:bb:22:cc:33:dd:44:ee:55:ff:66:00:77:88:99:00:11:22:33:44:55:66:77:88:99:00:aa:bb:cc:dd:ee"
-	if got, err := normalizeFingerprint(colon); err != nil || got != bare {
-		t.Fatalf("normalizeFingerprint(colon) = (%q,%v), want (%q,nil)", got, err, bare)
-	}
-	for _, f := range []string{"", "abcd", bare + "ff", "zz11" + bare[4:]} {
-		if _, err := normalizeFingerprint(f); err == nil {
-			t.Fatalf("normalizeFingerprint(%q): want error, got nil", f)
-		}
-	}
-}
-
 // clearTargetEnv unsets every AF_DAEMON_* env var (and any bound flag) so a test's
 // remote-target resolution starts from a known-empty state, then restores the flag
 // vars on cleanup. Env vars are cleared via t.Setenv, which auto-restores.
@@ -126,7 +99,7 @@ func tlsSnapshotServer(t *testing.T, wantToken string) (*httptest.Server, string
 	})
 	srv := httptest.NewTLSServer(mux)
 	t.Cleanup(srv.Close)
-	return srv, certFingerprint(srv.Certificate().Raw)
+	return srv, agentproto.CertFingerprint(srv.Certificate().Raw)
 }
 
 // TestNewRemote_RESTRoundTripWithPinAndToken is the core remote proof: a Client
@@ -218,7 +191,7 @@ func TestDialStream_RemoteThreadsTokenHeaderAndQuery(t *testing.T) {
 	})
 	srv := httptest.NewTLSServer(mux)
 	t.Cleanup(srv.Close)
-	pin := certFingerprint(srv.Certificate().Raw)
+	pin := agentproto.CertFingerprint(srv.Certificate().Raw)
 
 	c, err := NewRemote(srv.URL, "secret-token", pin)
 	if err != nil {

--- a/integration/agent_server_remote_test.go
+++ b/integration/agent_server_remote_test.go
@@ -1,0 +1,178 @@
+package integration_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/internal/testguard"
+	"github.com/sachiniyer/agent-factory/session"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// TestRemoteAgentServerRoundTrip is the #1592 Phase 4 PR2 de-risk payoff: it
+// starts a REAL, out-of-process `af agent-server` (PR1) on a loopback TLS+token
+// listener, constructs a daemon-side session.remoteAgentServer pointing at it, and
+// drives the FULL AgentServer surface across the process boundary — Provision +
+// Launch the workspace in the remote runtime, Subscribe to its PTY stream, Input
+// and see the pane echo it, Snapshot + Preview reflecting the pane, Alive, and
+// Kill — exactly as the daemon drives the in-process local runtime.
+//
+// This proves the hard part of the whole phase — the daemon driving a sandboxed
+// agent-server over the wire, behaviorally indistinguishable from local — before
+// any docker/ssh runtime adds sandbox provisioning on top (PR4/PR5).
+//
+// Run it in the container fence: make remote-agent-server-roundtrip-container.
+func TestRemoteAgentServerRoundTrip(t *testing.T) {
+	requireTool(t, "git")
+	requireTool(t, "tmux")
+	testguard.IsolateTmux(t)
+
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+	// The fake agent pane runs `cat` (echoes input) behind a wrapper that prints a
+	// ready prompt and swallows the agent-specific flags injectSystemPrompt adds.
+	wrapper := home + "/fake-agent.sh"
+	writeFile(t, wrapper, "#!/bin/sh\nprintf '❯ '\nexec cat\n", 0755)
+	writeConfigWithProgramPath(t, home, wrapper)
+
+	bin := buildBinary(t)
+	repo := setupGitRepo(t)
+
+	// --- start the real out-of-process agent-server -------------------------
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, "agent-server",
+		"--listen", "127.0.0.1:0", "--repo", repo, "--title", "probe", "--program", tmux.ProgramClaude)
+	cmd.Env = append(os.Environ(), "AGENT_FACTORY_HOME="+home, "TERM=xterm")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start agent-server: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		done := make(chan struct{})
+		go func() { _, _ = cmd.Process.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			_ = cmd.Process.Kill()
+		}
+		// Backstop: sweep the workspace tmux session if teardown did not.
+		if name := tmuxNameForProbe(); name != "" && tmuxSessionExists(name) {
+			_ = exec.Command("tmux", "kill-session", "-t="+name).Run()
+		}
+	})
+
+	banner := readAgentServerBanner(t, stdout)
+	if banner.Addr == "" || banner.Token == "" || banner.Fingerprint == "" {
+		t.Fatalf("incomplete startup banner: %+v", banner)
+	}
+	t.Logf("agent-server up: addr=%s self_signed=%v fingerprint=%s title=%s (token %d bytes)",
+		banner.Addr, banner.SelfSigned, banner.Fingerprint, banner.Title, len(banner.Token))
+
+	// --- construct the daemon-side remote agent-server ----------------------
+	// This is the exact impl Instance.AgentServer() returns for a remote-runtime
+	// session; the whole point is that it satisfies session.AgentServer identically
+	// to the in-process local one, so the daemon above it is unchanged.
+	as, err := session.NewRemoteAgentServer(session.AgentServerEndpoint{
+		URL:         "wss://" + banner.Addr,
+		Token:       banner.Token,
+		Fingerprint: banner.Fingerprint,
+	}, "probe")
+	if err != nil {
+		t.Fatalf("NewRemoteAgentServer: %v", err)
+	}
+
+	// --- create the session in the remote runtime (control REST) ------------
+	if err := as.Provision(true); err != nil {
+		t.Fatalf("Provision over the wire: %v", err)
+	}
+	if err := as.Launch(true); err != nil {
+		t.Fatalf("Launch over the wire: %v", err)
+	}
+
+	// --- Subscribe to the PTY stream across the process boundary ------------
+	sub, err := as.Subscribe(0, 0)
+	if err != nil {
+		t.Fatalf("Subscribe to remote PTY stream: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+
+	pumpCtx, pumpCancel := context.WithCancel(context.Background())
+	defer pumpCancel()
+	var (
+		pumpMu sync.Mutex
+		pump   strings.Builder
+	)
+	go func() {
+		for {
+			ev, rerr := sub.NextEvent(pumpCtx)
+			if rerr != nil {
+				return
+			}
+			// The broker paints a fresh subscriber (PTYRepaint) then streams live
+			// output (PTYData); both carry pane text through the daemon-side fan-out.
+			if ev.Kind == session.PTYData || ev.Kind == session.PTYRepaint {
+				pumpMu.Lock()
+				pump.Write(ev.Data)
+				pumpMu.Unlock()
+			}
+		}
+	}()
+	output := func() string {
+		pumpMu.Lock()
+		defer pumpMu.Unlock()
+		return pump.String()
+	}
+
+	// --- Input; the remote `cat` pane echoes it back over the stream --------
+	if err := as.Input(0, []byte("hello-remote\n")); err != nil {
+		t.Fatalf("Input over the wire: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "remote PTY stream echoes typed input", func() bool {
+		return strings.Contains(output(), "hello-remote")
+	})
+	t.Logf("remote PTY stream echoed typed input across the process boundary: %q", strings.TrimSpace(output()))
+
+	// --- Snapshot over the control REST reflects the pane -------------------
+	waitUntil(t, 10*time.Second, "remote Snapshot reflects the typed input", func() bool {
+		obs, serr := as.Snapshot()
+		return serr == nil && strings.Contains(obs.Content, "hello-remote")
+	})
+	obs, err := as.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot over the wire: %v", err)
+	}
+	t.Logf("Snapshot over control REST reflects the pane: %q", strings.TrimSpace(obs.Content))
+
+	// --- Preview mirrors the pane content -----------------------------------
+	preview, err := as.Preview(0, false)
+	if err != nil {
+		t.Fatalf("Preview over the wire: %v", err)
+	}
+	if !strings.Contains(preview, "hello-remote") {
+		t.Fatalf("Preview did not reflect the typed input: %q", preview)
+	}
+
+	// --- Alive reports the remote workspace is running ----------------------
+	if !as.Alive() {
+		t.Fatal("expected the remote workspace to report Alive")
+	}
+
+	// --- Kill tears the remote workspace down; the stream ends --------------
+	if err := as.Kill(); err != nil {
+		t.Fatalf("Kill over the wire: %v", err)
+	}
+	waitUntil(t, 10*time.Second, "remote workspace reports not-Alive after Kill", func() bool {
+		return !as.Alive()
+	})
+}

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -40,13 +40,22 @@ type localAgentServer struct {
 // AgentServer returns the cached agent-server for this instance's runtime (#1592
 // Phase 2). The daemon speaks to a session ONLY through this interface, so its
 // observation/delivery paths never assume the session is local tmux. Cached so
-// the data-plane ring buffer and subscribers persist across calls. Local today; a
-// per-runtime factory selects container/ssh agent-servers in Phase 4.
+// the data-plane ring buffer and subscribers persist across calls.
+//
+// This is the per-runtime factory (#1592 Phase 4 PR2): a session whose runtime
+// exposes a remote agent-server (i.remoteClient, set at NewInstance from
+// InstanceOptions.RemoteAgentServer) gets a remoteAgentServer HTTP/WS client;
+// every other session gets the local in-process impl over tmux — the default,
+// unchanged. The client was validated at construction, so this stays infallible.
 func (i *Instance) AgentServer() AgentServer {
 	i.agentSrvMu.Lock()
 	defer i.agentSrvMu.Unlock()
 	if i.agentSrv == nil {
-		i.agentSrv = &localAgentServer{inst: i}
+		if i.remoteClient != nil {
+			i.agentSrv = &remoteAgentServer{rc: i.remoteClient}
+		} else {
+			i.agentSrv = &localAgentServer{inst: i}
+		}
 	}
 	return i.agentSrv
 }

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -1,0 +1,560 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/apiproto"
+)
+
+// remoteAgentServer is the daemon-side AgentServer for a runtime whose agent runs
+// in a SANDBOX behind an authed URL (#1592 Phase 4 PR2): a real `af agent-server`
+// (PR1) reachable over HTTP/WS+TLS+token, on another host/container. It is the
+// mirror image of localAgentServer — where localAgentServer drives an in-process
+// tmux session directly, this is an HTTP/WS CLIENT to an out-of-process
+// agent-server, satisfying the SAME session.AgentServer interface so the daemon's
+// observation/delivery paths above it do not change (§0, §1.1).
+//
+//   - The control plane (Provision/Launch/Expose/Snapshot/Preview/Alive/
+//     SendPrompt/TapEnter/Kill) is REST to /v1/agent/* — the 1:1 mirror the
+//     agent-server exposes.
+//   - The data plane (Subscribe/Input/Resize) is the WS PTY stream to the
+//     agent-server, reached through the SAME ptyBroker fan-out the local runtime
+//     uses — with a remote WS clientlessChannel in place of the tmux one. So one
+//     WS to the sandbox is fanned to N local subscribers, ?since replay and the
+//     multi-writer input path work identically, and none of the broker logic is
+//     reimplemented (§ boundaries: reuse Phase 1-3, no protocol reimpl).
+//
+// Transport is Phase-3's: mandatory TLS (self-signed TOFU pin or CA cert) + a
+// bearer token on every REST call and WS handshake, and agentproto for the PTY
+// wire frames. It cannot import apiclient (that package sits above daemon, which
+// sits above session — a cycle), so it shares the pieces that matter through the
+// agentproto/apiproto leaves the whole stack already agrees on: the TLS pin
+// (agentproto.PinnedTLSConfig), the token header (agentproto.AuthHeader), the WS
+// codec (agentproto.ReadMessage/WriteFrame), and the {data,error} envelope
+// (apiproto). The thin HTTP/WS plumbing below is the only local piece.
+//
+// DARK for users in PR2: no docker/ssh runtime provisions a sandbox to point one
+// at yet (PR3-PR5). It is proven by an out-of-process integration test that
+// starts a real `af agent-server` on loopback and drives it through here.
+type remoteAgentServer struct {
+	rc *remoteAgentClient
+
+	mu sync.Mutex
+	// brokers holds one lazy ptyBroker per tab index, exactly like localAgentServer
+	// — each fans a single remote WS to N local subscribers. The channel behind
+	// each is a remoteClientlessChannel (the remote WS) rather than a tmux one.
+	brokers map[int]*ptyBroker
+	// closed latches once Kill has run so a Subscribe/Input/Resize racing the kill
+	// cannot lazily resurrect a broker (and dial a fresh WS to a torn-down sandbox
+	// that never gets closed) — the local runtime's #1632 guard, same reasoning.
+	closed bool
+}
+
+var _ AgentServer = (*remoteAgentServer)(nil)
+
+// AgentServerEndpoint is the runtime handle that points an Instance at a remote
+// agent-server (#1592 Phase 4 PR2): the authed URL of the `af agent-server` in the
+// sandbox plus the auth material to reach it. A nil endpoint ⇒ the local
+// in-process runtime (the default, unchanged). Phase 4 PR3 generalizes this into a
+// Runtime that PROVISIONS the sandbox and fills these in; PR2 only consumes them.
+type AgentServerEndpoint struct {
+	// URL is the agent-server's TLS base URL — `wss://host:port` or
+	// `https://host:port` (equivalent; both select TLS, only the authority is
+	// used).
+	URL string
+	// Token is the bearer credential presented on every REST call and WS handshake.
+	Token string
+	// Fingerprint pins the agent-server's self-signed cert by SHA-256 (TOFU); empty
+	// ⇒ verify a real CA cert against the system trust store.
+	Fingerprint string
+}
+
+// NewRemoteAgentServer builds a remoteAgentServer that drives the `af agent-server`
+// reachable at ep.URL for a single workspace titled `title`. It validates the URL
+// and fingerprint up front (no dial) so a bad endpoint fails at construction
+// rather than on first use — which is why Instance.AgentServer() (infallible) can
+// build one from an endpoint validated at NewInstance. The integration test
+// constructs one here directly against a real out-of-process agent-server.
+func NewRemoteAgentServer(ep AgentServerEndpoint, title string) (AgentServer, error) {
+	rc, err := newRemoteAgentClient(ep, title)
+	if err != nil {
+		return nil, err
+	}
+	return &remoteAgentServer{rc: rc}, nil
+}
+
+func (s *remoteAgentServer) Provision(firstTimeSetup bool) error {
+	return s.rc.call("/v1/agent/provision", agentLifecycleReq{FirstTimeSetup: firstTimeSetup}, nil)
+}
+
+func (s *remoteAgentServer) Launch(firstTimeSetup bool) error {
+	return s.rc.call("/v1/agent/launch", agentLifecycleReq{FirstTimeSetup: firstTimeSetup}, nil)
+}
+
+func (s *remoteAgentServer) Expose() (StreamEndpoint, error) {
+	// The daemon PROXIES a remote session's stream: it subscribes to the sandbox
+	// (Subscribe below dials the remote WS) and re-fans to its own subscribers, so
+	// from a TUI's perspective the stream is still reachable at the daemon's local
+	// path — the daemon relays. Returning Local=true keeps the daemon's stream
+	// handler on its proxy path and the TUI unchanged. The stream-info-returns-a-URL
+	// indirection (a browser dialing the sandbox directly) is a Phase-5 concern that
+	// also needs the sandbox token handed to the browser; PR2 does not flip it.
+	return StreamEndpoint{Local: true}, nil
+}
+
+func (s *remoteAgentServer) Snapshot() (Observation, error) {
+	var resp agentSnapshotResp
+	if err := s.rc.call("/v1/agent/snapshot", struct{}{}, &resp); err != nil {
+		return Observation{}, err
+	}
+	return Observation{Updated: resp.Updated, HasPrompt: resp.HasPrompt, Content: resp.Content}, nil
+}
+
+func (s *remoteAgentServer) Preview(tab int, full bool) (string, error) {
+	return s.rc.preview(tab, full)
+}
+
+func (s *remoteAgentServer) Alive() bool {
+	var resp agentAliveResp
+	if err := s.rc.call("/v1/agent/alive", struct{}{}, &resp); err != nil {
+		return false
+	}
+	return resp.Alive
+}
+
+func (s *remoteAgentServer) SendPrompt(prompt string) error {
+	return s.rc.call("/v1/agent/send-prompt", agentSendPromptReq{Prompt: prompt}, nil)
+}
+
+func (s *remoteAgentServer) TapEnter() {
+	// Mirrors localAgentServer.TapEnter: fire-and-forget, no error surfaced (a
+	// no-op unless the workspace has AutoYes; the daemon never consumed a result).
+	_ = s.rc.call("/v1/agent/tap-enter", struct{}{}, nil)
+}
+
+// --- data plane: one remote WS per tab, fanned by the shared ptyBroker ---
+
+// ensureBroker lazily builds the ptyBroker for tab `tab`, bound to a remote WS
+// clientlessChannel. Refuses once Kill has latched closed (the #1632 guard): a
+// Subscribe racing teardown must not dial a fresh WS to a sandbox being torn down.
+func (s *remoteAgentServer) ensureBroker(tab int) (*ptyBroker, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, fmt.Errorf("remote session %q is being terminated", s.rc.title)
+	}
+	if br := s.brokers[tab]; br != nil {
+		return br, nil
+	}
+	if s.brokers == nil {
+		s.brokers = make(map[int]*ptyBroker)
+	}
+	br := newPTYBroker(newRemoteClientlessChannel(s.rc, tab))
+	s.brokers[tab] = br
+	return br, nil
+}
+
+func (s *remoteAgentServer) Subscribe(tab int, since Seq) (PTYSubscription, error) {
+	br, err := s.ensureBroker(tab)
+	if err != nil {
+		return nil, err
+	}
+	return br.subscribe(since)
+}
+
+func (s *remoteAgentServer) Input(tab int, b []byte) error {
+	br, err := s.ensureBroker(tab)
+	if err != nil {
+		return err
+	}
+	return br.input(b)
+}
+
+func (s *remoteAgentServer) Resize(tab int, rows, cols uint16) error {
+	br, err := s.ensureBroker(tab)
+	if err != nil {
+		return err
+	}
+	return br.resize(rows, cols)
+}
+
+func (s *remoteAgentServer) Kill() error {
+	// Tear every tab's data plane down first (closing each remote WS so subscribers
+	// see io.EOF), latch closed under the same lock that snapshots the brokers so a
+	// racing Subscribe can't resurrect one, then kill the remote workspace over REST.
+	s.mu.Lock()
+	s.closed = true
+	brokers := s.brokers
+	s.brokers = nil
+	s.mu.Unlock()
+	for _, br := range brokers {
+		br.close()
+	}
+	return s.rc.call("/v1/agent/kill", struct{}{}, nil)
+}
+
+// --- remote WS clientlessChannel: the sandbox stream as a broker channel ---
+
+// remoteClientlessChannel is the remote runtime's clientlessChannel: it binds ONE
+// tab's ptyBroker to the sandbox's WS PTY stream. Where tmuxClientlessChannel
+// drives pipe-pane/send-keys/resize-window on a local tmux pane, this drives the
+// same three verbs over a single bidirectional WebSocket to the `af agent-server`:
+//
+//   - StartCapture dials the tab's WS and returns a reader that yields the
+//     sandbox's PTY_OUT bytes (dropping the remote's own repaint/resize-echo control
+//     frames — the daemon-side broker re-derives those locally, so feeding them into
+//     the ring would double-count them in the seq).
+//   - SendRaw/Resize write INPUT/RESIZE frames back over that same socket (the
+//     agent-server accepts input from any subscriber — the multi-writer model).
+//   - Snapshot fetches the current screen over REST Preview so the broker can paint
+//     a fresh local subscriber, exactly as the tmux channel's capture-pane does.
+//
+// This is what lets remoteAgentServer reuse ptyBroker unchanged: the broker never
+// knows whether its bytes come from a local pipe or a remote socket.
+type remoteClientlessChannel struct {
+	rc  *remoteAgentClient
+	tab int
+
+	mu     sync.Mutex
+	conn   *websocket.Conn
+	ctx    context.Context
+	cancel context.CancelFunc
+	// writeMu serializes SendRaw/Resize writes: coder/websocket allows one
+	// concurrent reader + one writer, but two goroutines writing (an input and a
+	// resize) would race the frame boundary.
+	writeMu sync.Mutex
+}
+
+var _ clientlessChannel = (*remoteClientlessChannel)(nil)
+
+func newRemoteClientlessChannel(rc *remoteAgentClient, tab int) *remoteClientlessChannel {
+	return &remoteClientlessChannel{rc: rc, tab: tab}
+}
+
+// StartCapture dials the tab's WS stream (from the live tail) and returns a reader
+// over the sandbox's PTY_OUT bytes. The reader goroutine also drains the socket's
+// control/repaint frames (dropping them) so the connection stays healthy — coder/
+// websocket auto-responds to the server's keepalive pings only while a read is in
+// flight, so this loop IS the keepalive. It is the broker's first-Subscribe entry
+// point, so the returned reader is consumed immediately and never blocks the socket.
+func (c *remoteClientlessChannel) StartCapture() (io.ReadCloser, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn != nil {
+		return nil, fmt.Errorf("remote clientless capture already started")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	conn, err := c.rc.dialStream(ctx, c.tab)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	c.conn, c.ctx, c.cancel = conn, ctx, cancel
+	pr, pw := io.Pipe()
+	go c.readLoop(ctx, conn, pw)
+	return pr, nil
+}
+
+// readLoop copies the sandbox's PTY_OUT bytes into the broker's pipe until the
+// socket errors or capture is stopped. It DROPS the remote's OpRepaint and every
+// control frame (MsgResize echo, MsgExit): the daemon-side broker paints its own
+// per-subscriber repaint via Snapshot and manages its own resize echo, so passing
+// the remote's through would double-count repaint bytes in the ring seq and echo
+// resizes twice. This makes the remote socket behave to the broker exactly like
+// tmux pipe-pane: a future-only stream of raw output.
+func (c *remoteClientlessChannel) readLoop(ctx context.Context, conn *websocket.Conn, pw *io.PipeWriter) {
+	defer func() { _ = pw.Close() }()
+	for {
+		msg, err := agentproto.ReadMessage(ctx, conn)
+		if err != nil {
+			return
+		}
+		if msg.Binary && msg.Frame.Op == agentproto.OpPTYOut {
+			if _, werr := pw.Write(msg.Frame.Data); werr != nil {
+				return
+			}
+		}
+	}
+}
+
+// StopCapture cancels the read loop and closes the WS, so the broker's read side
+// (the pipe) returns EOF. Idempotent.
+func (c *remoteClientlessChannel) StopCapture() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn == nil {
+		return nil
+	}
+	c.cancel()
+	err := c.conn.Close(websocket.StatusNormalClosure, "")
+	c.conn, c.ctx, c.cancel = nil, nil, nil
+	return err
+}
+
+// SendRaw writes verbatim input bytes to the sandbox PTY as an INPUT frame over
+// the capture socket (multi-writer: the agent-server accepts input from any
+// subscriber). It requires the capture socket, which the broker always opens on
+// the first Subscribe before any input can be routed here.
+func (c *remoteClientlessChannel) SendRaw(b []byte) error {
+	conn, ctx, err := c.activeConn()
+	if err != nil {
+		return err
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	wctx, cancel := context.WithTimeout(ctx, remoteWSWriteTimeout)
+	defer cancel()
+	return agentproto.WriteFrame(wctx, conn, agentproto.InputFrame(b))
+}
+
+// Resize sends the winning size to the sandbox PTY as a RESIZE frame. The broker
+// tracks last-resize-wins + echoes the authoritative size to local subscribers;
+// this just forwards the size to the remote (whose own echo is dropped by readLoop).
+func (c *remoteClientlessChannel) Resize(rows, cols uint16) error {
+	conn, ctx, err := c.activeConn()
+	if err != nil {
+		return err
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	wctx, cancel := context.WithTimeout(ctx, remoteWSWriteTimeout)
+	defer cancel()
+	return agentproto.WriteFrame(wctx, conn, agentproto.ResizeFrame(rows, cols))
+}
+
+// Snapshot returns the sandbox's current visible screen over REST Preview — the
+// repaint the broker injects so a fresh local subscriber sees the screen before
+// the first live byte, mirroring tmux capture-pane. The WS stream carries only
+// future output, so without this a just-opened remote pane would render blank.
+func (c *remoteClientlessChannel) Snapshot() ([]byte, error) {
+	content, err := c.rc.preview(c.tab, false)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(content), nil
+}
+
+// activeConn returns the live capture socket and its context, or an error if
+// capture is not running (no subscriber has opened the stream yet).
+func (c *remoteClientlessChannel) activeConn() (*websocket.Conn, context.Context, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.conn == nil {
+		return nil, nil, fmt.Errorf("remote pty stream for tab %d is not open", c.tab)
+	}
+	return c.conn, c.ctx, nil
+}
+
+// --- remoteAgentClient: the thin REST + WS transport to one agent-server ---
+
+// remoteWSWriteTimeout bounds a single INPUT/RESIZE write to the sandbox socket so
+// a wedged connection surfaces as an error rather than blocking a broker goroutine.
+const remoteWSWriteTimeout = 10 * time.Second
+
+// remoteAgentDialTimeout bounds the TCP connect to the sandbox (a real network
+// hop), and remoteAgentCallTimeout bounds a whole control REST round-trip.
+const (
+	remoteAgentDialTimeout = 10 * time.Second
+	remoteAgentCallTimeout = 30 * time.Second
+)
+
+// remoteAgentClient is the transport to ONE `af agent-server`: a TLS-pinned,
+// token-bearing HTTP client for the /v1/agent/* control REST and a matching WS
+// dialer for the /v1/sessions/{title}/stream data plane. It is the session-package
+// analogue of apiclient.Client (which session cannot import — the cycle), sharing
+// the pieces that define the contract through the agentproto/apiproto leaves.
+type remoteAgentClient struct {
+	httpClient *http.Client
+	httpBase   string // https://host:port
+	wsBase     string // wss://host:port
+	token      string
+	title      string // the sandbox's single-workspace session title (the stream path id)
+}
+
+// newRemoteAgentClient builds the transport for ep, validating the URL and pin up
+// front (no dial). It mirrors apiclient.NewRemote: TLS is mandatory and never
+// skipped (pinned self-signed fingerprint or system-root CA), and the token rides
+// every request.
+func newRemoteAgentClient(ep AgentServerEndpoint, title string) (*remoteAgentClient, error) {
+	if title == "" {
+		return nil, fmt.Errorf("remote agent-server requires a workspace title")
+	}
+	httpBase, wsBase, err := splitTLSBaseURL(ep.URL)
+	if err != nil {
+		return nil, err
+	}
+	tlsCfg, err := agentproto.PinnedTLSConfig(ep.Fingerprint)
+	if err != nil {
+		return nil, err
+	}
+	dialer := &net.Dialer{Timeout: remoteAgentDialTimeout}
+	return &remoteAgentClient{
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				DialContext:     dialer.DialContext,
+				TLSClientConfig: tlsCfg,
+			},
+		},
+		httpBase: httpBase,
+		wsBase:   wsBase,
+		token:    ep.Token,
+		title:    title,
+	}, nil
+}
+
+// call POSTs req as JSON to the agent-server control route at `path`, decodes the
+// shared {data,error} envelope, and unmarshals the data member into resp (nil resp
+// ⇒ success/failure only). It is the client-side twin of the agent-server's
+// rpcHandler dispatch — the same envelope the daemon's own httpserver speaks —
+// with the bearer token on every call.
+func (c *remoteAgentClient) call(path string, req, resp any) error {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("remote agent-server: marshal request: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), remoteAgentCallTimeout)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.httpBase+path, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("remote agent-server: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set(agentproto.AuthHeader, agentproto.BearerScheme+c.token)
+
+	httpResp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("remote agent-server: POST %s: %w", path, err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	raw, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return fmt.Errorf("remote agent-server: read %s response: %w", path, err)
+	}
+	// Decode into a RawMessage-backed envelope so the data member is unmarshaled in
+	// a second pass only when there is no error — the same two-pass decode apiclient
+	// uses, so a failure body's null data is never interpreted as the typed struct.
+	var env struct {
+		Data  json.RawMessage         `json:"data"`
+		Error *apiproto.EnvelopeError `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return fmt.Errorf("remote agent-server: malformed %s response envelope: %w", path, err)
+	}
+	if env.Error != nil {
+		return fmt.Errorf("%s", env.Error.Message)
+	}
+	if resp != nil {
+		if err := json.Unmarshal(env.Data, resp); err != nil {
+			return fmt.Errorf("remote agent-server: malformed %s response data: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// preview fetches tab `tab`'s content over the control REST — shared by the
+// AgentServer.Preview surface and the broker's fresh-subscriber repaint (Snapshot).
+func (c *remoteAgentClient) preview(tab int, full bool) (string, error) {
+	var resp agentPreviewResp
+	if err := c.call("/v1/agent/preview", agentPreviewReq{Tab: tab, Full: full}, &resp); err != nil {
+		return "", err
+	}
+	return resp.Content, nil
+}
+
+// dialStream opens the WS PTY subscription to tab `tab` (from the live tail). The
+// token rides both the Authorization header and the ?access_token= query — the
+// agent-server honors either, and the query mirrors the browser WS path Phase 5
+// needs. The read limit is raised off the 32 KiB default: a repaint of a wide pane
+// is a single large binary frame.
+func (c *remoteAgentClient) dialStream(ctx context.Context, tab int) (*websocket.Conn, error) {
+	q := url.Values{}
+	if tab != 0 {
+		q.Set("tab", strconv.Itoa(tab))
+	}
+	q.Set(agentproto.AccessTokenQueryParam, c.token)
+	u := c.wsBase + "/v1/sessions/" + url.PathEscape(c.title) + "/stream?" + q.Encode()
+
+	opts := &websocket.DialOptions{
+		HTTPClient: c.httpClient,
+		HTTPHeader: http.Header{agentproto.AuthHeader: []string{agentproto.BearerScheme + c.token}},
+	}
+	conn, _, err := websocket.Dial(ctx, u, opts)
+	if err != nil {
+		return nil, fmt.Errorf("remote agent-server: dial pty stream: %w", err)
+	}
+	conn.SetReadLimit(4 << 20)
+	return conn, nil
+}
+
+// splitTLSBaseURL validates an agent-server base URL and derives its REST
+// (https://host:port) and WS (wss://host:port) authorities. It accepts the TLS
+// schemes wss/https interchangeably (the agent-server serves REST and WS on one
+// TLS listener) and rejects plaintext ws/http — there is no clear-text mode, the
+// token would leak. Only scheme+authority are used. It mirrors apiclient's
+// parseDaemonURL but with agent-server-appropriate error text.
+func splitTLSBaseURL(raw string) (httpBase, wsBase string, err error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", "", fmt.Errorf("invalid agent-server URL %q: %w", raw, err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "wss", "https":
+	case "ws", "http":
+		return "", "", fmt.Errorf("agent-server URL %q uses a plaintext scheme; it is TLS-only, use wss:// or https://", raw)
+	default:
+		return "", "", fmt.Errorf("agent-server URL %q must be a wss:// or https:// URL", raw)
+	}
+	if u.Host == "" {
+		return "", "", fmt.Errorf("agent-server URL %q has no host:port", raw)
+	}
+	return "https://" + u.Host, "wss://" + u.Host, nil
+}
+
+// --- wire structs: the /v1/agent/* request/response shapes (mirror PR1) ---
+//
+// These match daemon/agentserver_headless.go's agent* types field-for-field (the
+// server side). They are duplicated as unexported session types rather than
+// imported because daemon imports session (a cycle the other way); the shared
+// contract is the JSON tags, which the round-trip test pins.
+
+type agentLifecycleReq struct {
+	FirstTimeSetup bool `json:"first_time_setup"`
+}
+
+type agentSnapshotResp struct {
+	Updated   bool   `json:"updated"`
+	HasPrompt bool   `json:"has_prompt"`
+	Content   string `json:"content"`
+}
+
+type agentPreviewReq struct {
+	Tab  int  `json:"tab"`
+	Full bool `json:"full"`
+}
+
+type agentPreviewResp struct {
+	Content string `json:"content"`
+}
+
+type agentAliveResp struct {
+	Alive bool `json:"alive"`
+}
+
+type agentSendPromptReq struct {
+	Prompt string `json:"prompt"`
+}

--- a/session/agentserver_remote_test.go
+++ b/session/agentserver_remote_test.go
@@ -1,0 +1,78 @@
+package session
+
+import (
+	"testing"
+)
+
+// validFingerprint is a well-formed (64-hex) SHA-256 pin — enough for
+// construction, which validates the shape without dialing.
+const validFingerprint = "aa11bb22cc33dd44ee55ff66007788990011223344556677889900aabbccddee"
+
+// TestAgentServerFactory_SelectsRuntime is the per-runtime factory proof (#1592
+// Phase 4 PR2): AgentServer() returns the local in-process impl for a default
+// instance, and a remoteAgentServer for one whose runtime exposes a remote
+// agent-server endpoint — with the local default provably unchanged.
+func TestAgentServerFactory_SelectsRuntime(t *testing.T) {
+	local, err := NewInstance(InstanceOptions{Title: "local", Path: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewInstance(local): %v", err)
+	}
+	if _, ok := local.AgentServer().(*localAgentServer); !ok {
+		t.Fatalf("default instance must get the local in-process agent-server, got %T", local.AgentServer())
+	}
+
+	remote, err := NewInstance(InstanceOptions{
+		Title: "remote",
+		Path:  t.TempDir(),
+		RemoteAgentServer: &AgentServerEndpoint{
+			URL:         "wss://127.0.0.1:1",
+			Token:       "secret",
+			Fingerprint: validFingerprint,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewInstance(remote): %v", err)
+	}
+	if _, ok := remote.AgentServer().(*remoteAgentServer); !ok {
+		t.Fatalf("remote-runtime instance must get the remote agent-server client, got %T", remote.AgentServer())
+	}
+	// Cached: a second call returns the same instance (the data-plane ring buffer
+	// and subscriber set must persist across calls).
+	if remote.AgentServer() != remote.AgentServer() {
+		t.Fatal("AgentServer() must cache the per-instance server")
+	}
+}
+
+// TestNewRemoteAgentServer_ValidatesEndpoint proves the endpoint is validated at
+// construction (no dial): a plaintext scheme, a malformed fingerprint, and a
+// missing title are all rejected up front, so the AgentServer() factory can stay
+// infallible.
+func TestNewRemoteAgentServer_ValidatesEndpoint(t *testing.T) {
+	cases := []struct {
+		name  string
+		ep    AgentServerEndpoint
+		title string
+	}{
+		{"plaintext scheme", AgentServerEndpoint{URL: "ws://host:1", Fingerprint: validFingerprint}, "t"},
+		{"http scheme", AgentServerEndpoint{URL: "http://host:1", Fingerprint: validFingerprint}, "t"},
+		{"no host", AgentServerEndpoint{URL: "wss://", Fingerprint: validFingerprint}, "t"},
+		{"bad fingerprint", AgentServerEndpoint{URL: "wss://host:1", Fingerprint: "nope"}, "t"},
+		{"empty title", AgentServerEndpoint{URL: "wss://host:1", Fingerprint: validFingerprint}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewRemoteAgentServer(tc.ep, tc.title); err == nil {
+				t.Fatalf("NewRemoteAgentServer(%+v, %q): want error, got nil", tc.ep, tc.title)
+			}
+		})
+	}
+
+	// A well-formed endpoint constructs (still no dial — the URL is never reached).
+	as, err := NewRemoteAgentServer(AgentServerEndpoint{URL: "wss://127.0.0.1:1", Token: "tok", Fingerprint: validFingerprint}, "probe")
+	if err != nil {
+		t.Fatalf("NewRemoteAgentServer(valid): %v", err)
+	}
+	if _, ok := as.(*remoteAgentServer); !ok {
+		t.Fatalf("expected *remoteAgentServer, got %T", as)
+	}
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -173,9 +173,19 @@ type Instance struct {
 	// must persist across calls; a fresh server each call would drop subscribers
 	// and lose the replay buffer. Lazily built by AgentServer(), guarded by
 	// agentSrvMu (a dedicated mutex, not i.mu, so building the server never
-	// contends with the session-state fields i.mu guards).
-	agentSrv   *localAgentServer
+	// contends with the session-state fields i.mu guards). Interface-typed since
+	// #1592 Phase 4 PR2: AgentServer() returns the local in-process impl by
+	// default, or a remoteAgentServer when remoteClient is set.
+	agentSrv   AgentServer
 	agentSrvMu sync.Mutex
+	// remoteClient is the runtime handle selecting the REMOTE agent-server impl
+	// (#1592 Phase 4 PR2): when non-nil, AgentServer() returns a remoteAgentServer
+	// driving the `af agent-server` this points at, instead of the local in-process
+	// runtime. Built once at NewInstance from InstanceOptions.RemoteAgentServer (so
+	// a bad endpoint fails there, keeping AgentServer() infallible) and nil for
+	// every local session — the default path is provably unchanged. DARK in PR2: no
+	// runtime sets it yet (PR3-PR5).
+	remoteClient *remoteAgentClient
 }
 
 // tabTmuxSession returns the tmux session backing the tab at idx (0 is the agent

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -25,6 +25,13 @@ type InstanceOptions struct {
 	// git worktree+branch. The worktree is marked external so kill/cleanup
 	// never removes the user's tree or branch. Local backend only.
 	InPlace bool
+	// RemoteAgentServer, when set, points the instance's AgentServer() at a REMOTE
+	// `af agent-server` reachable at the endpoint's authed URL (#1592 Phase 4 PR2)
+	// instead of the local in-process runtime. Validated at NewInstance (a bad URL
+	// or fingerprint fails there). DARK in PR2: no runtime provisions a sandbox to
+	// fill this in yet (PR3-PR5); it is exercised by the out-of-process round-trip
+	// test.
+	RemoteAgentServer *AgentServerEndpoint
 }
 
 // backendFactory constructs the Backend used by a new Instance. It is a
@@ -89,18 +96,31 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		return nil, err
 	}
 
+	// A remote-runtime session builds its agent-server transport up front so the
+	// endpoint (URL, TLS pin) is validated here rather than on first AgentServer()
+	// use — which is what keeps the AgentServer() factory infallible (#1592 Phase 4
+	// PR2). nil for every local session, so the default path is untouched.
+	var remoteClient *remoteAgentClient
+	if opts.RemoteAgentServer != nil {
+		remoteClient, err = newRemoteAgentClient(*opts.RemoteAgentServer, opts.Title)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build remote agent-server client: %w", err)
+		}
+	}
+
 	return &Instance{
-		ID:        newSessionID(),
-		Title:     opts.Title,
-		liveness:  LiveReady,
-		Path:      absPath,
-		Program:   opts.Program,
-		Height:    0,
-		Width:     0,
-		CreatedAt: t,
-		UpdatedAt: t,
-		AutoYes:   opts.AutoYes,
-		inPlace:   opts.InPlace,
-		backend:   backend,
+		ID:           newSessionID(),
+		Title:        opts.Title,
+		liveness:     LiveReady,
+		Path:         absPath,
+		Program:      opts.Program,
+		Height:       0,
+		Width:        0,
+		CreatedAt:    t,
+		UpdatedAt:    t,
+		AutoYes:      opts.AutoYes,
+		inPlace:      opts.InPlace,
+		backend:      backend,
+		remoteClient: remoteClient,
 	}, nil
 }


### PR DESCRIPTION
## What

The **#1592 Phase 4 de-risk milestone**: teach the daemon to drive a REAL, out-of-process `af agent-server` (PR1) over the network, exactly like it drives the in-process local runtime. PR1 proved the agent-server standalone; this proves the **daemon-side client** that will later reach into every docker/ssh sandbox — the hard part (the protocol over the wire) settled before any sandbox provisioning lands on top.

**DARK / additive:** no runtime provisions a sandbox to point one at yet (PR3–PR5), and nothing wires a remote endpoint on a real session. The local in-process path is the default, **provably unchanged**.

## The remote impl — `session/agentserver_remote.go`

`remoteAgentServer` satisfies the SAME `session.AgentServer` interface as the in-process impl, but is an HTTP/WS client to an `af agent-server` URL:

- **Control plane** (`Provision`/`Launch`/`Expose`/`Snapshot`/`Preview`/`Alive`/`SendPrompt`/`TapEnter`/`Kill`) → REST to `/v1/agent/*`, the 1:1 mirror PR1 serves, over the shared `{data,error}` envelope.
- **Data plane** (`Subscribe`/`Input`/`Resize`) → the WS PTY stream, reached through the **SAME `ptyBroker` fan-out** the local runtime uses — with a remote-WS `clientlessChannel` swapped in for the tmux one. One socket to the sandbox is fanned to N local subscribers; `?since` replay and multi-writer input work identically; **no broker logic is reimplemented**. The remote's own repaint/resize-echo frames are dropped so the daemon-side broker re-derives them locally (making the remote socket behave to the broker exactly like tmux pipe-pane).

`Expose()` returns `Local=true`: the daemon **proxies** a remote session's stream (relays the sandbox socket to its own subscribers), so the TUI is unchanged. The stream-info-returns-a-URL indirection stays a Phase-5 concern (it also needs the sandbox token handed to a browser).

## Per-runtime factory

`Instance.AgentServer()` is now the factory: a session whose runtime exposes a remote agent-server (`InstanceOptions.RemoteAgentServer` → a validated `remoteAgentClient` cached on the instance) gets a `remoteAgentServer`; every other session gets the local in-process impl. The endpoint (URL + TLS pin) is validated at `NewInstance`, keeping `AgentServer()` **infallible**. Wired cleanly via a runtime handle on the instance; local default untouched.

## Reuse of Phase 1–3 (no protocol reimpl, no shims)

`session` **cannot** import `apiclient` (it sits above `daemon`, above `session` — an import cycle), so the remote client shares what defines the contract through the leaf packages the whole stack already agrees on:

- `agentproto` — PTY wire frames, auth header/scheme, WS codec (`ReadMessage`/`WriteFrame`).
- `apiproto` — the `{data,error}` envelope.
- **TLS pin** — moved into `agentproto.PinnedTLSConfig` (+ `NormalizeFingerprint`/`CertFingerprint`) as **one source of truth**. `apiclient`'s remote-daemon client now **delegates** to it, deduping the Phase-3 copy rather than forking a second (structural cleanup, covered by the existing `apiclient/remote_test.go`).

The only session-local piece is the thin REST/WS transport plumbing (dial + envelope decode), which the cycle forces.

## The de-risk proof (out-of-process)

`integration/agent_server_remote_test.go` — `TestRemoteAgentServerRoundTrip` starts a **real `af agent-server` subprocess** on a loopback TLS+token listener, constructs a `remoteAgentServer` pointing at it, and drives the **full AgentServer surface across the process boundary**:

\`\`\`
agent-server up: addr=127.0.0.1:42319 self_signed=true fingerprint=sha256:09be…ce9a title=probe (token 43 bytes)
remote PTY stream echoed typed input across the process boundary: "…❯ …hello-remote\r\nhello-remote"
Snapshot over control REST reflects the pane: "❯ hello-remote\nhello-remote"
--- PASS: TestRemoteAgentServerRoundTrip (1.08s)
\`\`\`

Provision + Launch the workspace in the remote runtime → Subscribe to its PTY stream → Input and see the `cat` pane echo it → Snapshot + Preview reflect the pane → Alive → Kill — behaviorally indistinguishable from the in-process path. Run it with \`make remote-agent-server-roundtrip-container\`. A session unit test (`TestAgentServerFactory_SelectsRuntime`) pins the local-vs-remote selection and construction-time endpoint validation.

## Gates

- `gofmt -l .` / `golangci-lint run --fast` / `deadcode -test ./...` / `scripts/lint-file-length.sh` — clean
- `go build ./...` — clean
- `make test-container` — all packages green
- `make remote-agent-server-roundtrip-container` — the de-risk proof, green
- `make tui-driver-selftest` — 25/25 (local path unaffected)
- `scripts/gen-docs.sh` — no drift (no CLI/route surface added)

Link #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)