### PR TITLE
feat(session): Runtime provision-and-expose interface + backend registry + config (#1592 Phase 4 PR3)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -447,6 +447,7 @@ func init() {
 	sessionsCreateCmd.Flags().StringVar(&createProgramFlag, "program", "", "Program to run (one of: "+tmux.SupportedProgramsString()+"; defaults to config default)")
 	sessionsCreateCmd.Flags().BoolVar(&createHereFlag, "here", false, "Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both)")
 	sessionsCreateCmd.Flags().BoolVar(&createInPlaceFlag, "in-place", false, "Alias for --here")
+	sessionsCreateCmd.Flags().StringVar(&createBackendFlag, "backend", "", "Runtime to run the session on (one of: "+config.BackendLocal+", "+config.BackendDocker+", "+config.BackendSSH+", "+config.BackendHook+"; defaults to the repo's backend config, or local). docker/ssh are not yet implemented")
 	sessionsCreateCmd.MarkFlagRequired("name")
 
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptCreateFlag, "create", false, "Auto-create the session if it doesn't exist")

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -184,6 +184,7 @@ var (
 	createProgramFlag string
 	createHereFlag    bool
 	createInPlaceFlag bool
+	createBackendFlag string
 )
 
 var sessionsCreateCmd = &cobra.Command{
@@ -252,6 +253,16 @@ pointing at one).`,
 			return jsonError(err)
 		}
 
+		// Validate --backend up front so a typo fails on the client with a clear
+		// message rather than after a daemon round trip (#1592 Phase 4 PR3). An
+		// empty flag defers to the repo's `backend` config key.
+		if _, err := session.ParseBackendKind(createBackendFlag); err != nil {
+			return jsonError(err)
+		}
+		if inPlace && createBackendFlag != "" && createBackendFlag != config.BackendLocal {
+			return jsonError(fmt.Errorf("--here runs in the local working tree and is incompatible with --backend %s", createBackendFlag))
+		}
+
 		data, err := createSessionViaDaemon(daemon.CreateSessionRequest{
 			Title:    createNameFlag,
 			RepoPath: repo.Root,
@@ -259,6 +270,7 @@ pointing at one).`,
 			Prompt:   createPromptFlag,
 			AutoYes:  cfg.AutoYes,
 			InPlace:  inPlace,
