### PR TITLE
fix(session): repaint cursor lands on the correct line regardless of client width (#1688)

### DIFF
--- a/session/agentserver_remote.go
+++ b/session/agentserver_remote.go
@@ -377,8 +377,13 @@ func (c *remoteClientlessChannel) Snapshot() (PaneSnapshot, error) {
 		return PaneSnapshot{}, err
 	}
 	// REST Preview carries only the screen, not the cursor position, so the repaint
-	// omits cursor restore for remote panes (HasCursor stays false) — the pre-fix
-	// behavior, unchanged over the wire.
+	// omits cursor restore for remote panes (HasCursor stays false). It is also
+	// -J-joined (the agent-server's Preview uses CapturePaneContent), NOT the grid form
+	// buildRepaint's per-row positioning wants (#1688) — so a wrapped logical line
+	// re-wraps by the client width here. This is a known screen-only best-effort
+	// limitation of the still-dark remote runtime (no cursor cascade to corrupt, since
+	// HasCursor is false); productizing it needs the agent-server to expose a grid
+	// capture + cursor over REST, mirroring tmuxClientlessChannel.Snapshot.
 	return PaneSnapshot{Screen: []byte(content)}, nil
 }
 

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -220,7 +220,15 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 // the emulator cursor on the real position so that redraw overwrites in place.
 func buildRepaint(snap PaneSnapshot) []byte {
 	out := []byte("\x1b[2J")
-	for i, line := range strings.Split(string(snap.Screen), "\n") {
+	// capture-pane emits ONE trailing "\n" after the last row and strips trailing
+	// blank rows, so that final "\n" is a row SEPARATOR, not a real empty row.
+	// Splitting without trimming it would yield a phantom trailing "" element and emit
+	// an out-of-range CSI (N+1);1 H + erase — which, in an emulator clamped to the pane
+	// height, clamps onto the real bottom row and WIPES it (Claude's input/status
+	// line). Trim exactly that one separator; a genuinely-blank last row is impossible
+	// here because capture-pane strips it. TrimSuffix is a no-op when there is none.
+	screen := strings.TrimSuffix(string(snap.Screen), "\n")
+	for i, line := range strings.Split(screen, "\n") {
 		out = append(out, []byte(fmt.Sprintf("\x1b[%d;1H\x1b[K", i+1))...)
 		out = append(out, line...)
 	}

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -56,9 +56,10 @@ type clientlessChannel interface {
 	// Resize sets the pane/window size (clientless resize-window). Last-resize-wins
 	// is enforced by the broker; this just applies the winning size.
 	Resize(rows, cols uint16) error
-	// Snapshot returns the pane's current visible screen AND the pane cursor
-	// position — the repaint the broker injects on subscribe, since pipe-pane never
-	// delivers tmux's screen redraw (#1592 Phase 2 PR6). The cursor position lets the
+	// Snapshot returns the pane's current visible screen (GRID-form, one line per pane
+	// row — see PaneSnapshot) AND the pane cursor position — the repaint the broker
+	// injects on subscribe, since pipe-pane never delivers tmux's screen redraw (#1592
+	// Phase 2 PR6). The cursor position lets the
 	// repaint leave the emulator cursor where the pane program's cursor actually is;
 	// without it the snapshot's trailing blank lines strand the emulator cursor at the
 	// bottom, so the pane's next relative-positioned redraw (a shell's SIGWINCH prompt
@@ -71,6 +72,14 @@ type clientlessChannel interface {
 // PaneSnapshot is a fresh-subscriber repaint source: the pane's current visible
 // screen (with escapes) plus the pane cursor position. CursorRow/CursorCol are
 // 0-based; they are meaningful only when HasCursor is true.
+//
+// Screen MUST be GRID-form — one line per PHYSICAL pane row, NOT -J-joined logical
+// lines. buildRepaint places each line at its own absolute row, so line index i is
+// taken to be pane row i; feeding it -J-joined lines (where one logical line spans
+// several pane rows) would mis-map the rows. The local tmux channel captures grid
+// form (CaptureVisiblePaneGrid). The remote channel's REST preview is -J-joined and
+// carries no cursor (HasCursor=false) — a known screen-only best-effort limitation,
+// see remoteClientlessChannel.Snapshot.
 type PaneSnapshot struct {
 	Screen    []byte
 	CursorRow int
@@ -183,23 +192,38 @@ func (b *ptyBroker) subscribe(since Seq) (*ptySub, error) {
 	return sub, nil
 }
 
-// buildRepaint turns a pane snapshot into bytes that reconstruct the screen when
-// written to the emulator: clear + home, then the captured lines with CR before
-// each LF so every line starts at column 0 (capture-pane joins lines with bare
-// "\n", which would otherwise leave the column where the previous line ended).
+// buildRepaint turns a GRID-form pane snapshot (see PaneSnapshot) into bytes that
+// reconstruct the screen when written to the emulator: clear the screen, then place
+// each captured row at its OWN absolute line — CSI row;1 H, erase-to-EOL, then the
+// row's content — and finally restore the cursor to the pane's real position (1-based
+// CSI H) when the snapshot carries one.
 //
-// It ends by restoring the cursor to the pane's actual position (1-based CSI H)
-// when the snapshot carries one. Writing the full screen leaves the emulator
-// cursor at the bottom of the captured lines — including the trailing blank rows a
-// fresh shell's snapshot carries — but the pane program's cursor is wherever it
-// really is (row 0 for a just-started shell). Without the restore, the pane's next
-// relative-positioned output (a shell's SIGWINCH prompt redraw, which uses CR to
-// return to the current line) renders at the bottom while the repaint's copy sits
-// stale at the top: the duplicated-prompt artifact. The restore lands the emulator
-// cursor on the real position so that redraw overwrites in place.
+// The explicit per-row positioning is the #1688 fix. The old form wrote the whole
+// screen as one CRLF-joined blob and let the emulator RE-WRAP it by the emulator's
+// OWN width, then issued an absolute cursor move to the pane's cursor_y. That is only
+// correct when the client width == pane width: under a mismatch (multi-writer
+// last-resize-wins — e.g. a browser subscriber opening at a different size than the
+// pane) the re-wrap shifts the rows, so the absolute cursor row named the wrong line
+// and Claude's relative-cursor status-block redraw corrupted the frame. Pinning each
+// pane row at its own absolute line decouples the layout from the emulator's width:
+// row i lands on line i whether the emulator is wider or narrower than the pane, so
+// cursor_y names the same row it named in the pane. A row that overflows a narrower
+// emulator wraps, but the next row's absolute CSI H + erase overwrites the overflow,
+// so rows never accumulate a drift — correct by construction at any width.
+//
+// The cursor restore also fixes the earlier duplicated-prompt artifact (#1676):
+// writing the screen leaves the emulator cursor at the bottom (past the trailing
+// blank rows), but the pane program's cursor is wherever it really is (row 0 for a
+// just-started shell). Without the restore, the pane's next relative-positioned
+// redraw (a shell's SIGWINCH prompt redraw, which uses CR to return to the current
+// line) renders at the bottom while a stale copy sits at the top. The restore lands
+// the emulator cursor on the real position so that redraw overwrites in place.
 func buildRepaint(snap PaneSnapshot) []byte {
-	body := strings.ReplaceAll(string(snap.Screen), "\n", "\r\n")
-	out := append([]byte("\x1b[2J\x1b[H"), body...)
+	out := []byte("\x1b[2J")
+	for i, line := range strings.Split(string(snap.Screen), "\n") {
+		out = append(out, []byte(fmt.Sprintf("\x1b[%d;1H\x1b[K", i+1))...)
+		out = append(out, line...)
+	}
 	if snap.HasCursor {
 		out = append(out, []byte(fmt.Sprintf("\x1b[%d;%dH", snap.CursorRow+1, snap.CursorCol+1))...)
 	}

--- a/session/ptybroker_test.go
+++ b/session/ptybroker_test.go
@@ -381,6 +381,55 @@ func TestPTYBrokerRepaintCursorWidthMismatch(t *testing.T) {
 	}
 }
 
+// TestPTYBrokerRepaintTrailingNewlineKeepsBottomRow guards the trailing-newline
+// edge Greptile/T-Rex reproduced. Real `capture-pane -p -e` (no -J) ends with ONE
+// trailing "\n" after the last row (it strips trailing blank rows, so that "\n" is a
+// row SEPARATOR, not a real empty row). If buildRepaint splits without trimming it,
+// the split yields a phantom trailing "" element and emits an out-of-range
+// CSI (N+1);1 H + erase — which, in an emulator clamped to the pane height, clamps
+// onto the real bottom row and WIPES it (often Claude's input/status line). The fake
+// emulator runs WITHOUT tmux, so this closes the CI coverage gap the real-tmux test
+// left (tmux is not on the CI PATH, so that test is skipped there).
+func TestPTYBrokerRepaintTrailingNewlineKeepsBottomRow(t *testing.T) {
+	const cols, rows = 20, 3
+	// A snapshot that FILLS the pane height (all 3 rows have content) and ends with a
+	// trailing "\n" — exactly what capture-pane emits. The bottom row is the one the
+	// phantom out-of-range clear would wipe.
+	screen := "top-row\nmid-row\nBOTTOM-ROW\n"
+	const curRow, curCol = 2, 10 // cursor on the bottom row (end of "BOTTOM-ROW")
+
+	ch := &fakeClientlessChannel{
+		snapshot:  []byte(screen),
+		hasCursor: true,
+		cursorRow: curRow, cursorCol: curCol,
+	}
+	br := newPTYBroker(ch)
+	sub, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	ev, err := nextWithin(t, sub, 2*time.Second)
+	if err != nil {
+		t.Fatalf("repaint NextEvent: %v", err)
+	}
+	if ev.Kind != PTYRepaint {
+		t.Fatalf("first event = %+v, want PTYRepaint", ev)
+	}
+
+	emu := vt.NewEmulator(cols, rows)
+	if _, err := emu.Write(ev.Data); err != nil {
+		t.Fatalf("emulator write: %v", err)
+	}
+	grid := gridRows(emu, cols, rows)
+	if !strings.Contains(grid[curRow], "BOTTOM-ROW") {
+		t.Fatalf("bottom row erased by phantom trailing-newline clear: row %d = %q; rows=%#v", curRow, grid[curRow], grid)
+	}
+	// And the cursor is still on the bottom row where the pane program left it.
+	if pos := emu.CursorPosition(); pos.Y != curRow || pos.X != curCol {
+		t.Fatalf("post-repaint cursor = (row %d,col %d), want (row %d,col %d)", pos.Y, pos.X, curRow, curCol)
+	}
+}
+
 func TestPTYBrokerFanout(t *testing.T) {
 	ch := &fakeClientlessChannel{}
 	br := newPTYBroker(ch)

--- a/session/ptybroker_test.go
+++ b/session/ptybroker_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -168,13 +169,15 @@ func TestPTYBrokerInitialRepaint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)
 	}
-	// First event is the initial repaint: ED2 + home + the screen with CRLF line
-	// breaks so columns reset. It is a PTYRepaint (not counted toward the cursor).
+	// First event is the initial repaint: ED2, then each captured row placed at its own
+	// absolute line (CSI row;1 H + erase-to-EOL + content) so the layout is pinned to
+	// the pane grid regardless of the client's width (#1688). It is a PTYRepaint (not
+	// counted toward the cursor).
 	ev, err := nextWithin(t, sub, 2*time.Second)
 	if err != nil {
 		t.Fatalf("initial NextEvent: %v", err)
 	}
-	want := "\x1b[2J\x1b[HSCREEN-A\r\nline2"
+	want := "\x1b[2J\x1b[1;1H\x1b[KSCREEN-A\x1b[2;1H\x1b[Kline2"
 	if ev.Kind != PTYRepaint || string(ev.Data) != want {
 		t.Fatalf("initial event = %+v, want PTYRepaint %q", ev, want)
 	}
@@ -296,6 +299,85 @@ func TestPTYBrokerRepaintRestoresCursor(t *testing.T) {
 	n, grid = countPromptRows(repaintFor(false))
 	if n != 2 {
 		t.Fatalf("without cursor: prompt on %d rows, want 2 (the pre-fix doubling this test guards against): %#v", n, grid)
+	}
+}
+
+// TestPTYBrokerRepaintCursorWidthMismatch is the #1688 gate: the repaint must land
+// the restored cursor on the pane's REAL row/col even when the client emulator's
+// width differs from the pane's — the case #1676's test (which used client width ==
+// pane width) missed.
+//
+// The bug: the pre-fix repaint wrote the captured screen as one CRLF-joined blob and
+// let the client emulator RE-WRAP it by the emulator's own width, then issued an
+// ABSOLUTE cursor move to the pane's cursor_y. When the emulator width != pane width
+// the re-wrap shifts the rows, so the absolute row no longer names the row the
+// content actually landed on — the cursor sits on the wrong line, and Claude's
+// relative-cursor status-block redraw corrupts the whole frame.
+//
+// The scenario models a pane of width paneW with the real cursor on the "PROMPT>"
+// row, and renders the repaint into an emulator NARROWER than the pane (clientW <
+// paneW) — the general width-mismatch case. The invariant asserted is
+// correct-by-construction: the emulator row the pane's cursor names must show the
+// content that was on that pane row, and the emulator cursor must equal the pane
+// cursor exactly.
+func TestPTYBrokerRepaintCursorWidthMismatch(t *testing.T) {
+	const paneW, paneH = 20, 6
+	// The pane grid, one entry per physical pane row — exactly what a grid-form
+	// capture (capture-pane WITHOUT -J) returns, trailing blank rows stripped. Row 0
+	// is full pane width (a command that wrapped), row 1 its continuation; the live
+	// prompt is on row 3, where the pane program's cursor sits.
+	gridRowsIn := []string{
+		"0123456789ABCDEFGHIJ", // row 0: full width (20)
+		"KLMNO",                // row 1: wrap continuation of row 0's logical line
+		"file1",                // row 2
+		"PROMPT>",              // row 3: the pane program's cursor row
+	}
+	const curRow, curCol = 3, 7 // real pane cursor: end of "PROMPT>"
+	screen := strings.Join(gridRowsIn, "\n")
+
+	// Assert the invariant at BOTH a narrower and a wider client than the pane. The
+	// narrow case is the one the pre-fix CRLF-join repaint got wrong: at clientW <
+	// paneW row 0 re-wraps into two emulator rows, shifting "PROMPT>" down while the
+	// absolute cursor move still names row 3 — landing the cursor a row above the
+	// prompt.
+	for _, clientW := range []int{10, 40} {
+		t.Run(fmt.Sprintf("clientW=%d", clientW), func(t *testing.T) {
+			ch := &fakeClientlessChannel{
+				snapshot:  []byte(screen),
+				hasCursor: true,
+				cursorRow: curRow, cursorCol: curCol,
+			}
+			br := newPTYBroker(ch)
+			sub, err := br.subscribe(0)
+			if err != nil {
+				t.Fatalf("subscribe: %v", err)
+			}
+			ev, err := nextWithin(t, sub, 2*time.Second)
+			if err != nil {
+				t.Fatalf("repaint NextEvent: %v", err)
+			}
+			if ev.Kind != PTYRepaint {
+				t.Fatalf("first event = %+v, want PTYRepaint", ev)
+			}
+
+			emu := vt.NewEmulator(clientW, paneH)
+			if _, err := emu.Write(ev.Data); err != nil {
+				t.Fatalf("emulator write: %v", err)
+			}
+
+			// Invariant 1: the emulator cursor lands exactly on the pane's real cursor.
+			pos := emu.CursorPosition()
+			if pos.Y != curRow || pos.X != curCol {
+				t.Fatalf("post-repaint cursor = (row %d,col %d), want the pane's real (row %d,col %d) at clientW=%d != paneW=%d",
+					pos.Y, pos.X, curRow, curCol, clientW, paneW)
+			}
+			// Invariant 2: the row the cursor names shows that pane row's content (the
+			// prompt), not another row shifted in by the emulator's re-wrap.
+			grid := gridRows(emu, clientW, paneH)
+			if !strings.Contains(grid[curRow], "PROMPT>") {
+				t.Fatalf("emulator row %d = %q, want the pane's %q; rows=%#v", curRow, grid[curRow], "PROMPT>", grid)
+			}
+		})
 	}
 }
 

--- a/session/ptychannel_tmux.go
+++ b/session/ptychannel_tmux.go
@@ -88,15 +88,17 @@ func (c *tmuxClientlessChannel) SendRaw(b []byte) error {
 	return c.ts.SendRawKeys(b)
 }
 
-// Snapshot returns the pane's current visible screen with escape sequences
-// (`capture-pane -p -e -J`) plus the pane cursor position — the repaint the broker
-// injects so a fresh subscriber sees the actual screen. `pipe-pane` only streams
-// FUTURE output, and — unlike a `tmux attach` client — never receives tmux's screen
-// redraw, so without this a just-opened pane would render blank until the next byte
-// of output (#1592 Phase 2 PR6). The cursor position lets the repaint leave the
-// emulator cursor where the pane program's cursor really is (see PaneSnapshot).
+// Snapshot returns the pane's current visible screen as a GRID (one line per pane
+// row, `capture-pane -p -e` WITHOUT -J) plus the pane cursor position — the repaint
+// the broker injects so a fresh subscriber sees the actual screen. `pipe-pane` only
+// streams FUTURE output, and — unlike a `tmux attach` client — never receives tmux's
+// screen redraw, so without this a just-opened pane would render blank until the
+// next byte of output (#1592 Phase 2 PR6). The grid form (not -J-joined) is what
+// lets buildRepaint pin each row at its true position and land the restored cursor
+// on the right line regardless of the client's width (#1688); the 0-based cursor_y
+// then names the same row in the client that it named in the pane.
 func (c *tmuxClientlessChannel) Snapshot() (PaneSnapshot, error) {
-	content, err := c.ts.CapturePaneContent()
+	content, err := c.ts.CaptureVisiblePaneGrid()
 	if err != nil {
 		return PaneSnapshot{}, err
 	}

--- a/session/ptychannel_tmux_test.go
+++ b/session/ptychannel_tmux_test.go
@@ -1,0 +1,99 @@
+package session
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/vt"
+	"github.com/sachiniyer/agent-factory/session/tmux"
+)
+
+// TestTmuxSnapshotRepaintCursorRealTmux is the #1688 end-to-end gate against a REAL
+// tmux server: it drives the actual capture → buildRepaint → emulator path and
+// asserts the restored cursor lands on its true pane row when the client emulator's
+// width differs from the pane's.
+//
+// The pane (20 wide) holds a line that WRAPS (25 chars → two physical rows) above a
+// prompt carrying a unique marker where the pane cursor sits. Under the pre-fix
+// `capture-pane -J` + CRLF-join repaint, that wrapped line collapses to one row in a
+// 40-wide emulator and shifts the marker up, so the absolute cursor move named the
+// wrong line. The grid capture (`capture-pane` without -J) + per-row positioning
+// makes the layout width-independent, so the emulator row the cursor names still
+// shows the marker.
+func TestTmuxSnapshotRepaintCursorRealTmux(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("tmux not available: %v", err)
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("bash not available: %v", err)
+	}
+
+	ts := tmux.NewTmuxSession("repaint-1688", "bash --noprofile --norc -i")
+	if err := ts.Start(t.TempDir()); err != nil {
+		t.Fatalf("start tmux session: %v", err)
+	}
+	t.Cleanup(func() { _ = ts.Close() })
+
+	// Narrow the pane so a 25-char line wraps across two physical rows.
+	const paneW, paneH = 20, 8
+	if err := ts.ResizeWindow(paneW, paneH); err != nil {
+		t.Fatalf("resize window: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	// Print a wrapping line, then leave the cursor after a unique marker on the live
+	// prompt line (no Enter) so the pane cursor sits at a known row/col.
+	if err := ts.SendKeysCommand("printf '%s\\n' AAAAAAAAAAAAAAAAAAAABBBBB"); err != nil {
+		t.Fatalf("send wrapping line: %v", err)
+	}
+	const marker = "ZZMARK"
+	if err := ts.SendRawKeys([]byte(marker)); err != nil {
+		t.Fatalf("send marker: %v", err)
+	}
+
+	ch := newTmuxClientlessChannel(ts)
+	var snap PaneSnapshot
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		s, err := ch.Snapshot()
+		if err == nil && s.HasCursor && strings.Contains(string(s.Screen), marker) {
+			snap = s
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("marker/cursor never appeared in snapshot: screen=%q hasCursor=%v err=%v",
+				string(s.Screen), s.HasCursor, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// The grid capture must SPLIT the wrapped line into two physical rows (not
+	// -J-join it) — the property the cursor mapping depends on.
+	if !strings.Contains(string(snap.Screen), "AAAAAAAAAAAAAAAAAAAA\nBBBBB") {
+		t.Fatalf("grid capture did not split the wrapped line across rows: %q", string(snap.Screen))
+	}
+	// The marker must be on the pane's real cursor row, and the cursor just past it.
+	gridLines := strings.Split(string(snap.Screen), "\n")
+	if snap.CursorRow >= len(gridLines) || !strings.Contains(gridLines[snap.CursorRow], marker) {
+		t.Fatalf("pane cursor row %d does not hold the marker; lines=%#v", snap.CursorRow, gridLines)
+	}
+
+	// Render the repaint into an emulator WIDER than the pane (the mismatch that broke
+	// the -J path), and assert the cursor row still shows the marker.
+	const clientW = 40
+	emu := vt.NewEmulator(clientW, paneH)
+	if _, err := emu.Write(buildRepaint(snap)); err != nil {
+		t.Fatalf("emulator write: %v", err)
+	}
+	pos := emu.CursorPosition()
+	if pos.Y != snap.CursorRow || pos.X != snap.CursorCol {
+		t.Fatalf("post-repaint cursor = (row %d,col %d), want the pane's real (row %d,col %d) at clientW=%d != paneW=%d",
+			pos.Y, pos.X, snap.CursorRow, snap.CursorCol, clientW, paneW)
+	}
+	row := gridRows(emu, clientW, paneH)[snap.CursorRow]
+	if !strings.Contains(row, marker) {
+		t.Fatalf("emulator cursor row %d = %q, want the marker %q (cursor landed on the wrong line)", snap.CursorRow, row, marker)
+	}
+}

--- a/session/tmux/io.go
+++ b/session/tmux/io.go
@@ -162,6 +162,29 @@ func (t *TmuxSession) CapturePaneContent() (string, error) {
 	return string(output), nil
 }
 
+// CaptureVisiblePaneGrid captures the visible pane as a GRID — one output line per
+// PHYSICAL pane row (capture-pane WITHOUT -J), escapes preserved (-e). Unlike
+// CapturePaneContent, which -J-joins wrapped logical lines (right for prompt
+// detection / preview, where the logical text matters), this keeps the row
+// structure so output line index i is exactly pane row i. The WS-broker repaint
+// relies on that 1:1 mapping to place each row at its true grid position and land
+// the restored cursor (a 0-based pane cursor_y) on the correct line REGARDLESS of
+// the client emulator's width (#1688): -J-joined lines re-wrap by the client's
+// width, so a client wider or narrower than the pane shifts the rows out from under
+// the absolute cursor move. Wraps ErrSessionGone when the session has vanished,
+// mirroring CapturePaneContent (#496, #1006).
+func (t *TmuxSession) CaptureVisiblePaneGrid() (string, error) {
+	cmd := exec.Command("tmux", "capture-pane", "-p", "-e", "-t", exactTarget(t.sanitizedName))
+	output, err := t.cmdExec.Output(cmd)
+	if err != nil {
+		if !t.DoesSessionExist() {
+			return "", fmt.Errorf("%w: capture-pane: %v", ErrSessionGone, err)
+		}
+		return "", fmt.Errorf("error capturing pane grid: %v", err)
+	}
+	return string(output), nil
+}
+
 // CursorPosition reports the pane cursor position as 0-based (row, col) via
 // display-message (`#{cursor_y} #{cursor_x}`, both 0-based in tmux). The broker's
 // repaint uses it to restore the emulator cursor to where the pane program's


### PR DESCRIPTION
Fixes #1688. Residual of #1676: the WS-broker repaint restored the cursor with an **absolute** move to the pane's `cursor_y`, but laid the screen out in a way that only matched the pane when the **client emulator width == pane width**. Under a width mismatch (multi-writer last-resize-wins — a browser subscriber at a different size than the pane) the layout shifted the rows out from under that absolute cursor move, so the cursor landed on the wrong line. Claude Code redraws its live status block with **relative** cursor moves, so a wrong post-repaint cursor row corrupted the whole frame (codex's more static output survived).

## Root cause (two compounding triggers)
1. `capture-pane -J` **joins** wrapped logical lines into one long line; the emulator re-wraps them by **its** width → rows shift even when the client is **wider** than the pane.
2. Writing the screen as a CRLF blob lets a client **narrower** than the pane wrap grid rows too.

Both proven deterministically on `master` before the fix (see below) and confirmed against real tmux 3.4.

## Fix (correct-by-construction — clean break, no shim, no dual path)
- **Grid capture:** new `TmuxSession.CaptureVisiblePaneGrid()` runs `capture-pane -p -e` **without `-J`**, so output line `i` is exactly pane row `i`. `CapturePaneContent` keeps `-J` for preview / prompt detection — unchanged.
- **Per-row positioning:** `buildRepaint` now places each row at its **own absolute line** (`CSI row;1 H` + erase-to-EOL + content) instead of a CRLF blob, then restores the cursor. Row `i` lands on line `i` whether the emulator is wider or narrower than the pane, so `cursor_y` names the same row it named in the pane. A row that overflows a narrow emulator wraps, but the next row's absolute `CSI H` + erase overwrites the overflow — no drift accumulates.

**Deletes** the width-dependent `strings.ReplaceAll(screen, "\n", "\r\n")` + absolute-only cursor path.

## Repro (before → after)
`-J` join, client **wider** than pane (40 > 20), on `master`:
```
[-J joined, clientW=40>paneW=20] cursor=(y=3,x=7)
  row0: "0123456789ABCDEFGHIJKLMNO"
  row1: "file1"
  row2: "PROMPT>"      <- content here
  row3: ""             <- cursor here: WRONG LINE
```
Grid form, client **narrower** than pane (10 < 20), on `master`:
```
emulator row 3 = "file1", want the pane's "PROMPT>"   (cursor a row above the prompt)
```
After the fix, both land the cursor on `PROMPT>` at the pane's real `(row 3, col 7)` — asserted at client widths 10 and 40.

## Tests (the load-bearing gate #1676 missed)
- `TestPTYBrokerRepaintCursorWidthMismatch` — grid snapshot + cursor rendered through the vt emulator at **client width != pane width**; asserts the emulator cursor == the pane's real row/col and that row shows the pane row's content. Fails on `master`, passes now.
- `TestTmuxSnapshotRepaintCursorRealTmux` — **real tmux** end-to-end (grid capture → `buildRepaint` → emulator at 40 != pane 20); asserts the grid capture splits the wrapped line and the cursor lands on the marker row.

## Audit (#1688 step 3)
- `agentserver_remote.Snapshot()` stays **screen-only** (`HasCursor=false`) and `-J`-joined; documented as a known best-effort limitation of the still-dark remote runtime (no cursor cascade to corrupt). Productizing it needs the agent-server to expose a grid capture + cursor over REST — noted inline.
- `CursorPosition()` is **0-based pane-visible** coords (`#{cursor_y}`/`#{cursor_x}`), which line up 1:1 with the grid capture's row index — confirmed on tmux 3.4.

Does **not** touch the local-attach or termpane flows (they use `CapturePaneContent` / `tmux attach`, unchanged).

## Gates (all green)
`gofmt -l .` clean · `golangci-lint --fast` clean · `deadcode -test ./...` clean · `scripts/lint-file-length.sh` clean · `make tui-driver-selftest` 25/25 · `make web-test` 45/45 · `make test-container` all packages ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)