### PR TITLE
feat(web): live session sidebar from Snapshot + /v1/events (#1592 Phase 5 PR3)

### DIFF
--- a/web/dist/af-web.css
+++ b/web/dist/af-web.css
@@ -9,6 +9,12 @@
   --af-accent-text: #ffffff;
   --af-error: #f85149;
   --af-radius: 8px;
+  --af-dot-ready: #7f9f7f;
+  --af-dot-lost: #f0dfaf;
+  --af-dot-dead: #989890;
+  --af-dot-archived: #989890;
+  --af-dot-limit: #cc9393;
+  --af-dot-working: #e6edf3;
   font-family:
     ui-monospace,
     SFMono-Regular,
@@ -108,20 +114,44 @@ body {
   line-height: 1.4;
 }
 .af-app {
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
 }
 .af-appbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 1rem;
   padding: 0.75rem 1.25rem;
   background: var(--af-surface);
   border-bottom: 1px solid var(--af-border);
 }
 .af-brand {
   font-weight: 600;
+}
+.af-appbar .af-live {
+  margin-left: auto;
+}
+.af-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--af-muted);
+}
+.af-live-pip {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--af-muted);
+}
+.af-live-pip.af-live-open {
+  background: var(--af-dot-ready);
+}
+.af-live-pip.af-live-connecting,
+.af-live-pip.af-live-reconnecting {
+  background: var(--af-dot-lost);
+  animation: af-pulse 1.2s ease-in-out infinite;
 }
 .af-ghost {
   padding: 0.4rem 0.75rem;
@@ -137,10 +167,139 @@ body {
   color: var(--af-text);
   border-color: var(--af-muted);
 }
-.af-empty {
+.af-body {
   flex: 1;
   display: flex;
+  min-height: 0;
+}
+.af-rail {
+  width: 18rem;
+  flex: 0 0 18rem;
+  border-right: 1px solid var(--af-border);
+  background: var(--af-surface);
+  display: flex;
   flex-direction: column;
+  min-height: 0;
+}
+.af-rail-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid var(--af-border);
+}
+.af-rail-title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--af-muted);
+}
+.af-rail-count {
+  font-size: 0.75rem;
+  color: var(--af-muted);
+  background: var(--af-bg);
+  border: 1px solid var(--af-border);
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+}
+.af-rail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem;
+  overflow-y: auto;
+  flex: 1;
+}
+.af-rail-empty {
+  padding: 1rem 0.75rem;
+  color: var(--af-muted);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+.af-rail-empty code {
+  color: var(--af-text);
+}
+.af-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.af-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+.af-row-selected {
+  background: rgba(47, 129, 247, 0.16);
+}
+.af-row-selected:hover {
+  background: rgba(47, 129, 247, 0.22);
+}
+.af-row-archived {
+  opacity: 0.55;
+}
+.af-row-main {
+  min-width: 0;
+  flex: 1;
+}
+.af-row-title {
+  font-size: 0.85rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.af-row-branch {
+  margin-top: 0.15rem;
+  font-size: 0.72rem;
+  color: var(--af-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.af-branch-icon {
+  opacity: 0.8;
+}
+.af-dot {
+  flex: 0 0 auto;
+  line-height: 1.4;
+  font-size: 0.8rem;
+}
+.af-dot-ready {
+  color: var(--af-dot-ready);
+}
+.af-dot-lost {
+  color: var(--af-dot-lost);
+}
+.af-dot-dead {
+  color: var(--af-dot-dead);
+}
+.af-dot-archived {
+  color: var(--af-dot-archived);
+}
+.af-dot-limit {
+  color: var(--af-dot-limit);
+}
+.af-dot-working {
+  color: var(--af-dot-working);
+}
+.af-dot-spin {
+  animation: af-pulse 1.1s ease-in-out infinite;
+}
+@keyframes af-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+.af-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.af-main-empty {
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
@@ -155,4 +314,16 @@ body {
   margin: 0;
   color: var(--af-muted);
   font-size: 0.85rem;
+}
+@media (max-width: 640px) {
+  .af-body {
+    flex-direction: column;
+  }
+  .af-rail {
+    width: 100%;
+    flex: 0 0 auto;
+    max-height: 45vh;
+    border-right: none;
+    border-bottom: 1px solid var(--af-border);
+  }
 }

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -3,8 +3,8 @@ var TOKEN_KEY = "af.token";
 function loadToken() {
   return sessionStorage.getItem(TOKEN_KEY);
 }
-function storeToken(token) {
-  sessionStorage.setItem(TOKEN_KEY, token);
+function storeToken(token2) {
+  sessionStorage.setItem(TOKEN_KEY, token2);
 }
 function clearToken() {
   sessionStorage.removeItem(TOKEN_KEY);
@@ -17,14 +17,14 @@ var ApiError = class extends Error {
     this.status = status;
   }
 };
-async function af(method, body, token) {
+async function af(method, body, token2) {
   let resp;
   try {
     resp = await fetch(`/v1/${method}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`
+        Authorization: `Bearer ${token2}`
       },
       body: JSON.stringify(body ?? {})
     });
@@ -44,8 +44,148 @@ async function af(method, body, token) {
   }
   return env?.data;
 }
-function probeToken(token) {
-  return af("Snapshot", { repo_id: "" }, token);
+async function fetchSnapshot(token2) {
+  const resp = await af("Snapshot", { repo_id: "" }, token2);
+  return resp.instances ?? [];
+}
+function probeToken(token2) {
+  return fetchSnapshot(token2);
+}
+
+// src/events.ts
+var BACKOFF_BASE_MS = 500;
+var BACKOFF_MAX_MS = 1e4;
+function wsScheme() {
+  return window.location.protocol === "https:" ? "wss:" : "ws:";
+}
+var EventStream = class {
+  constructor(token2, cb) {
+    this.token = token2;
+    this.cb = cb;
+  }
+  ws = null;
+  stopped = false;
+  everOpened = false;
+  retry = 0;
+  reconnectTimer = null;
+  /** Opens the socket and begins delivering events. Idempotent-ish: call once. */
+  start() {
+    this.stopped = false;
+    this.open();
+  }
+  /** Permanently closes the stream and cancels any pending reconnect. */
+  stop() {
+    this.stopped = true;
+    if (this.reconnectTimer !== null) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.onopen = null;
+      this.ws.onmessage = null;
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+  open() {
+    this.cb.onStatus(this.everOpened ? "reconnecting" : "connecting");
+    const url = `${wsScheme()}//${window.location.host}/v1/events?access_token=${encodeURIComponent(this.token)}`;
+    let ws;
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      this.scheduleReconnect();
+      return;
+    }
+    this.ws = ws;
+    ws.onopen = () => {
+      this.retry = 0;
+      const wasReconnect = this.everOpened;
+      this.everOpened = true;
+      this.cb.onStatus("open");
+      if (wasReconnect) {
+        this.cb.onResync();
+      }
+    };
+    ws.onmessage = (e) => {
+      if (typeof e.data !== "string") {
+        return;
+      }
+      let ev;
+      try {
+        ev = JSON.parse(e.data);
+      } catch {
+        return;
+      }
+      if (ev && typeof ev.type === "string") {
+        this.cb.onEvent(ev);
+      }
+    };
+    ws.onclose = () => this.scheduleReconnect();
+    ws.onerror = () => {
+      try {
+        ws.close();
+      } catch {
+      }
+    };
+  }
+  scheduleReconnect() {
+    if (this.stopped || this.reconnectTimer !== null) {
+      return;
+    }
+    this.ws = null;
+    this.cb.onStatus("reconnecting");
+    const delay = Math.min(BACKOFF_BASE_MS * 2 ** this.retry, BACKOFF_MAX_MS);
+    this.retry += 1;
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this.stopped) {
+        this.open();
+      }
+    }, delay);
+  }
+};
+
+// src/sessions.ts
+function upsertSession(list, s) {
+  const i = list.findIndex((x) => x.title === s.title);
+  if (i === -1) {
+    return [...list, s];
+  }
+  const next = list.slice();
+  next[i] = s;
+  return next;
+}
+function removeSession(list, title) {
+  return list.filter((x) => x.title !== title);
+}
+function applyEvent(list, ev) {
+  switch (ev.type) {
+    case "session.created":
+    case "session.updated":
+      if (ev.data && ev.data.title) {
+        return { sessions: upsertSession(list, ev.data), needsResync: false };
+      }
+      return { sessions: list, needsResync: false };
+    case "session.killed":
+      if (ev.data && ev.data.title) {
+        return { sessions: removeSession(list, ev.data.title), needsResync: false };
+      }
+      return { sessions: list, needsResync: false };
+    case "session.archived":
+    case "session.restored":
+      return { sessions: list, needsResync: true };
+    default:
+      return { sessions: list, needsResync: false };
+  }
+}
+function pickSelection(list, current) {
+  if (current && list.some((s) => s.title === current)) {
+    return current;
+  }
+  return null;
 }
 
 // src/store.ts
@@ -75,6 +215,129 @@ var Store = class {
   }
 };
 
+// src/types.ts
+var Liveness = {
+  Unset: 0,
+  Running: 1,
+  Ready: 2,
+  Lost: 3,
+  Dead: 4,
+  Archived: 5,
+  LimitReached: 6
+};
+var InFlightOp = {
+  None: 0,
+  Creating: 1,
+  Killing: 2,
+  Archiving: 3,
+  Restoring: 4
+};
+var Status = {
+  Running: 0,
+  Ready: 1,
+  Loading: 2,
+  Deleting: 3,
+  Dead: 4,
+  Lost: 5,
+  Archived: 6
+};
+
+// src/status.ts
+var READY_GLYPH = "\u25CF";
+var DEAD_GLYPH = "\u25CB";
+var LOST_GLYPH = "\u25CC";
+var ARCHIVED_GLYPH = "\u25A7";
+var LIMIT_GLYPH = "\u25C6";
+var WORKING_GLYPH = "\u25CF";
+var WORKING = { glyph: WORKING_GLYPH, kind: "working", spinning: true, label: "Working" };
+function rowStatus(s) {
+  const op = s.in_flight_op ?? InFlightOp.None;
+  if (op !== InFlightOp.None) {
+    return WORKING;
+  }
+  return dotForLiveness(livenessOf(s));
+}
+function livenessOf(s) {
+  const lv = s.liveness ?? Liveness.Unset;
+  if (lv !== Liveness.Unset) {
+    return lv;
+  }
+  switch (s.status) {
+    case Status.Ready:
+      return Liveness.Ready;
+    case Status.Dead:
+      return Liveness.Dead;
+    case Status.Lost:
+      return Liveness.Lost;
+    case Status.Archived:
+      return Liveness.Archived;
+    // Running and the transient values (Loading/Deleting, which never persist)
+    // fall through to the working dot, matching render.go's LivenessUnset arm.
+    default:
+      return Liveness.Running;
+  }
+}
+function dotForLiveness(lv) {
+  switch (lv) {
+    case Liveness.Ready:
+      return { glyph: READY_GLYPH, kind: "ready", spinning: false, label: "Ready" };
+    case Liveness.Lost:
+      return { glyph: LOST_GLYPH, kind: "lost", spinning: false, label: "Lost" };
+    case Liveness.Dead:
+      return { glyph: DEAD_GLYPH, kind: "dead", spinning: false, label: "Dead" };
+    case Liveness.Archived:
+      return { glyph: ARCHIVED_GLYPH, kind: "archived", spinning: false, label: "Archived" };
+    case Liveness.LimitReached:
+      return { glyph: LIMIT_GLYPH, kind: "limit", spinning: false, label: "Limit reached" };
+    // LiveRunning and LivenessUnset both render as working (render.go:285, 297).
+    case Liveness.Running:
+    case Liveness.Unset:
+    default:
+      return WORKING;
+  }
+}
+function isArchived(s) {
+  return livenessOf(s) === Liveness.Archived;
+}
+function rowTitle(s) {
+  const lv = livenessOf(s);
+  const op = s.in_flight_op ?? InFlightOp.None;
+  let title = s.title;
+  if (op === InFlightOp.Killing || op === InFlightOp.Archiving) {
+    title = "[deleting] " + title;
+  } else if (lv === Liveness.Lost) {
+    title = "[lost] " + title;
+  } else if (lv === Liveness.LimitReached) {
+    title = limitBadgePrefix(s) + title;
+  }
+  if (s.backend_type === "remote") {
+    title = "[remote] " + title;
+  }
+  return title;
+}
+function limitBadgePrefix(s) {
+  if (!s.limit_reset_at) {
+    return "[limit] ";
+  }
+  const reset = new Date(s.limit_reset_at);
+  if (Number.isNaN(reset.getTime())) {
+    return "[limit] ";
+  }
+  return `[limit] resets ${formatLimitReset(reset, /* @__PURE__ */ new Date())} `;
+}
+function formatLimitReset(reset, now) {
+  const h12 = (reset.getHours() + 11) % 12 + 1;
+  const ampm = reset.getHours() < 12 ? "am" : "pm";
+  const min = reset.getMinutes();
+  const clock = min === 0 ? `${h12}${ampm}` : `${h12}:${String(min).padStart(2, "0")}${ampm}`;
+  const sameDay = reset.getFullYear() === now.getFullYear() && reset.getMonth() === now.getMonth() && reset.getDate() === now.getDate();
+  if (sameDay) {
+    return clock;
+  }
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${months[reset.getMonth()]} ${reset.getDate()} ${clock}`;
+}
+
 // src/ui.ts
 function h(tag, props = {}, ...children) {
   const el = document.createElement(tag);
@@ -90,8 +353,23 @@ function h(tag, props = {}, ...children) {
   }
   return el;
 }
+function orderedSessions(sessions) {
+  return [...sessions].sort((a, b) => {
+    const aa = isArchived(a) ? 1 : 0;
+    const bb = isArchived(b) ? 1 : 0;
+    if (aa !== bb) {
+      return aa - bb;
+    }
+    const at = a.created_at ?? "";
+    const bt = b.created_at ?? "";
+    if (at !== bt) {
+      return at < bt ? -1 : 1;
+    }
+    return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
+  });
+}
 function render(root, state, actions) {
-  root.replaceChildren(state.phase === "login" ? loginView(state, actions) : appView(actions));
+  root.replaceChildren(state.phase === "login" ? loginView(state, actions) : appView(state, actions));
 }
 function loginView(state, actions) {
   const input = h("input", {
@@ -116,9 +394,9 @@ function loginView(state, actions) {
   );
   form.addEventListener("submit", (e) => {
     e.preventDefault();
-    const token = input.value.trim();
-    if (token !== "") {
-      actions.connect(token);
+    const token2 = input.value.trim();
+    if (token2 !== "") {
+      actions.connect(token2);
     }
   });
   const children = [
@@ -137,58 +415,242 @@ function loginView(state, actions) {
   }
   return h("main", { class: "af-login" }, h("div", { class: "af-card" }, ...children));
 }
-function appView(actions) {
+function appView(state, actions) {
   const disconnect2 = h("button", { type: "button", class: "af-ghost" }, "Disconnect");
   disconnect2.addEventListener("click", () => actions.disconnect());
   const header = h(
     "header",
     { class: "af-appbar" },
     h("span", { class: "af-brand" }, "Agent Factory"),
+    liveIndicator(state.live),
     disconnect2
   );
-  const body = h(
-    "section",
-    { class: "af-empty" },
-    h("p", { class: "af-empty-title" }, "Connected."),
-    h("p", { class: "af-empty-hint" }, "The session list and terminal arrive in the next update.")
-  );
+  const body = h("div", { class: "af-body" }, sidebar(state, actions), mainPane(state));
   return h("main", { class: "af-app" }, header, body);
+}
+function liveIndicator(live) {
+  const label = live === "open" ? "Live" : live === "connecting" ? "Connecting\u2026" : "Reconnecting\u2026";
+  const pip = h("span", { class: `af-live-pip af-live-${live}` });
+  pip.setAttribute("aria-hidden", "true");
+  const wrap = h("span", { class: "af-live" }, pip, h("span", { class: "af-live-label" }, label));
+  wrap.setAttribute("role", "status");
+  return wrap;
+}
+function sidebar(state, actions) {
+  const count = state.sessions.length;
+  const head = h(
+    "div",
+    { class: "af-rail-head" },
+    h("span", { class: "af-rail-title" }, "Sessions"),
+    h("span", { class: "af-rail-count" }, String(count))
+  );
+  const list = h("ul", { class: "af-rail-list" });
+  list.setAttribute("role", "listbox");
+  list.setAttribute("aria-label", "Sessions");
+  if (count === 0) {
+    list.append(
+      h(
+        "li",
+        { class: "af-rail-empty" },
+        "No sessions yet. Create one in the TUI or with ",
+        h("code", {}, "af sessions create"),
+        "."
+      )
+    );
+  } else {
+    for (const s of orderedSessions(state.sessions)) {
+      list.append(sessionRow(s, s.title === state.selectedTitle, actions));
+    }
+  }
+  return h("nav", { class: "af-rail" }, head, list);
+}
+function sessionRow(s, selected, actions) {
+  const status = rowStatus(s);
+  const dot = h(
+    "span",
+    { class: `af-dot af-dot-${status.kind}${status.spinning ? " af-dot-spin" : ""}` },
+    status.glyph
+  );
+  dot.setAttribute("aria-hidden", "true");
+  const title = h("div", { class: "af-row-title" }, rowTitle(s));
+  const branch = h(
+    "div",
+    { class: "af-row-branch" },
+    h("span", { class: "af-branch-icon" }, "\u2387"),
+    " ",
+    s.branch || "\u2014"
+  );
+  const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}`;
+  const row = h("li", { class: cls }, dot, h("div", { class: "af-row-main" }, title, branch));
+  row.setAttribute("role", "option");
+  row.setAttribute("aria-selected", selected ? "true" : "false");
+  row.setAttribute("title", `${s.title} \u2014 ${status.label}`);
+  row.addEventListener("click", () => actions.select(s.title));
+  return row;
+}
+function mainPane(state) {
+  const selected = state.sessions.find((s) => s.title === state.selectedTitle) ?? null;
+  if (!selected) {
+    return h(
+      "section",
+      { class: "af-main af-main-empty" },
+      h("p", { class: "af-empty-title" }, "Select a session"),
+      h("p", { class: "af-empty-hint" }, "The terminal arrives in the next update.")
+    );
+  }
+  const status = rowStatus(selected);
+  return h(
+    "section",
+    { class: "af-main af-main-empty" },
+    h("p", { class: "af-empty-title" }, selected.title),
+    h(
+      "p",
+      { class: "af-empty-hint" },
+      `${status.label}${selected.branch ? ` \xB7 ${selected.branch}` : ""}`
+    ),
+    h("p", { class: "af-empty-hint" }, "The terminal for this session arrives in the next update.")
+  );
 }
 
 // src/index.ts
 var store = new Store({
   phase: "login",
   connecting: false,
-  loginError: null
+  loginError: null,
+  sessions: [],
+  selectedTitle: null,
+  live: "connecting"
 });
+var token = null;
+var stream = null;
+var resyncTimer = null;
 function mount() {
   const root = document.getElementById("app");
   if (!root) {
     throw new Error("af-web: #app root element missing from index.html");
   }
-  const rerender = () => render(root, store.get(), { connect, disconnect });
+  const rerender = () => render(root, store.get(), { connect, disconnect, select });
   store.subscribe(rerender);
   rerender();
+  document.addEventListener("keydown", onKeydown);
   const existing = loadToken();
   if (existing) {
     void connect(existing);
   }
 }
-async function connect(token) {
+async function connect(candidate) {
   store.set({ connecting: true, loginError: null });
+  let sessions;
   try {
-    await probeToken(token);
+    sessions = await probeToken(candidate);
   } catch (e) {
     clearToken();
     store.set({ phase: "login", connecting: false, loginError: describeError(e) });
     return;
   }
-  storeToken(token);
-  store.set({ phase: "app", connecting: false, loginError: null });
+  token = candidate;
+  storeToken(candidate);
+  store.set({
+    phase: "app",
+    connecting: false,
+    loginError: null,
+    sessions,
+    selectedTitle: pickSelection(sessions, store.get().selectedTitle),
+    live: "connecting"
+  });
+  startStream(candidate);
 }
 function disconnect() {
+  stopStream();
+  token = null;
   clearToken();
-  store.set({ phase: "login", connecting: false, loginError: null });
+  store.set({
+    phase: "login",
+    connecting: false,
+    loginError: null,
+    sessions: [],
+    selectedTitle: null,
+    live: "connecting"
+  });
+}
+function select(title) {
+  store.set({ selectedTitle: title });
+}
+function startStream(tok) {
+  stopStream();
+  stream = new EventStream(tok, {
+    onEvent,
+    onResync: requestResync,
+    onStatus: (s) => store.set({ live: s })
+  });
+  stream.start();
+}
+function stopStream() {
+  if (resyncTimer !== null) {
+    window.clearTimeout(resyncTimer);
+    resyncTimer = null;
+  }
+  if (stream) {
+    stream.stop();
+    stream = null;
+  }
+}
+function onEvent(ev) {
+  const { sessions, needsResync } = applyEvent(store.get().sessions, ev);
+  store.set({ sessions, selectedTitle: pickSelection(sessions, store.get().selectedTitle) });
+  if (needsResync) {
+    requestResync();
+  }
+}
+function requestResync() {
+  if (resyncTimer !== null) {
+    return;
+  }
+  resyncTimer = window.setTimeout(() => {
+    resyncTimer = null;
+    const tok = token;
+    if (!tok) {
+      return;
+    }
+    void fetchSnapshot(tok).then((sessions) => {
+      store.set({ sessions, selectedTitle: pickSelection(sessions, store.get().selectedTitle) });
+    }).catch(() => {
+    });
+  }, 150);
+}
+function onKeydown(e) {
+  const state = store.get();
+  if (state.phase !== "app") {
+    return;
+  }
+  const target = e.target;
+  if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) {
+    return;
+  }
+  let delta = 0;
+  if (e.key === "ArrowDown" || e.key === "j") {
+    delta = 1;
+  } else if (e.key === "ArrowUp" || e.key === "k") {
+    delta = -1;
+  } else {
+    return;
+  }
+  const ordered = orderedSessions(state.sessions);
+  if (ordered.length === 0) {
+    return;
+  }
+  e.preventDefault();
+  const cur = ordered.findIndex((s) => s.title === state.selectedTitle);
+  let next;
+  if (cur === -1) {
+    next = delta > 0 ? 0 : ordered.length - 1;
+  } else {
+    next = Math.min(Math.max(cur + delta, 0), ordered.length - 1);
+  }
+  const target2 = ordered[next];
+  if (target2) {
+    select(target2.title);
+  }
 }
 function describeError(e) {
   if (e instanceof ApiError) {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -8,8 +8,10 @@
 // knows the credential: it is kept in sessionStorage (survives reload within the
 // tab, gone on tab-close — design §1.2, a deliberate "don't persist a full-access
 // credential to disk" posture) and attached as `Authorization: Bearer` on every
-// request. The WS `?access_token=` fallback (browsers cannot set WS headers) lands
-// with the terminal in PR4.
+// request. The WS `?access_token=` fallback (browsers cannot set WS headers) is
+// used by the /v1/events subscriber (events.ts) and, in PR4, the PTY stream.
+
+import type { SessionData, SnapshotResponse } from "./types.js";
 
 const TOKEN_KEY = "af.token";
 
@@ -88,19 +90,25 @@ export async function af<T>(method: string, body: unknown, token: string): Promi
   return env?.data as T;
 }
 
-/** The Snapshot response shape the login probe reads (daemon/snapshot.go). Only
- *  the fields the shell needs are declared; PR3 grows the session projection. */
-export interface SnapshotResponse {
-  instances: unknown[];
-  delivery_alarms?: unknown[];
+/**
+ * Fetches the authoritative session projection for all repos (design §2.1). This
+ * is the read side of the single-writer model (#960): the daemon owns the state
+ * and the web mirrors this Snapshot exactly like the TUI does, seeding the rail on
+ * login and re-seeding it after an events-stream reconnect. Returns the instances
+ * (never null — an empty daemon yields []); throws ApiError on transport/auth
+ * failure so callers share one error path.
+ */
+export async function fetchSnapshot(token: string): Promise<SessionData[]> {
+  const resp = await af<SnapshotResponse>("Snapshot", { repo_id: "" }, token);
+  return resp.instances ?? [];
 }
 
 /**
  * Validates a token by probing an authed endpoint with it. Snapshot is the auth
  * check (design §1.2): a 200 means the token is accepted; a 401 means it is not.
- * Returns the snapshot on success so the caller can seed the app; throws ApiError
- * otherwise.
+ * Returns the snapshot's instances on success so the caller can seed the rail in
+ * the same round-trip as the login probe; throws ApiError otherwise.
  */
-export function probeToken(token: string): Promise<SnapshotResponse> {
-  return af<SnapshotResponse>("Snapshot", { repo_id: "" }, token);
+export function probeToken(token: string): Promise<SessionData[]> {
+  return fetchSnapshot(token);
 }

--- a/web/src/events.ts
+++ b/web/src/events.ts
@@ -1,0 +1,155 @@
+// The live-update transport for the sidebar (#1592 Phase 5 PR3): a subscriber to
+// the daemon's /v1/events WebSocket (daemon/ws_events.go). It replaces polling
+// entirely — the rail updates when the daemon publishes a session.* event, which
+// it does for every create, kill, archive, restore, and liveness/limit transition
+// (daemon/control_server.go, daemon/limit.go). This is the browser analogue of the
+// TUI's push model: the web is a pure projection of daemon state, no client-side
+// source of truth (design §2.1, §3.1).
+//
+// Events ride the same auth seam as the REST API; a browser WebSocket cannot set
+// an Authorization header, so the token travels as the ?access_token= query param
+// the daemon already accepts (agentproto/auth.go:23). The socket is server→client
+// only; the client sends nothing. Browsers answer the daemon's WS keepalive ping
+// at the protocol layer, so there is no client keepalive to write (design §4.4).
+//
+// On any drop (network blip, daemon restart) the stream reconnects with capped
+// exponential backoff, and on every RE-connect it asks the caller to re-Snapshot —
+// events published during the gap are lost by design (the hub is drop-slow, not
+// replayed), so a fresh Snapshot is how the rail re-synchronises. This mirrors the
+// plan's "reconnect + re-Snapshot" resume for a plain event stream.
+
+import type { WireEvent } from "./types.js";
+
+/** The connection state surfaced to the UI for a subtle liveness indicator. */
+export type EventStreamStatus = "connecting" | "open" | "reconnecting";
+
+export interface EventStreamCallbacks {
+  /** A parsed events-plane message (session.* / task.*). */
+  onEvent(ev: WireEvent): void;
+  /** Fired after a RE-connect (not the first connect): the caller should
+   *  re-Snapshot because events may have been missed during the gap. */
+  onResync(): void;
+  /** Fired on every connection-state change, for the header indicator. */
+  onStatus(status: EventStreamStatus): void;
+}
+
+const BACKOFF_BASE_MS = 500;
+const BACKOFF_MAX_MS = 10_000;
+
+/** Returns the WS scheme matching the page origin: wss: under https: (the TLS TCP
+ *  listener the SPA is served from), ws: otherwise. */
+function wsScheme(): string {
+  return window.location.protocol === "https:" ? "wss:" : "ws:";
+}
+
+/**
+ * A self-healing subscription to /v1/events. Call start() once after login and
+ * stop() on logout; it owns its reconnect loop and never throws to the caller —
+ * transport failures become reconnect attempts, not exceptions.
+ */
+export class EventStream {
+  private ws: WebSocket | null = null;
+  private stopped = false;
+  private everOpened = false;
+  private retry = 0;
+  private reconnectTimer: number | null = null;
+
+  constructor(
+    private readonly token: string,
+    private readonly cb: EventStreamCallbacks,
+  ) {}
+
+  /** Opens the socket and begins delivering events. Idempotent-ish: call once. */
+  start(): void {
+    this.stopped = false;
+    this.open();
+  }
+
+  /** Permanently closes the stream and cancels any pending reconnect. */
+  stop(): void {
+    this.stopped = true;
+    if (this.reconnectTimer !== null) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      // Drop our handlers first so the close doesn't schedule a reconnect.
+      this.ws.onopen = null;
+      this.ws.onmessage = null;
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  private open(): void {
+    this.cb.onStatus(this.everOpened ? "reconnecting" : "connecting");
+    const url = `${wsScheme()}//${window.location.host}/v1/events?access_token=${encodeURIComponent(this.token)}`;
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      // Constructor can throw on a malformed URL/state; treat as a drop.
+      this.scheduleReconnect();
+      return;
+    }
+    this.ws = ws;
+
+    ws.onopen = () => {
+      this.retry = 0;
+      const wasReconnect = this.everOpened;
+      this.everOpened = true;
+      this.cb.onStatus("open");
+      // A reconnect may have missed events; re-Snapshot to resynchronise. The
+      // first-ever open needs no resync — the caller already seeded from Snapshot.
+      if (wasReconnect) {
+        this.cb.onResync();
+      }
+    };
+
+    ws.onmessage = (e) => {
+      // The events plane sends JSON text frames (agentproto.WriteControl); binary
+      // frames belong to the PTY stream (PR4) and never arrive here.
+      if (typeof e.data !== "string") {
+        return;
+      }
+      let ev: WireEvent;
+      try {
+        ev = JSON.parse(e.data) as WireEvent;
+      } catch {
+        return; // Ignore a malformed frame rather than tear down the stream.
+      }
+      if (ev && typeof ev.type === "string") {
+        this.cb.onEvent(ev);
+      }
+    };
+
+    ws.onclose = () => this.scheduleReconnect();
+    ws.onerror = () => {
+      // onerror is followed by onclose; close here so a socket stuck in a half-open
+      // state still funnels through the single reconnect path.
+      try {
+        ws.close();
+      } catch {
+        // already closing
+      }
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer !== null) {
+      return;
+    }
+    this.ws = null;
+    this.cb.onStatus("reconnecting");
+    const delay = Math.min(BACKOFF_BASE_MS * 2 ** this.retry, BACKOFF_MAX_MS);
+    this.retry += 1;
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this.stopped) {
+        this.open();
+      }
+    }, delay);
+  }
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -1,31 +1,52 @@
-// Entry point for the Agent Factory web client (#1592 Phase 5). This PR (PR2)
-// wires the serving shell + token login: load the page → paste the daemon token →
-// probe an authed endpoint → on success render the authed (empty) app, on failure
-// show an actionable error. The sidebar, terminal, and modals land in PR3+.
+// Entry point for the Agent Factory web client (#1592 Phase 5). PR3 fills the
+// authed app with the live session rail: on login the app fetches Snapshot to seed
+// the rail, then subscribes to /v1/events and applies deltas so the list stays in
+// lock-step with the daemon — no polling. Creating/killing a session in the TUI or
+// via the CLI shows up in the browser through the push stream (design §2.1).
 //
 // The bundle is fully self-contained (esbuild output + the imported CSS, no CDN,
 // no off-origin fetch) so the daemon's `Content-Security-Policy: default-src
-// 'self'` holds — the only network calls are same-origin /v1/ requests.
+// 'self'` holds — the only network calls are same-origin /v1/ requests + the
+// same-origin /v1/events WebSocket.
 
 import "./styles.css";
-import { ApiError, clearToken, loadToken, probeToken, storeToken } from "./api.js";
+import { ApiError, clearToken, fetchSnapshot, loadToken, probeToken, storeToken } from "./api.js";
+import { EventStream, type EventStreamStatus } from "./events.js";
+import { applyEvent, pickSelection } from "./sessions.js";
 import { Store } from "./store.js";
-import { render, type AppState } from "./ui.js";
+import { orderedSessions, render, type AppState } from "./ui.js";
+import type { SessionData, WireEvent } from "./types.js";
 
 const store = new Store<AppState>({
   phase: "login",
   connecting: false,
   loginError: null,
+  sessions: [],
+  selectedTitle: null,
+  live: "connecting",
 });
+
+// The credential and the push stream are process-local singletons: one token
+// drives both the REST resync fetch and the events WS, and one stream is live at a
+// time (started on connect, stopped on disconnect).
+let token: string | null = null;
+let stream: EventStream | null = null;
+// Debounces the re-Snapshot that archived/restored events and reconnects trigger,
+// so a burst of events collapses into a single authoritative refetch.
+let resyncTimer: number | null = null;
 
 function mount(): void {
   const root = document.getElementById("app");
   if (!root) {
     throw new Error("af-web: #app root element missing from index.html");
   }
-  const rerender = () => render(root, store.get(), { connect, disconnect });
+  const rerender = () => render(root, store.get(), { connect, disconnect, select });
   store.subscribe(rerender);
   rerender();
+
+  // Keyboard navigation over the rail (arrows / j / k), wired once at the document
+  // level so it works regardless of which row last had focus.
+  document.addEventListener("keydown", onKeydown);
 
   // Resume within the tab: sessionStorage keeps the token across a reload, so a
   // returning tab re-probes it silently and skips the login form on success.
@@ -35,25 +56,151 @@ function mount(): void {
   }
 }
 
-/** Validates the token (Snapshot probe), and on success persists it and shows the
- *  app; on failure clears it and surfaces an actionable error on the login view. */
-async function connect(token: string): Promise<void> {
+/** Validates the token (Snapshot probe), and on success persists it, seeds the rail
+ *  from the probe's snapshot, subscribes to /v1/events, and shows the app; on
+ *  failure clears it and surfaces an actionable error on the login view. */
+async function connect(candidate: string): Promise<void> {
   store.set({ connecting: true, loginError: null });
+  let sessions: SessionData[];
   try {
-    await probeToken(token);
+    sessions = await probeToken(candidate);
   } catch (e) {
     clearToken();
     store.set({ phase: "login", connecting: false, loginError: describeError(e) });
     return;
   }
-  storeToken(token);
-  store.set({ phase: "app", connecting: false, loginError: null });
+  token = candidate;
+  storeToken(candidate);
+  store.set({
+    phase: "app",
+    connecting: false,
+    loginError: null,
+    sessions,
+    selectedTitle: pickSelection(sessions, store.get().selectedTitle),
+    live: "connecting",
+  });
+  startStream(candidate);
 }
 
-/** Forgets the token and returns to the login view. */
+/** Forgets the token, tears down the push stream, and returns to the login view. */
 function disconnect(): void {
+  stopStream();
+  token = null;
   clearToken();
-  store.set({ phase: "login", connecting: false, loginError: null });
+  store.set({
+    phase: "login",
+    connecting: false,
+    loginError: null,
+    sessions: [],
+    selectedTitle: null,
+    live: "connecting",
+  });
+}
+
+/** Selects a session row (click or keyboard). */
+function select(title: string): void {
+  store.set({ selectedTitle: title });
+}
+
+// --- events plane wiring ---------------------------------------------------
+
+function startStream(tok: string): void {
+  stopStream();
+  stream = new EventStream(tok, {
+    onEvent,
+    onResync: requestResync,
+    onStatus: (s: EventStreamStatus) => store.set({ live: s }),
+  });
+  stream.start();
+}
+
+function stopStream(): void {
+  if (resyncTimer !== null) {
+    window.clearTimeout(resyncTimer);
+    resyncTimer = null;
+  }
+  if (stream) {
+    stream.stop();
+    stream = null;
+  }
+}
+
+/**
+ * Applies one events-plane delta to the store via the pure reducer (sessions.ts):
+ * created/updated upsert in place (the instant, poll-free path the create/status
+ * play-test checks), killed removes the row, and archived/restored request a
+ * debounced re-Snapshot because the event can't convey the new liveness. The
+ * selection is re-validated against the new list so a killed selected row clears.
+ */
+function onEvent(ev: WireEvent): void {
+  const { sessions, needsResync } = applyEvent(store.get().sessions, ev);
+  store.set({ sessions, selectedTitle: pickSelection(sessions, store.get().selectedTitle) });
+  if (needsResync) {
+    requestResync();
+  }
+}
+
+/** Re-fetches the authoritative Snapshot (debounced) and replaces the rail — the
+ *  resync path for reconnects and partial archived/restored events. Failures are
+ *  swallowed: the stream keeps running and a later event/reconnect retries. */
+function requestResync(): void {
+  if (resyncTimer !== null) {
+    return;
+  }
+  resyncTimer = window.setTimeout(() => {
+    resyncTimer = null;
+    const tok = token;
+    if (!tok) {
+      return;
+    }
+    void fetchSnapshot(tok)
+      .then((sessions) => {
+        store.set({ sessions, selectedTitle: pickSelection(sessions, store.get().selectedTitle) });
+      })
+      .catch(() => {
+        // Transport/auth failure: the events stream owns reconnection; a later
+        // reconnect fires onResync again. Nothing to surface here.
+      });
+  }, 150);
+}
+
+// --- keyboard navigation ---------------------------------------------------
+
+function onKeydown(e: KeyboardEvent): void {
+  const state = store.get();
+  if (state.phase !== "app") {
+    return;
+  }
+  // Don't hijack typing in a form field (the login input, future modals).
+  const target = e.target as HTMLElement | null;
+  if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) {
+    return;
+  }
+  let delta = 0;
+  if (e.key === "ArrowDown" || e.key === "j") {
+    delta = 1;
+  } else if (e.key === "ArrowUp" || e.key === "k") {
+    delta = -1;
+  } else {
+    return;
+  }
+  const ordered = orderedSessions(state.sessions);
+  if (ordered.length === 0) {
+    return;
+  }
+  e.preventDefault();
+  const cur = ordered.findIndex((s) => s.title === state.selectedTitle);
+  // From no selection, ArrowDown lands on the first row and ArrowUp on the last.
+  let next: number;
+  if (cur === -1) {
+    next = delta > 0 ? 0 : ordered.length - 1;
+  } else {
+    next = Math.min(Math.max(cur + delta, 0), ordered.length - 1);
+  }
+  const target2 = ordered[next];
+  if (target2) {
+    select(target2.title);
+  }
 }
 
 /** Turns a probe failure into a message that tells the operator what to fix. */

--- a/web/src/sessions.test.ts
+++ b/web/src/sessions.test.ts
@@ -1,0 +1,85 @@
+// Tests for the pure session-list reducer (#1592 Phase 5 PR3): how Snapshot +
+// /v1/events deltas fold into the rail. These pin the live-update semantics the
+// play-test exercises — created/updated upsert, killed removes, archived/restored
+// ask for a resync — without a daemon or a DOM.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyEvent, pickSelection, removeSession, upsertSession } from "./sessions.js";
+import { orderedSessions } from "./ui.js";
+import { Liveness, type SessionData, type WireEvent } from "./types.js";
+
+function sess(title: string, over: Partial<SessionData> = {}): SessionData {
+  return { title, branch: "b", ...over };
+}
+
+test("upsert inserts a new title and replaces an existing one without mutating", () => {
+  const a = [sess("x", { branch: "old" })];
+  const inserted = upsertSession(a, sess("y"));
+  assert.deepEqual(inserted.map((s) => s.title), ["x", "y"]);
+  assert.equal(a.length, 1, "input array is not mutated");
+
+  const replaced = upsertSession(inserted, sess("x", { branch: "new" }));
+  assert.equal(replaced.find((s) => s.title === "x")?.branch, "new");
+  assert.equal(replaced.length, 2, "replace does not grow the list");
+});
+
+test("remove drops the matching title only", () => {
+  const list = [sess("x"), sess("y")];
+  assert.deepEqual(removeSession(list, "x").map((s) => s.title), ["y"]);
+  assert.deepEqual(removeSession(list, "absent").map((s) => s.title), ["x", "y"]);
+});
+
+test("applyEvent: created/updated upsert in place with no resync", () => {
+  let list: SessionData[] = [];
+  const created: WireEvent = { type: "session.created", data: sess("x", { liveness: Liveness.Running }) };
+  let r = applyEvent(list, created);
+  assert.equal(r.needsResync, false);
+  assert.deepEqual(r.sessions.map((s) => s.title), ["x"]);
+  list = r.sessions;
+
+  const updated: WireEvent = { type: "session.updated", data: sess("x", { liveness: Liveness.Ready }) };
+  r = applyEvent(list, updated);
+  assert.equal(r.needsResync, false);
+  assert.equal(r.sessions[0]?.liveness, Liveness.Ready, "status transition applied in place");
+});
+
+test("applyEvent: killed removes by title with no resync", () => {
+  const list = [sess("x"), sess("y")];
+  const r = applyEvent(list, { type: "session.killed", data: sess("x") });
+  assert.equal(r.needsResync, false);
+  assert.deepEqual(r.sessions.map((s) => s.title), ["y"]);
+});
+
+test("applyEvent: archived/restored ask for a resync and leave the list untouched", () => {
+  const list = [sess("x")];
+  for (const type of ["session.archived", "session.restored"] as const) {
+    const r = applyEvent(list, { type, data: sess("x") });
+    assert.equal(r.needsResync, true, `${type} → resync`);
+    assert.equal(r.sessions, list, "list reference unchanged pending the refetch");
+  }
+});
+
+test("applyEvent: task.* and dataless events are no-ops", () => {
+  const list = [sess("x")];
+  assert.equal(applyEvent(list, { type: "task.created" }).sessions, list);
+  assert.equal(applyEvent(list, { type: "session.created" }).needsResync, false);
+  assert.deepEqual(applyEvent(list, { type: "session.created" }).sessions, list);
+});
+
+test("pickSelection keeps a still-present selection, else clears it", () => {
+  const list = [sess("x"), sess("y")];
+  assert.equal(pickSelection(list, "y"), "y");
+  assert.equal(pickSelection(list, "gone"), null);
+  assert.equal(pickSelection(list, null), null);
+});
+
+test("orderedSessions puts live rows before archived, then by created_at", () => {
+  const list = [
+    sess("late", { created_at: "2026-01-02T00:00:00Z" }),
+    sess("arch", { liveness: Liveness.Archived, created_at: "2026-01-01T00:00:00Z" }),
+    sess("early", { created_at: "2026-01-01T00:00:00Z" }),
+  ];
+  assert.deepEqual(orderedSessions(list).map((s) => s.title), ["early", "late", "arch"]);
+});

--- a/web/src/sessions.ts
+++ b/web/src/sessions.ts
@@ -1,0 +1,80 @@
+// The pure session-list reducer behind the sidebar (#1592 Phase 5 PR3). It holds
+// the browser analogue of the TUI's read-only projection logic: how a Snapshot and
+// a stream of /v1/events deltas fold into the rail's session list, with no DOM and
+// no I/O. Keeping it pure means the exact create/kill/update/archive semantics the
+// sidebar depends on are unit-tested (sessions.test.ts) independently of the DOM
+// wiring in index.ts.
+//
+// Identity is the session title: titles are unique in af (one worktree, one row),
+// and the killed/archived/restored events carry ONLY the title (see
+// daemon/control_server.go), so the title is the one key every event shares.
+
+import type { SessionData, WireEvent } from "./types.js";
+
+/** The result of applying one event: the next list plus whether the caller must
+ *  re-Snapshot. Partial events (archived/restored carry only a title, with no
+ *  liveness to reconstruct) set needsResync so index.ts refetches authoritative
+ *  state; the common created/updated/killed deltas apply in place (needsResync
+ *  false) for an instant, poll-free update. */
+export interface ApplyResult {
+  sessions: SessionData[];
+  needsResync: boolean;
+}
+
+/** Inserts or replaces a session by title, returning a new array (never mutates
+ *  the input — the store swaps references so subscribers see a fresh state). */
+export function upsertSession(list: SessionData[], s: SessionData): SessionData[] {
+  const i = list.findIndex((x) => x.title === s.title);
+  if (i === -1) {
+    return [...list, s];
+  }
+  const next = list.slice();
+  next[i] = s;
+  return next;
+}
+
+/** Removes a session by title, returning a new array. */
+export function removeSession(list: SessionData[], title: string): SessionData[] {
+  return list.filter((x) => x.title !== title);
+}
+
+/**
+ * Folds one events-plane delta into the list, mirroring the daemon's event
+ * contract (agentproto/message.go, daemon/control_server.go):
+ *  - created/updated carry the full projection → upsert in place;
+ *  - killed carries only the title → remove the row;
+ *  - archived/restored carry only the title and flip a liveness the event can't
+ *    convey → signal a resync so the caller refetches Snapshot;
+ *  - task.* are not a sidebar concern → no-op.
+ * The list is returned unchanged (same reference) for events that don't touch it.
+ */
+export function applyEvent(list: SessionData[], ev: WireEvent): ApplyResult {
+  switch (ev.type) {
+    case "session.created":
+    case "session.updated":
+      if (ev.data && ev.data.title) {
+        return { sessions: upsertSession(list, ev.data), needsResync: false };
+      }
+      return { sessions: list, needsResync: false };
+    case "session.killed":
+      if (ev.data && ev.data.title) {
+        return { sessions: removeSession(list, ev.data.title), needsResync: false };
+      }
+      return { sessions: list, needsResync: false };
+    case "session.archived":
+    case "session.restored":
+      return { sessions: list, needsResync: true };
+    default:
+      return { sessions: list, needsResync: false };
+  }
+}
+
+/** Keeps a valid selection: preserves the current one if it still exists, else
+ *  null. Never auto-selects, so selection stays a deliberate user act — matching
+ *  the read-only, no-surprise projection model. */
+export function pickSelection(list: SessionData[], current: string | null): string | null {
+  if (current && list.some((s) => s.title === current)) {
+    return current;
+  }
+  return null;
+}

--- a/web/src/status.test.ts
+++ b/web/src/status.test.ts
@@ -1,0 +1,100 @@
+// Parity tests for the status-dot + title mapping (#1592 Phase 5 PR3). They pin
+// web/src/status.ts to ui/tree/render.go: every Liveness value and every in-flight
+// op maps to the SAME dot color-bucket and the SAME [lost]/[deleting]/[limit]/
+// [remote] title prefix the TUI paints. If the Go renderer's mapping changes, these
+// must change with it — the two clients cannot diverge in status semantics (§3).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isArchived, rowStatus, rowTitle } from "./status.js";
+import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
+
+function sess(over: Partial<SessionData> = {}): SessionData {
+  return { title: "s", branch: "b", ...over };
+}
+
+test("liveness → dot kind mirrors render.go's TOTAL switch", () => {
+  const cases: Array<[number, string, string]> = [
+    [Liveness.Ready, "ready", "●"],
+    [Liveness.Lost, "lost", "◌"],
+    [Liveness.Dead, "dead", "○"],
+    [Liveness.Archived, "archived", "▧"],
+    [Liveness.LimitReached, "limit", "◆"],
+    [Liveness.Running, "working", "●"],
+    [Liveness.Unset, "working", "●"], // stray zero renders like Running (render.go:297)
+  ];
+  for (const [lv, kind, glyph] of cases) {
+    const st = rowStatus(sess({ liveness: lv }));
+    assert.equal(st.kind, kind, `liveness ${lv} → ${kind}`);
+    assert.equal(st.glyph, glyph, `liveness ${lv} glyph`);
+  }
+});
+
+test("only Ready/Running/Unset spin like the TUI (Ready is a settled dot)", () => {
+  assert.equal(rowStatus(sess({ liveness: Liveness.Running })).spinning, true);
+  assert.equal(rowStatus(sess({ liveness: Liveness.Ready })).spinning, false);
+  assert.equal(rowStatus(sess({ liveness: Liveness.Lost })).spinning, false);
+});
+
+test("any in-flight op overlays the liveness and wins the working dot", () => {
+  for (const op of [InFlightOp.Creating, InFlightOp.Killing, InFlightOp.Archiving, InFlightOp.Restoring]) {
+    // Even a Ready liveness reads as working while an op is in flight (render.go:280).
+    const st = rowStatus(sess({ liveness: Liveness.Ready, in_flight_op: op }));
+    assert.equal(st.kind, "working", `op ${op} → working`);
+    assert.equal(st.spinning, true);
+  }
+});
+
+test("liveness absent falls back to the legacy status int", () => {
+  assert.equal(rowStatus(sess({ status: Status.Ready })).kind, "ready");
+  assert.equal(rowStatus(sess({ status: Status.Lost })).kind, "lost");
+  assert.equal(rowStatus(sess({ status: Status.Dead })).kind, "dead");
+  assert.equal(rowStatus(sess({ status: Status.Archived })).kind, "archived");
+  assert.equal(rowStatus(sess({ status: Status.Running })).kind, "working");
+});
+
+test("title prefixes match render.go precedence", () => {
+  // [lost] on a Lost row (render.go:315).
+  assert.equal(rowTitle(sess({ title: "w", liveness: Liveness.Lost })), "[lost] w");
+  // [deleting] while killing/archiving, and it beats the [lost] marker.
+  assert.equal(
+    rowTitle(sess({ title: "w", liveness: Liveness.Lost, in_flight_op: InFlightOp.Killing })),
+    "[deleting] w",
+  );
+  assert.equal(rowTitle(sess({ title: "w", in_flight_op: InFlightOp.Archiving })), "[deleting] w");
+  // Archived carries NO word prefix (render.go:326-338) — the glyph + dimming say it.
+  assert.equal(rowTitle(sess({ title: "w", liveness: Liveness.Archived })), "w");
+  // [remote] is outermost.
+  assert.equal(
+    rowTitle(sess({ title: "w", liveness: Liveness.Lost, backend_type: "remote" })),
+    "[remote] [lost] w",
+  );
+});
+
+test("[limit] badge shows the reset time like render.go's limitBadgePrefix", () => {
+  const noReset = rowTitle(sess({ title: "w", liveness: Liveness.LimitReached }));
+  assert.equal(noReset, "[limit] w");
+  const withReset = rowTitle(
+    sess({ title: "w", liveness: Liveness.LimitReached, limit_reset_at: isoTodayAt(15, 0) }),
+  );
+  assert.match(withReset, /^\[limit\] resets 3pm w$/);
+  const withMinutes = rowTitle(
+    sess({ title: "w", liveness: Liveness.LimitReached, limit_reset_at: isoTodayAt(15, 4) }),
+  );
+  assert.match(withMinutes, /^\[limit\] resets 3:04pm w$/);
+});
+
+test("isArchived reads the liveness (and the legacy fallback)", () => {
+  assert.equal(isArchived(sess({ liveness: Liveness.Archived })), true);
+  assert.equal(isArchived(sess({ liveness: Liveness.Ready })), false);
+  assert.equal(isArchived(sess({ status: Status.Archived })), true);
+});
+
+/** Builds an RFC3339 timestamp for today at the given local hour/min so the
+ *  formatLimitReset "same day → bare clock" branch is exercised deterministically. */
+function isoTodayAt(hour: number, min: number): string {
+  const d = new Date();
+  d.setHours(hour, min, 0, 0);
+  return d.toISOString();
+}

--- a/web/src/status.ts
+++ b/web/src/status.ts
@@ -1,0 +1,167 @@
+// The status-dot + title mapping for a sidebar row (#1592 Phase 5 PR3). This is a
+// line-for-line port of the TUI renderer, ui/tree/render.go — the single source of
+// truth for how (Liveness, InFlightOp) become a glyph, a color, and the [lost] /
+// [deleting] / [limit] / [remote] title prefixes. The web MUST match it exactly:
+// two thin clients of the same projection cannot diverge in status semantics, only
+// in pixels (design §3). Adding a Liveness value forces a deliberate choice here,
+// mirroring the TUI's TOTAL liveness switch (render.go:274-301).
+//
+// Glyph shapes are copied from render.go so the state survives low contrast and
+// color-blindness the same way the TUI intends (its #935 discipline): a filled ●
+// for Ready, hollow ○/◌ for Dead/Lost, ▧ for Archived, ◆ for LimitReached. Colors
+// (the `kind`) map to the exact hexes render.go paints (see styles.css .af-dot-*).
+
+import { InFlightOp, Liveness, Status, type SessionData } from "./types.js";
+
+/** The visual kind of a status dot, one per color bucket the TUI paints. Drives
+ *  the .af-dot-<kind> CSS class whose color matches render.go's lipgloss styles. */
+export type DotKind = "working" | "ready" | "lost" | "dead" | "archived" | "limit";
+
+/** A fully-resolved status descriptor for one row: the dot to draw and the
+ *  human label (used for the row's aria/title so the state is legible to a
+ *  screen reader, not only by color — the same intent as the TUI's text prefixes). */
+export interface RowStatus {
+  glyph: string;
+  kind: DotKind;
+  /** Whether the dot should animate (the TUI shows a spinner for working). */
+  spinning: boolean;
+  /** Accessible one-word state label, e.g. "Ready", "Working", "Lost". */
+  label: string;
+}
+
+// Glyphs copied verbatim from ui/tree/render.go (readyIcon/deadIcon/lostIcon/
+// archivedIcon/limitIcon), minus the trailing pad space the terminal adds.
+const READY_GLYPH = "●";
+const DEAD_GLYPH = "○";
+const LOST_GLYPH = "◌";
+const ARCHIVED_GLYPH = "▧";
+const LIMIT_GLYPH = "◆";
+// Working has no fixed glyph in the TUI (a bubbles spinner); the web draws a
+// filled dot and animates it via .af-dot-working (styles.css).
+const WORKING_GLYPH = "●";
+
+const WORKING: RowStatus = { glyph: WORKING_GLYPH, kind: "working", spinning: true, label: "Working" };
+
+/**
+ * Resolves a session's status dot from its two axes, mirroring render.go exactly:
+ * any in-flight op keeps the spinner ("busy"); otherwise the liveness picks the
+ * dot. Falls back to the legacy `status` int only when `liveness` is absent (a
+ * pre-#1195 record — never emitted by the daemon's live Snapshot, but handled so
+ * a stray zero never blanks the dot, matching render.go's LivenessUnset arm).
+ */
+export function rowStatus(s: SessionData): RowStatus {
+  const op = s.in_flight_op ?? InFlightOp.None;
+  // An in-flight op overlays the liveness and wins the dot (render.go:280-282):
+  // the [deleting] title prefix, added below, distinguishes kill/archive.
+  if (op !== InFlightOp.None) {
+    return WORKING;
+  }
+  return dotForLiveness(livenessOf(s));
+}
+
+/** The daemon always emits `liveness`; this only guards a pre-#1195 record by
+ *  deriving it from the legacy `status` int (session.LivenessForStatus). */
+function livenessOf(s: SessionData): number {
+  const lv = s.liveness ?? Liveness.Unset;
+  if (lv !== Liveness.Unset) {
+    return lv;
+  }
+  switch (s.status) {
+    case Status.Ready:
+      return Liveness.Ready;
+    case Status.Dead:
+      return Liveness.Dead;
+    case Status.Lost:
+      return Liveness.Lost;
+    case Status.Archived:
+      return Liveness.Archived;
+    // Running and the transient values (Loading/Deleting, which never persist)
+    // fall through to the working dot, matching render.go's LivenessUnset arm.
+    default:
+      return Liveness.Running;
+  }
+}
+
+/** The TOTAL liveness→dot switch, one arm per value (render.go:284-301). */
+function dotForLiveness(lv: number): RowStatus {
+  switch (lv) {
+    case Liveness.Ready:
+      return { glyph: READY_GLYPH, kind: "ready", spinning: false, label: "Ready" };
+    case Liveness.Lost:
+      return { glyph: LOST_GLYPH, kind: "lost", spinning: false, label: "Lost" };
+    case Liveness.Dead:
+      return { glyph: DEAD_GLYPH, kind: "dead", spinning: false, label: "Dead" };
+    case Liveness.Archived:
+      return { glyph: ARCHIVED_GLYPH, kind: "archived", spinning: false, label: "Archived" };
+    case Liveness.LimitReached:
+      return { glyph: LIMIT_GLYPH, kind: "limit", spinning: false, label: "Limit reached" };
+    // LiveRunning and LivenessUnset both render as working (render.go:285, 297).
+    case Liveness.Running:
+    case Liveness.Unset:
+    default:
+      return WORKING;
+  }
+}
+
+/** True when the row is an archived session (dimmed, no text prefix — the ▧ glyph
+ *  and dimming already convey it), mirroring render.go:335. */
+export function isArchived(s: SessionData): boolean {
+  return livenessOf(s) === Liveness.Archived;
+}
+
+/**
+ * Builds the row title with the same prefixes the TUI prepends (render.go:304-345),
+ * in the same precedence: [remote] outermost, then the state marker. Archived rows
+ * deliberately carry NO word prefix (render.go:326-338) — the glyph + dimming say
+ * it, and an 11-char prefix would eat the title cell.
+ */
+export function rowTitle(s: SessionData): string {
+  const lv = livenessOf(s);
+  const op = s.in_flight_op ?? InFlightOp.None;
+  let title = s.title;
+  if (op === InFlightOp.Killing || op === InFlightOp.Archiving) {
+    title = "[deleting] " + title;
+  } else if (lv === Liveness.Lost) {
+    title = "[lost] " + title;
+  } else if (lv === Liveness.LimitReached) {
+    title = limitBadgePrefix(s) + title;
+  }
+  if (s.backend_type === "remote") {
+    title = "[remote] " + title;
+  }
+  return title;
+}
+
+/** Mirrors ui/tree/render.go:limitBadgePrefix: "[limit] resets <t> " when a reset
+ *  time is known, else a bare "[limit] ". */
+function limitBadgePrefix(s: SessionData): string {
+  if (!s.limit_reset_at) {
+    return "[limit] ";
+  }
+  const reset = new Date(s.limit_reset_at);
+  if (Number.isNaN(reset.getTime())) {
+    return "[limit] ";
+  }
+  return `[limit] resets ${formatLimitReset(reset, new Date())} `;
+}
+
+/**
+ * Mirrors ui/tree/render.go:formatLimitReset: a bare hour like "3pm" on the hour,
+ * "3:04pm" otherwise, prefixed with the month/day ("Jul 6 3pm") when the reset is
+ * not today, rendered in the viewer's local zone.
+ */
+function formatLimitReset(reset: Date, now: Date): string {
+  const h12 = ((reset.getHours() + 11) % 12) + 1;
+  const ampm = reset.getHours() < 12 ? "am" : "pm";
+  const min = reset.getMinutes();
+  const clock = min === 0 ? `${h12}${ampm}` : `${h12}:${String(min).padStart(2, "0")}${ampm}`;
+  const sameDay =
+    reset.getFullYear() === now.getFullYear() &&
+    reset.getMonth() === now.getMonth() &&
+    reset.getDate() === now.getDate();
+  if (sameDay) {
+    return clock;
+  }
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${months[reset.getMonth()]} ${reset.getDate()} ${clock}`;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15,6 +15,14 @@
   --af-accent-text: #ffffff;
   --af-error: #f85149;
   --af-radius: 8px;
+  /* Status-dot colors mirror ui/tree/render.go's lipgloss styles exactly, so the
+   * web reads the same as the TUI at a glance (design §2.1, §7.2 item 3). */
+  --af-dot-ready: #7f9f7f; /* readyStyle  — green   */
+  --af-dot-lost: #f0dfaf; /* lostStyle   — amber   */
+  --af-dot-dead: #989890; /* deadStyle   — gray    */
+  --af-dot-archived: #989890; /* archivedStyle — gray */
+  --af-dot-limit: #cc9393; /* limitStyle  — red-orange */
+  --af-dot-working: #e6edf3; /* spinner default foreground */
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
 }
 
@@ -124,9 +132,9 @@ body {
   line-height: 1.4;
 }
 
-/* Authed app shell (empty until PR3) */
+/* Authed app shell: appbar over a rail + main body (the terminal lands in PR4). */
 .af-app {
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
 }
@@ -134,7 +142,7 @@ body {
 .af-appbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 1rem;
   padding: 0.75rem 1.25rem;
   background: var(--af-surface);
   border-bottom: 1px solid var(--af-border);
@@ -142,6 +150,36 @@ body {
 
 .af-brand {
   font-weight: 600;
+}
+
+/* Push the disconnect button to the far right; the live pip sits beside it. */
+.af-appbar .af-live {
+  margin-left: auto;
+}
+
+.af-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--af-muted);
+}
+
+.af-live-pip {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--af-muted);
+}
+
+.af-live-pip.af-live-open {
+  background: var(--af-dot-ready);
+}
+
+.af-live-pip.af-live-connecting,
+.af-live-pip.af-live-reconnecting {
+  background: var(--af-dot-lost);
+  animation: af-pulse 1.2s ease-in-out infinite;
 }
 
 .af-ghost {
@@ -160,10 +198,171 @@ body {
   border-color: var(--af-muted);
 }
 
-.af-empty {
+/* Body: fixed-width rail + flexible main content. */
+.af-body {
   flex: 1;
   display: flex;
+  min-height: 0;
+}
+
+.af-rail {
+  width: 18rem;
+  flex: 0 0 18rem;
+  border-right: 1px solid var(--af-border);
+  background: var(--af-surface);
+  display: flex;
   flex-direction: column;
+  min-height: 0;
+}
+
+.af-rail-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid var(--af-border);
+}
+
+.af-rail-title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--af-muted);
+}
+
+.af-rail-count {
+  font-size: 0.75rem;
+  color: var(--af-muted);
+  background: var(--af-bg);
+  border: 1px solid var(--af-border);
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+}
+
+.af-rail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.af-rail-empty {
+  padding: 1rem 0.75rem;
+  color: var(--af-muted);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.af-rail-empty code {
+  color: var(--af-text);
+}
+
+.af-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.af-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.af-row-selected {
+  background: rgba(47, 129, 247, 0.16);
+}
+
+.af-row-selected:hover {
+  background: rgba(47, 129, 247, 0.22);
+}
+
+.af-row-archived {
+  opacity: 0.55;
+}
+
+.af-row-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.af-row-title {
+  font-size: 0.85rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.af-row-branch {
+  margin-top: 0.15rem;
+  font-size: 0.72rem;
+  color: var(--af-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.af-branch-icon {
+  opacity: 0.8;
+}
+
+/* Status dot: the glyph itself carries shape (● / ○ / ◌ / ▧ / ◆ — copied from the
+ * TUI so state survives color-blindness), the class carries the matching color. */
+.af-dot {
+  flex: 0 0 auto;
+  line-height: 1.4;
+  font-size: 0.8rem;
+}
+
+.af-dot-ready {
+  color: var(--af-dot-ready);
+}
+
+.af-dot-lost {
+  color: var(--af-dot-lost);
+}
+
+.af-dot-dead {
+  color: var(--af-dot-dead);
+}
+
+.af-dot-archived {
+  color: var(--af-dot-archived);
+}
+
+.af-dot-limit {
+  color: var(--af-dot-limit);
+}
+
+.af-dot-working {
+  color: var(--af-dot-working);
+}
+
+.af-dot-spin {
+  animation: af-pulse 1.1s ease-in-out infinite;
+}
+
+@keyframes af-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+/* Main content area — empty state until PR4 brings the terminal. */
+.af-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.af-main-empty {
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
@@ -180,4 +379,19 @@ body {
   margin: 0;
   color: var(--af-muted);
   font-size: 0.85rem;
+}
+
+/* Narrow viewport: stack the rail above the main pane (design §7.2 item 7 —
+ * usable-but-not-optimized on a phone). */
+@media (max-width: 640px) {
+  .af-body {
+    flex-direction: column;
+  }
+  .af-rail {
+    width: 100%;
+    flex: 0 0 auto;
+    max-height: 45vh;
+    border-right: none;
+    border-bottom: 1px solid var(--af-border);
+  }
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,100 @@
+// The wire DTOs the sidebar reads (#1592 Phase 5 PR3). These are a hand-mirror of
+// the Go source of truth — NOT a fork of it: SessionData mirrors the subset of
+// session.InstanceData (session/storage.go) the rail renders, and the Liveness /
+// InFlightOp enums mirror session/liveness.go. Per design §3.2 the client reuses
+// the daemon's projection shapes verbatim; it must not invent its own status
+// logic. (FLAG §7.1: hand-mirror vs codegen — hand-mirror in v1, revisit if it
+// drifts.)
+//
+// Liveness and InFlightOp are Go `int` types with no custom MarshalJSON, so they
+// travel as bare integers on the wire; these const objects pin the exact numeric
+// values from session/liveness.go's iota blocks. Adding a value there is a
+// deliberate, breaking change here too — the same "the switch is TOTAL" discipline
+// the TUI renderer keeps (ui/tree/render.go:274).
+
+/** session.Liveness (session/liveness.go): the daemon-owned health axis. */
+export const Liveness = {
+  Unset: 0,
+  Running: 1,
+  Ready: 2,
+  Lost: 3,
+  Dead: 4,
+  Archived: 5,
+  LimitReached: 6,
+} as const;
+
+/** session.InFlightOp (session/liveness.go): the transient client-op axis. */
+export const InFlightOp = {
+  None: 0,
+  Creating: 1,
+  Killing: 2,
+  Archiving: 3,
+  Restoring: 4,
+} as const;
+
+/** session.Status (session/instance.go) — the legacy single-axis int, read ONLY
+ *  as a defensive fallback when a projection somehow omits `liveness` (never
+ *  expected from the daemon's live Snapshot, which always emits it). */
+export const Status = {
+  Running: 0,
+  Ready: 1,
+  Loading: 2,
+  Deleting: 3,
+  Dead: 4,
+  Lost: 5,
+  Archived: 6,
+} as const;
+
+/**
+ * The subset of session.InstanceData (session/storage.go) the sidebar renders.
+ * Field names and JSON tags match the Go struct exactly so this decodes the
+ * daemon projection as-is. Optional fields carry Go's `omitempty` semantics:
+ * `liveness`/`in_flight_op` are dropped when zero, `limit_reset_at` only present
+ * for a LimitReached row.
+ */
+export interface SessionData {
+  id?: string;
+  title: string;
+  branch: string;
+  path?: string;
+  /** RFC3339 creation time; the rail orders rows by it for a stable list. */
+  created_at?: string;
+  /** Legacy single-axis status int (fallback source only; see Status). */
+  status?: number;
+  /** Daemon-owned health axis; absent (→ Unset) only on pre-#1195 records. */
+  liveness?: number;
+  /** Transient client-op axis; absent (→ None) in the steady state. */
+  in_flight_op?: number;
+  /** Usage-limit reset time (RFC3339), present only for a LimitReached row. */
+  limit_reset_at?: string;
+  /** Backend discriminator; "remote" marks a remote-hook session (→ [remote]). */
+  backend_type?: string;
+}
+
+/** The Snapshot RPC response (daemon/snapshot.go: SnapshotResponse). */
+export interface SnapshotResponse {
+  instances: SessionData[] | null;
+  delivery_alarms?: unknown[];
+}
+
+/** agentproto.EventType (agentproto/message.go): the /v1/events discriminators. */
+export type EventType =
+  | "session.created"
+  | "session.updated"
+  | "session.killed"
+  | "session.archived"
+  | "session.restored"
+  | "task.created"
+  | "task.updated"
+  | "task.removed";
+
+/**
+ * agentproto.Event (agentproto/message.go): one message on the /v1/events plane.
+ * A session.* event's `data` is a marshaled InstanceData; created/updated carry
+ * the full projection, while killed/archived/restored carry only `{title}` (see
+ * daemon/control_server.go), so a client keys deletes/refetches off the title.
+ */
+export interface WireEvent {
+  type: EventType;
+  data?: SessionData;
+}

--- a/web/src/ui.ts
+++ b/web/src/ui.ts
@@ -1,26 +1,42 @@
-// The view layer of the web client shell (#1592 Phase 5 PR2). It renders exactly
-// two views into #app: the paste-token login (design §1.2) and the authed — but
-// still empty — app shell. The session sidebar, terminal, and modals arrive in
-// PR3+; this PR proves the serving + auth handoff with zero session UI.
+// The view layer of the web client (#1592 Phase 5). It renders two views into
+// #app: the paste-token login (design §1.2) and the authed app — a left rail of
+// live sessions (PR3) beside a main content area (the terminal lands in PR4). The
+// rail mirrors the TUI sidebar (ui/sidebar_render.go): a status dot per row from
+// the daemon projection, the title with the TUI's [lost]/[deleting]/[limit]/
+// [remote] prefixes, and the branch as the secondary line. It is a pure projection
+// of store state fed by Snapshot + /v1/events — no client-side source of truth.
 //
 // Rendering is direct DOM via a tiny `h()` helper (no framework, design §3.1) and
 // is strictly CSP-safe: no inline scripts, no inline event handlers, no innerHTML
 // with markup — everything is createElement + addEventListener, so the served
 // `Content-Security-Policy: default-src 'self'` holds.
 
-/** The whole client state for PR2: which view to show plus the login details. */
+import type { EventStreamStatus } from "./events.js";
+import { isArchived, rowStatus, rowTitle } from "./status.js";
+import type { SessionData } from "./types.js";
+
+/** The whole client state: which view to show, the login details, and — once
+ *  authed — the live session projection plus the current selection. */
 export interface AppState {
   phase: "login" | "app";
   /** true while a token probe is in flight (disables the login form). */
   connecting: boolean;
   /** an actionable message shown under the login form after a failed probe. */
   loginError: string | null;
+  /** the live session projection (Snapshot + /v1/events), the rail's data. */
+  sessions: SessionData[];
+  /** the selected row's identity (session title; titles are unique in af), or
+   *  null when nothing is selected. */
+  selectedTitle: string | null;
+  /** the /v1/events connection state, shown as a small header indicator. */
+  live: EventStreamStatus;
 }
 
 /** Callbacks the shell invokes; index.ts owns the real behavior. */
 export interface Actions {
   connect(token: string): void;
   disconnect(): void;
+  select(title: string): void;
 }
 
 /** Minimal hyperscript: create an element, apply props, append children. Keeps the
@@ -45,9 +61,31 @@ function h<K extends keyof HTMLElementTagNameMap>(
   return el;
 }
 
+/**
+ * The rail's session order, mirroring the TUI sidebar: live sessions first, the
+ * archived group last (ui/tree groups Archived under its own section), each group
+ * ordered by creation time so the list is stable across re-renders and events.
+ * Exported so keyboard navigation (index.ts) walks the SAME order the DOM shows.
+ */
+export function orderedSessions(sessions: SessionData[]): SessionData[] {
+  return [...sessions].sort((a, b) => {
+    const aa = isArchived(a) ? 1 : 0;
+    const bb = isArchived(b) ? 1 : 0;
+    if (aa !== bb) {
+      return aa - bb;
+    }
+    const at = a.created_at ?? "";
+    const bt = b.created_at ?? "";
+    if (at !== bt) {
+      return at < bt ? -1 : 1;
+    }
+    return a.title < b.title ? -1 : a.title > b.title ? 1 : 0;
+  });
+}
+
 /** Renders the current state into the given root, replacing its contents. */
 export function render(root: HTMLElement, state: AppState, actions: Actions): void {
-  root.replaceChildren(state.phase === "login" ? loginView(state, actions) : appView(actions));
+  root.replaceChildren(state.phase === "login" ? loginView(state, actions) : appView(state, actions));
 }
 
 function loginView(state: AppState, actions: Actions): HTMLElement {
@@ -99,7 +137,7 @@ function loginView(state: AppState, actions: Actions): HTMLElement {
   return h("main", { class: "af-login" }, h("div", { class: "af-card" }, ...children));
 }
 
-function appView(actions: Actions): HTMLElement {
+function appView(state: AppState, actions: Actions): HTMLElement {
   const disconnect = h("button", { type: "button", class: "af-ghost" }, "Disconnect");
   disconnect.addEventListener("click", () => actions.disconnect());
 
@@ -107,15 +145,108 @@ function appView(actions: Actions): HTMLElement {
     "header",
     { class: "af-appbar" },
     h("span", { class: "af-brand" }, "Agent Factory"),
+    liveIndicator(state.live),
     disconnect,
   );
 
-  const body = h(
-    "section",
-    { class: "af-empty" },
-    h("p", { class: "af-empty-title" }, "Connected."),
-    h("p", { class: "af-empty-hint" }, "The session list and terminal arrive in the next update."),
+  const body = h("div", { class: "af-body" }, sidebar(state, actions), mainPane(state));
+  return h("main", { class: "af-app" }, header, body);
+}
+
+/** The events-stream health pip in the header: green when the push stream is open,
+ *  amber while (re)connecting — so "live updates are flowing" is legible at a glance. */
+function liveIndicator(live: EventStreamStatus): HTMLElement {
+  const label = live === "open" ? "Live" : live === "connecting" ? "Connecting…" : "Reconnecting…";
+  const pip = h("span", { class: `af-live-pip af-live-${live}` });
+  pip.setAttribute("aria-hidden", "true");
+  const wrap = h("span", { class: "af-live" }, pip, h("span", { class: "af-live-label" }, label));
+  wrap.setAttribute("role", "status");
+  return wrap;
+}
+
+/** The left rail: a header with the session count and a row per session. */
+function sidebar(state: AppState, actions: Actions): HTMLElement {
+  const count = state.sessions.length;
+  const head = h(
+    "div",
+    { class: "af-rail-head" },
+    h("span", { class: "af-rail-title" }, "Sessions"),
+    h("span", { class: "af-rail-count" }, String(count)),
   );
 
-  return h("main", { class: "af-app" }, header, body);
+  const list = h("ul", { class: "af-rail-list" });
+  list.setAttribute("role", "listbox");
+  list.setAttribute("aria-label", "Sessions");
+  if (count === 0) {
+    list.append(
+      h(
+        "li",
+        { class: "af-rail-empty" },
+        "No sessions yet. Create one in the TUI or with ",
+        h("code", {}, "af sessions create"),
+        ".",
+      ),
+    );
+  } else {
+    for (const s of orderedSessions(state.sessions)) {
+      list.append(sessionRow(s, s.title === state.selectedTitle, actions));
+    }
+  }
+
+  return h("nav", { class: "af-rail" }, head, list);
+}
+
+/** One session row: a status dot, the (prefixed) title, and the branch line —
+ *  the same three signals the TUI row carries (ui/tree/render.go). */
+function sessionRow(s: SessionData, selected: boolean, actions: Actions): HTMLElement {
+  const status = rowStatus(s);
+  const dot = h(
+    "span",
+    { class: `af-dot af-dot-${status.kind}${status.spinning ? " af-dot-spin" : ""}` },
+    status.glyph,
+  );
+  dot.setAttribute("aria-hidden", "true");
+
+  const title = h("div", { class: "af-row-title" }, rowTitle(s));
+  const branch = h(
+    "div",
+    { class: "af-row-branch" },
+    h("span", { class: "af-branch-icon" }, "⎇"),
+    " ",
+    s.branch || "—",
+  );
+
+  const cls = `af-row${selected ? " af-row-selected" : ""}${isArchived(s) ? " af-row-archived" : ""}`;
+  const row = h("li", { class: cls }, dot, h("div", { class: "af-row-main" }, title, branch));
+  row.setAttribute("role", "option");
+  row.setAttribute("aria-selected", selected ? "true" : "false");
+  row.setAttribute("title", `${s.title} — ${status.label}`);
+  row.addEventListener("click", () => actions.select(s.title));
+  return row;
+}
+
+/** The main content area — an empty state until the terminal lands in PR4. It
+ *  names the selected session so selection is visibly wired end-to-end. */
+function mainPane(state: AppState): HTMLElement {
+  const selected = state.sessions.find((s) => s.title === state.selectedTitle) ?? null;
+  if (!selected) {
+    return h(
+      "section",
+      { class: "af-main af-main-empty" },
+      h("p", { class: "af-empty-title" }, "Select a session"),
+      h("p", { class: "af-empty-hint" }, "The terminal arrives in the next update."),
+    );
+  }
+  const status = rowStatus(selected);
+  return h(
+    "section",
+    { class: "af-main af-main-empty" },
+    h("p", { class: "af-empty-title" }, selected.title),
+    h(
+      "p",
+      { class: "af-empty-hint" },
+      `${status.label}${selected.branch ? ` · ${selected.branch}` : ""}`,
+    ),
+    h("p", { class: "af-empty-hint" }, "The terminal for this session arrives in the next update."),
+  );
 }


### PR DESCRIPTION
Fills the authed web app's left rail with the **live session list** — the first real UI mirroring the TUI. Merged so far: PR1 (frame codec + `MsgHello`), PR2 (embedded SPA + paste-token login → authed empty app). This PR makes that empty app render the sessions and keep them live.

**Scope: READ-ONLY** — list + live status. Terminal/attach is PR4; create/kill actions are PR5. Additive only: no daemon route, no protocol change, no new config key.

## Snapshot → rail render

On login the app POSTs `/v1/Snapshot` (`web/src/api.ts` `fetchSnapshot`, the same read the TUI mirrors since #960) and renders each `InstanceData` as a row in a left rail mirroring `ui/sidebar_render.go`:

- a **status dot**, the **title** with the TUI's state prefixes, and the **branch** as the secondary line;
- rows ordered live-first then archived-last (mirroring the TUI's Archived section), by `created_at`;
- click or **↑/↓ (j/k)** to select a row; the main pane names the selection (the terminal fills it in PR4).

The wire shapes are reused as-is — `web/src/types.ts` hand-mirrors the subset of `session.InstanceData` the rail reads plus the `Liveness`/`InFlightOp` int enums (design §3.2); the projection is not forked.

## Liveness/InFlightOp → status dot (matches the TUI)

`web/src/status.ts` is a **line-for-line port of `ui/tree/render.go`** — the single source of truth for the dot. Same TOTAL liveness switch (`render.go:272-301`), same glyphs (shape carries state for color-blindness, #935), same lipgloss hexes, same title prefixes:

| Liveness / op | TUI (`render.go`) | Web dot | Title prefix |
|---|---|---|---|
| any in-flight op / `LiveRunning` / `Unset` | spinner (default fg) | `●` working, pulsing | `[deleting]` while killing/archiving |
| `LiveReady` | `●` `#7F9F7F` | `●` green | — |
| `LiveLost` | `◌` `#F0DFAF` | `◌` amber | `[lost]` |
| `LiveDead` | `○` `#989890` | `○` gray | — |
| `LiveArchived` | `▧` `#989890` | `▧` gray, dimmed | none (glyph+dim only, `render.go:326`) |
| `LiveLimitReached` | `◆` `#CC9393` | `◆` red-orange | `[limit] resets <t>` |

`[remote]` is prepended for a `backend_type == "remote"` row. `status.test.ts` pins the parity for every value.

## /v1/events PUSH, no polling

`web/src/events.ts` `EventStream` subscribes to the daemon's `/v1/events` WebSocket over `wss://…?access_token=<token>` (browsers can't set WS headers; the daemon already accepts the query param, `agentproto/auth.go:23`). Browsers answer the daemon keepalive ping at the protocol layer, so there's no client keepalive. Deltas fold through a **pure reducer** (`web/src/sessions.ts`, unit-tested in `sessions.test.ts`):

- `session.created` / `session.updated` (full `InstanceData`) → upsert in place — the instant, poll-free path;
- `session.killed` (title only) → remove the row (and clear a stale selection);
- `session.archived` / `session.restored` (title only, no liveness to reconstruct) → debounced authoritative re-Snapshot.

On any drop the stream reconnects with capped exponential backoff and re-Snapshots on reconnect (missed events aren't replayed — the hub is drop-slow — so a fresh Snapshot resynchronises). A header pip shows Live / Reconnecting. **No polling loop anywhere.**

Vanilla TS + the tiny store, no framework (locked, design §3.1). Reproducible esbuild bundle committed to `web/dist/`.

## Play-test transcript (isolated container fence)

Ran a throwaway harness inside `scripts/testbox.sh` (private tmux, throwaway AF home, mock repo) that does **exactly what `web/src` does** — POST `/v1/Snapshot` to seed the rail, then subscribe to the `/v1/events` WS with `?access_token=` — while real `af sessions create`/`kill` mutations run over a live daemon + TLS TCP listener. It proves the rail updates live via push with no poll (throwaway, not committed — PR3 is web-only; the scripted browser regression harness is PR6):

```
PLAYTEST: created 'alpha' before connecting (seeds the rail)
PLAYTEST: GET Snapshot over TLS+token → rail seeds with [alpha(liveness=1)]
PLAYTEST: subscribed to /v1/events push stream (no polling)
PLAYTEST: `af sessions create beta` issued; watching the push stream…
PLAYTEST:   ← push session.created{beta}
PLAYTEST: ✓ session.created{beta} arrived via PUSH — rail adds the row live
PLAYTEST: `af sessions kill beta` issued; watching the push stream…
PLAYTEST:   ← push session.updated{alpha}
PLAYTEST:   ← push session.killed{beta}
PLAYTEST: ✓ session.killed{beta} arrived via PUSH — rail drops the row live
PLAYTEST: PASS — Snapshot seeds the rail; /v1/events pushes create+kill with no poll
--- PASS: TestWebSidebarLivePlaytest (3.30s)
```

`liveness=1` (Running) confirms the Snapshot→dot mapping; the `session.updated{alpha}` push is a live liveness transition that `applyEvent` upserts in place (dots update live too). No status-dot mismatch vs the TUI observed. The full browser-DOM render + a scripted create/kill in a live Chromium is PR6's Playwright harness, per the plan.

## Gates

- `go build ./...`, `gofmt -l`, `golangci-lint --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — clean (zero Go changes)
- `make web-build` reproducible (two builds → identical bytes; committed `dist/` matches source) + `make web-test` green (**35/35**: frame parity + status parity + reducer/ordering)
- `make tui-driver-selftest` **25/25** (daemon/TUI unaffected)
- gen-docs: no drift (no CLI/API/help surface changed; `docs/web.md` is PR10)

Refs #1592. Do not merge yet — root re-verifies + merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)