### PR TITLE
feat(agentproto,web): additive MsgHello start-seq frame + web TS frame codec + JS toolchain (#1592 Phase 5 PR1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,15 @@ vendor/
 *.prof
 __debug_bin*
 
+# Web client toolchain (#1592 Phase 5). node_modules is never committed; the built
+# web/dist/ IS committed (locked decision) so `go build`/Go tests stay Node-free.
+web/node_modules/
+web/*.tsbuildinfo
+# Playwright browser downloads / run artifacts (harness itself lands in PR6).
+web/test-results/
+web/playwright-report/
+web/.playwright/
+
 # MkDocs build output
 site/
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 	agent-server-roundtrip-container remote-agent-server-roundtrip-container \
 	backend-docker-roundtrip backend-ssh-roundtrip \
 	playtest-container playtest-container-detached tui-driver tui-driver-selftest \
-	testbox-image lint-file-length docs
+	testbox-image lint-file-length docs web-build web-test
 
 # Structural-health lint (#1145): fail if any Go file exceeds its line limit
 # (1000 for production code, 1500 for *_test.go) unless grandfathered in
@@ -116,3 +116,28 @@ tui-driver-selftest:
 # (Re)build the toolchain image only.
 testbox-image:
 	scripts/testbox.sh build
+
+# Web client toolchain (#1592 Phase 5). The JS build+test are gated ENTIRELY behind
+# these targets: `go build ./...` and `make test-container` never invoke Node — the
+# built web/dist/ is committed so the Go side is self-sufficient. Both targets depend
+# on web/node_modules, an order-only-style file target rebuilt from the lockfile.
+#
+# web/node_modules is a real file target: `npm ci` runs only when the committed
+# package-lock.json (or package.json) is newer than the installed tree, so repeated
+# web-build/web-test don't reinstall. Deleting web/node_modules forces a fresh `npm ci`.
+web/node_modules: web/package-lock.json web/package.json
+	cd web && npm ci
+	@touch web/node_modules
+
+# esbuild the SPA bundle into the committed web/dist/ (design §3.1, §1.3). PR1 bundles
+# only the wire-frame codec; later PRs add the UI and go:embed dist/ into the daemon.
+web-build: web/node_modules
+	cd web && npm run build
+
+# TypeScript unit tests: the frame golden-vector parity (web/src/frame.test.ts)
+# asserting the TS codec is byte-identical to the Go encoder against the SAME fixture
+# (agentproto/testdata/frame_vectors.json). Also typechecks the sources. The
+# Playwright browser harness lands in PR6 (`make web-selftest-container`); the dep is
+# wired now but not invoked here.
+web-test: web/node_modules
+	cd web && npm run typecheck && npm run test

--- a/agentproto/frame.go
+++ b/agentproto/frame.go
@@ -31,11 +31,26 @@ const (
 	// is not part of the shared ring's monotonic seq, so counting it would desync the
 	// ?since arithmetic.
 	OpRepaint Opcode = 0x03
+	// OpHello (server → client) is the FIRST frame on every new subscription: an
+	// 8-byte big-endian uint64 carrying the subscription's starting seq. It delivers
+	// in-band the same value the X-Af-Stream-Seq handshake header carries, because a
+	// browser WebSocket cannot read 101-handshake response headers and so cannot
+	// otherwise learn its absolute cursor to seed ?since replay (#1592 Phase 5 PR1,
+	// design §4.3). It carries no PTY bytes and is NOT counted toward the replay
+	// cursor. Strictly additive: appended after OpRepaint, existing ops unchanged.
+	// Stream consumers that don't handle it (the TUI/apiclient path) ignore it — the
+	// opcode decodes cleanly, so ReadMessage never errors and their frame switch
+	// simply skips it (unknown-op tolerance without any client change).
+	OpHello Opcode = 0x04
 )
 
 // resizePayloadLen is the fixed body size of an OpResize frame: two big-endian
 // uint16s, rows then cols.
 const resizePayloadLen = 4
+
+// helloPayloadLen is the fixed body size of an OpHello frame: one big-endian
+// uint64, the subscription's starting seq.
+const helloPayloadLen = 8
 
 // String renders an opcode for diagnostics.
 func (o Opcode) String() string {
@@ -48,6 +63,8 @@ func (o Opcode) String() string {
 		return "RESIZE"
 	case OpRepaint:
 		return "REPAINT"
+	case OpHello:
+		return "HELLO"
 	default:
 		return fmt.Sprintf("Opcode(0x%02x)", byte(o))
 	}
@@ -59,13 +76,19 @@ func (o Opcode) String() string {
 // inverse, so DecodeFrame(f.Encode()) round-trips f.
 type Frame struct {
 	Op   Opcode
-	Data []byte // OpPTYOut, OpInput: raw payload. OpResize: nil.
+	Data []byte // OpPTYOut, OpInput, OpRepaint: raw payload. OpResize/OpHello: nil.
 	Rows uint16 // OpResize only.
 	Cols uint16 // OpResize only.
+	Seq  uint64 // OpHello only.
 }
 
 // PTYOutFrame wraps verbatim PTY output bytes (server → client).
 func PTYOutFrame(b []byte) Frame { return Frame{Op: OpPTYOut, Data: b} }
+
+// HelloFrame wraps a subscription's starting seq (server → client), emitted as the
+// first frame so a client that cannot read the X-Af-Stream-Seq handshake header (a
+// browser WebSocket) still learns its absolute cursor to seed ?since replay.
+func HelloFrame(seq uint64) Frame { return Frame{Op: OpHello, Seq: seq} }
 
 // RepaintFrame wraps a one-shot screen repaint (server → client): rendered like
 // PTY_OUT but NOT counted toward the client's replay cursor (§ OpRepaint).
@@ -89,6 +112,11 @@ func (f Frame) Encode() []byte {
 		binary.BigEndian.PutUint16(out[1:3], f.Rows)
 		binary.BigEndian.PutUint16(out[3:5], f.Cols)
 		return out
+	case OpHello:
+		out := make([]byte, 1+helloPayloadLen)
+		out[0] = byte(OpHello)
+		binary.BigEndian.PutUint64(out[1:9], f.Seq)
+		return out
 	default:
 		out := make([]byte, 1+len(f.Data))
 		out[0] = byte(f.Op)
@@ -98,7 +126,7 @@ func (f Frame) Encode() []byte {
 }
 
 // DecodeFrame parses an opcode-prefixed binary frame. It errors on an empty frame,
-// an unknown opcode, or a malformed OpResize body.
+// an unknown opcode, or a malformed OpResize/OpHello body.
 func DecodeFrame(raw []byte) (Frame, error) {
 	if len(raw) == 0 {
 		return Frame{}, fmt.Errorf("agentproto: empty binary frame")
@@ -117,6 +145,11 @@ func DecodeFrame(raw []byte) (Frame, error) {
 			Rows: binary.BigEndian.Uint16(body[0:2]),
 			Cols: binary.BigEndian.Uint16(body[2:4]),
 		}, nil
+	case OpHello:
+		if len(body) != helloPayloadLen {
+			return Frame{}, fmt.Errorf("agentproto: HELLO frame body is %d bytes, want %d", len(body), helloPayloadLen)
+		}
+		return Frame{Op: OpHello, Seq: binary.BigEndian.Uint64(body[0:8])}, nil
 	default:
 		return Frame{}, fmt.Errorf("agentproto: unknown opcode 0x%02x", byte(op))
 	}

--- a/agentproto/frame_test.go
+++ b/agentproto/frame_test.go
@@ -2,13 +2,17 @@ package agentproto
 
 import (
 	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"strconv"
 	"testing"
 )
 
 // frameEqual compares two frames, treating nil and empty Data as equal (Encode of
 // an empty payload and DecodeFrame of a 1-byte frame differ only in nil-ness).
 func frameEqual(a, b Frame) bool {
-	return a.Op == b.Op && a.Rows == b.Rows && a.Cols == b.Cols && bytes.Equal(a.Data, b.Data)
+	return a.Op == b.Op && a.Rows == b.Rows && a.Cols == b.Cols && a.Seq == b.Seq && bytes.Equal(a.Data, b.Data)
 }
 
 func TestFrameRoundTrip(t *testing.T) {
@@ -24,6 +28,9 @@ func TestFrameRoundTrip(t *testing.T) {
 		{"resize", ResizeFrame(24, 80)},
 		{"resize_zero", ResizeFrame(0, 0)},
 		{"resize_max", ResizeFrame(65535, 65535)},
+		{"hello_zero", HelloFrame(0)},
+		{"hello", HelloFrame(4294967297)},
+		{"hello_max", HelloFrame(18446744073709551615)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -53,6 +60,13 @@ func TestFrameEncodeWireBytes(t *testing.T) {
 	if b := ResizeFrame(258, 259).Encode(); !bytes.Equal(b, []byte{0x02, 0x01, 0x02, 0x01, 0x03}) {
 		t.Errorf("RESIZE wire bytes = % x", b)
 	}
+	// HELLO: opcode 0x04, then the start seq as a big-endian uint64.
+	if b := HelloFrame(0).Encode(); !bytes.Equal(b, []byte{0x04, 0, 0, 0, 0, 0, 0, 0, 0}) {
+		t.Errorf("HELLO(0) wire bytes = % x", b)
+	}
+	if b := HelloFrame(4294967297).Encode(); !bytes.Equal(b, []byte{0x04, 0, 0, 0, 1, 0, 0, 0, 1}) {
+		t.Errorf("HELLO(2^32+1) wire bytes = % x", b)
+	}
 }
 
 func TestDecodeFrameErrors(t *testing.T) {
@@ -64,6 +78,8 @@ func TestDecodeFrameErrors(t *testing.T) {
 		{"unknown_opcode", []byte{0x7f, 'x'}},
 		{"resize_too_short", []byte{byte(OpResize), 0x00, 24}},
 		{"resize_too_long", []byte{byte(OpResize), 0, 24, 0, 80, 0}},
+		{"hello_too_short", []byte{byte(OpHello), 0, 0, 0, 0, 0, 0, 1}},
+		{"hello_too_long", []byte{byte(OpHello), 0, 0, 0, 0, 0, 0, 0, 1, 2}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -82,10 +98,139 @@ func TestOpcodeString(t *testing.T) {
 		{OpPTYOut, "PTY_OUT"},
 		{OpInput, "INPUT"},
 		{OpResize, "RESIZE"},
+		{OpRepaint, "REPAINT"},
+		{OpHello, "HELLO"},
 		{Opcode(0x42), "Opcode(0x42)"},
 	} {
 		if got := tc.op.String(); got != tc.want {
 			t.Errorf("Opcode(%#x).String() = %q, want %q", byte(tc.op), got, tc.want)
 		}
+	}
+}
+
+// frameVector mirrors one entry of testdata/frame_vectors.json — the fixture the
+// TypeScript codec (web/src/frame.test.ts) validates against too, so the browser
+// and daemon codecs are pinned to byte-identical framing.
+type frameVector struct {
+	Name    string `json:"name"`
+	Op      string `json:"op"`
+	DataHex string `json:"dataHex"`
+	Rows    uint16 `json:"rows"`
+	Cols    uint16 `json:"cols"`
+	Seq     string `json:"seq"` // decimal uint64 (string so JS BigInt keeps it exact)
+	WireHex string `json:"wireHex"`
+}
+
+// frame reconstructs the logical Frame a vector describes.
+func (v frameVector) frame(t *testing.T) Frame {
+	t.Helper()
+	switch v.Op {
+	case "PTY_OUT":
+		return PTYOutFrame(mustHex(t, v.DataHex))
+	case "INPUT":
+		return InputFrame(mustHex(t, v.DataHex))
+	case "REPAINT":
+		return RepaintFrame(mustHex(t, v.DataHex))
+	case "RESIZE":
+		return ResizeFrame(v.Rows, v.Cols)
+	case "HELLO":
+		seq, err := strconv.ParseUint(v.Seq, 10, 64)
+		if err != nil {
+			t.Fatalf("vector %q: bad seq %q: %v", v.Name, v.Seq, err)
+		}
+		return HelloFrame(seq)
+	default:
+		t.Fatalf("vector %q: unknown op %q", v.Name, v.Op)
+		return Frame{}
+	}
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	return b
+}
+
+// TestFrameGoldenVectors is the Go half of the cross-language codec contract: it
+// asserts Encode produces the fixture's exact wire bytes and DecodeFrame reparses
+// them back to the same Frame. web/src/frame.test.ts asserts the identical property
+// against the SAME file, so the Go and TS codecs cannot silently diverge. On a
+// mismatch this prints the actual bytes — the way to (re)derive a fixture entry.
+func TestFrameGoldenVectors(t *testing.T) {
+	raw, err := os.ReadFile("testdata/frame_vectors.json")
+	if err != nil {
+		t.Fatalf("read fixtures: %v", err)
+	}
+	var fixture struct {
+		Vectors []frameVector `json:"vectors"`
+	}
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("parse fixtures: %v", err)
+	}
+	if len(fixture.Vectors) == 0 {
+		t.Fatal("no vectors in fixture")
+	}
+	for _, v := range fixture.Vectors {
+		t.Run(v.Name, func(t *testing.T) {
+			f := v.frame(t)
+			wantWire := mustHex(t, v.WireHex)
+			if got := f.Encode(); !bytes.Equal(got, wantWire) {
+				t.Fatalf("Encode mismatch:\n got  = %x\n want = %s (%q)", got, v.WireHex, v.Name)
+			}
+			back, err := DecodeFrame(wantWire)
+			if err != nil {
+				t.Fatalf("DecodeFrame(%s) error: %v", v.WireHex, err)
+			}
+			if !frameEqual(back, f) {
+				t.Fatalf("DecodeFrame round-trip mismatch:\n in  = %+v\n got = %+v", f, back)
+			}
+		})
+	}
+}
+
+// TestStreamConsumerToleratesHello is the additive-safety property (#1592 Phase 5
+// PR1): an existing stream consumer shaped exactly like the TUI/apiclient path
+// (app/live_stream.go apiStream.Recv, integration ws_pty readPump) — which switches
+// on Frame.Op and skips anything it doesn't handle — ignores the new OpHello frame
+// with NO behavior change. OpHello decodes cleanly (it is a known op, so ReadMessage
+// never errors), the consumer's switch falls through to its skip branch, no bytes are
+// rendered, and the replay cursor is untouched. This is why the TUI is byte-for-byte
+// unaffected by the broker now emitting a leading hello.
+func TestStreamConsumerToleratesHello(t *testing.T) {
+	// The exact wire sequence the broker now sends a fresh subscriber: hello, then a
+	// repaint, then live output.
+	wire := [][]byte{
+		HelloFrame(42).Encode(),
+		RepaintFrame([]byte("screen")).Encode(),
+		PTYOutFrame([]byte("live")).Encode(),
+	}
+	// consume mirrors the TUI/apiclient frame switch: collect PTY_OUT bytes only,
+	// render repaint without counting it, ignore everything else. A decode error
+	// would model the consumer choking — which must NOT happen for OpHello.
+	var out []byte
+	var repainted bool
+	for _, raw := range wire {
+		f, err := DecodeFrame(raw)
+		if err != nil {
+			t.Fatalf("consumer decode error on % x: %v (a consumer would drop the stream)", raw, err)
+		}
+		switch f.Op {
+		case OpPTYOut:
+			out = append(out, f.Data...)
+		case OpRepaint:
+			repainted = true
+		default:
+			// INPUT/RESIZE/HELLO and any future op: skipped, exactly as apiStream.Recv
+			// and the integration readPump do. The hello lands here — a no-op.
+		}
+	}
+	if string(out) != "live" {
+		t.Fatalf("PTY output after a leading hello = %q, want %q", out, "live")
+	}
+	if !repainted {
+		t.Fatal("repaint frame was not delivered through the leading hello")
 	}
 }

--- a/agentproto/testdata/frame_vectors.json
+++ b/agentproto/testdata/frame_vectors.json
@@ -1,0 +1,22 @@
+{
+  "note": "Shared golden vectors for the agentproto PTY frame codec (#1592 Phase 5 PR1). Both the Go codec (agentproto/frame_test.go: TestFrameGoldenVectors) and the TypeScript port (web/src/frame.test.ts) validate against THIS file, pinning the browser and daemon to byte-identical framing. wireHex is the exact opcode-prefixed wire encoding, lowercase hex. seq is a decimal string (uint64) so a JS number's 53-bit mantissa never truncates it — the TS codec parses it with BigInt. To regenerate the expected bytes, run the Go test; on a mismatch it prints the actual encoding.",
+  "opcodes": { "PTY_OUT": 0, "INPUT": 1, "RESIZE": 2, "REPAINT": 3, "HELLO": 4 },
+  "vectors": [
+    { "name": "pty_out_ascii", "op": "PTY_OUT", "dataHex": "6869", "wireHex": "006869" },
+    { "name": "pty_out_empty", "op": "PTY_OUT", "dataHex": "", "wireHex": "00" },
+    { "name": "pty_out_ansi", "op": "PTY_OUT", "dataHex": "1b5b33316d780a", "wireHex": "001b5b33316d780a" },
+    { "name": "pty_out_binary", "op": "PTY_OUT", "dataHex": "000102fffe", "wireHex": "00000102fffe" },
+    { "name": "input_line", "op": "INPUT", "dataHex": "6c730a", "wireHex": "016c730a" },
+    { "name": "input_ctrl_c", "op": "INPUT", "dataHex": "03", "wireHex": "0103" },
+    { "name": "input_empty", "op": "INPUT", "dataHex": "", "wireHex": "01" },
+    { "name": "repaint", "op": "REPAINT", "dataHex": "1b5b324a58", "wireHex": "031b5b324a58" },
+    { "name": "resize_24x80", "op": "RESIZE", "rows": 24, "cols": 80, "wireHex": "0200180050" },
+    { "name": "resize_258x259", "op": "RESIZE", "rows": 258, "cols": 259, "wireHex": "0201020103" },
+    { "name": "resize_zero", "op": "RESIZE", "rows": 0, "cols": 0, "wireHex": "0200000000" },
+    { "name": "resize_max", "op": "RESIZE", "rows": 65535, "cols": 65535, "wireHex": "02ffffffff" },
+    { "name": "hello_zero", "op": "HELLO", "seq": "0", "wireHex": "040000000000000000" },
+    { "name": "hello_one", "op": "HELLO", "seq": "1", "wireHex": "040000000000000001" },
+    { "name": "hello_over_u32", "op": "HELLO", "seq": "4294967297", "wireHex": "040000000100000001" },
+    { "name": "hello_max_u64", "op": "HELLO", "seq": "18446744073709551615", "wireHex": "04ffffffffffffffff" }
+  ]
+}

--- a/daemon/agentserver_headless_test.go
+++ b/daemon/agentserver_headless_test.go
@@ -229,12 +229,27 @@ func TestHeadlessAgentServer_TLSTokenRoundTrip(t *testing.T) {
 	require.NoError(t, err, "authorized WS handshake must upgrade")
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
 
-	require.NoError(t, agentproto.WriteFrame(ctx, conn, agentproto.InputFrame([]byte("typed\n"))))
-	msg, err := agentproto.ReadMessage(ctx, conn)
+	// The very first frame on a fresh subscription is the OpHello start-seq (#1592
+	// Phase 5 PR1): the in-band cursor seed a browser needs because it cannot read the
+	// X-Af-Stream-Seq handshake header off the WS upgrade. Assert it here on the real
+	// TLS/WSS transport this test drives.
+	first, err := agentproto.ReadMessage(ctx, conn)
 	require.NoError(t, err)
-	require.True(t, msg.Binary)
-	require.Equal(t, agentproto.OpPTYOut, msg.Frame.Op)
-	require.Equal(t, "echo:typed\n", string(msg.Frame.Data))
+	require.True(t, first.Binary)
+	require.Equal(t, agentproto.OpHello, first.Frame.Op, "first stream frame must be the start-seq hello")
+
+	// Then type input and assert it echoes back as PTY output, skipping any initial
+	// repaint/resize frames exactly as a real stream consumer (app/live_stream
+	// apiStream) does — it collects OpPTYOut and ignores everything else.
+	require.NoError(t, agentproto.WriteFrame(ctx, conn, agentproto.InputFrame([]byte("typed\n"))))
+	var echoed []byte
+	for !strings.Contains(string(echoed), "echo:typed\n") {
+		msg, rerr := agentproto.ReadMessage(ctx, conn)
+		require.NoError(t, rerr) // ctx deadline bounds the loop if the echo never lands
+		if msg.Binary && msg.Frame.Op == agentproto.OpPTYOut {
+			echoed = append(echoed, msg.Frame.Data...)
+		}
+	}
 
 	// --- WS PTY stream: no token → handshake rejected -----------------------
 	badCtx, badCancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/daemon/ws_pty.go
+++ b/daemon/ws_pty.go
@@ -135,6 +135,20 @@ func servePTYStream(as session.AgentServer, tab int, sub session.PTYSubscription
 // output bytes and resize echoes onto the one connection. Keeping it single means
 // no concurrent data writes race on the socket.
 func writePTYStream(ctx context.Context, sub session.PTYSubscription, conn *websocket.Conn) {
+	// Emit the start-seq hello as the VERY FIRST frame, before any PTY_OUT/repaint,
+	// so a browser client — which cannot read the X-Af-Stream-Seq handshake header
+	// off a WS upgrade (#1592 Phase 5 PR1, §4.3) — learns its absolute cursor in-band
+	// to seed ?since replay. sub.Seq() here is still the subscription's start cursor
+	// (no PTYData consumed yet, and repaint/resize don't advance it), so it is
+	// byte-identical to the streamSeqHeader value set at handshake. Additive: Go
+	// stream consumers (TUI/apiclient) decode the frame cleanly and skip it — no
+	// behavior change (see agentproto OpHello).
+	hctx, hcancel := context.WithTimeout(ctx, wsWriteTimeout)
+	err := agentproto.WriteFrame(hctx, conn, agentproto.HelloFrame(uint64(sub.Seq())))
+	hcancel()
+	if err != nil {
+		return // wedged/dead client before the first byte: drop it (session untouched)
+	}
 	for {
 		ev, err := sub.NextEvent(ctx)
 		if err != nil {

--- a/integration/ws_pty_test.go
+++ b/integration/ws_pty_test.go
@@ -81,13 +81,16 @@ func TestWSPTYBrokerRoundTrip(t *testing.T) {
 	// server's ping times out and drops it. It must NOT take the session or the live
 	// subscriber down.
 	dead := h.dialWSRaw(t, streamPath)
-	// A fresh subscriber receives a one-shot initial screen repaint (#1592 PR6).
-	// Drain that single frame first, otherwise the keepalive diagnostic below would
-	// read the buffered repaint (a non-error) instead of the eventual close. After
-	// this one read the client stops reading, so the next ping goes unanswered and
-	// the server drops it.
-	if err := dead.readErrWithin(2 * time.Second); err != nil {
-		t.Fatalf("dead subscriber never received its initial repaint: %v", err)
+	// A fresh subscriber receives two leading server→client frames before it goes
+	// silent: the OpHello start-seq (#1592 Phase 5 PR1) then the one-shot initial
+	// screen repaint (#1592 PR6). Drain BOTH first, otherwise the keepalive diagnostic
+	// below would read one of those still-buffered frames (a non-error) instead of the
+	// eventual close. After draining them the client stops reading, so the next ping
+	// goes unanswered and the server drops it.
+	for _, what := range []string{"hello", "repaint"} {
+		if err := dead.readErrWithin(2 * time.Second); err != nil {
+			t.Fatalf("dead subscriber never received its initial %s frame: %v", what, err)
+		}
 	}
 	// Wait out several keepalive cycles (300ms ping + 300ms pong timeout).
 	time.Sleep(1500 * time.Millisecond)

--- a/web/build.mjs
+++ b/web/build.mjs
@@ -1,0 +1,21 @@
+// esbuild build for the Agent Factory web client (#1592 Phase 5).
+//
+// esbuild is a single fast bundler (the locked toolchain choice, design §3.1). It
+// bundles src/index.ts into a self-contained ESM file under dist/. The built dist/
+// is COMMITTED (locked decision) so `go build ./...` and the Go test suite never
+// need Node — the JS toolchain is gated entirely behind `make web-*`. Later PRs add
+// the SPA (xterm.js, sidebar, modals) and go:embed dist/ into the daemon; PR1 ships
+// only the wire-frame codec so the bundle is tiny.
+import { build } from "esbuild";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: "es2022",
+  outfile: "dist/af-web.js",
+  sourcemap: false,
+  minify: false,
+  logLevel: "info",
+});

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -1,0 +1,119 @@
+// src/frame.ts
+var Op = /* @__PURE__ */ ((Op2) => {
+  Op2[Op2["PTYOut"] = 0] = "PTYOut";
+  Op2[Op2["Input"] = 1] = "Input";
+  Op2[Op2["Resize"] = 2] = "Resize";
+  Op2[Op2["Repaint"] = 3] = "Repaint";
+  Op2[Op2["Hello"] = 4] = "Hello";
+  return Op2;
+})(Op || {});
+var RESIZE_PAYLOAD_LEN = 4;
+var HELLO_PAYLOAD_LEN = 8;
+var EMPTY = new Uint8Array(0);
+function makeFrame(f) {
+  return {
+    op: f.op,
+    data: f.data ?? EMPTY,
+    rows: f.rows ?? 0,
+    cols: f.cols ?? 0,
+    seq: f.seq ?? 0n
+  };
+}
+function ptyOutFrame(data) {
+  return makeFrame({ op: 0 /* PTYOut */, data });
+}
+function inputFrame(data) {
+  return makeFrame({ op: 1 /* Input */, data });
+}
+function repaintFrame(data) {
+  return makeFrame({ op: 3 /* Repaint */, data });
+}
+function resizeFrame(rows, cols) {
+  return makeFrame({ op: 2 /* Resize */, rows, cols });
+}
+function helloFrame(seq) {
+  return makeFrame({ op: 4 /* Hello */, seq });
+}
+function encode(f) {
+  switch (f.op) {
+    case 2 /* Resize */: {
+      const out = new Uint8Array(1 + RESIZE_PAYLOAD_LEN);
+      out[0] = 2 /* Resize */;
+      const dv = new DataView(out.buffer);
+      dv.setUint16(1, f.rows, false);
+      dv.setUint16(3, f.cols, false);
+      return out;
+    }
+    case 4 /* Hello */: {
+      const out = new Uint8Array(1 + HELLO_PAYLOAD_LEN);
+      out[0] = 4 /* Hello */;
+      const dv = new DataView(out.buffer);
+      dv.setBigUint64(1, f.seq, false);
+      return out;
+    }
+    default: {
+      const out = new Uint8Array(1 + f.data.length);
+      out[0] = f.op;
+      out.set(f.data, 1);
+      return out;
+    }
+  }
+}
+function decode(raw) {
+  if (raw.length === 0) {
+    throw new Error("agentproto: empty binary frame");
+  }
+  const op = raw[0];
+  const body = raw.subarray(1);
+  switch (op) {
+    case 0 /* PTYOut */:
+    case 1 /* Input */:
+    case 3 /* Repaint */:
+      return makeFrame({ op, data: body.slice() });
+    case 2 /* Resize */: {
+      if (body.length !== RESIZE_PAYLOAD_LEN) {
+        throw new Error(`agentproto: RESIZE frame body is ${body.length} bytes, want ${RESIZE_PAYLOAD_LEN}`);
+      }
+      const dv = new DataView(body.buffer, body.byteOffset, body.byteLength);
+      return makeFrame({ op, rows: dv.getUint16(0, false), cols: dv.getUint16(2, false) });
+    }
+    case 4 /* Hello */: {
+      if (body.length !== HELLO_PAYLOAD_LEN) {
+        throw new Error(`agentproto: HELLO frame body is ${body.length} bytes, want ${HELLO_PAYLOAD_LEN}`);
+      }
+      const dv = new DataView(body.buffer, body.byteOffset, body.byteLength);
+      return makeFrame({ op, seq: dv.getBigUint64(0, false) });
+    }
+    default:
+      throw new Error(`agentproto: unknown opcode 0x${op.toString(16).padStart(2, "0")}`);
+  }
+}
+function opName(op) {
+  switch (op) {
+    case 0 /* PTYOut */:
+      return "PTY_OUT";
+    case 1 /* Input */:
+      return "INPUT";
+    case 2 /* Resize */:
+      return "RESIZE";
+    case 3 /* Repaint */:
+      return "REPAINT";
+    case 4 /* Hello */:
+      return "HELLO";
+    default:
+      return `Opcode(0x${op.toString(16).padStart(2, "0")})`;
+  }
+}
+export {
+  HELLO_PAYLOAD_LEN,
+  Op,
+  RESIZE_PAYLOAD_LEN,
+  decode,
+  encode,
+  helloFrame,
+  inputFrame,
+  opName,
+  ptyOutFrame,
+  repaintFrame,
+  resizeFrame
+};

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,655 @@
+{
+  "name": "af-web",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "af-web",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.56.1",
+        "@types/node": "22.10.2",
+        "esbuild": "^0.25.10",
+        "tsx": "^4.20.6",
+        "typescript": "5.7.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "af-web",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Agent Factory browser web client (#1592 Phase 5) — a second thin client of the daemon's REST+WS API. PR1 ships only the wire-frame codec + toolchain; UI lands in PR2+.",
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.1",
+    "@types/node": "22.10.2",
+    "esbuild": "^0.25.10",
+    "tsx": "^4.20.6",
+    "typescript": "5.7.2"
+  }
+}

