### PR TITLE
feat(daemon,web): embedded SPA serving + token login shell (#1592 Phase 5 PR2)

### DIFF
--- a/daemon/httpserver.go
+++ b/daemon/httpserver.go
@@ -164,6 +164,12 @@ func newHTTPMux(cs *controlServer) *http.ServeMux {
 	// Catch-all: any other path is an unknown route → 404 with the envelope.
 	// ServeMux routes the longest prefix match, so a real route above always
 	// wins and only genuinely-unknown paths (e.g. /v1/Nope, /) land here.
+	//
+	// On the unix socket this 404 is the final word — the socket never serves the
+	// web app (#1592 Phase 5 PR2). On the TCP listener, webShellHandler
+	// (tcpserver.go) sits IN FRONT of this mux and intercepts every non-/v1 path
+	// to serve the embedded SPA, so the browser sees index.html here instead of
+	// this 404; only genuinely-unknown /v1/ paths still reach it there.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		writeHTTPError(w, http.StatusNotFound, fmt.Errorf("unknown route %q", r.URL.Path))
 	})

--- a/daemon/tcpserver.go
+++ b/daemon/tcpserver.go
@@ -90,8 +90,14 @@ func startTCPListener(mux http.Handler, cfg *config.Config) (func() error, tcpLi
 		return nil, tcpListenerInfo{}, fmt.Errorf("bind TCP listener on %q: %w", cfg.ListenAddr, err)
 	}
 
+	// The TCP listener also serves the embedded browser SPA (#1592 Phase 5 PR2,
+	// design §1). webShellHandler serves the static shell UNAUTHENTICATED on every
+	// non-/v1 path (you cannot paste a token into a page that won't load) while
+	// routing /v1/... through the token gate below exactly as before. This wrapper
+	// is TCP-only: the unix socket keeps its bare mux (whose `/` still 404s), so
+	// the web assets never appear on the socket path.
 	srv := &http.Server{
-		Handler:           withAuth(mux, gate, cfg.CORSAllowedOrigins),
+		Handler:           webShellHandler(withAuth(mux, gate, cfg.CORSAllowedOrigins)),
 		ReadHeaderTimeout: httpReadHeaderTimeout,
 	}
 	go func() {

--- a/daemon/tcpserver_test.go
+++ b/daemon/tcpserver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -128,6 +129,61 @@ func TestTCPListener_TLS_TokenRoundTrip(t *testing.T) {
 		_ = badConn.Close(websocket.StatusNormalClosure, "")
 	}
 	require.Error(t, err, "unauthenticated WS handshake must be rejected")
+}
+
+// TestTCPListener_ServesWebShellUnauthed is the PR2 payoff: the TLS TCP listener
+// serves the embedded SPA shell WITHOUT a token (you cannot paste a token into a
+// page that will not load), while the /v1/ data plane stays token-gated on the
+// exact same listener. It also asserts the strict CSP the static handler sets.
+func TestTCPListener_ServesWebShellUnauthed(t *testing.T) {
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.ListenAddr = "127.0.0.1:0"
+	m, err := NewManager(cfg)
+	require.NoError(t, err)
+
+	cs := &controlServer{manager: m, scheduler: newTaskScheduler()}
+	closeTCP, info, err := startTCPListener(newHTTPMux(cs), cfg)
+	require.NoError(t, err)
+	defer func() { _ = closeTCP() }()
+
+	dir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: pinnedTLSConfig(t, dir+"/"+daemonTLSCertFileName)},
+	}
+	baseURL := "https://" + info.Addr
+
+	// --- Static shell: NO token → 200 + index.html + strict CSP ------------
+	resp, err := client.Get(baseURL + "/")
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "the shell must load without a token")
+	require.Contains(t, string(body), `id="app"`)
+	require.Equal(t, "default-src 'self'", resp.Header.Get("Content-Security-Policy"))
+
+	// The JS bundle is likewise reachable unauthenticated.
+	resp, err = client.Get(baseURL + "/af-web.js")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "the bundle must load without a token")
+
+	// --- API on the SAME listener: still token-gated -----------------------
+	resp, err = client.Get(baseURL + "/v1/health")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "the data plane stays gated")
+
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/health", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+info.Token)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "a valid token still reaches the API")
 }
 
 // TestStartHTTPServer_NoTCPByDefault pins the off-by-default guarantee: with an