+			Backend:  createBackendFlag,
 		})
 		if err != nil {
 			return jsonError(err)

--- a/config/backend.go
+++ b/config/backend.go
@@ -1,0 +1,54 @@
+package config
+
+// Backend selection (#1592 Phase 4 PR3). A repo declares which runtime its
+// sessions run on via the in-repo `backend` key, alongside the docker/ssh
+// sections that parameterize the two sandboxed runtimes. The canonical values
+// are the four registered runtimes; validation of the VALUE lives at
+// backend-resolution time in the session package (mirroring how RemoteHooks are
+// validated when a backend is resolved, not at config load), so the config
+// layer only carries the raw strings and structs.
+//
+// The four canonical `backend` values. `local` (or empty) is the default —
+// today's in-process tmux+worktree runtime, unchanged. `hook` is the existing
+// remote-hook backend. `docker` and `ssh` are the first-class sandboxed
+// runtimes (implemented in Phase 4 PR4/PR5); until then they resolve to a
+// registered runtime that returns a clear "not yet implemented" error.
+const (
+	BackendLocal  = "local"
+	BackendDocker = "docker"
+	BackendSSH    = "ssh"
+	BackendHook   = "hook"
+)
+
+// DockerConfig parameterizes the docker runtime (#1592 Phase 4 PR3 config
+// surface; the runtime that consumes it lands in PR4). A session with
+// `backend = "docker"` runs its workspace + agent in a container started from
+// Image, with RunArgs appended to the `docker run` invocation.
+type DockerConfig struct {
+	// Image is the container image the session's sandbox is started from. It
+	// must carry git + the agent CLIs + the `af` binary (or have `af` copied in
+	// per the BYO-image recipe). Required when the docker runtime is selected;
+	// the requirement is enforced by the runtime, not at config load.
+	Image string `json:"image,omitempty" toml:"image,omitempty"`
+	// RunArgs are extra arguments appended verbatim to `docker run` (e.g. extra
+	// mounts, env, or resource limits). Optional.
+	RunArgs []string `json:"run_args,omitempty" toml:"run_args,omitempty"`
+}
+
+// SSHConfig parameterizes the ssh runtime (#1592 Phase 4 PR3 config surface; the
+// runtime that consumes it lands in PR5). A session with `backend = "ssh"` runs
+// its workspace + agent on Host over an ssh connection, with the agent-server
+// reached through a local-forward tunnel.
+type SSHConfig struct {
+	// Host is the ssh target (`host` or `host:port`) the session is provisioned
+	// on. Required when the ssh runtime is selected; enforced by the runtime.
+	Host string `json:"host,omitempty" toml:"host,omitempty"`
+	// User is the ssh login user. Optional — empty defers to the ssh client's
+	// default (the current user or an ssh_config Match).
+	User string `json:"user,omitempty" toml:"user,omitempty"`
+	// Port is the ssh port. Optional — 0 means the default (22).
+	Port int `json:"port,omitempty" toml:"port,omitempty"`
+	// IdentityFile is the path to the private key used for auth. Optional —
+	// empty defers to the agent/default keys.
+	IdentityFile string `json:"identity_file,omitempty" toml:"identity_file,omitempty"`
+}

--- a/config/inrepo.go
+++ b/config/inrepo.go
@@ -47,6 +47,17 @@ type InRepoConfig struct {
 	// RemoteHooks configures the remote hook backend for this repo.
 	RemoteHooks *RemoteHooks `json:"remote_hooks,omitempty" toml:"remote_hooks,omitempty"`
 
+	// Backend selects the runtime a repo's sessions run on (#1592 Phase 4 PR3):
+	// one of local|docker|ssh|hook (empty means local, the default). The value
+	// is validated when a session's runtime is resolved (session package), not
+	// at config load — the same "validate at resolution, not load" contract the
+	// remote-hook commands follow.
+	Backend string `json:"backend,omitempty" toml:"backend,omitempty"`
+	// Docker parameterizes the docker runtime (used when Backend == "docker").
+	Docker *DockerConfig `json:"docker,omitempty" toml:"docker,omitempty"`
+	// SSH parameterizes the ssh runtime (used when Backend == "ssh").
+	SSH *SSHConfig `json:"ssh,omitempty" toml:"ssh,omitempty"`
+
 	// setKeys records which top-level keys were present in the JSON file so
 	// the resolver can distinguish "set to an empty value" (overrides) from
 	// "absent" (falls through to the legacy/global value).
@@ -80,10 +91,13 @@ func (c *InRepoConfig) CommandBearingFields() []string {
 // contain. Anything else is rejected so typos fail loudly instead of being
 // silently ignored in a file that can execute shell commands.
 var inRepoAllowedKeys = []string{
+	"backend",
 	"default_program",
+	"docker",
 	"post_worktree_commands",
 	"program_overrides",
 	"remote_hooks",
+	"ssh",
 }
 
 // inRepoGlobalOnlyKeys maps keys that configure the host or daemon — not the

--- a/config/inrepo_test.go
+++ b/config/inrepo_test.go
@@ -53,6 +53,44 @@ func TestLoadInRepoConfigFields(t *testing.T) {
 	assert.Equal(t, []string{"post_worktree_commands", "program_overrides", "remote_hooks"}, cfg.CommandBearingFields())
 }
 
+// TestLoadInRepoConfigBackendKeys covers the Phase 4 PR3 config surface: the
+// `backend` selector and the `docker`/`ssh` sections load, are marked set, and
+// resolve through ResolveConfig — while an unknown value is not rejected at load
+// (validation runs when the runtime is resolved, like remote_hooks).
+func TestLoadInRepoConfigBackendKeys(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	writeInRepoConfig(t, repoRoot, `{
+		"backend": "docker",
+		"docker": {"image": "af-runtime:latest", "run_args": ["--memory", "2g"]},
+		"ssh": {"host": "build-box", "user": "ci", "port": 2222, "identity_file": "/keys/id"}
+	}`)
+
+	cfg, _, err := LoadInRepoConfig(repoRoot)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "docker", cfg.Backend)
+	require.NotNil(t, cfg.Docker)
+	assert.Equal(t, "af-runtime:latest", cfg.Docker.Image)
+	assert.Equal(t, []string{"--memory", "2g"}, cfg.Docker.RunArgs)
+	require.NotNil(t, cfg.SSH)
+	assert.Equal(t, "build-box", cfg.SSH.Host)
+	assert.Equal(t, "ci", cfg.SSH.User)
+	assert.Equal(t, 2222, cfg.SSH.Port)
+	assert.Equal(t, "/keys/id", cfg.SSH.IdentityFile)
+	for _, key := range []string{"backend", "docker", "ssh"} {
+		assert.True(t, cfg.IsSet(key), "expected %s to be marked set", key)
+	}
+
+	res, err := ResolveConfig(repoRoot)
+	require.NoError(t, err)
+	assert.Equal(t, "docker", res.Backend)
+	require.NotNil(t, res.Docker)
+	assert.Equal(t, "af-runtime:latest", res.Docker.Image)
+	require.NotNil(t, res.SSH)
+	assert.Equal(t, "build-box", res.SSH.Host)
+}
+
 func TestLoadInRepoConfigEmptyValueIsSet(t *testing.T) {
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	repoRoot := t.TempDir()

--- a/config/resolve.go
+++ b/config/resolve.go
@@ -42,6 +42,16 @@ type ResolvedConfig struct {
 	// absolute paths under repoRoot (#834); consumers can exec them without
 	// caring about the process cwd.
 	RemoteHooks *RemoteHooks
+
+	// Backend is the effective `backend` runtime selector (#1592 Phase 4 PR3):
+	// one of local|docker|ssh|hook, empty meaning local. In-repo only — there
+	// is no legacy per-repo location for it. Validated by the session package
+	// when it resolves the runtime, not here.
+	Backend string
+	// Docker/SSH parameterize the docker/ssh runtimes; non-nil only when the
+	// repo's in-repo config declares the corresponding section.
+	Docker *DockerConfig
+	SSH    *SSHConfig
 }
 
 // ResolveConfig returns the effective configuration for the repository
@@ -94,6 +104,17 @@ func ResolveConfig(repoRoot string) (*ResolvedConfig, error) {
 		}
 		if inRepo.IsSet("remote_hooks") {
 			res.RemoteHooks = inRepo.RemoteHooks
+		}
+		// backend/docker/ssh are in-repo only (no legacy location), so they
+		// take the in-repo value directly whenever present.
+		if inRepo.Backend != "" {
+			res.Backend = inRepo.Backend
+		}
+		if inRepo.IsSet("docker") {
+			res.Docker = inRepo.Docker
+		}
+		if inRepo.IsSet("ssh") {
+			res.SSH = inRepo.SSH
 		}
 		logInRepoConfigLoaded(repoID, repoRoot, inRepo, raw)
 	}

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -25,6 +25,12 @@ type CreateSessionRequest struct {
 	// intact. Incompatible with ForceRemote.
 	InPlace     bool `json:"in_place"`
 	ForceRemote bool `json:"force_remote"`
+	// Backend explicitly selects the session's runtime (the `--backend` create
+	// flag, #1592 Phase 4 PR3): one of local|docker|ssh|hook. Empty resolves
+	// from the repo's `backend` config key, defaulting to local. docker/ssh are
+	// registered but not yet implemented (they fail create with a clear error
+	// until Phase 4 PR4/PR5).
+	Backend string `json:"backend,omitempty"`
 
 	// allowReserved lets the daemon's own root-agent ensure loop (#1106)
 	// create the reserved "root" title that reserveCreate rejects for

--- a/daemon/httproutes_test.go
+++ b/daemon/httproutes_test.go
@@ -101,7 +101,7 @@ func TestHTTPRoutes_RequestFieldsMatchWireStruct(t *testing.T) {
 	}
 	require.NotNil(t, create)
 	assert.Equal(t,
-		[]string{"title", "title_base", "repo_path", "program", "prompt", "auto_yes", "in_place", "force_remote"},
+		[]string{"title", "title_base", "repo_path", "program", "prompt", "auto_yes", "in_place", "force_remote", "backend"},
 		create.RequestFields,
 		"request_fields must mirror CreateSessionRequest's json tags in declaration order")
 }

--- a/daemon/manager_create.go
+++ b/daemon/manager_create.go
@@ -44,6 +44,7 @@ func (m *Manager) CreateSession(req CreateSessionRequest) (session.InstanceData,
 		AutoYes:     req.AutoYes,
 		InPlace:     req.InPlace,
 		ForceRemote: req.ForceRemote,
+		Backend:     session.BackendKind(req.Backend),
 	})
 	if err != nil {
 		return session.InstanceData{}, err

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,9 +238,39 @@ terminal_cmd = "./infra/terminal.sh"
 |-------|-------|
 | `default_program`, `program_overrides` | Valid globally **and** in-repo (in-repo wins). |
 | `post_worktree_commands`, `remote_hooks` | **In-repo only.** The legacy `~/.agent-factory/repos/<repoID>/config.json` location keeps working for one more release (a deprecation warning in the log points at the new file) and is shadowed whenever the in-repo file sets the same key — including by an explicit empty value like `post_worktree_commands = []`. |
+| `backend`, `docker`, `ssh` | **In-repo only.** Select the runtime a repo's sessions run on. |
 | `auto_yes`, `auto_update`, `daemon_poll_interval`, `branch_prefix`, `worktree_root`, `detach_keys`, `log_max_size_mb`, `log_max_backups`, `update_channel`, `keys`, `root_agents`, `limit_auto_resume`, `limit_retry_interval` | Global only. Setting them in-repo is rejected with an error naming the key. |
 
 `post_worktree_commands` are shell commands run after each new worktree is created (e.g. `npm install`, `make build`) — they can also be edited from the TUI via the `e` (worktree hooks) key. `remote_hooks` configures a remote-machine backend; see [remote-hooks.md](remote-hooks.md) for the script protocol.
+
+### Backend runtime (`backend`, `docker`, `ssh`)
+
+`backend` selects the runtime a repo's sessions run on, and `--backend` overrides
+it per `af sessions create`:
+
+| Value | Runtime |
+|-------|---------|
+| `local` (default, or unset) | Today's in-process runtime: the agent runs as a tmux session in a git worktree on the machine running the daemon. |
+| `hook` | The remote-hook backend — a bring-your-own provisioner driven by the `[remote_hooks]` scripts (equivalent to the TUI's "new remote session"). |
+| `docker` | Run the workspace + agent in a container started from `[docker].image`. *Not yet implemented — selecting it fails create with a clear error (arrives in a later Phase 4 PR).* |
+| `ssh` | Run the workspace + agent on `[ssh].host` over ssh. *Not yet implemented — selecting it fails create with a clear error (arrives in a later Phase 4 PR).* |
+
+```toml
+backend = "docker"
+
+[docker]
+image = "af-runtime:latest"
+run_args = ["--memory", "2g"]
+
+[ssh]
+host = "build-box"
+user = "ci"
+port = 2222
+identity_file = "~/.ssh/id_ed25519"
+```
+
+An unknown `backend` value (or `--backend`) is reported when the session's
+runtime is resolved at create time, naming the valid options.
 
 ### In-repo file name: `config.toml` or `config.json`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -13,7 +13,7 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | Method | Path | Request fields | Description |
 |--------|------|----------------|-------------|
 | `GET` | `/v1/health` | — | Liveness probe (alias for the Ping RPC); answers even while the daemon is restoring sessions. |
-| `POST` | `/v1/CreateSession` | `title`, `title_base`, `repo_path`, `program`, `prompt`, `auto_yes`, `in_place`, `force_remote` | Create a new session (git worktree + agent) in a repo. |
+| `POST` | `/v1/CreateSession` | `title`, `title_base`, `repo_path`, `program`, `prompt`, `auto_yes`, `in_place`, `force_remote`, `backend` | Create a new session (git worktree + agent) in a repo. |
 | `POST` | `/v1/Snapshot` | `repo_id` | List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos). |
 | `POST` | `/v1/KillSession` | `title`, `repo_id` | Tear down a session: kill its tmux/agent and remove its worktree and record. |
 | `POST` | `/v1/ArchiveSession` | `title`, `repo_id` | Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -892,6 +892,7 @@ af sessions create [flags]
 
 | Flag | Type | Description |
 |------|------|-------------|
+| `--backend` | `string` | Runtime to run the session on (one of: local, docker, ssh, hook; defaults to the repo's backend config, or local). docker/ssh are not yet implemented |
 | `--here` |  | Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both) |
 | `--in-place` |  | Alias for --here |
 | `--name` | `string` | Session name (required) |

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -18,8 +18,16 @@ type InstanceOptions struct {
 	// If AutoYes is true, then
 	AutoYes bool
 	// ForceRemote forces the instance to use the remote hook backend,
-	// even if the repo config would default to local.
+	// even if the repo config would default to local. It is the pre-Phase-4
+	// hook selector, equivalent to Backend == BackendHook, and takes precedence
+	// over a config-declared backend (it is set by the TUI's "new remote
+	// session" action, which means "hook now" regardless of config).
 	ForceRemote bool
+	// Backend, when set, selects the session's runtime explicitly (the
+	// `--backend` create flag, #1592 Phase 4 PR3), overriding the repo's
+	// `backend` config key. Empty means "resolve from config" — which defaults
+	// to local, so an unset Backend keeps the local default byte-identical.
+	Backend BackendKind
 	// InPlace attaches the session to the repo's existing working tree at its
 	// current branch (`af sessions create --here`) instead of creating a new
 	// git worktree+branch. The worktree is marked external so kill/cleanup
@@ -40,15 +48,56 @@ type InstanceOptions struct {
 // code paths. Defaults to the real local/remote branching.
 var backendFactory = defaultBackendFactory
 
+// defaultBackendFactory resolves the session's runtime from the requested
+// backend kind (the `--backend` flag / repo `backend` config, or ForceRemote for
+// the legacy hook path) and provisions it, returning the in-process Backend. It
+// is the production path behind the backendFactory test seam; a test that
+// replaces backendFactory injects a FakeBackend directly and never reaches here.
+//
+// The remote-endpoint half of a runtime's provision result (ProvisionResult.
+// Endpoint) is intentionally not consumed on this path in PR3: local/hook
+// provision in-process (nil endpoint) and docker/ssh error out, so no non-nil
+// endpoint is ever produced yet. PR4/PR5 wire the endpoint through when the
+// sandboxed runtimes start producing one.
 func defaultBackendFactory(opts InstanceOptions, absPath string) (Backend, error) {
-	if opts.ForceRemote {
-		hook, err := loadHookBackendForPath(absPath)
-		if err != nil {
-			return nil, fmt.Errorf("remote hooks not configured for this repo: %w", err)
-		}
-		return hook, nil
+	kind, err := resolveBackendKind(opts, absPath)
+	if err != nil {
+		return nil, err
 	}
-	return &LocalBackend{}, nil
+	rt, err := ResolveRuntime(kind)
+	if err != nil {
+		return nil, err
+	}
+	res, err := rt.Provision(ProvisionSpec{RepoRoot: absPath})
+	if err != nil {
+		return nil, err
+	}
+	return res.Backend, nil
+}
+
+// resolveBackendKind decides which runtime a new session uses, in precedence
+// order: an explicit --backend flag (opts.Backend) wins; then the legacy
+// ForceRemote hook selector; otherwise the repo's `backend` config key, which
+// defaults to local.
+//
+// The config read is best-effort for the DEFAULT (no explicit selection) path:
+// a path that is not a git repo, or a repo with no readable config, falls back
+// to local so a local session is never blocked by config resolution here (the
+// same posture as before Phase 4, where this factory read no config for a local
+// session). A config that loads but declares an invalid backend value surfaces
+// that error — misconfiguration should fail the create, not silently run local.
+func resolveBackendKind(opts InstanceOptions, absPath string) (BackendKind, error) {
+	if opts.Backend != "" {
+		return ParseBackendKind(string(opts.Backend))
+	}
+	if opts.ForceRemote {
+		return BackendHook, nil
+	}
+	cfg, err := resolveRepoConfig(absPath)
+	if err != nil {
+		return BackendLocal, nil
+	}
+	return ParseBackendKind(cfg.Backend)
 }
 
 // SetBackendFactoryForTest replaces the backend factory with f and returns a
@@ -80,8 +129,10 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 	t := time.Now()
 
 	// An in-place session runs in the repo's local working tree; a remote
-	// session has no local worktree at all — the two are contradictory.
-	if opts.InPlace && opts.ForceRemote {
+	// session has no local worktree at all — the two are contradictory. This
+	// covers both the legacy ForceRemote hook selector and an explicit
+	// non-local --backend (#1592 Phase 4 PR3).
+	if opts.InPlace && (opts.ForceRemote || (opts.Backend != "" && opts.Backend != BackendLocal)) {
 		return nil, fmt.Errorf("remote sessions cannot run in-place in the local repo working tree")
 	}
 

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -1,0 +1,182 @@
+package session
+
+import (
+	"fmt"
+
+	"github.com/sachiniyer/agent-factory/config"
+)
+
+// BackendKind names a session runtime family (#1592 Phase 4 PR3). It is the
+// value of the in-repo `backend` config key and the `--backend` create flag,
+// and the key the runtime registry maps to a Runtime constructor.
+type BackendKind string
+
+const (
+	// BackendLocal is today's in-process runtime: the agent runs as a tmux
+	// session in a git worktree on the daemon's own box. The default — an empty
+	// `backend` selection resolves here, unchanged from before Phase 4.
+	BackendLocal BackendKind = config.BackendLocal
+	// BackendDocker runs the workspace + agent in a container (Phase 4 PR4).
+	BackendDocker BackendKind = config.BackendDocker
+	// BackendSSH runs the workspace + agent on a remote host over ssh (PR5).
+	BackendSSH BackendKind = config.BackendSSH
+	// BackendHook is the existing remote-hook backend (the bring-your-own
+	// provisioner escape hatch). Adapted to the Runtime seam here; its
+	// provision-and-expose migration is PR7.
+	BackendHook BackendKind = config.BackendHook
+)
+
+// ParseBackendKind validates a raw `backend` value (from the `--backend` flag or
+// the in-repo config) and returns the corresponding BackendKind. An empty value
+// is the default, local. An unknown value is a misconfiguration and errors —
+// mirroring RemoteHooks.Validate, this validation runs when a runtime is
+// resolved at create time, not at config load.
+func ParseBackendKind(s string) (BackendKind, error) {
+	switch s {
+	case "":
+		return BackendLocal, nil
+	case config.BackendLocal, config.BackendDocker, config.BackendSSH, config.BackendHook:
+		return BackendKind(s), nil
+	default:
+		return "", fmt.Errorf("unknown backend %q (valid: %s, %s, %s, %s)",
+			s, config.BackendLocal, config.BackendDocker, config.BackendSSH, config.BackendHook)
+	}
+}
+
+// ProvisionSpec is the input a Runtime needs to establish a session's execution
+// environment. It is deliberately small: the local/hook runtimes provision from
+// the repo root alone, and the sandboxed runtimes (docker/ssh) read their own
+// section from the repo's resolved config by RepoRoot. PR4/PR5 extend it with
+// what a sandbox needs (the repo@branch to clone, the agent-server workspace id)
+// when those runtimes start consuming it.
+type ProvisionSpec struct {
+	// RepoRoot is the absolute repo root the session is created against.
+	RepoRoot string
+}
+
+// ProvisionResult is what a Runtime hands back: the in-process Backend that
+// drives the session plus, for a runtime that runs the agent in a remote
+// sandbox, the authed endpoint the daemon's remoteAgentServer (PR2) dials.
+type ProvisionResult struct {
+	// Backend is the in-process Backend an Instance is built with. Always set
+	// on success.
+	Backend Backend
+	// Endpoint is the authed `af agent-server` URL + token + TLS pin a sandbox
+	// runtime exposes (#1592 Phase 4). nil for an in-process runtime
+	// (local/hook), whose agent-server is the local tmux facade with no network
+	// hop. The docker/ssh runtimes fill this in PR4/PR5; NewInstance threads a
+	// non-nil endpoint into the instance's remote agent-server client. The
+	// runtime-contract test exercises the non-nil path via a fake runtime.
+	Endpoint *AgentServerEndpoint
+}
+
+// Runtime is the provision-and-expose seam (#1592 Phase 4 PR3): given a session
+// spec it establishes the workspace/sandbox and exposes an agent-server in it,
+// returning the wiring a new Instance needs. It is the extensibility point the
+// docker and ssh runtimes plug into — the registry below maps a `backend` value
+// to a Runtime, and session creation resolves one from config instead of
+// hard-coding local-vs-hook.
+//
+// The local and hook runtimes provision in-process on the daemon's box, so they
+// expose an in-process endpoint (Endpoint nil) and the session keeps using the
+// local AgentServer over tmux — byte-identical to before Phase 4. The docker and
+// ssh runtimes (PR4/PR5) provision a real sandbox, start an `af agent-server`,
+// and expose its authed wss:// URL; the session then drives it through the
+// remoteAgentServer client (PR2). Both satisfy this one interface, so the create
+// flow above does not branch on locality.
+type Runtime interface {
+	// Provision establishes the session's execution environment and returns the
+	// backend (+ optional remote endpoint) the instance is built with.
+	Provision(spec ProvisionSpec) (ProvisionResult, error)
+}
+
+// runtimeRegistry maps a BackendKind to the constructor for its Runtime. It is
+// the single source of truth for "which runtimes exist"; ResolveRuntime looks a
+// kind up here. Keeping it a map (not a switch) is what makes the set
+// extensible — PR4/PR5 register real docker/ssh runtimes by swapping their
+// entries, and a future out-of-tree runtime could register here too.
+var runtimeRegistry = map[BackendKind]func() Runtime{
+	BackendLocal:  func() Runtime { return localRuntime{} },
+	BackendHook:   func() Runtime { return hookRuntime{} },
+	BackendDocker: func() Runtime { return dockerRuntime{} },
+	BackendSSH:    func() Runtime { return sshRuntime{} },
+}
+
+// ResolveRuntime returns the Runtime registered for kind, or an error naming the
+// unknown backend. Every registered kind is constructible; the docker/ssh
+// runtimes construct fine but return a not-implemented error from Provision
+// until PR4/PR5.
+func ResolveRuntime(kind BackendKind) (Runtime, error) {
+	ctor, ok := runtimeRegistry[kind]
+	if !ok {
+		return nil, fmt.Errorf("unknown backend %q", kind)
+	}
+	return ctor(), nil
+}
+
+// localRuntime is the default in-process runtime: a git worktree + tmux agent on
+// the daemon's own box. Its Provision is exactly what defaultBackendFactory
+// returned for a non-remote session before Phase 4 — a bare LocalBackend, no
+// endpoint — so a local session is byte-identical to today.
+type localRuntime struct{}
+
+func (localRuntime) Provision(ProvisionSpec) (ProvisionResult, error) {
+	return ProvisionResult{Backend: &LocalBackend{}}, nil
+}
+
+// hookRuntime adapts the existing remote-hook backend to the Runtime seam. It
+// loads the repo's validated RemoteHooks and builds a HookBackend — the same
+// backend the pre-Phase-4 ForceRemote path produced — so remote-hook sessions
+// keep working unchanged. Its migration to a real provision-and-expose contract
+// (launch_cmd returns an agent-server URL) is PR7.
+type hookRuntime struct{}
+
+func (hookRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
+	hook, err := loadHookBackendForPath(spec.RepoRoot)
+	if err != nil {
+		return ProvisionResult{}, fmt.Errorf("remote hooks not configured for this repo: %w", err)
+	}
+	return ProvisionResult{Backend: hook}, nil
+}
+
+// dockerRuntime is registered so `backend = "docker"` resolves cleanly, but its
+// real provisioning (run a container, clone repo@branch, start an
+// `af agent-server`, expose its published-port URL) lands in PR4. Until then it
+// fails create with an actionable error. It reads the resolved docker.image so a
+// user who has already configured it gets it echoed back — and so the config
+// field is genuinely consumed here, not dead until PR4.
+type dockerRuntime struct{}
+
+func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
+	image := ""
+	if cfg, err := resolveRepoConfig(spec.RepoRoot); err == nil && cfg.Docker != nil {
+		image = cfg.Docker.Image
+	}
+	return ProvisionResult{}, fmt.Errorf("the docker backend is not yet implemented (image %q); it lands in #1592 Phase 4 PR4 — use backend=local for now", image)
+}
+
+// sshRuntime is registered so `backend = "ssh"` resolves cleanly; its real
+// provisioning (dial the host, clone repo@branch, start an `af agent-server`,
+// tunnel its port back) lands in PR5. Until then it fails create with an
+// actionable error, echoing the configured ssh.host for the same reason
+// dockerRuntime echoes the image.
+type sshRuntime struct{}
+
+func (sshRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
+	host := ""
+	if cfg, err := resolveRepoConfig(spec.RepoRoot); err == nil && cfg.SSH != nil {
+		host = cfg.SSH.Host
+	}
+	return ProvisionResult{}, fmt.Errorf("the ssh backend is not yet implemented (host %q); it lands in #1592 Phase 4 PR5 — use backend=local for now", host)
+}
+
+// resolveRepoConfig loads the resolved config for the repo containing absPath.
+// Shared by the runtime resolver (to read the `backend` key) and the docker/ssh
+// runtimes (to read their sections).
+func resolveRepoConfig(absPath string) (*config.ResolvedConfig, error) {
+	repo, err := config.RepoFromPath(absPath)
+	if err != nil {
+		return nil, err
+	}
+	return config.ResolveConfig(repo.Root)
+}

--- a/session/runtime_test.go
+++ b/session/runtime_test.go
@@ -1,0 +1,231 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeInRepoConfig drops a .agent-factory/config.json with the given fields at
+// repoRoot, so config.ResolveConfig (and the runtime resolver above it) picks up
+// a `backend` selection for the repo.
+func writeInRepoConfig(t *testing.T, repoRoot string, fields map[string]any) {
+	t.Helper()
+	dir := filepath.Join(repoRoot, config.InRepoConfigDirName)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	data, err := json.Marshal(fields)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, config.ConfigFileName), data, 0644))
+}
+
+// TestParseBackendKind pins the enum validation: empty defaults to local, the
+// four canonical values round-trip, and anything else is a clear error (the
+// validation the --backend flag and the config `backend` key both run).
+func TestParseBackendKind(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    BackendKind
+		wantErr bool
+	}{
+		{"", BackendLocal, false},
+		{"local", BackendLocal, false},
+		{"docker", BackendDocker, false},
+		{"ssh", BackendSSH, false},
+		{"hook", BackendHook, false},
+		{"nope", "", true},
+		{"Local", "", true}, // case-sensitive
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseBackendKind(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestResolveRuntime_RegistryMapsEveryBackend proves the registry maps each
+// canonical backend to its Runtime and rejects an unknown one. This is the
+// "registry maps backend→Runtime" gate.
+func TestResolveRuntime_RegistryMapsEveryBackend(t *testing.T) {
+	cases := []struct {
+		kind BackendKind
+		want Runtime
+	}{
+		{BackendLocal, localRuntime{}},
+		{BackendHook, hookRuntime{}},
+		{BackendDocker, dockerRuntime{}},
+		{BackendSSH, sshRuntime{}},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			rt, err := ResolveRuntime(tc.kind)
+			require.NoError(t, err)
+			assert.IsType(t, tc.want, rt)
+		})
+	}
+
+	if _, err := ResolveRuntime("kubernetes"); err == nil {
+		t.Fatal("ResolveRuntime(unknown): want error, got nil")
+	}
+}
+
+// TestLocalRuntimeProvision_Unchanged locks the local default: the local runtime
+// provisions a bare LocalBackend and no remote endpoint — byte-identical to the
+// pre-Phase-4 factory.
+func TestLocalRuntimeProvision_Unchanged(t *testing.T) {
+	res, err := localRuntime{}.Provision(ProvisionSpec{RepoRoot: t.TempDir()})
+	require.NoError(t, err)
+	if _, ok := res.Backend.(*LocalBackend); !ok {
+		t.Fatalf("local runtime must provision a *LocalBackend, got %T", res.Backend)
+	}
+	assert.Nil(t, res.Endpoint, "an in-process runtime exposes no remote endpoint")
+}
+
+// TestDockerSSHRuntime_NotImplemented proves docker and ssh are registered but
+// fail create with a clear, actionable error naming the PR that implements them
+// — and that the error echoes the configured image/host (so the config sections
+// are genuinely consumed).
+func TestDockerSSHRuntime_NotImplemented(t *testing.T) {
+	repoRoot := initTempGitRepo(t)
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+	writeInRepoConfig(t, repoRoot, map[string]any{
+		"backend": "docker",
+		"docker":  map[string]any{"image": "my-runtime:latest"},
+		"ssh":     map[string]any{"host": "build-box:2222"},
+	})
+
+	_, derr := dockerRuntime{}.Provision(ProvisionSpec{RepoRoot: repoRoot})
+	require.Error(t, derr)
+	assert.Contains(t, derr.Error(), "docker backend is not yet implemented")
+	assert.Contains(t, derr.Error(), "PR4")
+	assert.Contains(t, derr.Error(), "my-runtime:latest")
+
+	_, serr := sshRuntime{}.Provision(ProvisionSpec{RepoRoot: repoRoot})
+	require.Error(t, serr)
+	assert.Contains(t, serr.Error(), "ssh backend is not yet implemented")
+	assert.Contains(t, serr.Error(), "PR5")
+	assert.Contains(t, serr.Error(), "build-box:2222")
+}
+
+// fakeRuntime is a Runtime that returns a fixed provision result — used to
+// exercise the interface contract, including the remote-endpoint half that the
+// real local/hook runtimes leave nil and docker/ssh don't reach yet.
+type fakeRuntime struct {
+	res ProvisionResult
+	err error
+}
+
+func (f fakeRuntime) Provision(ProvisionSpec) (ProvisionResult, error) { return f.res, f.err }
+
+// TestRuntimeContract_SurfacesEndpoint proves the Runtime contract carries a
+// remote agent-server endpoint end-to-end: a runtime that provisions a sandbox
+// returns its authed endpoint alongside the backend, which is exactly what the
+// docker/ssh runtimes will fill in PR4/PR5.
+func TestRuntimeContract_SurfacesEndpoint(t *testing.T) {
+	ep := &AgentServerEndpoint{URL: "wss://127.0.0.1:9", Token: "tok", Fingerprint: validFingerprint}
+	var rt Runtime = fakeRuntime{res: ProvisionResult{Backend: &LocalBackend{}, Endpoint: ep}}
+
+	res, err := rt.Provision(ProvisionSpec{RepoRoot: t.TempDir()})
+	require.NoError(t, err)
+	require.NotNil(t, res.Backend)
+	require.NotNil(t, res.Endpoint)
+	assert.Equal(t, ep.URL, res.Endpoint.URL)
+	assert.Equal(t, ep.Token, res.Endpoint.Token)
+}
+
+// TestResolveBackendKind_Precedence pins the selection precedence: an explicit
+// --backend wins, then ForceRemote (the legacy hook selector), then the repo's
+// `backend` config; a non-repo path and an unreadable config both fall back to
+// local so a local create is never blocked here.
+func TestResolveBackendKind_Precedence(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	// Explicit flag wins over everything (even ForceRemote).
+	got, err := resolveBackendKind(InstanceOptions{Backend: BackendDocker, ForceRemote: true}, t.TempDir())
+	require.NoError(t, err)
+	assert.Equal(t, BackendDocker, got)
+
+	// Invalid explicit flag errors.
+	if _, err := resolveBackendKind(InstanceOptions{Backend: "nope"}, t.TempDir()); err == nil {
+		t.Fatal("resolveBackendKind(invalid --backend): want error")
+	}
+
+	// ForceRemote selects hook when no explicit backend is given.
+	got, err = resolveBackendKind(InstanceOptions{ForceRemote: true}, t.TempDir())
+	require.NoError(t, err)
+	assert.Equal(t, BackendHook, got)
+
+	// A non-repo path with no explicit selection defaults to local.
+	got, err = resolveBackendKind(InstanceOptions{}, t.TempDir())
+	require.NoError(t, err)
+	assert.Equal(t, BackendLocal, got)
+
+	// The repo `backend` config key drives the default path.
+	repoRoot := initTempGitRepo(t)
+	writeInRepoConfig(t, repoRoot, map[string]any{"backend": "ssh", "ssh": map[string]any{"host": "h"}})
+	got, err = resolveBackendKind(InstanceOptions{}, repoRoot)
+	require.NoError(t, err)
+	assert.Equal(t, BackendSSH, got)
+}
+
+// TestDefaultBackendFactory_ConfigSelection drives the full factory the way
+// NewInstance does: local is byte-identical, a docker config fails cleanly with
+// the not-implemented error, and a hook config still resolves to a working
+// HookBackend (the "hook still works" gate).
+func TestDefaultBackendFactory_ConfigSelection(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	t.Run("local default is a plain LocalBackend", func(t *testing.T) {
+		repoRoot := initTempGitRepo(t) // no in-repo config → local
+		b, err := defaultBackendFactory(InstanceOptions{Title: "s"}, repoRoot)
+		require.NoError(t, err)
+		if _, ok := b.(*LocalBackend); !ok {
+			t.Fatalf("local default must be *LocalBackend, got %T", b)
+		}
+	})
+
+	t.Run("docker config fails not-implemented", func(t *testing.T) {
+		repoRoot := initTempGitRepo(t)
+		writeInRepoConfig(t, repoRoot, map[string]any{"backend": "docker", "docker": map[string]any{"image": "img"}})
+		_, err := defaultBackendFactory(InstanceOptions{Title: "s"}, repoRoot)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not yet implemented")
+	})
+
+	t.Run("hook config still builds a HookBackend", func(t *testing.T) {
+		repoRoot := initTempGitRepo(t)
+		writeInRepoConfig(t, repoRoot, map[string]any{
+			"backend": "hook",
+			"remote_hooks": map[string]any{
+				"launch_cmd": "echo",
+				"attach_cmd": "echo",
+				"delete_cmd": "echo",
+			},
+		})
+		b, err := defaultBackendFactory(InstanceOptions{Title: "s"}, repoRoot)
+		require.NoError(t, err)
+		if _, ok := b.(*HookBackend); !ok {
+			t.Fatalf("backend=hook must build a *HookBackend, got %T", b)
+		}
+	})
+
+	t.Run("hook config without hooks errors cleanly", func(t *testing.T) {
+		repoRoot := initTempGitRepo(t)
+		writeInRepoConfig(t, repoRoot, map[string]any{"backend": "hook"})
+		_, err := defaultBackendFactory(InstanceOptions{Title: "s"}, repoRoot)
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "remote hooks not configured"),
+			"want 'remote hooks not configured', got %v", err)
+	})
+}