--- a/web/src/frame.test.ts
+++ b/web/src/frame.test.ts
@@ -1,0 +1,109 @@
+// The TypeScript half of the cross-language codec contract (#1592 Phase 5 PR1).
+// It validates web/src/frame.ts against the SAME fixture the Go test uses
+// (agentproto/testdata/frame_vectors.json), so the browser and daemon codecs are
+// pinned to byte-identical framing and cannot silently diverge. The Go half is
+// agentproto/frame_test.go: TestFrameGoldenVectors — same file, same assertions.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { Op, decode, encode, helloFrame, inputFrame, ptyOutFrame, repaintFrame, resizeFrame, type Frame } from "./frame.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// web/src → repo-root/agentproto/testdata/frame_vectors.json (single source of truth).
+const FIXTURE_PATH = join(here, "..", "..", "agentproto", "testdata", "frame_vectors.json");
+
+interface Vector {
+  name: string;
+  op: "PTY_OUT" | "INPUT" | "RESIZE" | "REPAINT" | "HELLO";
+  dataHex?: string;
+  rows?: number;
+  cols?: number;
+  seq?: string; // decimal uint64 string — parsed with BigInt so it never truncates
+  wireHex: string;
+}
+
+function fromHex(s: string): Uint8Array {
+  if (s.length % 2 !== 0) throw new Error(`odd-length hex: ${s}`);
+  const out = new Uint8Array(s.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(s.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function toHex(b: Uint8Array): string {
+  return Array.from(b, (x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+function frameForVector(v: Vector): Frame {
+  switch (v.op) {
+    case "PTY_OUT":
+      return ptyOutFrame(fromHex(v.dataHex ?? ""));
+    case "INPUT":
+      return inputFrame(fromHex(v.dataHex ?? ""));
+    case "REPAINT":
+      return repaintFrame(fromHex(v.dataHex ?? ""));
+    case "RESIZE":
+      return resizeFrame(v.rows ?? 0, v.cols ?? 0);
+    case "HELLO":
+      return helloFrame(BigInt(v.seq ?? "0"));
+    default:
+      throw new Error(`unknown op ${(v as Vector).op}`);
+  }
+}
+
+function framesEqual(a: Frame, b: Frame): boolean {
+  return (
+    a.op === b.op &&
+    a.rows === b.rows &&
+    a.cols === b.cols &&
+    a.seq === b.seq &&
+    a.data.length === b.data.length &&
+    a.data.every((x, i) => x === b.data[i])
+  );
+}
+
+const fixture = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as { vectors: Vector[] };
+
+test("fixture has vectors", () => {
+  assert.ok(fixture.vectors.length > 0, "no vectors in fixture");
+});
+
+for (const v of fixture.vectors) {
+  test(`golden vector: ${v.name}`, () => {
+    const f = frameForVector(v);
+
+    // encode(f) must produce the fixture's exact wire bytes.
+    assert.equal(toHex(encode(f)), v.wireHex, `encode mismatch for ${v.name}`);
+
+    // decode(wire) must round-trip back to the same logical frame.
+    const back = decode(fromHex(v.wireHex));
+    assert.ok(framesEqual(back, f), `decode mismatch for ${v.name}: ${JSON.stringify({ f, back }, bigintReplacer)}`);
+  });
+}
+
+// A couple of targeted OpHello assertions beyond the fixture loop, documenting the
+// browser's reason for existing: the in-band start-seq it cannot read off the header.
+test("hello carries the start seq as a big-endian uint64", () => {
+  const wire = encode(helloFrame(4294967297n)); // 2^32 + 1
+  assert.equal(toHex(wire), "040000000100000001");
+  assert.equal(decode(wire).op, Op.Hello);
+  assert.equal(decode(wire).seq, 4294967297n);
+});
+
+test("hello preserves the full uint64 range without truncation", () => {
+  const max = 18446744073709551615n; // 2^64 - 1
+  assert.equal(decode(encode(helloFrame(max))).seq, max);
+});
+
+test("decode rejects an unknown opcode (parity with Go DecodeFrame)", () => {
+  assert.throws(() => decode(Uint8Array.from([0x7f, 0x78])), /unknown opcode/);
+});
+
+function bigintReplacer(_key: string, value: unknown): unknown {
+  return typeof value === "bigint" ? value.toString() : value;
+}

--- a/web/src/frame.ts
+++ b/web/src/frame.ts
@@ -1,0 +1,165 @@
+// A faithful, byte-for-byte port of the Go PTY frame codec (agentproto/frame.go).
+// The browser web client (#1592 Phase 5) is a second thin client of the same
+// WS PTY protocol the TUI/apiclient speak, so it must encode/decode frames
+// identically to the daemon. This is the one place the browser reimplements Go, so
+// it is pinned to the Go source of truth by a golden-vector test (frame.test.ts)
+// that validates both codecs against the SAME fixture (agentproto/testdata/
+// frame_vectors.json). Keep this in lockstep with frame.go; do NOT renumber ops.
+
+/** Opcode is the first byte of a binary WS frame on the PTY stream. */
+export enum Op {
+  /** server → client: verbatim PTY output bytes. */
+  PTYOut = 0x00,
+  /** client → server: raw key bytes (multi-writer, accepted from any client). */
+  Input = 0x01,
+  /** client → server: a rows,cols uint16 pair (last-resize-wins). */
+  Resize = 0x02,
+  /** server → client: one-shot fresh-subscriber repaint; rendered but NOT counted
+   *  toward the replay cursor. */
+  Repaint = 0x03,
+  /** server → client: the subscription's starting seq as a big-endian uint64, sent
+   *  as the FIRST frame so a browser — which cannot read the X-Af-Stream-Seq
+   *  handshake header — learns its absolute cursor to seed `?since` replay
+   *  (#1592 Phase 5 PR1, design §4.3). NOT counted toward the replay cursor. */
+  Hello = 0x04,
+}
+
+/** The fixed body size of a RESIZE frame: two big-endian uint16s (rows, cols). */
+export const RESIZE_PAYLOAD_LEN = 4;
+/** The fixed body size of a HELLO frame: one big-endian uint64 (start seq). */
+export const HELLO_PAYLOAD_LEN = 8;
+
+/**
+ * A decoded binary PTY frame. Mirrors Go's agentproto.Frame: `data` carries the
+ * payload for PTYOut/Input/Repaint; `rows`/`cols` carry a Resize; `seq` carries a
+ * Hello. Unused fields hold their zero values (empty data, 0, 0n) so a decoded
+ * frame compares cleanly against a constructed one.
+ */
+export interface Frame {
+  op: Op;
+  data: Uint8Array;
+  rows: number;
+  cols: number;
+  seq: bigint;
+}
+
+const EMPTY = new Uint8Array(0);
+
+function makeFrame(f: { op: Op; data?: Uint8Array; rows?: number; cols?: number; seq?: bigint }): Frame {
+  return {
+    op: f.op,
+    data: f.data ?? EMPTY,
+    rows: f.rows ?? 0,
+    cols: f.cols ?? 0,
+    seq: f.seq ?? 0n,
+  };
+}
+
+/** Wraps verbatim PTY output bytes (server → client). */
+export function ptyOutFrame(data: Uint8Array): Frame {
+  return makeFrame({ op: Op.PTYOut, data });
+}
+
+/** Wraps raw key bytes (client → server). */
+export function inputFrame(data: Uint8Array): Frame {
+  return makeFrame({ op: Op.Input, data });
+}
+
+/** Wraps a one-shot screen repaint (server → client); rendered like PTYOut but NOT
+ *  counted toward the replay cursor. */
+export function repaintFrame(data: Uint8Array): Frame {
+  return makeFrame({ op: Op.Repaint, data });
+}
+
+/** Wraps a terminal size (client → server; last-resize-wins). */
+export function resizeFrame(rows: number, cols: number): Frame {
+  return makeFrame({ op: Op.Resize, rows, cols });
+}
+
+/** Wraps a subscription's starting seq (server → client), the in-band cursor seed. */
+export function helloFrame(seq: bigint): Frame {
+  return makeFrame({ op: Op.Hello, seq });
+}
+
+/** Serializes a frame to its opcode-prefixed wire form (byte-identical to Go's
+ *  Frame.Encode). */
+export function encode(f: Frame): Uint8Array {
+  switch (f.op) {
+    case Op.Resize: {
+      const out = new Uint8Array(1 + RESIZE_PAYLOAD_LEN);
+      out[0] = Op.Resize;
+      const dv = new DataView(out.buffer);
+      dv.setUint16(1, f.rows, false); // big-endian
+      dv.setUint16(3, f.cols, false);
+      return out;
+    }
+    case Op.Hello: {
+      const out = new Uint8Array(1 + HELLO_PAYLOAD_LEN);
+      out[0] = Op.Hello;
+      const dv = new DataView(out.buffer);
+      dv.setBigUint64(1, f.seq, false); // big-endian
+      return out;
+    }
+    default: {
+      // PTYOut / Input / Repaint (and any op): opcode byte then the raw payload.
+      const out = new Uint8Array(1 + f.data.length);
+      out[0] = f.op;
+      out.set(f.data, 1);
+      return out;
+    }
+  }
+}
+
+/**
+ * Parses an opcode-prefixed binary frame (the inverse of encode; mirrors Go's
+ * DecodeFrame including its error behavior). Throws on an empty frame, an unknown
+ * opcode, or a malformed RESIZE/HELLO body.
+ */
+export function decode(raw: Uint8Array): Frame {
+  if (raw.length === 0) {
+    throw new Error("agentproto: empty binary frame");
+  }
+  const op = raw[0] as Op;
+  const body = raw.subarray(1);
+  switch (op) {
+    case Op.PTYOut:
+    case Op.Input:
+    case Op.Repaint:
+      // Copy so the returned frame does not alias the caller's buffer.
+      return makeFrame({ op, data: body.slice() });
+    case Op.Resize: {
+      if (body.length !== RESIZE_PAYLOAD_LEN) {
+        throw new Error(`agentproto: RESIZE frame body is ${body.length} bytes, want ${RESIZE_PAYLOAD_LEN}`);
+      }
+      const dv = new DataView(body.buffer, body.byteOffset, body.byteLength);
+      return makeFrame({ op, rows: dv.getUint16(0, false), cols: dv.getUint16(2, false) });
+    }
+    case Op.Hello: {
+      if (body.length !== HELLO_PAYLOAD_LEN) {
+        throw new Error(`agentproto: HELLO frame body is ${body.length} bytes, want ${HELLO_PAYLOAD_LEN}`);
+      }
+      const dv = new DataView(body.buffer, body.byteOffset, body.byteLength);
+      return makeFrame({ op, seq: dv.getBigUint64(0, false) });
+    }
+    default:
+      throw new Error(`agentproto: unknown opcode 0x${(op as number).toString(16).padStart(2, "0")}`);
+  }
+}
+
+/** Renders an opcode for diagnostics (mirrors Go's Opcode.String). */
+export function opName(op: Op): string {
+  switch (op) {
+    case Op.PTYOut:
+      return "PTY_OUT";
+    case Op.Input:
+      return "INPUT";
+    case Op.Resize:
+      return "RESIZE";
+    case Op.Repaint:
+      return "REPAINT";
+    case Op.Hello:
+      return "HELLO";
+    default:
+      return `Opcode(0x${(op as number).toString(16).padStart(2, "0")})`;
+  }
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,0 +1,5 @@
+// Entry point for the Phase-5 web client bundle (#1592). This PR ships only the
+// protocol foundation — the wire-frame codec — so the bundle re-exports it and has
+// no UI yet (xterm.js, the sidebar, and serving arrive in PR2+). esbuild bundles
+// this into the committed dist/ that the daemon will later go:embed and serve.
+export * from "./frame.js";

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src", "build.mjs"]
+}


### PR DESCRIPTION
First **Phase 5** (browser web frontend) PR and the phase's **only server-side wire change**. It (a) adds one additive control frame so a browser can learn the stream start-seq in-band, and (b) stands up the TS/JS toolchain with a byte-identical frame codec. **Ships no UI.**

Plan: `docs/design/phase5-web.md` §4.3, §6.1 (PR1), §3.2.

## Why the in-band start-seq is needed
Every session terminal is already an authed `wss://` endpoint via the ptyBroker. On subscribe the broker returns the stream's starting seq in the **`X-Af-Stream-Seq` handshake response header**, so a client seeds its absolute cursor (`startSeq + bytesReceived`) and reconnects with `?since=<cursor>` to replay exactly the gap. **But the browser `WebSocket` API cannot read 101-handshake response headers** — so a browser can't learn `startSeq`. Without it the first reconnect can't compute a correct `?since`. Fix: deliver the start seq **in-band** as the first frame.

## Additive `OpHello` frame (`agentproto`)
- New binary opcode **`OpHello` (0x04)**, appended after `OpRepaint` — **existing ops are NOT renumbered**. Payload is an 8-byte **big-endian uint64**: the start seq.
- `HelloFrame` ctor + `Encode`/`DecodeFrame` + `Opcode.String`; `Frame` gains a `Seq` field.
- The broker (`daemon/ws_pty.go`) emits it as the **first frame on every new subscription** (before the repaint), carrying the same value the header does.

## Additive + version-tolerant — the TUI-unaffected proof
`OpHello` is a *known* op, so `ReadMessage` decodes it cleanly (**never errors**), and the existing TUI/apiclient stream consumers **ignore it** via their frame switch's skip branch (`app/live_stream` `apiStream.Recv`, integration `readPump`) — no client change, no rendered bytes, replay cursor untouched. Proven by:
- **`agentproto` `TestStreamConsumerToleratesHello`** — the safety property (a TUI-shaped consumer skips the hello, PTY output + repaint intact).
- **`tui-driver-selftest` 25/25** — attach/detach full-screen over the real WS PTY.
- **WS PTY round-trip** + **headless agent-server TLS/WSS round-trip** green with hello emitted. Two tests were updated to *drain the leading frame* (not a behavior change): the ws-pty dead-subscriber drain now consumes hello+repaint; the headless test asserts the hello contract on the real WSS transport, then skips to the echoed output.

## New `web/` toolchain (home of the whole Phase-5 app)
`package.json` + `tsconfig.json` + **esbuild** build (`build.mjs` → committed `web/dist/`) + a **Playwright** devDependency stub (harness lands in PR6). Makefile gains **`make web-build`** and **`make web-test`**. Locked decisions honored: esbuild + Playwright/Chromium, **commit `dist/`**.

**The Go build + Go CI stay Node-free:** JS is gated entirely behind `make web-*`; `go build ./...` / `make test-container` never invoke Node. `web/node_modules/` is gitignored; `web/dist/` is committed.

## Go↔TS golden-vector parity
`web/src/frame.ts` is a faithful port of the Go codec incl. `OpHello`. Both codecs validate against the **same committed fixture** (`agentproto/testdata/frame_vectors.json`): Go `TestFrameGoldenVectors` and TS `frame.test.ts` assert **byte-identical encode + round-trip decode** across all opcodes, pinning browser and daemon to one wire format. `seq` is a decimal string in the fixture so the TS side keeps the full uint64 range via `BigInt`.

## Gates (all green)
- gofmt / golangci-lint / `go build ./...` / **`make test-container`** (full suite) / deadcode / `scripts/lint-file-length.sh`
- **`make tui-driver-selftest` → 25/25** (TUI stream path unaffected)
- **`make ws-pty-roundtrip-container` / `TestWSPTYBrokerRoundTrip`** green with hello emitted
- **`make web-build`** produces `web/dist/af-web.js`; **`make web-test`** → 20/20 (16 golden vectors byte-identical to the Go fixture + uint64-range + unknown-op parity)
- no docs drift (`gen-docs`)

## Boundaries
No UI, no serving, no xterm.js (PR2+). Purely: the additive frame + the toolchain + the codec parity. Nothing existing changes behavior.

Link: #1592

🤖 Generated with [Claude Code](https://claude.com/claude-code)