--- a/daemon/webserve.go
+++ b/daemon/webserve.go
@@ -1,0 +1,128 @@
+package daemon
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/sachiniyer/agent-factory/web"
+)
+
+// The embedded SPA serving layer for the daemon's TLS TCP listener (#1592 Phase
+// 5 PR2, design §1). Phases 2–4 made the daemon's HTTP mux the whole API; this
+// file mounts the browser web client on the catch-all so the SAME listener that
+// serves `/v1/...` also serves the app at `/`.
+//
+// The one load-bearing nuance is the auth split (§1.2): a browser starts with NO
+// token, so the static shell (index.html + the JS/CSS bundle) MUST load
+// unauthenticated — you cannot paste a token into a page that won't render. But
+// every data path stays token-gated exactly as before. webShellHandler encodes
+// that split by prefix:
+//
+//	/v1/...  → the authed API/WS handler (withAuth gate, unchanged)
+//	anything else → the embedded static SPA, served WITHOUT a token
+//
+// This wrapper is applied ONLY to the TCP listener (tcpserver.go). The local unix
+// socket keeps its bare mux whose `/` catch-all still 404s, so the web assets are
+// never exposed on the socket path — a browser cannot reach a unix socket anyway,
+// and keeping them off it means the only new surface is behind the opt-in
+// listen_addr TLS+token gate.
+
+// webCSP is the Content-Security-Policy served with every static asset. The
+// bundle is fully self-contained (esbuild output, no CDN, no external fonts or
+// scripts, no off-origin fetch), so `default-src 'self'` is honest and keeps it
+// that way: any accidental off-origin dependency introduced later fails loudly in
+// the browser instead of silently phoning home.
+const webCSP = "default-src 'self'"
+
+// webShellHandler wraps the authed API handler so the TCP listener serves the
+// embedded SPA on every non-API path while `/v1/...` keeps flowing through the
+// token gate untouched. api is the fully-composed authed handler
+// (withAuth(mux, gate, cors)); the static branch deliberately sits OUTSIDE it so
+// the shell loads with no token.
+func webShellHandler(api http.Handler) http.Handler {
+	assets := web.Dist()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The API namespace (REST mirror, WS stream, WS events) is entirely under
+		// /v1/. Route it to the authed handler so token enforcement, CORS, and the
+		// mux's own routing/404 are all preserved verbatim. Everything else is the
+		// web app.
+		if strings.HasPrefix(r.URL.Path, "/v1/") {
+			api.ServeHTTP(w, r)
+			return
+		}
+		serveSPA(assets, w, r)
+	})
+}
+
+// serveSPA serves the embedded web client for a non-API request. It serves the
+// concrete asset when the path names a real embedded file, and falls back to
+// index.html for any other path so browser-side client routing works (an unknown
+// /path deep-link renders the app, not a 404). The static shell is
+// unauthenticated by design (§1.2); the CSP header is set on every response so
+// the self-contained guarantee is enforced by the browser.
+func serveSPA(assets fs.FS, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		writeHTTPError(w, http.StatusMethodNotAllowed,
+			fmt.Errorf("method %s not allowed for %q; use GET", r.Method, r.URL.Path))
+		return
+	}
+	w.Header().Set("Content-Security-Policy", webCSP)
+	// nosniff pairs with the CSP: the browser must honor the declared
+	// Content-Type (set by serveAsset from the extension) and never sniff a
+	// JS/HTML bundle into a different type.
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	name := path.Clean(strings.TrimPrefix(r.URL.Path, "/"))
+	if name == "" || name == "." {
+		name = "index.html"
+	}
+	// path.Clean strips any ".." traversal to a rooted-relative name, but a
+	// leading "/" or residual ".." would make fs.FS.Open reject the path; guard
+	// explicitly so a hostile path deterministically falls back to the shell
+	// rather than erroring.
+	if name == ".." || strings.HasPrefix(name, "../") || strings.HasPrefix(name, "/") {
+		name = "index.html"
+	}
+
+	if serveAsset(assets, name, w, r) {
+		return
+	}
+	// SPA fallback: the path names no embedded asset, so serve the app shell for
+	// client-side routing.
+	serveAsset(assets, "index.html", w, r)
+}
+
+// serveAsset writes the embedded file named `name` and returns true, or returns
+// false without writing if the name does not resolve to a regular file (missing,
+// or a directory) so the caller can fall back to the shell. The asset bytes are
+// small (a bundle + a page), so reading them whole and handing http.ServeContent
+// a bytes.Reader is simpler than plumbing a Seeker and gives correct
+// Content-Type/HEAD/Range handling for free.
+func serveAsset(assets fs.FS, name string, w http.ResponseWriter, r *http.Request) bool {
+	f, err := assets.Open(name)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil || info.IsDir() {
+		return false
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return false
+	}
+	// Zero modtime → ServeContent emits no Last-Modified and does no caching
+	// negotiation; it still infers Content-Type from the extension and handles
+	// HEAD. The assets are embedded and versioned with the binary, so per-file
+	// modtimes carry no meaning.
+	http.ServeContent(w, r, name, time.Time{}, bytes.NewReader(data))
+	return true
+}

--- a/daemon/webserve_test.go
+++ b/daemon/webserve_test.go
@@ -1,0 +1,109 @@
+package daemon
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// apiSpy stands in for the authed API handler webShellHandler wraps. It records
+// that a request reached it and answers 200, so a test can assert which paths are
+// routed to the API branch (token-gated) vs the static SPA branch.
+type apiSpy struct{ reached bool }
+
+func (s *apiSpy) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	s.reached = true
+	w.Header().Set("X-Api-Reached", "1")
+	w.WriteHeader(http.StatusOK)
+}
+
+// TestWebShellHandler_RoutesApiVsStatic pins the auth split (#1592 Phase 5 PR2):
+// /v1/... flows to the authed API handler untouched, while every other path is
+// served the embedded SPA WITHOUT reaching the API — so the static shell needs no
+// token but the data plane stays gated.
+func TestWebShellHandler_RoutesApiVsStatic(t *testing.T) {
+	spy := &apiSpy{}
+	srv := httptest.NewServer(webShellHandler(spy))
+	defer srv.Close()
+
+	// /v1/ is routed to the API handler.
+	spy.reached = false
+	resp, err := http.Get(srv.URL + "/v1/Snapshot")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.True(t, spy.reached, "/v1/ path must reach the authed API handler")
+	require.Equal(t, "1", resp.Header.Get("X-Api-Reached"))
+	// The API branch must NOT carry the static CSP — that is set only on the shell.
+	require.Empty(t, resp.Header.Get("Content-Security-Policy"))
+
+	// A non-/v1 path is served the SPA and never touches the API handler.
+	spy.reached = false
+	resp, err = http.Get(srv.URL + "/")
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.False(t, spy.reached, "static path must not reach the API handler")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, string(body), `id="app"`, "/ must serve the index.html shell")
+}
+
+// TestServeSPA_StaticAssetsAndFallback covers the static branch: the CSP + nosniff
+// headers, concrete-asset serving with the right content type, and the SPA
+// fallback to index.html for unknown deep-link paths.
+func TestServeSPA_StaticAssetsAndFallback(t *testing.T) {
+	srv := httptest.NewServer(webShellHandler(&apiSpy{}))
+	defer srv.Close()
+
+	// The bundled JS asset: served with the CSP + a JS content type.
+	resp, err := http.Get(srv.URL + "/af-web.js")
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "default-src 'self'", resp.Header.Get("Content-Security-Policy"))
+	require.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+	require.Contains(t, resp.Header.Get("Content-Type"), "javascript")
+	require.NotEmpty(t, body)
+
+	// The extracted CSS asset exists and is served with a CSS content type.
+	resp, err = http.Get(srv.URL + "/af-web.css")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, resp.Header.Get("Content-Type"), "css")
+
+	// An unknown deep link falls back to the index.html shell (client-side routing),
+	// still with the CSP set.
+	resp, err = http.Get(srv.URL + "/sessions/deadbeef")
+	require.NoError(t, err)
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "default-src 'self'", resp.Header.Get("Content-Security-Policy"))
+	require.Contains(t, string(body), `id="app"`, "unknown path must fall back to index.html")
+
+	// A path traversal attempt is contained: it resolves to the shell, never
+	// escapes the embed root.
+	resp, err = http.Get(srv.URL + "/../../etc/passwd")
+	require.NoError(t, err)
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, string(body), `id="app"`)
+}
+
+// TestServeSPA_RejectsNonGet pins that the static branch only answers GET/HEAD; a
+// mutating verb on a non-API path is a 405, not a silent index.html.
+func TestServeSPA_RejectsNonGet(t *testing.T) {
+	srv := httptest.NewServer(webShellHandler(&apiSpy{}))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/", "text/plain", strings.NewReader("x"))
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}

