### PR TITLE
fix(tui): embedded pane refreshes live output from send-prompt/daemon delivery (#1661)

### DIFF
--- a/app/live_termpane.go
+++ b/app/live_termpane.go
@@ -72,7 +72,19 @@ func (m *home) reconcileLiveTermPanes() {
 	// fight over size, and our stream would generate tmux traffic in an interactive
 	// client's way (#598 class). The attach dispatch path already closed them; this
 	// covers any path that flips the flag without going through showHelpScreen.
-	if m.attached.Load() {
+	//
+	// attachTransitioning is checked alongside attached to close the #1661 window:
+	// when the one-time attach help is already seen, showHelpScreen closes the panes
+	// and then dispatches the attach through a 20ms tea.Tick (beginAttachTransition).
+	// For those ~20ms attached is still false and m.state is still stateDefault, so
+	// without this a previewTick reconcile RE-CREATES an embedded attachment that then
+	// lives THROUGH the full-screen attach — where the attach client's full-screen
+	// resize reflows its emulator to garbage — and is kept (same bind key) after
+	// detach, rendering a blank/stale grid that never recovers because the stream
+	// never dropped. Treating the whole transition as "no WS panes" means the pane is
+	// instead freshly rebuilt after detach with a clean repaint. attachTransitioning
+	// is written and read only on the event loop, so no atomic is needed.
+	if m.attached.Load() || m.attachTransitioning {
 		m.closeAllLiveTermPanes()
 		return
 	}

--- a/app/live_termpane_test.go
+++ b/app/live_termpane_test.go
@@ -166,6 +166,43 @@ func TestSyncLiveTermPaneClosesWhileAttached(t *testing.T) {
 	assert.Len(t, *fakes, 1)
 }
 
+// TestSyncLiveTermPaneClosesWhileAttachTransitioning is the #1661 regression: the
+// window between the attach dispatch (which closes the panes) and the attach
+// actually starting. When the one-time attach help is already seen, showHelpScreen
+// closes the panes and dispatches the attach through a 20ms tea.Tick, during which
+// attached is still false and m.state is still stateDefault. A reconcile in that
+// window must NOT rebuild an attachment — one rebuilt here would live through the
+// full-screen attach, be reflowed to garbage by the attach client's resize, and be
+// kept (stale/blank) after detach because its stream never dropped.
+func TestSyncLiveTermPaneClosesWhileAttachTransitioning(t *testing.T) {
+	h, _ := liveTestHome(t)
+	fakes, _ := stubLiveTermFactory(t)
+	h.syncLiveTermPane()
+	require.Len(t, *fakes, 1)
+
+	// The attach is dispatched but not yet started: attached is false, state is
+	// still default — only attachTransitioning marks the in-flight attach.
+	h.attachTransitioning = true
+	require.False(t, h.attached.Load())
+	require.Equal(t, stateDefault, h.state)
+
+	h.syncLiveTermPane()
+	assert.True(t, (*fakes)[0].closed, "the pending attach must release every live attachment")
+	assert.Empty(t, h.liveTerms)
+
+	// And nothing rebinds during the transition — otherwise a pane created here
+	// survives into the attach and renders stale after detach (#1661).
+	h.syncLiveTermPane()
+	assert.Len(t, *fakes, 1, "no attachment may be rebuilt while the attach is in flight")
+
+	// Once the attach fully unwinds (detach clears both flags), a fresh attachment
+	// is rebuilt — with a clean emulator, not the corrupted one.
+	h.attachTransitioning = false
+	h.syncLiveTermPane()
+	require.Len(t, *fakes, 2, "detach must rebuild a fresh attachment")
+	assert.False(t, (*fakes)[1].closed)
+}
+
 func TestAttachHelpScreenClosesLiveAttachment(t *testing.T) {
 	h, _ := liveTestHome(t)
 	fakes, _ := stubLiveTermFactory(t)

--- a/integration/repro1661_test.go
+++ b/integration/repro1661_test.go
@@ -1,0 +1,49 @@
+package integration_test
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEmbeddedPaneRefreshesFromSendPrompt is the #1661 end-to-end guard: an
+// already-connected WS subscriber (the embedded pane) must refresh with output
+// delivered out-of-band via `af sessions send-prompt` (daemon DeliverPrompt), not
+// only with input it types itself.
+//
+// It then exercises the exact regression trigger — a full-screen attach+detach
+// re-binds the embedded pane, whose reconnect used to race the attach
+// subscriber's capture teardown and strand the pane on a disabled pane pipe. The
+// reconnected subscriber must still receive a subsequent send-prompt delivery.
+//
+// Run it in the container fence: make ws-pty-roundtrip-container GOTESTARGS=...
+// (a real daemon + real tmux, like TestWSPTYBrokerRoundTrip).
+func TestEmbeddedPaneRefreshesFromSendPrompt(t *testing.T) {
+	h := newHarness(t)
+	h.startDaemon()
+	h.createSession("beta")
+
+	// The embedded pane: a live WS subscriber, already connected before the prompt.
+	emb := h.dialWS(t, "/v1/sessions/beta/stream")
+	defer emb.close()
+	time.Sleep(500 * time.Millisecond) // let the initial repaint drain
+
+	// Out-of-band delivery through the daemon (the CLI/send-prompt path), NOT the
+	// WS input path. The already-open subscriber must see it.
+	h.run("sessions", "--repo", h.repo, "send-prompt", "beta", "echo REFRESH_ONE")
+	emb.waitOutput(t, "REFRESH_ONE")
+
+	// Now model the attach+detach cycle that triggers #1661: a full-screen attach
+	// opens its own subscriber, the embedded panes are closed, then the attach
+	// detaches (last subscriber leaves → capture teardown), and the embedded pane
+	// re-binds with a FRESH subscription that races that teardown.
+	att := h.dialWS(t, "/v1/sessions/beta/stream")
+	emb.close()                                     // attach closes the embedded panes
+	att.close()                                     // detach: last subscriber leaves → teardown
+	emb2 := h.dialWS(t, "/v1/sessions/beta/stream") // embedded re-binds after detach
+	defer emb2.close()
+
+	// The re-bound embedded pane must refresh from a subsequent send-prompt — the
+	// teardown must not have disabled the pane pipe out from under it.
+	h.run("sessions", "--repo", h.repo, "send-prompt", "beta", "echo REFRESH_TWO")
+	emb2.waitOutput(t, "REFRESH_TWO")
+}

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -68,6 +68,19 @@ type ptyBroker struct {
 	ch       clientlessChannel
 	maxBytes int
 
+	// captureMu serializes the clientless capture's bring-up and tear-down so a
+	// teardown can NEVER clobber a concurrently-(re)started capture (#1661). The
+	// clientless channel drives a SINGLE pane pipe (`tmux pipe-pane`), so an
+	// out-of-order StopCapture would `pipe-pane`-disable whatever pipe is current —
+	// including a fresh one a new subscriber just enabled — leaving the new
+	// subscriber with a live ring/readLoop but no bytes ever arriving (a stale pane
+	// after a full-screen attach+detach cycle re-binds the embedded pane). Every
+	// start/stop runs through a captureMu-serialized reconcile that re-reads the
+	// live subscriber count, so the last operation to run always converges the
+	// pipe to the true desired state. Lock ordering: captureMu THEN mu, never the
+	// reverse.
+	captureMu sync.Mutex
+
 	mu   sync.Mutex
 	buf  []byte // ring: recent output bytes, buf[0] is at seq `base`
 	base Seq    // seq of buf[0]; head == base + len(buf)
@@ -104,12 +117,6 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 		b.mu.Unlock()
 		return nil, fmt.Errorf("pty broker closed")
 	}
-	if !b.capturing {
-		if err := b.startCaptureLocked(); err != nil {
-			b.mu.Unlock()
-			return nil, err
-		}
-	}
 	head := b.headLocked()
 	cursor := since
 	// since == 0 means "from the live tail" (the documented default); a real
@@ -130,6 +137,16 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 	}
 	b.subs[sub.id] = sub
 	b.mu.Unlock()
+
+	// Bring up the clientless capture through the serialized reconcile — NOT inline
+	// under b.mu — so it can never interleave with a teardown that races it (#1661).
+	// Register-first (above) means the reconcile sees this subscriber, so a
+	// concurrent last-leaver teardown re-checking the count won't tear down the
+	// capture this subscriber needs.
+	if err := b.ensureCaptureStarted(); err != nil {
+		b.remove(sub.id)
+		return nil, err
+	}
 
 	// A fresh subscriber (since == 0, the live tail) gets an initial repaint of the
 	// current screen — pipe-pane only streams future output, so without this a
@@ -160,14 +177,33 @@ func buildRepaint(snapshot []byte) []byte {
 	return append([]byte("\x1b[2J\x1b[H"), body...)
 }
 
-// startCaptureLocked spins up the clientless output capture and the goroutine
-// that feeds its bytes into the ring. Caller holds mu.
-func (b *ptyBroker) startCaptureLocked() error {
+// ensureCaptureStarted brings the clientless output capture up if it is not
+// already running, serialized against every other capture transition by
+// captureMu so a concurrent teardown can neither interleave with nor clobber it
+// (#1661). It runs WITHOUT holding b.mu across the tmux exec ch.StartCapture
+// does, and errors (a vanished session) propagate to the caller so the WS dial
+// fails and the client reconnects. Idempotent: a no-op when already capturing.
+func (b *ptyBroker) ensureCaptureStarted() error {
+	b.captureMu.Lock()
+	defer b.captureMu.Unlock()
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return fmt.Errorf("pty broker closed")
+	}
+	if b.capturing {
+		b.mu.Unlock()
+		return nil
+	}
+	b.mu.Unlock()
+
 	r, err := b.ch.StartCapture()
 	if err != nil {
 		return fmt.Errorf("start clientless pty capture: %w", err)
 	}
 	done := make(chan struct{})
+	b.mu.Lock()
 	b.capturing = true
 	b.stopCapture = func() {
 		if err := b.ch.StopCapture(); err != nil {
@@ -176,8 +212,36 @@ func (b *ptyBroker) startCaptureLocked() error {
 		_ = r.Close()
 		<-done
 	}
+	b.mu.Unlock()
 	go b.readLoop(r, done)
 	return nil
+}
+
+// maybeStopCapture tears the capture down IFF no subscriber remains — the
+// counterpart to ensureCaptureStarted, and serialized against it by captureMu.
+// It RE-CHECKS the live subscriber count under captureMu (not just at the caller's
+// earlier read) so a subscriber that (re)connected in the meantime keeps its
+// capture: this is the invariant that fixes #1661, where a detach's teardown
+// raced a reconnect's bring-up and disabled the pane pipe out from under it. The
+// blocking teardown runs WITHOUT b.mu held so the read loop (which takes b.mu in
+// feed) can drain and exit.
+func (b *ptyBroker) maybeStopCapture() {
+	b.captureMu.Lock()
+	defer b.captureMu.Unlock()
+
+	b.mu.Lock()
+	if len(b.subs) != 0 || !b.capturing {
+		b.mu.Unlock()
+		return
+	}
+	stop := b.stopCapture
+	b.capturing = false
+	b.stopCapture = nil
+	b.mu.Unlock()
+
+	if stop != nil {
+		stop()
+	}
 }
 
 // readLoop copies the clientless capture reader into the ring until it errors or
@@ -263,7 +327,10 @@ func (b *ptyBroker) wakeAllLocked() {
 }
 
 // remove drops a subscriber and stops the clientless capture once the last one
-// leaves — never touching the PTY/session itself.
+// leaves — never touching the PTY/session itself. The stop goes through
+// maybeStopCapture, which re-checks the subscriber count under captureMu so a
+// subscriber that connects while this teardown is deciding is not stranded on a
+// disabled pipe (#1661).
 func (b *ptyBroker) remove(id uint64) {
 	b.mu.Lock()
 	if _, ok := b.subs[id]; !ok {
@@ -271,21 +338,22 @@ func (b *ptyBroker) remove(id uint64) {
 		return
 	}
 	delete(b.subs, id)
-	var stop func()
-	if len(b.subs) == 0 && b.capturing {
-		stop = b.stopCapture
-		b.capturing = false
-		b.stopCapture = nil
-	}
+	lastLeft := len(b.subs) == 0 && b.capturing
 	b.mu.Unlock()
-	if stop != nil {
-		stop()
+	if lastLeft {
+		b.maybeStopCapture()
 	}
 }
 
 // close tears down the broker: every subscriber's NextEvent returns io.EOF and
-// the clientless capture is stopped. Called when the session is killed.
+// the clientless capture is stopped. Called when the session is killed. Holds
+// captureMu (captureMu-then-mu ordering) so it cannot race a concurrent
+// ensureCaptureStarted into resurrecting a capture on a closed broker (#1661) —
+// a bring-up that lost the race sees b.closed and unwinds.
 func (b *ptyBroker) close() {
+	b.captureMu.Lock()
+	defer b.captureMu.Unlock()
+
 	b.mu.Lock()
 	if b.closed {
 		b.mu.Unlock()

--- a/session/ptybroker_test.go
+++ b/session/ptybroker_test.go
@@ -25,6 +25,18 @@ type fakeClientlessChannel struct {
 	// subscribe and after a resize; snapshots counts how many times it was read.
 	snapshot  []byte
 	snapshots int
+	// wClosed reports whether the CURRENT capture writer (f.w) has been closed by a
+	// StopCapture — the test proxy for "the pane pipe was disabled". Reset on each
+	// StartCapture. Used by the #1661 teardown-clobber regression test.
+	wClosed bool
+	// stopEntered/stopRelease gate StopCapture: when both are non-nil, StopCapture
+	// signals stopEntered on entry and then blocks on stopRelease before doing any
+	// teardown, so a test can pin the "teardown runs mid-reconnect" interleaving.
+	stopEntered chan struct{}
+	stopRelease chan struct{}
+	// stopDone, when non-nil, is signaled AFTER StopCapture has closed the writer,
+	// so a test can order an assertion strictly after the teardown's effect.
+	stopDone chan struct{}
 }
 
 func (f *fakeClientlessChannel) StartCapture() (io.ReadCloser, error) {
@@ -35,15 +47,26 @@ func (f *fakeClientlessChannel) StartCapture() (io.ReadCloser, error) {
 	}
 	f.starts++
 	f.r, f.w = io.Pipe()
+	f.wClosed = false
 	return f.r, nil
 }
 
 func (f *fakeClientlessChannel) StopCapture() error {
+	// Gate BEFORE taking f.mu so a concurrent StartCapture can proceed while this
+	// teardown is parked — the interleaving the #1661 regression test forces.
+	if f.stopEntered != nil && f.stopRelease != nil {
+		f.stopEntered <- struct{}{}
+		<-f.stopRelease
+	}
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.stops++
 	if f.w != nil {
 		_ = f.w.Close()
+		f.wClosed = true
+	}
+	f.mu.Unlock()
+	if f.stopDone != nil {
+		f.stopDone <- struct{}{}
 	}
 	return nil
 }
@@ -82,6 +105,20 @@ func (f *fakeClientlessChannel) emit(t *testing.T, b []byte) {
 	if _, err := w.Write(b); err != nil {
 		t.Fatalf("emit: %v", err)
 	}
+}
+
+// emitErr writes pane output into the current capture pipe and RETURNS any error
+// (rather than fataling) so a test can assert the pipe is still live — a torn-down
+// pipe surfaces as a write error.
+func (f *fakeClientlessChannel) emitErr(b []byte) error {
+	f.mu.Lock()
+	w := f.w
+	f.mu.Unlock()
+	if w == nil {
+		return io.ErrClosedPipe
+	}
+	_, err := w.Write(b)
+	return err
 }
 
 func nextWithin(t *testing.T, sub PTYSubscription, d time.Duration) (PTYEvent, error) {
@@ -268,6 +305,82 @@ func TestPTYBrokerEvictionFastForwards(t *testing.T) {
 	if ev.Kind != PTYData || string(ev.Data) != "efgh" {
 		t.Fatalf("event = %+v, want the retained tail %q", ev, "efgh")
 	}
+}
+
+// TestPTYBrokerTeardownDoesNotClobberReconnect is the #1661 regression: the
+// clientless channel drives a SINGLE pane pipe, so the last-subscriber teardown
+// (StopCapture → `pipe-pane`-disable) must not run AFTER a new subscriber has
+// brought the capture back up — that ordering would disable the fresh pipe and
+// leave the reconnected subscriber (e.g. an embedded pane re-bound after a
+// full-screen attach+detach) with a live ring but no bytes ever arriving.
+//
+// The test pins the hostile interleaving deterministically: subscriber A leaves
+// and its teardown parks inside StopCapture; subscriber B reconnects while the
+// teardown is mid-flight; then the teardown is released. B must end up on a LIVE
+// capture and receive freshly emitted output.
+func TestPTYBrokerTeardownDoesNotClobberReconnect(t *testing.T) {
+	ch := &fakeClientlessChannel{
+		stopEntered: make(chan struct{}, 1),
+		stopRelease: make(chan struct{}),
+		stopDone:    make(chan struct{}, 1),
+	}
+	br := newPTYBroker(ch)
+
+	a, err := br.subscribe(0) // brings the capture up (StartCapture #1)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+
+	// A leaves: its last-subscriber teardown parks inside the gated StopCapture.
+	go func() { _ = a.Close() }()
+	select {
+	case <-ch.stopEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("teardown never reached StopCapture")
+	}
+
+	// B reconnects while the teardown is parked. With the fix this blocks on the
+	// capture reconcile until the teardown finishes and then starts a FRESH
+	// capture; without it, B starts a capture the parked teardown then disables.
+	type subResult struct {
+		sub *ptySub
+		err error
+	}
+	bres := make(chan subResult, 1)
+	go func() {
+		s, e := br.subscribe(0)
+		bres <- subResult{s, e}
+	}()
+
+	// Give B time to reach the capture reconcile (blocked) or, in the buggy path,
+	// to start its capture before we release the teardown.
+	time.Sleep(50 * time.Millisecond)
+	close(ch.stopRelease)
+
+	var b subResult
+	select {
+	case b = <-bres:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnecting subscribe B never returned")
+	}
+	if b.err != nil {
+		t.Fatalf("subscribe B: %v", b.err)
+	}
+
+	// Order the assertion strictly AFTER the parked teardown's writer-close so the
+	// emit below cannot race ahead of a clobber and pass spuriously.
+	select {
+	case <-ch.stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("teardown never completed")
+	}
+
+	// The reconnected subscriber must be on a LIVE pipe: a freshly emitted byte
+	// reaches it. A clobbered pipe surfaces as a write error here (#1661).
+	if err := ch.emitErr([]byte("LIVE-AFTER-RECONNECT")); err != nil {
+		t.Fatalf("capture pipe was torn down under the reconnected subscriber (#1661): %v", err)
+	}
+	mustData(t, b.sub, "LIVE-AFTER-RECONNECT")
 }
 
 func TestPTYBrokerStopsCaptureWhenLastSubscriberLeaves(t *testing.T) {


### PR DESCRIPTION
Fixes #1661.

## Symptom
An already-open **embedded pane** could go stale — not refreshing output delivered out-of-band via `af sessions send-prompt` (daemon `DeliverPrompt`) — even though `af sessions preview` and a full-screen re-attach (`o`) both showed the output. This is a regression class from the #1592 Phase-2 WS-pane rework (PR6).

## Investigation
I reproduced end-to-end in the container (real daemon + real tmux + the real TUI via the driver) and traced the whole path: `send-prompt` → daemon `DeliverPrompt` → `AgentServer.SendPrompt` → tmux `send-keys` → `pipe-pane` capture → `ptyBroker` fan-out → WS → `apiclient` stream → `ui/termpane` emulator → render.

Two independent causes, both surfacing as a frozen WS-streamed grid:

### 1. Attach-transition reconcile window — the reported symptom (post-detach)
The plain "open pane + `send-prompt`" case actually works on master (verified 4/4). The stale grid the play-test saw is the **post-detach** state. When the one-time attach help is already seen, `showHelpScreen` closes the embedded panes and then dispatches the full-screen attach through a **20ms `tea.Tick`** (`beginAttachTransition`). For those ~20ms `attached` is still `false` and `m.state` is still `stateDefault`, so a `previewTick` reconcile **re-creates an embedded attachment**. That attachment then lives *through* the full-screen attach — where the attach client's full-screen resize reflows its emulator to garbage — and is kept afterward (same bind key), rendering a blank/stale grid that never recovers because the stream never dropped.

Instrumentation confirmed it precisely: post-detach the client **received** the delivered bytes (`readStream: EventData 92 bytes …D2…`) but its emulator rendered an empty grid.

**Fix:** `reconcileLiveTermPanes` now treats the whole attach transition (`attachTransitioning`), not just `attached`, as "no WS panes", so the pane is freshly rebuilt after detach with a clean repaint.

### 2. Broker capture teardown/setup race — latent, same stale-pane class
The clientless channel drives a **single** pane pipe. The last-subscriber teardown (`StopCapture` → `pipe-pane` disable) ran outside the broker lock, so it could execute **after** a new subscriber's `StartCapture` and disable the fresh pipe — leaving a live ring/read-loop with no bytes ever arriving. Proven with a deterministic hostile-interleaving test.

**Fix:** serialize capture bring-up/tear-down through a dedicated `captureMu` reconcile that re-reads the live subscriber count, so a teardown can never clobber a concurrently-(re)started capture.

## Regression coverage
- **app** `TestSyncLiveTermPaneClosesWhileAttachTransitioning` — reconcile releases and does not rebuild an attachment during the attach transition, then rebuilds fresh after detach. Fails without the guard.
- **session** `TestPTYBrokerTeardownDoesNotClobberReconnect` — deterministic race; the reconnected subscriber stays on a live pipe. Fails without the serialization.
- **integration** `TestEmbeddedPaneRefreshesFromSendPrompt` — end-to-end against a real daemon+tmux, including the attach+detach re-bind.

## Verification (container)
Exact issue repro — open `beta` with `s`, `af sessions send-prompt beta "echo CLI_PARITY_OK"`:
```
--- embedded pane BEFORE send-prompt ---
 beta · Agent
 dev@…:~/sandbox/mock-repo-beta$
--- embedded pane AFTER send-prompt ---
 dev@…:~/sandbox/mock-repo-beta$ echo CLI_PARITY_OK
 CLI_PARITY_OK
RESULT: PASS — embedded pane shows BOTH command and output (no re-attach)
```
Attach+detach variant (issue step 5) — post-detach `send-prompt` refreshes the re-bound pane within 1s. **5/5 runs pass (was 3/6 before the fix).**

Gates: `gofmt` clean, `golangci-lint --fast` clean, `go build ./...`, `deadcode -test ./...` clean, file-length lint pass, **`make test-container` full suite green**, **`tui-driver-selftest` 25/25**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)