### PR TITLE
test(web): Playwright web-driver-selftest harness (#1592 Phase 5 PR6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,14 @@ __debug_bin*
 # web/dist/ IS committed (locked decision) so `go build`/Go tests stay Node-free.
 web/node_modules/
 web/*.tsbuildinfo
-# Playwright browser downloads / run artifacts (harness itself lands in PR6).
+# Playwright web-driver-selftest run artifacts (#1592 Phase 5 PR6). The harness
+# sources (web/playwright.config.ts, web/selftest/*.spec.ts) ARE committed; only
+# the per-run outputs below are ignored.
 web/test-results/
 web/playwright-report/
 web/.playwright/
+web/selftest/.last-run.json
+web/blob-report/
 
 # MkDocs build output
 site/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 	agent-server-roundtrip-container remote-agent-server-roundtrip-container \
 	backend-docker-roundtrip backend-ssh-roundtrip \
 	playtest-container playtest-container-detached tui-driver tui-driver-selftest \
-	testbox-image lint-file-length docs web-build web-test
+	testbox-image lint-file-length docs web-build web-test web-selftest-container
 
 # Structural-health lint (#1145): fail if any Go file exceeds its line limit
 # (1000 for production code, 1500 for *_test.go) unless grandfathered in
@@ -141,3 +141,16 @@ web-build: web/node_modules
 # wired now but not invoked here.
 web-test: web/node_modules
 	cd web && npm run typecheck && npm run test
+
+# Playwright web-driver-selftest (#1592 Phase 5 PR6): the browser analogue of
+# tui-driver-selftest. It builds a dedicated Go+Node+Chromium image and runs the
+# WHOLE harness inside ONE ephemeral container — build af, boot a real daemon on a
+# loopback TLS+token listener, open the embedded SPA in headless Chromium, and
+# assert the core flows (login, sidebar, click-to-attach + live xterm output, the
+# #1694 j/k/Enter/Esc keyboard model, create/kill/archive). Assertions are the
+# gate, not screenshots. Node/Playwright stay behind this target — the Go build and
+# `make test-container` never invoke them. Needs a real docker/podman daemon; the
+# whole run is fenced in the container, isolated from the host tmux + real AF home.
+# See docs/web-selftest.md.
+web-selftest-container:
+	scripts/testbox.sh web-selftest

--- a/docs/web-selftest.md
+++ b/docs/web-selftest.md
@@ -1,0 +1,63 @@
+# Web client selftest
+
+The **web-driver-selftest** is the acceptance proof for the embedded browser web
+client (`web/`, #1592 Phase 5) — the browser analogue of the
+[TUI driver selftest](tui-manual-testing.md). It drives the daemon's embedded
+single-page app in a headless Chromium against a **real** `af` daemon and asserts
+the core flows end to end. Assertions are the gate, not screenshots.
+
+## Running it
+
+```bash
+make web-selftest-container
+```
+
+That is the only sanctioned entry point. It:
+
+1. Builds a dedicated container image
+   (`scripts/container/Dockerfile.web-selftest`) carrying three toolchains the
+   plain [testbox image](container-testing.md) deliberately omits: **Go** (to
+   build `af` and run the daemon), **Node** (to run Playwright), and a real
+   **Chromium** with all its system deps. It is pinned to the Playwright version
+   locked in `web/package-lock.json` so the bundled browser matches the npm
+   package.
+2. Runs the whole harness inside **one ephemeral container**
+   (`scripts/container/web-selftest-entry.sh`): builds `af`, brings up a real
+   daemon on a **throwaway home** with a loopback TLS+token listener
+   (`listen_addr=127.0.0.1:8899`), seeds two sessions in a mock repo behind a
+   fake agent, then runs Playwright (`web/selftest/web-driver.spec.ts`).
+
+Everything — the daemon, its tmux server, the sessions, the browser — lives on
+`127.0.0.1` inside the container and dies with it. There are **no published
+ports**, no access to the host tmux server, and no touch of the real
+`~/.agent-factory`, exactly like the other container harnesses.
+
+## What it asserts
+
+Against the live SPA served over the daemon's TLS listener:
+
+| Flow | Assertion |
+| --- | --- |
+| **Login** | Pasting the daemon token into the login form renders the authed app. |
+| **Sidebar** | The rail lists the seeded sessions from the Snapshot/events plane, and the live pip reads "Live". |
+| **Attach** | Click-to-attach opens the xterm terminal and shows the fake agent's live output (a real binary PTY frame decoded by the TS codec and painted in the browser). |
+| **Keyboard (#1694)** | In rail mode `j`/`k` navigate the rail; `Enter` attaches the selection; `Escape` returns to the rail. |
+| **Create** | The **+ New** modal creates a session and its row appears in the rail. |
+| **Kill** | The kill confirm removes the session's row. |
+| **Archive** | The archive confirm moves a session into the archived group. |
+
+## Toolchain boundary
+
+Node and Playwright stay **entirely** behind `make web-selftest-container` (and
+`make web-build` / `make web-test`). `go build ./...` and `make test-container`
+never invoke them — the built `web/dist/` is committed, so the Go side is
+Node-free (the locked toolchain decision). The harness tests the **committed**
+`web/dist/` bundle the binary embeds; rebuild it with `make web-build` after
+changing `web/src/`.
+
+## Artifacts
+
+The harness is assertion-gated, so it needs no committed artifacts. Per-run
+Playwright outputs (`web/test-results/`, `web/playwright-report/`,
+`web/blob-report/`, `web/selftest/.last-run.json`) are git-ignored; a failing run
+retains a trace under `web/test-results/` for local debugging.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
           - HTTP API reference: reference/api.md
       - Maintainers:
           - Container testing: container-testing.md
+          - Web client selftest: web-selftest.md
           - File-length lint: file-length-lint.md
           - Release process: release-process.md
           - Release notes: release-notes.md

--- a/scripts/container/Dockerfile.web-selftest
+++ b/scripts/container/Dockerfile.web-selftest
@@ -1,0 +1,61 @@
+# Web-driver-selftest container for agent-factory (#1592 Phase 5 PR6).
+#
+# The browser harness needs THREE toolchains in one image that the plain testbox
+# image (Dockerfile.test) deliberately does NOT carry: Go (to build af + run the
+# daemon), Node (to run Playwright), and a real Chromium with all its system deps.
+# Rather than bloat the shared testbox image that every other gate uses, this is a
+# dedicated image built only for `make web-selftest-container`.
+#
+# Base: the official Playwright image, which pins Node + a Chromium build + every
+# libnss/libgbm/font system dep the browser needs. Pinned to v1.56.1-noble to match
+# the @playwright/test version locked in web/package-lock.json, so the bundled
+# browser revision matches the npm package the harness runs.
+#
+# Toolchain-only, like Dockerfile.test: the source is bind-mounted read-only at run
+# time (scripts/testbox.sh), so this image rebuilds only when the toolchain changes,
+# never on code changes. Build it with no context (`docker build - < …`); no COPY.
+FROM mcr.microsoft.com/playwright:v1.56.1-noble
+
+# tmux + git are what the daemon drives to run sessions; procps provides pgrep for
+# the daemon's SIGTERM fallback path — the same trio Dockerfile.test installs.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tmux git procps ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Go 1.25 (the repo floor, CLAUDE.md). Fetched from the official tarball for the
+# build arch so the image is not tied to a distro Go package. GO_SHA256 pins the
+# amd64 tarball; arm64 builds skip the checksum (dev box + CI are amd64).
+ARG GO_VERSION=1.25.0
+ARG GO_SHA256=2852af0cb20a13139b3448992e69b868e50ed0f8a1e5940ee1de9e19a123b613
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+        amd64) goarch=amd64 ;; \
+        arm64) goarch=arm64 ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    url="https://go.dev/dl/go${GO_VERSION}.linux-${goarch}.tar.gz"; \
+    curl -fsSL "$url" -o /tmp/go.tgz; \
+    if [ "$goarch" = amd64 ]; then echo "${GO_SHA256}  /tmp/go.tgz" | sha256sum -c -; fi; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz
+
+# Stable git identity so no mock-repo commit depends on host git config leaking in
+# (mirrors Dockerfile.test), and mark the read-only /src bind mount safe so the Go
+# toolchain / git never refuse it as "dubious ownership" (#1167).
+RUN git config --system user.name "AF Web Selftest" \
+    && git config --system user.email "web-selftest@localhost" \
+    && git config --system init.defaultBranch master \
+    && git config --system --add safe.directory /src \
+    && git config --system --add safe.directory /work
+
+# Go on PATH; module/build caches under /work (the writable copy the entry makes),
+# so a warm bind-mounted cache volume can speed repeat runs. TERM mirrors an
+# interactive box (the fake agent runs under tmux). PLAYWRIGHT_BROWSERS_PATH is set
+# by the base image to the bundled browser location — left as-is.
+ENV PATH=/usr/local/go/bin:/root/go/bin:$PATH \
+    TERM=xterm-256color \
+    GOMODCACHE=/cache/gomod \
+    GOCACHE=/cache/gobuild
+
+WORKDIR /src

--- a/scripts/container/web-selftest-entry.sh
+++ b/scripts/container/web-selftest-entry.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Runs INSIDE the web-selftest container (see scripts/testbox.sh web-selftest):
+# build af from the mounted source, bring up a REAL af daemon on a throwaway home
+# with a loopback TLS+token listener, seed a couple of sessions in a mock repo,
+# then drive the embedded SPA in a headless Chromium via Playwright and assert the
+# core flows (web/selftest/web-driver.spec.ts).
+#
+# Everything here — the tmux server, the daemon, the AF home, the sessions, the
+# browser — lives and dies with the container. Teardown is `docker rm -f`, not a
+# checklist. Nothing touches the host tmux server or the real ~/.agent-factory.
+set -euo pipefail
+
+# --- writable working copy (the /src bind mount is read-only) ---------------
+# Copy without .git: dev checkouts are often linked worktrees whose .git is a
+# pointer to a host path absent in the container (mirrors run-tests.sh).
+mkdir -p /work
+(cd /src && tar -c --exclude=.git --exclude=web/node_modules --exclude=web/test-results .) | tar -x -C /work
+cd /work
+
+HOME_DIR=/work/afhome
+MOCK=/work/mock-repo
+BIN=/work/bin/af
+LISTEN=127.0.0.1:8899
+BASE_URL="https://${LISTEN}"
+READY_MARKER=AF_SELFTEST_READY
+SESSION_A=probe-a
+SESSION_B=probe-b
+export AGENT_FACTORY_HOME="$HOME_DIR"
+# A container binary is built at the branch version (typically behind the latest
+# release); without this it would self-update on boot and restart the daemon
+# mid-run, racing session creation (#1596). Real users are unaffected.
+export AGENT_FACTORY_AUTO_UPDATE=false
+mkdir -p "$HOME_DIR" /work/bin
+
+echo ">>> building af from /work ..."
+go build -buildvcs=false -o "$BIN" .
+
+# --- throwaway AF home: TLS listener + a fake agent -------------------------
+# The fake agent prints a deterministic ready marker (the "live output" the
+# terminal flow asserts on) then execs `cat`, so typed input echoes back — the
+# same shape the WS PTY broker round-trip uses. Because the override is a custom
+# script (not literally "claude"), af appends no agent flags and counts the pane
+# ready as soon as it shows output (#1116/#1131).
+cat >"$HOME_DIR/fake-agent.sh" <<EOF
+#!/bin/sh
+printf '%s\n' "$READY_MARKER"
+exec cat
+EOF
+chmod +x "$HOME_DIR/fake-agent.sh"
+
+# listen_addr turns on the TLS TCP listener that serves the SPA + /v1 API and
+# generates the bearer token (daemon/tcpserver.go). Global-only key, so it lives
+# in the home config.json.
+cat >"$HOME_DIR/config.json" <<EOF
+{
+  "default_program": "claude",
+  "program_overrides": { "claude": "$HOME_DIR/fake-agent.sh" },
+  "listen_addr": "$LISTEN"
+}
+EOF
+
+# --- mock project repo (never a real repo) ----------------------------------
+if [ ! -d "$MOCK" ]; then
+    mkdir -p "$MOCK"
+    (
+        cd "$MOCK"
+        git init -q -b master
+        printf '# mock\nA throwaway repo for the web-driver-selftest.\n' >README.md
+        git add -A
+        git commit -qm "initial project"
+    )
+fi
+
+# --- start the daemon + wait for the TLS listener ---------------------------
+echo ">>> starting af daemon (listen_addr=$LISTEN) ..."
+"$BIN" --daemon >/work/daemon.log 2>&1 &
+DAEMON_PID=$!
+
+cleanup() {
+    rc=$?
+    echo ">>> tearing down (rc=$rc) ..."
+    "$BIN" sessions kill "$SESSION_A" >/dev/null 2>&1 || true
+    "$BIN" sessions kill "$SESSION_B" >/dev/null 2>&1 || true
+    kill "$DAEMON_PID" >/dev/null 2>&1 || true
+    if [ "$rc" -ne 0 ]; then
+        echo "===== daemon.log (tail) =====" >&2
+        tail -n 40 /work/daemon.log >&2 || true
+    fi
+}
+trap cleanup EXIT
+
+# Poll the TLS port until it serves the SPA shell (200). Once it binds, the token
+# file exists (EnsureToken runs before the port opens).
+echo ">>> waiting for the TLS listener ..."
+for i in $(seq 1 60); do
+    if curl -sk -o /dev/null -w '%{http_code}' "$BASE_URL/" 2>/dev/null | grep -q '^200$'; then
+        break
+    fi
+    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+        echo "daemon exited before binding the listener; see log:" >&2
+        cat /work/daemon.log >&2
+        exit 1
+    fi
+    sleep 1
+    if [ "$i" -eq 60 ]; then
+        echo "timed out waiting for $BASE_URL" >&2
+        cat /work/daemon.log >&2
+        exit 1
+    fi
+done
+
+TOKEN="$(cat "$HOME_DIR/daemon-token")"
+if [ -z "$TOKEN" ]; then
+    echo "no daemon token at $HOME_DIR/daemon-token" >&2
+    exit 1
+fi
+echo ">>> daemon up at $BASE_URL (token ${#TOKEN} bytes)"
+
+# --- seed two sessions in the mock repo -------------------------------------
+echo ">>> creating sessions $SESSION_A, $SESSION_B ..."
+"$BIN" sessions create --repo "$MOCK" --name "$SESSION_A" --program claude >/dev/null
+"$BIN" sessions create --repo "$MOCK" --name "$SESSION_B" --program claude >/dev/null
+
+# Give the workspaces a moment to launch (worktree + tmux pane) so the rail lists
+# them and the fake agent's marker is on-screen for the attach flow.
+for i in $(seq 1 30); do
+    count="$("$BIN" sessions list 2>/dev/null | grep -c '"title"' || true)"
+    if [ "${count:-0}" -ge 2 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# --- run the Playwright harness ---------------------------------------------
+echo ">>> installing web deps + running the Playwright harness ..."
+cd /work/web
+# The image already carries the matching Chromium build; skip npm's browser
+# download and use the bundled one.
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+npm ci --no-audit --no-fund
+
+export AF_WEB_BASE_URL="$BASE_URL"
+export AF_WEB_TOKEN="$TOKEN"
+export AF_WEB_SESSION_A="$SESSION_A"
+export AF_WEB_SESSION_B="$SESSION_B"
+export AF_WEB_READY_MARKER="$READY_MARKER"
+
+npx playwright test

--- a/scripts/testbox.sh
+++ b/scripts/testbox.sh
@@ -19,6 +19,10 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE="${AF_TESTBOX_IMAGE:-agent-factory-testbox}"
+# The web-driver-selftest uses a SEPARATE, heavier image (Go + Node + Chromium);
+# see scripts/container/Dockerfile.web-selftest. Kept distinct so it never bloats
+# the plain testbox image every other gate shares.
+WEB_IMAGE="${AF_WEB_TESTBOX_IMAGE:-agent-factory-web-selftest}"
 
 # _uniq — a per-invocation token (pid + a little randomness) for container
 # names, so two runs never share a name.
@@ -194,8 +198,27 @@ drive)
     echo "testbox: tear down with: $ENGINE rm -f $PLAYTEST_NAME" >&2
     exec "$ENGINE" exec -it "$PLAYTEST_NAME" tmux attach -t drive
     ;;
+web-selftest)
+    # Playwright web-driver-selftest (#1592 Phase 5 PR6): build the dedicated
+    # Go+Node+Chromium image, then run the whole harness in ONE ephemeral
+    # container — it builds af, boots a real daemon on a loopback TLS+token
+    # listener, and drives the embedded SPA in a headless Chromium. Everything
+    # (daemon, tmux, browser) lives on 127.0.0.1 inside the container: no
+    # published ports, no host tmux, no real AF home.
+    "$ENGINE" build -q -t "$WEB_IMAGE" - <"$REPO_ROOT/scripts/container/Dockerfile.web-selftest" >/dev/null
+    # Dedicated cache volumes (not the shared testbox ones): this container runs
+    # as root, so mixing caches would leave root-owned files the dev-user testbox
+    # can't write. Chromium wants more memory + pids than the default suite.
+    exec "$ENGINE" run --rm --init \
+        -v "$REPO_ROOT":/src:ro \
+        -v af-web-selftest-gomod:/cache/gomod \
+        -v af-web-selftest-gobuild:/cache/gobuild \
+        --pids-limit "${AF_TESTBOX_PIDS:-2048}" \
+        --memory "${AF_WEB_TESTBOX_MEMORY:-4g}" \
+        "$WEB_IMAGE" bash /src/scripts/container/web-selftest-entry.sh
+    ;;
 *)
-    echo "testbox: unknown command '$cmd' (want: test | playtest | selftest | drive | build)" >&2
+    echo "testbox: unknown command '$cmd' (want: test | playtest | selftest | drive | web-selftest | build)" >&2
     exit 1
     ;;
 esac

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "node build.mjs",
     "test": "node --import tsx --test \"src/**/*.test.ts\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "selftest": "playwright test"
   },
   "devDependencies": {
     "@playwright/test": "^1.56.1",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,56 @@
+// Playwright config for the web-driver-selftest harness (#1592 Phase 5 PR6).
+//
+// The harness is gated ENTIRELY behind `make web-selftest-container`: like
+// web-build/web-test, Node + Playwright never enter the Go build or the Go test
+// suite (the locked toolchain decision). It drives the daemon's embedded SPA in a
+// headless Chromium against a REAL af daemon that the container entry script
+// (scripts/container/web-selftest-entry.sh) brings up on a throwaway home — a
+// loopback TLS+token listener — and exports as env:
+//
+//   AF_WEB_BASE_URL   https://127.0.0.1:<port>   the SPA + /v1 API origin
+//   AF_WEB_TOKEN      the daemon bearer token (pasted into the login form)
+//   AF_WEB_SESSION_A  / AF_WEB_SESSION_B          the two seeded session titles
+//
+// The listener is self-signed (the daemon's generated default), so
+// ignoreHTTPSErrors accepts it — the browser cannot TOFU-pin a fingerprint the
+// way the CLI does, and this is a loopback test origin, not a trust boundary.
+
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.AF_WEB_BASE_URL;
+if (!baseURL) {
+  throw new Error(
+    "AF_WEB_BASE_URL is unset — run the harness through `make web-selftest-container` " +
+      "(or scripts/container/web-selftest-entry.sh), which boots the daemon and exports it.",
+  );
+}
+
+export default defineConfig({
+  testDir: "./selftest",
+  // One daemon, one browser: the flows mutate shared session state (create / kill /
+  // archive), so they must run serially against a single worker.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: true,
+  retries: 0,
+  // Generous but bounded: a real session create spins up a git worktree + tmux
+  // pane, so individual assertions poll for a few seconds.
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: [["list"]],
+  use: {
+    baseURL,
+    headless: true,
+    ignoreHTTPSErrors: true,
+    // Capture a trace only on a failing run, into the gitignored artifacts dir.
+    trace: "retain-on-failure",
+    // The harness container runs as root (it builds af + runs the daemon), and
+    // Chromium's setuid sandbox refuses to start as root; disable it. Safe here —
+    // the whole run is fenced inside a throwaway container, exactly like testbox.
+    // --disable-dev-shm-usage: a container's default 64MB /dev/shm is too small for
+    // Chromium and crashes it under load; route shared memory to /tmp instead.
+    launchOptions: { args: ["--no-sandbox", "--disable-dev-shm-usage"] },
+  },
+  outputDir: "./test-results",
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/web/selftest/web-driver.spec.ts
+++ b/web/selftest/web-driver.spec.ts
@@ -1,0 +1,179 @@
+// web-driver-selftest (#1592 Phase 5 PR6) — the acceptance proof for the embedded
+// browser web client, the browser analogue of tui-driver-selftest.sh.
+//
+// It drives a headless Chromium against a REAL af daemon (a throwaway home on a
+// loopback TLS+token listener, brought up by web-selftest-entry.sh) and asserts
+// the core v1 loop end to end — assertions are the gate, not screenshots:
+//
+//   1. login          paste the daemon token → the authed app renders
+//   2. sidebar         the rail lists the sessions from the Snapshot/events plane
+//   3. attach          click-to-attach opens the xterm terminal + shows live output
+//   4. keyboard (#1694) j/k navigate the rail, Enter attaches, Escape returns to rail
+//   5. create          the + New modal creates a session; its row appears
+//   6. kill            the kill confirm removes the session's row
+//   7. archive         the archive confirm moves a session to the archived group
+//
+// Everything the test needs is handed in via env by the entry script (see
+// playwright.config.ts): AF_WEB_BASE_URL, AF_WEB_TOKEN, and the two seeded
+// session titles AF_WEB_SESSION_A / AF_WEB_SESSION_B.
+
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+const TOKEN = requireEnv("AF_WEB_TOKEN");
+const SESSION_A = process.env.AF_WEB_SESSION_A ?? "probe-a";
+const SESSION_B = process.env.AF_WEB_SESSION_B ?? "probe-b";
+// The marker the seeded fake agent prints on launch (web-selftest-entry.sh), so
+// "the terminal shows live output" is a deterministic string assertion.
+const READY_MARKER = process.env.AF_WEB_READY_MARKER ?? "AF_SELFTEST_READY";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    throw new Error(`${name} is unset — run via \`make web-selftest-container\`, which boots the daemon.`);
+  }
+  return v;
+}
+
+/** A rail row by its session title. */
+function row(page: Page, title: string): Locator {
+  return page.locator(".af-rail-list .af-row", { hasText: title });
+}
+
+/** Logs in by pasting the daemon token and waits for the authed shell + the rail
+ *  to be populated by the Snapshot the probe returns. */
+async function login(page: Page): Promise<void> {
+  await page.goto("/");
+  await expect(page.locator("#af-token")).toBeVisible();
+  await page.locator("#af-token").fill(TOKEN);
+  await page.locator("form.af-login-form button.af-primary").click();
+  await expect(page.locator(".af-app")).toBeVisible();
+}
+
+// The flows share one daemon and mutate its session set (create/kill/archive), so
+// they must run in order against a single page.
+test.describe.configure({ mode: "serial" });
+
+let page: Page;
+// The title of the session the create flow makes, handed to the kill flow.
+let createdTitle = "";
+
+test.beforeAll(async ({ browser }) => {
+  page = await browser.newPage();
+  await login(page);
+});
+
+test.afterAll(async () => {
+  await page.close();
+});
+
+test("sidebar lists the seeded sessions from the Snapshot/events plane", async () => {
+  // Both seeded rows are present — proof the rail is driven by the daemon
+  // projection, not a static list.
+  await expect(row(page, SESSION_A)).toBeVisible();
+  await expect(row(page, SESSION_B)).toBeVisible();
+  await expect(page.locator(".af-rail-count")).toHaveText(/[2-9]|\d{2,}/);
+  // The events WebSocket connected: the live pip reads "Live" (open), proving the
+  // push plane the rail resyncs from is up.
+  await expect(page.locator(".af-live-pip.af-live-open")).toBeVisible();
+});
+
+test("click-to-attach opens the xterm terminal and shows live output", async () => {
+  await row(page, SESSION_A).click();
+
+  // The main pane switched to the terminal view and mounted a real xterm instance.
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await expect(page.locator(".af-term-host .xterm")).toBeVisible();
+
+  // Live output: the seeded fake agent printed its ready marker over the WS PTY
+  // stream, and xterm rendered it into the pane. This is the flagship assertion —
+  // a real binary PTY frame decoded by the TS codec and painted in the browser.
+  await expect(page.locator(".af-term-host")).toContainText(READY_MARKER);
+
+  // The pane header status resolved to the live stream, and the keyboard followed
+  // the attach into terminal mode (#1693/#1694).
+  await expect(page.locator(".af-term-meta")).toContainText("Live");
+  await expect(page.locator(".af-app.af-kb-terminal")).toBeVisible();
+});
+
+test("the #1694 keyboard model: j/k navigate, Enter attaches, Escape returns to rail", async () => {
+  // We are attached to A (terminal mode from the previous flow). Escape is the one
+  // hatch back to the rail — no stray ESC byte leaks to the PTY.
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
+  await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
+
+  // j moves the selection off A to the next row; the terminal is NOT stolen — j/k
+  // always navigate the rail in nav mode. (Pre-#1693 j/k silently fed the agent.)
+  await page.keyboard.press("j");
+  await expect(row(page, SESSION_A)).not.toHaveClass(/af-row-selected/);
+  const movedTo = page.locator(".af-rail-list .af-row.af-row-selected");
+  await expect(movedTo).toHaveCount(1);
+  await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
+
+  // k moves back up to A — j/k are symmetric rail navigation.
+  await page.keyboard.press("k");
+  await expect(row(page, SESSION_A)).toHaveClass(/af-row-selected/);
+
+  // Enter attaches the selected row and hands the keyboard to its terminal.
+  await page.keyboard.press("Enter");
+  await expect(page.locator(".af-app.af-kb-terminal")).toBeVisible();
+
+  // Escape detaches back to the rail, completing the round trip.
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".af-app.af-kb-rail")).toBeVisible();
+});
+
+test("create: the + New modal creates a session and its row appears", async () => {
+  const created = `probe-created-${Date.now().toString(36)}`;
+
+  await page.locator("button.af-rail-new").click();
+  const modal = page.locator(".af-modal-card");
+  await expect(modal).toBeVisible();
+
+  // Title is required; the project picker auto-selects the only project (the mock
+  // repo the seeded sessions live in). Program is left at "Repo default" (claude →
+  // the fake agent). Submit with the modal's Create button.
+  await modal.locator('input[aria-label="Session title"]').fill(created);
+  await modal.locator("button.af-primary").click();
+
+  // The created row lands in the rail (createSession returns the full projection,
+  // which index.ts upserts + selects immediately).
+  await expect(row(page, created)).toBeVisible({ timeout: 30_000 });
+  await expect(modal).toBeHidden();
+
+  // Stash it for the kill flow.
+  createdTitle = created;
+});
+
+test("kill: the kill confirm removes the session's row", async () => {
+  expect(createdTitle).not.toBe("");
+  // The created session is the current selection, so the pane header shows its
+  // actions. Kill it and confirm.
+  await row(page, createdTitle).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+  await page.locator(".af-term-head button.af-danger").click();
+
+  const modal = page.locator(".af-modal-card");
+  await expect(modal).toBeVisible();
+  await modal.locator("button.af-danger").click();
+
+  // The killed row disappears from the rail (the killed event removes it).
+  await expect(row(page, createdTitle)).toHaveCount(0, { timeout: 30_000 });
+});
+
+test("archive: the archive confirm moves a session to the archived group", async () => {
+  // Archive session B. Select it (click attaches, which is fine), then archive +
+  // confirm.
+  await row(page, SESSION_B).click();
+  await expect(page.locator(".af-main.af-main-term")).toBeVisible();
+
+  // The Archive action is the ghost button labeled "Archive" in the pane header.
+  await page.locator(".af-term-head button", { hasText: "Archive" }).click();
+  const modal = page.locator(".af-modal-card");
+  await expect(modal).toBeVisible();
+  await modal.locator("button.af-primary").click();
+
+  // B is not killed — it stays in the rail, but in the archived group (rendered
+  // with the af-row-archived modifier and sorted last).
+  await expect(row(page, SESSION_B)).toHaveClass(/af-row-archived/, { timeout: 30_000 });
+});


