### PR TITLE
fix(daemon,web): resolve web kill/archive/prompt by stable id, not cross-repo-ambiguous title (#1592 Phase 5 follow-up)

### DIFF
--- a/daemon/action_id_resolution_test.go
+++ b/daemon/action_id_resolution_test.go
@@ -1,0 +1,210 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/sachiniyer/agent-factory/agentproto"
+	"github.com/sachiniyer/agent-factory/config"
+	"github.com/sachiniyer/agent-factory/session"
+)
+
+// createDuplicateTitleSessions builds TWO real sessions that share the SAME title
+// in DIFFERENT repos under one manager/home — the cross-repo title collision at
+// the heart of the #1592 Phase 5 follow-up bug. It returns the manager, the two
+// repos, and their two distinct stable ids. Before the id-first action resolver,
+// a web kill/archive/send-prompt sent {title, repo_id:""} and the daemon resolved
+// it by FIRST title match in nondeterministic map order — so a destructive action
+// could hit the wrong repo's session.
+func createDuplicateTitleSessions(t *testing.T, title string) (*Manager, config.RepoContext, session.InstanceData, config.RepoContext, session.InstanceData) {
+	t.Helper()
+	t.Setenv("AGENT_FACTORY_HOME", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.ProgramOverrides = map[string]string{"claude": "sh -c 'echo agent-ready; exec sleep 600'"}
+	if err := config.SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+	manager, err := NewManager(cfg)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	create := func() (config.RepoContext, session.InstanceData) {
+		repoPath := setupOriginMasterRepo(t)
+		repo, err := config.RepoFromPath(repoPath)
+		if err != nil {
+			t.Fatalf("RepoFromPath: %v", err)
+		}
+		data, err := manager.CreateSession(CreateSessionRequest{Title: title, RepoPath: repoPath, Program: "claude"})
+		if err != nil {
+			t.Fatalf("CreateSession(%s): %v", repoPath, err)
+		}
+		if data.ID == "" {
+			t.Fatalf("created session has no stable id: %+v", data)
+		}
+		return *repo, data
+	}
+
+	repoA, dataA := create()
+	repoB, dataB := create()
+	if repoA.ID == repoB.ID {
+		t.Fatalf("test repos collided on id %q; they must differ", repoA.ID)
+	}
+	if dataA.ID == dataB.ID {
+		t.Fatalf("the two sessions share stable id %q; they must differ", dataA.ID)
+	}
+	t.Cleanup(func() {
+		_ = manager.KillSession(KillSessionRequest{Title: title, RepoID: repoA.ID})
+		_ = manager.KillSession(KillSessionRequest{Title: title, RepoID: repoB.ID})
+	})
+	return manager, repoA, dataA, repoB, dataB
+}
+
+// assertTracked asserts a session with the given stable id is still tracked in the
+// manager's live instance map under the given repo.
+func assertTracked(t *testing.T, m *Manager, repoID, title, wantID string) {
+	t.Helper()
+	inst, _, _, err := m.findSession(title, repoID)
+	if err != nil {
+		t.Fatalf("expected session %q in repo %s to survive, but findSession failed: %v", title, repoID, err)
+	}
+	if inst == nil || inst.ID != wantID {
+		got := "<nil>"
+		if inst != nil {
+			got = inst.ID
+		}
+		t.Fatalf("survivor lookup returned id %q, want %q — the WRONG session was operated on", got, wantID)
+	}
+}
+
+// TestResolveActionSessionByIDDisambiguatesCrossRepoTitle pins the crux of the
+// fix: with two same-title sessions in different repos and an EMPTY repo id, the
+// resolver keys off the stable id — the resolution all three write actions
+// (kill/archive/send-prompt) share — and returns exactly the addressed session,
+// never the first title match. The id-less title path still resolves (CLI contract).
+func TestResolveActionSessionByIDDisambiguatesCrossRepoTitle(t *testing.T) {
+	manager, repoA, dataA, repoB, dataB := createDuplicateTitleSessions(t, "feature")
+
+	// By id, empty repo → exactly the addressed session, correct repo.
+	inst, rid, title, _, err := manager.resolveActionSession(dataB.ID, "feature", "")
+	if err != nil {
+		t.Fatalf("resolveActionSession by id B: %v", err)
+	}
+	if inst == nil || inst.ID != dataB.ID {
+		t.Fatalf("resolved id = %v, want %q", inst, dataB.ID)
+	}
+	if rid != repoB.ID {
+		t.Fatalf("resolved repo = %q, want %q (repo B)", rid, repoB.ID)
+	}
+	if title != "feature" {
+		t.Fatalf("resolved title = %q, want %q", title, "feature")
+	}
+
+	inst, rid, _, _, err = manager.resolveActionSession(dataA.ID, "feature", "")
+	if err != nil {
+		t.Fatalf("resolveActionSession by id A: %v", err)
+	}
+	if inst == nil || inst.ID != dataA.ID || rid != repoA.ID {
+		t.Fatalf("resolved (%v, %q), want id %q repo %q", inst, rid, dataA.ID, repoA.ID)
+	}
+
+	// Id-less title path still works when the repo disambiguates (CLI/TUI contract).
+	inst, _, _, _, err = manager.resolveActionSession("", "feature", repoA.ID)
+	if err != nil {
+		t.Fatalf("resolveActionSession by title+repo A: %v", err)
+	}
+	if inst == nil || inst.ID != dataA.ID {
+		t.Fatalf("title+repo resolved id = %v, want %q", inst, dataA.ID)
+	}
+}
+
+// TestKillSessionByIDTargetsRightSessionAcrossRepoTitleCollision is the direct
+// analogue of Greptile's repro on the DESTRUCTIVE path: two same-title sessions in
+// different repos, a KillSession carrying the stable id (and an empty repo id, as
+// the web sends). The addressed session must die and the other must survive —
+// where a title-with-empty-repo request could kill either one. It also pins that
+// the killed event carries the addressed id.
+func TestKillSessionByIDTargetsRightSessionAcrossRepoTitleCollision(t *testing.T) {
+	manager, repoA, dataA, _, dataB := createDuplicateTitleSessions(t, "feature")
+	cs := &controlServer{manager: manager}
+
+	_, ch := manager.events.subscribe()
+	var resp KillSessionResponse
+	// Web-shaped request: id is the key, repo_id empty. Targets B.
+	if err := cs.KillSession(KillSessionRequest{ID: dataB.ID, Title: "feature", RepoID: ""}, &resp); err != nil {
+		t.Fatalf("KillSession by id B: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("KillSession resp not OK")
+	}
+
+	got := drainNextSessionEvent(t, ch, agentproto.EventSessionKilled)
+	if got.ID != dataB.ID {
+		t.Fatalf("killed event ID = %q, want %q (the addressed session)", got.ID, dataB.ID)
+	}
+
+	// The OTHER repo's same-title session must be untouched.
+	assertTracked(t, manager, repoA.ID, "feature", dataA.ID)
+
+	// And B must be gone: no live instance carries B's id anymore.
+	if rid := repoTrackingID(manager, dataB.ID); rid != "" {
+		t.Fatalf("session B (id %q) should have been killed but is still tracked under repo %q", dataB.ID, rid)
+	}
+}
+
+// repoTrackingID returns the repo id whose live instance currently carries the
+// given stable id, or "" if no live instance does (e.g. it was killed).
+func repoTrackingID(m *Manager, id string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, inst := range m.instances {
+		if inst.ID == id {
+			rid, _ := splitDaemonInstanceKey(key)
+			return rid
+		}
+	}
+	return ""
+}
+
+// TestArchiveSessionByIDTargetsRightSession pins the same id-first targeting for
+// the archive action: archiving B by id leaves A running.
+func TestArchiveSessionByIDTargetsRightSession(t *testing.T) {
+	manager, repoA, dataA, _, dataB := createDuplicateTitleSessions(t, "feature")
+	cs := &controlServer{manager: manager}
+
+	_, ch := manager.events.subscribe()
+	var resp ArchiveSessionResponse
+	if err := cs.ArchiveSession(ArchiveSessionRequest{ID: dataB.ID, Title: "feature", RepoID: ""}, &resp); err != nil {
+		t.Fatalf("ArchiveSession by id B: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("ArchiveSession resp not OK")
+	}
+	got := drainNextSessionEvent(t, ch, agentproto.EventSessionArchived)
+	if got.ID != dataB.ID {
+		t.Fatalf("archived event ID = %q, want %q", got.ID, dataB.ID)
+	}
+
+	// A survives and is still live (not archived).
+	assertTracked(t, manager, repoA.ID, "feature", dataA.ID)
+	inst, _, _, err := manager.findSession("feature", repoA.ID)
+	if err != nil {
+		t.Fatalf("findSession A after archiving B: %v", err)
+	}
+	if inst.GetLiveness() == session.LiveArchived {
+		t.Fatalf("session A was archived, but only B should have been")
+	}
+}
+
+// TestSendPromptByIDTargetsRightSession pins that a send-prompt addressed by id
+// (empty repo) resolves to the addressed session and delivers — where a title-only
+// request could resolve to either same-title session.
+func TestSendPromptByIDTargetsRightSession(t *testing.T) {
+	manager, _, _, _, dataB := createDuplicateTitleSessions(t, "feature")
+
+	// Sending by id B with an empty repo must resolve to B and deliver without
+	// error. (The resolver test above proves it is B, not the first title match.)
+	if err := manager.SendPrompt(SendPromptRequest{ID: dataB.ID, Title: "feature", RepoID: "", Prompt: "hello"}); err != nil {
+		t.Fatalf("SendPrompt by id B: %v", err)
+	}
+}

--- a/daemon/action_id_resolution_test.go
+++ b/daemon/action_id_resolution_test.go
@@ -54,8 +54,8 @@ func createDuplicateTitleSessions(t *testing.T, title string) (*Manager, config.
 		t.Fatalf("the two sessions share stable id %q; they must differ", dataA.ID)
 	}
 	t.Cleanup(func() {
-		_ = manager.KillSession(KillSessionRequest{Title: title, RepoID: repoA.ID})
-		_ = manager.KillSession(KillSessionRequest{Title: title, RepoID: repoB.ID})
+		_, _ = manager.KillSession(KillSessionRequest{Title: title, RepoID: repoA.ID})
+		_, _ = manager.KillSession(KillSessionRequest{Title: title, RepoID: repoB.ID})
 	})
 	return manager, repoA, dataA, repoB, dataB
 }
@@ -85,8 +85,8 @@ func assertTracked(t *testing.T, m *Manager, repoID, title, wantID string) {
 func TestResolveActionSessionByIDDisambiguatesCrossRepoTitle(t *testing.T) {
 	manager, repoA, dataA, repoB, dataB := createDuplicateTitleSessions(t, "feature")
 
-	// By id, empty repo → exactly the addressed session, correct repo.
-	inst, rid, title, _, err := manager.resolveActionSession(dataB.ID, "feature", "")
+	// By id, empty repo → exactly the addressed session, correct repo, resolved id.
+	inst, rid, title, id, _, err := manager.resolveActionSession(dataB.ID, "feature", "")
 	if err != nil {
 		t.Fatalf("resolveActionSession by id B: %v", err)
 	}
@@ -96,25 +96,32 @@ func TestResolveActionSessionByIDDisambiguatesCrossRepoTitle(t *testing.T) {
 	if rid != repoB.ID {
 		t.Fatalf("resolved repo = %q, want %q (repo B)", rid, repoB.ID)
 	}
-	if title != "feature" {
-		t.Fatalf("resolved title = %q, want %q", title, "feature")
+	if title != "feature" || id != dataB.ID {
+		t.Fatalf("resolved (title=%q, id=%q), want (%q, %q)", title, id, "feature", dataB.ID)
 	}
 
-	inst, rid, _, _, err = manager.resolveActionSession(dataA.ID, "feature", "")
+	inst, rid, _, id, _, err = manager.resolveActionSession(dataA.ID, "feature", "")
 	if err != nil {
 		t.Fatalf("resolveActionSession by id A: %v", err)
 	}
-	if inst == nil || inst.ID != dataA.ID || rid != repoA.ID {
-		t.Fatalf("resolved (%v, %q), want id %q repo %q", inst, rid, dataA.ID, repoA.ID)
+	if inst == nil || inst.ID != dataA.ID || rid != repoA.ID || id != dataA.ID {
+		t.Fatalf("resolved (%v, repo %q, id %q), want id %q repo %q", inst, rid, id, dataA.ID, repoA.ID)
 	}
 
-	// Id-less title path still works when the repo disambiguates (CLI/TUI contract).
-	inst, _, _, _, err = manager.resolveActionSession("", "feature", repoA.ID)
+	// Id-less title path still works when the repo disambiguates (CLI/TUI contract),
+	// and reports the resolved id (so the title-path event carries it too).
+	inst, _, _, id, _, err = manager.resolveActionSession("", "feature", repoA.ID)
 	if err != nil {
 		t.Fatalf("resolveActionSession by title+repo A: %v", err)
 	}
-	if inst == nil || inst.ID != dataA.ID {
-		t.Fatalf("title+repo resolved id = %v, want %q", inst, dataA.ID)
+	if inst == nil || inst.ID != dataA.ID || id != dataA.ID {
+		t.Fatalf("title+repo resolved (id=%v, reportedID=%q), want %q", inst, id, dataA.ID)
+	}
+
+	// A supplied-but-MISSING id is authoritative and must ERROR — never fall back to
+	// a title match that could hit a different same-title session (the stale-id leg).
+	if _, _, _, _, _, err := manager.resolveActionSession("no-such-id", "feature", ""); err == nil {
+		t.Fatalf("resolveActionSession with a stale id must error, not title-guess")
 	}
 }
 
@@ -207,4 +214,45 @@ func TestSendPromptByIDTargetsRightSession(t *testing.T) {
 	if err := manager.SendPrompt(SendPromptRequest{ID: dataB.ID, Title: "feature", RepoID: "", Prompt: "hello"}); err != nil {
 		t.Fatalf("SendPrompt by id B: %v", err)
 	}
+}
+
+// TestActionWithStaleIDErrorsRatherThanRetargeting is the missing coverage Greptile
+// flagged (the residual stale-id leg): with two same-title/different-id sessions, a
+// web-shaped Kill/Archive/SendPrompt carrying a STALE non-empty id (naming a session
+// that no longer exists) + an empty repo_id must ERROR — never silently fall back to
+// a title match that could operate on the OTHER same-title session, and never publish
+// a stale id. Erroring is the chosen design: a supplied id is authoritative, so a miss
+// is "session not found", not license to title-guess. Both sessions must survive.
+func TestActionWithStaleIDErrorsRatherThanRetargeting(t *testing.T) {
+	manager, repoA, dataA, repoB, dataB := createDuplicateTitleSessions(t, "feature")
+	cs := &controlServer{manager: manager}
+
+	// An id that names no live session (BEFORE the fix, a non-empty id that missed
+	// fell through to the collision-prone empty-repo title match).
+	staleID := "stale-" + dataA.ID
+
+	assertBothSurvive := func(where string) {
+		assertTracked(t, manager, repoA.ID, "feature", dataA.ID)
+		assertTracked(t, manager, repoB.ID, "feature", dataB.ID)
+		if t.Failed() {
+			t.Fatalf("a same-title session was operated on after %s despite the stale id", where)
+		}
+	}
+
+	var kResp KillSessionResponse
+	if err := cs.KillSession(KillSessionRequest{ID: staleID, Title: "feature", RepoID: ""}, &kResp); err == nil {
+		t.Fatalf("KillSession with a stale id must error, not fall back to a title match")
+	}
+	assertBothSurvive("kill")
+
+	var aResp ArchiveSessionResponse
+	if err := cs.ArchiveSession(ArchiveSessionRequest{ID: staleID, Title: "feature", RepoID: ""}, &aResp); err == nil {
+		t.Fatalf("ArchiveSession with a stale id must error, not fall back to a title match")
+	}
+	assertBothSurvive("archive")
+
+	if err := manager.SendPrompt(SendPromptRequest{ID: staleID, Title: "feature", RepoID: "", Prompt: "x"}); err == nil {
+		t.Fatalf("SendPrompt with a stale id must error, not fall back to a title match")
+	}
+	assertBothSurvive("send-prompt")
 }

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -26,10 +26,14 @@ import (
 // kill, and Lost-recovery never interleave). Returns the relocated worktree's
 // new path.
 func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
-	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+	instance, repoID, title, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
 		return "", err
 	}
+	// Canonicalize to the resolved session's title so every guard, the
+	// killsInFlight key, and the relocation key off the id-resolved identity,
+	// not the request's title. req is a value copy, so this is local.
+	req.Title = title
 	if session.IsReservedTitle(req.Title) {
 		return "", fmt.Errorf("cannot archive the reserved %q session", req.Title)
 	}

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -25,25 +25,31 @@ import (
 // finish-kill passes skip it) and holds the per-session op-lock (so archive,
 // kill, and Lost-recovery never interleave). Returns the relocated worktree's
 // new path.
-func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
-	instance, repoID, title, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
+// ArchiveSession archives the resolved session and returns the relocated worktree
+// path AND the stable identity (id + title) of the session it ACTUALLY resolved and
+// acted on, so the control server publishes the archived event for exactly that
+// session — never the request's own (possibly stale) id under a cross-repo title
+// collision (#1592 Phase 5 follow-up).
+func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, session.InstanceData, error) {
+	instance, repoID, title, resolvedID, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
-		return "", err
+		return "", session.InstanceData{}, err
 	}
 	// Canonicalize to the resolved session's title so every guard, the
 	// killsInFlight key, and the relocation key off the id-resolved identity,
 	// not the request's title. req is a value copy, so this is local.
 	req.Title = title
+	resolved := session.InstanceData{ID: resolvedID, Title: title}
 	if session.IsReservedTitle(req.Title) {
-		return "", fmt.Errorf("cannot archive the reserved %q session", req.Title)
+		return "", session.InstanceData{}, fmt.Errorf("cannot archive the reserved %q session", req.Title)
 	}
 	if instance == nil {
 		// A ghost disk record with no live instance has no in-memory worktree to
 		// relocate; there is nothing coherent to archive.
-		return "", fmt.Errorf("cannot archive session %q: it is not currently active", req.Title)
+		return "", session.InstanceData{}, fmt.Errorf("cannot archive session %q: it is not currently active", req.Title)
 	}
 	if !instance.Capabilities().Archive {
-		return "", fmt.Errorf("cannot archive remote session %q: it has no local worktree to relocate", req.Title)
+		return "", session.InstanceData{}, fmt.Errorf("cannot archive remote session %q: it has no local worktree to relocate", req.Title)
 	}
 	if instance.IsExternalWorktree() {
 		// An in-place/external worktree (`af sessions create --here`, #1107 — also
@@ -53,20 +59,20 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 		// that can never be archived — otherwise the rejection would only surface
 		// in the move step, after tmux is already down, leaving a broken
 		// half-archive that rolls back to Lost.
-		return "", fmt.Errorf("cannot archive an in-place/external worktree session %q — archive relocates the worktree, which isn't supported for in-place sessions", req.Title)
+		return "", session.InstanceData{}, fmt.Errorf("cannot archive an in-place/external worktree session %q — archive relocates the worktree, which isn't supported for in-place sessions", req.Title)
 	}
 	if instance.GetLiveness() == session.LiveArchived {
-		return "", fmt.Errorf("session %q is already archived", req.Title)
+		return "", session.InstanceData{}, fmt.Errorf("session %q is already archived", req.Title)
 	}
 	if instance.GetInFlightOp() != session.OpNone {
-		return "", fmt.Errorf("session %q is busy (%v); try again in a moment", req.Title, instance.GetStatus())
+		return "", session.InstanceData{}, fmt.Errorf("session %q is busy (%v); try again in a moment", req.Title, instance.GetStatus())
 	}
 
 	key := daemonInstanceKey(repoID, req.Title)
 	m.mu.Lock()
 	if _, busy := m.killsInFlight[key]; busy {
 		m.mu.Unlock()
-		return "", fmt.Errorf("an operation is already in progress for session %q", req.Title)
+		return "", session.InstanceData{}, fmt.Errorf("an operation is already in progress for session %q", req.Title)
 	}
 	m.killsInFlight[key] = struct{}{}
 	m.mu.Unlock()
@@ -86,7 +92,7 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	current := m.instances[key]
 	m.mu.Unlock()
 	if current != instance || instance.UserKilled() {
-		return "", fmt.Errorf("session %q changed state before archive could start", req.Title)
+		return "", session.InstanceData{}, fmt.Errorf("session %q changed state before archive could start", req.Title)
 	}
 
 	// A sandbox session (docker/ssh) archives by pushing its branch to origin and
@@ -94,12 +100,16 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	// Phase 4 PR6). Route it to the remote body, which shares this method's guards,
 	// locks, and archive fence.
 	if instance.Capabilities().Workspace == session.WorkspaceRemote {
-		return m.archiveRemoteSession(repoID, instance, req.Title)
+		archivedPath, rerr := m.archiveRemoteSession(repoID, instance, req.Title)
+		if rerr != nil {
+			return "", session.InstanceData{}, rerr
+		}
+		return archivedPath, resolved, nil
 	}
 
 	dest, err := archivedWorktreePath(repoID, req.Title)
 	if err != nil {
-		return "", err
+		return "", session.InstanceData{}, err
 	}
 	// The pre-archive worktree location, captured before the move, so a persist
 	// failure after the commit can roll the worktree back home (#1538).
@@ -115,7 +125,7 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 	// the op-lock guarantee this edge is legal; a rejection would surface here
 	// before any teardown.
 	if err := instance.Transition(session.BeginArchive()); err != nil {
-		return "", fmt.Errorf("cannot archive session %q: %w", req.Title, err)
+		return "", session.InstanceData{}, fmt.Errorf("cannot archive session %q: %w", req.Title, err)
 	}
 
 	// Tear down tmux and relocate the worktree in one call: the move is folded
@@ -130,7 +140,7 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 		// Persist the recovery-eligible state, then surface the failure.
 		_ = instance.Transition(session.AbortArchiveToLost())
 		m.persistInstance(repoID, instance)
-		return "", fmt.Errorf("failed to archive session %q (its agent will be restored in place): %w", req.Title, err)
+		return "", session.InstanceData{}, fmt.Errorf("failed to archive session %q (its agent will be restored in place): %w", req.Title, err)
 	}
 
 	// Success: worktree relocated, tmux down. Commit the inert Archived state
@@ -157,12 +167,12 @@ func (m *Manager) ArchiveSession(req ArchiveSessionRequest) (string, error) {
 			// safest remaining state. Persist it best-effort and surface both
 			// failures so the operator can recover it manually.
 			m.persistInstance(repoID, instance)
-			return "", fmt.Errorf("archived session %q to %s but failed to record it durably (%v) and could not roll it back (%v); it may need manual recovery", req.Title, archivedPath, perr, rbErr)
+			return "", session.InstanceData{}, fmt.Errorf("archived session %q to %s but failed to record it durably (%v) and could not roll it back (%v); it may need manual recovery", req.Title, archivedPath, perr, rbErr)
 		}
-		return "", fmt.Errorf("failed to durably archive session %q; rolled it back and left it Lost to be restored in place: %w", req.Title, perr)
+		return "", session.InstanceData{}, fmt.Errorf("failed to durably archive session %q; rolled it back and left it Lost to be restored in place: %w", req.Title, perr)
 	}
 	log.InfoLog.Printf("archived session %q (repo %s): tmux torn down, worktree moved to %s", req.Title, repoID, archivedPath)
-	return archivedPath, nil
+	return archivedPath, resolved, nil
 }
 
 // undoCommittedArchive rolls a committed-but-unpersisted archive back to a

--- a/daemon/archive_test.go
+++ b/daemon/archive_test.go
@@ -57,7 +57,7 @@ func TestArchiveSession_MovesWorktreeAndMarksArchived(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	inst, srcPath := registerArchivable(t, manager, repoID, repoPath, "worker")
 
-	archivedPath, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	archivedPath, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
 
 	expected, perr := archivedWorktreePath(repoID, "worker")
@@ -103,7 +103,7 @@ func TestArchiveSession_MoveFailureMarksLost(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(dest, 0755))
 
-	_, err = manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	_, _, err = manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.Error(t, err, "a failed move must surface an error")
 
 	assert.Equal(t, session.Lost, inst.GetStatus(), "a failed archive marks the session Lost for self-heal")
@@ -132,7 +132,7 @@ func TestArchiveSession_PersistFailureRollsBack(t *testing.T) {
 	dest, derr := archivedWorktreePath(repoID, "worker")
 	require.NoError(t, derr)
 
-	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.Error(t, err, "a persist failure must surface an error, not a silent half-archive")
 
 	assert.Equal(t, session.Lost, inst.GetStatus(), "a persist failure rolls the archive back to Lost for self-heal")
@@ -160,7 +160,7 @@ func TestArchiveSession_RejectsReservedRoot(t *testing.T) {
 	manager, repoID, repoPath := newStatusTestManager(t)
 	registerArchivable(t, manager, repoID, repoPath, session.RootSessionTitle)
 
-	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: session.RootSessionTitle, RepoID: repoID})
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: session.RootSessionTitle, RepoID: repoID})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reserved")
 }
@@ -172,7 +172,7 @@ func TestArchiveSession_RejectsAlreadyArchived(t *testing.T) {
 	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
 	inst.SetStatusForTest(session.Archived)
 
-	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already archived")
 }
@@ -188,7 +188,7 @@ func TestArchiveSession_RejectsWhenOperationInFlight(t *testing.T) {
 	manager.killsInFlight[key] = struct{}{}
 	manager.mu.Unlock()
 
-	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "in progress")
 }
@@ -216,7 +216,7 @@ func TestArchiveSession_RejectsExternalWorktree(t *testing.T) {
 	manager.instances[daemonInstanceKey(repoID, "inplace")] = inst
 	manager.mu.Unlock()
 
-	_, err = manager.ArchiveSession(ArchiveSessionRequest{Title: "inplace", RepoID: repoID})
+	_, _, err = manager.ArchiveSession(ArchiveSessionRequest{Title: "inplace", RepoID: repoID})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "in-place")
 
@@ -236,7 +236,7 @@ func TestRestoreArchived_MovesWorktreeBackAndRespawns(t *testing.T) {
 	backend := &recoverFakeBackend{FakeBackend: session.NewFakeBackend()}
 	inst.SetBackend(backend)
 
-	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
 	require.Equal(t, session.Archived, inst.GetStatus())
 	archivedPath := inst.GetWorktreePath()
@@ -290,7 +290,7 @@ func TestRestoreArchived_RepoGoneLeavesArchiveIntact(t *testing.T) {
 	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
 	inst.SetBackend(&recoverFakeBackend{FakeBackend: session.NewFakeBackend()})
 
-	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
 	archivedPath := inst.GetWorktreePath()
 
@@ -310,7 +310,7 @@ func TestRestoreArchived_CollisionSuffixesPath(t *testing.T) {
 	inst, _ := registerArchivable(t, manager, repoID, repoPath, "worker")
 	inst.SetBackend(&recoverFakeBackend{FakeBackend: session.NewFakeBackend()})
 
-	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: "worker", RepoID: repoID})
 	require.NoError(t, err)
 
 	// Occupy the default sibling location so restore must suffix.
@@ -348,7 +348,7 @@ func TestArchiveSession_RejectsRemote(t *testing.T) {
 	manager.instances[daemonInstanceKey(repoID, "faraway")] = inst
 	manager.mu.Unlock()
 
-	_, err = manager.ArchiveSession(ArchiveSessionRequest{Title: "faraway", RepoID: repoID})
+	_, _, err = manager.ArchiveSession(ArchiveSessionRequest{Title: "faraway", RepoID: repoID})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "remote")
 }

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -268,8 +268,14 @@ func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionRes
 	}
 	// Resolve the stable id BEFORE the teardown, while the session is still
 	// tracked — the event must carry it so clients key their session list by id,
