### PR TITLE
refactor(api): remove inert kill flag state

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -455,7 +455,10 @@ func init() {
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptAllFlag, "all", false, "Broadcast the prompt to every live session in scope (current repo by default; excludes the reserved root session)")
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptAllReposFlag, "all-repos", false, "With --all, broadcast across every repo instead of only the current/--repo one")
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptIncludeRootFlag, "include-root", false, "With --all, also deliver to the reserved root session (excluded by default)")
-	sessionsKillCmd.Flags().BoolVar(&sessionsKillForce, "force", false, "Deprecated no-op, accepted for compatibility: kill always destroys the session (use 'af sessions archive' to keep it restorable)")
+	// --force is a deprecated no-op. Register it without binding a package
+	// variable: Cobra still accepts existing scripts' flag, but no mutable state
+	// can imply that it affects the always-destructive kill operation.
+	sessionsKillCmd.Flags().Bool("force", false, "Deprecated no-op, accepted for compatibility: kill always destroys the session (use 'af sessions archive' to keep it restorable)")
 	sessionsArchiveCmd.Flags().BoolVar(&sessionsArchiveSelf, "self", false, "Archive the current session (resolved via whoami); use from inside a session when your work is done")
 
 	sessionsWatchCmd.Flags().DurationVar(&watchTimeoutFlag, "timeout", 30*time.Minute, "Give up and exit non-zero if the session is not idle within this window (0 = wait forever)")

--- a/api/sessions.go
+++ b/api/sessions.go
@@ -30,7 +30,6 @@ var (
 	killSessionViaDaemon    = daemon.KillSession
 	archiveSessionViaDaemon = daemon.ArchiveSession
 	restoreSessionViaDaemon = daemon.RestoreSession
-	sessionsKillForce       bool
 	sessionsArchiveSelf     bool
 	sendPromptViaDaemon     = daemon.SendPrompt
 	deliverPromptViaDaemon  = daemon.DeliverPrompt
@@ -783,7 +782,7 @@ its branch — there is no undo. To keep a session restorable instead, archive i
 			return jsonError(err)
 		}
 
-		// --force (sessionsKillForce) is accepted for backward compatibility but
+		// --force is accepted for backward compatibility but
 		// is a no-op: it is intentionally NOT forwarded to the daemon, whose
 		// KillSessionRequest no longer carries a force field (#1579).
 		if err := killSessionViaDaemon(daemon.KillSessionRequest{Title: args[0], RepoID: repoID}); err != nil {

--- a/api/sessions_test.go
+++ b/api/sessions_test.go
@@ -221,14 +221,11 @@ func TestSessionsKill_ForceFlagAcceptedButNotForwarded(t *testing.T) {
 
 	prevRepoFlag := repoFlag
 	repoFlag = ""
-	prevForce := sessionsKillForce
-	sessionsKillForce = false
 	if err := sessionsKillCmd.Flags().Set("force", "true"); err != nil {
 		t.Fatalf("set force flag: %v", err)
 	}
 	t.Cleanup(func() {
 		repoFlag = prevRepoFlag
-		sessionsKillForce = prevForce
 		_ = sessionsKillCmd.Flags().Set("force", "false")
 	})
 


### PR DESCRIPTION
## Summary

- Register the deprecated af sessions kill --force compatibility flag without a package-level bool.
- Remove the unused mutable state and test-only reset logic.

## Behavior preservation

Cobra still exposes the same --force name, default, help text, and parsing behavior. The flag remains an intentional no-op: kill still sends the identical KillSessionRequest, which has no force field.

## Validation

- golangci-lint run --timeout=3m --fast
- gofmt -l .
- go build ./...
- make test-container
- deadcode -test ./...
- make lint-file-length

Refs #1241 and #1195.

Review requested; not self-merged.

— Captain Claude