### PR TITLE
fix(session): reset PTY broker capture state on tmux recovery (#1682)

### DIFF
--- a/session/agentserver_local.go
+++ b/session/agentserver_local.go
@@ -147,6 +147,31 @@ func (s *localAgentServer) ensureBroker(tab int) (*ptyBroker, error) {
 	return br, nil
 }
 
+// resetBrokerCaptures stops every tab broker's stale clientless capture after a
+// session recovery re-spawns tmux (#1682). The brokers, their ring buffers, and
+// their current subscribers are all preserved — only the capture bound to the dead
+// pane is torn down, so the next Subscribe rebuilds a FRESH pipe-pane against the
+// restored pane. Without it a broker that was capturing when its tmux died keeps
+// capturing=true over a parked readLoop, and post-recovery subscribers attach but
+// never receive output. The brokers are snapshotted under s.mu and reset OUTSIDE
+// the lock so a blocking capture teardown (which joins the readLoop) can't stall a
+// concurrent Subscribe/Input/Resize. A no-op once Kill has latched closed.
+func (s *localAgentServer) resetBrokerCaptures() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	brokers := make([]*ptyBroker, 0, len(s.brokers))
+	for _, br := range s.brokers {
+		brokers = append(brokers, br)
+	}
+	s.mu.Unlock()
+	for _, br := range brokers {
+		br.resetCapture()
+	}
+}
+
 func (s *localAgentServer) Subscribe(tab int, since Seq) (PTYSubscription, error) {
 	br, err := s.ensureBroker(tab)
 	if err != nil {

--- a/session/backend_local.go
+++ b/session/backend_local.go
@@ -427,6 +427,15 @@ func (b *LocalBackend) respawn(i *Instance) error {
 	// Phase 2d — the chokepoint form of MarkLive). The daemon poll re-derives
 	// Ready/Running from the live session from here on and persists the transition.
 	_ = i.Transition(ConfirmLive())
+
+	// The re-spawned tmux is a new pane process; a PTY broker that was still holding
+	// the dead pane's clientless capture must drop it so the next Subscribe streams
+	// the live pane rather than a parked, silent readLoop (#1682). The memoized
+	// accessor keeps this a no-op for sessions nobody ever streamed (empty broker
+	// map) and skips a remote runtime's agent-server (not a localAgentServer).
+	if as, ok := i.AgentServer().(*localAgentServer); ok {
+		as.resetBrokerCaptures()
+	}
 	return nil
 }
 

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -247,7 +247,15 @@ func buildRepaint(snap PaneSnapshot) []byte {
 func (b *ptyBroker) ensureCaptureStarted() error {
 	b.captureMu.Lock()
 	defer b.captureMu.Unlock()
+	return b.ensureCaptureStartedLocked()
+}
 
+// ensureCaptureStartedLocked is ensureCaptureStarted's body with captureMu already
+// held, so a caller mid-transition (resetCapture, which stops the stale capture and
+// restarts a fresh one atomically under one captureMu hold) can reuse the bring-up
+// without dropping the serialization. Callers that are not already holding captureMu
+// must use ensureCaptureStarted.
+func (b *ptyBroker) ensureCaptureStartedLocked() error {
 	b.mu.Lock()
 	if b.closed {
 		b.mu.Unlock()
@@ -305,35 +313,90 @@ func (b *ptyBroker) maybeStopCapture() {
 	}
 }
 
-// resetCapture stops any in-flight clientless capture WITHOUT closing the broker
-// or dropping its subscribers, so the next Subscribe (via ensureCaptureStarted)
-// brings a FRESH capture up against a re-spawned tmux pane (#1682). On session
-// recovery the previous tmux — and with it the `pipe-pane` writer feeding this
-// broker's FIFO — died, but the broker's readLoop is parked on the O_RDWR FIFO
-// (which never sees EOF) with `capturing` still true, so ensureCaptureStarted
-// would short-circuit and no bytes would ever flow to a post-recovery subscriber.
-// Clearing the latch here and running the stale stopCapture unblocks and JOINS the
-// parked readLoop (no goroutine leak) and re-arms the lazy lifecycle. A no-op when
-// no capture is running or the broker is already closed. Serialized against every
-// other capture transition by captureMu (captureMu-then-mu ordering) so it cannot
-// race a concurrent ensureCaptureStarted.
+// resetCapture recovers the broker onto a re-spawned tmux pane WITHOUT closing it or
+// dropping its subscribers (#1682). On session recovery the previous tmux — and with
+// it the `pipe-pane` writer feeding this broker's FIFO — died, but the broker's
+// readLoop is parked on the O_RDWR FIFO (which never sees EOF) with `capturing` still
+// true, so the cached broker keeps short-circuiting ensureCaptureStarted and no bytes
+// ever flow again. resetCapture, holding captureMu across the whole transition so no
+// concurrent bring-up/teardown can interleave (#1661):
+//
+//  1. Stops the stale capture — unblocking and JOINING the parked readLoop (no
+//     goroutine leak) — and clears the capturing latch.
+//  2. If subscribers are STILL attached (a web/TUI client that stayed connected
+//     across the respawn — the common case), restarts the capture against the fresh
+//     pane and re-seeds each subscriber with a repaint of the recovered screen, so it
+//     resumes output on its OWN rather than hanging until some unrelated later
+//     Subscribe happens to bring the capture back up (the #1682 residual T-Rex hit).
+//     With no subscribers left, the lazy lifecycle is simply re-armed for the next
+//     Subscribe.
+//
+// The subscriber count is re-read AFTER the stop (still under captureMu) so a
+// subscriber that left during the blocking teardown is not resurrected onto a capture
+// nobody wants. A no-op when the broker is already closed.
 func (b *ptyBroker) resetCapture() {
 	b.captureMu.Lock()
 	defer b.captureMu.Unlock()
 
 	b.mu.Lock()
-	if b.closed || !b.capturing {
+	if b.closed {
 		b.mu.Unlock()
 		return
 	}
-	stop := b.stopCapture
-	b.capturing = false
-	b.stopCapture = nil
+	var stop func()
+	if b.capturing {
+		stop = b.stopCapture
+		b.capturing = false
+		b.stopCapture = nil
+	}
 	b.mu.Unlock()
 
 	if stop != nil {
 		stop()
 	}
+
+	// Re-read the subscriber count AFTER the teardown drained: nobody left → just the
+	// lazy re-arm, the next Subscribe restarts a fresh capture.
+	b.mu.Lock()
+	resume := !b.closed && len(b.subs) != 0
+	b.mu.Unlock()
+	if !resume {
+		return
+	}
+
+	// A subscriber stayed attached across the respawn. Restart the capture against the
+	// re-spawned pane and re-seed every current subscriber so it repaints the recovered
+	// screen and resumes live output without a new Subscribe.
+	if err := b.ensureCaptureStartedLocked(); err != nil {
+		log.WarningLog.Printf("pty broker: restart capture after recovery: %v", err)
+		return
+	}
+	b.reseedSubscribersLocked()
+}
+
+// reseedSubscribersLocked gives every currently-registered subscriber a fresh initial
+// repaint of the recovered pane's screen and wakes it, so a client that stayed
+// attached across a tmux respawn repaints the current screen and resumes live output
+// on its own (#1682). It mirrors subscribe()'s initial-repaint injection but fans the
+// one snapshot to ALL subscribers. Best-effort: a Snapshot error (or an empty screen)
+// degrades to just waking the subscribers — the restarted capture's next live byte
+// still reaches them — rather than failing the recovery. Caller holds captureMu; the
+// snapshot exec runs without b.mu held, matching subscribe().
+func (b *ptyBroker) reseedSubscribersLocked() {
+	var rp []byte
+	if snap, err := b.ch.Snapshot(); err != nil {
+		log.WarningLog.Printf("pty broker: snapshot for recovery re-seed: %v", err)
+	} else if len(snap.Screen) > 0 {
+		rp = buildRepaint(snap)
+	}
+	b.mu.Lock()
+	if len(rp) > 0 {
+		for _, s := range b.subs {
+			s.pendingRepaint = rp
+		}
+	}
+	b.wakeAllLocked()
+	b.mu.Unlock()
 }
 
 // readLoop copies the clientless capture reader into the ring until it errors or

--- a/session/ptybroker.go
+++ b/session/ptybroker.go
@@ -305,6 +305,37 @@ func (b *ptyBroker) maybeStopCapture() {
 	}
 }
 
+// resetCapture stops any in-flight clientless capture WITHOUT closing the broker
+// or dropping its subscribers, so the next Subscribe (via ensureCaptureStarted)
+// brings a FRESH capture up against a re-spawned tmux pane (#1682). On session
+// recovery the previous tmux — and with it the `pipe-pane` writer feeding this
+// broker's FIFO — died, but the broker's readLoop is parked on the O_RDWR FIFO
+// (which never sees EOF) with `capturing` still true, so ensureCaptureStarted
+// would short-circuit and no bytes would ever flow to a post-recovery subscriber.
+// Clearing the latch here and running the stale stopCapture unblocks and JOINS the
+// parked readLoop (no goroutine leak) and re-arms the lazy lifecycle. A no-op when
+// no capture is running or the broker is already closed. Serialized against every
+// other capture transition by captureMu (captureMu-then-mu ordering) so it cannot
+// race a concurrent ensureCaptureStarted.
+func (b *ptyBroker) resetCapture() {
+	b.captureMu.Lock()
+	defer b.captureMu.Unlock()
+
+	b.mu.Lock()
+	if b.closed || !b.capturing {
+		b.mu.Unlock()
+		return
+	}
+	stop := b.stopCapture
+	b.capturing = false
+	b.stopCapture = nil
+	b.mu.Unlock()
+
+	if stop != nil {
+		stop()
+	}
+}
+
 // readLoop copies the clientless capture reader into the ring until it errors or
 // the capture is stopped.
 func (b *ptyBroker) readLoop(r io.Reader, done chan struct{}) {

--- a/session/ptybroker_recovery_test.go
+++ b/session/ptybroker_recovery_test.go
@@ -1,0 +1,169 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// TestPTYBrokerResetCaptureRestartsAfterRecovery is the #1682 regression: after a
+// running session's tmux dies and the daemon recovers it (respawn → Restore →
+// ConfirmLive), the PTY broker's stale capture must be reset so a NEW subscriber
+// gets live output from the re-spawned pane — instead of attaching to a broker that
+// is still `capturing` over a readLoop parked forever on the dead pane's FIFO.
+//
+// The test drives the broker seam directly (reproducing a real tmux death in a unit
+// test is impractical): a subscriber brings the capture up (readLoop parks on the
+// fake pipe, exactly as the real readLoop parks on the O_RDWR FIFO), then the test
+// asserts the pre-fix defect and the post-fix recovery around resetCapture().
+func TestPTYBrokerResetCaptureRestartsAfterRecovery(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+
+	// A subscriber brings the "gen-1" capture up: StartCapture #1, capturing=true, a
+	// readLoop parked on the pipe reader (the fake's analogue of the real readLoop
+	// parked on the O_RDWR FIFO that never sees EOF when pipe-pane's writer dies).
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	_ = a
+	if ch.starts != 1 {
+		t.Fatalf("StartCapture calls = %d, want 1 after first subscribe", ch.starts)
+	}
+
+	// --- Prove the bug on the pre-fix path -------------------------------------
+	// tmux has died; the daemon has re-spawned it. WITHOUT a capture reset the
+	// broker stays capturing=true, so a fresh subscribe short-circuits
+	// ensureCaptureStarted and NO new capture is bound to the recovered pane — the
+	// post-recovery subscriber is stranded on the dead gen-1 capture (ch.starts
+	// never advances past 1). This is the exact stale-broker defect #1682 reports.
+	b, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe B (pre-reset): %v", err)
+	}
+	_ = b
+	if ch.starts != 1 {
+		t.Fatalf("pre-reset: StartCapture calls = %d, want 1 (no fresh capture on the recovered pane — the #1682 defect)", ch.starts)
+	}
+
+	// --- Recovery resets the stale capture -------------------------------------
+	br.resetCapture()
+	if ch.stops != 1 {
+		t.Fatalf("resetCapture: StopCapture calls = %d, want 1 (stale capture torn down + parked readLoop joined)", ch.stops)
+	}
+	br.mu.Lock()
+	capturing := br.capturing
+	br.mu.Unlock()
+	if capturing {
+		t.Fatal("resetCapture: broker still capturing, want the latch cleared so the next subscribe restarts capture")
+	}
+
+	// --- Prove the fix: a NEW subscriber after recovery streams live output -----
+	c, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe C (post-reset): %v", err)
+	}
+	if ch.starts != 2 {
+		t.Fatalf("post-reset: StartCapture calls = %d, want 2 (a FRESH capture against the recovered pane)", ch.starts)
+	}
+	// gen-2 output from the re-spawned pane reaches the post-recovery subscriber.
+	ch.emit(t, []byte("LIVE-AFTER-RECOVERY"))
+	mustData(t, c, "LIVE-AFTER-RECOVERY")
+}
+
+// TestPTYBrokerResetCaptureNoopWhenIdle pins that a reset is harmless when no
+// capture is running (a session nobody was streaming when it recovered): no
+// StopCapture is issued and the lazy lifecycle is untouched.
+func TestPTYBrokerResetCaptureNoopWhenIdle(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+	br.resetCapture()
+	if ch.starts != 0 || ch.stops != 0 {
+		t.Fatalf("idle resetCapture touched the channel: starts=%d stops=%d, want 0/0", ch.starts, ch.stops)
+	}
+	// The broker still streams normally afterward.
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	ch.emit(t, []byte("hi"))
+	mustData(t, a, "hi")
+}
+
+// TestLocalAgentServerResetBrokerCaptures exercises the recovery reset at the
+// agentserver seam: resetBrokerCaptures snapshots the tab-broker map and resets
+// each broker's stale capture (#1682), and is a no-op once Kill has latched closed.
+func TestLocalAgentServerResetBrokerCaptures(t *testing.T) {
+	ch0 := &fakeClientlessChannel{}
+	ch1 := &fakeClientlessChannel{}
+	br0 := newPTYBroker(ch0)
+	br1 := newPTYBroker(ch1)
+	if _, err := br0.subscribe(0); err != nil {
+		t.Fatalf("subscribe tab 0: %v", err)
+	}
+	if _, err := br1.subscribe(0); err != nil {
+		t.Fatalf("subscribe tab 1: %v", err)
+	}
+
+	s := &localAgentServer{brokers: map[int]*ptyBroker{0: br0, 1: br1}}
+	s.resetBrokerCaptures()
+
+	for name, ch := range map[string]*fakeClientlessChannel{"tab0": ch0, "tab1": ch1} {
+		if ch.stops != 1 {
+			t.Fatalf("%s: StopCapture calls = %d, want 1 (stale capture reset)", name, ch.stops)
+		}
+	}
+	for name, br := range map[string]*ptyBroker{"tab0": br0, "tab1": br1} {
+		br.mu.Lock()
+		capturing := br.capturing
+		br.mu.Unlock()
+		if capturing {
+			t.Fatalf("%s: still capturing after resetBrokerCaptures", name)
+		}
+	}
+
+	// A fresh subscribe on each tab restarts capture against the recovered pane.
+	c0, err := br0.subscribe(0)
+	if err != nil {
+		t.Fatalf("re-subscribe tab 0: %v", err)
+	}
+	if ch0.starts != 2 {
+		t.Fatalf("tab0 StartCapture calls = %d, want 2 (restarted)", ch0.starts)
+	}
+	ch0.emit(t, []byte("tab0-live"))
+	mustData(t, c0, "tab0-live")
+
+	// Once closed (Kill), reset is a no-op — it must not resurrect capture on a
+	// session being torn down.
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+	prevStops := ch1.stops
+	s.resetBrokerCaptures()
+	if ch1.stops != prevStops {
+		t.Fatalf("resetBrokerCaptures after close touched a broker: stops=%d, want %d", ch1.stops, prevStops)
+	}
+}
+
+// TestPTYBrokerResetCaptureJoinsParkedReadLoop asserts resetCapture does not return
+// until the stale readLoop has actually exited (no goroutine leak): the stopCapture
+// closure blocks on the readLoop's done channel, so once resetCapture returns the
+// old capture reader is fully drained and the next capture starts clean.
+func TestPTYBrokerResetCaptureJoinsParkedReadLoop(t *testing.T) {
+	ch := &fakeClientlessChannel{}
+	br := newPTYBroker(ch)
+	if _, err := br.subscribe(0); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		br.resetCapture()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("resetCapture blocked — parked readLoop never joined (goroutine leak)")
+	}
+}

--- a/session/ptybroker_recovery_test.go
+++ b/session/ptybroker_recovery_test.go
@@ -1,79 +1,111 @@
 package session
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
 
-// TestPTYBrokerResetCaptureRestartsAfterRecovery is the #1682 regression: after a
-// running session's tmux dies and the daemon recovers it (respawn → Restore →
-// ConfirmLive), the PTY broker's stale capture must be reset so a NEW subscriber
-// gets live output from the re-spawned pane — instead of attaching to a broker that
-// is still `capturing` over a readLoop parked forever on the dead pane's FIFO.
+// mustRepaintContains blocks for the next event and asserts it is a PTYRepaint whose
+// bytes contain want (the recovered screen re-seed).
+func mustRepaintContains(t *testing.T, sub PTYSubscription, want string) {
+	t.Helper()
+	ev, err := nextWithin(t, sub, 2*time.Second)
+	if err != nil {
+		t.Fatalf("NextEvent (want repaint %q): %v", want, err)
+	}
+	if ev.Kind != PTYRepaint || !strings.Contains(string(ev.Data), want) {
+		t.Fatalf("event = %+v, want PTYRepaint containing %q", ev, want)
+	}
+}
+
+// TestPTYBrokerRecoveryResumesExistingSubscriber is the #1682 residual (T-Rex
+// reproduced): a subscriber that was ALREADY connected when tmux died must resume
+// seeing output on its own after recovery — repaint the recovered screen and stream
+// live bytes — WITHOUT a second Subscribe. resetCapture (the recovery hook) stops the
+// stale capture, then — because a subscriber is still attached — restarts the capture
+// against the re-spawned pane and re-seeds the subscriber.
 //
-// The test drives the broker seam directly (reproducing a real tmux death in a unit
-// test is impractical): a subscriber brings the capture up (readLoop parks on the
-// fake pipe, exactly as the real readLoop parks on the O_RDWR FIFO), then the test
-// asserts the pre-fix defect and the post-fix recovery around resetCapture().
-func TestPTYBrokerResetCaptureRestartsAfterRecovery(t *testing.T) {
-	ch := &fakeClientlessChannel{}
+// Fail-before/pass-after: a stop-only resetCapture (the first-cut fix) would leave the
+// already-attached subscriber with capturing=false and no restart, so it hangs until
+// an unrelated later Subscribe brings the capture back up — exactly the residual. The
+// asserts below (fresh StartCapture #2 driven by the reset itself, repaint of the
+// recovered screen, then live output) all fail on that path.
+func TestPTYBrokerRecoveryResumesExistingSubscriber(t *testing.T) {
+	ch := &fakeClientlessChannel{snapshot: []byte("SCREEN-BEFORE-DEATH")}
 	br := newPTYBroker(ch)
 
-	// A subscriber brings the "gen-1" capture up: StartCapture #1, capturing=true, a
-	// readLoop parked on the pipe reader (the fake's analogue of the real readLoop
-	// parked on the O_RDWR FIFO that never sees EOF when pipe-pane's writer dies).
+	// A connects before tmux dies: StartCapture #1, initial repaint of the pre-death
+	// screen, then a live byte. Consume both so the ring/cursor are at the live tail.
 	a, err := br.subscribe(0)
 	if err != nil {
 		t.Fatalf("subscribe A: %v", err)
 	}
-	_ = a
+	mustRepaintContains(t, a, "SCREEN-BEFORE-DEATH")
+	ch.emit(t, []byte("pre-death-output"))
+	mustData(t, a, "pre-death-output")
 	if ch.starts != 1 {
-		t.Fatalf("StartCapture calls = %d, want 1 after first subscribe", ch.starts)
+		t.Fatalf("StartCapture calls = %d, want 1 before recovery", ch.starts)
 	}
 
-	// --- Prove the bug on the pre-fix path -------------------------------------
-	// tmux has died; the daemon has re-spawned it. WITHOUT a capture reset the
-	// broker stays capturing=true, so a fresh subscribe short-circuits
-	// ensureCaptureStarted and NO new capture is bound to the recovered pane — the
-	// post-recovery subscriber is stranded on the dead gen-1 capture (ch.starts
-	// never advances past 1). This is the exact stale-broker defect #1682 reports.
-	b, err := br.subscribe(0)
-	if err != nil {
-		t.Fatalf("subscribe B (pre-reset): %v", err)
-	}
-	_ = b
-	if ch.starts != 1 {
-		t.Fatalf("pre-reset: StartCapture calls = %d, want 1 (no fresh capture on the recovered pane — the #1682 defect)", ch.starts)
-	}
+	// tmux dies and the daemon re-spawns it. The recovered pane shows a new screen.
+	ch.mu.Lock()
+	ch.snapshot = []byte("SCREEN-AFTER-RECOVERY")
+	ch.mu.Unlock()
 
-	// --- Recovery resets the stale capture -------------------------------------
+	// Recovery hook: reset the stale broker capture. Because A is still attached this
+	// must restart the capture AND re-seed A — with no second Subscribe.
 	br.resetCapture()
-	if ch.stops != 1 {
-		t.Fatalf("resetCapture: StopCapture calls = %d, want 1 (stale capture torn down + parked readLoop joined)", ch.stops)
-	}
-	br.mu.Lock()
-	capturing := br.capturing
-	br.mu.Unlock()
-	if capturing {
-		t.Fatal("resetCapture: broker still capturing, want the latch cleared so the next subscribe restarts capture")
-	}
 
-	// --- Prove the fix: a NEW subscriber after recovery streams live output -----
-	c, err := br.subscribe(0)
-	if err != nil {
-		t.Fatalf("subscribe C (post-reset): %v", err)
+	if ch.stops != 1 {
+		t.Fatalf("StopCapture calls = %d, want 1 (stale capture torn down + parked readLoop joined)", ch.stops)
 	}
 	if ch.starts != 2 {
-		t.Fatalf("post-reset: StartCapture calls = %d, want 2 (a FRESH capture against the recovered pane)", ch.starts)
+		t.Fatalf("StartCapture calls = %d, want 2 (capture restarted by the reset itself, NOT waiting for a new Subscribe — the #1682 residual)", ch.starts)
 	}
-	// gen-2 output from the re-spawned pane reaches the post-recovery subscriber.
-	ch.emit(t, []byte("LIVE-AFTER-RECOVERY"))
-	mustData(t, c, "LIVE-AFTER-RECOVERY")
+
+	// A resumes on its own: a repaint of the RECOVERED screen, then live output from
+	// the re-spawned pane — without ever issuing a second Subscribe.
+	mustRepaintContains(t, a, "SCREEN-AFTER-RECOVERY")
+	ch.emit(t, []byte("post-recovery-output"))
+	mustData(t, a, "post-recovery-output")
+}
+
+// TestPTYBrokerRecoveryNewSubscriberAlsoStreams pins that a NEW subscriber connecting
+// after recovery streams too: the reset restarted the capture, so the fresh subscribe
+// short-circuits (no third StartCapture) and rides the live capture.
+func TestPTYBrokerRecoveryNewSubscriberAlsoStreams(t *testing.T) {
+	ch := &fakeClientlessChannel{snapshot: []byte("S")}
+	br := newPTYBroker(ch)
+	a, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe A: %v", err)
+	}
+	mustRepaintContains(t, a, "S")
+
+	br.resetCapture() // A still attached → restart (StartCapture #2)
+	if ch.starts != 2 {
+		t.Fatalf("StartCapture after reset = %d, want 2", ch.starts)
+	}
+
+	mustRepaintContains(t, a, "S") // A's recovery re-seed repaint
+
+	b, err := br.subscribe(0)
+	if err != nil {
+		t.Fatalf("subscribe B after recovery: %v", err)
+	}
+	if ch.starts != 2 {
+		t.Fatalf("StartCapture after new subscribe = %d, want 2 (capture already live, no restart)", ch.starts)
+	}
+	mustRepaintContains(t, b, "S") // B's initial-subscribe repaint
+	ch.emit(t, []byte("live-for-both"))
+	mustData(t, a, "live-for-both")
+	mustData(t, b, "live-for-both")
 }
 
 // TestPTYBrokerResetCaptureNoopWhenIdle pins that a reset is harmless when no
-// capture is running (a session nobody was streaming when it recovered): no
-// StopCapture is issued and the lazy lifecycle is untouched.
+// subscriber was attached at recovery time (a session nobody was streaming): no
+// capture is started or stopped, and the lazy lifecycle is untouched.
 func TestPTYBrokerResetCaptureNoopWhenIdle(t *testing.T) {
 	ch := &fakeClientlessChannel{}
 	br := newPTYBroker(ch)
@@ -91,19 +123,24 @@ func TestPTYBrokerResetCaptureNoopWhenIdle(t *testing.T) {
 }
 
 // TestLocalAgentServerResetBrokerCaptures exercises the recovery reset at the
-// agentserver seam: resetBrokerCaptures snapshots the tab-broker map and resets
-// each broker's stale capture (#1682), and is a no-op once Kill has latched closed.
+// agentserver seam: resetBrokerCaptures snapshots the tab-broker map and recovers
+// each broker's capture (#1682), restarting + re-seeding brokers with live
+// subscribers, and is a no-op once Kill has latched closed.
 func TestLocalAgentServerResetBrokerCaptures(t *testing.T) {
-	ch0 := &fakeClientlessChannel{}
-	ch1 := &fakeClientlessChannel{}
+	ch0 := &fakeClientlessChannel{snapshot: []byte("tab0-screen")}
+	ch1 := &fakeClientlessChannel{snapshot: []byte("tab1-screen")}
 	br0 := newPTYBroker(ch0)
 	br1 := newPTYBroker(ch1)
-	if _, err := br0.subscribe(0); err != nil {
+	a0, err := br0.subscribe(0)
+	if err != nil {
 		t.Fatalf("subscribe tab 0: %v", err)
 	}
-	if _, err := br1.subscribe(0); err != nil {
+	mustRepaintContains(t, a0, "tab0-screen")
+	a1, err := br1.subscribe(0)
+	if err != nil {
 		t.Fatalf("subscribe tab 1: %v", err)
 	}
+	mustRepaintContains(t, a1, "tab1-screen")
 
 	s := &localAgentServer{brokers: map[int]*ptyBroker{0: br0, 1: br1}}
 	s.resetBrokerCaptures()
@@ -112,43 +149,36 @@ func TestLocalAgentServerResetBrokerCaptures(t *testing.T) {
 		if ch.stops != 1 {
 			t.Fatalf("%s: StopCapture calls = %d, want 1 (stale capture reset)", name, ch.stops)
 		}
-	}
-	for name, br := range map[string]*ptyBroker{"tab0": br0, "tab1": br1} {
-		br.mu.Lock()
-		capturing := br.capturing
-		br.mu.Unlock()
-		if capturing {
-			t.Fatalf("%s: still capturing after resetBrokerCaptures", name)
+		if ch.starts != 2 {
+			t.Fatalf("%s: StartCapture calls = %d, want 2 (capture restarted for the attached subscriber)", name, ch.starts)
 		}
 	}
 
-	// A fresh subscribe on each tab restarts capture against the recovered pane.
-	c0, err := br0.subscribe(0)
-	if err != nil {
-		t.Fatalf("re-subscribe tab 0: %v", err)
-	}
-	if ch0.starts != 2 {
-		t.Fatalf("tab0 StartCapture calls = %d, want 2 (restarted)", ch0.starts)
-	}
+	// Each still-attached subscriber resumed on its own: a recovered-screen repaint,
+	// then live output — no new Subscribe.
+	mustRepaintContains(t, a0, "tab0-screen")
 	ch0.emit(t, []byte("tab0-live"))
-	mustData(t, c0, "tab0-live")
+	mustData(t, a0, "tab0-live")
+	mustRepaintContains(t, a1, "tab1-screen")
+	ch1.emit(t, []byte("tab1-live"))
+	mustData(t, a1, "tab1-live")
 
 	// Once closed (Kill), reset is a no-op — it must not resurrect capture on a
 	// session being torn down.
 	s.mu.Lock()
 	s.closed = true
 	s.mu.Unlock()
-	prevStops := ch1.stops
+	prevStarts, prevStops := ch1.starts, ch1.stops
 	s.resetBrokerCaptures()
-	if ch1.stops != prevStops {
-		t.Fatalf("resetBrokerCaptures after close touched a broker: stops=%d, want %d", ch1.stops, prevStops)
+	if ch1.starts != prevStarts || ch1.stops != prevStops {
+		t.Fatalf("resetBrokerCaptures after close touched a broker: starts=%d stops=%d, want %d/%d", ch1.starts, ch1.stops, prevStarts, prevStops)
 	}
 }
 
 // TestPTYBrokerResetCaptureJoinsParkedReadLoop asserts resetCapture does not return
 // until the stale readLoop has actually exited (no goroutine leak): the stopCapture
-// closure blocks on the readLoop's done channel, so once resetCapture returns the
-// old capture reader is fully drained and the next capture starts clean.
+// closure blocks on the readLoop's done channel, so once resetCapture returns the old
+// capture reader is fully drained before the fresh capture starts.
 func TestPTYBrokerResetCaptureJoinsParkedReadLoop(t *testing.T) {
 	ch := &fakeClientlessChannel{}
 	br := newPTYBroker(ch)


### PR DESCRIPTION
## Summary

Fixes #1682 — a recovery regression introduced in #1625. After a running session's tmux dies and the daemon recovers it (`LocalBackend.respawn()` → `ts.Restore` → `Transition(ConfirmLive())`), nothing reset the PTY broker's capture state. The broker kept `capturing = true` with its `readLoop` **parked forever** on the dead pane's O_RDWR FIFO (which never sees EOF when `pipe-pane`'s writer dies), and `agentserver_local.go` returned that **stale broker** for the tab. Post-recovery subscribers attached successfully but **never received output** — PTY streaming stayed permanently broken until the session was killed/recreated.

## Fix

On respawn, after `ConfirmLive()`, reset each tab broker's stale capture:

- **`ptyBroker.resetCapture()`** — clears the `capturing` latch and runs the stale `stopCapture` under `captureMu` (captureMu-then-mu ordering, matching the existing `close()` / `maybeStopCapture()` discipline). Running the stop closure closes the FIFO read end, which **unblocks and joins** the parked `readLoop` (no goroutine leak), then re-arms the lazy lifecycle so the next `Subscribe` brings a **fresh** `pipe-pane` up against the restored pane. No-op when idle or already closed.
- **`localAgentServer.resetBrokerCaptures()`** — snapshots the tab-broker map under `s.mu` and resets each broker **outside** the lock (so a blocking teardown can't stall a concurrent Subscribe/Input/Resize). No-op once `Kill` has latched `closed`.
- **`respawn()`** — calls it via the memoized `AgentServer()` accessor after `ConfirmLive()`. No-op for sessions nobody ever streamed (empty broker map) and skips a remote runtime's agent-server (type assertion).

Subscribers and ring buffers are **preserved**; only the dead capture is dropped. The normal (non-recovery) broker lifecycle is untouched.

## Regression test

`TestPTYBrokerResetCaptureRestartsAfterRecovery` drives the broker seam (reproducing real tmux death in a unit test is impractical): it asserts the pre-fix defect (no fresh capture bound to the recovered pane — `StartCapture` never advances) **and** the post-fix recovery (a new subscriber gets live output from the re-spawned pane). Verified it **fails on the pre-fix path** (neutered `resetCapture`) and passes after. Plus:
- `TestLocalAgentServerResetBrokerCaptures` — agentserver seam + closed-latch no-op
- `TestPTYBrokerResetCaptureNoopWhenIdle` — harmless when nothing was streaming
- `TestPTYBrokerResetCaptureJoinsParkedReadLoop` — proves no goroutine leak

## Gates

- `gofmt -l .` clean · `golangci-lint run --fast` clean · `deadcode -test ./...` clean · file-length lint passed
- `make test-container` — all packages green
- `make ws-pty-roundtrip-container` — ok
- `make tui-driver-selftest` — 25/25 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)