### PR DESCRIPTION
## What

Phase 4 PR3 of #1592. Adds the **`Runtime` provision-and-expose interface**, the **registry** that maps a `backend` config value to a Runtime, and the **config selection** that lets a session be created on a chosen runtime. Docker/SSH *implementations* land in PR4/PR5 — this PR is the interface + wiring + the existing local/hook runtimes adapted to it.

Merged prerequisites: PR1 (`af agent-server` headless), PR2 (`remoteAgentServer` — daemon drives a real out-of-process agent-server over HTTP/WS).

**Local default is byte-identical to today.**

## The Runtime interface (`session/runtime.go`)

```go
type Runtime interface {
    Provision(spec ProvisionSpec) (ProvisionResult, error)
}
type ProvisionResult struct {
    Backend  Backend               // in-process backend the Instance is built with
    Endpoint *AgentServerEndpoint  // authed sandbox agent-server URL+token+pin; nil for in-process
}
```

The single seam docker/ssh plug into. Local/hook provision **in-process** (nil endpoint → the session keeps using the local `AgentServer` over tmux, unchanged). A sandbox runtime (docker/ssh, PR4/PR5) provisions a real sandbox, starts an `af agent-server`, and exposes its authed `wss://` URL — the session then drives it through the `remoteAgentServer` client (PR2). Both satisfy one interface, so the create flow stops branching on locality.