--- a/web/build.mjs
+++ b/web/build.mjs
@@ -1,12 +1,19 @@
 // esbuild build for the Agent Factory web client (#1592 Phase 5).
 //
 // esbuild is a single fast bundler (the locked toolchain choice, design §3.1). It
-// bundles src/index.ts into a self-contained ESM file under dist/. The built dist/
-// is COMMITTED (locked decision) so `go build ./...` and the Go test suite never
-// need Node — the JS toolchain is gated entirely behind `make web-*`. Later PRs add
-// the SPA (xterm.js, sidebar, modals) and go:embed dist/ into the daemon; PR1 ships
-// only the wire-frame codec so the bundle is tiny.
+// bundles src/index.ts into a self-contained ESM file under dist/, and — because
+// index.ts imports styles.css — extracts the CSS into a sibling dist/af-web.css.
+// The static index.html shell is copied verbatim into dist/ so the whole served
+// tree lives under one committed directory the daemon go:embeds.
+//
+// The built dist/ is COMMITTED (locked decision) so `go build ./...` and the Go
+// test suite never need Node — the JS toolchain is gated entirely behind
+// `make web-*`. The build is deterministic: a rebuild reproduces the committed
+// bytes (the reproducibility gate).
 import { build } from "esbuild";
+import { copyFile, mkdir } from "node:fs/promises";
+
+await mkdir("dist", { recursive: true });
 
 await build({
   entryPoints: ["src/index.ts"],
@@ -19,3 +26,7 @@ await build({
   minify: false,
   logLevel: "info",
 });
+
+// The HTML shell is not an esbuild input (it references the bundle by URL), so
+// copy it into the embed root alongside the built JS/CSS.
+await copyFile("src/index.html", "dist/index.html");

--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -1,0 +1,158 @@
+/* src/styles.css */
+:root {
+  --af-bg: #0d1117;
+  --af-surface: #161b22;
+  --af-border: #30363d;
+  --af-text: #e6edf3;
+  --af-muted: #8b949e;
+  --af-accent: #2f81f7;
+  --af-accent-text: #ffffff;
+  --af-error: #f85149;
+  --af-radius: 8px;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    "SF Mono",
+    Menlo,
+    Consolas,
+    monospace;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--af-bg);
+  color: var(--af-text);
+}
+#app {
+  min-height: 100vh;
+}
+.af-login {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+.af-card {
+  width: 100%;
+  max-width: 26rem;
+  background: var(--af-surface);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-radius);
+  padding: 2rem;
+}
+.af-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+.af-subtitle {
+  margin: 0 0 1.5rem;
+  color: var(--af-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+.af-subtitle code {
+  color: var(--af-text);
+  background: var(--af-bg);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+.af-login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.af-field-label {
+  font-size: 0.75rem;
+  color: var(--af-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.af-login-form input {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  background: var(--af-bg);
+  border: 1px solid var(--af-border);
+  border-radius: 6px;
+  color: var(--af-text);
+  font: inherit;
+  font-size: 0.9rem;
+}
+.af-login-form input:focus {
+  outline: none;
+  border-color: var(--af-accent);
+}
+.af-primary {
+  margin-top: 0.4rem;
+  padding: 0.65rem 0.75rem;
+  background: var(--af-accent);
+  color: var(--af-accent-text);
+  border: none;
+  border-radius: 6px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+.af-primary:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.af-error {
+  margin: 1rem 0 0;
+  color: var(--af-error);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+.af-app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.af-appbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.25rem;
+  background: var(--af-surface);
+  border-bottom: 1px solid var(--af-border);
+}
+.af-brand {
+  font-weight: 600;
+}
+.af-ghost {
+  padding: 0.4rem 0.75rem;
+  background: transparent;
+  color: var(--af-muted);
+  border: 1px solid var(--af-border);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+.af-ghost:hover {
+  color: var(--af-text);
+  border-color: var(--af-muted);
+}
+.af-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 2rem;
+  text-align: center;
+}
+.af-empty-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+.af-empty-hint {
+  margin: 0;
+  color: var(--af-muted);
+  font-size: 0.85rem;
+}

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -1,119 +1,209 @@
-// src/frame.ts
-var Op = /* @__PURE__ */ ((Op2) => {
-  Op2[Op2["PTYOut"] = 0] = "PTYOut";
-  Op2[Op2["Input"] = 1] = "Input";
-  Op2[Op2["Resize"] = 2] = "Resize";
-  Op2[Op2["Repaint"] = 3] = "Repaint";
-  Op2[Op2["Hello"] = 4] = "Hello";
-  return Op2;
-})(Op || {});
-var RESIZE_PAYLOAD_LEN = 4;
-var HELLO_PAYLOAD_LEN = 8;
-var EMPTY = new Uint8Array(0);
-function makeFrame(f) {
-  return {
-    op: f.op,
-    data: f.data ?? EMPTY,
-    rows: f.rows ?? 0,
-    cols: f.cols ?? 0,
-    seq: f.seq ?? 0n
-  };
+// src/api.ts
+var TOKEN_KEY = "af.token";
+function loadToken() {
+  return sessionStorage.getItem(TOKEN_KEY);
 }
-function ptyOutFrame(data) {
-  return makeFrame({ op: 0 /* PTYOut */, data });
+function storeToken(token) {
+  sessionStorage.setItem(TOKEN_KEY, token);
 }
-function inputFrame(data) {
-  return makeFrame({ op: 1 /* Input */, data });
+function clearToken() {
+  sessionStorage.removeItem(TOKEN_KEY);
 }
-function repaintFrame(data) {
-  return makeFrame({ op: 3 /* Repaint */, data });
-}
-function resizeFrame(rows, cols) {
-  return makeFrame({ op: 2 /* Resize */, rows, cols });
-}
-function helloFrame(seq) {
-  return makeFrame({ op: 4 /* Hello */, seq });
-}
-function encode(f) {
-  switch (f.op) {
-    case 2 /* Resize */: {
-      const out = new Uint8Array(1 + RESIZE_PAYLOAD_LEN);
-      out[0] = 2 /* Resize */;
-      const dv = new DataView(out.buffer);
-      dv.setUint16(1, f.rows, false);
-      dv.setUint16(3, f.cols, false);
-      return out;
-    }
-    case 4 /* Hello */: {
-      const out = new Uint8Array(1 + HELLO_PAYLOAD_LEN);
-      out[0] = 4 /* Hello */;
-      const dv = new DataView(out.buffer);
-      dv.setBigUint64(1, f.seq, false);
-      return out;
-    }
-    default: {
-      const out = new Uint8Array(1 + f.data.length);
-      out[0] = f.op;
-      out.set(f.data, 1);
-      return out;
-    }
+var ApiError = class extends Error {
+  status;
+  constructor(status, message) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
   }
-}
-function decode(raw) {
-  if (raw.length === 0) {
-    throw new Error("agentproto: empty binary frame");
-  }
-  const op = raw[0];
-  const body = raw.subarray(1);
-  switch (op) {
-    case 0 /* PTYOut */:
-    case 1 /* Input */:
-    case 3 /* Repaint */:
-      return makeFrame({ op, data: body.slice() });
-    case 2 /* Resize */: {
-      if (body.length !== RESIZE_PAYLOAD_LEN) {
-        throw new Error(`agentproto: RESIZE frame body is ${body.length} bytes, want ${RESIZE_PAYLOAD_LEN}`);
-      }
-      const dv = new DataView(body.buffer, body.byteOffset, body.byteLength);
-      return makeFrame({ op, rows: dv.getUint16(0, false), cols: dv.getUint16(2, false) });
-    }
-    case 4 /* Hello */: {
-      if (body.length !== HELLO_PAYLOAD_LEN) {
-        throw new Error(`agentproto: HELLO frame body is ${body.length} bytes, want ${HELLO_PAYLOAD_LEN}`);
-      }
-      const dv = new DataView(body.buffer, body.byteOffset, body.byteLength);
-      return makeFrame({ op, seq: dv.getBigUint64(0, false) });
-    }
-    default:
-      throw new Error(`agentproto: unknown opcode 0x${op.toString(16).padStart(2, "0")}`);
-  }
-}
-function opName(op) {
-  switch (op) {
-    case 0 /* PTYOut */:
-      return "PTY_OUT";
-    case 1 /* Input */:
-      return "INPUT";
-    case 2 /* Resize */:
-      return "RESIZE";
-    case 3 /* Repaint */:
-      return "REPAINT";
-    case 4 /* Hello */:
-      return "HELLO";
-    default:
-      return `Opcode(0x${op.toString(16).padStart(2, "0")})`;
-  }
-}
-export {
-  HELLO_PAYLOAD_LEN,
-  Op,
-  RESIZE_PAYLOAD_LEN,
-  decode,
-  encode,
-  helloFrame,
-  inputFrame,
-  opName,
-  ptyOutFrame,
-  repaintFrame,
-  resizeFrame
 };
+async function af(method, body, token) {
+  let resp;
+  try {
+    resp = await fetch(`/v1/${method}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(body ?? {})
+    });
+  } catch (e) {
+    throw new ApiError(0, `cannot reach the daemon: ${e.message}`);
+  }
+  let env = null;
+  try {
+    env = await resp.json();
+  } catch {
+  }
+  if (!resp.ok) {
+    throw new ApiError(resp.status, env?.error ?? `${resp.status} ${resp.statusText}`);
+  }
+  if (env && env.error !== null) {
+    throw new ApiError(resp.status, env.error);
+  }
+  return env?.data;
+}
+function probeToken(token) {
+  return af("Snapshot", { repo_id: "" }, token);
+}
+
+// src/store.ts
+var Store = class {
+  state;
+  listeners = /* @__PURE__ */ new Set();
+  constructor(initial) {
+    this.state = initial;
+  }
+  /** The current immutable snapshot of state. */
+  get() {
+    return this.state;
+  }
+  /** Merges a partial update and notifies every subscriber with the new state. */
+  set(patch) {
+    this.state = { ...this.state, ...patch };
+    for (const listener of this.listeners) {
+      listener(this.state);
+    }
+  }
+  /** Registers a listener and returns an unsubscribe function. */
+  subscribe(listener) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+};
+
+// src/ui.ts
+function h(tag, props = {}, ...children) {
+  const el = document.createElement(tag);
+  for (const [key, value] of Object.entries(props)) {
+    if (key === "class") {
+      el.className = value;
+    } else {
+      el[key] = value;
+    }
+  }
+  for (const child of children) {
+    el.append(child);
+  }
+  return el;
+}
+function render(root, state, actions) {
+  root.replaceChildren(state.phase === "login" ? loginView(state, actions) : appView(actions));
+}
+function loginView(state, actions) {
+  const input = h("input", {
+    type: "password",
+    id: "af-token",
+    placeholder: "Paste your daemon token",
+    autocomplete: "off",
+    disabled: state.connecting
+  });
+  input.setAttribute("aria-label", "Daemon bearer token");
+  const button = h(
+    "button",
+    { type: "submit", class: "af-primary", disabled: state.connecting },
+    state.connecting ? "Connecting\u2026" : "Connect"
+  );
+  const form = h(
+    "form",
+    { class: "af-login-form" },
+    h("label", { class: "af-field-label", htmlFor: "af-token" }, "Daemon token"),
+    input,
+    button
+  );
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const token = input.value.trim();
+    if (token !== "") {
+      actions.connect(token);
+    }
+  });
+  const children = [
+    h("h1", { class: "af-title" }, "Agent Factory"),
+    h(
+      "p",
+      { class: "af-subtitle" },
+      "Paste the daemon bearer token to connect. Get it from ",
+      h("code", {}, "af token show"),
+      " on the host."
+    ),
+    form
+  ];
+  if (state.loginError) {
+    children.push(h("p", { class: "af-error", role: "alert" }, state.loginError));
+  }
+  return h("main", { class: "af-login" }, h("div", { class: "af-card" }, ...children));
+}
+function appView(actions) {
+  const disconnect2 = h("button", { type: "button", class: "af-ghost" }, "Disconnect");
+  disconnect2.addEventListener("click", () => actions.disconnect());
+  const header = h(
+    "header",
+    { class: "af-appbar" },
+    h("span", { class: "af-brand" }, "Agent Factory"),
+    disconnect2
+  );
+  const body = h(
+    "section",
+    { class: "af-empty" },
+    h("p", { class: "af-empty-title" }, "Connected."),
+    h("p", { class: "af-empty-hint" }, "The session list and terminal arrive in the next update.")
+  );
+  return h("main", { class: "af-app" }, header, body);
+}
+
+// src/index.ts
+var store = new Store({
+  phase: "login",
+  connecting: false,
+  loginError: null
+});
+function mount() {
+  const root = document.getElementById("app");
+  if (!root) {
+    throw new Error("af-web: #app root element missing from index.html");
+  }
+  const rerender = () => render(root, store.get(), { connect, disconnect });
+  store.subscribe(rerender);
+  rerender();
+  const existing = loadToken();
+  if (existing) {
+    void connect(existing);
+  }
+}
+async function connect(token) {
+  store.set({ connecting: true, loginError: null });
+  try {
+    await probeToken(token);
+  } catch (e) {
+    clearToken();
+    store.set({ phase: "login", connecting: false, loginError: describeError(e) });
+    return;
+  }
+  storeToken(token);
+  store.set({ phase: "app", connecting: false, loginError: null });
+}
+function disconnect() {
+  clearToken();
+  store.set({ phase: "login", connecting: false, loginError: null });
+}
+function describeError(e) {
+  if (e instanceof ApiError) {
+    if (e.status === 401) {
+      return "That token was rejected. Check `af token show` on the host and try again.";
+    }
+    if (e.status === 0) {
+      return `Couldn't reach the daemon. Confirm the listener address and TLS, then retry. (${e.message})`;
+    }
+    return `Login failed: ${e.message}`;
+  }
+  return `Login failed: ${e.message}`;
+}
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", mount, { once: true });
+} else {
+  mount();
+}

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Agent Factory</title>
+    <!-- Same-origin bundle only: the daemon serves this shell with a strict
+         `Content-Security-Policy: default-src 'self'` (#1592 Phase 5 PR2), so the
+         stylesheet and script are loaded from the origin, never a CDN. -->
+    <link rel="stylesheet" href="/af-web.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/af-web.js"></script>
+  </body>
+</html>

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,34 @@
+// Package web embeds the built browser web client (#1592 Phase 5) into the af
+// binary so the daemon can serve a self-contained SPA over its TLS TCP listener
+// with no external assets and no Node toolchain at `go build` time.
+//
+// The committed web/dist/ tree (the esbuild bundle + the index.html shell +
+// the extracted CSS, produced by `make web-build`, design §1.3/§3.3) is the sole
+// embed root. Keeping dist/ committed means `go build ./...` and the Go test
+// suite never need Node — the JS toolchain is gated entirely behind `make web-*`.
+//
+// This package is a pure leaf: it embeds assets and exposes them as an fs.FS. All
+// serving, routing, and the auth/CSP policy live in the daemon (daemon/webserve.go),
+// which composes this FS behind the same token gate the API rides.
+package web
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed dist
+var distFS embed.FS
+
+// Dist returns the embedded built web assets rooted at dist/, so "index.html"
+// and "af-web.js" are top-level names. The dist/ tree is committed, so the
+// fs.Sub can only fail on a build-time embed bug (a missing dist/ directory),
+// which is a programmer error worth panicking on rather than threading an error
+// through every serving call site.
+func Dist() fs.FS {
+	sub, err := fs.Sub(distFS, "dist")
+	if err != nil {
+		panic("web: embedded dist/ missing (run `make web-build`): " + err.Error())
+	}
+	return sub
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,0 +1,106 @@
+// The REST layer of the web client (#1592 Phase 5). It is the browser analogue of
+// the Go apiclient: one af<T>() helper that POSTs /v1/<Method>, attaches the
+// bearer token, and unwraps the shared {data,error} envelope (apiproto/envelope.go)
+// so every call site gets uniform error handling. The daemon API is the contract;
+// this file must not fork it.
+//
+// Token handling is deliberately minimal and lives here so there is ONE place that
+// knows the credential: it is kept in sessionStorage (survives reload within the
+// tab, gone on tab-close — design §1.2, a deliberate "don't persist a full-access
+// credential to disk" posture) and attached as `Authorization: Bearer` on every
+// request. The WS `?access_token=` fallback (browsers cannot set WS headers) lands
+// with the terminal in PR4.
+
+const TOKEN_KEY = "af.token";
+
+/** Reads the stored bearer token for this tab, or null if none is set. */
+export function loadToken(): string | null {
+  return sessionStorage.getItem(TOKEN_KEY);
+}
+
+/** Persists the bearer token for this tab (sessionStorage, not localStorage). */
+export function storeToken(token: string): void {
+  sessionStorage.setItem(TOKEN_KEY, token);
+}
+
+/** Forgets the stored token (logout / failed probe). */
+export function clearToken(): void {
+  sessionStorage.removeItem(TOKEN_KEY);
+}
+
+/** The shared REST envelope every /v1/ route returns (apiproto/envelope.go). */
+interface Envelope<T> {
+  data: T | null;
+  error: string | null;
+}
+
+/**
+ * A failed API call. `status` is the HTTP status (0 for a network/transport
+ * failure) so callers can distinguish 401-unauthorized from a genuine error.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+/**
+ * POSTs /v1/<method> with the given JSON body and bearer token, then unwraps the
+ * {data,error} envelope. Throws ApiError on a non-2xx status, on an envelope with
+ * a non-null error, or on a transport failure — mirroring apiclient.call so the
+ * whole client shares one error path.
+ */
+export async function af<T>(method: string, body: unknown, token: string): Promise<T> {
+  let resp: Response;
+  try {
+    resp = await fetch(`/v1/${method}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body ?? {}),
+    });
+  } catch (e) {
+    // A TypeError from fetch is a transport failure (daemon down, TLS rejected,
+    // wrong host). Surface it as status 0 with an actionable message.
+    throw new ApiError(0, `cannot reach the daemon: ${(e as Error).message}`);
+  }
+
+  // Parse the envelope regardless of status so a structured error message wins
+  // over the bare status line when the daemon sent one.
+  let env: Envelope<T> | null = null;
+  try {
+    env = (await resp.json()) as Envelope<T>;
+  } catch {
+    // Non-JSON body (unlikely from /v1/): fall through to the status-based error.
+  }
+
+  if (!resp.ok) {
+    throw new ApiError(resp.status, env?.error ?? `${resp.status} ${resp.statusText}`);
+  }
+  if (env && env.error !== null) {
+    throw new ApiError(resp.status, env.error);
+  }
+  return env?.data as T;
+}
+
+/** The Snapshot response shape the login probe reads (daemon/snapshot.go). Only
+ *  the fields the shell needs are declared; PR3 grows the session projection. */
+export interface SnapshotResponse {
+  instances: unknown[];
+  delivery_alarms?: unknown[];
+}
+
+/**
+ * Validates a token by probing an authed endpoint with it. Snapshot is the auth
+ * check (design §1.2): a 200 means the token is accepted; a 401 means it is not.
+ * Returns the snapshot on success so the caller can seed the app; throws ApiError
+ * otherwise.
+ */
+export function probeToken(token: string): Promise<SnapshotResponse> {
+  return af<SnapshotResponse>("Snapshot", { repo_id: "" }, token);
+}

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Agent Factory</title>
+    <!-- Same-origin bundle only: the daemon serves this shell with a strict
+         `Content-Security-Policy: default-src 'self'` (#1592 Phase 5 PR2), so the
+         stylesheet and script are loaded from the origin, never a CDN. -->
+    <link rel="stylesheet" href="/af-web.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/af-web.js"></script>
+  </body>
+</html>

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,5 +1,77 @@
-// Entry point for the Phase-5 web client bundle (#1592). This PR ships only the
-// protocol foundation — the wire-frame codec — so the bundle re-exports it and has
-// no UI yet (xterm.js, the sidebar, and serving arrive in PR2+). esbuild bundles
-// this into the committed dist/ that the daemon will later go:embed and serve.
-export * from "./frame.js";
+// Entry point for the Agent Factory web client (#1592 Phase 5). This PR (PR2)
+// wires the serving shell + token login: load the page → paste the daemon token →
+// probe an authed endpoint → on success render the authed (empty) app, on failure
+// show an actionable error. The sidebar, terminal, and modals land in PR3+.
+//
+// The bundle is fully self-contained (esbuild output + the imported CSS, no CDN,
+// no off-origin fetch) so the daemon's `Content-Security-Policy: default-src
+// 'self'` holds — the only network calls are same-origin /v1/ requests.
+
+import "./styles.css";
+import { ApiError, clearToken, loadToken, probeToken, storeToken } from "./api.js";
+import { Store } from "./store.js";
+import { render, type AppState } from "./ui.js";
+
+const store = new Store<AppState>({
+  phase: "login",
+  connecting: false,
+  loginError: null,
+});
+
+function mount(): void {
+  const root = document.getElementById("app");
+  if (!root) {
+    throw new Error("af-web: #app root element missing from index.html");
+  }
+  const rerender = () => render(root, store.get(), { connect, disconnect });
+  store.subscribe(rerender);
+  rerender();
+
+  // Resume within the tab: sessionStorage keeps the token across a reload, so a
+  // returning tab re-probes it silently and skips the login form on success.
+  const existing = loadToken();
+  if (existing) {
+    void connect(existing);
+  }
+}
+
+/** Validates the token (Snapshot probe), and on success persists it and shows the
+ *  app; on failure clears it and surfaces an actionable error on the login view. */
+async function connect(token: string): Promise<void> {
+  store.set({ connecting: true, loginError: null });
+  try {
+    await probeToken(token);
+  } catch (e) {
+    clearToken();
+    store.set({ phase: "login", connecting: false, loginError: describeError(e) });
+    return;
+  }
+  storeToken(token);
+  store.set({ phase: "app", connecting: false, loginError: null });
+}
+
+/** Forgets the token and returns to the login view. */
+function disconnect(): void {
+  clearToken();
+  store.set({ phase: "login", connecting: false, loginError: null });
+}
+
+/** Turns a probe failure into a message that tells the operator what to fix. */
+function describeError(e: unknown): string {
+  if (e instanceof ApiError) {
+    if (e.status === 401) {
+      return "That token was rejected. Check `af token show` on the host and try again.";
+    }
+    if (e.status === 0) {
+      return `Couldn't reach the daemon. Confirm the listener address and TLS, then retry. (${e.message})`;
+    }
+    return `Login failed: ${e.message}`;
+  }
+  return `Login failed: ${(e as Error).message}`;
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", mount, { once: true });
+} else {
+  mount();
+}

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1,0 +1,38 @@
+// A tiny observable store (#1592 Phase 5, design §3.1). It is the browser analogue
+// of the TUI's read-only projection: a plain object updated in one place, with
+// subscriber callbacks that re-render the affected DOM. No framework runtime — the
+// surface is small enough that a ~20-line store beats a dependency we go:embed into
+// every binary. PR3+ replaces the placeholder session state with the live
+// SnapshotResponse mirror fed by /v1/events.
+
+export type Listener<T> = (state: T) => void;
+
+export class Store<T> {
+  private state: T;
+  private readonly listeners = new Set<Listener<T>>();
+
+  constructor(initial: T) {
+    this.state = initial;
+  }
+
+  /** The current immutable snapshot of state. */
+  get(): T {
+    return this.state;
+  }
+
+  /** Merges a partial update and notifies every subscriber with the new state. */
+  set(patch: Partial<T>): void {
+    this.state = { ...this.state, ...patch };
+    for (const listener of this.listeners) {
+      listener(this.state);
+    }
+  }
+
+  /** Registers a listener and returns an unsubscribe function. */
+  subscribe(listener: Listener<T>): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,183 @@
+/* Web client shell styles (#1592 Phase 5 PR2). Imported by index.ts so esbuild
+ * extracts it into dist/af-web.css, which index.html links same-origin — keeping
+ * the strict `default-src 'self'` CSP honest (no inline <style>, no CDN fonts).
+ * The palette leans on the TUI's dark terminal aesthetic (design: "base the
+ * website pretty heavily on the TUI"); the full visual pass is a later play-test
+ * PR, so this is a clean, restrained baseline. */
+
+:root {
+  --af-bg: #0d1117;
+  --af-surface: #161b22;
+  --af-border: #30363d;
+  --af-text: #e6edf3;
+  --af-muted: #8b949e;
+  --af-accent: #2f81f7;
+  --af-accent-text: #ffffff;
+  --af-error: #f85149;
+  --af-radius: 8px;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--af-bg);
+  color: var(--af-text);
+}
+
+#app {
+  min-height: 100vh;
+}
+
+/* Login view */
+.af-login {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.af-card {
+  width: 100%;
+  max-width: 26rem;
+  background: var(--af-surface);
+  border: 1px solid var(--af-border);
+  border-radius: var(--af-radius);
+  padding: 2rem;
+}
+
+.af-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.af-subtitle {
+  margin: 0 0 1.5rem;
+  color: var(--af-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.af-subtitle code {
+  color: var(--af-text);
+  background: var(--af-bg);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+}
+
+.af-login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.af-field-label {
+  font-size: 0.75rem;
+  color: var(--af-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.af-login-form input {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  background: var(--af-bg);
+  border: 1px solid var(--af-border);
+  border-radius: 6px;
+  color: var(--af-text);
+  font: inherit;
+  font-size: 0.9rem;
+}
+
+.af-login-form input:focus {
+  outline: none;
+  border-color: var(--af-accent);
+}
+
+.af-primary {
+  margin-top: 0.4rem;
+  padding: 0.65rem 0.75rem;
+  background: var(--af-accent);
+  color: var(--af-accent-text);
+  border: none;
+  border-radius: 6px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.af-primary:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.af-error {
+  margin: 1rem 0 0;
+  color: var(--af-error);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+/* Authed app shell (empty until PR3) */
+.af-app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.af-appbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.25rem;
+  background: var(--af-surface);
+  border-bottom: 1px solid var(--af-border);
+}
+
+.af-brand {
+  font-weight: 600;
+}
+
+.af-ghost {
+  padding: 0.4rem 0.75rem;
+  background: transparent;
+  color: var(--af-muted);
+  border: 1px solid var(--af-border);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.af-ghost:hover {
+  color: var(--af-text);
+  border-color: var(--af-muted);
+}
+
+.af-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.af-empty-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.af-empty-hint {
+  margin: 0;
+  color: var(--af-muted);
+  font-size: 0.85rem;
+}

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -1,0 +1,121 @@
+// The view layer of the web client shell (#1592 Phase 5 PR2). It renders exactly
+// two views into #app: the paste-token login (design §1.2) and the authed — but
+// still empty — app shell. The session sidebar, terminal, and modals arrive in
+// PR3+; this PR proves the serving + auth handoff with zero session UI.
+//
+// Rendering is direct DOM via a tiny `h()` helper (no framework, design §3.1) and
+// is strictly CSP-safe: no inline scripts, no inline event handlers, no innerHTML
+// with markup — everything is createElement + addEventListener, so the served
+// `Content-Security-Policy: default-src 'self'` holds.
+
+/** The whole client state for PR2: which view to show plus the login details. */
+export interface AppState {
+  phase: "login" | "app";
+  /** true while a token probe is in flight (disables the login form). */
+  connecting: boolean;
+  /** an actionable message shown under the login form after a failed probe. */
+  loginError: string | null;
+}
+
+/** Callbacks the shell invokes; index.ts owns the real behavior. */
+export interface Actions {
+  connect(token: string): void;
+  disconnect(): void;
+}
+
+/** Minimal hyperscript: create an element, apply props, append children. Keeps the
+ *  views declarative without a framework and without innerHTML. */
+function h<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  props: Partial<HTMLElementTagNameMap[K]> & { class?: string } = {},
+  ...children: (Node | string)[]
+): HTMLElementTagNameMap[K] {
+  const el = document.createElement(tag);
+  for (const [key, value] of Object.entries(props)) {
+    if (key === "class") {
+      el.className = value as string;
+    } else {
+      // Assign DOM properties (className, textContent, type, value, disabled…).
+      (el as unknown as Record<string, unknown>)[key] = value;
+    }
+  }
+  for (const child of children) {
+    el.append(child);
+  }
+  return el;
+}
+
+/** Renders the current state into the given root, replacing its contents. */
+export function render(root: HTMLElement, state: AppState, actions: Actions): void {
+  root.replaceChildren(state.phase === "login" ? loginView(state, actions) : appView(actions));
+}
+
+function loginView(state: AppState, actions: Actions): HTMLElement {
+  const input = h("input", {
+    type: "password",
+    id: "af-token",
+    placeholder: "Paste your daemon token",
+    autocomplete: "off",
+    disabled: state.connecting,
+  });
+  input.setAttribute("aria-label", "Daemon bearer token");
+
+  const button = h(
+    "button",
+    { type: "submit", class: "af-primary", disabled: state.connecting },
+    state.connecting ? "Connecting…" : "Connect",
+  );
+
+  const form = h(
+    "form",
+    { class: "af-login-form" },
+    h("label", { class: "af-field-label", htmlFor: "af-token" }, "Daemon token"),
+    input,
+    button,
+  );
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const token = input.value.trim();
+    if (token !== "") {
+      actions.connect(token);
+    }
+  });
+
+  const children: (Node | string)[] = [
+    h("h1", { class: "af-title" }, "Agent Factory"),
+    h(
+      "p",
+      { class: "af-subtitle" },
+      "Paste the daemon bearer token to connect. Get it from ",
+      h("code", {}, "af token show"),
+      " on the host.",
+    ),
+    form,
+  ];
+  if (state.loginError) {
+    children.push(h("p", { class: "af-error", role: "alert" }, state.loginError));
+  }
+
+  return h("main", { class: "af-login" }, h("div", { class: "af-card" }, ...children));
+}
+
+function appView(actions: Actions): HTMLElement {
+  const disconnect = h("button", { type: "button", class: "af-ghost" }, "Disconnect");
+  disconnect.addEventListener("click", () => actions.disconnect());
+
+  const header = h(
+    "header",
+    { class: "af-appbar" },
+    h("span", { class: "af-brand" }, "Agent Factory"),
+    disconnect,
+  );
+
+  const body = h(
+    "section",
+    { class: "af-empty" },
+    h("p", { class: "af-empty-title" }, "Connected."),
+    h("p", { class: "af-empty-hint" }, "The session list and terminal arrive in the next update."),
+  );
+
+  return h("main", { class: "af-app" }, header, body);
+}


### PR DESCRIPTION
## What

Makes the daemon **serve a self-contained browser web client** from its existing TLS TCP listener and adds the **paste-token login**. No session UI yet — this is the milestone that proves the serving + auth model with an authed-but-empty app. PR1 (merged) landed the `web/` TS toolchain, the `frame.ts` codec, and the `OpHello` frame; the sidebar/terminal/modals arrive in PR3–PR5.

Design: `docs/design/phase5-web.md` §1 + §6.1 PR2. Part of **#1592** (multi-backend refactor epic, Phase 5).

## Serving model (`go:embed`, design §1)

- **`web/embed.go`** `go:embed`s the built `web/dist/` tree (esbuild bundle + extracted CSS + `index.html` shell) into the binary; `web.Dist()` exposes it as an `fs.FS`. `dist/` stays committed so `go build ./...` never needs Node.
- **`daemon/webserve.go`** mounts the SPA: `webShellHandler` routes `/v1/...` to the authed API/WS handler **untouched** and serves the embedded static app for every other path, with `index.html` as the **SPA fallback** for unknown deep links (client-side routing). This **replaces the `/` 404 catch-all** on the TCP listener.
- **TCP listener only.** The unix socket keeps its bare mux (whose `/` still 404s), so the web assets never appear on the socket path. Serving stays **opt-in** behind the existing `listen_addr` TLS listener (off by default); **no new config key**.

## The auth split (design §1.2)

The one load-bearing nuance: the **static shell (html/js/css) loads UNAUTHENTICATED** — you can't paste a token into a page that won't render — while **every `/v1/*` and WS call stays token-gated** by the existing `withAuth` verbatim. The static branch sits *outside* the auth gate; the API branch flows through it unchanged.

## CSP

The static handler sets **`Content-Security-Policy: default-src 'self'`** (plus `X-Content-Type-Options: nosniff`). The bundle is fully self-contained — esbuild output, no CDN, no external fonts/scripts, one same-origin `fetch(/v1/…)` — so the strict policy is honest.

## Login (`web/src`, vanilla TS + a tiny store, no framework)

Paste the bearer token → probe `POST /v1/Snapshot` with it → on 200 store it in **`sessionStorage`** (not localStorage, not disk) and render the authed empty app; on 401/failure show an **actionable error**. Subsequent calls attach `Authorization: Bearer`. `make web-build` is reproducible (`index.ts` imports `styles.css` so esbuild emits `dist/af-web.css`; `build.mjs` copies the `index.html` shell into `dist/`).

## Tests

- `daemon/webserve_test.go` — routing split (`/v1` → API, else → SPA), CSP/nosniff headers, asset content-types, SPA fallback, path-traversal containment, 405 on non-GET.
- `daemon/tcpserver_test.go` — TLS integration: the shell is served unauthenticated **with** the CSP header while `/v1/health` stays **401 without** a token and **200 with**.

## Play-test transcript

Real daemon on a TLS listener (`listen_addr = 127.0.0.1:18443`), isolated `AGENT_FACTORY_HOME`:

**curl — auth split + CSP**
~~~
$ curl -sk https://127.0.0.1:18443/                      # NO token
HTTP 200  → served index.html (<div id="app"></div>)
   Content-Security-Policy: default-src 'self'
   X-Content-Type-Options: nosniff

$ curl -sk https://127.0.0.1:18443/af-web.js             # NO token
HTTP 200  Content-Type: text/javascript   (+ CSP)
$ curl -sk https://127.0.0.1:18443/af-web.css            # NO token
HTTP 200  Content-Type: text/css
$ curl -sk https://127.0.0.1:18443/sessions/deadbeef     # NO token, unknown deep link
HTTP 200  → SPA fallback = index.html
$ curl -sk -X POST https://127.0.0.1:18443/              # NO token
HTTP 405

$ curl -sk -X POST .../v1/Snapshot -d '{"repo_id":""}'   # NO token
HTTP 401  {"data":null,"error":{"message":"unauthorized: missing or invalid bearer token"}}
$ curl -sk -X POST -H "Authorization: Bearer <token>" .../v1/Snapshot -d '{"repo_id":""}'
HTTP 200  {"data":{"instances":[]},"error":null}
$ curl -sk .../v1/health          → no-token: 401 ; with-token: 200
~~~

**Self-containment** — scanning the served `af-web.js`/`.css`/`.html`: zero `http(s)://`/CDN/fonts references; the only wire call is `fetch(/v1/${method})`; HTML links only same-origin `/af-web.css` + `/af-web.js`.

**Headless Chromium — full login flow** (against the running daemon, with a strict off-origin request monitor):
~~~
ok - login view shows the app title
ok - bad token shows actionable error: "That token was rejected. Check `af token show` on the host and try again."
ok - still on login view after a bad token
ok - authed empty app renders after a good token
ok - token stored in sessionStorage
ok - token NOT stored in localStorage
ok - reload resumes the authed app via sessionStorage
ok - disconnect clears the token and returns to login
ok - no off-origin network requests (saw 0)
ok - no CSP violations in console (saw 0)
ALL LOGIN-FLOW CHECKS PASSED
~~~

## Gates

`gofmt -l` clean · `golangci-lint --fast` clean · `deadcode -test ./...` clean · `scripts/lint-file-length.sh` pass · `go build ./...` ok · `make test-container` all green · `make web-build` reproducible (rebuild == committed bytes) · `make web-test` 20/20 + typecheck green · `make tui-driver-selftest` 25/25 (unaffected) · `make docs` no drift.

## Boundaries

No sidebar/session-list/terminal (PR3/PR4). Deletes/replaces only the `/` 404 catch-all (on the TCP listener). TUI + unix-socket + existing HTTP routes unaffected.

Link #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)