### PR TITLE
feat(session): docker container runtime — provision-and-expose to parity (#1592 Phase 4 PR4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 
 .PHONY: test-container remote-roundtrip-container ws-pty-roundtrip-container \
 	agent-server-roundtrip-container remote-agent-server-roundtrip-container \
+	backend-docker-roundtrip \
 	playtest-container playtest-container-detached tui-driver tui-driver-selftest \
 	testbox-image lint-file-length docs
 
@@ -55,6 +56,16 @@ agent-server-roundtrip-container:
 # across the process boundary — inside the same container fence as the full suite.
 remote-agent-server-roundtrip-container:
 	scripts/testbox.sh test ./integration -run TestRemoteAgentServerRoundTrip
+
+# Flagship docker backend round-trip (#1592 Phase 4 PR4): runs a session in a
+# REAL container to parity — build a slim git+tmux+bash image, create a session
+# on backend=docker, drive the in-container `af agent-server` over wss://+token
+# (Provision/Launch → PTY input echo → preview/snapshot/alive), then Kill and
+# assert the container is reaped. Runs ON THE HOST (needs a real docker daemon);
+# it is NOT inside the testbox fence, which has no docker. SKIPS cleanly where
+# docker is unavailable. See docs/backends.md.
+backend-docker-roundtrip:
+	go test ./integration -run TestDockerBackendRoundTrip -v -count=1 -timeout 15m
 
 # Interactive TUI play-test sandbox: builds af inside, scaffolds a
 # throwaway AF home + mock project repo, drops you in a shell with a

--- a/api/api.go
+++ b/api/api.go
@@ -447,7 +447,7 @@ func init() {
 	sessionsCreateCmd.Flags().StringVar(&createProgramFlag, "program", "", "Program to run (one of: "+tmux.SupportedProgramsString()+"; defaults to config default)")
 	sessionsCreateCmd.Flags().BoolVar(&createHereFlag, "here", false, "Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both)")
 	sessionsCreateCmd.Flags().BoolVar(&createInPlaceFlag, "in-place", false, "Alias for --here")
-	sessionsCreateCmd.Flags().StringVar(&createBackendFlag, "backend", "", "Runtime to run the session on (one of: "+config.BackendLocal+", "+config.BackendDocker+", "+config.BackendSSH+", "+config.BackendHook+"; defaults to the repo's backend config, or local). docker/ssh are not yet implemented")
+	sessionsCreateCmd.Flags().StringVar(&createBackendFlag, "backend", "", "Runtime to run the session on (one of: "+config.BackendLocal+", "+config.BackendDocker+", "+config.BackendSSH+", "+config.BackendHook+"; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh is not yet implemented")
 	sessionsCreateCmd.MarkFlagRequired("name")
 
 	sessionsSendPromptCmd.Flags().BoolVar(&sendPromptCreateFlag, "create", false, "Auto-create the session if it doesn't exist")

--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -125,6 +125,12 @@ func RunAgentServer(opts AgentServerOptions, stdout io.Writer) error {
 		Path:    opts.RepoPath,
 		Program: program,
 		AutoYes: opts.AutoYes,
+		// The in-sandbox agent-server ALWAYS runs the local runtime (tmux + git
+		// worktree against RepoPath) — it IS the sandbox (§1.2). Force it explicitly
+		// so a workspace whose repo config declares backend=docker/ssh (cloned into
+		// the container by the docker runtime, #1592 Phase 4 PR4) does not make the
+		// agent-server recursively try to provision another sandbox inside itself.
+		Backend: session.BackendLocal,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to build workspace instance: %w", err)

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,103 @@
+# Backends (runtimes)
+
+A session's **backend** decides *where* its workspace and agent run. Every
+backend exposes the exact same session surface — attach, preview, prompt
+delivery, the live PTY stream, tabs — so the TUI, CLI, and daemon drive a
+containerised session identically to a local one.
+
+| Backend | Where the agent runs | Selected with |
+|---------|----------------------|---------------|
+| `local` (default) | a git worktree + tmux on the daemon's own machine | nothing (the default), or `backend = "local"` |
+| `docker` | a container on the daemon's Docker host | `backend = "docker"` + `docker.image` |
+| `ssh` | a remote host over SSH | `backend = "ssh"` *(not yet implemented — #1592 Phase 4 PR5)* |
+| `hook` | wherever your provisioner scripts put it | `backend = "hook"` (see [Remote hooks](remote-hooks.md)) |
+
+Select a backend per-repo in `.agent-factory/config.json`, or per-session with
+`af sessions create --backend <name>` (the flag overrides the repo config).
+
+---
+
+## Docker backend
+
+With `backend = "docker"`, a session runs entirely inside a container:
+
+1. The daemon `docker run`s a container from your image, publishing an internal
+   port on a random loopback host port.
+2. It clones the repo (from the repo's `origin` remote) into `/workspace` in the
+   container.
+3. It copies the `af` binary into the container and starts an
+   **`af agent-server`** there — a headless, single-workspace server over the
+   same TLS + bearer-token HTTP/WS protocol the daemon speaks.
+4. The daemon drives that in-container agent-server over `wss://127.0.0.1:<port>`.
+   Attach, preview, prompts, and the live terminal stream all flow over that one
+   authed connection.
+5. On kill, the container is torn down (`docker rm -f`) — no leaked containers.
+
+The container is **disposable**: durability lives in GitHub (the workspace is a
+clone of `repo@origin`), not in the container filesystem. Archive/restore
+(push the branch, re-provision on restore) lands in a later PR.
+
+### Configuration
+
+```json
+{
+  "backend": "docker",
+  "docker": {
+    "image": "my-org/af-runtime:latest",
+    "run_args": ["--memory", "4g", "-e", "MY_VAR=1"]
+  }
+}
+```
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `docker.image` | yes | The container image the session runs in (see requirements below). |
+| `docker.run_args` | no | Extra arguments appended verbatim to `docker run` (mounts, env, resource limits). |
+
+### Image requirements (bring-your-own image)
+
+There is **no `af`-published image**: you bring your own (Sachin-locked
+decision). The `af` binary is copied in for you at session start, so your image
+only needs the workspace tooling:
+
+- **`git`** — to clone the workspace.
+- **`tmux`** — the in-container agent-server drives the agent through tmux.
+- **`sh`** and **`sleep`** — the container is kept alive with `sleep`, and setup
+  runs through `sh`.
+- **`dd`** — used to stream the live PTY (present in both busybox and coreutils).
+- The **agent CLIs** you intend to run (claude, codex, aider, gemini, …).
+- A libc/architecture compatible with the daemon's `af` binary. A **static**
+  `af` build (`CGO_ENABLED=0`) runs on any base (musl/alpine included); a
+  dynamically-linked `af` needs a matching glibc base (e.g. `debian:slim`).
+
+The container's internal agent-server port is `8000`; avoid binding it in your
+image.
+
+A minimal example Dockerfile:
+
+```dockerfile
+FROM alpine:3.20
+RUN apk add --no-cache git tmux bash
+# add the agent CLIs your sessions need, e.g. claude / codex / aider
+```
+
+### Operations
+
+- **List managed containers:** `docker ps -a --filter label=af.session`
+- **Reap a leaked container** (should never be needed — kill reaps automatically):
+  `docker rm -f <id>`
+
+### Requirements on the daemon host
+
+- The `docker` CLI on `PATH` and a reachable Docker daemon.
+- The repo must have an `origin` remote the container can clone from (GitHub for
+  a real repo; a `file://` path + a `run_args` bind-mount for a self-contained
+  test).
+
+### Testing
+
+`make backend-docker-roundtrip` runs the real end-to-end container round-trip on
+a host with Docker: it builds a slim git+tmux image, creates a session on the
+docker backend, drives the in-container agent-server over `wss://` (input →
+stream echo → preview/snapshot/liveness), and asserts the container is reaped on
+kill. It skips cleanly where Docker is unavailable.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -892,7 +892,7 @@ af sessions create [flags]
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `--backend` | `string` | Runtime to run the session on (one of: local, docker, ssh, hook; defaults to the repo's backend config, or local). docker/ssh are not yet implemented |
+| `--backend` | `string` | Runtime to run the session on (one of: local, docker, ssh, hook; defaults to the repo's backend config, or local). docker runs the session in a container (set docker.image in the repo config); ssh is not yet implemented |
 | `--here` |  | Run in the repo's existing working tree at its current branch (no new worktree/branch; kill preserves both) |
 | `--in-place` |  | Alias for --here |
 | `--name` | `string` | Session name (required) |

--- a/integration/backend_docker_test.go
+++ b/integration/backend_docker_test.go
@@ -1,0 +1,285 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestDockerBackendRoundTrip is the #1592 Phase 4 PR4 flagship proof: a session
+// runs in a REAL docker container, to parity with local.
+//
+// It builds a slim git+tmux+bash image, sets a repo's config to backend=docker,
+// and creates a session through the ordinary NewInstance path — so the docker
+// runtime runs a container, clones the workspace into it, docker cp's a static
+// `af` binary in, starts an `af agent-server` on a published loopback port behind
+// TLS+token, and exposes its wss:// URL. The daemon-side Instance then drives that
+// in-container agent-server over the wire through the FULL surface:
+//
+//	Start (Provision+Launch the in-container workspace) → Subscribe to its PTY
+//	stream → Input (typed bytes reach the in-container agent) → observe the echo →
+//	Preview / Snapshot / Alive reflect the pane → Kill → the container is reaped
+//	(no leak).
+//
+// This is the whole epic's payoff: a session, end to end, inside a container,
+// behaviorally indistinguishable from a local one.
+//
+// Run it on a host with docker: make backend-docker-roundtrip. It SKIPS cleanly
+// where docker is unavailable (e.g. inside the test-container fence), so the full
+// suite stays green there.
+func TestDockerBackendRoundTrip(t *testing.T) {
+	requireDocker(t)
+	requireTool(t, "git")
+
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	// A static `af` binary the runtime copies into the container (musl-compatible;
+	// the daemon's own binary is what production copies, but the test binary is not
+	// `af`, so build a real one and point the runtime at it).
+	afBin := buildStaticBinary(t)
+	restore := session.SetDockerSelfBinaryForTest(afBin)
+	defer restore()
+
+	image := buildDockerRoundTripImage(t)
+
+	// The source repo + a bare clone of it, bind-mounted into the container as the
+	// clone source (file:///repo.git). This makes the in-container clone a REAL git
+	// clone with no GitHub dependency — the durable-store model, self-contained.
+	repo := setupGitRepo(t)
+	writeFile(t, filepath.Join(repo, "README.md"), "docker round-trip\n", 0644)
+	runExternal(t, repo, "git", "add", "-A")
+	runExternal(t, repo, "git", "commit", "-m", "seed")
+	bare := filepath.Join(t.TempDir(), "repo.git")
+	runExternal(t, "", "git", "clone", "--bare", repo, bare)
+	runExternal(t, repo, "git", "remote", "add", "origin", "file:///repo.git")
+
+	// Repo config: backend=docker, the test image, and the bind-mount that serves
+	// the clone source at /repo.git inside the container.
+	writeDockerRepoConfig(t, repo, image, []string{"-v", bare + ":/repo.git:ro"})
+
+	title := "docker-rt"
+	slug := session.Slugify(title)
+	// Backstop cleanup: reap any container this test's label leaves behind even if
+	// it fails before Kill, so a container never leaks out of the test.
+	t.Cleanup(func() { reapByLabel(slug) })
+
+	// --- create the session on the docker backend (the full NewInstance path) ---
+	// program `cat` echoes the PTY, so typed input observably comes back over the
+	// stream — the input-reaches-the-in-container-agent proof.
+	t.Logf("provisioning docker session %q (image %s)...", title, image)
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    repo,
+		Program: "cat",
+		Backend: session.BackendDocker,
+	})
+	if err != nil {
+		t.Fatalf("NewInstance(backend=docker): %v", err)
+	}
+	// The container is up the instant NewInstance returns (the runtime provisioned
+	// it). Assert it, and route every later failure through Kill so it is reaped.
+	if got := containersForLabel(t, slug); len(got) == 0 {
+		t.Fatal("expected a running container for the docker session after provisioning")
+	}
+	t.Logf("container is up; agent-server exposed over wss:// with TLS+token")
+	killed := false
+	defer func() {
+		if !killed {
+			_ = inst.Kill()
+		}
+	}()
+
+	// --- Start: Provision + Launch the in-container workspace over the wire ------
+	if err := inst.Start(true); err != nil {
+		t.Fatalf("Start (drive in-container agent-server Provision+Launch): %v", err)
+	}
+
+	as := inst.AgentServer()
+
+	// --- Subscribe to the in-container PTY stream across the container boundary --
+	sub, err := as.Subscribe(0, 0)
+	if err != nil {
+		t.Fatalf("Subscribe to the in-container PTY stream: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+
+	pumpCtx, pumpCancel := context.WithCancel(context.Background())
+	defer pumpCancel()
+	var (
+		pumpMu sync.Mutex
+		pump   strings.Builder
+	)
+	go func() {
+		for {
+			ev, rerr := sub.NextEvent(pumpCtx)
+			if rerr != nil {
+				return
+			}
+			if ev.Kind == session.PTYData || ev.Kind == session.PTYRepaint {
+				pumpMu.Lock()
+				pump.Write(ev.Data)
+				pumpMu.Unlock()
+			}
+		}
+	}()
+	streamOutput := func() string {
+		pumpMu.Lock()
+		defer pumpMu.Unlock()
+		return pump.String()
+	}
+
+	// --- Input: typed bytes reach the in-container agent; the `cat` pane echoes --
+	marker := "docker-roundtrip-ping"
+	if err := as.Input(0, []byte(marker+"\n")); err != nil {
+		t.Fatalf("Input over the wire: %v", err)
+	}
+	waitUntil(t, 20*time.Second, "in-container PTY stream echoes typed input", func() bool {
+		return strings.Contains(streamOutput(), marker)
+	})
+	t.Logf("typed input reached the in-container agent and echoed over the stream: %q", strings.TrimSpace(streamOutput()))
+
+	// --- Preview / Snapshot / Alive reflect the in-container pane ----------------
+	waitUntil(t, 10*time.Second, "Snapshot reflects the in-container pane", func() bool {
+		obs, serr := as.Snapshot()
+		return serr == nil && strings.Contains(obs.Content, marker)
+	})
+	preview, err := as.Preview(0, false)
+	if err != nil {
+		t.Fatalf("Preview over the wire: %v", err)
+	}
+	if !strings.Contains(preview, marker) {
+		t.Fatalf("Preview did not reflect the typed input: %q", preview)
+	}
+	if !as.Alive() {
+		t.Fatal("expected the in-container workspace to report Alive")
+	}
+	t.Logf("preview/liveness reflect the in-container workspace over the wire")
+
+	// --- Kill: tear the workspace down AND reap the container -------------------
+	if err := inst.Kill(); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	killed = true
+	waitUntil(t, 30*time.Second, "the session's container is reaped after Kill", func() bool {
+		return len(containersForLabel(t, slug)) == 0
+	})
+	t.Logf("container reaped on Kill — no leak. docker round-trip complete.")
+}
+
+// --- docker round-trip helpers ---------------------------------------------
+
+// requireDocker skips the test when the docker CLI or daemon is unavailable (e.g.
+// inside the test-container fence), so the full suite stays green there while the
+// host `make backend-docker-roundtrip` runs it for real.
+func requireDocker(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not on PATH; skipping the docker backend round-trip")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, "docker", "version", "--format", "{{.Server.Version}}").CombinedOutput(); err != nil {
+		t.Skipf("docker daemon not reachable; skipping the docker backend round-trip: %s", strings.TrimSpace(string(out)))
+	}
+}
+
+// buildStaticBinary builds a fully static `af` (CGO_ENABLED=0) so it runs inside
+// the slim alpine (musl) test image the runtime copies it into.
+func buildStaticBinary(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Dir(filepath.Dir(file))
+	bin := filepath.Join(t.TempDir(), "af")
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", bin, repoRoot)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("static go build failed: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// buildDockerRoundTripImage builds a slim image carrying git + tmux + bash — the
+// minimum a BYO image needs for the in-container agent-server (git worktree + tmux
+// PTY). Returns the image tag. Cached across runs by docker's layer cache.
+func buildDockerRoundTripImage(t *testing.T) string {
+	t.Helper()
+	const tag = "af-docker-roundtrip:test"
+	dir := t.TempDir()
+	dockerfile := "FROM alpine:3.20\nRUN apk add --no-cache git tmux bash\n"
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "build", "-t", tag, dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("building the round-trip image failed (needs network on first run): %v\n%s", err, out)
+	}
+	return tag
+}
+
+// writeDockerRepoConfig drops a repo config selecting the docker backend with the
+// given image and run_args (the bind-mount that serves the clone source).
+func writeDockerRepoConfig(t *testing.T, repo, image string, runArgs []string) {
+	t.Helper()
+	dir := filepath.Join(repo, ".agent-factory")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir repo config: %v", err)
+	}
+	quotedArgs := make([]string, len(runArgs))
+	for i, a := range runArgs {
+		quotedArgs[i] = fmt.Sprintf("%q", a)
+	}
+	body := fmt.Sprintf(`{"backend":"docker","docker":{"image":%q,"run_args":[%s]}}`,
+		image, strings.Join(quotedArgs, ","))
+	writeFile(t, filepath.Join(dir, "config.json"), body, 0644)
+}
+
+// containersForLabel returns the ids of containers carrying the session label.
+func containersForLabel(t *testing.T, slug string) []string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "docker", "ps", "-aq", "-f", "label=af.session="+slug).CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker ps: %v\n%s", err, out)
+	}
+	var ids []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if s := strings.TrimSpace(line); s != "" {
+			ids = append(ids, s)
+		}
+	}
+	return ids
+}
+
+// reapByLabel best-effort removes any container carrying the session label — the
+// test's backstop so a container never leaks even on an early failure.
+func reapByLabel(slug string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "docker", "ps", "-aq", "-f", "label=af.session="+slug).Output()
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if id := strings.TrimSpace(line); id != "" {
+			_ = exec.Command("docker", "rm", "-f", id).Run()
+		}
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
           - The TUI: concepts/tui.md
           - The daemon: concepts/daemon.md
           - Tasks & automation: tasks.md
+          - Backends (runtimes): backends.md
           - Remote hooks: remote-hooks.md
           - Remote daemon access: remote-tcp-auth.md
           - Usage limits: usage-limits.md

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -52,7 +52,10 @@ func (i *Instance) AgentServer() AgentServer {
 	defer i.agentSrvMu.Unlock()
 	if i.agentSrv == nil {
 		if i.remoteClient != nil {
-			i.agentSrv = &remoteAgentServer{rc: i.remoteClient}
+			// teardown reaps the sandbox this session runs in (docker rm -f) after
+			// the remote Kill tears the in-sandbox workspace down — nil for the PR2
+			// out-of-process case (no sandbox to reap), set for a docker session.
+			i.agentSrv = &remoteAgentServer{rc: i.remoteClient, teardown: i.runtimeTeardown}
 		} else {
 			i.agentSrv = &localAgentServer{inst: i}
 		}

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -52,6 +53,12 @@ import (
 // starts a real `af agent-server` on loopback and drives it through here.
 type remoteAgentServer struct {
 	rc *remoteAgentClient
+	// teardown reaps the sandbox the agent runs in AFTER the in-sandbox workspace
+	// is killed over REST (#1592 Phase 4 PR4): `docker rm -f` the container. nil
+	// for the PR2 out-of-process case (an `af agent-server` the test owns — nothing
+	// for this client to reap). Run best-effort in Kill so a session kill also
+	// removes its container; idempotent (the runtime guards it with a sync.Once).
+	teardown func() error
 
 	mu sync.Mutex
 	// brokers holds one lazy ptyBroker per tab index, exactly like localAgentServer
@@ -204,7 +211,17 @@ func (s *remoteAgentServer) Kill() error {
 	for _, br := range brokers {
 		br.close()
 	}
-	return s.rc.call("/v1/agent/kill", struct{}{}, nil)
+	// Kill the in-sandbox workspace over REST, THEN reap the sandbox itself. Both
+	// run even if the REST kill fails (the container must not leak because its
+	// agent-server was already down) — the errors are joined so a caller sees
+	// both. teardown is idempotent, so a Kill retry after a partial failure is safe.
+	killErr := s.rc.call("/v1/agent/kill", struct{}{}, nil)
+	if s.teardown != nil {
+		if terr := s.teardown(); terr != nil {
+			return errors.Join(killErr, terr)
+		}
+	}
+	return killErr
 }
 
 // --- remote WS clientlessChannel: the sandbox stream as a broker channel ---

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -1,0 +1,576 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/log"
+)
+
+// The docker container runtime (#1592 Phase 4 PR4) — the first-class sandboxed
+// backend. A session's workspace + agent run in a container; the container
+// exposes an `af agent-server` (PR1) on a published loopback port behind TLS +
+// token; the daemon drives it through the remoteAgentServer HTTP/WS client (PR2)
+// exactly as it drives a local in-process session. This is the "provision-and-
+// expose" model the whole epic was built toward, at parity with local.
+//
+// It drives docker through the CLI (`os/exec`, the same idiom as HookBackend's
+// exec.Command), NOT the docker Go SDK: no heavy dependency, and the surface we
+// need is small (run/exec/cp/port/rm). Sachin-locked decisions this file
+// implements: BYO image (docker.image config, no af-published image — Q3), the
+// `af` binary docker cp'd into the running container (always version-matched to
+// the daemon), and GitHub as the durable workspace store (the container clones
+// repo@origin and is otherwise disposable).
+//
+// Lifecycle (dockerRuntime.Provision, called from the backend factory during
+// NewInstance):
+//
+//	docker run     — start a container from docker.image, kept alive, publishing
+//	                 the in-container agent-server port on a random loopback host port
+//	git clone      — clone the repo's origin into /workspace inside the container
+//	docker cp      — copy the daemon's own `af` binary into the container
+//	docker exec    — start `af agent-server --listen :<port>` headless in the
+//	                 container; read its startup banner (addr/token/fingerprint)
+//	docker port    — map the published port to build wss://127.0.0.1:<hostport>
+//
+// The result is an AgentServerEndpoint the daemon dials, plus a container-reap
+// teardown run when the session is killed. The in-container agent-server itself
+// runs the ordinary LOCAL runtime (tmux + git worktree) against /workspace — so
+// provision/launch/preview/prompt/stream all work in-container exactly as on the
+// daemon's own box, reached over the wire.
+
+const (
+	// dockerAgentPort is the fixed port the in-container `af agent-server` binds
+	// (0.0.0.0 so the published host port forwards to it). A constant rather than
+	// :0 because the host port must be published at `docker run` time, before the
+	// server is up to report a chosen port. Documented in docs/backends.md so a
+	// BYO image can avoid colliding with it.
+	dockerAgentPort = "8000"
+	// dockerWorkspaceDir is where the repo is cloned inside the container; the
+	// agent-server runs against it (--repo), and its LOCAL backend creates the
+	// session's git worktree + branch off it, just like a local session.
+	dockerWorkspaceDir = "/workspace"
+	// dockerAfBinaryPath is where the daemon's `af` binary is copied in the
+	// container so `af agent-server` is on PATH for the exec below.
+	dockerAfBinaryPath = "/usr/local/bin/af"
+	// dockerBannerPath/dockerLogPath capture the agent-server's stdout banner and
+	// stderr log inside the container. The banner is a single JSON line (addr,
+	// token, fingerprint) the server prints the instant its listener binds; the
+	// runtime polls the file for it because `docker exec -d` detaches the process.
+	dockerBannerPath = "/tmp/af-agent-server.json"
+	dockerLogPath    = "/tmp/af-agent-server.log"
+	// dockerSessionLabel tags every managed container so orphans can be swept with
+	// `docker ps -aq -f label=af.session` (documented in docs/backends.md). The
+	// runtime reaps by container ID; the label is for operators.
+	dockerSessionLabel = "af.session"
+)
+
+// docker command timeouts. Provisioning steps (run/clone/cp/exec) get a generous
+// budget because a first-run image pull or a large clone can be slow; reaping is
+// bounded tighter so a kill never hangs.
+const (
+	dockerProvisionStepTimeout = 5 * time.Minute
+	dockerShortStepTimeout     = 30 * time.Second
+	dockerReapTimeout          = 30 * time.Second
+	dockerBannerPollTimeout    = 45 * time.Second
+	dockerBannerPollInterval   = 400 * time.Millisecond
+)
+
+// dockerSelfBinary resolves the `af` binary to docker cp into the sandbox. In
+// production it is the running daemon's own executable — the same binary provides
+// `af agent-server`, so the sandbox is always version-matched to the daemon
+// (Sachin-locked Q3). The round-trip test overrides it with a freshly built
+// static binary compatible with the test image.
+var dockerSelfBinary = os.Executable
+
+// SetDockerSelfBinaryForTest overrides the `af` binary the docker runtime copies
+// into the sandbox and returns a restore function. The round-trip integration
+// test uses it to point at a freshly built static binary compatible with its test
+// image (the test binary itself is not `af`).
+func SetDockerSelfBinaryForTest(path string) func() {
+	prev := dockerSelfBinary
+	dockerSelfBinary = func() (string, error) { return path, nil }
+	return func() { dockerSelfBinary = prev }
+}
+
+// dockerBanner mirrors daemon.AgentServerInfo field-for-field (the JSON the
+// `af agent-server` prints on startup). It is duplicated here rather than
+// imported because daemon imports session (a cycle); the shared contract is the
+// JSON tags, pinned by the round-trip test.
+type dockerBanner struct {
+	Addr        string `json:"addr"`
+	Token       string `json:"token"`
+	Fingerprint string `json:"fingerprint"`
+	SelfSigned  bool   `json:"self_signed"`
+	CertPath    string `json:"cert_path"`
+	Title       string `json:"title"`
+}
+
+// dockerRuntime provisions a real container sandbox (#1592 Phase 4 PR4). Declared
+// in runtime.go's registry; its Provision is here.
+type dockerRuntime struct{}
+
+func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
+	cfg, err := resolveRepoConfig(spec.RepoRoot)
+	if err != nil {
+		return ProvisionResult{}, fmt.Errorf("backend=docker: cannot resolve repo config for %q: %w", spec.RepoRoot, err)
+	}
+	image := ""
+	var runArgs []string
+	if cfg.Docker != nil {
+		image = strings.TrimSpace(cfg.Docker.Image)
+		runArgs = cfg.Docker.RunArgs
+	}
+	if image == "" {
+		return ProvisionResult{}, fmt.Errorf("backend=docker requires docker.image to be set in this repo's .agent-factory/config.json (the container image that carries git + tmux + the agent CLIs; the `af` binary is copied in automatically)")
+	}
+	if spec.CloneURL == "" {
+		return ProvisionResult{}, fmt.Errorf("backend=docker: repo %q has no `origin` remote to clone the workspace from; add one (GitHub is the durable workspace store) or push the repo first", spec.RepoRoot)
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		return ProvisionResult{}, fmt.Errorf("backend=docker: the `docker` CLI is not on PATH; install Docker or select a different backend: %w", err)
+	}
+
+	afBin, err := dockerSelfBinary()
+	if err != nil {
+		return ProvisionResult{}, fmt.Errorf("backend=docker: cannot locate the af binary to copy into the container: %w", err)
+	}
+
+	p := &dockerProvisioner{
+		spec:    spec,
+		image:   image,
+		runArgs: runArgs,
+		afBin:   afBin,
+		program: spec.Program,
+	}
+	res, err := p.provision()
+	if err != nil {
+		// Reap anything the failed provision left running so a container never
+		// leaks on a partial failure.
+		if p.containerID != "" {
+			p.reap()
+		}
+		return ProvisionResult{}, err
+	}
+	return res, nil
+}
+
+// dockerProvisioner holds the state of one container provisioning so its steps
+// (run/clone/cp/exec/port) and its reap closure share the container ID.
+type dockerProvisioner struct {
+	spec    ProvisionSpec
+	image   string
+	runArgs []string
+	afBin   string
+	program string
+
+	containerID string
+	reapOnce    sync.Once
+}
+
+// provision runs the full container lifecycle and returns the wiring a docker
+// session needs. Each step wraps docker's combined output in the error so a
+// failure is self-diagnosing.
+func (p *dockerProvisioner) provision() (ProvisionResult, error) {
+	if err := p.runContainer(); err != nil {
+		return ProvisionResult{}, err
+	}
+	if err := p.configureGit(); err != nil {
+		return ProvisionResult{}, err
+	}
+	if err := p.cloneWorkspace(); err != nil {
+		return ProvisionResult{}, err
+	}
+	if err := p.copyAfBinary(); err != nil {
+		return ProvisionResult{}, err
+	}
+	if err := p.startAgentServer(); err != nil {
+		return ProvisionResult{}, err
+	}
+	banner, err := p.readBanner()
+	if err != nil {
+		return ProvisionResult{}, err
+	}
+	hostPort, err := p.publishedPort()
+	if err != nil {
+		return ProvisionResult{}, err
+	}
+
+	endpoint := &AgentServerEndpoint{
+		URL:         "wss://127.0.0.1:" + hostPort,
+		Token:       banner.Token,
+		Fingerprint: banner.Fingerprint,
+	}
+	teardown := p.reap
+	log.InfoLog.Printf("docker runtime: session %q running in container %s, agent-server at %s", p.spec.Title, p.shortID(), endpoint.URL)
+	return ProvisionResult{
+		Backend:  &dockerBackend{containerID: p.containerID, reap: teardown},
+		Endpoint: endpoint,
+		Teardown: teardown,
+	}, nil
+}
+
+// runContainer starts the sandbox container detached and kept alive, publishing
+// the in-container agent-server port on a random loopback host port. The image's
+// own entrypoint is overridden with a long sleep: the container is a host for the
+// agent-server we exec into it, not the image's default process. run_args are
+// appended verbatim (extra mounts/env/limits, or — in the round-trip test — the
+// bind-mount that serves the clone source).
+func (p *dockerProvisioner) runContainer() error {
+	args := []string{
+		"run", "-d",
+		"--label", dockerSessionLabel + "=" + Slugify(p.spec.Title),
+		"-e", "HOME=/root",
+		"-p", "127.0.0.1::" + dockerAgentPort,
+	}
+	args = append(args, p.runArgs...)
+	args = append(args, "--entrypoint", "sleep", p.image, "2147483647")
+
+	out, err := p.docker(dockerProvisionStepTimeout, args...)
+	if err != nil {
+		return fmt.Errorf("backend=docker: `docker run` failed for image %q: %s: %w", p.image, strings.TrimSpace(string(out)), err)
+	}
+	id := strings.TrimSpace(string(out))
+	if id == "" {
+		return fmt.Errorf("backend=docker: `docker run` returned no container id (output: %q)", string(out))
+	}
+	p.containerID = id
+	return nil
+}
+
+// configureGit sets a git identity and marks every directory safe inside the
+// container so the clone + worktree creation (which run as root over a possibly
+// foreign-owned bind mount) don't trip on "dubious ownership" or a missing
+// committer identity.
+func (p *dockerProvisioner) configureGit() error {
+	script := `git config --global user.email "af@agent-factory.local" && ` +
+		`git config --global user.name "Agent Factory" && ` +
+		`git config --global --add safe.directory "*"`
+	out, err := p.execSh(dockerShortStepTimeout, script)
+	if err != nil {
+		return fmt.Errorf("backend=docker: git config in container failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// cloneWorkspace clones the repo's origin into /workspace inside the container.
+// A fresh create clones the default branch; the in-container agent-server's LOCAL
+// backend then creates the session's git worktree + branch off it. Restore to a
+// pushed branch is PR6.
+func (p *dockerProvisioner) cloneWorkspace() error {
+	script := fmt.Sprintf("git clone %s %s", shellQuote(p.spec.CloneURL), shellQuote(dockerWorkspaceDir))
+	out, err := p.execSh(dockerProvisionStepTimeout, script)
+	if err != nil {
+		return fmt.Errorf("backend=docker: cloning %q into the container failed (is git in the image, and the URL reachable from inside the container?): %s: %w",
+			p.spec.CloneURL, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// copyAfBinary docker cp's the daemon's own `af` binary into the container and
+// makes it executable, so `af agent-server` is runnable inside. The binary must
+// be compatible with the image (matching arch/libc) — a static build runs
+// anywhere; documented in docs/backends.md.
+func (p *dockerProvisioner) copyAfBinary() error {
+	out, err := p.docker(dockerShortStepTimeout, "cp", p.afBin, p.containerID+":"+dockerAfBinaryPath)
+	if err != nil {
+		return fmt.Errorf("backend=docker: copying the af binary into the container failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	if out, err := p.execSh(dockerShortStepTimeout, "chmod +x "+shellQuote(dockerAfBinaryPath)); err != nil {
+		return fmt.Errorf("backend=docker: chmod on the copied af binary failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// startAgentServer launches `af agent-server` headless in the container,
+// detached, with its stdout banner + stderr redirected to files. It binds
+// :<port> (all interfaces) so the published host port forwards to it. The
+// workspace title matches the daemon-side session title so the daemon's remote
+// client dials /v1/sessions/{title}/stream. readBanner then polls the banner file.
+func (p *dockerProvisioner) startAgentServer() error {
+	inner := fmt.Sprintf("%s agent-server --listen :%s --repo %s --title %s",
+		shellQuote(dockerAfBinaryPath), dockerAgentPort, shellQuote(dockerWorkspaceDir), shellQuote(p.spec.Title))
+	if strings.TrimSpace(p.program) != "" {
+		inner += " --program " + shellQuote(p.program)
+	}
+	if p.spec.AutoYes {
+		inner += " --auto-yes"
+	}
+	inner += fmt.Sprintf(" >%s 2>%s", shellQuote(dockerBannerPath), shellQuote(dockerLogPath))
+
+	// -d: detach. The agent-server keeps running in the container after this exec
+	// client returns; we read its banner from the file below.
+	out, err := p.docker(dockerShortStepTimeout, "exec", "-d", p.containerID, "sh", "-c", inner)
+	if err != nil {
+		return fmt.Errorf("backend=docker: starting af agent-server in the container failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// readBanner polls the in-container banner file until the agent-server has bound
+// its listener and printed its {addr,token,fingerprint} JSON line, or times out.
+// On timeout it pulls the agent-server's stderr log into the error so a failure
+// to start (bad image, missing tmux, port clash) is self-diagnosing.
+func (p *dockerProvisioner) readBanner() (dockerBanner, error) {
+	deadline := time.Now().Add(dockerBannerPollTimeout)
+	for {
+		out, err := p.docker(dockerShortStepTimeout, "exec", p.containerID, "cat", dockerBannerPath)
+		if err == nil {
+			var b dockerBanner
+			if jErr := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &b); jErr == nil && b.Addr != "" && b.Token != "" {
+				return b, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			logOut, _ := p.docker(dockerShortStepTimeout, "exec", p.containerID, "cat", dockerLogPath)
+			return dockerBanner{}, fmt.Errorf("backend=docker: af agent-server did not report a startup banner within %s; container log:\n%s",
+				dockerBannerPollTimeout, strings.TrimSpace(string(logOut)))
+		}
+		// The poll interval bounds how long we can outrun the deadline; use a
+		// non-wall-clock sleep so it is deterministic under test time control.
+		time.Sleep(dockerBannerPollInterval)
+	}
+}
+
+// publishedPort reads the random host port docker mapped the agent-server port
+// to, so the daemon can dial it on loopback.
+func (p *dockerProvisioner) publishedPort() (string, error) {
+	out, err := p.docker(dockerShortStepTimeout, "port", p.containerID, dockerAgentPort+"/tcp")
+	if err != nil {
+		return "", fmt.Errorf("backend=docker: reading the published agent-server port failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	port := parseDockerPort(string(out))
+	if port == "" {
+		return "", fmt.Errorf("backend=docker: could not parse a host port from `docker port` output: %q", string(out))
+	}
+	return port, nil
+}
+
+// reap removes the container, idempotently. It runs on the session's Kill (after
+// the in-container workspace is torn down over REST), on a provisioning failure,
+// and on a bad-endpoint NewInstance failure — so a container is never leaked. The
+// sync.Once makes the repeated Kill retries and the Kill-vs-provision-failure
+// races collapse to one `docker rm -f`.
+func (p *dockerProvisioner) reap() error {
+	var reapErr error
+	p.reapOnce.Do(func() {
+		if p.containerID == "" {
+			return
+		}
+		out, err := p.docker(dockerReapTimeout, "rm", "-f", p.containerID)
+		if err != nil {
+			reapErr = fmt.Errorf("backend=docker: `docker rm -f %s` failed: %s: %w", p.shortID(), strings.TrimSpace(string(out)), err)
+			log.WarningLog.Printf("%v", reapErr)
+			return
+		}
+		log.InfoLog.Printf("docker runtime: reaped container %s for session %q", p.shortID(), p.spec.Title)
+	})
+	return reapErr
+}
+
+// docker runs `docker <args...>` with a timeout and returns its combined output.
+func (p *dockerProvisioner) docker(timeout time.Duration, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+}
+
+// execSh runs a `sh -c <script>` inside the container.
+func (p *dockerProvisioner) execSh(timeout time.Duration, script string) ([]byte, error) {
+	return p.docker(timeout, "exec", p.containerID, "sh", "-c", script)
+}
+
+func (p *dockerProvisioner) shortID() string {
+	if len(p.containerID) > 12 {
+		return p.containerID[:12]
+	}
+	return p.containerID
+}
+
+// parseDockerPort extracts the host port from `docker port` output. The output is
+// one or more `<hostip>:<port>` lines (IPv4 and possibly IPv6); we take the first
+// line's trailing port after the last colon, which is what the daemon dials on
+// 127.0.0.1.
+func parseDockerPort(out string) string {
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if idx := strings.LastIndex(line, ":"); idx >= 0 && idx+1 < len(line) {
+			return strings.TrimSpace(line[idx+1:])
+		}
+	}
+	return ""
+}
+
+// originRemoteURL returns the `origin` remote URL of the git repo at repoRoot, or
+// "" if there is none / the path is not a repo. It is the clone source a
+// sandboxed runtime pulls the workspace from (GitHub is the durable store). Best-
+// effort by design: the docker runtime surfaces the actionable "no origin" error
+// at create time when this is empty.
+func originRemoteURL(repoRoot string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), dockerShortStepTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// dockerBackend is the in-process Backend for a docker session. Where LocalBackend
+// drives a local tmux session, this backend's agent-facing operations delegate to
+// the instance's remote AgentServer (the HTTP/WS client to the in-container
+// agent-server) — so lifecycle, preview, prompt, and liveness all go over the wire
+// to the container. Its ONE local responsibility is reaping the container, which
+// it shares (via the same idempotent closure) with the AgentServer Kill path.
+//
+// The daemon's observation/delivery paths speak to a session ONLY through
+// Instance.AgentServer() (the remoteAgentServer), so most of these methods exist
+// for interface completeness + the create flow (which drives Preview/SendPrompt
+// through the Instance→backend wrappers). None re-enters the backend: the docker
+// instance's AgentServer() is the REMOTE client, not localAgentServer, so a
+// backend→AgentServer call is a network hop, never a loop.
+type dockerBackend struct {
+	containerID string
+	// reap removes the container; shared with the runtime's Teardown / the
+	// AgentServer Kill path, and idempotent (a sync.Once behind the closure).
+	reap func() error
+}
+
+var _ Backend = (*dockerBackend)(nil)
+
+func (b *dockerBackend) Type() string { return "docker" }
+
+// Capabilities advertises full interactive parity for docker (#1592 Phase 4 PR4,
+// epic §5): the workspace is off-box, but attach/preview/liveness/prompt/tabs all
+// work through the in-container agent-server. Archive/Recover (push/pull the
+// branch) land in PR6, so they are off here.
+func (b *dockerBackend) Capabilities() Capabilities {
+	return Capabilities{
+		Workspace:        WorkspaceRemote,
+		Attach:           true,
+		Archive:          false,
+		Recover:          false,
+		TabManagement:    true,
+		TerminalTab:      true,
+		InteractiveInput: true,
+	}
+}
+
+// Start provisions then launches the in-container workspace. The container +
+// agent-server were established by the runtime (during NewInstance); Start drives
+// the agent-server's own provision/launch over REST, so the in-container LOCAL
+// backend creates the git worktree + branch and spawns the agent.
+func (b *dockerBackend) Start(i *Instance, firstTimeSetup bool) error {
+	if err := b.Provision(i, firstTimeSetup); err != nil {
+		return err
+	}
+	return b.Launch(i, firstTimeSetup)
+}
+
+// Provision drives the in-container agent-server's Provision over the wire (clone
+// is already done by the runtime; this creates the in-container git worktree).
+func (b *dockerBackend) Provision(i *Instance, firstTimeSetup bool) error {
+	return i.AgentServer().Provision(firstTimeSetup)
+}
+
+// Launch drives the in-container agent-server's Launch (spawn the agent), sets the
+// started flag, and seeds the daemon-side tab model with the agent tab (the
+// container owns the real tabs; the daemon-side list mirrors the agent tab so the
+// UI renders it, matching the remote-hook baseline).
+func (b *dockerBackend) Launch(i *Instance, firstTimeSetup bool) error {
+	if err := i.AgentServer().Launch(firstTimeSetup); err != nil {
+		return err
+	}
+	i.mu.Lock()
+	i.started = true
+	if len(i.Tabs) == 0 {
+		i.Tabs = []*Tab{newRemoteAgentTab()}
+	}
+	i.mu.Unlock()
+	return nil
+}
+
+// Kill reaps the container. Instance.Kill routes through the AgentServer (which
+// tears the in-container workspace down over REST and then runs the same reap), so
+// this is normally reached only if something calls backend.Kill directly; the
+// shared idempotent reap makes either path safe.
+func (b *dockerBackend) Kill(i *Instance) error {
+	i.mu.Lock()
+	i.started = false
+	i.mu.Unlock()
+	if b.reap != nil {
+		return b.reap()
+	}
+	return nil
+}
+
+// CloseAttachOnly discards this instance's local view WITHOUT reaping the
+// container — used to drop a duplicate Instance built from disk that lost a race
+// to the canonical one (#867). Reaping here would tear down the container the
+// canonical Instance shares, so it must not run.
+func (b *dockerBackend) CloseAttachOnly(i *Instance) error {
+	i.mu.Lock()
+	i.started = false
+	i.mu.Unlock()
+	return nil
+}
+
+func (b *dockerBackend) Preview(i *Instance) (string, error) {
+	return i.AgentServer().Preview(0, false)
+}
+
+func (b *dockerBackend) PreviewFullHistory(i *Instance) (string, error) {
+	return i.AgentServer().Preview(0, true)
+}
+
+// Attach/AttachTerminal: a docker session attaches CLIENT-side over the WS PTY
+// stream (the daemon proxies the container's stream), exactly like a local
+// session — the client's attach dispatch branches on Capabilities().Workspace and
+// never reaches the backend. These satisfy the interface with an explicit
+// routing-invariant error rather than a silent no-op.
+func (b *dockerBackend) Attach(*Instance) (chan struct{}, error) {
+	return nil, fmt.Errorf("docker sessions attach client-side over the WS PTY stream, not through the backend")
+}
+
+func (b *dockerBackend) AttachTerminal(*Instance, int) (chan struct{}, error) {
+	return nil, fmt.Errorf("docker terminal tabs attach client-side over the WS PTY stream, not through the backend")
+}
+
+func (b *dockerBackend) HasUpdated(i *Instance) (updated bool, hasPrompt bool, content string) {
+	obs, err := i.AgentServer().Snapshot()
+	if err != nil {
+		return false, false, ""
+	}
+	return obs.Updated, obs.HasPrompt, obs.Content
+}
+
+func (b *dockerBackend) SendPromptCommand(i *Instance, prompt string) error {
+	return i.AgentServer().SendPrompt(prompt)
+}
+
+func (b *dockerBackend) IsAlive(i *Instance) bool {
+	return i.AgentServer().Alive()
+}
+
+// CheckAndHandleTrustPrompt is a daemon-side no-op: the in-container agent-server
+// dismisses trust/permission prompts itself on every Snapshot (its localAgentServer
+// runs CheckAndHandleTrustPrompt before reading the pane), so there is nothing for
+// the daemon to do over the wire.
+func (b *dockerBackend) CheckAndHandleTrustPrompt(*Instance) bool { return false }
+
+func (b *dockerBackend) TapEnter(i *Instance) { i.AgentServer().TapEnter() }
+
+// Recover/Respawn are unsupported until PR6 wires archive/restore (push/pull the
+// branch, re-provision the container). A Lost docker session is flagged but not
+// auto-reconnected yet.
+func (b *dockerBackend) Recover(*Instance) error { return ErrRecoverUnsupported }
+func (b *dockerBackend) Respawn(*Instance) error { return ErrRecoverUnsupported }

--- a/session/instance.go
+++ b/session/instance.go
@@ -183,9 +183,17 @@ type Instance struct {
 	// driving the `af agent-server` this points at, instead of the local in-process
 	// runtime. Built once at NewInstance from InstanceOptions.RemoteAgentServer (so
 	// a bad endpoint fails there, keeping AgentServer() infallible) and nil for
-	// every local session — the default path is provably unchanged. DARK in PR2: no
-	// runtime sets it yet (PR3-PR5).
+	// every local session — the default path is provably unchanged. Set by the
+	// docker runtime (#1592 Phase 4 PR4) from its provisioned container; nil for
+	// local/hook sessions.
 	remoteClient *remoteAgentClient
+	// runtimeTeardown reaps the off-box sandbox a runtime provisioned (#1592
+	// Phase 4 PR4): `docker rm -f` the container. Set at NewInstance from the
+	// runtime's ProvisionResult and run by the remote agent-server's Kill AFTER it
+	// tears the in-sandbox workspace down over REST, so killing the session also
+	// removes the container it ran in. nil for local/hook sessions (nothing
+	// off-box to reap). Idempotent — the runtime guards it with a sync.Once.
+	runtimeTeardown func() error
 }
 
 // tabTmuxSession returns the tmux session backing the tab at idx (0 is the agent

--- a/session/instance_factory.go
+++ b/session/instance_factory.go
@@ -42,37 +42,49 @@ type InstanceOptions struct {
 	RemoteAgentServer *AgentServerEndpoint
 }
 
-// backendFactory constructs the Backend used by a new Instance. It is a
-// package-level variable (not a hard-coded branch) so tests can inject a
-// FakeBackend through SetBackendFactoryForTest without touching production
-// code paths. Defaults to the real local/remote branching.
+// backendFactory provisions the runtime for a new Instance, returning the
+// in-process Backend plus (for a sandboxed runtime) the authed remote endpoint
+// and the sandbox-reap teardown. It is a package-level variable (not a
+// hard-coded branch) so tests can inject a FakeBackend through
+// SetBackendFactoryForTest without touching production code paths. Defaults to
+// the real runtime resolution.
 var backendFactory = defaultBackendFactory
 
 // defaultBackendFactory resolves the session's runtime from the requested
 // backend kind (the `--backend` flag / repo `backend` config, or ForceRemote for
-// the legacy hook path) and provisions it, returning the in-process Backend. It
-// is the production path behind the backendFactory test seam; a test that
+// the legacy hook path) and provisions it, returning the whole ProvisionResult.
+// It is the production path behind the backendFactory test seam; a test that
 // replaces backendFactory injects a FakeBackend directly and never reaches here.
 //
-// The remote-endpoint half of a runtime's provision result (ProvisionResult.
-// Endpoint) is intentionally not consumed on this path in PR3: local/hook
-// provision in-process (nil endpoint) and docker/ssh error out, so no non-nil
-// endpoint is ever produced yet. PR4/PR5 wire the endpoint through when the
-// sandboxed runtimes start producing one.
-func defaultBackendFactory(opts InstanceOptions, absPath string) (Backend, error) {
+// The full ProvisionResult flows to NewInstance (#1592 Phase 4 PR4): local/hook
+// provision in-process (nil Endpoint, nil Teardown — the local path is
+// unchanged), while the docker runtime returns the in-container agent-server's
+// authed endpoint + the container-reap teardown, which NewInstance threads into
+// the instance's remote agent-server client and Kill path.
+func defaultBackendFactory(opts InstanceOptions, absPath string) (ProvisionResult, error) {
 	kind, err := resolveBackendKind(opts, absPath)
 	if err != nil {
-		return nil, err
+		return ProvisionResult{}, err
 	}
 	rt, err := ResolveRuntime(kind)
 	if err != nil {
-		return nil, err
+		return ProvisionResult{}, err
 	}
-	res, err := rt.Provision(ProvisionSpec{RepoRoot: absPath})
-	if err != nil {
-		return nil, err
+	spec := ProvisionSpec{
+		RepoRoot: absPath,
+		Title:    opts.Title,
+		Program:  opts.Program,
+		AutoYes:  opts.AutoYes,
 	}
-	return res.Backend, nil
+	// A sandboxed runtime clones the workspace from the repo's origin (epic
+	// decision 4: GitHub is the durable store); resolve it only for those kinds so
+	// a local create never pays for an extra git subprocess. Best-effort — a repo
+	// with no origin yields "", and the docker runtime surfaces the actionable
+	// "no origin remote" error at create.
+	if kind == BackendDocker || kind == BackendSSH {
+		spec.CloneURL = originRemoteURL(absPath)
+	}
+	return rt.Provision(spec)
 }
 
 // resolveBackendKind decides which runtime a new session uses, in precedence
@@ -102,10 +114,19 @@ func resolveBackendKind(opts InstanceOptions, absPath string) (BackendKind, erro
 
 // SetBackendFactoryForTest replaces the backend factory with f and returns a
 // restore function. Intended for use in tests that need to swap in a
-// FakeBackend so NewInstance-driven creation flows stay on the hot path.
+// FakeBackend so NewInstance-driven creation flows stay on the hot path. f
+// returns just the Backend — the common case for a local FakeBackend — and is
+// adapted to the internal ProvisionResult factory here, so a test that only
+// wants to inject a backend needs no knowledge of the endpoint/teardown seam.
 func SetBackendFactoryForTest(f func(opts InstanceOptions, absPath string) (Backend, error)) func() {
 	prev := backendFactory
-	backendFactory = f
+	backendFactory = func(opts InstanceOptions, absPath string) (ProvisionResult, error) {
+		b, err := f(opts, absPath)
+		if err != nil {
+			return ProvisionResult{}, err
+		}
+		return ProvisionResult{Backend: b}, nil
+	}
 	return func() { backendFactory = prev }
 }
 
@@ -142,36 +163,51 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		return nil, fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
-	backend, err := backendFactory(opts, absPath)
+	res, err := backendFactory(opts, absPath)
 	if err != nil {
 		return nil, err
 	}
+	backend := res.Backend
 
-	// A remote-runtime session builds its agent-server transport up front so the
-	// endpoint (URL, TLS pin) is validated here rather than on first AgentServer()
-	// use — which is what keeps the AgentServer() factory infallible (#1592 Phase 4
-	// PR2). nil for every local session, so the default path is untouched.
+	// A sandboxed runtime (docker) provisions its workspace during backendFactory
+	// and hands back the in-sandbox agent-server's authed endpoint; a caller can
+	// also pass one explicitly (the PR2 out-of-process round-trip). Either way the
+	// session builds its agent-server transport up front so the endpoint (URL, TLS
+	// pin) is validated here rather than on first AgentServer() use — which keeps
+	// the AgentServer() factory infallible (#1592 Phase 4 PR2). nil for every local
+	// session, so the default path is untouched.
+	endpoint := res.Endpoint
+	if endpoint == nil {
+		endpoint = opts.RemoteAgentServer
+	}
 	var remoteClient *remoteAgentClient
-	if opts.RemoteAgentServer != nil {
-		remoteClient, err = newRemoteAgentClient(*opts.RemoteAgentServer, opts.Title)
+	if endpoint != nil {
+		remoteClient, err = newRemoteAgentClient(*endpoint, opts.Title)
 		if err != nil {
+			// The sandbox is already up (backendFactory provisioned it); a bad
+			// endpoint here would strand it, so reap it before failing rather than
+			// leaking a container/remote workspace.
+			if res.Teardown != nil {
+				_ = res.Teardown()
+			}
 			return nil, fmt.Errorf("failed to build remote agent-server client: %w", err)
 		}
 	}
 
 	return &Instance{
-		ID:           newSessionID(),
-		Title:        opts.Title,
-		liveness:     LiveReady,
-		Path:         absPath,
-		Program:      opts.Program,
-		Height:       0,
-		Width:        0,
-		CreatedAt:    t,
-		UpdatedAt:    t,
-		AutoYes:      opts.AutoYes,
-		inPlace:      opts.InPlace,
-		backend:      backend,
-		remoteClient: remoteClient,
+		ID:              newSessionID(),
+		Title:           opts.Title,
+		liveness:        LiveReady,
+		Path:            absPath,
+		Program:         opts.Program,
+		Height:          0,
+		Width:           0,
+		CreatedAt:       t,
+		UpdatedAt:       t,
+		AutoYes:         opts.AutoYes,
+		inPlace:         opts.InPlace,
+		backend:         backend,
+		remoteClient:    remoteClient,
+		runtimeTeardown: res.Teardown,
 	}, nil
 }

--- a/session/ptychannel_tmux.go
+++ b/session/ptychannel_tmux.go
@@ -109,11 +109,22 @@ func (c *tmuxClientlessChannel) Resize(rows, cols uint16) error {
 	return c.ts.ResizeWindow(int(cols), int(rows))
 }
 
-// pipePaneCommand builds the `cat >> <fifo>` shell snippet handed to pipe-pane
-// (tmux runs it through /bin/sh). The FIFO path is single-quoted so a home dir
-// with spaces or shell metacharacters cannot break the command.
+// pipePaneCommand builds the shell snippet handed to pipe-pane (tmux runs it
+// through /bin/sh) to copy the pane's live output into the broker's FIFO. The
+// FIFO path is single-quoted so a home dir with spaces or shell metacharacters
+// cannot break the command.
+//
+// It uses `dd` rather than `cat` because `cat` is NOT reliably unbuffered across
+// libc/coreutils implementations (#1592 Phase 4 PR4): busybox `cat` (musl/alpine,
+// the common docker BYO image base) block-buffers its stdout when it is a pipe,
+// so a session's live PTY output never streams — it sits in cat's buffer until
+// the pane closes, which breaks the WS stream inside a container while working on
+// a glibc host. `dd` does one read()→write() per block and writes each partial
+// read immediately, so it streams promptly EVERYWHERE while a large block size
+// keeps bulk output (a full-screen repaint, a fast log) as efficient as cat was.
+// dd's completion stats go to stderr, discarded here.
 func pipePaneCommand(fifoPath string) string {
-	return "cat >> " + shellSingleQuote(fifoPath)
+	return "dd of=" + shellSingleQuote(fifoPath) + " bs=65536 2>/dev/null"
 }
 
 // shellSingleQuote single-quotes s for safe interpolation into a /bin/sh command,

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -44,14 +44,32 @@ func ParseBackendKind(s string) (BackendKind, error) {
 }
 
 // ProvisionSpec is the input a Runtime needs to establish a session's execution
-// environment. It is deliberately small: the local/hook runtimes provision from
-// the repo root alone, and the sandboxed runtimes (docker/ssh) read their own
-// section from the repo's resolved config by RepoRoot. PR4/PR5 extend it with
-// what a sandbox needs (the repo@branch to clone, the agent-server workspace id)
-// when those runtimes start consuming it.
+// environment. The local/hook runtimes provision from the repo root alone; the
+// sandboxed runtimes (docker/ssh) additionally need the session's identity
+// (Title/Program/AutoYes) to start an `af agent-server` for exactly one
+// workspace, and the clone source so the sandbox can pull the repo from GitHub
+// (epic decision 4: GitHub is the durable workspace store). They read their own
+// section (docker.*/ssh.*) from the repo's resolved config by RepoRoot.
 type ProvisionSpec struct {
 	// RepoRoot is the absolute repo root the session is created against.
 	RepoRoot string
+	// Title is the session title. A sandbox runtime uses it as the single
+	// workspace's agent-server title (the /v1/sessions/{title}/stream path id the
+	// daemon's remote client dials) and — inside the sandbox — as the git branch
+	// seed, exactly as the local runtime does.
+	Title string
+	// Program is the agent program to run in the workspace (empty ⇒ the config
+	// default). Passed through to the sandbox's `af agent-server --program`.
+	Program string
+	// AutoYes enables the workspace's AutoYes accept.
+	AutoYes bool
+	// CloneURL is the git remote the sandbox clones the workspace from — the
+	// repo's `origin` for a docker/ssh session (GitHub for a real repo, a
+	// file:// or bind-mounted path for a self-contained test). Empty for the
+	// in-process local/hook runtimes, which never clone. On a fresh create the
+	// sandbox clones its default branch and the in-sandbox worktree derives the
+	// session branch from Title; restore-to-a-pushed-branch is PR6.
+	CloneURL string
 }
 
 // ProvisionResult is what a Runtime hands back: the in-process Backend that
@@ -64,10 +82,18 @@ type ProvisionResult struct {
 	// Endpoint is the authed `af agent-server` URL + token + TLS pin a sandbox
 	// runtime exposes (#1592 Phase 4). nil for an in-process runtime
 	// (local/hook), whose agent-server is the local tmux facade with no network
-	// hop. The docker/ssh runtimes fill this in PR4/PR5; NewInstance threads a
-	// non-nil endpoint into the instance's remote agent-server client. The
+	// hop. The docker/ssh runtimes fill this in (docker: PR4); NewInstance threads
+	// a non-nil endpoint into the instance's remote agent-server client. The
 	// runtime-contract test exercises the non-nil path via a fake runtime.
 	Endpoint *AgentServerEndpoint
+	// Teardown reaps the sandbox this Runtime provisioned — `docker rm -f` the
+	// container (PR4), close the ssh tunnel + remove the remote dir (PR5). nil for
+	// an in-process runtime (nothing off-box to reap). NewInstance stashes it on
+	// the instance so the agent-server Kill path runs it AFTER tearing the remote
+	// workspace down over REST, and NewInstance itself runs it if wiring the
+	// remote client fails, so a provisioned sandbox never leaks. Idempotent (the
+	// docker runtime guards it with a sync.Once).
+	Teardown func() error
 }
 
 // Runtime is the provision-and-expose seam (#1592 Phase 4 PR3): given a session
@@ -139,21 +165,11 @@ func (hookRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
 	return ProvisionResult{Backend: hook}, nil
 }
 
-// dockerRuntime is registered so `backend = "docker"` resolves cleanly, but its
-// real provisioning (run a container, clone repo@branch, start an
-// `af agent-server`, expose its published-port URL) lands in PR4. Until then it
-// fails create with an actionable error. It reads the resolved docker.image so a
-// user who has already configured it gets it echoed back — and so the config
-// field is genuinely consumed here, not dead until PR4.
-type dockerRuntime struct{}
-
-func (dockerRuntime) Provision(spec ProvisionSpec) (ProvisionResult, error) {
-	image := ""
-	if cfg, err := resolveRepoConfig(spec.RepoRoot); err == nil && cfg.Docker != nil {
-		image = cfg.Docker.Image
-	}
-	return ProvisionResult{}, fmt.Errorf("the docker backend is not yet implemented (image %q); it lands in #1592 Phase 4 PR4 — use backend=local for now", image)
-}
+// dockerRuntime provisions a real container sandbox (#1592 Phase 4 PR4). Its
+// Provision lives in backend_docker.go: run a container from the configured
+// docker.image, clone the repo inside it, docker cp the `af` binary in, start an
+// `af agent-server` on a published port, and expose its authed wss:// URL. The
+// type is declared there.
 
 // sshRuntime is registered so `backend = "ssh"` resolves cleanly; its real
 // provisioning (dial the host, clone repo@branch, start an `af agent-server`,

--- a/session/runtime_test.go
+++ b/session/runtime_test.go
@@ -92,30 +92,45 @@ func TestLocalRuntimeProvision_Unchanged(t *testing.T) {
 	assert.Nil(t, res.Endpoint, "an in-process runtime exposes no remote endpoint")
 }
 
-// TestDockerSSHRuntime_NotImplemented proves docker and ssh are registered but
-// fail create with a clear, actionable error naming the PR that implements them
-// — and that the error echoes the configured image/host (so the config sections
-// are genuinely consumed).
-func TestDockerSSHRuntime_NotImplemented(t *testing.T) {
+// TestSSHRuntime_NotImplemented proves ssh is registered but fails create with a
+// clear, actionable error naming the PR that implements it — and that the error
+// echoes the configured host (so the ssh config section is genuinely consumed).
+func TestSSHRuntime_NotImplemented(t *testing.T) {
 	repoRoot := initTempGitRepo(t)
 	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
 	writeInRepoConfig(t, repoRoot, map[string]any{
-		"backend": "docker",
-		"docker":  map[string]any{"image": "my-runtime:latest"},
+		"backend": "ssh",
 		"ssh":     map[string]any{"host": "build-box:2222"},
 	})
-
-	_, derr := dockerRuntime{}.Provision(ProvisionSpec{RepoRoot: repoRoot})
-	require.Error(t, derr)
-	assert.Contains(t, derr.Error(), "docker backend is not yet implemented")
-	assert.Contains(t, derr.Error(), "PR4")
-	assert.Contains(t, derr.Error(), "my-runtime:latest")
 
 	_, serr := sshRuntime{}.Provision(ProvisionSpec{RepoRoot: repoRoot})
 	require.Error(t, serr)
 	assert.Contains(t, serr.Error(), "ssh backend is not yet implemented")
 	assert.Contains(t, serr.Error(), "PR5")
 	assert.Contains(t, serr.Error(), "build-box:2222")
+}
+
+// TestDockerRuntime_ConfigValidation pins the docker runtime's cheap, hermetic
+// preconditions (no docker daemon needed): docker.image is required, and a fresh
+// repo with no origin remote fails with the actionable "no origin remote" error.
+// The real container round-trip lives in the integration package (docker-gated).
+func TestDockerRuntime_ConfigValidation(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	// backend=docker with no docker.image → clear "image required" error.
+	noImage := initTempGitRepo(t)
+	writeInRepoConfig(t, noImage, map[string]any{"backend": "docker", "docker": map[string]any{}})
+	_, err := dockerRuntime{}.Provision(ProvisionSpec{RepoRoot: noImage, Title: "s", CloneURL: "file:///x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "docker.image")
+
+	// image set but no origin remote to clone from → actionable error, before any
+	// docker call.
+	withImage := initTempGitRepo(t)
+	writeInRepoConfig(t, withImage, map[string]any{"backend": "docker", "docker": map[string]any{"image": "my-runtime:latest"}})
+	_, err = dockerRuntime{}.Provision(ProvisionSpec{RepoRoot: withImage, Title: "s", CloneURL: ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "origin")
 }
 
 // fakeRuntime is a Runtime that returns a fixed provision result — used to
@@ -188,19 +203,22 @@ func TestDefaultBackendFactory_ConfigSelection(t *testing.T) {
 
 	t.Run("local default is a plain LocalBackend", func(t *testing.T) {
 		repoRoot := initTempGitRepo(t) // no in-repo config → local
-		b, err := defaultBackendFactory(InstanceOptions{Title: "s"}, repoRoot)
+		res, err := defaultBackendFactory(InstanceOptions{Title: "s"}, repoRoot)
 		require.NoError(t, err)
-		if _, ok := b.(*LocalBackend); !ok {
-			t.Fatalf("local default must be *LocalBackend, got %T", b)
+		if _, ok := res.Backend.(*LocalBackend); !ok {
+			t.Fatalf("local default must be *LocalBackend, got %T", res.Backend)
 		}
+		assert.Nil(t, res.Endpoint, "a local session exposes no remote endpoint")
 	})
 
-	t.Run("docker config fails not-implemented", func(t *testing.T) {
+	t.Run("docker config without image fails cleanly", func(t *testing.T) {
+		// A docker create with no docker.image errors before any docker call — the
+		// hermetic precondition. The real container path is the integration round-trip.
 		repoRoot := initTempGitRepo(t)
-		writeInRepoConfig(t, repoRoot, map[string]any{"backend": "docker", "docker": map[string]any{"image": "img"}})
+		writeInRepoConfig(t, repoRoot, map[string]any{"backend": "docker", "docker": map[string]any{}})
 		_, err := defaultBackendFactory(InstanceOptions{Title: "s"}, repoRoot)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not yet implemented")
+		assert.Contains(t, err.Error(), "docker.image")
 	})
 
 	t.Run("hook config still builds a HookBackend", func(t *testing.T) {
@@ -213,10 +231,10 @@ func TestDefaultBackendFactory_ConfigSelection(t *testing.T) {
 				"delete_cmd": "echo",
 			},
 		})
-		b, err := defaultBackendFactory(InstanceOptions{Title: "s"}, repoRoot)
+		res, err := defaultBackendFactory(InstanceOptions{Title: "s"}, repoRoot)
 		require.NoError(t, err)
-		if _, ok := b.(*HookBackend); !ok {
-			t.Fatalf("backend=hook must build a *HookBackend, got %T", b)
+		if _, ok := res.Backend.(*HookBackend); !ok {
+			t.Fatalf("backend=hook must build a *HookBackend, got %T", res.Backend)
 		}
 	})
 


### PR DESCRIPTION
The FLAGSHIP of #1592 Phase 4: the first-class **docker** runtime. A session's
workspace + agent run inside a real container, driven by the daemon over an
authed `wss://` URL to **full parity with local**.

Builds on the merged spine: PR1 (`af agent-server` headless), PR2
(`remoteAgentServer` daemon client), PR3 (`Runtime` interface + registry +
`backend`/`docker.*` config).

## The docker Runtime (`session/backend_docker.go`)

Drives docker through the CLI (`os/exec` — the HookBackend idiom, not the SDK).
`dockerRuntime.Provision`, called from the backend factory during `NewInstance`:

1. **`docker run`** a container from the user's **BYO image** (`docker.image`
   config — no af-published image, Sachin-locked Q3), kept alive, publishing the
   in-container agent-server port on a random loopback host port.
2. **clone** the repo's `origin` into `/workspace` inside the container (GitHub
   is the durable workspace store, epic decision 4; the container is disposable).
3. **`docker cp`** the daemon's own `af` binary in (always version-matched).
4. **`docker exec`** an `af agent-server --listen :<port>` headless in the
   container (TLS + bearer token, PR1), and read its startup banner.
5. **`docker port`** → build the authed `wss://127.0.0.1:<hostport>` URL.

**Expose:** returns `{URL, Token, Fingerprint}`; the daemon drives the
in-container agent-server through PR2's `remoteAgentServer`. **Teardown:** kill →
`docker rm -f` (reaped on kill, on a partial-provision failure, and on a
bad-endpoint `NewInstance` failure — a container never leaks).

## Wiring

- `ProvisionResult` now carries the endpoint **and** a sandbox-reap `Teardown`.
  The backend factory propagates the whole result; `NewInstance` threads the
  endpoint into the remote agent-server client and the teardown into the Kill
  path (run after the REST `/v1/agent/kill`). `SetBackendFactoryForTest` keeps
  its Backend-only signature (adapted internally) → no test churn.
- The in-sandbox agent-server is forced to `Backend: BackendLocal` so a
  workspace whose cloned repo config declares `backend=docker` does **not**
  recurse into docker-in-docker.
- **Capabilities:** interactive parity — attach / preview / liveness / prompt /
  tabs. `Archive`/`Recover` (push/pull the branch) land in PR6.

## Fix: clientless PTY capture buffered in musl/busybox

The local-runtime clientless capture used `tmux pipe-pane … "cat >> fifo"`.
**busybox `cat`** (musl/alpine — the common BYO image base) block-buffers its
stdout to a pipe, so a container session's live PTY output never flushed (the
stream only delivered the initial repaint). Switched `pipePaneCommand` to
`dd of=fifo bs=65536`, which does one read→write per block (flushing each
partial read immediately) on every libc while keeping bulk output efficient.
Verified streaming on **both** alpine and glibc; the host WS-PTY / agent-server
round-trips and the full suite stay green.

## The REAL container round-trip

`make backend-docker-roundtrip` (host, docker-gated, **skips cleanly** without a
docker daemon so the fenced suite stays green) builds a slim git+tmux image,
creates a session on `backend=docker`, and drives the in-container agent-server
over `wss://`+token — create → preview/liveness → **type into the PTY stream
(input reaches the in-container agent) → observe the echo** → kill (container
reaped, no leak):

```
=== RUN   TestDockerBackendRoundTrip
    provisioning docker session "docker-rt" (image af-docker-roundtrip:test)...
    container is up; agent-server exposed over wss:// with TLS+token
    typed input reached the in-container agent and echoed over the stream:
      "\x1b[2J\x1b[H … docker-roundtrip-ping\r\ndocker-roundtrip-ping"
    preview/liveness reflect the in-container workspace over the wire
    container reaped on Kill — no leak. docker round-trip complete.
--- PASS: TestDockerBackendRoundTrip (3.54s)
```

A real container starts, the agent-server comes up inside it, the daemon reaches
it over `wss://`+token, typed bytes reach the in-container agent and stream back,
and the container is reaped on kill — a session runs in a container to parity.

## Gates

- gofmt / `golangci-lint --fast` / `go build` / deadcode / file-length — clean
- `make test-container` (full suite in the fence) — green
- `make tui-driver-selftest` — 25/25 (backend=local unaffected)
- `make backend-docker-roundtrip` — green, reliably (run 3×)
- `scripts/gen-docs.sh` committed; `docs/backends.md` added (docker setup,
  BYO-image requirements, example Dockerfile, operations)

Local / hook / ssh backends unchanged. ssh remains not-implemented (PR5).

Part of #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
