### PR TITLE
fix(tui): restore pane cursor in initial repaint — render correctly (not OpHello) (#1592 Phase 5 follow-up)

### DIFF
--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -371,12 +371,15 @@ func (c *remoteClientlessChannel) Resize(rows, cols uint16) error {
 // repaint the broker injects so a fresh local subscriber sees the screen before
 // the first live byte, mirroring tmux capture-pane. The WS stream carries only
 // future output, so without this a just-opened remote pane would render blank.
-func (c *remoteClientlessChannel) Snapshot() ([]byte, error) {
+func (c *remoteClientlessChannel) Snapshot() (PaneSnapshot, error) {
 	content, err := c.rc.preview(c.tab, false)
 	if err != nil {
-		return nil, err
+		return PaneSnapshot{}, err
 	}
-	return []byte(content), nil
+	// REST Preview carries only the screen, not the cursor position, so the repaint
+	// omits cursor restore for remote panes (HasCursor stays false) — the pre-fix
+	// behavior, unchanged over the wire.
+	return PaneSnapshot{Screen: []byte(content)}, nil
 }
 
 // activeConn returns the live capture socket and its context, or an error if

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -56,10 +56,26 @@ type clientlessChannel interface {
 	// Resize sets the pane/window size (clientless resize-window). Last-resize-wins
 	// is enforced by the broker; this just applies the winning size.
 	Resize(rows, cols uint16) error
-	// Snapshot returns the pane's current visible screen (with escapes) — the
-	// repaint the broker injects on subscribe and after a resize, since pipe-pane
-	// never delivers tmux's screen redraw (#1592 Phase 2 PR6).
-	Snapshot() ([]byte, error)
+	// Snapshot returns the pane's current visible screen AND the pane cursor
+	// position — the repaint the broker injects on subscribe, since pipe-pane never
+	// delivers tmux's screen redraw (#1592 Phase 2 PR6). The cursor position lets the
+	// repaint leave the emulator cursor where the pane program's cursor actually is;
+	// without it the snapshot's trailing blank lines strand the emulator cursor at the
+	// bottom, so the pane's next relative-positioned redraw (a shell's SIGWINCH prompt
+	// redraw) lands there and orphans a stale copy at the top (the duplicated-prompt
+	// artifact). HasCursor is false when the channel cannot report a position (the
+	// remote REST-preview snapshot), in which case the repaint omits cursor restore.
+	Snapshot() (PaneSnapshot, error)
+}
+
+// PaneSnapshot is a fresh-subscriber repaint source: the pane's current visible
+// screen (with escapes) plus the pane cursor position. CursorRow/CursorCol are
+// 0-based; they are meaningful only when HasCursor is true.
+type PaneSnapshot struct {
+	Screen    []byte
+	CursorRow int
+	CursorCol int
+	HasCursor bool
 }
 
 // ptyBroker is the per-session data plane. Guarded by mu; the ring buffer, the
@@ -156,7 +172,7 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 	// the snapshot and the cursor: bytes in that tiny window are simply in both the
 	// snapshot and the replayed tail (a harmless double-render), never dropped.
 	if since == 0 {
-		if snap, err := b.ch.Snapshot(); err == nil && len(snap) > 0 {
+		if snap, err := b.ch.Snapshot(); err == nil && len(snap.Screen) > 0 {
 			rp := buildRepaint(snap)
 			b.mu.Lock()
 			sub.pendingRepaint = rp
@@ -167,14 +183,27 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 	return sub, nil
 }
 
-// buildRepaint turns a capture-pane snapshot into bytes that reconstruct the
-// screen when written to the emulator: clear + home, then the captured lines with
-// CR before each LF so every line starts at column 0 (capture-pane joins lines
-// with bare "\n", which would otherwise leave the column where the previous line
-// ended).
-func buildRepaint(snapshot []byte) []byte {
-	body := strings.ReplaceAll(string(snapshot), "\n", "\r\n")
-	return append([]byte("\x1b[2J\x1b[H"), body...)
+// buildRepaint turns a pane snapshot into bytes that reconstruct the screen when
+// written to the emulator: clear + home, then the captured lines with CR before
+// each LF so every line starts at column 0 (capture-pane joins lines with bare
+// "\n", which would otherwise leave the column where the previous line ended).
+//
+// It ends by restoring the cursor to the pane's actual position (1-based CSI H)
+// when the snapshot carries one. Writing the full screen leaves the emulator
+// cursor at the bottom of the captured lines — including the trailing blank rows a
+// fresh shell's snapshot carries — but the pane program's cursor is wherever it
+// really is (row 0 for a just-started shell). Without the restore, the pane's next
+// relative-positioned output (a shell's SIGWINCH prompt redraw, which uses CR to
+// return to the current line) renders at the bottom while the repaint's copy sits
+// stale at the top: the duplicated-prompt artifact. The restore lands the emulator
+// cursor on the real position so that redraw overwrites in place.
+func buildRepaint(snap PaneSnapshot) []byte {
+	body := strings.ReplaceAll(string(snap.Screen), "\n", "\r\n")
+	out := append([]byte("\x1b[2J\x1b[H"), body...)
+	if snap.HasCursor {
+		out = append(out, []byte(fmt.Sprintf("\x1b[%d;%dH", snap.CursorRow+1, snap.CursorCol+1))...)
+	}
+	return out
 }
 
 // ensureCaptureStarted brings the clientless output capture up if it is not

--- a/session/ptybroker_test.go
+++ b/session/ptybroker_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/charmbracelet/x/vt"
 )
 
 // fakeClientlessChannel is an in-memory clientlessChannel: StartCapture hands
@@ -25,6 +28,12 @@ type fakeClientlessChannel struct {
 	// subscribe and after a resize; snapshots counts how many times it was read.
 	snapshot  []byte
 	snapshots int
+	// cursorRow/cursorCol/hasCursor are the canned cursor position Snapshot reports
+	// (0-based); hasCursor false (the default) means "channel can't report a cursor",
+	// so the repaint omits cursor restore — the pre-fix behavior.
+	cursorRow int
+	cursorCol int
+	hasCursor bool
 	// wClosed reports whether the CURRENT capture writer (f.w) has been closed by a
 	// StopCapture — the test proxy for "the pane pipe was disabled". Reset on each
 	// StartCapture. Used by the #1661 teardown-clobber regression test.
@@ -85,11 +94,16 @@ func (f *fakeClientlessChannel) Resize(rows, cols uint16) error {
 	return nil
 }
 
-func (f *fakeClientlessChannel) Snapshot() ([]byte, error) {
+func (f *fakeClientlessChannel) Snapshot() (PaneSnapshot, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.snapshots++
-	return append([]byte(nil), f.snapshot...), nil
+	return PaneSnapshot{
+		Screen:    append([]byte(nil), f.snapshot...),
+		CursorRow: f.cursorRow,
+		CursorCol: f.cursorCol,
+		HasCursor: f.hasCursor,
+	}, nil
 }
 
 // emit writes pane output into the capture pipe. Write blocks until the broker's
@@ -189,6 +203,100 @@ func TestPTYBrokerInitialRepaint(t *testing.T) {
 	}
 	ch.emit(t, []byte("live"))
 	mustData(t, re, "live")
+}
+
+// gridRows renders a vt emulator's grid to plain-text rows (cell contents, blanks
+// as spaces) so a test can assert what a terminal would actually show.
+func gridRows(emu *vt.Emulator, w, h int) []string {
+	rows := make([]string, h)
+	for y := 0; y < h; y++ {
+		var b strings.Builder
+		for x := 0; x < w; x++ {
+			if c := emu.CellAt(x, y); c != nil && c.Content != "" {
+				b.WriteString(c.Content)
+			} else {
+				b.WriteString(" ")
+			}
+		}
+		rows[y] = strings.TrimRight(b.String(), " ")
+	}
+	return rows
+}
+
+// TestPTYBrokerRepaintRestoresCursor pins the duplicated-prompt fix. The initial
+// repaint replays a capture-pane snapshot — for a fresh shell that is the prompt on
+// row 0 followed by trailing blank rows (capture-pane emits the full pane height).
+// Writing that body leaves the emulator cursor at the BOTTOM, but the pane program's
+// cursor is really on row 0. Before the fix, the pane's next relative-positioned
+// redraw (a shell's SIGWINCH prompt redraw, which uses CR to return to the current
+// line) therefore landed at the bottom and orphaned the row-0 copy: the prompt
+// rendered TWICE. The fix makes the repaint restore the cursor to the pane's real
+// position, so the redraw overwrites in place and the prompt renders ONCE. This is
+// the deterministic form of the visual artifact: feed the repaint the broker
+// produces, then the CR-redraw, into the SAME vt emulator the TUI/attach consumers
+// use, and count the prompt rows.
+func TestPTYBrokerRepaintRestoresCursor(t *testing.T) {
+	const cols, rows = 40, 8
+	const prompt = "user@host$ "
+	// The snapshot: prompt on row 0, then trailing blank rows to fill the pane — the
+	// exact shape `capture-pane -p -e -J` returns for a just-started shell.
+	screen := prompt + strings.Repeat("\n", rows-1)
+
+	// The CR-based prompt redraw a shell emits on the connect-time SIGWINCH: return
+	// to column 0 of the CURRENT line, clear it, reprint the prompt.
+	redraw := []byte("\r\x1b[K" + prompt)
+
+	repaintFor := func(hasCursor bool) []byte {
+		ch := &fakeClientlessChannel{
+			snapshot:  []byte(screen),
+			hasCursor: hasCursor,
+			cursorRow: 0, cursorCol: len(prompt),
+		}
+		br := newPTYBroker(ch)
+		sub, err := br.subscribe(0)
+		if err != nil {
+			t.Fatalf("subscribe: %v", err)
+		}
+		ev, err := nextWithin(t, sub, 2*time.Second)
+		if err != nil {
+			t.Fatalf("repaint NextEvent: %v", err)
+		}
+		if ev.Kind != PTYRepaint {
+			t.Fatalf("first event = %+v, want PTYRepaint", ev)
+		}
+		return ev.Data
+	}
+	countPromptRows := func(repaint []byte) (int, []string) {
+		emu := vt.NewEmulator(cols, rows)
+		_, _ = emu.Write(repaint)
+		_, _ = emu.Write(redraw)
+		grid := gridRows(emu, cols, rows)
+		n := 0
+		for _, ln := range grid {
+			if strings.Contains(ln, "user@host$") {
+				n++
+			}
+		}
+		return n, grid
+	}
+
+	// With the cursor restored (the fix), the redraw overwrites row 0 — one prompt.
+	n, grid := countPromptRows(repaintFor(true))
+	if n != 1 {
+		t.Fatalf("with cursor restore: prompt on %d rows, want 1 (duplicated-prompt artifact): %#v", n, grid)
+	}
+	if !strings.Contains(grid[0], "user@host$") {
+		t.Fatalf("with cursor restore: prompt not on row 0 (the pane's real cursor row): %#v", grid)
+	}
+
+	// Control: WITHOUT the cursor position the pre-fix behavior returns — the redraw
+	// lands at the bottom while row 0 stays stale, so the prompt doubles. This proves
+	// the test actually discriminates the artifact (and guards the graceful-degrade
+	// path the remote channel relies on).
+	n, grid = countPromptRows(repaintFor(false))
+	if n != 2 {
+		t.Fatalf("without cursor: prompt on %d rows, want 2 (the pre-fix doubling this test guards against): %#v", n, grid)
+	}
 }
 
 func TestPTYBrokerFanout(t *testing.T) {

--- a/session/ptychannel_tmux.go
+++ b/session/ptychannel_tmux.go
@@ -89,17 +89,24 @@ func (c *tmuxClientlessChannel) SendRaw(b []byte) error {
 }
 
 // Snapshot returns the pane's current visible screen with escape sequences
-// (`capture-pane -p -e -J`) — the repaint the broker injects so a fresh subscriber
-// (and every subscriber after a resize) sees the actual screen. `pipe-pane` only
-// streams FUTURE output, and — unlike a `tmux attach` client — never receives
-// tmux's screen redraw, so without this a just-opened or just-resized pane would
-// render blank until the next byte of output (#1592 Phase 2 PR6).
-func (c *tmuxClientlessChannel) Snapshot() ([]byte, error) {
+// (`capture-pane -p -e -J`) plus the pane cursor position — the repaint the broker
+// injects so a fresh subscriber sees the actual screen. `pipe-pane` only streams
+// FUTURE output, and — unlike a `tmux attach` client — never receives tmux's screen
+// redraw, so without this a just-opened pane would render blank until the next byte
+// of output (#1592 Phase 2 PR6). The cursor position lets the repaint leave the
+// emulator cursor where the pane program's cursor really is (see PaneSnapshot).
+func (c *tmuxClientlessChannel) Snapshot() (PaneSnapshot, error) {
 	content, err := c.ts.CapturePaneContent()
 	if err != nil {
-		return nil, err
+		return PaneSnapshot{}, err
 	}
-	return []byte(content), nil
+	snap := PaneSnapshot{Screen: []byte(content)}
+	// The cursor position is best-effort: a failure to read it degrades to a
+	// screen-only repaint (the pre-fix behavior) rather than failing the subscribe.
+	if row, col, curErr := c.ts.CursorPosition(); curErr == nil {
+		snap.CursorRow, snap.CursorCol, snap.HasCursor = row, col, true
+	}
+	return snap, nil
 }
 
 // Resize applies the winning size to the window (clientless resize-window). tmux

--- a/session/tmux/io.go
+++ b/session/tmux/io.go
@@ -162,6 +162,24 @@ func (t *TmuxSession) CapturePaneContent() (string, error) {
 	return string(output), nil
 }
 
+// CursorPosition reports the pane cursor position as 0-based (row, col) via
+// display-message (`#{cursor_y} #{cursor_x}`, both 0-based in tmux). The broker's
+// repaint uses it to restore the emulator cursor to where the pane program's
+// cursor actually is, so a fresh subscriber's redraw does not orphan a stale copy
+// of the line at the top (the duplicated-prompt artifact). `=` forces an exact
+// session match, mirroring CapturePaneContent (#1006).
+func (t *TmuxSession) CursorPosition() (row, col int, err error) {
+	cmd := exec.Command("tmux", "display-message", "-p", "-t", exactTarget(t.sanitizedName), "#{cursor_y} #{cursor_x}")
+	output, err := t.cmdExec.Output(cmd)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read tmux cursor position: %v", err)
+	}
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(output)), "%d %d", &row, &col); err != nil {
+		return 0, 0, fmt.Errorf("failed to parse tmux cursor position %q: %v", string(output), err)
+	}
+	return row, col, nil
+}
+
 // CapturePaneContentWithOptions captures the pane content with additional options
 // start and end specify the starting and ending line numbers (use "-" for the start/end of history).
 // Wraps ErrSessionGone when the session has vanished, mirroring CapturePaneContent.


### PR DESCRIPTION
## Summary

Investigation of Sachin's "TUI renders a bit weird" report on `1.0.182-preview-1` (master incl. #1592 Phase 5 PR1–3). **The prime suspect — PR1's additive `OpHello` frame (#1672) — is ruled out.** The real, reproduced artifact is a **duplicated shell prompt** on pane open and full-screen attach, rooted in the initial repaint (#1592 **Phase 2 PR6**), independent of Phase 5.

## Exact visual symptom (the missing detail)

On opening a live pane (`s`) **or** a full-screen attach (`o`), the shell prompt renders **twice** — a stale copy pinned to the top row and the live copy ~30 rows down:

```
row 1:  dev@host:~/…$      ← stale (from the repaint), never cleared
 …blank…
row 31: dev@host:~/…$      ← live prompt (the actual cursor)
```

## OpHello ruled out (evidence)

| Check | Result |
|---|---|
| A/B repro: daemon built **with** `OpHello`-emit vs **patched out**, identical scripted flow | **Byte-identical** render — embedded pane *and* full-screen attach |
| All 4 WS-frame consumers (`app/live_stream.go`, `apiclient/attach.go`, `session/agentserver_remote.go`, `daemon/ws_pty.go`) | Every one **skips `OpHello`** — its bytes never reach an emulator |
| PR2 (#1673) / PR3 (#1674) | TCP/TLS web listener only; TUI uses the unix socket + untouched `/v1/*` routes |

`OpHello` is purely additive and correctly ignored. PR1 is clean. The doubled prompt reproduces identically on the pre-`OpHello` baseline.

## Root cause

`buildRepaint` (`session/ptybroker.go`) replays a `capture-pane` snapshot — for a fresh shell that's the prompt on row 0 followed by **trailing blank rows** (capture-pane emits the full pane height). Writing that body leaves the **emulator** cursor at the bottom, but the pane program's real cursor is on row 0. The connect-time RESIZE fires a SIGWINCH; the shell redraws its prompt with **relative** positioning (`CR` to the current line), which the emulator applies at *its* cursor (bottom) — so the redraw lands low and the row-0 copy is orphaned. **The snapshot restored screen content but not cursor position.** Full-screen alt-screen agents (codex) use absolute positioning, so they glitch less — matching "kinda working, but weird."

## Fix

Carry the pane cursor position in the snapshot and have `buildRepaint` append an absolute cursor-home escape so post-repaint relative output overwrites in place:

- `clientlessChannel.Snapshot()` now returns `PaneSnapshot{Screen, CursorRow, CursorCol, HasCursor}`.
- The tmux channel fills the cursor via a new `TmuxSession.CursorPosition()` (`display-message #{cursor_y}/#{cursor_x}`, best-effort — a read failure degrades to the prior screen-only repaint).
- The remote channel leaves `HasCursor:false` (REST preview carries no cursor) — **no wire change**, graceful degrade to prior behavior.

Only the subscribe-time repaint changes; the resize path still injects no repaint, so the `ptybroker.go:306` resize-race guard is untouched.

## Regression test

`TestPTYBrokerRepaintRestoresCursor` feeds the broker's repaint plus a CR-based prompt redraw into the **same `vt` emulator** the TUI/attach consumers use and asserts the prompt renders on exactly **one** row (row 0) with the cursor restored — and **doubles to two** rows without it (a control proving the test discriminates the artifact and guards the remote graceful-degrade path).

## Verification

- **Before/after playtest-container A/B:** doubled prompt present on baseline & HEAD; **gone** after the fix in both embedded pane and full-screen attach.
- gofmt / `golangci-lint --fast` / `deadcode -test ./...` / `go build ./...` — clean
- `make test-container` — full suite green
- `make tui-driver-selftest` — **25/25**
- `make ws-pty-roundtrip-container` — green

This is a **#1592 Phase 5 PR1 follow-up** in the sense that the Phase-5 `OpHello` report triggered the investigation; the actual bug is a pre-existing Phase 2 PR6 repaint issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)