### PR TITLE
feat(session): archive/restore parity for docker+ssh via push/pull branch (#1592 Phase 4 PR6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,28 +57,35 @@ agent-server-roundtrip-container:
 remote-agent-server-roundtrip-container:
 	scripts/testbox.sh test ./integration -run TestRemoteAgentServerRoundTrip
 
-# Flagship docker backend round-trip (#1592 Phase 4 PR4): runs a session in a
+# Flagship docker backend round-trip (#1592 Phase 4 PR4/PR6): runs a session in a
 # REAL container to parity — build a slim git+tmux+bash image, create a session
 # on backend=docker, drive the in-container `af agent-server` over wss://+token
 # (Provision/Launch → PTY input echo → preview/snapshot/alive), then Kill and
-# assert the container is reaped. Runs ON THE HOST (needs a real docker daemon);
-# it is NOT inside the testbox fence, which has no docker. SKIPS cleanly where
-# docker is unavailable. See docs/backends.md.
+# assert the container is reaped. The PR6 archive/restore case additionally
+# commits real work on the session branch, ARCHIVES it (branch pushed to origin,
+# container reaped), RESTORES it (fresh container clones the branch back, the
+# commit is present, the session is drivable again) — proving state survives via
+# GitHub. Runs ON THE HOST (needs a real docker daemon); it is NOT inside the
+# testbox fence, which has no docker. SKIPS cleanly where docker is unavailable.
+# See docs/backends.md.
 backend-docker-roundtrip:
-	go test ./integration -run TestDockerBackendRoundTrip -v -count=1 -timeout 15m
+	go test ./integration -run 'TestDockerBackend(RoundTrip|ArchiveRestore)' -v -count=1 -timeout 20m
 
-# SSH remote-machine backend round-trip (#1592 Phase 4 PR5): runs a session on a
-# REAL remote host over ssh to parity — stand up a throwaway sshd+git+tmux
+# SSH remote-machine backend round-trip (#1592 Phase 4 PR5/PR6): runs a session on
+# a REAL remote host over ssh to parity — stand up a throwaway sshd+git+tmux
 # container as the ssh target, create a session on backend=ssh pointing at it, and
 # drive the remote `af agent-server` over the ssh-tunneled wss://+token
 # (Provision/Launch → PTY input echo → preview/snapshot/alive), then Kill and
 # assert the remote agent-server process is reaped + the session dir removed + the
-# tunnel closed. Uses the Go x/crypto/ssh client for a real ssh clone + tunnel with
-# no external host or the box's own sshd. Runs ON THE HOST (needs a real docker
-# daemon to host the sshd target); SKIPS cleanly where docker is unavailable. See
-# docs/backends.md.
+# tunnel closed. The PR6 archive/restore case additionally commits real work,
+# ARCHIVES it (branch pushed to origin, remote sandbox reaped), RESTORES it (fresh
+# remote clones the branch back, the commit is present, the session is drivable)
+# — the identical push/pull-branch flow, over ssh. Uses the Go x/crypto/ssh client
+# for a real ssh clone + tunnel with no external host or the box's own sshd. Runs
+# ON THE HOST (needs a real docker daemon to host the sshd target); SKIPS cleanly
+# where docker is unavailable. See docs/backends.md.
 backend-ssh-roundtrip:
-	go test ./integration -run TestSSHBackendRoundTrip -v -count=1 -timeout 15m
+	go test ./integration -run 'TestSSHBackend(RoundTrip|ArchiveRestore)' -v -count=1 -timeout 20m
 
 # Interactive TUI play-test sandbox: builds af inside, scaffolds a
 # throwaway AF home + mock project repo, drops you in a shell with a

--- a/daemon/agentserver_headless.go
+++ b/daemon/agentserver_headless.go
@@ -215,6 +215,7 @@ func (hs *headlessServer) newMux() *http.ServeMux {
 	mux.HandleFunc("/v1/agent/alive", rpcHandler(hs.Alive))
 	mux.HandleFunc("/v1/agent/send-prompt", rpcHandler(hs.SendPrompt))
 	mux.HandleFunc("/v1/agent/tap-enter", rpcHandler(hs.TapEnter))
+	mux.HandleFunc("/v1/agent/archive", rpcHandler(hs.Archive))
 	mux.HandleFunc("/v1/agent/kill", rpcHandler(hs.Kill))
 
 	// WS data plane — same paths, same broker, same wire as the daemon (§1.1: all
@@ -344,6 +345,23 @@ func (hs *headlessServer) SendPrompt(req agentSendPromptRequest, resp *agentOKRe
 func (hs *headlessServer) TapEnter(_ struct{}, resp *agentOKResponse) error {
 	hs.as.TapEnter()
 	resp.OK = true
+	return nil
+}
+
+// agentArchiveResponse carries the pushed branch back to the driving daemon so
+// it can record which branch to clone on a later restore (#1592 Phase 4 PR6).
+type agentArchiveResponse struct {
+	Branch string `json:"branch"`
+}
+
+// Archive commits + pushes the workspace's branch to origin, making it durable
+// on GitHub before the daemon reaps this sandbox (#1592 Phase 4 PR6).
+func (hs *headlessServer) Archive(_ struct{}, resp *agentArchiveResponse) error {
+	branch, err := hs.as.Archive()
+	if err != nil {
+		return err
+	}
+	resp.Branch = branch
 	return nil
 }
 

--- a/daemon/agentserver_headless_test.go
+++ b/daemon/agentserver_headless_test.go
@@ -51,6 +51,7 @@ func (f *fakeHeadlessAgentServer) Snapshot() (session.Observation, error) {
 }
 func (f *fakeHeadlessAgentServer) Preview(int, bool) (string, error) { return "preview-body", nil }
 func (f *fakeHeadlessAgentServer) Alive() bool                       { return true }
+func (f *fakeHeadlessAgentServer) Archive() (string, error)          { return "session/fake", nil }
 func (f *fakeHeadlessAgentServer) SendPrompt(p string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -203,6 +204,13 @@ func TestHeadlessAgentServer_TLSTokenRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	decodeData(resp, nil)
 	require.Equal(t, "hello world", fake.lastPrompt)
+
+	// --- control REST: archive returns the pushed branch (#1592 Phase 4 PR6) --
+	resp, err = post("/v1/agent/archive", ``)
+	require.NoError(t, err)
+	var archived agentArchiveResponse
+	decodeData(resp, &archived)
+	require.Equal(t, "session/fake", archived.Branch)
 
 	// --- REST: missing token → 401 ------------------------------------------
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/agent/snapshot", nil)

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -85,6 +85,14 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 		return "", fmt.Errorf("session %q changed state before archive could start", req.Title)
 	}
 
+	// A sandbox session (docker/ssh) archives by pushing its branch to origin and
+	// reaping the sandbox, not by relocating a worktree it does not have (#1592
+	// Phase 4 PR6). Route it to the remote body, which shares this method's guards,
+	// locks, and archive fence.
+	if instance.Capabilities().Workspace == session.WorkspaceRemote {
+		return m.archiveRemoteSession(repoID, instance, req.Title)
+	}
+
 	dest, err := archivedWorktreePath(repoID, req.Title)
 	if err != nil {
 		return "", err
@@ -174,6 +182,66 @@ func (m *Manager) undoCommittedArchive(repoID string, instance *session.Instance
 	return nil
 }
 
+// archiveRemoteSession archives a sandbox-backed session (docker/ssh) by pushing
+// its branch to origin then reaping the sandbox (#1592 Phase 4 PR6) — the remote
+// analogue of ArchiveSession's worktree-move body, sharing its guards, locks, and
+// archive fence. GitHub holds the durable branch, so unlike the local path there
+// is no worktree to move and no rollback-home on a persist failure: an archived
+// remote record is already recoverable from origin.
+func (m *Manager) archiveRemoteSession(repoID string, instance *session.Instance, title string) (string, error) {
+	// Raise the archive fence (OpArchiving) so the status poll skips this instance
+	// while its sandbox is torn down, exactly as the local path does.
+	if err := instance.Transition(session.BeginArchive()); err != nil {
+		return "", fmt.Errorf("cannot archive session %q: %w", title, err)
+	}
+
+	branch, err := instance.ArchiveSandbox()
+	if err != nil {
+		// Push and/or teardown failed. Roll the fence back to Lost so the session
+		// stays recovery-eligible, persist that, and surface the failure.
+		_ = instance.Transition(session.AbortArchiveToLost())
+		m.persistInstance(repoID, instance)
+		return "", fmt.Errorf("failed to archive session %q: %w", title, err)
+	}
+
+	// Success: branch is durable on origin, sandbox reaped. Commit the inert
+	// Archived state (started=false, op cleared) and persist it durably.
+	_ = instance.Transition(session.CommitArchive())
+	if perr := archivePersist(m, repoID, instance); perr != nil {
+		// The sandbox is already reaped and the branch is on origin, so there is
+		// nothing to undo — the Archived record is recoverable from origin either
+		// way. Persist best-effort and surface the durability failure; even a lost
+		// best-effort write leaves the on-disk record naming the pushed branch, so a
+		// restart loads the session Lost and an explicit restore re-provisions it.
+		log.ErrorLog.Printf("archive of remote session %q: failed to durably record the Archived state (%v); branch %q is on origin, so the session stays restorable", title, perr, branch)
+		m.persistInstance(repoID, instance)
+		return "", fmt.Errorf("archived remote session %q (branch %q pushed to origin) but failed to record it durably: %w", title, branch, perr)
+	}
+	log.InfoLog.Printf("archived remote session %q (repo %s): branch %q pushed to origin, sandbox reaped", title, repoID, branch)
+	return branch, nil
+}
+
+// restoreRemoteSession restores an archived sandbox session (docker/ssh) by
+// re-provisioning a fresh sandbox that clones the pushed branch back and
+// relaunching the agent (#1592 Phase 4 PR6) — the remote analogue of
+// RestoreArchived's worktree-move body, sharing its guards + locks. It reuses
+// RestoreFromArchive unchanged: BeginRestore fences the restore, then the
+// backend's Recover (recoverSandbox) re-provisions + relaunches + flips the
+// session live. The code survives via origin; a fresh agent runs on the pushed
+// branch (the pre-archive conversation lived only in the disposed sandbox).
+func (m *Manager) restoreRemoteSession(repoID string, instance *session.Instance, title string) (string, error) {
+	if err := instance.RestoreFromArchive(); err != nil {
+		// On a re-provision/relaunch failure RestoreFromArchive left the instance
+		// Lost; persist that and surface the failure (an explicit retry re-provisions
+		// from the still-pushed branch).
+		m.persistInstance(repoID, instance)
+		return "", fmt.Errorf("failed to restore remote session %q (re-provisioning its sandbox): %w", title, err)
+	}
+	m.persistInstance(repoID, instance)
+	log.InfoLog.Printf("restored remote session %q (repo %s): fresh sandbox provisioned, branch cloned back, agent relaunched", title, repoID)
+	return title, nil
+}
+
 // RestoreArchived restores an archived session (#1028): it moves the worktree
 // back to where session creation would place it under the configured
 // worktree_root (a free sibling path, or under $AF_HOME/worktrees for
@@ -221,6 +289,14 @@ func (m *Manager) RestoreArchived(req RestoreArchivedRequest) (string, error) {
 	m.mu.Unlock()
 	if current != instance || instance.GetLiveness() != session.LiveArchived {
 		return "", fmt.Errorf("session %q changed state before restore could start", req.Title)
+	}
+
+	// A sandbox session (docker/ssh) restores by re-provisioning a fresh sandbox
+	// that clones the pushed branch back, not by moving a worktree it does not have
+	// (#1592 Phase 4 PR6). Route it to the remote body, which shares this method's
+	// guards + locks.
+	if instance.Capabilities().Workspace == session.WorkspaceRemote {
+		return m.restoreRemoteSession(repoID, instance, req.Title)
 	}
 
 	repoPath := instance.GetRepoPath()

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -34,8 +34,9 @@ With `backend = "docker"`, a session runs entirely inside a container:
 5. On kill, the container is torn down (`docker rm -f`) — no leaked containers.
 
 The container is **disposable**: durability lives in GitHub (the workspace is a
-clone of `repo@origin`), not in the container filesystem. Archive/restore
-(push the branch, re-provision on restore) lands in a later PR.
+clone of `repo@origin`), not in the container filesystem — so archive pushes the
+branch and reaps the container, and restore re-provisions a fresh container that
+clones the branch back (see [Archive & restore](#archive--restore)).
 
 ### Configuration
 
@@ -96,11 +97,15 @@ RUN apk add --no-cache git tmux bash
 
 ### Testing
 
-`make backend-docker-roundtrip` runs the real end-to-end container round-trip on
+`make backend-docker-roundtrip` runs the real end-to-end container round-trips on
 a host with Docker: it builds a slim git+tmux image, creates a session on the
 docker backend, drives the in-container agent-server over `wss://` (input →
 stream echo → preview/snapshot/liveness), and asserts the container is reaped on
-kill. It skips cleanly where Docker is unavailable.
+kill. A second case commits real work on the session branch, **archives** it
+(asserting the branch is pushed to `origin` and the container reaped), then
+**restores** it (asserting a fresh container clones the branch back, the commit
+is present, and the session is drivable again). It skips cleanly where Docker is
+unavailable.
 
 ---
 
@@ -128,8 +133,9 @@ built-in, opinionated version of what a `hook` `launch_cmd` did by hand:
    disposable sandbox).
 
 Like docker, the workspace is **disposable**: durability lives in GitHub (the
-workspace is a clone of `repo@origin`). Archive/restore (push the branch,
-re-provision on restore) lands in a later PR.
+workspace is a clone of `repo@origin`) — archive pushes the branch and reaps the
+remote session, and restore re-provisions a fresh remote that clones the branch
+back (see [Archive & restore](#archive--restore)).
 
 ### Configuration
 
@@ -182,10 +188,59 @@ key first with `ssh-keyscan -H host >> ~/.ssh/known_hosts` (or point
 
 ### Testing
 
-`make backend-ssh-roundtrip` runs the real end-to-end SSH round-trip on a host
+`make backend-ssh-roundtrip` runs the real end-to-end SSH round-trips on a host
 with Docker: it stands up a throwaway `sshd`+git+tmux container as the ssh target
 (no external host, no dependency on the box's own sshd), creates a session on the
 ssh backend pointing at it, drives the remote agent-server over the ssh-tunneled
 `wss://` (input → stream echo → preview/snapshot/liveness), and asserts the remote
-process is reaped + the session dir removed + the tunnel closed on kill. It skips
-cleanly where Docker is unavailable.
+process is reaped + the session dir removed + the tunnel closed on kill. A second
+case commits real work, **archives** it (branch pushed to `origin`, remote
+sandbox reaped), then **restores** it (a fresh remote clones the branch back, the
+commit is present, the session is drivable) — the identical push/pull-branch
+flow, over ssh. It skips cleanly where Docker is unavailable.
+
+---
+
+## Archive & restore
+
+For the disposable sandbox backends (`docker` and `ssh`), archive and restore
+are **push/pull of the session branch** — the durable workspace is the branch on
+GitHub (`origin`), not the sandbox:
+
+- **Archive** (`af sessions archive`) pushes the session branch to `origin`, then
+  tears the sandbox down (reaps the container / removes the remote session dir +
+  closes the tunnel). The session record is preserved as an inert **Archived**
+  row — restorable, but consuming no container or remote process.
+- **Restore** (`af sessions restore`) re-provisions a **fresh** sandbox that
+  clones the pushed branch back, restarts the `af agent-server`, and relaunches
+  the agent. The session resumes from the pushed branch state.
+
+This is the same flow for both backends (it is written once against the runtime
+seam), and it is why `docker`/`ssh` reach full capability parity with `local` —
+`Archive` and `Recover` are both supported. A **Lost** sandbox session (its
+container/remote died) recovers the same way: re-provision + clone the branch
+back.
+
+### What survives, and what doesn't
+
+Because the sandbox is thrown away, **only what reaches `origin` survives** an
+archive:
+
+- **Committed work** on the session branch is pushed, so it is fully preserved.
+- **Uncommitted work** is snapshotted into a WIP commit
+  (`af: pre-archive snapshot (uncommitted work)`) and pushed too, so the working
+  tree is not lost — matching the `local` worktree-move archive's "nothing lost"
+  guarantee as closely as the disposable model allows. If you would rather not
+  carry that WIP commit, commit your work yourself before archiving.
+- **The agent's conversation history** lived only in the disposed sandbox and is
+  **not** restored — a fresh agent runs on the restored branch. (The `local`
+  backend, which relocates the worktree in place, does resume the conversation;
+  this is the one place the disposable model differs.)
+
+### Requirements
+
+The sandbox must be able to **push** to the repo's `origin` — the same remote it
+cloned from. For a real repo that means the container/remote has git credentials
+for `origin` (an HTTPS token or an SSH deploy key); for a self-contained test a
+read-write `file://` remote works. If the push fails, the archive fails and the
+session is left running (nothing is torn down), so no work is lost.

--- a/integration/backend_archive_test.go
+++ b/integration/backend_archive_test.go
@@ -1,0 +1,425 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// TestDockerBackendArchiveRestore is the #1592 Phase 4 PR6 proof for docker: a
+// session's state survives ARCHIVE → RESTORE via GitHub, and the restored session
+// is drivable again.
+//
+// The model (epic decision 4): the container is disposable, the branch on origin
+// is the durable workspace. So archive PUSHES the session branch to origin then
+// REAPS the container, and restore RE-PROVISIONS a fresh container that CLONES the
+// pushed branch back. This test drives that end to end against a real container:
+//
+//	create (docker backend) → Start → commit real work on the session branch →
+//	ArchiveSandbox (assert: branch pushed to origin, container reaped) →
+//	RestoreSandbox (assert: FRESH container, branch cloned back, the commit is
+//	present) → drive the restored session (typed input echoes) → Kill (reaped).
+//
+// Run on a host with docker: make backend-docker-roundtrip (it matches
+// TestDockerBackend*). SKIPS cleanly where docker is unavailable.
+func TestDockerBackendArchiveRestore(t *testing.T) {
+	requireDocker(t)
+	requireTool(t, "git")
+
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	afBin := buildStaticBinary(t)
+	restore := session.SetDockerSelfBinaryForTest(afBin)
+	defer restore()
+	image := buildDockerRoundTripImage(t)
+
+	// Source repo + a bare clone bind-mounted as the clone source. The mount is
+	// READ-WRITE (unlike the round-trip's :ro) so the in-container archive can push
+	// the branch to it — the bare repo IS "GitHub" for this self-contained test.
+	repo := setupGitRepo(t)
+	writeFile(t, filepath.Join(repo, "README.md"), "docker archive/restore\n", 0644)
+	runExternal(t, repo, "git", "add", "-A")
+	runExternal(t, repo, "git", "commit", "-m", "seed")
+	bareDir := t.TempDir()
+	bare := filepath.Join(bareDir, "repo.git")
+	runExternal(t, "", "git", "clone", "--bare", repo, bare)
+	runExternal(t, repo, "git", "remote", "add", "origin", "file:///repo.git")
+	writeDockerRepoConfig(t, repo, image, []string{"-v", bare + ":/repo.git"})
+	// The container pushes (as root) into the bind-mounted bare repo, so reown it
+	// before t.TempDir's RemoveAll runs (LIFO: registered after the TempDir).
+	reownTempViaDocker(t, bareDir)
+
+	title := "docker-ar"
+	slug := session.Slugify(title)
+	t.Cleanup(func() { reapByLabel(slug) })
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    repo,
+		Program: "cat",
+		Backend: session.BackendDocker,
+	})
+	if err != nil {
+		t.Fatalf("NewInstance(backend=docker): %v", err)
+	}
+	killed := false
+	defer func() {
+		if !killed {
+			_ = inst.Kill()
+		}
+	}()
+	if err := inst.Start(true); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ids := containersForLabel(t, slug)
+	if len(ids) == 0 {
+		t.Fatal("expected a container after provisioning")
+	}
+	container := ids[0]
+	worktree, branch := linkedWorktree(t, container, "/workspace")
+	t.Logf("session worktree %s on branch %s", worktree, branch)
+
+	// Make a DISTINCT commit on the session branch (standing in for the agent's
+	// work) so we can prove it survives archive→restore through GitHub.
+	marker := "archive-restore-marker-42"
+	dockerExec(t, container, fmt.Sprintf("cd %s && printf %%s %s > proof.txt && git add proof.txt && git commit -m %s",
+		shellQ(worktree), shellQ(marker), shellQ(marker)))
+	commitSHA := strings.TrimSpace(dockerExecOut(t, container, fmt.Sprintf("git -C %s rev-parse HEAD", shellQ(worktree))))
+	if len(commitSHA) < 12 {
+		t.Fatalf("could not read the session branch HEAD: %q", commitSHA)
+	}
+	t.Logf("committed %s on the session branch", commitSHA[:12])
+
+	// --- ARCHIVE: push the branch to origin, reap the container -----------------
+	pushed, err := inst.ArchiveSandbox()
+	if err != nil {
+		t.Fatalf("ArchiveSandbox: %v", err)
+	}
+	if pushed != branch {
+		t.Fatalf("archive pushed branch %q, want %q", pushed, branch)
+	}
+	waitUntil(t, 30*time.Second, "the container is reaped after archive", func() bool {
+		return len(containersForLabel(t, slug)) == 0
+	})
+	// The branch (with our commit) is now on origin — the durable proof.
+	bareLog := runExternal(t, "", "git", "-C", bare, "log", "--format=%H", branch)
+	if !strings.Contains(bareLog, commitSHA) {
+		t.Fatalf("archived branch %q on origin is missing commit %s:\n%s", branch, commitSHA, bareLog)
+	}
+	t.Logf("ARCHIVE ✓ branch %q pushed to origin with commit %s; container reaped", branch, commitSHA[:12])
+
+	// --- RESTORE: fresh container, branch cloned back, commit present ----------
+	if err := inst.RestoreSandbox(); err != nil {
+		t.Fatalf("RestoreSandbox: %v", err)
+	}
+	ids2 := containersForLabel(t, slug)
+	if len(ids2) == 0 {
+		t.Fatal("expected a fresh container after restore")
+	}
+	newContainer := ids2[0]
+	if newContainer == container {
+		t.Fatalf("restore reused the reaped container %s instead of provisioning a fresh one", shortID(container))
+	}
+	newWorktree, _ := linkedWorktree(t, newContainer, "/workspace")
+	restoredLog := dockerExecOut(t, newContainer, fmt.Sprintf("git -C %s log --format=%%H", shellQ(newWorktree)))
+	if !strings.Contains(restoredLog, commitSHA) {
+		t.Fatalf("restored worktree is missing the archived commit %s:\n%s", commitSHA, restoredLog)
+	}
+	restoredProof := strings.TrimSpace(dockerExecOut(t, newContainer, fmt.Sprintf("cat %s/proof.txt", shellQ(newWorktree))))
+	if restoredProof != marker {
+		t.Fatalf("restored proof.txt = %q, want %q", restoredProof, marker)
+	}
+	t.Logf("RESTORE ✓ fresh container %s; branch cloned back; commit %s present (proof.txt=%q)",
+		shortID(newContainer), commitSHA[:12], restoredProof)
+
+	// --- the restored session is drivable again --------------------------------
+	assertDrivable(t, inst.AgentServer(), "post-restore-ping")
+	t.Logf("restored session is drivable: typed input echoes over the fresh container's stream")
+
+	if err := inst.Kill(); err != nil {
+		t.Fatalf("Kill after restore: %v", err)
+	}
+	killed = true
+	waitUntil(t, 30*time.Second, "the restored container is reaped on Kill", func() bool {
+		return len(containersForLabel(t, slug)) == 0
+	})
+	t.Logf("docker archive→restore round-trip complete: state survived via GitHub, no leak.")
+}
+
+// TestSSHBackendArchiveRestore is the #1592 Phase 4 PR6 proof for ssh: identical
+// archive→restore-survives-via-GitHub round-trip against a REAL remote host over
+// ssh (a throwaway sshd container as the target). The mechanics are written ONCE
+// against the Runtime interface, so this exercises the same push-then-teardown /
+// re-provision-then-clone flow the docker test does, over the ssh transport.
+func TestSSHBackendArchiveRestore(t *testing.T) {
+	requireDocker(t)
+	requireTool(t, "git")
+	requireTool(t, "ssh-keygen")
+	requireTool(t, "ssh-keyscan")
+
+	home := t.TempDir()
+	t.Setenv("AGENT_FACTORY_HOME", home)
+
+	afBin := buildStaticBinary(t)
+	restore := session.SetSSHSelfBinaryForTest(afBin)
+	defer restore()
+	image := buildSSHDRoundTripImage(t)
+
+	repo := setupGitRepo(t)
+	writeFile(t, filepath.Join(repo, "README.md"), "ssh archive/restore\n", 0644)
+	runExternal(t, repo, "git", "add", "-A")
+	runExternal(t, repo, "git", "commit", "-m", "seed")
+	bareDir := t.TempDir()
+	bare := filepath.Join(bareDir, "repo.git")
+	runExternal(t, "", "git", "clone", "--bare", repo, bare)
+	runExternal(t, repo, "git", "remote", "add", "origin", "file:///repo.git")
+	// The sshd container pushes (as root) into the bind-mounted bare repo, so reown
+	// it before t.TempDir's RemoveAll runs (LIFO: registered after the TempDir).
+	reownTempViaDocker(t, bareDir)
+
+	keyDir := t.TempDir()
+	privKey := filepath.Join(keyDir, "id_ed25519")
+	runExternal(t, "", "ssh-keygen", "-t", "ed25519", "-N", "", "-f", privKey, "-C", "af-ssh-ar")
+	pubKey := privKey + ".pub"
+
+	cname := fmt.Sprintf("af-ssh-ar-%d", os.Getpid())
+	t.Cleanup(func() { _ = exec.Command("docker", "rm", "-f", cname).Run() })
+	// READ-WRITE clone-source mount so the remote archive can push the branch back.
+	runExternal(t, "", "docker", "run", "-d", "--name", cname,
+		"-p", "127.0.0.1::22",
+		"-v", bare+":/repo.git",
+		"-v", pubKey+":/authorized_keys:ro",
+		image)
+
+	sshHost := dockerPublishedHostPort(t, cname, "22")
+	waitForSSH(t, sshHost)
+	knownHosts := writeKnownHostsForContainer(t, sshHost)
+	writeSSHRepoConfig(t, repo, "127.0.0.1:"+sshHost, "root", privKey, knownHosts)
+
+	title := "ssh-ar"
+
+	inst, err := session.NewInstance(session.InstanceOptions{
+		Title:   title,
+		Path:    repo,
+		Program: "cat",
+		Backend: session.BackendSSH,
+	})
+	if err != nil {
+		t.Fatalf("NewInstance(backend=ssh): %v", err)
+	}
+	killed := false
+	defer func() {
+		if !killed {
+			_ = inst.Kill()
+		}
+	}()
+	if err := inst.Start(true); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	dirs := sshdSessionDirs(t, cname)
+	if len(dirs) == 0 {
+		t.Fatal("expected a per-session dir on the remote after provisioning")
+	}
+	workspace := "/root/.af-sessions/" + dirs[0] + "/workspace"
+	worktree, branch := linkedWorktree(t, cname, workspace)
+	t.Logf("remote session worktree %s on branch %s", worktree, branch)
+
+	marker := "archive-restore-marker-77"
+	dockerExec(t, cname, fmt.Sprintf("cd %s && printf %%s %s > proof.txt && git add proof.txt && git commit -m %s",
+		shellQ(worktree), shellQ(marker), shellQ(marker)))
+	commitSHA := strings.TrimSpace(dockerExecOut(t, cname, fmt.Sprintf("git -C %s rev-parse HEAD", shellQ(worktree))))
+	if len(commitSHA) < 12 {
+		t.Fatalf("could not read the remote session branch HEAD: %q", commitSHA)
+	}
+	t.Logf("committed %s on the remote session branch", commitSHA[:12])
+
+	// --- ARCHIVE: push the branch to origin, reap the remote sandbox -----------
+	pushed, err := inst.ArchiveSandbox()
+	if err != nil {
+		t.Fatalf("ArchiveSandbox: %v", err)
+	}
+	if pushed != branch {
+		t.Fatalf("archive pushed branch %q, want %q", pushed, branch)
+	}
+	waitUntil(t, 30*time.Second, "the remote agent-server is reaped after archive", func() bool {
+		return sshdAgentServerProcs(t, cname) == 0
+	})
+	waitUntil(t, 30*time.Second, "the remote session dir is removed after archive", func() bool {
+		return len(sshdSessionDirs(t, cname)) == 0
+	})
+	bareLog := runExternal(t, "", "git", "-C", bare, "log", "--format=%H", branch)
+	if !strings.Contains(bareLog, commitSHA) {
+		t.Fatalf("archived branch %q on origin is missing commit %s:\n%s", branch, commitSHA, bareLog)
+	}
+	t.Logf("ARCHIVE ✓ branch %q pushed to origin with commit %s; remote sandbox reaped", branch, commitSHA[:12])
+
+	// --- RESTORE: fresh remote sandbox, branch cloned back, commit present -----
+	if err := inst.RestoreSandbox(); err != nil {
+		t.Fatalf("RestoreSandbox: %v", err)
+	}
+	dirs2 := sshdSessionDirs(t, cname)
+	if len(dirs2) == 0 {
+		t.Fatal("expected a fresh per-session dir on the remote after restore")
+	}
+	if dirs2[0] == dirs[0] {
+		t.Fatalf("restore reused the reaped session dir %q instead of provisioning a fresh one", dirs[0])
+	}
+	newWorkspace := "/root/.af-sessions/" + dirs2[0] + "/workspace"
+	newWorktree, _ := linkedWorktree(t, cname, newWorkspace)
+	restoredLog := dockerExecOut(t, cname, fmt.Sprintf("git -C %s log --format=%%H", shellQ(newWorktree)))
+	if !strings.Contains(restoredLog, commitSHA) {
+		t.Fatalf("restored remote worktree is missing the archived commit %s:\n%s", commitSHA, restoredLog)
+	}
+	restoredProof := strings.TrimSpace(dockerExecOut(t, cname, fmt.Sprintf("cat %s/proof.txt", shellQ(newWorktree))))
+	if restoredProof != marker {
+		t.Fatalf("restored proof.txt = %q, want %q", restoredProof, marker)
+	}
+	t.Logf("RESTORE ✓ fresh remote dir %q; branch cloned back; commit %s present (proof.txt=%q)",
+		dirs2[0], commitSHA[:12], restoredProof)
+
+	assertDrivable(t, inst.AgentServer(), "post-restore-ping")
+	t.Logf("restored ssh session is drivable: typed input echoes over the fresh tunnel's stream")
+
+	if err := inst.Kill(); err != nil {
+		t.Fatalf("Kill after restore: %v", err)
+	}
+	killed = true
+	waitUntil(t, 30*time.Second, "the restored remote agent-server is reaped on Kill", func() bool {
+		return sshdAgentServerProcs(t, cname) == 0
+	})
+	t.Logf("ssh archive→restore round-trip complete: state survived via GitHub, no leak.")
+}
+
+// --- archive/restore shared helpers ----------------------------------------
+
+// shellQ single-quotes s for a POSIX sh -c command (the paths and markers here
+// are simple, but quoting keeps the exec robust).
+func shellQ(s string) string { return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'" }
+
+// reownTempViaDocker chowns dir back to the invoking user via a throwaway root
+// container, registered so it runs BEFORE t.TempDir's RemoveAll (LIFO). The
+// sandbox containers run as root and push git objects into the bind-mounted bare
+// repo, leaving root-owned files the non-root test user cannot delete; without
+// this, cleanup fails with EPERM.
+func reownTempViaDocker(t *testing.T, dir string) {
+	t.Helper()
+	uid, gid := os.Getuid(), os.Getgid()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		out, err := exec.CommandContext(ctx, "docker", "run", "--rm",
+			"-v", dir+":/reown", "alpine:3.20",
+			"chown", "-R", fmt.Sprintf("%d:%d", uid, gid), "/reown").CombinedOutput()
+		if err != nil {
+			t.Logf("reown %s failed (leaked root-owned files may remain): %v\n%s", dir, err, out)
+		}
+	})
+}
+
+// shortID trims a container id to the 12-char short form for logs.
+func shortID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}
+
+// dockerExec runs `sh -c <script>` inside container and fails the test on error,
+// returning nothing — used for state-mutating steps (making the marker commit).
+func dockerExec(t *testing.T, container, script string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "docker", "exec", container, "sh", "-c", script).CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker exec %q failed: %v\n%s", script, err, out)
+	}
+}
+
+// dockerExecOut runs `sh -c <script>` inside container and returns its combined
+// output (used to read git state). It does NOT fail on a non-zero exit — callers
+// assert on the returned text.
+func dockerExecOut(t *testing.T, container, script string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, _ := exec.CommandContext(ctx, "docker", "exec", container, "sh", "-c", script).CombinedOutput()
+	return string(out)
+}
+
+// linkedWorktree returns the (path, branch) of the session's LINKED git worktree
+// inside container — the one `git -C <mainRepo> worktree list` reports that is not
+// the main clone itself. It is where the agent's work + the pushed branch live.
+func linkedWorktree(t *testing.T, container, mainRepo string) (string, string) {
+	t.Helper()
+	out := dockerExecOut(t, container, fmt.Sprintf("git -C %s worktree list --porcelain", shellQ(mainRepo)))
+	var path, branch string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			p := strings.TrimSpace(strings.TrimPrefix(line, "worktree "))
+			if p == mainRepo {
+				path = "" // main clone; skip until its branch line passes
+				continue
+			}
+			path = p
+		case strings.HasPrefix(line, "branch ") && path != "":
+			branch = strings.TrimSpace(strings.TrimPrefix(line, "branch "))
+			branch = strings.TrimPrefix(branch, "refs/heads/")
+			return path, branch
+		}
+	}
+	t.Fatalf("could not find the session's linked worktree in %s:\n%s", mainRepo, out)
+	return "", ""
+}
+
+// assertDrivable proves a (freshly restored) agent-server is live and interactive:
+// it subscribes to the PTY stream, types a marker, and waits for the `cat` pane to
+// echo it back over the stream.
+func assertDrivable(t *testing.T, as session.AgentServer, marker string) {
+	t.Helper()
+	sub, err := as.Subscribe(0, 0)
+	if err != nil {
+		t.Fatalf("Subscribe after restore: %v", err)
+	}
+	defer func() { _ = sub.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var (
+		mu   sync.Mutex
+		buf  strings.Builder
+		read = func() string { mu.Lock(); defer mu.Unlock(); return buf.String() }
+	)
+	go func() {
+		for {
+			ev, rerr := sub.NextEvent(ctx)
+			if rerr != nil {
+				return
+			}
+			if ev.Kind == session.PTYData || ev.Kind == session.PTYRepaint {
+				mu.Lock()
+				buf.Write(ev.Data)
+				mu.Unlock()
+			}
+		}
+	}()
+	if err := as.Input(0, []byte(marker+"\n")); err != nil {
+		t.Fatalf("Input after restore: %v", err)
+	}
+	waitUntil(t, 20*time.Second, "restored PTY stream echoes typed input", func() bool {
+		return strings.Contains(read(), marker)
+	})
+}

--- a/session/agentserver.go
+++ b/session/agentserver.go
@@ -89,6 +89,18 @@ type AgentServer interface {
 
 	// Kill terminates the session and releases its backing resources.
 	Kill() error
+
+	// Archive makes the workspace durable before its sandbox is torn down (#1592
+	// Phase 4 PR6): it commits any uncommitted work and pushes the session branch
+	// to origin (GitHub is the durable workspace store, epic decision 4),
+	// returning the pushed branch so the orchestrator can clone it back on
+	// restore. It is the primitive the disposable sandbox runtimes (docker/ssh)
+	// archive through — the daemon calls it over the wire, and the in-sandbox
+	// local agent-server pushes the branch it owns. The local in-process runtime
+	// implements it too (a plain commit+push of its worktree), but the daemon
+	// never drives a LOCAL session's archive through here — a local session
+	// archives by relocating its worktree (§5.1), so this stays dormant for it.
+	Archive() (string, error)
 }
 
 // Seq is a monotonic cursor into a session's PTY output ring buffer, used by

--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -171,6 +171,15 @@ func (s *localAgentServer) Resize(tab int, rows, cols uint16) error {
 	return br.resize(rows, cols)
 }
 
+// Archive commits any uncommitted work and pushes this session's branch to
+// origin (#1592 Phase 4 PR6). Running INSIDE a sandbox as the in-process
+// agent-server, this is where a docker/ssh session's push actually happens — it
+// owns the git worktree, so it can snapshot the working tree and push the branch
+// GitHub will hold as the durable workspace. Returns the pushed branch name.
+func (s *localAgentServer) Archive() (string, error) {
+	return s.inst.pushBranchForArchive()
+}
+
 func (s *localAgentServer) Kill() error {
 	// Tear every tab's data plane down first so the clientless captures stop and
 	// each subscriber's NextEvent returns io.EOF, then kill the underlying session.

--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -224,6 +224,20 @@ func (s *remoteAgentServer) Kill() error {
 	return killErr
 }
 
+// Archive pushes the sandbox's session branch to origin over the control REST
+// (#1592 Phase 4 PR6): the in-sandbox agent-server owns the worktree, so the
+// push happens THERE (it commits any uncommitted work and pushes), and this
+// returns the branch name the daemon records so a later restore clones it back.
+// No teardown here — the daemon runs Kill (which reaps the sandbox) after the
+// branch is durable, so archive is push-then-teardown.
+func (s *remoteAgentServer) Archive() (string, error) {
+	var resp agentArchiveResp
+	if err := s.rc.call("/v1/agent/archive", struct{}{}, &resp); err != nil {
+		return "", err
+	}
+	return resp.Branch, nil
+}
+
 // --- remote WS clientlessChannel: the sandbox stream as a broker channel ---
 
 // remoteClientlessChannel is the remote runtime's clientlessChannel: it binds ONE
@@ -574,4 +588,8 @@ type agentAliveResp struct {
 
 type agentSendPromptReq struct {
 	Prompt string `json:"prompt"`
+}
+
+type agentArchiveResp struct {
+	Branch string `json:"branch"`
 }

--- a/session/archive_sandbox.go
+++ b/session/archive_sandbox.go
@@ -1,0 +1,228 @@
+package session
+
+import (
+	"fmt"
+)
+
+// Archive/restore for the disposable sandbox backends (#1592 Phase 4 PR6),
+// written ONCE against the Runtime interface so docker and ssh share it. The
+// model (epic decision 4): GitHub is the durable workspace store, so —
+//
+//   - Archive = push the session branch to origin (durability), then tear the
+//     sandbox down (the container/remote is disposable, the branch is not).
+//   - Restore/Recover = re-provision a FRESH sandbox that clones the pushed
+//     branch back, then relaunch the agent.
+//
+// Both go through the same two Runtime primitives every sandbox runtime already
+// implements — Provision (with RestoreBranch on restore) and the Teardown/Kill
+// reap — so there is no per-backend archive logic here and no locality branch.
+// The local runtime keeps its worktree-move archive (daemon/archive.go), untouched.
+
+// pushBranchForArchive commits any uncommitted work and pushes this instance's
+// branch to origin, returning the pushed branch (#1592 Phase 4 PR6). It runs
+// INSIDE a sandbox as the local agent-server's Archive implementation
+// (agentserver_local.go), where the git worktree it pushes actually lives.
+func (i *Instance) pushBranchForArchive() (string, error) {
+	i.mu.RLock()
+	gw := i.gitWorktree
+	i.mu.RUnlock()
+	if gw == nil {
+		return "", fmt.Errorf("cannot archive session %q: no worktree to push", i.Title)
+	}
+	return gw.SnapshotAndPushBranch()
+}
+
+// ArchiveSandbox makes a sandbox-backed session (docker/ssh) durable and reaps
+// its sandbox (#1592 Phase 4 PR6): it pushes the branch to origin over the
+// agent-server, then tears the in-sandbox workspace down and reaps the sandbox
+// (the AgentServer.Kill path), and finally clears the now-dead remote wiring so a
+// later restore rebuilds it. Returns the pushed branch, which the caller records
+// so restore knows which branch to clone back.
+//
+// This is the raw mechanic the daemon's ArchiveSession wraps with its locks +
+// state transitions + persistence (and which the round-trip test drives
+// directly, like Start/Kill). It is a no-op-and-error for a session with no
+// remote runtime — a local session archives by relocating its worktree, not here.
+func (i *Instance) ArchiveSandbox() (string, error) {
+	i.mu.RLock()
+	isRemote := i.remoteClient != nil
+	i.mu.RUnlock()
+	if !isRemote {
+		return "", fmt.Errorf("session %q is not a sandbox session; cannot archive via push/teardown", i.Title)
+	}
+
+	as := i.AgentServer()
+	// 1. Push the branch to origin while the sandbox is still alive — the workspace
+	//    state must be durable on GitHub before anything is torn down.
+	branch, err := as.Archive()
+	if err != nil {
+		return "", fmt.Errorf("failed to push branch for session %q before archive: %w", i.Title, err)
+	}
+	// 2. Tear the in-sandbox workspace down over REST and reap the sandbox itself
+	//    (container rm / remote dir cleanup + tunnel close) — the branch is durable,
+	//    the sandbox is disposable.
+	if err := as.Kill(); err != nil {
+		return branch, fmt.Errorf("pushed branch %q but failed to tear the sandbox down for session %q: %w", branch, i.Title, err)
+	}
+	// 3. Drop the dead remote wiring so the instance is an inert archived record
+	//    until restore re-provisions it. The backend stays (its Type()/Capabilities
+	//    keep the session classified as a remote sandbox for load + restore).
+	i.resetRemoteRuntime()
+	i.mu.Lock()
+	i.Branch = branch
+	i.started = false
+	i.mu.Unlock()
+	return branch, nil
+}
+
+// RestoreSandbox re-provisions a fresh sandbox for an archived sandbox session,
+// cloning the pushed branch back, and relaunches the agent (#1592 Phase 4 PR6).
+// It is the raw restore mechanic (the daemon wraps it with locks + the restore
+// transition; the round-trip test drives it directly). The session resumes from
+// the pushed branch state — the code survives via GitHub; a fresh agent runs on
+// it (the pre-archive conversation lived only in the disposed sandbox).
+func (i *Instance) RestoreSandbox() error {
+	if err := i.reprovisionRemote(); err != nil {
+		return err
+	}
+	return i.Start(true)
+}
+
+// recoverSandbox re-establishes a Lost/restoring sandbox session in place: it
+// re-provisions a fresh sandbox (cloning the branch back), relaunches, and flips
+// the session live (#1592 Phase 4 PR6). It is the remote analogue of
+// LocalBackend.respawn — the guard-free core the docker/ssh backends' Recover and
+// Respawn both call, so the daemon's Lost-restore loop and the archive-restore
+// path (RestoreFromArchive → backend.Recover) reuse it unchanged. The caller's
+// transition owns the liveness precondition; ConfirmLive clears the restore fence
+// on success, exactly as the local respawn does.
+func recoverSandbox(i *Instance) error {
+	if err := i.reprovisionRemote(); err != nil {
+		return err
+	}
+	if err := i.Start(true); err != nil {
+		return err
+	}
+	_ = i.Transition(ConfirmLive())
+	return nil
+}
+
+// reprovisionRemote provisions a FRESH sandbox for this instance and rebinds the
+// instance to it (#1592 Phase 4 PR6). It resolves the runtime from the instance's
+// persisted backend kind and provisions with RestoreBranch set to the session's
+// branch, so the new sandbox clones the pushed state back; on success the new
+// backend + remote agent-server endpoint + teardown replace the old (dead) ones.
+func (i *Instance) reprovisionRemote() error {
+	i.mu.RLock()
+	backend := i.backend
+	spec := ProvisionSpec{
+		RepoRoot:      i.Path,
+		Title:         i.Title,
+		Program:       i.Program,
+		AutoYes:       i.AutoYes,
+		CloneURL:      originRemoteURL(i.Path),
+		RestoreBranch: i.Branch,
+	}
+	i.mu.RUnlock()
+	if backend == nil {
+		return fmt.Errorf("cannot re-provision session %q: no backend on record", i.Title)
+	}
+	kind, err := backendKindForType(backend.Type())
+	if err != nil {
+		return fmt.Errorf("cannot re-provision session %q: %w", i.Title, err)
+	}
+	rt, err := ResolveRuntime(kind)
+	if err != nil {
+		return fmt.Errorf("cannot re-provision session %q: %w", i.Title, err)
+	}
+	res, err := rt.Provision(spec)
+	if err != nil {
+		return fmt.Errorf("failed to re-provision sandbox for session %q: %w", i.Title, err)
+	}
+	if err := i.bindProvisionResult(res); err != nil {
+		// The sandbox is up but its endpoint could not be wired — reap it so a
+		// bad restore never leaks a container/remote.
+		if res.Teardown != nil {
+			_ = res.Teardown()
+		}
+		return fmt.Errorf("failed to bind re-provisioned sandbox for session %q: %w", i.Title, err)
+	}
+	return nil
+}
+
+// bindProvisionResult installs a freshly provisioned sandbox's wiring on the
+// instance (#1592 Phase 4 PR6): the new backend, a remote agent-server client
+// built from the new endpoint, and the new teardown, discarding the cached
+// agent-server so AgentServer() rebuilds it against the new client. It mirrors the
+// endpoint wiring NewInstance does at create, reused for restore.
+func (i *Instance) bindProvisionResult(res ProvisionResult) error {
+	var rc *remoteAgentClient
+	if res.Endpoint != nil {
+		var err error
+		rc, err = newRemoteAgentClient(*res.Endpoint, i.Title)
+		if err != nil {
+			return err
+		}
+	}
+	i.agentSrvMu.Lock()
+	i.agentSrv = nil
+	i.agentSrvMu.Unlock()
+
+	i.mu.Lock()
+	i.backend = res.Backend
+	i.remoteClient = rc
+	i.runtimeTeardown = res.Teardown
+	i.mu.Unlock()
+	return nil
+}
+
+// resetRemoteRuntime clears the instance's remote-runtime wiring after its
+// sandbox has been reaped (archive), leaving an inert record whose backend still
+// classifies it as a remote sandbox (#1592 Phase 4 PR6). A subsequent restore
+// rebuilds the wiring via bindProvisionResult.
+func (i *Instance) resetRemoteRuntime() {
+	i.agentSrvMu.Lock()
+	i.agentSrv = nil
+	i.agentSrvMu.Unlock()
+
+	i.mu.Lock()
+	i.remoteClient = nil
+	i.runtimeTeardown = nil
+	i.mu.Unlock()
+}
+
+// isSandboxBackendType reports whether a persisted backend Type() names a
+// disposable sandbox runtime (docker/ssh) — the runtimes archive/restore
+// re-provision (#1592 Phase 4 PR6).
+func isSandboxBackendType(t string) bool {
+	_, err := backendKindForType(t)
+	return err == nil
+}
+
+// newInertSandboxBackend rebuilds a sandbox backend with NO live sandbox handle,
+// for a docker/ssh session loaded from disk (#1592 Phase 4 PR6). Its Type() and
+// Capabilities() keep the session classified as its runtime so archive/restore
+// route correctly; its reap is nil (nothing live to tear down), and restore
+// replaces it wholesale via a fresh Provision. Only ever called for a sandbox
+// backend type (the FromInstanceData switch guards it).
+func newInertSandboxBackend(t string) Backend {
+	if t == "ssh" {
+		return &sshBackend{}
+	}
+	return &dockerBackend{}
+}
+
+// backendKindForType maps a persisted backend Type() discriminator to the
+// BackendKind whose Runtime re-provisions it (#1592 Phase 4 PR6). Only the
+// sandbox runtimes are re-provisionable; local/hook never route here (they don't
+// push/re-clone), so their types are rejected with an actionable error.
+func backendKindForType(t string) (BackendKind, error) {
+	switch t {
+	case "docker":
+		return BackendDocker, nil
+	case "ssh":
+		return BackendSSH, nil
+	default:
+		return "", fmt.Errorf("backend %q is not a re-provisionable sandbox runtime", t)
+	}
+}

--- a/session/archive_sandbox_test.go
+++ b/session/archive_sandbox_test.go
@@ -1,0 +1,164 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackendKindForType pins the persisted-type → runtime-kind mapping the
+// re-provision path keys on: only the sandbox runtimes are re-provisionable
+// (#1592 Phase 4 PR6); local/hook are rejected.
+func TestBackendKindForType(t *testing.T) {
+	got, err := backendKindForType("docker")
+	require.NoError(t, err)
+	assert.Equal(t, BackendDocker, got)
+
+	got, err = backendKindForType("ssh")
+	require.NoError(t, err)
+	assert.Equal(t, BackendSSH, got)
+
+	for _, bad := range []string{"local", "remote", "", "nope"} {
+		if _, err := backendKindForType(bad); err == nil {
+			t.Fatalf("backendKindForType(%q): want error", bad)
+		}
+	}
+
+	assert.True(t, isSandboxBackendType("docker"))
+	assert.True(t, isSandboxBackendType("ssh"))
+	assert.False(t, isSandboxBackendType("local"))
+	assert.False(t, isSandboxBackendType("remote"))
+}
+
+// TestNewInertSandboxBackend pins that a loaded sandbox backend classifies the
+// session correctly (Type + full remote parity) with no live handle, so archive/
+// restore route on it and Kill is a safe no-op (#1592 Phase 4 PR6).
+func TestNewInertSandboxBackend(t *testing.T) {
+	for _, tc := range []struct {
+		typ  string
+		want string
+	}{{"docker", "docker"}, {"ssh", "ssh"}} {
+		b := newInertSandboxBackend(tc.typ)
+		assert.Equal(t, tc.want, b.Type())
+		caps := b.Capabilities()
+		assert.Equal(t, WorkspaceRemote, caps.Workspace)
+		assert.True(t, caps.Archive, "archive capability")
+		assert.True(t, caps.Recover, "recover capability")
+		// Nil-reap Kill must not panic (nothing live to tear down).
+		require.NoError(t, b.Kill(&Instance{}))
+	}
+}
+
+// TestFromInstanceData_SandboxBackends pins how a docker/ssh session loads from
+// disk (#1592 Phase 4 PR6): an ARCHIVED record loads inert + Archived (restore
+// re-provisions), and a non-archived one loads inert + Lost with started=false
+// (so the poll + Lost-restore loop skip it — no dead endpoint driven, no
+// infinite backend recursion). Both keep their sandbox Type/Capabilities.
+func TestFromInstanceData_SandboxBackends(t *testing.T) {
+	for _, typ := range []string{"docker", "ssh"} {
+		t.Run(typ+" archived loads inert + Archived", func(t *testing.T) {
+			inst, err := FromInstanceData(InstanceData{
+				ID:          "id1",
+				Title:       "s",
+				Path:        t.TempDir(),
+				Branch:      "root/s",
+				BackendType: typ,
+				Liveness:    LiveArchived,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, typ, inst.GetBackend().Type())
+			assert.Equal(t, WorkspaceRemote, inst.Capabilities().Workspace)
+			assert.True(t, inst.Capabilities().Archive)
+			assert.Equal(t, LiveArchived, inst.GetLiveness())
+			assert.False(t, inst.Started())
+		})
+
+		t.Run(typ+" live loads inert + Lost, not started", func(t *testing.T) {
+			inst, err := FromInstanceData(InstanceData{
+				ID:          "id2",
+				Title:       "s",
+				Path:        t.TempDir(),
+				Branch:      "root/s",
+				BackendType: typ,
+				Liveness:    LiveRunning,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, typ, inst.GetBackend().Type())
+			assert.Equal(t, LiveLost, inst.GetLiveness())
+			assert.False(t, inst.Started(), "a reloaded sandbox session must not be started (loop skips it)")
+		})
+	}
+}
+
+// TestArchiveSandbox_RejectsNonSandbox pins that ArchiveSandbox is only for
+// remote sandbox sessions — a local session (no remote client) is rejected, so
+// the daemon's Workspace-kind branch is the only path that reaches it.
+func TestArchiveSandbox_RejectsNonSandbox(t *testing.T) {
+	i := &Instance{Title: "local-one", backend: &LocalBackend{}}
+	if _, err := i.ArchiveSandbox(); err == nil {
+		t.Fatal("ArchiveSandbox on a non-sandbox session: want error")
+	}
+}
+
+// TestReprovisionRemote_RebindsInstance drives the restore re-provision wiring
+// without a real sandbox (#1592 Phase 4 PR6): a fakeRuntime swapped into the
+// registry returns a fresh backend + authed endpoint + teardown, and
+// reprovisionRemote must install all three on the instance (new backend, a
+// remoteClient built from the endpoint, and the teardown), replacing the inert
+// ones a restore starts from. This is the CI-safe half of the docker/ssh
+// round-trip's restore.
+func TestReprovisionRemote_RebindsInstance(t *testing.T) {
+	freshBackend := &dockerBackend{containerID: "fresh"}
+	var toreDown bool
+	ep := &AgentServerEndpoint{URL: "wss://127.0.0.1:9", Token: "tok", Fingerprint: validFingerprint}
+	fake := fakeRuntime{res: ProvisionResult{
+		Backend:  freshBackend,
+		Endpoint: ep,
+		Teardown: func() error { toreDown = true; return nil },
+	}}
+
+	// Swap the docker runtime for the fake for the duration of the test.
+	prev := runtimeRegistry[BackendDocker]
+	runtimeRegistry[BackendDocker] = func() Runtime { return fake }
+	defer func() { runtimeRegistry[BackendDocker] = prev }()
+
+	// Start from an inert, archived-style docker instance (no live wiring).
+	i := &Instance{Title: "s", Path: t.TempDir(), Branch: "root/s", backend: newInertSandboxBackend("docker")}
+
+	require.NoError(t, i.reprovisionRemote())
+
+	i.mu.RLock()
+	gotBackend := i.backend
+	gotClient := i.remoteClient
+	gotTeardown := i.runtimeTeardown
+	i.mu.RUnlock()
+	assert.Same(t, freshBackend, gotBackend, "backend rebound to the fresh sandbox")
+	require.NotNil(t, gotClient, "remote agent-server client built from the new endpoint")
+	require.NotNil(t, gotTeardown, "teardown rebound to the fresh sandbox")
+	// The cached agent-server is discarded so AgentServer() rebuilds against the
+	// new client.
+	i.agentSrvMu.Lock()
+	assert.Nil(t, i.agentSrv)
+	i.agentSrvMu.Unlock()
+	assert.False(t, toreDown, "a successful bind does not tear the new sandbox down")
+}
+
+// TestResetRemoteRuntime clears the live wiring but keeps the backend (which
+// carries the sandbox Type/Capabilities for load + restore).
+func TestResetRemoteRuntime(t *testing.T) {
+	i := &Instance{
+		Title:           "s",
+		backend:         &dockerBackend{containerID: "c"},
+		remoteClient:    &remoteAgentClient{title: "s"},
+		runtimeTeardown: func() error { return nil },
+		agentSrv:        &remoteAgentServer{},
+	}
+	i.resetRemoteRuntime()
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	assert.Nil(t, i.remoteClient)
+	assert.Nil(t, i.runtimeTeardown)
+	assert.Nil(t, i.agentSrv)
+	assert.Equal(t, "docker", i.backend.Type(), "backend is kept for restore classification")
+}

--- a/session/backend_docker.go
+++ b/session/backend_docker.go
@@ -261,14 +261,37 @@ func (p *dockerProvisioner) configureGit() error {
 
 // cloneWorkspace clones the repo's origin into /workspace inside the container.
 // A fresh create clones the default branch; the in-container agent-server's LOCAL
-// backend then creates the session's git worktree + branch off it. Restore to a
-// pushed branch is PR6.
+// backend then creates the session's git worktree + branch off it. On a RESTORE
+// (spec.RestoreBranch set, #1592 Phase 4 PR6) it additionally materializes the
+// pushed session branch as a local ref so the in-container Setup checks it out.
 func (p *dockerProvisioner) cloneWorkspace() error {
 	script := fmt.Sprintf("git clone %s %s", shellQuote(p.spec.CloneURL), shellQuote(dockerWorkspaceDir))
 	out, err := p.execSh(dockerProvisionStepTimeout, script)
 	if err != nil {
 		return fmt.Errorf("backend=docker: cloning %q into the container failed (is git in the image, and the URL reachable from inside the container?): %s: %w",
 			p.spec.CloneURL, strings.TrimSpace(string(out)), err)
+	}
+	if branch := strings.TrimSpace(p.spec.RestoreBranch); branch != "" {
+		return p.fetchRestoreBranch(branch)
+	}
+	return nil
+}
+
+// fetchRestoreBranch materializes the archived session branch (pushed to origin
+// at archive time) as a LOCAL ref in the fresh clone, WITHOUT checking it out in
+// /workspace's main tree (#1592 Phase 4 PR6). The `<branch>:<branch>` refspec
+// creates refs/heads/<branch> from origin/<branch>; the in-container local
+// backend's Setup then finds that local ref and adds the session worktree from
+// it (setupFromExistingBranch), bringing the pushed commits back. It stays on the
+// main tree's default branch so the later `git worktree add <path> <branch>` does
+// not collide with a checked-out branch.
+func (p *dockerProvisioner) fetchRestoreBranch(branch string) error {
+	script := fmt.Sprintf("git -C %s fetch origin %s:%s",
+		shellQuote(dockerWorkspaceDir), shellQuote(branch), shellQuote(branch))
+	out, err := p.execSh(dockerProvisionStepTimeout, script)
+	if err != nil {
+		return fmt.Errorf("backend=docker: restoring archived branch %q into the container failed (was it pushed to origin?): %s: %w",
+			branch, strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }
@@ -449,16 +472,17 @@ var _ Backend = (*dockerBackend)(nil)
 
 func (b *dockerBackend) Type() string { return "docker" }
 
-// Capabilities advertises full interactive parity for docker (#1592 Phase 4 PR4,
-// epic §5): the workspace is off-box, but attach/preview/liveness/prompt/tabs all
-// work through the in-container agent-server. Archive/Recover (push/pull the
-// branch) land in PR6, so they are off here.
+// Capabilities advertises FULL parity for docker (#1592 Phase 4 PR6, epic §5):
+// the workspace is off-box, but attach/preview/liveness/prompt/tabs work through
+// the in-container agent-server, and Archive/Recover work by pushing the branch
+// to GitHub and re-provisioning a fresh container that clones it back (§5.1) — so
+// every capability is true, no ErrRecoverUnsupported and no locality special-case.
 func (b *dockerBackend) Capabilities() Capabilities {
 	return Capabilities{
 		Workspace:        WorkspaceRemote,
 		Attach:           true,
-		Archive:          false,
-		Recover:          false,
+		Archive:          true,
+		Recover:          true,
 		TabManagement:    true,
 		TerminalTab:      true,
 		InteractiveInput: true,
@@ -569,8 +593,12 @@ func (b *dockerBackend) CheckAndHandleTrustPrompt(*Instance) bool { return false
 
 func (b *dockerBackend) TapEnter(i *Instance) { i.AgentServer().TapEnter() }
 
-// Recover/Respawn are unsupported until PR6 wires archive/restore (push/pull the
-// branch, re-provision the container). A Lost docker session is flagged but not
-// auto-reconnected yet.
-func (b *dockerBackend) Recover(*Instance) error { return ErrRecoverUnsupported }
-func (b *dockerBackend) Respawn(*Instance) error { return ErrRecoverUnsupported }
+// Recover/Respawn re-establish a docker session by RE-PROVISIONING a fresh
+// container that clones the session's branch back from origin, then relaunching
+// the agent (#1592 Phase 4 PR6). Both share recoverSandbox with the ssh runtime
+// (written once against the Runtime interface): a disposable container has no
+// in-place session to reconnect, so recovery is always a fresh provision + clone
+// of the durable branch on GitHub. Only the pushed state survives — a session
+// that went Lost without ever pushing recovers to whatever origin last held.
+func (b *dockerBackend) Recover(i *Instance) error { return recoverSandbox(i) }
+func (b *dockerBackend) Respawn(i *Instance) error { return recoverSandbox(i) }

--- a/session/backend_ssh.go
+++ b/session/backend_ssh.go
@@ -408,14 +408,36 @@ func (p *sshProvisioner) configureGit() error {
 
 // cloneWorkspace clones the repo's origin into <sessionDir>/workspace on the
 // remote. A fresh create clones the default branch; the remote agent-server's
-// LOCAL backend then creates the session's git worktree + branch off it. Restore to
-// a pushed branch is PR6.
+// LOCAL backend then creates the session's git worktree + branch off it. On a
+// RESTORE (spec.RestoreBranch set, #1592 Phase 4 PR6) it additionally
+// materializes the pushed session branch as a local ref so the remote Setup
+// checks it out.
 func (p *sshProvisioner) cloneWorkspace() error {
 	script := fmt.Sprintf("git clone %s %s", shellQuote(p.spec.CloneURL), shellQuote(p.workspacePath()))
 	out, err := p.runCombined(sshProvisionStepTimeout, script)
 	if err != nil {
 		return fmt.Errorf("backend=ssh: cloning %q on the remote failed (is git installed, and the URL reachable from the remote host?): %s: %w",
 			p.spec.CloneURL, strings.TrimSpace(string(out)), err)
+	}
+	if branch := strings.TrimSpace(p.spec.RestoreBranch); branch != "" {
+		return p.fetchRestoreBranch(branch)
+	}
+	return nil
+}
+
+// fetchRestoreBranch materializes the archived session branch (pushed to origin
+// at archive time) as a LOCAL ref in the fresh remote clone, WITHOUT checking it
+// out in the main tree (#1592 Phase 4 PR6) — the ssh mirror of the docker
+// runtime's fetchRestoreBranch. The `<branch>:<branch>` refspec creates
+// refs/heads/<branch> so the remote local backend's Setup reuses it and brings
+// the pushed commits back.
+func (p *sshProvisioner) fetchRestoreBranch(branch string) error {
+	script := fmt.Sprintf("git -C %s fetch origin %s:%s",
+		shellQuote(p.workspacePath()), shellQuote(branch), shellQuote(branch))
+	out, err := p.runCombined(sshProvisionStepTimeout, script)
+	if err != nil {
+		return fmt.Errorf("backend=ssh: restoring archived branch %q on the remote failed (was it pushed to origin?): %s: %w",
+			branch, strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }
@@ -683,16 +705,17 @@ var _ Backend = (*sshBackend)(nil)
 
 func (b *sshBackend) Type() string { return "ssh" }
 
-// Capabilities advertises full interactive parity for ssh (#1592 Phase 4 PR5, epic
-// §5): the workspace is off-box, but attach/preview/liveness/prompt/tabs all work
-// through the remote agent-server over the tunnel. Archive/Recover (push/pull the
-// branch) land in PR6, so they are off here.
+// Capabilities advertises FULL parity for ssh (#1592 Phase 4 PR6, epic §5): the
+// workspace is off-box, but attach/preview/liveness/prompt/tabs work through the
+// remote agent-server over the tunnel, and Archive/Recover work by pushing the
+// branch to GitHub and re-provisioning a fresh remote that clones it back (§5.1)
+// — every capability true, no ErrRecoverUnsupported and no locality special-case.
 func (b *sshBackend) Capabilities() Capabilities {
 	return Capabilities{
 		Workspace:        WorkspaceRemote,
 		Attach:           true,
-		Archive:          false,
-		Recover:          false,
+		Archive:          true,
+		Recover:          true,
 		TabManagement:    true,
 		TerminalTab:      true,
 		InteractiveInput: true,
@@ -803,8 +826,11 @@ func (b *sshBackend) CheckAndHandleTrustPrompt(*Instance) bool { return false }
 
 func (b *sshBackend) TapEnter(i *Instance) { i.AgentServer().TapEnter() }
 
-// Recover/Respawn are unsupported until PR6 wires archive/restore (push/pull the
-// branch, re-provision the remote). A Lost ssh session is flagged but not
-// auto-reconnected yet.
-func (b *sshBackend) Recover(*Instance) error { return ErrRecoverUnsupported }
-func (b *sshBackend) Respawn(*Instance) error { return ErrRecoverUnsupported }
+// Recover/Respawn re-establish an ssh session by RE-PROVISIONING a fresh remote
+// that clones the session's branch back from origin, then relaunching the agent
+// (#1592 Phase 4 PR6) — the same recoverSandbox the docker runtime uses (written
+// once). A disposable remote dir has no in-place session to reconnect, so
+// recovery is always a fresh provision + clone of the durable branch on GitHub;
+// only the pushed state survives.
+func (b *sshBackend) Recover(i *Instance) error { return recoverSandbox(i) }
+func (b *sshBackend) Respawn(i *Instance) error { return recoverSandbox(i) }

--- a/session/backend_test.go
+++ b/session/backend_test.go
@@ -121,6 +121,35 @@ func TestBackendCapabilities(t *testing.T) {
 				InteractiveInput: false,
 			},
 		},
+		{
+			// #1592 Phase 4 PR6: the sandbox runtimes reach FULL parity — a remote
+			// workspace, but every capability true (Archive/Recover via
+			// push/pull-branch). No ErrRecoverUnsupported, no locality special-case.
+			name: "docker sandbox runtime — full remote parity",
+			b:    &dockerBackend{},
+			want: Capabilities{
+				Workspace:        WorkspaceRemote,
+				Attach:           true,
+				Archive:          true,
+				Recover:          true,
+				TabManagement:    true,
+				TerminalTab:      true,
+				InteractiveInput: true,
+			},
+		},
+		{
+			name: "ssh sandbox runtime — full remote parity",
+			b:    &sshBackend{},
+			want: Capabilities{
+				Workspace:        WorkspaceRemote,
+				Attach:           true,
+				Archive:          true,
+				Recover:          true,
+				TabManagement:    true,
+				TerminalTab:      true,
+				InteractiveInput: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/session/git/worktree_push.go
+++ b/session/git/worktree_push.go
@@ -1,0 +1,64 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+// archiveSnapshotMessage labels the WIP commit SnapshotAndPushBranch makes for
+// uncommitted work at archive time. It is deliberately recognizable so a user
+// who restores the session sees why the extra commit exists.
+const archiveSnapshotMessage = "af: pre-archive snapshot (uncommitted work)"
+
+// SnapshotAndPushBranch makes the session's branch durable on origin (#1592
+// Phase 4 PR6) — the archive-side primitive for the disposable sandbox backends
+// (docker/ssh). Because a sandbox is thrown away on archive and re-cloned from
+// GitHub on restore, the branch on origin IS the durable workspace (epic
+// decision 4), so archive pushes it there before the sandbox is torn down.
+//
+// It first snapshots any uncommitted work as a WIP commit so archive preserves
+// the working tree, matching the local worktree-move archive's "nothing lost"
+// guarantee as closely as the disposable model allows: local archive moves the
+// worktree bytes verbatim, but a sandbox has no bytes to move once reaped, so
+// the only way its uncommitted work survives is to commit it. The commit is
+// clearly labeled (archiveSnapshotMessage) and made with --no-verify so a slow
+// or failing pre-commit hook never blocks an archive. A clean tree skips the
+// commit entirely.
+//
+// The push runs under the network timeout (a stalled or auth-prompting origin
+// must not hang the archive forever). Credentials are the sandbox image's/host's
+// responsibility — the same `origin` the sandbox cloned from must be pushable
+// (documented in docs/backends.md).
+func (g *GitWorktree) SnapshotAndPushBranch() (string, error) {
+	if g.externalWorktree {
+		return "", fmt.Errorf("cannot push an in-place/external worktree branch (it is user-owned)")
+	}
+	branch := strings.TrimSpace(g.branchName)
+	if branch == "" {
+		return "", fmt.Errorf("cannot push worktree %s: branch name is empty", g.worktreePath)
+	}
+
+	// Snapshot uncommitted work so it survives the sandbox teardown. `git status
+	// --porcelain` is empty for a clean tree, in which case there is nothing to
+	// commit and we push the committed history as-is.
+	status, err := g.runGitCommand(g.worktreePath, "status", "--porcelain")
+	if err != nil {
+		return "", fmt.Errorf("failed to check worktree status before archive push: %w", err)
+	}
+	if strings.TrimSpace(status) != "" {
+		if _, err := g.runGitCommand(g.worktreePath, "add", "-A"); err != nil {
+			return "", fmt.Errorf("failed to stage uncommitted work before archive push: %w", err)
+		}
+		if _, err := g.runGitCommand(g.worktreePath, "commit", "--no-verify", "-m", archiveSnapshotMessage); err != nil {
+			return "", fmt.Errorf("failed to snapshot uncommitted work before archive push: %w", err)
+		}
+	}
+
+	// Push the branch to origin under the network timeout. A "src refspec ..."
+	// or auth failure surfaces here with git's stderr folded in.
+	if out, err := g.runGitNetworkCommand(g.worktreePath, "push", "origin", branch); err != nil {
+		return "", fmt.Errorf("failed to push branch %q to origin (archive stores durable state on GitHub): %s: %w",
+			branch, strings.TrimSpace(out), err)
+	}
+	return branch, nil
+}

--- a/session/git/worktree_push_test.go
+++ b/session/git/worktree_push_test.go
@@ -1,0 +1,127 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runGitOut runs a git command in dir and returns its output (runGit, shared with
+// the network tests, is the fail-on-error, no-output form).
+func runGitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), gitEnv...)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, string(out))
+	return string(out)
+}
+
+// pushTestRepo sets up a repo with an initial commit, a bare `origin` it can push
+// to, and a session worktree on branch `<branch>` — the shape a sandbox has at
+// archive time. Returns the GitWorktree bound to the session worktree + branch,
+// and the bare origin path so tests can assert what landed there.
+func pushTestRepo(t *testing.T, branch string) (*GitWorktree, string) {
+	t.Helper()
+	repoRoot := createGitRepo(t)
+	// SnapshotAndPushBranch commits via the production git runner (os.Environ, no
+	// injected identity), so the repo itself must carry a committer identity — the
+	// sandbox configures this globally; here we set it repo-local.
+	runGit(t, repoRoot, "config", "user.email", "af@agent-factory.local")
+	runGit(t, repoRoot, "config", "user.name", "Agent Factory")
+	runGit(t, repoRoot, "commit", "--allow-empty", "-m", "init")
+
+	bare := filepath.Join(t.TempDir(), "origin.git")
+	require.NoError(t, exec.Command("git", "clone", "--bare", repoRoot, bare).Run())
+	runGit(t, repoRoot, "remote", "add", "origin", bare)
+
+	wtPath := filepath.Join(filepath.Dir(repoRoot), "session-wt")
+	runGit(t, repoRoot, "worktree", "add", "-b", branch, wtPath)
+
+	gw, err := NewGitWorktreeFromStorage(repoRoot, wtPath, "session", branch, "", false, true)
+	require.NoError(t, err)
+	return gw, bare
+}
+
+func branchTip(t *testing.T, dir, ref string) string {
+	t.Helper()
+	return strings.TrimSpace(runGitOut(t, dir, "rev-parse", ref))
+}
+
+// TestSnapshotAndPushBranch_PushesCommittedWork pins the archive primitive: a
+// committed change on the session branch is pushed to origin, and the returned
+// branch name matches (#1592 Phase 4 PR6).
+func TestSnapshotAndPushBranch_PushesCommittedWork(t *testing.T) {
+	sandboxHome(t)
+	gw, bare := pushTestRepo(t, "root/feature")
+	wt := gw.GetWorktreePath()
+
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "file.txt"), []byte("work"), 0644))
+	runGit(t, wt, "add", "-A")
+	runGit(t, wt, "commit", "-m", "real work")
+	want := branchTip(t, wt, "HEAD")
+
+	got, err := gw.SnapshotAndPushBranch()
+	require.NoError(t, err)
+	assert.Equal(t, "root/feature", got)
+
+	// origin now has the branch at the committed tip.
+	assert.Equal(t, want, branchTip(t, bare, "refs/heads/root/feature"))
+}
+
+// TestSnapshotAndPushBranch_SnapshotsUncommitted pins the "nothing lost"
+// guarantee: uncommitted work in the worktree is committed as a snapshot and
+// pushed, so it survives the sandbox teardown (#1592 Phase 4 PR6).
+func TestSnapshotAndPushBranch_SnapshotsUncommitted(t *testing.T) {
+	sandboxHome(t)
+	gw, bare := pushTestRepo(t, "root/wip")
+	wt := gw.GetWorktreePath()
+
+	tipBefore := branchTip(t, wt, "HEAD")
+	// Leave an UNCOMMITTED file in the worktree.
+	require.NoError(t, os.WriteFile(filepath.Join(wt, "dirty.txt"), []byte("uncommitted"), 0644))
+
+	_, err := gw.SnapshotAndPushBranch()
+	require.NoError(t, err)
+
+	// A snapshot commit was made (tip advanced) and pushed with the file present.
+	tipAfter := branchTip(t, wt, "HEAD")
+	assert.NotEqual(t, tipBefore, tipAfter, "a snapshot commit should have been made")
+	pushed := branchTip(t, bare, "refs/heads/root/wip")
+	assert.Equal(t, tipAfter, pushed)
+	files := runGitOut(t, wt, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, files, "dirty.txt", "the uncommitted file should be in the snapshot commit")
+}
+
+// TestSnapshotAndPushBranch_CleanTreeJustPushes pins that a clean tree makes no
+// snapshot commit — it only pushes the existing history.
+func TestSnapshotAndPushBranch_CleanTreeJustPushes(t *testing.T) {
+	sandboxHome(t)
+	gw, bare := pushTestRepo(t, "root/clean")
+	wt := gw.GetWorktreePath()
+	runGit(t, wt, "commit", "--allow-empty", "-m", "a commit")
+	tip := branchTip(t, wt, "HEAD")
+
+	_, err := gw.SnapshotAndPushBranch()
+	require.NoError(t, err)
+
+	assert.Equal(t, tip, branchTip(t, wt, "HEAD"), "clean tree must not add a snapshot commit")
+	assert.Equal(t, tip, branchTip(t, bare, "refs/heads/root/clean"))
+}
+
+// TestSnapshotAndPushBranch_RejectsExternalWorktree pins that an in-place/external
+// worktree (the user's own tree) is never pushed by the archive primitive.
+func TestSnapshotAndPushBranch_RejectsExternalWorktree(t *testing.T) {
+	sandboxHome(t)
+	gw, _ := pushTestRepo(t, "root/ext")
+	gw.externalWorktree = true
+	if _, err := gw.SnapshotAndPushBranch(); err == nil {
+		t.Fatal("SnapshotAndPushBranch on an external worktree: want error")
+	}
+}

--- a/session/instance_data.go
+++ b/session/instance_data.go
@@ -146,13 +146,23 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 	}
 
 	// Pick backend based on persisted BackendType.
-	if data.BackendType == "remote" {
+	switch {
+	case data.BackendType == "remote":
 		hook, err := loadHookBackendForPath(data.Path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load remote hooks config: %w", err)
 		}
 		instance.backend = hook
-	} else {
+	case isSandboxBackendType(data.BackendType):
+		// A sandbox session (docker/ssh, #1592 Phase 4 PR6) has no daemon-side
+		// worktree or tmux to reconstruct — its workspace lived in a
+		// container/remote that does not survive a daemon restart; only its pushed
+		// branch on origin does. Rebuild only an INERT sandbox backend so the row
+		// still classifies as its runtime (Type/Capabilities) for archive +
+		// restore; the live runtime is re-provisioned on restore, never
+		// reconstructed here.
+		instance.backend = newInertSandboxBackend(data.BackendType)
+	default:
 		instance.backend = &LocalBackend{}
 
 		// Preserve backward compatibility: when the branch_created_by_us
@@ -208,6 +218,18 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 	// tmux-less for the same reason (its TmuxName entries reference sessions
 	// that no longer exist, and restoreLocalTabs only binds names, never spawns).
 	if liveness == LiveArchived {
+		return instance, nil
+	}
+
+	// A non-archived sandbox session (docker/ssh) cannot be driven on load: its
+	// container/remote is gone after a daemon restart and only its pushed branch
+	// on origin survives (#1592 Phase 4 PR6). Load it INERT + Lost — started stays
+	// false, so the status poll and the Lost-restore loop both pass it by (the
+	// #1028 started=false fence) — and let an explicit restore re-provision a fresh
+	// sandbox from the branch. Skipping Start also avoids driving the recursive
+	// remote backend with no live agent-server client.
+	if isSandboxBackendType(data.BackendType) {
+		instance.liveness = LiveLost
 		return instance, nil
 	}
 

--- a/session/runtime.go
+++ b/session/runtime.go
@@ -68,8 +68,16 @@ type ProvisionSpec struct {
 	// file:// or bind-mounted path for a self-contained test). Empty for the
 	// in-process local/hook runtimes, which never clone. On a fresh create the
 	// sandbox clones its default branch and the in-sandbox worktree derives the
-	// session branch from Title; restore-to-a-pushed-branch is PR6.
+	// session branch from Title.
 	CloneURL string
+	// RestoreBranch, when set, makes this a RESTORE provision rather than a fresh
+	// create (#1592 Phase 4 PR6): after cloning, the sandbox materializes this
+	// exact branch (the one archive pushed to origin) as a LOCAL ref so the
+	// in-sandbox local backend's Setup reuses it — bringing the pushed commits
+	// back — instead of branching fresh off the default. Empty on a fresh create.
+	// Only the sandbox runtimes (docker/ssh) honor it; the in-process runtimes
+	// never clone, so it is a no-op for them.
+	RestoreBranch string
 }
 
 // ProvisionResult is what a Runtime hands back: the in-process Backend that


### PR DESCRIPTION
## What

Brings **ARCHIVE / RESTORE to full parity** for the disposable sandbox backends (`docker`/`ssh`), the last piece of #1592 Phase 4. The docker + ssh Runtimes are already live (PR4/PR5); this PR makes them durable. Written **once** against the `Runtime` seam — no per-backend archive logic, no locality special-case.

Local archive/restore is **unchanged** (it still relocates the worktree in place).

## The seam — the Runtime archive/restore flow

GitHub is the durable workspace store (epic decision 4), so the sandbox is disposable and the branch on `origin` is the durable state:

- **Archive** — push the session branch to `origin`, then tear the sandbox down. The push happens over the in-sandbox `af agent-server` (it owns the worktree), via a new `POST /v1/agent/archive` route → `AgentServer.Archive()` → `GitWorktree.SnapshotAndPushBranch()`. Then `AgentServer.Kill()` reaps the container / remote dir + tunnel. The instance persists as an inert **Archived** row.
- **Restore / Recover** — re-provision a **fresh** sandbox that clones the pushed branch back (a new `ProvisionSpec.RestoreBranch` makes the sandbox's clone step fetch `<branch>:<branch>` into a local ref, so the in-sandbox `Setup` checks out the pushed commits instead of branching fresh), restart the agent-server, relaunch the agent.

`docker`/`ssh` now advertise **`Archive` + `Recover` = true** — full capability parity, no `ErrRecoverUnsupported`, no locality branch. The push-teardown / provision-then-clone mechanics live in `session/archive_sandbox.go` (`ArchiveSandbox`, `reprovisionRemote`, `recoverSandbox`), shared by both backends; their `Recover`/`Respawn` both call `recoverSandbox`. The daemon's `ArchiveSession`/`RestoreArchived` branch on `Workspace == WorkspaceRemote` to the remote bodies, **reusing the existing locks + archive/restore state transitions** — remote restore reuses `RestoreFromArchive` unchanged (`BeginRestore` → `backend.Recover` → re-provision + relaunch + `ConfirmLive`).

`FromInstanceData` reconstructs inert docker/ssh backends on load: an **archived** record loads Archived + restorable; a **live** one loads **Lost** with `started=false` (so the poll + Lost-restore loop pass it by — a sandbox's container/tunnel doesn't survive a daemon restart, and the recursive remote backend is never driven without a live client).

## Uncommitted-work semantics

Only what reaches `origin` survives an archive. To match local's *worktree-move* "nothing lost" guarantee as closely as the disposable model allows:

- **Committed work** on the branch is pushed → fully preserved.
- **Uncommitted work** is snapshotted into a labeled WIP commit (`af: pre-archive snapshot (uncommitted work)`) and pushed → not lost.
- **Agent conversation history** lived only in the disposed sandbox and is **not** restored — a fresh agent runs on the restored branch. This is the one place the disposable model differs from local's in-place worktree move.

Documented in `docs/backends.md` (new **Archive & restore** section; the sandbox must be able to push to `origin`).

## Tests

Host-side (CI, no docker): the git push primitive (committed / uncommitted-snapshot / clean-tree / external-worktree-rejected), the docker/ssh load path (archived→Archived, live→Lost-not-started), the reprovision rebind (via a `fakeRuntime`), and the capability parity matrix.

**REAL archive→restore round-trips** (`make backend-docker-roundtrip` / `backend-ssh-roundtrip`, each now runs plain + archive/restore): create a sandbox session, commit real work on its branch, **archive** (assert branch pushed to `origin` + sandbox reaped), **restore** (assert a *fresh* sandbox, branch cloned back, the commit present, session drivable again).

### archive→restore survives via GitHub — real transcript

Docker:
```
session worktree /workspace-docker-ar on branch root/docker-ar
committed dc184917f7d8 on the session branch
ARCHIVE ✓ branch "root/docker-ar" pushed to origin with commit dc184917f7d8; container reaped
RESTORE ✓ fresh container 01932122655b; branch cloned back; commit dc184917f7d8 present (proof.txt="archive-restore-marker-42")
restored session is drivable: typed input echoes over the fresh container's stream
docker archive→restore round-trip complete: state survived via GitHub, no leak.
--- PASS: TestDockerBackendArchiveRestore (6.50s)
```

SSH:
```
remote session worktree /root/.af-sessions/ssh-ar.hmDcDc/workspace-ssh-ar on branch root/ssh-ar
committed 2bd1df5abfcc on the remote session branch
ARCHIVE ✓ branch "root/ssh-ar" pushed to origin with commit 2bd1df5abfcc; remote sandbox reaped
RESTORE ✓ fresh remote dir "ssh-ar.aONnHE"; branch cloned back; commit 2bd1df5abfcc present (proof.txt="archive-restore-marker-77")
restored ssh session is drivable: typed input echoes over the fresh tunnel's stream
ssh archive→restore round-trip complete: state survived via GitHub, no leak.
--- PASS: TestSSHBackendArchiveRestore (6.84s)
```

The commit made in the (reaped) sandbox is present in the *fresh* sandbox after restore — proving state survived purely via the branch on GitHub.

## Gates

`gofmt` · `golangci-lint --fast` · `go build ./...` · file-length lint · `deadcode -test ./...` (0) · `make test-container` (full suite) · `make tui-driver-selftest` (25/25) · `gen-docs` (no drift) · both real docker+ssh round-trips (plain + archive/restore) — all green.

Part of #1592 (Phase 4 PR6). Base `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)