### PR DESCRIPTION
## What this adds

The browser analogue of `tui-driver-selftest` for the embedded web client (#1592 Phase 5): a **headless-Chromium Playwright harness** that proves the SPA's core flows end to end. Assertions are the gate — no screenshots.

It is gated **entirely** behind a new `make web-selftest-container` target, so `go build ./...` and `make test-container` stay Node-free (the locked toolchain decision) — Go carries no Playwright/Node dependency; the JS lives behind `make` only.

## How it runs

One ephemeral container (a dedicated **Go + Node + Chromium** image, `scripts/container/Dockerfile.web-selftest`, pinned to the Playwright version locked in `web/package-lock.json`) does the whole thing (`scripts/container/web-selftest-entry.sh`):

1. builds `af` from source,
2. brings up its **own** daemon — a fresh `af --daemon` on a **throwaway home** with a loopback TLS+token listener (`listen_addr=127.0.0.1:8899`) behind a fake agent — **not** any existing daemon,
3. seeds two sessions in a mock repo,
4. opens the SPA over the daemon's TLS listener, logs in by pasting the token, and runs the spec.

Everything (daemon, tmux, browser) lives on `127.0.0.1` inside the container and dies with it: no published ports, no host tmux, no real AF home — the same fence as the other container harnesses.

## What it asserts (`web/selftest/web-driver.spec.ts`)

- **login** — pasting the daemon token renders the authed app
- **sidebar** — the rail lists sessions from the Snapshot/events plane (live pip reads "Live")
- **attach** — click-to-attach opens the xterm terminal and shows live PTY output (a real binary frame decoded by the TS codec and painted in the browser)
- **keyboard (#1694)** — `j`/`k` navigate the rail, `Enter` attaches, `Escape` returns to the rail
- **create / kill / archive** — the modal actions work end to end

## Files

- `web/playwright.config.ts`, `web/selftest/web-driver.spec.ts` — the harness (committed; per-run artifacts are git-ignored, no pre-built artifacts needed since it's assertion-gated)
- `scripts/container/Dockerfile.web-selftest`, `scripts/container/web-selftest-entry.sh` — the container + entry
- `scripts/testbox.sh` — new `web-selftest` command
- `Makefile` — `web-selftest-container` target
- `docs/web-selftest.md` — docs page, wired into the mkdocs nav
- `.gitignore`, `web/package.json` (`selftest` script) — supporting bits

## Gates (all green locally)

- **`make web-selftest-container`** — 6/6 passed (verified against the committed config)
- **`make tui-driver-selftest`** — 25/25 steps green
- `make web-test` — 53/53 (typecheck + units)
- `go build ./...`, `gofmt -l .` clean, `golangci-lint run --timeout=3m --fast`, `deadcode -test ./...`, `scripts/lint-file-length.sh` — all clean

Part of #1592 (Phase 5). **Do not merge** — flagged for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)