The endpoint half is exercised by the runtime-contract test (a `fakeRuntime` returns one); it is intentionally not consumed on the production path in PR3 because local/hook produce nil and docker/ssh error out — PR4/PR5 wire it through when the sandboxed runtimes start producing one.

## Registry + config selection

- `BackendKind` + `ResolveRuntime` map `local|docker|ssh|hook` → a Runtime constructor.
  - **`local`** (default / empty): today's `LocalBackend` — in-process tmux + git worktree, unchanged.
  - **`hook`**: the existing `HookBackend`, adapted to the seam (its provision-and-expose migration is PR7 — for now it keeps working).
  - **`docker`/`ssh`**: registered but return a clear **"not yet implemented (PR4/PR5)"** error, echoing the configured image/host.
- **Config (the Sachin-locked shape):** in-repo `backend` key + `[docker]` (`image`, `run_args`) and `[ssh]` (`host`, `user`, `port`, `identity_file`) sections. In-repo only (repo-describing, like `remote_hooks`). The `backend` **value** is validated when the runtime is resolved at create time (mirroring how `remote_hooks` validate at resolution, not load).

## Wiring

- New **`--backend`** create flag (validated client-side) → `CreateSessionRequest.Backend` → `InstanceOptions.Backend`.
- Empty `--backend` resolves the repo's `backend` config, defaulting to local. Precedence: **`--backend` > `ForceRemote` (legacy hook selector) > repo `backend` config > local**.
- A config read failure on the default (no explicit selection) path falls back to **local** so a local create is never blocked by config resolution here — the same posture as before Phase 4.
- `--here` / in-place is rejected against a non-local backend.

## Tests

- registry maps every `backend` → its Runtime (+ unknown rejected)
- `ParseBackendKind` enum (empty→local, four values, invalid errors, case-sensitive)
- local runtime unchanged (bare `*LocalBackend`, nil endpoint)
- docker/ssh not-implemented, error names the PR + echoes configured image/host
- **hook still builds a `HookBackend`** via the config path (and errors cleanly when hooks are unconfigured)
- the Runtime contract surfaces a remote endpoint end-to-end (`fakeRuntime`)
- config keys load + resolve through `ResolveConfig`; wire-struct route test updated
- `gen-docs` regenerated (new `--backend` flag + `backend` request field)

## Gates

- gofmt / lint / build / deadcode / file-length clean
- `make test-container` green
- `make tui-driver-selftest` **25/25** (local backend unaffected)

Link #1592. Do **not** merge yet — flagged green here for the root to merge.