-	// not the collision-prone title (#1592 Phase 5 PR5).
-	id := s.manager.stableIDFor(req.RepoID, req.Title)
+	// not the collision-prone title (#1592 Phase 5 PR5). A web caller addresses
+	// the session by id, so trust that directly; only a title-only TUI/CLI caller
+	// needs the in-memory title lookup (which is itself collision-prone under an
+	// empty repo, but that is the pre-existing CLI contract, out of scope here).
+	id := req.ID
+	if id == "" {
+		id = s.manager.stableIDFor(req.RepoID, req.Title)
+	}
 	if err := s.manager.KillSession(req); err != nil {
 		return err
 	}
@@ -286,8 +292,13 @@ func (s *controlServer) ArchiveSession(req ArchiveSessionRequest, resp *ArchiveS
 		return err
 	}
 	// Resolve the stable id BEFORE the archive relocates/re-marks the session, so
-	// the event carries the id clients key their rail by (#1592 Phase 5 PR5).
-	id := s.manager.stableIDFor(req.RepoID, req.Title)
+	// the event carries the id clients key their rail by (#1592 Phase 5 PR5). A
+	// web caller supplies the id directly; fall back to the title lookup only for
+	// title-only TUI/CLI callers.
+	id := req.ID
+	if id == "" {
+		id = s.manager.stableIDFor(req.RepoID, req.Title)
+	}
 	archivedPath, err := s.manager.ArchiveSession(req)
 	if err != nil {
 		return err

--- a/daemon/control_server.go
+++ b/daemon/control_server.go
@@ -266,21 +266,17 @@ func (s *controlServer) KillSession(req KillSessionRequest, resp *KillSessionRes
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
-	// Resolve the stable id BEFORE the teardown, while the session is still
-	// tracked — the event must carry it so clients key their session list by id,
-	// not the collision-prone title (#1592 Phase 5 PR5). A web caller addresses
-	// the session by id, so trust that directly; only a title-only TUI/CLI caller
-	// needs the in-memory title lookup (which is itself collision-prone under an
-	// empty repo, but that is the pre-existing CLI contract, out of scope here).
-	id := req.ID
-	if id == "" {
-		id = s.manager.stableIDFor(req.RepoID, req.Title)
-	}
-	if err := s.manager.KillSession(req); err != nil {
+	// KillSession resolves the target (id-first, erroring on a stale/missing id)
+	// and returns the stable identity it ACTUALLY killed — so the event names that
+	// exact session, never the request's own id, which under a cross-repo title
+	// collision could point at a different (or gone) session (#1592 Phase 5 PR5 +
+	// follow-up: the write-path analogue of the id-keyed read/stream paths).
+	killed, err := s.manager.KillSession(req)
+	if err != nil {
 		return err
 	}
 	resp.OK = true
-	s.manager.publishEvent(agentproto.EventSessionKilled, session.InstanceData{ID: id, Title: req.Title})
+	s.manager.publishEvent(agentproto.EventSessionKilled, session.InstanceData{ID: killed.ID, Title: killed.Title})
 	return nil
 }
 
@@ -291,21 +287,16 @@ func (s *controlServer) ArchiveSession(req ArchiveSessionRequest, resp *ArchiveS
 	if err := validateRPCRepoID(req.RepoID); err != nil {
 		return err
 	}
-	// Resolve the stable id BEFORE the archive relocates/re-marks the session, so
-	// the event carries the id clients key their rail by (#1592 Phase 5 PR5). A
-	// web caller supplies the id directly; fall back to the title lookup only for
-	// title-only TUI/CLI callers.
-	id := req.ID
-	if id == "" {
-		id = s.manager.stableIDFor(req.RepoID, req.Title)
-	}
-	archivedPath, err := s.manager.ArchiveSession(req)
+	// ArchiveSession resolves the target (id-first, erroring on a stale/missing id)
+	// and returns the stable identity it ACTUALLY archived — so the event names that
+	// exact session, never the request's own id (#1592 Phase 5 PR5 + follow-up).
+	archivedPath, archived, err := s.manager.ArchiveSession(req)
 	if err != nil {
 		return err
 	}
 	resp.OK = true
 	resp.ArchivedPath = archivedPath
-	s.manager.publishEvent(agentproto.EventSessionArchived, session.InstanceData{ID: id, Title: req.Title})
+	s.manager.publishEvent(agentproto.EventSessionArchived, session.InstanceData{ID: archived.ID, Title: archived.Title})
 	return nil
 }
 

--- a/daemon/control_types.go
+++ b/daemon/control_types.go
@@ -45,6 +45,13 @@ type CreateSessionResponse struct {
 type KillSessionRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
+	// ID is the session's stable id (session.InstanceData.ID). When non-empty it
+	// is the PRIMARY lookup key: the daemon resolves the target by id first and
+	// only falls back to {Title, RepoID} when it is empty. Web clients send it so
+	// a duplicate title across repos can't target the wrong session on this
+	// destructive action — the write-path analogue of the id-keyed read/stream
+	// paths (#1592 Phase 5 PR5). TUI/CLI callers omit it and resolve by title.
+	ID string `json:"id"`
 	// No force field: kill always destroys the session since the unmerged-work
 	// guard was dropped (#1579). The CLI `--force` flag is accepted as a no-op
 	// but is never sent to the daemon, so the request shape exposes no
@@ -62,6 +69,11 @@ type KillSessionResponse struct {
 type ArchiveSessionRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
+	// ID is the session's stable id; see KillSessionRequest.ID. When non-empty
+	// the daemon resolves the archive target by id first, so a web archive can't
+	// hit the wrong session under a cross-repo title collision (#1592 Phase 5
+	// follow-up). TUI/CLI callers omit it and resolve by {Title, RepoID}.
+	ID string `json:"id"`
 }
 
 type ArchiveSessionResponse struct {
@@ -102,6 +114,11 @@ type SendPromptRequest struct {
 	Title  string `json:"title"`
 	RepoID string `json:"repo_id"`
 	Prompt string `json:"prompt"`
+	// ID is the session's stable id; see KillSessionRequest.ID. When non-empty
+	// the daemon resolves the prompt target by id first, so a web send-prompt
+	// can't land on the wrong session under a cross-repo title collision (#1592
+	// Phase 5 follow-up). TUI/CLI/delivery callers omit it and resolve by title.
+	ID string `json:"id"`
 }
 
 type SendPromptResponse struct {

--- a/daemon/create_tab_archive_test.go
+++ b/daemon/create_tab_archive_test.go
@@ -100,7 +100,7 @@ func TestCreateTab_RejectedAfterArchive(t *testing.T) {
 	const title, agentName = "worker", "af_worker_agent"
 	_, srcPath, isAlive := registerArchivableWithTmux(t, manager, repoID, repoPath, title, agentName)
 
-	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
 	require.NoError(t, err)
 	require.False(t, exists(srcPath), "archive must have moved the worktree out of its original path")
 
@@ -181,7 +181,7 @@ func TestArchiveSession_ModeBTearsDownExtraTabsNoOrphan(t *testing.T) {
 	require.Equal(t, 2, inst.TabCount(), "the session now has agent + process tabs")
 	require.True(t, isAlive(agentName+"__btop"), "the process tab's tmux session is live before archive")
 
-	_, err = manager.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
+	_, _, err = manager.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
 	require.NoError(t, err)
 
 	// Mode B: the extra tab is torn down and dropped, only the agent name-holder
@@ -200,7 +200,7 @@ func TestCreateTab_ShellRejectedAfterArchive(t *testing.T) {
 	const title, agentName = "worker", "af_worker_agent"
 	_, _, isAlive := registerArchivableWithTmux(t, manager, repoID, repoPath, title, agentName)
 
-	_, err := manager.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
+	_, _, err := manager.ArchiveSession(ArchiveSessionRequest{Title: title, RepoID: repoID})
 	require.NoError(t, err)
 
 	_, err = manager.CreateTab(CreateTabRequest{Title: title, RepoID: repoID, Shell: true})

--- a/daemon/deliver_prompt_test.go
+++ b/daemon/deliver_prompt_test.go
@@ -496,7 +496,8 @@ func TestSendPrompt_RefusesKillInFlightTarget(t *testing.T) {
 
 	killDone := make(chan error, 1)
 	go func() {
-		killDone <- manager.KillSession(KillSessionRequest{Title: "captain", RepoID: repo.ID})
+		_, kerr := manager.KillSession(KillSessionRequest{Title: "captain", RepoID: repo.ID})
+		killDone <- kerr
 	}()
 	select {
 	case <-backend.killStarted:
@@ -586,7 +587,8 @@ func TestSendPrompt_DeliversBeforeLaterKillStartsTeardown(t *testing.T) {
 
 	killDone := make(chan error, 1)
 	go func() {
-		killDone <- manager.KillSession(KillSessionRequest{Title: "captain", RepoID: repo.ID})
+		_, kerr := manager.KillSession(KillSessionRequest{Title: "captain", RepoID: repo.ID})
+		killDone <- kerr
 	}()
 	key := daemonInstanceKey(repo.ID, "captain")
 	deadline := time.After(5 * time.Second)
@@ -678,7 +680,8 @@ func TestDeliverPrompt_RefusesKillInFlightTarget(t *testing.T) {
 
 	killDone := make(chan error, 1)
 	go func() {
-		killDone <- manager.KillSession(KillSessionRequest{Title: "captain", RepoID: repo.ID})
+		_, kerr := manager.KillSession(KillSessionRequest{Title: "captain", RepoID: repo.ID})
+		killDone <- kerr
 	}()
 	select {
 	case <-backend.killStarted:

--- a/daemon/kill_inflight_conflict_test.go
+++ b/daemon/kill_inflight_conflict_test.go
@@ -62,7 +62,8 @@ func TestKillSessionBlocksTitleReuseDuringTeardown(t *testing.T) {
 
 	killDone := make(chan error, 1)
 	go func() {
-		killDone <- manager.KillSession(KillSessionRequest{Title: "busy", RepoID: repo.ID})
+		_, kerr := manager.KillSession(KillSessionRequest{Title: "busy", RepoID: repo.ID})
+		killDone <- kerr
 	}()
 	select {
 	case <-backend.killStarted:

--- a/daemon/kill_test.go
+++ b/daemon/kill_test.go
@@ -63,7 +63,7 @@ func createRealKillSession(t *testing.T, title string) (*Manager, config.RepoCon
 		t.Fatalf("created session missing worktree metadata: %+v", data.Worktree)
 	}
 	t.Cleanup(func() {
-		_ = manager.KillSession(KillSessionRequest{Title: title, RepoID: repo.ID})
+		_, _ = manager.KillSession(KillSessionRequest{Title: title, RepoID: repo.ID})
 	})
 	return manager, *repo, data
 }
@@ -132,7 +132,7 @@ func TestKillSessionDestroysUnmergedBranchWithoutForce(t *testing.T) {
 	// guard refused ("N commits not on master").
 	commitInWorktree(t, data.Worktree.WorktreePath, "work.txt")
 
-	if err := manager.KillSession(KillSessionRequest{Title: data.Title, RepoID: repo.ID}); err != nil {
+	if _, err := manager.KillSession(KillSessionRequest{Title: data.Title, RepoID: repo.ID}); err != nil {
 		t.Fatalf("kill of unmerged branch without --force should succeed, got: %v", err)
 	}
 	assertWorktreeGone(t, data.Worktree.WorktreePath)
@@ -145,7 +145,7 @@ func TestKillSessionDestroysDirtyWorktreeWithoutForce(t *testing.T) {
 		t.Fatalf("write dirty file: %v", err)
 	}
 
-	if err := manager.KillSession(KillSessionRequest{Title: data.Title, RepoID: repo.ID}); err != nil {
+	if _, err := manager.KillSession(KillSessionRequest{Title: data.Title, RepoID: repo.ID}); err != nil {
 		t.Fatalf("kill of dirty worktree without --force should succeed, got: %v", err)
 	}
 	assertWorktreeGone(t, data.Worktree.WorktreePath)
@@ -159,7 +159,7 @@ func TestKillSessionDestroysBranchMismatchWorktreeWithoutForce(t *testing.T) {
 	// "worktree is on branch X but the stored session branch is Y".
 	runGitTest(t, data.Worktree.WorktreePath, "checkout", "-b", "some-other-branch")
 
-	if err := manager.KillSession(KillSessionRequest{Title: data.Title, RepoID: repo.ID}); err != nil {
+	if _, err := manager.KillSession(KillSessionRequest{Title: data.Title, RepoID: repo.ID}); err != nil {
 		t.Fatalf("kill of branch-mismatched worktree without --force should succeed, got: %v", err)
 	}
 	assertWorktreeGone(t, data.Worktree.WorktreePath)
@@ -169,7 +169,7 @@ func TestKillSessionDestroysBranchMismatchWorktreeWithoutForce(t *testing.T) {
 func TestKillSessionCleanBranchProceedsWithoutForce(t *testing.T) {
 	manager, repo, data := createRealKillSession(t, "clean-proceeds")
 
-	if err := manager.KillSession(KillSessionRequest{Title: data.Title, RepoID: repo.ID}); err != nil {
+	if _, err := manager.KillSession(KillSessionRequest{Title: data.Title, RepoID: repo.ID}); err != nil {
 		t.Fatalf("clean KillSession without force: %v", err)
 	}
 	assertWorktreeGone(t, data.Worktree.WorktreePath)
@@ -228,7 +228,7 @@ func TestKillSessionInPlaceDoesNotDeleteRepoRoot(t *testing.T) {
 		t.Fatalf("write scratch: %v", err)
 	}
 
-	if err := manager.KillSession(KillSessionRequest{Title: "inplace", RepoID: repo.ID}); err != nil {
+	if _, err := manager.KillSession(KillSessionRequest{Title: "inplace", RepoID: repo.ID}); err != nil {
 		t.Fatalf("kill of in-place session: %v", err)
 	}
 

--- a/daemon/lost_kill_test.go
+++ b/daemon/lost_kill_test.go
@@ -65,7 +65,7 @@ func TestKillSession_TombstoneSurvivesFailedTeardown(t *testing.T) {
 		t.Fatalf("CreateSession: %v", err)
 	}
 
-	if err := manager.KillSession(KillSessionRequest{Title: "doomed", RepoID: repo.ID}); err == nil {
+	if _, err := manager.KillSession(KillSessionRequest{Title: "doomed", RepoID: repo.ID}); err == nil {
 		t.Fatal("expected KillSession to surface the teardown failure")
 	}
 
@@ -142,11 +142,12 @@ func TestKillSession_RejectsConcurrentDuplicate(t *testing.T) {
 
 	killDone := make(chan error, 1)
 	go func() {
-		killDone <- manager.KillSession(KillSessionRequest{Title: "busy", RepoID: repo.ID})
+		_, kerr := manager.KillSession(KillSessionRequest{Title: "busy", RepoID: repo.ID})
+		killDone <- kerr
 	}()
 	<-backend.killStarted
 
-	if err := manager.KillSession(KillSessionRequest{Title: "busy", RepoID: repo.ID}); err == nil {
+	if _, err := manager.KillSession(KillSessionRequest{Title: "busy", RepoID: repo.ID}); err == nil {
 		t.Fatal("expected the duplicate kill to be rejected while the first teardown is in flight")
 	}
 

--- a/daemon/lostrestore_test.go
+++ b/daemon/lostrestore_test.go
@@ -515,7 +515,8 @@ func TestKillSession_WaitsForInFlightRecover(t *testing.T) {
 
 	killDone := make(chan error, 1)
 	go func() {
-		killDone <- manager.KillSession(KillSessionRequest{Title: "contested", RepoID: repoID})
+		_, kerr := manager.KillSession(KillSessionRequest{Title: "contested", RepoID: repoID})
+		killDone <- kerr
 	}()
 
 	// The kill must be blocked behind the in-flight recover attempt.
@@ -567,7 +568,8 @@ func TestRestoreLostSessions_SkipsDuringInFlightKill(t *testing.T) {
 	killStarted := backend.killStarted
 	killDone := make(chan error, 1)
 	go func() {
-		killDone <- manager.KillSession(KillSessionRequest{Title: "doomed", RepoID: repoID})
+		_, kerr := manager.KillSession(KillSessionRequest{Title: "doomed", RepoID: repoID})
+		killDone <- kerr
 	}()
 	<-killStarted // teardown in flight, op lock + killsInFlight held
 

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -10,10 +10,14 @@ import (
 )
 
 func (m *Manager) KillSession(req KillSessionRequest) error {
-	instance, repoID, data, err := m.findSession(req.Title, req.RepoID)
+	instance, repoID, title, data, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
 		return err
 	}
+	// Canonicalize to the resolved session's title so the killsInFlight key,
+	// storage delete, and event all key off the identity we actually resolved
+	// (by id), not the request's title. req is a value copy, so this is local.
+	req.Title = title
 	targetID := killTargetStableID(instance, data)
 	// Kill destroys the session unconditionally (#1579). The old unmerged-work
 	// guard that refused kills with commits-not-on-base / a dirty worktree / a
@@ -107,10 +111,13 @@ func (m *Manager) SendPrompt(req SendPromptRequest) error {
 	if req.Prompt == "" {
 		return fmt.Errorf("prompt is required")
 	}
-	instance, repoID, _, err := m.findSession(req.Title, req.RepoID)
+	instance, repoID, title, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
 		return err
 	}
+	// Canonicalize to the resolved session's title so the killsInFlight gate and
+	// delivery target key off the id-resolved identity, not the request's title.
+	req.Title = title
 	if instance == nil {
 		return fmt.Errorf("failed to restore instance %q", req.Title)
 	}
@@ -250,6 +257,43 @@ func (m *Manager) resolveStreamSession(idOrTitle, repoID string) (*session.Insta
 	m.mu.Unlock()
 	instance, resolvedRepoID, _, err := m.findSession(idOrTitle, repoID)
 	return instance, resolvedRepoID, idOrTitle, err
+}
+
+// resolveActionSession resolves a write-action target (kill/archive/send-prompt)
+// by the caller-supplied stable id FIRST — the web client's collision-proof key —
+// and falls back to {title, repoID} only when no id is given (TUI/CLI callers).
+// Resolving by id is what stops a duplicate title across repos from targeting the
+// WRONG session on a destructive action: findSession with an empty repoID returns
+// the first title match in nondeterministic map order (#1592 Phase 5 follow-up).
+//
+// It mirrors the stream path's id-first scan (resolveStreamSession): the id scan
+// sees only in-memory (live) instances — all a client's rail ever shows — and an
+// id that isn't tracked in memory falls through to findSession, which also
+// restores a disk-only record the title path may need. It returns the same tuple
+// as findSession plus the resolved canonical title, so the caller keys teardown,
+// storage, and events off the real session identity rather than the request's
+// (possibly stale) title.
+func (m *Manager) resolveActionSession(id, title, repoID string) (*session.Instance, string, string, *session.InstanceData, error) {
+	if id != "" {
+		m.mu.Lock()
+		if err := m.refreshLocked(); err != nil {
+			m.mu.Unlock()
+			return nil, "", "", nil, err
+		}
+		for key, instance := range m.instances {
+			if instance.ID != "" && instance.ID == id {
+				rid, _ := splitDaemonInstanceKey(key)
+				resolvedTitle := instance.Title
+				m.mu.Unlock()
+				return instance, rid, resolvedTitle, nil, nil
+			}
+		}
+		m.mu.Unlock()
+		// id supplied but not tracked in memory: fall through to the title lookup
+		// so a legacy/disk-only record still resolves (the caller sends title too).
+	}
+	instance, resolvedRepoID, data, err := m.findSession(title, repoID)
+	return instance, resolvedRepoID, title, data, err
 }
 
 func (m *Manager) findSession(title, repoID string) (*session.Instance, string, *session.InstanceData, error) {

--- a/daemon/manager_sessions.go
+++ b/daemon/manager_sessions.go
@@ -9,15 +9,21 @@ import (
 	"github.com/sachiniyer/agent-factory/session"
 )
 
-func (m *Manager) KillSession(req KillSessionRequest) error {
-	instance, repoID, title, data, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
+// KillSession tears down and deletes the resolved session. It returns the stable
+// identity (id + title) of the session it ACTUALLY resolved and acted on, so the
+// control server publishes the killed event for exactly that session — never the
+// request's own (possibly stale) id under a cross-repo title collision (#1592
+// Phase 5 follow-up).
+func (m *Manager) KillSession(req KillSessionRequest) (session.InstanceData, error) {
+	instance, repoID, title, resolvedID, data, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
-		return err
+		return session.InstanceData{}, err
 	}
 	// Canonicalize to the resolved session's title so the killsInFlight key,
 	// storage delete, and event all key off the identity we actually resolved
 	// (by id), not the request's title. req is a value copy, so this is local.
 	req.Title = title
+	resolved := session.InstanceData{ID: resolvedID, Title: title}
 	targetID := killTargetStableID(instance, data)
 	// Kill destroys the session unconditionally (#1579). The old unmerged-work
 	// guard that refused kills with commits-not-on-base / a dirty worktree / a
@@ -34,7 +40,7 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 	m.mu.Lock()
 	if _, busy := m.killsInFlight[key]; busy {
 		m.mu.Unlock()
-		return fmt.Errorf("kill already in progress for session %q", req.Title)
+		return session.InstanceData{}, fmt.Errorf("kill already in progress for session %q", req.Title)
 	}
 	m.killsInFlight[key] = struct{}{}
 	m.mu.Unlock()
@@ -56,7 +62,7 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 
 	if m.currentInstanceReplaced(key, instance, targetID) {
 		log.InfoLog.Printf("kill of session %q skipped: current instance identity changed before teardown", req.Title)
-		return nil
+		return resolved, nil
 	}
 
 	// Persist the kill-intent tombstone BEFORE teardown begins (#1108): if the
@@ -69,7 +75,7 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 
 	if instance != nil {
 		if err := instance.Kill(); err != nil {
-			return fmt.Errorf("failed to kill instance: %w", err)
+			return session.InstanceData{}, fmt.Errorf("failed to kill instance: %w", err)
 		}
 	} else if data != nil {
 		ghostCleanup(data, req.Title)
@@ -78,15 +84,15 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 	state := config.LoadState()
 	storage, err := session.NewStorage(state, repoID)
 	if err != nil {
-		return err
+		return session.InstanceData{}, err
 	}
 	deleted, err := storage.DeleteInstanceByStableID(req.Title, targetID)
 	if err != nil {
-		return fmt.Errorf("failed to delete instance from storage: %w", err)
+		return session.InstanceData{}, fmt.Errorf("failed to delete instance from storage: %w", err)
 	}
 	if !deleted {
 		log.InfoLog.Printf("kill of session %q skipped storage delete: current record has a different instance identity", req.Title)
-		return nil
+		return resolved, nil
 	}
 
 	m.mu.Lock()
@@ -104,14 +110,14 @@ func (m *Manager) KillSession(req KillSessionRequest) error {
 		log.InfoLog.Printf("root agent for repo %s killed by user; the ensure loop will re-create it in ~%s unless the repo is removed from root_agents", repoID, rootKillHealDelay)
 	}
 	m.mu.Unlock()
-	return nil
+	return resolved, nil
 }
 
 func (m *Manager) SendPrompt(req SendPromptRequest) error {
 	if req.Prompt == "" {
 		return fmt.Errorf("prompt is required")
 	}
-	instance, repoID, title, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
+	instance, repoID, title, _, _, err := m.resolveActionSession(req.ID, req.Title, req.RepoID)
 	if err != nil {
 		return err
 	}
@@ -261,39 +267,55 @@ func (m *Manager) resolveStreamSession(idOrTitle, repoID string) (*session.Insta
 
 // resolveActionSession resolves a write-action target (kill/archive/send-prompt)
 // by the caller-supplied stable id FIRST — the web client's collision-proof key —
-// and falls back to {title, repoID} only when no id is given (TUI/CLI callers).
+// and falls back to {title, repoID} only when NO id is given (TUI/CLI callers).
 // Resolving by id is what stops a duplicate title across repos from targeting the
 // WRONG session on a destructive action: findSession with an empty repoID returns
 // the first title match in nondeterministic map order (#1592 Phase 5 follow-up).
 //
+// A supplied id is AUTHORITATIVE — it uniquely names one session. If it is not
+// tracked in memory (the session was killed/archived out from under a stale client
+// rail), this returns a clear "not found" error rather than falling back to a title
+// match: an empty-repoID title lookup could resolve a DIFFERENT same-title session
+// in another repo and operate on it — the exact destructive cross-repo collision
+// this fix closes, just re-entered through a stale id. Erroring keeps a stale id
+// from ever silently retargeting; the id-less title path stays for legacy/CLI.
+//
 // It mirrors the stream path's id-first scan (resolveStreamSession): the id scan
-// sees only in-memory (live) instances — all a client's rail ever shows — and an
-// id that isn't tracked in memory falls through to findSession, which also
-// restores a disk-only record the title path may need. It returns the same tuple
-// as findSession plus the resolved canonical title, so the caller keys teardown,
-// storage, and events off the real session identity rather than the request's
-// (possibly stale) title.
-func (m *Manager) resolveActionSession(id, title, repoID string) (*session.Instance, string, string, *session.InstanceData, error) {
+// sees only in-memory (live) instances — all a client's rail ever shows. It returns
+// the resolved instance, its repoID, its canonical title, its stable id, and (for
+// the title path) its on-disk data — so the caller keys teardown, storage, AND the
+// lifecycle event off the session actually resolved, never the request's own
+// (possibly stale) id/title.
+func (m *Manager) resolveActionSession(id, title, repoID string) (*session.Instance, string, string, string, *session.InstanceData, error) {
 	if id != "" {
 		m.mu.Lock()
 		if err := m.refreshLocked(); err != nil {
 			m.mu.Unlock()
-			return nil, "", "", nil, err
+			return nil, "", "", "", nil, err
 		}
 		for key, instance := range m.instances {
 			if instance.ID != "" && instance.ID == id {
 				rid, _ := splitDaemonInstanceKey(key)
 				resolvedTitle := instance.Title
 				m.mu.Unlock()
-				return instance, rid, resolvedTitle, nil, nil
+				return instance, rid, resolvedTitle, instance.ID, nil, nil
 			}
 		}
 		m.mu.Unlock()
-		// id supplied but not tracked in memory: fall through to the title lookup
-		// so a legacy/disk-only record still resolves (the caller sends title too).
+		return nil, "", "", "", nil, fmt.Errorf("session with id %q not found", id)
 	}
+	// Legacy/CLI path: no id supplied, resolve by {title, repoID}.
 	instance, resolvedRepoID, data, err := m.findSession(title, repoID)
-	return instance, resolvedRepoID, title, data, err
+	if err != nil {
+		return nil, "", "", "", nil, err
+	}
+	resolvedID := ""
+	if instance != nil {
+		resolvedID = instance.ID
+	} else if data != nil {
+		resolvedID = data.ID
+	}
+	return instance, resolvedRepoID, title, resolvedID, data, nil
 }
 
 func (m *Manager) findSession(title, repoID string) (*session.Instance, string, *session.InstanceData, error) {

--- a/daemon/outage_e2e_test.go
+++ b/daemon/outage_e2e_test.go
@@ -57,7 +57,7 @@ func TestOutageEndToEnd_LostRestoreAndReplay(t *testing.T) {
 		t.Fatalf("CreateSession: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = manager.KillSession(KillSessionRequest{Title: "worker", RepoID: repo.ID})
+		_, _ = manager.KillSession(KillSessionRequest{Title: "worker", RepoID: repo.ID})
 	})
 	key := daemonInstanceKey(repo.ID, "worker")
 	manager.mu.Lock()

--- a/daemon/rootagent_test.go
+++ b/daemon/rootagent_test.go
@@ -338,7 +338,7 @@ func TestEnsureRootAgentsUserKillHealsAfterGraceWindow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RepoFromPath: %v", err)
 	}
-	if err := manager.KillSession(KillSessionRequest{Title: session.RootSessionTitle, RepoID: repo.ID}); err != nil {
+	if _, err := manager.KillSession(KillSessionRequest{Title: session.RootSessionTitle, RepoID: repo.ID}); err != nil {
 		t.Fatalf("KillSession: %v", err)
 	}
 
@@ -411,7 +411,8 @@ func TestKillDeadRootDoesNotDeleteSelfHealedRoot(t *testing.T) {
 
 	killDone := make(chan error, 1)
 	go func() {
-		killDone <- manager.KillSession(KillSessionRequest{Title: session.RootSessionTitle, RepoID: repo.ID})
+		_, kerr := manager.KillSession(KillSessionRequest{Title: session.RootSessionTitle, RepoID: repo.ID})
+		killDone <- kerr
 	}()
 	waitUntil(t, 5*time.Second, "KillSession to resolve root-A and wait on the op lock", func() bool {
 		manager.mu.Lock()

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -15,11 +15,11 @@ Request fields are the JSON keys of each route's request body; a `—` means the
 | `GET` | `/v1/health` | — | Liveness probe (alias for the Ping RPC); answers even while the daemon is restoring sessions. |
 | `POST` | `/v1/CreateSession` | `title`, `title_base`, `repo_path`, `program`, `prompt`, `auto_yes`, `in_place`, `force_remote`, `backend` | Create a new session (git worktree + agent) in a repo. |
 | `POST` | `/v1/Snapshot` | `repo_id` | List sessions from the daemon's authoritative in-memory state (empty repo_id = all repos). |
-| `POST` | `/v1/KillSession` | `title`, `repo_id` | Tear down a session: kill its tmux/agent and remove its worktree and record. |
-| `POST` | `/v1/ArchiveSession` | `title`, `repo_id` | Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record. |
+| `POST` | `/v1/KillSession` | `title`, `repo_id`, `id` | Tear down a session: kill its tmux/agent and remove its worktree and record. |
+| `POST` | `/v1/ArchiveSession` | `title`, `repo_id`, `id` | Archive a session: tear down tmux and relocate its worktree to the archive dir, keeping the record. |
 | `POST` | `/v1/RestoreArchived` | `title`, `repo_id` | Restore an archived session: move its worktree back next to the repo and re-spawn the agent. |
 | `POST` | `/v1/RestoreSession` | `title`, `repo_id` | Restore an archived, Lost, or Dead session. |
-| `POST` | `/v1/SendPrompt` | `title`, `repo_id`, `prompt` | Send a prompt to an existing session's agent. |
+| `POST` | `/v1/SendPrompt` | `title`, `repo_id`, `prompt`, `id` | Send a prompt to an existing session's agent. |
 | `POST` | `/v1/DeliverPrompt` | `title`, `repo_path`, `program`, `prompt`, `auto_yes`, `defer_while_attached` | Deliver a prompt to a session, auto-creating it if it does not exist yet. |
 | `POST` | `/v1/CreateTab` | `title`, `repo_id`, `command`, `name`, `shell` | Spawn a tab (process or shell) in a session's worktree. |
 | `POST` | `/v1/CloseTab` | `title`, `repo_id`, `tab_name`, `tab_index` | Close a non-agent tab of a session (the agent tab cannot be closed). |

--- a/web/dist/af-web.js
+++ b/web/dist/af-web.js
@@ -6186,14 +6186,14 @@ async function createSession(input, token2) {
   );
   return resp.instance;
 }
-async function sendPrompt(title, prompt, token2) {
-  await af("SendPrompt", { title, repo_id: "", prompt }, token2);
+async function sendPrompt(id, title, prompt, token2) {
+  await af("SendPrompt", { id, title, repo_id: "", prompt }, token2);
 }
-async function killSession(title, token2) {
-  await af("KillSession", { title, repo_id: "" }, token2);
+async function killSession(id, title, token2) {
+  await af("KillSession", { id, title, repo_id: "" }, token2);
 }
-async function archiveSession(title, token2) {
-  await af("ArchiveSession", { title, repo_id: "" }, token2);
+async function archiveSession(id, title, token2) {
+  await af("ArchiveSession", { id, title, repo_id: "" }, token2);
 }
 
 // src/events.ts
@@ -7357,9 +7357,10 @@ function disconnect() {
 function select(id) {
   store.set({ selectedId: id });
 }
-function selectedTitle() {
+function selectedSession2() {
   const { sessions, selectedId } = store.get();
-  return sessions.find((s) => s.id === selectedId)?.title ?? null;
+  const s = sessions.find((x) => x.id === selectedId);
+  return s ? { id: s.id ?? "", title: s.title } : null;
 }
 function closeModal() {
   if (modal) {
@@ -7399,12 +7400,12 @@ function newSession() {
   );
 }
 function openSendPrompt() {
-  const title = selectedTitle();
-  if (!title) {
+  const sel = selectedSession2();
+  if (!sel) {
     return;
   }
   openModal(
-    promptModal(title, {
+    promptModal(sel.title, {
       onSubmit: (text) => {
         const tok = token;
         if (!tok || !modal) {
@@ -7412,7 +7413,7 @@ function openSendPrompt() {
         }
         const m = modal;
         m.setBusy(true);
-        void sendPrompt(title, text, tok).then(closeModal).catch((e) => {
+        void sendPrompt(sel.id, sel.title, text, tok).then(closeModal).catch((e) => {
           m.setBusy(false);
           m.setError(describeError(e));
         });
@@ -7422,14 +7423,14 @@ function openSendPrompt() {
   );
 }
 function openConfirm(action) {
-  const title = selectedTitle();
-  if (!title) {
+  const sel = selectedSession2();
+  if (!sel) {
     return;
   }
   openModal(
     confirmModal({
       action,
-      sessionTitle: title,
+      sessionTitle: sel.title,
       onConfirm: () => {
         const tok = token;
         if (!tok || !modal) {
@@ -7437,7 +7438,7 @@ function openConfirm(action) {
         }
         const m = modal;
         m.setBusy(true);
-        const run = action === "kill" ? killSession(title, tok) : archiveSession(title, tok);
+        const run = action === "kill" ? killSession(sel.id, sel.title, tok) : archiveSession(sel.id, sel.title, tok);
         void run.then(closeModal).catch((e) => {
           m.setBusy(false);
           m.setError(describeError(e));

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -1,0 +1,67 @@
+// Tests for the write-side lifecycle callers (#1592 Phase 5 follow-up): they must
+// send the session's STABLE id as the primary lookup key, not just the title. The
+// daemon resolves the action target by id first, so a cross-repo duplicate title
+// can't make a web kill/archive/prompt hit the wrong session. These pin the id in
+// the request body without a daemon (fetch is stubbed).
+
+import { test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { archiveSession, killSession, sendPrompt } from "./api.js";
+
+interface Captured {
+  url: string;
+  body: Record<string, unknown>;
+  auth: string | undefined;
+}
+
+// Stubs global.fetch, capturing the last request and returning a 200 {data,error}
+// envelope. Returns the capture box the test asserts against.
+function stubFetch(): Captured {
+  const cap: Captured = { url: "", body: {}, auth: undefined };
+  (globalThis as { fetch: unknown }).fetch = async (url: string, init: RequestInit): Promise<Response> => {
+    cap.url = url;
+    cap.body = JSON.parse(String(init.body));
+    cap.auth = (init.headers as Record<string, string>).Authorization;
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ data: { ok: true }, error: null }),
+    } as unknown as Response;
+  };
+  return cap;
+}
+
+afterEach(() => {
+  delete (globalThis as { fetch?: unknown }).fetch;
+});
+
+test("killSession posts the stable id as the primary key alongside the title", async () => {
+  const cap = stubFetch();
+  await killSession("id-repoB", "feature", "tok");
+  assert.equal(cap.url, "/v1/KillSession");
+  assert.equal(cap.auth, "Bearer tok");
+  assert.equal(cap.body.id, "id-repoB", "id must be sent so the daemon resolves by id, not title");
+  assert.equal(cap.body.title, "feature");
+  assert.equal(cap.body.repo_id, "", "web is an all-repos client; repo_id stays empty");
+});
+
+test("archiveSession posts the stable id alongside the title", async () => {
+  const cap = stubFetch();
+  await archiveSession("id-repoB", "feature", "tok");
+  assert.equal(cap.url, "/v1/ArchiveSession");
+  assert.equal(cap.body.id, "id-repoB");
+  assert.equal(cap.body.title, "feature");
+  assert.equal(cap.body.repo_id, "");
+});
+
+test("sendPrompt posts the stable id alongside the title and prompt", async () => {
+  const cap = stubFetch();
+  await sendPrompt("id-repoB", "feature", "do the thing", "tok");
+  assert.equal(cap.url, "/v1/SendPrompt");
+  assert.equal(cap.body.id, "id-repoB");
+  assert.equal(cap.body.title, "feature");
+  assert.equal(cap.body.prompt, "do the thing");
+  assert.equal(cap.body.repo_id, "");
+});

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -156,19 +156,26 @@ export async function createSession(input: CreateSessionInput, token: string): P
   return resp.instance;
 }
 
+// The lifecycle mutations send the session's stable `id` as the primary lookup
+// key alongside the (display) title, with an empty repo_id. The daemon resolves
+// the target by id FIRST, so a duplicate title across repos can never make the
+// web kill/archive/prompt the wrong session — the write-path analogue of the
+// id-keyed read/stream paths (#1592 Phase 5 PR5). The title is still sent so the
+// daemon's lifecycle event and any title-only fallback stay correct.
+
 /** Sends a prompt to an existing session (mirrors `af sessions send-prompt`). */
-export async function sendPrompt(title: string, prompt: string, token: string): Promise<void> {
-  await af("SendPrompt", { title, repo_id: "", prompt }, token);
+export async function sendPrompt(id: string, title: string, prompt: string, token: string): Promise<void> {
+  await af("SendPrompt", { id, title, repo_id: "", prompt }, token);
 }
 
 /** Kills a session (mirrors `af sessions kill`). The session.killed event removes
  *  its row from the rail live. */
-export async function killSession(title: string, token: string): Promise<void> {
-  await af("KillSession", { title, repo_id: "" }, token);
+export async function killSession(id: string, title: string, token: string): Promise<void> {
+  await af("KillSession", { id, title, repo_id: "" }, token);
 }
 
 /** Archives a session (mirrors `af sessions archive`) — non-destructive, keeps it
  *  restorable. The session.archived event triggers a rail resync. */
-export async function archiveSession(title: string, token: string): Promise<void> {
-  await af("ArchiveSession", { title, repo_id: "" }, token);
+export async function archiveSession(id: string, title: string, token: string): Promise<void> {
+  await af("ArchiveSession", { id, title, repo_id: "" }, token);
 }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -167,10 +167,16 @@ function select(id: string): void {
 
 // --- lifecycle actions (modals) --------------------------------------------
 
-/** The title of the currently selected session, or null. */
-function selectedTitle(): string | null {
+/** The currently selected session's stable id + display title, or null if none.
+ *  The id is the collision-proof key the daemon resolves actions by; the title is
+ *  for the modal chrome and the daemon's lifecycle event (#1592 Phase 5 follow-up). */
+function selectedSession(): { id: string; title: string } | null {
   const { sessions, selectedId } = store.get();
-  return sessions.find((s) => s.id === selectedId)?.title ?? null;
+  const s = sessions.find((x) => x.id === selectedId);
+  // A legacy/disk-only row may carry no id; send "" and the daemon falls back to
+  // its title lookup, exactly as before this fix (the id is the fast path, not a
+  // hard requirement).
+  return s ? { id: s.id ?? "", title: s.title } : null;
 }
 
 /** Closes and clears the open modal, if any. */
@@ -229,12 +235,12 @@ function newSession(): void {
 
 /** Opens the send-prompt modal for the selected session. */
 function openSendPrompt(): void {
-  const title = selectedTitle();
-  if (!title) {
+  const sel = selectedSession();
+  if (!sel) {
     return;
   }
   openModal(
-    promptModal(title, {
+    promptModal(sel.title, {
       onSubmit: (text: string) => {
         const tok = token;
         if (!tok || !modal) {
@@ -242,7 +248,7 @@ function openSendPrompt(): void {
         }
         const m = modal;
         m.setBusy(true);
-        void sendPrompt(title, text, tok)
+        void sendPrompt(sel.id, sel.title, text, tok)
           .then(closeModal)
           .catch((e) => {
             m.setBusy(false);
@@ -256,14 +262,14 @@ function openSendPrompt(): void {
 
 /** Opens the kill/archive confirm modal for the selected session. */
 function openConfirm(action: "kill" | "archive"): void {
-  const title = selectedTitle();
-  if (!title) {
+  const sel = selectedSession();
+  if (!sel) {
     return;
   }
   openModal(
     confirmModal({
       action,
-      sessionTitle: title,
+      sessionTitle: sel.title,
       onConfirm: () => {
         const tok = token;
         if (!tok || !modal) {
@@ -271,7 +277,8 @@ function openConfirm(action: "kill" | "archive"): void {
         }
         const m = modal;
         m.setBusy(true);
-        const run = action === "kill" ? killSession(title, tok) : archiveSession(title, tok);
+        const run =
+          action === "kill" ? killSession(sel.id, sel.title, tok) : archiveSession(sel.id, sel.title, tok);
         void run.then(closeModal).catch((e) => {
           m.setBusy(false);
           m.setError(describeError(e));


### PR DESCRIPTION
## The bug (reproduced, destructive)

PR5 (#1677) keyed the web rail's **read** (events) and **terminal-stream** paths by the session's stable `id`. But the web's **action/write** requests — **kill / archive / send-prompt** — still send `{title, repo_id:""}`. The daemon resolves an empty-repo request by **FIRST title match** in nondeterministic map order (`findSession` in `daemon/manager_sessions.go`).

So when two sessions in **different repos share a title**, a web **Kill/Archive/SendPrompt can operate on the WRONG session** — killing/archiving/prompting a different session than the one selected. Kill is destructive; this is the write-path leg of the cross-repo title-collision bug class that PR5 fixed on the read/stream paths.

Greptile reproduced it with a Go test: two in-memory daemon sessions with the same title, different repo + stable ids; a `KillSession` with empty `repo_id` resolves to the first title match → wrong stable id / wrong session.

## The fix (structural, id-first — mirrors the stream path)

Plumb the stable `id` through the web action requests so the daemon resolves the target by id, not title-with-empty-repo — the same way the stream path already resolves (`resolveStreamSession`: by stable id first, then title).

- **`id` field** added to `KillSession`/`ArchiveSession`/`SendPrompt` requests.
- **`resolveActionSession`** (new) resolves by stable **id FIRST** — reusing the same in-memory id scan `resolveStreamSession` uses — and falls back to `{title, repoID}` only when no id is given. **TUI/CLI/delivery callers pass no id and are unchanged.**
- Manager methods **canonicalize `req.Title`** to the resolved session's title, so the `killsInFlight` key, storage delete, and lifecycle event all key off the id-resolved identity, not the request's (possibly stale) title.
- Kill/Archive **events carry the addressed id** directly (`req.ID` when present, else the prior `stableIDFor` fallback for CLI).
- **Web callers** send the selected row's stable id (the rail is already id-keyed, so the id is in hand). An id-less legacy row sends `""` and falls back to the daemon's title lookup — no behavior change for that case.

This is the **write/action path only**. The read (events) + stream paths are untouched; PR5 is not reverted. No shims.

## Regression test (the one that was missing)

`daemon/action_id_resolution_test.go` — the direct analogue of Greptile's repro, now passing:
- Builds **two real same-title sessions in different repos** under one daemon.
- A web-shaped `KillSession`/`ArchiveSession`/`SendPrompt` carrying the **stable id** (empty `repo_id`) targets the **RIGHT** session and leaves the **other untouched** (asserted via survival + the killed/archived event carrying the addressed id).
- Plus a resolver unit test pinning id-first resolution (the resolution all three actions share) and the id-less title fallback (CLI contract).

`web/src/api.test.ts` — asserts the `killSession`/`archiveSession`/`sendPrompt` callers send the `id` in the request body.

## Play-test

The real browser Playwright harness lands in a later PR (`web-selftest-container`) and isn't in-tree yet, so the play-test is the **end-to-end daemon simulation** of the exact scenario (two real same-title sessions in two real git repos → web-shaped kill by id → the other real session survives, verified live in `TestKillSessionByIDTargetsRightSessionAcrossRepoTitleCollision`) **plus** the web unit test proving the id reaches the request body.

## Gates

gofmt / `golangci-lint --fast` / `go build ./...` / `make test-container` (daemon+api) / `deadcode -test ./...` / `scripts/lint-file-length.sh` / `make web-build` (dist regenerated) / `make web-test` (45/45, 3 new) / `make tui-driver-selftest` **25/25** — TUI kill/archive by title still works.

Links #1677, #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)